### PR TITLE
update license year

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -2,7 +2,7 @@ All components of Drake are licensed under the BSD 3-Clause License
 shown below. Where noted in the source code, some portions may 
 be subject to other permissive, non-viral licenses.
 
-Copyright 2012-2016 Robot Locomotion Group @ CSAIL
+Copyright 2012-2022 Robot Locomotion Group @ CSAIL
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Happened to notice this while inspecting release tooling development stuff.  Maybe we should configure a reminder on slack or a GH action to update this each year?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16823)
<!-- Reviewable:end -->
