### PR TITLE
Build current checkout, not a fresh clone

### DIFF
--- a/tools/wheel/dev/Dockerfile
+++ b/tools/wheel/dev/Dockerfile
@@ -41,11 +41,13 @@ RUN /image/build-vtk.sh
 
 FROM incubator
 
-ENV REPO=https://api.github.com/repos/robotlocomotion/drake
+ARG REPO=https://github.com/RobotLocomotion/drake
+ARG REPO_ARCHIVE=${REPO}/archive/refs/heads/master.tar.gz
 
 ADD image/build-drake.sh /image/
 ADD image/pip-drake.patch /image/
-ADD ${REPO}/git/refs/heads/master /tmp/drake.sha
+
+ADD ${REPO_ARCHIVE} /drake/
 
 RUN --mount=type=ssh \
     /image/build-drake.sh

--- a/tools/wheel/dev/image/build-drake.sh
+++ b/tools/wheel/dev/image/build-drake.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-cd /
-
-git clone https://github.com/RobotLocomotion/drake
-
 cd /drake
+
+if [ $(ls | wc -l) -eq 1 ] && [ -f *.tar.gz ]; then
+    tar --strip-components=1 -xf *.tar.gz
+fi
 
 git apply < /image/pip-drake.patch
 

--- a/tools/wheel/dev/test/test-wheels.sh
+++ b/tools/wheel/dev/test/test-wheels.sh
@@ -6,11 +6,12 @@
 
 set -e
 
-wheel_version="$1"
-wheel_dir="$(readlink -f "${2:-$PWD}")"
-test_root="$(readlink -f "$(dirname "${BASH_SOURCE}")")"
-
 ###############################################################################
+
+canonicalize()
+{
+    perl -e 'use Cwd;print Cwd::abs_path(shift) . "\n";' -- "$@"
+}
 
 test_wheel()
 {
@@ -32,6 +33,10 @@ test_wheel()
 }
 
 ###############################################################################
+
+wheel_version="$1"
+wheel_dir="$(canonicalize "${2:-$PWD}")"
+test_root="$(canonicalize "$(dirname "${BASH_SOURCE}")")"
 
 if [ -z "$wheel_version" ]; then
     echo "Usage: $0 <version> [<path to wheels>]" >&2


### PR DESCRIPTION
Modify build script to create an archive of the current repository checkout, and to use this rather than cloning the latest master. This will make some testing easier, as well as enable CI to build wheels against pull requests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16088)
<!-- Reviewable:end -->
