### PR TITLE
[doxygen] use @name rather than \name

### DIFF
--- a/geometry/render/render_engine_vtk.h
+++ b/geometry/render/render_engine_vtk.h
@@ -84,7 +84,7 @@ class ShaderCallback : public vtkCommand {
 class RenderEngineVtk : public RenderEngine,
                         private internal::ModuleInitVtkRenderingOpenGL2 {
  public:
-  /** \name Does not allow copy, move, or assignment  */
+  /** @name Does not allow copy, move, or assignment  */
   //@{
 #ifdef DRAKE_DOXYGEN_CXX
   // Note: the copy constructor operator is actually protected to serve as the


### PR DESCRIPTION
For consistency. `bazel run //doc/doxygen_cxx:build -- --serve --quick drake.geometry.render` to check, the `Does not allow copy, move, or assignment` section is still bold as expected.  File will likely be at `http://localhost:8000/doxygen_cxx/classdrake_1_1geometry_1_1render_1_1_render_engine_vtk.html` if using that command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16438)
<!-- Reviewable:end -->
