### PR TITLE
Allow external fmt, spdlog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,77 @@ set(BAZEL_OUTPUT_BASE
   "${BAZEL_OUTPUT_BASE}/_bazel_$ENV{USER}/${PROJECT_BINARY_DIR_MD5}"
 )
 
+function(generate_external_repository_file OUTPUT)
+  set(out_path
+    ${CMAKE_CURRENT_BINARY_DIR}/external/$<CONFIG>/workspace/${OUTPUT})
+  if(ARGN)
+    file(GENERATE OUTPUT ${out_path}
+      INPUT ${CMAKE_CURRENT_SOURCE_DIR}/cmake/external/workspace/${ARGN})
+  else()
+    file(GENERATE OUTPUT ${out_path} CONTENT "")
+  endif()
+endfunction()
+
+function(symlink_external_repository_includes NAME TARGET)
+  if(ARGN)
+    get_target_property(include_dir ${TARGET} INTERFACE_INCLUDE_DIRECTORIES)
+    foreach(config IN LISTS ARGN)
+      set(workspace ${CMAKE_CURRENT_BINARY_DIR}/external/${config}/workspace)
+      file(MAKE_DIRECTORY ${workspace}/${NAME})
+      file(CREATE_LINK ${include_dir} ${workspace}/${NAME}/include SYMBOLIC)
+    endforeach()
+  else()
+    if(CMAKE_CONFIGURATION_TYPES)
+      symlink_external_repository_includes(${NAME} ${TARGET}
+        ${CMAKE_CONFIGURATION_TYPES})
+    elseif(CMAKE_BUILD_TYPE)
+      symlink_external_repository_includes(${NAME} ${TARGET}
+        ${CMAKE_BUILD_TYPE})
+    endif()
+  endif()
+endfunction()
+
+macro(override_repository NAME)
+  set(repo "${CMAKE_CURRENT_BINARY_DIR}/external/$<CONFIG>/workspace/${NAME}")
+  list(APPEND BAZEL_OVERRIDE_REPOS --override_repository=${NAME}=${repo})
+endmacro()
+
+set(BAZEL_OVERRIDE_REPOS)
+
+option(WITH_USER_FMT "Use user-provided fmt" OFF)
+
+if(WITH_USER_FMT)
+  find_package(fmt CONFIG REQUIRED)
+
+  symlink_external_repository_includes(fmt fmt::fmt)
+  generate_external_repository_file(fmt/WORKSPACE)
+  generate_external_repository_file(
+    fmt/BUILD.bazel
+    fmt/BUILD.bazel.in)
+
+  override_repository(fmt)
+endif()
+
+option(WITH_USER_SPDLOG "Use user-provided spdlog" OFF)
+
+if(WITH_USER_SPDLOG)
+  if(NOT WITH_USER_FMT)
+    message(FATAL_ERROR
+      "User-provided spdlog (WITH_USER_SPDLOG) "
+      "requires user-provided fmt (WITH_USER_FMT).")
+  endif()
+
+  find_package(spdlog CONFIG REQUIRED)
+
+  symlink_external_repository_includes(spdlog spdlog::spdlog)
+  generate_external_repository_file(spdlog/WORKSPACE)
+  generate_external_repository_file(
+    spdlog/BUILD.bazel
+    spdlog/BUILD.bazel.in)
+
+  override_repository(spdlog)
+endif()
+
 set(BAZEL_CONFIGS)
 
 option(WITH_GUROBI "Build with support for Gurobi" OFF)
@@ -446,6 +517,9 @@ if(CMAKE_CONFIGURATION_TYPES OR BUILD_TYPE_LOWER MATCHES "^(debug|minsizerel|rel
   )
 else()
   set(BAZEL_ARGS)
+endif()
+if(BAZEL_OVERRIDE_REPOS)
+  list(APPEND BAZEL_ARGS ${BAZEL_OVERRIDE_REPOS})
 endif()
 
 # N.B. If you are testing the CMake API and making changes to `installer.py`,

--- a/cmake/external/workspace/fmt/BUILD.bazel.in
+++ b/cmake/external/workspace/fmt/BUILD.bazel.in
@@ -1,0 +1,19 @@
+# -*- python -*-
+
+load("@drake//tools/install:install.bzl", "install")
+load("@drake//tools/lint:lint.bzl", "add_lint_tests")
+
+cc_library(
+    name = "fmt",
+    hdrs = glob(["include/**"]),
+    includes = ["include"],
+    linkopts = ["$<TARGET_LINKER_FILE:fmt::fmt>"],
+    visibility = ["//visibility:public"]
+)
+
+install(
+    name = "install",
+    visibility = ["//visibility:public"]
+)
+
+add_lint_tests()

--- a/cmake/external/workspace/spdlog/BUILD.bazel.in
+++ b/cmake/external/workspace/spdlog/BUILD.bazel.in
@@ -1,0 +1,25 @@
+# -*- python -*-
+
+load("@drake//tools/install:install.bzl", "install")
+load("@drake//tools/lint:lint.bzl", "add_lint_tests")
+
+cc_library(
+    name = "spdlog",
+    hdrs = glob(["include/**"]),
+    includes = ["include"],
+    defines = [
+        "$<JOIN:$<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_COMPILE_DEFINITIONS>,",
+        ">",
+        "HAVE_SPDLOG"
+    ],
+    linkopts = ["$<TARGET_LINKER_FILE:spdlog::spdlog>", "-pthread"],
+    deps = ["@fmt"],
+    visibility = ["//visibility:public"]
+)
+
+install(
+    name = "install",
+    visibility = ["//visibility:public"]
+)
+
+add_lint_tests()


### PR DESCRIPTION
Add logic (only when using the CMake wrapper) to allow the user to select and use external version(s) of fmt and/or spdlog.

Fixes #15815.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16624)
<!-- Reviewable:end -->
