### PR TITLE
[meshcat] Upgrade meshcat to fix animation "interference" issue

### DIFF
--- a/geometry/meshcat_animation.h
+++ b/geometry/meshcat_animation.h
@@ -17,11 +17,6 @@ class Meshcat;
 /** An interface for recording/playback animations in Meshcat. Use
 Meshcat::SetAnimation to publish a MeshcatAnimation to the visualizer.
 
-NOTE: There is a significant bug in meshcat/three.js that limits the ability to
-set multiple property types in a single animation.  Your mileage with property
-animations may vary until we can resolve
-https://github.com/rdeits/meshcat/issues/105.
-
 Currently, an animation consists of (only) transforms and properties that are
 set at a particular integer frame number. Although we do not support calls to
 SetObject/Delete in an animation, you can consider using `SetProperty(frame,

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -93,36 +93,25 @@ Open up your browser to the URL above.
   animation.SetTransform(
       40, "box", RigidTransformd(RotationMatrixd::MakeZRotation(2 * M_PI)));
   animation.set_repetitions(4);
-  meshcat->SetAnimation(animation);
-
-  // TODO(russt): Do all of these in a single animation pending resolution of
-  // https://github.com/rdeits/meshcat/issues/105
-  std::cout << "[Press RETURN to continue]." << std::endl;
-  std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-
-  MeshcatAnimation animation2;
-  animation2.SetProperty(0, "cylinder", "visible", true);
-  animation2.SetProperty(20, "cylinder", "visible", false);
-  animation2.SetProperty(40, "cylinder", "visible", true);
-  animation2.set_repetitions(4);
-  meshcat->SetAnimation(animation2);
 
   std::cout << "- the green cylinder should appear and disappear.\n";
-  std::cout << "[Press RETURN to continue]." << std::endl;
-  std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-
-  MeshcatAnimation animation3;
-  animation3.SetProperty(0, "ellipsoid/<object>", "material.opacity", 1.0);
-  animation3.SetProperty(20, "ellipsoid/<object>", "material.opacity", 0.0);
-  animation3.SetProperty(40, "ellipsoid/<object>", "material.opacity", 1.0);
-  animation3.set_repetitions(4);
-  meshcat->SetAnimation(animation3);
+  animation.SetProperty(0, "cylinder", "visible", true);
+  animation.SetProperty(20, "cylinder", "visible", false);
+  animation.SetProperty(40, "cylinder", "visible", true);
+  animation.set_repetitions(4);
 
   std::cout
       << "- the pink ellipsoid should get less and then more transparent.\n";
+  animation.SetProperty(0, "ellipsoid/<object>", "material.opacity", 1.0);
+  animation.SetProperty(20, "ellipsoid/<object>", "material.opacity", 0.0);
+  animation.SetProperty(40, "ellipsoid/<object>", "material.opacity", 1.0);
+  animation.set_repetitions(4);
+
+  meshcat->SetAnimation(animation);
+
+  std::cout << "You can review/replay the animation from the controls menu.\n";
   std::cout << "[Press RETURN to continue]." << std::endl;
   std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-
 
   meshcat->Set2dRenderMode(math::RigidTransform(Eigen::Vector3d{0, -3, 0}), -4,
                            4, -2, 2);

--- a/tools/workspace/meshcat/repository.bzl
+++ b/tools/workspace/meshcat/repository.bzl
@@ -11,8 +11,8 @@ def meshcat_repository(
         repository = "rdeits/meshcat",
         # Updating this commit requires local testing; see
         # drake/tools/workspace/meshcat/README.md for details.
-        commit = "675a312a2e91921d786fe83c49b492f02c1fc6c3",
-        sha256 = "ea05fad66d761284026c2396e79922164dc4ae28817705316783eeacbf345a08",  # noqa
+        commit = "978cb8f519f9bb540e94b7f97a39ada4d7916b7c",
+        sha256 = "3f7cc8b255a5d8a744903e94d2037b0e35291e286e7b1293fbc11c2fceb396e4",  # noqa
         build_file = "@drake//tools/workspace/meshcat:package.BUILD.bazel",  # noqa
         mirrors = mirrors,
     )


### PR DESCRIPTION
@rdeits has fixed https://github.com/rdeits/meshcat/issues/105.
This PR bumps the meshcat sha and removes the TODO in the test
that was blocked by this issue.  Hoorah!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16062)
<!-- Reviewable:end -->
