### PR TITLE
[geometry] Avoid NANs in the computation of centroids for zero area meshes

### DIFF
--- a/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
+++ b/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
@@ -24,6 +24,8 @@ DEFINE_double(simulation_time, 2.0,
 // Contact model parameters.
 DEFINE_string(contact_model, "point",
               "Contact model. Options are: 'point', 'hydroelastic', 'hybrid'.");
+DEFINE_string(hydro_rep, "tri",
+              "Surface representation. Options are: 'tri', 'poly'.");
 DEFINE_double(hydroelastic_modulus, 5.0e4,
               "For hydroelastic (and hybrid) contact, "
               "hydroelastic modulus, [Pa].");
@@ -133,6 +135,14 @@ int do_main() {
     illus_prop.AddProperty("phong", "diffuse", Vector4d(0.7, 0.5, 0.4, 0.5));
     plant.RegisterVisualGeometry(plant.world_body(), X_WB, wall, "wall_visual",
                                  std::move(illus_prop));
+  }
+
+  if (FLAGS_hydro_rep == "tri") {
+    plant.set_contact_surface_representation(
+        geometry::HydroelasticContactRepresentation::kTriangle);
+  } else {
+    plant.set_contact_surface_representation(
+        geometry::HydroelasticContactRepresentation::kPolygon);
   }
 
   // Set contact model and parameters.

--- a/geometry/proximity/polygon_surface_mesh.cc
+++ b/geometry/proximity/polygon_surface_mesh.cc
@@ -25,9 +25,24 @@ PolygonSurfaceMesh<T>::PolygonSurfaceMesh(vector<int> face_data,
   int i = 0;
   while (i < static_cast<int>(face_data_.size())) {
     poly_indices_.push_back(i);
-    CalcAreaNormalAndCentroid(++poly_count);
-    i += face_data_[i] + 1;  /* Jump to the next polygon. */
+    // Accumulate contribution to the centroid and total area of the mesh.
+    const auto [p_MPi_area_scaled, Ai] =
+        CalcAreaNormalAndCentroid(++poly_count);
+    p_MSc_ += p_MPi_area_scaled;
+    total_area_ += Ai;
+    i += face_data_[i] + 1; /* Jump to the next polygon. */
   }
+
+  if (total_area_ != 0) {
+    // The centroid is well defined only if the total area is non-zero.
+    p_MSc_ /= total_area_;
+  } else {
+    // If the total area is zero, we return the mean vertex position.
+    p_MSc_.setZero();
+    for (const Vector3<T>& p_MV : vertices_M_) p_MSc_ += p_MV;
+    p_MSc_ /= num_vertices();
+  }
+
   DRAKE_DEMAND(poly_indices_.size() == areas_.size());
   DRAKE_DEMAND(poly_indices_.size() == face_normals_.size());
 }
@@ -76,7 +91,8 @@ bool PolygonSurfaceMesh<T>::Equal(const PolygonSurfaceMesh<T>& mesh) const {
 }
 
 template <class T>
-void PolygonSurfaceMesh<T>::CalcAreaNormalAndCentroid(int poly_index) {
+std::pair<Vector3<T>, T> PolygonSurfaceMesh<T>::CalcAreaNormalAndCentroid(
+    int poly_index) {
   int data_index = poly_indices_[poly_index];
   const int v_count = face_data_[data_index];
   int v_index_offset = data_index + 1;
@@ -159,10 +175,20 @@ void PolygonSurfaceMesh<T>::CalcAreaNormalAndCentroid(int poly_index) {
    polygon's contribution proportionately (although, we want to add in Aₚ⋅p_MFc,
    but what we computed is 6⋅Aₚ⋅p_MFc. */
   const Vector3<T> p_MTc_area_scaled = p_MTc_scaled / 6;
-  element_centroid_M_.emplace_back(p_MTc_area_scaled / poly_area);
-  const T old_area = total_area_;
-  total_area_ += poly_area;
-  p_MSc_ = (p_MSc_ * old_area + p_MTc_area_scaled) / total_area_;
+  if (poly_area != 0) {
+    element_centroid_M_.emplace_back(p_MTc_area_scaled / poly_area);
+  } else {
+    // Compute mean vertex position. In the limit to a zero size polygon, mean
+    // vertex position and centroid are the same.
+    Vector3<T> p_MVmean(0, 0, 0);
+    for (int v = 0; v < v_count; ++v) {
+      const Vector3<T>& p_MV = vertices_M_[face_data_[v_index_offset + v]];
+      p_MVmean += p_MV;
+    }
+    p_MVmean /= v_count;
+    element_centroid_M_.emplace_back(p_MVmean);
+  }
+  return std::make_pair(p_MTc_area_scaled, poly_area);
 }
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(

--- a/geometry/proximity/polygon_surface_mesh.h
+++ b/geometry/proximity/polygon_surface_mesh.h
@@ -296,11 +296,14 @@ class PolygonSurfaceMesh {
 
  private:
   /* Calculates the area and face normal of a polygon. Further computes its
-   contribution to the surface centroid.
+   contribution to the surface centroid and returns it.
 
    @param poly_index The index of the polygon to compute the derived quantities.
-                     Must be in the range [0, poly_indices_.size()). */
-  void CalcAreaNormalAndCentroid(int poly_index);
+                     Must be in the range [0, poly_indices_.size()).
+   @returns The pair {p_MPi_area_scaled, Ai} where Ai is the area of the
+   polygon indicated by `poly_index` and p_MPi_area_scaled = Ai * p_MPi, with
+   p_MPi the centroid of the polygon. */
+  std::pair<Vector3<T>, T> CalcAreaNormalAndCentroid(int poly_index);
 
   /* The encoding of the mesh's polygons. See the advanced constructor for
    details. */

--- a/geometry/proximity/test/polygon_surface_mesh_test.cc
+++ b/geometry/proximity/test/polygon_surface_mesh_test.cc
@@ -303,8 +303,13 @@ TYPED_TEST(PolygonSurfaceMeshTest, ZeroFaceNormal) {
   /* Make sure the face normals computed are in the frame of the vertices. */
   const PolygonSurfaceMesh<T> mesh = this->MakeMesh({poly});
 
-  ASSERT_TRUE(
+  // For a zero sized polygon we expect the centroid to be the average of the
+  // vertex positions.
+  const Vector3d expected_centroid(1.0, 0.0, 0.0);
+  EXPECT_TRUE(
       CompareMatrices(ExtractDoubleOrThrow(mesh.face_normal(0)), poly.normal));
+  EXPECT_TRUE(CompareMatrices(ExtractDoubleOrThrow(mesh.centroid()),
+                              expected_centroid));
 }
 
 /* In the case where a face has collinear vertices, we want to confirm that we


### PR DESCRIPTION
The computation of the centroid (both for individual polygons and for the entire mesh) is not valid for zero sized areas. Specifically, it returns NAN.

As a side effect this resolves #16244. I added option to run that example with polygonal meshes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16255)
<!-- Reviewable:end -->
