### PR TITLE
[examples/multibody] Hydroelastic-representation option for rolling sphere

### DIFF
--- a/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
+++ b/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
@@ -24,6 +24,10 @@ DEFINE_double(simulation_time, 2.0,
 // Contact model parameters.
 DEFINE_string(contact_model, "point",
               "Contact model. Options are: 'point', 'hydroelastic', 'hybrid'.");
+DEFINE_string(hydro_rep, "tri",
+              "Contact-surface representation for hydroelastics. "
+              "Options are: 'tri' for triangles, 'poly' for polygons. "
+              "Default is 'tri'. It has no effect on point contact.");
 DEFINE_double(hydroelastic_modulus, 5.0e4,
               "For hydroelastic (and hybrid) contact, "
               "hydroelastic modulus, [Pa].");
@@ -133,6 +137,17 @@ int do_main() {
     illus_prop.AddProperty("phong", "diffuse", Vector4d(0.7, 0.5, 0.4, 0.5));
     plant.RegisterVisualGeometry(plant.world_body(), X_WB, wall, "wall_visual",
                                  std::move(illus_prop));
+  }
+
+  if (FLAGS_hydro_rep == "tri") {
+    plant.set_contact_surface_representation(
+        geometry::HydroelasticContactRepresentation::kTriangle);
+  } else if (FLAGS_hydro_rep == "poly") {
+    plant.set_contact_surface_representation(
+        geometry::HydroelasticContactRepresentation::kPolygon);
+  } else {
+    throw std::runtime_error("Invalid choice of contact-surface representation "
+                             "for hydroelastics '" + FLAGS_hydro_rep + "'.");
   }
 
   // Set contact model and parameters.


### PR DESCRIPTION
- Add option `hydro_rep` for contact-surface representation in hydroelastics.

Relevant to #16244.

To illustrate or verify the solution to the problem of the crash in continuous hydroleastics with polygonal contact surfaces, this PR let users try:

```
bazel run //examples/multibody/rolling_sphere:rolling_sphere_run_dynamics -- --mbp_dt=0.0 --contact_model=hydroelastic --hydro_rep=poly
```

As of December 19, 2021, using the above command in this PR will crash with this error message:
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  Encountered singular articulated body hinge inertia for body node index 1. Please ensure that this body has non-zero inertia along all axes of motion.
```

Once we fix Issue #16244 (and rebase on the new master), the above command should run fine. Perhaps PR #16257 will fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16258)
<!-- Reviewable:end -->
