### PR TITLE
[pydrake/examples] store visualizer return for args.playback

### DIFF
--- a/bindings/pydrake/examples/multibody/run_planar_scenegraph_visualizer.py
+++ b/bindings/pydrake/examples/multibody/run_planar_scenegraph_visualizer.py
@@ -68,7 +68,7 @@ def run_manipulation_example(args):
     T_VW = np.array([[1., 0., 0., 0.],
                      [0., 0., 1., 0.],
                      [0., 0., 0., 1.]])
-    ConnectPlanarSceneGraphVisualizer(
+    visualizer = ConnectPlanarSceneGraphVisualizer(
         builder, scene_graph, query_object_output_port, T_VW=T_VW,
         xlim=[-0.5, 1.0], ylim=[-1.2, 1.2], draw_period=0.1)
 


### PR DESCRIPTION
The example cannot run correctly if the reference is not stored.

`bazel run //bindings/pydrake/examples/multibody:run_planar_scenegraph_visualizer -- -m manip -T 10 -p true` (don't need `-T 10`, it's the `manip` and `-p true` that will make you crash without this change).

Found this by accident shopping for an example to test some unrelated changes.  Byproduct of https://github.com/RobotLocomotion/drake/pull/15456 according to the blame.

I don't think this needs a feature review, or at least, not sure who to add.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16559)
<!-- Reviewable:end -->
