### PR TITLE
[multibody] By default, use hydroelastic contact with fallback.

### DIFF
--- a/multibody/hydroelastics/hydroelastic_user_guide_doxygen.h
+++ b/multibody/hydroelastics/hydroelastic_user_guide_doxygen.h
@@ -53,9 +53,12 @@ There are three different options:
 - drake::multibody::ContactModel::kHydroelastic
 - drake::multibody::ContactModel::kHydroelasticWithFallback
 
-The default model is @ref drake::multibody::ContactModel::kPoint "kPoint" and is
-the implementation of the point contact model (see @ref hydro_appendix_a).
-Hydroelastic contact plays no role in determining the dynamics.
+The default model is
+@ref drake::multibody::ContactModel::kHydroelasticWithFallback
+"kHydroelasticWithFallback".
+
+@ref drake::multibody::ContactModel::kPoint "kPoint" is the implementation of
+the point contact model (see @ref hydro_appendix_a).
 
 Models @ref drake::multibody::ContactModel::kHydroelastic "kHydroelastic" and
 @ref drake::multibody::ContactModel::kHydroelasticWithFallback

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -360,8 +360,9 @@ template <typename T>
 MultibodyPlant<T>::MultibodyPlant(double time_step)
     : MultibodyPlant(nullptr, time_step) {
   // Cross-check that the Config default matches our header file default.
-  DRAKE_DEMAND(contact_model_ == ContactModel::kPoint);
-  DRAKE_DEMAND(MultibodyPlantConfig{}.contact_model == "point");
+  DRAKE_DEMAND(contact_model_ == ContactModel::kHydroelasticWithFallback);
+  DRAKE_DEMAND(MultibodyPlantConfig{}.contact_model ==
+               "hydroelastic_with_fallback");
 }
 
 template <typename T>

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -4912,7 +4912,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // The model used by the plant to compute contact forces. Keep this in sync
   // with the default value in multibody_plant_config.h; there are already
   // assertions in the cc file that enforce this.
-  ContactModel contact_model_{ContactModel::kPoint};
+  ContactModel contact_model_{ContactModel::kHydroelasticWithFallback};
 
   // User's choice of the representation of contact surfaces in discrete
   // systems. The default value is dependent on whether the system is

--- a/multibody/plant/multibody_plant_config.h
+++ b/multibody/plant/multibody_plant_config.h
@@ -40,7 +40,7 @@ struct MultibodyPlantConfig {
   /// - "point"
   /// - "hydroelastic"
   /// - "hydroelastic_with_fallback"
-  std::string contact_model{"point"};
+  std::string contact_model{"hydroelastic_with_fallback"};
 
   /// Configures the MultibodyPlant::set_contact_surface_representation().
   /// Refer to drake::geometry::HydroelasticContactRepresentation for details.

--- a/multibody/plant/test/multibody_plant_hydroelastic_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_test.cc
@@ -69,8 +69,9 @@ class HydroelasticModelTests : public ::testing::Test {
     body_ = &AddObject(plant_, kSphereRadius, kElasticModulus, kDissipation,
                        kFrictionCoefficient);
 
-    // The default contact model today is point contact.
-    EXPECT_EQ(plant_->get_contact_model(), ContactModel::kPoint);
+    // The default contact model today is hydroelastic with fallback.
+    EXPECT_EQ(plant_->get_contact_model(),
+              ContactModel::kHydroelasticWithFallback);
 
     // Tell the plant to use the hydroelastic model.
     plant_->set_contact_model(ContactModel::kHydroelastic);


### PR DESCRIPTION
Related to #16565 
- Switch the default contact model from point contact to hydroelastic with
  fallback.
- The fallback to point contact happens between two rigid-hydroelastic
  collision geometries. It also happens when one or both of the two
  contacting geometries is non-hydroelastic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16569)
<!-- Reviewable:end -->
