### PR TITLE
py math: Fix missing default for RotationMatrix.IsNearlyIdentity()

### DIFF
--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -205,7 +205,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.IsValid.doc_0args)
         .def("IsExactlyIdentity", &Class::IsExactlyIdentity,
             cls_doc.IsExactlyIdentity.doc)
-        .def("IsNearlyIdentity", &Class::IsNearlyIdentity, py::arg("tolerance"),
+        .def("IsNearlyIdentity", &Class::IsNearlyIdentity,
+            py::arg("tolerance") =
+                Class::get_internal_tolerance_for_orthonormality(),
             cls_doc.IsNearlyIdentity.doc);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -270,6 +270,7 @@ class TestMath(unittest.TestCase):
         self.assertIsInstance(angle_axis, AngleAxis)
         R_AngleAxis = RotationMatrix(angle_axis)
         R_I = R.inverse().multiply(R_AngleAxis)
+        numpy_compare.assert_equal(R_I.IsNearlyIdentity(), True)
         numpy_compare.assert_equal(R_I.IsNearlyIdentity(2E-15), True)
         R_I = R.InvertAndCompose(other=R_AngleAxis)
         numpy_compare.assert_equal(R_I.IsNearlyIdentity(2E-15), True)


### PR DESCRIPTION
For expected parity between C++ and Python

C++ has default:
https://github.com/RobotLocomotion/drake/blob/4181a9ab633bbf683f463811fb7fed4d0b73b0f9/math/rotation_matrix.h#L569-L570
Minor omission in #16541 (\cc @mitiguy)

Relates Anzu PR 8468 (to fix deprecation of `.IsIdentityToInternalTolerance()`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16661)
<!-- Reviewable:end -->
