### PR TITLE
Adds missing collision filters to Atlas model.

### DIFF
--- a/examples/atlas/urdf/atlas_convex_hull.urdf
+++ b/examples/atlas/urdf/atlas_convex_hull.urdf
@@ -1023,6 +1023,12 @@
     <drake:member link="l_hand"/>
     <drake:ignored_collision_filter_group name="l_arm"/>
   </drake:collision_filter_group>
+  <drake:collision_filter_group name="hokuyo_filter">
+    <drake:member link="hokuyo_link"/>
+    <drake:member link="utorso"/>
+    <drake:member link="head"/>
+    <drake:ignored_collision_filter_group name="hokuyo_filter"/>
+  </drake:collision_filter_group>
   <link name="head">
     <inertial>
       <origin rpy="0 0 0" xyz="-0.075493 3.3383E-05 0.02774"/>


### PR DESCRIPTION
Updates Atlas model to avoid spurious collisions with the Hokuyo link.

In particular the "head" vs. "hokuyo_link" collision is annoying because those two links are effectively welded to each other (through a long chain of welded links). This leads to the unnecessary computation of a zero Jacobian which in some cases might cause modeling problems in sim.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16488)
<!-- Reviewable:end -->
