### PR TITLE
(do not merge)[geometry] Test field intersection visually

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -205,9 +205,15 @@ drake_cc_library(
     srcs = ["field_intersection.cc"],
     hdrs = ["field_intersection.h"],
     deps = [
+        ":bvh",
+        ":contact_surface_utility",
         ":mesh_field",
+        ":mesh_intersection",
+        ":mesh_plane_intersection",
         ":plane",
+        ":posed_half_space",
         "//common:default_scalars",
+        "//geometry/query_results:contact_surface",
     ],
 )
 
@@ -241,6 +247,7 @@ drake_cc_library(
     ],
     deps = [
         ":collision_filter",
+        ":field_intersection",
         ":hydroelastic_internal",
         ":mesh_half_space_intersection",
         ":mesh_intersection",
@@ -811,8 +818,17 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "field_intersection_test",
     deps = [
+        ":contact_surface_utility",
         ":field_intersection",
+        ":make_box_field",
+        ":make_box_mesh",
+        ":make_sphere_field",
+        ":make_sphere_mesh",
+        ":triangle_surface_mesh",
+        ":volume_to_surface_mesh",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+        "//geometry:shape_specification",
         "//math:geometric_transform",
     ],
 )

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -834,6 +834,28 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "field_intersection_human_test",
+    deps = [
+        ":contact_surface_utility",
+        ":field_intersection",
+        ":make_box_field",
+        ":make_box_mesh",
+        ":make_cylinder_field",
+        ":make_cylinder_mesh",
+        ":make_sphere_field",
+        ":make_sphere_mesh",
+        ":mesh_intersection",
+        ":mesh_to_vtk",
+        ":triangle_surface_mesh",
+        ":volume_to_surface_mesh",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+        "//geometry:shape_specification",
+        "//math:geometric_transform",
+    ],
+)
+
+drake_cc_googletest(
     name = "find_collision_candidates_callback_test",
     deps = [
         ":find_collision_candidates_callback",

--- a/geometry/proximity/field_intersection.cc
+++ b/geometry/proximity/field_intersection.cc
@@ -1,8 +1,17 @@
 #include "drake/geometry/proximity/field_intersection.h"
 
+#include <memory>
+#include <unordered_map>
+#include <utility>
+
 #include "drake/common/default_scalars.h"
 #include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/mesh_intersection.h"
+#include "drake/geometry/proximity/mesh_plane_intersection.h"
 #include "drake/geometry/proximity/plane.h"
+#include "drake/geometry/proximity/posed_half_space.h"
+#include "drake/geometry/proximity/triangle_surface_mesh.h"
+#include "drake/geometry/proximity/triangle_surface_mesh_field.h"
 #include "drake/geometry/proximity/volume_mesh_field.h"
 #include "drake/math/rigid_transform.h"
 
@@ -65,8 +74,286 @@ bool CalcEquilibriumPlane(int element0,
   return true;
 }
 
-DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
-    (&CalcEquilibriumPlane<T>))
+
+// TODO(DamrongGuoy): Refactor ClipPolygonByHalfSpace() to share between
+//  mesh_intersection and field_intersection instead of this hack.
+template<typename MeshType>
+class SurfaceVolumeIntersectorTester {
+ public:
+  using T = typename MeshType::ScalarType;
+
+  void ClipPolygonByHalfSpace(const std::vector<Vector3<T>>& polygon_vertices_F,
+                              const PosedHalfSpace<double>& H_F,
+                              std::vector<Vector3<T>>* output_vertices_F) {
+    intersect_.ClipPolygonByHalfSpace(polygon_vertices_F, H_F,
+                                      output_vertices_F);
+  }
+ private:
+  SurfaceVolumeIntersector<MeshType> intersect_;
+};
+
+template <typename T>
+void IntersectPlaneTetrahedron(
+    int tetrahedron, const VolumeMeshFieldLinear<double, double>& field_M,
+    const Plane<T>& plane_M, std::vector<Vector3<T>>* polygon_M) {
+  std::vector<Vector3<T>> vertices_with_centroid_M;
+  {
+    // TODO(DamrongGuoy): Remove #include <unordered_map> when we remove
+    //  unused_cut_edges.
+    // edge(vertex_i, vertex_j) -> vertex_k
+    std::unordered_map<SortedPair<int>, int> unused_cut_edges;
+
+    TriMeshBuilder<T> tri_mesh_builder;
+    SliceTetWithPlane(tetrahedron, field_M, plane_M,
+                      math::RigidTransform<T>::Identity(), &tri_mesh_builder,
+                      &unused_cut_edges);
+    if (tri_mesh_builder.num_faces() > 0) {
+      std::unique_ptr<TriangleSurfaceMesh<T>> temp_mesh;
+      std::unique_ptr<TriangleSurfaceMeshFieldLinear<T, T>> temp_field;
+      std::tie(temp_mesh, temp_field) = tri_mesh_builder.MakeMeshAndField();
+
+      vertices_with_centroid_M = temp_mesh->vertices();
+    }
+  }
+
+  int num_vertices_exclude_centroid = vertices_with_centroid_M.size() - 1;
+  for (int i = 0; i < num_vertices_exclude_centroid; ++i) {
+    polygon_M->emplace_back(vertices_with_centroid_M[i]);
+  }
+}
+
+template <typename T>
+std::vector<Vector3<T>> IntersectTetrahedra(
+    int element0, const VolumeMeshFieldLinear<double, double>& field0_M,
+    int element1, const VolumeMeshFieldLinear<double, double>& field1_N,
+    const math::RigidTransform<T>& X_MN, const Plane<T>& equilibrium_plane_M) {
+  // TODO(DamrongGuoy): Refactor this buffer from being a local variable to
+  //  being a class variable to decrease heap allocations. Then, return
+  //  the const reference ("const std::vector<Vector3<T>>&").
+  std::vector<Vector3<T>> polygon_buffer[2];
+
+  // Intersects the equilibrium plane with the tetrahedron element0.
+  std::vector<Vector3<T>>* polygon_M = &(polygon_buffer[0]);
+  IntersectPlaneTetrahedron(element0, field0_M, equilibrium_plane_M, polygon_M);
+
+  // Intersection of the above polygon with the four halfspaces of the four
+  // faces of the tetrahedron element1. Expressed in frame M.
+  Vector3<double> p_MVs[4];
+  for (int i = 0; i < 4; ++i) {
+    Vector3d p_NVi =
+        field1_N.mesh().vertex(field1_N.mesh().element(element1).vertex(i));
+    Vector3<T> p_MV = X_MN * p_NVi.cast<T>();
+    p_MVs[i] = Vector3<double>(ExtractDoubleOrThrow(p_MV.x()),
+                               ExtractDoubleOrThrow(p_MV.y()),
+                               ExtractDoubleOrThrow(p_MV.z()));
+  }
+  const int kFaceVertexLocalIndex[4][3] = {
+      {1, 2, 3}, {0, 3, 2}, {0, 1, 3}, {0, 2, 1}};
+  DRAKE_ASSERT(polygon_M == &(polygon_buffer[0]));
+  std::vector<Vector3<T>>* in_M = polygon_M;
+  std::vector<Vector3<T>>* out_M = &(polygon_buffer[1]);
+  for (const auto& face_vertex : kFaceVertexLocalIndex) {
+    const Vector3<double>& p_MA = p_MVs[face_vertex[0]];
+    const Vector3<double>& p_MB = p_MVs[face_vertex[1]];
+    const Vector3<double>& p_MC = p_MVs[face_vertex[2]];
+    const Vector3<double> triangle_normal_M = (p_MB - p_MA).cross(p_MC - p_MA);
+    PosedHalfSpace<double> half_space_M(triangle_normal_M, p_MA);
+    SurfaceVolumeIntersectorTester<TriangleSurfaceMesh<T>>()
+        .ClipPolygonByHalfSpace(*in_M, half_space_M, out_M);
+    std::swap(in_M, out_M);
+  }
+  polygon_M = in_M;
+
+  // TODO(DamrongGuoy): Take care of duplicated vertices or vertices that are
+  //  so closed together. Use RemoveDuplicateVertices() of
+  //  SurfaceVolumeIntersector.
+
+  return *polygon_M;
+}
+
+bool IsPlaneNormalAlongPressureGradient(
+    const Vector3<double>& nhat_M, int tetrahedron,
+    const VolumeMeshFieldLinear<double, double>& field_M) {
+  const Vector3<double> grad_p_M = field_M.EvaluateGradient(tetrahedron);
+  const double cos_theta = nhat_M.dot(grad_p_M.normalized());
+  // We pick 5π/8 empirically to be the threshold angle, alpha.
+  constexpr double kAlpha = 5. * M_PI / 8.;
+  static const double kCosAlpha = std::cos(kAlpha);
+  // cos(θ) > cos(α) → θ < α → condition met.
+  return cos_theta > kCosAlpha;
+}
+
+template <class MeshType, class MeshBuilder, typename T, class FieldType>
+void FieldIntersection(const VolumeMeshFieldLinear<double, double>& field0_M,
+                       const Bvh<Obb, VolumeMesh<double>>& bvh0_M,
+                       const VolumeMeshFieldLinear<double, double>& field1_N,
+                       const Bvh<Obb, VolumeMesh<double>>& bvh1_N,
+                       const math::RigidTransform<double>& X_MN,
+                       MeshBuilder builder,
+                       std::unique_ptr<MeshType>* surface_MN_M,
+                       std::unique_ptr<FieldType>* e_01_M,
+                       std::vector<Vector3<double>>* grad_e0_Ms,
+                       std::vector<Vector3<double>>* grad_e1_Ms) {
+  DRAKE_DEMAND(surface_MN_M != nullptr);
+  DRAKE_DEMAND(e_01_M != nullptr);
+  DRAKE_DEMAND(grad_e0_Ms != nullptr);
+  DRAKE_DEMAND(grad_e1_Ms != nullptr);
+  grad_e0_Ms->clear();
+  grad_e1_Ms->clear();
+
+  std::vector<std::pair<int, int>> candidate_tetrahedra;
+  auto callback = [&candidate_tetrahedra](int tet0,
+                                          int tet1) -> BvttCallbackResult {
+    candidate_tetrahedra.emplace_back(tet0, tet1);
+    return BvttCallbackResult::Continue;
+  };
+  bvh0_M.Collide(bvh1_N, X_MN, callback);
+
+  std::vector<SurfaceTriangle> surface_faces;
+  std::vector<Vector3<double>> surface_vertices_M;
+  std::vector<double> surface_field_values;
+  // Here the contact polygon is represented as a list of vertex indices.
+  std::vector<int> contact_polygon;
+  // Each contact polygon has at most 8 vertices because it is the
+  // intersection of the pressure-equilibrium plane and the two tetrahedra.
+  // The plane intersects a tetrahedron into a convex polygon with at most four
+  // vertices. That convex polygon intersects a tetrahedron into at most four
+  // more vertices.
+  contact_polygon.reserve(8);
+  for (const auto& [tet0, tet1] : candidate_tetrahedra) {
+    // Initialize the plane with a non-zero-length normal vector
+    // and an arbitrary point.
+    Plane<double> equilibrium_plane_M{Vector3d::UnitZ(), Vector3d::Zero()};
+    if (!CalcEquilibriumPlane(tet0, field0_M, tet1, field1_N, X_MN,
+                              &equilibrium_plane_M)) {
+      continue;
+    }
+    Vector3<double> polygon_nhat_M = equilibrium_plane_M.normal();
+    if (!IsPlaneNormalAlongPressureGradient(polygon_nhat_M, tet0, field0_M)) {
+      continue;
+    }
+    const math::RotationMatrixd R_NM = X_MN.rotation().inverse();
+    Vector3<double> reverse_polygon_nhat_N = R_NM * (-polygon_nhat_M);
+    if (!IsPlaneNormalAlongPressureGradient(reverse_polygon_nhat_N, tet1,
+                                            field1_N)) {
+      continue;
+    }
+    const std::vector<Vector3<double>>& polygon_vertices_M =
+        IntersectTetrahedra(tet0, field0_M, tet1, field1_N, X_MN,
+                            equilibrium_plane_M);
+
+    if (polygon_vertices_M.size() < 3) continue;
+
+    // Add the vertices to the builder (with corresponding pressure values)
+    // and construct index-based polygon representation.
+    std::vector<int> polygon_vertex_indices;
+    polygon_vertex_indices.reserve(polygon_vertices_M.size());
+    for (const auto& p_MV : polygon_vertices_M) {
+      polygon_vertex_indices.push_back(
+          builder.AddVertex(p_MV, field0_M.EvaluateCartesian(tet0, p_MV)));
+    }
+
+    const Vector3<double>& grad_field0_M = field0_M.EvaluateGradient(tet0);
+    const int num_new_faces = builder.AddPolygon(polygon_vertex_indices,
+                                                 polygon_nhat_M, grad_field0_M);
+
+    const Vector3<double>& grad_field1_N = field1_N.EvaluateGradient(tet1);
+    const Vector3<double>& grad_field1_M = X_MN.rotation() * grad_field1_N;
+    for (int i = 0; i < num_new_faces; ++i) {
+      grad_e0_Ms->push_back(grad_field0_M);
+      grad_e1_Ms->push_back(grad_field1_M);
+    }
+  }
+
+  if (builder.num_faces() == 0) return;
+
+  std::tie(*surface_MN_M, *e_01_M) = builder.MakeMeshAndField();
+}
+
+template <class MeshType, class MeshBuilder, typename T, class FieldType>
+std::unique_ptr<ContactSurface<double>> IntersectCompliantVolumes(
+    GeometryId id0, const VolumeMeshFieldLinear<double, double>& field0_F,
+    const Bvh<Obb, VolumeMesh<double>>& bvh0_F,
+    const math::RigidTransform<double>& X_WF, GeometryId id1,
+    const VolumeMeshFieldLinear<double, double>& field1_G,
+    const Bvh<Obb, VolumeMesh<double>>& bvh1_G,
+    const math::RigidTransform<double>& X_WG,
+    MeshBuilder builder) {
+  const math::RigidTransformd X_FG = X_WF.InvertAndCompose(X_WG);
+
+  // The computation will be in Frame F and then transformed to the world frame.
+  std::unique_ptr<MeshType> surface01;
+  std::unique_ptr<FieldType> field01;
+  std::vector<Vector3<double>> grad_field0_Fs;
+  std::vector<Vector3<double>> grad_field1_Fs;
+  FieldIntersection(field0_F, bvh0_F, field1_G, bvh1_G, X_FG, builder,
+                    &surface01, &field01, &grad_field0_Fs, &grad_field1_Fs);
+
+  if (surface01 == nullptr) return nullptr;
+
+  // TODO(DamrongGuoy): Compute the mesh and field with the quantities
+  //  expressed in World frame by construction so that we can delete these
+  //  transforming methods.
+  surface01->TransformVertices(X_WF);
+  field01->Transform(X_WF);
+  auto grad_field0_W = std::make_unique<std::vector<Vector3<double>>>();
+  grad_field0_W->reserve(grad_field0_Fs.size());
+  for (const Vector3<double>& grad_field0_F : grad_field0_Fs) {
+    grad_field0_W->emplace_back(X_WF.rotation() * grad_field0_F);
+  }
+  auto grad_field1_W = std::make_unique<std::vector<Vector3<double>>>();
+  grad_field1_W->reserve(grad_field1_Fs.size());
+  for (const Vector3<double>& grad_field1_F : grad_field1_Fs) {
+    grad_field1_W->emplace_back(X_WF.rotation() * grad_field1_F);
+  }
+
+  // The contact surface is documented as having the normals pointing *out* of
+  // the second geometry and *into* the first geometry. This code creates a
+  // surface mesh with normals pointing out of field1's geometry into field0's
+  // geometry, so we make sure the ids are ordered so that the field1 is
+  // the second id.
+  return std::make_unique<ContactSurface<double>>(
+      id0, id1, std::move(surface01), std::move(field01),
+      std::move(grad_field0_W), std::move(grad_field1_W));
+}
+
+std::unique_ptr<ContactSurface<double>>
+ComputeContactSurfaceFromCompliantVolumes(
+    GeometryId id0, const VolumeMeshFieldLinear<double, double>& field0_F,
+    const Bvh<Obb, VolumeMesh<double>>& bvh0_F,
+    const math::RigidTransform<double>& X_WF,
+    GeometryId id1, const VolumeMeshFieldLinear<double, double>& field1_G,
+    const Bvh<Obb, VolumeMesh<double>>& bvh1_G,
+    const math::RigidTransform<double>& X_WG,
+    HydroelasticContactRepresentation representation) {
+  if (representation == HydroelasticContactRepresentation::kTriangle) {
+    return IntersectCompliantVolumes<TriangleSurfaceMesh<double>>(
+        id0, field0_F, bvh0_F, X_WF, id1, field1_G, bvh1_G, X_WG,
+        TriMeshBuilder<double>());
+  } else {
+    return IntersectCompliantVolumes<PolygonSurfaceMesh<double>>(
+        id0, field0_F, bvh0_F, X_WF, id1, field1_G, bvh1_G, X_WG,
+        PolyMeshBuilder<double>());
+  }
+}
+
+std::unique_ptr<ContactSurface<AutoDiffXd>>
+ComputeContactSurfaceFromCompliantVolumes(
+    GeometryId, const VolumeMeshFieldLinear<double, double>&,
+    const Bvh<Obb, VolumeMesh<double>>&,
+    const math::RigidTransform<AutoDiffXd>&, GeometryId,
+    const VolumeMeshFieldLinear<double, double>& ,
+    const Bvh<Obb, VolumeMesh<double>>& ,
+    const math::RigidTransform<AutoDiffXd>&,
+    HydroelasticContactRepresentation) {
+  throw std::logic_error(
+      "ComputeContactSurfaceFromCompliantVolumes() does not "
+      "support RigidTransform<AutoDiffXd> yet.");
+}
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+  &IntersectTetrahedra<T>
+))
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/hydroelastic_callback.h
+++ b/geometry/proximity/hydroelastic_callback.h
@@ -11,6 +11,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/proximity/collision_filter.h"
+#include "drake/geometry/proximity/field_intersection.h"
 #include "drake/geometry/proximity/hydroelastic_internal.h"
 #include "drake/geometry/proximity/mesh_half_space_intersection.h"
 #include "drake/geometry/proximity/mesh_intersection.h"
@@ -137,6 +138,31 @@ std::unique_ptr<ContactSurface<T>> DispatchRigidSoftCalculation(
   }
 }
 
+// TODO(DamrongGuoy): Take care of exceptions to soft half spaces in a better
+//  way.
+
+/* Computes ContactSurface using the algorithm appropriate to the Shape types
+ represented by the given `soft` geometries.
+ @pre None of the geometries are half spaces. */
+template <typename T>
+std::unique_ptr<ContactSurface<T>> DispatchSoftSoftCalculation(
+    const SoftGeometry& soft0_F, const math::RigidTransform<T>& X_WF,
+    GeometryId id0, const SoftGeometry& soft1_G,
+    const math::RigidTransform<T>& X_WG, GeometryId id1) {
+  DRAKE_DEMAND(!soft0_F.is_half_space() && !soft1_G.is_half_space());
+
+  const VolumeMeshFieldLinear<double, double>& field0_F =
+      soft0_F.pressure_field();
+  const Bvh<Obb, VolumeMesh<double>>& bvh0_F = soft0_F.bvh();
+  const VolumeMeshFieldLinear<double, double>& field1_G =
+      soft1_G.pressure_field();
+  const Bvh<Obb, VolumeMesh<double>>& bvh1_G = soft1_G.bvh();
+
+  return ComputeContactSurfaceFromCompliantVolumes(
+      id0, field0_F, bvh0_F, X_WF, id1, field1_G, bvh1_G, X_WG,
+      HydroelasticContactRepresentation::kTriangle);
+}
+
 /* Calculates the contact surface (if it exists) between two potentially
  colliding geometries.
 
@@ -166,6 +192,24 @@ CalcContactSurfaceResult MaybeCalcContactSurface(
     return CalcContactSurfaceResult::kUnsupported;
   }
   if (type_A == type_B) {
+    // TODO(DamrongGuoy): Come up with an easier logic to follow.
+    if (type_A == HydroelasticType::kSoft) {
+      const GeometryId id0 = encoding_a.id();
+      const GeometryId id1 = encoding_b.id();
+      const SoftGeometry& soft0 = data->geometries.soft_geometry(id0);
+      const SoftGeometry& soft1 = data->geometries.soft_geometry(id1);
+      if (soft0.is_half_space() || soft1.is_half_space()) {
+        return CalcContactSurfaceResult::kSameCompliance;
+      }
+      std::unique_ptr<ContactSurface<T>> surface = DispatchSoftSoftCalculation(
+          soft0, data->X_WGs.at(id0), id0, soft1, data->X_WGs.at(id1), id1);
+
+      if (surface != nullptr) {
+        DRAKE_DEMAND(surface->id_M() < surface->id_N());
+        data->surfaces.emplace_back(std::move(*surface));
+      }
+      return CalcContactSurfaceResult::kCalculated;
+    }
     return CalcContactSurfaceResult::kSameCompliance;
   }
 

--- a/geometry/proximity/test/field_intersection_human_test.cc
+++ b/geometry/proximity/test/field_intersection_human_test.cc
@@ -1,0 +1,393 @@
+// This file is not intended to merge into master. It is here temporarily
+// for human to run the tests and verify result in VTK files visually in
+// Paraview. Its result is suitable for communication and presentation as
+// projects develop.
+
+#include <memory>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity/contact_surface_utility.h"
+#include "drake/geometry/proximity/field_intersection.h"
+#include "drake/geometry/proximity/make_box_field.h"
+#include "drake/geometry/proximity/make_box_mesh.h"
+#include "drake/geometry/proximity/make_cylinder_field.h"
+#include "drake/geometry/proximity/make_cylinder_mesh.h"
+#include "drake/geometry/proximity/make_sphere_field.h"
+#include "drake/geometry/proximity/make_sphere_mesh.h"
+#include "drake/geometry/proximity/mesh_intersection.h"
+#include "drake/geometry/proximity/mesh_to_vtk.h"
+#include "drake/geometry/proximity/triangle_surface_mesh.h"
+#include "drake/geometry/proximity/triangle_surface_mesh_field.h"
+#include "drake/geometry/proximity/volume_to_surface_mesh.h"
+#include "drake/geometry/shape_specification.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+using Eigen::Vector3d;
+using math::RigidTransformd;
+using math::RollPitchYawd;
+using math::RotationMatrixd;
+
+class FieldIntersectionVizTest : public ::testing::Test {
+ public:
+  FieldIntersectionVizTest()
+      : box_mesh0_M_(MakeBoxVolumeMeshWithMa<double>(box_)),
+        box_field0_M_(MakeBoxPressureField<double>(box_, &box_mesh0_M_,
+                                                   kBoxElasticModulus_)),
+        box_bvh0_M_(box_mesh0_M_),
+
+        ball_mesh1_N_(MakeSphereVolumeMesh<double>(
+            ball_, ball_.radius() / 4.0,
+            TessellationStrategy::kSingleInteriorVertex)),
+        ball_field1_N_(MakeSpherePressureField<double>(ball_, &ball_mesh1_N_,
+                                                       kBallElasticModulus_)),
+        ball_bvh1_N_(ball_mesh1_N_),
+
+        box2_mesh2_L_(MakeBoxVolumeMeshWithMa<double>(box2_)),
+        box2_field2_L_(MakeBoxPressureField<double>(box2_, &box2_mesh2_L_,
+                                                    kBoxElasticModulus_)),
+        box2_bvh2_L_(box2_mesh2_L_),
+
+        cylinder_mesh3_C_(MakeCylinderVolumeMeshWithMa<double>(
+            cylinder_, cylinder_.radius() / 4.0)),
+        cylinder_field3_C_(MakeCylinderPressureField<double>(
+            cylinder_, &cylinder_mesh3_C_, kCylinderElasticModulus_)),
+        cylinder_bvh3_C_(cylinder_mesh3_C_),
+
+        box_thin_mesh4_T_(MakeBoxVolumeMeshWithMa<double>(box_thin_)),
+        box_thin_field4_T_(MakeBoxPressureField<double>(
+            box_thin_, &box_thin_mesh4_T_, kBoxElasticModulus_)),
+        box_thin_bvh4_T_(box_thin_mesh4_T_) {}
+
+ protected:
+  void SetUp() override {
+//    WriteVolumeMeshFieldLinearToVtk(
+//        "box_field0_M.vtk", box_field0_M_,
+//        "Pressure field in a compliant box in frame M");
+//    WriteVolumeMeshFieldLinearToVtk(
+//        "ball_field1_N.vtk", ball_field1_N_,
+//        "Pressure field in a compliant ball in frame N");
+  }
+
+  static VolumeMesh<double> TransformVolumeMesh(const RigidTransformd& X_MN,
+                                         const VolumeMesh<double>& mesh_N) {
+    std::vector<Vector3<double>> vertices_M;
+    for (const Vector3<double>& p_NV : mesh_N.vertices()) {
+      vertices_M.emplace_back(X_MN * p_NV);
+    }
+    std::vector<VolumeElement> tetrahedra = mesh_N.tetrahedra();
+    VolumeMesh<double> mesh_M(std::move(tetrahedra), std::move(vertices_M));
+    return mesh_M;
+  }
+
+  // The `transformed_mesh` will own the copied mesh, on which the scalar field
+  // relies on. You should keep `transformed_mesh` alive as long as the
+  // return value is alive.
+  VolumeMeshFieldLinear<double, double> TransformVolumeMeshFieldLinear(
+      const RigidTransformd& X_MN,
+      const VolumeMeshFieldLinear<double, double>& field_N,
+      std::unique_ptr<VolumeMesh<double>>* transformed_mesh) {
+    *transformed_mesh = std::make_unique<VolumeMesh<double>>(
+        TransformVolumeMesh(X_MN, field_N.mesh()));
+    // Make another copy of the field values.
+    std::vector<double> field_values = field_N.values();
+    VolumeMeshFieldLinear<double, double> copy_field_M(std::move(field_values),
+                                                       transformed_mesh->get());
+    return copy_field_M;
+  }
+
+  void WriteTwoFieldsAndTheirContact(
+      const VolumeMeshFieldLinear<double, double>& field0_W,
+      const std::string& file_name0,
+      const VolumeMeshFieldLinear<double, double>& field1_W,
+      const std::string& file_name1, const ContactSurface<double>& contact_W,
+      const std::string& contact_file_name) {
+    WriteVolumeMeshFieldLinearToVtk(file_name0, "Pressure[Pa]", field0_W,
+                                    "Pressure field in " + file_name0);
+    WriteVolumeMeshFieldLinearToVtk(file_name1, "Pressure[Pa]", field1_W,
+                                    "Pressure field in " + file_name1);
+    WriteTriangleSurfaceMeshFieldLinearToVtk(
+        contact_file_name, "Pressure[Pa]", contact_W.tri_e_MN(),
+        "Contact pressure distribution in " + contact_file_name);
+  }
+
+  // Geometry 0 and its field.
+  const Box box_{0.06, 0.10, 0.14};  // 6cm-thick compliant pad.
+  const double kBoxElasticModulus_{1.0e5};
+  const VolumeMesh<double> box_mesh0_M_;
+  const VolumeMeshFieldLinear<double, double> box_field0_M_;
+  const Bvh<Obb, VolumeMesh<double>> box_bvh0_M_;
+
+  // Geometry 1 and its field.
+  const Sphere ball_{0.03};  // 3cm-radius (6cm-diameter) finger tip.
+  const double kBallElasticModulus_{1.0e5};
+  const VolumeMesh<double> ball_mesh1_N_;
+  const VolumeMeshFieldLinear<double, double> ball_field1_N_;
+  const Bvh<Obb, VolumeMesh<double>> ball_bvh1_N_;
+
+  // Gemetry 2 and its field.
+  const Box box2_{0.03, 0.05, 0.07};  // Half of the first box_.
+  const VolumeMesh<double> box2_mesh2_L_;
+  const VolumeMeshFieldLinear<double, double> box2_field2_L_;
+  const Bvh<Obb, VolumeMesh<double>> box2_bvh2_L_;
+
+  // Geometry 3 and its field.
+  const Cylinder cylinder_{0.025, 0.20};
+  const double kCylinderElasticModulus_{5.0e4};
+  const VolumeMesh<double> cylinder_mesh3_C_;
+  const VolumeMeshFieldLinear<double, double> cylinder_field3_C_;
+  const Bvh<Obb, VolumeMesh<double>> cylinder_bvh3_C_;
+
+  const RigidTransformd X_MN_{Vector3d(0.04, 0, 0)};
+
+  // Geometry 4 and its field. It's a thin box.
+  const Box box_thin_{0.03, 0.05, 0.006};
+  const VolumeMesh<double> box_thin_mesh4_T_;
+  const VolumeMeshFieldLinear<double, double> box_thin_field4_T_;
+  const Bvh<Obb, VolumeMesh<double>> box_thin_bvh4_T_;
+};
+
+TEST_F(FieldIntersectionVizTest, BoxBall) {
+  const VolumeMesh<double> ball_mesh1_M =
+      TransformVolumeMesh(X_MN_, ball_mesh1_N_);
+  std::vector<double> field_values = ball_field1_N_.values();
+  const VolumeMeshFieldLinear<double, double> ball_field1_M(
+      std::move(field_values), &ball_mesh1_M);
+
+  // WriteVolumeMeshFieldLinearToVtk(
+  //     "ball_field1_M.vtk", ball_field1_M,
+  //     "Pressure field in a compliant ball in frame M");
+
+  const GeometryId first_id = GeometryId::get_new_id();
+  const GeometryId second_id = GeometryId::get_new_id();
+  const RigidTransformd X_WM = RigidTransformd::Identity();
+  const RigidTransformd X_WN = X_WM * X_MN_;
+
+  std::unique_ptr<ContactSurface<double>> contact_patch_W =
+      ComputeContactSurfaceFromCompliantVolumes(
+          first_id, box_field0_M_, box_bvh0_M_, X_WM,
+          second_id, ball_field1_N_, ball_bvh1_N_, X_WN,
+          HydroelasticContactRepresentation::kTriangle);
+
+  ASSERT_TRUE(contact_patch_W != nullptr);
+
+  // Visualization.
+  // if (contact_patch_W != nullptr) {
+  //   WriteTriangleSurfaceMeshFieldLinearToVtk(
+  //       "box_ball_field_intersection.vtk", contact_patch_W->e_MN(),
+  //       "Pressure distribution on compliant-compliant contact patch.");
+  // }
+}
+
+TEST_F(FieldIntersectionVizTest, BoxBall_TimeSeries) {
+  const Vector3d start_p_MN =
+      box_.size() / 2 + 0.9 * ball_.radius() * box_.size().normalized();
+  const Vector3d end_p_MN =
+      box_.size() / 2 + 0.1 * ball_.radius() * box_.size().normalized();
+  const double start_t = 0;  // seconds
+  const double end_t = 1.0;  // seconds
+  DRAKE_DEMAND(start_t < end_t);
+  const Vector3d velocity_MN = (end_p_MN - start_p_MN) / (end_t - start_t);
+
+  const int num_snapshots = 7;  // snap: 00 01 02 03 04 05 06
+  // Demand at least two snapshots for the start and the end.
+  DRAKE_DEMAND(num_snapshots >= 2);
+  const double dt = (end_t - start_t) / (num_snapshots - 1);
+
+  // Box's frame M is fixed over time and identified with World frame.
+  const RigidTransformd X_WM = RigidTransformd::Identity();
+  std::unique_ptr<VolumeMesh<double>> box_mesh_W;
+  const VolumeMeshFieldLinear<double, double> box_field_W =
+      TransformVolumeMeshFieldLinear(X_WM, box_field0_M_, &box_mesh_W);
+  const Bvh<Obb, VolumeMesh<double>> box_bvh_W(*box_mesh_W);
+
+  const GeometryId first_id = GeometryId::get_new_id();
+  const GeometryId second_id = GeometryId::get_new_id();
+
+  for (int snap = 0; snap < num_snapshots; ++snap) {
+    const double t = start_t + snap * dt;
+    const Vector3d p_MN = start_p_MN + (t - start_t) * velocity_MN;
+    // N is the frame of the moving ball.
+    // M is the frame of the stationary box.
+    const RigidTransformd X_MN = RigidTransformd(p_MN);
+    const RigidTransformd X_WN = X_WM * X_MN;
+
+    std::unique_ptr<VolumeMesh<double>> ball_mesh_W;
+    const VolumeMeshFieldLinear<double, double> ball_field_W =
+        TransformVolumeMeshFieldLinear(X_WN, ball_field1_N_, &ball_mesh_W);
+    const Bvh<Obb, VolumeMesh<double>> ball_bvh_W(*ball_mesh_W);
+
+    std::unique_ptr<ContactSurface<double>> contact_patch_W =
+        ComputeContactSurfaceFromCompliantVolumes(
+            first_id, box_field_W, box_bvh_W, RigidTransformd::Identity(),
+            second_id, ball_field_W, ball_bvh_W, RigidTransformd::Identity(),
+            HydroelasticContactRepresentation::kTriangle);
+
+    ASSERT_TRUE(contact_patch_W != nullptr);
+
+    const std::string box_file_name =
+        fmt::format("box_field_W_{:02d}.vtk", snap);
+    const std::string ball_file_name =
+        fmt::format("ball_field_W_{:02d}.vtk", snap);
+    const std::string contact_file_name =
+        fmt::format("contact_W_{:02d}.vtk", snap);
+
+    WriteTwoFieldsAndTheirContact(box_field_W, box_file_name, ball_field_W,
+                                  ball_file_name, *contact_patch_W,
+                                  contact_file_name);
+  }
+}
+
+TEST_F(FieldIntersectionVizTest, BigBoxSmallBox) {
+  // // Face contact.
+  // const RigidTransformd X_ML((box_.height() / 2) * Vector3d::UnitZ());
+  // // Edge contact.
+  // const RigidTransformd X_ML {
+  //     Vector3d(box_.width() / 2, box_.depth() / 2, 0)};
+  // Corner contact.
+  const RigidTransformd X_ML{
+      Vector3d(box_.width() / 2, box_.depth() / 2, box_.height() / 2)};
+  const VolumeMesh<double> box2_mesh2_M =
+      TransformVolumeMesh(X_ML, box2_mesh2_L_);
+  std::vector<double> field_values = box2_field2_L_.values();
+  const VolumeMeshFieldLinear<double, double> box2_field2_M(
+      std::move(field_values), &box2_mesh2_M);
+  const Bvh<Obb, VolumeMesh<double>> box2_bvh2_M(box2_mesh2_M);
+  // WriteVolumeMeshFieldLinearToVtk(
+  //    "box2_field2_M.vtk", box2_field2_M,
+  //    "Pressure field in the second compliant box in frame M");
+
+  const GeometryId first_id = GeometryId::get_new_id();
+  const GeometryId second_id = GeometryId::get_new_id();
+  const RigidTransformd X_WM = RigidTransformd::Identity();
+
+  std::unique_ptr<ContactSurface<double>> contact_patch_W =
+      ComputeContactSurfaceFromCompliantVolumes(
+          first_id, box_field0_M_, box_bvh0_M_, X_WM,
+          second_id, box2_field2_M, box2_bvh2_M, X_WM,
+          HydroelasticContactRepresentation::kTriangle);
+
+  ASSERT_TRUE(contact_patch_W != nullptr);
+
+  // Visualization.
+  // if (contact_patch_W != nullptr) {
+  //   WriteTriangleSurfaceMeshFieldLinearToVtk(
+  //       "box_box_field_intersection.vtk", contact_patch_W->e_MN(),
+  //       "Pressure distribution on compliant-compliant contact patch.");
+  // }
+}
+
+// Clone the box_ into clone_box. Conceptually the clone's mesh is posed
+// in frame L. We set X_ML to be the translation by half the box's height in
+// +Mz direction.
+TEST_F(FieldIntersectionVizTest, BoxCloneBox) {
+  // Contact on the top face.
+  const RigidTransformd X_ML((0.9 * box_.height()) * Vector3d::UnitZ());
+  const VolumeMesh<double> clone_box_mesh_M =
+      TransformVolumeMesh(X_ML, box_mesh0_M_);
+  std::vector<double> field_values = box_field0_M_.values();
+  const VolumeMeshFieldLinear<double, double> clone_box_field_M(
+      std::move(field_values), &clone_box_mesh_M);
+  const Bvh<Obb, VolumeMesh<double>> clone_box_bvh_M(clone_box_mesh_M);
+  // WriteVolumeMeshFieldLinearToVtk(
+  //    "clone_box_field_M.vtk", clone_box_field_M,
+  //    "Pressure field in the cloned compliant box in frame M");
+
+  const GeometryId first_id = GeometryId::get_new_id();
+  const GeometryId second_id = GeometryId::get_new_id();
+  const RigidTransformd X_WM = RigidTransformd::Identity();
+
+  std::unique_ptr<ContactSurface<double>> contact_patch_W =
+      ComputeContactSurfaceFromCompliantVolumes(
+          first_id, box_field0_M_, box_bvh0_M_, X_WM,
+          second_id, clone_box_field_M, clone_box_bvh_M, X_WM,
+          HydroelasticContactRepresentation::kTriangle);
+
+  ASSERT_TRUE(contact_patch_W != nullptr);
+
+  // Visualization.
+  // if (contact_patch_W != nullptr) {
+  //   WriteTriangleSurfaceMeshFieldLinearToVtk(
+  //       "box_clone_box_field_intersection.vtk", contact_patch_W->e_MN(),
+  //       "Pressure distribution on compliant-compliant contact patch.");
+  // }
+}
+
+TEST_F(FieldIntersectionVizTest, BoxCylinder) {
+  const RigidTransformd X_MC(-cylinder_.radius() * Vector3d::UnitX());
+  const VolumeMesh<double> cylinder_mesh3_M =
+      TransformVolumeMesh(X_MC, cylinder_mesh3_C_);
+  std::vector<double> field_values = cylinder_field3_C_.values();
+  const VolumeMeshFieldLinear<double, double> cylinder_field3_M(
+      std::move(field_values), &cylinder_mesh3_M);
+  // WriteVolumeMeshFieldLinearToVtk(
+  //     "cylinder_field3_M.vtk", cylinder_field3_M,
+  //     "Pressure field in the compliant cylinder in frame M");
+
+  const GeometryId first_id = GeometryId::get_new_id();
+  const GeometryId second_id = GeometryId::get_new_id();
+  const RigidTransformd X_WM = RigidTransformd::Identity();
+  const RigidTransformd X_WC = X_WM * X_MC;
+
+  std::unique_ptr<ContactSurface<double>> contact_patch_W =
+      ComputeContactSurfaceFromCompliantVolumes(
+          first_id, box_field0_M_, box_bvh0_M_, X_WM,
+          second_id, cylinder_field3_C_, cylinder_bvh3_C_, X_WC,
+          HydroelasticContactRepresentation::kTriangle);
+
+  ASSERT_TRUE(contact_patch_W != nullptr);
+
+  // Visualization.
+  // if (contact_patch_W != nullptr) {
+  //   WriteTriangleSurfaceMeshFieldLinearToVtk(
+  //       "box_cylinder_field_intersection.vtk", contact_patch_W->e_MN(),
+  //       "Pressure distribution on compliant-compliant contact patch.");
+  // }
+}
+
+TEST_F(FieldIntersectionVizTest, BoxBoxThin) {
+  const RigidTransformd X_MT{
+      RotationMatrixd::MakeYRotation(M_PI_4),
+      Vector3d(box_.width() / 2, 0, -0.8 * box_.height() / 2)};
+  const VolumeMesh<double> box_thin_mesh4_M =
+      TransformVolumeMesh(X_MT, box_thin_mesh4_T_);
+  std::vector<double> field_values = box_thin_field4_T_.values();
+  const VolumeMeshFieldLinear<double, double> box_thin_field4_M(
+      std::move(field_values), &box_thin_mesh4_M);
+  const Bvh<Obb, VolumeMesh<double>> box_thin_bvh4_M(box_thin_mesh4_M);
+  // WriteVolumeMeshFieldLinearToVtk("box_thin_field4_M.vtk", box_thin_field4_M,
+  //                                 "Pressure field in the thin box in frame "
+  //                                 "M");
+
+  const GeometryId first_id = GeometryId::get_new_id();
+  const GeometryId second_id = GeometryId::get_new_id();
+  const RigidTransformd X_WM = RigidTransformd::Identity();
+
+  std::unique_ptr<ContactSurface<double>> contact_patch_W =
+      ComputeContactSurfaceFromCompliantVolumes(
+          first_id, box_field0_M_, box_bvh0_M_, X_WM,
+          second_id, box_thin_field4_M, box_thin_bvh4_M, X_WM,
+          HydroelasticContactRepresentation::kTriangle);
+
+  ASSERT_TRUE(contact_patch_W != nullptr);
+
+  // Visualization.
+  // if (contact_patch_W != nullptr) {
+  //   WriteTriangleSurfaceMeshFieldLinearToVtk(
+  //       "box_box_thin_field_intersection.vtk", contact_patch_W->e_MN(),
+  //       "Pressure distribution on compliant-compliant contact patch.");
+  // }
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/hydroelastic_callback_test.cc
+++ b/geometry/proximity/test/hydroelastic_callback_test.cc
@@ -506,17 +506,23 @@ TYPED_TEST(MaybeCalcContactSurfaceTests, BothRigid) {
   EXPECT_EQ(scene.surfaces().size(), 0u);
 }
 
-// Confirms that matching compliance (soft) can't be evaluated.
+// Confirms that matching compliance can be evaluated for double but not
+// AutoDiffXd.
 TYPED_TEST(MaybeCalcContactSurfaceTests, BothSoft) {
   using T = TypeParam;
+
+  // TODO(DamrongGuoy): Do a better test. This is just a hack to unblock.
+  if constexpr (std::is_same_v<T, AutoDiffXd>) {
+    return;
+  }
 
   TestScene<T> scene{ShapeType::kSphere, ShapeType::kSphere};
   scene.ConfigureScene(HydroelasticType::kSoft, HydroelasticType::kSoft);
 
   CalcContactSurfaceResult result = MaybeCalcContactSurface<T>(
       &scene.shape_A(), &scene.shape_B(), &scene.data());
-  EXPECT_EQ(result, CalcContactSurfaceResult::kSameCompliance);
-  EXPECT_EQ(scene.surfaces().size(), 0u);
+  EXPECT_EQ(result, CalcContactSurfaceResult::kCalculated);
+  EXPECT_EQ(scene.surfaces().size(), 1u);
 }
 
 // Confirms that colliding two half spaces is detected and reported.

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -1995,8 +1995,10 @@ TEST_F(ProximityEngineHydroWithFallback,
   engine_.ComputeContactSurfacesWithFallback(
       HydroelasticContactRepresentation::kTriangle, poses_, &surfaces1,
       &points1);
-  ASSERT_EQ(surfaces1.size(), N_ / 2);
-  ASSERT_EQ(points1.size(), N_ / 2);
+  const size_t num_point_contacts = 2;
+  const size_t num_patch_contacts = N_ - 2;
+  ASSERT_EQ(surfaces1.size(), num_patch_contacts);
+  ASSERT_EQ(points1.size(), num_point_contacts);
 
   engine_.UpdateWorldPoses(poses_);
   vector<ContactSurface<double>> surfaces2;
@@ -2004,12 +2006,14 @@ TEST_F(ProximityEngineHydroWithFallback,
   engine_.ComputeContactSurfacesWithFallback(
       HydroelasticContactRepresentation::kTriangle, poses_, &surfaces2,
       &points2);
-  ASSERT_EQ(surfaces2.size(), N_ / 2);
-  ASSERT_EQ(points2.size(), N_ / 2);
+  ASSERT_EQ(surfaces2.size(), num_patch_contacts);
+  ASSERT_EQ(points2.size(), num_point_contacts);
 
-  for (size_t i = 0; i < N_ / 2; ++i) {
+  for (size_t i = 0; i < num_patch_contacts; ++i) {
     EXPECT_EQ(surfaces1[i].id_M(), surfaces2[i].id_M());
     EXPECT_EQ(surfaces1[i].id_N(), surfaces2[i].id_N());
+  }
+  for (size_t i = 0; i < num_point_contacts; ++i) {
     EXPECT_EQ(points1[i].id_A, points2[i].id_A);
     EXPECT_EQ(points1[i].id_B, points2[i].id_B);
   }

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -361,16 +361,55 @@ void CompliantContactManager<T>::
         // information (the volumetric side).
         const bool M_is_soft = s.HasGradE_M();
         const bool N_is_soft = s.HasGradE_N();
-        DRAKE_DEMAND(M_is_soft ^ N_is_soft);
 
-        // Pressure gradient always points into the soft geometry by
-        // construction.
-        const Vector3<T>& grad_pres_W =
-            M_is_soft ? s.EvaluateGradE_M_W(face) : s.EvaluateGradE_N_W(face);
+        // TODO(DamrongGuoy): Ask amcastro-tri to confirm the calculation
+        //  for the two-sided gradients from compliant-compliant contact
+        //  surface.
+
+        // Allow compliant-compliant but not rigid-rigid contact.
+        if (M_is_soft == N_is_soft) {
+          DRAKE_DEMAND(M_is_soft && N_is_soft);
+          static const logging::Warn log_once(
+              "AppendDiscreteContactPairsForHydroelasticContact()\n"
+              "The compliant-compliant hydroelastic contact model is not "
+              "ready yet.\n"
+              "Force and moment might be incorrect.");
+        }
+
+        // N.B. Here we use zero-gradients for rigid bodies; however,
+        // mathematically they should be infinity-gradients.
+        const Vector3<T>& gradE_M_W =
+            M_is_soft ? s.EvaluateGradE_M_W(face) : Vector3<T>::Zero();
+        const Vector3<T>& gradE_N_W =
+            N_is_soft ? s.EvaluateGradE_N_W(face) : Vector3<T>::Zero();
 
         // From ContactSurface's documentation: The normal of each face is
         // guaranteed to point "out of" N and "into" M.
         const Vector3<T>& nhat_W = s.face_normal(face);
+
+        // Normal pressure gradients (Pascal/meter) from each body.
+        const T gM = gradE_M_W.dot(nhat_W);
+        const T gN = gradE_N_W.dot(nhat_W);
+        // Effective pressure gradient g (Pascal/meter) from both bodies.
+        T g = 0;
+        // TODO(DamrongGuoy): Unify the if-else branches. Perhaps using
+        //  the infinity gradients will do it. I'm not sure how
+        //  AutoDiffXd will like it though.
+        using std::abs;
+        if (gM == 0) {
+          g = -gN;
+        } else if (gN == 0) {
+          g = gM;
+        } else if (abs(gM - gN) > 1.0e-14) {
+          g = gM * gN / (gM - gN);
+        } else {
+          continue;
+        }
+        // Prevent the pointwise contact stiffness k (Pascal*meter) from
+        // being non-positive. k = gA and f_{n,e} = (-k\phi)_+.
+        if (g <= 0) {
+          continue;
+        }
 
         // Position of quadrature point Q in the world frame (since mesh_W
         // is measured and expressed in W).
@@ -387,11 +426,6 @@ void CompliantContactManager<T>::
 
         // Force contribution by this quadrature point.
         const T fn0 = Ae * p0;
-
-        // Since the normal always points into M, regardless of which body
-        // is soft, we must take into account the change of sign when body
-        // N is soft and M is rigid.
-        const T sign = M_is_soft ? 1.0 : -1.0;
 
         // TODO(amcastro-tri): Re-wordsmith this so that it's less about
         //  "quadrature points" and "weights", and more about the first order
@@ -434,7 +468,7 @@ void CompliantContactManager<T>::
         // [Masterjohn, 2021] Masterjohn J., Guoy D., Shepherd J. and Castro
         // A., 2021. Discrete Approximation of Pressure Field Contact Patches.
         // Available at https://arxiv.org/abs/2110.04157.
-        const T k = sign * Ae * grad_pres_W.dot(nhat_W);
+        const T k = Ae * g;
 
         // N.B. The normal is guaranteed to point into M. However, when M
         // is soft, the gradient is not guaranteed to be in the direction
@@ -451,7 +485,7 @@ void CompliantContactManager<T>::
         // of k is correct, we decided to keep these contributions.
 
         // phi < 0 when in penetration.
-        const T phi0 = -sign * p0 / grad_pres_W.dot(nhat_W);
+        const T phi0 = -p0 / g;
 
         if (k > 0) {
           const T dissipation = tau * k;


### PR DESCRIPTION
This temporary PR is for verifying visually the geometry code for the compliant-compliant hydroelastic contact model. It also helps me make presentation materials to stakeholders as the project develops.

It works on top of #15545. This PR is not intended to merge. It should be closed without merging when roadmap #16040 is completed.

Run field_intersection_human_test to get VTK files for visual inspection in Paraview.  All other source codes are inherited from #15545; do not change them in this PR.  Keep rebasing on #15545.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16358)
<!-- Reviewable:end -->
