### PR TITLE
[examples] Add realsense camera geometries to manipulation station

### DIFF
--- a/examples/manipulation_station/BUILD.bazel
+++ b/examples/manipulation_station/BUILD.bazel
@@ -29,6 +29,7 @@ drake_cc_library(
         ":models",
         "//examples/kuka_iiwa_arm:models",
         "//manipulation/models/iiwa_description:models",
+        "//manipulation/models/realsense2_description:models",
         "//manipulation/models/wsg_50_description:models",
         "//manipulation/models/ycb:models",
     ],

--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -935,6 +935,11 @@ void ManipulationStation<T>::RegisterRgbdSensor(
   info.color_camera = color_camera;
 
   camera_information_[name] = info;
+
+  const std::string urdf_path = FindResourceOrThrow(
+      "drake/manipulation/models/realsense2_description/urdf/d415.urdf");
+  internal::AddAndWeldModelFrom(
+      urdf_path, name, parent_frame, "base_link", X_PC, plant_);
 }
 
 template <typename T>

--- a/manipulation/models/realsense2_description/BUILD.bazel
+++ b/manipulation/models/realsense2_description/BUILD.bazel
@@ -26,8 +26,32 @@ _REALSENSE2_DESCRIPTION_FILES = forward_files(
     visibility = ["//visibility:private"],
 )
 
+_STLS = [
+    x
+    for x in _REALSENSE2_DESCRIPTION_FILES
+    if x.endswith(".stl")
+]
+
+_OBJS = [x[:-3] + "obj" for x in _STLS]
+
+[
+    genrule(
+        name = obj + "_genrule",
+        srcs = [stl],
+        outs = [obj],
+        cmd = "$(location //manipulation/util:stl2obj) --input $< --output $@",
+        tools = ["//manipulation/util:stl2obj"],
+        visibility = ["//visibility:private"],
+    )
+    for stl, obj in zip(_STLS, _OBJS)
+]
+
 install_data(
-    extra_prod_models = _REALSENSE2_DESCRIPTION_FILES,
+    extra_prod_models = [
+        x
+        for x in _REALSENSE2_DESCRIPTION_FILES + _OBJS
+        if x not in _STLS
+    ],
 )
 
 drake_cc_googletest(

--- a/manipulation/models/realsense2_description/test/realsense_parse_test.cc
+++ b/manipulation/models/realsense2_description/test/realsense_parse_test.cc
@@ -45,8 +45,6 @@ class ParseTest : public testing::TestWithParam<std::string> {};
 
 TEST_P(ParseTest, ParsesUrdfAndVisualizes) {
   const std::string object_name = GetParam();
-  const std::string package = FindResourceOrThrow(
-      "drake/manipulation/models/realsense2_description/package.xml");
   const std::string filename = FindResourceOrThrow(fmt::format(
       "drake/manipulation/models/realsense2_description/urdf/{}.urdf",
       object_name));
@@ -58,8 +56,6 @@ TEST_P(ParseTest, ParsesUrdfAndVisualizes) {
 
   // Check to ensure URDF is parsable.
   Parser parser(&plant);
-  // TODO(#16676) This should be using drake/package.xml, not it's own.
-  parser.package_map().AddPackageXml(package);
   EXPECT_NO_THROW(parser.AddModelFromFile(filename));
 
   // Ensure there was exactly one model instance added for the new model.

--- a/tools/workspace/intel_realsense_ros/files.bzl
+++ b/tools/workspace/intel_realsense_ros/files.bzl
@@ -7,6 +7,5 @@ def realsense2_description_files():
     return [
         "realsense2_description/LICENSE",
         "realsense2_description/meshes/d415.stl",
-        "realsense2_description/package.xml",
         "realsense2_description/urdf/d415.urdf",
     ]

--- a/tools/workspace/intel_realsense_ros/repository.bzl
+++ b/tools/workspace/intel_realsense_ros/repository.bzl
@@ -20,6 +20,8 @@ def intel_realsense_ros_repository(
             "sed -i -e 's|$(arg use_mesh)|true|' realsense2_description/urdf/*.xacro",  # noqa
             "sed -i -e 's|$(arg use_nominal_extrinsics)|false|' realsense2_description/urdf/*.xacro",  # noqa
             "sed -i -e 's|$(arg add_plug)|false|' realsense2_description/urdf/*.xacro",  # noqa
+            "sed -i -e 's|package://realsense2_description|package://drake/manipulation/models/realsense2_description|' realsense2_description/urdf/*.xacro",  # noqa
+            "sed -i -e 's|\\.stl|.obj|' realsense2_description/urdf/*.xacro",
         ],
         mirrors = mirrors,
     )


### PR DESCRIPTION
When launching the default `mock_station_simulation` that has three cameras, the time from launching the program to the scene first appearing in the display increases:
- from ~2 seconds to ~6 seconds when using `drake-visualizer`;
- from ~3 seconds to ~12 seconds when using `meldis`.

This is because mesh file added in #14203 is very detailed (200k vertices).

Closes #16676.