### PR TITLE
[multibody/parsing] Feature parity tests between sdformat and model directives

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -344,6 +344,18 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "model_directives_to_sdf_parity_test",
+    data = [
+        ":process_model_directives_test_models",
+    ],
+    deps = [
+        ":process_model_directives",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
     name = "model_directives_test",
     deps = [
         ":model_directives",

--- a/multibody/parsing/README_sdformat_model_composition.md
+++ b/multibody/parsing/README_sdformat_model_composition.md
@@ -1,0 +1,156 @@
+The SDFormat Composition mechanism
+==================================
+
+This README describes the use of [model composition in SDFormat](http://sdformat.org/tutorials?tut=composition_proposal&cat=pose_semantics_docs&)
+in favor of the Model Directives mechanism.
+
+A good start to review how it is being used, would be comparing the various
+Model Directives files with their SDFormat counterpart used in
+`test/model_directives_to_sdf_parity_test.cc`. These test files are in
+`test/process_model_directives_test/*.sdf`.
+
+Below are some features of Model Composition that allow us to achieve this, as
+well as the caveats.
+
+---
+
+# Features
+
+## Stricter scoping
+
+Backreferences will not be allowed, for example in [`add_backreference.yaml`](test/process_model_directives_test/add_backreference.yaml).
+
+More information about frame semantics and scopes can be found [here](http://sdformat.org/tutorials?tut=pose_frame_semantics_proposal&cat=pose_semantics_docs&).
+
+## Merge including
+
+This allows users to include `model`s described in a file into a top level
+`world`/`model` without introducing an additional scope. For example,
+
+in the downstream model,
+```
+<model name="to_be_included">
+  <model name="model_1">
+    ...
+  </model>
+  <model name="model_2">
+    ...
+  </model>
+</model>
+
+```
+in the top level model,
+```
+<model name="top_level_model">
+  <include merge="true">
+    <uri>to_be_included</uri>
+  </include>
+</model>
+```
+
+This produces the scopes `top_level_model::model_1` instead of
+`top_level_model::to_be_included::model_1`.
+
+## Placement frames and fixed joints
+
+Using a combination of `//include/placement_frame`, `//model/@placement_frame`,
+`//pose/@relative_to` and fixed joints, users are able to recreate the bahavior
+of `add_weld` from Model Directives. For example,
+
+
+In Model Directives,
+```
+directives:
+- add_model:
+    name: simple_model
+    file: simple_model.sdf
+- add_model:
+    name: extra_model
+    file: simple_model.sdf
+- add_weld:
+    parent: simple_model::frame
+    child: extra_model::base
+```
+
+In SDFormat it would be described as,
+```
+<model name="top_level">
+  <include>
+    <name>simple_model</name>
+    <uri>simple_model.sdf</uri>
+  </include>
+  <include>
+    <name>extra_model</name>
+    <uri>simple_model.sdf</uri>
+    <placement_frame>base</placement_frame>
+    <pose relative_to="simple_model::frame"/>
+  </include>
+  <joint name="weld" type="fixed">
+    <parent>simple_model::frame</parent>
+    <child>extra_model::base</child>
+  </joint>
+</model>
+```
+
+---
+
+# Caveats
+
+* Adding scopes to names explicitly is no longer supported. Workflows that
+  involve adding a frame (e.g. `left::arm::gripper_origin`) from a top level
+  include would be impacted, while leveraging the top level scope (e.g. `left`)
+  for other purposes, would be impacted and will need to be readjusted if
+  SDFormat is used.
+
+* Due to the stricter scoping rules, references to frames outside/above the
+  current scope will no longer be allowed. Depends on the use-case, this
+  can be circumvented using a combination of `//include/placement_frame`,
+  `//include/pose` and `//include/pose/@relative_to` when including the model
+  in the top level world/model. For example, in this directive where
+  world is not defined in this model instance,
+
+```
+directives:
+- add_model_instance:
+    name: nested
+- add_frame:
+    name: nested::simple_model_origin
+    X_PF:
+      base_frame: world
+      translation: [10, 0, 0]
+  ...
+```
+
+```
+<world name="top_level">
+  <include>
+    <uri>nested</uri>
+    <placement_frame>simple_model_origin</placement_frame>
+    <pose relative_to="world"/>
+  </include>
+</world>
+```
+
+* SDFormat files without a top level `actor`, `model` or `world` are not
+  supported, therefore workflows that involve files describing a single weld
+  would not be allowed. For example, `add_backreference.yaml`,
+
+```
+directives:
+- add_weld:
+    parent: simple_model_origin
+    child: simple_model::base
+```
+
+* There is no support for including or merge-including a `world` into another
+  `world`, whereas Model Directives do not have a strict top level limit.
+
+---
+
+## To be supported
+
+* Allow merge including `model` into `world` where possible. If the included
+  `model` contains elements that are not supported in a `world`, an error will
+  be returned during parsing.
+
+* [Reintroduce world joints](https://github.com/ignitionrobotics/sdf_tutorials/commit/52795e17bc6fb398b56801f94cb2cbf197c61d9f).

--- a/multibody/parsing/test/model_directives_to_sdf_parity_test.cc
+++ b/multibody/parsing/test/model_directives_to_sdf_parity_test.cc
@@ -1,0 +1,221 @@
+#include <memory>
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/filesystem.h"
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/parsing/process_model_directives.h"
+#include "drake/multibody/parsing/scoped_names.h"
+#include "drake/multibody/plant/multibody_plant.h"
+
+namespace drake {
+namespace multibody {
+namespace parsing {
+namespace {
+
+using std::optional;
+using drake::math::RigidTransformd;
+using drake::multibody::AddMultibodyPlantSceneGraph;
+using drake::multibody::Frame;
+using drake::multibody::MultibodyPlant;
+using drake::multibody::Parser;
+using drake::systems::DiagramBuilder;
+
+const char* const kTestDir =
+    "drake/multibody/parsing/test/process_model_directives_test";
+
+// Our unit test's package is not normally loaded; construct a parser that
+// has it and can resolve package://process_model_directives_test urls.
+std::unique_ptr<Parser> MakeTestParser(MultibodyPlant<double>* plant) {
+  auto parser = std::make_unique<Parser>(plant);
+  const drake::filesystem::path abspath_xml = FindResourceOrThrow(
+      std::string(kTestDir) + "/package.xml");
+  parser->package_map().AddPackageXml(abspath_xml.string());
+  return parser;
+}
+
+// Parity test for add_scoped_sub.
+GTEST_TEST(ProcessModelDirectivesTest, BasicSmokeTestFromSDF) {
+  ModelDirectives station_directives = LoadModelDirectives(
+      FindResourceOrThrow(std::string(kTestDir) + "/add_scoped_sub.yaml"));
+  const MultibodyPlant<double> md_empty_plant(0.0);
+
+  // md_ prefixes are added to artifacts generated using Model Directives.
+  MultibodyPlant<double> md_plant(0.0);
+  ProcessModelDirectives(station_directives, &md_plant,
+                         nullptr, MakeTestParser(&md_plant).get());
+  md_plant.Finalize();
+  auto md_context = md_plant.CreateDefaultContext();
+
+  // sdf_ prefixes are added to artifacts generated using sdformat.
+  MultibodyPlant<double> sdf_plant(0.0);
+
+  const std::string sdf_name = FindResourceOrThrow(
+      std::string(kTestDir) + "/add_scoped_sub.sdf");
+  auto parser = MakeTestParser(&sdf_plant);
+  parser->AddAllModelsFromFile(sdf_name);
+  sdf_plant.Finalize();
+  auto sdf_context = sdf_plant.CreateDefaultContext();
+
+  // The number of model instances for sdf_plant is now 3, due to the overall
+  // top level model add_scoped_sub.
+  const MultibodyPlant<double> empty_plant(0.0);
+  EXPECT_EQ(md_plant.num_model_instances() - empty_plant.num_model_instances(),
+            2);
+  EXPECT_EQ(sdf_plant.num_model_instances() - empty_plant.num_model_instances(),
+            3);
+
+  // Expect the two bodies added by the directives.
+  EXPECT_EQ(md_plant.num_bodies() - empty_plant.num_bodies(), 2);
+  EXPECT_EQ(sdf_plant.num_bodies() - empty_plant.num_bodies(), 2);
+
+  // A great many frames are added in model directives processing, but we
+  // should at least expect that our named ones are present.
+  EXPECT_TRUE(sdf_plant.HasFrameNamed("sub_added_frame"));
+  EXPECT_TRUE(sdf_plant.HasFrameNamed(
+      "sub_added_frame",
+      sdf_plant.GetModelInstanceByName("add_scoped_sub::simple_model")));
+  EXPECT_TRUE(sdf_plant.HasFrameNamed(
+      "frame",
+      sdf_plant.GetModelInstanceByName("add_scoped_sub::simple_model")));
+  EXPECT_TRUE(sdf_plant.HasFrameNamed(
+      "frame",
+      sdf_plant.GetModelInstanceByName("add_scoped_sub::extra_model")));
+
+  // Compare all the frames
+  EXPECT_TRUE(CompareMatrices(
+      md_plant.GetFrameByName("sub_added_frame")
+          .CalcPoseInWorld(*md_context)
+          .GetAsMatrix4(),
+      sdf_plant.GetFrameByName("sub_added_frame")
+          .CalcPoseInWorld(*sdf_context)
+          .GetAsMatrix4()));
+  EXPECT_TRUE(CompareMatrices(
+      md_plant.GetFrameByName(
+          "frame",
+          md_plant.GetModelInstanceByName("simple_model"))
+              .CalcPoseInWorld(*md_context)
+              .GetAsMatrix4(),
+      sdf_plant.GetFrameByName(
+          "frame",
+          sdf_plant.GetModelInstanceByName("add_scoped_sub::simple_model"))
+              .CalcPoseInWorld(*sdf_context)
+              .GetAsMatrix4()));
+  EXPECT_TRUE(CompareMatrices(
+      md_plant.GetFrameByName(
+          "frame",
+          md_plant.GetModelInstanceByName("extra_model"))
+              .CalcPoseInWorld(*md_context)
+              .GetAsMatrix4(),
+      sdf_plant.GetFrameByName(
+          "frame",
+          sdf_plant.GetModelInstanceByName("add_scoped_sub::extra_model"))
+              .CalcPoseInWorld(*sdf_context)
+              .GetAsMatrix4()));
+}
+
+// Parity test for add_scoped_top.
+GTEST_TEST(ProcessModelDirectivesTest, AddScopedSmokeTestFromWorldFile) {
+  ModelDirectives directives = LoadModelDirectives(
+      FindResourceOrThrow(std::string(kTestDir) + "/add_scoped_top.yaml"));
+
+  // Ensure that we have a SceneGraph present so that we test relevant visual
+  // pieces.
+  DiagramBuilder<double> builder;
+
+  // md_ prefixes are added to artifacts generated using Model Directives.
+  MultibodyPlant<double>& md_plant = AddMultibodyPlantSceneGraph(&builder, 0.);
+  ProcessModelDirectives(directives, &md_plant,
+                         nullptr, MakeTestParser(&md_plant).get());
+  md_plant.Finalize();
+  auto diagram = builder.Build();
+  auto md_context = md_plant.CreateDefaultContext();
+
+  // sdf_ prefixes are added to artifacts generated using sdformat.
+  MultibodyPlant<double> sdf_plant(0.0);
+  const std::string sdf_name = FindResourceOrThrow(
+      std::string(kTestDir) + "/add_scoped_top.sdf");
+  auto parser = MakeTestParser(&sdf_plant);
+  parser->AddAllModelsFromFile(sdf_name);
+  sdf_plant.Finalize();
+  auto sdf_context = sdf_plant.CreateDefaultContext();
+
+  // The number of model instances for sdf_plant is now 13, due to the overall
+  // top level model add_scoped_top.
+  const MultibodyPlant<double> empty_plant(0.0);
+  EXPECT_EQ(md_plant.num_model_instances() - empty_plant.num_model_instances(),
+            12);
+  EXPECT_EQ(sdf_plant.num_model_instances() - empty_plant.num_model_instances(),
+            13);
+
+  // Expect the 8 bodies added by the directives.
+  EXPECT_EQ(md_plant.num_bodies() - empty_plant.num_bodies(), 8);
+  EXPECT_EQ(sdf_plant.num_bodies() - empty_plant.num_bodies(), 8);
+
+  // Query information and ensure we have expected results.
+  // - Manually spell out one example.
+  ASSERT_EQ(
+      &GetScopedFrameByName(sdf_plant,
+                            "add_scoped_top::left::simple_model::frame"),
+      &sdf_plant.GetFrameByName(
+          "frame",
+          sdf_plant.GetModelInstanceByName(
+              "add_scoped_top::left::simple_model")));
+
+  // - Automate remaining tests.
+  auto check_frame = [&md_plant, &md_context, &sdf_plant, &sdf_context](
+      const std::string md_instance, const std::string frame) {
+    // TODO(aaronchongth): We currently do not have the ability to read a top
+    // level SDFormat model/world without its own scope included.
+    const std::string sdf_instance = "add_scoped_top::" + md_instance;
+
+    drake::log()->debug("Check instance: {}", sdf_instance);
+    ASSERT_TRUE(md_plant.HasModelInstanceNamed(md_instance));
+    ASSERT_TRUE(sdf_plant.HasModelInstanceNamed(sdf_instance));
+
+    drake::log()->debug("Check frame: {}", frame);
+    ASSERT_TRUE(
+        md_plant.HasFrameNamed(
+            frame, md_plant.GetModelInstanceByName(md_instance)));
+    ASSERT_TRUE(
+        sdf_plant.HasFrameNamed(
+            frame, sdf_plant.GetModelInstanceByName(sdf_instance)));
+
+    const std::string scoped_frame = sdf_instance + "::" + frame;
+    ASSERT_EQ(
+        &GetScopedFrameByName(sdf_plant, scoped_frame),
+        &sdf_plant.GetFrameByName(frame,
+            sdf_plant.GetModelInstanceByName(sdf_instance)));
+
+    EXPECT_TRUE(CompareMatrices(
+        md_plant.GetFrameByName(
+            frame,
+            md_plant.GetModelInstanceByName(md_instance))
+                .CalcPoseInWorld(*md_context)
+                .GetAsMatrix4(),
+        sdf_plant.GetFrameByName(
+            frame,
+            sdf_plant.GetModelInstanceByName(sdf_instance))
+                .CalcPoseInWorld(*sdf_context)
+                .GetAsMatrix4()));
+  };
+  for (const std::string prefix : {"", "left::", "right::", "mid::nested::"}) {
+    const std::string simple_model = prefix + "simple_model";
+    check_frame(simple_model, "base");
+    check_frame(simple_model, "frame");
+    check_frame(simple_model, "sub_added_frame");
+    check_frame(simple_model, "top_added_frame");
+    const std::string extra_model = prefix + "extra_model";
+    check_frame(extra_model, "base");
+    check_frame(extra_model, "frame");
+  }
+}
+
+}  // namespace
+}  // namespace parsing
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/test/process_model_directives_test.cc
+++ b/multibody/parsing/test/process_model_directives_test.cc
@@ -103,6 +103,59 @@ GTEST_TEST(ProcessModelDirectivesTest, AddScopedSmokeTest) {
   }
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+// Test the model error mechanism.
+GTEST_TEST(ProcessModelDirectivesTest, SmokeTestInjectWeldError) {
+  const RigidTransformd error_transform({0.1, 0., 0.1}, {2, 3, 4});
+  ModelDirectives directives = LoadModelDirectives(
+      FindResourceOrThrow(std::string(kTestDir) + "/add_scoped_sub.yaml"));
+
+  // This error function should add model error to exactly one weld, the
+  // attachment of the `first_instance` sdf model to the `smoke_test_origin`
+  // frame.
+  MultibodyPlant<double> plant(0.0);
+
+  auto error = [&](const std::string& parent, const std::string& child) {
+    const std::string error_parent = "simple_model::frame";
+    const std::string error_child = "extra_model::base";
+    optional<RigidTransformd> out;
+    if (parent == error_parent && child == error_child)
+        out = error_transform;
+    return out;
+  };
+
+  ProcessModelDirectives(directives, &plant,
+                         nullptr, make_parser(&plant).get(), error);
+  plant.Finalize();
+
+  // This should have created an error frame for the relevant weld.
+  const std::string expected_error_frame_name = "frame_weld_error_to_base";
+  EXPECT_TRUE(plant.HasFrameNamed(expected_error_frame_name));
+  const auto& frame = plant.GetFrameByName(expected_error_frame_name);
+  EXPECT_TRUE(
+      dynamic_cast<const drake::multibody::FixedOffsetFrame<double>*>(&frame));
+  const RigidTransformd expected_error =
+      (plant
+       .GetFrameByName("frame", plant.GetModelInstanceByName("simple_model"))
+       .GetFixedPoseInBodyFrame())
+      * error_transform;
+
+  EXPECT_TRUE(
+      frame.GetFixedPoseInBodyFrame().IsExactlyEqualTo(expected_error));
+
+  // This should not have created an error frame for other welds.
+  for (drake::multibody::FrameIndex frame_id(0);
+       frame_id < plant.num_frames();
+       frame_id++) {
+    const std::string frame_name = plant.get_frame(frame_id).name();
+    if (frame_name != expected_error_frame_name) {
+      EXPECT_TRUE(frame_name.find("error") == std::string::npos);
+    }
+  }
+}
+#pragma GCC diagnostic pop
+
 // Make sure we have good error messages.
 GTEST_TEST(ProcessModelDirectivesTest, ErrorMessages) {
   // When the user gives a bogus filename, at minimum we must echo it back to

--- a/multibody/parsing/test/process_model_directives_test/add_scoped_mid.sdf
+++ b/multibody/parsing/test/process_model_directives_test/add_scoped_mid.sdf
@@ -1,0 +1,34 @@
+<?xml version="1.0" ?>
+<sdf version="1.9">
+  <model name="add_scoped_mid">
+    <model name="nested">
+      <!--
+      simple_model_origin was supposed to have world as base frame, but that violates
+      scoping, this will be relative to the model frame instead.
+      -->
+      <frame name="simple_model_origin">
+        <pose>10 0 0   0 0 0</pose>
+      </frame>
+
+      <include merge="true">
+        <uri>package://process_model_directives_test/add_scoped_sub.sdf</uri>
+        <!--
+          //placement frame and //pose[@relative_to] is added here to pass the
+          tests of comparing poses between the frames added by model directives
+          and frames through sdf.
+        -->
+        <placement_frame>simple_model::base</placement_frame>
+        <pose relative_to="simple_model_origin"/>
+      </include>
+
+      <!--
+      This backreference sdf does not have a top level model and violates
+      scoping rules.
+      <include>
+        <uri>package://process_model_directives_test/add_backreference.sdf
+      </include>
+      -->
+    </model>
+
+  </model>
+</sdf>

--- a/multibody/parsing/test/process_model_directives_test/add_scoped_sub.sdf
+++ b/multibody/parsing/test/process_model_directives_test/add_scoped_sub.sdf
@@ -1,0 +1,47 @@
+<?xml version="1.0" ?>
+<sdf version="1.9">
+  <model name="add_scoped_sub">
+
+    <include>
+      <name>simple_model</name>
+      <uri>package://process_model_directives_test/simple_model.sdf</uri>
+    </include>
+
+    <!-- This will implicitly resolve to the `simple_model` instance. -->
+    <frame name="sub_added_frame" attached_to="simple_model::frame">
+      <pose>10 20 30   0 0 0</pose>
+    </frame>
+
+    <!--
+      Explicitly resolving a frame by namespacing its name is not supported
+      and not needed, hence they will be commented out.
+
+      TODO(aaronchongth): Without this feature, there may be existing workflows
+      that are impacted and will need adjustment. For example, adding
+      "left::arm::gripper_origin" from a top level include, and then leveraging
+      this new model scope for other operations just scoped within "left::".
+    -->
+    <!--
+    <frame name="simple_model::sub_added_frame_explicit" ...>
+      <pose>10 20 30   0 0 0</pose>
+    </frame>
+    -->
+
+    <include>
+      <name>extra_model</name>
+      <uri>package://process_model_directives_test/simple_model.sdf</uri>
+      <placement_frame>base</placement_frame>
+      <pose relative_to="simple_model::frame"/>
+    </include>
+
+    <!--
+    A weld can be replaced by having a zero relative pose between the two frames,
+    as well as a fixed joint between them.
+    -->
+    <joint name="add_scoped_sub_weld" type="fixed">
+      <parent>simple_model::frame</parent>
+      <child>extra_model::base</child>
+    </joint>
+
+  </model>
+</sdf>

--- a/multibody/parsing/test/process_model_directives_test/add_scoped_top.sdf
+++ b/multibody/parsing/test/process_model_directives_test/add_scoped_top.sdf
@@ -1,0 +1,64 @@
+<?xml version="1.0" ?>
+<sdf version="1.9">
+  <model name="add_scoped_top">
+    <frame name="world_frame"/>
+
+    <frame name="simple_model_origin" attached_to="world_frame"/>
+    <include merge="true">
+      <uri>package://process_model_directives_test/add_scoped_sub.sdf</uri>
+    </include>
+    <frame name="top_added_frame" attached_to="simple_model">
+      <!--
+      sub_added_frame was added under the scope of add_scoped_sub, even though
+      the directives indicate it is under add_scoped_top::simple_model
+      <pose relative_to="simple_model::sub_added_frame">
+      -->
+      <pose relative_to="sub_added_frame">
+        5 10 15   0 0 0
+      </pose>
+    </frame>
+
+    <model name="left">
+      <pose relative_to="world_frame"/>
+      <frame name="simple_model_origin">
+        <pose>0 1 0   0 0 0</pose>
+      </frame>
+      <include merge="true">
+        <uri>package://process_model_directives_test/add_scoped_sub.sdf</uri>
+      </include>
+      <frame name="top_added_frame" attached_to="simple_model">
+        <pose relative_to="sub_added_frame">
+          5 10 15   0 0 0
+        </pose>
+      </frame>
+    </model>
+
+    <model name="right">
+      <pose relative_to="world_frame"/>
+      <frame name="simple_model_origin">
+        <pose>0 -1 0   0 0 0</pose>
+      </frame>
+      <include merge="true">
+        <uri>package://process_model_directives_test/add_scoped_sub.sdf</uri>
+      </include>
+      <frame name="top_added_frame" attached_to="simple_model">
+        <pose relative_to="sub_added_frame">
+          5 10 15   0 0 0
+        </pose>
+      </frame>
+    </model>
+
+    <model name="mid">
+      <pose relative_to="world_frame"/>
+      <include merge="true">
+        <uri>package://process_model_directives_test/add_scoped_mid.sdf</uri>
+      </include>
+      <frame name="top_added_frame" attached_to="nested::simple_model">
+        <pose relative_to="nested::sub_added_frame">
+          5 10 15   0 0 0
+        </pose>
+      </frame>
+    </model>
+
+  </model>
+</sdf>


### PR DESCRIPTION
Related to https://github.com/RobotLocomotion/drake/issues/15948.

This PR adds tests to explore the possibility of deprecating Model Directives, with SDFormat. Overall, `sdf` introduces stricter rules for scopes, which resolves some questions that were raised in Model Directives, but is limited in some other aspects. This will all be listed below in points for discussion.

## Testing

This branch requires https://github.com/ignitionrobotics/sdformat/pull/824, which is not in the released `sdformat` package that `drake` is currently tagged to, as of 25 Jan 2022. In order to build, and have the tests pass, a local repository override is needed

```bash
mkdir ~/drake_ws
cd ~/drake_ws
git clone https://github.com/aaronchongth/drake -b aaron/deprecate-model-directives
git clone https://github.com/ignitionrobotics/sdformat
cd ~/drake_ws/sdformat
git checkout 76298d1                 # this is the commit tag is before changes to sdf_config,h was made, otherwise the build will fail
```

modify `~/drake_ws/drake/tools/workspace/sdformat/repository.bzl`, adding `local_repository_override = "/home/USER/drake_ws/sdformat",`,

then build,

```bash
cd ~/drake_ws/drake
bazel build multibody/parsing:model_directives_to_sdf_parity_test
./bazel-bin/multibody/parsing/model_directives_to_sdf_parity_test
```

## Some initial findings

* `sdf` has stopped supporting explicit scopes in names, hence [this test](https://github.com/aaronchongth/drake/blob/aaron/deprecate-model-directives/multibody/parsing/test/process_model_directives_test/add_scoped_sub.yaml#L19-L24) will be left out
  * Comments can be found [here](https://github.com/aaronchongth/drake/blob/aaron/deprecate-model-directives/multibody/parsing/test/process_model_directives_test/add_scoped_sub.sdf#L15-L21)

* a good way to replicate `add_weld` in `sdf` is to use
  * `placement_frame` and `//pose[@relative_to]`, to have both frames share the same origin
  * adding a fixed joint between the two frames, to ensure they are welded together
  * example [model directive here](https://github.com/aaronchongth/drake/blob/aaron/deprecate-model-directives/multibody/parsing/test/process_model_directives_test/add_scoped_sub.yaml#L30-L32) translated to [SDF here](https://github.com/aaronchongth/drake/blob/aaron/deprecate-model-directives/multibody/parsing/test/process_model_directives_test/add_scoped_sub.sdf#L26-L37)

```
- add_weld:
    parent: simple_model::frame
    child: extra_model::base
```
```
    <include>
      <name>extra_model</name>
      <uri>package://process_model_directives_test/simple_model.sdf</uri>
      <placement_frame>base</placement_frame>
      <pose relative_to="simple_model::frame"/>
    </include>

    <joint name="add_scoped_sub_weld" type="fixed">
      <parent>simple_model::frame</parent>
      <child>extra_model::base</child>
    </joint>
```

* elements in `sdf` can only reference frames, links or models that are in the same scope, or nested below. Referencing frames, links or models above the element's own scope is not allowed.
  * Referencing a `world` frame from within standalone models will not be supported, placement frames should be used instead, [example here](https://github.com/aaronchongth/drake/blob/aaron/deprecate-model-directives/multibody/parsing/test/process_model_directives_test/add_scoped_mid.yaml#L12)
  * Including a backreferenced weld will not be supported, [here](https://github.com/aaronchongth/drake/blob/aaron/deprecate-model-directives/multibody/parsing/test/process_model_directives_test/add_backreference.yaml)

## Points for discussion

* `world` in `sdf` does not support merge including models, which will be needed to support including downstream models without introducing an extra model namespace, [example here](https://github.com/aaronchongth/drake/blob/aaron/deprecate-model-directives/multibody/parsing/test/process_model_directives_test/add_scoped_top.yaml#L16-L17)
  * Per VC, we discussed the possibility to support merge-include in `world`,
    * this feature will allow mergeable models to be merge included into the world during parsing, while non-mergeable models will cause errors or exceptions to be thrown during parsing.
    * Non-mergeable models are models that have elements that are not supported in `world`, such as `link` and `joint` (see below for more about `//world/joint`)
  * the temporary solution is to have the top level world be written as a model as well, but:
    * this may require a user-specified frame, such as `world_frame`, [example here](https://github.com/aaronchongth/drake/blob/aaron/deprecate-model-directives/multibody/parsing/test/process_model_directives_test/add_scoped_top.sdf#L3-L4)
    * As mentioned above, we'd need to provide the ability to "unscope" models as included. This could be done with something like `<drake:model_as_world_workaround/>`, but it'd be an awkward alternative to `//world/include/@merge=true`

* Welding is a critical feature in Model Directives, which allows users to integrate models in the world without introducing additional levels of scope in any single model. For example, a robot arm that supports multiple custom grippers in the simulation.
  * However, `joint`s are not support in a `world` in `sdf`
    * `//world/joint` was [removed in SDFormat 1.7](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/637/page/1) - present in spec, but they were unused in libsdformat / gazebo
     * (Eric) We had intended to reintroduce this as part of composition... but forgot :facepalm: https://github.com/ignitionrobotics/sdf_tutorials/commit/52795e17bc6fb398b56801f94cb2cbf197c61d9f
  * Per VC, we discussed the possibility of having a custom element for this specific feature, like `<drake:weld>`
    * this custom element should be able to be merge included into models (or worlds once it is supported), as it is copied into the level above
    * (Eric) As a caveat, though, it could mean that trying to use `//world/include/@merge=true`, where a top-level model uses a `//joint` directly instead of `//drake:weld`, meaning expressing the same things in the "wrong" way could create an error. As a workaround, we could see about adding some sort of callback (ew) to allow source-level transformation... Not great, but an option.

* For generating new worlds, some changes in workflow might be needed. For example, when building a house,
  * using model directives, users might be including all sorts of models (fixtures, furniture) into a new world, and adding welds for each model. These are models that users or robots would not want to interact with.
  * using SDFormat, models would be included with `//include/static='true'` and have the poses defined in `//include/pose`
    * only the models that require interaction with (e.g. robot arm, mobile robot, objects for grasping, etc), will not be static

As discussed with @EricCousineau-TRI, @azeey. Let me know if I missed out anything or may have mistaken some concepts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16431)
<!-- Reviewable:end -->
