### PR TITLE
[tools] Declare 20.04 support for release engineering tools

### DIFF
--- a/tools/release_engineering/relnotes.py
+++ b/tools/release_engineering/relnotes.py
@@ -4,7 +4,7 @@ adding commit messages' content into a structured document template.
 This program is intended only for use by Drake maintainers who are preparing
 Drake's release notes documentation.
 
-This program is supported only on Ubuntu Bionic 18.04.
+This program is supported only on Ubuntu Bionic 20.04.
 
 The usage of this tool is outlined in the Drake release playbook
 document:

--- a/tools/workspace/github3_py/repository.bzl
+++ b/tools/workspace/github3_py/repository.bzl
@@ -8,8 +8,8 @@ def github3_py_repository(
     github_archive(
         name = name,
         repository = "sigmavirus24/github3.py",
-        commit = "1.3.0",
-        sha256 = "c6951691c5e1d182c042b49c9fe88dc73f84309c4393f0a8d5684a02464c35a2",  # noqa
+        commit = "3.0.0",
+        sha256 = "1bdd6f19d2c5756cdb017fb47828d31e77916bba0312b2726c67253a439ae61b",  # noqa
         build_file = "@drake//tools/workspace/github3_py:package.BUILD.bazel",
         mirrors = mirrors,
     )

--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -1,7 +1,7 @@
 """Reports on which of Drake's external dependencies can be updated to a more
 recent version.  This is intended for use by Drake maintainers (only).
 
-This program is only supported on Ubuntu Bionic 18.04.
+This program is only supported on Ubuntu Bionic 20.04.
 
 To query GitHub APIs, you'll need to authenticate yourself first.  There are
 two ways to do this:


### PR DESCRIPTION
Upgrade github3_py to latest release.

Closes #16066.

I've tested both tools locally (on 20.04).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16133)
<!-- Reviewable:end -->
