### PR TITLE
[geometry] Refactor a lighter version of SliceTetWithPlane()

### DIFF
--- a/geometry/proximity/mesh_plane_intersection.cc
+++ b/geometry/proximity/mesh_plane_intersection.cc
@@ -61,6 +61,49 @@ constexpr std::array<std::array<int, 4>, 16> kMarchingTetsTable = {
 
 }  // namespace
 
+template <typename T>
+void SliceTetrahedronWithPlane(int tet_index, const VolumeMesh<double>& mesh_M,
+                               const Plane<T>& plane_M,
+                               std::vector<Vector3<T>>* polygon_vertices) {
+  T distance[4];
+  // Bit encoding of the sign of signed-distance: v0, v1, v2, v3.
+  int intersection_code = 0;
+  for (int i = 0; i < 4; ++i) {
+    const int v = mesh_M.element(tet_index).vertex(i);
+    distance[i] = plane_M.CalcHeight(mesh_M.vertex(v));
+    if (distance[i] > T(0)) intersection_code |= 1 << i;
+  }
+
+  const std::array<int, 4>& intersected_edges =
+      kMarchingTetsTable[intersection_code];
+
+  // No intersecting edges --> no intersection.
+  if (intersected_edges[0] == -1) return;
+
+  int num_intersections = 0;
+  for (int e = 0; e < 4; ++e) {
+    const int edge_index = intersected_edges[e];
+    if (edge_index == -1) break;
+    ++num_intersections;
+    const TetrahedronEdge& tet_edge = kTetEdges[edge_index];
+    const int v0 = mesh_M.element(tet_index).vertex(tet_edge.first);
+    const int v1 = mesh_M.element(tet_index).vertex(tet_edge.second);
+    const SortedPair<int> mesh_edge{v0, v1};
+
+    const Vector3<double>& p_MV0 = mesh_M.vertex(v0);
+    const Vector3<double>& p_MV1 = mesh_M.vertex(v1);
+    const T d_v0 = distance[tet_edge.first];
+    const T d_v1 = distance[tet_edge.second];
+    // Note: It should be impossible for the denominator to be zero. By
+    // definition, this is an edge that is split by the plane; they can't
+    // both have the same value. More particularly, one must be strictly
+    // positive the other must be strictly non-positive.
+    const T t = d_v0 / (d_v0 - d_v1);
+    const Vector3<T> p_MC = p_MV0 + t * (p_MV1 - p_MV0);
+    polygon_vertices->push_back(p_MC);
+  }
+}
+
 template <typename MeshBuilder>
 int SliceTetWithPlane(
     int tet_index, const VolumeMeshFieldLinear<double, double>& field_M,
@@ -261,8 +304,9 @@ ComputeContactSurface<PolyMeshBuilder<AutoDiffXd>>(
     GeometryId plane_id, const Plane<AutoDiffXd>&, const std::vector<int>&,
     const math::RigidTransform<AutoDiffXd>&);
 
-DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
-    (&ComputeContactSurfaceFromSoftVolumeRigidHalfSpace<T>))
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    &ComputeContactSurfaceFromSoftVolumeRigidHalfSpace<T>,
+    &SliceTetrahedronWithPlane<T>))
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/mesh_plane_intersection.h
+++ b/geometry/proximity/mesh_plane_intersection.h
@@ -17,10 +17,34 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
+/* Lighter version of SliceTetWithPlane(). It doesn't require a MeshBuilder
+ and works on a tetrahedral mesh directly. No _linear_ volume mesh field is
+ needed since it doesn't perform linear interpolation of field values.
+
+ The output polygon is represented by a sequence of vertices ordered such that
+ the normal implied by their winding points in the direction of the plane's
+ normal.
+
+ @param[in] tet_index       The index of the tetrahedron to attempt to
+                            intersect.
+ @param[in] mesh_M          The mesh containing the tetrahedron to intersect.
+                            The vertex positions are all measured and expressed
+                            in Frame M.
+ @param[in] plane_M         The definition of a plane measured and expressed
+                            in Frame M.
+ @param[out] polygon_vertices_M  The output polygon is represented as a
+                            sequence of vertex positions in Frame M. It is
+                            empty if there is no intersection.
+
+ @returns an entry of a marching tetrahedron table that encodes which of the
+ six edges of the tetrahedron intersects the plane.
+
+ @pre `tet_index` lies in the range `[0, mesh_M.num_elements())`.
+ */
 template <typename T>
-void SliceTetrahedronWithPlane(int tet_index, const VolumeMesh<double>& mesh_M,
-                               const Plane<T>& plane_M,
-                               std::vector<Vector3<T>>* polygon_vertices);
+const std::array<int, 4>& SliceTetrahedronWithPlane(
+    int tet_index, const VolumeMesh<double>& mesh_M, const Plane<T>& plane_M,
+    std::vector<Vector3<T>>* polygon_vertices_M);
 
 /* Intersects a tetrahedron with a plane, the resulting polygon is passed
  into the provided MeshBuilder.

--- a/geometry/proximity/mesh_plane_intersection.h
+++ b/geometry/proximity/mesh_plane_intersection.h
@@ -17,6 +17,11 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
+template <typename T>
+void SliceTetrahedronWithPlane(int tet_index, const VolumeMesh<double>& mesh_M,
+                               const Plane<T>& plane_M,
+                               std::vector<Vector3<T>>* polygon_vertices);
+
 /* Intersects a tetrahedron with a plane, the resulting polygon is passed
  into the provided MeshBuilder.
 


### PR DESCRIPTION
Related to #16040.
- This lighter version will be re-used in computing contact surfaces between
  two compliant hydroelastic tetrahedral meshes (see #15545).
- For compliant mesh vs. rigid plane, the existing SliceTetWithPlane requires
  MeshBuilder template and interpolates field values onto vertices of the
  intersected polygon. Here, we create a lighter version without those overhead.
- The existing version calls the lighter version and continues to work for
  the compliant mesh vs. rigid plane.

This PR belongs to a multi-PRs strategy (some are rebased on the others), so we'll need to merge them in the right order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16363)
<!-- Reviewable:end -->
