### PR TITLE
[pydrake] Bind DepthImageToPointCloud.camera_pose_input_port

### DIFF
--- a/bindings/pydrake/perception_py.cc
+++ b/bindings/pydrake/perception_py.cc
@@ -138,6 +138,8 @@ void init_perception(py::module m) {
             py_rvp::reference_internal, cls_doc.depth_image_input_port.doc)
         .def("color_image_input_port", &Class::color_image_input_port,
             py_rvp::reference_internal, cls_doc.color_image_input_port.doc)
+        .def("camera_pose_input_port", &Class::camera_pose_input_port,
+            py_rvp::reference_internal, cls_doc.camera_pose_input_port.doc)
         .def("point_cloud_output_port", &Class::point_cloud_output_port,
             py_rvp::reference_internal, cls_doc.point_cloud_output_port.doc);
   }

--- a/bindings/pydrake/test/perception_test.py
+++ b/bindings/pydrake/test/perception_test.py
@@ -87,6 +87,7 @@ class TestPerception(unittest.TestCase):
         dut = mut.DepthImageToPointCloud(camera_info=camera_info)
         self.assertIsInstance(dut.depth_image_input_port(), InputPort)
         self.assertIsInstance(dut.color_image_input_port(), InputPort)
+        self.assertIsInstance(dut.camera_pose_input_port(), InputPort)
         self.assertIsInstance(dut.point_cloud_output_port(), OutputPort)
         dut = mut.DepthImageToPointCloud(
             camera_info=camera_info,


### PR DESCRIPTION
Inspired by a [StackOverflow question](https://stackoverflow.com/questions/69797712/pointcloud-visualization-in-drake-visualizer-in-python/69798666).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16048)
<!-- Reviewable:end -->
