### PR TITLE
[geometry/optimization] Add two-cycle constraint to Shortest Path formulation

### DIFF
--- a/bindings/pydrake/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry_py_optimization.cc
@@ -48,9 +48,27 @@ void DefineGeometryOptimization(py::module m) {
             py::arg("prog"), py::arg("vars"),
             cls_doc.AddPointInSetConstraints.doc)
         .def("AddPointInNonnegativeScalingConstraints",
-            &ConvexSet::AddPointInNonnegativeScalingConstraints,
+            overload_cast_explicit<
+                std::vector<solvers::Binding<solvers::Constraint>>,
+                solvers::MathematicalProgram*,
+                const Eigen::Ref<const solvers::VectorXDecisionVariable>&,
+                const symbolic::Variable&>(
+                &ConvexSet::AddPointInNonnegativeScalingConstraints),
             py::arg("prog"), py::arg("x"), py::arg("t"),
-            cls_doc.AddPointInNonnegativeScalingConstraints.doc)
+            cls_doc.AddPointInNonnegativeScalingConstraints.doc_3args)
+        .def("AddPointInNonnegativeScalingConstraints",
+            overload_cast_explicit<
+                std::vector<solvers::Binding<solvers::Constraint>>,
+                solvers::MathematicalProgram*,
+                const Eigen::Ref<const Eigen::MatrixXd>&,
+                const Eigen::Ref<const Eigen::VectorXd>&,
+                const Eigen::Ref<const Eigen::VectorXd>&, double,
+                const Eigen::Ref<const solvers::VectorXDecisionVariable>&,
+                const Eigen::Ref<const solvers::VectorXDecisionVariable>&>(
+                &ConvexSet::AddPointInNonnegativeScalingConstraints),
+            py::arg("prog"), py::arg("A"), py::arg("b"), py::arg("c"),
+            py::arg("d"), py::arg("x"), py::arg("t"),
+            cls_doc.AddPointInNonnegativeScalingConstraints.doc_7args)
         .def("ToShapeWithPose", &ConvexSet::ToShapeWithPose,
             cls_doc.ToShapeWithPose.doc);
     // Note: We use the copyable_unique_ptr constructor which calls Clone() on

--- a/geometry/optimization/cartesian_product.h
+++ b/geometry/optimization/cartesian_product.h
@@ -90,6 +90,15 @@ class CartesianProduct final : public ConvexSet {
       const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
       const symbolic::Variable& t) const final;
 
+  std::vector<solvers::Binding<solvers::Constraint>>
+  DoAddPointInNonnegativeScalingConstraints(
+      solvers::MathematicalProgram* prog,
+      const Eigen::Ref<const Eigen::MatrixXd>& A_x,
+      const Eigen::Ref<const Eigen::VectorXd>& b_x,
+      const Eigen::Ref<const Eigen::VectorXd>& c, double d,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& t) const final;
+
   std::pair<std::unique_ptr<Shape>, math::RigidTransformd> DoToShapeWithPose()
       const final;
 

--- a/geometry/optimization/convex_set.cc
+++ b/geometry/optimization/convex_set.cc
@@ -45,6 +45,25 @@ ConvexSet::AddPointInNonnegativeScalingConstraints(
   return constraints;
 }
 
+std::vector<solvers::Binding<solvers::Constraint>>
+ConvexSet::AddPointInNonnegativeScalingConstraints(
+    solvers::MathematicalProgram* prog,
+    const Eigen::Ref<const Eigen::MatrixXd>& A,
+    const Eigen::Ref<const Eigen::VectorXd>& b,
+    const Eigen::Ref<const Eigen::VectorXd>& c, double d,
+    const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
+    const Eigen::Ref<const solvers::VectorXDecisionVariable>& t) const {
+  DRAKE_DEMAND(A.rows() == ambient_dimension());
+  DRAKE_DEMAND(A.rows() == b.rows());
+  DRAKE_DEMAND(A.cols() == x.size());
+  DRAKE_DEMAND(c.rows() == t.size());
+  std::vector<solvers::Binding<solvers::Constraint>> constraints =
+      DoAddPointInNonnegativeScalingConstraints(prog, A, b, c, d, x, t);
+  constraints.emplace_back(prog->AddLinearConstraint(
+      c.transpose(), -d, std::numeric_limits<double>::infinity(), t));
+  return constraints;
+}
+
 }  // namespace optimization
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/optimization/convex_set.h
+++ b/geometry/optimization/convex_set.h
@@ -125,6 +125,31 @@ class ConvexSet : public ShapeReifier {
       const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
       const symbolic::Variable& t) const;
 
+  /** Let S be this convex set.  When S is bounded, this method adds the convex
+  constraints to imply
+  @verbatim
+  A * x + b ∈ (c' * t + d) S,
+  c * t + d ≥ 0,
+  @endverbatim
+  where A is an n-by-m matrix (with n the ambient_dimension), b is a vector of
+  size n, c is a vector of size p, x is a point in ℜᵐ, and t is a point in ℜ^p.
+
+  When S is unbounded, then the behavior is almost identical, except when c' *
+  t+d=0. In this case, the constraints imply c' * t + d ≥ 0, A * x + b ∈ (c' * t
+  + d) S ⊕ rec(S), where rec(S) is the recession cone of S (the asymptotic
+  directions in which S is not bounded) and ⊕ is the Minkowski sum.  For c' * t
+  + d > 0, this is equivalent
+  to A * x + b ∈ (c' * t + d) S, but for c' * t + d = 0, we have only A * x + b
+  ∈ rec(S). */
+  std::vector<solvers::Binding<solvers::Constraint>>
+  AddPointInNonnegativeScalingConstraints(
+      solvers::MathematicalProgram* prog,
+      const Eigen::Ref<const Eigen::MatrixXd>& A,
+      const Eigen::Ref<const Eigen::VectorXd>& b,
+      const Eigen::Ref<const Eigen::VectorXd>& c, double d,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& t) const;
+
   /** Constructs a Shape and a pose of the set in the world frame for use in
   the SceneGraph geometry ecosystem.
 
@@ -173,6 +198,20 @@ class ConvexSet : public ShapeReifier {
       solvers::MathematicalProgram* prog,
       const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
       const symbolic::Variable& t) const = 0;
+
+  /** An NVI method that subclasses must overwrite to add the constraints
+  needed to keep the point A * x + b in the non-negative scaling of the set.
+  Note that subclasses do not need to add the constraint c * t + d ≥ 0 as it is
+  already added.
+  */
+  virtual std::vector<solvers::Binding<solvers::Constraint>>
+  DoAddPointInNonnegativeScalingConstraints(
+      solvers::MathematicalProgram* prog,
+      const Eigen::Ref<const Eigen::MatrixXd>& A,
+      const Eigen::Ref<const Eigen::VectorXd>& b,
+      const Eigen::Ref<const Eigen::VectorXd>& c, double d,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& t) const = 0;
 
   virtual std::pair<std::unique_ptr<Shape>, math::RigidTransformd>
   DoToShapeWithPose() const = 0;

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -126,6 +126,15 @@ class HPolyhedron final : public ConvexSet {
       const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
       const symbolic::Variable& t) const final;
 
+  std::vector<solvers::Binding<solvers::Constraint>>
+  DoAddPointInNonnegativeScalingConstraints(
+      solvers::MathematicalProgram* prog,
+      const Eigen::Ref<const Eigen::MatrixXd>& A_x,
+      const Eigen::Ref<const Eigen::VectorXd>& b_x,
+      const Eigen::Ref<const Eigen::VectorXd>& c, double d,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& t) const final;
+
   // TODO(russt): Implement DoToShapeWithPose.  Currently we don't have a Shape
   // that can consume this output.  The obvious candidate is Convex, that class
   // currently only stores the filename of an .obj file, and I shouldn't need

--- a/geometry/optimization/hyperellipsoid.h
+++ b/geometry/optimization/hyperellipsoid.h
@@ -112,6 +112,15 @@ class Hyperellipsoid final : public ConvexSet {
       const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
       const symbolic::Variable& t) const final;
 
+  std::vector<solvers::Binding<solvers::Constraint>>
+  DoAddPointInNonnegativeScalingConstraints(
+      solvers::MathematicalProgram* prog,
+      const Eigen::Ref<const Eigen::MatrixXd>& A_x,
+      const Eigen::Ref<const Eigen::VectorXd>& b,
+      const Eigen::Ref<const Eigen::VectorXd>& c, double d,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& t) const final;
+
   std::pair<std::unique_ptr<Shape>, math::RigidTransformd> DoToShapeWithPose()
       const final;
 

--- a/geometry/optimization/minkowski_sum.h
+++ b/geometry/optimization/minkowski_sum.h
@@ -76,6 +76,15 @@ class MinkowskiSum final : public ConvexSet {
       const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
       const symbolic::Variable& t) const final;
 
+  std::vector<solvers::Binding<solvers::Constraint>>
+  DoAddPointInNonnegativeScalingConstraints(
+      solvers::MathematicalProgram* prog,
+      const Eigen::Ref<const Eigen::MatrixXd>& A,
+      const Eigen::Ref<const Eigen::VectorXd>& b,
+      const Eigen::Ref<const Eigen::VectorXd>& c, double d,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& t) const final;
+
   std::pair<std::unique_ptr<Shape>, math::RigidTransformd> DoToShapeWithPose()
       const final;
 

--- a/geometry/optimization/point.h
+++ b/geometry/optimization/point.h
@@ -62,6 +62,15 @@ class Point final : public ConvexSet {
       const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
       const symbolic::Variable& t) const final;
 
+  std::vector<solvers::Binding<solvers::Constraint>>
+  DoAddPointInNonnegativeScalingConstraints(
+      solvers::MathematicalProgram* prog,
+      const Eigen::Ref<const Eigen::MatrixXd>& A,
+      const Eigen::Ref<const Eigen::VectorXd>& b,
+      const Eigen::Ref<const Eigen::VectorXd>& c, double d,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& t) const final;
+
   std::pair<std::unique_ptr<Shape>, math::RigidTransformd> DoToShapeWithPose()
       const final;
 

--- a/geometry/optimization/test/cartesian_product_test.cc
+++ b/geometry/optimization/test/cartesian_product_test.cc
@@ -149,18 +149,75 @@ GTEST_TEST(CartesianProductTest, NonnegativeScalingTest) {
   // 1 vector constraint from P1, 1 from P2, and t>=0 3 times.
   EXPECT_EQ(constraints.size(), 5);
 
+  const double tol = 1e-16;
   Vector4d p;
   p << P1.x(), P2.x();
   for (const double scale : {0.5, 1.0, 2.0}) {
     prog.SetInitialGuess(x, scale * p);
     prog.SetInitialGuess(t, scale);
-    EXPECT_TRUE(prog.CheckSatisfiedAtInitialGuess(constraints, 1e-16));
+    EXPECT_TRUE(prog.CheckSatisfiedAtInitialGuess(constraints, tol));
     prog.SetInitialGuess(x, 0.99 * scale * p);
-    EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(constraints, 1e-16));
+    EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(constraints, tol));
   }
   prog.SetInitialGuess(x, p);
   prog.SetInitialGuess(t, -1.0);
-  EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(constraints, 1e-16));
+  EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(constraints, tol));
+}
+
+bool PointInScaledSet(const solvers::VectorXDecisionVariable& x_vars,
+                      const solvers::VectorXDecisionVariable& t_var,
+                      const Vector2d& x, const Vector2d& t,
+                      solvers::MathematicalProgram* prog) {
+  auto b1 = prog->AddBoundingBoxConstraint(x, x, x_vars);
+  auto b2 = prog->AddBoundingBoxConstraint(t, t, t_var);
+  auto result = solvers::Solve(*prog);
+  prog->RemoveConstraint(b1);
+  prog->RemoveConstraint(b2);
+  return result.is_success();
+}
+
+GTEST_TEST(CartesianProductTest, NonnegativeScalingTest2) {
+  const Point P1(Vector2d{1.2, 3.4}), P2(Vector2d{2.4, 6.8});
+  const CartesianProduct S(P1, P2);
+
+  solvers::MathematicalProgram prog;
+  Eigen::MatrixXd A(4, 2);
+  // clang-format off
+  A << 1, 0,
+       0, 1,
+       2, 0,
+       0, 2;
+  // clang-format on
+  Eigen::Vector4d b = Eigen::Vector4d::Zero();
+  auto x = prog.NewContinuousVariables(2, "x");
+  Eigen::Vector2d c(1, -1);
+  double d = 0;
+  auto t = prog.NewContinuousVariables(2, "t");
+
+  std::vector<solvers::Binding<solvers::Constraint>> constraints =
+      S.AddPointInNonnegativeScalingConstraints(&prog, A, b, c, d, x, t);
+
+  // 1 vector constraint from P1, 1 from P2, and c'*t+d>=0 3 times.
+  EXPECT_EQ(constraints.size(), 5);
+
+  Eigen::Vector2d x_solution = P1.x();
+  Eigen::Vector3d scale(0.5, 1.0, 2.0);
+  Eigen::MatrixXd t_solutions(2, 9);
+  // clang-format off
+  t_solutions << 0.5,  0,  0.25, 1,  0,  0.5, 2,  0,  1,
+                 0, -0.5, -0.25, 0, -1, -0.5, 0, -2, -1;
+  // clang-format on
+  for (int ii = 0; ii < t_solutions.cols(); ++ii) {
+    EXPECT_TRUE(PointInScaledSet(x, t, scale[ii / 3] * x_solution,
+                                 t_solutions.col(ii), &prog));
+    EXPECT_FALSE(PointInScaledSet(x, t, 0.99 * scale[ii / 3] * x_solution,
+                                  t_solutions.col(ii), &prog));
+  }
+
+  EXPECT_FALSE(
+      PointInScaledSet(x, t, x_solution, Eigen::Vector2d(0, 1), &prog));
+  EXPECT_FALSE(
+      PointInScaledSet(x, t, x_solution, Eigen::Vector2d(-1, 0), &prog));
 }
 
 // Test the case where A and b are set via the constructor.  Note that the

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -256,33 +256,98 @@ GTEST_TEST(HPolyhedronTest, NonnegativeScalingTest) {
 
   EXPECT_EQ(constraints.size(), 2);
 
-  prog.SetInitialGuess(x, .99 * ub);
+  const double tol = 0;
+
+  prog.SetInitialGuess(x, 0.99 * ub);
   prog.SetInitialGuess(t, 1.0);
-  EXPECT_TRUE(prog.CheckSatisfiedAtInitialGuess(constraints, 0));
+  EXPECT_TRUE(prog.CheckSatisfiedAtInitialGuess(constraints, tol));
 
   prog.SetInitialGuess(x, 1.01 * ub);
   prog.SetInitialGuess(t, 1.0);
-  EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(constraints, 0));
+  EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(constraints, tol));
 
-  prog.SetInitialGuess(x, .99 * ub);
+  prog.SetInitialGuess(x, 0.99 * ub);
   prog.SetInitialGuess(t, -0.01);
-  EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(constraints, 0));
+  EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(constraints, tol));
 
-  prog.SetInitialGuess(x, .49 * ub);
+  prog.SetInitialGuess(x, 0.49 * ub);
   prog.SetInitialGuess(t, 0.5);
-  EXPECT_TRUE(prog.CheckSatisfiedAtInitialGuess(constraints, 0));
+  EXPECT_TRUE(prog.CheckSatisfiedAtInitialGuess(constraints, tol));
 
-  prog.SetInitialGuess(x, .51 * ub);
+  prog.SetInitialGuess(x, 0.51 * ub);
   prog.SetInitialGuess(t, 0.5);
-  EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(constraints, 0));
+  EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(constraints, tol));
 
   prog.SetInitialGuess(x, 1.99 * ub);
   prog.SetInitialGuess(t, 2.0);
-  EXPECT_TRUE(prog.CheckSatisfiedAtInitialGuess(constraints, 0));
+  EXPECT_TRUE(prog.CheckSatisfiedAtInitialGuess(constraints, tol));
 
   prog.SetInitialGuess(x, 2.01 * ub);
   prog.SetInitialGuess(t, 2.0);
-  EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(constraints, 0));
+  EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(constraints, tol));
+}
+
+bool PointInScaledSet(const solvers::VectorXDecisionVariable& x_vars,
+                      const solvers::VectorXDecisionVariable& t_vars,
+                      const Vector2d& x, const Vector2d& t,
+                      solvers::MathematicalProgram* prog,
+                      const std::vector<Binding<Constraint>>& constraints) {
+  const double tol = 0;
+  prog->SetInitialGuess(x_vars, x);
+  prog->SetInitialGuess(t_vars, t);
+  return prog->CheckSatisfiedAtInitialGuess(constraints, tol);
+}
+
+GTEST_TEST(HPolyhedronTest, NonnegativeScalingTest2) {
+  const Vector3d lb{1, 1, 1}, ub{2, 3, 4};
+  HPolyhedron H = HPolyhedron::MakeBox(lb, ub);
+
+  MathematicalProgram prog;
+  Eigen::MatrixXd A(3, 2);
+  // clang-format off
+  A << 1, 0,
+       0, 1,
+       2, 0;
+  // clang-format on
+  Vector3d b = Vector3d::Zero();
+  auto x = prog.NewContinuousVariables(2, "x");
+  Eigen::Vector2d c(1, -1);
+  double d = 0;
+  auto t = prog.NewContinuousVariables(2, "t");
+
+  std::vector<Binding<Constraint>> constraints =
+      H.AddPointInNonnegativeScalingConstraints(&prog, A, b, c, d, x, t);
+
+  EXPECT_EQ(constraints.size(), 2);
+
+  EXPECT_TRUE(PointInScaledSet(x, t, 0.99 * ub.head(2), Vector2d(1.0, 0), &prog,
+                               constraints));
+  EXPECT_TRUE(PointInScaledSet(x, t, 0.99 * ub.head(2), Vector2d(0, -1.0),
+                               &prog, constraints));
+  EXPECT_FALSE(PointInScaledSet(x, t, 1.01 * ub.head(2), Vector2d(1.0, 0),
+                                &prog, constraints));
+  EXPECT_FALSE(PointInScaledSet(x, t, 1.01 * ub.head(2), Vector2d(0, -1.0),
+                                &prog, constraints));
+  EXPECT_FALSE(PointInScaledSet(x, t, 0.99 * ub.head(2), Vector2d(-0.01, 0),
+                                &prog, constraints));
+  EXPECT_FALSE(PointInScaledSet(x, t, 0.99 * ub.head(2), Vector2d(0, -0.01),
+                                &prog, constraints));
+  EXPECT_TRUE(PointInScaledSet(x, t, 0.49 * ub.head(2), Vector2d(0.5, 0), &prog,
+                               constraints));
+  EXPECT_TRUE(PointInScaledSet(x, t, 0.49 * ub.head(2), Vector2d(0, -0.5),
+                               &prog, constraints));
+  EXPECT_FALSE(PointInScaledSet(x, t, 0.51 * ub.head(2), Vector2d(0.5, 0),
+                                &prog, constraints));
+  EXPECT_FALSE(PointInScaledSet(x, t, 0.51 * ub.head(2), Vector2d(0, -0.5),
+                                &prog, constraints));
+  EXPECT_TRUE(PointInScaledSet(x, t, 1.99 * ub.head(2), Vector2d(2.0, 0), &prog,
+                               constraints));
+  EXPECT_TRUE(PointInScaledSet(x, t, 1.99 * ub.head(2), Vector2d(0, -2.0),
+                               &prog, constraints));
+  EXPECT_FALSE(PointInScaledSet(x, t, 2.01 * ub.head(2), Vector2d(2.0, 0),
+                                &prog, constraints));
+  EXPECT_FALSE(PointInScaledSet(x, t, 2.01 * ub.head(2), Vector2d(0, -2.0),
+                                &prog, constraints));
 }
 
 GTEST_TEST(HPolyhedronTest, IsBounded) {

--- a/geometry/optimization/test/hyperellipsoid_test.cc
+++ b/geometry/optimization/test/hyperellipsoid_test.cc
@@ -237,34 +237,102 @@ GTEST_TEST(HyperellipsoidTest, NonnegativeScalingTest) {
   // The point farthest from the origin on the set boundary on the line x=y=z.
   // x^2 + 4x^2 + 9x^2 = 1 => x = sqrt(1 / 14).
   const Vector3d ub = center + sqrt(1.0 / 14.0) * Vector3d::Ones();
+  const double tol = 0;
 
-  prog.SetInitialGuess(x, .99 * ub);
+  prog.SetInitialGuess(x, 0.99 * ub);
   prog.SetInitialGuess(t, 1.0);
-  EXPECT_TRUE(prog.CheckSatisfiedAtInitialGuess(constraints, 0));
+  EXPECT_TRUE(prog.CheckSatisfiedAtInitialGuess(constraints, tol));
 
   prog.SetInitialGuess(x, 1.01 * ub);
   prog.SetInitialGuess(t, 1.0);
-  EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(constraints, 0));
+  EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(constraints, tol));
 
-  prog.SetInitialGuess(x, .99 * ub);
+  prog.SetInitialGuess(x, 0.99 * ub);
   prog.SetInitialGuess(t, -0.01);
-  EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(constraints, 0));
+  EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(constraints, tol));
 
-  prog.SetInitialGuess(x, .49 * ub);
+  prog.SetInitialGuess(x, 0.49 * ub);
   prog.SetInitialGuess(t, 0.5);
-  EXPECT_TRUE(prog.CheckSatisfiedAtInitialGuess(constraints, 0));
+  EXPECT_TRUE(prog.CheckSatisfiedAtInitialGuess(constraints, tol));
 
-  prog.SetInitialGuess(x, .51 * ub);
+  prog.SetInitialGuess(x, 0.51 * ub);
   prog.SetInitialGuess(t, 0.5);
-  EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(constraints, 0));
+  EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(constraints, tol));
 
   prog.SetInitialGuess(x, 1.99 * ub);
   prog.SetInitialGuess(t, 2.0);
-  EXPECT_TRUE(prog.CheckSatisfiedAtInitialGuess(constraints, 0));
+  EXPECT_TRUE(prog.CheckSatisfiedAtInitialGuess(constraints, tol));
 
   prog.SetInitialGuess(x, 2.01 * ub);
   prog.SetInitialGuess(t, 2.0);
-  EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(constraints, 0));
+  EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(constraints, tol));
+}
+
+bool PointInScaledSet(const solvers::VectorXDecisionVariable& x_vars,
+                      const solvers::VectorXDecisionVariable& t_vars,
+                      const Vector2d& x, const Vector2d& t,
+                      solvers::MathematicalProgram* prog,
+                      const std::vector<Binding<Constraint>>& constraints) {
+  const double tol = 0;
+  prog->SetInitialGuess(x_vars, x);
+  prog->SetInitialGuess(t_vars, t);
+  return prog->CheckSatisfiedAtInitialGuess(constraints, tol);
+}
+
+GTEST_TEST(HyperellipsoidTest, NonnegativeScalingTest2) {
+  const Vector3d center{2, 2, 2};
+  Hyperellipsoid E(Matrix3d(Vector3d{1, 2, 3}.asDiagonal()), center);
+
+  MathematicalProgram prog;
+  Eigen::MatrixXd A(3, 2);
+  // clang-format off
+  A << 1, 0,
+       0, 1,
+       1, 0;
+  // clang-format on
+  Vector3d b = Vector3d::Zero();
+  auto x = prog.NewContinuousVariables(2, "x");
+  Eigen::Vector2d c(1, -1);
+  double d = 0;
+  auto t = prog.NewContinuousVariables(2, "t");
+
+  std::vector<Binding<Constraint>> constraints =
+      E.AddPointInNonnegativeScalingConstraints(&prog, A, b, c, d, x, t);
+
+  EXPECT_EQ(constraints.size(), 2);
+
+  // The point farthest from the origin on the set boundary on the line x=y=z.
+  // x^2 + 4x^2 + 9x^2 = 1 => x = sqrt(1 / 14).
+  const Vector2d ub = center.head(2) + sqrt(1.0 / 14.0) * Vector2d::Ones();
+
+  EXPECT_TRUE(
+      PointInScaledSet(x, t, 0.99 * ub, Vector2d(1.0, 0), &prog, constraints));
+  EXPECT_TRUE(
+      PointInScaledSet(x, t, 0.99 * ub, Vector2d(0, -1.0), &prog, constraints));
+  EXPECT_FALSE(
+      PointInScaledSet(x, t, 1.01 * ub, Vector2d(1.0, 0), &prog, constraints));
+  EXPECT_FALSE(
+      PointInScaledSet(x, t, 1.01 * ub, Vector2d(0, -1.0), &prog, constraints));
+  EXPECT_FALSE(PointInScaledSet(x, t, 0.99 * ub, Vector2d(-0.01, 0), &prog,
+                                constraints));
+  EXPECT_FALSE(PointInScaledSet(x, t, 0.99 * ub, Vector2d(0, -0.01), &prog,
+                                constraints));
+  EXPECT_TRUE(
+      PointInScaledSet(x, t, 0.49 * ub, Vector2d(0.5, 0), &prog, constraints));
+  EXPECT_TRUE(
+      PointInScaledSet(x, t, 0.49 * ub, Vector2d(0, -0.5), &prog, constraints));
+  EXPECT_FALSE(
+      PointInScaledSet(x, t, 0.51 * ub, Vector2d(0.5, 0), &prog, constraints));
+  EXPECT_FALSE(
+      PointInScaledSet(x, t, 0.51 * ub, Vector2d(0, -0.5), &prog, constraints));
+  EXPECT_TRUE(
+      PointInScaledSet(x, t, 1.99 * ub, Vector2d(2.0, 0), &prog, constraints));
+  EXPECT_TRUE(
+      PointInScaledSet(x, t, 1.99 * ub, Vector2d(0, -2.0), &prog, constraints));
+  EXPECT_FALSE(
+      PointInScaledSet(x, t, 2.01 * ub, Vector2d(2.0, 0), &prog, constraints));
+  EXPECT_FALSE(
+      PointInScaledSet(x, t, 2.01 * ub, Vector2d(0, -2.0), &prog, constraints));
 }
 
 GTEST_TEST(HyperellisoidTest, MakeUnitBallTest) {

--- a/geometry/optimization/vpolytope.h
+++ b/geometry/optimization/vpolytope.h
@@ -88,6 +88,15 @@ class VPolytope final : public ConvexSet {
       const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
       const symbolic::Variable& t) const final;
 
+  std::vector<solvers::Binding<solvers::Constraint>>
+  DoAddPointInNonnegativeScalingConstraints(
+      solvers::MathematicalProgram* prog,
+      const Eigen::Ref<const Eigen::MatrixXd>& A,
+      const Eigen::Ref<const Eigen::VectorXd>& b,
+      const Eigen::Ref<const Eigen::VectorXd>& c, double d,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& t) const final;
+
   std::pair<std::unique_ptr<Shape>, math::RigidTransformd> DoToShapeWithPose()
       const final;
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16397)
<!-- Reviewable:end -->
