### PR TITLE
[geometry:optimization] Add VPolytope from HPolyhedron

### DIFF
--- a/bindings/pydrake/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry_py_optimization.cc
@@ -182,11 +182,14 @@ void DefineGeometryOptimization(py::module m) {
     const auto& cls_doc = doc.VPolytope;
     py::class_<VPolytope, ConvexSet>(m, "VPolytope", cls_doc.doc)
         .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&>(),
-            py::arg("vertices"), cls_doc.ctor.doc_1args)
+            py::arg("vertices"), cls_doc.ctor.doc_vertices)
+        .def(py::init<const HPolyhedron&>(), py::arg("H"),
+            cls_doc.ctor.doc_hpolyhedron)
         .def(py::init<const QueryObject<double>&, GeometryId,
                  std::optional<FrameId>>(),
             py::arg("query_object"), py::arg("geometry_id"),
-            py::arg("reference_frame") = std::nullopt, cls_doc.ctor.doc_3args)
+            py::arg("reference_frame") = std::nullopt,
+            cls_doc.ctor.doc_scenegraph)
         .def("vertices", &VPolytope::vertices, cls_doc.vertices.doc)
         .def_static("MakeBox", &VPolytope::MakeBox, py::arg("lb"),
             py::arg("ub"), cls_doc.MakeBox.doc)

--- a/bindings/pydrake/test/geometry_optimization_test.py
+++ b/bindings/pydrake/test/geometry_optimization_test.py
@@ -120,6 +120,8 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertTrue(v_box.PointInSet([0, 0, 0]))
         v_unit_box = mut.VPolytope.MakeUnitBox(dim=3)
         self.assertTrue(v_unit_box.PointInSet([0, 0, 0]))
+        v_from_h = mut.VPolytope(H=mut.HPolyhedron.MakeUnitBox(dim=3))
+        self.assertTrue(v_from_h.PointInSet([0, 0, 0]))
 
     def test_cartesian_product(self):
         point = mut.Point(np.array([11.1, 12.2, 13.3]))

--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -44,6 +44,7 @@ drake_cc_library(
         "//geometry:scene_graph",
         "//solvers:mathematical_program",
         "//solvers:solve",
+        "@qhull",
     ],
 )
 
@@ -164,6 +165,7 @@ drake_cc_googletest(
         ":convex_set",
         ":test_utilities",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/geometry/optimization/test/vpolytope_test.cc
+++ b/geometry/optimization/test/vpolytope_test.cc
@@ -6,6 +6,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/optimization/test_utilities.h"
 #include "drake/geometry/scene_graph.h"
@@ -18,7 +19,10 @@ namespace drake {
 namespace geometry {
 namespace optimization {
 
+using Eigen::Matrix;
+using Eigen::Vector2d;
 using Eigen::Vector3d;
+using Eigen::Vector4d;
 using internal::CheckAddPointInSetConstraints;
 using internal::MakeSceneGraphWithShape;
 using math::RigidTransformd;
@@ -153,6 +157,134 @@ GTEST_TEST(VPolytopeTest, UnitBox6DTest) {
   EXPECT_TRUE(V.PointInSet(in2_W, kTol));
   EXPECT_FALSE(V.PointInSet(out1_W, kTol));
   EXPECT_FALSE(V.PointInSet(out2_W, kTol));
+}
+
+GTEST_TEST(VPolytopeTest, FromHUnitBoxTest) {
+  HPolyhedron H = HPolyhedron::MakeUnitBox(6);
+  VPolytope V(H);
+  EXPECT_EQ(V.ambient_dimension(), 6);
+  EXPECT_EQ(V.vertices().rows(), 6);
+  EXPECT_EQ(V.vertices().cols(), std::pow(2, 6));
+
+  const Vector6d in1_W{Vector6d::Constant(-.99)},
+      in2_W{Vector6d::Constant(.99)}, out1_W{Vector6d::Constant(-1.01)},
+      out2_W{Vector6d::Constant(1.01)};
+  Vector6d out3_W;
+  out3_W << .99, 1.01, .99, 1.01, .99, 1.01;
+
+  const double kTol = 1e-11;
+  EXPECT_TRUE(V.PointInSet(in1_W, kTol));
+  EXPECT_TRUE(V.PointInSet(in2_W, kTol));
+  EXPECT_FALSE(V.PointInSet(out1_W, kTol));
+  EXPECT_FALSE(V.PointInSet(out2_W, kTol));
+  EXPECT_FALSE(V.PointInSet(out3_W, kTol));
+}
+
+GTEST_TEST(VPolytopeTest, From2DHPolytopeTest) {
+  Matrix<double, 4, 2> A;
+  Vector4d b;
+  // clang-format off
+  A <<  1, -1,  // y ≥ x
+        1,  0,  // x ≤ 1
+        0,  1,  // y ≤ 2
+       -1,  0;  // x ≥ 0
+  // clang-format on
+  b << 0, 1, 2, 0;
+  HPolyhedron H(A, b);
+  VPolytope V(H);
+
+  // Vertices should be (0,0), (1,1), (1,2), and (0,2). The order of the
+  // returned vertices need not be unique.
+  Eigen::MatrixXd vertices(2, 4);
+  // clang-format off
+  vertices << 0, 1, 0, 1,
+              0, 1, 2, 2;
+  // clang-format on
+  for (int i = 0; i < 4; ++i) {
+    bool found_match = false;
+    for (int j = 0; j < 4; ++j) {
+      if (CompareMatrices(vertices.col(i), V.vertices().col(j), 1e-11)) {
+        found_match = true;
+        break;
+      }
+    }
+    EXPECT_TRUE(found_match);
+  }
+}
+
+GTEST_TEST(VPolytopeTest, From3DHSimplexTest) {
+  Matrix<double, 4, 3> A;
+  Vector4d b;
+  A <<  -1,  0,  0,
+         0, -1,  0,
+         0,  0, -1,
+         1,  1,  1;
+  b << 0, 0, 0, 1;
+  HPolyhedron H(A, b);
+  VPolytope V(H);
+
+  // Vertices are (0,0,0), (1,0,0), (0,1,0), and (0,0,1).
+  const Vector3d in1_W{.01, .01, .01}, in2_W{.9, .01, .01}, in3_W{.01, .9, .01},
+      in4_W{.01, .01, .9}, in5_W{.33, .33, .33}, out1_W{-.01, -.01, -.01},
+      out2_W{1., .01, .01}, out3_W{.01, 1., .01}, out4_W{.01, .01, 1.},
+      out5_W{.34, .34, .34};
+
+  const double kTol = 1e-11;
+  EXPECT_TRUE(V.PointInSet(in1_W, kTol));
+  EXPECT_TRUE(V.PointInSet(in2_W, kTol));
+  EXPECT_TRUE(V.PointInSet(in3_W, kTol));
+  EXPECT_TRUE(V.PointInSet(in4_W, kTol));
+  EXPECT_TRUE(V.PointInSet(in5_W, kTol));
+  EXPECT_FALSE(V.PointInSet(out1_W, kTol));
+  EXPECT_FALSE(V.PointInSet(out2_W, kTol));
+  EXPECT_FALSE(V.PointInSet(out3_W, kTol));
+  EXPECT_FALSE(V.PointInSet(out4_W, kTol));
+  EXPECT_FALSE(V.PointInSet(out5_W, kTol));
+}
+
+// Same as FromHPolytopeTest but with two redundant constraints.
+GTEST_TEST(VPolytopeTest, FromRedundantHPolytopeTest) {
+  Matrix<double, 6, 2> A;
+  Vector6d b;
+  A <<  1, -1,  // y ≥ x
+        1,  0,  // x ≤ 1
+        0,  1,  // y ≤ 2
+       -1,  0,  // x ≥ 0
+        1,  1,  // x + y ≤ 3.1   (redundant)
+       -1, -1;  // x + y ≥ - 0.1 (redundant)
+  b << 0, 1, 2, 0, 3.1, 0.1;
+  HPolyhedron H(A, b);
+  VPolytope V(H);
+
+  // Vertices should be (0,0), (1,1), (1,2), and (0,2). The order of the
+  // returned vertices need not be unique.
+  Eigen::MatrixXd vertices(2, 4);
+  // clang-format off
+  vertices << 0, 1, 0, 1,
+              0, 1, 2, 2;
+  // clang-format on
+  for (int i = 0; i < 4; ++i) {
+    bool found_match = false;
+    for (int j = 0; j < 4; ++j) {
+      if (CompareMatrices(vertices.col(i), V.vertices().col(j), 1e-11)) {
+        found_match = true;
+        break;
+      }
+    }
+    EXPECT_TRUE(found_match);
+  }
+}
+
+GTEST_TEST(VPolytopeTest, FromUnboundedHPolytopeTest) {
+  Matrix<double, 3, 2> A;
+  Vector3d b;
+  A <<  1, -1,  // y ≥ x
+        1,  0,  // x ≤ 1
+        0,  1;  // y ≤ 2
+  b << 0, 1, 2;
+  HPolyhedron H(A, b);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(VPolytope{H}, ".*hpoly.IsBounded().*");
 }
 
 GTEST_TEST(VPolytopeTest, CloneTest) {

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -3,6 +3,10 @@
 #include <limits>
 #include <memory>
 
+#include <fmt/format.h>
+#include <libqhullcpp/Qhull.h>
+#include <libqhullcpp/QhullVertexSet.h>
+
 #include "drake/common/is_approx_equal_abstol.h"
 #include "drake/solvers/solve.h"
 
@@ -38,6 +42,69 @@ VPolytope::VPolytope(const QueryObject<double>& query_object,
   const RigidTransformd& X_WG = query_object.GetPoseInWorld(geometry_id);
   const RigidTransformd X_EG = X_WE.InvertAndCompose(X_WG);
   vertices_ = X_EG * vertices;
+}
+
+VPolytope::VPolytope(const HPolyhedron& hpoly)
+    : ConvexSet(&ConvexSetCloner<VPolytope>, hpoly.ambient_dimension()) {
+  DRAKE_THROW_UNLESS(hpoly.IsBounded());
+
+  Eigen::MatrixXd coeffs(hpoly.A().rows(), hpoly.A().cols() + 1);
+  coeffs.leftCols(hpoly.A().cols()) = hpoly.A();
+  coeffs.col(hpoly.A().cols()) = -hpoly.b();
+
+  Eigen::MatrixXd coeffs_t = coeffs.transpose();
+  std::vector<double> flat_coeffs;
+  flat_coeffs.resize(coeffs_t.size());
+  Eigen::VectorXd::Map(&flat_coeffs[0], coeffs_t.size()) =
+      Eigen::VectorXd::Map(coeffs_t.data(), coeffs_t.size());
+
+  Eigen::VectorXd eigen_center = hpoly.ChebyshevCenter();
+  std::vector<double> center;
+  center.resize(eigen_center.size());
+  Eigen::VectorXd::Map(&center[0], eigen_center.size()) = eigen_center;
+
+  orgQhull::Qhull qhull;
+  qhull.setFeasiblePoint(orgQhull::Coordinates(center));
+  //  By default, Qhull takes in a sequence of vertices and generates a convex
+  //  hull from them. Alternatively it can generate the convex hull from a
+  //  sequence of halfspaces (requested via the "H" argument). In that case the
+  //  inputs are overloaded with the `pointDimension` representing the dimension
+  //  the convex hull exists in plus the offset and the `pointCount`
+  //  representing the number of faces. Slightly more documentation can be found
+  //  here: http://www.qhull.org/html/qhull.htm.
+  qhull.runQhull("", hpoly.A().cols() + 1, hpoly.A().rows(), flat_coeffs.data(),
+                 "H");
+  if (qhull.qhullStatus() != 0) {
+    throw std::runtime_error(
+        fmt::format("Qhull terminated with status {} and  message:\n{}",
+                    qhull.qhullStatus(), qhull.qhullMessage()));
+  }
+
+  // Qhull flips some notation when you use the halfspace intersection:
+  // http://www.qhull.org/html/qh-code.htm#facet-cpp . Each facet from qhull
+  // represents an intersection between halfspaces of the H polyhedron.
+  // However, I could not figure out if each QhullFacet stored the exact
+  // location of the intersection (i.e. the vertex). Instead, this code takes
+  // each intersection of hyperplanes (QhullFacet), pulls out the hyperplanes
+  // that are part of the intersection (facet.vertices()) and solves for the
+  // vertex that lies at the intersection of these hyperplanes.
+  vertices_.resize(hpoly.ambient_dimension(), qhull.facetCount());
+  int ii = 0;
+  for (const auto& facet : qhull.facetList()) {
+    auto incident_hyperplanes = facet.vertices();
+    Eigen::MatrixXd vertex_A(incident_hyperplanes.count(),
+                             hpoly.ambient_dimension());
+    for (int jj = 0; jj < incident_hyperplanes.count(); jj++) {
+      std::vector<double> hyperplane =
+          incident_hyperplanes.at(jj).point().toStdVector();
+      vertex_A.row(jj) = Eigen::Map<Eigen::RowVectorXd, Eigen::Unaligned>(
+          hyperplane.data(), hyperplane.size());
+    }
+    vertices_.col(ii) = vertex_A.partialPivLu().solve(Eigen::VectorXd::Ones(
+                            incident_hyperplanes.count())) +
+                        eigen_center;
+    ii++;
+  }
 }
 
 VPolytope::~VPolytope() = default;

--- a/geometry/optimization/vpolytope.h
+++ b/geometry/optimization/vpolytope.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "drake/geometry/optimization/convex_set.h"
+#include "drake/geometry/optimization/hpolyhedron.h"
 
 namespace drake {
 namespace geometry {
@@ -28,10 +29,18 @@ class VPolytope final : public ConvexSet {
 
   /** Constructs the polytope from a d-by-n matrix, where d is the ambient
   dimension, and n is the number of vertices.  The vertices do not have to be
-  ordered, nor minimal (they can contain points inside their convex hull).  */
+  ordered, nor minimal (they can contain points inside their convex hull).
+  @pydrake_mkdoc_identifier{vertices} */
   explicit VPolytope(const Eigen::Ref<const Eigen::MatrixXd>& vertices);
 
-  /** Construct the polytope from a SceneGraph geometry. */
+  /** Constructs the polytope from a bounded polyhedron (using Qhull).
+  @throws std::runtime_error if H is unbounded or if Qhull terminates with an
+  error.
+  @pydrake_mkdoc_identifier{hpolyhedron} */
+  explicit VPolytope(const HPolyhedron& H);
+
+  /** Constructs the polytope from a SceneGraph geometry.
+  @pydrake_mkdoc_identifier{scenegraph} */
   VPolytope(const QueryObject<double>& query_object, GeometryId geometry_id,
             std::optional<FrameId> reference_frame = std::nullopt);
 

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -58,6 +58,7 @@ _DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "meshcat_python",
     "petsc",
     "pybind11",
+    "qhull",
     "sdformat",
     "spdlog",
     "tinyobjloader",

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -70,6 +70,7 @@ load("@drake//tools/workspace/pycodestyle:repository.bzl", "pycodestyle_reposito
 load("@drake//tools/workspace/pygame_py:repository.bzl", "pygame_py_repository")  # noqa
 load("@drake//tools/workspace/python:repository.bzl", "python_repository")
 load("@drake//tools/workspace/qdldl:repository.bzl", "qdldl_repository")
+load("@drake//tools/workspace/qhull:repository.bzl", "qhull_repository")
 load("@drake//tools/workspace/ros_xacro:repository.bzl", "ros_xacro_repository")  # noqa
 load("@drake//tools/workspace/rules_pkg:repository.bzl", "rules_pkg_repository")  # noqa
 load("@drake//tools/workspace/rules_python:repository.bzl", "rules_python_repository")  # noqa
@@ -240,6 +241,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         python_repository(name = "python")
     if "qdldl" not in excludes:
         qdldl_repository(name = "qdldl", mirrors = mirrors)
+    if "qhull" not in excludes:
+        qhull_repository(name = "qhull", mirrors = mirrors)
     if "ros_xacro" not in excludes:
         ros_xacro_repository(name = "ros_xacro", mirrors = mirrors)
     if "rules_pkg" not in excludes:

--- a/tools/workspace/qhull/BUILD.bazel
+++ b/tools/workspace/qhull/BUILD.bazel
@@ -1,0 +1,5 @@
+# -*- python -*-
+
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/workspace/qhull/package.BUILD.bazel
+++ b/tools/workspace/qhull/package.BUILD.bazel
@@ -1,0 +1,41 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/install:install.bzl",
+    "install",
+)
+
+licenses(["notice"])  # Qhull
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "qhull",
+    hdrs = glob([
+        "src/libqhullcpp/*.h",
+        "src/libqhull_r/*.h",
+    ]),
+    copts = [
+        "-fvisibility=hidden",
+    ],
+    includes = ["src"],
+    srcs = glob(
+        [
+            "src/libqhullcpp/*.cpp",
+            "src/libqhull_r/*.c",
+        ],
+        exclude = [
+            "src/libqhullcpp/qt-qhull.cpp",
+            "src/libqhullcpp/usermem_r-cpp.cpp",
+            "src/libqhull_r/userprintf_r.c",
+            "src/libqhull_r/userprintf_rbox_r.c",
+        ],
+    ),
+    linkstatic = 1,
+)
+
+# Install the license file.
+install(
+    name = "install",
+    docs = ["COPYING.txt"],
+)

--- a/tools/workspace/qhull/repository.bzl
+++ b/tools/workspace/qhull/repository.bzl
@@ -1,0 +1,15 @@
+# -*- python -*-
+
+load("@drake//tools/workspace:github.bzl", "github_archive")
+
+def qhull_repository(
+        name,
+        mirrors = None):
+    github_archive(
+        name = name,
+        repository = "qhull/qhull",
+        commit = "2020.2",
+        sha256 = "59356b229b768e6e2b09a701448bfa222c37b797a84f87f864f97462d8dbc7c5",  # noqa
+        build_file = "@drake//tools/workspace/qhull:package.BUILD.bazel",
+        mirrors = mirrors,
+    )


### PR DESCRIPTION
- Brings in qhull as an external.
- Adds an implementation for generating VPolytope from HPolyhedron using qhull

Co-authored-by: Mark Petersen <markpetersen@g.harvard.edu>
Co-authored-by: Tobia Marcucci <tobiam@mit.edu>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16272)
<!-- Reviewable:end -->
