### PR TITLE
[geometry] Add host name option to MeshcatParams

### DIFF
--- a/bindings/pydrake/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry_py_visualizers.cc
@@ -197,6 +197,7 @@ void DoScalarIndependentDefinitions(py::module m) {
         m, "MeshcatParams", py::dynamic_attr(), cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>())
+        .def_readwrite("host", &MeshcatParams::host, cls_doc.host.doc)
         .def_readwrite("port", &MeshcatParams::port, cls_doc.port.doc)
         .def_readwrite("web_url_pattern", &MeshcatParams::web_url_pattern,
             cls_doc.web_url_pattern.doc)

--- a/bindings/pydrake/test/geometry_visualizers_test.py
+++ b/bindings/pydrake/test/geometry_visualizers_test.py
@@ -90,6 +90,7 @@ class TestGeometryVisualizers(unittest.TestCase):
     def test_meshcat(self):
         port = 7051
         params = mut.MeshcatParams(
+            host="localhost",
             port=port,
             web_url_pattern="http://host:{port}")
         meshcat = mut.Meshcat(params=params)

--- a/bindings/pydrake/visualization/meldis.py
+++ b/bindings/pydrake/visualization/meldis.py
@@ -47,6 +47,7 @@ from pydrake.geometry import (
     Ellipsoid,
     Mesh,
     Meshcat,
+    MeshcatParams,
     Rgba,
     Sphere,
 )
@@ -212,7 +213,8 @@ class Meldis:
         lcm_url = self._lcm.get_lcm_url()
         _logger.info(f"Meldis is listening for LCM messages at {lcm_url}")
 
-        self.meshcat = Meshcat(port=meshcat_port)
+        params = MeshcatParams(host="localhost", port=meshcat_port)
+        self.meshcat = Meshcat(params=params)
 
         viewer = _ViewerApplet(meshcat=self.meshcat)
         self._subscribe(channel="DRAKE_VIEWER_LOAD_ROBOT",

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -21,6 +21,11 @@ namespace geometry {
 
 /** The set of parameters for configuring Meshcat. */
 struct MeshcatParams {
+  /** Meshcat will listen only on the given hostname (e.g., "localhost").
+  If "*" is specified, then it will listen on all interfaces.
+  If empty, an appropriate default value will be chosen (currently "*"). */
+  std::string host{"*"};
+
   /** Meshcat will listen on the given http `port`. If no port is specified,
   then it will listen on the first available port starting at 7000 (up to 7099).
   @pre We require `port` >= 1024. */
@@ -35,10 +40,13 @@ struct MeshcatParams {
   specification language, except that `arg-id` substitutions are performed
   using named arguments instead of positional indices.
 
-  There is only a single argument available to the pattern: `{port}` will be
-  substitued with the %Meshcat server's listen port number.
+  There are two arguments available to the pattern:
+  - `{port}` will be substituted with the %Meshcat server's listen port number;
+  - `{host}` will be substituted with this params structure's `host` field, or
+    else with "localhost" in case the `host` was one of the placeholders for
+    "all interfaces".
   */
-  std::string web_url_pattern{"http://localhost:{port}"};
+  std::string web_url_pattern{"http://{host}:{port}"};
 };
 
 /** Provides an interface to %Meshcat (https://github.com/rdeits/meshcat).


### PR DESCRIPTION
The default remains to bind to "*".

Update meldis to only serve on localhost by default.

This provides the option to the user to decide where to bind.  I'd like to get this out there ASAP, so that in the future we can deprecate binding to "*" by default, giving users a smooth transition path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16654)
<!-- Reviewable:end -->
