### PR TITLE
Use `lsb_release` for distro detection

### DIFF
--- a/tools/workspace/os.bzl
+++ b/tools/workspace/os.bzl
@@ -93,28 +93,32 @@ def _determine_linux(repository_ctx):
                 drake_os,
             ))
 
-    # Run sed to determine Linux NAME and VERSION_ID.
-    sed = exec_using_which(repository_ctx, [
-        "sed",
-        "-n",
-        r"/^\(NAME\|VERSION_ID\)=/{s/[^=]*=//;s/\"//g;p}",
-        "/etc/os-release",
-    ])
-    if sed.error != None:
-        return _make_result(error = error_prologue + sed.error)
+    # Get distro name.
+    lsb = exec_using_which(repository_ctx, ["lsb_release", "-si"])
+    if lsb.error != None:
+        return _make_result(error = error_prologue + lsb.error)
+    distro = lsb.stdout.strip()
 
-    # Compute an identifying string, in the form of "$NAME $VERSION_ID".
-    lines = [line.strip() for line in sed.stdout.strip().split("\n")]
-    distro = " ".join([x for x in lines if len(x) > 0])
+    if distro == "Ubuntu":
+        lsb = exec_using_which(repository_ctx, ["lsb_release", "-sr"])
+        if lsb.error != None:
+            return _make_result(error = error_prologue + lsb.error)
+        ubuntu_release = lsb.stdout.strip()
 
-    # Match supported Ubuntu release(s). These should match those listed in
-    # both doc/developers.rst the root CMakeLists.txt.
-    for ubuntu_release in ["18.04", "20.04"]:
-        if distro == "Ubuntu " + ubuntu_release:
+        # Match supported Ubuntu release(s). These should match those listed in
+        # both doc/developers.rst the root CMakeLists.txt.
+        if ubuntu_release in ["18.04", "20.04"]:
             return _make_result(
                 ubuntu_release = ubuntu_release,
                 is_manylinux = is_manylinux,
             )
+
+        # Nothing matched.
+        return _make_result(
+            error = (error_prologue +
+                     "unsupported '%s' release '%s'" %
+                     (distro, ubuntu_release)),
+        )
 
     # Nothing matched.
     return _make_result(


### PR DESCRIPTION
Tweak how we detect the Linux distribution name and version to use `lsb_release` rather than directly examining `/etc/os-release` directly using sed "magic". This is more consistent with how we handle distro detection in other places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16353)
<!-- Reviewable:end -->
