### PR TITLE
[geometry] Add URL customization to Meshcat ctor

### DIFF
--- a/bindings/pydrake/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry_py_visualizers.cc
@@ -189,14 +189,36 @@ void DoScalarIndependentDefinitions(py::module m) {
         });
   }
 
+  // MeshcatParams
+  {
+    using Class = MeshcatParams;
+    constexpr auto& cls_doc = doc.MeshcatParams;
+    py::class_<Class, std::shared_ptr<Class>> cls(
+        m, "MeshcatParams", py::dynamic_attr(), cls_doc.doc);
+    cls  // BR
+        .def(ParamInit<Class>())
+        .def_readwrite("port", &MeshcatParams::port, cls_doc.port.doc)
+        .def_readwrite("web_url_pattern", &MeshcatParams::web_url_pattern,
+            cls_doc.web_url_pattern.doc)
+        .def("__repr__", [](const Class& self) {
+          return py::str(
+              "MeshcatParams("
+              "port={}, "
+              "web_url_pattern={})")
+              .format(self.port, self.web_url_pattern);
+        });
+  }
+
   // Meshcat
   {
     using Class = Meshcat;
     constexpr auto& cls_doc = doc.Meshcat;
     py::class_<Class, std::shared_ptr<Class>> cls(m, "Meshcat", cls_doc.doc);
     cls  // BR
-        .def(py::init<const std::optional<int>&>(),
-            py::arg("port") = std::nullopt, cls_doc.ctor.doc)
+        .def(py::init<std::optional<int>>(), py::arg("port") = std::nullopt,
+            cls_doc.ctor.doc_1args_port)
+        .def(py::init<const MeshcatParams&>(), py::arg("params"),
+            cls_doc.ctor.doc_1args_params)
         .def("web_url", &Class::web_url, cls_doc.web_url.doc)
         .def("port", &Class::port, cls_doc.port.doc)
         .def("ws_url", &Class::ws_url, cls_doc.ws_url.doc)

--- a/bindings/pydrake/test/geometry_visualizers_test.py
+++ b/bindings/pydrake/test/geometry_visualizers_test.py
@@ -88,10 +88,14 @@ class TestGeometryVisualizers(unittest.TestCase):
         draw_subscriber.clear()
 
     def test_meshcat(self):
-        meshcat = mut.Meshcat(port=7051)
-        self.assertEqual(meshcat.port(), 7051)
+        port = 7051
+        params = mut.MeshcatParams(
+            port=port,
+            web_url_pattern="http://host:{port}")
+        meshcat = mut.Meshcat(params=params)
+        self.assertEqual(meshcat.port(), port)
         with self.assertRaises(RuntimeError):
-            meshcat2 = mut.Meshcat(port=7051)
+            meshcat2 = mut.Meshcat(port=port)
         self.assertIn("http", meshcat.web_url())
         self.assertIn("ws", meshcat.ws_url())
         meshcat.SetObject(path="/test/box",

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -19,6 +19,28 @@
 namespace drake {
 namespace geometry {
 
+/** The set of parameters for configuring Meshcat. */
+struct MeshcatParams {
+  /** Meshcat will listen on the given http `port`. If no port is specified,
+  then it will listen on the first available port starting at 7000 (up to 7099).
+  @pre We require `port` >= 1024. */
+  std::optional<int> port{std::nullopt};
+
+  /** The `web_url_pattern` may be used to change the web_url() (and therefore
+  the ws_url()) reported by Meshcat. This may be useful in case %Meshcat sits
+  behind a firewall or proxy.
+
+  The pattern follows the
+  <a href="https://en.cppreference.com/w/cpp/utility/format">std::format</a>
+  specification language, except that `arg-id` substitutions are performed
+  using named arguments instead of positional indices.
+
+  There is only a single argument available to the pattern: `{port}` will be
+  substitued with the %Meshcat server's listen port number.
+  */
+  std::string web_url_pattern{"http://localhost:{port}"};
+};
+
 /** Provides an interface to %Meshcat (https://github.com/rdeits/meshcat).
 
 Each instance of this class spawns a thread which runs an http/websocket server.
@@ -85,11 +107,14 @@ class Meshcat {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Meshcat)
 
-  /** Constructs the Meshcat instance on `port`. If no port is specified, the it
-  will listen on the first available port starting at 7000 (up to 7099).
+  /** Constructs the %Meshcat instance on `port`. If no port is specified,
+  it will listen on the first available port starting at 7000 (up to 7099).
   @pre We require `port` >= 1024.
   @throws std::exception if no requested `port` is available. */
-  explicit Meshcat(const std::optional<int>& port = std::nullopt);
+  explicit Meshcat(std::optional<int> port = std::nullopt);
+
+  /** Constructs the %Meshcat instance using the given `params`. */
+  explicit Meshcat(const MeshcatParams& params);
 
   ~Meshcat();
 

--- a/geometry/meshcat.html
+++ b/geometry/meshcat.html
@@ -21,7 +21,12 @@
     viewer.set_property(['Cameras', 'default', 'rotated', '<object>'],
                         "position", [0.0, 1.0, 3.0])
     try {
-      viewer.connect();
+      url = location.toString();
+      url = url.replace("http://", "ws://")
+      url = url.replace("https://", "wss://")
+      url = url.replace("/index.html", "/")
+      url = url.replace("/meshcat.html", "/")
+      viewer.connect(url);
     } catch (e) {
       console.info("Not connected to MeshCat websocket server: ", e);
     }


### PR DESCRIPTION
Change unknown URLs to return empty, instead of random HTML.

When connecting from JavaScript, retain the sub-directory name (if any) from the http URL.

Towards #16639.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16638)
<!-- Reviewable:end -->
