### PR TITLE
[tools] Don't enable (split) debug symbols in release builds

### DIFF
--- a/tools/ubuntu-bionic.bazelrc
+++ b/tools/ubuntu-bionic.bazelrc
@@ -1,4 +1,4 @@
-build --fission=yes
+build --fission=dbg
 build --features=per_object_debug_info
 
 build:_drd --extra_toolchains=//tools/py_toolchain:linux_dbg_toolchain


### PR DESCRIPTION
This partially reverts cdd6652095c356f9c48b49fde60fbe392e465960 (https://github.com/RobotLocomotion/drake/pull/16587).

Build times for Release builds were substantially bloated as of that change, because fission turns on `-g`.  We should only do that in `-c dbg` builds.

The [linux-focal-unprovisioned-gcc-bazel-continuous-release build 2506](https://drake-jenkins.csail.mit.edu/view/Unprovisioned/job/linux-focal-unprovisioned-gcc-bazel-continuous-release/2506/) pretty clearly shows a 50% slowdown exactly when this commit landed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16788)
<!-- Reviewable:end -->
