### PR TITLE
[geometry/optimization] Add optional solver and solver options to SolveShortestPath

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -512,6 +512,7 @@ drake_py_unittest(
         "//bindings/pydrake/common/test_utilities:deprecation_py",
         "//bindings/pydrake/multibody:parsing_py",
         "//bindings/pydrake/multibody:plant_py",
+        "//bindings/pydrake/solvers:clp_py",
         "//bindings/pydrake/solvers:mathematicalprogram_py",
     ],
 )

--- a/bindings/pydrake/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry_py_optimization.cc
@@ -351,17 +351,25 @@ void DefineGeometryOptimization(py::module m) {
             .def("SolveShortestPath",
                 overload_cast_explicit<solvers::MathematicalProgramResult,
                     GraphOfConvexSets::VertexId, GraphOfConvexSets::VertexId,
-                    bool>(&GraphOfConvexSets::SolveShortestPath),
+                    bool, const solvers::SolverInterface*,
+                    const std::optional<solvers::SolverOptions>&>(
+                    &GraphOfConvexSets::SolveShortestPath),
                 py::arg("source_id"), py::arg("target_id"),
                 py::arg("convex_relaxation") = false,
+                py::arg("solver") = nullptr,
+                py::arg("solver_options") = std::nullopt,
                 cls_doc.SolveShortestPath.doc_by_id)
             .def("SolveShortestPath",
                 overload_cast_explicit<solvers::MathematicalProgramResult,
                     const GraphOfConvexSets::Vertex&,
-                    const GraphOfConvexSets::Vertex&, bool>(
+                    const GraphOfConvexSets::Vertex&, bool,
+                    const solvers::SolverInterface*,
+                    const std::optional<solvers::SolverOptions>&>(
                     &GraphOfConvexSets::SolveShortestPath),
                 py::arg("source"), py::arg("target"),
                 py::arg("convex_relaxation") = false,
+                py::arg("solver") = nullptr,
+                py::arg("solver_options") = std::nullopt,
                 cls_doc.SolveShortestPath.doc_by_reference);
 
     BindIdentifier<GraphOfConvexSets::VertexId>(

--- a/bindings/pydrake/test/geometry_optimization_test.py
+++ b/bindings/pydrake/test/geometry_optimization_test.py
@@ -13,8 +13,10 @@ from pydrake.math import RigidTransform
 from pydrake.multibody.parsing import Parser
 from pydrake.multibody.plant import AddMultibodyPlantSceneGraph
 from pydrake.systems.framework import DiagramBuilder
+from pydrake.solvers.clp import ClpSolver
 from pydrake.solvers.mathematicalprogram import (
-    MathematicalProgram, MathematicalProgramResult, Binding, Cost, Constraint
+    MathematicalProgram, MathematicalProgramResult, Binding, Cost, Constraint,
+    SolverOptions
 )
 from pydrake.symbolic import Variable
 
@@ -310,8 +312,22 @@ class TestGeometryOptimization(unittest.TestCase):
             convex_relaxation=True)
         self.assertIsInstance(result, MathematicalProgramResult)
         self.assertIsInstance(spp.SolveShortestPath(
+            source_id=source.id(), target_id=target.id(),
+            convex_relaxation=True, solver=ClpSolver()),
+            MathematicalProgramResult)
+        self.assertIsInstance(spp.SolveShortestPath(
+            source_id=source.id(), target_id=target.id(),
+            convex_relaxation=True, solver_options=SolverOptions()),
+            MathematicalProgramResult)
+        self.assertIsInstance(spp.SolveShortestPath(
             source=source, target=target, convex_relaxation=True),
             MathematicalProgramResult)
+        self.assertIsInstance(spp.SolveShortestPath(
+            source=source, target=target, convex_relaxation=True,
+            solver=ClpSolver()), MathematicalProgramResult)
+        self.assertIsInstance(spp.SolveShortestPath(
+            source=source, target=target, convex_relaxation=True,
+            solver_options=SolverOptions()), MathematicalProgramResult)
         self.assertIn("source", spp.GetGraphvizString(
             result=result, show_slacks=True, precision=2, scientific=False))
 

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -14,6 +14,8 @@
 #include "drake/common/symbolic.h"
 #include "drake/geometry/optimization/convex_set.h"
 #include "drake/solvers/mathematical_program_result.h"
+#include "drake/solvers/solver_interface.h"
+#include "drake/solvers/solver_options.h"
 
 namespace drake {
 namespace geometry {
@@ -317,7 +319,6 @@ class GraphOfConvexSets {
       bool show_slacks = true, int precision = 3,
       bool scientific = false) const;
 
-  // TODO(russt): Consider adding optional<Solver> argument.
   /** Formulates and solves the mixed-integer convex formulation of the
   shortest path problem on the graph, as discussed in detail in
 
@@ -333,6 +334,12 @@ class GraphOfConvexSets {
   discussed in the paper, we know that this relaxation cannot solve the original
   NP-hard problem for all instances, but there are also many instances for which
   the convex relaxation is tight.
+  @param solver provides the optimizer to be used to solve the shortest path
+  optimization problem. If not set, the best solver for the given problem is
+  selected. Note that if the solver cannot handle the type of optimization
+  problem generated, it will throw.
+  @param solver_options are passed to the solver once the problem is generated
+  to set the solver settings.
 
   @throws std::exception if any of the costs or constraints in the graph are
   incompatible with the shortest path formulation or otherwise unsupported.
@@ -340,8 +347,10 @@ class GraphOfConvexSets {
   @pydrake_mkdoc_identifier{by_id}
   */
   solvers::MathematicalProgramResult SolveShortestPath(
-      VertexId source_id, VertexId target_id,
-      bool convex_relaxation = false) const;
+      VertexId source_id, VertexId target_id, bool convex_relaxation = false,
+      const solvers::SolverInterface* solver = nullptr,
+      const std::optional<solvers::SolverOptions>& solver_options =
+          std::nullopt) const;
 
   /** Convenience overload that takes const reference arguments for source and
   target.
@@ -349,7 +358,10 @@ class GraphOfConvexSets {
   */
   solvers::MathematicalProgramResult SolveShortestPath(
       const Vertex& source, const Vertex& target,
-      bool convex_relaxation = false) const;
+      bool convex_relaxation = false,
+      const solvers::SolverInterface* solver = nullptr,
+      const std::optional<solvers::SolverOptions>& solver_options =
+          std::nullopt) const;
 
  private:
   std::map<VertexId, std::unique_ptr<Vertex>> vertices_{};


### PR DESCRIPTION
Enables passing `SolverOptions` to `SolveShortestPath` in `GraphOfConvexSets`.  Also cleans up a little code formatting in the same pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16616)
<!-- Reviewable:end -->
