### PR TITLE
[pydrake/geometry] Make ConvexSets picklable

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -510,6 +510,7 @@ drake_py_unittest(
         ":geometry_py",
         ":math_py",
         "//bindings/pydrake/common/test_utilities:deprecation_py",
+        "//bindings/pydrake/common/test_utilities:pickle_compare_py",
         "//bindings/pydrake/multibody:parsing_py",
         "//bindings/pydrake/multibody:plant_py",
         "//bindings/pydrake/solvers:mathematicalprogram_py",

--- a/bindings/pydrake/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry_py_optimization.cc
@@ -130,7 +130,14 @@ void DefineGeometryOptimization(py::module m) {
         .def_static("MakeBox", &HPolyhedron::MakeBox, py::arg("lb"),
             py::arg("ub"), cls_doc.MakeBox.doc)
         .def_static("MakeUnitBox", &HPolyhedron::MakeUnitBox, py::arg("dim"),
-            cls_doc.MakeUnitBox.doc);
+            cls_doc.MakeUnitBox.doc)
+        .def(py::pickle(
+            [](const HPolyhedron& self) {
+              return std::make_pair(self.A(), self.b());
+            },
+            [](std::pair<Eigen::MatrixXd, Eigen::VectorXd> args) {
+              return HPolyhedron(std::get<0>(args), std::get<1>(args));
+            }));
     py::implicitly_convertible<HPolyhedron, copyable_unique_ptr<ConvexSet>>();
   }
 
@@ -156,7 +163,14 @@ void DefineGeometryOptimization(py::module m) {
         .def_static("MakeHypersphere", &Hyperellipsoid::MakeHypersphere,
             py::arg("radius"), py::arg("center"), cls_doc.MakeHypersphere.doc)
         .def_static("MakeUnitBall", &Hyperellipsoid::MakeUnitBall,
-            py::arg("dim"), cls_doc.MakeUnitBall.doc);
+            py::arg("dim"), cls_doc.MakeUnitBall.doc)
+        .def(py::pickle(
+            [](const Hyperellipsoid& self) {
+              return std::make_pair(self.A(), self.center());
+            },
+            [](std::pair<Eigen::MatrixXd, Eigen::VectorXd> args) {
+              return Hyperellipsoid(std::get<0>(args), std::get<1>(args));
+            }));
     py::implicitly_convertible<Hyperellipsoid,
         copyable_unique_ptr<ConvexSet>>();
   }
@@ -191,7 +205,9 @@ void DefineGeometryOptimization(py::module m) {
             py::arg("reference_frame") = std::nullopt,
             py::arg("maximum_allowable_radius") = 0.0, cls_doc.ctor.doc_4args)
         .def("x", &Point::x, cls_doc.x.doc)
-        .def("set_x", &Point::set_x, py::arg("x"), cls_doc.set_x.doc);
+        .def("set_x", &Point::set_x, py::arg("x"), cls_doc.set_x.doc)
+        .def(py::pickle([](const Point& self) { return self.x(); },
+            [](Eigen::VectorXd arg) { return Point(arg); }));
     py::implicitly_convertible<Point, copyable_unique_ptr<ConvexSet>>();
   }
 
@@ -213,7 +229,9 @@ void DefineGeometryOptimization(py::module m) {
             py::arg("ub"), cls_doc.MakeBox.doc)
         .def_static("MakeUnitBox", &VPolytope::MakeUnitBox, py::arg("dim"),
             cls_doc.MakeUnitBox.doc)
-        .def("CalcVolume", &VPolytope::CalcVolume, cls_doc.CalcVolume.doc);
+        .def("CalcVolume", &VPolytope::CalcVolume, cls_doc.CalcVolume.doc)
+        .def(py::pickle([](const VPolytope& self) { return self.vertices(); },
+            [](Eigen::MatrixXd arg) { return VPolytope(arg); }));
     py::implicitly_convertible<VPolytope, copyable_unique_ptr<ConvexSet>>();
   }
 

--- a/bindings/pydrake/test/geometry_optimization_test.py
+++ b/bindings/pydrake/test/geometry_optimization_test.py
@@ -5,6 +5,7 @@ import unittest
 import numpy as np
 
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
+from pydrake.common.test_utilities.pickle_compare import assert_pickle
 from pydrake.geometry import (
     Box, Capsule, Cylinder, Ellipsoid, FramePoseVector, GeometryFrame,
     GeometryInstance, SceneGraph, Sphere,
@@ -43,6 +44,7 @@ class TestGeometryOptimization(unittest.TestCase):
         point.set_x(x=2*p)
         np.testing.assert_array_equal(point.x(), 2*p)
         point.set_x(x=p)
+        assert_pickle(self, point, lambda S: S.x())
 
         # TODO(SeanCurtis-TRI): This doesn't test the constructor that
         # builds from shape.
@@ -67,6 +69,7 @@ class TestGeometryOptimization(unittest.TestCase):
         with self.assertRaisesRegex(
                 RuntimeError, ".*not implemented yet for HPolyhedron.*"):
             hpoly.ToShapeWithPose()
+        assert_pickle(self, hpoly, lambda S: np.vstack((S.A(), S.b())))
 
         h_box = mut.HPolyhedron.MakeBox(
             lb=[-1, -1, -1], ub=[1, 1, 1])
@@ -110,6 +113,8 @@ class TestGeometryOptimization(unittest.TestCase):
         scale, witness = ellipsoid.MinimumUniformScalingToTouch(point)
         self.assertTrue(scale > 0.0)
         np.testing.assert_array_almost_equal(witness, p)
+        assert_pickle(self, ellipsoid,
+                      lambda S: np.vstack((S.A(), S.center())))
         e_ball = mut.Hyperellipsoid.MakeAxisAligned(
             radius=[1, 1, 1], center=self.b)
         np.testing.assert_array_equal(e_ball.A(), self.A)
@@ -149,6 +154,7 @@ class TestGeometryOptimization(unittest.TestCase):
             x=self.y, t=self.z)
         self.assertGreaterEqual(len(constraints), 2)
         self.assertIsInstance(constraints[0], Binding[Constraint])
+        assert_pickle(self, vpoly, lambda S: S.vertices())
         v_box = mut.VPolytope.MakeBox(
             lb=[-1, -1, -1], ub=[1, 1, 1])
         self.assertTrue(v_box.PointInSet([0, 0, 0]))


### PR DESCRIPTION
Add the ability to pickle the basic convex sets to enable their use in multi-processed python code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16628)
<!-- Reviewable:end -->
