### PR TITLE
Replace relative paths with package URIs in models

### DIFF
--- a/geometry/render/test/box.sdf
+++ b/geometry/render/test/box.sdf
@@ -22,7 +22,7 @@
       <visual name="box">
         <geometry>
           <mesh>
-            <uri>meshes/box.obj</uri>
+            <uri>package://drake/geometry/render/test/meshes/box.obj</uri>
           </mesh>
         </geometry>
       </visual>

--- a/manipulation/models/iiwa_description/iiwa7/iiwa7_with_box_collision.sdf
+++ b/manipulation/models/iiwa_description/iiwa7/iiwa7_with_box_collision.sdf
@@ -18,7 +18,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>link_0.obj</uri>
+            <uri>package://drake/manipulation/models/iiwa_description/iiwa7/link_0.obj</uri>
           </mesh>
         </geometry>
         <material>
@@ -55,7 +55,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>link_1.obj</uri>
+            <uri>package://drake/manipulation/models/iiwa_description/iiwa7/link_1.obj</uri>
           </mesh>
         </geometry>
         <material>
@@ -111,7 +111,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>link_2.obj</uri>
+            <uri>package://drake/manipulation/models/iiwa_description/iiwa7/link_2.obj</uri>
           </mesh>
         </geometry>
         <material>
@@ -167,7 +167,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>link_3.obj</uri>
+            <uri>package://drake/manipulation/models/iiwa_description/iiwa7/link_3.obj</uri>
           </mesh>
         </geometry>
         <material>
@@ -223,7 +223,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>link_4.obj</uri>
+            <uri>package://drake/manipulation/models/iiwa_description/iiwa7/link_4.obj</uri>
           </mesh>
         </geometry>
         <material>
@@ -279,7 +279,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>link_5.obj</uri>
+            <uri>package://drake/manipulation/models/iiwa_description/iiwa7/link_5.obj</uri>
           </mesh>
         </geometry>
         <material>
@@ -336,7 +336,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>link_6.obj</uri>
+            <uri>package://drake/manipulation/models/iiwa_description/iiwa7/link_6.obj</uri>
           </mesh>
         </geometry>
         <material>
@@ -391,7 +391,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>link_7.obj</uri>
+            <uri>package://drake/manipulation/models/iiwa_description/iiwa7/link_7.obj</uri>
           </mesh>
         </geometry>
         <material>

--- a/multibody/parsing/test/links_with_visuals_and_collisions.sdf
+++ b/multibody/parsing/test/links_with_visuals_and_collisions.sdf
@@ -26,7 +26,7 @@
       <visual name="link1_visual2">
         <geometry>
           <mesh>
-            <uri>tri_cube.obj</uri>
+            <uri>package://drake/multibody/parsing/test/tri_cube.obj</uri>
           </mesh>
         </geometry>
       </visual>

--- a/multibody/parsing/test/links_with_visuals_and_collisions.urdf
+++ b/multibody/parsing/test/links_with_visuals_and_collisions.urdf
@@ -18,7 +18,7 @@
     </visual>
     <visual name="link1_visual2">
       <geometry>
-        <mesh filename="tri_cube.obj"/>
+        <mesh filename="package://drake/multibody/parsing/test/tri_cube.obj"/>
       </geometry>
     </visual>
     <collision name="link1_collision1">

--- a/multibody/parsing/test/sdf_parser_test/all_geometries_as_collision.sdf
+++ b/multibody/parsing/test/sdf_parser_test/all_geometries_as_collision.sdf
@@ -51,7 +51,7 @@
         <geometry>
           <mesh>
             <drake:declare_convex/>
-            <uri>../tri_cube.obj</uri>
+            <uri>package://drake/multibody/parsing/test/tri_cube.obj</uri>
           </mesh>
         </geometry>
       </collision>
@@ -95,7 +95,7 @@
       <collision name="Mesh">
         <geometry>
           <mesh>
-            <uri>../tri_cube.obj</uri>
+            <uri>package://drake/multibody/parsing/test/tri_cube.obj</uri>
           </mesh>
         </geometry>
       </collision>

--- a/multibody/parsing/test/sdf_parser_test/all_geometries_as_visual.sdf
+++ b/multibody/parsing/test/sdf_parser_test/all_geometries_as_visual.sdf
@@ -59,7 +59,7 @@
         <geometry>
           <mesh>
             <drake:declare_convex/>
-            <uri>../tri_cube.obj</uri>
+            <uri>package://drake/multibody/parsing/test/tri_cube.obj</uri>
           </mesh>
         </geometry>
       </visual>
@@ -103,7 +103,7 @@
       <visual name="Mesh">
         <geometry>
           <mesh>
-            <uri>../tri_cube.obj</uri>
+            <uri>package://drake/multibody/parsing/test/tri_cube.obj</uri>
           </mesh>
         </geometry>
       </visual>

--- a/multibody/parsing/test/urdf_parser_test/all_geometries_as_collision.urdf
+++ b/multibody/parsing/test/urdf_parser_test/all_geometries_as_collision.urdf
@@ -28,7 +28,7 @@
     </collision>
     <collision name="Convex">
       <geometry>
-        <mesh filename="../tri_cube.obj">
+        <mesh filename="package://drake/multibody/parsing/test/tri_cube.obj">
           <drake:declare_convex/>
         </mesh>
       </geometry>
@@ -56,7 +56,7 @@
     -->
     <collision name="Mesh">
       <geometry>
-        <mesh filename="../tri_cube.obj"/>
+        <mesh filename="package://drake/multibody/parsing/test/tri_cube.obj"/>
       </geometry>
     </collision>
     <collision name="Sphere">

--- a/multibody/parsing/test/urdf_parser_test/all_geometries_as_visual.urdf
+++ b/multibody/parsing/test/urdf_parser_test/all_geometries_as_visual.urdf
@@ -28,7 +28,7 @@
     </visual>
     <visual name="Convex">
       <geometry>
-        <mesh filename="../tri_cube.obj">
+        <mesh filename="package://drake/multibody/parsing/test/tri_cube.obj">
           <drake:declare_convex/>
         </mesh>
       </geometry>
@@ -56,7 +56,7 @@
     -->
     <visual name="Mesh">
       <geometry>
-        <mesh filename="../tri_cube.obj"/>
+        <mesh filename="package://drake/multibody/parsing/test/tri_cube.obj"/>
       </geometry>
     </visual>
     <visual name="Sphere">

--- a/multibody/parsing/test/urdf_parser_test/convex_and_nonconvex_test.urdf
+++ b/multibody/parsing/test/urdf_parser_test/convex_and_nonconvex_test.urdf
@@ -9,14 +9,14 @@ This URDF contains a single link with, in order:
   <link name="base_link">
     <collision>
       <geometry>
-        <mesh filename="../tri_cube.obj">
+        <mesh filename="package://drake/multibody/parsing/test/tri_cube.obj">
           <drake:declare_convex/>
         </mesh>
       </geometry>
     </collision>
     <collision>
       <geometry>
-        <mesh filename="../tri_cube.obj"/>
+        <mesh filename="package://drake/multibody/parsing/test/tri_cube.obj"/>
       </geometry>
     </collision>
   </link>

--- a/multibody/parsing/test/urdf_parser_test/non_conflicting_materials_2.urdf
+++ b/multibody/parsing/test/urdf_parser_test/non_conflicting_materials_2.urdf
@@ -27,7 +27,7 @@ material should indeed be brown.
     </visual>
     <visual>
       <geometry>
-        <mesh filename="../tri_cube.obj" scale="1.1 1.1 1.1"/>
+        <mesh filename="package://drake/multibody/parsing/test/tri_cube.obj" scale="1.1 1.1 1.1"/>
       </geometry>
     </visual>
     <collision>


### PR DESCRIPTION
For the sake of consistency among other reasons, replace the handful of model-relative file paths with absolute `package://` URIs.

Related to #10218 and #10531

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16173)
<!-- Reviewable:end -->
