### PR TITLE
Fix/update supported Python versions

### DIFF
--- a/tools/workspace/python/repository.bzl
+++ b/tools/workspace/python/repository.bzl
@@ -50,7 +50,7 @@ _VERSION_SUPPORT_MATRIX = {
     "ubuntu:18.04": ["3.6"],
     "ubuntu:20.04": ["3.8"],
     "macos": ["3.9"],
-    "manylinux": ["3.6"],
+    "manylinux": ["3.6", "3.7", "3.8", "3.9"],
 }
 
 def repository_python_info(repository_ctx):


### PR DESCRIPTION
Update the list of Python versions that are supported when building a wheel. This just suppresses a warning message, but was apparently overlooked when support for wheels using Python > 3.6 was added some time ago.

+@jwnimmer-tri for feature review, please.