### PR TITLE
[multibody] Guard hazardous map access by GeometryId

### DIFF
--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -95,9 +95,9 @@ class MultibodyPlantTester {
   MultibodyPlantTester() = delete;
 
   template <typename T>
-  static BodyIndex geometry_id_to_body_index(
+  static BodyIndex FindBodyByGeometryId(
       const MultibodyPlant<T>& plant, GeometryId id) {
-    return plant.geometry_id_to_body_index_.at(id);
+    return plant.FindBodyByGeometryId(id);
   }
 
   static void CalcNormalAndTangentContactJacobians(
@@ -498,6 +498,17 @@ GTEST_TEST(MultibodyPlantTest, EmptyWorldContinuous) {
   EXPECT_EQ(residual.size(), 0);
   DRAKE_EXPECT_NO_THROW(plant.CalcImplicitTimeDerivativesResidual(
       *context, *new_derivatives, &residual));
+}
+
+GTEST_TEST(MultibodyPlantTest, EmptyWorldContactErrors) {
+  MultibodyPlant<double> plant(0.0);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      MultibodyPlantTester::FindBodyByGeometryId(plant, GeometryId{}),
+      ".* contact results for a null GeometryId.*");
+  const GeometryId unknown_id = GeometryId::get_new_id();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      MultibodyPlantTester::FindBodyByGeometryId(plant, unknown_id),
+      ".* contact results for GeometryId .* but that ID is not known.*");
 }
 
 GTEST_TEST(ActuationPortsTest, CheckActuation) {
@@ -2374,7 +2385,7 @@ class MultibodyPlantContactJacobianTests : public ::testing::Test {
     for (const auto& pair : pairs_set) {
       PenetrationAsPointPair<T> pair_on_T;
 
-      BodyIndex bodyA_index = MultibodyPlantTester::geometry_id_to_body_index(
+      BodyIndex bodyA_index = MultibodyPlantTester::FindBodyByGeometryId(
           plant_on_T, pair.id_A);
       const RigidTransform<T>& X_WA = plant_on_T.EvalBodyPoseInWorld(
           context_on_T, plant_on_T.get_body(bodyA_index));
@@ -2382,7 +2393,7 @@ class MultibodyPlantContactJacobianTests : public ::testing::Test {
           plant_on_T.EvalBodySpatialVelocityInWorld(
               context_on_T, plant_on_T.get_body(bodyA_index));
 
-      BodyIndex bodyB_index = MultibodyPlantTester::geometry_id_to_body_index(
+      BodyIndex bodyB_index = MultibodyPlantTester::FindBodyByGeometryId(
           plant_on_T, pair.id_B);
       const RigidTransform<T>& X_WB = plant_on_T.EvalBodyPoseInWorld(
           context_on_T, plant_on_T.get_body(bodyB_index));
@@ -2429,7 +2440,7 @@ class MultibodyPlantContactJacobianTests : public ::testing::Test {
     for (const auto& pair : pairs_set) {
       PenetrationAsPointPair<T> pair_on_T;
 
-      BodyIndex bodyA_index = MultibodyPlantTester::geometry_id_to_body_index(
+      BodyIndex bodyA_index = MultibodyPlantTester::FindBodyByGeometryId(
           plant_on_T, pair.id_A);
       const RigidTransform<T>& X_WA = plant_on_T.EvalBodyPoseInWorld(
           context_on_T, plant_on_T.get_body(bodyA_index));
@@ -2437,7 +2448,7 @@ class MultibodyPlantContactJacobianTests : public ::testing::Test {
           plant_on_T.EvalBodySpatialVelocityInWorld(
               context_on_T, plant_on_T.get_body(bodyA_index));
 
-      BodyIndex bodyB_index = MultibodyPlantTester::geometry_id_to_body_index(
+      BodyIndex bodyB_index = MultibodyPlantTester::FindBodyByGeometryId(
           plant_on_T, pair.id_B);
       const RigidTransform<T>& X_WB = plant_on_T.EvalBodyPoseInWorld(
           context_on_T, plant_on_T.get_body(bodyB_index));


### PR DESCRIPTION
The GeometryId values for collisions come in on an input port. We need to sanity-check them prior to using them.

For two maps that were already dead code, we just kill the deadwood instead of adding guards for it.  The related `default_coulomb_friction_` was also dead code, so is also purged.

Closes #16116.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16390)
<!-- Reviewable:end -->
