### PR TITLE
[hydro] Connect polygonal contact surface into dynamics

### DIFF
--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -82,6 +82,7 @@ DEFINE_bool(rigid_cylinders, true,
             "Set to true, the cylinders are given a rigid "
             "hydroelastic representation");
 DEFINE_bool(hybrid, false, "Set to true to run hybrid hydroelastic");
+DEFINE_bool(polygons, false, "Set to true to get polygonal contact surfaces");
 DEFINE_bool(force_full_name, false,
             "If true, the message will declare the body names are not unique, "
             "forcing the visualizer to use the full model/body names.");
@@ -208,13 +209,14 @@ class ContactResultMaker final : public LeafSystem<double> {
         get_geometry_query_port().Eval<QueryObject<double>>(context);
     std::vector<ContactSurface<double>> surfaces;
     std::vector<PenetrationAsPointPair<double>> points;
+    const geometry::HydroelasticContactRepresentation representation =
+        FLAGS_polygons ? geometry::HydroelasticContactRepresentation::kPolygon
+                       : geometry::HydroelasticContactRepresentation::kTriangle;
     if (use_strict_hydro_) {
-      surfaces = query_object.ComputeContactSurfaces(
-          geometry::HydroelasticContactRepresentation::kTriangle);
+      surfaces = query_object.ComputeContactSurfaces(representation);
     } else {
-      query_object.ComputeContactSurfacesWithFallback(
-          geometry::HydroelasticContactRepresentation::kTriangle, &surfaces,
-          &points);
+      query_object.ComputeContactSurfacesWithFallback(representation, &surfaces,
+                                                      &points);
     }
     const int num_surfaces = static_cast<int>(surfaces.size());
     const int num_pairs = static_cast<int>(points.size());
@@ -267,28 +269,22 @@ class ContactResultMaker final : public LeafSystem<double> {
             inspector.NumGeometriesForFrameWithRole(inspector.GetFrameId(id2),
                                                     Role::kProximity);
 
-        const auto& mesh_W = surface.tri_mesh_W();
-        const auto& e_MN_W = surface.tri_e_MN();
         // Fake contact *force* and *moment* data, with some variations across
         // different faces to facilitate visualizer testing.
-        write_double3(mesh_W.centroid(), surface_message.centroid_W);
+        write_double3(surface.centroid(), surface_message.centroid_W);
         write_double3(Vector3<double>(1.2 * (i + 1), 0, 0),
                       surface_message.force_C_W);
         write_double3(Vector3<double>(0, 0, 0.5 * (i + 1)),
                       surface_message.moment_C_W);
 
         // Write fake quadrature data.
-        surface_message.num_quadrature_points = mesh_W.num_triangles();
+        surface_message.num_quadrature_points = surface.num_faces();
         surface_message.quadrature_point_data.resize(
             surface_message.num_quadrature_points);
         for (int j = 0; j < surface_message.num_quadrature_points; ++j) {
           lcmt_hydroelastic_quadrature_per_point_data_for_viz&
               quad_data_message = surface_message.quadrature_point_data[j];
-          const auto& face = mesh_W.element(j);
-          const Vector3d& vA = mesh_W.vertex(face.vertex(0));
-          const Vector3d& vB = mesh_W.vertex(face.vertex(1));
-          const Vector3d& vC = mesh_W.vertex(face.vertex(2));
-          write_double3((vA + vB + vC) / 3.0, quad_data_message.p_WQ);
+          write_double3(surface.centroid(j), quad_data_message.p_WQ);
           write_double3(Vector3d(0, 0.2 + (j * 0.005), 0),
                         quad_data_message.vt_BqAq_W);
           write_double3(Vector3d(0, -0.2 - (j * 0.005), 0),
@@ -296,29 +292,48 @@ class ContactResultMaker final : public LeafSystem<double> {
         }
 
         // Now write the *real* mesh.
-        const int num_vertices = mesh_W.num_vertices();
+        const int num_vertices = surface.num_vertices();
         surface_message.num_vertices = num_vertices;
         surface_message.p_WV.resize(num_vertices);
         surface_message.pressure.resize(num_vertices);
 
-        // Write vertices and per vertex pressure values.
-        for (int v = 0; v < num_vertices; ++v) {
-          const Vector3d& p_WV = mesh_W.vertex(v);
-          surface_message.p_WV[v] = {p_WV.x(), p_WV.y(), p_WV.z()};
-          surface_message.pressure[v] =
-              ExtractDoubleOrThrow(e_MN_W.EvaluateAtVertex(v));
-        }
+        if (surface.is_triangle()) {
+          const auto& mesh_W = surface.tri_mesh_W();
+          const auto& e_MN_W = surface.tri_e_MN();
 
-        // Write faces.
-        surface_message.poly_data_int_count = mesh_W.num_triangles() * 4;
-        surface_message.poly_data.resize(surface_message.poly_data_int_count);
-        int index = -1;
-        for (int t = 0; t < mesh_W.num_triangles(); ++t) {
-          const geometry::SurfaceTriangle& tri = mesh_W.element(t);
-          surface_message.poly_data[++index] = 3;
-          surface_message.poly_data[++index] = tri.vertex(0);
-          surface_message.poly_data[++index] = tri.vertex(1);
-          surface_message.poly_data[++index] = tri.vertex(2);
+          // Write vertices and per vertex pressure values.
+          for (int v = 0; v < num_vertices; ++v) {
+            const Vector3d& p_WV = mesh_W.vertex(v);
+            surface_message.p_WV[v] = {p_WV.x(), p_WV.y(), p_WV.z()};
+            surface_message.pressure[v] =
+                ExtractDoubleOrThrow(e_MN_W.EvaluateAtVertex(v));
+          }
+
+          // Write faces.
+          surface_message.poly_data_int_count = mesh_W.num_triangles() * 4;
+          surface_message.poly_data.resize(surface_message.poly_data_int_count);
+          int index = -1;
+          for (int t = 0; t < mesh_W.num_triangles(); ++t) {
+            const geometry::SurfaceTriangle& tri = mesh_W.element(t);
+            surface_message.poly_data[++index] = 3;
+            surface_message.poly_data[++index] = tri.vertex(0);
+            surface_message.poly_data[++index] = tri.vertex(1);
+            surface_message.poly_data[++index] = tri.vertex(2);
+          }
+        } else {
+          const auto& mesh_W = surface.poly_mesh_W();
+          const auto& e_MN_W = surface.poly_e_MN();
+
+          // Write vertices and per vertex pressure values.
+          for (int v = 0; v < num_vertices; ++v) {
+            const Vector3d& p_WV = mesh_W.vertex(v);
+            surface_message.p_WV[v] = {p_WV.x(), p_WV.y(), p_WV.z()};
+            surface_message.pressure[v] =
+                ExtractDoubleOrThrow(e_MN_W.EvaluateAtVertex(v));
+          }
+
+          surface_message.poly_data_int_count = mesh_W.face_data().size();
+          surface_message.poly_data = mesh_W.face_data();
         }
     }
 

--- a/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
+++ b/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
@@ -270,38 +270,53 @@ class ContactResultMaker final : public LeafSystem<double> {
           msg.hydroelastic_contacts[i];
       const ContactSurface<double>& surface = contacts[i];
 
-      const auto& mesh_W = surface.tri_mesh_W();
-      const auto& e_MN_W = surface.tri_e_MN();
-
       // TODO(SeanCurtis-TRI): This currently skips the full naming and doesn't
       //  report any dynamics (e.g., force, moment, or quadrature data).
 
       surface_message.body1_name = "Id_" + to_string(surface.id_M());
       surface_message.body2_name = "Id_" + to_string(surface.id_N());
 
-      const int num_vertices = mesh_W.num_vertices();
+      const int num_vertices = surface.num_vertices();
       surface_message.num_vertices = num_vertices;
       surface_message.p_WV.resize(num_vertices);
       surface_message.pressure.resize(num_vertices);
+      if (surface.is_triangle()) {
+        const auto& mesh_W = surface.tri_mesh_W();
+        const auto& e_MN_W = surface.tri_e_MN();
 
-      // Write vertices and per vertex pressure values.
-      for (int v = 0; v < num_vertices; ++v) {
-        const Vector3d& p_WV = mesh_W.vertex(v);
-        surface_message.p_WV[v] = {p_WV.x(), p_WV.y(), p_WV.z()};
-        surface_message.pressure[v] =
-            ExtractDoubleOrThrow(e_MN_W.EvaluateAtVertex(v));
-      }
+        // Write vertices and per vertex pressure values.
+        for (int v = 0; v < num_vertices; ++v) {
+          const Vector3d& p_WV = mesh_W.vertex(v);
+          surface_message.p_WV[v] = {p_WV.x(), p_WV.y(), p_WV.z()};
+          surface_message.pressure[v] =
+              ExtractDoubleOrThrow(e_MN_W.EvaluateAtVertex(v));
+        }
 
-      // Write faces.
-      surface_message.poly_data_int_count = mesh_W.num_triangles() * 4;
-      surface_message.poly_data.resize(surface_message.poly_data_int_count);
-      int index = -1;
-      for (int t = 0; t < mesh_W.num_triangles(); ++t) {
-        const geometry::SurfaceTriangle& tri = mesh_W.element(t);
-        surface_message.poly_data[++index] = 3;
-        surface_message.poly_data[++index] = tri.vertex(0);
-        surface_message.poly_data[++index] = tri.vertex(1);
-        surface_message.poly_data[++index] = tri.vertex(2);
+        // Write faces.
+        surface_message.poly_data_int_count = mesh_W.num_triangles() * 4;
+        surface_message.poly_data.resize(surface_message.poly_data_int_count);
+        int index = -1;
+        for (int t = 0; t < mesh_W.num_triangles(); ++t) {
+          const geometry::SurfaceTriangle& tri = mesh_W.element(t);
+          surface_message.poly_data[++index] = 3;
+          surface_message.poly_data[++index] = tri.vertex(0);
+          surface_message.poly_data[++index] = tri.vertex(1);
+          surface_message.poly_data[++index] = tri.vertex(2);
+        }
+      } else {
+        const auto& mesh_W = surface.poly_mesh_W();
+        const auto& e_MN_W = surface.poly_e_MN();
+
+        // Write vertices and per vertex pressure values.
+        for (int v = 0; v < num_vertices; ++v) {
+          const Vector3d& p_WV = mesh_W.vertex(v);
+          surface_message.p_WV[v] = {p_WV.x(), p_WV.y(), p_WV.z()};
+          surface_message.pressure[v] =
+              ExtractDoubleOrThrow(e_MN_W.EvaluateAtVertex(v));
+        }
+
+        surface_message.poly_data_int_count = mesh_W.face_data().size();
+        surface_message.poly_data = mesh_W.face_data();
       }
     }
   }

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -253,20 +253,18 @@ void CompliantContactManager<T>::CalcDiscreteContactPairs(
   }
 
   int num_quadrature_pairs = 0;
-  // N.B. For discrete hydro we use a first order quadrature rule.
-  // Higher order quadratures are possible, however using a lower order
-  // quadrature leads to a smaller number of discrete pairs and therefore a
-  // smaller number of constraints in the discrete contact problem.
-  const GaussianTriangleQuadratureRule quadrature(1 /* order */);
-  const std::vector<double>& wq = quadrature.weights();
-  const int num_quad_points = wq.size();
+  // N.B. For discrete hydro we use a first order quadrature rule. As such,
+  // the per-face quadrature point is the face's centroid and the weight is 1.
+  // This is compatible with a mesh that is triangle or polygon. If we attempted
+  // higher order quadrature, polygons would have to be decomposed into smaller
+  // n-gons which can receive an appropriate set of quadrature points.
   if (contact_model == ContactModel::kHydroelastic ||
       contact_model == ContactModel::kHydroelasticWithFallback) {
     const std::vector<geometry::ContactSurface<T>>& surfaces =
         this->EvalContactSurfaces(context);
     for (const auto& s : surfaces) {
-      const geometry::TriangleSurfaceMesh<T>& mesh = s.tri_mesh_W();
-      num_quadrature_pairs += num_quad_points * mesh.num_triangles();
+      // One quadrature point per face.
+      num_quadrature_pairs += s.num_faces();
     }
   }
   const int num_contact_pairs = num_point_pairs + num_quadrature_pairs;
@@ -326,14 +324,11 @@ void CompliantContactManager<T>::
         std::vector<internal::DiscreteContactPair<T>>* result) const {
   std::vector<internal::DiscreteContactPair<T>>& contact_pairs = *result;
 
-  // N.B. For discrete hydro we use a first order quadrature rule.
-  // Higher order quadratures are possible, however using a lower order
-  // quadrature leads to a smaller number of discrete pairs and therefore a
-  // smaller number of constraints in the discrete contact problem.
-  const GaussianTriangleQuadratureRule quadrature(1 /* order */);
-  const std::vector<Vector2<double>>& xi = quadrature.quadrature_points();
-  const std::vector<double>& wq = quadrature.weights();
-  const int num_quad_points = wq.size();
+  // N.B. For discrete hydro we use a first order quadrature rule. As such,
+  // the per-face quadrature point is the face's centroid and the weight is 1.
+  // This is compatible with a mesh that is triangle or polygon. If we attempted
+  // higher order quadrature, polygons would have to be decomposed into smaller
+  // n-gons which can receive an appropriate set of quadrature points.
 
   const geometry::QueryObject<T>& query_object =
       this->plant()
@@ -343,13 +338,12 @@ void CompliantContactManager<T>::
   const std::vector<geometry::ContactSurface<T>>& surfaces =
       this->EvalContactSurfaces(context);
   for (const auto& s : surfaces) {
-    const geometry::TriangleSurfaceMesh<T>& mesh_W = s.tri_mesh_W();
     const T tau_M = GetDissipationTimeConstant(s.id_M(), inspector);
     const T tau_N = GetDissipationTimeConstant(s.id_N(), inspector);
     const T tau = CombineDissipationTimeConstant(tau_M, tau_N);
 
-    for (int face = 0; face < mesh_W.num_triangles(); ++face) {
-      const T& Ae = mesh_W.area(face);  // Face element area.
+    for (int face = 0; face < s.num_faces(); ++face) {
+      const T& Ae = s.area(face);  // Face element area.
 
       // We found out that the hydroelastic query might report
       // infinitesimally small triangles (consider for instance an initial
@@ -376,84 +370,93 @@ void CompliantContactManager<T>::
 
         // From ContactSurface's documentation: The normal of each face is
         // guaranteed to point "out of" N and "into" M.
-        const Vector3<T>& nhat_W = mesh_W.face_normal(face);
-        for (int qp = 0; qp < num_quad_points; ++qp) {
-          const Vector3<T> barycentric(xi[qp](0), xi[qp](1),
-                                       1.0 - xi[qp](0) - xi[qp](1));
-          // Pressure at the quadrature point.
-          const T p0 = s.tri_e_MN().Evaluate(face, barycentric);
+        const Vector3<T>& nhat_W = s.face_normal(face);
 
-          // Force contribution by this quadrature point.
-          const T fn0 = wq[qp] * Ae * p0;
+        // Position of quadrature point Q in the world frame (since mesh_W
+        // is measured and expressed in W).
+        const Vector3<T>& p_WQ = s.centroid(face);
+        // TODO(DamrongGuoy) EvaluateCartesian() on the triangle mesh field
+        //  is expensive if the field doesn't have the gradients. The
+        //  field computation for triangle representation should capture
+        //  the field gradients, just like the polygon field does. (That
+        //  also unifies the APIs and logic on the geometry side better.)
+        // Pressure at the quadrature point.
+        const T p0 = s.is_triangle()
+                          ? s.tri_e_MN().EvaluateCartesian(face, p_WQ)
+                          : s.poly_e_MN().EvaluateCartesian(face, p_WQ);
 
-          // Since the normal always points into M, regardless of which body
-          // is soft, we must take into account the change of sign when body
-          // N is soft and M is rigid.
-          const T sign = M_is_soft ? 1.0 : -1.0;
+        // Force contribution by this quadrature point.
+        const T fn0 = Ae * p0;
 
-          // In order to provide some intuition, and though not entirely
-          // complete, here we document the first order idea that leads to
-          // the discrete hydroelastic approximation used below. In
-          // hydroelastics, each quadrature point contributes to the total
-          // "elastic" force along the normal direction as:
-          //   f₀ₚ = ωₚ Aₑ pₚ
-          // where subindex p denotes a quantity evaluated at quadrature
-          // point P and subindex e identifies the e-th contact surface
-          // element in which the quadrature is being evaluated.
-          // Notice f₀ only includes the "elastic" contribution. Dissipation is
-          // dealt with by the contact solver. In point contact, stiffness is
-          // related to changes in the normal force with changes in the
-          // penetration distance. In that spirit, the approximation used here
-          // is to define the discrete hydroelastics stiffness as the
-          // directional derivative of the scalar force f₀ₚ along the normal
-          // direction n̂:
-          //   k := ∂f₀ₚ/∂n̂ ≈ ωₚ⋅Aₑ⋅∇pₚ⋅n̂ₚ
-          // that is, the variation of the normal force experiences if the
-          // quadrature point is pushed inwards in the direction of the
-          // normal. Notice that this expression approximates the element
-          // area and normal as constant. Keeping normals and Jacobians
-          // is a very common approximation in first order methods. Keeping
-          // the area constant here is a higher order approximation for
-          // inner triangles given that shrinkage of a triangle is related
-          // the growth of a neighboring triangle (i.e. the contact surface
-          // does not stretch nor shrink). For triangles close to the
-          // boundary of the contact surface, this is only a first order
-          // approximation.
-          //
-          // Refer to [Masterjohn, 2021] for details.
-          //
-          // [Masterjohn, 2021] Masterjohn J., Guoy D., Shepherd J. and Castro
-          // A., 2021. Discrete Approximation of Pressure Field Contact Patches.
-          // Available at https://arxiv.org/abs/2110.04157.
-          const T k = sign * wq[qp] * Ae * grad_pres_W.dot(nhat_W);
+        // Since the normal always points into M, regardless of which body
+        // is soft, we must take into account the change of sign when body
+        // N is soft and M is rigid.
+        const T sign = M_is_soft ? 1.0 : -1.0;
 
-          // N.B. The normal is guaranteed to point into M. However, when M
-          // is soft, the gradient is not guaranteed to be in the direction
-          // of the normal. The geometry code that determines which
-          // triangles to keep in the contact surface may keep triangles for
-          // which the pressure gradient times normal is negative (see
-          // IsFaceNormalInNormalDirection() in contact_surface_utility.cc).
-          // Therefore there are cases for which the definition above of k
-          // might lead to negative values. We observed that this condition
-          // happens sparsely at some of the boundary triangles of the
-          // contact surface, while the positive values in inner triangles
-          // dominates the overall compliance. In practice we did not
-          // observe this to cause stability issues. Since a negative value
-          // of k is correct, we decided to keep these contributions.
+        // TODO(amcastro-tri): Re-wordsmith this so that it's less about
+        //  "quadrature points" and "weights", and more about the first order
+        //  integration of the linear function is simply the value at the
+        //  element centroid times the area of the element. The same update
+        //  should be applied in multibody_plant.cc in
+        //  CalcDiscreteContactPairs().
 
-          // Position of quadrature point Q in the world frame (since mesh_W
-          // is measured and expressed in W).
-          const Vector3<T> p_WQ =
-              mesh_W.CalcCartesianFromBarycentric(face, barycentric);
+        // In order to provide some intuition, and though not entirely
+        // complete, here we document the first order idea that leads to
+        // the discrete hydroelastic approximation used below. In
+        // hydroelastics, each quadrature point contributes to the total
+        // "elastic" force along the normal direction as:
+        //   f₀ₚ = ωₚ Aₑ pₚ
+        // where subindex p denotes a quantity evaluated at quadrature
+        // point P and subindex e identifies the e-th contact surface
+        // element in which the quadrature is being evaluated.
+        // Notice f₀ only includes the "elastic" contribution. Dissipation is
+        // dealt with by the contact solver. In point contact, stiffness is
+        // related to changes in the normal force with changes in the
+        // penetration distance. In that spirit, the approximation used here
+        // is to define the discrete hydroelastics stiffness as the
+        // directional derivative of the scalar force f₀ₚ along the normal
+        // direction n̂:
+        //   k := ∂f₀ₚ/∂n̂ ≈ ωₚ⋅Aₑ⋅∇pₚ⋅n̂ₚ
+        // that is, the variation of the normal force experiences if the
+        // quadrature point is pushed inwards in the direction of the
+        // normal. Notice that this expression approximates the element
+        // area and normal as constant. Keeping normals and Jacobians
+        // is a very common approximation in first order methods. Keeping
+        // the area constant here is a higher order approximation for
+        // inner triangles given that shrinkage of a triangle is related
+        // the growth of a neighboring triangle (i.e. the contact surface
+        // does not stretch nor shrink). For triangles close to the
+        // boundary of the contact surface, this is only a first order
+        // approximation.
+        //
+        // Refer to [Masterjohn, 2021] for details.
+        //
+        // [Masterjohn, 2021] Masterjohn J., Guoy D., Shepherd J. and Castro
+        // A., 2021. Discrete Approximation of Pressure Field Contact Patches.
+        // Available at https://arxiv.org/abs/2110.04157.
+        const T k = sign * Ae * grad_pres_W.dot(nhat_W);
 
-          // phi < 0 when in penetration.
-          const T phi0 = -sign * p0 / grad_pres_W.dot(nhat_W);
+        // N.B. The normal is guaranteed to point into M. However, when M
+        // is soft, the gradient is not guaranteed to be in the direction
+        // of the normal. The geometry code that determines which
+        // triangles to keep in the contact surface may keep triangles for
+        // which the pressure gradient times normal is negative (see
+        // IsFaceNormalInNormalDirection() in contact_surface_utility.cc).
+        // Therefore there are cases for which the definition above of k
+        // might lead to negative values. We observed that this condition
+        // happens sparsely at some of the boundary triangles of the
+        // contact surface, while the positive values in inner triangles
+        // dominates the overall compliance. In practice we did not
+        // observe this to cause stability issues. Since a negative value
+        // of k is correct, we decided to keep these contributions.
 
-          if (k > 0) {
-            const T dissipation = tau * k;
-            contact_pairs.push_back(
-                {s.id_M(), s.id_N(), p_WQ, nhat_W, phi0, fn0, k, dissipation});
-          }
+        // phi < 0 when in penetration.
+        const T phi0 = -sign * p0 / grad_pres_W.dot(nhat_W);
+
+        if (k > 0) {
+          const T dissipation = tau * k;
+          contact_pairs.push_back(
+              {s.id_M(), s.id_N(), p_WQ, nhat_W, phi0, fn0, k, dissipation});
         }
       }
     }

--- a/multibody/plant/hydroelastic_traction_calculator.cc
+++ b/multibody/plant/hydroelastic_traction_calculator.cc
@@ -47,33 +47,42 @@ void HydroelasticTractionCalculator<T>::
   // Reserve enough memory to keep from doing repeated heap allocations in the
   // quadrature process.
   traction_at_quadrature_points->clear();
-  traction_at_quadrature_points->reserve(
-      data.surface.tri_mesh_W().num_triangles());
+  traction_at_quadrature_points->reserve(data.surface.num_faces());
 
   // Integrate the tractions over all triangles in the contact surface.
-  for (int i = 0; i < data.surface.tri_mesh_W().num_triangles(); ++i) {
+  for (int i = 0; i < data.surface.num_faces(); ++i) {
     // Construct the function to be integrated over triangle i.
     // TODO(sherm1) Pull functor creation out of the loop (not a good idea to
     //              create a new functor for every i).
-    std::function<SpatialForce<T>(const Vector3<T>&)> traction_Ac_W =
-        [this, &data, i, dissipation, mu_coulomb,
-         traction_at_quadrature_points](const Vector3<T>& Q_barycentric) {
-          traction_at_quadrature_points->emplace_back(CalcTractionAtPoint(
-              data, i, Q_barycentric, dissipation, mu_coulomb));
-          const HydroelasticQuadraturePointData<T>& traction_output =
-              traction_at_quadrature_points->back();
-          return ComputeSpatialTractionAtAcFromTractionAtAq(
+    if (data.surface.is_triangle()) {
+      std::function<SpatialForce<T>(const Vector3<T>&)> traction_Ac_W =
+          [this, &data, i, dissipation, mu_coulomb,
+           traction_at_quadrature_points](const Vector3<T>& Q_barycentric) {
+            traction_at_quadrature_points->emplace_back(CalcTractionAtPoint(
+                data, i, Q_barycentric, dissipation, mu_coulomb));
+            const HydroelasticQuadraturePointData<T>& traction_output =
+                traction_at_quadrature_points->back();
+            return ComputeSpatialTractionAtAcFromTractionAtAq(
+                data, traction_output.p_WQ, traction_output.traction_Aq_W);
+          };
+
+      // Compute the integral over the triangle to get a force from the
+      // tractions (force/area) at the Gauss points (shifted to C).
+      const SpatialForce<T> Fi_Ac_W =  // Force from triangle i.
+          TriangleQuadrature<SpatialForce<T>, T>::Integrate(
+              traction_Ac_W, gaussian, data.surface.area(i));
+      // Update the spatial force at the centroid.
+      (*F_Ac_W) += Fi_Ac_W;
+    } else {
+      traction_at_quadrature_points->emplace_back(
+          CalcTractionAtCentroid(data, i, dissipation, mu_coulomb));
+      const HydroelasticQuadraturePointData<T>& traction_output =
+          traction_at_quadrature_points->back();
+      const SpatialForce<T> traction_Ac_W =
+          ComputeSpatialTractionAtAcFromTractionAtAq(
               data, traction_output.p_WQ, traction_output.traction_Aq_W);
-        };
-
-    // Compute the integral over the triangle to get a force from the
-    // tractions (force/area) at the Gauss points (shifted to C).
-    const SpatialForce<T> Fi_Ac_W =  // Force from triangle i.
-        TriangleQuadrature<SpatialForce<T>, T>::Integrate(
-            traction_Ac_W, gaussian, data.surface.area(i));
-
-    // Update the spatial force at the centroid.
-    (*F_Ac_W) += Fi_Ac_W;
+      (*F_Ac_W) += data.surface.area(i) * traction_Ac_W;
+    }
   }
 }
 
@@ -144,10 +153,34 @@ HydroelasticTractionCalculator<T>::CalcTractionAtPoint(
   // Contact surfaces are documented to have face normals that point *out of* N
   // and *into* M -- which is the face normal of the contact surface (as
   // documented).
-  const Vector3<T>& nhat_W = data.surface.face_normal(face_index);
+  const Vector3<T> nhat_W = data.surface.face_normal(face_index);
 
   return CalcTractionAtQHelper(data, face_index, e, nhat_W, dissipation,
                                mu_coulomb, p_WQ);
+}
+
+template <typename T>
+HydroelasticQuadraturePointData<T>
+HydroelasticTractionCalculator<T>::CalcTractionAtCentroid(
+    const Data& data, int face_index, double dissipation,
+    double mu_coulomb) const {
+  const Vector3<T>& p_WC = data.surface.centroid(face_index);
+  T e;
+  if (data.surface.is_triangle()) {
+    const typename TriangleSurfaceMesh<T>::template Barycentric<T>
+        centroid_barycentric(1. / 3., 1. / 3., 1. / 3.);
+    e = data.surface.tri_e_MN().Evaluate(face_index, centroid_barycentric);
+  } else {
+    e = data.surface.poly_e_MN().EvaluateCartesian(face_index, p_WC);
+  }
+
+  // Contact surfaces are documented to have face normals that point *out of* N
+  // and *into* M -- which is the face normal of the contact surface (as
+  // documented).
+  const Vector3<T>& nhat_W = data.surface.face_normal(face_index);
+
+  return CalcTractionAtQHelper(data, face_index, e, nhat_W, dissipation,
+                               mu_coulomb, p_WC);
 }
 
 /*

--- a/multibody/plant/hydroelastic_traction_calculator.h
+++ b/multibody/plant/hydroelastic_traction_calculator.h
@@ -25,7 +25,7 @@ namespace internal {
  moment between nominally rigid objects. Proc. IEEE/RSJ Intl. Conf. on
  Intelligent Robots and Systems (IROS), 2019.
 
- This class is only compatible with 'double' and 'AutoDiffXd' scalar types.
+ @tparam_nonsymbolic_scalar
  */
 template <typename T>
 class HydroelasticTractionCalculator {
@@ -144,6 +144,10 @@ class HydroelasticTractionCalculator {
       const Data& data, int face_index,
       const typename geometry::TriangleSurfaceMesh<T>::template Barycentric<T>&
           Q_barycentric,
+      double dissipation, double mu_coulomb) const;
+
+  HydroelasticQuadraturePointData<T> CalcTractionAtCentroid(
+      const Data& data, int face_index,
       double dissipation, double mu_coulomb) const;
 
   HydroelasticQuadraturePointData<T> CalcTractionAtQHelper(

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1981,13 +1981,11 @@ void MultibodyPlant<T>::CalcContactSurfaces(
   const auto& query_object = EvalGeometryQueryInput(context);
 
   if (is_discrete()) {
-    // NOTE: This is currently being left here as a place holder for when
-    // ComputeContactSurfaces takes a flag for indicating mesh representation.
     *contact_surfaces = query_object.ComputeContactSurfaces(
-      geometry::HydroelasticContactRepresentation::kTriangle);
+        geometry::HydroelasticContactRepresentation::kPolygon);
   } else {
     *contact_surfaces = query_object.ComputeContactSurfaces(
-      geometry::HydroelasticContactRepresentation::kTriangle);
+        geometry::HydroelasticContactRepresentation::kTriangle);
   }
 }
 
@@ -2012,11 +2010,8 @@ void MultibodyPlant<T>::CalcHydroelasticWithFallback(
     data->point_pairs.clear();
 
     if (is_discrete()) {
-      // NOTE: This is currently being left here as a place holder for when
-      // ComputeContactSurfacesWithFallback takes a flag for indicating mesh
-      // representation.
       query_object.ComputeContactSurfacesWithFallback(
-          geometry::HydroelasticContactRepresentation::kTriangle,
+          geometry::HydroelasticContactRepresentation::kPolygon,
           &data->contact_surfaces, &data->point_pairs);
     } else {
       query_object.ComputeContactSurfacesWithFallback(
@@ -2048,14 +2043,11 @@ void MultibodyPlant<T>::CalcDiscreteContactPairs(
 
   if (num_collision_geometries() == 0) return;
 
-  // N.B. For discrete hydro we use a first order quadrature rule.
-  // Higher order quadratures are possible, however using a lower order
-  // quadrature leads to a smaller number of discrete pairs and therefore a
-  // smaller number of constraints in the discrete contact problem.
-  const GaussianTriangleQuadratureRule quadrature(1 /* order */);
-  const std::vector<Vector2<double>>& xi = quadrature.quadrature_points();
-  const std::vector<double>& wq = quadrature.weights();
-  const int num_quad_points = wq.size();
+  // N.B. For discrete hydro we use a first order quadrature rule. As such,
+  // the per-face quadrature point is the face's centroid and the weight is 1.
+  // This is compatible with a mesh that is triangle or polygon. If we attempted
+  // higher order quadrature, polygons would have to be decomposed into smaller
+  // n-gons which can receive an appropriate set of quadrature points.
 
   // Only numeric values are supported. We detect that T is a Drake numeric type
   // using scalar_predicate::is_bool. That is true for numeric types and false
@@ -2082,7 +2074,7 @@ void MultibodyPlant<T>::CalcDiscreteContactPairs(
       const std::vector<geometry::ContactSurface<T>>& surfaces =
           EvalContactSurfaces(context);
       for (const auto& s : surfaces) {
-        num_quadrature_pairs += num_quad_points * s.num_faces();
+        num_quadrature_pairs += s.num_faces();
       }
     }
 
@@ -2119,24 +2111,22 @@ void MultibodyPlant<T>::CalcDiscreteContactPairs(
       const std::vector<geometry::ContactSurface<T>>& surfaces =
           EvalContactSurfaces(context);
       for (const auto& s : surfaces) {
-        const geometry::TriangleSurfaceMesh<T>& mesh_W = s.tri_mesh_W();
-
         // Combined Hunt & Crossley dissipation.
         const T dissipation = hydroelastics_engine_.CalcCombinedDissipation(
             s.id_M(), s.id_N(), inspector);
 
-        for (int face = 0; face < mesh_W.num_triangles(); ++face) {
-          const T& Ae = mesh_W.area(face);  // Face element area.
+        for (int face = 0; face < s.num_faces(); ++face) {
+          const T& Ae = s.area(face);  // Face element area.
 
           // We found out that the hydroelastic query might report
-          // infinitesimally small triangles (consider for instance an initial
+          // infinitesimally small faces (consider for instance an initial
           // condition that perfectly places an object at zero distance from the
           // ground.) While the area of zero sized triangles is not a problem by
           // itself, the badly computed normal on these triangles leads to
           // problems when computing the contact Jacobians (since we need to
           // obtain an orthonormal basis based on that normal.)
           // We therefore ignore infinitesimally small triangles. The tolerance
-          // below is somehow arbitrary and could possibly be tightened.
+          // below is somewhat arbitrary and could possibly be tightened.
           if (Ae > 1.0e-14) {
             // N.B Assuming rigid-soft contact, and thus only a single pressure
             // gradient is considered to be valid. We first verify this indeed
@@ -2144,7 +2134,7 @@ void MultibodyPlant<T>::CalcDiscreteContactPairs(
             // information (the volumetric side).
             const bool M_is_soft = s.HasGradE_M();
             const bool N_is_soft = s.HasGradE_N();
-            DRAKE_DEMAND(M_is_soft ^ N_is_soft);
+            DRAKE_DEMAND(M_is_soft != N_is_soft);
 
             // Pressure gradient always points into the soft geometry by
             // construction.
@@ -2154,82 +2144,84 @@ void MultibodyPlant<T>::CalcDiscreteContactPairs(
 
             // From ContactSurface's documentation: The normal of each face is
             // guaranteed to point "out of" N and "into" M.
-            const Vector3<T>& nhat_W = mesh_W.face_normal(face);
-            for (int qp = 0; qp < num_quad_points; ++qp) {
-              const Vector3<T> barycentric(xi[qp](0), xi[qp](1),
-                                           1.0 - xi[qp](0) - xi[qp](1));
-              // Pressure at the quadrature point.
-              const T p0 = s.tri_e_MN().Evaluate(face, barycentric);
+            const Vector3<T>& nhat_W = s.face_normal(face);
 
-              // Force contribution by this quadrature point.
-              const T fn0 = wq[qp] * Ae * p0;
+            // Position of quadrature point Q in the world frame (since mesh_W
+            // is measured and expressed in W).
+            const Vector3<T>& p_WQ = s.centroid(face);
+            // TODO(DamrongGuoy) EvaluateCartesian() on the triangle mesh field
+            //  is expensive if the field doesn't have the gradients. The
+            //  field computation for triangle representation should capture
+            //  the field gradients, just like the polygon field does. (That
+            //  also unifies the APIs and logic on the geometry side better.)
+            // Pressure at the quadrature point.
+            const T p0 = s.is_triangle()
+                             ? s.tri_e_MN().EvaluateCartesian(face, p_WQ)
+                             : s.poly_e_MN().EvaluateCartesian(face, p_WQ);
 
-              // Since the normal always points into M, regardless of which body
-              // is soft, we must take into account the change of sign when body
-              // N is soft and M is rigid.
-              const T sign = M_is_soft ? 1.0 : -1.0;
+            // Force contribution by this quadrature point.
+            const T fn0 = Ae * p0;
 
-              // In order to provide some intuition, and though not entirely
-              // complete, here we document the first order idea that leads to
-              // the discrete hydroelastic approximation used below. In
-              // hydroelastics, each quadrature point contributes to the total
-              // "elastic" force along the normal direction as:
-              //   f₀ₚ = ωₚ Aₑ pₚ
-              // where subindex p denotes a quantity evaluated at quadrature
-              // point P and subindex e identifies the e-th contact surface
-              // element in which the quadrature is being evaluated.
-              // Notice f₀ only includes the "elastic" contribution. Dissipation
-              // is dealt with by a separate multiplicative factor. Given the
-              // local stiffness for the normal forces contribution, our
-              // discrete TAMSI solver implicitly handles the dissipative Hunt &
-              // Crossley forces.
-              // In point contact, stiffness is related to changes in the normal
-              // force with changes in the penetration distance. In that spirit,
-              // the approximation used here is to define the discrete
-              // hydroelastics stiffness as the directional derivative of the
-              // scalar force f₀ₚ along the normal direction n̂:
-              //   k := ∂f₀ₚ/∂n̂ ≈ ωₚ⋅Aₑ⋅∇pₚ⋅n̂ₚ
-              // that is, the variation of the normal force experiences if the
-              // quadrature point is pushed inwards in the direction of the
-              // normal. Notice that this expression approximates the element
-              // area and normal as constant. Keeping normals and Jacobians
-              // is a very common approximation in first order methods. Keeping
-              // the area constant here is a higher order approximation for
-              // inner triangles given that shrinkage of a triangle is related
-              // the growth of a neighboring triangle (i.e. the contact surface
-              // does not stretch nor shrink). For triangles close to the
-              // boundary of the contact surface, this is only a first order
-              // approximation.
-              const T k = sign * wq[qp] * Ae * grad_pres_W.dot(nhat_W);
+            // Since the normal always points into M, regardless of which body
+            // is soft, we must take into account the change of sign when body
+            // N is soft and M is rigid.
+            const T sign = M_is_soft ? 1.0 : -1.0;
 
-              // N.B. The normal is guaranteed to point into M. However, when M
-              // is soft, the gradient is not guaranteed to be in the direction
-              // of the normal. The geometry code that determines which
-              // triangles to keep in the contact surface may keep triangles for
-              // which the pressure gradient times normal is negative (see
-              // IsFaceNormalInNormalDirection() in contact_surface_utility.cc).
-              // Therefore there are cases for which the definition above of k
-              // might lead to negative values. We observed that this condition
-              // happens sparsely at some of the boundary triangles of the
-              // contact surface, while the positive values in inner triangles
-              // dominates the overall compliance. In practice we did not
-              // observe this to cause stability issues. Since a negative value
-              // of k is correct, we decided to keep these contributions.
+            // In order to provide some intuition, and though not entirely
+            // complete, here we document the first order idea that leads to
+            // the discrete hydroelastic approximation used below. In
+            // hydroelastics, each quadrature point contributes to the total
+            // "elastic" force along the normal direction as:
+            //   f₀ₚ = ωₚ Aₑ pₚ
+            // where subindex p denotes a quantity evaluated at quadrature
+            // point P and subindex e identifies the e-th contact surface
+            // element in which the quadrature is being evaluated.
+            // Notice f₀ only includes the "elastic" contribution. Dissipation
+            // is dealt with by a separate multiplicative factor. Given the
+            // local stiffness for the normal forces contribution, our
+            // discrete TAMSI solver implicitly handles the dissipative Hunt &
+            // Crossley forces.
+            // In point contact, stiffness is related to changes in the normal
+            // force with changes in the penetration distance. In that spirit,
+            // the approximation used here is to define the discrete
+            // hydroelastics stiffness as the directional derivative of the
+            // scalar force f₀ₚ along the normal direction n̂:
+            //   k := ∂f₀ₚ/∂n̂ ≈ ωₚ⋅Aₑ⋅∇pₚ⋅n̂ₚ
+            // that is, the variation of the normal force experiences if the
+            // quadrature point is pushed inwards in the direction of the
+            // normal. Notice that this expression approximates the element
+            // area and normal as constant. Keeping normals and Jacobians
+            // is a very common approximation in first order methods. Keeping
+            // the area constant here is a higher order approximation for
+            // inner triangles given that shrinkage of a triangle is related
+            // the growth of a neighboring triangle (i.e. the contact surface
+            // does not stretch nor shrink). For triangles close to the
+            // boundary of the contact surface, this is only a first order
+            // approximation.
+            const T k = sign * Ae * grad_pres_W.dot(nhat_W);
 
-              // Position of quadrature point Q in the world frame (since mesh_W
-              // is measured and expressed in W).
-              const Vector3<T> p_WQ =
-                  mesh_W.CalcCartesianFromBarycentric(face, barycentric);
+            // N.B. The normal is guaranteed to point into M. However, when M
+            // is soft, the gradient is not guaranteed to be in the direction
+            // of the normal. The geometry code that determines which
+            // triangles to keep in the contact surface may keep triangles for
+            // which the pressure gradient times normal is negative (see
+            // IsFaceNormalInNormalDirection() in contact_surface_utility.cc).
+            // Therefore there are cases for which the definition above of k
+            // might lead to negative values. We observed that this condition
+            // happens sparsely at some of the boundary triangles of the
+            // contact surface, while the positive values in inner triangles
+            // dominates the overall compliance. In practice we did not
+            // observe this to cause stability issues. Since a negative value
+            // of k is correct, we decided to keep these contributions.
 
-              // N.B. Today 01/25/2021, Only TAMSI supports discrete
-              // hydroelastics and uses the discrete force fn0 instead of the
-              // distance function phi0. phi0 is only used in experimental
-              // ContactSolver(s). Therefore we set phi0 to NaN since it is not
-              // used by TAMSI.
-              const T nan_phi0 = std::numeric_limits<double>::quiet_NaN();
-              contact_pairs.push_back({s.id_M(), s.id_N(), p_WQ, nhat_W,
-                                       nan_phi0, fn0, k, dissipation});
-            }
+            // N.B. Today 01/25/2021, Only TAMSI supports discrete
+            // hydroelastics and uses the discrete force fn0 instead of the
+            // distance function phi0. phi0 is only used in experimental
+            // ContactSolver(s). Therefore we set phi0 to NaN since it is not
+            // used by TAMSI.
+            const T nan_phi0 = std::numeric_limits<double>::quiet_NaN();
+            contact_pairs.push_back({s.id_M(), s.id_N(), p_WQ, nhat_W, nan_phi0,
+                                     fn0, k, dissipation});
           }
         }
       }

--- a/multibody/plant/test/hydroelastic_traction_test.cc
+++ b/multibody/plant/test/hydroelastic_traction_test.cc
@@ -1,10 +1,12 @@
 #include <fstream>
+#include <ostream>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity/polygon_surface_mesh.h"
 #include "drake/geometry/proximity/triangle_surface_mesh.h"
 #include "drake/geometry/query_results/contact_surface.h"
 #include "drake/geometry/scene_graph.h"
@@ -16,11 +18,25 @@
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/diagram_builder.h"
 
+using drake::geometry::HydroelasticContactRepresentation;
+const HydroelasticContactRepresentation kTriangle =
+    HydroelasticContactRepresentation::kTriangle;
+
+namespace std {
+std::ostream& operator<<(std::ostream& out,
+                         drake::geometry::HydroelasticContactRepresentation r) {
+  out << ((r == kTriangle) ? "Triangles" : "Polygons");
+  return out;
+}
+}  // namespace std
+
 namespace drake {
 
+using Eigen::Vector3d;
 using geometry::ContactSurface;
 using geometry::GeometryId;
 using geometry::MeshFieldLinear;
+using geometry::PolygonSurfaceMesh;
 using geometry::SceneGraph;
 using geometry::SurfaceTriangle;
 using geometry::TriangleSurfaceMesh;
@@ -38,7 +54,7 @@ namespace internal {
 // halfspace were a fluid. The entire wetted surface *would* yield
 // an open box with five faces but, for simplicity, we'll only
 // use the bottom face (two triangles).
-std::unique_ptr<TriangleSurfaceMesh<double>> CreateSurfaceMesh() {
+std::unique_ptr<TriangleSurfaceMesh<double>> CreateTriangleMesh() {
   std::vector<SurfaceTriangle> faces;
 
   // Create the vertices, all of which are offset vectors defined in the
@@ -75,7 +91,7 @@ std::unique_ptr<TriangleSurfaceMesh<double>> CreateSurfaceMesh() {
     // Can't use an ASSERT_TRUE here because it interferes with the return
     // value.
     if (!CompareMatrices(mesh->face_normal(f), -Vector3<double>::UnitZ(),
-        std::numeric_limits<double>::epsilon())) {
+                         std::numeric_limits<double>::epsilon())) {
       throw std::logic_error("Malformed mesh; normals don't point downwards");
     }
   }
@@ -83,10 +99,43 @@ std::unique_ptr<TriangleSurfaceMesh<double>> CreateSurfaceMesh() {
   return mesh;
 }
 
-GeometryId FindGeometry(
-    const MultibodyPlant<double>& plant, const std::string body_name) {
-  const auto& geometries = plant.GetCollisionGeometriesForBody(
-      plant.GetBodyByName(body_name));
+// The same mesh as returned by CreateTriangleMesh() except rather than two
+// triangles, it is a single quad.
+std::unique_ptr<PolygonSurfaceMesh<double>> CreatePolygonMesh() {
+  // Create the vertices, all of which are offset vectors defined in the
+  // halfspace body frame.
+  std::vector<Vector3<double>> vertices = {
+      {0.5, 0.5, -0.5},
+      {-0.5, 0.5, -0.5},
+      {-0.5, -0.5, -0.5},
+      {0.5, -0.5, -0.5},
+  };
+
+  // We define a single square polygon.
+  // The first entry is the number of vertices in the polygon, in this case four
+  // vertices. The next three entries are the indexes of the vertices in vector
+  // "vertices". The normal vector of the quadrilateral is in the -Z direction.
+  std::vector<int> faces = {4, 3, 2, 1, 0};
+
+  auto mesh = std::make_unique<PolygonSurfaceMesh<double>>(std::move(faces),
+                                                           std::move(vertices));
+
+  for (int f = 0; f < mesh->num_faces(); ++f) {
+    // Can't use an ASSERT_TRUE here because it interferes with the return
+    // value.
+    if (!CompareMatrices(mesh->face_normal(f), -Vector3<double>::UnitZ(),
+                         std::numeric_limits<double>::epsilon())) {
+      throw std::logic_error("Malformed mesh; normals don't point downwards");
+    }
+  }
+
+  return mesh;
+}
+
+GeometryId FindGeometry(const MultibodyPlant<double>& plant,
+                        const std::string body_name) {
+  const auto& geometries =
+      plant.GetCollisionGeometriesForBody(plant.GetBodyByName(body_name));
   DRAKE_DEMAND(geometries.size() == 1);
   return geometries[0];
 }
@@ -94,26 +143,42 @@ GeometryId FindGeometry(
 // Creates a contact surface between the two given geometries.
 std::unique_ptr<ContactSurface<double>> CreateContactSurface(
     GeometryId halfspace_id, GeometryId block_id,
-    const math::RigidTransform<double>& X_WH) {
+    const math::RigidTransform<double>& X_WH,
+    geometry::HydroelasticContactRepresentation representation =
+        geometry::HydroelasticContactRepresentation::kTriangle) {
   // Create the surface mesh first (in the halfspace frame); we'll transform
   // it to the world frame *after* we use the vertices in the halfspace frame
   // to determine the hydroelastic pressure.
-  auto mesh = CreateSurfaceMesh();
+  // We create the "e" field values (i.e., "hydroelastic pressure") using
+  // negated "z" values in the half-space frame.
 
-  // Create the "e" field values (i.e., "hydroelastic pressure") using
-  // negated "z" values.
-  std::vector<double> e_MN(mesh->num_vertices());
-  for (int i = 0; i < mesh->num_vertices(); ++i)
-    e_MN[i] = -mesh->vertex(i).z();
-
-  // Now transform the mesh to the world frame, as ContactSurface specifies.
-  mesh->TransformVertices(X_WH);
-
-  TriangleSurfaceMesh<double>* mesh_pointer = mesh.get();
-  return std::make_unique<ContactSurface<double>>(
-      halfspace_id, block_id, std::move(mesh),
-      std::make_unique<MeshFieldLinear<double, TriangleSurfaceMesh<double>>>(
-          std::move(e_MN), mesh_pointer));
+  if (representation ==
+      geometry::HydroelasticContactRepresentation::kTriangle) {
+    auto mesh = CreateTriangleMesh();
+    std::vector<double> e_MN(mesh->num_vertices());
+    for (int i = 0; i < mesh->num_vertices(); ++i)
+      e_MN[i] = -mesh->vertex(i).z();
+    mesh->TransformVertices(X_WH);
+    TriangleSurfaceMesh<double>* mesh_pointer = mesh.get();
+    return std::make_unique<ContactSurface<double>>(
+        halfspace_id, block_id, std::move(mesh),
+        std::make_unique<MeshFieldLinear<double, TriangleSurfaceMesh<double>>>(
+            std::move(e_MN), mesh_pointer));
+  } else {
+    auto mesh = CreatePolygonMesh();
+    std::vector<double> e_MN(mesh->num_vertices());
+    for (int i = 0; i < mesh->num_vertices(); ++i)
+      e_MN[i] = -mesh->vertex(i).z();
+    mesh->TransformVertices(X_WH);
+    PolygonSurfaceMesh<double>* mesh_pointer = mesh.get();
+    return std::make_unique<ContactSurface<double>>(
+        halfspace_id, block_id, std::move(mesh),
+        std::make_unique<MeshFieldLinear<double, PolygonSurfaceMesh<double>>>(
+            std::move(e_MN), mesh_pointer,
+            // In the half space frame, the half space's pressure field is -z
+            // and its gradient is -Hz. We re-express it into the world frame.
+            std::vector<Vector3d>{X_WH.rotation() * -Vector3d::UnitZ()}));
+  }
 }
 
 // This fixture defines a contacting configuration between a box and a
@@ -126,8 +191,10 @@ std::unique_ptr<ContactSurface<double>> CreateContactSurface(
 // an arbitrary set of poses X_WY of frame Y in the world frame W to assess the
 // frame invariance of the computed results, which only depend (modulo the
 // "expressed-in" frame) on the relative pose of the bodies.
-class MultibodyPlantHydroelasticTractionTests :
-public ::testing::TestWithParam<RigidTransform<double>> {
+class MultibodyPlantHydroelasticTractionTests
+    : public ::testing::TestWithParam<
+          std::tuple<RigidTransform<double>,
+                     geometry::HydroelasticContactRepresentation>> {
  public:
   const HydroelasticTractionCalculator<double>& traction_calculator() const {
     return traction_calculator_;
@@ -149,7 +216,15 @@ public ::testing::TestWithParam<RigidTransform<double>> {
   }
 
   const ContactSurface<double>& contact_surface() const {
-      return *contact_surface_;
+    return *contact_surface_;
+  }
+
+  const RigidTransform<double>& GetPose() const {
+    return std::get<0>(GetParam());
+  }
+
+  geometry::HydroelasticContactRepresentation GetRepresentation() const {
+    return std::get<1>(GetParam());
   }
 
   // Returns the default numerical tolerance.
@@ -168,16 +243,21 @@ public ::testing::TestWithParam<RigidTransform<double>> {
     // First compute the traction applied to Body A at point Q, expressed in the
     // world frame.
     HydroelasticQuadraturePointData<double> output =
-        traction_calculator().CalcTractionAtPoint(
-            calculator_data(), 0 /* tri_index */,
-            TriangleSurfaceMesh<double>::Barycentric<double>(1.0, 0.0, 0.0),
-            dissipation, mu_coulomb);
+        traction_calculator().CalcTractionAtCentroid(
+            calculator_data(), 0 /* face index */, dissipation, mu_coulomb);
 
     // Compute the expected point of contact in the world frame. The class
     // definition and SetUp() note that the parameter to this test transforms
     // both bodies from their definition in Frame Y to the world frame.
-    const RigidTransform<double>& X_WY = GetParam();
-    const Vector3<double> p_YQ(0.5, 0.5, -0.5);
+    const RigidTransform<double>& X_WY = GetPose();
+    const geometry::HydroelasticContactRepresentation representation =
+        GetRepresentation();
+    // For the first triangle, the centroid is in the second quadrant of the x-y
+    // plane.
+    // When we use the polygons representation, the centroid is at the origin.
+    const Vector3<double> p_YQ = representation == kTriangle
+                                     ? Vector3d(-1. / 6.0, 1. / 6.0, -0.5)
+                                     : Vector3d(0., 0., -0.5);
     const Vector3<double> p_WQ_expected = X_WY * p_YQ;
 
     // Verify the point of contact.
@@ -270,7 +350,7 @@ public ::testing::TestWithParam<RigidTransform<double>> {
         &diagram_->GetMutableSubsystemContext(plant, context_.get());
 
     // See class documentation for description of Frames Y, B, and H.
-    const RigidTransform<double>& X_WY = GetParam();
+    const RigidTransform<double>& X_WY = GetPose();
     const auto& X_YH = RigidTransform<double>::Identity();
     const auto& X_YB = RigidTransform<double>::Identity();
     const RigidTransform<double> X_WH = X_WY * X_YH;
@@ -280,7 +360,8 @@ public ::testing::TestWithParam<RigidTransform<double>> {
 
     GeometryId halfspace_id = internal::FindGeometry(plant, "ground");
     GeometryId block_id = internal::FindGeometry(plant, "box");
-    contact_surface_ = CreateContactSurface(halfspace_id, block_id, X_WH);
+    contact_surface_ =
+        CreateContactSurface(halfspace_id, block_id, X_WH, GetRepresentation());
   }
 
   const double tol_{10 * std::numeric_limits<double>::epsilon()};
@@ -308,25 +389,26 @@ TEST_P(MultibodyPlantHydroelasticTractionTests, VanillaTraction) {
   // Re-express the spatial tractions in Y's frame for easy interpretability.
   // Note that f and tau here are still tractions, so our notation is being
   // misused a little here.
-  const math::RotationMatrix<double>& R_WY = GetParam().rotation();
+  const math::RotationMatrix<double>& R_WY = GetPose().rotation();
   const Vector3<double> f_Bo_Y = R_WY.transpose() * Ft_Bo_W.translational();
   const Vector3<double> tau_Bo_Y = R_WY.transpose() * Ft_Bo_W.rotational();
 
   // Check the spatial traction at p. We know that geometry M is the halfspace,
   // so we'll check the spatial traction for geometry N instead. Note that the
   // tangential components are zero.
-  EXPECT_NEAR(f_Bo_Y[0], 0.0, tol());
-  EXPECT_NEAR(f_Bo_Y[1], 0.0, tol());
-  EXPECT_NEAR(f_Bo_Y[2], 0.5, tol());
+  const Vector3d f_Bo_Y_expected(0., 0., 0.5);
+  EXPECT_TRUE(CompareMatrices(f_Bo_Y, f_Bo_Y_expected, tol()));
 
   // A moment on the box will be generated due to the normal traction. The
   // origin of the box frame is located at (0,0,0) in the Y frame.
-  // The moment arm at the point will be (.5, .5, -.5), again in the Y frame.
-  // Crossing this vector with the traction at that point (0, 0, 0.5) yields the
-  // following.
-  EXPECT_NEAR(tau_Bo_Y[0], 0.25, tol());
-  EXPECT_NEAR(tau_Bo_Y[1], -0.25, tol());
-  EXPECT_NEAR(tau_Bo_Y[2], 0, tol());
+  // The moment arm at the point will be (-1./6., 1./6., -.5), again in the Y
+  // frame. Crossing this vector with the traction at that point (0, 0, 0.5)
+  // yields the following.
+  const Vector3d p_BoCo_Y = GetRepresentation() == kTriangle
+                                ? Vector3d(-1. / 6., 1. / 6., -.5)
+                                : Vector3d(0., 0., -0.5);
+  const Vector3d tau_Bo_Y_expected = p_BoCo_Y.cross(f_Bo_Y_expected);
+  EXPECT_TRUE(CompareMatrices(tau_Bo_Y, tau_Bo_Y_expected, tol()));
 
   // The translational components of the two wrenches should be equal and
   // opposite.
@@ -342,7 +424,7 @@ TEST_P(MultibodyPlantHydroelasticTractionTests, TractionWithFriction) {
 
   // Give the box an initial (vertical) velocity along the +x axis in the Y
   // frame.
-  const math::RotationMatrix<double>& R_WY = GetParam().rotation();
+  const math::RotationMatrix<double>& R_WY = GetPose().rotation();
   SetBoxTranslationalVelocity(R_WY * Vector3<double>(1, 0, 0));
 
   // Compute the spatial tractions at the origins of the body frames.
@@ -367,17 +449,23 @@ TEST_P(MultibodyPlantHydroelasticTractionTests, TractionWithFriction) {
   const double field_value = 0.5;  // in N/m².
   const double regularization_scalar =
       traction_calculator().regularization_scalar();
-  EXPECT_NEAR(f_Bo_Y[0], -mu_coulomb * field_value, regularization_scalar);
-  EXPECT_NEAR(f_Bo_Y[1], 0.0, tol());
-  EXPECT_NEAR(f_Bo_Y[2], field_value, tol());
+  const Vector3d f_Bo_Y_expected(-mu_coulomb * field_value, 0., field_value);
+  EXPECT_NEAR(f_Bo_Y(0), f_Bo_Y_expected(0), regularization_scalar);
+  EXPECT_NEAR(f_Bo_Y(1), f_Bo_Y_expected(1), tol());
+  EXPECT_NEAR(f_Bo_Y(2), f_Bo_Y_expected(2), tol());
 
   // A moment on the box will be generated due to the traction. The
   // origin of the box frame is located at (0,0,0) in the Y frame.
-  // The moment arm at the point will be (.5, .5, -.5). Crossing this vector
-  // with the traction at that point (-.5, 0, 0.5) yields the following.
-  EXPECT_NEAR(tau_Bo_Y[0], 0.25, tol());
-  EXPECT_NEAR(tau_Bo_Y[1], 0.0, regularization_scalar);
-  EXPECT_NEAR(tau_Bo_Y[2], 0.25, regularization_scalar);
+  // The moment arm at the point will be (-1./6., 1./6., -.5), again in the Y
+  // frame. Crossing this vector with the traction at that point (0, 0, 0.5)
+  // yields the following.
+  const Vector3d p_BoCo_Y = GetRepresentation() == kTriangle
+                                ? Vector3d(-1. / 6., 1. / 6., -.5)
+                                : Vector3d(0., 0., -0.5);
+  const Vector3d tau_Bo_Y_expected = p_BoCo_Y.cross(f_Bo_Y_expected);
+  EXPECT_NEAR(tau_Bo_Y(0), tau_Bo_Y_expected(0), tol());
+  EXPECT_NEAR(tau_Bo_Y(1), tau_Bo_Y_expected(1), regularization_scalar);
+  EXPECT_NEAR(tau_Bo_Y(2), tau_Bo_Y_expected(2), regularization_scalar);
 
   // The translational components of the two wrenches should be equal and
   // opposite.
@@ -393,7 +481,7 @@ TEST_P(MultibodyPlantHydroelasticTractionTests, TractionWithDissipation) {
 
   // Give the box an initial (vertical) velocity along the -z axis in the Y
   // frame.
-  const math::RotationMatrix<double>& R_WY = GetParam().rotation();
+  const math::RotationMatrix<double>& R_WY = GetPose().rotation();
   const double separating_velocity = -1.0;
   SetBoxTranslationalVelocity(R_WY *
       Vector3<double>(0, 0, separating_velocity));
@@ -421,18 +509,19 @@ TEST_P(MultibodyPlantHydroelasticTractionTests, TractionWithDissipation) {
   // so we'll check the spatial traction for geometry N instead. The coefficient
   // of friction is unity, so the total frictional traction will have the same
   // magnitude as the normal traction.
-  EXPECT_NEAR(f_Bo_Y[0], 0.0, tol());
-  EXPECT_NEAR(f_Bo_Y[1], 0.0, tol());
-  EXPECT_NEAR(f_Bo_Y[2], normal_traction_magnitude, tol());
+  const Vector3d f_Bo_Y_expected(0., 0., normal_traction_magnitude);
+  EXPECT_TRUE(CompareMatrices(f_Bo_Y, f_Bo_Y_expected, tol()));
 
   // A moment on the box will be generated due to the traction. The
   // origin of the box frame is located at (0,0,0) in the world frame.
   // The moment arm at the point will be (.5, .5, -.5). Crossing this vector
   // with the traction at that point (0, 0, normal_traction_magnitude) yields
   // the following.
-  EXPECT_NEAR(tau_Bo_Y[0], 0.5 * normal_traction_magnitude, tol());
-  EXPECT_NEAR(tau_Bo_Y[1], -0.5 * normal_traction_magnitude, tol());
-  EXPECT_NEAR(tau_Bo_Y[2], 0.0, tol());
+  const Vector3d p_BoCo_Y = GetRepresentation() == kTriangle
+                                ? Vector3d(-1. / 6., 1. / 6., -.5)
+                                : Vector3d(0., 0., -0.5);
+  const Vector3d tau_Bo_Y_expected = p_BoCo_Y.cross(f_Bo_Y_expected);
+  EXPECT_TRUE(CompareMatrices(tau_Bo_Y, tau_Bo_Y_expected, tol()));
 
   // The translational components of the two wrenches should be equal and
   // opposite.
@@ -452,7 +541,7 @@ TEST_P(MultibodyPlantHydroelasticTractionTests, VanillaTractionOverPatch) {
       dissipation, mu_coulomb, &F_Ao_W, &F_Bo_W);
 
   // Re-express the spatial forces in Y's frame for easy interpretability.
-  const math::RotationMatrix<double>& R_WY = GetParam().rotation();
+  const math::RotationMatrix<double>& R_WY = GetPose().rotation();
   const Vector3<double> f_Bo_Y = R_WY.transpose() * F_Bo_W.translational();
   const Vector3<double> tau_Bo_Y = R_WY.transpose() * F_Bo_W.rotational();
 
@@ -477,7 +566,7 @@ TEST_P(MultibodyPlantHydroelasticTractionTests, FrictionalTractionOverPatch) {
 
   // Give the box an initial (vertical) velocity along the +x axis in the Y
   // frame.
-  const math::RotationMatrix<double>& R_WY = GetParam().rotation();
+  const math::RotationMatrix<double>& R_WY = GetPose().rotation();
   SetBoxTranslationalVelocity(R_WY * Vector3<double>(1, 0, 0));
 
   // Compute the spatial forces at the origins of the body frames.
@@ -523,7 +612,7 @@ TEST_P(MultibodyPlantHydroelasticTractionTests,
 
   // Give the box an initial (vertical) velocity along the -z axis in the Y
   // frame.
-  const math::RotationMatrix<double>& R_WY = GetParam().rotation();
+  const math::RotationMatrix<double>& R_WY = GetPose().rotation();
   const double separating_velocity = -1.0;
   SetBoxTranslationalVelocity(R_WY *
       Vector3<double>(0, 0, separating_velocity));
@@ -785,7 +874,7 @@ class HydroelasticReportingTests
     const GeometryId null_id;
 
     // Create the surface mesh first.
-    auto mesh = CreateSurfaceMesh();
+    auto mesh = CreateTriangleMesh();
 
     // Create the e field values (i.e., "hydroelastic pressure").
     std::vector<double> e_MN(mesh->num_vertices());
@@ -836,9 +925,14 @@ const RigidTransform<double> poses[] = {
         drake::Vector3<double>(1, 2, 3))
 };
 
-INSTANTIATE_TEST_SUITE_P(PoseInstantiations,
-                        MultibodyPlantHydroelasticTractionTests,
-                        ::testing::ValuesIn(poses));
+const geometry::HydroelasticContactRepresentation representations[] = {
+    geometry::HydroelasticContactRepresentation::kTriangle,
+    geometry::HydroelasticContactRepresentation::kPolygon};
+
+INSTANTIATE_TEST_SUITE_P(
+    TractionTestsInstantiations, MultibodyPlantHydroelasticTractionTests,
+    ::testing::Combine(::testing::ValuesIn(poses),
+                       ::testing::ValuesIn(representations)));
 
 // TODO(edrumwri) Break the tests below out into a separate file.
 
@@ -924,4 +1018,3 @@ GTEST_TEST(HydroelasticContactInfo, MoveConstruction) {
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake
-

--- a/multibody/plant/test/multibody_plant_hydroelastic_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_test.cc
@@ -576,6 +576,141 @@ TEST_F(ContactModelTest, HydroelasticWithFallbackDisconnectedPorts) {
       "port in a Diagram.");
 }
 
+// TODO(DamrongGuoy): Create an independent test fixture instead of using
+//  inheritance and consider using parameter-value tests.
+
+// Tests MultibodyPlant::CalcContactSurfaces() which is used in
+// kHydroelastic contact model for both continuous systems and discrete
+// systems.
+//
+// This fixture sets up only rigid-compliant contact without rigid-rigid
+// contact.
+class CalcContactSurfacesTest : public ContactModelTest {
+ protected:
+  // @param time_step   Set to 0 to select a continuous system, and non-zero
+  //                    for a discrete system. The actual non-zero value is not
+  //                    relevant because we are not doing time stepping.
+  void Configure(double time_step) {
+    const bool connect_scene_graph = true;
+    // No rigid-rigid contact. Only the rigid-compliant contact.
+    bool are_rigid_spheres_in_contact = false;
+    ContactModelTest::Configure(ContactModel::kHydroelastic,
+                                connect_scene_graph, time_step,
+                                are_rigid_spheres_in_contact);
+  }
+};
+
+TEST_F(CalcContactSurfacesTest, ContinuousSystem_Triangles) {
+  const double time_step = 0.0;  // Zero to select continuous system.
+  this->Configure(time_step);
+
+  const ContactResults<double>& contact_results = GetContactResults();
+
+  EXPECT_EQ(contact_results.num_point_pair_contacts(), 0);
+  EXPECT_EQ(contact_results.num_hydroelastic_contacts(), 1);
+  EXPECT_TRUE(
+      contact_results.hydroelastic_contact_info(0).contact_surface().Equal(
+          plant_->get_geometry_query_input_port()
+              .template Eval<geometry::QueryObject<double>>(*plant_context_)
+              .ComputeContactSurfaces(
+                  geometry::HydroelasticContactRepresentation::kTriangle)
+              .at(0)));
+}
+
+TEST_F(CalcContactSurfacesTest, DiscreteSystem_Polygons) {
+  const double time_step = 5.0e-3;  // Non-zero to select discrete system.
+  this->Configure(time_step);
+
+  const ContactResults<double>& contact_results = GetContactResults();
+
+  EXPECT_EQ(contact_results.num_point_pair_contacts(), 0);
+  EXPECT_EQ(contact_results.num_hydroelastic_contacts(), 1);
+  EXPECT_TRUE(
+      contact_results.hydroelastic_contact_info(0).contact_surface().Equal(
+          plant_->get_geometry_query_input_port()
+              .template Eval<geometry::QueryObject<double>>(*plant_context_)
+              .ComputeContactSurfaces(
+                  geometry::HydroelasticContactRepresentation::kPolygon)
+              .at(0)));
+}
+
+// TODO(DamrongGuoy): Create an independent test fixture instead of using
+//  inheritance and consider using parameter-value tests.
+
+// Tests MultibodyPlant::CalcHydroelasticWithFallback() which is used in
+// kHydroelasticWithFallback contact model for both continuous systems and
+// discrete systems.
+//
+// This fixture sets up both rigid-compliant contact and rigid-rigid
+// contact.
+class CalcHydroelasticWithFallbackTest : public CalcContactSurfacesTest {
+ protected:
+  // @param time_step   Set to 0 to select a continuous system, and non-zero
+  //                    for a discrete system. The actual non-zero value is not
+  //                    relevant because we are not doing time stepping.
+  void Configure(double time_step) {
+    const bool connect_scene_graph = true;
+    // Get both the rigid-rigid-sphere contact and the rigid-compliant
+    // sphere-box contact.
+    bool are_rigid_spheres_in_contact = true;
+    ContactModelTest::Configure(ContactModel::kHydroelasticWithFallback,
+                                connect_scene_graph, time_step,
+                                are_rigid_spheres_in_contact);
+  }
+};
+
+TEST_F(CalcHydroelasticWithFallbackTest, ContinuousSystem_Triangles) {
+  const double time_step = 0.0;  // Zero to select continuous system.
+  this->Configure(time_step);
+
+  const ContactResults<double>& contact_results = GetContactResults();
+
+  std::vector<geometry::ContactSurface<double>> expected_surfaces;
+  std::vector<geometry::PenetrationAsPointPair<double>> expected_point_pairs;
+  plant_->get_geometry_query_input_port()
+      .template Eval<geometry::QueryObject<double>>(*plant_context_)
+      .ComputeContactSurfacesWithFallback(
+          geometry::HydroelasticContactRepresentation::kTriangle,
+          &expected_surfaces, &expected_point_pairs);
+
+  // We only check the penetration depth as an evidence that the tested
+  // result is what expected.
+  EXPECT_EQ(contact_results.num_point_pair_contacts(), 1);
+  EXPECT_EQ(contact_results.point_pair_contact_info(0).point_pair().depth,
+              expected_point_pairs.at(0).depth);
+
+  EXPECT_EQ(contact_results.num_hydroelastic_contacts(), 1);
+  EXPECT_TRUE(
+      contact_results.hydroelastic_contact_info(0).contact_surface().Equal(
+          expected_surfaces.at(0)));
+}
+
+TEST_F(CalcHydroelasticWithFallbackTest, DiscreteSystem_Polygons) {
+  const double time_step = 5.0e-3;  // Non-zero to select discrete system.
+  this->Configure(time_step);
+
+  const ContactResults<double>& contact_results = GetContactResults();
+
+  std::vector<geometry::ContactSurface<double>> expected_surfaces;
+  std::vector<geometry::PenetrationAsPointPair<double>> expected_point_pairs;
+  plant_->get_geometry_query_input_port()
+      .template Eval<geometry::QueryObject<double>>(*plant_context_)
+      .ComputeContactSurfacesWithFallback(
+          geometry::HydroelasticContactRepresentation::kPolygon,
+          &expected_surfaces, &expected_point_pairs);
+
+  // We only check the penetration depth as an evidence that the tested
+  // result is what expected.
+  EXPECT_EQ(contact_results.num_point_pair_contacts(), 1);
+  EXPECT_EQ(contact_results.point_pair_contact_info(0).point_pair().depth,
+            expected_point_pairs.at(0).depth);
+
+  EXPECT_EQ(contact_results.num_hydroelastic_contacts(), 1);
+  EXPECT_TRUE(
+      contact_results.hydroelastic_contact_info(0).contact_surface().Equal(
+          expected_surfaces.at(0)));
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake


### PR DESCRIPTION
- `MultibodyPlant` now uses a polygonal contact surface for discrete hydro.
  - This includes changes to the compliant contact manager and hydro traction calculator.
  - Note: a large portion of the changed loc count is due to large blocks of code having their indentation changed due to the removal of a for loop.
- Objects that visualize contact surfaces are taught about polygonal meshes
  - this includes non-dynamics related stubs in examples and geometry/profiling.

relates #15796

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16175)
<!-- Reviewable:end -->
