### PR TITLE
Allow external fmt, spdlog

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -89,4 +89,9 @@ install_test(
     ],
 )
 
-add_lint_tests()
+add_lint_tests(
+    bazel_lint_extra_srcs = [
+        "cmake/external/workspace/spdlog/BUILD.bazel.in",
+        "cmake/external/workspace/fmt/BUILD.bazel.in",
+    ],
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,77 @@ set(BAZEL_OUTPUT_BASE
   "${BAZEL_OUTPUT_BASE}/_bazel_$ENV{USER}/${PROJECT_BINARY_DIR_MD5}"
 )
 
+function(generate_external_repository_file OUTPUT)
+  set(out_path
+    ${CMAKE_CURRENT_BINARY_DIR}/external/$<CONFIG>/workspace/${OUTPUT})
+  if(ARGN)
+    file(GENERATE OUTPUT ${out_path}
+      INPUT ${CMAKE_CURRENT_SOURCE_DIR}/cmake/external/workspace/${ARGN})
+  else()
+    file(GENERATE OUTPUT ${out_path} CONTENT "")
+  endif()
+endfunction()
+
+function(symlink_external_repository_includes NAME TARGET)
+  if(ARGN)
+    get_target_property(include_dir ${TARGET} INTERFACE_INCLUDE_DIRECTORIES)
+    foreach(config IN LISTS ARGN)
+      set(workspace ${CMAKE_CURRENT_BINARY_DIR}/external/${config}/workspace)
+      file(MAKE_DIRECTORY ${workspace}/${NAME})
+      file(CREATE_LINK ${include_dir} ${workspace}/${NAME}/include SYMBOLIC)
+    endforeach()
+  else()
+    if(CMAKE_CONFIGURATION_TYPES)
+      symlink_external_repository_includes(${NAME} ${TARGET}
+        ${CMAKE_CONFIGURATION_TYPES})
+    elseif(CMAKE_BUILD_TYPE)
+      symlink_external_repository_includes(${NAME} ${TARGET}
+        ${CMAKE_BUILD_TYPE})
+    endif()
+  endif()
+endfunction()
+
+macro(override_repository NAME)
+  set(repo "${CMAKE_CURRENT_BINARY_DIR}/external/$<CONFIG>/workspace/${NAME}")
+  list(APPEND BAZEL_OVERRIDE_REPOS --override_repository=${NAME}=${repo})
+endmacro()
+
+set(BAZEL_OVERRIDE_REPOS)
+
+option(WITH_USER_FMT "Use user-provided fmt" OFF)
+
+if(WITH_USER_FMT)
+  find_package(fmt CONFIG REQUIRED)
+
+  symlink_external_repository_includes(fmt fmt::fmt)
+  generate_external_repository_file(fmt/WORKSPACE)
+  generate_external_repository_file(
+    fmt/BUILD.bazel
+    fmt/BUILD.bazel.in)
+
+  override_repository(fmt)
+endif()
+
+option(WITH_USER_SPDLOG "Use user-provided spdlog" OFF)
+
+if(WITH_USER_SPDLOG)
+  if(NOT WITH_USER_FMT)
+    message(FATAL_ERROR
+      "User-provided spdlog (WITH_USER_SPDLOG) "
+      "requires user-provided fmt (WITH_USER_FMT).")
+  endif()
+
+  find_package(spdlog CONFIG REQUIRED)
+
+  symlink_external_repository_includes(spdlog spdlog::spdlog)
+  generate_external_repository_file(spdlog/WORKSPACE)
+  generate_external_repository_file(
+    spdlog/BUILD.bazel
+    spdlog/BUILD.bazel.in)
+
+  override_repository(spdlog)
+endif()
+
 set(BAZEL_CONFIGS)
 
 option(WITH_GUROBI "Build with support for Gurobi" OFF)
@@ -446,6 +517,9 @@ if(CMAKE_CONFIGURATION_TYPES OR BUILD_TYPE_LOWER MATCHES "^(debug|minsizerel|rel
   )
 else()
   set(BAZEL_ARGS)
+endif()
+if(BAZEL_OVERRIDE_REPOS)
+  list(APPEND BAZEL_ARGS ${BAZEL_OVERRIDE_REPOS})
 endif()
 
 # N.B. If you are testing the CMake API and making changes to `installer.py`,

--- a/cmake/external/workspace/fmt/BUILD.bazel.in
+++ b/cmake/external/workspace/fmt/BUILD.bazel.in
@@ -1,0 +1,33 @@
+# -*- python -*-
+
+load("@drake//tools/install:install.bzl", "install")
+load(
+    "@drake//tools/workspace:cmake_util.bzl",
+    "library_to_linkopts",
+    "split_cmake_list",
+)
+
+FMT_DEFINES = split_cmake_list(
+    "$<TARGET_PROPERTY:fmt::fmt,INTERFACE_COMPILE_DEFINITIONS>",
+)
+
+FMT_LINKOPTS = library_to_linkopts(
+    "$<TARGET_LINKER_FILE:fmt::fmt>",
+)
+
+cc_library(
+    name = "fmt",
+    hdrs = glob(
+        ["include/**"],
+        allow_empty = False,
+    ),
+    defines = FMT_DEFINES,
+    includes = ["include"],
+    linkopts = FMT_LINKOPTS,
+    visibility = ["//visibility:public"],
+)
+
+install(
+    name = "install",
+    visibility = ["//visibility:public"],
+)

--- a/cmake/external/workspace/spdlog/BUILD.bazel.in
+++ b/cmake/external/workspace/spdlog/BUILD.bazel.in
@@ -1,0 +1,34 @@
+# -*- python -*-
+
+load("@drake//tools/install:install.bzl", "install")
+load(
+    "@drake//tools/workspace:cmake_util.bzl",
+    "library_to_linkopts",
+    "split_cmake_list",
+)
+
+SPDLOG_DEFINES = split_cmake_list(
+    "$<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_COMPILE_DEFINITIONS>",
+)
+
+SPDLOG_LINKOPTS = library_to_linkopts(
+    "$<TARGET_LINKER_FILE:spdlog::spdlog>",
+)
+
+cc_library(
+    name = "spdlog",
+    hdrs = glob(
+        ["include/**"],
+        allow_empty = False,
+    ),
+    defines = SPDLOG_DEFINES + ["HAVE_SPDLOG"],
+    includes = ["include"],
+    linkopts = SPDLOG_LINKOPTS + ["-pthread"],
+    visibility = ["//visibility:public"],
+    deps = ["@fmt"],
+)
+
+install(
+    name = "install",
+    visibility = ["//visibility:public"],
+)

--- a/tools/workspace/cmake_util.bzl
+++ b/tools/workspace/cmake_util.bzl
@@ -1,0 +1,50 @@
+# -*- python -*-
+
+# This file contains some helper functions that are meant to be used with
+# CMake imported targets.
+
+def split_cmake_list(cmake_list_str):
+    """Convert a string containing a CMake-style list into a 'proper' list."""
+    if len(cmake_list_str) == 0:
+        return []
+    return cmake_list_str.split(";")
+
+def _is_library_extension(ext):
+    """Return True if ext looks like a library extension."""
+    if ext in ["a", "so", "dylib"]:
+        return True
+    if ext.startswith("so."):
+        return True
+    if ext.endswith(".dylib"):
+        return True
+
+    return False
+
+def library_to_linkopts(path):
+    """Convert absolute path to a library to suitable linkopts."""
+    opts = []
+
+    if not path.startswith("/"):
+        fail("{} is not an absolute path.".format(path))
+
+    dirname, libname = path.rsplit("/", 1)
+
+    # Add `-Wl,-rpath,<path>` for `-L<path>`.
+    # See https://github.com/RobotLocomotion/drake/issues/7387#issuecomment-359952616  # noqa
+    opts.append("-Wl,-rpath," + dirname)
+    opts.append("-L" + dirname)
+
+    if "." in libname:
+        ext = libname.split(".", 1)[1]
+    else:
+        ext = ""
+
+    if not _is_library_extension(ext):
+        fail("{} does not appear to be a path to a library.".format(path))
+
+    if not libname.startswith("lib"):
+        fail("Name of library {} must start with `lib`.".format(libname))
+
+    opts.append("-l" + libname[3:].split(".", 1)[0])
+
+    return opts


### PR DESCRIPTION
Add logic (only when using the CMake wrapper) to allow the user to select and use external version(s) of fmt and/or spdlog.

Fixes #15815.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16652)
<!-- Reviewable:end -->
