### PR TITLE
[meshcat] Add Meshcat::SetLine and Meshcat::SetLineSegments

### DIFF
--- a/bindings/pydrake/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry_py_visualizers.cc
@@ -209,6 +209,13 @@ void DoScalarIndependentDefinitions(py::module m) {
                 double, const Rgba&>(&Class::SetObject),
             py::arg("path"), py::arg("cloud"), py::arg("point_size") = 0.001,
             py::arg("rgba") = Rgba(.9, .9, .9, 1.), cls_doc.SetObject.doc_cloud)
+        .def("SetLine", &Class::SetLine, py::arg("path"), py::arg("vertices"),
+            py::arg("line_width") = 1.0,
+            py::arg("rgba") = Rgba(0.1, 0.1, 0.1, 1.0), cls_doc.SetLine.doc)
+        .def("SetLineSegments", &Class::SetLineSegments, py::arg("path"),
+            py::arg("start"), py::arg("end"), py::arg("line_width") = 1.0,
+            py::arg("rgba") = Rgba(0.1, 0.1, 0.1, 1.0),
+            cls_doc.SetLineSegments.doc)
         // TODO(russt): Bind SetCamera.
         .def("Set2dRenderMode", &Class::Set2dRenderMode,
             py::arg("X_WC") = RigidTransformd{Eigen::Vector3d{0, -1, 0}},

--- a/bindings/pydrake/test/geometry_visualizers_test.py
+++ b/bindings/pydrake/test/geometry_visualizers_test.py
@@ -103,6 +103,11 @@ class TestGeometryVisualizers(unittest.TestCase):
         cloud.mutable_xyzs()[:] = np.zeros((3, 4))
         meshcat.SetObject(path="/test/cloud", cloud=cloud,
                           point_size=0.01, rgba=mut.Rgba(.5, .5, .5))
+        meshcat.SetLine(path="/test/line", vertices=np.eye(3),
+                        line_width=2.0, rgba=mut.Rgba(.3, .3, .3))
+        meshcat.SetLineSegments(path="/test/line_segments", start=np.eye(3),
+                                end=2*np.eye(3), line_width=2.0,
+                                rgba=mut.Rgba(.3, .3, .3))
         meshcat.SetProperty(path="/Background",
                             property="visible",
                             value=True)

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -135,6 +135,42 @@ class Meshcat {
                  double point_size = 0.001,
                  const Rgba& rgba = Rgba(.9, .9, .9, 1.));
 
+  /** Sets the "object" at `path` in the scene tree to a piecewise-linear
+  interpolation between the `vertices`.
+
+  @param path a "/"-delimited string indicating the path in the scene tree. See
+              @ref meshcat_path "Meshcat paths" for the semantics.
+  @param vertices are the 3D points defining the lines.
+  @param line_width is the width in pixels.  Due to limitations in WebGL
+                    implementations, the line width may be 1 regardless
+                    of the set value.
+  @param rgba is the line color. */
+  void SetLine(std::string_view path,
+               const Eigen::Ref<const Eigen::Matrix3Xd>& vertices,
+               double line_width = 1.0,
+               const Rgba& rgba = Rgba(0.1, 0.1, 0.1, 1.0));
+
+  /** Sets the "object" at `path` in the scene tree to a number of line
+  segments.
+
+  @param path a "/"-delimited string indicating the path in the scene tree. See
+              @ref meshcat_path "Meshcat paths" for the semantics.
+  @param start is a 3-by-N matrix of 3D points defining the start of each
+               segment.
+  @param end is a 3-by-N matrix of 3D points defining the end of each
+             segment.
+  @param line_width is the width in pixels.  Due to limitations in WebGL
+                    implementations, the line width may be 1 regardless
+                    of the set value.
+  @param rgba is the line color.
+
+  @throws std::exception if start.cols != end.cols(). */
+  void SetLineSegments(std::string_view path,
+                       const Eigen::Ref<const Eigen::Matrix3Xd>& start,
+                       const Eigen::Ref<const Eigen::Matrix3Xd>& end,
+                       double line_width = 1.0,
+                       const Rgba& rgba = Rgba(0.1, 0.1, 0.1, 1.0));
+
   // TODO(russt): Provide a more general SetObject(std::string_view path,
   // msgpack::object object) that would allow users to pass through anything
   // that meshcat.js / three.js can handle.  Possible this could use

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -61,6 +61,24 @@ int do_main() {
   cloud.mutable_rgbs() = (255.0 * (m.array() + 1.0) / 2.0).cast<uint8_t>();
   meshcat->SetObject("point_cloud", cloud, 0.01);
   meshcat->SetTransform("point_cloud", RigidTransformd(Vector3d{4, 0, 0}));
+
+  Eigen::Matrix3Xd vertices(3, 200);
+  Eigen::RowVectorXd t = Eigen::RowVectorXd::LinSpaced(200, 0, 10 * M_PI);
+  vertices << .25 * t.array().sin(), .25 * t.array().cos(), t / (10 * M_PI);
+  meshcat->SetLine("line", vertices, 3.0, Rgba(0, 0, 1, 1));
+  meshcat->SetTransform("line", RigidTransformd(Vector3d{5, 0, -.5}));
+
+  Eigen::Matrix3Xd start(3, 4), end(3, 4);
+  // clang-format off
+  start << -.1, -.1,  .1, .1,
+           -.1,  .1, -.1, .1,
+           0, 0, 0, 0;
+  // clang-format on
+  end = start;
+  end.row(2) = Eigen::RowVector4d::Ones();
+  meshcat->SetLineSegments("line_segments", start, end, 5.0, Rgba(0, 1, 0, 1));
+  meshcat->SetTransform("line_segments", RigidTransformd(Vector3d{6, 0, -.5}));
+
   std::cout << R"""(
 Open up your browser to the URL above.
 
@@ -74,6 +92,8 @@ Open up your browser to the URL above.
   - a bright green cube (the green comes from a texture map)
   - a yellow mustard bottle w/ label
   - a dense rainbow point cloud in a box (long axis in z)
+  - a blue line coiling up (in z).
+  - 4 green vertical line segments (in z).
 )""";
   std::cout << "[Press RETURN to continue]." << std::endl;
   std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -139,6 +139,33 @@ GTEST_TEST(MeshcatTest, SetObjectWithPointCloud) {
   EXPECT_FALSE(meshcat.GetPackedObject("rgb_cloud").empty());
 }
 
+GTEST_TEST(MeshcatTest, SetLine) {
+  Meshcat meshcat;
+
+  Eigen::Matrix3Xd vertices(3, 200);
+  Eigen::RowVectorXd t = Eigen::RowVectorXd::LinSpaced(200, 0, 10 * M_PI);
+  vertices << .25 * t.array().sin(), .25 * t.array().cos(), t / (10 * M_PI);
+  meshcat.SetLine("line", vertices, 3.0, Rgba(0, 0, 1, 1));
+  EXPECT_FALSE(meshcat.GetPackedObject("line").empty());
+
+  Eigen::Matrix3Xd start(3, 4), end(3, 4);
+  // clang-format off
+  start << -.1, -.1,  .1, .1,
+           -.1,  .1, -.1, .1,
+           0, 0, 0, 0;
+  // clang-format on
+  end = start;
+  end.row(2) = Eigen::RowVector4d::Ones();
+  meshcat.SetLineSegments("line_segments", start, end, 5.0, Rgba(0, 1, 0, 1));
+  EXPECT_FALSE(meshcat.GetPackedObject("line_segments").empty());
+
+  // Throws if start.cols() != end.cols().
+  EXPECT_THROW(
+      meshcat.SetLineSegments("bad_segments", Eigen::Matrix3Xd::Identity(3, 4),
+                              Eigen::Matrix3Xd::Identity(3, 3)),
+      std::exception);
+}
+
 GTEST_TEST(MeshcatTest, SetTransform) {
   Meshcat meshcat;
   EXPECT_FALSE(meshcat.HasPath("frame"));


### PR DESCRIPTION
Provides the API necessary to push line geometry to meshcat.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16063)
<!-- Reviewable:end -->
