### PR TITLE
fix libcurl installation

### DIFF
--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -100,8 +100,8 @@ apt-get install ${maybe_yes} --no-install-recommends ${packages}
 
 # TODO(svenevs): when bionic is dropped, satisfy can be used unconditionally.
 if  [[ "${codename}" != 'bionic' ]]; then
-  cat "${BASH_SOURCE%/*}/packages-${codename}-satisfy.txt" | \
-    xargs -I{} apt-get satisfy ${maybe_yes} --no-install-recommends {}
+  apt-get satisfy  ${maybe_yes} --no-install-recommends \
+    'libcurl4-gnutls-dev | libcurl4-dev'
 fi
 
 # Ensure that we have available a locale that supports UTF-8 for generating a

--- a/setup/ubuntu/source_distribution/packages-focal-satisfy.txt
+++ b/setup/ubuntu/source_distribution/packages-focal-satisfy.txt
@@ -1,1 +1,0 @@
-libcurl4-dev | libcurl4-gnutls-dev


### PR DESCRIPTION
xargs was hiding the [Y/n] prompt

Refs: #16233.

Edit: Link to bug report on Slack [here](https://drakedevelopers.slack.com/archives/C270MN28G/p1640183163197600)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16280)
<!-- Reviewable:end -->
