### PR TITLE
[systems] Mark simulator_gflags as internal

### DIFF
--- a/examples/hydroelastic/ball_plate/ball_plate_run_dynamics.cc
+++ b/examples/hydroelastic/ball_plate/ball_plate_run_dynamics.cc
@@ -104,7 +104,7 @@ int do_main() {
                                          /* lcm */ nullptr);
 
   auto diagram = builder.Build();
-  auto simulator = systems::MakeSimulatorFromGflags(*diagram);
+  auto simulator = MakeSimulatorFromGflags(*diagram);
 
   // Set the ball's initial pose.
   systems::Context<double>& plant_context =

--- a/examples/mass_spring_cloth/run_cloth_spring_model.cc
+++ b/examples/mass_spring_cloth/run_cloth_spring_model.cc
@@ -43,8 +43,7 @@ int DoMain() {
       &builder, *scene_graph, std::make_shared<geometry::Meshcat>());
   auto diagram = builder.Build();
   auto context = diagram->CreateDefaultContext();
-  auto simulator =
-      systems::MakeSimulatorFromGflags(*diagram, std::move(context));
+  auto simulator = MakeSimulatorFromGflags(*diagram, std::move(context));
   simulator->AdvanceTo(FLAGS_simulation_time);
   return 0;
 }

--- a/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
+++ b/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
@@ -213,7 +213,7 @@ int do_main() {
       &plant_context, plant.GetBodyByName("Ball"), V_WB);
 
   auto simulator =
-      systems::MakeSimulatorFromGflags(*diagram, std::move(diagram_context));
+      MakeSimulatorFromGflags(*diagram, std::move(diagram_context));
 
   using clock = std::chrono::steady_clock;
   const clock::time_point start = clock::now();

--- a/systems/analysis/simulator_gflags.cc
+++ b/systems/analysis/simulator_gflags.cc
@@ -60,6 +60,7 @@ DEFINE_bool(simulator_use_error_control,
 
 namespace drake {
 namespace systems {
+namespace internal {
 
 template <typename T>
 IntegratorBase<T>& ResetIntegratorFromGflags(Simulator<T>* simulator) {
@@ -109,5 +110,7 @@ DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
       &ResetIntegratorFromGflags<T>,
       &MakeSimulatorFromGflags<T>
 ))
+
+}  // namespace internal
 }  // namespace systems
 }  // namespace drake

--- a/systems/analysis/simulator_gflags.h
+++ b/systems/analysis/simulator_gflags.h
@@ -1,8 +1,8 @@
 #pragma once
 
-/// @file
-/// This file defines gflags settings to control Simulator settings.
-/// Only include this from translation units that declare a `main` function.
+// @file
+// This file defines gflags settings to control Simulator settings.
+// Only include this from translation units that declare a `main` function.
 
 #include <memory>
 
@@ -23,31 +23,33 @@ DECLARE_bool(simulator_publish_every_time_step);
 
 namespace drake {
 namespace systems {
+namespace internal {
 
-/// Resets the integrator used to advanced the continuous time dynamics of the
-/// system associated with `simulator` according to the gflags declared in this
-/// file.
-/// @param[in,out] simulator
-///   On input, a valid pointer to a Simulator. On output the
-///   integrator for `simulator` is reset according to the gflags declared in
-///   this file.
-/// @tparam_nonsymbolic_scalar
-/// @returns A reference to the newly created integrator owned by `simulator`.
+// Resets the integrator used to advanced the continuous time dynamics of the
+// system associated with `simulator` according to the gflags declared in this
+// file.
+// @param[in,out] simulator
+//   On input, a valid pointer to a Simulator. On output the
+//   integrator for `simulator` is reset according to the gflags declared in
+//   this file.
+// @tparam_nonsymbolic_scalar
+// @returns A reference to the newly created integrator owned by `simulator`.
 template <typename T>
 IntegratorBase<T>& ResetIntegratorFromGflags(Simulator<T>* simulator);
 
-/// Makes a new simulator according to the gflags declared in this file.
-/// @param[in] system
-///   The System to be associated with the newly crated Simulator. You must
-///   ensure that `system` has a longer lifetime than the new Simulator.
-/// @param[in] context
-///   The Context that will be used as the initial condition for the simulation;
-///   otherwise the Simulator will obtain a default Context from `system`.
-/// @tparam_nonsymbolic_scalar
-/// @returns The newly created Simulator.
+// Makes a new simulator according to the gflags declared in this file.
+// @param[in] system
+//   The System to be associated with the newly crated Simulator. You must
+//   ensure that `system` has a longer lifetime than the new Simulator.
+// @param[in] context
+//   The Context that will be used as the initial condition for the simulation;
+//   otherwise the Simulator will obtain a default Context from `system`.
+// @tparam_nonsymbolic_scalar
+// @returns The newly created Simulator.
 template <typename T>
 std::unique_ptr<Simulator<T>> MakeSimulatorFromGflags(
     const System<T>& system, std::unique_ptr<Context<T>> context = nullptr);
 
+}  // namespace internal
 }  // namespace systems
 }  // namespace drake

--- a/systems/analysis/test/simulator_gflags_main.cc
+++ b/systems/analysis/test/simulator_gflags_main.cc
@@ -10,8 +10,8 @@ namespace systems {
 template <typename T>
 void ResetIntegratorFromGflagsTest() {
   ConstantVectorSource<T> source(2);
-  auto simulator = MakeSimulatorFromGflags(source);
-  ResetIntegratorFromGflags(simulator.get());
+  auto simulator = internal::MakeSimulatorFromGflags(source);
+  internal::ResetIntegratorFromGflags(simulator.get());
   const auto simulator_config = ExtractSimulatorConfig(*simulator);
   drake::log()->info(drake::yaml::SaveYamlString(simulator_config));
 }


### PR DESCRIPTION
It has Drake-only package visibility, is not installed, and therefore is unavailable to end users. As such, we don't want it [showing up in Doxygen](https://drake.mit.edu/doxygen_cxx/namespacedrake_1_1systems.html#a0a6e4906135fe23f2a8f8f9cd68f3385).

Follow-up from discussions in #16657.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16671)
<!-- Reviewable:end -->
