### PR TITLE
[pydrake] Ensure GIL is locked when logging from a C++ worker thread

### DIFF
--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -474,6 +474,14 @@ drake_py_unittest(
     ],
 )
 
+drake_py_unittest(
+    name = "text_logging_gil_test",
+    deps = [
+        ":module_py",
+        ":text_logging_test_py",
+    ],
+)
+
 drake_cc_googletest(
     name = "type_pack_test",
     deps = [

--- a/bindings/pydrake/common/test/text_logging_gil_test.py
+++ b/bindings/pydrake/common/test/text_logging_gil_test.py
@@ -1,0 +1,37 @@
+import logging
+import time
+import unittest
+
+from pydrake.common import configure_logging
+from pydrake.common.test.text_logging_test import (
+    Worker,
+    do_log_test,
+)
+
+configure_logging()
+
+
+class TestTextLoggingGil(unittest.TestCase):
+    def test_multithreaded_logging(self):
+        """Exercises Drake's Python logging sink in the case where the log
+        messages are coming from multiple kinds of sources concurrently:
+        from pure Python, from the Python main thread calling into pybind11'd
+        C++ code, and from a C++ worker thread.
+
+        Prior to the bugfix merged along with this test case, the code would
+        segfault (when using the prior implementation), or deadlock and timeout
+        (if the implementation still used spdlog mutexes). A successful test
+        does not make any unittest assertions; the fact that is runs without
+        faults is a sufficient proof of safety.
+        """
+        logging.info("Starting Worker")
+        worker = Worker()
+        worker.Start()
+
+        for i in range(100):
+            logging.info(f"Looping {i}")
+            do_log_test()
+            time.sleep(0.01)
+
+        logging.info("Shutting down")
+        worker.Stop()

--- a/bindings/pydrake/common/test/text_logging_test_py.cc
+++ b/bindings/pydrake/common/test/text_logging_test_py.cc
@@ -1,21 +1,76 @@
+#include <atomic>
+#include <chrono>
+#include <thread>
+
 #include "pybind11/pybind11.h"
 
+#include "drake/common/drake_throw.h"
 #include "drake/common/text_logging.h"
 
 namespace drake {
 namespace pydrake {
+namespace {
+
+// Logs one message at every available level.
+void do_log_test() {
+  drake::log()->trace("Test Trace message");
+  drake::log()->debug("Test Debug message");
+  drake::log()->info("Test Info message");
+  drake::log()->warn("Test Warn message");
+  drake::log()->error("Test Error message");
+  drake::log()->critical("Test Critical message");
+}
+
+// Launches a C++ thread that logs periodically.
+class Worker {
+ public:
+  Worker() = default;
+
+  ~Worker() {
+    if (thread_ != nullptr) {
+      Stop();
+    }
+  }
+
+  void Start() {
+    DRAKE_THROW_UNLESS(thread_ == nullptr);
+    keep_running_.store(true);
+    thread_ = std::make_unique<std::thread>([this]() { this->ThreadMain(); });
+  }
+
+  void Stop() {
+    DRAKE_THROW_UNLESS(thread_ != nullptr);
+    keep_running_.store(false);
+    thread_->join();
+    thread_.reset();
+  }
+
+  void ThreadMain() {
+    while (keep_running_.load()) {
+      drake::log()->info("Thread info message");
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
+
+ private:
+  std::atomic<bool> keep_running_{true};
+  std::unique_ptr<std::thread> thread_;
+};
+
+}  // namespace
 
 PYBIND11_MODULE(text_logging_test, m) {
   m.doc() = "Test text logging";
 
-  m.def("do_log_test", []() {
-    drake::log()->trace("Test Trace message");
-    drake::log()->debug("Test Debug message");
-    drake::log()->info("Test Info message");
-    drake::log()->warn("Test Warn message");
-    drake::log()->error("Test Error message");
-    drake::log()->critical("Test Critical message");
-  });
+  m.def("do_log_test", &do_log_test);
+
+  {
+    using Class = Worker;
+    pybind11::class_<Class>(m, "Worker")
+        .def(pybind11::init<>())
+        .def("Start", &Class::Start)
+        .def("Stop", &Class::Stop);
+  }
 }
 
 }  // namespace pydrake


### PR DESCRIPTION
To avoid lock order inversion, we must avoid using any mutexes in the spdlog code paths; instead we should grab the GIL once we've reached the Python sink.

This means that users will not be able to log to both a C++ sink and Python sink anymore. Users who want to do so can configure logging on their own, in which case Drake's logging reconfiguration will leave it unchanged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16724)
<!-- Reviewable:end -->
