### PR TITLE
[meshcat] Add Meshcat::StaticHtml()

### DIFF
--- a/bindings/pydrake/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry_py_visualizers.cc
@@ -280,7 +280,8 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def("DeleteSlider", &Class::DeleteSlider, py::arg("name"),
             cls_doc.DeleteSlider.doc)
         .def("DeleteAddedControls", &Class::DeleteAddedControls,
-            cls_doc.DeleteAddedControls.doc);
+            cls_doc.DeleteAddedControls.doc)
+        .def("StaticHtml", &Class::StaticHtml, cls_doc.StaticHtml.doc);
     // Note: we intentionally do not bind the advanced methods (HasProperty and
     // GetPacked*) which were intended primarily for testing in C++.
   }

--- a/bindings/pydrake/test/geometry_visualizers_test.py
+++ b/bindings/pydrake/test/geometry_visualizers_test.py
@@ -141,6 +141,8 @@ class TestGeometryVisualizers(unittest.TestCase):
             name="slider"), 0.7, delta=1e-14)
         meshcat.DeleteSlider(name="slider")
         meshcat.DeleteAddedControls()
+        self.assertIn("data:application/octet-binary;base64",
+                      meshcat.StaticHtml())
 
     def test_meshcat_animation(self):
         animation = mut.MeshcatAnimation(frames_per_second=64)

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -420,6 +420,15 @@ class Meshcat {
 
   //@}
 
+  /** Returns an HTML string that can be saved to a file for a snapshot of the
+  visualizer and its contents. The HTML can be viewed in the browser
+  without any connection to a Meshcat "server" (e.g. `this`). This is a great
+  way to save and share your 3D content.
+
+  Note that controls (e.g. sliders and buttons) are not included in the HTML
+  output, because their usefulness relies on a connection to the server. */
+  std::string StaticHtml();
+
   /* These remaining public methods are intended to primarily for testing. These
   calls must safely acquire the data from the websocket thread and will block
   execution waiting for that data to be acquired. They are intentionally

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -1,4 +1,9 @@
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+
 #include "drake/common/find_resource.h"
+#include "drake/common/temp_directory.h"
 #include "drake/geometry/meshcat.h"
 #include "drake/geometry/meshcat_animation.h"
 #include "drake/geometry/meshcat_visualizer.h"
@@ -270,6 +275,25 @@ Open up your browser to the URL above.
 
   std::cout << "[Press RETURN to continue]." << std::endl;
   std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+
+  const std::string html_filename(temp_directory() + "/meshcat_static.html");
+  std::ofstream html_file(html_filename);
+  html_file << meshcat->StaticHtml();
+  html_file.close();
+
+  std::cout << "A standalone HTML file capturing this scene (including the "
+               "animation) has been written to file://"
+            << html_filename
+            << "\nOpen that location in your browser now and confirm that "
+               "the iiwa is visible and the animation plays."
+            << std::endl;
+
+  std::cout << "[Press RETURN to continue]." << std::endl;
+    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+
+  std::remove(html_filename.c_str());
+  std::cout
+      << "Note: I've deleted the temporary HTML file (it's several Mb).\n\n";
 
   meshcat->AddButton("ButtonTest");
   meshcat->AddSlider("SliderTest", 0, 1, 0.01, 0.5);


### PR DESCRIPTION
Adds support for saving the scene (including animations) into a
standalone HTML file which can be shared and enjoyed.  It is
equivalent to the `static_html()` method from `meshcat-python`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16142)
<!-- Reviewable:end -->
