### PR TITLE
[geometry] Be sure to print exceptions from Meshcat's worker thread

### DIFF
--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -506,10 +506,16 @@ class Meshcat {
                                 std::string property) const;
 
 #ifndef DRAKE_DOXYGEN_CXX
-  /* (Internal use only) Causes the websocket worker thread to exit with an
-  error, which will spit out an exception from the next Meshcat main thread
-  function that gets called. */
-  void InjectWebsocketThreadFault();
+  /* (Internal use for unit testing only) Causes the websocket worker thread to
+  exit with an error, which will spit out an exception from the next Meshcat
+  main thread function that gets called. The fault_number selects which fault to
+  inject, between 0 and kMaxFaultNumber inclusive; refer to the implementation
+  for details on meaning of each number. */
+  void InjectWebsocketThreadFault(int fault_number);
+
+  /* (Internal use for unit testing only) The max value (inclusive) for
+  fault_number, above. */
+  static constexpr int kMaxFaultNumber = 3;
 #endif
 
  private:

--- a/geometry/test/meshcat_websocket_client.py
+++ b/geometry/test/meshcat_websocket_client.py
@@ -44,7 +44,7 @@ def print_recursive_comparison(d1, d2, level='root'):
 
 async def socket_operations_async(args):
     logger.info("Connecting...")
-    async with websockets.connect(args.ws_url) as websocket:
+    async with websockets.connect(args.ws_url, timeout=1) as websocket:
         logger.info("... connected")
         if args.send_message is not None:
             logger.info("Sending...")


### PR DESCRIPTION
Without this, exceptions that leak back to `std::thread` end up in `std::terminate` and usually won't show up for Python.

With this, exceptions will be logged immediately and any additional calls on the Meshcat object will throw an exception.

Requires:
- [x] #16662 
- [x] #16664
- [x] #16667
- [x] #16681
- [x] #16682
- [x] #16670
- [x] #16703
- [x] #16724
- [x] #16695
- [x] #16757
- [x] #16763

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16659)
<!-- Reviewable:end -->
