### PR TITLE
[install] Remove LICENSE files from drake-bazel-installed runfiles

### DIFF
--- a/tools/install/bazel/README.md
+++ b/tools/install/bazel/README.md
@@ -1,9 +1,7 @@
 This directory contains logic to support the drake_bazel_installed use case,
-where external users can consume Drake binary releases via Bazel.
-
-The support for this feature is currently under development and experimental.
-In the future, we plan to document it as the "drake_bazel_installed" project
-within https://github.com/RobotLocomotion/drake-external-examples.
+where external users can consume Drake binary releases via Bazel.  Check the
+https://github.com/RobotLocomotion/drake-external-examples example named
+"drake_bazel_installed" for how to use this.
 
 The implementation mechanism is a single repo.bzl file that the user loads into
 their WORKSPACE, which is then able to rehydrate the @drake workspace based on

--- a/tools/install/bazel/generate_installed_files_manifest.bzl
+++ b/tools/install/bazel/generate_installed_files_manifest.bzl
@@ -2,17 +2,24 @@
 # vi: set ft=python :
 
 load("@drake//tools/install:install.bzl", "InstallInfo")
+load("@drake//tools/skylark:pathutils.bzl", "basename")
 load("@python//:version.bzl", "PYTHON_SITE_PACKAGES_RELPATH")
 
 def _impl(ctx):
     known_non_runfiles = [
         # These are installed in share/drake, but are not runfiles (at least,
         # not with these paths).
+        "manipulation/models/iiwa_description/iiwa_stack.LICENSE.txt",
         "setup/Brewfile",
         "setup/install_prereqs",
         "setup/packages-bionic.txt",
         "setup/packages-focal.txt",
         "setup/requirements.txt",
+    ]
+    known_non_runfiles_basenames = [
+        "LICENSE",
+        "LICENSE.TXT",
+        "LICENSE.txt",
     ]
     drake_runfiles = []
     drake_prologue = "share/drake/"
@@ -22,6 +29,8 @@ def _impl(ctx):
         if dest.startswith(drake_prologue):
             relative_path = dest[len(drake_prologue):]
             if relative_path in known_non_runfiles:
+                continue
+            if basename(relative_path) in known_non_runfiles_basenames:
                 continue
             drake_runfiles.append(relative_path)
         elif dest.startswith(lcmtypes_drake_py_prologue):
@@ -36,8 +45,6 @@ def _impl(ctx):
     }
     ctx.actions.write(
         output = ctx.outputs.out,
-        # TODO(jwnimmer-tri) The compact json format makes emacs sad; maybe we
-        # should artisally write it out as python so it is more readable?
         content = "MANIFEST = " + struct(**content).to_json(),
         is_executable = False,
     )


### PR DESCRIPTION
This improves compatibility with 'apt install drake-dev', towards https://github.com/RobotLocomotion/drake-external-examples/issues/209.  In any case, the licenses should not be part of runfiles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16070)
<!-- Reviewable:end -->
