### PR TITLE
Partially revert "Replace `"${var[@]:-}"` with `"${var[@]}"`"

### DIFF
--- a/setup/mac/install_prereqs.sh
+++ b/setup/mac/install_prereqs.sh
@@ -37,14 +37,17 @@ done
 # needed when developing with binary distributions are also needed when
 # developing with source distributions.
 
+# N.B. We need `${var:-}` here because mac's older version of bash does
+# not seem to be able to cope with an empty array.
+
 source "${BASH_SOURCE%/*}/binary_distribution/install_prereqs.sh" \
-  "${binary_distribution_args[@]}"
+  "${binary_distribution_args[@]:-}"
 
 # The following additional dependencies are only needed when developing with
 # source distributions.
 
 source "${BASH_SOURCE%/*}/source_distribution/install_prereqs.sh" \
-  "${source_distribution_args[@]}"
+  "${source_distribution_args[@]:-}"
 
 # The preceding only needs to be run once per machine. The following sourced
 # script should be run once per user who develops with source distributions.


### PR DESCRIPTION
Reverts RobotLocomotion/drake#16666

Dear @EricCousineau-TRI 

 The on-call build cop, @svenevs , believes that your PR #16666 may have
 broken one or more of Drake's continuous integration builds [1]. It is
 possible to break a build even if your PR passed continuous integration
 pre-merge because additional platforms are tested post-merge.

 The specific build failures under investigation are:

- https://drake-jenkins.csail.mit.edu/job/mac-big-sur-unprovisioned-clang-bazel-continuous-snopt-packaging/1233/consoleFull
- `/Users/bigsur/workspace/mac-big-sur-unprovisioned-clang-bazel-continuous-snopt-packaging/src/setup/mac/install_prereqs.sh: line 40: binary_distribution_args[@]: unbound variable`
- Alternative to reverting could be to guarantee this variable is at least created as an empty array?  macOS bash is 3.x.  In potential future or alternative fixes, add a mac unprovisioned build to verify the change.

 Therefore, the build cop has created this revert PR and started a complete
 post-merge build to determine whether your PR was in fact the cause of the
 problem. If that build passes, this revert PR will be merged 60 minutes from
 now. You can then fix the problem at your leisure, and send a new PR to
 reinstate your change.

 If you believe your original PR did not actually break the build, please
 explain on this thread.

 If you believe you can fix the break promptly in lieu of a revert, please
 explain on this thread, and send a PR to the build cop for review ASAP.

 If you believe your original PR definitely did break the build and should be
 reverted, please review and LGTM this PR. This allows the build cop to merge
 without waiting for CI results.

 For advice on how to handle a build cop revert, see [2].

 Thanks!
 Your Friendly On-call Build Cop

 [1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
 [2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16672)
<!-- Reviewable:end -->
