### PR TITLE
[doc] macOS releases use Big Sur now

### DIFF
--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -109,7 +109,7 @@ the main body of the document:
       has nothing still running (modulo the ``*-coverage`` builds, which we can
       ignore)
    3. Open the latest builds from the following builds:
-      1. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/mac-catalina-unprovisioned-clang-bazel-nightly-snopt-packaging/>
+      1. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/mac-big-sur-unprovisioned-clang-bazel-nightly-snopt-packaging/>
       2. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-bionic-unprovisioned-gcc-bazel-nightly-snopt-packaging/>
       3. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-focal-unprovisioned-gcc-bazel-nightly-snopt-packaging/>
    4. Check the logs for those packaging builds and find the URLs they posted


### PR DESCRIPTION
Changed in https://github.com/RobotLocomotion/drake-ci/pull/126 and in effect as of last night.  The uploaded URL pattern stays the same, so the "download_release_candidate" script does not need to change.

Towards #16001.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16053)
<!-- Reviewable:end -->
