### PR TITLE
[symbolic] Output symbolic::Expression/Formula as a LaTeX string

### DIFF
--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -13,6 +13,7 @@
 #include "drake/bindings/pydrake/symbolic_py_unapply.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
 #include "drake/common/symbolic_decompose.h"
+#include "drake/common/symbolic_latex.h"
 
 #pragma GCC diagnostic push
 // Apple LLVM version 10.0.1 (clang-1001.0.46.3) and Clang version 7.0.0 add
@@ -850,6 +851,26 @@ PYBIND11_MODULE(symbolic, m) {
         return Jacobian(f, vars);
       },
       py::arg("f"), py::arg("vars"), doc.Jacobian.doc_polynomial);
+
+  m.def("ToLatex",
+      overload_cast_explicit<std::string, const Expression&, int>(&ToLatex),
+      py::arg("e"), py::arg("precision") = 3, doc.ToLatex.doc_expression);
+  m.def("ToLatex",
+      overload_cast_explicit<std::string, const Formula&, int>(&ToLatex),
+      py::arg("f"), py::arg("precision") = 3, doc.ToLatex.doc_formula);
+
+  m.def(
+      "ToLatex",
+      [](const MatrixX<Expression>& M, int precision) {
+        return ToLatex(M, precision);
+      },
+      py::arg("M"), py::arg("precision") = 3, doc.ToLatex.doc_matrix);
+  m.def(
+      "ToLatex",
+      [](const MatrixX<double>& M, int precision) {
+        return ToLatex(M, precision);
+      },
+      py::arg("M"), py::arg("precision") = 3, doc.ToLatex.doc_matrix);
 
   // We have this line because pybind11 does not permit transitive
   // conversions. See

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -53,6 +53,7 @@ drake_cc_package_library(
         ":sorted_pair",
         ":symbolic",
         ":symbolic_decompose",
+        ":symbolic_latex",
         ":temp_directory",
         ":type_safe_index",
         ":unused",
@@ -252,6 +253,19 @@ drake_cc_library(
     ],
     hdrs = [
         "symbolic_decompose.h",
+    ],
+    deps = [
+        ":symbolic",
+    ],
+)
+
+drake_cc_library(
+    name = "symbolic_latex",
+    srcs = [
+        "symbolic_latex.cc",
+    ],
+    hdrs = [
+        "symbolic_latex.h",
     ],
     deps = [
         ":symbolic",
@@ -1155,6 +1169,16 @@ drake_cc_googletest(
         ":symbolic",
         "//common/test_utilities:eigen_matrix_compare",
         "//math:geometric_transform",
+    ],
+)
+
+drake_cc_googletest(
+    name = "symbolic_latex_test",
+    deps = [
+        ":essential",
+        ":symbolic",
+        ":symbolic_latex",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/common/symbolic_latex.cc
+++ b/common/symbolic_latex.cc
@@ -1,0 +1,366 @@
+#include "drake/common/symbolic_latex.h"
+
+#include <sstream>
+#include <stdexcept>
+
+namespace drake {
+namespace symbolic {
+
+using std::ostringstream;
+using std::runtime_error;
+using std::string;
+using std::to_string;
+
+namespace {
+
+// Visitor class for code generation.
+class LatexVisitor {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LatexVisitor)
+
+  explicit LatexVisitor(int precision) : precision_{precision} {};
+
+  // Generates latex expression for the expression @p e.
+  [[nodiscard]] std::string Latex(const Expression& e) const {
+    return VisitExpression<string>(this, e);
+  }
+  [[nodiscard]] std::string Latex(const Formula& f) const {
+    return VisitFormula(f, true);
+  }
+
+ private:
+  [[nodiscard]] std::string VisitVariable(const Expression& e) const {
+    return get_variable(e).to_string();
+  }
+
+  [[nodiscard]] std::string VisitConstant(const Expression& e) const {
+    return ToLatex(get_constant_value(e), precision_);
+  }
+
+  [[nodiscard]] std::string VisitAddition(const Expression& e) const {
+    const double c{get_constant_in_addition(e)};
+    const auto& expr_to_coeff_map{get_expr_to_coeff_map_in_addition(e)};
+    ostringstream oss;
+    bool print_plus{false};
+    oss << "(";
+    if (c != 0.0) {
+      oss << ToLatex(c, precision_);
+      print_plus = true;
+    }
+    for (const auto& [term, coeff] : expr_to_coeff_map) {
+      if (coeff > 0.0) {
+        if (print_plus) {
+          oss << " + ";
+        }
+        // Do not print "1 * t"
+        if (coeff != 1.0) {
+          oss << ToLatex(coeff, precision_);
+        }
+      } else {
+        // Instead of printing "+ (- E)", just print "- E".
+        oss << " - ";
+        if (coeff != -1.0) {
+          oss << ToLatex((-coeff), precision_);
+        }
+      }
+      oss << Latex(term);
+      print_plus = true;
+    }
+    oss << ")";
+    return oss.str();
+  }
+
+  [[nodiscard]] std::string VisitMultiplication(const Expression& e) const {
+    const double c{get_constant_in_multiplication(e)};
+    const auto& base_to_exponent_map{
+        get_base_to_exponent_map_in_multiplication(e)};
+    bool print_space = false;
+    ostringstream oss;
+    if (c != 1.0) {
+      oss << ToLatex(c, precision_);
+      print_space = true;
+    }
+    for (const auto& [e_1, e_2] : base_to_exponent_map) {
+      if (print_space) { oss << " "; }
+      if (is_one(e_2)) {
+        oss << Latex(e_1);
+      } else {
+        oss << Latex(e_1) << "^{" << Latex(e_2) << "}";
+      }
+      print_space = true;
+    }
+    return oss.str();
+  }
+
+  // Helper method to handle unary cases.
+  [[nodiscard]] string VisitUnary(const string& f, const Expression& e) const {
+    return "\\" + f + "{" + Latex(get_argument(e)) + "}";
+  }
+
+  // Helper method to handle binary cases.
+  [[nodiscard]] string VisitBinary(const string& f, const Expression& e) const {
+    return "\\" + f + "\\{" + Latex(get_first_argument(e)) + ", " +
+           Latex(get_second_argument(e)) + "\\}";
+  }
+
+  [[nodiscard]] string VisitPow(const Expression& e) const {
+    return Latex(get_first_argument(e)) + "^{" + Latex(get_second_argument(e)) +
+           "}";
+  }
+
+  [[nodiscard]] string VisitDivision(const Expression& e) const {
+    return "\\frac{" + Latex(get_first_argument(e)) + "}{" +
+           Latex(get_second_argument(e)) + "}";
+  }
+
+  [[nodiscard]] string VisitAbs(const Expression& e) const {
+    return "|" + Latex(get_argument(e)) + "|";
+  }
+
+  [[nodiscard]] string VisitLog(const Expression& e) const {
+    return VisitUnary("log", e);
+  }
+
+  [[nodiscard]] string VisitExp(const Expression& e) const {
+    return "e^{" + Latex(get_argument(e)) + "}";
+  }
+
+  [[nodiscard]] string VisitSqrt(const Expression& e) const {
+    return VisitUnary("sqrt", e);
+  }
+
+  [[nodiscard]] string VisitSin(const Expression& e) const {
+    return VisitUnary("sin", e);
+  }
+
+  [[nodiscard]] string VisitCos(const Expression& e) const {
+    return VisitUnary("cos", e);
+  }
+
+  [[nodiscard]] string VisitTan(const Expression& e) const {
+    return VisitUnary("tan", e);
+  }
+
+  [[nodiscard]] string VisitAsin(const Expression& e) const {
+    return VisitUnary("asin", e);
+  }
+
+  [[nodiscard]] string VisitAcos(const Expression& e) const {
+    return VisitUnary("acos", e);
+  }
+
+  [[nodiscard]] string VisitAtan(const Expression& e) const {
+    return VisitUnary("atan", e);
+  }
+
+  [[nodiscard]] string VisitAtan2(const Expression& e) const {
+    return "\\atan{\\frac{" + Latex(get_first_argument(e)) + "}{" +
+           Latex(get_second_argument(e)) + "}}";
+  }
+
+  [[nodiscard]] string VisitSinh(const Expression& e) const {
+    return VisitUnary("sinh", e);
+  }
+
+  [[nodiscard]] string VisitCosh(const Expression& e) const {
+    return VisitUnary("cosh", e);
+  }
+
+  [[nodiscard]] string VisitTanh(const Expression& e) const {
+    return VisitUnary("tanh", e);
+  }
+
+  [[nodiscard]] string VisitMin(const Expression& e) const {
+    return VisitBinary("min", e);
+  }
+
+  [[nodiscard]] string VisitMax(const Expression& e) const {
+    return VisitBinary("max", e);
+  }
+
+  [[nodiscard]] string VisitCeil(const Expression& e) const {
+    return "\\lceil " + Latex(get_argument(e)) + " \\rceil";
+  }
+
+  [[nodiscard]] string VisitFloor(const Expression& e) const {
+    return "\\lfloor " + Latex(get_argument(e)) + " \\rfloor";
+  }
+
+  [[nodiscard]] string VisitIfThenElse(const Expression& e) const {
+    std::ostringstream oss;
+    oss << "\\begin{cases} ";
+    oss << Latex(get_then_expression(e)) << " & \\text{if } ";
+    oss << Latex(get_conditional_formula(e)) << ", \\\\ ";
+    oss << Latex(get_else_expression(e)) << " & \\text{otherwise}.";
+    oss << "\\end{cases}";
+    return oss.str();
+  }
+
+  [[nodiscard]] string VisitUninterpretedFunction(const Expression&) const {
+    throw runtime_error("ToLatex does not support uninterpreted functions.");
+  }
+
+  // The parameter `polarity` is to indicate whether it processes `f` (if
+  // `polarity` is true) or `¬f` (if `polarity` is false).
+  [[nodiscard]] std::string VisitFormula(const Formula& f,
+                                         const bool polarity = true) const {
+    return symbolic::VisitFormula<std::string>(this, f, polarity);
+  }
+  [[nodiscard]] std::string VisitFalse(const Formula&,
+                                       const bool polarity) const {
+    return polarity ? "\\text{false}" : "\\text{true}";
+  }
+  [[nodiscard]] std::string VisitTrue(const Formula&,
+                                      const bool polarity) const {
+    return polarity ? "\\text{true}" : "\\text{false}";
+  }
+  [[nodiscard]] std::string VisitVariable(const Formula& f,
+                                          const bool polarity) const {
+    return (polarity ? "" : "\\neg") + get_variable(f).to_string();
+  }
+  [[nodiscard]] std::string VisitEqualTo(const Formula& f,
+                                         const bool polarity) const {
+    return Latex(get_lhs_expression(f)) +
+           (polarity ? " = " : " \\neq ") +
+           Latex(get_rhs_expression(f));
+  }
+  [[nodiscard]] std::string VisitNotEqualTo(const Formula& f,
+                                            const bool polarity) const {
+    return Latex(get_lhs_expression(f)) +
+           (polarity ? " \\neq " : " = ") +
+           Latex(get_rhs_expression(f));
+  }
+  [[nodiscard]] std::string VisitGreaterThan(const Formula& f,
+                                             const bool polarity) const {
+    return Latex(get_lhs_expression(f)) +
+           (polarity ? " > " : " \\le ") +
+           Latex(get_rhs_expression(f));
+  }
+  [[nodiscard]] std::string VisitGreaterThanOrEqualTo(
+      const Formula& f, const bool polarity) const {
+    return Latex(get_lhs_expression(f)) +
+           (polarity ? " \\ge " : " < ") +
+           Latex(get_rhs_expression(f));
+  }
+  [[nodiscard]] std::string VisitLessThan(const Formula& f,
+                                          const bool polarity) const {
+    return Latex(get_lhs_expression(f)) +
+           (polarity ? " < " : " \\ge ") +
+           Latex(get_rhs_expression(f));
+  }
+  [[nodiscard]] std::string VisitLessThanOrEqualTo(const Formula& f,
+                                                   const bool polarity) const {
+    return Latex(get_lhs_expression(f)) +
+           (polarity ? " \\le " : " > ") +
+           Latex(get_rhs_expression(f));
+  }
+  [[nodiscard]] std::string VisitConjunction(const Formula& f,
+                                             const bool polarity) const {
+    ostringstream oss;
+    bool print_symbol = false;
+    for (const auto& o : get_operands(f)) {
+      if (print_symbol) {
+        oss << (polarity ? " \\land " : " \\lor ");
+      }
+      oss << VisitFormula(o, polarity);
+      print_symbol = true;
+    }
+    return oss.str();
+  }
+  [[nodiscard]] std::string VisitDisjunction(const Formula& f,
+                                             const bool polarity) const {
+    ostringstream oss;
+    bool print_symbol = false;
+    for (const auto& o : get_operands(f)) {
+      if (print_symbol) {
+        oss << (polarity ? " \\lor " : " \\land ");
+      }
+      oss << VisitFormula(o, polarity);
+      print_symbol = true;
+    }
+    return oss.str();
+  }
+
+  [[nodiscard]] std::string VisitNegation(const Formula& f,
+                                          const bool polarity) const {
+    return VisitFormula(get_operand(f), !polarity);
+  }
+
+  [[nodiscard]] std::string VisitForall(const Formula& f,
+                                        const bool polarity) const {
+    // TODO(russt): The polarity==False case can be further reduced into
+    // ∃v₁...vₙ. (¬f). However, we do not have a representation
+    // FormulaExists(∃) yet. Revisit this when we add FormulaExists.
+    ostringstream oss;
+    if (!polarity) { oss << "\\neg "; }
+    oss << "\\forall " << VisitVariables(get_quantified_variables(f)) << ": "
+        << get_quantified_formula(f);
+    return oss.str();
+  }
+
+  [[nodiscard]] std::string VisitIsnan(const Formula& f,
+                                       const bool polarity) const {
+    ostringstream oss;
+    if (!polarity) { oss << "\\neg "; }
+    oss << "\\text{isnan}(" << Latex(get_unary_expression(f)) << ")";
+    return oss.str();
+  }
+
+  [[nodiscard]] std::string VisitPositiveSemidefinite(
+      const Formula& f, const bool polarity) const {
+    DRAKE_ASSERT(polarity);  // "Not PSD" could be an arbitrary matrix.
+    return ToLatex(get_matrix_in_positive_semidefinite(f), precision_) +
+           " \\succeq 0";
+  }
+
+  // Note: This method is not called directly from VisitExpression; but can be
+  // used by other methods in this class.
+  [[nodiscard]] std::string VisitVariables(const Variables& vars) const {
+    ostringstream oss;
+    bool delimiter = false;
+    for (const auto& v : vars) {
+      if (delimiter) { oss << ", "; }
+      oss << VisitVariable(v);
+      delimiter = true;
+    }
+    return oss.str();
+  }
+
+  // Makes VisitExpression a friend of this class so that it can use private
+  // methods.
+  friend std::string VisitExpression<std::string>(const LatexVisitor*,
+                                                  const Expression&);
+
+  // Makes VisitFormula a friend of this class so that it can use private
+  // methods.
+  friend std::string symbolic::VisitFormula<std::string>(const LatexVisitor*,
+                                                         const Formula&,
+                                                         const bool&);
+
+  int precision_;
+};
+
+}  // namespace
+
+string ToLatex(const Expression& e, int precision) {
+  return LatexVisitor{precision}.Latex(e);
+}
+
+string ToLatex(const Formula& f, int precision) {
+  return LatexVisitor{precision}.Latex(f);
+}
+
+string ToLatex(double val, int precision) {
+  double intpart;
+  if (std::modf(val, &intpart) == 0.0) {
+    // Then it's an integer.
+    return std::to_string(static_cast<int>(val));
+  }
+  std::ostringstream oss;
+  oss.precision(precision);
+  oss << std::fixed << val;
+  return oss.str();
+}
+
+}  // namespace symbolic
+}  // namespace drake

--- a/common/symbolic_latex.h
+++ b/common/symbolic_latex.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <Eigen/Core>
+#include <Eigen/Sparse>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/symbolic.h"
+
+namespace drake {
+namespace symbolic {
+
+/// Generates a LaTeX string representation of `e` with floating point
+/// coefficients displayed using `precision`.
+/// @pydrake_mkdoc_identifier{expression}
+std::string ToLatex(const Expression& e, int precision = 3);
+
+/// Generates a LaTeX string representation of `f` with floating point
+/// coefficients displayed using `precision`.
+/// @pydrake_mkdoc_identifier{formula}
+std::string ToLatex(const Formula& f, int precision = 3);
+
+/// Generates a Latex string representation of `val` displayed with `precision`,
+/// with one exception. If the fractional part of `val` is exactly zero, then
+/// `val` is represented perfectly as an integer, and is displayed without the
+/// trailing decimal point and zeros (in this case, the `precision` argument is
+/// ignored).
+std::string ToLatex(double val, int precision = 3);
+
+/// Generates a LaTeX string representation of `M` with floating point
+/// coefficients displayed using `precision`.
+/// @pydrake_mkdoc_identifier{matrix}
+template <typename Derived>
+std::string ToLatex(const Eigen::PlainObjectBase<Derived>& M,
+                    int precision = 3) {
+  std::ostringstream oss;
+  oss << "\\begin{bmatrix}";
+  for (int i = 0; i < M.rows(); ++i) {
+    for (int j = 0; j < M.cols(); ++j) {
+      oss << " " << ToLatex(M(i, j), precision);
+      if (j < M.cols() - 1) {
+        oss << " &";
+      }
+    }
+    if (i < M.rows() - 1) {
+      oss << " \\\\";
+    }
+  }
+  oss << " \\end{bmatrix}";
+  return oss.str();
+}
+
+}  // namespace symbolic
+}  // namespace drake

--- a/common/test/symbolic_latex_test.cc
+++ b/common/test/symbolic_latex_test.cc
@@ -1,0 +1,105 @@
+#include "drake/common/symbolic_latex.h"
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/symbolic.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace symbolic {
+namespace {
+
+GTEST_TEST(SymbolicLatex, BasicTest) {
+  Variable x{"x"}, y{"y"};
+  Variable b("b", Variable::Type::BOOLEAN);
+
+  // Expressions
+  EXPECT_EQ(ToLatex(x), "x");
+  EXPECT_EQ(ToLatex(1.0), "1");
+  EXPECT_EQ(ToLatex(1.0, 1), "1");
+  EXPECT_EQ(ToLatex(1.01), "1.010");
+  EXPECT_EQ(ToLatex(1.01, 1), "1.0");
+  EXPECT_EQ(ToLatex(x + y), "(x + y)");
+  EXPECT_EQ(ToLatex(x + 2.3), "(2.300 + x)");
+  EXPECT_EQ(ToLatex(x - y), "(x - y)");
+  EXPECT_EQ(ToLatex(x - 2*y), "(x - 2y)");
+  EXPECT_EQ(ToLatex(2 * x + 3 * x + 4 * y), "(5x + 4y)");
+  EXPECT_EQ(ToLatex(2.1 * x + 3.2 * y * y, 1), "(2.1x + 3.2y^{2})");
+  EXPECT_EQ(ToLatex(x * pow(y, 2)), "x y^{2}");
+  EXPECT_EQ(ToLatex(2 * x * y), "2 x y");
+  EXPECT_EQ(ToLatex(pow(x, 3)), "x^{3}");
+  EXPECT_EQ(ToLatex(pow(x, 3.1)), "x^{3.100}");
+  EXPECT_EQ(ToLatex(x / y), R"""(\frac{x}{y})""");
+  EXPECT_EQ(ToLatex(abs(x)), "|x|");
+  EXPECT_EQ(ToLatex(log(x)), R"""(\log{x})""");
+  EXPECT_EQ(ToLatex(exp(x)), "e^{x}");
+  EXPECT_EQ(ToLatex(sqrt(x)), R"""(\sqrt{x})""");
+  EXPECT_EQ(ToLatex(sin(x)), R"""(\sin{x})""");
+  EXPECT_EQ(ToLatex(cos(x)), R"""(\cos{x})""");
+  EXPECT_EQ(ToLatex(tan(x)), R"""(\tan{x})""");
+  EXPECT_EQ(ToLatex(asin(x)), R"""(\asin{x})""");
+  EXPECT_EQ(ToLatex(acos(x)), R"""(\acos{x})""");
+  EXPECT_EQ(ToLatex(atan(x)), R"""(\atan{x})""");
+  EXPECT_EQ(ToLatex(atan2(y, x)), R"""(\atan{\frac{y}{x}})""");
+  EXPECT_EQ(ToLatex(sinh(x)), R"""(\sinh{x})""");
+  EXPECT_EQ(ToLatex(cosh(x)), R"""(\cosh{x})""");
+  EXPECT_EQ(ToLatex(tanh(x)), R"""(\tanh{x})""");
+  EXPECT_EQ(ToLatex(min(x, y)), R"""(\min\{x, y\})""");
+  EXPECT_EQ(ToLatex(max(x, y)), R"""(\max\{x, y\})""");
+  EXPECT_EQ(ToLatex(ceil(x)), R"""(\lceil x \rceil)""");
+  EXPECT_EQ(ToLatex(floor(x)), R"""(\lfloor x \rfloor)""");
+  EXPECT_EQ(ToLatex(if_then_else(x > y, 2 * x, 3)),
+            R"""(\begin{cases} 2 x & \text{if } x > y, \\)"""
+            R"""( 3 & \text{otherwise}.\end{cases})""");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      ToLatex(uninterpreted_function("myfunc", std::vector<Expression>())),
+      "ToLatex does not support uninterpreted functions.");
+
+  // Formulas
+  EXPECT_EQ(ToLatex(Formula::False()), R"""(\text{false})""");
+  EXPECT_EQ(ToLatex(Formula::True()), R"""(\text{true})""");
+  EXPECT_EQ(ToLatex(Formula(b)), "b");
+  EXPECT_EQ(ToLatex(x == y), R"""(x = y)""");
+  EXPECT_EQ(ToLatex(2.5 * x == y, 2), R"""(2.50 x = y)""");
+  EXPECT_EQ(ToLatex(2 * x != y), R"""(2 x \neq y)""");
+  EXPECT_EQ(ToLatex(2 * x > y), R"""(2 x > y)""");
+  EXPECT_EQ(ToLatex(2 * x >= y), R"""(2 x \ge y)""");
+  EXPECT_EQ(ToLatex(2 * x < y), R"""(2 x < y)""");
+  EXPECT_EQ(ToLatex(2 * x <= y), R"""(2 x \le y)""");
+  EXPECT_EQ(ToLatex(x == y && x * y > x), R"""(x = y \land x y > x)""");
+  EXPECT_EQ(ToLatex(!(x == y && x * y > x)), R"""(x \neq y \lor x y \le x)""");
+  EXPECT_EQ(ToLatex(x == y || x * y < x), R"""(x = y \lor x y < x)""");
+  EXPECT_EQ(ToLatex(!(x == y || x * y < x)), R"""(x \neq y \land x y \ge x)""");
+  EXPECT_EQ(ToLatex(!(x == y)), R"""(x \neq y)""");
+  EXPECT_EQ(ToLatex(forall({x, y}, x > y)), R"""(\forall x, y: (x > y))""");
+  EXPECT_EQ(ToLatex(isnan(x)), R"""(\text{isnan}(x))""");
+  EXPECT_EQ(ToLatex(!isnan(x)), R"""(\neg \text{isnan}(x))""");
+
+  // Matrix<double>
+  Eigen::Matrix<double, 2, 2> M;
+  M << 1.2, 3, 4.56, 7;
+  EXPECT_EQ(ToLatex(M, 1),
+            R"""(\begin{bmatrix} 1.2 & 3 \\ 4.6 & 7 \end{bmatrix})""");
+
+  // Matrix<Expression>
+  Eigen::Matrix<Expression, 2, 2> Me;
+  Me << x, 2.3 * y, 2.3 * y, x + y;
+  EXPECT_EQ(
+      ToLatex(Me, 1),
+      R"""(\begin{bmatrix} x & 2.3 y \\ 2.3 y & (x + y) \end{bmatrix})""");
+
+  // Formula with a PSD Matrix.
+  EXPECT_EQ(
+      ToLatex(positive_semidefinite(Me), 1),
+      R"""(\begin{bmatrix} x & 2.3 y \\ 2.3 y & (x + y) \end{bmatrix})"""
+      R"""( \succeq 0)""");
+}
+
+}  // namespace
+}  // namespace symbolic
+}  // namespace drake


### PR DESCRIPTION
Now we can render our symbolic expressions beautifully in Jupyter notebooks.  :-)

Example from the underactuated intro notebook:
```
plant = MultibodyPlant(time_step=0)
parser = Parser(plant)
parser.AddModelFromFile(FindResource("models/double_pendulum.urdf"))
plant.Finalize()

q = [Variable("\\theta_0"), Variable("\\theta_1")]
v = [Variable("\\dot\\theta_0"), Variable("\\dot\\theta_1")]
(M, Cv, tauG, B, tauExt) = ManipulatorDynamics(plant.ToSymbolic(), q, v)
display(Math("M = " + ToLatex(M, precision=2)))
display(Math("Cv = " + ToLatex(Cv, precision=2)))
display(Math("\\tau_G = " + ToLatex(tauG, precision=2)))
display(Math("B = " + ToLatex(B, precision=2)))
display(Math("\\tau_{ext} = " + ToLatex(tauExt, precision=2)))
```
gives e.g. 
![Screenshot from 2022-01-08 14-13-53](https://user-images.githubusercontent.com/6442292/148656788-4c427e53-006d-4184-bec5-7671af884ff4.png)

fyi @soonhokong .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16336)
<!-- Reviewable:end -->
