### PR TITLE
Enable ipopt in pip build

### DIFF
--- a/tools/wheel/image/build-drake.sh
+++ b/tools/wheel/image/build-drake.sh
@@ -13,7 +13,6 @@ bazel run \
     --repository_cache=/var/cache/bazel/repository_cache \
     --repo_env=DRAKE_OS=manylinux \
     --define NO_DRAKE_VISUALIZER=ON \
-    --define NO_IPOPT=ON \
     --define NO_DREAL=ON \
     --define WITH_SNOPT=ON \
     //:install -- /opt/drake

--- a/tools/wheel/image/dependencies/projects.cmake
+++ b/tools/wheel/image/dependencies/projects.cmake
@@ -120,5 +120,9 @@ set(clp_md5 "f7c25af22d2f03398cbbdf38c8b4f6fd")
 set(clp_dlname "clp-${clp_version}.tar.gz")
 list(APPEND ALL_PROJECTS clp)
 
-# ipopt (TODO)
+# ipopt
+set(ipopt_version 3.11.9)
+set(ipopt_url "https://github.com/coin-or/Ipopt/archive/refs/tags/releases/${ipopt_version}.tar.gz")
+set(ipopt_md5 "55275c202072ad30db25d2b723ef9b7a")
+set(ipopt_dlname "ipopt-${ipopt_version}.tar.gz")
 list(APPEND ALL_PROJECTS ipopt)

--- a/tools/wheel/image/dependencies/projects/ipopt.cmake
+++ b/tools/wheel/image/dependencies/projects/ipopt.cmake
@@ -1,6 +1,21 @@
-# TODO: This is a placeholder to pacify the build
-file(WRITE ${CMAKE_INSTALL_PREFIX}/share/pkgconfig/ipopt.pc
-    "Name: IPOPT\n"
-    "Version: 0\n"
-    "Description:\n"
+ExternalProject_Add(ipopt
+    URL ${ipopt_url}
+    URL_MD5 ${ipopt_md5}
+    DOWNLOAD_NAME ${ipopt_dlname}
+    DEPENDS lapack
+    ${COMMON_EP_ARGS}
+    BUILD_IN_SOURCE 1
+    CONFIGURE_COMMAND ./configure
+        --prefix=${CMAKE_INSTALL_PREFIX}
+        --disable-shared
+        FFLAGS=-fPIC
+        CFLAGS=-fPIC
+        CXXFLAGS=-fPIC
+        LDFLAGS=-L${CMAKE_INSTALL_PREFIX}/lib
+    BUILD_COMMAND make
+    INSTALL_COMMAND make install
     )
+
+extract_license(ipopt
+    Ipopt/LICENSE
+)


### PR DESCRIPTION
Add necessary logic to build ipopt in the pip build, and enable it in Drake for the pip build.

Fixes #15971.

+@jwnimmer-tri for feature review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16532)
<!-- Reviewable:end -->
