### PR TITLE
[tutorials] Rewrite instructions for solver verbosity

### DIFF
--- a/tutorials/debug_mathematical_program.ipynb
+++ b/tutorials/debug_mathematical_program.ipynb
@@ -248,15 +248,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Set solver verbosity level\n",
-    "Many solvers can print out the progress in each iterations, and allow the users to set the verbosity levels. Here is a list of method to set the print out for each solver\n",
+    "## Enable solver verbosity\n",
+    "Many solvers can print out the progress in each iteration. To enable printouts, enable either [kPrintToConsole](https://drake.mit.edu/pydrake/pydrake.solvers.mathematicalprogram.html#pydrake.solvers.mathematicalprogram.CommonSolverOption) or [kPrintToFile](https://drake.mit.edu/pydrake/pydrake.solvers.mathematicalprogram.html#pydrake.solvers.mathematicalprogram.CommonSolverOption) in the [SolverOptions](https://drake.mit.edu/pydrake/pydrake.solvers.mathematicalprogram.html#pydrake.solvers.mathematicalprogram.SolverOptions).\n",
     "\n",
-    "1. For Mosek, call [MosekSolver::set_stream_logging(True)](https://drake.mit.edu/pydrake/pydrake.solvers.mosek.html?highlight=moseksolver#pydrake.solvers.mosek.MosekSolver.set_stream_logging).\n",
-    "2. For SNOPT, call [SetSolverOption(SnoptSolver().solver_id(), \"print file\", FILE_NAME)](https://drake.mit.edu/pydrake/pydrake.solvers.mathematicalprogram.html?highlight=setsolveroption#pydrake.solvers.mathematicalprogram.MathematicalProgram.SetSolverOption) to print the result to a file `FILE_NAME`.\n",
-    "3. For IPOPT, call [SetSolverOption(IpoptSolver().solver_id(), options, options_val)](https://drake.mit.edu/pydrake/pydrake.solvers.mathematicalprogram.html?highlight=setsolveroption#pydrake.solvers.mathematicalprogram.MathematicalProgram.SetSolverOption) to set the options relating to the solver output. You could refer to the [IPOPT documentation](https://coin-or.github.io/Ipopt/OPTIONS.html) on the supported options. For example, to adjust print level, call `prog.SetSolverOptions(IpoptSolver.id(), \"print_level\", 5)` to set the print_level to 5. \n",
-    "4. For Gurobi, call `prog.SetSolverOption(GurobiSolver().solver_id(), \"OutputFlag\", True)`.\n",
-    "5. For SCS, call `prog.SetSolverOption(ScsSolver().solver_id(), \"verbose\", 1)`.\n",
-    "6. For OSQP, call `prog.SetSolverOption(OsqpSolver().solver_id(), \"verbose\", 1)`."
+    "Note that when running code in a Jupyter notebook, solvers print to the console from which the notebook is launched, rather than the notebook window."
    ]
   },
   {
@@ -265,21 +260,45 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Demonstrate setting solver verbosity level.\n",
+    "# Create a simple program consisting of\n",
+    "#  constraint: 1 <= squared_norm(x) <= 2.\n",
+    "#  constraint: 2 <= x[0]**2 + 4 * x[0]*x[1] + 4*x[1]**2 + 2 * x[0] <= 5.\n",
     "prog = mp.MathematicalProgram()\n",
     "x = prog.NewContinuousVariables(2)\n",
-    "# Add the constraint 1 <= squared_norm(x) <= 2\n",
     "prog.AddConstraint(lambda z: [z.dot(z)], [1], [2], x)\n",
-    "# Add the constraint 2 <= x[0]**2 + 4 * x[0]*x[1] + 4*x[1]**2 + 2 * x[0] <= 5\n",
     "prog.AddConstraint(lambda z: [z[0] ** 2 + 4 * z[0] * z[1] + 4 * z[1]**2 + 2 * z[0]], [2], [5], x)\n",
-    "\n",
-    "ipopt_solver = IpoptSolver()\n",
-    "# Set print level to 5. \n",
-    "prog.SetSolverOption(ipopt_solver.solver_id(), \"print_level\", 5)\n",
     "prog.SetInitialGuess(x, [0, 0])\n",
-    "# If you are running this code in jupyter notebook, the solver prints out the\n",
-    "# progress in the console from which this notebook is launched.\n",
+    "\n",
+    "# Solve without printing.\n",
+    "ipopt_solver = IpoptSolver()\n",
+    "result = ipopt_solver.Solve(prog)\n",
+    "\n",
+    "# Solve with printing.\n",
+    "solver_options = mp.SolverOptions()\n",
+    "solver_options.SetOption(mp.CommonSolverOption.kPrintToConsole, 1)\n",
+    "result = ipopt_solver.Solve(prog, solver_options=solver_options)\n",
+    "\n",
+    "# The options can also be attached to the program, instead of passed to Solve().\n",
+    "prog.SetSolverOptions(solver_options)\n",
     "result = ipopt_solver.Solve(prog)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Some solvers offer more fine-tuning for the progress output.  For example, the [IPOPT options](https://coin-or.github.io/Ipopt/OPTIONS.html) offer an IPOPT-specific `print_level`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Enable extreme levels of IPOPT printing for this Solve().\n",
+    "solver_options.SetOption(IpoptSolver.id(), \"print_level\", 12)\n",
+    "result = ipopt_solver.Solve(prog, solver_options=solver_options)"
    ]
   },
   {


### PR DESCRIPTION
The existing instructions were mostly using deprecated / dis-preferred spellings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16019)
<!-- Reviewable:end -->
