### PR TITLE
[pydrake] Stop installing useless bazel py_binary stubs

### DIFF
--- a/bindings/pydrake/examples/multibody/BUILD.bazel
+++ b/bindings/pydrake/examples/multibody/BUILD.bazel
@@ -29,18 +29,12 @@ drake_py_library(
     ],
 )
 
-drake_py_binary(
-    name = "cart_pole_passive_simulation",
+drake_py_library(
+    name = "cart_pole_passive_simulation_py",
     srcs = ["cart_pole_passive_simulation.py"],
-    add_test_rule = 1,
     data = [
         "//examples/multibody/cart_pole:cart_pole.sdf",
     ],
-    test_rule_args = [
-        "--target_realtime_rate=0",
-        "--simulation_time=0.1",
-    ],
-    visibility = ["//visibility:public"],
     deps = [
         ":module_py",
         "//bindings/pydrake:lcm_py",
@@ -51,17 +45,51 @@ drake_py_binary(
 )
 
 drake_py_binary(
+    name = "cart_pole_passive_simulation",
+    srcs = ["cart_pole_passive_simulation.py"],
+    add_test_rule = 1,
+    test_rule_args = [
+        "--target_realtime_rate=0",
+        "--simulation_time=0.1",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":cart_pole_passive_simulation_py",
+    ],
+)
+
+drake_py_library(
+    name = "pendulum_lqr_monte_carlo_analysis_py",
+    srcs = ["pendulum_lqr_monte_carlo_analysis.py"],
+    data = ["//examples/pendulum:models"],
+    deps = [
+        ":module_py",
+        "//bindings/pydrake/multibody",
+        "//bindings/pydrake/systems",
+    ],
+)
+
+drake_py_binary(
     name = "pendulum_lqr_monte_carlo_analysis",
     srcs = ["pendulum_lqr_monte_carlo_analysis.py"],
     add_test_rule = 1,
-    data = ["//examples/pendulum:models"],
     test_rule_args = [
         "--num_samples=10",
         "--torque_limit=2.0",
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":pendulum_lqr_monte_carlo_analysis_py",
+    ],
+)
+
+drake_py_library(
+    name = "run_planar_scenegraph_visualizer_py",
+    srcs = ["run_planar_scenegraph_visualizer.py"],
+    data = ["//examples/pendulum:models"],
+    deps = [
         ":module_py",
+        "//bindings/pydrake/examples:manipulation_station_py",
         "//bindings/pydrake/multibody",
         "//bindings/pydrake/systems",
     ],
@@ -71,20 +99,16 @@ drake_py_binary(
     name = "run_planar_scenegraph_visualizer",
     srcs = ["run_planar_scenegraph_visualizer.py"],
     add_test_rule = 1,
-    data = ["//examples/pendulum:models"],
     visibility = ["//visibility:public"],
     deps = [
-        ":module_py",
-        "//bindings/pydrake/examples:manipulation_station_py",
-        "//bindings/pydrake/multibody",
-        "//bindings/pydrake/systems",
+        ":run_planar_scenegraph_visualizer_py",
     ],
 )
 
 PY_LIBRARIES = [
-    ":cart_pole_passive_simulation",
-    ":pendulum_lqr_monte_carlo_analysis",
-    ":run_planar_scenegraph_visualizer",
+    ":cart_pole_passive_simulation_py",
+    ":pendulum_lqr_monte_carlo_analysis_py",
+    ":run_planar_scenegraph_visualizer_py",
 ]
 
 # Package roll-up (for Bazel dependencies).


### PR DESCRIPTION
Closes #11303.

This doesn't fail-fast in case a future developer ever tries to install a `py_binary` again, but _shrug_.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16583)
<!-- Reviewable:end -->
