### PR TITLE
[workspace] Upgrade lcm to latest commit

### DIFF
--- a/tools/workspace/lcm/BUILD.bazel
+++ b/tools/workspace/lcm/BUILD.bazel
@@ -1,6 +1,7 @@
 # -*- python -*-
 
 load("//tools/lint:lint.bzl", "add_lint_tests")
+load("@drake//tools/skylark:drake_py.bzl", "drake_py_unittest")
 
 exports_files(
     [
@@ -9,6 +10,11 @@ exports_files(
         "test/lcm-gen_install_test.py",
     ],
     visibility = ["@lcm//:__pkg__"],
+)
+
+drake_py_unittest(
+    name = "no_lcm_warnings_test",
+    deps = ["@lcm//:lcm-python"],
 )
 
 add_lint_tests(python_lint_extra_srcs = ["test/lcm-gen_install_test.py"])

--- a/tools/workspace/lcm/repository.bzl
+++ b/tools/workspace/lcm/repository.bzl
@@ -11,8 +11,8 @@ def lcm_repository(
         # When upgrading this commit, check if the LCM maintainers have tagged
         # a new version number; if so, then update the version numbers within
         # the two lcm-*.cmake files in this directory to match.
-        commit = "e83d2d0810c7f1751123383ab7c3dc4da1b53602",
-        sha256 = "13f478db7002165e9987b6e6cbcc8e42e2c103c882b360236b83c9ba5355f539",  # noqa
+        commit = "91ce7a2ae46ad05f8a232f5fe32a06cccbead1c2",
+        sha256 = "8ea0076d2f2158fc750fec697b68c6903a9d70ccbe4e3f24240415a13445381f",  # noqa
         build_file = "@drake//tools/workspace/lcm:package.BUILD.bazel",
         mirrors = mirrors,
     )

--- a/tools/workspace/lcm/test/no_lcm_warnings_test.py
+++ b/tools/workspace/lcm/test/no_lcm_warnings_test.py
@@ -1,0 +1,16 @@
+import unittest
+import warnings
+
+from lcm import LCM
+
+
+class Test(unittest.TestCase):
+
+    def test_publish(self):
+        """
+        Ensures that no warnings are issued using `lcm.publish()`.
+        """
+        lcm = LCM("memq://")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            lcm.publish("TEST_CHANNEL", b"")


### PR DESCRIPTION
Fixes DeprecationWarning about PY_SSIZE_T_CLEAN on later
versions of Python

Resolves #16033

Requires:
- [x] https://github.com/lcm-proj/lcm/pull/363

FYI @sloretz @jwnimmer-tri

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16034)
<!-- Reviewable:end -->
