### PR TITLE
[system framework] Expose default diagram port name

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -41,6 +41,7 @@ drake_cc_package_library(
         ":is_approx_equal_abstol",
         ":is_cloneable",
         ":is_less_than_comparable",
+        ":name_deprecator",
         ":name_value",
         ":nice_type_name",
         ":pointer_cast",
@@ -405,6 +406,15 @@ drake_cc_library(
 drake_cc_library(
     name = "is_approx_equal_abstol",
     hdrs = ["is_approx_equal_abstol.h"],
+    deps = [
+        ":essential",
+    ],
+)
+
+drake_cc_library(
+    name = "name_deprecator",
+    srcs = ["name_deprecator.cc"],
+    hdrs = ["name_deprecator.h"],
     deps = [
         ":essential",
     ],
@@ -960,6 +970,13 @@ drake_cc_googletest(
     deps = [
         ":essential",
         ":is_approx_equal_abstol",
+    ],
+)
+
+drake_cc_googletest(
+    name = "name_deprecator_test",
+    deps = [
+        ":name_deprecator",
     ],
 )
 

--- a/common/name_deprecator.cc
+++ b/common/name_deprecator.cc
@@ -1,0 +1,59 @@
+#include "drake/common/name_deprecator.h"
+
+#include <regex>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/text_logging.h"
+
+namespace drake {
+namespace internal {
+
+NameDeprecator::NameDeprecator() {}
+
+bool NameDeprecator::HasScope() const {
+  return !scope_name_.empty();
+}
+
+void NameDeprecator::DeclareScope(
+    const std::string& name,
+    std::function<bool(const std::string&)> predicate) {
+  DRAKE_ASSERT(!HasScope());
+  scope_name_ = name;
+  scope_predicate_ = predicate;
+}
+
+void NameDeprecator::DeclareDeprecatedName(
+    const std::string& removal_date,
+    const std::string& deprecated_name,
+    const std::string& correct_name) {
+  // Do lots of (debug-only) error checking here so deprecations don't get
+  // casually mis-typed, and so the translation/warn step can be simple and
+  // relatively fast.
+  DRAKE_ASSERT(HasScope());
+  DRAKE_ASSERT(std::regex_match(removal_date,
+                                std::regex(R"""(\d{4}-\d{2}-\d{2})""")));
+  DRAKE_ASSERT(!scope_predicate_(deprecated_name));
+  DRAKE_ASSERT(scope_predicate_(correct_name));
+  DRAKE_ASSERT(deprecations_.count(deprecated_name) == 0);
+  NameRecord record{removal_date, correct_name};
+  deprecations_[deprecated_name] = record;
+}
+
+const std::string& NameDeprecator::MaybeTranslate(
+    const std::string& name) const {
+  const auto it = deprecations_.find(name);
+  if (it == deprecations_.end()) {
+    return name;
+  }
+  auto& record = it->second;
+  if (!record.is_warning_issued) {
+    record.is_warning_issued = true;
+    log()->warn("Name '{}' is deprecated within scope '{}'"
+                " and will be removed after {}. Use '{}' instead.",
+                name, scope_name_, record.removal_date, record.correct_name);
+  }
+  return record.correct_name;
+}
+
+}  // namespace internal
+}  // namespace drake

--- a/common/name_deprecator.h
+++ b/common/name_deprecator.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <functional>
+#include <string>
+#include <unordered_map>
+
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace internal {
+
+// NameDeprecator supports deprecated alias names within some limited
+// scope. If the deprecated name is given to MaybeTranslate(), emit text log
+// warning once per process. The warning message will include the scope,
+// deprecated name, correct name, and removal date.
+//
+// Clients should consider wrapping this API for convenience. For example:
+//
+// @code
+// void Something::DeclareDeprecatedWidget(
+//     const std::string& removal_date,
+//     const std::string& deprecated_name,
+//     const std::string& correct_name) {
+//   if (!widget_deprecator_.HasScope()) {
+//     widget_deprecator_.DeclareScope(
+//         "something widgets",
+//         [this](const std::string& x){ return IsWidget(x); });
+//   }
+//   widget_deprecator_.DeclareDeprecatedName(
+//       removal_date, deprecated_name, correct_name);
+// }
+// @endcode
+class NameDeprecator {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(NameDeprecator)
+
+  NameDeprecator();
+
+  // @returns true if scope has been declared.
+  bool HasScope() const;
+
+  // Declare the scope in which names are relevant, once per instance.
+  // @param name       the name of the overall scope
+  // @param predicate  returns true if a name is a "correct name" in scope
+  // @pre HasScope() is false.
+  void DeclareScope(const std::string& name,
+                    std::function<bool(const std::string&)> predicate);
+
+  // Declare a deprecated name, the correct name it aliases, and the date when
+  // the deprecated alias will be removed.
+  // @pre HasScope() is true, `removal_date` roughly matches Y-m-d format,
+  //      `deprecated_name` fails the scope predicate, `correct_name` satisfies
+  //      the scope predicate, and `deprecated_name` has not already been
+  //      declared.
+  void DeclareDeprecatedName(
+      const std::string& removal_date,
+      const std::string& deprecated_name,
+      const std::string& correct_name);
+
+  // If the provided name is a deprecated name, return the correct
+  // name. Otherwise return the passed-in reference. Note that the return
+  // value lifetime will be the minimum of the lifetime of this deprecator,
+  // and the lifetime of the passed name.
+  const std::string& MaybeTranslate(const std::string& name) const;
+
+ private:
+  std::string scope_name_;
+  std::function<bool(const std::string&)> scope_predicate_;
+
+  struct NameRecord {
+    std::string removal_date;
+    std::string correct_name;
+    mutable bool is_warning_issued{false};
+  };
+  std::unordered_map<std::string, NameRecord> deprecations_;
+};
+
+}  // namespace internal
+}  // namespace drake

--- a/common/test/name_deprecator_test.cc
+++ b/common/test/name_deprecator_test.cc
@@ -1,0 +1,45 @@
+#include "drake/common/name_deprecator.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace internal {
+namespace {
+
+GTEST_TEST(NameDeprecatorTest, SmokeTest) {
+  NameDeprecator dut;
+  std::set<std::string> correct_names({"ca", "cb"});
+  EXPECT_FALSE(dut.HasScope());
+  dut.DeclareScope(
+      "test",
+      [&correct_names](const std::string& x) {
+        return correct_names.count(x);
+      });
+  EXPECT_TRUE(dut.HasScope());
+  dut.DeclareDeprecatedName("2453-11-11", "da", "ca");
+  // Multiple aliases to one target is ok.
+  dut.DeclareDeprecatedName("2453-11-11", "dda", "ca");
+  dut.DeclareDeprecatedName("2453-11-11", "db", "cb");
+
+  // First requests for deprecated names warn.
+  EXPECT_EQ(dut.MaybeTranslate("da"), "ca");
+  EXPECT_EQ(dut.MaybeTranslate("dda"), "ca");
+  EXPECT_EQ(dut.MaybeTranslate("db"), "cb");
+
+  // Subsequent requests for deprecated names are silent; check the console
+  // output for this test to see.
+  EXPECT_EQ(dut.MaybeTranslate("da"), "ca");
+  EXPECT_EQ(dut.MaybeTranslate("dda"), "ca");
+  EXPECT_EQ(dut.MaybeTranslate("db"), "cb");
+
+  // Correct names pass through.
+  EXPECT_EQ(dut.MaybeTranslate("cb"), "cb");
+
+  // Random strings pass through.
+  EXPECT_EQ(dut.MaybeTranslate("xq"), "xq");
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace drake
+

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -339,6 +339,7 @@ drake_cc_library(
         ":input_port_base",
         ":output_port_base",
         ":value_producer",
+        "//common:name_deprecator",
     ],
 )
 

--- a/systems/framework/diagram_builder.cc
+++ b/systems/framework/diagram_builder.cc
@@ -117,11 +117,9 @@ InputPortIndex DiagramBuilder<T>::DeclareInput(
   InputPortLocator id{&input.get_system(), input.get_index()};
   ThrowIfSystemNotRegistered(&input.get_system());
 
-  // The requirement that subsystem names are unique guarantees uniqueness
-  // of the port names.
   std::string port_name =
       name == kUseDefaultName
-          ? input.get_system().get_name() + "_" + input.get_name()
+          ? DefaultDiagramPortName(input)
           : std::get<std::string>(std::move(name));
   DRAKE_DEMAND(!port_name.empty());
 
@@ -209,11 +207,9 @@ OutputPortIndex DiagramBuilder<T>::ExportOutput(
   output_port_ids_.push_back(
       OutputPortLocator{&output.get_system(), output.get_index()});
 
-  // The requirement that subsystem names are unique guarantees uniqueness
-  // of the port names.
   std::string port_name =
       name == kUseDefaultName
-          ? output.get_system().get_name() + "_" + output.get_name()
+          ? DefaultDiagramPortName(output)
           : std::get<std::string>(std::move(name));
   DRAKE_DEMAND(!port_name.empty());
   output_port_names_.emplace_back(std::move(port_name));

--- a/systems/framework/diagram_builder.h
+++ b/systems/framework/diagram_builder.h
@@ -17,6 +17,16 @@
 namespace drake {
 namespace systems {
 
+/// Returns the name used for a diagram port if it is declared using the
+/// `kUseDefaultName` argument to the `ExportInput` or `ExportOutput` methods
+/// of DiagramBuilder.
+template <typename PortType>
+std::string DefaultDiagramPortName(const PortType& port) {
+  // The requirement that subsystem names are unique guarantees uniqueness of
+  // the port names.
+  return port.get_system().get_name() + "_" + port.get_name();
+}
+
 /// DiagramBuilder is a factory class for Diagram.
 ///
 /// It is single use: after calling Build or BuildInto, DiagramBuilder gives up

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -659,10 +659,8 @@ const InputPort<T>* System<T>::get_input_port_selection(
 template <typename T>
 const InputPort<T>& System<T>::GetInputPort(
     const std::string& port_name) const {
-  for (InputPortIndex i{0}; i < num_input_ports(); i++) {
-    if (port_name == get_input_port_base(i).get_name()) {
-      return get_input_port(i);
-    }
+  if (const auto found = this->FindInputPort(port_name)) {
+    return get_input_port(*found);
   }
   throw std::logic_error("System " + GetSystemName() +
                          " does not have an input port named " +
@@ -672,12 +670,7 @@ const InputPort<T>& System<T>::GetInputPort(
 template <typename T>
 bool System<T>::HasInputPort(
     const std::string& port_name) const {
-  for (InputPortIndex i{0}; i < num_input_ports(); i++) {
-    if (port_name == get_input_port_base(i).get_name()) {
-      return true;
-    }
-  }
-  return false;
+  return this->FindInputPort(port_name).has_value();
 }
 
 template <typename T>
@@ -701,10 +694,8 @@ const OutputPort<T>* System<T>::get_output_port_selection(
 template <typename T>
 const OutputPort<T>& System<T>::GetOutputPort(
     const std::string& port_name) const {
-  for (OutputPortIndex i{0}; i < num_output_ports(); i++) {
-    if (port_name == get_output_port_base(i).get_name()) {
-      return get_output_port(i);
-    }
+  if (const auto found = this->FindOutputPort(port_name)) {
+    return get_output_port(*found);
   }
   throw std::logic_error("System " + GetSystemName() +
                          " does not have an output port named " +
@@ -714,12 +705,7 @@ const OutputPort<T>& System<T>::GetOutputPort(
 template <typename T>
 bool System<T>::HasOutputPort(
     const std::string& port_name) const {
-  for (OutputPortIndex i{0}; i < num_output_ports(); i++) {
-    if (port_name == get_output_port_base(i).get_name()) {
-      return true;
-    }
-  }
-  return false;
+  return this->FindOutputPort(port_name).has_value();
 }
 
 template <typename T>

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "drake/common/drake_throw.h"
+#include "drake/common/name_deprecator.h"
 #include "drake/common/unused.h"
 #include "drake/systems/framework/abstract_value_cloner.h"
 #include "drake/systems/framework/cache_entry.h"
@@ -203,6 +204,24 @@ class SystemBase : public internal::SystemMessageInterface {
   const OutputPortBase& get_output_port_base(OutputPortIndex port_index) const {
     return GetOutputPortBaseOrThrow(__func__, port_index);
   }
+
+  /** Returns an index to an InputPort given its name. */
+  std::optional<InputPortIndex>
+  FindInputPort(const std::string& port_name) const;
+
+  /** Returns an index to an OutputPort given its name. */
+  std::optional<OutputPortIndex>
+  FindOutputPort(const std::string& port_name) const;
+
+  /** Declare a deprecated alias name for an input port. */
+  void DeclareDeprecatedInputPort(const std::string& removal_date,
+                                  const std::string& deprecated_name,
+                                  const std::string& correct_name);
+
+  /** Declare a deprecated alias name for an output port. */
+  void DeclareDeprecatedOutputPort(const std::string& removal_date,
+                                   const std::string& deprecated_name,
+                                   const std::string& correct_name);
 
   /** Returns the total dimension of all of the vector-valued input ports (as if
   they were muxed). */
@@ -1210,6 +1229,10 @@ class SystemBase : public internal::SystemMessageInterface {
   std::vector<TrackerInfo> numeric_parameter_tickets_;
   // Indexed by AbstractParameterIndex.
   std::vector<TrackerInfo> abstract_parameter_tickets_;
+
+  // Ports may have deprecated names.
+  drake::internal::NameDeprecator input_port_deprecator_;
+  drake::internal::NameDeprecator output_port_deprecator_;
 
   // Initialize to the first ticket number available after all the well-known
   // ones. This gets incremented as tickets are handed out for the optional

--- a/systems/framework/test/diagram_builder_test.cc
+++ b/systems/framework/test/diagram_builder_test.cc
@@ -464,6 +464,17 @@ GTEST_TEST(DiagramBuilderTest, DefaultInputPortNamesAreUniqueTest) {
   DRAKE_EXPECT_NO_THROW(builder.Build());
 }
 
+GTEST_TEST(DiagramBuilderTest, DefaultInputPortNamesDeprecationTest) {
+  DiagramBuilder<double> builder;
+  auto sink = builder.AddSystem<Sink<double>>();
+  builder.ExportInput(sink->get_input_port(0), "input");
+  auto diagram = builder.Build();
+  const auto deprecated = DefaultDiagramPortName(sink->get_input_port(0));
+  diagram->DeclareDeprecatedInputPort("3456-11-11", deprecated, "input");
+  EXPECT_EQ(&diagram->GetInputPort("input"),
+            &diagram->GetInputPort(deprecated));
+}
+
 GTEST_TEST(DiagramBuilderTest, DefaultOutputPortNamesAreUniqueTest) {
   DiagramBuilder<double> builder;
 
@@ -475,6 +486,17 @@ GTEST_TEST(DiagramBuilderTest, DefaultOutputPortNamesAreUniqueTest) {
 
   // If the port names were not unique, then the build step would throw.
   DRAKE_EXPECT_NO_THROW(builder.Build());
+}
+
+GTEST_TEST(DiagramBuilderTest, DefaultOutputPortNamesDeprecationTest) {
+  DiagramBuilder<double> builder;
+  auto source = builder.AddSystem<Source<double>>();
+  builder.ExportOutput(source->get_output_port(0), "output");
+  auto diagram = builder.Build();
+  const auto deprecated = DefaultDiagramPortName(source->get_output_port(0));
+  diagram->DeclareDeprecatedOutputPort("3456-11-11", deprecated, "output");
+  EXPECT_EQ(&diagram->GetOutputPort("output"),
+            &diagram->GetOutputPort(deprecated));
 }
 
 GTEST_TEST(DiagramBuilderTest, DefaultPortNamesAreUniqueTest2) {

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -427,6 +427,9 @@ TEST_F(SystemTest, PortNameTest) {
       system_.DeclareInputPort("my_input", kVectorValued, 3);
   const auto& named_abstract_input =
       system_.DeclareInputPort("abstract", kAbstractValued, 0);
+  system_.DeclareDeprecatedInputPort(
+      "2345-11-11", "dep_in", unnamed_input.get_name());
+  system_.DeclareDeprecatedInputPort("2345-11-11", "dep_in2", "abstract");
 
   EXPECT_EQ(unnamed_input.get_name(), "u0");
   EXPECT_EQ(named_input.get_name(), "my_input");
@@ -438,18 +441,31 @@ TEST_F(SystemTest, PortNameTest) {
       std::logic_error, ".*already has an input port named.*");
 
   // Test string-based get_input_port accessors.
+  EXPECT_EQ(system_.FindInputPort("dep_in"), system_.FindInputPort("u0"));
+  EXPECT_EQ(system_.FindInputPort("dep_in2"),
+            system_.FindInputPort("abstract"));
   EXPECT_EQ(&system_.GetInputPort("u0"), &unnamed_input);
+  EXPECT_EQ(&system_.GetInputPort("dep_in"), &unnamed_input);
   EXPECT_EQ(&system_.GetInputPort("my_input"), &named_input);
   EXPECT_EQ(&system_.GetInputPort("abstract"), &named_abstract_input);
-  EXPECT_EQ(system_.HasInputPort("u0"), true);
-  EXPECT_EQ(system_.HasInputPort("fake_name"), false);
+  EXPECT_EQ(&system_.GetInputPort("dep_in2"), &named_abstract_input);
+  EXPECT_TRUE(system_.HasInputPort("u0"));
+  EXPECT_TRUE(system_.HasInputPort("dep_in"));
+  EXPECT_FALSE(system_.HasInputPort("fake_name"));
+  EXPECT_FALSE(system_.FindInputPort("fake_name"));
 
   // Test output port names.
   const auto& output_port = system_.AddAbstractOutputPort();
+  system_.DeclareDeprecatedOutputPort(
+      "2345-11-11", "dep_out", output_port.get_name());
   EXPECT_EQ(output_port.get_name(), "y0");
+  EXPECT_EQ(system_.FindOutputPort("y0"), system_.FindOutputPort("dep_out"));
   EXPECT_EQ(&system_.GetOutputPort("y0"), &output_port);
-  EXPECT_EQ(system_.HasOutputPort("y0"), true);
-  EXPECT_EQ(system_.HasOutputPort("fake_name"), false);
+  EXPECT_EQ(&system_.GetOutputPort("dep_out"), &output_port);
+  EXPECT_TRUE(system_.HasOutputPort("y0"));
+  EXPECT_TRUE(system_.HasOutputPort("dep_out"));
+  EXPECT_FALSE(system_.HasOutputPort("fake_name"));
+  EXPECT_FALSE(system_.FindOutputPort("fake_name"));
 
   // Requesting a non-existing port name should throw.
   DRAKE_EXPECT_THROWS_MESSAGE(


### PR DESCRIPTION
Relevant to: #12214, #9496
    
This patch is necessary to enable deprecation of default diagram port
names, as proposed in comments in PR #16193.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16270)
<!-- Reviewable:end -->
