### PR TITLE
[system framework] Add port string name deprecation

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -41,6 +41,7 @@ drake_cc_package_library(
         ":is_approx_equal_abstol",
         ":is_cloneable",
         ":is_less_than_comparable",
+        ":name_deprecator",
         ":name_value",
         ":nice_type_name",
         ":pointer_cast",
@@ -405,6 +406,15 @@ drake_cc_library(
 drake_cc_library(
     name = "is_approx_equal_abstol",
     hdrs = ["is_approx_equal_abstol.h"],
+    deps = [
+        ":essential",
+    ],
+)
+
+drake_cc_library(
+    name = "name_deprecator",
+    srcs = ["name_deprecator.cc"],
+    hdrs = ["name_deprecator.h"],
     deps = [
         ":essential",
     ],
@@ -960,6 +970,13 @@ drake_cc_googletest(
     deps = [
         ":essential",
         ":is_approx_equal_abstol",
+    ],
+)
+
+drake_cc_googletest(
+    name = "name_deprecator_test",
+    deps = [
+        ":name_deprecator",
     ],
 )
 

--- a/common/name_deprecator.cc
+++ b/common/name_deprecator.cc
@@ -1,0 +1,83 @@
+#include "drake/common/name_deprecator.h"
+
+#include <regex>
+#include <set>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/never_destroyed.h"
+#include "drake/common/text_logging.h"
+
+namespace drake {
+namespace internal {
+
+namespace {
+// Keep a process-wide collection of offered messages; return true if the
+// message has been seen before.
+bool TrackIssuedWarnings(const std::string& message) {
+  static drake::never_destroyed<std::mutex> mutex;
+  static drake::never_destroyed<std::set<std::string>> issued_messages;
+  std::lock_guard<std::mutex> lock(mutex.access());
+
+  const auto result = issued_messages.access().insert(message);
+  const bool inserted = result.second;
+  return !inserted;
+}
+}  // namespace
+
+NameDeprecator::NameDeprecator() {}
+
+bool NameDeprecator::HasScope() const {
+  return !scope_name_.empty();
+}
+
+void NameDeprecator::DeclareScope(
+    const std::string& name,
+    std::function<bool(const std::string&)> predicate) {
+  DRAKE_DEMAND(!HasScope());
+  scope_name_ = name;
+  scope_predicate_ = predicate;
+}
+
+void NameDeprecator::DeclareDeprecatedName(
+    const std::string& removal_date,
+    const std::string& deprecated_name,
+    const std::string& correct_name) {
+  // Do lots of error checking here so deprecations don't get casually
+  // mis-typed, and so the translation/warn step can be simple and relatively
+  // fast.
+  DRAKE_DEMAND(HasScope());
+  DRAKE_DEMAND(std::regex_match(removal_date,
+                                std::regex(R"""(\d{4}-\d{2}-\d{2})""")));
+  DRAKE_DEMAND(deprecations_.count(deprecated_name) == 0);
+  // N.B. We scope-exclude the deprecated name *before* activating it, since
+  // the client may well be using a predicate that also searches deprecated
+  // names.
+  DRAKE_DEMAND(!scope_predicate_(deprecated_name));
+  DRAKE_DEMAND(scope_predicate_(correct_name));
+
+  NameRecord record{removal_date, correct_name};
+  deprecations_[deprecated_name] = record;
+}
+
+const std::string& NameDeprecator::MaybeTranslate(
+    const std::string& name) const {
+  const auto it = deprecations_.find(name);
+  if (it == deprecations_.end()) {
+    return name;
+  }
+  auto& record = it->second;
+  if (!record.is_warning_issued) {
+    const auto message = fmt::format(
+        "Name '{}' is deprecated within scope '{}'"
+        " and will be removed after {}. Use '{}' instead.",
+        name, scope_name_, record.removal_date, record.correct_name);
+    record.is_warning_issued = TrackIssuedWarnings(message);
+    if (!record.is_warning_issued) {
+      log()->warn(message);
+    }
+  }
+  return record.correct_name;
+}
+
+}  // namespace internal
+}  // namespace drake

--- a/common/name_deprecator.h
+++ b/common/name_deprecator.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <functional>
+#include <string>
+#include <unordered_map>
+
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace internal {
+
+// NameDeprecator supports deprecated alias names within some limited
+// scope. If the deprecated name is given to MaybeTranslate(), emit text log
+// warning once per process. The warning message will include the scope,
+// deprecated name, correct name, and removal date.
+//
+// Clients should consider wrapping this API for convenience. For example:
+//
+// @code
+// void Something::DeclareDeprecatedWidget(
+//     const std::string& removal_date,
+//     const std::string& deprecated_name,
+//     const std::string& correct_name) {
+//   if (!widget_deprecator_.HasScope()) {
+//     widget_deprecator_.DeclareScope(
+//         "something widgets",
+//         [this](const std::string& x){ return IsWidget(x); });
+//   }
+//   widget_deprecator_.DeclareDeprecatedName(
+//       removal_date, deprecated_name, correct_name);
+// }
+// @endcode
+class NameDeprecator {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(NameDeprecator)
+
+  NameDeprecator();
+
+  // @returns true if scope has been declared.
+  bool HasScope() const;
+
+  // Declare the scope in which names are relevant, once per instance.
+  // @param name       the name of the overall scope
+  // @param predicate  returns true if a name is a "correct name" in scope
+  // @pre HasScope() is false.
+  //
+  // It is permissible for the predicate to be aware of declared deprecated
+  // names; predicates are checked and acted on for a potential declaration
+  // before the declaration is made active.
+  void DeclareScope(const std::string& name,
+                    std::function<bool(const std::string&)> predicate);
+
+  // Declare a deprecated name, the correct name it aliases, and the date when
+  // the deprecated alias will be removed.
+  // @pre HasScope() is true, `removal_date` roughly matches Y-m-d format,
+  //      `deprecated_name` fails the scope predicate, `correct_name` satisfies
+  //      the scope predicate, and `deprecated_name` has not already been
+  //      declared.
+  void DeclareDeprecatedName(
+      const std::string& removal_date,
+      const std::string& deprecated_name,
+      const std::string& correct_name);
+
+  // If the provided name is a deprecated name, return the correct
+  // name. Otherwise return the passed-in reference. Note that the return
+  // value lifetime will be the minimum of the lifetime of this deprecator,
+  // and the lifetime of the passed name.
+  const std::string& MaybeTranslate(const std::string& name) const;
+
+ private:
+  std::string scope_name_;
+  std::function<bool(const std::string&)> scope_predicate_;
+
+  struct NameRecord {
+    std::string removal_date;
+    std::string correct_name;
+    mutable bool is_warning_issued{false};
+  };
+  std::unordered_map<std::string, NameRecord> deprecations_;
+};
+
+}  // namespace internal
+}  // namespace drake

--- a/common/test/name_deprecator_test.cc
+++ b/common/test/name_deprecator_test.cc
@@ -1,0 +1,79 @@
+#include "drake/common/name_deprecator.h"
+
+#include <thread>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace internal {
+namespace {
+
+GTEST_TEST(NameDeprecatorTest, SmokeTest) {
+  NameDeprecator dut;
+  std::set<std::string> correct_names({"ca", "cb"});
+  EXPECT_FALSE(dut.HasScope());
+  dut.DeclareScope(
+      "test",
+      [&correct_names](const std::string& x) {
+        return correct_names.count(x);
+      });
+  EXPECT_TRUE(dut.HasScope());
+  dut.DeclareDeprecatedName("2453-11-11", "da", "ca");
+  // Multiple aliases to one target is ok.
+  dut.DeclareDeprecatedName("2453-11-11", "dda", "ca");
+  dut.DeclareDeprecatedName("2453-11-11", "db", "cb");
+
+  // First requests for deprecated names warn.
+  EXPECT_EQ(dut.MaybeTranslate("da"), "ca");
+  EXPECT_EQ(dut.MaybeTranslate("dda"), "ca");
+  EXPECT_EQ(dut.MaybeTranslate("db"), "cb");
+
+  // Subsequent requests for deprecated names are silent; check the console
+  // output for this test to see.
+  EXPECT_EQ(dut.MaybeTranslate("da"), "ca");
+  EXPECT_EQ(dut.MaybeTranslate("dda"), "ca");
+  EXPECT_EQ(dut.MaybeTranslate("db"), "cb");
+
+  // Correct names pass through.
+  EXPECT_EQ(dut.MaybeTranslate("cb"), "cb");
+
+  // Random strings pass through.
+  EXPECT_EQ(dut.MaybeTranslate("xq"), "xq");
+}
+
+GTEST_TEST(NameDeprecatorTest, OncePerProcessTest) {
+  // Give multiple threads identical deprecators and see if they emit more than
+  // one message. Thread sanitizer builds will be able to detect races; manual
+  // inspection of test output can be used to detect leaked duplicates.
+
+  static constexpr int kThreads = 2;
+  std::vector<std::thread> threads;
+  for (int k = 0; k < kThreads; k++) {
+    threads.push_back(
+        std::thread([]() {
+            std::set<std::string> correct_names({"ca", "cb"});
+            NameDeprecator dut;
+            dut.DeclareScope(
+                "thread_test",
+                [&correct_names](const std::string& x) {
+                  return correct_names.count(x);
+                });
+            dut.DeclareDeprecatedName("5432-11-11", "da", "ca");
+
+            static constexpr int kTranslateAttempts = 100;
+            for (int n = 0; n < kTranslateAttempts; n++) {
+              // Sleep to allow thread actions to interleave.
+              std::this_thread::sleep_for(std::chrono::milliseconds(10));
+              dut.MaybeTranslate("da");
+            }
+          }));
+  }
+    for (auto& thread : threads) {
+      thread.join();
+    }
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace drake
+

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -339,6 +339,7 @@ drake_cc_library(
         ":input_port_base",
         ":output_port_base",
         ":value_producer",
+        "//common:name_deprecator",
     ],
 )
 

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -659,10 +659,8 @@ const InputPort<T>* System<T>::get_input_port_selection(
 template <typename T>
 const InputPort<T>& System<T>::GetInputPort(
     const std::string& port_name) const {
-  for (InputPortIndex i{0}; i < num_input_ports(); i++) {
-    if (port_name == get_input_port_base(i).get_name()) {
-      return get_input_port(i);
-    }
+  if (const auto found = this->FindInputPortIndex(port_name)) {
+    return get_input_port(*found);
   }
   throw std::logic_error("System " + GetSystemName() +
                          " does not have an input port named " +
@@ -672,12 +670,7 @@ const InputPort<T>& System<T>::GetInputPort(
 template <typename T>
 bool System<T>::HasInputPort(
     const std::string& port_name) const {
-  for (InputPortIndex i{0}; i < num_input_ports(); i++) {
-    if (port_name == get_input_port_base(i).get_name()) {
-      return true;
-    }
-  }
-  return false;
+  return this->FindInputPortIndex(port_name).has_value();
 }
 
 template <typename T>
@@ -701,10 +694,8 @@ const OutputPort<T>* System<T>::get_output_port_selection(
 template <typename T>
 const OutputPort<T>& System<T>::GetOutputPort(
     const std::string& port_name) const {
-  for (OutputPortIndex i{0}; i < num_output_ports(); i++) {
-    if (port_name == get_output_port_base(i).get_name()) {
-      return get_output_port(i);
-    }
+  if (const auto found = this->FindOutputPortIndex(port_name)) {
+    return get_output_port(*found);
   }
   throw std::logic_error("System " + GetSystemName() +
                          " does not have an output port named " +
@@ -714,12 +705,7 @@ const OutputPort<T>& System<T>::GetOutputPort(
 template <typename T>
 bool System<T>::HasOutputPort(
     const std::string& port_name) const {
-  for (OutputPortIndex i{0}; i < num_output_ports(); i++) {
-    if (port_name == get_output_port_base(i).get_name()) {
-      return true;
-    }
-  }
-  return false;
+  return this->FindOutputPortIndex(port_name).has_value();
 }
 
 template <typename T>

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -25,6 +25,36 @@ internal::SystemId SystemBase::get_next_id() {
   return internal::SystemId::get_new_id();
 }
 
+void SystemBase::DeclareDeprecatedInputPort(
+    const std::string& removal_date,
+    const std::string& deprecated_name,
+    const std::string& correct_name) {
+  if (!input_port_deprecator_.HasScope()) {
+    input_port_deprecator_.DeclareScope(
+        fmt::format("system '{}' input ports", get_name()),
+        [this](const std::string& x){
+          return FindInputPortIndex(x).has_value();
+        });
+  }
+  input_port_deprecator_.DeclareDeprecatedName(
+      removal_date, deprecated_name, correct_name);
+}
+
+void SystemBase::DeclareDeprecatedOutputPort(
+    const std::string& removal_date,
+    const std::string& deprecated_name,
+    const std::string& correct_name) {
+  if (!output_port_deprecator_.HasScope()) {
+    output_port_deprecator_.DeclareScope(
+        fmt::format("system '{}' output ports", get_name()),
+        [this](const std::string& x){
+          return FindOutputPortIndex(x).has_value();
+        });
+  }
+  output_port_deprecator_.DeclareDeprecatedName(
+      removal_date, deprecated_name, correct_name);
+}
+
 std::string SystemBase::GetSystemPathname() const {
   const std::string parent_path =
       get_parent_service() ? get_parent_service()->GetParentPathname()
@@ -107,6 +137,28 @@ void SystemBase::InitializeContextBase(ContextBase* context_ptr) const {
 
   internal::SystemBaseContextBaseAttorney::mark_context_base_initialized(
       &context);
+}
+
+std::optional<InputPortIndex>
+SystemBase::FindInputPortIndex(const std::string& port_name) const {
+  const auto& checked_name = input_port_deprecator_.MaybeTranslate(port_name);
+  for (InputPortIndex i{0}; i < num_input_ports(); i++) {
+    if (checked_name == get_input_port_base(i).get_name()) {
+      return i;
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<OutputPortIndex>
+SystemBase::FindOutputPortIndex(const std::string& port_name) const {
+  const auto& checked_name = output_port_deprecator_.MaybeTranslate(port_name);
+  for (OutputPortIndex i{0}; i < num_output_ports(); i++) {
+    if (checked_name == get_output_port_base(i).get_name()) {
+      return i;
+    }
+  }
+  return std::nullopt;
 }
 
 // Set up trackers for variable-numbered independent sources: discrete and

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -427,6 +427,9 @@ TEST_F(SystemTest, PortNameTest) {
       system_.DeclareInputPort("my_input", kVectorValued, 3);
   const auto& named_abstract_input =
       system_.DeclareInputPort("abstract", kAbstractValued, 0);
+  system_.DeclareDeprecatedInputPort(
+      "2345-11-11", "dep_in", unnamed_input.get_name());
+  system_.DeclareDeprecatedInputPort("2345-11-11", "dep_in2", "abstract");
 
   EXPECT_EQ(unnamed_input.get_name(), "u0");
   EXPECT_EQ(named_input.get_name(), "my_input");
@@ -439,17 +442,24 @@ TEST_F(SystemTest, PortNameTest) {
 
   // Test string-based get_input_port accessors.
   EXPECT_EQ(&system_.GetInputPort("u0"), &unnamed_input);
+  EXPECT_EQ(&system_.GetInputPort("dep_in"), &unnamed_input);
   EXPECT_EQ(&system_.GetInputPort("my_input"), &named_input);
   EXPECT_EQ(&system_.GetInputPort("abstract"), &named_abstract_input);
-  EXPECT_EQ(system_.HasInputPort("u0"), true);
-  EXPECT_EQ(system_.HasInputPort("fake_name"), false);
+  EXPECT_EQ(&system_.GetInputPort("dep_in2"), &named_abstract_input);
+  EXPECT_TRUE(system_.HasInputPort("u0"));
+  EXPECT_TRUE(system_.HasInputPort("dep_in"));
+  EXPECT_FALSE(system_.HasInputPort("fake_name"));
 
   // Test output port names.
   const auto& output_port = system_.AddAbstractOutputPort();
+  system_.DeclareDeprecatedOutputPort(
+      "2345-11-11", "dep_out", output_port.get_name());
   EXPECT_EQ(output_port.get_name(), "y0");
   EXPECT_EQ(&system_.GetOutputPort("y0"), &output_port);
-  EXPECT_EQ(system_.HasOutputPort("y0"), true);
-  EXPECT_EQ(system_.HasOutputPort("fake_name"), false);
+  EXPECT_EQ(&system_.GetOutputPort("dep_out"), &output_port);
+  EXPECT_TRUE(system_.HasOutputPort("y0"));
+  EXPECT_TRUE(system_.HasOutputPort("dep_out"));
+  EXPECT_FALSE(system_.HasOutputPort("fake_name"));
 
   // Requesting a non-existing port name should throw.
   DRAKE_EXPECT_THROWS_MESSAGE(


### PR DESCRIPTION
Relevant to: #12214

This patch adds infrastructure and system APIs for deprecating port
names, but does not actually change or deprecate any port names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16268)
<!-- Reviewable:end -->
