### PR TITLE
Fix asan_everything config

### DIFF
--- a/tools/dynamic_analysis/bazel.rc
+++ b/tools/dynamic_analysis/bazel.rc
@@ -74,8 +74,8 @@ build:asan_everything --copt=-fno-omit-frame-pointer
 build:asan_everything --linkopt=-fsanitize=address
 build:asan_everything --linkopt=-fsanitize-address-use-after-scope
 # ld.gold: warning: Cannot export local symbol __asan_extra_spill_area
-build:asan --linkopt=-fuse-ld=ld
-build:asan --start_end_lib=no
+build:asan_everything --linkopt=-fuse-ld=ld
+build:asan_everything --start_end_lib=no
 # LSan is run with ASan by default
 build:asan_everything --test_tag_filters=-no_asan,-no_lsan
 build:asan_everything --run_under=//tools/dynamic_analysis:asan


### PR DESCRIPTION
Fix some `build:asan` that were clearly meant to be `build:asan_everything`, as they appear in this section and are otherwise redundant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16646)
<!-- Reviewable:end -->
