### PR TITLE
[geometry/dev] cleanup more proactively on the client side

### DIFF
--- a/geometry/render/dev/render_client_gltf.cc
+++ b/geometry/render/dev/render_client_gltf.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/render/dev/render_client_gltf.h"
 
 #include <atomic>
+#include <cstdio>
 
 #include <vtkCamera.h>
 #include <vtkGLTFExporter.h>
@@ -113,6 +114,21 @@ void LogFrameServerResponsePath(internal::ImageType image_type,
       ImageTypeToString(image_type), path);
 }
 
+// Delete the file and log if verbose, only call if no_cleanup() == false.
+void DeleteFileAndLogIfVerbose(const std::string& path, bool verbose) {
+  int failed = std::remove(path.c_str());
+  if (verbose) {
+    if (!failed) {
+      drake::log()->debug("RenderClientGltf: deleted unused file '{}'.", path);
+    } else {
+      drake::log()->debug(
+          "RenderClientGltf: unable to delete file '{}' with std::remove "
+          "returning code {}.",
+          path, failed);
+    }
+  }
+}
+
 }  // namespace
 
 RenderClientGltf::RenderClientGltf(const RenderClientGltfParams& parameters)
@@ -199,6 +215,12 @@ void RenderClientGltf::DoRenderColorImage(const ColorRenderCamera& camera,
 
   // Load the returned image back to the drake buffer.
   LoadColorImage(image_path, color_image_out);
+
+  // The scene and returned image file can be deleted now.
+  if (!no_cleanup()) {
+    DeleteFileAndLogIfVerbose(scene_path, verbose());
+    DeleteFileAndLogIfVerbose(image_path, verbose());
+  }
 }
 
 void RenderClientGltf::DoRenderDepthImage(
@@ -233,6 +255,12 @@ void RenderClientGltf::DoRenderDepthImage(
 
   // Load the returned image back to the drake buffer.
   LoadDepthImage(image_path, depth_image_out);
+
+  // The scene and returned image file can be deleted now.
+  if (!no_cleanup()) {
+    DeleteFileAndLogIfVerbose(scene_path, verbose());
+    DeleteFileAndLogIfVerbose(image_path, verbose());
+  }
 }
 
 void RenderClientGltf::DoRenderLabelImage(
@@ -266,6 +294,12 @@ void RenderClientGltf::DoRenderLabelImage(
 
   // Load the returned image back to the drake buffer.
   LoadLabelImage(image_path, label_image_out);
+
+  // The scene and returned image file can be deleted now.
+  if (!no_cleanup()) {
+    DeleteFileAndLogIfVerbose(scene_path, verbose());
+    DeleteFileAndLogIfVerbose(image_path, verbose());
+  }
 }
 
 std::string RenderClientGltf::ExportPathFor(internal::ImageType image_type,


### PR DESCRIPTION
Delete the scene and image files once they are no longer needed.