### PR TITLE
[geometry] Fix Meshcat crash with duplicated controls names

### DIFF
--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -420,7 +420,8 @@ class Meshcat {
   //@{
 
   /** Adds a button with the label `name` to the meshcat browser controls GUI.
-   */
+   @throws std::exception if `name` has already been added as any type of
+   control (e.g., either button or slider). */
   void AddButton(std::string name);
 
   /** Returns the number of times the button `name` has been clicked in the
@@ -437,7 +438,9 @@ class Meshcat {
    The slider range is given by [`min`, `max`]. `step` is the smallest
    increment by which the slider can change values (and therefore send updates
    back to this Meshcat instance). `value` specifies the initial value; it will
-   be truncated to the slider range and rounded to the nearest increment. */
+   be truncated to the slider range and rounded to the nearest increment.
+   @throws std::exception if `name` has already been added as any type of
+   control (e.g., either button or slider). */
   void AddSlider(std::string name, double min, double max, double step,
                  double value);
 

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -545,6 +545,9 @@ GTEST_TEST(MeshcatTest, Buttons) {
 
   meshcat.AddButton("button");
   EXPECT_EQ(meshcat.GetButtonClicks("button"), 0);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      meshcat.AddButton("button"),
+      "Meshcat already has a button named button.");
   meshcat.DeleteButton("button");
 
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -579,6 +582,9 @@ GTEST_TEST(MeshcatTest, Sliders) {
   EXPECT_NEAR(meshcat.GetSliderValue("slider"), 1.5, 1e-14);
   meshcat.SetSliderValue("slider", 1.245);
   EXPECT_NEAR(meshcat.GetSliderValue("slider"), 1.2, 1e-14);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      meshcat.AddSlider("slider", 0.2, 1.5, 0.1, 0.5),
+      "Meshcat already has a slider named slider.");
 
   meshcat.DeleteSlider("slider");
 
@@ -595,6 +601,21 @@ GTEST_TEST(MeshcatTest, Sliders) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       meshcat.GetSliderValue("slider2"),
       "Meshcat does not have any slider named slider2.");
+}
+
+GTEST_TEST(MeshcatTest, DuplicateMixedControls) {
+  Meshcat meshcat;
+
+  meshcat.AddButton("button");
+  meshcat.AddSlider("slider", 0.2, 1.5, 0.1, 0.5);
+
+  // We must reject adding controls with duplicated names.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      meshcat.AddButton("slider"),
+      "Meshcat already has a slider named slider.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      meshcat.AddSlider("button", 0.2, 1.5, 0.1, 0.5),
+      "Meshcat already has a button named button.");
 }
 
 GTEST_TEST(MeshcatTest, SetPropertyWebSocket) {


### PR DESCRIPTION
When asked to add a control with a duplicate name, throw an exception instead of trying to implicitly delete the existing control.

Deleting the existing control never worked anyway; it was checking for duplicates using the moved-from name, which was always empty. This led to duplicate names in the controls_ vector, and then segfaults.

Add more internal assertions that the controls_ vector is congruent with the buttons_ and sliders_ vectors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16726)
<!-- Reviewable:end -->
