### PR TITLE
[controllers] Implements the square-root form of finite-horizon LQR

### DIFF
--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -270,14 +270,20 @@ PYBIND11_MODULE(controllers, m) {
       .def_readwrite("input_port_index",
           &FiniteHorizonLinearQuadraticRegulatorOptions::input_port_index,
           doc.FiniteHorizonLinearQuadraticRegulatorOptions.input_port_index.doc)
+      .def_readwrite("use_square_root_method",
+          &FiniteHorizonLinearQuadraticRegulatorOptions::use_square_root_method,
+          doc.FiniteHorizonLinearQuadraticRegulatorOptions
+              .use_square_root_method.doc)
       .def("__repr__",
           [](const FiniteHorizonLinearQuadraticRegulatorOptions& self) {
             return py::str(
                 "FiniteHorizonLinearQuadraticRegulatorOptions("
                 "Qf={}, "
                 "N={}, "
-                "input_port_index={})")
-                .format(self.Qf, self.N, self.input_port_index);
+                "input_port_index={}, "
+                "use_square_root_method={})")
+                .format(self.Qf, self.N, self.input_port_index,
+                    self.use_square_root_method);
           });
 
   DefReadWriteKeepAlive(&fhlqr_options, "x0",

--- a/bindings/pydrake/systems/test/controllers_test.py
+++ b/bindings/pydrake/systems/test/controllers_test.py
@@ -337,6 +337,7 @@ class TestControllers(unittest.TestCase):
 
         options = FiniteHorizonLinearQuadraticRegulatorOptions()
         options.Qf = Q
+        options.use_square_root_method = False
         self.assertIsNone(options.N)
         self.assertIsNone(options.x0)
         self.assertIsNone(options.u0)
@@ -350,7 +351,8 @@ class TestControllers(unittest.TestCase):
             r"Qf=\[\[ *1\. *0\.\]\s*\[ *0\. *1\.\]\], "
             r"N=None, ",
             r"input_port_index=",
-            r"InputPortSelection.kUseFirstInputIfItExists\)"]))
+            r"InputPortSelection.kUseFirstInputIfItExists, ",
+            r"use_square_root_method=False\)"]))
 
         context = double_integrator.CreateDefaultContext()
         double_integrator.get_input_port(0).FixValue(context, 0.0)

--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -294,7 +294,7 @@ class TestTrajectories(unittest.TestCase):
         numpy_compare.assert_float_equal(pp.end_time(), -1.0)
 
     @numpy_compare.check_all_types
-    def test_reshape_and_block(self, T):
+    def test_reshape_block_and_transpose(self, T):
         PiecewisePolynomial = PiecewisePolynomial_[T]
 
         t = [0., 1., 2., 3.]
@@ -308,6 +308,9 @@ class TestTrajectories(unittest.TestCase):
         pp2 = pp.Block(start_row=0, start_col=0, block_rows=2, block_cols=1)
         self.assertEqual(pp2.rows(), 2)
         self.assertEqual(pp2.cols(), 1)
+        pp3 = pp2.Transpose()
+        self.assertEqual(pp3.rows(), 1)
+        self.assertEqual(pp3.cols(), 2)
 
     @numpy_compare.check_all_types
     def test_slice_and_shift(self, T):

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -362,6 +362,7 @@ struct Impl {
               cls_doc.isApprox.doc)
           .def("Reshape", &Class::Reshape, py::arg("rows"), py::arg("cols"),
               cls_doc.Reshape.doc)
+          .def("Transpose", &Class::Transpose, cls_doc.Transpose.doc)
           .def("Block", &Class::Block, py::arg("start_row"),
               py::arg("start_col"), py::arg("block_rows"),
               py::arg("block_cols"), cls_doc.Block.doc)

--- a/common/trajectories/piecewise_polynomial.cc
+++ b/common/trajectories/piecewise_polynomial.cc
@@ -513,6 +513,17 @@ void PiecewisePolynomial<T>::Reshape(int rows, int cols) {
 }
 
 template <typename T>
+PiecewisePolynomial<T> PiecewisePolynomial<T>::Transpose() const {
+  std::vector<PolynomialMatrix> transposed;
+  std::transform(polynomials_.begin(), polynomials_.end(),
+                 std::back_inserter(transposed),
+                 [](const PolynomialMatrix& matrix) {
+                   return matrix.transpose();
+                 });
+  return PiecewisePolynomial<T>(transposed, this->breaks());
+}
+
+template <typename T>
 PiecewisePolynomial<T> PiecewisePolynomial<T>::Block(int start_row,
                                                      int start_col,
                                                      int block_rows,

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -574,6 +574,10 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    */
   void Reshape(int rows, int cols);
 
+  /** Constructs a new PiecewisePolynomial for which value(t) ==
+   * this.value(t).transpose(). */
+  PiecewisePolynomial Transpose() const;
+
   /**
    * Extracts a trajectory representing a block of size (block_rows, block_cols)
    * starting at (start_row, start_col) from the PiecewisePolynomial.

--- a/common/trajectories/test/piecewise_polynomial_test.cc
+++ b/common/trajectories/test/piecewise_polynomial_test.cc
@@ -393,7 +393,7 @@ GTEST_TEST(testPiecewisePolynomial, ReverseAndScaleTimeTest) {
   TestScaling(spline, 4.3);
 }
 
-GTEST_TEST(testPiecewisePolynomial, ReshapeAndBlockTest) {
+GTEST_TEST(testPiecewisePolynomial, ReshapeBlockAndTranspose) {
   std::vector<double> breaks = {0, .5, 1.};
   std::vector<Eigen::MatrixXd> samples(3);
   samples[0].resize(2, 3);
@@ -427,6 +427,12 @@ GTEST_TEST(testPiecewisePolynomial, ReshapeAndBlockTest) {
   EXPECT_EQ(zoh.Block(0, 0, 1, 1).value(0.25), samples[0].block(0, 0, 1, 1));
   EXPECT_EQ(zoh.Block(2, 1, 1, 1).value(0.75), samples[1].block(2, 1, 1, 1));
   EXPECT_EQ(zoh.Block(1, 1, 2, 1).value(0.75), samples[1].block(1, 1, 2, 1));
+
+  PiecewisePolynomial<double> transposed = zoh.Transpose();
+  EXPECT_EQ(transposed.rows(), 2);
+  EXPECT_EQ(transposed.cols(), 3);
+  EXPECT_TRUE(CompareMatrices(transposed.value(0.25), samples[0].transpose()));
+  EXPECT_TRUE(CompareMatrices(transposed.value(0.75), samples[1].transpose()));
 }
 
 GTEST_TEST(testPiecewisePolynomial, IsApproxTest) {

--- a/systems/controllers/finite_horizon_linear_quadratic_regulator.h
+++ b/systems/controllers/finite_horizon_linear_quadratic_regulator.h
@@ -67,6 +67,14 @@ struct FiniteHorizonLinearQuadraticRegulatorOptions {
   */
   std::variant<systems::InputPortSelection, InputPortIndex> input_port_index{
       systems::InputPortSelection::kUseFirstInputIfItExists};
+
+  /**
+  Enables the "square-root" method solution to the Ricatti equation. This is
+  slightly more expensive and potentially less numerically accurate (errors are
+  bounded on the square root), but is more numerically robust. When `true`,
+  then you must also set a (positive definite and symmetric) Qf in this options
+  struct. */
+  bool use_square_root_method{false};
 };
 
 /**


### PR DESCRIPTION
Also implements transpose() in PiecewisePolynomial, which makes the
LQR code cleaner.

This method are needed to use time-varying LQR on the perching glider
example, and are generally good to have.  The equations are documented
at the end of section 8.2.1 in
http://underactuated.csail.mit.edu/lqr.html .

+@rcory for feature review, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16812)
<!-- Reviewable:end -->
