### PR TITLE
[hydro] Adds the PolygonSurfaceMesh

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -47,6 +47,7 @@ drake_cc_package_library(
         ":obj_to_surface_mesh",
         ":penetration_as_point_pair_callback",
         ":plane",
+        ":polygon_surface_mesh",
         ":posed_half_space",
         ":proximity_utilities",
         ":sorted_triplet",
@@ -597,6 +598,16 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "polygon_surface_mesh",
+    srcs = ["polygon_surface_mesh.cc"],
+    hdrs = ["polygon_surface_mesh.h"],
+    deps = [
+        ":mesh_traits",
+        "//math:geometric_transform",
+    ],
+)
+
+drake_cc_library(
     name = "tessellation_strategy",
     hdrs = ["tessellation_strategy.h"],
 )
@@ -1027,6 +1038,15 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//math:autodiff",
+    ],
+)
+
+drake_cc_googletest(
+    name = "polygon_surface_mesh_test",
+    deps = [
+        ":polygon_surface_mesh",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/geometry/proximity/polygon_surface_mesh.cc
+++ b/geometry/proximity/polygon_surface_mesh.cc
@@ -1,0 +1,167 @@
+#include "drake/geometry/proximity/polygon_surface_mesh.h"
+
+#include <limits>
+
+namespace drake {
+namespace geometry {
+
+using math::RigidTransform;
+using std::move;
+using std::vector;
+
+template <typename T>
+PolygonSurfaceMesh<T>::PolygonSurfaceMesh(vector<int> face_data,
+                                          vector<Vector3<T>> vertices)
+    : face_data_(move(face_data)),
+      vertices_M_(move(vertices)),
+      p_MSc_(Vector3<T>::Zero()) {
+  /* Build the polygons and derived quantities from the given data. */
+  int poly_count = -1;
+  int i = 0;
+  while (i < static_cast<int>(face_data_.size())) {
+    poly_indices_.push_back(i);
+    CalcAreaNormalAndCentroid(++poly_count);
+    i += face_data_[i] + 1;  /* Jump to the next polygon. */
+  }
+  DRAKE_DEMAND(poly_indices_.size() == areas_.size());
+  DRAKE_DEMAND(poly_indices_.size() == face_normals_.size());
+}
+
+template <typename T>
+void PolygonSurfaceMesh<T>::TransformVertices(const RigidTransform<T>& X_NM) {
+  for (auto& v : vertices_M_) {
+    v = X_NM * v;
+  }
+  for (auto& n : face_normals_) {
+    n = (X_NM.rotation() * n).normalized();
+  }
+  for (auto& c : element_centroid_M_) {
+    c = X_NM * c;
+  }
+  p_MSc_ = X_NM * p_MSc_;
+}
+
+template <typename T>
+std::pair<Vector3<T>, Vector3<T>> PolygonSurfaceMesh<T>::CalcBoundingBox()
+    const {
+  Vector3<T> min_extent =
+      Vector3<T>::Constant(std::numeric_limits<double>::max());
+  Vector3<T> max_extent =
+      Vector3<T>::Constant(std::numeric_limits<double>::lowest());
+  for (const auto& vertex : vertices_M_) {
+    min_extent = min_extent.cwiseMin(vertex);
+    max_extent = max_extent.cwiseMax(vertex);
+  }
+  Vector3<T> center = (max_extent + min_extent) / 2.0;
+  Vector3<T> size = max_extent - min_extent;
+  return std::make_pair(center, size);
+}
+
+template <typename T>
+bool PolygonSurfaceMesh<T>::Equal(const PolygonSurfaceMesh<T>& mesh) const {
+  if (this == &mesh) return true;
+
+  if (this->num_faces() != mesh.num_faces()) return false;
+  if (this->num_vertices() != mesh.num_vertices()) return false;
+  if (this->vertices_M_ != mesh.vertices_M_) return false;
+  if (this->poly_indices_ != mesh.poly_indices_) return false;
+  if (this->face_data_ != mesh.face_data_) return false;
+
+  return true;
+}
+
+template <class T>
+void PolygonSurfaceMesh<T>::CalcAreaNormalAndCentroid(int poly_index) {
+  int data_index = poly_indices_[poly_index];
+  const int v_count = face_data_[data_index];
+  int v_index_offset = data_index + 1;
+  const Vector3<T>& r_MA = vertices_M_[face_data_[v_index_offset]];
+
+  Vector3<T> p_MTc_scaled(0, 0, 0);
+
+  Vector3<T> normal_M{0, 0, 0};
+  Vector3<T> cross;
+  T cross_magnitude{};
+  T double_poly_area(0);
+
+  // TODO(SeanCurtis-TRI): We could reduce square roots by computing the normal
+  //  from the first triangle and use that to facilitate area calculations for
+  //  subsequent triangles. This *kind* of would allow this algorithm to work
+  //  with non-convex polygons. However, where it fails is if the first triangle
+  //  has locally reversed winding. The normal direction would not be as
+  //  expected. The best solution is to pass in normals upon construction (we
+  //  have them in computing a contact surface) and use those normals to compute
+  //  area.
+
+  /* Compute the polygon *total* area and centroid (Tc) by decomposing it into a
+   set of triangles. The triangles are defined as a triangle fan around vertex
+   0. We use the normal of the last triangle in the fan as the face normal; this
+   only works because of the requirement that the polygons be strictly planar
+   and convex.
+
+   For efficiency, we actually accumulate 2 * area in double_face_area and
+   6 * p_MTc in p_MTc_scaled to defer otherwise redundant scaling operations. */
+  for (int v = 1; v < v_count - 1; ++v) {
+    const Vector3<T>& r_MB = vertices_M_[face_data_[v_index_offset + v]];
+    const Vector3<T>& r_MC = vertices_M_[face_data_[v_index_offset + v + 1]];
+    const auto r_UV_M = r_MB - r_MA;
+    const auto r_UW_M = r_MC - r_MA;
+
+    cross = r_UV_M.cross(r_UW_M);
+    normal_M += cross;
+    /* The cross product magnitude is equal to twice the triangle area. */
+    cross_magnitude = cross.norm();
+    double_poly_area += cross_magnitude;
+
+    /* The triangle centroid Tc is the mean position of the vertices:
+     (A + B + C) / 3. Its contribution to the polygon centroid is scaled by
+     its portion of the polygon area: Aₜ⋅(A + B + C) / (3⋅Aₚ) (where Aₜ is the
+     triangle area and Aₚ is the polygon area). Because we are doing this
+     weighted sum, it doesn't matter if the scale factor is Aₜ / (3⋅Aₚ) or
+     k⋅Aₜ / (k⋅3⋅Aₚ), the scale factors cancel out. So, that means we can ignore
+     the factor of two in the "double" area and omit the divisor 3 in the mean
+     vertex position when combining triangle centroids; *proportional*
+     contribution remains the same. We'll deal with this factor 6 when we need
+     the final value.
+
+     The area value used here is an *absolute* area value. This requires the
+     polygon to be convex (although it does allow for collinear vertices). To
+     allow for non-convex polygons, we'd have to have a *signed* area. This is
+     most easily done by using a known normal direction for computing the
+     area. */
+    p_MTc_scaled += cross_magnitude * (r_MA + r_MB + r_MC);
+  }
+
+  /* Correct the scaled poly centroid as documented above. */
+  const T poly_area = double_poly_area / 2;
+  areas_.push_back(poly_area);
+
+  /* We've accumulated all of the cross products into normal_M. The resulting
+   vector result is the area-scaled polygon normal. This vector sum protects us
+   from any triangles in the fan that may have zero area, or even if the
+   triangle is non-convex. However, this robust *normal* calculation still
+   does not allow this function to support non-convex polygons (see the note
+   on computing the polygon centroid). If the area of the polygon is properly
+   zero, we rely on Eigen's documented behavior that the normalized zero vector
+   is the zero vector.
+   https://eigen.tuxfamily.org/dox/classEigen_1_1MatrixBase.html#a5cf2fd4c57e59604fd4116158fd34308
+   */
+  face_normals_.emplace_back(normal_M.normalized());
+
+  /* Accumulate the contribution of *this* polygon into the mesh centroid. We
+   implicitly have the weighted contribution of all previous polygons as the
+   product of current centroid and total area. This allows us to add in this
+   polygon's contribution proportionately (although, we want to add in Aₚ⋅p_MFc,
+   but what we computed is 6⋅Aₚ⋅p_MFc. */
+  const Vector3<T> p_MTc_area_scaled = p_MTc_scaled / 6;
+  element_centroid_M_.emplace_back(p_MTc_area_scaled / poly_area);
+  const T old_area = total_area_;
+  total_area_ += poly_area;
+  p_MSc_ = (p_MSc_ * old_area + p_MTc_area_scaled) / total_area_;
+}
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class PolygonSurfaceMesh)
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/polygon_surface_mesh.h
+++ b/geometry/proximity/polygon_surface_mesh.h
@@ -1,0 +1,335 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <utility>
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/unused.h"
+#include "drake/geometry/proximity/mesh_traits.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace geometry {
+
+// Forward declaration for friendship.
+template <typename T>
+class PolygonSurfaceMesh;
+
+/** Representation of a polygonal face in a SurfacePolygon. */
+class SurfacePolygon {
+ public:
+  // TODO(SeanCurtis-TRI): Consider making this copy-constructible.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SurfacePolygon)
+
+  /** Returns the number of vertices in this face. */
+  int num_vertices() const { return mesh_face_data_.at(index_); }
+
+  /** Returns the vertex index in PolygonSurfaceMesh of the i-th vertex of
+   this face.
+
+   @param i  The local index of the vertex in this face.
+   @pre 0 <= i < num_vertices() */
+  int vertex(int i) const { return mesh_face_data_.at(index_ + 1 + i); }
+
+  // TODO(SeanCurtis-TRI): Introduce vertices() method that returns a *range*
+  //  iterator over the vertex indices referenced by this face.
+
+ private:
+  /* Only PolygonSurfaceMesh can create faces. */
+  template <typename>
+  friend class PolygonSurfaceMesh;
+
+  /* Constructs a SurfacePolygon.
+   @param face_data  The mesh's face data from which this polygon is drawn. It
+                     is the face data as documented in PolygonSurfaceMesh.
+   @param index      The index into the face data of where this polygon's data
+                     starts; the value contained is the number of vertices for
+                     this polygon. It is _not_ the publicly visible index of the
+                     polygon.
+   */
+  SurfacePolygon(const std::vector<int>* face_data, int index)
+      : index_(index), mesh_face_data_(*face_data) {
+    DRAKE_DEMAND(face_data != nullptr);
+  }
+
+  /* The index of *this* polygon in the polygonal surface. The index points to
+   the first entry, which contains the vertex count. */
+  const int index_{};
+
+  /* The vertex data for the mesh to which this face belongs. */
+  const std::vector<int>& mesh_face_data_;
+};
+
+/** %PolygonSurfaceMesh represents a surface comprised of *polygonal* elements
+ (three or more sides).
+ @tparam_nonsymbolic_scalar */
+template <class T>
+class PolygonSurfaceMesh {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PolygonSurfaceMesh)
+
+  /** @name Mesh type traits
+
+   A collection of type traits to enable mesh consumers to be templated on mesh
+   type. Each mesh type provides specific definitions of _element_ and
+   _barycentric coordinates_. For %PolygonSurfaceMesh, an element is a
+   polygon. */
+  //@{
+
+  using ScalarType = T;
+
+  /** A definition that satisfies the interface that MeshFieldLinear requires.
+   The value -1 indicates "unbounded" (as opposed to 3 for TriangleSurfaceMesh
+   or 4 for VolumeMesh). It is up to MeshFieldLinear (and any other
+   MeshType-compatible classes that pair with PolygonSurfaceMesh) to decide how
+   they handle this unbounded value. */
+  static constexpr int kVertexPerElement = -1;
+
+  /** %PolygonSurfaceMesh doesn't actually support barycentric coordinates. This
+   is here to satisfy the MeshFieldLinear interface. The dimension is selected
+   to be zero to minimize memory footprint in case one is inadvertently
+   instantiated. */
+  template <typename U = T>
+  using Barycentric = Vector<U, 0>;
+
+  // TODO(SeanCurtis-TRI): Implement FaceRangeIterator faces() so people can
+  //  iterate over the faces. And VertexRangeIterator vertices() so people can
+  //  iterate over the vertices. This would help create better parallels with
+  //  TriangleSurfaceMesh and VolumeMesh.
+
+  /** Returns the polygonal element identified by the given index `e`.
+    @pre e ∈ {0, 1, 2, ..., num_faces()-1}. */
+  SurfacePolygon element(int e) const {
+    DRAKE_DEMAND(0 <= e && e < num_faces());
+    return {&face_data_, poly_indices_[e]};
+  }
+
+  /** Returns the vertex identified by the given index `v`.
+   @pre v ∈ {0, 1, 2, ..., num_vertices()-1}. */
+  const Vector3<T>& vertex(int v) const {
+    DRAKE_DEMAND(0 <= v && v < num_vertices());
+    return vertices_M_[v];
+  }
+
+  /** Returns the number of vertices in the mesh. */
+  int num_vertices() const { return static_cast<int>(vertices_M_.size()); }
+
+  /** Returns the number of elements in the mesh. For %PolygonSurfaceMesh, an
+   element is a polygon. Returns the same number as num_faces() and enables
+   mesh consumers to be templated on mesh type. */
+  int num_elements() const { return num_faces(); }
+
+  //@}
+
+  /** Advanced() Constructs an *empty* mesh. This enables compatibility with STL
+   container types and facilitates some unit tests. Otherwise, it shouldn't be
+   used. */
+  PolygonSurfaceMesh() : p_MSc_(Vector3<T>::Zero()) {}
+
+  /** Constructs a mesh from specified vertex and mesh data.
+
+   The vertices are simply a vector of position vectors (interpreted as being
+   measured and expressed in the mesh's frame M).
+
+   The polygon data is more complex. Syntactically, it is a sequence of integers
+   which _encodes_ P polygons. Each polygon can have an arbitrary number of
+   vertices. The encoding of the P polygons is as follows:
+
+       |c₁|v₁₀|v₁₁|...|cᵢ|cᵢ₀|cᵢ₁|...|cₚ|cₚ₀|cₚ₁|...|
+
+   Each polygon is defined in sequence. The definition consists of an integer
+   indicating the *number* of vertices in that polygon (c₁, cᵢ, and cₘ in the
+   illustration above). The next cᵢ integers in the sequence are zero-based
+   indices into the vector of vertex positions (indicating which vertices the
+   polygon spans). The vertex indices are sorted such that the plane normal
+   found by applying the right-handed rule is used as the face normal.
+
+   This implies the following:
+     Polygon one:
+       Located at index i₁ = 0 in `face_data`.
+       c₁ = face_data[i₁] is the number of vertices in polygon one.
+     Polygon two:
+       Located at index i₂ = i₁ + c₁ + 1 in `face_data`.
+       c₂ = face_data[i₂] is the number of vertices in polygon zero.
+     Polygon j:
+       Located at index iⱼ = iⱼ₋₁ + cⱼ₋₁ + 1
+       cⱼ = face_data[iⱼ]
+
+   The polygons must all be planar and convex.
+
+   @param face_data  The sequence of counts and indices which encode the faces
+                     of the mesh (see above).
+   @param vertices   The vertex positions, measured and expressed in this
+                     mesh's frame.
+   @pre The indices in `face_data` all refer to valid indices into `vertices`.
+   */
+  PolygonSurfaceMesh(std::vector<int> face_data,
+                     std::vector<Vector3<T>> vertices);
+
+  /** Transforms the vertices of this mesh from its initial frame M to the new
+   frame N. */
+  void TransformVertices(const math::RigidTransform<T>& X_NM);
+
+  // TODO(SeanCurtis-TRI): ContactResultsToLcm and HydroelasticContactInfo
+  //  ostensibly support symbolic::Expression. However, the ContactSurface that
+  //  they both interact with *doesn't*. Their unit tests blindly assume that
+  //  there is full scalar support. ContactSurface calls ReverseFaceWinding so,
+  //  for the offending unit tests to maintain the illusion of support, this
+  //  must be defined in the header so they can compile and link -- although,
+  //  the resulting ContactSurface<symbolic::Expression> is only a partial
+  //  implementation and can't do any interesting math, this allows the tests
+  //  to create the type they need. Ideally, the tests wouldn't be expressed
+  //  in a way that suggests non-existent support is otherwise possible.
+  //  Alternatively, there's a question about whether ContactSurface should be
+  //  calling this method *at all*. Choosing that it's not necessary would
+  //  likewise enable this implementation to move to the .cc file.
+  /** Reverses the ordering of all the faces' indices. */
+  void ReverseFaceWinding() {
+    for (const int f_index : poly_indices_) {
+      const int v_count = face_data_[f_index];
+      /* The indices before and after the first and last entries.  */
+      int f_0 = f_index;
+      int f_n = f_index + v_count + 1;
+      for (int i = 0; i < v_count / 2; ++i) {
+        std::swap(face_data_[++f_0], face_data_[--f_n]);
+      }
+    }
+    for (auto& n : face_normals_) {
+      n = -n;
+    }
+  }
+
+  /** Returns the number of polygonal elements in the mesh. */
+  int num_faces() const { return static_cast<int>(poly_indices_.size()); }
+
+  /** Returns area of a polygonal element.
+   @pre f ∈ {0, 1, 2, ..., num_faces()-1}. */
+  const T& area(int f) const {
+    DRAKE_DEMAND(0 <= f && f < num_faces());
+    return areas_[f];
+  }
+
+  /** Returns the total area of all the faces of this surface mesh. */
+  const T& total_area() const { return total_area_; }
+
+  /** Returns the unit face normal vector of a polygon. It respects the
+   right-handed normal rule. A near-zero-area triangle may get an unreliable
+   normal vector. A zero-area triangle will get a zero vector.
+   @pre f ∈ {0, 1, 2, ..., num_faces()-1}. */
+  const Vector3<T>& face_normal(int f) const {
+    DRAKE_DEMAND(0 <= f && f < num_faces());
+    return face_normals_[f];
+  }
+
+  /** Returns the geometric centroid of the element indicated be index `e`,
+   measured and expressed in the mesh's frame M.
+   @pre f ∈ {0, 1, 2, ..., num_faces()-1}. */
+  const Vector3<T>& element_centroid(int e) const {
+    DRAKE_DEMAND(0 <= e && e < num_faces());
+    return element_centroid_M_[e];
+  }
+
+  /** Returns the geometric centroid of this mesh measured and expressed in
+   the mesh's frame M. (M is the frame in which this mesh's vertices are
+   measured and expressed.) Note that the centroid is not necessarily a point on
+   the surface. If the total mesh area is exactly zero, we define the centroid
+   to be (0,0,0). */
+  const Vector3<T>& centroid() const { return p_MSc_; }
+
+  /** See TriangleSurfaceMesh::CalcBaryCentric(). This implementation is
+   provided to maintain compatibility with MeshFieldLinear. However, it only
+   throws. %PolygonSurfaceMesh does not support barycentric coordinates. */
+  template <typename C>
+  Barycentric<promoted_numerical_t<T, C>> CalcBarycentric(
+      const Vector3<C>& p_MQ, int p) const {
+    unused(p_MQ, p);
+    throw std::runtime_error(
+        "PolygonSurfaceMesh::CalcBarycentric(): PolygonSurfaceMesh does not "
+        "have barycentric coordinates.");
+  }
+
+  // TODO(DamrongGuoy): Consider using an oriented bounding box in obb.h.
+  //  Currently we have a problem that PolygonSurfaceMesh and its vertices are
+  //  templated on T, but Obb is for double only.
+  /** Calculates the axis-aligned bounding box of this surface mesh M.
+   @returns the center and the size vector of the box expressed in M's frame. */
+  std::pair<Vector3<T>, Vector3<T>> CalcBoundingBox() const;
+
+  // TODO(#12173): Consider NaN==NaN to be true in equality tests.
+  /** Checks to see whether the given PolygonSurfaceMesh object is equal
+   via deep exact comparison. NaNs are treated as not equal as per the IEEE
+   standard.
+   @param mesh The mesh for comparison.
+   @returns `true` if the given mesh is equal. */
+  bool Equal(const PolygonSurfaceMesh<T>& mesh) const;
+
+  /* (Advanced) Provide access to the underlying face data to facilitate
+   efficient visualization. */
+  const std::vector<int>& face_data() const { return face_data_; }
+
+  /** This is a stub method. It is provided so that PolygonSurfaceMesh provides
+   a sufficient API to compile against MeshFieldLinear. However, we expect
+   that the gradients of the field will always be provided when defining a
+   MeshFieldLinear with a PolygonSurfaceMesh. Failure to provide those gradients
+   will cause *this* method to be invoked which will, in turn, throw. */
+  template <typename FieldValue>
+  Vector3<FieldValue> CalcGradientVectorOfLinearField(
+      const std::array<FieldValue, 3>& field_value, int p) const {
+    unused(field_value, p);
+    throw std::runtime_error(
+        "PolygonSurfaceMesh::CalcGradientVectorOfLinearField(): "
+        "PolygonSurfaceMesh does not support this calculation. Defining a "
+        "MeshFieldLinear on a PolygonSurfaceMesh requires field gradients to "
+        "be provided at construction.");
+  }
+
+ private:
+  /* Calculates the area and face normal of a polygon. Further computes its
+   contribution to the surface centroid.
+
+   @param poly_index The index of the polygon to compute the derived quantities.
+                     Must be in the range [0, poly_indices_.size()). */
+  void CalcAreaNormalAndCentroid(int poly_index);
+
+  /* The encoding of the mesh's polygons. See the advanced constructor for
+   details. */
+  std::vector<int> face_data_;
+
+  /* The ith polygon is defined in face_data_ at index poly_indices_[i]. In
+   other words, this contains the indices of face_data_ that point to the c₁,
+   cᵢ, ..., cₘ entries for M polygons in the mesh. */
+  std::vector<int> poly_indices_;
+
+  /* The vertices referenced by the mesh's polygons. */
+  std::vector<Vector3<T>> vertices_M_;
+
+  /* Derived quantities of the mesh -- computed as elements are added. */
+
+  /* Per-polygon areas. areas_.size() == poly_indices_.size() is always true. */
+  std::vector<T> areas_;
+
+  /* The total area of all polygons in the mesh. */
+  T total_area_{0};
+
+  /* Per-polygon normals. face_normals_.size() == poly_indices_.size() is always
+   true. */
+  std::vector<Vector3<T>> face_normals_;
+
+  /* Per-polygon centroids. */
+  std::vector<Vector3<T>> element_centroid_M_;
+
+  /* The geometric centroid Sc of the surface mesh, measured and expressed in
+   the mesh frame M. */
+  Vector3<T> p_MSc_;
+};
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class PolygonSurfaceMesh)
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/polygon_surface_mesh_test.cc
+++ b/geometry/proximity/test/polygon_surface_mesh_test.cc
@@ -1,0 +1,429 @@
+#include "drake/geometry/proximity/polygon_surface_mesh.h"
+
+#include <numeric>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace geometry {
+namespace {
+
+using Eigen::AngleAxisd;
+using Eigen::Vector3d;
+using math::RigidTransformd;
+using math::RotationMatrixd;
+using std::vector;
+
+/* Simple struct for defining an expected polygon. It doesn't do math and
+ assumes that the various quantities are defined consistently. */
+struct Polygon {
+  std::string name;
+  vector<Vector3d> vertices;
+  double area;
+  Vector3d normal;
+  Vector3d centroid;
+};
+
+template <typename T>
+class PolygonSurfaceMeshTest : public ::testing::Test {
+ protected:
+  /* Adds the given polygon to the raw vertex and face data for exercising the
+   advanced constructor. */
+  void AddPolygon(const Polygon& polygon, vector<int>* face_data,
+                  vector<Vector3<T>>* vertices) {
+    const int first_new_index = static_cast<int>(vertices->size());
+    for (const auto& v : polygon.vertices) {
+      vertices->emplace_back(v.cast<T>());
+    }
+    const int polygon_size = static_cast<int>(polygon.vertices.size());
+    vector<int> v_indices(polygon_size);
+    std::iota(v_indices.begin(), v_indices.end(), first_new_index);
+    face_data->push_back(polygon_size);
+    face_data->insert(face_data->end(), v_indices.begin(), v_indices.end());
+  }
+
+  /* Returns an isosceles triangle with a known area and normal, posed in
+   Frame W. */
+  Polygon MakeIsoscelesTriangle(const RigidTransformd& X_WM = {}) {
+    vector<Vector3d> vertices{{0, 0, 0}, {1, 0, 0}, {0, 1, 0}};
+    Vector3d centroid(0, 0, 0);
+    for (auto& p_MV : vertices) {
+      p_MV = X_WM * p_MV;
+      centroid += p_MV;
+    }
+    centroid /= 3;
+    Vector3d normal_W = X_WM.rotation() * Vector3d{0, 0, 1};
+    return {.name = "Isosceles triangle",
+            .vertices = vertices,
+            .area = 0.5,
+            .normal = normal_W,
+            .centroid = centroid};
+  }
+
+  /* Returns a simple square polygon posed in frame W. */
+  Polygon MakeSquare(const RigidTransformd& X_WM = {}) {
+    const double h = 0.25;
+    vector<Vector3d> vertices{{0, 0, 0}, {h, 0, 0}, {h, 0, h}, {0, 0, h}};
+    for (auto& p_MV : vertices) {
+      p_MV = X_WM * p_MV;
+    }
+    Vector3d normal_W = X_WM.rotation() * Vector3d{0, -1, 0};
+    return {.name = "Square",
+            .vertices = vertices,
+            .area = h * h,
+            .normal = normal_W,
+            .centroid = X_WM * Vector3d(h / 2, 0, h / 2)};
+  }
+
+  /* Returns a regular pentagon posed in frame W. */
+  Polygon MakePentagon(const RigidTransformd& X_WM = {}) {
+    /* We'll define the pentagon by simply sampling a circle of radius R at
+     2π/5 intervals. These five points are the polygon vertices. They'll lie on
+     the yz-plane (so the normal is in the x-direction). The area is computed
+     as the sum of the areas of five isosceles triangles.
+
+               θ         θ/2 = π/5
+              /|\          w = R⋅sin(θ/2)
+           R / | \         h = R⋅cos(θ/2)
+            /  |  \      A = R²⋅sin(θ/2)⋅cos(θ/2)
+           /  h|   \
+          /____|____\
+             w                                       */
+    vector<Vector3d> vertices;
+    const double kR = 0.75;
+    const double kTheta = M_PI * 2 / 5;
+    for (int i = 0; i < 5; ++i) {
+      const double alpha = i * kTheta;
+      vertices.emplace_back(
+          X_WM * Vector3d(0, kR * std::cos(alpha), kR * std::sin(alpha)));
+    }
+    return {.name = "Pentagon",
+            .vertices = vertices,
+            .area = 5 * kR * kR * std::sin(kTheta / 2) * std::cos(kTheta / 2),
+            .normal = X_WM.rotation() * Vector3d(1, 0, 0),
+            .centroid = X_WM.translation()};
+  }
+
+  /* Build a mesh from a number of polygons. */
+  PolygonSurfaceMesh<T> MakeMesh(const vector<Polygon> polygons) {
+    vector<Vector3<T>> vertices;
+    vector<int> face_data;
+    for (const auto& polygon : polygons) {
+      AddPolygon(polygon, &face_data, &vertices);
+    }
+    return {move(face_data), move(vertices)};
+  }
+};
+
+using ScalarTypes = ::testing::Types<double, AutoDiffXd>;
+TYPED_TEST_SUITE(PolygonSurfaceMeshTest, ScalarTypes);
+
+/* Simple confirmation that the default constructor creates a valid, but empty
+ mesh. */
+TYPED_TEST(PolygonSurfaceMeshTest, DefaultConstructor) {
+  using T = TypeParam;
+  PolygonSurfaceMesh<T> mesh;
+  EXPECT_EQ(mesh.num_vertices(), 0);
+  EXPECT_EQ(mesh.num_elements(), 0);
+  EXPECT_EQ(mesh.num_faces(), 0);
+  EXPECT_EQ(ExtractDoubleOrThrow(mesh.total_area()), 0);
+  EXPECT_TRUE(
+      CompareMatrices(ExtractDoubleOrThrow(mesh.centroid()), Vector3d::Zero()));
+  EXPECT_TRUE(PolygonSurfaceMesh<T>().Equal(PolygonSurfaceMesh<T>()));
+}
+
+/* Tests the advanced constructor and the various accessors (including the
+ SurfacePolygon API). confirms that it produces the same mesh as
+ building a mesh by adding vertices/polygons via the main API. This test relies
+ on the AddVertex(), AddPolygon(), and Equal() methods as already tested. */
+TYPED_TEST(PolygonSurfaceMeshTest, FullConstructor) {
+  using T = TypeParam;
+
+  /* we'll build a mesh consisting of these polygons. */
+  vector<Polygon> polygons = {this->MakeIsoscelesTriangle(), this->MakeSquare(),
+                              this->MakePentagon()};
+
+  const PolygonSurfaceMesh<T> mesh = this->MakeMesh(polygons);
+  const int expected_face_count = static_cast<int>(polygons.size());
+  int expected_vert_count = 0;
+  for (const auto& polygon : polygons) {
+    expected_vert_count += static_cast<int>(polygon.vertices.size());
+  }
+
+  EXPECT_EQ(mesh.num_vertices(), expected_vert_count);
+  EXPECT_EQ(mesh.num_elements(), expected_face_count);
+  EXPECT_EQ(mesh.num_faces(), expected_face_count);
+  for (int f = 0; f < expected_face_count; ++f) {
+    const auto& face = mesh.element(f);
+    const int v_count = static_cast<int>(polygons[f].vertices.size());
+    EXPECT_EQ(face.num_vertices(), v_count);
+    for (int v = 0; v < v_count; ++v) {
+      ASSERT_TRUE(CompareMatrices(mesh.vertex(face.vertex(v)),
+                                  polygons[f].vertices[v]));
+    }
+  }
+}
+
+/* This tests centroid computation: both the per-polygon centroid and the
+ overall mesh centroid. By using polygons with different numbers of vertices,
+ we'll confirm that the per-polygon calculation is correct (as reported by
+ element_centroid()) and that they are subsequently combined correctly (as
+ reported by centroid()) */
+TYPED_TEST(PolygonSurfaceMeshTest, MeshCentroid) {
+  using T = TypeParam;
+
+  /* Arbitrary transform so polygons don't have centroids at the origin. */
+  const RigidTransformd X_WM{
+      AngleAxisd{M_PI / 4, Vector3d(1, 2, 3).normalized()}, Vector3d{1, 2, 3}};
+  vector<Polygon> polygons = {this->MakeIsoscelesTriangle(X_WM),
+                              this->MakeSquare(X_WM), this->MakePentagon(X_WM)};
+
+  double total_area_expected = 0;
+  Vector3d scaled_centroid_expected(0, 0, 0);
+  /* We're using asserts throughout this for loop because if *one* polygon
+   fails they will likely all fail in an unhelpful way; so we'll stop at the
+   first. */
+  vector<Vector3<T>> vertices;
+  vector<int> face_data;
+  for (const auto& polygon : polygons) {
+    /* Accumulate the polygon into the full mesh. */
+    this->AddPolygon(polygon, &face_data, &vertices);
+    total_area_expected += polygon.area;
+    scaled_centroid_expected += polygon.area * polygon.centroid;
+  }
+  const PolygonSurfaceMesh<T> mesh(move(face_data), move(vertices));
+
+  ASSERT_TRUE(CompareMatrices(
+      mesh.centroid(), scaled_centroid_expected / total_area_expected, 1e-15));
+  for (int e = 0; e < mesh.num_elements(); ++e) {
+    ASSERT_TRUE(
+        CompareMatrices(mesh.element_centroid(e), polygons[e].centroid, 1e-15));
+  }
+}
+
+TYPED_TEST(PolygonSurfaceMeshTest, Area) {
+  using T = TypeParam;
+
+  /* We want to make sure the area is invariant w.r.t. orientation and position
+   of the polygon, so we'll apply a non-trivial transform. */
+  const RigidTransformd X_WM{
+      AngleAxisd{M_PI / 4, Vector3d(1, 2, 3).normalized()}, Vector3d{1, 2, 3}};
+  const vector<Polygon> polygons = {this->MakeIsoscelesTriangle(X_WM),
+                                    this->MakeSquare(X_WM),
+                                    this->MakePentagon(X_WM)};
+
+  double expected_total_area = 0;
+  vector<Vector3<T>> vertices;
+  vector<int> face_data;
+  for (const auto& polygon : polygons) {
+    /* We're using asserts throughout this for loop because if *one* polygon
+     fails they will likely all fail in an unhelpful way; so we'll stop at the
+     first. */
+    this->AddPolygon(polygon, &face_data, &vertices);
+    expected_total_area += polygon.area;
+  }
+  const PolygonSurfaceMesh<T> mesh(move(face_data), move(vertices));
+
+  ASSERT_NEAR(ExtractDoubleOrThrow(mesh.total_area()), expected_total_area,
+              1e-15);
+  for (int e = 0; e < mesh.num_elements(); ++e) {
+    ASSERT_NEAR(ExtractDoubleOrThrow(mesh.area(e)), polygons[e].area, 1e-15);
+  }
+}
+
+TYPED_TEST(PolygonSurfaceMeshTest, CalcBoundingBox) {
+  using T = TypeParam;
+
+  /* Make sure the box is well-defined in the frame of the vertices by using
+   a non-trivial pose. */
+  const RigidTransformd X_WM{
+      AngleAxisd{M_PI / 4, Vector3d(1, 2, 3).normalized()}, Vector3d{1, 2, 3}};
+  const vector<Polygon> polygons = {this->MakeIsoscelesTriangle(X_WM),
+                                    this->MakeSquare(X_WM),
+                                    this->MakePentagon(X_WM)};
+
+  Vector3d min_corner =
+      Vector3d::Constant(std::numeric_limits<double>::infinity());
+  Vector3d max_corner = -min_corner;
+
+  vector<Vector3<T>> vertices;
+  vector<int> face_data;
+  for (const auto& polygon : polygons) {
+    this->AddPolygon(polygon, &face_data, &vertices);
+    for (const auto& v : polygon.vertices) {
+      min_corner = min_corner.array().min(v.array());
+      max_corner = max_corner.array().max(v.array());
+    }
+  }
+  const PolygonSurfaceMesh<T> mesh(move(face_data), move(vertices));
+
+  const Vector3d center_expected = (min_corner + max_corner) / 2;
+  const Vector3d size_expected = max_corner - min_corner;
+  const auto [center, size] = mesh.CalcBoundingBox();
+  EXPECT_TRUE(CompareMatrices(ExtractDoubleOrThrow(center), center_expected));
+  EXPECT_TRUE(CompareMatrices(ExtractDoubleOrThrow(size), size_expected));
+}
+
+TYPED_TEST(PolygonSurfaceMeshTest, FaceNormals) {
+  using T = TypeParam;
+
+  /* Make sure the face normals computed are in the frame of the vertices by
+   using a non-trivial pose. */
+  const RigidTransformd X_WM{
+      AngleAxisd{M_PI / 4, Vector3d(1, 2, 3).normalized()}, Vector3d{1, 2, 3}};
+  const vector<Polygon> polygons = {this->MakeIsoscelesTriangle(X_WM),
+                                    this->MakeSquare(X_WM),
+                                    this->MakePentagon(X_WM)};
+
+  const PolygonSurfaceMesh<T> mesh = this->MakeMesh(polygons);
+
+  for (int p = 0; p < static_cast<int>(polygons.size()); ++p) {
+    ASSERT_TRUE(CompareMatrices(ExtractDoubleOrThrow(mesh.face_normal(p)),
+                                polygons[p].normal, 1e-15));
+  }
+}
+
+/* In the case where a face is zero-area, we want to confirm that we get the
+ zero vector for a face normal. */
+TYPED_TEST(PolygonSurfaceMeshTest, ZeroFaceNormal) {
+  using T = TypeParam;
+
+  /* The mesh is a single triangle built on collinear vertices. We leave the
+   vertex positions axis aligned in the mesh's frame to *guarantee* getting
+   a zero cross product between the triangle edges. Any non-zero bit will
+   produce a non-zero normal. */
+  const Polygon poly{.name = "line",
+                     .vertices = {{0, 0, 0}, {1, 0, 0}, {2, 0, 0}},
+                     .area = 0,
+                     .normal = {0, 0, 0},
+                     .centroid = {0, 0, 0}};
+  /* Make sure the face normals computed are in the frame of the vertices. */
+  const PolygonSurfaceMesh<T> mesh = this->MakeMesh({poly});
+
+  ASSERT_TRUE(
+      CompareMatrices(ExtractDoubleOrThrow(mesh.face_normal(0)), poly.normal));
+}
+
+/* In the case where a face has collinear vertices, we want to confirm that we
+ still get the actual polygon area. */
+TYPED_TEST(PolygonSurfaceMeshTest, DegenerateFaceNormal) {
+  using T = TypeParam;
+
+  /* We'll create a triangle with one of the edges split by a vertex:
+
+      o
+      |\
+      | \
+      o  \
+      |   \
+      |    \
+      o-----o
+
+   We'll try it on four permutations such that each vertex takes it in turn to
+   be the *first* vertex in the polygon. This will show that the code is robust
+   to vertex ordering. */
+  vector<Vector3d> vertices{{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {0, 0.5, 0}};
+  vector<vector<int>> polygons{
+      {0, 1, 2, 3}, {1, 2, 3, 0}, {2, 3, 0, 1}, {3, 0, 1, 2}};
+  for (const auto& ordering : polygons) {
+    vector<Vector3d> ordered_vertices;
+    for (int index : ordering) {
+      ordered_vertices.push_back(vertices[index]);
+    }
+    const Polygon poly{.name = "unused",
+                       .vertices = ordered_vertices,
+                       .area = 0.5,
+                       .normal = {0, 0, 1},
+                       .centroid = {1 / 3.0, 1 / 3.0, 0.0}};
+    const PolygonSurfaceMesh<T> mesh = this->MakeMesh({poly});
+
+    ASSERT_TRUE(CompareMatrices(ExtractDoubleOrThrow(mesh.face_normal(0)),
+                                poly.normal));
+    ASSERT_TRUE(CompareMatrices(ExtractDoubleOrThrow(mesh.element_centroid(0)),
+                                poly.centroid));
+    ASSERT_EQ(mesh.total_area(), poly.area);
+  }
+}
+
+TYPED_TEST(PolygonSurfaceMeshTest, ReverseFaceWinding) {
+  using T = TypeParam;
+
+  PolygonSurfaceMesh<T> mesh =
+      this->MakeMesh({this->MakeIsoscelesTriangle(), this->MakeSquare(),
+                      this->MakePentagon()});
+
+  /* Create a copy to preserve the original winding to test against. */
+  const PolygonSurfaceMesh<T> mesh_copy(mesh);
+  mesh.ReverseFaceWinding();
+
+  for (int p = 0; p < mesh.num_elements(); ++p) {
+    const SurfacePolygon face = mesh.element(p);
+    const SurfacePolygon face_copy = mesh_copy.element(p);
+    const int v_count = face.num_vertices();
+    for (int i = 0; i < v_count; ++i) {
+      ASSERT_EQ(face.vertex(i), face_copy.vertex(v_count - 1 - i));
+    }
+    ASSERT_TRUE(
+        CompareMatrices(mesh.face_normal(p), -mesh_copy.face_normal(p)));
+  }
+}
+
+TYPED_TEST(PolygonSurfaceMeshTest, TransformVertices) {
+  using T = TypeParam;
+
+  /* Create a mesh in the mesh's frame M. */
+  PolygonSurfaceMesh<T> mesh_M =
+      this->MakeMesh({this->MakeIsoscelesTriangle(), this->MakeSquare(),
+                      this->MakePentagon()});
+
+  /* Now create a mesh directly in the world frame with an arbitrary,
+   non-trivial pose. */
+  const RigidTransformd X_WM{
+      AngleAxisd{M_PI / 4, Vector3d(1, 2, 3).normalized()}, Vector3d{1, 2, 3}};
+  const PolygonSurfaceMesh<T> mesh_W =
+      this->MakeMesh({this->MakeIsoscelesTriangle(X_WM), this->MakeSquare(X_WM),
+                      this->MakePentagon(X_WM)});
+
+  /* Quick indicator that the two meshes do *not* have the same pose. */
+  ASSERT_FALSE(CompareMatrices(mesh_M.vertex(0), mesh_W.vertex(0), 1e-8));
+
+  /* Now mesh_M is also mesh_W. */
+  mesh_M.TransformVertices(X_WM.cast<T>());
+
+  ASSERT_NEAR(ExtractDoubleOrThrow(mesh_M.total_area()),
+              ExtractDoubleOrThrow(mesh_W.total_area()), 1e-15)
+      << "Area should be invariant to rigid vertex transformations";
+  for (int v = 0; v < mesh_M.num_vertices(); ++v) {
+    ASSERT_TRUE(CompareMatrices(mesh_M.vertex(v), mesh_W.vertex(v), 1e-15));
+  }
+  for (int p = 0; p < mesh_M.num_elements(); ++p) {
+    ASSERT_TRUE(
+        CompareMatrices(mesh_M.face_normal(p), mesh_W.face_normal(p), 1e-15));
+    ASSERT_TRUE(CompareMatrices(mesh_M.element_centroid(p),
+                                mesh_W.element_centroid(p), 1e-15));
+  }
+  ASSERT_TRUE(CompareMatrices(mesh_M.centroid(), mesh_W.centroid(), 1e-15));
+}
+
+TYPED_TEST(PolygonSurfaceMeshTest, CalcGradientVectorOfLinearField) {
+  using T = TypeParam;
+
+  /* Create a mesh in the mesh's frame M. */
+  PolygonSurfaceMesh<T> mesh_M =
+      this->MakeMesh({this->MakeIsoscelesTriangle(), this->MakeSquare(),
+                      this->MakePentagon()});
+  std::array<T, 3> dummy_values;
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      mesh_M.CalcGradientVectorOfLinearField(dummy_values, 0),
+      "PolygonSurfaceMesh::CalcGradientVectorOfLinearField\\(\\): "
+      "PolygonSurfaceMesh does not support this calculation. Defining a "
+      "MeshFieldLinear on a PolygonSurfaceMesh requires field gradients to "
+      "be provided at construction.");
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
Like the `TriangleSurfaceMesh`, it represents a discrete 2D surface. Unlike it, the discrete elements can be polygons with 3 or more sides. It is designed to be basically compatible with `TriangleSurfaceMesh`.

It currently lacks the ability to iterate through faces and vertices via *range* iteration. A TODO calls that missing feature out.

Co-authored-by: Joe Masterjohn `<joe.masterjohn@tri.global>`

relates #15796

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16111)
<!-- Reviewable:end -->
