### PR TITLE
[primitives] Deprecate RandomSourced alias

### DIFF
--- a/systems/primitives/random_source.h
+++ b/systems/primitives/random_source.h
@@ -120,9 +120,10 @@ class RandomSource final : public LeafSystem<T> {
   std::optional<Seed> fixed_seed_;
 };
 
-// TODO(jwnimmer-tri) On 2022-01-01 we should deprecate this vestigial alias.
 /// A convenient alias for a RandomSource that uses the `double` scalar type.
-using RandomSourced = RandomSource<double>;
+using RandomSourced
+    DRAKE_DEPRECATED("2022-05-01", "Use RandomSource<double> instead.")
+    = RandomSource<double>;
 
 /// For each subsystem input port in @p builder that is (a) not yet connected
 /// and (b) labeled as random in the InputPort, this method will add a


### PR DESCRIPTION
Users should spell out `RandomSource<double>` instead.

This alias was here as part of a transition plan -- the `class RandomSource` was previously un-templated; in the process of making it be templated, we offered this helper in the meantime.  With the exception of a few key classes (`RotationMatrix`, etc.) we tend _not_ to off the `Myclassd = MyClass<double>` aliases in Drake.  We should really just be using CTAD (and/or `T = double` in more places, instead).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16359)
<!-- Reviewable:end -->
