### PR TITLE
[fem] Use PETSc matrix in DeformableRigidManager

### DIFF
--- a/multibody/fixed_fem/dev/fem_model.h
+++ b/multibody/fixed_fem/dev/fem_model.h
@@ -226,6 +226,7 @@ class FemModel : public FemModelBase<typename Element::Traits::T> {
         }
         tangent_matrix->AddToBlock(block_indices, element_tangent_matrix);
       }
+      tangent_matrix->AssembleIfNecessary();
     }
   }
 
@@ -311,6 +312,7 @@ class FemModel : public FemModelBase<typename Element::Traits::T> {
       }
       tangent_matrix->AddToBlock(block_indices, zero_matrix);
     }
+    tangent_matrix->AssembleIfNecessary();
     return tangent_matrix;
   }
 


### PR DESCRIPTION
This is the last PR to integrate PETSc into the deformable solver. In `double` calculations, the tangent matrix now uses PETSc symmetric block sparse matrix instead of Eigen::SparseMatrix.

Run `bazel run //multibody/fixed_fem/dev:run_cantilever_beam` and compare with base line commit `d0db6f` to observe the performance improvement. On my P53 laptop, the speedup is about 2X.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16311)
<!-- Reviewable:end -->
