### PR TITLE
[geometry/optimization] Fix Iris regions not collision free issue

### DIFF
--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -77,14 +77,13 @@ HPolyhedron Iris(const ConvexSets& obstacles, const Ref<const VectorXd>& sample,
     int num_constraints = domain.A().rows();
     tangent_matrix = 2.0 * E.A().transpose() * E.A();
     for (int i = 0; i < N; ++i) {
-      const VectorXd point = closest_points.col(scaling[i].second);
-      // Only add a constraint if this point is still within the set that has
-      // been constructed so far on this iteration.
-      if (((A.topRows(num_constraints) * point).array() <=
-           b.head(num_constraints).array())
-              .all()) {
+      // Only add a constraint if this obstacle still has overlap with the set
+      // that has been constructed so far on this iteration.
+      if (HPolyhedron(A.topRows(num_constraints), b.head(num_constraints))
+              .IntersectsWith(*obstacles[scaling[i].second])) {
         // Add the tangent to the (scaled) ellipsoid at this point as a
         // constraint.
+        const VectorXd point = closest_points.col(scaling[i].second);
         A.row(num_constraints) =
             (tangent_matrix * (point - E.center())).normalized();
         b[num_constraints] = A.row(num_constraints) * point;


### PR DESCRIPTION
Since Iris only checks the closest point on an obstacle to see if a new hyperplane should be added, there are cases where the closest point of an obstacle is not in the region that has been constructed so far, but a different part of the obstacle is.  The old implementation would therefore result in Iris regions that overlapped obstacles.  This PR fixes the decision criteria for adding a hyperplane and adds a test that failed prior to the change to Iris.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16398)
<!-- Reviewable:end -->
