### PR TITLE
[hydro] Patch triangle surface mesh

### DIFF
--- a/bindings/pydrake/geometry_py_hydro.cc
+++ b/bindings/pydrake/geometry_py_hydro.cc
@@ -37,8 +37,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("triangles", &Class::triangles,
             doc.TriangleSurfaceMesh.triangles.doc)
         .def("vertices", &Class::vertices, doc.TriangleSurfaceMesh.vertices.doc)
-        .def(
-            "centroid", &Class::centroid, doc.TriangleSurfaceMesh.centroid.doc);
+        .def("centroid", &Class::centroid, doc.TriangleSurfaceMesh.centroid.doc)
+        .def("element_centroid", &Class::element_centroid, py::arg("t"),
+            doc.TriangleSurfaceMesh.element_centroid.doc);
   }
 
   // VolumeMesh

--- a/bindings/pydrake/test/geometry_hydro_test.py
+++ b/bindings/pydrake/test/geometry_hydro_test.py
@@ -86,6 +86,8 @@ class TestGeometryHydro(unittest.TestCase):
         self.assertEqual(len(mesh.triangles()), 2)
         self.assertEqual(len(mesh.vertices()), 4)
         self.assertListEqual(list(mesh.centroid()), [0, 0, 0])
+        self.assertListEqual(list(mesh.element_centroid(t=1)),
+                             [-1/3.0, 1/3.0, 0])
 
     def test_volume_mesh(self):
         # Create a mesh out of two tetrahedra with a single, shared face

--- a/geometry/proximity/test/triangle_surface_mesh_test.cc
+++ b/geometry/proximity/test/triangle_surface_mesh_test.cc
@@ -129,9 +129,11 @@ std::unique_ptr<TriangleSurfaceMesh<T>> TestSurfaceMesh(
   EXPECT_EQ(4, surface_mesh_W->num_vertices());
   for (int v = 0; v < 4; ++v)
     EXPECT_EQ(X_WM * vertex_data_M[v], surface_mesh_W->vertex(v));
-  for (int f = 0; f < 2; ++f)
+  for (int f = 0; f < 2; ++f) {
+    EXPECT_EQ(surface_mesh_W->element(f).num_vertices(), 3);
     for (int v = 0; v < 3; ++v)
       EXPECT_EQ(face_data[f][v], surface_mesh_W->element(f).vertex(v));
+  }
   return surface_mesh_W;
 }
 
@@ -195,9 +197,12 @@ GTEST_TEST(SurfaceMeshTest, TestCentroid) {
   const double tol = 10 * std::numeric_limits<double>::epsilon();
   auto surface_mesh = GenerateTwoTriangleMesh<double>();
   const Vector3<double> centroid = surface_mesh->centroid();
-  EXPECT_NEAR(centroid[0], 1.0/6, tol);
-  EXPECT_NEAR(centroid[1], -1.0/6, tol);
-  EXPECT_NEAR(centroid[2], -0.5, tol);
+  EXPECT_TRUE(
+      CompareMatrices(centroid, Vector3d(1.0 / 6, -1.0 / 6, -0.5), tol));
+  EXPECT_TRUE(CompareMatrices(surface_mesh->element_centroid(0),
+                              Vector3d(-0.5 / 3, 0.5 / 3, -0.5), tol));
+  EXPECT_TRUE(CompareMatrices(surface_mesh->element_centroid(1),
+                              Vector3d(1.0 / 3, -1.0 / 3, -0.5), tol));
 
   // The documentation for the centroid method specifies particular behavior
   // when the total area is zero. Test that.

--- a/geometry/proximity/triangle_surface_mesh.h
+++ b/geometry/proximity/triangle_surface_mesh.h
@@ -37,6 +37,9 @@ class SurfaceTriangle {
   explicit SurfaceTriangle(const int v[3])
       : SurfaceTriangle(v[0], v[1], v[2]) {}
 
+  /** Returns the number of vertices in this face. */
+  int num_vertices() const { return 3; }
+
   /** Returns the vertex index in TriangleSurfaceMesh of the i-th vertex of this
    triangle.
    @param i  The local index of the vertex in this triangle.
@@ -126,6 +129,21 @@ class TriangleSurfaceMesh {
     return triangles_[e];
   }
 
+  /** Returns the centroid of a triangle measured and expressed in the mesh's
+   frame. */
+  Vector3<T> element_centroid(int t) const {
+    DRAKE_DEMAND(0 <= t && t < num_triangles());
+    /* We're not pre-computing and returning stored values because the current
+     expectation is that the cost of storing the values (greater construction
+     time, more complexity in code) is probably not justified based on how
+     many times the centroid would be accessed. So, for now, we'll compute on
+     the fly until we know that the query cost dominates. */
+    const auto& tri = triangles_[t];
+    return (vertices_[tri.vertex(0)] + vertices_[tri.vertex(1)] +
+            vertices_[tri.vertex(2)]) /
+           3;
+  }
+
   /** Returns the triangles. */
   const std::vector<SurfaceTriangle>& triangles() const { return triangles_; }
 
@@ -160,7 +178,7 @@ class TriangleSurfaceMesh {
    @param vertices  The vertices.
    */
   TriangleSurfaceMesh(std::vector<SurfaceTriangle>&& triangles,
-              std::vector<Vector3<T>>&& vertices)
+                      std::vector<Vector3<T>>&& vertices)
       : triangles_(std::move(triangles)),
         vertices_(std::move(vertices)),
         area_(triangles_.size()),  // Pre-allocate here, not yet calculated.
@@ -284,8 +302,8 @@ class TriangleSurfaceMesh {
    @pre t ∈ {0, 1, 2,..., num_triangles()-1}.
    */
   template <typename C>
-  Vector3<promoted_numerical_t<T, C>> CalcBarycentric(const Vector3<C>& p_MQ,
-                                                      int t) const {
+  Barycentric<promoted_numerical_t<T, C>> CalcBarycentric(
+      const Vector3<C>& p_MQ, int t) const {
     const Vector3<T>& v0 = vertex(element(t).vertex(0));
     const Vector3<T>& v1 = vertex(element(t).vertex(1));
     const Vector3<T>& v2 = vertex(element(t).vertex(2));


### PR DESCRIPTION
Tweaks the triangle surface mesh so that it will be forward compatible with the polygon surface mesh (and incidentally cleans up a formatting issue).

1. `SurfaceTriangle` can report number of vertices (hard-coded to 3).
2. Can report the centroid of each triangle.
3. The return type for `CalcBarycentric` is properly expressed as the declared barycentric type. This is a cosmetic change here to help it match `PolygonSurfaceMesh`.

relates #15796

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16112)
<!-- Reviewable:end -->
