### PR TITLE
[fixed_fem] Re-enable ubsan for PETSc tests

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -890,10 +890,6 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "petsc_symmetric_block_sparse_matrix_test",
-    tags = [
-        # TODO(xuchenhan-tri) Re-enable these after fixing.
-        "no_ubsan",
-    ],
     deps = [
         ":petsc_symmetric_block_sparse_matrix",
         "//common/test_utilities:eigen_matrix_compare",

--- a/multibody/fixed_fem/dev/petsc_symmetric_block_sparse_matrix.cc
+++ b/multibody/fixed_fem/dev/petsc_symmetric_block_sparse_matrix.cc
@@ -137,8 +137,8 @@ class PetscSymmetricBlockSparseMatrix::Impl {
       case PreconditionerType::kIncompleteCholesky:
         PCSetType(preconditioner_, PCICC);
         break;
-      case PreconditionerType::kBlockJacobi:
-        PCSetType(preconditioner_, PCBJACOBI);
+      case PreconditionerType::kJacobi:
+        PCSetType(preconditioner_, PCJACOBI);
         break;
     }
 

--- a/multibody/fixed_fem/dev/petsc_symmetric_block_sparse_matrix.h
+++ b/multibody/fixed_fem/dev/petsc_symmetric_block_sparse_matrix.h
@@ -31,8 +31,9 @@ class PetscSymmetricBlockSparseMatrix {
   };
 
   enum class PreconditionerType {
-    /* For generic matrix. */
-    kBlockJacobi,
+    /* For generic matrix. N.B. the BlockJacobi preconditioner from PETSc by
+     default seems to assume positive definite blocks.*/
+    kJacobi,
     /* For positive definite matrix. */
     kCholesky,
     kIncompleteCholesky,

--- a/multibody/fixed_fem/dev/test/petsc_symmetric_block_sparse_matrix_test.cc
+++ b/multibody/fixed_fem/dev/test/petsc_symmetric_block_sparse_matrix_test.cc
@@ -122,18 +122,18 @@ GTEST_TEST(PetscSymmetricBlockSparseMatrixTest, Solve) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       A->Solve(
           PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
-          PetscSymmetricBlockSparseMatrix::PreconditionerType::kBlockJacobi, b),
+          PetscSymmetricBlockSparseMatrix::PreconditionerType::kJacobi, b),
       std::exception,
       "PetscSymmetricBlockSparseMatrix::Solve.*: matrix is not yet "
       "assembled.*");
   A->AssembleIfNecessary();
   const VectorXd x = A->Solve(
       PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
-      PetscSymmetricBlockSparseMatrix::PreconditionerType::kBlockJacobi, b);
+      PetscSymmetricBlockSparseMatrix::PreconditionerType::kJacobi, b);
   VectorXd x_in_place = b;
   A->SolveInPlace(
       PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
-      PetscSymmetricBlockSparseMatrix::PreconditionerType::kBlockJacobi,
+      PetscSymmetricBlockSparseMatrix::PreconditionerType::kJacobi,
       &x_in_place);
   EXPECT_EQ(x, x_in_place);
 }
@@ -163,10 +163,10 @@ GTEST_TEST(PetscSymmetricBlockSparseMatrixTest, Clone) {
   const VectorXd b = MakeVector9d();
   const VectorXd x = A->Solve(
       PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
-      PetscSymmetricBlockSparseMatrix::PreconditionerType::kBlockJacobi, b);
+      PetscSymmetricBlockSparseMatrix::PreconditionerType::kJacobi, b);
   const VectorXd x_clone = A_clone->Solve(
       PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
-      PetscSymmetricBlockSparseMatrix::PreconditionerType::kBlockJacobi, b);
+      PetscSymmetricBlockSparseMatrix::PreconditionerType::kJacobi, b);
   EXPECT_TRUE(CompareMatrices(x, x_clone, kEps));
 }
 


### PR DESCRIPTION
Use Jacobi preconditioner instead of BlockJacobi for generic matrices
since PETSc's BlockJacobi preconditioner assumes SPD blocks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16205)
<!-- Reviewable:end -->
