### PR TITLE
Removes unnecessary cone constraint smoothness specification

### DIFF
--- a/multibody/contact_solvers/sap/test/sap_friction_cone_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_friction_cone_constraint_test.cc
@@ -185,8 +185,7 @@ Vector3d SolveProjectionWithScs(double mu, const Vector3d& R,
   const Matrix3d A =
       (Matrix3d() << 0., 0., mu, 1., 0., 0., 0., 1., 0.).finished();
   const Vector3d b = Vector3d::Zero();
-  auto cone_constraint = std::make_shared<LorentzConeConstraint>(
-      A, b, LorentzConeConstraint::EvalType::kConvexSmooth);  // kConvexSmooth
+  auto cone_constraint = std::make_shared<LorentzConeConstraint>(A, b);
   Binding<LorentzConeConstraint> binding(cone_constraint, gamma);
   prog.AddConstraint(binding);
 


### PR DESCRIPTION
I thought I'd only remove this dead comment. But I realized that specifying smoothness when using SCS should have no effect and therefore I removed it. Would you confirm @hongkai-dai?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16777)
<!-- Reviewable:end -->
