### PR TITLE
Remove deprecated 2021-11 solvers

### DIFF
--- a/bindings/pydrake/solvers/mosek_py.cc
+++ b/bindings/pydrake/solvers/mosek_py.cc
@@ -24,14 +24,6 @@ PYBIND11_MODULE(mosek, m) {
       m, "MosekSolver", doc.MosekSolver.doc);
   cls.def(py::init<>(), doc.MosekSolver.ctor.doc)
       .def_static("id", &MosekSolver::id, doc.MosekSolver.id.doc);
-
-  {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    cls.def("set_stream_logging", &MosekSolver::set_stream_logging,
-        py::arg("flag"), py::arg("log_file"));
-#pragma GCC diagnostic pop
-  }
   pysolvers::BindAcquireLicense(&cls, doc.MosekSolver);
 
   py::class_<MosekSolverDetails>(

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -1891,17 +1891,8 @@ void MosekSolver::DoSolve(const MathematicalProgram& prog,
   }
 
   // log file.
-  bool print_to_console = merged_options.get_print_to_console();
-  std::string print_file_name = merged_options.get_print_file_name();
-  // TODO(hongkai.dai) remove stream_logging_ and log_file_ once
-  // set_stream_logging() is deprecated on 2021-11-01.
-  if (stream_logging_) {
-    if (log_file_.empty()) {
-      print_to_console = true;
-    } else {
-      print_file_name = log_file_;
-    }
-  }
+  const bool print_to_console = merged_options.get_print_to_console();
+  const std::string print_file_name = merged_options.get_print_file_name();
   // Refer to https://docs.mosek.com/9.2/capi/solver-io.html#stream-logging
   // for Mosek stream logging.
   // First we check if the user wants to print to both the console and the file.

--- a/solvers/mosek_solver.h
+++ b/solvers/mosek_solver.h
@@ -76,22 +76,6 @@ class MosekSolver final : public SolverBase {
   ~MosekSolver() final;
 
   /**
-   * Control stream logging. Refer to
-   * https://docs.mosek.com/9.2/capi/solver-io.html for more details.
-   * @param flag Set to true if the user want to turn on stream logging.
-   * @param log_file If the user wants to output the logging to a file, then
-   * set @p log_file to the name of that file. If the user wants to output the
-   * logging to the console, then set log_file to empty string.
-   */
-  DRAKE_DEPRECATED("2021-11-01",
-                   "Please set CommonSolverOption::kPrintFileName or "
-                   "CommonSolverOption::kPrintToConsole in SolverOptions")
-  void set_stream_logging(bool flag, const std::string& log_file) {
-    stream_logging_ = flag;
-    log_file_ = log_file;
-  }
-
-  /**
    * This type contains a valid MOSEK license environment, and is only to be
    * used from AcquireLicense().
    */
@@ -134,14 +118,6 @@ class MosekSolver final : public SolverBase {
   // during the first call of Solve() (which avoids grabbing a Mosek license
   // before we know that we actually want one).
   mutable std::shared_ptr<License> license_;
-  // Set to true if the user wants the solver to produce output to the console
-  // or a log file. Default to false, such that the solver runs silently.
-  // Check out https://docs.mosek.com/9.2/capi/solver-io.html for more info.
-  bool stream_logging_{false};
-  // set @p log_file to the name of that file. If the user wants to output the
-  // logging to the console, then set log_file to empty string. Default to an
-  // empty string.
-  std::string log_file_{};
 };
 
 }  // namespace solvers

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -203,32 +203,6 @@ GTEST_TEST(TestExponentialConeProgram, MinimalEllipsoidConveringPoints) {
   }
 }
 
-GTEST_TEST(MosekTest, TestLogFile) {
-  // Test if we can print the logging info to a log file.
-  MathematicalProgram prog;
-  const auto x = prog.NewContinuousVariables<2>();
-  prog.AddLinearConstraint(x(0) + x(1) == 1);
-
-  const std::string log_file = temp_directory() + "/mosek.log";
-  EXPECT_FALSE(filesystem::exists({log_file}));
-  MosekSolver solver;
-  MathematicalProgramResult result;
-  solver.Solve(prog, {}, {}, &result);
-  // By default, no logging file.
-  EXPECT_FALSE(filesystem::exists({log_file}));
-  // Output the logging to the console
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  solver.set_stream_logging(true, "");
-  solver.Solve(prog, {}, {}, &result);
-  EXPECT_FALSE(filesystem::exists({log_file}));
-  // Output the logging to the file.
-  solver.set_stream_logging(true, log_file);
-#pragma GCC diagnostic pop
-  solver.Solve(prog, {}, {}, &result);
-  EXPECT_TRUE(filesystem::exists({log_file}));
-}
-
 GTEST_TEST(MosekTest, TestLogging) {
   // Test if we can print the logging info to a log file.
   MathematicalProgram prog;


### PR DESCRIPTION
Note that this deprecated function is also referred to by our tutorials, but that is fixed separately in #16019.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16020)
<!-- Reviewable:end -->
