### PR TITLE
[hydro] Make MeshFieldLinear compatible with PolygonSurfaceMesh

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -409,18 +409,22 @@ drake_cc_library(
 drake_cc_library(
     name = "mesh_field",
     srcs = [
+        "polygon_surface_mesh_field.cc",
         "triangle_surface_mesh_field.cc",
         "volume_mesh_field.cc",
     ],
     hdrs = [
         "mesh_field_linear.h",
+        "polygon_surface_mesh_field.h",
         "triangle_surface_mesh_field.h",
         "volume_mesh_field.h",
     ],
     deps = [
         ":mesh_traits",
+        ":polygon_surface_mesh",
         ":triangle_surface_mesh",
         ":volume_mesh",
+        "//common:nice_type_name",
         "//common:reset_on_copy",
         "//common:sorted_pair",
     ],

--- a/geometry/proximity/polygon_surface_mesh_field.cc
+++ b/geometry/proximity/polygon_surface_mesh_field.cc
@@ -1,0 +1,11 @@
+#include "drake/geometry/proximity/polygon_surface_mesh_field.h"
+
+namespace drake {
+namespace geometry {
+
+template class MeshFieldLinear<double, PolygonSurfaceMesh<double>>;
+template class MeshFieldLinear<AutoDiffXd, PolygonSurfaceMesh<AutoDiffXd>>;
+
+}  // namespace geometry
+}  // namespace drake
+

--- a/geometry/proximity/polygon_surface_mesh_field.h
+++ b/geometry/proximity/polygon_surface_mesh_field.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "drake/geometry/proximity/mesh_field_linear.h"
+#include "drake/geometry/proximity/polygon_surface_mesh.h"
+
+namespace drake {
+namespace geometry {
+
+/** A convenience alias for instantiating a MeshFieldLinear on a
+ PolygonSurfaceMesh.
+ @tparam FieldValue  A valid Eigen scalar or vector of valid Eigen scalars for
+                     the field value.
+ @tparam T  A valid Eigen scalar for mesh coordinates.
+ */
+template <typename FieldValue, typename T>
+using PolygonSurfaceMeshFieldLinear =
+    MeshFieldLinear<FieldValue, PolygonSurfaceMesh<T>>;
+
+// The homogeneous instances are sufficiently common in Drake, that we'll
+// build them once. Types with mixed scalars, or a *vector* mesh field type will
+// be compiled as needed, but if they become common, they can be added here.
+extern template class MeshFieldLinear<double, PolygonSurfaceMesh<double>>;
+extern template class MeshFieldLinear<AutoDiffXd,
+                                      PolygonSurfaceMesh<AutoDiffXd>>;
+
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
- The mesh field has conditional barycentric behavior (as barycentric coordinates are not well defined for polygonal elements).
- Provides an alias and instantiation for `MeshFieldLinear` on `PolygonSurfaceMesh` (to parallel `TriangleSurfaceMeshFieldLinear`).

Relates #15796

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16122)
<!-- Reviewable:end -->
