### PR TITLE
[solvers] Allow evaluators to provide gradients w/o AutoDiffXd

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -1598,7 +1598,8 @@ void BindEvaluatorsAndBindings(py::module m) {
             cls_doc.SetGradientSparsityPattern.doc)
         .def("gradient_sparsity_pattern", &Class::gradient_sparsity_pattern,
             cls_doc.gradient_sparsity_pattern.doc);
-    auto bind_eval = [&cls, &cls_doc](auto dummy_x, auto dummy_y) {
+    auto bind_eval = [&cls, &cls_doc](
+                         auto dummy_x, auto dummy_y, const char* this_doc) {
       using T_x = decltype(dummy_x);
       using T_y = decltype(dummy_y);
       cls.def(
@@ -1608,11 +1609,12 @@ void BindEvaluatorsAndBindings(py::module m) {
             self.Eval(x, &y);
             return y;
           },
-          py::arg("x"), cls_doc.Eval.doc);
+          py::arg("x"), this_doc);
     };
-    bind_eval(double{}, double{});
-    bind_eval(AutoDiffXd{}, AutoDiffXd{});
-    bind_eval(symbolic::Variable{}, symbolic::Expression{});
+    bind_eval(double{}, double{}, cls_doc.Eval.doc_double);
+    bind_eval(AutoDiffXd{}, AutoDiffXd{}, cls_doc.Eval.doc_AutoDiffXd);
+    bind_eval(symbolic::Variable{}, symbolic::Expression{},
+        cls_doc.Eval.doc_Expression);
   }
 
   auto evaluator_binding = RegisterBinding<EvaluatorBase>(&m);

--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -10,6 +10,11 @@ load(
 )
 load("@drake//tools/skylark:test_tags.bzl", "gurobi_test_tags")
 load("//tools/lint:lint.bzl", "add_lint_tests")
+load(
+    "@drake//tools/performance:defs.bzl",
+    "drake_cc_googlebench_binary",
+    "drake_py_experiment_binary",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -126,6 +131,26 @@ drake_cc_googletest(
         ":inverse_kinematics_test_utilities",
         ":kinematic_constraint",
     ],
+)
+
+drake_cc_googlebench_binary(
+    name = "position_constraint_benchmark",
+    srcs = ["position_constraint_benchmark.cc"],
+    data = [
+        "//manipulation/models/iiwa_description:models",
+    ],
+    deps = [
+        ":kinematic_constraint",
+        "//common:find_resource",
+        "//multibody/parsing",
+        "//multibody/plant",
+        "//tools/performance:fixture_common",
+    ],
+)
+
+drake_py_experiment_binary(
+    name = "position_constraint_experiment",
+    googlebench_binary = ":position_constraint_benchmark",
 )
 
 drake_cc_googletest(

--- a/multibody/inverse_kinematics/position_constraint.cc
+++ b/multibody/inverse_kinematics/position_constraint.cc
@@ -85,7 +85,7 @@ void PositionConstraint::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
                                 Eigen::VectorXd* y) const {
   if (use_autodiff()) {
     AutoDiffVecXd y_t;
-    Eval(math::InitializeAutoDiff(x), &y_t);
+    Eval(x.cast<AutoDiffXd>(), &y_t);
     *y = math::ExtractValue(y_t);
   } else {
     DoEvalGeneric(*plant_double_, context_double_, frameA_index_, frameB_index_,
@@ -101,6 +101,28 @@ void PositionConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
   } else {
     DoEvalGeneric(*plant_autodiff_, context_autodiff_, frameA_index_,
                   frameB_index_, p_BQ_, x, y);
+  }
+}
+
+void PositionConstraint::DoEvalWithGradients(
+    const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd* y,
+    Eigen::MatrixXd* dydx) const {
+  if (use_autodiff()) {
+    AutoDiffVecXd y_t;
+    Eval(math::InitializeAutoDiff(x), &y_t);
+    *y = math::ExtractValue(y_t);
+    *dydx = math::ExtractGradient(y_t);
+  } else {
+    y->resize(3);
+    dydx->resize(3, plant_double_->num_positions());
+    UpdateContextConfiguration(context_double_, *plant_double_, x);
+    const Frame<double>& frameA = plant_double_->get_frame(frameA_index_);
+    const Frame<double>& frameB = plant_double_->get_frame(frameB_index_);
+    plant_double_->CalcPointsPositions(*context_double_, frameB, p_BQ_, frameA,
+                                       y);
+    plant_double_->CalcJacobianTranslationalVelocity(
+        *context_double_, JacobianWrtVariable::kQDot, frameB, p_BQ_, frameA,
+        frameA, dydx);
   }
 }
 

--- a/multibody/inverse_kinematics/position_constraint.h
+++ b/multibody/inverse_kinematics/position_constraint.h
@@ -81,6 +81,10 @@ class PositionConstraint : public solvers::Constraint {
         "PositionConstraint::DoEval() does not work for symbolic variables.");
   }
 
+  void DoEvalWithGradients(const Eigen::Ref<const Eigen::VectorXd>& x,
+                           Eigen::VectorXd* y,
+                           Eigen::MatrixXd* dydx) const override;
+
   bool use_autodiff() const { return plant_autodiff_; }
 
   const MultibodyPlant<double>* const plant_double_;

--- a/multibody/inverse_kinematics/position_constraint_benchmark.cc
+++ b/multibody/inverse_kinematics/position_constraint_benchmark.cc
@@ -1,0 +1,108 @@
+// @file
+// Benchmarks for PositionConstraint.
+//
+
+#include <benchmark/benchmark.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/multibody/inverse_kinematics/position_constraint.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/tools/performance/fixture_common.h"
+
+namespace drake {
+namespace multibody {
+namespace inverse_kinematics {
+namespace {
+
+using Eigen::MatrixXd;
+using systems::Context;
+using systems::Diagram;
+using systems::System;
+
+class IiwaPositionConstraintFixture : public benchmark::Fixture {
+ public:
+  using benchmark::Fixture::SetUp;
+  void SetUp(const ::benchmark::State&) override {
+    tools::performance::AddMinMaxStatistics(this);
+
+    const int kNumIiwas = 10;
+
+    const std::string iiwa_path = FindResourceOrThrow(
+        "drake/manipulation/models/iiwa_description/sdf/"
+        "iiwa14_no_collision.sdf");
+    systems::DiagramBuilder<double> builder{};
+    plant_ = builder.AddSystem<MultibodyPlant<double>>(0.0);
+    multibody::Parser parser{plant_};
+    for (int i = 0; i < kNumIiwas; ++i) {
+      const ModelInstanceIndex model_instance =
+          parser.AddModelFromFile(iiwa_path, fmt::format("iiwa{}", i));
+      plant_->WeldFrames(plant_->world_frame(),
+                         plant_->GetFrameByName("iiwa_link_0", model_instance));
+    }
+    plant_->Finalize();
+
+    diagram_ = builder.Build();
+    diagram_context_ = diagram_->CreateDefaultContext();
+    plant_context_ =
+        &diagram_->GetMutableSubsystemContext(*plant_, diagram_context_.get());
+
+    const Eigen::Vector3d p_BQ(0.1, 0.2, 0.3);
+    const Eigen::Vector3d p_AQ_lower(-0.2, -0.3, -0.4);
+    const Eigen::Vector3d p_AQ_upper(0.2, 0.3, 0.4);
+    const ModelInstanceIndex first_iiwa =
+        plant_->GetModelInstanceByName("iiwa0");
+    const Frame<double>& frameA =
+        plant_->GetFrameByName("iiwa_link_7", first_iiwa);
+    const Frame<double>& frameB =
+        plant_->GetFrameByName("iiwa_link_3", first_iiwa);
+    constraint_ = std::make_unique<PositionConstraint>(
+        plant_, frameA, p_AQ_lower, p_AQ_upper, frameB, p_BQ, plant_context_);
+
+    q_.resize(7 * kNumIiwas);
+    for (int i = 0; i < kNumIiwas; ++i) {
+      q_.segment(7 * i, 7) << 0.1, 0.2, 0.3, 0.4, -0.1, -0.2, -0.3;
+    }
+  }
+
+ protected:
+  std::unique_ptr<Diagram<double>> diagram_{};
+  MultibodyPlant<double>* plant_{};
+  std::unique_ptr<Context<double>> diagram_context_{};
+  Context<double>* plant_context_{};
+  std::unique_ptr<PositionConstraint> constraint_{};
+  Eigen::VectorXd q_;
+};
+
+BENCHMARK_F(IiwaPositionConstraintFixture, EvalWGradientMbpDouble)
+// NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+(benchmark::State& state) {
+  Eigen::VectorXd y(constraint_->num_constraints());
+  Eigen::MatrixXd dydx(constraint_->num_constraints(), q_.size());
+  for (auto _ : state) {
+    q_(0) += 0.01;  // avoid caching.
+    constraint_->Eval(q_, &y, &dydx);
+  }
+}
+
+BENCHMARK_F(IiwaPositionConstraintFixture, EvalAutoDiffMbpDouble)
+// NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+(benchmark::State& state) {
+  for (auto _ : state) {
+    q_(0) += 0.01;  // avoid caching.
+    // We include initialization / extraction on each step to mimic the work
+    // that a solver would do using the original original Eval() with
+    // AutoDiffXd.
+    VectorX<AutoDiffXd> q_autodiff = math::InitializeAutoDiff(q_);
+    AutoDiffVecXd y_autodiff;
+    constraint_->Eval(q_autodiff, &y_autodiff);
+    math::ExtractValue(y_autodiff);
+    math::ExtractGradient(y_autodiff);
+  }
+}
+
+}  // namespace
+}  // namespace inverse_kinematics
+}  // namespace multibody
+}  // namespace drake
+
+BENCHMARK_MAIN();

--- a/multibody/inverse_kinematics/test/position_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/position_constraint_test.cc
@@ -64,6 +64,14 @@ TEST_F(IiwaKinematicConstraintTest, PositionConstraint) {
       plant_autodiff_->GetFrameByName(frameB.name()), p_BQ);
   CompareAutoDiffVectors(y_autodiff, y_autodiff_expected, tol);
 
+  // Test EvalWithGradients variant.
+  Eigen::VectorXd y2;
+  Eigen::MatrixXd dydx;
+  constraint.Eval(q, &y2, &dydx);
+  EXPECT_TRUE(CompareMatrices(y2, y_expected, tol));
+  EXPECT_TRUE(
+      CompareMatrices(dydx, math::ExtractGradient(y_autodiff_expected), tol));
+
   // Test with non-identity gradient for q_autodiff.
   q_autodiff = math::InitializeAutoDiff(q, MatrixX<double>::Ones(q.size(), 2));
   plant_autodiff_->GetMutablePositions(plant_context_autodiff_.get()) =

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -150,6 +150,7 @@ drake_cc_library(
         "//common:polynomial",
         "//common:symbolic",
         "//math:autodiff",
+        "//math:gradient",
         "//math:matrix_util",
     ],
 )

--- a/solvers/test/evaluator_base_test.cc
+++ b/solvers/test/evaluator_base_test.cc
@@ -112,10 +112,15 @@ void VerifyFunctionEvaluator(F&& f, const VectorXd& x) {
   Eigen::VectorXd y(3);
   evaluator->Eval(x, &y);
   EXPECT_TRUE(CompareMatrices(y, y_expected));
-  // Check AutoDif.
+  // Check AutoDiff.
   AutoDiffVecXd ty(3);
   evaluator->Eval(tx, &ty);
   EXPECT_TRUE(CompareAutodiff(ty, ty_expected));
+  // Check EvalWithGradients.
+  Eigen::MatrixXd dydx;
+  evaluator->Eval(x, &y, &dydx);
+  EXPECT_TRUE(CompareMatrices(y, y_expected));
+  EXPECT_TRUE(CompareMatrices(dydx, dy_expected));
 }
 
 // Store generic callable (e.g. a lambda), and assign sizes to it manually.

--- a/solvers/test/snopt_solver_test.cc
+++ b/solvers/test/snopt_solver_test.cc
@@ -408,6 +408,7 @@ class AutoDiffOnlyCost final : public drake::solvers::Cost {
 
   void DoEval(const Eigen::Ref<const drake::AutoDiffVecXd>& x,
               drake::AutoDiffVecXd* y) const override {
+    y->resize(1);
     (*y)(0) = x(0) * x(0) + 1;
   }
 


### PR DESCRIPTION
Consider the cost of using EvaluatorBase for a Cost/Constraint with a
huge number of parameters (like the ones we get with
MultilayerPerceptrons).  On each call to Eval(AutoDiff), we using
InitializeAutoDiffXd(x) to create an enormous set of .derivatives() to
inefficiently represent the identity matrix, which the Evaluator
doesn't even want to use.  Furthermore, because the method *could* be
called with any AutoDiffXd on the input, each implementation must
implement the chain rule to compute dydx*dxd__ , when we really just
want dydx.

This PR provides a shortcut, so that implementations of EvaluatorBase
can provide the relevant gradients (only).  In the short term, derived
classes will also have to implement the DoEval(AutoDiff..), or throw.

I've updated only snopt_solver to use this so far, just to initiate
the concept.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16635)
<!-- Reviewable:end -->
