### PR TITLE
[framework] Improve error message for diagram scalar conversion

### DIFF
--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -315,6 +315,10 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
                             CompositeEventCollection<T>* event_info,
                             T* time) const override;
 
+  std::string GetUnsupportedScalarConversionMessage(
+      const std::type_info& source_type,
+      const std::type_info& destination_type) const final;
+
  private:
   std::unique_ptr<AbstractValue> DoAllocateInput(
       const InputPort<T>& input_port) const final;

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -1204,9 +1204,10 @@ class System : public SystemBase {
   static std::unique_ptr<S<U>> ToScalarType(const S<T>& from) {
     auto base_result = from.template ToScalarTypeMaybe<U>();
     if (!base_result) {
-      ThrowUnsupportedScalarConversion(from, NiceTypeName::Get<U>());
+      const System<T>& upcast_from = from;
+      throw std::logic_error(upcast_from.GetUnsupportedScalarConversionMessage(
+          typeid(T), typeid(U)));
     }
-
     return dynamic_pointer_cast_or_throw<S<U>>(std::move(base_result));
   }
 

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -4,6 +4,7 @@
 
 #include <fmt/format.h>
 
+#include "drake/common/unused.h"
 #include "drake/systems/framework/fixed_input_port_value.h"
 
 namespace {
@@ -281,15 +282,26 @@ void SystemBase::ThrowNotCreatedForThisSystemImpl(
   }
 }
 
-[[noreturn]] void SystemBase::ThrowUnsupportedScalarConversion(
-    const SystemBase& from, const std::string& destination_type_name) {
-  std::stringstream ss;
-  ss << "The object named [" << from.get_name() << "] of type "
-     << NiceTypeName::Get(from)
-     << " does not support scalar conversion to type ["
-     << destination_type_name <<"].";
-  throw std::logic_error(ss.str().c_str());
+std::string SystemBase::GetUnsupportedScalarConversionMessage(
+    const std::type_info& source_type,
+    const std::type_info& destination_type) const {
+  unused(source_type);
+  return fmt::format(
+      "System {} of type {} does not support scalar conversion to type {}",
+      GetSystemPathname(), GetSystemType(),
+      NiceTypeName::Get(destination_type));
 }
+
+namespace internal {
+
+std::string DiagramSystemBaseAttorney::GetUnsupportedScalarConversionMessage(
+    const SystemBase& system, const std::type_info& source_type,
+    const std::type_info& destination_type) {
+  return system.GetUnsupportedScalarConversionMessage(
+      source_type, destination_type);
+}
+
+}  // namespace internal
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/system_scalar_converter.cc
+++ b/systems/framework/system_scalar_converter.cc
@@ -42,6 +42,17 @@ void SystemScalarConverter::Remove() {
   funcs_.erase(Key(typeid(T), typeid(U)));
 }
 
+template <typename T, typename U>
+bool SystemScalarConverter::IsConvertible() const {
+  return IsConvertible(typeid(T), typeid(U));
+}
+
+bool SystemScalarConverter::IsConvertible(
+    const std::type_info& t_info, const std::type_info& u_info) const {
+  const auto* converter = Find(t_info, u_info);
+  return (converter != nullptr);
+}
+
 const SystemScalarConverter::ErasedConverterFunc* SystemScalarConverter::Find(
     const std::type_info& t_info, const std::type_info& u_info) const {
   const auto& key = Key{t_info, u_info};
@@ -106,6 +117,7 @@ DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
 }  // namespace system_scalar_converter_internal
 
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &SystemScalarConverter::IsConvertible<T, U>,
     &SystemScalarConverter::Remove<T, U>
 ))
 

--- a/systems/framework/system_scalar_converter.h
+++ b/systems/framework/system_scalar_converter.h
@@ -113,8 +113,15 @@ class SystemScalarConverter {
   template <typename T, typename U>
   bool IsConvertible() const;
 
+  /// Returns true iff this object can convert a System<U> into a System<T>,
+  /// i.e., whether Convert() will return non-null.
+  bool IsConvertible(
+      const std::type_info& t_info,
+      const std::type_info& u_info) const;
+
   /// Converts a System<U> into a System<T>.  This is the API that LeafSystem
   /// uses to provide a default implementation of DoToAutoDiffXd, etc.
+  /// Returns null when IsConvertible() is false.
   template <typename T, typename U>
   std::unique_ptr<System<T>> Convert(const System<U>& other) const;
 
@@ -175,12 +182,6 @@ class SystemScalarConverter {
 };
 
 #if !defined(DRAKE_DOXYGEN_CXX)
-
-template <typename T, typename U>
-bool SystemScalarConverter::IsConvertible() const {
-  const ErasedConverterFunc* converter = Find(typeid(T), typeid(U));
-  return (converter != nullptr);
-}
 
 template <typename T, typename U>
 std::unique_ptr<System<T>> SystemScalarConverter::Convert(

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -1079,7 +1079,9 @@ TEST_F(DiagramTest, ToAutoDiffXd) {
   const bool use_double_only = true;
   auto diagram_with_double_only = std::make_unique<ExampleDiagram>(
       kSize, use_abstract, use_double_only);
-  EXPECT_THROW(diagram_with_double_only->ToAutoDiffXd(), std::exception);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      diagram_with_double_only->ToAutoDiffXd(), std::exception,
+      ".*ExampleDiagram.*AutoDiffXd.*DoubleOnlySystem.*");
 }
 
 /// Tests that a diagram can be transmogrified to symbolic.

--- a/systems/framework/test/system_scalar_converter_test.cc
+++ b/systems/framework/test/system_scalar_converter_test.cc
@@ -121,6 +121,7 @@ void TestConversionPass() {
 
   // Do the conversion.
   EXPECT_TRUE((dut.IsConvertible<T, U>()));
+  EXPECT_TRUE(dut.IsConvertible(typeid(T), typeid(U)));
   const S<U> original{kMagic};
   const std::unique_ptr<System<T>> converted = dut.Convert<T, U>(original);
   EXPECT_TRUE(converted != nullptr);
@@ -139,6 +140,7 @@ void TestConversionFail() {
 
   // Do the conversion.
   EXPECT_FALSE((dut.IsConvertible<T, U>()));
+  EXPECT_FALSE(dut.IsConvertible(typeid(T), typeid(U)));
   const S<U> original{0};
   const std::unique_ptr<System<T>> converted = dut.Convert<T, U>(original);
 


### PR DESCRIPTION
Closes #14978.

Running the issue's example now produces: `RuntimeError: System ::_ of type drake::systems::Diagram<double> does not support scalar conversion to type drake::AutoDiffXd (because System ::_::meshcat_visualizer of type pydrake.systems.meshcat_visualizer.MeshcatVisualizer does not support scalar conversion to type drake::AutoDiffXd)`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16131)
<!-- Reviewable:end -->
