### PR TITLE
Fix noncompliant name kInfeasible_Or_Unbounded

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -541,6 +541,9 @@ void BindMathematicalProgram(py::module m) {
       .def("get_solution_result",
           &MathematicalProgramResult::get_solution_result,
           doc.MathematicalProgramResult.get_solution_result.doc)
+      .def("set_solution_result",
+          &MathematicalProgramResult::set_solution_result,
+          doc.MathematicalProgramResult.set_solution_result.doc)
       .def("get_optimal_cost", &MathematicalProgramResult::get_optimal_cost,
           doc.MathematicalProgramResult.get_optimal_cost.doc)
       .def("get_solver_id", &MathematicalProgramResult::get_solver_id,
@@ -1541,7 +1544,9 @@ for every column of ``prog_var_vals``. )""")
               .doc_deprecated);
 #pragma GCC diagnostic pop
 
-  py::enum_<SolutionResult>(m, "SolutionResult", doc.SolutionResult.doc)
+  py::enum_<SolutionResult> solution_result_enum(
+      m, "SolutionResult", doc.SolutionResult.doc);
+  solution_result_enum
       .value("kSolutionFound", SolutionResult::kSolutionFound,
           doc.SolutionResult.kSolutionFound.doc)
       .value("kInvalidInput", SolutionResult::kInvalidInput,
@@ -1552,13 +1557,26 @@ for every column of ``prog_var_vals``. )""")
           doc.SolutionResult.kUnbounded.doc)
       .value("kUnknownError", SolutionResult::kUnknownError,
           doc.SolutionResult.kUnknownError.doc)
-      .value("kInfeasible_Or_Unbounded",
-          SolutionResult::kInfeasible_Or_Unbounded,
-          doc.SolutionResult.kInfeasible_Or_Unbounded.doc)
+      .value("kInfeasibleOrUnbounded", SolutionResult::kInfeasibleOrUnbounded,
+          doc.SolutionResult.kInfeasibleOrUnbounded.doc)
       .value("kIterationLimit", SolutionResult::kIterationLimit,
           doc.SolutionResult.kIterationLimit.doc)
       .value("kDualInfeasible", SolutionResult::kDualInfeasible,
           doc.SolutionResult.kDualInfeasible.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  constexpr char deprecation[] =
+      "Deprecated:\n kInfeasible_Or_Unbounded is deprecated. Please use "
+      "kInfeasibleOrUnbounded instead. This will be removed on or "
+      "after 2022-07-01.";
+  solution_result_enum.def_property_static(
+      "kInfeasible_Or_Unbounded",
+      [deprecation](py::handle /* cls */) {
+        WarnDeprecated(deprecation);
+        return SolutionResult::kInfeasible_Or_Unbounded;
+      },
+      nullptr, deprecation);
+#pragma GCC diagnostic pop
 }  // NOLINT(readability/fn_size)
 
 void BindEvaluatorsAndBindings(py::module m) {

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -208,6 +208,16 @@ class TestMathematicalProgram(unittest.TestCase):
         result.set_x_val(x_val_new)
         np.testing.assert_array_equal(x_val_new, result.get_x_val())
 
+    def test_solution_result_deprecation(self):
+        # Remove after 2022-07-01.
+        result = MathematicalProgramResult()
+        with catch_drake_warnings(expected_count=1):
+            result.set_solution_result(
+                mp.SolutionResult.kInfeasible_Or_Unbounded)
+        self.assertEqual(
+            result.get_solution_result(),
+            mp.SolutionResult.kInfeasibleOrUnbounded)
+
     def test_str(self):
         qp = TestQP()
         s = str(qp.prog)

--- a/multibody/inverse_kinematics/test/global_inverse_kinematics_reachable_test.cc
+++ b/multibody/inverse_kinematics/test/global_inverse_kinematics_reachable_test.cc
@@ -92,7 +92,7 @@ TEST_F(KukaTest, ReachableTest) {
     EXPECT_TRUE(result.get_solution_result() ==
                     solvers::SolutionResult::kInfeasibleConstraints ||
                 result.get_solution_result() ==
-                    solvers::SolutionResult::kInfeasible_Or_Unbounded);
+                    solvers::SolutionResult::kInfeasibleOrUnbounded);
   }
 }
 }  // namespace

--- a/multibody/inverse_kinematics/test/global_inverse_kinematics_test.cc
+++ b/multibody/inverse_kinematics/test/global_inverse_kinematics_test.cc
@@ -48,7 +48,7 @@ TEST_F(KukaTest, UnreachableTest) {
     const solvers::MathematicalProgramResult result =
         gurobi_solver.Solve(global_ik_.prog(), {}, {});
     EXPECT_TRUE(result.get_solution_result() ==
-                    SolutionResult::kInfeasible_Or_Unbounded ||
+                    SolutionResult::kInfeasibleOrUnbounded ||
                 result.get_solution_result() ==
                     SolutionResult::kInfeasibleConstraints);
   }

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -642,6 +642,9 @@ drake_cc_library(
         "solution_result.cc",
     ],
     hdrs = ["solution_result.h"],
+    deps = [
+        "//common:essential",  # For DRAKE_DEPRECATED; remove 2022-07-01
+    ],
 )
 
 drake_cc_library(

--- a/solvers/gurobi_solver.cc
+++ b/solvers/gurobi_solver.cc
@@ -1171,7 +1171,7 @@ void GurobiSolver::DoSolve(
     if (optimstatus != GRB_OPTIMAL && optimstatus != GRB_SUBOPTIMAL) {
       switch (optimstatus) {
         case GRB_INF_OR_UNBD: {
-          solution_result = SolutionResult::kInfeasible_Or_Unbounded;
+          solution_result = SolutionResult::kInfeasibleOrUnbounded;
           break;
         }
         case GRB_UNBOUNDED: {

--- a/solvers/solution_result.cc
+++ b/solvers/solution_result.cc
@@ -12,8 +12,8 @@ std::string to_string(SolutionResult solution_result) {
       return "InfeasibleConstraints";
     case SolutionResult::kUnbounded:
       return "Unbounded";
-    case SolutionResult::kInfeasible_Or_Unbounded:
-      return "Infeasible_Or_Unbounded";
+    case SolutionResult::kInfeasibleOrUnbounded:
+      return "InfeasibleOrUnbounded";
     case SolutionResult::kIterationLimit:
       return "IterationLimit";
     case SolutionResult::kUnknownError:

--- a/solvers/solution_result.h
+++ b/solvers/solution_result.h
@@ -3,6 +3,8 @@
 #include <ostream>
 #include <string>
 
+#include "drake/common/drake_deprecated.h"
+
 namespace drake {
 namespace solvers {
 enum SolutionResult {
@@ -11,11 +13,13 @@ enum SolutionResult {
   kInfeasibleConstraints = -2,  ///< The primal is infeasible.
   kUnbounded = -3,              ///< The primal is unbounded.
   kUnknownError = -4,           ///< Unknown error.
-  kInfeasible_Or_Unbounded =
+  kInfeasibleOrUnbounded =
       -5,                ///< The primal is either infeasible or unbounded.
   kIterationLimit = -6,  ///< Reaches the iteration limits.
   kDualInfeasible = -7,  ///< Dual problem is infeasible. In this case we cannot
                          /// infer the status of the primal problem.
+  kInfeasible_Or_Unbounded
+  DRAKE_DEPRECATED("2022-07-01", "Use kInfeasibleOrUnbounded instead.") = -5,
 };
 
 std::string to_string(SolutionResult solution_result);

--- a/solvers/test/diagonally_dominant_matrix_test.cc
+++ b/solvers/test/diagonally_dominant_matrix_test.cc
@@ -60,14 +60,14 @@ GTEST_TEST(DiagonallyDominantMatrixConstraint, FeasibilityCheck) {
   EXPECT_FALSE(result.is_success());
   EXPECT_TRUE(
       result.get_solution_result() == SolutionResult::kInfeasibleConstraints ||
-      result.get_solution_result() == SolutionResult::kInfeasible_Or_Unbounded);
+      result.get_solution_result() == SolutionResult::kInfeasibleOrUnbounded);
   // [1 -1.1; -1.1 2] is not diagonally dominant
   set_X_value(Eigen::Vector3d(1, -1.1, 2));
   result = Solve(prog);
   EXPECT_FALSE(result.is_success());
   EXPECT_TRUE(
       result.get_solution_result() == SolutionResult::kInfeasibleConstraints ||
-      result.get_solution_result() == SolutionResult::kInfeasible_Or_Unbounded);
+      result.get_solution_result() == SolutionResult::kInfeasibleOrUnbounded);
 }
 
 GTEST_TEST(DiagonallyDominantMatrixConstraint, three_by_three_vertices) {

--- a/solvers/test/gurobi_solver_test.cc
+++ b/solvers/test/gurobi_solver_test.cc
@@ -39,7 +39,7 @@ TEST_F(InfeasibleLinearProgramTest0, TestGurobiInfeasible) {
     prog_->SetSolverOption(GurobiSolver::id(), "DualReductions", 1);
     auto result = solver.Solve(*prog_, {}, {});
     EXPECT_EQ(result.get_solution_result(),
-              SolutionResult::kInfeasible_Or_Unbounded);
+              SolutionResult::kInfeasibleOrUnbounded);
     EXPECT_TRUE(std::isnan(result.get_optimal_cost()));
     prog_->SetSolverOption(GurobiSolver::id(), "DualReductions", 0);
     result = solver.Solve(*prog_, {}, {});
@@ -60,7 +60,7 @@ TEST_F(UnboundedLinearProgramTest0, TestGurobiUnbounded) {
     auto result = solver.Solve(*prog_, {}, solver_options);
     EXPECT_FALSE(result.is_success());
     EXPECT_EQ(result.get_solution_result(),
-              SolutionResult::kInfeasible_Or_Unbounded);
+              SolutionResult::kInfeasibleOrUnbounded);
     // This code is defined in
     // https://www.gurobi.com/documentation/9.0/refman/optimization_status_codes.html
     const int GRB_INF_OR_UNBD = 4;

--- a/solvers/test/mathematical_program_result_test.cc
+++ b/solvers/test/mathematical_program_result_test.cc
@@ -233,6 +233,17 @@ GTEST_TEST(TestMathematicalProgramResult, InfeasibleProblem) {
   }
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+// Remove on 2022-07-01
+TEST_F(MathematicalProgramResultTest, InfeasibleOrUnboundedDeprecation) {
+  MathematicalProgramResult result;
+  result.set_solution_result(SolutionResult::kInfeasible_Or_Unbounded);
+  EXPECT_EQ(result.get_solution_result(),
+            SolutionResult::kInfeasibleOrUnbounded);
+}
+#pragma GCC diagnostic pop
+
 GTEST_TEST(TestMathematicalProgramResult, GetInfeasibleConstraintNames) {
   if (SnoptSolver::is_available()) {
     MathematicalProgram prog;

--- a/solvers/test/mixed_integer_rotation_constraint_test.cc
+++ b/solvers/test/mixed_integer_rotation_constraint_test.cc
@@ -385,7 +385,7 @@ TEST_P(TestOrthant, test) {
     SolutionResult sol_result = result.get_solution_result();
     // Since no two row or column vectors in R can lie in either the same of the
     // opposite orthant, the program should be infeasible.
-    EXPECT_TRUE(sol_result == SolutionResult::kInfeasible_Or_Unbounded ||
+    EXPECT_TRUE(sol_result == SolutionResult::kInfeasibleOrUnbounded ||
                 sol_result == SolutionResult::kInfeasibleConstraints);
   }
 }

--- a/solvers/test/non_convex_optimization_util_test.cc
+++ b/solvers/test/non_convex_optimization_util_test.cc
@@ -326,7 +326,7 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion,
       Eigen::Vector2d(1, 0), 0.1);
 
   auto result = Solve(prog_).get_solution_result();
-  EXPECT_TRUE(result == SolutionResult::kInfeasible_Or_Unbounded ||
+  EXPECT_TRUE(result == SolutionResult::kInfeasibleOrUnbounded ||
               result == SolutionResult::kInfeasibleConstraints);
 }
 
@@ -350,7 +350,7 @@ GTEST_TEST(TestRelaxNonConvexQuadraticConstraintInTrustRegionInfeasible,
 
   auto result = Solve(prog1).get_solution_result();
   EXPECT_TRUE(result == SolutionResult::kInfeasibleConstraints ||
-              result == SolutionResult::kInfeasible_Or_Unbounded);
+              result == SolutionResult::kInfeasibleOrUnbounded);
 
   // If we linearize the problem at about (7, -5), then the relaxed problem has
   // a solution around the linearization point.
@@ -506,7 +506,7 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, ZeroQ1Test2) {
       -1, Eigen::Vector2d(0, 1), 1);
 
   auto result = Solve(prog_).get_solution_result();
-  EXPECT_TRUE(result == SolutionResult::kInfeasible_Or_Unbounded ||
+  EXPECT_TRUE(result == SolutionResult::kInfeasibleOrUnbounded ||
               result == SolutionResult::kInfeasibleConstraints);
 }
 
@@ -560,7 +560,7 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, ZeroQ2Test2) {
       4, Eigen::Vector2d(0, 1), 1);
 
   auto result = Solve(prog_).get_solution_result();
-  EXPECT_TRUE(result == SolutionResult::kInfeasible_Or_Unbounded ||
+  EXPECT_TRUE(result == SolutionResult::kInfeasibleOrUnbounded ||
               result == SolutionResult::kInfeasibleConstraints);
 }
 

--- a/solvers/test/scaled_diagonally_dominant_matrix_test.cc
+++ b/solvers/test/scaled_diagonally_dominant_matrix_test.cc
@@ -97,7 +97,7 @@ void CheckSDDMatrix(const Eigen::Ref<const Eigen::MatrixXd>& X_val,
     EXPECT_TRUE(result.get_solution_result() ==
                     SolutionResult::kInfeasibleConstraints ||
                 result.get_solution_result() ==
-                    SolutionResult::kInfeasible_Or_Unbounded);
+                    SolutionResult::kInfeasibleOrUnbounded);
   }
 }
 
@@ -232,7 +232,7 @@ GTEST_TEST(SdsosTest, NotSdsosPolynomial) {
   EXPECT_FALSE(result.is_success());
   EXPECT_TRUE(
       result.get_solution_result() == SolutionResult::kInfeasibleConstraints ||
-      result.get_solution_result() == SolutionResult::kInfeasible_Or_Unbounded);
+      result.get_solution_result() == SolutionResult::kInfeasibleOrUnbounded);
 }
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
Also bind MathematicalProgramResult.set_solution_result.

The old name is deprecated.  Uses of the old name are rectified.
One test is added to ensure old code still compiles.
The bindings are updated likewise.  However we also
bind set_solution_result in order to test these.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16688)
<!-- Reviewable:end -->
