### PR TITLE
[tools] Deprecate drake-visualizer on macOS

### DIFF
--- a/doc/_release-notes/v0.38.0.md
+++ b/doc/_release-notes/v0.38.0.md
@@ -17,7 +17,7 @@ released: 2022-01-14
     time (in order to switch to Python 3.8 or Python 3.9).
   * macOS users already use Python 3.9, so will not be affected.
 * The use of ``drake-visualizer`` on macOS is deprecated and will be removed
-  from Drake on or after April 1st, 2022.
+  from Drake on or after April 1st, 2022 ([#16386][_#16386]).
   * On Ubuntu 20.04, support of ``drake-visualizer`` remains intact.
   * On Ubuntu 18.04, support of ``drake-visualizer`` will remain intact as
     long as our overall support of 18.04 (which ends on April 1st, 2022).
@@ -253,6 +253,7 @@ Philip E. Gill and Elizabeth Wong for their kind support.
 [_#16352]: https://github.com/RobotLocomotion/drake/pull/16352
 [_#16354]: https://github.com/RobotLocomotion/drake/pull/16354
 [_#16359]: https://github.com/RobotLocomotion/drake/pull/16359
+[_#16386]: https://github.com/RobotLocomotion/drake/pull/16386
 <!-- <end issue links> -->
 
 <!--

--- a/tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts/__init__.py
+++ b/tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts/__init__.py
@@ -75,6 +75,11 @@ def _exec_drake_visualizer_with_plugins(drake_visualizer_real, arg0):
     use_builtin_scripts_file = os.path.join(
         os.path.dirname(__file__), "use_builtin_scripts.py")
 
+    # Warn about macOS deprecation.
+    if sys.platform == "darwin":
+        print("\nWARNING: On macOS, drake-visualizer is deprecated and will be"
+              " removed from Drake on or after 2022-04-01.", file=sys.stderr)
+
     if "-h" in argv or "--help" in argv:
         # Show real help, followed by our wrapper help.
         # TODO(eric.cousineau): Fix indentation if it ever matters.


### PR DESCRIPTION
Per #16215.

Note that this deprecation window is tighter than usual (it would be 2022-05-01 by the usual math).  This change was already announced as of the v0.38.0 release notes and in #16215 and in slack, and is somewhat urgent to retire sooner rather than later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16386)
<!-- Reviewable:end -->
