### PR TITLE
[parsing] Allow linear bushing parse to fail

### DIFF
--- a/multibody/parsing/detail_common.cc
+++ b/multibody/parsing/detail_common.cc
@@ -110,12 +110,14 @@ geometry::ProximityProperties ParseProximityProperties(
   return properties;
 }
 
-const LinearBushingRollPitchYaw<double>& ParseLinearBushingRollPitchYaw(
+const LinearBushingRollPitchYaw<double>* ParseLinearBushingRollPitchYaw(
     const std::function<Eigen::Vector3d(const char*)>& read_vector,
-    const std::function<const Frame<double>&(const char*)>& read_frame,
+    const std::function<const Frame<double>*(const char*)>& read_frame,
     MultibodyPlant<double>* plant) {
-  const Frame<double>& frame_A = read_frame("drake:bushing_frameA");
-  const Frame<double>& frame_C = read_frame("drake:bushing_frameC");
+  const Frame<double>* frame_A = read_frame("drake:bushing_frameA");
+  if (!frame_A) { return {}; }
+  const Frame<double>* frame_C = read_frame("drake:bushing_frameC");
+  if (!frame_C) { return {}; }
 
   const Eigen::Vector3d bushing_torque_stiffness =
       read_vector("drake:bushing_torque_stiffness");
@@ -126,8 +128,8 @@ const LinearBushingRollPitchYaw<double>& ParseLinearBushingRollPitchYaw(
   const Eigen::Vector3d bushing_force_damping =
       read_vector("drake:bushing_force_damping");
 
-  return plant->AddForceElement<LinearBushingRollPitchYaw>(
-      frame_A, frame_C, bushing_torque_stiffness, bushing_torque_damping,
+  return &plant->AddForceElement<LinearBushingRollPitchYaw>(
+      *frame_A, *frame_C, bushing_torque_stiffness, bushing_torque_damping,
       bushing_force_stiffness, bushing_force_damping);
 }
 

--- a/multibody/parsing/detail_common.h
+++ b/multibody/parsing/detail_common.h
@@ -148,9 +148,14 @@ geometry::ProximityProperties ParseProximityProperties(
 //   <drake:bushing_force_stiffness  value="0 0 0"/>
 //   <drake:bushing_force_damping    value="0 0 0"/>
 // </drake:linear_bushing_rpy>
-const LinearBushingRollPitchYaw<double>& ParseLinearBushingRollPitchYaw(
+//
+// The @p read_frame functor may (at its option) throw std:exception, or return
+// nullptr when frame parsing fails. Similarly,
+// ParseLinearBushingRollPitchYaw() may return nullptr when read_frame has
+// returned nullptr.
+const LinearBushingRollPitchYaw<double>* ParseLinearBushingRollPitchYaw(
     const std::function<Eigen::Vector3d(const char*)>& read_vector,
-    const std::function<const Frame<double>&(const char*)>& read_frame,
+    const std::function<const Frame<double>*(const char*)>& read_frame,
     MultibodyPlant<double>* plant);
 
 // TODO(@SeanCurtis-TRI): The real solution here is to create a wrapper

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -877,13 +877,17 @@ const LinearBushingRollPitchYaw<double>& AddBushingFromSpecification(
   // frame name, e.g. <element_name>frame_name</element_name>
   // Throws an error if the tag does not exist or if the frame does not exist in
   // the plant.
-  auto read_frame = [node,
-                     model_instance,
-                     plant](const char* element_name) -> const Frame<double>& {
-    return ParseFrame(node, model_instance, plant, element_name);
+  auto read_frame = [node, model_instance, plant](const char* element_name)
+                    -> const Frame<double>* {
+    return &ParseFrame(node, model_instance, plant, element_name);
   };
 
-  return ParseLinearBushingRollPitchYaw(read_vector, read_frame, plant);
+  auto result = ParseLinearBushingRollPitchYaw(read_vector, read_frame, plant);
+  // TODO(rpoyner-tri): The SDFormat parser may use the nullptr result later,
+  // when errors are allowed to continue execution, rather than throw. This
+  // invariant will be true until those changes are made.
+  DRAKE_DEMAND(result != nullptr);
+  return *result;
 }
 
 // Helper to determine if two links are welded together.

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -642,9 +642,8 @@ void ParseBushing(ModelInstanceIndex model_instance,
   // Functor to read a child element with a string valued `name` attribute.
   // Throws an error if unable to find the tag of if the name attribute is
   // improperly formed.
-  auto read_frame = [model_instance,
-                     node,
-                     plant](const char* element_name) -> const Frame<double>& {
+  auto read_frame = [model_instance, node, plant]
+                    (const char* element_name) -> const Frame<double>* {
     XMLElement* value_node = node->FirstChildElement(element_name);
 
     if (value_node != nullptr) {
@@ -655,7 +654,7 @@ void ParseBushing(ModelInstanceIndex model_instance,
               "Frame: {} specified for <{}> does not exist in the model.",
               frame_name, element_name));
         }
-        return plant->GetFrameByName(frame_name, model_instance);
+        return &plant->GetFrameByName(frame_name, model_instance);
 
       } else {
         throw std::runtime_error(


### PR DESCRIPTION
Relevant to: #16782

This refactoring clears the way for any implementation of parsing errors
that is not `throw`. In this case, the change in signatures is justified
by the difficulty of constructing Frame objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16821)
<!-- Reviewable:end -->
