### PR TITLE
adding dual iiwa14 polytope collision test

### DIFF
--- a/manipulation/models/iiwa_description/test/iiwa14_variants_parsing_test.cc
+++ b/manipulation/models/iiwa_description/test/iiwa14_variants_parsing_test.cc
@@ -66,7 +66,9 @@ GTEST_TEST(JointLimitsIiwa14, TestEffortVelocityPositionValues) {
       "drake/manipulation/models/iiwa_description/urdf/"
       "iiwa14_spheres_dense_collision.urdf",
       "drake/manipulation/models/iiwa_description/urdf/"
-      "iiwa14_spheres_dense_elbow_collision.urdf"};
+      "iiwa14_spheres_dense_elbow_collision.urdf",
+      "drake/manipulation/models/iiwa_description/urdf/"
+      "dual_iiwa14_polytope_collision.urdf"};
 
   for (auto& model_file : model_files) {
     multibody::MultibodyPlant<double> plant(0.0);
@@ -82,6 +84,17 @@ GTEST_TEST(JointLimitsIiwa14, TestEffortVelocityPositionValues) {
           plant.get_joint_actuator(drake::multibody::JointActuatorIndex(i));
 
       CompareActuatorLimits(canonical_joint_actuator, joint_actuator);
+
+      // Test the joints from the second instance of tue dual iiwa14 polytope
+      // collision model. They correspond to joints 7 to 13 of the model.
+      if (model_file.substr(model_file.find_last_of('/') + 1) ==
+          "dual_iiwa14_polytope_collision.urdf") {
+        const multibody::JointActuator<double>& second_instance_joint_actuator =
+            plant.get_joint_actuator(
+                drake::multibody::JointActuatorIndex(i + 7));
+        CompareActuatorLimits(canonical_joint_actuator,
+                              second_instance_joint_actuator);
+      }
     }
   }
 }

--- a/manipulation/models/iiwa_description/test/iiwa14_variants_parsing_test.cc
+++ b/manipulation/models/iiwa_description/test/iiwa14_variants_parsing_test.cc
@@ -85,7 +85,7 @@ GTEST_TEST(JointLimitsIiwa14, TestEffortVelocityPositionValues) {
 
       CompareActuatorLimits(canonical_joint_actuator, joint_actuator);
 
-      // Test the joints from the second instance of tue dual iiwa14 polytope
+      // Test the joints from the second instance of the dual iiwa14 polytope
       // collision model. They correspond to joints 7 to 13 of the model.
       if (model_file.substr(model_file.find_last_of('/') + 1) ==
           "dual_iiwa14_polytope_collision.urdf") {


### PR DESCRIPTION
Missed test in https://github.com/RobotLocomotion/drake/pull/16003.

Adding `dual_iiwa14_polytope_collision.urdf` to the tests. 

Since this `URDF` contains two instances of the `iiwa14_polytope_collision` model, the extra test steps have been added.

@EricCousineau-TRI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16376)
<!-- Reviewable:end -->
