### PR TITLE
[multibody/parsing] Splitting up existing ModelDirectives tests

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -344,6 +344,20 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "scoped_names_test",
+    data = [
+        ":test_models",
+    ],
+    deps = [
+        ":parser",
+        ":scoped_names",
+        "//common:filesystem",
+        "//common:find_resource",
+        "//common/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
     name = "model_directives_test",
     deps = [
         ":model_directives",

--- a/multibody/parsing/test/process_model_directives_test.cc
+++ b/multibody/parsing/test/process_model_directives_test.cc
@@ -18,6 +18,7 @@ namespace parsing {
 namespace {
 
 using std::optional;
+using Eigen::Vector3d;
 using drake::math::RigidTransformd;
 using drake::multibody::AddMultibodyPlantSceneGraph;
 using drake::multibody::Frame;
@@ -76,21 +77,15 @@ GTEST_TEST(ProcessModelDirectivesTest, AddScopedSmokeTest) {
   plant.Finalize();
   auto diagram = builder.Build();
 
-  // Query information and ensure we have expected results.
-  // - Manually spell out one example.
-  ASSERT_EQ(
-      &GetScopedFrameByName(plant, "left::simple_model::frame"),
-      &plant.GetFrameByName(
-          "frame", plant.GetModelInstanceByName("left::simple_model")));
-  // - Automate other stuff.
+  // Helper lambda for checking existence of frame in model scope.
   auto check_frame = [&plant](
       const std::string instance, const std::string frame) {
     const std::string scoped_frame = instance + "::" + frame;
     drake::log()->debug("Check: {}", scoped_frame);
-    ASSERT_EQ(
-        &GetScopedFrameByName(plant, scoped_frame),
-        &plant.GetFrameByName(frame, plant.GetModelInstanceByName(instance)));
+    EXPECT_TRUE(
+        plant.HasFrameNamed(frame, plant.GetModelInstanceByName(instance)));
   };
+  // Query information and ensure we have expected results.
   for (const std::string prefix : {"", "left::", "right::", "mid::nested::"}) {
     const std::string simple_model = prefix + "simple_model";
     check_frame(simple_model, "base");
@@ -101,6 +96,104 @@ GTEST_TEST(ProcessModelDirectivesTest, AddScopedSmokeTest) {
     check_frame(extra_model, "base");
     check_frame(extra_model, "frame");
   }
+  // - Checking simple_model_test_frame frames that have model namespaces.
+  for (const std::string model_namespace : {"left", "right", "mid::nested"}) {
+    check_frame(model_namespace, "simple_model_test_frame");
+  }
+  // - Checking for simple_model_test_frame that was added without a model
+  // namespace. This frame was added without a model namespace, but ties itself
+  // to the model namespace of its base frame instead of the world. See next
+  // test, AddFrameWithoutScope, for a more concrete example.
+  check_frame("simple_model", "simple_model_test_frame");
+}
+
+// Tests for frames added without a model name, but different base_frame.
+GTEST_TEST(ProcessModelDirectivesTest, AddFrameWithoutScope) {
+  ModelDirectives directives = LoadModelDirectives(
+      FindResourceOrThrow(
+          std::string(kTestDir) + "/add_frame_without_model_namespace.yaml"));
+
+  // Ensure that we have a SceneGraph present so that we test relevant visual
+  // pieces.
+  DiagramBuilder<double> builder;
+  MultibodyPlant<double>& plant = AddMultibodyPlantSceneGraph(&builder, 0.);
+  ProcessModelDirectives(directives, &plant,
+                         nullptr, make_parser(&plant).get());
+  plant.Finalize();
+  auto diagram = builder.Build();
+
+  // When a frame is added without a namespace, it will scope itself under the
+  // base_frame's model instance.
+
+  // Frame added with world as base frame.
+  EXPECT_TRUE(
+      plant.HasFrameNamed("world_as_base_frame", world_model_instance()));
+
+  // Frame added with included model as base frame.
+  auto simple_model_instance = plant.GetModelInstanceByName("simple_model");
+  EXPECT_TRUE(
+      plant.HasFrameNamed("included_as_base_frame", simple_model_instance));
+}
+
+// Test backreference behavior in ModelDirectives.
+GTEST_TEST(ProcessModelDirectivesTest, TestBackreferences) {
+  ModelDirectives directives = LoadModelDirectives(
+      FindResourceOrThrow(std::string(kTestDir) + "/test_backreferences.yaml"));
+
+  // Ensure that we have a SceneGraph present so that we test relevant visual
+  // pieces.
+  DiagramBuilder<double> builder;
+  MultibodyPlant<double>& plant = AddMultibodyPlantSceneGraph(&builder, 0.);
+  ProcessModelDirectives(directives, &plant,
+                         nullptr, make_parser(&plant).get());
+  plant.Finalize();
+  auto diagram = builder.Build();
+
+  // Weld joint for the model without a namespace is placed under simple_model
+  // instead of world.
+  EXPECT_TRUE(plant.HasJointNamed(
+      "simple_model_origin_welds_to_base",
+      plant.GetModelInstanceByName("simple_model")));
+
+  // Weld joint for the nested model.
+  EXPECT_TRUE(plant.HasJointNamed(
+      "simple_model_origin_welds_to_base",
+      plant.GetModelInstanceByName("nested::simple_model")));
+}
+
+// Test frame injection in ModelDirectives.
+GTEST_TEST(ProcessModelDirectivesTest, InjectFrames) {
+  ModelDirectives directives = LoadModelDirectives(
+      FindResourceOrThrow(std::string(kTestDir) + "/inject_frames.yaml"));
+
+  // Ensure that we have a SceneGraph present so that we test relevant visual
+  // pieces.
+  DiagramBuilder<double> builder;
+  MultibodyPlant<double>& plant = AddMultibodyPlantSceneGraph(&builder, 0.);
+  ProcessModelDirectives(directives, &plant,
+                         nullptr, make_parser(&plant).get());
+  plant.Finalize();
+  auto diagram = builder.Build();
+  auto context = plant.CreateDefaultContext();
+
+  // Check that injected frames exist.
+  EXPECT_TRUE(plant.HasFrameNamed(
+      "top_injected_frame", plant.GetModelInstanceByName("top_level_model")));
+  EXPECT_TRUE(plant.HasFrameNamed(
+      "base", plant.GetModelInstanceByName("mid_level_model")));
+
+  // Check for pose of welded models' base.
+  EXPECT_TRUE(plant
+      .GetFrameByName("base", plant.GetModelInstanceByName("mid_level_model"))
+      .CalcPoseInWorld(*context)
+      .translation()
+      .isApprox(Vector3d(1, 2, 3)));
+  EXPECT_TRUE(plant
+      .GetFrameByName("base",
+                      plant.GetModelInstanceByName("bottom_level_model"))
+      .CalcPoseInWorld(*context)
+      .translation()
+      .isApprox(Vector3d(2, 4, 6)));
 }
 
 // Make sure we have good error messages.

--- a/multibody/parsing/test/process_model_directives_test/add_frame_without_model_namespace.yaml
+++ b/multibody/parsing/test/process_model_directives_test/add_frame_without_model_namespace.yaml
@@ -1,0 +1,21 @@
+# This file tests the model namespaces of added frames, on the world level,
+# with different base_frame.
+
+directives:
+
+# Adding simple_model.
+- add_model:
+    name: simple_model
+    file: package://process_model_directives_test/simple_model.sdf
+
+# Adding frame with world as base_frame.
+- add_frame:
+    name: world_as_base_frame
+    X_PF:
+      base_frame: world
+
+# Adding frame with simple_model as base_frame.
+- add_frame:
+    name: included_as_base_frame
+    X_PF:
+      base_frame: simple_model::__model__

--- a/multibody/parsing/test/process_model_directives_test/add_scoped_mid.yaml
+++ b/multibody/parsing/test/process_model_directives_test/add_scoped_mid.yaml
@@ -6,17 +6,12 @@
 directives:
 - add_model_instance:
     name: nested
-- add_frame:
-    name: nested::simple_model_origin
-    X_PF:
-      base_frame: world
-      translation: [10, 0, 0]
 - add_directives:
     file: package://process_model_directives_test/add_scoped_sub.yaml
     model_namespace: nested
-
-# Include a test for model directives backreferences (which are possibly a bug;
-# see the included file for details)
-- add_directives:
-    file: package://process_model_directives_test/add_backreference.yaml
-    model_namespace: nested
+# This frame is only for testing name scoping.
+# TODO(aaronchongth): Add testing for posturing and welding.
+- add_frame:
+    name: nested::simple_model_test_frame
+    X_PF:
+      base_frame: nested::simple_model::__model__

--- a/multibody/parsing/test/process_model_directives_test/add_scoped_top.yaml
+++ b/multibody/parsing/test/process_model_directives_test/add_scoped_top.yaml
@@ -7,12 +7,6 @@ directives:
 # N.B. The namespacing features are only available for RBT.
 
 # No namespace.
-# N.B. If this were added after the namespaced instances, `simple_model_origin`
-# would cause a failure because it appears in multiple model instances.
-- add_frame:
-    name: simple_model_origin
-    X_PF:
-      base_frame: world
 - add_directives:
     file: package://process_model_directives_test/add_scoped_sub.yaml
 - add_frame:
@@ -20,17 +14,19 @@ directives:
     X_PF:
       base_frame: simple_model::sub_added_frame
       translation: [5, 10, 15]
+# N.B. If this were added after the namespaced instances,
+# `simple_model_test_frame` would cause a failure because it appears in multiple
+# model instances.
+- add_frame:
+    name: simple_model_test_frame
+    X_PF:
+      base_frame: simple_model::__model__
 
 # Left.
 - add_model_instance:
     # `model_namespace` requires a corresponding model instance so that frames
     # can be added to it.
     name: left
-- add_frame:
-    name: left::simple_model_origin
-    X_PF:
-      base_frame: world
-      translation: [0, 1, 0]
 - add_directives:
     file: package://process_model_directives_test/add_scoped_sub.yaml
     model_namespace: left
@@ -39,15 +35,16 @@ directives:
     X_PF:
       base_frame: left::simple_model::sub_added_frame
       translation: [5, 10, 15]
+# This frame is only for testing name scoping.
+# TODO(aaronchongth): Add testing for posturing and welding.
+- add_frame:
+    name: left::simple_model_test_frame
+    X_PF:
+      base_frame: left::simple_model::__model__
 
 # Right.
 - add_model_instance:
     name: right
-- add_frame:
-    name: right::simple_model_origin
-    X_PF:
-      base_frame: world
-      translation: [0, -1, 0]
 - add_directives:
     file: package://process_model_directives_test/add_scoped_sub.yaml
     model_namespace: right
@@ -56,6 +53,12 @@ directives:
     X_PF:
       base_frame: right::simple_model::sub_added_frame
       translation: [5, 10, 15]
+# This frame is only for testing name scoping.
+# TODO(aaronchongth): Add testing for posturing and welding.
+- add_frame:
+    name: right::simple_model_test_frame
+    X_PF:
+      base_frame: right::simple_model::__model__
 
 # Mid (nested).
 - add_model_instance:

--- a/multibody/parsing/test/process_model_directives_test/inject_frames.yaml
+++ b/multibody/parsing/test/process_model_directives_test/inject_frames.yaml
@@ -1,0 +1,43 @@
+# This file shows that we are able to inject frames into included models using
+# ModelDirectives. This workflow allows users to posture and/or weld other
+# models onto injected frames that would be relative to a nested model.
+# For example, injecting a frame onto a robot arm model's gripper, and welding
+# a newly included tool model onto it for the robot to use.
+
+directives:
+
+# Top level model, for example the robot arm.
+- add_model:
+    name: top_level_model
+    file: package://process_model_directives_test/simple_model.sdf
+
+# Injecting a frame from the world level into top_level_model, for example the
+# gripper of the robot arm.
+- add_frame:
+    name: top_injected_frame
+    X_PF:
+      base_frame: top_level_model::base
+      translation: [1, 2, 3]
+
+# Including a new model, for example a new tool.
+- add_model:
+    name: mid_level_model
+    file: package://process_model_directives_test/simple_model.sdf
+
+# Welding the newly included tool to top_injected_frame, from the world level.
+- add_weld:
+    parent: top_injected_frame
+    child: mid_level_model::base
+
+# Repeat the steps for another level lower.
+- add_frame:
+    name: mid_injected_frame
+    X_PF:
+      base_frame: mid_level_model::base
+      translation: [1, 2, 3]
+- add_model:
+    name: bottom_level_model
+    file: package://process_model_directives_test/simple_model.sdf
+- add_weld:
+    parent: mid_injected_frame
+    child: bottom_level_model::base

--- a/multibody/parsing/test/process_model_directives_test/test_backreferences.yaml
+++ b/multibody/parsing/test/process_model_directives_test/test_backreferences.yaml
@@ -1,0 +1,34 @@
+# This file is for testing the backreference behavior of Model Directives, which
+# is possibly a design flaw; see README for more information.
+
+directives:
+
+# Adding simple_model and a simple_model_origin frame.
+- add_model:
+    name: simple_model
+    file: package://process_model_directives_test/simple_model.sdf
+- add_frame:
+    name: simple_model_origin
+    X_PF:
+      base_frame: world
+
+# Including a backreference without specifying a model namespace.
+- add_directives:
+    file: package://process_model_directives_test/add_backreference.yaml
+
+# Including simple_model within another model namespace called 'nested'.
+- add_model_instance:
+    name: nested
+- add_directives:
+    file: package://process_model_directives_test/add_scoped_sub.yaml
+    model_namespace: nested
+- add_frame:
+    name: nested::simple_model_origin
+    X_PF:
+      base_frame: world
+      translation: [1, 2, 3]
+
+# Including the same backreference under the 'nested' model namespace.
+- add_directives:
+    file: package://process_model_directives_test/add_backreference.yaml
+    model_namespace: nested

--- a/multibody/parsing/test/scoped_names_model.sdf
+++ b/multibody/parsing/test/scoped_names_model.sdf
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<sdf xmlns:drake="http://drake.mit.edu" version="1.9">
+  <model name="scoped_names_model">
+    <link name="base">
+      <inertial>
+        <mass>1</mass>
+      </inertial>
+      <visual name="visual">
+        <geometry>
+          <box>
+            <size>0.2 0.2 2.2</size>
+          </box>
+        </geometry>
+      </visual>
+    </link>
+    <frame name="frame">
+      <pose relative_to="base">1 2 3  0 0 0</pose>
+    </frame>
+
+    <model name="inner_model">
+      <link name="inner_link"/>
+      <frame name="inner_frame"/>
+    </model>
+  </model>
+</sdf>

--- a/multibody/parsing/test/scoped_names_test.cc
+++ b/multibody/parsing/test/scoped_names_test.cc
@@ -1,0 +1,39 @@
+#include "drake/multibody/parsing/scoped_names.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/filesystem.h"
+#include "drake/common/find_resource.h"
+#include "drake/multibody/parsing/parser.h"
+
+namespace drake {
+namespace multibody {
+namespace parsing {
+namespace {
+
+GTEST_TEST(ScopedNamesTest, GetScopedFrameByName) {
+  const std::string full_name = FindResourceOrThrow(
+      "drake/multibody/parsing/test/scoped_names_model.sdf");
+
+  MultibodyPlant<double> plant(0.0);
+  Parser parser(&plant);
+  parser.AddModelFromFile(full_name);
+  plant.Finalize();
+
+  ASSERT_EQ(
+      &GetScopedFrameByName(plant, "scoped_names_model::frame"),
+      &plant.GetFrameByName(
+          "frame", plant.GetModelInstanceByName("scoped_names_model")));
+
+  ASSERT_EQ(
+      &GetScopedFrameByName(
+          plant, "scoped_names_model::inner_model::inner_frame"),
+      &plant.GetFrameByName(
+          "inner_frame",
+          plant.GetModelInstanceByName("scoped_names_model::inner_model")));
+}
+
+}  // namespace
+}  // namespace parsing
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Per discussion in https://github.com/RobotLocomotion/drake/pull/16431, with @EricCousineau-TRI.

Separated tests for ModelDirectives into
* scoping (what we have currently, with some additional checks)
* back referencing during include
* frame injection from top level models
* new test showing the behavior of adding frames without a model namespace, but with different base frames

Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16593)
<!-- Reviewable:end -->
