### PR TITLE
Add VectorX-returning value methods to BasicVector and DiscreteValues

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -874,6 +874,11 @@ void DoScalarDependentDefinitions(py::module m) {
           overload_cast_explicit<void, const Eigen::Ref<const VectorX<T>>&>(
               &DiscreteValues<T>::set_value),
           py::arg("value"), doc.DiscreteValues.set_value.doc_1args)
+      .def("value",
+          overload_cast_explicit<const VectorX<T>&, int>(
+              &DiscreteValues<T>::value),
+          py_rvp::reference_internal, py::arg("index") = 0,
+          doc.DiscreteValues.value.doc_1args)
       .def("get_vector",
           overload_cast_explicit<const BasicVector<T>&, int>(
               &DiscreteValues<T>::get_vector),

--- a/bindings/pydrake/systems/framework_py_values.cc
+++ b/bindings/pydrake/systems/framework_py_values.cc
@@ -89,6 +89,12 @@ void DoScalarDependentDefinitions(py::module m) {
           },
           doc.BasicVector.set_value.doc)
       .def(
+          "value",
+          [](const BasicVector<T>* self) -> const VectorX<T>& {
+            return self->value();
+          },
+          py_rvp::reference_internal, doc.BasicVector.value.doc)
+      .def(
           "get_value",
           [](const BasicVector<T>* self) -> Eigen::Ref<const VectorX<T>> {
             return self->get_value();

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -343,6 +343,7 @@ class TestGeneral(unittest.TestCase):
         self.assertEqual(discrete_values.get_mutable_vector(index=0).size(), 3)
         x = np.array([1., 3., 4.])
         discrete_values.set_value(x)
+        np.testing.assert_array_equal(discrete_values.value(index=0), x)
         np.testing.assert_array_equal(discrete_values.get_value(), x)
         np.testing.assert_array_equal(discrete_values.get_mutable_value(), x)
         discrete_values[1] = 5.

--- a/bindings/pydrake/systems/test/value_test.py
+++ b/bindings/pydrake/systems/test/value_test.py
@@ -46,6 +46,8 @@ class TestValue(unittest.TestCase):
                 value[:] += 1
                 self.assertTrue(np.allclose(value, expected_add))
                 self.assertTrue(
+                    np.allclose(value_data.value(), expected_add))
+                self.assertTrue(
                     np.allclose(value_data.get_value(), expected_add))
                 self.assertTrue(
                     np.allclose(value_data.get_mutable_value(), expected_add))

--- a/examples/allegro_hand/test/allegro_lcm_test.cc
+++ b/examples/allegro_hand/test/allegro_lcm_test.cc
@@ -26,7 +26,7 @@ GTEST_TEST(AllegroLcmTest, AllegroCommandReceiver) {
   dut.CalcOutput(*context, output.get());
   const double tol = 1e-5;
   EXPECT_TRUE(CompareMatrices(
-      expected, output->get_vector_data(0)->get_value(),
+      expected, output->get_vector_data(0)->value(),
       tol, MatrixCompareType::absolute));
 
   Eigen::VectorXd position(kAllegroNumJoints);
@@ -35,12 +35,12 @@ GTEST_TEST(AllegroLcmTest, AllegroCommandReceiver) {
   dut.set_initial_position(context.get(), position);
   dut.CalcOutput(*context, output.get());
   EXPECT_TRUE(CompareMatrices(
-      position, output->get_vector_data(0)->get_value()
+      position, output->get_vector_data(0)->value()
       .head(kAllegroNumJoints),
       tol, MatrixCompareType::absolute));
   EXPECT_TRUE(CompareMatrices(
       expected.tail(kAllegroNumJoints),
-      output->get_vector_data(0)->get_value().tail(kAllegroNumJoints),
+      output->get_vector_data(0)->value().tail(kAllegroNumJoints),
       tol, MatrixCompareType::absolute));
 
   Eigen::VectorXd delta(kAllegroNumJoints);
@@ -65,15 +65,15 @@ GTEST_TEST(AllegroLcmTest, AllegroCommandReceiver) {
   dut.CalcOutput(*context, output.get());
   EXPECT_TRUE(CompareMatrices(
       position + delta,
-      output->get_vector_data(0)->get_value().head(kAllegroNumJoints),
+      output->get_vector_data(0)->value().head(kAllegroNumJoints),
       tol, MatrixCompareType::absolute));
   EXPECT_TRUE(CompareMatrices(
       VectorX<double>::Zero(kAllegroNumJoints),
-      output->get_vector_data(0)->get_value().tail(kAllegroNumJoints),
+      output->get_vector_data(0)->value().tail(kAllegroNumJoints),
       tol, MatrixCompareType::absolute));
   EXPECT_TRUE(CompareMatrices(
       VectorX<double>::Zero(kAllegroNumJoints),
-      output->get_vector_data(1)->get_value(),
+      output->get_vector_data(1)->value(),
       tol, MatrixCompareType::absolute));
 }
 

--- a/examples/bead_on_a_wire/test/bead_on_a_wire_test.cc
+++ b/examples/bead_on_a_wire/test/bead_on_a_wire_test.cc
@@ -51,7 +51,7 @@ TEST_F(BeadOnAWireTest, Output) {
                                                 get_continuous_state();
   dut_abs_->CalcOutput(*context_abs_, output_abs_.get());
   for (int i = 0; i < v.size(); ++i)
-    EXPECT_EQ(v[i], output_abs_->get_vector_data(0)->get_value()(i));
+    EXPECT_EQ(v[i], output_abs_->get_vector_data(0)->value()(i));
 }
 
 // Tests parameter getting and setting.

--- a/examples/kuka_iiwa_arm/kuka_torque_controller.cc
+++ b/examples/kuka_iiwa_arm/kuka_torque_controller.cc
@@ -59,7 +59,7 @@ class StateDependentDamper : public LeafSystem<T> {
    * damping gain for the i-th joint is given by 2*sqrt(M(i,i)*stiffness(i)).
    */
   void CalcTorque(const Context<T>& context, BasicVector<T>* torque) const {
-    Eigen::VectorXd x = this->EvalVectorInput(context, 0)->get_value();
+    const Eigen::VectorXd& x = this->EvalVectorInput(context, 0)->value();
     plant_.SetPositionsAndVelocities(plant_context_.get(), x);
 
     const int num_v = plant_.num_velocities();

--- a/examples/kuka_iiwa_arm/test/kuka_torque_controller_test.cc
+++ b/examples/kuka_iiwa_arm/test/kuka_torque_controller_test.cc
@@ -95,7 +95,7 @@ GTEST_TEST(KukaTorqueControllerTest, GravityCompensationTest) {
   // Check output.
   controller.CalcOutput(*context, output.get());
   const BasicVector<double>* output_vector = output->get_vector_data(0);
-  EXPECT_TRUE(CompareMatrices(expected_torque, output_vector->get_value(),
+  EXPECT_TRUE(CompareMatrices(expected_torque, output_vector->value(),
                               1e-10, MatrixCompareType::absolute));
 }
 
@@ -160,7 +160,7 @@ GTEST_TEST(KukaTorqueControllerTest, SpringTorqueTest) {
   // Check output.
   controller.CalcOutput(*context, output.get());
   const BasicVector<double>* output_vector = output->get_vector_data(0);
-  EXPECT_TRUE(CompareMatrices(expected_torque, output_vector->get_value(),
+  EXPECT_TRUE(CompareMatrices(expected_torque, output_vector->value(),
                               1e-10, MatrixCompareType::absolute));
 }
 
@@ -234,7 +234,7 @@ GTEST_TEST(KukaTorqueControllerTest, DampingTorqueTest) {
   // Check output.
   controller.CalcOutput(*context, output.get());
   const BasicVector<double>* output_vector = output->get_vector_data(0);
-  EXPECT_TRUE(CompareMatrices(expected_torque, output_vector->get_value(),
+  EXPECT_TRUE(CompareMatrices(expected_torque, output_vector->value(),
                               1e-10, MatrixCompareType::absolute));
 }
 

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -179,8 +179,7 @@ GTEST_TEST(ManipulationStationTest, CheckDynamics) {
       plant.num_positions() + base_joint.velocity_start();
   VectorXd next_velocity =
       station.GetSubsystemDiscreteValues(plant, *next_state)
-          .get_vector()
-          .get_value()
+          .value()
           .segment<7>(iiwa_velocity_start);
 
   // Note: This tolerance could be much smaller if the wsg was not attached.

--- a/examples/mass_spring_cloth/cloth_spring_model.cc
+++ b/examples/mass_spring_cloth/cloth_spring_model.cc
@@ -158,7 +158,7 @@ void ClothSpringModel<T>::CopyDiscreteStateOut(
   const systems::BasicVector<T>& discrete_state_vector =
       context.get_discrete_state(0);
   output->SetFromVector(
-      discrete_state_vector.get_value().head(3 * num_particles_));
+      discrete_state_vector.value().head(3 * num_particles_));
 }
 
 template <typename T>
@@ -195,9 +195,7 @@ template <typename T>
 void ClothSpringModel<T>::UpdateDiscreteState(
     const systems::Context<T>& context,
     systems::DiscreteValues<T>* next_states) const {
-  const systems::BasicVector<T>& current_state =
-      context.get_discrete_state().get_vector();
-  const VectorX<T>& current_state_values = current_state.get_value();
+  const VectorX<T>& current_state_values = context.get_discrete_state().value();
   const auto& q_n = current_state_values.head(3 * num_particles_);
   const auto& v_n = current_state_values.tail(3 * num_particles_);
   // v_hat is the velocity of the particles after adding the effect of the

--- a/examples/pendulum/lqr_simulation.cc
+++ b/examples/pendulum/lqr_simulation.cc
@@ -69,8 +69,8 @@ int DoMain() {
   simulator.AdvanceTo(10);
 
   // Adds a numerical test to make sure we're stabilizing the fixed point.
-  DRAKE_DEMAND(is_approx_equal_abstol(state.get_value(),
-                                      desired_state.get_value(), 1e-3));
+  DRAKE_DEMAND(is_approx_equal_abstol(state.value(),
+                                      desired_state.value(), 1e-3));
 
   return 0;
 }

--- a/examples/pendulum/trajectory_optimization_simulation.cc
+++ b/examples/pendulum/trajectory_optimization_simulation.cc
@@ -58,15 +58,15 @@ int DoMain() {
   final_state.set_thetadot(0.0);
 
   dircol.AddLinearConstraint(dircol.initial_state() ==
-                             initial_state.get_value());
-  dircol.AddLinearConstraint(dircol.final_state() == final_state.get_value());
+                             initial_state.value());
+  dircol.AddLinearConstraint(dircol.final_state() == final_state.value());
 
   const double R = 10;  // Cost on input "effort".
   dircol.AddRunningCost((R * u) * u);
 
   const double timespan_init = 4;
   auto traj_init_x = PiecewisePolynomial<double>::FirstOrderHold(
-      {0, timespan_init}, {initial_state.get_value(), final_state.get_value()});
+      {0, timespan_init}, {initial_state.value(), final_state.value()});
   dircol.SetInitialTrajectory(PiecewisePolynomial<double>(), traj_init_x);
   const auto result = solvers::Solve(dircol);
   if (!result.is_success()) {
@@ -117,8 +117,8 @@ int DoMain() {
       PendulumPlant<double>::get_state(diagram->GetSubsystemContext(
           *pendulum_ptr, simulator.get_context()));
 
-  if (!is_approx_equal_abstol(pendulum_state.get_value(),
-                              final_state.get_value(), 1e-3)) {
+  if (!is_approx_equal_abstol(pendulum_state.value(),
+                              final_state.value(), 1e-3)) {
     throw std::runtime_error("Did not reach trajectory target.");
   }
   return 0;

--- a/examples/planar_gripper/planar_gripper_lcm.cc
+++ b/examples/planar_gripper/planar_gripper_lcm.cc
@@ -81,7 +81,7 @@ systems::EventStatus GripperCommandDecoder::UpdateDiscreteState(
 void GripperCommandDecoder::OutputStateCommand(
     const Context<double>& context, BasicVector<double>* output) const {
   Eigen::VectorBlock<VectorX<double>> output_vec = output->get_mutable_value();
-  output_vec = context.get_discrete_state(0).get_value().head(num_joints_ * 2);
+  output_vec = context.get_discrete_state(0).value().head(num_joints_ * 2);
 }
 
 void GripperCommandDecoder::OutputTorqueCommand(
@@ -181,13 +181,13 @@ systems::EventStatus GripperStatusDecoder::UpdateDiscreteState(
 void GripperStatusDecoder::OutputStateStatus(
     const Context<double>& context, BasicVector<double>* output) const {
   Eigen::VectorBlock<VectorX<double>> output_vec = output->get_mutable_value();
-  output_vec = context.get_discrete_state(0).get_value().head(num_joints_ * 2);
+  output_vec = context.get_discrete_state(0).value().head(num_joints_ * 2);
 }
 
 void GripperStatusDecoder::OutputForceStatus(
     const Context<double>& context, BasicVector<double>* output) const {
   Eigen::VectorBlock<VectorX<double>> output_vec = output->get_mutable_value();
-  output_vec = context.get_discrete_state(0).get_value().tail(num_fingers_ * 2);
+  output_vec = context.get_discrete_state(0).value().tail(num_fingers_ * 2);
 }
 
 GripperStatusEncoder::GripperStatusEncoder(int num_fingers)
@@ -207,10 +207,10 @@ void GripperStatusEncoder::OutputStatus(
   status->utime = static_cast<int64_t>(context.get_time() * 1e6);
   const systems::BasicVector<double>* state_input =
       this->EvalVectorInput(context, 0);
-  auto state_value = state_input->get_value();
+  const VectorX<double>& state_value = state_input->value();
   const systems::BasicVector<double>* force_input =
       this->EvalVectorInput(context, 1);
-  auto force_value = force_input->get_value();
+  const VectorX<double>& force_value = force_input->value();
 
   status->num_fingers = num_fingers_;
   status->finger_status.resize(num_fingers_);

--- a/examples/planar_gripper/planar_gripper_simulation.cc
+++ b/examples/planar_gripper/planar_gripper_simulation.cc
@@ -177,8 +177,10 @@ class GeneralizedForceToActuationOrdering : public systems::LeafSystem<double> {
 
   void remap_output(const systems::Context<double>& context,
                     systems::BasicVector<double>* output_vector) const {
-    auto output_value = output_vector->get_mutable_value();
-    auto input_value = this->EvalVectorInput(context, 0)->get_value();
+    Eigen::VectorBlock<VectorX<double>> output_value =
+        output_vector->get_mutable_value();
+    const VectorX<double>& input_value =
+        this->EvalVectorInput(context, 0)->value();
 
     output_value.setZero();
     output_value = Binv_ * input_value;

--- a/examples/planar_gripper/planar_manipuland_lcm.cc
+++ b/examples/planar_gripper/planar_manipuland_lcm.cc
@@ -41,7 +41,7 @@ void PlanarManipulandStatusDecoder::OutputStatus(
     const systems::Context<double>& context,
     systems::BasicVector<double>* output) const {
   Eigen::VectorBlock<VectorX<double>> output_vec = output->get_mutable_value();
-  output_vec = context.get_discrete_state(0).get_value();
+  output_vec = context.get_discrete_state(0).value();
 }
 
 PlanarManipulandStatusEncoder::PlanarManipulandStatusEncoder() {

--- a/examples/quadrotor/quadrotor_plant.cc
+++ b/examples/quadrotor/quadrotor_plant.cc
@@ -56,7 +56,7 @@ void QuadrotorPlant<T>::DoCalcTimeDerivatives(
     const systems::Context<T> &context,
     systems::ContinuousState<T> *derivatives) const {
   // Get the input value characterizing each of the 4 rotor's aerodynamics.
-  const Vector4<T> u = this->EvalVectorInput(context, 0)->get_value();
+  const Vector4<T> u = this->EvalVectorInput(context, 0)->value();
 
   // For each rotor, calculate the Bz measure of its aerodynamic force on B.
   // Note: B is the quadrotor body and Bz is parallel to each rotor's spin axis.

--- a/examples/rod2d/rod2d.cc
+++ b/examples/rod2d/rod2d.cc
@@ -495,8 +495,8 @@ void Rod2D<T>::DoCalcDiscreteVariableUpdates(
 
   // Get the necessary state variables.
   const systems::BasicVector<T>& state = context.get_discrete_state(0);
-  const auto& q = state.get_value().template segment<3>(0);
-  Vector3<T> v = state.get_value().template segment<3>(3);
+  const auto& q = state.value().template segment<3>(0);
+  Vector3<T> v = state.value().template segment<3>(3);
   const T& x = q(0);
   const T& y = q(1);
   const T& theta = q(2);

--- a/examples/rod2d/test/rod2d_test.cc
+++ b/examples/rod2d/test/rod2d_test.cc
@@ -297,7 +297,7 @@ TEST_F(Rod2DDAETest, Output) {
       dut_->AllocateOutput();
   dut_->CalcOutput(*context_, output.get());
   for (int i = 0; i < xc.size(); ++i)
-    EXPECT_EQ(xc[i], output->get_vector_data(0)->get_value()(i));
+    EXPECT_EQ(xc[i], output->get_vector_data(0)->value()(i));
 }
 
 // Verifies that setting dut to an impacting state actually results in an
@@ -804,7 +804,7 @@ TEST_F(Rod2DDiscretizedTest, RodGoesToRest) {
   simulator.AdvanceTo(t_final);
 
   // Get angular orientation and velocity.
-  const auto xd = simulator.get_context().get_discrete_state(0).get_value();
+  const VectorXd& xd = simulator.get_context().get_discrete_state(0).value();
   const double theta = xd(2);
   const double theta_dot = xd(5);
 

--- a/examples/scene_graph/solar_system.cc
+++ b/examples/scene_graph/solar_system.cc
@@ -333,7 +333,7 @@ void SolarSystem<T>::DoCalcTimeDerivatives(
   BasicVector<T>& derivative_vector = get_mutable_state(derivatives);
   derivative_vector.SetZero();
   derivative_vector.get_mutable_value().head(kBodyCount) =
-      state.get_value().tail(kBodyCount);
+      state.value().tail(kBodyCount);
 }
 
 template class SolarSystem<double>;

--- a/multibody/tree/multibody_tree_system.cc
+++ b/multibody/tree/multibody_tree_system.cc
@@ -255,11 +255,8 @@ void MultibodyTreeSystem<T>::DoCalcTimeDerivatives(
   // entries at all and the system framework will never call this.
   if (internal_tree().num_states() == 0) return;
 
-  // N.B. get_value() here is inexplicably returning a VectorBlock
-  // rather than a reference to the stored VectorX.
-  const auto x =
-      dynamic_cast<const systems::BasicVector<T>&>(
-          context.get_continuous_state_vector()).get_value();
+  const VectorX<T>& x = dynamic_cast<const systems::BasicVector<T>&>(
+      context.get_continuous_state_vector()).value();
   const auto v = x.bottomRows(internal_tree().num_velocities());
 
   const VectorX<T>& vdot = this->EvalForwardDynamics(context).get_vdot();
@@ -337,9 +334,9 @@ void MultibodyTreeSystem<T>::DoCalcImplicitTimeDerivativesResidual(
 
   // TODO(sherm1) This dynamic_cast is likely too expensive -- replace with
   //              static_cast in Release builds.
-  Eigen::VectorBlock<const VectorX<T>> qvdot_proposed =
+  const VectorX<T>& qvdot_proposed =
       dynamic_cast<const systems::BasicVector<T>&>(
-          proposed_derivatives.get_vector()).get_value();
+          proposed_derivatives.get_vector()).value();
   DRAKE_ASSERT(qvdot_proposed.size() == nq+nv);
 
   auto qdot_residual = residual->head(nq);

--- a/systems/controllers/pid_controller.cc
+++ b/systems/controllers/pid_controller.cc
@@ -108,10 +108,10 @@ void PidController<T>::CalcControl(const Context<T>& context,
   const VectorX<T> controlled_state_diff =
       state_d - (state_projection_.cast<T>() * state);
 
-  // Intergral error, which is stored in the continuous state.
-  const VectorBase<T>& state_vector = context.get_continuous_state_vector();
-  const Eigen::VectorBlock<const VectorX<T>> state_block =
-      dynamic_cast<const BasicVector<T>&>(state_vector).get_value();
+  // Integral error, which is stored in the continuous state.
+  const VectorX<T>& state_vector =
+      dynamic_cast<const BasicVector<T>&>(context.get_continuous_state_vector())
+          .value();
 
   // Sets output to the sum of all three terms.
   control->SetFromVector(
@@ -120,7 +120,7 @@ void PidController<T>::CalcControl(const Context<T>& context,
            .matrix() +
        (kd_.array() * controlled_state_diff.tail(num_controlled_q_).array())
            .matrix() +
-       (ki_.array() * state_block.array()).matrix()));
+       (ki_.array() * state_vector.array()).matrix()));
 }
 
 // Adds a simple record-based representation of the PID controller to @p dot.

--- a/systems/framework/basic_vector.h
+++ b/systems/framework/basic_vector.h
@@ -73,10 +73,9 @@ class BasicVector : public VectorBase<T> {
     values_ = value;
   }
 
-  /// Returns the entire vector as a const Eigen::VectorBlock.
-  Eigen::VectorBlock<const VectorX<T>> get_value() const {
-    return values_.head(values_.rows());
-  }
+  /// Returns a const reference to the contained `VectorX<T>`. This is the
+  /// preferred method for examining a BasicVector's value.
+  const VectorX<T>& value() const { return values_; }
 
   /// Returns the entire vector as a mutable Eigen::VectorBlock, which allows
   /// mutation of the values, but does not allow `resize()` to be invoked on
@@ -110,6 +109,14 @@ class BasicVector : public VectorBase<T> {
     auto clone = std::unique_ptr<BasicVector<T>>(DoClone());
     clone->set_value(this->get_value());
     return clone;
+  }
+
+  // TODO(sherm1) Consider deprecating this.
+  /// (Don't use this in new code) Returns the entire vector as a const
+  /// Eigen::VectorBlock. Prefer `value()` which returns direct access to the
+  /// underlying VectorX rather than wrapping it in a VectorBlock.
+  Eigen::VectorBlock<const VectorX<T>> get_value() const {
+    return values_.head(values_.rows());
   }
 
  protected:
@@ -161,10 +168,14 @@ class BasicVector : public VectorBase<T> {
     (*data)[index++] = T(constructor_arg);
   }
 
-  /// Provides const access to the element storage.
+  // TODO(sherm1) Deprecate this method.
+  /// Provides const access to the element storage. Prefer the synonymous
+  /// public `value()` method -- this protected method remains for backwards
+  /// compatibility in derived classes.
   const VectorX<T>& values() const { return values_; }
 
-  /// Provides mutable access to the element storage.
+  /// (Advanced) Provides mutable access to the element storage. Be careful
+  /// not to resize the storage unless you really know what you're doing.
   VectorX<T>& values() { return values_; }
 
  private:

--- a/systems/framework/discrete_values.h
+++ b/systems/framework/discrete_values.h
@@ -94,7 +94,6 @@ class DiscreteValues {
 
   const std::vector<BasicVector<T>*>& get_data() const { return data_; }
 
-  //----------------------------------------------------------------------------
   /// @name Convenience accessors for %DiscreteValues with just one group.
   /// These will throw if there is not exactly one group in this %DiscreteValues
   /// object.
@@ -115,70 +114,69 @@ class DiscreteValues {
     return get_vector()[idx];
   }
 
-  /// Returns a const reference to the BasicVector containing the values for
-  /// the _only_ group.
-  const BasicVector<T>& get_vector() const {
-    ThrowUnlessExactlyOneGroup();
-    return get_vector(0);
-  }
-
-  /// Returns a mutable reference to the BasicVector containing the values for
-  /// the _only_ group.
-  BasicVector<T>& get_mutable_vector() {
-    ThrowUnlessExactlyOneGroup();
-    return get_mutable_vector(0);
+  /// Returns a const reference to the underlying VectorX containing the values
+  /// for the _only_ group. This is the preferred method for examining the
+  /// value of the only group.
+  const VectorX<T>& value() const {
+    return get_vector().value();
   }
 
   /// Sets the vector to the given value for the _only_ group.
   void set_value(const Eigen::Ref<const VectorX<T>>& value) {
-    ThrowUnlessExactlyOneGroup();
-    get_mutable_vector(0).set_value(value);
-  }
-
-  /// Returns the entire vector as a const Eigen::VectorBlock for the _only_
-  /// group.
-  Eigen::VectorBlock<const VectorX<T>> get_value() const {
-    ThrowUnlessExactlyOneGroup();
-    return get_vector(0).get_value();
+    get_mutable_vector().set_value(value);
   }
 
   /// Returns the entire vector for the _only_ group as a mutable
   /// Eigen::VectorBlock, which allows mutation of the values, but does not
   /// allow resize() to be called on the vector.
   Eigen::VectorBlock<VectorX<T>> get_mutable_value() {
-    ThrowUnlessExactlyOneGroup();
-    return get_mutable_vector(0).get_mutable_value();
+    return get_mutable_vector().get_mutable_value();
   }
 
+  /// (Advanced) Returns a const reference to the BasicVector containing the
+  /// values for the _only_ group. Prefer `value()` to get the underlying
+  /// VectorX directly unless you really need the BasicVector wrapping it.
+  const BasicVector<T>& get_vector() const {
+    ThrowUnlessExactlyOneGroup();
+    return get_vector(0);
+  }
+
+  /// (Advanced) Returns a mutable reference to the BasicVector containing the
+  /// values for the _only_ group. Prefer `get_mutable_value()` to get the
+  /// underlying Eigen object.
+  BasicVector<T>& get_mutable_vector() {
+    ThrowUnlessExactlyOneGroup();
+    return get_mutable_vector(0);
+  }
+
+  // TODO(sherm1) Consider deprecating this.
+  /// (Don't use this in new code) Returns the entire vector as a const
+  /// Eigen::VectorBlock for the _only_ group. Prefer `value()` which returns
+  /// direct access to the underlying VectorX rather than wrapping it in a
+  /// VectorBlock.
+  Eigen::VectorBlock<const VectorX<T>> get_value() const {
+    ThrowUnlessExactlyOneGroup();
+    return get_vector(0).get_value();
+  }
   //@}
 
-  /// Returns a const reference to the vector holding data for the indicated
-  /// group.
-  const BasicVector<T>& get_vector(int index) const {
-    DRAKE_THROW_UNLESS(0 <= index && index < num_groups());
-    return *data_[index];
-  }
+  /// @name Accessors for %DiscreteValues with multiple groups.
+  /// If you know there is only one group consider
+  /// using the alternative signatures that don't take a group index.
+  //@{
 
-  /// Returns a mutable reference to the vector holding data for the indicated
-  /// group.
-  BasicVector<T>& get_mutable_vector(int index) {
-    DRAKE_THROW_UNLESS(0 <= index && index < num_groups());
-    return *data_[index];
-  }
-
-  /// Returns the entire vector as a const Eigen::VectorBlock for the indicated
-  /// group.
-  Eigen::VectorBlock<const VectorX<T>> get_value(int index) const {
-    DRAKE_THROW_UNLESS(0 <= index && index < num_groups());
-    return data_[index]->get_value();
+  /// Returns a const reference to the underlying VectorX containing the values
+  /// for the indicated group. This is the preferred method for examining the
+  /// value of a group.
+  const VectorX<T>& value(int index) const {
+    return get_vector(index).value();
   }
 
   /// Returns the entire vector for the indicated group as a mutable
   /// Eigen::VectorBlock, which allows mutation of the values, but does not
   /// allow resize() to be called on the vector.
   Eigen::VectorBlock<VectorX<T>> get_mutable_value(int index) {
-    DRAKE_THROW_UNLESS(0 <= index && index < num_groups());
-    return data_[index]->get_mutable_value();
+    return get_mutable_vector(index).get_mutable_value();
   }
 
   /// Sets the vector to the given value for the indicated group.
@@ -186,6 +184,32 @@ class DiscreteValues {
       int index, const Eigen::Ref<const VectorX<T>>& value) {
     get_mutable_vector(index).set_value(value);
   }
+
+  /// (Advanced) Returns a const reference to the BasicVector holding data for
+  /// the indicated group. Prefer `value(index)` to get the underlying
+  ///  VectorX directly unless you really need the BasicVector wrapping it.
+  const BasicVector<T>& get_vector(int index) const {
+    DRAKE_THROW_UNLESS(0 <= index && index < num_groups());
+    return *data_[index];
+  }
+
+  /// (Advanced) Returns a mutable reference to the BasicVector holding data for
+  /// the indicated group. Prefer `get_mutable_value()` to get the underlying
+  /// Eigen object unless you really need the BasicVector wrapping it.
+  BasicVector<T>& get_mutable_vector(int index) {
+    DRAKE_THROW_UNLESS(0 <= index && index < num_groups());
+    return *data_[index];
+  }
+
+  // TODO(sherm1) Consider deprecating this.
+  /// (Don't use this in new code) Returns the entire vector as a const
+  /// Eigen::VectorBlock for the indicated group. Prefer `value()` which returns
+  /// direct access to the underlying VectorX rather than wrapping it in a
+  /// VectorBlock.
+  Eigen::VectorBlock<const VectorX<T>> get_value(int index) const {
+    return get_vector(index).get_value();
+  }
+  //@}
 
   /// Resets the values in this DiscreteValues from the values in @p other,
   /// possibly writing through to unowned data. Throws if the dimensions don't

--- a/systems/primitives/discrete_time_delay.cc
+++ b/systems/primitives/discrete_time_delay.cc
@@ -80,8 +80,7 @@ void DiscreteTimeDelay<T>::SaveInputVectorToBuffer(
   const auto& input = this->get_input_port().Eval(context);
   Eigen::VectorBlock<VectorX<T>> updated_state_value =
       discrete_state->get_mutable_value(0);
-  Eigen::VectorBlock<const VectorX<T>> old_state_value =
-      context.get_discrete_state(0).get_value();
+  const VectorX<T>& old_state_value = context.get_discrete_state(0).value();
   updated_state_value.head((delay_buffer_size_ - 1) * vector_size_) =
       old_state_value.tail((delay_buffer_size_ - 1) * vector_size_);
   updated_state_value.tail(vector_size_) = input;

--- a/systems/sensors/rotary_encoders.cc
+++ b/systems/sensors/rotary_encoders.cc
@@ -79,8 +79,8 @@ void RotaryEncoders<T>::DoCalcVectorOutput(
     Eigen::VectorBlock<VectorX<T>>* output) const {
   unused(state);
 
-  const Eigen::VectorBlock<const VectorX<T>>& calibration_offsets =
-      context.get_numeric_parameter(0).get_value();
+  const VectorX<T>& calibration_offsets =
+      context.get_numeric_parameter(0).value();
   DRAKE_ASSERT(calibration_offsets.size() == num_encoders_);
 
   // Loop through the outputs.


### PR DESCRIPTION
As discussed in #16031, this PR adds `value() -> const VectorX<T>&` methods to BasicVector and DiscreteValues, moving `get_value() -> VectorBlock<const VectorX<T>>` methods to "to be deprecated".

Some call sites are updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16051)
<!-- Reviewable:end -->
