### PR TITLE
Add macos_wheel platform

### DIFF
--- a/tools/workspace/boost/repository.bzl
+++ b/tools/workspace/boost/repository.bzl
@@ -35,7 +35,7 @@ def _impl(repository_ctx):
     os_result = determine_os(repository_ctx)
     if os_result.error != None:
         fail(os_result.error)
-    elif os_result.is_macos:
+    elif os_result.is_macos or os_result.is_macos_wheel:
         prefix = "{}/opt/boost".format(os_result.homebrew_prefix)
     elif os_result.is_ubuntu or os_result.is_manylinux:
         prefix = "/usr"

--- a/tools/workspace/double_conversion/repository.bzl
+++ b/tools/workspace/double_conversion/repository.bzl
@@ -24,7 +24,7 @@ def _impl(repository_ctx):
             "/usr/include/double-conversion",
             "include/double-conversion",
         )
-    elif os_result.is_manylinux:
+    elif os_result.is_manylinux or os_result.is_macos_wheel:
         libdir = "/opt/drake-dependencies/lib"
         repository_ctx.symlink(
             "/opt/drake-dependencies/include/double-conversion",

--- a/tools/workspace/fmt/repository.bzl
+++ b/tools/workspace/fmt/repository.bzl
@@ -14,7 +14,7 @@ def _impl(repo_ctx):
     os_result = determine_os(repo_ctx)
     if os_result.error != None:
         fail(os_result.error)
-    if os_result.is_macos:
+    if os_result.is_macos or os_result.is_macos_wheel:
         # On macOS, we use fmt from homebrew via pkg-config.
         error = setup_pkg_config_repository(repo_ctx).error
     elif os_result.is_manylinux:

--- a/tools/workspace/gfortran/repository.bzl
+++ b/tools/workspace/gfortran/repository.bzl
@@ -30,7 +30,7 @@ def _gfortran_impl(repo_ctx):
     os_result = determine_os(repo_ctx)
     if os_result.error != None:
         fail(os_result.error)
-    if os_result.is_macos:
+    if os_result.is_macos or os_result.is_macos_wheel:
         suffix = ".dylib"
     else:
         suffix = ".so"
@@ -40,7 +40,7 @@ def _gfortran_impl(repo_ctx):
     libquadmath_path = _find_library(repo_ctx, compiler, libquadmath)
 
     # The cc_library linking is different on Ubuntu vs macOS.
-    if os_result.is_macos:
+    if os_result.is_macos or os_result.is_macos_wheel:
         srcs = []
         linkopts = [
             "-L{}".format(repo_ctx.path(libgfortran_path).dirname),

--- a/tools/workspace/libjpeg/repository.bzl
+++ b/tools/workspace/libjpeg/repository.bzl
@@ -16,7 +16,7 @@ def _impl(repository_ctx):
             "{}/opt/jpeg/include".format(os_result.homebrew_prefix),
             "include",
         )
-    elif os_result.is_manylinux:
+    elif os_result.is_manylinux or os_result.is_macos_wheel:
         libdir = "/opt/drake-dependencies/lib"
         for hdr in noarch_hdrs + ["jconfig.h"]:
             repository_ctx.symlink(

--- a/tools/workspace/nlopt/repository.bzl
+++ b/tools/workspace/nlopt/repository.bzl
@@ -8,7 +8,7 @@ def _impl(repository_ctx):
     if os_result.error != None:
         fail(os_result.error)
 
-    if os_result.is_macos:
+    if os_result.is_macos or os_result.is_macos_wheel:
         build_flavor = "macos"
         repository_ctx.symlink(
             "{}/opt/nlopt/include/nlopt.h".format(os_result.homebrew_prefix),

--- a/tools/workspace/openblas/repository.bzl
+++ b/tools/workspace/openblas/repository.bzl
@@ -21,7 +21,7 @@ def _impl(repo_ctx):
     os_result = determine_os(repo_ctx)
     if os_result.error != None:
         fail(os_result.error)
-    if os_result.is_macos:
+    if os_result.is_macos or os_result.is_macos_wheel:
         error = setup_pkg_config_repository(repo_ctx).error
         if error != None:
             fail(error)

--- a/tools/workspace/opengl/repository.bzl
+++ b/tools/workspace/opengl/repository.bzl
@@ -8,7 +8,7 @@ def _impl(repository_ctx):
     if os_result.error != None:
         fail(os_result.error)
 
-    if os_result.is_macos:
+    if os_result.is_macos or os_result.is_macos_wheel:
         repository_ctx.symlink(
             Label("@drake//tools/workspace/opengl:package-macos.BUILD.bazel"),
             "BUILD.bazel",

--- a/tools/workspace/python/repository.bzl
+++ b/tools/workspace/python/repository.bzl
@@ -64,7 +64,7 @@ def repository_python_info(repository_ctx):
     os_result = determine_os(repository_ctx)
     if os_result.error != None:
         fail(os_result.error)
-    if os_result.is_macos:
+    if os_result.is_macos or os_result.is_macos_wheel:
         os_key = os_result.distribution
     elif os_result.is_ubuntu:
         os_key = os_result.distribution + ":" + os_result.ubuntu_release
@@ -72,7 +72,7 @@ def repository_python_info(repository_ctx):
         os_key = "manylinux"
     versions_supported = _VERSION_SUPPORT_MATRIX[os_key]
 
-    if os_result.is_macos:
+    if os_result.is_macos or os_result.is_macos_wheel:
         # This value must match the interpreter_path in
         # @drake//tools/py_toolchain:macos_py3_runtime
         python = repository_ctx.attr.macos_interpreter_path

--- a/tools/workspace/snopt/repository.bzl
+++ b/tools/workspace/snopt/repository.bzl
@@ -198,7 +198,7 @@ def _impl(repo_ctx):
             Label("@drake//tools/workspace/snopt:fortran-ubuntu.bzl"),
             "fortran.bzl",
         )
-    elif os_result.is_macos:
+    elif os_result.is_macos or os_result.is_macos_wheel:
         repo_ctx.symlink(
             Label("@drake//tools/workspace/snopt:fortran-macos.bzl"),
             "fortran.bzl",

--- a/tools/workspace/suitesparse/repository.bzl
+++ b/tools/workspace/suitesparse/repository.bzl
@@ -20,7 +20,7 @@ def _impl(repo_ctx):
         libdir = "{}/opt/suite-sparse/lib".format(
             os_result.homebrew_prefix,
         )
-    elif os_result.is_manylinux:
+    elif os_result.is_manylinux or os_result.is_macos_wheel:
         # TODO(jwnimmer-tri) Ideally, we wouldn't be hard-coding paths when
         # using manylinux.
         include = "/opt/drake-dependencies/include"

--- a/tools/workspace/vtk/repository.bzl
+++ b/tools/workspace/vtk/repository.bzl
@@ -80,7 +80,7 @@ def _vtk_cc_library(
     elif os_result.is_ubuntu:
         if not header_only:
             srcs = ["lib/lib{}-{}.so.1".format(name, VTK_MAJOR_MINOR_VERSION)]
-    elif os_result.is_manylinux:
+    elif os_result.is_manylinux or os_result.is_macos_wheel:
         if not header_only:
             # TODO(jwnimmer-tri) Ideally, we wouldn't be hard-coding paths when
             # using manylinux.
@@ -138,7 +138,7 @@ def _impl(repository_ctx):
             sha256 = sha256,
             type = "tar.gz",
         )
-    elif os_result.is_manylinux:
+    elif os_result.is_manylinux or os_result.is_macos_wheel:
         repository_ctx.symlink("/opt/vtk/include", "include")
     else:
         fail("Operating system is NOT supported {}".format(os_result))
@@ -837,7 +837,7 @@ licenses([
         "vtkGenericRenderWindowInteractor.h",
         "vtkRenderingUIModule.h",
     ]
-    if not os_result.is_macos:
+    if not os_result.is_macos and not os_result.is_macos_wheel:
         vtk_rendering_ui_hdrs.append("vtkXRenderWindowInteractor.h")
     file_content += _vtk_cc_library(
         os_result,
@@ -871,7 +871,7 @@ licenses([
         "vtkShader.h",
         "vtkShaderProgram.h",
     ]
-    if not os_result.is_macos:
+    if not os_result.is_macos and not os_result.is_macos_wheel:
         vtk_rendering_opengl2_hdrs.append("vtkXOpenGLRenderWindow.h")
 
     if os_result.is_manylinux:


### PR DESCRIPTION
Add ability to override the platform on macOS. Add a new platform, `macos_wheel`, which roughly corresponds to `manylinux` on Ubuntu. (There are some additional implications to `manylinux` specifically with regard to additional processing of the resulting wheels, but conceptually, both represent their respective platforms being used to produce a wheel.)

+@jwnimmer-tri for feature review, please.

This "probably" isn't buildable on its own (the scripts for building the dependencies and the actual wheel are still WIP), but it should be ready for comment and shouldn't break anything existing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16768)
<!-- Reviewable:end -->
