### PR TITLE
Suppress vtkRenderWindow TSAN warning

### DIFF
--- a/tools/dynamic_analysis/tsan.supp
+++ b/tools/dynamic_analysis/tsan.supp
@@ -49,6 +49,9 @@ called_from_lib:libembree3.so
 race:__cxa_finalize
 mutex:__cxa_finalize
 
+# Issue #16494.
+race:vtkNew<vtkRenderWindow>::~vtkNew
+
 # In the lcm_memq handler, while correctly holding a mutex it obtains exclusive
 # access to the next message by popping it off of the queue, but then it
 # releases the mutex before passing the message along to the user code.  TSan


### PR DESCRIPTION
Something is causing TSAN to report a data race whenever a `vtkNew<vtkRenderWindow>` is destroyed. As the cause is not clear at this time, suppress the warning for now so CI does not fail.

See also #16494.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16544)
<!-- Reviewable:end -->
