### PR TITLE
WIP: [workspace] Patch vtkGLTFExporter Camera Matrix

### DIFF
--- a/geometry/render/dev/render_client_gltf.h
+++ b/geometry/render/dev/render_client_gltf.h
@@ -37,9 +37,6 @@ class RenderClientGltf : public RenderEngineVtk, public RenderClient {
   RenderClientGltf(
       const RenderClientGltfParams& parameters = RenderClientGltfParams());
 
-  // TODO(svenevs): remove this once vtkGLTFExporter is patched to invert.
-  void UpdateViewpoint(const math::RigidTransformd& X_WC) override;
-
  protected:
   /** Copy constructor for the purpose of cloning. */
   RenderClientGltf(const RenderClientGltf& other);

--- a/tools/wheel/Dockerfile
+++ b/tools/wheel/Dockerfile
@@ -26,6 +26,7 @@ ADD image/build-dependencies.sh /image/
 RUN /image/build-dependencies.sh
 
 ADD image/build-vtk.sh /image/
+ADD image/vtk-patches/* /vtk/patches/
 ADD image/vtk-args /vtk/
 
 RUN /image/build-vtk.sh

--- a/tools/wheel/image/build-vtk.sh
+++ b/tools/wheel/image/build-vtk.sh
@@ -14,6 +14,9 @@ git clone \
     --branch v${VTK_VERSION} --depth 1 \
     https://gitlab.kitware.com/vtk/vtk.git src
 
+cd /vtk/src
+git apply /vtk/patches/*.patch
+
 mkdir -p /vtk/build
 cd /vtk/build
 

--- a/tools/wheel/image/vtk-patches/0001-gltf-export-camera-matrix.patch
+++ b/tools/wheel/image/vtk-patches/0001-gltf-export-camera-matrix.patch
@@ -1,0 +1,24 @@
+--- a/IO/Export/vtkGLTFExporter.cxx
++++ b/IO/Export/vtkGLTFExporter.cxx
+@@ -553,14 +553,20 @@ void vtkGLTFExporter::WriteToStream(ostream& output)
+     }
+ 
+     // setup the camera data in case we need to use it later
++    // the glTF "nodes" list stores global transformations for objects in the
++    // scene, so we need to invert the ModelViewTransformMatrix of the camera
++    // (by a copy, to avoid mutating the renderer's camera)
+     Json::Value anode;
+     anode["camera"] = cameras.size(); // camera node
+     vtkMatrix4x4* mat = ren->GetActiveCamera()->GetModelViewTransformMatrix();
++    vtkNew<vtkMatrix4x4> inv;
++    inv->DeepCopy(mat);
++    inv->Invert();
+     for (int i = 0; i < 4; ++i)
+     {
+       for (int j = 0; j < 4; ++j)
+       {
+-        anode["matrix"].append(mat->GetElement(j, i));
++        anode["matrix"].append(inv->GetElement(j, i));
+       }
+     }
+     anode["name"] = "Camera Node";

--- a/tools/workspace/vtk/Dockerfile
+++ b/tools/workspace/vtk/Dockerfile
@@ -23,6 +23,7 @@ RUN /image/provision.sh
 FROM base AS vtk
 
 ADD image/build-vtk.sh /image/
+ADD image/patches/* /vtk/patches/
 ADD image/vtk-args /vtk/
 
 RUN /image/build-vtk.sh

--- a/tools/workspace/vtk/image/build-vtk.sh
+++ b/tools/workspace/vtk/image/build-vtk.sh
@@ -11,6 +11,9 @@ git clone \
     --branch v${VTK_VERSION} --depth 1 \
     https://gitlab.kitware.com/vtk/vtk.git src
 
+cd /vtk/src
+git apply /vtk/patches/*.patch
+
 mkdir -p /vtk/build
 cd /vtk/build
 

--- a/tools/workspace/vtk/image/package.sh
+++ b/tools/workspace/vtk/image/package.sh
@@ -6,7 +6,7 @@ set -eu -o pipefail
 readonly vtk_tag=vtk-9.1.0
 # To re-package, increase build_number by 1 and update repository.bzl to avoid
 # overwriting artifacts thus breaking historical builds.
-readonly build_number=1
+readonly build_number=2
 readonly platform=$(lsb_release --codename --short)-$(uname --processor)
 
 # Create archive named:

--- a/tools/workspace/vtk/image/patches/0001-gltf-export-camera-matrix.patch
+++ b/tools/workspace/vtk/image/patches/0001-gltf-export-camera-matrix.patch
@@ -1,0 +1,24 @@
+--- a/IO/Export/vtkGLTFExporter.cxx
++++ b/IO/Export/vtkGLTFExporter.cxx
+@@ -553,14 +553,20 @@ void vtkGLTFExporter::WriteToStream(ostream& output)
+     }
+ 
+     // setup the camera data in case we need to use it later
++    // the glTF "nodes" list stores global transformations for objects in the
++    // scene, so we need to invert the ModelViewTransformMatrix of the camera
++    // (by a copy, to avoid mutating the renderer's camera)
+     Json::Value anode;
+     anode["camera"] = cameras.size(); // camera node
+     vtkMatrix4x4* mat = ren->GetActiveCamera()->GetModelViewTransformMatrix();
++    vtkNew<vtkMatrix4x4> inv;
++    inv->DeepCopy(mat);
++    inv->Invert();
+     for (int i = 0; i < 4; ++i)
+     {
+       for (int j = 0; j < 4; ++j)
+       {
+-        anode["matrix"].append(mat->GetElement(j, i));
++        anode["matrix"].append(inv->GetElement(j, i));
+       }
+     }
+     anode["name"] = "Camera Node";

--- a/tools/workspace/vtk/repository.bzl
+++ b/tools/workspace/vtk/repository.bzl
@@ -118,11 +118,11 @@ def _impl(repository_ctx):
         ), "include")
     elif os_result.is_ubuntu:
         if os_result.ubuntu_release == "18.04":
-            archive = "vtk-9.1.0-1-bionic-x86_64.tar.gz"
-            sha256 = "1b51691d09c9fa77a74ad237fe320fed606e071f732f10645efeffa859352bb6"  # noqa
+            archive = "vtk-9.1.0-2-bionic-x86_64.tar.gz"
+            sha256 = "5d9f98533e8a2dfb9bdcc81b75c605bf728d29ebb9622a58d31f1aff12a95f90"  # noqa
         elif os_result.ubuntu_release == "20.04":
-            archive = "vtk-9.1.0-1-focal-x86_64.tar.gz"
-            sha256 = "b21e8b98ad71da205305bc074d8e3d4208e9dff307ae716384cefb4d1e606d2f"  # noqa
+            archive = "vtk-9.1.0-2-focal-x86_64.tar.gz"
+            sha256 = "a6f3379b1f0d308ae9c3209d88a42a29e9121b63a53adeafac344b1207a5e400"  # noqa
         else:
             fail("Operating system is NOT supported {}".format(os_result))
 


### PR DESCRIPTION
- [X] Add glTF export patch to `tools/workspace/vtk` build system.
- [X] Upload new VTK artifacts to `drake-packages` S3 bucket.
- [X] Patch VTK for wheel builds.
- [X] Remove `RenderClientGltf::UpdateViewpoint` inversion workaround now that VTK is patched.
- [ ] Patch macOS bottles.
   - [ ] Test on fork by modifying `setup/` tap and unprovisioned macOS.
   - [ ] Undo this change after updating provisioned images.
- [ ] Wait until upstream patch is finalized: https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8883
- [ ] Squash and rebase commits when everything is ready.
- [ ] Question: would we rather symlink `tools/wheel/image/vtk-patches` to `tools/workspace/image/vtk-patches`?  I can see arguments in favor of both.

Adding PR now to test CI packaging tests (core, wheel, macOS soon).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16519)
<!-- Reviewable:end -->
