### PR TITLE
[geometry] Add meshcat_environment test utility

### DIFF
--- a/geometry/test_utilities/BUILD.bazel
+++ b/geometry/test_utilities/BUILD.bazel
@@ -37,4 +37,21 @@ drake_cc_library(
     deps = ["//geometry/render:render_engine"],
 )
 
+drake_cc_library(
+    name = "meshcat_environment",
+    testonly = 1,
+    srcs = ["meshcat_environment.cc"],
+    hdrs = ["meshcat_environment.h"],
+    tags = [
+        # This utility introduces global test set-up and tear-down.
+        # Developers should opt-in to that behavior, rather than have it occur
+        # implicitly by depending on the entire utilities library.
+        "exclude_from_package",
+    ],
+    deps = [
+        "//geometry:meshcat",
+        "@gtest//:without_main",
+    ],
+)
+
 add_lint_tests()

--- a/geometry/test_utilities/meshcat_environment.cc
+++ b/geometry/test_utilities/meshcat_environment.cc
@@ -1,0 +1,55 @@
+#include "drake/geometry/test_utilities/meshcat_environment.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace geometry {
+
+namespace {
+
+class MeshcatEnvironment final : public ::testing::Environment {
+ public:
+  // This function is called by googletest during main(), but before any test
+  // cases are run.
+  void SetUp() final {
+    meshcat_ = std::make_shared<Meshcat>();
+  }
+
+  // This function is called by googletest during main() after all test cases
+  // have been run.
+  void TearDown() final {
+    meshcat_.reset();
+  }
+
+  // Helper for GetTestEnvironmentMeshcat, below.
+  std::shared_ptr<Meshcat> GetSingleton() const {
+    DRAKE_DEMAND(meshcat_ != nullptr);
+    return meshcat_;
+  }
+
+ private:
+  std::shared_ptr<Meshcat> meshcat_;
+};
+
+// This is a global variable with a non-trivial constructor, so is a violation
+// of our style guide rules related to the static initialization order fiasco.
+// However, we know that it will be safe because it's constructor does not
+// depend on any other code, and unfortunately it is difficult to formulate
+// testing globals that need tear-down in any other way.
+const ::testing::Environment* g_meshcat_environment =
+    testing::AddGlobalTestEnvironment(new MeshcatEnvironment);
+
+}  // namespace
+
+std::shared_ptr<Meshcat> GetTestEnvironmentMeshcat() {
+  DRAKE_DEMAND(g_meshcat_environment != nullptr);
+  auto* cast = dynamic_cast<const MeshcatEnvironment*>(g_meshcat_environment);
+  DRAKE_DEMAND(cast != nullptr);
+  return cast->GetSingleton();
+}
+
+}  // namespace geometry
+}  // namespace drake
+

--- a/geometry/test_utilities/meshcat_environment.h
+++ b/geometry/test_utilities/meshcat_environment.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/geometry/meshcat.h"
+
+namespace drake {
+namespace geometry {
+
+/** Returns a singleton Meshcat object to be used during unit tests. The same
+object is used for all test cases. If test code needs to reset the scene
+between tests, it must do so explicitly. */
+std::shared_ptr<Meshcat> GetTestEnvironmentMeshcat();
+
+}  // namespace geometry
+}  // namespace drake

--- a/manipulation/models/ycb/BUILD.bazel
+++ b/manipulation/models/ycb/BUILD.bazel
@@ -35,6 +35,7 @@ drake_cc_googletest(
         "//common:find_resource",
         "//common:scope_exit",
         "//geometry:meshcat_visualizer",
+        "//geometry/test_utilities:meshcat_environment",
         "//multibody/parsing",
         "//multibody/plant",
         "//systems/analysis:simulator",


### PR DESCRIPTION
Port the ycb parsing demo to use it.

The utility ensures that the test-global meshcat object is torn down upon the completion of the tests.

Closes #16235.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16236)
<!-- Reviewable:end -->
