### PR TITLE
[parsing] Route SDFormat warnings through DiagnosticPolicy

### DIFF
--- a/tools/workspace/sdformat/patches/deprecation_unit_testing.patch
+++ b/tools/workspace/sdformat/patches/deprecation_unit_testing.patch
@@ -1,0 +1,23 @@
+Add deprecated element definition for Drake's unit testing.
+
+When writing unit tests to exercise SDFormat deprecation notices, we can't
+rely on any _actually_ deprecated elements, because they will disappear in
+a future upstream release. Therefore, we inject a Drake-specific element
+definition that will always be available.
+
+--- src/parser.cc.orig	2021-09-30 15:33:35.000000000 -0700
++++ src/parser.cc	2022-03-17 12:29:01.296905847 -0700
+@@ -359,7 +359,12 @@
+   std::string xmldata = SDF::EmbeddedSpec("root.sdf", false);
+   auto xmlDoc = makeSdfDoc();
+   xmlDoc.Parse(xmldata.c_str());
+-  return initDoc(&xmlDoc, _sdf);
++  bool result = initDoc(&xmlDoc, _sdf);
++  ElementPtr drake_testing_element(new Element);
++  drake_testing_element->SetName("_drake_deprecation_unit_test_element");
++  drake_testing_element->SetRequired("-1" /* deprecated */);
++  _sdf->Root()->AddElementDescription(drake_testing_element);
++  return result;
+ }
+ 
+ //////////////////////////////////////////////////

--- a/tools/workspace/sdformat/repository.bzl
+++ b/tools/workspace/sdformat/repository.bzl
@@ -13,6 +13,7 @@ def sdformat_repository(
         build_file = "@drake//tools/workspace/sdformat:package.BUILD.bazel",
         patches = [
             "@drake//tools/workspace/sdformat:patches/console.patch",
+            "@drake//tools/workspace/sdformat:patches/deprecation_unit_testing.patch",  # noqa
             "@drake//tools/workspace/sdformat:patches/fix_broken_config.patch",
             "@drake//tools/workspace/sdformat:patches/no_global_config.patch",
             "@drake//tools/workspace/sdformat:patches/no_urdf.patch",


### PR DESCRIPTION
This will allow us to more easily toggle their strictness.

Towards #16784.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16819)
<!-- Reviewable:end -->
