### PR TITLE
Enable CLP in pip build

### DIFF
--- a/tools/wheel/image/build-drake.sh
+++ b/tools/wheel/image/build-drake.sh
@@ -13,7 +13,6 @@ bazel run \
     --repository_cache=/var/cache/bazel/repository_cache \
     --repo_env=DRAKE_OS=manylinux \
     --define NO_DRAKE_VISUALIZER=ON \
-    --define NO_CLP=ON \
     --define NO_IPOPT=ON \
     --define NO_DREAL=ON \
     --define WITH_SNOPT=ON \

--- a/tools/wheel/image/dependencies/projects.cmake
+++ b/tools/wheel/image/dependencies/projects.cmake
@@ -106,7 +106,18 @@ set(suitesparse_url "http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-$
 set(SuiteSparse_md5 "a2926c27f8a5285e4a10265cc68bbc18")
 list(APPEND ALL_PROJECTS suitesparse)
 
-# clp (TODO)
+# coinutils
+set(coinutils_version 2.11.4)
+set(coinutils_url "https://github.com/coin-or/CoinUtils/archive/refs/tags/releases/${coinutils_version}.tar.gz")
+set(coinutils_md5 "dcdb2a327344014de9d8b050575fa90b")
+set(coinutils_dlname "coinutils-${coinutils_version}.tar.gz")
+list(APPEND ALL_PROJECTS coinutils)
+
+# clp
+set(clp_version 1.17.5)
+set(clp_url "https://github.com/coin-or/Clp/archive/refs/tags/releases/${clp_version}.tar.gz")
+set(clp_md5 "f7c25af22d2f03398cbbdf38c8b4f6fd")
+set(clp_dlname "clp-${clp_version}.tar.gz")
 list(APPEND ALL_PROJECTS clp)
 
 # ipopt (TODO)

--- a/tools/wheel/image/dependencies/projects/coinutils.cmake
+++ b/tools/wheel/image/dependencies/projects/coinutils.cmake
@@ -1,8 +1,7 @@
-ExternalProject_Add(clp
-    URL ${clp_url}
-    URL_MD5 ${clp_md5}
-    DOWNLOAD_NAME ${clp_dlname}
-    DEPENDS coinutils
+ExternalProject_Add(coinutils
+    URL ${coinutils_url}
+    URL_MD5 ${coinutils_md5}
+    DOWNLOAD_NAME ${coinutils_dlname}
     ${COMMON_EP_ARGS}
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND ./configure
@@ -14,6 +13,6 @@ ExternalProject_Add(clp
     INSTALL_COMMAND make install
     )
 
-extract_license(clp
-    Clp/LICENSE
+extract_license(coinutils
+    CoinUtils/LICENSE
 )

--- a/tools/wheel/image/dependencies/projects/libjpeg-turbo.cmake
+++ b/tools/wheel/image/dependencies/projects/libjpeg-turbo.cmake
@@ -5,7 +5,6 @@ endif()
 ExternalProject_Add(libjpeg-turbo
     URL ${libjpeg-turbo_url}
     URL_MD5 ${libjpeg-turbo_md5}
-    DEPENDS ${libjpeg-turbo_DEPENDS}
     ${COMMON_EP_ARGS}
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND ./configure


### PR DESCRIPTION
Add necessary logic to build clp (and its dependency coinutils) in the pip build. Enable CLP in Drake for the pip build.

Fixes #15969.