### PR TITLE
Add ability to create a VPolytope from a non-minimal set of vertices

### DIFF
--- a/bindings/pydrake/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry_py_optimization.cc
@@ -241,6 +241,8 @@ void DefineGeometryOptimization(py::module m) {
             py::arg("query_object"), py::arg("geometry_id"),
             py::arg("reference_frame") = std::nullopt,
             cls_doc.ctor.doc_scenegraph)
+        .def("GetMinimalRepresentation", &VPolytope::GetMinimalRepresentation,
+            cls_doc.GetMinimalRepresentation.doc)
         .def("vertices", &VPolytope::vertices, cls_doc.vertices.doc)
         .def_static("MakeBox", &VPolytope::MakeBox, py::arg("lb"),
             py::arg("ub"), cls_doc.MakeBox.doc)

--- a/bindings/pydrake/test/geometry_optimization_test.py
+++ b/bindings/pydrake/test/geometry_optimization_test.py
@@ -168,6 +168,31 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertTrue(v_unit_box.PointInSet([0, 0, 0]))
         v_from_h = mut.VPolytope(H=mut.HPolyhedron.MakeUnitBox(dim=3))
         self.assertTrue(v_from_h.PointInSet([0, 0, 0]))
+        # Test creating a vpolytope from a non-minimal set of vertices
+        # 2D: Random points inside a circle
+        r = 2.0
+        n = 400
+        vertices = np.zeros((2, n + 4))
+        theta = np.linspace(0, 2 * np.pi, n, endpoint=False)
+        vertices[0, 0:n] = r * np.cos(theta) + 0.5 * r
+        vertices[1, 0:n] = r * np.sin(theta) + 0.5 * r
+        vertices[:, n:] = np.array([
+            [r/2, r/3, r/4, r/5],
+            [r/2, r/3, r/4, r/5]
+        ])
+        vpoly = mut.VPolytope(vertices=vertices).GetMinimalRepresentation()
+        self.assertAlmostEqual(vpoly.CalcVolume(), np.pi * r * r, delta=1e-3)
+        self.assertEqual(vpoly.vertices().shape[1], n)
+        # 3D: Random points inside a box
+        a = 2.0
+        vertices = np.array([
+            [0, a, 0, a, 0, a, 0, a, a/2, a/3, a/4, a/5],
+            [0, 0, a, a, 0, 0, a, a, a/2, a/3, a/4, a/5],
+            [0, 0, 0, 0, a, a, a, a, a/2, a/3, a/4, a/5]
+        ])
+        vpoly = mut.VPolytope(vertices=vertices).GetMinimalRepresentation()
+        self.assertAlmostEqual(vpoly.CalcVolume(), a * a * a)
+        self.assertEqual(vpoly.vertices().shape[1], 8)
 
     def test_cartesian_product(self):
         point = mut.Point(np.array([11.1, 12.2, 13.3]))

--- a/geometry/optimization/test/vpolytope_test.cc
+++ b/geometry/optimization/test/vpolytope_test.cc
@@ -477,6 +477,69 @@ GTEST_TEST(VPolytopeTest, CalcVolume) {
   EXPECT_NEAR(VPolytope(vertices_3d_planar).CalcVolume(), 0., tol);
 }
 
+GTEST_TEST(VPolytopeTest, GetMinimalRepresentationTest) {
+  const double tol{1E-6};
+
+  // 2D: Square plus some points inside
+  {
+    Eigen::Matrix<double, 2, 6> vertices;
+    const double l = 2.0;
+    // clang-format off
+    vertices << 0, l, 0, l, l/4, l/2,
+                0, 0, l, l, l/5, l/3;
+    // clang-format on
+    auto vpoly = VPolytope(vertices).GetMinimalRepresentation();
+    EXPECT_EQ(vpoly.vertices().cols(), 4);
+    EXPECT_NEAR(vpoly.CalcVolume(), l*l, tol);
+
+    // Test PointInSet with points nearby the four edges.
+    const double d = 10 * tol;
+    for (int axis = 0; axis < 2; ++axis) {
+      for (int face = 0; face < 2; ++face) {
+        for (int side = 0; side < 2; ++side) {
+          Vector2d point(l/2, l/2);
+          point[axis] = l * face + d * (side * 2 - 1);
+          if (face + side == 1) {
+            EXPECT_TRUE(vpoly.PointInSet(point, tol));
+          } else {
+            EXPECT_FALSE(vpoly.PointInSet(point, tol));
+          }
+        }
+      }
+    }
+  }
+
+  // 3D: Box plus some points inside
+  {
+    Eigen::Matrix<double, 3, 10> vertices;
+    const double l = 2.0;
+    // clang-format off
+    vertices << 0, l, 0, l, 0, l, 0, l, l/4, l/2,
+                0, 0, l, l, 0, 0, l, l, l/5, l/3,
+                0, 0, 0, 0, l, l, l, l, l/6, l/4;
+    // clang-format on
+    auto vpoly = VPolytope(vertices).GetMinimalRepresentation();
+    EXPECT_EQ(vpoly.vertices().cols(), 8);
+    EXPECT_NEAR(vpoly.CalcVolume(), l*l*l, tol);
+
+    // Test PointInSet with points nearby the six faces.
+    const double d = 10 * tol;
+    for (int axis = 0; axis < 3; ++axis) {
+      for (int face = 0; face < 2; ++face) {
+        for (int side = 0; side < 2; ++side) {
+          Vector3d point(l/2, l/2, l/2);
+          point[axis] = l * face + d * (side * 2 - 1);
+          if (face + side == 1) {
+            EXPECT_TRUE(vpoly.PointInSet(point, tol));
+          } else {
+            EXPECT_FALSE(vpoly.PointInSet(point, tol));
+          }
+        }
+      }
+    }
+  }
+}
+
 }  // namespace optimization
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/optimization/vpolytope.h
+++ b/geometry/optimization/vpolytope.h
@@ -20,7 +20,7 @@ namespace optimization {
  Note: Unlike the half-space representation, this
  definition means the set is always bounded (hence the name polytope, instead of
  polyhedron).
- 
+
 @ingroup geometry_optimization
 */
 class VPolytope final : public ConvexSet {
@@ -45,6 +45,12 @@ class VPolytope final : public ConvexSet {
             std::optional<FrameId> reference_frame = std::nullopt);
 
   ~VPolytope() final;
+
+  /** Creates a new VPolytope whose vertices are guaranteed to be minimal,
+  i.e. if we remove any point from its vertices, then the convex hull of the
+  remaining vertices is a strict subset of the polytope.
+  */
+  VPolytope GetMinimalRepresentation() const;
 
   /** Returns true if the point is within @p tol of the set under the L∞-norm.
    Note: This requires the solution of a linear program; the achievable


### PR DESCRIPTION
This is a pre-requisite to remove the `scipy.spatial.ConvexHull` dependency.

Related to #14691

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16729)
<!-- Reviewable:end -->
