### PR TITLE
[systems/analysis] Implements RegionOfAttraction for implicit dynamics

### DIFF
--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -226,6 +226,7 @@ drake_cc_library(
         "//solvers:mathematical_program",
         "//solvers:solve",
         "//systems/framework",
+        "//systems/primitives:linear_system",
     ],
 )
 

--- a/systems/analysis/region_of_attraction.h
+++ b/systems/analysis/region_of_attraction.h
@@ -27,6 +27,18 @@ struct RegionOfAttractionOptions {
    * system.
    */
   VectorX<symbolic::Variable> state_variables{};
+
+  /** If true, the system dynamics will be evaluated using
+   * CalcImplicitTimeDerivativesResidual instead of CalcTimeDerivatives to
+   * obtain g(x,ẋ) = 0 (instead of ẋ = f(x)).  The Lyapunov conditions will
+   * also be evaluated in the implicit form. This is more expensive than
+   * analysis in the explicit form, as it requires more indeterminates, but it
+   * enables analysis of systems with rational polynomial dynamics.
+   *
+   * See https://underactuated.csail.mit.edu/lyapunov.html#ex:implicit for more
+   * details.
+   */
+  bool use_implicit_dynamics{false};
 };
 
 /**


### PR DESCRIPTION
This PR moves one step closer to support RegionOfAttraction analysis
of MultibodyPlant systems. MultibodyPlant systems introduce two
additional complexities: (1) the dynamics are trigonometric +
polynomial, and (2) the dynamics are rational.  This PR adds support
for (2).  Support for (1) will come in the follow-up, incorporating #16690.

+@hongkai-dai for feature review
+@shensquared for additional feature review, if you're available

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16704)
<!-- Reviewable:end -->
