### PR TITLE
[geometry] Refactor Meshcat to strictly obey PIMPL

### DIFF
--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -505,7 +505,7 @@ class Meshcat {
  private:
   // Provides PIMPL encapsulation of websocket types.
   class WebSocketPublisher;
-  std::unique_ptr<WebSocketPublisher> publisher_;
+  const std::unique_ptr<WebSocketPublisher> publisher_;
 };
 
 }  // namespace geometry


### PR DESCRIPTION
Having functions implementations on both the inner class and outer class is too difficult to maintain.

Towards #16670.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16681)
<!-- Reviewable:end -->
