### PR TITLE
Allow start_new_change_event() on const Context

### DIFF
--- a/systems/framework/cache_entry.h
+++ b/systems/framework/cache_entry.h
@@ -153,6 +153,8 @@ class CacheEntry {
     return cache_value.get_abstract_value();
   }
 
+  // Keep this method as small as possible to encourage inlining; it may be
+  // called *a lot*.
   /** Returns a reference to the _known up-to-date_ value of this cache entry
   contained in the given Context. The purpose of this method is to avoid
   unexpected recomputations in circumstances where you believe the value must
@@ -165,8 +167,6 @@ class CacheEntry {
        this cache entry.
   @throws std::exception if the value is out of date or if it does not
                          actually have type `ValueType`. */
-  // Keep this method as small as possible to encourage inlining; it gets
-  // called *a lot*.
   template <typename ValueType>
   const ValueType& GetKnownUpToDate(const ContextBase& context) const {
     const CacheEntryValue& cache_value = get_cache_entry_value(context);
@@ -175,14 +175,14 @@ class CacheEntry {
                                           __func__);
   }
 
+  // Keep this method as small as possible to encourage inlining; it may be
+  // called *a lot*.
   /** Returns a reference to the _known up-to-date_ abstract value of this cache
   entry contained in the given Context. See GetKnownUpToDate() for more
   information.
   @pre `context` is a subcontext that is compatible with the subsystem that owns
        this cache entry.
   @throws std::exception if the value is not up to date. */
-  // Keep this method as small as possible to encourage inlining; it gets
-  // called *a lot*.
   const AbstractValue& GetKnownUpToDateAbstract(
       const ContextBase& context) const {
     const CacheEntryValue& cache_value = get_cache_entry_value(context);

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -681,7 +681,11 @@ TEST_F(DiagramContextTest, NextChangeEventNumber) {
   const int64_t first = context_->start_new_change_event();
 
   EXPECT_EQ(context_->start_new_change_event(), first + 1);
-  EXPECT_EQ(context_->start_new_change_event(), first + 2);
+
+  // Verify that this also works on a const Context.
+  EXPECT_EQ(const_cast<const DiagramContext<double>*>(context_.get())
+                ->start_new_change_event(),
+            first + 2);
 
   // Obtain a subcontext and verify we still count up.
   Context<double>& discrete_context =


### PR DESCRIPTION
Allows cache dependency sweeps to be initiated on a const Context.

Resolves #16579

I won't attempt to add new sugar methods until we're sure we need them, but this change allows a determined programmer to get the job done.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16619)
<!-- Reviewable:end -->
