### PR TITLE
[meshcat] Add JointSliders system

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -133,6 +133,23 @@ drake_pybind_library(
 )
 
 drake_pybind_library(
+    name = "meshcat_py",
+    cc_deps = [
+        "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake/common:cpp_template_pybind",
+        "//bindings/pydrake/common:default_scalars_pybind",
+        "//bindings/pydrake/common:monostate_pybind",
+        "//bindings/pydrake/common:type_pack",
+    ],
+    cc_srcs = ["meshcat_py.cc"],
+    package_info = PACKAGE_INFO,
+    py_deps = [
+        ":module_py",
+        ":plant_py",
+    ],
+)
+
+drake_pybind_library(
     name = "inverse_kinematics_py",
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
@@ -177,6 +194,7 @@ PY_LIBRARIES_WITH_INSTALL = [
     ":benchmarks_py",
     ":inverse_kinematics_py",
     ":math_py",
+    ":meshcat_py",
     ":optimization_py",
     ":parsing_py",
     ":plant_py",
@@ -274,6 +292,17 @@ drake_py_unittest(
     deps = [
         ":math_py",
         "//bindings/pydrake/common/test_utilities",
+    ],
+)
+
+drake_py_unittest(
+    name = "meshcat_test",
+    data = [
+        "//multibody/benchmarks/acrobot:models",
+    ],
+    deps = [
+        ":meshcat_py",
+        ":parsing_py",
     ],
 )
 

--- a/bindings/pydrake/multibody/all.py
+++ b/bindings/pydrake/multibody/all.py
@@ -3,6 +3,7 @@ import warnings
 # Normal symbols.
 from .inverse_kinematics import *  # noqa
 from .math import *  # noqa
+from .meshcat import *  # noqa
 from .optimization import *  # noqa
 from .parsing import *  # noqa
 from .plant import *  # noqa

--- a/bindings/pydrake/multibody/meshcat_py.cc
+++ b/bindings/pydrake/multibody/meshcat_py.cc
@@ -1,0 +1,61 @@
+#include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
+
+#include "drake/bindings/pydrake/common/cpp_template_pybind.h"
+#include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/common/monostate_pybind.h"
+#include "drake/bindings/pydrake/common/type_pack.h"
+#include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/multibody/meshcat/joint_sliders.h"
+
+using drake::multibody::MultibodyPlant;
+using drake::systems::LeafSystem;
+
+namespace drake {
+namespace pydrake {
+
+namespace {
+template <typename T>
+void DoScalarDependentDefinitions(py::module m, T) {
+  py::tuple param = GetPyParam<T>();
+
+  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+  using namespace drake::multibody::meshcat;
+  constexpr auto& doc = pydrake_doc.drake.multibody.meshcat;
+
+  // JointSliders
+  {
+    using Class = JointSliders<T>;
+    constexpr auto& cls_doc = doc.JointSliders;
+    DefineTemplateClassWithDefault<JointSliders<T>, LeafSystem<T>>(
+        m, "JointSliders", param, doc.JointSliders.doc)
+        .def(py::init<std::shared_ptr<geometry::Meshcat>,
+                 const MultibodyPlant<T>*, std::optional<Eigen::VectorXd>,
+                 std::variant<std::monostate, double, Eigen::VectorXd>,
+                 std::variant<std::monostate, double, Eigen::VectorXd>,
+                 std::variant<std::monostate, double, Eigen::VectorXd>>(),
+            py::arg("meshcat"), py::arg("plant"),
+            py::arg("initial_value") = py::none(),
+            py::arg("lower_limit") = py::none(),
+            py::arg("upper_limit") = py::none(), py::arg("step") = py::none(),
+            // Keep alive, reference: `self` keeps `plant` alive.
+            py::keep_alive<1, 3>(),  // BR
+            cls_doc.ctor.doc)
+        .def("Delete", &Class::Delete, cls_doc.Delete.doc);
+  }
+}
+}  // namespace
+
+PYBIND11_MODULE(meshcat, m) {
+  PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(m);
+  m.doc() = "Interface code for Meshcat-based visualization";
+
+  py::module::import("pydrake.multibody.plant");
+
+  type_visit([m](auto dummy) { DoScalarDependentDefinitions(m, dummy); },
+      NonSymbolicScalarPack{});
+}
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/multibody/test/meshcat_test.py
+++ b/bindings/pydrake/multibody/test/meshcat_test.py
@@ -1,0 +1,77 @@
+from pydrake.multibody.meshcat import (
+    JointSliders,
+)
+
+import os
+import unittest
+
+from pydrake.common import (
+    FindResourceOrThrow,
+)
+from pydrake.geometry import (
+    Meshcat,
+)
+from pydrake.multibody.parsing import (
+    Parser,
+)
+from pydrake.multibody.plant import (
+    AddMultibodyPlantSceneGraph,
+    MultibodyPlant,
+)
+from pydrake.systems.framework import (
+    DiagramBuilder,
+)
+
+
+class TestMeshcat(unittest.TestCase):
+
+    def test_joint_sliders(self):
+        # Load up an acrobot.
+        acrobot_file = FindResourceOrThrow(
+            "drake/multibody/benchmarks/acrobot/acrobot.urdf")
+        builder = DiagramBuilder()
+        plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
+        parser = Parser(plant)
+        parser.AddModelFromFile(acrobot_file)
+        plant.Finalize()
+
+        # Construct a sliders system, using every available option.
+        meshcat = Meshcat()
+        dut = JointSliders(
+            meshcat=meshcat,
+            plant=plant,
+            initial_value=[0.1, 0.2],
+            lower_limit=[-3.0, -6.0],
+            upper_limit=[3.0, 6.0],
+            step=[0.25, 0.50],
+        )
+
+        # Various methods should not crash.
+        dut.get_output_port()
+        dut.Delete()
+
+        # The constructor also accepts single values for broadcast (except for
+        # the initial value).
+        dut = JointSliders(
+            meshcat=meshcat,
+            plant=plant,
+            initial_value=[0.1, 0.2],
+            lower_limit=-3.0,
+            upper_limit=3.0,
+            step=0.1,
+        )
+        dut.Delete()
+
+        # The constructor also accepts None directly, for optionals.
+        dut = JointSliders(
+            meshcat=meshcat,
+            plant=plant,
+            initial_value=None,
+            lower_limit=None,
+            upper_limit=None,
+            step=None,
+        )
+        dut.Delete()
+
+        # The constructor has default values, in any case.
+        dut = JointSliders(meshcat, plant)

--- a/bindings/pydrake/test/all_test.py
+++ b/bindings/pydrake/test/all_test.py
@@ -125,6 +125,8 @@ class TestAll(unittest.TestCase):
             "InverseKinematics",
             # - math
             "SpatialVelocity",
+            # - meshcat
+            "JointSliders",
             # - parsing
             "Parser",
             # - parsers

--- a/multibody/meshcat/BUILD.bazel
+++ b/multibody/meshcat/BUILD.bazel
@@ -1,0 +1,45 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+    "drake_cc_package_library",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+drake_cc_package_library(
+    name = "meshcat",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":joint_sliders",
+    ],
+)
+
+drake_cc_library(
+    name = "joint_sliders",
+    srcs = ["joint_sliders.cc"],
+    hdrs = ["joint_sliders.h"],
+    deps = [
+        "//multibody/plant",
+    ],
+)
+
+drake_cc_googletest(
+    name = "joint_sliders_test",
+    data = [
+        ":test/universal_joint.sdf",
+        "//multibody:models",
+        "//multibody/benchmarks/acrobot:models",
+    ],
+    deps = [
+        ":joint_sliders",
+        "//common/test_utilities:expect_throws_message",
+        "//geometry/test_utilities:meshcat_environment",
+        "//multibody/parsing",
+    ],
+)
+
+add_lint_tests()

--- a/multibody/meshcat/joint_sliders.cc
+++ b/multibody/meshcat/joint_sliders.cc
@@ -1,0 +1,223 @@
+#include "drake/multibody/meshcat/joint_sliders.h"
+
+#include <unordered_set>
+#include <utility>
+
+#include <fmt/format.h>
+
+#include "drake/common/unused.h"
+
+namespace {
+// Boilerplate for std::visit.
+template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+}  // namespace
+
+namespace drake {
+namespace multibody {
+namespace meshcat {
+
+using Eigen::VectorXd;
+using systems::BasicVector;
+using systems::Context;
+
+namespace {
+
+// Returns the plant's default positions.
+template <typename T>
+VectorXd GetDefaultPositions(const MultibodyPlant<T>* plant) {
+  DRAKE_THROW_UNLESS(plant != nullptr);
+  const int nq = plant->num_positions();
+  VectorXd result(nq);
+  auto context = plant->CreateDefaultContext();
+  auto positions = plant->GetPositions(*context);
+  for (int i = 0; i < nq; ++i) {
+    result[i] = ExtractDoubleOrThrow(positions[i]);
+  }
+  return result;
+}
+
+// Returns true iff data has any duplicated values.
+bool HasAnyDuplicatedValues(const std::map<int, std::string>& data) {
+  std::unordered_set<std::string_view> values_seen;
+  for (const auto& iter : data) {
+    const std::string& one_value = iter.second;
+    const bool inserted = values_seen.insert(one_value).second;
+    if (!inserted) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Returns a mapping from an index within the plant's position vector to the
+// slider name that refers to it.  Note that the map is sparse; positions
+// without joints (e.g., a floating base) are not represented here.
+//
+// When use_model_instance_name is set, both the joint name and model name will
+// be used to to form the slider name; otherwise, only the joint name is used,
+// unless there are duplicate joint names in which case this is forced to be
+// "true".
+template <typename T>
+std::map<int, std::string> GetPositionNames(
+    const MultibodyPlant<T>* plant,
+    bool use_model_instance_name = false) {
+  DRAKE_THROW_UNLESS(plant != nullptr);
+
+  // Map all joints into the positions-to-name result.
+  std::map<int, std::string> result;
+  for (JointIndex i{0}; i < plant->num_joints(); ++i) {
+    const Joint<T>& joint = plant->get_joint(i);
+    for (int j = 0; j < joint.num_positions(); ++j) {
+      const int position_index = joint.position_start() + j;
+      std::string description;
+      if (joint.num_positions() > 1) {
+        description = fmt::format("{}_{}",
+            joint.name(), joint.position_suffix(j));
+      } else {
+        description = joint.name();
+      }
+      if (use_model_instance_name) {
+        description += fmt::format("/{}",
+            plant->GetModelInstanceName(joint.model_instance()));
+      }
+      const bool inserted = result.insert({
+          position_index, std::move(description)}).second;
+      DRAKE_DEMAND(inserted);
+    }
+  }
+
+  // Check for duplicate names.  If we had a name collision, then we'll need
+  // need to use the model_instance_name to make them unique.
+  if (HasAnyDuplicatedValues(result)) {
+    DRAKE_DEMAND(use_model_instance_name == false);
+    return GetPositionNames(plant, true);
+  }
+
+  return result;
+}
+
+// Returns a vector of size num_positions, based on the given value variant.
+// If a VectorXd is given, it's checked for size and then returned unchanged.
+// If a double is given, it's broadcast to size and returned.
+// If no value is given, then the default_value is broadcast instead.
+VectorXd Broadcast(
+    const char* diagnostic_name, double default_value, int num_positions,
+    std::variant<std::monostate, double, VectorXd> value) {
+  return std::visit(overloaded{
+    [num_positions, default_value](std::monostate) -> VectorXd {
+      return VectorXd::Constant(num_positions, default_value);
+    },
+    [num_positions](double arg) -> VectorXd {
+      return VectorXd::Constant(num_positions, arg);
+    },
+    [num_positions, diagnostic_name](VectorXd&& arg) -> VectorXd {
+      if (arg.size() != num_positions) {
+        throw std::logic_error(fmt::format(
+            "Expected {} of size {}, but got size {} instead",
+            diagnostic_name, num_positions, arg.size()));
+      }
+      return std::move(arg);
+    },
+  }, std::move(value));
+}
+
+}  // namespace
+
+template <typename T>
+JointSliders<T>::JointSliders(
+    std::shared_ptr<geometry::Meshcat> meshcat,
+    const MultibodyPlant<T>* plant,
+    std::optional<VectorXd> initial_value,
+    std::variant<std::monostate, double, VectorXd> lower_limit,
+    std::variant<std::monostate, double, VectorXd> upper_limit,
+    std::variant<std::monostate, double, VectorXd> step)
+    : meshcat_(std::move(meshcat)),
+      plant_(plant),
+      position_names_(GetPositionNames(plant)),
+      initial_value_(std::move(initial_value).value_or(
+          GetDefaultPositions(plant))),
+      is_registered_{true} {
+  DRAKE_THROW_UNLESS(meshcat_ != nullptr);
+  DRAKE_THROW_UNLESS(plant_ != nullptr);
+
+  const int nq = plant->num_positions();
+  if (initial_value_.size() != nq) {
+    throw std::logic_error(fmt::format(
+        "Expected initial_value of size {}, but got size {} instead",
+        nq, initial_value_.size()));
+  }
+
+  // Default any missing arguments; check (or widen) them to be of size == nq.
+  const VectorXd lower_broadcast = Broadcast(
+      "lower_limit", -10.0,  nq, std::move(lower_limit));
+  const VectorXd upper_broadcast = Broadcast(
+      "upper_limit",  10.0,  nq, std::move(upper_limit));
+  const VectorXd step_broadcast = Broadcast(
+      "step",          0.01, nq, std::move(step));
+
+  // Add one slider per joint position.
+  const VectorXd lower_plant = plant_->GetPositionLowerLimits();
+  const VectorXd upper_plant = plant_->GetPositionUpperLimits();
+  for (const auto& [position_index, slider_name] : position_names_) {
+    DRAKE_DEMAND(position_index >= 0);
+    DRAKE_DEMAND(position_index < nq);
+    const double one_min = std::max(
+        lower_broadcast[position_index],
+        lower_plant[position_index]);
+    const double one_max = std::min(
+        upper_broadcast[position_index],
+        upper_plant[position_index]);
+    const double one_step = step_broadcast[position_index];
+    const double one_value = initial_value_[position_index];
+    meshcat_->AddSlider(slider_name, one_min, one_max, one_step, one_value);
+  }
+
+  // Declare the output port.
+  auto& output = this->DeclareVectorOutputPort(
+      "positions", nq, &JointSliders<T>::CalcOutput);
+
+  // The port is always marked out-of-date, so that the slider values will be
+  // fetched every time the output port is needed in a computation.
+  output.disable_caching_by_default();
+}
+
+template <typename T>
+void JointSliders<T>::Delete() {
+  const auto was_registered = is_registered_.exchange(false);
+  if (was_registered) {
+    for (const auto& [position_index, slider_name] : position_names_) {
+      unused(position_index);
+      meshcat_->DeleteSlider(slider_name);
+    }
+  }
+}
+
+template <typename T>
+JointSliders<T>::~JointSliders() {
+  Delete();
+}
+
+template <typename T>
+void JointSliders<T>::CalcOutput(
+    const Context<T>&, BasicVector<T>* output) const {
+  const int nq = plant_->num_positions();
+  DRAKE_DEMAND(output->size() == nq);
+  for (int i = 0; i < nq; ++i) {
+    (*output)[i] = initial_value_[i];
+  }
+  if (is_registered_) {
+    for (const auto& [position_index, slider_name] : position_names_) {
+      // TODO(jwnimmer-tri) If CalcOutput is in flight concurrently with a
+      // call to Delete, we might race and ask for a deleted slider value.
+      (*output)[position_index] = meshcat_->GetSliderValue(slider_name);
+    }
+  }
+}
+
+}  // namespace meshcat
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::meshcat::JointSliders)

--- a/multibody/meshcat/joint_sliders.h
+++ b/multibody/meshcat/joint_sliders.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <atomic>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+
+#include "drake/geometry/meshcat.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace multibody {
+namespace meshcat {
+
+/** %JointSliders adds slider bars to the Meshcat control panel for the joints
+of a MultibodyPlant. These might be useful for interactive or teleoperation
+demos. The sliders' current values are available on the `positions` output port
+of this system.
+
+@system
+name: JointSliders
+output_ports:
+- positions
+@endsystem
+
+The output port is of size `plant.num_positions()`, and the order of its
+elements matches `plant.GetPositions()`.
+
+At the moment, any positions that are not associated with joints (e.g.,
+floating-base "mobilizers") are held fixed at a nominal value.  In the future,
+this class might add in sliders for a floating base as well.
+
+Beware that the output port of this system always provides the sliders' current
+values, even if evaluated by multiple different downstream input ports during a
+single computation.  If you need to have a synchronized view of the slider data,
+place a systems::ZeroOrderHold system between the sliders and downstream
+calculations.
+
+@tparam_nonsymbolic_scalar
+@ingroup visualization */
+template <typename T>
+class JointSliders final : public systems::LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(JointSliders)
+
+  /** Creates a meshcat slider for each joint in the given plant.
+
+  @param meshcat The Meshcat instance where the sliders will be added.
+
+  @param plant The MultibodyPlant to create sliders for.
+  The plant pointer is aliased for the lifetime of this %JointSliders object.
+
+  @param initial_value (Optional) If provided, the sliders' initial values
+  will be as given; otherwise, the plant's default values will be used.
+
+  @param lower_limit (Optional) The lower limit of the slider will be the
+  maximum value of this number and any limit specified in the Joint.
+  May be a single value or else a vector of length plant.num_positions().
+  If no value is provided, a sensible default will be used.
+
+  @param upper_limit (Optional) The upper limit of the slider will be the
+  minimum value of this number and any limit specified in the Joint.
+  May be a single value or else a vector of length plant.num_positions().
+  If no value is provided, a sensible default will be used.
+
+  @param step (Optional) The step argument of the slider, which is the
+  smallest increment by which the slider can change values (and therefore
+  update our output port's value).
+  May be a single value or else a vector of length plant.num_positions().
+  If no value is provided, a sensible default will be used.
+  */
+  JointSliders(
+      std::shared_ptr<geometry::Meshcat> meshcat,
+      const MultibodyPlant<T>* plant,
+      std::optional<Eigen::VectorXd> initial_value = {},
+      std::variant<std::monostate, double, Eigen::VectorXd> lower_limit = {},
+      std::variant<std::monostate, double, Eigen::VectorXd> upper_limit = {},
+      std::variant<std::monostate, double, Eigen::VectorXd> step = {});
+
+  /** Removes our sliders from the associated meshcat instance.
+
+  From this point on, our output port produces the initial_value from the
+  constructor, not any slider values.
+
+  @warning It is not safe to call this when a CalcOutput might be happening on
+  this instance concurrently on another thread. */
+  void Delete();
+
+  /** Performs a Delete(), if one has not already been done. */
+  ~JointSliders() final;
+
+ private:
+  void CalcOutput(const systems::Context<T>&, systems::BasicVector<T>*) const;
+
+  std::shared_ptr<geometry::Meshcat> meshcat_;
+  const MultibodyPlant<T>* const plant_;
+  const std::map<int, std::string> position_names_;
+  const Eigen::VectorXd initial_value_;
+  std::atomic<bool> is_registered_;
+};
+
+}  // namespace meshcat
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::meshcat::JointSliders)

--- a/multibody/meshcat/test/joint_sliders_test.cc
+++ b/multibody/meshcat/test/joint_sliders_test.cc
@@ -1,0 +1,267 @@
+#include "drake/multibody/meshcat/joint_sliders.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/test_utilities/meshcat_environment.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+namespace drake {
+namespace multibody {
+namespace meshcat {
+namespace {
+
+using Eigen::Vector2d;
+using geometry::Meshcat;
+
+class JointSlidersTest : public ::testing::Test {
+ public:
+  JointSlidersTest()
+      : meshcat_{geometry::GetTestEnvironmentMeshcat()},
+        builder_{},
+        plant_{static_cast<MultibodyPlant<double>&>(
+            AddMultibodyPlantSceneGraph(&builder_, 0.0))} {}
+
+  void Add(const std::string& resource_path,
+           const std::string& model_name = {}) {
+    Parser parser(&plant_);
+    parser.AddModelFromFile(FindResourceOrThrow(resource_path), model_name);
+  }
+
+  void AddAcrobot() {
+    Add("drake/multibody/benchmarks/acrobot/acrobot.urdf");
+    plant_.Finalize();
+  }
+
+  static constexpr char kAcrobotJoint1[] = "ShoulderJoint";
+  static constexpr char kAcrobotJoint2[] = "ElbowJoint";
+
+ protected:
+  std::shared_ptr<Meshcat> meshcat_;
+  systems::DiagramBuilder<double> builder_;
+  MultibodyPlant<double>& plant_;
+};
+
+// Test the narrowest constructor, where all optionals are null.
+TEST_F(JointSlidersTest, NarrowConstructor) {
+  // Parse the acrobot model.
+  AddAcrobot();
+  auto& joint_1 = plant_.GetMutableJointByName(kAcrobotJoint1);
+  auto& joint_2 = plant_.GetMutableJointByName(kAcrobotJoint2);
+
+  // Set default positions.
+  const double default_angle_1 = 0.1;
+  const double default_angle_2 = 0.2;
+  joint_1.set_default_positions(Vector1d(default_angle_1));
+  joint_2.set_default_positions(Vector1d(default_angle_2));
+
+  // Set joint limits.
+  const double min_angle_1 = -1.0;
+  const double max_angle_1 = 1.0;
+  const double min_angle_2 = -200.0;
+  const double max_angle_2 = 200.0;
+  joint_1.set_position_limits(Vector1d(min_angle_1), Vector1d(max_angle_1));
+  joint_2.set_position_limits(Vector1d(min_angle_2), Vector1d(max_angle_2));
+
+  // Add the sliders.
+  const JointSliders<double> dut(meshcat_, &plant_);
+  auto context = dut.CreateDefaultContext();
+
+  // Sliders start at their default context value.
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), default_angle_1);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint2), default_angle_2);
+  EXPECT_EQ(dut.get_output_port().Eval(*context),
+            Vector2d(default_angle_1, default_angle_2));
+
+  // Slider limits obey the joint positions limits.
+  meshcat_->SetSliderValue(kAcrobotJoint1, -9999);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), min_angle_1);
+  meshcat_->SetSliderValue(kAcrobotJoint1, 9999);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), max_angle_1);
+  EXPECT_EQ(dut.get_output_port().Eval(*context),
+            Vector2d(max_angle_1, default_angle_2));
+
+  // When the joint position limits are huge, the slider uses a narrower range.
+  meshcat_->SetSliderValue(kAcrobotJoint1, -9999);
+  EXPECT_GT(meshcat_->GetSliderValue(kAcrobotJoint2), min_angle_2);
+  meshcat_->SetSliderValue(kAcrobotJoint1, 9999);
+  EXPECT_LT(meshcat_->GetSliderValue(kAcrobotJoint2), max_angle_2);
+}
+
+// Test the widest constructor, where all optionals are set to vectors.
+TEST_F(JointSlidersTest, WideConstructorWithVectors) {
+  // Parse the acrobot model.
+  AddAcrobot();
+
+  const double default_angle_1 = 0.1;
+  const double default_angle_2 = 0.2;
+  const double min_angle_1 = -1.0;
+  const double max_angle_1 = 1.0;
+  const double min_angle_2 = -200.0;
+  const double max_angle_2 = 200.0;
+  const double step_1 = 0.1;   // Round to one decimal.
+  const double step_2 = 0.01;  // Round to two decimals.
+
+  // Add some very specifically configured sliders.
+  const Eigen::Vector2d initial_value(default_angle_1, default_angle_2);
+  const Eigen::Vector2d lower_limit(min_angle_1, min_angle_2);
+  const Eigen::Vector2d upper_limit(max_angle_1, max_angle_2);
+  const Eigen::Vector2d step(step_1, step_2);
+  const JointSliders dut(
+      meshcat_, &plant_, initial_value, lower_limit, upper_limit, step);
+  auto context = dut.CreateDefaultContext();
+
+  // Sliders start at their initial value.
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), default_angle_1);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint2), default_angle_2);
+  EXPECT_EQ(dut.get_output_port().Eval(*context),
+            Vector2d(default_angle_1, default_angle_2));
+
+  // Slider obey their configured limits.
+  meshcat_->SetSliderValue(kAcrobotJoint1, -9999);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), min_angle_1);
+  meshcat_->SetSliderValue(kAcrobotJoint1, 9999);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), max_angle_1);
+  EXPECT_EQ(dut.get_output_port().Eval(*context),
+            Vector2d(max_angle_1, default_angle_2));
+
+  // When the limits are huge, the slider uses a narrower range.
+  meshcat_->SetSliderValue(kAcrobotJoint1, -9999);
+  EXPECT_GT(meshcat_->GetSliderValue(kAcrobotJoint2), min_angle_2);
+  meshcat_->SetSliderValue(kAcrobotJoint1, 9999);
+  EXPECT_LT(meshcat_->GetSliderValue(kAcrobotJoint2), max_angle_2);
+
+  // Each slider has a different roundoff step.
+  meshcat_->SetSliderValue(kAcrobotJoint1, 0.1111111111);
+  meshcat_->SetSliderValue(kAcrobotJoint2, 0.2222222222);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), 0.1);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint2), 0.22);
+}
+
+// Test the widest constructor, with the variants set to single scalars.
+TEST_F(JointSlidersTest, WideConstructorWithScalars) {
+  // Parse the acrobot model.
+  AddAcrobot();
+
+  // Add some very specifically configured sliders.
+  const double min_angle = -1.0;
+  const double max_angle = 1.0;
+  const double step = 0.1;
+  const JointSliders dut(
+      meshcat_, &plant_, {}, min_angle, max_angle, step);
+  auto context = dut.CreateDefaultContext();
+
+  // Slider obey their configured limits.
+  meshcat_->SetSliderValue(kAcrobotJoint1, -9999);
+  meshcat_->SetSliderValue(kAcrobotJoint2, -9999);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), min_angle);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint2), min_angle);
+  meshcat_->SetSliderValue(kAcrobotJoint1, 9999);
+  meshcat_->SetSliderValue(kAcrobotJoint2, 9999);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), max_angle);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint2), max_angle);
+  EXPECT_EQ(dut.get_output_port().Eval(*context),
+            Vector2d::Constant(max_angle));
+
+  // Each slider uses the given step.
+  meshcat_->SetSliderValue(kAcrobotJoint1, 0.1111111111);
+  meshcat_->SetSliderValue(kAcrobotJoint2, 0.2222222222);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), 0.1);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint2), 0.2);
+}
+
+// Test that the constructor diagnoses num_positions mismatches.
+TEST_F(JointSlidersTest, WrongNumPositions) {
+  AddAcrobot();
+  DRAKE_EXPECT_THROWS_MESSAGE(JointSliders(
+      meshcat_, &plant_, Vector1d::Zero(), {}, {}, {}),
+      "Expected initial_value of size 2, but got size 1 instead");
+  DRAKE_EXPECT_THROWS_MESSAGE(JointSliders(
+      meshcat_, &plant_, {}, Vector1d::Zero(), {}, {}),
+      "Expected lower_limit of size 2, but got size 1 instead");
+  DRAKE_EXPECT_THROWS_MESSAGE(JointSliders(
+      meshcat_, &plant_, {}, {}, Vector1d::Zero(), {}),
+      "Expected upper_limit of size 2, but got size 1 instead");
+  DRAKE_EXPECT_THROWS_MESSAGE(JointSliders(
+      meshcat_, &plant_, {}, {}, {}, Vector1d::Zero()),
+      "Expected step of size 2, but got size 1 instead");
+}
+
+// Test robots with overlapping joint names, in which case the model name must
+// be used to disambiguate them.
+TEST_F(JointSlidersTest, DuplicatedJointNames) {
+  Add("drake/multibody/benchmarks/acrobot/acrobot.urdf", "alpha");
+  Add("drake/multibody/benchmarks/acrobot/acrobot.urdf", "bravo");
+  plant_.Finalize();
+
+  // Add the sliders.
+  const JointSliders<double> dut(meshcat_, &plant_);
+
+  // Confirm that the names are unique.
+  const std::string alpha = "/alpha";
+  const std::string bravo = "/bravo";
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1 + alpha), 0.0);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint2 + alpha), 0.0);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1 + bravo), 0.0);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint2 + bravo), 0.0);
+}
+
+// Test a multi-dof joint.
+TEST_F(JointSlidersTest, MultiDofJoint) {
+  Add("drake/multibody/meshcat/test/universal_joint.sdf");
+  plant_.Finalize();
+  const JointSliders<double> dut(meshcat_, &plant_);
+
+  // Confirm the names hasve the per-dof suffix.
+  EXPECT_EQ(meshcat_->GetSliderValue("charlie_qx"), 0.0);
+  EXPECT_EQ(meshcat_->GetSliderValue("charlie_qy"), 0.0);
+}
+
+// Tests that a free body gets no sliders. In the future we might add support
+// for this, which is fine (and thus we'd change this test), but at least for
+// now we should confirm that nothing crashes in this case.
+TEST_F(JointSlidersTest, FreeBody) {
+  Add("drake/multibody/models/box.urdf");
+  plant_.Finalize();
+  const JointSliders<double> dut(meshcat_, &plant_);
+  EXPECT_EQ(dut.get_output_port().size(), 7);
+}
+
+// Tests that the Delete function removes the sliders.
+TEST_F(JointSlidersTest, DeleteFunction) {
+  // Add the sliders.
+  AddAcrobot();
+  auto dut = std::make_unique<JointSliders<double>>(meshcat_, &plant_);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), 0.0);
+
+  // Remove them; confirm that they are gone.
+  dut->Delete();
+  EXPECT_THROW(meshcat_->GetSliderValue(kAcrobotJoint1), std::exception);
+
+  // A second call is harmless.
+  dut->Delete();
+
+  // The destructor does not crash.
+  EXPECT_NO_THROW(dut.reset());
+}
+
+// Tests that the destructor removes the sliders.
+TEST_F(JointSlidersTest, Destructor) {
+  // Add the sliders.
+  AddAcrobot();
+  auto dut = std::make_unique<JointSliders<double>>(meshcat_, &plant_);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), 0.0);
+
+  // Delete the entire object; confirm that the sliders are gone.
+  EXPECT_NO_THROW(dut.reset());
+  EXPECT_THROW(meshcat_->GetSliderValue(kAcrobotJoint1), std::exception);
+}
+
+
+}  // namespace
+}  // namespace meshcat
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/meshcat/test/universal_joint.sdf
+++ b/multibody/meshcat/test/universal_joint.sdf
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<sdf version="1.7">
+  <model name="alice">
+    <link name="bob">
+      <inertial>
+        <mass>1</mass>
+        <inertia>
+          <ixx>0.1</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.1</iyy>
+          <iyz>0</iyz>
+          <izz>0.1</izz>
+        </inertia>
+      </inertial>
+    </link>
+    <joint name="charlie" type="universal">
+      <child>bob</child>
+      <parent>world</parent>
+      <axis>
+        <dynamics>
+          <damping>0.1</damping>
+        </dynamics>
+        <xyz expressed_in="__model__">0 0 1</xyz>
+      </axis>
+    </joint>
+  </model>
+</sdf>

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -63,6 +63,7 @@ LIBDRAKE_COMPONENTS = [
     "//multibody/hydroelastics",
     "//multibody/inverse_kinematics",
     "//multibody/math",
+    "//multibody/meshcat",
     "//multibody/optimization",
     "//multibody/parsing",
     "//multibody/plant",


### PR DESCRIPTION
Based on [meshcat_cpp_utils.py](https://github.com/RussTedrake/manipulation/blob/008cec6343dd39063705287e6664a3fee71a43b8/manipulation/meshcat_cpp_utils.py#L236) from Russ.

Part of #16385.

This PR only adds the System itself (and the pydrake bindings).  It does not yet offer the `Run` loop.

Requires:
- [x] #16407

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16400)
<!-- Reviewable:end -->
