### PR TITLE
[tools] Purge some vestigial macOS paths for sanitizer builds

### DIFF
--- a/tools/dynamic_analysis/asan.sh
+++ b/tools/dynamic_analysis/asan.sh
@@ -6,5 +6,5 @@ export ASAN_OPTIONS="$ASAN_OPTIONS:check_initialization_order=1:detect_container
 # errors
 export LSAN_OPTIONS="$LSAN_OPTIONS:strip_path_prefix=/proc/self/cwd/:suppressions=$mydir/lsan.supp"
 # Ensure executable named llvm-symbolizer is on the PATH.
-export PATH="$PATH:/usr/lib/llvm-9/bin:/usr/local/opt/llvm/bin"
+export PATH="$PATH:/usr/lib/llvm-9/bin"
 "$@"

--- a/tools/dynamic_analysis/lsan.sh
+++ b/tools/dynamic_analysis/lsan.sh
@@ -3,5 +3,5 @@ me=$(python3 -c 'import os; print(os.path.realpath("'"$0"'"))')
 mydir=$(dirname "$me")
 export LSAN_OPTIONS="$LSAN_OPTIONS:strip_path_prefix=/proc/self/cwd/:suppressions=$mydir/lsan.supp"
 # Ensure executable named llvm-symbolizer is on the PATH.
-export PATH="$PATH:/usr/lib/llvm-9/bin:/usr/local/opt/llvm/bin"
+export PATH="$PATH:/usr/lib/llvm-9/bin"
 "$@"

--- a/tools/dynamic_analysis/tsan.sh
+++ b/tools/dynamic_analysis/tsan.sh
@@ -3,5 +3,5 @@ me=$(python3 -c 'import os; print(os.path.realpath("'"$0"'"))')
 mydir=$(dirname "$me")
 export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=1:second_deadlock_stack=1:strip_path_prefix=/proc/self/cwd/:suppressions=$mydir/tsan.supp"
 # Ensure executable named llvm-symbolizer is on the PATH.
-export PATH="$PATH:/usr/lib/llvm-9/bin:/usr/local/opt/llvm/bin"
+export PATH="$PATH:/usr/lib/llvm-9/bin"
 "$@"

--- a/tools/dynamic_analysis/ubsan.sh
+++ b/tools/dynamic_analysis/ubsan.sh
@@ -6,5 +6,5 @@ mydir=$(dirname "$me")
 # clang without this option.
 export UBSAN_OPTIONS="$UBSAN_OPTIONS:halt_on_error=1:strip_path_prefix=/proc/self/cwd/:suppressions=$mydir/ubsan.supp"
 # Ensure executable named llvm-symbolizer is on the PATH.
-export PATH="$PATH:/usr/lib/llvm-9/bin:/usr/local/opt/llvm/bin"
+export PATH="$PATH:/usr/lib/llvm-9/bin"
 "$@"

--- a/tools/macos.bazelrc
+++ b/tools/macos.bazelrc
@@ -1,12 +1,3 @@
 # Configure ${PATH} for actions.
 # N.B. Ensure this is consistent with `execute.bzl`.
 build --action_env=PATH=/usr/local/bin:/usr/bin:/bin
-
-# Suppress numerous "'_FORTIFY_SOURCE' macro redefined" warnings when using
-# sanitizers.
-build:asan --copt=-Wno-macro-redefined
-build:asan_everything --copt=-Wno-macro-redefined
-build:tsan --copt=-Wno-macro-redefined
-build:tsan_everything --copt=-Wno-macro-redefined
-build:ubsan --copt=-Wno-macro-redefined
-build:ubsan_everything --copt=-Wno-macro-redefined


### PR DESCRIPTION
We do not support the sanitizer builds on macOS.  Remove some paths and options that were leftover from when we did have support.

(Noted while working on #16389 porting to ARM homebrew.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16399)
<!-- Reviewable:end -->
