### PR TITLE
[workspace] Add abseil-cpp dependency

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -553,6 +553,7 @@ drake_cc_library(
         "//common:essential",
         "//common:pointer_cast",
         "//common:unused",
+        "@abseil_cpp_internal//absl/container:inlined_vector",
     ],
 )
 
@@ -872,6 +873,7 @@ drake_cc_googletest(
         ":leaf_system",
         "//common:essential",
         "//common/test_utilities",
+        "//common/test_utilities:limit_malloc",
         "//systems/framework/test_utilities",
     ],
 )

--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -3,6 +3,8 @@
 #include <cmath>
 #include <limits>
 
+#include "absl/container/inlined_vector.h"
+
 #include "drake/common/pointer_cast.h"
 #include "drake/systems/framework/system_symbolic_inspector.h"
 #include "drake/systems/framework/value_checker.h"
@@ -308,7 +310,10 @@ namespace {
 // this storage is responsible for resetting any values prior to their use.
 template <typename T>
 struct Scratch {
-  std::vector<const Event<T>*> next_events;
+  using NextEventsVector = absl::InlinedVector<
+      const Event<T>*, LeafEventCollection<PublishEvent<T>>::kDefaultCapacity>;
+
+  NextEventsVector next_events;
 };
 }  // namespace
 
@@ -380,7 +385,7 @@ void LeafSystem<T>::DoCalcNextUpdateTime(
       this->get_cache_entry(scratch_cache_index_)
       .get_mutable_cache_entry_value(context)
       .template GetMutableValueOrThrow<Scratch<T>>();
-  std::vector<const Event<T>*>& next_events = scratch.next_events;
+  typename Scratch<T>::NextEventsVector& next_events = scratch.next_events;
   next_events.clear();
 
   // Find the minimum next sample time across all declared periodic events,

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -71,6 +71,7 @@ _DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "vtk",
     "yaml_cpp_internal",
 ]] + ["//tools/workspace/%s:install" % p for p in [
+    "abseil_cpp_internal",
     "conex",
     "cds",
     "dreal",

--- a/tools/workspace/abseil_cpp_internal/BUILD.bazel
+++ b/tools/workspace/abseil_cpp_internal/BUILD.bazel
@@ -1,0 +1,19 @@
+# -*- python -*-
+
+load("@drake//tools/install:install.bzl", "install_files")
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+install_files(
+    name = "install",
+    dest = "share/doc/abseil_cpp",
+    files = [
+        "@abseil_cpp_internal//:AUTHORS",
+        "@abseil_cpp_internal//:LICENSE",
+    ],
+    allowed_externals = [
+        "@abseil_cpp_internal//:LICENSE",
+    ],
+    visibility = ["//tools/workspace:__pkg__"],
+)
+
+add_lint_tests()

--- a/tools/workspace/abseil_cpp_internal/patches/hidden_visibility.patch
+++ b/tools/workspace/abseil_cpp_internal/patches/hidden_visibility.patch
@@ -1,0 +1,15 @@
+Use hidden symbol visibility for Abseil's C++ code.
+
+This probably improves linker and loader throughput.
+
+--- absl/base/config.h.orig	2022-03-08 13:01:16.000000000 -0800
++++ absl/base/config.h	2022-03-13 13:46:02.698469827 -0700
+@@ -153,7 +153,7 @@
+ #define ABSL_INTERNAL_C_SYMBOL(x) x
+ #elif ABSL_OPTION_USE_INLINE_NAMESPACE == 1
+ #define ABSL_NAMESPACE_BEGIN \
+-  inline namespace ABSL_OPTION_INLINE_NAMESPACE_NAME {
++  inline namespace ABSL_OPTION_INLINE_NAMESPACE_NAME __attribute__ ((visibility ("hidden"))) {
+ #define ABSL_NAMESPACE_END }
+ #define ABSL_INTERNAL_C_SYMBOL_HELPER_2(x, v) x##_##v
+ #define ABSL_INTERNAL_C_SYMBOL_HELPER_1(x, v) \

--- a/tools/workspace/abseil_cpp_internal/patches/inline_namespace.patch
+++ b/tools/workspace/abseil_cpp_internal/patches/inline_namespace.patch
@@ -1,0 +1,18 @@
+Use an inline namespace for Abseil.
+
+This prevents Drake's build of Abseil from interfering with a user's
+downstream build of Abseil when the user is using static linking.
+
+--- absl/base/options.h.orig	2022-03-08 13:01:16.000000000 -0800
++++ absl/base/options.h	2022-03-13 13:44:21.385254191 -0700
+@@ -205,8 +205,8 @@
+ // be changed to a new, unique identifier name.  In particular "head" is not
+ // allowed.
+ 
+-#define ABSL_OPTION_USE_INLINE_NAMESPACE 0
+-#define ABSL_OPTION_INLINE_NAMESPACE_NAME head
++#define ABSL_OPTION_USE_INLINE_NAMESPACE 1
++#define ABSL_OPTION_INLINE_NAMESPACE_NAME drake_vendor
+ 
+ // ABSL_OPTION_HARDENED
+ //

--- a/tools/workspace/abseil_cpp_internal/repository.bzl
+++ b/tools/workspace/abseil_cpp_internal/repository.bzl
@@ -1,0 +1,23 @@
+# -*- python -*-
+load("@drake//tools/workspace:github.bzl", "github_archive")
+
+def abseil_cpp_internal_repository(
+        name,
+        mirrors = None):
+    github_archive(
+        name = name,
+        repository = "abseil/abseil-cpp",
+        commit = "c5a424a2a21005660b182516eb7a079cd8021699",
+        sha256 = "9bbe4fd382bbd2911f31e8d70eae035a2168f8ca00d5aa51586c5ac7c86010b3",  # noqa
+        patches = [
+            "@drake//tools/workspace/abseil_cpp_internal:patches/hidden_visibility.patch",  # noqa
+            "@drake//tools/workspace/abseil_cpp_internal:patches/inline_namespace.patch",  # noqa
+        ],
+        patch_cmds = [
+            # Force linkstatic = 1 everywhere. First, remove the few existing
+            # uses so that we don't get "duplicate kwarg" errors. Then, add it
+            # anywhere that linkopts already appears.
+            "sed -i -e 's|linkstatic = 1,||; s|linkopts = |linkstatic = 1, linkopts =|' absl/*/BUILD.bazel",  # noqa
+        ],
+        mirrors = mirrors,
+    )

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -2,6 +2,7 @@
 
 load("@drake//tools/workspace:mirrors.bzl", "DEFAULT_MIRRORS")
 load("@drake//tools/workspace:os.bzl", "os_repository")
+load("@drake//tools/workspace/abseil_cpp_internal:repository.bzl", "abseil_cpp_internal_repository")  # noqa
 load("@drake//tools/workspace/bazel_skylib:repository.bzl", "bazel_skylib_repository")  # noqa
 load("@drake//tools/workspace/blas:repository.bzl", "blas_repository")
 load("@drake//tools/workspace/boost:repository.bzl", "boost_repository")
@@ -107,6 +108,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
           be useful if a WORKSPACE file has already supplied its own external
           of a given name.
     """
+    if "abseil_cpp_internal" not in excludes:
+        abseil_cpp_internal_repository(name = "abseil_cpp_internal", mirrors = mirrors)  # noqa
     if "bazel_skylib" not in excludes:
         bazel_skylib_repository(name = "bazel_skylib", mirrors = mirrors)
     if "blas" not in excludes:


### PR DESCRIPTION
The absl library has several very fast container types.  Due to ABI stability we can't use it in our header files, but we _can_ use it in our cc files with a few tweaks.

In the case of function-local containers, `InlinedVector` can be a be a notable win vs `std::vector`.  When the number of items is within a specified constexpr bound, they will be stored on the stack instead of the heap.

As a demonstration and proof of life, use it to make `LeafSystem::CalcNextUpdateTime` heapless (unless we exceed more than 32 concurrent events).