### PR TITLE
[symbolic] ToLatex displays matrix/vector variables using subscript for indices

### DIFF
--- a/common/symbolic_latex.cc
+++ b/common/symbolic_latex.cc
@@ -30,7 +30,17 @@ class LatexVisitor {
 
  private:
   [[nodiscard]] std::string VisitVariable(const Expression& e) const {
-    return get_variable(e).to_string();
+    std::string s = get_variable(e).to_string();
+    // Use subscripts for variable indices.
+    // x(a) => x_{a}, x(a,b) => x_{a,b}, etc.
+    const auto start_paren = s.find_first_of('(');
+    const auto end_paren = s.find_last_of(')');
+    if (start_paren != std::string::npos && end_paren != std::string::npos &&
+        end_paren > start_paren) {
+      s.replace(end_paren, 1, "}");
+      s.replace(start_paren, 1, "_{");
+    }
+    return s;
   }
 
   [[nodiscard]] std::string VisitConstant(const Expression& e) const {

--- a/common/test/symbolic_latex_test.cc
+++ b/common/test/symbolic_latex_test.cc
@@ -100,6 +100,21 @@ GTEST_TEST(SymbolicLatex, BasicTest) {
       R"""( \succeq 0)""");
 }
 
+GTEST_TEST(SymbolicLatex, MatrixSubscripts) {
+  const VectorX<Variable> x = MakeVectorVariable(2, "x");
+  const Vector2<Variable> y = MakeVectorVariable<2>("y");
+  const MatrixX<Variable> A = MakeMatrixVariable(2, 2, "A");
+
+  EXPECT_EQ(ToLatex(x[0]), "x_{0}");
+  EXPECT_EQ(ToLatex(x[1]), "x_{1}");
+  EXPECT_EQ(ToLatex(y[0]), "y_{0}");
+  EXPECT_EQ(ToLatex(y[1]), "y_{1}");
+  EXPECT_EQ(ToLatex(A(0, 0)), "A_{0, 0}");
+  EXPECT_EQ(ToLatex(A(0, 1)), "A_{0, 1}");
+  EXPECT_EQ(ToLatex(A(1, 0)), "A_{1, 0}");
+  EXPECT_EQ(ToLatex(A(1, 1)), "A_{1, 1}");
+}
+
 }  // namespace
 }  // namespace symbolic
 }  // namespace drake


### PR DESCRIPTION
+@hongkai-dai for feature review, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16720)
<!-- Reviewable:end -->
