### PR TITLE
[plant] Add internal::GeometryNames utility

### DIFF
--- a/multibody/models/box.urdf
+++ b/multibody/models/box.urdf
@@ -12,7 +12,7 @@
         <box size=".1 .2 .3"/>
       </geometry>
     </visual>
-    <collision>
+    <collision name="box">
       <geometry>
         <box size=".1 .2 .3"/>
       </geometry>

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -27,6 +27,7 @@ drake_cc_package_library(
         ":hydroelastic_contact_info",
         ":hydroelastic_quadrature_point_data",
         ":hydroelastic_traction",
+        ":internal_geometry_names",
         ":multibody_plant_config",
         ":multibody_plant_config_functions",
         ":multibody_plant_core",
@@ -238,6 +239,17 @@ drake_cc_library(
     deps = [
         ":contact_results_to_meshcat_params",
         "//multibody/meshcat:contact_visualizer",
+    ],
+)
+
+drake_cc_library(
+    name = "internal_geometry_names",
+    srcs = ["internal_geometry_names.cc"],
+    hdrs = ["internal_geometry_names.h"],
+    deps = [
+        ":multibody_plant_core",
+        "//common:default_scalars",
+        "//geometry:scene_graph_inspector",
     ],
 )
 
@@ -682,6 +694,18 @@ drake_cc_googletest(
         "//multibody/benchmarks/inclined_plane",
         "//systems/analysis:radau_integrator",
         "//systems/analysis:simulator",
+    ],
+)
+
+drake_cc_googletest(
+    name = "internal_geometry_names_test",
+    data = [
+        "//examples/manipulation_station:models",
+        "//multibody:models",
+    ],
+    deps = [
+        ":internal_geometry_names",
+        "//multibody/parsing",
     ],
 )
 

--- a/multibody/plant/internal_geometry_names.cc
+++ b/multibody/plant/internal_geometry_names.cc
@@ -1,0 +1,126 @@
+#include "drake/multibody/plant/internal_geometry_names.h"
+
+#include <stdexcept>
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+using geometry::GeometryId;
+using geometry::SceneGraphInspector;
+
+GeometryNames::GeometryNames() = default;
+
+GeometryNames::~GeometryNames() = default;
+
+namespace {
+
+// There's an anonymous helper function in multibody_plant.cc ("GetScopedName")
+// that rewrites the user-provided geometry names by prefixing them with the
+// model instance name, such that the names reported by GeometryInspector are
+// a pack of lies. This function undoes that rewrite, so that we can report
+// the actual names that the user specified. Hopefully the MbP is repaired in
+// the future to stop screwing up the geometry names.
+template <typename T>
+std::string_view UndoGetScopedName(
+    const MultibodyPlant<T>& plant, ModelInstanceIndex model,
+    std::string_view geometry_name) {
+  if (model != world_model_instance() && model != default_model_instance()) {
+    const std::string_view prefix = plant.GetModelInstanceName(model);
+    if (geometry_name.substr(0, prefix.size()) == prefix) {
+      const std::string_view remaining = geometry_name.substr(prefix.size());
+      if (remaining.substr(0, 2) == "::") {
+        return remaining.substr(2);
+      }
+    }
+  }
+  return geometry_name;
+}
+
+/* Resets the `entries` output parameter to reflect the collision geometries
+from the given plant; use `lookup` to obtain the geometry_name strings. */
+template <typename T>
+void ResetHelper(
+    const MultibodyPlant<T>& plant,
+    const std::function<std::optional<std::string_view>(GeometryId)>& lookup,
+    std::unordered_map<GeometryId, GeometryNames::Entry>* entries) {
+  DRAKE_DEMAND(entries != nullptr);
+  DRAKE_THROW_UNLESS(plant.is_finalized());
+  entries->clear();
+  const int num_bodies = plant.num_bodies();
+  for (BodyIndex i{0}; i < num_bodies; ++i) {
+    const Body<T>& body = plant.get_body(i);
+    const auto& geometry_ids = plant.GetCollisionGeometriesForBody(body);
+    if (geometry_ids.empty()) {
+      continue;
+    }
+
+    // Create an Entry with the body's details (no geometry details yet).
+    GeometryNames::Entry prototype;
+    prototype.model_instance_name =
+        plant.GetModelInstanceName(body.model_instance());
+    prototype.body_name = body.name();
+    prototype.body_name_is_unique_within_plant =
+        (plant.NumBodiesWithName(body.name()) == 1);
+    prototype.is_sole_geometry_within_body =
+        (geometry_ids.size() == 1);
+
+    // Add an Entry for each collision geometry.
+    for (const auto& geometry_id : geometry_ids) {
+      GeometryNames::Entry entry = prototype;
+      std::optional<std::string_view> geometry_name = lookup(geometry_id);
+      if (geometry_name.has_value()) {
+        geometry_name = UndoGetScopedName(
+            plant, body.model_instance(), *geometry_name);
+      }
+      entry.geometry_name = geometry_name;
+      entries->insert({geometry_id, entry});
+    }
+  }
+}
+
+}  // namespace
+
+template <typename T>
+void GeometryNames::ResetFull(
+    const MultibodyPlant<T>& plant,
+    const SceneGraphInspector<T>& inspector) {
+  DRAKE_THROW_UNLESS(plant.is_finalized());
+  std::function lookup = [&inspector](GeometryId id)
+      -> std::optional<std::string_view> {
+    return inspector.GetName(id);
+  };
+  ResetHelper(plant, lookup, &entries_);
+}
+
+template <typename T>
+void GeometryNames::ResetBasic(const MultibodyPlant<T>& plant) {
+  DRAKE_THROW_UNLESS(plant.is_finalized());
+  std::function lookup = [](GeometryId)
+      -> std::optional<std::string_view> {
+    return std::nullopt;
+  };
+  ResetHelper(plant, lookup, &entries_);
+}
+
+const GeometryNames::Entry& GeometryNames::Find(GeometryId id) const {
+  auto iter = entries_.find(id);
+  if (iter != entries_.end()) {
+    return iter->second;
+  }
+  throw std::logic_error("GeometryNames::Find could not find the given id");
+}
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    &GeometryNames::ResetFull<T>
+))
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &GeometryNames::ResetBasic<T>
+))
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/internal_geometry_names.h
+++ b/multibody/plant/internal_geometry_names.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/scene_graph_inspector.h"
+#include "drake/multibody/plant/multibody_plant.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+/* Maintains a mapping from GeometryId to its various names, intended as an
+aid for visualization tools. */
+class GeometryNames {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeometryNames);
+
+  /* Stores the relevant three names associated with a body in contact:
+  its model instance name, body name, and geometry name. Taken together,
+  they will uniquely specify any piece of geometry.
+
+  A model instance name is always unique within a plant.
+  A body name is always unique within its model instance.
+  A geometry name is always unique within its body.
+
+  This struct also includes information that allows visualizers to streamline
+  their display (the two bools), so they can omit redundant qualifiers.
+  */
+  struct Entry {
+    std::string_view model_instance_name;
+    std::string_view body_name;
+    std::optional<std::string_view> geometry_name;
+
+    /* Whether the body_name is globally unique within all bodies in the plant,
+    across all model instances. If so, a visualizer could choose to omit the
+    model instance name for brevity. */
+    bool body_name_is_unique_within_plant{};
+
+    /* Whether this geometry is the one and only geometry added to its body.
+    If so, a visualizer could choose to omit the geometry name for brevity. */
+    bool is_sole_geometry_within_body{};
+
+    // Note that it would be easy to add the ModelInstanceIndex, BodyIndex, and
+    // GeometryId to this struct if we ever needed them.
+  };
+
+  /* Creates an empty mapping. */
+  GeometryNames();
+
+  ~GeometryNames();
+
+  /* Clears this object and re-populates it using the given plant and
+  inspector. This is the preferred form of reset (vs ResetBasic).
+  @pre plant.is_finalized().
+  @tparam_nonsymbolic_scalar */
+  template <typename T>
+  void ResetFull(const MultibodyPlant<T>& plant,
+                 const geometry::SceneGraphInspector<T>& inspector);
+
+  /* Clears this object and re-populates using the given plant.
+  This overload sets the geometry_name fields to nullopt.
+  This is NOT the preferred form; use ResetFull if you can do so.
+  @pre plant.is_finalized().
+  @tparam_default_scalar */
+  template <typename T>
+  void ResetBasic(const MultibodyPlant<T>& plant);
+
+  /* Returns the entry associated with the given ID.
+  The return value is no longer valid after any call to a reset function. */
+  const Entry& Find(geometry::GeometryId) const;
+
+  /* Returns the full mapping.
+  The return value is no longer valid after any call to a reset function. */
+  const std::unordered_map<geometry::GeometryId, Entry>& entries() const {
+    return entries_;
+  }
+
+ private:
+  std::unordered_map<geometry::GeometryId, Entry> entries_;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -242,7 +242,8 @@ struct JointLimitsPenaltyParametersEstimator {
 namespace {
 
 // Hack to fully qualify frame names, pending resolution of #9128. Used by
-// geometry registration routines.
+// geometry registration routines. When this hack is removed, also undo the
+// de-hacking step within internal_geometry_names.cc.
 template <typename T>
 std::string GetScopedName(
     const MultibodyPlant<T>& plant,

--- a/multibody/plant/test/internal_geometry_names_test.cc
+++ b/multibody/plant/test/internal_geometry_names_test.cc
@@ -1,0 +1,187 @@
+#include "drake/multibody/plant/internal_geometry_names.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/multibody/parsing/parser.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace {
+
+using geometry::GeometryId;
+using geometry::SceneGraph;
+using geometry::SceneGraphInspector;
+using systems::Context;
+using systems::Diagram;
+using systems::DiagramBuilder;
+
+using Entry = GeometryNames::Entry;
+
+class GeometryNamesTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    DiagramBuilder<double> builder;
+    std::tie(plant_, scene_graph_) = AddMultibodyPlantSceneGraph(
+        &builder, 0.001);
+    Parser parser(plant_);
+
+    // A single model, single body, single geometry.
+    const std::string box = FindResourceOrThrow(
+        "drake/multibody/models/box.urdf");
+    parser.AddModelFromFile(box);
+
+    // A single model, single body, multiple geometries.
+    const std::string bin = FindResourceOrThrow(
+        "drake/examples/manipulation_station/models/bin.sdf");
+    parser.AddModelFromFile(bin);
+
+    // Two identical models (each one has a single body, single geometry).
+    const std::string sphere = FindResourceOrThrow(
+        "drake/examples/manipulation_station/models/sphere.sdf");
+    parser.AddModelFromFile(sphere, "sphere1");
+    parser.AddModelFromFile(sphere, "sphere2");
+
+    // Build everything.
+    plant_->Finalize();
+    diagram_ = builder.Build();
+  }
+
+  const MultibodyPlant<double>& plant() const {
+    return *plant_;
+  }
+
+  const SceneGraphInspector<double>& inspector() const {
+    return scene_graph_->model_inspector();
+  }
+
+  const std::vector<GeometryId>& GetGeometryIds(
+      std::string_view body_name,
+      std::optional<std::string_view> model_name = {}) const {
+    const Body<double>* body{};
+    if (model_name.has_value()) {
+      ModelInstanceIndex index = plant_->GetModelInstanceByName(*model_name);
+      body = &(plant_->GetBodyByName(body_name, index));
+    } else {
+      body = &(plant_->GetBodyByName(body_name));
+    }
+    return plant_->GetCollisionGeometriesForBody(*body);
+  }
+
+  GeometryId GetSoleGeometryId(
+      std::string_view body_name,
+      std::optional<std::string_view> model_name = {}) const {
+    const auto& ids = GetGeometryIds(body_name, model_name);
+    DRAKE_DEMAND(ids.size() == 1);
+    return ids.front();
+  }
+
+ private:
+  std::unique_ptr<Diagram<double>> diagram_;
+  MultibodyPlant<double>* plant_{};
+  SceneGraph<double>* scene_graph_{};
+};
+
+TEST_F(GeometryNamesTest, ResetBasic) {
+  GeometryNames dut;
+  EXPECT_EQ(dut.entries().size(), 0);
+
+  dut.ResetBasic(plant());
+  const size_t num_entries = dut.entries().size();
+  EXPECT_GT(num_entries, 0);
+
+  dut.ResetBasic(plant());
+  EXPECT_EQ(dut.entries().size(), num_entries);
+}
+
+TEST_F(GeometryNamesTest, ResetFull) {
+  GeometryNames dut;
+  EXPECT_EQ(dut.entries().size(), 0);
+
+  dut.ResetFull(plant(), inspector());
+  const size_t num_entries = dut.entries().size();
+  EXPECT_GT(num_entries, 0);
+
+  dut.ResetFull(plant(), inspector());
+  EXPECT_EQ(dut.entries().size(), num_entries);
+}
+
+TEST_F(GeometryNamesTest, BasicBox) {
+  GeometryNames dut;
+  dut.ResetBasic(plant());
+  const GeometryId id = GetSoleGeometryId("box");
+  const Entry& entry = dut.Find(id);
+  EXPECT_EQ(entry.model_instance_name, "box");
+  EXPECT_EQ(entry.body_name, "box");
+  EXPECT_EQ(entry.geometry_name, std::nullopt);
+  EXPECT_EQ(entry.body_name_is_unique_within_plant, true);
+  EXPECT_EQ(entry.is_sole_geometry_within_body, true);
+}
+
+TEST_F(GeometryNamesTest, FullBox) {
+  GeometryNames dut;
+  dut.ResetFull(plant(), inspector());
+  const GeometryId id = GetSoleGeometryId("box");
+  const Entry& entry = dut.Find(id);
+  EXPECT_EQ(entry.model_instance_name, "box");
+  EXPECT_EQ(entry.body_name, "box");
+  EXPECT_EQ(entry.geometry_name, "box");
+  EXPECT_EQ(entry.body_name_is_unique_within_plant, true);
+  EXPECT_EQ(entry.is_sole_geometry_within_body, true);
+}
+
+TEST_F(GeometryNamesTest, BasicSphere1) {
+  GeometryNames dut;
+  dut.ResetBasic(plant());
+  const GeometryId id = GetSoleGeometryId("base_link", "sphere1");
+  const Entry& entry = dut.Find(id);
+  EXPECT_EQ(entry.model_instance_name, "sphere1");
+  EXPECT_EQ(entry.body_name, "base_link");
+  EXPECT_EQ(entry.geometry_name, std::nullopt);
+  EXPECT_EQ(entry.body_name_is_unique_within_plant, false);
+  EXPECT_EQ(entry.is_sole_geometry_within_body, true);
+}
+
+TEST_F(GeometryNamesTest, FullSphere1) {
+  GeometryNames dut;
+  dut.ResetFull(plant(), inspector());
+  const GeometryId id = GetSoleGeometryId("base_link", "sphere1");
+  const Entry& entry = dut.Find(id);
+  EXPECT_EQ(entry.model_instance_name, "sphere1");
+  EXPECT_EQ(entry.body_name, "base_link");
+  EXPECT_EQ(entry.geometry_name, "sphere_collision");
+  EXPECT_EQ(entry.body_name_is_unique_within_plant, false);
+  EXPECT_EQ(entry.is_sole_geometry_within_body, true);
+}
+
+TEST_F(GeometryNamesTest, BasicBin) {
+  GeometryNames dut;
+  dut.ResetBasic(plant());
+  const auto& ids = GetGeometryIds("bin_base");
+  const GeometryId id = ids.front();
+  const Entry& entry = dut.Find(id);
+  EXPECT_EQ(entry.model_instance_name, "bin_model");
+  EXPECT_EQ(entry.body_name, "bin_base");
+  EXPECT_EQ(entry.geometry_name, std::nullopt);
+  EXPECT_EQ(entry.body_name_is_unique_within_plant, true);
+  EXPECT_EQ(entry.is_sole_geometry_within_body, false);
+}
+
+TEST_F(GeometryNamesTest, FullBin) {
+  GeometryNames dut;
+  dut.ResetFull(plant(), inspector());
+  const auto& ids = GetGeometryIds("bin_base");
+  const GeometryId id = ids.front();
+  const Entry& entry = dut.Find(id);
+  EXPECT_EQ(entry.model_instance_name, "bin_model");
+  EXPECT_EQ(entry.body_name, "bin_base");
+  EXPECT_EQ(entry.geometry_name, "front");
+  EXPECT_EQ(entry.body_name_is_unique_within_plant, true);
+  EXPECT_EQ(entry.is_sole_geometry_within_body, false);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Towards #16476.

This takes the information currently retrieved within `ContactResultsToLcmSystem` and changes it into a reusable abstraction.

Future PRs will port the `meshcat::ContactVisualizer` to use this (resolving a TODO) and refactor the `ContactResultsToLcmSystem` to use this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16489)
<!-- Reviewable:end -->
