### PR TITLE
[meshcat] Add `SetObject(TriangleSurfaceMesh)` and `SetTriangleMesh(...)`

### DIFF
--- a/bindings/pydrake/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry_py_visualizers.cc
@@ -209,6 +209,14 @@ void DoScalarIndependentDefinitions(py::module m) {
                 double, const Rgba&>(&Class::SetObject),
             py::arg("path"), py::arg("cloud"), py::arg("point_size") = 0.001,
             py::arg("rgba") = Rgba(.9, .9, .9, 1.), cls_doc.SetObject.doc_cloud)
+        .def("SetObject",
+            py::overload_cast<std::string_view,
+                const TriangleSurfaceMesh<double>&, const Rgba&, bool, double>(
+                &Class::SetObject),
+            py::arg("path"), py::arg("mesh"),
+            py::arg("rgba") = Rgba(0.1, 0.1, 0.1, 1.0),
+            py::arg("wireframe") = false, py::arg("wireframe_line_width") = 1.0,
+            cls_doc.SetObject.doc_triangle_surface_mesh)
         .def("SetLine", &Class::SetLine, py::arg("path"), py::arg("vertices"),
             py::arg("line_width") = 1.0,
             py::arg("rgba") = Rgba(0.1, 0.1, 0.1, 1.0), cls_doc.SetLine.doc)
@@ -216,6 +224,11 @@ void DoScalarIndependentDefinitions(py::module m) {
             py::arg("start"), py::arg("end"), py::arg("line_width") = 1.0,
             py::arg("rgba") = Rgba(0.1, 0.1, 0.1, 1.0),
             cls_doc.SetLineSegments.doc)
+        .def("SetTriangleMesh", &Class::SetTriangleMesh, py::arg("path"),
+            py::arg("vertices"), py::arg("faces"),
+            py::arg("rgba") = Rgba(0.1, 0.1, 0.1, 1.0),
+            py::arg("wireframe") = false, py::arg("wireframe_line_width") = 1.0,
+            cls_doc.SetTriangleMesh.doc)
         // TODO(russt): Bind SetCamera.
         .def("Set2dRenderMode", &Class::Set2dRenderMode,
             py::arg("X_WC") = RigidTransformd{Eigen::Vector3d{0, -1, 0}},
@@ -244,6 +257,11 @@ void DoScalarIndependentDefinitions(py::module m) {
                 &Class::SetProperty),
             py::arg("path"), py::arg("property"), py::arg("value"),
             cls_doc.SetProperty.doc_double)
+        .def("SetProperty",
+            py::overload_cast<std::string_view, std::string,
+                const std::vector<double>&>(&Class::SetProperty),
+            py::arg("path"), py::arg("property"), py::arg("value"),
+            cls_doc.SetProperty.doc_vector_double)
         .def("SetAnimation", &Class::SetAnimation, py::arg("animation"),
             +cls_doc.SetAnimation.doc)
         .def("AddButton", &Class::AddButton, py::arg("name"),

--- a/bindings/pydrake/test/geometry_visualizers_test.py
+++ b/bindings/pydrake/test/geometry_visualizers_test.py
@@ -103,16 +103,32 @@ class TestGeometryVisualizers(unittest.TestCase):
         cloud.mutable_xyzs()[:] = np.zeros((3, 4))
         meshcat.SetObject(path="/test/cloud", cloud=cloud,
                           point_size=0.01, rgba=mut.Rgba(.5, .5, .5))
+        mesh = mut.TriangleSurfaceMesh(
+            triangles=[mut.SurfaceTriangle(
+                0, 1, 2), mut.SurfaceTriangle(3, 0, 2)],
+            vertices=[[0, 0, 0], [1, 0, 0], [1, 0, 1], [0, 0, 1]])
+        meshcat.SetObject(path="/test/triangle_surface_mesh", mesh=mesh,
+                          rgba=mut.Rgba(0.3, 0.3, 0.3), wireframe=True,
+                          wireframe_line_width=2.0)
         meshcat.SetLine(path="/test/line", vertices=np.eye(3),
                         line_width=2.0, rgba=mut.Rgba(.3, .3, .3))
         meshcat.SetLineSegments(path="/test/line_segments", start=np.eye(3),
                                 end=2*np.eye(3), line_width=2.0,
                                 rgba=mut.Rgba(.3, .3, .3))
+        meshcat.SetTriangleMesh(
+            path="/test/triangle_mesh",
+            vertices=np.array([[0, 0, 0], [1, 0, 0], [1, 0, 1], [0, 0, 1]]).T,
+            faces=np.array([[0, 1, 2], [3, 0, 2]]).T,
+            rgba=mut.Rgba(0.3, 0.3, 0.3),
+            wireframe=True,
+            wireframe_line_width=2.0)
         meshcat.SetProperty(path="/Background",
                             property="visible",
                             value=True)
         meshcat.SetProperty(path="/Lights/DirectionalLight/<object>",
                             property="intensity", value=1.0)
+        meshcat.SetProperty(path="/Background", property="top_color",
+                            value=[0, 0, 0])
         meshcat.Set2dRenderMode(
             X_WC=RigidTransform(), xmin=-1, xmax=1, ymin=-1, ymax=1)
         meshcat.ResetRenderMode()

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -411,6 +411,7 @@ drake_cc_library(
         "//common:essential",
         "//common:find_resource",
         "//common:unused",
+        "//geometry/proximity:triangle_surface_mesh",
         "//math:geometric_transform",
         "//perception:point_cloud",
         "@common_robotics_utilities",

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -454,8 +454,6 @@ int ToMeshcatColor(const Rgba& rgba) {
          static_cast<int>(255 * rgba.b());
 }
 
-
-
 }  // namespace
 
 class Meshcat::WebSocketPublisher {

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -81,6 +81,18 @@ using MsgPackMap = std::map<std::string, msgpack::object>;
 // reasonable meshfiles.
 constexpr static double kMaxBackPressure{50 * 1024 * 1024};
 
+void CheckBackPressure(const std::string& path, const std::string& message) {
+  if (message.size() > kMaxBackPressure) {
+    drake::log()->warn(
+        "The message describing the object at {} is too large for the "
+        "current websocket setup (size {} is greater than the max "
+        "backpressure {}).  You will either need to reduce the size of "
+        "your object/mesh/textures, or modify the code to increase the "
+        "allowance.",
+        path, message.size(), kMaxBackPressure);
+  }
+}
+
 class SceneTreeElement {
  public:
   // Member access methods (object_, transform_, and properties_ should be
@@ -442,6 +454,8 @@ int ToMeshcatColor(const Rgba& rgba) {
          static_cast<int>(255 * rgba.b());
 }
 
+
+
 }  // namespace
 
 class Meshcat::WebSocketPublisher {
@@ -545,15 +559,7 @@ class Meshcat::WebSocketPublisher {
       // (here and throughout) to avoid this copy.
       // https://github.com/redboltz/msgpack-c/wiki/v2_0_cpp_packer
       std::string message = message_stream.str();
-      if (message.size() > kMaxBackPressure) {
-        drake::log()->warn(
-            "The message describing the object at {} is too large for the "
-            "current websocket setup (size {} is greater than the max "
-            "backpressure {}).  You will either need to reduce the size of "
-            "your object/mesh/textures, or modify the code to increase the "
-            "allowance.",
-            data.path, message.size(), kMaxBackPressure);
-      }
+      CheckBackPressure(data.path, message);
       app_->publish("all", message, uWS::OpCode::BINARY, false);
       SceneTreeElement& e = scene_tree_root_[data.path];
       e.object() = std::move(message);
@@ -581,6 +587,8 @@ class Meshcat::WebSocketPublisher {
     material->uuid = uuids::to_string(uuid_generator());
     material->type = "PointsMaterial";
     material->color = ToMeshcatColor(rgba);
+    material->transparent = (rgba.a() != 1.0);
+    material->opacity = rgba.a();
     material->size = point_size;
     material->vertexColors = cloud.has_rgbs();
     data.object.material = std::move(material);
@@ -596,15 +604,7 @@ class Meshcat::WebSocketPublisher {
       std::stringstream message_stream;
       msgpack::pack(message_stream, data);
       std::string message = message_stream.str();
-      if (message.size() > kMaxBackPressure) {
-        drake::log()->warn(
-            "The message describing the object at {} is too large for the "
-            "current websocket setup (size {} is greater than the max "
-            "backpressure {}).  You will either need to reduce the size of "
-            "your object/mesh/textures, or modify the code to increase the "
-            "allowance.",
-            data.path, message.size(), kMaxBackPressure);
-      }
+      CheckBackPressure(data.path, message);
       app_->publish("all", message, uWS::OpCode::BINARY, false);
       SceneTreeElement& e = scene_tree_root_[data.path];
       e.object() = std::move(message);
@@ -645,15 +645,54 @@ class Meshcat::WebSocketPublisher {
       std::stringstream message_stream;
       msgpack::pack(message_stream, data);
       std::string message = message_stream.str();
-      if (message.size() > kMaxBackPressure) {
-        drake::log()->warn(
-            "The message describing the object at {} is too large for the "
-            "current websocket setup (size {} is greater than the max "
-            "backpressure {}).  You will either need to reduce the size of "
-            "your object/mesh/textures, or modify the code to increase the "
-            "allowance.",
-            data.path, message.size(), kMaxBackPressure);
-      }
+      CheckBackPressure(data.path, message);
+      app_->publish("all", message, uWS::OpCode::BINARY, false);
+      SceneTreeElement& e = scene_tree_root_[data.path];
+      e.object() = std::move(message);
+    });
+  }
+
+  void SetTriangleMesh(std::string_view path,
+                       const Eigen::Ref<const Eigen::Matrix3Xd>& vertices,
+                       const Eigen::Ref<const Eigen::Matrix3Xi>& faces,
+                       const Rgba& rgba, bool wireframe,
+                       double wireframe_line_width) {
+    DRAKE_DEMAND(std::this_thread::get_id() == main_thread_id_);
+    DRAKE_DEMAND(loop_ != nullptr);
+
+    uuids::uuid_random_generator uuid_generator{generator_};
+    internal::SetObjectData data;
+    data.path = FullPath(path);
+
+    auto geometry = std::make_unique<internal::BufferGeometryData>();
+    geometry->uuid = uuids::to_string(uuid_generator());
+    geometry->position = vertices.cast<float>();
+    geometry->faces = faces.cast<uint32_t>();
+    data.object.geometry = std::move(geometry);
+
+    auto material = std::make_unique<internal::MaterialData>();
+    material->uuid = uuids::to_string(uuid_generator());
+    material->type = "MeshPhongMaterial";
+    material->color = ToMeshcatColor(rgba);
+    material->transparent = (rgba.a() != 1.0);
+    material->opacity = rgba.a();
+    material->wireframe = wireframe;
+    material->wireframeLineWidth = wireframe_line_width;
+    material->vertexColors = false;
+    data.object.material = std::move(material);
+
+    internal::MeshData mesh;
+    mesh.uuid = uuids::to_string(uuid_generator());
+    mesh.type = "Mesh";
+    mesh.geometry = data.object.geometry->uuid;
+    mesh.material = data.object.material->uuid;
+    data.object.object = std::move(mesh);
+
+    loop_->defer([this, data = std::move(data)]() {
+      std::stringstream message_stream;
+      msgpack::pack(message_stream, data);
+      std::string message = message_stream.str();
+      CheckBackPressure(data.path, message);
       app_->publish("all", message, uWS::OpCode::BINARY, false);
       SceneTreeElement& e = scene_tree_root_[data.path];
       e.object() = std::move(message);
@@ -1311,6 +1350,25 @@ void Meshcat::SetObject(std::string_view path,
   publisher_->SetObject(path, cloud, point_size, rgba);
 }
 
+void Meshcat::SetObject(std::string_view path,
+                        const TriangleSurfaceMesh<double>& mesh,
+                        const Rgba& rgba, bool wireframe,
+                        double wireframe_line_width) {
+  Eigen::Matrix3Xd vertices(3, mesh.num_vertices());
+  for (int i = 0; i < mesh.num_vertices(); ++i) {
+    vertices.col(i) = mesh.vertex(i);
+  }
+  Eigen::Matrix3Xi faces(3, mesh.num_triangles());
+  for (int i = 0; i < mesh.num_triangles(); ++i) {
+    const auto& e = mesh.element(i);
+    for (int j = 0; j < 3; ++j) {
+      faces(j, i) = e.vertex(j);
+    }
+  }
+  publisher_->SetTriangleMesh(path, vertices, faces, rgba, wireframe,
+                              wireframe_line_width);
+}
+
 void Meshcat::SetLine(std::string_view path,
                       const Eigen::Ref<const Eigen::Matrix3Xd>& vertices,
                       double line_width, const Rgba& rgba) {
@@ -1330,6 +1388,14 @@ void Meshcat::SetLineSegments(std::string_view path,
   Eigen::Map<Eigen::Matrix3Xd> vertices(vstack.data(), 3, 2*start.cols());
   const bool kLineSegments = true;
   publisher_->SetLine(path, vertices, line_width, rgba, kLineSegments);
+}
+
+void Meshcat::SetTriangleMesh(
+    std::string_view path, const Eigen::Ref<const Eigen::Matrix3Xd>& vertices,
+    const Eigen::Ref<const Eigen::Matrix3Xi>& faces, const Rgba& rgba,
+    bool wireframe, double wireframe_line_width) {
+  publisher_->SetTriangleMesh(path, vertices, faces, rgba, wireframe,
+                              wireframe_line_width);
 }
 
 void Meshcat::SetCamera(PerspectiveCamera camera, std::string path) {

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -9,6 +9,7 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/geometry/meshcat_animation.h"
+#include "drake/geometry/proximity/triangle_surface_mesh.h"
 #include "drake/geometry/rgba.h"
 #include "drake/geometry/shape_specification.h"
 #include "drake/math/rigid_transform.h"
@@ -135,6 +136,23 @@ class Meshcat {
                  double point_size = 0.001,
                  const Rgba& rgba = Rgba(.9, .9, .9, 1.));
 
+  /** Sets the "object" at `path` in the scene tree to a TriangleSurfaceMesh.
+
+  @param path a "/"-delimited string indicating the path in the scene tree. See
+              @ref meshcat_path "Meshcat paths" for the semantics.
+  @param mesh is a TriangleSurfaceMesh object.
+  @param rgba is the mesh face or wireframe color.
+  @param wireframe if "true", then only the triangle edges are visualized, not
+                   the faces.
+  @param wireframe_line_width is the width in pixels.  Due to limitations in
+                              WebGL implementations, the line width may be 1
+                              regardless of the set value.
+  @pydrake_mkdoc_identifier{triangle_surface_mesh}
+  */
+  void SetObject(std::string_view path, const TriangleSurfaceMesh<double>& mesh,
+                 const Rgba& rgba = Rgba(0.1, 0.1, 0.1, 1.0),
+                 bool wireframe = false, double wireframe_line_width = 1.0);
+
   /** Sets the "object" at `path` in the scene tree to a piecewise-linear
   interpolation between the `vertices`.
 
@@ -170,6 +188,29 @@ class Meshcat {
                        const Eigen::Ref<const Eigen::Matrix3Xd>& end,
                        double line_width = 1.0,
                        const Rgba& rgba = Rgba(0.1, 0.1, 0.1, 1.0));
+
+  // TODO(russt): Support per-vertex coloring (maybe rgba as std::variant).
+  /** Sets the "object" at `path` in the scene tree to a triangular mesh.
+
+  @param path a "/"-delimited string indicating the path in the scene tree. See
+              @ref meshcat_path "Meshcat paths" for the semantics.
+  @param vertices is a 3-by-N matrix of 3D point defining the vertices of the
+                  mesh.
+  @param faces is a 3-by-N integer matrix with each entry denoting an index
+               into vertices and each column denoting one face (aka
+               SurfaceTriangle).
+  @param rgba is the mesh face or wireframe color.
+  @param wireframe if "true", then only the triangle edges are visualized, not
+                   the faces.
+  @param wireframe_line_width is the width in pixels.  Due to limitations in
+                              WebGL implementations, the line width may be 1
+                              regardless of the set value. */
+  void SetTriangleMesh(std::string_view path,
+                       const Eigen::Ref<const Eigen::Matrix3Xd>& vertices,
+                       const Eigen::Ref<const Eigen::Matrix3Xi>& faces,
+                       const Rgba& rgba = Rgba(0.1, 0.1, 0.1, 1.0),
+                       bool wireframe = false,
+                       double wireframe_line_width = 1.0);
 
   // TODO(russt): Provide a more general SetObject(std::string_view path,
   // msgpack::object object) that would allow users to pass through anything
@@ -297,7 +338,7 @@ class Meshcat {
 
   /** Sets a single named property of the object at the given path. For example,
   @verbatim
-  meshcat.SetProperty("box", "position", [1.0, 0.0, 0.0]);
+  meshcat.SetProperty("/Background", "top_color", {1.0, 0.0, 0.0});
   @endverbatim
   See @ref meshcat_path "Meshcat paths" for more details about these properties
   and how to address them.

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -53,31 +53,60 @@ int do_main() {
                                "006_mustard_bottle_textured.obj"), 3.0));
   meshcat->SetTransform("mustard", RigidTransformd(Vector3d{3, 0, 0}));
 
-  const int kPoints = 100000;
-  perception::PointCloud cloud(
-      kPoints, perception::pc_flags::kXYZs | perception::pc_flags::kRGBs);
-  Eigen::Matrix3Xf m = Eigen::Matrix3Xf::Random(3, kPoints);
-  cloud.mutable_xyzs() = Eigen::DiagonalMatrix<float, 3>{.25, .25, .5} * m;
-  cloud.mutable_rgbs() = (255.0 * (m.array() + 1.0) / 2.0).cast<uint8_t>();
-  meshcat->SetObject("point_cloud", cloud, 0.01);
-  meshcat->SetTransform("point_cloud", RigidTransformd(Vector3d{4, 0, 0}));
+  {
+    const int kPoints = 100000;
+    perception::PointCloud cloud(
+        kPoints, perception::pc_flags::kXYZs | perception::pc_flags::kRGBs);
+    Eigen::Matrix3Xf m = Eigen::Matrix3Xf::Random(3, kPoints);
+    cloud.mutable_xyzs() = Eigen::DiagonalMatrix<float, 3>{.25, .25, .5} * m;
+    cloud.mutable_rgbs() = (255.0 * (m.array() + 1.0) / 2.0).cast<uint8_t>();
+    meshcat->SetObject("point_cloud", cloud, 0.01);
+    meshcat->SetTransform("point_cloud", RigidTransformd(Vector3d{4, 0, 0}));
+  }
 
-  Eigen::Matrix3Xd vertices(3, 200);
-  Eigen::RowVectorXd t = Eigen::RowVectorXd::LinSpaced(200, 0, 10 * M_PI);
-  vertices << .25 * t.array().sin(), .25 * t.array().cos(), t / (10 * M_PI);
-  meshcat->SetLine("line", vertices, 3.0, Rgba(0, 0, 1, 1));
-  meshcat->SetTransform("line", RigidTransformd(Vector3d{5, 0, -.5}));
+  {
+    Eigen::Matrix3Xd vertices(3, 200);
+    Eigen::RowVectorXd t = Eigen::RowVectorXd::LinSpaced(200, 0, 10 * M_PI);
+    vertices << .25 * t.array().sin(), .25 * t.array().cos(), t / (10 * M_PI);
+    meshcat->SetLine("line", vertices, 3.0, Rgba(0, 0, 1, 1));
+    meshcat->SetTransform("line", RigidTransformd(Vector3d{5, 0, -.5}));
+  }
 
-  Eigen::Matrix3Xd start(3, 4), end(3, 4);
-  // clang-format off
-  start << -.1, -.1,  .1, .1,
-           -.1,  .1, -.1, .1,
-           0, 0, 0, 0;
-  // clang-format on
-  end = start;
-  end.row(2) = Eigen::RowVector4d::Ones();
-  meshcat->SetLineSegments("line_segments", start, end, 5.0, Rgba(0, 1, 0, 1));
-  meshcat->SetTransform("line_segments", RigidTransformd(Vector3d{6, 0, -.5}));
+  {
+    Eigen::Matrix3Xd start(3, 4), end(3, 4);
+    // clang-format off
+    start << -.1, -.1,  .1, .1,
+            -.1,  .1, -.1, .1,
+            0, 0, 0, 0;
+    // clang-format on
+    end = start;
+    end.row(2) = Eigen::RowVector4d::Ones();
+    meshcat->SetLineSegments("line_segments", start, end, 5.0,
+                             Rgba(0, 1, 0, 1));
+    meshcat->SetTransform("line_segments",
+                          RigidTransformd(Vector3d{6, 0, -.5}));
+  }
+
+  // The TriangleSurfaceMesh variant of SetObject calls SetTriangleMesh(), so
+  // visually inspecting the results of TriangleSurfaceMesh is sufficient here.
+  {
+    const int face_data[2][3] = {{0, 1, 2}, {2, 3, 0}};
+    std::vector<SurfaceTriangle> faces;
+    for (int f = 0; f < 2; ++f) faces.emplace_back(face_data[f]);
+    const Eigen::Vector3d vertex_data[4] = {
+        {0, 0, 0}, {0.5, 0, 0}, {0.5, 0.5, 0}, {0, 0.5, 0.5}};
+    std::vector<Eigen::Vector3d> vertices;
+    for (int v = 0; v < 4; ++v) vertices.emplace_back(vertex_data[v]);
+    TriangleSurfaceMesh<double> surface_mesh(move(faces), std::move(vertices));
+    meshcat->SetObject("triangle_mesh", surface_mesh, Rgba(.9, 0, .9, 1.0));
+    meshcat->SetTransform("triangle_mesh",
+                          RigidTransformd(Vector3d{6.75, -.25, 0}));
+
+    meshcat->SetObject("triangle_mesh_wireframe", surface_mesh,
+                       Rgba(.9, 0, .9, 1.0), true, 5.0);
+    meshcat->SetTransform("triangle_mesh_wireframe",
+                          RigidTransformd(Vector3d{7.75, -.25, 0}));
+  }
 
   std::cout << R"""(
 Open up your browser to the URL above.
@@ -94,6 +123,8 @@ Open up your browser to the URL above.
   - a dense rainbow point cloud in a box (long axis in z)
   - a blue line coiling up (in z).
   - 4 green vertical line segments (in z).
+  - a purple triangle mesh with 2 faces.
+  - the same purple triangle mesh drawn as a wireframe.
 )""";
   std::cout << "[Press RETURN to continue]." << std::endl;
   std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -97,7 +97,8 @@ int do_main() {
         {0, 0, 0}, {0.5, 0, 0}, {0.5, 0.5, 0}, {0, 0.5, 0.5}};
     std::vector<Eigen::Vector3d> vertices;
     for (int v = 0; v < 4; ++v) vertices.emplace_back(vertex_data[v]);
-    TriangleSurfaceMesh<double> surface_mesh(move(faces), std::move(vertices));
+    TriangleSurfaceMesh<double> surface_mesh(
+        std::move(faces), std::move(vertices));
     meshcat->SetObject("triangle_mesh", surface_mesh, Rgba(.9, 0, .9, 1.0));
     meshcat->SetTransform("triangle_mesh",
                           RigidTransformd(Vector3d{6.75, -.25, 0}));

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -150,7 +150,7 @@ GTEST_TEST(MeshcatTest, SetObjectWithTriangleSurfaceMesh) {
   std::vector<Eigen::Vector3d> vertices;
   for (int v = 0; v < 4; ++v) vertices.emplace_back(vertex_data[v]);
   TriangleSurfaceMesh<double> surface_mesh(
-    std::move(faces), std::move(vertices));
+      std::move(faces), std::move(vertices));
   meshcat.SetObject("triangle_mesh", surface_mesh, Rgba(.9, 0, .9, 1.0));
   EXPECT_FALSE(meshcat.GetPackedObject("triangle_mesh").empty());
 

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -139,6 +139,25 @@ GTEST_TEST(MeshcatTest, SetObjectWithPointCloud) {
   EXPECT_FALSE(meshcat.GetPackedObject("rgb_cloud").empty());
 }
 
+GTEST_TEST(MeshcatTest, SetObjectWithTriangleSurfaceMesh) {
+  Meshcat meshcat;
+
+  const int face_data[2][3] = {{0, 1, 2}, {2, 3, 0}};
+  std::vector<SurfaceTriangle> faces;
+  for (int f = 0; f < 2; ++f) faces.emplace_back(face_data[f]);
+  const Eigen::Vector3d vertex_data[4] = {
+      {0, 0, 0}, {0.5, 0, 0}, {0.5, 0.5, 0}, {0, 0.5, 0.5}};
+  std::vector<Eigen::Vector3d> vertices;
+  for (int v = 0; v < 4; ++v) vertices.emplace_back(vertex_data[v]);
+  TriangleSurfaceMesh<double> surface_mesh(move(faces), std::move(vertices));
+  meshcat.SetObject("triangle_mesh", surface_mesh, Rgba(.9, 0, .9, 1.0));
+  EXPECT_FALSE(meshcat.GetPackedObject("triangle_mesh").empty());
+
+  meshcat.SetObject("triangle_mesh_wireframe", surface_mesh,
+                     Rgba(.9, 0, .9, 1.0), true, 5.0);
+  EXPECT_FALSE(meshcat.GetPackedObject("triangle_mesh_wireframe").empty());
+}
+
 GTEST_TEST(MeshcatTest, SetLine) {
   Meshcat meshcat;
 
@@ -164,6 +183,26 @@ GTEST_TEST(MeshcatTest, SetLine) {
       meshcat.SetLineSegments("bad_segments", Eigen::Matrix3Xd::Identity(3, 4),
                               Eigen::Matrix3Xd::Identity(3, 3)),
       std::exception);
+}
+
+GTEST_TEST(MeshcatTest, SetTriangleMesh) {
+  Meshcat meshcat;
+
+  // Populate the vertices/faces transposed, for easier Eigen initialization.
+  Eigen::MatrixXd vertices(4, 3);
+  Eigen::MatrixXi faces(2, 3);
+  // clang-format off
+  vertices << 0, 0, 0,
+              1, 0, 0,
+              1, 0, 1,
+              0, 0, 1;
+  faces << 0, 1, 2,
+           3, 0, 2;
+  // clang-format on
+
+  meshcat.SetTriangleMesh("triangle_mesh", vertices.transpose(),
+                         faces.transpose(), Rgba(1, 0, 0, 1), true, 5.0);
+  EXPECT_FALSE(meshcat.GetPackedObject("triangle_mesh").empty());
 }
 
 GTEST_TEST(MeshcatTest, SetTransform) {

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -149,12 +149,13 @@ GTEST_TEST(MeshcatTest, SetObjectWithTriangleSurfaceMesh) {
       {0, 0, 0}, {0.5, 0, 0}, {0.5, 0.5, 0}, {0, 0.5, 0.5}};
   std::vector<Eigen::Vector3d> vertices;
   for (int v = 0; v < 4; ++v) vertices.emplace_back(vertex_data[v]);
-  TriangleSurfaceMesh<double> surface_mesh(move(faces), std::move(vertices));
+  TriangleSurfaceMesh<double> surface_mesh(
+    std::move(faces), std::move(vertices));
   meshcat.SetObject("triangle_mesh", surface_mesh, Rgba(.9, 0, .9, 1.0));
   EXPECT_FALSE(meshcat.GetPackedObject("triangle_mesh").empty());
 
   meshcat.SetObject("triangle_mesh_wireframe", surface_mesh,
-                     Rgba(.9, 0, .9, 1.0), true, 5.0);
+                    Rgba(.9, 0, .9, 1.0), true, 5.0);
   EXPECT_FALSE(meshcat.GetPackedObject("triangle_mesh_wireframe").empty());
 }
 


### PR DESCRIPTION
Adds support for sending triangle meshes directly to Meshcat
(e.g. without having to write them to an .obj file on disk).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16077)
<!-- Reviewable:end -->
