### PR TITLE
[pydrake] Add deprecation for ContactResultsToMeshcat.AddToBuilder

### DIFF
--- a/bindings/pydrake/multibody/_plant_extra.py
+++ b/bindings/pydrake/multibody/_plant_extra.py
@@ -7,13 +7,21 @@ from pydrake.autodiffutils import AutoDiffXd as _AD
 from pydrake.common.deprecation import deprecated_callable as _deprecated
 
 
-@_deprecated("Spell as ContactVisualizerParams instead", date="2022-05-01")
+@_deprecated(
+    "pydrake.multibody.plant.ContactResultsToMeshcatParams has been renamed to"
+    " pydrake.multibody.meshcat.ContactVisualizerParams."
+    " The old name is deprecated.",
+    date="2022-05-01")
 def ContactResultsToMeshcatParams(*args, **kwargs):
     from pydrake.multibody.meshcat import ContactVisualizerParams as real
     return real(*args, **kwargs)
 
 
-@_deprecated("Spell as ContactVisualizer instead", date="2022-05-01")
+@_deprecated(
+    "pydrake.multibody.plant.ContactResultsToMeshcat has been renamed to"
+    " pydrake.multibody.meshcat.ContactVisualizer."
+    " The old name is deprecated.",
+    date="2022-05-01")
 def ContactResultsToMeshcat(T=float, *args, **kwargs):
     from pydrake.multibody.meshcat import ContactVisualizer_ as real
     return real[T](*args, **kwargs)
@@ -23,3 +31,19 @@ ContactResultsToMeshcat_ = dict((
     (float, ContactResultsToMeshcat),
     (_AD, _functools.partial(ContactResultsToMeshcat, T=_AD)),
 ))
+
+
+@_deprecated(
+    "pydrake.multibody.plant.ContactResultsToMeshcat has been renamed to"
+    " pydrake.multibody.meshcat.ContactVisualizer."
+    " The old name is deprecated.",
+    date="2022-05-01")
+def _AddToBuilder(T=float, *args, **kwargs):
+    from pydrake.multibody.meshcat import ContactVisualizer_ as real
+    return real[T].AddToBuilder(*args, **kwargs)
+
+
+ContactResultsToMeshcat.AddToBuilder = _AddToBuilder
+ContactResultsToMeshcat_[float].AddToBuilder = _AddToBuilder
+ContactResultsToMeshcat_[_AD].AddToBuilder = _functools.partial(
+    _AddToBuilder, T=_AD)

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -61,6 +61,7 @@ from pydrake.multibody.plant import (
     ContactResults_,
     ContactResultsToLcmSystem,
     ContactResultsToMeshcatParams,
+    ContactResultsToMeshcat,
     ContactResultsToMeshcat_,
     CoulombFriction_,
     ExternallyAppliedSpatialForce_,
@@ -2273,8 +2274,25 @@ class TestPlant(unittest.TestCase):
         dut.Equal(surface=dut)
         copy.copy(dut)
 
+    def test_deprecated_contact_results_to_meshcat_default_scalar(self):
+        """Checks ContactResultsToMeshcat for deprecation."""
+        meshcat = Meshcat()
+        with catch_drake_warnings(expected_count=1):
+            params = ContactResultsToMeshcatParams()
+        self.assertIsNotNone(params)
+        with catch_drake_warnings(expected_count=1):
+            vis = ContactResultsToMeshcat(meshcat=meshcat, params=params)
+        vis.Delete()
+        builder = DiagramBuilder_[float]()
+        plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.01)
+        plant.Finalize()
+        with catch_drake_warnings(expected_count=1):
+            ContactResultsToMeshcat.AddToBuilder(
+                builder=builder, plant=plant, meshcat=meshcat, params=params)
+
     @numpy_compare.check_nonsymbolic_types
-    def test_deprecated_contact_results_to_meshcat(self, T):
+    def test_deprecated_contact_results_to_meshcat_specific_scalar(self, T):
+        """Checks ContactResultsToMeshcat_[T] for deprecation."""
         meshcat = Meshcat()
         with catch_drake_warnings(expected_count=1):
             params = ContactResultsToMeshcatParams()
@@ -2282,6 +2300,12 @@ class TestPlant(unittest.TestCase):
         with catch_drake_warnings(expected_count=1):
             vis = ContactResultsToMeshcat_[T](meshcat=meshcat, params=params)
         vis.Delete()
+        builder = DiagramBuilder_[T]()
+        plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.01)
+        plant.Finalize()
+        with catch_drake_warnings(expected_count=1):
+            ContactResultsToMeshcat_[T].AddToBuilder(
+                builder=builder, plant=plant, meshcat=meshcat, params=params)
 
     def test_free_base_bodies(self):
         plant = MultibodyPlant_[float](time_step=0.01)


### PR DESCRIPTION
Closes #16464.

With manual testing, I've also confirmed that the original `plant_test.py` at 2c567f482b096c6c002bd49a4caa84a034fbe8e3 (prior to any renaming changes) passes, modulo the new warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16465)
<!-- Reviewable:end -->
