### PR TITLE
[parsing] Split TinyXml2Diagnostic to its own module

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -78,18 +78,21 @@ drake_cc_library(
         "detail_ignition.cc",
         "detail_path_utils.cc",
         "detail_tinyxml.cc",
+        "detail_tinyxml2_diagnostic.cc",
     ],
     hdrs = [
         "detail_common.h",
         "detail_ignition.h",
         "detail_path_utils.h",
         "detail_tinyxml.h",
+        "detail_tinyxml2_diagnostic.h",
     ],
     install_hdrs_exclude = [
         "detail_common.h",
         "detail_ignition.h",
         "detail_path_utils.h",
         "detail_tinyxml.h",
+        "detail_tinyxml2_diagnostic.h",
     ],
     visibility = [
         "//visibility:private",
@@ -511,6 +514,13 @@ drake_cc_googletest(
     deps = [
         ":detail_misc",
         "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "detail_tinyxml2_diagnostic_test",
+    deps = [
+        ":detail_misc",
     ],
 )
 

--- a/multibody/parsing/detail_tinyxml2_diagnostic.cc
+++ b/multibody/parsing/detail_tinyxml2_diagnostic.cc
@@ -1,0 +1,47 @@
+#include "drake/multibody/parsing/detail_tinyxml2_diagnostic.h"
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+using drake::internal::DiagnosticDetail;
+using tinyxml2::XMLNode;
+
+TinyXml2Diagnostic::TinyXml2Diagnostic(
+    const drake::internal::DiagnosticPolicy* diagnostic,
+    const DataSource* data_source,
+    const std::string& file_extension)
+    : diagnostic_(diagnostic), data_source_(data_source),
+      file_extension_(file_extension) {
+  DRAKE_DEMAND(diagnostic != nullptr);
+  DRAKE_DEMAND(data_source != nullptr);
+}
+
+DiagnosticDetail TinyXml2Diagnostic::MakeDetail(
+    const XMLNode& location, const std::string& message) const {
+  DiagnosticDetail detail;
+  if (data_source_->IsFilename()) {
+    detail.filename = data_source_->GetAbsolutePath();
+  } else {
+    detail.filename = data_source_->GetStem() + "." + file_extension_;
+  }
+  detail.line = location.GetLineNum();
+  detail.message = message;
+  return detail;
+}
+
+void TinyXml2Diagnostic::Warning(
+    const XMLNode& location, const std::string& message) const {
+  diagnostic_->Warning(MakeDetail(location, message));
+}
+
+void TinyXml2Diagnostic::Error(
+    const XMLNode& location, const std::string& message) const {
+  diagnostic_->Error(MakeDetail(location, message));
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/detail_tinyxml2_diagnostic.h
+++ b/multibody/parsing/detail_tinyxml2_diagnostic.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <string>
+
+#include <tinyxml2.h>
+
+#include "drake/common/diagnostic_policy.h"
+#include "drake/multibody/parsing/detail_common.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Helper class to format diagnostic messages for a TinyXML2 data source.
+class TinyXml2Diagnostic {
+ public:
+  // Both @p diagnostic and @p data_source are aliased; their lifetime must
+  // exceed that of this object.  @p file_extension is only used for formatting
+  // diagnostics from file_contents sources. It is copied internally, so places
+  // no restrictions on the lifetime of the passed parameter.
+  // @pre diagnostic cannot be nullptr.
+  // @pre data_source cannot be nullptr.
+  TinyXml2Diagnostic(
+      const drake::internal::DiagnosticPolicy* diagnostic,
+      const DataSource* data_source,
+      const std::string& file_extension = "urdf");
+
+  // Issues a warning for an XMLNode.
+  void Warning(const tinyxml2::XMLNode& location,
+               const std::string& message) const;
+
+  // Issues an error for an XMLNode.
+  void Error(const tinyxml2::XMLNode& location,
+             const std::string& message) const;
+
+ private:
+  // Makes a diagnostic detail record based on an XMLNode.
+  drake::internal::DiagnosticDetail MakeDetail(
+      const tinyxml2::XMLNode& location,
+      const std::string& message) const;
+
+  const drake::internal::DiagnosticPolicy* diagnostic_{};
+  const DataSource* data_source_{};
+  const std::string file_extension_;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -19,6 +19,7 @@
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/parsing/detail_path_utils.h"
 #include "drake/multibody/parsing/detail_tinyxml.h"
+#include "drake/multibody/parsing/detail_tinyxml2_diagnostic.h"
 #include "drake/multibody/parsing/detail_urdf_geometry.h"
 #include "drake/multibody/parsing/package_map.h"
 #include "drake/multibody/parsing/scoped_names.h"
@@ -35,8 +36,6 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-using drake::internal::DiagnosticDetail;
-using drake::internal::DiagnosticPolicy;
 using Eigen::Matrix3d;
 using Eigen::Vector3d;
 using Eigen::Vector4d;
@@ -46,51 +45,6 @@ using tinyxml2::XMLDocument;
 using tinyxml2::XMLElement;
 
 namespace {
-
-// Helper class to format diagnostic messages for a TinyXML2 data source.
-class TinyXml2Diagnostic {
- public:
-  // Both @p diagnostic and @p data_source are aliased; their lifetime must
-  // exceed that of this object.
-  // @pre diagnostic cannot be nullptr.
-  // @pre data_source cannot be nullptr.
-  TinyXml2Diagnostic(
-      const drake::internal::DiagnosticPolicy* diagnostic,
-      const DataSource* data_source)
-      : diagnostic_(diagnostic), data_source_(data_source) {
-    DRAKE_DEMAND(diagnostic != nullptr);
-    DRAKE_DEMAND(data_source != nullptr);
-  }
-
-  // Makes a diagnostic detail record based on an XMLNode.
-  // @pre location cannot be nullptr.
-  DiagnosticDetail MakeDetail(const XMLNode& location,
-                              const std::string& message) const {
-    DiagnosticDetail detail;
-    if (data_source_->IsFilename()) {
-      detail.filename = data_source_->GetAbsolutePath();
-    } else {
-      detail.filename = data_source_->GetStem() + ".urdf";
-    }
-    detail.line = location.GetLineNum();
-    detail.message = message;
-    return detail;
-  }
-
-  // Issues a warning for an XMLNode.
-  void Warning(const XMLNode& location, const std::string& message) const {
-    diagnostic_->Warning(MakeDetail(location, message));
-  }
-
-  // Issues an error for an XMLNode.
-  void Error(const XMLNode& location, const std::string& message) const {
-    diagnostic_->Error(MakeDetail(location, message));
-  }
-
- private:
-  const drake::internal::DiagnosticPolicy* diagnostic_{};
-  const DataSource* data_source_{};
-};
 
 const char* kWorldName = "world";
 

--- a/multibody/parsing/test/detail_tinyxml2_diagnostic_test.cc
+++ b/multibody/parsing/test/detail_tinyxml2_diagnostic_test.cc
@@ -1,0 +1,124 @@
+#include "drake/multibody/parsing/detail_tinyxml2_diagnostic.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/temp_directory.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace {
+
+using tinyxml2::XMLDocument;
+using tinyxml2::XMLElement;
+
+using drake::internal::DiagnosticDetail;
+using drake::internal::DiagnosticPolicy;
+
+class TinyXml2DiagnosticTest : public ::testing::Test {
+ public:
+  TinyXml2DiagnosticTest() {
+    policy_.SetActionForErrors(
+        [this](const DiagnosticDetail& detail) {
+          error_records_.push_back(detail);
+        });
+    policy_.SetActionForWarnings(
+        [this](const DiagnosticDetail& detail) {
+          warning_records_.push_back(detail);
+        });
+
+    data_ = R"""(
+<?xml version="1.0"?>
+<stuff>
+  <error/>
+  <warning/>
+</stuff>
+)""";
+  }
+
+ protected:
+  std::string data_;
+  DiagnosticPolicy policy_;
+
+  XMLDocument xml_doc_;
+  XMLElement* root_{};
+
+  std::vector<DiagnosticDetail> error_records_;
+  std::vector<DiagnosticDetail> warning_records_;
+};
+
+class TinyXml2DiagnosticContentsTest : public TinyXml2DiagnosticTest {
+ public:
+  TinyXml2DiagnosticContentsTest() {
+    xml_doc_.Parse(data_.c_str());
+    root_ = xml_doc_.RootElement();
+    DRAKE_DEMAND(root_ != nullptr);
+  }
+
+ protected:
+  DataSource source_{DataSource::kContents, &data_};
+  TinyXml2Diagnostic diagnostic_{&policy_, &source_, "stuff"};
+};
+
+class TinyXml2DiagnosticFilenameTest : public TinyXml2DiagnosticTest {
+ public:
+  TinyXml2DiagnosticFilenameTest() {
+    filename_ = temp_directory() + "/test_data.stuff";
+    std::ofstream file(filename_);
+    file << data_;
+    file.close();
+    xml_doc_.LoadFile(filename_.c_str());
+    root_ = xml_doc_.RootElement();
+    DRAKE_DEMAND(root_ != nullptr);
+  }
+
+ protected:
+  std::string filename_;
+  DataSource source_{DataSource::kFilename, &filename_};
+  TinyXml2Diagnostic diagnostic_{&policy_, &source_, "stuff"};
+};
+
+TEST_F(TinyXml2DiagnosticContentsTest, Error) {
+  const XMLElement* error_node = root_->FirstChildElement("error");
+  ASSERT_NE(error_node, nullptr);
+  diagnostic_.Error(*error_node, "badness");
+  ASSERT_EQ(error_records_.size(), 1);
+  const std::string full_message = error_records_[0].FormatError();
+  EXPECT_EQ(full_message, "<literal-string>.stuff:4: error: badness");
+}
+
+TEST_F(TinyXml2DiagnosticContentsTest, Warning) {
+  const XMLElement* warning_node = root_->FirstChildElement("warning");
+  ASSERT_NE(warning_node, nullptr);
+  diagnostic_.Warning(*warning_node, "regret");
+  ASSERT_EQ(warning_records_.size(), 1);
+  const std::string full_message = warning_records_[0].FormatWarning();
+  EXPECT_EQ(full_message, "<literal-string>.stuff:5: warning: regret");
+}
+
+TEST_F(TinyXml2DiagnosticFilenameTest, Error) {
+  const XMLElement* error_node = root_->FirstChildElement("error");
+  ASSERT_NE(error_node, nullptr);
+  diagnostic_.Error(*error_node, "badness");
+  ASSERT_EQ(error_records_.size(), 1);
+  const std::string full_message = error_records_[0].FormatError();
+  EXPECT_THAT(full_message,
+              testing::MatchesRegex("/.*/test_data.stuff:4: error: badness"));
+}
+
+TEST_F(TinyXml2DiagnosticFilenameTest, Warning) {
+  const XMLElement* warning_node = root_->FirstChildElement("warning");
+  ASSERT_NE(warning_node, nullptr);
+  diagnostic_.Warning(*warning_node, "regret");
+  ASSERT_EQ(warning_records_.size(), 1);
+  const std::string full_message = warning_records_[0].FormatWarning();
+  EXPECT_THAT(full_message,
+              testing::MatchesRegex("/.*/test_data.stuff:5: warning: regret"));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Relevant to: #16229

Split out the TinyXml2Diagnostic class, to make it available for use in
detail_urdf_geometry, and possibly elsewhere.

 * split out class
   * divide into header and cc file
 * add tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16770)
<!-- Reviewable:end -->
