### PR TITLE
[parsing] Introduce parsing workspace

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -34,6 +34,7 @@ drake_cc_package_library(
     ],
     deps = [
         ":detail_misc",
+        ":detail_parsing_workspace",
         ":detail_sdf_geometry",
         ":detail_sdf_parser",
         ":detail_urdf_parser",
@@ -171,9 +172,8 @@ drake_cc_library(
     ],
     deps = [
         ":detail_misc",
-        ":package_map",
+        ":detail_parsing_workspace",
         ":scoped_names",
-        "//multibody/plant",
         "@fmt",
         "@tinyxml2",
     ],
@@ -206,6 +206,21 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "detail_parsing_workspace",
+    hdrs = [
+        "detail_parsing_workspace.h",
+    ],
+    visibility = [
+        "//visibility:private",
+    ],
+    deps = [
+        ":package_map",
+        "//common:diagnostic_policy",
+        "//multibody/plant",
+    ],
+)
+
+drake_cc_library(
     name = "parser",
     srcs = [
         "parser.cc",
@@ -217,8 +232,10 @@ drake_cc_library(
         "//visibility:public",
     ],
     deps = [
+        ":detail_parsing_workspace",
         ":detail_sdf_parser",
         ":detail_urdf_parser",
+        "//common:diagnostic_policy",
         "//common:filesystem",
     ],
 )

--- a/multibody/parsing/detail_parsing_workspace.h
+++ b/multibody/parsing/detail_parsing_workspace.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "drake/common/diagnostic_policy.h"
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/multibody/parsing/package_map.h"
+#include "drake/multibody/plant/multibody_plant.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// ParsingWorkspace bundles the commonly-needed elements for parsing routines.
+// It owns nothing; all members are references or pointers to objects owned
+// elsewhere.
+//
+// Note that code using this struct may pass it via const-ref, but the
+// indicated plant will still be mutable; only its pointer within the struct is
+// const.
+struct ParsingWorkspace {
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ParsingWorkspace)
+
+  // All parameters are aliased; they must have a lifetime greater than that of
+  // this struct.
+  ParsingWorkspace(
+    const PackageMap& package_map_in,
+    const drake::internal::DiagnosticPolicy& diagnostic_in,
+    MultibodyPlant<double>* plant_in)
+      : package_map(package_map_in),
+        diagnostic(diagnostic_in),
+        plant(plant_in) {
+    DRAKE_DEMAND(plant != nullptr);
+  }
+
+  const PackageMap& package_map;
+  const drake::internal::DiagnosticPolicy& diagnostic;
+  MultibodyPlant<double>* const plant;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -1171,9 +1171,12 @@ sdf::InterfaceModelPtr ParseNestedInterfaceModel(
   // New instances will have indices starting from cur_num_models
   int cur_num_models = plant->num_model_instances();
   if (is_urdf) {
+    // TODO(rpoyner-tri): integrate with overall diagnostic policy.
+    drake::internal::DiagnosticPolicy diagnostic;
+    ParsingWorkspace workspace{package_map, diagnostic, plant};
     main_model_instance =
         AddModelFromUrdf(data_source, include.LocalModelName().value_or(""),
-                         include.AbsoluteParentName(), package_map, plant);
+                         include.AbsoluteParentName(), workspace);
     // Add explicit model frame to first link.
     auto body_indices = plant->GetBodyIndices(main_model_instance);
     if (body_indices.empty()) {

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -22,6 +22,7 @@
 #include "drake/multibody/parsing/detail_urdf_geometry.h"
 #include "drake/multibody/parsing/package_map.h"
 #include "drake/multibody/parsing/scoped_names.h"
+#include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/ball_rpy_joint.h"
 #include "drake/multibody/tree/fixed_offset_frame.h"
 #include "drake/multibody/tree/planar_joint.h"
@@ -776,8 +777,8 @@ ModelInstanceIndex AddModelFromUrdf(
     const DataSource& data_source,
     const std::string& model_name_in,
     const std::optional<std::string>& parent_model_name,
-    const PackageMap& package_map,
-    MultibodyPlant<double>* plant) {
+    const ParsingWorkspace& workspace) {
+  MultibodyPlant<double>* plant = workspace.plant;
   DRAKE_THROW_UNLESS(plant != nullptr);
   DRAKE_THROW_UNLESS(!plant->is_finalized());
   data_source.DemandExactlyOne();
@@ -816,8 +817,8 @@ ModelInstanceIndex AddModelFromUrdf(
     }
   }
 
-  return ParseUrdf(model_name_in, parent_model_name, package_map, root_dir,
-                   &xml_doc, plant);
+  return ParseUrdf(model_name_in, parent_model_name, workspace.package_map,
+                   root_dir, &xml_doc, plant);
 }
 
 }  // namespace internal

--- a/multibody/parsing/detail_urdf_parser.h
+++ b/multibody/parsing/detail_urdf_parser.h
@@ -4,8 +4,7 @@
 #include <string>
 
 #include "drake/multibody/parsing/detail_common.h"
-#include "drake/multibody/parsing/package_map.h"
-#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/parsing/detail_parsing_workspace.h"
 #include "drake/multibody/tree/multibody_tree_indexes.h"
 
 namespace drake {
@@ -29,16 +28,14 @@ namespace internal {
 //   name (either `model_name` or from the "name" attribute) using the SDFormat
 //   scope delimiter "::". The prefixed name will used as the name given to the
 //   newly created instance of this model.
-// @param plant
-//   A pointer to a mutable MultibodyPlant object to which the model will be
-//   added.
+// @param workspace
+//   The ParsingWorkspace.
 // @returns The model instance index for the newly added model.
 ModelInstanceIndex AddModelFromUrdf(
     const DataSource& data_source,
     const std::string& model_name,
     const std::optional<std::string>& parent_model_name,
-    const PackageMap& package_map,
-    MultibodyPlant<double>* plant);
+    const ParsingWorkspace& workspace);
 
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/parsing/parser.cc
+++ b/multibody/parsing/parser.cc
@@ -2,6 +2,7 @@
 
 #include "drake/common/filesystem.h"
 #include "drake/multibody/parsing/detail_common.h"
+#include "drake/multibody/parsing/detail_parsing_workspace.h"
 #include "drake/multibody/parsing/detail_sdf_parser.h"
 #include "drake/multibody/parsing/detail_urdf_parser.h"
 
@@ -12,6 +13,7 @@ using internal::AddModelFromSdf;
 using internal::AddModelFromUrdf;
 using internal::AddModelsFromSdf;
 using internal::DataSource;
+using internal::ParsingWorkspace;
 
 Parser::Parser(
     MultibodyPlant<double>* plant,
@@ -54,8 +56,8 @@ std::vector<ModelInstanceIndex> Parser::AddAllModelsFromFile(
   if (type == FileType::kSdf) {
     return AddModelsFromSdf(data_source, package_map_, plant_);
   } else {
-    return {AddModelFromUrdf(
-        data_source, {}, {}, package_map_, plant_)};
+    ParsingWorkspace workspace{package_map_, diagnostic_policy_, plant_};
+    return {AddModelFromUrdf(data_source, {}, {}, workspace)};
   }
 }
 
@@ -74,7 +76,8 @@ ModelInstanceIndex Parser::AddModelFromFile(
   if (type == FileType::kSdf) {
     return AddModelFromSdf(data_source, model_name, package_map_, plant_);
   } else {
-    return AddModelFromUrdf(data_source, model_name, {}, package_map_, plant_);
+    ParsingWorkspace workspace{package_map_, diagnostic_policy_, plant_};
+    return AddModelFromUrdf(data_source, model_name, {}, workspace);
   }
 }
 
@@ -88,7 +91,8 @@ ModelInstanceIndex Parser::AddModelFromString(
   if (type == FileType::kSdf) {
     return AddModelFromSdf(data_source, model_name, package_map_, plant_);
   } else {
-    return AddModelFromUrdf(data_source, model_name, {}, package_map_, plant_);
+    ParsingWorkspace workspace{package_map_, diagnostic_policy_, plant_};
+    return AddModelFromUrdf(data_source, model_name, {}, workspace);
   }
 }
 

--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 
+#include "drake/common/diagnostic_policy.h"
 #include "drake/multibody/parsing/package_map.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/multibody_tree_indexes.h"
@@ -88,6 +89,7 @@ class Parser final {
 
  private:
   PackageMap package_map_;
+  drake::internal::DiagnosticPolicy diagnostic_policy_;
   MultibodyPlant<double>* const plant_;
 };
 


### PR DESCRIPTION
Relevant to: #16229

This patch sets up some of the infrastructure for a centralized
diagnostic policy, also performs some long-languishing cleanups on the
URDF parser tests.

There should be no change in functionality (yet); future patches will
port messages to the policy, and allow API control of it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16650)
<!-- Reviewable:end -->
