### PR TITLE
[workspace] Don't build libsdformat's URDF parser

### DIFF
--- a/multibody/parsing/detail_common.h
+++ b/multibody/parsing/detail_common.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <variant>
 
-#include <sdf/sdf.hh>
+#include <sdf/Element.hh>
 #include <tinyxml2.h>
 
 #include "drake/common/drake_copyable.h"

--- a/multibody/parsing/detail_sdf_geometry.cc
+++ b/multibody/parsing/detail_sdf_geometry.cc
@@ -7,7 +7,13 @@
 #include <string>
 #include <utility>
 
-#include <sdf/sdf.hh>
+#include <sdf/Box.hh>
+#include <sdf/Capsule.hh>
+#include <sdf/Cylinder.hh>
+#include <sdf/Element.hh>
+#include <sdf/Ellipsoid.hh>
+#include <sdf/Plane.hh>
+#include <sdf/Sphere.hh>
 
 #include "drake/common/filesystem.h"
 #include "drake/geometry/geometry_instance.h"

--- a/multibody/parsing/detail_sdf_geometry.h
+++ b/multibody/parsing/detail_sdf_geometry.h
@@ -3,7 +3,9 @@
 #include <memory>
 #include <string>
 
-#include <sdf/sdf.hh>
+#include <sdf/Collision.hh>
+#include <sdf/Geometry.hh>
+#include <sdf/Visual.hh>
 
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/geometry_roles.h"

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -10,8 +10,15 @@
 #include <variant>
 #include <vector>
 
-#include <sdf/sdf.hh>
-#include <tinyxml2.h>
+#include <sdf/Error.hh>
+#include <sdf/Frame.hh>
+#include <sdf/Joint.hh>
+#include <sdf/JointAxis.hh>
+#include <sdf/Link.hh>
+#include <sdf/Model.hh>
+#include <sdf/ParserConfig.hh>
+#include <sdf/Root.hh>
+#include <sdf/World.hh>
 
 #include "drake/geometry/geometry_instance.h"
 #include "drake/math/rigid_transform.h"

--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -8,6 +8,8 @@
 
 #include "fmt/ostream.h"
 #include <gtest/gtest.h>
+#include <sdf/Root.hh>
+#include <sdf/parser.hh>
 
 #include "drake/common/filesystem.h"
 #include "drake/common/find_resource.h"

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -6,7 +6,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <sdf/sdf.hh>
+#include <sdf/parser.hh>
 #include <spdlog/sinks/dist_sink.h>
 #include <spdlog/sinks/ostream_sink.h>
 

--- a/tools/workspace/sdformat/package.BUILD.bazel
+++ b/tools/workspace/sdformat/package.BUILD.bazel
@@ -21,50 +21,6 @@ licenses(["notice"])  # Apache-2.0 AND BSD-3-Clause AND BSL-1.0
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
-    name = "urdfdom",
-    srcs = [
-        "src/urdf/urdf_parser/joint.cpp",
-        "src/urdf/urdf_parser/link.cpp",
-        "src/urdf/urdf_parser/model.cpp",
-        "src/urdf/urdf_parser/pose.cpp",
-        "src/urdf/urdf_parser/twist.cpp",
-        "src/urdf/urdf_parser/urdf_model_state.cpp",
-        "src/urdf/urdf_parser/urdf_sensor.cpp",
-        "src/urdf/urdf_parser/world.cpp",
-    ],
-    hdrs = [
-        "src/urdf/urdf_exception/exception.h",
-        "src/urdf/urdf_model/color.h",
-        "src/urdf/urdf_model/joint.h",
-        "src/urdf/urdf_model/link.h",
-        "src/urdf/urdf_model/model.h",
-        "src/urdf/urdf_model/pose.h",
-        "src/urdf/urdf_model/twist.h",
-        "src/urdf/urdf_model/types.h",
-        "src/urdf/urdf_model/utils.h",
-        "src/urdf/urdf_model_state/model_state.h",
-        "src/urdf/urdf_model_state/twist.h",
-        "src/urdf/urdf_model_state/types.h",
-        "src/urdf/urdf_parser/exportdecl.h",
-        "src/urdf/urdf_parser/urdf_parser.h",
-        "src/urdf/urdf_sensor/sensor.h",
-        "src/urdf/urdf_sensor/types.h",
-        "src/urdf/urdf_world/types.h",
-        "src/urdf/urdf_world/world.h",
-    ],
-    # TODO(jamiesnape): Enable visibility after resolving warnings such as
-    # "Direct access in function means the weak symbol cannot be overridden at
-    # runtime. This was likely caused by different translation units being
-    # compiled with different visibility settings."
-    copts = ["-w"],
-    defines = ["URDFDOM_STATIC"],
-    includes = ["src/urdf"],
-    linkstatic = 1,
-    visibility = ["//visibility:private"],
-    deps = ["@tinyxml2"],
-)
-
 # Generates sdf_config.h based on the version numbers in CMake code.
 cmake_configure_file(
     name = "config",
@@ -143,17 +99,6 @@ SDFORMAT_MOST_PUBLIC_HDRS = [
     "include/sdf/system_util.hh",
 ]
 
-# Generates sdf.hh, which consists of #include statements for all of the public
-# headers in the library.  There is one line like '#include <sdf/Assert.hh>'
-# for each non-generated header, followed at the end by a
-# single '#include <sdf/sdf_config.h>'.
-drake_generate_include_header(
-    name = "sdfhh_genrule",
-    out = "include/sdf/sdf.hh",
-    hdrs = SDFORMAT_MOST_PUBLIC_HDRS + [":config"],
-    visibility = ["//visibility:private"],
-)
-
 # Generates EmbeddedSdf.cc.
 genrule(
     name = "embed_sdf_genrule",
@@ -174,15 +119,14 @@ py_binary(
 )
 
 SDFORMAT_ALL_PUBLIC_HDRS = SDFORMAT_MOST_PUBLIC_HDRS + [
-    "include/sdf/sdf.hh",  # from genrule above
     "include/sdf/sdf_config.h",  # from cmake_configure_file above
 ]
 
 # Generates the library exported to users. The explicitly listed srcs= matches
-# upstream's explicitly listed sources (sdformat/src/CMakeLists.txt). The
-# explicitly listed hdrs= matches upstream's private headers. ign.hh and ign.cc
-# are not incorporated in this library, but are incorporated into the
-# `ign_sdf_cmdline` library defined below.
+# upstream's explicitly listed sources (sdformat/src/CMakeLists.txt), with two
+# exceptions: ign.hh and ign.cc are not incorporated in this library, but are
+# incorporated into the `ign_sdf_cmdline` library defined below; and the
+# parser_urdf.hh and parser_urdf.cc are excluded because we don't use them.
 cc_library(
     name = "sdformat",
     srcs = [
@@ -259,8 +203,6 @@ cc_library(
         "src/XmlUtils.hh",
         "src/parser.cc",
         "src/parser_private.hh",
-        "src/parser_urdf.cc",
-        "src/parser_urdf.hh",
         ":src/EmbeddedSdf.cc",
     ],
     hdrs = SDFORMAT_ALL_PUBLIC_HDRS,
@@ -273,7 +215,6 @@ cc_library(
     includes = ["include"],
     linkstatic = 1,
     deps = [
-        ":urdfdom",
         "@ignition_math",
         "@ignition_utils",
         "@tinyxml2",

--- a/tools/workspace/sdformat/patches/no_urdf.patch
+++ b/tools/workspace/sdformat/patches/no_urdf.patch
@@ -1,0 +1,48 @@
+Disable transmogrification of URDF files into SDFormat files.
+Drake has its own URDF parser that we should always use.
+
+diff --git a/src/parser.cc b/src/parser.cc
+index 5f29f93d..8e98983c 100644
+--- src/parser.cc
++++ src/parser.cc
+@@ -44,7 +44,7 @@
+ #include "ScopedGraph.hh"
+ #include "Utils.hh"
+ #include "parser_private.hh"
+-#include "parser_urdf.hh"
++// #include "parser_urdf.hh"
+ 
+ namespace sdf
+ {
+@@ -726,6 +726,7 @@ bool readFileInternal(const std::string &_filename, const bool _convert,
+   {
+     return true;
+   }
++#if 0  // Disable URDF2SDF for Drake.
+   else if (URDF2SDF::IsURDF(filename))
+   {
+     URDF2SDF u2g;
+@@ -742,6 +743,7 @@ bool readFileInternal(const std::string &_filename, const bool _convert,
+       return false;
+     }
+   }
++#endif  // Disable URDF2SDF for Drake.
+ 
+   return false;
+ }
+@@ -803,6 +805,7 @@ bool readStringInternal(const std::string &_xmlString, const bool _convert,
+   {
+     return true;
+   }
++#if 0  // Disable URDF2SDF for Drake.
+   else
+   {
+     URDF2SDF u2g;
+@@ -821,6 +824,7 @@ bool readStringInternal(const std::string &_xmlString, const bool _convert,
+       return false;
+     }
+   }
++#endif  // Disable URDF2SDF for Drake.
+ 
+   return false;
+ }

--- a/tools/workspace/sdformat/repository.bzl
+++ b/tools/workspace/sdformat/repository.bzl
@@ -13,6 +13,7 @@ def sdformat_repository(
         build_file = "@drake//tools/workspace/sdformat:package.BUILD.bazel",
         patches = [
             "@drake//tools/workspace/sdformat:patches/console.patch",
+            "@drake//tools/workspace/sdformat:patches/no_urdf.patch",
         ],
         mirrors = mirrors,
     )


### PR DESCRIPTION
Drake has its own URDF parser that we must always use, so we should disable libsdformat's automatic transmogrification of URDF files into SDFormat files.

Don't generate `sdf/sdf.hh`; it's only effect is IWYU violations.

Towards #12610.

+@rpoyner-tri for feature review, please.

+@EricCousineau-TRI for platform review (as SME), please.
Should we have anyone from OpenRobotics take a look here as well?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16772)
<!-- Reviewable:end -->
