### PR TITLE
[geometry] Denote the Meshcat worker thread's lifecycle with an enum

### DIFF
--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -489,16 +489,22 @@ class Meshcat::Impl {
 
   // Some implementation notes for this Impl constructor:
   //
-  // It must not call any nontrivial class methods. In general self-calls from a
-  // constructor should always be treated with caution, but it's especially
+  // It must not call any nontrivial class methods. In general self-calls from
+  // a constructor should always be treated with caution, but it's especially
   // important in this case because of the complicated threading and state
   // invariants that we need to maintain.
   //
   // It launches the websocket thread and waits for the thread to reply that
   // either the application started listning successfully, or else failed.
-  // The postcondition is that either:
-  //   defer_ and loop_ are nonnull and the websocket thread is not joined, or
-  //   defer_ and loop_ are null and the websocket thread is stopped and joined.
+  //
+  // If the websocket thread failed to bind to a port, then this constructor
+  // will first join the websocket thread and then throw an exception; the
+  // destructor will not be run.
+  //
+  // Otherwise, upon success the postconditions are that both:
+  //   loop_ is non-null; and
+  //   mode_ is either kFinished (the typical case) or possibly kStopping (in
+  //     the unusual case where websocket thread faulted soon after starting).
   explicit Impl(const MeshcatParams& params)
       : prefix_("/drake"),
         main_thread_id_(std::this_thread::get_id()),
@@ -527,7 +533,7 @@ class Meshcat::Impl {
     std::tie(port_, connected) = app_future.get();
 
     if (!connected) {
-      defer_.store(nullptr);
+      mode_.store(kFinished);
       websocket_thread_.join();
       throw std::runtime_error("Meshcat failed to open a websocket port.");
     }
@@ -546,7 +552,7 @@ class Meshcat::Impl {
       us_listen_socket_close(0, listen_socket_);
       listen_socket_ = nullptr;
     });
-    defer_.store(nullptr);
+    mode_.store(kFinished);
     websocket_thread_.join();
   }
 
@@ -564,11 +570,10 @@ class Meshcat::Impl {
   // will continue to succeed.
   void ThrowIfWebsocketThreadExited() const {
     DRAKE_DEMAND(IsThread(main_thread_id_));
-    // N.B. Refer to the comments on the `defer_` and `loop_` class member
+    // N.B. Refer to the comments on the `mode_` and `loop_` class member
     // fields to help understand what's happening here.
-    DeferImpl discard = &DeferImplDiscard;
-    const bool was_discard = defer_.compare_exchange_strong(discard, nullptr);
-    if (was_discard) {
+    if (mode_.load() != kNominal) {
+      mode_.store(kFinished);
       throw std::runtime_error(
           "Meshcat's internal websocket thread exited unexpectedly");
     }
@@ -1459,21 +1464,20 @@ class Meshcat::Impl {
       std::string host, std::optional<int> desired_port) {
     websocket_thread_id_ = std::this_thread::get_id();
     ScopeExit guard([this]() {
-      // N.B. Refer to the comments on the `defer_` and `loop_` class member
+      // N.B. Refer to the comments on the `mode_` and `loop_` class member
       // fields to help understand what's happening here.
-      DeferImpl nominal = &DeferImplNominal;
-      DeferImpl discard = &DeferImplDiscard;
-      defer_.compare_exchange_strong(nominal, discard);
+      OperatingMode nominal = kNominal;
+      mode_.compare_exchange_strong(nominal, kStopping);
       // We must not exit this thread (destroying the thread_local uWS::Loop)
       // until we know that the main thread is no longer adding more callbacks.
-      // It signals that to us by nulling out the defer_ pointer.
-      while (defer_.load() != nullptr) {
+      // It signals that by setting mode_ to kFinshed.
+      while (mode_.load() != kFinished) {
         // TODO(jwnimmer-tri) Use atomic::wait instead, once we have C++20.
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
       }
       loop_ = nullptr;
       // Given this scope guard, the post-condition upon return from
-      // WebSocketMain is that defer_ and loop_ are both null.
+      // WebSocketMain is that mode_ is kFinished and loop_ is null.
     });
     loop_ = uWS::Loop::get();
 
@@ -1625,35 +1629,17 @@ class Meshcat::Impl {
   // thread.
   using Callback = uWS::MoveOnlyFunction<void()>;
 
-  // A function pointer to implement Defer(Callback&&).
-  using DeferImpl = void (*)(uWS::Loop*, Callback&&);
-
   // This function is a private utility for use within this class.
   // It posts the given callback into the websocket thread, safely.
   // If the websocket thread is no longer operating, then this function will
   // destroy the callback, without ever invoking it.
   void Defer(Callback&& callback) const {
     DRAKE_DEMAND(IsThread(main_thread_id_));
-    DeferImpl handler = defer_.load();
-    if (handler) {
-      handler(loop_, std::move(callback));
+    if (mode_.load() == kNominal) {
+      DRAKE_DEMAND(loop_ != nullptr);
+      loop_->defer(std::move(callback));
     }
   }
-
-  // This function is a private utility for use within this class.
-  // It should only be called indirectly, via the defer_ function pointer.
-  // This is the *nominal* implementation of Defer, i.e., when the websocket
-  // thread is operating correctly.
-  static void DeferImplNominal(uWS::Loop* loop, Callback&& callback) {
-    DRAKE_DEMAND(loop != nullptr);
-    loop->defer(std::move(callback));
-  }
-
-  // This function is a private utility for use within this class.
-  // It should only be called indirectly, via the defer_ function pointer.
-  // This is the *dummy* implementation of Defer, i.e., when the websocket
-  // thread is no longer able to add new callbacks.
-  static void DeferImplDiscard(uWS::Loop*, Callback&&) {}
 
   // This function is a private utility for use within this class.
   std::string FullPath(std::string_view path) const {
@@ -1720,44 +1706,61 @@ class Meshcat::Impl {
   // Therefore, we must prevent the websocket thread from exiting until it's
   // sure that the main thread will never again use the loop_. We implement
   // that using a scope guard within the websocket thread, where it monitors
-  // the defer_ member. Only once defer_ is set to nullptr may the thread be
+  // the mode_ member. Only once mode_ is set to kFinished may the thread be
   // allowed to exit. We also encapsulate all main-thread access to loop_
   // within the Defer() helper function, to help maintain this invariant.
   //
-  // In short, our invariant is that: loop_ is nonnull if defer_ is nonnull.
+  // In short, our invariant is that: loop_ is only guaranteed to be non-null
+  // when mode_ is either kNominal or kStopping.
   uWS::Loop* loop_{nullptr};
 
   // The other half of maintaining the loop lifecycle invariant (as described
-  // on the loop_ member above) is the defer_ function pointer.
+  // on the loop_ member above) is the mode_ enum.
   //
-  // The defer_ pointer is always set to one of exactly three values:
-  // - DeferImplNominal
-  // - DeferImplDiscard
-  // - nullptr
+  // The mode_ enum is always set to one of exactly three values:
+  // - kNominal
+  // - kStopping
+  // - kFinished
   //
   // It begins life set to Nominal. In this mode, calls to the Defer()
   // helper are passed along to the websocket thread's uWS event loop.
   //
   // Within the websocket thread, anytime the thread is about to exit (whether
   // through normal means or an exception), the scope guard takes over and
-  // does an atomic compare-and-swap, demoting Nominal to Discard. This is
+  // does an atomic compare-and-swap, demoting Nominal to Stopping. This is
   // the indication to the main thread that the websocket thread is shutting
   // down. Any *thereafter* calls to Defer() will destroy the callback functor
   // instead of posting it into the uWS loop.
   //
   // Note, however, that if a call to Defer() was partway through execution
-  // (where it had done defer_.load() to obtain the function pointer, but not
-  // yet called into the pointer), then callbacks could still be placed into the
-  // uWS loop even after the compare-and-swap had completed. This is still fine.
-  // They will not be run (because the loop isn't running), but they will be
-  // correctly destroyed when the loop is destroyed.
+  // (where it had done mode_.load(), but not yet called into the loop_),
+  // then callbacks could still be placed into the uWS loop even after the
+  // compare-and-swap had completed. This is still fine. They will not be run
+  // (because the loop isn't running), but they will be correctly destroyed
+  // when the loop is destroyed.
   //
-  // The websocket thread then spinloops until it sees that defer_ has been
-  // set to nullptr. In relevant places on the main thread (i.e., in the
+  // The websocket thread then spinloops until it sees that mode_ has been
+  // set to kFinished. In relevant places on the main thread (i.e., in the
   // ThrowIfWebsocketThreadExited failure poll, or in the constructor when
-  // throwing, or during the destructor as normal), it sets defer_ to null to
-  // indicate that it will never post into the loop again.
-  mutable std::atomic<DeferImpl> defer_{&DeferImplNominal};
+  // throwing, or during the destructor as normal), it sets mode_ to
+  // kFinished to indicate that it will never post into the loop again.
+
+  enum OperatingMode {
+    // The main thread and websocket thread are operating as normal.
+    kNominal,
+
+    // The websocket thread is no longer running the event loop. It is paused
+    // waiting for the main thread to acknowledge the that the event loop is
+    // no longer running.
+    kStopping,
+
+    // Once this mode is reached, the main thread will not perform any more
+    // operations on the websocket thread, other than joining it. Therefore,
+    // in this mode the main thread is not allowed to refer to the loop_
+    // pointer (it might be nullptr).
+    kFinished,
+  };
+  mutable std::atomic<OperatingMode> mode_{kNominal};
 };
 
 namespace {


### PR DESCRIPTION
Follow-up from #16670.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16695)
<!-- Reviewable:end -->
