### PR TITLE
[pydrake] Factor out the std::monostate support for reuse

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -131,6 +131,7 @@ drake_pybind_library(
         "//bindings/pydrake/common:default_scalars_pybind",
         "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:identifier_pybind",
+        "//bindings/pydrake/common:monostate_pybind",
         "//bindings/pydrake/common:type_pack",
         "//bindings/pydrake/common:type_safe_index_pybind",
         "//bindings/pydrake/common:value_pybind",

--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -77,6 +77,16 @@ drake_py_library(
 )
 
 drake_cc_library(
+    name = "monostate_pybind",
+    hdrs = ["monostate_pybind.h"],
+    declare_installed_headers = 0,
+    visibility = ["//visibility:public"],
+    deps = [
+        "@pybind11",
+    ],
+)
+
+drake_cc_library(
     name = "type_pack",
     hdrs = ["type_pack.h"],
     declare_installed_headers = 0,

--- a/bindings/pydrake/common/monostate_pybind.h
+++ b/bindings/pydrake/common/monostate_pybind.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <variant>
+
+#include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
+
+// TODO(SeanCurtis-TRI) When pybind issue 3019 gets resolved, we won't need to
+//  define this locally anymore. In fact, it will probably cause link errors.
+namespace pybind11 {
+namespace detail {
+
+/* This class teaches pybind11 that C++'s `std::monostate` and Python's `None`
+are the same thing. You must include it when binding any API that uses a
+`std::variant<std::monostate, ...>`. */
+template <>
+struct type_caster<std::monostate> {
+ public:
+  PYBIND11_TYPE_CASTER(std::monostate, _("None"));
+
+  bool load(handle src, bool) { return src.ptr() == Py_None; }
+
+  static handle cast(
+      std::monostate, return_value_policy /* policy */, handle /* parent */) {
+    Py_RETURN_NONE;
+  }
+};
+
+}  // namespace detail
+}  // namespace pybind11

--- a/bindings/pydrake/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry_py_scene_graph.cc
@@ -5,30 +5,12 @@
 
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
+#include "drake/bindings/pydrake/common/monostate_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/scene_graph.h"
-
-// TODO(SeanCurtis-TRI) When pybind issue 3019 gets resolved, we won't need to
-//  define this locally anymore. In fact, it will probably cause link errors.
-namespace pybind11 {
-namespace detail {
-template <>
-struct type_caster<std::monostate> {
- public:
-  PYBIND11_TYPE_CASTER(std::monostate, _("None"));
-
-  bool load(handle src, bool) { return src.ptr() == Py_None; }
-
-  static handle cast(
-      std::monostate, return_value_policy /* policy */, handle /* parent */) {
-    Py_RETURN_NONE;
-  }
-};
-}  // namespace detail
-}  // namespace pybind11
 
 namespace drake {
 namespace pydrake {


### PR DESCRIPTION
This is a prerequisite of #16400.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16407)
<!-- Reviewable:end -->
