### PR TITLE
[fem] Integrate PETSc matrix with FemSolver

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -231,6 +231,7 @@ drake_cc_library(
     ],
     deps = [
         ":fem_indexes",
+        ":petsc_symmetric_block_sparse_matrix",
         "//common:essential",
     ],
 )

--- a/multibody/fixed_fem/dev/fem_model_base.cc
+++ b/multibody/fixed_fem/dev/fem_model_base.cc
@@ -15,7 +15,7 @@ void FemModelBase<T>::CalcResidual(const FemStateBase<T>& state,
   ThrowIfModelStateIncompatible(__func__, state);
   DoCalcResidual(state, residual);
   if (dirichlet_bc_ != nullptr) {
-    dirichlet_bc_->ApplyBcToResidual(residual);
+    dirichlet_bc_->ApplyBoundaryConditionToResidual(residual);
   }
 }
 
@@ -29,7 +29,7 @@ void FemModelBase<T>::CalcTangentMatrix(
   ThrowIfModelStateIncompatible(__func__, state);
   DoCalcTangentMatrix(state, tangent_matrix);
   if (dirichlet_bc_ != nullptr) {
-    dirichlet_bc_->ApplyBcToTangentMatrix(tangent_matrix);
+    dirichlet_bc_->ApplyBoundaryConditionToTangentMatrix(tangent_matrix);
   }
 }
 
@@ -42,7 +42,9 @@ void FemModelBase<T>::CalcTangentMatrix(
   DRAKE_DEMAND(tangent_matrix->cols() == num_dofs());
   ThrowIfModelStateIncompatible(__func__, state);
   DoCalcTangentMatrix(state, tangent_matrix);
-  // TODO(xuchenhan-tri): Apply boundary condition to the tangent matrix.
+  if (dirichlet_bc_ != nullptr) {
+    dirichlet_bc_->ApplyBoundaryConditionToTangentMatrix(tangent_matrix);
+  }
 }
 
 template <typename T>

--- a/multibody/fixed_fem/dev/petsc_symmetric_block_sparse_matrix.cc
+++ b/multibody/fixed_fem/dev/petsc_symmetric_block_sparse_matrix.cc
@@ -210,7 +210,7 @@ class PetscSymmetricBlockSparseMatrix::Impl {
                        PETSC_NULL, PETSC_NULL);
   }
 
-  void SetRelativeTolerance(double tolerance) {
+  void set_relative_tolerance(double tolerance) {
     KSPSetTolerances(owned_solver_, tolerance, PETSC_DEFAULT, PETSC_DEFAULT,
                      PETSC_DEFAULT);
   }
@@ -378,8 +378,8 @@ void PetscSymmetricBlockSparseMatrix::ZeroRowsAndColumns(
   pimpl_->ZeroRowsAndColumns(indexes, value);
 }
 
-void PetscSymmetricBlockSparseMatrix::SetRelativeTolerance(double tolerance) {
-  pimpl_->SetRelativeTolerance(tolerance);
+void PetscSymmetricBlockSparseMatrix::set_relative_tolerance(double tolerance) {
+  pimpl_->set_relative_tolerance(tolerance);
 }
 
 SchurComplement<double> PetscSymmetricBlockSparseMatrix::CalcSchurComplement(

--- a/multibody/fixed_fem/dev/petsc_symmetric_block_sparse_matrix.h
+++ b/multibody/fixed_fem/dev/petsc_symmetric_block_sparse_matrix.h
@@ -131,7 +131,7 @@ class PetscSymmetricBlockSparseMatrix {
    other tolerance parameters (e.g. absolute tolerance, maximum number of
    iterations, etc) are set to the default value specified in the PETSc
    documentaion. */
-  void SetRelativeTolerance(double tolerance);
+  void set_relative_tolerance(double tolerance);
 
   /* Given a linear system of equations Mz = c that can be written in block form
   as:


### PR DESCRIPTION
This PR contains two commits:

Commit 1: Apply Dirichlet boundary conditions to tangent matrices in PETSc format.
Commit 2: Build and solve tangent matrices in PETSc format in FemSolver when the scalar type is `double`. Fall back to the slow `Eigen::SparseMatrix` tangent matrix for other scalar types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16306)
<!-- Reviewable:end -->
