### PR TITLE
include HAVE_SPDLOG compile definition for cmake consumers

### DIFF
--- a/tools/install/libdrake/drake-config.cmake
+++ b/tools/install/libdrake/drake-config.cmake
@@ -64,6 +64,7 @@ set_target_properties(drake::drake PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/include"
   INTERFACE_LINK_LIBRARIES "drake::drake-lcmtypes-cpp;drake::drake-marker;Eigen3::Eigen;fmt::fmt-header-only;lcm::lcm;optitrack::optitrack-lcmtypes-cpp;spdlog::spdlog;tinyxml2::tinyxml2;${yaml-cpp_LIBRARIES}"
   INTERFACE_COMPILE_FEATURES "cxx_std_17"
+  INTERFACE_COMPILE_DEFINITIONS "HAVE_SPDLOG"
 )
 
 add_library(drake::drake-lcmtypes-cpp INTERFACE IMPORTED)


### PR DESCRIPTION
Fixes #15004.

I could not follow the conversation about turning on or off the "toggle" for spdlog.  Currently, that CMake file assumes that `spdlog` is a hard dependency -- `find_dependency` more or less the same thing as `find_package(... REQUIRED)`.

To make spdlog optional

1. Please tell me how to actually do that with bazel :upside_down_face:
2. We'll need to `configure_file` on the `drake-config.cmake` to optionally `find_dependency` on `spdlog` and conditionally add that interface compile definition.

Sample consumer code to validate:

## `CMakeLists.txt`

```cmake
cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
project(drake-spdlog-checking)

# hack for easy testing, set to wherever you installed
# or delete this line and properly set CMAKE_PREFIX_PATH in your env
set(CMAKE_PREFIX_PATH "/tmp/drake-install-testing/lib/cmake")
find_package(drake CONFIG REQUIRED)  # transitively brings in spdlog

add_executable(loggy main.cpp)
target_link_libraries(loggy PUBLIC drake::drake)
```

## `main.cpp`

```cpp
#include <iostream>
#include <iomanip>
#include <drake/common/text_logging.h>

int main() {
    // see text_logging.h: constexpr bool that indicates if it is included
    std::cout << "drake::logging::kHaveSpdlog: "
              << std::boolalpha << drake::logging::kHaveSpdlog << '\n';
    return 0;
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16044)
<!-- Reviewable:end -->
