### PR TITLE
[hydro] Enable polygon contact surface from mesh-mesh intersection

### DIFF
--- a/geometry/benchmarking/mesh_intersection_benchmark.cc
+++ b/geometry/benchmarking/mesh_intersection_benchmark.cc
@@ -235,11 +235,12 @@ BENCHMARK_DEFINE_F(MeshIntersectionBenchmark, RigidSoftMesh)
   const auto bvh_R = Bvh<Obb, TriangleSurfaceMesh<double>>(mesh_R_);
   std::unique_ptr<TriangleSurfaceMesh<double>> surface_SR;
   std::unique_ptr<TriangleSurfaceMeshFieldLinear<double, double>> e_SR;
-  std::vector<Vector3<double>> grad_eM_Ms;
   for (auto _ : state) {
-    SurfaceVolumeIntersector<double>().SampleVolumeFieldOnSurface(
-        field_S_, bvh_S, mesh_R_, bvh_R, X_SR_, &surface_SR, &e_SR,
-        &grad_eM_Ms);
+    SurfaceVolumeIntersector<TriangleSurfaceMesh<double>> intersector;
+    intersector.SampleVolumeFieldOnSurface(field_S_, bvh_S, mesh_R_, bvh_R,
+                                           X_SR_, TriMeshBuilder<double>());
+    surface_SR = intersector.release_mesh();
+    e_SR = intersector.release_field();
   }
   RecordContactSurfaceResult(surface_SR.get(), "RigidSoftMesh", state);
 }

--- a/geometry/proximity/hydroelastic_callback.h
+++ b/geometry/proximity/hydroelastic_callback.h
@@ -121,7 +121,8 @@ std::unique_ptr<ContactSurface<T>> DispatchRigidSoftCalculation(
     const Bvh<Obb, TriangleSurfaceMesh<double>>& bvh_R = rigid.bvh();
 
     return ComputeContactSurfaceFromSoftVolumeRigidSurface(
-        id_S, field_S, bvh_S, X_WS, id_R, mesh_R, bvh_R, X_WR);
+        id_S, field_S, bvh_S, X_WS, id_R, mesh_R, bvh_R, X_WR,
+        HydroelasticContactRepresentation::kTriangle);
   }
 }
 

--- a/geometry/proximity/mesh_intersection.cc
+++ b/geometry/proximity/mesh_intersection.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <utility>
@@ -44,8 +45,9 @@ namespace internal {
 //  tetrahedrons.
 
 // TODO(DamrongGuoy): Handle the case that the line is parallel to the plane.
-template <typename T>
-Vector3<T> SurfaceVolumeIntersector<T>::CalcIntersection(
+template <typename MeshType>
+Vector3<typename MeshType::ScalarType>
+SurfaceVolumeIntersector<MeshType>::CalcIntersection(
     const Vector3<T>& p_FA, const Vector3<T>& p_FB,
     const PosedHalfSpace<double>& H_F) {
   const T a = H_F.CalcSignedDistance(p_FA);
@@ -93,8 +95,8 @@ Vector3<T> SurfaceVolumeIntersector<T>::CalcIntersection(
   //      = 0 when a != b.
 }
 
-template <typename T>
-void SurfaceVolumeIntersector<T>::ClipPolygonByHalfSpace(
+template <typename MeshType>
+void SurfaceVolumeIntersector<MeshType>::ClipPolygonByHalfSpace(
     const std::vector<Vector3<T>>& input_vertices_F,
     const PosedHalfSpace<double>& H_F,
     std::vector<Vector3<T>>* output_vertices_F) {
@@ -137,8 +139,8 @@ void SurfaceVolumeIntersector<T>::ClipPolygonByHalfSpace(
   }
 }
 
-template <typename T>
-void SurfaceVolumeIntersector<T>::RemoveDuplicateVertices(
+template <typename MeshType>
+void SurfaceVolumeIntersector<MeshType>::RemoveDuplicateVertices(
     std::vector<Vector3<T>>* polygon) {
   DRAKE_ASSERT(polygon != nullptr);
 
@@ -190,9 +192,9 @@ void SurfaceVolumeIntersector<T>::RemoveDuplicateVertices(
   DRAKE_ASSERT(polygon->size() != 2 || !near((*polygon)[0], (*polygon)[1]));
 }
 
-template <typename T>
-const std::vector<Vector3<T>>&
-SurfaceVolumeIntersector<T>::ClipTriangleByTetrahedron(
+template <typename MeshType>
+const std::vector<Vector3<typename MeshType::ScalarType>>&
+SurfaceVolumeIntersector<MeshType>::ClipTriangleByTetrahedron(
     int element, const VolumeMesh<double>& volume_M, int face,
     const TriangleSurfaceMesh<double>& surface_N,
     const math::RigidTransform<T>& X_MN) {
@@ -278,46 +280,43 @@ SurfaceVolumeIntersector<T>::ClipTriangleByTetrahedron(
   return *polygon_M;
 }
 
-template <typename T>
-bool SurfaceVolumeIntersector<T>::IsFaceNormalAlongPressureGradient(
+template <typename MeshType>
+bool SurfaceVolumeIntersector<MeshType>::IsFaceNormalAlongPressureGradient(
     const VolumeMeshFieldLinear<double, double>& volume_field_M,
     const TriangleSurfaceMesh<double>& surface_N,
     const math::RigidTransform<double>& X_MN,
     int tet_index, int tri_index) {
   const Vector3<double> grad_p_M = volume_field_M.EvaluateGradient(tet_index);
+  // TODO(SeanCurtis-TRI) If we pass in an *unnormalized* vector, we can
+  //  reduce the number of square roots. Currently, we produce the *unit*
+  //  gradient normal n̂ and the triangle face normal f̂ (we normalize this vector
+  //  to correct for rounding error that creeps in from rotations). We use the
+  //  unit vectors so that we can compute cos(θ) = f̂⋅n̂. However, we could
+  //  compute the following instead:
+  //
+  //      cos(θ) = f⃗/|f⃗|⋅n⃗/|n⃗|
+  //      cos(θ) = f⃗⋅n⃗/(|f⃗||n⃗|)
+  //      cos(θ) = f⃗⋅n⃗/√(|f⃗|²|n⃗|²)
+  //
+  //  Two square roots become one square root.
   return IsFaceNormalInNormalDirection(grad_p_M.normalized(), surface_N,
                                        tri_index, X_MN.rotation());
 }
 
-template <typename T>
-void SurfaceVolumeIntersector<T>::SampleVolumeFieldOnSurface(
+template <typename MeshType>
+template <typename MeshBuilder>
+void SurfaceVolumeIntersector<MeshType>::SampleVolumeFieldOnSurface(
     const VolumeMeshFieldLinear<double, double>& volume_field_M,
     const Bvh<Obb, VolumeMesh<double>>& bvh_M,
     const TriangleSurfaceMesh<double>& surface_N,
     const Bvh<Obb, TriangleSurfaceMesh<double>>& bvh_N,
-    const math::RigidTransform<T>& X_MN,
-    std::unique_ptr<TriangleSurfaceMesh<T>>* surface_MN_M,
-    std::unique_ptr<TriangleSurfaceMeshFieldLinear<T, T>>* e_MN,
-    std::vector<Vector3<T>>* grad_eM_Ms) {
-  DRAKE_DEMAND(surface_MN_M != nullptr);
-  DRAKE_DEMAND(e_MN != nullptr);
-  DRAKE_DEMAND(grad_eM_Ms != nullptr);
-  grad_eM_Ms->clear();
+    const math::RigidTransform<T>& X_MN, MeshBuilder builder_M) {
+  const VolumeMesh<double>& vol_mesh_M = volume_field_M.mesh();
 
-  std::vector<SurfaceTriangle> surface_faces;
-  std::vector<Vector3<T>> surface_vertices_M;
-  std::vector<T> surface_e;
-  const VolumeMesh<double>& mesh_M = volume_field_M.mesh();
-  // We know that each contact polygon has at most 7 vertices because
-  // each surface triangle is clipped by four half-spaces of the four
-  // triangular faces of a tetrahedron.
-  std::vector<int> contact_polygon;
-  contact_polygon.reserve(7);
-
-  const math::RigidTransform<double> X_MN_d = convert_to_double(X_MN);
-  auto callback = [&volume_field_M, &surface_N, &surface_faces,
-                   &surface_vertices_M, &surface_e, &mesh_M, &X_MN_d, &X_MN,
-                   &contact_polygon, grad_eM_Ms,
+  const math::RigidTransform<double>& X_MN_d = convert_to_double(X_MN);
+  auto callback = [&volume_field_M, &surface_N,
+                   &vol_mesh_M, &X_MN_d, &X_MN,
+                   &builder_M,
                    this](int tet_index, int tri_index) -> BvttCallbackResult {
     if (!this->IsFaceNormalAlongPressureGradient(
             volume_field_M, surface_N, X_MN_d, tet_index, tri_index)) {
@@ -335,56 +334,46 @@ void SurfaceVolumeIntersector<T>::SampleVolumeFieldOnSurface(
     //  disjoint regions, *no* vertices will be transformed. Unclear what the
     //  best balance for best average performance.
     const std::vector<Vector3<T>>& polygon_vertices_M =
-        this->ClipTriangleByTetrahedron(tet_index, mesh_M, tri_index, surface_N,
-                                        X_MN);
+        this->ClipTriangleByTetrahedron(tet_index, vol_mesh_M, tri_index,
+                                        surface_N, X_MN);
 
-    const int poly_vertex_count = static_cast<int>(polygon_vertices_M.size());
-    if (poly_vertex_count < 3) return BvttCallbackResult::Continue;
+    if (polygon_vertices_M.size() < 3) return BvttCallbackResult::Continue;
 
-    const int num_previous_vertices = surface_vertices_M.size();
-
-    // Add the new polygon vertices to the mesh vertices and construct a
-    // polygon from the vertex indices.
-    contact_polygon.clear();
-    for (int i = 0; i < poly_vertex_count; ++i) {
-      contact_polygon.emplace_back(surface_vertices_M.size());
-      surface_vertices_M.emplace_back(polygon_vertices_M[i]);
+    // Add the vertices to the builder (with corresponding pressure values) and
+    // construct index-based polygon representation.
+    polygon_vertex_indices_.clear();
+    for (const auto& p_MV : polygon_vertices_M) {
+      polygon_vertex_indices_.push_back(builder_M.AddVertex(
+          p_MV, volume_field_M.EvaluateCartesian(tet_index, p_MV)));
     }
 
     const Vector3<T> nhat_M =
-        X_MN.rotation() * surface_N.face_normal(tri_index).cast<T>();
+        X_MN.rotation() * surface_N.face_normal(tri_index).template cast<T>();
+    // The gradient of the pressure field in the volume mesh is *also* the
+    // gradient of the pressure field on the contact surface. That's not
+    // generally true, but is for the special case of compliant-rigid case.
+    // So, we use it both for AddPolygon() as grad_e_MN_M and as grad_e_M when
+    // we store it per-face below.
+    const Vector3<T> grad_e_MN_M = volume_field_M.EvaluateGradient(tet_index);
+    const int num_new_faces =
+        builder_M.AddPolygon(polygon_vertex_indices_, nhat_M, grad_e_MN_M);
 
-    size_t old_count = surface_faces.size();
-    AddPolygonToTriangleMeshData(contact_polygon, nhat_M, &surface_faces,
-                                 &surface_vertices_M);
-    // TODO(SeanCurtis-TRI) Consider rolling this operation into
-    //  AddPolygonToTriangleMeshData to eliminate the extra pass through
-    //  triangles.
-    const Vector3<double>& grad_eMi_M =
-        volume_field_M.EvaluateGradient(tet_index);
-    for (size_t i = old_count; i < surface_faces.size(); ++i) {
-      grad_eM_Ms->push_back(grad_eMi_M.cast<T>());
+    // TODO(SeanCurtis-TRI) This represents a *second* iteration on the vertices
+    //  of the polygon. Rolling this into the builder would allow us to reduce
+    //  the loops.
+    // Store the constituent pressure gradient values from the soft mesh for
+    // each face in the contact surface.
+    for (int i = 0; i < num_new_faces; ++i) {
+      this->grad_eM_Ms_.push_back(grad_e_MN_M);
     }
 
-    const int num_current_vertices = surface_vertices_M.size();
-    // Calculate values of the pressure field at the new vertices.
-    for (int v = num_previous_vertices; v < num_current_vertices; ++v) {
-      const Vector3<T>& r_MV = surface_vertices_M[v];
-      const T pressure = volume_field_M.EvaluateCartesian(tet_index, r_MV);
-      surface_e.push_back(pressure);
-    }
     return BvttCallbackResult::Continue;
   };
   bvh_M.Collide(bvh_N, X_MN_d, callback);
 
-  DRAKE_DEMAND(surface_vertices_M.size() == surface_e.size());
-  if (surface_faces.empty()) return;
+  if (builder_M.num_faces() == 0) return;
 
-  *surface_MN_M = std::make_unique<TriangleSurfaceMesh<T>>(
-      std::move(surface_faces), std::move(surface_vertices_M));
-  const bool calculate_gradient = false;
-  *e_MN = std::make_unique<TriangleSurfaceMeshFieldLinear<T, T>>(
-      std::move(surface_e), surface_MN_M->get(), calculate_gradient);
+  std::tie(mesh_M_, field_M_) = builder_M.MakeMeshAndField();
 }
 
 template <typename T>
@@ -395,63 +384,62 @@ ComputeContactSurfaceFromSoftVolumeRigidSurface(
     const math::RigidTransform<T>& X_WS, const GeometryId id_R,
     const TriangleSurfaceMesh<double>& mesh_R,
     const Bvh<Obb, TriangleSurfaceMesh<double>>& bvh_R,
-    const math::RigidTransform<T>& X_WR) {
-  // TODO(SeanCurtis-TRI): This function is insufficiently templated. Generally,
-  //  there are three types of scalars: the pose scalar, the mesh field *value*
-  //  scalar, and the mesh vertex-position scalar. However, short term, it is
-  //  probably unnecessary to distinguish all three here. If we assume that this
-  //  function is *only* called to find the contact surface between two declared
-  //  geometries, then the volume mesh values and vertex positions will always
-  //  be in double. However, even dividing between pose and mesh scalars has
-  //  *huge* downstream implications on how the meshes and mesh fields are
-  //  defined. We're deferring this work by simply disallowing invocation of
-  //  this method on AutoDiffXd (see below). It compiles, but throws.
-  //  See issue #14136.
+    const math::RigidTransform<T>& X_WR,
+    HydroelasticContactRepresentation representation) {
+  auto process_intersection =
+      [&X_WS, id_S,
+       id_R](auto&& intersector_in) -> std::unique_ptr<ContactSurface<T>> {
+    if (intersector_in.has_intersection()) {
+      // TODO(DamrongGuoy): Compute the mesh and field with the quantities
+      //  expressed in World frame by construction so that we can delete these
+      //  two transforming methods.
+
+      // Transform the mesh from the S frame to the world frame. This entails:
+      //  1. Transforming the surface's vertices.
+      //  2. Allowing the LinearField e_SR a chance to re-express its cached
+      //     gradient values.
+      //  3. Re-expressing the gradients of the soft-mesh's pressure field
+      //    (grad_eS_S) in the world frame (grad_eS_W).
+      intersector_in.mutable_mesh().TransformVertices(X_WS);
+      intersector_in.mutable_field().Transform(X_WS);
+      std::vector<Vector3<T>>& grad_eS_S = intersector_in.mutable_grad_eM_M();
+      for (auto& grad_eSi_S : grad_eS_S) {
+        grad_eSi_S = X_WS.rotation() * grad_eSi_S;
+      }
+      // The contact surface is documented as having the normals pointing *out*
+      // of the second surface and into the first. This mesh intersection
+      // creates a surface mesh with normals pointing out of the rigid surface,
+      // so we make sure the ids are ordered so that the rigid is the second id.
+      return std::make_unique<ContactSurface<T>>(
+          id_S, id_R, intersector_in.release_mesh(),
+          intersector_in.release_field(),
+          std::make_unique<std::vector<Vector3<T>>>(std::move(grad_eS_S)),
+          nullptr);
+    }
+    return nullptr;
+  };
 
   // Compute the transformation from the rigid frame to the soft frame.
   const math::RigidTransform<T> X_SR = X_WS.InvertAndCompose(X_WR);
 
-  // The mesh will be computed in Frame S and then transformed to the world
-  // frame.
-  std::unique_ptr<TriangleSurfaceMesh<T>> surface_SR;
-  std::unique_ptr<TriangleSurfaceMeshFieldLinear<T, T>> e_SR;
-  std::vector<Vector3<T>> grad_eS_S;
-
-  SurfaceVolumeIntersector<T>().SampleVolumeFieldOnSurface(
-      field_S, bvh_S, mesh_R, bvh_R, X_SR, &surface_SR, &e_SR, &grad_eS_S);
-
-  if (surface_SR == nullptr) return nullptr;
-
-  // TODO(DamrongGuoy): Compute the mesh and field with the quantities
-  //  expressed in World frame by construction so that we can delete these two
-  //  transforming methods.
-
-  // Transform the mesh from the S frame to the world frame. This entails:
-  //  1. Transforming the surface's vertices.
-  //  2. Allowing the LinearField e_SR a chance to re-express its cached
-  //     gradient values.
-  //  3. Re-expressing the gradients of the soft-mesh's pressure field
-  //    (grad_eS_S) in the world frame (grad_eS_W).
-  surface_SR->TransformVertices(X_WS);
-  e_SR->Transform(X_WS);
-  std::unique_ptr<std::vector<Vector3<T>>> grad_eS_W;
-  grad_eS_W = std::make_unique<std::vector<Vector3<T>>>();
-  grad_eS_W->reserve(grad_eS_S.size());
-  for (const auto& grad_eSi_S : grad_eS_S) {
-    grad_eS_W->emplace_back(X_WS.rotation() * grad_eSi_S);
+  if (representation == HydroelasticContactRepresentation::kTriangle) {
+    SurfaceVolumeIntersector<TriangleSurfaceMesh<T>> intersector;
+    intersector.SampleVolumeFieldOnSurface(field_S, bvh_S, mesh_R, bvh_R, X_SR,
+                                           TriMeshBuilder<T>());
+    return process_intersection(intersector);
+  } else {
+    // Polygon.
+    SurfaceVolumeIntersector<PolygonSurfaceMesh<T>> intersector;
+    intersector.SampleVolumeFieldOnSurface(field_S, bvh_S, mesh_R, bvh_R, X_SR,
+                                           PolyMeshBuilder<T>());
+    return process_intersection(intersector);
   }
-
-  // The contact surface is documented as having the normals pointing *out* of
-  // the second surface and into the first. This mesh intersection creates a
-  // surface mesh with normals pointing out of the rigid surface, so we make
-  // sure the ids are ordered so that the rigid is the second id.
-  return std::make_unique<ContactSurface<T>>(id_S, id_R, std::move(surface_SR),
-                                             std::move(e_SR),
-                                             std::move(grad_eS_W), nullptr);
 }
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
-    class SurfaceVolumeIntersector)
+template class SurfaceVolumeIntersector<TriangleSurfaceMesh<double>>;
+template class SurfaceVolumeIntersector<TriangleSurfaceMesh<AutoDiffXd>>;
+template class SurfaceVolumeIntersector<PolygonSurfaceMesh<double>>;
+template class SurfaceVolumeIntersector<PolygonSurfaceMesh<AutoDiffXd>>;
 
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
     &ComputeContactSurfaceFromSoftVolumeRigidSurface<T>
@@ -460,4 +448,3 @@ DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake
-

--- a/geometry/proximity/mesh_intersection.h
+++ b/geometry/proximity/mesh_intersection.h
@@ -1,12 +1,16 @@
 #pragma once
 
 #include <memory>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/proximity/bvh.h"
 #include "drake/geometry/proximity/contact_surface_utility.h"
+#include "drake/geometry/proximity/polygon_surface_mesh.h"
+#include "drake/geometry/proximity/polygon_surface_mesh_field.h"
 #include "drake/geometry/proximity/posed_half_space.h"
 #include "drake/geometry/proximity/triangle_surface_mesh.h"
 #include "drake/geometry/proximity/triangle_surface_mesh_field.h"
@@ -20,18 +24,22 @@ namespace geometry {
 namespace internal {
 
 // Forward declaration of Tester class, so we can grant friend access.
-template <typename T> class SurfaceVolumeIntersectorTester;
+template <typename MeshType> class SurfaceVolumeIntersectorTester;
 
 /* %SurfaceVolumeIntersector performs a mesh-intersection algorithm between a
  triangulated surface mesh and a tetrahedral volume mesh with a field
  variable. It also interpolates the field variable onto the resulted
  surface.
 
- @tparam_nonsymbolic_scalar
- */
-template <typename T>
+ @tparam MeshType The type of surface mesh to represent the contact surface.
+   It can be either TriangleSurfaceMesh<T> or PolygonSurfaceMesh<T> for
+   T = double or AutoDiffXd. */
+template <typename MeshType>
 class SurfaceVolumeIntersector {
  public:
+  using T = typename MeshType::ScalarType;
+  using FieldType = MeshFieldLinear<T, MeshType>;
+
   SurfaceVolumeIntersector() {
     // We know that each contact polygon has at most 7 vertices.
     // Each surface triangle is clipped by four half-spaces of the four
@@ -77,16 +85,25 @@ class SurfaceVolumeIntersector {
        triangle in `surface_MN_M`).
    @note
        The output surface mesh may have duplicate vertices.
+   @tparam MeshBuilder An instance of either TriMeshBuilder<T> or
+    PolyMeshBuilder<T> (for T = double or AutoDiffXd).
+    (See the documentation in contact_surface_utility.h for details.)
    */
+  template <typename MeshBuilder>
   void SampleVolumeFieldOnSurface(
       const VolumeMeshFieldLinear<double, double>& volume_field_M,
       const Bvh<Obb, VolumeMesh<double>>& bvh_M,
       const TriangleSurfaceMesh<double>& surface_N,
       const Bvh<Obb, TriangleSurfaceMesh<double>>& bvh_N,
       const math::RigidTransform<T>& X_MN,
-      std::unique_ptr<TriangleSurfaceMesh<T>>* surface_MN_M,
-      std::unique_ptr<TriangleSurfaceMeshFieldLinear<T, T>>* e_MN,
-      std::vector<Vector3<T>>* grad_eM_Ms);
+      MeshBuilder builder);
+
+  bool has_intersection() const { return mesh_M_ != nullptr; }
+  MeshType& mutable_mesh() { return *mesh_M_; }
+  std::unique_ptr<MeshType>&& release_mesh() { return std::move(mesh_M_); }
+  FieldType& mutable_field() { return *field_M_; }
+  std::unique_ptr<FieldType>&& release_field() { return std::move(field_M_); }
+  std::vector<Vector3<T>>& mutable_grad_eM_M() { return grad_eM_Ms_; }
 
  private:
   /* Calculates the intersection point between an infinite straight line
@@ -305,7 +322,22 @@ class SurfaceVolumeIntersector {
   // not introduced.
   std::vector<Vector3<T>> polygon_[2];
 
-  friend class SurfaceVolumeIntersectorTester<T>;
+  // A container for the vertex indices that define an intersection polygon.
+  // By making it a member, we only allocate on the heap *once* for a pair
+  // of meshes (instead of once per intersecting polygon). This exists purely
+  // for performance optimization.
+  std::vector<int> polygon_vertex_indices_;
+
+  // The mesh produced from intersecting the volume mesh with the surface mesh,
+  // measured and expressed in the volume mesh's frame M.
+  std::unique_ptr<MeshType> mesh_M_;
+  // The field defined on mesh_M_ (in the same frame M).
+  std::unique_ptr<FieldType> field_M_;
+  // The spatial gradient of the volume mesh field, sampled once for each face
+  // in mesh_M_.
+  std::vector<Vector3<T>> grad_eM_Ms_;
+
+  friend class SurfaceVolumeIntersectorTester<MeshType>;
 };
 
 /* Computes the contact surface between a soft geometry S and a rigid
@@ -332,6 +364,8 @@ class SurfaceVolumeIntersector {
      A bounding volume hierarchy built on the geometry contained in `mesh_R`.
  @param[in] X_WR
      The pose of the rigid frame R in the world frame W.
+ @param[in] representation
+     The preferred representation of each contact polygon.
  @return
      The contact surface between M and N. Geometries S and R map to M and N
      with a consistent mapping (as documented in ContactSurface) but without any
@@ -364,7 +398,8 @@ ComputeContactSurfaceFromSoftVolumeRigidSurface(
     const math::RigidTransform<T>& X_WS,
     const GeometryId id_R, const TriangleSurfaceMesh<double>& mesh_R,
     const Bvh<Obb, TriangleSurfaceMesh<double>>& bvh_R,
-    const math::RigidTransform<T>& X_WR);
+    const math::RigidTransform<T>& X_WR,
+    HydroelasticContactRepresentation representation);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/test/mesh_intersection_test.cc
+++ b/geometry/proximity/test/mesh_intersection_test.cc
@@ -19,13 +19,23 @@
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/math/rotation_matrix.h"
 
+/* @file Tests the the main function
+ ComputeContactSurfaceFromSoftVolumeRigidSurface and it's supporting code. The
+ main function can produce ContactSurfaces with either triangle or polygon
+ representations. However, not all tests need to be exercised against both
+ possible representations. Each test is documented as to whether it needs to
+ consider the two possible representations or if the code under test is
+ orthogonal to that choice. */
+
 namespace drake {
 namespace geometry {
 namespace internal {
 
-template<typename T>
+template<typename MeshType>
 class SurfaceVolumeIntersectorTester {
  public:
+  using T = typename MeshType::ScalarType;
+
   Vector3<T> CalcIntersection(const Vector3<T>& p_FA, const Vector3<T>& p_FB,
                               const PosedHalfSpace<double>& H_F) {
     return intersect_.CalcIntersection(p_FA, p_FB, H_F);
@@ -55,7 +65,7 @@ class SurfaceVolumeIntersectorTester {
   }
 
  private:
-  SurfaceVolumeIntersector<T> intersect_;
+  SurfaceVolumeIntersector<MeshType> intersect_;
 };
 
 namespace {
@@ -77,7 +87,11 @@ using std::vector;
 //  depend on the magnitude of the values in play.
 
 // TODO(DamrongGuoy): More comprehensive tests.
+/* This test is independent of ContactSurface mesh representation; so we'll
+ simply use TriangleSurfaceMesh. */
 GTEST_TEST(MeshIntersectionTest, CalcIntersection) {
+  using MeshType = TriangleSurfaceMesh<double>;
+
   const double kEps = std::numeric_limits<double>::epsilon();
   // TODO(SeanCurtis-TRI): This test has too many zeros in it (the normal is
   //  [1, 0, 0] -- that is not a robust test. Pick a more arbitrary normal.
@@ -92,7 +106,7 @@ GTEST_TEST(MeshIntersectionTest, CalcIntersection) {
     const Vector3d p_HA = Vector3d::Zero();
     const Vector3d p_HB(4, 6, 10);
     const Vector3d intersection =
-        SurfaceVolumeIntersectorTester<double>().CalcIntersection(
+        SurfaceVolumeIntersectorTester<MeshType>().CalcIntersection(
             p_HA, p_HB, half_space_H);
     const Vector3d expect_intersection(2, 3, 5);
     EXPECT_LE((expect_intersection - intersection).norm(), kEps);
@@ -103,7 +117,7 @@ GTEST_TEST(MeshIntersectionTest, CalcIntersection) {
     const Vector3d p_HA(plane_offset + 2.0 * kEps, 0., 0.);
     const Vector3d p_HB(plane_offset - 2.0 * kEps, 1., 1.);
     const Vector3d intersection =
-        SurfaceVolumeIntersectorTester<double>().CalcIntersection(
+        SurfaceVolumeIntersectorTester<MeshType>().CalcIntersection(
             p_HA, p_HB, half_space_H);
     const Vector3d expect_intersection(2., 0.5, 0.5);
     EXPECT_LE((expect_intersection - intersection).norm(), kEps);
@@ -112,7 +126,7 @@ GTEST_TEST(MeshIntersectionTest, CalcIntersection) {
   // TODO(SeanCurtis-TRI): Confirm death test in debug mode for if the points
   //  don't properly "straddle" the boundary plane.
   //  - Both on negative, both on positive, both *on* the plane.
-  //  - parallel negative, parallel positive, parallel on the plane.
+  //  - parallel negative, parallel positive.
 }
 
 // TODO(DamrongGuoy): Move the definition of this function here after 11612
@@ -123,8 +137,11 @@ bool CompareConvexPolygon(const std::vector<Vector3<T>>& polygon0,
 
 // Although polygons with zero, one, or two vertices are valid input and are
 // treated correctly by this function, they are not tested as being a
-// meaningless operation.
+// meaningless operation. This test is independent of ContactSurface mesh
+// representation; so we'll simply use TriangleSurfaceMesh.
 GTEST_TEST(MeshIntersectionTest, ClipPolygonByHalfSpace) {
+  using MeshType = TriangleSurfaceMesh<double>;
+
   // All quantities are (measured and) expressed in the half space frame H.
 
   // TODO(SeanCurtis-TRI): This half space does *not* tax the numerics at all.
@@ -159,7 +176,7 @@ GTEST_TEST(MeshIntersectionTest, ClipPolygonByHalfSpace) {
     // Also, by construction, the winding matches, so we will also not be
     // explicitly testing that.
     std::vector<Vector3d> output_polygon;
-    SurfaceVolumeIntersectorTester<double>().ClipPolygonByHalfSpace(
+    SurfaceVolumeIntersectorTester<MeshType>().ClipPolygonByHalfSpace(
         input_polygon, half_space_H, &output_polygon);
     EXPECT_TRUE(CompareConvexPolygon(expect_output_polygon, output_polygon));
   }
@@ -178,7 +195,7 @@ GTEST_TEST(MeshIntersectionTest, ClipPolygonByHalfSpace) {
     // Because we expect the output polygon to *be* the input polygon, we don't
     // need to explicitly test planarity or winding.
     std::vector<Vector3d> output_polygon;
-    SurfaceVolumeIntersectorTester<double>().ClipPolygonByHalfSpace(
+    SurfaceVolumeIntersectorTester<MeshType>().ClipPolygonByHalfSpace(
         input_polygon, half_space_H, &output_polygon);
     EXPECT_TRUE(CompareConvexPolygon(input_polygon, output_polygon));
   }
@@ -196,7 +213,7 @@ GTEST_TEST(MeshIntersectionTest, ClipPolygonByHalfSpace) {
     // clang-format on
     // Empty polygons have no winding and no planarity.
     std::vector<Vector3d> output_polygon;
-    SurfaceVolumeIntersectorTester<double>().ClipPolygonByHalfSpace(
+    SurfaceVolumeIntersectorTester<MeshType>().ClipPolygonByHalfSpace(
         input_polygon, half_space_H, &output_polygon);
     const std::vector<Vector3d> empty_polygon;
     EXPECT_TRUE(CompareConvexPolygon(empty_polygon, output_polygon));
@@ -215,7 +232,7 @@ GTEST_TEST(MeshIntersectionTest, ClipPolygonByHalfSpace) {
     // Because we expect the output polygon to *be* the input polygon, we don't
     // need to explicitly test planarity or winding.
     std::vector<Vector3d> output_polygon;
-    SurfaceVolumeIntersectorTester<double>().ClipPolygonByHalfSpace(
+    SurfaceVolumeIntersectorTester<MeshType>().ClipPolygonByHalfSpace(
         input_polygon, half_space_H, &output_polygon);
     EXPECT_TRUE(CompareConvexPolygon(input_polygon, output_polygon));
   }
@@ -240,7 +257,7 @@ GTEST_TEST(MeshIntersectionTest, ClipPolygonByHalfSpace) {
     // By construction, expected output is planar (z = 0 for all vertices). It
     // has no area, so winding is immaterial.
     std::vector<Vector3d> output_polygon;
-    SurfaceVolumeIntersectorTester<double>().ClipPolygonByHalfSpace(
+    SurfaceVolumeIntersectorTester<MeshType>().ClipPolygonByHalfSpace(
         input_polygon, half_space_H, &output_polygon);
     EXPECT_TRUE(CompareConvexPolygon(expect_output_polygon, output_polygon));
   }
@@ -263,7 +280,7 @@ GTEST_TEST(MeshIntersectionTest, ClipPolygonByHalfSpace) {
     // By construction, expected output is planar (z = 0 for all vertices). It
     // has no area, so winding is immaterial.
     std::vector<Vector3d> output_polygon;
-    SurfaceVolumeIntersectorTester<double>().ClipPolygonByHalfSpace(
+    SurfaceVolumeIntersectorTester<MeshType>().ClipPolygonByHalfSpace(
         input_polygon, half_space_H, &output_polygon);
     EXPECT_TRUE(CompareConvexPolygon(expect_output_polygon, output_polygon));
   }
@@ -271,7 +288,11 @@ GTEST_TEST(MeshIntersectionTest, ClipPolygonByHalfSpace) {
   // triangle.
 }
 
+/* This test is independent of ContactSurface mesh representation; so we'll
+ simply use TriangleSurfaceMesh. */
 GTEST_TEST(MeshIntersectionTest, RemoveDuplicateVertices) {
+  using MeshType = TriangleSurfaceMesh<double>;
+
   // ABCD: No duplicate vertices. Expect no change to the polygon.
   {
     // clang-format off
@@ -283,7 +304,7 @@ GTEST_TEST(MeshIntersectionTest, RemoveDuplicateVertices) {
     };
     // clang-format on
     std::vector<Vector3d> output_polygon = input_polygon;
-    SurfaceVolumeIntersectorTester<double>().RemoveDuplicateVertices(
+    SurfaceVolumeIntersectorTester<MeshType>().RemoveDuplicateVertices(
         &output_polygon);
     EXPECT_TRUE(CompareConvexPolygon(input_polygon, output_polygon));
   }
@@ -300,7 +321,7 @@ GTEST_TEST(MeshIntersectionTest, RemoveDuplicateVertices) {
     };
     // clang-format on
     std::vector<Vector3d> output_polygon = input_polygon;
-    SurfaceVolumeIntersectorTester<double>().RemoveDuplicateVertices(
+    SurfaceVolumeIntersectorTester<MeshType>().RemoveDuplicateVertices(
         &output_polygon);
     EXPECT_TRUE(CompareConvexPolygon(expect_single_vertex, output_polygon));
   }
@@ -319,7 +340,7 @@ GTEST_TEST(MeshIntersectionTest, RemoveDuplicateVertices) {
     };
     // clang-format on
     std::vector<Vector3d> output_polygon = input_polygon;
-    SurfaceVolumeIntersectorTester<double>().RemoveDuplicateVertices(
+    SurfaceVolumeIntersectorTester<MeshType>().RemoveDuplicateVertices(
         &output_polygon);
     EXPECT_TRUE(CompareConvexPolygon(expect_two_vertices, output_polygon));
   }
@@ -347,7 +368,7 @@ GTEST_TEST(MeshIntersectionTest, RemoveDuplicateVertices) {
     };
     // clang-format on
     std::vector<Vector3d> output_polygon = input_polygon;
-    SurfaceVolumeIntersectorTester<double>().RemoveDuplicateVertices(
+    SurfaceVolumeIntersectorTester<MeshType>().RemoveDuplicateVertices(
         &output_polygon);
     EXPECT_TRUE(CompareConvexPolygon(expect_three_vertices, output_polygon));
   }
@@ -357,8 +378,8 @@ GTEST_TEST(MeshIntersectionTest, RemoveDuplicateVertices) {
 //  because so much of the math simply disappears. Reframe these tests with
 //  non-trivial triangles and tets -- the recommendation is to formulate these
 //  in an easy frame, find the answer in the easy frame, and then transform
-//  them all into an obnoxious frame and solve it there. This applies to both
-//  triangle and tetrahedron.
+//  them all into an obnoxious frame and test the code there. This applies to
+//  both triangle and tetrahedron.
 
 // Generates a trivial surface mesh consisting of one triangle with vertices
 // at the origin and on the X- and Y-axes. We will use it for testing
@@ -496,7 +517,11 @@ bool CompareConvexPolygon(const std::vector<Vector3<T>>& polygon0,
   return true;
 }
 
+/* This test is independent of ContactSurface mesh representation; so we'll
+ simply use TriangleSurfaceMesh. */
 GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
+  using MeshType = TriangleSurfaceMesh<double>;
+
   auto volume_M = TrivialVolumeMesh<double>();
   auto surface_N = TrivialSurfaceMesh<double>();
   // TODO(SeanCurtis-TRI): Seeing these two types together suggests there's a
@@ -515,7 +540,7 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
   {
     const auto X_MN = RigidTransformd(Vector3d::UnitX());
     const std::vector<Vector3d> polygon =
-        SurfaceVolumeIntersectorTester<double>().ClipTriangleByTetrahedron(
+        SurfaceVolumeIntersectorTester<MeshType>().ClipTriangleByTetrahedron(
             element0, *volume_M, face, *surface_N, X_MN);
     const std::vector<Vector3d> expect_empty_polygon;
     EXPECT_TRUE(CompareConvexPolygon(expect_empty_polygon, polygon));
@@ -527,7 +552,7 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
     const auto X_MN = RigidTransformd(RollPitchYawd(0, 0, M_PI_2),
                                              Vector3d::Zero());
     const std::vector<Vector3d> polygon =
-        SurfaceVolumeIntersectorTester<double>().ClipTriangleByTetrahedron(
+        SurfaceVolumeIntersectorTester<MeshType>().ClipTriangleByTetrahedron(
             element0, *volume_M, face, *surface_N, X_MN);
     EXPECT_TRUE(CompareConvexPolygon(empty_polygon, polygon));
   }
@@ -540,10 +565,10 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
   {
     const auto X_MN = RigidTransformd::Identity();
     const std::vector<Vector3d> polygon0_M =
-        SurfaceVolumeIntersectorTester<double>().ClipTriangleByTetrahedron(
+        SurfaceVolumeIntersectorTester<MeshType>().ClipTriangleByTetrahedron(
             element0, *volume_M, face, *surface_N, X_MN);
     const std::vector<Vector3d> polygon1_M =
-        SurfaceVolumeIntersectorTester<double>().ClipTriangleByTetrahedron(
+        SurfaceVolumeIntersectorTester<MeshType>().ClipTriangleByTetrahedron(
             element1, *volume_M, face, *surface_N, X_MN);
     // clang-format off
     const std::vector<Vector3d> expect_triangle_M{
@@ -560,7 +585,7 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
   {
     const auto X_MN = RigidTransformd(Vector3d(0, 0, 0.5));
     const std::vector<Vector3d> polygon0_M =
-        SurfaceVolumeIntersectorTester<double>().ClipTriangleByTetrahedron(
+        SurfaceVolumeIntersectorTester<MeshType>().ClipTriangleByTetrahedron(
             element0, *volume_M, face, *surface_N, X_MN);
     // clang-format off
     const std::vector<Vector3d> expect_triangle_M{
@@ -576,7 +601,7 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
   {
     const auto X_MN = RigidTransformd(Vector3d(0, 0, 0.5));
     const std::vector<Vector3d> polygon1_M =
-        SurfaceVolumeIntersectorTester<double>().ClipTriangleByTetrahedron(
+        SurfaceVolumeIntersectorTester<MeshType>().ClipTriangleByTetrahedron(
             element1, *volume_M, face, *surface_N, X_MN);
     EXPECT_TRUE(CompareConvexPolygon(empty_polygon, polygon1_M));
   }
@@ -587,7 +612,7 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
     const auto X_MN = RigidTransformd(RollPitchYawd(0, 0, M_PI),
                                              Vector3d(0.5, 0.5, 0));
     const std::vector<Vector3d> polygon0_M =
-        SurfaceVolumeIntersectorTester<double>().ClipTriangleByTetrahedron(
+        SurfaceVolumeIntersectorTester<MeshType>().ClipTriangleByTetrahedron(
             element0, *volume_M, face, *surface_N, X_MN);
     // clang-format off
     const std::vector<Vector3d> expect_square_M{
@@ -650,7 +675,11 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
 //    heptagon. A triangle with vertices (◯) t0(1.5,1.5,0), t1(-1.5,0,0), and
 //    t2(0,-1.5,0) will do. See the above picture.
 //
+// This test is independent of ContactSurface mesh representation; so we'll
+// simply use TriangleSurfaceMesh.
 GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedronIntoHeptagon) {
+  using MeshType = TriangleSurfaceMesh<double>;
+
   unique_ptr<VolumeMesh<double>> volume_M;
   {
     const int element_data[4] = {0, 1, 2, 3};
@@ -683,7 +712,7 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedronIntoHeptagon) {
   const int triangle = 0;
   const auto X_MN = RigidTransformd::Identity();
   const std::vector<Vector3d> polygon_M =
-      SurfaceVolumeIntersectorTester<double>().ClipTriangleByTetrahedron(
+      SurfaceVolumeIntersectorTester<MeshType>().ClipTriangleByTetrahedron(
           tetrahedron, *volume_M, triangle, *surface_N, X_MN);
   // clang-format off
   const std::vector<Vector3d> expect_heptagon_M{
@@ -699,7 +728,11 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedronIntoHeptagon) {
   EXPECT_TRUE(CompareConvexPolygon(expect_heptagon_M, polygon_M));
 }
 
+/* This test is independent of ContactSurface mesh representation; so we'll
+ simply use TriangleSurfaceMesh. */
 GTEST_TEST(MeshIntersectionTest, IsFaceNormalAlongPressureGradient) {
+  using MeshType = TriangleSurfaceMesh<double>;
+
   // It is ok to use the trivial mesh and trivial mesh field in this test.
   // The function under test asks for the gradient values and operates on it.
   // It is not responsible for making sure that the gradient is computed
@@ -744,30 +777,31 @@ GTEST_TEST(MeshIntersectionTest, IsFaceNormalAlongPressureGradient) {
     // general X_MN as an argument to the tested function
     // IsFaceNormalAlongPressureGradient().
     const auto X_MN = X_MF * X_FN;
-    EXPECT_EQ(t.expect_result,
-              SurfaceVolumeIntersectorTester<double>()
-                  .IsFaceNormalAlongPressureGradient(
-                      *volume_field_M, *rigid_N, X_MN, 0 /*tet_index*/,
-                      0 /*tri_index*/));
+    EXPECT_EQ(t.expect_result, SurfaceVolumeIntersectorTester<MeshType>()
+                                   .IsFaceNormalAlongPressureGradient(
+                                       *volume_field_M, *rigid_N, X_MN,
+                                       0 /*tet_index*/, 0 /*tri_index*/));
   }
 }
 
-// Given a triangle in a surface mesh, reports the tet in the volume mesh that
-// completely contains the triangle. Throws if a test cannot be identified.
-template <typename T>
-int GetTetForTriangle(const TriangleSurfaceMesh<T>& surface_S, int f,
-                      const VolumeMesh<double>& volume_V,
-                      const RigidTransform<T>& X_VS) {
-  const std::vector<Vector3<T>>& vertices_S = surface_S.vertices();
+// Given a face in a surface mesh, reports the tet in the volume mesh that
+// completely contains the face. Throws if a test cannot be identified.
+template <typename MeshType>
+int GetTetForFace(
+    const MeshType& surface_S, int f, const VolumeMesh<double>& volume_V,
+    const RigidTransform<typename MeshType::ScalarType>& X_VS) {
+  using T = typename MeshType::ScalarType;
 
-  // Each triangle lies completely within one tet in the volume mesh. The
+  // Each face lies completely within one tet in the volume mesh. The
   // gradient value reported should be that of that tet. So, we'll grab
-  // the centroid of each triangle, find the tet it lies in, and confirm
-  // that the pressure gradient on that triangle matches the tet.
-  const SurfaceTriangle& face = surface_S.element(f);
+  // a point inside each face (mean point of the first three vertices),
+  // and compute the barycentric coordinate of that point in the tet. The tet
+  // that computes a "valid" barycentric coordinate, is the tet that contains
+  // the polygon.
+  const auto& face = surface_S.element(f);
   const Vector3<T> p_SC =
-      (vertices_S[face.vertex(0)] + vertices_S[face.vertex(1)] +
-       vertices_S[face.vertex(2)]) /
+      (surface_S.vertex(face.vertex(0)) + surface_S.vertex(face.vertex(1)) +
+       surface_S.vertex(face.vertex(2))) /
       3;
   const Vector3<T> p_VC = X_VS * p_SC;
   for (int e = 0; e < volume_V.num_elements(); ++e) {
@@ -781,11 +815,19 @@ int GetTetForTriangle(const TriangleSurfaceMesh<T>& surface_S, int f,
       f));
 }
 
+template <typename MeshType>
+using MeshBuilderForMesh = std::conditional_t<
+    std::is_same_v<MeshType,
+                   TriangleSurfaceMesh<typename MeshType::ScalarType>>,
+    TriMeshBuilder<typename MeshType::ScalarType>,
+    PolyMeshBuilder<typename MeshType::ScalarType>>;
+
 // This fixture will test SampleVolumeFieldOnSurface() and
 // ComputeContactSurfaceFromSoftVolumeRigidSurface(). The latter is the main API
 // of this module and calls the former. They share many parameters. This
 // fixture uses `double` for checking the algorithm. There is another fixture
 // that uses `AutoDiffXd` for checking derivatives.
+template <typename MeshType>
 class MeshIntersectionFixture : public testing::Test {
  protected:
   void SetUp() override {
@@ -808,14 +850,14 @@ class MeshIntersectionFixture : public testing::Test {
   // This helper function verifies the output (surface_S, e_field, and
   // grad_eS_S) of SampleVolumeFieldOnSurface().
   void VerifySampleVolumeFieldOnSurface(
-      const unique_ptr<TriangleSurfaceMesh<double>>& surface_S,
-      const unique_ptr<TriangleSurfaceMeshFieldLinear<double, double>>& e_field,
+      const MeshType& surface_S,
+      const typename SurfaceVolumeIntersector<MeshType>::FieldType& e_field,
       const vector<Vector3<double>>& grad_eS_S) {
     // The two geometries intersect such that both tets get sliced into
     // identical right, isosceles triangles (with a leg length of 0.25m). The
     // total area is 2 * 0.25**2 / 2 = 0.25**2.
     const double expect_area = 0.25 * 0.25;
-    EXPECT_NEAR(expect_area, surface_S->total_area(), kEps);
+    EXPECT_NEAR(expect_area, surface_S.total_area(), kEps);
 
     // Here we exploit the simplicity of TrivialVolumeMeshField<>() to check
     // the field value. The test of field evaluation with more complex field
@@ -827,18 +869,17 @@ class MeshIntersectionFixture : public testing::Test {
     // for *this* test. Note: we're skipping the vertices located at the
     // triangle centroids.
     const double kEpsPressure = kEps * 1e10;
-    const std::vector<Vector3<double>>& vertices = surface_S->vertices();
     bool domain_checked[] = {false, false, false};
-    for (int v = 0; v < surface_S->num_vertices(); ++v) {
-      const double p_SV_z = vertices[v][2];
+    for (int v = 0; v < surface_S.num_vertices(); ++v) {
+      const double p_SV_z = surface_S.vertex(v)[2];
       if (std::abs(p_SV_z) < kEps) {
-        ASSERT_NEAR(e_field->EvaluateAtVertex(v), 0.0, kEpsPressure);
+        ASSERT_NEAR(e_field.EvaluateAtVertex(v), 0.0, kEpsPressure);
         domain_checked[0] = true;
       } else if (std::abs(p_SV_z - 0.25) < kEps) {
-        ASSERT_NEAR(e_field->EvaluateAtVertex(v), 0.25 * 1e7, kEpsPressure);
+        ASSERT_NEAR(e_field.EvaluateAtVertex(v), 0.25 * 1e7, kEpsPressure);
         domain_checked[1] = true;
       } else if (std::abs(p_SV_z + 0.25) < kEps) {
-        ASSERT_NEAR(e_field->EvaluateAtVertex(v), 0.25 * 1e10, kEpsPressure);
+        ASSERT_NEAR(e_field.EvaluateAtVertex(v), 0.25 * 1e10, kEpsPressure);
         domain_checked[2] = true;
       }
     }
@@ -858,17 +899,16 @@ class MeshIntersectionFixture : public testing::Test {
     // have the same normal.
     ASSERT_TRUE(
         CompareMatrices(surface_R_->face_normal(0), Vector3d::UnitZ()));
-    for (int f = 0; f < surface_S->num_triangles(); ++f) {
-      EXPECT_TRUE(CompareMatrices(surface_S->face_normal(f),
+    for (int f = 0; f < surface_S.num_elements(); ++f) {
+      EXPECT_TRUE(CompareMatrices(surface_S.face_normal(f),
                                   X_SR_.rotation() * Vector3d::UnitZ(),
                                   4 * kEps));
     }
 
     // Only the soft volume mesh provides gradients.
-    const std::vector<SurfaceTriangle>& faces = surface_S->triangles();
-    ASSERT_EQ(faces.size(), grad_eS_S.size());
-    for (int f = 0; f < surface_S->num_elements(); ++f) {
-      const int t = GetTetForTriangle(*surface_S, f, *mesh_S_, {});
+    ASSERT_EQ(surface_S.num_elements(), static_cast<int>(grad_eS_S.size()));
+    for (int f = 0; f < surface_S.num_elements(); ++f) {
+      const int t = GetTetForFace(surface_S, f, *mesh_S_, {});
       ASSERT_TRUE(
           CompareMatrices(grad_eS_S[f], field_S_->EvaluateGradient(t)));
     }
@@ -886,29 +926,53 @@ class MeshIntersectionFixture : public testing::Test {
   // ComputeContactSurfaceFromSoftVolumeRigidSurface() twice with different
   // orders of GeometryIds.
   void VerifyComputeContactSurfaceFromSoftRigid(
-      const unique_ptr<ContactSurface<double>>& contact_SR,
-      const unique_ptr<ContactSurface<double>>& contact_RS,
+      const ContactSurface<double>& contact_SR,
+      const ContactSurface<double>& contact_RS,
       const RigidTransformd& X_WS) {
+    using FieldType = typename SurfaceVolumeIntersector<MeshType>::FieldType;
+    const MeshType* mesh_SR_raw{};
+    const FieldType* field_SR_raw{};
+    const MeshType* mesh_RS_raw{};
+    const FieldType* field_RS_raw{};
+    if constexpr (std::is_same_v<
+                      MeshType,
+                      TriangleSurfaceMesh<typename MeshType::ScalarType>>) {
+      mesh_SR_raw = &contact_SR.tri_mesh_W();
+      field_SR_raw = &contact_SR.tri_e_MN();
+      mesh_RS_raw = &contact_RS.tri_mesh_W();
+      field_RS_raw = &contact_RS.tri_e_MN();
+    } else {
+      mesh_SR_raw = &contact_SR.poly_mesh_W();
+      field_SR_raw = &contact_SR.poly_e_MN();
+      mesh_RS_raw = &contact_RS.poly_mesh_W();
+      field_RS_raw = &contact_RS.poly_e_MN();
+    }
+    const MeshType& mesh_SR_W = *mesh_SR_raw;
+    const FieldType& field_SR_W = *field_SR_raw;
+    const MeshType& mesh_RS_W = *mesh_RS_raw;
+    const FieldType& field_RS_W = *field_RS_raw;
+
     // Mesh invariants:
     // Meshes are the same "size" (topologically).
-    EXPECT_EQ(contact_SR->mesh_W().num_triangles(),
-              contact_RS->mesh_W().num_triangles());
-    EXPECT_EQ(contact_SR->mesh_W().num_vertices(),
-              contact_RS->mesh_W().num_vertices());
+    EXPECT_EQ(mesh_SR_W.num_elements(), mesh_RS_W.num_elements());
+    EXPECT_EQ(mesh_SR_W.num_vertices(), mesh_RS_W.num_vertices());
 
     // Test one and assume all share the same property.
-    EXPECT_TRUE(CompareMatrices(contact_SR->mesh_W().vertex(0),
-                                contact_RS->mesh_W().vertex(0)));
+    EXPECT_TRUE(CompareMatrices(mesh_SR_W.vertex(0), mesh_RS_W.vertex(0)));
 
     // TODO(SeanCurtis-TRI): Test that the face winding has been reversed, once
     //  that is officially documented as a property of the ContactSurface.
 
     // The "pressure" field is frame invariant and should be equal.
-    const TriangleSurfaceMesh<double>::Barycentric<double> centroid(
-        1. / 3., 1. / 3., 1. / 3.);
+    // Pick a point to test the pressure field evaluation.
+    const auto& face = mesh_SR_W.element(0);
+    const Vector3<double> p_WV =
+        (mesh_SR_W.vertex(face.vertex(0)) + mesh_SR_W.vertex(face.vertex(1)) +
+         mesh_SR_W.vertex(face.vertex(2))) /
+        3;
     const int f_index = 0;
-    EXPECT_EQ(contact_SR->e_MN().Evaluate(f_index, centroid),
-              contact_RS->e_MN().Evaluate(f_index, centroid));
+    EXPECT_EQ(field_SR_W.EvaluateCartesian(f_index, p_WV),
+              field_RS_W.EvaluateCartesian(f_index, p_WV));
 
     // The gradients for the pressure field of the soft mesh are expressed in
     // the world frame. To determine the world transformation has taken place,
@@ -916,9 +980,8 @@ class MeshIntersectionFixture : public testing::Test {
     // surface. We'll confirm that its gradient has been transformed to the
     // world frame.
     const int f0 = 0;
-    const int t = GetTetForTriangle<double>(contact_SR->mesh_W(), f0, *mesh_S_,
-                                            X_WS.inverse());
-    EXPECT_TRUE(CompareMatrices(contact_SR->EvaluateGradE_M_W(f0),
+    const int t = GetTetForFace(mesh_SR_W, f0, *mesh_S_, X_WS.inverse());
+    EXPECT_TRUE(CompareMatrices(contact_SR.EvaluateGradE_M_W(f0),
                                 X_WS.rotation() * field_S_->EvaluateGradient(t),
                                 4. * kEps));
   }
@@ -937,19 +1000,36 @@ class MeshIntersectionFixture : public testing::Test {
   static constexpr double kEps = std::numeric_limits<double>::epsilon();
 };
 
-TEST_F(MeshIntersectionFixture, SampleVolumeFieldOnSurface) {
-  vector<Vector3<double>> grad_eS_S;
-  unique_ptr<TriangleSurfaceMesh<double>> surface_S;
-  unique_ptr<TriangleSurfaceMeshFieldLinear<double, double>> e_field;
+using MeshTypes =
+    ::testing::Types<TriangleSurfaceMesh<double>, PolygonSurfaceMesh<double>>;
+TYPED_TEST_SUITE(MeshIntersectionFixture, MeshTypes);
 
-  SCOPED_TRACE("Triangulate each polygon around its centroid.");
-  SurfaceVolumeIntersector<double>().SampleVolumeFieldOnSurface(
-      *field_S_, *bvh_mesh_S_, *surface_R_, *bvh_surface_R_, X_SR_, &surface_S,
-      &e_field, &grad_eS_S);
+// A simple smoke test. We perform the collision, confirm the face count of the
+// contact surface's mesh, and then confirm that the we've sampled the compliant
+// mesh's pressure field.
+TYPED_TEST(MeshIntersectionFixture, SampleVolumeFieldOnSurface) {
+  using MeshType = TypeParam;
+  using T = typename MeshType::ScalarType;
 
-  EXPECT_EQ(6, surface_S->num_triangles());
-  VerifySampleVolumeFieldOnSurface(surface_S, e_field, grad_eS_S);
+  SurfaceVolumeIntersector<MeshType> intersector;
+  intersector.SampleVolumeFieldOnSurface(
+      *this->field_S_, *this->bvh_mesh_S_, *this->surface_R_,
+      *this->bvh_surface_R_, this->X_SR_, MeshBuilderForMesh<MeshType>());
+
+  const auto& surface_S = intersector.mutable_mesh();
+  // The two meshes intersected forming two triangles. Each mesh type responds
+  // slightly differently.
+  if constexpr (std::is_same_v<MeshType, TriangleSurfaceMesh<T>>) {
+    // Two triangles tesselate around centroids into six in TriangleSurfaceMesh.
+    EXPECT_EQ(6, surface_S.num_elements());
+  } else {
+    // Two triangles added directly in PolygonSurfaceMesh.
+    EXPECT_EQ(2, surface_S.num_elements());
+  }
+  this->VerifySampleVolumeFieldOnSurface(surface_S, intersector.mutable_field(),
+                                         intersector.mutable_grad_eM_M());
 }
+
 
 // Tests the generation of the ContactSurface between a soft volume and rigid
 // surface. This highest-level function's primary responsibility is to make
@@ -959,14 +1039,23 @@ TEST_F(MeshIntersectionFixture, SampleVolumeFieldOnSurface) {
 // gradients are mirrored.) The difference test is coarsely sampled and assumes
 // that some good results are correlated with all good results based on the
 // unit tests for ContactSurface.
-TEST_F(MeshIntersectionFixture, TestComputeContactSurfaceSoftRigid) {
+TYPED_TEST(MeshIntersectionFixture, TestComputeContactSurfaceSoftRigid) {
   const auto id_A = GeometryId::get_new_id();
   const auto id_B = GeometryId::get_new_id();
   EXPECT_LT(id_A, id_B);
   // The relationship between the frames for the soft body and the
   // world frame is irrelevant for this test.
   const RigidTransformd X_WS = RigidTransformd::Identity();
-  const RigidTransformd X_WR = X_WS * X_SR_;
+  const RigidTransformd X_WR = X_WS * this->X_SR_;
+
+  using MeshType = TypeParam;
+  using T = typename MeshType::ScalarType;
+
+  HydroelasticContactRepresentation representation =
+      HydroelasticContactRepresentation::kTriangle;
+  if (!std::is_same_v<MeshType, TriangleSurfaceMesh<T>>) {
+    representation = HydroelasticContactRepresentation::kPolygon;
+  }
 
   // Regardless of how we assign id_A and id_B to mesh_S_ and surface_R_, the
   // contact surfaces will always have id_M = id_A and id_N = id_B (because
@@ -975,8 +1064,8 @@ TEST_F(MeshIntersectionFixture, TestComputeContactSurfaceSoftRigid) {
   // In this case, we assign id_A to soft and we already know that
   // id_A < id_B. Confirm order
   auto contact_SR = ComputeContactSurfaceFromSoftVolumeRigidSurface(
-      id_A, *field_S_, *bvh_mesh_S_, X_WS, id_B, *surface_R_, *bvh_surface_R_,
-      X_WR);
+      id_A, *this->field_S_, *this->bvh_mesh_S_, X_WS, id_B, *this->surface_R_,
+      *this->bvh_surface_R_, X_WR, representation);
   EXPECT_EQ(contact_SR->id_M(), id_A);
   EXPECT_EQ(contact_SR->id_N(), id_B);
   EXPECT_TRUE(contact_SR->HasGradE_M());
@@ -986,14 +1075,15 @@ TEST_F(MeshIntersectionFixture, TestComputeContactSurfaceSoftRigid) {
   // is less than id_B, but we should further satisfy various invariants
   // in VerifyComputeContactSurfaceFromSoftRigid().
   auto contact_RS = ComputeContactSurfaceFromSoftVolumeRigidSurface(
-      id_B, *field_S_, *bvh_mesh_S_, X_WS, id_A, *surface_R_, *bvh_surface_R_,
-      X_WR);
+      id_B, *this->field_S_, *this->bvh_mesh_S_, X_WS, id_A, *this->surface_R_,
+      *this->bvh_surface_R_, X_WR, representation);
   EXPECT_EQ(contact_RS->id_M(), id_A);
   EXPECT_EQ(contact_RS->id_N(), id_B);
   EXPECT_FALSE(contact_RS->HasGradE_M());
   EXPECT_TRUE(contact_RS->HasGradE_N());
 
-  VerifyComputeContactSurfaceFromSoftRigid(contact_SR, contact_RS, X_WS);
+  this->VerifyComputeContactSurfaceFromSoftRigid(*contact_SR, *contact_RS,
+                                                 X_WS);
 }
 
 /* This test fixture enables some limited testing of the autodiff-valued contact
@@ -1040,7 +1130,11 @@ TEST_F(MeshIntersectionFixture, TestComputeContactSurfaceSoftRigid) {
  Otherwise, it's line for line and comment for comment identical. We might want
  to consider refactoring it but for the fact that it only appears two places. If
  we end up supporting other customized implementations between planar rigid
- objects and soft mesh, it would make sense to refactor. */
+ objects and soft mesh, it would make sense to refactor.
+
+ We do all the tests with TriangleSurfaceMesh; the difference between
+ TriangleSurfaceMesh and PolygonalSurfaceMesh is inconsequential to this test.
+ */
 class MeshMeshDerivativesTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -1195,11 +1289,12 @@ class MeshMeshDerivativesTest : public ::testing::Test {
       const RigidTransform<AutoDiffXd> X_WS(R_WS_d.cast<AutoDiffXd>(), p_WS);
 
       auto surface = ComputeContactSurfaceFromSoftVolumeRigidSurface(
-          id_S_, *field_S_, *bvh_S_, X_WS, id_R_, *tri_mesh_R_, *bvh_R_, X_WR_);
+          id_S_, *field_S_, *bvh_S_, X_WS, id_R_, *tri_mesh_R_, *bvh_R_,
+          X_WR_, HydroelasticContactRepresentation::kTriangle);
 
       SCOPED_TRACE(config.name);
       ASSERT_NE(surface, nullptr);
-      ASSERT_EQ(surface->mesh_W().num_triangles(), config.num_faces);
+      ASSERT_EQ(surface->tri_mesh_W().num_triangles(), config.num_faces);
 
       evaluate_quantity(*surface, X_WS, config.pose);
     }
@@ -1277,7 +1372,7 @@ TEST_F(MeshMeshDerivativesTest, Area) {
                            const ContactSurface<AutoDiffXd>& surface,
                            const RigidTransform<AutoDiffXd>& X_WS_ad,
                            TetPose pose) {
-    const auto& mesh_W = surface.mesh_W();
+    const auto& mesh_W = surface.tri_mesh_W();
 
     // For v × A, this makes a matrix V such that VA = v × A.
     auto skew_matrix = [](const Vector3d& v) {
@@ -1434,7 +1529,7 @@ TEST_F(MeshMeshDerivativesTest, VertexPosition) {
      from intersecting a tet edge with the triangle. We'll evaluate all of those
      and then handle the centroid specially. */
     const Vector3d n_R{0, 0, 1};
-    const TriangleSurfaceMesh<AutoDiffXd>& mesh_W = surface.mesh_W();
+    const TriangleSurfaceMesh<AutoDiffXd>& mesh_W = surface.tri_mesh_W();
     const RotationMatrixd R_WR = convert_to_double(this->X_WR_).rotation();
     const RotationMatrixd R_RW = R_WR.inverse();
     const RigidTransformd X_WS = convert_to_double(X_WS_ad);
@@ -1489,7 +1584,7 @@ TEST_F(MeshMeshDerivativesTest, FaceNormalsWrtPosition) {
                               const ContactSurface<AutoDiffXd>& surface,
                               const RigidTransform<AutoDiffXd>& X_WS, TetPose) {
     constexpr double kEps = std::numeric_limits<double>::epsilon();
-    const auto& mesh_W = surface.mesh_W();
+    const auto& mesh_W = surface.tri_mesh_W();
     const Vector3d plane_n_W = X_WR.rotation().col(2);
     const Matrix3<double> zeros = Matrix3<double>::Zero();
     for (int f = 0; f < mesh_W.num_elements(); ++f) {
@@ -1536,12 +1631,13 @@ TEST_F(MeshMeshDerivativesTest, FaceNormalsWrtOrientation) {
 
     auto surface = ComputeContactSurfaceFromSoftVolumeRigidSurface(
         this->id_S_, *this->field_S_, *this->bvh_S_, X_WS, this->id_R_,
-        *this->tri_mesh_R_, *this->bvh_R_, this->X_WR_);
+        *this->tri_mesh_R_, *this->bvh_R_, this->X_WR_,
+        HydroelasticContactRepresentation::kTriangle);
 
     SCOPED_TRACE(fmt::format("theta = {:.5f} radians", theta));
     ASSERT_NE(surface, nullptr);
     /* Make sure the test doesn't pass simply because we have no triangles. */
-    const auto& mesh_W = surface->mesh_W();
+    const auto& mesh_W = surface->tri_mesh_W();
     ASSERT_GT(mesh_W.num_elements(), 0);
 
     constexpr double kEps = std::numeric_limits<double>::epsilon();
@@ -1594,12 +1690,12 @@ TEST_F(MeshMeshDerivativesTest, Pressure) {
     constexpr double kEps = 8 * std::numeric_limits<double>::epsilon();
     const RigidTransform<double> X_WS_d = convert_to_double(X_WS);
     const Vector3d grad_p_W = X_WS_d.rotation() * grad_p_S;
-    for (int v = 0; v < surface.mesh_W().num_vertices(); ++v) {
+    for (int v = 0; v < surface.tri_mesh_W().num_vertices(); ++v) {
       const Matrix3<double> dp_WQ_dp_WSo_W =
-          math::ExtractGradient(surface.mesh_W().vertex(v));
+          math::ExtractGradient(surface.tri_mesh_W().vertex(v));
       const Vector3d dp_dp_WSo_W_expected =
           grad_p_W.transpose() * (dp_WQ_dp_WSo_W - Matrix3<double>::Identity());
-      const AutoDiffXd& p = surface.e_MN().EvaluateAtVertex(v);
+      const AutoDiffXd& p = surface.tri_e_MN().EvaluateAtVertex(v);
       EXPECT_TRUE(CompareMatrices(p.derivatives(), dp_dp_WSo_W_expected, kEps));
     }
   };

--- a/geometry/proximity/test/mesh_to_vtk_test.cc
+++ b/geometry/proximity/test/mesh_to_vtk_test.cc
@@ -79,7 +79,8 @@ unique_ptr<ContactSurface<double>> BoxContactSurface() {
 
   return ComputeContactSurfaceFromSoftVolumeRigidSurface(
       GeometryId::get_new_id(), field_S, bvh_volume_S, X_WS,
-      GeometryId::get_new_id(), surface_R, bvh_surface_R, X_WR);
+      GeometryId::get_new_id(), surface_R, bvh_surface_R, X_WR,
+      HydroelasticContactRepresentation::kTriangle);
 }
 
 GTEST_TEST(MeshToVtkTest, BoxContactSurfacePressure) {


### PR DESCRIPTION
This reframes mesh-mesh intersection to use the new `MeshBuilder` so it can create either polygon or triangle mesh representations. The APIs have been modified to communicate the desired representation and the tests have been updated accordingly.

Various related call sites have been updated to *explicitly* request triangle meshes (this was implicit before).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16163)
<!-- Reviewable:end -->
