### PR TITLE
[pydrake] Add missing LeafSystem and State bindings

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -787,6 +787,11 @@ void DoScalarDependentDefinitions(py::module m) {
           overload_cast_explicit<DiscreteValues<T>&>(
               &State<T>::get_mutable_discrete_state),
           py_rvp::reference_internal, doc.State.get_mutable_discrete_state.doc)
+      .def("get_mutable_discrete_state",
+          overload_cast_explicit<BasicVector<T>&, int>(
+              &State<T>::get_mutable_discrete_state),
+          py::arg("index"), py_rvp::reference_internal,
+          doc.State.get_mutable_discrete_state.doc)
       .def("get_abstract_state",
           static_cast<const AbstractValues& (State<T>::*)() const>(
               &State<T>::get_abstract_state),
@@ -796,7 +801,15 @@ void DoScalarDependentDefinitions(py::module m) {
           [](State<T>* self) -> AbstractValues& {
             return self->get_mutable_abstract_state();
           },
-          py_rvp::reference_internal, doc.State.get_mutable_abstract_state.doc);
+          py_rvp::reference_internal,
+          doc.State.get_mutable_abstract_state.doc_0args)
+      .def(
+          "get_mutable_abstract_state",
+          [](State<T>* self, int index) -> AbstractValue& {
+            return self->get_mutable_abstract_state().get_mutable_value(index);
+          },
+          py::arg("index"), py_rvp::reference_internal,
+          doc.State.get_mutable_abstract_state.doc_1args);
 
   // - Constituents.
   auto continuous_state = DefineTemplateClassWithDefault<ContinuousState<T>>(

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -566,7 +566,7 @@ class TestCustom(unittest.TestCase):
         self.assertEqual(
             context.get_abstract_state(0).get_value(), model_value.get_value())
 
-        # Check state API
+        # Check state API.
         state = context.get_mutable_state()
         self.assertTrue(
             state.get_mutable_discrete_state(index=0) is

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -454,7 +454,8 @@ class LeafSystem : public System<T> {
   @code
     void MySystem::MyUpdate(const Context<T>&, State<T>*) const;
   @endcode
-  See the other signature for more information. */
+  See the other signature for more information.
+  @exclude_from_pydrake_mkdoc{This overload is not bound.} */
   template <class MySystem>
   void DeclarePeriodicUnrestrictedUpdateEvent(
       double period_sec, double offset_sec,

--- a/systems/framework/state.h
+++ b/systems/framework/state.h
@@ -84,6 +84,8 @@ class State {
     return *abstract_state_.get();
   }
 
+  /// Returns a mutable reference to the abstract component of the state,
+  /// which may be of size zero.
   AbstractValues& get_mutable_abstract_state() {
     DRAKE_ASSERT(abstract_state_ != nullptr);
     return *abstract_state_.get();


### PR DESCRIPTION
Along with #16190 , these bindings were required to enable the following simple example:

```
from pydrake.all import (AbstractValue, EventStatus, LeafSystem, PiecewisePolynomial, Simulator)

# This simple planner stores it's plan (trajectory) as state, and replans at time ≈ 1.

class MySimplePlanner(LeafSystem):
    def __init__(self, traj):
        LeafSystem.__init__(self)
        assert traj.cols() == 1
        self.DeclareVectorOutputPort("value", traj.rows(), self.CalcOutput)

        self.DeclareAbstractState(AbstractValue.Make(traj)) # The trajectory.
        self.DeclareDiscreteState(1) # Add one more state to denote whether the trajectory been updated yet...
        self.DeclarePeriodicUnrestrictedUpdateEvent(
            period_sec=0.1, offset_sec=0.0, update=self.MaybeUpdatePlan)

    def MaybeUpdatePlan(self, context, state):
        # Note: you can add input ports and read their values here.
        updated = state.get_mutable_discrete_state(0)
        if not updated[0] and context.get_time() > 1.0:
            traj = state.get_mutable_abstract_state(0)
            traj.set_value(PiecewisePolynomial.FirstOrderHold([0, 1, 2], [[-2,-1,-3],[-4,-5,-6]]))
            updated[0] = True
            print("Replanning; outputs should now be negative values")
        return EventStatus.Succeeded()

    def CalcOutput(self, context, output):
        traj = context.get_abstract_state(0).get_value()
        output.SetFromVector(traj.value(context.get_time()))


print("Initial plan: outputs should be positive values")        
traj = PiecewisePolynomial.FirstOrderHold([0, 1, 2], [[2,1,3],[4,5,6]])
source = MySimplePlanner(traj)
simulator = Simulator(source)
simulator.AdvanceTo(0.5)
print(f"Output at time 0.5: {source.get_output_port().Eval(simulator.get_context())}")

simulator.AdvanceTo(1.5) 
print(f"Output at time 1.5: {source.get_output_port().Eval(simulator.get_context())}")
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16207)
<!-- Reviewable:end -->
