### PR TITLE
CMake: --fission needs to be a build argument

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -575,9 +575,11 @@ if(CMAKE_CONFIGURATION_TYPES OR BUILD_TYPE_LOWER MATCHES "^(debug|relwithdebinfo
       "symbols because support for SNOPT is enabled"
     )
   else()
+    list(INSERT BAZEL_ARGS 0
+      "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:--fission=no>"
+    )
     list(INSERT BAZEL_TARGETS_ARGS 0
       "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:--no_strip>"
-      "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:--fission=no>"
     )
   endif()
 endif()


### PR DESCRIPTION
Fixes error in introduced in #16587.

Failing CI builds:
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-bionic-clang-cmake-continuous-debug/4666/
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-bionic-gcc-cmake-continuous-debug/4668/
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-focal-clang-cmake-continuous-debug/1378/
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-focal-gcc-cmake-continuous-debug/1379/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16767)
<!-- Reviewable:end -->
