### PR TITLE
[hydro] Extend ContactSurface to include polygonal mesh representation

### DIFF
--- a/geometry/proximity/test/contact_surface_test.cc
+++ b/geometry/proximity/test/contact_surface_test.cc
@@ -17,23 +17,11 @@
 namespace drake {
 namespace geometry {
 
-// TODO(DamrongGuoy): Remove this helper class when ContactSurface allows
-//  direct access to e_MN_.
 template <typename T>
 class ContactSurfaceTester {
  public:
   explicit ContactSurfaceTester(const geometry::ContactSurface<T>& surface)
       : surface_(surface) {}
-
-  const TriangleSurfaceMeshFieldLinear<T, T>& e_MN() const {
-    DRAKE_DEMAND(surface_.e_MN_ != nullptr);
-    return *(surface_.e_MN_);
-  }
-
-  TriangleSurfaceMesh<T>& mutable_mesh_W() const {
-    DRAKE_DEMAND(surface_.mesh_W_ != nullptr);
-    return *(surface_.mesh_W_);
-  }
 
  private:
   const geometry::ContactSurface<T>& surface_;
@@ -47,60 +35,74 @@ using std::move;
 using std::unique_ptr;
 using std::vector;
 
-// TODO(DamrongGuoy): Consider splitting the test into several smaller tests
-//  including a separated mesh test.
-// Tests instantiation of ContactSurface and inspecting its components (the
-// mesh and the mesh fields). We cannot access its mesh fields directly, so
-// we check them by evaluating the field values at certain positions.
-template<typename T> ContactSurface<T> TestContactSurface();
-
-// Tests instantiation of ContactSurface using `double` as the underlying
-// scalar type.
-GTEST_TEST(ContactSurfaceTest, TestContactSurfaceDouble) {
-  auto contact_surface = TestContactSurface<double>();
-}
-
-// Smoke tests using `AutoDiffXd` as the underlying scalar type. The purpose
-// of this test is simply to check that it compiles. There is no tests of
-// differentiation.
-GTEST_TEST(ContactSurfaceTest, TestContactSurfaceAutoDiffXd) {
-  auto contact_surface = TestContactSurface<AutoDiffXd>();
-}
-
-template <typename T>
-unique_ptr<TriangleSurfaceMesh<T>> GenerateMesh() {
-// A simple mesh for a contact surface. It consists of two right
-// triangles that make a square.
-//
-//   y
-//   |
-//   |
-//   |
-//   v3(0,1,0)  v2(1,1,0)
-//   +-----------+
-//   |         . |
-//   |  f1  . .  |
-//   |    . .    |
-//   | . .   f0  |
-//   |.          |
-//   +-----------+---------- x
-//   v0(0,0,0)  v1(1,0,0)
-//
-  const int face_data[2][3] = {{0, 1, 2}, {2, 3, 0}};
-  vector<SurfaceTriangle> faces;
-  for (int f = 0; f < 2; ++f) faces.emplace_back(face_data[f]);
+template <typename MeshType>
+unique_ptr<MeshType> GenerateMesh() {
+  // A simple mesh for a contact surface. It consists of two right
+  // triangles that make a square.
+  //
+  //   y
+  //   |
+  //   |
+  //   |
+  //   v3(0,1,0)  v2(1,1,0)
+  //   +-----------+
+  //   |         . |
+  //   |  f1  . .  |
+  //   |    . .    |
+  //   | . .   f0  |
+  //   |.          |
+  //   +-----------+---------- x
+  //   v0(0,0,0)  v1(1,0,0)
+  //
+  using T = typename MeshType::ScalarType;
   vector<Vector3<T>> vertices = {
       {0., 0., 0.}, {1., 0., 0.}, {1., 1., 0.}, {0., 1., 0.}};
-  auto surface_mesh =
-      make_unique<TriangleSurfaceMesh<T>>(move(faces), move(vertices));
-  return surface_mesh;
+  if constexpr (std::is_same_v<MeshType, TriangleSurfaceMesh<T>>) {
+    vector<SurfaceTriangle> faces{{0, 1, 2}, {2, 3, 0}};
+    return make_unique<TriangleSurfaceMesh<T>>(move(faces), move(vertices));
+  } else {
+    vector<int> face_data{3, 0, 1, 2, 3, 2, 3, 0};
+    return make_unique<PolygonSurfaceMesh<T>>(move(face_data), move(vertices));
+  }
 }
 
-template <typename T>
-ContactSurface<T> TestContactSurface() {
+// Creates a field for a mesh created by GenerateMesh().
+template <typename MeshType>
+unique_ptr<MeshFieldLinear<typename MeshType::ScalarType, MeshType>> MakeField(
+    vector<typename MeshType::ScalarType>&& e_values, const MeshType& mesh) {
+  using T = typename MeshType::ScalarType;
+  if constexpr (std::is_same_v<MeshType, TriangleSurfaceMesh<T>>) {
+    return make_unique<MeshFieldLinear<T, MeshType>>(move(e_values), &mesh);
+  } else {
+    // A MeshFieldLinear on PolygonSurfaceMesh requires the gradients to be
+    // provided. So, we'll create the equivalent triangle mesh and field and
+    // ask for *its* gradients. Because both meshes consist purely of triangles,
+    // we can easily map from one to the other.
+    auto tri_mesh = GenerateMesh<TriangleSurfaceMesh<T>>();
+    TriangleSurfaceMeshFieldLinear<T, T> field(vector<T>(e_values),
+                                               tri_mesh.get());
+    vector<Vector3<T>> e_grad;
+    for (int t = 0; t < tri_mesh->num_elements(); ++t) {
+      e_grad.push_back(field.EvaluateGradient(t));
+    }
+    return make_unique<MeshFieldLinear<T, MeshType>>(move(e_values), &mesh,
+                                                     move(e_grad));
+  }
+}
+
+// Generates a ContactSurface from the mesh returned by GenerateMesh(). By
+// default, certain invariants of the test will be validated. But that can be
+// skipped if we only need a contact surface.
+// We also test the sugar mesh representation-independent APIs if
+// `test_return_value` is `true`. We don't test the mesh field internal values
+// directly. Instead, we evaluate the field at various positions.
+template <typename MeshType>
+ContactSurface<typename MeshType::ScalarType> TestContactSurface(
+    bool test_return_value = true) {
+  using T = typename MeshType::ScalarType;
   auto id_M = GeometryId::get_new_id();
   auto id_N = GeometryId::get_new_id();
-  auto surface_mesh = GenerateMesh<T>();
+  auto surface_mesh = GenerateMesh<MeshType>();
 
   // We record the reference for testing later.
   auto& surface_mesh_ref = *(surface_mesh.get());
@@ -112,39 +114,83 @@ ContactSurface<T> TestContactSurface() {
   const T e2{2.};
   const T e3{3.};
   vector<T> e_values = {e0, e1, e2, e3};
-  auto e_field = make_unique<TriangleSurfaceMeshFieldLinear<T, T>>(
-      move(e_values), surface_mesh.get());
+  unique_ptr<MeshFieldLinear<T, MeshType>> e_field =
+      MakeField(move(e_values), *surface_mesh);
 
   ContactSurface<T> contact_surface(id_M, id_N, move(surface_mesh),
                                     move(e_field));
 
-  // Start testing the ContactSurface<> data structure.
-  EXPECT_EQ(id_M, contact_surface.id_M());
-  EXPECT_EQ(id_N, contact_surface.id_N());
-  // Check memory address of the mesh. We don't want to compare the mesh
-  // objects themselves.
-  EXPECT_EQ(&surface_mesh_ref, &contact_surface.mesh_W());
-  EXPECT_EQ(2, contact_surface.mesh_W().num_triangles());
-  EXPECT_EQ(4, contact_surface.mesh_W().num_vertices());
-  // Tests evaluation of `e` on face f0 {0, 1, 2}.
-  {
-    const int f0{0};
-    const typename TriangleSurfaceMesh<T>::template Barycentric<double> b{
-        0.2, 0.3, 0.5};
-    const T expect_e = b(0) * e0 + b(1) * e1 + b(2) * e2;
-    EXPECT_EQ(expect_e, contact_surface.e_MN().Evaluate(f0, b));
-  }
-  // Tests area() of triangular faces.
-  {
-    EXPECT_EQ(T(0.5), contact_surface.mesh_W().area(0));
-    EXPECT_EQ(T(0.5), contact_surface.mesh_W().area(1));
+  if (test_return_value) {
+    // Start testing the ContactSurface<> data structure.
+    EXPECT_EQ(id_M, contact_surface.id_M());
+    EXPECT_EQ(id_N, contact_surface.id_N());
+    EXPECT_EQ(2, contact_surface.num_faces());
+    EXPECT_EQ(4, contact_surface.num_vertices());
+    // Tests area() of triangular faces.
+    EXPECT_EQ(T(0.5), contact_surface.area(0));
+    EXPECT_EQ(T(0.5), contact_surface.area(1));
+    EXPECT_EQ(1.0, contact_surface.total_area());
+    // Tests centroids.
+    EXPECT_TRUE(
+        CompareMatrices(contact_surface.centroid(), Vector3<T>{0.5, 0.5, 0}));
+    EXPECT_TRUE(
+        CompareMatrices(contact_surface.centroid(0), Vector3<T>{2, 1, 0} / 3));
+    EXPECT_TRUE(
+        CompareMatrices(contact_surface.centroid(1), Vector3<T>{1, 2, 0} / 3));
+    // Face normals
+    EXPECT_TRUE(
+        CompareMatrices(contact_surface.face_normal(0), Vector3<T>{0, 0, 1}));
+    EXPECT_TRUE(
+        CompareMatrices(contact_surface.face_normal(1), Vector3<T>{0, 0, 1}));
+
+    // We'll confirm the surface properly references its field. The previous
+    // tests already suggest correctness of mesh and field values.
+    if constexpr (std::is_same_v<MeshType, TriangleSurfaceMesh<T>>) {
+      EXPECT_EQ(contact_surface.representation(),
+                HydroelasticContactRepresentation::kTriangle);
+      EXPECT_TRUE(contact_surface.is_triangle());
+      EXPECT_EQ(&surface_mesh_ref, &contact_surface.tri_mesh_W());
+      EXPECT_EQ(contact_surface.tri_e_MN().EvaluateCartesian(
+                    0, contact_surface.centroid(0)),
+                (e0 + e1 + e2) / 3);
+      EXPECT_EQ(contact_surface.tri_e_MN().EvaluateCartesian(
+                    1, contact_surface.centroid(1)),
+                (e2 + e3 + e0) / 3);
+    } else {
+      EXPECT_EQ(contact_surface.representation(),
+                HydroelasticContactRepresentation::kPolygon);
+      EXPECT_FALSE(contact_surface.is_triangle());
+      EXPECT_EQ(&surface_mesh_ref, &contact_surface.poly_mesh_W());
+      EXPECT_EQ(contact_surface.poly_e_MN().EvaluateCartesian(
+                      0, contact_surface.centroid(0)),
+                  (e0 + e1 + e2) / 3);
+      EXPECT_EQ(contact_surface.poly_e_MN().EvaluateCartesian(
+                      1, contact_surface.centroid(1)),
+                  (e2 + e3 + e0) / 3);
+    }
   }
 
   return contact_surface;
 }
 
+// Tests instantiation of ContactSurface using `double` as the underlying
+// scalar type.
+GTEST_TEST(ContactSurfaceTest, TestContactSurfaceDouble) {
+  TestContactSurface<TriangleSurfaceMesh<double>>();
+  TestContactSurface<PolygonSurfaceMesh<double>>();
+}
+
+// Smoke tests using `AutoDiffXd` as the underlying scalar type. The purpose
+// of this test is simply to check that it compiles. There is no tests of
+// differentiation.
+GTEST_TEST(ContactSurfaceTest, TestContactSurfaceAutoDiffXd) {
+  TestContactSurface<TriangleSurfaceMesh<AutoDiffXd>>();
+  TestContactSurface<PolygonSurfaceMesh<AutoDiffXd>>();
+}
+
 // Tests the ContactSurface with constituent gradients: construction, successful
-// reversal, access, etc.
+// reversal, access, etc. This logic doesn't depend on mesh representation
+// so, we simply test it against one type.
 GTEST_TEST(ContactSurfaceTest, ConstituentGradients) {
   // Define two ids: A and B. When we create a ContactSurface with A and B in
   // that order, then the data is taken as is (i.e., A --> M, B --> N). When
@@ -154,7 +200,8 @@ GTEST_TEST(ContactSurfaceTest, ConstituentGradients) {
   const auto id_B = GeometryId::get_new_id();
   ASSERT_LT(id_A, id_B);
 
-  unique_ptr<TriangleSurfaceMesh<double>> surface_mesh = GenerateMesh<double>();
+  unique_ptr<TriangleSurfaceMesh<double>> surface_mesh =
+      GenerateMesh<TriangleSurfaceMesh<double>>();
   auto make_e_field = [](TriangleSurfaceMesh<double>* mesh) {
     vector<double> e_values{0, 1, 2, 3};
     return make_unique<TriangleSurfaceMeshFieldLinear<double, double>>(
@@ -259,48 +306,95 @@ GTEST_TEST(ContactSurfaceTest, ConstituentGradients) {
   }
 }
 
-// Tests copy constructor of ContactSurface. We use `double` as a
-// representative scalar type.
+// Tests copy constructor of ContactSurface.
 GTEST_TEST(ContactSurfaceTest, TestCopy) {
-  ContactSurface<double> original = TestContactSurface<double>();
+  ContactSurface<double> original_tri =
+      TestContactSurface<TriangleSurfaceMesh<double>>(false /*test*/);
+  ASSERT_EQ(original_tri.representation(),
+            HydroelasticContactRepresentation::kTriangle);
+
+  auto test_copy = [](const auto& source_mesh, const auto& target_mesh) {
+    // They have different addresses; it is a deep copy.
+    EXPECT_NE(&source_mesh, &target_mesh);
+    // They are structurally similar; this doesn't confirm that all the values
+    // are copied -- that should be tested by the mesh type's unit tests.
+    EXPECT_EQ(source_mesh.num_elements(), target_mesh.num_elements());
+    EXPECT_EQ(source_mesh.num_vertices(), target_mesh.num_vertices());
+  };
+
   // Copy constructor.
-  ContactSurface<double> copy(original);
+  ContactSurface<double> copy_tri(original_tri);
+  ASSERT_EQ(copy_tri.representation(),
+            HydroelasticContactRepresentation::kTriangle);
 
-  // Confirm that it was a deep copy, i.e., the `original` mesh and the `copy`
-  // mesh are different objects.
-  EXPECT_NE(&original.mesh_W(), &copy.mesh_W());
+  EXPECT_EQ(original_tri.id_M(), copy_tri.id_M());
+  EXPECT_EQ(original_tri.id_N(), copy_tri.id_N());
 
-  EXPECT_EQ(original.id_M(), copy.id_M());
-  EXPECT_EQ(original.id_N(), copy.id_N());
-  // We use `num_triangles()` as a representative of the mesh. We do not check
-  // everything in the mesh.
-  EXPECT_EQ(original.mesh_W().num_triangles(), copy.mesh_W().num_triangles());
+  test_copy(original_tri.tri_mesh_W(), copy_tri.tri_mesh_W());
 
   // We check evaluation of field values only at one position.
   const int f{0};
-  const typename TriangleSurfaceMesh<double>::Barycentric<double> b{0.2, 0.3,
-                                                                    0.5};
-  EXPECT_EQ(original.e_MN().Evaluate(f, b), copy.e_MN().Evaluate(f, b));
+  const Vector3d p_MC0 = original_tri.tri_mesh_W().element_centroid(f);
+  EXPECT_EQ(original_tri.tri_e_MN().EvaluateCartesian(f, p_MC0),
+            copy_tri.tri_e_MN().EvaluateCartesian(f, p_MC0));
+
+  // Repeat the test for polygon mesh representation.
+  ContactSurface<double> original_poly =
+      TestContactSurface<PolygonSurfaceMesh<double>>(false /*test*/);
+  ASSERT_EQ(original_poly.representation(),
+            HydroelasticContactRepresentation::kPolygon);
+
+  ContactSurface<double> copy_poly(original_poly);
+  ASSERT_EQ(copy_poly.representation(),
+            HydroelasticContactRepresentation::kPolygon);
+
+  EXPECT_EQ(original_poly.id_M(), copy_poly.id_M());
+  EXPECT_EQ(original_poly.id_N(), copy_poly.id_N());
+
+  test_copy(original_poly.poly_mesh_W(), copy_poly.poly_mesh_W());
+
+  // We check evaluation of field values only at one position.
+  EXPECT_EQ(original_poly.poly_e_MN().EvaluateCartesian(f, p_MC0),
+            copy_poly.poly_e_MN().EvaluateCartesian(f, p_MC0));
+
+  // Because we now have different mesh representations (triangle and polygon).
+  // Copy *assignment* should change the type of the representation. Let's
+  // confirm.
+
+  copy_tri = original_poly;
+  ASSERT_EQ(copy_tri.representation(),
+            HydroelasticContactRepresentation::kPolygon);
+  copy_poly = original_tri;
+  ASSERT_EQ(copy_poly.representation(),
+            HydroelasticContactRepresentation::kTriangle);
 }
 
+// TODO(DamrongGuoy): This test should also be run with a polygon
+// representation.
 // Tests the equality comparisons.
 GTEST_TEST(ContactSurfaceTest, TestEqual) {
   // Create contact surface for comparison.
-  const ContactSurface<double> surface = TestContactSurface<double>();
+  const ContactSurface<double> surface =
+      TestContactSurface<TriangleSurfaceMesh<double>>(false /*test*/);
 
   // Same contact surface.
   auto surface0 = ContactSurface<double>(surface);
   EXPECT_TRUE(surface.Equal(surface0));
 
-  // Different mesh.
+  // To get a "different" mesh, we'll copy the current contact surface so it's
+  // all the same and then sneak around the const access to change the mesh by
+  // reversing its winding. That will be sufficient to show mesh differences
+  // imply constact surface differences (even if all else is bit identical).
   auto surface1 = ContactSurface<double>(surface);
-  ContactSurfaceTester<double>(surface1).mutable_mesh_W().ReverseFaceWinding();
+  const_cast<TriangleSurfaceMesh<double>&>(surface1.tri_mesh_W())
+      .ReverseFaceWinding();
   EXPECT_FALSE(surface.Equal(surface1));
 
   // Equal mesh, Different pressure field.
   // First, copy the mesh.
-  auto mesh2 = make_unique<TriangleSurfaceMesh<double>>(surface.mesh_W());
-  const TriangleSurfaceMeshFieldLinear<double, double>& field = surface.e_MN();
+  auto mesh2 = make_unique<TriangleSurfaceMesh<double>>(surface.tri_mesh_W());
+  const TriangleSurfaceMeshFieldLinear<double, double>& field =
+      surface.tri_e_MN();
   // Then, copy the field values and change it.
   vector<double> field2_values(field.values());
   field2_values.at(0) += 2.0;
@@ -312,16 +406,15 @@ GTEST_TEST(ContactSurfaceTest, TestEqual) {
 }
 
 // Tests the constructor of ContactSurface that when id_M is greater than
-// id_N, it will swap M and N.
+// id_N, it will swap M and N. The logic doesn't depend on mesh
+// representation or scalar type, so we simply test it against one mesh type.
 GTEST_TEST(ContactSurfaceTest, TestSwapMAndN) {
   // Create the original contact surface for comparison later.
-  const ContactSurface<double> original = TestContactSurface<double>();
-  auto mesh = make_unique<TriangleSurfaceMesh<double>>(original.mesh_W());
+  const ContactSurface<double> original =
+      TestContactSurface<TriangleSurfaceMesh<double>>(false /*test*/);
+  auto mesh = make_unique<TriangleSurfaceMesh<double>>(original.tri_mesh_W());
   TriangleSurfaceMesh<double>* mesh_pointer = mesh.get();
-  // TODO(DamrongGuoy): Remove `original_tester` when ContactSurface allows
-  //  direct access to e_MN.
-  const ContactSurfaceTester<double> original_tester(original);
-  vector<double> e_MN_values = original_tester.e_MN().values();
+  vector<double> e_MN_values = original.tri_e_MN().values();
 
   // Create id_M after id_N, so id_M > id_N. This condition will trigger
   // SwapMAndN in the constructor of ContactSurface.
@@ -348,16 +441,17 @@ GTEST_TEST(ContactSurfaceTest, TestSwapMAndN) {
            f1.vertex(2) == f2.vertex(2);
   };
   // Face winding is changed.
-  for (int f = 0; f < original.mesh_W().num_triangles(); ++f) {
-    EXPECT_FALSE(
-        are_identical(dut.mesh_W().element(f), original.mesh_W().element(f)));
+  for (int f = 0; f < original.tri_mesh_W().num_triangles(); ++f) {
+    EXPECT_FALSE(are_identical(dut.tri_mesh_W().element(f),
+                               original.tri_mesh_W().element(f)));
   }
 
   // Evaluate the mesh field, once per face for an arbitrary point Q on the
   // interior of the triangle. We expect e_MN function hasn't changed.
   const TriangleSurfaceMesh<double>::Barycentric<double> b_Q{0.25, 0.25, 0.5};
-  for (int f = 0; f < original.mesh_W().num_triangles(); ++f) {
-    EXPECT_EQ(dut.e_MN().Evaluate(f, b_Q), original.e_MN().Evaluate(f, b_Q));
+  for (int f = 0; f < original.tri_mesh_W().num_triangles(); ++f) {
+    EXPECT_EQ(dut.tri_e_MN().Evaluate(f, b_Q),
+              original.tri_e_MN().Evaluate(f, b_Q));
   }
 }
 

--- a/geometry/query_results/contact_surface.cc
+++ b/geometry/query_results/contact_surface.cc
@@ -5,9 +5,58 @@
 namespace drake {
 namespace geometry {
 
+using std::make_unique;
+using std::move;
+using std::unique_ptr;
+using std::vector;
+
+template <typename T>
+const Vector3<T>& ContactSurface<T>::EvaluateGradE_M_W(int index) const {
+  if (grad_eM_W_ == nullptr) {
+    throw std::runtime_error(
+        "ContactSurface::EvaluateGradE_M_W() invalid; no gradient values "
+        "stored. Mesh M may be rigid, or the constituent gradients weren't "
+        "requested.");
+  }
+  return (*grad_eM_W_)[index];
+}
+
+template <typename T>
+const Vector3<T>& ContactSurface<T>::EvaluateGradE_N_W(int index) const {
+  if (grad_eN_W_ == nullptr) {
+    throw std::runtime_error(
+        "ContactSurface::EvaluateGradE_N_W() invalid; no gradient values "
+        "stored. Mesh N may be rigid, or the constituent gradients weren't "
+        "requested.");
+  }
+  return (*grad_eN_W_)[index];
+}
+
+template <typename T>
+bool ContactSurface<T>::Equal(const ContactSurface<T>& surface) const {
+  // Confirm we have the same representation. Technically, mesh and field
+  // representations are linked, but we'll test both to be safe.
+  if (this->mesh_W_.index() != surface.mesh_W_.index()) return false;
+  if (this->e_MN_.index() != surface.e_MN_.index()) return false;
+
+  if (is_triangle()) {
+    if (!this->tri_mesh_W().Equal(surface.tri_mesh_W())) return false;
+    if (!this->tri_e_MN().Equal(surface.tri_e_MN())) return false;
+  } else {
+    if (!this->poly_mesh_W().Equal(surface.poly_mesh_W())) return false;
+    if (!this->poly_e_MN().Equal(surface.poly_e_MN())) return false;
+  }
+
+  // TODO(SeanCurtis-TRI) This isn't testing the following quantities:
+  //  1. Geometry ids
+  //  2. Gradients.
+
+  // All checks passed.
+  return true;
+}
+
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class ContactSurface);
 
 }  // namespace geometry
 }  // namespace drake
-

--- a/geometry/query_results/contact_surface.h
+++ b/geometry/query_results/contact_surface.h
@@ -3,17 +3,30 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/proximity/polygon_surface_mesh.h"
+#include "drake/geometry/proximity/polygon_surface_mesh_field.h"
 #include "drake/geometry/proximity/triangle_surface_mesh.h"
 #include "drake/geometry/proximity/triangle_surface_mesh_field.h"
 #include "drake/math/rigid_transform.h"
 
 namespace drake {
 namespace geometry {
+
+// TODO(SeanCurtis-TRI): It would be nice if this were *inside* `ContactSurface`
+//  so it didn't have to be a scoped enumeration -- the class would handle the
+//  scope. But, because ContactSurface is templated, I'd end up with different
+//  enumerations that depend on scalar.  :-P  And going non-scoped seems a bad
+//  idea with such simple designations of "kTriangle" and "kPolygon".
+/** Reports on how a hydroelastic contact surface is represented. See
+ @ref contact_surface_discrete_representation
+ "the documentation in ContactSurface" for more details. */
+enum class HydroelasticContactRepresentation { kTriangle, kPolygon };
 
 /** The %ContactSurface characterizes the intersection of two geometries M
   and N as a contact surface with a scalar field and a vector field, whose
@@ -89,21 +102,44 @@ namespace geometry {
   Even though eₘₙ and ∇hₘₙ are defined on different domains (𝕊ₘₙ and 𝕄 ∩ ℕ),
   our implementation only represents them on their common domain, i.e., 𝕊ₘₙ.
 
+  @anchor contact_surface_discrete_representation
   <h2> Discrete Representation </h2>
 
-  In practice, the contact surface is approximated with a discrete triangle
-  mesh. The triangle mesh's normals are defined *per face*. The normal of each
-  face is guaranteed to point "out of" N and "into" M. They can be accessed via
-  `mesh_W().face_normal(face_index)`.
+  In practice, hydroelastic geometries themselves have a discrete
+  representation: either a triangular surface mesh for rigid geometries or a
+  tetrahedral volume mesh for compliant geometry. This discretization leads to
+  contact surfaces that are likewise discrete.
+
+  Intersection between triangles and tetrahedra (or tetrahedra and tetrahedra)
+  can produce polygons with up to eight sides. A %ContactSurface can represent
+  the resulting surface as a mesh of such polygons, or as a mesh of tesselated
+  triangles. The domains of the two representations are identical. The
+  triangular version admits for simple, high-order integration over the domain.
+  Every element is a triangle, and triangles will only disappear and reappear
+  as their areas go to zero. However, this increases the total number of
+  faces in the mesh by more than a factor of three over the polygonal mesh. The
+  polygonal representation produces fewer faces, but high order integration over
+  polygons is problematic. We recommend choosing the cheapest representation
+  that nevertheless supports your required fidelity (see
+  QueryObject::ComputeContactSurfaces()).
+
+  The representation of any %ContactSurface instance can be reported by calling
+  representation(). If it returns HydroelasticContactRepresentation::kTriangle,
+  then the mesh and pressure field can be accessed via tri_mesh_W() and
+  tri_e_MN(), respectively. If it returns
+  HydroelasticContactRepresentation::kPolygon, then use poly_mesh_W() and
+  poly_e_MN().
+
+  Regardless of representation (polygon or triangle), the normal for each
+  mesh face is guaranteed to point "out of" N and "into" M. They can be accessed
+  via the mesh, e.g., `tri_mesh_W().face_normal(face_index)`. By definition,
+  the normals of the mesh are discontinuous at triangle boundaries.
 
   The pressure values on the contact surface are represented as a continuous,
-  piecewise-linear function, accessed via e_MN().
-
-  The normals of the mesh are discontinuous at triangle boundaries, but the
-  pressure can be meaningfully evaluated over the entire domain of the mesh.
+  piecewise-linear function, accessed via tri_e_MN() or poly_e_MN().
 
   When available, the values of ∇eₘ and ∇eₙ are represented as a discontinuous,
-  piecewise-constant function over the triangles -- one vector per triangle.
+  piecewise-constant function over the faces -- one gradient vector per face.
   These quantities are accessed via EvaluateGradE_M_W() and EvaluateGradE_N_W(),
   respectively.
 
@@ -129,22 +165,39 @@ namespace geometry {
 template <typename T>
 class ContactSurface {
  public:
-  ContactSurface(const ContactSurface& surface) {
-    *this = surface;
-  }
+  ContactSurface(const ContactSurface& surface) { *this = surface; }
+
+  // TODO(SeanCurtis-TRI) Copy assignment, both constructors, and SwapMAndN
+  //  would all be better defined in the .cc file. The primary reason they are
+  //  not is that multibody::HydroelasticContactInfo and
+  //  multibody::ContactResultsToLcm unit tests
+  //  (which explicitly declare support for T = symbolic::Expression), blindly
+  //  assume that the contact surface likewise supports symbolic::Expression
+  //  (even though that is not the case). Their only meaningful actions are to
+  //  copy/create instances. By leaving these functions in the header, those
+  //  workflows continue to work. Ideally, they'd protect themselves against the
+  //  fact that they are instantiating types that don't *truly* support
+  //  symbolic::Expression and these functions can move into the .cc file.
+  //  This has a downstream effect of requiring the surface meshes
+  //  ReverseFaceWinding methods defined in the header as it gets invoked by
+  //  SwapMAndN.
 
   ContactSurface& operator=(const ContactSurface& surface) {
-    if (&surface == this)
-      return *this;
+    if (&surface == this) return *this;
 
     id_M_ = surface.id_M_;
     id_N_ = surface.id_N_;
-    mesh_W_ = std::make_unique<TriangleSurfaceMesh<T>>(*surface.mesh_W_);
-
-    // We can't simply copy the mesh fields; the copies must contain pointers
-    // to the new mesh. So, we use CloneAndSetMesh() instead.
-    e_MN_.reset(static_cast<TriangleSurfaceMeshFieldLinear<T, T>*>(
-        surface.e_MN_->CloneAndSetMesh(mesh_W_.get()).release()));
+    if (surface.is_triangle()) {
+      mesh_W_ = std::make_unique<TriangleSurfaceMesh<T>>(surface.tri_mesh_W());
+      // We can't simply copy the mesh fields; the copies must contain pointers
+      // to the new mesh. So, we use CloneAndSetMesh() instead.
+      e_MN_ = surface.tri_e_MN().CloneAndSetMesh(&tri_mesh_W());
+    } else {
+      mesh_W_ = std::make_unique<PolygonSurfaceMesh<T>>(surface.poly_mesh_W());
+      // We can't simply copy the mesh fields; the copies must contain pointers
+      // to the new mesh. So, we use CloneAndSetMesh() instead.
+      e_MN_ = surface.poly_e_MN().CloneAndSetMesh(&poly_mesh_W());
+    }
 
     if (surface.grad_eM_W_) {
       grad_eM_W_ =
@@ -161,26 +214,16 @@ class ContactSurface {
   ContactSurface(ContactSurface&&) = default;
   ContactSurface& operator=(ContactSurface&&) = default;
 
-  /** Constructs a ContactSurface.
-   @param id_M         The id of the first geometry M.
-   @param id_N         The id of the second geometry N.
-   @param mesh_W       The surface mesh of the contact surface 𝕊ₘₙ between M
-                       and N. The mesh vertices are defined in the world frame.
-   @param e_MN         Represents the scalar field eₘₙ on the surface mesh.
-   @pre The face normals in `mesh_W` point *out of* geometry N and *into* M.
-   @note If `id_M > id_N`, the labels will be swapped and the normals of the
-         mesh reversed (to maintain the documented invariants). Comparing the
-         input parameters with the members of the resulting %ContactSurface will
-         reveal if such a swap has occurred.
-   */
-  ContactSurface(GeometryId id_M, GeometryId id_N,
-                 std::unique_ptr<TriangleSurfaceMesh<T>> mesh_W,
-                 std::unique_ptr<TriangleSurfaceMeshFieldLinear<T, T>> e_MN)
-      : ContactSurface(id_M, id_N, std::move(mesh_W), std::move(e_MN), nullptr,
-                       nullptr) {}
+  /** @name Constructors
 
-  /** Constructs a ContactSurface with the optional gradients of the constituent
-   scalar fields.
+   The %ContactSurface can be constructed with either a polygon or triangle
+   mesh representation. The constructor invoked determines the representation.
+
+   The general shape of each constructor is identical. They take the unique
+   identifiers for the two geometries in contact, a mesh representation, a
+   field representation, and (optional) gradients of the contacting geometries'
+   pressure fields.
+
    @param id_M         The id of the first geometry M.
    @param id_N         The id of the second geometry N.
    @param mesh_W       The surface mesh of the contact surface 𝕊ₘₙ between M
@@ -195,34 +238,168 @@ class ContactSurface {
    @note If `id_M > id_N`, the labels will be swapped and the normals of the
          mesh reversed (to maintain the documented invariants). Comparing the
          input parameters with the members of the resulting %ContactSurface will
-         reveal if such a swap has occurred.
-   */
+         reveal if such a swap has occurred. */
+  //@{
+
+  /** Constructs a %ContactSurface with a triangle mesh representation. */
   ContactSurface(GeometryId id_M, GeometryId id_N,
                  std::unique_ptr<TriangleSurfaceMesh<T>> mesh_W,
                  std::unique_ptr<TriangleSurfaceMeshFieldLinear<T, T>> e_MN,
-                 std::unique_ptr<std::vector<Vector3<T>>> grad_eM_W,
-                 std::unique_ptr<std::vector<Vector3<T>>> grad_eN_W)
-      : id_M_(id_M),
-        id_N_(id_N),
-        mesh_W_(std::move(mesh_W)),
-        e_MN_(std::move(e_MN)),
-        grad_eM_W_(std::move(grad_eM_W)),
-        grad_eN_W_(std::move(grad_eN_W)) {
-    // If defined the gradient values must map 1-to-1 onto elements.
-    DRAKE_THROW_UNLESS(grad_eM_W_ == nullptr ||
-                       static_cast<int>(grad_eM_W_->size()) ==
-                           mesh_W_->num_elements());
-    DRAKE_THROW_UNLESS(grad_eN_W_ == nullptr ||
-                       static_cast<int>(grad_eN_W_->size()) ==
-                           mesh_W_->num_elements());
-    if (id_N_ < id_M_) SwapMAndN();
-  }
+                 std::unique_ptr<std::vector<Vector3<T>>> grad_eM_W = nullptr,
+                 std::unique_ptr<std::vector<Vector3<T>>> grad_eN_W = nullptr)
+    : ContactSurface(id_M, id_N, std::move(mesh_W), std::move(e_MN),
+                     std::move(grad_eM_W), std::move(grad_eN_W), 1) {}
+
+  /** Constructs a %ContactSurface with a polygonal mesh representation. */
+  ContactSurface(GeometryId id_M, GeometryId id_N,
+                 std::unique_ptr<PolygonSurfaceMesh<T>> mesh_W,
+                 std::unique_ptr<PolygonSurfaceMeshFieldLinear<T, T>> e_MN,
+                 std::unique_ptr<std::vector<Vector3<T>>> grad_eM_W = nullptr,
+                 std::unique_ptr<std::vector<Vector3<T>>> grad_eN_W = nullptr)
+    : ContactSurface(id_M, id_N, std::move(mesh_W), std::move(e_MN),
+                     std::move(grad_eM_W), std::move(grad_eN_W), 1) {}
+
+  //@}
 
   /** Returns the geometry id of Geometry M. */
   GeometryId id_M() const { return id_M_; }
 
   /** Returns the geometry id of Geometry N. */
   GeometryId id_N() const { return id_N_; }
+
+  /** @name Representation-independent API
+
+   These methods represent sugar which masks the details of the mesh
+   representation. They facilitate querying various mesh quantities that are
+   common to the two representations, so that code can access the properties
+   without worrying about the representation. If necessary, the actual meshes
+   and fields can be accessed directly via the representation-dependent APIs
+   below. */
+  //@{
+
+  int num_faces() const {
+    return is_triangle() ? tri_mesh_W().num_elements()
+                         : poly_mesh_W().num_elements();
+  }
+
+  int num_vertices() const {
+    return is_triangle() ? tri_mesh_W().num_vertices()
+                         : poly_mesh_W().num_vertices();
+  }
+
+  const T& area(int face_index) const {
+    return is_triangle() ? tri_mesh_W().area(face_index)
+                         : poly_mesh_W().area(face_index);
+  }
+
+  const T& total_area() const {
+    return is_triangle() ? tri_mesh_W().total_area()
+                         : poly_mesh_W().total_area();
+  }
+
+  const Vector3<T>& face_normal(int face_index) const {
+    return is_triangle() ? tri_mesh_W().face_normal(face_index)
+                         : poly_mesh_W().face_normal(face_index);
+  }
+
+  // TODO(SeanCurtis-TRI): If TriangleSurfaceMesh pre-computed centroids and
+  //  stored them, this could return a const reference. It's not clear, however,
+  //  that this would get invoked enough to matter.
+  Vector3<T> centroid(int face_index) const {
+    return is_triangle() ? tri_mesh_W().element_centroid(face_index)
+                         : poly_mesh_W().element_centroid(face_index);
+  }
+
+  const Vector3<T>& centroid() const {
+    return is_triangle() ? tri_mesh_W().centroid() : poly_mesh_W().centroid();
+  }
+
+  //@}
+
+  /** @name Representation-dependent API
+
+   These functions provide insight into what representation the %ContactSurface
+   instance uses, and provide access to the representation-dependent quantities:
+   mesh and field. */
+  //@{
+
+  /** Simpley reports if this contact surface's mesh representation is triangle.
+   Equivalent to:
+
+       representation() == HydroelasticContactRepresentation::kTriangle
+
+   and offered as convenient sugar. */
+  bool is_triangle() const {
+    return std::holds_alternative<std::unique_ptr<TriangleSurfaceMesh<T>>>(
+        mesh_W_);
+  }
+
+  /** Reports the representation mode of this contact surface. If accessing the
+   mesh or field directly, the APIs that can be successfully exercised are
+   related to this methods return value. See below. */
+  HydroelasticContactRepresentation representation() const {
+    return is_triangle() ? HydroelasticContactRepresentation::kTriangle
+                         : HydroelasticContactRepresentation::kPolygon;
+  }
+
+  /** Returns a reference to the surface mesh whose vertex positions are
+   measured and expressed in the world frame.
+
+   This method is provided for short-term legacy reasons. Once the polygonal
+   mesh representation is fully supported across the entire contact model
+   code path, this will be removed in favor of its explicitly declared
+   `tri_` or `poly_` variant.
+
+   @pre is_triangle() returns `true`. */
+  const TriangleSurfaceMesh<T>& mesh_W() const {
+    return tri_mesh_W();
+  }
+
+  /** Returns a reference to the scalar field eₘₙ.
+
+   This method is provided for short-term legacy reasons. Once the polygonal
+   mesh representation is fully supported across the entire contact model
+   code path, this will be removed in favor of its explicitly declared
+   `tri_` or `poly_` variant.
+
+   @pre is_triangle() returns `true`. */
+  const TriangleSurfaceMeshFieldLinear<T, T>& e_MN() const {
+    return tri_e_MN();
+  }
+
+  /** Returns a reference to the _triangular_ surface mesh whose vertex
+   positions are measured and expressed in the world frame.
+   @pre `is_triangle()` returns `true`. */
+  const TriangleSurfaceMesh<T>& tri_mesh_W() const {
+    DRAKE_DEMAND(is_triangle());
+    return *std::get<std::unique_ptr<TriangleSurfaceMesh<T>>>(mesh_W_);
+  }
+
+  /** Returns a reference to the scalar field eₘₙ for the _triangle_ mesh.
+   @pre `is_triangle()` returns `true`. */
+  const TriangleSurfaceMeshFieldLinear<T, T>& tri_e_MN() const {
+    DRAKE_DEMAND(is_triangle());
+    return *std::get<std::unique_ptr<TriangleSurfaceMeshFieldLinear<T, T>>>(
+        e_MN_);
+  }
+
+  /** Returns a reference to the _polygonal_ surface mesh whose vertex
+   positions are measured and expressed in the world frame.
+   @pre `is_triangle()` returns `false`. */
+  const PolygonSurfaceMesh<T>& poly_mesh_W() const {
+    DRAKE_DEMAND(!is_triangle());
+    return *std::get<std::unique_ptr<PolygonSurfaceMesh<T>>>(mesh_W_);
+  }
+
+  /** Returns a reference to the scalar field eₘₙ for the _polygonal_ mesh.
+   @pre `is_triangle()` returns `false`. */
+  const PolygonSurfaceMeshFieldLinear<T, T>& poly_e_MN() const {
+    DRAKE_DEMAND(!is_triangle());
+    return *std::get<std::unique_ptr<PolygonSurfaceMeshFieldLinear<T, T>>>(
+        e_MN_);
+  }
+
+  //@}
 
   /** @name  Evaluation of constituent pressure fields
 
@@ -241,7 +418,7 @@ class ContactSurface {
    The presence of gradient data for each geometry must be confirmed separately.
 
    The values ∇eₘ and ∇eₘ are piecewise constant over the %ContactSurface and
-   can only be evaluate on a per-triangle basis.  */
+   can only be evaluate on a per-face basis.  */
   //@{
 
   /** @returns `true` if `this` contains values for ∇eₘ.  */
@@ -250,44 +427,17 @@ class ContactSurface {
   /** @returns `true` if `this` contains values for ∇eₙ.  */
   bool HasGradE_N() const { return grad_eN_W_ != nullptr; }
 
-  /** Returns the value of ∇eₘ for the triangle with index `index`.
+  /** Returns the value of ∇eₘ for the face with index `index`.
    @throws std::exception if HasGradE_M() returns false.
-   @pre `index ∈ [0, mesh().num_triangles())`.  */
-  const Vector3<T>& EvaluateGradE_M_W(int index) const {
-    if (grad_eM_W_ == nullptr) {
-      throw std::runtime_error(
-          "ContactSurface::EvaluateGradE_M_W() invalid; no gradient values "
-          "stored. Mesh M may be rigid, or the constituent gradients weren't "
-          "requested.");
-    }
-    return (*grad_eM_W_)[index];
-  }
+   @pre `index ∈ [0, mesh().num_faces())`.  */
+  const Vector3<T>& EvaluateGradE_M_W(int index) const;
 
-  /** Returns the value of ∇eₙ for the triangle with index `index`.
+  /** Returns the value of ∇eₙ for the face with index `index`.
    @throws std::exception if HasGradE_N() returns false.
-   @pre `index ∈ [0, mesh().num_triangles())`.  */
-  const Vector3<T>& EvaluateGradE_N_W(int index) const {
-    if (grad_eN_W_ == nullptr) {
-      throw std::runtime_error(
-          "ContactSurface::EvaluateGradE_N_W() invalid; no gradient values "
-          "stored. Mesh N may be rigid, or the constituent gradients weren't "
-          "requested.");
-    }
-    return (*grad_eN_W_)[index];
-  }
+   @pre `index ∈ [0, mesh().num_faces())`.  */
+  const Vector3<T>& EvaluateGradE_N_W(int index) const;
 
   //@}
-
-  /** Returns a reference to the surface mesh whose vertex
-   positions are measured and expressed in the world frame.
-   */
-  const TriangleSurfaceMesh<T>& mesh_W() const {
-    DRAKE_DEMAND(mesh_W_ != nullptr);
-    return *mesh_W_;
-  }
-
-  /** Returns a reference to the scalar field eₘₙ. */
-  const TriangleSurfaceMeshFieldLinear<T, T>& e_MN() const { return *e_MN_; }
 
   // TODO(#12173): Consider NaN==NaN to be true in equality tests.
   /** Checks to see whether the given ContactSurface object is equal via deep
@@ -296,29 +446,53 @@ class ContactSurface {
    @param surface The contact surface for comparison.
    @returns `true` if the given contact surface is equal.
    */
-  bool Equal(const ContactSurface<T>& surface) const {
-    // First check the meshes.
-    if (!this->mesh_W().Equal(surface.mesh_W())) return false;
-
-    // Now examine the pressure field.
-    if (!this->e_MN().Equal(surface.e_MN())) return false;
-
-    // TODO(SeanCurtis-TRI) This isn't testing the following quantities:
-    //  1. Geometry ids
-    //  2. Gradients.
-
-    // All checks passed.
-    return true;
-  }
+  bool Equal(const ContactSurface<T>& surface) const;
 
  private:
+  using MeshVariant = std::variant<std::unique_ptr<TriangleSurfaceMesh<T>>,
+                                   std::unique_ptr<PolygonSurfaceMesh<T>>>;
+  using FieldVariant =
+      std::variant<std::unique_ptr<TriangleSurfaceMeshFieldLinear<T, T>>,
+                   std::unique_ptr<PolygonSurfaceMeshFieldLinear<T, T>>>;
+
+  // Main delegation constructor. The extra int parameter is to introduce a
+  // disambiguation mechanism.
+  ContactSurface(GeometryId id_M, GeometryId id_N, MeshVariant mesh_W,
+                 FieldVariant e_MN,
+                 std::unique_ptr<std::vector<Vector3<T>>> grad_eM_W,
+                 std::unique_ptr<std::vector<Vector3<T>>> grad_eN_W, int)
+      : id_M_(id_M),
+        id_N_(id_N),
+        mesh_W_(move(mesh_W)),
+        e_MN_(move(e_MN)),
+        grad_eM_W_(move(grad_eM_W)),
+        grad_eN_W_(move(grad_eN_W)) {
+    // If defined the gradient values must map 1-to-1 onto elements.
+    if (is_triangle()) {
+      DRAKE_THROW_UNLESS(grad_eM_W_ == nullptr ||
+                         static_cast<int>(grad_eM_W_->size()) ==
+                             tri_mesh_W().num_elements());
+      DRAKE_THROW_UNLESS(grad_eN_W_ == nullptr ||
+                         static_cast<int>(grad_eN_W_->size()) ==
+                             tri_mesh_W().num_elements());
+    } else {
+      DRAKE_THROW_UNLESS(grad_eM_W_ == nullptr ||
+                         static_cast<int>(grad_eM_W_->size()) ==
+                             poly_mesh_W().num_elements());
+      DRAKE_THROW_UNLESS(grad_eN_W_ == nullptr ||
+                         static_cast<int>(grad_eN_W_->size()) ==
+                             poly_mesh_W().num_elements());
+    }
+    if (id_N_ < id_M_) SwapMAndN();
+  }
+
   // Swaps M and N (modifying the data in place to reflect the change).
   void SwapMAndN() {
     std::swap(id_M_, id_N_);
     // TODO(SeanCurtis-TRI): Determine if this work is necessary. It is neither
     // documented nor tested that the face winding is guaranteed to be one way
     // or the other. Alternatively, this should be documented and tested.
-    mesh_W_->ReverseFaceWinding();
+    std::visit([](auto&& mesh) { mesh->ReverseFaceWinding(); }, mesh_W_);
 
     // Note: the scalar field does not depend on the order of M and N.
     std::swap(grad_eM_W_, grad_eN_W_);
@@ -328,22 +502,20 @@ class ContactSurface {
   GeometryId id_M_;
   // The id of the second geometry N.
   GeometryId id_N_;
+
   // The surface mesh of the contact surface 𝕊ₘₙ between M and N.
-  std::unique_ptr<TriangleSurfaceMesh<T>> mesh_W_;
-  // TODO(SeanCurtis-TRI): We can only construct from a linear field, so store
-  //  it as such for now. This can be promoted once there's a construction that
-  //  uses a different derivation.
+  MeshVariant mesh_W_;
+
   // Represents the scalar field eₘₙ on the surface mesh.
-  std::unique_ptr<TriangleSurfaceMeshFieldLinear<T, T>> e_MN_;
+  FieldVariant e_MN_;
 
   // The gradients of the pressure fields eₘ and eₙ sampled on the contact
-  // surface. There is one gradient value *per contact surface triangle*.
+  // surface. There is one gradient value *per contact surface face*.
   // These quantities may not be defined if the gradient is not well-defined.
   // See class documentation for elaboration.
   std::unique_ptr<std::vector<Vector3<T>>> grad_eM_W_;
   std::unique_ptr<std::vector<Vector3<T>>> grad_eN_W_;
 
-  // TODO(DamrongGuoy): Remove this when we allow direct access to e_MN.
   template <typename U> friend class ContactSurfaceTester;
 };
 


### PR DESCRIPTION
The contact surface now supports the polygonal mesh representation. It maintains old apis (`mesh_W()` and `e_MN()`) which map to the historical triangle representation of those quantities. We'll remove calls to those prior to actually *producing* polygonal contact surfaces.

Relates #15796

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16126)
<!-- Reviewable:end -->
