### PR TITLE
[workspace] Nerf the license checker for jar files

### DIFF
--- a/tools/install/check_licenses.bzl
+++ b/tools/install/check_licenses.bzl
@@ -54,9 +54,14 @@ def _check_licenses_for_label(label):
 
 #------------------------------------------------------------------------------
 def _check_licenses_impl(ctx):
+    # Compose the list of labels, minus the ignore list.
+    to_check = list(ctx.attr.install_labels)
+    for label in ctx.attr.ignore_labels:
+        to_check.remove(label)
+
     # Iterate over labels, collecting ones that are missing licenses.
     labels_missing_licenses = []
-    for label in ctx.attr.install_labels:
+    for label in to_check:
         labels_missing_licenses += _check_licenses_for_label(label)
 
     # Report collected failures.
@@ -67,11 +72,15 @@ def _check_licenses_impl(ctx):
 _check_licenses = rule(
     attrs = {
         "install_labels": attr.label_list(providers = [InstallInfo]),
+        "ignore_labels": attr.label_list(),
     },
     implementation = _check_licenses_impl,
 )
 
-def check_licenses(install_labels, name = "check_licenses"):
+def check_licenses(
+        install_labels,
+        name = "check_licenses",
+        ignore_labels = None):
     """Check that install labels include license files.
 
     Given a list of install labels (e.g. ``//package:install``), check that the
@@ -87,8 +96,11 @@ def check_licenses(install_labels, name = "check_licenses"):
         install_labels (:obj:`list` of :obj:`Label`): List of install labels
             (must be created by :func:`install` or :func:`install_files`) to
             be checked.
+        ignore_labels (:obj:`list` of :obj:`Label`): Optional subset of the
+            ``install_labels`` to skip during checking.
     """
     _check_licenses(
         name = name,
         install_labels = install_labels,
+        ignore_labels = ignore_labels,
     )

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -107,6 +107,16 @@ install(
     deps = _DRAKE_EXTERNAL_PACKAGE_INSTALLS,
 )
 
-check_licenses(_DRAKE_EXTERNAL_PACKAGE_INSTALLS)
+check_licenses(
+    _DRAKE_EXTERNAL_PACKAGE_INSTALLS,
+    ignore_labels = [
+        # Jar files have their license notices embedded into the jar already;
+        # there is no need for them to install a separate license file.
+        "@com_jidesoft_jide_oss//:install",
+        "@commons_io//:install",
+        "@net_sf_jchart2d//:install",
+        "@org_apache_xmlgraphics_commons//:install",
+    ],
+)
 
 add_lint_tests()


### PR DESCRIPTION
Hotfix for #16185 on macOS.

Manually tested the linter:
- [x] Malformed target names in the ignore list bombs out Bazel.
- [x] Target names in the ignore list that aren't in the install list bombs out Bazel.
- [x] Removing the license files install from `@meshcat` (but still installing its javascript & etc) fails the linter.

Manually tested the lack-of-build failure now:
- [x] tweak `drake/tools/workspace/commons_io/repository.bzl` to set `local_distributions = []` (so that the jar install happens on Ubuntu also) and confirm that `bazel test //tools/workspace/...` passes with this fix, and fails without it

Closes #16612.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16613)
<!-- Reviewable:end -->
