### PR TITLE
Remove errant comma when writing a RotationalInertia

### DIFF
--- a/multibody/tree/rotational_inertia.cc
+++ b/multibody/tree/rotational_inertia.cc
@@ -60,7 +60,7 @@ std::ostream& operator<<(std::ostream& out, const RotationalInertia<T>& I) {
     if (width) out.width(width);
     out << I(i, 0);
     for (int j = 1; j < I.cols(); ++j) {
-      out << ", ";
+      out << "  ";
       if (width) out.width(width);
       out << I(i, j);
     }

--- a/multibody/tree/test/rotational_inertia_test.cc
+++ b/multibody/tree/test/rotational_inertia_test.cc
@@ -93,9 +93,9 @@ GTEST_TEST(RotationalInertia, MakeFromMomentsAndProductsOfInertia) {
     // invalid rotational inertia (a principal moment of inertia is negative).
     std::string expected_message =
         "MakeFromMomentsAndProductsOfInertia\\(\\): The rotational inertia\n"
-        "\\[ 1, -3, -3\\]\n"
-        "\\[-3, 13, -6\\]\n"
-        "\\[-3, -6, 10\\]\n"
+        "\\[ 1  -3  -3\\]\n"
+        "\\[-3  13  -6\\]\n"
+        "\\[-3  -6  10\\]\n"
         "did not pass the test CouldBePhysicallyValid\\(\\)\\.";
     expected_message += fmt::format(
         "\nThe associated principal moments of inertia:"
@@ -112,9 +112,9 @@ GTEST_TEST(RotationalInertia, MakeFromMomentsAndProductsOfInertia) {
     // rotational inertia that violates the triangle inequality.
     expected_message =
       "MakeFromMomentsAndProductsOfInertia\\(\\): The rotational inertia\n"
-        "\\[34, -3, -3\\]\n"
-        "\\[-3, 13, -6\\]\n"
-        "\\[-3, -6, 10\\]\n"
+        "\\[34  -3  -3\\]\n"
+        "\\[-3  13  -6\\]\n"
+        "\\[-3  -6  10\\]\n"
         "did not pass the test CouldBePhysicallyValid\\(\\)\\.";
     expected_message += fmt::format(
         "\nThe associated principal moments of inertia:"
@@ -628,9 +628,9 @@ GTEST_TEST(RotationalInertia, ShiftOperator) {
   RotationalInertia<double> I(1, 2.718, 3.14);
   stream << std::fixed << std::setprecision(4) << I;
   std::string expected_string =
-                  "[1.0000, 0.0000, 0.0000]\n"
-                  "[0.0000, 2.7180, 0.0000]\n"
-                  "[0.0000, 0.0000, 3.1400]\n";
+                  "[1.0000  0.0000  0.0000]\n"
+                  "[0.0000  2.7180  0.0000]\n"
+                  "[0.0000  0.0000  3.1400]\n";
   EXPECT_EQ(expected_string, stream.str());
 }
 

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -154,9 +154,9 @@ GTEST_TEST(SpatialInertia, ShiftOperator) {
       " mass = 2.5\n"
       " Center of mass = [0.1  -0.2  0.3]\n"
       " Inertia about point P, I_BP =\n"
-      "[ 5.0000,  0.2500, -0.2500]\n"
-      "[ 0.2500,  5.7500,  0.5000]\n"
-      "[-0.2500,  0.5000,  6.0000]\n";
+      "[ 5.0000   0.2500  -0.2500]\n"
+      "[ 0.2500   5.7500   0.5000]\n"
+      "[-0.2500   0.5000   6.0000]\n";
   EXPECT_EQ(expected_string, stream.str());
 }
 
@@ -346,9 +346,9 @@ GTEST_TEST(SpatialInertia, IsPhysicallyValidWithBadInertia) {
       " mass = 1(\\.0)?\n"
       " Center of mass = \\[0(\\.0)?  0(\\.0)?  0(\\.0)?\\]\n"
       " Inertia about point P, I_BP =\n"
-      "\\[  -2, -0.1, -0.2\\]\n"
-      "\\[-0.1,   -3, -0.3\\]\n"
-      "\\[-0.2, -0.3,   -4\\]\n"
+      "\\[  -2  -0.1  -0.2\\]\n"
+      "\\[-0.1    -3  -0.3\\]\n"
+      "\\[-0.2  -0.3    -4\\]\n"
       " Principal moments of inertia about Bcm \\(center of mass\\) =\n"
       "\\[-4.105976670111\\d+  -2.9188291125626\\d+  -1.9751942173260\\d+\\]\n";
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -364,13 +364,13 @@ GTEST_TEST(SpatialInertia, IsPhysicallyValidWithCOMTooFarOut) {
       " mass = 1(\\.0)?\n"
       " Center of mass = \\[2(\\.0)?  0(\\.0)?  0(\\.0)?\\]\n"
       " Inertia about point P, I_BP =\n"
-      "\\[0.4,   0,   0\\]\n"
-      "\\[  0, 0.4,   0\\]\n"
-      "\\[  0,   0, 0.4\\]\n"
+      "\\[0.4    0    0\\]\n"
+      "\\[  0  0.4    0\\]\n"
+      "\\[  0    0  0.4\\]\n"
       " Inertia about center of mass, I_BBcm =\n"
-      "\\[ 0.4,    0,    0\\]\n"
-      "\\[   0, -3.6,    0\\]\n"
-      "\\[   0,    0, -3.6\\]\n"
+      "\\[ 0.4     0     0\\]\n"
+      "\\[   0  -3.6     0\\]\n"
+      "\\[   0     0  -3.6\\]\n"
       " Principal moments of inertia about Bcm \\(center of mass\\) =\n"
       "\\[-3.6  -3.6  0.4\\]\n";
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -409,13 +409,13 @@ GTEST_TEST(SpatialInertia, IsPhysicallyValidThrowsNiceExceptionMessage) {
       " mass = 0.634\n"
       " Center of mass = \\[0(\\.0)?  0.016  -0.02\\]\n"
       " Inertia about point P, I_BP =\n"
-      "\\[  0.0023989,    0.000245,     1.3e-05\\]\n"
-      "\\[   0.000245,   0.0023566,  0.00020438\\]\n"
-      "\\[    1.3e-05,  0.00020438, 0.000570304\\]\n"
+      "\\[  0.0023989     0.000245      1.3e-05\\]\n"
+      "\\[   0.000245    0.0023566   0.00020438\\]\n"
+      "\\[    1.3e-05   0.00020438  0.000570304\\]\n"
       " Inertia about center of mass, I_BBcm =\n"
-      "\\[0.001983, 0.000245,  1.3e-05\\]\n"
-      "\\[0.000245, 0.002103,  1.5e-06\\]\n"
-      "\\[ 1.3e-05,  1.5e-06, 0.000408\\]\n"
+      "\\[0.001983  0.000245   1.3e-05\\]\n"
+      "\\[0.000245  0.002103   1.5e-06\\]\n"
+      "\\[ 1.3e-05   1.5e-06  0.000408\\]\n"
       " Principal moments of inertia about Bcm \\(center of mass\\) =\n"
       "\\[0.0004078925412\\d+  0.001790822592803\\d+  0.00229528486596\\d+\\]"
       "\n");


### PR DESCRIPTION
Cleanup errant comma when writing a RotationalInertia.  This was requested by @EricCousineau-TRI during recent PR for writing error messages when user has a bad RotationalInertia or SpatialInertia.  The bigger issue of a good way to consistently write matrices is not addressed here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16222)
<!-- Reviewable:end -->
