### PR TITLE
Add wheels for Focal (Python 3.8 and 3.9)

### DIFF
--- a/tools/wheel/Dockerfile
+++ b/tools/wheel/Dockerfile
@@ -8,6 +8,7 @@ FROM ${PLATFORM} AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+ADD image/packages-* /image/
 ADD image/provision-base.sh /image/
 ADD image/known_hosts /root/.ssh/
 

--- a/tools/wheel/build-wheels
+++ b/tools/wheel/build-wheels
@@ -35,7 +35,12 @@ targets = (
     Target('36', 'ubuntu', '18.04', 'bionic'),
     Target('37', 'ubuntu', '18.04', 'bionic'),
     Target('38', 'ubuntu', '18.04', 'bionic'),
+    Target('39', 'ubuntu', '20.04', 'focal'),
 )
+glibc_versions = {
+    'bionic': '2_27',
+    'focal': '2_31',
+}
 
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -216,11 +221,12 @@ def test_wheel(target, options):
     Runs the test script for the wheel matching the specified target.
     """
     vm = f'cp{target.python_version}'
+    glibc = glibc_versions[target.platform_alias]
     if target.python_version < '38':
         abi = f'{vm}m'
     else:
         abi = f'{vm}'
-    wheel = f'drake-{options.version}-{vm}-{abi}-manylinux_2_27_x86_64.whl'
+    wheel = f'drake-{options.version}-{vm}-{abi}-manylinux_{glibc}_x86_64.whl'
 
     platform = target.platform_alias
     container = f'{tag_base}:test-{platform}-py{target.python_version}'

--- a/tools/wheel/image/packages-bionic
+++ b/tools/wheel/image/packages-bionic
@@ -1,0 +1,38 @@
+# JDK (for Bazel).
+default-jdk
+# GNU autotools.
+autoconf
+automake
+libtool
+libltdl-dev
+# Core compilers.
+gcc
+g++
+gfortran
+libgfortran-7-dev
+yasm
+# Clang (for clang-format).
+libclang-9-dev
+clang-format-9
+# Other code tools.
+git
+cmake
+make
+ninja-build
+pkg-config
+# Other general tools.
+file
+patch
+ssh
+wget
+unzip
+zip
+
+# Build dependencies (general).
+libgl1-mesa-dev
+libglib2.0-dev
+libnlopt-dev
+libxt-dev
+# Build dependencies (OpenCL).
+opencl-headers
+ocl-icd-opencl-dev

--- a/tools/wheel/image/packages-focal
+++ b/tools/wheel/image/packages-focal
@@ -1,0 +1,39 @@
+# JDK (for Bazel).
+default-jdk
+# GNU autotools.
+autoconf
+automake
+libtool
+libltdl-dev
+# Core compilers.
+gcc
+g++
+gfortran
+libgfortran-7-dev
+yasm
+# Clang (for clang-format).
+libclang-9-dev
+clang-format-9
+# Other code tools.
+git
+cmake
+make
+ninja-build
+pkg-config
+# Other general tools.
+file
+patch
+ssh
+wget
+unzip
+zip
+
+# Build dependencies (general).
+libgl1-mesa-dev
+libglib2.0-dev
+libnlopt-dev
+libnlopt-cxx-dev
+libxt-dev
+# Build dependencies (OpenCL).
+opencl-headers
+ocl-icd-opencl-dev

--- a/tools/wheel/image/provision-base.sh
+++ b/tools/wheel/image/provision-base.sh
@@ -5,26 +5,23 @@ set -eu -o pipefail
 readonly BAZEL_VERSION=4.2.1
 readonly BAZEL_ROOT=https://github.com/bazelbuild/bazel/releases/download
 
+
 # Fix ssh permissions.
 chmod 700 ~/.ssh
 chmod 600 ~/.ssh/known_hosts
 
-# Install prerequisites.
+# Prepare system to install packages, and apply any updates.
 apt-get -y update
 apt-get -y upgrade
 
-apt-get -y install --no-install-recommends \
-    default-jdk \
-    autoconf automake libtool libltdl-dev \
-    gcc g++ gfortran libgfortran-7-dev \
-    libclang-9-dev clang-format-9 \
-    git cmake ninja-build pkg-config \
-    yasm file wget unzip zip ssh
+apt-get -y install lsb-release
 
-apt-get -y install --no-install-recommends \
-    libglib2.0-dev libnlopt-dev \
-    libgl1-mesa-dev libxt-dev \
-    opencl-headers ocl-icd-opencl-dev
+# Install prerequisites.
+readonly DISTRO=$(lsb_release -sc)
+
+mapfile -t PACKAGES < <(sed -e '/^#/d' < /image/packages-${DISTRO})
+
+apt-get -y install --no-install-recommends ${PACKAGES[@]}
 
 # Install Bazel.
 cd /tmp

--- a/tools/workspace/nlopt/repository.bzl
+++ b/tools/workspace/nlopt/repository.bzl
@@ -18,13 +18,8 @@ def _impl(repository_ctx):
             "/usr/local/opt/nlopt/include/nlopt.hpp",
             "include/nlopt.hpp",
         )
-    elif os_result.is_ubuntu:
+    elif os_result.is_ubuntu or os_result.is_manylinux:
         build_flavor = "ubuntu-{}".format(os_result.ubuntu_release)
-        repository_ctx.symlink("/usr/include/nlopt.h", "include/nlopt.h")
-        repository_ctx.symlink("/usr/include/nlopt.hpp", "include/nlopt.hpp")
-    elif os_result.is_manylinux:
-        # We expect that "manylinux" is based on Ubuntu 18.04.
-        build_flavor = "ubuntu-18.04"
         repository_ctx.symlink("/usr/include/nlopt.h", "include/nlopt.h")
         repository_ctx.symlink("/usr/include/nlopt.hpp", "include/nlopt.hpp")
     else:


### PR DESCRIPTION
Refactor wheel provisioning to allow for different packages between Bionic and Focal. Update build script to add new targets for Focal, and to account for additional changes in the wheel name.

Refactor OS detection so that "manylinux" is a subset of "ubuntu". Particularly, this means that `is_ubuntu` is true if `is_manylinux` is true, and that `ubuntu_release` is set.

Tweak logic in various packages to account for this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16308)
<!-- Reviewable:end -->
