### PR TITLE
Update valgrind builds to use Focal

### DIFF
--- a/doc/_pages/jenkins.md
+++ b/doc/_pages/jenkins.md
@@ -54,7 +54,7 @@ where ``<job-name>`` is the name of an
 For example:
 
 * ``@drake-jenkins-bot mac-big-sur-clang-bazel-experimental-release please``
-* ``@drake-jenkins-bot linux-bionic-clang-bazel-experimental-valgrind-memcheck please``
+* ``@drake-jenkins-bot linux-focal-clang-bazel-experimental-valgrind-memcheck please``
 
 ## Scheduling Builds via the Jenkins User Interface
 

--- a/tools/dynamic_analysis/drd.sh
+++ b/tools/dynamic_analysis/drd.sh
@@ -24,7 +24,7 @@ valgrind \
     --num-callers=16 \
     --suppressions="${mydir}/drd.supp" \
     --suppressions=/usr/lib/valgrind/debian.supp \
-    --suppressions=/usr/lib/valgrind/python.supp \
+    --suppressions=/usr/lib/valgrind/python3.supp \
     --tool=drd \
     --trace-children=yes \
     --trace-children-skip=/bin/cat,/bin/cp,/bin/ln,/bin/ls,/bin/mkdir,/bin/mv,/bin/sed,/lib/ld-linux.so.\*,/lib64/ld-linux-x86-64.so.\*,/usr/bin/clang,/usr/bin/clang-9,/usr/bin/clang-format-9,/usr/bin/diff,/usr/bin/dot,/usr/bin/fc-list,/usr/bin/file,/usr/bin/find,/usr/bin/gcc,/usr/bin/ldd,/usr/bin/patchelf,/usr/bin/strip,/usr/bin/uname,\*/external/buildifier/buildifier \

--- a/tools/dynamic_analysis/helgrind.sh
+++ b/tools/dynamic_analysis/helgrind.sh
@@ -24,7 +24,7 @@ valgrind \
     --num-callers=16 \
     --suppressions="${mydir}/helgrind.supp" \
     --suppressions=/usr/lib/valgrind/debian.supp \
-    --suppressions=/usr/lib/valgrind/python.supp \
+    --suppressions=/usr/lib/valgrind/python3.supp \
     --tool=helgrind \
     --trace-children=yes \
     --trace-children-skip=/bin/cat,/bin/cp,/bin/ln,/bin/ls,/bin/mkdir,/bin/mv,/bin/sed,/lib/ld-linux.so.\*,/lib64/ld-linux-x86-64.so.\*,/usr/bin/clang,/usr/bin/clang-9,/usr/bin/clang-format-9,/usr/bin/diff,/usr/bin/dot,/usr/bin/fc-list,/usr/bin/file,/usr/bin/find,/usr/bin/gcc,/usr/bin/ldd,/usr/bin/patchelf,/usr/bin/strip,/usr/bin/uname,\*/external/buildifier/buildifier \

--- a/tools/dynamic_analysis/valgrind.sh
+++ b/tools/dynamic_analysis/valgrind.sh
@@ -26,7 +26,7 @@ valgrind \
     --show-leak-kinds=definite,possible \
     --suppressions="${mydir}/valgrind.supp" \
     --suppressions=/usr/lib/valgrind/debian.supp \
-    --suppressions=/usr/lib/valgrind/python.supp \
+    --suppressions=/usr/lib/valgrind/python3.supp \
     --tool=memcheck \
     --trace-children=yes \
     --trace-children-skip=/bin/cat,/bin/cp,/bin/ln,/bin/ls,/bin/mkdir,/bin/mv,/bin/sed,/lib/ld-linux.so.\*,/lib64/ld-linux-x86-64.so.\*,/usr/bin/clang,/usr/bin/clang-9,/usr/bin/clang-format-9,/usr/bin/diff,/usr/bin/dot,/usr/bin/fc-list,/usr/bin/file,/usr/bin/find,/usr/bin/gcc,/usr/bin/ldd,/usr/bin/patchelf,/usr/bin/strip,/usr/bin/uname,\*/external/buildifier/buildifier \


### PR DESCRIPTION
Update valgrind wrapper scripts to account for the name of the distro-provided Python suppressions file changing between Bionic and Focal. Update Jenkins job name in documentation.

See also #14928. Supersedes #16223.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16557)
<!-- Reviewable:end -->
