### PR TITLE
[multibody] Disable asan for supernodal_solver_test.

### DIFF
--- a/multibody/contact_solvers/BUILD.bazel
+++ b/multibody/contact_solvers/BUILD.bazel
@@ -221,6 +221,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "supernodal_solver_test",
+    tags = ["no_asan"],
     deps = [
         ":supernodal_solver",
         "//common/test_utilities:expect_throws_message",


### PR DESCRIPTION
Otherwise, these two CI jobs failed.
linux-bionic-clang-bazel-continuous-address-sanitizer
linux-bionic-clang-bazel-continuous-everything-address-sanitizer
Without this change, "bazel test --config=asan //multibody/..." failed on bionic with clang.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16136)
<!-- Reviewable:end -->
