### PR TITLE
[parsing] Stop putting memory addresses into geometry names

### DIFF
--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -314,27 +314,38 @@ std::unique_ptr<geometry::Shape> ParseGeometry(const XMLElement* node,
       "does not have a recognizable shape type", node->GetLineNum()));
 }
 
-std::string MakeGeometryName(const std::string& basename,
-                             const XMLElement* node) {
-  using std::hex;
-  using std::setfill;
-  using std::setw;
-
-  // Append the address spelled like "@0123456789abcdef".
-  intptr_t address = reinterpret_cast<intptr_t>(node);
-  std::ostringstream result;
-  result << basename << '@' << setfill('0') << setw(16) << hex << address;
-  return result.str();
+// The goal here is to invent a name that will be unique within the enclosing
+// body (i.e., link). To be as useful as possible, we'll use the shape name as
+// the geometry name, and then tack on a number if necessary to be unique.
+//
+// TODO(jwnimmer-tri) The "tack on a number" heuristic might fail if the user
+// mixes named and unnamed geometry within the same link and they happen to
+// use the shape name. We should probably try to handle this in the outer
+// parsing loop during ParseBody (by detecting the name collision). For now,
+// though, that doesn't seem worth dealing with yet.
+std::string MakeDefaultGeometryName(
+    const geometry::Shape& shape,
+    const std::unordered_set<std::string>& geometry_names) {
+  const std::string shape_name = geometry::ShapeName(shape).name();
+  if (geometry_names.count(shape_name) == 0) {
+    return shape_name;
+  }
+  for (int i = 1; i < 10000; ++i) {
+    std::string guess = fmt::format("{}{}", shape_name, i);
+    if (geometry_names.count(guess) == 0) {
+      return guess;
+    }
+  }
+  throw std::runtime_error("Too may identical geometries with default names.");
 }
 
 }  // namespace
 
 // Parses a "visual" element in @p node.
-geometry::GeometryInstance ParseVisual(const std::string& parent_element_name,
-                                       const PackageMap& package_map,
-                                       const std::string& root_dir,
-                                       const XMLElement* node,
-                                       MaterialMap* materials) {
+geometry::GeometryInstance ParseVisual(
+    const std::string& parent_element_name, const PackageMap& package_map,
+    const std::string& root_dir, const XMLElement* node,
+    MaterialMap* materials, std::unordered_set<std::string>* geometry_names) {
   if (std::string(node->Name()) != "visual") {
     throw std::runtime_error("In link " + parent_element_name +
                              " expected visual element, got " + node->Name());
@@ -402,8 +413,9 @@ geometry::GeometryInstance ParseVisual(const std::string& parent_element_name,
 
   std::string geometry_name;
   if (!ParseStringAttribute(node, "name", &geometry_name)) {
-    geometry_name = MakeGeometryName(parent_element_name + "_Visual", node);
+    geometry_name = MakeDefaultGeometryName(*shape, *geometry_names);
   }
+  geometry_names->insert(geometry_name);
 
   auto instance = geometry::GeometryInstance(T_element_to_link,
                                              std::move(shape), geometry_name);
@@ -486,7 +498,8 @@ CoulombFriction<double> ParseCoulombFrictionFromDrakeCompliance(
 // @param[out] friction Coulomb friction for the associated geometry.
 geometry::GeometryInstance ParseCollision(
     const std::string& parent_element_name, const PackageMap& package_map,
-    const std::string& root_dir, const XMLElement* node) {
+    const std::string& root_dir, const XMLElement* node,
+    std::unordered_set<std::string>* geometry_names) {
   if (std::string(node->Name()) != "collision") {
     throw std::runtime_error(
         fmt::format("In link '{}' expected collision element, got {}",
@@ -603,8 +616,9 @@ geometry::GeometryInstance ParseCollision(
 
   std::string geometry_name;
   if (!ParseStringAttribute(node, "name", &geometry_name)) {
-    geometry_name = MakeGeometryName(parent_element_name + "_Collision", node);
+    geometry_name = MakeDefaultGeometryName(*shape, *geometry_names);
   }
+  geometry_names->insert(geometry_name);
 
   geometry::GeometryInstance instance(T_element_to_link, std::move(shape),
                                       geometry_name);

--- a/multibody/parsing/detail_urdf_geometry.h
+++ b/multibody/parsing/detail_urdf_geometry.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <unordered_set>
 #include <utility>
 
 #include <Eigen/Dense>
@@ -122,17 +123,20 @@ UrdfMaterial ParseMaterial(const tinyxml2::XMLElement* node, bool name_required,
  This feature is one way to provide multiple visual representations of a body.
 
  @param[in] parent_element_name The name of the parent link element, used
- to construct default geometry names and for error reporting.
+ for error reporting.
  @param[in,out] materials The MaterialMap is used to look up materials
  which are referenced by name only in the visual element.  New materials
  which are specified by both color and name will be added to the map and
  can be used by later visual elements.  Material definitions may be
- repeated if the material properties are identical. */
+ repeated if the material properties are identical.
+ @param[in,out] geometry_names The list of geometry names already used within
+ the current MbP body (i.e., link), so that this function can be sure not to
+ reuse an already-used name. The name used by this geometry is added to it. */
 geometry::GeometryInstance ParseVisual(
     const std::string& parent_element_name,
     const PackageMap& package_map,
     const std::string& root_dir, const tinyxml2::XMLElement* node,
-    MaterialMap* materials);
+    MaterialMap* materials, std::unordered_set<std::string>* geometry_names);
 
 /* @anchor urdf_contact_material
  Parses a <collision> element in @p node.
@@ -192,14 +196,18 @@ geometry::GeometryInstance ParseVisual(
  the ('material', 'coulomb_friction') property.
 
  @param[in] parent_element_name The name of the parent link element, used
- to construct default geometry names and for error reporting.
+ for error reporting.
  @param[in] package_map The map used to resolve paths.
  @param[in] root_dir The root directory of the containing URDF file.
- @param[in] node The node corresponding to the <collision> tag. */
+ @param[in] node The node corresponding to the <collision> tag.
+ @param[in,out] geometry_names The list of geometry names already used within
+ the current MbP body (i.e., link), so that this function can be sure not to
+ reuse an already-used name. The name used by this geometry is added to it. */
 geometry::GeometryInstance ParseCollision(
     const std::string& parent_element_name,
     const PackageMap& package_map,
-    const std::string& root_dir, const tinyxml2::XMLElement* node);
+    const std::string& root_dir, const tinyxml2::XMLElement* node,
+    std::unordered_set<std::string>* geometry_names);
 
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -7,6 +7,7 @@
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <variant>
 
@@ -149,12 +150,14 @@ void ParseBody(const multibody::PackageMap& package_map,
 
   if (plant->geometry_source_is_registered()) {
     const RigidBody<double>& body = *body_pointer;
+    std::unordered_set<std::string> geometry_names;
 
     for (XMLElement* visual_node = node->FirstChildElement("visual");
          visual_node;
          visual_node = visual_node->NextSiblingElement("visual")) {
       geometry::GeometryInstance geometry_instance =
-          ParseVisual(body_name, package_map, root_dir, visual_node, materials);
+          ParseVisual(body_name, package_map, root_dir, visual_node, materials,
+                      &geometry_names);
       // The parsing should *always* produce an IllustrationProperties
       // instance, even if it is empty.
       DRAKE_DEMAND(geometry_instance.illustration_properties() != nullptr);
@@ -168,7 +171,8 @@ void ParseBody(const multibody::PackageMap& package_map,
          collision_node;
          collision_node = collision_node->NextSiblingElement("collision")) {
       geometry::GeometryInstance geometry_instance =
-          ParseCollision(body_name, package_map, root_dir, collision_node);
+          ParseCollision(body_name, package_map, root_dir, collision_node,
+          &geometry_names);
       DRAKE_DEMAND(geometry_instance.proximity_properties() != nullptr);
       plant->RegisterCollisionGeometry(
           body, geometry_instance.pose(), geometry_instance.shape(),

--- a/multibody/parsing/test/urdf_parser_test/two_unnamed_boxes.urdf
+++ b/multibody/parsing/test/urdf_parser_test/two_unnamed_boxes.urdf
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<robot name="two_unnamed_boxes">
+  <link name="base_link">
+    <collision>
+      <geometry>
+        <box size=".1 .2 .3"/>
+      </geometry>
+    </collision>
+    <collision>
+      <geometry>
+        <box size=".3 .2 .1"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>


### PR DESCRIPTION
Towards #16493.

Here's one specific example of the new names:
![image](https://user-images.githubusercontent.com/17596505/152275523-7dc91750-fee5-4ed4-8421-f0f698639c0f.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16499)
<!-- Reviewable:end -->
