### PR TITLE
[multibody] Install deprecated contact_results_to_meshcat.h header

### DIFF
--- a/multibody/contact_solvers/sap/BUILD.bazel
+++ b/multibody/contact_solvers/sap/BUILD.bazel
@@ -5,11 +5,26 @@ load(
     "@drake//tools/skylark:drake_cc.bzl",
     "drake_cc_googletest",
     "drake_cc_library",
+    "drake_cc_package_library",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(
     default_visibility = ["//visibility:public"],
+)
+
+drake_cc_package_library(
+    name = "sap",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":contact_problem_graph",
+        ":partial_permutation",
+        ":sap_constraint",
+        ":sap_constraint_bundle",
+        ":sap_contact_problem",
+        ":sap_friction_cone_constraint",
+        ":sap_model",
+    ],
 )
 
 drake_cc_library(

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -60,6 +60,7 @@ LIBDRAKE_COMPONENTS = [
     "//multibody/benchmarks/pendulum",
     "//multibody/constraint",
     "//multibody/contact_solvers",
+    "//multibody/contact_solvers/sap",
     "//multibody/hydroelastics",
     "//multibody/inverse_kinematics",
     "//multibody/math",
@@ -68,6 +69,8 @@ LIBDRAKE_COMPONENTS = [
     "//multibody/parsing",
     "//multibody/plant",
     "//multibody/plant:contact_results_to_lcm",  # unpackaged
+    "//multibody/plant:contact_results_to_meshcat",  # unpackaged
+    "//multibody/plant:contact_results_to_meshcat_params",  # unpackaged
     "//multibody/topology:multibody_graph",  # unpackaged
     "//multibody/tree",
     "//multibody/triangle_quadrature",


### PR DESCRIPTION
This fixes an omission from 8b96d899578e5d7f2059e9a991ecc9e4b1a393ea (#16437).

Also add an SAP solver package_library, to de-chaff the install list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16789)
<!-- Reviewable:end -->
