### PR TITLE
[geometry] Use polygons in a profiling example of contact surface creation.

### DIFF
--- a/geometry/profiling/README.md
+++ b/geometry/profiling/README.md
@@ -30,19 +30,23 @@ a coarse tetrahedral mesh, which is typical in hydroelastic contact model.
 
 To visualize the contact surface and pressure, run drake_visualizer and
 configure Hydroelastic Contact Visualization plugin as follows:
-1. From the top menu, click on: Plugins > Contacts > Configure Hydroelastic
- Contact
- Visualization.
-2. Change "Maximum pressure" to a reasonably large number (for example, 4e7).
-3. Check or uncheck "Render contact surface with pressure" as you prefer.
-4. Check or uncheck "Render contact surface wireframe" as you prefer.
-5. Click "OK".
+1. From the top menu, click on: `Plugins > Contacts > Configure Hydroelastic
+ Contact Visualization.`
+2. Change `Maximum pressure` to a reasonably large number (for example, 4e7).
+3. Check or uncheck `Render contact surface with pressure` as you prefer.
+4. Check or uncheck `Render contact surface edges` (wireframe) as you prefer.
+5. Click `OK`.
 6. Run this profiling example.
+
+Instead of using polygons to represent contact surfaces, it can use triangles.
+- use triangles to represent contact surfaces,
+```
+bazel-bin/geometry/profiling/contact_surface_rigid_bowl_soft_ball --polygons=false
+```
 
 Instead of the default rigid bowl, it can optionally use a rigid ball, a
 rigid box, a rigid cylinder or a rigid capsule. Instead of the default soft
 ball, it can use a soft box, a soft cylinder or a soft capsule.
-
 - default rigid bowl and default soft ball,
 ```
 bazel-bin/geometry/profiling/contact_surface_rigid_bowl_soft_ball
@@ -58,5 +62,6 @@ bazel-bin/geometry/profiling/contact_surface_rigid_bowl_soft_ball --rigid=box
 - general syntax with all options.
 ```
 bazel-bin/geometry/profiling/contact_surface_rigid_bowl_soft_ball \
---rigid=[ball, bowl, box, capsule, cylinder] --soft=[ball, box, capsule, cylinder]
+--rigid=[ball, bowl, box, capsule, cylinder] --soft=[ball, box, capsule, cylinder] \
+--polygons=[true, false]
 ```

--- a/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
+++ b/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
@@ -100,6 +100,10 @@ DEFINE_string(soft, "ball",
               "Specify the shape of the soft geometry.\n"
               "[--soft={ball,box,capsule,cylinder}]\n"
               "By default, it is the ball.\n");
+DEFINE_bool(polygons, true,
+            "Set to true to use polygons to represent contact surfaces.\n"
+            "Set to false to use triangles to represent contact surfaces.\n"
+            "By default, it is true.");
 
 /* Places a soft geometry (a ball by default) and defines its velocity as being
  sinusoidal in time in World z direction.
@@ -253,9 +257,11 @@ class ContactResultMaker final : public LeafSystem<double> {
                           lcmt_contact_results_for_viz* results) const {
     const auto& query_object =
         get_geometry_query_port().Eval<QueryObject<double>>(context);
+    const auto contact_representation =
+        FLAGS_polygons ? HydroelasticContactRepresentation::kPolygon
+                       : HydroelasticContactRepresentation::kTriangle;
     std::vector<ContactSurface<double>> contacts =
-        query_object.ComputeContactSurfaces(
-            HydroelasticContactRepresentation::kTriangle);
+        query_object.ComputeContactSurfaces(contact_representation);
     const int num_contacts = static_cast<int>(contacts.size());
 
     auto& msg = *results;


### PR DESCRIPTION
The rigid-bowl/soft-ball contact surfaces use polygons by default with an option to use triangles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16197)
<!-- Reviewable:end -->
