### PR TITLE
[fixed_fem] Disable deformable_rigid_manager_test under ubsan

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -734,6 +734,8 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "deformable_rigid_manager_test",
+    # TODO(xuchenhan-tri) Re-enable once this test passes for UBSan.
+    tags = ["no_ubsan"],
     deps = [
         ":deformable_rigid_manager",
         "//common/test_utilities:eigen_matrix_compare",


### PR DESCRIPTION
Original error reproducible locally on Ubuntu Focal:
```
export CC=clang-9 CXX=clang++-9
bazel test --config=ubsan //multibody/fixed_fem/dev:deformable_rigid_manager_test
```

Context (Slack): https://drakedevelopers.slack.com/archives/C270MN28G/p1641479669001500

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16321)
<!-- Reviewable:end -->
