### PR TITLE
[hydro] Edit most public document to use the word "compliant" instead of "soft"

### DIFF
--- a/bindings/pydrake/geometry_py_common.cc
+++ b/bindings/pydrake/geometry_py_common.cc
@@ -502,7 +502,7 @@ void DefGetPropertyCpp(py::module m) {
 // defined in set of properties. If we ever move HydroelasticType out of
 // internal and bind it, we can eliminate this helper.
 //
-// Return true if the properties indicate soft compliance, false if rigid, and
+// Return true if the properties indicate being compliant, false if rigid, and
 // throws if the property isn't set at all (or set to undefined).
 bool PropertiesIndicateSoftHydro(const geometry::ProximityProperties& props) {
   using geometry::internal::HydroelasticType;

--- a/examples/multibody/rolling_sphere/README.md
+++ b/examples/multibody/rolling_sphere/README.md
@@ -22,7 +22,7 @@ corresponding parameters vx and ωy, respectively). The ball will begin sliding
 in the +Wx direction but eventually friction will cause the ball to slow and
 then accelerate in the -Wx direction.
 
-Both the ground and the sphere can be modeled with soft or rigid compliance
+Both the ground and the sphere can be modeled as being compliant or rigid
 in the hydroelastic model. However, choice of compliance type (more particularly
 contact between objects of particular compliance) will constrain your choice
 of contact model. See details below.
@@ -47,10 +47,10 @@ The "hydroelastic" model doesn't support all combinations of geometries and
 compliance types. There are some types of geometries that cannot yet be given a
 hydroelastic representation and some types of contact which aren't modeled yet.
 
-  - Contact between a rigid shape and soft shape is supported.
-  - Contact between two rigid or two soft objects isn't supported.
+  - Contact between a rigid shape and compliant shape is supported.
+  - Contact between two rigid or two compliant objects isn't supported.
   - Drake `Mesh` shapes can only be modeled with _rigid_ hydroleastic
-    representation
+    representation.
 
 __Solvers__
 
@@ -74,13 +74,13 @@ __Changing the configuration__
 This example allows you to experiment with the contact models by changing the
 configuration in various ways:
 
-  - Add in an optional soft wall (as shown below). When using "hybrid" or
+  - Add in an optional compliant wall (as shown below). When using "hybrid" or
     "hydroelastic" contact models, the wall will have a _soft_ hydroelastic
     representation.
-  - Change the compliance type of the sphere from soft (default) to rigid for
-    the "hybrid" and "hydroelastic" models.
-  - Change the compliance type of the ground from rigid (default) to soft for
-    the "hybrid" and "hydroelastic" models.
+  - Change the compliance type of the sphere from compliant (default) to 
+    rigid for the "hybrid" and "hydroelastic" models.
+  - Change the compliance type of the ground from rigid (default) to 
+    compliant for the "hybrid" and "hydroelastic" models.
 
 ```
      ▒▒▒▒▒
@@ -104,20 +104,20 @@ behave as described in __Figure 1__ but eventually hit the wall.
 The following table enumerates some configuration options and the simulation
 outcome. Default values are indicated as "(d)".
 
-|  Ground   |  Soft Wall  |  Sphere  | Contact Model | Note |
-| --------- | ----------- | -------- | ------------- | ---------------------------------- |
-| rigid (d) |    no (d)   | soft (d) |   point (d)   | Behavior as described in Figure 1 - point pairs visualized |
-| rigid (d) |    no (d)   | soft (d) | hydroelastic  | Behavior as described in Figure 1 - contact surfaces visualized |
-| rigid (d) |    no (d)   | soft (d) |    hybrid     | Same as "hydroelastic" |
-| rigid (d) |    no (d)   |  rigid   |   point (d)   | Behavior as described in Figure 1 - the sphere's rigid declaration is meaningless for point contact and ignored |
-| rigid (d) |    no (d)   |  rigid   | hydroelastic  | Throws _immediate_ exception -- cannot support rigid-rigid contact surface between ground and sphere |
-| rigid (d) |    no (d)   |  rigid   |    hybrid     | Behavior as described in Figure 1 - rigid-rigid contact (between sphere and ground) uses point-pair contact |
-| rigid (d) |     yes     | soft (d) |   point (d)   | Behavior as described in Figure 2 - point pairs visualized |
-| rigid (d) |     yes     | soft (d) | hydroelastic  | Behavior as described in Figure 2 - Throws exception when sphere hits wall; cannot support soft-soft contact |
-| rigid (d) |     yes     | soft (d) |    hybrid     | Behavior as described in Figure 2 - sphere-ground contact is contact surface, sphere-wall contact is point pair |
-| rigid (d) |     yes     |  rigid   |    hybrid     | Behavior as described in Figure 2 - sphere-ground contact is point pair, sphere-wall contact is contact surface |
-|   soft    |   either    | soft (d) | point/hybrid  | Soft-soft contact requires "hybrid" or "point" -- crashes with "hydroelastic" |  
-|   soft    |   either    |  rigid   |     any       | Behavior as described in Figure 2 - contact visualized depends on model |  
+|  Ground   |  Compliant Wall  |     Sphere    | Contact Model | Note |
+| --------- | ---------------- | ------------- | ------------- | ---------------------------------- |
+| rigid (d) |      no (d)      | compliant (d) |   point (d)   | Behavior as described in Figure 1 - point pairs visualized |
+| rigid (d) |      no (d)      | compliant (d) | hydroelastic  | Behavior as described in Figure 1 - contact surfaces visualized |
+| rigid (d) |      no (d)      | compliant (d) |    hybrid     | Same as "hydroelastic" |
+| rigid (d) |      no (d)      |  rigid        |   point (d)   | Behavior as described in Figure 1 - the sphere's rigid declaration is meaningless for point contact and ignored |
+| rigid (d) |      no (d)      |  rigid        | hydroelastic  | Throws _immediate_ exception -- cannot support rigid-rigid contact surface between ground and sphere |
+| rigid (d) |      no (d)      |  rigid        |    hybrid     | Behavior as described in Figure 1 - rigid-rigid contact (between sphere and ground) uses point-pair contact |
+| rigid (d) |       yes        | compliant (d) |   point (d)   | Behavior as described in Figure 2 - point pairs visualized |
+| rigid (d) |       yes        | compliant (d) | hydroelastic  | Behavior as described in Figure 2 - Throws exception when sphere hits wall; cannot support compliant-compliant contact |
+| rigid (d) |       yes        | compliant (d) |    hybrid     | Behavior as described in Figure 2 - sphere-ground contact is contact surface, sphere-wall contact is point pair |
+| rigid (d) |       yes        |  rigid        |    hybrid     | Behavior as described in Figure 2 - sphere-ground contact is point pair, sphere-wall contact is contact surface |
+| compliant |     either       | compliant (d) | point/hybrid  | Compliant-compliant contact requires "hybrid" or "point" -- crashes with "hydroelastic" |  
+| compliant |     either       |  rigid        |     any       | Behavior as described in Figure 2 - contact visualized depends on model |  
 
 ## Prerequisites
 
@@ -166,12 +166,12 @@ bazel-bin/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics --mbp_dt
 The discrete solver supports all other configurations below, including hybrid
 contact.
 
-##### Default behavior with hydroelastic contact with default compliance; rigid ground, soft ball
+##### Default behavior with hydroelastic contact with default compliance type; rigid ground, compliant ball
 ```
 bazel-bin/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics --contact_model=hydroelastic
 ```
 
-##### Default behavior with hydroelastic contact with reversed compliance; soft ground, rigid ball
+##### Default behavior with hydroelastic contact with reversed compliance; compliant ground, rigid ball
 ```
 bazel-bin/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics --contact_model=hydroelastic --rigid_ball=1 --soft_ground=1
 ```

--- a/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
+++ b/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
@@ -33,18 +33,18 @@ DEFINE_double(dissipation, 5.0,
 DEFINE_double(friction_coefficient, 0.3, "friction coefficient.");
 DEFINE_bool(rigid_ball, false,
             "If true, the ball is given a rigid hydroelastic representation "
-            "(instead of the default soft value). Make sure you have the right "
-            "contact model to support this representation.");
+            "(instead of being compliant by the default). Make sure "
+            "you have the right contact model to support this representation.");
 DEFINE_bool(soft_ground, false,
             "If true, the ground is given a soft hydroelastic representation "
             "(instead of the default rigid value). Make sure you have the "
             "right contact model to support this representation.");
 DEFINE_bool(add_wall, false,
-            "If true, adds a wall with soft hydroelastic representation in the "
-            "path of the default ball trajectory. This will cause the "
-            "simulation to throw when the soft ball hits the wall with the "
-            "'hydroelastic' model; use the 'hybrid' or 'point' contact model "
-            "to simulate beyond this contact.");
+            "If true, adds a wall with compliant hydroelastic representation "
+            "in the path of the default ball trajectory. This will cause the "
+            "simulation to throw when the compliant ball hits the wall with "
+            "the 'hydroelastic' model; use the 'hybrid' or 'point' contact"
+            " model to simulate beyond this contact.");
 DEFINE_double(
     mbp_dt, 0.0,
     "The fixed time step period (in seconds) of discrete updates for the "

--- a/geometry/benchmarking/mesh_intersection_benchmark.cc
+++ b/geometry/benchmarking/mesh_intersection_benchmark.cc
@@ -14,7 +14,7 @@ namespace internal {
 /* @defgroup mesh_intersection_benchmarks Mesh Intersection Benchmarks
  @ingroup proximity_queries
 
- The benchmark evaluates mesh intersection between soft and rigid meshes.
+ The benchmark evaluates mesh intersection between compliant and rigid meshes.
 
  It computes the contact surface formed from the intersection of an ellipsoid
  and a sphere using broad-phase culling (via a bounding volume hierarchy).
@@ -109,15 +109,15 @@ Resulting contact surface sizes:
      the scenes to a resolution hint, see AddRigidHydroelasticProperties() for
      more details.
    - __contact_overlap__: Affects the size of the resulting contact surface by
-     translating the rigid mesh relative to the soft mesh. Contact overlap
+     translating the rigid mesh relative to the compliant mesh. Contact overlap
      should be one of the following enumeration values representing:
      - 0: No contact and no overlapping bounding volumes at all.
      - 1: No contact but overlapping bounding volumes.
      - 2: The minimal, or at least very small, contact surface.
      - 3: An intermediate sized contact surface.
      - 4: The maximal contact surface (in area).
-   - __rotation_factor__: How much rotation to offset between the soft and the
-     rigid mesh to increase axis misalignment. Given an offset, int `i`, the
+   - __rotation_factor__: How much rotation to offset between the compliant and
+     the rigid mesh to increase axis misalignment. Given an offset, int `i`, the
      resulting rotation is calculated as `i / max_factor * π/4` radians around
      the geometry's shortest axis, in this case, the x-axis. When rotation
      factor is zero, they are perfectly aligned, as rotation factor increases,

--- a/geometry/profiling/README.md
+++ b/geometry/profiling/README.md
@@ -24,9 +24,10 @@ kcachegrind callgrind.out.19482
 # Available Examples.
 
 ## contact_surface_rigid_bowl_soft_ball.cc:
-Compute contact surface between an anchored rigid bowl and a moving soft
-ball. The rigid bowl is a realistic non-convex object, and the soft ball uses
-a coarse tetrahedral mesh, which is typical in hydroelastic contact model.
+Compute contact surface between an anchored rigid bowl and a moving compliant
+ball. The rigid bowl is a realistic non-convex object, and the compliant
+ball uses a coarse tetrahedral mesh, which is typical in hydroelastic 
+contact model.
 
 To visualize the contact surface and pressure, run drake_visualizer and
 configure Hydroelastic Contact Visualization plugin as follows:
@@ -45,23 +46,24 @@ bazel-bin/geometry/profiling/contact_surface_rigid_bowl_soft_ball --polygons=fal
 ```
 
 Instead of the default rigid bowl, it can optionally use a rigid ball, a
-rigid box, a rigid cylinder or a rigid capsule. Instead of the default soft
-ball, it can use a soft box, a soft cylinder or a soft capsule.
-- default rigid bowl and default soft ball,
+rigid box, a rigid cylinder or a rigid capsule. Instead of the default
+compliant ball, it can use a compliant box, a compliant cylinder or a
+compliant capsule.
+- default rigid bowl and default compliant ball,
 ```
 bazel-bin/geometry/profiling/contact_surface_rigid_bowl_soft_ball
 ```
-- default rigid bowl with a soft box option,
+- default rigid bowl with a compliant box option,
 ```
-bazel-bin/geometry/profiling/contact_surface_rigid_bowl_soft_ball --soft=box
+bazel-bin/geometry/profiling/contact_surface_rigid_bowl_soft_ball --compliant=box
 ```
-- rigid box option and default soft ball,
+- rigid box option and default compliant ball,
 ```
 bazel-bin/geometry/profiling/contact_surface_rigid_bowl_soft_ball --rigid=box
 ```
 - general syntax with all options.
 ```
 bazel-bin/geometry/profiling/contact_surface_rigid_bowl_soft_ball \
---rigid=[ball, bowl, box, capsule, cylinder] --soft=[ball, box, capsule, cylinder] \
+--rigid=[ball, bowl, box, capsule, cylinder] --compliant=[ball, box, capsule, cylinder] \
 --polygons=[true, false]
 ```

--- a/geometry/proximity/triangle_surface_mesh.h
+++ b/geometry/proximity/triangle_surface_mesh.h
@@ -512,7 +512,7 @@ Vector3<T> TriangleSurfaceMesh<T>::CalcGradBarycentric(int t, int i) const {
   //  vector in TriangleSurfaceMeshFieldLinear since this calculation is not
   //  reliable for zero- or almost-zero-area triangles. For example, the code
   //  that creates ContactSurface by triangle-tetrahedron intersection can set
-  //  the pressure gradient along a contact polygon by projecting the soft
+  //  the pressure gradient along a contact polygon by projecting the compliant
   //  tetrahedron's pressure gradient onto the plane of the rigid triangle.
 
   // Let bᵥ be the barycentric coordinate function corresponding to vertex V.

--- a/geometry/proximity_properties.cc
+++ b/geometry/proximity_properties.cc
@@ -89,9 +89,9 @@ namespace {
 void AddSoftHydroelasticProperties(double hydroelastic_modulus,
                                    ProximityProperties* properties) {
   DRAKE_DEMAND(properties != nullptr);
-  // The bare minimum of defining a soft geometry is to declare its compliance
-  // type. Downstream consumers (ProximityEngine) will determine if this is
-  // sufficient.
+  // The bare minimum of defining a compliant geometry is to declare its
+  // compliance type. Downstream consumers (ProximityEngine) will determine
+  // if this is sufficient.
   if (hydroelastic_modulus <= 0) {
     throw std::logic_error(
         fmt::format("The hydroelastic modulus must be positive; given {}",

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -51,7 +51,7 @@ extern const char* const kPointStiffness;  ///< Point stiffness property
    - string constants to read and write the indicated properties, and
    - utility functions for declaring consistent hydroelastic properties
      including
-       - differentiating between a rigid and soft geometry
+       - differentiating between a rigid and compliant geometry
        - accounting for differences between tessellated meshes and half spaces.
 
  @todo Add reference to discussion of hydroelastic proximity properties along
@@ -72,8 +72,8 @@ extern const char* const kSlabThickness;    ///< Slab thickness property name
 
 // TODO(SeanCurtis-TRI): Update this to have an additional classification: kBoth
 //  when we have the need from the algorithm. For example: when we have two
-//  very stiff objects, we'd want to process them as soft. But when one
-//  very stiff and one very soft object interact, it might make sense to
+//  very stiff objects, we'd want to process them as compliant. But when one
+//  very stiff and one very compliant object interact, it might make sense to
 //  consider the stiff object as effectively rigid and simplify the computation.
 //  In this case, the object would get two representations.
 /* Classification of the type of representation a shape has for the
@@ -155,9 +155,9 @@ void AddSoftHydroelasticProperties(double resolution_hint,
                                    double hydroelastic_modulus,
                                    ProximityProperties* properties);
 
-/** Soft half spaces are handled as a special case; they do not get tessellated.
- Instead, they are treated as infinite slabs with a finite thickness. This
- variant is required for hydroelastic half spaces.
+/** Compliant half spaces are handled as a special case; they do not get
+ tessellated. Instead, they are treated as infinite slabs with a finite
+ thickness. This variant is required for hydroelastic half spaces.
 
  @param slab_thickness       The distance from the half space boundary to its
                              rigid core (this helps define the extent field of

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -277,25 +277,25 @@ class QueryObject {
      - This table shows which shapes can be declared for use in hydroelastic
        contact, and what compliance can be assigned.
 
-       |   Shape   | Soft  | Rigid |
-       | :-------: | :---: | :---- |
-       | Sphere    |  yes  |  yes  |
-       | Cylinder  |  yes  |  yes  |
-       | Box       |  yes  |  yes  |
-       | Capsule   |  yes  |  yes  |
-       | Ellipsoid |  yes  |  yes  |
-       | HalfSpace |  yes  |  yes  |
-       | Mesh      |  no   |  yes  |
-       | Convex    |  no   |  yes  |
+       |   Shape   | Compliant | Rigid |
+       | :-------: | :-------: | :---: |
+       | Sphere    |    yes    |  yes  |
+       | Cylinder  |    yes    |  yes  |
+       | Box       |    yes    |  yes  |
+       | Capsule   |    yes    |  yes  |
+       | Ellipsoid |    yes    |  yes  |
+       | HalfSpace |    yes    |  yes  |
+       | Mesh      |    no     |  yes  |
+       | Convex    |    no     |  yes  |
 
-     - We do not currently support contact between two geometries with the
-       *same* compliance; one geometry *must* be soft, and the other *must* be
-       rigid. If geometries with the same compliance collide, an exception will
-       be thrown. More particularly, if such a geometry pair *cannot be culled*
-       an exception will be thrown. No exception is thrown if the pair has been
-       filtered.
-     - The elasticity modulus E (N/m^2) of each geometry is set in
-       ProximityProperties (see AddContactMaterial()).
+     - We do not currently support contact between two geometries with
+       the *same* compliance type; one geometry *must* be compliant, and the
+       other *must* be rigid. If geometries with the same compliance type
+       collide, an exception will be thrown. More particularly, if such a
+       geometry pair *cannot be culled* an exception will be thrown. No
+       exception is thrown if the pair has been filtered.
+     - The hydroelastic modulus (N/m^2) of each compliant geometry is set in
+       ProximityProperties by AddSoftHydroelasticProperties().
      - The tessellation of the corresponding meshes is controlled by the
        resolution hint (where appropriate), as defined by
        AddSoftHydroelasticProperties() and AddRigidHydroelasticProperties().

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -110,9 +110,9 @@ GTEST_TEST(ProximityEngineTests, AddDynamicGeometry) {
 // sufficient to confirm that it is being properly invoked. We'll simply attempt
 // to instantiate every shape and assert its classification based on whether
 // it's supported or not (note: this test doesn't depend on the choice of
-// rigid/soft -- for each shape, we pick an arbitrary compliance, preferring
-// one that is supported over one that is not. Otherwise, the compliance choice
-// is immaterial.)
+// rigid/compliant -- for each shape, we pick an arbitrary compliance type,
+// preferring one that is supported over one that is not. Otherwise, the
+// compliance choice is immaterial.)
 GTEST_TEST(ProximityEngineTests, ProcessHydroelasticProperties) {
   ProximityEngine<double> engine;
   // All of the geometries will have a scale comparable to edge_length, so that
@@ -125,7 +125,7 @@ GTEST_TEST(ProximityEngineTests, ProcessHydroelasticProperties) {
   ProximityProperties rigid_properties;
   AddRigidHydroelasticProperties(edge_length, &rigid_properties);
 
-  // Case: soft sphere.
+  // Case: compliant sphere.
   {
     Sphere sphere{edge_length};
     const GeometryId sphere_id = GeometryId::get_new_id();
@@ -253,8 +253,8 @@ GTEST_TEST(ProximityEngineTest, ComputeContactSurfacesAutodiffSupport) {
       drake::FindResourceOrThrow("drake/geometry/test/non_convex_mesh.obj"),
       1.0 /* scale */};
 
-  // Case: Soft sphere and rigid mesh with AutoDiffXd -- confirm the contact
-  // surface has derivatives.
+  // Case: Compliant sphere and rigid mesh with AutoDiffXd -- confirm the
+  // contact surface has derivatives.
   {
     ProximityEngine<double> engine_d;
     const auto X_WGs_d = PopulateEngine(&engine_d, sphere, anchored, soft, mesh,

--- a/multibody/contact_solvers/contact_solver.h
+++ b/multibody/contact_solvers/contact_solver.h
@@ -69,7 +69,7 @@ enum class ContactSolverStatus {
 // i.e. `N(q)` is the identity mapping.
 //
 // Finally, it is evident that this same framework allows for a model
-// containing both rigid and soft objects.
+// containing both rigid and deformable objects.
 //
 // TODO(amcastro-tri): add sections specific to bilateral and unilateral
 // constraints.
@@ -191,9 +191,9 @@ enum class ContactSolverStatus {
 // where τ₀ includes external forces as well as Coriolis and centrifugal terms.
 // In this case A = ∇F = M, v* = v₀ + dt⋅M⁻¹⋅τ₀.
 //
-// As a second example, consider the simulation of soft bodies with frictional
-// contact for which, without diving into the details, the momentum equations
-// can be briefly summarized as:
+// As a second example, consider the simulation of deformable bodies with
+// frictional contact for which, without diving into the details, the momentum
+// equations can be briefly summarized as:
 // <pre>
 //   F(v) = M⋅(v−v₀) + dt⋅Fᵢₙₜ(q(v), v)
 //   q(v) = q₀ + dt⋅v

--- a/multibody/plant/test/multibody_plant_hydroelastic_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_test.cc
@@ -140,12 +140,12 @@ class HydroelasticModelTests : public ::testing::Test {
     plant_->SetFreeBodyPose(plant_context_, *body_, X_WB);
   }
 
-  // This method computes the repulsion force between a soft sphere and a rigid
-  // half-space as predicted by the hydroelastic model, when dissipation is
-  // zero. The integral is performed analytically. For this case,  the
-  // extent field is specified to be e(r) = 1 - r / R, where `r` is the radial
-  // spherical coordinate and `R` is the radius of the sphere. For a given
-  // penetration distance d, the hydroelastic model predicts a contact
+  // This method computes the repulsion force between a compliant sphere and a
+  // rigid half-space as predicted by the hydroelastic contact model, when
+  // dissipation is zero. The integral is performed analytically. For this
+  // case, the extent field is specified to be e(r) = 1 - r / R, where `r` is
+  // the radial spherical coordinate and `R` is the radius of the sphere. For
+  // a given penetration distance d, the hydroelastic model predicts a contact
   // patch of radius `a` which is the intersection of the sphere with the half
   // space. Using trigonometry the contact patch radius is given by a² = d (2R -
   // d). The normal force is then computed by integrating the pressure p(r) = E


### PR DESCRIPTION
- No change in the code except in the comments.
- No change to the internal namespace.
- Keep the word "soft" when the context is clear. Specifically, the terms
  "soft hydroelastics" and API AddSoftHydroelasticProperties() stay.

The follow-up PR #16224 will change the API like AddSoftHydroelasticProperties() to AddCompliantHydroelasticProperties() (and corresponding SDF/URDF tags).

Relates #15796.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16218)
<!-- Reviewable:end -->
