### PR TITLE
Use std::vector<Variable> instead of VectorX<Variable> for decision_variables_ and indeterminates_ in MathematicalProgram

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -1476,13 +1476,15 @@ for every column of ``prog_var_vals``. )""")
           py::arg("bindings"), py::arg("tol") = 1e-6,
           doc.MathematicalProgram.CheckSatisfiedAtInitialGuess.doc_vector)
       .def("indeterminates", &MathematicalProgram::indeterminates,
-          doc.MathematicalProgram.indeterminates.doc)
+          // dtype = object arrays must be copied, and cannot be referenced.
+          py_rvp::copy, doc.MathematicalProgram.indeterminates.doc)
       .def("indeterminate", &MathematicalProgram::indeterminate, py::arg("i"),
           doc.MathematicalProgram.indeterminate.doc)
       .def("indeterminates_index", &MathematicalProgram::indeterminates_index,
           doc.MathematicalProgram.indeterminates_index.doc)
       .def("decision_variables", &MathematicalProgram::decision_variables,
-          doc.MathematicalProgram.decision_variables.doc)
+          // dtype = object arrays must be copied, and cannot be  referenced.
+          py_rvp::copy, doc.MathematicalProgram.decision_variables.doc)
       .def("decision_variable", &MathematicalProgram::decision_variable,
           py::arg("i"), doc.MathematicalProgram.decision_variable.doc)
       .def("decision_variable_index",


### PR DESCRIPTION
Resolve #16470 

I have a simple test
```cc
#include "drake/common/symbolic.h"
#include "drake/solvers/mathematical_program.h"

#include <vector>
#include <iostream>
#include <chrono>

namespace drake {
namespace solvers {
int DoMain() {
  solvers::MathematicalProgram prog;
  const int count = 1000;
  auto start1 = std::chrono::high_resolution_clock::now();
  for (int i = 0; i < count; ++i) {
    prog.NewContinuousVariables(100);
  }
  auto end1 = std::chrono::high_resolution_clock::now();
  std::cout << "takes " << std::chrono::duration_cast<std::chrono::duration<double>>(end1 - start1).count() << " seconds\n";

  return 0;
}
}  // namespace solvers
}  // namespace drake

int main() {
  drake::solvers::DoMain();
}
```
to add new variables. Before this PR it takes 3.7s to run, with this PR it takes 0.054s, so there is 70x speedup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16472)
<!-- Reviewable:end -->
