### PR TITLE
Fix building with snopt on "manylinux"

### DIFF
--- a/tools/workspace/snopt/repository.bzl
+++ b/tools/workspace/snopt/repository.bzl
@@ -193,12 +193,18 @@ def _impl(repo_ctx):
         _setup_local_archive(repo_ctx, snopt_path)
 
     # Add in the helper.
-    repo_ctx.symlink(
-        Label("@drake//tools/workspace/snopt:fortran-{}.bzl".format(
-            os_result.distribution,
-        )),
-        "fortran.bzl",
-    )
+    if os_result.is_ubuntu or os_result.is_manylinux:
+        repo_ctx.symlink(
+            Label("@drake//tools/workspace/snopt:fortran-ubuntu.bzl"),
+            "fortran.bzl",
+        )
+    elif os_result.is_macos:
+        repo_ctx.symlink(
+            Label("@drake//tools/workspace/snopt:fortran-macos.bzl"),
+            "fortran.bzl",
+        )
+    else:
+        fail("Operating system is NOT supported {}".format(os_result))
 
     return updated_attrs
 


### PR DESCRIPTION
Modify snopt build logic to enable building on the "manylinux" platform.

Towards #15961.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16076)
<!-- Reviewable:end -->
