### PR TITLE
Return const VectorX& rather than VectorBlock where possible

### DIFF
--- a/examples/bead_on_a_wire/bead_on_a_wire.cc
+++ b/examples/bead_on_a_wire/bead_on_a_wire.cc
@@ -204,8 +204,7 @@ void BeadOnAWire<T>::DoCalcTimeDerivatives(
   systems::VectorBase<T>& f = derivatives->get_mutable_vector();
 
   // Get the inputs.
-  const Eigen::VectorBlock<const VectorX<T>> input =
-      this->get_input_port(0).Eval(context);
+  const VectorX<T>& input = this->get_input_port(0).Eval(context);
 
   // Compute the derivatives using the desired coordinate representation.
   if (coordinate_type_ == kMinimalCoordinates) {

--- a/examples/compass_gait/compass_gait_geometry.cc
+++ b/examples/compass_gait/compass_gait_geometry.cc
@@ -139,7 +139,7 @@ void CompassGaitGeometry::OutputGeometryPose(
   DRAKE_DEMAND(left_leg_frame_id_.is_valid());
   DRAKE_DEMAND(right_leg_frame_id_.is_valid());
 
-  Eigen::VectorBlock<const VectorXd> input = get_input_port(0).Eval(context);
+  const VectorXd& input = get_input_port(0).Eval(context);
   const math::RigidTransformd left_pose(
       math::RollPitchYawd(input.segment<3>(3)), input.head<3>());
   const double hip_angle = input[6];

--- a/examples/mass_spring_cloth/cloth_spring_model.cc
+++ b/examples/mass_spring_cloth/cloth_spring_model.cc
@@ -230,8 +230,6 @@ void ClothSpringModel<T>::UpdateDiscreteState(
   // which we abbreviate as H * dv = f * dt.
   VectorX<T> dv = VectorX<T>::Zero(v_hat.size());
   VectorX<T> damping_force = VectorX<T>::Zero(v_hat.size());
-  // Extract a const Eigen::VectorBlock<const VectorX<T>>& tmp_v_hat to comply
-  // with the API of AccumulateDampingForce.
   AccumulateDampingForce(p, q_n, v_hat, &damping_force);
   CalcDiscreteDv(p, q_n, &damping_force, &dv);
 

--- a/examples/rimless_wheel/rimless_wheel_geometry.cc
+++ b/examples/rimless_wheel/rimless_wheel_geometry.cc
@@ -108,7 +108,7 @@ void RimlessWheelGeometry::OutputGeometryPose(
     geometry::FramePoseVector<double>* poses) const {
   DRAKE_DEMAND(frame_id_.is_valid());
 
-  Eigen::VectorBlock<const VectorXd> input = get_input_port(0).Eval(context);
+  const VectorXd& input = get_input_port(0).Eval(context);
   const math::RigidTransformd pose(math::RollPitchYawd(input.segment<3>(3)),
                                    input.head<3>());
 

--- a/examples/rod2d/rod2d.cc
+++ b/examples/rod2d/rod2d.cc
@@ -64,8 +64,7 @@ Vector3<T> Rod2D<T>::ComputeExternalForces(
     const systems::Context<T>& context) const {
   // Compute the external forces (expressed in the world frame).
   const int port_index = 0;
-  const Eigen::VectorBlock<const VectorX<T>> input =
-      this->get_input_port(port_index).Eval(context);
+  const VectorX<T>& input = this->get_input_port(port_index).Eval(context);
   const Vector3<T> fgrav(0, mass_ * get_gravitational_acceleration(), 0);
   const Vector3<T> fapplied = input.segment(0, 3);
   return fgrav + fapplied;

--- a/systems/controllers/inverse_dynamics.cc
+++ b/systems/controllers/inverse_dynamics.cc
@@ -69,8 +69,7 @@ template <typename T>
 void InverseDynamics<T>::SetMultibodyContext(
     const Context<T>& context,
     Context<T>* multibody_plant_context) const {
-  const Eigen::VectorBlock<const VectorX<T>> x =
-      get_input_port_estimated_state().Eval(context);
+  const VectorX<T>& x = get_input_port_estimated_state().Eval(context);
 
   if (this->is_pure_gravity_compensation()) {
     // Velocities remain zero, as set in the constructor, for pure gravity
@@ -112,7 +111,7 @@ void InverseDynamics<T>::CalcOutputForce(const Context<T>& context,
             .template Eval<MultibodyForces<T>>(context);
 
     // Compute inverse dynamics.
-    Eigen::VectorBlock<const VectorX<T>> desired_vd =
+    const VectorX<T>& desired_vd =
         get_input_port_desired_acceleration().Eval(context);
     output->get_mutable_value() = plant.CalcInverseDynamics(
         multibody_plant_context, desired_vd, external_forces);

--- a/systems/controllers/linear_model_predictive_controller.cc
+++ b/systems/controllers/linear_model_predictive_controller.cc
@@ -72,8 +72,7 @@ LinearModelPredictiveController<T>::LinearModelPredictiveController(
 template <typename T>
 void LinearModelPredictiveController<T>::CalcControl(
     const Context<T>& context, BasicVector<T>* control) const {
-  const Eigen::VectorBlock<const VectorX<T>> current_state =
-      get_state_port().Eval(context);
+  const VectorX<T>& current_state = get_state_port().Eval(context);
 
   const Eigen::VectorXd current_input =
       SetupAndSolveQp(*base_context_, current_state);

--- a/systems/controllers/pid_controller.cc
+++ b/systems/controllers/pid_controller.cc
@@ -83,10 +83,8 @@ PidController<T>::PidController(const PidController<U>& other)
 template <typename T>
 void PidController<T>::DoCalcTimeDerivatives(
     const Context<T>& context, ContinuousState<T>* derivatives) const {
-  const Eigen::VectorBlock<const VectorX<T>> state =
-      get_input_port_estimated_state().Eval(context);
-  const Eigen::VectorBlock<const VectorX<T>> state_d =
-      get_input_port_desired_state().Eval(context);
+  const VectorX<T>& state = get_input_port_estimated_state().Eval(context);
+  const VectorX<T>& state_d = get_input_port_desired_state().Eval(context);
 
   // The derivative of the continuous state is the instantaneous position error.
   VectorBase<T>& derivatives_vector = derivatives->get_mutable_vector();
@@ -99,10 +97,8 @@ void PidController<T>::DoCalcTimeDerivatives(
 template <typename T>
 void PidController<T>::CalcControl(const Context<T>& context,
                                    BasicVector<T>* control) const {
-  const Eigen::VectorBlock<const VectorX<T>> state =
-      get_input_port_estimated_state().Eval(context);
-  const Eigen::VectorBlock<const VectorX<T>> state_d =
-      get_input_port_desired_state().Eval(context);
+  const VectorX<T>& state = get_input_port_estimated_state().Eval(context);
+  const VectorX<T>& state_d = get_input_port_desired_state().Eval(context);
 
   // State error.
   const VectorX<T> controlled_state_diff =

--- a/systems/estimators/luenberger_observer.cc
+++ b/systems/estimators/luenberger_observer.cc
@@ -125,14 +125,14 @@ void LuenbergerObserver<T>::DoCalcTimeDerivatives(
       observed_system_context_cache_entry_->Eval<Context<T>>(context);
 
   // Evaluate the observed system.
-  Eigen::VectorBlock<const VectorX<T>> yhat =
+  const VectorX<T>& yhat =
       observed_system_->get_output_port(0).Eval(observed_system_context);
   VectorX<T> xdothat =
       observed_system_->EvalTimeDerivatives(observed_system_context)
           .CopyToVector();
 
   // Get the measurements.
-  Eigen::VectorBlock<const VectorX<T>> y =
+  const VectorX<T>& y =
       this->get_observed_system_output_input_port().Eval(context);
 
   // xdothat = f(xhat,u) + L(y-yhat).

--- a/systems/framework/input_port.h
+++ b/systems/framework/input_port.h
@@ -48,7 +48,7 @@ class InputPort final : public InputPortBase {
   _very_ fast if the value is already up to date.
 
   @tparam ValueType The type of the const-reference returned by this method.
-  When omitted, the return type is an `Eigen::VectorBlock` (this is only valid
+  When omitted, the return type is `const VectorX<T>&` (this is only valid
   when this is a vector-valued port).  For abstract ports, the `ValueType`
   either can be the declared type of the port (e.g., `lcmt_iiwa_status`), or
   else in advanced use cases can be `AbstractValue` to get the type-erased
@@ -56,7 +56,7 @@ class InputPort final : public InputPortBase {
 
   @return reference to the up-to-date value; if a ValueType is provided, the
   return type is `const ValueType&`; if a ValueType is omitted, the return type
-  is `Eigen::VectorBlock<const VectorX<T>>`.
+  is `const VectorX<T>&`.
 
   @throw std::exception if the port is not connected.  (Use HasValue() to check
   first, if necessary.)
@@ -65,12 +65,12 @@ class InputPort final : public InputPortBase {
   @pre The input port is of type ValueType (when ValueType is provided).
   */
 #ifdef DRAKE_DOXYGEN_CXX
-  template <typename ValueType = Eigen::VectorBlock<const VectorX<T>>>
+  template <typename ValueType = VectorX<T>>
   const ValueType& Eval(const Context<T>& context) const;
 #else
   // Without a template -- return Eigen.
-  Eigen::VectorBlock<const VectorX<T>> Eval(const Context<T>& context) const {
-    return Eval<BasicVector<T>>(context).get_value();
+  const VectorX<T>& Eval(const Context<T>& context) const {
+    return Eval<BasicVector<T>>(context).value();
   }
   // With ValueType == AbstractValue, we don't need to downcast.
   template <typename ValueType, typename = std::enable_if_t<

--- a/systems/framework/output_port.h
+++ b/systems/framework/output_port.h
@@ -79,7 +79,7 @@ class OutputPort : public OutputPortBase {
   _very_ fast if the value is already up to date.
 
   @tparam ValueType The type of the const-reference returned by this method.
-  When omitted, the return type is an `Eigen::VectorBlock` (this is only valid
+  When omitted, the return type is `const VectorX<T>&` (this is only valid
   when this is a vector-valued port).  For abstract ports, the `ValueType`
   either can be the declared type of the port (e.g., `lcmt_iiwa_status`), or
   else in advanced use cases can be `AbstractValue` to get the type-erased
@@ -87,7 +87,7 @@ class OutputPort : public OutputPortBase {
 
   @return reference to the up-to-date value; if a ValueType is provided, the
   return type is `const ValueType&`; if a ValueType is omitted, the return type
-  is `Eigen::VectorBlock<const VectorX<T>>`.
+  is `const VectorX<T>&`.
 
   @throw std::exception if the port is not connected.
 
@@ -95,12 +95,12 @@ class OutputPort : public OutputPortBase {
   @pre The output port is of type ValueType (when ValueType is provided).
   */
 #ifdef DRAKE_DOXYGEN_CXX
-  template <typename ValueType = Eigen::VectorBlock<const VectorX<T>>>
+  template <typename ValueType = VectorX<T>>
   const ValueType& Eval(const Context<T>& context) const;
 #else
   // Without a template -- return Eigen.
-  Eigen::VectorBlock<const VectorX<T>> Eval(const Context<T>& context) const {
-    return Eval<BasicVector<T>>(context).get_value();
+  const VectorX<T>& Eval(const Context<T>& context) const {
+    return Eval<BasicVector<T>>(context).value();
   }
   // With ValueType == AbstractValue, we don't need to downcast.
   template <typename ValueType, typename = std::enable_if_t<

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -841,8 +841,7 @@ void System<T>::FixInputPortsFrom(const System<double>& other_system,
       case kVectorValued: {
         // For vector-valued input ports, we placewise initialize a fixed
         // input vector using the explicit conversion from double to T.
-        const Eigen::VectorBlock<const VectorX<double>> other_vec =
-            other_port.Eval(other_context);
+        const VectorX<double>& other_vec = other_port.Eval(other_context);
         auto our_vec = this->AllocateInputVector(input_port);
         for (int j = 0; j < our_vec->size(); ++j) {
           (*our_vec)[j] = T(other_vec[j]);

--- a/systems/framework/system_symbolic_inspector.h
+++ b/systems/framework/system_symbolic_inspector.h
@@ -75,35 +75,31 @@ class SystemSymbolicInspector {
 
   /// Returns a reference to the symbolic representation of the input.
   /// @param i The input port number.
-  Eigen::VectorBlock<const VectorX<symbolic::Variable>> input(int i) const {
+  const VectorX<symbolic::Variable>& input(int i) const {
     DRAKE_DEMAND(i >= 0 && i < static_cast<int>(input_variables_.size()));
-    return input_variables_[i].head(input_variables_[i].rows());
+    return input_variables_[i];
   }
 
   /// Returns a reference to the symbolic representation of the continuous
   /// state.
-  Eigen::VectorBlock<const VectorX<symbolic::Variable>> continuous_state()
-      const {
-    return continuous_state_variables_.head(continuous_state_variables_.rows());
+  const VectorX<symbolic::Variable>& continuous_state() const {
+    return continuous_state_variables_;
   }
 
   /// Returns a reference to the symbolic representation of the discrete state.
   /// @param i The discrete state group number.
-  Eigen::VectorBlock<const VectorX<symbolic::Variable>> discrete_state(
-      int i) const {
+  const VectorX<symbolic::Variable>& discrete_state(int i) const {
     DRAKE_DEMAND(i >= 0 &&
                  i < static_cast<int>(discrete_state_variables_.size()));
-    return discrete_state_variables_[i].head(
-        discrete_state_variables_[i].rows());
+    return discrete_state_variables_[i];
   }
 
   /// Returns a reference to the symbolic representation of the numeric
   /// parameters.
   /// @param i The numeric parameter group number.
-  Eigen::VectorBlock<const VectorX<symbolic::Variable>> numeric_parameters(
-      int i) const {
+  const VectorX<symbolic::Variable>& numeric_parameters(int i) const {
     DRAKE_DEMAND(i >= 0 && i < static_cast<int>(numeric_parameters_.size()));
-    return numeric_parameters_[i].head(numeric_parameters_[i].rows());
+    return numeric_parameters_[i];
   }
 
   /// Returns a copy of the symbolic representation of the continuous-time
@@ -115,17 +111,16 @@ class SystemSymbolicInspector {
   /// Returns a reference to the symbolic representation of the discrete-time
   /// dynamics.
   /// @param i The discrete state group number.
-  Eigen::VectorBlock<const VectorX<symbolic::Expression>> discrete_update(
-      int i) const {
+  const VectorX<symbolic::Expression>& discrete_update(int i) const {
     DRAKE_DEMAND(i >= 0 && i < context_->num_discrete_state_groups());
-    return discrete_updates_->get_vector(i).get_value();
+    return discrete_updates_->value(i);
   }
 
   /// Returns a reference to the symbolic representation of the output.
   /// @param i The output port number.
-  Eigen::VectorBlock<const VectorX<symbolic::Expression>> output(int i) const {
+  const VectorX<symbolic::Expression>& output(int i) const {
     DRAKE_DEMAND(output_port_types_[i] == kVectorValued);
-    return output_->get_vector_data(i)->get_value();
+    return output_->get_vector_data(i)->value();
   }
 
   /// Returns a reference to the symbolic representation of the constraints.

--- a/systems/lcm/lcm_scope_system.cc
+++ b/systems/lcm/lcm_scope_system.cc
@@ -12,7 +12,7 @@ namespace {
 
 void Convert(
     const double time,
-    const Eigen::VectorBlock<const VectorX<double>>& input,
+    const VectorX<double>& input,
     lcmt_scope* output) {
   output->utime = static_cast<int64_t>(time * 1e6);
   output->size = input.size();

--- a/systems/primitives/linear_transform_density.cc
+++ b/systems/primitives/linear_transform_density.cc
@@ -64,8 +64,7 @@ void LinearTransformDensity<T>::CalcOutputDensity(
 template <typename T>
 Eigen::Map<const MatrixX<T>> LinearTransformDensity<T>::GetA(
     const Context<T>& context) const {
-  const Eigen::VectorBlock<const VectorX<T>> A_flat =
-      this->get_input_port_A().Eval(context);
+  const VectorX<T>& A_flat = this->get_input_port_A().Eval(context);
   return Eigen::Map<const MatrixX<T>>(A_flat.data(), output_size_, input_size_);
 }
 

--- a/systems/primitives/sine.cc
+++ b/systems/primitives/sine.cc
@@ -158,8 +158,7 @@ void Sine<T>::CalcArg(
     time_vec.fill(context.get_time());
     *arg = frequency_.array() * time_vec.array() + phase_.array();
   } else {
-    Eigen::VectorBlock<const VectorX<T>> input =
-        this->get_input_port(0).Eval(context);
+    const VectorX<T>& input = this->get_input_port(0).Eval(context);
     *arg = frequency_.array() * input.array() + phase_.array();
   }
 }

--- a/systems/primitives/vector_log.h
+++ b/systems/primitives/vector_log.h
@@ -46,6 +46,8 @@ class VectorLog {
   /** Returns the number of samples taken since construction or last Clear(). */
   int num_samples() const { return num_samples_; }
 
+  // The return type here must be a VectorBlock because only the leading
+  // part of the sample_times_ vector contains meaningful data.
   /** Accesses the logged time stamps. */
   Eigen::VectorBlock<const VectorX<T>> sample_times() const {
     return const_cast<const VectorX<T>&>(sample_times_).head(num_samples_);

--- a/systems/sensors/rotary_encoders.cc
+++ b/systems/sensors/rotary_encoders.cc
@@ -109,9 +109,9 @@ void RotaryEncoders<T>::set_calibration_offsets(
 }
 
 template <typename T>
-Eigen::VectorBlock<const VectorX<T>> RotaryEncoders<T>::get_calibration_offsets(
+const VectorX<T>& RotaryEncoders<T>::get_calibration_offsets(
     const Context<T>& context) const {
-  return context.get_numeric_parameter(0).get_value();
+  return context.get_numeric_parameter(0).value();
 }
 
 }  // namespace sensors

--- a/systems/sensors/rotary_encoders.h
+++ b/systems/sensors/rotary_encoders.h
@@ -51,8 +51,7 @@ class RotaryEncoders final : public VectorSystem<T> {
       const Eigen::Ref<VectorX<T>>& calibration_offsets) const;
 
   /// Retrieve the calibration offset parameters.
-  Eigen::VectorBlock<const VectorX<T>> get_calibration_offsets(
-      const Context<T>& context) const;
+  const VectorX<T>& get_calibration_offsets(const Context<T>& context) const;
 
  private:
   // Allow different specializations to access each other's private data.


### PR DESCRIPTION
Change `port.Eval()` methods and several other public methods to return `const VectorX<T>&` rather than `VectorBlock<const VectorX<T>>`.

This is a precursor to API cleanup work for #11346 and #15986. For motivation see Slack discussion beginning [here](https://drakedevelopers.slack.com/archives/C2CHRT98E/p1635787391010100).

Here are the changed public methods. Each previously returned `VectorBlock<const VectorX<T>>` and now returns `const VectorX<T>&`.
- InputPort::Eval() with no template argument
- OutputPort::Eval() with no template argument
- SystemSymbolicInspector:: input() output() continuous_state() discrete_state() numeric_parameters() discrete_update()
- VectorSystem:: EvalVectorInput() GetVectorState() 
- RotaryEncoders::get_calibration_offsets()
  
Notes:
- This is a **breaking change** in cases where callers explicitly denote the return type as a VectorBlock.
- `System::EvalVectorInput()` is _not_ changed here (it returns `BasicVector` by default but should return `VectorX`) because we intend to deprecate it -- it has been superseded by `input_port.Eval()`. 
- Virtuals defined by `VectorSystem` still take VectorBlock parameters. The const ones could be VectorX's instead but the existing signature is harmless and only affects programmers deriving from VectorSystem. It does not affect the intro-to-Drake API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16031)
<!-- Reviewable:end -->
