### PR TITLE
[geometry] Fix unit tests of hydroelastic callback on macOS unprovisioned

### DIFF
--- a/geometry/proximity/test/hydroelastic_callback_test.cc
+++ b/geometry/proximity/test/hydroelastic_callback_test.cc
@@ -333,7 +333,8 @@ TYPED_TEST(DispatchRigidSoftCalculationTests, SoftMeshRigidMesh) {
   for (const auto representation :
        {HydroelasticContactRepresentation::kTriangle,
         HydroelasticContactRepresentation::kPolygon}) {
-    SCOPED_TRACE(fmt::format("representation = {}", representation));
+    SCOPED_TRACE(
+        fmt::format("representation = {}", static_cast<int>(representation)));
     {
       // Case 1: Intersecting spheres.
       scene.PoseGeometry(colliding);
@@ -386,7 +387,8 @@ TYPED_TEST(DispatchRigidSoftCalculationTests, SoftMeshRigidHalfSpace) {
   for (const auto representation :
        {HydroelasticContactRepresentation::kTriangle,
         HydroelasticContactRepresentation::kPolygon}) {
-    SCOPED_TRACE(fmt::format("representation = {}", representation));
+    SCOPED_TRACE(
+        fmt::format("representation = {}", static_cast<int>(representation)));
     // Case 1: Intersecting geometry.
     scene.PoseGeometry(colliding);
     const RigidTransform<T>& X_WB = scene.pose_in_world(id_B);
@@ -428,7 +430,8 @@ TYPED_TEST(DispatchRigidSoftCalculationTests, SoftHalfSpaceRigidMesh) {
   for (const auto representation :
        {HydroelasticContactRepresentation::kTriangle,
         HydroelasticContactRepresentation::kPolygon}) {
-    SCOPED_TRACE(fmt::format("representation = {}", representation));
+    SCOPED_TRACE(
+        fmt::format("representation = {}", static_cast<int>(representation)));
     // Case 1: Intersecting geometry.
     scene.PoseGeometry(colliding);
     const RigidTransform<T>& X_WB = scene.pose_in_world(id_B);


### PR DESCRIPTION
- Use static_cast<int> on enum class HydroelasticContactRepresentation.

The failure happened on mac-big-sur-unprovisioned-clang-bazel-nightly-release as reported here:
https://drake-cdash.csail.mit.edu/viewBuildError.php?buildid=1536205

Buildcop discussion: https://drakedevelopers.slack.com/archives/C270MN28G/p1641826183010800

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16341)
<!-- Reviewable:end -->
