### PR TITLE
SAP: Implements stopping criteria on the cost.

### DIFF
--- a/multibody/contact_solvers/sap_solver.h
+++ b/multibody/contact_solvers/sap_solver.h
@@ -24,7 +24,16 @@ struct SapSolverParameters {
   // momentum equally.
   double abs_tolerance{1.e-14};  // Absolute tolerance εₐ, square root of Joule.
   double rel_tolerance{1.e-6};   // Relative tolerance εᵣ.
-  int max_iterations{100};       // Maximum number of Newton iterations.
+
+  // We monitor the decrease of the cost on each iteration. It is not worth it
+  // to keep iterating if round-off errors do not allow the cost to keep
+  // decreasing. Therefore SAP stops the Newton iteration when the optimality
+  // condition OR the cost condition is satisfied. Given the costs ℓᵐ and ℓᵐ⁺¹
+  // at Newton iterations m and m+1 respectively, the cost condition is:
+  // |ℓᵐ⁺¹−ℓᵐ| < εₐ + εᵣ (ℓᵐ⁺¹+ℓᵐ)/2.
+  double cost_abs_tolerance{1.e-14};  // Absolute tolerance εₐ, in Joules.
+  double cost_rel_tolerance{1.e-12};  // Relative tolerance εᵣ.
+  int max_iterations{100};  // Maximum number of Newton iterations.
 
   // Line-search parameters.
   double ls_alpha_max{1.5};   // Maximum line search parameter allowed.

--- a/multibody/contact_solvers/test/sap_solver_test.cc
+++ b/multibody/contact_solvers/test/sap_solver_test.cc
@@ -607,7 +607,7 @@ GTEST_TEST(PizzaSaver, Stiction) {
   EXPECT_TRUE(
       CompareMatrices(result.v_next.head<3>(), Vector3d::Zero(), 1.0e-9));
   EXPECT_TRUE((result.tau_contact - tau_expected).norm() / tau_expected.norm() <
-              params.rel_tolerance);
+              2.0 * params.rel_tolerance);
   EXPECT_TRUE(CompareMatrices(
       result.fn,
       VectorXd::Constant(problem.kNumContacts, tau_expected(2) / 3.0),
@@ -621,7 +621,7 @@ GTEST_TEST(PizzaSaver, Stiction) {
     const double normal_force = result.fn(i);
     EXPECT_LE(friction_force, mu * normal_force);
     EXPECT_NEAR(friction_force, friction_force_expected,
-                params.rel_tolerance * friction_force_expected);
+                5.0 * params.rel_tolerance * friction_force_expected);
     EXPECT_LE(slip, max_slip_expected);
   }
 }


### PR DESCRIPTION
This resolves the mac continuous failure [here](https://drake-jenkins.csail.mit.edu/view/Production/job/mac-monterey-clang-bazel-continuous-release/81/consoleFull)

## About the failure. 
Sometimes, due to round-off errors, the optimality condition is not satisfied but the search directions is already very small (||dv||≈1e-8 to 1e-7) and dℓ/dα is close to machine epsilon. Under this circumstances, the line search cannot find the minimum and aborts (essentially it thinks the cost is a flat line and reaches the maximum number of iterations without converging). These smalls number do not cause trouble in Linux but apparently mac is more sensitive.

Still, going into the line search when dℓ/dα is close to machine epsilon is a bad idea. This PR avoids this problem by also monitoring the convergence of the cost. If the cost does not change any longer, then there is no point on keep iterating (this actually happens often due to round off errors when the user request a very tight relative tolerance for the optimality, typically < 1e-7). 

## Consequence in accuracy

While before we were strictly enforcing the satisfaction of the optimality condition, this new error metric allows the solver to end earlier, even if the optimality condition is not satisfied to the specified tolerance.
This is ok on practice, given that there is no gain when the cost does not decrease any longer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16240)
<!-- Reviewable:end -->
