### PR TITLE
Add SceneGraphInspector::GetParent(FrameId)

### DIFF
--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -239,7 +239,7 @@ const std::string& GeometryState<T>::GetName(FrameId frame_id) const {
 }
 
 template <typename T>
-FrameId GeometryState<T>::GetParent(FrameId frame_id) const {
+FrameId GeometryState<T>::GetParentFrame(FrameId frame_id) const {
   FindOrThrow(frame_id, frames_, [frame_id]() {
     return "No frame name available for invalid frame id: " +
         to_string(frame_id);

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -239,6 +239,20 @@ const std::string& GeometryState<T>::GetName(FrameId frame_id) const {
 }
 
 template <typename T>
+FrameId GeometryState<T>::GetParent(FrameId frame_id) const {
+  FindOrThrow(frame_id, frames_, [frame_id]() {
+    return "No frame name available for invalid frame id: " +
+        to_string(frame_id);
+  });
+  const FrameId parent_frame_id = frames_.at(frame_id).parent_frame_id();
+  if (parent_frame_id == frame_id) {
+    // If there's no parent frame then world frame is implicitly the parent
+    return InternalFrame::world_frame_id();
+  }
+  return parent_frame_id;
+}
+
+template <typename T>
 int GeometryState<T>::GetFrameGroup(FrameId frame_id) const {
   FindOrThrow(frame_id, frames_, [frame_id]() {
     return "No frame group available for invalid frame id: " +

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -173,6 +173,9 @@ class GeometryState {
   /** Implementation of SceneGraphInspector::GetName(FrameId) const.  */
   const std::string& GetName(FrameId frame_id) const;
 
+  /** Implementation of SceneGraphInspector::GetParent(FrameId) const.  */
+  FrameId GetParent(FrameId frame_id) const;
+
   /** Implementation of SceneGraphInspector::GetFrameGroup().  */
   int GetFrameGroup(FrameId frame_id) const;
 

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -173,8 +173,8 @@ class GeometryState {
   /** Implementation of SceneGraphInspector::GetName(FrameId) const.  */
   const std::string& GetName(FrameId frame_id) const;
 
-  /** Implementation of SceneGraphInspector::GetParent(FrameId) const.  */
-  FrameId GetParent(FrameId frame_id) const;
+  /** Implementation of SceneGraphInspector::GetParentFrame(FrameId) const.  */
+  FrameId GetParentFrame(FrameId frame_id) const;
 
   /** Implementation of SceneGraphInspector::GetFrameGroup().  */
   int GetFrameGroup(FrameId frame_id) const;

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -254,9 +254,9 @@ class SceneGraphInspector {
   /** Reports the FrameId of the parent of `frame_id`.
    @throws std::exception if `frame_id` does not map to a registered frame.
    */
-  FrameId GetParent(FrameId frame_id) const {
+  FrameId GetParentFrame(FrameId frame_id) const {
     DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetParent(frame_id);
+    return state_->GetParentFrame(frame_id);
   }
 
   /** Reports the frame group for the frame with the given `frame_id`.

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -251,6 +251,14 @@ class SceneGraphInspector {
     return state_->GetName(frame_id);
   }
 
+  /** Reports the FrameId of the parent of `frame_id`.
+   @throws std::exception if `frame_id` does not map to a registered frame.
+   */
+  FrameId GetParent(FrameId frame_id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetParent(frame_id);
+  }
+
   /** Reports the frame group for the frame with the given `frame_id`.
    @throws std::exception if `frame_id` does not map to a registered frame.
    @internal This value is equivalent to the old "model instance id".  */

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/geometry_state.h"
 
 #include <algorithm>
+#include <map>
 #include <memory>
 #include <set>
 #include <unordered_set>
@@ -2357,7 +2358,7 @@ TEST_F(GeometryStateTest, GeometryAncestryStorage) {
   SetUpSingleSourceTree();
 
   // {child, parent}
-  std::vector<std::pair<std::string, std::string>> expected_relationships = {
+  std::map<std::string, std::string> expected_relationships = {
     {"world", "world"},
     {"f0", "world"},
     {"f1", "world"},
@@ -2371,19 +2372,7 @@ TEST_F(GeometryStateTest, GeometryAncestryStorage) {
     const FrameId parent_frame_id = geometry_state_.GetParentFrame(frame_id);
     const std::string& parent_frame_name = geometry_state_.GetName(
         parent_frame_id);
-    bool found_relationship;
-
-    for (const auto& relationship : expected_relationships) {
-      const std::string & expected_frame_name = relationship.first;
-      const std::string & expected_parent_name = relationship.second;
-      if (expected_frame_name == frame_name) {
-        EXPECT_EQ(expected_parent_name, parent_frame_name);
-        found_relationship = true;
-        break;
-      }
-    }
-    EXPECT_TRUE(found_relationship)
-      << "test knows no relationship for [" << frame_name << "]";
+    EXPECT_EQ(parent_frame_name, expected_relationships[frame_name]);
   }
 }
 

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -2368,7 +2368,7 @@ TEST_F(GeometryStateTest, GeometryAncestryStorage) {
 
   for (const FrameId frame_id : geometry_state_.get_frame_ids()) {
     const std::string& frame_name = geometry_state_.GetName(frame_id);
-    const FrameId parent_frame_id = geometry_state_.GetParent(frame_id);
+    const FrameId parent_frame_id = geometry_state_.GetParentFrame(frame_id);
     const std::string& parent_frame_name = geometry_state_.GetName(
         parent_frame_id);
     bool found_relationship;

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -2382,7 +2382,7 @@ TEST_F(GeometryStateTest, GeometryAncestryStorage) {
         break;
       }
     }
-    ASSERT_TRUE(found_relationship)
+    EXPECT_TRUE(found_relationship)
       << "test knows no relationship for [" << frame_name << "]";
   }
 }

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -2352,6 +2352,41 @@ TEST_F(GeometryStateTest, GeometryNameStorage) {
   }
 }
 
+// Confirms parental relationships between frames are stored
+TEST_F(GeometryStateTest, GeometryAncestryStorage) {
+  SetUpSingleSourceTree();
+
+  // {child, parent}
+  std::vector<std::pair<std::string, std::string>> expected_relationships = {
+    {"world", "world"},
+    {"f0", "world"},
+    {"f1", "world"},
+    {"f2", "f1"},
+  };
+
+  ASSERT_EQ(expected_relationships.size(), geometry_state_.get_num_frames());
+
+  for (const FrameId frame_id : geometry_state_.get_frame_ids()) {
+    const std::string& frame_name = geometry_state_.GetName(frame_id);
+    const FrameId parent_frame_id = geometry_state_.GetParent(frame_id);
+    const std::string& parent_frame_name = geometry_state_.GetName(
+        parent_frame_id);
+    bool found_relationship;
+
+    for (const auto& relationship : expected_relationships) {
+      const std::string & expected_frame_name = relationship.first;
+      const std::string & expected_parent_name = relationship.second;
+      if (expected_frame_name == frame_name) {
+        EXPECT_EQ(expected_parent_name, parent_frame_name);
+        found_relationship = true;
+        break;
+      }
+    }
+    ASSERT_TRUE(found_relationship)
+      << "test knows no relationship for [" << frame_name << "]";
+  }
+}
+
 // Tests the logic for confirming if a name is valid or not.
 TEST_F(GeometryStateTest, GeometryNameValidation) {
   SetUpSingleSourceTree(Assign::kProximity);

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -69,6 +69,7 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   inspector.BelongsToSource(frame_id, source_id);
   inspector.GetOwningSourceName(frame_id);
   inspector.GetName(frame_id);
+  inspector.GetParent(frame_id);
   inspector.GetFrameGroup(frame_id);
   inspector.NumGeometriesForFrame(frame_id);
   inspector.NumGeometriesForFrameWithRole(frame_id, Role::kUnassigned);

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -69,7 +69,7 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   inspector.BelongsToSource(frame_id, source_id);
   inspector.GetOwningSourceName(frame_id);
   inspector.GetName(frame_id);
-  inspector.GetParent(frame_id);
+  inspector.GetParentFrame(frame_id);
   inspector.GetFrameGroup(frame_id);
   inspector.NumGeometriesForFrame(frame_id);
   inspector.NumGeometriesForFrameWithRole(frame_id, Role::kUnassigned);


### PR DESCRIPTION
This adds a new API `SceneGraphInspector::GetParent()` to get the parent frame given a `FrameId` of the child. The motivation is to enable RobotLocomotion/drake-ros#20 to include the parent/child relationships in the published tf tree.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16368)
<!-- Reviewable:end -->
