### PR TITLE
[bindings] Correct return type for MbP::GetUniqueFreeBaseBodyOrThrow

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -471,6 +471,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("model_instance"), cls_doc.HasUniqueFreeBaseBody.doc)
         .def("GetUniqueFreeBaseBodyOrThrow",
             &Class::GetUniqueFreeBaseBodyOrThrow, py::arg("model_instance"),
+            py_rvp::reference_internal,
             cls_doc.GetUniqueFreeBaseBodyOrThrow.doc)
         .def(
             "EvalBodyPoseInWorld",

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2304,3 +2304,15 @@ class TestPlant(unittest.TestCase):
             contact_results_port=plant.get_contact_results_output_port(),
             meshcat=meshcat,
             params=params)
+
+    def test_free_base_bodies(self):
+        plant = MultibodyPlant_[float](time_step=0.01)
+        model_instance = plant.AddModelInstance("new instance")
+        added_body = plant.AddRigidBody(
+            name="body", model_instance=model_instance,
+            M_BBo_B=SpatialInertia_[float]())
+        plant.Finalize()
+        self.assertTrue(plant.HasBodyNamed("body", model_instance))
+        self.assertTrue(plant.HasUniqueFreeBaseBody(model_instance))
+        body = plant.GetUniqueFreeBaseBodyOrThrow(model_instance)
+        self.assertEqual(body.index(), added_body.index())


### PR DESCRIPTION
Currently, invoking the method from pydrake causes runtime error `return_value_policy = copy, but type is non-copyable!`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16274)
<!-- Reviewable:end -->
