### PR TITLE
Allow external Eigen3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,6 +396,20 @@ endmacro()
 
 set(BAZEL_OVERRIDE_REPOS)
 
+option(WITH_USER_EIGEN "Use user-provided Eigen3" OFF)
+
+if(WITH_USER_EIGEN)
+  find_package(Eigen3 CONFIG REQUIRED)
+
+  symlink_external_repository_includes(eigen Eigen3::Eigen)
+  generate_external_repository_file(eigen/WORKSPACE)
+  generate_external_repository_file(
+    eigen/BUILD.bazel
+    eigen/BUILD.bazel.in)
+
+  override_repository(eigen)
+endif()
+
 option(WITH_USER_FMT "Use user-provided fmt" OFF)
 
 if(WITH_USER_FMT)

--- a/cmake/external/workspace/eigen/BUILD.bazel.in
+++ b/cmake/external/workspace/eigen/BUILD.bazel.in
@@ -1,0 +1,24 @@
+# -*- python -*-
+
+load("@drake//tools/install:install.bzl", "install")
+load("@drake//tools/workspace:cmake_util.bzl", "split_cmake_list")
+
+EIGEN_DEFINES = split_cmake_list(
+    "$<TARGET_PROPERTY:Eigen3::Eigen,INTERFACE_COMPILE_DEFINITIONS>",
+)
+
+cc_library(
+    name = "eigen",
+    hdrs = glob(
+        ["include/**"],
+        allow_empty = False,
+    ),
+    defines = EIGEN_DEFINES,
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)
+
+install(
+    name = "install",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Add logic (only when using the CMake wrapper) to allow the user to select and use an external version of Eigen3.

Fixes #16693.

+@jwnimmer-tri for feature review, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16700)
<!-- Reviewable:end -->
