### PR TITLE
Fix internally inconsistent RenderEngineVtk opacity.

### DIFF
--- a/geometry/render/render_engine_vtk.cc
+++ b/geometry/render/render_engine_vtk.cc
@@ -441,6 +441,7 @@ void RenderEngineVtk::InitializePipelines() {
   pipelines_[ImageType::kColor]->renderer->UseFXAAOn();
   pipelines_[ImageType::kColor]->renderer->SetBackground(
       default_clear_color_.r, default_clear_color_.g, default_clear_color_.b);
+  pipelines_[ImageType::kColor]->renderer->SetBackgroundAlpha(1.0);
 }
 
 void RenderEngineVtk::ImplementObj(const std::string& file_name, double scale,

--- a/geometry/render/test/render_engine_vtk_test.cc
+++ b/geometry/render/test/render_engine_vtk_test.cc
@@ -493,7 +493,7 @@ TEST_F(RenderEngineVtkTest, NoBodyTest) {
   Init(RigidTransformd::Identity());
   Render();
 
-  VerifyUniformColor(kBgColor, 0u);
+  VerifyUniformColor(kBgColor, 255u);
   VerifyUniformLabel(RenderLabel::kEmpty);
   VerifyUniformDepth(std::numeric_limits<float>::infinity());
 }
@@ -506,7 +506,7 @@ TEST_F(RenderEngineVtkTest, ControlBackgroundColor) {
         {}, {}, Vector3d{bg.r / 255., bg.g / 255., bg.b / 255.}};
     RenderEngineVtk engine(params);
     Render(&engine);
-    VerifyUniformColor(bg, 0u);
+    VerifyUniformColor(bg, 255u);
   }
 }
 


### PR DESCRIPTION
Current tests of the background alpha value are internally inconsistent, some test for alpha=0 and some for alpha=255.  Explicitly requesting the SetBackgroundAlpha of the color renderer to 1.0 (rather than default of 0.0), and updating tests to all check for alpha=255 is the correct fix, where 1.0 in floating point color is 255 in RGBA uint8 color.

Refs: https://gitlab.kitware.com/vtk/vtk/-/commit/0546373c89227384f68c0e5acfc4d47c26f6a81b

Current code testing for alpha=255 relies on the hard-coded return alpha value of 1.0 in the FXAA shader.  Once VTK 9 is used, the above commit will break these tests as alpha will become 0.

vtkRenderWindow will have the correct background color with alpha=0, however vtkRenderWindow => vtkWindowToImageFilter => vtkImageExport will lose the background color when alpha=0.  Using alpha=255 will preserve the background color via the corrected VTK FXAA shader.

--------------------

The loss of background color cannot be replicated without updating to VTK-9 but we are moving this fix ahead of that, ref: https://github.com/RobotLocomotion/drake/pull/16132#issuecomment-1008339580

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16340)
<!-- Reviewable:end -->
