### PR TITLE
[fem] Calculate FEM tangent matrix in PETSc format

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -355,6 +355,7 @@ drake_cc_library(
     deps = [
         ":dirichlet_boundary_condition",
         ":fem_state_base",
+        ":petsc_symmetric_block_sparse_matrix",
         ":state_updater",
         "//common:default_scalars",
         "//common:essential",

--- a/multibody/fixed_fem/dev/dynamic_elasticity_model.h
+++ b/multibody/fixed_fem/dev/dynamic_elasticity_model.h
@@ -26,6 +26,7 @@ class DynamicElasticityModel : public ElasticityModel<Element> {
 
   using T = typename Element::Traits::T;
   using ConstitutiveModel = typename Element::Traits::ConstitutiveModel;
+  using State = FemState<Element>;
 
   // TODO(xuchenhan-tri): Currently the time stepping scheme is hard coded to
   //  gamma = 1.0 and beta = 0.5. Consider letting the user configure the time

--- a/multibody/fixed_fem/dev/fem_model_base.cc
+++ b/multibody/fixed_fem/dev/fem_model_base.cc
@@ -34,10 +34,28 @@ void FemModelBase<T>::CalcTangentMatrix(
 }
 
 template <typename T>
+void FemModelBase<T>::CalcTangentMatrix(
+    const FemStateBase<T>& state,
+    internal::PetscSymmetricBlockSparseMatrix* tangent_matrix) const {
+  DRAKE_DEMAND(tangent_matrix != nullptr);
+  DRAKE_DEMAND(tangent_matrix->rows() == num_dofs());
+  DRAKE_DEMAND(tangent_matrix->cols() == num_dofs());
+  ThrowIfModelStateIncompatible(__func__, state);
+  DoCalcTangentMatrix(state, tangent_matrix);
+  // TODO(xuchenhan-tri): Apply boundary condition to the tangent matrix.
+}
+
+template <typename T>
 void FemModelBase<T>::SetTangentMatrixSparsityPattern(
     Eigen::SparseMatrix<T>* tangent_matrix) const {
   DRAKE_DEMAND(tangent_matrix != nullptr);
   DoSetTangentMatrixSparsityPattern(tangent_matrix);
+}
+
+template <typename T>
+std::unique_ptr<internal::PetscSymmetricBlockSparseMatrix>
+FemModelBase<T>::MakePetscSymmetricBlockSparseTangentMatrix() const {
+  return DoMakePetscSymmetricBlockSparseTangentMatrix();
 }
 
 template <typename T>

--- a/multibody/fixed_fem/dev/static_elasticity_model.h
+++ b/multibody/fixed_fem/dev/static_elasticity_model.h
@@ -24,6 +24,7 @@ class StaticElasticityModel : public ElasticityModel<Element> {
 
   using T = typename Element::Traits::T;
   using ConstitutiveModel = typename Element::Traits::ConstitutiveModel;
+  using State = FemState<Element>;
 
   StaticElasticityModel()
       : ElasticityModel<Element>(

--- a/multibody/fixed_fem/dev/test/static_elasticity_model_test.cc
+++ b/multibody/fixed_fem/dev/test/static_elasticity_model_test.cc
@@ -15,21 +15,39 @@ namespace drake {
 namespace multibody {
 namespace fem {
 namespace {
+
+using Eigen::MatrixXd;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+
 constexpr int kNaturalDimension = 3;
 constexpr int kSpatialDimension = 3;
 constexpr int kSolutionDimension = 3;
 constexpr int kQuadratureOrder = 1;
-using T = AutoDiffXd;
+
 using QuadratureType =
     internal::SimplexGaussianQuadrature<kNaturalDimension, kQuadratureOrder>;
 constexpr int kNumQuads = QuadratureType::num_quadrature_points;
-using IsoparametricElementType =
-    internal::LinearSimplexElement<T, kNaturalDimension, kSpatialDimension,
+
+using AutoDiffIsoparametricElement =
+    internal::LinearSimplexElement<AutoDiffXd, kNaturalDimension,
+                                   kSpatialDimension, kNumQuads>;
+using DoubleIsoparametricElement =
+    internal::LinearSimplexElement<double, kNaturalDimension, kSpatialDimension,
                                    kNumQuads>;
-using ConstitutiveModelType = internal::LinearConstitutiveModel<T, kNumQuads>;
-using ElementType =
-    StaticElasticityElement<IsoparametricElementType, QuadratureType,
-                            ConstitutiveModelType>;
+
+using AutoDiffConstitutiveModel =
+    internal::LinearConstitutiveModel<AutoDiffXd, kNumQuads>;
+using DoubleConstitutiveModel =
+    internal::LinearConstitutiveModel<double, kNumQuads>;
+
+using AutoDiffElement =
+    StaticElasticityElement<AutoDiffIsoparametricElement, QuadratureType,
+                            AutoDiffConstitutiveModel>;
+using DoubleElement =
+    StaticElasticityElement<DoubleIsoparametricElement, QuadratureType,
+                            DoubleConstitutiveModel>;
+
 const double kYoungsModulus = 1.23;
 const double kPoissonRatio = 0.456;
 /* The geometry of the model under test is a cube and it has 8 vertices and 6
@@ -37,12 +55,13 @@ const double kPoissonRatio = 0.456;
 constexpr int kNumCubeVertices = 8;
 constexpr int kNumDofs = kNumCubeVertices * kSolutionDimension;
 constexpr int kNumElements = 6;
-const T kDensity{0.123};
+const double kDensity{0.123};
 
 class StaticElasticityModelTest : public ::testing::Test {
  protected:
   /* Make a box and subdivide it into 6 tetrahedra. */
-  static geometry::VolumeMesh<T> MakeBoxTetMesh() {
+  template <typename T>
+  geometry::VolumeMesh<T> MakeBoxTetMesh() {
     const double length = 0.1;
     geometry::Box box(length, length, length);
     geometry::VolumeMesh<T> mesh =
@@ -50,11 +69,16 @@ class StaticElasticityModelTest : public ::testing::Test {
     return mesh;
   }
 
-  void SetUp() override {
-    geometry::VolumeMesh<T> mesh = MakeBoxTetMesh();
-    ConstitutiveModelType constitutive_model(kYoungsModulus, kPoissonRatio);
-    model_.AddStaticElasticityElementsFromTetMesh(mesh, constitutive_model,
-                                                  kDensity);
+  void SetUp() override { AddBoxToModel(&model_); }
+
+  template <typename FemModel>
+  void AddBoxToModel(FemModel* fem_model) {
+    using T = typename FemModel::T;
+    geometry::VolumeMesh<T> mesh = MakeBoxTetMesh<T>();
+    const typename FemModel::ConstitutiveModel constitutive_model(
+        kYoungsModulus, kPoissonRatio);
+    fem_model->AddStaticElasticityElementsFromTetMesh(mesh, constitutive_model,
+                                                      kDensity);
   }
 
   /* Returns an arbitrary perturbation to the reference configuration of the
@@ -67,20 +91,30 @@ class StaticElasticityModelTest : public ::testing::Test {
     return dx;
   }
 
-  /* Returns a perturbed FemState whose generalized positions are different from
-   reference positions. */
-  FemState<ElementType> MakeDeformedState() const {
-    FemState<ElementType> state = model_.MakeFemState();
-    const Vector<double, kNumDofs> perturbed_q =
-        math::ExtractValue(state.q()) + perturbation();
-    Vector<T, kNumDofs> perturbed_q_autodiff;
-    math::InitializeAutoDiff(perturbed_q, &perturbed_q_autodiff);
-    state.SetQ(perturbed_q_autodiff);
+  /* Returns a perturbed FemState whose generalized positions are different
+   from reference positions. */
+  template <typename FemModelType>
+  typename FemModelType::State MakeDeformedState(
+      const FemModelType& fem_model) const {
+    using State = typename FemModelType::State;
+    using T = typename FemModelType::T;
+
+    State state = fem_model.MakeFemState();
+    if constexpr (std::is_same_v<T, AutoDiffXd>) {
+      const Vector<double, kNumDofs> perturbed_q =
+          math::ExtractValue(state.q()) + perturbation();
+      Vector<AutoDiffXd, kNumDofs> perturbed_q_autodiff;
+      math::InitializeAutoDiff(perturbed_q, &perturbed_q_autodiff);
+      state.SetQ(perturbed_q_autodiff);
+    } else {
+      const Vector<double, kNumDofs> perturbed_q = state.q() + perturbation();
+      state.SetQ(perturbed_q);
+    }
     return state;
   }
 
   /* The model under test. */
-  StaticElasticityModel<ElementType> model_;
+  StaticElasticityModel<AutoDiffElement> model_;
 };
 
 /* Tests the mesh has been successfully converted to elements. */
@@ -89,11 +123,12 @@ TEST_F(StaticElasticityModelTest, Geometry) {
   EXPECT_EQ(model_.num_elements(), kNumElements);
 }
 
-/* Tests that the residual of the model is the derivative of the elastic energy
- with respect to the generalized positions plus external force. */
+/* Tests that the residual of the model is the derivative of the elastic
+ energy with respect to the generalized positions plus external force. */
 TEST_F(StaticElasticityModelTest,
        ResidualIsEnergyDerivativeMinusExternalForce) {
-  FemState<ElementType> state = MakeDeformedState();
+  using T = AutoDiffXd;
+  FemState<AutoDiffElement> state = MakeDeformedState(model_);
   T energy = model_.CalcElasticEnergy(state);
   VectorX<T> residual(state.num_generalized_positions());
   model_.CalcResidual(state, &residual);
@@ -103,10 +138,11 @@ TEST_F(StaticElasticityModelTest,
                               std::numeric_limits<double>::epsilon()));
 }
 
-/* Tests that the tangent matrix of the model is the derivative of the residual
- with respect to generalized positions. */
+/* Tests that the tangent matrix of the model is the derivative of the
+ residual with respect to generalized positions. */
 TEST_F(StaticElasticityModelTest, TangentMatrixIsResidualDerivative) {
-  FemState<ElementType> state = MakeDeformedState();
+  using T = AutoDiffXd;
+  FemState<AutoDiffElement> state = MakeDeformedState(model_);
 
   VectorX<T> residual(state.num_generalized_positions());
   model_.CalcResidual(state, &residual);
@@ -115,9 +151,10 @@ TEST_F(StaticElasticityModelTest, TangentMatrixIsResidualDerivative) {
   model_.SetTangentMatrixSparsityPattern(&tangent_matrix);
   model_.CalcTangentMatrix(state, &tangent_matrix);
 
-  /* In the discretization of the unit cube by 6 tetrahedra, there are 19 edges,
-   and 8 nodes, creating 19*2 + 8 blocks of 3-by-3 nonzero entries. Hence the
-   number of nonzero entries of the tangent matrix should be (19*2+8)*9. */
+  /* In the discretization of the unit cube by 6 tetrahedra, there are 19
+   edges, and 8 nodes, creating 19*2 + 8 blocks of 3-by-3 nonzero entries.
+   Hence the number of nonzero entries of the tangent matrix should be
+   (19*2+8)*9. */
   const int nnz = (19 * 2 + 8) * 9;
   EXPECT_EQ(tangent_matrix.nonZeros(), nnz);
 
@@ -129,31 +166,36 @@ TEST_F(StaticElasticityModelTest, TangentMatrixIsResidualDerivative) {
   }
 }
 
-/* Adds two copies of the same set of elements and tests that the residual for
- the two copies are identical. */
-TEST_F(StaticElasticityModelTest, MultipleMesh) {
-  geometry::VolumeMesh<T> mesh = MakeBoxTetMesh();
-  ConstitutiveModelType constitutive_model(kYoungsModulus, kPoissonRatio);
-  model_.AddStaticElasticityElementsFromTetMesh(mesh, constitutive_model,
-                                                kDensity);
+/* Verifies that the tangent matrix calculated as PETSc matrix is the same as
+ that calculated as Eigen::SparseMatrix. */
+TEST_F(StaticElasticityModelTest, TangentMatrixParity) {
+  FemState<AutoDiffElement> autodiff_state = MakeDeformedState(model_);
+  Eigen::SparseMatrix<AutoDiffXd> eigen_tangent_matrix;
+  model_.SetTangentMatrixSparsityPattern(&eigen_tangent_matrix);
+  model_.CalcTangentMatrix(autodiff_state, &eigen_tangent_matrix);
+  const MatrixX<AutoDiffXd> eigen_dense_autodiff_matrix = eigen_tangent_matrix;
+  const MatrixXd eigen_dense_matrix =
+      math::ExtractValue(eigen_dense_autodiff_matrix);
 
-  EXPECT_EQ(model_.num_nodes(), 2 * kNumCubeVertices);
-  /* Each cube is split into 6 tetrahedra. */
-  EXPECT_EQ(model_.num_elements(), 2 * kNumElements);
+  StaticElasticityModel<DoubleElement> double_model;
+  AddBoxToModel(&double_model);
+  FemState<DoubleElement> double_state = MakeDeformedState(double_model);
+  std::unique_ptr<internal::PetscSymmetricBlockSparseMatrix>
+      petsc_tangent_matrix =
+          double_model.MakePetscSymmetricBlockSparseTangentMatrix();
+  double_model.CalcTangentMatrix(double_state, petsc_tangent_matrix.get());
+  petsc_tangent_matrix->AssembleIfNecessary();
+  const MatrixXd petsc_dense_matrix = petsc_tangent_matrix->MakeDenseMatrix();
 
-  FemState<ElementType> state = model_.MakeFemState();
-  EXPECT_EQ(state.num_generalized_positions(), 2 * kNumDofs);
-
-  VectorX<T> residual(state.num_generalized_positions());
-  model_.CalcResidual(state, &residual);
-  EXPECT_TRUE(
-      CompareMatrices(residual.head(kNumDofs), residual.tail(kNumDofs), 0));
+  EXPECT_TRUE(CompareMatrices(eigen_dense_matrix, petsc_dense_matrix,
+                              std::numeric_limits<double>::epsilon()));
 }
 
 /* Tests that the total external force exerted on a model matches the expected
  value. */
 TEST_F(StaticElasticityModelTest, ExternalForce) {
-  FemState<ElementType> state = MakeDeformedState();
+  using T = AutoDiffXd;
+  FemState<AutoDiffElement> state = MakeDeformedState(model_);
   const Vector3<T> gravity{1, 0, 0};
   model_.SetGravity(gravity);
   VectorX<T> external_force(state.num_generalized_positions());
@@ -162,13 +204,14 @@ TEST_F(StaticElasticityModelTest, ExternalForce) {
   for (int i = 0; i < model_.num_nodes(); ++i) {
     total_external_force += external_force.template segment<3>(i * 3);
   }
-  T volume = MakeBoxTetMesh().CalcVolume();
+  T volume = MakeBoxTetMesh<T>().CalcVolume();
   // TODO(xuchenhan-tri) We are assuming that the only external force is gravity
   //  now. This might change in the future. Change this test accordingly.
   Vector3<T> expected_external_force = gravity * kDensity * volume;
   EXPECT_TRUE(CompareMatrices(total_external_force, expected_external_force,
                               std::numeric_limits<double>::epsilon()));
 }
+
 }  // namespace
 }  // namespace fem
 }  // namespace multibody


### PR DESCRIPTION
Add `FemModelBase::CalcTangentMatrix()` that populates a PETSc matrix. 
Add `FemModelBase::MakePetscSymmetricBlockSparseTangentMatrix()` that initializes the tangent matrix in PETSc format with the sparsity pattern of the problem.
The added unit tests verify that the tangent matrix calculated in PETSc form and the one calculated in Eigen::SparseMatrix form are the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16267)
<!-- Reviewable:end -->
