### PR TITLE
[examples] Add meshcat sliders / buttons to manipulation_station

### DIFF
--- a/examples/manipulation_station/BUILD.bazel
+++ b/examples/manipulation_station/BUILD.bazel
@@ -163,6 +163,15 @@ drake_py_library(
     ],
 )
 
+drake_py_library(
+    name = "schunk_wsg_buttons",
+    srcs = ["schunk_wsg_buttons.py"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//bindings/pydrake",
+    ],
+)
+
 drake_py_binary(
     name = "joint_teleop",
     srcs = ["joint_teleop.py"],
@@ -175,6 +184,7 @@ drake_py_binary(
     test_rule_tags = vtk_test_tags(),
     test_rule_timeout = "moderate",  # Frequently exceeds short timeout in dbg.
     deps = [
+        ":schunk_wsg_buttons",
         "//bindings/pydrake",
     ],
 )

--- a/examples/manipulation_station/schunk_wsg_buttons.py
+++ b/examples/manipulation_station/schunk_wsg_buttons.py
@@ -1,0 +1,47 @@
+from pydrake.systems.framework import LeafSystem
+
+
+class SchunkWsgButtons(LeafSystem):
+    """
+    Adds buttons to open/close the Schunk WSG gripper.
+
+    .. pydrake_system::
+
+        name: SchunkWsgButtons
+        output_ports:
+        - position
+        - max_force
+    """
+
+    _BUTTON_NAME = "Open/Close Gripper"
+    """The name of the button added to the meshcat UI."""
+
+    def __init__(self, meshcat, open_position=0.107, closed_position=0.002,
+                 force_limit=40):
+        """"
+        Args:
+            open_position:   Target position for the gripper when open.
+            closed_position: Target position for the gripper when closed.
+                             **Warning**: closing to 0mm can smash the fingers
+                             together and keep applying force even when no
+                             object is grasped.
+            force_limit:     Force limit to send to Schunk WSG controller.
+        """
+        super().__init__()
+        self.meshcat = meshcat
+        self.DeclareVectorOutputPort("position", 1, self.CalcPositionOutput)
+        self.DeclareVectorOutputPort("force_limit", 1,
+                                     self.CalcForceLimitOutput)
+        self._open_button = meshcat.AddButton(self._BUTTON_NAME)
+        self._open_position = open_position
+        self._closed_position = closed_position
+        self._force_limit = force_limit
+
+    def CalcPositionOutput(self, context, output):
+        if self.meshcat.GetButtonClicks(name=self._BUTTON_NAME) % 2 == 0:
+            output.SetAtIndex(0, self._open_position)
+        else:
+            output.SetAtIndex(0, self._closed_position)
+
+    def CalcForceLimitOutput(self, context, output):
+        output.SetAtIndex(0, self._force_limit)


### PR DESCRIPTION
Toward #14702.

- [X] Depends: #17247
- Always create the `meshcat` instance regardless of `args.hardware`.
- Replace the deprecated python `JointSliders` with `multibody.meshcat`.
- Add a new meshcat specific `SchunkWsgButtons` helper class to open and close the gripper.
- Note: when using this against hardware, if the gripper is closed when we run joint_teleop then the teleop will command gripper-open and the robot would drop whatever it's holding.  However, that is the same behavior as the old code and will be fixed in a followup.

-----------------------------

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16816)
<!-- Reviewable:end -->
