### PR TITLE
[multibody] Extend public API to let users choose contact-surface representation.

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1982,8 +1982,8 @@ void MultibodyPlant<T>::CalcContactSurfaces(
 
   if (is_discrete()) {
     *contact_surfaces = query_object.ComputeContactSurfaces(
-        geometry::HydroelasticContactRepresentation::kPolygon);
-  } else {
+        get_contact_surface_representation());
+  } else {  // Continuous system has only one choice: kTriangle.
     *contact_surfaces = query_object.ComputeContactSurfaces(
         geometry::HydroelasticContactRepresentation::kTriangle);
   }
@@ -2011,9 +2011,9 @@ void MultibodyPlant<T>::CalcHydroelasticWithFallback(
 
     if (is_discrete()) {
       query_object.ComputeContactSurfacesWithFallback(
-          geometry::HydroelasticContactRepresentation::kPolygon,
-          &data->contact_surfaces, &data->point_pairs);
-    } else {
+          get_contact_surface_representation(), &data->contact_surfaces,
+          &data->point_pairs);
+    } else {  // Continuous system has only one choice: kTriangle.
       query_object.ComputeContactSurfacesWithFallback(
           geometry::HydroelasticContactRepresentation::kTriangle,
           &data->contact_surfaces, &data->point_pairs);

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -794,6 +794,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     collision_geometries_ = other.collision_geometries_;
     X_WB_default_list_ = other.X_WB_default_list_;
     contact_model_ = other.contact_model_;
+    contact_surface_representation_ =
+        other.contact_surface_representation_;
     penetration_allowance_ = other.penetration_allowance_;
     // Note: The physical models must be cloned before `FinalizePlantOnly()` is
     // called because `FinalizePlantOnly()` has to allocate system resources
@@ -1616,6 +1618,19 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// The default contact model is ContactModel::kPoint.
   /// @throws std::exception iff called post-finalize.
   void set_contact_model(ContactModel model);
+
+  /// Sets the representation of contact surfaces to be used by `this`
+  /// %MultibodyPlant for discrete systems.
+  void set_contact_surface_representation(
+      geometry::HydroelasticContactRepresentation representation) {
+    contact_surface_representation_ = representation;
+  }
+  /// Gets the representation of contact surfaces to be used by `this`
+  /// %MultibodyPlant for discrete systems.
+  geometry::HydroelasticContactRepresentation
+  get_contact_surface_representation() const {
+    return contact_surface_representation_;
+  }
 
 #ifndef DRAKE_DOXYGEN_CXX
   // TODO(xuchenhan-tri): Remove SetContactSolver() once
@@ -4875,6 +4890,12 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // with the default value in multibody_plant_config.h; there are already
   // assertions in the cc file that enforce this.
   ContactModel contact_model_{ContactModel::kPoint};
+
+  // User's choice of the representation of contact surfaces in discrete
+  // systems. Keep it sync with the default value in multibody_plant_config.h.
+  geometry::HydroelasticContactRepresentation
+      contact_surface_representation_{
+          geometry::HydroelasticContactRepresentation::kPolygon};
 
   // Port handles for geometry:
   systems::InputPortIndex geometry_query_port_;


### PR DESCRIPTION
Relates #15796.

Basically the better version of `set_low_resolution_contact_surface()`, which is recently removed in #16120.

- Add C++ API get/set_contact_surface_representation().
- Update MultibodyPlantConfig
- Future task: python binding

Implementation note:
- Use the choice in MbP CalcContactSurfaces() and CalcHydroelasticWithFallback().

Still a draft PR. No work on MultibodyPlantConfig, no unit tests, no python binding yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16228)
<!-- Reviewable:end -->
