### PR TITLE
Improve documentation for AddMaximizeLogDeterminantSymmetricMatrixCost

### DIFF
--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -1199,9 +1199,12 @@ class MathematicalProgram {
    * log(det(X)) is a concave function of X, so we can maximize it through
    * convex optimization. In order to do that, we introduce slack variables t,
    * and a lower triangular matrix Z, with the constraints
-   * ⌈X         Z⌉ is positive semidifinite.
-   * ⌊Zᵀ  diag(Z)⌋
-   * log(Z(i, i)) >= t(i)
+   *
+   *     ⌈X         Z⌉ is positive semidifinite.
+   *     ⌊Zᵀ  diag(Z)⌋
+   *
+   *     log(Z(i, i)) >= t(i)
+   *
    * and we will minimize -∑ᵢt(i).
    * @param X A symmetric positive semidefinite matrix X, whose log(det(X)) will
    * be maximized.
@@ -1209,6 +1212,8 @@ class MathematicalProgram {
    * @note The constraint log(Z(i, i)) >= t(i) is imposed as an exponential cone
    * constraint. Please make sure your have a solver that supports exponential
    * cone constraint (currently SCS does).
+   * Refer to https://docs.mosek.com/modeling-cookbook/sdo.html#log-determinant
+   * for more details.
    */
   void AddMaximizeLogDeterminantSymmetricMatrixCost(
       const Eigen::Ref<const MatrixX<symbolic::Expression>>& X);


### PR DESCRIPTION
Previously the documentation was
![Screenshot from 2021-12-29 19-39-54](https://user-images.githubusercontent.com/6314000/147719920-aa1cc636-d969-423f-b14f-5ce7cea14bbb.png)

Now it is
![Screenshot from 2021-12-29 19-39-25](https://user-images.githubusercontent.com/6314000/147719938-06149886-b7a0-45f0-b5f2-8ba8b90bdb4e.png)

where the matrix shows up correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16291)
<!-- Reviewable:end -->
