### PR TITLE
[meshcat] Avoid dropping messages due to backpressure, and provide Flush()

### DIFF
--- a/bindings/pydrake/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry_py_visualizers.cc
@@ -199,6 +199,7 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def("web_url", &Class::web_url, cls_doc.web_url.doc)
         .def("port", &Class::port, cls_doc.port.doc)
         .def("ws_url", &Class::ws_url, cls_doc.ws_url.doc)
+        .def("Flush", &Class::Flush, cls_doc.Flush.doc)
         .def("SetObject",
             py::overload_cast<std::string_view, const Shape&, const Rgba&>(
                 &Class::SetObject),

--- a/bindings/pydrake/test/geometry_visualizers_test.py
+++ b/bindings/pydrake/test/geometry_visualizers_test.py
@@ -143,6 +143,7 @@ class TestGeometryVisualizers(unittest.TestCase):
         meshcat.DeleteAddedControls()
         self.assertIn("data:application/octet-binary;base64",
                       meshcat.StaticHtml())
+        meshcat.Flush()
 
     def test_meshcat_animation(self):
         animation = mut.MeshcatAnimation(frames_per_second=64)

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -75,24 +75,6 @@ struct PerSocketData {
 using WebSocket = uWS::WebSocket<kSsl, kIsServer, PerSocketData>;
 using MsgPackMap = std::map<std::string, msgpack::object>;
 
-// The maximum "backpressure" allowed each websocket, in bytes.  This
-// effectively sets a maximum size for messages, which may include mesh files
-// and texture maps.  50mb is a guess at a compromise that is safely larger than
-// reasonable meshfiles.
-constexpr static double kMaxBackPressure{50 * 1024 * 1024};
-
-void CheckBackPressure(const std::string& path, const std::string& message) {
-  if (message.size() > kMaxBackPressure) {
-    drake::log()->warn(
-        "The message describing the object at {} is too large for the "
-        "current websocket setup (size {} is greater than the max "
-        "backpressure {}).  You will either need to reduce the size of "
-        "your object/mesh/textures, or modify the code to increase the "
-        "allowance.",
-        path, message.size(), kMaxBackPressure);
-  }
-}
-
 // Encode the meshcat command into a Javascript fetch() command.  The particular
 // syntax using `fetch()` was replicated from the corresponding functionality in
 // meshcat-python.
@@ -533,6 +515,43 @@ class Meshcat::WebSocketPublisher {
     return port_;
   }
 
+  void Flush() const {
+    DRAKE_DEMAND(IsThread(main_thread_id_));
+    DRAKE_DEMAND(loop_ != nullptr);
+
+    // We simply loop until the backpressure is zero.  In each iteration,
+    // loop->defer will add our query to the queue, allowing the websocket
+    // thread to drain before our request gets processed again.
+    int main_backpressure;
+
+    // Set a very conservative iteration limit; this is only intended to escape
+    // infinite loops that would be the result of a logic bug.
+    const int kIterationLimit{100000};
+    int iteration = 0;
+
+    do {
+      std::promise<int> p;
+      std::future<int> f = p.get_future();
+      loop_->defer([this, p = std::move(p)]() mutable {
+        DRAKE_DEMAND(IsThread(websocket_thread_id_));
+        int websocket_backpressure = 0;
+        for (WebSocket* ws : websockets_) {
+          websocket_backpressure += ws->getBufferedAmount();
+        }
+        p.set_value(websocket_backpressure);
+      });
+      main_backpressure = f.get();
+      ++iteration;
+    } while (main_backpressure > 0 && iteration < kIterationLimit);
+
+    if (main_backpressure > 0) {
+      drake::log()->warn(
+          "Meshcat::Flush() reached an iteration limit before the buffer could "
+          "be completely flushed.  Our intention was that this limit should "
+          "never be reached. If you encounter this, please open an issue.");
+    }
+  }
+
   void SetObject(std::string_view path, const Shape& shape, const Rgba& rgba) {
     DRAKE_DEMAND(IsThread(main_thread_id_));
     DRAKE_DEMAND(loop_ != nullptr);
@@ -592,7 +611,6 @@ class Meshcat::WebSocketPublisher {
       // (here and throughout) to avoid this copy.
       // https://github.com/redboltz/msgpack-c/wiki/v2_0_cpp_packer
       std::string message = message_stream.str();
-      CheckBackPressure(data.path, message);
       app_->publish("all", message, uWS::OpCode::BINARY, false);
       SceneTreeElement& e = scene_tree_root_[data.path];
       e.object() = std::move(message);
@@ -637,7 +655,6 @@ class Meshcat::WebSocketPublisher {
       std::stringstream message_stream;
       msgpack::pack(message_stream, data);
       std::string message = message_stream.str();
-      CheckBackPressure(data.path, message);
       app_->publish("all", message, uWS::OpCode::BINARY, false);
       SceneTreeElement& e = scene_tree_root_[data.path];
       e.object() = std::move(message);
@@ -678,7 +695,6 @@ class Meshcat::WebSocketPublisher {
       std::stringstream message_stream;
       msgpack::pack(message_stream, data);
       std::string message = message_stream.str();
-      CheckBackPressure(data.path, message);
       app_->publish("all", message, uWS::OpCode::BINARY, false);
       SceneTreeElement& e = scene_tree_root_[data.path];
       e.object() = std::move(message);
@@ -725,7 +741,6 @@ class Meshcat::WebSocketPublisher {
       std::stringstream message_stream;
       msgpack::pack(message_stream, data);
       std::string message = message_stream.str();
-      CheckBackPressure(data.path, message);
       app_->publish("all", message, uWS::OpCode::BINARY, false);
       SceneTreeElement& e = scene_tree_root_[data.path];
       e.object() = std::move(message);
@@ -1239,7 +1254,7 @@ class Meshcat::WebSocketPublisher {
       websockets_.emplace(ws);
       ws->subscribe("all");
       // Update this new connection with previously published data.
-      SendTree(ws);
+      scene_tree_root_.Send(ws);
       if (!animation_.empty()) {
         ws->send(animation_);
       }
@@ -1259,11 +1274,9 @@ class Meshcat::WebSocketPublisher {
         }
       }
     };
-    // TODO(russt): I could increase this more if necessary (when it was too
-    // low, some SetObject messages were dropped).  But at some point the real
-    // fix is to actually throttle the sending (e.g. by slowing down the main
-    // thread).
-    behavior.maxBackpressure = kMaxBackPressure;
+    // Set maxBackpressure = 0 so that uWS does *not* drop any messages due to
+    // back pressure.
+    behavior.maxBackpressure = 0;
     behavior.message = [this](WebSocket* ws, std::string_view message,
                               uWS::OpCode op_code) {
       unused(ws, op_code);
@@ -1338,11 +1351,6 @@ class Meshcat::WebSocketPublisher {
     }
   }
 
-  void SendTree(WebSocket* ws) {
-    DRAKE_DEMAND(IsThread(websocket_thread_id_));
-    scene_tree_root_.Send(ws);
-  }
-
   std::string FullPath(std::string_view path) const {
     DRAKE_DEMAND(IsThread(main_thread_id_));
     while (path.size() > 1 && path.back() == '/') {
@@ -1408,6 +1416,10 @@ int Meshcat::port() const {
 
 std::string Meshcat::ws_url() const {
   return fmt::format("ws://localhost:{}", publisher_->port());
+}
+
+void Meshcat::Flush() const {
+  publisher_->Flush();
 }
 
 void Meshcat::SetObject(std::string_view path, const Shape& shape,

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -103,6 +103,13 @@ class Meshcat {
   interface.  Most users should connect via a browser opened to web_url(). */
   std::string ws_url() const;
 
+  /** Blocks the calling thread until all buffered data in the websocket thread
+  has been sent to any connected clients. This can be especially useful when
+  sending many or large mesh files / texture maps, to avoid large "backpressure"
+  and/or simply to make sure that the simulation does not get far ahead of the
+  visualization. */
+  void Flush() const;
+
   /** Sets the 3D object at a given `path` in the scene tree.  Note that
   `path`="/foo" will always set an object in the tree at "/foo/<object>".  See
   @ref meshcat_path.  Any objects previously set at this `path` will be

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -135,6 +135,11 @@ Open up your browser to the URL above.
   std::cout << "[Press RETURN to continue]." << std::endl;
   std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
+  std::cout << "Calling meshcat.Flush(), which will block until all clients "
+               "have received all the data)...";
+  meshcat->Flush();
+  std::cout << "Done." << std::endl;
+
   std::cout << "Animations:\n";
   MeshcatAnimation animation;
   std::cout << "- the red sphere should move up and down in z.\n";

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -457,6 +457,10 @@ GTEST_TEST(MeshcatTest, SetPropertyWebSocket) {
       "property": "visible",
       "value": false
     })""");
+
+  // Confirm that meshcat.Flush() doesn't crash even when we've had multiple
+  // clients connect, received data, and disconnect.
+  meshcat.Flush();
 }
 
 GTEST_TEST(MeshcatTest, SetPerspectiveCamera) {


### PR DESCRIPTION
Resolves #16109

After reading through the uwebsockets code, I understand now that the
maxBackpressure websocket option was *only* being used to decide when
to drop packets.  We never want to drop packets, so setting that to
zero is the correct behavior.

Backpressure is still a legitmate concern.  If we keep shoving data
into the send buffer faster than the websocket can send, then
backpressure will build up (consuming memory and causing the
visualizer to fall behind the main thread).  I've provided a `Flush()`
command for Meshcat which allows users to manually sync the main
thread if it is useful/needed in their application.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16144)
<!-- Reviewable:end -->
