### PR TITLE
[hydro] Enable polygon contact surface in mesh-plane intersection

### DIFF
--- a/geometry/proximity/hydroelastic_callback.h
+++ b/geometry/proximity/hydroelastic_callback.h
@@ -110,7 +110,8 @@ std::unique_ptr<ContactSurface<T>> DispatchRigidSoftCalculation(
           soft.pressure_field();
       const Bvh<Obb, VolumeMesh<double>>& bvh_S = soft.bvh();
       return ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
-          id_S, field_S, bvh_S, X_WS, id_R, X_WR);
+          id_S, field_S, bvh_S, X_WS, id_R, X_WR,
+          HydroelasticContactRepresentation::kTriangle);
     }
   } else {
     // soft cannot be a half space; so this must be mesh-mesh.

--- a/geometry/proximity/mesh_plane_intersection.cc
+++ b/geometry/proximity/mesh_plane_intersection.cc
@@ -61,15 +61,14 @@ constexpr std::array<std::array<int, 4>, 16> kMarchingTetsTable = {
 
 }  // namespace
 
-template <typename T>
-void SliceTetWithPlane(int tet_index,
-                       const VolumeMeshFieldLinear<double, double>& field_M,
-                       const Plane<T>& plane_M,
-                       const math::RigidTransform<T>& X_WM,
-                       std::vector<SurfaceTriangle>* faces,
-                       std::vector<Vector3<T>>* vertices_W,
-                       std::vector<T>* surface_e,
-                       std::unordered_map<SortedPair<int>, int>* cut_edges) {
+template <typename MeshBuilder>
+int SliceTetWithPlane(
+    int tet_index, const VolumeMeshFieldLinear<double, double>& field_M,
+    const Plane<typename MeshBuilder::ScalarType>& plane_M,
+    const math::RigidTransform<typename MeshBuilder::ScalarType>& X_WM,
+    MeshBuilder* builder_W,
+    std::unordered_map<SortedPair<int>, int>* cut_edges) {
+  using T = typename MeshBuilder::ScalarType;
   const VolumeMesh<double>& mesh_M = field_M.mesh();
 
   T distance[4];
@@ -85,7 +84,7 @@ void SliceTetWithPlane(int tet_index,
       kMarchingTetsTable[intersection_code];
 
   // No intersecting edges --> no intersection.
-  if (intersected_edges[0] == -1) return;
+  if (intersected_edges[0] == -1) return 0;
 
   int num_intersections = 0;
   // Indices of the new polygon's vertices in vertices_W. There can be, at
@@ -118,67 +117,63 @@ void SliceTetWithPlane(int tet_index,
       // positive the other must be strictly non-positive.
       const T t = d_v0 / (d_v0 - d_v1);
       const Vector3<T> p_MC = p_MV0 + t * (p_MV1 - p_MV0);
-      const Vector3<T> p_WC = X_WM * p_MC;
-
-      int new_index = static_cast<int>(vertices_W->size());
-      vertices_W->emplace_back(p_WC);
       const double e0 = field_M.EvaluateAtVertex(v0);
       const double e1 = field_M.EvaluateAtVertex(v1);
-      surface_e->emplace_back(e0 + t * (e1 - e0));
+      const int new_index =
+          builder_W->AddVertex(X_WM * p_MC, e0 + t * (e1 - e0));
       (*cut_edges)[mesh_edge] = new_index;
       face_verts[e] = new_index;
     }
   }
+  face_verts.resize(num_intersections);
 
   // Because the vertices are measured and expressed in the world frame, we
   // need to provide a normal expressed in the same.
   const Vector3<T> nhat_W = X_WM.rotation() * plane_M.normal();
-  const size_t before = vertices_W->size();
-  face_verts.resize(num_intersections);
-  AddPolygonToTriangleMeshData(face_verts, nhat_W, faces, vertices_W);
-  for (size_t v = before; v < vertices_W->size(); ++v) {
-    const Vector3<T> p_MV = X_WM.inverse() * vertices_W->at(v);
-    surface_e->emplace_back(field_M.EvaluateCartesian(tet_index, p_MV));
-  }
+  const Vector3<T> grad_e_MN_W =
+      X_WM.rotation() * field_M.EvaluateGradient(tet_index).cast<T>();
+  return builder_W->AddPolygon(face_verts, nhat_W, grad_e_MN_W);
 }
 
-template <typename T>
-std::unique_ptr<ContactSurface<T>> ComputeContactSurface(
+template <typename MeshBuilder>
+std::unique_ptr<ContactSurface<typename MeshBuilder::ScalarType>>
+ComputeContactSurface(
     GeometryId mesh_id,
     const VolumeMeshFieldLinear<double, double>& mesh_field_M,
-    GeometryId plane_id, const Plane<T>& plane_M,
+    GeometryId plane_id, const Plane<typename MeshBuilder::ScalarType>& plane_M,
     const std::vector<int>& tet_indices,
-    const math::RigidTransform<T>& X_WM) {
+    const math::RigidTransform<typename MeshBuilder::ScalarType>& X_WM) {
+  using T = typename MeshBuilder::ScalarType;
   if (tet_indices.size() == 0) return nullptr;
 
-  std::vector<SurfaceTriangle> faces;
-  std::vector<Vector3<T>> vertices_W;
-  std::vector<T> surface_e;
+  // Build infrastructure as we process each potentially colliding tet.
+  MeshBuilder builder_W;
   std::unordered_map<SortedPair<int>, int> cut_edges;
 
   auto grad_eM_W = std::make_unique<std::vector<Vector3<T>>>();
-  size_t old_face_count = 0;
   for (const auto& tet_index : tet_indices) {
+    const int num_new_faces = SliceTetWithPlane(
+        tet_index, mesh_field_M, plane_M, X_WM, &builder_W, &cut_edges);
+    // ContactSurface requires us to store the gradient of the *constituent*
+    // fields sampled on each face in the contact surface. The only constiutent
+    // field we have is of the soft mesh M. So, we'll store the gradient of the
+    // intersecting tet, once per newly added face. In this case, it just
+    // so happens that grad_e_MN equals grad_e_M, but MeshBuilder cannot
+    // know that, so we appear to redundantly store this gradient. But the
+    // consumer of the ContactSurface also cannot know about any particular
+    // relationship between grad_eN, grad_eM, and grad_eMN.
     const Vector3<T>& grad_eMi_W =
         X_WM.rotation() * mesh_field_M.EvaluateGradient(tet_index).cast<T>();
-    SliceTetWithPlane(tet_index, mesh_field_M, plane_M, X_WM, &faces,
-                      &vertices_W, &surface_e, &cut_edges);
-    // The gradient of every triangle that arises from slicing a tet with a
-    // plane is the *constant* gradient inside that tet.
-    for (size_t i = old_face_count; i < faces.size(); ++i) {
+    for (int i = 0; i < num_new_faces; ++i) {
       grad_eM_W->push_back(grad_eMi_W);
     }
-    old_face_count = faces.size();
   }
 
   // Construct the contact surface from the components.
-  DRAKE_DEMAND(vertices_W.size() == surface_e.size());
-  if (faces.empty()) return nullptr;
+  if (builder_W.num_faces() == 0) return nullptr;
 
-  auto mesh_W = std::make_unique<TriangleSurfaceMesh<T>>(std::move(faces),
-                                                         std::move(vertices_W));
-  auto field_W = std::make_unique<TriangleSurfaceMeshFieldLinear<T, T>>(
-      std::move(surface_e), mesh_W.get(), false /* calculate_gradient */);
+  auto [mesh_W, field_W] = builder_W.MakeMeshAndField();
+
   // SliceTetWithPlane promises to make the surface normals point in the plane
   // normal direction (i.e., out of the plane and into the mesh).
   return std::make_unique<ContactSurface<T>>(
@@ -192,7 +187,8 @@ ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
     const GeometryId id_S, const VolumeMeshFieldLinear<double, double>& field_S,
     const Bvh<Obb, VolumeMesh<double>>& bvh_S,
     const math::RigidTransform<T>& X_WS, const GeometryId id_R,
-    const math::RigidTransform<T>& X_WR) {
+    const math::RigidTransform<T>& X_WR,
+    HydroelasticContactRepresentation representation) {
   std::vector<int> tet_indices;
   tet_indices.reserve(field_S.mesh().num_elements());
   auto callback = [&tet_indices](int tet_index) {
@@ -217,14 +213,56 @@ ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
 
   // Build the contact surface from the plane and the list of tetrahedron
   // indices.
-  return ComputeContactSurface(id_S, field_S, id_R, plane_S, tet_indices, X_WS);
+
+  if (representation == HydroelasticContactRepresentation::kTriangle) {
+    return ComputeContactSurface<TriMeshBuilder<T>>(
+        id_S, field_S, id_R, plane_S, tet_indices, X_WS);
+  } else {
+    return ComputeContactSurface<PolyMeshBuilder<T>>(
+        id_S, field_S, id_R, plane_S, tet_indices, X_WS);
+  }
 }
 
-DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
-    &ComputeContactSurface<T>,
-    &ComputeContactSurfaceFromSoftVolumeRigidHalfSpace<T>,
-    &SliceTetWithPlane<T>
-))
+template int SliceTetWithPlane<TriMeshBuilder<double>>(
+    int, const VolumeMeshFieldLinear<double, double>&, const Plane<double>&,
+    const math::RigidTransform<double>&,
+    TriMeshBuilder<double>*, std::unordered_map<SortedPair<int>, int>*);
+template int SliceTetWithPlane<TriMeshBuilder<AutoDiffXd>>(
+    int, const VolumeMeshFieldLinear<double, double>&, const Plane<AutoDiffXd>&,
+    const math::RigidTransform<AutoDiffXd>&,
+    TriMeshBuilder<AutoDiffXd>*, std::unordered_map<SortedPair<int>, int>*);
+template int SliceTetWithPlane<PolyMeshBuilder<double>>(
+    int, const VolumeMeshFieldLinear<double, double>&, const Plane<double>&,
+    const math::RigidTransform<double>&,
+    PolyMeshBuilder<double>*, std::unordered_map<SortedPair<int>, int>*);
+template int SliceTetWithPlane<PolyMeshBuilder<AutoDiffXd>>(
+    int, const VolumeMeshFieldLinear<double, double>&, const Plane<AutoDiffXd>&,
+    const math::RigidTransform<AutoDiffXd>&,
+    PolyMeshBuilder<AutoDiffXd>*, std::unordered_map<SortedPair<int>, int>*);
+
+template std::unique_ptr<ContactSurface<double>>
+ComputeContactSurface<TriMeshBuilder<double>>(
+    GeometryId, const VolumeMeshFieldLinear<double, double>&,
+    GeometryId plane_id, const Plane<double>&, const std::vector<int>&,
+    const math::RigidTransform<double>&);
+template std::unique_ptr<ContactSurface<AutoDiffXd>>
+ComputeContactSurface<TriMeshBuilder<AutoDiffXd>>(
+    GeometryId, const VolumeMeshFieldLinear<double, double>&,
+    GeometryId plane_id, const Plane<AutoDiffXd>&, const std::vector<int>&,
+    const math::RigidTransform<AutoDiffXd>&);
+template std::unique_ptr<ContactSurface<double>>
+ComputeContactSurface<PolyMeshBuilder<double>>(
+    GeometryId, const VolumeMeshFieldLinear<double, double>&,
+    GeometryId plane_id, const Plane<double>&, const std::vector<int>&,
+    const math::RigidTransform<double>&);
+template std::unique_ptr<ContactSurface<AutoDiffXd>>
+ComputeContactSurface<PolyMeshBuilder<AutoDiffXd>>(
+    GeometryId, const VolumeMeshFieldLinear<double, double>&,
+    GeometryId plane_id, const Plane<AutoDiffXd>&, const std::vector<int>&,
+    const math::RigidTransform<AutoDiffXd>&);
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    (&ComputeContactSurfaceFromSoftVolumeRigidHalfSpace<T>))
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/mesh_plane_intersection.h
+++ b/geometry/proximity/mesh_plane_intersection.h
@@ -17,38 +17,30 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
-/* Intersects a tetrahedron with a plane, storing the result in the provided
- collections.
+/* Intersects a tetrahedron with a plane, the resulting polygon is passed
+ into the provided MeshBuilder.
 
- This method constructs a mesh by a sequence of invocations. The vertices are
- written to `vertices_W`, the triangles are written to `faces`, and the
- pressure values at each intersection vertex are written to `surface_e`.
+ This method constructs a mesh by a sequence of invocations. It guarantees
+ the output surface mesh has the same topological coherency as the input mesh.
+ For example, if the plane cuts through a tetrahedron edge e at a point P, then
+ each of the tetrahedra incident to that edge will be cut into a polygon on
+ the plane which all share a _single_ vertex at P; no duplicate vertices will be
+ introduced.
+
+ This is accomplished by storing the edges that have already been evaluated.
+ Call after call, the cached set of intersected edges grows and subsequent
+ calls look up edges in the cache to see if the plane-edge intersection has
+ already been accounted for.
+
+ The unique vertices, their corresponding pressure values, and the unique
+ faces are all stored within the MeshBuilder; only their indices are stored
+ in the cache.
 
  The face vertices are ordered such that the normal implied by their winding
  points in the direction of the plane's normal.
 
- After each call the following invariants are maintained:
-
-   - `vertices_W.size() == surface_e.size()`
-   - `i ∈ [0, N) ∀ i` referenced in `faces` (and `N = vertices_W.size()`).
-   - The iᵗʰ entry in `surface_e` is the pressure at the position for the iᵗʰ
-     vertex in `vertices_W`.
-   - No intersection guarantees no changes to _any_ of the output parameters.
-
- This method represents the intersected polygon as its fan-triangulation
- around its centroid and guarantees the output surface mesh has the same
- topological coherency as the input mesh. For example, if the plane cuts
- through a tetrahedron edge e at vertex v, then each of the tetrahedra
- incident to that edge will be cut into a polygon which includes the same
- vertex v; no duplicate vertices will be introduced. This is accomplished by
- storing the edges that have already been evaluated. Call after call, the
- cached set of intersected edges grows and subsequent calls look up edges in
- the cache to see if the plane-edge intersection has already been accounted
- for. After each call the following additional invariants are maintained:
-
-   - Every vertex position in `vertices_W` that represents an intersection of
-     edge and plane can be found in `cut_edges`. All remaining vertex
-     positions are the centroids of the intersected polygons.
+ If there is no intersection, then neither the mesh, nor the cache data
+ structures will change.
 
  @param[in] tet_index       The index of the tetrahedron to attempt to
                             intersect.
@@ -61,31 +53,32 @@ namespace internal {
                             in Frame M.
  @param[in] X_WM            The relative pose between the mesh frame M and the
                             world frame W.
- @param[in,out] faces       The triangles (defined by triples of vertex
-                            indices) forming the intersection mesh so far.
- @param[in,out] vertices_W  The vertex positions for the intersecting mesh,
-                            measured and expressed in Frame W.
- @param[in,out] surface_e   The per-vertex field values. Upon returning,
-                            surface_e.size() == vertices_W.size() is true.
+ @param[in,out] builder_W   The mesh builder that will add the resulting
+                            intersecting polygon to the mesh (along with sampled
+                            pressure values). It builds the mesh in the world
+                            frame (requiring polygon quantities to be expressed
+                            appropriately).
  @param[in,out] cut_edges   The cache of volume mesh edges that have already
                             been cut and the index of the surface mesh vertex
                             (indexing into vertices_W) that represents the cut
                             point.
+ @returns The number of faces added.
  @pre `tet_index` lies in the range `[0, field_M.mesh().num_elements())`.
  */
-template <typename T>
-void SliceTetWithPlane(int tet_index,
-                       const VolumeMeshFieldLinear<double, double>& field_M,
-                       const Plane<T>& plane_M,
-                       const math::RigidTransform<T>& X_WM,
-                       std::vector<SurfaceTriangle>* faces,
-                       std::vector<Vector3<T>>* vertices_W,
-                       std::vector<T>* surface_e,
-                       std::unordered_map<SortedPair<int>, int>* cut_edges);
+template <typename MeshBuilder>
+int SliceTetWithPlane(
+    int tet_index, const VolumeMeshFieldLinear<double, double>& field_M,
+    const Plane<typename MeshBuilder::ScalarType>& plane_M,
+    const math::RigidTransform<typename MeshBuilder::ScalarType>& X_WM,
+    MeshBuilder* builder_W,
+    std::unordered_map<SortedPair<int>, int>* cut_edges);
 
 /* Computes a ContactSurface by intersecting a plane with a set of tetrahedra
  drawn from the given volume mesh (and its pressure field). The indicated
  tetrahedra would typically be the result of broadphase culling.
+
+ The mesh representation of the resulting contact surface is defined by the type
+ of MeshBuilder provided: polygon or triangle.
 
  @param[in] mesh_id         The id associated with the volume mesh.
  @param[in] mesh_field_M    The _linear_ mesh field (and corresponding mesh,
@@ -102,20 +95,20 @@ void SliceTetWithPlane(int tet_index,
                             world frame W. Used to guarantee that the contact
                             surface is measured and expressed in the world
                             frame.
-
  @returns `nullptr` if there is no intersection, otherwise the appropriate
            ContactSurface. The normals of the contact surface mesh will all
            be parallel with the plane normal.
  @pre  `i ∈ [0, N) ∀ i ∈ tet_indices`, where N is the number of tetrahedra in
        mesh_M.
 */
-template <typename T>
-std::unique_ptr<ContactSurface<T>> ComputeContactSurface(
+template <typename MeshBuilder>
+std::unique_ptr<ContactSurface<typename MeshBuilder::ScalarType>>
+ComputeContactSurface(
     GeometryId mesh_id,
     const VolumeMeshFieldLinear<double, double>& mesh_field_M,
-    GeometryId plane_id, const Plane<T>& plane_M,
+    GeometryId plane_id, const Plane<typename MeshBuilder::ScalarType>& plane_M,
     const std::vector<int>& tet_indices,
-    const math::RigidTransform<T>& X_WM);
+    const math::RigidTransform<typename MeshBuilder::ScalarType>& X_WM);
 
 // TODO(SeanCurtis-TRI): This is, in some sense, the "public" api. It refers to
 //  half spaces. Does it belong in this file? Does it belong elsewhere? At the
@@ -127,19 +120,20 @@ std::unique_ptr<ContactSurface<T>> ComputeContactSurface(
  defined by the HalfSpace class, thus, only its id and its pose in a common
  frame (the world frame) is necessary.
 
- @param[in] id_S        The id of the soft mesh.
- @param[in] field_S     The _linear_ mesh field (and its corresponding mesh
-                        `mesh_S`) for the soft mesh. The field and mesh vertices
-                        are measured and expressed in Frame S. The linearity of
-                        the field is a strict requirement of the underlying
-                        algorithm.
- @param[in] bvh_S       The bounding-volume hierarchy of the soft volume mesh
-                        measured and expressed in Frame S.
- @param[in] X_WS        The relative pose of Frame S and the world frame W.
- @param[in] id_R        The id of the rigid half space.
- @param[in] X_WR        The relative pose between Frame R -- the frame the half
-                        space is defined in -- and the world frame W.
-
+ @param[in] id_S             The id of the soft mesh.
+ @param[in] field_S          The _linear_ mesh field (and its corresponding mesh
+                             `mesh_S`) for the soft mesh. The field and mesh
+                             vertices are measured and expressed in Frame S. The
+                             linearity of the field is a strict requirement of
+                             the underlying algorithm.
+ @param[in] bvh_S            The bounding-volume hierarchy of the soft volume
+                             mesh measured and expressed in Frame S.
+ @param[in] X_WS             The relative pose of Frame S and the world frame W.
+ @param[in] id_R             The id of the rigid half space.
+ @param[in] X_WR             The relative pose between Frame R -- the frame the
+                             half space is defined in -- and the world frame W.
+ @param[in] representation   The preferred representation of each contact
+                             polygon.
  @returns `nullptr` if there is no collision, otherwise the ContactSurface
           between geometries S and R. The normals of the contact surface mesh
           will all be parallel with the plane normal.
@@ -151,7 +145,8 @@ ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
     const GeometryId id_S, const VolumeMeshFieldLinear<double, double>& field_S,
     const Bvh<Obb, VolumeMesh<double>>& bvh_S,
     const math::RigidTransform<T>& X_WS, const GeometryId id_R,
-    const math::RigidTransform<T>& X_WR);
+    const math::RigidTransform<T>& X_WR,
+    HydroelasticContactRepresentation representation);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/test/mesh_plane_intersection_test.cc
+++ b/geometry/proximity/test/mesh_plane_intersection_test.cc
@@ -12,6 +12,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/unused.h"
 #include "drake/geometry/proximity/contact_surface_utility.h"
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
@@ -107,22 +108,12 @@ VolumeMesh<T> TrivialVolumeMesh(
   return {std::move(elements), std::move(vertices)};
 }
 
-/* Compute a unit-length normal to the plane spanned by the three vertices. The
- direction of the normal will be based on right-handed winding and it is assumed
- the vertex positions are _not_ colinear. */
-Vector3d CalcPlaneNormal(
-    const Vector3d& p_FV0, const Vector3d& p_FV1, const Vector3d& p_FV2) {
-  const Vector3d phat_V0V1 = (p_FV1 - p_FV0).normalized();
-  const Vector3d phat_V0V2 = (p_FV2 - p_FV0).normalized();
-  return phat_V0V1.cross(phat_V0V2).normalized();
-}
-
 /* Infrastructure for testing SliceTetWithPlane(). These tests involve three
  frames: M, F, and W. The trivial mesh (see above) is defined in its frame M.
  However, we transform that trivial mesh into some arbitrary frame F (so that
  the mesh vertices don't have a bunch of trivial zeros and ones). The
  intersecting plane is likewise defined in that same frame F. Finally, the
- result of slicing the test with the plane produces results in the *world* frame
+ result of slicing the tet with the plane produces results in the *world* frame
  W (via the X_WF_ transform). */
 class SliceTetWithPlaneTest : public ::testing::Test {
  protected:
@@ -135,113 +126,66 @@ class SliceTetWithPlaneTest : public ::testing::Test {
         Vector3d{1.25, 2.5, -3.75}};
   }
 
-  /* Performs a test of SliceTetWithPlane() by constructing a trivial mesh in
-   frame F and invoking SliceTetWithPlane() using the test class's accumulator
-   structures to capture the result. The various accumulators are guaranteed
-   to be cleared with each invocation of this method before calling
-   SliceTetWithPlane(), so the resultant state is solely attributable to the
-   last invocation.
+  /* Invokes SliceTetWithPlane() on a trivial mesh in frame F. This method
+   arbitrarily uses a PolygonMeshBuilder (the choice doesn't matter, but we
+   choose it because it leads to simpler mesh analysis). The mesh and field
+   created by building the mesh after this single slicing operation are
+   returned. The mesh *may* be empty.
 
-   If `do_analysis` is `true`, the mesh will be evaluated for internal
-   consistency, and the return value reflects that analysis. Otherwise, it
-   trivially reports success.
+   As a side effect, member fields volume_mesh_F_ and field_F_ are written to;
+   they are the mesh and field used in the query (posed in frame F via the given
+   X_FM).
 
    @param plane_F       The slicing plane (measured and expressed in Frame F).
    @param X_FM          The relative pose between the trivial mesh's canonical
                         frame M and the query frame F.
-   @param do_analysis   If `true`, evaluate the resulting intersection mesh for
-                        consistency and return the result.
-   @returns AssertionSuccess if `do_analysis` is `false`, otherwise the
-            AssertionResult produced by the consistency analysis.
-  */
-  ::testing::AssertionResult CallSliceTetWithPlane(
-      const Plane<double>& plane_F, const RigidTransformd& X_FM,
-      bool do_analysis) {
-    VolumeMesh<double> mesh_F = TrivialVolumeMesh(X_FM);
+
+   @returns The resulting mesh and field expressed in the world frame. */
+  pair<unique_ptr<PolygonSurfaceMesh<double>>,
+       unique_ptr<PolygonSurfaceMeshFieldLinear<double, double>>>
+  CallSliceTetWithPlane(const Plane<double>& plane_F,
+                        const RigidTransformd& X_FM) {
+    volume_mesh_F_ = make_unique<VolumeMesh<double>>(TrivialVolumeMesh(X_FM));
     // Make an arbitrary mesh field with heterogeneous values.
     vector<double> values{0.25, 0.5, 0.75, 1, -1};
-    VolumeMeshFieldLinear<double, double> field_F{move(values), &mesh_F};
+    field_F_ = make_unique<VolumeMeshFieldLinear<double, double>>(
+        move(values), volume_mesh_F_.get());
 
-    faces_.clear();
-    vertices_W_.clear();
-    surface_pressure_.clear();
     cut_edges_.clear();
-    int tet_index{0};
-    SliceTetWithPlane(tet_index, field_F, plane_F, X_WF_, &faces_, &vertices_W_,
-                      &surface_pressure_, &cut_edges_);
-    if (do_analysis) {
-      return SliceIsConsistent(tet_index, field_F);
-    }
-    return ::testing::AssertionSuccess();
+    const int tet_index = 0;
+    // Every invocation gets a new builder instance.
+    builder_W_ = PolyMeshBuilder<double>();
+    SliceTetWithPlane(tet_index, *field_F_, plane_F, X_WF_, &builder_W_,
+                      &cut_edges_);
+    return builder_W_.MakeMeshAndField();
   }
 
-  /* Reports `true` if the accumulators' states are consistent with the expected
-   number of faces generated by a call to `SliceTestWithPlane()`. */
-  ::testing::AssertionResult HasNFaces(size_t num_faces) const {
+  /* Reports `true` if mesh and field have a single face and the indicated
+   number of vertices and field values. */
+  ::testing::AssertionResult HasNVertices(
+      const PolygonSurfaceMesh<double>& mesh_W,
+      const PolygonSurfaceMeshFieldLinear<double, double>& field_W,
+      size_t num_vertices) const {
     bool error = false;
     ::testing::AssertionResult failure = ::testing::AssertionFailure();
-    auto test_features = [&failure, &error](const auto& features, size_t count,
+    auto test_features = [&failure, &error](size_t test_count,
+                                            size_t expected_count,
                                             const char* label) {
-      if (features.size() != count) {
+      if (test_count != expected_count) {
         error = true;
-        failure << "Wrong number of " << label << ".\n Expected: " << count
-                << "\n Found: " << features.size() << "\n";
+        failure << "Wrong number of " << label
+                << ".\n Expected: " << expected_count
+                << "\n Found: " << test_count << "\n";
       }
     };
-    test_features(faces_, num_faces, "faces");
-    // For no faces, there are no vertices. But for n faces, we expect n + 1
-    // vertices.
-    const size_t num_verts = num_faces == 0 ? 0 : num_faces + 1;
-    test_features(vertices_W_, num_verts, "vertices");
-    test_features(surface_pressure_, num_verts, "pressure values");
-    test_features(cut_edges_, num_faces, "cut edges");
+    const int num_faces = num_vertices > 0 ? 1 : 0;
+    test_features(mesh_W.num_elements(), num_faces, "faces");
+    test_features(mesh_W.num_vertices(), num_vertices, "vertices");
+    test_features(field_W.values().size(), num_vertices, "pressure values");
+    // Each vertex in the mesh arose from slicing one tet edge.
+    test_features(cut_edges_.size(), num_vertices, "cut edges");
 
     return error ? failure : ::testing::AssertionSuccess();
-  }
-
-  /* Determine which vertex is the center of the triangle fan; it should be the
-   single vertex referenced by every face (all other vertices should be
-   referenced twice). */
-  static pair<int, ::testing::AssertionResult> IdentifyFanVertex(
-      const vector<SurfaceTriangle>& faces) {
-    const int num_faces = static_cast<int>(faces.size());
-    int centroid_index = -1;
-    std::unordered_map<int, int> vertex_references;
-    for (const auto& face : faces) {
-      for (int i = 0; i < 3; ++i) {
-        int v = face.vertex(i);
-        // This relies on unordered_map's value initialization of the value
-        // type. In this case, int gets initialized to zero and then
-        // incremented.
-        ++vertex_references[v];
-      }
-    }
-    int num_perim_vertex{0};
-    for (const auto& pair : vertex_references) {
-      if (pair.second == 2) {
-        ++num_perim_vertex;
-      } else if (pair.second == num_faces) {
-        // While this test could blindly accept two different vertices to be
-        // classified as the centroid, that means the subsequent test on the
-        // expected number of perimeter tests will fail.
-        centroid_index = pair.first;
-      } else {
-        return {{},
-                ::testing::AssertionFailure()
-                    << "The surface vertex " << pair.first
-                    << " is neither boundary nor centroid"};
-      }
-    }
-    DRAKE_DEMAND(centroid_index >= 0);
-    // There is one and only one centroid candidate.
-    if (num_perim_vertex != num_faces) {
-      return {{},
-              ::testing::AssertionFailure()
-                  << "There should be " << num_faces
-                  << " identified perimeter vertices; "
-                  << "only " << num_perim_vertex << " were identified"};
-    }
-    return {centroid_index, ::testing::AssertionSuccess()};
   }
 
   /* Struct for associating a vertex produced from a slice with the mesh edge
@@ -256,16 +200,17 @@ class SliceTetWithPlaneTest : public ::testing::Test {
     double weight{};
   };
 
-  /* For each vertex in the "slice" mesh (that isn't the fan vertex), determine
-   which edge in the tet it lies on and its "weight" along that edge. If the
-   classification fails for any vertex, report failure (without edge data). */
-  pair<vector<EdgeVertex>, ::testing::AssertionResult>
-  CharacterizeEdgeVertices(
-      int fan_index, const vector<SurfaceTriangle>& slice,
-      const vector<Vector3d>& slice_vertices_W, int tet_index,
-      const VolumeMesh<double>& mesh_F) const {
-    constexpr double kEps = std::numeric_limits<double>::epsilon();
-    const VolumeElement& tet = mesh_F.element(tet_index);
+  /* For each vertex in the "slice" mesh polygon, determine which edge in the
+   tet it lies on and its "weight" along that edge. If the classification fails
+   for any vertex, report failure (without edge data). */
+  pair<vector<EdgeVertex>, ::testing::AssertionResult> CharacterizeEdgeVertices(
+      const PolygonSurfaceMesh<double>& slice_mesh_W, int tet_index,
+      const VolumeMesh<double>& volume_mesh_F) const {
+    // This test is designed to work with a *single* slice polygon.
+    DRAKE_DEMAND(slice_mesh_W.num_elements() == 1);
+
+    constexpr double kEps = 2 * std::numeric_limits<double>::epsilon();
+    const VolumeElement& tet = volume_mesh_F.element(tet_index);
 
     // Enumeration of all tetrahedron edges defined by vertex pairs referenced
     // by tet-local index values.
@@ -275,56 +220,54 @@ class SliceTetWithPlaneTest : public ::testing::Test {
     const RigidTransformd X_FW = X_WF_.inverse();
 
     vector<EdgeVertex> edge_vertices;
-    // We include the fan index in the set of vertices already processed so that
-    // we don't attempt to process it (it is the one vertex we presume should
-    // _not_ lie on any edge).
-    set<int> slice_vertex_indices{fan_index};
-    for (const auto& face : slice) {
-      for (int i = 0; i < 3; ++i) {
-        const int v = face.vertex(i);
-        if (slice_vertex_indices.count(v) > 0) continue;
-        slice_vertex_indices.insert(v);
-        // The slice polygon vertex S in the mesh frame F.
-        const Vector3d p_FS = X_FW * slice_vertices_W[v];
-        for (int e = 0; e < 6; ++e) {
-          const int V0 = tet.vertex(tet_edges[e][0]);
-          const int V1 = tet.vertex(tet_edges[e][1]);
-          const Vector3d p_FV0 = mesh_F.vertex(V0);
-          const Vector3d p_FV1 = mesh_F.vertex(V1);
-          const Vector3d p_V0V1_F = p_FV1 - p_FV0;
-          const double d_V0V1 = p_V0V1_F.norm();
-          const Vector3d p_V0S_F = p_FS - p_FV0;
-          const double d_V0S = p_V0S_F.norm();
-          // Test that S lies on the line segment spanned by V0V1.
-          //  - It is colinear with the _line_ passing through V0V1 and
-          //  - its "weight" (i.e., interpolation between V0 and V1) is in the
-          //    interval [0, 1].
-
-          // We can implicitly test colinearity (and part of the weight value)
-          // by comparing the vector V0S with V0V1. A negative dot product
-          // indicates that S *cannot* lie between V0 and V1 (colinear or not)
-          // and a positive value equal to |V0S| * |V0V1| indicates
-          // colinearity.
-          if (std::abs(p_V0V1_F.dot(p_V0S_F) - d_V0V1 * d_V0S) > kEps) continue;
-          // Define weight w such that: S = w * V0 + (1 - w) * V1.
-          double w = 1.0 - d_V0S / d_V0V1;
-          // The previous test already confirmed colinearity and w >= 0.
-          if (w > 1 + kEps) {
-            return {{},
-                    ::testing::AssertionFailure()
-                        << "Vertex " << v << " is co-linear with edge " << e
-                        << " but doesn't lie on the edge"};
-          }
-          edge_vertices.push_back(EdgeVertex{v, {V0, V1}, w});
+    // The sliced mesh vertices we've classified.
+    set<int> slice_vertex_indices;
+    const auto& poly = slice_mesh_W.element(0);
+    for (int i = 0; i < poly.num_vertices(); ++i) {
+      const int v = poly.vertex(i);
+      if (slice_vertex_indices.count(v) > 0) continue;
+      slice_vertex_indices.insert(v);
+      // The slice polygon vertex S in the mesh frame F.
+      const Vector3d p_FS = X_FW * slice_mesh_W.vertex(v);
+      for (int e = 0; e < 6; ++e) {
+        const int V0 = tet.vertex(tet_edges[e][0]);
+        const int V1 = tet.vertex(tet_edges[e][1]);
+        const Vector3d p_FV0 = volume_mesh_F.vertex(V0);
+        const Vector3d p_FV1 = volume_mesh_F.vertex(V1);
+        const Vector3d p_V0V1_F = p_FV1 - p_FV0;
+        const double d_V0V1 = p_V0V1_F.norm();
+        const Vector3d p_V0S_F = p_FS - p_FV0;
+        const double d_V0S = p_V0S_F.norm();
+        // Test that if S lies on the line segment spanned by V0V1.
+        //  - it is colinear with the _line_ passing through V0V1 and
+        //  - its "weight" (i.e., interpolation between V0 and V1) is in the
+        //    interval [0, 1].
+        //
+        // We can implicitly test collinearity (and part of the weight value)
+        // by comparing the vector V0S with V0V1. A negative dot product
+        // indicates that S *cannot* lie between V0 and V1 (colinear or not)
+        // and a positive value equal to |V0S| * |V0V1| indicates
+        // colinearity (it can still lie beyond the edge's vertices).
+        if (p_V0V1_F.dot(p_V0S_F) - d_V0V1 * d_V0S <= -kEps) continue;
+        // Define weight w such that: S = w * V0 + (1 - w) * V1.
+        double w = 1.0 - d_V0S / d_V0V1;
+        // The previous test already confirmed colinearity and w >= 0.
+        if (w > 1 + kEps) {
+          return {{},
+                  ::testing::AssertionFailure()
+                      << "Vertex " << v << " is co-linear with edge " << e
+                      << " but doesn't lie on the edge"};
         }
+        edge_vertices.push_back(EdgeVertex{v, {V0, V1}, w});
       }
     }
-    // The number of edge vertices should be equal to the number of faces.
-    if (edge_vertices.size() != slice.size()) {
+    // With a single element, we expect all vertices to be classified.
+    if (static_cast<int>(edge_vertices.size()) != slice_mesh_W.num_vertices()) {
       return {{},
               ::testing::AssertionFailure()
                   << "Only " << edge_vertices.size() << " slice vertices were "
-                  << "mapped to tet edges; expected " << slice.size()};
+                  << "mapped to tet edges; expected "
+                  << slice_mesh_W.num_vertices()};
     }
     // Every edge I've identified should be located in the clipping algorithm's
     // cache: cut_edges_. Make sure they line up.
@@ -351,49 +294,25 @@ class SliceTetWithPlaneTest : public ::testing::Test {
     return {edge_vertices, ::testing::AssertionSuccess()};
   }
 
-  /* Given the edge vertices (assuming they are properly ordered to form a
-   coherent polygon), computes the centroid. */
-  Vector3d CentroidFromFan(const vector<EdgeVertex>& edge_vertices) const {
-    vector<int> polygon;
-    for (const auto& edge_vertex : edge_vertices) {
-      polygon.push_back(edge_vertex.slice_vertex);
-    }
-    const Vector3d nhat_W = CalcPlaneNormal(vertices_W_[polygon[0]],
-                                            vertices_W_[polygon[1]],
-                                            vertices_W_[polygon[2]]);
-    return CalcPolygonCentroid(polygon, nhat_W, vertices_W_);
-  }
-
-  /* Confirm that the centroid is properly the geometric centroid of the
-   polygon formed by the perimeter vertices. This relies on the edge
-   vertices to be ordered properly (i.e., around the perimeter and not
-   jumbled up). */
-  ::testing::AssertionResult FanVertexIsCentroid(
-      const vector<EdgeVertex>& edge_vertices, int centroid_index) const {
-    constexpr double kEps = 8 * std::numeric_limits<double>::epsilon();
-    const Vector3d p_WC = CentroidFromFan(edge_vertices);
-    return CompareMatrices(p_WC, vertices_W_[centroid_index], kEps);
-  }
-
   /* Confirms that the pressures stored in surface_pressure_ can be reproduced
    by linearly interpolating pressure values on the `tet` based on the
    data in `edge_vertices`. */
   ::testing::AssertionResult PressuresMatchVertices(
-      int tet_index, int centroid_index,
+      const PolygonSurfaceMeshFieldLinear<double, double>& field_W,
+      int tet_index,
       const vector<EdgeVertex>& edge_vertices,
       const VolumeMeshFieldLinear<double, double>& field_F) const {
     constexpr double kEps = 32 * std::numeric_limits<double>::epsilon();
     for (const auto& edge_vertex : edge_vertices) {
       // Compute expected pressure.
-      const double p0 =
-          field_F.EvaluateAtVertex(edge_vertex.edge.first());
-      const double p1 =
-          field_F.EvaluateAtVertex(edge_vertex.edge.second());
+      const auto [V0, V1] = edge_vertex.edge;
+      const double p0 = field_F.EvaluateAtVertex(V0);
+      const double p1 = field_F.EvaluateAtVertex(V1);
       // Combine using the weight as documented in EdgeVertex.
       const double expected_pressure =
           p0 * edge_vertex.weight + (1 - edge_vertex.weight) * p1;
       const int test_vertex_index = edge_vertex.slice_vertex;
-      const double pressure = surface_pressure_[test_vertex_index];
+      const double pressure = field_W.EvaluateAtVertex(test_vertex_index);
       if (std::abs(pressure - expected_pressure) > kEps) {
         return ::testing::AssertionFailure()
                << "\nSurface vertex " << test_vertex_index
@@ -403,72 +322,35 @@ class SliceTetWithPlaneTest : public ::testing::Test {
       }
     }
 
-    // Pressure is likewise correct at the centroid.
-    const Vector3d p_FC = X_WF_.inverse() * CentroidFromFan(edge_vertices);
-    const double p_at_C_expected = field_F.EvaluateCartesian(tet_index, p_FC);
-    const double p_at_C = surface_pressure_.at(centroid_index);
-    if (std::abs(p_at_C - p_at_C_expected) > kEps) {
-      return ::testing::AssertionFailure()
-          << "\nPressure at centroid is wrong.\n"
-          << " Found    " << p_at_C << "\n"
-          << " Expected " << p_at_C_expected;
-    }
-
     return ::testing::AssertionSuccess();
   }
 
-  /* This tests the values in faces_, vertices_W_, and surface_pressure_ against
-   the given mesh and confirms they are consistent. It assumes that the
-   result has no duplicate vertices. The following is tested:
+  /* This tests the mesh created after a _single_ call to SliceTetWithPlane()
+   against the given _volume_ mesh and confirms they are consistent.
 
-      1. The vertices all lie within the tetrahedron (and contains no NaN
-         values).
-      2. The vertices define a fan (i.e., each triangle shares a common
-         vertex, the fan origin). All other vertices are referenced twice,
-         once by each face.
-      3. Every non-centroid (perimeter) vertex lies on an edge of the
-         indicated tet.
-      4. The shared vertex is properly the centroid of the polygon formed
-         by the perimeter vertices.
-      5. The reported pressure at a perimeter vertex is a linear combination
-         of its edge vertex values just like the vertex position is -- using
-         the same weight. */
+   Which mesh builder is used is arbitrary, but this test code needs to know so
+   that it can recognize successful properties. In this case, the resulting mesh
+   data will include a single polygon, wholly contained by the tet indicated by
+   tet_index.
+
+   The following is tested:
+
+      1. Proper intersection:
+         - Each vertex lies on an *edge* of the tet.
+      3. Pressure evaluation:
+         - Pressure at each vertex is the linear interpolation of the values
+           at the vertices for that edge (using the same weight). */
   ::testing::AssertionResult SliceIsConsistent(
+      const PolygonSurfaceMesh<double>& mesh_W,
+      const PolygonSurfaceMeshFieldLinear<double, double>& field_W,
       int tet_index,
       const VolumeMeshFieldLinear<double, double>& field_F) const {
-    // Confirms that the triangles lie within the tetrahedron; the barycentric
-    // coordinates should all lie within [0, 1]. This will also catch NaN
-    // values because the condition will be de facto false.
-    constexpr double kEps = 32 * std::numeric_limits<double>::epsilon();
-    const RigidTransformd X_FW = X_WF_.inverse();
-    for (const Vector3d& p_WV : vertices_W_) {
-      const Vector3d& p_FV = X_FW * p_WV;
-      const VolumeMesh<double>::Barycentric<double> b_V =
-          field_F.mesh().CalcBarycentric(p_FV, tet_index);
-      for (int i = 0; i < 4; ++i) {
-        if (!(b_V(i) >= -kEps && b_V(i) <= 1 + kEps)) {
-          return ::testing::AssertionFailure()
-                 << "Mesh vertex reported outside of the tet:\n"
-                 << "    p_FV: " << p_FV.transpose() << "\n"
-                 << "    b_V: " << b_V.transpose();
-        }
-      }
-    }
-    // The slicing produces a small triangle fan around a common vertex. That
-    // vertex _should_ be the centroid. This identifies the fan vertex (but
-    // confirmation that it is the centroid is deferred to below).
-    const auto [fan_index, result1] = IdentifyFanVertex(faces_);
-    if (!result1) return result1;
-
     // Confirms that each perimeter vertex lies on an edge of the tetrahedron.
-    const auto [edge_vertices, result2] = CharacterizeEdgeVertices(
-        fan_index, faces_, vertices_W_, tet_index, field_F.mesh());
-    if (!result2) return result2;
+    const auto [edge_vertices, result] =
+        CharacterizeEdgeVertices(mesh_W, tet_index, field_F.mesh());
+    if (!result) return result;
 
-    const auto result3 = FanVertexIsCentroid(edge_vertices, fan_index);
-    if (!result3) return result3;
-
-    return PressuresMatchVertices(tet_index, fan_index, edge_vertices, field_F);
+    return PressuresMatchVertices(field_W, tet_index, edge_vertices, field_F);
   }
 
   /* Computes the centroid of the indicated tet in the given mesh. */
@@ -483,29 +365,21 @@ class SliceTetWithPlaneTest : public ::testing::Test {
     return p_MC / 4.0;
   }
 
-  /* Confirms that the normal implied by the triangle indicated by `face_index`
+  /* Confirms that the normal implied by the face indicated by `face_index`
    matches the given expected normal. */
   ::testing::AssertionResult FaceNormalMatches(
-      int tri_index, const Vector3d& expected_n_W) const {
-    const SurfaceTriangle& tri = faces_[tri_index];
-    const Vector3d& r_WV0 = vertices_W_[tri.vertex(0)];
-    const Vector3d& r_WV1 = vertices_W_[tri.vertex(1)];
-    const Vector3d& r_WV2 = vertices_W_[tri.vertex(2)];
-    const Vector3d n_W = ((r_WV1 - r_WV0).cross(r_WV2 - r_WV0)).normalized();
-    // The difference between computing the normal like this and the
-    // transformation of nhat_F into nhat_W for the space of arbitrary R_WF used
-    // in these tests seem to lead to a difference in about six bits -- so we
-    // scale epsilon by 2^6.
-    constexpr double kEps = 64 * std::numeric_limits<double>::epsilon();
+      const PolygonSurfaceMesh<double>& mesh_W, int face_index,
+      const Vector3d& expected_n_W) const {
+    const Vector3d& n_W = mesh_W.face_normal(face_index);
+    constexpr double kEps = 32 * std::numeric_limits<double>::epsilon();
     return CompareMatrices(expected_n_W, n_W, kEps);
   }
 
+  /* The operands for the SliceTetWithPlane() method. */
+  PolyMeshBuilder<double> builder_W_;
+  unique_ptr<VolumeMesh<double>> volume_mesh_F_;
+  unique_ptr<VolumeMeshFieldLinear<double, double>> field_F_;
   RigidTransformd X_WF_;
-
-  /* The accumulators for the SliceTetWithPlane() method. */
-  vector<SurfaceTriangle> faces_;
-  vector<Vector3d> vertices_W_;
-  vector<double> surface_pressure_;
   unordered_map<SortedPair<int>, int> cut_edges_;
 };
 
@@ -530,18 +404,12 @@ TEST_F(SliceTetWithPlaneTest, NonIntersectingConfiguration) {
   const Vector3d p_MMin{0, 0, 0};
   constexpr double kEps = 4 * std::numeric_limits<double>::epsilon();
 
-  // For these tests, we do not want to do analysis; just confirming the
-  // existence/non-existence of intersection results.
-  const bool no_analysis = false;
-
   vector<RigidTransformd> X_FMs{
       RigidTransformd::Identity(),
       RigidTransformd{RotationMatrixd{AngleAxisd{
                           8 * M_PI / 7, Vector3d{1, 2, 3}.normalized()}},
                       Vector3d{-2.3, -4.2, 3.7}}};
-  int index_X_FM = 0;
   for (const auto& X_FM : X_FMs) {
-    SCOPED_TRACE(fmt::format("index_X_FM {}", index_X_FM++));
     const Vector3d& Mz_F = X_FM.rotation().col(2);
     // The minimum and maximum points of the tet in frame F.
     const Vector3d p_FMax = X_FM * p_MMax;
@@ -550,54 +418,62 @@ TEST_F(SliceTetWithPlaneTest, NonIntersectingConfiguration) {
     const Vector3d offset_F = kEps * Mz_F;
 
     // Case: Plane lies completely above the tet (just beyond V3)
-    CallSliceTetWithPlane(Plane<double>{Mz_F, p_FMax + offset_F}, X_FM,
-                          no_analysis);
-    EXPECT_TRUE(HasNFaces(0));
+    {
+      const auto [mesh_W, field_W] =
+          CallSliceTetWithPlane(Plane<double>{Mz_F, p_FMax + offset_F}, X_FM);
+      EXPECT_TRUE(HasNVertices(*mesh_W, *field_W, 0));
+    }
 
     // Case: Plane lies _almost_ completely above the tet (V3 penetrates the
     // plane).
-    CallSliceTetWithPlane(Plane<double>{Mz_F, p_FMax - offset_F}, X_FM,
-                          no_analysis);
-    EXPECT_TRUE(HasNFaces(3));
+    {
+      const auto [mesh_W, field_W] =
+          CallSliceTetWithPlane(Plane<double>{Mz_F, p_FMax - offset_F}, X_FM);
+      EXPECT_TRUE(HasNVertices(*mesh_W, *field_W, 3));
+    }
 
     // Case: Plane lies completely below the tet (the bottom faces lies on the
     // z = 0 plane in Frame M).
-    CallSliceTetWithPlane(Plane<double>{Mz_F, p_FMin - offset_F}, X_FM,
-                          no_analysis);
-    EXPECT_TRUE(HasNFaces(0));
+    {
+      const auto [mesh_W, field_W] =
+          CallSliceTetWithPlane(Plane<double>{Mz_F, p_FMin - offset_F}, X_FM);
+      EXPECT_TRUE(HasNVertices(*mesh_W, *field_W, 0));
+    }
 
     // Case: Plane lies _almost_ completely below the tet.
-    CallSliceTetWithPlane(Plane<double>{Mz_F, p_FMin + offset_F}, X_FM,
-                          no_analysis);
-    EXPECT_TRUE(HasNFaces(3));
+    {
+      const auto [mesh_W, field_W] =
+          CallSliceTetWithPlane(Plane<double>{Mz_F, p_FMin + offset_F}, X_FM);
+      EXPECT_TRUE(HasNVertices(*mesh_W, *field_W, 3));
+    }
 
     // Tests in which the plane normal is _not_ the Mz axis. We'll align it so
     // that it is normal to the v1, v2, v3 plane. We happen to know that
     // that normal (expressed in M) points in the <1, 1, 1> direction.
     const Vector3d normal_F = X_FM.rotation() * Vector3d{1, 1, 1}.normalized();
 
-    // We need to construct an instance of mesh_F so we can find out where
-    // vertices v1, v2, v3 are so we know where to position the plane.
-    VolumeMesh<double> mesh_F = TrivialVolumeMesh(X_FM);
-
     // Case: Plane is just beyond the v1, v2, v3, plane; it passes through a
     // point _near_ V3, but just offset in the normal direction.
-    CallSliceTetWithPlane(Plane<double>{normal_F, p_FMax + kEps * normal_F},
-                          X_FM, no_analysis);
-    EXPECT_TRUE(HasNFaces(0));
+    {
+      const auto [mesh_W, field_W] = CallSliceTetWithPlane(
+          Plane<double>{normal_F, p_FMax + kEps * normal_F}, X_FM);
+      EXPECT_TRUE(HasNVertices(*mesh_W, *field_W, 0));
+    }
 
     // Case: Plane intersects the tet near the v1, v2, v3, plane; it passes
     // through a point _near_ V3, but offset in the _negative_ normal direction.
-    CallSliceTetWithPlane(Plane<double>{normal_F, p_FMax - 4 * kEps * normal_F},
-                          X_FM, no_analysis);
-    EXPECT_TRUE(HasNFaces(3));
+    {
+      const auto [mesh_W, field_W] = CallSliceTetWithPlane(
+          Plane<double>{normal_F, p_FMax - 4 * kEps * normal_F}, X_FM);
+      EXPECT_TRUE(HasNVertices(*mesh_W, *field_W, 3));
+    }
   }
 }
 
 /* This tests the cases where the plane intersects with the tet, creating a
- triangle. It confirms the number of triangles produced, confirms face normal
- direction, and uses the test infrastructure to evaluate the coherency of the
- set of triangles. */
+ triangle. It confirms the triangular polygon produced, confirms face normal
+ direction, and uses the test infrastructure to evaluate the consistency of the
+ set of polygons. */
 TEST_F(SliceTetWithPlaneTest, TriangleIntersections) {
   // There are eight unique configurations for a plane-tet intersection to be
   // a triangle. If a single vertex of the tet lies on one side of the plane
@@ -622,9 +498,7 @@ TEST_F(SliceTetWithPlaneTest, TriangleIntersections) {
       RigidTransformd{RotationMatrixd{AngleAxisd{
                           9 * M_PI / 7, Vector3d{1, 2, 3}.normalized()}},
                       Vector3d{-2.3, -4.2, 3.7}}};
-  int index_X_FM = 0;
   for (const auto& X_FM : X_FMs) {
-    SCOPED_TRACE(fmt::format("index_X_FM = {}", index_X_FM++));
     VolumeMesh<double> mesh_F = TrivialVolumeMesh(X_FM);
     const VolumeElement& tet = mesh_F.element(tet_index);
 
@@ -632,7 +506,6 @@ TEST_F(SliceTetWithPlaneTest, TriangleIntersections) {
     const Vector3d p_FC = ComputeTetCentroid(mesh_F, tet);
 
     for (int i = 0; i < 4; ++i) {
-      SCOPED_TRACE(fmt::format("i = {}; 0 <= i < 4", i));
       // The position of the "isolated" vertex -- the lone vertex lying on one
       // side of the plane.
       const Vector3d& p_FVi = mesh_F.vertex(tet.vertex(i));
@@ -646,7 +519,6 @@ TEST_F(SliceTetWithPlaneTest, TriangleIntersections) {
       // definition of the plane so that once the isolated vertex has a
       // negative signed distance, and once a positive distance.
       for (const auto plane_sign : {1.0, -1.0}) {
-        SCOPED_TRACE(fmt::format("plane_sign = {}", plane_sign));
         Plane<double> plane_F{plane_sign * nhat_F, p_FP};
 
         // Confirm configuration.
@@ -659,21 +531,19 @@ TEST_F(SliceTetWithPlaneTest, TriangleIntersections) {
             EXPECT_LT(plane_sign * plane_F.CalcHeight(p_FVj), 0);
           }
         }
-        ASSERT_TRUE(
-            CallSliceTetWithPlane(plane_F, X_FM, true /* do_analysis */));
+        const auto [mesh_W, field_W] = CallSliceTetWithPlane(plane_F, X_FM);
+        ASSERT_TRUE(SliceIsConsistent(*mesh_W, *field_W, 0, *field_F_));
 
         // Further consistency analysis.
-        ASSERT_TRUE(HasNFaces(3));
+        ASSERT_TRUE(HasNVertices(*mesh_W, *field_W, 3));
         const Vector3d nhat_W = X_WF_.rotation() * plane_F.normal();
-        for (int t = 0; t < 3; ++t) {
-          EXPECT_TRUE(FaceNormalMatches(t, nhat_W));
-        }
+        EXPECT_TRUE(FaceNormalMatches(*mesh_W, 0 /* poly index */, nhat_W));
       }
     }
   }
 }
 
-/* Similar for the TriangleIntersections test, but for intersections that for
+/* Similar for the TriangleIntersections test, but for intersections that form
  quads. */
 TEST_F(SliceTetWithPlaneTest, QuadIntersections) {
   /* A plane forms a quad when intersecting a tet when two vertices are on one
@@ -703,9 +573,7 @@ TEST_F(SliceTetWithPlaneTest, QuadIntersections) {
       RigidTransformd{RotationMatrixd{AngleAxisd{
           9 * M_PI / 7, Vector3d{1, 2, 3}.normalized()}},
                       Vector3d{-2.3, -4.2, 3.7}}};
-  int index_X_FM = 0;
   for (const auto& X_FM : X_FMs) {
-    SCOPED_TRACE(fmt::format("index_X_FM = {}", index_X_FM++));
     VolumeMesh<double> mesh_F = TrivialVolumeMesh(X_FM);
     const VolumeElement& tet = mesh_F.element(tet_index);
 
@@ -729,7 +597,6 @@ TEST_F(SliceTetWithPlaneTest, QuadIntersections) {
     // to every other unique pair being a complement of one of those three.
     for (const auto& [v0, v1] :
          vector<pair<int, int>>{{0, 1}, {0, 2}, {0, 3}}) {
-      SCOPED_TRACE(fmt::format("[v0, v1] = [{}, {}]", v0, v1));
       const Vector3d& p_FV0 = mesh_F.vertex(tet.vertex(v0));
       const Vector3d& p_FV1 = mesh_F.vertex(tet.vertex(v1));
       // Position on edge E nearest the centroid.
@@ -744,7 +611,6 @@ TEST_F(SliceTetWithPlaneTest, QuadIntersections) {
       // definition of the  plane so that once the isolated vertex has a
       // negative signed distance, and once a positive distance.
       for (const auto plane_sign : {-1.0, 1.0}) {
-        SCOPED_TRACE(fmt::format("plane_sign = {}", plane_sign));
         Plane<double> plane_F{plane_sign * nhat_F, p_FP};
 
         // Confirm configuration; all four vertices are on the expected side
@@ -758,15 +624,13 @@ TEST_F(SliceTetWithPlaneTest, QuadIntersections) {
           }
         }
 
-        ASSERT_TRUE(
-            CallSliceTetWithPlane(plane_F, X_FM, true /* do_analysis */));
+        const auto [mesh_W, field_W] = CallSliceTetWithPlane(plane_F, X_FM);
+        ASSERT_TRUE(SliceIsConsistent(*mesh_W, *field_W, 0, *field_F_));
 
         // Further consistency analysis.
-        ASSERT_TRUE(HasNFaces(4));
+        ASSERT_TRUE(HasNVertices(*mesh_W, *field_W, 4));
         const Vector3d nhat_W = X_WF_.rotation() * plane_F.normal();
-        for (int t = 0; t < 4; ++t) {
-          FaceNormalMatches(t, nhat_W);
-        }
+        FaceNormalMatches(*mesh_W, 0 /* poly index */, nhat_W);
       }
     }
   }
@@ -779,8 +643,8 @@ TEST_F(SliceTetWithPlaneTest, DuplicateOutputFromDuplicateInput) {
   // We create the mesh twice; once with duplicates, once without. The plane
   // will slice through *both* tets simultaneously. In both cases we should
   // end up with six triangles (one triangle per tet divided into three
-  // sub-triangles each). One resulting surface will have five vertices
-  // and one will have eight. We confirm that the triangles  occupy the
+  // sub-triangles each). One resulting surface will have six vertices
+  // and one will have eight. We confirm that the triangles occupy the
   // same space -- i.e., the only difference is duplication of vertices.
 
   // We're going to do this with a single X_FM; we've already evaluated the
@@ -793,9 +657,6 @@ TEST_F(SliceTetWithPlaneTest, DuplicateOutputFromDuplicateInput) {
       TrivialVolumeMesh(X_FM, true /* min_vertices */);
   VolumeMeshFieldLinear<double, double> min_field_F{
       vector<double>{0, 0, 0, 1, -1}, &min_mesh_F};
-  vector<SurfaceTriangle> min_faces;
-  vector<Vector3d> min_vertices_F;
-  vector<double> min_surface_pressure;
   unordered_map<SortedPair<int>, int> min_cut_edges;
 
   // The infrastructure for the mesh with duplicate vertices.
@@ -803,46 +664,54 @@ TEST_F(SliceTetWithPlaneTest, DuplicateOutputFromDuplicateInput) {
       TrivialVolumeMesh(X_FM, false /* min_vertices */);
   VolumeMeshFieldLinear<double, double> dupe_field_F{
       vector<double>{0, 0, 0, 1, 0, 0, 0, -1}, &dupe_mesh_F};
-  vector<SurfaceTriangle> dupe_faces;
-  vector<Vector3d> dupe_vertices_F;
-  vector<double> dupe_surface_pressure;
   unordered_map<SortedPair<int>, int> dupe_cut_edges;
 
   // The common slicing plane.
   Plane<double> plane_F{Vector3d::UnitX(), Vector3d{0.5, 0, 0}};
 
+  TriMeshBuilder<double> min_builder_W;
+  TriMeshBuilder<double> dupe_builder_W;
   for (int i = 0; i < 2; ++i) {
-    SliceTetWithPlane(i, min_field_F, plane_F, X_WF_,
-                      &min_faces, &min_vertices_F, &min_surface_pressure,
+    SliceTetWithPlane(i, min_field_F, plane_F, X_WF_, &min_builder_W,
                       &min_cut_edges);
-    SliceTetWithPlane(i, dupe_field_F, plane_F, X_WF_,
-                      &dupe_faces, &dupe_vertices_F, &dupe_surface_pressure,
+    SliceTetWithPlane(i, dupe_field_F, plane_F, X_WF_, &dupe_builder_W,
                       &dupe_cut_edges);
   }
 
+  const auto [min_mesh_W, min_field_W] = min_builder_W.MakeMeshAndField();
+  const auto [dupe_mesh_W, dupe_field_W] = dupe_builder_W.MakeMeshAndField();
+
+  // We're not examining the fields.
+  unused(min_field_W, dupe_field_W);
+
   // Both have the expected number (6) of faces.
-  ASSERT_EQ(dupe_faces.size(), 6u);
-  ASSERT_EQ(min_faces.size(), 6u);
+  ASSERT_EQ(dupe_mesh_W->num_triangles(), 6);
+  ASSERT_EQ(min_mesh_W->num_triangles(), 6);
+  // Different vertex counts.
+  ASSERT_EQ(dupe_mesh_W->num_vertices(), 8);
+  ASSERT_EQ(min_mesh_W->num_vertices(), 6);
   constexpr double kEps = std::numeric_limits<double>::epsilon();
   // We exploit knowledge of the algorithm to assume that the faces in both
   // results are in the exact same order with the constituent vertices also in
-  // same order.
+  // same order; the jth vertex of the ith triangle in each mesh should be in
+  // the same location.
   for (int f = 0; f < 6; ++f) {
-    const SurfaceTriangle& min_face = min_faces[0];
-    const SurfaceTriangle& dupe_face = dupe_faces[0];
+    const SurfaceTriangle& min_face = min_mesh_W->element(f);
+    const SurfaceTriangle& dupe_face = dupe_mesh_W->element(f);
     for (int v = 0; v < 3; ++v) {
-      const Vector3d& p_FVm = min_vertices_F[min_face.vertex(v)];
-      const Vector3d& p_FVd = dupe_vertices_F[dupe_face.vertex(v)];
+      const Vector3d& p_FVm = min_mesh_W->vertex(min_face.vertex(v));
+      const Vector3d& p_FVd = dupe_mesh_W->vertex(dupe_face.vertex(v));
       EXPECT_NEAR((p_FVm - p_FVd).norm(), 0, kEps);
     }
   }
 
   // Confirm that all of the vertices in the duplicate mesh are referenced.
   set<int> vertex_indices;
-  for (const auto& face : dupe_faces) {
-    for (int i = 0; i < 3; ++i) vertex_indices.insert(face.vertex(i));
+  for (const auto& tri : dupe_mesh_W->triangles()) {
+    for (int i = 0; i < 3; ++i) vertex_indices.insert(tri.vertex(i));
   }
-  ASSERT_EQ(vertex_indices.size(), dupe_vertices_F.size());
+  ASSERT_EQ(static_cast<int>(vertex_indices.size()),
+            dupe_mesh_W->num_vertices());
 }
 
 /* This confirms that the structure of the query precludes "double counting". If
@@ -854,7 +723,9 @@ TEST_F(SliceTetWithPlaneTest, NoDoubleCounting) {
    confirm implicit handling of this scenario is to do the test in a regime
    where all the values are perfectly represented. So, in this case, we are
    doing all of the computations in the mesh frame where the zeros and ones
-   give us that perfect precision for free. */
+   give us that perfect precision for free.
+
+   We use a PolyMeshBuilder because we can build an "empty" mesh. */
 
   const Plane<double> plane_M{Vector3d::UnitZ(), Vector3d::Zero()};
   const RigidTransformd I;
@@ -863,34 +734,35 @@ TEST_F(SliceTetWithPlaneTest, NoDoubleCounting) {
   vector<double> values{0.25, 0.5, 0.75, 1, -1};
   VolumeMeshFieldLinear<double, double> field_M{move(values), &mesh_M};
 
-  // Slicing against tet 0 should intersect and produce the faces.
   {
-    vector<SurfaceTriangle> faces;
-    vector<Vector3d> vertices_W;
-    vector<double> surface_pressure;
+    // Slicing against tet 0 should intersect and produce the three faces.
+    PolyMeshBuilder<double> builder_W;
     unordered_map<SortedPair<int>, int> cut_edges;
-    int tet_index{0};
-    SliceTetWithPlane(tet_index, field_M, plane_M, I, &faces, &vertices_W,
-                      &surface_pressure, &cut_edges);
-    EXPECT_EQ(faces.size(), 3u);
+    const int tet_index = 0;
+    SliceTetWithPlane(tet_index, field_M, plane_M, I, &builder_W, &cut_edges);
+    const auto [mesh_W, field_W] = builder_W.MakeMeshAndField();
+    // We're not examining the fields.
+    unused(field_W);
+    EXPECT_EQ(mesh_W->num_elements(), 1);
   }
 
-  // Slicing against tet 1 should produce no intersection.
   {
-    vector<SurfaceTriangle> faces;
-    vector<Vector3d> vertices_W;
-    vector<double> surface_pressure;
+    // Slicing against tet 1 should produce no intersection.
+    PolyMeshBuilder<double> builder_W;
     unordered_map<SortedPair<int>, int> cut_edges;
-    int tet_index{1};
-    SliceTetWithPlane(tet_index, field_M, plane_M, I, &faces, &vertices_W,
-                      &surface_pressure, &cut_edges);
-    EXPECT_EQ(faces.size(), 0);
+    const int tet_index = 1;
+    SliceTetWithPlane(tet_index, field_M, plane_M, I, &builder_W, &cut_edges);
+    const auto [mesh_W, field_W] = builder_W.MakeMeshAndField();
+    // We're not examining the fields.
+    unused(field_W);
+    EXPECT_EQ(mesh_W->num_elements(), 0);
   }
 }
 
 /* Test of ComputeContactSurface(). Most of the hard-core math is contained in
  SliceTetWithPlane (and is covered by its unit tests). This function has the
  following unique responsibilities:
+
   1. No intersection returns nullptr.
   2. The resulting contact surface is a function of the tets provided; they
      are all considered and only those that actually intersect contribute to
@@ -902,9 +774,17 @@ TEST_F(SliceTetWithPlaneTest, NoDoubleCounting) {
      resultant ContactSurface.
   5. Mesh normals point out of plane and into soft mesh.
   6. Report the pressure gradient of the soft mesh on the contact surface.
+  7. The mesh representation of the contact surface is consistent with the
+     type of MeshBuilder passed.
+
  These tests are done in a single, non-trivial frame F. The robustness of the
  numerics is covered in the SliceTetWithPlaneTest and this just needs to
- account for data tracking. */
+ account for data tracking.
+
+ ComputeContactSurface() is *largely* agnostic of the type of mesh
+ representation being requested. Only responsibility 7 directly depends on that
+ type and so will be tested in its own test. All other tests simply use one
+ of the MeshBuilder types, inferring success for the other. */
 class ComputeContactSurfaceTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -958,7 +838,7 @@ TEST_F(ComputeContactSurfaceTest, NoIntersectionReturnsNullPtr) {
     // Case: plane slices through *nothing*; but we'll test all tets.
     const Vector3d p_FB = X_FM_.translation() + 1.5 * Mz_F;
     const Plane<double> plane_F{Mz_F, p_FB};
-    EXPECT_EQ(ComputeContactSurface<double>(
+    EXPECT_EQ(ComputeContactSurface<TriMeshBuilder<double>>(
                   mesh_id_, *field_F_, plane_id_, plane_F, both_tets_, X_WF_),
               nullptr);
   }
@@ -968,7 +848,7 @@ TEST_F(ComputeContactSurfaceTest, NoIntersectionReturnsNullPtr) {
     // therefore no intersection is detected and nullptr is returned.
     const Vector3d p_FB = X_FM_.translation() + 0.5 * Mz_F;
     const Plane<double> plane_F{Mz_F, p_FB};
-    EXPECT_EQ(ComputeContactSurface<double>(
+    EXPECT_EQ(ComputeContactSurface<TriMeshBuilder<double>>(
                   mesh_id_, *field_F_, plane_id_, plane_F, only_tet_1_, X_WF_),
               nullptr);
   }
@@ -983,38 +863,37 @@ TEST_F(ComputeContactSurfaceTest, AllTetsAreConsidered) {
   const Vector3d p_FB = X_FM_.translation() + 0.5 * Mx_F;
   const Plane<double> plane_F{Mx_F, p_FB};
 
-  // Passing in all tet indices produces the full intersection.
+  // Passing in all tet indices produces the full intersection: 6 triangles.
   unique_ptr<ContactSurface<double>> contact_surface =
-      ComputeContactSurface<double>(
+      ComputeContactSurface<TriMeshBuilder<double>>(
           mesh_id_, *field_F_, plane_id_, plane_F, both_tets_, X_WF_);
   ASSERT_NE(contact_surface, nullptr);
-  EXPECT_EQ(contact_surface->mesh_W().num_elements(), 6);
-  EXPECT_EQ(contact_surface->mesh_W().num_vertices(), 6);
+  EXPECT_EQ(contact_surface->tri_mesh_W().num_elements(), 6);
+  EXPECT_EQ(contact_surface->tri_mesh_W().num_vertices(), 6);
 
   // Passing just one or the other produces only one tet's worth of triangles.
-  auto contact_surface_0 = ComputeContactSurface<double>(
+  auto contact_surface_0 = ComputeContactSurface<TriMeshBuilder<double>>(
       mesh_id_, *field_F_, plane_id_, plane_F, only_tet_0_, X_WF_);
   ASSERT_NE(contact_surface_0, nullptr);
-  EXPECT_EQ(contact_surface_0->mesh_W().num_elements(), 3);
-  EXPECT_EQ(contact_surface_0->mesh_W().num_vertices(), 4);
+  EXPECT_EQ(contact_surface_0->tri_mesh_W().num_elements(), 3);
+  EXPECT_EQ(contact_surface_0->tri_mesh_W().num_vertices(), 4);
   const RigidTransformd X_MW = X_FM_.InvertAndCompose(X_WF_.inverse());
+  const int last_vertex = 3;
   {
     // For tet 0, the z-value of the last vertex should be > 0.
-    const Vector3d& p_WV =
-        contact_surface_0->mesh_W().vertices().back();
+    const Vector3d& p_WV = contact_surface_0->tri_mesh_W().vertex(last_vertex);
     const Vector3d& p_MV = X_MW * p_WV;
     EXPECT_GT(p_MV(2), 0);
   }
 
-  auto contact_surface_1 = ComputeContactSurface<double>(
+  auto contact_surface_1 = ComputeContactSurface<TriMeshBuilder<double>>(
       mesh_id_, *field_F_, plane_id_, plane_F, only_tet_1_, X_WF_);
   ASSERT_NE(contact_surface_1, nullptr);
-  EXPECT_EQ(contact_surface_1->mesh_W().num_elements(), 3);
-  EXPECT_EQ(contact_surface_1->mesh_W().num_vertices(), 4);
+  EXPECT_EQ(contact_surface_1->tri_mesh_W().num_elements(), 3);
+  EXPECT_EQ(contact_surface_1->tri_mesh_W().num_vertices(), 4);
   {
     // For tet 1, the z-value of the last vertex should be < 0.
-    const Vector3d& p_WV =
-        contact_surface_1->mesh_W().vertices().back();
+    const Vector3d& p_WV = contact_surface_1->tri_mesh_W().vertex(last_vertex);
     const Vector3d& p_MV = X_MW * p_WV;
     EXPECT_LT(p_MV(2), 0);
   }
@@ -1052,11 +931,11 @@ TEST_F(ComputeContactSurfaceTest, DuplicatesHandledProperly) {
 
     // Passing in all tet indices produces the full intersection: 6 triangles.
     unique_ptr<ContactSurface<double>> contact_surface =
-        ComputeContactSurface<double>(
+        ComputeContactSurface<TriMeshBuilder<double>>(
             mesh_id_, *field_F_, plane_id_, plane_F, both_tets_, X_WF_);
     ASSERT_NE(contact_surface, nullptr);
     const TriangleSurfaceMesh<double>& contact_mesh_W =
-        contact_surface->mesh_W();
+        contact_surface->tri_mesh_W();
     EXPECT_EQ(contact_mesh_W.num_elements(), 6);
     EXPECT_EQ(contact_mesh_W.num_vertices(), 6);
 
@@ -1084,11 +963,11 @@ TEST_F(ComputeContactSurfaceTest, DuplicatesHandledProperly) {
 
     // Passing in all tet indices produces the full intersection: 6 triangles.
     unique_ptr<ContactSurface<double>> contact_surface =
-        ComputeContactSurface<double>(
+        ComputeContactSurface<TriMeshBuilder<double>>(
             mesh_id_, dupe_field_F, plane_id_, plane_F, both_tets_, X_WF_);
     ASSERT_NE(contact_surface, nullptr);
     const TriangleSurfaceMesh<double>& contact_mesh_W =
-        contact_surface->mesh_W();
+        contact_surface->tri_mesh_W();
     EXPECT_EQ(contact_mesh_W.num_elements(), 6);
     EXPECT_EQ(contact_mesh_W.num_vertices(), 8);
 
@@ -1110,18 +989,17 @@ TEST_F(ComputeContactSurfaceTest, DuplicatesHandledProperly) {
 /* Tests responsibility 4: the returned contact surface has a pressure field
  that references its own mesh. */
 TEST_F(ComputeContactSurfaceTest, ContactSurfaceFieldReferencesMesh) {
-  // The plane slices through tet 0.
+  // The plane slices through tet 0 creating a single triangle (decomposed into
+  // three in the output).
   const Vector3d& Mz_F = X_FM_.rotation().col(2);
   const Vector3d p_FB = X_FM_.translation() + 0.5 * Mz_F;
   const Plane<double> plane_F{Mz_F, p_FB};
-
-  unique_ptr<ContactSurface<double>> contact = ComputeContactSurface<double>(
-      mesh_id_, *field_F_, plane_id_, plane_F, both_tets_, X_WF_);
-  EXPECT_EQ(&contact->mesh_W(), &contact->e_MN().mesh());
-
-  contact = ComputeContactSurface<double>(
-      mesh_id_, *field_F_, plane_id_, plane_F, both_tets_, X_WF_);
-  EXPECT_EQ(&contact->mesh_W(), &contact->e_MN().mesh());
+  unique_ptr<ContactSurface<double>> contact =
+      ComputeContactSurface<TriMeshBuilder<double>>(
+          mesh_id_, *field_F_, plane_id_, plane_F, both_tets_, X_WF_);
+  const auto& mesh_W = contact->tri_mesh_W();
+  const auto& field_W = contact->tri_e_MN();
+  EXPECT_EQ(&mesh_W, &field_W.mesh());
 }
 
 /* Tests responsibility 5: the normals point out of the plane and into the
@@ -1135,22 +1013,20 @@ TEST_F(ComputeContactSurfaceTest, NormalsInPlaneDirection) {
 
   // We'll evaluate it with two id configurations. We want to make sure that
   // the normals are correct, regardless of relationship between ids.
-  const vector<pair<GeometryId, GeometryId>> ids{{mesh_id_, plane_id_},
-                                                 {plane_id_, mesh_id_}};
-
+  vector<pair<GeometryId, GeometryId>> ids{{mesh_id_, plane_id_},
+                                           {plane_id_, mesh_id_}};
   for (const auto& [id_A, id_B] : ids) {
-    SCOPED_TRACE(fmt::format("[id_A, id_B] = [{}, {}]", id_A, id_B));
-    unique_ptr<ContactSurface<double>> contact = ComputeContactSurface<double>(
-        id_A, *field_F_, id_B, plane_F, both_tets_, X_WF_);
+    unique_ptr<ContactSurface<double>> contact =
+        ComputeContactSurface<TriMeshBuilder<double>>(
+            id_A, *field_F_, id_B, plane_F, both_tets_, X_WF_);
 
     const double normal_sign = contact->id_N() == id_B ? 1.0 : -1.0;
     const Vector3d nhat_W = X_WF_.rotation() * (normal_sign * Mz_F);
     // NOTE: When we set the normals directly from the plane, this precision
     // will improve.
     constexpr double kEps = 64 * std::numeric_limits<double>::epsilon();
-    const TriangleSurfaceMesh<double>& mesh_W = contact->mesh_W();
-    for (int f = 0; f < mesh_W.num_triangles(); ++f) {
-      SCOPED_TRACE(fmt::format("Face index f = {}", f));
+    const TriangleSurfaceMesh<double>& mesh_W = contact->tri_mesh_W();
+    for (int f = 0; f < mesh_W.num_elements(); ++f) {
       EXPECT_TRUE(CompareMatrices(mesh_W.face_normal(f), nhat_W, kEps));
     }
   }
@@ -1178,21 +1054,18 @@ TEST_F(ComputeContactSurfaceTest, GradientConstituentPressure) {
   // 0, and for the last three should be tet 1.
   {
     unique_ptr<ContactSurface<double>> contact_surface =
-        ComputeContactSurface<double>(mesh_id_, *field_F_, plane_id_, plane_F,
-                                      both_tets_, X_WF_);
+        ComputeContactSurface<TriMeshBuilder<double>>(
+            mesh_id_, *field_F_, plane_id_, plane_F, both_tets_, X_WF_);
     ASSERT_NE(contact_surface, nullptr);
-    EXPECT_EQ(contact_surface->mesh_W().num_elements(), 6);
-    EXPECT_EQ(contact_surface->mesh_W().num_vertices(), 6);
+    EXPECT_EQ(contact_surface->tri_mesh_W().num_elements(), 6);
+    EXPECT_EQ(contact_surface->tri_mesh_W().num_vertices(), 6);
     EXPECT_TRUE(contact_surface->HasGradE_M());
     EXPECT_FALSE(contact_surface->HasGradE_N());
-    int num_triangles = contact_surface->mesh_W().num_elements();
-    for (int f = 0; f < num_triangles / 2; ++f) {
-      SCOPED_TRACE(fmt::format("Face index f = {}", f));
+    for (int f = 0; f < 3; ++f) {
       EXPECT_TRUE(CompareMatrices(contact_surface->EvaluateGradE_M_W(f),
                                   grad_eMesh_W_expected0));
     }
-    for (int f = num_triangles / 2; f < num_triangles; ++f) {
-      SCOPED_TRACE(fmt::format("Face index f = {}", f));
+    for (int f = 3; f < 6; ++f) {
       EXPECT_TRUE(CompareMatrices(contact_surface->EvaluateGradE_M_W(f),
                                   grad_eMesh_W_expected1));
     }
@@ -1202,33 +1075,51 @@ TEST_F(ComputeContactSurfaceTest, GradientConstituentPressure) {
   // be the same.
   {
     unique_ptr<ContactSurface<double>> contact_surface =
-        ComputeContactSurface<double>(plane_id_, *field_F_, mesh_id_, plane_F,
-                                      both_tets_, X_WF_);
+        ComputeContactSurface<TriMeshBuilder<double>>(
+            plane_id_, *field_F_, mesh_id_, plane_F, both_tets_, X_WF_);
     ASSERT_NE(contact_surface, nullptr);
-    EXPECT_EQ(contact_surface->mesh_W().num_elements(), 6);
-    EXPECT_EQ(contact_surface->mesh_W().num_vertices(), 6);
+    EXPECT_EQ(contact_surface->tri_mesh_W().num_elements(), 6);
+    EXPECT_EQ(contact_surface->tri_mesh_W().num_vertices(), 6);
     EXPECT_FALSE(contact_surface->HasGradE_M());
     EXPECT_TRUE(contact_surface->HasGradE_N());
-    int num_triangles = contact_surface->mesh_W().num_elements();
-    for (int f = 0; f < num_triangles / 2; ++f) {
-      SCOPED_TRACE(fmt::format("Face index f = {}", f));
+    for (int f = 0; f < 3; ++f) {
       EXPECT_TRUE(CompareMatrices(contact_surface->EvaluateGradE_N_W(f),
                                   grad_eMesh_W_expected0));
     }
-    for (int f = num_triangles / 2; f < num_triangles; ++f) {
-      SCOPED_TRACE(fmt::format("Face index f = {}", f));
+    for (int f = 3; f < 6; ++f) {
       EXPECT_TRUE(CompareMatrices(contact_surface->EvaluateGradE_N_W(f),
                                   grad_eMesh_W_expected1));
     }
   }
 }
 
+/* Tests responsibility 7: confirms that the mesh type respects the requested
+ type: poly or tri. */
+TEST_F(ComputeContactSurfaceTest, MeshRepresentation) {
+  // The plane slices through tet 0 creating a single triangular polygon.
+  const Vector3d& Mz_F = X_FM_.rotation().col(2);
+  const Vector3d p_FB = X_FM_.translation() + 0.5 * Mz_F;
+  const Plane<double> plane_F{Mz_F, p_FB};
+
+  unique_ptr<ContactSurface<double>> tri_contact =
+      ComputeContactSurface<TriMeshBuilder<double>>(
+          mesh_id_, *field_F_, plane_id_, plane_F, both_tets_, X_WF_);
+  unique_ptr<ContactSurface<double>> poly_contact =
+      ComputeContactSurface<PolyMeshBuilder<double>>(
+          mesh_id_, *field_F_, plane_id_, plane_F, both_tets_, X_WF_);
+
+  EXPECT_EQ(tri_contact->representation(),
+            HydroelasticContactRepresentation::kTriangle);
+  EXPECT_EQ(poly_contact->representation(),
+            HydroelasticContactRepresentation::kPolygon);
+}
+
 /* Test of ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(). This function
  has the following unique responsibilities:
 
   1. Simply that all of the values contribute to the output (poses, ids, etc.)
-*/
-void MeshPlaneIntersectionTestSoftVolumeRigidHalfSpace() {
+  2. Representation request is respected. */
+GTEST_TEST(MeshPlaneIntersectionTest, SoftVolumeRigidHalfSpace) {
   const GeometryId id_A = GeometryId::get_new_id();
   const GeometryId id_B = GeometryId::get_new_id();
   // Create mesh and volume mesh.
@@ -1259,9 +1150,9 @@ void MeshPlaneIntersectionTestSoftVolumeRigidHalfSpace() {
     // appropriate contact info. We won't exhaustively test the data, relying
     // on previous tests to prove correctness. We're just looking for positive
     // indicators.
-    SCOPED_TRACE("Case 1: Initial configuration gets a contact surface.");
     auto contact_surface = ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
-        id_A, field_F, bvh_F, X_WS, id_B, X_WR);
+        id_A, field_F, bvh_F, X_WS, id_B, X_WR,
+        HydroelasticContactRepresentation::kTriangle);
     EXPECT_TRUE(contact_surface->HasGradE_M());
     EXPECT_FALSE(contact_surface->HasGradE_N());
     ASSERT_NE(contact_surface, nullptr);
@@ -1269,13 +1160,15 @@ void MeshPlaneIntersectionTestSoftVolumeRigidHalfSpace() {
     ASSERT_LT(id_A, id_B);
     EXPECT_EQ(contact_surface->id_M(), id_A);
     EXPECT_EQ(contact_surface->id_N(), id_B);
-    EXPECT_EQ(contact_surface->mesh_W().num_elements(), 6);
+    EXPECT_EQ(contact_surface->tri_mesh_W().num_elements(), 6);
     // Sample the face normals.
-    const Vector3d& norm_W = contact_surface->mesh_W().face_normal(0);
+    const Vector3d& norm_W =
+        contact_surface->tri_mesh_W().face_normal(0);
     const Vector3d& Sx_W = X_WS.rotation().col(0);
     EXPECT_TRUE(CompareMatrices(norm_W, Sx_W, kEps));
     // Sample the vertex positions: in the S frame they should all have x = 0.5.
-    const Vector3d& p_WV = contact_surface->mesh_W().vertex(0);
+    const Vector3d& p_WV =
+        contact_surface->tri_mesh_W().vertex(0);
     const Vector3d p_SV = X_WS.inverse() * p_WV;
     EXPECT_NEAR(p_SV(0), 0.5, kEps);
   }
@@ -1284,39 +1177,47 @@ void MeshPlaneIntersectionTestSoftVolumeRigidHalfSpace() {
   // surface. We assume that the initial test indicates the values come through.
 
   {
-    SCOPED_TRACE("Case 2: Move the mesh out of intersection.");
+    // Case 2: Move the mesh out of intersection.
     const RigidTransformd X_SM{Vector3d{-0.51, 0, 0}};
     auto contact_surface = ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
-        id_A, field_F, bvh_F, X_WS * X_SM, id_B, X_WR);
+        id_A, field_F, bvh_F, X_WS * X_SM, id_B, X_WR,
+        HydroelasticContactRepresentation::kTriangle);
     ASSERT_EQ(contact_surface, nullptr);
   }
 
   {
-    SCOPED_TRACE("Case 3: Move the plane out of intersection.");
+    // Case 3: Move the plane out of intersection.
     const RigidTransformd X_SR2{X_SR.rotation(), Vector3d{1.01, 0, 0}};
     auto contact_surface = ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
-        id_A, field_F, bvh_F, X_WS, id_B, X_WS * X_SR2);
+        id_A, field_F, bvh_F, X_WS, id_B, X_WS * X_SR2,
+        HydroelasticContactRepresentation::kTriangle);
     ASSERT_EQ(contact_surface, nullptr);
   }
 
   {
-    SCOPED_TRACE("Case 4: Reverse GeometryIds.");
+    // Case 4: Reverse GeometryIds.
     auto contact_surface = ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
-        id_B, field_F, bvh_F, X_WS, id_A, X_WR);
+        id_B, field_F, bvh_F, X_WS, id_A, X_WR,
+        HydroelasticContactRepresentation::kTriangle);
     ASSERT_NE(contact_surface, nullptr);
     EXPECT_EQ(contact_surface->id_M(), id_A);
     EXPECT_EQ(contact_surface->id_N(), id_B);
     // The effect of reversing the labels reverses the normals, so repeat the
     // normal test, but in the opposite direction.
     const Vector3d& norm_W =
-        contact_surface->mesh_W().face_normal(0);
+        contact_surface->tri_mesh_W().face_normal(0);
     const Vector3d& Sx_W = X_WS.rotation().col(0);
     EXPECT_TRUE(CompareMatrices(norm_W, -Sx_W, kEps));
   }
-}
 
-GTEST_TEST(MeshPlaneIntersectionTest, SoftVolumeRigidHalfSpace) {
-  MeshPlaneIntersectionTestSoftVolumeRigidHalfSpace();
+  {
+    // Case 5: Request polygon mesh.
+    auto contact_surface = ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
+        id_A, field_F, bvh_F, X_WS, id_B, X_WR,
+        HydroelasticContactRepresentation::kPolygon);
+    EXPECT_EQ(contact_surface->representation(),
+              HydroelasticContactRepresentation::kPolygon);
+  }
 }
 
 /* This test fixture enables some limited testing of the autodiff-valued contact
@@ -1350,7 +1251,11 @@ GTEST_TEST(MeshPlaneIntersectionTest, SoftVolumeRigidHalfSpace) {
  The function TestPositionDerivative() will pose the tetrahedral mesh and
  compute a contact surface. It invokes a provided functor to assess the reported
  derivatives of some arbitrary quantity of the contact surface with respect to
- the position of the origin of frame S. */
+ the position of the origin of frame S.
+
+ These tests actively use the triangle mesh because the position and value of
+ the polygon centroid provides a further basis for reasoning about derivatives.
+ */
 class MeshPlaneDerivativesTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -1497,11 +1402,12 @@ class MeshPlaneDerivativesTest : public ::testing::Test {
       const RigidTransform<AutoDiffXd> X_WS(R_WS_d.cast<AutoDiffXd>(), p_WS);
 
       auto surface = ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
-          id_S_, *field_S_, *bvh_S_, X_WS, id_R_, X_WR_);
+          id_S_, *field_S_, *bvh_S_, X_WS, id_R_, X_WR_,
+          HydroelasticContactRepresentation::kTriangle);
 
       SCOPED_TRACE(config.name);
       ASSERT_NE(surface, nullptr);
-      ASSERT_EQ(surface->mesh_W().num_triangles(), config.num_triangles);
+      ASSERT_EQ(surface->tri_mesh_W().num_triangles(), config.num_triangles);
 
       evaluate_quantity(*surface, X_WS, config.pose);
     }
@@ -1577,7 +1483,7 @@ TEST_F(MeshPlaneDerivativesTest, Area) {
                            const ContactSurface<AutoDiffXd>& surface,
                            const RigidTransform<AutoDiffXd>& X_WS_ad,
                            TetPose pose) {
-    const auto& mesh_W = surface.mesh_W();
+    const auto& mesh_W = surface.tri_mesh_W();
 
     // For v × A, this makes a matrix V such that VA = v × A.
     auto skew_matrix = [](const Vector3d& v) {
@@ -1733,7 +1639,7 @@ TEST_F(MeshPlaneDerivativesTest, VertexPosition) {
      from intersecting a tet edge with the plane. We'll evaluate all of those
      and then handle the centroid specially. */
     const Vector3d n_R{0, 0, 1};
-    const TriangleSurfaceMesh<AutoDiffXd>& mesh_W = surface.mesh_W();
+    const TriangleSurfaceMesh<AutoDiffXd>& mesh_W = surface.tri_mesh_W();
     const RotationMatrixd R_WR = convert_to_double(this->X_WR_).rotation();
     const RotationMatrixd R_RW = R_WR.inverse();
     const RigidTransformd X_WS = convert_to_double(X_WS_ad);
@@ -1788,7 +1694,7 @@ TEST_F(MeshPlaneDerivativesTest, FaceNormalsWrtPosition) {
                               const ContactSurface<AutoDiffXd>& surface,
                               const RigidTransform<AutoDiffXd>& X_WS, TetPose) {
     constexpr double kEps = std::numeric_limits<double>::epsilon();
-    const auto& mesh_W = surface.mesh_W();
+    const auto& mesh_W = surface.tri_mesh_W();
     const Vector3d plane_n_W = X_WR.rotation().col(2);
     const Matrix3<double> zeros = Matrix3<double>::Zero();
     for (int f = 0; f < mesh_W.num_elements(); ++f) {
@@ -1835,12 +1741,12 @@ TEST_F(MeshPlaneDerivativesTest, FaceNormalsWrtOrientation) {
 
     auto surface = ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
         this->id_S_, *this->field_S_, *this->bvh_S_, X_WS, this->id_R_,
-        this->X_WR_);
+        this->X_WR_, HydroelasticContactRepresentation::kTriangle);
 
     SCOPED_TRACE(fmt::format("theta = {:.5f} radians", theta));
     ASSERT_NE(surface, nullptr);
     /* Make sure the test doesn't pass simply because we have no triangles. */
-    const auto& mesh_W = surface->mesh_W();
+    const auto& mesh_W = surface->tri_mesh_W();
     ASSERT_GT(mesh_W.num_elements(), 0);
 
     constexpr double kEps = std::numeric_limits<double>::epsilon();
@@ -1873,8 +1779,8 @@ TEST_F(MeshPlaneDerivativesTest, Pressure) {
 
                            ┌                   ┐
                            │ ∂p_WQ      ∂p_WE  │
-                   = ∇p_Wᵀ │──────── - ────────│   // Transpose and subtraction
-                           │ ∂p_WSo     ∂p_WSo │   // are is linear operators.
+                   = ∇p_Wᵀ │──────── - ────────│   // Subtraction is a linear
+                           │ ∂p_WSo     ∂p_WSo │   // operator.
                            └                   ┘
 
                            ┌                  ┐
@@ -1893,13 +1799,14 @@ TEST_F(MeshPlaneDerivativesTest, Pressure) {
     constexpr double kEps = 8 * std::numeric_limits<double>::epsilon();
     const RigidTransform<double> X_WS_d = convert_to_double(X_WS);
     const Vector3d grad_p_W = X_WS_d.rotation() * grad_p_S;
-    for (int v = 0; v < surface.mesh_W().num_vertices(); ++v) {
+    for (int v = 0; v < surface.tri_mesh_W().num_vertices(); ++v) {
       const Matrix3<double> dp_WQ_dp_WSo_W =
-          math::ExtractGradient(surface.mesh_W().vertex(v));
+          math::ExtractGradient(surface.tri_mesh_W().vertex(v));
       const Vector3d dp_dp_WSo_W_expected =
           grad_p_W.transpose() * (dp_WQ_dp_WSo_W - Matrix3<double>::Identity());
-      const AutoDiffXd& p = surface.e_MN().EvaluateAtVertex(v);
-      EXPECT_TRUE(CompareMatrices(p.derivatives(), dp_dp_WSo_W_expected, kEps));
+      const AutoDiffXd& p = surface.tri_e_MN().EvaluateAtVertex(v);
+      EXPECT_TRUE(CompareMatrices(p.derivatives(), dp_dp_WSo_W_expected, kEps))
+          << v << " out of " << surface.tri_mesh_W().num_vertices();
     }
   };
 


### PR DESCRIPTION
This reframes mesh-plane intersection to use the new `MeshBuilder` so it can create either polygon or triangle mesh representations. The APIs have been modified to communicate the desired representation and the tests have
been updated accordingly.

Call sites have been updated to *explicitly* request triangle meshes (this was implicit before).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16162)
<!-- Reviewable:end -->
