### PR TITLE
[pydrake] Add bindings for SimulatorConfig, MultibodyPlantConfig

### DIFF
--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -376,6 +376,7 @@ drake_pybind_library(
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake:symbolic_types_pybind",
+        "//bindings/pydrake/common:serialize_pybind",
     ],
     cc_srcs = ["schema_py.cc"],
     package_info = PACKAGE_INFO,

--- a/bindings/pydrake/common/schema_py.cc
+++ b/bindings/pydrake/common/schema_py.cc
@@ -5,6 +5,7 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
+#include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
@@ -43,8 +44,8 @@ PYBIND11_MODULE(schema, m) {
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc)
         .def(py::init<const Class&>(), py::arg("other"))
-        .def(py::init<double>(), py::arg("value"), cls_doc.ctor.doc)
-        .def_readwrite("value", &Class::value, cls_doc.value.doc);
+        .def(py::init<double>(), py::arg("value"), cls_doc.ctor.doc);
+    DefAttributesUsingSerialize(&cls, cls_doc);
     DefCopyAndDeepCopy(&cls);
   }
 
@@ -56,9 +57,8 @@ PYBIND11_MODULE(schema, m) {
         .def(py::init<>(), cls_doc.ctor.doc)
         .def(py::init<const Class&>(), py::arg("other"))
         .def(py::init<double, double>(), py::arg("mean"), py::arg("stddev"),
-            cls_doc.ctor.doc)
-        .def_readwrite("mean", &Class::mean, cls_doc.mean.doc)
-        .def_readwrite("stddev", &Class::stddev, cls_doc.stddev.doc);
+            cls_doc.ctor.doc);
+    DefAttributesUsingSerialize(&cls, cls_doc);
     DefCopyAndDeepCopy(&cls);
   }
 
@@ -70,9 +70,8 @@ PYBIND11_MODULE(schema, m) {
         .def(py::init<>(), cls_doc.ctor.doc)
         .def(py::init<const Class&>(), py::arg("other"))
         .def(py::init<double, double>(), py::arg("min"), py::arg("max"),
-            cls_doc.ctor.doc)
-        .def_readwrite("min", &Class::min, cls_doc.min.doc)
-        .def_readwrite("max", &Class::max, cls_doc.max.doc);
+            cls_doc.ctor.doc);
+    DefAttributesUsingSerialize(&cls, cls_doc);
     DefCopyAndDeepCopy(&cls);
   }
 
@@ -84,8 +83,8 @@ PYBIND11_MODULE(schema, m) {
         .def(py::init<>(), cls_doc.ctor.doc)
         .def(py::init<const Class&>(), py::arg("other"))
         .def(py::init<std::vector<double>>(), py::arg("values"),
-            cls_doc.ctor.doc)
-        .def_readwrite("values", &Class::values, cls_doc.values.doc);
+            cls_doc.ctor.doc);
+    DefAttributesUsingSerialize(&cls, cls_doc);
     DefCopyAndDeepCopy(&cls);
   }
 
@@ -144,8 +143,8 @@ PYBIND11_MODULE(schema, m) {
         .def(py::init<>(), cls_doc.ctor.doc)
         .def(py::init<const Class&>(), py::arg("other"))
         .def(py::init<const drake::Vector<double, size>&>(), py::arg("value"),
-            cls_doc.ctor.doc)
-        .def_readwrite("value", &Class::value, cls_doc.value.doc);
+            cls_doc.ctor.doc);
+    DefAttributesUsingSerialize(&cls, cls_doc);
     DefCopyAndDeepCopy(&cls);
   }
 
@@ -160,9 +159,8 @@ PYBIND11_MODULE(schema, m) {
         .def(py::init<const Class&>(), py::arg("other"))
         .def(py::init<const drake::Vector<double, size>&,
                  const drake::VectorX<double>&>(),
-            py::arg("mean"), py::arg("stddev"), cls_doc.ctor.doc)
-        .def_readwrite("mean", &Class::mean, cls_doc.mean.doc)
-        .def_readwrite("stddev", &Class::stddev, cls_doc.stddev.doc);
+            py::arg("mean"), py::arg("stddev"), cls_doc.ctor.doc);
+    DefAttributesUsingSerialize(&cls, cls_doc);
     DefCopyAndDeepCopy(&cls);
   }
 
@@ -176,9 +174,8 @@ PYBIND11_MODULE(schema, m) {
         .def(py::init<const Class&>(), py::arg("other"))
         .def(py::init<const drake::Vector<double, size>&,
                  const drake::Vector<double, size>&>(),
-            py::arg("min"), py::arg("max"), cls_doc.ctor.doc)
-        .def_readwrite("min", &Class::min, cls_doc.min.doc)
-        .def_readwrite("max", &Class::max, cls_doc.max.doc);
+            py::arg("min"), py::arg("max"), cls_doc.ctor.doc);
+    DefAttributesUsingSerialize(&cls, cls_doc);
     DefCopyAndDeepCopy(&cls);
   }
 

--- a/bindings/pydrake/common/test/schema_test.py
+++ b/bindings/pydrake/common/test/schema_test.py
@@ -22,12 +22,14 @@ class TestSchema(unittest.TestCase):
 
     def test_deterministic(self):
         mut.Deterministic()
-        dut = mut.Deterministic(1.0)
+        mut.Deterministic(0.5)
+        dut = mut.Deterministic(value=1.0)
         dut.value = 2.0
         self._check_distribution(dut)
 
     def test_gaussian(self):
         mut.Gaussian()
+        mut.Gaussian(0.5, 0.2)
         dut = mut.Gaussian(mean=1.0, stddev=0.1)
         dut.mean = 2.0
         dut.stddev = 0.2
@@ -35,6 +37,7 @@ class TestSchema(unittest.TestCase):
 
     def test_uniform(self):
         mut.Uniform()
+        mut.Uniform(-0.5, 0.5)
         dut = mut.Uniform(min=-1.0, max=1.0)
         dut.min = -2.0
         dut.max = 2.0
@@ -42,6 +45,7 @@ class TestSchema(unittest.TestCase):
 
     def test_uniform_discrete(self):
         mut.UniformDiscrete()
+        mut.UniformDiscrete([0.0, 1.0])
         dut = mut.UniformDiscrete(values=[0.0, 0.1])
         dut.values = [0.0, 0.2]
         self._check_distribution(dut)
@@ -78,12 +82,14 @@ class TestSchema(unittest.TestCase):
 
     def test_deterministic_vector(self):
         mut.DeterministicVectorX()
+        mut.DeterministicVectorX([0.1, 0.2])
         dut = mut.DeterministicVectorX(value=[0.0, 1.0])
         dut.value = [0.0, 2.0]
         self._check_distribution_vector(dut)
 
     def test_gaussian_vector(self):
         mut.GaussianVectorX()
+        mut.GaussianVectorX([-0.5, 0.5], [0.2, 0.2])
         dut = mut.GaussianVectorX(mean=[-1.0, 1.0], stddev=[0.1, 0.1])
         dut.mean = [-2.0, 2.0]
         dut.stddev = [0.2, 0.2]
@@ -91,6 +97,7 @@ class TestSchema(unittest.TestCase):
 
     def test_uniform_vector(self):
         mut.UniformVectorX()
+        mut.UniformVectorX([-0.5, -5.0], [0.5, 5.0])
         dut = mut.UniformVectorX(min=[-1.0, -10.0], max=[1.0, 10.0])
         dut.min = [-2.0, -20.0]
         dut.max = [2.0, 20.0]

--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -108,6 +108,7 @@ drake_pybind_library(
         "//bindings/pydrake/common:default_scalars_pybind",
         "//bindings/pydrake/common:eigen_geometry_pybind",
         "//bindings/pydrake/common:eigen_pybind",
+        "//bindings/pydrake/common:serialize_pybind",
         "//bindings/pydrake/common:type_pack",
         "//bindings/pydrake/common:type_safe_index_pybind",
         "//bindings/pydrake/common:value_pybind",

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -54,6 +54,7 @@ from pydrake.multibody.math import (
     SpatialAcceleration_,
 )
 from pydrake.multibody.plant import (
+    AddMultibodyPlant,
     AddMultibodyPlantSceneGraph,
     CalcContactFrictionFromSurfaceProperties,
     ConnectContactResultsToDrakeVisualizer,
@@ -66,6 +67,7 @@ from pydrake.multibody.plant import (
     CoulombFriction_,
     ExternallyAppliedSpatialForce_,
     MultibodyPlant_,
+    MultibodyPlantConfig,
     PointPairContactInfo_,
     PropellerInfo,
     Propeller_,
@@ -229,6 +231,17 @@ class TestPlant(unittest.TestCase):
         context = diagram.CreateDefaultContext()
         with self.assertRaises(RuntimeError):
             plant.EvalBodyPoseInWorld(context, body)
+
+    def test_multibody_plant_config(self):
+        MultibodyPlantConfig()
+        config = MultibodyPlantConfig(time_step=0.01)
+        self.assertEqual(config.time_step, 0.01)
+        copy.copy(config)
+
+        builder = DiagramBuilder_[float]()
+        plant, scene_graph = AddMultibodyPlant(config, builder)
+        self.assertIsNotNone(plant)
+        self.assertIsNotNone(scene_graph)
 
     @numpy_compare.check_all_types
     def test_multibody_plant_api_via_parsing(self, T):

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -107,6 +107,7 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/common:cpp_template_pybind",
         "//bindings/pydrake/common:default_scalars_pybind",
+        "//bindings/pydrake/common:serialize_pybind",
         "//bindings/pydrake/common:wrap_pybind",
     ],
     cc_srcs = ["analysis_py.cc"],

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -2,6 +2,7 @@
 
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
@@ -11,6 +12,7 @@
 #include "drake/systems/analysis/runge_kutta2_integrator.h"
 #include "drake/systems/analysis/runge_kutta3_integrator.h"
 #include "drake/systems/analysis/simulator.h"
+#include "drake/systems/analysis/simulator_config.h"
 #include "drake/systems/analysis/simulator_config_functions.h"
 #include "drake/systems/analysis/simulator_print_stats.h"
 
@@ -26,6 +28,17 @@ PYBIND11_MODULE(analysis, m) {
   m.doc() = "Bindings for the analysis portion of the Systems framework.";
 
   py::module::import("pydrake.systems.framework");
+
+  {
+    using Class = SimulatorConfig;
+    constexpr auto& cls_doc = pydrake_doc.drake.systems.SimulatorConfig;
+    py::class_<Class> cls(m, "SimulatorConfig", cls_doc.doc);
+    cls  // BR
+        .def(py::init<>())
+        .def(ParamInit<Class>());
+    DefAttributesUsingSerialize(&cls, cls_doc);
+    DefCopyAndDeepCopy(&cls);
+  }
 
   {
     constexpr auto& doc = pydrake_doc.drake.systems;
@@ -120,7 +133,7 @@ PYBIND11_MODULE(analysis, m) {
   };
   type_visit(bind_scalar_types, CommonScalarPack{});
 
-  auto bind_nonsymbolic_scalar_types = [m](auto dummy) {
+  auto bind_nonsymbolic_scalar_types = [&m](auto dummy) {
     constexpr auto& doc = pydrake_doc.drake.systems;
     using T = decltype(dummy);
 
@@ -188,6 +201,14 @@ PYBIND11_MODULE(analysis, m) {
             doc.Simulator.ResetStatistics.doc)
         .def("get_system", &Simulator<T>::get_system, py_rvp::reference,
             doc.Simulator.get_system.doc);
+
+    m  // BR
+        .def("ApplySimulatorConfig", &ApplySimulatorConfig<T>,
+            py::arg("simulator"), py::arg("config"),
+            pydrake_doc.drake.systems.ApplySimulatorConfig.doc)
+        .def("ExtractSimulatorConfig", &ExtractSimulatorConfig<T>,
+            py::arg("simulator"),
+            pydrake_doc.drake.systems.ExtractSimulatorConfig.doc);
   };
   type_visit(bind_nonsymbolic_scalar_types, NonSymbolicScalarPack{});
 
@@ -221,6 +242,7 @@ PYBIND11_MODULE(analysis, m) {
           pydrake_doc.drake.systems.ResetIntegratorFromFlags.doc)
       .def("GetIntegrationSchemes", &GetIntegrationSchemes,
           pydrake_doc.drake.systems.GetIntegrationSchemes.doc);
+
   // Print Simulator Statistics
   m  // BR
       .def("PrintSimulatorStatistics", &PrintSimulatorStatistics<double>,

--- a/bindings/pydrake/systems/test/analysis_test.py
+++ b/bindings/pydrake/systems/test/analysis_test.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 
 from pydrake.symbolic import Variable, Expression
@@ -10,6 +11,8 @@ from pydrake.systems.primitives import (
 )
 from pydrake.systems.framework import EventStatus
 from pydrake.systems.analysis import (
+    ApplySimulatorConfig,
+    ExtractSimulatorConfig,
     PrintSimulatorStatistics,
     ResetIntegratorFromFlags,
     RungeKutta2Integrator_,
@@ -18,6 +21,7 @@ from pydrake.systems.analysis import (
     RegionOfAttractionOptions,
     Simulator,
     Simulator_,
+    SimulatorConfig,
     SimulatorStatus,
 )
 from pydrake.trajectories import PiecewisePolynomial
@@ -105,6 +109,21 @@ class TestAnalysis(unittest.TestCase):
             result = ResetIntegratorFromFlags(
                 simulator=simulator, scheme="runge_kutta2",
                 max_step_size=0.001)
+
+    def test_simulator_config(self):
+        SimulatorConfig()
+        config = SimulatorConfig(target_realtime_rate=2.0)
+        self.assertEqual(config.target_realtime_rate, 2.0)
+        copy.copy(config)
+
+    def test_simulator_config_functions(self):
+        for T in (float, AutoDiffXd):
+            source = ConstantVectorSource_[T]([2, 3])
+            simulator = Simulator_[T](source)
+            config = ExtractSimulatorConfig(simulator)
+            config.target_realtime_rate = 100.0
+            ApplySimulatorConfig(simulator, config)
+            self.assertEqual(simulator.get_target_realtime_rate(), 100.0)
 
     def test_system_monitor(self):
         x = Variable("x")


### PR DESCRIPTION
Add bindings for functions that operate on them: `AddMultibodyPlant`, `ApplySimulatorConfig`, `ExtractSimulatorConfig`.

Use `DefAttributesUsingSerialize` in `pydrake.common.schema` for consistency.

- [x] Requires #16718.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16717)
<!-- Reviewable:end -->
