### PR TITLE
[examples] Recommend using meldis where possible

### DIFF
--- a/examples/acrobot/README.md
+++ b/examples/acrobot/README.md
@@ -29,8 +29,7 @@ SDFormat file.
 ### `//examples/acrobot:`*run_passive*
 
 This program runs a passive acrobot with no applied torque.  It publishes
-visualization data over LCM, so if you run `//tools:drake_visualizer` it will
-appear there.
+visualization data over LCM, so if you run `meldis` it will appear there.
 
 ```
 bazel run //tools:meldis -- --open-window &
@@ -78,7 +77,7 @@ output is limited to joint positions, and an observer system with a model of
 the acrobot estimates the model state from the observed positions.  The
 controller then relies only on the estimated positions.
 
-The observer trajectory is not visible in drake_visualizer, but can be
+The observer trajectory does not show up in the visualizer, but can be
 visualized via the `call_python_client_cli` remote python interpreter.
 
 ```

--- a/examples/acrobot/run_lqr.cc
+++ b/examples/acrobot/run_lqr.cc
@@ -16,8 +16,8 @@ namespace acrobot {
 namespace {
 
 // Simple example which simulates the Acrobot, started near the upright, with an
-// LQR controller designed to stabilize the unstable fixed point.  Run
-// drake-visualizer to see the animated result.
+// LQR controller designed to stabilize the unstable fixed point.  Run meldis to
+// see the animated result.
 //
 // Note: See also examples/multibody/acrobot for an almost identical test
 // using the MultibodyPlant version of the Acrobot dynamics.

--- a/examples/acrobot/run_lqr_w_estimator.cc
+++ b/examples/acrobot/run_lqr_w_estimator.cc
@@ -23,8 +23,8 @@ namespace {
 
 // Simple example which simulates the Acrobot, started near the upright
 // configuration, with an LQR controller designed to stabilize the unstable
-// fixed point and a state estimator in the loop. Run drake-visualizer to
-// see the animated result.
+// fixed point and a state estimator in the loop. Run meldis to see the
+// animated result.
 
 DEFINE_double(simulation_sec, 5.0,
               "Number of seconds to simulate.");

--- a/examples/acrobot/run_passive.cc
+++ b/examples/acrobot/run_passive.cc
@@ -15,8 +15,8 @@ namespace examples {
 namespace acrobot {
 namespace {
 
-// Simple example which simulates the (passive) Acrobot.  Run drake-visualizer
-// to see the animated result.
+// Simple example which simulates the (passive) Acrobot.  Run meldis to see
+// the animated result.
 
 DEFINE_double(simulation_sec, 10.0,
               "Number of seconds to simulate.");

--- a/examples/acrobot/run_swing_up.cc
+++ b/examples/acrobot/run_swing_up.cc
@@ -18,7 +18,7 @@ namespace {
 
 // Simple example which simulates the Acrobot, started near its stable fixed
 // point, with a Spong swing-up controller designed to reach the unstable
-// fixed point.  Run drake-visualizer to see the animated result.
+// fixed point.  Run meldis to see the animated result.
 
 DEFINE_double(simulation_sec, 10.0,
               "Number of seconds to simulate.");

--- a/examples/allegro_hand/joint_control/README.md
+++ b/examples/allegro_hand/joint_control/README.md
@@ -10,20 +10,22 @@ that the joint-level controllers do not cause the simulation to become unstable
 in a numerical sense. Eventually, the mug may come loose, which is expected for
 this simple controller setup.
 
+Open a visualizer window
+```
+bazel run //tools:meldis -- --open-window &
+```
+
 To run the following example:
 
 ```sh
-bazel build \
-    //examples/allegro_hand/joint_control/...
-    //tools:drake_visualizer
+bazel build //examples/allegro_hand/joint_control/...
 ```
 
 Run each of the following lines in separate terminals:
 
 ```sh
-bazel-bin/tools/drake_visualizer
-
-bazel-bin/examples/allegro_hand/joint_control/allegro_single_object_simulation
+bazel-bin/examples/allegro_hand/joint_control/allegro_single_object_simulation \
+    --simulator_target_realtime_rate=1.0
 
 bazel-bin/examples/allegro_hand/joint_control/run_twisting_mug
 ```

--- a/examples/atlas/atlas_run_dynamics.cc
+++ b/examples/atlas/atlas_run_dynamics.cc
@@ -127,7 +127,7 @@ int main(int argc, char* argv[]) {
       "\nconverge quadratically to the rigid limit as the time step is "
       "\ndecreased. Thus, decrease the time step for more accurately resolved "
       "\njoint limits. "
-      "\nLaunch drake-visualizer before running this example.");
+      "\nLaunch meldis before running this example.");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   return drake::examples::atlas::do_main();
 }

--- a/examples/compass_gait/simulate.cc
+++ b/examples/compass_gait/simulate.cc
@@ -19,7 +19,7 @@ DEFINE_double(target_realtime_rate, 1.0,
               "Simulator::set_target_realtime_rate() for details.");
 
 /// Simulates the compass gait from various initial velocities (accepted as
-/// command-line arguments.  Run drake-visualizer to watch the results.
+/// command-line arguments.  Run meldis to watch the results.
 int DoMain() {
   systems::DiagramBuilder<double> builder;
   auto compass_gait = builder.AddSystem<CompassGait>();

--- a/examples/kinova_jaco_arm/README.md
+++ b/examples/kinova_jaco_arm/README.md
@@ -13,9 +13,9 @@ workspace directory.
 cd drake
 ```
 
-Ensure that you have installed the drake visualizer with
+Open a visualizer window
 ```
-bazel build //tools:drake_visualizer
+bazel run //tools:meldis -- --open-window &
 ```
 
 Build the examples in this directory:
@@ -25,13 +25,7 @@ bazel build //examples/kinova_jaco_arm/...
 
 ### Examples
 
-Before running any examples, launch the visualizer:
-```
-bazel-bin/tools/drake_visualizer
-```
-
 The following examples of a simulated jaco are present:
-
 
 ```
 bazel-bin/examples/kinova_jaco_arm/jaco_simulation

--- a/examples/kuka_iiwa_arm/README.md
+++ b/examples/kuka_iiwa_arm/README.md
@@ -9,25 +9,20 @@ The following instructions assume Drake was
 Prerequisites
 -------------
 
-Ensure that you have installed the drake visualizer with
-```
-bazel build //tools:drake_visualizer
-```
-
 All instructions assume that you are launching from the `drake`
 workspace directory.
 ```
 cd drake
 ```
 
+Open a visualizer window
+```
+bazel run //tools:meldis -- --open-window &
+```
+
 
 Basic IIWA Simulation
 ---------------------
-
-Launch the visualizer
-```
-bazel-bin/tools/drake_visualizer
-```
 
 Launch the kuka simulation
 ```

--- a/examples/multibody/acrobot/passive_simulation.cc
+++ b/examples/multibody/acrobot/passive_simulation.cc
@@ -173,7 +173,7 @@ int main(int argc, char* argv[]) {
   gflags::SetUsageMessage(
       "A simple acrobot demo using Drake's MultibodyPlant,"
       "with SceneGraph visualization. "
-      "Launch drake-visualizer before running this example.");
+      "Launch meldis before running this example.");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   return drake::examples::multibody::acrobot::do_main();
 }

--- a/examples/multibody/acrobot/run_lqr.cc
+++ b/examples/multibody/acrobot/run_lqr.cc
@@ -179,7 +179,7 @@ int main(int argc, char* argv[]) {
   gflags::SetUsageMessage(
       "A simple acrobot demo using Drake's MultibodyPlant with "
       "LQR stabilization. "
-      "Launch drake-visualizer before running this example.");
+      "Launch meldis before running this example.");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   return drake::examples::multibody::acrobot::do_main();
 }

--- a/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
+++ b/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
@@ -107,7 +107,7 @@ int main(int argc, char* argv[]) {
   gflags::SetUsageMessage(
       "A simple cart pole demo using Drake's MultibodyPlant,"
       "with SceneGraph visualization. "
-      "Launch drake-visualizer before running this example.");
+      "Launch meldis before running this example.");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   return drake::examples::multibody::cart_pole::do_main();
 }

--- a/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
+++ b/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
@@ -140,7 +140,7 @@ int main(int argc, char* argv[]) {
   gflags::SetUsageMessage(
       "A demo for a cylinder falling towards the ground using Drake's"
       "MultibodyPlant, with SceneGraph contact handling and visualization. "
-      "Launch drake-visualizer before running this example.");
+      "Launch meldis before running this example.");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   return drake::examples::multibody::cylinder_with_multicontact::do_main();
 }

--- a/examples/multibody/four_bar/passive_simulation.cc
+++ b/examples/multibody/four_bar/passive_simulation.cc
@@ -176,8 +176,8 @@ int do_main() {
 int main(int argc, char* argv[]) {
   gflags::SetUsageMessage(
       "A four bar linkage demo demonstrating the use of a linear bushing as "
-      "a way to model a kinematic loop. Launch drake-visualizer before running "
-      "this example.");
+      "a way to model a kinematic loop. Launch meldis before running this "
+      "example.");
   // Changes the default realtime rate to 1.0, so the visualization looks
   // realistic. Otherwise, it finishes so fast that we can't appreciate the
   // motion. Users can still change it on command-line, e.g. "

--- a/examples/multibody/pendulum/passive_simulation.cc
+++ b/examples/multibody/pendulum/passive_simulation.cc
@@ -168,7 +168,7 @@ int do_main() {
 int main(int argc, char* argv[]) {
   gflags::SetUsageMessage(
       "A simple pendulum demo using Drake's MultibodyPlant. "
-      "Launch drake-visualizer before running this example.");
+      "Launch meldis before running this example.");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   return drake::examples::multibody::pendulum::do_main();
 }

--- a/examples/particles/README.md
+++ b/examples/particles/README.md
@@ -16,6 +16,11 @@ bazel build examples/particles/uniformly_accelerated_particle_demo
 
 ### How do I run it?
 
+Open a visualizer window
+```
+bazel run //tools:meldis -- --open-window &
+```
+
 To run this demo, from Drake's repository root just run:
 
 ```

--- a/examples/particles/uniformly_accelerated_particle.cc
+++ b/examples/particles/uniformly_accelerated_particle.cc
@@ -92,7 +92,7 @@ UniformlyAcceleratedParticle::CreateContext(
 ///
 int main(int argc, char* argv[]) {
   gflags::SetUsageMessage("A very simple demonstration, "
-                          "make sure drake-visualizer is running!");
+                          "make sure the meldis visualizer is running!");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   // Instantiate example system.
   auto system = std::make_unique<UniformlyAcceleratedParticle>(

--- a/examples/planar_gripper/README.md
+++ b/examples/planar_gripper/README.md
@@ -12,9 +12,9 @@ workspace directory.
 cd drake
 ```
 
-Ensure that you have built the Drake visualizer with
+Open a visualizer window
 ```
-bazel build //tools:drake_visualizer
+bazel run //tools:meldis -- --open-window &
 ```
 
 Build the example in this directory
@@ -22,19 +22,12 @@ Build the example in this directory
 bazel build //examples/planar_gripper/...
 ```
 
-## Visualizer
-
-Before running the example, launch the visualizer:
-```
-bazel-bin/tools/drake_visualizer
-```
-
 ## Example
 
 ### Run Trajectory Publisher
 
 ```
-bazel-bin/examples/planar_gripper/planar_gripper_trajectory_publisher
+bazel-bin/examples/planar_gripper/run_planar_gripper_trajectory_publisher
 ```
 
 Sends desired joint positions over LCM. Requires a suitable LCM based

--- a/examples/rimless_wheel/simulate.cc
+++ b/examples/rimless_wheel/simulate.cc
@@ -25,7 +25,7 @@ DEFINE_double(target_realtime_rate, 1.0,
               "Simulator::set_target_realtime_rate() for details.");
 
 /// Simulates the rimless wheel from various initial velocities (accepted as
-/// command-line arguments.  Run drake-visualizer to watch the results.
+/// command-line arguments.  Run meldis to watch the results.
 int DoMain() {
   systems::DiagramBuilder<double> builder;
   auto rimless_wheel = builder.AddSystem<RimlessWheel>();

--- a/examples/simple_gripper/README.md
+++ b/examples/simple_gripper/README.md
@@ -40,11 +40,11 @@ Prerequisites
 -------------
 
 From your `drake` workspace directory you first need to build this example and
-the drake visualizer.
+the visualizer.
 
-Ensure that you have built drake visualizer with
+Open a visualizer window
 ```
-bazel build //tools:drake_visualizer
+bazel run //tools:meldis -- --open-window &
 ```
 
 Build this example with
@@ -55,19 +55,10 @@ bazel build //examples/simple_gripper
 Running the Example
 -------------------
 
-Launch the visualizer (optionally visualizing contact forces or not)
-
-Without contact forces visualized:
-```
-./bazel-bin/tools/drake_visualizer```
-With contact forces visualized:
-```
-./bazel-bin/tools/drake_visualizer --script multibody/rigid_body_plant/visualization/contact_viz.py
-```
-
 Launch the simulation with
 ```
-./bazel-bin/examples/simple_gripper/simple_gripper --simulation_time=10.0
+./bazel-bin/examples/simple_gripper/simple_gripper --simulation_time=10.0 \
+  --simulator_target_realtime_rate=1.0
 ```
 where for this particular invocation example we are specifying the simulation
 time in seconds as a command line option. To get a list of command line options

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -345,7 +345,7 @@ int main(int argc, char* argv[]) {
       "Demo used to exercise MultibodyPlant's contact modeling in a gripping "
       "scenario. SceneGraph is used for both visualization and contact "
       "handling. "
-      "Launch drake-visualizer before running this example.");
+      "Launch meldis before running this example.");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   return drake::examples::simple_gripper::do_main();
 }

--- a/multibody/plant/contact_results_to_lcm.h
+++ b/multibody/plant/contact_results_to_lcm.h
@@ -190,9 +190,9 @@ class ContactResultsToLcmSystem final : public systems::LeafSystem<T> {
  @anchor contact_result_vis_creation
 
  These functions extend a Diagram with the required components to publish
- contact results (as reported by MultibodyPlant) to drake_visualizer. We
- recommend using these functions instead of assembling the requisite components
- by hand.
+ contact results (as reported by MultibodyPlant) to a visualizer (either meldis
+ or drake_visualizer). We recommend using these functions instead of assembling
+ the requisite components by hand.
 
  These must be called _during_ Diagram building. Each function makes
  modifications to the diagram being constructed by `builder` including the


### PR DESCRIPTION
For now, demos of hydroelastics or demos with camera images remain pinned to drake_visualizer.  Neither `geometry::Meshcat` nor `meldis` support that data (yet).

The problem in #16454 is what motivated some of the "realtime rate = 1.0" changes to README files here.  Some of our examples were running at crazy multiples of realtime, which overloaded the visualizer.  I've already fixed the overloading issue, but I still think it doesn't make sense to run short demos at dozens of multiples of realtime -- they are difficult to watch in that case.

Towards #16216.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16452)
<!-- Reviewable:end -->
