### PR TITLE
[ibex] Use --no-same-owner when untarring

### DIFF
--- a/tools/workspace/ibex/package.BUILD.bazel
+++ b/tools/workspace/ibex/package.BUILD.bazel
@@ -183,7 +183,7 @@ genrule(
         "interval_lib_wrapper/filib/3rd/filibsrc-3.0.2.2.all.all.patch",
     ],
     outs = _FILIB_FILES,
-    cmd = "tar -xzf $(location interval_lib_wrapper/filib/3rd/filibsrc-3.0.2.2.tar.gz) -C $(@D) && patch --quiet -p1 -d $(@D) <$(location interval_lib_wrapper/filib/3rd/filibsrc-3.0.2.2.all.all.patch)",  # noqa
+    cmd = "tar --no-same-owner -xzf $(location interval_lib_wrapper/filib/3rd/filibsrc-3.0.2.2.tar.gz) -C $(@D) && patch --quiet -p1 -d $(@D) <$(location interval_lib_wrapper/filib/3rd/filibsrc-3.0.2.2.all.all.patch)",  # noqa
 )
 
 # Excerpt from the Filib CMakeLists.txt (contained in the .tar.gz file):


### PR DESCRIPTION
When running as root, we should keep the workspace files owned by root.

Towards #16107.  (No closing yet, because we might want to add CI testing for this.)

See also [#build slack discussion](https://app.slack.com/client/T0JNB2DS4/C0KDGF4V9/thread/C0KDGF4V9-1637077937.035000) for evidence of local testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16108)
<!-- Reviewable:end -->
