### PR TITLE
[common] Switch RandomGenerator to use 64-bit twister

### DIFF
--- a/bindings/pydrake/common/test/module_test.py
+++ b/bindings/pydrake/common/test/module_test.py
@@ -59,9 +59,9 @@ class TestCommon(unittest.TestCase):
 
     def test_random_generator(self):
         g1 = mut.RandomGenerator()
-        self.assertEqual(g1(), 3499211612)
+        self.assertEqual(g1(), 4143361702)
         g2 = mut.RandomGenerator(seed=10)
-        self.assertEqual(g2(), 3312796937)
+        self.assertEqual(g2(), 2863645618)
 
     def test_random_numpy_coordination(self):
         # Verify that multiple numpy generators can be seeded from

--- a/common/random.h
+++ b/common/random.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <random>
 
@@ -14,14 +15,12 @@
 namespace drake {
 /// Defines Drake's canonical implementation of the UniformRandomBitGenerator
 /// C++ concept (as well as a few conventional extras beyond the concept, e.g.,
-/// seeds).  This uses the 32-bit Mersenne Twister mt19937 by Matsumoto and
-/// Nishimura, 1998.  For more information, see
-/// https://en.cppreference.com/w/cpp/numeric/random/mersenne_twister_engine
+/// seeds).
 class RandomGenerator {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RandomGenerator)
 
-  using result_type = std::mt19937::result_type;
+  using result_type = std::uint32_t;
 
   /// Creates a generator using the `default_seed`.  Actual creation of the
   /// generator is deferred until first use so this constructor is fast and
@@ -47,7 +46,7 @@ class RandomGenerator {
   static constexpr result_type default_seed = std::mt19937::default_seed;
 
  private:
-  using Engine = std::mt19937;
+  using Engine = std::independent_bits_engine<std::mt19937_64, 32, result_type>;
 
   static std::unique_ptr<Engine> CreateEngine(result_type seed);
 

--- a/common/test/random_test.cc
+++ b/common/test/random_test.cc
@@ -31,6 +31,11 @@ GTEST_TEST(RandomGeneratorTest, Traits) {
   EXPECT_TRUE(std::is_move_assignable_v<RandomGenerator>);
 }
 
+GTEST_TEST(RandomGeneratorTest, Range) {
+  EXPECT_EQ(RandomGenerator::min(), 0);
+  EXPECT_EQ(RandomGenerator::max(), 4294967295ull);
+}
+
 GTEST_TEST(RandomGeneratorTest, Efficiency) {
   // Check an insanity upper bound, to demonstrate that we don't store large
   // random state on the stack.
@@ -141,18 +146,6 @@ GTEST_TEST(RandomGeneratorTest, MovedFrom1) {
   }
 }
 
-GTEST_TEST(RandomGeneratorTest, CompareWith19337) {
-  std::mt19937 oracle;
-
-  RandomGenerator dut;
-  EXPECT_EQ(dut.min(), oracle.min());
-  EXPECT_EQ(dut.max(), oracle.max());
-
-  for (int i = 0; i < kNumSteps; ++i) {
-    ASSERT_EQ(dut(), oracle()) << "with i = " << i;
-  }
-}
-
 // The sequence from a default-constructed generator is the same as explicitly
 // passing in the default seed.
 GTEST_TEST(RandomGeneratorTest, DefaultMatchesSeedConstant) {
@@ -160,6 +153,15 @@ GTEST_TEST(RandomGeneratorTest, DefaultMatchesSeedConstant) {
   RandomGenerator bar(RandomGenerator::default_seed);
   for (int i = 0; i < kNumSteps; ++i) {
     ASSERT_EQ(foo(), bar()) << "with i = " << i;
+  }
+}
+
+// Random numbers are not "4, 4, 4, 4, 4, ...".
+// https://xkcd.com/221/
+GTEST_TEST(RandomGeneratorTest, Bogosity) {
+  RandomGenerator dut;
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_NE(dut(), dut()) << "with i = " << i;
   }
 }
 

--- a/systems/benchmarking/framework_benchmarks.cc
+++ b/systems/benchmarking/framework_benchmarks.cc
@@ -1,5 +1,6 @@
 #include <benchmark/benchmark.h>
 
+#include "drake/common/random.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/primitives/pass_through.h"
 #include "drake/tools/performance/fixture_common.h"
@@ -59,6 +60,17 @@ BENCHMARK_F(BasicFixture, PassThrough3)(benchmark::State& state) {
     // scenario of interest, where the inputs change on every tick.
     input.GetMutableData();
     output.Eval(*context_);
+  }
+}
+
+// NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+BENCHMARK_F(BasicFixture, RandomGenerator)(benchmark::State& state) {
+  RandomGenerator dut;
+
+  for (auto _ : state) {
+    for (int i = 0; i < 5000; ++i) {
+      dut();
+    }
   }
 }
 

--- a/systems/primitives/test/multilayer_perceptron_test.cc
+++ b/systems/primitives/test/multilayer_perceptron_test.cc
@@ -78,30 +78,31 @@ GTEST_TEST(MultilayerPerceptronTest, Basic) {
 }
 
 GTEST_TEST(MultilayerPerceptronTest, RandomParameters) {
-  MultilayerPerceptron<double> mlp({1, 100, 1},
+  const int N = 100;
+  MultilayerPerceptron<double> mlp({1, N, 1},
                                    PerceptronActivationType::kIdentity);
   auto context = mlp.CreateDefaultContext();
   RandomGenerator generator(243);
 
-  // Generate N sets of random parameters.
-  int N = 100;
+  // Generate K sets of random parameters.
+  const int K = 123;
   VectorXd mean = VectorXd::Zero(mlp.num_parameters());
   VectorXd var = VectorXd::Zero(mlp.num_parameters());
-  for (int i = 0; i < N; ++i) {
+  for (int i = 0; i < K; ++i) {
     mlp.SetRandomContext(context.get(), &generator);
     mean += mlp.GetParameters(*context);
     // Compute the variance with the true mean (zero) instead of the empirical
     // mean, for tighter statistics. This reduces to E[x^2].
     var += mlp.GetParameters(*context).array().square().matrix();
   }
-  mean /= N;
-  var /= N;
+  mean /= K;
+  var /= K;
   VectorXd std_dev = var.array().sqrt();
 
-  // Note: The large tolerances below are due to the small N and the fact that
-  // it is a worse-case bound over 100 parameters (each). The order of magnitude
-  // differences between the first and second layers confirms that the logic is
-  // correct.
+  // Note: The large tolerances below are due to the small K=123 and the fact
+  // that it is a worse-case bound over N=100 parameters (each). The order of
+  // magnitude differences between the first and second layers confirms that
+  // the logic is correct.
 
   // First layer should have mean≈0, std_dev≈1.
   EXPECT_TRUE(CompareMatrices(mlp.GetWeights(mean, 0), VectorXd::Zero(N), 0.3));


### PR DESCRIPTION
Using the 32-bit twister on 64 bit platforms doubles the state storage size due to padding -- 2504 bytes (for the 64-bit rng) vs 5000 bytes (for the 32-bit rng on a 64-bit platform).

This may cause randomized results to differ vs prior revisions of Drake.

- [x] Requires #16633.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16626)
<!-- Reviewable:end -->
