### PR TITLE
[meldis] Use flushing and throttling to keep pace

### DIFF
--- a/bindings/pydrake/visualization/test/meldis_test.py
+++ b/bindings/pydrake/visualization/test/meldis_test.py
@@ -57,6 +57,7 @@ class TestMeldis(unittest.TestCase):
 
         # Process the load + draw; make sure the geometry exists now.
         lcm.HandleSubscriptions(timeout_millis=0)
+        dut._invoke_subscriptions()
         self.assertEqual(meshcat.HasPath(link_path), True)
 
     def test_contact_applet(self):
@@ -98,4 +99,5 @@ class TestMeldis(unittest.TestCase):
 
         # Process the load + draw; make sure the geometry exists now.
         lcm.HandleSubscriptions(timeout_millis=0)
+        dut._invoke_subscriptions()
         self.assertEqual(meshcat.HasPath(pair_path), True)


### PR DESCRIPTION
Without this, very fast simulations tend to clog up the queues and the web view falls far behind.

The [allegro joint control mug demo](https://github.com/RobotLocomotion/drake/blob/master/examples/allegro_hand/joint_control/README.md) when run at maximum speed (a realtime target rate of 0.0) is a particularly acute example.  It's what I suggest to use for local testing.  It was posting draw commands at 2000 Hz (wall clock) for me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16454)
<!-- Reviewable:end -->
