### PR TITLE
[geometry/dev] Use new HttpService Interface with GLTF

### DIFF
--- a/geometry/render/dev/BUILD.bazel
+++ b/geometry/render/dev/BUILD.bazel
@@ -82,12 +82,13 @@ drake_cc_library(
     srcs = ["render_client.cc"],
     hdrs = ["render_client.h"],
     deps = [
+        ":http_service",
+        ":http_service_curl",
         "//common:filesystem",
+        "//common:nice_type_name",
         "//common:temp_directory",
         "//geometry/render:render_camera",
         "//systems/sensors:image",
-        "@json",
-        "@libcurl",
         "@picosha2",
         "@vtk//:vtkIOImage",
     ],
@@ -170,6 +171,19 @@ drake_cc_googletest(
         ":http_service_curl",
         "//common:temp_directory",
         "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "render_client_test",
+    # TODO(svenevs): out of /dev this becomes :test_models.
+    data = ["//geometry/render:test_models"],
+    deps = [
+        ":render_client",
+        "//common:find_resource",
+        "//common/test_utilities:expect_no_throw",
+        "//common/test_utilities:expect_throws_message",
+        "//geometry/render/dev/test_utilities",
     ],
 )
 

--- a/geometry/render/dev/render_client.h
+++ b/geometry/render/dev/render_client.h
@@ -1,14 +1,18 @@
 #pragma once
 
+#include <memory>
 #include <optional>
 #include <string>
 
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/render/dev/http_service.h"
 #include "drake/geometry/render/render_camera.h"
 #include "drake/systems/sensors/image.h"
 
 namespace drake {
 namespace geometry {
 namespace render {
+namespace internal {
 
 /** The type of image being rendered. */
 enum RenderImageType {
@@ -22,42 +26,35 @@ enum RenderImageType {
 /** The client which communicates with a render server. */
 class RenderClient {
  public:
-  /** @name Does not allow copy, move, or assignment  */
-  //@{
-#ifdef DRAKE_DOXYGEN_CXX
-  // Note: the copy constructor operator is actually protected to serve as the
-  // basis for implementing the DoClone() method of derived classes.
-  RenderClient(const RenderClient&) = delete;
-#endif
-  RenderClient& operator=(const RenderClient&) = delete;
-  RenderClient(RenderClient&&) = delete;
-  RenderClient& operator=(RenderClient&&) = delete;
-  virtual ~RenderClient();
-  //@}}
-
   /** Constructs the render engine from the given parameters.
    @param url
-     The url of the server to communicate with, e.g., `"http://127.0.0.1"`.
+     The url of the server to communicate with, e.g., `"http://127.0.0.1"`.  May
+     **not** have a trailing `/`.
    @param port
      The port to communicate with the server on, e.g., `8000`.  A value of less
      than or equal to `0` implies no port-level communication is needed.
    @param render_endpoint
      The endpoint that the server expects to receive render requests to, e.g.,
-     `"render"`.  Do not include a preceding `/`, communications with the server
-     are constructed as `{url}/{render_endpoint}`.
+     `"render"`.  May **not** have a leading or trailing `/`, communications
+     with the server are constructed as `{url}/{render_endpoint}`.
    @param verbose
      Whether or not the client should be verbose in logging its communications
      with the server.
    @param no_cleanup
      Whether or not the temp_directory() should be deleted upon destruction of
-     this instance. */
-  explicit RenderClient(const std::string& url, int32_t port,
-                        const std::string& render_endpoint, bool verbose,
-                        bool no_cleanup);
+     this instance.
+   @throws std::logic_error
+     If the provided `url` is empty or ends with a `/`, via
+     HttpService::HttpService.
+   @throws std::runtime_error
+     If the provided `render_endpoint` has any leading or trailing slashes. */
+  RenderClient(const std::string& url, int32_t port,
+               const std::string& render_endpoint, bool verbose,
+               bool no_cleanup);
 
- protected:
-  /** Copy constructor for the purpose of cloning. */
-  RenderClient(const RenderClient& other);
+  virtual ~RenderClient();
+
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RenderClient);
 
   /** @name Server communication */
   //@{
@@ -86,12 +83,10 @@ class RenderClient {
      The mime type to set for the scene file being uploaded as a file.  If not
      provided, no mime type will be sent to the server.  No validity checks on
      the value of the provided mime type are performed.
-   @param min_depth
-     The minimum depth range.  Required when `image_type` is depth.  See also:
-     ValidDepthRangeOrThrow().
-   @param max_depth
-     The maximum depth range.  Required when `image_type` is depth.  See also:
-     ValidDepthRangeOrThrow().
+   @param depth_range
+     When `image_type` describes a depth render, this parameter must be provided
+     from the DepthRenderCamera::depth_range().  May not have a value for color
+     or label image renders.
    @return
      A successful download of a rendering from the server will return the path
      to the downloaded file, which will be exactly
@@ -99,14 +94,15 @@ class RenderClient {
      `extension` will depend on what the server returns, e.g., `.png` or
      `.tiff`.
    @throws std::runtime_error
-     If a rendering cannot be obtained from the server for any reason, including
-     invalid parameters supplied to this method such as not including
-     `min_depth` and/or `max_depth` when `image_type` is depth. */
+     If a rendering cannot be obtained from the server for any reason.
+   @throws std::logic_error
+     If `image_type` is a depth image but `depth_range` was not provided, or
+     `depth_range` was provided but `image_type` is color or label. */
   virtual std::string RenderOnServer(
       const RenderCameraCore& camera_core, RenderImageType image_type,
       const std::string& scene_path,
-      const std::optional<std::string>& mime_type, double min_depth = -1.0,
-      double max_depth = -1.0) const;
+      const std::optional<std::string>& mime_type = std::nullopt,
+      const std::optional<DepthRange>& depth_range = std::nullopt) const;
 
   //@}
   /** @name Server communication helpers */
@@ -118,33 +114,42 @@ class RenderClient {
    */
   std::string ComputeSha256(const std::string& path) const;
 
-  /** Validates the specified depth range.  Helper method used in
-   RetrieveRender() when the `image_type` is depth.
+  /** Rename the specified file `response_data_path` to have the same name as
+   `reference_path`, with a new file extension provided by `extension`.
+   Helper method for RetrieveRender() which will download files as
+   `{temp_directory()}/{response_data_path}` and then rename the file
+   depending on the type of image that was downloaded.  Examples:
 
-   @sa DepthRange
-   @param min_depth The minimum depth range.
-   @param max_depth The maximum depth range.
-   @throws std::logic_error
-     If `min_depth` or `max_depth` are less than `0.0`, or if
-     `max_depth <= min_depth`. */
-  void ValidDepthRangeOrThrow(double min_depth, double max_depth) const;
+   @code{.cpp}
+    const auto renamed_1 = RenameHttpServiceResponse(
+        "/some/other/ABC.curl",
+        "/some/input/XYZ.gltf",
+        ".png");
+    // renamed_1: "/some/input/XYZ.png"
+    const auto renamed_2 = RenameHttpServiceResponse(
+        "/a/folder/999.bin",
+        "/a/folder/123.gltf",
+        ".tiff");
+    // renamed_2: "/a/folder/123.tiff"
+   @endcode
 
-  /** Rename the specified file with the provided extension.  Helper method for
-   RetrieveRender() which will download files as
-   `{temp_directory()}/{scene_path}.bin` and then rename the file depending on
-   the type of image that was downloaded.
-
-   @param path
-     The input path to change the file extension for, e.g., `"file.bin"`.
-   @param ext
+   @param response_data_path
+     The input path to change the file extension for, e.g., `"file.curl"`.
+     Should be the value of HttpResponse::data_path.
+   @param reference_path
+     The reference path to be renaming `response_data_path` to, with a different
+     file extension, e.g., `"scene.gltf"`.
+   @param extension
      The new file extension, e.g., `".png"`.  Uses
      `std::filesystem::path::replace_extension()` internally.
    @return
      The path to the new file after renaming it.
    @throws std::exception
-     When any errors arise from renaming the file. */
-  std::string RenameFileExtension(const std::string& path,
-                                  const std::string& ext) const;
+     If `input_scene` or `path` do not exist, or any errors arise from renaming
+     the file. */
+  std::string RenameHttpServiceResponse(const std::string& response_data_path,
+                                        const std::string& reference_path,
+                                        const std::string& extension) const;
 
   //@}
 
@@ -246,15 +251,21 @@ class RenderClient {
 
   //@}
 
+  /** (Internal use only) for testing. */
+  void SetHttpService(std::unique_ptr<HttpService> service);
+
  private:
+  friend class RenderClientTester;
   std::string temp_directory_;
   std::string url_;
   int32_t port_;
   std::string render_endpoint_;
   bool verbose_;
   bool no_cleanup_;
+  std::unique_ptr<HttpService> http_service_;
 };
 
+}  // namespace internal
 }  // namespace render
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render/dev/render_engine_gltf_client.h
+++ b/geometry/render/dev/render_engine_gltf_client.h
@@ -17,7 +17,7 @@ namespace render {
 /** A RenderClient that exports
  <a href="https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html">glTF
  </a> scenes to upload to a render server. */
-class RenderEngineGltfClient : public RenderEngineVtk, public RenderClient {
+class RenderEngineGltfClient : public RenderEngineVtk {
  public:
   /** @name Does not allow copy, move, or assignment  */
   //@{
@@ -78,6 +78,9 @@ class RenderEngineGltfClient : public RenderEngineVtk, public RenderClient {
    be called when `!no_cleanup()`. */
   void CleanupFrame(const std::string& scene_path,
                     const std::string& image_path) const;
+
+ private:
+  std::unique_ptr<internal::RenderClient> render_client_;
 };
 
 }  // namespace render

--- a/geometry/render/dev/test/render_client_test.cc
+++ b/geometry/render/dev/test/render_client_test.cc
@@ -1,0 +1,1102 @@
+#include "drake/geometry/render/dev/render_client.h"
+
+#include <cstdio>
+#include <fstream>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/filesystem.h"
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/expect_no_throw.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/render/dev/http_service.h"
+#include "drake/geometry/render/dev/test_utilities/test_png.h"
+#include "drake/geometry/render/dev/test_utilities/test_tiff.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+
+using systems::sensors::ImageDepth32F;
+using systems::sensors::ImageLabel16I;
+using systems::sensors::ImageRgba8U;
+
+class RenderClientTester {
+ public:
+  explicit RenderClientTester(const RenderClient* client) : client_(*client) {}
+
+  void ValidateAttributes(const std::string& url, int32_t port,
+                          const std::string& render_endpoint, bool verbose,
+                          bool no_cleanup) const {
+    EXPECT_EQ(client_.url(), url);
+    EXPECT_EQ(client_.port(), port);
+    EXPECT_EQ(client_.render_endpoint(), render_endpoint);
+    EXPECT_EQ(client_.verbose(), verbose);
+    EXPECT_EQ(client_.no_cleanup(), no_cleanup);
+  }
+
+  void CompareAttributes(const RenderClient& other) {
+    ValidateAttributes(other.url(), other.port(), other.render_endpoint(),
+                       other.verbose(), other.no_cleanup());
+  }
+
+ private:
+  const RenderClient& client_;
+};
+
+namespace {
+
+namespace fs = drake::filesystem;
+
+// Constructor / destructor ----------------------------------------------------
+GTEST_TEST(RenderClient, Constructor) {
+  const std::string url{"127.0.0.1"};
+  const int32_t port{8000};
+  const std::string render_endpoint{"render"};
+  const bool verbose = false;
+  const bool no_cleanup = false;
+
+  {
+    // Provided url may not end with slash.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        RenderClient(url + "/", port, render_endpoint, verbose, no_cleanup),
+        "HttpService: url may not end with '/'\\.");
+    // Provided url may not be empty.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        RenderClient("", port, render_endpoint, verbose, no_cleanup),
+        "HttpService: url parameter may not be empty\\.");
+    // Provided endpoint may not start with a slash.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        RenderClient(url, port, "/" + render_endpoint, verbose, no_cleanup),
+        "Provided endpoint='/render' is not valid, it may not start or end "
+        "with a '/'\\.");
+    // Provided endpoint may not end with a slash.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        RenderClient(url, port, render_endpoint + "/", verbose, no_cleanup),
+        "Provided endpoint='render/' is not valid, it may not start or end "
+        "with a '/'\\.");
+  }
+
+  {
+    // Verify attributes after valid construction.
+    auto make_client_and_verify = [&](bool p_no_cleanup) {
+      std::string temp_directory;
+      {
+        RenderClient client{url, port, render_endpoint, verbose, p_no_cleanup};
+        temp_directory = client.temp_directory();
+        RenderClientTester tester{&client};
+        EXPECT_TRUE(fs::is_directory(client.temp_directory()));
+        tester.ValidateAttributes(url, port, render_endpoint, verbose,
+                                  p_no_cleanup);
+      }  // Client is deleted.
+      if (p_no_cleanup) {
+        EXPECT_TRUE(fs::is_directory(temp_directory));
+      } else {
+        EXPECT_FALSE(fs::is_directory(temp_directory));
+      }
+    };
+    make_client_and_verify(true);
+    make_client_and_verify(false);
+  }
+}
+
+GTEST_TEST(RenderClient, Destructor) {
+  const std::string url{"127.0.0.1"};
+  const int32_t port{8000};
+  const std::string render_endpoint = "render";
+  const bool verbose = false;
+
+  std::string temp_dir_path;
+  // Construction with no_cleanup=false: temp_directory should be gone.
+  {
+    const RenderClient client{url, port, render_endpoint, verbose, false};
+    temp_dir_path = client.temp_directory();
+    EXPECT_TRUE(fs::is_directory(temp_dir_path));
+  }  // Client is deleted.
+  EXPECT_FALSE(fs::is_directory(temp_dir_path));
+
+  // Construction with no_cleanup=true: temp_directory should remain.
+  {
+    const RenderClient client{url, port, render_endpoint, verbose, true};
+    temp_dir_path = client.temp_directory();
+    EXPECT_TRUE(fs::is_directory(temp_dir_path));
+  }  // Client is deleted.
+  EXPECT_TRUE(fs::is_directory(temp_dir_path));
+  fs::remove(temp_dir_path);
+}
+
+// RenderOnServer --------------------------------------------------------------
+// Convenience definitions for interacting with HttpService.
+using data_map_t = std::map<std::string, std::string>;
+using file_map_t =
+    std::map<std::string, std::pair<std::string, std::optional<std::string>>>;
+
+// A simple HttpService that always fails.
+class FailService : public HttpService {
+ public:
+  FailService() : HttpService() {}
+
+  HttpResponse PostForm(const std::string& /* temp_directory */,
+                        const std::string& /* url */, int32_t /* port */,
+                        const std::string& /* endpoint */,
+                        const data_map_t& /* data_fields */,
+                        const file_map_t& /* file_fields */,
+                        bool /* verbose */ = false) override {
+    HttpResponse ret;
+    ret.http_code = 500;
+    ret.service_error = true;
+    ret.service_error_message = "FailService always fails.";
+    return ret;
+  }
+};
+
+/* Verifies the contract fullfilled by RenderClient::RenderOnServer, checking
+ that all fields are exactly as expected (and where min_depth / max_depth are
+ concerned, they are included / excluded as expected).  The code checks in
+ PostForm are more or less a duplication of RenderClient::RenderOnServer,
+ meaning any changes to the code populating the <form> will break this test case
+ (intentionally).
+
+ A test using a FieldCheckService will construct with the exact same parameters
+ that RenderClient::RenderOnServer is going to use, so that when PostForm is
+ called behind the scenes we have all the information to cross-check against. */
+class FieldCheckService : public HttpService {
+ public:
+  /* All parameters for HttpService, followed by RenderClient::RenderOnServer
+   with the addition of the sha256. */
+  FieldCheckService(const RenderCameraCore& camera_core,
+                    RenderImageType image_type, const std::string& scene_path,
+                    const std::string& scene_sha256,
+                    const std::optional<std::string>& mime_type = std::nullopt,
+                    const std::optional<DepthRange>& depth_range = std::nullopt)
+      : HttpService(),
+        camera_core_{camera_core},
+        image_type_{image_type},
+        scene_path_{scene_path},
+        scene_sha256_{scene_sha256},
+        mime_type_{mime_type},
+        depth_range_{depth_range} {}
+
+  /* Check all of the <form> fields.  Always respond with failure (http 500). */
+  HttpResponse PostForm(const std::string& /* temp_directory */,
+                        const std::string& url, int32_t /* port */,
+                        const std::string& endpoint,
+                        const data_map_t& data_fields,
+                        const file_map_t& file_fields,
+                        bool /* verbose */ = false) override {
+    ThrowIfUrlInvalid(url);
+    ThrowIfEndpointInvalid(endpoint);
+    ThrowIfFilesMissing(file_fields);
+
+    /* Validate all of the expected fields.  This also implicitly validates that
+     every expected key has actually been provided since the test will fail on
+     directly accessing a key that does not exist. */
+    EXPECT_EQ(data_fields.at("scene_sha256"), scene_sha256_);
+    if (image_type_ == RenderImageType::kColorRgba8U) {
+      EXPECT_EQ(data_fields.at("image_type"), "color");
+    } else if (image_type_ == RenderImageType::kDepthDepth32F) {
+      EXPECT_EQ(data_fields.at("image_type"), "depth");
+    } else {  // image_type_ := RenderImageType::kLabel16I
+      EXPECT_EQ(data_fields.at("image_type"), "label");
+    }
+    const auto& intrinsics = camera_core_.intrinsics();
+    EXPECT_EQ(data_fields.at("width"), std::to_string(intrinsics.width()));
+    EXPECT_EQ(data_fields.at("height"), std::to_string(intrinsics.height()));
+    const auto& clipping = camera_core_.clipping();
+    EXPECT_EQ(data_fields.at("near"), std::to_string(clipping.near()));
+    EXPECT_EQ(data_fields.at("far"), std::to_string(clipping.far()));
+    EXPECT_EQ(data_fields.at("focal_x"), std::to_string(intrinsics.focal_x()));
+    EXPECT_EQ(data_fields.at("focal_y"), std::to_string(intrinsics.focal_y()));
+    EXPECT_EQ(data_fields.at("fov_x"), std::to_string(intrinsics.fov_x()));
+    EXPECT_EQ(data_fields.at("fov_y"), std::to_string(intrinsics.fov_y()));
+    EXPECT_EQ(data_fields.at("center_x"),
+              std::to_string(intrinsics.center_x()));
+    EXPECT_EQ(data_fields.at("center_y"),
+              std::to_string(intrinsics.center_y()));
+    // min_depth and max_depth should only be provided for depth renders.
+    if (image_type_ == RenderImageType::kDepthDepth32F) {
+      const auto& range = depth_range_.value();
+      EXPECT_EQ(data_fields.at("min_depth"), std::to_string(range.min_depth()));
+      EXPECT_EQ(data_fields.at("max_depth"), std::to_string(range.max_depth()));
+    } else {
+      EXPECT_EQ(data_fields.find("min_depth"), data_fields.end());
+      EXPECT_EQ(data_fields.find("max_depth"), data_fields.end());
+    }
+    EXPECT_EQ(data_fields.at("submit"), "Render");
+
+    // Make sure no extra fields are being added to data_fields.
+    std::set<std::string> data_fields_keys{
+        "scene_sha256", "image_type", "width",   "height", "near",
+        "far",          "focal_x",    "focal_y", "fov_x",  "fov_y",
+        "center_x",     "center_y",   "submit"};
+    if (image_type_ == RenderImageType::kDepthDepth32F) {
+      data_fields_keys.insert("min_depth");
+      data_fields_keys.insert("max_depth");
+    }
+    std::string unexpected_keys{""};
+    for (const auto& pair : data_fields) {
+      const auto& key = pair.first;
+      if (data_fields_keys.find(key) == data_fields_keys.end()) {
+        // no cover: these only execute if a test is failing.
+        // LCOV_EXCL_START
+        if (unexpected_keys.empty()) {
+          unexpected_keys = "Unexpected key(s) in data_fields: " + key;
+        } else {
+          unexpected_keys += ", " + key;
+        }
+        // LCOV_EXCL_STOP
+      }
+    }
+    EXPECT_EQ(unexpected_keys, "");
+
+    // Make sure the scene file path has been provided with the expected mime.
+    const auto& [path, mime] = file_fields.at("scene");
+    EXPECT_EQ(path, scene_path_);
+    EXPECT_EQ(mime, mime_type_);
+
+    // Only one file should be getting added.
+    EXPECT_EQ(file_fields.size(), 1);
+
+    // Fail the test so that no attempted image loading occurs.
+    HttpResponse ret;
+    ret.http_code = 500;
+    return ret;
+  }
+
+  const RenderCameraCore& camera_core_;
+  /* NOTE: do not store references for the data fields, EXPECT_EQ may not work
+   correctly for value comparisons. */
+  const RenderImageType image_type_;
+  const std::string scene_path_;
+  const std::string scene_sha256_;
+  const std::optional<std::string> mime_type_;
+  const std::optional<DepthRange> depth_range_;
+};
+
+using PostFormCallback_t = typename std::function<HttpResponse(
+    const std::string&, const data_map_t&, const file_map_t&)>;
+
+/* A proxy HttpService that can be cunstructed with an std::function to modify
+ the behavior of PostForm. */
+class ProxyService : public HttpService {
+ public:
+  explicit ProxyService(const PostFormCallback_t& callback)
+      : HttpService(), post_form_callback_{callback} {}
+
+  HttpResponse PostForm(const std::string& /* temp_directory */,
+                        const std::string& url, int32_t /* port */,
+                        const std::string& endpoint,
+                        const data_map_t& data_fields,
+                        const file_map_t& file_fields,
+                        bool /* verbose */ = false) override {
+    ThrowIfUrlInvalid(url);
+    ThrowIfEndpointInvalid(endpoint);
+    ThrowIfFilesMissing(file_fields);
+    return post_form_callback_(endpoint, data_fields, file_fields);
+  }
+
+  PostFormCallback_t post_form_callback_;
+};
+
+/* These tests are only for the various error conditions that can come up in
+ RenderOnServer.  They are tested linearly start to finish following the
+ implementation.  There are additional tests at the end to ensure that valid
+ images returned from the server (png and tiff) are accepted, however these
+ tests do *NOT* validate against image dimensions / content.  Image content
+ tests take place in Load{Color,Depth,Label}Image tests, these tests are just
+ for "round-trip" communications with the HttpService. */
+GTEST_TEST(RenderClient, RenderOnServer) {
+  /* NOTE: these values help ensure nothing actually gets sent over curl.  No
+   test should proceed with the default HttpServiceCurl, the HttpService backend
+   should be changed using client.SetHttpService before doing anything. */
+  const std::string url{"notarealserver"};
+  const int32_t port{8192};
+  const std::string render_endpoint{"no_render"};
+  const bool verbose{false};
+  const bool no_cleanup{false};
+
+  // Create a client and proxy HttpService creation helper.
+  RenderClient client{url, port, render_endpoint, verbose, no_cleanup};
+  const auto temp_dir_path = fs::path(client.temp_directory());
+
+  // Create a fake scene to "upload" to the "server" and fake response file.
+  const auto fake_scene_path = (temp_dir_path / "fake_scene.gltf").string();
+  std::ofstream fake_scene{fake_scene_path};
+  fake_scene << "This is not a real glTF scene!\n";
+  fake_scene.close();
+  // This value is from: echo 'This is not a real glTF scene!' | sha256sum
+  const auto fake_scene_sha256 =
+      "8985d0a8aec5a091dce05fef24ee2f3daaa20b4c0dbcd521f0217632c9001a4c";
+
+  /* Create some render camera instances to validate against.  Note that the
+   atypical values chosen for e.g., clipping or depth ranges is to ensure there
+   are no hard-coded or default values leaking in anywhere. */
+  const ColorRenderCamera color_camera{
+      {"proxy_render", {798, 247, M_PI_4}, {0.11, 111.111}, {}}, false};
+  const DepthRenderCamera depth_camera{color_camera.core(), {0.12, 21.12}};
+
+  {
+    // Forgetting to include the depth_range for a depth render should raise.
+    client.SetHttpService(std::make_unique<FailService>());
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.RenderOnServer(depth_camera.core(),
+                              RenderImageType::kDepthDepth32F, fake_scene_path),
+        "RenderOnServer: depth image render requested, but no depth_range was "
+        "provided.");
+
+    // Providing depth_range for non-depth should raise.
+    const auto expected_message =
+        "RenderOnServer: the depth_range parameter may only be provided when "
+        "the image_type is a depth image.";
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.RenderOnServer(color_camera.core(),
+                              RenderImageType::kColorRgba8U, fake_scene_path,
+                              std::nullopt, depth_camera.depth_range()),
+        expected_message);
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.RenderOnServer(color_camera.core(), RenderImageType::kLabel16I,
+                              fake_scene_path, std::nullopt,
+                              depth_camera.depth_range()),
+        expected_message);
+  }
+
+  {
+    /* Verify that the RenderClient::RenderOnServer adheres to the API contract
+     by populating the correct data and file fields.  Tests in this section
+     use DRAKE_EXPECTS_THROWS_MESSAGE all looking for the same error being
+     raised, as no image response is provided.  However, the bulk of the test
+     takes place in the assertions in FieldCheckService::PostForm. */
+    const auto expected_message = fmt::format(
+        "\\s*ERROR doing POST:\\s*/{0}\\s*"  // ERROR doing POST: /{endpoint}
+        "Server URL:\\s*{1}:{2}\\s*"         // Server URL:       {url}:{port}
+        "Service Message:\\s*None\\.\\s*"    // Service Message:  None.
+        "HTTP Code:\\s*500\\s*"              // Http Code:        {code}
+        "Server Message:\\s*None\\.\\s*",    // Server Message:   None.
+        render_endpoint, url, port);
+
+    // Check fields for a color render.
+    client.SetHttpService(std::make_unique<FieldCheckService>(
+        color_camera.core(), RenderImageType::kColorRgba8U, fake_scene_path,
+        fake_scene_sha256));
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.RenderOnServer(color_camera.core(),
+                              RenderImageType::kColorRgba8U, fake_scene_path),
+        expected_message);
+
+    /* Check fields for a depth render.  This test also includes a verification
+     that the provided mime_type is propagated correctly.  There is no special
+     reason for this to be checked with the depth render, it is just convenient
+     since a new HttpService is being set for the client. */
+    client.SetHttpService(std::make_unique<FieldCheckService>(
+        depth_camera.core(), RenderImageType::kDepthDepth32F, fake_scene_path,
+        fake_scene_sha256, "test/mime_type", depth_camera.depth_range()));
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.RenderOnServer(depth_camera.core(),
+                              RenderImageType::kDepthDepth32F, fake_scene_path,
+                              "test/mime_type", depth_camera.depth_range()),
+        expected_message);
+
+    // Check fields for a label render.
+    client.SetHttpService(std::make_unique<FieldCheckService>(
+        color_camera.core(), RenderImageType::kLabel16I, fake_scene_path,
+        fake_scene_sha256, std::nullopt, std::nullopt));
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.RenderOnServer(color_camera.core(), RenderImageType::kLabel16I,
+                              fake_scene_path),
+        expected_message);
+  }
+
+  {
+    /* These tests confirm the error reporting format from UrlWithPort without a
+     port and alternative urls. */
+    const std::vector<std::pair<std::string, int32_t>> url_port{
+        {"some_url", 0}, {"another_url", -1}, {"url_with_port", 200}};
+    for (const auto& [u, p] : url_port) {
+      const auto expected_message = fmt::format(
+          "\\s*ERROR doing POST:\\s*/{0}\\s*"
+          "Server URL:\\s*{1}\\s*"
+          "Service Message:\\s*FailService always fails\\.\\s*"
+          "HTTP Code:\\s*500\\s*"
+          "Server Message:\\s*None\\.\\s*",
+          render_endpoint, p > 0 ? fmt::format("{}:{}", u, p) : u);
+      RenderClient c{u, p, render_endpoint, verbose, no_cleanup};
+      const auto temp = fs::path(c.temp_directory());
+      c.SetHttpService(std::make_unique<FailService>());
+      DRAKE_EXPECT_THROWS_MESSAGE(
+          c.RenderOnServer(color_camera.core(), RenderImageType::kColorRgba8U,
+                           fake_scene_path),
+          expected_message);
+    }
+  }
+
+  // Trampoline helper to set the client HttpService.
+  const auto response_path = (temp_dir_path / "response.file").string();
+  auto set_proxy = [&](const PostFormCallback_t& callback) {
+    // Delete the response file if it exists to start clean on each test.
+    try {
+      fs::remove(response_path);
+      // no cover: this does not ever fail.
+      // LCOV_EXCL_START
+    } catch (...) {
+    }
+    // LCOV_EXCL_STOP
+    // Set the service with the provided callback.
+    client.SetHttpService(std::make_unique<ProxyService>(callback));
+  };
+
+  {
+    /* Test bad HttpResponse's that have a server message provided.  Previous
+     tests validating the FieldCheckService exception have already validated the
+     path that the HttpResponse.data_path is not populated.  Edge cases should
+     all produce 'None.' as the server message.
+     NOTE: file extensions do not matter. */
+    // NOTE: all tests using this must use http code 400.
+    const auto message_template = fmt::format(
+        "\\s*ERROR doing POST:\\s*/{0}\\s*"  // ERROR doing POST: /{endpoint}
+        "Server URL:\\s*{1}:{2}\\s*"         // Server URL:       {url}:{port}
+        "Service Message:\\s*None\\.\\s*"    // Service Message:  None.
+        "HTTP Code:\\s*400\\s*"              // Http Code:        {code}
+        "Server Message:\\s*{{}}\\s*",       // Server Message:   {message}
+        render_endpoint, url, port);
+
+    // Case 1: edge case, service populated data_path but file is length 0.
+    set_proxy([&](const std::string&, const data_map_t&, const file_map_t&) {
+      std::ofstream response{response_path};
+      response.close();
+      HttpResponse ret;
+      ret.http_code = 400;
+      ret.data_path = response_path;
+      return ret;
+    });
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.RenderOnServer(color_camera.core(),
+                              RenderImageType::kColorRgba8U, fake_scene_path),
+        fmt::format(message_template, "None\\."));
+
+    // Case 2: edge case, bad response but provided message "too long".
+    set_proxy([&](const std::string&, const data_map_t&, const file_map_t&) {
+      std::ofstream response{response_path};
+      // NOTE: this value is hard-coded in RenderClient::RenderOnServer.
+      for (int i = 0; i < 8192; ++i) response << '0';
+      response.close();
+      HttpResponse ret;
+      ret.http_code = 400;
+      ret.data_path = response_path;
+      return ret;
+    });
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.RenderOnServer(color_camera.core(), RenderImageType::kLabel16I,
+                              fake_scene_path),
+        fmt::format(message_template, "None\\."));
+
+    // Case 3: edge case, message provided of valid length but cannot be opened.
+    set_proxy([&](const std::string&, const data_map_t&, const file_map_t&) {
+      std::ofstream response{response_path};
+      response << "If only you could read me!\n";
+      response.close();
+      fs::permissions(response_path, fs::perms::all, fs::perm_options::remove);
+      HttpResponse ret;
+      ret.http_code = 400;
+      ret.data_path = response_path;
+      return ret;
+    });
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.RenderOnServer(color_camera.core(),
+                              RenderImageType::kColorRgba8U, fake_scene_path),
+        fmt::format(message_template, "None\\."));
+
+    // Case 4: server response that can be read.
+    const auto response_text = "You are not a valid request :p";
+    set_proxy([&](const std::string&, const data_map_t&, const file_map_t&) {
+      std::ofstream response{response_path};
+      response << response_text;
+      response.close();
+      HttpResponse ret;
+      ret.http_code = 400;
+      ret.data_path = response_path;
+      return ret;
+    });
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.RenderOnServer(color_camera.core(), RenderImageType::kLabel16I,
+                              fake_scene_path),
+        fmt::format(message_template, response_text));
+  }
+
+  {
+    // No file response from server should be reported correctly.
+    set_proxy([&](const std::string&, const data_map_t&, const file_map_t&) {
+      HttpResponse ret;
+      ret.http_code = 200;
+      return ret;
+    });
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.RenderOnServer(color_camera.core(),
+                              RenderImageType::kColorRgba8U, fake_scene_path);
+        ,
+        fmt::format(
+            "ERROR with POST /{} response from server, url={}:{}, HTTP "
+            "code=200: the server was supposed to respond with a file but did "
+            "not.",
+            render_endpoint, url, port));
+  }
+
+  {
+    // File response provided that does not exist should be reported correctly.
+    set_proxy([&](const std::string&, const data_map_t&, const file_map_t&) {
+      // NOTE: set_proxy deletes the file.
+      HttpResponse ret;
+      ret.http_code = 200;
+      ret.data_path = response_path;
+      return ret;
+    });
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.RenderOnServer(color_camera.core(), RenderImageType::kLabel16I,
+                              fake_scene_path),
+        fmt::format(
+            "ERROR with POST /{} response from service, url={}:{}, HTTP "
+            "code=200: the service responded with a file path '{}' but the "
+            "file does not exist.",
+            render_endpoint, url, port, response_path));
+  }
+
+  {
+    // File response cannot be loaded as image should be reported correctly.
+    set_proxy([&](const std::string&, const data_map_t&, const file_map_t&) {
+      std::ofstream response{response_path};
+      response << "I am not an image file!\n";
+      response.close();
+      HttpResponse ret;
+      ret.http_code = 200;
+      ret.data_path = response_path;
+      return ret;
+    });
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.RenderOnServer(color_camera.core(),
+                              RenderImageType::kColorRgba8U, fake_scene_path),
+        fmt::format(
+            "RenderClient: while trying to render the scene '{}' with a sha256 "
+            "hash of '{}', the file returned by the server saved in '{}' is "
+            "not understood as an image type that is supported.  Image types "
+            "attempted loading as: PNG, TIFF.",
+            fake_scene_path, fake_scene_sha256, response_path));
+  }
+
+  {
+    // Copy a "valid" PNG file and check that it is renamed.
+    set_proxy([&](const std::string&, const data_map_t&, const file_map_t&) {
+      auto box_png =
+          FindResourceOrThrow("drake/geometry/render/test/meshes/box.png");
+      fs::copy_file(box_png, response_path);
+      HttpResponse ret;
+      ret.http_code = 200;
+      ret.data_path = response_path;
+      return ret;
+    });
+    const auto expected_path =
+        fs::path(fake_scene_path).replace_extension(".png").string();
+    const auto response_png = client.RenderOnServer(
+        color_camera.core(), RenderImageType::kColorRgba8U, fake_scene_path);
+    EXPECT_EQ(response_png, expected_path);
+  }
+
+  {
+    /* Manufacture a "valid" (not the same width and height) TIFF file and check
+     that it is renamed. */
+    set_proxy([&](const std::string&, const data_map_t&, const file_map_t&) {
+      TestTiffGray32 gray_32{response_path, 16, 4};
+      HttpResponse ret;
+      ret.http_code = 200;
+      ret.data_path = response_path;
+      return ret;
+    });
+    const auto expected_path =
+        fs::path(fake_scene_path).replace_extension(".tiff").string();
+    const auto response_tiff = client.RenderOnServer(
+        color_camera.core(), RenderImageType::kColorRgba8U, fake_scene_path);
+    EXPECT_EQ(response_tiff, expected_path);
+  }
+
+  fs::remove_all(temp_dir_path);
+}
+
+GTEST_TEST(RenderClient, ComputeSha256) {
+  const std::string url{"127.0.0.1"};
+  const int32_t port{8000};
+  const std::string render_endpoint{"render"};
+  const bool verbose = false;
+  const bool no_cleanup = false;
+  RenderClient client{url, port, render_endpoint, verbose, no_cleanup};
+
+  {
+    // Failure case 1: provided input file does not exist.
+    const auto unlikely = "/unlikely/to/be/a.file";
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.ComputeSha256(unlikely),
+        fmt::format("ComputeSha256: input file '{}' does not exist.",
+                    unlikely));
+  }
+
+  {
+    // Failure case 2: sha256 cannot be computed.
+    const std::string bad_path = fs::path(client.temp_directory()) / "bad.file";
+    std::ofstream bad_file{bad_path};
+    bad_file << "contents should not matter.\n";
+    bad_file.close();
+    fs::permissions(bad_path, fs::perms::all, fs::perm_options::remove);
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.ComputeSha256(bad_path),
+        fmt::format(
+            "ComputeSha256: unable to compute hash: cannot open file '{}'.",
+            bad_path));
+    fs::remove(bad_path);
+  }
+
+  {
+    // Success case 1.
+    const std::string f1_path = fs::path(client.temp_directory()) / "f1.bin";
+    std::ofstream f1_file{f1_path};
+    f1_file << "some valuable data!\n";
+    f1_file.close();
+    // echo 'some valuable data!' | sha256sum
+    EXPECT_EQ(
+        "03cbafcd18635120cee6c8d51ac3534a315649627d822651b3d2b587e81ab6e5",
+        client.ComputeSha256(f1_path));
+    fs::remove(f1_path);
+
+    // Success case 2 (proof that different hashes returned).
+    const std::string f2_path = fs::path(client.temp_directory()) / "f2.bin";
+    std::ofstream f2_file{f2_path};
+    f2_file << "additional data that is also valuable?";
+    f2_file.close();
+    // echo -n 'additional data that is also valuable?' | sha256sum
+    EXPECT_EQ(
+        "d40433c78b8f35adf78d25bcc374ea9dbf42f96d85ff29a8d726fe37178878fe",
+        client.ComputeSha256(f2_path));
+    fs::remove(f2_path);
+  }
+}
+
+GTEST_TEST(RenderClient, RenameHttpServiceResponse) {
+  const std::string url{"127.0.0.1"};
+  const int32_t port{8000};
+  const std::string render_endpoint{"render"};
+  // Keep verbose and no_cleanup `true` to get coverage on log() calls.
+  const bool verbose = true;
+  const bool no_cleanup = true;
+  const RenderClient client{url, port, render_endpoint, verbose, no_cleanup};
+  const fs::path temp_dir = fs::path(client.temp_directory());
+  const std::string scene = temp_dir / "scene.gltf";
+  std::ofstream scene_file{scene};
+  scene_file << "not a real glTF scene!\n";
+  scene_file.close();
+  const auto unlikely = "/unlikely/to/be/a.file";
+
+  {
+    // Failure case 1: file to rename does not exist.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.RenameHttpServiceResponse(unlikely, scene, ".png"),
+        fmt::format("RenderClient: cannot rename '{}', file does not exist.",
+                    unlikely));
+
+    // Failure case 2: file to rename based off does not exist.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.RenameHttpServiceResponse(scene, unlikely, ".tiff"),
+        fmt::format(
+            "RenderClient: cannot rename '{0}' to '{1}' with extension '{2}': "
+            "'{1}' does not exist.",
+            scene, unlikely, ".tiff"));
+
+    // Failure case 3: destination file already exists.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.RenameHttpServiceResponse(scene, scene, ".gltf"),
+        fmt::format(
+            "RenderClient: refusing to rename '{}' to '{}', file already "
+            "exists!",
+            scene, scene));
+  }
+
+  {
+    /* Creates input scene and path for easy enumeration of extension rename
+     edge cases below. */
+    struct RenameResult {
+      RenameResult(const std::string response_data_path,
+                   std::string reference_path, const std::string extension,
+                   const std::string expected)
+          : response_data_path_{response_data_path},
+            reference_path_{reference_path},
+            extension_{extension},
+            expected_{expected} {
+        std::ofstream reference_path_file{reference_path_};
+        reference_path_file << "input_scene with contents.\n";
+        reference_path_file.close();
+
+        std::ofstream response_data_path_file{response_data_path_};
+        response_data_path_file << "path with contents.\n";
+        response_data_path_file.close();
+      }
+
+      const std::string response_data_path_;
+      const std::string reference_path_;
+      const std::string extension_;
+      const std::string expected_;
+    };
+
+    /* NOTE: files are created, not deleted, do not reuse names.
+     Additionally, do not test for no extension input_scene + ext="", this is
+     already tested for above as an expected exception. */
+    const fs::path sub_dir = temp_dir / "sub_directory";
+    fs::create_directory(sub_dir);
+    const std::vector<RenameResult> renames{
+        // All components have extensions.
+        {temp_dir / "path_0.bin", temp_dir / "input_0.gltf", ".png",
+         temp_dir / "input_0.png"},
+        // Input scene does not have a file extension.
+        {temp_dir / "path_1.curl", temp_dir / "input_1", ".foo",
+         temp_dir / "input_1.foo"},
+        // Input path does not have an extension.
+        {temp_dir / "path_2", temp_dir / "input_2.gltf", ".tiff",
+         temp_dir / "input_2.tiff"},
+        // Input and path do not have an extension.
+        {temp_dir / "path_3", temp_dir / "input_3", ".zip",
+         temp_dir / "input_3.zip"},
+        // Empty extension is allowed.
+        {temp_dir / "path_4.txt", temp_dir / "input_4.txt", "",
+         temp_dir / "input_4"},
+        // Source is in different directory.
+        {sub_dir / "path_5.bin", temp_dir / "input_5.gltf", ".jpg",
+         temp_dir / "input_5.jpg"}};
+    for (const auto& r : renames) {
+      /* Before renaming, response_data_path_ and reference_path_ exist, and
+       expected_ does not. */
+      EXPECT_TRUE(fs::is_regular_file(r.response_data_path_));
+      EXPECT_TRUE(fs::is_regular_file(r.reference_path_));
+      EXPECT_FALSE(fs::is_regular_file(r.expected_));
+
+      // Renaming the file should result in our expected value.
+      const auto result = client.RenameHttpServiceResponse(
+          r.response_data_path_, r.reference_path_, r.extension_);
+      EXPECT_EQ(result, r.expected_);
+      EXPECT_EQ(fs::path(result).extension(), r.extension_);
+
+      /* After renaming, response_data_path_ should no longer exist, and
+       expected_ should. */
+      EXPECT_TRUE(fs::is_regular_file(r.reference_path_));
+      EXPECT_FALSE(fs::is_regular_file(r.response_data_path_));
+      EXPECT_TRUE(fs::is_regular_file(r.expected_));
+    }
+  }
+
+  fs::remove_all(temp_dir);
+}
+
+GTEST_TEST(RenderClient, LoadColorImage) {
+  const std::string url{"127.0.0.1"};
+  const int32_t port{8000};
+  const std::string render_endpoint{"render"};
+  const bool verbose = false;
+  const bool no_cleanup = false;
+  const RenderClient client{url, port, render_endpoint, verbose, no_cleanup};
+  const fs::path temp_dir = fs::path(client.temp_directory());
+
+  // NOTE: keep the images small to reduce test overhead.
+  constexpr int width = 222;
+  constexpr int height = 111;
+  ImageRgba8U drake_image{width, height};
+  auto zero_drake_image = [&drake_image]() {
+    for (int j = 0; j < height; ++j) {
+      for (int i = 0; i < width; ++i) {
+        drake_image.at(i, j)[0] = 0;  // r
+        drake_image.at(i, j)[1] = 0;  // g
+        drake_image.at(i, j)[2] = 0;  // b
+        drake_image.at(i, j)[3] = 0;  // a
+      }
+    }
+  };
+
+  {
+    // Failure case 1: not a valid PNG file.
+    const auto expected_message = "RenderClient: cannot load '{}' as PNG.";
+    const auto unlikely = "/not/likely/a.png";
+    DRAKE_EXPECT_THROWS_MESSAGE(client.LoadColorImage(unlikely, &drake_image),
+                                fmt::format(expected_message, unlikely));
+
+    const std::string fake_png_path = temp_dir / "fake.png";
+    std::ofstream fake_png{fake_png_path};
+    fake_png << "not a valid png file.\n";
+    fake_png.close();
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.LoadColorImage(fake_png_path, &drake_image),
+        fmt::format(expected_message, fake_png_path));
+    fs::remove(fake_png_path);
+  }
+
+  {
+    /* Failure case 2: wrong image dimensions on file.  drake_image should not
+     be accessed especially when the file dimensions are bigger. */
+    const std::vector<std::pair<int, int>> width_height{
+        {width, height / 2}, {width + 12, height}, {width * 2, height * 2}};
+    for (const auto& [w, h] : width_height) {
+      const std::string path = temp_dir / fmt::format("rgb_{}_{}.png", w, h);
+      TestPngRgb8 rgb{path, w, h};
+      DRAKE_EXPECT_THROWS_MESSAGE(
+          client.LoadColorImage(path, &drake_image),
+          fmt::format("RenderClient: expected to import "
+                      "\\(width={},height={}\\) from the "
+                      "file '{}', but got \\(width={},height={}\\).",
+                      width, height, path, w, h));
+      fs::remove(path);
+    }
+  }
+
+  {
+    // Failure case 3: number of channels not equal to 3 or 4.
+    const std::string path = temp_dir / "gray.png";
+    TestPngGray16 gray{path, width, height};
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.LoadColorImage(path, &drake_image),
+        fmt::format(
+            "RenderClient: loaded PNG image from '{}' has 1 channel\\(s\\), "
+            "but either 3 \\(RGB\\) or 4 \\(RGBA\\) are required for color "
+            "images.",
+            path));
+    fs::remove(path);
+  }
+
+  {
+    // Failure case 4: right number of channels, but 16 bit color.
+    const std::string path = temp_dir / "rgb_16_bit.png";
+    TestPngRgb16 rgb_16{path, width, height};
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.LoadColorImage(path, &drake_image),
+        fmt::format(
+            "RenderClient: loaded PNG image from '{}' has a channel size in "
+            "bytes of 2, but only RGB and RGBA uchar \\(channel size=1\\) "
+            "images are supported.",
+            path));
+    fs::remove(path);
+  }
+
+  {
+    // Loading a three channel (RGB) png file should work as expected.
+    zero_drake_image();
+    const auto rgb_png_path = temp_dir / "rgb.png";
+    TestPngRgb8 rgb{rgb_png_path, width, height};
+    DRAKE_EXPECT_NO_THROW(client.LoadColorImage(rgb_png_path, &drake_image));
+    TestPngRgb8::CornerCheckColor(drake_image);
+    TestPngRgb8::FullImageCheckColor(drake_image);
+    fs::remove(rgb_png_path);
+  }
+
+  {
+    // Loading a four channel (RGBA) png file should work as expected.
+    zero_drake_image();
+    const auto rgba_png_path = temp_dir / "rgba.png";
+    TestPngRgba8 rgba{rgba_png_path, width, height};
+    DRAKE_EXPECT_NO_THROW(client.LoadColorImage(rgba_png_path, &drake_image));
+    TestPngRgba8::CornerCheckColor(drake_image);
+    TestPngRgba8::FullImageCheckColor(drake_image);
+    fs::remove(rgba_png_path);
+  }
+}
+
+GTEST_TEST(RenderClient, LoadDepthImage) {
+  const std::string url{"127.0.0.1"};
+  const int32_t port{8000};
+  const std::string render_endpoint{"render"};
+  const bool verbose = false;
+  const bool no_cleanup = false;
+  const RenderClient client{url, port, render_endpoint, verbose, no_cleanup};
+  const fs::path temp_dir = fs::path(client.temp_directory());
+
+  // NOTE: keep the images small to reduce test overhead.
+  constexpr int width = 222;
+  constexpr int height = 111;
+  ImageDepth32F drake_image{width, height};
+  auto zero_drake_image = [&drake_image]() {
+    for (int j = 0; j < height; ++j) {
+      for (int i = 0; i < width; ++i) {
+        drake_image.at(i, j)[0] = 0;
+      }
+    }
+  };
+
+  {
+    // Failure case 1: not a valid TIFF file.
+    const auto expected_message = "RenderClient: cannot load '{}' as TIFF.";
+    const auto unlikely = "/not/likely/a.tiff";
+    DRAKE_EXPECT_THROWS_MESSAGE(client.LoadDepthImage(unlikely, &drake_image),
+                                fmt::format(expected_message, unlikely));
+
+    const std::string fake_tiff_path = temp_dir / "fake.tiff";
+    std::ofstream fake_tiff{fake_tiff_path};
+    fake_tiff << "not a valid tiff file.\n";
+    fake_tiff.close();
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.LoadDepthImage(fake_tiff_path, &drake_image),
+        fmt::format(expected_message, fake_tiff_path));
+    fs::remove(fake_tiff_path);
+  }
+
+  {
+    /* Failure case 2: wrong image dimensions on file.  drake_image should not
+     be accessed especially when the file dimensions are bigger. */
+    const std::vector<std::pair<int, int>> width_height{
+        {width, height / 2}, {width + 12, height}, {width * 2, height * 2}};
+    for (const auto& [w, h] : width_height) {
+      const std::string path =
+          temp_dir / fmt::format("gray_16_{}_{}.tiff", w, h);
+      TestTiffGray16 gray{path, w, h};
+      DRAKE_EXPECT_THROWS_MESSAGE(
+          client.LoadDepthImage(path, &drake_image),
+          fmt::format("RenderClient: expected to import "
+                      "\\(width={},height={}\\) from the "
+                      "file '{}', but got \\(width={},height={}\\).",
+                      width, height, path, w, h));
+      fs::remove(path);
+    }
+  }
+
+  {
+    // Failure case 3: number of channels not equal to 1.
+    const std::string path = temp_dir / "rgb.tiff";
+    TestTiffRgb32 rgb{path, width, height};
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.LoadDepthImage(path, &drake_image),
+        fmt::format(
+            "RenderClient: loaded TIFF image from '{}' has 3 channels, but "
+            "only 1 is allowed for depth images.",
+            path));
+    fs::remove(path);
+  }
+
+  {
+    // Failure case 4: right number of channels, but wrong bit depth.
+    const std::string path = temp_dir / "gray_8.tiff";
+    TestTiffGray8 gray_8{path, width, height};
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.LoadDepthImage(path, &drake_image),
+        fmt::format(
+            "RenderClient: loaded TIFF image from '{}' did not have floating "
+            "point data, but float TIFF is required for depth images.",
+            path));
+    fs::remove(path);
+  }
+
+  {
+    // Loading a single channel 32 bit tiff file should work as expected.
+    zero_drake_image();
+    const auto gray_32_tiff_path = temp_dir / "gray_32.tiff";
+    TestTiffGray32 gray_32{gray_32_tiff_path, width, height};
+    DRAKE_EXPECT_NO_THROW(
+        client.LoadDepthImage(gray_32_tiff_path, &drake_image));
+    TestTiffGray32::CornerCheck(drake_image);
+    TestTiffGray32::FullImageCheck(drake_image);
+    fs::remove(gray_32_tiff_path);
+  }
+}
+
+GTEST_TEST(RenderClient, LoadLabelImage) {
+  const std::string url{"127.0.0.1"};
+  const int32_t port{8000};
+  const std::string render_endpoint{"render"};
+  const bool verbose = false;
+  const bool no_cleanup = true;
+  const RenderClient client{url, port, render_endpoint, verbose, no_cleanup};
+  const fs::path temp_dir = fs::path(client.temp_directory());
+
+  // NOTE: keep the images small to reduce test overhead.
+  constexpr int width = 222;
+  constexpr int height = 111;
+  ImageLabel16I drake_image{width, height};
+  auto zero_drake_image = [&drake_image]() {
+    for (int j = 0; j < height; ++j) {
+      for (int i = 0; i < width; ++i) {
+        drake_image.at(i, j)[0] = 0;
+      }
+    }
+  };
+
+  {
+    // Failure case 1: not a valid PNG file.
+    const auto expected_message = "RenderClient: cannot load '{}' as PNG.";
+    const auto unlikely = "/not/likely/a.png";
+    DRAKE_EXPECT_THROWS_MESSAGE(client.LoadLabelImage(unlikely, &drake_image),
+                                fmt::format(expected_message, unlikely));
+
+    const std::string fake_png_path = temp_dir / "fake.png";
+    std::ofstream fake_png{fake_png_path};
+    fake_png << "not a valid png file.\n";
+    fake_png.close();
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.LoadLabelImage(fake_png_path, &drake_image),
+        fmt::format(expected_message, fake_png_path));
+    fs::remove(fake_png_path);
+  }
+
+  {
+    /* Failure case 2: wrong image dimensions on file.  drake_image should not
+     be accessed especially when the file dimensions are bigger. */
+    const std::vector<std::pair<int, int>> width_height{
+        {width, height / 2}, {width + 12, height}, {width * 2, height * 2}};
+    for (const auto& [w, h] : width_height) {
+      const std::string path = temp_dir / fmt::format("label_{}_{}.png", w, h);
+      TestPngGray16 rgb{path, w, h};
+      DRAKE_EXPECT_THROWS_MESSAGE(
+          client.LoadLabelImage(path, &drake_image),
+          fmt::format("RenderClient: expected to import "
+                      "\\(width={},height={}\\) from the "
+                      "file '{}', but got \\(width={},height={}\\).",
+                      width, height, path, w, h));
+      fs::remove(path);
+    }
+  }
+
+  {
+    // Failure case 3: number of channels not equal to 1.
+    const std::string path = temp_dir / "rgb.png";
+    TestPngRgb8 rgb{path, width, height};
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.LoadLabelImage(path, &drake_image),
+        fmt::format(
+            "RenderClient: loaded PNG image from '{}' has 3 channels, but only "
+            "1 is allowed for label images.",
+            path));
+    fs::remove(path);
+  }
+
+  {
+    // Failure case 4: right number of channels, but 16 bit color.
+    const std::string path = temp_dir / "gray_8_bit.png";
+    TestPngGray8 gray_8{path, width, height};
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        client.LoadLabelImage(path, &drake_image),
+        fmt::format(
+            "RenderClient: loaded PNG image from '{}' did not have ushort "
+            "data, but single channel ushort PNG is required for label images.",
+            path));
+    fs::remove(path);
+  }
+
+  {
+    // Loading a 16 bit label image file should work as expected.
+    zero_drake_image();
+    const auto label_path = temp_dir / "label.png";
+    TestPngGray16 label_image{label_path, width, height};
+    DRAKE_EXPECT_NO_THROW(client.LoadLabelImage(label_path, &drake_image));
+    TestPngGray16::CornerCheckGray(drake_image);
+    TestPngGray16::FullImageCheckGray(drake_image);
+  }
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/dev/test_utilities/BUILD.bazel
+++ b/geometry/render/dev/test_utilities/BUILD.bazel
@@ -1,0 +1,49 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+    "drake_cc_package_library",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+drake_cc_package_library(
+    name = "test_utilities",
+    testonly = 1,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":test_png",
+        ":test_tiff",
+    ],
+)
+
+drake_cc_library(
+    name = "test_png",
+    testonly = 1,
+    srcs = ["test_png.cc"],
+    hdrs = ["test_png.h"],
+    deps = [
+        "//common:unused",
+        "//systems/sensors:image",
+        "@gtest//:without_main",
+        "@libpng",
+    ],
+)
+
+drake_cc_library(
+    name = "test_tiff",
+    testonly = 1,
+    srcs = ["test_tiff.cc"],
+    hdrs = ["test_tiff.h"],
+    deps = [
+        "//systems/sensors:image",
+        "@gtest//:without_main",
+        "@libtiff",
+    ],
+)
+
+add_lint_tests()

--- a/geometry/render/dev/test_utilities/test_png.cc
+++ b/geometry/render/dev/test_utilities/test_png.cc
@@ -1,0 +1,200 @@
+#include "drake/geometry/render/dev/test_utilities/test_png.h"
+
+#include <limits>
+
+#include <libpng/png.h>
+
+#include "drake/common/unused.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+
+namespace {
+
+using systems::sensors::ImageRgba8U;
+
+// Return the `color_type` for `png_set_IHDR`.
+template <int channels>
+int ColorType() {
+  static_assert(channels == 1 || channels == 3 || channels == 4,
+                "Only Gray, RGB, and RGBA supported.");
+  if constexpr (channels == 1) {
+    return PNG_COLOR_TYPE_GRAY;
+  } else if constexpr (channels == 3) {
+    return PNG_COLOR_TYPE_RGB;
+  } else {  // channels := 4
+    return PNG_COLOR_TYPE_RGB_ALPHA;
+  }
+}
+
+}  // namespace
+
+template <int channels, int bit_depth>
+TestPng<channels, bit_depth>::TestPng(const std::string& path, int width,
+                                      int height)
+    : path_{path}, width_{width}, height_{height} {
+  /* See the docs:
+   http://www.libpng.org/pub/png/libpng-1.0.3-manual.html
+
+   If something goes wrong, throw an exception to fail the test.  Each is
+   marked to exclude coverage as they do not happen in normal tests. */
+  FILE* fp = fopen(path.c_str(), "wb");
+  if (fp == nullptr) {
+    // LCOV_EXCL_START
+    throw std::runtime_error("Could not create FILE* for png.");
+    // LCOV_EXCL_STOP
+  }
+  png_structp png_ptr =
+      png_create_write_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+  if (png_ptr == nullptr) {
+    // LCOV_EXCL_START
+    fclose(fp);
+    throw std::runtime_error("Could not create png_ptr for png.");
+    // LCOV_EXCL_STOP
+  }
+  png_infop info_ptr = png_create_info_struct(png_ptr);
+  if (!info_ptr) {
+    // LCOV_EXCL_START
+    png_destroy_write_struct(&png_ptr, static_cast<png_infopp>(nullptr));
+    fclose(fp);
+    throw std::runtime_error("Error creating info_ptr for png.");
+    // LCOV_EXCL_STOP
+  }
+
+  // Error callback for libpng.
+  if (setjmp(png_jmpbuf(png_ptr))) {
+    // LCOV_EXCL_START
+    png_destroy_write_struct(&png_ptr, &info_ptr);
+    fclose(fp);
+    throw std::runtime_error("Critical error trying to write png.");
+    // LCOV_EXCL_STOP
+  }
+
+  // Setup and write out the header information.
+  png_init_io(png_ptr, fp);
+  png_set_IHDR(png_ptr, info_ptr, width_, height_, bit_depth,
+               ColorType<channels>(), PNG_INTERLACE_NONE,
+               PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
+  png_write_info(png_ptr, info_ptr);
+
+  /* Populate the pixel data.  See constructor comments.
+   NOTE: do not use png_set_filler! */
+  if (bit_depth > 8) png_set_swap(png_ptr);
+  ChannelType* row_data[height_];
+  ChannelType gray{kGrayStart};
+  ChannelType red{kRedStart};
+  ChannelType green{kGreenStart};
+  ChannelType blue{kBlueStart};
+  ChannelType alpha{kAlphaStart};
+  /* Due to the template, and this method supporting gray, RGB, and RGBA, we
+   must mark them as "unused" since depending on the template a given variable
+   may not be used in the loop. */
+  unused(gray);
+  unused(red);
+  unused(green);
+  unused(blue);
+  unused(alpha);
+  for (int j = 0; j < height_; ++j) {
+    row_data[j] = static_cast<ChannelType*>(
+        png_malloc(png_ptr, png_get_rowbytes(png_ptr, info_ptr)));
+    ChannelType* row_ptr = row_data[j];
+    for (int i = 0; i < width_; ++i) {
+      for (int k = 0; k < channels; ++k) {
+        if constexpr (channels == 1) {
+          *row_ptr++ = TestPngValue(&gray);
+        } else if constexpr (channels == 3 || channels == 4) {
+          if (k == 0) {
+            *row_ptr++ = TestPngValue(&red);
+          } else if (k == 1) {
+            *row_ptr++ = TestPngValue(&green);
+          } else if (k == 2) {
+            *row_ptr++ = TestPngValue(&blue);
+          } else if (k == 3) {
+            *row_ptr++ = TestPngValue(&alpha);
+          }
+        }
+      }
+    }
+  }
+  // NOTE: reinterpret_cast is needed for uint16_t data.
+  png_write_rows(png_ptr, reinterpret_cast<png_bytepp>(row_data), height);
+
+  // Finalize the png image.
+  png_write_end(png_ptr, info_ptr);
+  for (int j = 0; j < height_; ++j) {
+    png_free(png_ptr, row_data[j]);
+  }
+  png_destroy_write_struct(&png_ptr, &info_ptr);
+  fclose(fp);
+}
+
+template <int channels, int bit_depth>
+typename TestPng<channels, bit_depth>::ChannelType
+TestPng<channels, bit_depth>::TestPngValue(ChannelType* current) {
+  const ChannelType ret = *current;
+  *current = static_cast<ChannelType>(
+      (static_cast<uint32_t>(*current) + static_cast<uint32_t>(1)) %
+      static_cast<uint32_t>(std::numeric_limits<ChannelType>::max()));
+  return ret;
+}
+
+template <int channels, int bit_depth>
+void TestPng<channels, bit_depth>::CornerCheckColor(const ImageRgba8U& image) {
+  constexpr bool source_had_alpha = channels == 4;
+  // Safeguard against incorrect usage of this function with non color types.
+  EXPECT_TRUE(channels == 3 || channels == 4);
+
+  EXPECT_EQ(image.at(0, 0)[0], kRedStart);
+  EXPECT_EQ(image.at(0, 0)[1], kGreenStart);
+  EXPECT_EQ(image.at(0, 0)[2], kBlueStart);
+  // For RGBA, use the expected value.  RGB, alpha is padded with 255.
+  if constexpr (source_had_alpha) {
+    EXPECT_EQ(image.at(0, 0)[3], kAlphaStart);
+  } else {
+    EXPECT_EQ(image.at(0, 0)[3], kAlphaPad);
+  }
+}
+
+template <int channels, int bit_depth>
+void TestPng<channels, bit_depth>::FullImageCheckColor(
+    const ImageRgba8U& image) {
+  constexpr bool source_had_alpha = channels == 4;
+  // Safeguard against incorrect usage of this function with non color types.
+  EXPECT_TRUE(channels == 3 || channels == 4);
+
+  int n_good{0};
+  const int n_expected = image.width() * image.height() * 4;
+  ChannelType red{kRedStart};
+  ChannelType green{kGreenStart};
+  ChannelType blue{kBlueStart};
+  ChannelType alpha{kAlphaStart};
+  unused(alpha);  // Due to template, not used for channels == 3 (RGB).
+  for (int j = 0; j < image.height(); ++j) {
+    for (int i = 0; i < image.width(); ++i) {
+      n_good += static_cast<int>(image.at(i, j)[0] == TestPngValue(&red));
+      n_good += static_cast<int>(image.at(i, j)[1] == TestPngValue(&green));
+      n_good += static_cast<int>(image.at(i, j)[2] == TestPngValue(&blue));
+      // For RGBA, use the expected value.  RGB, alpha is padded with 255.
+      if (source_had_alpha) {
+        n_good += static_cast<int>(image.at(i, j)[3] == TestPngValue(&alpha));
+      } else {
+        n_good += static_cast<int>(image.at(i, j)[3] == kAlphaPad);
+      }
+    }
+  }
+  EXPECT_EQ(n_good, n_expected);
+}
+
+// Instantiate the templates that test cases need.
+template class TestPng<3, 8>;
+template class TestPng<4, 8>;
+template class TestPng<1, 16>;
+template class TestPng<3, 16>;
+template class TestPng<1, 8>;
+
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/dev/test_utilities/test_png.h
+++ b/geometry/render/dev/test_utilities/test_png.h
@@ -1,0 +1,174 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "drake/systems/sensors/image.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+
+// Type trait for TestPng image data underlying type, similar to ImageTraits.
+template <int bit_depth>
+struct TestPngTraits {
+  // Compile error for unspecialized use.
+};
+
+template <>
+struct TestPngTraits<8> {
+  using ChannelType = uint8_t;
+};
+
+template <>
+struct TestPngTraits<16> {
+  using ChannelType = uint16_t;
+};
+
+/* On construction, create a PNG with some arbitrary but non-zero values.  Only
+ supports creating single channel, three channel (RGB), or 4 channel (RGBA) PNG
+ images.  To help validate that the image coordinate system is being set
+ correctly (which corner is "lower left") we create an "image" that has
+ "increasing values" (modulo the maximum value for ChannelType) by pixel
+ channel.  For example, with an RGB image, the pixels start as:
+
+ - (0, 0): [kRedStart, kGreenStart, kBlueStart]
+ - (0, 1): [(kRedStart+1) % 255, (kGreenStart+1) % 255, (kBlueStart+1) % 255]
+
+ For a 16 bit gray image,
+
+ - (0, 0): kGrayStart
+ - (0, 1): (kGrayStart+1) % 65535
+
+ This enables testing below to always know what the first pixel value should be
+ at coordinate (0, 0).  The tests for image load verification rely on the
+ pattern created in the constructor here, changing the pattern requires
+ updating the tests as well.
+
+ Tip: if a test image is desired to be viewed, run tests with --sandbox_debug
+ so that the temporary files are not deleted.  Note that `no_cleanup` needs to
+ be set to `true` for a test case, and each test usually removes the image
+ with `fs::remove` so these will need to be updated to keep the image. */
+template <int channels, int bit_depth>
+class TestPng {
+ public:
+  static_assert(channels == 1 || channels == 3 || channels == 4,
+                "TestPng <channels> must be 1, 3, or 4");
+  static_assert(bit_depth == 8 || bit_depth == 16,
+                "TestPng <bit_depth> must be 8 or 16");
+  static_assert((channels == 1 && bit_depth == 16) ||      // 16 bit gray
+                    (channels == 3 && bit_depth == 8) ||   // 8 bit RGB
+                    (channels == 4 && bit_depth == 8) ||   // 8 bit RGBA
+                    (channels == 3 && bit_depth == 16) ||  // 16 bit RGB
+                    (channels == 1 && bit_depth == 8),     // 8 bit gray
+                "TestPng: unsupported <channels, bit_depth> combination.");
+
+  // Data type to allocate for memory, either uint8_t or uint16_t.
+  using ChannelType = typename TestPngTraits<bit_depth>::ChannelType;
+  static_assert(
+      std::is_same_v<ChannelType, uint8_t> ||
+          std::is_same_v<ChannelType, uint16_t>,
+      "TestPng: only uint8_t and uint16_t channel types are supported.");
+
+  // For when writing a color image.
+  static constexpr ChannelType kRedStart = static_cast<ChannelType>(50);
+  static constexpr ChannelType kGreenStart = static_cast<ChannelType>(100);
+  static constexpr ChannelType kBlueStart = static_cast<ChannelType>(150);
+  static constexpr ChannelType kAlphaStart = static_cast<ChannelType>(0);
+
+  // For testing against RGB, alpha should be padded to 255.
+  static constexpr ChannelType kAlphaPad = static_cast<ChannelType>(255);
+
+  // For when writing a single channel image.
+  static constexpr ChannelType kGrayStart = static_cast<ChannelType>(0);
+
+  /* Create a TIFF image at the specified path with dimensions width x height,
+   generating the pattern described on the class documentation.  User is
+   responsible for deleting the file after it is created. */
+  TestPng(const std::string& path, int width, int height);
+
+  /* Returns `current` value, but also increments `current` by 1.  If increasing
+   by 1 would put `current` out of bounds for the numeric limits of ChannelType,
+   current will be reset to 0.
+
+   Convenience method for loop bodies so that the increase and bounds check do
+   not need to be repeated in every case (e.g., red, green, blue, alpha). */
+  static ChannelType TestPngValue(ChannelType* current);
+
+  /* If the image coordinates are wrong for loading, this test will fail with
+   actual test information being reported in the failure.  Only to be used for
+   channels == 3 (RGB) or channels == 4 (RGBA). */
+  static void CornerCheckColor(const systems::sensors::ImageRgba8U& image);
+
+  /* Tests all the pixels in the test image, but error reporting is not helpful
+   in identifying what was wrong where.  Only to be used for channels == 3
+   (RGB) or channels == 4 (RGBA).*/
+  static void FullImageCheckColor(const systems::sensors::ImageRgba8U& image);
+
+  /* If the image coordinates are wrong for loading, this test will fail with
+   actual test information being reported in the failure.  Only to be used for
+   channels == 1 (gray). */
+  template <class DrakeImage>
+  static void CornerCheckGray(const DrakeImage& image) {
+    // TODO(svenevs): support for ImageDepth32f can be added.
+    static_assert(std::is_same_v<DrakeImage, systems::sensors::ImageLabel16I>,
+                  "Unexpected drake image type for TestPng::CornerCheckGray.");
+    using DestType = typename DrakeImage::T;
+    // Safeguard against incorrect usage of this function with non gray types.
+    EXPECT_EQ(channels, 1);
+
+    EXPECT_EQ(image.at(0, 0)[0], static_cast<DestType>(kGrayStart));
+  }
+
+  /* Tests all the pixels in the test image, but error reporting is not helpful
+   in identifying what was wrong where. */
+  template <class DrakeImage>
+  static void FullImageCheckGray(const DrakeImage& image) {
+    // TODO(svenevs): support for ImageDepth32f can be added.
+    static_assert(std::is_same_v<DrakeImage, systems::sensors::ImageLabel16I>,
+                  "Unexpected drake image type for TestPng::CornerCheckGray.");
+    using DestType = typename DrakeImage::T;
+    // Safeguard against incorrect usage of this function with non gray types.
+    EXPECT_EQ(channels, 1);
+
+    int n_good{0};
+    const int n_expected = image.width() * image.height();
+    ChannelType gray{kGrayStart};
+    for (int j = 0; j < image.height(); ++j) {
+      for (int i = 0; i < image.width(); ++i) {
+        n_good += static_cast<int>(image.at(i, j)[0] ==
+                                   static_cast<DestType>(TestPngValue(&gray)));
+      }
+    }
+    EXPECT_EQ(n_good, n_expected);
+  }
+
+  const std::string path_;
+  const int width_;
+  const int height_;
+};
+
+// Instantiate them once in the source file.
+extern template class TestPng<3, 8>;   // TestPngRgb8
+extern template class TestPng<4, 8>;   // TestPngRgba8
+extern template class TestPng<1, 16>;  // TestPngGray16
+/* NOTE: these do not generate the same expected patterns, these are only used
+ to generate a file to check that loading with the wrong bit width / channel
+ type raise an error. */
+extern template class TestPng<3, 16>;  // TestPngRgb16
+extern template class TestPng<1, 8>;   // TestPngGray8
+
+// Declare nice type names for test cases to use.
+using TestPngRgb8 = TestPng<3, 8>;
+using TestPngRgba8 = TestPng<4, 8>;
+using TestPngGray16 = TestPng<1, 16>;
+using TestPngRgb16 = TestPng<3, 16>;
+using TestPngGray8 = TestPng<1, 8>;
+
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/dev/test_utilities/test_tiff.cc
+++ b/geometry/render/dev/test_utilities/test_tiff.cc
@@ -1,0 +1,83 @@
+#include "drake/geometry/render/dev/test_utilities/test_tiff.h"
+
+#include <limits>
+#include <vector>
+
+#include <tiffio.h>
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+
+template <int channels, int bit_depth>
+TestTiff<channels, bit_depth>::TestTiff(const std::string& path, int width,
+                                        int height)
+    : path_{path}, width_{width}, height_{height} {
+  /* See the docs:
+    http://www.libtiff.org/libtiff.html
+
+    If something goes wrong, throw an exception to fail the test.  Each is
+    marked to exclude coverage as they do not happen in normal tests. */
+  TIFF* tiff = TIFFOpen(path_.c_str(), "w");
+  if (tiff == nullptr) {
+    // LCOV_EXCL_START
+    throw std::runtime_error("Could not create TIFF* for tiff.");
+    // LCOV_EXCL_STOP
+  }
+
+  TIFFSetField(tiff, TIFFTAG_IMAGEWIDTH, width_);
+  TIFFSetField(tiff, TIFFTAG_IMAGELENGTH, height_);
+  TIFFSetField(tiff, TIFFTAG_SAMPLESPERPIXEL, channels);
+  TIFFSetField(tiff, TIFFTAG_BITSPERSAMPLE, sizeof(ChannelType) * 8);
+  TIFFSetField(tiff, TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT);
+  /* Extra fields by trial and error using `tiffinfo` and `gimp` to read the
+    file after writing.  Useful table with links to the field meanings:
+    https://www.loc.gov/preservation/digital/formats/content/tiff_tags.shtml */
+  if constexpr (channels == 1) {
+    TIFFSetField(tiff, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK);
+  } else if constexpr (channels == 3) {
+    TIFFSetField(tiff, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+    TIFFSetField(tiff, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_RGB);
+  }
+  if constexpr (std::is_same_v<ChannelType, uint8_t> ||
+                std::is_same_v<ChannelType, uint16_t>) {
+    TIFFSetField(tiff, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_UINT);
+  } else if constexpr (std::is_same_v<ChannelType, float>) {
+    TIFFSetField(tiff, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_IEEEFP);
+  }
+
+  // First, populate an image buffer.  Then use libtiff to write to disk.
+  std::vector<ChannelType> image;
+  for (int idx = 0; idx < width_ * height_ * channels; ++idx) {
+    image.emplace_back(TestTiffValue(idx));
+  }
+  for (int j = 0; j < height_; ++j) {
+    const int scan_id = j * width_ * channels;
+    TIFFWriteScanline(tiff, static_cast<void*>(&image[scan_id]), j, 0);
+  }
+  TIFFClose(tiff);
+}
+
+template <int channels, int bit_depth>
+typename TestTiff<channels, bit_depth>::ChannelType
+TestTiff<channels, bit_depth>::TestTiffValue(int idx) {
+  if constexpr (std::is_same_v<ChannelType, uint8_t> ||
+                std::is_same_v<ChannelType, uint16_t>) {
+    return static_cast<ChannelType>(idx %
+                                    std::numeric_limits<ChannelType>::max());
+  } else {
+    return static_cast<ChannelType>(idx);
+  }
+}
+
+// Instantiate the templates that test cases need.
+template class TestTiff<1, 8>;   // TestTiffGray8
+template class TestTiff<1, 16>;  // TestTiffGray16
+template class TestTiff<1, 32>;  // TestTiffGray32
+template class TestTiff<3, 32>;  // TestTiffRgb32
+
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/dev/test_utilities/test_tiff.h
+++ b/geometry/render/dev/test_utilities/test_tiff.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "drake/systems/sensors/image.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+
+// Type trait for TestTiff image data underlying type, similar to ImageTraits.
+template <int bit_depth>
+struct TestTiffTraits {
+  // Compile error for unspecialized use.
+};
+
+template <>
+struct TestTiffTraits<8> {
+  using ChannelType = uint8_t;
+};
+
+template <>
+struct TestTiffTraits<16> {
+  using ChannelType = uint16_t;
+};
+
+template <>
+struct TestTiffTraits<32> {
+  using ChannelType = float;
+  static_assert(sizeof(ChannelType) == 4, "Expected float to be 4 bytes.");
+};
+
+/* On construction, create a TIFF with some arbitrary but non-zero values.  This
+ class is primarily used for generating fake depth images, so a simple scheme
+ of increasing each pixel / channel value by one is used.  For example, with
+ an RGB image, the pixels start as:
+
+ - (0, 0): [0, 1, 2]
+ - (0, 1): [3, 4, 5]
+
+ For a gray image,
+
+ - (0, 0): 0
+ - (0, 1): 1
+
+ For uint8_t and uint16_t, the value inserted will roll back to 0 via a modulus
+ with the maximum value for the ChannelType (e.g., % 255 for uint8_t).  For
+ float, no bounds checking is enforced as the size of image being generated
+ will not overflow pas the range of float unless unreasonably large images
+ are requrested to be generated. */
+template <int channels, int bit_depth>
+class TestTiff {
+ public:
+  static_assert(channels == 1 || channels == 3,
+                "TestTiff <channels> must be 1 (gray) or 3 (RGB).");
+  static_assert(bit_depth == 8 || bit_depth == 16 || bit_depth == 32,
+                "TestTiff <bit_depth> must be 8, 16, or 32");
+  static_assert((channels == 1 && bit_depth == 16) ||      // 16 bit gray
+                    (channels == 1 && bit_depth == 32) ||  // 32 bit gray
+                    (channels == 3 && bit_depth == 32) ||  // 32 bit RGB
+                    (channels == 1 && bit_depth == 8),     // 8 bit gray
+                "TestTiff: unsupported <channels, bit_depth> combination.");
+
+  // Data type to allocate for memory, either uint8_t or uint16_t.
+  using ChannelType = typename TestTiffTraits<bit_depth>::ChannelType;
+  static_assert(
+      std::is_same_v<ChannelType, uint8_t> ||
+          std::is_same_v<ChannelType, uint16_t> ||
+          std::is_same_v<ChannelType, float>,
+      "TestTiff: only uint8_t, uint16_t, and 32 bit float supported.");
+
+  /* Create a TIFF image at the specified path with dimensions width x height,
+   generating the pattern described on the class documentation.  User is
+   responsible for deleting the file after it is created. */
+  TestTiff(const std::string& path, int width, int height);
+
+  // Returns the value for the provided loop index
+  static ChannelType TestTiffValue(int idx);
+
+  /* If the image coordinates are wrong for loading, this test will fail with
+   actual test information being reported in the failure. */
+  template <class DrakeImage>
+  static void CornerCheck(const DrakeImage& image) {
+    using DestType = typename DrakeImage::T;
+    EXPECT_EQ(image.at(0, 0)[0], static_cast<DestType>(0));
+  }
+
+  /* Tests all the pixels in the test image, but error reporting is not helpful
+   in identifying what was wrong where. */
+  template <class DrakeImage>
+  static void FullImageCheck(const DrakeImage& image) {
+    int n_good{0};
+    const int n_expected = image.width() * image.height();
+    float idx = 0.0f;
+    for (int j = 0; j < image.height(); ++j) {
+      for (int i = 0; i < image.width(); ++i) {
+        n_good += static_cast<int>(image.at(i, j)[0] == TestTiffValue(idx++));
+      }
+    }
+    EXPECT_EQ(n_good, n_expected);
+  }
+
+  const std::string path_;
+  const int width_;
+  const int height_;
+};
+
+// Instantiate them once in the source file.
+extern template class TestTiff<1, 8>;   // TestTiffGray8
+extern template class TestTiff<1, 16>;  // TestTiffGray16
+extern template class TestTiff<1, 32>;  // TestTiffGray32
+extern template class TestTiff<3, 32>;  // TestTiffRgb32
+
+// Declare nice type names for test cases to use.
+using TestTiffGray8 = TestTiff<1, 8>;
+using TestTiffGray16 = TestTiff<1, 16>;
+using TestTiffGray32 = TestTiff<1, 32>;
+using TestTiffRgb32 = TestTiff<3, 32>;
+
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
- RenderEngineGltfClient now has a RenderClient data member rather than multiple inheritance.
- RenderClient uses an HttpService data member to facilitate RenderOnServer interactions.  Default behavior is to create an HttpServiceCurl instance.
    - Most code removed from RenderClient was previously added to HttpServiceCurl.
- RenderClient is the owner of the temp_directory(), but it is shared across clones, RenderEngineGltfClient, and HttpService.
- Add tests for RenderClient.

TODO:

- [X] FYI it will take a bit to finalize reviewable callouts.
- [X] LoadDepthImage tests.
- [X] Coverage verification (at least one test with a `port <= 0` should be added).
- [X] Decision on what to do about `temp_directory` ownership.
    - [X] Refactor `HttpService` and cloning for `RenderClient` (this PR): https://github.com/RobotLocomotion/drake/pull/16776
- [X] Refactor png / tiff test image generation and checker routines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16751)
<!-- Reviewable:end -->
