### PR TITLE
[tools] Set Python version to 3 explicitly

### DIFF
--- a/tools/skylark/drake_py.bzl
+++ b/tools/skylark/drake_py.bzl
@@ -13,6 +13,7 @@ def drake_py_library(
     py_library(
         name = name,
         deps = deps,
+        srcs_version = "PY3",
         **kwargs
     )
 
@@ -140,6 +141,8 @@ def drake_py_binary(
         data = data,
         deps = deps,
         tags = tags,
+        python_version = "PY3",
+        srcs_version = "PY3",
         **kwargs
     )
     if add_test_rule:
@@ -236,6 +239,8 @@ def drake_py_test(
         srcs = srcs,
         deps = deps,
         tags = tags,
+        python_version = "PY3",
+        srcs_version = "PY3",
         **kwargs
     )
 


### PR DESCRIPTION
This removes spurious warnings from Bazel when other things go wrong.

Closes #14745.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16259)
<!-- Reviewable:end -->
