### PR TITLE
[geometry/test] Add PauseTestEnvironmentMeshcat helper

### DIFF
--- a/geometry/test_utilities/BUILD.bazel
+++ b/geometry/test_utilities/BUILD.bazel
@@ -50,6 +50,7 @@ drake_cc_library(
     ],
     deps = [
         "//geometry:meshcat",
+        "//common:scope_exit",
         "@gtest//:without_main",
     ],
 )

--- a/geometry/test_utilities/meshcat_environment.h
+++ b/geometry/test_utilities/meshcat_environment.h
@@ -12,5 +12,9 @@ object is used for all test cases. If test code needs to reset the scene
 between tests, it must do so explicitly. */
 std::shared_ptr<Meshcat> GetTestEnvironmentMeshcat();
 
+/** When in interactive mode (--meshcat_pause_during_tests), waits for the user
+to click a button to proceed. When not interactive, does nothing .*/
+void PauseTestEnvironmentMeshcat();
+
 }  // namespace geometry
 }  // namespace drake

--- a/multibody/meshcat/test/joint_sliders_test.cc
+++ b/multibody/meshcat/test/joint_sliders_test.cc
@@ -16,6 +16,7 @@ namespace {
 
 using Eigen::Vector2d;
 using geometry::Meshcat;
+using geometry::PauseTestEnvironmentMeshcat;
 
 class JointSlidersTest : public ::testing::Test {
  public:
@@ -69,6 +70,7 @@ TEST_F(JointSlidersTest, NarrowConstructor) {
   // Add the sliders.
   const JointSliders<double> dut(meshcat_, &plant_);
   auto context = dut.CreateDefaultContext();
+  PauseTestEnvironmentMeshcat();
 
   // Sliders start at their default context value.
   EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), default_angle_1);
@@ -113,6 +115,7 @@ TEST_F(JointSlidersTest, WideConstructorWithVectors) {
   const JointSliders dut(
       meshcat_, &plant_, initial_value, lower_limit, upper_limit, step);
   auto context = dut.CreateDefaultContext();
+  PauseTestEnvironmentMeshcat();
 
   // Sliders start at their initial value.
   EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), default_angle_1);
@@ -199,6 +202,7 @@ TEST_F(JointSlidersTest, DuplicatedJointNames) {
 
   // Add the sliders.
   const JointSliders<double> dut(meshcat_, &plant_);
+  PauseTestEnvironmentMeshcat();
 
   // Confirm that the names are unique.
   const std::string alpha = "/alpha";


### PR DESCRIPTION
When debugging unit tests that touch a Meshcat, I've found that sometimes I want to pause at the end of a test case (or sometimes, in the middle of one).  This is one approach to doing that.  I'm not sure if it's a good one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16435)
<!-- Reviewable:end -->
