### PR TITLE
[hydro] Enable polygon contact surface in mesh-half space intersection

### DIFF
--- a/geometry/proximity/hydroelastic_callback.h
+++ b/geometry/proximity/hydroelastic_callback.h
@@ -103,7 +103,8 @@ std::unique_ptr<ContactSurface<T>> DispatchRigidSoftCalculation(
       const TriangleSurfaceMesh<double>& mesh_R = rigid.mesh();
       const Bvh<Obb, TriangleSurfaceMesh<double>>& bvh_R = rigid.bvh();
       return ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
-          id_S, X_WS, soft.pressure_scale(), id_R, mesh_R, bvh_R, X_WR);
+          id_S, X_WS, soft.pressure_scale(), id_R, mesh_R, bvh_R, X_WR,
+          HydroelasticContactRepresentation::kTriangle);
     } else {
       // Soft volume vs rigid half space.
       const VolumeMeshFieldLinear<double, double>& field_S =

--- a/geometry/proximity/mesh_half_space_intersection.cc
+++ b/geometry/proximity/mesh_half_space_intersection.cc
@@ -23,18 +23,17 @@ int sgn(const T& x) {
   }
 }
 
-/* Utility routine for calculating the intersection point between an edge and
- a plane. Given an edge (defined by its two end-point vertices a and b) and the
- signed distances from a plane (`s_a` and `s_b`, respectively), returns the
- position where the plane splits the edge.
+/* Calculates the intersection point between an edge and a plane. Given an edge
+ (defined by its two end-point vertices A and B) and the vertices' signed
+ distances from the plane (`s_a` and `s_b`, respectively), returns the position
+ where the plane splits the edge. The split vertex is measured and expressed in
+ the same frame as the input vertices, F.
 
- @pre s_a and s_b must not have the same sign (positive, negative, or zero).
- */
+ @pre s_a and s_b must not have the same sign (positive, negative, or zero). */
 template <typename T>
 Vector3<T> CalcEdgePlaneIntersection(
     int a, int b, const T& s_a, const T& s_b,
-    const std::vector<Vector3<double>>& vertices_F,
-    const math::RigidTransform<T>& X_WF) {
+    const std::vector<Vector3<double>>& vertices_F) {
   DRAKE_DEMAND(a != b);
   DRAKE_DEMAND(sgn(s_a) != sgn(s_b));
   using std::abs;
@@ -44,9 +43,7 @@ Vector3<T> CalcEdgePlaneIntersection(
   // never be greater than unity). Barring an (unlikely) machine epsilon
   // remainder on division, the assertion below should hold.
   DRAKE_DEMAND(t >= 0 && t <= 1);
-  const Vector3<T> p_WV =
-      X_WF * (vertices_F[a] + t * (vertices_F[b] - vertices_F[a]));
-  return p_WV;
+  return vertices_F[a] + t * (vertices_F[b] - vertices_F[a]);
 }
 
 /* Utility routine for getting the vertex index from the
@@ -56,75 +53,83 @@ Vector3<T> CalcEdgePlaneIntersection(
  crossing plane. The method creates the vertex if the edge hasn't previously
  been split.
 
- @pre s_a and s_b must not have the same sign (positive, negative, or zero).
- */
-template <typename T>
+ @pre s_a and s_b must not have the same sign (positive, negative, or zero). */
+template <typename MeshBuilder>
 int GetVertexAddIfNeeded(
-    int a, int b, const T& s_a, const T& s_b,
+    int a, int b, const typename MeshBuilder::ScalarType& s_a,
+    const typename MeshBuilder::ScalarType& s_b,
     const std::vector<Vector3<double>>& vertices_F,
-    const math::RigidTransform<T>& X_WF,
+    const std::function<typename MeshBuilder::ScalarType(
+        const Vector3<typename MeshBuilder::ScalarType>&)>& pressure_in_F,
+    const math::RigidTransform<typename MeshBuilder::ScalarType>& X_WF,
     std::unordered_map<SortedPair<int>, int>* edges_to_newly_created_vertices,
-    std::vector<Vector3<T>>* new_vertices_W) {
+    MeshBuilder* builder_W) {
+  using T = typename MeshBuilder::ScalarType;
   DRAKE_DEMAND(sgn(s_a) != sgn(s_b));
 
   SortedPair<int> edge_a_b(a, b);
   auto edge_a_b_intersection_iter =
       edges_to_newly_created_vertices->find(edge_a_b);
   if (edge_a_b_intersection_iter == edges_to_newly_created_vertices->end()) {
+    const Vector3<T> p_FV =
+        CalcEdgePlaneIntersection(a, b, s_a, s_b, vertices_F);
+    const int builder_index =
+        builder_W->AddVertex(X_WF * p_FV, pressure_in_F(p_FV));
     bool inserted;
     std::tie(edge_a_b_intersection_iter, inserted) =
-        edges_to_newly_created_vertices->insert(
-            {edge_a_b, static_cast<int>(new_vertices_W->size())});
+        edges_to_newly_created_vertices->insert({edge_a_b, builder_index});
     DRAKE_DEMAND(inserted);
-    new_vertices_W->emplace_back(
-        CalcEdgePlaneIntersection(a, b, s_a, s_b, vertices_F, X_WF));
   }
 
   return edge_a_b_intersection_iter->second;
 }
 
 /* Utility routine for getting the vertex index from the
- `vertices_to_newly_created_vertices` hashtable. Given a vertex `index` from the
- input mesh, returns the corresponding vertex index in `new_vertices_W`. The
- method creates the vertex in `new_vertices_W` if it hasn't already been added.
- */
-template <typename T>
+ `vertices_to_newly_created_vertices` hashtable. Given a vertex `v_index` from
+ the input mesh, returns the corresponding vertex index in `builder_W`. The
+ method adds the vertex to `builder_W` if it doesn't already exist. */
+template <typename MeshBuilder, typename T = typename MeshBuilder::ScalarType>
 int GetVertexAddIfNeeded(
-    const std::vector<Vector3<double>>& vertices_F, int index,
+    const std::vector<Vector3<double>>& vertices_F, int v_index,
+    const std::function<T(const Vector3<T>&)>& pressure_in_F,
     const math::RigidTransform<T>& X_WF,
     std::unordered_map<int, int>* vertices_to_newly_created_vertices,
-    std::vector<Vector3<T>>* new_vertices_W) {
-  auto v_to_new_v_iter = vertices_to_newly_created_vertices->find(index);
+    MeshBuilder* builder_W) {
+  auto v_to_new_v_iter = vertices_to_newly_created_vertices->find(v_index);
   if (v_to_new_v_iter == vertices_to_newly_created_vertices->end()) {
-    bool inserted;
-    std::tie(v_to_new_v_iter, inserted) =
-        vertices_to_newly_created_vertices->insert(
-            {index, static_cast<int>(new_vertices_W->size())});
-    DRAKE_DEMAND(inserted);
     // Note: although the vertex is *always* Vector3<double>, we don't support
     // Vector3<AD> = RigidTransform<AD> * Vector3<double>. Therefore, we must
     // cast the vector to T to account for when it is AutoDiffXd.
-    const Vector3<T> p_WV = X_WF * vertices_F[index].cast<T>();
-    new_vertices_W->emplace_back(p_WV);
+    const Vector3<T> p_FV = vertices_F[v_index].cast<T>();
+    const int builder_index =
+        builder_W->AddVertex(X_WF * p_FV, pressure_in_F(p_FV));
+    bool inserted;
+    std::tie(v_to_new_v_iter, inserted) =
+        vertices_to_newly_created_vertices->insert({v_index, builder_index});
+    DRAKE_DEMAND(inserted);
   }
   return v_to_new_v_iter->second;
 }
 
 }  // namespace
 
-template <typename T>
+template <typename MeshBuilder>
 void ConstructTriangleHalfspaceIntersectionPolygon(
     const TriangleSurfaceMesh<double>& mesh_F, int tri_index,
-    const PosedHalfSpace<T>& half_space_F, const math::RigidTransform<T>& X_WF,
-    std::vector<Vector3<T>>* new_vertices_W,
-    std::vector<SurfaceTriangle>* new_faces,
+    const PosedHalfSpace<typename MeshBuilder::ScalarType>& half_space_F,
+    const std::function<typename MeshBuilder::ScalarType(
+        const Vector3<typename MeshBuilder::ScalarType>&)>&
+        pressure_in_F,
+    const Vector3<typename MeshBuilder::ScalarType>& grad_pressure_in_W,
+    const math::RigidTransform<typename MeshBuilder::ScalarType>& X_WF,
+    MeshBuilder* builder_W,
     std::unordered_map<int, int>* vertices_to_newly_created_vertices,
     std::unordered_map<SortedPair<int>, int>* edges_to_newly_created_vertices) {
+  using T = typename MeshBuilder::ScalarType;
   // TODO(SeanCurtis-TRI): This needs to support the "backface" culling that is
   //  implemented in mesh-mesh intersection. See the
   //  IsFaceNormalAlongPressureGradient() function in mesh_intersection.h.
-  DRAKE_DEMAND(new_vertices_W != nullptr);
-  DRAKE_DEMAND(new_faces != nullptr);
+  DRAKE_DEMAND(builder_W != nullptr);
   DRAKE_DEMAND(vertices_to_newly_created_vertices != nullptr);
   DRAKE_DEMAND(edges_to_newly_created_vertices != nullptr);
 
@@ -187,12 +192,12 @@ void ConstructTriangleHalfspaceIntersectionPolygon(
   // Compute the signed distance of each triangle vertex from the half space.
   // The table of possibilities is listed next with p = num_positive.
   //
-  //     p  intersection
+  //     p  |  intersection
   //     ---------------------------------
-  // 1.  0  triangle (original)
-  // 2.  1  quad (2 edges clipped)
-  // 3.  2  triangle (2 edges clipped)
-  // 4.  3  none
+  // 1.  0  |  triangle (original)
+  // 2.  1  |  quad (2 edges clipped)
+  // 3.  2  |  triangle (2 edges clipped)
+  // 4.  3  |  none
 
   // Compute the signed distance of each triangle vertex from the half space.
   T s[3];
@@ -214,17 +219,17 @@ void ConstructTriangleHalfspaceIntersectionPolygon(
   // the ordering of the triangle vertices.
   if (num_positive == 0) {
     const int v0_new_index = GetVertexAddIfNeeded(
-        vertices_F, triangle.vertex(0), X_WF,
-        vertices_to_newly_created_vertices, new_vertices_W);
+        vertices_F, triangle.vertex(0), pressure_in_F, X_WF,
+        vertices_to_newly_created_vertices, builder_W);
     const int v1_new_index = GetVertexAddIfNeeded(
-        vertices_F, triangle.vertex(1), X_WF,
-        vertices_to_newly_created_vertices, new_vertices_W);
+        vertices_F, triangle.vertex(1), pressure_in_F, X_WF,
+        vertices_to_newly_created_vertices, builder_W);
     const int v2_new_index = GetVertexAddIfNeeded(
-        vertices_F, triangle.vertex(2), X_WF,
-        vertices_to_newly_created_vertices, new_vertices_W);
+        vertices_F, triangle.vertex(2), pressure_in_F, X_WF,
+        vertices_to_newly_created_vertices, builder_W);
 
-    AddPolygonToTriangleMeshData({v0_new_index, v1_new_index, v2_new_index},
-                                 nhat_W, new_faces, new_vertices_W);
+    builder_W->AddPolygon({v0_new_index, v1_new_index, v2_new_index}, nhat_W,
+                          grad_pressure_in_W);
     return;
   }
 
@@ -241,19 +246,19 @@ void ConstructTriangleHalfspaceIntersectionPolygon(
         // Get the vertices that result from intersecting edge i0/i1 and
         // i0/i2.
         const int edge_i0_i1_intersection_index = GetVertexAddIfNeeded(
-            v0, v1, s[i0], s[i1], vertices_F, X_WF,
-            edges_to_newly_created_vertices, new_vertices_W);
+            v0, v1, s[i0], s[i1], vertices_F, pressure_in_F, X_WF,
+            edges_to_newly_created_vertices, builder_W);
         const int edge_i0_i2_intersection_index = GetVertexAddIfNeeded(
-            v0, v2, s[i0], s[i2], vertices_F, X_WF,
-            edges_to_newly_created_vertices, new_vertices_W);
+            v0, v2, s[i0], s[i2], vertices_F, pressure_in_F, X_WF,
+            edges_to_newly_created_vertices, builder_W);
 
         // Get the indices of the new vertices, adding them if needed.
-        const int i1_new_index = GetVertexAddIfNeeded(
-            vertices_F, v1, X_WF, vertices_to_newly_created_vertices,
-            new_vertices_W);
-        const int i2_new_index = GetVertexAddIfNeeded(
-            vertices_F, v2, X_WF, vertices_to_newly_created_vertices,
-            new_vertices_W);
+        const int i1_new_index =
+            GetVertexAddIfNeeded(vertices_F, v1, pressure_in_F, X_WF,
+                                 vertices_to_newly_created_vertices, builder_W);
+        const int i2_new_index =
+            GetVertexAddIfNeeded(vertices_F, v2, pressure_in_F, X_WF,
+                                 vertices_to_newly_created_vertices, builder_W);
 
         // Add the polygon (i1, i2, e02, e01)
         //
@@ -265,16 +270,13 @@ void ConstructTriangleHalfspaceIntersectionPolygon(
         //        ╱________╲
         //      i1          i2
         //
-        AddPolygonToTriangleMeshData(
+        builder_W->AddPolygon(
             {i1_new_index, i2_new_index, edge_i0_i2_intersection_index,
              edge_i0_i1_intersection_index},
-            nhat_W, new_faces, new_vertices_W);
-
+            nhat_W, grad_pressure_in_W);
         return;
       }
     }
-
-    DRAKE_UNREACHABLE();
   }
 
   // Case 3: The portion of the triangle in the half space is a triangle.
@@ -288,25 +290,23 @@ void ConstructTriangleHalfspaceIntersectionPolygon(
         const int v2 = triangle.vertex(i2);
 
         // Get the vertex that corresponds to i0.
-        const int i0_new_index = GetVertexAddIfNeeded(
-            vertices_F, v0, X_WF, vertices_to_newly_created_vertices,
-            new_vertices_W);
+        const int i0_new_index =
+            GetVertexAddIfNeeded(vertices_F, v0, pressure_in_F, X_WF,
+                                 vertices_to_newly_created_vertices, builder_W);
 
         // Get the vertex that results from intersecting edge i0/i1.
         const int edge_i0_i1_intersection_index = GetVertexAddIfNeeded(
-            v0, v1, s[i0], s[i1], vertices_F, X_WF,
-            edges_to_newly_created_vertices, new_vertices_W);
+            v0, v1, s[i0], s[i1], vertices_F, pressure_in_F, X_WF,
+            edges_to_newly_created_vertices, builder_W);
 
         // Get the vertex that results from intersecting edge i0/i2.
         const int edge_i0_i2_intersection_index = GetVertexAddIfNeeded(
-            v0, v2, s[i0], s[i2], vertices_F, X_WF,
-            edges_to_newly_created_vertices, new_vertices_W);
+            v0, v2, s[i0], s[i2], vertices_F, pressure_in_F, X_WF,
+            edges_to_newly_created_vertices, builder_W);
 
-        AddPolygonToTriangleMeshData(
-            {i0_new_index, edge_i0_i1_intersection_index,
-             edge_i0_i2_intersection_index},
-            nhat_W, new_faces, new_vertices_W);
-
+        builder_W->AddPolygon({i0_new_index, edge_i0_i1_intersection_index,
+                               edge_i0_i2_intersection_index},
+                              nhat_W, grad_pressure_in_W);
         return;
       }
     }
@@ -315,34 +315,49 @@ void ConstructTriangleHalfspaceIntersectionPolygon(
   }
 }
 
-template <typename T>
-std::unique_ptr<TriangleSurfaceMesh<T>>
-ConstructSurfaceMeshFromMeshHalfspaceIntersection(
-    const TriangleSurfaceMesh<double>& input_mesh_F,
-    const PosedHalfSpace<T>& half_space_F,
+template <typename MeshBuilder>
+std::unique_ptr<ContactSurface<typename MeshBuilder::ScalarType>>
+ComputeContactSurface(
+    GeometryId mesh_id, const TriangleSurfaceMesh<double>& input_mesh_F,
+    GeometryId half_space_id,
+    const PosedHalfSpace<typename MeshBuilder::ScalarType>& half_space_F,
+    const std::function<typename MeshBuilder::ScalarType(
+        const Vector3<typename MeshBuilder::ScalarType>&)>&
+        pressure_in_F,
+    const Vector3<typename MeshBuilder::ScalarType>& grad_p_W,
     const std::vector<int>& tri_indices,
-    const math::RigidTransform<T>& X_WF) {
-  std::vector<Vector3<T>> new_vertices_W;
-  std::vector<SurfaceTriangle> new_faces;
+    const math::RigidTransform<typename MeshBuilder::ScalarType>& X_WF) {
+  using T = typename MeshBuilder::ScalarType;
+
+  if (tri_indices.size() == 0) return nullptr;
+
+  // Build infrastructure as we process each potentially colliding triangle.
+  MeshBuilder builder_W;
   std::unordered_map<int, int> vertices_to_newly_created_vertices;
   std::unordered_map<SortedPair<int>, int> edges_to_newly_created_vertices;
 
   for (const auto& tri_index : tri_indices) {
     ConstructTriangleHalfspaceIntersectionPolygon(
-        input_mesh_F, tri_index, half_space_F, X_WF, &new_vertices_W,
-        &new_faces, &vertices_to_newly_created_vertices,
+        input_mesh_F, tri_index, half_space_F, pressure_in_F, grad_p_W, X_WF,
+        &builder_W, &vertices_to_newly_created_vertices,
         &edges_to_newly_created_vertices);
   }
 
-  if (new_faces.size() == 0) return nullptr;
+  if (builder_W.num_faces() == 0) return nullptr;
 
-  // TODO(SeanCurtis-TRI): This forces TriangleSurfaceMesh to recompute the
-  //  normals for every triangle in the set of faces. But we know that they
-  //  should be the normals drawn from the input mesh. We should accumulate the
-  //  normals during accumulation and explicitly provide them here (with a
-  //  reasonable check that the winding and the normals are consistent).
-  return std::make_unique<TriangleSurfaceMesh<T>>(std::move(new_faces),
-                                                  std::move(new_vertices_W));
+  auto [mesh_W, field_W] = builder_W.MakeMeshAndField();
+
+  // TODO(SeanCurtis-TRI) In this case, the gradient across the contact surface
+  //  is a constant. It would be good if we could exploit this and *not* copy
+  //  the same vector value once per face.
+  auto grad_eS_W = std::make_unique<std::vector<Vector3<T>>>(
+      mesh_W->num_elements(), grad_p_W);
+
+  // ConstructTriangleHalfspaceIntersectionPolygon() promises to make the
+  // face normals point out of the rigid surface and into the soft half space.
+  return std::make_unique<ContactSurface<T>>(
+      half_space_id, mesh_id, std::move(mesh_W), std::move(field_W),
+      std::move(grad_eS_W), nullptr);
 }
 
 template <typename T>
@@ -351,7 +366,8 @@ ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
     GeometryId id_S, const math::RigidTransform<T>& X_WS, double pressure_scale,
     GeometryId id_R, const TriangleSurfaceMesh<double>& mesh_R,
     const Bvh<Obb, TriangleSurfaceMesh<double>>& bvh_R,
-    const math::RigidTransform<T>& X_WR) {
+    const math::RigidTransform<T>& X_WR,
+    HydroelasticContactRepresentation representation) {
   std::vector<int> tri_indices;
   tri_indices.reserve(mesh_R.num_elements());
   auto bvh_callback = [&tri_indices, &mesh_R,
@@ -384,53 +400,90 @@ ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
   // sufficiently unit-length for our purposes.
   const PosedHalfSpace<T> hs_R{Sz_R, p_RSo, false /* needs_normalization */};
 
-  // TODO(SeanCurtis-TRI): Modify this to return the signed distances of all the
-  //  vertices. It will be cheaper than re-evaluating the signed distance for
-  //  every vertex just so I can compute the pressure. Alternatively, these
-  //  should take a functor for evaluating the pressure or some such thing.
-  //  This is a recurrent them in _all_ of the contact surface generating
-  //  methods.
-  std::unique_ptr<TriangleSurfaceMesh<T>> mesh_W =
-      ConstructSurfaceMeshFromMeshHalfspaceIntersection(mesh_R, hs_R,
-                                                        tri_indices, X_WR);
-
-  if (mesh_W == nullptr) return nullptr;
-
-  // Compute the pressure field
-  using std::min;
-  std::vector<T> vertex_pressures;
-  const PosedHalfSpace<T> hs_W{X_WR.rotation() * hs_R.normal(), X_WR * p_RSo};
-  vertex_pressures.reserve(mesh_W->num_vertices());
-  for (int v = 0; v < mesh_W->num_vertices(); ++v) {
-    const Vector3<T> p_WV = mesh_W->vertex(v);
+  auto calc_pressure_R = [&hs_R, pressure_scale](const Vector3<T>& p_RV) {
     // The signed distance of the point is the negative of the penetration
     // depth. We can use the pressure_scale to directly compute pressure at the
     // point.
-    const T phi_V = hs_W.CalcSignedDistance(p_WV);
-    vertex_pressures.push_back(-phi_V * pressure_scale);
+    const T phi_V = hs_R.CalcSignedDistance(p_RV);
+    return -phi_V * pressure_scale;
+  };
+
+  // The pressure gradient lies in the opposite direction of the half space
+  // normal.
+  const Vector3<T> grad_p_W = (-pressure_scale) * X_WS.rotation().col(2);
+
+  if (representation == HydroelasticContactRepresentation::kTriangle) {
+    return ComputeContactSurface<TriMeshBuilder<T>>(
+        id_R, mesh_R, id_S, hs_R, calc_pressure_R, grad_p_W, tri_indices, X_WR);
+  } else {
+    return ComputeContactSurface<PolyMeshBuilder<T>>(
+        id_R, mesh_R, id_S, hs_R, calc_pressure_R, grad_p_W, tri_indices, X_WR);
   }
-  auto field_W = std::make_unique<TriangleSurfaceMeshFieldLinear<T, T>>(
-      std::move(vertex_pressures), mesh_W.get(), false /* calc_gradient */);
-
-  // TODO(SeanCurtis-TRI) In this case, the gradient across the contact surface
-  //  is a constant. It would be good if we could exploit this and *not* copy
-  //  the same vector value once per triangle.
-  const Vector3<T>& unit_grad_p_W = X_WS.rotation().col(2);
-  auto grad_eS_W = std::make_unique<std::vector<Vector3<T>>>(
-      mesh_W->num_elements(), -pressure_scale * unit_grad_p_W);
-
-  // ConstructSurfaceMeshFromMeshHalfspaceIntersection() promises to make the
-  // face normals point out of the rigid surface and into the soft half space.
-  return std::make_unique<ContactSurface<T>>(id_S, id_R, std::move(mesh_W),
-                                             std::move(field_W),
-                                             std::move(grad_eS_W), nullptr);
 }
 
-DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
-    &ConstructTriangleHalfspaceIntersectionPolygon<T>,
-    &ConstructSurfaceMeshFromMeshHalfspaceIntersection<T>,
-    &ComputeContactSurfaceFromSoftHalfSpaceRigidMesh<T>
-))
+// We can't use the standard Drake macros for defining these because these
+// aren't templated purely on *scalar*; they are templated on mesh builder.
+
+template void
+ConstructTriangleHalfspaceIntersectionPolygon<TriMeshBuilder<double>>(
+    const TriangleSurfaceMesh<double>&, int, const PosedHalfSpace<double>&,
+    const std::function<double(const Vector3<double>&)>&,
+    const Vector3<double>&, const math::RigidTransform<double>&,
+    TriMeshBuilder<double>*, std::unordered_map<int, int>*,
+    std::unordered_map<SortedPair<int>, int>*);
+template void
+ConstructTriangleHalfspaceIntersectionPolygon<TriMeshBuilder<AutoDiffXd>>(
+    const TriangleSurfaceMesh<double>&, int, const PosedHalfSpace<AutoDiffXd>&,
+    const std::function<AutoDiffXd(const Vector3<AutoDiffXd>&)>&,
+    const Vector3<AutoDiffXd>&, const math::RigidTransform<AutoDiffXd>&,
+    TriMeshBuilder<AutoDiffXd>*, std::unordered_map<int, int>*,
+    std::unordered_map<SortedPair<int>, int>*);
+template void
+ConstructTriangleHalfspaceIntersectionPolygon<PolyMeshBuilder<double>>(
+    const TriangleSurfaceMesh<double>&, int, const PosedHalfSpace<double>&,
+    const std::function<double(const Vector3<double>&)>&,
+    const Vector3<double>&, const math::RigidTransform<double>&,
+    PolyMeshBuilder<double>*, std::unordered_map<int, int>*,
+    std::unordered_map<SortedPair<int>, int>*);
+template void
+ConstructTriangleHalfspaceIntersectionPolygon<PolyMeshBuilder<AutoDiffXd>>(
+    const TriangleSurfaceMesh<double>&, int, const PosedHalfSpace<AutoDiffXd>&,
+    const std::function<AutoDiffXd(const Vector3<AutoDiffXd>&)>&,
+    const Vector3<AutoDiffXd>&, const math::RigidTransform<AutoDiffXd>&,
+    PolyMeshBuilder<AutoDiffXd>*, std::unordered_map<int, int>*,
+    std::unordered_map<SortedPair<int>, int>*);
+
+template std::unique_ptr<ContactSurface<double>>
+ComputeContactSurface<TriMeshBuilder<double>>(
+    GeometryId, const TriangleSurfaceMesh<double>&, GeometryId,
+    const PosedHalfSpace<double>&,
+    const std::function<double(const Vector3<double>&)>&,
+    const Vector3<double>&, const std::vector<int>&,
+    const math::RigidTransform<double>&);
+template std::unique_ptr<ContactSurface<AutoDiffXd>>
+ComputeContactSurface<TriMeshBuilder<AutoDiffXd>>(
+    GeometryId, const TriangleSurfaceMesh<double>&, GeometryId,
+    const PosedHalfSpace<AutoDiffXd>&,
+    const std::function<AutoDiffXd(const Vector3<AutoDiffXd>&)>&,
+    const Vector3<AutoDiffXd>&, const std::vector<int>&,
+    const math::RigidTransform<AutoDiffXd>&);
+template std::unique_ptr<ContactSurface<double>>
+ComputeContactSurface<PolyMeshBuilder<double>>(
+    GeometryId, const TriangleSurfaceMesh<double>&, GeometryId,
+    const PosedHalfSpace<double>&,
+    const std::function<double(const Vector3<double>&)>&,
+    const Vector3<double>&, const std::vector<int>&,
+    const math::RigidTransform<double>&);
+template std::unique_ptr<ContactSurface<AutoDiffXd>>
+ComputeContactSurface<PolyMeshBuilder<AutoDiffXd>>(
+    GeometryId, const TriangleSurfaceMesh<double>&, GeometryId,
+    const PosedHalfSpace<AutoDiffXd>&,
+    const std::function<AutoDiffXd(const Vector3<AutoDiffXd>&)>&,
+    const Vector3<AutoDiffXd>&, const std::vector<int>&,
+    const math::RigidTransform<AutoDiffXd>&);
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    (&ComputeContactSurfaceFromSoftHalfSpaceRigidMesh<T>))
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/mesh_half_space_intersection.h
+++ b/geometry/proximity/mesh_half_space_intersection.h
@@ -20,7 +20,7 @@ namespace internal {
 /*
  Computes the intersection between a triangle and a half space.
  The intersecting geometry (e.g. vertices and triangles) are added to the
- provided collections. This method is intended to be used in contexts where
+ provided mesh builder. This method is intended to be used in contexts where
  zero area triangles and triangles coplanar with the half space boundary are
  unimportant (see note below).
 
@@ -30,9 +30,10 @@ namespace internal {
  We do not introduce any duplicate vertices (beyond those already in the input
  mesh). This function uses bookkeeping to prevent the addition of such
  duplicate vertices, which can be created when either a vertex lies inside/on
- the half space or when an edge intersects the half space. The method tracks
- these resultant vertices using `vertices_to_newly_created_vertices` and
- `edges_to_newly_created_vertices`, respectively.
+ the half space or when an edge intersects the boundary of the half space. The
+ method tracks these resultant vertices using
+ `vertices_to_newly_created_vertices` and `edges_to_newly_created_vertices`,
+ respectively.
 
  @param mesh_F
      The surface mesh to intersect, measured and expressed in Frame F.
@@ -40,18 +41,18 @@ namespace internal {
      The index of the triangle, drawn from `mesh_F` to intersect with the half
      space.
  @param half_space_F
-     The half space measured and expressed in Frame F.
+     The half space measured and expressed in the mesh's frame F.
+ @param pressure_in_F
+     A function that evaluates the pressure at a position X inside the half
+     space measured and expressed in the common frame F.
+ @param grad_pressure_in_W
+     The gradient of the pressure field, expressed in the world frame.
  @param X_WF
      The relative pose between Frame F and Frame W.
- @param[in,out] new_vertices_W
-     The accumulator for all of the vertices in the intersecting mesh. It should
-     be empty for the first call and will gradually accumulate all of the
-     vertices with each subsequent call to this method. The vertex positions are
-     measured and expressed in frame W.
- @param[in,out] new_faces
-     The accumulator for all of the faces in the intersecting mesh. It should be
-     empty for the first call and will gradually accumulate all of the faces
-     with each subsequent call to this method.
+ @param[in,out] builder_W
+     The mesh builder that will add the resulting intersecting polygon to the
+     mesh (along with sampled pressure values). The mesh being constructed has
+     vertex positions measured and expressed in the world frame.
  @param[in,out] vertices_to_newly_created_vertices
      The accumulated mapping from indices in `mesh_F.vertices()` to indices in
      `new_vertices_W`. It should be empty for the first call and will gradually
@@ -72,43 +73,66 @@ namespace internal {
        half space surface are innocuous (in hydroelastic contact, for example,
        both cases contribute nothing to the contact wrench).
 */
-template <typename T>
+template <typename MeshBuilder>
 void ConstructTriangleHalfspaceIntersectionPolygon(
     const TriangleSurfaceMesh<double>& mesh_F, int tri_index,
-    const PosedHalfSpace<T>& half_space_F, const math::RigidTransform<T>& X_WF,
-    std::vector<Vector3<T>>* new_vertices_W,
-    std::vector<SurfaceTriangle>* new_faces,
+    const PosedHalfSpace<typename MeshBuilder::ScalarType>& half_space_F,
+    const std::function<typename MeshBuilder::ScalarType(
+        const Vector3<typename MeshBuilder::ScalarType>&)>&
+        pressure_in_F,
+    const Vector3<typename MeshBuilder::ScalarType>& grad_pressure_in_W,
+    const math::RigidTransform<typename MeshBuilder::ScalarType>& X_WF,
+    MeshBuilder* builder_W,
     std::unordered_map<int, int>* vertices_to_newly_created_vertices,
     std::unordered_map<SortedPair<int>, int>* edges_to_newly_created_vertices);
 
 /*
- Computes a triangular surface mesh by intersecting a half space with a set of
- triangles drawn from the given surface mesh. The indicated triangles would
- typically be the result of broadphase culling.
+ Computes a ContactSurface between a half space and a collection of triangles
+ drawn from a triangle surface mesh. The indicated triangles would typically be
+ the result of broadphase culling.
 
- Each triangle in `mesh_W` is a proper subset of one triangle in `input_mesh_F`
- (i.e., fully contained within the triangle in `input_mesh_F`). As such,
- the face normal for each triangle in `mesh_W` will point in the same direction
- as its containing triangle in `input_mesh_F`.
+ Each face in the contact surface's mesh corresponds to one triangle in
+ `input_mesh_F` (although multiple contact surface faces may map to the same
+ input triangle based on the ContactSurface's mesh representation). The
+ correspondence is that the contact surface mesh face is always fully contained
+ by a single triangle in the input mesh. As such, the face normal for each face
+ in the contact surface mesh will point in the same direction as its
+ corresponding triangle's in `input_mesh_F`.
 
+ @param mesh_id
+     The identifier for the surface mesh.
  @param input_mesh_F
      The mesh with vertices measured and expressed in some frame, F.
+ @param half_space_id
+     The identifier for the half space.
  @param half_space_F
-     The half space measured and expressed in Frame F.
+     The half space measured and expressed in the common frame F.
+ @param pressure_in_F
+     A function that evaluates the pressure at a position X inside the half
+     space measured and expressed in the common frame F.
  @param tri_indices
      A collection of triangle indices in `input_mesh_F`.
  @param X_WF
      The relative pose of Frame F with the world frame W.
+ @param grad_p_W
+     The gradient of the half space's pressure field, expressed in the world
+     frame.
  @retval `mesh_W`, the TriangleSurfaceMesh corresponding to the intersection
          between the mesh and the half space; the vertices are measured and
          expressed in Frame W. `nullptr` if there is no intersection.
  */
-template <typename T>
-std::unique_ptr<TriangleSurfaceMesh<T>>
-ConstructSurfaceMeshFromMeshHalfspaceIntersection(
-    const TriangleSurfaceMesh<double>& input_mesh_F,
-    const PosedHalfSpace<T>& half_space_F, const std::vector<int>& tri_indices,
-    const math::RigidTransform<T>& X_WF);
+template <typename MeshBuilder>
+std::unique_ptr<ContactSurface<typename MeshBuilder::ScalarType>>
+ComputeContactSurface(
+    GeometryId mesh_id, const TriangleSurfaceMesh<double>& input_mesh_F,
+    GeometryId half_space_id,
+    const PosedHalfSpace<typename MeshBuilder::ScalarType>& half_space_F,
+    const std::function<typename MeshBuilder::ScalarType(
+        const Vector3<typename MeshBuilder::ScalarType>&)>&
+        pressure_in_F,
+    const Vector3<typename MeshBuilder::ScalarType>& grad_p_W,
+    const std::vector<int>& tri_indices,
+    const math::RigidTransform<typename MeshBuilder::ScalarType>& X_WF);
 
 /*
  Computes the ContactSurface formed by a soft half space and the given rigid
@@ -131,6 +155,8 @@ ConstructSurfaceMeshFromMeshHalfspaceIntersection(
                             mesh measured and expressed in Frame R.
  @param[in] X_WR            The relative pose between Frame R -- the frame the
                             mesh is defined in -- and the world frame W.
+ @param[in] representation  The preferred representation of each contact
+                            polygon.
  @returns `nullptr` if there is no collision, otherwise the ContactSurface
           between geometries S and R. Each triangle in the contact surface is a
           piece of a triangle in the input `mesh_R`; the normals of the former
@@ -144,7 +170,8 @@ ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
     GeometryId id_S, const math::RigidTransform<T>& X_WS, double pressure_scale,
     GeometryId id_R, const TriangleSurfaceMesh<double>& mesh_R,
     const Bvh<Obb, TriangleSurfaceMesh<double>>& bvh_R,
-    const math::RigidTransform<T>& X_WR);
+    const math::RigidTransform<T>& X_WR,
+    HydroelasticContactRepresentation representation);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/test/mesh_half_space_intersection_test.cc
+++ b/geometry/proximity/test/mesh_half_space_intersection_test.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/proximity/mesh_half_space_intersection.h"
 
+#include <functional>
 #include <limits>
 #include <memory>
 #include <utility>
@@ -82,183 +83,303 @@ TriangleSurfaceMesh<double> CreateBoxMesh(const RigidTransform<double>& X_FB) {
   return {move(faces), move(vertices_F)};
 }
 
-// Creates a new TriangleSurfaceMesh mesh from the given input mesh, such that
-// the resulting mesh has the same domain, but with two differences:
-//
-//   1. The vertices in the resultant mesh are measured and expressed in
-//      Frame W (as opposed to the input mesh's Frame F)
-//   2. Each triangle in the input mesh has been turned into three triangles;
-//      the original turned into a triangle fan around its centroid.
-// This method confirms that the face normal directions are preserved.
-template <typename T>
-static TriangleSurfaceMesh<double> CreateMeshWithCentroids(
-    const TriangleSurfaceMesh<double>& mesh_F, const RigidTransform<T>& X_WF) {
-  constexpr double kEps = 8 * std::numeric_limits<double>::epsilon();
-  const RigidTransform<double>& X_WF_d = convert_to_double(X_WF);
-
-  // All of the original vertices are part of the final mesh. And each face
-  // is a polygon we want to add to the new mesh. So, we copy the vertices
-  // and then simply add polygon after polygon.
-  std::vector<SurfaceTriangle> new_faces;
-  std::vector<Vector3d> new_vertices_W;
-  std::transform(mesh_F.vertices().begin(), mesh_F.vertices().end(),
-                 std::back_inserter(new_vertices_W),
-                 [&X_WF_d](const Vector3d& v_F) -> Vector3d {
-                   return X_WF_d * v_F;
-                 });
-
-  const RotationMatrix<double>& R_WF = X_WF_d.rotation();
-  for (int f_index = 0; f_index < mesh_F.num_triangles(); ++f_index) {
-    const SurfaceTriangle& f = mesh_F.element(f_index);
-    // We want to add the triangle fan for the existing face, but also want to
-    // confirm that the new faces have normals that match the input face.
-    std::vector<int> polygon{f.vertex(0), f.vertex(1), f.vertex(2)};
-    const Vector3d& nhat_W = R_WF * mesh_F.face_normal(f_index);
-    AddPolygonToTriangleMeshData(polygon, nhat_W, &new_faces, &new_vertices_W);
-
-    // Confirm polygon winding matches between source triangle and triangles
-    // in the new fan.
-    // The triangle fan consists of the last three faces in `new_faces`.
-    const int num_new_faces = static_cast<int>(new_faces.size());
-    const int first_new_face_index = num_new_faces - 3;
-    for (int j = first_new_face_index; j < num_new_faces; ++j) {
-      const SurfaceTriangle& new_face = new_faces[j];
-      const Vector3d& a = new_vertices_W[new_face.vertex(0)];
-      const Vector3d& b = new_vertices_W[new_face.vertex(1)];
-      const Vector3d& c = new_vertices_W[new_face.vertex(2)];
-      const Vector3d new_nhat_W = (b - a).cross((c - a)).normalized();
-      if (!CompareMatrices(nhat_W, new_nhat_W, kEps)) {
-        throw std::runtime_error("Derived mesh's normals are incorrect");
+// Given a triangle mesh expressed in frame F, creates a "contact surface mesh"
+// expressed in frame W. If the mesh representation is polygon, the triangles
+// are simply transformed into 3-sided polygons. If the mesh representation is
+// triangle, each triangle is tessellated around its centroid.
+template <typename MeshType>
+MeshType RexpressAsContactMesh(
+    const TriangleSurfaceMesh<double>& mesh_F,
+    const RigidTransform<typename MeshType::ScalarType>& X_WF) {
+  using T = typename MeshType::ScalarType;
+  vector<Vector3<T>> vertices_W;
+  vertices_W.reserve(mesh_F.num_vertices());
+  for (const auto& p_MV : mesh_F.vertices()) {
+    vertices_W.emplace_back(X_WF * p_MV.cast<T>());
+  }
+  if constexpr (std::is_same_v<MeshType, TriangleSurfaceMesh<T>>) {
+    vector<SurfaceTriangle> triangles;
+    triangles.reserve(mesh_F.num_triangles() * 3);
+    vector<int> polygon(8);
+    for (int t_index = 0; t_index < mesh_F.num_triangles(); ++t_index) {
+      const auto& tri = mesh_F.element(t_index);
+      polygon.clear();
+      polygon.push_back(tri.vertex(0));
+      polygon.push_back(tri.vertex(1));
+      polygon.push_back(tri.vertex(2));
+      const Vector3<T>& nhat_W =
+          X_WF.rotation() * mesh_F.face_normal(t_index).cast<T>();
+      AddPolygonToTriangleMeshData(polygon, nhat_W, &triangles, &vertices_W);
+    }
+    return {move(triangles), move(vertices_W)};
+  } else {
+    vector<int> face_data;
+    face_data.reserve(mesh_F.num_triangles() * 4);
+    for (const auto& tri : mesh_F.triangles()) {
+      face_data.push_back(3);
+      for (int i = 0; i < 3; ++i) {
+        face_data.push_back(tri.vertex(i));
       }
     }
+    return {move(face_data), move(vertices_W)};
   }
-
-  return TriangleSurfaceMesh<double>(move(new_faces), move(new_vertices_W));
 }
 
+
+// TODO(SeanCurtis-TRI): All of the tests where we actually examine the mesh
+//  use a mesh with a _single_ triangle. In this case, the face-local index
+//  values are perfectly aligned with the mesh-local index values. This hides
+//  potential errors where the two sets of indices do _not_ align so nicely.
+//  One potential solution is to simply insert an additional vertex in the mesh
+//  that isn't referenced so the face isn't built on (0, 1, 2), but (1, 2, 3).
+//
 // Creates a TriangleSurfaceMesh with a single triangle using the given
 // vertices.
 TriangleSurfaceMesh<double> CreateOneTriangleMesh(const Vector3d& v0,
-                                          const Vector3d& v1,
-                                          const Vector3d& v2) {
+                                                  const Vector3d& v1,
+                                                  const Vector3d& v2) {
   std::vector<Vector3d> vertices{{v0, v1, v2}};
-
   std::vector<SurfaceTriangle> faces{{0, 1, 2}};
-
   return TriangleSurfaceMesh<double>(move(faces), move(vertices));
 }
+
+// Helper for getting the appropriate mesh builder from an expected mesh type.
+template <typename MeshType>
+struct BuilderTypeFromMesh {};
+
+template <typename T>
+struct BuilderTypeFromMesh<TriangleSurfaceMesh<T>> {
+ public:
+  using Type = TriMeshBuilder<T>;
+};
+
+template <typename T>
+struct BuilderTypeFromMesh<PolygonSurfaceMesh<T>> {
+ public:
+  using Type = PolyMeshBuilder<T>;
+};
 
 /* This test evaluates the *values* of the mesh-half space intersection
  algorithm for all supported scalars (double and AutoDiffXd). The derivatives
  for AutoDiffXd are tested below. */
-template <typename T>
+template <typename MeshType>
 class MeshHalfSpaceValueTest : public ::testing::Test {
  public:
+  // Using the symbol T here wreaks havoc with trying to use that same symbol
+  // in the classes in the derived types: shadow warnings. So, we'll simply
+  // distinguish names.
+  using Scalar = typename MeshType::ScalarType;
+
   // Accessors for data structures used repeatedly.
-  std::vector<Vector3<T>>& new_vertices_W() { return new_vertices_W_; }
-  std::vector<SurfaceTriangle>& new_faces() { return new_faces_; }
   std::unordered_map<int, int>& vertices_to_newly_created_vertices() {
     return vertices_to_newly_created_vertices_;
   }
   std::unordered_map<SortedPair<int>, int>& edges_to_newly_created_vertices() {
     return edges_to_newly_created_vertices_;
   }
-
-  // Checks whether two faces from two meshes are equivalent, which we define
-  // to mean as some permutation of acceptable windings for the vertices of
-  // `fb` yields vertices coincident with those of `fa`.
-  bool AreFacesEquivalent(const SurfaceTriangle& fa,
-                          const TriangleSurfaceMesh<double>& mesh_a,
-                          const SurfaceTriangle& fb,
-                          const TriangleSurfaceMesh<T>& mesh_b) {
-    constexpr double kEps = 32 * std::numeric_limits<double>::epsilon();
-    // Get the three vertices from each.
-    std::array<Vector3d, 3> vertices_a = {mesh_a.vertex(fa.vertex(0)),
-                                          mesh_a.vertex(fa.vertex(1)),
-                                          mesh_a.vertex(fa.vertex(2))};
-    std::array<Vector3<T>, 3> vertices_b = {mesh_b.vertex(fb.vertex(0)),
-                                            mesh_b.vertex(fb.vertex(1)),
-                                            mesh_b.vertex(fb.vertex(2))};
-
-    // Set an array of faces that will be used to determine how the two
-    // triangles align. Each of these faces encodes an "acceptable" triangle
-    // winding. They are "acceptable" because they represent triangles with the
-    // same winding and, therefore, the same normal.
-    std::array<SurfaceTriangle, 3> permutations = {SurfaceTriangle(0, 1, 2),
-                                                   SurfaceTriangle(1, 2, 0),
-                                                   SurfaceTriangle(2, 0, 1)};
-
-    // Verify that at least one of the permutations gives essentially the
-    // vertices from fb. We use epsilon because the centroid vertex may have
-    // rounding error in it.
-    using std::min;
-    T closest_dist = std::numeric_limits<T>::max();
-    for (const auto& face : permutations) {
-      T dist = 0;
-      for (int i = 0; i < 3; ++i)
-        dist += (vertices_a[face.vertex(i)] - vertices_b[i]).norm();
-      closest_dist = min(closest_dist, dist);
-      if (closest_dist <= kEps) break;
-    }
-
-    return closest_dist <= kEps;
+  typename BuilderTypeFromMesh<MeshType>::Type& builder_W() {
+    return builder_W_;
   }
 
-  // Checks whether two meshes are equivalent, meaning that there is a bijective
-  // mapping from every face in mesh a to every face in mesh b. A mapping
-  // between faces can only exist if the face in a is considered equivalent to
-  // the corresponding face in b -- see AreFacesEquivalent().
-  void VerifyMeshesEquivalent(const TriangleSurfaceMesh<double>& mesh_a,
-                              const TriangleSurfaceMesh<T>& mesh_b) {
+  // Checks whether two faces (identified by their indices) from two meshes are
+  // equivalent, which we define to mean as some permutation of acceptable
+  // windings for the vertices of `fb` yields vertices coincident with those of
+  // `fa`.
+  bool AreFacesEquivalent(int a,
+                          const MeshType& mesh_a,
+                          int b,
+                          const MeshType& mesh_b) {
+    const auto& fa = mesh_a.element(a);
+    const auto& fb = mesh_b.element(b);
+    if (fa.num_vertices() != fb.num_vertices()) return false;
+
+    // Verify that there exists a valid rotation that aligns the vertices in fa
+    // and fb. A "rotation" between two ordered lists is a permutation in which
+    // the position of every element in one list is a constant, fixed offset
+    // from its position in the other (with periodic boundary conditions). For
+    // a given rotation, the ith vertex in each face "align" if the vertices
+    // are coincident (to within epsilon units of distance).
+    const int num_vertices = fa.num_vertices();
+    constexpr double kEps = 32 * std::numeric_limits<double>::epsilon();
+    constexpr double kEps2 = kEps * kEps;
+    // For N vertices, there are N valid rotations.
+    for (int rotation = 0; rotation < num_vertices; ++rotation) {
+      bool match = true;
+      for (int a_i = 0; a_i < num_vertices; ++a_i) {
+        const int b_i = (a_i + rotation) % num_vertices;
+        if ((mesh_a.vertex(fa.vertex(a_i)) - mesh_b.vertex(fb.vertex(b_i)))
+                .squaredNorm() > kEps2) {
+          match = false;
+          break;
+        }
+      }
+      if (match) return true;
+    }
+
+    return false;
+  }
+
+  // Calling CallConstructTriangleHalfspaceIntersectionPolygon() produces a mesh
+  // and field. This confirms that the resulting test mesh is equivalent to an
+  // expected mesh. Specifically:
+  //
+  //   - The meshes must:
+  //     - have the same number of vertices (permuted order is allowed).
+  //     - have the same number of faces (again, permuted order is allowed)
+  //       - There must be a 1-to-1 correspondence between mesh faces in that
+  //         they span the same surface (but possibly with "rotated" vertex
+  //         ordering).
+  ::testing::AssertionResult MeshesEquivalent(const MeshType& test_mesh_W,
+                                              const MeshType& expected_mesh_W) {
     // Simple checks first.
-    ASSERT_EQ(mesh_a.num_triangles(), mesh_b.num_triangles());
-    ASSERT_EQ(mesh_a.num_vertices(), mesh_b.num_vertices());
+    if (test_mesh_W.num_elements() != expected_mesh_W.num_elements()) {
+      return ::testing::AssertionFailure()
+             << "Mismatch in face count. Test has "
+             << test_mesh_W.num_elements() << " faces; expected "
+             << expected_mesh_W.num_elements();
+    }
+    if (test_mesh_W.num_vertices() != expected_mesh_W.num_vertices()) {
+      return ::testing::AssertionFailure()
+             << "Mismatch in vertex count. Test has "
+             << test_mesh_W.num_vertices() << " vertices; expected "
+             << expected_mesh_W.num_vertices();
+    }
 
     // Iterate through each face of the first mesh, looking for a face from the
     // second mesh that is within the given tolerance. This is a quadratic
     // time algorithm (in the number of faces of the meshes) but we expect the
     // number of faces that this algorithm is run on to be small.
-    std::vector<SurfaceTriangle> faces_from_mesh_b = mesh_b.triangles();
-    for (const SurfaceTriangle& f1 : mesh_a.triangles()) {
+    const int face_count = test_mesh_W.num_elements();
+    vector<int> unmatched_from_expected(face_count);
+    std::iota(unmatched_from_expected.begin(), unmatched_from_expected.end(),
+              0);
+    for (int i = 0; i < face_count; ++i) {
       bool found_match = false;
-      for (int i = 0; i < static_cast<int>(faces_from_mesh_b.size()); ++i) {
-        if (AreFacesEquivalent(f1, mesh_a, faces_from_mesh_b[i], mesh_b)) {
+      for (int j : unmatched_from_expected) {
+        if (AreFacesEquivalent(i, test_mesh_W, j, expected_mesh_W)) {
           found_match = true;
-          faces_from_mesh_b[i] = faces_from_mesh_b.back();
-          faces_from_mesh_b.pop_back();
+          // Modifying the vector during range iteration is ok, because this
+          // modifications triggers dropping out of the iteration.
+          unmatched_from_expected[j] = unmatched_from_expected.back();
+          unmatched_from_expected.pop_back();
           break;
         }
       }
-
-      // If this test fails, it may fail catastrophically badly such that no two
-      // faces match between the meshes. We don't want to spew *all* the
-      // failures. The first is sufficient.
-      ASSERT_TRUE(found_match)
-          << "At least one face failed to match; there may be more.";
+      // One unmatched element is sufficient to stop the test with failure.
+      if (!found_match) {
+        return ::testing::AssertionFailure()
+               << "At least one face in the test mesh failed to match to a "
+                  "face in the expected mesh; there may be more.";
+      }
     }
+
+    return ::testing::AssertionSuccess();
+  }
+
+  // Calling CallConstructTriangleHalfspaceIntersectionPolygon() produces a mesh
+  // and field. This tests the resulting mesh field against this test fixture's
+  // pressure field. Specifically:
+  //
+  //   - The field must:
+  //     - report the same per-vertex pressure as when evaluating this fixture's
+  //       pressure_in_F_.
+  //     - The gradient on each element is equal to this fixture's grad_p_F_.
+  //     - For each face, given two vertices on that face, the following must be
+  //       true:
+  //           (p(V0) + p(V1)) / 2 = p((V0 + V1) / 2)
+  //       In other words, we're making sure the field value on the interior is
+  //       a linear function consistent with the per-vertex values.
+  ::testing::AssertionResult FieldConsistent(const MeshType& test_mesh_W,
+                    const MeshFieldLinear<Scalar, MeshType>& test_field_W,
+                    const RigidTransform<Scalar>& X_WF) {
+    using std::abs;
+    const RigidTransform<Scalar> X_FW = X_WF.inverse();
+
+    // This pressure test seems to need a bit more error tolerance. While it's
+    // still an acceptable order of magnitude, some investigation as to why
+    // this is would be beneficial.
+    constexpr double kPressureEps = 3e-14;
+    for (int v = 0; v < test_mesh_W.num_vertices(); ++v) {
+      const Scalar test_pressure = test_field_W.EvaluateAtVertex(v);
+      const Vector3<Scalar> p_FV = X_FW * test_mesh_W.vertex(v);
+      const Scalar expected_pressure = pressure_in_F_(p_FV);
+      const Scalar error = abs(test_pressure - expected_pressure);
+      if (error > kPressureEps) {
+        return ::testing::AssertionFailure()
+               << "\nBad pressure field value at vertex " << v << "\n"
+               << "  Expected: " << expected_pressure << "\n"
+               << "  Found: " << test_pressure << "\n"
+               << "  tolerance: " << kPressureEps << "\n"
+               << "  error: " << error;
+      }
+    }
+
+    // We don't store/compute the gradients of the field for
+    // TriangleSurfaceMesh. Given the algorithm would produce them
+    // automatically, if we choose to do so for the triangle mesh, we could
+    // remove the compilation guard here.
+    if (std::is_same_v<MeshType, PolygonSurfaceMesh<Scalar>>) {
+      const Vector3<Scalar> grad_p_W = X_WF.rotation() * grad_p_F_;
+      for (int f = 0; f < test_mesh_W.num_elements(); ++f) {
+        auto result =
+            CompareMatrices(test_field_W.EvaluateGradient(f), grad_p_W);
+        if (!result) return result << "\nOn face " << f;
+      }
+    }
+
+    for (int f = 0; f < test_mesh_W.num_elements(); ++f) {
+      const auto& face = test_mesh_W.element(f);
+      const Vector3<Scalar>& p_WV0 = test_mesh_W.vertex(face.vertex(0));
+      const Vector3<Scalar>& p_WV1 = test_mesh_W.vertex(face.vertex(1));
+      const Vector3<Scalar> p_WX = (p_WV0 + p_WV1) / 2;
+      const Scalar p_0 = test_field_W.EvaluateAtVertex(face.vertex(0));
+      const Scalar p_1 = test_field_W.EvaluateAtVertex(face.vertex(1));
+      const Scalar p_X_expected = (p_0 + p_1) / 2;
+      const Scalar p_X_test = test_field_W.EvaluateCartesian(f, p_WX);
+      const Scalar error = (p_X_test - p_X_expected);
+      if (error > kPressureEps) {
+        return ::testing::AssertionFailure()
+               << "\nMesh face " << f
+               << " failed to provide the correct pressure for a point on the "
+                  "inside of the face: " << p_WX.transpose() << ".\n"
+               << "  Expected: " << p_X_expected << "\n"
+               << "  Found: " << p_X_test << "\n"
+               << "  tolerance: " << kPressureEps << "\n"
+               << "  error: " << error;
+      }
+    }
+
+    return ::testing::AssertionSuccess();
   }
 
   // Clears all data structures used for constructing the intersection.
   void ClearConstructionDataStructures() {
-    new_vertices_W().clear();
-    new_faces().clear();
-    vertices_to_newly_created_vertices().clear();
-    edges_to_newly_created_vertices().clear();
+    builder_W_ = typename BuilderTypeFromMesh<MeshType>::Type();
+    vertices_to_newly_created_vertices_.clear();
+    edges_to_newly_created_vertices_.clear();
   }
 
-  // Calls the triangle-half space intersection routine using this object's
-  // half space as well as the test harness's built-in mesh and construction
-  // data structures. The vertices of the final answer will be expressed in the
-  // world frame based on the given relative pose between mesh frame F and
-  // world frame W.
+  // Calls the triangle-half space intersection routine between the test
+  // fixture's half space and the provided mesh (measured and expressed in frame
+  // F). The resulting builder data are measured and expressed in the world
+  // frame (courtesy of the X_WF value).
+  //
+  // The contact mesh and field are built by iteratively invoking
+  // ConstructTriangleHalfSpaceIntersectionPolygon() on *every* triangle of the
+  // mesh. It uses this test fixture's caching data structures (which can be
+  // inspected after the call).
+  //
+  // Each call starts with an empty mesh builder and empty cache data
+  // structures.
   void CallConstructTriangleHalfspaceIntersectionPolygon(
-      const TriangleSurfaceMesh<double>& mesh_F, const RigidTransform<T> X_WF) {
+      const TriangleSurfaceMesh<double>& mesh_F,
+      const RigidTransform<Scalar> X_WF) {
     ClearConstructionDataStructures();
-    for (int f_index = 0; f_index < mesh_F.num_elements();
-         ++f_index) {
+    const Vector3<Scalar> grad_p_W = X_WF.rotation() * this->grad_p_F_;
+    for (int f_index = 0; f_index < mesh_F.num_elements(); ++f_index) {
       ConstructTriangleHalfspaceIntersectionPolygon(
-          mesh_F, f_index, *this->half_space_F_, X_WF, &this->new_vertices_W_,
-          &this->new_faces_, &this->vertices_to_newly_created_vertices_,
+          mesh_F, f_index, *this->half_space_F_, this->pressure_in_F_, grad_p_W,
+          X_WF, &this->builder_W_, &this->vertices_to_newly_created_vertices_,
           &this->edges_to_newly_created_vertices_);
     }
   }
@@ -267,23 +388,35 @@ class MeshHalfSpaceValueTest : public ::testing::Test {
   void SetUp() {
     // The tests all use half space normal [0 0 1], with point [0 0 2]
     // lying on the half space.
-    Vector3<T> normal_H(0, 0, 1);
-    const Vector3<T> point_H(0, 0, 2);
-    half_space_F_ = std::make_unique<PosedHalfSpace<T>>(normal_H, point_H);
+    Vector3<Scalar> normal_F(0, 0, 1);
+    const Vector3<Scalar> point_F(0, 0, 2);
+    half_space_F_ = std::make_unique<PosedHalfSpace<Scalar>>(normal_F, point_F);
+    // Define the half space's pressure field with arbitrary pressure "scale",
+    // but make sure it is zero on the surface.
+    pressure_scale_ = 17;
+    grad_p_F_ = -pressure_scale_ * normal_F;
+    pressure_in_F_ = [grad_p_F = grad_p_F_,
+                      point_F](const Vector3<Scalar>& p_VF) {
+      return grad_p_F.dot(p_VF - point_F);
+    };
   }
 
-  std::vector<Vector3<T>> new_vertices_W_;
-  std::vector<SurfaceTriangle> new_faces_;
+  typename BuilderTypeFromMesh<MeshType>::Type builder_W_;
   std::unordered_map<int, int> vertices_to_newly_created_vertices_;
   std::unordered_map<SortedPair<int>, int> edges_to_newly_created_vertices_;
   // In this test harness, the half space is always simply defined in the
   // mesh's frame F.
-  std::unique_ptr<PosedHalfSpace<T>> half_space_F_;
+  std::unique_ptr<PosedHalfSpace<Scalar>> half_space_F_;
+  double pressure_scale_;
+  Vector3<Scalar> grad_p_F_;
+  std::function<Scalar(const Vector3<Scalar>&)> pressure_in_F_;
 };  // namespace
+
 TYPED_TEST_SUITE_P(MeshHalfSpaceValueTest);
 
 // Verifies that a triangle that lies fully outside of the half space yields an
-// empty intersection. This covers Case 4 in the code.
+// empty intersection. This covers Case 4 in the code. This code is agnostic
+// of the MeshBuilder type, so we simply execute it with a PolyMeshBuilder.
 TYPED_TEST_P(MeshHalfSpaceValueTest, NoIntersection) {
   // Create the mesh, constructing the vertices of the triangle to lie outside
   // the half space.
@@ -293,8 +426,7 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, NoIntersection) {
   // X_WF = I -- because there is no intersection, the frame of the
   // non-existent intersection mesh is irrelevant.
   this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, {});
-  EXPECT_TRUE(this->new_vertices_W().empty());
-  EXPECT_TRUE(this->new_faces().empty());
+  EXPECT_EQ(this->builder_W().num_faces(), 0);
   EXPECT_TRUE(this->vertices_to_newly_created_vertices().empty());
   EXPECT_TRUE(this->edges_to_newly_created_vertices().empty());
 }
@@ -302,7 +434,8 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, NoIntersection) {
 // Verifies that a triangle that lies inside or on the half space yields
 // that same triangle. This covers Case 1 in the code.
 TYPED_TEST_P(MeshHalfSpaceValueTest, InsideOrOnIntersection) {
-  using T = TypeParam;
+  using MeshType = TypeParam;
+  using T = typename MeshType::ScalarType;
 
   // An arbitrary relationship between Frames W and F -- avoiding additive and
   // multiplicative identities.
@@ -311,38 +444,35 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, InsideOrOnIntersection) {
           AngleAxis<T>{M_PI / 7, Vector3<T>{1, 2, 3}.normalized()}),
       Vector3<T>{-0.25, 0.5, 0.75});
 
-  // Case: The triangular mesh lies well inside the half space.
+  // Case: The triangular mesh lies *completely* inside the half space.
   {
-    const TriangleSurfaceMesh<double> mesh_F = CreateOneTriangleMesh(
+    // Because the mesh is wholly contained within the half space, the contact
+    // mesh is the same mesh, just re-expressed in the world frame. Remember,
+    // the half space is Fz <= 2. So, putting these triangles at Fz = 1,
+    // they'll lie inside.
+    const TriangleSurfaceMesh<double> tri_mesh_F = CreateOneTriangleMesh(
         Vector3d(3, 5, 1), Vector3d(4, 5, 1), Vector3d(3, 6, 1));
 
-    this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, X_WF);
+    this->CallConstructTriangleHalfspaceIntersectionPolygon(tri_mesh_F, X_WF);
+    auto [mesh_W, field_W] = this->builder_W().MakeMeshAndField();
 
-    std::unique_ptr<TriangleSurfaceMesh<double>> expected_mesh_W;
-    expected_mesh_W = std::make_unique<TriangleSurfaceMesh<double>>(
-        CreateMeshWithCentroids(mesh_F, X_WF));
-    // Verify the intersection.
-    SCOPED_TRACE("Single triangle inside half space");
-    this->VerifyMeshesEquivalent(
-        *expected_mesh_W, TriangleSurfaceMesh<T>{move(this->new_faces()),
-                                                 move(this->new_vertices_W())});
+    auto expected_mesh_W = RexpressAsContactMesh<MeshType>(tri_mesh_F, X_WF);
+    EXPECT_TRUE(this->MeshesEquivalent(*mesh_W, expected_mesh_W));
+    EXPECT_TRUE(this->FieldConsistent(*mesh_W, *field_W, X_WF));
   }
 
   // Case: triangle lies on the boundary plane.
   {
-    const TriangleSurfaceMesh<double> mesh_F = CreateOneTriangleMesh(
+    // This triangle is located at Fz = 2, so it lies exactly on the boundary.
+    const TriangleSurfaceMesh<double> tri_mesh_F = CreateOneTriangleMesh(
         Vector3d(3, 5, 2), Vector3d(4, 5, 2), Vector3d(3, 6, 2));
 
-    this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, X_WF);
+    this->CallConstructTriangleHalfspaceIntersectionPolygon(tri_mesh_F, X_WF);
+    auto [mesh_W, field_W] = this->builder_W().MakeMeshAndField();
 
-    std::unique_ptr<TriangleSurfaceMesh<double>> expected_mesh_W;
-    expected_mesh_W = std::make_unique<TriangleSurfaceMesh<double>>(
-        CreateMeshWithCentroids(mesh_F, X_WF));
-    SCOPED_TRACE("Single triangle on half space boundary");
-    // Verify the intersection.
-    this->VerifyMeshesEquivalent(
-        *expected_mesh_W, TriangleSurfaceMesh<T>{move(this->new_faces()),
-                                                 move(this->new_vertices_W())});
+    auto expected_mesh_W = RexpressAsContactMesh<MeshType>(tri_mesh_F, X_WF);
+    EXPECT_TRUE(this->MeshesEquivalent(*mesh_W, expected_mesh_W));
+    EXPECT_TRUE(this->FieldConsistent(*mesh_W, *field_W, X_WF));
   }
 
   // Case: two triangles with a shared edge, completely enclosed in the half
@@ -351,18 +481,15 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, InsideOrOnIntersection) {
     std::vector<Vector3d> vertices = {Vector3d(4, 5, 2), Vector3d(3, 5, 2),
                                       Vector3d(3, 5, 1), Vector3d(2, 5, 2)};
     std::vector<SurfaceTriangle> faces{{0, 1, 2}, {2, 1, 3}};
-    const TriangleSurfaceMesh<double> mesh_F(move(faces), move(vertices));
+    const TriangleSurfaceMesh<double> tri_mesh_F(move(faces), move(vertices));
 
     // Verify the intersection.
-    this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, X_WF);
+    this->CallConstructTriangleHalfspaceIntersectionPolygon(tri_mesh_F, X_WF);
+    auto [mesh_W, field_W] = this->builder_W().MakeMeshAndField();
 
-    std::unique_ptr<TriangleSurfaceMesh<double>> expected_mesh_W;
-    expected_mesh_W = std::make_unique<TriangleSurfaceMesh<double>>(
-        CreateMeshWithCentroids(mesh_F, X_WF));
-    SCOPED_TRACE("Two triangles inside half space");
-    this->VerifyMeshesEquivalent(
-        *expected_mesh_W, TriangleSurfaceMesh<T>{move(this->new_faces()),
-                                                 move(this->new_vertices_W())});
+    auto expected_mesh_W = RexpressAsContactMesh<MeshType>(tri_mesh_F, X_WF);
+    EXPECT_TRUE(this->MeshesEquivalent(*mesh_W, expected_mesh_W));
+    EXPECT_TRUE(this->FieldConsistent(*mesh_W, *field_W, X_WF));
   }
 }
 
@@ -372,7 +499,8 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, InsideOrOnIntersection) {
 // triangle (if the other two vertices lie within the half space). This
 // covers Case 3 for (a) and Case 1 for (b).
 TYPED_TEST_P(MeshHalfSpaceValueTest, VertexOnHalfspaceIntersection) {
-  using T = TypeParam;
+  using MeshType = TypeParam;
+  using T = typename MeshType::ScalarType;
 
   // An arbitrary relationship between Frames W and F -- avoiding additive and
   // multiplicative identities.
@@ -383,52 +511,51 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, VertexOnHalfspaceIntersection) {
 
   // Case: (a) one vertex on the boundary, two vertices outside.
   {
-    const TriangleSurfaceMesh<double> mesh_F = CreateOneTriangleMesh(
+    const TriangleSurfaceMesh<double> tri_mesh_F = CreateOneTriangleMesh(
         Vector3d(3, 5, 2), Vector3d(4, 5, 3), Vector3d(3, 6, 3));
 
     // Verify the degenerate intersection.
-    this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, X_WF);
+    this->CallConstructTriangleHalfspaceIntersectionPolygon(tri_mesh_F, X_WF);
+    auto [mesh_W, field_W] = this->builder_W().MakeMeshAndField();
 
-    EXPECT_EQ(this->new_vertices_W().size(), 4);
-    EXPECT_EQ(this->new_faces().size(), 3);
-    // Evidence that we copied one vertex and split two edges.
+    if constexpr (std::is_same_v<MeshType, TriangleSurfaceMesh<T>>) {
+        EXPECT_EQ(mesh_W->num_vertices(), 4);
+        EXPECT_EQ(mesh_W->num_elements(), 3);
+    } else {
+        EXPECT_EQ(mesh_W->num_vertices(), 3);
+        EXPECT_EQ(mesh_W->num_elements(), 1);
+    }
+    // Evidence that when computing the intersecting _polygon_, we copied one
+    // vertex and split two edges.
     EXPECT_EQ(this->vertices_to_newly_created_vertices().size(), 1);
     EXPECT_EQ(this->edges_to_newly_created_vertices().size(), 2);
 
-    // Check that the mesh that results is equivalent to the expected
-    // degenerate mesh. The degenerate mesh is a triangle fan around a
-    // centroid. We model the degeneracy as four identical vertices with
-    // the appropriate face topologies.
-    const RigidTransform<double>& X_WF_d = convert_to_double(X_WF);
-    std::vector<Vector3d> expected_vertices_W = {
-        X_WF_d * Vector3d(3, 5, 2), X_WF_d * Vector3d(3, 5, 2),
-        X_WF_d * Vector3d(3, 5, 2), X_WF_d * Vector3d(3, 5, 2)};
-    std::vector<SurfaceTriangle> expected_faces = {SurfaceTriangle(0, 1, 3),
-                                                   SurfaceTriangle(1, 2, 3),
-                                                   SurfaceTriangle(2, 0, 3)};
-    const TriangleSurfaceMesh<double> expected_mesh_W(
-        move(expected_faces), move(expected_vertices_W));
-    const TriangleSurfaceMesh<T> actual_mesh_W(move(this->new_faces()),
-                                               move(this->new_vertices_W()));
-    SCOPED_TRACE("Triangle outside half space has single vertex on the plane");
-    this->VerifyMeshesEquivalent(expected_mesh_W, actual_mesh_W);
+    // Confirm degeneracy: areas are close to zero, and vertices are close to
+    // vertex 0 in tri_mesh_F.
+    for (int f = 0; f < mesh_W->num_elements(); ++f) {
+      EXPECT_NEAR(ExtractDoubleOrThrow(mesh_W->area(f)), 0, 1e-15);
+    }
+    // The reference vertex.
+    const Vector3<T> p_WR = X_WF * tri_mesh_F.vertex(0).cast<T>();
+    for (int v = 0; v < mesh_W->num_vertices(); ++v) {
+      EXPECT_NEAR(ExtractDoubleOrThrow((mesh_W->vertex(v) - p_WR).norm()), 0,
+                  1e-15);
+      EXPECT_NEAR(ExtractDoubleOrThrow(field_W->EvaluateAtVertex(v)), 0, 1e-15);
+    }
   }
 
   // Case: (b) one vertex on the boundary, two vertices inside.
   {
-    const TriangleSurfaceMesh<double> mesh_F = CreateOneTriangleMesh(
+    const TriangleSurfaceMesh<double> tri_mesh_F = CreateOneTriangleMesh(
         Vector3d(3, 5, 2), Vector3d(4, 5, 1), Vector3d(3, 6, 1));
 
     // Verify the intersection.
-    this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, X_WF);
+    this->CallConstructTriangleHalfspaceIntersectionPolygon(tri_mesh_F, X_WF);
+    auto [mesh_W, field_W] = this->builder_W().MakeMeshAndField();
 
-    std::unique_ptr<TriangleSurfaceMesh<double>> expected_mesh_W;
-    expected_mesh_W = std::make_unique<TriangleSurfaceMesh<double>>(
-        CreateMeshWithCentroids(mesh_F, X_WF));
-    SCOPED_TRACE("Triangle inside half space has single vertex on the plane");
-    this->VerifyMeshesEquivalent(
-        *expected_mesh_W, TriangleSurfaceMesh<T>{move(this->new_faces()),
-                                                 move(this->new_vertices_W())});
+    auto expected_mesh_W = RexpressAsContactMesh<MeshType>(tri_mesh_F, X_WF);
+    EXPECT_TRUE(this->MeshesEquivalent(*mesh_W, expected_mesh_W));
+    EXPECT_TRUE(this->FieldConsistent(*mesh_W, *field_W, X_WF));
   }
 }
 
@@ -438,7 +565,8 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, VertexOnHalfspaceIntersection) {
 // triangle (if the other vertex lies within the half space). This covers
 // Case 2 for (a) and Case 1 for (b).
 TYPED_TEST_P(MeshHalfSpaceValueTest, EdgeOnHalfspaceIntersection) {
-  using T = TypeParam;
+  using MeshType = TypeParam;
+  using T = typename MeshType::ScalarType;
 
   // An arbitrary relationship between Frames W and F -- avoiding additive and
   // multiplicative identities.
@@ -449,13 +577,21 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, EdgeOnHalfspaceIntersection) {
 
   // Case: (a) two vertices on the boundary, one outside.
   {
-    const TriangleSurfaceMesh<double> mesh_F = CreateOneTriangleMesh(
+    const TriangleSurfaceMesh<double> tri_mesh_F = CreateOneTriangleMesh(
         Vector3d(3, 5, 3), Vector3d(2, 5, 2), Vector3d(4, 5, 2));
 
-    this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, X_WF);
+    this->CallConstructTriangleHalfspaceIntersectionPolygon(tri_mesh_F, X_WF);
+    auto [mesh_W, field_W] = this->builder_W().MakeMeshAndField();
 
-    EXPECT_EQ(this->new_vertices_W().size(), 5);
-    EXPECT_EQ(this->new_faces().size(), 4);
+    if constexpr (std::is_same_v<MeshType, TriangleSurfaceMesh<T>>) {
+        EXPECT_EQ(mesh_W->num_vertices(), 5);
+        EXPECT_EQ(mesh_W->num_elements(), 4);
+    } else {
+        EXPECT_EQ(mesh_W->num_vertices(), 4);
+        EXPECT_EQ(mesh_W->num_elements(), 1);
+    }
+    // Evidence that when computing the intersecting _polygon_, we copied two
+    // vertices and split two edges.
     EXPECT_EQ(this->vertices_to_newly_created_vertices().size(), 2);
     EXPECT_EQ(this->edges_to_newly_created_vertices().size(), 2);
 
@@ -473,49 +609,47 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, EdgeOnHalfspaceIntersection) {
     // and d, respectively. The resulting contact polygon is a zero-area quad
     // over vertices b, e, c, & d. The final triangle fan is formed around the
     // centroid f.
-
-    // Check that the mesh that results is equivalent to the expected
-    // degenerate mesh.
-    const RigidTransform<double>& X_WF_d = convert_to_double(X_WF);
-    std::vector<Vector3d> expected_vertices = {
-        X_WF_d * Vector3d(2, 5, 2), X_WF_d * Vector3d(4, 5, 2),
-        X_WF_d * Vector3d(4, 5, 2), X_WF_d * Vector3d(2, 5, 2),
-        X_WF_d * Vector3d(3, 5, 2)};
-    const int b{0}, c{1}, d{2}, e{3}, f{4};
-    std::vector<SurfaceTriangle> expected_faces = {
-        SurfaceTriangle(b, c, f), SurfaceTriangle(c, d, f),
-        SurfaceTriangle(d, e, f), SurfaceTriangle(e, b, f)};
-
-    SCOPED_TRACE("Triangle outside half space has single edge on the plane");
-    this->VerifyMeshesEquivalent(
-        TriangleSurfaceMesh<double>{move(expected_faces),
-                                    move(expected_vertices)},
-        TriangleSurfaceMesh<T>{move(this->new_faces()),
-                               move(this->new_vertices_W())});
+    //
+    // Confirm degeneracy: areas are close to zero, and vertices are close to
+    // vertices 1 and 2 in tri_mesh_F (as documented above).
+    for (int f = 0; f < mesh_W->num_elements(); ++f) {
+      EXPECT_NEAR(ExtractDoubleOrThrow(mesh_W->area(f)), 0, 1e-15);
+    }
+    // The reference vertices. For simplicity, we'll only consider the
+    // _minimum_ distance each vertex is to one of these two references.
+    const Vector3<T> p_WV1 = X_WF * tri_mesh_F.vertex(1).cast<T>();
+    const Vector3<T> p_WV2 = X_WF * tri_mesh_F.vertex(2).cast<T>();
+    using std::min;
+    // The last vertex is the centroid we're ignoring for now.
+    for (int v = 0; v < mesh_W->num_vertices() - 1; ++v) {
+      const double min_dist =
+          ExtractDoubleOrThrow(min((mesh_W->vertex(v) - p_WV1).norm(),
+                                   (mesh_W->vertex(v) - p_WV2).norm()));
+      EXPECT_NEAR(min_dist, 0, 1e-15);
+      EXPECT_NEAR(ExtractDoubleOrThrow(field_W->EvaluateAtVertex(v)), 0, 1e-15);
+    }
   }
 
   // Case: (b) two vertices on the boundary, one vertex inside.
   {
-    const TriangleSurfaceMesh<double> mesh_F = CreateOneTriangleMesh(
+    const TriangleSurfaceMesh<double> tri_mesh_F = CreateOneTriangleMesh(
         Vector3d(3, 5, 1), Vector3d(4, 5, 2), Vector3d(3, 6, 2));
 
     // Verify the intersection.
-    this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, X_WF);
+    this->CallConstructTriangleHalfspaceIntersectionPolygon(tri_mesh_F, X_WF);
+    auto [mesh_W, field_W] = this->builder_W().MakeMeshAndField();
 
-    std::unique_ptr<TriangleSurfaceMesh<double>> expected_mesh_W;
-    expected_mesh_W = std::make_unique<TriangleSurfaceMesh<double>>(
-        CreateMeshWithCentroids(mesh_F, X_WF));
-    SCOPED_TRACE("Triangle inside half space has single edge on the plane");
-    this->VerifyMeshesEquivalent(
-        *expected_mesh_W, TriangleSurfaceMesh<T>{move(this->new_faces()),
-                                                 move(this->new_vertices_W())});
+    auto expected_mesh_W = RexpressAsContactMesh<MeshType>(tri_mesh_F, X_WF);
+    EXPECT_TRUE(this->MeshesEquivalent(*mesh_W, expected_mesh_W));
+    EXPECT_TRUE(this->FieldConsistent(*mesh_W, *field_W, X_WF));
   }
 }
 
 // Verifies that a triangle that has two vertices within the half space and
 // another outside the half space produces a quadrilateral. This covers Case 2.
 TYPED_TEST_P(MeshHalfSpaceValueTest, QuadrilateralResults) {
-  using T = TypeParam;
+  using MeshType = TypeParam;
+  using T = typename MeshType::ScalarType;
 
   // An arbitrary relationship between Frames W and F -- avoiding additive and
   // multiplicative identities.
@@ -526,13 +660,8 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, QuadrilateralResults) {
 
   // Construct one vertex of the triangle to lie outside the half space and the
   // other two to lie inside the half space.
-  const TriangleSurfaceMesh<double> mesh_F = CreateOneTriangleMesh(
+  const TriangleSurfaceMesh<double> tri_mesh_F = CreateOneTriangleMesh(
       Vector3d(3, 5, 3), Vector3d(2, 5, 1), Vector3d(4, 5, 1));
-
-  const Vector3d nhat_F =
-      (mesh_F.vertices()[1] - mesh_F.vertices()[0])
-          .cross(mesh_F.vertices()[2] - mesh_F.vertices()[0])
-          .normalized();
 
   //                   a
   //                   ╱╲
@@ -544,34 +673,54 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, QuadrilateralResults) {
   // |         ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
   // --------> x
 
-  // Verify the intersection.
-  this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, X_WF);
+  {
+    // Verify the intersection.
+    this->CallConstructTriangleHalfspaceIntersectionPolygon(tri_mesh_F, X_WF);
+    auto [mesh_W, field_W] = this->builder_W().MakeMeshAndField();
 
-  ASSERT_EQ(this->new_faces().size(), 4);
-  ASSERT_EQ(this->new_vertices_W().size(), 5);
-  EXPECT_EQ(this->vertices_to_newly_created_vertices().size(), 2);
-  ASSERT_EQ(this->edges_to_newly_created_vertices().size(), 2);
+    if constexpr (std::is_same_v<MeshType, TriangleSurfaceMesh<T>>) {
+      EXPECT_EQ(mesh_W->num_vertices(), 5);
+      EXPECT_EQ(mesh_W->num_elements(), 4);
+    } else {
+      EXPECT_EQ(mesh_W->num_vertices(), 4);
+      EXPECT_EQ(mesh_W->num_elements(), 1);
+    }
+    // Evidence that when computing the intersecting _polygon_, we copied two
+    // vertices and split two edges.
+    EXPECT_EQ(this->vertices_to_newly_created_vertices().size(), 2);
+    EXPECT_EQ(this->edges_to_newly_created_vertices().size(), 2);
 
-  // Check that the mesh that results is equivalent to the expected mesh.
-  const RigidTransform<double> X_WF_d = convert_to_double(X_WF);
-  const std::vector<Vector3d> quad_W = {X_WF_d * Vector3d(2, 5, 1),     // b
-                                        X_WF_d * Vector3d(4, 5, 1),     // c
-                                        X_WF_d * Vector3d(3.5, 5, 2),   // d
-                                        X_WF_d * Vector3d(2.5, 5, 2)};  // e
-  std::vector<Vector3d> expected_vertices_W;
-  std::vector<SurfaceTriangle> expected_faces;
-  const Vector3d nhat_W = X_WF_d.rotation() * nhat_F;
-  expected_vertices_W = quad_W;
-  const int b{0}, c{1}, d{2}, e{3};
-  const std::vector<int> polygon{b, c, d, e};
-  AddPolygonToTriangleMeshData(polygon, nhat_W, &expected_faces,
-                               &expected_vertices_W);
-  SCOPED_TRACE("Triangle intersects; forms quad");
-  this->VerifyMeshesEquivalent(
-      TriangleSurfaceMesh<double>{move(expected_faces),
-                                  move(expected_vertices_W)},
-      TriangleSurfaceMesh<T>{move(this->new_faces()),
-                             move(this->new_vertices_W())});
+    // Check that the mesh that results is equivalent to the expected mesh.
+    std::vector<Vector3<T>> expected_vertices_W = {
+        X_WF * Vector3<T>(2, 5, 1),     // b
+        X_WF * Vector3<T>(4, 5, 1),     // c
+        X_WF * Vector3<T>(3.5, 5, 2),   // d
+        X_WF * Vector3<T>(2.5, 5, 2)};  // e
+    const int b{0}, c{1}, d{2}, e{3};
+    const std::vector<int> polygon{b, c, d, e};
+    // We have to use a unique_ptr because TriangleSurfaceMesh doesn't have a
+    // default constructor.
+    unique_ptr<MeshType> expected_mesh_W;
+    if constexpr (std::is_same_v<MeshType, TriangleSurfaceMesh<T>>) {
+    // TODO(SeanCurtis-TRI): When we use the known polygon normal in the
+    // AddPolygonToPolygonMeshData, move this normal definition out.
+    const Vector3<T> nhat_W =
+        X_WF.rotation() * tri_mesh_F.face_normal(0).cast<T>();
+      std::vector<SurfaceTriangle> expected_faces;
+      AddPolygonToTriangleMeshData(polygon, nhat_W, &expected_faces,
+                                   &expected_vertices_W);
+      expected_mesh_W = make_unique<MeshType>(move(expected_faces),
+                                              move(expected_vertices_W));
+    } else {
+      std::vector<int> face_data;
+      AddPolygonToPolygonMeshData(polygon, &face_data);
+      expected_mesh_W =
+          make_unique<MeshType>(move(face_data), move(expected_vertices_W));
+    }
+
+    EXPECT_TRUE(this->MeshesEquivalent(*mesh_W, *expected_mesh_W));
+    EXPECT_TRUE(this->FieldConsistent(*mesh_W, *field_W, X_WF));
+  }
 }
 
 // Verifies that a triangle that has one vertex outside the half space, one
@@ -579,7 +728,8 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, QuadrilateralResults) {
 // space produces the intersected polygon that is a degenerated quadrilateral
 // with a zero-length edge. This test covers Case 2.
 TYPED_TEST_P(MeshHalfSpaceValueTest, OutsideInsideOn) {
-  using T = TypeParam;
+  using MeshType = TypeParam;
+  using T = typename MeshType::ScalarType;
 
   // An arbitrary relationship between Frames W and F -- avoiding additive and
   // multiplicative identities.
@@ -587,17 +737,24 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, OutsideInsideOn) {
                                    M_PI / 7, Vector3<T>{1, 2, 3}.normalized()}),
                                Vector3<T>{-0.25, 0.5, 0.75});
 
-  const TriangleSurfaceMesh<double> mesh_F = CreateOneTriangleMesh(
+  const TriangleSurfaceMesh<double> tri_mesh_F = CreateOneTriangleMesh(
       Vector3d(3, 5, 3), Vector3d(2, 5, 1), Vector3d(3.5, 5, 2));
 
-  const Vector3d nhat_F =
-      (mesh_F.vertices()[1] - mesh_F.vertices()[0])
-          .cross(mesh_F.vertices()[2] - mesh_F.vertices()[0])
-          .normalized();
-
   // Verify the intersection.
-  this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, X_WF);
-  ASSERT_EQ(this->edges_to_newly_created_vertices().size(), 2);
+  this->CallConstructTriangleHalfspaceIntersectionPolygon(tri_mesh_F, X_WF);
+  auto [mesh_W, field_W] = this->builder_W().MakeMeshAndField();
+
+  if constexpr (std::is_same_v<MeshType, TriangleSurfaceMesh<T>>) {
+    EXPECT_EQ(mesh_W->num_vertices(), 5);
+    EXPECT_EQ(mesh_W->num_elements(), 4);
+  } else {
+    EXPECT_EQ(mesh_W->num_vertices(), 4);
+    EXPECT_EQ(mesh_W->num_elements(), 1);
+  }
+  // Evidence that when computing the intersecting _polygon_, we copied two
+  // vertices and split two edges.
+  EXPECT_EQ(this->vertices_to_newly_created_vertices().size(), 2);
+  EXPECT_EQ(this->edges_to_newly_created_vertices().size(), 2);
 
   //                   a
   //                   ╱╲
@@ -613,50 +770,55 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, OutsideInsideOn) {
   // can't draw a line at that angle.
 
   // Check that the mesh that results is equivalent to the expected mesh.
-  const RigidTransform<double> X_WF_d = convert_to_double(X_WF);
+
   // The intersected polygon is a degenerated quadrilateral with the
   // zero-length edge cd.
-  const std::vector<Vector3<double>> degenerated_quadrilateral_W = {
-      X_WF_d * Vector3d(2, 5, 1),     // b
-      X_WF_d * Vector3d(3.5, 5, 2),   // c
-      X_WF_d * Vector3d(3.5, 5, 2),   // d
-      X_WF_d * Vector3d(2.5, 5, 2)};  // e
-  std::vector<Vector3d> expected_vertices_W;
-  std::vector<SurfaceTriangle> expected_faces;
-  const Vector3d nhat_W = X_WF_d.rotation() * nhat_F;
-  expected_vertices_W = degenerated_quadrilateral_W;
+  std::vector<Vector3<T>> expected_vertices_W = {
+      X_WF * Vector3<T>(2, 5, 1),     // b
+      X_WF * Vector3<T>(3.5, 5, 2),   // c
+      X_WF * Vector3<T>(3.5, 5, 2),   // d
+      X_WF * Vector3<T>(2.5, 5, 2)};  // e
   const int b{0}, c{1}, d{2}, e{3};
-  std::vector<int> polygon{b, c, d, e};
-  AddPolygonToTriangleMeshData(polygon, nhat_W, &expected_faces,
-                               &expected_vertices_W);
-  SCOPED_TRACE("Triangle intersects; single vertex on boundary");
-  this->VerifyMeshesEquivalent(
-      TriangleSurfaceMesh<double>{move(expected_faces),
-                                  move(expected_vertices_W)},
-      TriangleSurfaceMesh<T>{move(this->new_faces()),
-                             move(this->new_vertices_W())});
+  const std::vector<int> polygon{b, c, d, e};
+  // We have to use a unique_ptr because TriangleSurfaceMesh doesn't have a
+  // default constructor.
+  unique_ptr<MeshType> expected_mesh_W;
+  if constexpr (std::is_same_v<MeshType, TriangleSurfaceMesh<T>>) {
+    // TODO(SeanCurtis-TRI): When we use the known polygon normal in the
+    // AddPolygonToPolygonMeshData, move this normal definition out.
+    const Vector3<T> nhat_W =
+        X_WF.rotation() * tri_mesh_F.face_normal(0).cast<T>();
+    std::vector<SurfaceTriangle> expected_faces;
+    AddPolygonToTriangleMeshData(polygon, nhat_W, &expected_faces,
+                                 &expected_vertices_W);
+    expected_mesh_W =
+        make_unique<MeshType>(move(expected_faces), move(expected_vertices_W));
+  } else {
+    std::vector<int> face_data;
+    AddPolygonToPolygonMeshData(polygon, &face_data);
+    expected_mesh_W =
+        make_unique<MeshType>(move(face_data), move(expected_vertices_W));
+  }
+
+  EXPECT_TRUE(this->MeshesEquivalent(*mesh_W, *expected_mesh_W));
+  EXPECT_TRUE(this->FieldConsistent(*mesh_W, *field_W, X_WF));
 }
 
 // Verifies that a triangle with one vertex inside the half space and two
 // vertices outside of the half space produces an interesected polygon that
 // is a triangle. This test covers Case 3.
 TYPED_TEST_P(MeshHalfSpaceValueTest, OneInsideTwoOutside) {
-  using T = TypeParam;
+  using MeshType = TypeParam;
+  using T = typename MeshType::ScalarType;
 
   // An arbitrary relationship between Frames W and F -- avoiding additive and
   // multiplicative identities.
-  const RigidTransform<T> X_WF(
-      RotationMatrix<T>(
-          AngleAxis<T>{M_PI / 7, Vector3<T>{1, 2, 3}.normalized()}),
-      Vector3<T>{-0.25, 0.5, 0.75});
+  const RigidTransform<T> X_WF(RotationMatrix<T>(AngleAxis<T>{
+                                   M_PI / 7, Vector3<T>{1, 2, 3}.normalized()}),
+                               Vector3<T>{-0.25, 0.5, 0.75});
 
-  const TriangleSurfaceMesh<double> mesh_F = CreateOneTriangleMesh(
+  const TriangleSurfaceMesh<double> tri_mesh_F = CreateOneTriangleMesh(
       Vector3d(3, 5, 3), Vector3d(4, 5, 3), Vector3d(3, 6, 1));
-
-  const Vector3d nhat_F =
-      (mesh_F.vertices()[1] - mesh_F.vertices()[0])
-          .cross(mesh_F.vertices()[2] - mesh_F.vertices()[0])
-          .normalized();
 
   // ^ z
   // |            b ________ c
@@ -668,33 +830,66 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, OneInsideTwoOutside) {
   // --------> x
 
   // Verify the intersection.
-  this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, X_WF);
+  this->CallConstructTriangleHalfspaceIntersectionPolygon(tri_mesh_F, X_WF);
+  auto [mesh_W, field_W] = this->builder_W().MakeMeshAndField();
 
-  // Check that the mesh that results is equivalent to the expected mesh.
-  const RigidTransform<double> X_WF_d = convert_to_double(X_WF);
-  std::vector<Vector3<double>> triangle_W = {X_WF_d * Vector3d(3, 6, 1),
-                                             X_WF_d * Vector3d(3, 5.5, 2),
-                                             X_WF_d * Vector3d(3.5, 5.5, 2)};
-  std::vector<Vector3d> expected_vertices_W;
-  std::vector<SurfaceTriangle> expected_faces;
-  const Vector3d nhat_W = X_WF_d.rotation() * nhat_F;
-  expected_vertices_W = triangle_W;
-  std::vector<int> polygon{0, 1, 2};
-  AddPolygonToTriangleMeshData(polygon, nhat_W, &expected_faces,
-                               &expected_vertices_W);
-  SCOPED_TRACE("Triangle intersects; forms a smaller triangle");
-  this->VerifyMeshesEquivalent(
-      TriangleSurfaceMesh<double>{move(expected_faces),
-                                  move(expected_vertices_W)},
-      TriangleSurfaceMesh<T>{move(this->new_faces()),
-                             move(this->new_vertices_W())});
+  if constexpr (std::is_same_v<MeshType, TriangleSurfaceMesh<T>>) {
+    EXPECT_EQ(mesh_W->num_vertices(), 4);
+    EXPECT_EQ(mesh_W->num_elements(), 3);
+  } else {
+    EXPECT_EQ(mesh_W->num_vertices(), 3);
+    EXPECT_EQ(mesh_W->num_elements(), 1);
+  }
+  // Evidence that when computing the intersecting _polygon_, we copied one
+  // vertex and split two edges.
+  EXPECT_EQ(this->vertices_to_newly_created_vertices().size(), 1);
+  EXPECT_EQ(this->edges_to_newly_created_vertices().size(), 2);
+
+  std::vector<Vector3<T>> expected_vertices_W = {
+      X_WF * Vector3<T>(3, 6, 1), X_WF * Vector3<T>(3, 5.5, 2),
+      X_WF * Vector3<T>(3.5, 5.5, 2)};
+  const std::vector<int> polygon{0, 1, 2};
+  // We have to use a unique_ptr because TriangleSurfaceMesh doesn't have a
+  // default constructor.
+  unique_ptr<MeshType> expected_mesh_W;
+  if constexpr (std::is_same_v<MeshType, TriangleSurfaceMesh<T>>) {
+    // TODO(SeanCurtis-TRI): When we use the known polygon normal in the
+    // AddPolygonToPolygonMeshData, move this normal definition out.
+    const Vector3<T> nhat_W =
+        X_WF.rotation() * tri_mesh_F.face_normal(0).cast<T>();
+    std::vector<SurfaceTriangle> expected_faces;
+    AddPolygonToTriangleMeshData(polygon, nhat_W, &expected_faces,
+                                 &expected_vertices_W);
+    expected_mesh_W =
+        make_unique<MeshType>(move(expected_faces), move(expected_vertices_W));
+  } else {
+    std::vector<int> face_data;
+    AddPolygonToPolygonMeshData(polygon, &face_data);
+    expected_mesh_W =
+        make_unique<MeshType>(move(face_data), move(expected_vertices_W));
+  }
+
+  EXPECT_TRUE(this->MeshesEquivalent(*mesh_W, *expected_mesh_W));
+  EXPECT_TRUE(this->FieldConsistent(*mesh_W, *field_W, X_WF));
 }
 
-// Tests that a mesh of a box bisected by the half space produces the expected
-// number of faces and vertices (other unit tests in this file assess the
-// correctness of various kinds of triangle/half space intersections).
-TYPED_TEST_P(MeshHalfSpaceValueTest, BoxMesh) {
-  using T = TypeParam;
+// Tests ComputeContactSurface() by intersecting a box with a half space. We
+// pretend that BVH culling produced a vector consisting of *all* box triangles.
+// In this case, we need to confirm the following:
+//   - nullptr is returned for empty index list or no *actual* intersections
+//     among the triangle indices provided.
+//   - Otherwise a valid contact surface is returned:
+//     - the mesh is as expected (coarsely), we rely on the unit tests of the
+//       underlying infrastructure to get the details correct.
+//     - the field is as expected (again, coarsely).
+//     - We have gradient samples on geometry M.
+TYPED_TEST_P(MeshHalfSpaceValueTest, ComputeContactSurfaceInvocation) {
+  using MeshType = TypeParam;
+  using T = typename MeshType::ScalarType;
+
+  static_assert(std::is_same_v<MeshType, TriangleSurfaceMesh<T>> ||
+                    std::is_same_v<MeshType, PolygonSurfaceMesh<T>>,
+                "Mesh type isn't a mesh");
 
   // An arbitrary relationship between Frames W and F -- avoiding additive and
   // multiplicative identities.
@@ -705,53 +900,111 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, BoxMesh) {
 
   // Set B to an arbitrarily chosen pose relative to F.
   RigidTransform<T> X_FB(math::RollPitchYaw<T>(M_PI_4, M_PI_4, M_PI_4),
-                               Vector3<T>(1.0, 2.0, 3.0));
+                         Vector3<T>(1.0, 2.0, 3.0));
   RigidTransform<double> X_FB_d = convert_to_double(X_FB);
 
-  const TriangleSurfaceMesh<double> mesh_F = CreateBoxMesh(X_FB_d);
+
+  const TriangleSurfaceMesh<double> tri_mesh_F = CreateBoxMesh(X_FB_d);
+  const GeometryId mesh_id = GeometryId::get_new_id();
 
   // Construct the half-space.
   const Vector3<T> Bz_F = X_FB.rotation().col(2);
   const PosedHalfSpace<T> half_space_F(Bz_F, X_FB.translation());
+  const GeometryId half_space_id = GeometryId::get_new_id();
+  const Vector3<T> grad_p_F = -17 * Bz_F;
+  const Vector3<T> grad_p_W = X_WF.rotation() * grad_p_F;
+  auto pressure_in_F = [grad_p_F,
+                        p_F0 = X_FB.translation()](const Vector3<T>& p_FV) {
+    return grad_p_F.dot(p_FV - p_F0);
+  };
 
+  using MeshBuilder = typename BuilderTypeFromMesh<MeshType>::Type;
+
+  // Case no intersections returns nullptr.
   {
-    // Case: Plane doesn't intersect. In fact, the plane _does_ intersect the
-    // mesh, but we will simulate non-intersection by providing indices to
-    // triangles that _don't_ intersect (the two triangles on the +z face).
-    std::vector<int> tri_indices{8, 9};
-    EXPECT_EQ(ConstructSurfaceMeshFromMeshHalfspaceIntersection(
-                  mesh_F, half_space_F, tri_indices, X_WF),
+    // The triangles indicated don't actually intersect the half space.
+    EXPECT_EQ(ComputeContactSurface<MeshBuilder>(
+                  mesh_id, tri_mesh_F, half_space_id, half_space_F,
+                  pressure_in_F, grad_p_W, {8, 9}, X_WF),
               nullptr);
-    EXPECT_EQ(ConstructSurfaceMeshFromMeshHalfspaceIntersection(
-                  mesh_F, half_space_F, tri_indices, X_WF),
+    // There are no indices provided.
+    EXPECT_EQ(ComputeContactSurface<MeshBuilder>(
+                  mesh_id, tri_mesh_F, half_space_id, half_space_F,
+                  pressure_in_F, grad_p_W, {}, X_WF),
               nullptr);
   }
 
-  // Case: Plane intersect the mesh.
+  // Case: Plane intersects the mesh.
   {
     // We pass in indices of *all* the triangles.
-    std::vector<int> tri_indices(mesh_F.num_elements());
+    std::vector<int> tri_indices(tri_mesh_F.num_elements());
     std::iota(tri_indices.begin(), tri_indices.end(), 0);
 
-    const std::unique_ptr<TriangleSurfaceMesh<T>> intersection_mesh_W =
-        ConstructSurfaceMeshFromMeshHalfspaceIntersection(mesh_F, half_space_F,
-                                                          tri_indices, X_WF);
-    // Total number of vertices:            22
+    const auto& surface = ComputeContactSurface<MeshBuilder>(
+        mesh_id, tri_mesh_F, half_space_id, half_space_F, pressure_in_F,
+        grad_p_W, tri_indices, X_WF);
+
+    // The half space intersects the mesh with four vertices inside and four
+    // outside. Therefore, we expect intersection to produce the following
+    // with respect to the intersecting *polygons*.
+    //
+    // Total number of vertices:            12
     //   -------------------------------------
     //   vertices lying in half space:       4
     //   vertices from split edges:          8
-    //   centroid per intersection polygon: 10
-    ASSERT_EQ(intersection_mesh_W->num_vertices(), 22);
+    //
+    // Each of the +/- X, Y faces of the box has two triangles. They get
+    // clipped into a triangle and quad. Furthermore, the -Z face has two
+    // triangles included directly. That leads to 10 total intersection
+    // *polygons*.
+    //
+    // If, however, we are creating a TriangleSurfaceMesh-valued result, each of
+    // those faces will be tessellated around its centroid, adding a further 10
+    // vertices. Furthermore, there are six triangles and four quads.
+    // Tessellating the quads will introduce an *additional* three triangles per
+    // quad (4 * 3 = 12 triangles). Tessellating the original triangles will
+    // introduce an additional two triangles each (2 * 6 = 12 triangles). So,
+    // the TriangleSurfaceMesh will have an addition 24 triangles.
+    const MeshType* mesh_W{};
+    const MeshFieldLinear<T, MeshType>* field_W{};
+    int expected_vert_count = 12;  // Baseline.
+    int expected_face_count = 10;
+    if constexpr (std::is_same_v<MeshType, TriangleSurfaceMesh<T>>) {
+      expected_vert_count += 10;
+      expected_face_count += 24;
+      mesh_W = &surface->tri_mesh_W();
+      field_W = &surface->tri_e_MN();
+    } else {
+      mesh_W = &surface->poly_mesh_W();
+      field_W = &surface->poly_e_MN();
+    }
 
-    // Each of the +/- X, Y faces of the box have two triangles. They get
-    // clipped into a triangle and quad. Each of those is transformed into a
-    // triangle fan around its centroid, producing 3 and 4 triangles for a
-    // total of seven per direction.
-    // Total number of faces:                         34
-    //   -----------------------------------------------
-    //   -Z triangles, each fanned around centroid:    6
-    //   4 X new triangles per box face:      7 * 4 = 28
-    ASSERT_EQ(intersection_mesh_W->num_triangles(), 34);
+    // We'll assert that the correct number of vertices *and* faces is
+    // sufficient evidence to show that ComputeContactSurfaces is correctly
+    // calling ConstructTriangleHalfspaceIntersectionPolygon().
+    ASSERT_EQ(mesh_W->num_vertices(), expected_vert_count);
+    ASSERT_EQ(mesh_W->num_elements(), expected_face_count);
+    // The field has been constructed with the same mesh is evidence that the
+    // surface has been constructed from the right pieces.
+    ASSERT_EQ(&field_W->mesh(), mesh_W);
+
+    // Confirm that we've sampled the half space gradient per face. This test is
+    // formulated without assumptions about whether the half space is M or N for
+    // the contact surface.
+    if (surface->id_M() == half_space_id) {
+      ASSERT_TRUE(surface->HasGradE_M());
+      for (int f = 0; f < mesh_W->num_elements(); ++f) {
+        EXPECT_TRUE(CompareMatrices(surface->EvaluateGradE_M_W(f), grad_p_W));
+      }
+    } else if (surface->id_N() == half_space_id) {
+      ASSERT_TRUE(surface->HasGradE_N());
+      for (int f = 0; f < mesh_W->num_elements(); ++f) {
+        EXPECT_TRUE(CompareMatrices(surface->EvaluateGradE_N_W(f), grad_p_W));
+      }
+    } else {
+      GTEST_FAIL()
+          << "The half space id was not referenced in the contact surface.";
+    }
   }
 }
 
@@ -759,24 +1012,23 @@ REGISTER_TYPED_TEST_SUITE_P(MeshHalfSpaceValueTest, NoIntersection,
                             InsideOrOnIntersection,
                             VertexOnHalfspaceIntersection,
                             EdgeOnHalfspaceIntersection, QuadrilateralResults,
-                            OutsideInsideOn, OneInsideTwoOutside, BoxMesh);
+                            OutsideInsideOn, OneInsideTwoOutside,
+                            ComputeContactSurfaceInvocation);
 
 // The ComputeContactSurfaceFromSoftHalfSpaceRigidMesh() method has the
 // following responsibilities:
 //
 //    - Dispatch BVH culling
 //    - If no candidates, return nullptr.
-//    - Pass candidates to ConstructSurfaceMeshFromMeshHalfspaceIntersection()
-//    - If no faces, return nullptr.
-//    - Compute pressure field on mesh.
-//    - Return contact surface with mesh and pressure; field must have pointer
-//      to the mesh.
-//    - Report the gradients of soft half space's pressure field across all
-//      triangles.
+//    - Otherwise, pass candidates to ComputeContactSurface() and return its
+//      return value directly. This function maps the enumeration type to the
+//      appropriate mesh representation type.
 //
 // It is impossible to test correct BVH use (it's all fully contained within
 // the implementation). So, we'll focus on intersecting and non-intersecting
-// configurations and make sure the data reported is as expected.
+// configurations and make sure the data reported is as expected. This function
+// does its work independent of scalar type, so we'll only check the
+// double-valued instantiation.
 GTEST_TEST(ComputeContactSurfaceFromSoftHalfSpaceRigidMeshTest, DoubleValued) {
   // An arbitrary relationship between Frames W and F -- avoiding additive and
   // multiplicative identities.
@@ -803,7 +1055,12 @@ GTEST_TEST(ComputeContactSurfaceFromSoftHalfSpaceRigidMeshTest, DoubleValued) {
     // Put the half space well below the box.
     const RigidTransform<double> X_WH{Vector3<double>{0, 0, -5}};
     EXPECT_EQ(ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
-                  hs_id, X_WH, pressure_scale, mesh_id, mesh_F, bvh_F, X_WF),
+                  hs_id, X_WH, pressure_scale, mesh_id, mesh_F, bvh_F, X_WF,
+                  HydroelasticContactRepresentation::kTriangle),
+              nullptr);
+    EXPECT_EQ(ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
+                  hs_id, X_WH, pressure_scale, mesh_id, mesh_F, bvh_F, X_WF,
+                  HydroelasticContactRepresentation::kPolygon),
               nullptr);
   }
 
@@ -816,88 +1073,46 @@ GTEST_TEST(ComputeContactSurfaceFromSoftHalfSpaceRigidMeshTest, DoubleValued) {
   // actually have the half space perfectly aligned with the mesh.
   // We pick a rotation roughly 5 degrees away from Bz and a small offset
   // from the origin.
+  //
+  // We will simply confirm that the resulting ContactSurface exists and
+  // respects the requested representation.
   const RigidTransform<double> X_BH{
       AngleAxis<double>{M_PI * 0.027, Vector3d{1, 1, 0}.normalized()},
       Vector3<double>{0.1, -0.05, 0.075}};
   const RigidTransform<double> X_WH = X_WF * X_FB * X_BH;
 
-  // Case: intersecting configuration (ignoring the gradients of the
-  // constituent pressure fields).
+  // Case: Request triangle surface mesh.
   {
     const std::unique_ptr<ContactSurface<double>> contact_surface =
         ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
-            hs_id, X_WH, pressure_scale, mesh_id, mesh_F, bvh_F, X_WF);
+            hs_id, X_WH, pressure_scale, mesh_id, mesh_F, bvh_F, X_WF,
+            HydroelasticContactRepresentation::kTriangle);
     ASSERT_NE(contact_surface, nullptr);
-
-    // Quick reality check on the topology of the contact surface's mesh. See
-    // BoxMesh test for the origin of the number of vertices and faces.
-    EXPECT_EQ(contact_surface->mesh_W().num_vertices(), 22);
-    EXPECT_EQ(contact_surface->mesh_W().num_triangles(), 34);
-
-    // Confirm wiring in the contact surface.
-    EXPECT_EQ(&contact_surface->mesh_W(), &contact_surface->e_MN().mesh());
-
-    // Confirm pressure values.
-    PosedHalfSpace<double> hs_W{X_WH.rotation().col(2), X_WH.translation()};
-    // Simply test each vertex and confirm that the corresponding pressure
-    // value is expected.
-    const TriangleSurfaceMesh<double>& mesh_W = contact_surface->mesh_W();
-    for (int v = 0; v < mesh_W.num_vertices(); ++v) {
-      const double pressure = contact_surface->e_MN().EvaluateAtVertex(v);
-      const Vector3d& p_WV = mesh_W.vertex(v);
-      // Pressure is a function of _penetration depth_ = -signed distance.
-      const double depth = -hs_W.CalcSignedDistance(p_WV);
-      const double expected_pressure = depth * pressure_scale;
-      EXPECT_NEAR(pressure, expected_pressure, 1e-15);
-    }
+    ASSERT_EQ(contact_surface->representation(),
+              HydroelasticContactRepresentation::kTriangle);
   }
 
-  // Case:  A repeat of the previous test, this time, we simply test for the
-  // existence (and correctness) of the pressure field gradient associated
-  // with the half space; it should be the negative scaled half space normal.
-  // We'll repeat the test twice, swapping ids to make sure the pressure field
-  // moves from M to N.
+  // Case: Request polygon surface mesh.
   {
-    const Vector3d grad_eH_W_expected =
-        -pressure_scale * X_WH.rotation().col(2);
-    {
-      const std::unique_ptr<ContactSurface<double>> contact_surface =
-          ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
-              hs_id, X_WH, pressure_scale, mesh_id, mesh_F, bvh_F, X_WF);
-      ASSERT_NE(contact_surface, nullptr);
-      ASSERT_LT(mesh_id, hs_id);
-      EXPECT_FALSE(contact_surface->HasGradE_M());
-      EXPECT_TRUE(contact_surface->HasGradE_N());
-
-      EXPECT_GT(contact_surface->mesh_W().num_triangles(), 0);
-      for (int f = 0; f < contact_surface->mesh_W().num_triangles(); ++f) {
-        ASSERT_TRUE(CompareMatrices(contact_surface->EvaluateGradE_N_W(f),
-                                    grad_eH_W_expected));
-      }
-    }
-
-    {
-      const std::unique_ptr<ContactSurface<double>> contact_surface =
-          ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
-              mesh_id, X_WH, pressure_scale, hs_id, mesh_F, bvh_F, X_WF);
-      ASSERT_NE(contact_surface, nullptr);
-      EXPECT_TRUE(contact_surface->HasGradE_M());
-      EXPECT_FALSE(contact_surface->HasGradE_N());
-
-      EXPECT_GT(contact_surface->mesh_W().num_triangles(), 0);
-      for (int f = 0; f < contact_surface->mesh_W().num_triangles(); ++f) {
-        ASSERT_TRUE(CompareMatrices(contact_surface->EvaluateGradE_M_W(f),
-                                    grad_eH_W_expected));
-      }
-    }
+    const std::unique_ptr<ContactSurface<double>> contact_surface =
+        ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
+            hs_id, X_WH, pressure_scale, mesh_id, mesh_F, bvh_F, X_WF,
+            HydroelasticContactRepresentation::kPolygon);
+    ASSERT_NE(contact_surface, nullptr);
+    ASSERT_EQ(contact_surface->representation(),
+              HydroelasticContactRepresentation::kPolygon);
   }
 }
 
 // Confirm that the rigid-soft intersection correctly culls backface geometry.
-GTEST_TEST(CompupteContactSurfaceFromSoftHalfSpaceRigidMeshTest, BackfaceCull) {
+// Culling is independent of ultimate contact surface mesh representation, so
+// we'll simply test it against one mesh and scalar type and call it good. We
+// choose the TriangleSurfaceMesh so we can invoke
+// IsFaceNormalInNormalDirection() as part of the test.
+GTEST_TEST(ComputeContactSurfaceFromSoftHalfSpaceRigidMeshTest, BackfaceCull) {
   // For this test, we're just testing for culling. We presume that for a given
   // configuration of mesh and half space, the right calculations will be done
-  // to compute the intersection mesh. So, to that end:
+  // to compute the intersection mesh based on previous tests. So, accordingly:
   //
   //   1. We'll leave the box centered on the world frame origin and aligned
   //      with the world frame basis.  This implies that B = F = W.
@@ -924,29 +1139,27 @@ GTEST_TEST(CompupteContactSurfaceFromSoftHalfSpaceRigidMeshTest, BackfaceCull) {
 
   const std::unique_ptr<ContactSurface<double>> contact_surface =
       ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
-          hs_id, X_WH, pressure_scale, mesh_id, mesh_F, bvh_F, X_WF);
+          hs_id, X_WH, pressure_scale, mesh_id, mesh_F, bvh_F, X_WF,
+          HydroelasticContactRepresentation::kTriangle);
   // It definitely produces a contact surface.
   ASSERT_NE(contact_surface, nullptr);
 
-  const TriangleSurfaceMesh<double>& contact_mesh_W = contact_surface->mesh_W();
+  const TriangleSurfaceMesh<double>& mesh_W = contact_surface->tri_mesh_W();
 
   // For a wholly enclosed mesh _without_ backface culling, the contact
-  // surface would be the full mesh. The input mesh has two triangles per
-  // face for a total of 12 triangles and 8 vertices. As a contact
-  // surface, each of those triangles would be split around its centroid.
-  // This means for each triangle in the input mesh, we have three
-  // triangles in the contact surface mesh, and one additional 1 vertex.
-  // Thus the unculled contact surface would have 8 + 12 = 20 vertices and
-  // 12 * 3 = 36 triangles.
+  // surface would be the full mesh. The input mesh has two triangles per face
+  // for a total of 12 triangles and 8 vertices.
   //
-  // In fact, because the face normal points along one of the box
-  // diagonals. Only three of the box's faces will contribute to the
-  // contact surface. So, we'll have 18 faces (6 triangles per face). For
-  // vertices, we'll include all but one of the input mesh's vertices (7),
-  // and introduce one vertex per input triangle (6) for a total of 13
-  // vertices.
-  ASSERT_EQ(contact_mesh_W.num_triangles(), 18);
-  ASSERT_EQ(contact_mesh_W.num_vertices(), 13);
+  // In fact, because the face normal points along one of the box diagonals.
+  // Only three of the box's faces will contribute to the contact surface. So,
+  // we'd have 6 faces (2 triangles per face). For vertices, we'll include all
+  // but one of the input mesh's vertices (7).
+  //
+  // For the TriangleSurfaceMesh, those faces would get tessellated around
+  // their centroids. So, instead of 6 3-sided polygons, we have 18 triangles.
+  // And in addition to the 7-input vertices, we add 6 centroids.
+  ASSERT_EQ(mesh_W.num_elements(), 18);
+  ASSERT_EQ(mesh_W.num_vertices(), 13);
 
   // Let's explicitly confirm that every face in the contact surface mesh
   // passes the culling test.
@@ -966,24 +1179,21 @@ GTEST_TEST(CompupteContactSurfaceFromSoftHalfSpaceRigidMeshTest, BackfaceCull) {
   //      lines of code do to define the gradient direction vector.
   const double grad_scale = contact_surface->id_N() == mesh_id ? 1.0 : -1.0;
   const Vector3<double> grad_p_W = grad_scale * -normal_W;
-  for (int tri = 0; tri < contact_mesh_W.num_triangles(); ++tri) {
+  for (int tri = 0; tri < mesh_W.num_elements(); ++tri) {
     // Everything is defined in the world frame; so the transform X_WM = I.
-    ASSERT_TRUE(
-        IsFaceNormalInNormalDirection(grad_p_W, contact_mesh_W, tri, {}))
+    ASSERT_TRUE(IsFaceNormalInNormalDirection(grad_p_W, mesh_W, tri, {}))
         << "Face " << tri;
   }
+
   // Note: this confirms that the reported faces satisfy the non-culling
   // criteria, but doesn't (can't) confirm that the omitted faces don't. Rethink
   // this test if that proves to be a problem (highly unlikely).
 }
 
-// TODO(SeanCurtis-TRI): All of the tests where we actually examine the mesh
-//  use a mesh with a _single_ triangle. In this case, the face-local index
-//  values are perfectly aligned with the mesh-local index values. This hides
-//  potential errors where the two sets of indices do _not_ align so nicely.
-//  Add a test where we intersect a face that doesn't use vertices 0, 1, and 2.
-
-typedef ::testing::Types<double, AutoDiffXd> MyTypes;
+typedef ::testing::Types<
+    TriangleSurfaceMesh<double>, TriangleSurfaceMesh<AutoDiffXd>,
+    PolygonSurfaceMesh<double>, PolygonSurfaceMesh<AutoDiffXd>>
+    MyTypes;
 INSTANTIATE_TYPED_TEST_SUITE_P(My, MeshHalfSpaceValueTest, MyTypes);
 
 /* This test fixture enables some limited testing of the autodiff-valued contact
@@ -1020,7 +1230,13 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, MeshHalfSpaceValueTest, MyTypes);
  The function TestPositionDerivative() will pose the triangle mesh and compute
  a contact surface. It invokes a provided functor to assess the reported
  derivatives of some arbitrary quantity of the contact surface with respect to
- the position of the origin of frame R. */
+ the position of the origin of frame R.
+
+ This test exclusively uses the TriangleSurfaceMesh output type. The reason for
+ this is that the introduction of the centroid is a very convenient property to
+ use for evaluating correct propagation of derivatives. All other face,
+ vertices, and per-feature values would be equivalent for the two mesh
+ representation types. */
 class MeshHalfSpaceDerivativesTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -1135,11 +1351,13 @@ class MeshHalfSpaceDerivativesTest : public ::testing::Test {
       const RigidTransform<AutoDiffXd> X_WR{R_WR_d.cast<AutoDiffXd>(), p_WR};
 
       auto surface = ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
-          id_S_, X_WS_, pressure_scale_, id_R_, *mesh_R_, *bvh_R_, X_WR);
+          id_S_, X_WS_, pressure_scale_, id_R_, *mesh_R_, *bvh_R_, X_WR,
+          HydroelasticContactRepresentation::kTriangle);
 
       SCOPED_TRACE(config.name);
       ASSERT_NE(surface, nullptr);
-      ASSERT_EQ(surface->mesh_W().num_triangles(), config.expected_num_faces);
+      ASSERT_EQ(surface->tri_mesh_W().num_triangles(),
+                config.expected_num_faces);
 
       evaluate_quantity(*surface, X_WR, config.pose);
     }
@@ -1210,7 +1428,7 @@ TEST_F(MeshHalfSpaceDerivativesTest, Area) {
                            const ContactSurface<AutoDiffXd>& surface,
                            const RigidTransform<AutoDiffXd>& X_WR_ad,
                            TriPose pose) {
-    const auto& mesh_W = surface.mesh_W();
+    const auto& mesh_W = surface.tri_mesh_W();
 
     // For v × A, this makes a matrix V such that VA = v × A.
     auto skew_matrix = [](const Vector3d& v) {
@@ -1385,7 +1603,7 @@ TEST_F(MeshHalfSpaceDerivativesTest, VertexPosition) {
      in the half space. We'll evaluate all of those and then handle the centroid
      specially. */
     const Vector3d n_S{0, 0, 1};
-    const TriangleSurfaceMesh<AutoDiffXd>& mesh_W = surface.mesh_W();
+    const TriangleSurfaceMesh<AutoDiffXd>& mesh_W = surface.tri_mesh_W();
     const RigidTransformd X_WS = convert_to_double(this->X_WS_);
     const RotationMatrixd& R_WS = X_WS.rotation();
     const RotationMatrixd R_SW = R_WS.inverse();
@@ -1450,8 +1668,8 @@ TEST_F(MeshHalfSpaceDerivativesTest, FaceNormalsWrtPosition) {
                              const RigidTransform<AutoDiffXd>&, TriPose) {
     constexpr double kEps = std::numeric_limits<double>::epsilon();
     const Matrix3<double> zero_matrix = Matrix3<double>::Zero();
-    for (int t = 0; t < surface.mesh_W().num_elements(); ++t) {
-      const Vector3<AutoDiffXd> n_W = surface.mesh_W().face_normal(t);
+    for (int t = 0; t < surface.tri_mesh_W().num_elements(); ++t) {
+      const Vector3<AutoDiffXd> n_W = surface.tri_mesh_W().face_normal(t);
       EXPECT_TRUE(CompareMatrices(math::ExtractGradient(n_W),
                                   zero_matrix, 32 * kEps));
     }
@@ -1503,19 +1721,20 @@ TEST_F(MeshHalfSpaceDerivativesTest, FaceNormalsWrtOrientation) {
     const Vector3d v_W = convert_to_double(this->X_WS_).rotation() * v_S;
 
     auto surface = ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
-        id_S_, X_WS_, pressure_scale_, id_R_, *mesh_R_, *bvh_R_, X_WR);
+        id_S_, X_WS_, pressure_scale_, id_R_, *mesh_R_, *bvh_R_, X_WR,
+        HydroelasticContactRepresentation::kTriangle);
 
     SCOPED_TRACE(fmt::format("theta = {:.5f} radians", theta));
     /* surface != nullptr --> num_elements() > 0 as documented in the API but
      we'll explicitly confirm to make sure the test doesn't pass by accident. */
     ASSERT_NE(surface, nullptr);
-    ASSERT_GT(surface->mesh_W().num_elements(), 0);
+    ASSERT_GT(surface->tri_mesh_W().num_elements(), 0);
 
     /* Test dn̂/dθ = v̂ × n̂  = v̂ × Ry. */
     const Vector3d Ry_W = math::ExtractValue(X_WR.rotation().col(1));
     const Vector3d expected_deriv = v_W.cross(Ry_W);
-    for (int t = 0; t < surface->mesh_W().num_elements(); ++t) {
-      const auto& n = surface->mesh_W().face_normal(t);
+    for (int t = 0; t < surface->tri_mesh_W().num_elements(); ++t) {
+      const auto& n = surface->tri_mesh_W().face_normal(t);
       /* Precision decreases as the mesh gets closer to lying parallel to the
        half space surface. This simple switch accounts for the observed
        behavior in this test. */
@@ -1545,11 +1764,11 @@ TEST_F(MeshHalfSpaceDerivativesTest, Pressure) {
                                 double theta) {
     constexpr double kEps = std::numeric_limits<double>::epsilon();
     const Vector3d& n_W = X_WS.rotation().col(2);
-    for (int v = 0; v < surface.mesh_W().num_vertices(); ++v) {
-      const auto& p_WV = surface.mesh_W().vertex(v);
+    for (int v = 0; v < surface.tri_mesh_W().num_vertices(); ++v) {
+      const auto& p_WV = surface.tri_mesh_W().vertex(v);
       const Matrix3<double> dV_dRo = math::ExtractGradient(p_WV);
       const Vector3d expected_dp_dRo = -E * n_W.transpose() * dV_dRo;
-      const AutoDiffXd& p = surface.e_MN().EvaluateAtVertex(v);
+      const AutoDiffXd& p = surface.tri_e_MN().EvaluateAtVertex(v);
       EXPECT_TRUE(
           CompareMatrices(p.derivatives(), expected_dp_dRo, 3 * E * kEps));
     }


### PR DESCRIPTION
This reframes mesh-half space intersection to use the new `MeshBuilder` so it can create either polygon or triangle mesh representations. The APIs have been modified to communicate the desired representation and the tests have been updated accordingly.

Various related call sites have been updated to *explicitly* request triangle meshes (this was implicit before).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16164)
<!-- Reviewable:end -->
