### PR TITLE
[parsing] Clean up some path handling

### DIFF
--- a/multibody/parsing/detail_common.cc
+++ b/multibody/parsing/detail_common.cc
@@ -1,13 +1,48 @@
 #include "drake/multibody/parsing/detail_common.h"
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/filesystem.h"
 
 namespace drake {
 namespace multibody {
 namespace internal {
 
-void DataSource::DemandExactlyOne() const {
-  DRAKE_DEMAND((file_name != nullptr) ^ (file_contents != nullptr));
+DataSource::DataSource(DataSourceType type, const std::string* data)
+    : type_(type), data_(data) {
+  DRAKE_DEMAND(IsFilename() != IsContents());
+  DRAKE_DEMAND(data != nullptr);
+}
+
+const std::string& DataSource::filename() const {
+  DRAKE_DEMAND(IsFilename());
+  return *data_;
+}
+
+const std::string& DataSource::contents() const {
+  DRAKE_DEMAND(IsContents());
+  return *data_;
+}
+
+std::string DataSource::GetAbsolutePath() const {
+  if (IsFilename()) {
+    return filesystem::absolute(*data_).native();
+  }
+  return "";
+}
+
+std::string DataSource::GetRootDir() const {
+  if (IsFilename()) {
+    return filesystem::absolute(*data_).parent_path().native();
+  }
+  return "";
+}
+
+std::string DataSource::GetStem() const {
+  if (IsFilename()) {
+    filesystem::path p{*data_};
+    return p.stem();
+  }
+  return kContentsPseudoStem;
 }
 
 geometry::ProximityProperties ParseProximityProperties(

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -959,19 +959,17 @@ ModelInstanceIndex AddModelFromMujocoXml(
     MultibodyPlant<double>* plant) {
   DRAKE_THROW_UNLESS(plant != nullptr);
   DRAKE_THROW_UNLESS(!plant->is_finalized());
-  data_source.DemandExactlyOne();
 
   XMLDocument xml_doc;
-  if (data_source.file_name) {
-    xml_doc.LoadFile(data_source.file_name->c_str());
+  if (data_source.IsFilename()) {
+    xml_doc.LoadFile(data_source.filename().c_str());
     if (xml_doc.ErrorID()) {
       throw std::runtime_error(fmt::format("Failed to parse XML file {}:\n{}",
-                                           *data_source.file_name,
+                                           data_source.filename(),
                                            xml_doc.ErrorName()));
     }
   } else {
-    DRAKE_DEMAND(data_source.file_contents != nullptr);
-    xml_doc.Parse(data_source.file_contents->c_str());
+    xml_doc.Parse(data_source.contents().c_str());
     if (xml_doc.ErrorID()) {
       throw std::runtime_error(
           fmt::format("Failed to parse XML string: {}", xml_doc.ErrorName()));

--- a/multibody/parsing/detail_path_utils.cc
+++ b/multibody/parsing/detail_path_utils.cc
@@ -17,40 +17,6 @@ namespace internal {
 using std::string;
 
 namespace {
-bool IsAbsolutePath(const string& filename) {
-  const string prefix = "/";
-  return filename.substr(0, prefix.size()) == prefix;
-}
-}  // namespace
-
-string GetFullPath(const string& file_name) {
-  string result = file_name;
-  if (result.empty()) {
-    throw std::runtime_error("drake::parsers::GetFullPath: ERROR: file_name is "
-                             "empty.");
-  }
-
-  if (IsAbsolutePath(result)) {
-    // The specified file is already an absolute path. The following code
-    // verifies that the file exists.
-    if (!filesystem::is_regular_file({file_name})) {
-      throw std::runtime_error("drake::parsers::GetFullPath: ERROR: "
-          "file_name \"" + file_name + "\" is not a file.");
-    }
-  } else {
-    // The specified file is a relative path. The following code obtains the
-    // full path and verifies that the file exists.
-    result = (filesystem::current_path() /
-              filesystem::path(file_name)).lexically_normal().string();
-    if (!filesystem::is_regular_file({result})) {
-      throw std::runtime_error("drake::parsers::GetFullPath: ERROR: "
-          "file_name \"" + file_name + "\" is not a file or does not exist.");
-    }
-  }
-  return result;
-}
-
-namespace {
 
 // Searches for key package in package_map. If the key exists, returns the
 // associated value; else prints a warning and returns nullopt.
@@ -103,9 +69,9 @@ string ResolveUri(const string& uri, const PackageMap& package_map,
     // Strictly speaking a URI should not just be a bare filename, but we allow
     // this for backward compatibility and user convenience.
     const string& filename = uri;
-    if (IsAbsolutePath(filename)) {
+    if (filesystem::path(filename).is_absolute()) {
       result = filename;
-    } else if (IsAbsolutePath(root_dir)) {
+    } else if (filesystem::path(root_dir).is_absolute()) {
       result = root_dir;
       result.append(filename);
     } else {

--- a/multibody/parsing/detail_path_utils.h
+++ b/multibody/parsing/detail_path_utils.h
@@ -8,15 +8,6 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-// Obtains the full path of @file_name. If @p file_name is already a
-// full path (i.e., it starts with a "/"), the path is not modified.
-// If @p file_name is a relative path, this method converts it into
-// an absolute path based on the current working directory.
-//
-// @throws std::exception if the file does not exist or if @p
-// file_name is empty.
-std::string GetFullPath(const std::string& file_name);
-
 // Resolves the full path of a URI. If @p uri starts with "package:" or
 // "model:", the ROS packages specified in @p package_map are searched.
 // Otherwise, iff a root_dir was provided then @p uri is appended to the end

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -577,33 +577,16 @@ sdf::InterfaceModelPtr ParseNestedInterfaceModel(
 
 // Helper method to load an SDF file and read the contents into an sdf::Root
 // object.
-std::string LoadSdf(
+void LoadSdf(
     sdf::Root* root,
     const DataSource& data_source,
     const sdf::ParserConfig& parser_config) {
-  data_source.DemandExactlyOne();
-
-  std::string root_dir;
-  if (data_source.file_name) {
-    const std::string full_path = GetFullPath(*data_source.file_name);
+  if (data_source.IsFilename()) {
+    const std::string full_path = data_source.GetAbsolutePath();
     ThrowAnyErrors(root->Load(full_path, parser_config));
-    // Uses the directory holding the SDF to be the root directory
-    // in which to search for files referenced within the SDF file.
-    size_t found = full_path.find_last_of("/\\");
-    if (found != std::string::npos) {
-      root_dir = full_path.substr(0, found);
-    } else {
-      // TODO(jwnimmer-tri) This is not unit tested.  In any case, we should be
-      // using drake::filesystem for path manipulation, not string searching.
-      root_dir = ".";
-    }
   } else {
-    DRAKE_DEMAND(data_source.file_contents != nullptr);
-    ThrowAnyErrors(root->LoadSdfString(*data_source.file_contents,
-                                       parser_config));
+    ThrowAnyErrors(root->LoadSdfString(data_source.contents(), parser_config));
   }
-
-  return root_dir;
 }
 
 struct LinkInfo {
@@ -1164,8 +1147,7 @@ sdf::InterfaceModelPtr ParseNestedInterfaceModel(
     return nullptr;
   }
 
-  DataSource data_source;
-  data_source.file_name = &include.ResolvedFileName();
+  DataSource data_source(DataSource::kFilename, &include.ResolvedFileName());
 
   ModelInstanceIndex main_model_instance;
   // New instances will have indices starting from cur_num_models
@@ -1198,7 +1180,7 @@ sdf::InterfaceModelPtr ParseNestedInterfaceModel(
     // another included model that requires a custom parser.
     sdf::Root root;
 
-    std::string root_dir = LoadSdf(&root, data_source, parser_config);
+    LoadSdf(&root, data_source, parser_config);
     DRAKE_DEMAND(nullptr != root.Model());
     const sdf::Model &model = *root.Model();
 
@@ -1206,7 +1188,7 @@ sdf::InterfaceModelPtr ParseNestedInterfaceModel(
         include.LocalModelName().value_or(model.Name());
     main_model_instance = AddModelsFromSpecification(
         model, sdf::JoinName(include.AbsoluteParentName(), model_name), {},
-        plant, package_map, root_dir).front();
+        plant, package_map, data_source.GetRootDir()).front();
   }
 
   // Now that the model is parsed, we create interface elements to send to
@@ -1325,7 +1307,7 @@ ModelInstanceIndex AddModelFromSdf(
 
   sdf::Root root;
 
-  std::string root_dir = LoadSdf(&root, data_source, parser_config);
+  LoadSdf(&root, data_source, parser_config);
 
   if (root.Model() == nullptr) {
     throw std::runtime_error("File must have a single <model> element.");
@@ -1338,7 +1320,7 @@ ModelInstanceIndex AddModelFromSdf(
 
   std::vector<ModelInstanceIndex> added_model_instances =
       AddModelsFromSpecification(model, model_name, {}, plant, package_map,
-                                 root_dir);
+                                 data_source.GetRootDir());
 
   DRAKE_DEMAND(!added_model_instances.empty());
   return added_model_instances.front();
@@ -1357,7 +1339,7 @@ std::vector<ModelInstanceIndex> AddModelsFromSdf(
 
   sdf::Root root;
 
-  std::string root_dir = LoadSdf(&root, data_source, parser_config);
+  LoadSdf(&root, data_source, parser_config);
 
   // There either must be exactly one model, or exactly one world.
 #pragma GCC diagnostic push
@@ -1383,7 +1365,7 @@ std::vector<ModelInstanceIndex> AddModelsFromSdf(
 
     std::vector<ModelInstanceIndex> added_model_instances =
         AddModelsFromSpecification(model, model.Name(), {}, plant,
-                                   package_map, root_dir);
+                                   package_map, data_source.GetRootDir());
     model_instances.insert(model_instances.end(),
                            added_model_instances.begin(),
                            added_model_instances.end());
@@ -1402,7 +1384,7 @@ std::vector<ModelInstanceIndex> AddModelsFromSdf(
       const sdf::Model& model = *world.ModelByIndex(model_index);
       std::vector<ModelInstanceIndex> added_model_instances =
           AddModelsFromSpecification(model, model.Name(), {}, plant,
-                                     package_map, root_dir);
+                                     package_map, data_source.GetRootDir());
       model_instances.insert(model_instances.end(),
                              added_model_instances.begin(),
                              added_model_instances.end());

--- a/multibody/parsing/parser.cc
+++ b/multibody/parsing/parser.cc
@@ -44,8 +44,7 @@ FileType DetermineFileType(const std::string& file_name) {
 
 std::vector<ModelInstanceIndex> Parser::AddAllModelsFromFile(
     const std::string& file_name) {
-  DataSource data_source;
-  data_source.file_name = &file_name;
+  DataSource data_source(DataSource::kFilename, &file_name);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   // Always search for a package.xml file, starting the crawl upward from
@@ -64,8 +63,7 @@ std::vector<ModelInstanceIndex> Parser::AddAllModelsFromFile(
 ModelInstanceIndex Parser::AddModelFromFile(
     const std::string& file_name,
     const std::string& model_name) {
-  DataSource data_source;
-  data_source.file_name = &file_name;
+  DataSource data_source(DataSource::kFilename, &file_name);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   // Always search for a package.xml file, starting the crawl upward from
@@ -85,9 +83,9 @@ ModelInstanceIndex Parser::AddModelFromString(
     const std::string& file_contents,
     const std::string& file_type,
     const std::string& model_name) {
-  DataSource data_source;
-  data_source.file_contents = &file_contents;
-  const FileType type = DetermineFileType("<literal-string>." + file_type);
+  DataSource data_source(DataSource::kContents, &file_contents);
+  const FileType type = DetermineFileType(
+      data_source.GetStem() + "." + file_type);
   if (type == FileType::kSdf) {
     return AddModelFromSdf(data_source, model_name, package_map_, plant_);
   } else {

--- a/multibody/parsing/test/detail_common_test.cc
+++ b/multibody/parsing/test/detail_common_test.cc
@@ -1,5 +1,6 @@
 #include "drake/multibody/parsing/detail_common.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 namespace drake {
@@ -19,6 +20,35 @@ using geometry::internal::kHydroGroup;
 using geometry::internal::kMaterialGroup;
 using geometry::internal::kRezHint;
 using std::optional;
+
+class DataSourceTest : public ::testing::Test {
+ protected:
+  const std::string relative_path_{"relative.txt"};
+  const DataSource relative_{DataSource::kFilename, &relative_path_};
+  const std::string absolute_path_{"/a/b/c/absolute.txt"};
+  const DataSource absolute_{DataSource::kFilename, &absolute_path_};
+  const std::string stuff_{"stuff"};
+  const DataSource contents_{DataSource::kContents, &stuff_};
+};
+
+TEST_F(DataSourceTest, GetAbsolutePath) {
+  EXPECT_THAT(relative_.GetAbsolutePath(),
+              ::testing::MatchesRegex("/.*/relative.txt"));
+  EXPECT_EQ(absolute_.GetAbsolutePath(), absolute_path_);  // no change.
+  EXPECT_EQ(contents_.GetAbsolutePath(), "");
+}
+
+TEST_F(DataSourceTest, GetRootDir) {
+  EXPECT_THAT(relative_.GetRootDir(), ::testing::MatchesRegex("/.*[^/]"));
+  EXPECT_EQ(absolute_.GetRootDir(), "/a/b/c");
+  EXPECT_EQ(contents_.GetRootDir(), "");
+}
+
+TEST_F(DataSourceTest, GetStem) {
+  EXPECT_EQ(relative_.GetStem(), "relative");
+  EXPECT_EQ(absolute_.GetStem(), "absolute");
+  EXPECT_EQ(contents_.GetStem(), DataSource::kContentsPseudoStem);
+}
 
 using ReadDoubleFunc = std::function<optional<double>(const char*)>;
 const bool rigid{true};

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -45,7 +45,7 @@ GTEST_TEST(MujocoParser, GymModels) {
 
     const std::string filename = FindResourceOrThrow(
         fmt::format("drake/multibody/parsing/dm_control/suite/{}.xml", f));
-    AddModelFromMujocoXml({.file_name = &filename}, f, std::nullopt, &plant);
+    AddModelFromMujocoXml({DataSource::kFilename, &filename}, f, {}, &plant);
 
     EXPECT_TRUE(plant.HasModelInstanceNamed(f));
   }
@@ -63,8 +63,7 @@ GTEST_TEST(MujocoParser, Option) {
 </mujoco>
 )""";
 
-  AddModelFromMujocoXml({.file_name = nullptr, .file_contents = &xml}, "test",
-                        std::nullopt, &plant);
+  AddModelFromMujocoXml({DataSource::kContents, &xml}, "test", {}, &plant);
   EXPECT_TRUE(CompareMatrices(plant.gravity_field().gravity_vector(),
                               Vector3d{0, -9.81, 0}));
 }
@@ -97,8 +96,7 @@ GTEST_TEST(MujocoParser, GeometryTypes) {
 </mujoco>
 )""";
 
-  AddModelFromMujocoXml({.file_name = nullptr, .file_contents = &xml}, "test",
-                        std::nullopt, &plant);
+  AddModelFromMujocoXml({DataSource::kContents, &xml}, "test", {}, &plant);
   const SceneGraphInspector<double>& inspector = scene_graph.model_inspector();
 
   auto CheckShape = [&inspector](const std::string& geometry_name,
@@ -147,8 +145,8 @@ GTEST_TEST(MujocoParser, UnrecognizedGeometryTypes) {
 </mujoco>
 )""";
   DRAKE_EXPECT_THROWS_MESSAGE(
-      AddModelFromMujocoXml({.file_name = nullptr, .file_contents = &xml},
-                            "test_unrecognized", std::nullopt, &plant),
+      AddModelFromMujocoXml({DataSource::kContents, &xml},
+                            "test_unrecognized", {}, &plant),
       ".*Unrecognized.*");
 }
 
@@ -166,10 +164,10 @@ GTEST_TEST(MujocoParser, GeometryPose) {
   <worldbody>
     <geom name="identity" type="sphere" size="0.1" />
     <geom name="quat" quat="0 1 0 0" pos="1 2 3" type="sphere" size="0.1" />
-    <geom name="axisangle" axisangle="4 5 6 30" pos="1 2 3" type="sphere" 
+    <geom name="axisangle" axisangle="4 5 6 30" pos="1 2 3" type="sphere"
           size="0.1" />
     <geom name="euler" euler="30 45 60" pos="1 2 3" type="sphere" size="0.1" />
-    <geom name="xyaxes" xyaxes="0 1 0 -1 0 0" pos="1 2 3" type="sphere" 
+    <geom name="xyaxes" xyaxes="0 1 0 -1 0 0" pos="1 2 3" type="sphere"
           size="0.1" />
     <geom name="zaxis" zaxis="0 1 0" pos="1 2 3" type="sphere" size="0.1" />
     <geom name="fromto_capsule" fromto="-1 -3 -3 -1 -1 -3"
@@ -186,7 +184,7 @@ GTEST_TEST(MujocoParser, GeometryPose) {
 <mujoco model="test">
   <compiler angle="radian"/>
   <worldbody>
-    <geom name="axisangle_rad" axisangle="4 5 6 0.5" pos="1 2 3" type="sphere" 
+    <geom name="axisangle_rad" axisangle="4 5 6 0.5" pos="1 2 3" type="sphere"
           size="0.1" />
     <geom name="euler_rad" euler="0.5 0.7 1.05" pos="1 2 3" type="sphere"
           size="0.1" />
@@ -199,7 +197,7 @@ GTEST_TEST(MujocoParser, GeometryPose) {
 <mujoco model="test">
   <compiler angle="degree"/>
   <worldbody>
-    <geom name="axisangle_deg" axisangle="4 5 6 30" pos="1 2 3" type="sphere" 
+    <geom name="axisangle_deg" axisangle="4 5 6 30" pos="1 2 3" type="sphere"
           size="0.1" />
     <geom name="euler_deg" euler="30 45 60" pos="1 2 3" type="sphere"
           size="0.1" />
@@ -207,12 +205,11 @@ GTEST_TEST(MujocoParser, GeometryPose) {
 </mujoco>
 )""";
 
-  AddModelFromMujocoXml({.file_name = nullptr, .file_contents = &xml}, "test",
-                        std::nullopt, &plant);
-  AddModelFromMujocoXml({.file_name = nullptr, .file_contents = &radians_xml},
-                        "radians_test", std::nullopt, &plant);
-  AddModelFromMujocoXml({.file_name = nullptr, .file_contents = &degrees_xml},
-                        "degrees_test", std::nullopt, &plant);
+  AddModelFromMujocoXml({DataSource::kContents, &xml}, "test", {}, &plant);
+  AddModelFromMujocoXml({DataSource::kContents, &radians_xml},
+                        "radians_test", {}, &plant);
+  AddModelFromMujocoXml({DataSource::kContents, &degrees_xml},
+                        "degrees_test", {}, &plant);
 
   const SceneGraphInspector<double>& inspector = scene_graph.model_inspector();
 
@@ -282,8 +279,7 @@ GTEST_TEST(MujocoParser, GeometryProperties) {
 </mujoco>
 )""";
 
-  AddModelFromMujocoXml({.file_name = nullptr, .file_contents = &xml}, "test",
-                        std::nullopt, &plant);
+  AddModelFromMujocoXml({DataSource::kContents, &xml}, "test", {}, &plant);
 
   const SceneGraphInspector<double>& inspector = scene_graph.model_inspector();
 
@@ -381,12 +377,11 @@ GTEST_TEST(MujocoParser, InertiaFromGeometry) {
 </mujoco>
 )""";
 
-  AddModelFromMujocoXml({.file_name = nullptr, .file_contents = &xml}, "test",
-                        std::nullopt, &plant);
+  AddModelFromMujocoXml({DataSource::kContents, &xml}, "test", {}, &plant);
 
   xml = R"""(
 <mujoco model="test_auto">
-  <compiler inertiafromgeom="auto"/> 
+  <compiler inertiafromgeom="auto"/>
   <worldbody>
     <body name="sphere_auto">
       <inertial mass="524" diaginertia="1 2 3"/>
@@ -402,12 +397,11 @@ GTEST_TEST(MujocoParser, InertiaFromGeometry) {
 </mujoco>
 )""";
 
-  AddModelFromMujocoXml({.file_name = nullptr, .file_contents = &xml},
-                        "test_auto", std::nullopt, &plant);
+  AddModelFromMujocoXml({DataSource::kContents, &xml}, "test_auto", {}, &plant);
 
   xml = R"""(
 <mujoco model="test_true">
-  <compiler inertiafromgeom="true"/> 
+  <compiler inertiafromgeom="true"/>
   <default class="main">
     <geom mass="2.53"/>
   </default>
@@ -420,12 +414,11 @@ GTEST_TEST(MujocoParser, InertiaFromGeometry) {
 </mujoco>
 )""";
 
-  AddModelFromMujocoXml({.file_name = nullptr, .file_contents = &xml},
-                        "test_true", std::nullopt, &plant);
+  AddModelFromMujocoXml({DataSource::kContents, &xml}, "test_true", {}, &plant);
 
   xml = R"""(
 <mujoco model="test_false">
-  <compiler inertiafromgeom="false"/> 
+  <compiler inertiafromgeom="false"/>
   <default class="main">
     <geom mass="2.53"/>
   </default>
@@ -445,8 +438,8 @@ GTEST_TEST(MujocoParser, InertiaFromGeometry) {
 </mujoco>
 )""";
 
-  AddModelFromMujocoXml({.file_name = nullptr, .file_contents = &xml},
-                        "test_false", std::nullopt, &plant);
+  AddModelFromMujocoXml({DataSource::kContents, &xml},
+                        "test_false", {}, &plant);
 
   plant.Finalize();
 
@@ -545,7 +538,7 @@ GTEST_TEST(MujocoParser, Joint) {
       <joint type="ball" name="ball" damping="0.1" pos=".1 .2 .3"/>
     </body>
     <body name="slide" pos="1 2 3" euler="30 45 60">
-      <joint type="slide" name="slide" damping="0.2" pos=".1 .2 .3" 
+      <joint type="slide" name="slide" damping="0.2" pos=".1 .2 .3"
              axis="1 0 0" limited="true" range="-2 1.5"/>
     </body>
     <body name="hinge" pos="1 2 3" euler="30 45 60">
@@ -563,7 +556,7 @@ GTEST_TEST(MujocoParser, Joint) {
       <joint type="hinge" name="hinge2" damping="0.6" pos=".1 .2 .3"
              axis="0 1 0"/>
     </body>
-    <body name="default_joint"> 
+    <body name="default_joint">
       <!-- provides code coverage for defaults logic. -->
       <joint/>
     </body>
@@ -571,8 +564,7 @@ GTEST_TEST(MujocoParser, Joint) {
 </mujoco>
 )""";
 
-  AddModelFromMujocoXml({.file_name = nullptr, .file_contents = &xml}, "test",
-                        std::nullopt, &plant);
+  AddModelFromMujocoXml({DataSource::kContents, &xml}, "test", {}, &plant);
   plant.Finalize();
 
   auto context = plant.CreateDefaultContext();
@@ -697,8 +689,7 @@ GTEST_TEST(MujocoParser, JointThrows) {
 )""";
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      AddModelFromMujocoXml({.file_name = nullptr, .file_contents = &xml},
-                            "test", std::nullopt, &plant),
+      AddModelFromMujocoXml({DataSource::kContents, &xml}, "test", {}, &plant),
       ".*a free joint is defined.*");
 }
 
@@ -739,8 +730,7 @@ GTEST_TEST(MujocoParser, Motor) {
 </mujoco>
 )""";
 
-  AddModelFromMujocoXml({.file_name = nullptr, .file_contents = &xml}, "test",
-                        std::nullopt, &plant);
+  AddModelFromMujocoXml({DataSource::kContents, &xml}, "test", {}, &plant);
   plant.Finalize();
 
   EXPECT_EQ(plant.get_actuation_input_port().size(), 4);

--- a/multibody/parsing/test/detail_path_utils_test.cc
+++ b/multibody/parsing/test/detail_path_utils_test.cc
@@ -16,40 +16,6 @@ namespace multibody {
 namespace internal {
 namespace {
 
-// Verifies that GetFullPath() promotes a relative path to an absolute path,
-// and leaves already-absolute paths alone.
-GTEST_TEST(ParserPathUtilsTest, TestGetFullPath_Relative) {
-  const string relative_path = "test_file.txt";
-  std::ofstream ostr(relative_path);
-  ASSERT_TRUE(ostr.is_open());
-  ostr.close();
-
-  // Relative path -> absolute path.
-  string full_path;
-  ASSERT_NO_THROW(full_path = GetFullPath(relative_path));
-  ASSERT_TRUE(!full_path.empty());
-  EXPECT_EQ(full_path[0], '/');
-  EXPECT_TRUE(filesystem::exists({full_path}));
-
-  // Absolute path unchanged.
-  string full_path_idempotent;
-  ASSERT_NO_THROW(full_path_idempotent = GetFullPath(full_path));
-  EXPECT_EQ(full_path_idempotent, full_path);
-}
-
-// Verifies that GetFullPath() throws when given a relative path to a
-// non-existent file.
-GTEST_TEST(ParserPathUtilsTest, TestGetFullPathToNonexistentFile) {
-  const string relative_path =
-      "drake/multibody/parsers/test/parser_common_test/nonexistent_file.txt";
-  EXPECT_THROW(GetFullPath(relative_path), std::runtime_error);
-}
-
-// Verifies that GetFullPath() throws when given an empty path.
-GTEST_TEST(ParserPathUtilsTest, TestGetFullPathOfEmptyPath) {
-  EXPECT_THROW(GetFullPath(""), std::runtime_error);
-}
-
 // Verifies that the path returned is a normalized path. This is not an
 // exhaustive list of all ways a valid path can be unnormalized. Ultimately,
 // we're relying on std::filesystem to get the job done and these are just

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -60,7 +60,7 @@ ModelInstanceIndex AddModelFromSdfFile(
     const PackageMap& package_map,
     MultibodyPlant<double>* plant,
     bool test_sdf_forced_nesting = false) {
-  const DataSource data_source{&file_name, {}};
+  const DataSource data_source{DataSource::kFilename, &file_name};
   return AddModelFromSdf(data_source, model_name, package_map, plant,
                          test_sdf_forced_nesting);
 }
@@ -69,7 +69,7 @@ std::vector<ModelInstanceIndex> AddModelsFromSdfFile(
     const PackageMap& package_map,
     MultibodyPlant<double>* plant,
     bool test_sdf_forced_nesting = false) {
-  const DataSource data_source{&file_name, {}};
+  const DataSource data_source{DataSource::kFilename, &file_name};
   return AddModelsFromSdf(
       data_source, package_map, plant, test_sdf_forced_nesting);
 }
@@ -78,7 +78,7 @@ std::vector<ModelInstanceIndex> AddModelsFromSdfString(
     const PackageMap& package_map,
     MultibodyPlant<double>* plant,
     bool test_sdf_forced_nesting = false) {
-  const DataSource data_source{{}, &file_contents};
+  const DataSource data_source{DataSource::kContents, &file_contents};
   return AddModelsFromSdf(data_source, package_map, plant,
                           test_sdf_forced_nesting);
 }

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -224,7 +224,7 @@ class UrdfGeometryTests : public testing::Test {
   // Loads a URDF file and parses the minimal amount of it which
   // urdf_geometry.cc handles.
   void ParseUrdfGeometry(const std::string& file_name) {
-    const std::string full_path = GetFullPath(file_name);
+    const std::string full_path = filesystem::absolute(file_name).native();
 
     xml_doc_.LoadFile(full_path.c_str());
     ASSERT_FALSE(xml_doc_.ErrorID()) << xml_doc_.ErrorName();

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -43,7 +43,8 @@ class UrdfParserTest : public ::testing::Test {
   ModelInstanceIndex AddModelFromUrdfFile(
       const std::string& file_name,
       const std::string& model_name) {
-    return AddModelFromUrdf({ .file_name = &file_name }, model_name, {}, w_);
+    return AddModelFromUrdf(
+        {DataSource::kFilename, &file_name}, model_name, {}, w_);
   }
 
  protected:
@@ -339,8 +340,7 @@ TEST_F(UrdfParserTest, AddingGeometriesToWorldLink) {
   </link>
 </robot>
 )""";
-  DataSource source;
-  source.file_contents = &test_urdf;
+  DataSource source{DataSource::kContents, &test_urdf};
 
   AddModelFromUrdf(source, "urdf", {}, w_);
 
@@ -452,7 +452,7 @@ void ParseTestString(const std::string& inner,
   DiagnosticPolicy diagnostic;
   ParsingWorkspace workspace{package_map, diagnostic, plant};
   drake::log()->debug("inner: {}", inner);
-  AddModelFromUrdf({ .file_name = nullptr, .file_contents = &contents },
+  AddModelFromUrdf({DataSource::kContents, &contents},
                    model_name, {}, workspace);
 }
 

--- a/multibody/parsing/test/parser_test.cc
+++ b/multibody/parsing/test/parser_test.cc
@@ -168,10 +168,10 @@ GTEST_TEST(FileParserTest, ExtensionMatchTest) {
   // URDF parser, shown here by it generating a different exception message).
   DRAKE_EXPECT_THROWS_MESSAGE(
       Parser(&plant).AddModelFromFile("acrobot.SDF"),
-      ".*does not exist.*");
+      ".*\n.*Unable to read file.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       Parser(&plant).AddModelFromFile("acrobot.URDF"),
-      ".*does not exist.*");
+      "Failed to parse XML file .*\nXML_ERROR_FILE_NOT_FOUND");
 }
 
 GTEST_TEST(FileParserTest, BadStringTest) {


### PR DESCRIPTION
Relevant to: #16229

Get rid of redundant hidden calculations of root_dir in sub-parsers.
Instead, add some path-like operations to DataSource, implemented with
drake::filesystem, and port to those. Remove some old string-fiddly path
operations.

In particular, this patch gets rid of the comingling of path algebra
with existence checking. The underlying XML parsers will report file
non-existence instead.

Also, this patch makes (somewhat) official the pseudo-filename already
in use for file_contents data sources: "<literal-string>". This will
allow diagnostics issued against such sources to be more consistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16677)
<!-- Reviewable:end -->
