### PR TITLE
Implements contact manager to be used with new solvers

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -18,6 +18,7 @@ drake_cc_package_library(
     visibility = ["//visibility:public"],
     deps = [
         ":calc_distance_and_time_derivative",
+        ":compliant_contact_manager",
         ":contact_jacobians",
         ":contact_permutation",
         ":contact_results",
@@ -35,6 +36,17 @@ drake_cc_package_library(
         ":point_pair_contact_info",
         ":propeller",
         ":tamsi_solver",
+    ],
+)
+
+drake_cc_library(
+    name = "compliant_contact_manager",
+    srcs = ["compliant_contact_manager.cc"],
+    hdrs = ["compliant_contact_manager.h"],
+    deps = [
+        ":multibody_plant_core",
+        "//multibody/contact_solvers:contact_solver",
+        "//multibody/triangle_quadrature",
     ],
 )
 
@@ -330,6 +342,16 @@ drake_cc_library(
         ":multibody_plant_config",
         ":multibody_plant_core",
         "//systems/framework:diagram_builder",
+    ],
+)
+
+drake_cc_googletest(
+    name = "compliant_contact_manager_test",
+    deps = [
+        ":compliant_contact_manager",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+        "//multibody/contact_solvers:pgs_solver",
     ],
 )
 

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -1,0 +1,429 @@
+#include "drake/multibody/plant/compliant_contact_manager.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/query_results/penetration_as_point_pair.h"
+#include "drake/math/rotation_matrix.h"
+#include "drake/multibody/contact_solvers/contact_solver.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/triangle_quadrature/gaussian_triangle_quadrature_rule.h"
+#include "drake/systems/framework/context.h"
+
+using drake::geometry::GeometryId;
+using drake::geometry::PenetrationAsPointPair;
+using drake::math::RotationMatrix;
+using drake::systems::Context;
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+template <typename T>
+CompliantContactManager<T>::CompliantContactManager(
+    std::unique_ptr<contact_solvers::internal::ContactSolver<T>> contact_solver)
+    : contact_solver_(std::move(contact_solver)) {
+  DRAKE_DEMAND(contact_solver_ != nullptr);
+}
+
+template <typename T>
+void CompliantContactManager<T>::DeclareCacheEntries() {
+  // N.B. We use xd_ticket() instead of q_ticket() since discrete
+  // multibody plant does not have q's, but rather discrete state.
+  // Therefore if we make it dependent on q_ticket() the Jacobian only
+  // gets evaluated once at the start of the simulation.
+
+  // Cache discrete contact pairs.
+  const auto& discrete_contact_pairs_cache_entry = this->DeclareCacheEntry(
+      "Discrete contact pairs.",
+      systems::ValueProducer(
+          this, &CompliantContactManager<T>::CalcDiscreteContactPairs),
+      {systems::System<T>::xd_ticket(),
+       systems::System<T>::all_parameters_ticket()});
+  cache_indexes_.discrete_contact_pairs =
+      discrete_contact_pairs_cache_entry.cache_index();
+
+  // Contact Jacobian for the discrete pairs computed with
+  // CompliantContactManager::CalcDiscreteContactPairs().
+  auto& contact_jacobian_cache_entry = this->DeclareCacheEntry(
+      std::string("Contact Jacobian."),
+      systems::ValueProducer(
+          this, &CompliantContactManager<T>::CalcContactJacobianCache),
+      {systems::System<T>::xd_ticket(),
+       systems::System<T>::all_parameters_ticket()});
+  cache_indexes_.contact_jacobian = contact_jacobian_cache_entry.cache_index();
+}
+
+template <typename T>
+void CompliantContactManager<T>::CalcContactJacobianCache(
+    const systems::Context<T>& context,
+    internal::ContactJacobianCache<T>* cache) const {
+  DRAKE_DEMAND(cache != nullptr);
+
+  const std::vector<internal::DiscreteContactPair<T>>& contact_pairs =
+      EvalDiscreteContactPairs(context);
+  const int num_contacts = contact_pairs.size();
+
+  MatrixX<T>& Jc = cache->Jc;
+  Jc.resize(3 * num_contacts, plant().num_velocities());
+
+  std::vector<drake::math::RotationMatrix<T>>& R_WC_set = cache->R_WC_list;
+  R_WC_set.clear();
+  R_WC_set.reserve(num_contacts);
+
+  // Quick no-op exit.
+  if (num_contacts == 0) return;
+
+  const int nv = plant().num_velocities();
+
+  // Scratch workspace variables.
+  Matrix3X<T> Jv_WAc_W(3, nv);
+  Matrix3X<T> Jv_WBc_W(3, nv);
+  Matrix3X<T> Jv_AcBc_W(3, nv);
+
+  const Frame<T>& frame_W = plant().world_frame();
+  for (int icontact = 0; icontact < num_contacts; ++icontact) {
+    const auto& point_pair = contact_pairs[icontact];
+
+    const GeometryId geometryA_id = point_pair.id_A;
+    const GeometryId geometryB_id = point_pair.id_B;
+
+    BodyIndex bodyA_index = this->geometry_id_to_body_index().at(geometryA_id);
+    const Body<T>& bodyA = plant().get_body(bodyA_index);
+    BodyIndex bodyB_index = this->geometry_id_to_body_index().at(geometryB_id);
+    const Body<T>& bodyB = plant().get_body(bodyB_index);
+
+    // Contact normal from point A into B.
+    const Vector3<T>& nhat_W = -point_pair.nhat_BA_W;
+    const Vector3<T>& p_WC = point_pair.p_WC;
+
+    // Since v_AcBc_W = v_WBc - v_WAc the relative velocity Jacobian will be:
+    //   J_AcBc_W = Jv_WBc_W - Jv_WAc_W.
+    // That is the relative velocity at C is v_AcBc_W = J_AcBc_W * v.
+    this->internal_tree().CalcJacobianTranslationalVelocity(
+        context, JacobianWrtVariable::kV, bodyA.body_frame(), frame_W, p_WC,
+        frame_W, frame_W, &Jv_WAc_W);
+    this->internal_tree().CalcJacobianTranslationalVelocity(
+        context, JacobianWrtVariable::kV, bodyB.body_frame(), frame_W, p_WC,
+        frame_W, frame_W, &Jv_WBc_W);
+    Jv_AcBc_W = Jv_WBc_W - Jv_WAc_W;
+
+    // Define a contact frame C at the contact point such that the z-axis Cz
+    // equals nhat_W. The tangent vectors are arbitrary, with the only
+    // requirement being that they form a valid right handed basis with nhat_W.
+    const math::RotationMatrix<T> R_WC =
+        math::RotationMatrix<T>::MakeFromOneVector(nhat_W, 2);
+    R_WC_set.push_back(R_WC);
+
+    Jc.template middleRows<3>(3 * icontact).noalias() =
+        R_WC.matrix().transpose() * Jv_AcBc_W;
+  }
+}
+
+template <typename T>
+T CompliantContactManager<T>::GetPointContactStiffness(
+    geometry::GeometryId id,
+    const geometry::SceneGraphInspector<T>& inspector) const {
+  const geometry::ProximityProperties* prop =
+      inspector.GetProximityProperties(id);
+  DRAKE_DEMAND(prop != nullptr);
+  // N.B. Here we rely on the resolution of #13289 and #5454 to get properties
+  // with the proper scalar type T. This will not work on scalar converted
+  // models until those issues are resolved.
+  return prop->template GetPropertyOrDefault<T>(
+      geometry::internal::kMaterialGroup, geometry::internal::kPointStiffness,
+      this->default_contact_stiffness());
+}
+
+template <typename T>
+T CompliantContactManager<T>::GetDissipationTimeConstant(
+    geometry::GeometryId id,
+    const geometry::SceneGraphInspector<T>& inspector) const {
+  const geometry::ProximityProperties* prop =
+      inspector.GetProximityProperties(id);
+  DRAKE_DEMAND(prop != nullptr);
+  // N.B. Here we rely on the resolution of #13289 and #5454 to get properties
+  // with the proper scalar type T. This will not work on scalar converted
+  // models until those issues are resolved.
+  return prop->template GetPropertyOrDefault<T>(
+      geometry::internal::kMaterialGroup, "dissipation_time_constant",
+      plant().time_step());
+}
+
+template <typename T>
+T CompliantContactManager<T>::CombineStiffnesses(const T& k1, const T& k2) {
+  // Simple utility to detect 0 / 0. As it is used in this method, denom
+  // can only be zero if num is also zero, so we'll simply return zero.
+  auto safe_divide = [](const T& num, const T& denom) {
+    return denom == 0.0 ? 0.0 : num / denom;
+  };
+  return safe_divide(k1 * k2, k1 + k2);
+}
+
+template <typename T>
+T CompliantContactManager<T>::CombineDissipationTimeConstant(const T& tau1,
+                                                             const T& tau2) {
+  return tau1 + tau2;
+}
+
+template <typename T>
+void CompliantContactManager<T>::CalcDiscreteContactPairs(
+    const systems::Context<T>& context,
+    std::vector<internal::DiscreteContactPair<T>>* contact_pairs) const {
+  plant().ValidateContext(context);
+  DRAKE_DEMAND(contact_pairs != nullptr);
+
+  contact_pairs->clear();
+  if (plant().num_collision_geometries() == 0) return;
+
+  const auto contact_model = plant().get_contact_model();
+
+  // We first compute the number of contact pairs so that we can allocate all
+  // memory at once.
+  // N.B. num_point_pairs = 0 when:
+  //   1. There are legitimately no point pairs or,
+  //   2. the point pair model is not even in use.
+  // We guard for case (2) since EvalPointPairPenetrations() cannot be called
+  // when point contact is not used and would otherwise throw an exception.
+  int num_point_pairs = 0;  // The number of point contact pairs.
+  if (contact_model == ContactModel::kPoint ||
+      contact_model == ContactModel::kHydroelasticWithFallback) {
+    num_point_pairs = plant().EvalPointPairPenetrations(context).size();
+  }
+
+  int num_quadrature_pairs = 0;
+  // N.B. For discrete hydro we use a first order quadrature rule.
+  // Higher order quadratures are possible, however using a lower order
+  // quadrature leads to a smaller number of discrete pairs and therefore a
+  // smaller number of constraints in the discrete contact problem.
+  const GaussianTriangleQuadratureRule quadrature(1 /* order */);
+  const std::vector<double>& wq = quadrature.weights();
+  const int num_quad_points = wq.size();
+  if (contact_model == ContactModel::kHydroelastic ||
+      contact_model == ContactModel::kHydroelasticWithFallback) {
+    const std::vector<geometry::ContactSurface<T>>& surfaces =
+        this->EvalContactSurfaces(context);
+    for (const auto& s : surfaces) {
+      const geometry::TriangleSurfaceMesh<T>& mesh = s.mesh_W();
+      num_quadrature_pairs += num_quad_points * mesh.num_triangles();
+    }
+  }
+  const int num_contact_pairs = num_point_pairs + num_quadrature_pairs;
+  contact_pairs->reserve(num_contact_pairs);
+  if (contact_model == ContactModel::kPoint ||
+      contact_model == ContactModel::kHydroelasticWithFallback) {
+    AppendDiscreteContactPairsForPointContact(context, contact_pairs);
+  }
+  if (contact_model == ContactModel::kHydroelastic ||
+      contact_model == ContactModel::kHydroelasticWithFallback) {
+    AppendDiscreteContactPairsForHydroelasticContact(context, contact_pairs);
+  }
+}
+
+template <typename T>
+void CompliantContactManager<T>::AppendDiscreteContactPairsForPointContact(
+    const systems::Context<T>& context,
+    std::vector<internal::DiscreteContactPair<T>>* result) const {
+  std::vector<internal::DiscreteContactPair<T>>& contact_pairs = *result;
+
+  const geometry::QueryObject<T>& query_object =
+      this->plant()
+          .get_geometry_query_input_port()
+          .template Eval<geometry::QueryObject<T>>(context);
+  const geometry::SceneGraphInspector<T>& inspector = query_object.inspector();
+
+  // Fill in the point contact pairs.
+  const std::vector<PenetrationAsPointPair<T>>& point_pairs =
+      plant().EvalPointPairPenetrations(context);
+  for (const PenetrationAsPointPair<T>& pair : point_pairs) {
+    const T kA = GetPointContactStiffness(pair.id_A, inspector);
+    const T kB = GetPointContactStiffness(pair.id_B, inspector);
+    const T k = CombineStiffnesses(kA, kB);
+    const T tauA = GetDissipationTimeConstant(pair.id_A, inspector);
+    const T tauB = GetDissipationTimeConstant(pair.id_B, inspector);
+    const T tau = CombineDissipationTimeConstant(tauA, tauB);
+    const T d = tau * k;
+
+    // We compute the position of the point contact based on Hertz's theory
+    // for contact between two elastic bodies.
+    const T denom = kA + kB;
+    const T wA = (denom == 0 ? 0.5 : kA / denom);
+    const T wB = (denom == 0 ? 0.5 : kB / denom);
+    const Vector3<T> p_WC = wA * pair.p_WCa + wB * pair.p_WCb;
+
+    const T phi0 = -pair.depth;
+    const T fn0 = -k * phi0;
+    contact_pairs.push_back(
+        {pair.id_A, pair.id_B, p_WC, pair.nhat_BA_W, phi0, fn0, k, d});
+  }
+}
+
+template <typename T>
+void CompliantContactManager<T>::
+    AppendDiscreteContactPairsForHydroelasticContact(
+        const systems::Context<T>& context,
+        std::vector<internal::DiscreteContactPair<T>>* result) const {
+  std::vector<internal::DiscreteContactPair<T>>& contact_pairs = *result;
+
+  // N.B. For discrete hydro we use a first order quadrature rule.
+  // Higher order quadratures are possible, however using a lower order
+  // quadrature leads to a smaller number of discrete pairs and therefore a
+  // smaller number of constraints in the discrete contact problem.
+  const GaussianTriangleQuadratureRule quadrature(1 /* order */);
+  const std::vector<Vector2<double>>& xi = quadrature.quadrature_points();
+  const std::vector<double>& wq = quadrature.weights();
+  const int num_quad_points = wq.size();
+
+  const geometry::QueryObject<T>& query_object =
+      this->plant()
+          .get_geometry_query_input_port()
+          .template Eval<geometry::QueryObject<T>>(context);
+  const geometry::SceneGraphInspector<T>& inspector = query_object.inspector();
+  const std::vector<geometry::ContactSurface<T>>& surfaces =
+      this->EvalContactSurfaces(context);
+  for (const auto& s : surfaces) {
+    const geometry::TriangleSurfaceMesh<T>& mesh_W = s.mesh_W();
+    const T tau_M = GetDissipationTimeConstant(s.id_M(), inspector);
+    const T tau_N = GetDissipationTimeConstant(s.id_N(), inspector);
+    const T tau = CombineDissipationTimeConstant(tau_M, tau_N);
+
+    for (int face = 0; face < mesh_W.num_triangles(); ++face) {
+      const T& Ae = mesh_W.area(face);  // Face element area.
+
+      // We found out that the hydroelastic query might report
+      // infinitesimally small triangles (consider for instance an initial
+      // condition that perfectly places an object at zero distance from the
+      // ground.) While the area of zero sized triangles is not a problem by
+      // itself, the badly computed normal on these triangles leads to
+      // problems when computing the contact Jacobians (since we need to
+      // obtain an orthonormal basis based on that normal.)
+      // We therefore ignore infinitesimally small triangles. The tolerance
+      // below is somehow arbitrary and could possibly be tightened.
+      if (Ae > 1.0e-14) {
+        // N.B Assuming rigid-soft contact, and thus only a single pressure
+        // gradient is considered to be valid. We first verify this indeed
+        // is the case by checking that only one side has gradient
+        // information (the volumetric side).
+        const bool M_is_soft = s.HasGradE_M();
+        const bool N_is_soft = s.HasGradE_N();
+        DRAKE_DEMAND(M_is_soft ^ N_is_soft);
+
+        // Pressure gradient always points into the soft geometry by
+        // construction.
+        const Vector3<T>& grad_pres_W =
+            M_is_soft ? s.EvaluateGradE_M_W(face) : s.EvaluateGradE_N_W(face);
+
+        // From ContactSurface's documentation: The normal of each face is
+        // guaranteed to point "out of" N and "into" M.
+        const Vector3<T>& nhat_W = mesh_W.face_normal(face);
+        for (int qp = 0; qp < num_quad_points; ++qp) {
+          const Vector3<T> barycentric(xi[qp](0), xi[qp](1),
+                                       1.0 - xi[qp](0) - xi[qp](1));
+          // Pressure at the quadrature point.
+          const T p0 = s.e_MN().Evaluate(face, barycentric);
+
+          // Force contribution by this quadrature point.
+          const T fn0 = wq[qp] * Ae * p0;
+
+          // Since the normal always points into M, regardless of which body
+          // is soft, we must take into account the change of sign when body
+          // N is soft and M is rigid.
+          const T sign = M_is_soft ? 1.0 : -1.0;
+
+          // In order to provide some intuition, and though not entirely
+          // complete, here we document the first order idea that leads to
+          // the discrete hydroelastic approximation used below. In
+          // hydroelastics, each quadrature point contributes to the total
+          // "elastic" force along the normal direction as:
+          //   f₀ₚ = ωₚ Aₑ pₚ
+          // where subindex p denotes a quantity evaluated at quadrature
+          // point P and subindex e identifies the e-th contact surface
+          // element in which the quadrature is being evaluated.
+          // Notice f₀ only includes the "elastic" contribution. Dissipation is
+          // dealt with by the contact solver. In point contact, stiffness is
+          // related to changes in the normal force with changes in the
+          // penetration distance. In that spirit, the approximation used here
+          // is to define the discrete hydroelastics stiffness as the
+          // directional derivative of the scalar force f₀ₚ along the normal
+          // direction n̂:
+          //   k := ∂f₀ₚ/∂n̂ ≈ ωₚ⋅Aₑ⋅∇pₚ⋅n̂ₚ
+          // that is, the variation of the normal force experiences if the
+          // quadrature point is pushed inwards in the direction of the
+          // normal. Notice that this expression approximates the element
+          // area and normal as constant. Keeping normals and Jacobians
+          // is a very common approximation in first order methods. Keeping
+          // the area constant here is a higher order approximation for
+          // inner triangles given that shrinkage of a triangle is related
+          // the growth of a neighboring triangle (i.e. the contact surface
+          // does not stretch nor shrink). For triangles close to the
+          // boundary of the contact surface, this is only a first order
+          // approximation.
+          //
+          // Refer to [Masterjohn, 2021] for details.
+          //
+          // [Masterjohn, 2021] Masterjohn J., Guoy D., Shepherd J. and Castro
+          // A., 2021. Discrete Approximation of Pressure Field Contact Patches.
+          // Available at https://arxiv.org/abs/2110.04157.
+          const T k = sign * wq[qp] * Ae * grad_pres_W.dot(nhat_W);
+
+          // N.B. The normal is guaranteed to point into M. However, when M
+          // is soft, the gradient is not guaranteed to be in the direction
+          // of the normal. The geometry code that determines which
+          // triangles to keep in the contact surface may keep triangles for
+          // which the pressure gradient times normal is negative (see
+          // IsFaceNormalInNormalDirection() in contact_surface_utility.cc).
+          // Therefore there are cases for which the definition above of k
+          // might lead to negative values. We observed that this condition
+          // happens sparsely at some of the boundary triangles of the
+          // contact surface, while the positive values in inner triangles
+          // dominates the overall compliance. In practice we did not
+          // observe this to cause stability issues. Since a negative value
+          // of k is correct, we decided to keep these contributions.
+
+          // Position of quadrature point Q in the world frame (since mesh_W
+          // is measured and expressed in W).
+          const Vector3<T> p_WQ =
+              mesh_W.CalcCartesianFromBarycentric(face, barycentric);
+
+          // phi < 0 when in penetration.
+          const T phi0 = -sign * p0 / grad_pres_W.dot(nhat_W);
+
+          if (k > 0) {
+            const T dissipation = tau * k;
+            contact_pairs.push_back(
+                {s.id_M(), s.id_N(), p_WQ, nhat_W, phi0, fn0, k, dissipation});
+          }
+        }
+      }
+    }
+  }
+}
+
+template <typename T>
+const std::vector<internal::DiscreteContactPair<T>>&
+CompliantContactManager<T>::EvalDiscreteContactPairs(
+    const systems::Context<T>& context) const {
+  return plant()
+      .get_cache_entry(cache_indexes_.discrete_contact_pairs)
+      .template Eval<std::vector<internal::DiscreteContactPair<T>>>(context);
+}
+
+template <typename T>
+const internal::ContactJacobianCache<T>&
+CompliantContactManager<T>::EvalContactJacobianCache(
+    const systems::Context<T>& context) const {
+  return plant()
+      .get_cache_entry(cache_indexes_.contact_jacobian)
+      .template Eval<internal::ContactJacobianCache<T>>(context);
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::CompliantContactManager);

--- a/multibody/plant/compliant_contact_manager.h
+++ b/multibody/plant/compliant_contact_manager.h
@@ -1,0 +1,173 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/scene_graph_inspector.h"
+#include "drake/math/rotation_matrix.h"
+#include "drake/multibody/plant/discrete_update_manager.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// CompliantContactManager computes the contact Jacobian J_AcBc_C for the
+// relative velocity at a contact point Co between two geometries A and B,
+// expressed in a contact frame C with Cz coincident with the contact normal.
+// This structure is used to cache J_AcBc_C and rotation R_WC.
+template <typename T>
+struct ContactJacobianCache {
+  // Contact Jacobian J_AcBc_C. Jc.middleRows<3>(3*i), corresponds to J_AcBc_C
+  // for the i-th contact pair.
+  MatrixX<T> Jc;
+
+  // Rotation matrix to re-express between contact frame C and world frame W.
+  // R_WC_list[i] corresponds to rotation R_WC for the i-th contact pair.
+  std::vector<drake::math::RotationMatrix<T>> R_WC_list;
+};
+
+// This class implements the interface given by DiscreteUpdateManager so that
+// contact computations can be consumed by MultibodyPlant.
+//
+// In particular, this manager sets up a contact problem where each of the
+// bodies in the MultibodyPlant model is compliant, i.e. the contact model does
+// not introduce state. Supported models include point contact with a linear
+// model of compliance, see GetPointContactStiffness() and the hydroelastic
+// contact model, see @ref mbp_hydroelastic_materials_properties in
+// MultibodyPlant's Doxygen documentation.
+// Dissipation is modeled using a linear model. For point contact, given the
+// penetration distance x and its time derivative ẋ, the normal contact force
+// (in Newtons) is modeled as:
+//   fₙ = k⋅(x + τ⋅ẋ)₊
+// where k is the point contact stiffness, see GetPointContactStiffness(), τ is
+// the dissipation time scale, and ()₊ corresponds to the "positive part"
+// operator.
+// Similarly, for hydroelastic contact the normal traction p (in Pascals) is:
+//   p = (p₀+τ⋅dp₀/dn⋅ẋ)₊
+// where p₀ is the object-centric virtual pressure field introduced by the
+// hydroelastic model.
+//
+// TODO(amcastro-tri): Retire code from MultibodyPlant as this contact manager
+// replaces all the contact related capabilities, per #16106.
+//
+// @tparam_nonsymbolic_scalar
+template <typename T>
+class CompliantContactManager : public internal::DiscreteUpdateManager<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(CompliantContactManager)
+
+  // Constructs a contact manager that takes ownership of the supplied
+  // `contact_solver` to solve the underlying contact problem.
+  // @pre contact_solver != nullptr.
+  explicit CompliantContactManager(
+      std::unique_ptr<contact_solvers::internal::ContactSolver<T>>
+          contact_solver);
+
+  ~CompliantContactManager() = default;
+
+ private:
+  // Struct used to conglomerate the indexes of cache entries declared by the
+  // manager.
+  struct CacheIndexes {
+    systems::CacheIndex discrete_contact_pairs;
+    systems::CacheIndex contact_jacobian;
+  };
+
+  using internal::DiscreteUpdateManager<T>::plant;
+
+  // Provide private access for unit testing only.
+  friend class CompliantContactManagerTest;
+
+  // TODO(amcastro-tri): Implement these methods in future PRs.
+  void DoCalcContactSolverResults(
+      const systems::Context<T>&,
+      contact_solvers::internal::ContactSolverResults<T>*) const final {}
+  void DoCalcAccelerationKinematicsCache(
+      const systems::Context<T>&,
+      multibody::internal::AccelerationKinematicsCache<T>*) const final {}
+  void DoCalcDiscreteValues(const drake::systems::Context<T>&,
+                            drake::systems::DiscreteValues<T>*) const final {}
+
+  void DeclareCacheEntries() final;
+
+  // Returns the point contact stiffness stored in group
+  // geometry::internal::kMaterialGroup with property
+  // geometry::internal::kPointStiffness for the specified geometry.
+  // If the stiffness property is absent, it returns MultibodyPlant's default
+  // stiffness.
+  // GeometryId `id` must exist in the model or an exception is thrown.
+  T GetPointContactStiffness(
+      geometry::GeometryId id,
+      const geometry::SceneGraphInspector<T>& inspector) const;
+
+  // Returns the dissipation time constant stored in group
+  // geometry::internal::kMaterialGroup with property
+  // "dissipation_time_constant". If not present, it returns
+  // plant().time_step().
+  T GetDissipationTimeConstant(
+      geometry::GeometryId id,
+      const geometry::SceneGraphInspector<T>& inspector) const;
+
+  // Utility to combine stiffnesses k1 and k2 according to the rule:
+  //   k  = k₁⋅k₂/(k₁+k₂)
+  // In other words, the combined compliance (the inverse of stiffness) is the
+  // sum of the individual compliances.
+  static T CombineStiffnesses(const T& k1, const T& k2);
+
+  // Utility to combine linear dissipation time constants. Consider two
+  // spring-dampers with stiffnesses k₁ and k₂, and dissipation time scales τ₁
+  // and τ₂, respectively. When these spring-dampers are connected in series,
+  // they result in an equivalent spring-damper with stiffness k  =
+  // k₁⋅k₂/(k₁+k₂) and dissipation τ = τ₁ + τ₂.
+  // This method returns tau1 + tau2.
+  static T CombineDissipationTimeConstant(const T& tau1, const T& tau2);
+
+  // Given the configuration stored in `context`, this method appends discrete
+  // pairs corresponding to point contact into `pairs`.
+  // @pre pairs != nullptr.
+  void AppendDiscreteContactPairsForPointContact(
+      const systems::Context<T>& context,
+      std::vector<internal::DiscreteContactPair<T>>* pairs) const;
+
+  // Given the configuration stored in `context`, this method appends discrete
+  // pairs corresponding to hydroelastic contact into `pairs`.
+  // @pre pairs != nullptr.
+  void AppendDiscreteContactPairsForHydroelasticContact(
+      const systems::Context<T>& context,
+      std::vector<internal::DiscreteContactPair<T>>* pairs) const;
+
+  // Given the configuration stored in `context`, this method computes all
+  // discrete contact pairs, including point and hydroelastic contact, into
+  // `pairs.`
+  // Throws an exception if `pairs` is nullptr.
+  void CalcDiscreteContactPairs(
+      const systems::Context<T>& context,
+      std::vector<internal::DiscreteContactPair<T>>* pairs) const;
+
+  // Eval version of CalcDiscreteContactPairs().
+  const std::vector<internal::DiscreteContactPair<T>>& EvalDiscreteContactPairs(
+      const systems::Context<T>& context) const;
+
+  // Given the configuration stored in `context`, this method computes the
+  // contact Jacobian cache. See ContactJacobianCache for details.
+  void CalcContactJacobianCache(const systems::Context<T>& context,
+                                internal::ContactJacobianCache<T>* cache) const;
+
+  // Eval version of CalcContactJacobianCache().
+  const internal::ContactJacobianCache<T>& EvalContactJacobianCache(
+      const systems::Context<T>& context) const;
+
+  std::unique_ptr<contact_solvers::internal::ContactSolver<T>> contact_solver_;
+  CacheIndexes cache_indexes_;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::internal::CompliantContactManager);

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -7,6 +7,7 @@
 namespace drake {
 namespace multibody {
 namespace internal {
+
 template <typename T>
 std::unique_ptr<DiscreteUpdateManager<double>>
 DiscreteUpdateManager<T>::CloneToDouble() const {
@@ -87,6 +88,14 @@ DiscreteUpdateManager<T>::EvalDiscreteContactPairs(
 }
 
 template <typename T>
+const std::vector<geometry::ContactSurface<T>>&
+DiscreteUpdateManager<T>::EvalContactSurfaces(
+    const systems::Context<T>& context) const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<T>::EvalContactSurfaces(
+      plant(), context);
+}
+
+template <typename T>
 std::vector<CoulombFriction<double>>
 DiscreteUpdateManager<T>::CalcCombinedFrictionCoefficients(
     const systems::Context<T>& context,
@@ -128,6 +137,7 @@ DiscreteUpdateManager<T>::geometry_id_to_body_index() const {
   return MultibodyPlantDiscreteUpdateManagerAttorney<
       T>::geometry_id_to_body_index(*plant_);
 }
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/query_results/contact_surface.h"
 #include "drake/multibody/contact_solvers/contact_solver.h"
 #include "drake/multibody/contact_solvers/contact_solver_results.h"
 #include "drake/multibody/plant/contact_jacobians.h"
@@ -183,6 +184,9 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
       const systems::Context<T>& context) const;
 
   const std::vector<internal::DiscreteContactPair<T>>& EvalDiscreteContactPairs(
+      const systems::Context<T>& context) const;
+
+  const std::vector<geometry::ContactSurface<T>>& EvalContactSurfaces(
       const systems::Context<T>& context) const;
 
   std::vector<CoulombFriction<double>> CalcCombinedFrictionCoefficients(

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -71,6 +71,11 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
     plant.AddInForcesFromInputPorts(context, forces);
   }
 
+  static const std::vector<geometry::ContactSurface<T>>& EvalContactSurfaces(
+      const MultibodyPlant<T>& plant, const systems::Context<T>& context) {
+    return plant.EvalContactSurfaces(context);
+  }
+
   // TODO(xuchenhan-tri): Remove this when SceneGraph takes control of all
   //  geometries.
   /* Returns the per-body arrays of collision geometries indexed by BodyIndex

--- a/multibody/plant/test/compliant_contact_manager_test.cc
+++ b/multibody/plant/test/compliant_contact_manager_test.cc
@@ -1,0 +1,459 @@
+#include "drake/multibody/plant/compliant_contact_manager.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/contact_solvers/pgs_solver.h"
+#include "drake/multibody/plant/multibody_plant.h"
+
+using drake::geometry::GeometryId;
+using drake::geometry::PenetrationAsPointPair;
+using drake::geometry::ProximityProperties;
+using drake::geometry::SceneGraph;
+using drake::geometry::TriangleSurfaceMesh;
+using drake::geometry::VolumeMesh;
+using drake::geometry::VolumeMeshFieldLinear;
+using drake::math::RigidTransformd;
+using drake::math::RotationMatrixd;
+using drake::multibody::contact_solvers::internal::PgsSolver;
+using drake::multibody::internal::DiscreteContactPair;
+using drake::systems::Context;
+using Eigen::MatrixXd;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Helper method for NaN initialization.
+static constexpr double nan() {
+  return std::numeric_limits<double>::quiet_NaN();
+}
+
+// In this fixture we set a simple model consisting of:
+//  1. The flat ground.
+//  2. A sphere (sphere 1) on top of the ground.
+//  3. A second sphere (sphere 2) on top of the first sphere.
+// The flat ground is modeled as rigid-hydroelastic.
+// Sphere 1 interacts with the ground using the hydroelastic contact model
+// Sphere 2 interacts with sphere 1 using the point contact model.
+// We use this fixture to verify the contact quantities computed by the
+// CompliantContactManager.
+class CompliantContactManagerTest : public ::testing::Test {
+ public:
+  // Contact model parameters.
+  struct ContactParameters {
+    // Point contact stiffness. If nullopt, this property is not added to the
+    // model.
+    std::optional<double> point_stiffness;
+    // Hydroelastic modulus. If nullopt, this property is not added to the
+    // model.
+    std::optional<double> hydro_modulus;
+    // Dissipation time constant τ is used to setup the linear dissipation model
+    // where dissipation is c = τ⋅k, with k the point pair stiffness.
+    double dissipation_time_constant{nan()};
+    // Coefficient of dynamic friction.
+    double friction_coefficient{nan()};
+  };
+
+  // Parameters used to setup the model of a compliant sphere.
+  struct SphereParameters {
+    const std::string name;
+    double mass;
+    double radius;
+    ContactParameters contact_parameters;
+  };
+
+  // The default setup for this fixture corresponds to:
+  //   - A rigid-hydroelastic half-space for the ground.
+  //   - A compliant-hydroelastic sphere on top of the ground.
+  //   - A second compliant-hydroelastic sphere on top of the first sphere.
+  //   - Both spheres also have point contact compliance.
+  //   - We set MultibodyPlant to use hydroelastic contact with fallback.
+  //   - Sphere 1 penetrates into the ground penetration_distance_.
+  //   - Sphere 1 and 2 penetrate penetration_distance_.
+  //   - Velocities are zero.
+  void MakeDefaultSetup() {
+    const ContactParameters soft_contact{1.0e5, 1.0e5, 0.01, 1.0};
+    const ContactParameters hard_hydro_contact{
+        std::nullopt, std::numeric_limits<double>::infinity(), 0.0, 1.0};
+    const SphereParameters sphere1_params{"Sphere1",
+                                          10.0 /* mass */,
+                                          0.2 /* size */,
+                                          soft_contact};
+    const SphereParameters sphere2_params{"Sphere2",
+                                          10.0 /* mass */,
+                                          0.2 /* size */,
+                                          soft_contact};
+    MakeModel(hard_hydro_contact, sphere1_params, sphere2_params);
+  }
+
+  void MakeModel(const ContactParameters& ground_params,
+                 const SphereParameters& sphere1_params,
+                 const SphereParameters& sphere2_params) {
+    systems::DiagramBuilder<double> builder;
+    std::tie(plant_, scene_graph_) =
+        AddMultibodyPlantSceneGraph(&builder, time_step_);
+
+    // Add model of the ground.
+    const ProximityProperties ground_properties =
+        MakeProximityProperties(ground_params);
+    plant_->RegisterCollisionGeometry(plant_->world_body(), RigidTransformd(),
+                                      geometry::HalfSpace(), "ground_collision",
+                                      ground_properties);
+    const Vector4<double> green(0.5, 1.0, 0.5, 1.0);
+    plant_->RegisterVisualGeometry(plant_->world_body(), RigidTransformd(),
+                                   geometry::HalfSpace(), "ground_visual",
+                                   green);
+
+    // Add models of the spheres.
+    sphere1_ = &AddSphere(sphere1_params);
+    sphere2_ = &AddSphere(sphere2_params);
+
+    plant_->set_contact_model(
+        drake::multibody::ContactModel::kHydroelasticWithFallback);
+
+    plant_->Finalize();
+    auto owned_contact_manager =
+        std::make_unique<CompliantContactManager<double>>(
+            std::make_unique<PgsSolver<double>>());
+    contact_manager_ = owned_contact_manager.get();
+    plant_->SetDiscreteUpdateManager(std::move(owned_contact_manager));
+
+    diagram_ = builder.Build();
+    diagram_context_ = diagram_->CreateDefaultContext();
+    plant_context_ =
+        &plant_->GetMyMutableContextFromRoot(diagram_context_.get());
+
+    SetContactState(sphere1_params, sphere2_params);
+  }
+
+  // Sphere 1 is set on top of the ground and sphere 2 sits right on top of
+  // sphere 1. We set the state of the model so that sphere 1 penetrates into
+  // the ground a distance penetration_distance_ and so that sphere 1 and 2 also
+  // interpenetrate a distance penetration_distance_.
+  // MakeModel() must have already been called.
+  void SetContactState(const SphereParameters& sphere1_params,
+                       const SphereParameters& sphere2_params) const {
+    DRAKE_DEMAND(plant_ != nullptr);
+    const double sphere1_com_z = sphere1_params.radius - penetration_distance_;
+    const RigidTransformd X_WB1(Vector3d(0, 0, sphere1_com_z));
+    plant_->SetFreeBodyPose(plant_context_, *sphere1_, X_WB1);
+    const double sphere2_com_z = 2.0 * sphere1_params.radius +
+                                 sphere2_params.radius -
+                                 2.0 * penetration_distance_;
+    const RigidTransformd X_WB2(Vector3d(0, 0, sphere2_com_z));
+    plant_->SetFreeBodyPose(plant_context_, *sphere2_, X_WB2);
+  }
+
+  // This method makes a model with the specified sphere 1 and sphere 2
+  // properties and verifies the resulting contact pairs.
+  // In this model sphere 1 always interacts with the ground using the
+  // hydroelastic contact model.
+  // Point contact stiffness must be provided for both spheres in
+  // sphere1_point_params and sphere2_point_params.
+  void VerifyDiscreteContactPairsFromPointContact(
+      const ContactParameters& sphere1_point_params,
+      const ContactParameters& sphere2_point_params) {
+    // This test is specific to point contact. Both spheres must have point
+    // contact properties.
+    DRAKE_DEMAND(sphere1_point_params.point_stiffness.has_value());
+    DRAKE_DEMAND(sphere2_point_params.point_stiffness.has_value());
+
+    ContactParameters sphere1_contact_params = sphere1_point_params;
+    sphere1_contact_params.hydro_modulus = 1.0e5;
+    const ContactParameters sphere2_contact_params = sphere2_point_params;
+
+    const ContactParameters hard_hydro_contact{
+        std::nullopt, std::numeric_limits<double>::infinity(), 0.0, 1.0};
+    const SphereParameters sphere1_params{"Sphere1",
+                                          10.0 /* mass */,
+                                          0.2 /* size */,
+                                          sphere1_contact_params};
+    const SphereParameters sphere2_params{"Sphere2",
+                                          10.0 /* mass */,
+                                          0.2 /* size */,
+                                          sphere2_contact_params};
+
+    // Soft sphere/hard ground.
+    MakeModel(hard_hydro_contact, sphere1_params, sphere2_params);
+
+    const std::vector<PenetrationAsPointPair<double>>& point_pair_penetrations =
+        EvalPointPairPenetrations(*plant_context_);
+    const int num_point_pairs = point_pair_penetrations.size();
+    const std::vector<geometry::ContactSurface<double>>& surfaces =
+        EvalContactSurfaces(*plant_context_);
+    ASSERT_EQ(surfaces.size(), 1u);
+    const int num_hydro_pairs = surfaces[0].mesh_W().num_triangles();
+    const std::vector<DiscreteContactPair<double>>& pairs =
+        EvalDiscreteContactPairs(*plant_context_);
+    EXPECT_EQ(pairs.size(), num_point_pairs + num_hydro_pairs);
+
+    constexpr double kEps = std::numeric_limits<double>::epsilon();
+
+    // Here we use our knowledge that we always place point contact pairs
+    // followed by hydroelastic contact pairs.
+    const DiscreteContactPair<double>& point_pair = pairs[0];
+
+    const GeometryId sphere2_geometry =
+        plant_->GetCollisionGeometriesForBody(*sphere2_)[0];
+
+    const int sign = point_pair.id_A == sphere2_geometry ? 1 : -1;
+    const Vector3d normal_expected = sign * Vector3d::UnitZ();
+    EXPECT_TRUE(CompareMatrices(point_pair.nhat_BA_W, normal_expected));
+
+    const double phi_expected = -penetration_distance_;
+    // The geometry engine computes absolute values of penetration to machine
+    // epsilon (at least for sphere vs. sphere contact).
+    EXPECT_NEAR(point_pair.phi0, phi_expected, kEps);
+
+    const double k1 = *sphere1_contact_params.point_stiffness;
+    const double k2 = *sphere2_contact_params.point_stiffness;
+    const double stiffness_expected = (k1 * k2) / (k1 + k2);
+    EXPECT_NEAR(point_pair.stiffness, stiffness_expected,
+                kEps * stiffness_expected);
+
+    const double tau1 = sphere1_contact_params.dissipation_time_constant;
+    const double tau2 = sphere2_contact_params.dissipation_time_constant;
+    const double dissipation_expected = stiffness_expected * (tau1 + tau2);
+    EXPECT_NEAR(point_pair.damping, dissipation_expected,
+                kEps * dissipation_expected);
+
+    const double pz_WS1 =
+        plant_->GetFreeBodyPose(*plant_context_, *sphere1_).translation().z();
+    const double pz_WC = -k2 / (k1 + k2) * penetration_distance_ + pz_WS1 +
+                         sphere1_params.radius;
+    EXPECT_NEAR(point_pair.p_WC.z(), pz_WC, 1.0e-14);
+
+    // A little error propagation here. The expected relative error in fn0 is:
+    //   |Δfₙ₀/fₙ₀| = |Δϕ/ϕ| + |Δk/k|
+    // In this case the error in ϕ dominates, since Δϕ is computed to machine
+    // epsilon by the geometry engine and ϕ = 10⁻³. Then we expect |Δfₙ₀/fₙ₀| ≈
+    // 10⁻¹³.
+    constexpr double fn0_tolerance = 1.0e-13;
+    const double fn0_expected = -stiffness_expected * phi_expected;
+    EXPECT_NEAR(point_pair.fn0, fn0_expected, fn0_tolerance * fn0_expected);
+  }
+
+  // In the methods below we use CompliantContactManagerTest's friendship with
+  // CompliantContactManager to provide access to private methods for unit
+  // testing.
+
+  const std::vector<PenetrationAsPointPair<double>>& EvalPointPairPenetrations(
+      const Context<double>& context) const {
+    return plant_->EvalPointPairPenetrations(context);
+  }
+
+  const std::vector<geometry::ContactSurface<double>>& EvalContactSurfaces(
+      const Context<double>& context) const {
+    return contact_manager_->EvalContactSurfaces(context);
+  }
+
+  const std::vector<DiscreteContactPair<double>>& EvalDiscreteContactPairs(
+      const Context<double>& context) const {
+    return contact_manager_->EvalDiscreteContactPairs(context);
+  }
+
+  const internal::ContactJacobianCache<double>& EvalContactJacobianCache(
+      const systems::Context<double>& context) const {
+    return contact_manager_->EvalContactJacobianCache(context);
+  }
+
+ protected:
+  // Arbitrary positive value so that the model is discrete.
+  double time_step_{0.001};
+
+  // Default penetration distance. The configuration of the model is set so that
+  // ground/sphere1 and sphere1/sphere2 interpenetrate by this amount.
+  const double penetration_distance_{1.0e-3};
+
+  std::unique_ptr<systems::Diagram<double>> diagram_;
+  MultibodyPlant<double>* plant_{nullptr};
+  SceneGraph<double>* scene_graph_{nullptr};
+  const RigidBody<double>* sphere1_{nullptr};
+  const RigidBody<double>* sphere2_{nullptr};
+  CompliantContactManager<double>* contact_manager_{nullptr};
+  std::unique_ptr<Context<double>> diagram_context_;
+  Context<double>* plant_context_{nullptr};
+
+ private:
+  // Helper to add a spherical body into the model.
+  const RigidBody<double>& AddSphere(const SphereParameters& params) {
+    // Add rigid body.
+    const Vector3<double> p_BoBcm_B = Vector3<double>::Zero();
+    const UnitInertia<double> G_BBcm_B =
+        UnitInertia<double>::SolidSphere(params.radius);
+    const SpatialInertia<double> M_BBcm_B(params.mass, p_BoBcm_B, G_BBcm_B);
+    const RigidBody<double>& body = plant_->AddRigidBody(params.name, M_BBcm_B);
+
+    // Add collision geometry.
+    const geometry::Sphere shape(params.radius);
+    const ProximityProperties properties =
+        MakeProximityProperties(params.contact_parameters);
+    plant_->RegisterCollisionGeometry(body, RigidTransformd(), shape,
+                                      params.name + "_collision", properties);
+
+    return body;
+  }
+
+  // Utility to make ProximityProperties from ContactParameters.
+  static ProximityProperties MakeProximityProperties(
+      const ContactParameters& params) {
+    DRAKE_DEMAND(params.point_stiffness || params.hydro_modulus);
+    ProximityProperties properties;
+    if (params.point_stiffness) {
+      properties.AddProperty(geometry::internal::kMaterialGroup,
+                             geometry::internal::kPointStiffness,
+                             *params.point_stiffness);
+    }
+
+    if (params.hydro_modulus) {
+      if (params.hydro_modulus == std::numeric_limits<double>::infinity()) {
+        properties.AddProperty(geometry::internal::kHydroGroup,
+                               geometry::internal::kComplianceType,
+                               geometry::internal::HydroelasticType::kRigid);
+      } else {
+        properties.AddProperty(geometry::internal::kHydroGroup,
+                               geometry::internal::kComplianceType,
+                               geometry::internal::HydroelasticType::kSoft);
+        properties.AddProperty(geometry::internal::kHydroGroup,
+                               geometry::internal::kElastic,
+                               *params.hydro_modulus);
+      }
+      // N.B. Add the slab thickness property by default so that we can model a
+      // half space (either compliant or rigid).
+      properties.AddProperty(geometry::internal::kHydroGroup,
+                             geometry::internal::kSlabThickness, 1.0);
+      properties.AddProperty(geometry::internal::kHydroGroup,
+                             geometry::internal::kRezHint, 1.0);
+    }
+
+    properties.AddProperty(geometry::internal::kMaterialGroup,
+                           "dissipation_time_constant",
+                           params.dissipation_time_constant);
+    properties.AddProperty(
+        geometry::internal::kMaterialGroup, geometry::internal::kFriction,
+        CoulombFriction<double>(params.friction_coefficient,
+                                params.friction_coefficient));
+    return properties;
+  }
+};
+
+// Unit test to verify discrete contact pairs computed by the manager for
+// different combinations of compliance.
+TEST_F(CompliantContactManagerTest,
+       VerifyDiscreteContactPairsFromPointContact) {
+  ContactParameters soft_point_contact{1.0e3, std::nullopt, 0.01, 1.0};
+  ContactParameters hard_point_contact{1.0e40, std::nullopt, 0.0, 1.0};
+
+  // Hard sphere 1/soft sphere 2.
+  VerifyDiscreteContactPairsFromPointContact(hard_point_contact,
+                                             soft_point_contact);
+
+  // Equally soft spheres.
+  VerifyDiscreteContactPairsFromPointContact(soft_point_contact,
+                                             soft_point_contact);
+
+  // Soft sphere 1/hard sphere 2.
+  VerifyDiscreteContactPairsFromPointContact(soft_point_contact,
+                                             hard_point_contact);
+}
+
+// Unit test to verify discrete contact pairs computed by the manager for
+// hydroelastic contact.
+TEST_F(CompliantContactManagerTest,
+       VerifyDiscreteContactPairsFromHydroelasticContact) {
+  MakeDefaultSetup();
+
+  const std::vector<PenetrationAsPointPair<double>>& point_pairs =
+      EvalPointPairPenetrations(*plant_context_);
+  const int num_point_pairs = point_pairs.size();
+  EXPECT_EQ(num_point_pairs, 1);
+  const std::vector<DiscreteContactPair<double>>& pairs =
+      EvalDiscreteContactPairs(*plant_context_);
+
+  const std::vector<geometry::ContactSurface<double>>& surfaces =
+      EvalContactSurfaces(*plant_context_);
+  ASSERT_EQ(surfaces.size(), 1u);
+  const geometry::TriangleSurfaceMesh<double>& patch = surfaces[0].mesh_W();
+  EXPECT_EQ(pairs.size(), patch.num_triangles() + num_point_pairs);
+}
+
+// Unit test to verify the computation of the contact Jacobian.
+TEST_F(CompliantContactManagerTest, EvalContactJacobianCache) {
+  MakeDefaultSetup();
+  const double radius = 0.2;  // Spheres's radii in the default setup.
+  const double kTolerance = std::numeric_limits<double>::epsilon();
+
+  const std::vector<DiscreteContactPair<double>>& pairs =
+      EvalDiscreteContactPairs(*plant_context_);
+  const auto& cache = EvalContactJacobianCache(*plant_context_);
+  const auto& Jc = cache.Jc;
+  EXPECT_EQ(Jc.cols(), plant_->num_velocities());
+  EXPECT_EQ(Jc.rows(), 3 * pairs.size());
+
+  // Arbitrary velocity of sphere 1.
+  const Vector3d v_WS1(1, 2, 3);
+  const Vector3d w_WS1(4, 5, 6);
+  const SpatialVelocity<double> V_WS1(w_WS1, v_WS1);
+
+  // Arbitrary velocity of sphere 2.
+  const Vector3d v_WS2(7, 8, 9);
+  const Vector3d w_WS2(10, 11, 12);
+  const SpatialVelocity<double> V_WS2(w_WS2, v_WS2);
+
+  plant_->SetFreeBodySpatialVelocity(plant_context_, *sphere1_, V_WS1);
+  plant_->SetFreeBodySpatialVelocity(plant_context_, *sphere2_, V_WS2);
+  const VectorXd v = plant_->GetVelocities(*plant_context_);
+
+  const GeometryId sphere1_geometry =
+      plant_->GetCollisionGeometriesForBody(*sphere1_)[0];
+
+  // Verify contact Jacobian for the point pair.
+  // For this model we know the first entry corresponds to the single point pair
+  // between sphere 1 and sphere 2.
+  {
+    // For the default setup both spheres are equally compliant and therefore
+    // the contact point C lies right in the middle.
+    const Vector3d p_S1C_W(0, 0, radius - penetration_distance_ / 2.0);
+    const Vector3d p_S2C_W(0, 0, -(radius - penetration_distance_ / 2.0));
+
+    // Compute expected contact point velocity.
+    const Vector3d v_WS1c = V_WS1.Shift(p_S1C_W).translational();
+    const Vector3d v_WS2c = V_WS2.Shift(p_S2C_W).translational();
+    const Vector3d expected_v_S1cS2c_W = v_WS2c - v_WS1c;
+
+    const int sign = pairs[0].id_A == sphere1_geometry ? 1 : -1;
+    const MatrixXd J_S1cS2c_C = sign * Jc.topRows(3);
+    const RotationMatrixd& R_WC = cache.R_WC_list[0];
+    const MatrixXd J_S1cS2c_W = R_WC.matrix() * J_S1cS2c_C;
+    const Vector3d v_S1cS2c_W = J_S1cS2c_W * v;
+    EXPECT_TRUE(CompareMatrices(v_S1cS2c_W, expected_v_S1cS2c_W, kTolerance,
+                                MatrixCompareType::relative));
+  }
+
+  // Verify contact Jacobian for hydroelastic pairs.
+  // We know hydroelastic pairs come after point pairs.
+  {
+    const Vector3d p_WS1(0, 0, radius - penetration_distance_);
+    for (size_t q = 1; q < pairs.size(); ++q) {
+      const Vector3d& p_WC = pairs[q].p_WC;
+      const Vector3d p_S1C_W = p_WC - p_WS1;
+      const Vector3d expected_v_WS1c = V_WS1.Shift(p_S1C_W).translational();
+      const int sign = pairs[q].id_B == sphere1_geometry ? 1 : -1;
+      const MatrixXd J_WS1c_C =
+          sign * Jc.block(3 * q, 0, 3, plant_->num_velocities());
+      const RotationMatrixd& R_WC = cache.R_WC_list[q];
+      const MatrixXd J_WS1c_W = R_WC.matrix() * J_WS1c_C;
+      const Vector3d v_WS1c_W = J_WS1c_W * v;
+      EXPECT_TRUE(CompareMatrices(v_WS1c_W, expected_v_WS1c, kTolerance,
+                                  MatrixCompareType::relative));
+    }
+  }
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Thus far this implements discrete pairs and contact Jacobian compuation.
The reason we don't use the ones currently in MultibodyPlant are:
1. This manager sets up a problem based on a linear model of dissipation instead of the currently used Hunt & Crossley model.
2. The new method to compute the Jacobian avoids unnecessary copies (about 30% faster) and cleans up sign conventions.
3. The long term solution in terms of mangers removes all contact related computation from MultibodyPlant, leading to a more modular design.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16047)
<!-- Reviewable:end -->
