### PR TITLE
Add lightweight version of Tetrahedron/Plane intersection

### DIFF
--- a/geometry/proximity/mesh_plane_intersection.h
+++ b/geometry/proximity/mesh_plane_intersection.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
@@ -17,7 +18,40 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
-/* Intersects a tetrahedron with a plane, the resulting polygon is passed
+/* Intersects a tetrahedron with a plane; the resulting polygon is added to
+ polygon_vertices. An optional parameter, cut_edges, is provided to store,
+ for each vertex in polygon_vertices, the intersected edge in mesh_M on which
+ it lies.
+
+ The face vertices are ordered such that the normal implied by their winding
+ points in the direction of the plane's normal.
+
+ If there is no intersection, then neither polygon_vertices nor cut_edges will
+ change.
+
+ @param[in] tet_index              The index of the tetrahedron to attempt to
+                                   intersect.
+ @param[in] mesh_M                 The volume mesh containing the tetrahedron to
+                                   intersect. The vertex positions are all
+                                   measured and expressed in Frame M.
+ @param[in] plane_M                The definition of a plane measured and
+                                   expressed in Frame M.
+ @param[in, out] polygon_vertices  The list of vertices of the resulting
+                                   intersection polygon.
+ @param[in, out] cut_edges         The optional list of volume mesh edges that
+                                   contains at index *i* the edge in mesh_M
+                                   that was intersected to create vertex *i*
+                                   in polygon_vertices. It is ignored if
+                                   omitted or `nullptr` is passed in.
+ @pre `tet_index` lies in the range `[0, mesh_M.mesh().num_elements())`.
+ */
+template <typename T>
+void SliceTetrahedronWithPlane(
+    int tet_index, const VolumeMesh<double>& mesh_M, const Plane<T>& plane_M,
+    std::vector<Vector3<T>>* polygon_vertices,
+    std::vector<SortedPair<int>>* cut_edges = nullptr);
+
+/* Intersects a tetrahedron with a plane; the resulting polygon is passed
  into the provided MeshBuilder.
 
  This method constructs a mesh by a sequence of invocations. It guarantees


### PR DESCRIPTION
Related to #16040.

- This lighter version will be re-used in computing contact surfaces between
two compliant hydroelastic tetrahedral meshes (see #15545).
- For compliant mesh vs. rigid plane, the existing SliceTetWithPlane requires
MeshBuilder template and interpolates field values onto vertices of the
intersected polygon. Here, we create a lighter version without those overhead.

This PR belongs to a multi-PRs strategy (some are rebased on the others), so we'll need to merge them in the right order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16458)
<!-- Reviewable:end -->
