### PR TITLE
[geometry] Fix Meshcat crash on unknown message

### DIFF
--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -28,9 +28,47 @@ int SystemCall(const std::vector<std::string>& argv) {
   for (const std::string& arg : argv) {
     // Note: Can't use ASSERT_THAT inside this subroutine.
     EXPECT_THAT(arg, ::testing::Not(HasSubstr("'")));
-    command = std::move(command) + "'" + arg + "' ";
+    command += fmt::format("'{}' ", arg);
   }
   return std::system(command.c_str());
+}
+
+// Calls a python helper program to send and receive websocket messages(s)
+// to/from the given Meshcat instance.
+//
+// @param send_json Message to send, as a json string.
+// @param expect_num_messages Expected number of messages to receive.
+// @param expect_json Expected content of the final message, as a json string.
+// @param expect_success Whether to insist that the python helper finished and
+//     the expected_json (if given) was actually received.
+void CheckWebsocketCommand(
+    const Meshcat& meshcat,
+    std::optional<std::string> send_json,
+    std::optional<int> expect_num_messages,
+    std::optional<std::string> expect_json,
+    bool expect_success = true) {
+  std::vector<std::string> argv;
+  argv.push_back(FindResourceOrThrow(
+      "drake/geometry/meshcat_websocket_client"));
+  argv.push_back(fmt::format("--ws_url={}", meshcat.ws_url()));
+  if (send_json) {
+    DRAKE_DEMAND(!send_json->empty());
+    argv.push_back(fmt::format("--send_message={}", std::move(*send_json)));
+  }
+  if (expect_num_messages) {
+    argv.push_back(fmt::format("--expect_num_messages={}",
+        *expect_num_messages));
+  }
+  if (expect_json) {
+    DRAKE_DEMAND(!expect_json->empty());
+    argv.push_back(fmt::format("--expect_message={}", std::move(*expect_json)));
+  }
+  argv.push_back(fmt::format("--expect_success={}",
+      expect_success ? "1" : "0"));
+  const int exit_code = SystemCall(argv);
+  if (expect_success) {
+    EXPECT_EQ(exit_code, 0);
+  }
 }
 
 GTEST_TEST(MeshcatTest, TestHttp) {
@@ -141,6 +179,42 @@ GTEST_TEST(MeshcatTest, MalformedCustom) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       Meshcat({"", std::nullopt, "file:///tmp"}),
       ".*web_url_pattern.*http.*");
+}
+
+// Checks that unparseable messages are ignored.
+GTEST_TEST(MeshcatTest, UnparseableMessageIgnored) {
+  auto dut = std::make_unique<Meshcat>();
+
+  // Send an unparseable message; don't expect a reply.
+  const char* const message = "0";
+  const bool expect_success = false;
+  CheckWebsocketCommand(*dut, message, {}, {}, expect_success);
+
+  // Pause to allow the websocket thread to run.
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  // The object can be destroyed with neither errors nor sanitizer leaks.
+  EXPECT_NO_THROW(dut.reset());
+}
+
+// Checks that parseable messages with unknown semantics are ignored.
+GTEST_TEST(MeshcatTest, UnknownEventIgnored) {
+  auto dut = std::make_unique<Meshcat>();
+
+  // Send a syntactically well-formed UserInterfaceEvent to tickle the
+  // stack, but don't expect a reply.
+  const char* const message = R"""({
+    "type": "no_such_type",
+    "name": "no_such_name"
+  })""";
+  const bool expect_success = false;
+  CheckWebsocketCommand(*dut, message, {}, {}, expect_success);
+
+  // Pause to allow the websocket thread to run.
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  // The object can be destroyed with neither errors nor sanitizer leaks.
+  EXPECT_NO_THROW(dut.reset());
 }
 
 // Checks that a problem with the worker thread eventually ends up as an
@@ -523,20 +597,10 @@ GTEST_TEST(MeshcatTest, Sliders) {
       "Meshcat does not have any slider named slider2.");
 }
 
-void CheckWebsocketCommand(const drake::geometry::Meshcat& meshcat,
-                           int message_num,
-                           const std::string& desired_command_json) {
-  EXPECT_EQ(SystemCall(
-                {FindResourceOrThrow("drake/geometry/meshcat_websocket_client"),
-                 meshcat.ws_url(), std::to_string(message_num),
-                 desired_command_json}),
-            0);
-}
-
 GTEST_TEST(MeshcatTest, SetPropertyWebSocket) {
   Meshcat meshcat;
   meshcat.SetProperty("/Background", "visible", false);
-  CheckWebsocketCommand(meshcat, 1, R"""({
+  CheckWebsocketCommand(meshcat, {}, 1, R"""({
       "type": "set_property",
       "path": "/Background",
       "property": "visible",
@@ -545,13 +609,13 @@ GTEST_TEST(MeshcatTest, SetPropertyWebSocket) {
   meshcat.SetProperty("/Grid", "visible", false);
   // Note: The order of the messages is due to "/Background" < "/Grid" in the
   // std::map, not due to the order that SetProperty was called.
-  CheckWebsocketCommand(meshcat, 1, R"""({
+  CheckWebsocketCommand(meshcat, {}, 1, R"""({
       "type": "set_property",
       "path": "/Background",
       "property": "visible",
       "value": false
     })""");
-  CheckWebsocketCommand(meshcat, 2, R"""({
+  CheckWebsocketCommand(meshcat, {}, 2, R"""({
       "type": "set_property",
       "path": "/Grid",
       "property": "visible",
@@ -569,7 +633,7 @@ GTEST_TEST(MeshcatTest, SetPerspectiveCamera) {
   perspective.fov = 82;
   perspective.aspect = 1.5;
   meshcat.SetCamera(perspective, "/my/camera");
-  CheckWebsocketCommand(meshcat, 1, R"""({
+  CheckWebsocketCommand(meshcat, {}, 1, R"""({
       "type": "set_object",
       "path": "/my/camera",
       "object": {
@@ -590,7 +654,7 @@ GTEST_TEST(MeshcatTest, SetOrthographicCamera) {
   ortho.left = -1.23;
   ortho.bottom = .84;
   meshcat.SetCamera(ortho, "/my/camera");
-  CheckWebsocketCommand(meshcat, 1, R"""({
+  CheckWebsocketCommand(meshcat, {}, 1, R"""({
       "type": "set_object",
       "path": "/my/camera",
       "object": {
@@ -633,7 +697,7 @@ GTEST_TEST(MeshcatTest, SetAnimation) {
 
   // The animations will be in lexographical order by path since we're using a
   // std::map with the path strings as the (sorted) keys.
-  CheckWebsocketCommand(meshcat, 1, R"""({
+  CheckWebsocketCommand(meshcat, {}, 1, R"""({
       "type": "set_animation",
       "animations": [{
           "path": "/drake/cylinder",

--- a/geometry/test/meshcat_websocket_client.py
+++ b/geometry/test/meshcat_websocket_client.py
@@ -41,37 +41,50 @@ def print_recursive_comparison(d1, d2, level='root'):
             print(f"{level:<20} {repr(d1)} != {repr(d2)}")
 
 
-async def check_command(ws_url, message_number, desired_command):
-    async with websockets.connect(ws_url) as websocket:
-        message = ''
-        for n in range(message_number):
+async def socket_operations_async(args):
+    async with websockets.connect(args.ws_url) as websocket:
+        if args.send_message is not None:
+            await websocket.send(umsgpack.packb(args.send_message))
+        message = None
+        for n in range(args.expect_num_messages):
             message = await asyncio.wait_for(websocket.recv(), timeout=10)
-        command = umsgpack.unpackb(message)
-        if command != desired_command:
-            print("FAILED")
-            print_recursive_comparison(desired_command, command)
-            sys.exit(1)
+        if args.expect_message:
+            parsed = umsgpack.unpackb(message)
+            if parsed != args.expect_message:
+                print("FAILED")
+                print_recursive_comparison(parsed, args.expect_message)
+                sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Test utility for Meshcat websockets")
+    parser.add_argument(
+        "--ws_url", type=str, required=True,
+        help="websocket URL")
+    parser.add_argument(
+        "--send_message", type=json.loads, default=None, metavar="JSON",
+        help="send this message (given as a json string) to the websocket")
+    parser.add_argument(
+        "--expect_num_messages", type=int, default=0, metavar="N",
+        help="the expected number of messages to receive")
+    parser.add_argument(
+        "--expect_message", type=json.loads, default=None, metavar="JSON",
+        help="the expected contents of the the final message "
+        + "(given as a json string)")
+    parser.add_argument(
+        "--expect_success", type=int, default=True, metavar="0|1",
+        help="must be 0 or 1; when zero, exceptions and errors are ignored")
+    args = parser.parse_args()
+    try:
+        asyncio.get_event_loop().run_until_complete(
+            socket_operations_async(args))
+    except Exception as e:
+        if args.expect_success:
+            raise
+        else:
+            print(e)
 
 
 assert __name__ == "__main__"
-
-parser = argparse.ArgumentParser(
-    description="Test utility for Meshcat websockets")
-parser.add_argument("ws_url", type=str, help="websocket URL")
-parser.add_argument(
-    "message_number",
-    type=int,
-    help="number of messages to receive")
-parser.add_argument(
-    "desired_command_json",
-    type=str,
-    help="the last message will be unpacked (to a dictionary) and compared to "
-    + "this desired value (specified as a json string)"
-)
-args = parser.parse_args()
-
-asyncio.get_event_loop().run_until_complete(
-    check_command(args.ws_url, args.message_number,
-                  json.loads(args.desired_command_json)))
-
-sys.exit(0)
+main()


### PR DESCRIPTION
Improve unit test tooling to tickle this kind of bug.

```console
jwnimmer@call-cps:~/jwnimmer-tri/drake$ bazel-bin/geometry/meshcat_test --spdlog_level=debug --gtest_filter='*Ignored*' 2>&1 | grep -i 'ignored'
Note: Google Test filter = *Ignored*
[ RUN      ] MeshcatTest.UnparseableMessageIgnored
[2022-03-02 20:56:49.223] [console] [debug] Meshcat ignored an unparseable message
[       OK ] MeshcatTest.UnparseableMessageIgnored (240 ms)
[ RUN      ] MeshcatTest.UnknownEventIgnored
[2022-03-02 20:56:49.463] [console] [warning] Meshcat ignored a 'no_such_type' event
[       OK ] MeshcatTest.UnknownEventIgnored (241 ms)
```

Using `kcov`, also this shows an improvement in statement coverage from the unit test.

One more step towards #16659.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16703)
<!-- Reviewable:end -->
