### PR TITLE
Minor wheel fixes

### DIFF
--- a/tools/wheel/build-wheels
+++ b/tools/wheel/build-wheels
@@ -126,7 +126,7 @@ def create_source_tar(path):
     print('[-] Creating source archive', end='', flush=True)
     for f in sorted(os.listdir(repo_dir)):
         # Exclude build and VCS directories.
-        if f == '.git' or f.startswith('bazel-'):
+        if f == '.git' or f == 'user.bazelrc' or f.startswith('bazel-'):
             continue
 
         print('.', end='', flush=True)

--- a/tools/wheel/test/provision.sh
+++ b/tools/wheel/test/provision.sh
@@ -10,7 +10,7 @@ PYTHON=python${1:-3}
 
 export DEBIAN_FRONTEND=noninteractive
 
-apt-get update
+apt-get -y update
 
 apt-get -y install --no-install-recommends \
     lib${PYTHON}-dev ${PYTHON}-venv \


### PR DESCRIPTION
Don't include `user.bazelrc` in the source tarball used to build wheels; it shouldn't be needed, and its inclusion results in user environment leaking into what is supposed to be a hermetic build environment. Tweak the script used to provision the wheel test containers to use `-y` when running `apt-get update`, for consistency with similar calls in other scripts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16290)
<!-- Reviewable:end -->
