### PR TITLE
Revert "MultibodyPlant (internally) starts using DFT ordering."

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -20,6 +20,7 @@ drake_cc_package_library(
         ":calc_distance_and_time_derivative",
         ":compliant_contact_manager",
         ":contact_jacobians",
+        ":contact_permutation",
         ":contact_results",
         ":contact_results_to_meshcat",
         ":contact_results_to_meshcat_params",
@@ -312,6 +313,15 @@ drake_cc_library(
     hdrs = ["propeller.h"],
     deps = [
         ":multibody_plant_core",
+    ],
+)
+
+drake_cc_library(
+    name = "contact_permutation",
+    srcs = ["contact_permutation.cc"],
+    hdrs = ["contact_permutation.h"],
+    deps = [
+        "//multibody/tree:multibody_tree_topology",
     ],
 )
 
@@ -780,6 +790,22 @@ drake_cc_googletest(
         "//common/test_utilities:expect_throws_message",
         "//systems/analysis:simulator",
         "//systems/framework:abstract_value_cloner",
+    ],
+)
+
+drake_cc_googletest(
+    name = "contact_permutation_test",
+    data = [
+        "//examples/kuka_iiwa_arm/models",
+        "//examples/simple_gripper:simple_gripper_models",
+        "//manipulation/models/allegro_hand_description:models",
+        "//manipulation/models/iiwa_description:models",
+    ],
+    deps = [
+        ":contact_permutation",
+        ":plant",
+        "//common:find_resource",
+        "//multibody/parsing",
     ],
 )
 

--- a/multibody/plant/contact_permutation.cc
+++ b/multibody/plant/contact_permutation.cc
@@ -1,0 +1,78 @@
+#include "drake/multibody/plant/contact_permutation.h"
+
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/multibody/tree/multibody_tree_topology.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Helper to deep traverse a tree from its base at base_node_index.
+void TreeDepthFirstTraversal(const MultibodyTreeTopology& tree_topology,
+                             BodyNodeIndex base_node_index,
+                             std::vector<int>* tree_velocity_permutation,
+                             std::vector<BodyIndex>* tree_bodies) {
+  const BodyNodeTopology& node = tree_topology.get_body_node(base_node_index);
+  tree_bodies->push_back(node.body);
+
+  for (BodyNodeIndex child_index : node.child_nodes) {
+    TreeDepthFirstTraversal(tree_topology, child_index,
+                            tree_velocity_permutation, tree_bodies);
+  }
+
+  // Push the velocity indexes for this node.
+  for (int i = 0; i < node.num_mobilizer_velocities; ++i) {
+    const int m = node.mobilizer_velocities_start_in_v + i;
+    tree_velocity_permutation->push_back(m);
+  }
+}
+
+// Recall, v = velocity_permutation[t][vt]
+// where:
+//   t: tree index.
+//   vt: local velocity index in tree t with DFS order.
+//   v: original velocity index in tree_topology.
+// and t = body_to_tree_map[body_index]. t < 0 if body_index
+// is anchored to the world. Therefore body_to_tree_map[0] < 0 always.
+void ComputeDfsPermutation(const MultibodyTreeTopology& tree_topology,
+                           std::vector<std::vector<int>>* velocity_permutation,
+                           std::vector<int>* body_to_tree_map) {
+  DRAKE_DEMAND(velocity_permutation != nullptr);
+  DRAKE_DEMAND(body_to_tree_map != nullptr);
+
+  velocity_permutation->clear();
+  body_to_tree_map->clear();
+
+  const BodyNodeTopology& world_node =
+      tree_topology.get_body_node(BodyNodeIndex(0));
+
+  // Invalid (negative) index for the world. It does not belong to any tree in
+  // particular, but it's the "floor" of the forest. Also any "tree" that is
+  // anchored to the world is labeled with -1.
+  body_to_tree_map->resize(tree_topology.num_bodies(), -1);
+
+  // We deep traverse one tree at a time.
+  for (BodyNodeIndex base_index : world_node.child_nodes) {
+    // Bodies of the tree with base_index at the base.
+    std::vector<BodyIndex> tree_bodies;
+    // The permutation for the tree with base_index at its base.
+    std::vector<int> tree_permutation;
+    TreeDepthFirstTraversal(tree_topology, base_index, &tree_permutation,
+                            &tree_bodies);
+    const int tree_num_velocities = tree_permutation.size();
+    // Trees with zero dofs are not considered.
+    if (tree_num_velocities != 0) {
+      const int t = velocity_permutation->size();
+      velocity_permutation->push_back(tree_permutation);
+      for (BodyIndex body_index : tree_bodies) {
+        (*body_to_tree_map)[body_index] = t;
+      }
+    }
+  }
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/contact_permutation.h
+++ b/multibody/plant/contact_permutation.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/multibody/tree/multibody_tree_topology.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Computes a permutation to go from velocities in the order specified by
+// `tree_topology` (currently BFS order) to DFS order, so that all dofs for a
+// tree are contiguous.
+//
+// This new ordering depicts the mental model of a "forest of trees" topology.
+// Each tree in this forest has a base body which is a direct child of the world
+// body. Trees are assigned arbitrary contiguous positive indices.
+// In this picture, the world body is the "ground" of this forest and is not
+// assigned to any particular tree. Therefore the "ground" is identified with an
+// invalid, negative, tree index. Any other bodies or entire kinematic trees
+// that are anchored to the world are also assigned a negative index. That is,
+// only trees with non-zero dofs are assigned a positive tree index. Refer to
+// contact_permutation_test.cc for worked examples illustrating these
+// properties.
+//
+// The permutation is a bijection, i.e. there is a one-to-one correspondence
+// between the original dofs ordering in `tree_toplogy` and the new DFS
+// ordering.
+//
+// For each velocity dof with index v in tree_topology, the new permutation will
+// assign a dof with index vt within a tree with index t. A tree will have nt
+// dofs in total, and therefore dofs vt for t will be in the range [0, nt-1].
+//
+// NOTE: We use a "reverse" DFS order (that is, deeper dofs are first)
+// since for complex tree structures with a free floating base (consider the
+// Allegro hand for instance) the mass matrix will have an arrow sparsity
+// pattern (pointing to the bottom right). With a traditional DFS ordering we
+// also get an arrow pattern, but pointing to the upper left. The distinction
+// here is when performing Cholesky on the resulting mass matrix. In principle,
+// the two matrices above (with "forward" and "reverse" DFS order) have the same
+// underlying sparsity pattern and the choice of ordering does not hinder our
+// ability to exploit it. However if we wanted to use a general purpose sparse
+// Cholesky with no reordering (as we'd do for prototyping or even to avoid the
+// overhead of computing the permutation), the Cholesky factorization of the
+// mass matrix with reverse DFS proceeds without fill-in (that is, zero entries
+// in the mass matrix remain zero in the Cholesky factor). Ideally, we'd write
+// custom factorizations that exploit branch-induced sparsity but using this
+// ordering allow us to get away without this special purpose code using general
+// purpose sparse algebra. For more on this interesting subject refer to
+// [Featherstone, 2005].
+//
+// NOTE: There are multiple DFS numbering of dofs for the same topology
+// depending on the order branches are traversed. They all describe the same
+// topology and they all lead to zero fill-in. For convenience and speed, this
+// method simply traverses branches in tree_topology in the order they are
+// loaded for each node of the tree, see BodyNodeTopology::child_nodes.
+//
+// - [Featherstone, 2005] Featherstone, R., 2005. Efficient factorization of the
+//   joint-space inertia matrix for branched kinematic trees. The International
+//   Journal of Robotics Research, 24(6), pp.487-500.
+//
+// @param[in] tree_topology The topology of our multibody model. There is no
+//   requiremnt on the specific ordering, though currently it uses a BFS
+//   ordering.
+// @param[out] velocity_permutation
+//   The permutation is built such that dof vt of tree t maps to dof
+//   v = velocity_permutation[t][vt] in the original tree_topology.
+//   Valid vt indexes are in the range [0, nt-1], with nt =
+//   velocity_permutation[t].size(), the number of dofs for tree with index t.
+//   The total number of trees is given by velocity_permutation.size().
+//   The mapping is a bijection, and therefore each and every dof v in
+//   tree_topology is mapped by a dof vt in its tree t.
+//   Summarizing.
+//     v = velocity_permutation[t][vt]
+//   where:
+//     t: tree index.
+//     vt: local velocity index in tree t with DFS order.
+//     v: original velocity index in tree_topology.
+// @param[out] body_to_tree_map
+//   This map stores what tree each body belongs to. It is built such that
+//   t = body_to_tree_map[body_index] is the tree to which body_index belongs.
+//   t < 0 if body_index is anchored to the world. body_to_tree_map[0] < 0
+//   always since body_index = 0 corresponds to the world body.
+void ComputeDfsPermutation(
+    const MultibodyTreeTopology& tree_topology,
+    std::vector<std::vector<int>>* velocity_permutation,
+    std::vector<int>* body_to_tree_map);
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/contact_permutation_test.cc
+++ b/multibody/plant/test/contact_permutation_test.cc
@@ -1,0 +1,338 @@
+#include "drake/multibody/plant/contact_permutation.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
+
+using drake::math::RigidTransform;
+using drake::math::RigidTransformd;
+using Eigen::Vector3d;
+
+namespace drake {
+namespace multibody {
+
+// Builds a complex enough model leading to a forest topology with four trees.
+// The model consists of two Kuka arms mounted on top of a robot table. A second
+// table is used for objects. The model also includes two free floating mug
+// models.
+// A few things to notice about this model:
+// 1. We add each component of the model in a rather arbitrary, probably not
+//    common order. That is, we add a robot then a mug, followed by a robot and
+//    yet another mug. Instead of adding all robots first followed by objects.
+//    We do this intentionally to "mix" the dofs and make the unit test more
+//    interesting.
+// 2. The two robots are directly welded to the world rather than to the table,
+//    as it'd be in real life. Though equivalent, this leads to two tables
+//    anchored to the world. We want to test these do not show up in our
+//    permutation since they are not even considered part of a "tree".
+void AddScenarioWithTwoArms(MultibodyPlant<double>* plant) {
+  DRAKE_DEMAND(!plant->is_finalized());
+
+  const std::string iiwa_sdf_path = FindResourceOrThrow(
+      "drake/manipulation/models/iiwa_description/sdf/"
+      "iiwa14_no_collision.sdf");
+
+  const std::string table_sdf_path = FindResourceOrThrow(
+      "drake/examples/kuka_iiwa_arm/models/table/"
+      "extra_heavy_duty_table_surface_only_collision.sdf");
+
+  const std::string mug_sdf_path =
+      FindResourceOrThrow("drake/examples/simple_gripper/simple_mug.sdf");
+
+  // Load a model of a table for the robot.
+  Parser parser(&*plant);
+  const ModelInstanceIndex robot_table_model =
+      parser.AddModelFromFile(table_sdf_path, "robot_table");
+  plant->WeldFrames(plant->world_frame(),
+                    plant->GetFrameByName("link", robot_table_model));
+
+  // Load the robot and weld it on top of the robot table.
+  const ModelInstanceIndex arm1_model =
+      parser.AddModelFromFile(iiwa_sdf_path, "robot1");
+
+  // Add a floating mug.
+  parser.AddModelFromFile(mug_sdf_path, "mug1");
+
+  const ModelInstanceIndex arm2_model =
+      parser.AddModelFromFile(iiwa_sdf_path, "robot2");
+
+  // Add a second floating mug.
+  parser.AddModelFromFile(mug_sdf_path, "mug2");
+
+  // Though only the topology is important for this test, we place the robot
+  // somewhere reasonble on top of the robot table.
+  const double table_top_z_in_world =
+      // table's top height
+      0.736 +
+      // table's top width
+      0.057 / 2;
+  const RigidTransformd X_WRobot1Link0(
+      Vector3d(0.0, 0.0, table_top_z_in_world));
+  plant->WeldFrames(plant->world_frame(),
+                    plant->GetFrameByName("iiwa_link_0", arm1_model),
+                    X_WRobot1Link0);
+
+  // Second arm.
+  const RigidTransformd X_WRobot2Link0(
+      Vector3d(0.5, 0.0, table_top_z_in_world));
+  plant->WeldFrames(plant->world_frame(),
+                    plant->GetFrameByName("iiwa_link_0", arm2_model),
+                    X_WRobot2Link0);
+
+  // Load a second table for objects.
+  const ModelInstanceIndex objects_table_model =
+      parser.AddModelFromFile(table_sdf_path, "objects_table");
+  const RigidTransformd X_WT(Vector3d(0.8, 0.0, 0.0));
+  plant->WeldFrames(plant->world_frame(),
+                    plant->GetFrameByName("link", objects_table_model), X_WT);
+
+  plant->Finalize();
+}
+
+int VerifyModelInstanceIsATreeAndReturnTreeIndex(
+    const MultibodyPlant<double>& plant, const std::string& model_instance_name,
+    const std::vector<int>& body_to_tree_map) {
+  const std::vector<BodyIndex> model_bodies =
+      plant.GetBodyIndices(plant.GetModelInstanceByName(model_instance_name));
+  DRAKE_DEMAND(model_bodies.size() > 0);
+  // For the purpose of these tests, verify the entire model instance belongs to
+  // the same tree.
+  const int t = body_to_tree_map[model_bodies[0]];  // tree for the first body.
+  for (const BodyIndex& body_index : model_bodies) {
+    EXPECT_EQ(body_to_tree_map[body_index], t);
+  }
+  return t;
+}
+
+void VerifyDofsWhenModelInstanceIsATree(
+    const MultibodyPlant<double>& plant, const std::string& model_instance_name,
+    const std::vector<std::string>& joint_names,
+    const std::vector<int>& tree_permutation, bool is_floating = false) {
+  const ModelInstanceIndex model_instance =
+      plant.GetModelInstanceByName(model_instance_name);
+  const int nt = tree_permutation.size();
+  if (is_floating) {
+    // We expect 1 dof per joint + the floating base.
+    EXPECT_EQ(tree_permutation.size(), joint_names.size() + 6);
+
+    const auto& base_body = plant.GetUniqueFreeBaseBodyOrThrow(model_instance);
+    const int nq = plant.num_positions();
+    for (int i = 0; i < 6; ++i) {
+      // Dof index for a vector of velocities, therefore we subtract nq.
+      const int v = base_body.floating_velocities_start() + i - nq;
+      // N.B. Since we use a "reverse DFS order", the six dofs of a floating
+      // base will always be at the end of a tree's dofs.
+      EXPECT_EQ(tree_permutation[nt - 6 + i], v);
+    }
+
+  } else {
+    // In these tests we expect one dof per joint.
+    EXPECT_EQ(tree_permutation.size(), joint_names.size());
+  }
+
+  for (size_t i = 0; i < joint_names.size(); ++i) {
+    const auto& joint = plant.GetJointByName(joint_names[i], model_instance);
+    // Here we are implicitly assuming 1 dof per joint. Verify this.
+    ASSERT_EQ(joint.num_velocities(), 1);
+    // Verify dof.
+    EXPECT_EQ(tree_permutation[i], joint.velocity_start());
+  }
+}
+
+class MultibodyPlantTester {
+ public:
+  MultibodyPlantTester() = delete;
+  static const internal::MultibodyTreeTopology& get_topology(
+      const MultibodyPlant<double>& plant) {
+    DRAKE_DEMAND(plant.is_finalized());
+    return plant.internal_tree().get_topology();
+  }
+};
+
+namespace {
+
+GTEST_TEST(DofsPermutation, VelocitiesPermutation) {
+  MultibodyPlant<double> plant(0.0);
+  AddScenarioWithTwoArms(&plant);
+  // Two 7 dofs arms + two 6 dofs free bodies.
+  EXPECT_EQ(plant.num_velocities(), 26);
+
+  std::vector<std::vector<int>> velocity_permutation;
+  std::vector<int> body_to_tree_map;
+
+  const internal::MultibodyTreeTopology& topology =
+      MultibodyPlantTester::get_topology(plant);
+  drake::multibody::internal::ComputeDfsPermutation(
+      topology, &velocity_permutation, &body_to_tree_map);
+  // We expect four trees in the forest.
+  EXPECT_EQ(velocity_permutation.size(), 4);
+
+  // The permutation is a bijection. Verify the number of permuted dofs matches
+  // the total number of velocities in the model.
+  const int num_permuted_dofs =
+      std::accumulate(velocity_permutation.begin(), velocity_permutation.end(),
+                      0, [](int current, const std::vector<int>& tperm) {
+                        return current + tperm.size();
+                      });
+  EXPECT_EQ(num_permuted_dofs, plant.num_velocities());
+
+  // The world body does not belong to any tree.
+  EXPECT_LT(body_to_tree_map[0], 0);
+
+  // We form a vector of joint names in the order we expect them to be in
+  // (reversed) DFS order.
+  std::vector<std::string> joint_names = {
+      "iiwa_joint_7", "iiwa_joint_6", "iiwa_joint_5", "iiwa_joint_4",
+      "iiwa_joint_3", "iiwa_joint_2", "iiwa_joint_1"};
+
+  // Verify permutation for robot1.
+  const int robot1_tree = VerifyModelInstanceIsATreeAndReturnTreeIndex(
+      plant, "robot1", body_to_tree_map);
+  ASSERT_GE(robot1_tree, 0);  // non-zero dofs tree.
+  VerifyDofsWhenModelInstanceIsATree(plant, "robot1", joint_names,
+                                     velocity_permutation[robot1_tree]);
+
+  // Verify permutation for robot2.
+  const int robot2_tree = VerifyModelInstanceIsATreeAndReturnTreeIndex(
+      plant, "robot2", body_to_tree_map);
+  ASSERT_GE(robot2_tree, 0);  // non-zero dofs tree.
+  VerifyDofsWhenModelInstanceIsATree(plant, "robot2", joint_names,
+                                     velocity_permutation[robot2_tree]);
+
+  // We expect anchored models to have a negative tree index.
+  const int robot_table = VerifyModelInstanceIsATreeAndReturnTreeIndex(
+      plant, "robot_table", body_to_tree_map);
+  EXPECT_LT(robot_table, 0);  // zero dofs tree.
+  const int objects_table = VerifyModelInstanceIsATreeAndReturnTreeIndex(
+      plant, "objects_table", body_to_tree_map);
+  EXPECT_LT(objects_table, 0);  // zero dofs tree.
+
+  // Verify permutation for mug1.
+  const int mug1_tree = VerifyModelInstanceIsATreeAndReturnTreeIndex(
+      plant, "mug1", body_to_tree_map);
+  ASSERT_GE(mug1_tree, 0);  // non-zero dofs tree.
+  VerifyDofsWhenModelInstanceIsATree(plant, "mug1", {},
+                                     velocity_permutation[mug1_tree], true);
+
+  // Verify permutation for mug2.
+  const int mug2_tree = VerifyModelInstanceIsATreeAndReturnTreeIndex(
+      plant, "mug2", body_to_tree_map);
+  ASSERT_GE(mug2_tree, 0);  // non-zero dofs tree.
+  VerifyDofsWhenModelInstanceIsATree(plant, "mug2", {},
+                                     velocity_permutation[mug2_tree], true);
+}
+
+GTEST_TEST(DofsPermutation, AllegroHands) {
+  const std::string right_hand_model_path = FindResourceOrThrow(
+      "drake/manipulation/models/"
+      "allegro_hand_description/sdf/allegro_hand_description_right.sdf");
+
+  const std::string left_hand_model_path = FindResourceOrThrow(
+      "drake/manipulation/models/"
+      "allegro_hand_description/sdf/allegro_hand_description_left.sdf");
+
+  MultibodyPlant<double> plant(0);
+  Parser parser(&plant);
+  parser.AddModelFromFile(right_hand_model_path, "right hand");
+  const ModelInstanceIndex left_hand =
+      parser.AddModelFromFile(left_hand_model_path, "left hand");
+
+  // We weld the left hand to the world while the right hand is free.
+  plant.WeldFrames(plant.world_frame(),
+                   plant.GetFrameByName("hand_root", left_hand));
+  plant.Finalize();
+
+  // Compute BFS to DFS permutation.
+  std::vector<std::vector<int>> velocity_permutation;
+  std::vector<int> body_to_tree_map;
+  const internal::MultibodyTreeTopology& topology =
+      MultibodyPlantTester::get_topology(plant);
+  drake::multibody::internal::ComputeDfsPermutation(
+      topology, &velocity_permutation, &body_to_tree_map);
+
+  // We expect two trees in the forest, one for each hand.
+  EXPECT_EQ(velocity_permutation.size(), 2);
+
+  // The permutation is bijective. Verify the number of permuted dofs matches
+  // the total number of velocities in the model.
+  const int num_permuted_dofs =
+      velocity_permutation[0].size() + velocity_permutation[1].size();
+  EXPECT_EQ(num_permuted_dofs, plant.num_velocities());
+
+  // The world body does not belong to any tree.
+  EXPECT_LT(body_to_tree_map[0], 0);
+
+  // N.B. The order in which specific fingers show in the model depends on how
+  // the model was constructed. This ultimately has to do with the specific
+  // order given in the original SDF file. Therefore the ordering of the names
+  // in this test must be kept in sync with the original SDF file model.
+  std::vector<std::string> left_hand_joint_names;
+  // Ring finger
+  left_hand_joint_names.push_back("joint_11");
+  left_hand_joint_names.push_back("joint_10");
+  left_hand_joint_names.push_back("joint_9");
+  left_hand_joint_names.push_back("joint_8");
+
+  // Thumb finger
+  left_hand_joint_names.push_back("joint_15");
+  left_hand_joint_names.push_back("joint_14");
+  left_hand_joint_names.push_back("joint_13");
+  left_hand_joint_names.push_back("joint_12");
+
+  // Middle finger
+  left_hand_joint_names.push_back("joint_7");
+  left_hand_joint_names.push_back("joint_6");
+  left_hand_joint_names.push_back("joint_5");
+  left_hand_joint_names.push_back("joint_4");
+
+  // Index finger
+  left_hand_joint_names.push_back("joint_3");
+  left_hand_joint_names.push_back("joint_2");
+  left_hand_joint_names.push_back("joint_1");
+  left_hand_joint_names.push_back("joint_0");
+
+  std::vector<std::string> right_hand_joint_names;
+  // Index finger
+  right_hand_joint_names.push_back("joint_3");
+  right_hand_joint_names.push_back("joint_2");
+  right_hand_joint_names.push_back("joint_1");
+  right_hand_joint_names.push_back("joint_0");
+
+  // Thumb finger
+  right_hand_joint_names.push_back("joint_15");
+  right_hand_joint_names.push_back("joint_14");
+  right_hand_joint_names.push_back("joint_13");
+  right_hand_joint_names.push_back("joint_12");
+
+  // Middle finger
+  right_hand_joint_names.push_back("joint_7");
+  right_hand_joint_names.push_back("joint_6");
+  right_hand_joint_names.push_back("joint_5");
+  right_hand_joint_names.push_back("joint_4");
+
+  // Ring finger
+  right_hand_joint_names.push_back("joint_11");
+  right_hand_joint_names.push_back("joint_10");
+  right_hand_joint_names.push_back("joint_9");
+  right_hand_joint_names.push_back("joint_8");
+
+  // Verify permutation for the left hand.
+  const int left_hand_tree = VerifyModelInstanceIsATreeAndReturnTreeIndex(
+      plant, "left hand", body_to_tree_map);
+  VerifyDofsWhenModelInstanceIsATree(plant, "left hand", left_hand_joint_names,
+                                     velocity_permutation[left_hand_tree]);
+
+  // Verify permutation for the right hand. The right hand is floating.
+  const int right_hand_tree = VerifyModelInstanceIsATreeAndReturnTreeIndex(
+      plant, "right hand", body_to_tree_map);
+  VerifyDofsWhenModelInstanceIsATree(
+      plant, "right hand", right_hand_joint_names,
+      velocity_permutation[right_hand_tree], true);
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
+++ b/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
@@ -184,10 +184,10 @@ GTEST_TEST(MultibodyPlantForwardDynamics, AtlasRobot) {
   // Verify that the implicit dynamics match the continuous ones.
   Eigen::VectorXd residual = plant.AllocateImplicitTimeDerivativesResidual();
   plant.CalcImplicitTimeDerivativesResidual(*context, *derivatives, &residual);
-  // Note the slightly looser tolerance of 4e-13 which was required for this
+  // Note the slightly looser tolerance of 2e-13 which was required for this
   // test.
   EXPECT_TRUE(CompareMatrices(
-      residual, Eigen::VectorXd::Zero(plant.num_multibody_states()), 4e-13));
+      residual, Eigen::VectorXd::Zero(plant.num_multibody_states()), 2e-13));
 }
 
 // Verifies we can do forward dynamics on a model with a zero-sized state.

--- a/multibody/plant/test/multibody_plant_introspection_test.cc
+++ b/multibody/plant/test/multibody_plant_introspection_test.cc
@@ -120,24 +120,15 @@ GTEST_TEST(MultibodyPlantIntrospection, FloatingBodies) {
   EXPECT_EQ(expected_floating_bodies, floating_bodies);
 
   // Verify state indexes for free bodies.
-  // N.B. This test assumes DOFs are in a depth-first-traversal order with
-  // mobilities assigned in the order mobilizers were added to the model. In
-  // addition, we use our internal knowledge that free floating mobilizers are
-  // assigned in the order bodies were added to the model. This assumption
-  // implies that DOFs for the first tree are first, followed by DOFs for the
-  // second tree, etc.
-  const int atlas_nq = plant.num_positions(atlas_model1);
-  const std::unordered_set<int> expected_floating_positions_start(
-      {0, atlas_nq, 2 * atlas_nq});
+  const std::unordered_set<int> expected_floating_positions_start({0, 7, 14});
   const std::unordered_set<int> floating_positions_start(
       {pelvis1.floating_positions_start(), pelvis2.floating_positions_start(),
        mug.floating_positions_start()});
   EXPECT_EQ(floating_positions_start, expected_floating_positions_start);
 
   const int nq = plant.num_positions();
-  const int atlas_nv = plant.num_velocities(atlas_model1);
   const std::unordered_set<int> expected_floating_velocities_start(
-      {nq, nq + atlas_nv, nq + 2 * atlas_nv});
+      {nq, nq + 6, nq + 12});
   const std::unordered_set<int> floating_velocities_start(
       {pelvis1.floating_velocities_start(), pelvis2.floating_velocities_start(),
        mug.floating_velocities_start()});

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -3053,17 +3053,12 @@ GTEST_TEST(StateSelection, KukaWithSimpleGripper) {
   Su_arm_expected(2, 2) = 1;  // Actuator on third joint, iiwa_joint_3.
   EXPECT_EQ(Su_arm, Su_arm_expected);
 
-  const auto& left_finger_sliding_joint =
-      plant.GetJointByName("left_finger_sliding_joint");
-  const auto& right_finger_sliding_joint =
-      plant.GetJointByName("right_finger_sliding_joint");
-
   // We build a state selector for the gripper dofs.
   std::vector<JointIndex> gripper_selected_joints;
-  gripper_selected_joints.push_back(
-      left_finger_sliding_joint.index());  // user index = 0.
-  gripper_selected_joints.push_back(
-      right_finger_sliding_joint.index());  // user index = 1.
+  gripper_selected_joints.push_back(plant.GetJointByName(
+      "left_finger_sliding_joint").index());  // user index = 0.
+  gripper_selected_joints.push_back(plant.GetJointByName(
+      "right_finger_sliding_joint").index());  // user index = 1.
 
   // State selector for the griper.
   const MatrixX<double> Sx_gripper =
@@ -3077,15 +3072,13 @@ GTEST_TEST(StateSelection, KukaWithSimpleGripper) {
   MatrixX<double> Sx_gripper_expected =
       MatrixX<double>::Zero(4, plant.num_multibody_states());
   // first joint position, left finger.
-  Sx_gripper_expected(0, left_finger_sliding_joint.position_start()) = 1;
+  Sx_gripper_expected(0, num_floating_positions + 7) = 1;
   // second joint position, right finger.
-  Sx_gripper_expected(1, right_finger_sliding_joint.position_start()) = 1;
+  Sx_gripper_expected(1, num_floating_positions + 8) = 1;
   // first joint velocity, left finger.
-  Sx_gripper_expected(2, plant.num_positions() +
-                             left_finger_sliding_joint.velocity_start()) = 1;
+  Sx_gripper_expected(2, num_floating_velocities + nq + 7) = 1;
   // second joint velocity, right finger.
-  Sx_gripper_expected(3, plant.num_positions() +
-                             right_finger_sliding_joint.velocity_start()) = 1;
+  Sx_gripper_expected(3, num_floating_velocities + nq + 8) = 1;
   EXPECT_EQ(Sx_gripper, Sx_gripper_expected);
 
   // Verify the grippers's actuation selector.
@@ -3127,21 +3120,14 @@ GTEST_TEST(StateSelection, KukaWithSimpleGripper) {
   ASSERT_EQ(B.rows(), nv);
   ASSERT_EQ(B.cols(), nu);
   MatrixX<double> B_expected = MatrixX<double>::Zero(nv, nu);
-
-  // Fill in the block for the IIWA's actuators.
-  auto B_iiwa = B_expected.block(6 /* skip floating base */, 0,
-                                 7 /* iiwa joints */, 7 /* iiwa actuators */);
+  auto B_iiwa = B_expected.block(
+      6 /* skip floating base */, 0,
+      7 /* iiwa joints */, 7 /* iiwa actuators */);
+  auto B_wsg = B_expected.block(
+      13 /* skip iiwa dofs */, 7 /* skip iiwa actuators */,
+      2 /* wsg joints */, 2 /* wsg actuators */);
   B_iiwa.setIdentity();
-
-  // Fill in the block for the gripper's actuators.
-  const auto& left_finger_actuator =
-      plant.GetJointActuatorByName("left_finger_sliding_joint");
-  const auto& right_finger_actuator =
-      plant.GetJointActuatorByName("right_finger_sliding_joint");
-  B_expected(left_finger_actuator.joint().velocity_start(),
-             left_finger_actuator.index()) = 1;
-  B_expected(right_finger_actuator.joint().velocity_start(),
-             right_finger_actuator.index()) = 1;
+  B_wsg.setIdentity();
   EXPECT_TRUE(CompareMatrices(B, B_expected, 0.0, MatrixCompareType::absolute));
 
   // Test old spellings.

--- a/multibody/tree/acceleration_kinematics_cache.h
+++ b/multibody/tree/acceleration_kinematics_cache.h
@@ -91,7 +91,7 @@ class AccelerationKinematicsCache {
 
  private:
   // Pools store entries in the same order that multibody tree nodes are
-  // ordered in the tree, i.e. in DFT (Depth-First Traversal) order. Therefore
+  // ordered in the tree, i.e. in BFT (Breadth-First Traversal) order. Therefore
   // clients of this class will access entries by BodyNodeIndex, see
   // `get_A_WB()` for instance.
 

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -631,7 +631,7 @@ void MultibodyTree<T>::FinalizeInternals() {
 
   // Creates BodyNode's:
   // This recursion order ensures that a BodyNode's parent is created before the
-  // node itself, since BodyNode objects are in Depth First Traversal order.
+  // node itself, since BodyNode objects are in Breadth First Traversal order.
   for (BodyNodeIndex body_node_index(0);
        body_node_index < topology_.get_num_body_nodes(); ++body_node_index) {
     CreateBodyNode(body_node_index);

--- a/multibody/tree/multibody_tree_topology.h
+++ b/multibody/tree/multibody_tree_topology.h
@@ -22,8 +22,8 @@
 ///   topology can be validated against the stored topology in debug builds.
 
 #include <algorithm>
+#include <queue>
 #include <set>
-#include <stack>
 #include <string>
 #include <utility>
 #include <vector>
@@ -88,9 +88,7 @@ struct BodyTopology {
   BodyIndex parent_body{};
 
   // Within the tree structure of a MultibodyTree, the immediate outboard (or
-  // "child") bodies to this Body. Bodies appear in child_bodies in the order
-  // mobilizers were added to the model, with
-  // MultibodyTreeTopology::add_mobilizer().
+  // "child") bodies to this Body.
   std::vector<BodyIndex> child_bodies;
 
   // Unique index to the frame associated with this body.
@@ -716,7 +714,7 @@ class MultibodyTreeTopology {
   // performs all the required pre-processing to perform computations at a
   // later stage. This preprocessing includes:
   //
-  // - sorting in DFT order for fast recursions through the tree,
+  // - sorting in BFT order for fast recursions through the tree,
   // - computation of state sizes and of pool sizes within cache entries,
   // - computation of index maps to retrieve either state or cache entries for
   //   each multibody element.
@@ -737,14 +735,17 @@ class MultibodyTreeTopology {
           "finalized MultibodyTree.");
     }
 
-    // For each body, assign a body node in a depth first traversal order.
-    std::stack<BodyIndex> stack;
-    stack.push(BodyIndex(0));  // Starts at the root.
+    // Compute body levels in the tree. Root is the zero level.
+    // Breadth First Traversal (a.k.a. Level Order Traversal).
+    std::queue<BodyIndex> queue;
+    queue.push(BodyIndex(0));  // Starts at the root.
     tree_height_ = 1;  // At least one level with the world body at the root.
+    // While at it, create body nodes and index them in this BFT order for
+    // fast tree traversals of MultibodyTree recursive algorithms.
     body_nodes_.reserve(num_bodies());
-    while (!stack.empty()) {
+    while (!queue.empty()) {
       const BodyNodeIndex node(get_num_body_nodes());
-      const BodyIndex current = stack.top();
+      const BodyIndex current = queue.front();
       const BodyIndex parent = bodies_[current].parent_body;
 
       bodies_[current].body_node = node;
@@ -761,7 +762,7 @@ class MultibodyTreeTopology {
       // Keep track of the number of levels, the deepest (i.e. max) level.
       tree_height_ = std::max(tree_height_, level + 1);
 
-      // Since we are doing a DFT, it is valid to ask for the parent node,
+      // Since we are doing a BFT, it is valid to ask for the parent node,
       // unless we are at the root.
       BodyNodeIndex parent_node;
       if (node != 0) {  // If we are not at the root:
@@ -777,18 +778,11 @@ class MultibodyTreeTopology {
           bodies_[current].parent_body       /* This node's parent body */,
           bodies_[current].inboard_mobilizer /* This node's mobilizer */);
 
-      // We process bodies in the order they were added to the vector of child
-      // bodies; this vector is filled in the order mobilizers are added to the
-      // model. Therefore, when a given node branches out, we spawn branches in
-      // the order mobilizers that connect this node to its children were added.
-      // Since we are using a stack to store bodies that will be processed next,
-      // we must place bodies in reverse order so that the first child is at the
-      // top of the stack.
-      stack.pop();  // Pops top element.
-      for (auto it = bodies_[current].child_bodies.rbegin();
-           it != bodies_[current].child_bodies.rend(); ++it) {
-        stack.push(*it);
+      // Pushes children to the back of the queue and pops current.
+      for (BodyIndex child : bodies_[current].child_bodies) {
+        queue.push(child);  // Pushes at the back.
       }
+      queue.pop();  // Pops front element.
     }
 
     // Checks that all bodies were reached. We could have this situation if a
@@ -814,7 +808,7 @@ class MultibodyTreeTopology {
     //
     // TODO(amcastro-tri): count body dofs (i.e. for flexible dofs).
     //
-    // Base-to-Tip loop in DFT order, skipping the world (node = 0).
+    // Base-to-Tip loop in BFT order, skipping the world (node = 0).
 
     // Count number of generalized positions and velocities.
     num_positions_ = 0;

--- a/multibody/tree/position_kinematics_cache.h
+++ b/multibody/tree/position_kinematics_cache.h
@@ -125,7 +125,7 @@ class PositionKinematicsCache {
  private:
   // Pool types:
   // Pools store entries in the same order multibody tree nodes are
-  // ordered in the tree, i.e. in DFT (Depth-First Traversal) order. Therefore
+  // ordered in the tree, i.e. in BFT (Breadth-First Traversal) order. Therefore
   // clients of this class will access entries by BodyNodeIndex, see
   // `get_X_WB()` for instance.
 

--- a/multibody/tree/test/model_instance_test.cc
+++ b/multibody/tree/test/model_instance_test.cc
@@ -75,20 +75,12 @@ GTEST_TEST(ModelInstance, ModelInstanceTest) {
                               Vector1d(3)));
   EXPECT_TRUE(CompareMatrices(act_vector, Eigen::Vector3d(1, 2, 3)));
 
-  // N.B. These tests assume a specific ordering of the state. Each body in the
-  // model has an associated mobility. Mobilities are numbered in the order
-  // mobilizers are added. For this simple model MultibodyTree adds mobilizers
-  // for each joint in the order joints were added. Free floating mobilizers are
-  // added last at Finalize(). This implies that DOFs for the first tree are
-  // first, followed by DOFs of the second tree, etc.
-
   Eigen::VectorXd pos_vector(10);
   pos_vector << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10;
 
-  // DOFs for instance1 correspond to those DOFs in the first tree.
   Eigen::VectorXd instance1_pos =
       tree.GetPositionsFromArray(instance1, pos_vector);
-  EXPECT_TRUE(CompareMatrices(instance1_pos, Eigen::Vector2d(1, 2)));
+  EXPECT_TRUE(CompareMatrices(instance1_pos, Eigen::Vector2d(8, 10)));
 
   // Change the positions for this instance and check again.
   const Eigen::Vector2d new_pos(21, 23);
@@ -100,7 +92,7 @@ GTEST_TEST(ModelInstance, ModelInstanceTest) {
       tree.GetPositionsFromArray(instance2, pos_vector);
 
   Eigen::VectorXd instance2_pos_expected(8);
-  instance2_pos_expected << 3, 4, 5, 6, 7, 8, 9, 10;
+  instance2_pos_expected << 1, 2, 3, 4, 5, 6, 7, 9;
   EXPECT_TRUE(CompareMatrices(instance2_pos, instance2_pos_expected));
 
   Eigen::VectorXd vel_vector(9);
@@ -108,7 +100,7 @@ GTEST_TEST(ModelInstance, ModelInstanceTest) {
 
   Eigen::VectorXd instance1_vel =
       tree.GetVelocitiesFromArray(instance1, vel_vector);
-  EXPECT_TRUE(CompareMatrices(instance1_vel, Eigen::Vector2d(11, 12)));
+  EXPECT_TRUE(CompareMatrices(instance1_vel, Eigen::Vector2d(17, 19)));
 
   // Change the velocities for this instance and check again.
   const Eigen::Vector2d new_vel(29, 31);
@@ -119,7 +111,7 @@ GTEST_TEST(ModelInstance, ModelInstanceTest) {
   Eigen::VectorXd instance2_vel =
       tree.GetVelocitiesFromArray(instance2, vel_vector);
   Eigen::VectorXd instance2_vel_expected(7);
-  instance2_vel_expected << 13, 14, 15, 16, 17, 18, 19;
+  instance2_vel_expected << 11, 12, 13, 14, 15, 16, 18;
   EXPECT_TRUE(CompareMatrices(instance2_vel, instance2_vel_expected));
 
   // Create a MultibodyTreeSystem so that we can get a context.

--- a/multibody/tree/test/multibody_tree_creation_test.cc
+++ b/multibody/tree/test/multibody_tree_creation_test.cc
@@ -216,32 +216,35 @@ GTEST_TEST(MultibodyTree, MultibodyElementChecks) {
 // mobilizer index (assigned by MultibodyTree in the order mobilizers are
 // created).
 // At Finalize(), a body node is created per (body, inboard_mobilizer) pair.
-// Body node indexes, shown in parentheses, are assigned in DFT order. In
-// addition, we know that internal::MultibodyTreeTopology assigns body nodes to
-// each branch in the order mobilizers are added. For instance, in the schematic
-// below, node (1) is created before node (2) because mobilizer m2 was added
-// before m4. Similarly, node (5) is created before (6) because mobilizer m1 was
-// added before m5.
+// Body node indexes are assigned according to a BFT order.
+// Tests below make reference to the indexes in this schematic. The following
+// points are important:
+// - Body nodes are ordered by a BFT sort however,
+// - There is no guarantee on which body node is assigned to which body,
+// - Body nodes at a particular level are not guaranteed to be in any particular
+//   order, only that they belong to the right level is important.
 //
-//                    ┌───┐
-//                    │ 0 │(0)                         Level 0 (root, world)
-//                    └─┬─┘
-//                      │
-//        ┌─────────────┼─────────────┐
-//        │ m2          │ m4          │ m6
-//      ┌─┴─┐         ┌─┴─┐         ┌─┴─┐
-//      │ 7 │(1)      │ 5 │(2)      │ 4 │(4)           Level 1
-//      └───┘         └─┬─┘         └─┬─┘
-//                      │             │
-//                      │       ┌─────┴──────┐
-//                      │ m3    │ m1         │ m5
-//                    ┌─┴─┐   ┌─┴─┐        ┌─┴─┐
-//                    │ 3 │(3)│ 2 │(5)     │ 1 │(6)    Level 2
-//                    └───┘   └───┘        └─┬─┘
-//                                           │ m0
-//                                         ┌─┴─┐
-//                                         │ 6 │(7)    Level 3
-//                                         └───┘
+//                        +---+
+//                        | 0 |                        Level 0 (root, world)
+//            +-----------+-+-+-----------+
+//            |             |             |
+//            | m6          | m2          | m4
+//            |             |             |
+//          +-v-+         +-v-+         +-v-+
+//          | 4 |         | 7 |         | 5 |          Level 1
+//       +--+---+--+      +---+         +-+-+
+//       |         |                      |
+//       | m1      | m5                   | m3
+//       |         |                      |
+//     +-v-+     +-v-+                  +-v-+
+//     | 2 |     | 1 |                  | 3 |          Level 2
+//     +---+     +-+-+                  +---+
+//                 |
+//                 | m0
+//                 |
+//               +-v-+
+//               | 6 |                                 Level 3
+//               +---+
 //
 class TreeTopologyTests : public ::testing::Test {
  public:
@@ -381,17 +384,20 @@ class TreeTopologyTests : public ::testing::Test {
     set<BodyIndex> expected_level2 = {BodyIndex(2), BodyIndex(1), BodyIndex(3)};
     set<BodyIndex> expected_level3 = {BodyIndex(6)};
 
-    std::vector<std::set<BodyIndex>> levels(topology.num_bodies());
-    for (BodyIndex b(0); b < topology.num_bodies(); ++b) {
-      const BodyTopology& body = topology.get_body(b);
-      levels[body.level].insert(b);
-    }
+    set<BodyIndex> level0 = {topology.get_body_node(BodyNodeIndex(0)).body};
+    set<BodyIndex> level1 = {topology.get_body_node(BodyNodeIndex(1)).body,
+                             topology.get_body_node(BodyNodeIndex(2)).body,
+                             topology.get_body_node(BodyNodeIndex(3)).body};
+    set<BodyIndex> level2 = {topology.get_body_node(BodyNodeIndex(4)).body,
+                             topology.get_body_node(BodyNodeIndex(5)).body,
+                             topology.get_body_node(BodyNodeIndex(6)).body};
+    set<BodyIndex> level3 = {topology.get_body_node(BodyNodeIndex(7)).body};
 
     // Comparison of sets. The order of the elements is not important.
-    EXPECT_EQ(levels[0], expected_level0);
-    EXPECT_EQ(levels[1], expected_level1);
-    EXPECT_EQ(levels[2], expected_level2);
-    EXPECT_EQ(levels[3], expected_level3);
+    EXPECT_EQ(level0, expected_level0);
+    EXPECT_EQ(level1, expected_level1);
+    EXPECT_EQ(level2, expected_level2);
+    EXPECT_EQ(level3, expected_level3);
 
     // Verifies the expected number of child nodes.
     EXPECT_EQ(node_topology_from_body_index(topology, 0).get_num_children(), 3);
@@ -407,19 +413,6 @@ class TreeTopologyTests : public ::testing::Test {
     for (BodyIndex body(0); body < kNumBodies; ++body) {
       TestBodyNode(topology, body);
     }
-
-    // We now verify the precise expected topology. We use our internal
-    // knowledge that branches are created according to the order in which
-    // mobilizers are added. Refer to schematic in the documentation of this
-    // test fixture.
-    EXPECT_EQ(topology.get_body_node(BodyNodeIndex(0)).body, 0);
-    EXPECT_EQ(topology.get_body_node(BodyNodeIndex(1)).body, 7);
-    EXPECT_EQ(topology.get_body_node(BodyNodeIndex(2)).body, 5);
-    EXPECT_EQ(topology.get_body_node(BodyNodeIndex(3)).body, 3);
-    EXPECT_EQ(topology.get_body_node(BodyNodeIndex(4)).body, 4);
-    EXPECT_EQ(topology.get_body_node(BodyNodeIndex(5)).body, 2);
-    EXPECT_EQ(topology.get_body_node(BodyNodeIndex(6)).body, 1);
-    EXPECT_EQ(topology.get_body_node(BodyNodeIndex(7)).body, 6);
   }
 
  protected:

--- a/multibody/tree/velocity_kinematics_cache.h
+++ b/multibody/tree/velocity_kinematics_cache.h
@@ -109,7 +109,7 @@ class VelocityKinematicsCache {
 
  private:
   // Pools store entries in the same order multibody tree nodes are
-  // ordered in the tree, i.e. in DFT (Depth-First Traversal) order. Therefore
+  // ordered in the tree, i.e. in BFT (Breadth-First Traversal) order. Therefore
   // clients of this class will access entries by BodyNodeIndex, see
   // `get_V_WB()` for instance.
 


### PR DESCRIPTION
Reverts RobotLocomotion/drake#16035

It broke `mac-big-sur-clang-bazel-continuous-release`.
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/mac-big-sur-clang-bazel-continuous-release/909/
```
[4:13:51 PM]  ERROR: /Users/bigsur/workspace/mac-big-sur-clang-bazel-continuous-release/src/multibody/plant/BUILD.bazel:400:20: Compiling multibody/plant/test/multibody_plant_test.cc failed: (Aborted): wrapped_clang failed: error executing command external/local_config_cc/wrapped_clang '-D_FORTIFY_SOURCE=1' -fstack-protector -fcolor-diagnostics -Wall -Wthread-safety -Wself-assign -fno-omit-frame-pointer -g0 -O2 -DNDEBUG '-DNS_BLOCK_ASSERTIONS=1' ... (remaining 522 argument(s) skipped)
[4:13:51 PM]  
[4:13:51 PM]  Use --sandbox_debug to see verbose messages from the sandbox
[4:13:51 PM]  multibody/plant/test/multibody_plant_test.cc:3142:44: error: no viable overloaded '='
[4:13:51 PM]               left_finger_actuator.index()) = 1;
[4:13:51 PM]               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~
[4:13:51 PM]  external/eigen/include/_usr_local_Cellar_eigen_3.4.0_1_include_eigen3/Eigen/src/Core/MatrixBase.h:139:14: note: candidate function not viable: no known conversion from 'int' to 'const Eigen::MatrixBase<Eigen::IndexedView<Eigen::Matrix<double, -1, -1, 0>, Eigen::internal::SingleRange, drake::TypeSafeIndex<drake::multibody::JointActuatorElementTag>>>' for 1st argument
```

It will need fixes similar to #15335.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16113)
<!-- Reviewable:end -->
