### PR TITLE
[doc] Withdraw support for macOS Catalina

### DIFF
--- a/doc/_pages/code_review_checklist.md
+++ b/doc/_pages/code_review_checklist.md
@@ -125,7 +125,7 @@ changes, be sure to opt-in to a pre-merge macOS build.
 [Schedule one on-demand build](/jenkins.html#scheduling-an-on-demand-build) using an "everything"
 flavor, for example:
 
-* ``@drake-jenkins-bot mac-catalina-clang-bazel-experimental-everything-release please``
+* ``@drake-jenkins-bot mac-big-sur-clang-bazel-experimental-everything-release please``
 
 # Have you run linting tools?
 

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -12,8 +12,8 @@ integration. Any other configurations are provided on a best-effort basis.
 |----------------------------------|--------------|---------|-------|-------|------------------------------------|-------------------------------|
 | Ubuntu 18.04 LTS (Bionic Beaver) | x86_64 ⁽¹⁾   | 3.6 ⁽³⁾ | 4.2   | 3.10  | GCC 7.5 (default) or Clang 9   | OpenJDK 11                    |
 | Ubuntu 20.04 LTS (Focal Fossa)   | x86_64 ⁽¹⁾   | 3.8 ⁽³⁾ | 4.2   | 3.16  | GCC 9.3 (default) or Clang 9   | OpenJDK 11                    |
-| macOS Catalina (10.15)           | x86_64 ⁽²⁾   | 3.9 ⁽³⁾ | 4.2   | 3.19  | Apple LLVM 12.0.0 (Xcode 12.4) | AdoptOpenJDK 15 (HotSpot JVM) |
 | macOS Big Sur (11)               | x86_64 ⁽²⁾   | 3.9 ⁽³⁾ | 4.2   | 3.19  | Apple LLVM 12.0.0 (Xcode 12.4) | AdoptOpenJDK 15 (HotSpot JVM) |
+| macOS Monterey (12) support is coming soon. |
 
 ⁽¹⁾ Drake Ubuntu builds assume support for Intel's AVX2 and FMA instructions,
 introduced with the Haswell architecture in 2013 with substantial performance

--- a/doc/_pages/getting_help.md
+++ b/doc/_pages/getting_help.md
@@ -37,7 +37,7 @@ If you wish to contribute a patch, please see how to [submit a pull request](/de
 When reporting an issue, please consider providing the following information
 (*examples in italics*, ``helper command in monospace``):
 
-* Operating system (*Ubuntu 18.04, macOS Catalina*)
+* Operating system (*Ubuntu 18.04, macOS Monterey*)
 * Language (C++, [Python](/python_bindings.html))
     * C++ compiler (*GCC 7.5.0, GCC 9.3.0, Clang 6.0.0*)
     * Python version (*Python 3.6.7*)

--- a/doc/_pages/installation.md
+++ b/doc/_pages/installation.md
@@ -18,8 +18,8 @@ officially supports:
 |----------------------------------|--------------|---------|
 | Ubuntu 18.04 LTS (Bionic Beaver) | x86_64 ⁽¹⁾   | 3.6 ⁽³⁾ |
 | Ubuntu 20.04 LTS (Focal Fossa)   | x86_64 ⁽¹⁾   | 3.8 ⁽³⁾ |
-| macOS Catalina (10.15)           | x86_64 ⁽²⁾   | 3.9 ⁽³⁾ |
 | macOS Big Sur (11)               | x86_64 ⁽²⁾   | 3.9 ⁽³⁾ |
+| macOS Monterey (12) support is coming soon. |
 
 ⁽¹⁾ Drake Ubuntu builds assume support for Intel's AVX2 and FMA instructions,
 introduced with the Haswell architecture in 2013 with substantial performance
@@ -46,8 +46,8 @@ compiler as our releases:
 |----------------------------------|--------------------------------|
 | Ubuntu 18.04 LTS (Bionic Beaver) | GCC 7.5                        |
 | Ubuntu 20.04 LTS (Focal Fossa)   | GCC 9.3                        |
-| macOS Catalina (10.15)           | Apple LLVM 12.0.0 (Xcode 12.4) |
 | macOS Big Sur (11)               | Apple LLVM 12.0.0 (Xcode 12.4) |
+| macOS Monterey (12) support is coming soon. |
 
 ## Available Versions
 

--- a/doc/_pages/jenkins.md
+++ b/doc/_pages/jenkins.md
@@ -53,7 +53,7 @@ where ``<job-name>`` is the name of an
 
 For example:
 
-* ``@drake-jenkins-bot mac-catalina-clang-bazel-experimental-release please``
+* ``@drake-jenkins-bot mac-big-sur-clang-bazel-experimental-release please``
 * ``@drake-jenkins-bot linux-bionic-clang-bazel-experimental-valgrind-memcheck please``
 
 ## Scheduling Builds via the Jenkins User Interface
@@ -106,7 +106,7 @@ unprovisioned experimental builds, e.g.:
 
 * ``@drake-jenkins-bot linux-bionic-unprovisioned-gcc-bazel-experimental-release please``
 * ``@drake-jenkins-bot linux-focal-unprovisioned-gcc-bazel-experimental-release please``
-* ``@drake-jenkins-bot mac-catalina-unprovisioned-clang-bazel-experimental-release please``
+* ``@drake-jenkins-bot mac-big-sur-unprovisioned-clang-bazel-experimental-release please``
 
 After this has passed, go through normal review. Once normal review is done,
 add `@BetsyMcPhail` for review and request that the provisioned instances be
@@ -119,7 +119,7 @@ comment on an open pull request as follows:
 
 * ``@drake-jenkins-bot linux-bionic-unprovisioned-gcc-bazel-experimental-snopt-packaging please``
 * ``@drake-jenkins-bot linux-focal-unprovisioned-gcc-bazel-experimental-snopt-packaging please``
-* ``@drake-jenkins-bot mac-catalina-unprovisioned-clang-bazel-experimental-snopt-packaging please``
+* ``@drake-jenkins-bot mac-big-sur-unprovisioned-clang-bazel-experimental-snopt-packaging please``
 
 or follow the [instructions above](#scheduling-builds-via-the-jenkins-user-interface)
 to schedule a build of one of the following jobs from the Jenkins user
@@ -127,7 +127,7 @@ interface:
 
 * linux-bionic-unprovisioned-gcc-bazel-experimental-snopt-packaging
 * linux-focal-unprovisioned-gcc-bazel-experimental-snopt-packaging
-* mac-catalina-unprovisioned-clang-bazel-experimental-snopt-packaging
+* mac-big-sur-unprovisioned-clang-bazel-experimental-snopt-packaging
 
 The URL from which to download the built package will be indicated in the
 Jenkins console log for the completed build, for example:


### PR DESCRIPTION
Towards #16001.

Before we spin up macOS Monterey support, we need to retire the older Catalina support.  Our general policy for both macOS and Ubuntu is that we support the two most recent stable releases.

At the moment we are still running CI for Catalina, but will be turning that off soon, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16041)
<!-- Reviewable:end -->
