### PR TITLE
[yaml] Allow serializing a top-level map with no enclosing struct

### DIFF
--- a/common/yaml/test/yaml_write_archive_test.cc
+++ b/common/yaml/test/yaml_write_archive_test.cc
@@ -165,6 +165,25 @@ TEST_F(YamlWriteArchiveTest, StdUnorderedMap) {
 )""");
 }
 
+TEST_F(YamlWriteArchiveTest, StdMapDirectly) {
+  const auto test = [](const std::map<std::string, double>& value,
+                       const std::string& expected) {
+    EXPECT_EQ(Save(value), expected);
+  };
+
+  test({}, R"""(doc:
+)""");
+
+  test({{"foo", 0.0}}, R"""(doc:
+  foo: 0.0
+)""");
+
+  test({{"foo", 0.0}, {"bar", 1.0}}, R"""(doc:
+  bar: 1.0
+  foo: 0.0
+)""");
+}
+
 TEST_F(YamlWriteArchiveTest, Optional) {
   const auto test = [](const std::optional<double>& value,
                        const std::string& expected) {

--- a/common/yaml/yaml_doxygen.h
+++ b/common/yaml/yaml_doxygen.h
@@ -102,4 +102,21 @@ std::unordered_map.
 
 For inspiration and background, see:
 https://www.boost.org/doc/libs/release/libs/serialization/doc/tutorial.html
+
+<!--
+TODO(jwnimmer-tri) Describe the special case for top-level collections without
+a Serialize function, i.e., std::map<std::string, Serializable>.
+
+Usually we require that we have a serializable struct that matches the YAML
+document. However, for the special case of a C++ collection type that matches
+a YAML node type exactly, sometimes it's convenient to parse the document
+directly into that collection, without the need to define an enclosing struct.
+
+This PR adds std::map<std::string, Serializable> along those lines. In the
+future we could imagine adding std::vector<Serializable> as well just for
+completeness, though I no examples of needing that come to mind. Those are the
+only two collection types that we'd want to allow in this kind of special case.
+(They are the only ones that directly align with YAML node semantics.)
+-->
+
 */


### PR DESCRIPTION
Towards #15868.

Refer to Anzu PR 8004 for the motivating use case.

Usually we require that we have a serializable struct that matches the YAML document.  However, for the special case of a C++ collection type that matches a YAML node type exactly, sometimes it's convenient to parse the document directly into that collection, without the need to define an enclosing struct.

This PR adds `std::map<std::string, Serializable>` along those lines.  In the future we _could_ imagine adding `std::vector<Serializable>` as well just for completeness, though I no examples of needing that come to mind.  Those are the only two collection types that we'd want to allow in this kind of special case.  (They are the only ones that directly align with YAML node semantics.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16059)
<!-- Reviewable:end -->
