### PR TITLE
[geometry] Fix centroid computation for poly meshes

### DIFF
--- a/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
+++ b/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
@@ -24,6 +24,8 @@ DEFINE_double(simulation_time, 2.0,
 // Contact model parameters.
 DEFINE_string(contact_model, "point",
               "Contact model. Options are: 'point', 'hydroelastic', 'hybrid'.");
+DEFINE_string(hydro_rep, "tri",
+              "Surface representation. Options are: 'tri', 'poly'.");
 DEFINE_double(hydroelastic_modulus, 5.0e4,
               "For hydroelastic (and hybrid) contact, "
               "hydroelastic modulus, [Pa].");
@@ -133,6 +135,14 @@ int do_main() {
     illus_prop.AddProperty("phong", "diffuse", Vector4d(0.7, 0.5, 0.4, 0.5));
     plant.RegisterVisualGeometry(plant.world_body(), X_WB, wall, "wall_visual",
                                  std::move(illus_prop));
+  }
+
+  if (FLAGS_hydro_rep == "tri") {
+    plant.set_contact_surface_representation(
+        geometry::HydroelasticContactRepresentation::kTriangle);
+  } else {
+    plant.set_contact_surface_representation(
+        geometry::HydroelasticContactRepresentation::kPolygon);
   }
 
   // Set contact model and parameters.

--- a/geometry/proximity/contact_surface_utility.cc
+++ b/geometry/proximity/contact_surface_utility.cc
@@ -276,6 +276,10 @@ Vector3<T> CalcPolygonCentroid(const std::vector<int>& polygon,
     total_weight += weight;
   }
 
+  // TODO(amcastro-tri): Incorporate definition of the centroid introduced in
+  // #16253 so that this computation is valid for areas close to machine
+  // epsilon. The exact comparison below would only be valid for precisely set
+  // configurations for which areas are exactly zero.
   if (total_weight == 0) {
     // The polygon is degenerate with no area. In that case, we'll simply
     // define the centroid as the average vertex position. (Alternatively we

--- a/geometry/proximity/test/polygon_surface_mesh_test.cc
+++ b/geometry/proximity/test/polygon_surface_mesh_test.cc
@@ -303,8 +303,13 @@ TYPED_TEST(PolygonSurfaceMeshTest, ZeroFaceNormal) {
   /* Make sure the face normals computed are in the frame of the vertices. */
   const PolygonSurfaceMesh<T> mesh = this->MakeMesh({poly});
 
-  ASSERT_TRUE(
+  // For a zero sized polygon we expect the centroid to be the average of the
+  // vertex positions.
+  const Vector3d expected_centroid(1.0, 0.0, 0.0);
+  EXPECT_TRUE(
       CompareMatrices(ExtractDoubleOrThrow(mesh.face_normal(0)), poly.normal));
+  EXPECT_TRUE(CompareMatrices(ExtractDoubleOrThrow(mesh.centroid()),
+                              expected_centroid));
 }
 
 /* In the case where a face has collinear vertices, we want to confirm that we
@@ -343,7 +348,7 @@ TYPED_TEST(PolygonSurfaceMeshTest, DegenerateFaceNormal) {
     ASSERT_TRUE(CompareMatrices(ExtractDoubleOrThrow(mesh.face_normal(0)),
                                 poly.normal));
     ASSERT_TRUE(CompareMatrices(ExtractDoubleOrThrow(mesh.element_centroid(0)),
-                                poly.centroid));
+                                poly.centroid, 2.0e-15));
     ASSERT_EQ(mesh.total_area(), poly.area);
   }
 }

--- a/geometry/proximity/triangle_surface_mesh.h
+++ b/geometry/proximity/triangle_surface_mesh.h
@@ -493,6 +493,10 @@ void TriangleSurfaceMesh<T>::CalcAreasNormalsAndCentroid() {
   }
 
   // Finalize centroid.
+  // TODO(amcastro-tri): Incorporate definition of the centroid introduced in
+  // #16253 so that this computation is valid for areas close to machine
+  // epsilon. The exact comparison below would only be valid for precisely set
+  // configurations for which areas are exactly zero.
   if (total_area_ != T(0.))
     p_MSc_ /= (3. * total_area_);
 }


### PR DESCRIPTION
The computation of the centroid (both for individual polygons and for the entire mesh) is not valid for zero sized areas. Specifically, it returns NAN.

This PR introduces a smooth computation of the centroid that is valid at zero sized area and it is differentiable.

As a side effect this resolves #16244. I added option to run that example with polygonal meshes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16253)
<!-- Reviewable:end -->
