### PR TITLE
[pydrake/common] Bind __index__ for TypeSafeIndex

### DIFF
--- a/bindings/pydrake/common/type_safe_index_pybind.h
+++ b/bindings/pydrake/common/type_safe_index_pybind.h
@@ -20,6 +20,7 @@ auto BindTypeSafeIndex(
   cls  // BR
       .def(py::init<int>(), pydrake_doc.drake.TypeSafeIndex.ctor.doc_0args)
       .def("__int__", &Class::operator int)
+      .def("__index__", &Class::operator int)
       .def(py::self == py::self)
       .def(py::self == int{})
       .def(py::self < py::self)

--- a/bindings/pydrake/systems/test/controllers_test.py
+++ b/bindings/pydrake/systems/test/controllers_test.py
@@ -308,7 +308,12 @@ class TestControllers(unittest.TestCase):
 
         context = double_integrator.CreateDefaultContext()
         double_integrator.get_input_port(0).FixValue(context, [0])
-        controller = LinearQuadraticRegulator(double_integrator, context, Q, R)
+        controller = LinearQuadraticRegulator(
+            double_integrator,
+            context,
+            Q,
+            R,
+            input_port_index=double_integrator.get_input_port().get_index())
         np.testing.assert_almost_equal(controller.D(), -K_expected)
 
     def test_discrete_time_linear_quadratic_regulator(self):


### PR DESCRIPTION
Previously, running `type_safe_index_pybind_test` produced the following deprecation warning:
```
[  PASSED  ] 1 test.
<string>:2: DeprecationWarning: an integer is required (got type __main__.Index).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
Target //bindings/pydrake/common:py/type_safe_index_pybind_test up-to-date:
  bazel-bin/bindings/pydrake/common/py/type_safe_index_pybind_test
```

In #16611, @jwnimmer-tri proposed that binding __index__ would be a
better solution, and notes that "As of Python 3.8, we could bind only
the `__index__` method (and drop the `__int__` binding) since
`__int__` automatically falls back to `__index__`. However, in Python
3.6 there is no fallback, so we need to have both methods bound for
now."

I originally hit this warning using `LinearQuadraticRegulator` when
passing an `InputPortIndex` instead of an `int`, so I've added that
test here, too.

Unfortunately, these `DeprecationWarning`s are getting through our
build system without being reported, so it requires running the tests
with outputs streamed to see that the message disappears.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16632)
<!-- Reviewable:end -->
