### PR TITLE
Replace RotationMatrix::IsIdentityToInternalTolerance() with RotationMatrix::IsNearlyIdentity().

### DIFF
--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -201,10 +201,18 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.IsValid.doc_0args)
         .def("IsExactlyIdentity", &Class::IsExactlyIdentity,
             cls_doc.IsExactlyIdentity.doc)
+        .def("IsNearlyIdentity", &Class::IsNearlyIdentity, py::arg("tolerance"),
+            cls_doc.IsNearlyIdentity.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
         .def("IsIdentityToInternalTolerance",
-            &Class::IsIdentityToInternalTolerance,
-            cls_doc.IsIdentityToInternalTolerance.doc)
-        // Does not return the quality_factor
+            WrapDeprecated(cls_doc.IsIdentityToInternalTolerance.doc_deprecated,
+                &Class::IsIdentityToInternalTolerance),
+            cls_doc.IsIdentityToInternalTolerance.doc_deprecated);
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
+    cls                     // BR
+                            // Does not return the quality_factor
         .def_static(
             "ProjectToRotationMatrix",
             [](const Matrix3<T>& M) {

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -300,6 +300,7 @@ class TestMath(unittest.TestCase):
         R = RotationMatrix()
         numpy_compare.assert_equal(R.IsExactlyIdentity(), True)
         numpy_compare.assert_equal(R.IsNearlyIdentity(0.0), True)
+        numpy_compare.assert_equal(R.IsNearlyIdentity(tolerance = 1E-15), True)
         # TODO(2022-06-01) Remove with completion of deprecation.
         with catch_drake_warnings(expected_count=1):
             numpy_compare.assert_equal(R.IsIdentityToInternalTolerance(), True)

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -268,7 +268,7 @@ class TestMath(unittest.TestCase):
         self.assertIsInstance(angle_axis, AngleAxis)
         R_AngleAxis = RotationMatrix(angle_axis)
         R_I = R.inverse().multiply(R_AngleAxis)
-        numpy_compare.assert_equal(R_I.IsIdentityToInternalTolerance(), True)
+        numpy_compare.assert_equal(R_I.IsNearlyIdentity(2E-15), True)
         # - Inverse, transpose, projection
         R_I = R.inverse().multiply(R)
         numpy_compare.assert_float_equal(R_I.matrix(), np.eye(3))
@@ -299,7 +299,10 @@ class TestMath(unittest.TestCase):
         numpy_compare.assert_equal(R.IsValid(), True)
         R = RotationMatrix()
         numpy_compare.assert_equal(R.IsExactlyIdentity(), True)
-        numpy_compare.assert_equal(R.IsIdentityToInternalTolerance(), True)
+        numpy_compare.assert_equal(R.IsNearlyIdentity(0.0), True)
+        # TODO(2022-06-01) Remove with completion of deprecation.
+        with catch_drake_warnings(expected_count=1):
+            numpy_compare.assert_equal(R.IsIdentityToInternalTolerance(), True)
         # - Repr.
         z = repr(T(0.0))
         i = repr(T(1.0))

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -300,7 +300,7 @@ class TestMath(unittest.TestCase):
         R = RotationMatrix()
         numpy_compare.assert_equal(R.IsExactlyIdentity(), True)
         numpy_compare.assert_equal(R.IsNearlyIdentity(0.0), True)
-        numpy_compare.assert_equal(R.IsNearlyIdentity(tolerance = 1E-15), True)
+        numpy_compare.assert_equal(R.IsNearlyIdentity(tolerance=1E-15), True)
         # TODO(2022-06-01) Remove with completion of deprecation.
         with catch_drake_warnings(expected_count=1):
             numpy_compare.assert_equal(R.IsIdentityToInternalTolerance(), True)

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -407,13 +407,13 @@ class RigidTransform {
   /// (e.g., the magnitude of a characteristic position vector) by an epsilon
   /// (e.g., RotationMatrix::get_internal_tolerance_for_orthonormality()).
   /// @returns `true` if the RotationMatrix portion of `this` satisfies
-  /// RotationMatrix::IsIdentityToInternalTolerance() and if the position vector
-  /// portion of `this` is equal to zero vector within `translation_tolerance`.
+  /// RotationMatrix::IsNearlyIdentity() and if the position vector portion of
+  /// `this` is equal to zero vector within `translation_tolerance`.
   /// @see IsExactlyIdentity().
   boolean<T> IsNearlyIdentity(double translation_tolerance) const {
     const T max_component = translation().template lpNorm<Eigen::Infinity>();
     return max_component <= translation_tolerance &&
-        rotation().IsIdentityToInternalTolerance();
+        rotation().IsNearlyIdentity();
   }
 
   DRAKE_DEPRECATED("2022-06-01", "Use RigidTransform::IsNearlyIdentity()")

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -12,6 +12,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/never_destroyed.h"
@@ -42,13 +43,12 @@ struct DoNotInitializeMemberFields {};
 /// @note This class does not store the frames associated with a rotation matrix
 /// nor does it enforce strict proper usage of this class with vectors.
 ///
-/// @note When assertions are enabled, several methods in this class
-/// do a validity check and throw an exception (std::exception) if the
-/// rotation matrix is invalid.  When assertions are disabled,
-/// many of these validity checks are skipped (which helps improve speed).
-/// In addition, these validity tests are only performed for scalar types for
-/// which drake::scalar_predicate<T>::is_bool is `true`. For instance, validity
-/// checks are not performed when T is symbolic::Expression.
+/// @note When assertions are enabled, several methods in this class perform a
+/// validity check and throw std::exception if the rotation matrix is invalid.
+/// When assertions are disabled, many of these validity checks are skipped
+/// (which helps improve speed). These validity tests are only performed for
+/// scalar types for which drake::scalar_predicate<T>::is_bool is `true`. For
+/// instance, validity checks are not performed when T is symbolic::Expression.
 ///
 /// @authors Paul Mitiguy (2018) Original author.
 /// @authors Drake team (see https://drake.mit.edu/credits).
@@ -559,15 +559,23 @@ class RotationMatrix {
   boolean<T> IsValid() const { return IsValid(matrix()); }
 
   /// Returns `true` if `this` is exactly equal to the identity matrix.
+  /// @see IsNearlyIdentity().
   boolean<T> IsExactlyIdentity() const {
     return matrix() == Matrix3<T>::Identity();
   }
 
-  /// Returns true if `this` is equal to the identity matrix to within the
-  /// threshold of get_internal_tolerance_for_orthonormality().
+  /// Returns true if `this` is within tolerance of the identity RigidTransform.
+  /// @param[in] tolerance non-negative number that is generally the default
+  /// value, namely RotationMatrix::get_internal_tolerance_for_orthonormality().
+  /// @see IsExactlyIdentity().
+  boolean<T> IsNearlyIdentity(
+      double tolerance = get_internal_tolerance_for_orthonormality()) const {
+    return IsNearlyEqualTo(matrix(), Matrix3<T>::Identity(), tolerance);
+  }
+
+  DRAKE_DEPRECATED("2022-06-01", "Use RotationMatrix::IsNearlyIdentity()")
   boolean<T> IsIdentityToInternalTolerance() const {
-    return IsNearlyEqualTo(matrix(), Matrix3<T>::Identity(),
-                           get_internal_tolerance_for_orthonormality());
+    return IsNearlyIdentity();
   }
 
   /// Compares each element of `this` to the corresponding element of `other`
@@ -576,6 +584,7 @@ class RotationMatrix {
   /// @param[in] tolerance maximum allowable absolute difference between the
   /// matrix elements in `this` and `other`.
   /// @returns `true` if `‖this - other‖∞ <= tolerance`.
+  /// @see IsExactlyEqualTo().
   boolean<T> IsNearlyEqualTo(const RotationMatrix<T>& other,
                              double tolerance) const {
     return IsNearlyEqualTo(matrix(), other.matrix(), tolerance);
@@ -586,6 +595,7 @@ class RotationMatrix {
   /// @param[in] other %RotationMatrix to compare to `this`.
   /// @returns true if each element of `this` is exactly equal to the
   /// corresponding element in `other`.
+  /// @see IsNearlyEqualTo().
   boolean<T> IsExactlyEqualTo(const RotationMatrix<T>& other) const {
     return matrix() == other.matrix();
   }

--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -120,11 +120,11 @@ GTEST_TEST(RigidTransform, ConstructorAndSet) {
   // RotationMatrix class, it is here due to the bug (mentioned below) in
   // EXPECT_THROW.  Contrast the use here of EXPECT_THROW (which does not have
   // an extra set of parentheses around its first argument) with the use of
-  // EXPECT_THROW((RigidTransform<double>(isometryC)), std::logic_error); below.
+  // EXPECT_THROW((RigidTransform<double>(isometryC)), std::exception); below.
   const Matrix3d bad = GetBadRotationMatrix();
   if (kDrakeAssertIsArmed) {
     EXPECT_THROW(RigidTransform<double>(RotationMatrix<double>(bad), p),
-                 std::logic_error);
+                 std::exception);
   }
 }
 
@@ -199,7 +199,7 @@ GTEST_TEST(RigidTransform, ConstructorFromMatrix34) {
 
   if (kDrakeAssertIsArmed) {
     pose(2, 2) += 1E-5;  // Corrupt the last element of the rotation matrix.
-    EXPECT_THROW(RigidTransformd XX(pose), std::logic_error);
+    EXPECT_THROW(RigidTransformd XX(pose), std::exception);
   }
 }
 
@@ -216,13 +216,13 @@ GTEST_TEST(RigidTransform, ConstructorFromMatrix4) {
   if (kDrakeAssertIsArmed) {
     DRAKE_EXPECT_NO_THROW(RigidTransformd Xm(pose));
     pose(3, 0) = kEpsilon;
-    EXPECT_THROW(RigidTransformd Xm(pose), std::logic_error);
+    EXPECT_THROW(RigidTransformd Xm(pose), std::exception);
     pose(3, 0) = 0;  pose(3, 1) = kEpsilon;
-    EXPECT_THROW(RigidTransformd Xm(pose), std::logic_error);
+    EXPECT_THROW(RigidTransformd Xm(pose), std::exception);
     pose(3, 1) = 0;  pose(3, 2) = kEpsilon;
-    EXPECT_THROW(RigidTransformd Xm(pose), std::logic_error);
+    EXPECT_THROW(RigidTransformd Xm(pose), std::exception);
     pose(3, 2) = 0;  pose(3, 3) = 1 + 2 * kEpsilon;
-    EXPECT_THROW(RigidTransformd Xm(pose), std::logic_error);
+    EXPECT_THROW(RigidTransformd Xm(pose), std::exception);
   }
 }
 
@@ -252,19 +252,19 @@ GTEST_TEST(RigidTransform, ConstructorFromEigenExpression) {
   if (kDrakeAssertIsArmed) {
     DRAKE_EXPECT_NO_THROW(RigidTransformd Xm(pose4 * pose4));
     pose4(3, 0) = kEpsilon;
-    EXPECT_THROW(RigidTransformd Xm(pose4 * pose4), std::logic_error);
+    EXPECT_THROW(RigidTransformd Xm(pose4 * pose4), std::exception);
     pose4(3, 0) = 0;  pose4(3, 1) = kEpsilon;
-    EXPECT_THROW(RigidTransformd Xm(pose4 * pose4), std::logic_error);
+    EXPECT_THROW(RigidTransformd Xm(pose4 * pose4), std::exception);
     pose4(3, 1) = 0;  pose4(3, 2) = kEpsilon;
-    EXPECT_THROW(RigidTransformd Xm(pose4 * pose4), std::logic_error);
+    EXPECT_THROW(RigidTransformd Xm(pose4 * pose4), std::exception);
     pose4(3, 2) = 0;  pose4(3, 3) = 1 + 2 * kEpsilon;
-    EXPECT_THROW(RigidTransformd Xm(pose4 * pose4), std::logic_error);
+    EXPECT_THROW(RigidTransformd Xm(pose4 * pose4), std::exception);
   }
 
   // Ensure calling the constructor with a 3x3 matrix Eigen expression fails.
   if (kDrakeAssertIsArmed) {
     const Matrix3<double> m3 = R.matrix();  // 3x3 matrix.
-    EXPECT_THROW(RigidTransformd Xm(1.0 * m3), std::logic_error);
+    EXPECT_THROW(RigidTransformd Xm(1.0 * m3), std::exception);
   }
 }
 
@@ -356,7 +356,7 @@ GTEST_TEST(RigidTransform, Isometry3) {
   // means the EXPECT_THROW fails.  The fix (credit Sherm) was to add an extra
   // set of parentheses around the first argument of EXPECT_THROW.
   if (kDrakeAssertIsArmed) {
-    EXPECT_THROW((RigidTransform<double>(isometryC)), std::logic_error);
+    EXPECT_THROW((RigidTransform<double>(isometryC)), std::exception);
   }
 }
 
@@ -608,23 +608,23 @@ GTEST_TEST(RigidTransform, SymbolicRigidTransformThrowsExceptions) {
   // The next four tests should throw exceptions since the tests are
   // inconclusive because the value of x is unknown.
   Formula test_Bool = X_symbolic.IsExactlyIdentity();
-  EXPECT_THROW(test_Bool.Evaluate(), std::runtime_error);
+  EXPECT_THROW(test_Bool.Evaluate(), std::exception);
 
   test_Bool = X_symbolic.IsNearlyIdentity(kEpsilon);
-  EXPECT_THROW(test_Bool.Evaluate(), std::runtime_error);
+  EXPECT_THROW(test_Bool.Evaluate(), std::exception);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   test_Bool = X_symbolic.IsIdentityToEpsilon(kEpsilon);
-  EXPECT_THROW(test_Bool.Evaluate(), std::runtime_error);
+  EXPECT_THROW(test_Bool.Evaluate(), std::exception);
 #pragma GCC diagnostic pop
 
   const RigidTransform<Expression>& X_identity =
       RigidTransform<Expression>::Identity();
   test_Bool = X_symbolic.IsExactlyEqualTo(X_identity);
-  EXPECT_THROW(test_Bool.Evaluate(), std::runtime_error);
+  EXPECT_THROW(test_Bool.Evaluate(), std::exception);
 
   test_Bool = X_symbolic.IsNearlyEqualTo(X_identity, kEpsilon);
-  EXPECT_THROW(test_Bool.Evaluate(), std::runtime_error);
+  EXPECT_THROW(test_Bool.Evaluate(), std::exception);
 }
 
 // Test constructing a RigidTransform constructor from an Eigen::Translation3.
@@ -784,7 +784,7 @@ GTEST_TEST(RigidTransform, OperatorMultiplyByMatrix3X) {
     Eigen::MatrixXd m_7x8(7, 8);
     m_7x8 = Eigen::MatrixXd::Identity(7, 8);
     Eigen::MatrixXd bad_matrix_multiply;
-    EXPECT_THROW(bad_matrix_multiply = X_AB * m_7x8, std::logic_error);
+    EXPECT_THROW(bad_matrix_multiply = X_AB * m_7x8, std::exception);
   }
 }
 

--- a/math/test/rotation_matrix_test.cc
+++ b/math/test/rotation_matrix_test.cc
@@ -78,6 +78,24 @@ GTEST_TEST(RotationMatrix, RotationMatrixConstructor) {
   }
 }
 
+// Test IsIdentity() and IsNearlyIdentity().
+GTEST_TEST(RotationMatrix, IsIdentity) {
+  RotationMatrix<double> R;  // Default constructor is identity matrix.
+  EXPECT_TRUE(R.IsExactlyIdentity());
+  EXPECT_TRUE(R.IsNearlyIdentity(0.0));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  EXPECT_TRUE(R.IsIdentityToInternalTolerance());
+#pragma GCC diagnostic pop
+
+  // Test non-identity matrix.
+  const double theta = 256 * kEpsilon;
+  R = RotationMatrix<double>::MakeZRotation(theta);
+  EXPECT_FALSE(R.IsExactlyIdentity());
+  EXPECT_FALSE(R.IsNearlyIdentity());
+  EXPECT_TRUE(R.IsNearlyIdentity(512 * kEpsilon));
+}
+
 // Test making a RotationMatrix from three right-handed orthogonal unit vectors.
 GTEST_TEST(RotationMatrix, MakeFromOrthonormalRowsOrColumns) {
   const double cos_theta = std::cos(0.5);
@@ -195,7 +213,7 @@ GTEST_TEST(RotationMatrix, SetRotationMatrix) {
        0, cos_theta, sin_theta,
        0, -sin_theta, cos_theta;
   if (kDrakeAssertIsArmed) {
-    EXPECT_THROW(R.set(m), std::logic_error);
+    EXPECT_THROW(R.set(m), std::exception);
   } else {
     DRAKE_EXPECT_NO_THROW(R.set(m));
   }
@@ -476,7 +494,7 @@ GTEST_TEST(RotationMatrix, IsExactlyIdentity) {
   DRAKE_EXPECT_NO_THROW(R.set(m));
   m(0, 2) = 129 * kEpsilon;
   if (kDrakeAssertIsArmed) {
-    EXPECT_THROW(R.set(m), std::logic_error);
+    EXPECT_THROW(R.set(m), std::exception);
   } else {
     DRAKE_EXPECT_NO_THROW(R.set(m));
   }
@@ -577,7 +595,7 @@ GTEST_TEST(RotationMatrix, ProjectToRotationMatrix) {
   EXPECT_TRUE(-64 * kEpsilon * kEpsilon * kEpsilon < m.determinant() &&
                m.determinant() < 0);
   EXPECT_THROW(RotationMatrix<double>::ProjectToRotationMatrix(m,
-               &quality_factor), std::logic_error);
+               &quality_factor), std::exception);
 
   // Test a 3x3 orthogonal matrix but whose determinant is negative (-1).
   // clang-format off
@@ -587,7 +605,7 @@ GTEST_TEST(RotationMatrix, ProjectToRotationMatrix) {
   // clang-format on
   EXPECT_TRUE(std::abs(m.determinant() + 1) < 64 * kEpsilon);
   EXPECT_THROW(RotationMatrix<double>::ProjectToRotationMatrix(m,
-               &quality_factor), std::logic_error);
+               &quality_factor), std::exception);
 
   // Check that an exception is thrown if the resulting rotation matrix would
   // have been improper (the resulting rotation matrix would have a determinant
@@ -604,7 +622,7 @@ GTEST_TEST(RotationMatrix, ProjectToRotationMatrix) {
   // clang-format on
   EXPECT_TRUE(-1600 * kEpsilon < m.determinant() && m.determinant() < 0);
   EXPECT_THROW(RotationMatrix<double>::ProjectToRotationMatrix(m,
-               &quality_factor), std::logic_error);
+               &quality_factor), std::exception);
 
   // Check that no exception is thrown if the resulting rotation matrix is a
   // valid rotation matrix and is proper (meaning the resulting rotation matrix
@@ -634,7 +652,7 @@ GTEST_TEST(RotationMatrix, ProjectToRotationMatrix) {
   // clang-format on
   EXPECT_LT(m.determinant(), 0);
   EXPECT_THROW(RotationMatrix<double>::ProjectToRotationMatrix(m,
-               &quality_factor), std::logic_error);
+               &quality_factor), std::exception);
 
   // Check that returned rotation matrix is orthonormal.  In other words, its
   // transpose should be equal to its inverse so  that R * Rᵀ = IdentityMatrix.
@@ -919,7 +937,7 @@ GTEST_TEST(RotationMatrixTest, OperatorMultiplyByMatrix3X) {
     Eigen::MatrixXd m_7x8(7, 8);
     m_7x8 = Eigen::MatrixXd::Identity(7, 8);
     Eigen::MatrixXd bad_matrix_multiply;
-    EXPECT_THROW(bad_matrix_multiply = R_AB * m_7x8, std::logic_error);
+    EXPECT_THROW(bad_matrix_multiply = R_AB * m_7x8, std::exception);
     DRAKE_EXPECT_THROWS_MESSAGE(
         bad_matrix_multiply = R_AB * m_7x8,
         "Error: Inner dimension for matrix multiplication is not 3.");
@@ -1035,12 +1053,12 @@ TEST_F(RotationMatrixConversionTests, QuaternionToRotationMatrix) {
   if (kDrakeAssertIsArmed) {
     // A zero quaternion should throw an exception.
     const Eigen::Quaterniond q_zero(0, 0, 0, 0);
-    EXPECT_THROW(const RotationMatrix<double> R_bad(q_zero), std::logic_error);
+    EXPECT_THROW(const RotationMatrix<double> R_bad(q_zero), std::exception);
 
     // A quaternion containing a NaN throw an exception.
     double nan = std::numeric_limits<double>::quiet_NaN();
     const Eigen::Quaterniond q_nan(nan, 0, 0, 0);
-    EXPECT_THROW(const RotationMatrix<double> R_nan(q_nan), std::logic_error);
+    EXPECT_THROW(const RotationMatrix<double> R_nan(q_nan), std::exception);
   }
 }
 
@@ -1071,12 +1089,12 @@ TEST_F(RotationMatrixConversionTests, AngleAxisToRotationMatrix) {
     // An AngleAxis with a zero unit vector should throw an exception.
     const Eigen::AngleAxisd aa_zero(5, Vector3d(0, 0, 0));
     EXPECT_THROW(const RotationMatrix<double> R_zero(aa_zero),
-        std::logic_error);
+        std::exception);
 
     // An AngleAxis containing a NaN should throw an exception.
     double nan = std::numeric_limits<double>::quiet_NaN();
     const Eigen::AngleAxisd aa_nan(nan, Vector3d(1, 0, 0));
-    EXPECT_THROW(const RotationMatrix<double> R_nan(aa_nan), std::logic_error);
+    EXPECT_THROW(const RotationMatrix<double> R_nan(aa_nan), std::exception);
   }
 }
 


### PR DESCRIPTION
Resolves issue #16551

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16552)
<!-- Reviewable:end -->
