### PR TITLE
Call scaling() before solving in ClpSolver.

### DIFF
--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -765,7 +765,7 @@ GTEST_TEST(ShortestPathTest, TobiasToyExample) {
 GTEST_TEST(ShortestPathTest, Graphviz) {
   GraphOfConvexSets g;
   auto source = g.AddVertex(Point(Vector2d{1.0, 2.}), "source");
-  auto target = g.AddVertex(Point(Vector1d{1e-8}), "target");
+  auto target = g.AddVertex(Point(Vector1d{1e-6}), "target");
   g.AddEdge(*source, *target, "edge");
 
   // Note: Testing the entire string against a const string is too fragile,
@@ -786,7 +786,7 @@ GTEST_TEST(ShortestPathTest, Graphviz) {
   EXPECT_THAT(g.GetGraphvizString(result, false, 2, false),
               AllOf(HasSubstr("x = [1.00 2.00]"), HasSubstr("x = [0.00]")));
   EXPECT_THAT(g.GetGraphvizString(result, false, 2, true),
-              AllOf(HasSubstr("x = [1 2]"), HasSubstr("x = [1e-08]")));
+              AllOf(HasSubstr("x = [1 2]"), HasSubstr("x = [1e-06]")));
 }
 
 }  // namespace optimization

--- a/solvers/clp_solver.cc
+++ b/solvers/clp_solver.cc
@@ -301,6 +301,17 @@ int ChooseLogLevel(const SolverOptions& options) {
   }
   return 0;
 }
+
+int ChooseScaling(const SolverOptions& options) {
+  const auto& clp_options = options.GetOptionsInt(ClpSolver::id());
+  auto it = clp_options.find("scaling");
+  if (it == clp_options.end()) {
+    // Default scaling is 1.
+    return 1;
+  } else {
+    return it->second;
+  }
+}
 }  // namespace
 
 bool ClpSolver::is_available() { return true; }
@@ -340,6 +351,11 @@ void ClpSolver::DoSolve(const MathematicalProgram& prog,
     SetBoundingBoxConstraintDualIndices(prog, bb_con, xlow, xupp,
                                         &bb_con_dual_variable_indices);
   }
+
+  // As suggested by the CLP author, we should call scaling() to handle tiny (or
+  // huge) number in program data. See https://github.com/coin-or/Clp/issues/217
+  // for the discussion.
+  model.scaling(ChooseScaling(merged_options));
 
   // Solve
   model.primal();

--- a/solvers/clp_solver.h
+++ b/solvers/clp_solver.h
@@ -30,6 +30,12 @@ struct ClpSolverDetails {
  * A wrapper to call CLP using Drake's MathematicalProgram.
  * @note Currently our ClpSolver has a memory issue when solving a QP. The user
  * should be aware of this risk.
+ * @note The authors can adjust the problem scaling option by setting "scaling"
+ as mentioned in
+ https://github.com/coin-or/Clp/blob/43129ba1a7fd66ce70fe0761fcd696951917ed2e/src/ClpModel.hpp#L705-L706
+ * For example
+ * prog.SetSolverOption(ClpSolver::id(), "scaling", 0);
+ * will do "no scaling". The default is 1.
  */
 class ClpSolver final : public SolverBase {
  public:

--- a/solvers/test/clp_solver_test.cc
+++ b/solvers/test/clp_solver_test.cc
@@ -202,6 +202,17 @@ GTEST_TEST(ClpSolverTest, TestVerbosity) {
     solver.Solve(prog, {}, options);
   }
 }
+GTEST_TEST(ClpSolverTest, TestNumericalScaling) {
+  ClpSolver solver;
+  TestLPPoorScaling1(solver);
+  TestLPPoorScaling2(solver);
+  // Try another scaling option. Set scaling equal to 2. Somehow in CLP with
+  // this scaling mode, the problem is not solved successfully.
+  SolverOptions solver_options;
+  solver_options.SetOption(ClpSolver::id(), "scaling", 2);
+  TestLPPoorScaling1(solver, false, 1E-14, solver_options);
+  TestLPPoorScaling2(solver, false, 1E-4, solver_options);
+}
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/ipopt_solver_test.cc
+++ b/solvers/test/ipopt_solver_test.cc
@@ -313,6 +313,12 @@ GTEST_TEST(TestSOCP, SmallestEllipsoidCoveringProblem) {
   IpoptSolver solver;
   SolveAndCheckSmallestEllipsoidCoveringProblems(solver, 1E-6);
 }
+
+GTEST_TEST(TestLP, PoorScaling) {
+  IpoptSolver solver;
+  TestLPPoorScaling1(solver, true, 1E-6);
+  TestLPPoorScaling2(solver, true, 1E-4);
+}
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/linear_program_examples.h
+++ b/solvers/test/linear_program_examples.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <tuple>
 #include <vector>
 
@@ -222,6 +223,28 @@ void TestLPDualSolution2Scaled(const SolverInterface& solver,
 
 /** This LP has only bounding box constraints. */
 void TestLPDualSolution3(const SolverInterface& solver, double tol = 1e-6);
+
+/** This test confirms that the solver can solve problems with poorly scaled
+ * data. See github issue https://github.com/RobotLocomotion/drake/issues/15341
+ * for more discussion. Mathematically this program finds the point with the
+ * smallest infinity norm to (0.99, 1.99). The point is within the convex hull
+ * of four points (eps, eps), (1, 1), (eps, 2), (1, 2).
+ */
+void TestLPPoorScaling1(
+    const SolverInterface& solver, bool expect_success = true,
+    double tol = 1E-12,
+    const std::optional<SolverOptions>& options = std::nullopt);
+
+/** This test confirms that the solver can solve problems with poorly scaled
+ * data. See github issue https://github.com/RobotLocomotion/drake/issues/15341
+ * for more discussion.
+ * The optimal solution isn't computed analytically, hence we take a loose
+ * tolerance.
+ */
+void TestLPPoorScaling2(
+    const SolverInterface& solver, bool expect_success = true,
+    double tol = 1E-4,
+    const std::optional<SolverOptions>& options = std::nullopt);
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
This handles the poor scaling in the problem data.

Resolves #15341

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16281)
<!-- Reviewable:end -->
