### PR TITLE
tools: Remove global subdirs from installer

### DIFF
--- a/tools/install/installer.py
+++ b/tools/install/installer.py
@@ -21,8 +21,6 @@ import stat
 import sys
 from subprocess import check_output, check_call
 
-# Stores subdirectories that have already been created.
-subdirs = set()
 # Stored from command-line.
 color = False
 prefix = None
@@ -137,8 +135,6 @@ def copy_or_link(src, dst):
 
 
 def install(src, dst):
-    global subdirs
-
     # In list-only mode, just display the filename, don't do any real work.
     if list_only:
         print(dst)
@@ -146,11 +142,8 @@ def install(src, dst):
 
     # Ensure destination subdirectory exists, creating it if necessary.
     subdir = os.path.dirname(dst)
-    if subdir not in subdirs:
-        subdir_full = os.path.join(prefix, subdir)
-        if not os.path.exists(subdir_full):
-            os.makedirs(subdir_full)
-        subdirs.add(subdir)
+    subdir_full = os.path.join(prefix, subdir)
+    os.makedirs(subdir_full, exist_ok=True)
 
     dst_full = os.path.join(prefix, dst)
     # Install file, if not up to date.

--- a/tools/install/test/install_meta_test.py
+++ b/tools/install/test/install_meta_test.py
@@ -44,7 +44,6 @@ class TestInstallMeta(unittest.TestCase):
         # Forcibly reset globals.
         # TODO(rpoyner-tri): get rid of installer globals; see #7331.
         installer.libraries_to_fix_rpath.clear()
-        installer.subdirs = set()
 
         stream = io.StringIO()
         with redirect_stdout(stream), redirect_stderr(stream):


### PR DESCRIPTION
Relevant to: #7331

At best, the subdirs tracking was an optimization; at worst, a
temptation to TOCTOU errors. Removing it is another baby step toward
testability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16430)
<!-- Reviewable:end -->
