### PR TITLE
[doc] Document Hunt and Crossley-inspired dissipation model

### DIFF
--- a/multibody/parsing/parsing_doxygen.h
+++ b/multibody/parsing/parsing_doxygen.h
@@ -367,12 +367,10 @@ units of 1/m for prismatic joints.
 If present, this element provides a value (units of inverse of velocity,
 i.e. s/m) for the Hunt-Crossley dissipation model. It is stored in a
 ProximityProperties object under `(material, hunt_crossley_dissipation)`.
-<!-- TODO(rpoyner-tri): Find a home for @amcastro's theory documentation, discussed
-     in #16444. -->
 
 @see drake::geometry::ProximityProperties,
 @ref mbp_hydroelastic_materials_properties "Hydroelastic contact",
-@ref MODULE_NOT_WRITTEN_YET
+@ref mbp_dissipation_model "Modeling Dissipation"
 
 @subsection tag_drake_hydroelastic_modulus drake:hydroelastic_modulus
 


### PR DESCRIPTION
Detour from: #13314, PR #16444

@amcastro gave a very nice theory lesson on dissipation in a recent PR
discussion. This patch puts that lesson in a (somewhat) reasonable
location.

Also, the patch fixes a bunch of long-festering typos.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16517)
<!-- Reviewable:end -->
