### PR TITLE
[geometry/dev] Only use one endpoint between the client and server.

### DIFF
--- a/geometry/render/dev/render_client_gltf.h
+++ b/geometry/render/dev/render_client_gltf.h
@@ -73,16 +73,6 @@ class RenderClientGltf : public RenderEngineVtk, public RenderClient {
   glTF file, returning the path to the newly exported file. */
   std::string ExportScene(internal::ImageType image_type,
                           int64_t scene_id) const;
-
-  /* Upload and render the scene described by `scene_path` for the associated
-  camera `core` and `image_type`.  Both `min_depth` and `max_depth` must be
-  supplied with `image_type=depth`.  The returned value is the path to the image
-  file on disk ready to be loaded into a drake image buffer. */
-  std::string UploadAndRender(const RenderCameraCore& core,
-                              internal::ImageType image_type,
-                              const std::string& scene_path,
-                              double min_depth = -1.0,
-                              double max_depth = -1.0) const;
 };
 
 }  // namespace render

--- a/geometry/render/dev/render_client_gltf_factory.h
+++ b/geometry/render/dev/render_client_gltf_factory.h
@@ -23,9 +23,6 @@ struct RenderClientGltfParams {
    `0` implies no port level communication is needed. */
   int32_t port{8000};
 
-  /** The RenderClient::upload_endpoint() to upload scene files to. */
-  std::string upload_endpoint{"upload"};
-
   /** The RenderClient::render_endpoint() to retrieve renderings from. */
   std::string render_endpoint{"render"};
 


### PR DESCRIPTION
- Remove `upload_endpoint_` and related fields from `RenderClient`,
  `RenderClientGltf`, and `RenderClientGltfParams`.
- Rename `RenderClient` method `RetrieveRender` to `RenderOnServer`, simplify
  parameters.
- Render server API updates:
    - `<input type="file">` form field `data` renamed to `scene`.
    - Field `id` renamed to `scene_sha256`.
    - Added additional documentation on README about the relationship between
      `"cameras"` and `"nodes"` arrays in the glTF specification.
- Render server implementation updates:
    - Only implement one endpoint for the client, /render.
    - Introduce `RenderRequest` and related helper classes / methods to simplify
      `<form>` validation code-reuse.
        - `RenderError` is the preferred form of communicating any problems.
    - Add `NO_CLEANUP` developer switch, make all other constants upper-case.
        - render_endpoint will delete the .gltf scene file after complete.
        - send_file prevents image file deletion, delete all files in cache
          older than five minutes upon new request.

Fixes #16455.  Fixes #16457.  Adding additional comments in review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16504)
<!-- Reviewable:end -->
