### PR TITLE
[multibody] Prohibit SDFormat/URDF tag drake:soft_hydroelastic

### DIFF
--- a/multibody/parsing/detail_scene_graph.cc
+++ b/multibody/parsing/detail_scene_graph.cc
@@ -420,6 +420,17 @@ ProximityProperties MakeProximityPropertiesForCollision(
     const bool is_compliant =
         drake_element->HasElement("drake:compliant_hydroelastic");
 
+    // TODO(16229): Remove this ad-hoc input sanitization when we resolve
+    //  issue 16229 "Diagnostics for unsupported SDFormat and URDF stanzas."
+    const bool is_unsupported_soft =
+        drake_element->HasElement("drake:soft_hydroelastic");
+    if (is_unsupported_soft) {
+      throw std::runtime_error(
+          "A <collision> geometry has defined the unsupported tag "
+          "<drake:soft_hydroelastic>. Please change it to "
+          "<drake:compliant_hydroelastic>.");
+    }
+
     if (is_rigid && is_compliant) {
       throw std::runtime_error(
           "A <collision> geometry has defined mutually-exclusive tags "

--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -550,6 +550,20 @@ geometry::GeometryInstance ParseCollision(
         drake_element->FirstChildElement("drake:rigid_hydroelastic");
     const XMLElement* const compliant_element =
         drake_element->FirstChildElement("drake:compliant_hydroelastic");
+
+    // TODO(16229): Remove this ad-hoc input sanitization when we resolve
+    //  issue 16229 "Diagnostics for unsupported SDFormat and URDF stanzas."
+    const XMLElement* const no_longer_supported =
+        drake_element->FirstChildElement("drake:soft_hydroelastic");
+    if (no_longer_supported) {
+      throw std::runtime_error(fmt::format(
+          "Collision geometry uses the tag <drake:soft_hydroelastic> "
+          "on line {}, "
+          "which is no longer supported. Please change it to "
+          "<drake:compliant_hydroelastic>.",
+          no_longer_supported->GetLineNum()));
+    }
+
     if (rigid_element && compliant_element) {
       throw std::runtime_error(fmt::format(
           "Collision geometry has defined mutually-exclusive tags "

--- a/multibody/parsing/test/detail_scene_graph_test.cc
+++ b/multibody/parsing/test/detail_scene_graph_test.cc
@@ -1126,6 +1126,22 @@ GTEST_TEST(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
               geometry::internal::HydroelasticType::kSoft);
   }
 
+  // TODO(16229): Remove this ad-hoc input sanitization when we resolve
+  //  issue 16229 "Diagnostics for unsupported SDFormat and URDF stanzas."
+  // Case: specifies unsupported drake:soft_hydroelastic -- should be an error.
+  {
+    unique_ptr<sdf::Collision> sdf_collision = make_sdf_collision(R"""(
+  <drake:proximity_properties>
+    <drake:soft_hydroelastic/>
+  </drake:proximity_properties>)""");
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        MakeProximityPropertiesForCollision(*sdf_collision),
+        std::runtime_error,
+        "A <collision> geometry has defined the unsupported tag "
+        "<drake:soft_hydroelastic>. Please change it to "
+        "<drake:compliant_hydroelastic>.");
+  }
+
   // Case: specifies both -- should be an error.
   {
     unique_ptr<sdf::Collision> sdf_collision = make_sdf_collision(R"""(

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -616,6 +616,24 @@ TEST_F(UrdfGeometryTests, CollisionProperties) {
               geometry::internal::HydroelasticType::kSoft);
   }
 
+  // TODO(16229): Remove this ad-hoc input sanitization when we resolve
+  //  issue 16229 "Diagnostics for unsupported SDFormat and URDF stanzas."
+  // Case: specifies unsupported drake:soft_hydroelastic -- should be an error.
+  {
+    unique_ptr<XMLDocument> doc = MakeCollisionDocFromString(R"""(
+  <drake:proximity_properties>
+    <drake:soft_hydroelastic/>
+  </drake:proximity_properties>)""");
+    const XMLElement* collision_node = doc->FirstChildElement("collision");
+    ASSERT_NE(collision_node, nullptr);
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        ParseCollision("link_name", package_map, root_dir, collision_node),
+        std::runtime_error,
+        "Collision geometry uses the tag <drake:soft_hydroelastic> .* "
+        "which is no longer supported. Please change it to "
+        "<drake:compliant_hydroelastic>.");
+  }
+
   // Case: specifies both -- should be an error.
   {
     unique_ptr<XMLDocument> doc = MakeCollisionDocFromString(R"""(


### PR DESCRIPTION
Require drake:compliant_hydroelastic instead of drake:soft_hydroelastic.

Before this PR, any collision geometry with <drake:soft_hydroelastic/> tag in SDF/URDF file will be silently ignored by hydroelastics. We want to give an error and tell users to change it to <drake:compliant_hydroelastic/>. Otherwise, users won't be aware that their geometries participate in point contact instead.

Relevant to #15796

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16249)
<!-- Reviewable:end -->
