### PR TITLE
[tools] Fix "generated by these conflicting actions" in Bazel 5.0

### DIFF
--- a/tools/cc_toolchain/bazel.rc
+++ b/tools/cc_toolchain/bazel.rc
@@ -19,9 +19,11 @@ build --define=DRAKE_WERROR=ON
 
 ### Debug symbols on OS X. ###
 # See https://github.com/bazelbuild/bazel/issues/2537
+# and https://github.com/bazelbuild/bazel/issues/14294
 build:apple_debug --spawn_strategy=standalone
 build:apple_debug --genrule_strategy=standalone
 build:apple_debug --compilation_mode=dbg
+build:apple_debug --notrim_test_configuration
 
 # We don't actually use APPLE_DEBUG in code. It's just here to invalidate any
 # sandboxed .o files that might be in cache if a developer tried to build

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -112,6 +112,13 @@ def _dsym_command(name):
         ),
     })
 
+def _dsym_srcs(name):
+    """Returns the input for making a .dSYM on macOS, or a no-op on Linux."""
+    return select({
+        "//tools/cc_toolchain:apple_debug": [":" + name],
+        "//conditions:default": [],
+    })
+
 def _check_library_deps_blacklist(name, deps):
     """Report an error if a library should not use something from deps."""
     if not deps:
@@ -545,7 +552,7 @@ def drake_cc_binary(
     tags = kwargs.pop("tags", [])
     native.genrule(
         name = name + "_dsym",
-        srcs = [":" + name],
+        srcs = _dsym_srcs(name),
         outs = [name + ".dSYM"],
         output_to_bindir = 1,
         testonly = testonly,
@@ -619,7 +626,7 @@ def drake_cc_test(
     # Also generate the OS X debug symbol file for this test.
     native.genrule(
         name = name + "_dsym",
-        srcs = [":" + name],
+        srcs = _dsym_srcs(name),
         outs = [name + ".dSYM"],
         output_to_bindir = 1,
         testonly = kwargs["testonly"],


### PR DESCRIPTION
When something depends on a unit test (in our case, the macOS dSYM generation), then Bazel as of 5.0 dies a horrible death.

Work around that by adding the dependency only in cases where the user has opted-in to debugging on macOS, and in that case also turn off the problematic trim_test_configuration feature.

Relates to https://github.com/bazelbuild/bazel/issues/14294.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16405)
<!-- Reviewable:end -->
