### PR TITLE
[meshcat] Add JointSliders::Run

### DIFF
--- a/bindings/pydrake/multibody/meshcat_py.cc
+++ b/bindings/pydrake/multibody/meshcat_py.cc
@@ -42,7 +42,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 3>(),  // BR
             cls_doc.ctor.doc)
-        .def("Delete", &Class::Delete, cls_doc.Delete.doc);
+        .def("Delete", &Class::Delete, cls_doc.Delete.doc)
+        .def("Run", &Class::Run, py::arg("diagram"),
+            py::arg("timeout") = py::none(), cls_doc.Run.doc);
   }
 }
 }  // namespace

--- a/bindings/pydrake/multibody/test/meshcat_test.py
+++ b/bindings/pydrake/multibody/test/meshcat_test.py
@@ -75,3 +75,8 @@ class TestMeshcat(unittest.TestCase):
 
         # The constructor has default values, in any case.
         dut = JointSliders(meshcat, plant)
+
+        # The Run function doesn't crash.
+        builder.AddSystem(dut)
+        diagram = builder.Build()
+        dut.Run(diagram=diagram, timeout=1.0)

--- a/multibody/meshcat/BUILD.bazel
+++ b/multibody/meshcat/BUILD.bazel
@@ -23,6 +23,8 @@ drake_cc_library(
     srcs = ["joint_sliders.cc"],
     hdrs = ["joint_sliders.h"],
     deps = [
+        "//common:scope_exit",
+        "//geometry:meshcat",
         "//multibody/plant",
     ],
 )
@@ -37,6 +39,7 @@ drake_cc_googletest(
     deps = [
         ":joint_sliders",
         "//common/test_utilities:expect_throws_message",
+        "//geometry:meshcat_visualizer",
         "//geometry/test_utilities:meshcat_environment",
         "//multibody/parsing",
     ],

--- a/multibody/meshcat/joint_sliders.h
+++ b/multibody/meshcat/joint_sliders.h
@@ -9,6 +9,7 @@
 
 #include "drake/geometry/meshcat.h"
 #include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
@@ -91,6 +92,24 @@ class JointSliders final : public systems::LeafSystem<T> {
 
   /** Performs a Delete(), if one has not already been done. */
   ~JointSliders() final;
+
+  /** Publishes the given Diagram (typically, to cause it to be visualized)
+  whenever our sliders' values change.  Blocks until the user clicks a "Stop"
+  button in the MeshCat control panel, or if the timeout limit is reached.
+
+  @param timeout (Optional) In the absence of a button click, the duration (in
+  seconds) to wait before returning. If the button is clicked, this function
+  will return promptly, without waiting for the timeout. When no timeout is
+  given, this function will block indefinitely.
+
+  @pre `diagram` must be a top-level (i.e., "root") diagram.
+  @pre `diagram` must contain this JointSliders system.
+  @pre `diagarm` must contain the `plant` that was passed into this
+  JointSliders system's constructor.
+  */
+  void Run(
+      const systems::Diagram<T>& diagram,
+      std::optional<double> timeout = std::nullopt) const;
 
  private:
   void CalcOutput(const systems::Context<T>&, systems::BasicVector<T>*) const;


### PR DESCRIPTION
Based on [meshcat_cpp_utils.py](https://github.com/RussTedrake/manipulation/blob/008cec6343dd39063705287e6664a3fee71a43b8/manipulation/meshcat_cpp_utils.py#L330) from Russ.

This flavor does not offer the `root_context` nor `callback` arguments that the original one did.  They did not appear to be necessary in the near term -- almost all uses had a null callback, and always used a default-constructed context.  We can add them later, if we find that they are necessary.

Closes #16385.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16426)
<!-- Reviewable:end -->
