### PR TITLE
Fix failing Mac build caused by #16037

### DIFF
--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -417,7 +417,7 @@ struct GeometryPairWithDistance {
   GeometryPairWithDistance(GeometryId gA, GeometryId gB, double dist)
       : geomA(gA), geomB(gB), distance(dist) {}
 
-  bool operator<(const GeometryPairWithDistance& other) {
+  bool operator<(const GeometryPairWithDistance& other) const {
     return distance < other.distance;
   }
 };
@@ -487,7 +487,7 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
   // improve computation times in Ibex here and produce regions with fewer
   // faces.
   std::vector<GeometryPairWithDistance> sorted_pairs;
-  for (const auto [geomA, geomB] : pairs) {
+  for (const auto& [geomA, geomB] : pairs) {
     sorted_pairs.emplace_back(
         geomA, geomB,
         query_object.ComputeSignedDistancePairClosestPoints(geomA, geomB)
@@ -525,7 +525,7 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
 
     // First use a fast nonlinear optimizer to add as many constraint as it
     // can find.
-    for (const auto pair : sorted_pairs) {
+    for (const auto& pair : sorted_pairs) {
       while (sample_point_requirement &&
              FindClosestCollision(
                  same_point_constraint, *frames.at(pair.geomA),
@@ -544,7 +544,7 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
       // Now loop back through and use Ibex for rigorous certification.
       // TODO(russt): Consider (re-)implementing a "feasibility only" version of
       // the IRIS check + nonlinear optimization to improve.
-      for (const auto pair : sorted_pairs) {
+      for (const auto& pair : sorted_pairs) {
         while (sample_point_requirement &&
                FindClosestCollision(
                    same_point_constraint, *frames.at(pair.geomA),


### PR DESCRIPTION
Fixes an error caused on Mac builds for not using the reference type in a loop. Supersedes #16149

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16150)
<!-- Reviewable:end -->
