### PR TITLE
Don't memcheck lcm_vector_gen_test

### DIFF
--- a/tools/vector_gen/BUILD.bazel
+++ b/tools/vector_gen/BUILD.bazel
@@ -81,6 +81,8 @@ sh_test(
         "test/goal/sample.h",
         "test/lcmt_sample_t.lcm",
     ],
+    # Valgrind Memcheck reports several leaks in the sed executable.
+    tags = ["no_memcheck"],
 )
 
 add_lint_tests()


### PR DESCRIPTION
Exclude `lcm_vector_gen_test` from being run under `valgrind` (memcheck). This test is just a shell script comparing some generated output to the expected output, so does not gain anything by being run under valgrind. However, on Focal, valgrind reports errors in `sed`, resulting in a test failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16372)
<!-- Reviewable:end -->
