### PR TITLE
[parsing] Port URDF diagnostics to policy: first steps

### DIFF
--- a/multibody/parsing/detail_urdf_parser.h
+++ b/multibody/parsing/detail_urdf_parser.h
@@ -30,8 +30,9 @@ namespace internal {
 //   newly created instance of this model.
 // @param workspace
 //   The ParsingWorkspace.
-// @returns The model instance index for the newly added model.
-ModelInstanceIndex AddModelFromUrdf(
+// @returns The model instance index for the newly added model, std::nullopt if
+//          the parse was incomplete.
+std::optional<ModelInstanceIndex> AddModelFromUrdf(
     const DataSource& data_source,
     const std::string& model_name,
     const std::optional<std::string>& parent_model_name,

--- a/multibody/parsing/test/parser_test.cc
+++ b/multibody/parsing/test/parser_test.cc
@@ -171,7 +171,8 @@ GTEST_TEST(FileParserTest, ExtensionMatchTest) {
       ".*\n.*Unable to read file.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       Parser(&plant).AddModelFromFile("acrobot.URDF"),
-      "Failed to parse XML file .*\nXML_ERROR_FILE_NOT_FOUND");
+      "/.*/acrobot.URDF:0: error: "
+      "Failed to parse XML file: XML_ERROR_FILE_NOT_FOUND");
 }
 
 GTEST_TEST(FileParserTest, BadStringTest) {
@@ -184,6 +185,7 @@ GTEST_TEST(FileParserTest, BadStringTest) {
   // Malformed URDF string is an error.
   DRAKE_EXPECT_THROWS_MESSAGE(
       Parser(&plant).AddModelFromString("bad", "urdf"),
+      "<literal-string>.urdf:1: error: "
       "Failed to parse XML string: XML_ERROR_PARSING_TEXT");
 
   // Unknown extension is an error.


### PR DESCRIPTION
Relevant to: #16229

This patch takes just the shallowest cut at porting URDF diagnostic
messages to use the diagnostic policy object; only two error messages
are ported.

It does introduce some necessary formatting machinery (which might be
useful elsewhere later?), and updates affected test clauses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16687)
<!-- Reviewable:end -->
