### PR TITLE
[meshcat] Factor out internal::PointContactVisualizer

### DIFF
--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -26,10 +26,10 @@ Users can navigate their browser to the hosted URL to visualize the Meshcat
 scene.  Note that, unlike many visualizers, one cannot open the visualizer until
 this server is running.
 
-In the current implementation, Meshcat methods must be called from the same
-thread where the class instance was constructed.  For example, running multiple
-simulations in parallel using the same Meshcat instance is not yet supported. We
-may generalize this in the future.
+@warning In the current implementation, Meshcat methods must be called from the
+same thread where the class instance was constructed.  For example, running
+multiple simulations in parallel using the same Meshcat instance is not yet
+supported. We may generalize this in the future.
 
 @section meshcat_path Meshcat paths and the scene tree
 

--- a/multibody/meshcat/BUILD.bazel
+++ b/multibody/meshcat/BUILD.bazel
@@ -17,6 +17,7 @@ drake_cc_package_library(
         ":contact_visualizer",
         ":contact_visualizer_params",
         ":joint_sliders",
+        ":point_contact_visualizer",
     ],
 )
 
@@ -26,6 +27,7 @@ drake_cc_library(
     hdrs = ["contact_visualizer.h"],
     deps = [
         ":contact_visualizer_params",
+        ":point_contact_visualizer",
         "//common:essential",
         "//geometry:meshcat",
         "//math:geometric_transform",
@@ -81,6 +83,18 @@ drake_cc_googletest(
         "//geometry:meshcat_visualizer",
         "//geometry/test_utilities:meshcat_environment",
         "//multibody/parsing",
+    ],
+)
+
+drake_cc_library(
+    name = "point_contact_visualizer",
+    srcs = ["point_contact_visualizer.cc"],
+    hdrs = ["point_contact_visualizer.h"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":contact_visualizer_params",
+        "//geometry:meshcat",
+        "//math:geometric_transform",
     ],
 )
 

--- a/multibody/meshcat/point_contact_visualizer.cc
+++ b/multibody/meshcat/point_contact_visualizer.cc
@@ -1,0 +1,124 @@
+#include "drake/multibody/meshcat/point_contact_visualizer.h"
+
+#include <utility>
+
+#include <fmt/format.h>
+
+#include "drake/common/unused.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace multibody {
+namespace meshcat {
+namespace internal {
+
+using Eigen::Matrix4d;
+using Eigen::Vector3d;
+using Eigen::Vector4d;
+using geometry::Cylinder;
+using geometry::Meshcat;
+using geometry::MeshcatCone;
+using math::RigidTransformd;
+using math::RotationMatrixd;
+
+PointContactVisualizer::PointContactVisualizer(
+    std::shared_ptr<Meshcat> meshcat, ContactVisualizerParams params)
+    : meshcat_(std::move(meshcat)),
+      params_(std::move(params)) {
+  DRAKE_DEMAND(meshcat_ != nullptr);
+}
+
+PointContactVisualizer::~PointContactVisualizer() = default;
+
+void PointContactVisualizer::Delete() {
+  meshcat_->Delete(params_.prefix);
+  path_visibility_status_.clear();
+}
+
+void PointContactVisualizer::Update(
+      const std::vector<PointContactVisualizerItem>& items) {
+  // Set all contacts to be inactive. They will be re-activated as we loop over
+  // `items`, below. Anything that is not re-activated will be set to invisible
+  // in a final clean-up pass at the end.
+  for (auto& [path, status] : path_visibility_status_) {
+    unused(path);
+    status.active = false;
+  }
+
+  // Process the new contacts to find the active ones.
+  for (const PointContactVisualizerItem& item : items) {
+    // Find our meshcat state for this contact pair.
+    const std::string path = fmt::format(
+        "{}/{}+{}", params_.prefix, item.body_A, item.body_B);
+    VisibilityStatus& status = FindOrAdd(path);
+
+    // Decide whether the contact should be shown.
+    const double force_norm = item.contact_force.norm();
+    status.active = (force_norm >= params_.force_threshold);
+    if (!status.active) {
+      continue;
+    }
+
+    // Update this active contact's transforms.
+    // Position the center.
+    meshcat_->SetTransform(
+        path,
+        RigidTransformd(
+            RotationMatrixd::MakeFromOneVector(item.contact_force, 2),
+            item.contact_point));
+    // Stretch the cylinder in z.
+    const double height = force_norm / params_.newtons_per_meter;
+    meshcat_->SetTransform(
+        path + "/cylinder",
+        Matrix4d(Vector4d{1, 1, height, 1}.asDiagonal()));
+    // Translate the arrowheads.
+    const double arrowhead_height = params_.radius * 2.0;
+    meshcat_->SetTransform(
+        path + "/head",
+        RigidTransformd(Vector3d{0, 0, -height - arrowhead_height}));
+    meshcat_->SetTransform(
+        path + "/tail",
+        RigidTransformd(
+            RotationMatrixd::MakeXRotation(M_PI),
+            Vector3d{0, 0, height + arrowhead_height}));
+  }
+
+  // Update meshcat visiblity to match the active status.
+  for (auto& [path, status] : path_visibility_status_) {
+    if (status.visible != status.active) {
+      meshcat_->SetProperty(path, "visible", status.active);
+      status.visible = status.active;
+    }
+  }
+}
+
+PointContactVisualizer::VisibilityStatus& PointContactVisualizer::FindOrAdd(
+    const std::string& path) {
+  auto iter = path_visibility_status_.find(path);
+  if (iter != path_visibility_status_.end()) {
+    return iter->second;
+  }
+
+  // Start with it invisible, to prevent flickering at the origin.
+  iter = path_visibility_status_.insert({path, {false, false}}).first;
+  meshcat_->SetProperty(path, "visible", false);
+
+  // Add the geometry to meshcat. The height of the cylinder is 2 and gets
+  // scaled to twice the contact force length because we draw both (equal
+  // and opposite) forces.
+  const Cylinder cylinder(params_.radius, 2.0);
+  meshcat_->SetObject(path + "/cylinder", cylinder, params_.color);
+  const double arrowhead_height = params_.radius * 2.0;
+  const double arrowhead_width = params_.radius * 2.0;
+  const MeshcatCone arrowhead(
+      arrowhead_height, arrowhead_width, arrowhead_width);
+  meshcat_->SetObject(path + "/head", arrowhead, params_.color);
+  meshcat_->SetObject(path + "/tail", arrowhead, params_.color);
+
+  return iter->second;
+}
+
+}  // namespace internal
+}  // namespace meshcat
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/meshcat/point_contact_visualizer.h
+++ b/multibody/meshcat/point_contact_visualizer.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "drake/geometry/meshcat.h"
+#include "drake/multibody/meshcat/contact_visualizer_params.h"
+
+namespace drake {
+namespace multibody {
+namespace meshcat {
+namespace internal {
+
+/* Like multibody::PointPairContactInfo, but only the visualization info. */
+struct PointContactVisualizerItem {
+  // TODO(jwnimmer-tri) Once ContactVisualizer has useful (permanent) names
+  // for its bodies, we might use a string_view here instead of a string.
+  std::string body_A;
+  std::string body_B;
+  Eigen::Vector3d contact_force;
+  Eigen::Vector3d contact_point;
+};
+
+/* PointContactVisualizer publishes point contact results in MeshCat.
+It draws double-sided arrows at the location of the contact force with length
+scaled by the magnitude of the contact force.
+
+This is unit tested via contact_visualizer_test overall; there is currently no
+point-contact-specific unit test.
+*/
+class PointContactVisualizer {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PointContactVisualizer)
+
+  /* Creates an instance of PointContactVisualizer.
+  Note that not all fields of `params` are relevant nor used. */
+  PointContactVisualizer(std::shared_ptr<geometry::Meshcat> meshcat,
+                         ContactVisualizerParams params);
+
+  ~PointContactVisualizer();
+
+  /* Update meshcat to show _only_ the given contact pairs.
+  Any previously-visualized contact points will no longer be visible. */
+  void Update(const std::vector<PointContactVisualizerItem>& items);
+
+  /* Calls geometry::Meshcat::Delete(path), with the path set to params.prefix.
+  Since this visualizer will only ever add geometry under this prefix, this will
+  remove all geometry/transforms added by the visualizer, or by a previous
+  instance of this visualizer using the same prefix. */
+  void Delete();
+
+ private:
+  /* When a contact disappears, we mark it invisible rather than deleting it
+  (to improve resposiveness). This struct tracks that state. */
+  struct VisibilityStatus {
+    /* Whether this path is currently visible in meshcat. */
+    bool visible{false};
+    /* Whether this contact was active as of the most recent Update(). */
+    bool active{false};
+  };
+
+  /* Find an entry in path_visibility_status_, or else add one and return it.
+  When an entry is added by this function, the arrow geometry is also added to
+  meshcat (with visible=false) as a side-effect. */
+  VisibilityStatus& FindOrAdd(const std::string& path);
+
+  const std::shared_ptr<geometry::Meshcat> meshcat_;
+  const ContactVisualizerParams params_;
+
+  /* Map of from a contact pair's path to its status. When the map has no key
+  for a given path, that indicates no geometry for that pair exists yet. */
+  std::unordered_map<std::string, VisibilityStatus> path_visibility_status_;
+};
+
+}  // namespace internal
+}  // namespace meshcat
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Separating the logic for meshcat geometry updates (versus the framework goop and body naming) provides for a clearer and more efficient implementation, and will also allow for reusing the geometry update code as part of meldis (towards #16436).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16440)
<!-- Reviewable:end -->
