### PR TITLE
[yaml] Extract Options struct out of YamlReadArchive

### DIFF
--- a/common/yaml/BUILD.bazel
+++ b/common/yaml/BUILD.bazel
@@ -16,10 +16,17 @@ drake_cc_package_library(
     visibility = ["//visibility:public"],
     deps = [
         ":yaml_io",
+        ":yaml_io_options",
         ":yaml_node",
         ":yaml_read_archive",
         ":yaml_write_archive",
     ],
+)
+
+drake_cc_library(
+    name = "yaml_io_options",
+    srcs = ["yaml_io_options.cc"],
+    hdrs = ["yaml_io_options.h"],
 )
 
 drake_cc_library(
@@ -36,6 +43,7 @@ drake_cc_library(
     srcs = ["yaml_read_archive.cc"],
     hdrs = ["yaml_read_archive.h"],
     deps = [
+        ":yaml_io_options",
         ":yaml_node",
         "//common:essential",
         "//common:name_value",
@@ -64,6 +72,7 @@ drake_cc_library(
     srcs = ["yaml_io.cc"],
     hdrs = ["yaml_io.h"],
     deps = [
+        ":yaml_io_options",
         ":yaml_read_archive",
         ":yaml_write_archive",
     ],

--- a/common/yaml/test/yaml_io_test.cc
+++ b/common/yaml/test/yaml_io_test.cc
@@ -73,7 +73,7 @@ extra_junk: will_be_ignored
 )""";
   const std::optional<std::string> no_child_name;
   const std::optional<StringStruct> no_defaults;
-  YamlReadArchive::Options options;
+  LoadYamlOptions options;
   options.allow_yaml_with_no_cpp = true;
   const auto result = LoadYamlString<StringStruct>(
       data, no_child_name, no_defaults, options);
@@ -94,7 +94,7 @@ extra_junk:
 )""";
   const std::optional<std::string> no_child_name;
   const MapStruct defaults;  // The defaults contains kNominalDouble already.
-  YamlReadArchive::Options options;
+  LoadYamlOptions options;
   options.allow_yaml_with_no_cpp = true;
   const auto result = LoadYamlString<MapStruct>(
       data, no_child_name, defaults, options);

--- a/common/yaml/test/yaml_performance_test.cc
+++ b/common/yaml/test/yaml_performance_test.cc
@@ -85,7 +85,7 @@ GTEST_TEST(YamlPerformanceTest, VectorNesting) {
     // We'll set the hard limit ~20x higher than currently observed to allow
     // some flux as library implementations evolve, etc.
     test::LimitMalloc guard({.max_num_allocations = 1'000'000});
-    const YamlReadArchive::Options default_options;
+    const LoadYamlOptions default_options;
     YamlReadArchive archive(std::move(yaml_root), default_options);
     archive.Accept(&new_data);
   }
@@ -182,7 +182,7 @@ GTEST_TEST(YamlPerformanceTest, EigenMatrix) {
     // We'll set the hard limit ~20x higher than currently observed to allow
     // some flux as library implementations evolve, etc.
     test::LimitMalloc guard({.max_num_allocations = 250000});
-    const YamlReadArchive::Options default_options;
+    const LoadYamlOptions default_options;
     YamlReadArchive archive(std::move(yaml_root), default_options);
     archive.Accept(&new_data);
   }

--- a/common/yaml/test/yaml_read_archive_test.cc
+++ b/common/yaml/test/yaml_read_archive_test.cc
@@ -26,7 +26,7 @@ namespace {
 
 // A test fixture with common helpers.
 class YamlReadArchiveTest
-    : public ::testing::TestWithParam<YamlReadArchive::Options> {
+    : public ::testing::TestWithParam<LoadYamlOptions> {
  public:
   // Loads a single "doc: { ... }" map from `contents` and returns the nested
   // map (i.e., just the "{ ... }" part, not the "doc" part).  It is an error
@@ -1033,12 +1033,12 @@ doc:
       " [^ ]*InnerStruct inner_struct\\.");
 }
 
-std::vector<YamlReadArchive::Options> MakeAllPossibleOptions() {
-  std::vector<YamlReadArchive::Options> all;
+std::vector<LoadYamlOptions> MakeAllPossibleOptions() {
+  std::vector<LoadYamlOptions> all;
   for (const bool i : {false, true}) {
     for (const bool j : {false, true}) {
       for (const bool k : {false, true}) {
-        all.push_back(YamlReadArchive::Options{i, j, k});
+        all.push_back(LoadYamlOptions{i, j, k});
       }
     }
   }

--- a/common/yaml/yaml_io.h
+++ b/common/yaml/yaml_io.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 
+#include "drake/common/yaml/yaml_io_options.h"
 #include "drake/common/yaml/yaml_read_archive.h"
 #include "drake/common/yaml/yaml_write_archive.h"
 
@@ -35,7 +36,7 @@ static Serializable LoadYamlFile(
     const std::string& filename,
     const std::optional<std::string>& child_name = std::nullopt,
     const std::optional<Serializable>& defaults = std::nullopt,
-    const std::optional<YamlReadArchive::Options>& options = std::nullopt);
+    const std::optional<LoadYamlOptions>& options = std::nullopt);
 
 /** Loads data from a YAML-formatted string.
 
@@ -62,7 +63,7 @@ static Serializable LoadYamlString(
     const std::string& data,
     const std::optional<std::string>& child_name = std::nullopt,
     const std::optional<Serializable>& defaults = std::nullopt,
-    const std::optional<YamlReadArchive::Options>& options = std::nullopt);
+    const std::optional<LoadYamlOptions>& options = std::nullopt);
 
 /** Saves data as a YAML-formatted file.
 
@@ -124,11 +125,10 @@ template <typename Serializable>
 static Serializable LoadNode(
     internal::Node node,
     const std::optional<Serializable>& defaults,
-    const std::optional<YamlReadArchive::Options>& options) {
+    const std::optional<LoadYamlOptions>& options) {
   // Reify our optional arguments.
   Serializable result = defaults.value_or(Serializable{});
-  YamlReadArchive::Options new_options = options.value_or(
-      YamlReadArchive::Options{});
+  LoadYamlOptions new_options = options.value_or(LoadYamlOptions{});
   if (defaults.has_value() && !options.has_value()) {
     // Do not overwrite existing values.
     new_options.allow_cpp_with_no_yaml = true;
@@ -148,7 +148,7 @@ static Serializable LoadYamlFile(
     const std::string& filename,
     const std::optional<std::string>& child_name,
     const std::optional<Serializable>& defaults,
-    const std::optional<YamlReadArchive::Options>& options) {
+    const std::optional<LoadYamlOptions>& options) {
   internal::Node node = YamlReadArchive::LoadFileAsNode(filename, child_name);
   return internal::LoadNode(std::move(node), defaults, options);
 }
@@ -160,7 +160,7 @@ static Serializable LoadYamlString(
     const std::string& data,
     const std::optional<std::string>& child_name,
     const std::optional<Serializable>& defaults,
-    const std::optional<YamlReadArchive::Options>& options) {
+    const std::optional<LoadYamlOptions>& options) {
   internal::Node node = YamlReadArchive::LoadStringAsNode(data, child_name);
   return internal::LoadNode(std::move(node), defaults, options);
 }

--- a/common/yaml/yaml_io_options.cc
+++ b/common/yaml/yaml_io_options.cc
@@ -1,0 +1,16 @@
+#include "drake/common/yaml/yaml_io_options.h"
+
+namespace drake {
+namespace yaml {
+
+std::ostream& operator<<(std::ostream& os, const LoadYamlOptions& x) {
+  return os << "{.allow_yaml_with_no_cpp = "
+            << x.allow_yaml_with_no_cpp
+            << ", .allow_cpp_with_no_yaml = "
+            << x.allow_cpp_with_no_yaml
+            << ", .retain_map_defaults = "
+            << x.retain_map_defaults << "}";
+}
+
+}  // namespace yaml
+}  // namespace drake

--- a/common/yaml/yaml_io_options.h
+++ b/common/yaml/yaml_io_options.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <ostream>
+
+namespace drake {
+namespace yaml {
+
+/** Configuration for LoadYamlFile() and LoadYamlString() to govern when certain
+conditions are errors or not. Refer to the member fields for details. */
+struct LoadYamlOptions {
+  friend std::ostream& operator<<(std::ostream&, const LoadYamlOptions&);
+
+  /** Allows yaml Maps to have extra key-value pairs that are not Visited by the
+  Serializable being parsed into. In other words, the Serializable types provide
+  an incomplete schema for the YAML data. This allows for parsing only a subset
+  of the YAML data. */
+  bool allow_yaml_with_no_cpp{false};
+
+  /** Allows Serializables to provide more key-value pairs than are present in
+  the YAML data. In other words, the structs have default values that are left
+  intact unless the YAML data provides a value. */
+  bool allow_cpp_with_no_yaml{false};
+
+  /** If set to true, when parsing a std::map the Archive will merge the YAML
+  data into the destination, instead of replacing the std::map contents
+  entirely. In other words, a visited std::map can have default values that are
+  left intact unless the YAML data provides a value *for that specific key*. */
+  bool retain_map_defaults{false};
+};
+
+}  // namespace yaml
+}  // namespace drake

--- a/common/yaml/yaml_read_archive.cc
+++ b/common/yaml/yaml_read_archive.cc
@@ -146,7 +146,9 @@ internal::Node ConvertJbederYamlNodeToDrakeYamlNode(
 
 }  // namespace
 
-YamlReadArchive::YamlReadArchive(internal::Node root, const Options& options)
+YamlReadArchive::YamlReadArchive(
+    internal::Node root,
+    const LoadYamlOptions& options)
     : owned_root_(std::move(root)),
       root_(&owned_root_.value()),
       mapish_item_key_(nullptr),
@@ -379,15 +381,6 @@ void YamlReadArchive::PrintVisitNameType(std::ostream& s) const {
   fmt::print(s, "{} {}",
              drake::NiceTypeName::Get(*debug_visit_type_),
              debug_visit_name_);
-}
-
-std::ostream& operator<<(std::ostream& os, const YamlReadArchive::Options& x) {
-  return os << "{.allow_yaml_with_no_cpp = "
-            << x.allow_yaml_with_no_cpp
-            << ", .allow_cpp_with_no_yaml = "
-            << x.allow_cpp_with_no_yaml
-            << ", .retain_map_defaults = "
-            << x.retain_map_defaults << "}";
 }
 
 }  // namespace yaml

--- a/common/yaml/yaml_read_archive.h
+++ b/common/yaml/yaml_read_archive.h
@@ -22,6 +22,7 @@
 #include "drake/common/name_value.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/unused.h"
+#include "drake/common/yaml/yaml_io_options.h"
 #include "drake/common/yaml/yaml_node.h"
 
 namespace drake {
@@ -33,32 +34,12 @@ class YamlReadArchive final {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(YamlReadArchive)
 
-  /// Configuration for YamlReadArchive to govern when certain conditions are
-  /// errors or not.  Refer to the member fields for details.
-  struct Options {
-    friend std::ostream& operator<<(std::ostream& os, const Options& x);
-
-    /// Allows yaml Maps to have extra key-value pairs that are not Visited by
-    /// the Serializable being parsed into.  In other words, the Serializable
-    /// types provide an incomplete schema for the YAML data.  This allows for
-    /// parsing only a subset of the YAML data.
-    bool allow_yaml_with_no_cpp{false};
-
-    /// Allows Serializables to provide more key-value pairs than are present
-    /// in the YAML data.  In other words, the structs have default values that
-    /// are left intact unless the YAML data provides a value.
-    bool allow_cpp_with_no_yaml{false};
-
-    /// If set to true, when parsing a std::map the Archive will merge the YAML
-    /// data into the destination, instead of replacing the std::map contents
-    /// entirely.  In other words, a visited std::map can have default values
-    /// that are left intact unless the YAML data provides a value *for that
-    /// specific key*.
-    bool retain_map_defaults{false};
-  };
+  /// (To be marked deprecated as of 2022-05-01)
+  /// Compatibility alias; do not use.
+  using Options = LoadYamlOptions;
 
   /// (Internal use only.)
-  YamlReadArchive(internal::Node root, const Options& options);
+  YamlReadArchive(internal::Node root, const LoadYamlOptions& options);
 
   /// (Internal use only.)
   static internal::Node LoadFileAsNode(
@@ -568,7 +549,7 @@ class YamlReadArchive final {
 
   // When the C++ structure and YAML structure disagree, these options govern
   // which mismatches are permitted without an error.
-  const Options options_;
+  const LoadYamlOptions options_;
 
   // The set of NameValue::name keys that have been Visited by the current
   // Serializable's Accept method so far.


### PR DESCRIPTION
This is cleaner for users, and is a prerequisite of moving the archive classes to an internal namespace.

Towards #16706.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16801)
<!-- Reviewable:end -->
