### PR TITLE
[kuka_iiwa_arm] Deprecate installed use of kuka sim and plan runner

### DIFF
--- a/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/BUILD.bazel
@@ -214,7 +214,9 @@ sh_test(
     tags = ["no_kcov"],
 )
 
-# This examples needs to be install for external projects such as Spartan.
+# TODO(jwnimmer-tri) On 2022-01-01 once this deprecation date has passed,
+# remove this entire stanza, 'git rm' these two python test files, and
+# remove the references to these two programs from drake/tools/wheel/...
 install(
     name = "install",
     install_tests = [

--- a/examples/kuka_iiwa_arm/kuka_plan_runner.cc
+++ b/examples/kuka_iiwa_arm/kuka_plan_runner.cc
@@ -11,6 +11,8 @@
 /// If a stop message is received, it will immediately discard the
 /// current plan and wait until a new plan is received.
 
+#include <string.h>
+
 #include <iostream>
 #include <memory>
 
@@ -18,6 +20,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/find_resource.h"
+#include "drake/common/text_logging.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/lcmt_iiwa_command.hpp"
 #include "drake/lcmt_iiwa_status.hpp"
@@ -198,6 +201,15 @@ int do_main() {
 }  // namespace drake
 
 
-int main() {
+int main(int /* argc */, char* argv[]) {
+  // TODO(jwnimmer-tri) On 2022-01-01 once this deprecation date has passed,
+  // revert the portion of the patch that changed this file.
+  if (::strstr(argv[0], "bazel-bin/") == NULL) {
+    drake::log()->warn(
+        "The use of kuka_plan_runner outside of Drake"
+        " (i.e., via 'make install'  or a pre-compiled release image)"
+        " is deprecated and will be removed from the install"
+        " on or after 2022-01-01");
+  }
   return drake::examples::kuka_iiwa_arm::do_main();
 }

--- a/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -5,12 +5,15 @@
 /// and lcmt_iiwa_command messages. It is intended to be a be a direct
 /// replacement for the KUKA iiwa driver and the actual robot hardware.
 
+#include <string.h>
+
 #include <memory>
 
 #include <gflags/gflags.h>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/find_resource.h"
+#include "drake/common/text_logging.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_common.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_lcm.h"
 #include "drake/examples/kuka_iiwa_arm/kuka_torque_controller.h"
@@ -185,6 +188,15 @@ int DoMain() {
 }  // namespace drake
 
 int main(int argc, char* argv[]) {
+  // TODO(jwnimmer-tri) On 2022-01-01 once this deprecation date has passed,
+  // revert the portion of the patch that changed this file.
+  if (::strstr(argv[0], "bazel-bin/") == NULL) {
+    drake::log()->warn(
+        "The use of kuka_simulation outside of Drake"
+        " (i.e., via 'make install'  or a pre-compiled release image)"
+        " is deprecated and will be removed from the install"
+        " on or after 2022-01-01");
+  }
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   return drake::examples::kuka_iiwa_arm::DoMain();
 }

--- a/examples/kuka_iiwa_arm/test/kuka_simulation_installed_test.py
+++ b/examples/kuka_iiwa_arm/test/kuka_simulation_installed_test.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import unittest
 
 import install_test_helper
@@ -6,14 +7,15 @@ import install_test_helper
 
 class TestKukaSimulation(unittest.TestCase):
     def test_install(self):
-        # Get install directory
+        """Makes sure the simulation can run without error."""
         install_dir = install_test_helper.get_install_dir()
-        # Make sure the simulation can run without error.
         simulation = os.path.join(
             install_dir,
             "share/drake/examples/kuka_iiwa_arm/kuka_simulation")
         self.assertTrue(os.path.exists(simulation), "Can't find " + simulation)
-        install_test_helper.check_call([simulation, "--simulation_sec=0.01"])
+        console_output = install_test_helper.check_output(
+            [simulation, "--simulation_sec=0.01"], stderr=subprocess.STDOUT)
+        self.assertIn("kuka_simulation outside of Drake", console_output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
These are not even public to Bazel users or other programs within Drake.  They definitely should not be published for use by binary release users.  Relates #4224.

Note that the deprecation fuse on this one is only two release tags (instead of three+ like usual), because I'd like to get it out of the way in time for release pipeline improvements due in January, and because it seems unlikely to severely disrupt any users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16061)
<!-- Reviewable:end -->
