### PR TITLE
Iiwa14 acceleration limits

### DIFF
--- a/manipulation/models/iiwa_description/README.md
+++ b/manipulation/models/iiwa_description/README.md
@@ -66,12 +66,12 @@ on 2022-01-15)
 
 For the record, acceleration limits:
 
-|Axis data  |    deg/s    |     rad/s     |
-|-----------|------------:|--------------:|
-|Axis 1 (A1)|490.77 deg/s |8.57 rad/s     |
-|Axis 2 (A2)|490.80 deg/s |8.57 rad/s     |
-|Axis 3 (A3)|500.77 deg/s |8.74 rad/s     |
-|Axis 4 (A4)|650.71 deg/s |11.36 rad/s    |
-|Axis 5 (A5)|700.73 deg/s |12.23 rad/s    |
-|Axis 6 (A6)|900.66 deg/s |15.72 rad/s    |
-|Axis 7 (A7)|900.69 deg/s |15.72 rad/s    |
+|Axis data  | deg/s^2 | rad/s^2 |
+|-----------|--------:|--------:|
+|Axis 1 (A1)|490.77   |8.57     |
+|Axis 2 (A2)|490.80   |8.57     |
+|Axis 3 (A3)|500.77   |8.74     |
+|Axis 4 (A4)|650.71   |11.36    |
+|Axis 5 (A5)|700.73   |12.23    |
+|Axis 6 (A6)|900.66   |15.72    |
+|Axis 7 (A7)|900.69   |15.72    |

--- a/manipulation/models/iiwa_description/README.md
+++ b/manipulation/models/iiwa_description/README.md
@@ -65,9 +65,9 @@ Christian Larsen, Gothenburg, Sweden 2019. (URL:
 on 2022-01-15)
 
 The average acceleration limits are used, and rounded to second decimal
-place.
+place for radians.
 
-For the record, te rounded average acceleration limits:
+For the record, the rounded average acceleration limits:
 
 |Axis data  | deg/s^2 | rad/s^2 |
 |-----------|--------:|--------:|

--- a/manipulation/models/iiwa_description/README.md
+++ b/manipulation/models/iiwa_description/README.md
@@ -64,7 +64,10 @@ Christian Larsen, Gothenburg, Sweden 2019. (URL:
 <https://odr.chalmers.se/bitstream/20.500.12380/256658/1/256658.pdf>, Accessed
 on 2022-01-15)
 
-For the record, acceleration limits:
+The average acceleration limits are used, and rounded to second decimal
+place.
+
+For the record, te rounded average acceleration limits:
 
 |Axis data  | deg/s^2 | rad/s^2 |
 |-----------|--------:|--------:|

--- a/manipulation/models/iiwa_description/README.md
+++ b/manipulation/models/iiwa_description/README.md
@@ -30,13 +30,13 @@ manually.
 
 ## Additional Edits
 
+Limits have been added to the xacro files, and then manually merged into the
+hand-edited files.
+
 ### Velocity and Effort Limits
 
-Velocity and effort limits have been added to the xacro files, and then manually
-merged into the hand-edited files.
-
-The limits were derived from the third table at page 30 of the followking KUKA
-brochure:
+Velocity and effort limits were derived from the third table at page 30 of the
+followking KUKA brochure:
 
 * "KUKA Sensitive robotics_LBR iiwa. (URL:
 <https://www.kuka.com/-/media/kuka-downloads/imported/9cb8e311bfd744b4b0eab25ca883f6d3/kuka_lbr_iiwa_brochure_en.pdf>
@@ -53,3 +53,25 @@ For the record, the velocity and effort limits:
 |Axis 5 (A5)|110 Nm     |130 deg/s    |
 |Axis 6 (A6)|40 Nm      |135 deg/s    |
 |Axis 7 (A7)|40 Nm      |135 deg/s    |
+
+### Acceleration Limits
+
+Acceleration limits were derived from experimental results listed in Table 4
+(page 50) of the following Master's thesis:
+
+* "Including a Collaborative Robot in Digital Twin Manufacturing Systems",
+Christian Larsen, Gothenburg, Sweden 2019. (URL:
+<https://odr.chalmers.se/bitstream/20.500.12380/256658/1/256658.pdf>, Accessed
+on 2022-01-15)
+
+For the record, acceleration limits:
+
+|Axis data  |    deg/s    |     rad/s     |
+|-----------|------------:|--------------:|
+|Axis 1 (A1)|490.77 deg/s |8.57 rad/s     |
+|Axis 2 (A2)|490.80 deg/s |8.57 rad/s     |
+|Axis 3 (A3)|500.77 deg/s |8.74 rad/s     |
+|Axis 4 (A4)|650.71 deg/s |11.36 rad/s    |
+|Axis 5 (A5)|700.73 deg/s |12.23 rad/s    |
+|Axis 6 (A6)|900.66 deg/s |15.72 rad/s    |
+|Axis 7 (A7)|900.69 deg/s |15.72 rad/s    |

--- a/manipulation/models/iiwa_description/sdf/iiwa14_no_collision.sdf
+++ b/manipulation/models/iiwa_description/sdf/iiwa14_no_collision.sdf
@@ -77,6 +77,7 @@ Later edited by hand to:
           <upper>2.96705972839</upper>
           <effort>320</effort>
           <velocity>1.4835298641951802</velocity>
+          <drake:acceleration>8.57</drake:acceleration>
         </limit>
         <dynamics>
           <damping>0.0</damping>
@@ -139,6 +140,7 @@ Later edited by hand to:
           <upper>2.09439510239</upper>
           <effort>320</effort>
           <velocity>1.4835298641951802</velocity>
+          <drake:acceleration>8.57</drake:acceleration>
         </limit>
         <dynamics>
           <damping>0.0</damping>
@@ -210,6 +212,7 @@ Later edited by hand to:
           <upper>2.96705972839</upper>
           <effort>176</effort>
           <velocity>1.7453292519943295</velocity>
+          <drake:acceleration>8.74</drake:acceleration>
         </limit>
         <dynamics>
           <damping>0.0</damping>
@@ -270,6 +273,7 @@ Later edited by hand to:
           <upper>2.09439510239</upper>
           <effort>176</effort>
           <velocity>1.3089969389957472</velocity>
+          <drake:acceleration>11.36</drake:acceleration>
         </limit>
         <dynamics>
           <damping>0.0</damping>
@@ -341,6 +345,7 @@ Later edited by hand to:
           <upper>2.96705972839</upper>
           <effort>110</effort>
           <velocity>2.2689280275926285</velocity>
+          <drake:acceleration>12.23</drake:acceleration>
         </limit>
         <dynamics>
           <damping>0.0</damping>
@@ -401,6 +406,7 @@ Later edited by hand to:
           <upper>2.09439510239</upper>
           <effort>40</effort>
           <velocity>2.356194490192345</velocity>
+          <drake:acceleration>15.72</drake:acceleration>
         </limit>
         <dynamics>
           <damping>0.0</damping>
@@ -452,6 +458,7 @@ Later edited by hand to:
           <upper>3.05432619099</upper>
           <effort>40</effort>
           <velocity>2.356194490192345</velocity>
+          <drake:acceleration>15.72</drake:acceleration>
         </limit>
         <dynamics>
           <damping>0.0</damping>

--- a/manipulation/models/iiwa_description/sdf/iiwa14_polytope_collision.sdf
+++ b/manipulation/models/iiwa_description/sdf/iiwa14_polytope_collision.sdf
@@ -73,6 +73,7 @@ Later edited by hand to rename the base link and remove damping from the joints.
           <upper>2.96705972839</upper>
           <effort>320</effort>
           <velocity>1.4835298641951802</velocity>
+          <drake:acceleration>8.57</drake:acceleration>
         </limit>
         <dynamics>
           <damping>0</damping>
@@ -132,6 +133,7 @@ Later edited by hand to rename the base link and remove damping from the joints.
           <upper>2.09439510239</upper>
           <effort>320</effort>
           <velocity>1.4835298641951802</velocity>
+          <drake:acceleration>8.57</drake:acceleration>
         </limit>
         <dynamics>
           <damping>0</damping>
@@ -202,6 +204,7 @@ Later edited by hand to rename the base link and remove damping from the joints.
           <upper>2.96705972839</upper>
           <effort>176</effort>
           <velocity>1.7453292519943295</velocity>
+          <drake:acceleration>8.74</drake:acceleration>
         </limit>
         <dynamics>
           <damping>0</damping>
@@ -261,6 +264,7 @@ Later edited by hand to rename the base link and remove damping from the joints.
           <upper>2.09439510239</upper>
           <effort>176</effort>
           <velocity>1.3089969389957472</velocity>
+          <drake:acceleration>11.36</drake:acceleration>
         </limit>
         <dynamics>
           <damping>0</damping>
@@ -331,6 +335,7 @@ Later edited by hand to rename the base link and remove damping from the joints.
           <upper>2.96705972839</upper>
           <effort>110</effort>
           <velocity>2.2689280275926285</velocity>
+          <drake:acceleration>12.23</drake:acceleration>
         </limit>
         <dynamics>
           <damping>0</damping>
@@ -390,6 +395,7 @@ Later edited by hand to rename the base link and remove damping from the joints.
           <upper>2.09439510239</upper>
           <effort>40</effort>
           <velocity>2.356194490192345"</velocity>
+          <drake:acceleration>15.72</drake:acceleration>
         </limit>
         <dynamics>
           <damping>0</damping>
@@ -455,9 +461,9 @@ Later edited by hand to rename the base link and remove damping from the joints.
         <limit>
           <lower>-3.05432619099</lower>
           <upper>3.05432619099</upper>
-
           <effort>40</effort>
           <velocity>2.356194490192345"</velocity>
+          <drake:acceleration>15.72</drake:acceleration>
         </limit>
         <dynamics>
           <damping>0</damping>

--- a/manipulation/models/iiwa_description/test/iiwa14_variants_parsing_test.cc
+++ b/manipulation/models/iiwa_description/test/iiwa14_variants_parsing_test.cc
@@ -21,7 +21,8 @@ multibody::ModelInstanceIndex LoadIiwa14CanonicalModel(
   return parser.AddModelFromFile(canonical_model_file);
 }
 
-// Compares velocity, effort and position limits of two given actuators
+// Compares velocity, acceleration, effort and position limits of two given
+// actuators.
 void CompareActuatorLimits(const multibody::JointActuator<double>& joint_a,
                            const multibody::JointActuator<double>& joint_b) {
   EXPECT_NE(&joint_a, &joint_b);  // Different instance.
@@ -34,6 +35,10 @@ void CompareActuatorLimits(const multibody::JointActuator<double>& joint_a,
   EXPECT_TRUE(CompareMatrices(joint_a.joint().position_upper_limits(),
                               joint_b.joint().position_upper_limits()));
   EXPECT_EQ(joint_a.effort_limit(), joint_b.effort_limit());
+  EXPECT_TRUE(CompareMatrices(joint_a.joint().acceleration_lower_limits(),
+            joint_b.joint().acceleration_lower_limits()));
+  EXPECT_TRUE(CompareMatrices(joint_a.joint().acceleration_upper_limits(),
+            joint_b.joint().acceleration_upper_limits()));
 }
 
 // Tests that KUKA LBR iiwa14 models have consistent joint limits.

--- a/manipulation/models/iiwa_description/urdf/dual_iiwa14_polytope_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/dual_iiwa14_polytope_collision.urdf
@@ -13,7 +13,7 @@
      polytope model.
 -->
 <!-- ===================================================================== -->
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="dual_iiwa14">
+<robot xmlns:drake="http://drake.mit.edu" xmlns:xacro="http://www.ros.org/wiki/xacro" name="dual_iiwa14">
   <!-- Import Rviz colors -->
   <material name="Black">
     <color rgba="0.0 0.0 0.0 1.0"/>
@@ -77,7 +77,7 @@
     <child link="left_iiwa_link_1"/>
     <origin rpy="0 0 0" xyz="0 0 0.1575"/>
     <axis xyz="0 0 1"/>
-    <limit effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
+    <limit drake:acceleration="8.57" effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.93215314335" soft_upper_limit="2.93215314335"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -101,7 +101,7 @@
     <child link="left_iiwa_link_2"/>
     <origin rpy="1.570796326794897   0 3.141592653589793" xyz="0 0 0.2025"/>
     <axis xyz="0 0 1"/>
-    <limit effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
+    <limit drake:acceleration="8.57" effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -134,7 +134,7 @@
     <child link="left_iiwa_link_3"/>
     <origin rpy="1.570796326794897 0 3.141592653589793" xyz="0 0.2045 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
+    <limit drake:acceleration="8.74" effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -174,7 +174,7 @@
     <child link="left_iiwa_link_4"/>
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
-    <limit effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
+    <limit drake:acceleration="11.36" effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -207,7 +207,7 @@
     <child link="left_iiwa_link_5"/>
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.1845 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
+    <limit drake:acceleration="12.23" effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -247,7 +247,7 @@
     <child link="left_iiwa_link_6"/>
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
-    <limit effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
+    <limit drake:acceleration="15.72" effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -280,7 +280,7 @@
     <child link="left_iiwa_link_7"/>
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.081 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
+    <limit drake:acceleration="15.72" effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-3.01941960595" soft_upper_limit="3.01941960595"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -486,7 +486,7 @@
     <child link="right_iiwa_link_1"/>
     <origin rpy="0 0 0" xyz="0 0 0.1575"/>
     <axis xyz="0 0 1"/>
-    <limit effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
+    <limit drake:acceleration="8.57" effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.93215314335" soft_upper_limit="2.93215314335"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -510,7 +510,7 @@
     <child link="right_iiwa_link_2"/>
     <origin rpy="1.570796326794897   0 3.141592653589793" xyz="0 0 0.2025"/>
     <axis xyz="0 0 1"/>
-    <limit effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
+    <limit drake:acceleration="8.57" effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -543,7 +543,7 @@
     <child link="right_iiwa_link_3"/>
     <origin rpy="1.570796326794897 0 3.141592653589793" xyz="0 0.2045 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
+    <limit drake:acceleration="8.74" effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -583,7 +583,7 @@
     <child link="right_iiwa_link_4"/>
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
-    <limit effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
+    <limit drake:acceleration="11.36" effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -616,7 +616,7 @@
     <child link="right_iiwa_link_5"/>
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.1845 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
+    <limit drake:acceleration="12.23" effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -656,7 +656,7 @@
     <child link="right_iiwa_link_6"/>
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
-    <limit effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
+    <limit drake:acceleration="15.72" effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -689,7 +689,7 @@
     <child link="right_iiwa_link_7"/>
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.081 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
+    <limit drake:acceleration="15.72" effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-3.01941960595" soft_upper_limit="3.01941960595"/>
     <dynamics damping="0.5"/>
   </joint>

--- a/manipulation/models/iiwa_description/urdf/iiwa14.xacro
+++ b/manipulation/models/iiwa_description/urdf/iiwa14.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot xmlns:drake="http://drake.mit.edu" xmlns:xacro="http://www.ros.org/wiki/xacro">
   <!-- Provide additional material for the silver logo band. -->
   <material name="Silver">
     <color rgba="0.6 0.6 0.6 1.0"/>
@@ -66,7 +66,7 @@
       <child link="${robot_name}_link_1"/>
       <origin xyz="0 0 0.1575" rpy="0 0 0"/>
       <axis xyz="0 0 1"/>
-      <limit lower="${-170 * PI / 180}" upper="${170 * PI / 180}" effort="320" velocity="${85 * PI / 180}"/>
+      <limit lower="${-170 * PI / 180}" upper="${170 * PI / 180}" effort="320" velocity="${85 * PI / 180}" drake:acceleration="8.57"/>
       <safety_controller soft_lower_limit="${-168 * PI / 180}" soft_upper_limit="${168 * PI / 180}" k_position="${safety_controller_k_pos}" k_velocity="${safety_controller_k_vel}"/>
       <dynamics damping="${joint_damping}"/>
     </joint>
@@ -109,7 +109,7 @@
       <child link="${robot_name}_link_2"/>
       <origin xyz="0 0 0.2025" rpy="${PI / 2}   0 ${PI}"/>
       <axis xyz="0 0 1"/>
-      <limit lower="${-120 * PI / 180}" upper="${120 * PI / 180}" effort="320" velocity="${85 * PI / 180}"/>
+      <limit lower="${-120 * PI / 180}" upper="${120 * PI / 180}" effort="320" velocity="${85 * PI / 180}" drake:acceleration="8.57"/>
       <safety_controller soft_lower_limit="${-118 * PI / 180}" soft_upper_limit="${118 * PI / 180}" k_position="${safety_controller_k_pos}" k_velocity="${safety_controller_k_vel}"/>
       <dynamics damping="${joint_damping}"/>
     </joint>
@@ -161,7 +161,7 @@
       <child link="${robot_name}_link_3"/>
       <origin xyz="0 0.2045 0" rpy="${PI / 2} 0 ${PI}"/>
       <axis xyz="0 0 1"/>
-      <limit lower="${-170 * PI / 180}" upper="${170 * PI / 180}" effort="176" velocity="${100 * PI / 180}"/>
+      <limit lower="${-170 * PI / 180}" upper="${170 * PI / 180}" effort="176" velocity="${100 * PI / 180}" drake:acceleration="8.74"/>
       <safety_controller soft_lower_limit="${-118 * PI / 180}" soft_upper_limit="${118 * PI / 180}" k_position="${safety_controller_k_pos}" k_velocity="${safety_controller_k_vel}"/>
       <dynamics damping="${joint_damping}"/>
     </joint>
@@ -220,7 +220,7 @@
       <child link="${robot_name}_link_4"/>
       <origin xyz="0 0 0.2155" rpy="${PI / 2} 0 0"/>
       <axis xyz="0 0 1"/>
-      <limit lower="${-120 * PI / 180}" upper="${120 * PI / 180}" effort="176" velocity="${75 * PI / 180}"/>
+      <limit lower="${-120 * PI / 180}" upper="${120 * PI / 180}" effort="176" velocity="${75 * PI / 180}" drake:acceleration="11.36"/>
       <safety_controller soft_lower_limit="${-118 * PI / 180}" soft_upper_limit="${118 * PI / 180}" k_position="${safety_controller_k_pos}" k_velocity="${safety_controller_k_vel}"/>
       <dynamics damping="${joint_damping}"/>
     </joint>
@@ -272,7 +272,7 @@
       <child link="${robot_name}_link_5"/>
       <origin xyz="0 0.1845 0" rpy="${-PI / 2} ${PI} 0"/>
       <axis xyz="0 0 1"/>
-      <limit lower="${-170 * PI / 180}" upper="${170 * PI / 180}" effort="110" velocity="${130 * PI / 180}"/>
+      <limit lower="${-170 * PI / 180}" upper="${170 * PI / 180}" effort="110" velocity="${130 * PI / 180}" drake:acceleration="12.23"/>
       <safety_controller soft_lower_limit="${-118 * PI / 180}" soft_upper_limit="${118 * PI / 180}" k_position="${safety_controller_k_pos}" k_velocity="${safety_controller_k_vel}"/>
       <dynamics damping="${joint_damping}"/>
     </joint>
@@ -331,7 +331,7 @@
       <child link="${robot_name}_link_6"/>
       <origin xyz="0 0 0.2155" rpy="${PI / 2} 0 0"/>
       <axis xyz="0 0 1"/>
-      <limit lower="${-120 * PI / 180}" upper="${120 * PI / 180}" effort="40" velocity="${135 * PI / 180}"/>
+      <limit lower="${-120 * PI / 180}" upper="${120 * PI / 180}" effort="40" velocity="${135 * PI / 180}" drake:acceleration="15.72"/>
       <safety_controller soft_lower_limit="${-118 * PI / 180}" soft_upper_limit="${118 * PI / 180}" k_position="${safety_controller_k_pos}" k_velocity="${safety_controller_k_vel}"/>
       <dynamics damping="${joint_damping}"/>
     </joint>
@@ -385,7 +385,7 @@
       <child link="${robot_name}_link_7"/>
       <origin xyz="0 0.081 0" rpy="${- PI / 2} ${PI} 0"/>
       <axis xyz="0 0 1"/>
-      <limit lower="${-175 * PI / 180}" upper="${175 * PI / 180}" effort="40" velocity="${135 * PI / 180}"/>
+      <limit lower="${-175 * PI / 180}" upper="${175 * PI / 180}" effort="40" velocity="${135 * PI / 180}" drake:acceleration="15.72"/>
       <safety_controller soft_lower_limit="${-173 * PI / 180}" soft_upper_limit="${173 * PI / 180}" k_position="${safety_controller_k_pos}" k_velocity="${safety_controller_k_vel}"/>
       <dynamics damping="${joint_damping}"/>
     </joint>

--- a/manipulation/models/iiwa_description/urdf/iiwa14_no_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/iiwa14_no_collision.urdf
@@ -3,7 +3,7 @@
 <!-- Collision models: All collision models are omitted in this version of
      the iiwa arm.-->
 <!-- ===================================================================== -->
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="iiwa14">
+<robot xmlns:drake="http://drake.mit.edu" xmlns:xacro="http://www.ros.org/wiki/xacro" name="iiwa14">
   <!-- Import Rviz colors -->
   <material name="Black">
     <color rgba="0.0 0.0 0.0 1.0"/>
@@ -66,7 +66,7 @@
     <child link="iiwa_link_1"/>
     <origin rpy="0 0 0" xyz="0 0 0.1575"/>
     <axis xyz="0 0 1"/>
-    <limit effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
+    <limit drake:acceleration="8.57" effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.93215314335" soft_upper_limit="2.93215314335"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -90,7 +90,7 @@
     <child link="iiwa_link_2"/>
     <origin rpy="1.570796326794897   0 3.141592653589793" xyz="0 0 0.2025"/>
     <axis xyz="0 0 1"/>
-    <limit effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
+    <limit drake:acceleration="8.57" effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -123,7 +123,7 @@
     <child link="iiwa_link_3"/>
     <origin rpy="1.570796326794897 0 3.141592653589793" xyz="0 0.2045 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
+    <limit drake:acceleration="8.74" effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -163,7 +163,7 @@
     <child link="iiwa_link_4"/>
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
-    <limit effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
+    <limit drake:acceleration="11.36" effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -196,7 +196,7 @@
     <child link="iiwa_link_5"/>
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.1845 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
+    <limit drake:acceleration="12.23" effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -236,7 +236,7 @@
     <child link="iiwa_link_6"/>
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
-    <limit effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
+    <limit drake:acceleration="15.72" effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -269,7 +269,7 @@
     <child link="iiwa_link_7"/>
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.081 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
+    <limit drake:acceleration="15.72" effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-3.01941960595" soft_upper_limit="3.01941960595"/>
     <dynamics damping="0.5"/>
   </joint>

--- a/manipulation/models/iiwa_description/urdf/iiwa14_polytope_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/iiwa14_polytope_collision.urdf
@@ -9,7 +9,7 @@
      polytope model.
 -->
 <!-- ===================================================================== -->
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="iiwa14">
+<robot xmlns:drake="http://drake.mit.edu" xmlns:xacro="http://www.ros.org/wiki/xacro" name="iiwa14">
   <!-- Import Rviz colors -->
   <material name="Black">
     <color rgba="0.0 0.0 0.0 1.0"/>
@@ -72,7 +72,7 @@
     <child link="iiwa_link_1"/>
     <origin rpy="0 0 0" xyz="0 0 0.1575"/>
     <axis xyz="0 0 1"/>
-    <limit effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
+    <limit drake:acceleration="8.57" effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.93215314335" soft_upper_limit="2.93215314335"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -96,7 +96,7 @@
     <child link="iiwa_link_2"/>
     <origin rpy="1.570796326794897   0 3.141592653589793" xyz="0 0 0.2025"/>
     <axis xyz="0 0 1"/>
-    <limit effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
+    <limit drake:acceleration="8.57" effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -129,7 +129,7 @@
     <child link="iiwa_link_3"/>
     <origin rpy="1.570796326794897 0 3.141592653589793" xyz="0 0.2045 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
+    <limit drake:acceleration="8.74" effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -169,7 +169,7 @@
     <child link="iiwa_link_4"/>
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
-    <limit effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
+    <limit drake:acceleration="11.36" effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -202,7 +202,7 @@
     <child link="iiwa_link_5"/>
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.1845 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
+    <limit drake:acceleration="12.23" effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -242,7 +242,7 @@
     <child link="iiwa_link_6"/>
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
-    <limit effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
+    <limit drake:acceleration="15.72" effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -275,7 +275,7 @@
     <child link="iiwa_link_7"/>
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.081 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
+    <limit drake:acceleration="15.72" effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-3.01941960595" soft_upper_limit="3.01941960595"/>
     <dynamics damping="0.5"/>
   </joint>

--- a/manipulation/models/iiwa_description/urdf/iiwa14_primitive_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/iiwa14_primitive_collision.urdf
@@ -11,7 +11,7 @@
      most likely part of the arm to make contact.
 -->
 <!-- ===================================================================== -->
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="iiwa14">
+<robot xmlns:drake="http://drake.mit.edu" xmlns:xacro="http://www.ros.org/wiki/xacro" name="iiwa14">
   <!-- Import Rviz colors -->
   <material name="Black">
     <color rgba="0.0 0.0 0.0 1.0"/>
@@ -81,7 +81,7 @@
     <child link="iiwa_link_1"/>
     <origin rpy="0 0 0" xyz="0 0 0.1575"/>
     <axis xyz="0 0 1"/>
-    <limit effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
+    <limit drake:acceleration="8.57" effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.93215314335" soft_upper_limit="2.93215314335"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -112,7 +112,7 @@
     <child link="iiwa_link_2"/>
     <origin rpy="1.570796326794897   0 3.141592653589793" xyz="0 0 0.2025"/>
     <axis xyz="0 0 1"/>
-    <limit effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
+    <limit drake:acceleration="8.57" effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -152,7 +152,7 @@
     <child link="iiwa_link_3"/>
     <origin rpy="1.570796326794897 0 3.141592653589793" xyz="0 0.2045 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
+    <limit drake:acceleration="8.74" effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -199,7 +199,7 @@
     <child link="iiwa_link_4"/>
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
-    <limit effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
+    <limit drake:acceleration="11.36" effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -239,7 +239,7 @@
     <child link="iiwa_link_5"/>
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.1845 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
+    <limit drake:acceleration="12.23" effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -286,7 +286,7 @@
     <child link="iiwa_link_6"/>
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
-    <limit effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
+    <limit drake:acceleration="15.72" effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -328,7 +328,7 @@
     <child link="iiwa_link_7"/>
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.081 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
+    <limit drake:acceleration="15.72" effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-3.01941960595" soft_upper_limit="3.01941960595"/>
     <dynamics damping="0.5"/>
   </joint>

--- a/manipulation/models/iiwa_description/urdf/iiwa14_spheres_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/iiwa14_spheres_collision.urdf
@@ -11,7 +11,7 @@
      most likely part of the arm to make contact.
 -->
 <!-- ===================================================================== -->
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="iiwa14">
+<robot xmlns:drake="http://drake.mit.edu" xmlns:xacro="http://www.ros.org/wiki/xacro" name="iiwa14">
   <!-- Import Rviz colors -->
   <material name="Black">
     <color rgba="0.0 0.0 0.0 1.0"/>
@@ -81,7 +81,7 @@
     <child link="iiwa_link_1"/>
     <origin rpy="0 0 0" xyz="0 0 0.1575"/>
     <axis xyz="0 0 1"/>
-    <limit effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
+    <limit drake:acceleration="8.57" effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.93215314335" soft_upper_limit="2.93215314335"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -112,7 +112,7 @@
     <child link="iiwa_link_2"/>
     <origin rpy="1.570796326794897   0 3.141592653589793" xyz="0 0 0.2025"/>
     <axis xyz="0 0 1"/>
-    <limit effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
+    <limit drake:acceleration="8.57" effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -159,7 +159,7 @@
     <child link="iiwa_link_3"/>
     <origin rpy="1.570796326794897 0 3.141592653589793" xyz="0 0.2045 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
+    <limit drake:acceleration="8.74" effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -220,7 +220,7 @@
     <child link="iiwa_link_4"/>
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
-    <limit effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
+    <limit drake:acceleration="11.36" effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -267,7 +267,7 @@
     <child link="iiwa_link_5"/>
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.1845 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
+    <limit drake:acceleration="12.23" effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -321,7 +321,7 @@
     <child link="iiwa_link_6"/>
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
-    <limit effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
+    <limit drake:acceleration="15.72" effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -361,7 +361,7 @@
     <child link="iiwa_link_7"/>
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.081 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
+    <limit drake:acceleration="15.72" effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-3.01941960595" soft_upper_limit="3.01941960595"/>
     <dynamics damping="0.5"/>
   </joint>

--- a/manipulation/models/iiwa_description/urdf/iiwa14_spheres_dense_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/iiwa14_spheres_dense_collision.urdf
@@ -11,7 +11,7 @@
      most likely part of the arm to make contact.
 -->
 <!-- ===================================================================== -->
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="iiwa14">
+<robot xmlns:drake="http://drake.mit.edu" xmlns:xacro="http://www.ros.org/wiki/xacro" name="iiwa14">
   <!-- Import Rviz colors -->
   <material name="Black">
     <color rgba="0.0 0.0 0.0 1.0"/>
@@ -102,7 +102,7 @@
     <child link="iiwa_link_1"/>
     <origin rpy="0 0 0" xyz="0 0 0.1575"/>
     <axis xyz="0 0 1"/>
-    <limit effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
+    <limit drake:acceleration="8.57" effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.93215314335" soft_upper_limit="2.93215314335"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -161,7 +161,7 @@
     <child link="iiwa_link_2"/>
     <origin rpy="1.570796326794897   0 3.141592653589793" xyz="0 0 0.2025"/>
     <axis xyz="0 0 1"/>
-    <limit effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
+    <limit drake:acceleration="8.57" effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -257,7 +257,7 @@
     <child link="iiwa_link_3"/>
     <origin rpy="1.570796326794897 0 3.141592653589793" xyz="0 0.2045 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
+    <limit drake:acceleration="8.74" effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -360,7 +360,7 @@
     <child link="iiwa_link_4"/>
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
-    <limit effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
+    <limit drake:acceleration="11.36" effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -435,7 +435,7 @@
     <child link="iiwa_link_5"/>
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.1845 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
+    <limit drake:acceleration="12.23" effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -538,7 +538,7 @@
     <child link="iiwa_link_6"/>
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
-    <limit effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
+    <limit drake:acceleration="15.72" effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -592,7 +592,7 @@
     <child link="iiwa_link_7"/>
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.081 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
+    <limit drake:acceleration="15.72" effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-3.01941960595" soft_upper_limit="3.01941960595"/>
     <dynamics damping="0.5"/>
   </joint>

--- a/manipulation/models/iiwa_description/urdf/iiwa14_spheres_dense_elbow_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/iiwa14_spheres_dense_elbow_collision.urdf
@@ -11,7 +11,7 @@
      most likely part of the arm to make contact.
 -->
 <!-- ===================================================================== -->
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="iiwa14">
+<robot xmlns:drake="http://drake.mit.edu" xmlns:xacro="http://www.ros.org/wiki/xacro" name="iiwa14">
   <!-- Import Rviz colors -->
   <material name="Black">
     <color rgba="0.0 0.0 0.0 1.0"/>
@@ -81,7 +81,7 @@
     <child link="iiwa_link_1"/>
     <origin rpy="0 0 0" xyz="0 0 0.1575"/>
     <axis xyz="0 0 1"/>
-    <limit effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
+    <limit drake:acceleration="8.57" effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.93215314335" soft_upper_limit="2.93215314335"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -112,7 +112,7 @@
     <child link="iiwa_link_2"/>
     <origin rpy="1.570796326794897   0 3.141592653589793" xyz="0 0 0.2025"/>
     <axis xyz="0 0 1"/>
-    <limit effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
+    <limit drake:acceleration="8.57" effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -159,7 +159,7 @@
     <child link="iiwa_link_3"/>
     <origin rpy="1.570796326794897 0 3.141592653589793" xyz="0 0.2045 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
+    <limit drake:acceleration="8.74" effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -262,7 +262,7 @@
     <child link="iiwa_link_4"/>
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
-    <limit effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
+    <limit drake:acceleration="11.36" effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -337,7 +337,7 @@
     <child link="iiwa_link_5"/>
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.1845 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
+    <limit drake:acceleration="12.23" effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -377,7 +377,7 @@
     <child link="iiwa_link_6"/>
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
-    <limit effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
+    <limit drake:acceleration="15.72" effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -424,7 +424,7 @@
     <child link="iiwa_link_7"/>
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.081 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
+    <limit drake:acceleration="15.72" effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-3.01941960595" soft_upper_limit="3.01941960595"/>
     <dynamics damping="0.5"/>
   </joint>

--- a/manipulation/models/iiwa_description/urdf/planar_iiwa14_spheres_dense_elbow_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/planar_iiwa14_spheres_dense_elbow_collision.urdf
@@ -8,7 +8,7 @@
 <!-- |    (e.g. transmissions for the newly welded joints) have been     | -->
 <!-- |    removed.                                                       | -->
 <!-- ===================================================================== -->
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="iiwa14">
+<robot xmlns:drake="http://drake.mit.edu" xmlns:xacro="http://www.ros.org/wiki/xacro" name="iiwa14">
   <!-- Import Rviz colors -->
   <material name="Black">
     <color rgba="0.0 0.0 0.0 1.0"/>
@@ -83,7 +83,7 @@
     <child link="iiwa_link_2"/>
     <origin rpy="1.570796326794897   0 3.141592653589793" xyz="0 0 0.2025"/>
     <axis xyz="0 0 1"/>
-    <limit effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
+    <limit drake:acceleration="8.57" effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -229,7 +229,7 @@
     <child link="iiwa_link_4"/>
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
-    <limit effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
+    <limit  drake:acceleration="11.36" effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
@@ -340,7 +340,7 @@
     <child link="iiwa_link_6"/>
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
-    <limit effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
+    <limit drake:acceleration="15.72" effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
     <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>


### PR DESCRIPTION
Addresses the second task of https://github.com/RobotLocomotion/drake/issues/15613.

Provides an estimation of acceleration joint limits for the KUKA IWA14 models. Includes unit tests consistency checks and `README.md` updates.

Acceleration joint limit estimations have been derived from experimental results listed in Table 4 (page 50) of the following Master's thesis:

https://odr.chalmers.se/bitstream/20.500.12380/256658/1/256658.pdf

@EricCousineau-TRI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16377)
<!-- Reviewable:end -->
