### PR TITLE
Update Ubuntu codename to match release

### DIFF
--- a/tools/release_engineering/relnotes.py
+++ b/tools/release_engineering/relnotes.py
@@ -4,7 +4,7 @@ adding commit messages' content into a structured document template.
 This program is intended only for use by Drake maintainers who are preparing
 Drake's release notes documentation.
 
-This program is supported only on Ubuntu Bionic 20.04.
+This program is supported only on Ubuntu Focal 20.04.
 
 The usage of this tool is outlined in the Drake release playbook
 document:

--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -1,7 +1,7 @@
 """Reports on which of Drake's external dependencies can be updated to a more
 recent version.  This is intended for use by Drake maintainers (only).
 
-This program is only supported on Ubuntu Bionic 20.04.
+This program is only supported on Ubuntu Focal 20.04.
 
 To query GitHub APIs, you'll need to authenticate yourself first.  There are
 two ways to do this:


### PR DESCRIPTION
#16133 updated the Ubuntu release number but not the code name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16305)
<!-- Reviewable:end -->
