### PR TITLE
iris_test: Run in 12 shards (#16459)

### DIFF
--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -132,7 +132,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "iris_test",
-    shard_count = 4,
+    shard_count = 12,
     deps = [
         ":iris",
         "//common/test_utilities:eigen_matrix_compare",


### PR DESCRIPTION
Increase `iris_test` shard count from 4 to 12; 4 is not enough to avoid timeouts under memcheck.

Fixes #16459.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16461)
<!-- Reviewable:end -->
