### PR TITLE
Revert "[multibody/parsing] Support default geometry attributes in MuJoCo parser"

### DIFF
--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -1,6 +1,5 @@
 #include "drake/multibody/parsing/detail_mujoco_parser.h"
 
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -25,7 +24,6 @@ using Eigen::Vector4d;
 using geometry::GeometryInstance;
 using math::RigidTransformd;
 using math::RotationMatrixd;
-using tinyxml2::XMLAttribute;
 using tinyxml2::XMLDocument;
 using tinyxml2::XMLElement;
 
@@ -56,39 +54,13 @@ void WarnUnsupportedAttribute(const XMLElement& node,
   }
 }
 
-// Any attributes from `default` that are not specified in `node` will be added
-// to `node`.
-void ApplyDefaultAttributes(const XMLElement& default_node, XMLElement* node) {
-  for (const XMLAttribute* default_attr = default_node.FirstAttribute();
-       default_attr != nullptr; default_attr = default_attr->Next()) {
-    if (!node->Attribute(default_attr->Name())) {
-      node->SetAttribute(default_attr->Name(), default_attr->Value());
-    }
-  }
-}
-
 class MujocoParser {
  public:
   explicit MujocoParser(MultibodyPlant<double>* plant) : plant_{plant} {}
 
-  RigidTransformd ParseTransform(
-      XMLElement* node, const RigidTransformd& X_default = RigidTransformd{}) {
-    Vector3d pos(X_default.translation());
+  RigidTransformd ParseTransform(XMLElement* node) {
+    Vector3d pos{0, 0, 0};  // Default position is zero.
     ParseVectorAttribute(node, "pos", &pos);
-
-    // Check that only one of the orientation variants are supplied:
-    std::vector<bool> orientation_attrs = {
-        node->Attribute("quat"), node->Attribute("axisangle"),
-        node->Attribute("euler"), node->Attribute("xyaxes"),
-        node->Attribute("zaxis")};
-    if (std::count(orientation_attrs.begin(), orientation_attrs.end(), true) >
-        1) {
-      throw std::logic_error(fmt::format(
-          "Element {} has more than one orientation attribute specified "
-          "(perhaps through defaults). There must be no more than one instance "
-          "of `quat`, `axisangle`, `euler`, `xyaxes`, or `zaxis`.",
-          node->Name()));
-    }
 
     Vector4d quat;  // MuJoCo uses w,x,y,z order.
     if (ParseVectorAttribute(node, "quat", &quat)) {
@@ -132,7 +104,7 @@ class MujocoParser {
           pos);
     }
 
-    return RigidTransformd(X_default.rotation(), pos);
+    return RigidTransformd(pos);
   }
 
   struct MujocoGeometry {
@@ -143,26 +115,16 @@ class MujocoParser {
     CoulombFriction<double> friction{1.0, 1.0};
   };
 
-  MujocoGeometry ParseGeometry(XMLElement* node, int num_geom,
-                               const std::string& child_class = "") {
+  MujocoGeometry ParseGeometry(XMLElement* node, int num_geom) {
     MujocoGeometry geom;
+    geom.X_BG = ParseTransform(node);
 
     if (!ParseStringAttribute(node, "name", &geom.name)) {
       // Use "geom#" as the default body name.
       geom.name = fmt::format("geom{}", num_geom);
     }
 
-    std::string class_name;
-    if (!ParseStringAttribute(node, "class", &class_name)) {
-      class_name = child_class.empty() ? "main" : child_class;
-    }
-    if (default_geometry_.count(class_name) > 0) {
-      // TODO(russt): Add a test case covering childclass/default nesting once
-      // the body element is supported.
-      ApplyDefaultAttributes(*default_geometry_.at(class_name), node);
-    }
-
-    geom.X_BG = ParseTransform(node);
+    WarnUnsupportedAttribute(*node, "class");
 
     std::string type;
     if (!ParseStringAttribute(node, "type", &type)) {
@@ -292,22 +254,13 @@ class MujocoParser {
 
     ParseVectorAttribute(node, "rgba", &geom.rgba);
 
-    // Note: The documentation suggests that at least 3 friction parameters
-    // should be specified.  But humanoid_CMU.xml in the DeepMind suite
-    // specifies only one, and in fact we only need one.
-    std::vector<double> friction;
-    {
-      std::string friction_attr;
-      ParseStringAttribute(node, "friction", &friction_attr);
-      friction = ConvertToDoubles(friction_attr);
-    }
-    if (!friction.empty()) {
+    Vector3d friction{1, 0.005, 0.0001};
+    if (ParseVectorAttribute(node, "friction", &friction)) {
       // MuJoCo's friction specification is [sliding, torsional, rolling].  We
       // set the static and dynamic friction to `sliding`, and do not support
       // the other parameters.
       geom.friction = CoulombFriction(friction[0], friction[0]);
-      if ((friction.size() > 1 && friction[1] != 0.0) ||
-          (friction.size() > 2 && friction[2] != 0.0)) {
+      if (friction[1] != 0.0 || friction[2] != 0.0) {
         drake::log()->warn(
             "The torsional and rolling friction specified in the friction "
             "attribute of {} are unsupported and will be ignored.",
@@ -333,7 +286,7 @@ class MujocoParser {
     if (plant_->geometry_source_is_registered()) {
       std::vector<MujocoGeometry> geometries;
       for (XMLElement* link_node = node->FirstChildElement("geom"); link_node;
-           link_node = link_node->NextSiblingElement("geom")) {
+          link_node = link_node->NextSiblingElement("geom")) {
         auto geom = ParseGeometry(link_node, geometries.size());
         if (!geom.shape) continue;
         plant_->RegisterVisualGeometry(plant_->world_body(), geom.X_BG,
@@ -349,53 +302,6 @@ class MujocoParser {
     WarnUnsupportedElement(*node, "camera");
     WarnUnsupportedElement(*node, "light");
     WarnUnsupportedElement(*node, "composite");
-  }
-
-  void ParseDefault(XMLElement* node, const std::string& parent_default = "") {
-    std::string class_name;
-    if (!ParseStringAttribute(node, "class", &class_name)) {
-      if (parent_default.empty()) {
-        class_name = "main";
-      } else {
-        throw std::logic_error(
-            "The `class` attribute is required for all `default` elements "
-            "except at the top-level");
-      }
-    }
-
-    // Parse default geometries.
-    for (XMLElement* geom_node = node->FirstChildElement("geom"); geom_node;
-         geom_node = geom_node->NextSiblingElement("geom")) {
-      default_geometry_[class_name] = geom_node;
-      if (!parent_default.empty() &&
-          default_geometry_.count(parent_default) > 0) {
-        ApplyDefaultAttributes(*default_geometry_.at(parent_default),
-                               geom_node);
-      }
-    }
-
-    // Parse child defaults.
-    for (XMLElement* default_node = node->FirstChildElement("default");
-         default_node;
-         default_node = default_node->NextSiblingElement("default")) {
-      ParseDefault(default_node, class_name);
-    }
-
-    WarnUnsupportedElement(*node, "mesh");
-    WarnUnsupportedElement(*node, "material");
-    WarnUnsupportedElement(*node, "joint");
-    WarnUnsupportedElement(*node, "site");
-    WarnUnsupportedElement(*node, "camera");
-    WarnUnsupportedElement(*node, "light");
-    WarnUnsupportedElement(*node, "pair");
-    WarnUnsupportedElement(*node, "equality");
-    WarnUnsupportedElement(*node, "tendon");
-    WarnUnsupportedElement(*node, "general");
-    WarnUnsupportedElement(*node, "motor");
-    WarnUnsupportedElement(*node, "position");
-    WarnUnsupportedElement(*node, "velocity");
-    WarnUnsupportedElement(*node, "cylinder");
-    WarnUnsupportedElement(*node, "muscle");
   }
 
   void ParseOption(XMLElement* node) {
@@ -491,15 +397,9 @@ class MujocoParser {
 
     // Parse the options.
     for (XMLElement* option_node = node->FirstChildElement("option");
-         option_node; option_node = option_node->NextSiblingElement("option")) {
+         option_node;
+         option_node = option_node->NextSiblingElement("option")) {
       ParseOption(option_node);
-    }
-
-    // Parse the defaults.
-    for (XMLElement* default_node = node->FirstChildElement("default");
-         default_node;
-         default_node = default_node->NextSiblingElement("default")) {
-      ParseDefault(default_node);
     }
 
     // Parses the model's world link elements.
@@ -516,6 +416,7 @@ class MujocoParser {
     WarnUnsupportedElement(*node, "size");
     WarnUnsupportedElement(*node, "visual");
     WarnUnsupportedElement(*node, "statistic");
+    WarnUnsupportedElement(*node, "default");
     WarnUnsupportedElement(*node, "custom");
     WarnUnsupportedElement(*node, "asset");
     WarnUnsupportedElement(*node, "contact");
@@ -532,7 +433,6 @@ class MujocoParser {
   ModelInstanceIndex model_instance_{};
   enum Angle { kRadian, kDegree };
   Angle angle_{kDegree};
-  std::map<std::string, XMLElement*> default_geometry_{};
 };
 
 }  // namespace

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -72,12 +72,6 @@ GTEST_TEST(MujocoParser, GeometryTypes) {
 
   std::string xml = R"""(
 <mujoco model="test">
-  <default class="default_box">
-    <geom type="box" size="0.1 0.2 0.3"/>
-    <default class="sub">
-      <geom size="0.4 0.5 0.6"/>
-    </default>
-  </default>
   <worldbody>
     <geom name="default" size="0.1"/>
     <geom name="plane" type="plane"/>
@@ -86,9 +80,6 @@ GTEST_TEST(MujocoParser, GeometryTypes) {
     <geom name="ellipsoid" type="ellipsoid" size="0.1 0.2 0.3"/>
     <geom name="cylinder" type="cylinder" size="0.1 2.0"/>
     <geom name="box" type="box" size="0.1 2.0 3.0"/>
-    <geom name="box_from_default" class="default_box"/>
-    <geom name="ellipsoid_from_default" type="ellipsoid" class="default_box"/>
-    <geom name="box_from_sub" class="sub"/>
   </worldbody>
 </mujoco>
 )""";
@@ -120,9 +111,6 @@ GTEST_TEST(MujocoParser, GeometryTypes) {
   CheckShape("ellipsoid", "Ellipsoid");
   CheckShape("cylinder", "Cylinder");
   CheckShape("box", "Box");
-  CheckShape("box_from_default", "Box");
-  CheckShape("ellipsoid_from_default", "Ellipsoid");
-  CheckShape("box_from_sub", "Box");
 
   // TODO(russt): Check the sizes of the shapes.  (It seems that none of our
   // existing parser tests actually check the sizes of of the shapes; the Reify
@@ -150,9 +138,6 @@ GTEST_TEST(MujocoParser, GeometryPose) {
   // By default, angles are in degrees.
   std::string xml = R"""(
 <mujoco model="test">
-  <default class="default_pose">
-    <geom pos="1 2 3" quat="0 1 0 0"/>
-  </default>
   <worldbody>
     <geom name="identity" type="sphere" size="0.1" />
     <geom name="quat" quat="0 1 0 0" pos="1 2 3" type="sphere" size="0.1" />
@@ -166,7 +151,6 @@ GTEST_TEST(MujocoParser, GeometryPose) {
           quat="0.2 0.4 0.3 .1" pos="1 2 3" type="capsule" size="0.1" />
     <geom name="fromto_cylinder" fromto="-1 -3 -3 -1 -1 -3"
           quat="0.2 0.4 0.3 .1" pos="1 2 3" type="cylinder" size="0.1" />
-    <geom name="from_default" type="sphere" size="0.1" class="default_pose" />
   </worldbody>
 </mujoco>
 )""";
@@ -238,8 +222,6 @@ GTEST_TEST(MujocoParser, GeometryPose) {
             RigidTransformd(RotationMatrixd::MakeXRotation(-M_PI / 2.0), -p));
   CheckPose("fromto_cylinder",
             RigidTransformd(RotationMatrixd::MakeXRotation(-M_PI / 2.0), -p));
-  CheckPose("from_default",
-            RigidTransformd(Eigen::Quaternion<double>{0, 1, 0, 0}, p));
 
   CheckPose(
       "axisangle_rad",
@@ -260,12 +242,8 @@ GTEST_TEST(MujocoParser, GeometryProperties) {
 
   std::string xml = R"""(
 <mujoco model="test">
-  <default class="default_rgba">
-    <geom rgba="0 1 0 1"/>
-  </default>
   <worldbody>
     <geom name="default" type="sphere" size="0.1"/>
-    <geom name="default_rgba" type="sphere" size="0.1" class="default_rgba"/>
     <geom name="sphere" type="sphere" size="0.1" friction="0.9 0.0 0.0"
           rgba="1 0 0 1"/>
   </worldbody>
@@ -310,7 +288,6 @@ GTEST_TEST(MujocoParser, GeometryProperties) {
   };
 
   CheckProperties("default", 1.0, Vector4d{.5, .5, .5, 1});
-  CheckProperties("default_rgba", 1.0, Vector4d{0, 1, 0, 1});
   CheckProperties("sphere", 0.9, Vector4d{1, 0, 0, 1});
 }
 


### PR DESCRIPTION
Dear @RussTedrake ,

 The on-call build cop, @BetsyMcPhail , believes that your PR #16425 may have
 broken one or more of Drake's continuous integration builds [1]. It is
 possible to break a build even if your PR passed continuous integration
 pre-merge because additional platforms are tested post-merge.

 The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/job/mac-monterey-clang-bazel-continuous-release/216/
https://drake-jenkins.csail.mit.edu/job/mac-big-sur-clang-bazel-continuous-release/1128/

 Therefore, the build cop has created this revert PR and started a complete
 post-merge build to determine whether your PR was in fact the cause of the
 problem. If that build passes, this revert PR will be merged 60 minutes from
 now. You can then fix the problem at your leisure, and send a new PR to
 reinstate your change.

 If you believe your original PR did not actually break the build, please
 explain on this thread.

 If you believe you can fix the break promptly in lieu of a revert, please
 explain on this thread, and send a PR to the build cop for review ASAP.

 If you believe your original PR definitely did break the build and should be
 reverted, please review and LGTM this PR. This allows the build cop to merge
 without waiting for CI results.

 For advice on how to handle a build cop revert, see [2].

 Thanks!
 Your Friendly On-call Build Cop

 [1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
 [2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16427)
<!-- Reviewable:end -->
