### PR TITLE
[common] Move IsAffine into symbolic_decompose

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -194,6 +194,7 @@ drake_cc_library(
         "symbolic_chebyshev_polynomial.h",
         "symbolic_codegen.cc",
         "symbolic_codegen.h",
+        "symbolic_decompose.cc",
         "symbolic_environment.cc",
         "symbolic_environment.h",
         "symbolic_expression.cc",
@@ -232,6 +233,9 @@ drake_cc_library(
     ],
     hdrs = [
         "symbolic.h",
+        # TODO(#13833) We should split out this header into its own library,
+        # once we have the new subdirectory established.
+        "symbolic_decompose.h",
     ],
     deps = [
         ":bit_cast",
@@ -246,14 +250,11 @@ drake_cc_library(
     ],
 )
 
+# TODO(#13833) This library name is vestigial.  Once we are finished with the
+# new file layout in drake/common/symbolic/..., then we should deprecate this
+# library name.
 drake_cc_library(
     name = "symbolic_decompose",
-    srcs = [
-        "symbolic_decompose.cc",
-    ],
-    hdrs = [
-        "symbolic_decompose.h",
-    ],
     deps = [
         ":symbolic",
     ],

--- a/common/symbolic.h
+++ b/common/symbolic.h
@@ -51,3 +51,10 @@
 #include "drake/common/symbolic_codegen.h"
 // clang-format on
 #undef DRAKE_COMMON_SYMBOLIC_HEADER
+
+// TODO(#13833) We should split out this header into its own library,
+// once we have the new subdirectory established.  In the meantime,
+// we want to provide it "for free" here, but it is NOT part of the
+// monolithic symbolic implementation components, so it should not
+// appear within the preprocessor ifdef.
+#include "drake/common/symbolic_decompose.h"

--- a/common/symbolic_decompose.cc
+++ b/common/symbolic_decompose.cc
@@ -15,6 +15,70 @@ using std::runtime_error;
 using std::string;
 
 namespace {
+
+// Helper class for IsAffine functions below where an instance of this class
+// is passed to Eigen::MatrixBase::visit() function.
+class IsAffineVisitor {
+ public:
+  IsAffineVisitor() = default;
+  explicit IsAffineVisitor(const Variables& variables)
+      : variables_{&variables} {}
+
+  // Called for the first coefficient. Needed for Eigen::MatrixBase::visit()
+  // function.
+  void init(const Expression& e, const Eigen::Index i, const Eigen::Index j) {
+    (*this)(e, i, j);
+  }
+
+  // Called for all other coefficients. Needed for Eigen::MatrixBase::visit()
+  // function.
+  void operator()(const Expression& e, const Eigen::Index, const Eigen::Index) {
+    // Note that `IsNotAffine` is only called when we have not found a
+    // non-affine element yet.
+    found_non_affine_element_ = found_non_affine_element_ || IsNotAffine(e);
+  }
+
+  [[nodiscard]] bool result() const { return !found_non_affine_element_; }
+
+ private:
+  // Returns true if `e` is *not* affine in variables_ (if exists) or all
+  // variables in `e`.
+  [[nodiscard]] bool IsNotAffine(const Expression& e) const {
+    // TODO(#16393) This check is incorrect when variables_ is non-null.
+    if (!e.is_polynomial()) {
+      return true;
+    }
+    const Polynomial p{(variables_ != nullptr) ? Polynomial{e, *variables_}
+                                               : Polynomial{e}};
+    return p.TotalDegree() > 1;
+  }
+
+  bool found_non_affine_element_{false};
+  const Variables* const variables_{nullptr};
+};
+
+}  // namespace
+
+bool IsAffine(const Eigen::Ref<const MatrixX<Expression>>& m,
+              const Variables& vars) {
+  if (m.size() == 0) {
+    return true;
+  }
+  IsAffineVisitor visitor{vars};
+  m.visit(visitor);
+  return visitor.result();
+}
+
+bool IsAffine(const Eigen::Ref<const MatrixX<Expression>>& m) {
+  if (m.size() == 0) {
+    return true;
+  }
+  IsAffineVisitor visitor;
+  m.visit(visitor);
+  return visitor.result();
+}
+
+namespace {
 void ThrowError(const string& type, const string& expression) {
   throw runtime_error("While decomposing an expression, we detects that a " +
                       type + " expression: " + expression + ".");

--- a/common/symbolic_decompose.h
+++ b/common/symbolic_decompose.h
@@ -14,6 +14,15 @@
 namespace drake {
 namespace symbolic {
 
+/** Checks if every element in `m` is affine in `vars`.
+@note If `m` is an empty matrix, it returns true. */
+bool IsAffine(const Eigen::Ref<const MatrixX<Expression>>& m,
+              const Variables& vars);
+
+/** Checks if every element in `m` is affine.
+@note If `m` is an empty matrix, it returns true. */
+bool IsAffine(const Eigen::Ref<const MatrixX<Expression>>& m);
+
 /** Decomposes @p expressions into @p M * @p vars.
 
 @throws std::exception if @p expressions is not linear in @p vars.

--- a/common/symbolic_expression.cc
+++ b/common/symbolic_expression.cc
@@ -919,69 +919,6 @@ MatrixX<Expression> Jacobian(const Eigen::Ref<const VectorX<Expression>>& f,
 }
 
 namespace {
-
-// Helper class for IsAffine functions below where an instance of this class
-// is passed to Eigen::MatrixBase::visit() function.
-class IsAffineVisitor {
- public:
-  IsAffineVisitor() = default;
-  explicit IsAffineVisitor(const Variables& variables)
-      : variables_{&variables} {}
-
-  // Called for the first coefficient. Needed for Eigen::MatrixBase::visit()
-  // function.
-  void init(const Expression& e, const Eigen::Index i, const Eigen::Index j) {
-    (*this)(e, i, j);
-  }
-
-  // Called for all other coefficients. Needed for Eigen::MatrixBase::visit()
-  // function.
-  void operator()(const Expression& e, const Eigen::Index, const Eigen::Index) {
-    // Note that `IsNotAffine` is only called when we have not found a
-    // non-affine element yet.
-    found_non_affine_element_ = found_non_affine_element_ || IsNotAffine(e);
-  }
-
-  [[nodiscard]] bool result() const { return !found_non_affine_element_; }
-
- private:
-  // Returns true if `e` is *not* affine in variables_ (if exists) or all
-  // variables in `e`.
-  [[nodiscard]] bool IsNotAffine(const Expression& e) const {
-    if (!e.is_polynomial()) {
-      return true;
-    }
-    const Polynomial p{(variables_ != nullptr) ? Polynomial{e, *variables_}
-                                               : Polynomial{e}};
-    return p.TotalDegree() > 1;
-  }
-
-  bool found_non_affine_element_{false};
-  const Variables* const variables_{nullptr};
-};
-
-}  // namespace
-
-bool IsAffine(const Eigen::Ref<const MatrixX<Expression>>& m,
-              const Variables& vars) {
-  if (m.size() == 0) {
-    return true;
-  }
-  IsAffineVisitor visitor{vars};
-  m.visit(visitor);
-  return visitor.result();
-}
-
-bool IsAffine(const Eigen::Ref<const MatrixX<Expression>>& m) {
-  if (m.size() == 0) {
-    return true;
-  }
-  IsAffineVisitor visitor;
-  m.visit(visitor);
-  return visitor.result();
-}
-
-namespace {
 // Helper functions for TaylorExpand.
 //
 // We use the multi-index notation. Please read

--- a/common/symbolic_expression.h
+++ b/common/symbolic_expression.h
@@ -1423,15 +1423,6 @@ MatrixX<Expression> Jacobian(const Eigen::Ref<const VectorX<Expression>>& f,
 MatrixX<Expression> Jacobian(const Eigen::Ref<const VectorX<Expression>>& f,
                              const Eigen::Ref<const VectorX<Variable>>& vars);
 
-/// Checks if every element in `m` is affine in `vars`.
-/// @note If `m` is an empty matrix, it returns true.
-bool IsAffine(const Eigen::Ref<const MatrixX<Expression>>& m,
-              const Variables& vars);
-
-/// Checks if every element in `m` is affine.
-/// @note If `m` is an empty matrix, it returns true.
-bool IsAffine(const Eigen::Ref<const MatrixX<Expression>>& m);
-
 /// Returns the distinct variables in the matrix of expressions.
 Variables GetDistinctVariables(const Eigen::Ref<const MatrixX<Expression>>& v);
 


### PR DESCRIPTION
We do not want code in the basic scalartype-expression library to depend on all of the polynomial analysis logic.  It gets in the way of completing #13833 successfully.

In the future, the BUILD labels for this function will change, but the function declaration and definition will stay where they are.

---

The C++ code in this PR is a straight move, except for adding one new TODO comment for #16393 that I noticed while working on this.