### PR TITLE
Change comment openers and replace int32_t with int

### DIFF
--- a/geometry/render/dev/http_service.h
+++ b/geometry/render/dev/http_service.h
@@ -14,15 +14,15 @@ namespace geometry {
 namespace render {
 namespace internal {
 
-/** A simple wrapper struct to encapsulate an HTTP server response. */
+/* A simple wrapper struct to encapsulate an HTTP server response. */
 struct HttpResponse {
-  /** The HTTP response code from the server.  Note that in the special case of
+  /* The HTTP response code from the server.  Note that in the special case of
    an HttpService not being able to connect to a server (e.g., the wrong url
    was provided or the server is not running), this field will often have a
    value of `0`.  Use HttpResponse::Good() to validate server responses. */
-  int32_t http_code{0};
+  int http_code{0};
 
-  /** In the event that the server has provided a text or binary response in
+  /* In the event that the server has provided a text or binary response in
    addition to its HTTP response code, the file path described by this attribute
    will contain the response.  An HttpService will populate this field with a
    non-optional value if and only if a response from the server was provided.
@@ -33,17 +33,17 @@ struct HttpResponse {
      the file when it is no longer needed. */
   std::optional<std::string> data_path{std::nullopt};
 
-  /** If the underlying HttpService encountered an error, this will be set to
+  /* If the underlying HttpService encountered an error, this will be set to
    true and any additional information provided in
    HttpResponse::service_error_message. */
   bool service_error{false};
 
-  /** In the event that there was an error with the HttpService processing the
+  /* In the event that there was an error with the HttpService processing the
    request, HttpResponse::service_error will be set to `true` and any additional
    information that can be provided will be in this string. */
   std::optional<std::string> service_error_message{std::nullopt};
 
-  /** Whether or not the HTTP transaction was successful.  This includes
+  /* Whether or not the HTTP transaction was successful.  This includes
    verifying that the HttpResponse::http_code indicates success, but also
    whether or not the underlying HttpService marked it for failure via
    HttpResponse::service_error.  Note that if a server has not been
@@ -55,7 +55,7 @@ struct HttpResponse {
   }
 };
 
-/** An HTTP service API, used by a RenderClient to facilitate server
+/* An HTTP service API, used by a RenderClient to facilitate server
  communications.  This class is not intended to be used on its own, it is a
  helper class to perform server communications, but does not have any specific
  knowledge of a given client-server API.  The owning entity, such as
@@ -66,9 +66,9 @@ class HttpService {
   virtual ~HttpService();
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(HttpService);
 
-  /** @name Server Interaction Interface */
+  /* @name Server Interaction Interface */
   //@{
-  /** Post an HTML `<form>` to the specified `endpoint`.
+  /* Post an HTML `<form>` to the specified `endpoint`.
 
    An HTML `<form>` may allow for a wide range of different kinds of `<input>`
    data.  For the full listing of available input `type`'s, see the
@@ -197,7 +197,7 @@ class HttpService {
      produce an exception but rather encode this information in the
      returned HttpResponse for the caller to determine how to proceed. */
   virtual HttpResponse PostForm(
-      const std::string& temp_directory, const std::string& url, int32_t port,
+      const std::string& temp_directory, const std::string& url, int port,
       const std::string& endpoint,
       const std::map<std::string, std::string>& data_fields,
       const std::map<std::string,
@@ -206,16 +206,16 @@ class HttpService {
       bool verbose = false) = 0;
   //@}
 
-  /** @name Server Parameter Validation Helpers */
+  /* @name Server Parameter Validation Helpers */
   //@{
-  /** Throws `std::logic_error` if the provided url is empty or has trailing
+  /* Throws `std::logic_error` if the provided url is empty or has trailing
    slashes. */
   void ThrowIfUrlInvalid(const std::string& url) const;
 
-  /** Throws `std::runtime_error` if `endpoint` starts or ends with a '/'. */
+  /* Throws `std::runtime_error` if `endpoint` starts or ends with a '/'. */
   void ThrowIfEndpointInvalid(const std::string& endpoint) const;
 
-  /** Verify that all file paths provided are regular files, throw if not.
+  /* Verify that all file paths provided are regular files, throw if not.
 
    @param file_fields See HttpService::PostForm.
    @throws std::runtime_error

--- a/geometry/render/dev/http_service_curl.cc
+++ b/geometry/render/dev/http_service_curl.cc
@@ -200,7 +200,7 @@ HttpServiceCurl::HttpServiceCurl() : HttpService() {
 HttpServiceCurl::~HttpServiceCurl() {}
 
 HttpResponse HttpServiceCurl::PostForm(
-    const std::string& temp_directory, const std::string& url, int32_t port,
+    const std::string& temp_directory, const std::string& url, int port,
     const std::string& endpoint,
     const std::map<std::string, std::string>& data_fields,
     const std::map<std::string,

--- a/geometry/render/dev/http_service_curl.h
+++ b/geometry/render/dev/http_service_curl.h
@@ -14,16 +14,16 @@ namespace geometry {
 namespace render {
 namespace internal {
 
-/** An HttpService that uses libcurl to communicate with the server. */
+/* An HttpService that uses libcurl to communicate with the server. */
 class HttpServiceCurl : public HttpService {
  public:
   HttpServiceCurl();
   ~HttpServiceCurl() override;
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(HttpServiceCurl);
 
-  /** @see HttpService::PostForm */
+  /* @see HttpService::PostForm */
   HttpResponse PostForm(
-      const std::string& temp_directory, const std::string& url, int32_t port,
+      const std::string& temp_directory, const std::string& url, int port,
       const std::string& endpoint,
       const std::map<std::string, std::string>& data_fields,
       const std::map<std::string,

--- a/geometry/render/dev/render_client.cc
+++ b/geometry/render/dev/render_client.cc
@@ -84,7 +84,7 @@ void AddField<RenderImageType>(data_map_t* data_map,
   // LCOV_EXCL_STOP
 }
 
-/** Verify the loaded image has the correct dimensions.  This includes verifying
+/* Verify the loaded image has the correct dimensions.  This includes verifying
  that the image is 2D (depth=1).
 
  @param expected_width
@@ -131,14 +131,14 @@ void VerifyImportedImageDimensions(int expected_width, int expected_height,
 
 /* Return '{url}' if port is <= 0, '{url}:{port}' otherwise.  Used for
  populating error messages. */
-std::string UrlWithPort(const std::string& url, int32_t port) {
+std::string UrlWithPort(const std::string& url, int port) {
   if (port > 0) return fmt::format("{}:{}", url, port);
   return url;
 }
 
 }  // namespace
 
-RenderClient::RenderClient(const std::string& url, int32_t port,
+RenderClient::RenderClient(const std::string& url, int port,
                            const std::string& render_endpoint, bool verbose,
                            bool no_cleanup)
     : temp_directory_{drake::temp_directory()},

--- a/geometry/render/dev/render_client.h
+++ b/geometry/render/dev/render_client.h
@@ -14,7 +14,7 @@ namespace geometry {
 namespace render {
 namespace internal {
 
-/** The type of image being rendered. */
+/* The type of image being rendered. */
 enum RenderImageType {
   kColorRgba8U = 0,    ///< The color frame.
   kLabel16I = 1,       ///< The label frame.
@@ -23,10 +23,10 @@ enum RenderImageType {
 
 /* TODO(svenevs): link to the render-client specification document once we
  decide where in the documentation it will live. */
-/** The client which communicates with a render server. */
+/* The client which communicates with a render server. */
 class RenderClient {
  public:
-  /** Constructs the render engine from the given parameters.
+  /* Constructs the render engine from the given parameters.
    @param url
      The url of the server to communicate with, e.g., `"http://127.0.0.1"`.  May
      **not** have a trailing `/`.
@@ -48,7 +48,7 @@ class RenderClient {
      HttpService::HttpService.
    @throws std::runtime_error
      If the provided `render_endpoint` has any leading or trailing slashes. */
-  RenderClient(const std::string& url, int32_t port,
+  RenderClient(const std::string& url, int port,
                const std::string& render_endpoint, bool verbose,
                bool no_cleanup);
 
@@ -56,10 +56,10 @@ class RenderClient {
 
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RenderClient);
 
-  /** @name Server communication */
+  /* @name Server communication */
   //@{
 
-  /** Upload the scene file from `scene_path` to the render server, download
+  /* Upload the scene file from `scene_path` to the render server, download
    the image file response, and return the path to the image file.
    The returned file path may be used directly with any one of the helper
    methods LoadColorImage(), LoadDepthImage(), or LoadLabelImage().  The file
@@ -105,16 +105,16 @@ class RenderClient {
       const std::optional<DepthRange>& depth_range = std::nullopt) const;
 
   //@}
-  /** @name Server communication helpers */
+  /* @name Server communication helpers */
   //@{
 
-  /** Compute and return the `sha256sum` of the specified `path`.
+  /* Compute and return the `sha256sum` of the specified `path`.
    @throws std::runtime_error
      If the `path` cannot be opened or the hash fails to compute.
    */
   std::string ComputeSha256(const std::string& path) const;
 
-  /** Rename the specified file `response_data_path` to have the same name as
+  /* Rename the specified file `response_data_path` to have the same name as
    `reference_path`, with a new file extension provided by `extension`.
    Helper method for RetrieveRender() which will download files as
    `{temp_directory()}/{response_data_path}` and then rename the file
@@ -153,10 +153,10 @@ class RenderClient {
 
   //@}
 
-  /** @name Image loading helpers */
+  /* @name Image loading helpers */
   //@{
 
-  /** Load the specified image file to a drake output buffer.
+  /* Load the specified image file to a drake output buffer.
 
    This method only supports loading unsigned char PNG images with either three
    (RGB) or four (RGBA) channels.
@@ -175,7 +175,7 @@ class RenderClient {
       const std::string& path,
       drake::systems::sensors::ImageRgba8U* color_image_out) const;
 
-  /** Load the specified image file to a drake output buffer.
+  /* Load the specified image file to a drake output buffer.
 
    This method supports loading:
 
@@ -198,7 +198,7 @@ class RenderClient {
       const std::string& path,
       drake::systems::sensors::ImageDepth32F* depth_image_out) const;
 
-  /** Load the specified image file to a drake output buffer.
+  /* Load the specified image file to a drake output buffer.
 
    This method only supports loading single channel unsigned short PNG images.
 
@@ -217,13 +217,13 @@ class RenderClient {
 
   //@}
 
-  /** @name Access the default properties
+  /* @name Access the default properties
 
    Provides access to the default values of this instance.  These values must be
    set at construction. */
   //@{
 
-  /** The temporary directory used for scratch space, including but not limited
+  /* The temporary directory used for scratch space, including but not limited
    to where downloaded images are saved.  Child classes are permitted (and
    encouraged) to utilize this directory to create any additional files needed
    to communicate with the server such as scene files to upload.  The temporary
@@ -231,34 +231,34 @@ class RenderClient {
    no_cleanup() is true. */
   const std::string& temp_directory() const { return temp_directory_; }
 
-  /** The url of the server to communicate with. */
+  /* The url of the server to communicate with. */
   const std::string& url() const { return url_; }
 
-  /** The port of the server to communicate on.  A value of less than or equal
+  /* The port of the server to communicate on.  A value of less than or equal
    `0` means no port level communication is required. */
-  int32_t port() const { return port_; }
+  int port() const { return port_; }
 
-  /** The render endpoint of the server, used in RetrieveRender().
+  /* The render endpoint of the server, used in RetrieveRender().
    Should **not** include a preceding slash. */
   const std::string& render_endpoint() const { return render_endpoint_; }
 
-  /** Whether or not the client should be verbose including logging all curl
+  /* Whether or not the client should be verbose including logging all curl
    communications. */
   bool verbose() const { return verbose_; }
 
-  /** Whether or not the client should cleanup its temp_directory(). */
+  /* Whether or not the client should cleanup its temp_directory(). */
   bool no_cleanup() const { return no_cleanup_; }
 
   //@}
 
-  /** (Internal use only) for testing. */
+  /* (Internal use only) for testing. */
   void SetHttpService(std::unique_ptr<HttpService> service);
 
  private:
   friend class RenderClientTester;
   std::string temp_directory_;
   std::string url_;
-  int32_t port_;
+  int port_;
   std::string render_endpoint_;
   bool verbose_;
   bool no_cleanup_;

--- a/geometry/render/dev/render_engine_gltf_client_factory.h
+++ b/geometry/render/dev/render_engine_gltf_client_factory.h
@@ -21,7 +21,7 @@ struct RenderEngineGltfClientParams {
 
   /** The RenderClient::port() to communicate on.  A value less than or equal to
    `0` implies no port level communication is needed. */
-  int32_t port{8000};
+  int port{8000};
 
   /** The RenderClient::render_endpoint() to retrieve renderings from. */
   std::string render_endpoint{"render"};

--- a/geometry/render/dev/test/http_service_curl_test.cc
+++ b/geometry/render/dev/test/http_service_curl_test.cc
@@ -23,7 +23,7 @@ GTEST_TEST(HttpServiceCurlTest, PostForm) {
    Use verbose=true (last parameter) to increase coverage via curl callbacks. */
   const std::string temp_dir = drake::temp_directory();
   const std::string url{"notawebsite"};
-  const int32_t port{1};
+  const int port{1};
   const bool verbose{true};
   HttpServiceCurl service;
 

--- a/geometry/render/dev/test/http_service_test.cc
+++ b/geometry/render/dev/test/http_service_test.cc
@@ -25,7 +25,7 @@ class EmptyService : public HttpService {
 
   HttpResponse PostForm(
       const std::string& /* temp_directory */, const std::string& url,
-      int32_t /* port */, const std::string& endpoint,
+      int /* port */, const std::string& endpoint,
       const std::map<std::string, std::string>& /* data_fields */,
       const std::map<std::string,
                      std::pair<std::string, std::optional<std::string>>>&

--- a/geometry/render/dev/test/render_client_test.cc
+++ b/geometry/render/dev/test/render_client_test.cc
@@ -32,7 +32,7 @@ class RenderClientTester {
  public:
   explicit RenderClientTester(const RenderClient* client) : client_(*client) {}
 
-  void ValidateAttributes(const std::string& url, int32_t port,
+  void ValidateAttributes(const std::string& url, int port,
                           const std::string& render_endpoint, bool verbose,
                           bool no_cleanup) const {
     EXPECT_EQ(client_.url(), url);
@@ -58,7 +58,7 @@ namespace fs = drake::filesystem;
 // Constructor / destructor ----------------------------------------------------
 GTEST_TEST(RenderClient, Constructor) {
   const std::string url{"127.0.0.1"};
-  const int32_t port{8000};
+  const int port{8000};
   const std::string render_endpoint{"render"};
   const bool verbose = false;
   const bool no_cleanup = false;
@@ -109,7 +109,7 @@ GTEST_TEST(RenderClient, Constructor) {
 
 GTEST_TEST(RenderClient, Destructor) {
   const std::string url{"127.0.0.1"};
-  const int32_t port{8000};
+  const int port{8000};
   const std::string render_endpoint = "render";
   const bool verbose = false;
 
@@ -144,7 +144,7 @@ class FailService : public HttpService {
   FailService() : HttpService() {}
 
   HttpResponse PostForm(const std::string& /* temp_directory */,
-                        const std::string& /* url */, int32_t /* port */,
+                        const std::string& /* url */, int /* port */,
                         const std::string& /* endpoint */,
                         const data_map_t& /* data_fields */,
                         const file_map_t& /* file_fields */,
@@ -186,7 +186,7 @@ class FieldCheckService : public HttpService {
 
   /* Check all of the <form> fields.  Always respond with failure (http 500). */
   HttpResponse PostForm(const std::string& /* temp_directory */,
-                        const std::string& url, int32_t /* port */,
+                        const std::string& url, int /* port */,
                         const std::string& endpoint,
                         const data_map_t& data_fields,
                         const file_map_t& file_fields,
@@ -291,7 +291,7 @@ class ProxyService : public HttpService {
       : HttpService(), post_form_callback_{callback} {}
 
   HttpResponse PostForm(const std::string& /* temp_directory */,
-                        const std::string& url, int32_t /* port */,
+                        const std::string& url, int /* port */,
                         const std::string& endpoint,
                         const data_map_t& data_fields,
                         const file_map_t& file_fields,
@@ -317,7 +317,7 @@ GTEST_TEST(RenderClient, RenderOnServer) {
    test should proceed with the default HttpServiceCurl, the HttpService backend
    should be changed using client.SetHttpService before doing anything. */
   const std::string url{"notarealserver"};
-  const int32_t port{8192};
+  const int port{8192};
   const std::string render_endpoint{"no_render"};
   const bool verbose{false};
   const bool no_cleanup{false};
@@ -416,7 +416,7 @@ GTEST_TEST(RenderClient, RenderOnServer) {
   {
     /* These tests confirm the error reporting format from UrlWithPort without a
      port and alternative urls. */
-    const std::vector<std::pair<std::string, int32_t>> url_port{
+    const std::vector<std::pair<std::string, int>> url_port{
         {"some_url", 0}, {"another_url", -1}, {"url_with_port", 200}};
     for (const auto& [u, p] : url_port) {
       const auto expected_message = fmt::format(
@@ -628,7 +628,7 @@ GTEST_TEST(RenderClient, RenderOnServer) {
 
 GTEST_TEST(RenderClient, ComputeSha256) {
   const std::string url{"127.0.0.1"};
-  const int32_t port{8000};
+  const int port{8000};
   const std::string render_endpoint{"render"};
   const bool verbose = false;
   const bool no_cleanup = false;
@@ -685,7 +685,7 @@ GTEST_TEST(RenderClient, ComputeSha256) {
 
 GTEST_TEST(RenderClient, RenameHttpServiceResponse) {
   const std::string url{"127.0.0.1"};
-  const int32_t port{8000};
+  const int port{8000};
   const std::string render_endpoint{"render"};
   // Keep verbose and no_cleanup `true` to get coverage on log() calls.
   const bool verbose = true;
@@ -798,7 +798,7 @@ GTEST_TEST(RenderClient, RenameHttpServiceResponse) {
 
 GTEST_TEST(RenderClient, LoadColorImage) {
   const std::string url{"127.0.0.1"};
-  const int32_t port{8000};
+  const int port{8000};
   const std::string render_endpoint{"render"};
   const bool verbose = false;
   const bool no_cleanup = false;
@@ -908,7 +908,7 @@ GTEST_TEST(RenderClient, LoadColorImage) {
 
 GTEST_TEST(RenderClient, LoadDepthImage) {
   const std::string url{"127.0.0.1"};
-  const int32_t port{8000};
+  const int port{8000};
   const std::string render_endpoint{"render"};
   const bool verbose = false;
   const bool no_cleanup = false;
@@ -1004,7 +1004,7 @@ GTEST_TEST(RenderClient, LoadDepthImage) {
 
 GTEST_TEST(RenderClient, LoadLabelImage) {
   const std::string url{"127.0.0.1"};
-  const int32_t port{8000};
+  const int port{8000};
   const std::string render_endpoint{"render"};
   const bool verbose = false;
   const bool no_cleanup = true;

--- a/geometry/render/dev/test/render_engine_gltf_client_test.cc
+++ b/geometry/render/dev/test/render_engine_gltf_client_test.cc
@@ -28,7 +28,7 @@ class RenderEngineGltfClientTester {
 
   // RenderClient access methods.
   const std::string& url() const { return engine_->render_client_->url(); }
-  int32_t port() const { return engine_->render_client_->port(); }
+  int port() const { return engine_->render_client_->port(); }
   const std::string& render_endpoint() const {
     return engine_->render_client_->render_endpoint();
   }
@@ -241,7 +241,7 @@ class FakeServer : public HttpService {
    depth.response, or label.response.  It will overwrite the file if it already
    exists. */
   HttpResponse PostForm(const std::string& temp_directory,
-                        const std::string& url, int32_t /* port */,
+                        const std::string& url, int /* port */,
                         const std::string& endpoint,
                         const data_map_t& data_fields,
                         const file_map_t& file_fields,


### PR DESCRIPTION
Per discussion in Slack-

- Replace comment openers `/**` with `/*` for all the internal classes.
- Replace `int32_t` with `int` for `http_code` and `port` variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16827)
<!-- Reviewable:end -->
