### PR TITLE
[meshcat] Remove accidental support for Expression

### DIFF
--- a/bindings/pydrake/multibody/meshcat_py.cc
+++ b/bindings/pydrake/multibody/meshcat_py.cc
@@ -99,7 +99,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
   constexpr auto& doc = pydrake_doc.drake.multibody.meshcat;
 
   // ContactVisualizer
-  if constexpr (!std::is_same_v<T, symbolic::Expression>) {
+  {
     using Class = ContactVisualizer<T>;
     constexpr auto& cls_doc = doc.ContactVisualizer;
     auto cls = DefineTemplateClassWithDefault<Class, systems::LeafSystem<T>>(

--- a/multibody/meshcat/contact_visualizer.h
+++ b/multibody/meshcat/contact_visualizer.h
@@ -132,6 +132,14 @@ using ContactVisualizerd = ContactVisualizer<double>;
 
 }  // namespace meshcat
 }  // namespace multibody
+
+namespace systems {
+namespace scalar_conversion {
+template <> struct Traits<drake::multibody::meshcat::ContactVisualizer>
+    : public NonSymbolicTraits {};
+}  // namespace scalar_conversion
+}  // namespace systems
+
 }  // namespace drake
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(


### PR DESCRIPTION
The documentation and template definitions said "nonsymbolic only", but the scalar conversion still accidentally allowed for Expression. Add the opt-out for Expression to the header.

Relatedly, the pydrake bindings had an if-check for Expression, but it was dead code (due to the caller's list of types) so is also removed here.

Towards #16476.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16475)
<!-- Reviewable:end -->
