### PR TITLE
[hydro] Rename public API and SDF/URDF tags to use "compliant" for "soft"

### DIFF
--- a/bindings/pydrake/geometry_py_common.cc
+++ b/bindings/pydrake/geometry_py_common.cc
@@ -504,13 +504,14 @@ void DefGetPropertyCpp(py::module m) {
 //
 // Return true if the properties indicate being compliant, false if rigid, and
 // throws if the property isn't set at all (or set to undefined).
-bool PropertiesIndicateSoftHydro(const geometry::ProximityProperties& props) {
+bool PropertiesIndicateCompliantHydro(
+    const geometry::ProximityProperties& props) {
   using geometry::internal::HydroelasticType;
   const HydroelasticType hydro_type =
       props.GetPropertyOrDefault(geometry::internal::kHydroGroup,
           geometry::internal::kComplianceType, HydroelasticType::kUndefined);
   if (hydro_type == HydroelasticType::kUndefined) {
-    throw std::runtime_error("No specification of rigid or soft");
+    throw std::runtime_error("No specification of rigid or compliant");
   }
   return hydro_type == HydroelasticType::kSoft;
 }
@@ -521,7 +522,7 @@ void def_testing_module(py::module m) {
   const auto constant_id = geometry::FilterId::get_new_id();
   m.def("get_constant_id", [constant_id]() { return constant_id; });
 
-  m.def("PropertiesIndicateSoftHydro", &PropertiesIndicateSoftHydro);
+  m.def("PropertiesIndicateCompliantHydro", &PropertiesIndicateCompliantHydro);
 
   // For use with `test_geometry_properties_cpp_types`.
   DefGetPropertyCpp<std::string>(m);

--- a/bindings/pydrake/geometry_py_hydro.cc
+++ b/bindings/pydrake/geometry_py_hydro.cc
@@ -166,14 +166,16 @@ void DoScalarIndependentDefinitions(py::module m) {
       py::overload_cast<ProximityProperties*>(&AddRigidHydroelasticProperties),
       py::arg("properties"), doc.AddRigidHydroelasticProperties.doc_1args);
 
-  m.def("AddSoftHydroelasticProperties", &AddSoftHydroelasticProperties,
-      py::arg("resolution_hint"), py::arg("hydroelastic_modulus"),
-      py::arg("properties"), doc.AddSoftHydroelasticProperties.doc);
-
-  m.def("AddSoftHydroelasticPropertiesForHalfSpace",
-      &AddSoftHydroelasticPropertiesForHalfSpace, py::arg("slab_thickness"),
+  m.def("AddCompliantHydroelasticProperties",
+      &AddCompliantHydroelasticProperties, py::arg("resolution_hint"),
       py::arg("hydroelastic_modulus"), py::arg("properties"),
-      doc.AddSoftHydroelasticPropertiesForHalfSpace.doc);
+      doc.AddCompliantHydroelasticProperties.doc);
+
+  m.def("AddCompliantHydroelasticPropertiesForHalfSpace",
+      &AddCompliantHydroelasticPropertiesForHalfSpace,
+      py::arg("slab_thickness"), py::arg("hydroelastic_modulus"),
+      py::arg("properties"),
+      doc.AddCompliantHydroelasticPropertiesForHalfSpace.doc);
 }
 
 }  // namespace

--- a/bindings/pydrake/multibody/test/hydroelastic.sdf
+++ b/bindings/pydrake/multibody/test/hydroelastic.sdf
@@ -57,7 +57,7 @@
           <drake:mesh_resolution_hint>0.2</drake:mesh_resolution_hint>
           <drake:hydroelastic_modulus>180.0e9</drake:hydroelastic_modulus>
           <drake:hunt_crossley_dissipation>1.25</drake:hunt_crossley_dissipation>
-          <drake:soft_hydroelastic/>
+          <drake:compliant_hydroelastic/>
         </drake:proximity_properties>
       </collision>
     </link>

--- a/bindings/pydrake/test/geometry_common_test.py
+++ b/bindings/pydrake/test/geometry_common_test.py
@@ -256,7 +256,7 @@ class TestGeometryCore(unittest.TestCase):
         mut.AddRigidHydroelasticProperties(
             resolution_hint=res_hint, properties=props)
         self.assertTrue(props.HasProperty("hydroelastic", "compliance_type"))
-        self.assertFalse(mut_testing.PropertiesIndicateSoftHydro(props))
+        self.assertFalse(mut_testing.PropertiesIndicateCompliantHydro(props))
         self.assertTrue(props.HasProperty("hydroelastic", "resolution_hint"))
         self.assertEqual(props.GetProperty("hydroelastic", "resolution_hint"),
                          res_hint)
@@ -264,15 +264,15 @@ class TestGeometryCore(unittest.TestCase):
         props = mut.ProximityProperties()
         mut.AddRigidHydroelasticProperties(properties=props)
         self.assertTrue(props.HasProperty("hydroelastic", "compliance_type"))
-        self.assertFalse(mut_testing.PropertiesIndicateSoftHydro(props))
+        self.assertFalse(mut_testing.PropertiesIndicateCompliantHydro(props))
         self.assertFalse(props.HasProperty("hydroelastic", "resolution_hint"))
 
         props = mut.ProximityProperties()
         res_hint = 0.275
-        mut.AddSoftHydroelasticProperties(
+        mut.AddCompliantHydroelasticProperties(
             resolution_hint=res_hint, hydroelastic_modulus=E, properties=props)
         self.assertTrue(props.HasProperty("hydroelastic", "compliance_type"))
-        self.assertTrue(mut_testing.PropertiesIndicateSoftHydro(props))
+        self.assertTrue(mut_testing.PropertiesIndicateCompliantHydro(props))
         self.assertTrue(props.HasProperty("hydroelastic", "resolution_hint"))
         self.assertEqual(props.GetProperty("hydroelastic", "resolution_hint"),
                          res_hint)
@@ -283,11 +283,11 @@ class TestGeometryCore(unittest.TestCase):
 
         props = mut.ProximityProperties()
         slab_thickness = 0.275
-        mut.AddSoftHydroelasticPropertiesForHalfSpace(
+        mut.AddCompliantHydroelasticPropertiesForHalfSpace(
             slab_thickness=slab_thickness, hydroelastic_modulus=E,
             properties=props)
         self.assertTrue(props.HasProperty("hydroelastic", "compliance_type"))
-        self.assertTrue(mut_testing.PropertiesIndicateSoftHydro(props))
+        self.assertTrue(mut_testing.PropertiesIndicateCompliantHydro(props))
         self.assertTrue(props.HasProperty("hydroelastic", "slab_thickness"))
         self.assertEqual(props.GetProperty("hydroelastic", "slab_thickness"),
                          slab_thickness)

--- a/bindings/pydrake/test/geometry_hydro_test.py
+++ b/bindings/pydrake/test/geometry_hydro_test.py
@@ -21,7 +21,7 @@ class TestGeometryHydro(unittest.TestCase):
         mut.AddRigidHydroelasticProperties(
             resolution_hint=res_hint, properties=props)
         self.assertTrue(props.HasProperty("hydroelastic", "compliance_type"))
-        self.assertFalse(mut_testing.PropertiesIndicateSoftHydro(props))
+        self.assertFalse(mut_testing.PropertiesIndicateCompliantHydro(props))
         self.assertTrue(props.HasProperty("hydroelastic", "resolution_hint"))
         self.assertEqual(props.GetProperty("hydroelastic", "resolution_hint"),
                          res_hint)
@@ -29,15 +29,15 @@ class TestGeometryHydro(unittest.TestCase):
         props = mut.ProximityProperties()
         mut.AddRigidHydroelasticProperties(properties=props)
         self.assertTrue(props.HasProperty("hydroelastic", "compliance_type"))
-        self.assertFalse(mut_testing.PropertiesIndicateSoftHydro(props))
+        self.assertFalse(mut_testing.PropertiesIndicateCompliantHydro(props))
         self.assertFalse(props.HasProperty("hydroelastic", "resolution_hint"))
 
         props = mut.ProximityProperties()
         res_hint = 0.275
-        mut.AddSoftHydroelasticProperties(
+        mut.AddCompliantHydroelasticProperties(
             resolution_hint=res_hint, hydroelastic_modulus=E, properties=props)
         self.assertTrue(props.HasProperty("hydroelastic", "compliance_type"))
-        self.assertTrue(mut_testing.PropertiesIndicateSoftHydro(props))
+        self.assertTrue(mut_testing.PropertiesIndicateCompliantHydro(props))
         self.assertTrue(props.HasProperty("hydroelastic", "resolution_hint"))
         self.assertEqual(props.GetProperty("hydroelastic", "resolution_hint"),
                          res_hint)
@@ -48,11 +48,11 @@ class TestGeometryHydro(unittest.TestCase):
 
         props = mut.ProximityProperties()
         slab_thickness = 0.275
-        mut.AddSoftHydroelasticPropertiesForHalfSpace(
+        mut.AddCompliantHydroelasticPropertiesForHalfSpace(
             slab_thickness=slab_thickness, hydroelastic_modulus=E,
             properties=props)
         self.assertTrue(props.HasProperty("hydroelastic", "compliance_type"))
-        self.assertTrue(mut_testing.PropertiesIndicateSoftHydro(props))
+        self.assertTrue(mut_testing.PropertiesIndicateCompliantHydro(props))
         self.assertTrue(props.HasProperty("hydroelastic", "slab_thickness"))
         self.assertEqual(props.GetProperty("hydroelastic", "slab_thickness"),
                          slab_thickness)

--- a/bindings/pydrake/test/geometry_scene_graph_test.py
+++ b/bindings/pydrake/test/geometry_scene_graph_test.py
@@ -50,14 +50,15 @@ class TestGeometrySceneGraph(unittest.TestCase):
         mut.AddRigidHydroelasticProperties(resolution_hint=1, properties=props)
         scene_graph.AssignRole(source_id=global_source, geometry_id=sphere_2,
                                properties=props)
-        # We'll explicitly give sphere_3 a soft hydroelastic representation.
+        # We'll explicitly give sphere_3 a compliant hydroelastic
+        # representation.
         sphere_3 = scene_graph.RegisterAnchoredGeometry(
             source_id=global_source,
             geometry=mut.GeometryInstance(X_PG=RigidTransform_[float](),
                                           shape=mut.Sphere(1.),
                                           name="sphere3"))
         props = mut.ProximityProperties()
-        mut.AddSoftHydroelasticProperties(
+        mut.AddCompliantHydroelasticProperties(
             resolution_hint=1, hydroelastic_modulus=1e8, properties=props)
         scene_graph.AssignRole(source_id=global_source, geometry_id=sphere_3,
                                properties=props)

--- a/examples/multibody/rolling_sphere/make_rolling_sphere_plant.cc
+++ b/examples/multibody/rolling_sphere/make_rolling_sphere_plant.cc
@@ -12,8 +12,8 @@ namespace bouncing_ball {
 
 using drake::geometry::AddContactMaterial;
 using drake::geometry::AddRigidHydroelasticProperties;
-using drake::geometry::AddSoftHydroelasticProperties;
-using drake::geometry::AddSoftHydroelasticPropertiesForHalfSpace;
+using drake::geometry::AddCompliantHydroelasticProperties;
+using drake::geometry::AddCompliantHydroelasticPropertiesForHalfSpace;
 using drake::geometry::ProximityProperties;
 using drake::geometry::SceneGraph;
 using drake::geometry::Sphere;
@@ -27,7 +27,7 @@ using drake::math::RigidTransformd;
 std::unique_ptr<drake::multibody::MultibodyPlant<double>> MakeBouncingBallPlant(
     double mbp_dt, double radius, double mass, double hydroelastic_modulus,
     double dissipation, const CoulombFriction<double>& surface_friction,
-    const Vector3<double>& gravity_W, bool rigid_sphere, bool soft_ground,
+    const Vector3<double>& gravity_W, bool rigid_sphere, bool compliant_ground,
     SceneGraph<double>* scene_graph) {
   auto plant = std::make_unique<MultibodyPlant<double>>(mbp_dt);
 
@@ -41,8 +41,8 @@ std::unique_ptr<drake::multibody::MultibodyPlant<double>> MakeBouncingBallPlant(
 
     const RigidTransformd X_WG;  // identity.
     ProximityProperties ground_props;
-    if (soft_ground) {
-      AddSoftHydroelasticPropertiesForHalfSpace(
+    if (compliant_ground) {
+      AddCompliantHydroelasticPropertiesForHalfSpace(
           1.0, hydroelastic_modulus, &ground_props);
     } else {
       AddRigidHydroelasticProperties(&ground_props);
@@ -66,7 +66,9 @@ std::unique_ptr<drake::multibody::MultibodyPlant<double>> MakeBouncingBallPlant(
     if (rigid_sphere) {
       AddRigidHydroelasticProperties(radius, &ball_props);
     } else {
-      AddSoftHydroelasticProperties(radius, hydroelastic_modulus, &ball_props);
+      AddCompliantHydroelasticProperties(radius,
+                                         hydroelastic_modulus,
+                                         &ball_props);
     }
     plant->RegisterCollisionGeometry(ball, X_BS, Sphere(radius), "collision",
                                      std::move(ball_props));

--- a/examples/multibody/rolling_sphere/make_rolling_sphere_plant.h
+++ b/examples/multibody/rolling_sphere/make_rolling_sphere_plant.h
@@ -44,7 +44,7 @@ namespace bouncing_ball {
 /// @param[in] rigid_sphere
 ///   If `true`, the sphere will have a _rigid_ hydroelastic representation
 ///   (soft otherwise).
-/// @param[in] soft_ground
+/// @param[in] compliant_ground
 ///   If 'true', the ground will have a _soft_ hydroelastic representation
 ///   (rigid otherwise).
 /// @param scene_graph
@@ -60,7 +60,7 @@ MakeBouncingBallPlant(
     double radius, double mass,
     double hydroelastic_modulus, double dissipation,
     const drake::multibody::CoulombFriction<double>& surface_friction,
-    const Vector3<double>& gravity_W, bool rigid_sphere, bool soft_ground,
+    const Vector3<double>& gravity_W, bool rigid_sphere, bool compliant_ground,
     geometry::SceneGraph<double>* scene_graph = nullptr);
 
 }  // namespace bouncing_ball

--- a/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
+++ b/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
@@ -35,10 +35,11 @@ DEFINE_bool(rigid_ball, false,
             "If true, the ball is given a rigid hydroelastic representation "
             "(instead of being compliant by the default). Make sure "
             "you have the right contact model to support this representation.");
-DEFINE_bool(soft_ground, false,
-            "If true, the ground is given a soft hydroelastic representation "
-            "(instead of the default rigid value). Make sure you have the "
-            "right contact model to support this representation.");
+DEFINE_bool(
+    compliant_ground, false,
+    "If true, the ground is given a compliant hydroelastic representation "
+    "(instead of the default rigid value). Make sure you have the "
+    "right contact model to support this representation.");
 DEFINE_bool(add_wall, false,
             "If true, adds a wall with compliant hydroelastic representation "
             "in the path of the default ball trajectory. This will cause the "
@@ -115,7 +116,7 @@ int do_main() {
   MultibodyPlant<double>& plant = *builder.AddSystem(MakeBouncingBallPlant(
       FLAGS_mbp_dt, radius, mass, FLAGS_hydroelastic_modulus, FLAGS_dissipation,
       coulomb_friction, -g * Vector3d::UnitZ(), FLAGS_rigid_ball,
-      FLAGS_soft_ground, &scene_graph));
+      FLAGS_compliant_ground, &scene_graph));
 
   if (FLAGS_add_wall) {
     geometry::Box wall{0.2, 4, 0.4};
@@ -124,7 +125,7 @@ int do_main() {
     geometry::AddContactMaterial({} /* dissipation */, {} /* point stiffness */,
                                  CoulombFriction<double>(),
                                  &prox_prop);
-    geometry::AddSoftHydroelasticProperties(0.1, 1e8, &prox_prop);
+    geometry::AddCompliantHydroelasticProperties(0.1, 1e8, &prox_prop);
     plant.RegisterCollisionGeometry(plant.world_body(), X_WB, wall,
                                     "wall_collision", std::move(prox_prop));
 

--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -42,7 +42,7 @@ namespace contact_surface {
 using Eigen::Vector3d;
 using Eigen::Vector4d;
 using geometry::AddRigidHydroelasticProperties;
-using geometry::AddSoftHydroelasticProperties;
+using geometry::AddCompliantHydroelasticProperties;
 using geometry::Box;
 using geometry::ContactSurface;
 using geometry::Cylinder;
@@ -119,7 +119,7 @@ class MovingBall final : public LeafSystem<double> {
                                       make_unique<Sphere>(1.0), "ball"));
 
     ProximityProperties prox_props;
-    AddSoftHydroelasticProperties(FLAGS_length, 1e8, &prox_props);
+    AddCompliantHydroelasticProperties(FLAGS_length, 1e8, &prox_props);
     scene_graph->AssignRole(source_id_, geometry_id_, prox_props);
 
     IllustrationProperties illus_props;

--- a/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
+++ b/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
@@ -50,7 +50,7 @@ using Eigen::Vector3d;
 using Eigen::Vector4d;
 using geometry::AddContactMaterial;
 using geometry::AddRigidHydroelasticProperties;
-using geometry::AddSoftHydroelasticProperties;
+using geometry::AddCompliantHydroelasticProperties;
 using geometry::Box;
 using geometry::Capsule;
 using geometry::ContactSurface;
@@ -189,7 +189,7 @@ class MovingCompliantGeometry final : public LeafSystem<double> {
     }
     ProximityProperties prox_props;
     // Resolution Hint affects the compliant ball but not the compliant box.
-    AddSoftHydroelasticProperties(FLAGS_resolution_hint, 1e8, &prox_props);
+    AddCompliantHydroelasticProperties(FLAGS_resolution_hint, 1e8, &prox_props);
     scene_graph->AssignRole(source_id_, geometry_id_, prox_props);
 
     IllustrationProperties illus_props;

--- a/geometry/proximity/test/hydroelastic_callback_test.cc
+++ b/geometry/proximity/test/hydroelastic_callback_test.cc
@@ -47,7 +47,7 @@ ProximityProperties rigid_properties() {
 ProximityProperties soft_properties() {
   ProximityProperties props;
   const double resolution_hint = 0.25;
-  AddSoftHydroelasticProperties(resolution_hint, 1e8, &props);
+  AddCompliantHydroelasticProperties(resolution_hint, 1e8, &props);
   // Redundantly add slab thickness so it can be used with compliant mesh or
   // compliant half space.
   props.AddProperty(kHydroGroup, kSlabThickness, 0.25);

--- a/geometry/proximity/test/hydroelastic_internal_test.cc
+++ b/geometry/proximity/test/hydroelastic_internal_test.cc
@@ -343,7 +343,7 @@ GTEST_TEST(Hydroelastic, GeometriesPopulationAndQuery) {
 
   GeometryId soft_id = GeometryId::get_new_id();
   ProximityProperties soft_properties;
-  AddSoftHydroelasticProperties(1.0, 1e8, &soft_properties);
+  AddCompliantHydroelasticProperties(1.0, 1e8, &soft_properties);
 
   GeometryId bad_id = GeometryId::get_new_id();
   EXPECT_EQ(geometries.hydroelastic_type(rigid_id),
@@ -378,7 +378,7 @@ GTEST_TEST(Hydroelastic, RemoveGeometry) {
   // Add a soft geometry.
   const GeometryId soft_id = GeometryId::get_new_id();
   ProximityProperties soft_properties;
-  AddSoftHydroelasticProperties(1.0, 1e8, &soft_properties);
+  AddCompliantHydroelasticProperties(1.0, 1e8, &soft_properties);
   geometries.MaybeAddGeometry(Sphere(0.5), soft_id, soft_properties);
   ASSERT_EQ(geometries.hydroelastic_type(soft_id), HydroelasticType::kSoft);
 
@@ -801,7 +801,7 @@ class HydroelasticSoftGeometryTest : public ::testing::Test {
   /* Creates a simple set of properties for generating soft geometry. */
   ProximityProperties soft_properties(double edge_length = 0.1) const {
     ProximityProperties soft_properties;
-    AddSoftHydroelasticProperties(edge_length, 1e8, &soft_properties);
+    AddCompliantHydroelasticProperties(edge_length, 1e8, &soft_properties);
     return soft_properties;
   }
 };

--- a/geometry/proximity_properties.cc
+++ b/geometry/proximity_properties.cc
@@ -86,8 +86,8 @@ void AddRigidHydroelasticProperties(ProximityProperties* properties) {
 }
 
 namespace {
-void AddSoftHydroelasticProperties(double hydroelastic_modulus,
-                                   ProximityProperties* properties) {
+void AddCompliantHydroelasticProperties(double hydroelastic_modulus,
+                                        ProximityProperties* properties) {
   DRAKE_DEMAND(properties != nullptr);
   // The bare minimum of defining a compliant geometry is to declare its
   // compliance type. Downstream consumers (ProximityEngine) will determine
@@ -104,22 +104,22 @@ void AddSoftHydroelasticProperties(double hydroelastic_modulus,
 }
 }  // namespace
 
-void AddSoftHydroelasticProperties(double resolution_hint,
-                                   double hydroelastic_modulus,
-                                   ProximityProperties* properties) {
+void AddCompliantHydroelasticProperties(double resolution_hint,
+                                        double hydroelastic_modulus,
+                                        ProximityProperties* properties) {
   DRAKE_DEMAND(properties != nullptr);
   properties->AddProperty(internal::kHydroGroup, internal::kRezHint,
                           resolution_hint);
-  AddSoftHydroelasticProperties(hydroelastic_modulus, properties);
+  AddCompliantHydroelasticProperties(hydroelastic_modulus, properties);
 }
 
-void AddSoftHydroelasticPropertiesForHalfSpace(
+void AddCompliantHydroelasticPropertiesForHalfSpace(
     double slab_thickness, double hydroelastic_modulus,
     ProximityProperties* properties) {
   DRAKE_DEMAND(properties != nullptr);
   properties->AddProperty(internal::kHydroGroup, internal::kSlabThickness,
                           slab_thickness);
-  AddSoftHydroelasticProperties(hydroelastic_modulus, properties);
+  AddCompliantHydroelasticProperties(hydroelastic_modulus, properties);
 }
 
 }  // namespace geometry

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -135,9 +135,9 @@ void AddRigidHydroelasticProperties(ProximityProperties* properties);
 // TODO(SeanCurtis-TRI): Add module that explains resolution hint and reference
 //  it in the documentation below.
 /** Adds properties to the given set of proximity properties sufficient to cause
- the associated geometry to generate a soft hydroelastic representation. The
- geometry's pressure field will be the function p(e) = Ee, where E is the
- elastic modulus stored in the given `properties`.
+ the associated geometry to generate a compliant hydroelastic representation.
+ The geometry's pressure field will be the function p(e) = Ee, where E is the
+ hydroelastic modulus stored in the given `properties`.
 
  @param resolution_hint       If the geometry is to be tessellated, it is the
                               parameter that guides the level of mesh
@@ -151,9 +151,9 @@ void AddRigidHydroelasticProperties(ProximityProperties* properties);
                               names that this function would need to add.
  @pre 0 < `resolution_hint` < ∞, 0 < `hydroelastic_modulus`, and `properties`
       is not nullptr. */
-void AddSoftHydroelasticProperties(double resolution_hint,
-                                   double hydroelastic_modulus,
-                                   ProximityProperties* properties);
+void AddCompliantHydroelasticProperties(double resolution_hint,
+                                        double hydroelastic_modulus,
+                                        ProximityProperties* properties);
 
 /** Compliant half spaces are handled as a special case; they do not get
  tessellated. Instead, they are treated as infinite slabs with a finite
@@ -168,9 +168,9 @@ void AddSoftHydroelasticProperties(double resolution_hint,
                         that this function would need to add.
  @pre 0 < `slab_thickness` < ∞, 0 < `hydroelastic_modulus`, and `properties`
       is not nullptr. */
-void AddSoftHydroelasticPropertiesForHalfSpace(double slab_thickness,
-                                               double hydroelastic_modulus,
-                                               ProximityProperties* properties);
+void AddCompliantHydroelasticPropertiesForHalfSpace(
+    double slab_thickness, double hydroelastic_modulus,
+    ProximityProperties* properties);
 
 //@}
 

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -295,10 +295,11 @@ class QueryObject {
        geometry pair *cannot be culled* an exception will be thrown. No
        exception is thrown if the pair has been filtered.
      - The hydroelastic modulus (N/m^2) of each compliant geometry is set in
-       ProximityProperties by AddSoftHydroelasticProperties().
+       ProximityProperties by AddCompliantHydroelasticProperties().
      - The tessellation of the corresponding meshes is controlled by the
        resolution hint (where appropriate), as defined by
-       AddSoftHydroelasticProperties() and AddRigidHydroelasticProperties().
+       AddCompliantHydroelasticProperties() and
+       AddRigidHydroelasticProperties().
 
    <h3>Scalar support</h3>
 

--- a/geometry/test/drake_visualizer_test.cc
+++ b/geometry/test/drake_visualizer_test.cc
@@ -775,7 +775,9 @@ TYPED_TEST(DrakeVisualizerTest, VisualizeHydroGeometry) {
   add_geometry(make_unique<Box>(1, 1, 1), "box", props, X_PBox);
   add_geometry(make_unique<HalfSpace>(), "rigid_half_space", props);
 
-  /* Populate with soft hydroelastic properties and add soft geometries. */
+  /* Populate with compliant hydroelastic properties and add
+     compliant geometries.
+  */
   props.AddProperty(internal::kHydroGroup, internal::kSlabThickness, 5.0);
   props.AddProperty(internal::kHydroGroup, internal::kElastic, 5.0);
   props.UpdateProperty(internal::kHydroGroup, internal::kComplianceType,

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -3716,7 +3716,7 @@ GTEST_TEST(GeometryStateHydroTest, GetHydroMesh) {
   AddRigidHydroelasticProperties(1.0, &rigid_hydro);
   ProximityProperties soft_hydro;
   AddContactMaterial(0.0, {}, {}, &soft_hydro);
-  AddSoftHydroelasticProperties(1.0, 1e8, &soft_hydro);
+  AddCompliantHydroelasticProperties(1.0, 1e8, &soft_hydro);
 
   // We'll simply affix a number of geometries as anchored with the identity
   // pose. The other details don't really matter.

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -121,7 +121,7 @@ GTEST_TEST(ProximityEngineTests, ProcessHydroelasticProperties) {
   const double edge_length = 0.5;
   const double E = 1e8;  // Elastic modulus.
   ProximityProperties soft_properties;
-  AddSoftHydroelasticProperties(edge_length, E, &soft_properties);
+  AddCompliantHydroelasticProperties(edge_length, E, &soft_properties);
   ProximityProperties rigid_properties;
   AddRigidHydroelasticProperties(edge_length, &rigid_properties);
 
@@ -215,7 +215,7 @@ std::pair<GeometryId, RigidTransformd> AddShape(ProximityEngine<double>* engine,
   const double edge_length = 0.5;
   ProximityProperties properties;
   if (is_soft) {
-    AddSoftHydroelasticProperties(edge_length, 1e8, &properties);
+    AddCompliantHydroelasticProperties(edge_length, 1e8, &properties);
   } else {
     AddRigidHydroelasticProperties(edge_length, &properties);
   }
@@ -520,7 +520,7 @@ GTEST_TEST(ProximityEngineTests, ReplaceProperties) {
     EXPECT_EQ(PET::hydroelastic_type(sphere.id(), engine), kUndefined);
   }
 
-  // Create a baseline property set that requests a soft hydroelastic
+  // Create a baseline property set that requests a compliant hydroelastic
   // representation, but is not necessarily sufficient to define one.
   ProximityProperties hydro_trigger;
   hydro_trigger.AddProperty(kHydroGroup, kComplianceType,
@@ -1902,7 +1902,7 @@ class ProximityEngineHydro : public testing::Test {
     poses_ = MakeCollidingRing(r, 4);
 
     ProximityProperties soft_properties;
-    AddSoftHydroelasticProperties(r, 1e8, &soft_properties);
+    AddCompliantHydroelasticProperties(r, 1e8, &soft_properties);
     ProximityProperties rigid_properties;
     AddRigidHydroelasticProperties(r, &rigid_properties);
 
@@ -1960,7 +1960,7 @@ class ProximityEngineHydroWithFallback : public testing::Test {
     poses_ = MakeCollidingRing(r, N_);
 
     ProximityProperties soft_properties;
-    AddSoftHydroelasticProperties(r / 2, 1e8, &soft_properties);
+    AddCompliantHydroelasticProperties(r / 2, 1e8, &soft_properties);
     ProximityProperties rigid_properties;
     AddRigidHydroelasticProperties(r, &rigid_properties);
 

--- a/geometry/test/proximity_properties_test.cc
+++ b/geometry/test/proximity_properties_test.cc
@@ -133,11 +133,11 @@ void CheckDisallowedModulusValues(
 // vigorously test multiple values of the other fields. We assume that it's been
 // tested already, and we just want to make sure the custom pressure field comes
 // through.
-GTEST_TEST(ProximityPropertiesTest, AddSoftProperties) {
+GTEST_TEST(ProximityPropertiesTest, AddCompliantProperties) {
   const double E = 1.5e8;
   for (double length : {1e-5, 1.25, 1e7}) {
     ProximityProperties props;
-    AddSoftHydroelasticProperties(length, E, &props);
+    AddCompliantHydroelasticProperties(length, E, &props);
     EXPECT_TRUE(props.HasProperty(kHydroGroup, kComplianceType));
     EXPECT_EQ(props.GetProperty<HydroelasticType>(kHydroGroup, kComplianceType),
               HydroelasticType::kSoft);
@@ -148,9 +148,9 @@ GTEST_TEST(ProximityPropertiesTest, AddSoftProperties) {
   }
 
   CheckDisallowedModulusValues(
-      "AddSoftHydroelasticProperties",
+      "AddCompliantHydroelasticProperties",
       [](double modulus, ProximityProperties* p) {
-        AddSoftHydroelasticProperties(1., modulus, p);
+        AddCompliantHydroelasticProperties(1., modulus, p);
       });
 }
 
@@ -160,7 +160,7 @@ GTEST_TEST(ProximityPropertiesTest, AddHalfSpaceSoftProperties) {
   const double E = 1.5e8;
   for (double thickness : {1e-5, 1.25, 1e7}) {
     ProximityProperties props;
-    AddSoftHydroelasticPropertiesForHalfSpace(thickness, E, &props);
+    AddCompliantHydroelasticPropertiesForHalfSpace(thickness, E, &props);
     EXPECT_TRUE(props.HasProperty(kHydroGroup, kSlabThickness));
     EXPECT_EQ(props.GetProperty<double>(kHydroGroup, kSlabThickness),
               thickness);
@@ -171,9 +171,9 @@ GTEST_TEST(ProximityPropertiesTest, AddHalfSpaceSoftProperties) {
   }
 
   CheckDisallowedModulusValues(
-      "AddSoftHydroelasticPropertiesForHalfSpace",
+      "AddCompliantHydroelasticPropertiesForHalfSpace",
       [](double modulus, ProximityProperties* p) {
-        AddSoftHydroelasticPropertiesForHalfSpace(1., modulus, p);
+        AddCompliantHydroelasticPropertiesForHalfSpace(1., modulus, p);
       });
 }
 

--- a/multibody/hydroelastics/test/hydroelastic_engine_test.cc
+++ b/multibody/hydroelastics/test/hydroelastic_engine_test.cc
@@ -46,9 +46,9 @@ class HydroelasticEngineTest : public ::testing::Test {
     return id;
   }
 
-  /** Adds a geometry with the given name and assigns soft hydroelastic geometry
-   properties.  */
-  GeometryId AddSoftGeometry(const std::string& name,
+  /** Adds a geometry with the given name and assigns compliant hydroelastic
+   geometry properties.  */
+  GeometryId AddCompliantGeometry(const std::string& name,
                              double hydroelastic_modulus, double dissipation) {
     GeometryId id = AddGeometry(name);
     ProximityProperties props;
@@ -83,7 +83,7 @@ class HydroelasticEngineTest : public ::testing::Test {
 TEST_F(HydroelasticEngineTest, CombineSoftAndRigidMaterialProperties) {
   const double E_A = 10.0;
   const double d_A = 1.0;
-  GeometryId id_A = AddSoftGeometry("SoftBody", E_A, d_A);
+  GeometryId id_A = AddCompliantGeometry("SoftBody", E_A, d_A);
   GeometryId id_B = AddRigidGeometry("RigidBody");
 
   // Create an engine.
@@ -119,8 +119,8 @@ TEST_F(HydroelasticEngineTest, CombineSoftAndSoftMaterialProperties) {
   // Expected combined properties.
   const double Estar = 1.6;
   const double dstar = 1.6;
-  GeometryId id_A = AddSoftGeometry("SoftBodyA", E_A, d_A);
-  GeometryId id_B = AddSoftGeometry("SoftBodyB", E_B, d_B);
+  GeometryId id_A = AddCompliantGeometry("SoftBodyA", E_A, d_A);
+  GeometryId id_B = AddCompliantGeometry("SoftBodyB", E_B, d_B);
 
   // Create an engine.
   HydroelasticEngine<double> engine;

--- a/multibody/parsing/detail_common.cc
+++ b/multibody/parsing/detail_common.cc
@@ -12,20 +12,20 @@ void DataSource::DemandExactlyOne() const {
 
 geometry::ProximityProperties ParseProximityProperties(
     const std::function<std::optional<double>(const char*)>& read_double,
-    bool is_rigid, bool is_soft) {
+    bool is_rigid, bool is_compliant) {
   using HT = geometry::internal::HydroelasticType;
   using geometry::internal::kComplianceType;
   using geometry::internal::kElastic;
   using geometry::internal::kHydroGroup;
   using geometry::internal::kRezHint;
 
-  // Both being true is disallowed -- so assert is_rigid NAND is_soft.
-  DRAKE_DEMAND(!(is_rigid && is_soft));
+  // Both being true is disallowed -- so assert is_rigid NAND is_compliant.
+  DRAKE_DEMAND(!(is_rigid && is_compliant));
   geometry::ProximityProperties properties;
 
   if (is_rigid) {
     properties.AddProperty(kHydroGroup, kComplianceType, HT::kRigid);
-  } else if (is_soft) {
+  } else if (is_compliant) {
     properties.AddProperty(kHydroGroup, kComplianceType, HT::kSoft);
   }
 

--- a/multibody/parsing/detail_common.h
+++ b/multibody/parsing/detail_common.h
@@ -48,7 +48,7 @@ inline CoulombFriction<double> default_friction() {
 // the two parsers use different mechanisms to extract data from the file):
 //
 //   1. Determine if the `<drake:rigid_hydroelastic>` tag is present.
-//   2. Determine if the `<drake:soft_hydroelastic>` tag is present.
+//   2. Determine if the `<drake:compliant_hydroelastic>` tag is present.
 //   3. Create a function that will extract an *optional* double-valued scalar
 //      from a <drake:some_property> child tag of the
 //      <drake:proximity_properties> tag.
@@ -64,13 +64,13 @@ inline CoulombFriction<double> default_friction() {
 //                     named tags.
 // @param is_rigid     True if the caller detected the presence of the
 //                     <drake:rigid_hydroelastic> tag.
-// @param is_soft      True if the caller detected the presence of the
-//                     <drake:soft_hydroelastic> tag.
+// @param is_compliant True if the caller detected the presence of the
+//                     <drake:compliant_hydroelastic> tag.
 // @return All proximity properties discovered via the `read_double` function.
-// @pre At most one of `is_rigid` and `is_soft` is true.
+// @pre At most one of `is_rigid` and `is_compliant` is true.
 geometry::ProximityProperties ParseProximityProperties(
     const std::function<std::optional<double>(const char*)>& read_double,
-    bool is_rigid, bool is_soft);
+    bool is_rigid, bool is_compliant);
 
 // Populates a LinearBushingRollPitchYaw from a reading interface in a URDF/SDF
 // agnostic manner. This function does no semantic parsing and leaves the

--- a/multibody/parsing/detail_scene_graph.cc
+++ b/multibody/parsing/detail_scene_graph.cc
@@ -417,16 +417,17 @@ ProximityProperties MakeProximityPropertiesForCollision(
     };
 
     const bool is_rigid = drake_element->HasElement("drake:rigid_hydroelastic");
-    const bool is_soft = drake_element->HasElement("drake:soft_hydroelastic");
+    const bool is_compliant =
+        drake_element->HasElement("drake:compliant_hydroelastic");
 
-    if (is_rigid && is_soft) {
+    if (is_rigid && is_compliant) {
       throw std::runtime_error(
           "A <collision> geometry has defined mutually-exclusive tags "
-          "<drake:rigid_hydroelastic> and <drake:soft_hydroelastic>. Only one "
-          "can be provided.");
+          "<drake:rigid_hydroelastic> and <drake:compliant_hydroelastic>. Only "
+          "one can be provided.");
     }
 
-    properties = ParseProximityProperties(read_double, is_rigid, is_soft);
+    properties = ParseProximityProperties(read_double, is_rigid, is_compliant);
   }
 
   // TODO(SeanCurtis-TRI): Remove all of this legacy parsing code based on

--- a/multibody/parsing/detail_scene_graph.h
+++ b/multibody/parsing/detail_scene_graph.h
@@ -147,12 +147,12 @@ math::RigidTransformd MakeGeometryPoseFromSdfCollision(
  | Tag                              | Group        | Property                  | Notes                                                                                                                            |
  | :------------------------------: | :----------: | :-----------------------: | :------------------------------------------------------------------------------------------------------------------------------: |
  | drake:mesh_resolution_hint       | hydroelastic | resolution_hint           | Required for shapes that require tessellation to support hydroelastic contact.                                                   |
- | drake:hydroelastic_modulus       | hydroelastic | hydroelastic_modulus      | Finite positive value. Required for soft hydroelastic representations.                                                           |
+ | drake:hydroelastic_modulus       | hydroelastic | hydroelastic_modulus      | Finite positive value. Required for compliant hydroelastic representations.                                                           |
  | drake:hunt_crossley_dissipation  | material     | hunt_crossley_dissipation |                                                                                                                                  |
  | drake:mu_dynamic                 | material     | coulomb_friction          | See note below on friction.                                                                                                      |
  | drake:mu_static                  | material     | coulomb_friction          | See note below on friction.                                                                                                      |
  | drake:rigid_hydroelastic         | hydroelastic | compliance_type           | Requests a rigid hydroelastic representation. Cannot be combined *with* soft_hydroelastic.                                       |
- | drake:soft_hydroelastic          | hydroelastic | compliance_type           | Requests a soft hydroelastic representation. Cannot be combined *with* rigid_hydroelastic. Requires a value for hydroelastic_modulus. |
+ | drake:compliant_hydroelastic     | hydroelastic | compliance_type           | Requests a compliant hydroelastic representation. Cannot be combined *with* rigid_hydroelastic. Requires a value for hydroelastic_modulus. |
 
  <h3>Coefficients of friction</h3>
 

--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -548,18 +548,19 @@ geometry::GeometryInstance ParseCollision(
 
     const XMLElement* const rigid_element =
         drake_element->FirstChildElement("drake:rigid_hydroelastic");
-    const XMLElement* const soft_element =
-        drake_element->FirstChildElement("drake:soft_hydroelastic");
-    if (rigid_element && soft_element) {
+    const XMLElement* const compliant_element =
+        drake_element->FirstChildElement("drake:compliant_hydroelastic");
+    if (rigid_element && compliant_element) {
       throw std::runtime_error(fmt::format(
           "Collision geometry has defined mutually-exclusive tags "
-          "<drake:rigid_hydroelastic> and <drake:soft_hydroelastic> on lines "
+          "<drake:rigid_hydroelastic> and "
+          "<drake:compliant_hydroelastic> on lines "
           "{} and {}, respectively. Only one can be provided.",
-          rigid_element->GetLineNum(), soft_element->GetLineNum()));
+          rigid_element->GetLineNum(), compliant_element->GetLineNum()));
     }
 
     props = ParseProximityProperties(read_double, rigid_element != nullptr,
-        soft_element != nullptr);
+                                     compliant_element != nullptr);
   }
 
   // TODO(SeanCurtis-TRI): Remove all of this legacy parsing code based on

--- a/multibody/parsing/detail_urdf_geometry.h
+++ b/multibody/parsing/detail_urdf_geometry.h
@@ -160,12 +160,12 @@ geometry::GeometryInstance ParseVisual(
  | Tag                              | Group        | Property                  | Notes                                                                                                                            |
  | :------------------------------: | :----------: | :-----------------------: | :------------------------------------------------------------------------------------------------------------------------------: |
  | drake:mesh_resolution_hint       | hydroelastic | resolution_hint           | Required for shapes that require tessellation to support hydroelastic contact.                                                   |
- | drake:hydroelastic_modulus       | hydroelastic | hydroelastic_modulus      | Finite positive value. Required for soft hydroelastic representations.                                                           |
+ | drake:hydroelastic_modulus       | hydroelastic | hydroelastic_modulus      | Finite positive value. Required for compliant hydroelastic representations.                                                      |
  | drake:hunt_crossley_dissipation  | material     | hunt_crossley_dissipation |                                                                                                                                  |
  | drake:mu_dynamic                 | material     | coulomb_friction          | See note below on friction.                                                                                                      |
  | drake:mu_static                  | material     | coulomb_friction          | See note below on friction.                                                                                                      |
  | drake:rigid_hydroelastic         | hydroelastic | compliance_type           | Requests a rigid hydroelastic representation. Cannot be combined *with* soft_hydroelastic.                                       |
- | drake:soft_hydroelastic          | hydroelastic | compliance_type           | Requests a soft hydroelastic representation. Cannot be combined *with* rigid_hydroelastic. Requires a value for hydroelastic_modulus. |
+ | drake:compliant_hydroelastic     | hydroelastic | compliance_type           | Requests a compliant hydroelastic representation. Cannot be combined *with* rigid_hydroelastic. Requires a value for hydroelastic_modulus. |
 
  <h3>Coefficients of friction</h3>
 

--- a/multibody/parsing/test/detail_scene_graph_test.cc
+++ b/multibody/parsing/test/detail_scene_graph_test.cc
@@ -1111,11 +1111,11 @@ GTEST_TEST(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
               geometry::internal::HydroelasticType::kRigid);
   }
 
-  // Case: specifies soft hydroelastic.
+  // Case: specifies compliant hydroelastic.
   {
     unique_ptr<sdf::Collision> sdf_collision = make_sdf_collision(R"""(
   <drake:proximity_properties>
-    <drake:soft_hydroelastic/>
+    <drake:compliant_hydroelastic/>
   </drake:proximity_properties>)""");
     ProximityProperties properties =
         MakeProximityPropertiesForCollision(*sdf_collision);
@@ -1131,13 +1131,13 @@ GTEST_TEST(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
     unique_ptr<sdf::Collision> sdf_collision = make_sdf_collision(R"""(
   <drake:proximity_properties>
     <drake:rigid_hydroelastic/>
-    <drake:soft_hydroelastic/>
+    <drake:compliant_hydroelastic/>
   </drake:proximity_properties>)""");
     DRAKE_EXPECT_THROWS_MESSAGE(
         MakeProximityPropertiesForCollision(*sdf_collision),
         std::runtime_error,
         "A <collision> geometry has defined mutually-exclusive tags .*rigid.* "
-        "and .*soft.*");
+        "and .*compliant.*");
   }
 
   // Case: has no drake coefficients, only mu & m2 in ode: contains mu, mu2

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -597,11 +597,11 @@ TEST_F(UrdfGeometryTests, CollisionProperties) {
             geometry::internal::HydroelasticType::kRigid);
   }
 
-  // Case: specifies soft hydroelastic.
+  // Case: specifies compliant hydroelastic.
   {
     unique_ptr<XMLDocument> doc = MakeCollisionDocFromString(R"""(
   <drake:proximity_properties>
-    <drake:soft_hydroelastic/>
+    <drake:compliant_hydroelastic/>
   </drake:proximity_properties>)""");
     const XMLElement* collision_node = doc->FirstChildElement("collision");
     ASSERT_NE(collision_node, nullptr);
@@ -620,7 +620,7 @@ TEST_F(UrdfGeometryTests, CollisionProperties) {
   {
     unique_ptr<XMLDocument> doc = MakeCollisionDocFromString(R"""(
   <drake:proximity_properties>
-    <drake:soft_hydroelastic/>
+    <drake:compliant_hydroelastic/>
     <drake:rigid_hydroelastic/>
   </drake:proximity_properties>)""");
     const XMLElement* collision_node = doc->FirstChildElement("collision");
@@ -629,7 +629,7 @@ TEST_F(UrdfGeometryTests, CollisionProperties) {
         ParseCollision("link_name", package_map, root_dir, collision_node),
         std::runtime_error,
         "Collision geometry has defined mutually-exclusive tags .*rigid.* and "
-        ".*soft.*");
+        ".*compliant.*");
   }
 
   // TODO(SeanCurtis-TRI): This is the *old* interface; the new

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1479,8 +1479,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// The hydroelastic modulus can be specified in one of two ways:
   ///
   /// - define it in an instance of geometry::ProximityProperties using
-  ///   the function geometry::AddSoftHydroelasticProperties() and
-  ///   geometry::AddSoftHydroelasticPropertiesForHalfSpace(), or
+  ///   the function geometry::AddCompliantHydroelasticProperties() and
+  ///   geometry::AddCompliantHydroelasticPropertiesForHalfSpace(), or
   /// - define it in an input URDF/SDF as detailed @ref sdf_contact_material
   ///   "here for SDF" or @ref urdf_contact_material "here for URDF".
   ///

--- a/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
@@ -47,7 +47,7 @@ class HydroelasticContactResultsOutputTester : public ::testing::Test {
         examples::multibody::bouncing_ball::MakeBouncingBallPlant(
             0.0 /* mbp_dt */, radius, mass, hydroelastic_modulus, dissipation,
             friction, gravity_W, false /* rigid_sphere */,
-            false /* soft_ground */, &scene_graph));
+            false /* compliant_ground */, &scene_graph));
     plant_->set_contact_model(ContactModel::kHydroelastic);
     plant_->Finalize();
 

--- a/multibody/plant/test/multibody_plant_hydroelastic_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_test.cc
@@ -124,7 +124,7 @@ class HydroelasticModelTests : public ::testing::Test {
 
     geometry::ProximityProperties props;
     // This should produce a level-2 refinement (two steps beyond octahedron).
-    geometry::AddSoftHydroelasticProperties(
+    geometry::AddCompliantHydroelasticProperties(
         radius / 2, hydroelastic_modulus, &props);
     geometry::AddContactMaterial(
         dissipation, {},
@@ -388,7 +388,7 @@ class ContactModelTest : public ::testing::Test {
     const double kSize = 10;
     const RigidTransformd X_WG{Vector3d{0, 0, -kSize / 2}};
     geometry::Box ground = geometry::Box::MakeCube(kSize);
-    geometry::AddSoftHydroelasticProperties(
+    geometry::AddCompliantHydroelasticProperties(
         kSize, kElasticModulus, &contact_material);
     plant->RegisterCollisionGeometry(plant->world_body(), X_WG, ground,
                                      "GroundCollisionGeometry",


### PR DESCRIPTION
Use "compliant" for hydroelastic contact model to distinguish it from "deformable" or "soft" FEM model.

Relates #15796.

It's a sequel to #16218.

There are still lots of "soft" in `geometry::internal` (like `geometry::internal::HydroelasticType::kSoft`), which is not a part of this PR. This PR focuses on public API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16224)
<!-- Reviewable:end -->
