### PR TITLE
[hydro] Extend mesh representation into public API

### DIFF
--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -209,10 +209,12 @@ class ContactResultMaker final : public LeafSystem<double> {
     std::vector<ContactSurface<double>> surfaces;
     std::vector<PenetrationAsPointPair<double>> points;
     if (use_strict_hydro_) {
-      surfaces = query_object.ComputeContactSurfaces();
+      surfaces = query_object.ComputeContactSurfaces(
+          geometry::HydroelasticContactRepresentation::kTriangle);
     } else {
-      query_object.ComputeContactSurfacesWithFallback(&surfaces,
-                                                      &points);
+      query_object.ComputeContactSurfacesWithFallback(
+          geometry::HydroelasticContactRepresentation::kTriangle, &surfaces,
+          &points);
     }
     const int num_surfaces = static_cast<int>(surfaces.size());
     const int num_pairs = static_cast<int>(points.size());

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -400,18 +400,20 @@ class GeometryState {
   }
 
   /** Implementation of QueryObject::ComputeContactSurfaces().  */
-  std::vector<ContactSurface<T>> ComputeContactSurfaces() const {
-    return geometry_engine_->ComputeContactSurfaces(X_WGs_);
+  std::vector<ContactSurface<T>> ComputeContactSurfaces(
+      HydroelasticContactRepresentation representation) const {
+    return geometry_engine_->ComputeContactSurfaces(representation, X_WGs_);
   }
 
   /** Implementation of QueryObject::ComputeContactSurfacesWithFallback().  */
   void ComputeContactSurfacesWithFallback(
+      HydroelasticContactRepresentation representation,
       std::vector<ContactSurface<T>>* surfaces,
       std::vector<PenetrationAsPointPair<T>>* point_pairs) const {
     DRAKE_DEMAND(surfaces != nullptr);
     DRAKE_DEMAND(point_pairs != nullptr);
     return geometry_engine_->ComputeContactSurfacesWithFallback(
-        X_WGs_, surfaces, point_pairs);
+        representation, X_WGs_, surfaces, point_pairs);
   }
 
   /** Implementation of QueryObject::FindCollisionCandidates().  */

--- a/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
+++ b/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
@@ -61,6 +61,7 @@ using geometry::FramePoseVector;
 using geometry::GeometryFrame;
 using geometry::GeometryId;
 using geometry::GeometryInstance;
+using geometry::HydroelasticContactRepresentation;
 using geometry::IllustrationProperties;
 using geometry::Mesh;
 using geometry::ProximityProperties;
@@ -253,7 +254,8 @@ class ContactResultMaker final : public LeafSystem<double> {
     const auto& query_object =
         get_geometry_query_port().Eval<QueryObject<double>>(context);
     std::vector<ContactSurface<double>> contacts =
-        query_object.ComputeContactSurfaces();
+        query_object.ComputeContactSurfaces(
+            HydroelasticContactRepresentation::kTriangle);
     const int num_contacts = static_cast<int>(contacts.size());
 
     auto& msg = *results;

--- a/geometry/proximity/hydroelastic_callback.h
+++ b/geometry/proximity/hydroelastic_callback.h
@@ -50,15 +50,22 @@ struct CallbackData {
    @param X_WGs_in                The T-valued poses. Aliased.
    @param geometries_in           The set of all hydroelastic geometric
                                   representations. Aliased.
+   @param representation          Controls the mesh representation of
+                                  the contact surface. See
+                                  @ref contact_surface_discrete_representation
+                                  "contact surface representation" for more
+                                  details.
    @param surfaces_in             The output results. Aliased.  */
   CallbackData(
       const CollisionFilter* collision_filter_in,
       const std::unordered_map<GeometryId, math::RigidTransform<T>>* X_WGs_in,
       const Geometries* geometries_in,
+      HydroelasticContactRepresentation representation_in,
       std::vector<ContactSurface<T>>* surfaces_in)
       : collision_filter(*collision_filter_in),
         X_WGs(*X_WGs_in),
         geometries(*geometries_in),
+        representation(representation_in),
         surfaces(*surfaces_in) {
     DRAKE_DEMAND(collision_filter_in != nullptr);
     DRAKE_DEMAND(X_WGs_in != nullptr);
@@ -74,6 +81,9 @@ struct CallbackData {
 
   /* The hydroelastic geometric representations.  */
   const Geometries& geometries;
+
+  /* The requested mesh representation type. */
+  const HydroelasticContactRepresentation representation;
 
   /* The results of the distance query.  */
   std::vector<ContactSurface<T>>& surfaces;
@@ -95,7 +105,8 @@ template <typename T>
 std::unique_ptr<ContactSurface<T>> DispatchRigidSoftCalculation(
     const SoftGeometry& soft, const math::RigidTransform<T>& X_WS,
     GeometryId id_S, const RigidGeometry& rigid,
-    const math::RigidTransform<T>& X_WR, GeometryId id_R) {
+    const math::RigidTransform<T>& X_WR, GeometryId id_R,
+    HydroelasticContactRepresentation representation) {
   if (soft.is_half_space() || rigid.is_half_space()) {
     if (soft.is_half_space()) {
       DRAKE_DEMAND(!rigid.is_half_space());
@@ -104,15 +115,14 @@ std::unique_ptr<ContactSurface<T>> DispatchRigidSoftCalculation(
       const Bvh<Obb, TriangleSurfaceMesh<double>>& bvh_R = rigid.bvh();
       return ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
           id_S, X_WS, soft.pressure_scale(), id_R, mesh_R, bvh_R, X_WR,
-          HydroelasticContactRepresentation::kTriangle);
+          representation);
     } else {
       // Soft volume vs rigid half space.
       const VolumeMeshFieldLinear<double, double>& field_S =
           soft.pressure_field();
       const Bvh<Obb, VolumeMesh<double>>& bvh_S = soft.bvh();
       return ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
-          id_S, field_S, bvh_S, X_WS, id_R, X_WR,
-          HydroelasticContactRepresentation::kTriangle);
+          id_S, field_S, bvh_S, X_WS, id_R, X_WR, representation);
     }
   } else {
     // soft cannot be a half space; so this must be mesh-mesh.
@@ -123,8 +133,7 @@ std::unique_ptr<ContactSurface<T>> DispatchRigidSoftCalculation(
     const Bvh<Obb, TriangleSurfaceMesh<double>>& bvh_R = rigid.bvh();
 
     return ComputeContactSurfaceFromSoftVolumeRigidSurface(
-        id_S, field_S, bvh_S, X_WS, id_R, mesh_R, bvh_R, X_WR,
-        HydroelasticContactRepresentation::kTriangle);
+        id_S, field_S, bvh_S, X_WS, id_R, mesh_R, bvh_R, X_WR, representation);
   }
 }
 
@@ -175,7 +184,7 @@ CalcContactSurfaceResult MaybeCalcContactSurface(
   const math::RigidTransform<T>& X_WR(data->X_WGs.at(id_R));
 
   std::unique_ptr<ContactSurface<T>> surface = DispatchRigidSoftCalculation(
-      soft, X_WS, id_S, rigid, X_WR, id_R);
+      soft, X_WS, id_S, rigid, X_WR, id_R, data->representation);
 
   if (surface != nullptr) {
     DRAKE_DEMAND(surface->id_M() < surface->id_N());

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -717,12 +717,13 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   }
 
   vector<ContactSurface<T>> ComputeContactSurfaces(
+      HydroelasticContactRepresentation representation,
       const unordered_map<GeometryId, RigidTransform<T>>& X_WGs) const {
     vector<ContactSurface<T>> surfaces;
     // All these quantities are aliased in the callback data.
     hydroelastic::CallbackData<T> data{&collision_filter_, &X_WGs,
                                        &hydroelastic_geometries_,
-                                       &surfaces};
+                                       representation, &surfaces};
 
     // Perform a query of the dynamic objects against themselves.
     dynamic_tree_.collide(&data, hydroelastic::Callback<T>);
@@ -737,6 +738,7 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   }
 
   void ComputeContactSurfacesWithFallback(
+      HydroelasticContactRepresentation representation,
       const std::unordered_map<GeometryId, RigidTransform<T>>& X_WGs,
       std::vector<ContactSurface<T>>* surfaces,
       std::vector<PenetrationAsPointPair<T>>* point_pairs) const {
@@ -746,7 +748,8 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     // All these quantities are aliased in the callback data.
     hydroelastic::CallbackWithFallbackData<T> data{
         hydroelastic::CallbackData<T>{&collision_filter_, &X_WGs,
-                                      &hydroelastic_geometries_, surfaces},
+                                      &hydroelastic_geometries_, representation,
+                                      surfaces},
         point_pairs};
 
     // Dynamic vs dynamic and dynamic vs anchored represent all the geometries
@@ -1072,17 +1075,19 @@ ProximityEngine<T>::ComputePointPairPenetration(
 
 template <typename T>
 std::vector<ContactSurface<T>> ProximityEngine<T>::ComputeContactSurfaces(
+    HydroelasticContactRepresentation representation,
     const std::unordered_map<GeometryId, RigidTransform<T>>& X_WGs) const {
-  return impl_->ComputeContactSurfaces(X_WGs);
+  return impl_->ComputeContactSurfaces(representation, X_WGs);
 }
 
 template <typename T>
 void ProximityEngine<T>::ComputeContactSurfacesWithFallback(
+    HydroelasticContactRepresentation representation,
     const std::unordered_map<GeometryId, RigidTransform<T>>& X_WGs,
     std::vector<ContactSurface<T>>* surfaces,
     std::vector<PenetrationAsPointPair<T>>* point_pairs) const {
-  return impl_->ComputeContactSurfacesWithFallback(X_WGs, surfaces,
-                                                   point_pairs);
+  return impl_->ComputeContactSurfacesWithFallback(representation, X_WGs,
+                                                   surfaces, point_pairs);
 }
 
 template <typename T>

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -224,6 +224,7 @@ class ProximityEngine {
    @param X_WGs the current poses of all geometries in World in the
                 current scalar type, keyed on each geometry's GeometryId.  */
   std::vector<ContactSurface<T>> ComputeContactSurfaces(
+      HydroelasticContactRepresentation representation,
       const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs)
       const;
 
@@ -231,6 +232,7 @@ class ProximityEngine {
    @param X_WGs the current poses of all geometries in World in the
                 current scalar type, keyed on each geometry's GeometryId.  */
   void ComputeContactSurfacesWithFallback(
+      HydroelasticContactRepresentation representation,
       const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs,
       std::vector<ContactSurface<T>>* surfaces,
       std::vector<PenetrationAsPointPair<T>>* point_pairs) const;

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -104,17 +104,18 @@ bool QueryObject<T>::HasCollisions() const {
 }
 
 template <typename T>
-std::vector<ContactSurface<T>>
-QueryObject<T>::ComputeContactSurfaces() const {
+std::vector<ContactSurface<T>> QueryObject<T>::ComputeContactSurfaces(
+    HydroelasticContactRepresentation representation) const {
   ThrowIfNotCallable();
 
   FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
-  return state.ComputeContactSurfaces();
+  return state.ComputeContactSurfaces(representation);
 }
 
 template <typename T>
 void QueryObject<T>::ComputeContactSurfacesWithFallback(
+    HydroelasticContactRepresentation representation,
     std::vector<ContactSurface<T>>* surfaces,
     std::vector<PenetrationAsPointPair<T>>* point_pairs) const {
   DRAKE_DEMAND(surfaces != nullptr);
@@ -124,7 +125,8 @@ void QueryObject<T>::ComputeContactSurfacesWithFallback(
 
   FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
-  state.ComputeContactSurfacesWithFallback(surfaces, point_pairs);
+  state.ComputeContactSurfacesWithFallback(representation, surfaces,
+                                           point_pairs);
 }
 
 template <typename T>

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -307,11 +307,17 @@ class QueryObject {
    *poses*. We cannot differentiate w.r.t. geometric properties (e.g., radius,
    length, etc.)
 
+   @param representation  Controls the mesh representation of the contact
+                          surface. See
+                          @ref contact_surface_discrete_representation
+                          "contact surface representation" for more details.
+
    @returns A vector populated with all detected intersections characterized as
             contact surfaces. The ordering of the results is guaranteed to be
             consistent -- for fixed geometry poses, the results will remain
             the same.  */
-  std::vector<ContactSurface<T>> ComputeContactSurfaces() const;
+  std::vector<ContactSurface<T>> ComputeContactSurfaces(
+      HydroelasticContactRepresentation representation) const;
 
   /** Reports pairwise intersections and characterizes each non-empty
    intersection as a ContactSurface _where possible_ and as a
@@ -334,6 +340,10 @@ class QueryObject {
    supports double and AutoDiffXd to the extent that those constituent methods
    do.
 
+   @param representation    Controls the mesh representation of the contact
+                            surface. See
+                            @ref contact_surface_discrete_representation
+                            "contact surface representation" for more details.
    @param[out] surfaces     The vector that contact surfaces will be added to.
                             The vector will _not_ be cleared.
    @param[out] point_pairs  The vector that fall back point pair data will be
@@ -342,6 +352,7 @@ class QueryObject {
    @throws std::exception for the reasons described in ComputeContactSurfaces()
                           and ComputePointPairPenetration(). */
   void ComputeContactSurfacesWithFallback(
+      HydroelasticContactRepresentation representation,
       std::vector<ContactSurface<T>>* surfaces,
       std::vector<PenetrationAsPointPair<T>>* point_pairs) const;
 

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -243,6 +243,8 @@ unordered_map<GeometryId, RigidTransformd> PopulateEngine(
   return X_WGs;
 }
 
+// The autodiff support is independent of what the contact surface mesh
+// representation is; so we'll simply use kTriangle.
 GTEST_TEST(ProximityEngineTest, ComputeContactSurfacesAutodiffSupport) {
   const bool anchored{true};
   const bool soft{true};
@@ -282,8 +284,9 @@ GTEST_TEST(ProximityEngineTest, ComputeContactSurfacesAutodiffSupport) {
     // callback. So, exercising one is "sufficient". If they ever deviate in
     // execution (i.e., there were to no longer share the same callback), this
     // test would have to be elaborated.
-    engine_ad->ComputeContactSurfacesWithFallback(X_WGs_ad, &surfaces,
-                                                  &point_pairs);
+    engine_ad->ComputeContactSurfacesWithFallback(
+        HydroelasticContactRepresentation::kTriangle, X_WGs_ad, &surfaces,
+        &point_pairs);
     EXPECT_EQ(surfaces.size(), 1);
     EXPECT_EQ(point_pairs.size(), 0);
     // We'll poke *one* quantity of the surface mesh to confirm it has
@@ -306,8 +309,9 @@ GTEST_TEST(ProximityEngineTest, ComputeContactSurfacesAutodiffSupport) {
 
     std::vector<ContactSurface<AutoDiffXd>> surfaces;
     std::vector<PenetrationAsPointPair<AutoDiffXd>> point_pairs;
-    engine_ad->ComputeContactSurfacesWithFallback(X_WGs_ad, &surfaces,
-                                                  &point_pairs);
+    engine_ad->ComputeContactSurfacesWithFallback(
+        HydroelasticContactRepresentation::kTriangle, X_WGs_ad, &surfaces,
+        &point_pairs);
     EXPECT_EQ(surfaces.size(), 0);
     EXPECT_EQ(point_pairs.size(), 1);
   }
@@ -324,6 +328,8 @@ GTEST_TEST(ProximityEngineTest, ComputeContactSurfacesAutodiffSupport) {
 //
 //   - A concave mesh queries penetration and distance like its convex hull.
 //   - A concave mesh queries hydroelastic based on the actual mesh.
+//
+// The test doesn't depend on the mesh representation type.
 GTEST_TEST(ProximityEngineTests, MeshSupportAsConvex) {
   /* This mesh looks like this:
                          +z
@@ -372,7 +378,8 @@ GTEST_TEST(ProximityEngineTests, MeshSupportAsConvex) {
     engine.UpdateWorldPoses(X_WGs);
 
     // Existence of a contact surface depends on the radius of the sphere.
-    const auto contact_surfaces = engine.ComputeContactSurfaces(X_WGs);
+    const auto contact_surfaces = engine.ComputeContactSurfaces(
+        HydroelasticContactRepresentation::kTriangle, X_WGs);
     EXPECT_EQ(contact_surfaces.size(), radius > 0.5 ? 1 : 0);
 
     {
@@ -1883,6 +1890,8 @@ GTEST_TEST(ProximityEngineTests, FindCollisionCandidatesResultOrdering) {
 // Confirms that the ComputeContactSurfaces() computation returns the
 // same results twice in a row. This test is explicitly required because it is
 // known that updating the pose in the FCL tree can lead to erratic ordering.
+// This logic doesn't depend on mesh representation, so we test it with a single
+// representation.
 class ProximityEngineHydro : public testing::Test {
  protected:
   void SetUp() override {
@@ -1920,11 +1929,13 @@ class ProximityEngineHydro : public testing::Test {
 
 TEST_F(ProximityEngineHydro, ComputeContactSurfacesResultOrdering) {
   engine_.UpdateWorldPoses(poses_);
-  const auto results1 = engine_.ComputeContactSurfaces(poses_);
+  const auto results1 = engine_.ComputeContactSurfaces(
+      HydroelasticContactRepresentation::kTriangle, poses_);
   ASSERT_EQ(results1.size(), poses_.size());
 
   engine_.UpdateWorldPoses(poses_);
-  const auto results2 = engine_.ComputeContactSurfaces(poses_);
+  const auto results2 = engine_.ComputeContactSurfaces(
+      HydroelasticContactRepresentation::kTriangle, poses_);
   ASSERT_EQ(results2.size(), poses_.size());
 
   for (size_t i = 0; i < poses_.size(); ++i) {
@@ -1936,6 +1947,8 @@ TEST_F(ProximityEngineHydro, ComputeContactSurfacesResultOrdering) {
 // Confirms that the ComputeContactSurfacesWithFallback() computation returns
 // the same results twice in a row. This test is explicitly required because it
 // is known that updating the pose in the FCL tree can lead to erratic ordering.
+// This logic is independent of mesh representation, so, we only test for one
+// mesh type.
 class ProximityEngineHydroWithFallback : public testing::Test {
  protected:
   void SetUp() override {
@@ -1979,14 +1992,18 @@ TEST_F(ProximityEngineHydroWithFallback,
   engine_.UpdateWorldPoses(poses_);
   vector<ContactSurface<double>> surfaces1;
   vector<PenetrationAsPointPair<double>> points1;
-  engine_.ComputeContactSurfacesWithFallback(poses_, &surfaces1, &points1);
+  engine_.ComputeContactSurfacesWithFallback(
+      HydroelasticContactRepresentation::kTriangle, poses_, &surfaces1,
+      &points1);
   ASSERT_EQ(surfaces1.size(), N_ / 2);
   ASSERT_EQ(points1.size(), N_ / 2);
 
   engine_.UpdateWorldPoses(poses_);
   vector<ContactSurface<double>> surfaces2;
   vector<PenetrationAsPointPair<double>> points2;
-  engine_.ComputeContactSurfacesWithFallback(poses_, &surfaces2, &points2);
+  engine_.ComputeContactSurfacesWithFallback(
+      HydroelasticContactRepresentation::kTriangle, poses_, &surfaces2,
+      &points2);
   ASSERT_EQ(surfaces2.size(), N_ / 2);
   ASSERT_EQ(points2.size(), N_ / 2);
 

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -165,11 +165,13 @@ TEST_F(QueryObjectTest, DefaultQueryThrows) {
 
   // Penetration queries.
   EXPECT_DEFAULT_ERROR(default_object.ComputePointPairPenetration());
-  EXPECT_DEFAULT_ERROR(default_object.ComputeContactSurfaces());
+  const HydroelasticContactRepresentation representation =
+      HydroelasticContactRepresentation::kTriangle;
+  EXPECT_DEFAULT_ERROR(default_object.ComputeContactSurfaces(representation));
   std::vector<ContactSurface<double>> surfaces;
   std::vector<PenetrationAsPointPair<double>> point_pairs;
   EXPECT_DEFAULT_ERROR(default_object.ComputeContactSurfacesWithFallback(
-      &surfaces, &point_pairs));
+      representation, &surfaces, &point_pairs));
 
   // Signed distance queries.
   EXPECT_DEFAULT_ERROR(

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1983,9 +1983,11 @@ void MultibodyPlant<T>::CalcContactSurfaces(
   if (is_discrete()) {
     // NOTE: This is currently being left here as a place holder for when
     // ComputeContactSurfaces takes a flag for indicating mesh representation.
-    *contact_surfaces = query_object.ComputeContactSurfaces();
+    *contact_surfaces = query_object.ComputeContactSurfaces(
+      geometry::HydroelasticContactRepresentation::kTriangle);
   } else {
-    *contact_surfaces = query_object.ComputeContactSurfaces();
+    *contact_surfaces = query_object.ComputeContactSurfaces(
+      geometry::HydroelasticContactRepresentation::kTriangle);
   }
 }
 
@@ -2013,11 +2015,13 @@ void MultibodyPlant<T>::CalcHydroelasticWithFallback(
       // NOTE: This is currently being left here as a place holder for when
       // ComputeContactSurfacesWithFallback takes a flag for indicating mesh
       // representation.
-      query_object.ComputeContactSurfacesWithFallback(&data->contact_surfaces,
-                                                      &data->point_pairs);
+      query_object.ComputeContactSurfacesWithFallback(
+          geometry::HydroelasticContactRepresentation::kTriangle,
+          &data->contact_surfaces, &data->point_pairs);
     } else {
-      query_object.ComputeContactSurfacesWithFallback(&data->contact_surfaces,
-                                                      &data->point_pairs);
+      query_object.ComputeContactSurfacesWithFallback(
+          geometry::HydroelasticContactRepresentation::kTriangle,
+          &data->contact_surfaces, &data->point_pairs);
     }
   }
 }

--- a/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
@@ -108,7 +108,8 @@ TEST_F(HydroelasticContactResultsOutputTester, ContactSurfaceEquivalent) {
   // Compute the contact surface using the hydroelastic engine.
   ASSERT_FALSE(plant_->is_discrete());
   std::vector<geometry::ContactSurface<double>> contact_surfaces =
-      query_object.ComputeContactSurfaces();
+      query_object.ComputeContactSurfaces(
+          geometry::HydroelasticContactRepresentation::kTriangle);
 
   // Check that the two contact surfaces are equivalent.
   ASSERT_EQ(contact_surfaces.size(), 1);
@@ -264,7 +265,8 @@ TEST_F(HydroelasticContactResultsOutputTester, AutoDiffXdSupport) {
   // as a reality check; make sure that the underlying contact surface has
   // derivatives as expected.
   std::vector<geometry::ContactSurface<AutoDiffXd>> contact_surfaces =
-      query_object.ComputeContactSurfaces();
+      query_object.ComputeContactSurfaces(
+          geometry::HydroelasticContactRepresentation::kTriangle);
 
   ASSERT_EQ(contact_surfaces.size(), 1);
   // Contact surface documents the surface normal as pointing "out of N and into


### PR DESCRIPTION
This adds the `HydroelasticMeshRepresentation` as a *required* parameter in the `QueryObject` contact surface API. Updates call sites to satisfy the non-optional parameter.

relates #15796

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16177)
<!-- Reviewable:end -->
