### PR TITLE
[common] Deprecate TrigPoly

### DIFF
--- a/common/test/trig_poly_test.cc
+++ b/common/test/trig_poly_test.cc
@@ -11,6 +11,9 @@ namespace drake {
 namespace util {
 namespace {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 typedef std::map<TrigPolyd::VarType, double> MapType;
 const double kPi = 3.1415926535897;
 
@@ -132,6 +135,8 @@ GTEST_TEST(TrigPolyTest, EvaluatePartialTest) {
   EXPECT_EQ(multivariate.EvaluatePartial(MapType {{phi_var, 1}}),
             theta + cos(theta) + sin(theta + 1));
 }
+
+#pragma GCC diagnostic pop
 
 }  // anonymous namespace
 }  // namespace util

--- a/common/trig_poly.h
+++ b/common/trig_poly.h
@@ -10,6 +10,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/polynomial.h"
 
 namespace drake {
@@ -46,7 +47,10 @@ namespace drake {
  * <!-- TODO(ggould-tri): Fix this in the future. -->
  */
 template <typename T = double>
-class TrigPoly final {
+class DRAKE_DEPRECATED(
+    "2022-07-01",
+    "TrigPoly is deprecated. Please use symbolic::Expression and the "
+    "SinCosSubstitution instead.") TrigPoly final {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(TrigPoly)
 
@@ -287,6 +291,8 @@ class TrigPoly final {
    * all base variables only; supplying values for sin/cos variables is an
    * error.
    */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   virtual TrigPoly<T> EvaluatePartial(
       const std::map<VarType, T>& var_values) const {
     std::map<VarType, T> var_values_with_sincos = var_values;
@@ -304,6 +310,7 @@ class TrigPoly final {
     return TrigPoly(poly_.EvaluatePartial(var_values_with_sincos),
                     sin_cos_map_);
   }
+#pragma GCC diagnostic pop
 
   /// Compares two TrigPolys for equality.
   /**
@@ -428,6 +435,8 @@ class TrigPoly final {
     return ret;
   }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   friend std::ostream& operator<<(std::ostream& os,
                                   const TrigPoly<T>& tp) {
     os << tp.poly_;
@@ -443,12 +452,15 @@ class TrigPoly final {
     }
     return os;
   }
+#pragma GCC diagnostic pop
 
  private:
   PolyType poly_;
   SinCosMap sin_cos_map_;
 };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 template <typename T, int Rows, int Cols>
 std::ostream& operator<<(
     std::ostream& os,
@@ -466,5 +478,7 @@ typedef TrigPoly<double> TrigPolyd;
 
 /// A column vector of TrigPoly; used in several optimization classes.
 typedef Eigen::Matrix<TrigPolyd, Eigen::Dynamic, 1> VectorXTrigPoly;
+
+#pragma GCC diagnostic pop
 
 }  // namespace drake

--- a/solvers/system_identification.cc
+++ b/solvers/system_identification.cc
@@ -9,6 +9,9 @@
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/solve.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 namespace drake {
 namespace solvers {
 
@@ -475,3 +478,5 @@ SystemIdentification<T>::ClassifyVars(
 }  // namespace drake
 
 template class drake::solvers::SystemIdentification<double>;
+
+#pragma GCC diagnostic pop

--- a/solvers/system_identification.h
+++ b/solvers/system_identification.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/polynomial.h"
 #include "drake/common/trig_poly.h"
 
@@ -38,7 +39,11 @@ namespace solvers {
  * those parameters based on empirical data.
  */
 template <typename T>
-class SystemIdentification {
+class DRAKE_DEPRECATED(
+    "2022-07-01",
+    "SystemIdentification is deprecated.  The preferred toolchain uses "
+    "symbolic::Expression to do this work now, as demonstrated in "
+    "http://underactuated.mit.edu/sysid.html .") SystemIdentification {
  public:
   typedef Polynomial<T> PolyType;
   typedef typename PolyType::Monomial MonomialType;

--- a/solvers/test/system_identification_test.cc
+++ b/solvers/test/system_identification_test.cc
@@ -12,6 +12,9 @@ namespace drake {
 namespace solvers {
 namespace {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 typedef SystemIdentification<double> SID;
 
 GTEST_TEST(SystemIdentificationTest, LumpedSingle) {
@@ -465,6 +468,7 @@ GTEST_TEST(SystemIdentificationTest, PendulaIdentification) {
   }
 }
 
+#pragma GCC diagnostic pop
 ///@}
 
 }  // anonymous namespace


### PR DESCRIPTION
Our symbolic::Expression can do this work, too, now, and with
Expression we can process trigonometric polynomials directly from
MultibodyPlant.

+@ggould-tri for feature review, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16741)
<!-- Reviewable:end -->
