### PR TITLE
framework: Fix a typo in system_compatibility doc

### DIFF
--- a/systems/framework/system_compatibility_doxygen.h
+++ b/systems/framework/system_compatibility_doxygen.h
@@ -15,7 +15,7 @@ AllocateContext(), AllocateOutput(), etc.
 
 In most cases users should be able to ignore this compatibility checking
 mechanism; setting and checking of IDs should happen naturally in most
-cases. However, when copying data values between similar systems, some case
+cases. However, when copying data values between similar systems, some care
 must be taken. for example, a Clone() of a checked object will not work with a
 system different from its source, but constructing a destination object using
 methods of the destination System and using SetFrom() or lower level value


### PR DESCRIPTION
Vaguely relevant to: #12570

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16118)
<!-- Reviewable:end -->
