### PR TITLE
[geometry:optimization] cleanup memory management in GraphOfConvexSets

### DIFF
--- a/bindings/pydrake/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry_py_optimization.cc
@@ -3,6 +3,7 @@
  pydrake.geometry.optimization module. */
 
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/identifier_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/geometry_py.h"
@@ -38,6 +39,8 @@ void DefineGeometryOptimization(py::module m) {
             cls_doc.Clone.doc)
         .def("ambient_dimension", &ConvexSet::ambient_dimension,
             cls_doc.ambient_dimension.doc)
+        .def("IntersectsWith", &ConvexSet::IntersectsWith, py::arg("other"),
+            cls_doc.IntersectsWith.doc)
         .def("IsBounded", &ConvexSet::IsBounded, cls_doc.IsBounded.doc)
         .def("PointInSet", &ConvexSet::PointInSet, py::arg("x"),
             py::arg("tol") = 1e-8, cls_doc.PointInSet.doc)
@@ -252,9 +255,33 @@ void DefineGeometryOptimization(py::module m) {
                     &GraphOfConvexSets::AddEdge),
                 py::arg("u"), py::arg("v"), py::arg("name") = "",
                 py_rvp::reference_internal, cls_doc.AddEdge.doc_by_reference)
-            .def("VertexIds", &GraphOfConvexSets::VertexIds,
-                cls_doc.VertexIds.doc)
-            .def("Edges", &GraphOfConvexSets::Edges, py_rvp::reference_internal,
+            .def(
+                "Vertices",
+                [](GraphOfConvexSets* self) {
+                  py::list out;
+                  py::object self_py = py::cast(self, py_rvp::reference);
+                  for (auto* vertex : self->Vertices()) {
+                    py::object vertex_py = py::cast(vertex, py_rvp::reference);
+                    // Keep alive, ownership: `vertex` keeps `self` alive.
+                    py_keep_alive(vertex_py, self_py);
+                    out.append(vertex_py);
+                  }
+                  return out;
+                },
+                cls_doc.Vertices.doc)
+            .def(
+                "Edges",
+                [](GraphOfConvexSets* self) {
+                  py::list out;
+                  py::object self_py = py::cast(self, py_rvp::reference);
+                  for (auto* edge : self->Edges()) {
+                    py::object edge_py = py::cast(edge, py_rvp::reference);
+                    // Keep alive, ownership: `edge` keeps `self` alive.
+                    py_keep_alive(edge_py, self_py);
+                    out.append(edge_py);
+                  }
+                  return out;
+                },
                 cls_doc.Edges.doc)
             .def("GetGraphvizString", &GraphOfConvexSets::GetGraphvizString,
                 py::arg("result"), py::arg("show_slacks") = true,

--- a/bindings/pydrake/test/geometry_optimization_test.py
+++ b/bindings/pydrake/test/geometry_optimization_test.py
@@ -45,6 +45,7 @@ class TestGeometryOptimization(unittest.TestCase):
         np.testing.assert_array_equal(hpoly.A(), self.A)
         np.testing.assert_array_equal(hpoly.b(), self.b)
         self.assertTrue(hpoly.PointInSet(x=[0, 0, 0], tol=0.0))
+        self.assertFalse(hpoly.IsBounded())
         hpoly.AddPointInSetConstraints(self.prog, self.x)
         with self.assertRaisesRegex(
                 RuntimeError, ".*not implemented yet for HPolyhedron.*"):
@@ -52,6 +53,7 @@ class TestGeometryOptimization(unittest.TestCase):
 
         h_box = mut.HPolyhedron.MakeBox(
             lb=[-1, -1, -1], ub=[1, 1, 1])
+        self.assertTrue(h_box.IntersectsWith(hpoly))
         h_unit_box = mut.HPolyhedron.MakeUnitBox(dim=3)
         np.testing.assert_array_equal(h_box.A(), h_unit_box.A())
         np.testing.assert_array_equal(h_box.b(), h_unit_box.b())
@@ -258,7 +260,7 @@ class TestGeometryOptimization(unittest.TestCase):
         target = spp.AddVertex(set=mut.Point([0.2]), name="target")
         edge0 = spp.AddEdge(u=source, v=target, name="edge0")
         edge1 = spp.AddEdge(u_id=source.id(), v_id=target.id(), name="edge1")
-        self.assertEqual(len(spp.VertexIds()), 2)
+        self.assertEqual(len(spp.Vertices()), 2)
         self.assertEqual(len(spp.Edges()), 2)
         result = spp.SolveShortestPath(
             source_id=source.id(), target_id=target.id(),

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -3,7 +3,6 @@
 #include <limits>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -67,7 +66,7 @@ Edge::Edge(const EdgeId& id, const Vertex* u, const Vertex* v, std::string name)
       name_(std::move(name)),
       y_{symbolic::MakeVectorContinuousVariable(u_->ambient_dimension(), "y")},
       z_{symbolic::MakeVectorContinuousVariable(v_->ambient_dimension(), "z")},
-      x_to_yz_(u_->ambient_dimension() + v_->ambient_dimension()) {
+      x_to_yz_{static_cast<size_t>(y_.size() + z_.size())} {
   DRAKE_DEMAND(u_ != nullptr);
   DRAKE_DEMAND(v_ != nullptr);
   allowed_vars_.insert(Variables(v_->x()));
@@ -101,9 +100,8 @@ Binding<Constraint> Edge::AddConstraint(const symbolic::Formula& f) {
 
 Binding<Constraint> Edge::AddConstraint(const Binding<Constraint>& binding) {
   DRAKE_THROW_UNLESS(Variables(binding.variables()).IsSubsetOf(allowed_vars_));
-  auto [iter, inserted] = constraints_.emplace(binding);
-  unused(inserted);
-  return *iter;
+  constraints_.emplace_back(binding);
+  return binding;
 }
 
 void Edge::AddPhiConstraint(bool phi_value) {
@@ -160,19 +158,38 @@ Edge* GraphOfConvexSets::AddEdge(const Vertex& u, const Vertex& v,
   return AddEdge(u.id(), v.id(), std::move(name));
 }
 
-std::unordered_set<VertexId> GraphOfConvexSets::VertexIds() const {
-  std::unordered_set<VertexId> ids(vertices_.size());
+std::vector<Vertex*> GraphOfConvexSets::Vertices() {
+  std::vector<Vertex*> vertices;
+  vertices.reserve(vertices_.size());
   for (const auto& v : vertices_) {
-    ids.emplace(v.first);
+    vertices.push_back(v.second.get());
   }
-  return ids;
+  return vertices;
 }
 
-std::unordered_set<Edge*> GraphOfConvexSets::Edges() {
-  std::unordered_set<Edge*> edges(edges_.size());
-  for (auto& [edge_id, e] : edges_) {
-    unused(edge_id);
-    edges.emplace(e.get());
+std::vector<const Vertex*> GraphOfConvexSets::Vertices() const {
+  std::vector<const Vertex*> vertices;
+  vertices.reserve(vertices_.size());
+  for (const auto& v : vertices_) {
+    vertices.push_back(v.second.get());
+  }
+  return vertices;
+}
+
+std::vector<Edge*> GraphOfConvexSets::Edges() {
+  std::vector<Edge*> edges;
+  edges.reserve(edges_.size());
+  for (const auto& e : edges_) {
+    edges.push_back(e.second.get());
+  }
+  return edges;
+}
+
+std::vector<const Edge*> GraphOfConvexSets::Edges() const {
+  std::vector<const Edge*> edges;
+  edges.reserve(edges_.size());
+  for (const auto& e : edges_) {
+    edges.push_back(e.second.get());
   }
   return edges;
 }
@@ -227,17 +244,13 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
 
   MathematicalProgram prog;
 
-  std::unordered_map<VertexId, std::vector<Edge*>> incoming_edges(
-      vertices_.size());
-  std::unordered_map<VertexId, std::vector<Edge*>> outgoing_edges(
-      vertices_.size());
+  std::map<VertexId, std::vector<Edge*>> incoming_edges;
+  std::map<VertexId, std::vector<Edge*>> outgoing_edges;
   const double inf = std::numeric_limits<double>::infinity();
 
-  std::unordered_map<const Edge*, Variable> relaxed_phi(
-      convex_relaxation ? edges_.size() : 0);
+  std::map<EdgeId, Variable> relaxed_phi;
 
   for (const auto& [edge_id, e] : edges_) {
-    unused(edge_id);
     outgoing_edges[e->u().id()].emplace_back(e.get());
     incoming_edges[e->v().id()].emplace_back(e.get());
 
@@ -245,7 +258,7 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
     if (convex_relaxation) {
       phi = prog.NewContinuousVariables<1>("phi")[0];
       prog.AddBoundingBoxConstraint(0, 1, phi);
-      relaxed_phi.emplace(e.get(), phi);
+      relaxed_phi.emplace(edge_id, phi);
     } else {
       phi = e->phi_;
       prog.AddDecisionVariables(Vector1<Variable>(phi));
@@ -419,10 +432,10 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
       // Conservation of flow: ∑ ϕ_out - ∑ ϕ_in = δ(is_source) - δ(is_target).
       int count = 0;
       for (const auto* e : incoming) {
-        vars[count++] = convex_relaxation ? relaxed_phi.at(e) : e->phi_;
+        vars[count++] = convex_relaxation ? relaxed_phi.at(e->id()) : e->phi_;
       }
       for (const auto* e : outgoing) {
-        vars[count++] = convex_relaxation ? relaxed_phi.at(e) : e->phi_;
+        vars[count++] = convex_relaxation ? relaxed_phi.at(e->id()) : e->phi_;
       }
       prog.AddLinearEqualityConstraint(
           a, (is_source ? 1.0 : 0.0) - (is_target ? 1.0 : 0.0), vars);
@@ -446,8 +459,8 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
     if (outgoing.size() > 0) {
       VectorXDecisionVariable phi_out(outgoing.size());
       for (int i = 0; i < static_cast<int>(outgoing.size()); ++i) {
-        phi_out[i] =
-            convex_relaxation ? relaxed_phi.at(outgoing[i]) : outgoing[i]->phi_;
+        phi_out[i] = convex_relaxation ? relaxed_phi.at(outgoing[i]->id())
+                                       : outgoing[i]->phi_;
       }
       prog.AddLinearConstraint(RowVectorXd::Ones(outgoing.size()), 0.0,
                                is_target ? 0.0 : 1.0, phi_out);
@@ -489,9 +502,10 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
   }
   if (convex_relaxation) {
     // Write the value of the relaxed phi into the phi placeholder.
-    for (const std::pair<const Edge* const, Variable>& phipair : relaxed_phi) {
-      decision_variable_index.emplace(phipair.first->phi_.get_id(), count);
-      x_val[count++] = result.GetSolution(phipair.second);
+    for (const auto& [edge_id, relaxed_phi_var] : relaxed_phi) {
+      decision_variable_index.emplace(edges_.at(edge_id)->phi_.get_id(),
+                                      count);
+      x_val[count++] = result.GetSolution(relaxed_phi_var);
     }
   }
   result.set_decision_variable_index(decision_variable_index);

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -7,7 +7,6 @@
 #include <set>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -236,7 +235,7 @@ class GraphOfConvexSets {
     // Note: ell_[i] is associated with costs_[i].
     solvers::VectorXDecisionVariable ell_{};
     std::vector<solvers::Binding<solvers::Cost>> costs_{};
-    std::unordered_set<solvers::Binding<solvers::Constraint>> constraints_{};
+    std::vector<solvers::Binding<solvers::Constraint>> constraints_{};
     std::optional<bool> phi_value_{};
 
     friend class GraphOfConvexSets;
@@ -264,13 +263,19 @@ class GraphOfConvexSets {
   */
   Edge* AddEdge(const Vertex& u, const Vertex& v, std::string name = "");
 
-  /** Returns the VertexIds of the vertices stored in the graph.  Note that the
-  order of the elements is not guaranteed. */
-  std::unordered_set<VertexId> VertexIds() const;
+  /** Returns mutable pointers to the vertices stored in the graph. */
+  std::vector<Vertex*> Vertices();
 
-  /** Returns pointers to the edges stored in the graph.  Note that the order of
-  the elements is not guaranteed. */
-  std::unordered_set<Edge*> Edges();
+  /** Returns pointers to the vertices stored in the graph.
+  @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.} */
+  std::vector<const Vertex*> Vertices() const;
+
+  /** Returns mutable pointers to the edges stored in the graph. */
+  std::vector<Edge*> Edges();
+
+  /** Returns pointers to the edges stored in the graph.
+  @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.} */
+  std::vector<const Edge*> Edges() const;
 
   /** Returns a Graphviz string describing the graph vertices and edges.  If
   `results` is supplied, then the graph will be annotated with the solution

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -71,9 +71,14 @@ GTEST_TEST(GraphOfConvexSetsTest, AddVertex) {
   p.set_x(Vector3d(4., 5., 6));
   EXPECT_FALSE(v->set().PointInSet(p.x()));
 
-  auto ids = g.VertexIds();
-  EXPECT_EQ(ids.size(), 1);
-  EXPECT_EQ(*ids.begin(), v->id());
+  auto vertices = g.Vertices();
+  EXPECT_EQ(vertices.size(), 1);
+  EXPECT_EQ(vertices.at(0), v);
+
+  const GraphOfConvexSets* const_g = &g;
+  const auto const_vertices = const_g->Vertices();
+  EXPECT_EQ(const_vertices.size(), 1);
+  EXPECT_EQ(const_vertices.at(0), v);
 }
 
 GTEST_TEST(GraphOfConvexSetsTest, GetVertexSolution) {
@@ -107,7 +112,12 @@ GTEST_TEST(GraphOfConvexSetsTest, AddEdge) {
 
   auto edges = g.Edges();
   EXPECT_EQ(edges.size(), 1);
-  EXPECT_EQ(*(edges.begin()), e);
+  EXPECT_EQ(edges.at(0), e);
+
+  const GraphOfConvexSets* const_g = &g;
+  const auto const_edges = const_g->Edges();
+  EXPECT_EQ(const_edges.size(), 1);
+  EXPECT_EQ(const_edges.at(0), e);
 }
 
 GTEST_TEST(GraphOfConvexSetsTest, AddEdge2) {
@@ -156,6 +166,12 @@ TEST_F(TwoPoints, Basic) {
 
   EXPECT_EQ(Variables(e_->xu()), Variables(u_->x()));
   EXPECT_EQ(Variables(e_->xv()), Variables(v_->x()));
+
+  auto vertices = g_.Vertices();
+  EXPECT_EQ(vertices.at(0), u_);
+  EXPECT_EQ(vertices.at(1), v_);
+
+  EXPECT_EQ(g_.Edges().at(0), e_);
 }
 
 // Confirms that I can add costs (both ways) and get the solution.


### PR DESCRIPTION
Replaces unordered_map and unordered_set with containers that will
provide consistent ordering.

Also
- Adds Vertices() and EdgeIds() access methods.
- Add some missing python bindings.

API breaking change: the return values of VertexIds and Edges are now
std::vector instead of std::unordered_set. This change was made
without deprecation, per the "Experimental API" warning in the
GraphOfConvexSets class documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16016)
<!-- Reviewable:end -->
