### PR TITLE
[primitives] Implement LeCun initialization for MultilayerPerceptron

### DIFF
--- a/systems/primitives/multilayer_perceptron.cc
+++ b/systems/primitives/multilayer_perceptron.cc
@@ -135,14 +135,23 @@ const VectorX<T>& MultilayerPerceptron<T>::GetParameters(
 
 template <typename T>
 void MultilayerPerceptron<T>::SetRandomParameters(
-    const Context<T>& context, Parameters<T>* parameters,
+    const Context<T>&, Parameters<T>* parameters,
     RandomGenerator* generator) const {
-  // TODO(russt): Consider more advanced approaches, e.g. Xavier initialization.
-  unused(context);
-  std::normal_distribution<double> normal(0.0, 0.01);
+  std::uniform_real_distribution<double> uniform(-1.0, 1.0);
   BasicVector<T>& params = parameters->get_mutable_numeric_parameter(0);
-  for (int i = 0; i < num_parameters_; ++i) {
-    params[i] = normal(*generator);
+  for (int i = 0; i < num_weights_; ++i) {
+    // We choose m here so that uniform(-m,m) has the desired standard
+    // deviation √1/n, where n is the number of incoming connections.  The
+    // factor of √3 can be derived from the variance of uniform(a,b), which is
+    // (b-a)²/12.
+    double m = std::sqrt(3.0/layers_[i]);
+    for (int n = weight_indices_[i];
+         n < weight_indices_[i] + layers_[i + 1] * layers_[i]; ++n) {
+      params[n] = m*uniform(*generator);
+    }
+    for (int n = bias_indices_[i]; n < bias_indices_[i] + layers_[i + 1]; ++n) {
+      params[n] = m*uniform(*generator);
+    }
   }
 }
 

--- a/systems/primitives/multilayer_perceptron.h
+++ b/systems/primitives/multilayer_perceptron.h
@@ -84,8 +84,12 @@ class MultilayerPerceptron final : public LeafSystem<T> {
   explicit MultilayerPerceptron(const MultilayerPerceptron<U>&);
 
   /** Sets all of the parameters (all weights and biases) in the `parameters`
-   from a zero-mean, 0.01*unit-covariance Gaussian distribution. This is
-   typically called via System<T>::SetRandomContext. By contrast,
+   using the "LeCun initialization": a uniform distribution with mean zero and
+   standard deviation √(1/m), where m is the number of connections feeding into
+   the corresponding node. See eq. (16) in
+   http://yann.lecun.com/exdb/publis/pdf/lecun-98b.pdf .
+
+   This is typically called via System<T>::SetRandomContext. By contrast,
    System<T>::SetDefaultContext will set all weights and biases to zero. */
   void SetRandomParameters(const Context<T>& context, Parameters<T>* parameters,
                            RandomGenerator* generator) const override;


### PR DESCRIPTION
These are the defaults used in PyTorch, and I find that they make a
huge difference in practice compared to the random small numbers I had
before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16529)
<!-- Reviewable:end -->
