### PR TITLE
[geometry] Don't include geometry_state.h publicly

### DIFF
--- a/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
+++ b/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
@@ -7,6 +7,7 @@
 #include "drake/examples/multibody/rolling_sphere/make_rolling_sphere_plant.h"
 #include "drake/geometry/drake_visualizer.h"
 #include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/proximity_properties.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/math/random_rotation.h"

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -2,6 +2,7 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
+#include "drake/geometry/geometry_state.h"
 #include "drake/geometry/scene_graph.h"
 
 namespace drake {

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -11,9 +11,11 @@
 #include "drake/geometry/query_results/signed_distance_pair.h"
 #include "drake/geometry/query_results/signed_distance_to_point.h"
 #include "drake/geometry/render/render_camera.h"
+#include "drake/geometry/render/render_engine.h"
 #include "drake/geometry/scene_graph_inspector.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/systems/framework/context.h"
+#include "drake/systems/sensors/image.h"
 
 namespace drake {
 namespace geometry {

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -81,7 +81,9 @@ class GeometryStateValue final : public Value<GeometryState<T>> {
 
 template <typename T>
 SceneGraph<T>::SceneGraph()
-    : LeafSystem<T>(SystemTypeTag<SceneGraph>{}) {
+    : LeafSystem<T>(SystemTypeTag<SceneGraph>{}),
+      owned_model_(std::make_unique<GeometryState<T>>()),
+      model_(*owned_model_) {
   model_inspector_.set(&model_);
   geometry_state_index_ =
       this->DeclareAbstractParameter(GeometryStateValue<T>());
@@ -127,6 +129,9 @@ SceneGraph<T>::SceneGraph(const SceneGraph<U>& other)
     DRAKE_DEMAND(new_ports.pose_port == ref_ports.pose_port);
   }
 }
+
+template <typename T>
+SceneGraph<T>::~SceneGraph() = default;
 
 template <typename T>
 SourceId SceneGraph<T>::RegisterSource(const std::string& name) {

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -7,8 +7,9 @@
 
 #include "drake/common/drake_deprecated.h"
 #include "drake/geometry/collision_filter_manager.h"
+#include "drake/geometry/frame_kinematics_vector.h"
+#include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_set.h"
-#include "drake/geometry/geometry_state.h"
 #include "drake/geometry/query_object.h"
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
 #include "drake/geometry/scene_graph_inspector.h"
@@ -18,10 +19,13 @@
 namespace drake {
 namespace geometry {
 
+#ifndef DRAKE_DOXYGEN_CXX
 class GeometryInstance;
-
+template <typename T>
+class GeometryState;
 template <typename T>
 class QueryObject;
+#endif
 
 /** SceneGraph serves as the nexus for all geometry (and geometry-based
  operations) in a Diagram. Through SceneGraph, other systems that introduce
@@ -280,7 +284,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
   template <typename U>
   explicit SceneGraph(const SceneGraph<U>& other);
 
-  ~SceneGraph() override {}
+  ~SceneGraph() final;
 
   /** @name       Port management
    Access to SceneGraph's input/output ports. This topic includes
@@ -892,8 +896,12 @@ class SceneGraph final : public systems::LeafSystem<T> {
   int query_port_index_{-1};
 
   // SceneGraph owns its configured model; it gets copied into the context when
-  // the context is set to its "default" state.
-  GeometryState<T> model_;
+  // the context is set to its "default" state. We use unique_ptr in support of
+  // forward-declaring GeometryState<T> to reduce our #include footprint, but
+  // initialize a model_ reference to always point to the owned_model_, as a
+  // convenient shortcut in the code to treat it as if it were a direct member.
+  std::unique_ptr<GeometryState<T>> owned_model_;
+  GeometryState<T>& model_;
 
   SceneGraphInspector<T> model_inspector_;
 

--- a/geometry/scene_graph_inspector.cc
+++ b/geometry/scene_graph_inspector.cc
@@ -2,12 +2,275 @@
 
 #include <memory>
 
+#include "drake/geometry/geometry_state.h"
+
 namespace drake {
 namespace geometry {
 
 template <typename T>
-std::unique_ptr<GeometryInstance>
-SceneGraphInspector<T>::CloneGeometryInstance(GeometryId id) const {
+int SceneGraphInspector<T>::num_sources() const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->get_num_sources();
+}
+
+template <typename T>
+int SceneGraphInspector<T>::num_frames() const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->get_num_frames();
+}
+
+template <typename T>
+std::vector<FrameId> SceneGraphInspector<T>::GetAllFrameIds() const {
+  DRAKE_DEMAND(state_ != nullptr);
+  typename GeometryState<T>::FrameIdRange range = state_->get_frame_ids();
+  return std::vector<FrameId>(range.begin(), range.end());
+}
+
+template <typename T>
+int SceneGraphInspector<T>::num_geometries() const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->get_num_geometries();
+}
+
+template <typename T>
+const std::vector<GeometryId> SceneGraphInspector<T>::GetAllGeometryIds()
+    const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetAllGeometryIds();
+}
+
+template <typename T>
+std::unordered_set<GeometryId> SceneGraphInspector<T>::GetGeometryIds(
+    const GeometrySet& geometry_set, const std::optional<Role>& role) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetGeometryIds(geometry_set, role);
+}
+
+template <typename T>
+int SceneGraphInspector<T>::NumGeometriesWithRole(Role role) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->NumGeometriesWithRole(role);
+}
+
+template <typename T>
+int SceneGraphInspector<T>::NumDynamicGeometries() const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->NumDynamicGeometries();
+}
+
+template <typename T>
+int SceneGraphInspector<T>::NumAnchoredGeometries() const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->NumAnchoredGeometries();
+}
+
+template <typename T>
+std::set<std::pair<GeometryId, GeometryId>>
+SceneGraphInspector<T>::GetCollisionCandidates() const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetCollisionCandidates();
+}
+
+template <typename T>
+const GeometryVersion& SceneGraphInspector<T>::geometry_version() const {
+  return state_->geometry_version();
+}
+
+template <typename T>
+bool SceneGraphInspector<T>::SourceIsRegistered(SourceId source_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->SourceIsRegistered(source_id);
+}
+
+template <typename T>
+const std::string& SceneGraphInspector<T>::GetName(SourceId source_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetName(source_id);
+}
+
+template <typename T>
+int SceneGraphInspector<T>::NumFramesForSource(SourceId source_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->NumFramesForSource(source_id);
+}
+
+template <typename T>
+const std::unordered_set<FrameId>& SceneGraphInspector<T>::FramesForSource(
+    SourceId source_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->FramesForSource(source_id);
+}
+
+template <typename T>
+bool SceneGraphInspector<T>::BelongsToSource(FrameId frame_id,
+                                             SourceId source_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->BelongsToSource(frame_id, source_id);
+}
+
+template <typename T>
+const std::string& SceneGraphInspector<T>::GetOwningSourceName(
+    FrameId frame_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetOwningSourceName(frame_id);
+}
+
+template <typename T>
+const std::string& SceneGraphInspector<T>::GetName(FrameId frame_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetName(frame_id);
+}
+
+template <typename T>
+FrameId SceneGraphInspector<T>::GetParentFrame(FrameId frame_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetParentFrame(frame_id);
+}
+
+template <typename T>
+int SceneGraphInspector<T>::GetFrameGroup(FrameId frame_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetFrameGroup(frame_id);
+}
+
+template <typename T>
+int SceneGraphInspector<T>::NumGeometriesForFrame(FrameId frame_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->NumGeometriesForFrame(frame_id);
+}
+
+template <typename T>
+int SceneGraphInspector<T>::NumGeometriesForFrameWithRole(FrameId frame_id,
+                                                          Role role) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->NumGeometriesForFrameWithRole(frame_id, role);
+}
+
+template <typename T>
+std::vector<GeometryId> SceneGraphInspector<T>::GetGeometries(
+    FrameId frame_id, const std::optional<Role>& role) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetGeometries(frame_id, role);
+}
+
+template <typename T>
+GeometryId SceneGraphInspector<T>::GetGeometryIdByName(
+    FrameId frame_id, Role role, const std::string& name) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetGeometryIdByName(frame_id, role, name);
+}
+
+template <typename T>
+bool SceneGraphInspector<T>::BelongsToSource(GeometryId geometry_id,
+                                             SourceId source_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->BelongsToSource(geometry_id, source_id);
+}
+
+template <typename T>
+const std::string& SceneGraphInspector<T>::GetOwningSourceName(
+    GeometryId geometry_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetOwningSourceName(geometry_id);
+}
+
+template <typename T>
+FrameId SceneGraphInspector<T>::GetFrameId(GeometryId geometry_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetFrameId(geometry_id);
+}
+
+template <typename T>
+const std::string& SceneGraphInspector<T>::GetName(
+    GeometryId geometry_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetName(geometry_id);
+}
+
+template <typename T>
+const Shape& SceneGraphInspector<T>::GetShape(GeometryId geometry_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetShape(geometry_id);
+}
+
+template <typename T>
+const math::RigidTransform<double>& SceneGraphInspector<T>::GetPoseInParent(
+    GeometryId geometry_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetPoseInParent(geometry_id);
+}
+
+template <typename T>
+const math::RigidTransform<double>& SceneGraphInspector<T>::GetPoseInFrame(
+    GeometryId geometry_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetPoseInFrame(geometry_id);
+}
+
+template <typename T>
+std::variant<std::monostate, const TriangleSurfaceMesh<double>*,
+             const VolumeMesh<double>*>
+SceneGraphInspector<T>::maybe_get_hydroelastic_mesh(
+    GeometryId geometry_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->maybe_get_hydroelastic_mesh(geometry_id);
+}
+
+template <typename T>
+const GeometryProperties* SceneGraphInspector<T>::GetProperties(
+    GeometryId geometry_id, Role role) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  switch (role) {
+    case Role::kProximity:
+      return state_->GetProximityProperties(geometry_id);
+    case Role::kIllustration:
+      return state_->GetIllustrationProperties(geometry_id);
+    case Role::kPerception:
+      return state_->GetPerceptionProperties(geometry_id);
+    case Role::kUnassigned:
+      return nullptr;
+  }
+  return nullptr;
+}
+
+template <typename T>
+const ProximityProperties* SceneGraphInspector<T>::GetProximityProperties(
+    GeometryId geometry_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetProximityProperties(geometry_id);
+}
+
+template <typename T>
+const IllustrationProperties* SceneGraphInspector<T>::GetIllustrationProperties(
+    GeometryId geometry_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetIllustrationProperties(geometry_id);
+}
+
+template <typename T>
+const PerceptionProperties* SceneGraphInspector<T>::GetPerceptionProperties(
+    GeometryId geometry_id) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetPerceptionProperties(geometry_id);
+}
+
+template <typename T>
+bool SceneGraphInspector<T>::CollisionFiltered(GeometryId geometry_id1,
+                                               GeometryId geometry_id2) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->CollisionFiltered(geometry_id1, geometry_id2);
+}
+
+template <typename T>
+void SceneGraphInspector<T>::Reify(GeometryId geometry_id,
+                                   ShapeReifier* reifier) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  state_->GetShape(geometry_id).Reify(reifier);
+}
+
+template <typename T>
+std::unique_ptr<GeometryInstance> SceneGraphInspector<T>::CloneGeometryInstance(
+    GeometryId id) const {
   const std::string name = GetName(id);
   const math::RigidTransformd X_PG = GetPoseInFrame(id);
   std::unique_ptr<Shape> shape = GetShape(id).Clone();

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -12,17 +12,24 @@
 #include "drake/common/drake_deprecated.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/geometry_roles.h"
-#include "drake/geometry/geometry_state.h"
+#include "drake/geometry/geometry_set.h"
+#include "drake/geometry/geometry_version.h"
 #include "drake/geometry/internal_frame.h"
+#include "drake/geometry/proximity/triangle_surface_mesh.h"
+#include "drake/geometry/proximity/volume_mesh.h"
 #include "drake/geometry/shape_specification.h"
 
 namespace drake {
 namespace geometry {
 
+#ifndef DRAKE_DOXYGEN_CXX
 template <typename T>
-class SceneGraph;
+class GeometryState;
 template <typename T>
 class QueryObject;
+template <typename T>
+class SceneGraph;
+#endif
 
 /** The %SceneGraphInspector serves as a mechanism to query the topological
  structure of a SceneGraph instance. The topological structure consists of all
@@ -74,26 +81,16 @@ class SceneGraphInspector {
   /** Reports the number of registered sources -- whether they have registered
    frames/geometries or not. This will always be at least 1; the SceneGraph
    itself counts as a source.  */
-  int num_sources() const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->get_num_sources();
-  }
+  int num_sources() const;
 
   /** Reports the _total_ number of frames registered in the scene graph
    (including the world frame).  */
-  int num_frames() const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->get_num_frames();
-  }
+  int num_frames() const;
 
   /** Returns all of the frame ids in the scene graph. The order is not
    guaranteed; but it will be consistent across invocations as long as there are
    no changes to the topology. The ids includes the world frame's id.  */
-  typename std::vector<FrameId> GetAllFrameIds() const {
-    DRAKE_DEMAND(state_ != nullptr);
-    typename GeometryState<T>::FrameIdRange range = state_->get_frame_ids();
-    return std::vector<FrameId>(range.begin(), range.end());
-  }
+  typename std::vector<FrameId> GetAllFrameIds() const;
 
   /** Reports the id for the world frame.  */
   FrameId world_frame_id() const {
@@ -102,19 +99,13 @@ class SceneGraphInspector {
   }
 
   /** Reports the _total_ number of geometries in the scene graph.  */
-  int num_geometries() const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->get_num_geometries();
-  }
+  int num_geometries() const;
 
   /** Returns the set of all ids for registered geometries. The order is _not_
    guaranteed to have any particular meaning. But the order is
    guaranteed to remain fixed until a topological change is made (e.g., removal
    or addition of geometry/frames).  */
-  const std::vector<GeometryId> GetAllGeometryIds() const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetAllGeometryIds();
-  }
+  const std::vector<GeometryId> GetAllGeometryIds() const;
 
   /** Returns the geometry ids that are *implied* by the given GeometrySet and
    `role`. Remember that a GeometrySet can reference a FrameId in place of the
@@ -133,31 +124,19 @@ class SceneGraphInspector {
    @returns The requested unique geometry ids.  */
   std::unordered_set<GeometryId> GetGeometryIds(
       const GeometrySet& geometry_set,
-      const std::optional<Role>& role = std::nullopt) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetGeometryIds(geometry_set, role);
-  }
+      const std::optional<Role>& role = std::nullopt) const;
 
   /** Reports the _total_ number of geometries in the scene graph with the
    indicated role.  */
-  int NumGeometriesWithRole(Role role) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->NumGeometriesWithRole(role);
-  }
+  int NumGeometriesWithRole(Role role) const;
 
   /** Reports the total number of _dynamic_ geometries in the scene graph.  */
-  int NumDynamicGeometries() const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->NumDynamicGeometries();
-  }
+  int NumDynamicGeometries() const;
 
   /** Reports the total number of _anchored_ geometries. This should provide
    the same answer as calling NumGeometriesForFrame() with the world frame id.
    */
-  int NumAnchoredGeometries() const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->NumAnchoredGeometries();
-  }
+  int NumAnchoredGeometries() const;
 
   /** Returns all pairs of geometries that are candidates for collision (in no
    particular order). See CollisionFilterDeclaration and
@@ -168,53 +147,35 @@ class SceneGraphInspector {
    in a fixed order (i.e., always (A, B) and _never_ (B, A)). This is the same
    ordering as would be returned by, e.g.,
    QueryObject::ComputePointPairPenetration().  */
-  std::set<std::pair<GeometryId, GeometryId>> GetCollisionCandidates()
-      const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetCollisionCandidates();
-  }
+  std::set<std::pair<GeometryId, GeometryId>> GetCollisionCandidates() const;
 
   /** Returns the geometry version that can be used to detect changes
    to the geometry data associated with geometry roles. The reference returned
    should not be persisted. If it needs to be persisted, it should be copied. */
-  const GeometryVersion& geometry_version() const {
-    return state_->geometry_version();
-  }
+  const GeometryVersion& geometry_version() const;
   //@}
 
   /** @name                Sources and source-related data  */
   //@{
 
   /** Reports `true` if the given `source_id` maps to a registered source.  */
-  bool SourceIsRegistered(SourceId source_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->SourceIsRegistered(source_id);
-  }
+  bool SourceIsRegistered(SourceId source_id) const;
 
   /** Reports the name for the source with the given `source_id`.
    @throws std::exception if `source_id` does not map to a registered source. */
-  const std::string& GetName(SourceId source_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetName(source_id);
-  }
+  const std::string& GetName(SourceId source_id) const;
 
   /** Reports the number of frames registered to the source with the given
    `source_id`.
    @throws std::exception if `source_id` does not map to a registered source.
    */
-  int NumFramesForSource(SourceId source_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->NumFramesForSource(source_id);
-  }
+  int NumFramesForSource(SourceId source_id) const;
 
   /** Reports the ids of all of the frames registered to the source with the
    given source `source_id`.
    @throws std::exception if `source_id` does not map to a registered source.
    */
-  const std::unordered_set<FrameId>& FramesForSource(SourceId source_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->FramesForSource(source_id);
-  }
+  const std::unordered_set<FrameId>& FramesForSource(SourceId source_id) const;
 
   //@}
 
@@ -229,63 +190,42 @@ class SceneGraphInspector {
    @throws std::exception  If `frame_id` does not map to a registered frame
                            or `source_id` does not map to a registered source.
    */
-  bool BelongsToSource(FrameId frame_id, SourceId source_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->BelongsToSource(frame_id, source_id);
-  }
+  bool BelongsToSource(FrameId frame_id, SourceId source_id) const;
 
   /** Reports the _name_ of the geometry source that registered the frame with
    the given `frame_id`.
    @throws std::exception  If `frame_id` does not map to a registered frame.
    */
-  const std::string& GetOwningSourceName(FrameId frame_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetOwningSourceName(frame_id);
-  }
+  const std::string& GetOwningSourceName(FrameId frame_id) const;
 
   /** Reports the name of the frame with the given `frame_id`.
    @throws std::exception if `frame_id` does not map to a registered frame.
    */
-  const std::string& GetName(FrameId frame_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetName(frame_id);
-  }
+  const std::string& GetName(FrameId frame_id) const;
 
   /** Reports the FrameId of the parent of `frame_id`.
    @throws std::exception if `frame_id` does not map to a registered frame.
    */
-  FrameId GetParentFrame(FrameId frame_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetParentFrame(frame_id);
-  }
+  FrameId GetParentFrame(FrameId frame_id) const;
 
   /** Reports the frame group for the frame with the given `frame_id`.
    @throws std::exception if `frame_id` does not map to a registered frame.
    @internal This value is equivalent to the old "model instance id".  */
-  int GetFrameGroup(FrameId frame_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetFrameGroup(frame_id);
-  }
+  int GetFrameGroup(FrameId frame_id) const;
 
   /** Reports the number of geometries affixed to the frame with the given
    `frame_id`. This count does _not_ include geometries attached to frames that
    are descendants of this frame.
    @throws std::exception if `frame_id` does not map to a registered frame.
    */
-  int NumGeometriesForFrame(FrameId frame_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->NumGeometriesForFrame(frame_id);
-  }
+  int NumGeometriesForFrame(FrameId frame_id) const;
 
   /** Reports the total number of geometries with the given `role` directly
    registered to the frame with the given `frame_id`. This count does _not_
    include geometries attached to frames that are descendants of this frame.
    @throws std::exception if `frame_id` does not map to a registered frame.
    */
-  int NumGeometriesForFrameWithRole(FrameId frame_id, Role role) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->NumGeometriesForFrameWithRole(frame_id, role);
-  }
+  int NumGeometriesForFrameWithRole(FrameId frame_id, Role role) const;
 
   /** Returns geometry ids that have been registered directly to the frame
    indicated by `frame_id`. If a `role` is provided, only geometries with that
@@ -296,10 +236,7 @@ class SceneGraphInspector {
    @returns The requested unique geometry ids in a consistent order.
    @throws std::exception if `id` does not map to a registered frame.  */
   std::vector<GeometryId> GetGeometries(
-      FrameId frame_id, const std::optional<Role>& role = std::nullopt) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetGeometries(frame_id, role);
-  }
+      FrameId frame_id, const std::optional<Role>& role = std::nullopt) const;
 
   /** Reports the id of the geometry with the given `name` and `role`, attached
    to the frame with the given frame `frame_id`.
@@ -315,10 +252,7 @@ class SceneGraphInspector {
                           that name, or if the `frame_id` does not map to a
                           registered frame.  */
   GeometryId GetGeometryIdByName(FrameId frame_id, Role role,
-                                 const std::string& name) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetGeometryIdByName(frame_id, role, name);
-  }
+                                 const std::string& name) const;
 
   //@}
 
@@ -333,46 +267,31 @@ class SceneGraphInspector {
    @throws std::exception  If `geometry_id` does not map to a registered
                            geometry or `source_id` does not map to a
                            registered source.  */
-  bool BelongsToSource(GeometryId geometry_id, SourceId source_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->BelongsToSource(geometry_id, source_id);
-  }
+  bool BelongsToSource(GeometryId geometry_id, SourceId source_id) const;
 
   /** Reports the _name_ of the geometry source that registered the geometry
    with the given `geometry_id`.
    @throws std::exception  If `geometry_id` does not map to a registered
    geometry. */
-  const std::string& GetOwningSourceName(GeometryId geometry_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetOwningSourceName(geometry_id);
-  }
+  const std::string& GetOwningSourceName(GeometryId geometry_id) const;
 
   /** Reports the id of the frame to which the given geometry with the given
    `geometry_id` is registered.
    @throws std::exception if `geometry_id` does not map to a registered
    geometry.  */
-  FrameId GetFrameId(GeometryId geometry_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetFrameId(geometry_id);
-  }
+  FrameId GetFrameId(GeometryId geometry_id) const;
 
   /** Reports the stored, canonical name of the geometry with the given
    `geometry_id` (see  @ref canonicalized_geometry_names "GeometryInstance" for
    details).
    @throws std::exception if `geometry_id` does not map to a registered
    geometry.  */
-  const std::string& GetName(GeometryId geometry_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetName(geometry_id);
-  }
+  const std::string& GetName(GeometryId geometry_id) const;
 
   /** Returns the shape specified for the geometry with the given `geometry_id`.
    In order to extract the details of the shape, it should be passed through an
    implementation of a ShapeReifier.  */
-  const Shape& GetShape(GeometryId geometry_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetShape(geometry_id);
-  }
+  const Shape& GetShape(GeometryId geometry_id) const;
 
   /** Reports the pose of the geometry G with the given `geometry_id` in its
    registered _topological parent_ P, `X_PG`. That topological parent may be a
@@ -382,10 +301,7 @@ class SceneGraphInspector {
    @throws std::exception if `geometry_id` does not map to a registered
    geometry.  */
   const math::RigidTransform<double>& GetPoseInParent(
-      GeometryId geometry_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetPoseInParent(geometry_id);
-  }
+      GeometryId geometry_id) const;
 
   /** Reports the pose of the geometry G with the given `geometry_id` in its
    registered frame F (regardless of whether its _topological parent_ is another
@@ -395,10 +311,7 @@ class SceneGraphInspector {
    @throws std::exception if `geometry_id` does not map to a registered
    geometry.  */
   const math::RigidTransform<double>& GetPoseInFrame(
-      GeometryId geometry_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetPoseInFrame(geometry_id);
-  }
+      GeometryId geometry_id) const;
 
   /** Returns the *mesh* used to represent this geometry in hydroelastic contact
    calculations, if it exists. Most primitives (sphere, cylinder, etc.) are
@@ -426,10 +339,7 @@ class SceneGraphInspector {
    @returns The associated mesh, if it exists. */
   std::variant<std::monostate, const TriangleSurfaceMesh<double>*,
                const VolumeMesh<double>*>
-  maybe_get_hydroelastic_mesh(GeometryId geometry_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->maybe_get_hydroelastic_mesh(geometry_id);
-  }
+  maybe_get_hydroelastic_mesh(GeometryId geometry_id) const;
 
   /** Return a pointer to the const properties indicated by `role` of the
    geometry with the given `geometry_id`.
@@ -440,20 +350,7 @@ class SceneGraphInspector {
    @throws std::exception if `geometry_id` does not map to a registered
            geometry.  */
   const GeometryProperties* GetProperties(GeometryId geometry_id,
-                                          Role role) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    switch (role) {
-      case Role::kProximity:
-        return state_->GetProximityProperties(geometry_id);
-      case Role::kIllustration:
-        return state_->GetIllustrationProperties(geometry_id);
-      case Role::kPerception:
-        return state_->GetPerceptionProperties(geometry_id);
-      case Role::kUnassigned:
-        return nullptr;
-    }
-    return nullptr;
-  }
+                                          Role role) const;
 
   /** Returns a pointer to the const proximity properties of the geometry with
    the given `geometry_id`.
@@ -463,10 +360,7 @@ class SceneGraphInspector {
    @throws std::exception if `geometry_id` does not map to a registered
            geometry.  */
   const ProximityProperties* GetProximityProperties(
-      GeometryId geometry_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetProximityProperties(geometry_id);
-  }
+      GeometryId geometry_id) const;
 
   /** Returns a pointer to the const illustration properties of the geometry
    with the given `geometry_id`.
@@ -476,10 +370,7 @@ class SceneGraphInspector {
    @throws std::exception if `geometry_id` does not map to a registered
            geometry.  */
   const IllustrationProperties* GetIllustrationProperties(
-      GeometryId geometry_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetIllustrationProperties(geometry_id);
-  }
+      GeometryId geometry_id) const;
 
   /** Returns a pointer to the const perception properties of the geometry
    with the given `geometry_id`.
@@ -489,10 +380,7 @@ class SceneGraphInspector {
    @throws std::exception if `geometry_id` does not map to a registered
            geometry.  */
   const PerceptionProperties* GetPerceptionProperties(
-      GeometryId geometry_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetPerceptionProperties(geometry_id);
-  }
+      GeometryId geometry_id) const;
 
   /** Reports true if the two geometries with given ids `geometry_id1` and
    `geometry_id2`, define a collision pair that has been filtered out.
@@ -500,10 +388,7 @@ class SceneGraphInspector {
                           or if any of the geometries do not have a proximity
                           role.  */
   bool CollisionFiltered(GeometryId geometry_id1,
-                         GeometryId geometry_id2) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->CollisionFiltered(geometry_id1, geometry_id2);
-  }
+                         GeometryId geometry_id2) const;
 
   /** Introspects the geometry indicated by the given `geometry_id`. The
    geometry will be passed into the provided `reifier`. This is the mechanism by
@@ -511,10 +396,7 @@ class SceneGraphInspector {
    geometries stored in SceneGraph. See ShapeToString as an example.
    @throws std::exception if the `geometry_id` does not refer to a valid
    geometry.  */
-  void Reify(GeometryId geometry_id, ShapeReifier* reifier) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    state_->GetShape(geometry_id).Reify(reifier);
-  }
+  void Reify(GeometryId geometry_id, ShapeReifier* reifier) const;
 
   /** Obtains a new GeometryInstance that copies the geometry indicated by the
    given `geometry_id`.

--- a/geometry/test/drake_visualizer_test.cc
+++ b/geometry/test/drake_visualizer_test.cc
@@ -14,6 +14,7 @@
 #include "drake/geometry/frame_kinematics_vector.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/proximity_properties.h"
 #include "drake/geometry/rgba.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/geometry/shape_specification.h"

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -8,6 +8,7 @@
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/geometry_state.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/math/rigid_transform.h"
 

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -8,6 +8,7 @@
 
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/geometry_state.h"
 
 namespace drake {
 namespace geometry {

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -11,6 +11,7 @@
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/geometry_set.h"
+#include "drake/geometry/geometry_state.h"
 #include "drake/geometry/query_object.h"
 #include "drake/geometry/render/render_label.h"
 #include "drake/geometry/shape_specification.h"

--- a/multibody/contact_solvers/test/multibody_sim_driver.cc
+++ b/multibody/contact_solvers/test/multibody_sim_driver.cc
@@ -1,6 +1,7 @@
 #include "drake/multibody/contact_solvers/test/multibody_sim_driver.h"
 
 #include "drake/geometry/drake_visualizer.h"
+#include "drake/geometry/proximity_properties.h"
 
 namespace drake {
 namespace multibody {

--- a/multibody/hydroelastics/hydroelastic_engine.cc
+++ b/multibody/hydroelastics/hydroelastic_engine.cc
@@ -8,6 +8,7 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/geometry/geometry_roles.h"
+#include "drake/geometry/proximity_properties.h"
 
 namespace drake {
 namespace multibody {

--- a/multibody/hydroelastics/test/hydroelastic_engine_test.cc
+++ b/multibody/hydroelastics/test/hydroelastic_engine_test.cc
@@ -8,6 +8,7 @@
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/proximity_properties.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/geometry/shape_specification.h"
 #include "drake/math/rigid_transform.h"

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -9,6 +9,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/scope_exit.h"
 #include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/proximity_properties.h"
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/contact_solvers/contact_solver.h"

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -4194,20 +4194,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // consistent and helpful error message in the situation where the
   // geometry_query_input_port is not connected, but is expected to be.
   const geometry::QueryObject<T>& EvalGeometryQueryInput(
-      const systems::Context<T>& context) const {
-    this->ValidateContext(context);
-    if (!get_geometry_query_input_port().HasValue(context)) {
-      throw std::logic_error(
-          "The geometry query input port (see "
-          "MultibodyPlant::get_geometry_query_input_port()) "
-          "of this MultibodyPlant is not connected. Please connect the"
-          "geometry query output port of a SceneGraph object "
-          "(see SceneGraph::get_query_output_port()) to this plants input "
-          "port in a Diagram.");
-    }
-    return get_geometry_query_input_port()
-        .template Eval<geometry::QueryObject<T>>(context);
-  }
+      const systems::Context<T>& context) const;
 
   // Helper to acquire per-geometry contact parameters from SG.
   // Returns the pair (stiffness, dissipation)
@@ -4215,33 +4202,13 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // isn't assigned that parameter.
   std::pair<T, T> GetPointContactParameters(
       geometry::GeometryId id,
-      const geometry::SceneGraphInspector<T>& inspector) const {
-    const geometry::ProximityProperties* prop =
-        inspector.GetProximityProperties(id);
-    DRAKE_DEMAND(prop != nullptr);
-    return std::pair(prop->template GetPropertyOrDefault<T>(
-                         geometry::internal::kMaterialGroup,
-                         geometry::internal::kPointStiffness,
-                         penalty_method_contact_parameters_.geometry_stiffness),
-                     prop->template GetPropertyOrDefault<T>(
-                         geometry::internal::kMaterialGroup,
-                         geometry::internal::kHcDissipation,
-                         penalty_method_contact_parameters_.dissipation));
-  }
+      const geometry::SceneGraphInspector<T>& inspector) const;
 
   // Helper to acquire per-geometry Coulomb friction coefficients from
   // SceneGraph.
   const CoulombFriction<double>& GetCoulombFriction(
       geometry::GeometryId id,
-      const geometry::SceneGraphInspector<T>& inspector) const {
-    const geometry::ProximityProperties* prop =
-        inspector.GetProximityProperties(id);
-    DRAKE_DEMAND(prop != nullptr);
-    DRAKE_THROW_UNLESS(prop->HasProperty(geometry::internal::kMaterialGroup,
-                                         geometry::internal::kFriction));
-    return prop->GetProperty<CoulombFriction<double>>(
-        geometry::internal::kMaterialGroup, geometry::internal::kFriction);
-  }
+      const geometry::SceneGraphInspector<T>& inspector) const;
 
   // Helper method to apply collision filters based on body-adjacency. By
   // default, we don't consider collisions between geometries affixed to

--- a/multibody/plant/test/compliant_contact_manager_test.cc
+++ b/multibody/plant/test/compliant_contact_manager_test.cc
@@ -4,6 +4,8 @@
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/proximity/volume_mesh_field.h"
+#include "drake/geometry/proximity_properties.h"
 #include "drake/multibody/contact_solvers/pgs_solver.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/prismatic_joint.h"

--- a/multibody/plant/test/multibody_plant_hydroelastic_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_test.cc
@@ -8,6 +8,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/drake_visualizer.h"
+#include "drake/geometry/proximity_properties.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/multibody/plant/contact_results_to_lcm.h"
 #include "drake/multibody/plant/multibody_plant.h"

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -20,6 +20,7 @@
 #include "drake/common/test_utilities/limit_malloc.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_roles.h"
+#include "drake/geometry/proximity_properties.h"
 #include "drake/geometry/query_object.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/geometry/test_utilities/dummy_render_engine.h"


### PR DESCRIPTION
It brings in many other header files (e.g., proximity engine) that would not typically be used by users of the model inspector, multibody plant, etc., and thus leads to bloated compile times (approximately 0.5 seconds per TU).

Move some overly-inlined code from h to cc files to match.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16591)
<!-- Reviewable:end -->
