### PR TITLE
[perception] Deprecate PoseSmoother

### DIFF
--- a/manipulation/perception/BUILD.bazel
+++ b/manipulation/perception/BUILD.bazel
@@ -58,6 +58,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "pose_smoother_test",
+    copts = ["-Wno-deprecated-declarations"],
     deps = [
         ":pose_smoother",
         "//common/test_utilities:eigen_geometry_compare",

--- a/manipulation/perception/pose_smoother.h
+++ b/manipulation/perception/pose_smoother.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/manipulation/util/moving_average_filter.h"
 #include "drake/systems/framework/event.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -44,7 +45,10 @@ namespace perception {
  *
  *  @ingroup manipulation_systems
  */
-class PoseSmoother : public systems::LeafSystem<double> {
+class DRAKE_DEPRECATED("2022-05-01",
+    "This class is being removed.  You are invited to copy it into your own"
+    " project in case you still need it.")
+PoseSmoother : public systems::LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PoseSmoother)
 


### PR DESCRIPTION
Closes #15929.  If someone wants to land the RigidTransform version in Drake, they can rework it from the git history.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16343)
<!-- Reviewable:end -->
