### PR TITLE
[framework] Fix a deprecation date typo

### DIFF
--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -402,7 +402,7 @@ class System : public SystemBase {
   @pre the port must be evaluable (connected or fixed).
 
   @see InputPort::Eval() */
-  DRAKE_DEPRECATED("2021-03-01",
+  DRAKE_DEPRECATED("2022-03-01",
       "Use get_input_port(index).Eval(context) instead.")
   Eigen::VectorBlock<const VectorX<T>> EvalEigenVectorInput(
       const Context<T>& context, int port_index) const;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16361)
<!-- Reviewable:end -->
