### PR TITLE
[parsing] Remove deprecated `drake:elastic_modulus`

### DIFF
--- a/multibody/parsing/detail_common.cc
+++ b/multibody/parsing/detail_common.cc
@@ -71,19 +71,6 @@ geometry::ProximityProperties ParseProximityProperties(
 
   std::optional<double> hydroelastic_modulus =
       read_double("drake:hydroelastic_modulus");
-  {
-    std::optional<double> elastic_modulus =
-        read_double("drake:elastic_modulus");
-    if (elastic_modulus.has_value()) {
-      static const logging::Warn log_once(
-          "The tag drake:elastic_modulus is deprecated, and will be removed on"
-          " or around 2022-02-01. Please use drake:hydroelastic_modulus"
-          " instead.");
-    }
-    if (!hydroelastic_modulus.has_value()) {
-      hydroelastic_modulus = elastic_modulus;
-    }
-  }
   if (hydroelastic_modulus) {
     if (is_rigid) {
       static const logging::Warn log_once(

--- a/multibody/parsing/test/detail_common_test.cc
+++ b/multibody/parsing/test/detail_common_test.cc
@@ -207,21 +207,6 @@ GTEST_TEST(ParseProximityPropertiesTest, RigidHydroelasticModulusIgnored) {
   EXPECT_EQ(properties.num_groups(), 2);  // Hydro and default groups.
 }
 
-// TODO(DamrongGuoy): Remove this test when we remove the support of the tag
-//  drake:elastic_modulus. See ParseProximityProperties().
-
-// Confirms the tag drake:elastic_modulus is still working.
-// The tag drake:elastic_modulus is deprecated, and will be removed on or
-// around 2022-02-01.
-GTEST_TEST(ParseProximityPropertiesTest, DeprecateElasticModulus) {
-  const double kValue = 1.75;
-  ProximityProperties properties = ParseProximityProperties(
-      param_read_double("drake:elastic_modulus", kValue), !rigid, !compliant);
-  EXPECT_TRUE(ExpectScalar(kHydroGroup, kElastic, kValue, properties));
-  EXPECT_EQ(properties.GetPropertiesInGroup(kHydroGroup).size(), 1u);
-  EXPECT_EQ(properties.num_groups(), 2);  // Hydro and default groups.
-}
-
 // Confirms successful parsing of dissipation.
 GTEST_TEST(ParseProximityPropertiesTest, Dissipation) {
   const double kValue = 1.25;


### PR DESCRIPTION
The deprecation began during the "hydro is experimental" period, so
wasn't done formally with announcements in release notes, etc. However,
the advertised deprecation period has elapsed. It can go.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16786)
<!-- Reviewable:end -->
