### PR TITLE
AddFooConstraint support matrix input.

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -959,9 +959,9 @@ void BindMathematicalProgram(py::module m) {
           doc.MathematicalProgram.AddLinearConstraint.doc_3args_e_lb_ub)
       .def("AddLinearConstraint",
           static_cast<Binding<LinearConstraint> (MathematicalProgram::*)(
-              const Eigen::Ref<const VectorX<symbolic::Expression>>&,
-              const Eigen::Ref<const Eigen::VectorXd>&,
-              const Eigen::Ref<const Eigen::VectorXd>&)>(
+              const Eigen::Ref<const MatrixX<symbolic::Expression>>&,
+              const Eigen::Ref<const Eigen::MatrixXd>&,
+              const Eigen::Ref<const Eigen::MatrixXd>&)>(
               &MathematicalProgram::AddLinearConstraint),
           py::arg("v"), py::arg("lb"), py::arg("ub"),
           doc.MathematicalProgram.AddLinearConstraint.doc_3args_v_lb_ub)
@@ -972,7 +972,7 @@ void BindMathematicalProgram(py::module m) {
       .def(
           "AddLinearConstraint",
           [](MathematicalProgram* self,
-              const Eigen::Ref<const VectorX<Formula>>& formulas) {
+              const Eigen::Ref<const MatrixX<Formula>>& formulas) {
             return self->AddLinearConstraint(formulas.array());
           },
           py::arg("formulas"),
@@ -1011,9 +1011,9 @@ void BindMathematicalProgram(py::module m) {
               .doc_2args_constEigenMatrixBase_constEigenMatrixBase)
       .def("AddBoundingBoxConstraint",
           static_cast<Binding<BoundingBoxConstraint> (MathematicalProgram::*)(
-              const Eigen::Ref<const Eigen::VectorXd>&,
-              const Eigen::Ref<const Eigen::VectorXd>&,
-              const Eigen::Ref<const VectorXDecisionVariable>&)>(
+              const Eigen::Ref<const Eigen::MatrixXd>&,
+              const Eigen::Ref<const Eigen::MatrixXd>&,
+              const Eigen::Ref<const MatrixXDecisionVariable>&)>(
               &MathematicalProgram::AddBoundingBoxConstraint),
           doc.MathematicalProgram.AddBoundingBoxConstraint.doc_3args_lb_ub_vars)
       .def("AddBoundingBoxConstraint",

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -411,8 +411,10 @@ class MathematicalProgram {
    * @pre Each entry in `decision_variables` should not be a dummy variable.
    * @throws std::exception if the preconditions are not satisfied.
    */
+  // TODO(hongkai.dai): also check if decision_variables contain duplicate
+  // entries.
   void AddDecisionVariables(
-      const Eigen::Ref<const VectorXDecisionVariable>& decision_variables);
+      const Eigen::Ref<const MatrixXDecisionVariable>& decision_variables);
 
   /**
    * Returns a free polynomial in a monomial basis over @p indeterminates of a
@@ -861,8 +863,9 @@ class MathematicalProgram {
    * @pre Each entry in new_indeterminates should not be dummy.
    * @pre Each entry in new_indeterminates should be of CONTINUOUS type.
    */
+  // TODO(hongkai.dai): check if new_indeterminates contain duplicate entries.
   void AddIndeterminates(
-      const Eigen::Ref<const VectorXIndeterminate>& new_indeterminates);
+      const Eigen::Ref<const MatrixXIndeterminate>& new_indeterminates);
 
   /**
    * Adds a callback method to visualize intermediate results of the
@@ -1378,9 +1381,9 @@ class MathematicalProgram {
    * @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
    */
   Binding<Constraint> AddConstraint(
-      const Eigen::Ref<const VectorX<symbolic::Expression>>& v,
-      const Eigen::Ref<const Eigen::VectorXd>& lb,
-      const Eigen::Ref<const Eigen::VectorXd>& ub);
+      const Eigen::Ref<const MatrixX<symbolic::Expression>>& v,
+      const Eigen::Ref<const Eigen::MatrixXd>& lb,
+      const Eigen::Ref<const Eigen::MatrixXd>& ub);
 
   /**
    * Add a constraint represented by a symbolic formula to the program. The
@@ -1584,9 +1587,9 @@ class MathematicalProgram {
    * ub</tt> includes trivial/unsatisfiable constraints.
    */
   Binding<LinearConstraint> AddLinearConstraint(
-      const Eigen::Ref<const VectorX<symbolic::Expression>>& v,
-      const Eigen::Ref<const Eigen::VectorXd>& lb,
-      const Eigen::Ref<const Eigen::VectorXd>& ub);
+      const Eigen::Ref<const MatrixX<symbolic::Expression>>& v,
+      const Eigen::Ref<const Eigen::MatrixXd>& lb,
+      const Eigen::Ref<const Eigen::MatrixXd>& ub);
 
   /**
    * Add a linear constraint represented by a symbolic formula to the
@@ -1889,13 +1892,13 @@ class MathematicalProgram {
    * decision variables.
    * @param lb The lower bound.
    * @param ub The upper bound.
-   * @param vars Will imposes constraint lb(i) <= vars(i) <= ub(i).
+   * @param vars Will imposes constraint lb(i, j) <= vars(i, j) <= ub(i, j).
    * @return The newly constructed BoundingBoxConstraint.
    */
   Binding<BoundingBoxConstraint> AddBoundingBoxConstraint(
-      const Eigen::Ref<const Eigen::VectorXd>& lb,
-      const Eigen::Ref<const Eigen::VectorXd>& ub,
-      const Eigen::Ref<const VectorXDecisionVariable>& vars);
+      const Eigen::Ref<const Eigen::MatrixXd>& lb,
+      const Eigen::Ref<const Eigen::MatrixXd>& ub,
+      const Eigen::Ref<const MatrixXDecisionVariable>& vars);
 
   /**
    * Adds bounds for a single variable.
@@ -2404,9 +2407,10 @@ class MathematicalProgram {
    * of the decision variables (defined in the vars parameter).
    */
   Binding<Constraint> AddPolynomialConstraint(
-      const VectorXPoly& polynomials,
+      const Eigen::Ref<const MatrixX<Polynomiald>>& polynomials,
       const std::vector<Polynomiald::VarType>& poly_vars,
-      const Eigen::VectorXd& lb, const Eigen::VectorXd& ub,
+      const Eigen::Ref<const Eigen::MatrixXd>& lb,
+      const Eigen::Ref<const Eigen::MatrixXd>& ub,
       const VariableRefList& vars) {
     return AddPolynomialConstraint(polynomials, poly_vars, lb, ub,
                                    ConcatenateVariableRefList(vars));
@@ -2417,9 +2421,10 @@ class MathematicalProgram {
    * of the decision variables (defined in the vars parameter).
    */
   Binding<Constraint> AddPolynomialConstraint(
-      const VectorXPoly& polynomials,
+      const Eigen::Ref<const MatrixX<Polynomiald>>& polynomials,
       const std::vector<Polynomiald::VarType>& poly_vars,
-      const Eigen::VectorXd& lb, const Eigen::VectorXd& ub,
+      const Eigen::Ref<const Eigen::MatrixXd>& lb,
+      const Eigen::Ref<const Eigen::MatrixXd>& ub,
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**


### PR DESCRIPTION
Previously when we pass in matrix input, it (silently) only impose
constraint on the first column of the matrix.

Resolves #16421

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16424)
<!-- Reviewable:end -->
