### PR TITLE
[geometry/dev] make HttpService stateless

### DIFF
--- a/geometry/render/dev/BUILD.bazel
+++ b/geometry/render/dev/BUILD.bazel
@@ -159,6 +159,7 @@ drake_cc_googletest(
     deps = [
         ":http_service",
         "//common:temp_directory",
+        "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
     ],
 )

--- a/geometry/render/dev/http_service.cc
+++ b/geometry/render/dev/http_service.cc
@@ -15,11 +15,11 @@ namespace internal {
 
 namespace fs = drake::filesystem;
 
-namespace {
+HttpService::HttpService() {}
 
-/* Throw an std::logic_error if the provided url is empty or has trailing
- slashes. */
-void ThrowIfInvalidUrl(const std::string& url) {
+HttpService::~HttpService() {}
+
+void HttpService::ThrowIfUrlInvalid(const std::string& url) const {
   // Validate what can be validated about the provided url.
   if (url.empty()) {
     throw std::logic_error("HttpService: url parameter may not be empty.");
@@ -27,41 +27,6 @@ void ThrowIfInvalidUrl(const std::string& url) {
   if (url.back() == '/') {
     throw std::logic_error("HttpService: url may not end with '/'.");
   }
-}
-
-}  // namespace
-
-HttpService::HttpService(const std::string& temp_directory,
-                         const std::string& url, int32_t port, bool verbose)
-    : temp_directory_{temp_directory},
-      url_{url},
-      port_{port},
-      verbose_{verbose} {
-  ThrowIfInvalidUrl(url_);
-}
-
-HttpService::HttpService(const HttpService& other)
-    : temp_directory_{other.temp_directory_},
-      url_{other.url_},
-      port_{other.port_},
-      verbose_{other.verbose_} {}
-
-std::unique_ptr<HttpService> HttpService::Clone() const {
-  std::unique_ptr<HttpService> clone(DoClone());
-  // Make sure that derived classes have actually overridden DoClone().
-  // Particularly important for derivations of derivations.
-  // Note: clang considers typeid(*clone) to be an expression with side effects.
-  // So, we capture a reference to the polymorphic type and provide that to
-  // typeid to make both clang and gcc happy.
-  const HttpService& clone_ref = *clone;
-  if (typeid(*this) != typeid(clone_ref)) {
-    throw std::logic_error(fmt::format(
-        "Error in cloning HttpService class of type {}; the clone returns "
-        "type {}. {}::DoClone() was probably not implemented",
-        NiceTypeName::Get(*this), NiceTypeName::Get(clone_ref),
-        NiceTypeName::Get(*this)));
-  }
-  return clone;
 }
 
 void HttpService::ThrowIfEndpointInvalid(const std::string& endpoint) const {

--- a/geometry/render/dev/http_service.h
+++ b/geometry/render/dev/http_service.h
@@ -7,6 +7,8 @@
 #include <string>
 #include <utility>
 
+#include "drake/common/drake_copyable.h"
+
 namespace drake {
 namespace geometry {
 namespace render {
@@ -60,50 +62,9 @@ struct HttpResponse {
  RenderClient, is responsible for adhering to the server API. */
 class HttpService {
  public:
-  /** @name Does not allow copy, move, or assignment  */
-  //@{
-#ifdef DRAKE_DOXYGEN_CXX
-  // Note: the copy constructor operator is actually protected to serve as the
-  // basis for implementing the DoClone() method.
-  HttpService(const HttpService&) = delete;
-#endif
-  HttpService& operator=(const HttpService&) = delete;
-  HttpService(HttpService&&) = delete;
-  HttpService& operator=(HttpService&&) = delete;
-  //@}
-  /** Constructs an %HttpService to be used throughout the duration of a client
-   server relationship.
-
-   @param temp_directory
-     The (shared) temporary directory, e.g., as created from
-     drake::temp_directory().  File responses from a server will be stored here.
-     The %HttpService does **not** own this directory, and is not responsible
-     for deleting it.  No validity checks on this directory are performed,
-     concrete derived classes are responsible for verifying that any temporary
-     files needed can be created.
-   @param url
-     The url this HTTP service will communicate with.  May **not** be the empty
-     string.  May **not** have any trailing slashes.  Helper methods such as
-     PostForm() construct their communications as
-     `temp_directory() + "/" + endpoint`.  For example, `https://drake.mit.edu`
-     will be accepted, but `https://drake.mit.edu/` will not be.  No other url
-     validation is performed (e.g., there is no initial transaction to verify
-     the server exists).
-   @param port
-     The TCP port this HTTP service will communicate on.  A value less than or
-     equal to `0` implies no port level communication is needed.
-   @param verbose
-     Whether or not client/server communications should be logged.
-   @throws std::logic_error
-     If the provided `url` is empty, or has any trailing slashes. */
-  HttpService(const std::string& temp_directory, const std::string& url,
-              int32_t port, bool verbose);
-
-  virtual ~HttpService() = default;
-
-  /** Clones the http service -- making the %HttpService compatible with
-   copyable_unique_ptr. */
-  std::unique_ptr<HttpService> Clone() const;
+  HttpService();
+  virtual ~HttpService();
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(HttpService);
 
   /** @name Server Interaction Interface */
   //@{
@@ -175,6 +136,22 @@ class HttpService {
    Make sure to check HttpResponse::Good() before continuing, or trying to load
    the HttpResponse::data_path as any specific kind of file.
 
+   @param temp_directory
+     The (shared) temporary directory, e.g., as created from
+     drake::temp_directory().  File responses from a server will be stored here.
+     The %HttpService does **not** own this directory, and is not responsible
+     for deleting it.  No validity checks on this directory are performed,
+     caller is responsible for providing a directory that can be used as scratch
+     space (e.g., from drake::temp_directory()).
+   @param url
+     The url this HTTP service will communicate with.  May **not** be the empty
+     string.  May **not** have any trailing slashes.  Communications are
+     typically constructed as  `temp_directory() + "/" + endpoint`.  For
+     example, `https://drake.mit.edu` is acceptable, but
+     `https://drake.mit.edu/` is not.
+   @param port
+     The TCP port this HTTP service will communicate on.  A value less than or
+     equal to `0` implies no port level communication is needed.
    @param endpoint
      The endpoint the `<form>` should be posted to, e.g., `render`.  May **not**
      have a leading or trailing `/`, the post is sent to
@@ -206,6 +183,8 @@ class HttpService {
      file_fields["id"] = {"/path/to/id.bin", std::nullopt};
      @endcode
      Supply the empty map if no files are to be uploaded with the `<form>`.
+   @param verbose
+     Whether or not client/server communications should be logged.
    @return HttpResponse
      The response from the server, including an HTTP code, and any potential
      additional server response text or data in HttpResponse::data_path.
@@ -218,39 +197,20 @@ class HttpService {
      produce an exception but rather encode this information in the
      returned HttpResponse for the caller to determine how to proceed. */
   virtual HttpResponse PostForm(
+      const std::string& temp_directory, const std::string& url, int32_t port,
       const std::string& endpoint,
       const std::map<std::string, std::string>& data_fields,
       const std::map<std::string,
                      std::pair<std::string, std::optional<std::string>>>&
-          file_fields) = 0;
+          file_fields,
+      bool verbose = false) = 0;
   //@}
-  /** @name Access the default properties
 
-   Provides access to the default values of this instance.  These values must be
-   set at construction. */
+  /** @name Server Parameter Validation Helpers */
   //@{
-  /** The folder where server file responses are stored.
-   @sa HttpResponse::data_path */
-  const std::string& temp_directory() const { return temp_directory_; }
-
-  /** The url of the server to communicate with. */
-  const std::string& url() const { return url_; }
-
-  /** The port of the server to communicate on.  A value less than or equal to
-   `0` means no port level communication is required. */
-  int32_t port() const { return port_; }
-
-  /** Wether or not client/server communications should be logged to
-   drake::log(). */
-  bool verbose() const { return verbose_; }
-  //@}
-
- protected:
-  /** Copy constructor for the purpose of cloning. */
-  HttpService(const HttpService& other);
-
-  /** The NVI-function for cloning this http service. */
-  virtual std::unique_ptr<HttpService> DoClone() const = 0;
+  /** Throws `std::logic_error` if the provided url is empty or has trailing
+   slashes. */
+  void ThrowIfUrlInvalid(const std::string& url) const;
 
   /** Throws `std::runtime_error` if `endpoint` starts or ends with a '/'. */
   void ThrowIfEndpointInvalid(const std::string& endpoint) const;
@@ -265,12 +225,7 @@ class HttpService {
       const std::map<std::string,
                      std::pair<std::string, std::optional<std::string>>>&
           file_fields) const;
-
- private:
-  std::string temp_directory_;
-  std::string url_;
-  int32_t port_;
-  bool verbose_;
+  //@}
 };
 
 }  // namespace internal

--- a/geometry/render/dev/http_service_curl.h
+++ b/geometry/render/dev/http_service_curl.h
@@ -17,25 +17,19 @@ namespace internal {
 /** An HttpService that uses libcurl to communicate with the server. */
 class HttpServiceCurl : public HttpService {
  public:
-  /** Constructs a libcurl based HttpService.  @sa HttpService::HttpService */
-  HttpServiceCurl(const std::string& temp_directory, const std::string& url,
-                  int32_t port, bool verbose);
+  HttpServiceCurl();
   ~HttpServiceCurl() override;
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(HttpServiceCurl);
 
   /** @see HttpService::PostForm */
   HttpResponse PostForm(
+      const std::string& temp_directory, const std::string& url, int32_t port,
       const std::string& endpoint,
       const std::map<std::string, std::string>& data_fields,
       const std::map<std::string,
                      std::pair<std::string, std::optional<std::string>>>&
-          file_fields) override;
-
- protected:
-  /** Copy constructor for the purpose of cloning. */
-  HttpServiceCurl(const HttpServiceCurl& other);
-
-  /** Clones this %HttpServiceCurl. */
-  std::unique_ptr<HttpService> DoClone() const override;
+          file_fields,
+      bool verbose = false) override;
 };
 
 }  // namespace internal

--- a/geometry/render/dev/test/http_service_test.cc
+++ b/geometry/render/dev/test/http_service_test.cc
@@ -7,6 +7,7 @@
 
 #include "drake/common/filesystem.h"
 #include "drake/common/temp_directory.h"
+#include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 
 namespace drake {
@@ -20,152 +21,58 @@ namespace fs = drake::filesystem;
 // A concrete implementation of HttpService that does nothing.
 class EmptyService : public HttpService {
  public:
-  EmptyService(const std::string& temp_directory, const std::string& url,
-               int32_t port, bool verbose)
-      : HttpService(temp_directory, url, port, verbose) {}
-
-  EmptyService(const EmptyService& other) : HttpService(other) {}
+  EmptyService() : HttpService() {}
 
   HttpResponse PostForm(
-      const std::string& endpoint,
+      const std::string& /* temp_directory */, const std::string& url,
+      int32_t /* port */, const std::string& endpoint,
       const std::map<std::string, std::string>& /* data_fields */,
       const std::map<std::string,
                      std::pair<std::string, std::optional<std::string>>>&
-          file_fields) override {
+          file_fields,
+      bool /* verbose */ = false) override {
+    ThrowIfUrlInvalid(url);
     ThrowIfEndpointInvalid(endpoint);
     ThrowIfFilesMissing(file_fields);
     HttpResponse ret;
     ret.http_code = 200;
     return ret;
   }
-
-  std::unique_ptr<HttpService> DoClone() const override {
-    return std::unique_ptr<EmptyService>(new EmptyService(*this));
-  }
 };
 
-// A concrete derived-derived class that properly implements cloning.
-class EmptyServiceGoodClone : public EmptyService {
- public:
-  EmptyServiceGoodClone(const std::string& temp_directory,
-                        const std::string& url, int32_t port, bool verbose)
-      : EmptyService(temp_directory, url, port, verbose) {}
-
-  EmptyServiceGoodClone(const EmptyServiceGoodClone& other)
-      : EmptyService(other) {}
-
-  std::unique_ptr<HttpService> DoClone() const override {
-    return std::unique_ptr<EmptyServiceGoodClone>(
-        new EmptyServiceGoodClone(*this));
-  }
-};
-
-// A concrete derived-derived class that does *not* implement cloning.
-class EmptyServiceBadClone : public EmptyService {
- public:
-  EmptyServiceBadClone(const std::string& temp_directory,
-                       const std::string& url, int32_t port, bool verbose)
-      : EmptyService(temp_directory, url, port, verbose) {}
-
-  EmptyServiceBadClone(const EmptyServiceBadClone& other)
-      : EmptyService(other) {}
-};
-
-GTEST_TEST(HttpServiceTest, Constructor) {
+GTEST_TEST(HttpService, ThrowIfUrlInvalid) {
   const std::string localhost{"127.0.0.1"};
-  const int32_t port{8000};
+  const EmptyService es;
 
-  {
-    // Validate normal construction works as expected.
-    const auto temp_dir = drake::temp_directory();
-    EmptyService es{temp_dir, localhost, port, false};
-    EXPECT_EQ(temp_dir, es.temp_directory());
-    EXPECT_EQ(localhost, es.url());
-    EXPECT_EQ(port, es.port());
-    EXPECT_EQ(false, es.verbose());
-    fs::remove(temp_dir);
-  }
+  // A valid url should not raise.
+  DRAKE_EXPECT_NO_THROW(es.ThrowIfUrlInvalid(localhost));
 
-  {
-    // An empty url should raise.
-    const auto temp_dir = drake::temp_directory();
-    DRAKE_EXPECT_THROWS_MESSAGE(EmptyService(temp_dir, "", port, false),
-                                "HttpService: url parameter may not be empty.");
+  // An empty url should raise.
+  DRAKE_EXPECT_THROWS_MESSAGE(es.ThrowIfUrlInvalid(""),
+                              "HttpService: url parameter may not be empty.");
 
-    // A url with a '/' at the end should raise.
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        EmptyService(temp_dir, localhost + "/", port, false),
-        "HttpService: url may not end with '/'.");
-    fs::remove(temp_dir);
-  }
-}
-
-GTEST_TEST(HttpService, Clone) {
-  // Create some parameters to use for testing clones.
-  const auto temp_dir = drake::temp_directory();
-  const std::string url{"0.0.0.0"};
-  const int32_t port{8192};
-  const bool verbose{true};
-  auto verify_attributes = [&](const HttpService& service) {
-    EXPECT_EQ(service.temp_directory(), temp_dir);
-    EXPECT_EQ(service.url(), url);
-    EXPECT_EQ(service.port(), port);
-    EXPECT_EQ(service.verbose(), verbose);
-  };
-
-  {
-    // Verify construction and cloning of EmptyService works.
-    EmptyService es{temp_dir, url, port, verbose};
-    verify_attributes(es);
-    auto clone = es.Clone();
-    verify_attributes(*clone);
-  }
-
-  {
-    // Verify construction and cloning of EmptyServiceGoodClone works.
-    EmptyServiceGoodClone esgc{temp_dir, url, port, verbose};
-    verify_attributes(esgc);
-    auto clone = esgc.Clone();
-    verify_attributes(*clone);
-  }
-
-  {
-    /* Verify that a derived class of a derived class that does not implement
-     DoClone() throws an exception. */
-    EmptyServiceBadClone esbc{temp_dir, url, port, verbose};
-    verify_attributes(esbc);
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        esbc.Clone(),
-        "Error in cloning HttpService class of type.*EmptyServiceBadClone; the "
-        "clone returns type .*EmptyService\\..*EmptyServiceBadClone::DoClone"
-        "\\(\\) was probably not implemented");
-  }
-
-  fs::remove(temp_dir);
+  // A url with a '/' at the end should raise.
+  DRAKE_EXPECT_THROWS_MESSAGE(es.ThrowIfUrlInvalid(localhost + "/"),
+                              "HttpService: url may not end with '/'.");
 }
 
 GTEST_TEST(HttpService, ThrowIfEndpointInvalid) {
-  auto temp_dir = drake::temp_directory();
-  EmptyService es{temp_dir, "127.0.0.1", 8000, false};
+  const EmptyService es;
 
   {
-    // Valid endpoint: no error.
-    auto response = es.PostForm("render", {}, {});
-    EXPECT_EQ(response.http_code, 200);
-
-    // Valid endpoint: no error, empty implies route to /.
-    response = es.PostForm("", {}, {});
-    EXPECT_EQ(response.http_code, 200);
-
-    // Valid endpoint: no error, interior / is allowed.
-    response = es.PostForm("render/scene", {}, {});
-    EXPECT_EQ(response.http_code, 200);
+    // Valid endpoints should not raise.
+    DRAKE_EXPECT_NO_THROW(es.ThrowIfEndpointInvalid("render"));
+    // Empty string implies route to /.
+    DRAKE_EXPECT_NO_THROW(es.ThrowIfEndpointInvalid(""));
+    // Interior / is allowed.
+    DRAKE_EXPECT_NO_THROW(es.ThrowIfEndpointInvalid("render/scene"));
   }
 
-  const std::string exc_message =
-      "Provided endpoint='{}' is not valid, it may not start or end with a "
-      "'/'.";
   {
+    // Invalid endpoints should raise.
+    const std::string exc_message =
+        "Provided endpoint='{}' is not valid, it may not start or end with a "
+        "'/'.";
     const std::vector<std::string> bad_endpoints{"/",
                                                  "//",
                                                  "/render",
@@ -175,7 +82,7 @@ GTEST_TEST(HttpService, ThrowIfEndpointInvalid) {
                                                  "/render/scene/",
                                                  "render/scene/"};
     for (const auto& endpoint : bad_endpoints) {
-      DRAKE_EXPECT_THROWS_MESSAGE(es.PostForm(endpoint, {}, {}),
+      DRAKE_EXPECT_THROWS_MESSAGE(es.ThrowIfEndpointInvalid(endpoint),
                                   fmt::format(exc_message, endpoint));
     }
   }
@@ -183,27 +90,25 @@ GTEST_TEST(HttpService, ThrowIfEndpointInvalid) {
 
 GTEST_TEST(HttpService, ThrowIfFilesMissing) {
   // Create an EmptyService and some files to test with.
-  auto temp_dir = drake::temp_directory();
-  EmptyService es{temp_dir, "127.0.0.1", 8000, true};
+  const auto temp_dir = drake::temp_directory();
+  const EmptyService es;
 
-  auto test_txt_path = (fs::path(temp_dir) / "test.txt").string();
+  const auto test_txt_path = (fs::path(temp_dir) / "test.txt").string();
   std::ofstream test_txt{test_txt_path};
   test_txt << "test!\n";
   test_txt.close();
 
-  auto fake_jpg_path = (fs::path(temp_dir) / "fake.jpg").string();
+  const auto fake_jpg_path = (fs::path(temp_dir) / "fake.jpg").string();
   std::ofstream fake_jpg{fake_jpg_path};
   fake_jpg << "not really a jpg!\n";
   fake_jpg.close();
 
   {
     // No exception should be thrown if all files are present.
-    auto response = es.PostForm("upload", {},
-                                {
-                                    {"test", {test_txt_path, std::nullopt}},
-                                    {"image", {fake_jpg_path, "image/jpeg"}},
-                                });
-    EXPECT_EQ(response.http_code, 200);
+    DRAKE_EXPECT_NO_THROW(es.ThrowIfFilesMissing({
+        {"test", {test_txt_path, std::nullopt}},
+        {"image", {fake_jpg_path, "image/jpeg"}},
+    }));
   }
 
   // Some file paths that do not exist for testing.
@@ -212,13 +117,13 @@ GTEST_TEST(HttpService, ThrowIfFilesMissing) {
       "/unlikely/to/exist.file_extension", std::nullopt};
   const std::string missing_1_desc{
       "missing_1='/unlikely/to/exist.file_extension'"};
-  EXPECT_FALSE(fs::is_regular_file(missing_1_value.first));
+  ASSERT_FALSE(fs::is_regular_file(missing_1_value.first));
 
   const std::string missing_2_key = "missing_2";
   const std::pair<std::string, std::optional<std::string>> missing_2_value = {
       "/this/is/not/a.real_file", std::nullopt};
   const std::string missing_2_desc{"missing_2='/this/is/not/a.real_file'"};
-  EXPECT_FALSE(fs::is_regular_file(missing_2_value.first));
+  ASSERT_FALSE(fs::is_regular_file(missing_2_value.first));
 
   // The exception message prefix.
   const std::string prefix = "Provided file fields had missing file\\(s\\): ";
@@ -230,35 +135,33 @@ GTEST_TEST(HttpService, ThrowIfFilesMissing) {
   {
     // Exception thrown: one file, does not exist.
     DRAKE_EXPECT_THROWS_MESSAGE(
-        es.PostForm("upload", {}, {{missing_1_key, missing_1_value}}),
+        es.ThrowIfFilesMissing({{missing_1_key, missing_1_value}}),
         prefix + missing_1_desc + "\\.");
   }
 
   {
     // Exception thrown: multiple files, none exist.
-    DRAKE_EXPECT_THROWS_MESSAGE(es.PostForm("upload", {},
-                                            {{missing_1_key, missing_1_value},
-                                             {missing_2_key, missing_2_value}}),
-                                make_regex(missing_1_desc, missing_2_desc));
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        es.ThrowIfFilesMissing({{missing_1_key, missing_1_value},
+                                {missing_2_key, missing_2_value}}),
+        make_regex(missing_1_desc, missing_2_desc));
   }
 
   {
     // Exception thrown: one file exists, the other does not.
     DRAKE_EXPECT_THROWS_MESSAGE(
-        es.PostForm("upload", {},
-                    {{"test", {test_txt_path, std::nullopt}},
-                     {missing_1_key, missing_1_value}}),
+        es.ThrowIfFilesMissing({{"test", {test_txt_path, std::nullopt}},
+                                {missing_1_key, missing_1_value}}),
         prefix + missing_1_desc + "\\.");
   }
 
   {
     // Exception thrown: multiple files exist, multiple do not.
     DRAKE_EXPECT_THROWS_MESSAGE(
-        es.PostForm("upload", {},
-                    {{"test", {test_txt_path, std::nullopt}},
-                     {missing_1_key, missing_1_value},
-                     {"image", {fake_jpg_path, "image/jpeg"}},
-                     {missing_2_key, missing_2_value}}),
+        es.ThrowIfFilesMissing({{"test", {test_txt_path, std::nullopt}},
+                                {missing_1_key, missing_1_value},
+                                {"image", {fake_jpg_path, "image/jpeg"}},
+                                {missing_2_key, missing_2_value}}),
         make_regex(missing_1_desc, missing_2_desc));
   }
 


### PR DESCRIPTION
Related to the [temp directory cloning discussion](https://drakedevelopers.slack.com/archives/C02HMU7B15Y/p1647031224056499) [TL;DR: get rid of state here and disable cloning, copy, move, assign for `HttpService` and `RenderClient`].

Doing as a separate PR for bikeshedding purposes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16776)
<!-- Reviewable:end -->
