### PR TITLE
Clean up state value setting call sites

### DIFF
--- a/examples/manipulation_station/differential_ik.py
+++ b/examples/manipulation_station/differential_ik.py
@@ -58,7 +58,7 @@ class DifferentialIK(LeafSystem):
                                     position_state_index)
 
     def SetPositions(self, context, q):
-        context.get_mutable_discrete_state(0).SetFromVector(q)
+        context.SetDiscreteState(0, q)
 
     def ForwardKinematics(self, q):
         x = self.robot.GetMutablePositionsAndVelocities(

--- a/examples/rod2d/rod2d.cc
+++ b/examples/rod2d/rod2d.cc
@@ -1021,7 +1021,7 @@ void Rod2D<T>::DoCalcTimeDerivatives(
 /// such that it and the halfspace are touching at exactly one point of contact.
 template <typename T>
 void Rod2D<T>::SetDefaultState(const systems::Context<T>&,
-                                  systems::State<T>* state) const {
+                               systems::State<T>* state) const {
   using std::sqrt;
   using std::sin;
 

--- a/examples/rod2d/test/rod2d_test.cc
+++ b/examples/rod2d/test/rod2d_test.cc
@@ -1141,7 +1141,7 @@ GTEST_TEST(Rod2DCrossValidationTest, Outputs) {
   x_pdae[0] = 0;
   x_pdae[1] = pdae.get_rod_half_length();
   x_pdae[2] = M_PI_2;
-  context_pdae->get_mutable_continuous_state().SetFromVector(x_pdae);
+  context_pdae->SetContinuousState(x_pdae);
   pdae.CalcOutput(*context_pdae, output_pdae.get());
 }
 

--- a/manipulation/planner/differential_inverse_kinematics_integrator.cc
+++ b/manipulation/planner/differential_inverse_kinematics_integrator.cc
@@ -54,7 +54,7 @@ void DifferentialInverseKinematicsIntegrator::SetPositions(
     Context<double>* context,
     const Eigen::Ref<const Eigen::VectorXd>& positions) const {
   DRAKE_DEMAND(positions.size() == robot_.num_positions());
-  context->get_mutable_discrete_state(0).SetFromVector(positions);
+  context->SetDiscreteState(0, positions);
 }
 
 math::RigidTransformd

--- a/systems/analysis/simulator.cc
+++ b/systems/analysis/simulator.cc
@@ -421,7 +421,7 @@ void Simulator<T>::IsolateWitnessTriggers(
       [&t0, &x0, &context, this](const T& t_des) {
     const T inf = std::numeric_limits<double>::infinity();
     context.SetTime(t0);
-    context.get_mutable_continuous_state().SetFromVector(x0);
+    context.SetContinuousState(x0);
     while (context.get_time() < t_des)
       integrator_->IntegrateNoFurtherThanTime(inf, inf, t_des);
   };

--- a/systems/controllers/inverse_dynamics.cc
+++ b/systems/controllers/inverse_dynamics.cc
@@ -96,7 +96,7 @@ void InverseDynamics<T>::CalcMultibodyForces(
 
 template <typename T>
 void InverseDynamics<T>::CalcOutputForce(const Context<T>& context,
-                                          BasicVector<T>* output) const {
+                                         BasicVector<T>* output) const {
   auto& plant = *multibody_plant_;
 
   const auto& multibody_plant_context =

--- a/systems/controllers/test/linear_model_predictive_controller_test.cc
+++ b/systems/controllers/test/linear_model_predictive_controller_test.cc
@@ -40,7 +40,7 @@ class TestMpcWithDoubleIntegrator : public ::testing::Test {
     std::unique_ptr<Context<double>> system_context =
         system->CreateDefaultContext();
     system->get_input_port().FixValue(system_context.get(), u0);
-    system_context->get_mutable_discrete_state(0).SetFromVector(x0);
+    system_context->SetDiscreteState(0, x0);
 
     dut_.reset(new LinearModelPredictiveController<double>(
         std::move(system), std::move(system_context), Q_, R_, kTimeStep,

--- a/systems/controllers/test/linear_quadratic_regulator_test.cc
+++ b/systems/controllers/test/linear_quadratic_regulator_test.cc
@@ -93,9 +93,9 @@ void TestLQRAffineSystemAgainstKnownSolution(
 
   sys.get_input_port().FixValue(context.get(), u0);
   if (sys.time_period() == 0.0) {
-    context->get_mutable_continuous_state().SetFromVector(x0);
+    context->SetContinuousState(x0);
   } else {
-    context->get_mutable_discrete_state(0).SetFromVector(x0);
+    context->SetDiscreteState(0, x0);
   }
   std::unique_ptr<AffineSystem<double>> lqr =
       LinearQuadraticRegulator(sys, *context, Q, R, N);

--- a/systems/estimators/test/kalman_filter_test.cc
+++ b/systems/estimators/test/kalman_filter_test.cc
@@ -48,8 +48,7 @@ GTEST_TEST(TestKalman, DoubleIntegrator) {
   auto sys = std::make_unique<LinearSystem<double>>(A, B, C, D);
   auto context = sys->CreateDefaultContext();
   sys->get_input_port().FixValue(context.get(), 0.0);
-  context->get_mutable_continuous_state().SetFromVector(
-      Eigen::Vector2d::Zero());
+  context->SetContinuousState(Eigen::Vector2d::Zero());
   auto filter =
       SteadyStateKalmanFilter(std::move(sys), std::move(context), W, V);
 

--- a/systems/framework/test/system_constraint_test.cc
+++ b/systems/framework/test/system_constraint_test.cc
@@ -287,8 +287,7 @@ TEST_F(ExternalSystemConstraintTest, NonSymbolic) {
   // and checking the result, for double.
   auto context_double = system_.CreateDefaultContext();
   system_.get_input_port().FixValue(context_double.get(), VectorXd::Zero(1));
-  context_double->get_mutable_continuous_state().SetFromVector(
-      (VectorXd(2) << 0.0, 22.0).finished());
+  context_double->SetContinuousState((VectorXd(2) << 0.0, 22.0).finished());
   VectorXd value_double;
   dut.get_calc<double>()(system_, *context_double, &value_double);
   EXPECT_TRUE(CompareMatrices(value_double, Vector2d(22.0, 0.0)));
@@ -300,7 +299,7 @@ TEST_F(ExternalSystemConstraintTest, NonSymbolic) {
   auto context_autodiff = system_autodiff->CreateDefaultContext();
   system_autodiff->get_input_port().FixValue(context_autodiff.get(),
                                              VectorX<T>::Zero(1));
-  context_autodiff->get_mutable_continuous_state().SetFromVector(
+  context_autodiff->SetContinuousState(
       (VectorX<T>(2) << T{0.0}, T{22.0}).finished());
   VectorX<T> value_autodiff;
   dut.get_calc<T>()(

--- a/systems/framework/test/vector_system_test.cc
+++ b/systems/framework/test/vector_system_test.cc
@@ -233,8 +233,7 @@ TEST_F(VectorSystemTest, OutputDiscrete) {
   auto context = dut.CreateDefaultContext();
   auto& output_port = dut.get_output_port();
   dut.get_input_port(0).FixValue(context.get(), Eigen::Vector2d(1.0, 2.0));
-  context->get_mutable_discrete_state(0).SetFromVector(
-      Eigen::Vector2d::Ones());
+  context->SetDiscreteState(0, Eigen::Vector2d::Ones());
   const auto& output = output_port.Eval(*context);
   EXPECT_EQ(dut.get_output_count(), 1);
   EXPECT_EQ(dut.get_last_context(), context.get());
@@ -296,8 +295,7 @@ TEST_F(VectorSystemTest, DiscreteVariableUpdates) {
   dut.DeclareDiscreteState(TestVectorSystem::kSize);
   context = dut.CreateDefaultContext();
   dut.get_input_port(0).FixValue(context.get(), Eigen::Vector2d(1.0, 2.0));
-  context->get_mutable_discrete_state(0).SetFromVector(
-      Eigen::Vector2d::Ones());
+  context->SetDiscreteState(0, Eigen::Vector2d::Ones());
   discrete_updates = dut.AllocateDiscreteVariables();
   dut.CalcDiscreteVariableUpdates(*context, discrete_updates.get());
   EXPECT_EQ(dut.get_last_context(), context.get());
@@ -386,7 +384,7 @@ TEST_F(VectorSystemTest, ImplicitlyNoFeedthroughTest) {
 TEST_F(VectorSystemTest, NoInputContinuousTimeSystemTest) {
   NoInputContinuousTimeSystem dut;
   auto context = dut.CreateDefaultContext();
-  context->get_mutable_continuous_state().SetFromVector(Vector1d::Ones());
+  context->SetContinuousState(Vector1d::Ones());
 
   // Ensure that time derivatives get calculated correctly.
   std::unique_ptr<ContinuousState<double>> derivatives =

--- a/systems/optimization/test/system_constraint_adapter_test.cc
+++ b/systems/optimization/test/system_constraint_adapter_test.cc
@@ -374,8 +374,7 @@ GTEST_TEST(SystemConstraintAdapterTest, MaybeCreateConstraintSymbolically1) {
 
   // Now test context.x = [a + b; 1]. Namely it contains both expression
   // and constant.
-  context_symbolic->get_mutable_continuous_state().SetFromVector(
-      Vector2<symbolic::Expression>(a + b, 1));
+  context_symbolic->SetContinuousState(Vector2<symbolic::Expression>(a + b, 1));
   // The newly generated constraint should be
   // -1 <= a + b <= 4
   // 0 <= 2 * a + 2 * b <= 3
@@ -396,8 +395,7 @@ GTEST_TEST(SystemConstraintAdapterTest, MaybeCreateConstraintSymbolically1) {
 
   // Now test a new context with context.x = [a^2, 1]. Hence the constraints
   // are nonlinear
-  context_symbolic->get_mutable_continuous_state().SetFromVector(
-      Vector2<symbolic::Expression>(a * a, 1));
+  context_symbolic->SetContinuousState(Vector2<symbolic::Expression>(a * a, 1));
   constraints = adapter.MaybeCreateConstraintSymbolically(
       system_constraint_index, *context_symbolic);
   EXPECT_FALSE(constraints.has_value());

--- a/systems/primitives/test/affine_system_test.cc
+++ b/systems/primitives/test/affine_system_test.cc
@@ -229,7 +229,7 @@ GTEST_TEST(DiscreteAffineSystemTest, DiscreteTime) {
 
   Eigen::Vector3d x0(26, 27, 28);
 
-  context->get_mutable_discrete_state(0).SetFromVector(x0);
+  context->SetDiscreteState(0, x0);
   double u0 = 29;
   system.get_input_port().FixValue(context.get(), u0);
 

--- a/systems/trajectory_optimization/direct_collocation.cc
+++ b/systems/trajectory_optimization/direct_collocation.cc
@@ -76,7 +76,7 @@ void DirectCollocationConstraint::dynamics(const AutoDiffVecXd& state,
   if (input_port_) {
     input_port_value_->GetMutableVectorData<AutoDiffXd>()->SetFromVector(input);
   }
-  context_->get_mutable_continuous_state().SetFromVector(state);
+  context_->SetContinuousState(state);
   system_->CalcTimeDerivatives(*context_, derivatives_.get());
   *xdot = derivatives_->CopyToVector();
 }
@@ -236,7 +236,7 @@ PiecewisePolynomial<double> DirectCollocation::ReconstructStateTrajectory(
       input_port_value_->GetMutableVectorData<double>()->SetFromVector(
           result.GetSolution(input(i)));
     }
-    context_->get_mutable_continuous_state().SetFromVector(states[i]);
+    context_->SetContinuousState(states[i]);
     system_->CalcTimeDerivatives(*context_, continuous_state_.get());
     derivatives[i] = continuous_state_->CopyToVector();
   }

--- a/systems/trajectory_optimization/direct_transcription.cc
+++ b/systems/trajectory_optimization/direct_transcription.cc
@@ -111,7 +111,7 @@ class DirectTranscriptionConstraint : public solvers::Constraint {
           evaluation_time_ + fixed_timestep_));
       *y = next_state - context->get_continuous_state_vector().CopyToVector();
     } else {
-      context->get_mutable_discrete_state(0).SetFromVector(state);
+      context->SetDiscreteState(0, state);
       integrator_->get_system().CalcDiscreteVariableUpdates(
           *context, discrete_state_.get());
       *y = next_state - discrete_state_->get_vector(0).get_value();


### PR DESCRIPTION
This is a minor cleanup PR to reduce ugliness at State-setting call sites by using the existing `context.SetContinuousState()` and `SetDiscreteState()` methods rather than `get_mutable_blah_blah_blah().get_mutable_vector().SetFromVector()` and the like.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16036)
<!-- Reviewable:end -->
