### PR TITLE
[geometry/dev] introduce HttpService helper interface

### DIFF
--- a/geometry/render/dev/BUILD.bazel
+++ b/geometry/render/dev/BUILD.bazel
@@ -3,6 +3,7 @@
 load(
     "@drake//tools/skylark:drake_cc.bzl",
     "drake_cc_binary",
+    "drake_cc_googletest",
     "drake_cc_library",
     "drake_cc_test",
 )
@@ -52,6 +53,17 @@ drake_cc_binary(
 
 # ------------------------------------------------------------------------------
 # Render client
+drake_cc_library(
+    name = "http_service",
+    srcs = ["http_service.cc"],
+    hdrs = ["http_service.h"],
+    deps = [
+        "//common:filesystem",
+        "//common:nice_type_name",
+        "@fmt",
+    ],
+)
+
 drake_cc_library(
     name = "render_client",
     srcs = ["render_client.cc"],
@@ -126,5 +138,16 @@ py_binary(
 )
 
 # ------------------------------------------------------------------------------
+
+# === test/ ===
+
+drake_cc_googletest(
+    name = "http_service_test",
+    deps = [
+        ":http_service",
+        "//common:temp_directory",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
 
 add_lint_tests()

--- a/geometry/render/dev/http_service.cc
+++ b/geometry/render/dev/http_service.cc
@@ -1,0 +1,103 @@
+#include "drake/geometry/render/dev/http_service.h"
+
+#include <fstream>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "drake/common/filesystem.h"
+#include "drake/common/nice_type_name.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+
+namespace fs = drake::filesystem;
+
+namespace {
+
+/* Throw an std::logic_error if the provided url is empty or has trailing
+ slashes. */
+void ThrowIfInvalidUrl(const std::string& url) {
+  // Validate what can be validated about the provided url.
+  if (url.empty()) {
+    throw std::logic_error("HttpService: url parameter may not be empty.");
+  }
+  if (url.back() == '/') {
+    throw std::logic_error("HttpService: url may not end with '/'.");
+  }
+}
+
+}  // namespace
+
+HttpService::HttpService(const std::string& temp_directory,
+                         const std::string& url, int32_t port, bool verbose)
+    : temp_directory_{temp_directory},
+      url_{url},
+      port_{port},
+      verbose_{verbose} {
+  ThrowIfInvalidUrl(url_);
+}
+
+HttpService::HttpService(const HttpService& other)
+    : temp_directory_{other.temp_directory_},
+      url_{other.url_},
+      port_{other.port_},
+      verbose_{other.verbose_} {}
+
+std::unique_ptr<HttpService> HttpService::Clone() const {
+  std::unique_ptr<HttpService> clone(DoClone());
+  // Make sure that derived classes have actually overridden DoClone().
+  // Particularly important for derivations of derivations.
+  // Note: clang considers typeid(*clone) to be an expression with side effects.
+  // So, we capture a reference to the polymorphic type and provide that to
+  // typeid to make both clang and gcc happy.
+  const HttpService& clone_ref = *clone;
+  if (typeid(*this) != typeid(clone_ref)) {
+    throw std::logic_error(fmt::format(
+        "Error in cloning HttpService class of type {}; the clone returns "
+        "type {}. {}::DoClone() was probably not implemented",
+        NiceTypeName::Get(*this), NiceTypeName::Get(clone_ref),
+        NiceTypeName::Get(*this)));
+  }
+  return clone;
+}
+
+void HttpService::ThrowIfEndpointInvalid(const std::string& endpoint) const {
+  if (endpoint.size() >= 1) {
+    if (endpoint.front() == '/' || endpoint.back() == '/') {
+      throw std::runtime_error(fmt::format(
+          "Provided endpoint='{}' is not valid, it may not start or end with "
+          "a '/'.",
+          endpoint));
+    }
+  }
+}
+
+void HttpService::ThrowIfFilesMissing(
+    const std::map<std::string,
+                   std::pair<std::string, std::optional<std::string>>>&
+        file_fields) const {
+  std::vector<std::string> missing_files;
+  for (const auto& [field_name, field_data_pair] : file_fields) {
+    const auto& file_path = field_data_pair.first;
+    if (!fs::is_regular_file(file_path)) {
+      missing_files.emplace_back(fmt::format("{}='{}'", field_name, file_path));
+    }
+  }
+  if (missing_files.size() > 0) {
+    std::string exc_message = "Provided file fields had missing file(s): ";
+    for (size_t i = 0; i < missing_files.size(); ++i) {
+      exc_message += missing_files[i];
+      if (i < missing_files.size() - 1) exc_message += ", ";
+    }
+    exc_message += ".";
+    throw std::runtime_error(exc_message);
+  }
+}
+
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/dev/http_service.h
+++ b/geometry/render/dev/http_service.h
@@ -1,0 +1,279 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+
+/** A simple wrapper struct to encapsulate an HTTP server response. */
+struct HttpResponse {
+  /** The HTTP response code from the server.  Note that in the special case of
+   an HttpService not being able to connect to a server (e.g., the wrong url
+   was provided or the server is not running), this field will often have a
+   value of `0`.  Use HttpResponse::Good() to validate server responses. */
+  int32_t http_code{0};
+
+  /** In the event that the server has provided a text or binary response in
+   addition to its HTTP response code, the file path described by this attribute
+   will contain the response.  An HttpService will populate this field with a
+   non-optional value if and only if a response from the server was provided.
+   @note
+     This is **not** a response loaded into a string, it is a path to a
+     non-empty file that contains the response.  The **caller** is responsible
+     for loading this file as the appropriate file type, **and** for deleting
+     the file when it is no longer needed. */
+  std::optional<std::string> data_path{std::nullopt};
+
+  /** If the underlying HttpService encountered an error, this will be set to
+   true and any additional information provided in
+   HttpResponse::service_error_message. */
+  bool service_error{false};
+
+  /** In the event that there was an error with the HttpService processing the
+   request, HttpResponse::service_error will be set to `true` and any additional
+   information that can be provided will be in this string. */
+  std::optional<std::string> service_error_message{std::nullopt};
+
+  /** Whether or not the HTTP transaction was successful.  This includes
+   verifying that the HttpResponse::http_code indicates success, but also
+   whether or not the underlying HttpService marked it for failure via
+   HttpResponse::service_error.  Note that if a server has not been
+   properly implemented, it may always return `200` even if the response text
+   indicates failure.  This is an error with the server, there is nothing this
+   framework can do to validate such a scenario. */
+  bool Good() const {
+    return !service_error && (http_code >= 200 && http_code < 400);
+  }
+};
+
+/** An HTTP service API, used by a RenderClient to facilitate server
+ communications.  This class is not intended to be used on its own, it is a
+ helper class to perform server communications, but does not have any specific
+ knowledge of a given client-server API.  The owning entity, such as
+ RenderClient, is responsible for adhering to the server API. */
+class HttpService {
+ public:
+  /** @name Does not allow copy, move, or assignment  */
+  //@{
+#ifdef DRAKE_DOXYGEN_CXX
+  // Note: the copy constructor operator is actually protected to serve as the
+  // basis for implementing the DoClone() method.
+  HttpService(const HttpService&) = delete;
+#endif
+  HttpService& operator=(const HttpService&) = delete;
+  HttpService(HttpService&&) = delete;
+  HttpService& operator=(HttpService&&) = delete;
+  //@}
+  /** Constructs an %HttpService to be used throughout the duration of a client
+   server relationship.
+
+   @param temp_directory
+     The (shared) temporary directory, e.g., as created from
+     drake::temp_directory().  File responses from a server will be stored here.
+     The %HttpService does **not** own this directory, and is not responsible
+     for deleting it.  No validity checks on this directory are performed,
+     concrete derived classes are responsible for verifying that any temporary
+     files needed can be created.
+   @param url
+     The url this HTTP service will communicate with.  May **not** be the empty
+     string.  May **not** have any trailing slashes.  Helper methods such as
+     PostForm() construct their communications as
+     `temp_directory() + "/" + endpoint`.  For example, `https://drake.mit.edu`
+     will be accepted, but `https://drake.mit.edu/` will not be.  No other url
+     validation is performed (e.g., there is no initial transaction to verify
+     the server exists).
+   @param port
+     The TCP port this HTTP service will communicate on.  A value less than or
+     equal to `0` implies no port level communication is needed.
+   @param verbose
+     Whether or not client/server communications should be logged.
+   @throws std::logic_error
+     If the provided `url` is empty, or has any trailing slashes. */
+  HttpService(const std::string& temp_directory, const std::string& url,
+              int32_t port, bool verbose);
+
+  virtual ~HttpService() = default;
+
+  /** Clones the http service -- making the %HttpService compatible with
+   copyable_unique_ptr. */
+  std::unique_ptr<HttpService> Clone() const;
+
+  /** @name Server Interaction Interface */
+  //@{
+  /** Post an HTML `<form>` to the specified `endpoint`.
+
+   An HTML `<form>` may allow for a wide range of different kinds of `<input>`
+   data.  For the full listing of available input `type`'s, see the
+   <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input">
+   <tt>&lt;input&gt;</tt> documentation</a>.  For many of these types, the way
+   an %HttpService will actually POST the data to the server will be the same, a
+   `name` and `value` are provided and the server takes care of validating the
+   `type`.  For example, an `<input type="number" name="age" min="0" max="150">`
+   on the server will be posted to with simply `number={value}`.  If the
+   `{value}` is invalid, the server will respond indicating so.  Similarly,
+   an `<input type="checkbox" name="check">` would have a submission of just
+   `check=on` or `check=off`.  Implementations are allowed to make the following
+   assumptions:
+
+   1. The server `<form>` is _valid_, namely that every `<input>` has a `name`
+      attribute.
+   2. Every input `value` being submitted corresponds appropriately with the
+      provided field `name`.  That is, no validation of the provided `<input>`s
+      is performed -- the `<form>` is simply submitted.  In the event that the
+      caller has provided invalid data for a `name={value}` pair, the server
+      is expected to respond with an error code and message indicating this.  If
+      it does, this will be provided in the returned HttpResponse.
+
+   @note
+     Callers are encouraged to provide the `<input type="submit">` entry in the
+     provided `data_fields`.  Although providing this entry is often not
+     required, it is encouraged.
+
+   Since file uploads (`<input type="file">`) are a special case, often
+   requiring the underlying implementation to wield different machinery, these
+   are required as a separate parameter.  This also enables the implementation
+   to validate that the file path(s) provided exist.
+
+   Finally, the %HttpService has no way of knowing what kind of a response to
+   expect from the server.  A server may only provide an HTTP response code,
+   a response code and an error message, or a response code and a binary file
+   response.  As such, the %HttpService will expect to receive a response in
+   addition to an HTTP return code.  In the event that the server responds with
+   data of any kind (text or binary), the returned HttpResponse::data_path will
+   have the path to the file where this information was saved.
+
+   Some examples for filling out simple `<form>`s:
+   @code{.cpp}
+   // A simple form that does not upload any files nor return anything.
+   // <form>
+   //   <input type="text" name="name">
+   //   <input type="number" name="age">
+   //   <!-- NOTE: often, the `value` is irrelevant. -->
+   //   <input type="submit" name="submit" value="Submit">
+   // <form>
+   // Submit form to /hello:
+   auto response_1 = http_service_->PostForm(
+       "hello",
+       {{"name", "Sue"}, {"age", "34"}, {"submit", "Submit"}},
+       {});  // No file fields.
+   // Suppose `<input type="file" name="photo">` and
+   // `<input type="file" name="id">` were added.
+   auto response_2 = http_service->PostForm(
+       "hello",
+       {{"name", "Bo"}, {"age", "49"}, {"submit", "Submit"}},
+       {{"photo", {"/path/to/bo-profile.jpg", "image/jpeg"}},
+        // No mime-type for this file, std::nullopt indicates this.
+        {"id", {"/path/to/bo-id.bin", std::nullopt}}});
+   @endcode
+   Make sure to check HttpResponse::Good() before continuing, or trying to load
+   the HttpResponse::data_path as any specific kind of file.
+
+   @param endpoint
+     The endpoint the `<form>` should be posted to, e.g., `render`.  May **not**
+     have a leading or trailing `/`, the post is sent to
+     `{url() + "/" + endpoint}`.  If the `<form>` should be posted to the server
+     root, then `endpoint` should be the empty string `""`.
+   @param data_fields
+     The entries for the `<input>` elements of the form.  Keys are the field
+     name, values are the field values.  For example:
+     @code{.cpp}
+     std::map<std::string, std::string> data_fields;
+     // <input type="text" name="scene_sha256">
+     data_fields["scene_sha256"] = "... hash value ...";
+     // <input type="number" name="width">
+     data_fields["width"] = "640";
+     @endcode
+     Do **not** zero pad numeric values, a given server may have trouble parsing
+     unanticipated numeric values.  Supply the empty map if no data fields
+     should be posted.
+   @param file_fields
+     Any entries for `<input type="file">` elements of the form.  Keys are the
+     field name, values are the (file path, optional mimetype) pair.  For
+     example:
+     @code{.cpp}
+     std::map<std::string,
+              std::pair<std::string, std::optional<std::string>>> file_fields;
+     // <input type="file" name="scene">, known mimetype
+     file_fields["scene"] = {"/path/to/scene_file.gltf", "model/gltf+json"};
+     // <input type="file" name="id">, unknown mimetype
+     file_fields["id"] = {"/path/to/id.bin", std::nullopt};
+     @endcode
+     Supply the empty map if no files are to be uploaded with the `<form>`.
+   @return HttpResponse
+     The response from the server, including an HTTP code, and any potential
+     additional server response text or data in HttpResponse::data_path.
+   @throws std::runtime_error
+     An exception may be thrown in the event that the provided `endpoint` starts
+     or ends with a `/` character.  An exception may also be thrown if an
+     irrecoverable error is encountered, e.g., a file path provided in one of
+     the values of `file_fields` does not exist.  Failed communications such as
+     an inability to connect, or an invalid HTTP response code, should **not**
+     produce an exception but rather encode this information in the
+     returned HttpResponse for the caller to determine how to proceed. */
+  virtual HttpResponse PostForm(
+      const std::string& endpoint,
+      const std::map<std::string, std::string>& data_fields,
+      const std::map<std::string,
+                     std::pair<std::string, std::optional<std::string>>>&
+          file_fields) = 0;
+  //@}
+  /** @name Access the default properties
+
+   Provides access to the default values of this instance.  These values must be
+   set at construction. */
+  //@{
+  /** The folder where server file responses are stored.
+   @sa HttpResponse::data_path */
+  const std::string& temp_directory() const { return temp_directory_; }
+
+  /** The url of the server to communicate with. */
+  const std::string& url() const { return url_; }
+
+  /** The port of the server to communicate on.  A value less than or equal to
+   `0` means no port level communication is required. */
+  int32_t port() const { return port_; }
+
+  /** Wether or not client/server communications should be logged to
+   drake::log(). */
+  bool verbose() const { return verbose_; }
+  //@}
+
+ protected:
+  /** Copy constructor for the purpose of cloning. */
+  HttpService(const HttpService& other);
+
+  /** The NVI-function for cloning this http service. */
+  virtual std::unique_ptr<HttpService> DoClone() const = 0;
+
+  /** Throws `std::runtime_error` if `endpoint` starts or ends with a '/'. */
+  void ThrowIfEndpointInvalid(const std::string& endpoint) const;
+
+  /** Verify that all file paths provided are regular files, throw if not.
+
+   @param file_fields See HttpService::PostForm.
+   @throws std::runtime_error
+     If any of the file paths provided are not regular files, an exception with
+     the list of all missing files is thrown. */
+  void ThrowIfFilesMissing(
+      const std::map<std::string,
+                     std::pair<std::string, std::optional<std::string>>>&
+          file_fields) const;
+
+ private:
+  std::string temp_directory_;
+  std::string url_;
+  int32_t port_;
+  bool verbose_;
+};
+
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/dev/test/http_service_test.cc
+++ b/geometry/render/dev/test/http_service_test.cc
@@ -1,0 +1,273 @@
+#include "drake/geometry/render/dev/http_service.h"
+
+#include <fstream>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/filesystem.h"
+#include "drake/common/temp_directory.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+namespace {
+
+namespace fs = drake::filesystem;
+
+// A concrete implementation of HttpService that does nothing.
+class EmptyService : public HttpService {
+ public:
+  EmptyService(const std::string& temp_directory, const std::string& url,
+               int32_t port, bool verbose)
+      : HttpService(temp_directory, url, port, verbose) {}
+
+  EmptyService(const EmptyService& other) : HttpService(other) {}
+
+  HttpResponse PostForm(
+      const std::string& endpoint,
+      const std::map<std::string, std::string>& /* data_fields */,
+      const std::map<std::string,
+                     std::pair<std::string, std::optional<std::string>>>&
+          file_fields) override {
+    ThrowIfEndpointInvalid(endpoint);
+    ThrowIfFilesMissing(file_fields);
+    HttpResponse ret;
+    ret.http_code = 200;
+    return ret;
+  }
+
+  std::unique_ptr<HttpService> DoClone() const override {
+    return std::unique_ptr<EmptyService>(new EmptyService(*this));
+  }
+};
+
+// A concrete derived-derived class that properly implements cloning.
+class EmptyServiceGoodClone : public EmptyService {
+ public:
+  EmptyServiceGoodClone(const std::string& temp_directory,
+                        const std::string& url, int32_t port, bool verbose)
+      : EmptyService(temp_directory, url, port, verbose) {}
+
+  EmptyServiceGoodClone(const EmptyServiceGoodClone& other)
+      : EmptyService(other) {}
+
+  std::unique_ptr<HttpService> DoClone() const override {
+    return std::unique_ptr<EmptyServiceGoodClone>(
+        new EmptyServiceGoodClone(*this));
+  }
+};
+
+// A concrete derived-derived class that does *not* implement cloning.
+class EmptyServiceBadClone : public EmptyService {
+ public:
+  EmptyServiceBadClone(const std::string& temp_directory,
+                       const std::string& url, int32_t port, bool verbose)
+      : EmptyService(temp_directory, url, port, verbose) {}
+
+  EmptyServiceBadClone(const EmptyServiceBadClone& other)
+      : EmptyService(other) {}
+};
+
+GTEST_TEST(HttpServiceTest, Constructor) {
+  const std::string localhost{"127.0.0.1"};
+  const int32_t port{8000};
+
+  {
+    // Validate normal construction works as expected.
+    const auto temp_dir = drake::temp_directory();
+    EmptyService es{temp_dir, localhost, port, false};
+    EXPECT_EQ(temp_dir, es.temp_directory());
+    EXPECT_EQ(localhost, es.url());
+    EXPECT_EQ(port, es.port());
+    EXPECT_EQ(false, es.verbose());
+    fs::remove(temp_dir);
+  }
+
+  {
+    // An empty url should raise.
+    const auto temp_dir = drake::temp_directory();
+    DRAKE_EXPECT_THROWS_MESSAGE(EmptyService(temp_dir, "", port, false),
+                                "HttpService: url parameter may not be empty.");
+
+    // A url with a '/' at the end should raise.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        EmptyService(temp_dir, localhost + "/", port, false),
+        "HttpService: url may not end with '/'.");
+    fs::remove(temp_dir);
+  }
+}
+
+GTEST_TEST(HttpService, Clone) {
+  // Create some parameters to use for testing clones.
+  const auto temp_dir = drake::temp_directory();
+  const std::string url{"0.0.0.0"};
+  const int32_t port{8192};
+  const bool verbose{true};
+  auto verify_attributes = [&](const HttpService& service) {
+    EXPECT_EQ(service.temp_directory(), temp_dir);
+    EXPECT_EQ(service.url(), url);
+    EXPECT_EQ(service.port(), port);
+    EXPECT_EQ(service.verbose(), verbose);
+  };
+
+  {
+    // Verify construction and cloning of EmptyService works.
+    EmptyService es{temp_dir, url, port, verbose};
+    verify_attributes(es);
+    auto clone = es.Clone();
+    verify_attributes(*clone);
+  }
+
+  {
+    // Verify construction and cloning of EmptyServiceGoodClone works.
+    EmptyServiceGoodClone esgc{temp_dir, url, port, verbose};
+    verify_attributes(esgc);
+    auto clone = esgc.Clone();
+    verify_attributes(*clone);
+  }
+
+  {
+    /* Verify that a derived class of a derived class that does not implement
+     DoClone() throws an exception. */
+    EmptyServiceBadClone esbc{temp_dir, url, port, verbose};
+    verify_attributes(esbc);
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        esbc.Clone(),
+        "Error in cloning HttpService class of type.*EmptyServiceBadClone; the "
+        "clone returns type .*EmptyService\\..*EmptyServiceBadClone::DoClone"
+        "\\(\\) was probably not implemented");
+  }
+
+  fs::remove(temp_dir);
+}
+
+GTEST_TEST(HttpService, ThrowIfEndpointInvalid) {
+  auto temp_dir = drake::temp_directory();
+  EmptyService es{temp_dir, "127.0.0.1", 8000, false};
+
+  {
+    // Valid endpoint: no error.
+    auto response = es.PostForm("render", {}, {});
+    EXPECT_EQ(response.http_code, 200);
+
+    // Valid endpoint: no error, empty implies route to /.
+    response = es.PostForm("", {}, {});
+    EXPECT_EQ(response.http_code, 200);
+
+    // Valid endpoint: no error, interior / is allowed.
+    response = es.PostForm("render/scene", {}, {});
+    EXPECT_EQ(response.http_code, 200);
+  }
+
+  const std::string exc_message =
+      "Provided endpoint='{}' is not valid, it may not start or end with a "
+      "'/'.";
+  {
+    const std::vector<std::string> bad_endpoints{"/",
+                                                 "//",
+                                                 "/render",
+                                                 "render/",
+                                                 "/render/",
+                                                 "/render/scene",
+                                                 "/render/scene/",
+                                                 "render/scene/"};
+    for (const auto& endpoint : bad_endpoints) {
+      DRAKE_EXPECT_THROWS_MESSAGE(es.PostForm(endpoint, {}, {}),
+                                  fmt::format(exc_message, endpoint));
+    }
+  }
+}
+
+GTEST_TEST(HttpService, ThrowIfFilesMissing) {
+  // Create an EmptyService and some files to test with.
+  auto temp_dir = drake::temp_directory();
+  EmptyService es{temp_dir, "127.0.0.1", 8000, true};
+
+  auto test_txt_path = (fs::path(temp_dir) / "test.txt").string();
+  std::ofstream test_txt{test_txt_path};
+  test_txt << "test!\n";
+  test_txt.close();
+
+  auto fake_jpg_path = (fs::path(temp_dir) / "fake.jpg").string();
+  std::ofstream fake_jpg{fake_jpg_path};
+  fake_jpg << "not really a jpg!\n";
+  fake_jpg.close();
+
+  {
+    // No exception should be thrown if all files are present.
+    auto response = es.PostForm("upload", {},
+                                {
+                                    {"test", {test_txt_path, std::nullopt}},
+                                    {"image", {fake_jpg_path, "image/jpeg"}},
+                                });
+    EXPECT_EQ(response.http_code, 200);
+  }
+
+  // Some file paths that do not exist for testing.
+  const std::string missing_1_key = "missing_1";
+  const std::pair<std::string, std::optional<std::string>> missing_1_value = {
+      "/unlikely/to/exist.file_extension", std::nullopt};
+  const std::string missing_1_desc{
+      "missing_1='/unlikely/to/exist.file_extension'"};
+  EXPECT_FALSE(fs::is_regular_file(missing_1_value.first));
+
+  const std::string missing_2_key = "missing_2";
+  const std::pair<std::string, std::optional<std::string>> missing_2_value = {
+      "/this/is/not/a.real_file", std::nullopt};
+  const std::string missing_2_desc{"missing_2='/this/is/not/a.real_file'"};
+  EXPECT_FALSE(fs::is_regular_file(missing_2_value.first));
+
+  // The exception message prefix.
+  const std::string prefix = "Provided file fields had missing file\\(s\\): ";
+  // Since it is a map, order can change -- only support building regex for 2.
+  auto make_regex = [&prefix](const std::string& p1, const std::string& p2) {
+    return fmt::format("{0}(({1}, {2})|({2}, {1}))\\.", prefix, p1, p2);
+  };
+
+  {
+    // Exception thrown: one file, does not exist.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        es.PostForm("upload", {}, {{missing_1_key, missing_1_value}}),
+        prefix + missing_1_desc + "\\.");
+  }
+
+  {
+    // Exception thrown: multiple files, none exist.
+    DRAKE_EXPECT_THROWS_MESSAGE(es.PostForm("upload", {},
+                                            {{missing_1_key, missing_1_value},
+                                             {missing_2_key, missing_2_value}}),
+                                make_regex(missing_1_desc, missing_2_desc));
+  }
+
+  {
+    // Exception thrown: one file exists, the other does not.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        es.PostForm("upload", {},
+                    {{"test", {test_txt_path, std::nullopt}},
+                     {missing_1_key, missing_1_value}}),
+        prefix + missing_1_desc + "\\.");
+  }
+
+  {
+    // Exception thrown: multiple files exist, multiple do not.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        es.PostForm("upload", {},
+                    {{"test", {test_txt_path, std::nullopt}},
+                     {missing_1_key, missing_1_value},
+                     {"image", {fake_jpg_path, "image/jpeg"}},
+                     {missing_2_key, missing_2_value}}),
+        make_regex(missing_1_desc, missing_2_desc));
+  }
+
+  // 3 deletions: 2 files + 1 folder.
+  EXPECT_EQ(fs::remove_all(temp_dir), 3);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
The HttpService interface serves as the primary mechanism for
facilitating client / server communications.  A given RenderClient
will maintain an HttpService for the lifetime of the application.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16702)
<!-- Reviewable:end -->
