### PR TITLE
Revert "[ycb] Swich models demo to use meshcat (#16220)"

### DIFF
--- a/manipulation/models/ycb/BUILD.bazel
+++ b/manipulation/models/ycb/BUILD.bazel
@@ -33,8 +33,7 @@ drake_cc_googletest(
     data = [":models"],
     deps = [
         "//common:find_resource",
-        "//common:scope_exit",
-        "//geometry:meshcat_visualizer",
+        "//geometry:drake_visualizer",
         "//multibody/parsing",
         "//multibody/plant",
         "//systems/analysis:simulator",


### PR DESCRIPTION
This reverts commit 3baf4af07e53d1fdc8c7319dd044e6783d5a4e77.

Dear @jwnimmer-tri ,

 The on-call build cop, @svenevs, believes that your PR #16220 may have
 broken one or more of Drake's continuous integration builds [1]. It is
 possible to break a build even if your PR passed continuous integration
 pre-merge because additional platforms are tested post-merge.

 The specific build failures under investigation are:
- https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-bionic-clang-bazel-nightly-everything-valgrind-memcheck/
- https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-bionic-clang-bazel-nightly-valgrind-memcheck/

 Therefore, the build cop has created this revert PR and started a complete
 post-merge build to determine whether your PR was in fact the cause of the
 problem. If that build passes, this revert PR will be merged 60 minutes from
 now. You can then fix the problem at your leisure, and send a new PR to
 reinstate your change.

 If you believe your original PR did not actually break the build, please
 explain on this thread.

 If you believe you can fix the break promptly in lieu of a revert, please
 explain on this thread, and send a PR to the build cop for review ASAP.

 If you believe your original PR definitely did break the build and should be
 reverted, please review and LGTM this PR. This allows the build cop to merge
 without waiting for CI results.

 For advice on how to handle a build cop revert, see [2].

 Thanks!
 Your Friendly On-call Build Cop

 [1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
 [2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

CC: @rpoyner-tri :policeman:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16235)
<!-- Reviewable:end -->
