### PR TITLE
[geometry] Rename Meshcat::Impl and use const-correct accessors

### DIFF
--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -504,8 +504,15 @@ class Meshcat {
 
  private:
   // Provides PIMPL encapsulation of websocket types.
-  class WebSocketPublisher;
-  const std::unique_ptr<WebSocketPublisher> publisher_;
+  class Impl;
+
+  // Safe accessors for the PIMPL object.
+  Impl& impl();
+  const Impl& impl() const;
+
+  // Always a non-nullptr Impl, but stored as void* to enforce that the
+  // impl() accessors are always used.
+  void* const impl_{};
 };
 
 }  // namespace geometry


### PR DESCRIPTION
The inner class has outgrown WebSocketPublisher, so is renamed to Impl per the usual pattern.

Outer class access to Impl is done through accessors for const correctness. This also paves the way for a future commit to mix in lifetime checks while accessing the Impl (in #16670).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16682)
<!-- Reviewable:end -->
