### PR TITLE
[analysis] Don't Initialize during MakeSimulatorFromGflags

### DIFF
--- a/systems/analysis/simulator_gflags.cc
+++ b/systems/analysis/simulator_gflags.cc
@@ -102,7 +102,6 @@ std::unique_ptr<Simulator<T>> MakeSimulatorFromGflags(
   };
   ApplySimulatorConfig(simulator.get(), config);
 
-  simulator->Initialize();
   return simulator;
 }
 


### PR DESCRIPTION
The user may want to alter the context before starting the simulation.

(No release notes, because this header file is private to Drake.)

Towards #15804.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16657)
<!-- Reviewable:end -->
