### PR TITLE
PositionConstraint can update lower and upper bounds

### DIFF
--- a/bindings/pydrake/multibody/inverse_kinematics_py.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py.cc
@@ -30,6 +30,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::multibody;
   constexpr auto& doc = pydrake_doc.drake.multibody;
+  constexpr auto& constraint_doc = pydrake_doc.drake.solvers.Constraint;
 
   m.doc() = "InverseKinematics module";
 
@@ -335,7 +336,13 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 8>(), ctor_doc_ad);
+            py::keep_alive<1, 8>(), ctor_doc_ad)
+        .def("set_bounds", &Class::set_bounds, py::arg("new_lb"),
+            py::arg("new_ub"), constraint_doc.set_bounds.doc)
+        .def("UpdateLowerBound", &Class::UpdateLowerBound, py::arg("new_lb"),
+            constraint_doc.UpdateLowerBound.doc)
+        .def("UpdateUpperBound", &Class::UpdateUpperBound, py::arg("new_ub"),
+            constraint_doc.UpdateUpperBound.doc);
   }
 
   {

--- a/bindings/pydrake/multibody/test/inverse_kinematics_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_test.py
@@ -457,6 +457,9 @@ class TestConstraints(unittest.TestCase):
             frameB=variables.body2_frame,
             p_BQ=[0.2, 0.3, 0.5], plant_context=variables.plant_context)
         self.assertIsInstance(constraint, mp.Constraint)
+        constraint.UpdateLowerBound(new_lb=np.array([-2, -3, -0.5]))
+        constraint.UpdateUpperBound(new_ub=np.array([10., 0.5, 2.]))
+        constraint.set_bounds(new_lb=[-1, -2, -2.], new_ub=[1., 2., 3.])
 
     @check_type_variables
     def test_com_position_constraint(self, variables):

--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -1656,6 +1656,7 @@ void BindEvaluatorsAndBindings(py::module m) {
       .def("UpdateUpperBound", &PyFunctionConstraint::UpdateUpperBound,
           py::arg("new_ub"), "Update the upper bound of the constraint.")
       .def("set_bounds", &PyFunctionConstraint::set_bounds,
+          // TODO(hongkai.dai): use new_lb and new_ub as kwargs.
           py::arg("lower_bound"), py::arg("upper_bound"),
           "Set both the lower and upper bounds of the constraint.");
 

--- a/multibody/inverse_kinematics/position_constraint.h
+++ b/multibody/inverse_kinematics/position_constraint.h
@@ -64,6 +64,10 @@ class PositionConstraint : public solvers::Constraint {
 
   ~PositionConstraint() override {}
 
+  using Constraint::set_bounds;
+  using Constraint::UpdateLowerBound;
+  using Constraint::UpdateUpperBound;
+
  private:
   void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
               Eigen::VectorXd* y) const override;

--- a/solvers/constraint.h
+++ b/solvers/constraint.h
@@ -140,15 +140,15 @@ class Constraint : public EvaluatorBase {
 
   /**
    * Set the upper and lower bounds of the constraint.
-   * @param lower_bound. A `num_constraints` x 1 vector.
-   * @param upper_bound. A `num_constraints` x 1 vector.
+   * @param new_lb . A `num_constraints` x 1 vector.
+   * @param new_ub. A `num_constraints` x 1 vector.
    * @note If the users want to expose this method in a sub-class, do
    * using Constraint::set_bounds, as in LinearConstraint.
    */
-  void set_bounds(const Eigen::Ref<const Eigen::VectorXd>& lower_bound,
-                  const Eigen::Ref<const Eigen::VectorXd>& upper_bound) {
-    UpdateLowerBound(lower_bound);
-    UpdateUpperBound(upper_bound);
+  void set_bounds(const Eigen::Ref<const Eigen::VectorXd>& new_lb,
+                  const Eigen::Ref<const Eigen::VectorXd>& new_ub) {
+    UpdateLowerBound(new_lb);
+    UpdateUpperBound(new_ub);
   }
 
   virtual bool DoCheckSatisfied(const Eigen::Ref<const Eigen::VectorXd>& x,


### PR DESCRIPTION
As requested in stackoverflow question https://stackoverflow.com/questions/71157985/how-to-update-bound-of-positionconstraint

I will add the constraint to update other kinematic constraints, these constraints are more complicated as their upper and lower bounds are computed from the kinematic parameter (like angle tolerance), so instead of using UpdateLower/UpperConstraint function, I will probably add `UpdateAngleTolerance` for example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16631)
<!-- Reviewable:end -->
