### PR TITLE
Minimize libtiff build (for wheels)

### DIFF
--- a/tools/wheel/image/dependencies/projects/libtiff.cmake
+++ b/tools/wheel/image/dependencies/projects/libtiff.cmake
@@ -13,6 +13,9 @@ ExternalProject_Add(libtiff
         -DZLIB_INCLUDE_DIR=${CMAKE_INSTALL_PREFIX}/include
         -DZLIB_LIBRARY_DEBUG=${CMAKE_INSTALL_PREFIX}/lib/libz.a
         -DZLIB_LIBRARY_RELEASE=${CMAKE_INSTALL_PREFIX}/lib/libz.a
+        -Djbig:BOOLEAN=OFF
+        -Dwebp:BOOLEAN=OFF
+        -Dzstd:BOOLEAN=OFF
         )
 
 extract_license(libtiff


### PR DESCRIPTION
When building libtiff (for wheels), explicitly disable some things that we don't need. This should have no effect for the manylinux builds, as those are fully hermetic and don't have anything we didn't ask to have installed, but will be very important on macOS (especially for local testing) to ensure we don't pick up libraries that happen to be installed from brew.

+@jwnimmer-tri  for feature review, please.