### PR TITLE
controllers: Add/update doxygen block diagrams

### DIFF
--- a/systems/controllers/inverse_dynamics.h
+++ b/systems/controllers/inverse_dynamics.h
@@ -27,6 +27,19 @@ namespace controllers {
  * @see Constructors for descriptions of how (and which) forces are incorporated
  *      into the inverse dynamics computation.
  *
+ * @system
+ * name: InverseDynamics
+ * input_ports:
+ * - u0
+ * - <span style="color:gray">u1</span>
+ * output_ports:
+ * - y0
+ * @endsystem
+ *
+ * Port `u0` accepts system state; port `y0` emits generalized forces. Port
+ * `u1` is only present when the `mode` at construction is not
+ * `kGravityCompensation`. When present, `u1` accepts desired accelerations.
+ *
  * @ingroup control_systems
  * @tparam_double_only
  */

--- a/systems/controllers/inverse_dynamics_controller.h
+++ b/systems/controllers/inverse_dynamics_controller.h
@@ -31,10 +31,13 @@ namespace controllers {
  * input_ports:
  * - estimated_state
  * - desired_state
- * - desired_acceleration*
+ * - <span style="color:gray">desired_acceleration</span>
  * output_ports:
  * - force
  * @endsystem
+ *
+ * Ports show in <span style="color:gray">gray</span> may be absent, depending
+ * on how the system is constructed.
  *
  * This controller always has a BasicVector input port for estimated robot state
  * `(q, v)`, a BasicVector input port for reference robot state `(q*, v*)` and

--- a/systems/controllers/linear_model_predictive_controller.h
+++ b/systems/controllers/linear_model_predictive_controller.h
@@ -27,6 +27,14 @@ namespace controllers {
 /// implementation solves the QP in whole at every time step, discarding any
 /// information between steps.
 ///
+/// @system
+/// name: LinearModelPredictiveController
+/// input_ports:
+/// - u0
+/// output_ports:
+/// - y0
+/// @endsystem
+///
 /// @tparam_double_only
 /// @ingroup control_systems
 template <typename T>

--- a/systems/controllers/pid_controlled_system.cc
+++ b/systems/controllers/pid_controlled_system.cc
@@ -80,11 +80,12 @@ void PidControlledSystem<T>::Initialize(
                         plant_->get_output_port(state_output_port_index_),
                         feedback_selector, Kp, Ki, Kd, &builder);
 
-  builder.ExportInput(input_ports.control_input_port);
-  builder.ExportInput(input_ports.state_input_port);
+  builder.ExportInput(input_ports.control_input_port, "feedforward_control");
+  builder.ExportInput(input_ports.state_input_port, "desired_state");
 
   for (int i=0; i < plant_->num_output_ports(); i++) {
-    builder.ExportOutput(plant_->get_output_port(i));
+    const auto& port = plant_->get_output_port(i);
+    builder.ExportOutput(port, port.get_name());
   }
   builder.BuildInto(this);
 }

--- a/systems/controllers/pid_controlled_system.h
+++ b/systems/controllers/pid_controlled_system.h
@@ -53,6 +53,17 @@ namespace controllers {
 /// desired state (size 2 * U), `S` is used to compute the state error as
 /// `x_err = S * x - x_d`.
 ///
+/// @system
+/// name: PidControlledSystem
+/// input_ports:
+/// - desired_state
+/// - feedforward_control
+/// output_ports:
+/// - (exported output port of plant, with same name)
+/// - ...
+/// - (exported output port of plant, with same name)
+/// @endsystem
+///
 /// @tparam_nonsymbolic_scalar
 /// @ingroup control_systems
 template <typename T>


### PR DESCRIPTION
Relevant to: #9496

This patch adds missing diagrams, updates some others for consistent
style, and in one case (PidControlledSystem), adds some previously
missing port names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16193)
<!-- Reviewable:end -->
