### PR TITLE
[multibody] Fix style defects in recent SpatialInertia fix

### DIFF
--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -435,11 +435,11 @@ GTEST_TEST(SdfParser, ZeroMassNonZeroInertia) {
 
 GTEST_TEST(SdfParserDeathTest, ZeroMassNonZeroInertia) {
   // Test that attempt to parse links with zero mass and non-zero inertia fails.
-  std::string expected_msg =
-    "RotationalInertia::SetFromRotationalInertia\\(\\):"
-    " Division by zero mass or negative mass.";
+  const std::string expected_message =
+      "RotationalInertia::SetFromRotationalInertia\\(\\):"
+      " Division by zero mass or negative mass.";
   DRAKE_EXPECT_THROWS_MESSAGE(
-      ParseZeroMassNonZeroInertia(), std::exception, expected_msg);
+      ParseZeroMassNonZeroInertia(), expected_message);
 }
 
 GTEST_TEST(SdfParser, FloatingBodyPose) {

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -621,11 +621,11 @@ GTEST_TEST(MultibodyPlantUrdfParserTest, ZeroMassNonZeroInertia) {
 
 GTEST_TEST(MultibodyPlantUrdfParserDeathTest, ZeroMassNonZeroInertia) {
   // Test that attempt to parse links with zero mass and non-zero inertia fails.
-  std::string expected_msg =
-    "RotationalInertia::SetFromRotationalInertia\\(\\):"
-    " Division by zero mass or negative mass.";
+  const std::string expected_message =
+      "RotationalInertia::SetFromRotationalInertia\\(\\):"
+      " Division by zero mass or negative mass.";
   DRAKE_EXPECT_THROWS_MESSAGE(
-      ParseZeroMassNonZeroInertia(), std::exception, expected_msg);
+      ParseZeroMassNonZeroInertia(), std::exception, expected_message);
 }
 
 GTEST_TEST(MultibodyPlantUrdfParserTest, BushingParsing) {

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -989,40 +989,18 @@ class RotationalInertia {
   typename std::enable_if_t<scalar_predicate<T1>::is_bool>
   ThrowIfNotPhysicallyValid(const char* func_name) {
     DRAKE_DEMAND(func_name != nullptr);
-    if (CouldBePhysicallyValid())
-      return;
-
-    std::string error_msg = fmt::format(
-        "{}(): The rotational inertia\n"
-        "{}did not pass the test CouldBePhysicallyValid().",
-        func_name, *this);
-    // Provide additional information if a moment of inertia is non-negative
-    // or if moments of inertia do not satisfy the triangle inequality.
-    if constexpr (scalar_predicate<T>::is_bool) {
-      if (!IsNaN()) {
-        const Vector3<double> p = CalcPrincipalMomentsOfInertia();
-        if (!AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality(
-                p(0), p(1), p(2), /* epsilon = */ 0.0)) {
-          error_msg += fmt::format(
-              "\nThe associated principal moments of inertia:"
-              "\n{}  {}  {}", p(0), p(1), p(2));
-          if (p(0) < 0 || p(1) < 0 || p(2) < 0) {
-            error_msg += "\nare invalid since at least one is negative.";
-          } else {
-            error_msg += "\ndo not satisify the triangle inequality.";
-          }
-        }
-      }
-    }
-
-    throw std::logic_error(error_msg);
+    if (!CouldBePhysicallyValid())
+      ThrowNotPhysicallyValid(func_name);
   }
+
 
   // SFINAE for non-numeric types. See documentation in the implementation for
   // numeric types.
   template <typename T1 = T>
   typename std::enable_if_t<!scalar_predicate<T1>::is_bool>
   ThrowIfNotPhysicallyValid(const char*) {}
+
+  [[noreturn]] void ThrowNotPhysicallyValid(const char* func_name) const;
 
   // Throws an exception if a rotational inertia is multiplied by a negative
   // number - which implies that the resulting rotational inertia is invalid.

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -500,13 +500,8 @@ class SpatialInertia {
   template <typename T1 = T>
   typename std::enable_if_t<scalar_predicate<T1>::is_bool> CheckInvariants()
       const {
-    if (!IsPhysicallyValid()) {
-      std::string error_msg = fmt::format(
-          "Spatial inertia fails SpatialInertia::IsPhysicallyValid()."
-          "{}", *this);
-      WriteExtraCentralInertiaProperties(&error_msg);
-      throw std::runtime_error(error_msg);
-    }
+    if (!IsPhysicallyValid())
+      ThrowNotPhysicallyValid();
   }
 
   // SFINAE for non-numeric types. See documentation in the implementation for
@@ -514,6 +509,8 @@ class SpatialInertia {
   template <typename T1 = T>
   typename std::enable_if_t<!scalar_predicate<T1>::is_bool> CheckInvariants()
       const {}
+
+  [[noreturn]] void ThrowNotPhysicallyValid() const;
 
   // Mass of the body or composite body.
   T mass_{nan()};
@@ -527,10 +524,10 @@ class SpatialInertia {
   // Appends text to an existing string with information about a SpatialInertia.
   // If the position vector p_PBcm from about-point P to Bcm (body B's center of
   // mass) is non-zero, appends I_BBcm (body B's rotational inertia about Bcm)
-  // to `msg`. In all cases, the central principal moments of inertia are
-  // appended to `msg`, e.g., to help identify a rotational inertia that
+  // to `message`. In all cases, the central principal moments of inertia are
+  // appended to `message`, e.g., to help identify a rotational inertia that
   // violates the "triangle inequality".
-  void WriteExtraCentralInertiaProperties(std::string* msg) const;
+  void WriteExtraCentralInertiaProperties(std::string* message) const;
 };
 
 /// Writes an instance of SpatialInertia into a std::ostream.

--- a/multibody/tree/test/rotational_inertia_test.cc
+++ b/multibody/tree/test/rotational_inertia_test.cc
@@ -91,13 +91,13 @@ GTEST_TEST(RotationalInertia, MakeFromMomentsAndProductsOfInertia) {
 
     // Check for a thrown exception with proper error message when creating an
     // invalid rotational inertia (a principal moment of inertia is negative).
-    std::string expected_msg =
-      "MakeFromMomentsAndProductsOfInertia\\(\\): The rotational inertia\n"
+    std::string expected_message =
+        "MakeFromMomentsAndProductsOfInertia\\(\\): The rotational inertia\n"
         "\\[ 1, -3, -3\\]\n"
         "\\[-3, 13, -6\\]\n"
         "\\[-3, -6, 10\\]\n"
         "did not pass the test CouldBePhysicallyValid\\(\\)\\.";
-    expected_msg += fmt::format(
+    expected_message += fmt::format(
         "\nThe associated principal moments of inertia:"
         "\n-1.583957883\\d+  7.881702629\\d+  17.702255254\\d+"
         "\nare invalid since at least one is negative.");
@@ -106,17 +106,17 @@ GTEST_TEST(RotationalInertia, MakeFromMomentsAndProductsOfInertia) {
     DRAKE_EXPECT_THROWS_MESSAGE(
         RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
           1.0, Iyy, Izz, Ixy, Ixz, Iyz, /* skip_validity_check = */ false),
-          std::exception, expected_msg);
+          expected_message);
 
     // Check for a thrown exception with proper error message when creating a
     // rotational inertia that violates the triangle inequality.
-    expected_msg =
+    expected_message =
       "MakeFromMomentsAndProductsOfInertia\\(\\): The rotational inertia\n"
         "\\[34, -3, -3\\]\n"
         "\\[-3, 13, -6\\]\n"
         "\\[-3, -6, 10\\]\n"
         "did not pass the test CouldBePhysicallyValid\\(\\)\\.";
-    expected_msg += fmt::format(
+    expected_message += fmt::format(
         "\nThe associated principal moments of inertia:"
         "\n4.70955263953\\d+  17.66953281\\d+  34.6209145475\\d+"
         "\ndo not satisify the triangle inequality.");
@@ -125,7 +125,7 @@ GTEST_TEST(RotationalInertia, MakeFromMomentsAndProductsOfInertia) {
     DRAKE_EXPECT_THROWS_MESSAGE(
         RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
           2 * Ixx, Iyy, Izz, Ixy, Ixz, Iyz, /* skip_validity_check = */ false),
-          std::exception, expected_msg);
+          expected_message);
 }
 
 // Test constructor for a principal axes rotational inertia matrix (products

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -320,17 +320,17 @@ GTEST_TEST(SpatialInertia, IsPhysicallyValidWithZeroMass) {
   // Test when an attempt to form UnitInertia with a divide-by-zero problem.
   p_PBcm = Vector3d(0.0, 0.0, 0.0);
   const RotationalInertia<double> I(2, 3, 4);
-  std::string expected_msg =
-    "RotationalInertia::SetFromRotationalInertia\\(\\):"
-    " Division by zero mass or negative mass.";
+  const std::string expected_message =
+      "RotationalInertia::SetFromRotationalInertia\\(\\):"
+      " Division by zero mass or negative mass.";
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::MakeFromCentralInertia(mass_zero, p_PBcm, I),
-      std::exception, expected_msg);
+      expected_message);
 
   p_PBcm = Vector3d(1.0, 2.0, 3.0);
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::MakeFromCentralInertia(mass_zero, p_PBcm, I),
-      std::exception, expected_msg);
+      expected_message);
 }
 
 // Test that it is not possible to create a spatial inertia with a bad
@@ -341,42 +341,42 @@ GTEST_TEST(SpatialInertia, IsPhysicallyValidWithBadInertia) {
   RotationalInertia<double> Ibad = I.MultiplyByScalarSkipValidityCheck(-1);
   Vector3d p_PBcm = Vector3d(0.0, 0.0, 0.0);
 
-  std::string expected_msg =
-    "Spatial inertia fails SpatialInertia::IsPhysicallyValid\\(\\).\n"
-    " mass = 1(\\.0)?\n"
-    " Center of mass = \\[0(\\.0)?  0(\\.0)?  0(\\.0)?\\]\n"
-    " Inertia about point P, I_BP =\n"
-    "\\[  -2, -0.1, -0.2\\]\n"
-    "\\[-0.1,   -3, -0.3\\]\n"
-    "\\[-0.2, -0.3,   -4\\]\n"
-    " Principal moments of inertia about Bcm \\(center of mass\\) =\n"
-    "\\[-4.105976670111\\d+  -2.9188291125626\\d+  -1.9751942173260\\d+\\]\n";
+  const std::string expected_message =
+      "Spatial inertia fails SpatialInertia::IsPhysicallyValid\\(\\).\n"
+      " mass = 1(\\.0)?\n"
+      " Center of mass = \\[0(\\.0)?  0(\\.0)?  0(\\.0)?\\]\n"
+      " Inertia about point P, I_BP =\n"
+      "\\[  -2, -0.1, -0.2\\]\n"
+      "\\[-0.1,   -3, -0.3\\]\n"
+      "\\[-0.2, -0.3,   -4\\]\n"
+      " Principal moments of inertia about Bcm \\(center of mass\\) =\n"
+      "\\[-4.105976670111\\d+  -2.9188291125626\\d+  -1.9751942173260\\d+\\]\n";
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::MakeFromCentralInertia(1.0, p_PBcm, Ibad),
-      std::exception, expected_msg);
+      expected_message);
 }
 
 // Tests IsPhysicallyValid() fails within the constructor since the COM given is
 // inconsistently too far out for the unit inertia provided.
 GTEST_TEST(SpatialInertia, IsPhysicallyValidWithCOMTooFarOut) {
-  std::string expected_msg =
-    "Spatial inertia fails SpatialInertia::IsPhysicallyValid\\(\\).\n"
-    " mass = 1(\\.0)?\n"
-    " Center of mass = \\[2(\\.0)?  0(\\.0)?  0(\\.0)?\\]\n"
-    " Inertia about point P, I_BP =\n"
-    "\\[0.4,   0,   0\\]\n"
-    "\\[  0, 0.4,   0\\]\n"
-    "\\[  0,   0, 0.4\\]\n"
-    " Inertia about center of mass, I_BBcm =\n"
-    "\\[ 0.4,    0,    0\\]\n"
-    "\\[   0, -3.6,    0\\]\n"
-    "\\[   0,    0, -3.6\\]\n"
-    " Principal moments of inertia about Bcm \\(center of mass\\) =\n"
-    "\\[-3.6  -3.6  0.4\\]\n";
+  const std::string expected_message =
+      "Spatial inertia fails SpatialInertia::IsPhysicallyValid\\(\\).\n"
+      " mass = 1(\\.0)?\n"
+      " Center of mass = \\[2(\\.0)?  0(\\.0)?  0(\\.0)?\\]\n"
+      " Inertia about point P, I_BP =\n"
+      "\\[0.4,   0,   0\\]\n"
+      "\\[  0, 0.4,   0\\]\n"
+      "\\[  0,   0, 0.4\\]\n"
+      " Inertia about center of mass, I_BBcm =\n"
+      "\\[ 0.4,    0,    0\\]\n"
+      "\\[   0, -3.6,    0\\]\n"
+      "\\[   0,    0, -3.6\\]\n"
+      " Principal moments of inertia about Bcm \\(center of mass\\) =\n"
+      "\\[-3.6  -3.6  0.4\\]\n";
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>(1.0, Vector3d(2.0, 0.0, 0.0),
                              UnitInertia<double>::SolidSphere(1.0)),
-      std::exception, expected_msg);
+      expected_message);
 }
 
 // Tests that an informative exception message is issued if a spatial inertia
@@ -404,25 +404,26 @@ GTEST_TEST(SpatialInertia, IsPhysicallyValidThrowsNiceExceptionMessage) {
 
   // Shift the spatial inertia from Bcm to point P and verify that it throws
   // an exception and the exception message makes sense.
-  std::string expected_msg = fmt::format(
-    "Spatial inertia fails SpatialInertia::IsPhysicallyValid\\(\\).\n"
-    " mass = 0.634\n"
-    " Center of mass = \\[0(\\.0)?  0.016  -0.02\\]\n"
-    " Inertia about point P, I_BP =\n"
-    "\\[  0.0023989,    0.000245,     1.3e-05\\]\n"
-    "\\[   0.000245,   0.0023566,  0.00020438\\]\n"
-    "\\[    1.3e-05,  0.00020438, 0.000570304\\]\n"
-    " Inertia about center of mass, I_BBcm =\n"
-    "\\[0.001983, 0.000245,  1.3e-05\\]\n"
-    "\\[0.000245, 0.002103,  1.5e-06\\]\n"
-    "\\[ 1.3e-05,  1.5e-06, 0.000408\\]\n"
-    " Principal moments of inertia about Bcm \\(center of mass\\) =\n"
-    "\\[0.0004078925412\\d+  0.001790822592803\\d+  0.00229528486596\\d+\\]\n");
-    // Note: The principal moments of inertia (with more significant digits)
-    // are: 0.0004078925412357755  0.0017908225928030743  0.002295284865961151.
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        SpatialInertia<double>::MakeFromCentralInertia(mass, p_PBcm, I_BBcm),
-        std::exception, expected_msg);
+  const std::string expected_message = fmt::format(
+      "Spatial inertia fails SpatialInertia::IsPhysicallyValid\\(\\).\n"
+      " mass = 0.634\n"
+      " Center of mass = \\[0(\\.0)?  0.016  -0.02\\]\n"
+      " Inertia about point P, I_BP =\n"
+      "\\[  0.0023989,    0.000245,     1.3e-05\\]\n"
+      "\\[   0.000245,   0.0023566,  0.00020438\\]\n"
+      "\\[    1.3e-05,  0.00020438, 0.000570304\\]\n"
+      " Inertia about center of mass, I_BBcm =\n"
+      "\\[0.001983, 0.000245,  1.3e-05\\]\n"
+      "\\[0.000245, 0.002103,  1.5e-06\\]\n"
+      "\\[ 1.3e-05,  1.5e-06, 0.000408\\]\n"
+      " Principal moments of inertia about Bcm \\(center of mass\\) =\n"
+      "\\[0.0004078925412\\d+  0.001790822592803\\d+  0.00229528486596\\d+\\]"
+      "\n");
+  // Note: The principal moments of inertia (with more significant digits)
+  // are: 0.0004078925412357755  0.0017908225928030743  0.002295284865961151.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SpatialInertia<double>::MakeFromCentralInertia(mass, p_PBcm, I_BBcm),
+      expected_message);
 }
 
 // Tests that by setting skip_validity_check = true, it is possible to create

--- a/multibody/tree/unit_inertia.h
+++ b/multibody/tree/unit_inertia.h
@@ -93,8 +93,8 @@ class UnitInertia : public RotationalInertia<T> {
   UnitInertia<T>& SetFromRotationalInertia(
       const RotationalInertia<T>& I, const T& mass) {
     if (mass <= 0) {
-      std::string message = fmt::format("RotationalInertia::{}():"
-        " Division by zero mass or negative mass.", __func__);
+      const std::string message = fmt::format("RotationalInertia::{}():"
+          " Division by zero mass or negative mass.", __func__);
       throw std::runtime_error(message);
     }
     RotationalInertia<T>::operator=(I / mass);


### PR DESCRIPTION
Amends #16065.

Inline functions must be small.
Correctly indent +4 for line-wrapped expressions.
Don't abbreviate `msg`.
Don't gratuitously check the expected exception types in unit tests.
Don't use `std::endl` as a synonym for `"\n"`.

~(We should wait for #16186 to be resolved, first.)~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16187)
<!-- Reviewable:end -->
