### PR TITLE
[tools] Attempt to fail-fast when violating ODR in pydrake

### DIFF
--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -563,7 +563,6 @@ drake_pybind_cc_googletest(
     cc_deps = [
         ":type_safe_index_pybind",
         "//bindings/pydrake:test_util_pybind",
-        "//common:nice_type_name",
     ],
 )
 

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -217,11 +217,6 @@ drake_pybind_library(
         ":lcm_pybind",
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/common:deprecation_pybind",
-        "//lcmtypes:contact_results_for_viz",
-        "//lcmtypes:iiwa",
-        "//lcmtypes:image_array",
-        "//lcmtypes:quaternion",
-        "//lcmtypes:schunk",
     ],
     cc_srcs = [
         "lcm_py.cc",


### PR DESCRIPTION
Discussed in [drakedevelopers#python](https://app.slack.com/client/T0JNB2DS4/CAHNDSJUB/thread/C3YB3EV5W-1637277861.042200).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16129)
<!-- Reviewable:end -->
