### PR TITLE
[multibody] Move ContactResultsToMeshcat into meshcat directory

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -303,6 +303,7 @@ drake_py_unittest(
     deps = [
         ":meshcat_py",
         ":parsing_py",
+        "//bindings/pydrake/common/test_utilities:numpy_compare_py",
     ],
 )
 

--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -120,6 +120,7 @@ drake_pybind_library(
         "//bindings/pydrake:geometry_py",
         "//bindings/pydrake/common:cpp_template_py",
     ],
+    py_srcs = ["_plant_extra.py"],
 )
 
 drake_pybind_library(
@@ -284,6 +285,8 @@ drake_py_unittest(
         "//bindings/pydrake/common/test_utilities:pickle_compare_py",
         "//bindings/pydrake/systems:analysis_py",
         "//bindings/pydrake/systems:scalar_conversion_py",
+        # TODO(jwnimmer-tri) Remove this on 2022-05-01 per deprecations.
+        ":meshcat_py",
     ],
 )
 

--- a/bindings/pydrake/multibody/_plant_extra.py
+++ b/bindings/pydrake/multibody/_plant_extra.py
@@ -1,0 +1,25 @@
+# See `ExecuteExtraPythonCode` in `pydrake_pybind.h` for usage details and
+# rationale.
+
+import functools as _functools
+
+from pydrake.autodiffutils import AutoDiffXd as _AD
+from pydrake.common.deprecation import deprecated_callable as _deprecated
+
+
+@_deprecated("Spell as ContactVisualizerParams instead", date="2022-05-01")
+def ContactResultsToMeshcatParams(*args, **kwargs):
+    from pydrake.multibody.meshcat import ContactVisualizerParams as real
+    return real(*args, **kwargs)
+
+
+@_deprecated("Spell as ContactVisualizer instead", date="2022-05-01")
+def ContactResultsToMeshcat(T=float, *args, **kwargs):
+    from pydrake.multibody.meshcat import ContactVisualizer_ as real
+    return real[T](*args, **kwargs)
+
+
+ContactResultsToMeshcat_ = dict((
+    (float, ContactResultsToMeshcat),
+    (_AD, _functools.partial(ContactResultsToMeshcat, T=_AD)),
+))

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -17,7 +17,6 @@
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/plant/contact_results.h"
 #include "drake/multibody/plant/contact_results_to_lcm.h"
-#include "drake/multibody/plant/contact_results_to_meshcat.h"
 #include "drake/multibody/plant/externally_applied_spatial_force.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/plant/point_pair_contact_info.h"
@@ -1162,51 +1161,6 @@ void DoScalarDependentDefinitions(py::module m, T) {
             doc.Propeller.get_spatial_forces_output_port.doc);
   }
 
-  // ContactResultsToMeshcat
-  if constexpr (!std::is_same_v<T, symbolic::Expression>) {
-    using Class = ContactResultsToMeshcat<T>;
-    constexpr auto& cls_doc = doc.ContactResultsToMeshcat;
-    auto cls = DefineTemplateClassWithDefault<Class, systems::LeafSystem<T>>(
-        m, "ContactResultsToMeshcat", param, cls_doc.doc);
-    cls  // BR
-        .def(py::init<std::shared_ptr<geometry::Meshcat>,
-                 ContactResultsToMeshcatParams>(),
-            py::arg("meshcat"),
-            py::arg("params") = ContactResultsToMeshcatParams{},
-            // `meshcat` is a shared_ptr, so does not need a keep_alive.
-            cls_doc.ctor.doc)
-        .def("Delete", &Class::Delete, cls_doc.Delete.doc)
-        .def("contact_results_input_port", &Class::contact_results_input_port,
-            py_rvp::reference_internal, cls_doc.contact_results_input_port.doc)
-        .def_static("AddToBuilder",
-            py::overload_cast<systems::DiagramBuilder<T>*,
-                const MultibodyPlant<T>&, std::shared_ptr<geometry::Meshcat>,
-                ContactResultsToMeshcatParams>(
-                &ContactResultsToMeshcat<T>::AddToBuilder),
-            py::arg("builder"), py::arg("plant"), py::arg("meshcat"),
-            py::arg("params") = ContactResultsToMeshcatParams{},
-            // Keep alive, ownership: `return` keeps `builder` alive.
-            py::keep_alive<0, 1>(),
-            // `meshcat` is a shared_ptr, so does not need a keep_alive.
-            py_rvp::reference,
-            cls_doc.AddToBuilder.doc_4args_builder_plant_meshcat_params)
-        .def_static("AddToBuilder",
-            py::overload_cast<systems::DiagramBuilder<T>*,
-                const systems::OutputPort<T>&,
-                std::shared_ptr<geometry::Meshcat>,
-                ContactResultsToMeshcatParams>(
-                &ContactResultsToMeshcat<T>::AddToBuilder),
-            py::arg("builder"), py::arg("contact_results_port"),
-            py::arg("meshcat"),
-            py::arg("params") = ContactResultsToMeshcatParams{},
-            // Keep alive, ownership: `return` keeps `builder` alive.
-            py::keep_alive<0, 1>(),
-            // `meshcat` is a shared_ptr, so does not need a keep_alive.
-            py_rvp::reference,
-            cls_doc.AddToBuilder
-                .doc_4args_builder_contact_results_port_meshcat_params);
-  }
-
   // NOLINTNEXTLINE(readability/fn_size)
 }
 }  // namespace
@@ -1242,47 +1196,6 @@ PYBIND11_MODULE(plant, m) {
         .def("get_lcm_message_output_port", &Class::get_lcm_message_output_port,
             py_rvp::reference_internal,
             cls_doc.get_lcm_message_output_port.doc);
-  }
-
-  // ContactResultsToMeshcatParams
-  {
-    using Class = ContactResultsToMeshcatParams;
-    constexpr auto& cls_doc = doc.ContactResultsToMeshcatParams;
-    py::class_<Class>(
-        m, "ContactResultsToMeshcatParams", py::dynamic_attr(), cls_doc.doc)
-        .def(ParamInit<Class>())
-        .def_readwrite("publish_period",
-            &ContactResultsToMeshcatParams::publish_period,
-            cls_doc.publish_period.doc)
-        .def_readwrite(
-            "color", &ContactResultsToMeshcatParams::color, cls_doc.color.doc)
-        .def_readwrite("prefix", &ContactResultsToMeshcatParams::prefix,
-            cls_doc.prefix.doc)
-        .def_readwrite("delete_on_initialization_event",
-            &ContactResultsToMeshcatParams::delete_on_initialization_event,
-            cls_doc.delete_on_initialization_event.doc)
-        .def_readwrite("force_threshold",
-            &ContactResultsToMeshcatParams::force_threshold,
-            cls_doc.force_threshold.doc)
-        .def_readwrite("newtons_per_meter",
-            &ContactResultsToMeshcatParams::newtons_per_meter,
-            cls_doc.newtons_per_meter.doc)
-        .def_readwrite("radius", &ContactResultsToMeshcatParams::radius,
-            cls_doc.radius.doc)
-        .def("__repr__", [](const Class& self) {
-          return py::str(
-              "ContactResultsToMeshcatParams("
-              "publish_period={}, "
-              "color={}, "
-              "prefix={}, "
-              "delete_on_initialization_event={}, "
-              "force_threshold={}, "
-              "newtons_per_meter={}, "
-              "radius={})")
-              .format(self.publish_period, self.color, self.prefix,
-                  self.delete_on_initialization_event, self.force_threshold,
-                  self.newtons_per_meter, self.radius);
-        });
   }
 
   m.def(

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -1257,6 +1257,8 @@ PYBIND11_MODULE(plant, m) {
 
   type_visit([m](auto dummy) { DoScalarDependentDefinitions(m, dummy); },
       CommonScalarPack{});
+
+  ExecuteExtraPythonCode(m);
 }  // NOLINT(readability/fn_size)
 
 }  // namespace pydrake

--- a/bindings/pydrake/multibody/test/meshcat_test.py
+++ b/bindings/pydrake/multibody/test/meshcat_test.py
@@ -1,4 +1,6 @@
 from pydrake.multibody.meshcat import (
+    ContactVisualizer_,
+    ContactVisualizerParams,
     JointSliders,
 )
 
@@ -8,8 +10,12 @@ import unittest
 from pydrake.common import (
     FindResourceOrThrow,
 )
+from pydrake.common.test_utilities import (
+    numpy_compare,
+)
 from pydrake.geometry import (
     Meshcat,
+    Rgba,
 )
 from pydrake.multibody.parsing import (
     Parser,
@@ -20,10 +26,40 @@ from pydrake.multibody.plant import (
 )
 from pydrake.systems.framework import (
     DiagramBuilder,
+    DiagramBuilder_,
 )
 
 
 class TestMeshcat(unittest.TestCase):
+
+    @numpy_compare.check_nonsymbolic_types
+    def test_contact_visualizer(self, T):
+        meshcat = Meshcat()
+        params = ContactVisualizerParams()
+        params.publish_period = 0.123
+        params.default_color = Rgba(0.5, 0.5, 0.5)
+        params.prefix = "py_visualizer"
+        params.delete_on_initialization_event = False
+        params.force_threshold = 0.2
+        params.newtons_per_meter = 5
+        params.radius = 0.1
+        self.assertNotIn("object at 0x", repr(params))
+        params2 = ContactVisualizerParams(publish_period=0.4)
+        self.assertEqual(params2.publish_period, 0.4)
+        vis = ContactVisualizer_[T](meshcat=meshcat, params=params)
+        vis.Delete()
+        vis.contact_results_input_port()
+
+        builder = DiagramBuilder_[T]()
+        plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.01)
+        plant.Finalize()
+        ContactVisualizer_[T].AddToBuilder(
+            builder=builder, plant=plant, meshcat=meshcat, params=params)
+        ContactVisualizer_[T].AddToBuilder(
+            builder=builder,
+            contact_results_port=plant.get_contact_results_output_port(),
+            meshcat=meshcat,
+            params=params)
 
     def test_joint_sliders(self):
         # Load up an acrobot.

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -60,6 +60,8 @@ from pydrake.multibody.plant import (
     ContactModel,
     ContactResults_,
     ContactResultsToLcmSystem,
+    ContactResultsToMeshcatParams,
+    ContactResultsToMeshcat_,
     CoulombFriction_,
     ExternallyAppliedSpatialForce_,
     MultibodyPlant_,
@@ -84,6 +86,7 @@ from pydrake.geometry import (
     GeometryId,
     GeometrySet,
     HydroelasticContactRepresentation,
+    Meshcat,
     Role,
     PenetrationAsPointPair_,
     ProximityProperties,
@@ -2269,6 +2272,16 @@ class TestPlant(unittest.TestCase):
             dut.EvaluateGradE_N_W(index=0)
         dut.Equal(surface=dut)
         copy.copy(dut)
+
+    @numpy_compare.check_nonsymbolic_types
+    def test_deprecated_contact_results_to_meshcat(self, T):
+        meshcat = Meshcat()
+        with catch_drake_warnings(expected_count=1):
+            params = ContactResultsToMeshcatParams()
+        self.assertIsNotNone(params)
+        with catch_drake_warnings(expected_count=1):
+            vis = ContactResultsToMeshcat_[T](meshcat=meshcat, params=params)
+        vis.Delete()
 
     def test_free_base_bodies(self):
         plant = MultibodyPlant_[float](time_step=0.01)

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -60,8 +60,6 @@ from pydrake.multibody.plant import (
     ContactModel,
     ContactResults_,
     ContactResultsToLcmSystem,
-    ContactResultsToMeshcatParams,
-    ContactResultsToMeshcat_,
     CoulombFriction_,
     ExternallyAppliedSpatialForce_,
     MultibodyPlant_,
@@ -86,8 +84,6 @@ from pydrake.geometry import (
     GeometryId,
     GeometrySet,
     HydroelasticContactRepresentation,
-    Meshcat,
-    Rgba,
     Role,
     PenetrationAsPointPair_,
     ProximityProperties,
@@ -2273,35 +2269,6 @@ class TestPlant(unittest.TestCase):
             dut.EvaluateGradE_N_W(index=0)
         dut.Equal(surface=dut)
         copy.copy(dut)
-
-    @numpy_compare.check_nonsymbolic_types
-    def test_contact_results_to_meshcat(self, T):
-        meshcat = Meshcat()
-        params = ContactResultsToMeshcatParams()
-        params.publish_period = 0.123
-        params.default_color = Rgba(0.5, 0.5, 0.5)
-        params.prefix = "py_visualizer"
-        params.delete_on_initialization_event = False
-        params.force_threshold = 0.2
-        params.newtons_per_meter = 5
-        params.radius = 0.1
-        self.assertNotIn("object at 0x", repr(params))
-        params2 = ContactResultsToMeshcatParams(publish_period=0.4)
-        self.assertEqual(params2.publish_period, 0.4)
-        vis = ContactResultsToMeshcat_[T](meshcat=meshcat, params=params)
-        vis.Delete()
-        self.assertIsInstance(vis.contact_results_input_port(), InputPort_[T])
-
-        builder = DiagramBuilder_[T]()
-        plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.01)
-        plant.Finalize()
-        ContactResultsToMeshcat_[T].AddToBuilder(
-            builder=builder, plant=plant, meshcat=meshcat, params=params)
-        ContactResultsToMeshcat_[T].AddToBuilder(
-            builder=builder,
-            contact_results_port=plant.get_contact_results_output_port(),
-            meshcat=meshcat,
-            params=params)
 
     def test_free_base_bodies(self):
         plant = MultibodyPlant_[float](time_step=0.01)

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -437,9 +437,9 @@ drake_cc_binary(
     deps = [
         ":meshcat",
         ":meshcat_visualizer",
+        "//multibody/meshcat:contact_visualizer",
         "//multibody/parsing",
         "//multibody/plant",
-        "//multibody/plant:contact_results_to_meshcat",
         "//systems/analysis:simulator",
     ],
 )

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -11,8 +11,8 @@
 #include "drake/geometry/shape_specification.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
+#include "drake/multibody/meshcat/contact_visualizer.h"
 #include "drake/multibody/parsing/parser.h"
-#include "drake/multibody/plant/contact_results_to_meshcat.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/systems/analysis/simulator.h"
 
@@ -242,9 +242,9 @@ Open up your browser to the URL above.
   auto& visualizer = MeshcatVisualizerd::AddToBuilder(
       &builder, scene_graph, meshcat, std::move(params));
 
-  multibody::ContactResultsToMeshcatParams cparams;
+  multibody::meshcat::ContactVisualizerParams cparams;
   cparams.newtons_per_meter = 60.0;
-  auto& contact = multibody::ContactResultsToMeshcatd::AddToBuilder(
+  auto& contact = multibody::meshcat::ContactVisualizerd::AddToBuilder(
       &builder, plant, meshcat, std::move(cparams));
 
   auto diagram = builder.Build();

--- a/multibody/meshcat/BUILD.bazel
+++ b/multibody/meshcat/BUILD.bazel
@@ -14,7 +14,46 @@ drake_cc_package_library(
     name = "meshcat",
     visibility = ["//visibility:public"],
     deps = [
+        ":contact_visualizer",
+        ":contact_visualizer_params",
         ":joint_sliders",
+    ],
+)
+
+drake_cc_library(
+    name = "contact_visualizer",
+    srcs = ["contact_visualizer.cc"],
+    hdrs = ["contact_visualizer.h"],
+    deps = [
+        ":contact_visualizer_params",
+        "//common:essential",
+        "//geometry:meshcat",
+        "//math:geometric_transform",
+        "//multibody/plant",
+        "//systems/framework:context",
+        "//systems/framework:diagram_builder",
+        "//systems/framework:leaf_system",
+    ],
+)
+
+drake_cc_googletest(
+    name = "contact_visualizer_test",
+    data = [
+        "//examples/manipulation_station:models",
+    ],
+    deps = [
+        ":contact_visualizer",
+        "//common/test_utilities:expect_throws_message",
+        "//multibody/parsing",
+        "//multibody/plant",
+    ],
+)
+
+drake_cc_library(
+    name = "contact_visualizer_params",
+    hdrs = ["contact_visualizer_params.h"],
+    deps = [
+        "//geometry:rgba",
     ],
 )
 

--- a/multibody/meshcat/contact_visualizer.h
+++ b/multibody/meshcat/contact_visualizer.h
@@ -6,22 +6,23 @@
 #include <utility>
 
 #include "drake/geometry/meshcat.h"
-#include "drake/multibody/plant/contact_results_to_meshcat_params.h"
+#include "drake/multibody/meshcat/contact_visualizer_params.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
 namespace multibody {
+namespace meshcat {
 
-/** ContactResultsToMeshcat is a system that publishes a ContactResults to
+/** ContactVisualizer is a system that publishes a ContactResults to
 geometry::Meshcat; it draws double-sided arrows at the location of the contact
 force with length scaled by the magnitude of the contact force.  The most common
 use of this system is to connect its input port to the contact results output
 port of a MultibodyPlant.
 
  @system
- name: ContactResultsToMeshcat
+ name: ContactVisualizer
  input_ports:
  - contact_results
  @endsystem
@@ -31,18 +32,18 @@ Note: This system current only visualizes "point pair" contacts.
 @tparam_nonsymbolic_scalar
 @ingroup visualization */
 template <typename T>
-class ContactResultsToMeshcat final : public systems::LeafSystem<T> {
+class ContactVisualizer final : public systems::LeafSystem<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ContactResultsToMeshcat)
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ContactVisualizer)
 
-  /** Creates an instance of %ContactResultsToMeshcat */
-  explicit ContactResultsToMeshcat(std::shared_ptr<geometry::Meshcat> meshcat,
-                                   ContactResultsToMeshcatParams params = {});
+  /** Creates an instance of %ContactVisualizer */
+  explicit ContactVisualizer(std::shared_ptr<geometry::Meshcat> meshcat,
+                                   ContactVisualizerParams params = {});
 
   /** Scalar-converting copy constructor. See @ref system_scalar_conversion.
   It should only be used to convert _from_ double _to_ other scalar types. */
   template <typename U>
-  explicit ContactResultsToMeshcat(const ContactResultsToMeshcat<U>& other);
+  explicit ContactVisualizer(const ContactVisualizer<U>& other);
 
   /** Calls geometry::Meshcat::Delete(std::string_view path), with the path set
   to `prefix`. Since this visualizer will only ever add geometry under this
@@ -60,26 +61,26 @@ class ContactResultsToMeshcat final : public systems::LeafSystem<T> {
     return this->get_input_port(contact_results_input_port_);
   }
 
-  /** Adds a ContactResultsToMeshcat and connects it to the given
+  /** Adds a ContactVisualizer and connects it to the given
   MultibodyPlant's ContactResults-valued output port. */
-  static const ContactResultsToMeshcat<T>& AddToBuilder(
+  static const ContactVisualizer<T>& AddToBuilder(
       systems::DiagramBuilder<T>* builder, const MultibodyPlant<T>& plant,
       std::shared_ptr<geometry::Meshcat> meshcat,
-      ContactResultsToMeshcatParams params = {});
+      ContactVisualizerParams params = {});
 
-  /** Adds a ContactResultsToMeshcat and connects it to the given
+  /** Adds a ContactVisualizer and connects it to the given
   multibody::ContactResults-valued output port. */
-  static const ContactResultsToMeshcat<T>& AddToBuilder(
+  static const ContactVisualizer<T>& AddToBuilder(
       systems::DiagramBuilder<T>* builder,
       const systems::OutputPort<T>& contact_results_port,
       std::shared_ptr<geometry::Meshcat> meshcat,
-      ContactResultsToMeshcatParams params = {});
+      ContactVisualizerParams params = {});
 
  private:
-  /* ContactResultsToMeshcat of different scalar types can all access each
+  /* ContactVisualizer of different scalar types can all access each
   other's data. */
   template <typename>
-  friend class ContactResultsToMeshcat;
+  friend class ContactVisualizer;
 
   /* The periodic event handler. It tests to see if the last scene description
   is valid (if not, sends the objects) and then sends the transforms. */
@@ -102,16 +103,16 @@ class ContactResultsToMeshcat final : public systems::LeafSystem<T> {
   mutable std::map<SortedPair<geometry::GeometryId>, bool> contacts_{};
 
   /* The parameters for the visualizer.  */
-  ContactResultsToMeshcatParams params_;
+  ContactVisualizerParams params_;
 };
 
-/** A convenient alias for the ContactResultsToMeshcat class when using
+/** A convenient alias for the ContactVisualizer class when using
 the `double` scalar type. */
-using ContactResultsToMeshcatd = ContactResultsToMeshcat<double>;
+using ContactVisualizerd = ContactVisualizer<double>;
 
+}  // namespace meshcat
 }  // namespace multibody
-
 }  // namespace drake
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
-    class ::drake::multibody::ContactResultsToMeshcat)
+    class ::drake::multibody::meshcat::ContactVisualizer)

--- a/multibody/meshcat/contact_visualizer_params.h
+++ b/multibody/meshcat/contact_visualizer_params.h
@@ -6,9 +6,10 @@
 
 namespace drake {
 namespace multibody {
+namespace meshcat {
 
-/** The set of parameters for configuring ContactResultsToMeshcat. */
-struct ContactResultsToMeshcatParams {
+/** The set of parameters for configuring ContactVisualizer. */
+struct ContactVisualizerParams {
   /** The duration (in simulation seconds) between attempts to update poses in
    the visualizer. (To help avoid small simulation timesteps, we use a default
    period that has an exact representation in binary floating point; see
@@ -19,7 +20,7 @@ struct ContactResultsToMeshcatParams {
   geometry::Rgba color{0, 1, 0, 1};
 
   /** A prefix to add to the path for all objects and transforms curated by the
-   ContactResultsToMeshcat. It can be an absolute path or relative path.
+   ContactVisualizer. It can be an absolute path or relative path.
    If relative, this `prefix` will be appended to the geometry::Meshcat `prefix`
    based on the standard path semantics in Meshcat. See @ref meshcat_path
    "Meshcat paths" for details. */
@@ -32,7 +33,7 @@ struct ContactResultsToMeshcatParams {
   bool delete_on_initialization_event{true};
 
   /** The threshold below which forces will no longer be drawn.  The
-   ContactResultsToMeshcat constructor enforces that this must be strictly
+   ContactVisualizer constructor enforces that this must be strictly
    positive; zero forces do not have a meaningful direction and cannot be
    visualized. */
   double force_threshold{0.01};
@@ -44,5 +45,6 @@ struct ContactResultsToMeshcatParams {
   double radius{0.01};
 };
 
+}  // namespace meshcat
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/meshcat/test/contact_visualizer_test.cc
+++ b/multibody/meshcat/test/contact_visualizer_test.cc
@@ -1,4 +1,4 @@
-#include "drake/multibody/plant/contact_results_to_meshcat.h"
+#include "drake/multibody/meshcat/contact_visualizer.h"
 
 #include <gtest/gtest.h>
 
@@ -11,18 +11,19 @@
 
 namespace drake {
 namespace multibody {
+namespace meshcat {
 namespace {
 
 using geometry::Meshcat;
 
 // Set up a simple plant + visualizer.  The plant has two spheres on prismatic
 // joints.
-class ContactResultsToMeshcatTest : public ::testing::Test {
+class ContactVisualizerTest : public ::testing::Test {
  protected:
-  ContactResultsToMeshcatTest() : meshcat_(std::make_shared<Meshcat>()) {}
+  ContactVisualizerTest() : meshcat_(std::make_shared<Meshcat>()) {}
 
-  void SetUpDiagram(const ContactResultsToMeshcatParams& cparams =
-                        ContactResultsToMeshcatParams()) {
+  void SetUpDiagram(const ContactVisualizerParams& cparams =
+                        ContactVisualizerParams()) {
     systems::DiagramBuilder<double> builder;
     auto [plant, scene_graph] =
         multibody::AddMultibodyPlantSceneGraph(&builder, 0.001);
@@ -43,7 +44,7 @@ class ContactResultsToMeshcatTest : public ::testing::Test {
     // The SceneGraph is needed for contact, but not referenced directly.
     unused(scene_graph);
 
-    visualizer_ = &ContactResultsToMeshcatd::AddToBuilder(&builder, plant,
+    visualizer_ = &ContactVisualizerd::AddToBuilder(&builder, plant,
                                                           meshcat_, cparams);
 
     diagram_ = builder.Build();
@@ -54,12 +55,12 @@ class ContactResultsToMeshcatTest : public ::testing::Test {
   }
 
   std::shared_ptr<Meshcat> meshcat_;
-  const ContactResultsToMeshcat<double>* visualizer_{};
+  const ContactVisualizer<double>* visualizer_{};
   std::unique_ptr<systems::Diagram<double>> diagram_{};
   std::unique_ptr<systems::Context<double>> context_{};
 };
 
-TEST_F(ContactResultsToMeshcatTest, Publish) {
+TEST_F(ContactVisualizerTest, Publish) {
   SetUpDiagram();
 
   EXPECT_FALSE(meshcat_->HasPath("contact_forces"));
@@ -67,8 +68,8 @@ TEST_F(ContactResultsToMeshcatTest, Publish) {
   EXPECT_TRUE(meshcat_->HasPath("contact_forces"));
 }
 
-TEST_F(ContactResultsToMeshcatTest, Parameters) {
-  ContactResultsToMeshcatParams params;
+TEST_F(ContactVisualizerTest, Parameters) {
+  ContactVisualizerParams params;
   params.prefix = "test_prefix";
   params.publish_period = 1 / 12.0;
   // We don't have a good way to test the other parameters without
@@ -87,7 +88,7 @@ TEST_F(ContactResultsToMeshcatTest, Parameters) {
   }
 }
 
-TEST_F(ContactResultsToMeshcatTest, Delete) {
+TEST_F(ContactVisualizerTest, Delete) {
   SetUpDiagram();
 
   diagram_->Publish(*context_);
@@ -100,10 +101,10 @@ TEST_F(ContactResultsToMeshcatTest, Delete) {
   EXPECT_TRUE(meshcat_->HasPath("contact_forces"));
 }
 
-GTEST_TEST(ContactResultsToMeshcat, PortTest) {
+GTEST_TEST(ContactVisualizer, PortTest) {
   auto meshcat = std::make_shared<Meshcat>();
   // Also tests the default constructor.
-  ContactResultsToMeshcat<double> visualizer(meshcat);
+  ContactVisualizer<double> visualizer(meshcat);
   auto context = visualizer.CreateDefaultContext();
 
   // Confirm that I can assign a ContactResults to this port.
@@ -113,7 +114,7 @@ GTEST_TEST(ContactResultsToMeshcat, PortTest) {
 
 // Test the other variant of AddToBuilder (taking the port instead of the
 // plant).
-GTEST_TEST(ContactResultsToMeshcat, AddToBuilderVariant) {
+GTEST_TEST(ContactVisualizer, AddToBuilderVariant) {
   auto meshcat = std::make_shared<Meshcat>();
   systems::DiagramBuilder<double> builder;
   auto [plant, scene_graph] =
@@ -135,7 +136,7 @@ GTEST_TEST(ContactResultsToMeshcat, AddToBuilderVariant) {
   // The SceneGraph is needed for contact, but not referenced directly.
   unused(scene_graph);
 
-  ContactResultsToMeshcatd::AddToBuilder(
+  ContactVisualizerd::AddToBuilder(
       &builder, plant.get_contact_results_output_port(), meshcat);
 
   auto diagram = builder.Build();
@@ -147,7 +148,7 @@ GTEST_TEST(ContactResultsToMeshcat, AddToBuilderVariant) {
   EXPECT_TRUE(meshcat->HasPath("contact_forces"));
 }
 
-TEST_F(ContactResultsToMeshcatTest, ScalarConversion) {
+TEST_F(ContactVisualizerTest, ScalarConversion) {
   SetUpDiagram();
 
   auto ad_diagram = diagram_->ToAutoDiffXd();
@@ -159,5 +160,6 @@ TEST_F(ContactResultsToMeshcatTest, ScalarConversion) {
 }
 
 }  // namespace
+}  // namespace meshcat
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -21,8 +21,6 @@ drake_cc_package_library(
         ":compliant_contact_manager",
         ":contact_jacobians",
         ":contact_results",
-        ":contact_results_to_meshcat",
-        ":contact_results_to_meshcat_params",
         ":coulomb_friction",
         ":discrete_contact_pair",
         ":externally_applied_spatial_force",
@@ -213,32 +211,6 @@ drake_cc_library(
         "//lcmtypes:point_pair_contact_info_for_viz",
         "//systems/framework:diagram_builder",
         "//systems/lcm:lcm_pubsub_system",
-    ],
-)
-
-drake_cc_library(
-    name = "contact_results_to_meshcat_params",
-    hdrs = ["contact_results_to_meshcat_params.h"],
-    deps = [
-        "//geometry:rgba",
-    ],
-)
-
-drake_cc_library(
-    name = "contact_results_to_meshcat",
-    srcs = ["contact_results_to_meshcat.cc"],
-    hdrs = [
-        "contact_results_to_meshcat.h",
-    ],
-    deps = [
-        ":contact_results_to_meshcat_params",
-        ":multibody_plant_core",
-        "//common:essential",
-        "//geometry:meshcat",
-        "//math:geometric_transform",
-        "//systems/framework:context",
-        "//systems/framework:diagram_builder",
-        "//systems/framework:leaf_system",
     ],
 )
 
@@ -641,19 +613,6 @@ drake_cc_googletest(
     deps = [
         ":contact_results_to_lcm",
         "//common/test_utilities:eigen_geometry_compare",
-    ],
-)
-
-drake_cc_googletest(
-    name = "contact_results_to_meshcat_test",
-    data = [
-        "//examples/manipulation_station:models",
-    ],
-    deps = [
-        ":contact_results_to_meshcat",
-        ":plant",
-        "//common/test_utilities:expect_throws_message",
-        "//multibody/parsing",
     ],
 )
 

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -215,6 +215,33 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "contact_results_to_meshcat_params",
+    hdrs = ["contact_results_to_meshcat_params.h"],
+    tags = [
+        # Don't add this deprecated library into the ":plant" package library.
+        # Doing so would cause a dependency cycle.
+        "exclude_from_package",
+    ],
+    deps = [
+        "//multibody/meshcat:contact_visualizer_params",
+    ],
+)
+
+drake_cc_library(
+    name = "contact_results_to_meshcat",
+    hdrs = ["contact_results_to_meshcat.h"],
+    tags = [
+        # Don't add this deprecated library into the ":plant" package library.
+        # Doing so would cause a dependency cycle.
+        "exclude_from_package",
+    ],
+    deps = [
+        ":contact_results_to_meshcat_params",
+        "//multibody/meshcat:contact_visualizer",
+    ],
+)
+
+drake_cc_library(
     name = "coulomb_friction",
     srcs = [
         "coulomb_friction.cc",
@@ -613,6 +640,14 @@ drake_cc_googletest(
     deps = [
         ":contact_results_to_lcm",
         "//common/test_utilities:eigen_geometry_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "contact_results_to_meshcat_test",
+    copts = ["-Wno-deprecated-declarations"],
+    deps = [
+        ":contact_results_to_meshcat",
     ],
 )
 

--- a/multibody/plant/contact_results_to_meshcat.h
+++ b/multibody/plant/contact_results_to_meshcat.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "drake/common/drake_deprecated.h"
+#include "drake/multibody/meshcat/contact_visualizer.h"
+#include "drake/multibody/plant/contact_results_to_meshcat_params.h"
+
+namespace drake {
+namespace multibody {
+
+template <typename T>
+using ContactResultsToMeshcat
+    DRAKE_DEPRECATED("2022-05-01",
+        "Spell as drake::multibody::meshcat::ContactVisualizer instead.")
+    = meshcat::ContactVisualizer<T>;
+
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/contact_results_to_meshcat_params.h
+++ b/multibody/plant/contact_results_to_meshcat_params.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "drake/common/drake_deprecated.h"
+#include "drake/multibody/meshcat/contact_visualizer_params.h"
+
+namespace drake {
+namespace multibody {
+
+using ContactResultsToMeshcatParams
+    DRAKE_DEPRECATED("2022-05-01",
+        "Spell as drake::multibody::meshcat::ContactVisualizerParams instead.")
+    = meshcat::ContactVisualizerParams;
+
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/contact_results_to_meshcat_test.cc
+++ b/multibody/plant/test/contact_results_to_meshcat_test.cc
@@ -1,0 +1,18 @@
+#include "drake/multibody/plant/contact_results_to_meshcat.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace multibody {
+namespace {
+
+// Merely confirm that the aliases can compile.
+GTEST_TEST(ContactResultToMeshcatTest, DeprecatedAliases) {
+  multibody::ContactResultsToMeshcatParams params;
+  multibody::ContactResultsToMeshcat<double>* unused{};
+  static_cast<void>(unused);
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
... and rename it to ContactVisualizer for simplicity.

We should not contaminate the MultibodyPlant library with an unconditional dependency on MeshCat.

Relates to #15968 and #16216.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16437)
<!-- Reviewable:end -->
