### PR TITLE
[solvers] Clean up CheckBinding code style

### DIFF
--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -1767,6 +1767,28 @@ void MathematicalProgram::CheckVariableType(VarType var_type) {
   }
 }
 
+void MathematicalProgram::CheckIsDecisionVariable(
+    const VectorXDecisionVariable& vars) const {
+  for (int i = 0; i < vars.rows(); ++i) {
+    for (int j = 0; j < vars.cols(); ++j) {
+      if (decision_variable_index_.count(vars(i, j).get_id()) == 0) {
+        throw std::logic_error(fmt::format(
+            "{} is not a decision variable of the mathematical program.",
+            vars(i, j)));
+      }
+    }
+  }
+}
+
+template <typename C>
+void MathematicalProgram::CheckBinding(const Binding<C>& binding) const {
+  // TODO(eric.cousineau): In addition to identifiers, hash bindings by
+  // their constraints and their variables, to prevent duplicates.
+  // TODO(eric.cousineau): Once bindings have identifiers (perhaps
+  // retrofitting `description`), ensure that they have unique names.
+  CheckIsDecisionVariable(binding.variables());
+}
+
 std::ostream& operator<<(std::ostream& os, const MathematicalProgram& prog) {
   if (prog.num_vars() > 0) {
     os << "Decision variables:" << prog.decision_variables().transpose()

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -3441,25 +3441,9 @@ class MathematicalProgram {
    * Given a matrix of decision variables, checks if every entry in the
    * matrix is a decision variable in the program; throws a runtime
    * error if any variable is not a decision variable in the program.
-   * @tparam Derived An Eigen::Matrix type of symbolic Variable.
-   * @param vars A matrix of variables.
+   * @param vars A vector of variables.
    */
-  template <typename Derived>
-  typename std::enable_if_t<
-      std::is_same_v<typename Derived::Scalar, symbolic::Variable>>
-  CheckIsDecisionVariable(const Eigen::MatrixBase<Derived>& vars) const {
-    for (int i = 0; i < vars.rows(); ++i) {
-      for (int j = 0; j < vars.cols(); ++j) {
-        if (decision_variable_index_.find(vars(i, j).get_id()) ==
-            decision_variable_index_.end()) {
-          std::ostringstream oss;
-          oss << vars(i, j)
-              << " is not a decision variable of the mathematical program.\n";
-          throw std::runtime_error(oss.str());
-        }
-      }
-    }
-  }
+  void CheckIsDecisionVariable(const VectorXDecisionVariable& vars) const;
 
   /*
    * Ensure a binding is valid *before* adding it to the program.
@@ -3468,13 +3452,7 @@ class MathematicalProgram {
    * @throws std::exception if the binding is invalid.
    */
   template <typename C>
-  void CheckBinding(const Binding<C>& binding) const {
-    // TODO(eric.cousineau): In addition to identifiers, hash bindings by
-    // their constraints and their variables, to prevent duplicates.
-    // TODO(eric.cousineau): Once bindings have identifiers (perhaps
-    // retrofitting `description`), ensure that they have unique names.
-    CheckIsDecisionVariable(binding.variables());
-  }
+  void CheckBinding(const Binding<C>& binding) const;
 
   /*
    * Adds new variables to MathematicalProgram.

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -647,7 +647,9 @@ void ExpectBadVar(MathematicalProgram* prog, int num_var, Args&&... args) {
   // Use minimal call site (directly on adding Binding<C>).
   // TODO(eric.cousineau): Check if there is a way to parse the error text to
   // ensure that we are capturing the correct error.
-  EXPECT_THROW(AddItem(prog, CreateBinding(c, x)), std::runtime_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      AddItem(prog, CreateBinding(c, x)),
+      ".*is not a decision variable.*");
 }
 
 }  // namespace
@@ -2820,8 +2822,12 @@ GTEST_TEST(TestMathematicalProgram, TestAddCostThrowError) {
 
   // Add a cost containing variable not included in the mathematical program.
   Variable y("y");
-  EXPECT_THROW(prog.AddCost(x(0) + y), runtime_error);
-  EXPECT_THROW(prog.AddCost(x(0) * x(0) + y), runtime_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      prog.AddCost(x(0) + y),
+      ".*is not a decision variable.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      prog.AddCost(x(0) * x(0) + y),
+      ".*is not a decision variable.*");
 }
 
 GTEST_TEST(TestMathematicalProgram, TestAddGenericCost) {
@@ -3300,9 +3306,10 @@ GTEST_TEST(TestMathematicalProgram, AddEqualityConstraintBetweenPolynomials) {
   // Test with a polynomial whose coefficients depend on variables that are not
   // decision variables of prog.
   symbolic::Variable b("b");
-  EXPECT_THROW(prog.AddEqualityConstraintBetweenPolynomials(
-                   p1, symbolic::Polynomial(b * x, {x})),
-               std::runtime_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      prog.AddEqualityConstraintBetweenPolynomials(
+          p1, symbolic::Polynomial(b * x, {x})),
+      ".*is not a decision variable.*");
   // If we add `b` to prog as decision variable, then the code throws no
   // exceptions.
   prog.AddDecisionVariables(Vector1<symbolic::Variable>(b));

--- a/systems/trajectory_optimization/test/multiple_shooting_test.cc
+++ b/systems/trajectory_optimization/test/multiple_shooting_test.cc
@@ -198,20 +198,20 @@ GTEST_TEST(MultipleShootingTest, DeprecatedPlaceholderVariableTest) {
   const solvers::VectorXDecisionVariable& u = prog.input();
   const solvers::VectorXDecisionVariable& x = prog.state();
 
-  EXPECT_THROW(prog.AddCost(t(0)), std::runtime_error);
-  EXPECT_THROW(prog.AddLinearCost(Vector1d(1.0), 0.0, u), std::runtime_error);
+  EXPECT_THROW(prog.AddCost(t(0)), std::exception);
+  EXPECT_THROW(prog.AddLinearCost(Vector1d(1.0), 0.0, u), std::exception);
   EXPECT_THROW(prog.AddQuadraticErrorCost(Eigen::Matrix2d::Identity(),
                                           Eigen::Vector2d::Zero(), x),
-               std::runtime_error);
+               std::exception);
 
-  EXPECT_THROW(prog.AddLinearConstraint(t(0) <= 1.0), std::runtime_error);
+  EXPECT_THROW(prog.AddLinearConstraint(t(0) <= 1.0), std::exception);
   EXPECT_THROW(prog.AddLinearConstraint(u <= Vector1d(1.0)),
-               std::runtime_error);
+               std::exception);
 
   EXPECT_THROW(prog.AddLinearConstraint(Eigen::Matrix2d::Identity(),
                                         Eigen::Vector2d::Zero(),
                                         Eigen::Vector2d::Zero(), x),
-               std::runtime_error);
+               std::exception);
 
   solvers::MathematicalProgramResult result;
   // Arbitrarily set the decision variable values to 0.
@@ -732,20 +732,20 @@ GTEST_TEST(MultipleShootingTest, PlaceholderVariableTest) {
   const solvers::VectorXDecisionVariable& u = trajopt.input();
   const solvers::VectorXDecisionVariable& x = trajopt.state();
 
-  EXPECT_THROW(prog.AddCost(t(0)), std::runtime_error);
-  EXPECT_THROW(prog.AddLinearCost(Vector1d(1.0), 0.0, u), std::runtime_error);
+  EXPECT_THROW(prog.AddCost(t(0)), std::exception);
+  EXPECT_THROW(prog.AddLinearCost(Vector1d(1.0), 0.0, u), std::exception);
   EXPECT_THROW(prog.AddQuadraticErrorCost(Eigen::Matrix2d::Identity(),
                                           Eigen::Vector2d::Zero(), x),
-               std::runtime_error);
+               std::exception);
 
-  EXPECT_THROW(prog.AddLinearConstraint(t(0) <= 1.0), std::runtime_error);
+  EXPECT_THROW(prog.AddLinearConstraint(t(0) <= 1.0), std::exception);
   EXPECT_THROW(prog.AddLinearConstraint(u <= Vector1d(1.0)),
-               std::runtime_error);
+               std::exception);
 
   EXPECT_THROW(prog.AddLinearConstraint(Eigen::Matrix2d::Identity(),
                                         Eigen::Vector2d::Zero(),
                                         Eigen::Vector2d::Zero(), x),
-               std::runtime_error);
+               std::exception);
 
   solvers::MathematicalProgramResult result;
   // Arbitrarily set the decision variable values to 0.


### PR DESCRIPTION
Remove unnecessary templating.
Move function definitions to cc file.
Use fmt instead of stringstream.
Use logic_error instead of runtime_error.
Update unit tests to check message text instead of type.

Towards #16825.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16826)
<!-- Reviewable:end -->
