### PR TITLE
[hydro] Remove the legacy e_MN() and mesh_W() apis from ContactSurface

### DIFF
--- a/bindings/pydrake/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry_py_scene_graph.cc
@@ -485,7 +485,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
     cls  // BR
         .def("id_M", &Class::id_M, doc.ContactSurface.id_M.doc)
         .def("id_N", &Class::id_N, doc.ContactSurface.id_N.doc)
-        .def("mesh_W", &Class::mesh_W, doc.ContactSurface.mesh_W.doc);
+        .def("tri_mesh_W", &Class::tri_mesh_W,
+            doc.ContactSurface.tri_mesh_W.doc);
   }
 }
 }  // namespace

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2227,7 +2227,7 @@ class TestPlant(unittest.TestCase):
         contact_info = contact_results.hydroelastic_contact_info(0)
         contact_info.contact_surface().id_M()
         contact_info.contact_surface().id_N()
-        contact_info.contact_surface().mesh_W().centroid()
+        contact_info.contact_surface().tri_mesh_W().centroid()
         contact_info.F_Ac_W().get_coeffs()
 
     @numpy_compare.check_nonsymbolic_types

--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -267,8 +267,8 @@ class ContactResultMaker final : public LeafSystem<double> {
             inspector.NumGeometriesForFrameWithRole(inspector.GetFrameId(id2),
                                                     Role::kProximity);
 
-        const auto& mesh_W = surface.mesh_W();
-        const auto& e_MN_W = surface.e_MN();
+        const auto& mesh_W = surface.tri_mesh_W();
+        const auto& e_MN_W = surface.tri_e_MN();
         // Fake contact *force* and *moment* data, with some variations across
         // different faces to facilitate visualizer testing.
         write_double3(mesh_W.centroid(), surface_message.centroid_W);

--- a/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
+++ b/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
@@ -270,8 +270,8 @@ class ContactResultMaker final : public LeafSystem<double> {
           msg.hydroelastic_contacts[i];
       const ContactSurface<double>& surface = contacts[i];
 
-      const auto& mesh_W = surface.mesh_W();
-      const auto& e_MN_W = surface.e_MN();
+      const auto& mesh_W = surface.tri_mesh_W();
+      const auto& e_MN_W = surface.tri_e_MN();
 
       // TODO(SeanCurtis-TRI): This currently skips the full naming and doesn't
       //  report any dynamics (e.g., force, moment, or quadrature data).

--- a/geometry/proximity/test/mesh_to_vtk_test.cc
+++ b/geometry/proximity/test/mesh_to_vtk_test.cc
@@ -87,7 +87,7 @@ GTEST_TEST(MeshToVtkTest, BoxContactSurfacePressure) {
   unique_ptr<ContactSurface<double>> contact = BoxContactSurface();
   auto contact_pressure =
       dynamic_cast<const TriangleSurfaceMeshFieldLinear<double, double>*>(
-          &contact->e_MN());
+          &contact->tri_e_MN());
   ASSERT_NE(contact_pressure, nullptr);
   WriteTriangleSurfaceMeshFieldLinearToVtk(
       temp_directory() + "/" + "box_rigid_soft_contact_pressure.vtk",

--- a/geometry/query_results/contact_surface.h
+++ b/geometry/query_results/contact_surface.h
@@ -342,31 +342,6 @@ class ContactSurface {
                          : HydroelasticContactRepresentation::kPolygon;
   }
 
-  /** Returns a reference to the surface mesh whose vertex positions are
-   measured and expressed in the world frame.
-
-   This method is provided for short-term legacy reasons. Once the polygonal
-   mesh representation is fully supported across the entire contact model
-   code path, this will be removed in favor of its explicitly declared
-   `tri_` or `poly_` variant.
-
-   @pre is_triangle() returns `true`. */
-  const TriangleSurfaceMesh<T>& mesh_W() const {
-    return tri_mesh_W();
-  }
-
-  /** Returns a reference to the scalar field eₘₙ.
-
-   This method is provided for short-term legacy reasons. Once the polygonal
-   mesh representation is fully supported across the entire contact model
-   code path, this will be removed in favor of its explicitly declared
-   `tri_` or `poly_` variant.
-
-   @pre is_triangle() returns `true`. */
-  const TriangleSurfaceMeshFieldLinear<T, T>& e_MN() const {
-    return tri_e_MN();
-  }
-
   /** Returns a reference to the _triangular_ surface mesh whose vertex
    positions are measured and expressed in the world frame.
    @pre `is_triangle()` returns `true`. */

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -292,7 +292,7 @@ GTEST_TEST(ProximityEngineTest, ComputeContactSurfacesAutodiffSupport) {
     // We'll poke *one* quantity of the surface mesh to confirm it has
     // derivatives. We won't consider the *value*, just the existence as proof
     // that it has been wired up to code that has already tested value.
-    EXPECT_EQ(surfaces[0].mesh_W().vertex(0).x().derivatives().size(), 3);
+    EXPECT_EQ(surfaces[0].tri_mesh_W().vertex(0).x().derivatives().size(), 3);
   }
 
   // Case: Rigid sphere and mesh with AutoDiffXd -- contact would be a point

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -265,7 +265,7 @@ void CompliantContactManager<T>::CalcDiscreteContactPairs(
     const std::vector<geometry::ContactSurface<T>>& surfaces =
         this->EvalContactSurfaces(context);
     for (const auto& s : surfaces) {
-      const geometry::TriangleSurfaceMesh<T>& mesh = s.mesh_W();
+      const geometry::TriangleSurfaceMesh<T>& mesh = s.tri_mesh_W();
       num_quadrature_pairs += num_quad_points * mesh.num_triangles();
     }
   }
@@ -343,7 +343,7 @@ void CompliantContactManager<T>::
   const std::vector<geometry::ContactSurface<T>>& surfaces =
       this->EvalContactSurfaces(context);
   for (const auto& s : surfaces) {
-    const geometry::TriangleSurfaceMesh<T>& mesh_W = s.mesh_W();
+    const geometry::TriangleSurfaceMesh<T>& mesh_W = s.tri_mesh_W();
     const T tau_M = GetDissipationTimeConstant(s.id_M(), inspector);
     const T tau_N = GetDissipationTimeConstant(s.id_N(), inspector);
     const T tau = CombineDissipationTimeConstant(tau_M, tau_N);
@@ -381,7 +381,7 @@ void CompliantContactManager<T>::
           const Vector3<T> barycentric(xi[qp](0), xi[qp](1),
                                        1.0 - xi[qp](0) - xi[qp](1));
           // Pressure at the quadrature point.
-          const T p0 = s.e_MN().Evaluate(face, barycentric);
+          const T p0 = s.tri_e_MN().Evaluate(face, barycentric);
 
           // Force contribution by this quadrature point.
           const T fn0 = wq[qp] * Ae * p0;

--- a/multibody/plant/contact_results_to_lcm.cc
+++ b/multibody/plant/contact_results_to_lcm.cc
@@ -219,8 +219,8 @@ void ContactResultsToLcmSystem<T>::CalcLcmContactOutput(
     surface_message.body2_unique = name2.body_name_is_unique;
     surface_message.collision_count2 = name2.geometry_count;
 
-    const auto& mesh_W = contact_surface.mesh_W();
-    const auto& e_MN_W = contact_surface.e_MN();
+    const auto& mesh_W = contact_surface.tri_mesh_W();
+    const auto& e_MN_W = contact_surface.tri_e_MN();
 
     // Resultant force quantities.
     write_double3(mesh_W.centroid(), surface_message.centroid_W);

--- a/multibody/plant/hydroelastic_contact_info.h
+++ b/multibody/plant/hydroelastic_contact_info.h
@@ -62,7 +62,7 @@ class HydroelasticContactInfo {
    @param[in] F_Ac_W Spatial force applied on body A, at contact surface
      centroid C, and expressed in the world frame W. The position `p_WC` of C in
      the world frame W can be obtained with
-     `ContactSurface::mesh_W().centroid()`.
+     `ContactSurface::centroid()`.
    @param[in] quadrature_point_data Hydroelastic field data at each quadrature
      point. Data must be provided in accordance to the convention that geometry
      M and N are attached to bodies A and B, respectively. Refer to
@@ -146,7 +146,7 @@ class HydroelasticContactInfo {
   /// Gets the spatial force applied on body A, at the centroid point C of the
   /// surface mesh M, and expressed in the world frame W. The position `p_WC` of
   /// the centroid point C in the world frame W can be obtained with
-  /// `contact_surface().mesh_W().centroid()`.
+  /// `contact_surface().centroid()`.
   const SpatialForce<T>& F_Ac_W() const { return F_Ac_W_; }
 
  private:

--- a/multibody/plant/hydroelastic_traction_calculator.h
+++ b/multibody/plant/hydroelastic_traction_calculator.h
@@ -42,7 +42,7 @@ class HydroelasticTractionCalculator {
         const geometry::ContactSurface<T>* surface_in) :
             X_WA(X_WA_in), X_WB(X_WB_in), V_WA(V_WA_in), V_WB(V_WB_in),
             surface(*surface_in),
-            p_WC(surface_in->mesh_W().centroid()) {
+            p_WC(surface_in->centroid()) {
       DRAKE_DEMAND(surface_in != nullptr);
     }
 

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -2082,8 +2082,7 @@ void MultibodyPlant<T>::CalcDiscreteContactPairs(
       const std::vector<geometry::ContactSurface<T>>& surfaces =
           EvalContactSurfaces(context);
       for (const auto& s : surfaces) {
-        const geometry::TriangleSurfaceMesh<T>& mesh = s.mesh_W();
-        num_quadrature_pairs += num_quad_points * mesh.num_triangles();
+        num_quadrature_pairs += num_quad_points * s.num_faces();
       }
     }
 
@@ -2120,7 +2119,7 @@ void MultibodyPlant<T>::CalcDiscreteContactPairs(
       const std::vector<geometry::ContactSurface<T>>& surfaces =
           EvalContactSurfaces(context);
       for (const auto& s : surfaces) {
-        const geometry::TriangleSurfaceMesh<T>& mesh_W = s.mesh_W();
+        const geometry::TriangleSurfaceMesh<T>& mesh_W = s.tri_mesh_W();
 
         // Combined Hunt & Crossley dissipation.
         const T dissipation = hydroelastics_engine_.CalcCombinedDissipation(
@@ -2160,7 +2159,7 @@ void MultibodyPlant<T>::CalcDiscreteContactPairs(
               const Vector3<T> barycentric(xi[qp](0), xi[qp](1),
                                            1.0 - xi[qp](0) - xi[qp](1));
               // Pressure at the quadrature point.
-              const T p0 = s.e_MN().Evaluate(face, barycentric);
+              const T p0 = s.tri_e_MN().Evaluate(face, barycentric);
 
               // Force contribution by this quadrature point.
               const T fn0 = wq[qp] * Ae * p0;

--- a/multibody/plant/test/compliant_contact_manager_test.cc
+++ b/multibody/plant/test/compliant_contact_manager_test.cc
@@ -200,7 +200,7 @@ class CompliantContactManagerTest : public ::testing::Test {
     const std::vector<geometry::ContactSurface<double>>& surfaces =
         EvalContactSurfaces(*plant_context_);
     ASSERT_EQ(surfaces.size(), 1u);
-    const int num_hydro_pairs = surfaces[0].mesh_W().num_triangles();
+    const int num_hydro_pairs = surfaces[0].num_faces();
     const std::vector<DiscreteContactPair<double>>& pairs =
         EvalDiscreteContactPairs(*plant_context_);
     EXPECT_EQ(pairs.size(), num_point_pairs + num_hydro_pairs);
@@ -401,8 +401,7 @@ TEST_F(CompliantContactManagerTest,
   const std::vector<geometry::ContactSurface<double>>& surfaces =
       EvalContactSurfaces(*plant_context_);
   ASSERT_EQ(surfaces.size(), 1u);
-  const geometry::TriangleSurfaceMesh<double>& patch = surfaces[0].mesh_W();
-  EXPECT_EQ(pairs.size(), patch.num_triangles() + num_point_pairs);
+  EXPECT_EQ(pairs.size(), surfaces[0].num_faces() + num_point_pairs);
 }
 
 // Unit test to verify the computation of the contact Jacobian.

--- a/multibody/plant/test/contact_results_to_lcm_test.cc
+++ b/multibody/plant/test/contact_results_to_lcm_test.cc
@@ -647,8 +647,8 @@ TYPED_TEST(ContactResultsToLcmTest, HydroContactOnly) {
     const auto& pair_message = message_in.hydroelastic_contacts[i];
     const auto& pair_data = contacts_in.hydroelastic_contact_info(i);
     const auto& surface = pair_data.contact_surface();
-    const auto& mesh = surface.mesh_W();
-    const auto& field = surface.e_MN();
+    const auto& mesh = surface.tri_mesh_W();
+    const auto& field = surface.tri_e_MN();
 
     const auto& name1 = geo_to_body_map.at(surface.id_M());
     EXPECT_EQ(pair_message.body1_name, name1.body);

--- a/multibody/plant/test/hydroelastic_traction_test.cc
+++ b/multibody/plant/test/hydroelastic_traction_test.cc
@@ -688,7 +688,7 @@ GTEST_TEST(HydroelasticTractionCalculatorTest,
   // direction of the normal to be in the +z axis, body A is situated above body
   // B. This is important to understand the sign of the resulting derivative
   // below.
-  const Vector3<AutoDiffXd>& nhat_W = surface.mesh_W().face_normal(f0);
+  const Vector3<AutoDiffXd>& nhat_W = surface.face_normal(f0);
 
   // We *emulate* an elastic foundation of modulus E and depth h.
   const double E = 1.0e5;  // in Pa.

--- a/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
@@ -125,7 +125,7 @@ TEST_F(HydroelasticContactResultsOutputTester, SpatialForceAtCentroid) {
 
   // The following crude quadrature process relies upon there being three
   // quadrature points per triangle.
-  ASSERT_EQ(results.contact_surface().mesh_W().num_triangles() * 3,
+  ASSERT_EQ(results.contact_surface().num_faces() * 3,
             results.quadrature_point_data().size());
 
   // Sanity check that geometry ID is consistent with direction of spatial
@@ -151,7 +151,7 @@ TEST_F(HydroelasticContactResultsOutputTester, SpatialForceAtCentroid) {
   for (const HydroelasticQuadraturePointData<double>& datum :
        results.quadrature_point_data()) {
     F_Ac_W_expected.translational() +=
-        results.contact_surface().mesh_W().area(datum.face_index) * 1.0 / 3 *
+        results.contact_surface().area(datum.face_index) * 1.0 / 3 *
         datum.traction_Aq_W;
   }
 
@@ -211,10 +211,10 @@ TEST_F(HydroelasticContactResultsOutputTester, Traction) {
   for (const auto& quadrature_point_datum : quadrature_point_data) {
     // Convert the quadrature point to barycentric coordinates.
     const Vector3d p_barycentric =
-        results.contact_surface().mesh_W().CalcBarycentric(
+        results.contact_surface().tri_mesh_W().CalcBarycentric(
             quadrature_point_datum.p_WQ, quadrature_point_datum.face_index);
 
-    const double pressure = results.contact_surface().e_MN().Evaluate(
+    const double pressure = results.contact_surface().tri_e_MN().Evaluate(
         quadrature_point_datum.face_index, p_barycentric);
 
     // The conversion from Cartesian to barycentric coordinates introduces some
@@ -282,7 +282,7 @@ TEST_F(HydroelasticContactResultsOutputTester, AutoDiffXdSupport) {
 
   // The area has derivatives (three) and the area only changes magnitude based
   // on p_WBo.z.
-  const AutoDiffXd area = contact_surfaces[0].mesh_W().total_area();
+  const AutoDiffXd area = contact_surfaces[0].total_area();
   ASSERT_EQ(area.derivatives().size(), 3);
   ASSERT_NEAR(area.derivatives()[0], 0, 1e-15);
   ASSERT_NEAR(area.derivatives()[1], 0, 1e-15);

--- a/multibody/plant/test/multibody_plant_hydroelastic_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_test.cc
@@ -467,7 +467,7 @@ class ContactModelTest : public ::testing::Test {
       const FrameId fB_id = inspector.GetFrameId(B_id);
       const Body<double>& body_B = *plant_->GetBodyFromFrameId(fB_id);
 
-      const Vector3d p_WC = surface.mesh_W().centroid();
+      const Vector3d& p_WC = surface.centroid();
       const Vector3d& p_WAo =
           body_A.EvalPoseInWorld(*plant_context_).translation();
       const Vector3d p_CAo_W = p_WAo - p_WC;


### PR DESCRIPTION
This eliminates the legacy methods (maintained for the duration of the PR train). It also captures all call sites and updates them to an appropriate alternative spelling.

relates #15796

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16176)
<!-- Reviewable:end -->
