### PR TITLE
[test_utilities] Deprecate checking the specific exception subtype

### DIFF
--- a/bindings/pydrake/common/test/cpp_template_pybind_test.cc
+++ b/bindings/pydrake/common/test/cpp_template_pybind_test.cc
@@ -71,7 +71,6 @@ GTEST_TEST(CppTemplateTest, TemplateClass) {
   // Python re's DOTALL flag. `[\s\S]` *should* work, but Apple LLVM 10.0.0
   // does not work with it.
   DRAKE_EXPECT_THROWS_MESSAGE(py::eval("simple_func('incorrect value')"),
-      std::runtime_error,
       R"([^\0]*incompatible function arguments[^\0]*\(arg0: __main__\.SimpleTemplate\[int\]\)[^\0]*)");  // NOLINT
 
   // Add dummy constructors to check __call__ pseudo-deduction.

--- a/lcm/test/drake_lcm_interface_test.cc
+++ b/lcm/test/drake_lcm_interface_test.cc
@@ -81,7 +81,6 @@ TEST_F(DrakeLcmInterfaceTest, DefaultErrorHandlingTest) {
   lcm_.Publish(channel_, corrupt_bytes.data(), corrupt_bytes.size(), {});
   DRAKE_EXPECT_THROWS_MESSAGE(
       lcm_.HandleSubscriptions(0),
-      std::runtime_error,
       "Error decoding message on NAME");
   EXPECT_TRUE(CompareLcmtDrakeSignalMessages(received, Message{}));
   received = {};

--- a/lcm/test/lcm_messages_test.cc
+++ b/lcm/test/lcm_messages_test.cc
@@ -33,7 +33,6 @@ GTEST_TEST(LcmMessagesTest, DecodeLcmMessageError) {
   corrupt_bytes.at(0) = 0;
   DRAKE_EXPECT_THROWS_MESSAGE(
       DecodeLcmMessage<lcmt_drake_signal>(corrupt_bytes),
-      std::runtime_error,
       "Error decoding message of type 'drake::lcmt_drake_signal'");
 }
 

--- a/math/test/roll_pitch_yaw_test.cc
+++ b/math/test/roll_pitch_yaw_test.cc
@@ -222,7 +222,7 @@ GTEST_TEST(RollPitchYaw, CalcAngularVelocityFromRpyDtAndViceVersa) {
   const RollPitchYaw<double> rpyA(0.2, M_PI / 2, 0.4);
   DRAKE_EXPECT_THROWS_MESSAGE(
       rpyA.CalcMatrixRelatingRpyDtToAngularVelocityInParent(),
-      std::runtime_error, expected_messageA);
+      expected_messageA);
 
   // Now test the inverse relationship.
   const Vector3d rpyDt_calculated =
@@ -236,27 +236,27 @@ GTEST_TEST(RollPitchYaw, CalcAngularVelocityFromRpyDtAndViceVersa) {
       ".*gimbal-lock.*"
       "roll_pitch_yaw.h.*";
   DRAKE_EXPECT_THROWS_MESSAGE(rpyA.CalcRpyDtFromAngularVelocityInParent(w_AD_A),
-                              std::runtime_error, expected_messageB);
+                              expected_messageB);
 
   const RollPitchYaw<double> rpyB(0.2, -M_PI / 2, 0.4);
   DRAKE_EXPECT_THROWS_MESSAGE(rpyB.CalcRpyDtFromAngularVelocityInParent(w_AD_A),
-                              std::runtime_error, expected_messageB);
+                              expected_messageB);
 
   const RollPitchYaw<double> rpyC(0.2, 3 * M_PI / 2, 0.4);
   DRAKE_EXPECT_THROWS_MESSAGE(rpyC.CalcRpyDtFromAngularVelocityInParent(w_AD_A),
-                              std::runtime_error, expected_messageB);
+                              expected_messageB);
 
   const RollPitchYaw<double> rpyD(0.2, -3 * M_PI / 2, 0.4);
   DRAKE_EXPECT_THROWS_MESSAGE(rpyD.CalcRpyDtFromAngularVelocityInParent(w_AD_A),
-                              std::runtime_error, expected_messageB);
+                              expected_messageB);
 
   const RollPitchYaw<double> rpyE(0.2, 3 * M_PI / 2 + 1E-8, 0.4);
   DRAKE_EXPECT_THROWS_MESSAGE(rpyE.CalcRpyDtFromAngularVelocityInParent(w_AD_A),
-                              std::runtime_error, expected_messageB);
+                              expected_messageB);
 
   const RollPitchYaw<double> rpyF(0.2, -3 * M_PI / 2 + 1E-8, 0.4);
   DRAKE_EXPECT_THROWS_MESSAGE(rpyF.CalcRpyDtFromAngularVelocityInParent(w_AD_A),
-                              std::runtime_error, expected_messageB);
+                              expected_messageB);
 }
 
 // Test accuracy of back-and-forth conversion from angular velocity to rpyDt
@@ -284,13 +284,13 @@ GTEST_TEST(RollPitchYaw, PrecisionOfAngularVelocityFromRpyDtAndViceVersa) {
           ".*gimbal-lock.*";
       DRAKE_EXPECT_THROWS_MESSAGE(
           rpyDt = rpy.CalcRpyDtFromAngularVelocityInParent(wA),
-          std::runtime_error, expected_message);
+          expected_message);
       expected_message =
           "RollPitchYaw::CalcRpyDDtFromRpyDtAndAngularAccelInParent()"
           ".*gimbal-lock.*";
       DRAKE_EXPECT_THROWS_MESSAGE(rpyDDt =
         rpy.CalcRpyDDtFromRpyDtAndAngularAccelInParent(rpyDt, alphaA),
-        std::runtime_error, expected_message);
+        expected_message);
     } else {
       ++number_of_precise_cases;
       rpyDt = rpy.CalcRpyDtFromAngularVelocityInParent(wA);
@@ -386,12 +386,12 @@ GTEST_TEST(RollPitchYaw, CalcRpyDDtFromAngularAccel) {
               ".*gimbal-lock.*";
           DRAKE_EXPECT_THROWS_MESSAGE(rpyDDt =
              rpy.CalcRpyDDtFromRpyDtAndAngularAccelInParent(rpyDt, alpha_AD_A),
-             std::runtime_error, expected_message);
+             expected_message);
           expected_message = "RollPitchYaw::CalcRpyDDtFromAngularAccelInChild()"
                              ".*gimbal-lock.*";
           DRAKE_EXPECT_THROWS_MESSAGE(rpyDDt_verify =
              rpy.CalcRpyDDtFromAngularAccelInChild(rpyDt, alpha_AD_D),
-             std::runtime_error, expected_message);
+             expected_message);
           continue;
         }
 

--- a/math/test/rotation_matrix_test.cc
+++ b/math/test/rotation_matrix_test.cc
@@ -43,7 +43,7 @@ GTEST_TEST(RotationMatrix, RotationMatrixConstructor) {
          4, 5,  6,
          7, 8, -10;
     DRAKE_EXPECT_THROWS_MESSAGE(
-        RotationMatrix<double>{m}, std::logic_error,
+        RotationMatrix<double>{m},
         "Error: Rotation matrix is not orthonormal[\\s\\S]*");
 
     // Barely non-orthogonal matrix should throw an exception.
@@ -51,7 +51,7 @@ GTEST_TEST(RotationMatrix, RotationMatrixConstructor) {
          0, cos_theta, sin_theta,
          0, -sin_theta, cos_theta;
     DRAKE_EXPECT_THROWS_MESSAGE(
-        RotationMatrix<double>{m}, std::logic_error,
+        RotationMatrix<double>{m},
         "Error: Rotation matrix is not orthonormal[\\s\\S]*");
 
     // Orthogonal matrix with determinant = -1 should throw an exception.
@@ -59,21 +59,21 @@ GTEST_TEST(RotationMatrix, RotationMatrixConstructor) {
          0, 1, 0,
          0, 0, -1;
     DRAKE_EXPECT_THROWS_MESSAGE(
-        RotationMatrix<double>{m}, std::logic_error,
+        RotationMatrix<double>{m},
         "Error: Rotation matrix determinant is negative.*");
 
     // Matrix with a NaN should throw an exception.
     m << 1, 0, 0,
          0, 1, 0,
          0, 0, std::numeric_limits<double>::quiet_NaN();
-    DRAKE_EXPECT_THROWS_MESSAGE(RotationMatrix<double>{m}, std::logic_error,
+    DRAKE_EXPECT_THROWS_MESSAGE(RotationMatrix<double>{m},
         "Error: Rotation matrix contains an element that is infinity or NaN.*");
 
     // Matrix with an infinity should throw an exception.
     m << 1, 0, 0,
          0, 1, 0,
          0, 0, std::numeric_limits<double>::infinity();
-    DRAKE_EXPECT_THROWS_MESSAGE(RotationMatrix<double>{m}, std::logic_error,
+    DRAKE_EXPECT_THROWS_MESSAGE(RotationMatrix<double>{m},
         "Error: Rotation matrix contains an element that is infinity or NaN.*");
   }
 }
@@ -130,43 +130,39 @@ GTEST_TEST(RotationMatrix, MakeFromOrthonormalRowsOrColumns) {
   // Non-orthogonal matrix should throw an exception (at least in debug builds).
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
       R = RotationMatrix<double>::MakeFromOrthonormalRows(Fx, Fy, Fz),
-      std::logic_error, "Error: Rotation matrix is not orthonormal[\\s\\S]*");
+      "Error: Rotation matrix is not orthonormal[\\s\\S]*");
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
       R = RotationMatrix<double>::MakeFromOrthonormalColumns(Fx, Fy, Fz),
-      std::logic_error, "Error: Rotation matrix is not orthonormal[\\s\\S]*");
+      "Error: Rotation matrix is not orthonormal[\\s\\S]*");
 
   // Non-right handed matrix with determinant < 0 should throw an exception.
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
       R = RotationMatrix<double>::MakeFromOrthonormalRows(
-          Vector3d(-1, 0, 0), Fy, Fz), std::logic_error,
+          Vector3d(-1, 0, 0), Fy, Fz),
       "Error: Rotation matrix determinant is negative.*");
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
       R = RotationMatrix<double>::MakeFromOrthonormalColumns(
-          Vector3d(-1, 0, 0), Fy, Fz), std::logic_error,
+          Vector3d(-1, 0, 0), Fy, Fz),
       "Error: Rotation matrix determinant is negative.*");
 
   // Matrix with a NaN should throw an exception.
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
       R = RotationMatrix<double>::MakeFromOrthonormalRows(
           Vector3d(std::numeric_limits<double>::quiet_NaN(), 0, 0), Fy, Fz),
-      std::logic_error,
       "Error: Rotation matrix contains an element that is infinity or NaN.*");
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
       R = RotationMatrix<double>::MakeFromOrthonormalColumns(
           Vector3d(std::numeric_limits<double>::quiet_NaN(), 0, 0), Fy, Fz),
-          std::logic_error,
         "Error: Rotation matrix contains an element that is infinity or NaN.*");
 
   // Matrix with an infinity should throw an exception.
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
       R = RotationMatrix<double>::MakeFromOrthonormalRows(
           Vector3d(std::numeric_limits<double>::infinity(), 0, 0), Fy, Fz),
-      std::logic_error,
       "Error: Rotation matrix contains an element that is infinity or NaN.*");
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
       R = RotationMatrix<double>::MakeFromOrthonormalColumns(
           Vector3d(std::numeric_limits<double>::infinity(), 0, 0), Fy, Fz),
-          std::logic_error,
         "Error: Rotation matrix contains an element that is infinity or NaN.*");
 
   if (kDrakeAssertIsDisarmed) {
@@ -727,7 +723,6 @@ GTEST_TEST(RotationMatrix, SymbolicProjectionTest) {
   Expression quality;
   DRAKE_EXPECT_THROWS_MESSAGE(
       RotMatExpr::ProjectToRotationMatrix(m_symbolic, &quality),
-      std::runtime_error,
       ".*environment does not have an entry for the variable.*\n*");
 
   // Removing the free variable allows us to succeed.
@@ -926,7 +921,7 @@ GTEST_TEST(RotationMatrixTest, OperatorMultiplyByMatrix3X) {
     Eigen::MatrixXd bad_matrix_multiply;
     EXPECT_THROW(bad_matrix_multiply = R_AB * m_7x8, std::logic_error);
     DRAKE_EXPECT_THROWS_MESSAGE(
-        bad_matrix_multiply = R_AB * m_7x8, std::logic_error,
+        bad_matrix_multiply = R_AB * m_7x8,
         "Error: Inner dimension for matrix multiplication is not 3.");
   }
 }

--- a/tools/vector_gen/test/sample_test.cc
+++ b/tools/vector_gen/test/sample_test.cc
@@ -132,7 +132,7 @@ GTEST_TEST(SampleTest, Move) {
   // Move construction.  The heap storage of `first` is stolen.
   Sample<double> second(std::move(first));
   EXPECT_EQ(first.size(), 0);
-  DRAKE_EXPECT_THROWS_MESSAGE(first.x(), std::out_of_range, ".*moved-from.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(first.x(), ".*moved-from.*");
   EXPECT_EQ(second.size(), nominal_size);
   EXPECT_EQ(second.x(), 1.0);
   EXPECT_EQ(&second.x(), original_storage);
@@ -143,7 +143,7 @@ GTEST_TEST(SampleTest, Move) {
   DRAKE_DEMAND(third.x() != 1.0);  // Prove that assignment will change this.
   third = std::move(second);
   EXPECT_EQ(second.size(), 0);
-  DRAKE_EXPECT_THROWS_MESSAGE(second.x(), std::out_of_range, ".*moved-from.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(second.x(), ".*moved-from.*");
   EXPECT_EQ(third.size(), nominal_size);
   EXPECT_EQ(third.x(), 1.0);
   EXPECT_EQ(&third.x(), original_storage);


### PR DESCRIPTION
Checking the exception class in `DRAKE_EXPECT_THROWS_MESSAGE` is just asking for trouble, when our [GSG says not to (except very rarely)](https://drake.mit.edu/styleguide/cppguide.html#Exceptions).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16514)
<!-- Reviewable:end -->
