### PR TITLE
Add L1NormCost and LInfNormCost to GraphOfConvexSets cost options

### DIFF
--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -62,10 +62,30 @@ class TestCost(unittest.TestCase):
         cost = mp.QuadraticCost(np.array([[1., 2.], [2., 6.]]), b, c)
         self.assertTrue(cost.is_convex())
 
+    def test_l1norm_cost(self):
+        A = np.array([[1., 2.], [-.4, .7]])
+        b = np.array([0.5, -.4])
+        cost = mp.L1NormCost(A=A, b=b)
+        np.testing.assert_allclose(cost.A(), A)
+        np.testing.assert_allclose(cost.b(), b)
+        cost.UpdateCoefficients(new_A=2*A, new_b=2*b)
+        np.testing.assert_allclose(cost.A(), 2*A)
+        np.testing.assert_allclose(cost.b(), 2*b)
+
     def test_l2norm_cost(self):
         A = np.array([[1., 2.], [-.4, .7]])
         b = np.array([0.5, -.4])
         cost = mp.L2NormCost(A=A, b=b)
+        np.testing.assert_allclose(cost.A(), A)
+        np.testing.assert_allclose(cost.b(), b)
+        cost.UpdateCoefficients(new_A=2*A, new_b=2*b)
+        np.testing.assert_allclose(cost.A(), 2*A)
+        np.testing.assert_allclose(cost.b(), 2*b)
+
+    def test_linfnorm_cost(self):
+        A = np.array([[1., 2.], [-.4, .7]])
+        b = np.array([0.5, -.4])
+        cost = mp.LInfNormCost(A=A, b=b)
         np.testing.assert_allclose(cost.A(), A)
         np.testing.assert_allclose(cost.b(), b)
         cost.UpdateCoefficients(new_A=2*A, new_b=2*b)
@@ -1406,7 +1426,9 @@ class TestMathematicalProgram(unittest.TestCase):
             mp.Cost,
             mp.LinearCost,
             mp.QuadraticCost,
+            mp.L1NormCost,
             mp.L2NormCost,
+            mp.LInfNormCost,
             mp.VisualizationCallback,
         ]
         for cls in cls_list:

--- a/solvers/cost.h
+++ b/solvers/cost.h
@@ -231,7 +231,58 @@ std::shared_ptr<QuadraticCost> Make2NormSquaredCost(
     const Eigen::Ref<const Eigen::VectorXd>& b);
 
 /**
- * Implements a cost of the form @f[ |Ax + b|₂ @f].
+ * Implements a cost of the form ‖Ax + b‖₁. Note that this cost is
+ * non-differentiable when any element of Ax + b equals zero.
+ *
+ * @ingroup solver_evaluators
+ */
+class L1NormCost : public Cost {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(L1NormCost)
+
+  /**
+   * Construct a cost of the form ‖Ax + b‖₁.
+   * @param A Linear term.
+   * @param b Constant term.
+   */
+  L1NormCost(const Eigen::Ref<const Eigen::MatrixXd>& A,
+             const Eigen::Ref<const Eigen::VectorXd>& b);
+
+  ~L1NormCost() override {}
+
+  const Eigen::MatrixXd& A() const { return A_; }
+
+  const Eigen::VectorXd& b() const { return b_; }
+
+  /**
+   * Updates the coefficients of the cost.
+   * Note that the number of variables (columns of A) cannot change.
+   * @param new_A New linear term.
+   * @param new_b New constant term.
+   */
+  void UpdateCoefficients(const Eigen::Ref<const Eigen::MatrixXd>& new_A,
+                          const Eigen::Ref<const Eigen::VectorXd>& new_b);
+
+ protected:
+  void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+              Eigen::VectorXd* y) const override;
+
+  void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+              AutoDiffVecXd* y) const override;
+
+  void DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>& x,
+              VectorX<symbolic::Expression>* y) const override;
+
+  std::ostream& DoDisplay(std::ostream&,
+                          const VectorX<symbolic::Variable>&) const override;
+
+ private:
+  Eigen::MatrixXd A_;
+  Eigen::VectorXd b_;
+};
+
+/**
+ * Implements a cost of the form ‖Ax + b‖₂.
  *
  * @ingroup solver_evaluators
  */
@@ -242,7 +293,7 @@ class L2NormCost : public Cost {
   // TODO(russt): Add an option to select an implementation that smooths the
   // gradient discontinuity at the origin.
   /**
-   * Construct a cost of the form @f[ |Ax + b|₂ @f].
+   * Construct a cost of the form ‖Ax + b‖₂.
    * @param A Linear term.
    * @param b Constant term.
    */
@@ -282,6 +333,56 @@ class L2NormCost : public Cost {
   Eigen::VectorXd b_;
 };
 
+/**
+ * Implements a cost of the form ‖Ax + b‖∞. Note that this cost is
+ * non-differentiable when any two or more elements of Ax + b are equal.
+ *
+ * @ingroup solver_evaluators
+ */
+class LInfNormCost : public Cost {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LInfNormCost)
+
+  /**
+   * Construct a cost of the form ‖Ax + b‖∞.
+   * @param A Linear term.
+   * @param b Constant term.
+   */
+  LInfNormCost(const Eigen::Ref<const Eigen::MatrixXd>& A,
+               const Eigen::Ref<const Eigen::VectorXd>& b);
+
+  ~LInfNormCost() override {}
+
+  const Eigen::MatrixXd& A() const { return A_; }
+
+  const Eigen::VectorXd& b() const { return b_; }
+
+  /**
+   * Updates the coefficients of the cost.
+   * Note that the number of variables (columns of A) cannot change.
+   * @param new_A New linear term.
+   * @param new_b New constant term.
+   */
+  void UpdateCoefficients(const Eigen::Ref<const Eigen::MatrixXd>& new_A,
+                          const Eigen::Ref<const Eigen::VectorXd>& new_b);
+
+ protected:
+  void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+              Eigen::VectorXd* y) const override;
+
+  void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+              AutoDiffVecXd* y) const override;
+
+  void DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>& x,
+              VectorX<symbolic::Expression>* y) const override;
+
+  std::ostream& DoDisplay(std::ostream&,
+                          const VectorX<symbolic::Variable>&) const override;
+
+ private:
+  Eigen::MatrixXd A_;
+  Eigen::VectorXd b_;
+};
 
 /**
  * A cost that may be specified using another (potentially nonlinear)

--- a/solvers/test/cost_test.cc
+++ b/solvers/test/cost_test.cc
@@ -361,6 +361,75 @@ GTEST_TEST(testCost, testFunctionCost) {
   VerifyFunctionCost(make_unique<GenericTrivialCost2>(), x);
 }
 
+GTEST_TEST(TestL1NormCost, Eval) {
+  Matrix<double, 2, 4> A;
+  // clang-format off
+  A << .32,  2.0, 1.3, -4.,
+       2.3, -2.0, 7.1, 1.3;
+  // clang-format on
+  const Vector2d b{.42, -3.2};
+
+  L1NormCost cost(A, b);
+  EXPECT_TRUE(CompareMatrices(A, cost.A()));
+  EXPECT_TRUE(CompareMatrices(b, cost.b()));
+
+  const Vector4d x0{5.2, 3.4, -1.3, 2.1};
+  const Vector2d z = A * x0 + b;
+
+  // Test double.
+  {
+    VectorXd y;
+    cost.Eval(x0, &y);
+    EXPECT_NEAR(z.cwiseAbs().sum(), y[0], 1e-15);
+  }
+
+  // Test AutoDiffXd.
+  {
+    const Vector4<AutoDiffXd> x = math::InitializeAutoDiff(x0);
+    VectorX<AutoDiffXd> y;
+    cost.Eval(x, &y);
+    EXPECT_NEAR(z.cwiseAbs().sum(), math::ExtractValue(y)[0], 1e-16);
+    const Matrix<double, 1, 4> grad_expected =
+        z.cwiseQuotient(z.cwiseAbs()).transpose() * A;
+    EXPECT_TRUE(
+        CompareMatrices(math::ExtractGradient(y), grad_expected, 1e-15));
+  }
+
+  // Test Symbolic.
+  {
+    auto x = symbolic::MakeVectorVariable(4, "x");
+    VectorX<Expression> y;
+    cost.Eval(x, &y);
+    symbolic::Environment env;
+    env.insert(x, x0);
+    EXPECT_NEAR(z.cwiseAbs().sum(), y[0].Evaluate(env), 1e-15);
+  }
+}
+
+GTEST_TEST(TestL1NormCost, UpdateCoefficients) {
+  L1NormCost cost(Matrix2d::Identity(), Vector2d::Zero());
+
+  cost.UpdateCoefficients(Matrix<double, 4, 2>::Identity(), Vector4d::Zero());
+  EXPECT_EQ(cost.A().rows(), 4);
+  EXPECT_EQ(cost.b().rows(), 4);
+
+  // Can't change the number of variables.
+  EXPECT_THROW(cost.UpdateCoefficients(Matrix3d::Identity(), Vector3d::Zero()),
+               std::exception);
+
+  // A and b must have the same number of rows.
+  EXPECT_THROW(cost.UpdateCoefficients(Matrix3d::Identity(), Vector4d::Zero()),
+               std::exception);
+}
+
+GTEST_TEST(TestL1NormCost, Display) {
+  L1NormCost cost(Matrix2d::Identity(), Vector2d::Ones());
+  std::ostringstream os;
+  cost.Display(os, symbolic::MakeVectorContinuousVariable(2, "x"));
+  EXPECT_EQ(fmt::format("{}", os.str()),
+            "L1NormCost (abs((1 + x(0))) + abs((1 + x(1))))");
+}
+
 GTEST_TEST(TestL2NormCost, Eval) {
   Matrix<double, 2, 4> A;
   // clang-format off
@@ -430,6 +499,77 @@ GTEST_TEST(TestL2NormCost, Display) {
   cost.Display(os, symbolic::MakeVectorContinuousVariable(2, "x"));
   EXPECT_EQ(fmt::format("{}", os.str()),
             "L2NormCost sqrt((pow((1 + x(0)), 2) + pow((1 + x(1)), 2)))");
+}
+
+GTEST_TEST(TestLInfNormCost, Eval) {
+  Matrix<double, 2, 4> A;
+  // clang-format off
+  A << .32,  2.0, 1.3, -4.,
+       2.3, -2.0, 7.1, 1.3;
+  // clang-format on
+  const Vector2d b{.42, -3.2};
+
+  LInfNormCost cost(A, b);
+  EXPECT_TRUE(CompareMatrices(A, cost.A()));
+  EXPECT_TRUE(CompareMatrices(b, cost.b()));
+
+  const Vector4d x0{5.2, 3.4, -1.3, 2.1};
+  const Vector2d z = A * x0 + b;
+
+  // Test double.
+  {
+    VectorXd y;
+    cost.Eval(x0, &y);
+    EXPECT_NEAR(z.cwiseAbs().maxCoeff(), y[0], 1e-16);
+  }
+
+  // Test AutoDiffXd.
+  {
+    const Vector4<AutoDiffXd> x = math::InitializeAutoDiff(x0);
+    VectorX<AutoDiffXd> y;
+    cost.Eval(x, &y);
+    int max_row;
+    EXPECT_NEAR(z.cwiseAbs().maxCoeff(&max_row), math::ExtractValue(y)[0],
+                1e-16);
+    const Matrix<double, 1, 4> grad_expected =
+        (z.cwiseQuotient(z.cwiseAbs()))(max_row)*A.row(max_row);
+    EXPECT_TRUE(
+        CompareMatrices(math::ExtractGradient(y), grad_expected, 1e-15));
+  }
+
+  // Test Symbolic.
+  {
+    auto x = symbolic::MakeVectorVariable(4, "x");
+    VectorX<Expression> y;
+    cost.Eval(x, &y);
+    symbolic::Environment env;
+    env.insert(x, x0);
+    EXPECT_NEAR(z.cwiseAbs().maxCoeff(), y[0].Evaluate(env), 1e-15);
+  }
+}
+
+GTEST_TEST(TestLInfNormCost, UpdateCoefficients) {
+  LInfNormCost cost(Matrix2d::Identity(), Vector2d::Zero());
+
+  cost.UpdateCoefficients(Matrix<double, 4, 2>::Identity(), Vector4d::Zero());
+  EXPECT_EQ(cost.A().rows(), 4);
+  EXPECT_EQ(cost.b().rows(), 4);
+
+  // Can't change the number of variables.
+  EXPECT_THROW(cost.UpdateCoefficients(Matrix3d::Identity(), Vector3d::Zero()),
+               std::exception);
+
+  // A and b must have the same number of rows.
+  EXPECT_THROW(cost.UpdateCoefficients(Matrix3d::Identity(), Vector4d::Zero()),
+               std::exception);
+}
+
+GTEST_TEST(TestLInfNormCost, Display) {
+  LInfNormCost cost(Matrix2d::Identity(), Vector2d::Ones());
+  std::ostringstream os;
+  cost.Display(os, symbolic::MakeVectorContinuousVariable(2, "x"));
+  EXPECT_EQ(fmt::format("{}", os.str()),
+            "LInfNormCost max(abs((1 + x(0))), abs((1 + x(1))))");
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
Also binds the creation of `Bindings` from a cost/constraint and decision variables to enable adding these costs in Python.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16334)
<!-- Reviewable:end -->
