### PR TITLE
fix detail_mujoco_parser on mac

### DIFF
--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -78,9 +78,11 @@ class MujocoParser {
 
     // Check that only one of the orientation variants are supplied:
     std::vector<bool> orientation_attrs = {
-        node->Attribute("quat"), node->Attribute("axisangle"),
-        node->Attribute("euler"), node->Attribute("xyaxes"),
-        node->Attribute("zaxis")};
+        static_cast<bool>(node->Attribute("quat")),
+        static_cast<bool>(node->Attribute("axisangle")),
+        static_cast<bool>(node->Attribute("euler")),
+        static_cast<bool>(node->Attribute("xyaxes")),
+        static_cast<bool>(node->Attribute("zaxis"))};
     if (std::count(orientation_attrs.begin(), orientation_attrs.end(), true) >
         1) {
       throw std::logic_error(fmt::format(


### PR DESCRIPTION
clang on mac needed an explicit cast of char* to bool in an initializer list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16428)
<!-- Reviewable:end -->
