### PR TITLE
[geometry/dev] Assign render labels to objects and add image saving feature

### DIFF
--- a/geometry/render/dev/BUILD.bazel
+++ b/geometry/render/dev/BUILD.bazel
@@ -30,6 +30,7 @@ drake_cc_binary(
     ],
     test_rule_tags = vtk_test_tags(),
     deps = [
+        "//common:filesystem",
         "//geometry:drake_visualizer",
         "//geometry:scene_graph",
         "//geometry/render:render_engine_vtk",
@@ -40,6 +41,7 @@ drake_cc_binary(
         "//systems/lcm:lcm_pubsub_system",
         "//systems/primitives:constant_vector_source",
         "//systems/sensors:image_to_lcm_image_array_t",
+        "//systems/sensors:image_writer",
         "//systems/sensors:rgbd_sensor",
         "@gflags",
     ],


### PR DESCRIPTION
Currently, no object in the scene has a `RenderLabel` assigned to it. The only exception is `mustard_bottle` where `RenderLabel` is assigned somewhere in the pipeline, but not in this code. This PR adds `RenderLabel` to all the objects.

Also, I added image saving feature to make debugging easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16237)
<!-- Reviewable:end -->
