### PR TITLE
[multibody] HydroelasticEngine ignores hydroelastic_modulus of rigid geometries.

### DIFF
--- a/multibody/hydroelastics/hydroelastic_engine.cc
+++ b/multibody/hydroelastics/hydroelastic_engine.cc
@@ -31,11 +31,23 @@ MaterialProperties GetMaterials(GeometryId id,
   MaterialProperties material;
   if (const ProximityProperties* properties =
           inspector.GetProximityProperties(id)) {
-    material.hydroelastic_modulus = properties->GetPropertyOrDefault(
-        geometry::internal::kHydroGroup, geometry::internal::kElastic, kInf);
+    // If the geometry is defined to be rigid, force an elastic modulus of
+    // infinity.
+    if (properties->GetPropertyOrDefault(
+            geometry::internal::kHydroGroup,
+            geometry::internal::kComplianceType,
+            geometry::internal::HydroelasticType::kUndefined) ==
+        geometry::internal::HydroelasticType::kRigid) {
+      material.hydroelastic_modulus = kInf;
+    } else {
+      material.hydroelastic_modulus = properties->GetPropertyOrDefault(
+          geometry::internal::kHydroGroup, geometry::internal::kElastic, kInf);
+    }
+
     material.dissipation = properties->GetPropertyOrDefault(
         geometry::internal::kMaterialGroup, geometry::internal::kHcDissipation,
         0.0);
+
     DRAKE_DEMAND(material.hydroelastic_modulus > 0);
     DRAKE_DEMAND(material.dissipation >= 0);
   } else {

--- a/multibody/parsing/detail_common.cc
+++ b/multibody/parsing/detail_common.cc
@@ -50,7 +50,14 @@ geometry::ProximityProperties ParseProximityProperties(
     }
   }
   if (hydroelastic_modulus) {
-    properties.AddProperty(kHydroGroup, kElastic, *hydroelastic_modulus);
+    if (is_rigid) {
+      static const logging::Warn log_once(
+        "Rigid geometries defined with the tag drake:rigid_hydroelastic should"
+        " not contain the tag drake:hydroelastic_modulus. Any values will be"
+        " ignored.");
+    } else {
+      properties.AddProperty(kHydroGroup, kElastic, *hydroelastic_modulus);
+    }
   }
 
   std::optional<double> dissipation =


### PR DESCRIPTION
Related to #15796

- Make `HydroelasticEngine` ignore the `hydroelastic_modulus` property on geometries declared "rigid"
- Add a warning to the parser when the `drake:hydroelastic_modulus` tag is present in a geometry declared "rigid"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16322)
<!-- Reviewable:end -->
