### PR TITLE
[hydro] Cleanup typos of "hydroelastic"

### DIFF
--- a/examples/multibody/rolling_sphere/README.md
+++ b/examples/multibody/rolling_sphere/README.md
@@ -49,7 +49,7 @@ hydroelastic representation and some types of contact which aren't modeled yet.
 
   - Contact between a rigid shape and compliant shape is supported.
   - Contact between two rigid or two compliant objects isn't supported.
-  - Drake `Mesh` shapes can only be modeled with _rigid_ hydroleastic
+  - Drake `Mesh` shapes can only be modeled with _rigid_ hydroelastic
     representation.
 
 __Solvers__

--- a/geometry/test/drake_visualizer_test.cc
+++ b/geometry/test/drake_visualizer_test.cc
@@ -741,7 +741,7 @@ TYPED_TEST(DrakeVisualizerTest, VisualizeHydroGeometry) {
   using T = TypeParam;
 
   DrakeVisualizerParams params;
-  /* We'll expect the visualizer default color gets applied to the hydroelasitc
+  /* We'll expect the visualizer default color gets applied to the hydroelastic
    meshes -- we haven't defined any other color to the geometry. So, we'll pick
    an arbitrary value that *isn't* the default value. */
   params.default_color = Rgba{0.25, 0.5, 0.75, 0.5};

--- a/multibody/parsing/detail_scene_graph.h
+++ b/multibody/parsing/detail_scene_graph.h
@@ -142,9 +142,10 @@ math::RigidTransformd MakeGeometryPoseFromSdfCollision(
  corresponding property will be missing from the property set.
 
  Mapping from SDF tag to geometry property. See
- @ref YET_TO_BE_WRITTEN_HYDROELATIC_GEOMETRY_MODULE for details on the semantics
- of these properties.
- | Tag                              | Group        | Property                  | Notes                                                                                                                            |
+  @ref YET_TO_BE_WRITTEN_HYDROELASTIC_GEOMETRY_MODULE for details on the
+ semantics of these properties.
+
+  | Tag                              | Group        | Property                  | Notes                                                                                                                            |
  | :------------------------------: | :----------: | :-----------------------: | :------------------------------------------------------------------------------------------------------------------------------: |
  | drake:mesh_resolution_hint       | hydroelastic | resolution_hint           | Required for shapes that require tessellation to support hydroelastic contact.                                                   |
  | drake:hydroelastic_modulus       | hydroelastic | hydroelastic_modulus      | Finite positive value. Required for compliant hydroelastic representations.                                                           |

--- a/multibody/parsing/detail_urdf_geometry.h
+++ b/multibody/parsing/detail_urdf_geometry.h
@@ -155,8 +155,9 @@ geometry::GeometryInstance ParseVisual(
  property set.
 
  Mapping from URDF tag to geometry property. See
- @ref YET_TO_BE_WRITTEN_HYDROELATIC_GEOMETRY_MODULE for details on the semantics
- of these properties.
+  @ref YET_TO_BE_WRITTEN_HYDROELASTIC_GEOMETRY_MODULE for details on the
+ semantics of these properties.
+
  | Tag                              | Group        | Property                  | Notes                                                                                                                            |
  | :------------------------------: | :----------: | :-----------------------: | :------------------------------------------------------------------------------------------------------------------------------: |
  | drake:mesh_resolution_hint       | hydroelastic | resolution_hint           | Required for shapes that require tessellation to support hydroelastic contact.                                                   |

--- a/multibody/plant/test/contact_results_to_lcm_test.cc
+++ b/multibody/plant/test/contact_results_to_lcm_test.cc
@@ -130,7 +130,7 @@ std::ostream& operator<<(std::ostream& out, const FullBodyName& name) {
 
 namespace {
 
-/* The fixed number of faces in the test mesh for hydroleastic contact. */
+/* The fixed number of faces in the test mesh for hydroelastic contact. */
 constexpr int kNumFaces = 2;
 constexpr int kNumPointPerTri = 3;
 
@@ -598,11 +598,11 @@ TYPED_TEST(ContactResultsToLcmTest, PointPairContactOnly) {
   }
 }
 
-/* Tests the case where ContactResults contains *only* hydroleastic data. This
- test bears primary responsibility to make sure that hydroleastic data is
+/* Tests the case where ContactResults contains *only* hydroelastic data. This
+ test bears primary responsibility to make sure that hydroelastic data is
  serialized correctly.
 
- Translation of hydroleastic contact results to lcm message is straightforward.
+ Translation of hydroelastic contact results to lcm message is straightforward.
  There are *three* things that this system does in the process:
 
    - Extracts double values from T-Valued quantities.


### PR DESCRIPTION
Noticed and fixed one while working on #16238; this patch fixes all the
others I could find that at least spell "hydro" correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16239)
<!-- Reviewable:end -->
