### PR TITLE
[multibody] Reduce build time

### DIFF
--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -4,6 +4,7 @@
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/geometry/scene_graph.h"
 #include "drake/multibody/parsing/package_map.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/parsing/process_model_directives.h"

--- a/multibody/benchmarks/inclined_plane/inclined_plane_plant.cc
+++ b/multibody/benchmarks/inclined_plane/inclined_plane_plant.cc
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include "drake/geometry/shape_specification.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/tree/uniform_gravity_field_element.h"
 

--- a/multibody/contact_solvers/test/multibody_sim_driver.cc
+++ b/multibody/contact_solvers/test/multibody_sim_driver.cc
@@ -2,6 +2,7 @@
 
 #include "drake/geometry/drake_visualizer.h"
 #include "drake/geometry/proximity_properties.h"
+#include "drake/geometry/scene_graph.h"
 
 namespace drake {
 namespace multibody {

--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -55,6 +55,7 @@ drake_cc_library(
     ],
     deps = [
         "//common:default_scalars",
+        "//geometry/query_results:signed_distance_pair",
         "//math:geometric_transform",
         "//math:gradient",
         "//multibody/plant",

--- a/multibody/inverse_kinematics/distance_constraint.cc
+++ b/multibody/inverse_kinematics/distance_constraint.cc
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/geometry/query_object.h"
 #include "drake/multibody/inverse_kinematics/distance_constraint_utilities.h"
 #include "drake/multibody/inverse_kinematics/kinematic_constraint_utilities.h"
 

--- a/multibody/inverse_kinematics/minimum_distance_constraint.cc
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.cc
@@ -5,6 +5,7 @@
 
 #include <Eigen/Dense>
 
+#include "drake/geometry/query_object.h"
 #include "drake/multibody/inverse_kinematics/distance_constraint_utilities.h"
 #include "drake/multibody/inverse_kinematics/kinematic_constraint_utilities.h"
 

--- a/multibody/meshcat/contact_visualizer.cc
+++ b/multibody/meshcat/contact_visualizer.cc
@@ -6,6 +6,7 @@
 #include <fmt/format.h>
 
 #include "drake/common/extract_double.h"
+#include "drake/geometry/query_object.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/meshcat/point_contact_visualizer.h"
 #include "drake/multibody/plant/contact_results.h"

--- a/multibody/meshcat/test/contact_visualizer_test.cc
+++ b/multibody/meshcat/test/contact_visualizer_test.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
+#include "drake/geometry/scene_graph.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/multibody_plant.h"

--- a/multibody/optimization/sliding_friction_complementarity_constraint.cc
+++ b/multibody/optimization/sliding_friction_complementarity_constraint.cc
@@ -4,6 +4,7 @@
 #include <limits>
 #include <memory>
 
+#include "drake/geometry/query_object.h"
 #include "drake/multibody/inverse_kinematics/kinematic_constraint_utilities.h"
 
 namespace drake {

--- a/multibody/optimization/static_friction_cone_complementarity_constraint.cc
+++ b/multibody/optimization/static_friction_cone_complementarity_constraint.cc
@@ -2,6 +2,7 @@
 
 #include <limits>
 
+#include "drake/geometry/query_object.h"
 #include "drake/multibody/inverse_kinematics/kinematic_constraint_utilities.h"
 
 namespace drake {

--- a/multibody/optimization/static_friction_cone_constraint.cc
+++ b/multibody/optimization/static_friction_cone_constraint.cc
@@ -3,6 +3,7 @@
 #include <limits>
 #include <vector>
 
+#include "drake/geometry/query_object.h"
 #include "drake/multibody/inverse_kinematics/kinematic_constraint_utilities.h"
 
 namespace drake {

--- a/multibody/parsing/detail_common.cc
+++ b/multibody/parsing/detail_common.cc
@@ -1,6 +1,7 @@
 #include "drake/multibody/parsing/detail_common.h"
 
 #include "drake/common/drake_assert.h"
+#include "drake/geometry/geometry_set.h"
 
 namespace drake {
 namespace multibody {

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -10,6 +10,7 @@
 #include <fmt/format.h>
 #include <tinyxml2.h>
 
+#include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/shape_specification.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -6,6 +6,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/text_logging.h"
+#include "drake/geometry/scene_graph.h"
 #include "drake/multibody/tree/ball_rpy_joint.h"
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/multibody/tree/revolute_joint.h"
@@ -166,10 +167,10 @@ GTEST_TEST(MujocoParser, GeometryPose) {
   <worldbody>
     <geom name="identity" type="sphere" size="0.1" />
     <geom name="quat" quat="0 1 0 0" pos="1 2 3" type="sphere" size="0.1" />
-    <geom name="axisangle" axisangle="4 5 6 30" pos="1 2 3" type="sphere" 
+    <geom name="axisangle" axisangle="4 5 6 30" pos="1 2 3" type="sphere"
           size="0.1" />
     <geom name="euler" euler="30 45 60" pos="1 2 3" type="sphere" size="0.1" />
-    <geom name="xyaxes" xyaxes="0 1 0 -1 0 0" pos="1 2 3" type="sphere" 
+    <geom name="xyaxes" xyaxes="0 1 0 -1 0 0" pos="1 2 3" type="sphere"
           size="0.1" />
     <geom name="zaxis" zaxis="0 1 0" pos="1 2 3" type="sphere" size="0.1" />
     <geom name="fromto_capsule" fromto="-1 -3 -3 -1 -1 -3"
@@ -186,7 +187,7 @@ GTEST_TEST(MujocoParser, GeometryPose) {
 <mujoco model="test">
   <compiler angle="radian"/>
   <worldbody>
-    <geom name="axisangle_rad" axisangle="4 5 6 0.5" pos="1 2 3" type="sphere" 
+    <geom name="axisangle_rad" axisangle="4 5 6 0.5" pos="1 2 3" type="sphere"
           size="0.1" />
     <geom name="euler_rad" euler="0.5 0.7 1.05" pos="1 2 3" type="sphere"
           size="0.1" />
@@ -199,7 +200,7 @@ GTEST_TEST(MujocoParser, GeometryPose) {
 <mujoco model="test">
   <compiler angle="degree"/>
   <worldbody>
-    <geom name="axisangle_deg" axisangle="4 5 6 30" pos="1 2 3" type="sphere" 
+    <geom name="axisangle_deg" axisangle="4 5 6 30" pos="1 2 3" type="sphere"
           size="0.1" />
     <geom name="euler_deg" euler="30 45 60" pos="1 2 3" type="sphere"
           size="0.1" />
@@ -386,7 +387,7 @@ GTEST_TEST(MujocoParser, InertiaFromGeometry) {
 
   xml = R"""(
 <mujoco model="test_auto">
-  <compiler inertiafromgeom="auto"/> 
+  <compiler inertiafromgeom="auto"/>
   <worldbody>
     <body name="sphere_auto">
       <inertial mass="524" diaginertia="1 2 3"/>
@@ -407,7 +408,7 @@ GTEST_TEST(MujocoParser, InertiaFromGeometry) {
 
   xml = R"""(
 <mujoco model="test_true">
-  <compiler inertiafromgeom="true"/> 
+  <compiler inertiafromgeom="true"/>
   <default class="main">
     <geom mass="2.53"/>
   </default>
@@ -425,7 +426,7 @@ GTEST_TEST(MujocoParser, InertiaFromGeometry) {
 
   xml = R"""(
 <mujoco model="test_false">
-  <compiler inertiafromgeom="false"/> 
+  <compiler inertiafromgeom="false"/>
   <default class="main">
     <geom mass="2.53"/>
   </default>
@@ -545,7 +546,7 @@ GTEST_TEST(MujocoParser, Joint) {
       <joint type="ball" name="ball" damping="0.1" pos=".1 .2 .3"/>
     </body>
     <body name="slide" pos="1 2 3" euler="30 45 60">
-      <joint type="slide" name="slide" damping="0.2" pos=".1 .2 .3" 
+      <joint type="slide" name="slide" damping="0.2" pos=".1 .2 .3"
              axis="1 0 0" limited="true" range="-2 1.5"/>
     </body>
     <body name="hinge" pos="1 2 3" euler="30 45 60">
@@ -563,7 +564,7 @@ GTEST_TEST(MujocoParser, Joint) {
       <joint type="hinge" name="hinge2" damping="0.6" pos=".1 .2 .3"
              axis="0 1 0"/>
     </body>
-    <body name="default_joint"> 
+    <body name="default_joint">
       <!-- provides code coverage for defaults logic. -->
       <joint/>
     </body>

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -15,6 +15,7 @@
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/geometry_roles.h"
+#include "drake/geometry/scene_graph.h"
 #include "drake/multibody/parsing/detail_path_utils.h"
 #include "drake/multibody/tree/ball_rpy_joint.h"
 #include "drake/multibody/tree/linear_bushing_roll_pitch_yaw.h"

--- a/multibody/parsing/test/drake_manifest_resolution_test.cc
+++ b/multibody/parsing/test/drake_manifest_resolution_test.cc
@@ -9,6 +9,7 @@ Parses and resolves manifest-relative mesh URIs in sdf/urdf.
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
+#include "drake/geometry/scene_graph.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/systems/framework/diagram_builder.h"
 

--- a/multibody/parsing/test/parser_test.cc
+++ b/multibody/parsing/test/parser_test.cc
@@ -10,6 +10,7 @@
 #include "drake/common/find_resource.h"
 #include "drake/common/temp_directory.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/scene_graph.h"
 
 namespace drake {
 namespace multibody {

--- a/multibody/plant/calc_distance_and_time_derivative.cc
+++ b/multibody/plant/calc_distance_and_time_derivative.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/plant/calc_distance_and_time_derivative.h"
 
+#include "drake/geometry/query_object.h"
+
 namespace drake {
 namespace multibody {
 using geometry::FrameId;

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -10,6 +10,7 @@
 #include "drake/common/scope_exit.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/proximity_properties.h"
+#include "drake/geometry/query_object.h"
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/contact_solvers/contact_solver.h"

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -18,6 +18,7 @@
 #include "drake/geometry/proximity_properties.h"
 #include "drake/geometry/query_results/contact_surface.h"
 #include "drake/geometry/render/render_label.h"
+#include "drake/geometry/scene_graph.h"
 #include "drake/math/random_rotation.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/contact_solvers/sparse_linear_operator.h"
@@ -3555,6 +3556,14 @@ template <typename T>
 AddMultibodyPlantSceneGraphResult<T>
 AddMultibodyPlantSceneGraph(
     systems::DiagramBuilder<T>* builder,
+    std::unique_ptr<MultibodyPlant<T>> plant) {
+  return AddMultibodyPlantSceneGraph(builder, std::move(plant), {});
+}
+
+template <typename T>
+AddMultibodyPlantSceneGraphResult<T>
+AddMultibodyPlantSceneGraph(
+    systems::DiagramBuilder<T>* builder,
     std::unique_ptr<MultibodyPlant<T>> plant,
     std::unique_ptr<geometry::SceneGraph<T>> scene_graph) {
   DRAKE_DEMAND(builder != nullptr);
@@ -3579,6 +3588,12 @@ AddMultibodyPlantSceneGraph(
 
 template <typename T>
 AddMultibodyPlantSceneGraphResult<T> AddMultibodyPlantSceneGraph(
+    systems::DiagramBuilder<T>* builder, double time_step) {
+  return AddMultibodyPlantSceneGraph(builder, time_step, {});
+}
+
+template <typename T>
+AddMultibodyPlantSceneGraphResult<T> AddMultibodyPlantSceneGraph(
     systems::DiagramBuilder<T>* builder, double time_step,
     std::unique_ptr<geometry::SceneGraph<T>> scene_graph) {
   DRAKE_DEMAND(builder != nullptr);
@@ -3589,12 +3604,21 @@ AddMultibodyPlantSceneGraphResult<T> AddMultibodyPlantSceneGraph(
 }
 
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
-    /* Use static_cast to disambiguate the two different overloads. */
+    /* Use static_cast to disambiguate the different overloads. */
+    static_cast<AddMultibodyPlantSceneGraphResult<T>(*)(
+        systems::DiagramBuilder<T>*, double)>(
+            &AddMultibodyPlantSceneGraph),
+    /* Use static_cast to disambiguate the different overloads. */
     static_cast<AddMultibodyPlantSceneGraphResult<T>(*)(
         systems::DiagramBuilder<T>*, double,
         std::unique_ptr<geometry::SceneGraph<T>>)>(
             &AddMultibodyPlantSceneGraph),
-    /* Use static_cast to disambiguate the two different overloads. */
+    /* Use static_cast to disambiguate the different overloads. */
+    static_cast<AddMultibodyPlantSceneGraphResult<T>(*)(
+        systems::DiagramBuilder<T>*,
+        std::unique_ptr<MultibodyPlant<T>>)>(
+            &AddMultibodyPlantSceneGraph),
+    /* Use static_cast to disambiguate the different overloads. */
     static_cast<AddMultibodyPlantSceneGraphResult<T>(*)(
         systems::DiagramBuilder<T>*,
         std::unique_ptr<MultibodyPlant<T>>,

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -17,6 +17,9 @@
 #include "drake/common/nice_type_name.h"
 #include "drake/common/random.h"
 #include "drake/geometry/frame_kinematics_vector.h"
+#include "drake/geometry/geometry_roles.h"
+#include "drake/geometry/geometry_set.h"
+#include "drake/geometry/shape_specification.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/contact_solvers/contact_solver.h"
 #include "drake/multibody/contact_solvers/contact_solver_results.h"
@@ -39,14 +42,13 @@
 #include "drake/systems/framework/scalar_conversion_traits.h"
 
 namespace drake {
+
+// To reduce the burden of required header files (and compilation time) on
+// clients, forward-declare some geometry types.
 namespace geometry {
-class GeometrySet;
-class IllustrationProperties;
-class ProximityProperties;
 template <typename T> class QueryObject;
 template <typename T> class SceneGraph;
 template <typename T> class SceneGraphInspector;
-class Shape;
 }  // namespace geometry
 
 namespace multibody {

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -16,7 +16,7 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/random.h"
-#include "drake/geometry/scene_graph.h"
+#include "drake/geometry/frame_kinematics_vector.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/contact_solvers/contact_solver.h"
 #include "drake/multibody/contact_solvers/contact_solver_results.h"
@@ -39,6 +39,16 @@
 #include "drake/systems/framework/scalar_conversion_traits.h"
 
 namespace drake {
+namespace geometry {
+class GeometrySet;
+class IllustrationProperties;
+class ProximityProperties;
+template <typename T> class QueryObject;
+template <typename T> class SceneGraph;
+template <typename T> class SceneGraphInspector;
+class Shape;
+}  // namespace geometry
+
 namespace multibody {
 namespace internal {
 
@@ -4996,6 +5006,30 @@ struct AddMultibodyPlantSceneGraphResult;
 
 /// Makes a new MultibodyPlant with discrete update period `time_step` and
 /// adds it to a diagram builder together with the provided SceneGraph instance,
+/// connecting the geometry ports.  A SceneGraph instance will be created and
+/// used automatically.
+/// @note Usage examples in @ref add_multibody_plant_scene_graph
+/// "AddMultibodyPlantSceneGraph".
+///
+/// @param[in,out] builder
+///   Builder to add to.
+/// @param[in] time_step
+///   The discrete update period for the new MultibodyPlant to be added.
+///   Please refer to the documentation provided in
+///   MultibodyPlant::MultibodyPlant(double) for further details on the
+///   parameter `time_step`.
+/// @return Pair of the registered plant and scene graph.
+/// @pre `builder` must be non-null.
+/// @tparam_default_scalar
+/// @relates MultibodyPlant
+template <typename T>
+AddMultibodyPlantSceneGraphResult<T>
+AddMultibodyPlantSceneGraph(
+    systems::DiagramBuilder<T>* builder,
+    double time_step);
+
+/// Makes a new MultibodyPlant with discrete update period `time_step` and
+/// adds it to a diagram builder together with the provided SceneGraph instance,
 /// connecting the geometry ports.
 /// @note Usage examples in @ref add_multibody_plant_scene_graph
 /// "AddMultibodyPlantSceneGraph".
@@ -5007,9 +5041,9 @@ struct AddMultibodyPlantSceneGraphResult;
 ///   Please refer to the documentation provided in
 ///   MultibodyPlant::MultibodyPlant(double) for further details on the
 ///   parameter `time_step`.
-/// @param[in] scene_graph (optional)
-///   Constructed scene graph. If none is provided, one will be created and
-///   used.
+/// @param[in] scene_graph
+///   Constructed scene graph. If `nullptr` is passed, a SceneGraph instance
+///   will be created and used automatically.
 /// @return Pair of the registered plant and scene graph.
 /// @pre `builder` must be non-null.
 /// @tparam_default_scalar
@@ -5019,7 +5053,28 @@ AddMultibodyPlantSceneGraphResult<T>
 AddMultibodyPlantSceneGraph(
     systems::DiagramBuilder<T>* builder,
     double time_step,
-    std::unique_ptr<geometry::SceneGraph<T>> scene_graph = nullptr);
+    std::unique_ptr<geometry::SceneGraph<T>> scene_graph);
+
+/// Adds a MultibodyPlant and a SceneGraph instance to a diagram builder,
+/// connecting the geometry ports.  A SceneGraph instance will be created and
+/// used automatically.
+///
+/// @note Usage examples in @ref add_multibody_plant_scene_graph
+/// "AddMultibodyPlantSceneGraph".
+///
+/// @param[in,out] builder
+///   Builder to add to.
+/// @param[in] plant
+///   Plant to be added to the builder.
+/// @return Pair of the registered plant and scene graph.
+/// @pre `builder` and `plant` must be non-null.
+/// @tparam_default_scalar
+/// @relates MultibodyPlant
+template <typename T>
+AddMultibodyPlantSceneGraphResult<T>
+AddMultibodyPlantSceneGraph(
+    systems::DiagramBuilder<T>* builder,
+    std::unique_ptr<MultibodyPlant<T>> plant);
 
 /// Adds a MultibodyPlant and a SceneGraph instance to a diagram
 /// builder, connecting the geometry ports.
@@ -5030,9 +5085,9 @@ AddMultibodyPlantSceneGraph(
 ///   Builder to add to.
 /// @param[in] plant
 ///   Plant to be added to the builder.
-/// @param[in] scene_graph (optional)
-///   Constructed scene graph. If none is provided, one will be created and
-///   used.
+/// @param[in] scene_graph
+///   Constructed scene graph. If `nullptr` is passed, a SceneGraph instance
+///   will be created and used automatically.
 /// @return Pair of the registered plant and scene graph.
 /// @pre `builder` and `plant` must be non-null.
 /// @tparam_default_scalar
@@ -5042,7 +5097,7 @@ AddMultibodyPlantSceneGraphResult<T>
 AddMultibodyPlantSceneGraph(
     systems::DiagramBuilder<T>* builder,
     std::unique_ptr<MultibodyPlant<T>> plant,
-    std::unique_ptr<geometry::SceneGraph<T>> scene_graph = nullptr);
+    std::unique_ptr<geometry::SceneGraph<T>> scene_graph);
 
 /// Temporary result from `AddMultibodyPlantSceneGraph`. This cannot be
 /// constructed outside of this method.

--- a/multibody/plant/test/internal_geometry_names_test.cc
+++ b/multibody/plant/test/internal_geometry_names_test.cc
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
+#include "drake/geometry/scene_graph.h"
 #include "drake/multibody/parsing/parser.h"
 
 namespace drake {

--- a/systems/rendering/test/multibody_position_to_geometry_pose_test.cc
+++ b/systems/rendering/test/multibody_position_to_geometry_pose_test.cc
@@ -5,6 +5,7 @@
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/scene_graph.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/multibody_plant.h"
 


### PR DESCRIPTION
The primary move here is to submerge scene_graph.h from
multibody_plant.h to the .cc file. The consequences are:

 * Several forward declarations in multibody_plant.h
 * Numerous .cc files needed to add include statements
 * AddMultibodyPlantSceneGraph:
   * Use overload instead of default arguments
   * Gives same API without compile errors about destructors

This branch cuts my Puget build time by about 13%.
~735s ==> ~645s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16623)
<!-- Reviewable:end -->
