### PR TITLE
[pydrake] Hotfix unit test for localhost vs *

### DIFF
--- a/bindings/pydrake/test/geometry_visualizers_test.py
+++ b/bindings/pydrake/test/geometry_visualizers_test.py
@@ -90,7 +90,7 @@ class TestGeometryVisualizers(unittest.TestCase):
     def test_meshcat(self):
         port = 7051
         params = mut.MeshcatParams(
-            host="localhost",
+            host="*",
             port=port,
             web_url_pattern="http://host:{port}")
         meshcat = mut.Meshcat(params=params)


### PR DESCRIPTION
Hotfix for #16654.  Apparently on macOS you can bind to the same port number on `localhost` and `*` and that's not an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16660)
<!-- Reviewable:end -->
