### PR TITLE
[parsing] Fix mis-parse of collision filter groups

### DIFF
--- a/multibody/parsing/detail_common.cc
+++ b/multibody/parsing/detail_common.cc
@@ -149,8 +149,8 @@ void CollectCollisionFilterGroup(
        std::holds_alternative<sdf::ElementPtr>(ignore_node)
            ? std::get<sdf::ElementPtr>(ignore_node) != nullptr
            : std::get<tinyxml2::XMLElement*>(ignore_node) != nullptr;
-       ignore_node =
-           next_sibling_element(ignore_node, "drake:collision_filter_group")) {
+       ignore_node = next_sibling_element(
+           ignore_node, "drake:ignored_collision_filter_group")) {
     const std::string target_name = read_tag_string(ignore_node, "name");
 
     // These two group names are allowed to be identical, which means the

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -825,49 +825,55 @@ GTEST_TEST(MultibodyPlantUrdfParserTest, CollisionFilterGroupParsingTest) {
   // Get geometry ids for all the bodies.
   const geometry::SceneGraphInspector<double>& inspector =
       scene_graph.model_inspector();
-  const auto geometry_id_link1 = inspector.GetGeometryIdByName(
-      plant.GetBodyFrameIdOrThrow(plant.GetBodyByName("link1").index()),
-      geometry::Role::kProximity,
-      "collision_filter_group_parsing_test::link1_sphere");
-  const auto geometry_id_link2 = inspector.GetGeometryIdByName(
-      plant.GetBodyFrameIdOrThrow(plant.GetBodyByName("link2").index()),
-      geometry::Role::kProximity,
-      "collision_filter_group_parsing_test::link2_sphere");
-  const auto geometry_id_link3 = inspector.GetGeometryIdByName(
-      plant.GetBodyFrameIdOrThrow(plant.GetBodyByName("link3").index()),
-      geometry::Role::kProximity,
-      "collision_filter_group_parsing_test::link3_sphere");
-  const auto geometry_id_link4 = inspector.GetGeometryIdByName(
-      plant.GetBodyFrameIdOrThrow(plant.GetBodyByName("link4").index()),
-      geometry::Role::kProximity,
-      "collision_filter_group_parsing_test::link4_sphere");
+  static constexpr int kNumLinks = 6;
+  std::vector<GeometryId> ids(1 + kNumLinks);  // allow 1-based indices.
+  for (int k = 1; k <= 6; ++k) {
+    const auto geometry_id = inspector.GetGeometryIdByName(
+        plant.GetBodyFrameIdOrThrow(
+            plant.GetBodyByName(fmt::format("link{}", k)).index()),
+        geometry::Role::kProximity,
+        fmt::format("collision_filter_group_parsing_test::link{}_sphere", k));
+    ids[k] = geometry_id;
+  }
 
   // Make sure the plant is not finalized such that the adjacent joint filter
   // has not taken into effect yet. This guarantees that the collision filtering
   // is applied due to the collision filter group parsing.
   ASSERT_FALSE(plant.is_finalized());
 
-  // We have four geometries and six possible pairs, each with a particular
+  // We have six geometries and 15 possible pairs, each with a particular
   // disposition.
   // (1, 2) - unfiltered
-  // (1, 3) - filtered by group_link_3 ignores group_link_14
-  // (1, 4) - filtered by group_link_14 ignores itself
-  // (2, 3) - filtered by group_link_2 ignores group_link_3
+  EXPECT_FALSE(inspector.CollisionFiltered(ids[1], ids[2]));
+  // (1, 3) - filtered by group_link3 ignores group_link14
+  EXPECT_TRUE(inspector.CollisionFiltered(ids[1], ids[3]));
+  // (1, 4) - filtered by group_link14 ignores itself
+  EXPECT_TRUE(inspector.CollisionFiltered(ids[1], ids[4]));
+  // (1, 5) - unfiltered
+  EXPECT_FALSE(inspector.CollisionFiltered(ids[1], ids[5]));
+  // (1, 6) - unfiltered
+  EXPECT_FALSE(inspector.CollisionFiltered(ids[1], ids[6]));
+  // (2, 3) - filtered by group_link2 ignores group_link3
+  EXPECT_TRUE(inspector.CollisionFiltered(ids[2], ids[3]));
   // (2, 4) - unfiltered (although declared in an *ignored* self-filtering
-  // group_link_24).
-  // (3, 4) - filtered by group_link_3 ignores group_link_14
-  EXPECT_FALSE(
-      inspector.CollisionFiltered(geometry_id_link1, geometry_id_link2));
-  EXPECT_TRUE(
-      inspector.CollisionFiltered(geometry_id_link1, geometry_id_link3));
-  EXPECT_TRUE(
-      inspector.CollisionFiltered(geometry_id_link1, geometry_id_link4));
-  EXPECT_TRUE(
-      inspector.CollisionFiltered(geometry_id_link2, geometry_id_link3));
-  EXPECT_FALSE(
-      inspector.CollisionFiltered(geometry_id_link2, geometry_id_link4));
-  EXPECT_TRUE(
-      inspector.CollisionFiltered(geometry_id_link3, geometry_id_link4));
+  // group_link24).
+  EXPECT_FALSE(inspector.CollisionFiltered(ids[2], ids[4]));
+  // (2, 5) - filtered by group_link56 ignored group_link2
+  EXPECT_TRUE(inspector.CollisionFiltered(ids[2], ids[5]));
+  // (2, 6) - filtered by group_link56 ignored group_link2
+  EXPECT_TRUE(inspector.CollisionFiltered(ids[2], ids[6]));
+  // (3, 4) - filtered by group_link3 ignores group_link14
+  EXPECT_TRUE(inspector.CollisionFiltered(ids[3], ids[4]));
+  // (3, 5) - filtered by group_link56 ignored group_link3
+  EXPECT_TRUE(inspector.CollisionFiltered(ids[3], ids[5]));
+  // (3, 6) - filtered by group_link56 ignored group_link3
+  EXPECT_TRUE(inspector.CollisionFiltered(ids[3], ids[6]));
+  // (4, 5) - unfiltered
+  EXPECT_FALSE(inspector.CollisionFiltered(ids[4], ids[5]));
+  // (4, 6) - unfiltered
+  EXPECT_FALSE(inspector.CollisionFiltered(ids[4], ids[6]));
+  // (5, 6) - filtered by group_link56 ignores itself
+  EXPECT_TRUE(inspector.CollisionFiltered(ids[5], ids[6]));
 
   // Make sure we can add the model a second time.
   AddModelFromUrdfFile(full_name, "model2", package_map, &plant, &scene_graph);

--- a/multibody/parsing/test/sdf_parser_test/collision_filter_group_parsing_test.sdf
+++ b/multibody/parsing/test/sdf_parser_test/collision_filter_group_parsing_test.sdf
@@ -2,20 +2,7 @@
 <sdf xmlns:drake="http://drake.mit.edu" version='1.7'>
   <model name='collision_filter_group_parsing_test'>
     <link name='link1'>
-      <inertial>
-        <pose>0 0 0 0 -0 0</pose>
-        <mass>1</mass>
-        <inertia>
-          <ixx>0.1</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.1</iyy>
-          <iyz>0</iyz>
-          <izz>0.1</izz>
-        </inertia>
-      </inertial>
       <collision name='link1_sphere'>
-        <pose>0 0 0 1.5708 -0 0</pose>
         <geometry>
           <sphere>
             <radius>0.4</radius>
@@ -24,39 +11,12 @@
       </collision>
     </link>
     <joint name='revolute_joint_12' type='revolute'>
-      <pose relative_to='link1'>0 0 0.15 0 -0 0</pose>
       <parent>link1</parent>
       <child>link2</child>
-      <axis>
-        <xyz>0 0 1</xyz>
-        <limit>
-          <lower>-1</lower>
-          <upper>2</upper>
-          <effort>100</effort>
-          <velocity>100</velocity>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
+      <axis/>
     </joint>
     <link name='link2'>
-      <pose relative_to='revolute_joint_12'>0 0 0 0 -0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 -0 0</pose>
-        <mass>1</mass>
-        <inertia>
-          <ixx>0.1</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.1</iyy>
-          <iyz>0</iyz>
-          <izz>0.1</izz>
-        </inertia>
-      </inertial>
       <collision name='link2_sphere'>
-        <pose>0 0 0 1.5708 -0 0</pose>
         <geometry>
           <sphere>
             <radius>0.4</radius>
@@ -65,39 +25,12 @@
       </collision>
     </link>
     <joint name='revolute_joint_23' type='revolute'>
-      <pose relative_to='link2'>0 0 0.15 0 -0 0</pose>
       <parent>link2</parent>
       <child>link3</child>
-      <axis>
-        <xyz>0 0 1</xyz>
-        <limit>
-          <lower>-1</lower>
-          <upper>2</upper>
-          <effort>100</effort>
-          <velocity>100</velocity>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
+      <axis/>
     </joint>
     <link name='link3'>
-      <pose relative_to='revolute_joint_23'>0 0 0 0 -0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 -0 0</pose>
-        <mass>1</mass>
-        <inertia>
-          <ixx>0.1</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.1</iyy>
-          <iyz>0</iyz>
-          <izz>0.1</izz>
-        </inertia>
-      </inertial>
       <collision name='link3_sphere'>
-        <pose>0 0 0 1.5708 -0 0</pose>
         <geometry>
           <sphere>
             <radius>0.4</radius>
@@ -106,39 +39,40 @@
       </collision>
     </link>
     <joint name='revolute_joint_34' type='revolute'>
-      <pose relative_to='link3'>0 0 0.15 0 -0 0</pose>
       <parent>link3</parent>
       <child>link4</child>
-      <axis>
-        <xyz>0 0 1</xyz>
-        <limit>
-          <lower>-1</lower>
-          <upper>2</upper>
-          <effort>100</effort>
-          <velocity>100</velocity>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
+      <axis/>
     </joint>
     <link name='link4'>
-      <pose relative_to='revolute_joint_34'>0 0 0 0 -0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 -0 0</pose>
-        <mass>1</mass>
-        <inertia>
-          <ixx>0.1</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.1</iyy>
-          <iyz>0</iyz>
-          <izz>0.1</izz>
-        </inertia>
-      </inertial>
       <collision name='link4_sphere'>
-        <pose>0 0 0 1.5708 -0 0</pose>
+        <geometry>
+          <sphere>
+            <radius>0.4</radius>
+          </sphere>
+        </geometry>
+      </collision>
+    </link>
+    <joint name='revolute_joint_35' type='revolute'>
+      <parent>link3</parent>
+      <child>link5</child>
+      <axis/>
+    </joint>
+    <link name='link5'>
+      <collision name='link5_sphere'>
+        <geometry>
+          <sphere>
+            <radius>0.4</radius>
+          </sphere>
+        </geometry>
+      </collision>
+    </link>
+    <joint name='revolute_joint_36' type='revolute'>
+      <parent>link3</parent>
+      <child>link6</child>
+      <axis/>
+    </joint>
+    <link name='link6'>
+      <collision name='link6_sphere'>
         <geometry>
           <sphere>
             <radius>0.4</radius>
@@ -163,6 +97,13 @@
     <drake:collision_filter_group name="group_link3">
       <drake:member>link3</drake:member>
       <drake:ignored_collision_filter_group>group_link14</drake:ignored_collision_filter_group>
+    </drake:collision_filter_group>
+    <drake:collision_filter_group name="group_link56">
+      <drake:member>link5</drake:member>
+      <drake:member>link6</drake:member>
+      <drake:ignored_collision_filter_group>group_link56</drake:ignored_collision_filter_group>
+      <drake:ignored_collision_filter_group>group_link3</drake:ignored_collision_filter_group>
+      <drake:ignored_collision_filter_group>group_link2</drake:ignored_collision_filter_group>
     </drake:collision_filter_group>
   </model>
 </sdf>

--- a/multibody/parsing/test/urdf_parser_test/collision_filter_group_parsing_test.urdf
+++ b/multibody/parsing/test/urdf_parser_test/collision_filter_group_parsing_test.urdf
@@ -4,78 +4,47 @@ Defines a URDF model with collision filter groups.
 -->
 <robot xmlns:drake="http://drake.mit.edu" xmlns:xacro="http://ros.org/wiki/xacro" name="collision_filter_group_parsing_test">
   <link name="link1">
-    <inertial>
-      <mass value="1"/>
-      <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.1"/>
-    </inertial>
     <collision name="link1_sphere">
-      <origin rpy="1.57079632679 0 0" xyz="0 0 0"/>
       <geometry>
         <sphere radius="0.40"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
   </link>
   <link name="link2">
-    <inertial>
-      <mass value="1"/>
-      <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.1"/>
-    </inertial>
     <collision name="link2_sphere">
-      <origin rpy="1.57079632679 0 0" xyz="0 0 0"/>
       <geometry>
         <sphere radius="0.40"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
   </link>
   <link name="link3">
-    <inertial>
-      <mass value="1"/>
-      <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.1"/>
-    </inertial>
     <collision name="link3_sphere">
-      <origin rpy="1.57079632679 0 0" xyz="0 0 0"/>
       <geometry>
         <sphere radius="0.40"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
   </link>
   <link name="link4">
-    <inertial>
-      <mass value="1"/>
-      <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.1"/>
-    </inertial>
     <collision name="link4_sphere">
-      <origin rpy="1.57079632679 0 0" xyz="0 0 0"/>
       <geometry>
         <sphere radius="0.40"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
   </link>
-  <joint name="revolute_joint_12" type="revolute">
-    <axis xyz="0 0 1"/>
-    <parent link="link1"/>
-    <child link="link2"/>
-    <origin rpy="0 0 0" xyz="0 0 0.15"/>
-    <limit effort="100" lower="-1" upper="2" velocity="100"/>
-  </joint>
-  <joint name="revolute_joint_23" type="revolute">
-    <axis xyz="0 0 1"/>
-    <parent link="link2"/>
-    <child link="link3"/>
-    <origin rpy="0 0 0" xyz="0 0 0.15"/>
-    <limit effort="100" lower="-1" upper="2" velocity="100"/>
-  </joint>
-  <joint name="revolute_joint_34" type="revolute">
-    <axis xyz="0 0 1"/>
-    <parent link="link3"/>
-    <child link="link4"/>
-    <origin rpy="0 0 0" xyz="0 0 0.15"/>
-    <limit effort="100" lower="-1" upper="2" velocity="100"/>
-  </joint>
+  <link name="link5">
+    <collision name="link5_sphere">
+      <geometry>
+        <sphere radius="0.40"/>
+      </geometry>
+    </collision>
+  </link>
+  <link name="link6">
+    <collision name="link6_sphere">
+      <geometry>
+        <sphere radius="0.40"/>
+      </geometry>
+    </collision>
+  </link>
   <drake:collision_filter_group name="group_link14">
     <drake:member link="link1"/>
     <drake:member link="link4"/>
@@ -89,9 +58,16 @@ Defines a URDF model with collision filter groups.
     <drake:member link="link2"/>
     <drake:member link="link4"/>
     <drake:ignored_collision_filter_group name="group_link24"/>
-  </drake:collision_filter_group>
+   </drake:collision_filter_group>
   <drake:collision_filter_group name="group_link3">
     <drake:member link="link3"/>
     <drake:ignored_collision_filter_group name="group_link14"/>
+  </drake:collision_filter_group>
+  <drake:collision_filter_group name="group_link56">
+    <drake:member link="link5"/>
+    <drake:member link="link6"/>
+    <drake:ignored_collision_filter_group name="group_link56"/>
+    <drake:ignored_collision_filter_group name="group_link3"/>
+    <drake:ignored_collision_filter_group name="group_link2"/>
   </drake:collision_filter_group>
 </robot>


### PR DESCRIPTION
Closes: #16310

Previously, a typo'd element name caused only the first element of
`drake:ignored_collision_filter_group` within a group to be actually
processed.  This patch fixes the typo and extends the existing tests to
cover the error case. Regrettably, it does not attempt a more vigorous
test refactoring. That may happen in the near future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16594)
<!-- Reviewable:end -->
