### PR TITLE
[doc] Clarify instructions for Bazel running with flags

### DIFF
--- a/doc/_pages/bazel.md
+++ b/doc/_pages/bazel.md
@@ -26,7 +26,7 @@ to install Bazel.
 To build or test Drake, run **bazel build** or **bazel test** with the desired
 target label (and optional configuration options if desired).  We give some
 typical examples below; for more reading about target patterns, see:
-[https://docs.bazel.build/versions/master/user-manual.html#target-patterns](https://docs.bazel.build/versions/master/user-manual.html#target-patterns).
+[https://docs.bazel.build/versions/main/user-manual.html#target-patterns](https://docs.bazel.build/versions/main/user-manual.html#target-patterns).
 
 On Ubuntu, the default compiler is the first ``gcc`` compiler in the
 ``PATH``, usually GCC 7.5 on Bionic and GCC 9.3 on Focal. On macOS, the default
@@ -104,23 +104,32 @@ bazel test --config lint //...                       # Only run style checks; do
 
 ## Running with Flags
 
+### Example programs
+
 In general, to figure out what binary-specific arguments are available, add
-"``-- --help``" to your ``bazel run`` command. If the binary can only run via
-``bazel test``, look at [--test_arg](https://docs.bazel.build/versions/master/user-manual.html#flag--test_arg).
-
-If a C++ unittest uses ``gtest`` (e.g. using ``drake_cc_googletest``),
-you can specify gtest-specific flags. As an example:
+"``-- --help``" to your ``bazel run`` command. An an example,
 
 ```
-bazel run multibody/plant:multibody_plant_test -- --gtest_filter='*SimpleModelCreation*'
+bazel run //examples/acrobot:run_passive -- --help
 ```
 
-If a Python unittest is run via ``drake_py_unittest_main.py`` (e.g. using
-``drake_py_unittest``), you can specify flags such as ``--trace`` or
-``--deprecation_action``. As an example:
+The bare ``--`` separates Bazel arguments from the program's arguments.
+
+## Unit tests
+
+For running tests, you may pass custom arguments to the test program via
+[--test_arg](https://docs.bazel.build/versions/main/user-manual.html#flag--test_arg).
+
+For a C++ unittest that uses ``drake_cc_googletest``, for example:
 
 ```
-bazel run bindings/pydrake:py/symbolic_test -- --trace=user --deprecation_action=error
+bazel test multibody/plant:multibody_plant_test --test_output=streamed --nocache_test_results --test_arg=--gtest_filter='*SimpleModelCreation*'
+```
+
+For a Python unittest that uses ``drake_py_unittest``, for example:
+
+```
+bazel test bindings/pydrake:py/symbolic_test --test_output=streamed --nocache_test_results --test_arg=--trace=user --test_arg=TestSymbolicVariable
 ```
 
 ## Debugging and profiling on macOS
@@ -199,7 +208,7 @@ To confirm that your setup was successful, run the tests that require Gurobi:
 The default value of ``--test_tag_filters`` in Drake's ``bazel.rc`` excludes
 these tests.  If you will be developing with Gurobi regularly, you may wish
 to specify a more convenient ``--test_tag_filters`` in a local ``.bazelrc``.
-See [https://docs.bazel.build/versions/master/user-manual.html#bazelrc](https://docs.bazel.build/versions/master/user-manual.html#bazelrc).
+See [https://docs.bazel.build/versions/main/user-manual.html#bazelrc](https://docs.bazel.build/versions/main/user-manual.html#bazelrc).
 
 ## MOSEK
 
@@ -215,7 +224,7 @@ To confirm that your setup was successful, run the tests that require MOSEK:
 The default value of ``--test_tag_filters`` in Drake's ``bazel.rc`` excludes
 these tests.  If you will be developing with MOSEK regularly, you may wish
 to specify a more convenient ``--test_tag_filters`` in a local ``.bazelrc``.
-See [https://docs.bazel.build/versions/master/user-manual.html#bazelrc](https://docs.bazel.build/versions/master/user-manual.html#bazelrc).
+See [https://docs.bazel.build/versions/main/user-manual.html#bazelrc](https://docs.bazel.build/versions/main/user-manual.html#bazelrc).
 
 ## SNOPT
 
@@ -244,7 +253,7 @@ To confirm that your setup was successful, run the tests that require SNOPT:
 The default value of ``--test_tag_filters`` in Drake's ``bazel.rc`` excludes
 these tests.  If you will be developing with SNOPT regularly, you may wish
 to specify a more convenient ``--test_tag_filters`` in a local ``.bazelrc``.
-See [https://docs.bazel.build/versions/master/user-manual.html#bazelrc](https://docs.bazel.build/versions/master/user-manual.html#bazelrc).
+See [https://docs.bazel.build/versions/main/user-manual.html#bazelrc](https://docs.bazel.build/versions/main/user-manual.html#bazelrc).
 
 SNOPT support has some known problems on certain programs (see drake issue
 [#10422](https://github.com/RobotLocomotion/drake/issues/10422) for a summary).

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -80,7 +80,7 @@ setup steps:
 
 See [above](#supported-configurations)
 for the configurations and platforms that Drake officially supports.
-All else being equal, we would recommend developers use Ubuntu Bionic.
+All else being equal, we would recommend developers use Ubuntu Focal.
 
 # Build with Bazel
 


### PR DESCRIPTION
More clearly distinguish examples (bazel run) from tests (bazel test). Update links to Bazel's documentation to avoid extra re-directions.

Also fix an (somewhat unrelated) reference to prefer Focal, not Bionic, for local development.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16588)
<!-- Reviewable:end -->
