### PR TITLE
[multibody] Document default collision filtering

### DIFF
--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -804,7 +804,14 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
    Simply acquiring an instance of CollisionFilterManager will advance the
    @ref scene_graph_versioning "proximity version" for the related geometry
-   data (model or context).  */
+   data (model or context).
+
+   @note %SceneGraph does not track topology or semantic information of models,
+   so decisions about *what* to filter belong in software layers that have the
+   necessary information. For example, some automatic filtering is done in
+   @ref mbp_finalize_stage "MultibodyPlant::Finalize()". Applications may
+   need to add more filtering or adjust filters during simulation.
+  */
   //@{
 
   /** Returns the collision filter manager for this %SceneGraph instance's

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -509,11 +509,15 @@ See Drake issue #12942 for more discussion.
 
 Once the user is done adding modeling elements and registering geometry, a
 call to Finalize() must be performed. This call will:
-- Build the underlying MultibodyTree topology, see MultibodyTree::Finalize()
-  for details,
+- Build the underlying tree structure of the multibody model,
 - declare the plant's state,
 - declare the plant's input and output ports,
-- declare input and output ports for communication with a SceneGraph.
+- declare collision filters to ignore collisions:
+  - between bodies connected by a joint,
+  - between bodies welded (directly or transitively) to the world.
+
+<!-- TODO(#16422): ignore collisions within all groups of welded-together
+     bodies -->
 
 <!-- TODO(amcastro-tri): Consider making the actual geometry registration
      with GS AFTER Finalize() so that we can tell if there are any bodies
@@ -1153,15 +1157,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// No more multibody elements can be added after a call to Finalize().
   ///
   /// At Finalize(), state and input/output ports for `this` plant are declared.
-  /// If `this` plant registered geometry with a SceneGraph, input and
-  /// output ports to enable communication with that SceneGraph are declared
-  /// as well.
   ///
-  /// If geometry has been registered on a SceneGraph instance, that instance
-  /// must be provided to the Finalize() method so that any geometric
-  /// implications of the finalization process can be appropriately handled.
+  /// For a full account of the effects of Finalize(), see
+  /// @ref mbp_finalize_stage "Finalize() stage".
   ///
-  /// @see is_finalized().
+  /// @see is_finalized(), @ref mbp_finalize_stage "Finalize() stage".
   ///
   /// @throws std::exception if the %MultibodyPlant has already been
   /// finalized.


### PR DESCRIPTION
Closes: #13672
Relevant to: #16422

Write down what we do now, add a clarification and cross-reference to the
SceneGraph docs, and delete some obsolete text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16490)
<!-- Reviewable:end -->
