### PR TITLE
primitives: Fix missed paste-o in documentation

### DIFF
--- a/systems/primitives/multiplexer.h
+++ b/systems/primitives/multiplexer.h
@@ -54,7 +54,7 @@ class Multiplexer : public LeafSystem<T> {
   /// - ...
   /// - u(input_sizes.size() - 1)
   /// output_ports:
-  /// - output
+  /// - y0
   /// @endsystem
   explicit Multiplexer(std::vector<int> input_sizes);
 


### PR DESCRIPTION
Relevant to: #9496

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16184)
<!-- Reviewable:end -->
