### PR TITLE
[multibody] Re-enable asan for supernodal_solver_test

### DIFF
--- a/multibody/contact_solvers/BUILD.bazel
+++ b/multibody/contact_solvers/BUILD.bazel
@@ -221,10 +221,6 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "supernodal_solver_test",
-    tags = [
-        "no_asan",
-        "no_memcheck",
-    ],
     deps = [
         ":supernodal_solver",
         "//common/test_utilities:expect_throws_message",

--- a/multibody/contact_solvers/test/supernodal_solver_test.cc
+++ b/multibody/contact_solvers/test/supernodal_solver_test.cc
@@ -535,7 +535,7 @@ GTEST_TEST(SupernodalSolver, FourStacks) {
         2, 5, 3,
         2, 3, 4;
   // clang-format on
-  MatrixXd G(3 * num_patches, 3 * num_patches);
+  MatrixXd G = MatrixXd::Zero(3 * num_patches, 3 * num_patches);
   std::vector<MatrixXd> blocks_of_G(num_patches);
   for (int i = 0; i < num_patches; ++i) {
     G.block(3 * i, 3 * i, 3, 3) = Gb;

--- a/tools/workspace/conex/repository.bzl
+++ b/tools/workspace/conex/repository.bzl
@@ -7,8 +7,8 @@ def conex_repository(
     github_archive(
         name = name,
         repository = "ToyotaResearchInstitute/conex",
-        commit = "e53ebc612ccb5c4da757bbe90f7be07ff13db0a4",
-        sha256 = "adfaef47709a751da0c8445719fb97f133acf79c3e75594b2663e89be76879e4",  # noqa
+        commit = "164a33df764d1f458756643e010f1bb62d0e1479",
+        sha256 = "3f88f45276a1b474946b67e7c650fefd6d7c9dcb48f0c0a11393be3e6adc5ba7",  # noqa
         build_file = "@drake//tools/workspace/conex:package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
This PR addresses the problem with asan builds reported in #16136:
1. Bumps to latest Conex commit, which removes hard coded build options.
2. Fixes uninitialized data in unit test, which triggered an error with asan.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16161)
<!-- Reviewable:end -->
