### PR TITLE
[systems/primitives] Add Swish / Sigmoid Linear Unit activation type

### DIFF
--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -60,7 +60,9 @@ PYBIND11_MODULE(primitives, m) {
       .value("kReLU", PerceptronActivationType::kReLU,
           doc.PerceptronActivationType.kReLU.doc)
       .value("kTanh", PerceptronActivationType::kTanh,
-          doc.PerceptronActivationType.kTanh.doc);
+          doc.PerceptronActivationType.kTanh.doc)
+      .value("kSiLU", PerceptronActivationType::kSiLU,
+          doc.PerceptronActivationType.kSiLU.doc);
 
   // N.B. Capturing `&doc` should not be required; workaround per #9600.
   auto bind_common_scalar_types = [&m, &doc](auto dummy) {

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -556,15 +556,18 @@ class TestGeneral(unittest.TestCase):
                                             dloss_dparams=dloss_dparams)
         self.assertTrue(dloss_dparams.any())  # No longer all zero.
 
-        mlp2 = MultilayerPerceptron(layers=[1, 2, 3],
+        mlp2 = MultilayerPerceptron(layers=[1, 2, 3, 1],
                                     activation_types=[
                                         PerceptronActivationType.kReLU,
-                                        PerceptronActivationType.kTanh
+                                        PerceptronActivationType.kTanh,
+                                        PerceptronActivationType.kSiLU,
                                     ])
         self.assertEqual(mlp2.activation_type(0),
                          PerceptronActivationType.kReLU)
         self.assertEqual(mlp2.activation_type(1),
                          PerceptronActivationType.kTanh)
+        self.assertEqual(mlp2.activation_type(2),
+                         PerceptronActivationType.kSiLU)
 
     def test_random_source(self):
         source = RandomSource(distribution=RandomDistribution.kUniform,

--- a/systems/primitives/multilayer_perceptron.h
+++ b/systems/primitives/multilayer_perceptron.h
@@ -13,6 +13,7 @@ enum PerceptronActivationType {
   kIdentity,
   kReLU,
   kTanh,
+  kSiLU,  ///<  x/(1+e⁻ˣ), the Sigmoid Linear Unit, also known as Swish.
 };
 
 /** The MultilayerPerceptron (MLP) is one of the most common forms of neural

--- a/systems/primitives/test/multilayer_perceptron_test.cc
+++ b/systems/primitives/test/multilayer_perceptron_test.cc
@@ -172,7 +172,7 @@ void BackpropTest(PerceptronActivationType type) {
 }
 
 GTEST_TEST(MultilayerPerceptionTest, Backprop) {
-  for (const auto& type : {kIdentity, kReLU, kTanh}) {
+  for (const auto& type : {kIdentity, kReLU, kTanh, kSiLU}) {
     BackpropTest(type);
   }
 }


### PR DESCRIPTION
The derivation of the analytical gradient can be found in
https://arxiv.org/pdf/1710.05941v1.pdf.