### PR TITLE
[wheel] Hotfix to add now-missing jchart2d dependency

### DIFF
--- a/tools/wheel/image/packages-bionic
+++ b/tools/wheel/image/packages-bionic
@@ -30,6 +30,7 @@ zip
 # Build dependencies (general).
 libgl1-mesa-dev
 libglib2.0-dev
+libjchart2d-java
 libnlopt-dev
 libxt-dev
 # Build dependencies (OpenCL).

--- a/tools/wheel/image/packages-focal
+++ b/tools/wheel/image/packages-focal
@@ -30,6 +30,7 @@ zip
 # Build dependencies (general).
 libgl1-mesa-dev
 libglib2.0-dev
+libjchart2d-java
 libnlopt-dev
 libnlopt-cxx-dev
 libxt-dev


### PR DESCRIPTION
The Bazel build requires that these be present in its workspace, but none of the files that end up in the wheel actually use this.

Hotfix for #16185, which added these to `drake/setup/ubuntu/...` for forgot to mimic that in the wheel prereqs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16614)
<!-- Reviewable:end -->
