### PR TITLE
[wheel] Add missing apt-get update

### DIFF
--- a/tools/wheel/image/provision-python.sh
+++ b/tools/wheel/image/provision-python.sh
@@ -5,6 +5,7 @@ set -eu -o pipefail
 readonly PYTHON=python${1:-3}
 
 # Set up Python environment and install Python prerequisites.
+apt-get -y update
 apt-get -y install --no-install-recommends \
     ${PYTHON}-dev lib${PYTHON}-dev ${PYTHON}-venv
 


### PR DESCRIPTION
Because the Dockerfile will cache based on the contents of these files only, and not the state of the internet hosts, we run the risk of security versions disappearing between the cached provision-base step and a new provision-python, resulting in the inability to build.

We must maintain the invariant that any shell script with 'apt-get install' must always do 'apt-get update' first.

+@mwoehlke-kitware for feature review, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16707)
<!-- Reviewable:end -->
