### PR TITLE
Add UpdateCoefficients to (rotated)LorentzConeConstraint

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -1656,7 +1656,10 @@ void BindEvaluatorsAndBindings(py::module m) {
       .def("A", &LorentzConeConstraint::A, doc.LorentzConeConstraint.A.doc)
       .def("b", &LorentzConeConstraint::b, doc.LorentzConeConstraint.b.doc)
       .def("eval_type", &LorentzConeConstraint::eval_type,
-          doc.LorentzConeConstraint.eval_type.doc);
+          doc.LorentzConeConstraint.eval_type.doc)
+      .def("UpdateCoefficients", &LorentzConeConstraint::UpdateCoefficients,
+          py::arg("new_A"), py::arg("new_b"),
+          doc.LorentzConeConstraint.UpdateCoefficients.doc);
 
   py::class_<RotatedLorentzConeConstraint, Constraint,
       std::shared_ptr<RotatedLorentzConeConstraint>>(
@@ -1668,7 +1671,11 @@ void BindEvaluatorsAndBindings(py::module m) {
       .def("A", &RotatedLorentzConeConstraint::A,
           doc.RotatedLorentzConeConstraint.A.doc)
       .def("b", &RotatedLorentzConeConstraint::b,
-          doc.RotatedLorentzConeConstraint.b.doc);
+          doc.RotatedLorentzConeConstraint.b.doc)
+      .def("UpdateCoefficients",
+          &RotatedLorentzConeConstraint::UpdateCoefficients, py::arg("new_A"),
+          py::arg("new_b"),
+          doc.RotatedLorentzConeConstraint.UpdateCoefficients.doc);
 
   py::class_<LinearEqualityConstraint, LinearConstraint,
       std::shared_ptr<LinearEqualityConstraint>>(

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -1119,6 +1119,9 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertEqual(
             constraint.eval_type(),
             mp.LorentzConeConstraint.EvalType.kConvexSmooth)
+        constraint.UpdateCoefficients(new_A=2 * A, new_b=3 * b)
+        np.testing.assert_array_equal(constraint.A().todense(), 2 * A)
+        np.testing.assert_array_equal(constraint.b(), 3 * b)
 
     def test_add_lorentz_cone_constraint(self):
         # Call AddLorentzConeConstraint, make sure no error is thrown.
@@ -1148,6 +1151,9 @@ class TestMathematicalProgram(unittest.TestCase):
         constraint = mp.RotatedLorentzConeConstraint(A=A, b=b)
         np.testing.assert_array_equal(constraint.A().todense(), A)
         np.testing.assert_array_equal(constraint.b(), b)
+        constraint.UpdateCoefficients(new_A=2 * A, new_b=3 * b)
+        np.testing.assert_array_equal(constraint.A().todense(), 2 * A)
+        np.testing.assert_array_equal(constraint.b(), 3 * b)
 
     def test_add_rotated_lorentz_cone_constraint(self):
         prog = mp.MathematicalProgram()

--- a/solvers/constraint.h
+++ b/solvers/constraint.h
@@ -335,6 +335,16 @@ class LorentzConeConstraint : public Constraint {
   /** Getter for eval type. */
   EvalType eval_type() const { return eval_type_; }
 
+  /**
+   * Updates the coefficients, the updated constraint is z=new_A * x + new_b in
+   * the Lorentz cone.
+   * @throws std::exception if the new_A.cols() != A.cols(), namely the variable
+   * size should not change.
+   * @pre `new_A` has to have at least 2 rows and new_A.rows() == new_b.rows().
+   */
+  void UpdateCoefficients(const Eigen::Ref<const Eigen::MatrixXd>& new_A,
+                          const Eigen::Ref<const Eigen::VectorXd>& new_b);
+
  private:
   template <typename DerivedX, typename ScalarY>
   void DoEvalGeneric(const Eigen::MatrixBase<DerivedX>& x,
@@ -352,11 +362,11 @@ class LorentzConeConstraint : public Constraint {
   std::ostream& DoDisplay(std::ostream&,
                           const VectorX<symbolic::Variable>&) const override;
 
-  const Eigen::SparseMatrix<double> A_;
+  Eigen::SparseMatrix<double> A_;
   // We need to store a dense matrix of A_, so that we can compute the gradient
   // using AutoDiffXd, and return the gradient as a dense matrix.
-  const Eigen::MatrixXd A_dense_;
-  const Eigen::VectorXd b_;
+  Eigen::MatrixXd A_dense_;
+  Eigen::VectorXd b_;
   const EvalType eval_type_;
 };
 
@@ -407,6 +417,16 @@ class RotatedLorentzConeConstraint : public Constraint {
 
   ~RotatedLorentzConeConstraint() override {}
 
+  /**
+   * Updates the coefficients, the updated constraint is z=new_A * x + new_b in
+   * the rotated Lorentz cone.
+   * @throw std::exception if the new_A.cols() != A.cols(), namely the variable
+   * size should not change.
+   * @pre new_A.rows() >= 3 and new_A.rows() == new_b.rows().
+   */
+  void UpdateCoefficients(const Eigen::Ref<const Eigen::MatrixXd>& new_A,
+                          const Eigen::Ref<const Eigen::VectorXd>& new_b);
+
  private:
   template <typename DerivedX, typename ScalarY>
   void DoEvalGeneric(const Eigen::MatrixBase<DerivedX>& x,
@@ -424,11 +444,11 @@ class RotatedLorentzConeConstraint : public Constraint {
   std::ostream& DoDisplay(std::ostream&,
                           const VectorX<symbolic::Variable>&) const override;
 
-  const Eigen::SparseMatrix<double> A_;
+  Eigen::SparseMatrix<double> A_;
   // We need to store a dense matrix of A_, so that we can compute the gradient
   // using AutoDiffXd, and return the gradient as a dense matrix.
-  const Eigen::MatrixXd A_dense_;
-  const Eigen::VectorXd b_;
+  Eigen::MatrixXd A_dense_;
+  Eigen::VectorXd b_;
 };
 
 /**


### PR DESCRIPTION
I don't remember why I made `A, b` as constant data inside LorentzConeConstraint and RotatedLorentzConeConstraint. Now I don't see a problem of updating their values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16297)
<!-- Reviewable:end -->
