### PR TITLE
[hydro] Add MeshBuilder -- interface for building ContactSurface meshes

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -142,6 +142,8 @@ drake_cc_library(
     srcs = ["contact_surface_utility.cc"],
     hdrs = ["contact_surface_utility.h"],
     deps = [
+        ":mesh_field",
+        ":polygon_surface_mesh",
         ":triangle_surface_mesh",
         "//common:default_scalars",
     ],

--- a/geometry/proximity/contact_surface_utility.h
+++ b/geometry/proximity/contact_surface_utility.h
@@ -7,13 +7,180 @@
  assist in maintaining those invariants.
  */
 
+#include <memory>
+#include <utility>
 #include <vector>
 
+#include "drake/geometry/proximity/polygon_surface_mesh.h"
+#include "drake/geometry/proximity/polygon_surface_mesh_field.h"
 #include "drake/geometry/proximity/triangle_surface_mesh.h"
+#include "drake/geometry/proximity/triangle_surface_mesh_field.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
+
+/* @name "MeshBuilder" implementations
+
+ These MeshBuilder classes are used as the function template parameter in
+ various contact surface algorithms. They provide sufficient infrastructure to
+ build meshes with different representations (e.g., triangle vs polygon).
+
+ MeshBuilders provide two services:
+
+   - Collect mesh and field data associated with the polygon that arises from
+     tet-tet, tet-tri, tet-plane, tri-half space, etc. intersections.
+   - Compute the mesh and field type tailored to that builder.
+
+ A MeshBuilder should be thought of as a frame-dependent quantity. The mesh it
+ builds is likewise a frame-dependent quantity. As such, it should be named with
+ the expected frame clearly identified: e.g., builder_W. Please note the frame
+ expectations on the various function parameters. In the classes' documentation,
+ we refer to the builder's frame as B. Some of the APIs require the fields or
+ meshes that are colliding, and their frames will be named in the scope of those
+ functions. */
+//@{
+
+/* A MeshBuilder type to build a triangle surface mesh. The mesh is built
+ incrementally. Vertices get added to the mesh (each with a corresponding
+ pressure field value). Subsequently, the polygon is declared, referencing
+ previously added vertices by index.
+
+ The TriMeshBuilder will always tessellate every polygon around its centroid
+ (adding an additional vertex to the declared vertices). */
+template <typename T>
+class TriMeshBuilder {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(TriMeshBuilder);
+
+  using ScalarType = T;
+
+  TriMeshBuilder() = default;
+
+  /* Adds a vertex V (and its corresponding field value) to the mesh.
+
+   @param p_BV         The position of the new vertex (measured and expressed in
+                       the builder's frame B).
+   @param field_value  The value of the pressure field evaluated at V.
+   @returns The index of the newly added vertex. */
+  int AddVertex(const Vector3<T>& p_BV, const T& field_value) {
+    vertices_B_.push_back(p_BV);
+    pressures_.push_back(field_value);
+    return static_cast<int>(vertices_B_.size() - 1);
+  }
+
+  /* Adds the polygon to the in-progress mesh. The polygon is defined by
+   indices into the set of vertices that have already been added to the builder.
+
+   @param polygon_vertices  The definition of the polygon to add, expressed as
+                            ordered indices into the currently existing
+                            vertices. They should be ordered in a counter-
+                            clockwise manner such that the implied face normal
+                            points "outward" (using the right-hand rule).
+   @param nhat_B            The normal to the polygon, measured and expressed in
+                            the builder's frame B.
+   @param grad_e_MN_B       The gradient of the pressure field in the domain of
+                            the polygon, expressed in the builder's frame B.
+   @returns The number of faces added to the mesh.
+
+   @sa AddVertex(). */
+  int AddPolygon(const std::vector<int>& polygon_vertices,
+                 const Vector3<T>& nhat_B, const Vector3<T>& grad_e_MN_B);
+
+  /* Returns the total number of vertices accumulated so far. */
+  int num_vertices() const { return static_cast<int>(vertices_B_.size()); }
+
+  /* Returns the total number of faces added by calls to AddPolygon(). */
+  int num_faces() const { return static_cast<int>(faces_.size()); }
+
+  /* Create a mesh and field from the mesh data that has been aggregated by
+   this builder. */
+  std::pair<std::unique_ptr<TriangleSurfaceMesh<T>>,
+            std::unique_ptr<TriangleSurfaceMeshFieldLinear<T, T>>>
+  MakeMeshAndField();
+
+ private:
+  /* The faces of the mesh being built. */
+  std::vector<SurfaceTriangle> faces_;
+  /* The vertices of the mesh being built. */
+  std::vector<Vector3<T>> vertices_B_;
+  /* The pressure values (e) of the surface being built. */
+  std::vector<T> pressures_;
+};
+
+/* A MeshBuilder type to build a polygon surface mesh. The mesh is built
+ incrementally. Vertices get added to the mesh (each with a corresponding
+ pressure field value). Subsequently, the polygon is declared, referencing
+ previously added vertices by index. */
+template <typename T>
+class PolyMeshBuilder {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PolyMeshBuilder);
+
+  using ScalarType = T;
+
+  PolyMeshBuilder();
+
+  /* Adds a vertex V (and its corresponding field value) to the mesh.
+
+   @param p_BV         The position of the new vertex (measured and expressed in
+                       the builder's frame B).
+   @param field_value  The value of the pressure field evaluated at V.
+   @returns The index of the newly added vertex. */
+  int AddVertex(const Vector3<T>& p_BV, const T& field_value) {
+    vertices_B_.push_back(p_BV);
+    pressures_.push_back(field_value);
+    return static_cast<int>(vertices_B_.size() - 1);
+  }
+
+  /* Adds the polygon to the in-progress mesh. The polygon is defined by
+   indices into the set of vertices that have already been added to the builder.
+
+   @param polygon_vertices  The definition of the polygon to add, expressed as
+                            ordered indices into the currently existing
+                            vertices. They should be ordered in a counter-
+                            clockwise manner such that the implied face normal
+                            points "outward" (using the right-hand rule).
+   @param nhat_B            The normal to the polygon, measured and expressed in
+                            the builder's frame B.
+   @param grad_e_MN_B       The gradient of the pressure field in the domain of
+                            the polygon, expressed in the builder's frame B.
+   @returns The number of faces added to the mesh.
+
+   @sa AddVertex(). */
+  int AddPolygon(const std::vector<int>& polygon_vertices,
+                 const Vector3<T>& nhat_B, const Vector3<T>& grad_e_MN_B);
+
+  /* Returns the total number of vertices accumulated so far. */
+  int num_vertices() const { return static_cast<int>(vertices_B_.size()); }
+
+  /* Returns the total number of faces added by calls to AddPolygon(). */
+  int num_faces() const { return polygon_count_; }
+
+  /* Create a mesh and field from the mesh data that has been aggregated by
+   this builder. */
+  std::pair<std::unique_ptr<PolygonSurfaceMesh<T>>,
+            std::unique_ptr<PolygonSurfaceMeshFieldLinear<T, T>>>
+  MakeMeshAndField();
+
+  /* Expose the accumulated, per-face gradients for testing. */
+  std::vector<Vector3<T>>& mutable_per_element_gradients() {
+    return grad_e_MN_B_per_face_;
+  }
+
+ private:
+  /* The number of polygons that have been added. It can't simply be inferred
+   from face_data_.size() because of the face encoding. */
+  int polygon_count_{0};
+  /* The definition of all faces of the mesh being built. */
+  std::vector<int> face_data_;
+  /* The per-face gradients of the pressure field. */
+  std::vector<Vector3<T>> grad_e_MN_B_per_face_;
+  /* The vertices of the mesh being built. */
+  std::vector<Vector3<T>> vertices_B_;
+  /* The pressure values (e) of the surface being built. */
+  std::vector<T> pressures_;
+};
 
 /* Given a planar, N-sided convex `polygon`, computes its centroid. The
  `polygon` is represented as an ordered list of indices into the given set of
@@ -77,10 +244,24 @@ Vector3<T> CalcPolygonCentroid(const std::vector<int>& polygon,
  @pre `n_F` has non-trivial length.
  @tparam_nonsymbolic_scalar */
 template <typename T>
-void AddPolygonToMeshData(const std::vector<int>& polygon,
-                          const Vector3<T>& n_F,
-                          std::vector<SurfaceTriangle>* faces,
-                          std::vector<Vector3<T>>* vertices_F);
+void AddPolygonToTriangleMeshData(const std::vector<int>& polygon,
+                                  const Vector3<T>& n_F,
+                                  std::vector<SurfaceTriangle>* faces,
+                                  std::vector<Vector3<T>>* vertices_F);
+
+/* Adds a polygon (defined by indices into a set of vertices) into the polygon
+ face data (as defined by PolygonSurfaceMesh).
+ 
+ This is similar to AddPolygonToTriangleMeshData() in that the specified polygon
+ is added to some representation of mesh faces. It's different in the following
+ ways:
+
+   1. The face_data isn't literally a vector of discrete faces, but an encoding
+      of the entire set of mesh polygons (as documented by PolygonSurfaceMesh).
+   2. No normal or vertices are required because adding a polygon requires no
+      operation on pre-existing vertex data (i.e., calculation of centroid). */
+void AddPolygonToPolygonMeshData(const std::vector<int>& polygon,
+                                 std::vector<int>* face_data);
 
 /* Determines if the indicated triangle has a face normal that is "in the
  direction" of the given normal.

--- a/geometry/proximity/mesh_half_space_intersection.cc
+++ b/geometry/proximity/mesh_half_space_intersection.cc
@@ -223,8 +223,8 @@ void ConstructTriangleHalfspaceIntersectionPolygon(
         vertices_F, triangle.vertex(2), X_WF,
         vertices_to_newly_created_vertices, new_vertices_W);
 
-    AddPolygonToMeshData({v0_new_index, v1_new_index, v2_new_index}, nhat_W,
-                         new_faces, new_vertices_W);
+    AddPolygonToTriangleMeshData({v0_new_index, v1_new_index, v2_new_index},
+                                 nhat_W, new_faces, new_vertices_W);
     return;
   }
 
@@ -265,7 +265,7 @@ void ConstructTriangleHalfspaceIntersectionPolygon(
         //        ╱________╲
         //      i1          i2
         //
-        AddPolygonToMeshData(
+        AddPolygonToTriangleMeshData(
             {i1_new_index, i2_new_index, edge_i0_i2_intersection_index,
              edge_i0_i1_intersection_index},
             nhat_W, new_faces, new_vertices_W);
@@ -302,9 +302,10 @@ void ConstructTriangleHalfspaceIntersectionPolygon(
             v0, v2, s[i0], s[i2], vertices_F, X_WF,
             edges_to_newly_created_vertices, new_vertices_W);
 
-        AddPolygonToMeshData({i0_new_index, edge_i0_i1_intersection_index,
-                              edge_i0_i2_intersection_index},
-                             nhat_W, new_faces, new_vertices_W);
+        AddPolygonToTriangleMeshData(
+            {i0_new_index, edge_i0_i1_intersection_index,
+             edge_i0_i2_intersection_index},
+            nhat_W, new_faces, new_vertices_W);
 
         return;
       }

--- a/geometry/proximity/mesh_intersection.cc
+++ b/geometry/proximity/mesh_intersection.cc
@@ -355,10 +355,11 @@ void SurfaceVolumeIntersector<T>::SampleVolumeFieldOnSurface(
         X_MN.rotation() * surface_N.face_normal(tri_index).cast<T>();
 
     size_t old_count = surface_faces.size();
-    AddPolygonToMeshData(contact_polygon, nhat_M, &surface_faces,
-                         &surface_vertices_M);
+    AddPolygonToTriangleMeshData(contact_polygon, nhat_M, &surface_faces,
+                                 &surface_vertices_M);
     // TODO(SeanCurtis-TRI) Consider rolling this operation into
-    // AddPolygonToMeshData to eliminate the extra pass through triangles.
+    //  AddPolygonToTriangleMeshData to eliminate the extra pass through
+    //  triangles.
     const Vector3<double>& grad_eMi_M =
         volume_field_M.EvaluateGradient(tet_index);
     for (size_t i = old_count; i < surface_faces.size(); ++i) {

--- a/geometry/proximity/mesh_plane_intersection.cc
+++ b/geometry/proximity/mesh_plane_intersection.cc
@@ -135,7 +135,7 @@ void SliceTetWithPlane(int tet_index,
   const Vector3<T> nhat_W = X_WM.rotation() * plane_M.normal();
   const size_t before = vertices_W->size();
   face_verts.resize(num_intersections);
-  AddPolygonToMeshData(face_verts, nhat_W, faces, vertices_W);
+  AddPolygonToTriangleMeshData(face_verts, nhat_W, faces, vertices_W);
   for (size_t v = before; v < vertices_W->size(); ++v) {
     const Vector3<T> p_MV = X_WM.inverse() * vertices_W->at(v);
     surface_e->emplace_back(field_M.EvaluateCartesian(tet_index, p_MV));

--- a/geometry/proximity/test/contact_surface_utility_test.cc
+++ b/geometry/proximity/test/contact_surface_utility_test.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <limits>
 #include <set>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -20,9 +21,310 @@ namespace {
 
 using Eigen::AngleAxisd;
 using Eigen::Vector3d;
-using math::RotationMatrixd;
 using math::RigidTransformd;
+using math::RotationMatrixd;
+using std::move;
+using std::unique_ptr;
 using std::vector;
+
+// Tests the accumulation API (AddVertex() and AddPolygon()) and the
+// construction API (MakeMeshAndField()).
+//
+// The following is explicitly tested.
+//
+//   a) The added vertex is stored and its corresponding field value likewise.
+//      Note: this isn't validated *during* aggregation, but merely confirmed by
+//      looking at the final, constructed mesh and field.
+//   b) AddPolygon() for vertex indices does the "right" work.
+//     - We call the appropriate "add polygon to mesh" function.
+//       - in this case, for the defined polygon, we should get *five* new
+//         vertices and *four* new triangles.
+//     - The centroid has the correct pressure value stored.
+//     - It *accumulates* face and vertex data across multiple calls.
+//   c) MakeMeshAndField() produces the expected mesh and field.
+//
+//
+// This behavior is orthogonal to scalar type, so, we'll do all of the tests
+// with T = double.
+//
+// We'll add a polygon with four vertices lying on the Ny = 0 plane with a
+// normal pointing in the -Ny direction. Three of the vertices (a, c, & d) are
+// co-linear. Geometrically, the polygon is a triangle and its centroid is
+// simply the average position of a, b, & c. By giving it *four* vertices, we
+// force the centroid computation to perform area-weighted computation. This
+// confirms that the normal is correctly used.
+//
+//           Nz
+//            ┆
+//            ┆ c
+//            ┆  ●
+//            ┆  │╲
+//            ┆ d●  ╲
+//            ┆  │    ╲
+//            ┆  ●─────●
+//            ┆  a      b
+//         ┄┄┄●┄┄┄┄┄┄┄┄┄┄┄┄┄┄ Nx
+//            ┆
+GTEST_TEST(TriMeshBuilderTest, AddingFeatures) {
+  // An arbitrary transform so that we're not using 0's and 1's.
+  const RigidTransformd X_MN(
+      AngleAxisd{M_PI / 7, Vector3d{1, 2, 3}.normalized()},
+      Vector3d{-0.5, 1.25, 0.75});
+  // The triangle defined in frame N so it's easy to reason about.
+  const std::vector<Vector3d> polygon_N{
+      {0.25, 0, 0.25}, {0.5, 0, 0.25}, {0.25, 0, 0.5}, {0.25, 0, 0.35}};
+  const std::vector<Vector3d> polygon_M{X_MN * polygon_N[0],
+                                        X_MN * polygon_N[1],
+                                        X_MN * polygon_N[2],
+                                        X_MN * polygon_N[3]};
+  const Vector3d p_MC_expected =
+      (polygon_M[0] + polygon_M[1] + polygon_M[2]) / 3;
+  const Vector3d nhat_M = X_MN.rotation() * Vector3d(0, -1, 0);
+
+  // To build the mesh, we just need to be able to evaluate *some* pressure
+  // value over the polygon, and know the gradient of the function.
+  const Vector3d grad_p_M{10, 11, 12};
+  auto calc_pressure_in_M = [&grad_p_M](const Vector3d& p_MV) {
+    return grad_p_M.dot(p_MV);
+  };
+
+  TriMeshBuilder<double> builder_M;
+
+  // Confirm that in debug build, bad vertex indices throw.
+#ifdef DRAKE_ASSERT_IS_ARMED
+  EXPECT_THROW(
+      builder_M.AddPolygon({0, 1, 2}, Vector3d::Zero(), Vector3d::Zero()),
+      std::exception);
+#endif
+
+  // First register the vertices; we won't directly test the result here, but
+  // examine the result in the final mesh and field below.
+  std::vector<int> polygon_indices;
+  std::vector<double> expected_pressures;
+  for (int v = 0; v < static_cast<int>(polygon_M.size()); ++v) {
+    const Vector3d& p_MV = polygon_M[v];
+    expected_pressures.push_back(calc_pressure_in_M(p_MV));
+    polygon_indices.push_back(
+        builder_M.AddVertex(p_MV, expected_pressures.back()));
+  }
+  builder_M.AddPolygon(polygon_indices, nhat_M, grad_p_M);
+  // Extra vertex introduces extra pressure value.
+  expected_pressures.push_back(calc_pressure_in_M(p_MC_expected));
+
+  // Confirm vertices and faces have accumulated.
+  const int expected_face_count = 4;
+  const int expected_vertex_count = 5;
+  EXPECT_EQ(builder_M.num_vertices(), expected_vertex_count);
+  EXPECT_EQ(builder_M.num_faces(), expected_face_count);
+
+  // Adding with the same data should double vertex and face counts.
+  polygon_indices.clear();
+  for (int v = 0; v < static_cast<int>(polygon_M.size()); ++v) {
+    const Vector3d& p_MV = polygon_M[v];
+    expected_pressures.push_back(calc_pressure_in_M(p_MV));
+    polygon_indices.push_back(
+        builder_M.AddVertex(p_MV, expected_pressures.back()));
+  }
+  builder_M.AddPolygon(polygon_indices, nhat_M, grad_p_M);
+  // Extra vertex introduces extra pressure value.
+  expected_pressures.push_back(calc_pressure_in_M(p_MC_expected));
+
+  EXPECT_EQ(builder_M.num_vertices(), 2 * expected_vertex_count);
+  EXPECT_EQ(builder_M.num_faces(), 2 * expected_face_count);
+
+  auto [mesh_M, surf_field_M] = builder_M.MakeMeshAndField();
+
+  // The last vertex should be the centroid of the polygon.
+  EXPECT_TRUE(CompareMatrices(mesh_M->vertices().back(), p_MC_expected, 1e-15));
+
+  // Now we want to confirm that the pressure field has appropriate pressure
+  // values -- including the centroid.
+  ASSERT_EQ(mesh_M->num_vertices(),
+            static_cast<int>(expected_pressures.size()));
+  for (int v = 0; v < mesh_M->num_vertices(); ++v) {
+    ASSERT_NEAR(surf_field_M->EvaluateAtVertex(v), expected_pressures[v],
+                10 * std::numeric_limits<double>::epsilon());
+    // NOTE: The TriMeshBuilder doesn't currently build a field with gradients,
+    // so we won't test them.
+  }
+
+  // Confirm that the field is built on the mesh.
+  EXPECT_EQ(mesh_M.get(), &surf_field_M->mesh());
+}
+
+// Same test as for TriMeshBuilderTest -- except no centroid is added. So, the
+// testing logic directly related to the centroid is absent here.
+GTEST_TEST(PolyMeshBuilderTest, AddingFeatures) {
+  // An arbitrary transform so that we're not using 0's and 1's.
+  const RigidTransformd X_MN(
+      AngleAxisd{M_PI / 7, Vector3d{1, 2, 3}.normalized()},
+      Vector3d{-0.5, 1.25, 0.75});
+  // The polygon's defined in frame N so it's easy to reason about.
+  const std::vector<Vector3d> polygon_N{
+      {0.25, 0, 0.25}, {0.5, 0, 0.25}, {0.25, 0, 0.5}, {0.25, 0, 0.35}};
+  const std::vector<Vector3d> polygon_M{X_MN * polygon_N[0],
+                                        X_MN * polygon_N[1],
+                                        X_MN * polygon_N[2],
+                                        X_MN * polygon_N[3]};
+  const Vector3d nhat_M = X_MN.rotation() * Vector3d(0, -1, 0);
+
+  // To build the mesh, we just need to be able to evaluate *some* pressure
+  // value over the polygon, and know the gradient of the function.
+  const Vector3d grad_p_M{10, 11, 12};
+  auto calc_pressure_in_M = [&grad_p_M](const Vector3d& p_MV) {
+    return grad_p_M.dot(p_MV);
+  };
+
+  PolyMeshBuilder<double> builder_M;
+
+  // Confirm that in debug build, bad vertex indices throw.
+#ifdef DRAKE_ASSERT_IS_ARMED
+  EXPECT_THROW(
+      builder_M.AddPolygon({0, 1, 2}, Vector3d::Zero(), Vector3d::Zero()),
+      std::exception);
+#endif
+
+  // First register the vertices; we won't directly test the result here, but
+  // examine the result in the final mesh and field below.
+  std::vector<int> polygon_indices;
+  std::vector<double> expected_pressures;
+  for (int v = 0; v < static_cast<int>(polygon_M.size()); ++v) {
+    const Vector3d& p_MV = polygon_M[v];
+    expected_pressures.push_back(calc_pressure_in_M(p_MV));
+    polygon_indices.push_back(
+        builder_M.AddVertex(p_MV, expected_pressures.back()));
+  }
+  builder_M.AddPolygon(polygon_indices, nhat_M, grad_p_M);
+
+  // Confirm vertices and faces have accumulated.
+  const int expected_face_count = 1;
+  const int expected_vertex_count = 4;
+  EXPECT_EQ(builder_M.num_vertices(), expected_vertex_count);
+  EXPECT_EQ(builder_M.num_faces(), expected_face_count);
+
+  // Adding with the same data should double vertex and face counts.
+  polygon_indices.clear();
+  for (int v = 0; v < static_cast<int>(polygon_M.size()); ++v) {
+    const Vector3d& p_MV = polygon_M[v];
+    expected_pressures.push_back(calc_pressure_in_M(p_MV));
+    polygon_indices.push_back(
+        builder_M.AddVertex(p_MV, expected_pressures.back()));
+  }
+  builder_M.AddPolygon(polygon_indices, nhat_M, grad_p_M);
+
+  EXPECT_EQ(builder_M.num_vertices(), 2 * expected_vertex_count);
+  EXPECT_EQ(builder_M.num_faces(), 2 * expected_face_count);
+
+  auto [mesh_M, surf_field_M] = builder_M.MakeMeshAndField();
+
+  // Now we want to confirm that the pressure field has appropriate pressure
+  // values -- including the centroid.
+  ASSERT_EQ(mesh_M->num_vertices(),
+            static_cast<int>(expected_pressures.size()));
+  for (int v = 0; v < mesh_M->num_vertices(); ++v) {
+    ASSERT_NEAR(surf_field_M->EvaluateAtVertex(v), expected_pressures[v],
+                10 * std::numeric_limits<double>::epsilon());
+  }
+  for (int p = 0; p < mesh_M->num_elements(); ++p) {
+    ASSERT_TRUE(CompareMatrices(surf_field_M->EvaluateGradient(p), grad_p_M));
+  }
+
+  // Confirm that the field is built on the mesh.
+  EXPECT_EQ(mesh_M.get(), &surf_field_M->mesh());
+}
+
+// Definition of a simple linear function f(x) = ∇f(x) + d for use in the
+// EquivalentForceIntegration test below.
+class LinearFunction {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LinearFunction);
+
+  LinearFunction(const Vector3d& grad_F, double d)
+      : grad_F_(grad_F), d_(d) {}
+
+  double operator()(const Vector3d& p_FV) const {
+    return grad_F_.dot(p_FV) + d_;
+  }
+  const Vector3d& gradient() const { return grad_F_; }
+
+ private:
+  Vector3d grad_F_;
+  double d_{};
+};
+
+// Definition of a polygon (the vertices and the pressure field defined on the
+// domain of the polygon) for the EquivalentForceIntegration test below.
+class Polygon {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Polygon)
+
+  Polygon(vector<Vector3d> vertices_P, const LinearFunction& func_P)
+      : vertices_P_(move(vertices_P)), func_P_(func_P) {}
+
+  const vector<Vector3d> vertices() const { return vertices_P_; }
+  double EvalPressure(const Vector3d& p_PV) const { return func_P_(p_PV); }
+  const Vector3d& pressure_gradient() const { return func_P_.gradient(); }
+  Vector3d normal() const {
+    const Vector3d p_AB = vertices_P_[1] - vertices_P_[0];
+    const Vector3d p_AC = vertices_P_[2] - vertices_P_[0];
+    return p_AB.cross(p_AC).normalized();
+  }
+
+ private:
+  vector<Vector3d> vertices_P_;
+  LinearFunction func_P_;
+};
+
+// The meshes we build (either polygon or triangle) should produce a mesh that
+// integrates to the same result. So, we'll create a couple of arbitrary
+// polygons (with equally arbitrary pressure functions) so that we can confirm
+// that the resulting meshes and fields integrate to the same normal force.
+GTEST_TEST(MeshBuilder, EquivalentForceIntegration) {
+  vector<Polygon> polygons_M{
+      {{Vector3d{0, 0, 0}, Vector3d{0, 1, 0}, Vector3d{0, 0, 1}},
+       LinearFunction{Vector3d{1, 2, 3}, 3}},
+      {{Vector3d{1, -1, 0}, Vector3d{1, 1, 0}, Vector3d{-1, 1, 0},
+        Vector3d{-1, -1, 0}},
+       LinearFunction{Vector3d{-1, 2, -3}, 2}}
+       };
+
+  TriMeshBuilder<double> tri_builder_M;
+  PolyMeshBuilder<double> poly_builder_M;
+  for (const auto& polygon_M : polygons_M) {
+    vector<int> tri_indices;
+    vector<int> poly_indices;
+    for (const auto& p_MV : polygon_M.vertices()) {
+      tri_indices.push_back(
+          tri_builder_M.AddVertex(p_MV, polygon_M.EvalPressure(p_MV)));
+      poly_indices.push_back(
+          poly_builder_M.AddVertex(p_MV, polygon_M.EvalPressure(p_MV)));
+    }
+    const Vector3d nhat_M = polygon_M.normal();
+    tri_builder_M.AddPolygon(tri_indices, nhat_M,
+                             polygon_M.pressure_gradient());
+    poly_builder_M.AddPolygon(poly_indices, nhat_M,
+                              polygon_M.pressure_gradient());
+  }
+
+  auto [tri_mesh, tri_field] = tri_builder_M.MakeMeshAndField();
+  auto [poly_mesh, poly_field] = poly_builder_M.MakeMeshAndField();
+
+  // Integrate the pressure over each mesh. They should integrate to the same
+  // force vector.
+  auto calc_normal_force = [](const auto& mesh, const auto& field) {
+    Vector3d force{0, 0, 0};
+    for (int e = 0; e < mesh.num_elements(); ++e) {
+      const Vector3d centroid = mesh.element_centroid(e);
+      force += mesh.area(e) * field.EvaluateCartesian(e, centroid) *
+               mesh.face_normal(e);
+    }
+    return force;
+  };
+
+  const Vector3d tri_force = calc_normal_force(*tri_mesh, *tri_field);
+  const Vector3d poly_force = calc_normal_force(*poly_mesh, *poly_field);
+  ASSERT_TRUE(CompareMatrices(tri_force, poly_force, 8e-16));
+}
 
 class ContactSurfaceUtilityTest : public ::testing::Test {
  protected:
@@ -382,7 +684,7 @@ TEST_F(ContactSurfaceUtilityTest, PolygonCentroidTest_NormalUse) {
 //   3. For N-sided polygon, N faces are added to the set of faces.
 //   4. Each of the triangles have winding that produce a normal in the same
 //      direction as the input polygons.
-TEST_F(ContactSurfaceUtilityTest, AddPolygonToMeshData) {
+TEST_F(ContactSurfaceUtilityTest, AddPolygonToTriangleMeshData) {
   // Vertices sufficient to support a well-defined quad.
   //
   //             y
@@ -405,7 +707,7 @@ TEST_F(ContactSurfaceUtilityTest, AddPolygonToMeshData) {
   vector<Vector3d> vertices_M(vertices_source);
   const vector<int> quad{0, 1, 2, 3};
   const Vector3d nhat_M{0, 0, 1};
-  AddPolygonToMeshData(quad, nhat_M, &faces, &vertices_M);
+  AddPolygonToTriangleMeshData(quad, nhat_M, &faces, &vertices_M);
 
   auto triangle_normal = [](int v0, int v1, int v2,
                             const vector<Vector3d>& vertices_F) -> Vector3d {
@@ -444,6 +746,34 @@ TEST_F(ContactSurfaceUtilityTest, AddPolygonToMeshData) {
   // would pass. We can consider making the test more robust to exclude this
   // possibility but are currently implicitly relying on the idea that such an
   // egregious error would be obvious during visualization.
+}
+
+// This confirms that in adding a new polygon to existing mesh data:
+//
+//   1. The polygon is properly encoded
+//      - The previous contents of the face data is unchanged.
+//      - Four the 4-gon added, the last four entries should be
+//          4, v0, v1, v2, v3
+TEST_F(ContactSurfaceUtilityTest, AddPolygonToPolygonMeshData) {
+  // For this test, we don't actually *need* vertices.
+
+  // Pre-populate the data with recognizable garbage so we can confirm that the
+  // new polygon strictly gets appended.
+  vector<int> face_data{-1, -2, -3, -4};
+  const vector<int> original_face_data(face_data);
+
+  const vector<int> polygon{10, 20, 30, 40};
+  AddPolygonToPolygonMeshData(polygon, &face_data);
+
+  ASSERT_EQ(face_data.size(), original_face_data.size() + polygon.size() + 1);
+  for (size_t i = 0; i < original_face_data.size(); ++i) {
+    ASSERT_EQ(face_data[i], original_face_data[i]);
+  }
+  ASSERT_EQ(face_data[original_face_data.size()], 4);
+  auto iter = face_data.begin() + (original_face_data.size());
+  for (size_t i = 0; i < polygon.size(); ++i) {
+    ASSERT_EQ(polygon[i], *(++iter));
+  }
 }
 
 }  // namespace

--- a/geometry/proximity/test/mesh_half_space_intersection_test.cc
+++ b/geometry/proximity/test/mesh_half_space_intersection_test.cc
@@ -114,7 +114,7 @@ static TriangleSurfaceMesh<double> CreateMeshWithCentroids(
     // confirm that the new faces have normals that match the input face.
     std::vector<int> polygon{f.vertex(0), f.vertex(1), f.vertex(2)};
     const Vector3d& nhat_W = R_WF * mesh_F.face_normal(f_index);
-    AddPolygonToMeshData(polygon, nhat_W, &new_faces, &new_vertices_W);
+    AddPolygonToTriangleMeshData(polygon, nhat_W, &new_faces, &new_vertices_W);
 
     // Confirm polygon winding matches between source triangle and triangles
     // in the new fan.
@@ -564,7 +564,8 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, QuadrilateralResults) {
   expected_vertices_W = quad_W;
   const int b{0}, c{1}, d{2}, e{3};
   const std::vector<int> polygon{b, c, d, e};
-  AddPolygonToMeshData(polygon, nhat_W, &expected_faces, &expected_vertices_W);
+  AddPolygonToTriangleMeshData(polygon, nhat_W, &expected_faces,
+                               &expected_vertices_W);
   SCOPED_TRACE("Triangle intersects; forms quad");
   this->VerifyMeshesEquivalent(
       TriangleSurfaceMesh<double>{move(expected_faces),
@@ -626,7 +627,8 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, OutsideInsideOn) {
   expected_vertices_W = degenerated_quadrilateral_W;
   const int b{0}, c{1}, d{2}, e{3};
   std::vector<int> polygon{b, c, d, e};
-  AddPolygonToMeshData(polygon, nhat_W, &expected_faces, &expected_vertices_W);
+  AddPolygonToTriangleMeshData(polygon, nhat_W, &expected_faces,
+                               &expected_vertices_W);
   SCOPED_TRACE("Triangle intersects; single vertex on boundary");
   this->VerifyMeshesEquivalent(
       TriangleSurfaceMesh<double>{move(expected_faces),
@@ -678,7 +680,8 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, OneInsideTwoOutside) {
   const Vector3d nhat_W = X_WF_d.rotation() * nhat_F;
   expected_vertices_W = triangle_W;
   std::vector<int> polygon{0, 1, 2};
-  AddPolygonToMeshData(polygon, nhat_W, &expected_faces, &expected_vertices_W);
+  AddPolygonToTriangleMeshData(polygon, nhat_W, &expected_faces,
+                               &expected_vertices_W);
   SCOPED_TRACE("Triangle intersects; forms a smaller triangle");
   this->VerifyMeshesEquivalent(
       TriangleSurfaceMesh<double>{move(expected_faces),


### PR DESCRIPTION
The mesh builder classes extract the knowledge of how to add intersection polygons to mesh representations. The intersection algorithms can simply generate the polygon (using whatever logic they require) and pass the data over to the builder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16134)
<!-- Reviewable:end -->
