### PR TITLE
[common] Give RandomGenerator efficient default and move constructors

### DIFF
--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -157,12 +157,10 @@ discussion), use e.g.
 
 )""")
           .c_str());
-  random_generator_cls
-      .def(py::init<>(),
-          "Default constructor. Seeds the engine with the default_seed.")
-      .def(py::init<RandomGenerator::result_type>(),
-          "Constructs the engine and initializes the state with a given "
-          "value.")
+  random_generator_cls  // BR
+      .def(py::init<>(), doc.RandomGenerator.ctor.doc_0args)
+      .def(py::init<RandomGenerator::result_type>(), py::arg("seed"),
+          doc.RandomGenerator.ctor.doc_1args)
       .def(
           "__call__", [](RandomGenerator& self) { return self(); },
           "Generates a pseudo-random value.");

--- a/bindings/pydrake/common/test/module_test.py
+++ b/bindings/pydrake/common/test/module_test.py
@@ -60,7 +60,7 @@ class TestCommon(unittest.TestCase):
     def test_random_generator(self):
         g1 = mut.RandomGenerator()
         self.assertEqual(g1(), 3499211612)
-        g2 = mut.RandomGenerator(10)
+        g2 = mut.RandomGenerator(seed=10)
         self.assertEqual(g2(), 3312796937)
 
     def test_random_numpy_coordination(self):

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -476,6 +476,7 @@ drake_cc_library(
     hdrs = ["random.h"],
     deps = [
         ":autodiff",
+        ":copyable_unique_ptr",
         ":essential",
         ":extract_double",
     ],
@@ -684,6 +685,7 @@ drake_cc_googletest(
     name = "random_test",
     deps = [
         ":random",
+        "//common/test_utilities:limit_malloc",
     ],
 )
 

--- a/common/random.cc
+++ b/common/random.cc
@@ -3,6 +3,11 @@
 #include "drake/common/autodiff.h"
 
 namespace drake {
+std::unique_ptr<RandomGenerator::Engine> RandomGenerator::CreateEngine(
+    result_type seed) {
+  return std::make_unique<RandomGenerator::Engine>(seed);
+}
+
 template <typename T>
 T CalcProbabilityDensity(RandomDistribution distribution,
                          const Eigen::Ref<const VectorX<T>>& x) {


### PR DESCRIPTION
Copying 5000 bytes of storage during a move is wasteful; better to just swap a heap pointer.

Calculating 624 random integers in the default constructor is wasteful, if we're only trying to allocate a storage for generator that will be moved into later (e.g., when resizing a collection of generators):

https://github.com/RobotLocomotion/drake/blob/6e0c78de480f9f6fec4d3ad0448d77f20259cf08/systems/analysis/monte_carlo.cc#L47-L52

Towards #16606.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16633)
<!-- Reviewable:end -->
