### PR TITLE
Introduces PartialPermutation

### DIFF
--- a/multibody/contact_solvers/sap/BUILD.bazel
+++ b/multibody/contact_solvers/sap/BUILD.bazel
@@ -13,6 +13,15 @@ package(
 )
 
 drake_cc_library(
+    name = "partial_permutation",
+    srcs = ["partial_permutation.cc"],
+    hdrs = ["partial_permutation.h"],
+    deps = [
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "sap_constraint",
     srcs = ["sap_constraint.cc"],
     hdrs = ["sap_constraint.h"],
@@ -29,6 +38,14 @@ drake_cc_library(
     deps = [
         "//common:default_scalars",
         "//common:essential",
+    ],
+)
+
+drake_cc_googletest(
+    name = "partial_permutation_test",
+    deps = [
+        ":partial_permutation",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/multibody/contact_solvers/sap/partial_permutation.cc
+++ b/multibody/contact_solvers/sap/partial_permutation.cc
@@ -1,0 +1,78 @@
+#include "drake/multibody/contact_solvers/sap/partial_permutation.h"
+
+#include <utility>
+
+#include "fmt/format.h"
+
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+PartialPermutation::PartialPermutation(std::vector<int> permutation)
+    : permutation_(std::move(permutation)) {
+  const int domain_size = permutation_.size();
+  // Determine size of the permuted domain.
+  const int permuted_domain_size =
+      *std::max_element(permutation_.begin(), permutation_.end()) + 1;
+
+  if (permuted_domain_size > domain_size) {
+    throw std::logic_error(fmt::format(
+        "The size of the permuted domain must be smaller or equal than that of "
+        "the original domian. Index {}, larger or equal than the domain size, "
+        "appears in the input permutation.",
+        permuted_domain_size - 1));
+  }
+
+  // Allocate inverse permutation and indicate values that are not present with
+  // an invalid (-1) index.
+  inverse_permutation_.resize(permuted_domain_size, -1);
+  // Fill in inverse permutation and check for valid permuted entries.
+  for (int i = 0; i < domain_size; ++i) {
+    const int i_permuted = permutation_[i];
+    // Ignore negative entries since those correspond to indexes that do not
+    // participate in the partial permutation.
+    if (i_permuted >= 0) {
+      if (inverse_permutation_[i_permuted] < 0) {
+        inverse_permutation_[i_permuted] = i;
+      } else {
+        throw std::logic_error(
+            fmt::format("Index {} appears at least twice in the input "
+                        "permutation. At {} and at {}.",
+                        i_permuted, inverse_permutation_[i_permuted], i));
+      }
+    }
+  }
+
+  // Verify that all indexes in [0; permuted_domain_size) were specified. This
+  // corresponds to all indexes in inverse_permutation_ being positive.
+  for (int i_permuted = 0; i_permuted < permuted_domain_size; ++i_permuted) {
+    if (inverse_permutation_[i_permuted] < 0) {
+      throw std::logic_error(
+          fmt::format("Index {} not present in the permutation. However the "
+                      "maximum specified permuted index is {}.",
+                      i_permuted, permuted_domain_size - 1));
+    }
+  }
+}
+
+int PartialPermutation::permuted_index(int i) const {
+  DRAKE_THROW_UNLESS(0 <= i && i < domain_size());
+  if (permutation_[i] < 0) {
+    throw std::runtime_error(
+        fmt::format("Index {} does not participate in this permutation.", i));
+  }
+  return permutation_[i];
+}
+
+bool PartialPermutation::participates(int i) const {
+  DRAKE_THROW_UNLESS(0 <= i && i < domain_size());
+  return permutation_[i] >= 0;
+}
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/sap/partial_permutation.h
+++ b/multibody/contact_solvers/sap/partial_permutation.h
@@ -1,0 +1,149 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+// Given a set S with n elements, this class represents the permutation of S
+// into a new set S' containing m (m ≤ n) non-repeated elements of S.
+// That is, given S = {s₁, s₂, ⋯ ,sᵢ, ⋯, sₙ}, this class represents the
+// mapping into a new set S' = {s'₁, s'₂, ⋯ ,s'ᵢₚ, ⋯ ,s'ₘ} where each s'ᵢₚ
+// corresponds to a distinct element of S. The mapping is defined by the
+// permutation of indexes in S into indexes in S' as ip = P(i), with i ∈ [0,n)
+// and ip ∈ [0,m).
+// In general we say that we have a "partial permutation" when m < n and
+// otherwise we say we have a "full permutation" when m = n.
+// We refer to S as the "domain", and to the number of elements contained in S
+// as "domain size". Similarly, we refer to S' as the "permuted domain" and to
+// the number of elements in S' as to "permuted domain size".
+// We define the "inverse permutation" as the mapping from elements s'ᵢₚ in S'
+// to elements sᵢ in S whenever there exist i ∈ [0,n) such that ip = P(i).
+// Elements sᵢ for which no ip is defined are left unchanged.
+class PartialPermutation {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PartialPermutation);
+
+  // An empty permutation. That is, domain_size() and permuted_domain_size()
+  // both return zero and Apply() and ApplyInverse() are no-ops.
+  PartialPermutation() = default;
+
+  // The permutation is provided as the vector `permutation` with size n =
+  // permutation.size(). This permutation maps indexes in [0, n) to indexes in
+  // [0, m), with m <= n. The permutation for the i-th integer in the domain [0,
+  // n) is given by ip = permutation[i] in [0, m). An index i that is not
+  // permuted is indicated with a negative entry, i.e. permutation[i] < 0. The
+  // permutation is said to be a "full permutation" whenever m = n and all
+  // indexes in [0, m) are present in `permutation`. It is said to be a "partial
+  // permutation" when m < n. Every index in [0, m) must be present and appear
+  // only once, or an exception is thrown.
+  //
+  // Example: permutation = {-1, 0, 2, 1, -1, 3} indicates P(1) = 0, P(2) = 2,
+  // P(3) = 1 and P(5) = 3. Since their entries are negative, elements indexed
+  // with 0 and 4 in the domain do not participate in the permutation. For this
+  // case domain_size() = 6 and permuted_domain_size() = 4. Notice that all
+  // indexes in [0, 4) are present in the provided array `permutation`.
+  //
+  // @throws if any entry in `permutation` is larger or equal than
+  // permutation.size() (this would correspond to m > n).
+  // @throws if `permutation` contains repeated entries.
+  // @throws if ip = P(i) for i ∈ [0,n) does not include all indexes in [0,m),
+  // i.e. there are holes in the permuted domain.
+  explicit PartialPermutation(std::vector<int> permutation);
+
+  // The size n of the domain.
+  int domain_size() const { return permutation_.size(); }
+
+  // The size m of the permuted domain.
+  int permuted_domain_size() const { return inverse_permutation_.size(); }
+
+  // Returns the index to which i is permuted by this permutation. That is,
+  // i_permuted = P(i).
+  // @throws a std::runtime_error if i does not particate in the permutation,
+  // see participates().
+  int permuted_index(int i) const;
+
+  // Returns `true` if the index i in the domain of the permutation participates
+  // in the permutation.
+  bool participates(int i) const;
+
+  // This method applies this permutation to the elements of x and writes them
+  // into x_permuted. That is, x_permuted[permuted_index(i)] = x[i] for all
+  // indexes i for which participates(i) is true.
+  //
+  // @pre VectorType must have value semantics while PointerToPermutedVectorType
+  // must have pointer semantics. Both types must implement:
+  //  - VectorType::size().
+  //  - VectorType::operator[](int).
+  //
+  // N.B. we allow for VectorType and PointerToPermutedVectorType to be
+  // completely different types to allow things like VectorType = VectorX or
+  // Eigen::Ref together with PointerToPermutedVectorType = VectorX* or
+  // drake::EigenPtr.
+  // TODO(amcastro-tri): consider an overload that takes iterators instead.
+  // Note that Eigen only supports iterators from version 3.4.
+  template <class VectorType, class PointerToPermutedVectorType>
+  void Apply(const VectorType& x,
+             PointerToPermutedVectorType x_permuted) const {
+    DRAKE_THROW_UNLESS(static_cast<int>(x.size()) == domain_size());
+    DRAKE_THROW_UNLESS(x_permuted != nullptr);
+    DRAKE_THROW_UNLESS(static_cast<int>(x_permuted->size()) ==
+                       permuted_domain_size());
+    for (int i_permuted = 0; i_permuted < permuted_domain_size();
+         ++i_permuted) {
+      const int i = inverse_permutation_[i_permuted];
+      (*x_permuted)[i_permuted] = x[i];
+    }
+  }
+
+  // This method applies this inverse permutation to the elements of x_permuted
+  // and writes them into x. That is, x[i] = x_permuted[permuted_index(i)] for
+  // all indexes i for which participates(i) is true.
+  //
+  // @pre PermutedVectorType must have value semantics while PointerToVectorType
+  // must have pointer semantics. Both types must implement:
+  //  - VectorType::size().
+  //  - VectorType::operator[](int).
+  //
+  // N.B. we allow for PermutedVectorType and PointerToVectorType to be
+  // completely different types to allow things like PermutedVectorType =
+  // VectorX or Eigen::Ref together with PointerToVectorType = VectorX* or
+  // drake::EigenPtr.
+  // TODO(amcastro-tri): consider an overload that takes iterators instead.
+  // Note that Eigen only supports iterators from version 3.4.
+  template <class PermutedVectorType, class PointerToVectorType>
+  void ApplyInverse(const PermutedVectorType& x_permuted,
+                    PointerToVectorType x) const {
+    DRAKE_THROW_UNLESS(static_cast<int>(x_permuted.size()) ==
+                       permuted_domain_size());
+    DRAKE_THROW_UNLESS(x != nullptr);
+    DRAKE_THROW_UNLESS(static_cast<int>(x->size()) == domain_size());
+    for (int i_permuted = 0; i_permuted < permuted_domain_size();
+         ++i_permuted) {
+      const int i = inverse_permutation_[i_permuted];
+      (*x)[i] = x_permuted[i_permuted];
+    }
+  }
+
+  // Returns permutation as a std::vector, see constructor for details.
+  const std::vector<int>& permutation() const { return permutation_; }
+
+ private:
+  // Vector of size n, domain size, such that for i ∈ [0,n) ip = permutation_[i]
+  // either maps to an element in [0,m), with no repetition, or it maps to a
+  // negative index.
+  std::vector<int> permutation_;
+  // Vector of size m, permuted domain size, such that for ip in [0,m)
+  // inverse_permutation_[ip] maps to elements in [0,n).
+  std::vector<int> inverse_permutation_;
+};
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/sap/test/partial_permutation_test.cc
+++ b/multibody/contact_solvers/sap/test/partial_permutation_test.cc
@@ -1,0 +1,110 @@
+#include "drake/multibody/contact_solvers/sap/partial_permutation.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+using Eigen::VectorXd;
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+namespace {
+
+GTEST_TEST(PartialPermutation, EmptyPermutation) {
+  PartialPermutation p;
+  EXPECT_EQ(p.domain_size(), 0);
+  EXPECT_EQ(p.permuted_domain_size(), 0);
+}
+
+GTEST_TEST(PartialPermutation, Construction) {
+  const std::vector<int> permutation = {-1, 0, 2, 1, -1, 3};
+  PartialPermutation p(permutation);
+  EXPECT_EQ(p.permutation(), permutation);
+  EXPECT_EQ(p.domain_size(), 6);
+  EXPECT_EQ(p.permuted_domain_size(), 4);
+  EXPECT_FALSE(p.participates(0));
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      p.permuted_index(0),
+      "Index .* does not participate in this permutation.");
+  EXPECT_TRUE(p.participates(1));
+  EXPECT_EQ(p.permuted_index(1), 0);
+  EXPECT_TRUE(p.participates(2));
+  EXPECT_EQ(p.permuted_index(2), 2);
+  EXPECT_TRUE(p.participates(1));
+  EXPECT_EQ(p.permuted_index(3), 1);
+  EXPECT_FALSE(p.participates(4));
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      p.permuted_index(4),
+      "Index .* does not participate in this permutation.");
+  EXPECT_EQ(p.permuted_index(5), 3);
+
+  // Argument index out of bounds.
+  EXPECT_THROW(p.participates(6), std::exception);
+  EXPECT_THROW(p.participates(-1), std::exception);
+  EXPECT_THROW(p.permuted_index(6), std::exception);
+  EXPECT_THROW(p.permuted_index(-1), std::exception);
+}
+
+// Perform the permutation of a VectorXd.
+GTEST_TEST(PartialPermutation, PermuteEigenVectorAndBack) {
+  PartialPermutation p({0, -1, 2, 1});
+  EXPECT_EQ(p.domain_size(), 4);
+  EXPECT_EQ(p.permuted_domain_size(), 3);
+  const VectorXd x = VectorXd::LinSpaced(p.domain_size(), 0.0, 3.0);
+  VectorXd xp(p.permuted_domain_size());
+  p.Apply(x, &xp);
+  const VectorXd xp_expected = (VectorXd(3) << 0., 3., 2.).finished();
+  EXPECT_EQ(xp, xp_expected);
+  VectorXd x_back = -VectorXd::Ones(p.domain_size());
+  p.ApplyInverse(xp, &x_back);
+  const VectorXd x_back_expected = (VectorXd(4) << 0., -1., 2., 3.).finished();
+  EXPECT_EQ(x_back, x_back_expected);
+}
+
+// Perform the permutation of a std::vector<int>.
+GTEST_TEST(PartialPermutation, PermuteStdVectorAndBack) {
+  PartialPermutation p({0, -1, 2, 1});
+  EXPECT_EQ(p.domain_size(), 4);
+  EXPECT_EQ(p.permuted_domain_size(), 3);
+  const std::vector<int> x = {0, 1, 2, 3};
+  std::vector<int> xp(p.permuted_domain_size());
+  p.Apply(x, &xp);
+  const std::vector<int> xp_expected = {0, 3, 2};
+  EXPECT_EQ(xp, xp_expected);
+  std::vector<int> x_back(p.domain_size(), -1);
+  p.ApplyInverse(xp, &x_back);
+  const std::vector<int> x_back_expected = {0, -1, 2, 3};
+  EXPECT_EQ(x_back, x_back_expected);
+}
+
+GTEST_TEST(PartialPermutation, PermutedDomainIsLargerThanOriginalDomain) {
+  // The input permutation is invalid since index = 4 is out-of-bounds for a
+  // domain of size 4.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      PartialPermutation p({0, -1, 4, 1}),
+      "The size of the permuted domain must be smaller or equal than that of "
+      "the original domian. Index 4, larger or equal than the domain size, "
+      "appears in the input permutation.");
+}
+
+// Verifies the constructor throws if there are repeated indexes.
+GTEST_TEST(PartialPermutation, RepeatedIndex) {
+  DRAKE_EXPECT_THROWS_MESSAGE(PartialPermutation dut({0, -1, 2, 2}),
+                              "Index 2 appears at least twice in the input "
+                              "permutation. At 2 and at 3.");
+}
+
+GTEST_TEST(PartialPermutation, MissingIndex) {
+  DRAKE_EXPECT_THROWS_MESSAGE(PartialPermutation dut({0, -1, -1, 4, 1}),
+                              "Index 2 not present in the permutation. However "
+                              "the maximum specified permuted index is 4.");
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
We need to shuffle indexes back and forth as we permute cliques, velocities and impulses in #16543. 
Therefore this class encapsulates the concept of a (partial) permutation.

Towards landing the [SapSolver](https://github.com/RobotLocomotion/drake/projects/10). Full working prototype in https://github.com/RobotLocomotion/drake/pull/16543.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16596)
<!-- Reviewable:end -->
