### PR TITLE
Rename dummy library to fix Bazel 5 error

### DIFF
--- a/tools/install/dummy/BUILD.bazel
+++ b/tools/install/dummy/BUILD.bazel
@@ -17,7 +17,7 @@ load(
 package(default_visibility = ["//tools/install:__subpackages__"])
 
 drake_cc_library(
-    name = "dummy",
+    name = "dummy_private",
     testonly = 1,
     srcs = ["dummy.cc"],
     hdrs = ["dummy.h"],
@@ -28,13 +28,13 @@ drake_cc_binary(
     testonly = 1,
     linkshared = 1,
     linkstatic = 1,
-    deps = [":dummy"],
+    deps = [":dummy_private"],
 )
 
 drake_transitive_installed_hdrs_filegroup(
     name = "libdummy_headers",
     testonly = 1,
-    deps = [":dummy"],
+    deps = [":dummy_private"],
 )
 
 py_library(


### PR DESCRIPTION
Fixes failure on Mac builds after updating to Bazel 5. 

```
[3:39:05 AM]  ERROR: file 'tools/install/dummy/libdummy.so' is generated by these conflicting actions:
[3:39:05 AM]  Label: //tools/install/dummy:libdummy.so, //tools/install/dummy:dummy
[3:39:05 AM]  RuleClass: cc_binary rule, cc_library rule
[3:39:05 AM]  Configuration: 21a5de7e367ccd7bd7015ef91735ce3d9e0fc525245b61fe7cb8b7c1d14be65c
[3:39:05 AM]  Mnemonic: CppLink, Fail
[3:39:05 AM]  Action key: ddc895ae1e57540d0f5864d077667683cbecc2a45e582d4ea839f7be56b9698d, d2b21694bd9c7986a236b5ae39648b4f403e57cdcf2d085a4136fea6ce1601c4
[3:39:05 AM]  Progress message: Linking tools/install/dummy/libdummy.so, Reporting failed target //tools/install/dummy:dummy located at /Users/bigsur/workspace/mac-big-sur-unprovisioned-clang-bazel-nightly-release/src/tools/install/dummy/BUILD.bazel:19:17
[3:39:05 AM]  PrimaryInput: File:[[<execution_root>]bazel-out/darwin-opt/bin]tools/install/dummy/libdummy.a, (null)
[3:39:05 AM]  PrimaryOutput: File:[[<execution_root>]bazel-out/darwin-opt/bin]tools/install/dummy/libdummy.so
[3:39:05 AM]  WARNING: errors encountered while analyzing target '//tools/install/dummy:libdummy.so': it will not be built
```


e.g. https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-big-sur-unprovisioned-clang-bazel-nightly-release/347/consoleFull

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16418)
<!-- Reviewable:end -->
