### PR TITLE
WIP: Python suppression file renamed on Focal

### DIFF
--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -131,7 +131,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "iris_test",
-    shard_count = 4,
+    shard_count = 12,
     deps = [
         ":iris",
         "//common/test_utilities:eigen_matrix_compare",

--- a/tools/dynamic_analysis/valgrind.sh
+++ b/tools/dynamic_analysis/valgrind.sh
@@ -26,7 +26,7 @@ valgrind \
     --show-leak-kinds=definite,possible \
     --suppressions="${mydir}/valgrind.supp" \
     --suppressions=/usr/lib/valgrind/debian.supp \
-    --suppressions=/usr/lib/valgrind/python.supp \
+    --suppressions=/usr/lib/valgrind/python3.supp \
     --tool=memcheck \
     --trace-children=yes \
     --trace-children-skip=/bin/cat,/bin/cp,/bin/ln,/bin/ls,/bin/mkdir,/bin/mv,/bin/sed,/lib/ld-linux.so.\*,/lib64/ld-linux-x86-64.so.\*,/usr/bin/clang,/usr/bin/clang-9,/usr/bin/clang-format-9,/usr/bin/diff,/usr/bin/dot,/usr/bin/fc-list,/usr/bin/file,/usr/bin/find,/usr/bin/gcc,/usr/bin/ldd,/usr/bin/patchelf,/usr/bin/strip,/usr/bin/uname,\*/external/buildifier/buildifier \


### PR DESCRIPTION
The valgrind python suppression file is `python.supp` on Bionic and `python3.supp` on Focal.

This change will break Bionic and should NOT be merged.

Working towards #14928

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16223)
<!-- Reviewable:end -->
