### PR TITLE
Eval augmented lagrangian

### DIFF
--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -72,6 +72,21 @@ drake_pybind_library(
 )
 
 drake_pybind_library(
+    name = "augmented_lagrangian_py",
+    cc_deps = [
+        "//bindings/pydrake:autodiff_types_pybind",
+        "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake:symbolic_types_pybind",
+    ],
+    cc_srcs = ["augmented_lagrangian_py.cc"],
+    package_info = PACKAGE_INFO,
+    py_deps = [
+        ":mathematicalprogram_py",
+        "//bindings/pydrake:autodiffutils_py",
+    ],
+)
+
+drake_pybind_library(
     name = "branch_and_bound_py",
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
@@ -286,6 +301,7 @@ drake_pybind_library(
 )
 
 PY_LIBRARIES_WITH_INSTALL = [
+    ":augmented_lagrangian_py",
     ":branch_and_bound_py",
     ":clp_py",
     ":csdp_py",
@@ -326,6 +342,14 @@ install(
     targets = PY_LIBRARIES + [":all_py"],
     py_dest = PACKAGE_INFO.py_dest,
     deps = get_drake_py_installs(PY_LIBRARIES_WITH_INSTALL),
+)
+
+drake_py_unittest(
+    name = "augmented_lagrangian_test",
+    deps = [
+        ":augmented_lagrangian_py",
+        "//bindings/pydrake:autodiffutils_py",
+    ],
 )
 
 drake_py_unittest(

--- a/bindings/pydrake/solvers/augmented_lagrangian_py.cc
+++ b/bindings/pydrake/solvers/augmented_lagrangian_py.cc
@@ -1,0 +1,69 @@
+#include "pybind11/eigen.h"
+#include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
+
+#include "drake/bindings/pydrake/autodiff_types_pybind.h"
+#include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/solvers/augmented_lagrangian.h"
+
+namespace drake {
+namespace pydrake {
+
+PYBIND11_MODULE(augmented_lagrangian, m) {
+  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+  using namespace drake::solvers;
+  constexpr auto& doc = pydrake_doc.drake.solvers;
+
+  m.doc() = "Augmented Lagrangian solver bindings for MathematicalProgram";
+
+  py::module::import("pydrake.solvers.mathematicalprogram");
+  py::module::import("pydrake.autodiffutils");
+
+  py::class_<NonsmoothAugmentedLagrangian>(
+      m, "NonsmoothAugmentedLagrangian", doc.NonsmoothAugmentedLagrangian.doc)
+      .def(py::init<const MathematicalProgram*, bool>(), py::arg("prog"),
+          py::arg("include_x_bounds"),
+          doc.NonsmoothAugmentedLagrangian.ctor.doc)
+      .def(
+          "Eval",
+          [](const NonsmoothAugmentedLagrangian* self,
+              const Eigen::Ref<const Eigen::VectorXd>& x,
+              const Eigen::VectorXd& lambda_val, double mu) {
+            Eigen::VectorXd constraint_residue;
+            double cost;
+            const double al_val = self->Eval<double>(
+                x, lambda_val, mu, &constraint_residue, &cost);
+            return std::make_tuple(al_val, constraint_residue, cost);
+          },
+          py::arg("x"), py::arg("lambda_val"), py::arg("mu"),
+          doc.NonsmoothAugmentedLagrangian.Eval.doc)
+      .def(
+          "Eval",
+          [](const NonsmoothAugmentedLagrangian* self,
+              const Eigen::Ref<const VectorX<AutoDiffXd>>& x,
+              const Eigen::VectorXd& lambda_val, double mu) {
+            VectorX<AutoDiffXd> constraint_residue;
+            AutoDiffXd cost;
+            const AutoDiffXd al_val = self->Eval<AutoDiffXd>(
+                x, lambda_val, mu, &constraint_residue, &cost);
+            return std::make_tuple(al_val, constraint_residue, cost);
+          },
+          py::arg("x"), py::arg("lambda_val"), py::arg("mu"),
+          doc.NonsmoothAugmentedLagrangian.Eval.doc)
+      .def("prog", &NonsmoothAugmentedLagrangian::prog, py_rvp::reference,
+          doc.NonsmoothAugmentedLagrangian.prog.doc)
+      .def("include_x_bounds", &NonsmoothAugmentedLagrangian::include_x_bounds,
+          doc.NonsmoothAugmentedLagrangian.include_x_bounds.doc)
+      .def("lagrangian_size", &NonsmoothAugmentedLagrangian::lagrangian_size,
+          doc.NonsmoothAugmentedLagrangian.lagrangian_size.doc)
+      .def("is_equality", &NonsmoothAugmentedLagrangian::is_equality,
+          doc.NonsmoothAugmentedLagrangian.is_equality.doc)
+      .def("x_lo", &NonsmoothAugmentedLagrangian::x_lo,
+          py_rvp::reference_internal, doc.NonsmoothAugmentedLagrangian.x_lo.doc)
+      .def("x_up", &NonsmoothAugmentedLagrangian::x_up,
+          py_rvp::reference_internal,
+          doc.NonsmoothAugmentedLagrangian.x_up.doc);
+}
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/solvers/test/augmented_lagrangian_test.py
+++ b/bindings/pydrake/solvers/test/augmented_lagrangian_test.py
@@ -1,0 +1,52 @@
+import unittest
+
+import numpy as np
+
+from pydrake.solvers import mathematicalprogram as mp
+
+from pydrake.solvers import augmented_lagrangian as al
+from pydrake.autodiffutils import InitializeAutoDiff, AutoDiffXd
+
+
+class TestNonsmoothAugmentedLagrangian(unittest.TestCase):
+    def setUp(self):
+        self.prog = mp.MathematicalProgram()
+        x = self.prog.NewContinuousVariables(2)
+        self.prog.AddQuadraticCost(x[0] * x[0] + 2 * x[1] * x[1])
+        self.prog.AddLinearConstraint(x[0] + x[1] <= 3)
+
+    def test_eval_double(self):
+        dut = al.NonsmoothAugmentedLagrangian(prog=self.prog,
+                                              include_x_bounds=True)
+        x_val = np.array([1., 3])
+        lambda_val = np.array([0.5])
+        al_val, constraint_residue, cost = dut.Eval(x=x_val,
+                                                    lambda_val=lambda_val,
+                                                    mu=0.1)
+        self.assertIsInstance(al_val, float)
+        self.assertIsInstance(constraint_residue, np.ndarray)
+        self.assertIsInstance(cost, float)
+
+    def test_eval_ad(self):
+        dut = al.NonsmoothAugmentedLagrangian(prog=self.prog,
+                                              include_x_bounds=True)
+        x_val = InitializeAutoDiff(np.array([1., 3]))
+        al_val, constraint_residue, cost = dut.Eval(x=x_val,
+                                                    lambda_val=np.array([0.5]),
+                                                    mu=0.1)
+        self.assertIsInstance(al_val, AutoDiffXd)
+        self.assertIsInstance(constraint_residue, np.ndarray)
+        self.assertIsInstance(cost, AutoDiffXd)
+
+    def test_lagrangian_size(self):
+        self.assertEqual(
+            al.NonsmoothAugmentedLagrangian(
+                prog=self.prog, include_x_bounds=True).lagrangian_size(), 1)
+        self.assertEqual(
+            al.NonsmoothAugmentedLagrangian(
+                prog=self.prog, include_x_bounds=False).lagrangian_size(), 1)
+
+    def test_is_equality(self):
+        self.assertEqual(
+            al.NonsmoothAugmentedLagrangian(
+                prog=self.prog, include_x_bounds=True).is_equality(), [False])

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -22,6 +22,7 @@ drake_cc_package_library(
     visibility = ["//visibility:public"],
     deps = [
         ":aggregate_costs_constraints",
+        ":augmented_lagrangian",
         ":bilinear_product_util",
         ":binding",
         ":branch_and_bound",
@@ -71,6 +72,16 @@ drake_cc_package_library(
         ":sos_basis_generator",
         ":system_identification",
         ":unrevised_lemke_solver",
+    ],
+)
+
+drake_cc_library(
+    name = "augmented_lagrangian",
+    srcs = ["augmented_lagrangian.cc"],
+    hdrs = ["augmented_lagrangian.h"],
+    deps = [
+        ":aggregate_costs_constraints",
+        ":mathematical_program",
     ],
 )
 
@@ -1795,6 +1806,14 @@ drake_cc_googletest(
         ":solver_options",
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "augmented_lagrangian_test",
+    deps = [
+        ":augmented_lagrangian",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/solvers/augmented_lagrangian.cc
+++ b/solvers/augmented_lagrangian.cc
@@ -1,0 +1,192 @@
+#include "drake/solvers/augmented_lagrangian.h"
+
+#include <fmt/format.h>
+
+#include "drake/common/default_scalars.h"
+#include "drake/solvers/aggregate_costs_constraints.h"
+#include "drake/solvers/mathematical_program.h"
+
+namespace drake {
+namespace solvers {
+
+// This function psi is defined as equation 17.55 of Numerical Optimization by
+// Jorge Nocedal and Stephen Wright, Edition 1, 1999. (Note this equation is not
+// presented in Edition 2). Mathematically it equals psi(c, λ, μ) = -λc +
+// 1/(2μ)c² if c - λμ <= 0 otherwise psi(c, λ, μ) = -0.5*μλ² The meaning of this
+// function psi(c, λ, μ) is psi(c,λ, μ)= −λ(c−s) + 1/(2μ)(c−s)² where s = max(c
+// − μλ, 0)
+template <typename T>
+T psi(const T& c, double lambda_val, double mu) {
+  if (ExtractDoubleOrThrow(c - lambda_val * mu) < 0) {
+    return -lambda_val * c + 1 / (2 * mu) * c * c;
+  } else {
+    return T(-0.5 * mu * lambda_val * lambda_val);
+  }
+}
+
+NonsmoothAugmentedLagrangian::NonsmoothAugmentedLagrangian(
+    const MathematicalProgram* prog, bool include_x_bounds)
+    : prog_{prog}, include_x_bounds_{include_x_bounds} {
+  lagrangian_size_ = 0;
+  for (const auto& constraint : prog_->GetAllConstraints()) {
+    if (!dynamic_cast<BoundingBoxConstraint*>(constraint.evaluator().get())) {
+      const auto& lb = constraint.evaluator()->lower_bound();
+      const auto& ub = constraint.evaluator()->upper_bound();
+      for (int i = 0; i < constraint.evaluator()->num_constraints(); ++i) {
+        if (lb(i) == ub(i)) {
+          lagrangian_size_++;
+        } else {
+          if (!std::isinf(lb(i))) {
+            lagrangian_size_++;
+          }
+          if (!std::isinf(ub(i))) {
+            lagrangian_size_++;
+          }
+        }
+      }
+    }
+  }
+  AggregateBoundingBoxConstraints(*prog_, &x_lo_, &x_up_);
+  if (include_x_bounds) {
+    for (int i = 0; i < prog_->num_vars(); ++i) {
+      if (x_lo_(i) == x_up_(i)) {
+        lagrangian_size_++;
+      } else {
+        if (!std::isinf(x_lo_(i))) {
+          lagrangian_size_++;
+        }
+        if (!std::isinf(x_up_(i))) {
+          lagrangian_size_++;
+        }
+      }
+    }
+  }
+  is_equality_.resize(lagrangian_size_);
+  // We loop through all the constraints again instead of combining this loop
+  // with the previous loop when we find lagrangian_size_. The reason is that we
+  // want to first find lagrangian_size_ and then allocate all the memory of
+  // is_equality_.
+  int constraint_row = 0;
+  for (const auto& constraint : prog_->GetAllConstraints()) {
+    if (!dynamic_cast<BoundingBoxConstraint*>(constraint.evaluator().get())) {
+      const auto& lb = constraint.evaluator()->lower_bound();
+      const auto& ub = constraint.evaluator()->upper_bound();
+      for (int i = 0; i < constraint.evaluator()->num_constraints(); ++i) {
+        if (lb(i) == ub(i)) {
+          is_equality_[constraint_row] = true;
+          constraint_row++;
+        } else {
+          if (!std::isinf(lb(i))) {
+            is_equality_[constraint_row] = false;
+            constraint_row++;
+          }
+          if (!std::isinf(ub(i))) {
+            is_equality_[constraint_row] = false;
+            constraint_row++;
+          }
+        }
+      }
+    }
+  }
+  if (include_x_bounds) {
+    for (int i = 0; i < prog_->num_vars(); ++i) {
+      if (x_lo_(i) == x_up_(i)) {
+        is_equality_[constraint_row] = true;
+        constraint_row++;
+      } else {
+        if (!std::isinf(x_lo_(i))) {
+          is_equality_[constraint_row] = false;
+          constraint_row++;
+        }
+        if (!std::isinf(x_up_(i))) {
+          is_equality_[constraint_row] = false;
+          constraint_row++;
+        }
+      }
+    }
+  }
+}
+
+template <typename T>
+T NonsmoothAugmentedLagrangian::Eval(const Eigen::Ref<const VectorX<T>>& x,
+                                     const Eigen::VectorXd& lambda_val,
+                                     double mu, VectorX<T>* constraint_residue,
+                                     T* cost) const {
+  DRAKE_DEMAND(x.rows() == prog_->num_vars());
+  DRAKE_DEMAND(lambda_val.rows() == lagrangian_size_);
+  DRAKE_DEMAND(mu > 0);
+  DRAKE_DEMAND(constraint_residue != nullptr);
+  DRAKE_DEMAND(cost != nullptr);
+  *cost = T{0};
+  constraint_residue->resize(lambda_val.rows());
+  for (const auto& cost_binding : prog_->GetAllCosts()) {
+    *cost += prog_->EvalBinding(cost_binding, x)(0);
+  }
+  T al = *cost;
+  int lagrangian_count = 0;
+  // First evaluate all generic nonlinear constraints
+  for (const auto& constraint : prog_->GetAllConstraints()) {
+    if (!dynamic_cast<BoundingBoxConstraint*>(constraint.evaluator().get())) {
+      const VectorX<T> constraint_val = prog_->EvalBinding(constraint, x);
+      // Now check if each row of the constraint is equality or inequality.
+      for (int i = 0; i < constraint.evaluator()->num_constraints(); ++i) {
+        const double& lb = constraint.evaluator()->lower_bound()(i);
+        const double& ub = constraint.evaluator()->upper_bound()(i);
+        if ((std::isinf(lb) && lb > 0) || (std::isinf(ub) && ub < 0)) {
+          throw std::invalid_argument(fmt::format(
+              "constraint lower bound is {}, upper bound is {}", lb, ub));
+        }
+        if (lb == ub) {
+          // We have one Lagrangian multiplier for the equality constraint. Add
+          // −λ h(x) + 1/(2μ)h(x)² to the augmented Lagrangian.
+          al += -lambda_val(lagrangian_count) * (constraint_val(i) - lb) +
+                1. / (2 * mu) * (constraint_val(i) - lb) *
+                    (constraint_val(i) - lb);
+          (*constraint_residue)(lagrangian_count) = constraint_val(i) - lb;
+          lagrangian_count++;
+        } else {
+          if (!std::isinf(lb)) {
+            // The constraint is constraint_val - lb >= 0.
+            al += psi(constraint_val(i) - lb, lambda_val(lagrangian_count), mu);
+            (*constraint_residue)(lagrangian_count) = constraint_val(i) - lb;
+            lagrangian_count++;
+          }
+          if (!std::isinf(ub)) {
+            // The constraint is ub - constraint_val >= 0.
+            al += psi(ub - constraint_val(i), lambda_val(lagrangian_count), mu);
+            (*constraint_residue)(lagrangian_count) = ub - constraint_val(i);
+            lagrangian_count++;
+          }
+        }
+      }
+    }
+  }
+  if (include_x_bounds_) {
+    for (int i = 0; i < prog_->num_vars(); ++i) {
+      if (x_lo_(i) == x_up_(i)) {
+        al += -lambda_val(lagrangian_count) * (x(i) - x_lo_(i)) +
+              1. / (2 * mu) * (x(i) - x_lo_(i)) * (x(i) - x_lo_(i));
+        (*constraint_residue)(lagrangian_count) = x(i) - x_lo_(i);
+        lagrangian_count++;
+      } else {
+        if (!std::isinf(x_lo_(i))) {
+          al += psi(x(i) - x_lo_(i), lambda_val(lagrangian_count), mu);
+          (*constraint_residue)(lagrangian_count) = x(i) - x_lo_(i);
+          lagrangian_count++;
+        }
+        if (!std::isinf(x_up_(i))) {
+          al += psi(x_up_(i) - x(i), lambda_val(lagrangian_count), mu);
+          (*constraint_residue)(lagrangian_count) = x_up_(i) - x(i);
+          lagrangian_count++;
+        }
+      }
+    }
+  }
+  return al;
+}
+
+// Explicit instantiation.
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    (&NonsmoothAugmentedLagrangian::Eval<T>))
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/augmented_lagrangian.h
+++ b/solvers/augmented_lagrangian.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/solvers/mathematical_program.h"
+
+namespace drake {
+namespace solvers {
+/**
+ * Compute the augmented Lagrangian (AL) of a given mathematical program
+ *
+ *     min f(x)
+ *     s.t h(x) = 0
+ *         l <= g(x) <= u
+ *         x_lo <= x <= x_up
+ *
+ * We first turn it into an equality constrained program with non-negative slack
+ * variable s as follows
+ *
+ *     min f(x)
+ *     s.t h(x) = 0
+ *         c(x) - s = 0
+ *         s >= 0
+ *
+ * Depending on the option include_x_bounds, the constraint h(x)=0, c(x)>=0 may
+ * or may not include the bounding box constraint x_lo <= x <= x_up.
+ *
+ * the (non-smooth) augmented Lagrangian is defined as
+ *
+ *     L(x, λ, μ) = f(x) − λ₁ᵀh(x) + μ/2 h(x)ᵀh(x)
+ *                  - λ₂ᵀ(c(x)-s) + μ/2 (c(x)-s)ᵀ(c(x)-s)
+ *
+ * where s = max(c(x) - λ₂/μ, 0).
+ *
+ * For more details, refer to section 17.4 of Numerical Optimization by Jorge
+ * Nocedal and Stephen Wright, Edition 1, 1999 (This formulation isn't presented
+ * in Edition 2, but to stay consistent with Edition 2, we use μ/2 as the
+ * coefficient of the quadratic penalty term instead of 1/(2μ) in Edition 1).
+ * Note that the augmented Lagrangian L(x, λ, μ) is NOT a smooth function of x,
+ * since s = max(c(x) - λ₂/μ, 0) is non-smooth at c(x) - λ₂/μ = 0.
+ */
+class NonsmoothAugmentedLagrangian {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(NonsmoothAugmentedLagrangian)
+
+  /**
+   * @param prog The mathematical program we will evaluate.
+   * @param include_x_bounds. Whether the Lagrangian and the penalty for the
+   * bounds x_lo <= x <= x_up are included in the augmented Lagrangian L(x, λ,
+   * μ) or not.
+   */
+  NonsmoothAugmentedLagrangian(const MathematicalProgram* prog,
+                               bool include_x_bounds);
+
+  /**
+   * @param x The value of all the decision variables.
+   * @param lambda_val The estimated Lagrangian multipliers. The order of the
+   * Lagrangian multiplier is as this: We first call to evaluate all
+   * constraints. Then for each row of the constraint, if it is an equality
+   * constraint, we append one single Lagrangian multiplier. Otherwise we
+   * append the Lagrangian multiplier for the lower and upper bounds (where the
+   * lower comes before the upper), if the corresponding bound is not ±∞. The
+   * order of evaluating all the constraints is the same as
+   * prog.GetAllConstraints() except for prog.bounding_box_constraints(). If
+   * include_x_bounds=true, then we aggregate all the bounding_box_constraints()
+   * and evaluate them at the end of all constraints.
+   * @param mu μ in the documentation above. The constant for penalty term
+   * weight. This should be a strictly positive number.
+   * @param[out] constraint_residue The value of the all the constraints. For an
+   * equality constraint c(x)=0 or the inequality constraint c(x)>= 0, the
+   * residue is c(x). Depending on include_x_bounds, `constraint_residue` may or
+   * may not contain the residue for bounding box constraints x_lo <= x <= x_up
+   * at the end.
+   * @param[out] cost The value of the cost function f(x).
+   * @return The evaluated Augmented Lagrangian (AL) L(x, λ, μ).
+   */
+  template <typename T>
+  T Eval(const Eigen::Ref<const VectorX<T>>& x,
+         const Eigen::VectorXd& lambda_val, double mu,
+         VectorX<T>* constraint_residue, T* cost) const;
+
+  /**
+   * @return The mathematical program for which the augmented Lagrangian is
+   * computed.
+   */
+  const MathematicalProgram& prog() const { return *prog_; }
+
+  /**
+   * @return Whether the bounding box constraint x_lo <= x <=
+   * x_up is included in the augmented Lagrangian L(x, λ, μ).
+   */
+  [[nodiscard]] bool include_x_bounds() const { return include_x_bounds_; }
+
+  /**
+   * @return The size of the Lagrangian multiplier λ.
+   */
+  [[nodiscard]] int lagrangian_size() const { return lagrangian_size_; }
+
+  /**
+   * @return Whether each constraint is equality or not. The order of the
+   * constraint is explained in the class documentation.
+   */
+  [[nodiscard]] const std::vector<bool>& is_equality() const {
+    return is_equality_;
+  }
+
+  /** @return all the lower bounds of x. */
+  [[nodiscard]] const Eigen::VectorXd& x_lo() const { return x_lo_; }
+
+  /** @return all the upper bounds of x. */
+  [[nodiscard]] const Eigen::VectorXd& x_up() const { return x_up_; }
+
+ private:
+  const MathematicalProgram* prog_;
+  bool include_x_bounds_;
+  int lagrangian_size_;
+  std::vector<bool> is_equality_;
+  Eigen::VectorXd x_lo_;
+  Eigen::VectorXd x_up_;
+};
+
+// TODO(hongkai.dai): add the alternative augmented Lagrangian using Lancelot
+// formulation.
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/test/augmented_lagrangian_test.cc
+++ b/solvers/test/augmented_lagrangian_test.cc
@@ -1,0 +1,329 @@
+#include "drake/solvers/augmented_lagrangian.h"
+
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/extract_double.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/solvers/aggregate_costs_constraints.h"
+#include "drake/solvers/mathematical_program.h"
+
+namespace drake {
+namespace solvers {
+namespace {
+const double kInf = std::numeric_limits<double>::infinity();
+GTEST_TEST(AugmentedLagrangian, TestObjective1) {
+  // Construct an un-constrained program.
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<2>();
+  const NonsmoothAugmentedLagrangian dut(&prog, false);
+  EXPECT_EQ(dut.lagrangian_size(), 0);
+  EXPECT_TRUE(dut.is_equality().empty());
+
+  Eigen::Vector2d x_val(1, 2);
+  // Now the program has no cost nor constraint. Its augmented Lagrangian is
+  // zero.
+  Eigen::VectorXd constraint_residue;
+  double cost;
+  EXPECT_EQ(dut.Eval<double>(x_val, Eigen::VectorXd(0), 0.5,
+                             &constraint_residue, &cost),
+            0);
+  EXPECT_EQ(constraint_residue.rows(), 0);
+  EXPECT_EQ(cost, 0);
+  EXPECT_TRUE(CompareMatrices(dut.x_lo(), Eigen::Vector2d::Constant(-kInf)));
+  EXPECT_TRUE(CompareMatrices(dut.x_up(), Eigen::Vector2d::Constant(kInf)));
+}
+
+GTEST_TEST(NonsmoothAugmentedLagrangian, TestObjective2) {
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<2>();
+
+  // Now add costs
+  auto cost1 = prog.AddQuadraticCost(x[0] * x[0] + 2 * x[1] + 3);
+  auto cost2 = prog.AddLinearCost(x[0] * 3 + 4);
+  for (bool include_x_bounds : {false, true}) {
+    const NonsmoothAugmentedLagrangian dut(&prog, include_x_bounds);
+
+    EXPECT_EQ(dut.lagrangian_size(), 0);
+    EXPECT_TRUE(dut.is_equality().empty());
+
+    // Now evaluate the augmented Lagrangian, it should just be the same as the
+    // costs.
+    Eigen::Vector2d x_val(1, 2);
+    double cost_expected =
+        prog.EvalBinding(cost1, x_val)(0) + prog.EvalBinding(cost2, x_val)(0);
+    Eigen::VectorXd constraint_residue;
+    double cost;
+    EXPECT_EQ(dut.Eval<double>(x_val, Eigen::VectorXd(0), 0.5,
+                               &constraint_residue, &cost),
+              cost_expected);
+    EXPECT_EQ(cost, cost_expected);
+    EXPECT_EQ(constraint_residue.rows(), 0);
+
+    // Now evaluate the augmented Lagrangian with autodiff.
+    VectorX<AutoDiffXd> constraint_residue_ad;
+    AutoDiffXd cost_ad;
+    const auto x_ad = math::InitializeAutoDiff(x_val);
+    const auto al = dut.Eval<AutoDiffXd>(x_ad, Eigen::VectorXd(0), 0.5,
+                                         &constraint_residue_ad, &cost_ad);
+    const auto al_expected =
+        prog.EvalBinding(cost1, x_ad)(0) + prog.EvalBinding(cost2, x_ad)(0);
+    EXPECT_EQ(ExtractDoubleOrThrow(al), ExtractDoubleOrThrow(al_expected));
+    EXPECT_TRUE(CompareMatrices(al.derivatives(), al_expected.derivatives()));
+    EXPECT_EQ(cost_ad.value(), al_expected.value());
+    EXPECT_TRUE(
+        CompareMatrices(cost_ad.derivatives(), al_expected.derivatives()));
+    EXPECT_EQ(constraint_residue_ad.rows(), 0);
+  }
+}
+
+class DummyConstraint final : public solvers::Constraint {
+ public:
+  DummyConstraint()
+      : Constraint(4, 2, Eigen::Vector4d(1, 2, 3, 4),
+                   Eigen::Vector4d(1, 2, 3, 4)) {}
+  using Constraint::set_bounds;
+
+ protected:
+  template <typename T>
+  void DoEvalGeneric(const Eigen::Ref<const VectorX<T>>& x,
+                     VectorX<T>* y) const {
+    y->resize(num_constraints());
+    (*y)(0) = x(0) * x(1) + 1;
+    (*y)(1) = x(0) + x(1);
+    (*y)(2) = 2 * x(0) + 3;
+    (*y)(3) = 2 * x(0) / x(1) + 4;
+  }
+  void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+              Eigen::VectorXd* y) const override {
+    DoEvalGeneric<double>(x, y);
+  }
+
+  void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+              AutoDiffVecXd* y) const override {
+    DoEvalGeneric<AutoDiffXd>(x, y);
+  }
+
+  void DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>& x,
+              VectorX<symbolic::Expression>* y) const override {
+    DoEvalGeneric<symbolic::Expression>(x.cast<symbolic::Expression>(), y);
+  }
+};
+
+template <typename T>
+void CompareAlResult(const T& al, const T& al_expected,
+                     const VectorX<T>& constraint_residue,
+                     const VectorX<T>& constraint_residue_expected,
+                     const T& cost, const T& cost_expected, double tol) {
+  if constexpr (std::is_same_v<T, double>) {
+    EXPECT_NEAR(al, al_expected, tol);
+    EXPECT_TRUE(
+        CompareMatrices(constraint_residue, constraint_residue_expected, tol));
+    EXPECT_NEAR(cost, cost_expected, tol);
+  } else {
+    EXPECT_NEAR(al.value(), al_expected.value(), tol);
+    EXPECT_TRUE(
+        CompareMatrices(al.derivatives(), al_expected.derivatives(), tol));
+    EXPECT_TRUE(CompareMatrices(math::ExtractValue(constraint_residue),
+                                math::ExtractValue(constraint_residue_expected),
+                                tol));
+    EXPECT_TRUE(CompareMatrices(
+        math::ExtractGradient(constraint_residue),
+        math::ExtractGradient(constraint_residue_expected), tol));
+    EXPECT_NEAR(cost.value(), cost_expected.value(), tol);
+    EXPECT_TRUE(
+        CompareMatrices(cost.derivatives(), cost_expected.derivatives(), tol));
+  }
+}
+
+// This function is only used inside the test
+// NonsmoothAugmentedLagrangian.EqualityConstraints. Ideally I want to put it
+// inside the test as a templated lambda, but our current compiler on Bionic
+// doesn't support this feature yet.
+template <typename T>
+void CheckAugmentedLagrangianEqualityConstraint(
+    const MathematicalProgram& prog, const Binding<Constraint>& constraint,
+    const Vector3<T>& x_val, const Eigen::Vector4d& lambda_val, double mu_val,
+    double tol_val) {
+  VectorX<T> constraint_residue;
+  T cost;
+  for (bool include_x_bounds : {false, true}) {
+    const NonsmoothAugmentedLagrangian dut(&prog, include_x_bounds);
+    EXPECT_EQ(dut.lagrangian_size(), 4);
+    EXPECT_EQ(dut.is_equality(), std::vector<bool>({true, true, true, true}));
+    const T al =
+        dut.Eval<T>(x_val, lambda_val, mu_val, &constraint_residue, &cost);
+    const auto constraint_val = prog.EvalBinding(constraint, x_val);
+    const auto& constraint_bound = constraint.evaluator()->lower_bound();
+    const T al_expected = -lambda_val.dot(constraint_val - constraint_bound) +
+                          1. / (2 * mu_val) *
+                              (constraint_val - constraint_bound)
+                                  .dot(constraint_val - constraint_bound);
+    EXPECT_EQ(constraint_residue.rows(), lambda_val.rows());
+    CompareAlResult<T>(al, al_expected, constraint_residue,
+                       constraint_val - constraint_bound, cost, T{0}, tol_val);
+  }
+}
+
+GTEST_TEST(AugmentedLagrangian, EqualityConstraints) {
+  // Test a program with on equality constraints.
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<3>();
+  auto constraint =
+      prog.AddConstraint(std::make_shared<DummyConstraint>(), x.head<2>());
+
+  const double tol = 1E-10;
+  CheckAugmentedLagrangianEqualityConstraint(
+      prog, constraint, Eigen::Vector3d(0.5, 1.5, 2),
+      Eigen::Vector4d(1, 3, -2, 4), 0.2, tol);
+  CheckAugmentedLagrangianEqualityConstraint(
+      prog, constraint, Eigen::Vector3d(-0.5, 2.5, 2),
+      Eigen::Vector4d(-1, 2, 3, -2), 0.6, tol);
+  CheckAugmentedLagrangianEqualityConstraint(
+      prog, constraint,
+      math::InitializeAutoDiff(Eigen::Vector3d(0.5, 0.3, 0.2)),
+      Eigen::Vector4d(1, 2, -3, -1), 0.5, tol);
+}
+
+// Refer to equation 17.55 of Numerical Optimization by Jorge Nocedal and
+// Stephen Wright, Edition 1, 1999 (This equation is not presented in Edition
+// 2). We use the alternative way to compute s first, and then compute psi.
+template <typename T>
+T psi(const T& c, double lambda, double mu) {
+  T s = c - mu * lambda;
+  if (ExtractDoubleOrThrow(s) < 0) {
+    s = T(0);
+  }
+  return -lambda * (c - s) + 1 / (2 * mu) * (c - s) * (c - s);
+}
+
+template <typename T>
+void CheckAugmentedLagrangianInequalityConstraint(
+    const MathematicalProgram& prog, const Binding<Constraint>& constraint,
+    const Vector3<T>& x_val, const Eigen::Matrix<double, 5, 1>& lambda_val,
+    double mu_val, double tol_val) {
+  VectorX<T> constraint_residue;
+  T cost;
+  for (const bool include_x_bounds : {false, true}) {
+    const NonsmoothAugmentedLagrangian dut(&prog, include_x_bounds);
+    EXPECT_EQ(dut.lagrangian_size(), 5);
+    EXPECT_EQ(dut.is_equality(),
+              std::vector<bool>({true, false, false, false, false}));
+
+    const T al =
+        dut.Eval<T>(x_val, lambda_val, mu_val, &constraint_residue, &cost);
+    const auto constraint_val = prog.EvalBinding(constraint, x_val);
+    const auto& lb = constraint.evaluator()->lower_bound();
+    const auto& ub = constraint.evaluator()->upper_bound();
+    using std::pow;
+    T al_expected = -lambda_val(0) * (constraint_val(0) - lb(0)) +
+                    1. / (2 * mu_val) * pow(constraint_val(0) - lb(0), 2) +
+                    psi(constraint_val(1) - lb(1), lambda_val(1), mu_val) +
+                    psi(ub(1) - constraint_val(1), lambda_val(2), mu_val) +
+                    psi(ub(2) - constraint_val(2), lambda_val(3), mu_val) +
+                    psi(constraint_val(3) - lb(3), lambda_val(4), mu_val);
+    EXPECT_EQ(constraint_residue.rows(), lambda_val.rows());
+    VectorX<T> constraint_residue_expected(constraint_residue.rows());
+    constraint_residue_expected << constraint_val(0) - lb(0),
+        constraint_val(1) - lb(1), ub(1) - constraint_val(1),
+        ub(2) - constraint_val(2), constraint_val(3) - lb(3);
+    CompareAlResult<T>(al, al_expected, constraint_residue,
+                       constraint_residue_expected, cost, T(0), tol_val);
+  }
+}
+
+GTEST_TEST(AugmentedLagrangian, InequalityConstraint) {
+  // Test with inequality constraints.
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<3>();
+  auto constraint_evaluator = std::make_shared<DummyConstraint>();
+  constraint_evaluator->set_bounds(Eigen::Vector4d(1, -1, -kInf, 2),
+                                   Eigen::Vector4d(1, 2, 3, kInf));
+  auto constraint = prog.AddConstraint(constraint_evaluator, x.tail<2>());
+
+  const double tol = 1E-10;
+  CheckAugmentedLagrangianInequalityConstraint(
+      prog, constraint, Eigen::Vector3d(1, 3, 2),
+      (Eigen::Matrix<double, 5, 1>() << 0.5, 0.4, 1.5, 0.2, 3).finished(), 0.5,
+      tol);
+  CheckAugmentedLagrangianInequalityConstraint(
+      prog, constraint, Eigen::Vector3d(-1, 3, -5),
+      (Eigen::Matrix<double, 5, 1>() << -.5, 1.4, 1.5, 0.5, 3).finished(), 0.2,
+      tol);
+  CheckAugmentedLagrangianInequalityConstraint(
+      prog, constraint, math::InitializeAutoDiff(Eigen::Vector3d(-1, 3, -5)),
+      (Eigen::Matrix<double, 5, 1>() << -.5, 1.4, 1.5, 0.5, 3).finished(), 0.2,
+      tol);
+}
+
+template <typename T>
+void CheckAugmentedLagrangianBoundingBoxConstraint(
+    const MathematicalProgram& prog, const Vector4<T>& x_val,
+    const Eigen::Matrix<double, 5, 1>& lambda, double mu, double tol_val) {
+  const NonsmoothAugmentedLagrangian dut(&prog, true);
+  EXPECT_EQ(dut.lagrangian_size(), 5);
+  EXPECT_EQ(dut.is_equality(),
+            std::vector<bool>({true, false, false, false, false}));
+  VectorX<T> constraint_residue;
+  T cost;
+  const T al = dut.Eval<T>(x_val, lambda, mu, &constraint_residue, &cost);
+  EXPECT_EQ(constraint_residue.rows(), lambda.rows());
+  Eigen::VectorXd x_lb, x_ub;
+  AggregateBoundingBoxConstraints(prog, &x_lb, &x_ub);
+  const T al_expected =
+      -lambda(0) * (x_val(0) - x_lb(0)) +
+      1. / (2 * mu) * (x_val(0) - x_lb(0)) * (x_val(0) - x_lb(0)) +
+      psi(x_val(1) - x_lb(1), lambda(1), mu) +
+      psi(x_ub(2) - x_val(2), lambda(2), mu) +
+      psi(x_val(3) - x_lb(3), lambda(3), mu) +
+      psi(x_ub(3) - x_val(3), lambda(4), mu);
+  Eigen::Matrix<T, 5, 1> constraint_residue_expected;
+  constraint_residue_expected << x_val(0) - x_lb(0), x_val(1) - x_lb(1),
+      x_ub(2) - x_val(2), x_val(3) - x_lb(3), x_ub(3) - x_val(3);
+  CompareAlResult<T>(al, al_expected, constraint_residue,
+                     constraint_residue_expected, cost, T(0), tol_val);
+  Eigen::VectorXd x_lo_expected, x_up_expected;
+  AggregateBoundingBoxConstraints(prog, &x_lo_expected, &x_up_expected);
+  EXPECT_TRUE(CompareMatrices(dut.x_lo(), x_lo_expected));
+  EXPECT_TRUE(CompareMatrices(dut.x_up(), x_up_expected));
+}
+
+GTEST_TEST(EvalAugmentedLagrangian, BoundingBoxConstraint) {
+  // Test with bounding box constraint.
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<4>();
+  auto constraint1 = prog.AddBoundingBoxConstraint(
+      Eigen::Vector4d(1, 3, -kInf, 0), Eigen::Vector4d(2, kInf, -1, 5), x);
+  auto constraint2 = prog.AddBoundingBoxConstraint(
+      Eigen::Vector4d(2, 1, -kInf, 1), Eigen::Vector4d(5, kInf, -1, 3), x);
+
+  const double tol = 1E-10;
+  CheckAugmentedLagrangianBoundingBoxConstraint(
+      prog, Eigen::Vector4d(1, 3, 5, 2),
+      (Eigen::Matrix<double, 5, 1>() << 0.5, 0.3, 1.5, 2, 1).finished(), 0.5,
+      tol);
+  CheckAugmentedLagrangianBoundingBoxConstraint(
+      prog, math::InitializeAutoDiff(Eigen::Vector4d(1, 3, 5, 2)),
+      (Eigen::Matrix<double, 5, 1>() << 0.5, 0.3, 1.5, 2, 1).finished(), 0.5,
+      tol);
+
+  // Test include_x_bounds = false, the augmented lagrangian is 0.
+  const NonsmoothAugmentedLagrangian dut(&prog, false);
+  EXPECT_EQ(dut.lagrangian_size(), 0);
+  EXPECT_TRUE(dut.is_equality().empty());
+  VectorX<double> constraint_residue;
+  double cost;
+  EXPECT_EQ(dut.Eval<double>(Eigen::Vector4d(1, 2, 3, 4), Eigen::VectorXd(0),
+                             0.5, &constraint_residue, &cost),
+            0);
+  EXPECT_EQ(constraint_residue.rows(), 0);
+  Eigen::VectorXd x_lo_expected, x_up_expected;
+  AggregateBoundingBoxConstraints(prog, &x_lo_expected, &x_up_expected);
+  EXPECT_TRUE(CompareMatrices(dut.x_lo(), x_lo_expected));
+  EXPECT_TRUE(CompareMatrices(dut.x_up(), x_up_expected));
+}
+}  // namespace
+}  // namespace solvers
+}  // namespace drake


### PR DESCRIPTION
Turn a constrained optimization problem to the unconstrained one, by
evaluating its augmented Lagrangian, given the variable value, the
estimated Lagrangian and the penalty term.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16391)
<!-- Reviewable:end -->
