### PR TITLE
[parsing] Simplify use of scene graph in parsing

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -120,8 +120,9 @@ drake_cc_library(
     deps = [
         ":detail_misc",
         ":package_map",
+        "//geometry:geometry_instance",
         "//geometry:geometry_roles",
-        "//geometry:scene_graph",
+        "//geometry:shape_specification",
         "//multibody/plant:coulomb_friction",
         "@sdformat",
     ],

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -856,7 +856,7 @@ class MujocoParser {
 ModelInstanceIndex AddModelFromMujocoXml(
     const DataSource& data_source, const std::string& model_name_in,
     const std::optional<std::string>& parent_model_name,
-    MultibodyPlant<double>* plant, geometry::SceneGraph<double>* scene_graph) {
+    MultibodyPlant<double>* plant) {
   DRAKE_THROW_UNLESS(plant != nullptr);
   DRAKE_THROW_UNLESS(!plant->is_finalized());
   data_source.DemandExactlyOne();
@@ -876,10 +876,6 @@ ModelInstanceIndex AddModelFromMujocoXml(
       throw std::runtime_error(
           fmt::format("Failed to parse XML string: {}", xml_doc.ErrorName()));
     }
-  }
-
-  if (scene_graph != nullptr && !plant->geometry_source_is_registered()) {
-    plant->RegisterAsSourceForSceneGraph(scene_graph);
   }
 
   MujocoParser parser(plant);

--- a/multibody/parsing/detail_mujoco_parser.h
+++ b/multibody/parsing/detail_mujoco_parser.h
@@ -3,7 +3,6 @@
 #include <optional>
 #include <string>
 
-#include "drake/geometry/scene_graph.h"
 #include "drake/multibody/parsing/detail_common.h"
 #include "drake/multibody/parsing/package_map.h"
 #include "drake/multibody/plant/multibody_plant.h"
@@ -36,15 +35,11 @@ namespace internal {
 //   used as the name given to the newly created instance of this model.
 // @param plant A pointer to a mutable MultibodyPlant object to which the model
 //   will be added.
-// @param scene_graph A pointer to a mutable SceneGraph object used for
-//   geometry registration (either to model visual or contact geometry).  May
-//   be nullptr.
 // @returns The model instance index for the newly added model.
 ModelInstanceIndex AddModelFromMujocoXml(
     const DataSource& data_source, const std::string& model_name,
     const std::optional<std::string>& parent_model_name,
-    MultibodyPlant<double>* plant,
-    geometry::SceneGraph<double>* scene_graph = nullptr);
+    MultibodyPlant<double>* plant);
 
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/parsing/detail_scene_graph.h
+++ b/multibody/parsing/detail_scene_graph.h
@@ -5,8 +5,9 @@
 
 #include <sdf/sdf.hh>
 
+#include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/geometry_roles.h"
-#include "drake/geometry/scene_graph.h"
+#include "drake/geometry/shape_specification.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/parsing/package_map.h"
 #include "drake/multibody/plant/coulomb_friction.h"

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -40,7 +40,6 @@ using Eigen::Matrix3d;
 using Eigen::Translation3d;
 using Eigen::Vector3d;
 using geometry::GeometryInstance;
-using geometry::SceneGraph;
 using math::RigidTransformd;
 using math::RotationMatrixd;
 using std::unique_ptr;
@@ -1314,7 +1313,6 @@ ModelInstanceIndex AddModelFromSdf(
     const std::string& model_name_in,
     const PackageMap& package_map,
     MultibodyPlant<double>* plant,
-    geometry::SceneGraph<double>* scene_graph,
     bool test_sdf_forced_nesting) {
   DRAKE_THROW_UNLESS(plant != nullptr);
     DRAKE_THROW_UNLESS(!plant->is_finalized());
@@ -1332,10 +1330,6 @@ ModelInstanceIndex AddModelFromSdf(
   // Get the only model in the file.
   const sdf::Model& model = *root.Model();
 
-  if (scene_graph != nullptr && !plant->geometry_source_is_registered()) {
-    plant->RegisterAsSourceForSceneGraph(scene_graph);
-  }
-
   const std::string model_name =
       model_name_in.empty() ? model.Name() : model_name_in;
 
@@ -1351,7 +1345,6 @@ std::vector<ModelInstanceIndex> AddModelsFromSdf(
     const DataSource& data_source,
     const PackageMap& package_map,
     MultibodyPlant<double>* plant,
-    geometry::SceneGraph<double>* scene_graph,
     bool test_sdf_forced_nesting) {
   DRAKE_THROW_UNLESS(plant != nullptr);
   DRAKE_THROW_UNLESS(!plant->is_finalized());
@@ -1373,10 +1366,6 @@ std::vector<ModelInstanceIndex> AddModelsFromSdf(
     throw std::runtime_error(fmt::format(
         "File must have exactly one <model> or exactly one <world>, but"
         " instead has {} models and {} worlds", model_count, world_count));
-  }
-
-  if (scene_graph != nullptr && !plant->geometry_source_is_registered()) {
-    plant->RegisterAsSourceForSceneGraph(scene_graph);
   }
 
   std::vector<ModelInstanceIndex> model_instances;

--- a/multibody/parsing/detail_sdf_parser.h
+++ b/multibody/parsing/detail_sdf_parser.h
@@ -3,7 +3,6 @@
 #include <string>
 #include <vector>
 
-#include "drake/geometry/scene_graph.h"
 #include "drake/multibody/parsing/detail_common.h"
 #include "drake/multibody/parsing/package_map.h"
 #include "drake/multibody/plant/multibody_plant.h"
@@ -36,9 +35,6 @@ namespace internal {
 // @param plant
 //   A pointer to a mutable MultibodyPlant object to which the model will be
 //   added.
-// @param scene_graph
-//   A pointer to a mutable SceneGraph object used for geometry registration
-//   (either to model visual or contact geometry).  May be nullptr.
 // @param test_sdf_forced_nesting
 //   If true, a custom parser for SDFormat files (but using a different file
 //   extension) will be registered when using libsdformat's Interface API. This
@@ -49,7 +45,6 @@ ModelInstanceIndex AddModelFromSdf(
     const std::string& model_name,
     const PackageMap& package_map,
     MultibodyPlant<double>* plant,
-    geometry::SceneGraph<double>* scene_graph = nullptr,
     bool test_sdf_forced_nesting = false);
 
 // Parses all `<model>` elements from the SDF file specified by `file_name`
@@ -71,9 +66,6 @@ ModelInstanceIndex AddModelFromSdf(
 //   added.
 // @param package_map
 //   An object that maps ROS packages to their full pathnames.
-// @param scene_graph
-//   A pointer to a mutable SceneGraph object used for geometry registration
-//   (either to model visual or contact geometry).  May be nullptr.
 // @param test_sdf_forced_nesting
 //   If true, a custom parser for SDFormat files (but using a different file
 //   extension) will be registered when using libsdformat's Interface API. This
@@ -83,7 +75,6 @@ std::vector<ModelInstanceIndex> AddModelsFromSdf(
     const DataSource& data_source,
     const PackageMap& package_map,
     MultibodyPlant<double>* plant,
-    geometry::SceneGraph<double>* scene_graph = nullptr,
     bool test_sdf_forced_nesting = false);
 
 }  // namespace internal

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -777,8 +777,7 @@ ModelInstanceIndex AddModelFromUrdf(
     const std::string& model_name_in,
     const std::optional<std::string>& parent_model_name,
     const PackageMap& package_map,
-    MultibodyPlant<double>* plant,
-    geometry::SceneGraph<double>* scene_graph) {
+    MultibodyPlant<double>* plant) {
   DRAKE_THROW_UNLESS(plant != nullptr);
   DRAKE_THROW_UNLESS(!plant->is_finalized());
   data_source.DemandExactlyOne();
@@ -815,10 +814,6 @@ ModelInstanceIndex AddModelFromUrdf(
           "Failed to parse XML string: {}",
           xml_doc.ErrorName()));
     }
-  }
-
-  if (scene_graph != nullptr && !plant->geometry_source_is_registered()) {
-    plant->RegisterAsSourceForSceneGraph(scene_graph);
   }
 
   return ParseUrdf(model_name_in, parent_model_name, package_map, root_dir,

--- a/multibody/parsing/detail_urdf_parser.h
+++ b/multibody/parsing/detail_urdf_parser.h
@@ -3,7 +3,6 @@
 #include <optional>
 #include <string>
 
-#include "drake/geometry/scene_graph.h"
 #include "drake/multibody/parsing/detail_common.h"
 #include "drake/multibody/parsing/package_map.h"
 #include "drake/multibody/plant/multibody_plant.h"
@@ -33,17 +32,13 @@ namespace internal {
 // @param plant
 //   A pointer to a mutable MultibodyPlant object to which the model will be
 //   added.
-// @param scene_graph
-//   A pointer to a mutable SceneGraph object used for geometry registration
-//   (either to model visual or contact geometry).  May be nullptr.
 // @returns The model instance index for the newly added model.
 ModelInstanceIndex AddModelFromUrdf(
     const DataSource& data_source,
     const std::string& model_name,
     const std::optional<std::string>& parent_model_name,
     const PackageMap& package_map,
-    MultibodyPlant<double>* plant,
-    geometry::SceneGraph<double>* scene_graph = nullptr);
+    MultibodyPlant<double>* plant);
 
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/parsing/parser.cc
+++ b/multibody/parsing/parser.cc
@@ -16,8 +16,12 @@ using internal::DataSource;
 Parser::Parser(
     MultibodyPlant<double>* plant,
     geometry::SceneGraph<double>* scene_graph)
-    : plant_(plant), scene_graph_(scene_graph) {
+    : plant_(plant) {
   DRAKE_THROW_UNLESS(plant != nullptr);
+
+  if (scene_graph != nullptr && !plant->geometry_source_is_registered()) {
+    plant->RegisterAsSourceForSceneGraph(scene_graph);
+  }
 }
 
 namespace {
@@ -48,11 +52,10 @@ std::vector<ModelInstanceIndex> Parser::AddAllModelsFromFile(
 #pragma GCC diagnostic pop
   const FileType type = DetermineFileType(file_name);
   if (type == FileType::kSdf) {
-    return AddModelsFromSdf(
-        data_source, package_map_, plant_, scene_graph_);
+    return AddModelsFromSdf(data_source, package_map_, plant_);
   } else {
     return {AddModelFromUrdf(
-        data_source, {}, {}, package_map_, plant_, scene_graph_)};
+        data_source, {}, {}, package_map_, plant_)};
   }
 }
 
@@ -69,11 +72,9 @@ ModelInstanceIndex Parser::AddModelFromFile(
 #pragma GCC diagnostic pop
   const FileType type = DetermineFileType(file_name);
   if (type == FileType::kSdf) {
-    return AddModelFromSdf(
-        data_source, model_name, package_map_, plant_, scene_graph_);
+    return AddModelFromSdf(data_source, model_name, package_map_, plant_);
   } else {
-    return AddModelFromUrdf(
-        data_source, model_name, {}, package_map_, plant_, scene_graph_);
+    return AddModelFromUrdf(data_source, model_name, {}, package_map_, plant_);
   }
 }
 
@@ -85,11 +86,9 @@ ModelInstanceIndex Parser::AddModelFromString(
   data_source.file_contents = &file_contents;
   const FileType type = DetermineFileType("<literal-string>." + file_type);
   if (type == FileType::kSdf) {
-    return AddModelFromSdf(
-        data_source, model_name, package_map_, plant_, scene_graph_);
+    return AddModelFromSdf(data_source, model_name, package_map_, plant_);
   } else {
-    return AddModelFromUrdf(
-        data_source, model_name, {}, package_map_, plant_, scene_graph_);
+    return AddModelFromUrdf(data_source, model_name, {}, package_map_, plant_);
   }
 }
 

--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -3,7 +3,6 @@
 #include <string>
 #include <vector>
 
-#include "drake/geometry/scene_graph.h"
 #include "drake/multibody/parsing/package_map.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/multibody_tree_indexes.h"
@@ -90,7 +89,6 @@ class Parser final {
  private:
   PackageMap package_map_;
   MultibodyPlant<double>* const plant_;
-  geometry::SceneGraph<double>* const scene_graph_;
 };
 
 }  // namespace multibody


### PR DESCRIPTION
Relevant to: #16229

Stop passing around scene graph everywhere internally. Instead, rely on
Parser to register the plant to the scene graph (if any). None of the
deeper parse modules actually need a scene graph; they instead condition
some behavior on the result of the is_registered() predicate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16608)
<!-- Reviewable:end -->
