### PR TITLE
[doc] Remove non-drake namespaces from Doxygen output

### DIFF
--- a/common/sorted_pair.h
+++ b/common/sorted_pair.h
@@ -203,7 +203,7 @@ struct __is_fast_hash<hash<drake::SortedPair<T>>> : std::false_type {};
 ///    SortedPair<Foo> pair(Foo(1), Foo(2));
 ///    const auto& [a, b] = pair;
 template <typename T>
-struct tuple_size<drake::SortedPair<T>> : integral_constant<size_t, 2> {};
+struct tuple_size<drake::SortedPair<T>> : std::integral_constant<size_t, 2> {};
 
 template <size_t Index, typename T>
 struct tuple_element<Index, drake::SortedPair<T>> {

--- a/geometry/meshcat_types.h
+++ b/geometry/meshcat_types.h
@@ -430,6 +430,8 @@ struct UserInterfaceEvent {
 }  // namespace geometry
 }  // namespace drake
 
+#ifndef DRAKE_DOXYGEN_CXX
+
 MSGPACK_ADD_ENUM(drake::geometry::internal::ThreeSide);
 MSGPACK_ADD_ENUM(drake::geometry::MeshcatAnimation::LoopMode);
 
@@ -547,3 +549,5 @@ struct pack<drake::geometry::Meshcat::PerspectiveCamera> {
 }  // namespace adaptor
 }  // namespace MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
 }  // namespace msgpack
+
+#endif  // DRAKE_DOXYGEN_CXX

--- a/multibody/contact_solvers/supernodal_solver.h
+++ b/multibody/contact_solvers/supernodal_solver.h
@@ -9,11 +9,13 @@
 
 #include "drake/common/drake_copyable.h"
 
+#ifndef DRAKE_DOXYGEN_CXX
 // Forward declaration to avoid the inclusion of conex's headers within a Drake
 // header.
 namespace conex {
 class SupernodalKKTSolver;
 }
+#endif
 
 namespace drake {
 namespace multibody {


### PR DESCRIPTION
Refer to https://drake.mit.edu/doxygen_cxx/namespaces.html to see the leaked namespaces (conex, msgpack) or https://drake.mit.edu/doxygen_cxx/annotated.html to see the leaked classname (integral_constant).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16527)
<!-- Reviewable:end -->
