### PR TITLE
iris_test: Run in 4 shards

### DIFF
--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -131,6 +131,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "iris_test",
+    shard_count = 4,
     deps = [
         ":iris",
         "//common/test_utilities:eigen_matrix_compare",


### PR DESCRIPTION
This patch aims to avoid test timeouts in asan and memcheck configurations.

Hotfix for #15789.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16024)
<!-- Reviewable:end -->
