### PR TITLE
[parsing] Use DiagnosticPolicy instead of log_once in SDFormat

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -99,6 +99,7 @@ drake_cc_library(
     ],
     deps = [
         ":package_map",
+        "//common:diagnostic_policy",
         "//common:essential",
         "//geometry:proximity_properties",
         "//math:geometric_transform",
@@ -125,6 +126,7 @@ drake_cc_library(
     deps = [
         ":detail_misc",
         ":package_map",
+        "//common:diagnostic_policy",
         "//geometry:geometry_instance",
         "//geometry:geometry_roles",
         "//geometry:shape_specification",

--- a/multibody/parsing/detail_common.cc
+++ b/multibody/parsing/detail_common.cc
@@ -7,6 +7,8 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
+using drake::internal::DiagnosticPolicy;
+
 DataSource::DataSource(DataSourceType type, const std::string* data)
     : type_(type), data_(data) {
   DRAKE_DEMAND(IsFilename() != IsContents());
@@ -46,6 +48,7 @@ std::string DataSource::GetStem() const {
 }
 
 geometry::ProximityProperties ParseProximityProperties(
+    const DiagnosticPolicy& diagnostic,
     const std::function<std::optional<double>(const char*)>& read_double,
     bool is_rigid, bool is_compliant) {
   using HT = geometry::internal::HydroelasticType;
@@ -73,10 +76,11 @@ geometry::ProximityProperties ParseProximityProperties(
       read_double("drake:hydroelastic_modulus");
   if (hydroelastic_modulus) {
     if (is_rigid) {
-      static const logging::Warn log_once(
-        "Rigid geometries defined with the tag drake:rigid_hydroelastic should"
-        " not contain the tag drake:hydroelastic_modulus. Any values will be"
-        " ignored.");
+      diagnostic.Warning(fmt::format(
+          "Rigid geometries defined with the tag drake:rigid_hydroelastic"
+          " should not contain the tag drake:hydroelastic_modulus. The"
+          " specified value ({}) will be ignored.",
+          *hydroelastic_modulus));
     } else {
       properties.AddProperty(kHydroGroup, kElastic, *hydroelastic_modulus);
     }

--- a/multibody/parsing/detail_common.h
+++ b/multibody/parsing/detail_common.h
@@ -9,6 +9,7 @@
 #include <sdf/Element.hh>
 #include <tinyxml2.h>
 
+#include "drake/common/diagnostic_policy.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/geometry/proximity_properties.h"
 #include "drake/multibody/plant/coulomb_friction.h"
@@ -102,6 +103,7 @@ inline CoulombFriction<double> default_friction() {
 // properties. Downstream consumers of those properties are responsible for
 // confirming that all required properties are present and well formed.
 //
+// @param diagnostic   The error-reporting channel.
 // @param read_double  The function for extracting double values for specific
 //                     named tags.
 // @param is_rigid     True if the caller detected the presence of the
@@ -111,6 +113,7 @@ inline CoulombFriction<double> default_friction() {
 // @return All proximity properties discovered via the `read_double` function.
 // @pre At most one of `is_rigid` and `is_compliant` is true.
 geometry::ProximityProperties ParseProximityProperties(
+    const drake::internal::DiagnosticPolicy& diagnostic,
     const std::function<std::optional<double>(const char*)>& read_double,
     bool is_rigid, bool is_compliant);
 

--- a/multibody/parsing/detail_sdf_geometry.cc
+++ b/multibody/parsing/detail_sdf_geometry.cc
@@ -33,6 +33,7 @@ using std::move;
 using std::set;
 using std::string;
 
+using drake::internal::DiagnosticPolicy;
 using geometry::GeometryInstance;
 using geometry::IllustrationProperties;
 using geometry::ProximityProperties;
@@ -404,6 +405,7 @@ RigidTransformd MakeGeometryPoseFromSdfCollision(
 }
 
 ProximityProperties MakeProximityPropertiesForCollision(
+    const DiagnosticPolicy& diagnostic,
     const sdf::Collision& sdf_collision) {
   const sdf::ElementPtr collision_element = sdf_collision.Element();
   DRAKE_DEMAND(collision_element != nullptr);
@@ -444,7 +446,8 @@ ProximityProperties MakeProximityPropertiesForCollision(
           "one can be provided.");
     }
 
-    properties = ParseProximityProperties(read_double, is_rigid, is_compliant);
+    properties = ParseProximityProperties(
+        diagnostic, read_double, is_rigid, is_compliant);
   }
 
   // TODO(SeanCurtis-TRI): Remove all of this legacy parsing code based on
@@ -466,13 +469,13 @@ ProximityProperties MakeProximityPropertiesForCollision(
         const sdf::Element* ode_element =
             MaybeGetChildElement(*friction_element, "ode");
         if (MaybeGetChildElement(*ode_element, "mu") ||
-        MaybeGetChildElement(*ode_element, "mu2")) {
-          logging::Warn one_time(
+            MaybeGetChildElement(*ode_element, "mu2")) {
+          diagnostic.Warning(fmt::format(
+              "In <collision name='{}'>: "
               "When drake contact parameters are fully specified in the "
               "<drake:proximity_properties> tag, the <surface><friction><ode>"
-              "<mu*> tags are ignored. While parsing, there was at least one "
-              "instance where friction coefficients were defined in both "
-              "locations.");
+              "<mu*> tags are ignored.",
+              sdf_collision.Name()));
         }
       }
     }

--- a/multibody/parsing/detail_sdf_geometry.h
+++ b/multibody/parsing/detail_sdf_geometry.h
@@ -7,6 +7,7 @@
 #include <sdf/Geometry.hh>
 #include <sdf/Visual.hh>
 
+#include "drake/common/diagnostic_policy.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/shape_specification.h"
@@ -180,7 +181,8 @@ math::RigidTransformd MakeGeometryPoseFromSdfCollision(
  As long as no exception is thrown, the resulting ProximityProperties will have
  the ('material', 'coulomb_friction') property.  */
 geometry::ProximityProperties MakeProximityPropertiesForCollision(
-        const sdf::Collision& sdf_collision);
+    const drake::internal::DiagnosticPolicy& diagnostic,
+    const sdf::Collision& sdf_collision);
 
 /* Parses friction coefficients from `sdf_collision`.
  This method looks for the definitions specific to ODE, as given by the SDF

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -716,7 +716,7 @@ std::vector<LinkInfo> AddLinksFromSpecification(
           const RigidTransformd X_LC =
               MakeGeometryPoseFromSdfCollision(sdf_collision, X_LG);
           geometry::ProximityProperties props =
-              MakeProximityPropertiesForCollision(sdf_collision);
+              MakeProximityPropertiesForCollision(diagnostic, sdf_collision);
           plant->RegisterCollisionGeometry(body, X_LC, *shape,
                                            sdf_collision.Name(),
                                            std::move(props));

--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -9,6 +9,7 @@
 
 #include <fmt/format.h>
 
+#include "drake/common/diagnostic_policy.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/filesystem.h"
 #include "drake/common/text_logging.h"
@@ -26,6 +27,8 @@ using Eigen::Vector3d;
 using Eigen::Vector4d;
 using math::RigidTransformd;
 using tinyxml2::XMLElement;
+
+using drake::internal::DiagnosticPolicy;
 
 UrdfMaterial AddMaterialToMaterialMap(const std::string& material_name,
                                       UrdfMaterial material,
@@ -590,8 +593,12 @@ geometry::GeometryInstance ParseCollision(
           rigid_element->GetLineNum(), compliant_element->GetLineNum()));
     }
 
-    props = ParseProximityProperties(read_double, rigid_element != nullptr,
-                                     compliant_element != nullptr);
+    // TODO(jwnimmer-tri) ParseCollision should accept a policy as an argument
+    // and pass it along here, instead of making a temporary one.
+    const DiagnosticPolicy diagnostic;
+    props = ParseProximityProperties(
+        diagnostic, read_double, rigid_element != nullptr,
+        compliant_element != nullptr);
   }
 
   // TODO(SeanCurtis-TRI): Remove all of this legacy parsing code based on


### PR DESCRIPTION
Towards #16784.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16810)
<!-- Reviewable:end -->
