### PR TITLE
[hydro] Correct bug in MeshFieldLinear::TransformGradients()

### DIFF
--- a/geometry/proximity/mesh_intersection.cc
+++ b/geometry/proximity/mesh_intersection.cc
@@ -432,7 +432,7 @@ ComputeContactSurfaceFromSoftVolumeRigidSurface(
   //  3. Re-expressing the gradients of the soft-mesh's pressure field
   //    (grad_eS_S) in the world frame (grad_eS_W).
   surface_SR->TransformVertices(X_WS);
-  e_SR->TransformGradients(X_WS);
+  e_SR->Transform(X_WS);
   std::unique_ptr<std::vector<Vector3<T>>> grad_eS_W;
   grad_eS_W = std::make_unique<std::vector<Vector3<T>>>();
   grad_eS_W->reserve(grad_eS_S.size());


### PR DESCRIPTION
The field is expressed in a frame M. When transforming it to a frame N, we call `TransformGradients()`. If the field has stored gradients, this re-expresses the gradients. However, that is insufficient. `EvaluateCartesian()` uses those gradients to evaluate the field (when they exist). But it also depends on `values_at_Mo_` -- another frame-dependent quantity.

This updates the function in question to update *both* quantities and expands the unit test to cover this previously uncovered aspect of the code.

relates #15796

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16160)
<!-- Reviewable:end -->
