### PR TITLE
Deprecate System::EvalEigenVectorInput()

### DIFF
--- a/examples/bead_on_a_wire/bead_on_a_wire.cc
+++ b/examples/bead_on_a_wire/bead_on_a_wire.cc
@@ -204,7 +204,8 @@ void BeadOnAWire<T>::DoCalcTimeDerivatives(
   systems::VectorBase<T>& f = derivatives->get_mutable_vector();
 
   // Get the inputs.
-  const auto input = this->EvalEigenVectorInput(context, 0);
+  const Eigen::VectorBlock<const VectorX<T>> input =
+      this->get_input_port(0).Eval(context);
 
   // Compute the derivatives using the desired coordinate representation.
   if (coordinate_type_ == kMinimalCoordinates) {

--- a/examples/rod2d/rod2d.cc
+++ b/examples/rod2d/rod2d.cc
@@ -64,7 +64,8 @@ Vector3<T> Rod2D<T>::ComputeExternalForces(
     const systems::Context<T>& context) const {
   // Compute the external forces (expressed in the world frame).
   const int port_index = 0;
-  const VectorX<T> input = this->EvalEigenVectorInput(context, port_index);
+  const Eigen::VectorBlock<const VectorX<T>> input =
+      this->get_input_port(port_index).Eval(context);
   const Vector3<T> fgrav(0, mass_ * get_gravitational_acceleration(), 0);
   const Vector3<T> fapplied = input.segment(0, 3);
   return fgrav + fapplied;

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -218,6 +218,7 @@ const T& System<T>::EvalNonConservativePower(const Context<T>& context) const {
   return entry.Eval<T>(context);
 }
 
+// Deprecated
 template <typename T>
 Eigen::VectorBlock<const VectorX<T>> System<T>::EvalEigenVectorInput(
     const Context<T>& context, int port_index) const {

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -18,6 +18,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/pointer_cast.h"
@@ -392,16 +393,17 @@ class System : public SystemBase {
     return value;
   }
 
-  // TODO(jwnimmer-tri) Deprecate me.
-  /** Returns the value of the vector-valued input port with the given
-  `port_index` as an %Eigen vector. Causes the value to become up to date
+  /** (Deprecated) Returns the value of the vector-valued input port with the
+  given `port_index` as an %Eigen vector. Causes the value to become up to date
   first if necessary. See EvalAbstractInput() for more information.
 
   @pre `port_index` selects an existing input port of this System.
   @pre the port must have been declared to be vector-valued.
   @pre the port must be evaluable (connected or fixed).
 
-  @see EvalVectorInput() */
+  @see InputPort::Eval() */
+  DRAKE_DEPRECATED("2021-03-01",
+      "Use get_input_port(index).Eval(context) instead.")
   Eigen::VectorBlock<const VectorX<T>> EvalEigenVectorInput(
       const Context<T>& context, int port_index) const;
   //@}

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -95,20 +95,23 @@ class SystemBase : public internal::SystemMessageInterface {
   }
 
   //----------------------------------------------------------------------------
-  /** @name                  Input port evaluation
-  These methods provide scalar type-independent evaluation of a System input
-  port in a particular Context. If necessary, they first cause the port's value
+  /** @name            Input port evaluation (deprecated)
+  These _deprecated_ methods provide scalar type-independent evaluation of a
+  System input port in a particular Context. Instead of these, prefer to use
+  InputPort::Eval(), acquiring the port with `get_input_port(port_index)`.
+
+  If necessary, the methods here first cause the port's value
   to become up to date, then they return a reference to the now-up-to-date value
   in the given Context.
 
   Specified preconditions for these methods operate as follows: The
   preconditions will be checked in Debug builds but some or all might not be
   checked in Release builds for performance reasons. If we do check, and a
-  precondition is violated, an std::logic_error will be thrown with a helpful
+  precondition is violated, an std::exception will be thrown with a helpful
   message.
 
-  @see System::EvalVectorInput(), System::EvalEigenVectorInput() for
-  scalar type-specific input port access. */
+  @see System::get_input_port(), InputPort::Eval() for scalar type-specific
+  input port access. */
   //@{
 
   // TODO(jwnimmer-tri) Deprecate me.
@@ -121,8 +124,7 @@ class SystemBase : public internal::SystemMessageInterface {
 
   @pre `port_index` selects an existing input port of this System.
 
-  @see EvalInputValue(), System::EvalVectorInput(),
-       System::EvalEigenVectorInput() */
+  @see InputPort::Eval() (preferred) */
   const AbstractValue* EvalAbstractInput(const ContextBase& context,
                                          int port_index) const {
     ValidateContext(context);
@@ -145,6 +147,7 @@ class SystemBase : public internal::SystemMessageInterface {
   @pre the port's value must be retrievable from the stored abstract value
        using `AbstractValue::get_value<V>`.
 
+  @see InputPort::Eval() (preferred)
   @tparam V The type of data expected. */
   template <typename V>
   const V* EvalInputValue(const ContextBase& context, int port_index) const {


### PR DESCRIPTION
Per discussion in #16031 this formerly "to be deprecated" method needs to go peacefully to its grave prior to other planned API changes.

Note that there remain several to-be-deprecated input port methods in SystemBase and System. I purged them of references to `EvalEigenVectorInput()` and added some mention of the now-preferred `InputPort::Eval()` method family but I'm not attempting true deprecation of them here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16042)
<!-- Reviewable:end -->
