### PR TITLE
jupyter: Pull in minor Bazel improvements

### DIFF
--- a/tools/jupyter/jupyter_bazel.py
+++ b/tools/jupyter/jupyter_bazel.py
@@ -18,7 +18,7 @@ For Drake developers:
 """
 
 
-def _jupyter_bazel_notebook_main(cur_dir, notebook_file, argv):
+def _jupyter_bazel_notebook_main(notebook_path, argv):
     # This should *ONLY* be called by targets generated via `jupyter_py_*`
     # rules.
     parser = argparse.ArgumentParser()
@@ -26,22 +26,13 @@ def _jupyter_bazel_notebook_main(cur_dir, notebook_file, argv):
         "--test", action="store_true", help="Run as a test (non-interactive)")
     args = parser.parse_args(argv)
 
-    # Assume that (hopefully) the notebook neighbors this generated file.
-    # Failure mode: If user puts a slash in the `name` which does not match the
-    # notebook's location. This should be infrequent.
-    notebook_path = os.path.join(cur_dir, notebook_file)
-    if not os.path.isfile(notebook_path):
-        # `name` may contain a subdirectory. Just use basename of file.
-        notebook_path = os.path.join(cur_dir, os.path.basename(notebook_file))
-
     if not args.test:
         print("Running notebook interactively")
-        # TODO(eric.cousineau): Possible to spin up notebook server directly?
+        notebook_path = os.path.realpath(notebook_path)
         sys.argv = ["jupyter", "notebook", notebook_path]
         exit(_jupyter_main())
     else:
-        print("Running notebook as a test (non-interactive):")
-        print("  {}".format(notebook_file))
+        print("Running notebook as a test (non-interactive)")
         tmp_dir = os.environ.get("TEST_TMPDIR")
         if tmp_dir is not None:
             # Change IPython directory to use test directory.


### PR DESCRIPTION
Derived from Anzu PR 8537

Another thing to keep in mind (in background) is https://github.com/jupyter-server/jupyter_server/issues/711

Not important as we don't (can't?) currently use `jupyter lab`, but may be relevant then.

Also, using workaround, calling `jupyter notebook $(realpath ${notebook_path})`, is nice for UX. Not sure if we care about that yet in Drake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16740)
<!-- Reviewable:end -->
