### PR TITLE
[pydrake] Port values borrowed from a Context keep the Context alive

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -450,6 +450,16 @@ drake_py_unittest(
     ],
 )
 
+drake_jupyter_py_binary(
+    name = "test/lifetime_test_notebook",
+    testonly = True,
+    add_test_rule = 1,
+    deps = [
+        ":framework_py",
+        ":primitives_py",
+    ],
+)
+
 drake_py_unittest(
     name = "custom_test",
     deps = [

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -41,8 +41,16 @@ py::object DoEval(const SomeObject* self, const systems::Context<T>& context) {
     }
     case systems::kAbstractValued: {
       const auto& abstract = self->template Eval<AbstractValue>(context);
-      py::object value_ref = py::cast(&abstract);
-      return value_ref.attr("get_value")();
+      // The storage for the abstract value is owned by the context, so we need
+      // to inform pybind that the abstract value reference should keep the
+      // entire context alive.  Note that `abstract_value_ref` itself will be
+      // immediately released (it's a local variable, and we don't return it)
+      // but in certain cases the return from `get_value` is an internal
+      // reference into the `abstract_value_ref`, and so will need to
+      // transitively keep the entire context alive as well.
+      py::object abstract_value_ref =
+          py::cast(&abstract, py_rvp::reference_internal, py::cast(&context));
+      return abstract_value_ref.attr("get_value")();
     }
   }
   DRAKE_UNREACHABLE();

--- a/bindings/pydrake/systems/test/lifetime_test_notebook.ipynb
+++ b/bindings/pydrake/systems/test/lifetime_test_notebook.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydrake.common.value import AbstractValue\n",
+    "from pydrake.math import RigidTransform\n",
+    "from pydrake.systems.primitives import ConstantValueSource\n",
+    "\n",
+    "def _create_context_value_reference():\n",
+    "    \"\"\"Returns a reference to a C++ object whose storage comes from inside a Context.\n",
+    "    The return value should keep the entire (otherwise-unused) context alive.\n",
+    "    \"\"\"\n",
+    "    system = ConstantValueSource(AbstractValue.Make(RigidTransform()))\n",
+    "    context = system.CreateDefaultContext()\n",
+    "    return system.get_output_port().Eval(context)\n",
+    "\n",
+    "# Check that the object still retains its correct value.\n",
+    "X = _create_context_value_reference()\n",
+    "print(X)\n",
+    "assert X.IsExactlyIdentity()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Re-check that the object still retains its correct value.\n",
+    "print(X)\n",
+    "assert X.IsExactlyIdentity()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
In a Jupyter notebook, if a helper function creates a local context and then returns a value computed by an abstract-valued output port evaluated against that context, and if the return value is a C++ class type that is bound in pydrake, and if the function does not retain or return the context itself such that the context is garbage collected, then the storage that backs the return value would be erroneously deleted at the conclusion of the cell, thus leaving the return value pointing at garbage memory.

This commit adds a reference_internal annotation on the value into the context, so that the context will not be destroyed in this case.

There does not seem to be any way to trigger these conditions outside of a Jupyter notebook, so the regression test here takes the form of an ipynb file.

Closes #15973.

Hopefully does not run afoul of #11046.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16095)
<!-- Reviewable:end -->
