### PR TITLE
Revert "[geometry:optimization] Add collection of fixes to speed up Iris region generation"

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -534,7 +534,6 @@ drake_py_unittest(
     deps = [
         ":geometry_py",
         ":math_py",
-        "//bindings/pydrake/common/test_utilities:deprecation_py",
         "//bindings/pydrake/multibody:parsing_py",
         "//bindings/pydrake/multibody:plant_py",
         "//bindings/pydrake/solvers:mathematicalprogram_py",

--- a/bindings/pydrake/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry_py_optimization.cc
@@ -205,9 +205,6 @@ void DefineGeometryOptimization(py::module m) {
       .def_readwrite("termination_threshold",
           &IrisOptions::termination_threshold,
           doc.IrisOptions.termination_threshold.doc)
-      .def_readwrite("relative_termination_threshold",
-          &IrisOptions::relative_termination_threshold,
-          doc.IrisOptions.relative_termination_threshold.doc)
       .def_readwrite("configuration_space_margin",
           &IrisOptions::configuration_space_margin,
           doc.IrisOptions.configuration_space_margin.doc)
@@ -219,13 +216,11 @@ void DefineGeometryOptimization(py::module m) {
             "require_sample_point_is_contained={}, "
             "iteration_limit={}, "
             "termination_threshold={}, "
-            "relative_termination_threshold={}, "
             "configuration_space_margin={}, "
             "enable_ibex={}"
             ")")
             .format(self.require_sample_point_is_contained,
                 self.iteration_limit, self.termination_threshold,
-                self.relative_termination_threshold,
                 self.configuration_space_margin, self.enable_ibex);
       });
 
@@ -235,27 +230,9 @@ void DefineGeometryOptimization(py::module m) {
   m.def("MakeIrisObstacles", &MakeIrisObstacles, py::arg("query_object"),
       py::arg("reference_frame") = std::nullopt, doc.MakeIrisObstacles.doc);
 
-  m.def("IrisInConfigurationSpace",
-      py::overload_cast<const multibody::MultibodyPlant<double>&,
-          const systems::Context<double>&, const IrisOptions&>(
-          &IrisInConfigurationSpace),
-      py::arg("plant"), py::arg("context"), py::arg("options") = IrisOptions(),
+  m.def("IrisInConfigurationSpace", &IrisInConfigurationSpace, py::arg("plant"),
+      py::arg("context"), py::arg("sample"), py::arg("options") = IrisOptions(),
       doc.IrisInConfigurationSpace.doc);
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  m.def("IrisInConfigurationSpace",
-      WrapDeprecated(doc.IrisInConfigurationSpace.doc_deprecated,
-          [](const multibody::MultibodyPlant<double>& plant,
-              const systems::Context<double>& context,
-              const Eigen::Ref<const Eigen::VectorXd>& sample,
-              const IrisOptions& options) {
-            return IrisInConfigurationSpace(plant, context, sample, options);
-          }),
-      py::arg("plant"), py::arg("context"), py::arg("sample"),
-      py::arg("options") = IrisOptions(),
-      doc.IrisInConfigurationSpace.doc_deprecated);
-#pragma GCC diagnostic pop
 
   // GraphOfConvexSets
   {

--- a/bindings/pydrake/test/geometry_optimization_test.py
+++ b/bindings/pydrake/test/geometry_optimization_test.py
@@ -4,7 +4,6 @@ import unittest
 
 import numpy as np
 
-from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.geometry import (
     Box, Capsule, Cylinder, Ellipsoid, FramePoseVector, GeometryFrame,
     GeometryInstance, SceneGraph, Sphere,
@@ -206,7 +205,6 @@ class TestGeometryOptimization(unittest.TestCase):
         options.require_sample_point_is_contained = True
         options.iteration_limit = 1
         options.termination_threshold = 0.1
-        options.relative_termination_threshold = 0.01
         self.assertNotIn("object at 0x", repr(options))
         region = mut.Iris(
             obstacles=obstacles, sample=[2, 3.4, 5],
@@ -247,14 +245,10 @@ class TestGeometryOptimization(unittest.TestCase):
         diagram = builder.Build()
         context = diagram.CreateDefaultContext()
         options = mut.IrisOptions()
-        with catch_drake_warnings(expected_count=1):
-            region = mut.IrisInConfigurationSpace(
-                plant=plant, context=plant.GetMyContextFromRoot(context),
-                sample=[0], options=options)
-        plant.SetPositions(plant.GetMyMutableContextFromRoot(context), [0])
         region = mut.IrisInConfigurationSpace(
-            plant=plant, context=plant.GetMyContextFromRoot(context),
-            options=options)
+            plant=plant,
+            context=plant.GetMyContextFromRoot(context),
+            sample=[0], options=options)
         self.assertIsInstance(region, mut.ConvexSet)
         self.assertEqual(region.ambient_dimension(), 1)
         self.assertTrue(region.PointInSet([1.0]))

--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <limits>
 #include <optional>
-#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -32,8 +31,9 @@ using multibody::Body;
 using multibody::Frame;
 using multibody::JacobianWrtVariable;
 using multibody::MultibodyPlant;
-using symbolic::Expression;
 using systems::Context;
+using symbolic::Expression;
+
 
 HPolyhedron Iris(const ConvexSets& obstacles, const Ref<const VectorXd>& sample,
                  const HPolyhedron& domain, const IrisOptions& options) {
@@ -64,7 +64,6 @@ HPolyhedron Iris(const ConvexSets& obstacles, const Ref<const VectorXd>& sample,
   MatrixXd tangent_matrix;
 
   while (true) {
-    DRAKE_ASSERT(best_volume > 0);
     // Find separating hyperplanes
     for (int i = 0; i < N; ++i) {
       const auto touch = E.MinimumUniformScalingToTouch(*obstacles[i]);
@@ -107,11 +106,7 @@ HPolyhedron Iris(const ConvexSets& obstacles, const Ref<const VectorXd>& sample,
 
     E = P.MaximumVolumeInscribedEllipsoid();
     const double volume = E.Volume();
-    const double delta_volume = volume - best_volume;
-    if (delta_volume <= options.termination_threshold) {
-      break;
-    }
-    if (delta_volume / best_volume <= options.relative_termination_threshold) {
+    if (volume - best_volume <= options.termination_threshold) {
       break;
     }
     best_volume = volume;
@@ -213,7 +208,7 @@ class SamePointConstraint : public solvers::Constraint {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SamePointConstraint)
 
   SamePointConstraint(const MultibodyPlant<double>* plant,
-                      const Context<double>& context)
+                  const Context<double>& context)
       : solvers::Constraint(3, plant ? plant->num_positions() + 6 : 0,
                             Vector3d::Zero(), Vector3d::Zero()),
         plant_(plant),
@@ -224,9 +219,13 @@ class SamePointConstraint : public solvers::Constraint {
 
   ~SamePointConstraint() override {}
 
-  void set_frameA(const multibody::Frame<double>* frame) { frameA_ = frame; }
+  void set_frameA(const multibody::Frame<double>* frame) {
+    frameA_ = frame;
+  }
 
-  void set_frameB(const multibody::Frame<double>* frame) { frameB_ = frame; }
+  void set_frameB(const multibody::Frame<double>* frame) {
+    frameB_ = frame;
+  }
 
   void EnableSymbolic() {
     if (symbolic_plant_ != nullptr) {
@@ -327,8 +326,8 @@ class SamePointConstraint : public solvers::Constraint {
 bool FindClosestCollision(
     std::shared_ptr<SamePointConstraint> same_point_constraint,
     const multibody::Frame<double>& frameA,
-    const multibody::Frame<double>& frameB, const ConvexSet& setA,
-    const ConvexSet& setB, const Hyperellipsoid& E,
+    const multibody::Frame<double>& frameB,
+    const ConvexSet& setA, const ConvexSet& setB, const Hyperellipsoid& E,
     const Eigen::Ref<const Eigen::MatrixXd>& A,
     const Eigen::Ref<const Eigen::VectorXd>& b,
     const solvers::SolverInterface& solver,
@@ -392,7 +391,8 @@ bool FindClosestCollision(
 // Add the tangent to the (scaled) ellipsoid at @p point as a
 // constraint.
 void AddTangentToPolytope(
-    const Hyperellipsoid& E, const Eigen::Ref<const Eigen::VectorXd>& point,
+    const Hyperellipsoid& E,
+    const Eigen::Ref<const Eigen::VectorXd>& point,
     const IrisOptions& options,
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>* A,
     Eigen::VectorXd* b, int* num_constraints) {
@@ -403,52 +403,28 @@ void AddTangentToPolytope(
   }
 
   A->row(*num_constraints) =
-      (E.A().transpose() * E.A() * (point - E.center())).normalized();
+        (E.A().transpose() * E.A() *(point - E.center())).normalized();
   (*b)[*num_constraints] =
       A->row(*num_constraints) * point - options.configuration_space_margin;
   *num_constraints += 1;
 }
 
-struct GeometryPairWithDistance {
-  GeometryId geomA;
-  GeometryId geomB;
-  double distance;
-
-  GeometryPairWithDistance(GeometryId gA, GeometryId gB, double dist)
-      : geomA(gA), geomB(gB), distance(dist) {}
-
-  bool operator<(const GeometryPairWithDistance& other) {
-    return distance < other.distance;
-  }
-};
-
 }  // namespace
 
 HPolyhedron IrisInConfigurationSpace(
-    const MultibodyPlant<double>& plant, const Context<double>& context,
+    const MultibodyPlant<double>& plant,
+    const Context<double>& context,
     const Eigen::Ref<const Eigen::VectorXd>& sample,
     const IrisOptions& options) {
-  const int nq = plant.num_positions();
-  DRAKE_DEMAND(sample.size() == nq);
-
-  auto sample_context = plant.CreateDefaultContext();
-  plant.FixInputPortsFrom(plant, context, sample_context.get());
-  sample_context->SetTimeStateAndParametersFrom(context);
-  plant.SetPositions(sample_context.get(), sample);
-  return IrisInConfigurationSpace(plant, *sample_context, options);
-}
-
-HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
-                                     const Context<double>& context,
-                                     const IrisOptions& options) {
   // Check the inputs.
   plant.ValidateContext(context);
   const int nq = plant.num_positions();
-  const Eigen::VectorXd sample = plant.GetPositions(context);
+  DRAKE_DEMAND(sample.size() == nq);
   // Note: We require finite joint limits to define the bounding box for the
   // IRIS algorithm.
   DRAKE_DEMAND(plant.GetPositionLowerLimits().array().isFinite().all());
   DRAKE_DEMAND(plant.GetPositionUpperLimits().array().isFinite().all());
+
 
   // Make the polytope and ellipsoid.
   HPolyhedron P = HPolyhedron::MakeBox(plant.GetPositionLowerLimits(),
@@ -477,23 +453,15 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
     frames.emplace(geom_id, &plant.GetBodyFromFrameId(frame_id)->body_frame());
   }
 
+  // TODO(russt): As a surrogate for the true objective, we could use convex
+  // optimization to compute the (squared?) distance between each collision pair
+  // from the sample point configuration, then sort the pairs by that distance.
+  // This could improve computation times in Ibex here and produce regions with
+  // less faces.
   auto pairs = inspector.GetCollisionCandidates();
   const int N = static_cast<int>(pairs.size());
   auto same_point_constraint =
       std::make_shared<SamePointConstraint>(&plant, context);
-
-  // As a surrogate for the true objective, the pairs are sorted by the distance
-  // between each collision pair from the sample point configuration. This could
-  // improve computation times in Ibex here and produce regions with fewer
-  // faces.
-  std::vector<GeometryPairWithDistance> sorted_pairs;
-  for (const auto [geomA, geomB] : pairs) {
-    sorted_pairs.emplace_back(
-        geomA, geomB,
-        query_object.ComputeSignedDistancePairClosestPoints(geomA, geomB)
-            .distance);
-  }
-  std::sort(sorted_pairs.begin(), sorted_pairs.end());
 
   // On each iteration, we will build the collision-free polytope represented as
   // {x | A * x <= b}.  Here we pre-allocate matrices with a generous maximum
@@ -519,24 +487,16 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
 
   while (true) {
     int num_constraints = 2 * nq;  // Start with just the joint limits.
-    bool sample_point_requirement = true;
-    DRAKE_ASSERT(best_volume > 0);
     // Find separating hyperplanes
 
     // First use a fast nonlinear optimizer to add as many constraint as it
     // can find.
-    for (const auto pair : sorted_pairs) {
-      while (sample_point_requirement &&
-             FindClosestCollision(
-                 same_point_constraint, *frames.at(pair.geomA),
-                 *frames.at(pair.geomB), *sets.at(pair.geomA),
-                 *sets.at(pair.geomB), E, A.topRows(num_constraints),
-                 b.head(num_constraints), *solver, sample, &closest)) {
+    for (const auto& [geomA, geomB] : pairs) {
+      while (FindClosestCollision(
+          same_point_constraint, *frames.at(geomA), *frames.at(geomB),
+          *sets.at(geomA), *sets.at(geomB), E, A.topRows(num_constraints),
+          b.head(num_constraints), *solver, sample, &closest)) {
         AddTangentToPolytope(E, closest, options, &A, &b, &num_constraints);
-        if (options.require_sample_point_is_contained) {
-          sample_point_requirement =
-              A.row(num_constraints - 1) * sample <= b(num_constraints - 1);
-        }
       }
     }
 
@@ -544,23 +504,20 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
       // Now loop back through and use Ibex for rigorous certification.
       // TODO(russt): Consider (re-)implementing a "feasibility only" version of
       // the IRIS check + nonlinear optimization to improve.
-      for (const auto pair : sorted_pairs) {
-        while (sample_point_requirement &&
-               FindClosestCollision(
-                   same_point_constraint, *frames.at(pair.geomA),
-                   *frames.at(pair.geomB), *sets.at(pair.geomA),
-                   *sets.at(pair.geomB), E, A.topRows(num_constraints),
-                   b.head(num_constraints), *ibex, sample, &closest)) {
+      for (const auto& [geomA, geomB] : pairs) {
+        while (FindClosestCollision(
+            same_point_constraint, *frames.at(geomA), *frames.at(geomB),
+            *sets.at(geomA), *sets.at(geomB), E, A.topRows(num_constraints),
+            b.head(num_constraints), *ibex, sample, &closest)) {
           AddTangentToPolytope(E, closest, options, &A, &b, &num_constraints);
-          if (options.require_sample_point_is_contained) {
-            sample_point_requirement =
-                A.row(num_constraints - 1) * sample <= b(num_constraints - 1);
-          }
         }
       }
     }
 
-    if (!sample_point_requirement) {
+    if (options.require_sample_point_is_contained &&
+        ((A.topRows(num_constraints) * sample).array() >=
+         b.head(num_constraints).array())
+            .any()) {
       break;
     }
     P = HPolyhedron(A.topRows(num_constraints), b.head(num_constraints));
@@ -572,15 +529,11 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
 
     E = P.MaximumVolumeInscribedEllipsoid();
     const double volume = E.Volume();
-    const double delta_volume = volume - best_volume;
-    if (delta_volume <= options.termination_threshold) {
-      break;
-    }
-    if (delta_volume / best_volume <= options.relative_termination_threshold) {
+    if (volume - best_volume <= options.termination_threshold) {
       break;
     }
     best_volume = volume;
-  }
+    }
   return P;
 }
 

--- a/geometry/optimization/iris.h
+++ b/geometry/optimization/iris.h
@@ -4,7 +4,6 @@
 #include <optional>
 #include <vector>
 
-#include "drake/common/drake_deprecated.h"
 #include "drake/common/symbolic.h"
 #include "drake/geometry/optimization/convex_set.h"
 #include "drake/geometry/optimization/hpolyhedron.h"
@@ -33,14 +32,8 @@ struct IrisOptions {
   int iteration_limit{100};
 
   /** IRIS will terminate if the change in the *volume* of the hyperellipsoid
-  between iterations is less that this threshold. This termination condition can
-  be disabled by setting to a negative value. */
+  between iterations is less that this threshold. */
   double termination_threshold{2e-2};  // from rdeits/iris-distro.
-
-  /** IRIS will terminate if the change in the *volume* of the hyperellipsoid
-  between iterations is less that this percent of the previouse best volume.
-  This termination condition can be disabled by setting to a negative value. */
-  double relative_termination_threshold{1e-3};  // from rdeits/iris-distro.
 
   // TODO(russt): Improve the implementation so that we can clearly document the
   // units for this margin.
@@ -118,27 +111,15 @@ documented in a forth-coming publication.
 
 @param plant describes the kinematics of configuration space.  It must be
 connected to a SceneGraph in a systems::Diagram.
-@param context is a context of the @p plant. The context must have the positions
-of the plant set to the initialIRIS seed configuration.
+@param context is a context of the @p plant.
+@param sample is a vector of size plant.num_positions() representing the initial
+IRIS seed configuration.
 @param options provides additional configuration options.  In particular,
 `options.enabled_ibex` may have a significant impact on the runtime of the
 algorithm.
 
 @ingroup geometry_optimization
 */
-HPolyhedron IrisInConfigurationSpace(
-    const multibody::MultibodyPlant<double>& plant,
-    const systems::Context<double>& context,
-    const IrisOptions& options = IrisOptions());
-
-/** A deprecated variation of the IrisInConfigurationSpace method where the
-initial Iris seed configuration is provided explicitly instead of via the
-context.
-
-@ingroup geometry_optimization
-*/
-DRAKE_DEPRECATED("2022-03-01",
-                 "Use IrisInConfigurationSpace() with sample set in context.")
 HPolyhedron IrisInConfigurationSpace(
     const multibody::MultibodyPlant<double>& plant,
     const systems::Context<double>& context,

--- a/geometry/optimization/test/iris_test.cc
+++ b/geometry/optimization/test/iris_test.cc
@@ -139,44 +139,6 @@ GTEST_TEST(IrisTest, MultipleBoxes) {
   EXPECT_FALSE(region.PointInSet(Vector2d(0.0, -.99)));
 }
 
-GTEST_TEST(IrisTest, TerminationConditions) {
-  ConvexSets obstacles;
-  obstacles.emplace_back(VPolytope::MakeBox(Vector2d(.1, .5), Vector2d(1, 1)));
-  obstacles.emplace_back(
-      VPolytope::MakeBox(Vector2d(-1, -1), Vector2d(-.1, -.5)));
-  obstacles.emplace_back(
-      HPolyhedron::MakeBox(Vector2d(.1, -1), Vector2d(1, -.5)));
-  obstacles.emplace_back(
-      HPolyhedron::MakeBox(Vector2d(-1, .5), Vector2d(-.1, 1)));
-  const HPolyhedron domain = HPolyhedron::MakeUnitBox(2);
-
-  const Vector2d sample{0, 0};  // center of the bounding box.
-  IrisOptions options;
-  options.iteration_limit = 1;
-  // Negative thresholds disable the termination condition.
-  options.termination_threshold = -1;
-  options.relative_termination_threshold = -1;
-  const HPolyhedron iteration_region = Iris(obstacles, sample, domain, options);
-  EXPECT_EQ(iteration_region.b().size(),
-            8);  // 4 from bbox + 1 from each obstacle.
-
-  options.iteration_limit = 100;
-  options.termination_threshold = 0.1;
-  options.relative_termination_threshold = -1;
-  const HPolyhedron abs_volume_region =
-      Iris(obstacles, sample, domain, options);
-  EXPECT_EQ(abs_volume_region.b().size(),
-            8);  // 4 from bbox + 1 from each obstacle.
-
-  options.iteration_limit = 100;
-  options.termination_threshold = -1;
-  options.relative_termination_threshold = 0.1;
-  const HPolyhedron rel_volume_region =
-      Iris(obstacles, sample, domain, options);
-  EXPECT_EQ(rel_volume_region.b().size(),
-            8);  // 4 from bbox + 1 from each obstacle.
-}
-
 GTEST_TEST(IrisTest, BallInBoxNDims) {
   const int N = 8;
   ConvexSets obstacles;
@@ -318,50 +280,6 @@ TEST_F(SceneGraphTester, MultipleBoxes) {
   EXPECT_TRUE(region.PointInSet(Vector3d(0.0, 0.0, -0.99)));
 }
 
-// One prismatic link with joint limits.  Iris should return the joint limits.
-GTEST_TEST(DeprecatedIrisInConfigurationSpaceTest, JointLimits) {
-  const std::string limits_urdf = R"(
-<robot name="limits">
-  <link name="movable">
-    <collision>
-      <geometry><box size="1 1 1"/></geometry>
-    </collision>
-  </link>
-  <joint name="movable" type="prismatic">
-    <axis xyz="1 0 0"/>
-    <limit lower="-2" upper="2"/>
-    <parent link="world"/>
-    <child link="movable"/>
-  </joint>
-</robot>
-)";
-
-  systems::DiagramBuilder<double> builder;
-  multibody::MultibodyPlant<double>& plant =
-      multibody::AddMultibodyPlantSceneGraph(&builder, 0.0);
-  multibody::Parser(&plant).AddModelFromString(limits_urdf, "urdf");
-  plant.Finalize();
-  auto diagram = builder.Build();
-
-  const Vector1d sample = Vector1d::Zero();
-  IrisOptions options;
-  auto context = diagram->CreateDefaultContext();
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  HPolyhedron region = IrisInConfigurationSpace(
-      plant, plant.GetMyContextFromRoot(*context), sample, options);
-#pragma GCC diagnostic pop
-
-  EXPECT_EQ(region.ambient_dimension(), 1);
-
-  const double kTol = 1e-5;
-  const double qmin = -2.0, qmax = 2.0;
-  EXPECT_TRUE(region.PointInSet(Vector1d{qmin + kTol}));
-  EXPECT_TRUE(region.PointInSet(Vector1d{qmax - kTol}));
-  EXPECT_FALSE(region.PointInSet(Vector1d{qmin - kTol}));
-  EXPECT_FALSE(region.PointInSet(Vector1d{qmax + kTol}));
-}
-
 namespace {
 
 // Helper method for testing IrisInConfigurationSpace from a urdf string.
@@ -376,9 +294,8 @@ HPolyhedron IrisFromUrdf(const std::string urdf,
   auto diagram = builder.Build();
 
   auto context = diagram->CreateDefaultContext();
-  plant.SetPositions(&plant.GetMyMutableContextFromRoot(context.get()), sample);
   return IrisInConfigurationSpace(plant, plant.GetMyContextFromRoot(*context),
-                                  options);
+                                  sample, options);
 }
 
 }  // namespace


### PR DESCRIPTION
 Dear @mpetersen94 ,

 The on-call build cop, @BetsyMcPhail , believes that your PR #16037 may have
 broken one or more of Drake's continuous integration builds [1]. It is
 possible to break a build even if your PR passed continuous integration
 pre-merge because additional platforms are tested post-merge.

 The specific build failures under investigation are continuous Mac builds, including:
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/mac-big-sur-clang-bazel-continuous-release/934/
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/mac-monterey-clang-bazel-continuous-release/22/

 Therefore, the build cop has created this revert PR and started a complete
 post-merge build to determine whether your PR was in fact the cause of the
 problem. If that build passes, this revert PR will be merged 60 minutes from
 now. You can then fix the problem at your leisure, and send a new PR to
 reinstate your change.

 If you believe your original PR did not actually break the build, please
 explain on this thread.

 If you believe you can fix the break promptly in lieu of a revert, please
 explain on this thread, and send a PR to the build cop for review ASAP.

 If you believe your original PR definitely did break the build and should be
 reverted, please review and LGTM this PR. This allows the build cop to merge
 without waiting for CI results.

 For advice on how to handle a build cop revert, see [2].

 Thanks!
 Your Friendly On-call Build Cop

 [1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
 [2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16149)
<!-- Reviewable:end -->
