### PR TITLE
Use latest pip to build wheels

### DIFF
--- a/tools/wheel/image/provision-python.sh
+++ b/tools/wheel/image/provision-python.sh
@@ -11,7 +11,9 @@ apt-get -y install --no-install-recommends \
 
 ${PYTHON} -m venv /usr/local
 
-pip install \
+pip install --upgrade pip
+
+pip install --upgrade \
     pyyaml \
     semantic-version \
     setuptools \


### PR DESCRIPTION
When setting up the Python environment for building wheels, also ensure we are using the latest version of pip.

+@jwnimmer-tri for feature review, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16834)
<!-- Reviewable:end -->
