### PR TITLE
[multibody] Add plant getter to Parser

### DIFF
--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -68,6 +68,8 @@ PYBIND11_MODULE(parsing, m) {
         .def(py::init<MultibodyPlant<double>*, SceneGraph<double>*>(),
             py::arg("plant"), py::arg("scene_graph") = nullptr,
             cls_doc.ctor.doc)
+        .def("plant", &Class::plant, py_rvp::reference_internal,
+            cls_doc.plant.doc)
         .def("package_map", &Class::package_map, py_rvp::reference_internal,
             cls_doc.package_map.doc)
         .def("AddAllModelsFromFile", &Class::AddAllModelsFromFile,

--- a/bindings/pydrake/multibody/test/parsing_test.py
+++ b/bindings/pydrake/multibody/test/parsing_test.py
@@ -100,6 +100,7 @@ class TestParsing(unittest.TestCase):
             sdf_contents = f.read()
         plant = MultibodyPlant(time_step=0.01)
         parser = Parser(plant=plant)
+        self.assertEqual(parser.plant(), plant)
         result = parser.AddModelFromString(
             file_contents=sdf_contents, file_type="sdf")
         self.assertIsInstance(result, ModelInstanceIndex)

--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -31,6 +31,10 @@ class Parser final {
     MultibodyPlant<double>* plant,
     geometry::SceneGraph<double>* scene_graph = nullptr);
 
+  /// Gets a mutable reference to the plant that will be modified by this
+  /// parser.
+  MultibodyPlant<double>& plant() { return *plant_; }
+
   /// Gets a mutable reference to the PackageMap used by this parser.
   PackageMap& package_map() { return package_map_; }
 

--- a/multibody/parsing/test/parser_test.cc
+++ b/multibody/parsing/test/parser_test.cc
@@ -34,6 +34,7 @@ GTEST_TEST(FileParserTest, BasicTest) {
   {
     MultibodyPlant<double> plant(0.0);
     Parser dut(&plant);
+    EXPECT_EQ(&dut.plant(), &plant);
     EXPECT_EQ(dut.AddAllModelsFromFile(sdf_name).size(), 1);
     dut.AddModelFromFile(sdf_name, "foo");
   }


### PR DESCRIPTION
This might be convenient when re-using the same Parser across an entire simulation setup, even when adding models by hand (i.e., #15804).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16655)
<!-- Reviewable:end -->
