### PR TITLE
[parsing] Stop using mutable globals

### DIFF
--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -1290,7 +1290,6 @@ sdf::ParserConfig MakeSdfParserConfig(
     MultibodyPlant<double>* plant,
     bool test_sdf_forced_nesting) {
 
-  // TODO(marcoag) ensure that we propagate the right ParserConfig instance.
   sdf::ParserConfig parser_config;
   parser_config.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   parser_config.SetDeprecatedElementsPolicy(sdf::EnforcementPolicy::WARN);

--- a/tools/workspace/sdformat/patches/fix_broken_config.patch
+++ b/tools/workspace/sdformat/patches/fix_broken_config.patch
@@ -1,0 +1,51 @@
+Fix a lack of ParserConfig propagation.
+
+This fix should be submitted to libsdformat upstream.
+
+--- src/parser.cc.orig	2021-09-30 15:33:35.000000000 -0700
+--- src/parser.cc	2022-03-14 23:23:10.623173055 -0700
+@@ -181,7 +181,7 @@
+ /// \param[out] _errors Captures errors encountered during parsing.
+ static void insertIncludedElement(sdf::SDFPtr _includeSDF,
+                                   const SourceLocation &_sourceLoc, bool _merge,
+-                                  sdf::ElementPtr _parent, sdf::Errors &_errors)
++                                  sdf::ElementPtr _parent, const ParserConfig &_config, sdf::Errors &_errors)
+ {
+   Error invalidFileError(ErrorCode::FILE_READ,
+                          "Included model is invalid. Skipping model.");
+@@ -231,7 +231,7 @@
+   // We create a throwaway sdf::Root object in order to validate the
+   // included entity.
+   sdf::Root includedRoot;
+-  sdf::Errors includeDOMerrors = includedRoot.Load(_includeSDF);
++  sdf::Errors includeDOMerrors = includedRoot.Load(_includeSDF, _config);
+   _errors.insert(_errors.end(), includeDOMerrors.begin(),
+                  includeDOMerrors.end());
+ 
+@@ -1512,7 +1512,7 @@
+     ElementPtr refSDF;
+     refSDF.reset(new Element);
+     std::string refFilename = refSDFStr + ".sdf";
+-    initFile(refFilename, refSDF);
++    initFile(refFilename, _config, refSDF);
+     _sdf->RemoveFromParent();
+     _sdf->Copy(refSDF);
+ 
+@@ -1585,7 +1585,7 @@
+           SDFPtr includeSDF(new SDF);
+           includeSDF->Root(includeSDFTemplate->Root()->Clone());
+ 
+-          if (!readFile(filename, includeSDF))
++          if (!readFile(filename, _config, includeSDF, _errors))
+           {
+             Error err(
+                 ErrorCode::FILE_READ,
+@@ -1803,7 +1803,7 @@
+           SourceLocation sourceLoc{includeXmlPath, _source,
+                                    elemXml->GetLineNum()};
+ 
+-          insertIncludedElement(includeSDF, sourceLoc, toMerge, _sdf, _errors);
++          insertIncludedElement(includeSDF, sourceLoc, toMerge, _sdf, _config, _errors);
+           continue;
+         }
+       }

--- a/tools/workspace/sdformat/patches/no_global_config.patch
+++ b/tools/workspace/sdformat/patches/no_global_config.patch
@@ -1,0 +1,78 @@
+Change the global singleton into a bomb.
+
+Use the default config when parsing the built-in root.sdf, and
+in the ign_sdf command-line tool.
+
+--- src/ParserConfig.cc.orig	2021-09-30 15:33:35.000000000 -0700
++++ src/ParserConfig.cc	2022-03-14 22:49:17.262811731 -0700
+@@ -57,8 +57,7 @@
+ /////////////////////////////////////////////////
+ ParserConfig &ParserConfig::GlobalConfig()
+ {
+-  static auto *defaultConfig = new ParserConfig;
+-  return *defaultConfig;
++  throw std::runtime_error("Drake must never use ParserConfig::GlobalConfig()");
+ }
+ 
+ /////////////////////////////////////////////////
+
+--- src/parser.cc.orig	2021-09-30 15:33:35.000000000 -0700
++++ src/parser.cc	2022-03-14 23:16:20.973451521 -0700
+@@ -597,7 +597,7 @@
+ 
+     ElementPtr element(new Element);
+ 
+-    initFile(filename, element);
++    initFile(filename, ParserConfig{}, element);
+ 
+     // override description for include elements
+     tinyxml2::XMLElement *description = child->FirstChildElement("description");
+--- src/ign.cc.orig	2021-09-30 15:33:35.000000000 -0700
++++ src/ign.cc	2022-03-15 00:13:58.609410856 -0700
+@@ -36,7 +36,7 @@
+   int result = 0;
+ 
+   sdf::Root root;
+-  sdf::Errors errors = root.Load(_path);
++  sdf::Errors errors = root.Load(_path, sdf::ParserConfig{});
+   if (!errors.empty())
+   {
+     for (auto &error : errors)
+@@ -85,8 +85,12 @@
+     return -1;
+   }
+ 
+-  if (!sdf::readFile(_path, sdf))
++  if (!sdf::readFile(_path, sdf::ParserConfig{}, sdf, errors))
+   {
++    for (auto &error : errors)
++    {
++      std::cerr << error << std::endl;
++    }
+     std::cerr << "Error: SDF parsing the xml failed.\n";
+     return -1;
+   }
+@@ -147,8 +152,13 @@
+     return -1;
+   }
+ 
+-  if (!sdf::readFile(_path, sdf))
++  sdf::Errors errors;
++  if (!sdf::readFile(_path, sdf::ParserConfig{}, sdf, errors))
+   {
++    for (auto &error : errors)
++    {
++      std::cerr << error << std::endl;
++    }
+     std::cerr << "Error: SDF parsing the xml failed.\n";
+     return -1;
+   }
+@@ -170,7 +180,7 @@
+   }
+ 
+   sdf::Root root;
+-  sdf::Errors errors = root.Load(_path);
++  sdf::Errors errors = root.Load(_path, sdf::ParserConfig{});
+   if (!errors.empty())
+   {
+     std::cerr << errors << std::endl;

--- a/tools/workspace/sdformat/repository.bzl
+++ b/tools/workspace/sdformat/repository.bzl
@@ -13,6 +13,8 @@ def sdformat_repository(
         build_file = "@drake//tools/workspace/sdformat:package.BUILD.bazel",
         patches = [
             "@drake//tools/workspace/sdformat:patches/console.patch",
+            "@drake//tools/workspace/sdformat:patches/fix_broken_config.patch",
+            "@drake//tools/workspace/sdformat:patches/no_global_config.patch",
             "@drake//tools/workspace/sdformat:patches/no_urdf.patch",
         ],
         mirrors = mirrors,


### PR DESCRIPTION
This ensures that our parsing configuration is always what we asked for.

Towards #16784.

A related issue has been filed upstream as https://github.com/ignitionrobotics/sdformat/issues/881.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16791)
<!-- Reviewable:end -->
