### PR TITLE
[WIP] Migrate FEM code out of dev

### DIFF
--- a/multibody/fem/BUILD.bazel
+++ b/multibody/fem/BUILD.bazel
@@ -15,14 +15,49 @@ drake_cc_package_library(
     name = "fem",
     visibility = ["//multibody/fixed_fem:__subpackages__"],
     deps = [
+        ":acceleration_newmark_scheme",
         ":calc_lame_parameters",
         ":constitutive_model",
+        ":corotated_model",
+        ":corotated_model_data",
+        ":damping_model",
         ":deformation_gradient_data",
+        ":dirichlet_boundary_condition",
+        ":discrete_time_integrator",
+        ":element_cache_entry",
+        ":fem_element",
+        ":fem_indexes",
+        ":fem_model",
+        ":fem_solver",
+        ":fem_state",
         ":isoparametric_element",
+        ":linear_constitutive_model",
         ":linear_constitutive_model_data",
         ":linear_simplex_element",
+        ":matrix_utilities",
+        ":mesh_utilities",
+        ":newmark_scheme",
+        ":petsc_symmetric_block_sparse_matrix",
         ":quadrature",
+        ":schur_complement",
         ":simplex_gaussian_quadrature",
+        ":velocity_newmark_scheme",
+        ":volumetric_element",
+        ":volumetric_model",
+    ],
+)
+
+drake_cc_library(
+    name = "acceleration_newmark_scheme",
+    srcs = [
+        "acceleration_newmark_scheme.cc",
+    ],
+    hdrs = [
+        "acceleration_newmark_scheme.h",
+    ],
+    deps = [
+        ":newmark_scheme",
+        "//common:default_scalars",
     ],
 )
 
@@ -51,6 +86,47 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "corotated_model",
+    srcs = [
+        "corotated_model.cc",
+    ],
+    hdrs = [
+        "corotated_model.h",
+    ],
+    deps = [
+        ":calc_lame_parameters",
+        ":constitutive_model",
+        ":corotated_model_data",
+        ":matrix_utilities",
+        "//common:autodiff",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "corotated_model_data",
+    hdrs = [
+        "corotated_model_data.h",
+    ],
+    deps = [
+        ":deformation_gradient_data",
+        ":matrix_utilities",
+        "//common:autodiff",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "damping_model",
+    hdrs = [
+        "damping_model.h",
+    ],
+    deps = [
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "deformation_gradient_data",
     srcs = [
         "deformation_gradient_data.cc",
@@ -65,6 +141,122 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "dirichlet_boundary_condition",
+    srcs = [
+        "dirichlet_boundary_condition.cc",
+    ],
+    hdrs = [
+        "dirichlet_boundary_condition.h",
+    ],
+    deps = [
+        ":fem_indexes",
+        ":fem_state",
+        ":petsc_symmetric_block_sparse_matrix",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "discrete_time_integrator",
+    srcs = [
+        "discrete_time_integrator.cc",
+    ],
+    hdrs = [
+        "discrete_time_integrator.h",
+    ],
+    deps = [
+        ":fem_state",
+        "//common:unused",
+    ],
+)
+
+drake_cc_library(
+    name = "element_cache_entry",
+    hdrs = [
+        "element_cache_entry.h",
+    ],
+    deps = [
+        ":fem_indexes",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "fem_element",
+    hdrs = [
+        "fem_element.h",
+    ],
+    deps = [
+        ":damping_model",
+        ":fem_state",
+        "//common:essential",
+        "//multibody/fem:constitutive_model",
+    ],
+)
+
+drake_cc_library(
+    name = "fem_indexes",
+    hdrs = [
+        "fem_indexes.h",
+    ],
+    deps = [
+        "//common:essential",
+        "//common:type_safe_index",
+    ],
+)
+
+drake_cc_library(
+    name = "fem_model",
+    srcs = [
+        "fem_model.cc",
+    ],
+    hdrs = [
+        "fem_model.h",
+        "fem_model_impl.h",
+    ],
+    deps = [
+        ":dirichlet_boundary_condition",
+        ":discrete_time_integrator",
+        ":fem_element",
+        ":fem_indexes",
+        ":fem_state",
+        ":petsc_symmetric_block_sparse_matrix",
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "fem_solver",
+    srcs = [
+        "fem_solver.cc",
+    ],
+    hdrs = [
+        "fem_solver.h",
+    ],
+    deps = [
+        ":discrete_time_integrator",
+        ":fem_model",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "fem_state",
+    srcs = [
+        "fem_state.cc",
+    ],
+    hdrs = [
+        "fem_state.h",
+        "fem_state_impl.h",
+    ],
+    deps = [
+        ":element_cache_entry",
+        "//common:default_scalars",
+    ],
+)
+
+drake_cc_library(
     name = "isoparametric_element",
     srcs = [
         "isoparametric_element.cc",
@@ -73,6 +265,23 @@ drake_cc_library(
         "isoparametric_element.h",
     ],
     deps = [
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "linear_constitutive_model",
+    srcs = [
+        "linear_constitutive_model.cc",
+    ],
+    hdrs = [
+        "linear_constitutive_model.h",
+    ],
+    deps = [
+        ":calc_lame_parameters",
+        ":constitutive_model",
+        ":linear_constitutive_model_data",
+        "//common:autodiff",
         "//common:essential",
     ],
 )
@@ -107,12 +316,83 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "matrix_utilities",
+    srcs = [
+        "matrix_utilities.cc",
+    ],
+    hdrs = [
+        "matrix_utilities.h",
+    ],
+    deps = [
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "mesh_utilities",
+    srcs = [
+        "mesh_utilities.cc",
+    ],
+    hdrs = [
+        "mesh_utilities.h",
+    ],
+    deps = [
+        "//common:default_scalars",
+        "//common:essential",
+        "//geometry:shape_specification",
+        "//geometry/proximity:make_box_mesh",
+        "//geometry/proximity:volume_mesh",
+    ],
+)
+
+drake_cc_library(
+    name = "newmark_scheme",
+    hdrs = [
+        "newmark_scheme.h",
+    ],
+    deps = [
+        ":discrete_time_integrator",
+    ],
+)
+
+drake_cc_library(
+    name = "petsc_symmetric_block_sparse_matrix",
+    srcs = [
+        "petsc_symmetric_block_sparse_matrix.cc",
+    ],
+    hdrs = [
+        "petsc_symmetric_block_sparse_matrix.h",
+    ],
+    deps = [
+        ":schur_complement",
+        "//common:essential",
+        "//common:unused",
+        "@petsc",
+    ],
+)
+
+drake_cc_library(
     name = "quadrature",
     srcs = [
         "quadrature.cc",
     ],
     hdrs = [
         "quadrature.h",
+    ],
+    deps = [
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "schur_complement",
+    srcs = [
+        "schur_complement.cc",
+    ],
+    hdrs = [
+        "schur_complement.h",
     ],
     deps = [
         "//common:default_scalars",
@@ -133,11 +413,96 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "velocity_newmark_scheme",
+    srcs = [
+        "velocity_newmark_scheme.cc",
+    ],
+    hdrs = [
+        "velocity_newmark_scheme.h",
+    ],
+    deps = [
+        ":newmark_scheme",
+        "//common:default_scalars",
+    ],
+)
+
+drake_cc_library(
+    name = "volumetric_element",
+    srcs = [
+        "volumetric_element.cc",
+    ],
+    hdrs = [
+        "volumetric_element.h",
+    ],
+    deps = [
+        ":fem_element",
+        "//common:essential",
+        "//common:unused",
+        "//multibody/fem:isoparametric_element",
+        "//multibody/fem:quadrature",
+    ],
+)
+
+drake_cc_library(
+    name = "volumetric_model",
+    hdrs = [
+        "volumetric_model.h",
+    ],
+    deps = [
+        ":acceleration_newmark_scheme",
+        ":damping_model",
+        ":fem_model",
+        ":volumetric_element",
+        "//geometry/proximity:volume_mesh",
+    ],
+)
+
+# === test/ ===
+# TODO(xuchenhan-tri): Merge this with matrix utilities.
+drake_cc_library(
+    name = "test_utilities",
+    testonly = 1,
+    srcs = ["test/test_utilities.cc"],
+    hdrs = ["test/test_utilities.h"],
+    deps = [
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_googletest(
+    name = "acceleration_newmark_scheme_test",
+    deps = [
+        ":acceleration_newmark_scheme",
+        ":dummy_element",
+        ":velocity_newmark_scheme",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
 drake_cc_googletest(
     name = "calc_lame_parameters_test",
     deps = [
         ":calc_lame_parameters",
         "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_library(
+    name = "constitutive_model_test_utilities",
+    testonly = 1,
+    srcs = ["test/constitutive_model_test_utilities.cc"],
+    hdrs = ["test/constitutive_model_test_utilities.h"],
+    deps = [
+        ":corotated_model",
+        ":linear_constitutive_model",
+        ":test_utilities",
+        "//common:autodiff",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+        "//math:gradient",
+        "//multibody/fem:constitutive_model",
     ],
 )
 
@@ -151,10 +516,98 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "corotated_model_test",
+    deps = [
+        ":constitutive_model_test_utilities",
+        ":corotated_model",
+    ],
+)
+
+drake_cc_googletest(
+    name = "damping_model_test",
+    deps = [
+        ":damping_model",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
     name = "deformation_gradient_data_test",
     deps = [
         ":deformation_gradient_data",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "dirichlet_boundary_condition_test",
+    deps = [
+        ":dirichlet_boundary_condition",
+        ":dummy_element",
+        ":fem_state",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_library(
+    name = "dummy_element",
+    testonly = 1,
+    srcs = ["test/dummy_element.cc"],
+    hdrs = ["test/dummy_element.h"],
+    deps = [
+        ":damping_model",
+        ":element_cache_entry",
+        ":fem_element",
+        ":fem_state",
+        ":linear_constitutive_model",
+    ],
+)
+
+drake_cc_library(
+    name = "dummy_model",
+    testonly = 1,
+    srcs = ["test/dummy_element.cc"],
+    hdrs = ["test/dummy_model.h"],
+    deps = [
+        ":dummy_element",
+        ":fem_model",
+    ],
+)
+
+drake_cc_googletest(
+    name = "element_cache_entry_test",
+    deps = [
+        ":element_cache_entry",
+    ],
+)
+
+drake_cc_googletest(
+    name = "fem_element_test",
+    deps = [
+        ":dummy_element",
+    ],
+)
+
+drake_cc_googletest(
+    name = "fem_solver_test",
+    deps = [
+        ":acceleration_newmark_scheme",
+        ":dummy_model",
+        ":fem_solver",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "fem_state_test",
+    deps = [
+        ":dummy_element",
+        ":element_cache_entry",
+        ":fem_element",
+        ":fem_state",
         "//common/test_utilities:expect_throws_message",
     ],
 )
@@ -166,6 +619,14 @@ drake_cc_googletest(
         ":linear_simplex_element",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "linear_constitutive_model_test",
+    deps = [
+        ":constitutive_model_test_utilities",
+        ":linear_constitutive_model",
     ],
 )
 
@@ -186,9 +647,94 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "matrix_utilities_test",
+    deps = [
+        ":matrix_utilities",
+        ":test_utilities",
+        "//common:essential",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:geometric_transform",
+        "//math:gradient",
+    ],
+)
+
+drake_cc_googletest(
+    name = "petsc_symmetric_block_sparse_matrix_test",
+    tags = [
+        # This tests uses multiple CPUs concurrently.
+        "cpu:100",
+    ],
+    deps = [
+        ":petsc_symmetric_block_sparse_matrix",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "schur_complement_test",
+    deps = [
+        ":schur_complement",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
     name = "simplex_gaussian_quadrature_test",
     deps = [
         ":simplex_gaussian_quadrature",
+    ],
+)
+
+drake_cc_googletest(
+    name = "stretch_test",
+    deps = [
+        ":fem_solver",
+        ":linear_constitutive_model",
+        ":linear_simplex_element",
+        ":mesh_utilities",
+        ":simplex_gaussian_quadrature",
+        ":volumetric_element",
+        ":volumetric_model",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//geometry/proximity:make_box_mesh",
+    ],
+)
+
+drake_cc_googletest(
+    name = "velocity_newmark_scheme_test",
+    deps = [
+        ":acceleration_newmark_scheme",
+        ":dummy_element",
+        ":velocity_newmark_scheme",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "volumetric_element_test",
+    deps = [
+        ":corotated_model",
+        ":volumetric_element",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:geometric_transform",
+        "//math:gradient",
+        "//multibody/fem:linear_simplex_element",
+        "//multibody/fem:simplex_gaussian_quadrature",
+    ],
+)
+
+drake_cc_googletest(
+    name = "volumetric_model_test",
+    deps = [
+        ":linear_constitutive_model",
+        ":volumetric_element",
+        ":volumetric_model",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//geometry/proximity:make_box_mesh",
+        "//math:gradient",
+        "//multibody/fem:linear_simplex_element",
+        "//multibody/fem:simplex_gaussian_quadrature",
     ],
 )
 

--- a/multibody/fem/BUILD.bazel
+++ b/multibody/fem/BUILD.bazel
@@ -15,6 +15,7 @@ drake_cc_package_library(
     name = "fem",
     visibility = ["//multibody/fixed_fem:__subpackages__"],
     deps = [
+        ":calc_lame_parameters",
         ":constitutive_model",
         ":deformation_gradient_data",
         ":isoparametric_element",
@@ -22,6 +23,19 @@ drake_cc_package_library(
         ":linear_simplex_element",
         ":quadrature",
         ":simplex_gaussian_quadrature",
+    ],
+)
+
+drake_cc_library(
+    name = "calc_lame_parameters",
+    srcs = [
+        "calc_lame_parameters.cc",
+    ],
+    hdrs = [
+        "calc_lame_parameters.h",
+    ],
+    deps = [
+        "//common:default_scalars",
     ],
 )
 
@@ -116,6 +130,14 @@ drake_cc_library(
     ],
     deps = [
         ":quadrature",
+    ],
+)
+
+drake_cc_googletest(
+    name = "calc_lame_parameters_test",
+    deps = [
+        ":calc_lame_parameters",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/multibody/fem/acceleration_newmark_scheme.cc
+++ b/multibody/fem/acceleration_newmark_scheme.cc
@@ -1,0 +1,39 @@
+#include "drake/multibody/fem/acceleration_newmark_scheme.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+template <typename T>
+void AccelerationNewmarkScheme<T>::DoUpdateStateFromChangeInUnknowns(
+    const VectorX<T>& dz, FemState<T>* state) const {
+  const VectorX<T>& a = state->GetAccelerations();
+  const VectorX<T>& v = state->GetVelocities();
+  const VectorX<T>& x = state->GetPositions();
+  state->SetAccelerations(a + dz);
+  state->SetVelocities(v + dt() * gamma() * dz);
+  state->SetPositions(x + dt() * dt() * beta() * dz);
+}
+
+template <typename T>
+void AccelerationNewmarkScheme<T>::DoAdvanceOneTimeStep(
+    const FemState<T>& prev_state, const VectorX<T>& unknown_variable,
+    FemState<T>* state) const {
+  const VectorX<T>& an = prev_state.GetAccelerations();
+  const VectorX<T>& vn = prev_state.GetVelocities();
+  const VectorX<T>& xn = prev_state.GetPositions();
+  const VectorX<T>& a = unknown_variable;
+  state->SetAccelerations(a);
+  state->SetVelocities(vn + dt() * (gamma() * a + (1.0 - gamma()) * an));
+  state->SetPositions(xn + dt() * vn +
+              dt() * dt() * (beta() * a + (0.5 - beta()) * an));
+}
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::internal::AccelerationNewmarkScheme)

--- a/multibody/fem/acceleration_newmark_scheme.h
+++ b/multibody/fem/acceleration_newmark_scheme.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "drake/common/default_scalars.h"
+#include "drake/multibody/fem/newmark_scheme.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+/* Implements NewmarkScheme with acceleration as the unknown variable.
+ Given the value for the current time step acceleration `a`, the state at the
+ next time step can be calculated from that of the previous time step according
+ to the following equations:
+
+      v = vₙ + dt ⋅ (γ ⋅ a + (1−γ) ⋅ aₙ)
+      x = xₙ + dt ⋅ vₙ + dt² ⋅ [β ⋅ a + (0.5−β) ⋅ aₙ].
+
+ See NewmarkScheme for the reference to the Newmark-beta integration scheme.
+ See VelocityNewmarkScheme for the same integration scheme implemented with
+ velocity as the unknown variable.
+ @tparam_nonsymbolic_scalar */
+template <typename T>
+class AccelerationNewmarkScheme final : public NewmarkScheme<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(AccelerationNewmarkScheme);
+
+  /* Constructs a Newmark scheme with acceleration as the unknown variable.
+   @pre dt_in > 0.
+   @pre 0.5 <= gamma_in <= 1.
+   @pre 0 <= beta_in <= 0.5. */
+  AccelerationNewmarkScheme(double dt_in, double gamma_in, double beta_in)
+      : NewmarkScheme<T>(dt_in, gamma_in, beta_in) {}
+
+  ~AccelerationNewmarkScheme() = default;
+
+ private:
+  using NewmarkScheme<T>::dt;
+  using NewmarkScheme<T>::gamma;
+  using NewmarkScheme<T>::beta;
+
+  Vector3<T> do_get_weights() const final {
+    return {beta() * dt() * dt(), gamma() * dt(), 1.0};
+  }
+
+  const VectorX<T>& DoGetUnknowns(const FemState<T>& state) const final {
+    return state.GetAccelerations();
+  }
+
+  void DoUpdateStateFromChangeInUnknowns(const VectorX<T>& dz,
+                                         FemState<T>* state) const final;
+
+  void DoAdvanceOneTimeStep(const FemState<T>& prev_state,
+                            const VectorX<T>& unknown_variable,
+                            FemState<T>* state) const final;
+};
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::internal::AccelerationNewmarkScheme)

--- a/multibody/fem/calc_lame_parameters.cc
+++ b/multibody/fem/calc_lame_parameters.cc
@@ -1,0 +1,31 @@
+#include "drake/multibody/fem/calc_lame_parameters.h"
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+template <typename T>
+LameParameters<T> CalcLameParameters(const T& youngs_modulus,
+                                     const T& poissons_ratio) {
+  if (!(youngs_modulus >= 0.0)) {
+    throw std::logic_error("Young's modulus must be nonnegative.");
+  }
+  if (!(poissons_ratio < 0.5 && poissons_ratio > -1)) {
+    throw std::logic_error("Poisson's ratio must be in (-1, 0.5).");
+  }
+  const T mu = youngs_modulus / (2.0 * (1.0 + poissons_ratio));
+  const T lambda = youngs_modulus * poissons_ratio /
+                   ((1.0 + poissons_ratio) * (1.0 - 2.0 * poissons_ratio));
+  return {lambda, mu};
+}
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    (&CalcLameParameters<T>))
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/calc_lame_parameters.h
+++ b/multibody/fem/calc_lame_parameters.h
@@ -1,0 +1,28 @@
+#pragma once
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+template <typename T>
+struct LameParameters {
+  T lambda{};  // First Lamé parameter.
+  T mu{};      // Second Lamé parameter.
+};
+
+/* Verifies that the given Young's modulus and Poisson's ratio are valid. If so,
+ calculates the Lamé parameters from the Young's modulus and the Poisson ratio.
+ If not, throw an exception. Note that a Poisson's ratio of -1 or 0.5 is _not_
+ allowed.
+ @tparam_nonsymbolic_scalar.
+ @throw std::exception if `youngs_modulus` is negative or if `poissons_ratio` is
+ not in (-1, 0.5). */
+template <typename T>
+LameParameters<T> CalcLameParameters(const T& youngs_modulus,
+                                     const T& poissons_ratio);
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/corotated_model.cc
+++ b/multibody/fem/corotated_model.cc
@@ -1,0 +1,77 @@
+#include "drake/multibody/fem/corotated_model.h"
+
+#include <array>
+#include <utility>
+
+#include "drake/common/autodiff.h"
+#include "drake/multibody/fem/calc_lame_parameters.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+template <typename T, int num_locations>
+CorotatedModel<T, num_locations>::CorotatedModel(const T& youngs_modulus,
+                                                 const T& poisson_ratio)
+    : E_(youngs_modulus), nu_(poisson_ratio) {
+  const LameParameters<T> lame = CalcLameParameters(E_, nu_);
+  lambda_ = lame.lambda;
+  mu_ = lame.mu;
+}
+
+template <typename T, int num_locations>
+void CorotatedModel<T, num_locations>::CalcElasticEnergyDensityImpl(
+    const Data& data, std::array<T, num_locations>* Psi) const {
+  for (int i = 0; i < num_locations; ++i) {
+    const T& Jm1 = data.Jm1()[i];
+    const Matrix3<T>& F = data.deformation_gradient()[i];
+    const Matrix3<T>& R = data.R()[i];
+    (*Psi)[i] = mu_ * (F - R).squaredNorm() + 0.5 * lambda_ * Jm1 * Jm1;
+  }
+}
+
+template <typename T, int num_locations>
+void CorotatedModel<T, num_locations>::CalcFirstPiolaStressImpl(
+    const Data& data, std::array<Matrix3<T>, num_locations>* P) const {
+  for (int i = 0; i < num_locations; ++i) {
+    const T& Jm1 = data.Jm1()[i];
+    const Matrix3<T>& F = data.deformation_gradient()[i];
+    const Matrix3<T>& R = data.R()[i];
+    const Matrix3<T>& JFinvT = data.JFinvT()[i];
+    (*P)[i] = 2.0 * mu_ * (F - R) + lambda_ * Jm1 * JFinvT;
+  }
+}
+
+template <typename T, int num_locations>
+void CorotatedModel<T, num_locations>::CalcFirstPiolaStressDerivativeImpl(
+    const Data& data,
+    std::array<Eigen::Matrix<T, 9, 9>, num_locations>* dPdF) const {
+  for (int i = 0; i < num_locations; ++i) {
+    const T& Jm1 = data.Jm1()[i];
+    const Matrix3<T>& F = data.deformation_gradient()[i];
+    const Matrix3<T>& R = data.R()[i];
+    const Matrix3<T>& S = data.S()[i];
+    const Matrix3<T>& JFinvT = data.JFinvT()[i];
+    const Vector<T, 3 * 3>& flat_JFinvT =
+        Eigen::Map<const Vector<T, 3 * 3>>(JFinvT.data(), 3 * 3);
+    auto& local_dPdF = (*dPdF)[i];
+    /* The contribution from derivatives of Jm1. */
+    local_dPdF.noalias() = lambda_ * flat_JFinvT * flat_JFinvT.transpose();
+    /* The contribution from derivatives of F. */
+    local_dPdF.diagonal().array() += 2.0 * mu_;
+    /* The contribution from derivatives of R. */
+    internal::AddScaledRotationalDerivative<T>(R, S, -2.0 * mu_, &local_dPdF);
+    /* The contribution from derivatives of JFinvT. */
+    internal::AddScaledCofactorMatrixDerivative<T>(F, lambda_ * Jm1,
+                                                   &local_dPdF);
+  }
+}
+
+template class CorotatedModel<double, 1>;
+template class CorotatedModel<AutoDiffXd, 1>;
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/corotated_model.h
+++ b/multibody/fem/corotated_model.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <array>
+
+#include "drake/multibody/fem/constitutive_model.h"
+#include "drake/multibody/fem/corotated_model_data.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+/* Traits for CorotatedModel. */
+template <typename T, int num_locations>
+struct CorotatedModelTraits {
+  using Scalar = T;
+  using Data = CorotatedModelData<T, num_locations>;
+};
+
+/* Implements the fixed corotated hyperelastic constitutive model as
+ described in [Stomakhin, 2012].
+ @tparam_nonsymbolic_scalar.
+ @tparam num_locations Number of locations at which the constitutive
+ relationship is evaluated. We currently only provide one instantiation of this
+ template with `num_locations = 1`, but more instantiations can easily be added
+ when needed.
+
+ [Stomakhin, 2012] Stomakhin, Alexey, et al. "Energetically consistent
+ invertible elasticity." Proceedings of the 11th ACM SIGGRAPH/Eurographics
+ conference on Computer Animation. 2012. */
+template <typename T, int num_locations>
+class CorotatedModel final
+    : public ConstitutiveModel<CorotatedModel<T, num_locations>,
+                               CorotatedModelTraits<T, num_locations>> {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CorotatedModel)
+
+  using Base = ConstitutiveModel<CorotatedModel<T, num_locations>,
+                                 CorotatedModelTraits<T, num_locations>>;
+  using Data = typename Base::Data;
+
+  /* Constructs a CorotatedModel constitutive model with the
+   prescribed Young's modulus and Poisson ratio.
+   @param youngs_modulus  Young's modulus of the model, with unit N/m²
+   @param poisson_ratio   Poisson ratio of the model, unitless.
+   @pre youngs_modulus >= 0.
+   @pre -1 < poisson_ratio < 0.5. */
+  CorotatedModel(const T& youngs_modulus, const T& poisson_ratio);
+
+  const T& youngs_modulus() const { return E_; }
+
+  const T& poisson_ratio() const { return nu_; }
+
+  /* Returns the shear modulus (Lame's second parameter) which is given by
+   `E/(2*(1+nu))` where `E` is the Young's modulus and `nu` is the Poisson
+   ratio. See `fem::internal::CalcLameParameters()`. */
+  const T& shear_modulus() const { return mu_; }
+
+  /* Returns the Lame's first parameter which is given by
+   `E*nu/((1+nu)*(1-2*nu))` where `E` is the Young's modulus and `nu` is the
+   Poisson ratio. See `fem::internal::CalcLameParameters()`. */
+  const T& lame_first_parameter() const { return lambda_; }
+
+ private:
+  friend Base;
+
+  /* Shadows ConstitutiveModel::CalcElasticEnergyDensityImpl() as required by
+   the CRTP base class. */
+  void CalcElasticEnergyDensityImpl(const Data& data,
+                                    std::array<T, num_locations>* Psi) const;
+
+  /* Shadows ConstitutiveModel::CalcFirstPiolaStressImpl() as required by the
+   CRTP base class. */
+  void CalcFirstPiolaStressImpl(const Data& data,
+                                std::array<Matrix3<T>, num_locations>* P) const;
+
+  /* Shadows ConstitutiveModel::CalcFirstPiolaStressDerivativeImpl() as required
+   by the CRTP base class. */
+  void CalcFirstPiolaStressDerivativeImpl(
+      const Data& data,
+      std::array<Eigen::Matrix<T, 9, 9>, num_locations>* dPdF) const;
+
+  T E_;       // Young's modulus, N/m².
+  T nu_;      // Poisson ratio.
+  T mu_;      // Lamé's second parameter/Shear modulus, N/m².
+  T lambda_;  // Lamé's first parameter, N/m².
+};
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/corotated_model_data.h
+++ b/multibody/fem/corotated_model_data.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <array>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/deformation_gradient_data.h"
+#include "drake/multibody/fem/matrix_utilities.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+/* Data supporting calculations in CorotatedModel.
+ See CorotatedModel for how the data is used. See DeformationGradientData for
+ more about constitutive model data.
+ @tparam_nonsymbolic_scalar T.
+ @tparam num_locations Number of locations at which the deformation gradient
+ dependent quantities are evaluated. */
+template <typename T, int num_locations>
+class CorotatedModelData
+    : public DeformationGradientData<
+          CorotatedModelData<T, num_locations>> {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CorotatedModelData);
+
+  /* Constructs a CorotatedModelData with no deformation. */
+  CorotatedModelData() {
+    std::fill(R_.begin(), R_.end(), Matrix3<T>::Identity());
+    std::fill(S_.begin(), S_.end(), Matrix3<T>::Identity());
+    std::fill(Jm1_.begin(), Jm1_.end(), 0);
+    std::fill(JFinvT_.begin(), JFinvT_.end(), Matrix3<T>::Identity());
+  }
+
+  const std::array<Matrix3<T>, num_locations>& R() const { return R_; }
+
+  const std::array<Matrix3<T>, num_locations>& S() const { return S_; }
+
+  const std::array<T, num_locations>& Jm1() const { return Jm1_; }
+
+  const std::array<Matrix3<T>, num_locations>& JFinvT() const {
+    return JFinvT_;
+  }
+
+ private:
+  friend DeformationGradientData<CorotatedModelData<T, num_locations>>;
+
+  /* Shadows DeformationGradientData::UpdateFromDeformationGradient() as
+   required by the CRTP base class. */
+  void UpdateFromDeformationGradient() {
+    const std::array<Matrix3<T>, num_locations>& F =
+        this->deformation_gradient();
+    for (int i = 0; i < num_locations; ++i) {
+      Matrix3<T>& local_R = R_[i];
+      Matrix3<T>& local_S = S_[i];
+      Matrix3<T>& local_JFinvT = JFinvT_[i];
+      internal::PolarDecompose<T>(F[i], &local_R, &local_S);
+      Jm1_[i] = F[i].determinant() - 1.0;
+      internal::CalcCofactorMatrix<T>(F[i], &local_JFinvT);
+    }
+  }
+
+  /* Let F = RS be the polar decomposition of the deformation gradient where R
+   is a rotation matrix and S is symmetric. */
+  std::array<Matrix3<T>, num_locations> R_;
+  std::array<Matrix3<T>, num_locations> S_;
+  /* The determinant of F minus 1, or J - 1. */
+  std::array<T, num_locations> Jm1_;
+  /* The cofactor matrix of F, or JF⁻ᵀ. */
+  std::array<Matrix3<T>, num_locations> JFinvT_;
+};
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/damping_model.h
+++ b/multibody/fem/damping_model.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <stdexcept>
+
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+
+/** A simple viscous Rayleigh damping model. The resulting damping matrix is a
+nonnegative linear combination of mass and stiffness matrices. Namely, D = αM +
+βK where α and β are nonnegative. The damping ratio ξ for a given frequency of
+the mode of vibration ω can be calculated by (α/ω + βω)/2. Noticeably, the
+contribution by the stiffness term βK is proportional to the frequency of the
+mode while the damping ratio contributed by the mass term αM is inversely
+proportional to the frequency. Furthermore, one should note that the mass
+proportional damping damps rigid body motions and should therefore be kept small
+in general.
+@tparam_nonsymbolic_scalar */
+template <typename T>
+class DampingModel {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DampingModel);
+
+  /** Constructs a Rayleigh damping model with the given mass and stiffness
+   damping coefficients.
+   @throw std::exception if either `mass_coeff` or `stiffness_coeff` is
+   negative. */
+  DampingModel(T mass_coeff, T stiffness_coeff)
+      : mass_coeff_(mass_coeff), stiffness_coeff_(stiffness_coeff) {
+    if (mass_coeff < 0.0 || stiffness_coeff < 0.0) {
+      throw std::logic_error(
+          "Mass and stiffness damping coefficients must be non-negative.");
+    }
+  }
+
+  const T& mass_coeff() const { return mass_coeff_; }
+  const T& stiffness_coeff() const { return stiffness_coeff_; }
+
+ private:
+  T mass_coeff_;
+  T stiffness_coeff_;
+};
+
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dirichlet_boundary_condition.cc
+++ b/multibody/fem/dirichlet_boundary_condition.cc
@@ -1,0 +1,109 @@
+#include "drake/multibody/fem/dirichlet_boundary_condition.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+template <class T>
+void DirichletBoundaryCondition<T>::AddBoundaryCondition(
+    int dof_index, const Eigen::Ref<const Vector3<T>>& boundary_state) {
+  index_to_boundary_state_[dof_index] = boundary_state;
+}
+
+template <class T>
+void DirichletBoundaryCondition<T>::ApplyBoundaryConditionToState(
+    FemState<T>* state) const {
+  if (index_to_boundary_state_.empty()) return;
+  DRAKE_DEMAND(state != nullptr);
+  VerifyIndexes(state->num_dofs());
+  VectorX<T> q = state->GetPositions();
+  VectorX<T> v = state->GetVelocities();
+  VectorX<T> a = state->GetAccelerations();
+  for (const auto& [dof_index, boundary_state] : index_to_boundary_state_) {
+    q(dof_index) = boundary_state(0);
+    v(dof_index) = boundary_state(1);
+    a(dof_index) = boundary_state(2);
+  }
+  state->SetPositions(q);
+  state->SetVelocities(v);
+  state->SetAccelerations(a);
+}
+
+template <class T>
+void DirichletBoundaryCondition<T>::ApplyBoundaryConditionToTangentMatrix(
+    Eigen::SparseMatrix<T>* tangent_matrix) const {
+  DRAKE_DEMAND(tangent_matrix != nullptr);
+  DRAKE_DEMAND(tangent_matrix->rows() == tangent_matrix->cols());
+  if (index_to_boundary_state_.empty()) {
+    return;
+  }
+  /* Check validity of the DoF indexes stored. */
+  VerifyIndexes(tangent_matrix->cols());
+
+  /* Zero out all rows and columns of the tangent matrix corresponding to
+   DoFs under the BC (except the diagonal entry which is set to 1). */
+  for (const auto& it : index_to_boundary_state_) {
+    const int dof_index = it.first;
+    tangent_matrix->row(dof_index) *= T(0);
+    tangent_matrix->col(dof_index) *= T(0);
+    tangent_matrix->coeffRef(dof_index, dof_index) = T(1);
+  }
+}
+
+template <class T>
+void DirichletBoundaryCondition<T>::ApplyBoundaryConditionToTangentMatrix(
+    internal::PetscSymmetricBlockSparseMatrix* tangent_matrix) const {
+  DRAKE_DEMAND(tangent_matrix != nullptr);
+  DRAKE_DEMAND(tangent_matrix->rows() == tangent_matrix->cols());
+  if (index_to_boundary_state_.empty()) {
+    return;
+  }
+  /* Check validity of the DoF indexes stored. */
+  VerifyIndexes(tangent_matrix->cols());
+
+  /* Zero out all rows and columns of the tangent matrix corresponding to
+   DoFs under the BC (except the diagonal entry which is set to 1). */
+  std::vector<int> indexes(index_to_boundary_state_.size());
+  int i = 0;
+  for (const auto& it : index_to_boundary_state_) {
+    indexes[i++] = it.first;
+  }
+  tangent_matrix->ZeroRowsAndColumns(indexes, /* diagonal entry */ 1.0);
+}
+
+template <class T>
+void DirichletBoundaryCondition<T>::ApplyBoundaryConditionToResidual(
+    EigenPtr<VectorX<T>> residual) const {
+  DRAKE_DEMAND(residual != nullptr);
+  if (index_to_boundary_state_.empty()) {
+    return;
+  }
+  /* Check validity of the DoF indices stored. */
+  VerifyIndexes(residual->size());
+
+  /* Zero out all entries of the residual corresponding to DoFs under the
+   BC. */
+  for (const auto& it : index_to_boundary_state_) {
+    const int dof_index = it.first;
+    (*residual)(dof_index) = 0;
+  }
+}
+
+template <class T>
+void DirichletBoundaryCondition<T>::VerifyIndexes(int size) const {
+  const auto& last_bc = index_to_boundary_state_.crbegin();
+  if (last_bc->first >= size) {
+    throw std::runtime_error(
+        "An index of the Dirichlet boundary condition is out of the "
+        "range.");
+  }
+}
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::internal::DirichletBoundaryCondition);

--- a/multibody/fem/dirichlet_boundary_condition.h
+++ b/multibody/fem/dirichlet_boundary_condition.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <map>
+#include <vector>
+
+#include <Eigen/Sparse>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/fem_state.h"
+#include "drake/multibody/fem/petsc_symmetric_block_sparse_matrix.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+/* DirichletBoundaryCondition provides functionalities related to Dirichlet
+ boundary conditions (BC) on FEM models. In particular, it provides the
+ following functionalities:
+ 1. storing the information necessary to apply the BC;
+ 2. modifying a given state to comply with the stored BC;
+ 3. modifying a given tangent matrix/residual that arises from the FEM model
+ without BC and transform it into the tangent matrix/residual for the same
+ model under the stored BC.
+ @tparam_nonsymbolic_scalar */
+template <class T>
+class DirichletBoundaryCondition {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DirichletBoundaryCondition);
+
+  /* Constructs an empty boundary condition. */
+  DirichletBoundaryCondition() {}
+
+  /* Sets the DoF with index `dof_index` to be subject to the prescribed
+   `boundary_state`.
+   @param[in] dof_index      The index of the degree of freedom (DoF) to which
+                             the boundary condition is applied.
+   @param[in] boundary_state The prescibed position, velocity, and acceleration
+                             at `dof_index`. */
+  void AddBoundaryCondition(int dof_index,
+                            const Eigen::Ref<const Vector3<T>>& boundary_state);
+
+  /* Returns the boundary conditions as an `std::map` with the index of the DoF
+   as the key and the prescribed boundary states as the value. */
+  const std::map<int, Vector3<T>>& index_to_boundary_state() const {
+    return index_to_boundary_state_;
+  }
+
+  /* Modifies the given `state` to comply with the Dirichlet boundary
+   conditions.
+   @pre state != nullptr. */
+  void ApplyBoundaryConditionToState(FemState<T>* state) const;
+
+  /* Modifies the given tangent matrix that arises from an FEM model without
+   BC into the tangent matrix for the same model subject to `this` BC. More
+   specifically, the rows and columns corresponding to DoFs under the BC will
+   be zeroed out with the exception of the diagonal entries for those DoFs
+   which will be set to 1.
+   @pre tangent_matrix != nullptr.
+   @pre tangent_matrix->rows() == tangent_matrix->cols().
+   @throw std::exception if the any of the indexes of the DoFs under the
+   boundary condition specified by `this` DirichletBoundaryCondition is
+   greater than or equal to the `tangent_matrix->cols()`. */
+  void ApplyBoundaryConditionToTangentMatrix(
+      Eigen::SparseMatrix<T>* tangent_matrix) const;
+
+  /* Alternative sigature for ApplyBoundaryConditionToTangentMatrix() that
+   modifies a PETSc matrix.
+   @pre tangent_matrix != nullptr.
+   @pre tangent_matrix->rows() == tangent_matrix->cols().
+   @throw std::exception if the any of the indexes of the DoFs under the
+   boundary condition specified by `this` DirichletBoundaryCondition is
+   greater than or equal to the `tangent_matrix->cols()`. */
+  void ApplyBoundaryConditionToTangentMatrix(
+      internal::PetscSymmetricBlockSparseMatrix* tangent_matrix) const;
+
+  /* Modifies the given residual that arises from an FEM model without BC into
+   the residual for the same model subject to `this` BC. More specifically,
+   the entries corresponding to DoFs under the BC will be zeroed out.
+   @pre residual != nullptr.
+   @throw std::exception if any of the indexes of the DoFs under the boundary
+   condition specified by `this` %DirichletBoundaryCondition  is greater than
+   or equal to the `residual->size()`. */
+  void ApplyBoundaryConditionToResidual(EigenPtr<VectorX<T>> residual) const;
+
+ private:
+  /* Verifies that the largest index for the DoFs under BC is smaller than the
+   given `size`. Otherwise, throw an exception. */
+  void VerifyIndexes(int size) const;
+
+  /* We sort the boundary conditions according to DoF indices for better
+   cache consistency when applying the BC. The value of the map stores the
+   value of q, v, and a (in that order and when applicable) of the DoF
+   with index of the key. */
+  std::map<int, Vector3<T>> index_to_boundary_state_{};
+};
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::internal::DirichletBoundaryCondition);

--- a/multibody/fem/discrete_time_integrator.cc
+++ b/multibody/fem/discrete_time_integrator.cc
@@ -1,0 +1,45 @@
+#include "drake/multibody/fem/discrete_time_integrator.h"
+
+// TODO(xuchenhan-tri): Add unit tests for this class.
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+template <typename T>
+Vector3<T> DiscreteTimeIntegrator<T>::weights() const {
+  return do_get_weights();
+}
+
+template <typename T>
+const VectorX<T>& DiscreteTimeIntegrator<T>::GetUnknowns(
+    const FemState<T>& state) const {
+  return DoGetUnknowns(state);
+}
+
+template <typename T>
+void DiscreteTimeIntegrator<T>::UpdateStateFromChangeInUnknowns(
+    const VectorX<T>& dz, FemState<T>* state) const {
+  DRAKE_DEMAND(state != nullptr);
+  DRAKE_DEMAND(dz.size() == state->num_dofs());
+  DoUpdateStateFromChangeInUnknowns(dz, state);
+}
+
+template <typename T>
+void DiscreteTimeIntegrator<T>::AdvanceOneTimeStep(
+    const FemState<T>& prev_state, const VectorX<T>& unknown_variable,
+    FemState<T>* next_state) const {
+  DRAKE_DEMAND(next_state != nullptr);
+  DRAKE_DEMAND(prev_state.num_dofs() == next_state->num_dofs());
+  DRAKE_DEMAND(prev_state.num_dofs() == unknown_variable.size());
+  DoAdvanceOneTimeStep(prev_state, unknown_variable, next_state);
+}
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::internal::DiscreteTimeIntegrator)

--- a/multibody/fem/discrete_time_integrator.h
+++ b/multibody/fem/discrete_time_integrator.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "drake/multibody/fem/fem_state.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+/* DiscreteTimeIntegrator is an abstract class that encapsulates discrete time
+ integrations schemes for second order ODEs. When a second order ODE
+
+     f(q, v = q̇, a = q̈) = 0
+
+ is discretized in time, the quantities of interest evaluated at the next time
+ step can often be expressed as an affine mapping on a single variable z, i.e.
+
+        qₙ₊₁ = αₚ z + bₚ
+        vₙ₊₁ = αᵥ z + bᵥ
+        aₙ₊₁ = αₐ z + bₐ
+
+ For example, for the Newmark-beta scheme, if one chooses z = a, we get
+
+        qₙ₊₁ = qₙ + dt ⋅ vₙ + dt² ⋅ [β ⋅ z + (0.5−β) ⋅ aₙ].
+        vₙ₊₁ = vₙ + dt ⋅ (γ ⋅ z + (1−γ) ⋅ aₙ)
+        aₙ₊₁ = z;
+
+ On the other hand, if one chooses z = v instead for the same scheme, we get
+
+        qₙ₊₁ = xₙ + dt ⋅ (β/γ ⋅ z +  (1 - β/γ) ⋅ vₙ) + dt² ⋅ (0.5 − β/γ) ⋅ aₙ.
+        vₙ₊₁ = z
+        aₙ₊₁ = (z - vₙ) / (dt ⋅ γ) - (1 − γ) / γ ⋅ aₙ
+
+ DiscreteTimeIntegrator provides the interface to query the relationship between
+ the states (`q`, `v`, and `a`) and the unknown variable `z`.
+ @tparam_non_symbolic. */
+template <typename T>
+class DiscreteTimeIntegrator {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiscreteTimeIntegrator);
+
+  virtual ~DiscreteTimeIntegrator() = default;
+
+  /* Returns (αₚ, αᵥ, αₐ), the derivative of (q, v, a) with respect to the
+   unknown variable z (See class documentation). These weights can be used to
+   combine stiffness, damping, and mass matrices to form the tangent
+   matrix (see FemModel::CalcTangentMatrix). */
+  Vector3<T> weights() const;
+
+  /* Extracts the unknown variable `z` from the given FEM `state`. */
+  const VectorX<T>& GetUnknowns(const FemState<T>& state) const;
+
+  /* Updates the FemState `state` given the change in the unknown variables.
+   More specifically, it sets the given `state` to the following values.
+
+        q = αₚ (z + dz) + bₚ
+        v = αᵥ (z + dz) + bᵥ
+        a = αₐ (z + dz) + bₐ
+
+   @pre state != nullptr.
+   @pre dz.size() == state->num_dofs(). */
+  void UpdateStateFromChangeInUnknowns(const VectorX<T>& dz,
+                                       FemState<T>* state) const;
+
+  /* Advances `prev_state` by one time step to the `next_state` with the given
+   value of the unknown variable z.
+   @param[in]  prev_state        The state at the previous time step.
+   @param[in]  unknown_variable  The unknown variable z.
+   @param[out] next_state        The state at the next time step.
+   @pre next_state != nullptr.
+   @pre The sizes of `prev_state`, `unknown_variable`, and `next_state` are
+   compatible. */
+  void AdvanceOneTimeStep(const FemState<T>& prev_state,
+                          const VectorX<T>& unknown_variable,
+                          FemState<T>* next_state) const;
+
+ protected:
+  DiscreteTimeIntegrator() = default;
+
+  /* Derived classes must override this method to implement the NVI
+   get_weights(). */
+  virtual Vector3<T> do_get_weights() const = 0;
+
+  /* Derived classes must override this method to implement the NVI
+   GetUnknowns(). */
+  virtual const VectorX<T>& DoGetUnknowns(const FemState<T>& state) const = 0;
+
+  /* Derived classes must override this method to implement the NVI
+   UpdateStateFromChangeInUnknowns(). */
+  virtual void DoUpdateStateFromChangeInUnknowns(const VectorX<T>& dz,
+                                                 FemState<T>* state) const = 0;
+
+  /* Derived classes must override this method to implement the NVI
+   AdvanceOneTimeStep(). */
+  virtual void DoAdvanceOneTimeStep(const FemState<T>& prev_state,
+                                    const VectorX<T>& unknowns,
+                                    FemState<T>* next_state) const = 0;
+};
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::internal::DiscreteTimeIntegrator)

--- a/multibody/fem/element_cache_entry.h
+++ b/multibody/fem/element_cache_entry.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "drake/multibody/fem/fem_indexes.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+/* ElementCacheEntry provides basic caching capabilities for the
+ per-element, state-dependent quantities used in an FEM simulation that are
+ not states themselves. These quantities are stored in `ElementData`.
+ @tparam ElementData    The state-dependent quantities of the element that are
+ stored. `ElementData` should be of type `FooElement::Traits::Data` where
+ `FooElement`, the element that this ElementCacheEntry is holding data for,
+ is the same type as the template parameter `DerivedElement` in FemElement. */
+template <class ElementData>
+class ElementCacheEntry {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ElementCacheEntry);
+
+  static_assert(std::is_default_constructible_v<ElementData>,
+                "The template parameter 'ElementData' in ElementCacheEntry "
+                "must be default constructible. ");
+
+  /* Constructs a new ElementCacheEntry with default initialized data. */
+  ElementCacheEntry() {}
+
+  /* Returns a mutable reference to the cached data. Doesn't modify the
+   staleness flag. The callers should modify the staleness flag through
+   set_stale() when needed.  */
+  ElementData& mutable_element_data() { return element_data_; }
+
+  const ElementData& element_data() const { return element_data_; }
+
+  /* Returns true if the element cache entry value is out of date. */
+  bool is_stale() const { return is_stale_; }
+
+  void set_stale(bool stale) { is_stale_ = stale; }
+
+ private:
+  ElementData element_data_;
+  bool is_stale_{true};
+};
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/fem_element.h
+++ b/multibody/fem/fem_element.h
@@ -1,0 +1,327 @@
+#pragma once
+
+#include <array>
+#include <string>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/constitutive_model.h"
+#include "drake/multibody/fem/damping_model.h"
+#include "drake/multibody/fem/fem_indexes.h"
+#include "drake/multibody/fem/fem_state_impl.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+// TODO(xuchenhan-tri) Document the definition of quantities like "natural
+//  dimension". See issue #14475.
+/* FemElement is the base class for spatially discretized FEM elements for
+ dynamic elasticity problems. It computes quantities such as the residual and
+ the tangent matrix on a single FEM element given the state of the FEM system.
+ These quantities are then assembled into their global counterparts by
+ FemModelImpl.
+
+ Since FEM elements are usually evaluated in computationally intensive inner
+ loops of the simulation, the overhead caused by virtual methods and heap
+ allocations may be significant. Therefore, this class uses CRTP to achieve
+ compile-time polymorphism and avoids the overhead of virtual methods and
+ facilitates inlining instead. The type information at compile time also helps
+ eliminate all heap allocations. Derived FEM elements must inherit from this
+ base class and implement the interface this class provides. The derived FEM
+ elements must also be accompanied by a corresponding traits class that declares
+ the compile time quantities and type declarations that this base class
+ requires.
+
+ FemElement also comes with per-element, state-dependent data. The data
+ specific to the `DerivedElement` should be declared in `DerivedTraits`, along
+ with the other responsibilities of `DerivedTraits` detailed below.
+
+ @tparam DerivedElement The concrete FEM element that inherits from %FemElement
+ through CRTP.
+ @tparam DerivedTraits The traits class associated with the DerivedElement. It
+ needs to provide a nested class `Data` for storing the per-element,
+ state-dependent data used by `DerivedElement`. In particular, the `Data` class
+ needs to provide a default constructor. It also needs to provide the following
+ compile time constants for the `DerivedElement`: the number of quadrature
+ points in a single `DerivedElement`, `num_quadrature_points`, the number of
+ nodes associated with a single `DerivedElement`, `num_nodes,` and the number of
+ degrees of freedom that a single `DerivedElement` possesses, `num_dofs`. It
+ also needs to provide the following type definitions: the type of the
+ constitutive model the element uses, `ConstitutiveModel`.*/
+template <class DerivedElement, class DerivedTraits>
+class FemElement {
+ public:
+  using T = typename DerivedTraits::T;
+  using Traits = DerivedTraits;
+  using Data = typename Traits::Data;
+  using ConstitutiveModel = typename Traits::ConstitutiveModel;
+  static constexpr int num_dofs = Traits::num_dofs;
+  static constexpr int num_nodes = Traits::num_nodes;
+  static constexpr int num_quadrature_points = Traits::num_quadrature_points;
+
+  /* Indices of the nodes of this element within the model. */
+  const std::array<NodeIndex, num_nodes>& node_indices() const {
+    return node_indices_;
+  }
+
+  /* The ElementIndex of this element within the model. */
+  ElementIndex element_index() const { return element_index_; }
+
+  /* Computes the per-element, state-dependent data associated with this
+   `DerivedElement` given the `state`. */
+  Data ComputeData(const FemStateImpl<DerivedElement>& state) const {
+    return static_cast<const DerivedElement*>(this)->DoComputeData(state);
+  }
+
+  /* Calculates the tangent matrix for the element by combining the stiffness
+   matrix, damping matrix, and the mass matrix according to the given `weights`.
+  */
+  void CalcTangentMatrix(
+      const FemStateImpl<DerivedElement>& state, const Vector3<T>& weights,
+      EigenPtr<Eigen::Matrix<T, num_dofs, num_dofs>> tangent_matrix) const {
+    DRAKE_DEMAND(tangent_matrix != nullptr);
+    tangent_matrix->setZero();
+    AddScaledStiffnessMatrix(state, weights(0), tangent_matrix);
+    AddScaledDampingMatrix(state, weights(1), tangent_matrix);
+    AddScaledMassMatrix(state, weights(2), tangent_matrix);
+  }
+
+  /* Calculates the element residual of this element evaluated at the input
+   state.
+   @param[in]  state     The FEM state at which to evaluate the residual.
+   @param[out] residual  A vector of residual of size `num_dofs`. All
+                         values in `residual` will be overwritten.
+   @pre residual != nullptr */
+  void CalcResidual(const FemStateImpl<DerivedElement>& state,
+                    EigenPtr<Vector<T, num_dofs>> residual) const {
+    DRAKE_ASSERT(residual != nullptr);
+    residual->setZero();
+    static_cast<const DerivedElement*>(this)->DoCalcResidual(state, residual);
+  }
+
+  /* Accumulates the stiffness matrix (the derivative, or an approximation
+   thereof, of the residual with respect to the generalized positions) of this
+   element given the `state`.
+   @param[in]  state  The FEM state at which to evaluate the stiffness matrix.
+   @param[in]  scale  The scaling factor applied to the stiffness matrix.
+   @param[out] K      The matrix matrix of size `num_dofs`-by-`num_dofs` to
+                      which the scaled stiffness matrix will be added.
+   @pre K != nullptr */
+  void AddScaledStiffnessMatrix(
+      const FemStateImpl<DerivedElement>& state, const T& scale,
+      EigenPtr<Eigen::Matrix<T, num_dofs, num_dofs>> K) const {
+    DRAKE_ASSERT(K != nullptr);
+    static_cast<const DerivedElement*>(this)->DoAddScaledStiffnessMatrix(
+        state, scale, K);
+  }
+
+  /* Accumulates the damping matrix (the derivative of the residual with
+   respect to the time derivative of generalized positions) of this element
+   given the `state`.
+   @param[in]  state  The FEM state at which to evaluate the damping matrix.
+   @param[in]  scale  The scaling factor applied to the damping matrix.
+   @param[out] D      The matrix of size `num_dofs`-by-`num_dofs` to which the
+                      scaled damping matrix will be added.
+   @pre D != nullptr */
+  void AddScaledDampingMatrix(
+      const FemStateImpl<DerivedElement>& state, const T& scale,
+      EigenPtr<Eigen::Matrix<T, num_dofs, num_dofs>> D) const {
+    DRAKE_ASSERT(D != nullptr);
+    static_cast<const DerivedElement*>(this)->DoAddScaledDampingMatrix(
+        state, scale, D);
+  }
+
+  /* Accumulates the mass matrix (the derivative of the residual with respect
+   to the time second derivative of generalized positions) of this element
+   given the `state`.
+   @param[in]  state  The FEM state at which to evaluate the mass matrix.
+   @param[in]  scale  The scaling factor applied to the mass matrix.
+   @param[out] M      The matrix of size `num_dofs`-by-`num_dofs` to which the
+                      scaled mass matrix will be added.
+   @pre M != nullptr */
+  void AddScaledMassMatrix(
+      const FemStateImpl<DerivedElement>& state, const T& scale,
+      EigenPtr<Eigen::Matrix<T, num_dofs, num_dofs>> M) const {
+    DRAKE_ASSERT(M != nullptr);
+    static_cast<const DerivedElement*>(this)->DoAddScaledMassMatrix(state,
+                                                                    scale, M);
+  }
+
+  /* Extracts the dofs corresponding to the nodes given by `node_indices` from
+   the given `state_dofs`. */
+  static Vector<T, 3 * num_nodes> ExtractElementDofs(
+      const std::array<NodeIndex, num_nodes>& node_indices,
+      const VectorX<T>& state_dofs) {
+    constexpr int kDim = 3;
+    Vector<T, kDim * num_nodes> element_dofs;
+    for (int i = 0; i < num_nodes; ++i) {
+      DRAKE_ASSERT((node_indices[i] + 1) * kDim <= state_dofs.size());
+      element_dofs.template segment<kDim>(i * kDim) =
+          state_dofs.template segment<kDim>(node_indices[i] * kDim);
+    }
+    return element_dofs;
+  }
+
+  void set_gravity_vector(const Vector3<T>& gravity) { gravity_ = gravity; }
+
+  const Vector3<T>& gravity_vector() const { return gravity_; }
+
+ protected:
+  /* Assignment and copy constructions are prohibited.
+   Move constructor is allowed so that FemElement can be stored in
+   `std::vector`. */
+  FemElement(const FemElement&) = delete;
+  FemElement(FemElement&&) = default;
+  const FemElement& operator=(const FemElement&) = delete;
+  FemElement&& operator=(const FemElement&&) = delete;
+
+  /* Constructs a new FEM element. The constructor is made protected because
+   FemElement should not be constructed directly. Use the constructor of the
+   derived classes instead.
+   @param[in] element_index  The index of the new element within the model.
+   @param[in] node_indices   The node indices of the nodes of this element
+                             within the model.
+   @pre element_index is valid.
+   @pre Entries in node_indices are valid. */
+  FemElement(ElementIndex element_index,
+             const std::array<NodeIndex, num_nodes>& node_indices,
+             const ConstitutiveModel& constitutive_model,
+             const DampingModel<T>& damping_model)
+      : element_index_(element_index),
+        node_indices_(node_indices),
+        constitutive_model_(constitutive_model),
+        damping_model_(damping_model) {
+    DRAKE_ASSERT(element_index.is_valid());
+    for (int i = 0; i < num_nodes; ++i) {
+      DRAKE_ASSERT(node_indices[i].is_valid());
+    }
+  }
+
+  /* Accumulates the total external force exerted on this element at the given
+   `state` scaled by `scale` into the output parameter `external_force`.
+   @pre external_force != nullptr. */
+  void AddScaledExternalForce(
+      const FemStateImpl<DerivedElement>& state, const T& scale,
+      EigenPtr<Vector<T, num_dofs>> external_force) const {
+    DRAKE_ASSERT(external_force != nullptr);
+    // The gravity force is always accounted for in the external forces.
+    AddScaledGravityForce(state, scale, external_force);
+    // Add element specific external forces.
+    DoAddScaledExternalForce(state, scale, external_force);
+  }
+
+  /* `DerivedElement` must provide an implementation for `DoComputeData()`.
+   @throw std::exception if `DerivedElement` does not provide an
+   implementation for `DoComputeData()`. */
+  Data DoComputeData(const FemStateImpl<DerivedElement>& state) const {
+    ThrowIfNotImplemented(__func__);
+  }
+
+  /* `DerivedElement` must provide an implementation for
+   `DoCalcResidual()` to provide the residual that is up to date given the
+   `state`. The caller guarantees that `residual` is non-null and contains all
+   zeros; the implementation in the derived class does not have to test for
+   this.
+   @throw std::exception if `DerivedElement` does not provide an implementation
+   for `DoCalcResidual()`. */
+  void DoCalcResidual(const FemStateImpl<DerivedElement>& state,
+                      EigenPtr<Vector<T, num_dofs>> residual) const {
+    ThrowIfNotImplemented(__func__);
+  }
+
+  /* `DerivedElement` must provide an implementation for
+   `DoAddScaledStiffnessMatrix()` to provide the stiffness matrix that is up to
+   date given the `state`. The caller guarantees that `K` is non-null; the
+   implementation in the derived class does not have to test for this.
+   @throw std::exception if `DerivedElement` does not provide an implementation
+   for `DoAddScaledStiffnessMatrix()`. */
+  void DoAddScaledStiffnessMatrix(
+      const FemStateImpl<DerivedElement>& state, const T& scale,
+      EigenPtr<Eigen::Matrix<T, num_dofs, num_dofs>> K) const {
+    ThrowIfNotImplemented(__func__);
+  }
+
+  /* `DerivedElement` must provide an implementation for
+   `DoAddScaledDampingMatrix()` to provide the damping matrix that is up to date
+   given the `state`. The caller guarantees that `D` is non-null; the
+   implementation in the derived class does not have to test for this.
+   @throw std::exception if `DerivedElement` does not provide an implementation
+   for `DoAddScaledDampingMatrix()`. */
+  void DoAddScaledDampingMatrix(
+      const FemStateImpl<DerivedElement>& state, const T& scale,
+      EigenPtr<Eigen::Matrix<T, num_dofs, num_dofs>> D) const {
+    ThrowIfNotImplemented(__func__);
+  }
+
+  /* `DerivedElement` must provide an implementation for
+   `DoAddScaledMassMatrix()` to provide the mass matrix that is up-to-date given
+   the `state`. The caller guarantees that `M` is non-null; the implementation
+   in the derived class does not have to test for this.
+   @throw std::exception if `DerivedElement` does not provide an implementation
+   for `DoAddScaledMassMatrix()`. */
+  void DoAddScaledMassMatrix(
+      const FemStateImpl<DerivedElement>& state, const T& scale,
+      EigenPtr<Eigen::Matrix<T, num_dofs, num_dofs>> M) const {
+    ThrowIfNotImplemented(__func__);
+  }
+
+  /* `DerivedElement` may override this method to include _non-gravity_
+   external
+   forces specific to the derived element. Default implementation is no-op. */
+  void DoAddScaledExternalForce(
+      const FemStateImpl<DerivedElement>& state, const T& scale,
+      EigenPtr<Vector<T, num_dofs>> external_force) const {}
+
+  /* Adds the gravity force acting on each node in the element scaled by
+   `scale` into `force`. Derived elements may choose to override this method
+   to provide a more efficient implementation for specific elements. */
+  void AddScaledGravityForce(const FemStateImpl<DerivedElement>& state,
+                             const T& scale,
+                             EigenPtr<Vector<T, num_dofs>> force) const {
+    Eigen::Matrix<T, num_dofs, num_dofs> mass_matrix =
+        Eigen::Matrix<T, num_dofs, num_dofs>::Zero();
+    AddScaledMassMatrix(state, 1, &mass_matrix);
+    constexpr int kDim = 3;
+    // TODO(xuchenhan-tri): stacked_gravity can be cached.
+    Vector<T, num_dofs> stacked_gravity;
+    for (int i = 0; i < num_nodes; ++i) {
+      stacked_gravity.template segment<kDim>(kDim * i) = gravity_;
+    }
+    *force += scale * mass_matrix * stacked_gravity;
+  }
+
+  const ConstitutiveModel& constitutive_model() const {
+    return constitutive_model_;
+  }
+
+  const DampingModel<T>& damping_model() const { return damping_model_; }
+
+ private:
+  /* Helper to throw a descriptive exception when a given function is not
+   implemented. */
+  void ThrowIfNotImplemented(const char* source_method) const {
+    throw std::runtime_error("The DerivedElement from " +
+                             NiceTypeName::Get(*this) +
+                             " must provide an implementation for " +
+                             std::string(source_method) + "().");
+  }
+
+  /* The index of this element within the model. */
+  ElementIndex element_index_;
+  /* The node indices of this element within the model. */
+  std::array<NodeIndex, num_nodes> node_indices_;
+  /* The constitutive model that describes the stress-strain relationship
+   for this element. */
+  ConstitutiveModel constitutive_model_;
+  DampingModel<T> damping_model_;
+  /* Gravity vector. */
+  Vector3<T> gravity_{0, 0, -9.81};
+  /* Gravity force on the each node. */
+  Vector<T, num_dofs> gravity_force_;
+};
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/fem_indexes.h
+++ b/multibody/fem/fem_indexes.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "drake/common/type_safe_index.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** Index used to identify element by index among FEM elements. */
+using ElementIndex = TypeSafeIndex<class ElementTag>;
+
+/** Index used to identify node by index among FEM nodes. */
+using NodeIndex = TypeSafeIndex<class NodeTag>;
+
+/** Index used to identify degrees of freedom (Dof) by index among FEM Dofs. */
+using DofIndex = TypeSafeIndex<class DofTag>;
+
+/** Index into a vector of deformable bodies. */
+using DeformableBodyIndex = TypeSafeIndex<class DeformableBodyTag>;
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/fem_model.cc
+++ b/multibody/fem/fem_model.cc
@@ -1,0 +1,78 @@
+#include "drake/multibody/fem/fem_model.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+
+template <typename T>
+std::unique_ptr<FemState<T>> FemModel<T>::MakeFemState() const {
+  return DoMakeFemState();
+}
+
+template <typename T>
+void FemModel<T>::CalcResidual(const FemState<T>& state,
+                                   EigenPtr<VectorX<T>> residual) const {
+  DRAKE_DEMAND(residual != nullptr);
+  ThrowIfModelStateIncompatible(__func__, state);
+  DoCalcResidual(state, residual);
+  dirichlet_bc_.ApplyBoundaryConditionToResidual(residual);
+}
+
+template <typename T>
+void FemModel<T>::CalcTangentMatrix(
+    const FemState<T>& state, const Vector3<T>& weights,
+    Eigen::SparseMatrix<T>* tangent_matrix) const {
+  DRAKE_DEMAND(tangent_matrix != nullptr);
+  DRAKE_DEMAND(tangent_matrix->rows() == num_dofs());
+  DRAKE_DEMAND(tangent_matrix->cols() == num_dofs());
+  ThrowIfModelStateIncompatible(__func__, state);
+  DoCalcTangentMatrix(state, weights, tangent_matrix);
+  dirichlet_bc_.ApplyBoundaryConditionToTangentMatrix(tangent_matrix);
+}
+
+template <typename T>
+void FemModel<T>::CalcTangentMatrix(
+    const FemState<T>& state, const Vector3<T>& weights,
+    internal::PetscSymmetricBlockSparseMatrix* tangent_matrix) const {
+  DRAKE_DEMAND(tangent_matrix != nullptr);
+  DRAKE_DEMAND(tangent_matrix->rows() == num_dofs());
+  DRAKE_DEMAND(tangent_matrix->cols() == num_dofs());
+  ThrowIfModelStateIncompatible(__func__, state);
+  DoCalcTangentMatrix(state, weights, tangent_matrix);
+  dirichlet_bc_.ApplyBoundaryConditionToTangentMatrix(tangent_matrix);
+}
+
+template <typename T>
+Eigen::SparseMatrix<T> FemModel<T>::MakeEigenSparseTangentMatrix() const {
+  return DoMakeEigenSparseTangentMatrix();
+}
+
+template <typename T>
+std::unique_ptr<internal::PetscSymmetricBlockSparseMatrix>
+FemModel<T>::MakePetscSymmetricBlockSparseTangentMatrix() const {
+  return DoMakePetscSymmetricBlockSparseTangentMatrix();
+}
+
+template <typename T>
+void FemModel<T>::ApplyBoundaryCondition(FemState<T>* state) const {
+  DRAKE_DEMAND(state != nullptr);
+  ThrowIfModelStateIncompatible(__func__, *state);
+  dirichlet_bc_.ApplyBoundaryConditionToState(state);
+}
+
+template <typename T>
+void FemModel<T>::SetGravityVector(const Vector3<T>& gravity) {
+  /* Store gravity so that all elements added after the call to this method
+   get the "new" gravity constant. */
+  gravity_ = gravity;
+  /* Update the gravity vector in elements added before the call to
+   this method. */
+  DoSetGravityVector(gravity);
+}
+
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::FemModel);

--- a/multibody/fem/fem_model.h
+++ b/multibody/fem/fem_model.h
@@ -1,0 +1,222 @@
+#pragma once
+
+#include <array>
+#include <memory>
+#include <utility>
+
+#include <Eigen/Sparse>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/dirichlet_boundary_condition.h"
+#include "drake/multibody/fem/fem_state.h"
+#include "drake/multibody/fem/petsc_symmetric_block_sparse_matrix.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+
+/** %FemModel calculates the components of the discretized FEM equations for
+ dynamic elasticity problems. Typically, in dynamic elasticity problems, we are
+ interested in the mapping that describes the motion of a material
+
+    ϕ(⋅,t) : Ω⁰ → Ωᵗ,
+
+ where Ω⁰ and Ωᵗ are subsets of R³, along with it's first and second derivatives
+ (velocity and acceleration respectively):
+
+    V(X,t) = ∂ϕ(X,t)/∂t,
+    A(X,t) = ∂²ϕ(X,t)/∂t².
+
+ The governing equations of interest are conservation of mass and conservation
+ of momentum:
+
+    R(X,t)J(X,t) = R(X,0),
+    R(X,0)A(X,t) = fᵢₙₜ(X,t) + fₑₓₜ(X,t),
+
+ where R is mass density and fᵢₙₜ and fₑₓₜ are internal and external force
+ densities respectively. Using finite element method to discretize space, one
+ gets
+
+    ϕ(X,t) = ∑ᵢ xᵢ(t)Nᵢ(X)
+    V(X,t) = ∑ᵢ vᵢ(t)Nᵢ(X)
+    A(X,t) = ∑ᵢ aᵢ(t)Nᵢ(X)
+
+where xᵢ, vᵢ, aᵢ ∈ R³ are nodal values of the spatially discretized position,
+velocity and acceleration, and Nᵢ(X):Ω⁰ → R are the the basis functions. With
+this spatial discretization, the PDE is turned in an ODE of the form
+
+    G(x, v, a) = 0,            (1)
+
+where x, v, a are the stacked xᵢ, vᵢ, aᵢ. %FemModel provides methods to
+query various information about equation (1) given an FEM state (x, v, a) such
+as the residual, G(x, v, a) (see CalcResidual()); the stiffness matrix, ∂G/∂x
+(see CalcStiffnessMatrix()); the damping matrix, ∂G/∂v (see
+CalcDampingMatrix()); the mass matrix, ∂G/∂a (see CalcMassMatrix()).
+@tparam_nonsymbolic_scalar */
+template <typename T>
+class FemModel {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FemModel);
+  virtual ~FemModel() = default;
+
+  /** The number of nodes that are associated with this model. */
+  int num_nodes() const { return num_nodes_; }
+
+  /** The number of degrees of freedom in this model. */
+  int num_dofs() const { return 3 * num_nodes_; }
+
+  /** The number of FEM elements in this model. */
+  virtual int num_elements() const = 0;
+
+  /** Creates a default FEM state for this model, where the positions are set to
+   the reference positions and the velocity and the accelerations are set to
+   zero. */
+  std::unique_ptr<FemState<T>> MakeFemState() const;
+
+  /** Calculates the residual at the given FEM state.
+  @pre residual != nullptr.
+  @throw std::exception if the FEM state is incompatible with this model.
+  @note Use MakeFemState() to create an FEM state compatible with this
+  model. */
+  void CalcResidual(const FemState<T>& state,
+                    EigenPtr<VectorX<T>> residual) const;
+
+  /** Calculates the tangent matrix at the given FEM state. The tangent matrix
+   is given by a weight sum of stiffness matrix, damping matrix, and mass
+   matrix.
+   @param[in] state            The FemState at which the tangent matrix is
+                               evaluated.
+   @param[in] weights          The weight used to combine stiffness, damping,
+                               and tangent matrices (in that order) into the
+                               tangent matrix.
+   @param[out] tangent_matrix  The output tangent_matrix.
+   @pre tangent_matrix != nullptr.
+   @pre The size of `tangent_matrix` is `num_dofs()` * `num_dofs()`.
+   @throw std::exception if the FEM state is incompatible with this model.
+   @note Use MakeFemState() to create an FEM state compatible with this
+   model. */
+  void CalcTangentMatrix(const FemState<T>& state,
+                         const Vector3<T>& weights,
+                         Eigen::SparseMatrix<T>* tangent_matrix) const;
+
+  /* Alternative signature for calculating tangent matrix that writes to a
+   PETSc matrix.
+   @param[in] state            The FemState at which the tangent matrix is
+                               evaluated.
+   @param[in] weights          The weight used to combine stiffness, damping,
+                               and tangent matrices (in that order) into the
+                               tangent matrix.
+   @param[out] tangent_matrix  The output tangent_matrix.
+   @pre tangent_matrix != nullptr.
+   @pre The size of `tangent_matrix` is `num_dofs()` by `num_dofs()`.
+   @throw std::exception if the FEM state is incompatible with this model.
+   @note Use MakeFemState() to create an FEM state compatible with this
+   model. */
+  void CalcTangentMatrix(
+      const FemState<T>& state, const Vector3<T>& weights,
+      internal::PetscSymmetricBlockSparseMatrix* tangent_matrix) const;
+
+  /** Creates an Eigen::SparseMatrix that has the sparsity pattern of the
+   tangent matrix of this FEM model. In particular, the size of the tangent
+   matrix is `num_dofs()` by `num_dofs()`. */
+  Eigen::SparseMatrix<T> MakeEigenSparseTangentMatrix() const;
+
+  // TODO(xuchenhan-tri): We are returning a pointer to internal objects in a
+  //  public method in a non-internal class.
+  /** Creates a PetscSymmetricBlockSparseMatrix that has the sparsity pattern of
+   the tangent matrix of this FEM model. In particular, the size of the tangent
+   matrix is `num_dofs()` by `num_dofs()`. */
+  std::unique_ptr<internal::PetscSymmetricBlockSparseMatrix>
+  MakePetscSymmetricBlockSparseTangentMatrix() const;
+
+  /** Applies boundary condition set for this %FemModel to the input
+   `state`. No-op if no boundary condition is set.
+   @pre state != nullptr. */
+  void ApplyBoundaryCondition(FemState<T>* state) const;
+
+  // TODO(xuchenhan-tri): Internal object in public method in non-internal
+  //  class.
+  /** Sets the Dirichlet boundary condition that this model is subject to. */
+  void SetDirichletBoundaryCondition(
+      internal::DirichletBoundaryCondition<T> dirichlet_bc) {
+    dirichlet_bc_ = std::move(dirichlet_bc);
+  }
+
+  /** Returns the dirichlet boundary condition that this model is subject to. */
+  const internal::DirichletBoundaryCondition<T>& dirichlet_boundary_condition()
+      const {
+    return dirichlet_bc_;
+  }
+
+  /** Returns the gravity vector for all elements in this model. */
+  const Vector3<T>& gravity() const { return gravity_; }
+
+  /** Sets the gravity vector of all existing and future elements in this model.
+   */
+  void SetGravityVector(const Vector3<T>& gravity);
+
+  /** (Internal use only) Throws std::exception to report a mismatch between
+  the concrete types of `this` FemModel and the FemState that was
+  passed to API method `func`. */
+  virtual void ThrowIfModelStateIncompatible(
+      const char* func, const FemState<T>& state_base) const = 0;
+
+ protected:
+  FemModel() = default;
+
+  /** Derived classes must override this method to provide an implementation for
+    the NVI MakeFemState(). */
+  virtual std::unique_ptr<FemState<T>> DoMakeFemState() const = 0;
+
+  /** Derived classes must override this method to provide an implementation
+   for the NVI CalcResidual(). The input `state` is guaranteed to be
+   compatible with `this` FEM model. */
+  virtual void DoCalcResidual(const FemState<T>& state,
+                              EigenPtr<VectorX<T>> residual) const = 0;
+
+  /** Derived classes must override this method to provide an implementation for
+   the NVI CalcTangentMatrix(). The input `state` is guaranteed to be compatible
+   with `this` FEM model. */
+  virtual void DoCalcTangentMatrix(
+      const FemState<T>& state, const Vector3<T>& weights,
+      Eigen::SparseMatrix<T>* tangent_matrix) const = 0;
+
+  /** Derived classes must override this method to provide an implementation for
+   the NVI CalcTangentMatrix(). The input `state` is guaranteed to be compatible
+   with `this` FEM model. */
+  virtual void DoCalcTangentMatrix(
+      const FemState<T>& state, const Vector3<T>& weights,
+      internal::PetscSymmetricBlockSparseMatrix* tangent_matrix) const = 0;
+
+  /** Derived classes must override this method to provide an implementation for
+   the NVI MakeEigenSparseTangentMatrix(). */
+  virtual Eigen::SparseMatrix<T> DoMakeEigenSparseTangentMatrix() const = 0;
+
+  /** Derived classes must override this method to provide an implementation for
+   the NVI MakePetscSymmetricBlockSparseTangentMatrix(). */
+  virtual std::unique_ptr<internal::PetscSymmetricBlockSparseMatrix>
+  DoMakePetscSymmetricBlockSparseTangentMatrix() const = 0;
+
+  /** Derived classes must override this method to set the gravity vector for
+   all existing elements in the model. */
+  virtual void DoSetGravityVector(const Vector3<T>& gravity) = 0;
+
+  /** Derived classes must invoke this method to update the number of nodes in
+   the model when they add more nodes to the FEM model. */
+  void increment_num_nodes(int num_new_nodes) { num_nodes_ += num_new_nodes; }
+
+ private:
+  /* The total number of nodes in the system. */
+  int num_nodes_{0};
+  /* The Dirichlet boundary condition that the model is subject to. */
+  internal::DirichletBoundaryCondition<T> dirichlet_bc_;
+
+  /* Returns the gravity vector for all elements in the model. */
+  Vector3<T> gravity_{0, 0, -9.81};
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::FemModel);

--- a/multibody/fem/fem_model_impl.h
+++ b/multibody/fem/fem_model_impl.h
@@ -1,0 +1,360 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <Eigen/Sparse>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/fem_element.h"
+#include "drake/multibody/fem/fem_indexes.h"
+#include "drake/multibody/fem/fem_model.h"
+#include "drake/multibody/fem/fem_state_impl.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+/* FemModelImpl provides a fixed size implementaion of FemModel by
+ templatizing on the type of FemElement. See FemModel for more information
+ on the user-facing APIs of this class. Many methods provided by FemModel
+ (e.g. FemModel::CalcTangentMatrix) involve evaluating computationally
+ intensive loops over FemElement, and the overhead caused by virtual methods may
+ be significant. Therefore, this class is templated on the FemElement to avoid
+ the overhead of virtual methods. The type information at compile time also
+ helps eliminate heap allocations.
+ @tparam Element    The type of FEM elements that makes up this FemModelImpl.
+ This template parameter must be an instantiation of FemElement, which provides
+ the scalar type and the compile time constants such as the natural dimension
+ and the number of nodes/quadrature points in each
+ element. See FemElements for more details. */
+template <class Element>
+class FemModelImpl : public FemModel<typename Element::Traits::T> {
+ public:
+  static_assert(
+      std::is_base_of_v<FemElement<Element, typename Element::Traits>, Element>,
+      "The template parameter Element should be derived from FemElement. ");
+  using T = typename Element::Traits::T;
+  using ElementType = Element;
+
+  int num_elements() const final { return elements_.size(); }
+
+ protected:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FemModelImpl);
+
+  /* Creates an empty FemModelImpl with no elements. */
+  FemModelImpl() = default;
+
+  virtual ~FemModelImpl() = default;
+
+  /* Derived classes must override this method to create a default FemStateImpl
+   for this model, which initializes the positions, velocities, and
+   accelerations of all nodes in the model. */
+  virtual FemStateImpl<Element> DoMakeFemStateImpl() const = 0;
+
+  const Element& element(ElementIndex i) const {
+    DRAKE_ASSERT(i.is_valid());
+    DRAKE_ASSERT(i < num_elements());
+    return elements_[i];
+  }
+
+  Element& mutable_element(ElementIndex i) {
+    DRAKE_ASSERT(i.is_valid());
+    DRAKE_ASSERT(i < num_elements());
+    return elements_[i];
+  }
+
+  /* Moves the input `element` into the vector of elements held by this
+   FemModelImpl. */
+  void AddElement(Element&& element) {
+    elements_.emplace_back(std::move(element));
+  }
+
+  /* Alternative signature for adding a new element to this FemModelImpl.
+   Forwards the arguments `args` to the constructor of the Element and
+   potentially creates the new element in place. */
+  template <typename... Args>
+  void AddElement(Args&&... args) {
+    elements_.emplace_back(std::forward<Args>(args)...);
+  }
+
+ private:
+  /* Implements FemModel::MakeFemState(). */
+  std::unique_ptr<FemState<T>> DoMakeFemState() const final {
+    auto state = std::make_unique<FemStateImpl<Element>>(DoMakeFemStateImpl());
+    /* Initialize per-element state-dependent data. */
+    state->MakeElementData(elements_);
+    return state;
+  }
+
+  /* Helper for DoCalcResidual(). */
+  void CalcResidualForConcreteState(const FemStateImpl<Element>& state,
+                                    EigenPtr<VectorX<T>> residual) const {
+    DRAKE_DEMAND(residual != nullptr && residual->size() == this->num_dofs());
+    DRAKE_DEMAND(state.element_cache_size() == num_elements());
+    /* The values are accumulated in the residual, so it is important to clear
+     the old data. */
+    residual->setZero();
+    /* Aliases to improve readability. */
+    constexpr int kNumDofs = Element::Traits::num_dofs;
+    constexpr int kNumNodes = Element::Traits::num_nodes;
+    constexpr int kDim = Element::Traits::kSpatialDimension;
+    /* Scratch space to store the contribution to the residual from each
+     element. */
+    Vector<T, kNumDofs> element_residual;
+    for (ElementIndex e(0); e < num_elements(); ++e) {
+      elements_[e].CalcResidual(state, &element_residual);
+      const std::array<NodeIndex, kNumNodes>& element_node_indices =
+          elements_[e].node_indices();
+      for (int i = 0; i < kNumNodes; ++i) {
+        const int ei = element_node_indices[i];
+        residual->template segment<kDim>(ei * kDim) +=
+            element_residual.template segment<kDim>(i * kDim);
+      }
+    }
+  }
+
+  /* Helper for DoCalcTangentMatrix(). */
+  void CalcTangentMatrixForConcreteState(
+      const FemStateImpl<Element>& state, const Vector3<T>& weights,
+      Eigen::SparseMatrix<T>* tangent_matrix) const {
+    DRAKE_DEMAND(tangent_matrix != nullptr &&
+                 tangent_matrix->rows() == this->num_dofs() &&
+                 tangent_matrix->cols() == this->num_dofs());
+    DRAKE_DEMAND(state.element_cache_size() == num_elements());
+    /* The values are accumulated in the tangent_matrix, so it is important to
+     clear the old data. */
+    using Iterator = typename Eigen::SparseMatrix<T>::InnerIterator;
+    for (int k = 0; k < tangent_matrix->outerSize(); ++k) {
+      for (Iterator it(*tangent_matrix, k); it; ++it) {
+        it.valueRef() = 0;
+      }
+    }
+    /* Aliases to improve readability. */
+    constexpr int kNumDofs = Element::Traits::num_dofs;
+    constexpr int kNumNodes = Element::Traits::num_nodes;
+    constexpr int kDim = Element::Traits::kSpatialDimension;
+    /* Scratch space to store the contribution to the tangent matrix from each
+     element. */
+    Eigen::Matrix<T, kNumDofs, kNumDofs> element_tangent_matrix;
+    for (ElementIndex e(0); e < num_elements(); ++e) {
+      element_tangent_matrix.setZero();
+      elements_[e].CalcTangentMatrix(state, weights, &element_tangent_matrix);
+      const std::array<NodeIndex, kNumNodes>& element_node_indices =
+          elements_[e].node_indices();
+      for (int a = 0; a < kNumNodes; ++a) {
+        for (int i = 0; i < kDim; ++i) {
+          for (int b = 0; b < kNumNodes; ++b) {
+            for (int j = 0; j < kDim; ++j) {
+              tangent_matrix->coeffRef(element_node_indices[a] * kDim + i,
+                                       element_node_indices[b] * kDim + j) +=
+                  element_tangent_matrix(a * kDim + i, b * kDim + j);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /* Helper for DoCalcTangentMatrix(). */
+  void CalcTangentMatrixForConcreteState(
+      const FemStateImpl<Element>& state, const Vector3<T>& weights,
+      PetscSymmetricBlockSparseMatrix* tangent_matrix) const {
+    if constexpr (!std::is_same_v<typename Element::T, double>) {
+      throw std::logic_error(
+          "The PetscSymmetricBlockSparseMatrix overload of "
+          "FemModelImpl::CalcTangentMatrixForConcreteState() only supports "
+          "scalar "
+          "type `double`.");
+    } else {
+      DRAKE_DEMAND(tangent_matrix != nullptr &&
+                   tangent_matrix->rows() == this->num_dofs() &&
+                   tangent_matrix->cols() == this->num_dofs());
+      DRAKE_DEMAND(state.element_cache_size() == num_elements());
+
+      /* The values are accumulated in the tangent_matrix, so it is important to
+       clear the old data. */
+      tangent_matrix->SetZero();
+
+      /* Aliases to improve readability. */
+      constexpr int kNumDofs = Element::Traits::num_dofs;
+      constexpr int kNumNodes = Element::Traits::num_nodes;
+
+      /* Scratch space to store the contribution to the tangent matrix from each
+       element. */
+      Vector<int, kNumNodes> block_indices;
+      Eigen::Matrix<T, kNumDofs, kNumDofs> element_tangent_matrix;
+      for (ElementIndex e(0); e < num_elements(); ++e) {
+        elements_[e].CalcTangentMatrix(state, weights, &element_tangent_matrix);
+        const std::array<NodeIndex, kNumNodes>& element_node_indices =
+            elements_[e].node_indices();
+        // TODO(xuchenhan-tri): Avoid this index copy.
+        for (int a = 0; a < kNumNodes; ++a) {
+          block_indices(a) = element_node_indices[a];
+        }
+        tangent_matrix->AddToBlock(block_indices, element_tangent_matrix);
+      }
+    }
+  }
+
+  /* Implements FemModel::DoMakeEigenSparseTangentMatrix(). */
+  Eigen::SparseMatrix<T> DoMakeEigenSparseTangentMatrix() const final {
+    Eigen::SparseMatrix<T> tangent_matrix(this->num_dofs(), this->num_dofs());
+    std::vector<Eigen::Triplet<T>> non_zero_entries;
+    /* Alias for readability. */
+    constexpr int element_num_dofs = Element::Traits::num_dofs;
+    constexpr int element_num_nodes = Element::Traits::num_nodes;
+    constexpr int kDim = Element::Traits::kSpatialDimension;
+    /* Get an upper bound for the number of nonzero entries and allocate
+     memories for them in the vector of triplets. */
+    non_zero_entries.reserve(num_elements() * element_num_dofs *
+                             element_num_dofs);
+    /* Create a nonzero block for each pair of nodes that are connected by an
+     edge in the mesh. */
+    for (int e = 0; e < num_elements(); ++e) {
+      const std::array<NodeIndex, element_num_nodes>& element_node_indices =
+          elements_[e].node_indices();
+      for (int a = 0; a < element_num_nodes; ++a) {
+        for (int i = 0; i < kDim; ++i) {
+          const int row_index = kDim * element_node_indices[a] + i;
+          for (int b = 0; b < element_num_nodes; ++b) {
+            for (int j = 0; j < kDim; ++j) {
+              const int col_index = kDim * element_node_indices[b] + j;
+              non_zero_entries.emplace_back(row_index, col_index, 0);
+            }
+          }
+        }
+      }
+    }
+    tangent_matrix.setFromTriplets(non_zero_entries.begin(),
+                                   non_zero_entries.end());
+    tangent_matrix.makeCompressed();
+    return tangent_matrix;
+  }
+
+  /* Implements FemModel::MakePetscSymmetricBlockSparseTangentMatrix(). */
+  std::unique_ptr<PetscSymmetricBlockSparseMatrix>
+  DoMakePetscSymmetricBlockSparseTangentMatrix() const final {
+    std::vector<std::unordered_set<int>> neighbor_nodes(this->num_nodes());
+    /* Alias for readability. */
+    constexpr int element_num_nodes = Element::Traits::num_nodes;
+    constexpr int element_num_dofs = Element::Traits::num_dofs;
+    constexpr int kDim = Element::Traits::kSpatialDimension;
+    /* Create a nonzero block for each pair of nodes that are connected by an
+     edge in the mesh. */
+    for (int e = 0; e < num_elements(); ++e) {
+      const std::array<NodeIndex, element_num_nodes>& element_node_indices =
+          elements_[e].node_indices();
+      for (int a = 0; a < element_num_nodes; ++a) {
+        for (int b = a; b < element_num_nodes; ++b) {
+          const int block_row =
+              std::min(element_node_indices[a], element_node_indices[b]);
+          const int block_col =
+              std::max(element_node_indices[a], element_node_indices[b]);
+          neighbor_nodes[block_row].insert(block_col);
+        }
+      }
+    }
+    std::vector<int> nonzero_blocks(this->num_nodes());
+    for (int i = 0; i < this->num_nodes(); ++i) {
+      nonzero_blocks[i] = neighbor_nodes[i].size();
+    }
+    auto tangent_matrix = std::make_unique<PetscSymmetricBlockSparseMatrix>(
+        this->num_dofs(), kDim, nonzero_blocks);
+
+    /* Populate the tangent matrix with zeros at appropriate places to allocate
+     memory. */
+    Vector<int, element_num_nodes> block_indices;
+    const Eigen::Matrix<double, element_num_dofs, element_num_dofs>
+        zero_matrix =
+            Eigen::Matrix<double, element_num_dofs, element_num_dofs>::Zero();
+    for (ElementIndex e(0); e < num_elements(); ++e) {
+      const std::array<NodeIndex, element_num_nodes>& element_node_indices =
+          elements_[e].node_indices();
+      // TODO(xuchenhan-tri): Avoid this index copy.
+      for (int a = 0; a < element_num_nodes; ++a) {
+        block_indices(a) = element_node_indices[a];
+      }
+      tangent_matrix->AddToBlock(block_indices, zero_matrix);
+    }
+    return tangent_matrix;
+  }
+
+  /* Implements FemModel::CalcResidual() by casting the FemState
+   to its concrete type. */
+  void DoCalcResidual(const FemState<T>& state,
+                      EigenPtr<VectorX<T>> residual) const final {
+    const FemStateImpl<Element>& concrete_state = cast_to_concrete_state(state);
+    CalcResidualForConcreteState(concrete_state, residual);
+  }
+
+  /* Implements FemModel::CalcTangentMatrix() by casting the
+   FemState to its concrete type. */
+  void DoCalcTangentMatrix(const FemState<T>& state, const Vector3<T>& weights,
+                           Eigen::SparseMatrix<T>* tangent_matrix) const final {
+    const FemStateImpl<Element>& concrete_state = cast_to_concrete_state(state);
+    CalcTangentMatrixForConcreteState(concrete_state, weights, tangent_matrix);
+  }
+
+  /* Implements FemModel::CalcTangentMatrix() by casting the
+   FemState to its concrete type. */
+  void DoCalcTangentMatrix(
+      const FemState<T>& state, const Vector3<T>& weights,
+      PetscSymmetricBlockSparseMatrix* tangent_matrix) const final {
+    const FemStateImpl<Element>& concrete_state = cast_to_concrete_state(state);
+    CalcTangentMatrixForConcreteState(concrete_state, weights, tangent_matrix);
+  }
+
+  /* Implements FemModel::SetGravityVector(). */
+  void DoSetGravityVector(const Vector3<T>& gravity) {
+    /* Update the gravity vector of all existing elements. */
+    for (ElementIndex e(0); e < num_elements(); ++e) {
+      elements_[e].set_gravity_vector(gravity);
+    }
+  }
+
+  /* Statically cast the given FemState to the FemStateImpl compatible
+   with `this` FemModelImpl.
+   @pre The given `abstract_state` is compatible with the `this` FemModelImpl.
+  */
+  const FemStateImpl<Element>& cast_to_concrete_state(
+      const FemState<T>& abstract_state) const {
+    const auto& concrete_state =
+        static_cast<const FemStateImpl<Element>&>(abstract_state);
+    return concrete_state;
+  }
+
+  /* Implements FemModel::ThrowIfModelStateIncompatible(). */
+  void ThrowIfModelStateIncompatible(
+      const char* func, const FemState<T>& abstract_state) const final {
+    const auto* concrete_state_ptr =
+        dynamic_cast<const FemStateImpl<Element>*>(&abstract_state);
+    if (concrete_state_ptr == nullptr) {
+      throw std::logic_error(std::string(func) +
+                             "(): The type of the FemStateImpl is incompatible "
+                             "with the type of the "
+                             "FemModelImpl.");
+    }
+    if (concrete_state_ptr->num_dofs() != this->num_dofs()) {
+      throw std::logic_error(
+          fmt::format("{}(): The size of the FemStateImpl ({}) is incompatible "
+                      "with the size of the FemModelImpl ({}).",
+                      func, concrete_state_ptr->num_dofs(), this->num_dofs()));
+    }
+  }
+
+  /* FemElements owned by this model. */
+  std::vector<Element> elements_{};
+};
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/fem_solver.cc
+++ b/multibody/fem/fem_solver.cc
@@ -1,0 +1,126 @@
+#include "drake/multibody/fem/fem_solver.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+template <typename T>
+FemSolver<T>::FemSolver(const FemModel<T>* model,
+                        const DiscreteTimeIntegrator<T>* integrator)
+    : model_(model), integrator_(integrator) {
+  DRAKE_DEMAND(model_ != nullptr);
+  DRAKE_DEMAND(integrator_ != nullptr);
+  ResetScratchDataIfNecessary();
+}
+
+template <typename T>
+int FemSolver<T>::AdvanceOneTimeStep(const FemState<T>& prev_state,
+                                     FemState<T>* next_state) const {
+  DRAKE_DEMAND(next_state != nullptr);
+  model_->ThrowIfModelStateIncompatible(__func__, prev_state);
+  model_->ThrowIfModelStateIncompatible(__func__, *next_state);
+  /* Make initial guess of the unknown variable that it stays the same. */
+  const VectorX<T>& unknown_variable = integrator_->GetUnknowns(prev_state);
+  integrator_->AdvanceOneTimeStep(prev_state, unknown_variable, next_state);
+  /* Run Newton-Raphson iterations. */
+  return SolveWithInitialGuess(next_state);
+}
+
+template <typename T>
+void FemSolver<T>::set_linear_solve_tolerance(const T& residual_norm) const {
+  /* The relative tolerance when solving for A * dz = -b, where A is the tangent
+   matrix. We set it to be on the order of the residual norm to achieve local
+   second order convergence [Nocedal and Wright, section 7.1]. We set it to be
+   smaller than or equal to the relative tolerance to ensure that linear models
+   converge in exact one Newton iteration.
+
+   [Nocedal and Wright] Nocedal, J., & Wright, S. (2006). Numerical
+   optimization. Springer Science & Business Media. */
+  double linear_solve_tolerance =
+      std::min(ExtractDoubleOrThrow(relative_tolerance_),
+               ExtractDoubleOrThrow(residual_norm));
+  if constexpr (std::is_same_v<T, double>) {
+    if (tangent_matrix_petsc_ != nullptr) {
+      tangent_matrix_petsc_->set_relative_tolerance(linear_solve_tolerance);
+    }
+  } else {
+    eigen_tangent_matrix_solver_.setTolerance(linear_solve_tolerance);
+  }
+}
+
+template <typename T>
+int FemSolver<T>::SolveWithInitialGuess(FemState<T>* state) const {
+  /* Make sure the scratch quantities are of the correct sizes. */
+  ResetScratchDataIfNecessary();
+  model_->ApplyBoundaryCondition(state);
+  model_->CalcResidual(*state, &b_);
+  T residual_norm = b_.norm();
+  T initial_residual_norm = residual_norm;
+  int iter = 0;
+  /* Newton-Raphson iterations. We iterate until any of the following is true:
+   1. The max number of allowed iterations is reached;
+   2. The norm of the residual is smaller than the absolute tolerance.
+   3. The relative error (the norm of the residual divided by the norm of the
+      initial residual) is smaller than the unitless relative tolerance. */
+  do {
+    set_linear_solve_tolerance(residual_norm);
+    /* Use PETSc matrix when scalar type is double. Otherwise, use Eigen
+     matrix. */
+    if constexpr (std::is_same_v<T, double>) {
+      model_->CalcTangentMatrix(*state, integrator_->weights(),
+                                tangent_matrix_petsc_.get());
+      tangent_matrix_petsc_->AssembleIfNecessary();
+      /* Solve for A * dz = -b, where A is the tangent matrix. */
+      dz_ = tangent_matrix_petsc_->Solve(
+          internal::PetscSymmetricBlockSparseMatrix::SolverType::
+              kConjugateGradient,
+          internal::PetscSymmetricBlockSparseMatrix::PreconditionerType::
+              kIncompleteCholesky,
+          -b_);
+    } else {
+      model_->CalcTangentMatrix(*state, integrator_->weights(),
+                                &tangent_matrix_eigen_);
+      /* Solve for A * dz = -b, where A is the tangent matrix. */
+      eigen_tangent_matrix_solver_.compute(tangent_matrix_eigen_);
+      dz_ = eigen_tangent_matrix_solver_.solve(-b_);
+    }
+    integrator_->UpdateStateFromChangeInUnknowns(dz_, state);
+    model_->CalcResidual(*state, &b_);
+    residual_norm = b_.norm();
+    ++iter;
+  } while (iter < kMaxIterations &&
+           residual_norm > relative_tolerance_ * initial_residual_norm &&
+           residual_norm > absolute_tolerance_);
+  if (iter == kMaxIterations) {
+    throw std::runtime_error(fmt::format(
+        "The solver did not converge in {} iterations. Please provide a "
+        "better initial guess. Consider taking a smaller time step, "
+        "especially if the constitutive model you are using is nonlinear "
+        "(e.g. CorotatedModel).",
+        kMaxIterations));
+  }
+  return iter;
+}
+
+template <typename T>
+void FemSolver<T>::ResetScratchDataIfNecessary() const {
+  if (b_.size() != model_->num_dofs()) {
+    b_.resize(model_->num_dofs());
+    dz_.resize(model_->num_dofs());
+    if constexpr (std::is_same_v<T, double>) {
+      tangent_matrix_petsc_ =
+          model_->MakePetscSymmetricBlockSparseTangentMatrix();
+    } else {
+      tangent_matrix_eigen_ = model_->MakeEigenSparseTangentMatrix();
+    }
+  }
+}
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::internal::FemSolver);

--- a/multibody/fem/fem_solver.h
+++ b/multibody/fem/fem_solver.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/discrete_time_integrator.h"
+#include "drake/multibody/fem/fem_model.h"
+#include "drake/multibody/fem/fem_state.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+/* FemSolver solves discrete dynamic elasticity problems. The governing PDE of
+ the dynamics is spatially discretized in FemModel and temporally
+ discretized by DiscreteTimeIntegrator. FemSolver provides the
+ AdvanceOneTimeStep method that advances the states of the spatially discretized
+ FEM model by one time step according to the prescribed discrete time
+ integration scheme using a Newton-Raphson solver.
+ @tparam_nonsymbolic_scalar. */
+template <typename T>
+class FemSolver {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FemSolver);
+
+  /* Max number of Newton-Raphson iterations the solver takes before it gives
+   up. */
+  static constexpr int kMaxIterations = 100;
+
+  /* Constructs a new FemSolver that solves the given `model` with the
+   `integrator` provided to advance time.
+   @note The `model` and `integrator` pointers persist in `this` FemSolver and
+   thus the model and the integrator must outlive this solver.
+   @pre model != nullptr.
+   @pre integrator != nullptr.*/
+  FemSolver(const FemModel<T>* model,
+            const DiscreteTimeIntegrator<T>* integrator);
+
+  /* Advances the state of the FEM model by one time step with the integrator
+   prescribed at construction.
+   @param[in] prev_state   The state of the FEM model evaluated at the previous
+                           time step.
+   @param[out] next_state  The state of the FEM model evaluated at the next time
+                           step.
+   @returns the number of Newton-Raphson iterations the solver takes to
+   converge.
+   @pre next_state != nullptr.
+   @pre prev_state.num_dofs() == next_state->dofs().
+   @throw std::exception if the input `prev_state` or `next_state` is
+   incompatible with the FEM model solved by this solver.
+   @throw std::exception if the solver doesn't converge after `kMaxIterations`
+   Newton-Raphson iterations. */
+  int AdvanceOneTimeStep(const FemState<T>& prev_state,
+                         FemState<T>* next_state) const;
+
+  /* Returns the FEM model that this solver solves for. */
+  const FemModel<T>& model() const { return *model_; }
+
+  /* Returns the discrete time integrator that this solver uses. */
+  const DiscreteTimeIntegrator<T>& integrator() const { return *integrator_; }
+
+  /* Sets the relative tolerance, unitless. The Newton-Raphson iterations are
+   considered as converged if the norm of the residual is smaller than the
+   relative tolerance times the norm of the residual at the start of the
+   Newton-Raphson iterations. The default value is 1e-4. */
+  void set_relative_tolerance(const T& tolerance) {
+    relative_tolerance_ = tolerance;
+  }
+
+  const T& relative_tolerance() const { return relative_tolerance_; }
+
+  /* Sets the absolute tolerance with unit N. The Newton-Raphson iterations are
+   considered as converged if the norm of the residual is smaller than the
+   absolute tolerance. The default value is 1e-6. */
+  void set_absolute_tolerance(const T& tolerance) {
+    absolute_tolerance_ = tolerance;
+  }
+
+  const T& absolute_tolerance() const { return absolute_tolerance_; }
+
+ private:
+  /* Uses a Newton-Raphson solver to solve for the equilibrium state that
+   satisfies the tolerances. See set_relative_tolerance() and
+   set_absolute_tolerance() for convergence criteria. The input FEM state is
+   non-null and is guaranteed to be compatible with the FEM model.
+   @param[in, out] state  As input, `state` provides an initial guess of
+   the solution. As output, `state` reports the equilibrium state. */
+  int SolveWithInitialGuess(FemState<T>* state) const;
+
+  /* Reset the scratch data in this class (tangent matrix, residual, and dz) if
+   necessary. */
+  void ResetScratchDataIfNecessary() const;
+
+  /* Updates the relative tolerance for the linear solver used in the
+   Newton-Raphson iterations based on the residual norm if the linear solver is
+   iterative. No-op if the linear solver is direct. */
+  void set_linear_solve_tolerance(const T& residual_norm) const;
+
+  /* The FEM model being solved by `this` solver. */
+  const FemModel<T>* model_;
+  /* The discrete time integrator the solver uses. */
+  const DiscreteTimeIntegrator<T>* integrator_;
+  /* A scratch sparse matrix to store the tangent matrix of the model. We use
+   PETSc matrix for T=double and an Eigen::SparseMatrix otherwise. */
+  mutable Eigen::SparseMatrix<T> tangent_matrix_eigen_;
+  mutable std::unique_ptr<internal::PetscSymmetricBlockSparseMatrix>
+      tangent_matrix_petsc_;
+  /* Solver for the tangent matrix when T!=double.  */
+  mutable Eigen::ConjugateGradient<Eigen::SparseMatrix<T>,
+                                   Eigen::Lower | Eigen::Upper>
+      eigen_tangent_matrix_solver_;
+  /* A scratch vector to store the residual of the model. */
+  mutable VectorX<T> b_;
+  /* A scratch vector to store the solution to A * dz = -b, where A is the
+   tangent matrix. */
+  mutable VectorX<T> dz_;
+
+  T relative_tolerance_{1e-4};
+  T absolute_tolerance_{1e-6};
+};
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::internal::FemSolver);

--- a/multibody/fem/fem_state.cc
+++ b/multibody/fem/fem_state.cc
@@ -1,0 +1,32 @@
+#include "drake/multibody/fem/fem_state.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+
+template <typename T>
+void FemState<T>::SetPositions(const Eigen::Ref<const VectorX<T>>& q) {
+  DRAKE_THROW_UNLESS(q.size() == q_.size());
+  InvalidateAllCacheEntries();
+  q_ = q;
+}
+
+template <typename T>
+void FemState<T>::SetVelocities(const Eigen::Ref<const VectorX<T>>& v) {
+  DRAKE_THROW_UNLESS(v.size() == v_.size());
+  InvalidateAllCacheEntries();
+  v_ = v;
+}
+
+template <typename T>
+void FemState<T>::SetAccelerations(const Eigen::Ref<const VectorX<T>>& a) {
+  DRAKE_THROW_UNLESS(a.size() == a_.size());
+  InvalidateAllCacheEntries();
+  a_ = a;
+}
+
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::FemState);

--- a/multibody/fem/fem_state.h
+++ b/multibody/fem/fem_state.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+
+/** An abstract class that stores the FEM states. The states include the
+ generalized positions, velocities, and accelerations associated with each node.
+ @tparam_nonsymbolic_scalar */
+template <typename T>
+class FemState {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FemState);
+
+  virtual ~FemState() = default;
+
+  /** @name State getters. @{ */
+  const VectorX<T>& GetPositions() const { return q_; }
+
+  const VectorX<T>& GetVelocities() const { return v_; }
+
+  const VectorX<T>& GetAccelerations() const { return a_; }
+  /** @} */
+
+  /** @name State setters.
+   The size of the values provided must match the current size of the states.
+   Throw an exception otherwise.
+   @{ */
+  void SetPositions(const Eigen::Ref<const VectorX<T>>& q);
+
+  void SetVelocities(const Eigen::Ref<const VectorX<T>>& v);
+
+  void SetAccelerations(const Eigen::Ref<const VectorX<T>>& a);
+  /** @} */
+
+  /* Returns the number of generalized positions in the state. */
+  int num_dofs() const { return q_.size(); }
+
+ protected:
+  /** Constructs an %FemState with prescribed generalized positions,
+   velocities, and accelerations.
+   @param[in] q  The prescribed generalized positions.
+   @param[in] v  The prescribed generalized velocities.
+   @param[in] a  The prescribed generalized accelerations.
+   @pre q.size() == v.size().
+   @pre q.size() == a.size(). */
+  FemState(const Eigen::Ref<const VectorX<T>>& q,
+               const Eigen::Ref<const VectorX<T>>& v,
+               const Eigen::Ref<const VectorX<T>>& a)
+      : q_(q), v_(v), a_(a) {
+    DRAKE_DEMAND(q_.size() == v_.size());
+    DRAKE_DEMAND(q_.size() == a_.size());
+  }
+
+ private:
+  /* Invalidate state-dependent quantities. Should be called on state changes.
+   */
+  virtual void InvalidateAllCacheEntries() = 0;
+
+  /* Generalized positions. */
+  VectorX<T> q_{};
+  /* Generalized velocities. */
+  VectorX<T> v_{};
+  /* Generalized accelerations. */
+  VectorX<T> a_{};
+};
+
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::FemState);

--- a/multibody/fem/fem_state_impl.cc
+++ b/multibody/fem/fem_state_impl.cc
@@ -1,0 +1,35 @@
+#include "drake/multibody/fem/fem_state.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+
+template <typename T>
+void FemStateImplImplImplImplBase<T>::SetPositions(
+    const Eigen::Ref<const VectorX<T>>& q) {
+  DRAKE_THROW_UNLESS(q.size() == q_.size());
+  InvalidateAllCacheEntries();
+  q_ = q;
+}
+
+template <typename T>
+void FemStateImplImplImplImplBase<T>::SetVelocities(
+    const Eigen::Ref<const VectorX<T>>& v) {
+  DRAKE_THROW_UNLESS(v.size() == v_.size());
+  InvalidateAllCacheEntries();
+  v_ = v;
+}
+
+template <typename T>
+void FemStateImplImplImplImplBase<T>::SetAccelerations(
+    const Eigen::Ref<const VectorX<T>>& a) {
+  DRAKE_THROW_UNLESS(a.size() == a_.size());
+  InvalidateAllCacheEntries();
+  a_ = a;
+}
+
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::FemStateImplImplImplImplBase);

--- a/multibody/fem/fem_state_impl.h
+++ b/multibody/fem/fem_state_impl.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/element_cache_entry.h"
+#include "drake/multibody/fem/fem_indexes.h"
+#include "drake/multibody/fem/fem_state.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+/* FemStateImpl implements FemState for a particular type of FEM element.
+ It is templated on the concrete FemElement type in order to allow compile time
+ optimizations based on fixed sizes. It also stores the per-element
+ state-dependent quantities for its corresponding elements (see
+ ElementCacheEntry).
+ @tparam Element The type of FemElement that consumes this FemStateImpl. This
+ template parameter provides the scalar type and the type of per-element data
+ this FemStateImpl stores. */
+template <typename Element>
+class FemStateImpl : public FemState<typename Element::T> {
+ public:
+  using T = typename Element::T;
+
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FemStateImpl);
+
+  /* Constructs an FemStateImpl with the prescribed positions, velocities, and
+   accelerations.
+   @param[in] q  The prescribed generalized positions.
+   @param[in] v  The prescribed generalized velocities.
+   @param[in] a  The prescribed generalized accelerations.
+   positions.
+   @pre q.size() == v.size().
+   @pre q.size() == a.size(). */
+  FemStateImpl(const Eigen::Ref<const VectorX<T>>& q,
+               const Eigen::Ref<const VectorX<T>>& v,
+               const Eigen::Ref<const VectorX<T>>& a)
+      : FemState<T>(q, v, a) {}
+
+  /* Creates the per-element state-dependent data for the given `elements`. The
+  following invariant must be satisfied: `elements[i].element_index() == i` --
+  the i-th element reports an element index of `i`, as FemStateImpl assumes this
+  invariant when the Element::Traits::Data are accessed via element_data().
+  @throw std::exception if elements[i].element_index() != i for some `i` = 0,
+  ..., `element.size()-1`. */
+  void MakeElementData(const std::vector<Element>& elements) {
+    /* Note: the element data is stored in a simple bespoke cache (see
+     internal::ElementCacheEntry). The newly created cache entries are
+     initially stale. */
+    element_cache_.clear();
+    for (int i = 0; i < static_cast<int>(elements.size()); ++i) {
+      if (elements[i].element_index() != ElementIndex(i)) {
+        throw std::runtime_error(
+            "Input element entry at " + std::to_string(i) + " has index " +
+            std::to_string(elements[i].element_index()) + " instead of " +
+            std::to_string(i) +
+            ". The entry with index i must be stored at position i.");
+      }
+    }
+    element_cache_.resize(elements.size());
+  }
+
+  /* Returns the number of element cache entries. */
+  int element_cache_size() const { return element_cache_.size(); }
+
+  /* Getter for element state-dependpent quantities. */
+  const typename Element::Traits::Data& element_data(
+      const Element& element) const {
+    ElementIndex id = element.element_index();
+    DRAKE_ASSERT(id.is_valid() && id < element_cache_size());
+    typename Element::Traits::Data& data =
+        element_cache_[id].mutable_element_data();
+    if (element_cache_[id].is_stale()) {
+      data = element.ComputeData(*this);
+      element_cache_[id].set_stale(false);
+    }
+    return data;
+  }
+
+ private:
+  friend class FemStateTest;
+
+  // TODO(xuchenhan-tri): Currently, all cache entries are thrashed when *any*
+  //  state (q, v, or a) is changed. For most FEM models, there exist more
+  //  fine-grained caching mechanisms which may improve the cache efficiency.
+  /* Mark all cache entries associated with `this` FemStateImpl as stale. */
+  void InvalidateAllCacheEntries() final {
+    for (auto& element_cache_entry : element_cache_) {
+      element_cache_entry.set_stale(true);
+    }
+  }
+
+  /* Owned element cache entries. */
+  mutable std::vector<ElementCacheEntry<typename Element::Traits::Data>>
+      element_cache_{};
+};
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/linear_constitutive_model.cc
+++ b/multibody/fem/linear_constitutive_model.cc
@@ -1,0 +1,85 @@
+#include "drake/multibody/fem/linear_constitutive_model.h"
+
+#include <array>
+#include <utility>
+
+#include "drake/common/autodiff.h"
+#include "drake/multibody/fem/calc_lame_parameters.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+template <typename T, int num_locations>
+LinearConstitutiveModel<T, num_locations>::LinearConstitutiveModel(
+    const T& youngs_modulus, const T& poisson_ratio)
+    : E_(youngs_modulus), nu_(poisson_ratio) {
+  const LameParameters<T> lame = CalcLameParameters(E_, nu_);
+  lambda_ = lame.lambda;
+  mu_ = lame.mu;
+  /* Recall that
+        Pᵢⱼ = 2μ * εᵢⱼ + λ * εₐₐ * δᵢⱼ,
+    So,
+        ∂Pᵢⱼ/∂Fₖₗ = 2μ * ∂εᵢⱼ/∂Fₖₗ + λ * ∂εₐₐ/∂Fₖₗ * δᵢⱼ,
+    Since
+        ∂εᵢⱼ/∂Fₖₗ = 0.5 * δᵢₖ δⱼₗ  + 0.5 * δᵢₗ δₖⱼ.
+    Plugging in, we get:
+        ∂Pᵢⱼ/∂Fₖₗ = μ * (δᵢₖδⱼₗ + δᵢₗ δⱼₖ) +  λ * δₖₗ * δᵢⱼ.
+    Keep in mind that the indices are laid out such that the ik-th entry in
+    the jl-th block corresponds to the value dPᵢⱼ/dFₖₗ.  */
+  /* First term. */
+  dPdF_ = mu_ * Eigen::Matrix<T, 9, 9>::Identity();
+  for (int k = 0; k < 3; ++k) {
+    /* Second term. */
+    for (int l = 0; l < 3; ++l) {
+      const int i = l;
+      const int j = k;
+      dPdF_(3 * j + i, 3 * l + k) += mu_;
+    }
+    /* Third term. */
+    for (int i = 0; i < 3; ++i) {
+      const int l = k;
+      const int j = i;
+      dPdF_(3 * j + i, 3 * l + k) += lambda_;
+    }
+  }
+}
+
+template <typename T, int num_locations>
+void LinearConstitutiveModel<T, num_locations>::CalcElasticEnergyDensityImpl(
+    const Data& data, std::array<T, num_locations>* Psi) const {
+  for (int i = 0; i < num_locations; ++i) {
+    const auto& strain = data.strain()[i];
+    const auto& trace_strain = data.trace_strain()[i];
+    (*Psi)[i] = mu_ * strain.squaredNorm() +
+                0.5 * lambda_ * trace_strain * trace_strain;
+  }
+}
+
+template <typename T, int num_locations>
+void LinearConstitutiveModel<T, num_locations>::CalcFirstPiolaStressImpl(
+    const Data& data, std::array<Matrix3<T>, num_locations>* P) const {
+  for (int i = 0; i < num_locations; ++i) {
+    const auto& strain = data.strain()[i];
+    const auto& trace_strain = data.trace_strain()[i];
+    (*P)[i] =
+        2.0 * mu_ * strain + lambda_ * trace_strain * Matrix3<T>::Identity();
+  }
+}
+
+template <typename T, int num_locations>
+void LinearConstitutiveModel<T, num_locations>::
+    CalcFirstPiolaStressDerivativeImpl(
+        const Data&,
+        std::array<Eigen::Matrix<T, 9, 9>, num_locations>* dPdF) const {
+  dPdF->fill(dPdF_);
+}
+
+template class LinearConstitutiveModel<double, 1>;
+template class LinearConstitutiveModel<AutoDiffXd, 1>;
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/linear_constitutive_model.h
+++ b/multibody/fem/linear_constitutive_model.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <array>
+
+#include "drake/multibody/fem/constitutive_model.h"
+#include "drake/multibody/fem/linear_constitutive_model_data.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+/* Traits for LinearConstitutiveModel. */
+template <typename T, int num_locations>
+struct LinearConstitutiveModelTraits {
+  using Scalar = T;
+  using Data = LinearConstitutiveModelData<T, num_locations>;
+};
+
+/* Implements the infinitesimal-strain linear elasticity constitutive model as
+ described in Section 7.4 of [Gonzalez, 2008].
+ @tparam_nonsymbolic_scalar.
+ @tparam num_locations Number of locations at which the constitutive
+ relationship is evaluated. We currently only provide one instantiation of this
+ template with `num_locations = 1`, but more instantiations can easily be added
+ when needed.
+
+[Gonzalez, 2008] Gonzalez, Oscar, and Andrew M. Stuart. A first course in
+continuum mechanics. Cambridge University Press, 2008. */
+template <typename T, int num_locations>
+class LinearConstitutiveModel final
+    : public ConstitutiveModel<
+          LinearConstitutiveModel<T, num_locations>,
+          LinearConstitutiveModelTraits<T, num_locations>> {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LinearConstitutiveModel)
+
+  using Base =
+      ConstitutiveModel<LinearConstitutiveModel<T, num_locations>,
+                        LinearConstitutiveModelTraits<T, num_locations>>;
+  using Data = typename Base::Data;
+
+  /* Constructs a LinearConstitutiveModel constitutive model with the
+   prescribed Young's modulus and Poisson ratio.
+   @param youngs_modulus Young's modulus of the model, with unit N/m²
+   @param poisson_ratio Poisson ratio of the model, unitless.
+   @pre youngs_modulus >= 0.
+   @pre -1 < poisson_ratio < 0.5. */
+  LinearConstitutiveModel(const T& youngs_modulus, const T& poisson_ratio);
+
+  const T& youngs_modulus() const { return E_; }
+
+  const T& poisson_ratio() const { return nu_; }
+
+  /* Returns the shear modulus (Lame's second parameter) which is given by
+   `E/(2*(1+nu))` where `E` is the Young's modulus and `nu` is the Poisson
+   ratio. See `fem::internal::CalcLameParameters()`. */
+  const T& shear_modulus() const { return mu_; }
+
+  /* Returns the Lame's first parameter which is given by
+   `E*nu/((1+nu)*(1-2*nu))` where `E` is the Young's modulus and `nu` is the
+   Poisson ratio. See `fem::internal::CalcLameParameters()`. */
+  const T& lame_first_parameter() const { return lambda_; }
+
+ private:
+  friend Base;
+
+  /* Shadows ConstitutiveModel::CalcElasticEnergyDensityImpl() as required by
+   the CRTP base class. */
+  void CalcElasticEnergyDensityImpl(const Data& data,
+                                    std::array<T, num_locations>* Psi) const;
+
+  /* Shadows ConstitutiveModel::CalcFirstPiolaStressImpl() as required by the
+   CRTP base class. */
+  void CalcFirstPiolaStressImpl(const Data& data,
+                                std::array<Matrix3<T>, num_locations>* P) const;
+
+  /* Shadows ConstitutiveModel::CalcFirstPiolaStressDerivativeImpl() as required
+   by the CRTP base class. */
+  void CalcFirstPiolaStressDerivativeImpl(
+      const Data& data,
+      std::array<Eigen::Matrix<T, 9, 9>, num_locations>* dPdF) const;
+
+  T E_;       // Young's modulus, N/m².
+  T nu_;      // Poisson ratio.
+  T mu_;      // Lamé's second parameter/Shear modulus, N/m².
+  T lambda_;  // Lamé's first parameter, N/m².
+  Eigen::Matrix<T, 9, 9>
+      dPdF_;  // The First Piola stress derivative is constant and precomputed.
+};
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/matrix_utilities.cc
+++ b/multibody/fem/matrix_utilities.cc
@@ -1,0 +1,174 @@
+#include "drake/multibody/fem/matrix_utilities.h"
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+template <typename T>
+void PolarDecompose(const Matrix3<T>& F, EigenPtr<Matrix3<T>> R,
+                    EigenPtr<Matrix3<T>> S) {
+  /* According to https://eigen.tuxfamily.org/dox/classEigen_1_1BDCSVD.html,
+   for matrix of size < 16, it's preferred to used JacobiSVD. */
+  const Eigen::JacobiSVD<Matrix3<T>, Eigen::HouseholderQRPreconditioner> svd(
+      F, Eigen::ComputeFullU | Eigen::ComputeFullV);
+  Matrix3<T> U = svd.matrixU();
+  const Matrix3<T>& V = svd.matrixV();
+  Vector3<T> sigma = svd.singularValues();
+  (*R).noalias() = U * V.transpose();
+  /* Ensure that R is a proper rotation. If R is a reflection, flip the sign of
+   the last column of U and the last singular value. */
+  if (R->determinant() < 0) {
+    U.col(2) *= -1.0;
+    sigma(2) *= -1.0;
+    (*R).noalias() = U * V.transpose();
+  }
+  (*S).noalias() = V * sigma.asDiagonal() * V.transpose();
+}
+
+template <typename T>
+void AddScaledRotationalDerivative(
+    const Matrix3<T>& R, const Matrix3<T>& S, const T& scale,
+    EigenPtr<Eigen::Matrix<T, 9, 9>> scaled_dRdF) {
+  Matrix3<T> A = -S;
+  A.diagonal().array() += S.trace();
+  const T J = A.determinant();
+  DRAKE_DEMAND(J != 0);
+  const T scale_over_J = scale / J;
+  const Matrix3<T> RA = R * A;
+  const Matrix3<T> sRA = scale_over_J * RA;
+  const Matrix3<T> sRART = sRA * R.transpose();
+  for (int a = 0; a < 3; ++a) {
+    for (int b = 0; b < 3; ++b) {
+      const int column_index = 3 * b + a;
+      for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+          const int row_index = 3 * j + i;
+          (*scaled_dRdF)(row_index, column_index) +=
+              sRART(i, a) * A(j, b) - sRA(i, b) * RA(a, j);
+        }
+      }
+    }
+  }
+}
+
+template <typename T>
+void CalcCofactorMatrix(const Matrix3<T>& M, EigenPtr<Matrix3<T>> cofactor) {
+  (*cofactor)(0, 0) = M(1, 1) * M(2, 2) - M(1, 2) * M(2, 1);
+  (*cofactor)(0, 1) = M(1, 2) * M(2, 0) - M(1, 0) * M(2, 2);
+  (*cofactor)(0, 2) = M(1, 0) * M(2, 1) - M(1, 1) * M(2, 0);
+  (*cofactor)(1, 0) = M(0, 2) * M(2, 1) - M(0, 1) * M(2, 2);
+  (*cofactor)(1, 1) = M(0, 0) * M(2, 2) - M(0, 2) * M(2, 0);
+  (*cofactor)(1, 2) = M(0, 1) * M(2, 0) - M(0, 0) * M(2, 1);
+  (*cofactor)(2, 0) = M(0, 1) * M(1, 2) - M(0, 2) * M(1, 1);
+  (*cofactor)(2, 1) = M(0, 2) * M(1, 0) - M(0, 0) * M(1, 2);
+  (*cofactor)(2, 2) = M(0, 0) * M(1, 1) - M(0, 1) * M(1, 0);
+}
+
+template <typename T>
+void AddScaledCofactorMatrixDerivative(
+    const Matrix3<T>& M, const T& scale,
+    EigenPtr<Eigen::Matrix<T, 9, 9>> scaled_dCdM) {
+  /* See the convention for ordering the 9-by-9 derivatives at the top of the
+   header file. */
+  const Matrix3<T> A = scale * M;
+  (*scaled_dCdM)(4, 0) += A(2, 2);
+  (*scaled_dCdM)(5, 0) += -A(1, 2);
+  (*scaled_dCdM)(7, 0) += -A(2, 1);
+  (*scaled_dCdM)(8, 0) += A(1, 1);
+  (*scaled_dCdM)(3, 1) += -A(2, 2);
+  (*scaled_dCdM)(5, 1) += A(0, 2);
+  (*scaled_dCdM)(6, 1) += A(2, 1);
+  (*scaled_dCdM)(8, 1) += -A(0, 1);
+  (*scaled_dCdM)(3, 2) += A(1, 2);
+  (*scaled_dCdM)(4, 2) += -A(0, 2);
+  (*scaled_dCdM)(6, 2) += -A(1, 1);
+  (*scaled_dCdM)(7, 2) += A(0, 1);
+  (*scaled_dCdM)(1, 3) += -A(2, 2);
+  (*scaled_dCdM)(2, 3) += A(1, 2);
+  (*scaled_dCdM)(7, 3) += A(2, 0);
+  (*scaled_dCdM)(8, 3) += -A(1, 0);
+  (*scaled_dCdM)(0, 4) += A(2, 2);
+  (*scaled_dCdM)(2, 4) += -A(0, 2);
+  (*scaled_dCdM)(6, 4) += -A(2, 0);
+  (*scaled_dCdM)(8, 4) += A(0, 0);
+  (*scaled_dCdM)(0, 5) += -A(1, 2);
+  (*scaled_dCdM)(1, 5) += A(0, 2);
+  (*scaled_dCdM)(6, 5) += A(1, 0);
+  (*scaled_dCdM)(7, 5) += -A(0, 0);
+  (*scaled_dCdM)(1, 6) += A(2, 1);
+  (*scaled_dCdM)(2, 6) += -A(1, 1);
+  (*scaled_dCdM)(4, 6) += -A(2, 0);
+  (*scaled_dCdM)(5, 6) += A(1, 0);
+  (*scaled_dCdM)(0, 7) += -A(2, 1);
+  (*scaled_dCdM)(2, 7) += A(0, 1);
+  (*scaled_dCdM)(3, 7) += A(2, 0);
+  (*scaled_dCdM)(5, 7) += -A(0, 0);
+  (*scaled_dCdM)(0, 8) += A(1, 1);
+  (*scaled_dCdM)(1, 8) += -A(0, 1);
+  (*scaled_dCdM)(3, 8) += -A(1, 0);
+  (*scaled_dCdM)(4, 8) += A(0, 0);
+}
+
+template <typename T>
+VectorX<T> PermuteBlockVector(const Eigen::Ref<const VectorX<T>>& v,
+                              const std::vector<int>& block_permutation) {
+  DRAKE_DEMAND(static_cast<int>(block_permutation.size() * 3) == v.size());
+  VectorX<T> permuted_v(v.size());
+  for (int i = 0; i < static_cast<int>(block_permutation.size()); ++i) {
+    permuted_v.template segment<3>(3 * block_permutation[i]) =
+        v.template segment<3>(3 * i);
+  }
+  return permuted_v;
+}
+
+template <typename T>
+Eigen::SparseMatrix<T> PermuteBlockSparseMatrix(
+    const Eigen::SparseMatrix<T>& matrix,
+    const std::vector<int>& block_permutation) {
+  DRAKE_ASSERT(matrix.rows() == matrix.cols());
+  DRAKE_ASSERT(static_cast<int>(block_permutation.size()) * 3 == matrix.cols());
+  const int nv = matrix.rows();
+  Eigen::SparseMatrix<T> permuted_matrix(nv, nv);
+  std::vector<Eigen::Triplet<T>> triplets;
+  triplets.reserve(matrix.nonZeros());
+  using InnerIterator = typename Eigen::SparseMatrix<T>::InnerIterator;
+  for (int k = 0; k < matrix.outerSize(); ++k) {
+    for (InnerIterator it(matrix, k); it; ++it) {
+      /* The row/column indices of a particular value within its block. */
+      const int block_row = it.row() % 3;
+      const int block_col = it.col() % 3;
+      /* The block indices B(i, j) in which the value is located. */
+      const int i = it.row() / 3;
+      const int j = it.col() / 3;
+      /* The block indices C(p(i), p(j)) into which the value will be written.
+       */
+      const int p_i = block_permutation[i];
+      const int p_j = block_permutation[j];
+      /* The block C(p_i, p_j) is located at (p_i * 3, p_j * 3) in the
+       output matrix and the value is offset from that origin by its
+       indices within the block. */
+      const int permuted_row = p_i * 3 + block_row;
+      const int permuted_col = p_j * 3 + block_col;
+
+      triplets.emplace_back(permuted_row, permuted_col, it.value());
+    }
+  }
+  /* The permuted matrix should have the exact same number of non-zero entries
+   as the old matrix. */
+  DRAKE_DEMAND(static_cast<int>(triplets.size()) == matrix.nonZeros());
+  permuted_matrix.setFromTriplets(triplets.begin(), triplets.end());
+  return permuted_matrix;
+}
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    (&PolarDecompose<T>, &AddScaledRotationalDerivative<T>,
+     &CalcCofactorMatrix<T>, &AddScaledCofactorMatrixDerivative<T>,
+     &PermuteBlockVector<T>, &PermuteBlockSparseMatrix<T>))
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/matrix_utilities.h
+++ b/multibody/fem/matrix_utilities.h
@@ -1,0 +1,146 @@
+#pragma once
+
+#include <vector>
+
+#include <Eigen/SparseCore>
+
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+/* Some of the following methods involve calculations about a 4th order tensor
+(call it A) of dimension 3*3*3*3. We follow the following convention to flatten
+the 4th order tensor into 9*9 matrices that are organized as follows:
+
+                  l = 1       l = 2       l = 3
+              -------------------------------------
+              |           |           |           |
+    j = 1     |   Aᵢ₁ₖ₁   |   Aᵢ₁ₖ₂   |   Aᵢ₁ₖ₃   |
+              |           |           |           |
+              -------------------------------------
+              |           |           |           |
+    j = 2     |   Aᵢ₂ₖ₁   |   Aᵢ₂ₖ₂   |   Aᵢ₂ₖ₃   |
+              |           |           |           |
+              -------------------------------------
+              |           |           |           |
+    j = 3     |   Aᵢ₃ₖ₁   |   Aᵢ₃ₖ₂   |   Aᵢ₃ₖ₃   |
+              |           |           |           |
+              -------------------------------------
+Namely the ik-th entry in the jl-th block corresponds to the value Aᵢⱼₖₗ. */
+
+/* Calculates the polar decomposition of a 3-by-3 matrix F = RS where R is a
+ rotation matrix and S is a symmetric matrix. The decomposition is unique when F
+ is non-singular.
+ @tparam_nonsymbolic_scalar. */
+template <typename T>
+void PolarDecompose(const Matrix3<T>& F, EigenPtr<Matrix3<T>> R,
+                    EigenPtr<Matrix3<T>> S);
+
+/* Some notes on derivation on the derivative of the rotation matrix from polar
+ decomposition: we start with the result from section 2 of [McAdams, 2011] about
+ the differential of the rotation matrix, which states that
+               δR = R[ε : ((tr(S)I − S)⁻¹(εᵀ : (RᵀδF)))]. (1)
+ For simplicity of notation, we define A = tr(S)I − S and B = RᵀδF
+ In index notation, equation (1) then reads
+               δRᵢⱼ = Rᵢₘεₘⱼₙ A⁻¹ₙₚ εₚₖₗBₖₗ. (2)
+ From there, we make use of the identity
+               A⁻¹ₙₚ = 1/(2*det(A)) εₙₛᵣεₚₜᵤAₜₛAᵤᵣ.
+ Plugging it into (2) gives
+               δRᵢⱼ = 1/(2*det(A)) * RᵢₘεₘⱼₙεₙₛᵣεₚₜᵤεₚₖₗAₜₛAᵤᵣBₖₗ.
+ Then, make use of the identity
+               εₚₜᵤεₚₖₗ = δₜₖδᵤₗ − δₜₗδᵤₖ,
+ we get
+  δRᵢⱼ = 1/(2*det(A)) * Rᵢₘ(δₘₛδⱼᵣ − δₘᵣδⱼₛ)(δₜₖδᵤₗ − δₜₗδᵤₖ)AₜₛAᵤᵣBₖₗ.
+ Cleaning up deltas, we get:
+               δRᵢⱼ = 1/det(A) * Rᵢₘ(AₖₘAₗⱼ−AₖⱼAₗₘ)Bₖₗ.
+ Finally, using ∂Bₖₗ/∂Fₐᵦ = Rₐₖδᵦₗ, we get
+               δRᵢⱼ/∂Fₐᵦ = 1/det(A) * Rᵢₘ(AₖₘAₗⱼ−AₖⱼAₗₘ)Rₐₖδᵦₗ
+                        = 1/det(A) * Rᵢₘ(AₖₘAᵦⱼ− AₖⱼAᵦₘ)Rₐₖ
+                        = 1/det(A) * (RARᵀ)ᵢₐAⱼᵦ - (RA)ᵢᵦ(RA)ₐⱼ
+ where we used the fact that A is symmetric in the last equality.
+
+ [McAdams, 2011] McAdams, Aleka, et al. "Technical Notes for Efficient
+ elasticity for character skinning with contact and collisions." ACM SIGGRAPH
+ 2011 papers. 2011. 1-12.
+ https://disneyanimation.com/publications/efficient-elasticity-for-character-skinning-with-contact-and-collisions.
+*/
+
+/* Computes the derivative of the rotation matrix from the polar decomposition
+ (see PolarDecompose()) with respect to the original matrix.
+ @param[in] R            The rotation matrix in the polar decomposition F = RS.
+ @param[in] S            The symmetric matrix in the polar decomposition F = RS.
+ @param[in] scale        The scalar multiple of the result.
+ @param[out] scaled_dRdF The variable to which scale * dR/dF is added.
+ @pre tr(S)I − S is invertible.
+ @tparam_nonsymbolic_scalar. */
+template <typename T>
+void AddScaledRotationalDerivative(
+    const Matrix3<T>& R, const Matrix3<T>& S, const T& scale,
+    EigenPtr<Eigen::Matrix<T, 9, 9>> scaled_dRdF);
+
+/* Calculates the cofactor matrix of the given input 3-by-3 matrix M. */
+template <typename T>
+void CalcCofactorMatrix(const Matrix3<T>& M, EigenPtr<Matrix3<T>> cofactor);
+
+/* Computes the derivative of the cofactor matrix C of a 3-by-3 matrix M
+ with respect to the matrix M itself.
+ @param[in] M            The input matrix.
+ @param[in] scale        The scalar multiple of the result.
+ @param[out] scaled_dCdF The variable to which scale * dC/dM is added.
+ @tparam_nonsymbolic_scalar. */
+template <typename T>
+void AddScaledCofactorMatrixDerivative(
+    const Matrix3<T>& M, const T& scale,
+    EigenPtr<Eigen::Matrix<T, 9, 9>> scaled_dCdM);
+
+/* Given a size 3N vector with block structure with size 3 block entries Bᵢ
+ where i ∈ V = {0, ..., N-1} and a permutation P on V, this method builds the
+ permuted vector with size 3 block entries C's such that Cₚ₍ᵢ₎ = Bᵢ.
+ For example, suppose the input `v` is given by
+       a a a b b b c c c
+and the input `block_permutation` is {1, 2, 0}, then the result of the
+permutation will be:
+       c c c a a a b b b
+@param[in] v                  The original block vector to be permuted.
+@param[in] block_permutation  block_permutation[i] gives the index of the
+                              permuted block whose original index is `i`.
+@pre v.size() % 3 == 0.
+@pre block_permutation is a permutation of {0, 1, ..., v.size()/3-1}.
+@tparam_nonsymbolic_scalar. */
+template <typename T>
+VectorX<T> PermuteBlockVector(const Eigen::Ref<const VectorX<T>>& v,
+                              const std::vector<int>& block_permutation);
+
+/* Given a 3N-by-3N Eigen::SparseMatrix with block structure with 3x3 block
+ entries Bᵢⱼ where i, j ∈ V = {0, ..., N-1} and a permutation P on V, this
+ method builds the permuted matrix with 3x3 block entries C's such that
+ Cₚ₍ᵢ₎ₚ₍ⱼ₎ = Bᵢⱼ.
+
+ For example, suppose the input `matrix` is given by
+    B00  B01  B02
+    B10  B11  B12
+    B20  B21  B22,
+ permutation {1, 2, 0} produces
+    B22  B20  B21
+    B02  B00  B01
+    B12  B10  B11.
+
+ @param[in] matrix             The original block sparse matrix to be permuted.
+ @param[in] block_permutation  block_permutation[i] gives the index of the
+                               permuted block whose original index is `i`.
+ @pre matrix.rows() == matrix.cols().
+ @pre matrix.rows() % 3 == 0.
+ @pre block_permutation is a permutation of {0, 1, ..., matrix.rows()/3-1}.
+ @tparam_nonsymbolic_scalar. */
+template <typename T>
+Eigen::SparseMatrix<T> PermuteBlockSparseMatrix(
+    const Eigen::SparseMatrix<T>& matrix,
+    const std::vector<int>& block_permutation);
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/mesh_utilities.cc
+++ b/multibody/fem/mesh_utilities.cc
@@ -1,0 +1,110 @@
+#include "drake/multibody/fem/mesh_utilities.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/geometry/proximity/make_box_mesh.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+
+using geometry::Box;
+using geometry::VolumeElement;
+using geometry::VolumeMesh;
+
+/* Generates connectivity for the tetrahedral elements of the mesh by splitting
+ each cube into five tetrahedra.
+ @param[in] num_vertices
+     Number of vertices in each of x-, y-, and z-directions.
+ @return
+     A sequence of tetrahedral elements that share unique vertices. */
+std::vector<VolumeElement> GenerateDiamondCubicElements(
+    const Vector3<int>& num_vertices) {
+  std::vector<VolumeElement> elements;
+  const Vector3<int> num_cells = num_vertices - Vector3<int>(1, 1, 1);
+  /* The number of vertices in each direction. */
+  for (int i = 0; i < num_cells(0); ++i) {
+    for (int j = 0; j < num_cells(1); ++j) {
+      for (int k = 0; k < num_cells(2); ++k) {
+        /* The following picture shows where vertex vₛ (for `v[s]` below)
+         locates in the rectangular cell.  The I-, J-, K-axes show the
+         direction of increasing i, j, k indices.
+
+                       v₁     v₃
+                       ●------●
+                      /|     /|
+                     / |  v₇/ |
+                 v₅ ●------●  |
+                    |  |   |  |
+                    |  ●---|--● v₂
+                    | /v₀  | /
+                    |/     |/
+            +K   v₄ ●------● v₆
+             |
+             |
+             o------+J
+            /
+           /
+         +I                                                        */
+        int v[8];
+        int s = 0;
+        for (int l = 0; l < 2; ++l) {
+          for (int m = 0; m < 2; ++m) {
+            for (int n = 0; n < 2; ++n) {
+              v[s++] = geometry::internal::CalcSequentialIndex(
+                  i + l, j + m, k + n, num_vertices);
+            }
+          }
+        }
+
+        /* The following table subdivides the rectangular cell into five
+         tetrahedra. Refer to the picture above to determine which four vertices
+         form a tetrahedron. Refer to splitting No. 13 in:
+         http://www.baumanneduard.ch/Splitting%20a%20cube%20in%20tetrahedras2.htm
+         The splitting alternates depending on the positions of the cube to
+         ensure that the mesh is conforming. */
+        if ((i + j + k) % 2 == 1) {
+          elements.emplace_back(v[6], v[4], v[7], v[2]);
+          elements.emplace_back(v[7], v[2], v[1], v[3]);
+          elements.emplace_back(v[1], v[4], v[7], v[5]);
+          elements.emplace_back(v[2], v[4], v[1], v[0]);
+          elements.emplace_back(v[7], v[4], v[1], v[2]);
+        } else {
+          elements.emplace_back(v[0], v[6], v[5], v[4]);
+          elements.emplace_back(v[3], v[6], v[0], v[2]);
+          elements.emplace_back(v[5], v[6], v[3], v[7]);
+          elements.emplace_back(v[3], v[0], v[5], v[1]);
+          elements.emplace_back(v[0], v[6], v[3], v[5]);
+        }
+      }
+    }
+  }
+  return elements;
+}
+
+template <typename T>
+geometry::VolumeMesh<T> MakeDiamondCubicBoxVolumeMesh(const Box& box,
+                                                      double resolution_hint) {
+  DRAKE_DEMAND(resolution_hint > 0.);
+  /* Number of vertices in x-, y-, and z- directions.  In each direction,
+   there is one more vertices than cells. */
+  const Vector3<int> num_vertices{
+      1 + static_cast<int>(ceil(box.width() / resolution_hint)),
+      1 + static_cast<int>(ceil(box.depth() / resolution_hint)),
+      1 + static_cast<int>(ceil(box.height() / resolution_hint))};
+
+  std::vector<Vector3<T>> vertices =
+      geometry::internal::GenerateVertices<T>(box, num_vertices);
+  std::vector<VolumeElement> elements =
+      GenerateDiamondCubicElements(num_vertices);
+  return {std::move(elements), std::move(vertices)};
+}
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    (&MakeDiamondCubicBoxVolumeMesh<T>))
+
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/mesh_utilities.h
+++ b/multibody/fem/mesh_utilities.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/geometry/shape_specification.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+
+/** Generates a volume mesh from a given box by subdividing the box into
+ _rectangular cells_ (volume bounded by six axis-aligned faces) and subdividing
+ each rectangular cell into five tetrahedra. Two adjacent rectangular cells
+ (sharing a rectangular face) are subdivided in the patterns that are mirrored
+ of each other so that the mesh is conforming.
+
+ The following picture file shows example of the diamond cubic box volume mesh
+ and demonstrates the mirrored subdivision pattern in adjacent cells. The file
+ is distributed with the source code.
+
+ | multibody/fem/images/diamond_cubic_box_volume_mesh.png  |
+ | (Top) A diamond cubic box volume mesh. (Center and bottom) mirrored
+   subdivision patterns to make sure the mesh is conforming.         |
+
+ The output mesh will have these properties:
+
+   1. The generated vertices are unique. There is no repeating vertices in
+      the list of vertex coordinates.
+   2. The generated tetrahedra are _conforming_. Two tetrahedra intersect in
+      their shared face, or shared edge, or shared vertex, or not at all.
+      There is no partial overlapping of two tetrahedra.
+ @param[in] box
+     The box shape specification (see drake::geometry::Box).
+ @param[in] resolution_hint
+     A measure (in meters) that controls the resolution of the mesh. The length
+     of the axis-aligned edges of the mesh will be less than or equal to this
+     parameter. The length of non-axis-aligned edges will be less than or equal
+     to √3 of this parameter. The coarsest possible mesh can be made by
+     providing a resolution hint at least as large as the box's largest
+     dimension.
+ @tparam_nonsymbolic_scalar */
+template <typename T>
+geometry::VolumeMesh<T> MakeDiamondCubicBoxVolumeMesh(const geometry::Box& box,
+                                                      double resolution_hint);
+
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/newmark_scheme.h
+++ b/multibody/fem/newmark_scheme.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "drake/multibody/fem/discrete_time_integrator.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+/* Implements the interface DiscreteTimeIntegrator with Newmark-beta time
+ integration scheme. Given the value for the next time step acceleration `a`,
+ the states are calculated from states from the previous time step according to
+ the following equations:
+
+      v = vₙ + dt ⋅ (γ ⋅ a + (1−γ) ⋅ aₙ)
+      x = xₙ + dt ⋅ vₙ + dt² ⋅ [β ⋅ a + (0.5−β) ⋅ aₙ].
+
+ Note that the scheme is unconditionally unstable for gamma < 0.5 and therefore
+ we require gamma >= 0.5.
+ See [Newmark, 1959] for the original reference for the method.
+
+ [Newmark, 1959] Newmark, Nathan M. "A method of computation for structural
+ dynamics." Journal of the engineering mechanics division 85.3 (1959): 67-94.
+ @tparam_nonsymbolic_scalar */
+template <typename T>
+class NewmarkScheme : public DiscreteTimeIntegrator<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(NewmarkScheme);
+
+  ~NewmarkScheme() = default;
+
+ protected:
+  NewmarkScheme() = default;
+
+  /* Constructs a Newmark scheme with the provided timestep, `gamma` and `beta`.
+   @pre dt > 0.
+   @pre 0.5 <= gamma <= 1.
+   @pre 0 <= beta <= 0.5. */
+  NewmarkScheme(double dt, double gamma, double beta)
+      : dt_(dt), gamma_(gamma), beta_(beta) {
+    DRAKE_DEMAND(dt > 0);
+    DRAKE_DEMAND(0.5 <= gamma && gamma <= 1);
+    DRAKE_DEMAND(0 <= beta && beta <= 0.5);
+  }
+
+  double dt() const { return dt_; }
+  double gamma() const { return gamma_; }
+  double beta() const { return beta_; }
+
+  double dt_{0};
+  /* Default values for gamma and beta are set to those of the mid-point rule.
+   */
+  double gamma_{0.5};
+  double beta_{0.25};
+};
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/petsc_symmetric_block_sparse_matrix.cc
+++ b/multibody/fem/petsc_symmetric_block_sparse_matrix.cc
@@ -1,0 +1,402 @@
+#include "drake/multibody/fem/petsc_symmetric_block_sparse_matrix.h"
+
+#include <numeric>
+#include <string>
+#include <utility>
+
+#include <petscksp.h>
+
+#include "drake/common/unused.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+using Eigen::MatrixXd;
+using std::vector;
+
+namespace {
+
+/* Returns true if the given PETSc matrix is "assembled". */
+bool is_assembled(const Mat& A) {
+  PetscBool assembled = PETSC_FALSE;
+  MatAssembled(A, &assembled);
+  return assembled == PETSC_TRUE;
+}
+
+using MatrixXdRowMajor =
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+
+/* Converts an assembled PETSc matrix to an Eigen row major dense matrix. */
+MatrixXdRowMajor MakeEigenRowMajorMatrix(const Mat& petsc_matrix) {
+  DRAKE_DEMAND(is_assembled(petsc_matrix));
+  int rows, cols;
+  MatGetSize(petsc_matrix, &rows, &cols);
+
+  vector<int> row_indexes(rows);
+  vector<int> col_indexes(cols);
+  std::iota(row_indexes.begin(), row_indexes.end(), 0);
+  std::iota(col_indexes.begin(), col_indexes.end(), 0);
+
+  MatrixXdRowMajor eigen_dense = MatrixXdRowMajor::Zero(rows, cols);
+  // MatGetValues extracts values from `petsc_matrix` in row major fashion.
+  MatGetValues(petsc_matrix, rows, row_indexes.data(), cols, col_indexes.data(),
+               eigen_dense.data());
+
+  return eigen_dense;
+}
+
+/* Converts an assembled PETSc matrix to an Eigen column major dense matrix. */
+MatrixX<double> MakeEigenMatrix(const Mat& petsc_matrix) {
+  DRAKE_DEMAND(is_assembled(petsc_matrix));
+  return MatrixX<double>(MakeEigenRowMajorMatrix(petsc_matrix));
+}
+
+}  // namespace
+
+/* The implementation class for PetscSymmetricBlockSparseMatrix. Each of these
+ functions mirrors a method on the PetscSymmetricBlockSparseMatrix. See
+ PetscSymmetricBlockSparseMatrix for documentation. */
+class PetscSymmetricBlockSparseMatrix::Impl {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Impl);
+
+  Impl() = default;
+
+  Impl(int size, int block_size,
+       const vector<int>& num_upper_triangular_blocks_per_row)
+      : size_(size), block_size_(block_size), num_blocks_(size / block_size) {
+    EnsurePetscIsInitialized();
+    MatCreateSeqSBAIJ(PETSC_COMM_SELF, block_size, size, size, 0,
+                      num_upper_triangular_blocks_per_row.data(),
+                      &owned_matrix_);
+    /* Initialize solver and preconditioner. */
+    KSPCreate(PETSC_COMM_SELF, &owned_solver_);
+    KSPGetPC(owned_solver_, &preconditioner_);
+  }
+
+  ~Impl() {
+    KSPDestroy(&owned_solver_);
+    MatDestroy(&owned_matrix_);
+  }
+
+  std::unique_ptr<Impl> Clone() const {
+    ThrowIfNotAssembled(__func__);
+    auto clone = std::make_unique<Impl>();
+    clone->size_ = this->size_;
+    clone->block_size_ = this->block_size_;
+    clone->num_blocks_ = this->num_blocks_;
+    MatDuplicate(this->owned_matrix_, MAT_COPY_VALUES, &clone->owned_matrix_);
+
+    /* Initialize solver and preconditioner. */
+    KSPCreate(PETSC_COMM_SELF, &clone->owned_solver_);
+    KSPGetPC(clone->owned_solver_, &clone->preconditioner_);
+
+    return clone;
+  }
+
+  void SetZero() {
+    AssembleIfNecessary();
+    MatZeroEntries(owned_matrix_);
+  }
+
+  VectorX<double> Solve(SolverType solver_type,
+                        PreconditionerType preconditioner_type,
+                        const VectorX<double>& b) const {
+    ThrowIfNotAssembled(__func__);
+    VectorX<double> x = b;
+    SolveInPlace(solver_type, preconditioner_type, &x);
+    return x;
+  }
+
+  void SolveInPlace(SolverType solver_type,
+                    PreconditionerType preconditioner_type,
+                    EigenPtr<VectorX<double>> b) const {
+    ThrowIfNotAssembled(__func__);
+    switch (solver_type) {
+      case SolverType::kDirect:
+        KSPSetType(owned_solver_, KSPPREONLY);
+        if (preconditioner_type != PreconditionerType::kCholesky) {
+          throw std::logic_error(
+              "Direct solver can only be paired with Cholesky preconditioner.");
+        }
+        break;
+      case SolverType::kMINRES:
+        KSPSetType(owned_solver_, KSPMINRES);
+        break;
+      case SolverType::kConjugateGradient:
+        KSPSetType(owned_solver_, KSPCG);
+        break;
+    }
+
+    switch (preconditioner_type) {
+      case PreconditionerType::kCholesky:
+        PCSetType(preconditioner_, PCCHOLESKY);
+        break;
+      case PreconditionerType::kIncompleteCholesky:
+        PCSetType(preconditioner_, PCICC);
+        break;
+      case PreconditionerType::kJacobi:
+        PCSetType(preconditioner_, PCJACOBI);
+        break;
+    }
+
+    KSPSetFromOptions(owned_solver_);
+
+    // TODO(xuchenhan-tri): The solve involves some dynamic allocation and
+    // moving data around. Measure whether they are heavy on performance and
+    // eliminate them if they are.
+
+    /* Allocate for PETSc version of x and b. */
+    Vec x_petsc;
+    VecCreateSeq(PETSC_COMM_SELF, size_, &x_petsc);
+    Vec b_petsc;
+    VecDuplicate(x_petsc, &b_petsc);
+
+    /* Copy right hand side data into b_petsc. */
+    vector<int> vector_indexes(size_);
+    std::iota(vector_indexes.begin(), vector_indexes.end(), 0);
+    VecSetValues(b_petsc, size_, vector_indexes.data(), b->data(),
+                 INSERT_VALUES);
+    VecAssemblyBegin(b_petsc);
+    VecAssemblyEnd(b_petsc);
+
+    // TODO(xuchenhan-tri): Currently we don't repeatedly solve the same system
+    // with multiple right hand sides, so we always reset the operators. Split
+    // the factorization and the solve into two distinct phases to reuse the
+    // factorization if we need that in the future.
+    /* Set matrix. */
+    KSPSetOperators(owned_solver_, owned_matrix_, owned_matrix_);
+    /* Solve! */
+    KSPSolve(owned_solver_, b_petsc, x_petsc);
+
+    /* Copy solution data to eigen vector. */
+    b->setZero();
+    VecGetValues(x_petsc, size_, vector_indexes.data(), b->data());
+
+    /* Clean up PETSc temporary variables. */
+    VecDestroy(&b_petsc);
+    VecDestroy(&x_petsc);
+  }
+
+  void AddToBlock(const VectorX<int>& block_indices,
+                  const MatrixX<double>& block) {
+    /* Notice that `MatSetValuesBlocked()` takes row oriented data whereas
+     `block.data()` is column oriented. But since `block` is symmetric, we
+     don't have to make the conversion. */
+    MatSetValuesBlocked(owned_matrix_, block_indices.size(),
+                        block_indices.data(), block_indices.size(),
+                        block_indices.data(), block.data(), ADD_VALUES);
+  }
+
+  /* Makes a dense matrix representation of this block-sparse matrix. This
+   operation is expensive and is usually only used for debugging purpose. */
+  MatrixX<double> MakeDenseMatrix() const {
+    ThrowIfNotAssembled(__func__);
+    MatrixX<double> eigen_dense = internal::MakeEigenMatrix(owned_matrix_);
+    /* Notice that we store the matrix in PETSc as upper triangular matrix
+     and the lower triangular part is ignored. To restore the full
+     matrix, we need to fill in these blocks by hand. */
+    eigen_dense.triangularView<Eigen::StrictlyLower>() =
+        eigen_dense.triangularView<Eigen::StrictlyUpper>().transpose();
+    return eigen_dense;
+  }
+
+  void ZeroRowsAndColumns(const vector<int>& indexes, double value) {
+    /* Ensure that the matrix has been assembled. */
+    AssembleIfNecessary();
+    MatZeroRowsColumns(owned_matrix_, indexes.size(), indexes.data(), value,
+                       PETSC_NULL, PETSC_NULL);
+  }
+
+  void set_relative_tolerance(double tolerance) {
+    KSPSetTolerances(owned_solver_, tolerance, PETSC_DEFAULT, PETSC_DEFAULT,
+                     PETSC_DEFAULT);
+  }
+
+  SchurComplement<double> CalcSchurComplement(
+      const vector<int>& D_block_indexes, const vector<int>& A_block_indexes) {
+    using std::move;
+
+    MatrixXd D_complement;          // A - BD⁻¹Bᵀ.
+    MatrixXd neg_Dinv_B_transpose;  // -D⁻¹Bᵀ.
+
+    if (D_block_indexes.size() == 0) {
+      D_complement = MakeDenseMatrix();
+      neg_Dinv_B_transpose.resize(0, size_);
+      return SchurComplement(move(D_complement), move(neg_Dinv_B_transpose));
+    }
+    if (A_block_indexes.size() == 0) {
+      D_complement.resize(0, 0);
+      neg_Dinv_B_transpose.resize(size_, 0);
+      return SchurComplement(move(D_complement), move(neg_Dinv_B_transpose));
+    }
+    // Build indices to create the four blocks in the Schur complement.
+    IS is0, is1;
+    ISCreateBlock(PETSC_COMM_SELF, block_size_, A_block_indexes.size(),
+                  A_block_indexes.data(), PETSC_COPY_VALUES, &is0);
+    ISCreateBlock(PETSC_COMM_SELF, block_size_, D_block_indexes.size(),
+                  D_block_indexes.data(), PETSC_COPY_VALUES, &is1);
+
+    // Create a MATSEQBAIJ version of the underlying PETSc matrix because
+    // MatCreateSubMatrix() doesn't support matrix of type MATSEQSBAIJ.
+    AssembleIfNecessary();
+    Mat matrix_sparse;
+    MatConvert(owned_matrix_, MATSEQBAIJ, MAT_INITIAL_MATRIX, &matrix_sparse);
+
+    // Copy to A, Bᵀ, D.
+    Mat A_petsc, B_transpose_petsc, D_petsc;
+    MatCreateSubMatrix(matrix_sparse, is0, is0, MAT_INITIAL_MATRIX, &A_petsc);
+    MatCreateSubMatrix(matrix_sparse, is1, is0, MAT_INITIAL_MATRIX,
+                       &B_transpose_petsc);
+    MatCreateSubMatrix(matrix_sparse, is1, is1, MAT_INITIAL_MATRIX, &D_petsc);
+
+    // Calculate D⁻¹Bᵀ.
+    KSP solver;
+    PC preconditioner;
+    KSPCreate(PETSC_COMM_SELF, &solver);
+    KSPGetPC(solver, &preconditioner);
+    KSPSetType(solver, KSPPREONLY);
+    PCSetType(preconditioner, PCCHOLESKY);
+    KSPSetOperators(solver, D_petsc, D_petsc);
+
+    // KSPMatSolve only takes dense right hand side.
+    Mat B_transpose_petsc_dense;
+    MatConvert(B_transpose_petsc, MATSEQDENSE, MAT_INITIAL_MATRIX,
+               &B_transpose_petsc_dense);
+    Mat Dinv_B_transpose_petsc;
+    MatDuplicate(B_transpose_petsc_dense, MAT_DO_NOT_COPY_VALUES,
+                 &Dinv_B_transpose_petsc);
+    KSPMatSolve(solver, B_transpose_petsc_dense, Dinv_B_transpose_petsc);
+
+    // Convert all quantities from PETSc to Eigen.
+    MatrixXd A = MakeEigenMatrix(A_petsc);
+    MatrixXd B_transpose = MakeEigenMatrix(B_transpose_petsc);
+    neg_Dinv_B_transpose = MakeEigenMatrix(Dinv_B_transpose_petsc);
+    neg_Dinv_B_transpose *= -1.0;
+    D_complement = A + B_transpose.transpose() * neg_Dinv_B_transpose;
+
+    // Clean up all allocated memories in this method.
+    KSPDestroy(&solver);
+    MatDestroy(&matrix_sparse);
+    MatDestroy(&Dinv_B_transpose_petsc);
+    MatDestroy(&B_transpose_petsc);
+    MatDestroy(&B_transpose_petsc_dense);
+    MatDestroy(&D_petsc);
+    MatDestroy(&A_petsc);
+    ISDestroy(&is0);
+    ISDestroy(&is1);
+
+    return SchurComplement(move(D_complement), move(neg_Dinv_B_transpose));
+  }
+
+  int size() const { return size_; }
+
+  void AssembleIfNecessary() {
+    if (!is_assembled(owned_matrix_)) {
+      MatAssemblyBegin(owned_matrix_, MAT_FINAL_ASSEMBLY);
+      MatAssemblyEnd(owned_matrix_, MAT_FINAL_ASSEMBLY);
+    }
+  }
+
+ private:
+  void ThrowIfNotAssembled(const char* func) const {
+    if (!is_assembled(owned_matrix_)) {
+      throw std::runtime_error(
+          "PetscSymmetricBlockSparseMatrix::" + std::string(func) +
+          "(): matrix is not yet assembled. Call AssembleIfNecessary() first.");
+    }
+  }
+
+  /* Invokes PetscInitialize() if it hasn't been invoked yet in the program.
+   No-op otherwise. */
+  void EnsurePetscIsInitialized() {
+    static bool done = []() {
+      // TODO(xuchenhan-tri): Investigate PETSc's usage of global state.
+      PetscInitialize(PETSC_NULL, PETSC_NULL, PETSC_NULL, PETSC_NULL);
+      return true;
+    }();
+    unused(done);
+  }
+
+  // The underlying PETSc matrix stored as MATSEQSBAIJ.
+  Mat owned_matrix_;
+  int size_{0};
+  int block_size_{0};
+  int num_blocks_{0};
+  KSP owned_solver_;
+  PC preconditioner_;
+};
+
+PetscSymmetricBlockSparseMatrix::PetscSymmetricBlockSparseMatrix() = default;
+
+PetscSymmetricBlockSparseMatrix::PetscSymmetricBlockSparseMatrix(
+    int size, int block_size,
+    const vector<int>& num_upper_triangular_blocks_per_row) {
+  DRAKE_DEMAND(size >= 0 && block_size > 0);
+  DRAKE_DEMAND(size % block_size == 0);
+  pimpl_ = std::make_unique<Impl>(size, block_size,
+                                  num_upper_triangular_blocks_per_row);
+}
+
+PetscSymmetricBlockSparseMatrix::~PetscSymmetricBlockSparseMatrix() = default;
+
+std::unique_ptr<PetscSymmetricBlockSparseMatrix>
+PetscSymmetricBlockSparseMatrix::Clone() const {
+  std::unique_ptr<PetscSymmetricBlockSparseMatrix> clone(
+      new PetscSymmetricBlockSparseMatrix());
+  clone->pimpl_ = pimpl_->Clone();
+  return clone;
+}
+
+void PetscSymmetricBlockSparseMatrix::AddToBlock(
+    const VectorX<int>& block_indices, const MatrixX<double>& block) {
+  pimpl_->AddToBlock(block_indices, block);
+}
+
+VectorX<double> PetscSymmetricBlockSparseMatrix::Solve(
+    SolverType solver_type, PreconditionerType preconditioner_type,
+    const VectorX<double>& b) const {
+  return pimpl_->Solve(solver_type, preconditioner_type, b);
+}
+
+void PetscSymmetricBlockSparseMatrix::SolveInPlace(
+    SolverType solver_type, PreconditionerType preconditioner_type,
+    EigenPtr<VectorX<double>> b) const {
+  pimpl_->SolveInPlace(solver_type, preconditioner_type, b);
+}
+
+void PetscSymmetricBlockSparseMatrix::SetZero() { pimpl_->SetZero(); }
+
+MatrixX<double> PetscSymmetricBlockSparseMatrix::MakeDenseMatrix() const {
+  return pimpl_->MakeDenseMatrix();
+}
+
+void PetscSymmetricBlockSparseMatrix::ZeroRowsAndColumns(
+    const vector<int>& indexes, double value) {
+  pimpl_->ZeroRowsAndColumns(indexes, value);
+}
+
+void PetscSymmetricBlockSparseMatrix::set_relative_tolerance(double tolerance) {
+  pimpl_->set_relative_tolerance(tolerance);
+}
+
+SchurComplement<double> PetscSymmetricBlockSparseMatrix::CalcSchurComplement(
+    const vector<int>& D_block_indexes,
+    const vector<int>& A_block_indexes) const {
+  return pimpl_->CalcSchurComplement(D_block_indexes, A_block_indexes);
+}
+
+int PetscSymmetricBlockSparseMatrix::rows() const { return pimpl_->size(); }
+
+int PetscSymmetricBlockSparseMatrix::cols() const { return pimpl_->size(); }
+
+void PetscSymmetricBlockSparseMatrix::AssembleIfNecessary() {
+  pimpl_->AssembleIfNecessary();
+}
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/petsc_symmetric_block_sparse_matrix.h
+++ b/multibody/fem/petsc_symmetric_block_sparse_matrix.h
@@ -1,0 +1,172 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/schur_complement.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+/* A symmetric block sparse matrix data structure that uses PETSc for storage
+ and linear algebra operations. It provides supports for the inverse operator,
+ i.e. one can solve for A*x = b where A is this matrix. It also supports
+ calculating the Schur complement of the matrix. It only supports double as
+ the scalar type. */
+class PetscSymmetricBlockSparseMatrix {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PetscSymmetricBlockSparseMatrix);
+
+  enum class SolverType {
+    /* For positive definite matrix. */
+    kConjugateGradient,
+    /* For positive definite matrix. Can only be paired with Cholesky
+     preconditioner. */
+    kDirect,
+    /* For generic symmetric matrix. */
+    kMINRES
+  };
+
+  enum class PreconditionerType {
+    /* For generic matrix. N.B. the BlockJacobi preconditioner from PETSc by
+     default seems to assume positive definite blocks.*/
+    kJacobi,
+    /* For positive definite matrix. */
+    kCholesky,
+    kIncompleteCholesky,
+  };
+
+  /* Constructs a symmetric block sparse matrix.
+   @param size            The number of rows and columns of the symmetric
+                          matrix.
+   @param block_size      The number rows and columns within a single non-zero
+                          block. Each non-zero block in the sparse matrix is of
+                          the same size.
+   @param num_upper_triangular_blocks_per_row
+                          `num_upper_triangular_blocks_per_row[i]` contains the
+                          number of non-zero upper triangular and diagonal
+                          blocks in the i-th row block.
+
+   @pre `size` >=  0, and `size` is a integer multiple of `block_size`.
+   @pre num_upper_triangular_blocks_per_row.size() == size/block_size.
+   @pre num_upper_triangular_blocks_per_row[i] <= size/block_size. */
+  PetscSymmetricBlockSparseMatrix(
+      int size, int block_size,
+      const std::vector<int>& num_upper_triangular_blocks_per_row);
+
+  ~PetscSymmetricBlockSparseMatrix();
+
+  /* Creates a deep identical copy of this matrix.
+   @pre Matrix must be assembled. See AssembleIfNecessary(). */
+  std::unique_ptr<PetscSymmetricBlockSparseMatrix> Clone() const;
+
+  /* Accumulate values in the block matrix. The Eigen analogy of this operation
+   is
+   ```
+   for (int i = 0; i < block_indices.size(); ++i) {
+     for (int j = 0; j < block_indices.size(); ++j){
+       // `A` is `this` matrix. `b` is block size specified at construction.
+       const int block_row = block_indices(i);
+       const int block_col = block_indices(j);
+       A.block(block_row * b, block_col * b, b, b) +=
+           block.block(i * b, j * b, b, b);
+     }
+   }
+   ```
+   @pre block is symmetric.
+   @pre block.rows() = block_indices.size() * block_size.
+   @pre 0 <= block_indices[i] * block_size < size for each i =
+   0, ..., block_indices.size()-1.
+   @warn None of the prerequisite is checked since this is used in inner loop.
+   @warn Over the lifespan of this object, for each row block i, the number of
+   blocks accumulated in the i-th row block through `AddToBlock()` whose column
+   block index is >= i must not exceed the number of nonzero upper triangular
+   blocks in the i-th row block specified at construction.
+   @note The full matrix is expected for `block` even though the matrix is
+   symmetric. */
+  void AddToBlock(const VectorX<int>& block_indices,
+                  const MatrixX<double>& block);
+
+  /* Solves for A*x = b using the given type of solver, where A is this matrix.
+   @warn The compatibility of the solver and preconditioner type with the
+   problem at hand is not checked. Callers need to be careful to choose the
+   reasonable combination of solver and preconditioner given the type of matrix.
+   @pre b.size() == A.rows()
+   @note The matrix/preconditioner will be refactored upon successive call to
+   this method even if the matrix hasn't changed.
+   @pre Matrix must be assembled. See AssembleIfNecessary(). */
+  VectorX<double> Solve(SolverType solver_type,
+                        PreconditionerType preconditioner_type,
+                        const VectorX<double>& b) const;
+
+  /* Similar to Solve(), but writes the result in `b`.
+   @pre Matrix must be assembled. See AssembleIfNecessary(). */
+  void SolveInPlace(SolverType solver_type,
+                    PreconditionerType preconditioner_type,
+                    EigenPtr<VectorX<double>> b) const;
+
+  /* Sets all blocks to zeros while maintaining the sparsity pattern. */
+  void SetZero();
+
+  /* Makes a dense matrix representation of this block-sparse matrix.
+   @pre Matrix must be assembled. See AssembleIfNecessary(). */
+  MatrixX<double> MakeDenseMatrix() const;
+
+  /* Zeros out all rows and columns whose index is included in `indexes` and
+   sets the diagonal entry of these rows and columns to `value`. In other words,
+   if `i` is contained in `indexes`, then the i-th row and column of the matrix
+   is set to zero and i-th diagonal entry is set to `value`. This operation
+   doesn't change the sparsity pattern.
+   @pre 0 <= indexes[i] < rows() for each i = 0, 1, ..., indexes.size()-1.  */
+  void ZeroRowsAndColumns(const std::vector<int>& indexes, double value);
+
+  /* Sets the relative tolerance of the linear solve A*x = b. Doesn't affect the
+   result of Solve() when the direct solver is used.
+   In particular, this sets the relative convergence tolerance in
+   https://petsc.org/main/docs/manualpages/KSP/KSPSetTolerances.html. All the
+   other tolerance parameters (e.g. absolute tolerance, maximum number of
+   iterations, etc) are set to the default value specified in the PETSc
+   documentaion. */
+  void set_relative_tolerance(double tolerance);
+
+  /* Given a linear system of equations Mz = c that can be written in block form
+  as:
+      Ax + By  =  a     (1)
+      Bᵀx + Dy =  0     (2)
+  where M = [A B; Bᵀ D] is `this` matrix, zᵀ = [xᵀ yᵀ], cᵀ = [aᵀ 0ᵀ], builds a
+  SchurComplement object that solves the system. See SchurComplement for more
+  details.
+  @param D_block_indexes The indexes of the block row and columns consisting of
+                         D.
+  @param A_block_indexes The indexes of the block row and columns consisting of
+                         A. */
+  SchurComplement<double> CalcSchurComplement(
+      const std::vector<int>& D_block_indexes,
+      const std::vector<int>& A_block_indexes) const;
+
+  int rows() const;
+
+  int cols() const;
+
+  /* Turn the matrix into "assembled" state if it's not already "assembled".
+   This method is cheap if the matrix is already "assembled", so invoke it if
+   unsure. */
+  void AssembleIfNecessary();
+
+ private:
+  class Impl;
+
+  /* Default construct that facilites the Clone() method. */
+  PetscSymmetricBlockSparseMatrix();
+
+  std::unique_ptr<Impl> pimpl_;
+};
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/schur_complement.cc
+++ b/multibody/fem/schur_complement.cc
@@ -1,0 +1,68 @@
+#include "drake/multibody/fem/schur_complement.h"
+
+#include <utility>
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+template <typename T>
+SchurComplement<T>::SchurComplement(
+    const Eigen::Ref<const Eigen::SparseMatrix<T>>& A,
+    const Eigen::Ref<const Eigen::SparseMatrix<T>>& B_transpose,
+    const Eigen::Ref<const Eigen::SparseMatrix<T>>& D)
+    : p_(A.rows()), q_(D.rows()) {
+  DRAKE_DEMAND(A.cols() == p_);
+  DRAKE_DEMAND(D.cols() == q_);
+  DRAKE_DEMAND(B_transpose.rows() == q_);
+  DRAKE_DEMAND(B_transpose.cols() == p_);
+  /* Special treatment for M = A is needed because Eigen::LLT::solve() throws
+   exception if the matrix under decomposition is empty. */
+  if (q_ == 0) {
+    neg_Dinv_B_transpose_.resize(0, p_);
+    D_complement_ = A;
+  } else if (p_ == 0) {
+    neg_Dinv_B_transpose_.resize(q_, 0);
+    // D_complement is empty, same as default.
+  } else {
+    /* Note that since D is SPD, we could use a sparse Cholesky factorization
+     here. But we opt for SparseLU for now due to the license restriction on
+     Eigen's sparse Cholesky. */
+    const Eigen::SparseLU<Eigen::SparseMatrix<T>> D_factorization(D);
+    /* A column major rhs is required for the SparseLU solve, so we take
+     `B_transpose` instead of `B.transpose()`. */
+    neg_Dinv_B_transpose_ = D_factorization.solve(-B_transpose);
+    D_complement_ = A + B_transpose.transpose() * neg_Dinv_B_transpose_;
+  }
+}
+
+template <typename T>
+SchurComplement<T>::SchurComplement(MatrixX<T>&& D_complement,
+                                    MatrixX<T>&& neg_Dinv_B_transpose)
+    : D_complement_(std::move(D_complement)),
+      neg_Dinv_B_transpose_(std::move(neg_Dinv_B_transpose)) {
+  DRAKE_DEMAND(D_complement_.rows() == D_complement_.cols());
+  DRAKE_DEMAND(neg_Dinv_B_transpose_.cols() == D_complement_.cols());
+  p_ = D_complement_.cols();
+  q_ = neg_Dinv_B_transpose_.rows();
+}
+
+template <typename T>
+VectorX<T> SchurComplement<T>::SolveForY(
+    const Eigen::Ref<const VectorX<T>>& x) const {
+  /* If M = D, then the system reduces to Dy = 0. */
+  if (p_ == 0) {
+    return VectorX<T>::Zero(q_);
+  }
+  DRAKE_DEMAND(x.size() == p_);
+  return neg_Dinv_B_transpose_ * x;
+}
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::internal::SchurComplement)

--- a/multibody/fem/schur_complement.h
+++ b/multibody/fem/schur_complement.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+/* Computes the Schur complement of a matrix given its block components.
+
+Given a linear system of equations Mz = c that can be written in block form
+as:
+    Ax + By  =  a     (1)
+    Bᵀx + Dy =  0     (2)
+where M = [A B; Bᵀ D], zᵀ = [xᵀ yᵀ], cᵀ = [aᵀ 0ᵀ], and A(size p-by-p),
+D(size q-by-q) and M(size p+q-by-p+q) are positive definite, we may choose to
+solve the system using Schur complement. Specifically, using equation (2), we
+get
+    y = -D⁻¹Bᵀx       (3)
+Plugging (3) in (1), we get
+   (A - BD⁻¹Bᵀ)x = a.
+After a solution for x is obtained, we can use (3) to recover the solution for
+y. The matrix A - BD⁻¹Bᵀ is the Schur complement of the block D of the matrix M.
+Since M is positive definite, so is the Schur complement A - BD⁻¹Bᵀ.
+
+@tparam_nonsymbolic_scalar */
+template <typename T>
+class SchurComplement {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SchurComplement);
+
+  /* Creates an empty Schur complement. This allows SchurComplement to be
+   directly constructed in containers. */
+  SchurComplement() = default;
+
+  /* Calculates the Schur complement of the positive definite matrix M = [A B;
+  Bᵀ D] given its block components. We take Bᵀ in the constructor instead of B
+  for efficient calculation of the Schur complement of D.
+  @pre A, D, and M are symmetric positive definite. Note that this prerequisite
+       is not checked at construction as the check is expensive. Callers to the
+       constructor should take care to pass in valid arguments. One way of
+       making sure that this prerequisite is satisfied is by passing in
+       components of a matrix M that is known to be symmetric positive-definite.
+  @pre A.rows() == B_transpose.cols().
+  @pre B_transpose.rows() == D.cols(). */
+  SchurComplement(const Eigen::Ref<const Eigen::SparseMatrix<T>>& A,
+                  const Eigen::Ref<const Eigen::SparseMatrix<T>>& B_transpose,
+                  const Eigen::Ref<const Eigen::SparseMatrix<T>>& D);
+
+  /* Creates a SchurComplement with prescribed A - BD⁻¹Bᵀ and -D⁻¹Bᵀ. */
+  SchurComplement(MatrixX<T>&& D_complement, MatrixX<T>&& neg_Dinv_B_transpose);
+
+  /* Returns the Schur complement for the block D of the matrix M, A - BD⁻¹Bᵀ.
+   */
+  const MatrixX<T>& get_D_complement() const { return D_complement_; }
+
+  /* Solves for y given the solution for x assuming the right hand side takes
+  the form  [aᵀ 0ᵀ]x using the fact that y = -D⁻¹Bᵀx. See class documentation.
+  */
+  VectorX<T> SolveForY(const Eigen::Ref<const VectorX<T>>& x) const;
+
+ private:
+  int p_{0};  // Number of rows and columns for A.
+  int q_{0};  // Number of rows and columns for D.
+  // TODO(xuchenhan-tri): Investigate the sparsity pattern of D⁻¹Bᵀ with actual
+  //  meshes.
+  MatrixX<T> D_complement_{};          // A - BD⁻¹Bᵀ.
+  MatrixX<T> neg_Dinv_B_transpose_{};  // -D⁻¹Bᵀ.
+};
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::internal::SchurComplement)

--- a/multibody/fem/test/acceleration_newmark_scheme_test.cc
+++ b/multibody/fem/test/acceleration_newmark_scheme_test.cc
@@ -1,0 +1,111 @@
+#include "drake/multibody/fem/acceleration_newmark_scheme.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/multibody/fem/test/dummy_element.h"
+#include "drake/multibody/fem/velocity_newmark_scheme.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace {
+
+using test::DummyElement;
+
+const double kDt = 1e-3;
+const double kGamma = 0.6;
+const double kBeta = 0.3;
+const double kTolerance = 8.0 * std::numeric_limits<double>::epsilon();
+
+Vector4<double> MakeQ() { return Vector4<double>(1.23, 2.34, 3.45, 4.56); }
+Vector4<double> MakeQdot() { return Vector4<double>(5.67, 6.78, 7.89, 9.10); }
+Vector4<double> MakeQddot() {
+  return Vector4<double>(0.1011, 0.1112, 0.1213, 0.1314);
+}
+
+/* Verify that the weights returned by the accessor match expectation. */
+GTEST_TEST(AccelerationNewmarkSchemeTest, Weights) {
+  AccelerationNewmarkScheme<double> scheme{kDt, kGamma, kBeta};
+  EXPECT_TRUE(CompareMatrices(
+      scheme.weights(), Vector3<double>(kBeta * kDt * kDt, kGamma * kDt, 1.0),
+      0));
+}
+
+/* Verify that the result of
+ `AccelerationNewmarkScheme::UpdateStateFromChangeInUnknowns()` is consistent
+ with the weights. */
+GTEST_TEST(AccelerationNewmarkSchemeTest, UpdateStateFromChangeInUnknowns) {
+  AccelerationNewmarkScheme<double> scheme{kDt, kGamma, kBeta};
+  FemStateImpl<DummyElement> state0(MakeQ(), MakeQdot(), MakeQddot());
+  FemStateImpl<DummyElement> state(state0);
+  const Vector4<double> dz(1.234, 4.567, 7.890, 0.123);
+  const Vector3<double>& weights = scheme.weights();
+  scheme.UpdateStateFromChangeInUnknowns(dz, &state);
+  EXPECT_TRUE(CompareMatrices(state.GetPositions() - state0.GetPositions(),
+                              weights(0) * dz, kTolerance));
+  EXPECT_TRUE(CompareMatrices(state.GetVelocities() - state0.GetVelocities(),
+                              weights(1) * dz, kTolerance));
+  EXPECT_TRUE(
+      CompareMatrices(state.GetAccelerations() - state0.GetAccelerations(),
+                      weights(2) * dz, kTolerance));
+}
+
+/* Tests that AccelerationNewmarkScheme reproduces analytical solutions with
+ constant acceleration. */
+GTEST_TEST(AccelerationNewmarkSchemeTest, AdvanceOneTimeStep) {
+  AccelerationNewmarkScheme<double> scheme{kDt, kGamma, kBeta};
+  const Vector4<double> q = MakeQ();
+  const Vector4<double> qdot = MakeQdot();
+  const Vector4<double> qddot = MakeQddot();
+  const FemStateImpl<DummyElement> state_0(q, qdot, qddot);
+  FemStateImpl<DummyElement> state_n(state_0);
+  FemStateImpl<DummyElement> state_np1(state_0);
+  const int kTimeSteps = 10;
+  for (int i = 0; i < kTimeSteps; ++i) {
+    scheme.AdvanceOneTimeStep(state_n, qddot, &state_np1);
+    state_n = state_np1;
+  }
+  const double total_time = kDt * kTimeSteps;
+  EXPECT_TRUE(
+      CompareMatrices(state_n.GetAccelerations(), state_0.GetAccelerations()));
+  EXPECT_TRUE(CompareMatrices(
+      state_n.GetVelocities(),
+      state_0.GetVelocities() + total_time * state_0.GetAccelerations(),
+      kTimeSteps * kTolerance));
+  EXPECT_TRUE(CompareMatrices(
+      state_n.GetPositions(),
+      state_0.GetPositions() + total_time * state_0.GetVelocities() +
+          0.5 * total_time * total_time * state_0.GetAccelerations(),
+      kTimeSteps * kTolerance));
+}
+
+/* Tests that `AccelerationNewmarkScheme` is equivalent with
+ `VelocityNewmarkScheme` by advancing one time step with each integration
+ scheme using the same initial state and verifying that the resulting new states
+ are the same. */
+GTEST_TEST(AccelerationNewmarkSchemeTest, EquivalenceWithVelocityNewmark) {
+  AccelerationNewmarkScheme<double> acceleration_scheme{kDt, kGamma, kBeta};
+  FemStateImpl<DummyElement> state0(MakeQ(), MakeQdot(), MakeQddot());
+  FemStateImpl<DummyElement> state_a(state0);
+  acceleration_scheme.AdvanceOneTimeStep(state0, MakeQddot(), &state_a);
+
+  VelocityNewmarkScheme<double> velocity_scheme{kDt, kGamma, kBeta};
+  FemStateImpl<DummyElement> state_v(state0);
+  velocity_scheme.AdvanceOneTimeStep(state0, state_a.GetVelocities(), &state_v);
+  /* Set a larger error tolerance to accomodate the division by `dt` used in the
+   VelocityNewmarkScheme. */
+  EXPECT_TRUE(CompareMatrices(state_v.GetAccelerations(),
+                              state_a.GetAccelerations(), kTolerance / kDt));
+  EXPECT_TRUE(CompareMatrices(state_v.GetVelocities(), state_a.GetVelocities(),
+                              kTolerance));
+  EXPECT_TRUE(CompareMatrices(state_v.GetPositions(), state_a.GetPositions(),
+                              kTolerance));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/calc_lame_parameters_test.cc
+++ b/multibody/fem/test/calc_lame_parameters_test.cc
@@ -1,0 +1,48 @@
+#include "drake/multibody/fem/calc_lame_parameters.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace {
+
+GTEST_TEST(CalcLameParametersTest, InvalidParameters) {
+  DRAKE_EXPECT_THROWS_MESSAGE(CalcLameParameters<double>(-1.0, 0.25),
+                              std::exception,
+                              "Young's modulus must be nonnegative.");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(CalcLameParameters<double>(100.0, 0.5),
+                              std::exception,
+                              "Poisson's ratio must be in .*");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(CalcLameParameters<double>(100.0, 0.6),
+                              std::exception,
+                              "Poisson's ratio must be in .*");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(CalcLameParameters<double>(100.0, -1.0),
+                              std::exception,
+                              "Poisson's ratio must be in .*");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(CalcLameParameters<double>(100.0, -1.1),
+                              std::exception,
+                              "Poisson's ratio must be in .*");
+}
+
+/* Verify that the calculated Lame parameters match pen and paper calculation.
+ */
+GTEST_TEST(CalcLameParametersTest, AnalyticResults) {
+  const LameParameters<double> lame_params =
+      CalcLameParameters<double>(280, 0.4);
+  EXPECT_DOUBLE_EQ(lame_params.mu, 100.0);
+  EXPECT_DOUBLE_EQ(lame_params.lambda, 400.0);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/constitutive_model_test_utilities.cc
+++ b/multibody/fem/test/constitutive_model_test_utilities.cc
@@ -1,0 +1,190 @@
+#include "drake/multibody/fem/test/constitutive_model_test_utilities.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/multibody/fem/constitutive_model.h"
+#include "drake/multibody/fem/corotated_model.h"
+#include "drake/multibody/fem/linear_constitutive_model.h"
+#include "drake/multibody/fem/test/test_utilities.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace test {
+
+using Eigen::Matrix3d;
+const double kTolerance = 1e-12;
+constexpr int kSpatialDimension = 3;
+
+/* Creates an array of arbitrary autodiff deformation gradients. */
+template <int num_locations>
+std::array<Matrix3<AutoDiffXd>, num_locations> MakeDeformationGradients() {
+  /* Create an arbitrary AutoDiffXd deformation. */
+  Matrix3d F;
+  // clang-format off
+  F << 0.18, 0.63, 0.54,
+       0.13, 0.92, 0.17,
+       0.03, 0.86, 0.85;
+  // clang-format on
+  const std::array<Matrix3d, num_locations> deformation_gradients{F};
+  std::array<Matrix3<AutoDiffXd>, num_locations> deformation_gradients_autodiff;
+  const Eigen::Matrix<double, 9, Eigen::Dynamic> derivatives(
+      Eigen::Matrix<double, 9, 9>::Identity());
+  for (int i = 0; i < num_locations; ++i) {
+    const auto F_autodiff_flat =
+        math::InitializeAutoDiff(Eigen::Map<const Eigen::Matrix<double, 9, 1>>(
+                                     deformation_gradients[i].data(), 9),
+                                 derivatives);
+    deformation_gradients_autodiff[i] =
+        Eigen::Map<const Matrix3<AutoDiffXd>>(F_autodiff_flat.data(), 3, 3);
+  }
+  return deformation_gradients_autodiff;
+}
+
+/* Tests the constructors correctly initializes St.Venant-Kichhoff like
+constitutive models and rejects invalid Young's modulus and poisson ratio.
+@tparam Model    Must be instantiations of LinearConstitutiveModel or
+CorotatedModel. */
+template <class Model>
+void TestParameters() {
+  using T = typename Model::T;
+  const T kYoungsModulus = 100.0;
+  const T kPoissonRatio = 0.25;
+  const Model model(kYoungsModulus, kPoissonRatio);
+  const T kExpectedMu = 40.0;
+  const T kExpectedLambda = 40.0;
+  EXPECT_EQ(model.youngs_modulus(), kYoungsModulus);
+  EXPECT_EQ(model.poisson_ratio(), kPoissonRatio);
+  EXPECT_EQ(model.shear_modulus(), kExpectedMu);
+  EXPECT_EQ(model.lame_first_parameter(), kExpectedLambda);
+
+  DRAKE_EXPECT_THROWS_MESSAGE((Model(-1.0, 0.25)), std::logic_error,
+                              "Young's modulus must be nonnegative.");
+
+  DRAKE_EXPECT_THROWS_MESSAGE((Model(100.0, 0.5)), std::logic_error,
+                              "Poisson ratio must be in \\(-1, 0.5\\).");
+
+  DRAKE_EXPECT_THROWS_MESSAGE((Model(100.0, 0.6)), std::logic_error,
+                              "Poisson ratio must be in \\(-1, 0.5\\).");
+
+  DRAKE_EXPECT_THROWS_MESSAGE((Model(100.0, -1.0)), std::logic_error,
+                              "Poisson ratio must be in \\(-1, 0.5\\).");
+
+  DRAKE_EXPECT_THROWS_MESSAGE((Model(100.0, -1.1)), std::logic_error,
+                              "Poisson ratio must be in \\(-1, 0.5\\).");
+}
+
+/* Tests that the energy density and the stress are zero at the undeformed
+state.
+@tparam Model    Must be instantiations of LinearConstitutiveModel or
+CorotatedModel. */
+template <class Model>
+void TestUndeformedState() {
+  constexpr int num_locations = Model::Data::num_locations;
+  using T = typename Model::T;
+
+  const T kYoungsModulus = 100.0;
+  const T kPoissonRatio = 0.25;
+  const Model model(kYoungsModulus, kPoissonRatio);
+  typename Model::Traits::Data data;
+  const std::array<Matrix3<T>, num_locations> F{Matrix3<T>::Identity()};
+  data.UpdateData(F);
+  /* At the undeformed state, the energy density should be zero. */
+  const std::array<T, num_locations> analytic_energy_density{0};
+  /* At the undeformed state, the stress should be zero. */
+  const std::array<Matrix3<T>, num_locations> analytic_stress{Matrix3d::Zero()};
+  std::array<T, num_locations> energy_density;
+  model.CalcElasticEnergyDensity(data, &energy_density);
+  EXPECT_EQ(energy_density, analytic_energy_density);
+  std::array<Matrix3<T>, num_locations> stress;
+  model.CalcFirstPiolaStress(data, &stress);
+  EXPECT_EQ(stress, analytic_stress);
+}
+
+/* Tests that the energy density and the stress are consistent by verifying the
+stress matches the derivative of energy density produced by automatic
+differentiation.
+@tparam Model    Must be AutoDiffXd instantiations of LinearConstitutiveModel or
+CorotatedModel. */
+template <class Model>
+void TestPIsDerivativeOfPsi() {
+  constexpr int num_locations = Model::Data::num_locations;
+  constexpr double kYoungsModulus = 100.0;
+  constexpr double kPoissonRatio = 0.3;
+  const Model model(kYoungsModulus, kPoissonRatio);
+  typename Model::Traits::Data data;
+  const std::array<Matrix3<AutoDiffXd>, num_locations> deformation_gradients =
+      MakeDeformationGradients<num_locations>();
+  data.UpdateData(deformation_gradients);
+  std::array<AutoDiffXd, num_locations> energy;
+  model.CalcElasticEnergyDensity(data, &energy);
+  std::array<Matrix3<AutoDiffXd>, num_locations> P;
+  model.CalcFirstPiolaStress(data, &P);
+  for (int i = 0; i < num_locations; ++i) {
+    EXPECT_TRUE(CompareMatrices(
+        Eigen::Map<const Matrix3d>(energy[i].derivatives().data(), 3, 3), P[i],
+        fem::test::CalcConditionNumber<AutoDiffXd>(P[i]) * kTolerance));
+  }
+}
+
+/* Tests that the stress and the stress derivatives are consistent by verifying
+the handcrafted derivative matches that produced by automatic differentiation.
+@tparam Model    Must be AutoDiffXd instantiations of LinearConstitutiveModel or
+CorotatedModel. */
+template <class Model>
+void TestdPdFIsDerivativeOfP() {
+  constexpr int num_locations = Model::Data::num_locations;
+  constexpr double kYoungsModulus = 100.0;
+  constexpr double kPoissonRatio = 0.3;
+  const Model model(kYoungsModulus, kPoissonRatio);
+  typename Model::Traits::Data data;
+  const std::array<Matrix3<AutoDiffXd>, num_locations> deformation_gradients =
+      MakeDeformationGradients<num_locations>();
+  data.UpdateData(deformation_gradients);
+  std::array<Matrix3<AutoDiffXd>, num_locations> P;
+  model.CalcFirstPiolaStress(data, &P);
+  std::array<Eigen::Matrix<AutoDiffXd, 9, 9>, num_locations> dPdF;
+  model.CalcFirstPiolaStressDerivative(data, &dPdF);
+  for (int q = 0; q < num_locations; ++q) {
+    for (int i = 0; i < kSpatialDimension; ++i) {
+      for (int j = 0; j < kSpatialDimension; ++j) {
+        Matrix3d dPijdF;
+        for (int k = 0; k < kSpatialDimension; ++k) {
+          for (int l = 0; l < kSpatialDimension; ++l) {
+            dPijdF(k, l) = dPdF[q](3 * j + i, 3 * l + k).value();
+          }
+        }
+        EXPECT_TRUE(CompareMatrices(
+            Eigen::Map<const Matrix3d>(P[q](i, j).derivatives().data(), 3, 3),
+            dPijdF,
+            fem::test::CalcConditionNumber<AutoDiffXd>(P[q]) * kTolerance));
+      }
+    }
+  }
+}
+
+template void TestParameters<LinearConstitutiveModel<double, 1>>();
+template void TestParameters<CorotatedModel<double, 1>>();
+template void TestParameters<LinearConstitutiveModel<AutoDiffXd, 1>>();
+template void TestParameters<CorotatedModel<AutoDiffXd, 1>>();
+
+template void TestUndeformedState<LinearConstitutiveModel<double, 1>>();
+template void TestUndeformedState<CorotatedModel<double, 1>>();
+template void TestUndeformedState<LinearConstitutiveModel<AutoDiffXd, 1>>();
+template void TestUndeformedState<CorotatedModel<AutoDiffXd, 1>>();
+
+template void TestPIsDerivativeOfPsi<LinearConstitutiveModel<AutoDiffXd, 1>>();
+template void TestPIsDerivativeOfPsi<CorotatedModel<AutoDiffXd, 1>>();
+
+template void TestdPdFIsDerivativeOfP<LinearConstitutiveModel<AutoDiffXd, 1>>();
+template void TestdPdFIsDerivativeOfP<CorotatedModel<AutoDiffXd, 1>>();
+
+}  // namespace test
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/constitutive_model_test_utilities.h
+++ b/multibody/fem/test/constitutive_model_test_utilities.h
@@ -1,0 +1,53 @@
+#pragma once
+
+/** @file
+ This file provides utilities that facilitates testing the subclasses of
+ ConstitutiveModel instead of the ConstitutiveModel class itself. */
+
+#include <array>
+
+#include "drake/common/autodiff.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace test {
+
+/* Creates an array of arbitrary autodiff deformation gradients. */
+template <int num_locations>
+std::array<Matrix3<AutoDiffXd>, num_locations> MakeDeformationGradients();
+
+/* Tests the constructor and the accessors for St.Venant-Kirchhoff like
+constitutive models.
+@tparam Model    Must be instantiations of LinearConstitutiveModel or
+CorotatedModel. */
+template <class Model>
+void TestParameters();
+
+/* Tests that the energy density and the stress are zero at the undeformed
+state.
+@tparam Model    Must be instantiations of a concrete ConstitutiveModel. */
+template <class Model>
+void TestUndeformedState();
+
+/* Tests that the energy density and the stress are consistent by verifying
+the stress matches the derivative of energy density produced by automatic
+differentiation.
+@tparam Model    Must be AutoDiffXd instantiations of a concrete
+ConstitutiveModel. */
+template <class Model>
+void TestPIsDerivativeOfPsi();
+
+/* Tests that the stress and the stress derivatives are consistent by verifying
+the handcrafted derivative matches that produced by automatic differentiation.
+@tparam Model    Must be AutoDiffXd instantiations of a concrete
+ConstitutiveModel. */
+template <class Model>
+void TestdPdFIsDerivativeOfP();
+
+}  // namespace test
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/corotated_model_test.cc
+++ b/multibody/fem/test/corotated_model_test.cc
@@ -1,0 +1,37 @@
+#include "drake/multibody/fem/corotated_model.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/multibody/fem/test/constitutive_model_test_utilities.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace test {
+
+constexpr int kNumLocations = 1;
+
+GTEST_TEST(CorotatedModelTest, Parameters) {
+  TestParameters<CorotatedModel<double, kNumLocations>>();
+  TestParameters<CorotatedModel<AutoDiffXd, kNumLocations>>();
+}
+
+GTEST_TEST(CorotatedModelTest, UndeformedState) {
+  TestUndeformedState<CorotatedModel<double, kNumLocations>>();
+  TestUndeformedState<CorotatedModel<AutoDiffXd, kNumLocations>>();
+}
+
+GTEST_TEST(CorotatedModelTest, PIsDerivativeOfPsi) {
+  TestPIsDerivativeOfPsi<CorotatedModel<AutoDiffXd, kNumLocations>>();
+}
+
+GTEST_TEST(CorotatedModelTest, dPdFIsDerivativeOfP) {
+  TestdPdFIsDerivativeOfP<CorotatedModel<AutoDiffXd, kNumLocations>>();
+}
+
+}  // namespace test
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/damping_model_test.cc
+++ b/multibody/fem/test/damping_model_test.cc
@@ -1,0 +1,35 @@
+#include "drake/multibody/fem/damping_model.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace {
+
+GTEST_TEST(DampingModelTest, Getters) {
+  const double mass_coeff = 1.0;
+  const double stiffness_coeff = 2.0;
+  const DampingModel<double> model(mass_coeff, stiffness_coeff);
+  EXPECT_EQ(model.mass_coeff(), mass_coeff);
+  EXPECT_EQ(model.stiffness_coeff(), stiffness_coeff);
+}
+
+GTEST_TEST(DampingModelTest, InvalidModel) {
+  /* Negative coefficients are not allowed. */
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      DampingModel<double>(1.0, -1.0), std::exception,
+      "Mass and stiffness damping coefficients must be non-negative.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      DampingModel<double>(1.0, -1.0), std::exception,
+      "Mass and stiffness damping coefficients must be non-negative.");
+  /* Zero coefficients are OK. */
+  EXPECT_NO_THROW(DampingModel<double>(0, 0));
+}
+
+}  // namespace
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/dirichlet_boundary_condition_test.cc
+++ b/multibody/fem/test/dirichlet_boundary_condition_test.cc
@@ -1,0 +1,152 @@
+#include "drake/multibody/fem/dirichlet_boundary_condition.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/fem/fem_state.h"
+#include "drake/multibody/fem/test/dummy_element.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace test {
+namespace {
+
+/* An arbitrary number of degree of freedom made up for testing purpose. */
+static constexpr int kNumDofs = 4;
+using DenseMatrix = Eigen::Matrix<double, kNumDofs, kNumDofs>;
+using Eigen::VectorXd;
+using SparseMatrix = Eigen::SparseMatrix<double>;
+using Element = DummyElement;
+using State = FemStateImpl<Element>;
+using std::make_unique;
+using std::unique_ptr;
+using std::vector;
+
+class DirichletBoundaryConditionTest : public ::testing::Test {
+ protected:
+  void SetUp() {
+    bc_.AddBoundaryCondition(0, Vector3<double>(3, 2, 1));
+    bc_.AddBoundaryCondition(2, Vector3<double>(-3, -2, 0));
+  }
+
+  /* Makes an arbitrary residual vector with appropriate size. */
+  static VectorXd MakeResidual() {
+    return Vector<double, kNumDofs>(1.1, 2.2, 3.3, 4.4);
+  }
+
+  /* Makes an arbitrary SPD tangent matrix with appropriate size. */
+  static SparseMatrix MakeEigenTangentMatrix() {
+    DenseMatrix A;
+    // clang-format off
+    A << 3,   1,     0.5, -1,
+         1,   2,     0.25, 0.125,
+         0.5, 0.25,  3,    0.25,
+        -1,   0.125, 0.25, 4;
+    // clang-format on
+    SparseMatrix A_eigen_sparse = A.sparseView();
+    return A_eigen_sparse;
+  }
+
+  /* Returns the same matrix as in MakeEigenTangentMatrix(), but in PETSc
+   format. The PETSc matrix contains a single block matrix of size 4-by-4.*/
+  static unique_ptr<PetscSymmetricBlockSparseMatrix> MakePetscTangentMatrix() {
+    const vector<int> num_upper_triangular_blocks_per_row = {1};
+    auto A = make_unique<PetscSymmetricBlockSparseMatrix>(
+        kNumDofs, kNumDofs, num_upper_triangular_blocks_per_row);
+    const Vector1<int> index(0);
+    A->AddToBlock(index, DenseMatrix(MakeEigenTangentMatrix()));
+    A->AssembleIfNecessary();
+    return A;
+  }
+
+  /* Makes an arbitrary compatible FemStateImpl with appropriate size. */
+  static State MakeState() {
+    State state{Vector<double, kNumDofs>(0.1, 0.2, 0.3, 0.4),
+                Vector<double, kNumDofs>(0.5, 0.6, 0.7, 0.8),
+                Vector<double, kNumDofs>(0.9, 1.0, 1.1, 1.2)};
+    return state;
+  }
+
+  /* The DirichletBoundaryCondition under test. */
+  DirichletBoundaryCondition<double> bc_;
+};
+
+/* Tests that the DirichletBoundaryCondition under test successfully modifies
+ a given state. */
+TEST_F(DirichletBoundaryConditionTest, ApplyBoundaryConditionToState) {
+  State s = MakeState();
+  bc_.ApplyBoundaryConditionToState(&s);
+  EXPECT_TRUE(CompareMatrices(s.GetPositions(),
+                              Vector<double, kNumDofs>{3, 0.2, -3, 0.4}));
+  EXPECT_TRUE(CompareMatrices(s.GetVelocities(),
+                              Vector<double, kNumDofs>{2, 0.6, -2, 0.8}));
+  EXPECT_TRUE(CompareMatrices(s.GetAccelerations(),
+                              Vector<double, kNumDofs>{1, 1.0, 0, 1.2}));
+}
+
+/* Tests that the DirichletBoundaryCondition under test successfully modifies
+ a given residual. */
+TEST_F(DirichletBoundaryConditionTest, ApplyBoundaryConditionToResidual) {
+  VectorXd b = MakeResidual();
+  bc_.ApplyBoundaryConditionToResidual(&b);
+  const Vector<double, kNumDofs> b_expected(0, 2.2, 0, 4.4);
+  EXPECT_TRUE(CompareMatrices(b, b_expected));
+}
+
+/* Tests that the DirichletBoundaryCondition under test successfully modifies a
+ given tangent matrix. */
+TEST_F(DirichletBoundaryConditionTest,
+       ApplyBoundaryConditionResidualAndTangentMatrix) {
+  /* Test for the Eigen::SparseMatrix overload. */
+  SparseMatrix A_eigen_sparse = MakeEigenTangentMatrix();
+  const int nnz = A_eigen_sparse.nonZeros();
+  bc_.ApplyBoundaryConditionToTangentMatrix(&A_eigen_sparse);
+  /* The number of nonzeros should not change. */
+  EXPECT_EQ(A_eigen_sparse.nonZeros(), nnz);
+  const DenseMatrix A(A_eigen_sparse);
+  DenseMatrix A_expected;
+  // clang-format off
+  A_expected << 1, 0,     0, 0,
+                0, 2,     0, 0.125,
+                0, 0,     1, 0,
+                0, 0.125, 0, 4;
+  // clang-format on
+  EXPECT_TRUE(CompareMatrices(A, A_expected));
+
+  /* Test for the PetscSymmetricBlockSparseMatrix overload. */
+  auto A_petsc = MakePetscTangentMatrix();
+  bc_.ApplyBoundaryConditionToTangentMatrix(A_petsc.get());
+  EXPECT_TRUE(CompareMatrices(A_petsc->MakeDenseMatrix(), A_expected));
+}
+
+/* Tests out-of-bound boundary conditions throw an exception. */
+TEST_F(DirichletBoundaryConditionTest, OutOfBound) {
+  /* Put a dof that is out-of-bound under boundary condition. */
+  bc_.AddBoundaryCondition(4, Vector3<double>(9, 1, 1));
+  State state = MakeState();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      bc_.ApplyBoundaryConditionToState(&state),
+      "An index of the Dirichlet boundary condition is out of the range.");
+  VectorXd b = MakeResidual();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      bc_.ApplyBoundaryConditionToResidual(&b),
+      "An index of the Dirichlet boundary condition is out of the range.");
+  SparseMatrix A_eigen_sparse = MakeEigenTangentMatrix();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      bc_.ApplyBoundaryConditionToTangentMatrix(&A_eigen_sparse),
+      "An index of the Dirichlet boundary condition is out of the range.");
+  auto A_petsc = MakePetscTangentMatrix();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      bc_.ApplyBoundaryConditionToTangentMatrix(A_petsc.get()),
+      "An index of the Dirichlet boundary condition is out of the range.");
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/dummy_element.cc
+++ b/multibody/fem/test/dummy_element.cc
@@ -1,0 +1,1 @@
+#include "drake/multibody/fem/test/dummy_element.h"

--- a/multibody/fem/test/dummy_element.h
+++ b/multibody/fem/test/dummy_element.h
@@ -1,0 +1,146 @@
+#pragma once
+
+#include <array>
+
+#include "drake/multibody/fem/damping_model.h"
+#include "drake/multibody/fem/element_cache_entry.h"
+#include "drake/multibody/fem/fem_element.h"
+#include "drake/multibody/fem/fem_state_impl.h"
+#include "drake/multibody/fem/linear_constitutive_model.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace test {
+
+/* The traits for the DummyElement. In this case, all of the traits are unique
+ values so we can detect that each value is used in the expected context. */
+struct DummyElementTraits {
+  using T = double;
+  struct Data {
+    double value{0};
+  };
+  static constexpr int num_quadrature_points = 1;
+  static constexpr int num_natural_dimension = 2;
+  static constexpr int kSpatialDimension = 3;
+  static constexpr int num_nodes = 4;
+  static constexpr int num_dofs = 12;
+  using ConstitutiveModel = LinearConstitutiveModel<T, num_quadrature_points>;
+};
+
+/* A simple FemElement implementation. The calculation methods are implemented
+ as returning a fixed value (which can independently be accessed by calling
+ the corresponding dummy_* method -- e.g., CalcResidual() should return the
+ value in dummy_residual(). */
+class DummyElement final : public FemElement<DummyElement, DummyElementTraits> {
+ public:
+  using Base = FemElement<DummyElement, DummyElementTraits>;
+  using Traits = DummyElementTraits;
+  using ConstitutiveModel = typename Traits::ConstitutiveModel;
+  using T = typename Base::T;
+  static constexpr int kNumDofs = Traits::num_dofs;
+
+  DummyElement(ElementIndex element_index,
+               const std::array<NodeIndex, Traits::num_nodes>& node_indices,
+               const ConstitutiveModel& constitutive_model,
+               const DampingModel<T>& damping_model)
+      : Base(element_index, node_indices, constitutive_model, damping_model) {}
+
+  /* Provides a fixed return value for CalcResidual(). */
+  static Vector<T, kNumDofs> dummy_residual() {
+    return Vector<T, kNumDofs>::Constant(1.23456);
+  }
+
+  /* Creates an arbitrary SPD matrix. */
+  static Eigen::Matrix<T, kNumDofs, kNumDofs> MakeSpdMatrix() {
+    Eigen::Matrix<T, kNumDofs, kNumDofs> A;
+    for (int i = 0; i < kNumDofs; ++i) {
+      for (int j = 0; j < kNumDofs; ++j) {
+        A(i, j) = 2.7 * i + 3.1 * j;
+      }
+    }
+    // A + A^T is guaranteed PSD. Adding the identity matrix to it makes it SPD.
+    return (A + A.transpose()) +
+           Eigen::Matrix<T, kNumDofs, kNumDofs>::Identity();
+  }
+
+  /* Provides a fixed return value for CalcStiffnessMatrix(). */
+  static Eigen::Matrix<T, kNumDofs, kNumDofs> dummy_stiffness_matrix() {
+    return 1.23 * MakeSpdMatrix();
+  }
+
+  /* Provides a fixed return value for CalcDampingMatrix(). */
+  static Eigen::Matrix<T, kNumDofs, kNumDofs> dummy_damping_matrix() {
+    return 4.56 * MakeSpdMatrix();
+  }
+
+  /* Provides a fixed return value for CalcMassMatrix(). */
+  static Eigen::Matrix<T, kNumDofs, kNumDofs> dummy_mass_matrix() {
+    return 7.89 * MakeSpdMatrix();
+  }
+
+  /* Provides a fixed value for the `Data` for `ComputeData()`. */
+  static typename Traits::Data dummy_data() { return {1.732}; }
+
+ private:
+  /* Friend the base class so that the interface in the CRTP base class can
+   access the private implementations of this class. */
+  friend Base;
+
+  /* Implements FemElement::ComputeData(). Returns a dummy data if `state` is
+    empty. Otherwise return the sum of the last entries in each state. */
+  typename Traits::Data DoComputeData(
+      const FemStateImpl<DummyElement>& state) const {
+    const int state_dofs = state.num_dofs();
+    if (state_dofs == 0) {
+      return dummy_data();
+    }
+    typename Traits::Data data;
+    data.value = state.GetPositions()(state_dofs - 1);
+    data.value += state.GetVelocities()(state_dofs - 1);
+    data.value += state.GetAccelerations()(state_dofs - 1);
+    return data;
+  }
+
+  /* Implements FemElement::CalcResidual().
+   The residual is equal to a dummy nonzero value if the states are all zero.
+   Otherwise the residual is zero.*/
+  void DoCalcResidual(const FemStateImpl<DummyElement>& state,
+                      EigenPtr<Vector<T, kNumDofs>> residual) const {
+    if (state.GetPositions().norm() == 0.0 &&
+        state.GetVelocities().norm() == 0.0 &&
+        state.GetAccelerations().norm() == 0.00) {
+      *residual = dummy_residual();
+    } else {
+      residual->setZero();
+    }
+  }
+
+  /* Implements FemElement::AddScaledStiffnessMatrix(). */
+  void DoAddScaledStiffnessMatrix(
+      const FemStateImpl<DummyElement>&, const T& scale,
+      EigenPtr<Eigen::Matrix<T, kNumDofs, kNumDofs>> K) const {
+    *K += scale * dummy_stiffness_matrix();
+  }
+
+  /* Implements FemElement::AddScaledDampingMatrix(). */
+  void DoAddScaledDampingMatrix(
+      const FemStateImpl<DummyElement>&, const T& scale,
+      EigenPtr<Eigen::Matrix<T, kNumDofs, kNumDofs>> D) const {
+    *D += scale * dummy_damping_matrix();
+  }
+
+  /* Implements FemElement::AddScaledMassMatrix(). */
+  void DoAddScaledMassMatrix(
+      const FemStateImpl<DummyElement>&, const T& scale,
+      EigenPtr<Eigen::Matrix<T, kNumDofs, kNumDofs>> M) const {
+    *M += scale * dummy_mass_matrix();
+  }
+};
+
+}  // namespace test
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/dummy_model.cc
+++ b/multibody/fem/test/dummy_model.cc
@@ -1,0 +1,1 @@
+#include "drake/multibody/fem/test/dummy_model.h"

--- a/multibody/fem/test/dummy_model.h
+++ b/multibody/fem/test/dummy_model.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "drake/multibody/fem/fem_model_impl.h"
+#include "drake/multibody/fem/test/dummy_element.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace test {
+
+/* A dummy FemModelImpl with a single DummyElement for testing purpose. */
+class DummyModel final : public FemModelImpl<DummyElement> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DummyModel);
+
+  using Traits = DummyElement::Traits;
+  using T = Traits::T;
+  using ConstitutiveModel = typename Traits::ConstitutiveModel;
+  static constexpr int kNumDofs = Traits::num_dofs;
+  const T kYoungsModulus = 1e7;
+  const T kPoissonRatio = 0.49;
+  const T kMassDamping = 0.001;
+  const T kStiffnessDamping = 0.02;
+
+  /* Creates a dummy FEM model with a single element. */
+  DummyModel() {
+    const ElementIndex element_index(0);
+    const std::array node_indices = {NodeIndex(0), NodeIndex(1), NodeIndex(2),
+                                     NodeIndex(3)};
+    const ConstitutiveModel constitutive_model(1e7, 0.49);
+    const DampingModel<T> damping_model(kMassDamping, kStiffnessDamping);
+    this->AddElement(element_index, node_indices, constitutive_model,
+                     damping_model);
+    increment_num_nodes(4);
+  }
+
+ private:
+  /* Creates an all-zero FEM state for the dummy model. */
+  FemStateImpl<DummyElement> DoMakeFemStateImpl() const final {
+    return FemStateImpl<DummyElement>(VectorX<T>::Zero(kNumDofs),
+                                      VectorX<T>::Zero(kNumDofs),
+                                      VectorX<T>::Zero(kNumDofs));
+  }
+};
+
+}  // namespace test
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/element_cache_entry_test.cc
+++ b/multibody/fem/test/element_cache_entry_test.cc
@@ -1,0 +1,43 @@
+#include "drake/multibody/fem/element_cache_entry.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace {
+
+struct Data {
+  double foo;
+};
+
+GTEST_TEST(ElementCacheEntryTest, Staleness) {
+  ElementCacheEntry<Data> cache_entry;
+  /* The cache entry is initialized to be stale. */
+  EXPECT_TRUE(cache_entry.is_stale());
+  /* Test setter and getter. */
+  cache_entry.set_stale(false);
+  EXPECT_FALSE(cache_entry.is_stale());
+  cache_entry.set_stale(true);
+  EXPECT_TRUE(cache_entry.is_stale());
+}
+
+GTEST_TEST(ElementCacheEntryTest, CachedData) {
+  ElementCacheEntry<Data> cache_entry;
+  EXPECT_TRUE(cache_entry.is_stale());
+  /* Set the cache entry value. */
+  Data& mutable_data = cache_entry.mutable_element_data();
+  mutable_data.foo = 1.23;
+  const Data& const_data = cache_entry.element_data();
+  /* Verify the cache entry value has been modified. */
+  EXPECT_EQ(const_data.foo, 1.23);
+  /* Verify the staleness flag is untouched. */
+  EXPECT_TRUE(cache_entry.is_stale());
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/fem_element_test.cc
+++ b/multibody/fem/test/fem_element_test.cc
@@ -1,0 +1,102 @@
+#include "drake/multibody/fem/fem_element.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/multibody/fem/test/dummy_element.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace test {
+namespace {
+
+using T = DummyElementTraits::T;
+const ElementIndex kZeroIndex = ElementIndex(0);
+const std::array<NodeIndex, DummyElementTraits::num_nodes> kNodeIndices = {
+    {NodeIndex(0), NodeIndex(1), NodeIndex(2), NodeIndex(3)}};
+const DummyElementTraits::ConstitutiveModel kConstitutiveModel(5e4, 0.4);
+const DampingModel<T> kDampingModel(0.01, 0.02);
+constexpr int kNumDofs = DummyElementTraits::num_dofs;
+
+class FemElementTest : public ::testing::Test {
+ protected:
+  /* Default values for the state. */
+  static VectorX<double> q() {
+    Vector<double, kNumDofs> q;
+    q << 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2;
+    return q;
+  }
+  static VectorX<double> v() {
+    Vector<double, kNumDofs> v;
+    v << 1.1, 1.2, 2.3, 2.4, 2.5, 2.6, 2.7, 1.8, 1.9, 2.0, 2.1, 2.2;
+    return v;
+  }
+  static VectorX<double> a() {
+    Vector<double, kNumDofs> a;
+    a << 2.1, 2.2, 3.3, 3.4, 3.5, 2.6, 2.7, 2.8, 2.9, 3.0, 3.1, 3.2;
+    return a;
+  }
+
+  /* FemElement under test. */
+  DummyElement element_{kZeroIndex, kNodeIndices, kConstitutiveModel,
+                        kDampingModel};
+  FemStateImpl<DummyElement> state_{q(), v(), a()};
+};
+
+TEST_F(FemElementTest, Constructor) {
+  EXPECT_EQ(element_.node_indices(), kNodeIndices);
+  EXPECT_EQ(element_.element_index(), kZeroIndex);
+}
+
+/* The following tests confirm that CalcResidual(), AddScaledStiffnessMatrix,
+ AddScaledDampingMatrix(), DoAddScaledMassMatrix(), correctly invoke their
+ DoCalc and DoAdd counterparts. We confirm this with a custom subclass of
+ FemElement whose implementation returns/adds a specific value. */
+TEST_F(FemElementTest, Residual) {
+  Vector<T, DummyElementTraits::num_dofs> residual;
+  element_.CalcResidual(state_, &residual);
+  const Vector<T, kNumDofs> zero_vector = Vector<T, kNumDofs>::Zero();
+  EXPECT_EQ(residual, zero_vector);
+
+  state_.SetPositions(zero_vector);
+  state_.SetVelocities(zero_vector);
+  state_.SetAccelerations(zero_vector);
+  element_.CalcResidual(state_, &residual);
+  EXPECT_EQ(residual, element_.dummy_residual());
+}
+
+TEST_F(FemElementTest, StiffnessMatrix) {
+  Eigen::Matrix<T, DummyElementTraits::num_dofs, DummyElementTraits::num_dofs>
+      K;
+  K.setZero();
+  const T scale = 3.14;
+  element_.AddScaledStiffnessMatrix(state_, scale, &K);
+  EXPECT_EQ(K, scale * element_.dummy_stiffness_matrix());
+}
+
+TEST_F(FemElementTest, DampingMatrix) {
+  Eigen::Matrix<T, DummyElementTraits::num_dofs, DummyElementTraits::num_dofs>
+      D;
+  D.setZero();
+  const T scale = 3.14;
+  element_.AddScaledDampingMatrix(state_, scale, &D);
+  EXPECT_EQ(D, scale * element_.dummy_damping_matrix());
+}
+
+/* Test that CalcMassMatrix() is calling the expected DoCalcMassMatrix(). */
+TEST_F(FemElementTest, MassMatrix) {
+  Eigen::Matrix<T, DummyElementTraits::num_dofs, DummyElementTraits::num_dofs>
+      M;
+  M.setZero();
+  const T scale = 3.14;
+  element_.AddScaledMassMatrix(state_, scale, &M);
+  EXPECT_EQ(M, scale * element_.dummy_mass_matrix());
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/fem_solver_test.cc
+++ b/multibody/fem/test/fem_solver_test.cc
@@ -1,0 +1,81 @@
+#include "drake/multibody/fem/fem_solver.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/fem/acceleration_newmark_scheme.h"
+#include "drake/multibody/fem/test/dummy_model.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace test {
+namespace {
+
+constexpr double kEps = 4.0 * std::numeric_limits<double>::epsilon();
+/* Parameters for the Newmark-beta integration scheme. */
+constexpr double kDt = 0.01;
+constexpr double kGamma = 0.5;
+constexpr double kBeta = 0.25;
+
+class FemSolverTest : public ::testing::Test {
+ protected:
+  DummyModel model_{};
+  AccelerationNewmarkScheme<double> integrator_{kDt, kGamma, kBeta};
+  FemSolver<double> solver_{&model_, &integrator_};
+};
+
+TEST_F(FemSolverTest, Tolerancse) {
+  /* Default values. */
+  EXPECT_EQ(solver_.relative_tolerance(), 1e-4);
+  EXPECT_EQ(solver_.absolute_tolerance(), 1e-6);
+  /* Test Setters. */
+  constexpr double kTol = 1e-8;
+  solver_.set_relative_tolerance(kTol);
+  solver_.set_absolute_tolerance(kTol);
+  EXPECT_EQ(solver_.relative_tolerance(), kTol);
+  EXPECT_EQ(solver_.absolute_tolerance(), kTol);
+}
+
+/* Tests that the behavior of FemSolver::AdvanceOneTimeStep agrees with analytic
+ results. The dummy model has a single dummy element which has a nonzero
+ residual at zero state and zero residual everywhere else. The dummy element
+ also has constant stiffness, damping, and mass matrix (aka they are
+ state-independent). As a result, we expect AdvanceOneTimeStep to converge after
+ exactly one Newton iteration, and the unknown variable z (acceleration in this
+ case) should satisfy A*z = -b, where A is the constant tangent matrix and b is
+ the nonzero residual evaluated at the zero state. */
+TEST_F(FemSolverTest, AdvanceOneTimeStep) {
+  std::unique_ptr<FemState<double>> state0 = model_.MakeFemState();
+  std::unique_ptr<FemState<double>> state = model_.MakeFemState();
+  std::unique_ptr<FemState<double>> expected_state =
+      model_.MakeFemState();
+  const int num_iterations = solver_.AdvanceOneTimeStep(*state0, state.get());
+  EXPECT_EQ(num_iterations, 1);
+
+  /* The expected result from AdvanceOneTimeStep(). */
+  Eigen::SparseMatrix<double> tangent_matrix =
+      model_.MakeEigenSparseTangentMatrix();
+  model_.CalcTangentMatrix(*state0, integrator_.weights(), &tangent_matrix);
+  VectorX<double> residual(model_.num_dofs());
+  model_.CalcResidual(*state0, &residual);
+  Eigen::ConjugateGradient<Eigen::SparseMatrix<double>> cg;
+  cg.compute(tangent_matrix);
+  const VectorX<double> dz = cg.solve(-residual);
+  integrator_.UpdateStateFromChangeInUnknowns(dz, expected_state.get());
+  EXPECT_TRUE(CompareMatrices(expected_state->GetPositions(),
+                              state->GetPositions(), kEps));
+  EXPECT_TRUE(CompareMatrices(expected_state->GetAccelerations(),
+                              state->GetAccelerations(), kEps));
+  EXPECT_TRUE(CompareMatrices(expected_state->GetVelocities(),
+                              state->GetVelocities(), kEps));
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/fem_state_test.cc
+++ b/multibody/fem/test/fem_state_test.cc
@@ -1,0 +1,150 @@
+#include "drake/multibody/fem/fem_state.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/fem/element_cache_entry.h"
+#include "drake/multibody/fem/test/dummy_element.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+using test::DummyElement;
+using test::DummyElementTraits;
+using T = DummyElementTraits::T;
+constexpr int kNumDofs = DummyElementTraits::num_dofs;
+constexpr int kNumElements = 2;
+const std::vector<ElementIndex> kElementIndices{ElementIndex(0),
+                                                ElementIndex(1)};
+const std::array<NodeIndex, DummyElementTraits::num_nodes> kNodeIndices = {
+    {NodeIndex(0), NodeIndex(1), NodeIndex(2), NodeIndex(3)}};
+const DummyElementTraits::ConstitutiveModel kConstitutiveModel(5e4, 0.4);
+const DampingModel<T> kDampingModel(0.01, 0.02);
+
+using Eigen::VectorXd;
+
+class FemStateTest : public ::testing::Test {
+ protected:
+  void SetUp() {
+    for (ElementIndex element_id : kElementIndices) {
+      elements_.emplace_back(element_id, kNodeIndices, kConstitutiveModel,
+                             kDampingModel);
+    }
+    state_.MakeElementData(elements_);
+  }
+
+  /* Default values for the state. */
+  static VectorX<double> q() {
+    Vector<double, kNumDofs> q;
+    q << 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2;
+    return q;
+  }
+  static VectorX<double> v() {
+    Vector<double, kNumDofs> v;
+    v << 1.1, 1.2, 2.3, 2.4, 2.5, 2.6, 2.7, 1.8, 1.9, 2.0, 2.1, 2.2;
+    return v;
+  }
+  static VectorX<double> a() {
+    Vector<double, kNumDofs> a;
+    a << 2.1, 2.2, 3.3, 3.4, 3.5, 2.6, 2.7, 2.8, 2.9, 3.0, 3.1, 3.2;
+    return a;
+  }
+
+  const ElementCacheEntry<DummyElement::Traits::Data>& cache_entry(
+      int i) const {
+    return state_.element_cache_[i];
+  }
+
+  /* For each cache entry,
+   1) Verify it is stale initially,
+   2) Verify calling element_data() provides the correct result, and
+   3) Verify it is not stale after the call to element_data(). */
+  void VerifyCacheEntries() const {
+    for (int i = 0; i < kNumElements; ++i) {
+      const auto& element_cache_entry = cache_entry(i);
+      EXPECT_TRUE(element_cache_entry.is_stale());
+      /* For DummyElement, the element data value is set to be the sum of the
+       last entries of all the states. */
+      EXPECT_EQ(
+          (state_.GetPositions().tail(1) + state_.GetVelocities().tail(1) +
+           state_.GetAccelerations().tail(1))(0),
+          state_.element_data(elements_[i]).value);
+      EXPECT_FALSE(element_cache_entry.is_stale());
+    }
+  }
+
+  /* FemState under test. */
+  FemStateImpl<DummyElement> state_{q(), v(), a()};
+  std::vector<DummyElement> elements_;
+};
+
+namespace {
+
+/* Verify setters and getters are working properly. */
+TEST_F(FemStateTest, GetStates) {
+  EXPECT_EQ(state_.num_dofs(), kNumDofs);
+  EXPECT_EQ(state_.GetPositions(), q());
+  EXPECT_EQ(state_.GetVelocities(), v());
+  EXPECT_EQ(state_.GetAccelerations(), a());
+}
+
+TEST_F(FemStateTest, SetStates) {
+  state_.SetPositions(-1.23 * q());
+  state_.SetVelocities(3.14 * v());
+  state_.SetAccelerations(-1.29 * a());
+  EXPECT_EQ(state_.GetPositions(), -1.23 * q());
+  EXPECT_EQ(state_.GetVelocities(), 3.14 * v());
+  EXPECT_EQ(state_.GetAccelerations(), -1.29 * a());
+  /* Setting values with incompatible sizes should throw. */
+  EXPECT_THROW(state_.SetPositions(VectorXd::Constant(1, 1.0)), std::exception);
+  EXPECT_THROW(state_.SetVelocities(VectorXd::Constant(1, 1.0)),
+               std::exception);
+  EXPECT_THROW(state_.SetAccelerations(VectorXd::Constant(1, 1.0)),
+               std::exception);
+}
+
+/* Test that element_data() retrieves the updated data. */
+TEST_F(FemStateTest, ElementData) {
+  EXPECT_EQ(state_.element_cache_size(), kNumElements);
+  for (int i = 0; i < kNumElements; ++i) {
+    EXPECT_EQ(state_.GetPositions()(kNumDofs - 1) +
+                  state_.GetVelocities()(kNumDofs - 1) +
+                  state_.GetAccelerations()(kNumDofs - 1),
+              state_.element_data(elements_[i]).value);
+  }
+}
+
+TEST_F(FemStateTest, MakeElementData) {
+  std::vector<DummyElement> invalid_ordered_elements;
+  invalid_ordered_elements.emplace_back(ElementIndex(1), kNodeIndices,
+                                        kConstitutiveModel, kDampingModel);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      state_.MakeElementData(invalid_ordered_elements),
+      "Input element entry at 0 has index 1 instead of 0. The entry with index "
+      "i must be stored at position i.");
+}
+
+/* Tests that element data cache is invalidated when the state changes and that
+ the request for the cached data triggers appropriate recalculations. */
+TEST_F(FemStateTest, ElementCache) {
+  /* Verify that cache entries are initially invalid and becomes valid after the
+   request for data triggers computation. */
+  VerifyCacheEntries();
+
+  /* Verify that state setters thrash the cache entries and the cached
+   quantities are correctly recomputed. */
+  state_.SetPositions(2 * q());
+  VerifyCacheEntries();
+  state_.SetVelocities(2 * v());
+  VerifyCacheEntries();
+  state_.SetAccelerations(2 * a());
+  VerifyCacheEntries();
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/linear_constitutive_model_test.cc
+++ b/multibody/fem/test/linear_constitutive_model_test.cc
@@ -1,0 +1,37 @@
+#include "drake/multibody/fem/linear_constitutive_model.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/multibody/fem/test/constitutive_model_test_utilities.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace test {
+
+constexpr int kNumLocations = 1;
+
+GTEST_TEST(LinearConstitutiveModelTest, Parameters) {
+  TestParameters<LinearConstitutiveModel<double, kNumLocations>>();
+  TestParameters<LinearConstitutiveModel<AutoDiffXd, kNumLocations>>();
+}
+
+GTEST_TEST(LinearConstitutiveModelTest, UndeformedState) {
+  TestUndeformedState<LinearConstitutiveModel<double, kNumLocations>>();
+  TestUndeformedState<LinearConstitutiveModel<AutoDiffXd, kNumLocations>>();
+}
+
+GTEST_TEST(LinearConstitutiveModelTest, PIsDerivativeOfPsi) {
+  TestPIsDerivativeOfPsi<LinearConstitutiveModel<AutoDiffXd, kNumLocations>>();
+}
+
+GTEST_TEST(LinearConstitutiveModelTest, dPdFIsDerivativeOfP) {
+  TestdPdFIsDerivativeOfP<LinearConstitutiveModel<AutoDiffXd, kNumLocations>>();
+}
+
+}  // namespace test
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/matrix_utilities_test.cc
+++ b/multibody/fem/test/matrix_utilities_test.cc
@@ -1,0 +1,154 @@
+#include "drake/multibody/fem/matrix_utilities.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/math/rotation_matrix.h"
+#include "drake/multibody/fem/test/test_utilities.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace {
+
+using Eigen::MatrixXd;
+
+/* Returns an arbitrary matrix for testing purpose. */
+MatrixXd MakeMatrix(int rows, int cols) {
+  MatrixXd A(rows, cols);
+  for (int i = 0; i < rows; ++i) {
+    for (int j = 0; j < cols; ++j) {
+      A(i, j) = cols * i + j;
+    }
+  }
+  return A;
+}
+
+MatrixX<AutoDiffXd> MakeAutoDiffMatrix(int rows, int cols) {
+  const MatrixXd A = MakeMatrix(rows, cols);
+  MatrixX<AutoDiffXd> A_ad(rows, cols);
+  math::InitializeAutoDiff(A, &A_ad);
+  return A_ad;
+}
+
+const double kTol = 1e-14;
+
+/* Calculates the absolute tolerance kTol scaled by the condition number of the
+ input matrix A. */
+template <typename T>
+double CalcTolerance(const Matrix3<T>& A) {
+  return test::CalcConditionNumber<T>(A) * kTol;
+}
+
+GTEST_TEST(MatrixUtilitiesTest, PolarDecompose) {
+  const Matrix3<double> A = MakeMatrix(3, 3);
+  Matrix3<double> R, S;
+  PolarDecompose<double>(A, &R, &S);
+  /* Tests reconstruction. */
+  EXPECT_TRUE(CompareMatrices(A, R * S, CalcTolerance(A)));
+  /* Tests symmetry of S. */
+  EXPECT_TRUE(CompareMatrices(S, S.transpose(), kTol));
+  /* Tests R is a rotation matrix. */
+  EXPECT_TRUE(math::RotationMatrix<double>::IsValid(R, kTol));
+}
+
+GTEST_TEST(MatrixUtilitiesTest, AddScaledRotationalDerivative) {
+  const Matrix3<AutoDiffXd> F = MakeAutoDiffMatrix(3, 3);
+  Matrix3<AutoDiffXd> R, S;
+  PolarDecompose<AutoDiffXd>(F, &R, &S);
+  Eigen::Matrix<AutoDiffXd, 9, 9> scaled_dRdF =
+      Eigen::Matrix<AutoDiffXd, 9, 9>::Zero();
+  AutoDiffXd scale = 1.23;
+  AddScaledRotationalDerivative<AutoDiffXd>(R, S, scale, &scaled_dRdF);
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      Matrix3<double> scaled_dRijdF;
+      for (int k = 0; k < 3; ++k) {
+        for (int l = 0; l < 3; ++l) {
+          scaled_dRijdF(k, l) = scaled_dRdF(3 * j + i, 3 * l + k).value();
+        }
+      }
+      EXPECT_TRUE(
+          CompareMatrices(scale * Eigen::Map<const Matrix3<double>>(
+                                      R(i, j).derivatives().data(), 3, 3),
+                          scaled_dRijdF, CalcTolerance(R)));
+    }
+  }
+}
+
+GTEST_TEST(MatrixUtilitiesTest, CalcCofactorMatrix) {
+  const Matrix3<double> A = MakeMatrix(3, 3);
+  Matrix3<double> C;
+  CalcCofactorMatrix<double>(A, &C);
+  EXPECT_TRUE(CompareMatrices(
+      A.inverse(), 1.0 / A.determinant() * C.transpose(), CalcTolerance(A)));
+}
+
+GTEST_TEST(MatrixUtilitiesTest, AddScaledCofactorMatrixDerivative) {
+  const Matrix3<AutoDiffXd> A = MakeAutoDiffMatrix(3, 3);
+  Matrix3<AutoDiffXd> C;
+  CalcCofactorMatrix<AutoDiffXd>(A, &C);
+  Eigen::Matrix<AutoDiffXd, 9, 9> scaled_dCdA =
+      Eigen::Matrix<AutoDiffXd, 9, 9>::Zero();
+  AutoDiffXd scale = 1.23;
+  AddScaledCofactorMatrixDerivative<AutoDiffXd>(A, scale, &scaled_dCdA);
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      Matrix3<double> scaled_dCijdA;
+      for (int k = 0; k < 3; ++k) {
+        for (int l = 0; l < 3; ++l) {
+          scaled_dCijdA(k, l) = scaled_dCdA(3 * j + i, 3 * l + k).value();
+        }
+      }
+      EXPECT_TRUE(
+          CompareMatrices(scale * Eigen::Map<const Matrix3<double>>(
+                                      C(i, j).derivatives().data(), 3, 3),
+                          scaled_dCijdA, CalcTolerance(A)));
+    }
+  }
+}
+
+GTEST_TEST(MatrixUtilitiesTest, PermuteBlockVector) {
+  constexpr int kNumBlocks = 3;
+  VectorX<double> v(3 * kNumBlocks);
+  v << 0, 1, 2, 3, 4, 5, 6, 7, 8;
+  const std::vector<int> block_permutation = {1, 2, 0};
+  const VectorX<double> permuted_v =
+      PermuteBlockVector<double>(v, block_permutation);
+  VectorX<double> expected_result(3 * kNumBlocks);
+  expected_result << 6, 7, 8, 0, 1, 2, 3, 4, 5;
+  EXPECT_TRUE(CompareMatrices(expected_result, permuted_v));
+}
+
+/* Verify that `PermuteBlockSparseMatrix()` provides the expected answer on a
+ 3x3 block matrix. We choose a 3x3 block test case so that the permutation is
+ neither the identity nor a self-inverse. */
+GTEST_TEST(MatrixUtilitiesTest, PermuteBlockSparseMatrix) {
+  constexpr int kNumBlocks = 3;
+  constexpr int kSize = kNumBlocks * 3;
+  const MatrixXd A = MakeMatrix(kSize, kSize);
+  const Eigen::SparseMatrix<double> A_sparse = A.sparseView();
+  const std::vector<int> block_permutation = {1, 2, 0};
+  const Eigen::SparseMatrix<double> permuted_A =
+      PermuteBlockSparseMatrix(A_sparse, block_permutation);
+  const MatrixXd permuted_A_dense = permuted_A;
+
+  MatrixXd expected_result(kSize, kSize);
+  for (int i = 0; i < kNumBlocks; ++i) {
+    for (int j = 0; j < kNumBlocks; ++j) {
+      expected_result.block<3, 3>(3 * block_permutation[i],
+                                  3 * block_permutation[j]) =
+          A.block<3, 3>(3 * i, 3 * j);
+    }
+  }
+  EXPECT_TRUE(CompareMatrices(expected_result, permuted_A_dense));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/petsc_symmetric_block_sparse_matrix_test.cc
+++ b/multibody/fem/test/petsc_symmetric_block_sparse_matrix_test.cc
@@ -1,0 +1,265 @@
+#include "drake/multibody/fem/petsc_symmetric_block_sparse_matrix.h"
+
+#include <memory>
+#include <thread>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace {
+
+using Eigen::Matrix3d;
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+using std::unique_ptr;
+using std::vector;
+
+constexpr double kEps = 2e-13;
+// Size of the matrix in this test.
+constexpr int kDofs = 9;
+
+// clang-format off
+const Matrix3d A00 =
+    (Eigen::Matrix3d() << -1, 2, 3,
+                          2, -5, 6,
+                          3, 6, -19).finished();
+const Matrix3d A11 =
+    (Eigen::Matrix3d() << 11, 12, 13,
+                          12, 15, 16,
+                          13, 16, 19).finished();
+const Matrix3d A02 =
+    (Eigen::Matrix3d() << 11, 12, 13,
+                          14, 15, 16,
+                          17, 18, 19).finished();
+const Matrix3d A22 =
+    (Eigen::Matrix3d() << 21, 22, 23,
+                          22, 25, 26,
+                          23, 26, 29).finished();
+// clang-format on
+
+/* Makes a dense matrix
+   A =   A00 |  0  | A02
+        -----------------
+          0  | A11 |  0
+        -----------------
+         A20 |  0  | A22
+where A21 = A02.transpose(). */
+MatrixXd MakeEigenDenseMatrix() {
+  MatrixXd A = MatrixXd::Zero(9, 9);
+  A.block<3, 3>(0, 0) = A00;
+  A.block<3, 3>(3, 3) = A11;
+  A.block<3, 3>(0, 6) = A02;
+  A.block<3, 3>(6, 0) = A02.transpose();
+  A.block<3, 3>(6, 6) = A22;
+  return A;
+}
+
+/* Makes a PETSc block sparse matrix
+   A =   A00 |  0  | A02
+        -----------------
+          0  | A11 |  0
+        -----------------
+         A02 |  0  | A22
+where A21 = A02.transpose(). */
+unique_ptr<PetscSymmetricBlockSparseMatrix> MakeBlockSparseMatrix() {
+  /* Number of nonzero blocks (on upper triangular portion + diagonal) per block
+   row. */
+  const vector<int> num_upper_triangular_blocks_per_row = {2, 1, 1};
+  auto A = std::make_unique<PetscSymmetricBlockSparseMatrix>(
+      9, 3, num_upper_triangular_blocks_per_row);
+  VectorX<int> block_indices;
+  MatrixXd block;
+
+  block_indices.resize(1);
+  block_indices(0) = 1;
+  block = A11;
+  A->AddToBlock(block_indices, block);
+
+  block_indices.resize(2);
+  block_indices(0) = 0;
+  block_indices(1) = 2;
+  block.resize(6, 6);
+  block.topLeftCorner<3, 3>() = A00;
+  block.topRightCorner<3, 3>() = A02;
+  block.bottomLeftCorner<3, 3>() = A02.transpose();
+  block.bottomRightCorner<3, 3>() = A22;
+  A->AddToBlock(block_indices, block);
+  return A;
+}
+
+VectorXd MakeVector9d() {
+  return (Eigen::VectorXd(9) << 1, 1, 2, 3, 5, 8, 13, 21, 34).finished();
+}
+
+/* Tests AddToBlock() and SetZero(). */
+GTEST_TEST(PetscSymmetricBlockSparseMatrixTest, Construction) {
+  unique_ptr<PetscSymmetricBlockSparseMatrix> A = MakeBlockSparseMatrix();
+  A->AssembleIfNecessary();
+  MatrixXd A_dense = A->MakeDenseMatrix();
+  const MatrixXd A_expected = MakeEigenDenseMatrix();
+  EXPECT_TRUE(CompareMatrices(A_dense, A_expected, kEps));
+  A->SetZero();
+  A_dense = A->MakeDenseMatrix();
+  EXPECT_EQ(A_dense, MatrixXd::Zero(9, 9));
+}
+
+/* Verifies that SetZero() can be called without any calls to AddToBlock(). */
+GTEST_TEST(PetscSymmetricBlockSparseMatrixTest, SetZero) {
+  PetscSymmetricBlockSparseMatrix A(3, 3, {1});
+  A.SetZero();
+  MatrixXd A_dense = A.MakeDenseMatrix();
+  EXPECT_EQ(A_dense, Matrix3d::Zero());
+}
+
+GTEST_TEST(PetscSymmetricBlockSparseMatrixTest, Solve) {
+  unique_ptr<PetscSymmetricBlockSparseMatrix> A = MakeBlockSparseMatrix();
+  const MatrixXd A_eigen = MakeEigenDenseMatrix();
+  const VectorXd b = MakeVector9d();
+  const VectorXd x_expected = A_eigen.lu().solve(b);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      A->Solve(PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
+               PetscSymmetricBlockSparseMatrix::PreconditionerType::kJacobi, b),
+      std::exception,
+      "PetscSymmetricBlockSparseMatrix::Solve.*: matrix is not yet "
+      "assembled.*");
+  A->AssembleIfNecessary();
+  const VectorXd x =
+      A->Solve(PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
+               PetscSymmetricBlockSparseMatrix::PreconditionerType::kJacobi, b);
+  VectorXd x_in_place = b;
+  A->SolveInPlace(PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
+                  PetscSymmetricBlockSparseMatrix::PreconditionerType::kJacobi,
+                  &x_in_place);
+  EXPECT_EQ(x, x_in_place);
+}
+
+GTEST_TEST(PetscSymmetricBlockSparseMatrixTest, ZeroRowsAndColumns) {
+  unique_ptr<PetscSymmetricBlockSparseMatrix> A = MakeBlockSparseMatrix();
+  const vector<int> indexes = {1, 2, 5};
+  constexpr double kDiagnoalValue = 3;
+  A->ZeroRowsAndColumns(indexes, kDiagnoalValue);
+  MatrixXd A_eigen = MakeEigenDenseMatrix();
+  for (int i : indexes) {
+    A_eigen.row(i).setZero();
+    A_eigen.col(i).setZero();
+    A_eigen(i, i) = kDiagnoalValue;
+  }
+  EXPECT_EQ(A->MakeDenseMatrix(), A_eigen);
+}
+
+GTEST_TEST(PetscSymmetricBlockSparseMatrixTest, Clone) {
+  unique_ptr<PetscSymmetricBlockSparseMatrix> A = MakeBlockSparseMatrix();
+  DRAKE_EXPECT_THROWS_MESSAGE(A->Clone(),
+                              "PetscSymmetricBlockSparseMatrix::Clone.*: "
+                              "matrix is not yet assembled.*");
+  A->AssembleIfNecessary();
+  unique_ptr<PetscSymmetricBlockSparseMatrix> A_clone = A->Clone();
+  EXPECT_EQ(A->MakeDenseMatrix(), A_clone->MakeDenseMatrix());
+  const VectorXd b = MakeVector9d();
+  const VectorXd x =
+      A->Solve(PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
+               PetscSymmetricBlockSparseMatrix::PreconditionerType::kJacobi, b);
+  const VectorXd x_clone = A_clone->Solve(
+      PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
+      PetscSymmetricBlockSparseMatrix::PreconditionerType::kJacobi, b);
+  EXPECT_TRUE(CompareMatrices(x, x_clone, kEps));
+}
+
+/* Test if we can run several PETSc solves simultaneously on multiple threads.
+ We solve the same linear system with multiple right hand sides. The solution
+ from using threads should be the same as those from serial. */
+GTEST_TEST(PetscSymmetricBlockSparseMatrixTest, MultiThreadTest) {
+  /* We first will solve each linear system one at a time, and then solve them
+   all in parallel. The two sets of results should match. */
+  constexpr int kNumThreads = 100;
+
+  std::vector<VectorXd> single_threaded_results(kNumThreads);
+  std::vector<VectorXd> multi_threaded_results(kNumThreads);
+
+  /* Create a functor that solves A*x = b. */
+  auto run_solver = [](const VectorXd& b, VectorXd* x) {
+    unique_ptr<PetscSymmetricBlockSparseMatrix> A = MakeBlockSparseMatrix();
+    A->AssembleIfNecessary();
+    *x = A->Solve(PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
+                  PetscSymmetricBlockSparseMatrix::PreconditionerType::kJacobi,
+                  b);
+  };
+
+  /* Solve without using threads. */
+  for (int i = 0; i < kNumThreads; ++i) {
+    VectorXd b = VectorXd::Zero(kDofs);
+    // Set b to a nonzero vector for a nontrivial solve.
+    const int nonzero_entry = i % kDofs;
+    b(nonzero_entry) = 1.0;
+    run_solver(b, &single_threaded_results[i]);
+  }
+
+  /* Solve using threads. */
+  std::vector<std::thread> test_threads;
+  for (int i = 0; i < kNumThreads; ++i) {
+    VectorXd b = VectorXd::Zero(kDofs);
+    // Set b to a nonzero vector for a nontrivial solve.
+    const int nonzero_entry = i % kDofs;
+    b(nonzero_entry) = 1.0;
+    test_threads.emplace_back(run_solver, b, &multi_threaded_results[i]);
+  }
+  for (int i = 0; i < kNumThreads; ++i) {
+    test_threads[i].join();
+  }
+
+  /* All solutions should be the same. */
+  for (int i = 0; i < kNumThreads; ++i) {
+    EXPECT_EQ(single_threaded_results[i], multi_threaded_results[i]);
+  }
+}
+
+GTEST_TEST(PetscSymmetricBlockSparseMatrixTest, CalcSchurComplement) {
+  unique_ptr<PetscSymmetricBlockSparseMatrix> M = MakeBlockSparseMatrix();
+  const vector<int> D_block_indexes = {1};
+  const vector<int> A_block_indexes = {0, 2};
+  const MatrixXd M_eigen = MakeEigenDenseMatrix();
+
+  MatrixXd A = MatrixXd::Zero(6, 6);
+  A.topLeftCorner<3, 3>() = M_eigen.topLeftCorner<3, 3>();
+  A.topRightCorner<3, 3>() = M_eigen.topRightCorner<3, 3>();
+  A.bottomLeftCorner<3, 3>() = M_eigen.bottomLeftCorner<3, 3>();
+  A.bottomRightCorner<3, 3>() = M_eigen.bottomRightCorner<3, 3>();
+
+  MatrixXd D = M_eigen.block<3, 3>(3, 3);
+
+  MatrixXd B = MatrixXd::Zero(6, 3);
+  B.topLeftCorner<3, 3>() = M_eigen.block<3, 3>(3, 0);
+  B.bottomLeftCorner<3, 3>() = M_eigen.block<3, 3>(3, 6);
+
+  const SchurComplement schur_complement =
+      M->CalcSchurComplement(D_block_indexes, A_block_indexes);
+  const MatrixXd schur_complement_matrix = schur_complement.get_D_complement();
+
+  const MatrixXd expected_schur_complement =
+      A - B * D.lu().solve(B.transpose());
+  EXPECT_TRUE(CompareMatrices(schur_complement_matrix,
+                              expected_schur_complement, kEps));
+
+  /* Set arbitrary solution for x in the system
+    Ax + By  =  a
+    Bᵀx + Dy =  0
+   Verify that y is solved to be -D⁻¹Bᵀx. */
+  VectorXd x(6);
+  x << 1, 2, 3, 4, 5, 6;
+  const VectorXd y = schur_complement.SolveForY(x);
+  VectorXd expected_y = -1.0 * D.lu().solve(B.transpose()) * x;
+  EXPECT_TRUE(CompareMatrices(y, expected_y, kEps));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/schur_complement_test.cc
+++ b/multibody/fem/test/schur_complement_test.cc
@@ -1,0 +1,97 @@
+#include "drake/multibody/fem/schur_complement.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace {
+
+using Eigen::Matrix2d;
+using Eigen::MatrixXd;
+using Eigen::Vector2d;
+using Eigen::VectorXd;
+/* Verify that SchurComplement provides the same answer as hand-calculated
+solution on a small problem. */
+GTEST_TEST(SchurComplementTest, AnalyticTest) {
+  Matrix2d A, B, D;
+  // clang-format off
+  A << 3, 0,
+       0, 2;
+  B << 1, 1,
+      -1, 0;
+  D << 4, 1,
+       1, 4;
+  // clang-format on
+  /* The matrix M is given by
+     3 0  | 1  1
+     0 2  | -1 0
+     -----------
+     1 -1 | 4  1
+     1 0  | 1  4
+  It is clearly symmetric and diagonally dominant and thus positive definite.
+  The Schur complement for the bottom right block is given by
+  A - BD⁻¹Bᵀ, which is equal to [13/5, 1/5; 1/5, 26/15] after simple
+  calculation. */
+  const SchurComplement<double> s(A.sparseView(), B.transpose().sparseView(),
+                                  D.sparseView());
+  Matrix2d expected_D_complement;
+  // clang-format off
+  expected_D_complement << 13./5., 1./5.,
+                           1./5., 26./15.;
+  // clang-format on
+  EXPECT_TRUE(CompareMatrices(s.get_D_complement(), expected_D_complement,
+                              std::numeric_limits<double>::epsilon()));
+
+  /* Verify that y = -D⁻¹Bᵀx. */
+  const Vector2d x(1, 2);
+  const Vector2d expected_y(1. / 3., -1. / 3.);
+  EXPECT_TRUE(CompareMatrices(s.SolveForY(x), expected_y,
+                              std::numeric_limits<double>::epsilon()));
+}
+
+/* Verify that when M = D, the Schur complement is a zero-sized matrix and the
+ solution to the y variable is zero. */
+GTEST_TEST(SchurComplementTest, MisD) {
+  const MatrixXd A(0, 0);
+  const MatrixXd B(0, 2);
+  Matrix2d D;
+  // clang-format off
+  D << 4, 1,
+       1, 4;
+  // clang-format on
+  const SchurComplement<double> s(A.sparseView(), B.transpose().sparseView(),
+                                  D.sparseView());
+  EXPECT_EQ(s.get_D_complement().rows(), 0);
+  EXPECT_EQ(s.get_D_complement().cols(), 0);
+  /* Verify that y = 0. */
+  const VectorXd x(0);
+  EXPECT_TRUE(CompareMatrices(s.SolveForY(x), Vector2d::Zero()));
+}
+
+/* Verify that when M = A, the Schur complement is equal to A. */
+GTEST_TEST(SchurComplementTest, MisA) {
+  Matrix2d A;
+  // clang-format off
+  A << 4, 1,
+       1, 4;
+  // clang-format on
+  const MatrixXd B(2, 0);
+  const MatrixXd D(0, 0);
+  const SchurComplement<double> s(A.sparseView(), B.transpose().sparseView(),
+                                  D.sparseView());
+  EXPECT_TRUE(CompareMatrices(s.get_D_complement(), A));
+  /* Verify that the y variable is empty. */
+  const VectorXd expected_y(0);
+  const Vector2d x(1, 2);
+  EXPECT_TRUE(CompareMatrices(s.SolveForY(x), expected_y));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/stretch_test.cc
+++ b/multibody/fem/test/stretch_test.cc
@@ -1,0 +1,154 @@
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity/make_box_mesh.h"
+#include "drake/multibody/fem/acceleration_newmark_scheme.h"
+#include "drake/multibody/fem/fem_solver.h"
+#include "drake/multibody/fem/linear_constitutive_model.h"
+#include "drake/multibody/fem/linear_simplex_element.h"
+#include "drake/multibody/fem/mesh_utilities.h"
+#include "drake/multibody/fem/simplex_gaussian_quadrature.h"
+#include "drake/multibody/fem/volumetric_element.h"
+#include "drake/multibody/fem/volumetric_model.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace {
+
+constexpr int kNaturalDimension = 3;
+constexpr int kSpatialDimension = 3;
+constexpr int kQuadratureOrder = 1;
+using T = double;
+using QuadratureType =
+    internal::SimplexGaussianQuadrature<kNaturalDimension, kQuadratureOrder>;
+constexpr int kNumQuads = QuadratureType::num_quadrature_points;
+using IsoparametricElementType =
+    internal::LinearSimplexElement<T, kNaturalDimension, kSpatialDimension,
+                                   kNumQuads>;
+using ConstitutiveModelType = internal::LinearConstitutiveModel<T, kNumQuads>;
+using ElementType = VolumetricElement<IsoparametricElementType, QuadratureType,
+                                      ConstitutiveModelType>;
+using ModelType = VolumetricModel<ElementType>;
+using geometry::VolumeMesh;
+
+const double kYoungsModulus = 1e7;  // Unit Pa.
+const double kPoissonRatio = 0.45;
+const double kDensity = 1e3;  // Unit kg/m^3.
+const double kTol = 1e-14;
+/* Side length of the bar with unit m. */
+const double kLx = 1;
+const double kLy = 4;
+const double kLz = 2;
+/* Resolution hint for meshing the box. */
+const double kDx = 0.5;
+
+const double kStretchFactor = 3.45;
+const double kEpsilon = kStretchFactor - 1;
+
+/* Parameters for the Newmark-beta integration scheme. */
+constexpr double kDt = 0.01;
+constexpr double kGamma = 0.5;
+constexpr double kBeta = 0.25;
+
+class StretchTest : public ::testing::Test {
+ protected:
+  /* Make a box with size kLx * kLy * kLz as in the accompanying analytical
+   solution document in doc/stretch_bar_test.tex and subdivide it into a
+   tetrahedral mesh. */
+  static VolumeMesh<T> MakeBoxTetMesh() {
+    geometry::Box box(kLx, kLy, kLz);
+    return MakeDiamondCubicBoxVolumeMesh<T>(box, kDx);
+  }
+
+  void SetUp() override {
+    /* Set up model. */
+    const ConstitutiveModelType constitutive_model(kYoungsModulus,
+                                                   kPoissonRatio);
+    const DampingModel<T> damping_model(0.01, 0.02);
+    const VolumeMesh<T> mesh = MakeBoxTetMesh();
+    model_.AddVolumetricElementsFromTetMesh(mesh, constitutive_model, kDensity,
+                                            damping_model);
+    model_.SetGravityVector({0, 0, 0});
+    const std::unique_ptr<FemState<T>> state = model_.MakeFemState();
+    model_.SetDirichletBoundaryCondition(MakeStretchBc(state->GetPositions()));
+  }
+
+  /* Given the rest positions, creates a Dirichlet boundary condition that
+   stretches the two ends of the bar in the y-direction by a factor of
+   kStretchFactor. */
+  DirichletBoundaryCondition<T> MakeStretchBc(const VectorX<T>& q) {
+    DirichletBoundaryCondition<T> bc;
+    const int num_dofs = q.size();
+    for (int node = 0; node < num_dofs / kSpatialDimension; ++node) {
+      const int x_dof_index = kSpatialDimension * node;
+      const int y_dof_index = kSpatialDimension * node + 1;
+      const int z_dof_index = kSpatialDimension * node + 2;
+      /* No translation in the x=0 plane. */
+      if (std::abs(q(x_dof_index)) <= kTol) {
+        bc.AddBoundaryCondition(x_dof_index,
+                                Vector3<T>(q(x_dof_index), 0.0, 0.0));
+      }
+      /* Stretch the two ends of the bar in y-direction. */
+      if (std::abs(std::abs(q(y_dof_index)) - std::abs(kLy / 2)) <= kTol) {
+        bc.AddBoundaryCondition(
+            y_dof_index, Vector3<T>(kStretchFactor * q(y_dof_index), 0.0, 0.0));
+      }
+      /* No translation in the z=0 plane. */
+      if (std::abs(q(z_dof_index)) <= kTol) {
+        bc.AddBoundaryCondition(z_dof_index,
+                                Vector3<T>(q(z_dof_index), 0.0, 0.0));
+      }
+    }
+    return bc;
+  }
+
+  ModelType model_;
+  AccelerationNewmarkScheme<T> integrator_{kDt, kGamma, kBeta};
+  /* The solver under test. */
+  FemSolver<T> solver_{&model_, &integrator_};
+};
+
+/* Tests that FEM solution matches the analytical solution provided in
+ doc/stretch_bar_test.pdf. */
+TEST_F(StretchTest, Stretch) {
+  std::unique_ptr<FemState<T>> state0 = model_.MakeFemState();
+  std::unique_ptr<FemState<T>> state = model_.MakeFemState();
+  const auto initial_positions = Eigen::Map<const Matrix3X<T>>(
+      state0->GetPositions().data(), 3, model_.num_nodes());
+  VectorX<T> expected_positions(state->num_dofs());
+  auto expected_positions_matrix =
+      Eigen::Map<Matrix3X<T>>(expected_positions.data(), 3, model_.num_nodes());
+  /* According to the pen and paper calculation, we should expect u₁ =
+   -νx * kEpsilon, u₂ = y * kEpsilon, and u₃ = -νz * kEpsilon. */
+  /* The displacement in x,y,z direction. */
+  expected_positions_matrix.row(0) =
+      initial_positions.row(0) * (1.0 - kPoissonRatio * kEpsilon);
+  expected_positions_matrix.row(1) =
+      initial_positions.row(1) * (1.0 + kEpsilon);
+  expected_positions_matrix.row(2) =
+      initial_positions.row(2) * (1.0 - kPoissonRatio * kEpsilon);
+  const VectorX<T> expected_velocities = VectorX<T>::Zero(state->num_dofs());
+  const VectorX<T> expected_accelerations = VectorX<T>::Zero(state->num_dofs());
+  state0->SetPositions(expected_positions);
+  state0->SetVelocities(expected_velocities);
+  state0->SetAccelerations(expected_accelerations);
+
+  /* Verify that state0 is already the equilibrium state. */
+  for (int i = 0; i < 100; ++i) {
+    solver_.AdvanceOneTimeStep(*state0, state.get());
+    *state0 = *state;
+  }
+  EXPECT_TRUE(CompareMatrices(state->GetPositions(), expected_positions, kTol));
+  EXPECT_TRUE(
+      CompareMatrices(state->GetVelocities(), expected_velocities, kTol / kDt));
+  EXPECT_TRUE(CompareMatrices(state->GetAccelerations(), expected_accelerations,
+                              kTol / (kDt * kDt)));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/test_utilities.cc
+++ b/multibody/fem/test/test_utilities.cc
@@ -1,0 +1,34 @@
+#include "drake/multibody/fem/test/test_utilities.h"
+
+#include <algorithm>
+#include <limits>
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace test {
+
+template <typename T>
+double CalcConditionNumber(const Eigen::Ref<const MatrixX<T>>& A) {
+  Eigen::JacobiSVD<MatrixX<T>> svd(A);
+  /* Eigen::JacobiSVD::singularValues() returns sigma as positive, monotonically
+   decreasing values.
+   See https://eigen.tuxfamily.org/dox/classEigen_1_1JacobiSVD.html. */
+  const VectorX<T>& sigma = svd.singularValues();
+  /* Prevents division by zero for singular matrix. */
+  const T& sigma_min = sigma(sigma.size() - 1);
+  DRAKE_DEMAND(sigma_min > 0);
+  const T& sigma_max = sigma(0);
+  const T cond = sigma_max / sigma_min;
+  return ExtractDoubleOrThrow(cond);
+}
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    (&CalcConditionNumber<T>))
+
+}  // namespace test
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/test_utilities.h
+++ b/multibody/fem/test/test_utilities.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace test {
+
+/* Calculates the condition number for the given matrix A.
+ The condition number is calculated via
+     k(A) = σₘₐₓ / σₘᵢₙ
+ where σₘₐₓ and σₘᵢₙ are the largest and smallest singular values (in magnitude)
+ of A.
+ @pre A is invertible.
+ @tparam_nonsymbolic_scalar. */
+template <typename T>
+double CalcConditionNumber(const Eigen::Ref<const MatrixX<T>>& A);
+
+}  // namespace test
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/velocity_newmark_scheme_test.cc
+++ b/multibody/fem/test/velocity_newmark_scheme_test.cc
@@ -1,0 +1,113 @@
+#include "drake/multibody/fem/velocity_newmark_scheme.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/multibody/fem/acceleration_newmark_scheme.h"
+#include "drake/multibody/fem/test/dummy_element.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace {
+
+using Eigen::Vector4d;
+using test::DummyElement;
+
+const double kDt = 1e-3;
+const double kGamma = 0.6;
+const double kBeta = 0.3;
+const double kTolerance = 8.0 * std::numeric_limits<double>::epsilon();
+
+Vector4<double> MakeQ() { return Vector4<double>(1.23, 2.34, 3.45, 4.56); }
+Vector4<double> MakeQdot() { return Vector4<double>(5.67, 6.78, 7.89, 9.10); }
+Vector4<double> MakeQddot() {
+  return Vector4<double>(0.1011, 0.1112, 0.1213, 0.1314);
+}
+
+/* Verify that the weights returned by the accessor match expectation. */
+GTEST_TEST(VelocityNewmarkSchemeTest, Weights) {
+  VelocityNewmarkScheme<double> scheme{kDt, kGamma, kBeta};
+  EXPECT_TRUE(CompareMatrices(
+      scheme.weights(),
+      Vector3<double>(kBeta / kGamma * kDt, 1.0, 1.0 / (kGamma * kDt))));
+}
+
+/* Verify that the result of
+ `VelocityNewmarkScheme::UpdateStateFromChangeInUnknowns()` is consistent with
+ the weights. */
+GTEST_TEST(VelocityNewmarkSchemeTest, UpdateStateFromChangeInUnknowns) {
+  VelocityNewmarkScheme<double> scheme{kDt, kGamma, kBeta};
+  FemStateImpl<DummyElement> state0(MakeQ(), MakeQdot(), MakeQddot());
+  FemStateImpl<DummyElement> state(state0);
+  const Vector4<double> dz(1.234, 4.567, 7.890, 0.123);
+  const Vector3<double>& weights = scheme.weights();
+  scheme.UpdateStateFromChangeInUnknowns(dz, &state);
+  EXPECT_TRUE(CompareMatrices(state.GetPositions() - state0.GetPositions(),
+                              weights(0) * dz, kTolerance));
+  EXPECT_TRUE(CompareMatrices(state.GetVelocities() - state0.GetVelocities(),
+                              weights(1) * dz, kTolerance));
+  EXPECT_TRUE(
+      CompareMatrices(state.GetAccelerations() - state0.GetAccelerations(),
+                      weights(2) * dz, kTolerance / kDt));
+}
+
+/* Tests that VelocityNewmarkScheme reproduces analytical solutions with
+ constant acceleration and linear velocity. */
+GTEST_TEST(VelocityNewmarkSchemeTest, AdvanceOneTimeStep) {
+  VelocityNewmarkScheme<double> scheme{kDt, kGamma, kBeta};
+  const Vector4d q = MakeQ();
+  Vector4d qdot = MakeQdot();
+  const Vector4d qddot = MakeQddot();
+  const FemStateImpl<DummyElement> state_0(q, qdot, qddot);
+  FemStateImpl<DummyElement> state_n(state_0);
+  FemStateImpl<DummyElement> state_np1(state_0);
+  const int kTimeSteps = 10;
+  for (int i = 0; i < kTimeSteps; ++i) {
+    qdot += kDt * qddot;
+    scheme.AdvanceOneTimeStep(state_n, qdot, &state_np1);
+    state_n = state_np1;
+  }
+  const double total_time = kDt * kTimeSteps;
+  EXPECT_TRUE(CompareMatrices(state_n.GetAccelerations(),
+                              state_0.GetAccelerations(),
+                              kTolerance * kTimeSteps / kDt));
+  EXPECT_TRUE(CompareMatrices(
+      state_n.GetVelocities(),
+      state_0.GetVelocities() + total_time * state_0.GetAccelerations(),
+      kTimeSteps * kTolerance));
+  EXPECT_TRUE(CompareMatrices(
+      state_n.GetPositions(),
+      state_0.GetPositions() + total_time * state_0.GetVelocities() +
+          0.5 * total_time * total_time * state_0.GetAccelerations(),
+      kTimeSteps * kTolerance));
+}
+
+/* Tests that `VelocityNewmarkScheme` is equivalent with
+ `AccelerationNewmarkScheme` by advancing one time step with each integration
+ scheme using the same initial state and verifying that the resulting new states
+ are the same. */
+GTEST_TEST(VelocityNewmarkSchemeTest, EquivalenceWithAccelerationNewmark) {
+  VelocityNewmarkScheme<double> velocity_scheme{kDt, kGamma, kBeta};
+  FemStateImpl<DummyElement> state0(MakeQ(), MakeQdot(), MakeQddot());
+  FemStateImpl<DummyElement> state_v(state0);
+  velocity_scheme.AdvanceOneTimeStep(state0, MakeQdot(), &state_v);
+
+  AccelerationNewmarkScheme<double> acceleration_scheme{kDt, kGamma, kBeta};
+  FemStateImpl<DummyElement> state_a(state0);
+  acceleration_scheme.AdvanceOneTimeStep(state0, state_v.GetAccelerations(),
+                                         &state_a);
+  EXPECT_TRUE(CompareMatrices(state_v.GetAccelerations(),
+                              state_a.GetAccelerations(), kTolerance));
+  EXPECT_TRUE(CompareMatrices(state_v.GetVelocities(), state_a.GetVelocities(),
+                              kTolerance));
+  EXPECT_TRUE(CompareMatrices(state_v.GetPositions(), state_a.GetPositions(),
+                              kTolerance));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/volumetric_element_test.cc
+++ b/multibody/fem/test/volumetric_element_test.cc
@@ -1,0 +1,328 @@
+#include "drake/multibody/fem/volumetric_element.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/roll_pitch_yaw.h"
+#include "drake/multibody/fem/corotated_model.h"
+#include "drake/multibody/fem/fem_state.h"
+#include "drake/multibody/fem/linear_simplex_element.h"
+#include "drake/multibody/fem/simplex_gaussian_quadrature.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+constexpr int kNaturalDimension = 3;
+constexpr int kSpatialDimension = 3;
+constexpr int kQuadratureOrder = 1;
+constexpr double kEpsilon = 1e-14;
+const ElementIndex kZeroIndex(0);
+using T = AutoDiffXd;
+using QuadratureType =
+    internal::SimplexGaussianQuadrature<kNaturalDimension, kQuadratureOrder>;
+static constexpr int kNumQuads = QuadratureType::num_quadrature_points;
+using IsoparametricElementType =
+    internal::LinearSimplexElement<T, kNaturalDimension, kSpatialDimension,
+                                   kNumQuads>;
+using ConstitutiveModelType = CorotatedModel<T, kNumQuads>;
+using DeformationGradientDataType = CorotatedModelData<T, kNumQuads>;
+
+class VolumetricElementTest : public ::testing::Test {
+ protected:
+  using ElementType = VolumetricElement<IsoparametricElementType,
+                                        QuadratureType, ConstitutiveModelType>;
+  static constexpr int kNumDofs = ElementType::num_dofs;
+  static constexpr int kNumNodes = ElementType::num_nodes;
+  const std::array<NodeIndex, kNumNodes> kNodeIndices = {
+      {NodeIndex(0), NodeIndex(1), NodeIndex(2), NodeIndex(3)}};
+  const T kYoungsModulus{1};
+  const T kPoissonRatio{0.25};
+  const T kDensity{1.23};
+  const T kMassDamping{1e-4};
+  const T kStiffnessDamping{1e-3};
+
+  void SetUp() override { SetupElement(); }
+
+  void SetupElement() {
+    Eigen::Matrix<T, kSpatialDimension, kNumNodes> X = reference_positions();
+    ConstitutiveModelType constitutive_model(kYoungsModulus, kPoissonRatio);
+    DampingModel<T> damping_model(0, 0);
+    elements_.emplace_back(kZeroIndex, kNodeIndices, constitutive_model, X,
+                           kDensity, damping_model);
+  }
+
+  /* Set up a state so that the element is deformed. */
+  FemStateImpl<ElementType> SetupDeformedState() {
+    Vector<double, kNumDofs> perturbation;
+    perturbation << 0.18, 0.63, 0.54, 0.13, 0.92, 0.17, 0.03, 0.86, 0.85, 0.25,
+        0.53, 0.67;
+    Eigen::Matrix<T, kSpatialDimension, kNumNodes> X = reference_positions();
+    Vector<double, kNumDofs> x =
+        Eigen::Map<Vector<double, kNumDofs>>(math::DiscardGradient(X).data(),
+                                             reference_positions().size()) +
+        perturbation;
+    Vector<T, kNumDofs> x_autodiff;
+    math::InitializeAutoDiff(x, &x_autodiff);
+    /* Set up arbitrary velocity and acceleration. */
+    const Vector<T, kNumDofs> v_autodiff = -1.23 * perturbation;
+    const Vector<T, kNumDofs> a_autodiff = 4.56 * perturbation;
+    FemStateImpl<ElementType> state(x_autodiff, v_autodiff, a_autodiff);
+    state.MakeElementData(elements_);
+    return state;
+  }
+
+  /* Set up a state where the positions are the same as reference positions. */
+  FemStateImpl<ElementType> SetupInitialState() {
+    Eigen::Matrix<T, kSpatialDimension, kNumNodes> X = reference_positions();
+    Vector<double, kNumDofs> x(Eigen::Map<Vector<double, kNumDofs>>(
+        math::DiscardGradient(X).data(), reference_positions().size()));
+    Vector<T, kNumDofs> x_autodiff;
+    math::InitializeAutoDiff(x, &x_autodiff);
+    const Vector<T, kNumDofs> v_autodiff = Vector<T, kNumDofs>::Zero();
+    const Vector<T, kNumDofs> a_autodiff = Vector<T, kNumDofs>::Zero();
+    FemStateImpl<ElementType> state(x_autodiff, v_autodiff, a_autodiff);
+    state.MakeElementData(elements_);
+    return state;
+  }
+
+  /* Set arbitrary reference positions with the requirement that the tetrahedron
+   is not inverted. */
+  Eigen::Matrix<T, kSpatialDimension, kNumNodes> reference_positions() const {
+    Eigen::Matrix<T, kSpatialDimension, kNumNodes> X(kSpatialDimension,
+                                                     kNumNodes);
+    // clang-format off
+    X << -0.10, 0.90, 0.02, 0.10,
+         1.33,  0.23, 0.04, 0.01,
+         0.20,  0.03, 2.31, -0.12;
+    // clang-format on
+    return X;
+  }
+
+  /* Get the one and only element. */
+  const ElementType& element() const {
+    DRAKE_DEMAND(elements_.size() == 1);
+    return elements_[0];
+  }
+
+  /* Calculates the negative elastic force acting on the nodes of the only
+   element evaluated at the given `state`. */
+  Vector<T, kNumDofs> CalcNegativeElasticForce(
+      const FemStateImpl<ElementType>& state) const {
+    Vector<T, kNumDofs> neg_force = Vector<T, kNumDofs>::Zero();
+    element().AddNegativeElasticForce(state, &neg_force);
+    return neg_force;
+  }
+
+  /* Calculates the negative elastic force derivative with respect to positions
+   for the only element evaluated at the given `state`. */
+  Eigen::Matrix<T, kNumDofs, kNumDofs> CalcNegativeElasticForceDerivative(
+      const FemStateImpl<ElementType>& state) const {
+    Eigen::Matrix<T, kNumDofs, kNumDofs> neg_force_derivative =
+        Eigen::Matrix<T, kNumDofs, kNumDofs>::Zero();
+    element().AddScaledElasticForceDerivative(state, -1, &neg_force_derivative);
+    return neg_force_derivative;
+  }
+
+  /* Calculates the DeformationGradientData for the only element evaluated at
+   the given `state`. */
+  DeformationGradientDataType CalcDeformationGradientData(
+      const FemStateImpl<ElementType>& state) const {
+    const std::array<Matrix3<T>, kNumQuads> F =
+        element().CalcDeformationGradient(state);
+    DeformationGradientDataType deformation_gradient_data;
+    deformation_gradient_data.UpdateData(F);
+    return deformation_gradient_data;
+  }
+
+  /* Calculates and verifies the energy and elastic forces evaluated at the
+   given `state` are zero. */
+  void VerifyEnergyAndForceAreZero(
+      const FemStateImpl<ElementType>& state) const {
+    T energy = element().CalcElasticEnergy(state);
+    EXPECT_NEAR(energy.value(), 0, std::numeric_limits<double>::epsilon());
+    Vector<T, kNumDofs> neg_elastic_force = CalcNegativeElasticForce(state);
+    EXPECT_TRUE(CompareMatrices(Vector<T, kNumDofs>::Zero(), neg_elastic_force,
+                                std::numeric_limits<double>::epsilon()));
+  }
+
+  /* Returns the constitutive model of the only element. */
+  const ConstitutiveModelType& constitutive_model() const {
+    return element().constitutive_model();
+  }
+
+  /* Returns the density of the only element. */
+  const T& density(const ElementType& e) const { return e.density_; }
+
+  /* Returns the volume evaluated at each quadrature point in the reference
+   configuration of the only element. */
+  const std::array<T, kNumQuads>& reference_volume() const {
+    return element().reference_volume_;
+  }
+
+  /* Returns the mass matrix of the only element. */
+  const Eigen::Matrix<T, kNumDofs, kNumDofs>& get_mass_matrix() const {
+    return element().mass_matrix_;
+  }
+
+  /* Returns the gravity force acting on the nodes of the only element at
+   the given `state`. */
+  Vector<T, kNumDofs> CalcGravityForce(
+      const FemStateImpl<ElementType>& state) const {
+    Vector<T, kNumDofs> gravity_force = Vector<T, kNumDofs>::Zero();
+    element().AddScaledGravityForce(state, 1.0, &gravity_force);
+    return gravity_force;
+  }
+
+  std::vector<ElementType> elements_;
+};
+
+namespace {
+
+TEST_F(VolumetricElementTest, Constructor) {
+  EXPECT_EQ(element().node_indices(), kNodeIndices);
+  EXPECT_EQ(element().element_index(), kZeroIndex);
+  EXPECT_EQ(density(element()), kDensity);
+  ElementType move_constructed_element(std::move(elements_[0]));
+  EXPECT_EQ(move_constructed_element.node_indices(), kNodeIndices);
+  EXPECT_EQ(move_constructed_element.element_index(), kZeroIndex);
+  EXPECT_EQ(density(move_constructed_element), kDensity);
+}
+
+/* Any undeformed state gives zero energy and zero force. */
+TEST_F(VolumetricElementTest, UndeformedState) {
+  /* The initial state where the current position is equal to reference
+   position is undeformed. */
+  FemStateImpl<ElementType> state = SetupInitialState();
+  VerifyEnergyAndForceAreZero(state);
+
+  /* Any rigid transformation of a undeformed state is undeformed. */
+  math::RigidTransform<T> transform(math::RollPitchYaw<T>(1, 2, 3),
+                                    Vector3<T>(0.314, 0.159, 0.265));
+  Eigen::Matrix<T, kSpatialDimension, kNumNodes> X = reference_positions();
+  Eigen::Matrix<T, kSpatialDimension, kNumNodes> rigid_transformed_X;
+  for (int i = 0; i < kNumNodes; ++i) {
+    rigid_transformed_X.col(i) = transform * X.col(i);
+  }
+  state.SetPositions(Eigen::Map<Vector<T, kNumDofs>>(
+      rigid_transformed_X.data(), rigid_transformed_X.size()));
+  VerifyEnergyAndForceAreZero(state);
+}
+
+/* Tests that in a deformed state, the energy and forces agrees with
+ hand-calculated results. */
+TEST_F(VolumetricElementTest, DeformedState) {
+  FemStateImpl<ElementType> state = SetupInitialState();
+  /* Deform the element by scaling the initial position by a factor of 2. */
+  state.SetPositions(state.GetPositions() * 2.0);
+  const auto deformation_gradient_data = CalcDeformationGradientData(state);
+  std::array<T, kNumQuads> energy_density_array;
+  constitutive_model().CalcElasticEnergyDensity(deformation_gradient_data,
+                                                &energy_density_array);
+  const double energy_density = ExtractDoubleOrThrow(energy_density_array[0]);
+  /* Set up a matrix to help with calculating volume of the element. */
+  Matrix4<double> matrix_for_volume_calculation;
+  matrix_for_volume_calculation.bottomRows<1>() = Vector4<double>::Ones();
+  const auto X = reference_positions();
+  const auto X_double = math::DiscardGradient(X);
+  matrix_for_volume_calculation.topRows<3>() = X_double;
+  const double reference_volume =
+      1.0 / 6.0 * std::abs(matrix_for_volume_calculation.determinant());
+  const double analytical_energy = energy_density * reference_volume;
+  /* Verify calculated energy is close to energy calculated analytically. */
+  EXPECT_NEAR(element().CalcElasticEnergy(state).value(), analytical_energy,
+              kEpsilon);
+
+  const auto neg_elastic_force_autodiff = CalcNegativeElasticForce(state);
+  Vector<double, kNumDofs> neg_elastic_force =
+      math::DiscardGradient(neg_elastic_force_autodiff);
+  /* Force on node 0. */
+  const Vector3<double> force0 = -neg_elastic_force.head<3>();
+  /* The first piola stress. */
+  std::array<Matrix3<T>, kNumQuads> P_array;
+  constitutive_model().CalcFirstPiolaStress(deformation_gradient_data,
+                                            &P_array);
+  const Matrix3<double>& P = math::DiscardGradient(P_array[0]);
+  /* The directional face area of the face formed by node 0, 1, and 2 in the
+   reference configuration. The indices are carefully ordered so that the
+   direction is pointing to the inward face normal. */
+  const Vector3<double> face012 =
+      0.5 * (X_double.col(1) - X_double.col(0))
+                .cross(X_double.col(2) - X_double.col(0));
+  const Vector3<double> face013 =
+      0.5 * (X_double.col(3) - X_double.col(0))
+                .cross(X_double.col(1) - X_double.col(0));
+  const Vector3<double> face023 =
+      0.5 * (X_double.col(2) - X_double.col(0))
+                .cross(X_double.col(3) - X_double.col(0));
+  /* The analytic force exerted on node 0 is the average of the total force
+   exerted the faces incidenting node 0. */
+  const Vector3<double> force0_expected =
+      P * (face012 + face013 + face023) / 3.0;
+  EXPECT_TRUE(CompareMatrices(force0, force0_expected, kEpsilon));
+}
+
+/* Tests that at any given state, the negative elastic force is the derivative
+ elastic energy with respect to the generalized positions. */
+TEST_F(VolumetricElementTest, NegativeElasticForceIsEnergyDerivative) {
+  FemStateImpl<ElementType> state = SetupDeformedState();
+  T energy = element().CalcElasticEnergy(state);
+  Vector<T, kNumDofs> neg_elastic_force = CalcNegativeElasticForce(state);
+  EXPECT_TRUE(
+      CompareMatrices(energy.derivatives(), neg_elastic_force, kEpsilon));
+}
+
+/* Tests that at any given state, CalcNegativeElasticForceDerivative() does in
+ fact calculates the derivative of the negative elastic force. */
+TEST_F(VolumetricElementTest, ElasticForceCompatibleWithItsDerivative) {
+  FemStateImpl<ElementType> state = SetupDeformedState();
+  Vector<T, kNumDofs> neg_elastic_force = CalcNegativeElasticForce(state);
+  Eigen::Matrix<T, kNumDofs, kNumDofs> neg_elastic_force_derivative =
+      CalcNegativeElasticForceDerivative(state);
+  for (int i = 0; i < kNumDofs; ++i) {
+    EXPECT_TRUE(CompareMatrices(neg_elastic_force(i).derivatives().transpose(),
+                                neg_elastic_force_derivative.row(i), kEpsilon));
+  }
+}
+
+/* In each dimension, the entries of the mass matrix should sum up to the
+ total mass assigned to the element. */
+TEST_F(VolumetricElementTest, MassMatrixSumUpToTotalMass) {
+  const Eigen::Matrix<T, kNumDofs, kNumDofs>& mass_matrix = get_mass_matrix();
+  const double mass_matrix_sum = mass_matrix.sum().value();
+  double total_mass = 0;
+  for (int q = 0; q < kNumQuads; ++q) {
+    total_mass += (reference_volume()[q] * kDensity).value();
+  }
+  /* The mass matrix repeats the mass in each spatial dimension and needs to
+   be scaled accordingly. */
+  EXPECT_EQ(mass_matrix_sum, total_mass * kSpatialDimension);
+}
+
+/* Tests that the gravity forces match the expected value. */
+TEST_F(VolumetricElementTest, Gravity) {
+  const Eigen::Matrix<T, kNumDofs, kNumDofs>& mass_matrix = get_mass_matrix();
+  Vector<T, kNumDofs> element_gravity_acceleration;
+  for (int i = 0; i < kNumNodes; ++i) {
+    element_gravity_acceleration.template segment<kSpatialDimension>(
+        i * kSpatialDimension) = element().gravity_vector();
+  }
+  const Vector<T, kNumDofs> expected_gravity_force =
+      mass_matrix * element_gravity_acceleration;
+
+  const FemStateImpl<ElementType> initial_state = SetupInitialState();
+  EXPECT_TRUE(
+      CompareMatrices(expected_gravity_force, CalcGravityForce(initial_state)));
+  const FemStateImpl<ElementType> deformed_state = SetupDeformedState();
+  EXPECT_TRUE(CompareMatrices(expected_gravity_force,
+                              CalcGravityForce(deformed_state)));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/volumetric_model_test.cc
+++ b/multibody/fem/test/volumetric_model_test.cc
@@ -1,0 +1,229 @@
+#include "drake/multibody/fem/volumetric_model.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity/make_box_mesh.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/multibody/fem/fem_state.h"
+#include "drake/multibody/fem/linear_constitutive_model.h"
+#include "drake/multibody/fem/linear_simplex_element.h"
+#include "drake/multibody/fem/simplex_gaussian_quadrature.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace {
+
+using Eigen::MatrixXd;
+
+constexpr int kNaturalDimension = 3;
+constexpr int kSpatialDimension = 3;
+constexpr int kQuadratureOrder = 1;
+using QuadratureType =
+    internal::SimplexGaussianQuadrature<kNaturalDimension, kQuadratureOrder>;
+constexpr int kNumQuads = QuadratureType::num_quadrature_points;
+
+using AutoDiffIsoparametricElement =
+    internal::LinearSimplexElement<AutoDiffXd, kNaturalDimension,
+                                   kSpatialDimension, kNumQuads>;
+using AutoDiffConstitutiveModel =
+    internal::LinearConstitutiveModel<AutoDiffXd, kNumQuads>;
+using AutoDiffElement =
+    VolumetricElement<AutoDiffIsoparametricElement, QuadratureType,
+                      AutoDiffConstitutiveModel>;
+
+using DoubleIsoparametricElement =
+    internal::LinearSimplexElement<double, kNaturalDimension, kSpatialDimension,
+                                   kNumQuads>;
+using DoubleConstitutiveModel =
+    internal::LinearConstitutiveModel<double, kNumQuads>;
+using DoubleElement =
+    VolumetricElement<DoubleIsoparametricElement, QuadratureType,
+                      DoubleConstitutiveModel>;
+
+const double kYoungsModulus = 1.23;
+const double kPoissonRatio = 0.456;
+const double kDensity = 0.789;
+/* The geometry of the model under test is a cube and it has 8 vertices and 6
+ elements. */
+constexpr int kNumCubeVertices = 8;
+constexpr int kNumDofs = kNumCubeVertices * kSpatialDimension;
+constexpr int kNumElements = 6;
+/* Parameters for Newmark scheme. */
+const double kDt = 1e-3;
+const double kGamma = 0.5;
+const double kBeta = 0.25;
+/* Parameters for the damping model. */
+const double kMassDamping = 0.01;
+const double kStiffnessDamping = 0.02;
+
+class VolumetricModelTest : public ::testing::Test {
+ protected:
+  /* Makes a box and subdivides it into 6 tetrahedra. */
+  template <typename T>
+  geometry::VolumeMesh<T> MakeBoxTetMesh() {
+    const double length = 0.1;
+    geometry::Box box(length, length, length);
+    geometry::VolumeMesh<T> mesh =
+        geometry::internal::MakeBoxVolumeMesh<T>(box, length);
+    DRAKE_DEMAND(mesh.num_elements() == 6);
+    return mesh;
+  }
+
+  /* Adds a FEM model of a box discretized into 6 tetrahedra into the given
+   `fem_model_impl`. */
+  template <typename FemModelType>
+  void AddBoxToModel(FemModelType* fem_model) {
+    using T = typename FemModelType::T;
+    geometry::VolumeMesh<T> mesh = MakeBoxTetMesh<T>();
+    const typename FemModelType::ConstitutiveModel constitutive_model(
+        kYoungsModulus, kPoissonRatio);
+    const DampingModel<T> damping_model(kMassDamping, kStiffnessDamping);
+    fem_model->AddVolumetricElementsFromTetMesh(mesh, constitutive_model,
+                                                kDensity, damping_model);
+  }
+
+  void SetUp() override { AddBoxToModel(&model_); }
+
+  /* Returns an arbitrary perturbation to the reference configuration of the
+   cube geometry. */
+  static Vector<double, kNumDofs> perturbation() {
+    Vector<double, kNumDofs> delta;
+    delta << 0.18, 0.63, 0.54, 0.13, 0.92, 0.17, 0.03, 0.86, 0.85, 0.25, 0.53,
+        0.67, 0.81, 0.36, 0.45, 0.31, 0.29, 0.71, 0.30, 0.68, 0.58, 0.52, 0.35,
+        0.76;
+    return delta;
+  }
+
+  /* Returns an arbitrary FEM state whose generalized positions are different
+   from reference positions and whose velocities and acclerations are nonzero.
+   In addition, set up autodiff derivatives for accelerations if the scalar type
+   is AutoDiffXd. */
+  template <typename FemModelType>
+  std::unique_ptr<FemState<typename FemModelType::T>> MakeDeformedState(
+      const FemModelType& fem_model) const {
+    using T = typename FemModelType::T;
+    using State = FemState<T>;
+
+    std::unique_ptr<State> reference_state = fem_model.MakeFemState();
+    std::unique_ptr<State> deformed_state = fem_model.MakeFemState();
+    if constexpr (std::is_same_v<T, AutoDiffXd>) {
+      /* Perturb a. */
+      const Vector<double, kNumDofs> perturbed_a =
+          math::ExtractValue(deformed_state->GetAccelerations()) +
+          perturbation();
+      /* Set up AutodiffXd derivatives. */
+      Vector<AutoDiffXd, kNumDofs> perturbed_a_autodiff;
+      math::InitializeAutoDiff(perturbed_a, &perturbed_a_autodiff);
+      /* It's important to set up the `deformed_state` with AdvanceOneTimeStep()
+       so that the derivatives such as dq/da are set up. */
+      integrator_.AdvanceOneTimeStep(*reference_state, perturbed_a_autodiff,
+                                     deformed_state.get());
+    } else {
+      /* Perturb a. */
+      const Vector<double, kNumDofs> perturbed_a =
+          deformed_state->GetAccelerations() + perturbation();
+      AccelerationNewmarkScheme<double> double_integrator(kDt, kGamma, kBeta);
+      double_integrator.AdvanceOneTimeStep(*reference_state, perturbed_a,
+                                           deformed_state.get());
+    }
+
+    return deformed_state;
+  }
+
+  /* The model under test. */
+  VolumetricModel<AutoDiffElement> model_{};
+  AccelerationNewmarkScheme<AutoDiffXd> integrator_{kDt, kGamma, kBeta};
+};
+
+/* Tests the mesh has been successfully converted to elements. */
+TEST_F(VolumetricModelTest, Geometry) {
+  EXPECT_EQ(model_.num_nodes(), kNumCubeVertices);
+  EXPECT_EQ(model_.num_elements(), kNumElements);
+}
+
+/* Tests that the tangent matrix of the model is the derivative of the residual
+ with respect to the change in a. */
+TEST_F(VolumetricModelTest, TangentMatrixIsResidualDerivative) {
+  using T = AutoDiffXd;
+
+  std::unique_ptr<FemState<AutoDiffXd>> state = MakeDeformedState(model_);
+  VectorX<T> residual(state->num_dofs());
+  model_.CalcResidual(*state, &residual);
+
+  Eigen::SparseMatrix<T> tangent_matrix = model_.MakeEigenSparseTangentMatrix();
+  model_.CalcTangentMatrix(*state, integrator_.weights(), &tangent_matrix);
+
+  /* In the discretization of the unit cube by 6 tetrahedra, there are 19 edges,
+   and 8 nodes, creating 19*2 + 8 blocks of 3-by-3 nonzero entries. Hence the
+   number of nonzero entries of the tangent matrix should be (19*2+8)*9. */
+  const int nnz = (19 * 2 + 8) * 9;
+  EXPECT_EQ(tangent_matrix.nonZeros(), nnz);
+
+  const MatrixX<T> dense_tangent_matrix(tangent_matrix);
+  for (int i = 0; i < state->num_dofs(); ++i) {
+    /* The tangent matrix should be the derivative of the residual. Notice that
+     here we are comparing a VectorX<double> and the value of a
+     VectorX<AutoDiffXd>. */
+    EXPECT_TRUE(CompareMatrices(residual(i).derivatives(),
+                                dense_tangent_matrix.col(i),
+                                4 * std::numeric_limits<double>::epsilon()));
+  }
+}
+
+/* Verifies that the tangent matrix calculated as PETSc matrix is the same as
+ that calculated as Eigen::SparseMatrix. */
+TEST_F(VolumetricModelTest, TangentMatrixParity) {
+  std::unique_ptr<FemState<AutoDiffXd>> state = MakeDeformedState(model_);
+  Eigen::SparseMatrix<AutoDiffXd> eigen_tangent_matrix =
+      model_.MakeEigenSparseTangentMatrix();
+  model_.CalcTangentMatrix(*state, integrator_.weights(),
+                           &eigen_tangent_matrix);
+  const MatrixX<AutoDiffXd> eigen_dense_autodiff_matrix = eigen_tangent_matrix;
+  const MatrixXd eigen_dense_matrix =
+      math::ExtractValue(eigen_dense_autodiff_matrix);
+
+  VolumetricModel<DoubleElement> double_model;
+  AddBoxToModel(&double_model);
+  std::unique_ptr<FemState<double>> double_state =
+      MakeDeformedState(double_model);
+  const AccelerationNewmarkScheme<double> double_integrator_{kDt, kGamma,
+                                                             kBeta};
+  std::unique_ptr<internal::PetscSymmetricBlockSparseMatrix>
+      petsc_tangent_matrix =
+          double_model.MakePetscSymmetricBlockSparseTangentMatrix();
+  double_model.CalcTangentMatrix(*double_state, double_integrator_.weights(),
+                                 petsc_tangent_matrix.get());
+  petsc_tangent_matrix->AssembleIfNecessary();
+  const MatrixXd petsc_dense_matrix = petsc_tangent_matrix->MakeDenseMatrix();
+  EXPECT_TRUE(CompareMatrices(eigen_dense_matrix, petsc_dense_matrix,
+                              std::numeric_limits<double>::epsilon()));
+}
+
+/* Adds two copies of the same set of elements and tests that the residual for
+ the two copies are identical. In particular, tests that the node offsets in
+ AddVolumetricElementsFromTetMesh() are working as intended. */
+TEST_F(VolumetricModelTest, MultipleMesh) {
+  using T = AutoDiffXd;
+  /* Add a second box mesh to the model. */
+  AddBoxToModel(&model_);
+  EXPECT_EQ(model_.num_nodes(), 2 * kNumCubeVertices);
+  /* Each cube is split into 6 tetrahedra. */
+  EXPECT_EQ(model_.num_elements(), 2 * kNumElements);
+
+  std::unique_ptr<FemState<AutoDiffXd>> state = model_.MakeFemState();
+  EXPECT_EQ(state->num_dofs(), 2 * kNumDofs);
+
+  VectorX<T> residual(state->num_dofs());
+  model_.CalcResidual(*state, &residual);
+  EXPECT_TRUE(
+      CompareMatrices(residual.head(kNumDofs), residual.tail(kNumDofs), 0));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/velocity_newmark_scheme.cc
+++ b/multibody/fem/velocity_newmark_scheme.cc
@@ -1,0 +1,41 @@
+#include "drake/multibody/fem/velocity_newmark_scheme.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+template <typename T>
+void VelocityNewmarkScheme<T>::DoUpdateStateFromChangeInUnknowns(
+    const VectorX<T>& dz, FemState<T>* state) const {
+  const VectorX<T>& a = state->GetAccelerations();
+  const VectorX<T>& v = state->GetVelocities();
+  const VectorX<T>& x = state->GetPositions();
+  state->SetAccelerations(a + one_over_dt_gamma_ * dz);
+  state->SetVelocities(v + dz);
+  state->SetPositions(x + dt() * beta_over_gamma_ * dz);
+}
+
+template <typename T>
+void VelocityNewmarkScheme<T>::DoAdvanceOneTimeStep(
+    const FemState<T>& prev_state, const VectorX<T>& unknown_variable,
+    FemState<T>* state) const {
+  const VectorX<T>& an = prev_state.GetAccelerations();
+  const VectorX<T>& vn = prev_state.GetVelocities();
+  const VectorX<T>& xn = prev_state.GetPositions();
+  const VectorX<T>& v = unknown_variable;
+  state->SetAccelerations(one_over_dt_gamma_ * (v - vn) -
+                          (1.0 - gamma()) / gamma() * an);
+  state->SetVelocities(v);
+  state->SetPositions(
+      xn + dt() * (beta_over_gamma_ * v + (1.0 - beta_over_gamma_) * vn) +
+      dt() * dt() * (0.5 - beta_over_gamma_) * an);
+}
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::internal::VelocityNewmarkScheme)

--- a/multibody/fem/velocity_newmark_scheme.h
+++ b/multibody/fem/velocity_newmark_scheme.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "drake/common/default_scalars.h"
+#include "drake/multibody/fem/newmark_scheme.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+/* Implements the interface DiscreteTimeIntegrator with Newmark-beta time
+ integration scheme with velocity being the unknown variable. Given the value
+ for the next time step velocity `v`, the states are calculated from that of
+ the previous time step according to the following equations:
+
+      a = (v - vₙ) / (dt ⋅ γ) - (1 − γ) / γ ⋅ aₙ
+      x = xₙ + dt ⋅ (β/γ ⋅ v +  (1 - β/γ) ⋅ vₙ) + dt² ⋅ (0.5 − β/γ) ⋅ aₙ.
+
+ See NewmarkScheme for the reference to the Newmark-beta integration scheme.
+ See AccelerationNewmarkScheme for the same integration scheme implemented with
+ acceleration as the unknown variable.
+ @tparam_nonsymbolic_scalar */
+template <typename T>
+class VelocityNewmarkScheme final : public NewmarkScheme<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(VelocityNewmarkScheme);
+
+  /* Constructs a Newmark scheme with velocity as the unknown variable.
+   @pre dt_in > 0.
+   @pre 0.5 <= gamma_in <= 1.
+   @pre 0 <= beta_in <= 0.5. */
+  VelocityNewmarkScheme(double dt_in, double gamma_in, double beta_in)
+      : NewmarkScheme<T>(dt_in, gamma_in, beta_in),
+        beta_over_gamma_(beta_in / gamma_in),
+        one_over_dt_gamma_(1.0 / (dt() * gamma())) {}
+
+  ~VelocityNewmarkScheme() = default;
+
+ private:
+  using NewmarkScheme<T>::dt;
+  using NewmarkScheme<T>::gamma;
+
+  Vector3<T> do_get_weights() const final {
+    return {beta_over_gamma_ * dt(), 1.0, one_over_dt_gamma_};
+  }
+
+  const VectorX<T>& DoGetUnknowns(const FemState<T>& state) const final {
+    return state.GetVelocities();
+  }
+
+  void DoUpdateStateFromChangeInUnknowns(const VectorX<T>& dz,
+                                         FemState<T>* state) const final;
+
+  void DoAdvanceOneTimeStep(const FemState<T>& prev_state,
+                            const VectorX<T>& unknown_variable,
+                            FemState<T>* state) const final;
+
+  double beta_over_gamma_{};
+  double one_over_dt_gamma_{};
+};
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::internal::VelocityNewmarkScheme)

--- a/multibody/fem/volumetric_element.cc
+++ b/multibody/fem/volumetric_element.cc
@@ -1,0 +1,1 @@
+#include "drake/multibody/fem/volumetric_element.h"

--- a/multibody/fem/volumetric_element.h
+++ b/multibody/fem/volumetric_element.h
@@ -1,0 +1,543 @@
+#pragma once
+
+#include <array>
+#include <type_traits>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/unused.h"
+#include "drake/multibody/fem/fem_element.h"
+#include "drake/multibody/fem/fem_state_impl.h"
+#include "drake/multibody/fem/isoparametric_element.h"
+#include "drake/multibody/fem/quadrature.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+/* Helper function that performs a contraction between a 4th order tensor A
+ and two vectors u and v and returns a matrix B. In Einstein notation, the
+ contraction is: Bᵢₖ = uⱼ Aᵢⱼₖₗ vₗ. The 4th order tensor A of dimension
+ 3*3*3*3 is flattened to a 9*9 matrix that is organized as following
+
+                  l = 1       l = 2       l = 3
+              -------------------------------------
+              |           |           |           |
+    j = 1     |   Aᵢ₁ₖ₁   |   Aᵢ₁ₖ₂   |   Aᵢ₁ₖ₃   |
+              |           |           |           |
+              -------------------------------------
+              |           |           |           |
+    j = 2     |   Aᵢ₂ₖ₁   |   Aᵢ₂ₖ₂   |   Aᵢ₂ₖ₃   |
+              |           |           |           |
+              -------------------------------------
+              |           |           |           |
+    j = 3     |   Aᵢ₃ₖ₁   |   Aᵢ₃ₖ₂   |   Aᵢ₃ₖ₃   |
+              |           |           |           |
+              -------------------------------------
+Namely the ik-th entry in the jl-th block corresponds to the value Aᵢⱼₖₗ. */
+template <typename T>
+void PerformDoubleTensorContraction(
+    const Eigen::Ref<const Eigen::Matrix<T, 9, 9>>& A,
+    const Eigen::Ref<const Vector3<T>>& u,
+    const Eigen::Ref<const Vector3<T>>& v, EigenPtr<Matrix3<T>> B) {
+  B->setZero();
+  for (int l = 0; l < 3; ++l) {
+    for (int j = 0; j < 3; ++j) {
+      *B += A.template block<3, 3>(3 * j, 3 * l) * u(j) * v(l);
+    }
+  }
+}
+
+/* The traits class for volumetric elasticity FEM element. */
+template <class IsoparametricElementType, class QuadratureType,
+          class ConstitutiveModelType>
+struct VolumetricElementTraits {
+  /* Check that template parameters are of the correct types. */
+  static_assert(
+      is_isoparametric_element<IsoparametricElementType>::value,
+      "The IsoparametricElementType template parameter must be a derived "
+      "class of IsoparametricElement");
+  static_assert(
+      is_quadrature<QuadratureType>::value,
+      "The QuadratureType template parameter must be a derived class of "
+      "Quadrature<T, natural_dimension, num_quadrature_points>, where "
+      "`natural_dimension` can be 1, 2 or 3.");
+  static_assert(
+      is_constitutive_model<ConstitutiveModelType>::value,
+      "The ConstitutiveModelType template parameter must be a derived "
+      "class of ConstitutiveModel");
+  /* Check that the scalar types are compatible. */
+  static_assert(std::is_same_v<typename IsoparametricElementType::T,
+                               typename ConstitutiveModelType::T>,
+                "The scalar type of the isoparametric element and the "
+                "constitutive model must be the same.");
+  /* Check that the number of quadrature points are compatible. */
+  static_assert(
+      QuadratureType::num_quadrature_points ==
+          IsoparametricElementType::num_sample_locations,
+      "The number of quadrature points of the quadrature rule must be the same "
+      "as the number of evaluation locations in the isoparametric element.");
+  static_assert(
+      QuadratureType::num_quadrature_points ==
+          ConstitutiveModelType::num_locations,
+      "The number of quadrature points must be the same as the number of "
+      "locations at which the constitutive model is evaluated.");
+  /* Check that the natural dimensions are compatible. */
+  static_assert(IsoparametricElementType::natural_dimension ==
+                    QuadratureType::natural_dimension,
+                "The natural dimension of the isoparametric element and the "
+                "quadrature rule must be the same.");
+  /* Only 3D elasticity is supported. */
+  static_assert(IsoparametricElementType::spatial_dimension == 3,
+                "The spatial dimension of the isoparametric element must be 3 "
+                "for volumetric FEM elements.");
+
+  using T = typename ConstitutiveModelType::T;
+  using IsoparametricElement = IsoparametricElementType;
+  using Quadrature = QuadratureType;
+  using ConstitutiveModel = ConstitutiveModelType;
+
+  static constexpr int num_nodes = IsoparametricElementType::num_nodes;
+  static constexpr int num_quadrature_points =
+      QuadratureType::num_quadrature_points;
+  static constexpr int natural_dimension = QuadratureType::natural_dimension;
+  static constexpr int kSpatialDimension =
+      IsoparametricElementType::spatial_dimension;
+  /* The number of degrees of freedom is equal to the spatial dimension (which
+   gives the number of degrees of freedom for a single node) times the number of
+   nodes. */
+  static constexpr int num_dofs = kSpatialDimension * num_nodes;
+
+  struct Data {
+    typename ConstitutiveModelType::Data deformation_gradient_data;
+    /* The elastic energy density evaluated at quadrature points. */
+    std::array<T, num_quadrature_points> Psi;
+    /* The first Piola stress evaluated at quadrature points. */
+    std::array<Matrix3<T>, num_quadrature_points> P;
+    /* The derivative of first Piola stress with respect to the deformation
+     gradient evaluated at quadrature points. */
+    std::array<Eigen::Matrix<T, 9, 9>, num_quadrature_points> dPdF;
+  };
+};
+
+/* This class models a single 3D elasticity FEM element.
+ @tparam IsoparametricElementType  The type of isoparametric element used in
+                                   this VolumetricElement.
+                                   IsoparametricElementType must derived
+                                   from IsoparametricElement.
+ @tparam QuadratureType  The type of quadrature rule used in this
+                         VolumetricElement. QuadratureType must be derived from
+                         Quadrature.
+ @tparam ConstitutiveModelType  The type of constitutive model used in this
+                                VolumetricElement. ConstitutiveModelType must be
+                                derived from ConstitutiveModel.
+ @tparam ElementType  The concrete FEM element that inherits from
+                         VolumetricElement through CRTP.
+ @tparam DerivedTraits   The traits class associated with the ElementType. */
+template <class IsoparametricElementType, class QuadratureType,
+          class ConstitutiveModelType>
+class VolumetricElement
+    : public FemElement<
+          VolumetricElement<IsoparametricElementType, QuadratureType,
+                            ConstitutiveModelType>,
+          VolumetricElementTraits<IsoparametricElementType, QuadratureType,
+                                  ConstitutiveModelType>> {
+ public:
+  using ElementType = VolumetricElement<IsoparametricElementType,
+                                        QuadratureType, ConstitutiveModelType>;
+  using Traits = VolumetricElementTraits<IsoparametricElementType,
+                                         QuadratureType, ConstitutiveModelType>;
+  using Data = typename Traits::Data;
+  using T = typename Traits::T;
+  static constexpr int natural_dimension = Traits::natural_dimension;
+  static constexpr int kSpatialDimension = Traits::kSpatialDimension;
+  static constexpr int num_quadrature_points = Traits::num_quadrature_points;
+  static constexpr int num_dofs = Traits::num_dofs;
+  static constexpr int num_nodes = Traits::num_nodes;
+
+  /* Constructs a new VolumetricElement. In that process, precomputes the mass
+   matrix and the gravity force acting on the element.
+   @param[in] element_index        The index of the new element.
+   @param[in] node_indices         The node indices of the nodes of this
+                                   element.
+   @param[in] constitutive_model   The ConstitutiveModel to be used for this
+                                   element.
+   @param[in] reference_positions  The positions (in world frame) of the nodes
+                                   of this element in the reference
+                                   configuration.
+   @param[in] denstiy              The mass density of the element with unit
+                                   kg/m³.
+   @param[in] damping_model        The DampingModel to be used for this element.
+   @pre element_index must be valid.
+   @pre density > 0. */
+  VolumetricElement(ElementIndex element_index,
+                    const std::array<NodeIndex, num_nodes>& node_indices,
+                    const ConstitutiveModelType& constitutive_model,
+                    const Eigen::Ref<const Eigen::Matrix<T, 3, num_nodes>>&
+                        reference_positions,
+                    const T& density, const DampingModel<T>& damping_model)
+      : FemElement<ElementType, Traits>(element_index, node_indices,
+                                        constitutive_model, damping_model),
+        density_(density) {
+    DRAKE_DEMAND(density_ > 0);
+    /* Find the Jacobian of the change of variable function X(ξ). */
+    const std::array<Eigen::Matrix<T, 3, natural_dimension>,
+                     num_quadrature_points>
+        dXdxi = isoparametric_element_.CalcJacobian(reference_positions);
+    /* Record the quadrature point volume in reference configuration for each
+     quadrature location. */
+    for (int q = 0; q < num_quadrature_points; ++q) {
+      /* The scale to transform quadrature weight in parent coordinates to
+       reference coordinates. */
+      T volume_scale;
+      if constexpr (natural_dimension == 3) {
+        volume_scale = dXdxi[q].determinant();
+        /* Degenerate tetrahedron in the initial configuration is not allowed.
+         */
+        DRAKE_DEMAND(volume_scale > 0);
+        // NOLINTNEXTLINE(readability/braces) false positive
+      } else if constexpr (natural_dimension == 2) {
+        /* Given the QR decomposition of the Jacobian matrix J = QR, where Q is
+         unitary and R is upper triangular, the 2x2 top left corner of R gives
+         the in plane deformation of the reference triangle. Its determinant
+         provides the ratio of the area of triangle in the reference
+         configuration over the area of the triangle in parent domain. */
+        Eigen::ColPivHouseholderQR<
+            Eigen::Matrix<T, kSpatialDimension, natural_dimension>>
+            qr(dXdxi[q]);
+        volume_scale =
+            abs(qr.matrixR()
+                    .topLeftCorner(natural_dimension, natural_dimension)
+                    .template triangularView<Eigen::Upper>()
+                    .determinant());
+      } else if constexpr (natural_dimension == 1) {
+        volume_scale = dXdxi[q].norm();
+      } else {
+        DRAKE_UNREACHABLE();
+      }
+      reference_volume_[q] = volume_scale * quadrature_.get_weight(q);
+    }
+
+    /* Record the inverse Jacobian at the reference configuration which is used
+     in the calculation of deformation gradient. */
+    dxidX_ = isoparametric_element_.CalcJacobianPseudoinverse(dXdxi);
+    /* Record the gradient of the shape functions w.r.t. the reference
+     positions, which is used in calculating the residual. */
+    const auto dSdX = isoparametric_element_.CalcGradientInSpatialCoordinates(
+        reference_positions);
+    for (int q = 0; q < num_quadrature_points; ++q) {
+      dSdX_transpose_[q] = dSdX[q].transpose();
+    }
+    mass_matrix_ = PrecomputeMassMatrix();
+    lumped_mass_ = mass_matrix_.rowwise().sum().eval();
+  }
+
+  /* Assignment and copy constructions are prohibited. Move constructor is
+   allowed so that elasticity elements can be stored in `std::vector`. */
+  VolumetricElement(const VolumetricElement&) = delete;
+  VolumetricElement(VolumetricElement&&) = default;
+  const VolumetricElement& operator=(const VolumetricElement&) = delete;
+  VolumetricElement&& operator=(const VolumetricElement&&) = delete;
+
+  /* Calculates the elastic potential energy (in joules) stored in this element
+   at the given `state`. */
+  T CalcElasticEnergy(const FemStateImpl<ElementType>& state) const {
+    T elastic_energy = 0;
+    const Data& data = state.element_data(*this);
+    for (int q = 0; q < num_quadrature_points; ++q) {
+      elastic_energy += reference_volume_[q] * data.Psi[q];
+    }
+    return elastic_energy;
+  }
+
+ private:
+  /* Friend the base class so that FemElement::DoFoo() can reach its
+   implementation. */
+  friend FemElement<ElementType, Traits>;
+  friend class VolumetricElementTest;
+
+  /* Adds the negative elastic force on the nodes of this element into the
+   given force vector. The negative elastic force is the derivative of the
+   elastic energy (see CalcElasticEnergy()) with respect to the generalized
+   positions of the nodes.
+   @param[in] state       The FEM state at which to evaluate the negative
+                          elastic force.
+   @param[out] neg_force  The negative force vector.
+   @pre neg_force != nullptr.
+   @warning It is the responsibility of the caller to initialize neg_force to
+   zero appropriately. */
+  void AddNegativeElasticForce(const FemStateImpl<ElementType>& state,
+                               EigenPtr<Vector<T, num_dofs>> neg_force) const {
+    DRAKE_ASSERT(neg_force != nullptr);
+    auto neg_force_matrix = Eigen::Map<Eigen::Matrix<T, 3, num_nodes>>(
+        neg_force->data(), 3, num_nodes);
+    const Data& data = state.element_data(*this);
+    for (int q = 0; q < num_quadrature_points; ++q) {
+      /* Negative force is the gradient of energy.
+       -f = ∫dΨ/dx = ∫dΨ/dF : dF/dx dX.
+       Notice that Fᵢⱼ = xₐᵢdSₐ/dXⱼ, so dFᵢⱼ/dxᵦₖ = δₐᵦδᵢₖdSₐ/dXⱼ,
+       and dΨ/dFᵢⱼ = Pᵢⱼ, so the integrand becomes
+       PᵢⱼδₐᵦδᵢₖdSₐ/dXⱼ = PₖⱼdSᵦ/dXⱼ = P * dSdX.transpose() */
+      neg_force_matrix += reference_volume_[q] * data.P[q] * dSdX_transpose_[q];
+    }
+  }
+
+  /* Adds the negative damping force on the nodes of this element into the given
+   `negative_damping_force`. The negative damping force is given by the product
+   of the damping matrix with the velocity of the nodes.
+   @param[in] state       The FEM state at which to evaluate the negative
+                          damping force.
+   @param[out] neg_force  The negative force vector.
+   @pre neg_force != nullptr.
+   @warning It is the responsibility of the caller to initialize neg_force to
+   zero appropriately. */
+  void AddNegativeDampingForce(const FemStateImpl<ElementType>& state,
+                               EigenPtr<Vector<T, num_dofs>> neg_force) const {
+    DRAKE_ASSERT(neg_force != nullptr);
+    Eigen::Matrix<T, num_dofs, num_dofs> damping_matrix =
+        Eigen::Matrix<T, num_dofs, num_dofs>::Zero();
+    this->AddScaledDampingMatrix(state, 1, &damping_matrix);
+    /* Note that the damping force fᵥ = -D * v, where D is the damping matrix.
+     As we are accumulating the negative damping force here, the `+=` sign
+     should be used. */
+    *neg_force +=
+        damping_matrix *
+        this->ExtractElementDofs(this->node_indices(), state.GetVelocities());
+  }
+
+  /* The matrix calculated here is the same as the stiffness matrix
+   calculated in [Bonet, 2016] equation (9.50b) without the external force
+   component.
+   Without the external force component, (9,50b) reads Kₐᵦ = Kₐᵦ,c + Kₐᵦ,σ.
+   Kₐᵦ,c is given by ∫dSᵃ/dxₖ cᵢₖⱼₗ dSᵇ/dxₗ dx (9.35), and
+   Kₐᵦ,σ is given by ∫dSᵃ/dxₖ σₖₗ dSᵇ/dxₗ dx (9.44c). Notice that we use S to
+   denote shape functions whereas [Bonet, 2016] uses N.
+   The negative force derivative we calculate here is given by ∫ dF/dxᵇ :
+   dP/dF : dF/dxᵃ dX. The calculation uses a different conjugate pair, but is
+   analytically equal to Kₐᵦ,c + Kₐᵦ,σ. See
+   multibody/fem/doc/stiffness_matrix.pdf for the derivation that
+   shows the equivalence.
+   // TODO(xuchenhan-tri): Update the directory above when this file moves out
+   //  of .
+
+   Reference: [Bonet, 2016] Bonet, Javier, Antonio J.Gil, and
+   Richard D. Wood. Nonlinear solid mechanics for finite element analysis:
+   statics. Cambridge University Press, 2016. */
+
+  /* TODO(xuchenhan-tri): Consider performing the calculation in current
+   coordinates. A few trade-offs:
+    1. The shape function derivatives needs to be recalculated every time.
+    2. There will be two terms instead of one.
+    3. The c matrix has symmetries that can be exploited and can be represented
+   by a symmetric 6x6 matrix, whereas dP/dF is an asymmetric 9x9 matrix. The
+   two stress-strain pairs need to be carefully profiled against each other as
+   this operation might be (one of) the bottleneck(s). */
+
+  /* Adds a scaled derivative of the elastic force on the nodes of this
+   element into the given matrix.
+   @param[in] state   The FEM state at which to evaluate the elastic force
+                      derivatives.
+   @param[out] scale  The scaling factor applied to the derivative.
+   @param[out] K      The scaled force derivative matrix.
+   @pre K != nullptr. */
+  void AddScaledElasticForceDerivative(
+      const FemStateImpl<ElementType>& state, const T& scale,
+      EigenPtr<Eigen::Matrix<T, num_dofs, num_dofs>> K) const {
+    DRAKE_ASSERT(K != nullptr);
+    // clang-format off
+    /* Let e be the elastic energy, then the ab-th block of the stiffness
+     matrix K is given by:
+     Kᵃᵇᵢⱼ = d²e/dxᵃᵢdxᵇⱼ = ∫dF/dxᵇⱼ:d²ψ/dF²:dF/dxᵃᵢ + dψ/dF:d²F/dxᵃᵢdxᵇⱼ dX.
+     The second term vanishes because Fₖₗ = xᵃₖdSᵃ/dXₗ is linear in x.
+     We calculate the first term:
+     dF/dxᵇⱼ : d²ψ/dF² : dF/dxᵃᵢ = dFₘₙ/dxᵃᵢ dPₘₙ/dFₖₗ dFₖₗ/dxᵇⱼ.  */
+    // clang-format on
+    const Data& data = state.element_data(*this);
+    // The ab-th 3-by-3 block of K.
+    Matrix3<T> K_ab;
+    for (int q = 0; q < num_quadrature_points; ++q) {
+      /* Notice that Fₖₗ = xᵃₖdSᵃ/dXₗ, so dFₖₗ/dxᵇⱼ = δᵃᵇδₖⱼdSᵃ/dXₗ, and thus
+       Kᵃᵇᵢⱼ = dFₘₙ/dxᵃᵢ dPₘₙ/dFₖₗ dFₖₗ/dxᵇⱼ =  dSᵃ/dXₙ dPᵢₙ/dFⱼₗ dSᵇ/dXₗ. */
+      for (int a = 0; a < num_nodes; ++a) {
+        for (int b = 0; b < num_nodes; ++b) {
+          /* Note that the scale is negated here because the tensor contraction
+           gives the second derivative of energy, which is the opposite of the
+           force derivative. */
+          PerformDoubleTensorContraction<T>(
+              data.dPdF[q], dSdX_transpose_[q].col(a),
+              dSdX_transpose_[q].col(b) * reference_volume_[q] * -scale, &K_ab);
+          AccumulateMatrixBlock(K_ab, a, b, K);
+        }
+      }
+    }
+  }
+
+  /* Implements FemElement::CalcResidual(). */
+  void DoCalcResidual(const FemStateImpl<ElementType>& state,
+                      EigenPtr<Vector<T, num_dofs>> residual) const {
+    /* residual = Ma-fₑ(x)-fᵥ(x, v)-fₑₓₜ, where M is the mass matrix, fₑ(x) is
+     the elastic force, fᵥ(x, v) is the damping force and fₑₓₜ is the external
+     force. */
+    *residual +=
+        mass_matrix_ * this->ExtractElementDofs(this->node_indices(),
+                                                state.GetAccelerations());
+    this->AddNegativeElasticForce(state, residual);
+    AddNegativeDampingForce(state, residual);
+    this->AddScaledExternalForce(state, -1.0, residual);
+  }
+
+  /* Implements FemElement::DoAddScaledStiffnessMatrix().
+   @warning This method calculates a first-order approximation of the stiffness
+   matrix. In other words, the contribution of the term ∂fᵥ(x, v)/∂x is ignored
+   as it involves complex second derivatives of the elastic force. */
+  void DoAddScaledStiffnessMatrix(
+      const FemStateImpl<ElementType>& state, const T& scale,
+      EigenPtr<Eigen::Matrix<T, num_dofs, num_dofs>> K) const {
+    /* Negate `scale` since stiffness matrix is the negative force derivative.
+     */
+    this->AddScaledElasticForceDerivative(state, -scale, K);
+  }
+
+  /* Implements FemElement::DoAddScaledDampingMatrix(). */
+  void DoAddScaledDampingMatrix(
+      const FemStateImpl<ElementType>& state, const T& scale,
+      EigenPtr<Eigen::Matrix<T, num_dofs, num_dofs>> D) const {
+    /* D = αM + βK, where α is the mass damping coefficient and β is the
+     stiffness damping coefficient. */
+    const T& alpha = this->damping_model().mass_coeff();
+    const T& beta = this->damping_model().stiffness_coeff();
+    this->AddScaledMassMatrix(state, scale * alpha, D);
+    this->AddScaledStiffnessMatrix(state, scale * beta, D);
+  }
+
+  /* Implements FemElement::DoAddScaledMassMatrix(). */
+  void DoAddScaledMassMatrix(
+      const FemStateImpl<ElementType>&, const T& scale,
+      EigenPtr<Eigen::Matrix<T, num_dofs, num_dofs>> M) const {
+    *M += scale * mass_matrix_;
+  }
+
+  /* Implements FemElement::ComputeData(). */
+  Data DoComputeData(const FemStateImpl<ElementType>& state) const {
+    Data data;
+    data.deformation_gradient_data.UpdateData(CalcDeformationGradient(state));
+    this->constitutive_model().CalcElasticEnergyDensity(
+        data.deformation_gradient_data, &data.Psi);
+    this->constitutive_model().CalcFirstPiolaStress(
+        data.deformation_gradient_data, &data.P);
+    this->constitutive_model().CalcFirstPiolaStressDerivative(
+        data.deformation_gradient_data, &data.dPdF);
+    return data;
+  }
+
+  /* Calculates the deformation gradient at all quadrature points in this
+   element. */
+  std::array<Matrix3<T>, num_quadrature_points> CalcDeformationGradient(
+      const FemStateImpl<ElementType>& state) const {
+    std::array<Matrix3<T>, num_quadrature_points> F;
+    const Vector<T, num_dofs> element_x =
+        this->ExtractElementDofs(this->node_indices(), state.GetPositions());
+    const auto& element_x_reshaped =
+        Eigen::Map<const Eigen::Matrix<T, 3, num_nodes>>(element_x.data(), 3,
+                                                         num_nodes);
+    const std::array<typename IsoparametricElementType::JacobianMatrix,
+                     num_quadrature_points>
+        dxdxi = isoparametric_element_.CalcJacobian(element_x_reshaped);
+    for (int q = 0; q < num_quadrature_points; ++q) {
+      F[q] = dxdxi[q] * dxidX_[q];
+    }
+    return F;
+  }
+
+  /* Helper function that adds a 3x3 matrix into the 3x3 block in a bigger
+   matrix `matrix` with starting row index 3*node_a and starting column index
+   3*node_b. Note that this function assumes the pointer `matrix` is not null.
+   It also does not check the index it tries to write in `matrix` is valid and
+   does not clear any stale data that might exist in `matrix`. */
+  static void AccumulateMatrixBlock(
+      const Eigen::Ref<const Matrix3<T>>& block, int node_a, int node_b,
+      EigenPtr<Eigen::Matrix<T, num_dofs, num_dofs>> matrix) {
+    matrix->template block<3, 3>(3 * node_a, 3 * node_b) += block;
+  }
+
+  Eigen::Matrix<T, num_dofs, num_dofs> PrecomputeMassMatrix() const {
+    Eigen::Matrix<T, num_dofs, num_dofs> mass =
+        Eigen::Matrix<T, num_dofs, num_dofs>::Zero();
+    const std::array<Vector<T, num_nodes>, num_quadrature_points>& S =
+        isoparametric_element_.GetShapeFunctions();
+    /* S_mat is the matrix representation of S. */
+    Eigen::Matrix<T, num_nodes, num_quadrature_points> S_mat;
+    for (int q = 0; q < num_quadrature_points; ++q) {
+      S_mat.col(q) = S[q];
+    }
+    /* weighted_S stores the shape function weighted by the reference
+     volume of the quadrature point. */
+    Eigen::Matrix<T, num_nodes, num_quadrature_points> weighted_S(S_mat);
+    for (int q = 0; q < num_quadrature_points; ++q) {
+      weighted_S.col(q) *= reference_volume_[q];
+    }
+    /* weighted_SST = weighted_S * Sᵀ. The ij-th entry approximates the integral
+     ∫SᵢSⱼ dX */
+    const Eigen::Matrix<T, num_nodes, num_nodes> weighted_SST =
+        weighted_S * S_mat.transpose();
+    constexpr int kDim = 3;
+    for (int i = 0; i < num_nodes; ++i) {
+      for (int j = 0; j < num_nodes; ++j) {
+        mass.template block<kDim, kDim>(kDim * i, kDim * j) =
+            Eigen::Matrix<T, kDim, kDim>::Identity() * weighted_SST(i, j) *
+            density_;
+      }
+    }
+    return mass;
+  }
+
+  /* Computes the gravity force on each node in the element using the stored
+   mass and gravity vector. */
+  void AddScaledGravityForce(const FemStateImpl<ElementType>& state,
+                             const T& scale,
+                             EigenPtr<Vector<T, num_dofs>> force) const {
+    // TODO(xuchenhan-tri): The calculation here is only required whenever the
+    //  gravity vector changes. Consider cahcing the gravity force.
+    unused(state);
+    constexpr int kDim = 3;
+    for (int i = 0; i < num_nodes; ++i) {
+      /* The following computation is equivalent to performing the matrix-vector
+       multiplication of the mass matrix and the stacked gravity vector. */
+      force->template segment<kDim>(kDim * i) +=
+          scale * lumped_mass_.template segment<kDim>(kDim * i).cwiseProduct(
+                      this->gravity_vector());
+    }
+  }
+
+  // TODO(xuchenhan-tri): Consider bumping this up into FemElement when new
+  //  FemElement types are added.
+  /* The quadrature rule used for this element. */
+  QuadratureType quadrature_{};
+  /* The isoparametric element used for this element. */
+  IsoparametricElementType isoparametric_element_{quadrature_.get_points()};
+  /* The inverse element Jacobian evaluated at reference configuration at
+   the quadrature points in this element. */
+  std::array<Eigen::Matrix<T, natural_dimension, 3>, num_quadrature_points>
+      dxidX_;
+  /* The transpose of the derivatives of the shape functions with respect to the
+   reference positions evaluated at the quadrature points in this element. */
+  std::array<Eigen::Matrix<T, 3, num_nodes>, num_quadrature_points>
+      dSdX_transpose_;
+  /* The volume evaluated at reference configuration occupied by the
+   quadrature points in this element. To integrate a function f over the
+   reference domain, sum f(q)*reference_volume_[q] over all the quadrature
+   points q in the element. */
+  std::array<T, num_quadrature_points> reference_volume_;
+  /* The uniform mass density of the element in the reference configuration with
+   unit kg/m³. */
+  T density_;
+  /* Precomputed mass matrix. */
+  Eigen::Matrix<T, num_dofs, num_dofs> mass_matrix_;
+  /* The diagonal of the lumped mass matrix (sum over each row). */
+  Vector<T, num_dofs> lumped_mass_;
+};
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/volumetric_model.h
+++ b/multibody/fem/volumetric_model.h
@@ -1,0 +1,151 @@
+#pragma once
+
+#include <array>
+#include <memory>
+#include <utility>
+
+#include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/multibody/fem/acceleration_newmark_scheme.h"
+#include "drake/multibody/fem/damping_model.h"
+#include "drake/multibody/fem/fem_model_impl.h"
+#include "drake/multibody/fem/volumetric_element.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+/* The FEM model for dynamic 3D volumetric elasticity problems.
+ @tparam Element  The type of FEM element used in this model. Must be of
+ template type VolumetricElement. */
+template <class Element>
+class VolumetricModel : public FemModelImpl<Element> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(VolumetricModel);
+
+  using State = FemStateImpl<Element>;
+  using Traits = typename Element::Traits;
+  using T = typename Traits::T;
+  using ConstitutiveModel = typename Traits::ConstitutiveModel;
+  static constexpr int kSpatialDimension = Traits::kSpatialDimension;
+
+  static_assert(
+      std::is_same_v<
+          VolumetricElement<typename Traits::IsoparametricElement,
+                            typename Traits::Quadrature, ConstitutiveModel>,
+          Element>,
+      "The template parameter `Element` must be of type VolumetricElement.");
+
+  /* Creates a new VolumetricModel with no elements. */
+  VolumetricModel() = default;
+
+  ~VolumetricModel() = default;
+
+  /* Add tetrahedral FEM elements to this VolumetricModel from a mesh. The
+   positions of the vertices in the mesh are used as reference positions as well
+   as positions in the default FEM state.
+   @param mesh  The input tetrahedral mesh that describes the connectivity and
+                the positions of the vertices. Each tetrahedral element in
+                the input `mesh` will generate an FEM element in this model.
+   @param constitutive_model  The ConstitutiveModel to be used for all the
+                              FEM elements created from the input mesh.
+   @param density  The mass density of the new elements, in unit kg/m³.
+   @param damping_model  The DampingModel to be used for all new elements.
+   @throw std::exception if Element::Traits::num_nodes != 4. */
+  void AddVolumetricElementsFromTetMesh(
+      const geometry::VolumeMesh<T>& mesh,
+      const ConstitutiveModel& constitutive_model, const T& density,
+      const DampingModel<T>& damping_model) {
+    if constexpr (Traits::num_nodes != 4) {
+      throw std::logic_error(
+          "AddVolumetricElementsFromTetMesh() only supports tetrahedral "
+          "elements.");
+    } else {
+      /* Record the reference positions of the input mesh. The returned offset
+       is from before the new tets are added. */
+      const NodeIndex node_index_offset(this->ParseTetMesh(mesh));
+
+      /* Add new elements. */
+      std::array<NodeIndex, Traits::num_nodes> element_node_indices;
+      for (int i = 0; i < mesh.num_elements(); ++i) {
+        for (int j = 0; j < Traits::num_nodes; ++j) {
+          /* To obtain the global node index, offset the local index of the
+           nodes in the mesh (starting from 0) by the existing number of nodes
+           before the current mesh is added. */
+          const int node_id = mesh.element(i).vertex(j) + node_index_offset;
+          element_node_indices[j] = NodeIndex(node_id);
+        }
+        const Vector<T, Traits::num_dofs> element_reference_positions =
+            Element::ExtractElementDofs(element_node_indices,
+                                        reference_positions_);
+        const ElementIndex next_element_index =
+            ElementIndex(this->num_elements());
+        const auto& element_reference_positions_reshaped = Eigen::Map<
+            const Eigen::Matrix<T, kSpatialDimension, Traits::num_nodes>>(
+            element_reference_positions.data(), kSpatialDimension,
+            Traits::num_nodes);
+        this->AddElement(
+            next_element_index, element_node_indices, constitutive_model,
+            element_reference_positions_reshaped, density, damping_model);
+        this->mutable_element(next_element_index)
+            .set_gravity_vector(this->gravity());
+      }
+    }
+  }
+
+  /* Calculates the total elastic potential energy (in joules) in this
+   VolumetricModel. */
+  T CalcElasticEnergy(const FemStateImpl<Element>& state) const {
+    T energy(0);
+    for (ElementIndex i(0); i < this->num_elements(); ++i) {
+      const Element& e = this->element(i);
+      energy += e.CalcElasticEnergy(state);
+    }
+    return energy;
+  }
+
+ protected:
+  /* Parse a tetrahedral volume mesh, store the positions of the vertices in
+   the mesh as the reference positions for the vertices, and increment the total
+   number of vertices in the model. Returns the total number of vertices
+   _before_ the input `mesh` is added. */
+  int ParseTetMesh(const geometry::VolumeMesh<T>& mesh) {
+    /* Alias for more readability. */
+    constexpr int kDim = kSpatialDimension;
+    /* Record the reference positions of the input mesh. */
+    const int num_new_vertices = mesh.num_vertices();
+    reference_positions_.conservativeResize(reference_positions_.size() +
+                                            kDim * num_new_vertices);
+    /* Record the number of vertices *before* the input mesh is parsed. */
+    const int num_existing_nodes = this->num_nodes();
+    const NodeIndex node_index_offset = NodeIndex(num_existing_nodes);
+    for (int i = 0; i < num_new_vertices; ++i) {
+      reference_positions_.template segment<kDim>(
+          kDim * (i + node_index_offset)) = mesh.vertex(i);
+    }
+    this->increment_num_nodes(num_new_vertices);
+    return num_existing_nodes;
+  }
+
+  /* Returns the reference positions of all nodes in the model. */
+  const VectorX<T>& reference_positions() const { return reference_positions_; }
+
+ private:
+  /* Implements FemModelImpl::DoMakeFemStateImpl(). Generalized positions are
+   initialized to be reference positions of the input mesh vertices. Velocities
+   and accelerations are initialized to 0. */
+  FemStateImpl<Element> DoMakeFemStateImpl() const final {
+    const int num_dofs = reference_positions_.size();
+    return FemStateImpl<Element>(reference_positions_,
+                                 VectorX<T>::Zero(num_dofs),
+                                 VectorX<T>::Zero(num_dofs));
+  }
+
+  VectorX<T> reference_positions_{};
+  Vector<T, kSpatialDimension> gravity_{0, 0, -9.81};
+};
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
This PR serves as a reference of what the FEM code would look like after the migration out of dev. I'll break this PR into a series of PR trains, and I hope this reference PR can provide some context to reviewers of the PR train on what the bigger picture is.

To make the migration process easier, each PR into the `multibody/fem` directory will not delete the corresponding code under `multibody/fixed_fem/dev`. This gives us maximum flexibility in decomposing the migration into digestible pieces. Once the migration process is complete, the obsolete code in `multibody/fixed_fem/dev` will be nuked in a single PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16492)
<!-- Reviewable:end -->
