### PR TITLE
[doc] Fix Jekyll output to avoid symlinks

### DIFF
--- a/doc/pages.py
+++ b/doc/pages.py
@@ -22,7 +22,7 @@ def _build(*, out_dir, temp_dir):
     """
     # Create a hermetic copy of our input.  This helps ensure that only files
     # listed in BUILD.bazel will render onto the website.
-    symlink_input("drake/doc/pages_input.txt", temp_dir)
+    symlink_input("drake/doc/pages_input.txt", temp_dir, copy=True)
 
     # Run the documentation generator.
     check_call([


### PR DESCRIPTION
Prior to this fix, on Jekyll on Ubuntu 20 would preserve the symlinks back into the source tree when populating its --out_dir, which meant that we were failing to push those resources into git, and our GitHub Pages deployments were failing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16598)
<!-- Reviewable:end -->
