### PR TITLE
[controllers] LQR should take an InputPortIndex

### DIFF
--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -251,11 +251,12 @@ PYBIND11_MODULE(controllers, m) {
           const systems::Context<double>&,
           const Eigen::Ref<const Eigen::MatrixXd>&,
           const Eigen::Ref<const Eigen::MatrixXd>&,
-          const Eigen::Ref<const Eigen::MatrixXd>&, int>(
+          const Eigen::Ref<const Eigen::MatrixXd>&, systems::InputPortIndex>(
           &LinearQuadraticRegulator),
       py::arg("system"), py::arg("context"), py::arg("Q"), py::arg("R"),
       py::arg("N") = Eigen::Matrix<double, 0, 0>::Zero(),
-      py::arg("input_port_index") = 0, doc.LinearQuadraticRegulator.doc_6args);
+      py::arg("input_port_index") = systems::InputPortIndex(0),
+      doc.LinearQuadraticRegulator.doc_6args);
 
   py::class_<FiniteHorizonLinearQuadraticRegulatorOptions> fhlqr_options(m,
       "FiniteHorizonLinearQuadraticRegulatorOptions",

--- a/systems/controllers/linear_quadratic_regulator.cc
+++ b/systems/controllers/linear_quadratic_regulator.cc
@@ -96,7 +96,7 @@ std::unique_ptr<systems::AffineSystem<double>> LinearQuadraticRegulator(
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
     const Eigen::Ref<const Eigen::MatrixXd>& R,
     const Eigen::Ref<const Eigen::MatrixXd>& N,
-    int input_port_index) {
+    InputPortIndex input_port_index) {
   // TODO(russt): accept optional additional argument to return the cost-to-go
   // but note that it will be a full quadratic form (x'S2x + s1'x + s0).
 

--- a/systems/controllers/linear_quadratic_regulator.h
+++ b/systems/controllers/linear_quadratic_regulator.h
@@ -140,7 +140,7 @@ std::unique_ptr<AffineSystem<double>> LinearQuadraticRegulator(
     const Eigen::Ref<const Eigen::MatrixXd>& R,
     const Eigen::Ref<const Eigen::MatrixXd>& N =
         Eigen::Matrix<double, 0, 0>::Zero(),
-    int input_port_index = 0);
+    InputPortIndex input_port_index = InputPortIndex(0));
 
 }  // namespace controllers
 }  // namespace systems


### PR DESCRIPTION
Without this change, passing an InputPortIndex in pydrake recently
started throwing a deprecation warning, saying the cast to __int__
will be removed soon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16611)
<!-- Reviewable:end -->
