### PR TITLE
Replace `"${var[@]:-}"` with `"${var[@]}"`

### DIFF
--- a/setup/mac/install_prereqs.sh
+++ b/setup/mac/install_prereqs.sh
@@ -38,13 +38,13 @@ done
 # developing with source distributions.
 
 source "${BASH_SOURCE%/*}/binary_distribution/install_prereqs.sh" \
-  "${binary_distribution_args[@]:-}"
+  "${binary_distribution_args[@]}"
 
 # The following additional dependencies are only needed when developing with
 # source distributions.
 
 source "${BASH_SOURCE%/*}/source_distribution/install_prereqs.sh" \
-  "${source_distribution_args[@]:-}"
+  "${source_distribution_args[@]}"
 
 # The preceding only needs to be run once per machine. The following sourced
 # script should be run once per user who develops with source distributions.

--- a/setup/ubuntu/install_prereqs.sh
+++ b/setup/ubuntu/install_prereqs.sh
@@ -77,12 +77,12 @@ done
 # development dependencies such as build-essential and cmake.
 
 source "${BASH_SOURCE%/*}/binary_distribution/install_prereqs.sh" \
-  "${binary_distribution_args[@]:-}"
+  "${binary_distribution_args[@]}"
 
 # The following additional dependencies are only needed when developing with
 # source distributions.
 source "${BASH_SOURCE%/*}/source_distribution/install_prereqs.sh" \
-  "${source_distribution_args[@]:-}"
+  "${source_distribution_args[@]}"
 
 # Configure user environment, executing as user if we're under `sudo`.
 user_env_script="${BASH_SOURCE%/*}/source_distribution/install_prereqs_user_environment.sh"


### PR DESCRIPTION
Array expansion should be fine as-is for empty case
Adding `:-` means it will expand to quoted form for one argument,
which is incorrect

---

Was futzing w/ Anzu stuff (PR 8471), cargo culted from here, then realized there might be an issue.

For example expansion:
https://gist.github.com/EricCousineau-TRI/c3c074de657d063b772c9fa9b355319f

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16666)
<!-- Reviewable:end -->
