### PR TITLE
[parsing] Port remainder of detail_urdf_parser to diagnostics

### DIFF
--- a/multibody/parsing/detail_common.cc
+++ b/multibody/parsing/detail_common.cc
@@ -157,6 +157,7 @@ void CollectCollisionFilterGroup(
     }
   }
   const std::string group_name = read_string_attribute(group_node, "name");
+  if (group_name.empty()) { return; }
 
   geometry::GeometrySet collision_filter_geometry_set;
   for (auto member_node = next_child_element(group_node, "drake:member");
@@ -165,6 +166,7 @@ void CollectCollisionFilterGroup(
            : std::get<tinyxml2::XMLElement*>(member_node) != nullptr;
        member_node = next_sibling_element(member_node, "drake:member")) {
     const std::string body_name = read_tag_string(member_node, "link");
+    if (body_name.empty()) { continue; }
 
     const auto& body = plant.GetBodyByName(body_name.c_str(), model_instance);
     collision_filter_geometry_set.Add(
@@ -180,6 +182,7 @@ void CollectCollisionFilterGroup(
        ignore_node = next_sibling_element(
            ignore_node, "drake:ignored_collision_filter_group")) {
     const std::string target_name = read_tag_string(ignore_node, "name");
+    if (target_name.empty()) { continue; }
 
     // These two group names are allowed to be identical, which means the
     // bodies inside this collision filter group should be collision excluded

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -46,6 +46,8 @@ using tinyxml2::XMLElement;
 
 namespace {
 
+using JointEffortLimits = std::map<std::string, double>;
+
 // Helper class to share infrastructure among parsing methods.
 class UrdfParser {
  public:
@@ -74,9 +76,25 @@ class UrdfParser {
   // @note: see AddModelFromUrdf for a full account of diagnostics, error
   // reporting, and return values.
   std::optional<ModelInstanceIndex> Parse();
-  // TODO(rpoyner-tri): assimilate all the remaining file-private parsing
-  // functions in this file into methods of this class, to properly plumb the
-  // error/warning channels.
+  void ParseBushing(XMLElement* node);
+  void ParseFrame(XMLElement* node);
+  void ParseTransmission(const JointEffortLimits& joint_effort_limits,
+                         XMLElement* node);
+  void ParseJoint(JointEffortLimits* joint_effort_limits, XMLElement* node);
+  const Body<double>* GetBodyForElement(const std::string& element_name,
+                                        const std::string& link_name);
+  void ParseJointDynamics(XMLElement* node, double* damping);
+  void ParseJointLimits(XMLElement* node, double* lower, double* upper,
+                        double* velocity, double* acceleration, double* effort);
+  void ParseJointKeyParams(XMLElement* node,
+                           std::string* name,
+                           std::string* type,
+                           std::string* parent_link_name,
+                           std::string* child_link_name);
+  void ParseCollisionFilterGroup(XMLElement* node);
+  void ParseBody(XMLElement* node, MaterialMap* materials);
+  SpatialInertia<double> ExtractSpatialInertiaAboutBoExpressedInB(
+      XMLElement* node);
 
   void Warning(const XMLNode& location, std::string message) const {
     diagnostic_.Warning(location, std::move(message));
@@ -99,7 +117,7 @@ class UrdfParser {
 
 const char* kWorldName = "world";
 
-SpatialInertia<double> ExtractSpatialInertiaAboutBoExpressedInB(
+SpatialInertia<double> UrdfParser::ExtractSpatialInertiaAboutBoExpressedInB(
     XMLElement* node) {
   RigidTransformd X_BBi;
 
@@ -152,12 +170,8 @@ SpatialInertia<double> ExtractSpatialInertiaAboutBoExpressedInB(
       body_mass, p_BoBcm_B, I_BBcm_B);
 }
 
-void ParseBody(const multibody::PackageMap& package_map,
-               const std::string& root_dir,
-               ModelInstanceIndex model_instance,
-               XMLElement* node,
-               MaterialMap* materials,
-               MultibodyPlant<double>* plant) {
+void UrdfParser::ParseBody(XMLElement* node, MaterialMap* materials) {
+  // TODO(rpoyner-tri): legacy undocumented tag: remove, fix?
   std::string drake_ignore;
   if (ParseStringAttribute(node, "drake_ignore", &drake_ignore) &&
       drake_ignore == std::string("true")) {
@@ -166,8 +180,8 @@ void ParseBody(const multibody::PackageMap& package_map,
 
   std::string body_name;
   if (!ParseStringAttribute(node, "name", &body_name)) {
-    throw std::runtime_error(
-        "ERROR: link tag is missing name attribute.");
+    Error(*node, "link tag is missing name attribute.");
+    return;
   }
 
   const RigidBody<double>* body_pointer{};
@@ -177,15 +191,12 @@ void ParseBody(const multibody::PackageMap& package_map,
     //  discoverable *somewhere*. But this function is in an anonymous
     //  namespace; where would the documentation go that supports this
     //  implementation?
-    body_pointer = &plant->world_body();
+    body_pointer = &w_.plant->world_body();
     if (node->FirstChildElement("inertial") != nullptr) {
-      // TODO(SeanCurtis-TRI): It would be good to report file name and line
-      //  number in this error.
-      static const logging::Warn log_once(
-          "A URDF file declared the \"world\" link and then attempted to "
-          "assign mass properties (via the <inertial> tag). Only geometries, "
-          "<collision> and <visual>, can be assigned to the world link. The "
-          "<inertial> tag is being ignored.");
+      Warning(*node, "A URDF file declared the \"world\" link and then"
+              " attempted to assign mass properties (via the <inertial> tag)."
+              " Only geometries, <collision> and <visual>, can be assigned to"
+              " the world link. The <inertial> tag is being ignored.");
     }
   } else {
     SpatialInertia<double> M_BBo_B;
@@ -198,84 +209,82 @@ void ParseBody(const multibody::PackageMap& package_map,
     }
 
     // Add a rigid body to model each link.
-    body_pointer = &plant->AddRigidBody(body_name, model_instance, M_BBo_B);
+    body_pointer = &w_.plant->AddRigidBody(body_name, model_instance_, M_BBo_B);
   }
 
-  if (plant->geometry_source_is_registered()) {
+  if (w_.plant->geometry_source_is_registered()) {
     const RigidBody<double>& body = *body_pointer;
     std::unordered_set<std::string> geometry_names;
 
     for (XMLElement* visual_node = node->FirstChildElement("visual");
          visual_node;
          visual_node = visual_node->NextSiblingElement("visual")) {
-      geometry::GeometryInstance geometry_instance =
-          ParseVisual(body_name, package_map, root_dir, visual_node, materials,
-                      &geometry_names);
+      std::optional<geometry::GeometryInstance> geometry_instance =
+          ParseVisual(body_name, w_.package_map, root_dir_,
+                      visual_node, materials, &geometry_names);
+      if (!geometry_instance) { continue; }
       // The parsing should *always* produce an IllustrationProperties
       // instance, even if it is empty.
-      DRAKE_DEMAND(geometry_instance.illustration_properties() != nullptr);
-      plant->RegisterVisualGeometry(
-          body, geometry_instance.pose(), geometry_instance.shape(),
-          geometry_instance.name(),
-          *geometry_instance.illustration_properties());
+      DRAKE_DEMAND(geometry_instance->illustration_properties() != nullptr);
+      w_.plant->RegisterVisualGeometry(
+          body, geometry_instance->pose(), geometry_instance->shape(),
+          geometry_instance->name(),
+          *geometry_instance->illustration_properties());
     }
 
     for (XMLElement* collision_node = node->FirstChildElement("collision");
          collision_node;
          collision_node = collision_node->NextSiblingElement("collision")) {
-      geometry::GeometryInstance geometry_instance =
-          ParseCollision(body_name, package_map, root_dir, collision_node,
-          &geometry_names);
-      DRAKE_DEMAND(geometry_instance.proximity_properties() != nullptr);
-      plant->RegisterCollisionGeometry(
-          body, geometry_instance.pose(), geometry_instance.shape(),
-          geometry_instance.name(),
-          std::move(*geometry_instance.mutable_proximity_properties()));
+      std::optional<geometry::GeometryInstance> geometry_instance =
+          ParseCollision(body_name, w_.package_map, root_dir_,
+                         collision_node, &geometry_names);
+      if (!geometry_instance) { continue; }
+      DRAKE_DEMAND(geometry_instance->proximity_properties() != nullptr);
+      w_.plant->RegisterCollisionGeometry(
+          body, geometry_instance->pose(), geometry_instance->shape(),
+          geometry_instance->name(),
+          std::move(*geometry_instance->mutable_proximity_properties()));
     }
   }
 }
 
-void ParseCollisionFilterGroup(ModelInstanceIndex model_instance,
-                               XMLElement* node,
-                               MultibodyPlant<double>* plant) {
+void UrdfParser::ParseCollisionFilterGroup(XMLElement* node) {
   auto next_child_element = [](const ElementNode& data_element,
                                const char* element_name) {
-    return std::get<tinyxml2::XMLElement*>(data_element)
+    return std::get<XMLElement*>(data_element)
         ->FirstChildElement(element_name);
   };
   auto next_sibling_element = [](const ElementNode& data_element,
                                  const char* element_name) {
-    return std::get<tinyxml2::XMLElement*>(data_element)
+    return std::get<XMLElement*>(data_element)
         ->NextSiblingElement(element_name);
   };
   auto has_attribute = [](const ElementNode& data_element,
                           const char* attribute_name) {
     std::string attribute_value;
-    return ParseStringAttribute(std::get<tinyxml2::XMLElement*>(data_element),
+    return ParseStringAttribute(std::get<XMLElement*>(data_element),
                                 attribute_name, &attribute_value);
   };
-  auto get_string_attribute = [](const ElementNode& data_element,
-                                 const char* attribute_name) {
+  auto get_string_attribute = [this](const ElementNode& data_element,
+                                     const char* attribute_name) {
     std::string attribute_value;
-    if (!ParseStringAttribute(std::get<tinyxml2::XMLElement*>(data_element),
-                              attribute_name, &attribute_value)) {
-      throw std::runtime_error(fmt::format(
-          "{}:{}:{} The tag <{}> does not specify the required attribute"
-          " \"{}\" at line {}.", __FILE__, __func__, __LINE__,
-          std::get<tinyxml2::XMLElement*>(data_element)->Value(),
-          attribute_name,
-          std::get<tinyxml2::XMLElement*>(data_element)->GetLineNum()));
+    XMLElement* anode = std::get<XMLElement*>(data_element);
+    if (!ParseStringAttribute(anode, attribute_name, &attribute_value)) {
+      Error(*anode, fmt::format("The tag <{}> does not specify the required"
+                                " attribute \"{}\".", anode->Value(),
+                                attribute_name));
+      // Fall through to return empty string.
     }
     return attribute_value;
   };
   auto get_bool_attribute = [](const ElementNode& data_element,
                                const char* attribute_name) {
     std::string attribute_value;
-    ParseStringAttribute(std::get<tinyxml2::XMLElement*>(data_element),
+    ParseStringAttribute(std::get<XMLElement*>(data_element),
                          attribute_name, &attribute_value);
     return attribute_value == std::string("true") ? true : false;
   };
-  ParseCollisionFilterGroupCommon(model_instance, node, plant,
+  ParseCollisionFilterGroupCommon(model_instance_, node, w_.plant,
                                   next_child_element, next_sibling_element,
                                   has_attribute, get_string_attribute,
                                   get_bool_attribute, get_string_attribute);
@@ -294,46 +303,49 @@ void ParseCollisionFilterGroup(ModelInstanceIndex model_instance,
 // parent link should be saved.
 // @param[out] child_link_name A reference to a string where the name of the
 // child link should be saved.
-void ParseJointKeyParams(XMLElement* node,
-                         std::string* name,
-                         std::string* type,
-                         std::string* parent_link_name,
-                         std::string* child_link_name) {
+void UrdfParser::ParseJointKeyParams(XMLElement* node,
+                                     std::string* name,
+                                     std::string* type,
+                                     std::string* parent_link_name,
+                                     std::string* child_link_name) {
   if (!ParseStringAttribute(node, "name", name)) {
-    throw std::runtime_error(
-        "ERROR: joint tag is missing name attribute");
+    Error(*node, "joint tag is missing name attribute");
+    return;
   }
 
   if (!ParseStringAttribute(node, "type", type)) {
-    throw std::runtime_error(
-        "ERROR: joint " + *name + " is missing type attribute");
+    Error(*node, fmt::format("joint '{}' is missing type attribute", *name));
+    return;
   }
 
   // Obtains the name of the joint's parent link.
   XMLElement* parent_node = node->FirstChildElement("parent");
   if (!parent_node) {
-    throw std::runtime_error(
-        "ERROR: joint " + *name + " doesn't have a parent node!");
+    Error(*node, fmt::format("joint '{}' doesn't have a parent node!", *name));
+    return;
   }
   if (!ParseStringAttribute(parent_node, "link", parent_link_name)) {
-    throw std::runtime_error(
-        "ERROR: joint " + *name + "'s parent does not have a link attribute!");
+    Error(*parent_node, fmt::format("joint {}'s parent does not have a link"
+                                    " attribute!", *name));
+    return;
   }
 
   // Obtains the name of the joint's child link.
   XMLElement* child_node = node->FirstChildElement("child");
   if (!child_node) {
-    throw std::runtime_error(
-        "ERROR: joint " + *name + " doesn't have a child node");
+    Error(*node, fmt::format("joint '{}' doesn't have a child node!", *name));
+    return;
   }
   if (!ParseStringAttribute(child_node, "link", child_link_name)) {
-    throw std::runtime_error(
-        "ERROR: joint " + *name + "'s child does not have a link attribute!");
+    Error(*child_node, fmt::format("joint {}'s child does not have a link"
+                                   " attribute!", *name));
+    return;
   }
 }
 
-void ParseJointLimits(XMLElement* node, double* lower, double* upper,
-                      double* velocity, double* acceleration, double* effort) {
+void UrdfParser::ParseJointLimits(
+    XMLElement* node, double* lower, double* upper,
+    double* velocity, double* acceleration, double* effort) {
   *lower = -std::numeric_limits<double>::infinity();
   *upper = std::numeric_limits<double>::infinity();
   *velocity = std::numeric_limits<double>::infinity();
@@ -350,7 +362,7 @@ void ParseJointLimits(XMLElement* node, double* lower, double* upper,
   }
 }
 
-void ParseJointDynamics(XMLElement* node, double* damping) {
+void UrdfParser::ParseJointDynamics(XMLElement* node, double* damping) {
   *damping = 0.0;
   double coulomb_friction = 0.0;
   double coulomb_window = std::numeric_limits<double>::epsilon();
@@ -360,44 +372,40 @@ void ParseJointDynamics(XMLElement* node, double* damping) {
     ParseScalarAttribute(dynamics_node, "damping", damping);
     if (ParseScalarAttribute(dynamics_node, "friction", &coulomb_friction) &&
         coulomb_friction != 0.0) {
-      static const logging::Warn log_once(
-          "At least one of your URDF files has specified a non-zero value for "
-          "the 'friction' attribute of a joint/dynamics tag. MultibodyPlant "
-          "does not currently support non-zero joint friction.");
+      Warning(*dynamics_node, "A joint has specified a non-zero value for the"
+              " 'friction' attribute of a joint/dynamics tag. MultibodyPlant"
+              " does not currently support non-zero joint friction.");
     }
-    if (ParseScalarAttribute(dynamics_node, "coulomb_window",
-                             &coulomb_window) &&
-        coulomb_window != std::numeric_limits<double>::epsilon()) {
-      static const logging::Warn log_once(
-          "At least one of your URDF files has specified a value for  the "
-          "'coulomb_window' attribute of a <joint> tag. Drake no longer makes "
-          "use of that attribute and all instances will be ignored.");
+    if (ParseScalarAttribute(
+            dynamics_node, "coulomb_window", &coulomb_window)) {
+      Warning(*dynamics_node, "A joint has specified a value for the"
+              " 'coulomb_window' attribute of a <joint> tag. Drake no longer"
+              " makes use of that attribute; all instances will be ignored.");
     }
   }
 }
 
-const Body<double>& GetBodyForElement(
+const Body<double>* UrdfParser::GetBodyForElement(
     const std::string& element_name,
-    const std::string& link_name,
-    ModelInstanceIndex model_instance,
-    MultibodyPlant<double>* plant) {
+    const std::string& link_name) {
+  auto plant = w_.plant;
   if (link_name == kWorldName) {
-    return plant->world_body();
+    return &plant->world_body();
   }
 
-  if (!plant->HasBodyNamed(link_name, model_instance)) {
-    throw std::runtime_error(
-        "ERROR: Could not find link named\"" +
-        link_name + "\" with model instance ID " +
-        std::to_string(model_instance) + " for element " + element_name + ".");
+  if (!plant->HasBodyNamed(link_name, model_instance_)) {
+    Error(*xml_doc_, fmt::format("Could not find link named '{}' with model"
+                                 " instance ID {} for element '{}'.", link_name,
+                                 model_instance_, element_name));
+    return nullptr;
   }
-  return plant->GetBodyByName(link_name, model_instance);
+  return &plant->GetBodyByName(link_name, model_instance_);
 }
 
-void ParseJoint(ModelInstanceIndex model_instance,
-                std::map<std::string, double>* joint_effort_limits,
-                XMLElement* node,
-                MultibodyPlant<double>* plant) {
+void UrdfParser::ParseJoint(
+    JointEffortLimits* joint_effort_limits,
+    XMLElement* node) {
+  // TODO(rpoyner-tri): legacy undocumented tag: remove, fix?
   std::string drake_ignore;
   if (ParseStringAttribute(node, "drake_ignore", &drake_ignore) &&
       drake_ignore == std::string("true")) {
@@ -407,11 +415,17 @@ void ParseJoint(ModelInstanceIndex model_instance,
   // Parses the parent and child link names.
   std::string name, type, parent_name, child_name;
   ParseJointKeyParams(node, &name, &type, &parent_name, &child_name);
+  if (name.empty() || type.empty() ||
+      parent_name.empty() || child_name.empty()) {
+    return;
+  }
 
-  const Body<double>& parent_body = GetBodyForElement(
-      name, parent_name, model_instance, plant);
-  const Body<double>& child_body = GetBodyForElement(
-      name, child_name, model_instance, plant);
+  const Body<double>* parent_body = GetBodyForElement(
+      name, parent_name);
+  if (parent_body == nullptr) { return; }
+  const Body<double>* child_body = GetBodyForElement(
+      name, child_name);
+  if (child_body == nullptr) { return; }
 
   RigidTransformd X_PJ;
   XMLElement* origin = node->FirstChildElement("origin");
@@ -425,8 +439,9 @@ void ParseJoint(ModelInstanceIndex model_instance,
       type.compare("floating") != 0 && type.compare("ball") != 0) {
     ParseVectorAttribute(axis_node, "xyz", &axis);
     if (axis.norm() < 1e-8) {
-      throw std::runtime_error(
-          "ERROR: Joint " + name + "axis is zero.  Don't do that.");
+      Error(*axis_node, fmt::format("Joint '{}' axis is zero.  Don't do that.",
+                                    name));
+      return;
     }
     axis.normalize();
   }
@@ -448,57 +463,59 @@ void ParseJoint(ModelInstanceIndex model_instance,
   // later if/when an actuator is created.
   double effort = std::numeric_limits<double>::infinity();
 
-  auto throw_on_custom_joint = [node, name, type](bool want_custom_joint) {
+  auto throw_on_custom_joint =
+      [node, name, type, this](bool want_custom_joint) {
     const std::string node_name(node->Name());
     const bool is_custom_joint = node_name == "drake:joint";
     if (want_custom_joint && !is_custom_joint) {
-      throw std::runtime_error(
-          "ERROR: Joint " + name + " of type " + type +
-          " is a custom joint type, and should be a <drake:joint>");
+      Error(*node, fmt::format("Joint {} of type {} is a custom joint type, and"
+                               " should be a <drake:joint>", name, type));
+      return;
     } else if (!want_custom_joint && is_custom_joint) {
-      throw std::runtime_error(
-          "ERROR: Joint " + name + " of type " + type +
-          " is a standard joint type, and should be a <joint>");
+      Error(*node, fmt::format("Joint {} of type {} is a standard joint type,"
+                               " and should be a <joint>", name, type));
+      return;
     }
   };
 
+  auto plant = w_.plant;
   if (type.compare("revolute") == 0 || type.compare("continuous") == 0) {
     throw_on_custom_joint(false);
     ParseJointLimits(node, &lower, &upper, &velocity, &acceleration, &effort);
     ParseJointDynamics(node, &damping);
     const JointIndex index = plant->AddJoint<RevoluteJoint>(
-        name, parent_body, X_PJ,
-        child_body, std::nullopt, axis, lower, upper, damping).index();
+        name, *parent_body, X_PJ,
+        *child_body, std::nullopt, axis, lower, upper, damping).index();
     Joint<double>& joint = plant->get_mutable_joint(index);
     joint.set_velocity_limits(Vector1d(-velocity), Vector1d(velocity));
     joint.set_acceleration_limits(
         Vector1d(-acceleration), Vector1d(acceleration));
   } else if (type.compare("fixed") == 0) {
     throw_on_custom_joint(false);
-    plant->AddJoint<WeldJoint>(name, parent_body, X_PJ,
-                               child_body, std::nullopt,
+    plant->AddJoint<WeldJoint>(name, *parent_body, X_PJ,
+                               *child_body, std::nullopt,
                                RigidTransformd::Identity());
   } else if (type.compare("prismatic") == 0) {
     throw_on_custom_joint(false);
     ParseJointLimits(node, &lower, &upper, &velocity, &acceleration, &effort);
     ParseJointDynamics(node, &damping);
     const JointIndex index = plant->AddJoint<PrismaticJoint>(
-        name, parent_body, X_PJ,
-        child_body, std::nullopt, axis, lower, upper, damping).index();
+        name, *parent_body, X_PJ,
+        *child_body, std::nullopt, axis, lower, upper, damping).index();
     Joint<double>& joint = plant->get_mutable_joint(index);
     joint.set_velocity_limits(Vector1d(-velocity), Vector1d(velocity));
     joint.set_acceleration_limits(
         Vector1d(-acceleration), Vector1d(acceleration));
   } else if (type.compare("floating") == 0) {
     throw_on_custom_joint(false);
-    drake::log()->warn("Joint {} specified as type floating which is not "
-                       "supported by MultibodyPlant.  Leaving {} as a "
-                       "free body.", name, child_name);
+    Warning(*node, fmt::format("Joint '{}' specified as type floating which is"
+                               " not supported by MultibodyPlant.  Leaving '{}'"
+                               " as a free body.", name, child_name));
   } else if (type.compare("ball") == 0) {
     throw_on_custom_joint(true);
     ParseJointDynamics(node, &damping);
-    plant->AddJoint<BallRpyJoint>(name, parent_body, X_PJ,
-                                  child_body, std::nullopt, damping);
+    plant->AddJoint<BallRpyJoint>(name, *parent_body, X_PJ,
+                                  *child_body, std::nullopt, damping);
   } else if (type.compare("planar") == 0) {
     throw_on_custom_joint(true);
     Vector3d damping_vec(0, 0, 0);
@@ -506,26 +523,25 @@ void ParseJoint(ModelInstanceIndex model_instance,
     if (dynamics_node) {
       ParseVectorAttribute(dynamics_node, "damping", &damping_vec);
     }
-    plant->AddJoint<PlanarJoint>(name, parent_body, X_PJ,
-                                 child_body, std::nullopt, damping_vec);
+    plant->AddJoint<PlanarJoint>(name, *parent_body, X_PJ,
+                                 *child_body, std::nullopt, damping_vec);
   } else if (type.compare("universal") == 0) {
     throw_on_custom_joint(true);
     ParseJointDynamics(node, &damping);
-    plant->AddJoint<UniversalJoint>(name, parent_body, X_PJ,
-                                    child_body, std::nullopt, damping);
+    plant->AddJoint<UniversalJoint>(name, *parent_body, X_PJ,
+                                    *child_body, std::nullopt, damping);
   } else {
-    throw std::runtime_error(
-        "ERROR: Joint " + name + " has unrecognized type: " + type);
+    Error(*node, fmt::format("Joint '{}' has unrecognized type: '{}'",
+                             name, type));
+    return;
   }
 
   joint_effort_limits->emplace(name, effort);
 }
 
-void ParseTransmission(
-    ModelInstanceIndex model_instance,
-    const std::map<std::string, double>& joint_effort_limits,
-    XMLElement* node,
-    MultibodyPlant<double>* plant) {
+void UrdfParser::ParseTransmission(
+    const JointEffortLimits& joint_effort_limits,
+    XMLElement* node) {
   // Determines the transmission type.
   std::string type;
   XMLElement* type_node = node->FirstChildElement("type");
@@ -534,9 +550,8 @@ void ParseTransmission(
   } else {
     // Old URDF format, kept for convenience
     if (!ParseStringAttribute(node, "type", &type)) {
-      throw std::runtime_error(
-          std::string(__FILE__) + ": " + __func__ +
-          "ERROR: Transmission element is missing a type.");
+      Error(*node, "Transmission element is missing a type.");
+      return;
     }
   }
 
@@ -544,69 +559,68 @@ void ParseTransmission(
   // print a warning and then abort this method call since only simple
   // transmissions are supported at this time.
   if (type.find("SimpleTransmission") == std::string::npos) {
-    static const logging::Warn log_once(
-        "At least one of your URDF files has <transmission> type that isn't "
-        "'SimpleTransmission'. Drake only supports 'SimpleTransmission'; all "
-        "other transmission types will be ignored.");
+    Warning(*node, "A <transmission> has a type that isn't"
+            " 'SimpleTransmission'. Drake only supports 'SimpleTransmission';"
+            " all other transmission types will be ignored.");
     return;
   }
 
   // Determines the actuator's name.
   XMLElement* actuator_node = node->FirstChildElement("actuator");
   if (!actuator_node) {
-    throw std::runtime_error(
-        "ERROR: Transmission is missing an actuator element.");
+    Error(*node, "Transmission is missing an actuator element.");
+    return;
   }
 
   std::string actuator_name;
   if (!ParseStringAttribute(actuator_node, "name", &actuator_name)) {
-    throw std::runtime_error(
-        "ERROR: Transmission is missing an actuator name.");
+    Error(*actuator_node, "Transmission is missing an actuator name.");
+    return;
   }
 
   // Determines the name of the joint to which the actuator is attached.
   XMLElement* joint_node = node->FirstChildElement("joint");
   if (!joint_node) {
-    throw std::runtime_error(
-        "ERROR: Transmission is missing a joint element.");
+    Error(*node, "Transmission is missing a joint element.");
+    return;
   }
 
   std::string joint_name;
   if (!ParseStringAttribute(joint_node, "name", &joint_name)) {
-    throw std::runtime_error(
-        "ERROR: Transmission is missing a joint name.");
+    Error(*joint_node, "Transmission is missing a joint name.");
+    return;
   }
 
-  if (!plant->HasJointNamed(joint_name, model_instance)) {
-    throw std::runtime_error(
-        "ERROR: Transmission specifies joint " + joint_name +
-        " which does not exist.");
+  auto plant = w_.plant;
+  if (!plant->HasJointNamed(joint_name, model_instance_)) {
+    Error(*joint_node, fmt::format("Transmission specifies joint '{}' which"
+                                   " does not exist.", joint_name));
+    return;
   }
   const Joint<double>& joint = plant->GetJointByName(
-      joint_name, model_instance);
+      joint_name, model_instance_);
 
   // Checks if the actuator is attached to a fixed joint. If so, abort this
   // method call.
   if (joint.num_positions() == 0) {
-    drake::log()->warn(
-        "WARNING: Skipping transmission since it's attached to "
-        "a fixed joint \"" + joint_name + "\".");
+    Warning(*joint_node, fmt::format("Skipping transmission since it's attached"
+                                     " to a fixed joint \"{}\".", joint_name));
     return;
   }
 
   const auto effort_iter = joint_effort_limits.find(joint_name);
   DRAKE_DEMAND(effort_iter != joint_effort_limits.end());
   if (effort_iter->second < 0) {
-    throw std::runtime_error(
-        "ERROR: Transmission specifies joint " + joint_name +
-        " which has a negative effort limit.");
+    Error(*joint_node, fmt::format("Transmission specifies joint '{}' which has"
+                                   " a negative effort limit.", joint_name));
+    return;
   }
 
   if (effort_iter->second <= 0) {
-    drake::log()->warn(
-        "WARNING: Skipping transmission since it's attached to "
-        "joint \"" + joint_name + "\" which has a zero "
-        "effort limit {}.", effort_iter->second);
+    Warning(*joint_node, fmt::format("Skipping transmission since it's attached"
+                                     " to joint \"{}\" which has a zero effort"
+                                     " limit {}.", joint_name,
+                                     effort_iter->second));
     return;
   }
 
@@ -619,9 +633,10 @@ void ParseTransmission(
   if (rotor_inertia_node) {
     double rotor_inertia;
     if (!ParseScalarAttribute(rotor_inertia_node, "value", &rotor_inertia)) {
-      throw std::runtime_error(
-          "ERROR: joint actuator " + actuator_name +
-          "'s drake:rotor_inertia does not have a \"value\" attribute!");
+      Error(*rotor_inertia_node,
+            fmt::format("joint actuator {}'s drake:rotor_inertia does not have"
+                        " a \"value\" attribute!", actuator_name));
+      return;
     }
     plant->get_mutable_joint_actuator(actuator.index())
         .set_default_rotor_inertia(rotor_inertia);
@@ -633,95 +648,91 @@ void ParseTransmission(
   if (gear_ratio_node) {
     double gear_ratio;
     if (!ParseScalarAttribute(gear_ratio_node, "value", &gear_ratio)) {
-      throw std::runtime_error(
-          "ERROR: joint actuator " + actuator_name +
-          "'s drake:gear_ratio does not have a \"value\" attribute!");
+      Error(*gear_ratio_node,
+            fmt::format("joint actuator {}'s drake:gear_ratio does not have a"
+                        " \"value\" attribute!", actuator_name));
+      return;
     }
     plant->get_mutable_joint_actuator(actuator.index())
         .set_default_gear_ratio(gear_ratio);
   }
 }
 
-void ParseFrame(ModelInstanceIndex model_instance,
-                XMLElement* node,
-                MultibodyPlant<double>* plant) {
+void UrdfParser::ParseFrame(XMLElement* node) {
   std::string name;
   if (!ParseStringAttribute(node, "name", &name)) {
-    throw std::runtime_error("ERROR parsing frame name.");
+    Error(*node, "parsing frame name.");
+    return;
   }
 
   std::string body_name;
   if (!ParseStringAttribute(node, "link", &body_name)) {
-    throw std::runtime_error(
-        "ERROR: missing link name for frame " + name + ".");
+    Error(*node, fmt::format("missing link name for frame {}.", name));
+    return;
   }
 
-  const Body<double>& body =
-      GetBodyForElement(name, body_name, model_instance, plant);
+  const Body<double>* body = GetBodyForElement(
+      name, body_name);
+  if (body == nullptr) { return; }
 
   RigidTransformd X_BF = OriginAttributesToTransform(node);
-  plant->AddFrame(std::make_unique<FixedOffsetFrame<double>>(
-      name, body.body_frame(), X_BF));
+  w_.plant->AddFrame(std::make_unique<FixedOffsetFrame<double>>(
+      name, body->body_frame(), X_BF));
 }
 
-void ParseBushing(ModelInstanceIndex model_instance,
-                  XMLElement* node,
-                  MultibodyPlant<double>* plant) {
-  // Functor to read a child element with a vector valued `value` attribute
-  // Throws an error if unable to find the tag or if the value attribute is
-  // improperly formed.
-  auto read_vector = [node](const char* element_name) -> Eigen::Vector3d {
+void UrdfParser::ParseBushing(XMLElement* node) {
+  // Functor to read a child element with a vector valued `value` attribute.
+  // Returns a zero vector if unable to find the tag or if the value attribute
+  // is improperly formed.
+  auto read_vector = [node, this](const char* element_name) -> Eigen::Vector3d {
     const XMLElement* value_node = node->FirstChildElement(element_name);
     if (value_node != nullptr) {
       Eigen::Vector3d value;
       if (ParseVectorAttribute(value_node, "value", &value)) {
         return value;
       } else {
-        throw std::runtime_error(
-            fmt::format("Unable to read the 'value' attribute for the <{}> "
-                        "tag on line {}",
-                        element_name, value_node->GetLineNum()));
+        Error(*node, fmt::format("Unable to read the 'value' attribute for the"
+                                 " <{}> tag", element_name));
+        return Eigen::Vector3d::Zero();
       }
     } else {
-      throw std::runtime_error(
-          fmt::format("Unable to find the <{}> "
-                      "tag on line {}",
-                      element_name, node->GetLineNum()));
+      Error(*node, fmt::format("Unable to find the <{}> tag", element_name));
+      return Eigen::Vector3d::Zero();
     }
   };
 
-  // Functor to read a child element with a string valued `name` attribute.
-  // Throws an error if unable to find the tag of if the name attribute is
-  // improperly formed.
-  auto read_frame = [model_instance, node, plant]
-                    (const char* element_name) -> const Frame<double>* {
+  // Functor to read a child element with a string-valued `name` attribute.
+  // Returns nullptr if unable to find the tag, if the name attribute is
+  // improperly formed, or if it does not refer to a frame already in the
+  // model.
+  auto read_frame = [node, this](const char* element_name)
+                    -> const Frame<double>* {
     XMLElement* value_node = node->FirstChildElement(element_name);
 
     if (value_node != nullptr) {
       std::string frame_name;
+      auto plant = w_.plant;
       if (ParseStringAttribute(value_node, "name", &frame_name)) {
-        if (!plant->HasFrameNamed(frame_name, model_instance)) {
-          throw std::runtime_error(fmt::format(
-              "Frame: {} specified for <{}> does not exist in the model.",
-              frame_name, element_name));
+        if (!plant->HasFrameNamed(frame_name, model_instance_)) {
+          Error(*value_node, fmt::format("Frame: {} specified for <{}> does not"
+                                         " exist in the model.", frame_name,
+                                         element_name));
+          return {};
         }
-        return &plant->GetFrameByName(frame_name, model_instance);
-
+        return &plant->GetFrameByName(frame_name, model_instance_);
       } else {
-        throw std::runtime_error(
-            fmt::format("Unable to read the 'name' attribute for the <{}> "
-                        "tag on line {}",
-                        element_name, value_node->GetLineNum()));
+        Error(*value_node, fmt::format("Unable to read the 'name' attribute for"
+                                       " the <{}> tag", element_name));
+        return {};
       }
 
     } else {
-      throw std::runtime_error(
-          fmt::format("Unable to find the <{}> tag on line {}", element_name,
-                      node->GetLineNum()));
+      Error(*node, fmt::format("Unable to find the <{}> tag", element_name));
+      return {};
     }
   };
 
-  ParseLinearBushingRollPitchYaw(read_vector, read_frame, plant);
+  ParseLinearBushingRollPitchYaw(read_vector, read_frame, w_.plant);
 }
 
 std::optional<ModelInstanceIndex> UrdfParser::Parse() {
@@ -758,18 +769,17 @@ std::optional<ModelInstanceIndex> UrdfParser::Parse() {
   for (XMLElement* link_node = node->FirstChildElement("link");
        link_node;
        link_node = link_node->NextSiblingElement("link")) {
-    ParseBody(w_.package_map, root_dir_, model_instance_, link_node,
-              &materials, w_.plant);
+    ParseBody(link_node, &materials);
   }
 
   // Parses the collision filter groups only if the scene graph is registered.
   if (w_.plant->geometry_source_is_registered()) {
-    ParseCollisionFilterGroup(model_instance_, node, w_.plant);
+    ParseCollisionFilterGroup(node);
   }
 
   // Joint effort limits are stored with joints, but used when creating the
   // actuator (which is done when parsing the transmission).
-  std::map<std::string, double> joint_effort_limits;
+  JointEffortLimits joint_effort_limits;
 
   // Parses the model's joint elements.  While it may not be strictly required
   // to be true in MultibodyPlant, generally the JointIndex for any given
@@ -781,7 +791,7 @@ std::optional<ModelInstanceIndex> UrdfParser::Parse() {
        joint_node = joint_node->NextSiblingElement()) {
     const std::string node_name(joint_node->Name());
     if (node_name == "joint" || node_name == "drake:joint") {
-      ParseJoint(model_instance_, &joint_effort_limits, joint_node, w_.plant);
+      ParseJoint(&joint_effort_limits, joint_node);
     }
   }
 
@@ -790,8 +800,7 @@ std::optional<ModelInstanceIndex> UrdfParser::Parse() {
        transmission_node;
        transmission_node =
            transmission_node->NextSiblingElement("transmission")) {
-    ParseTransmission(model_instance_, joint_effort_limits,
-                      transmission_node, w_.plant);
+    ParseTransmission(joint_effort_limits, transmission_node);
   }
 
   if (node->FirstChildElement("loop_joint")) {
@@ -802,7 +811,7 @@ std::optional<ModelInstanceIndex> UrdfParser::Parse() {
   // Parses the model's Drake frame elements.
   for (XMLElement* frame_node = node->FirstChildElement("frame"); frame_node;
        frame_node = frame_node->NextSiblingElement("frame")) {
-    ParseFrame(model_instance_, frame_node, w_.plant);
+    ParseFrame(frame_node);
   }
 
   // Parses the model's custom Drake bushing tags.
@@ -810,7 +819,7 @@ std::optional<ModelInstanceIndex> UrdfParser::Parse() {
            node->FirstChildElement("drake:linear_bushing_rpy");
        bushing_node; bushing_node = bushing_node->NextSiblingElement(
                          "drake:linear_bushing_rpy")) {
-    ParseBushing(model_instance_, bushing_node, w_.plant);
+    ParseBushing(bushing_node);
   }
 
   return model_instance_;


### PR DESCRIPTION
Relevant to: #16782

This patch completes the conversion of detail_urdf_parser to use the
passed-in diagnostic policy for reporting warnings and errors. Some
parsing routines in related modules are not yet ported.

The patch boosts test coverage of error and warning branches to 100%, by
adding numerous (25-ish?) new test cases. It also converts test cases
from relying on throw-and-catch mechanics to message capture by a
test-only diagnostics policy.

As collateral damage, the collision filter parsing routines in
detail_common gain some ability to tolerate parsing functors that return
on error, instead of throwing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16829)
<!-- Reviewable:end -->
