### PR TITLE
[solvers] Combine MathematicalProgram::AddConstraint overloads

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -946,7 +946,7 @@ void BindMathematicalProgram(py::module m) {
             return self->AddConstraint(formulas);
           },
           py::arg("formulas"),
-          doc.MathematicalProgram.AddConstraint.doc_matrix_formula)
+          doc.MathematicalProgram.AddConstraint.doc_1args_constEigenDenseBase)
       .def("AddLinearConstraint",
           static_cast<Binding<LinearConstraint> (MathematicalProgram::*)(
               const Eigen::Ref<const Eigen::MatrixXd>&,
@@ -981,8 +981,7 @@ void BindMathematicalProgram(py::module m) {
             return self->AddLinearConstraint(formulas.array());
           },
           py::arg("formulas"),
-          doc.MathematicalProgram.AddLinearConstraint
-              .doc_1args_constEigenArrayBase)
+          doc.MathematicalProgram.AddLinearConstraint.doc_1args_formulas)
       .def("AddLinearEqualityConstraint",
           static_cast<Binding<LinearEqualityConstraint> (
               MathematicalProgram::*)(const Eigen::Ref<const Eigen::MatrixXd>&,


### PR DESCRIPTION
A single overload is sufficient for both `Matrix<Formula>` or `Array<Formula>`. This reduces documentation and maintenance burden.

Remove two dead private helper functions on `MathematicalProgram` (for `std::set`).

Similarly, combine the `internal::ParseConstraint` overloads and move the remaining implementation into cc file per GSG.  Note that the diffs here area not great, because it's the overload definition from the header file that still survives (now in the cc file).

Towards #16761.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16778)
<!-- Reviewable:end -->
