### PR TITLE
[pydrake] Stub out scipy.sparse for unit testing

### DIFF
--- a/bindings/pydrake/common/test_utilities/BUILD.bazel
+++ b/bindings/pydrake/common/test_utilities/BUILD.bazel
@@ -72,6 +72,20 @@ drake_py_library(
     ],
 )
 
+# A minimal of implementation scipy.sparse that's barely functional enough
+# to support unit testing the Drake APIs that return Eigen::Sparse matrices.
+# The pybind11 type caster for Eigen::Sparse maps it to scipy.sparse.
+drake_py_library(
+    name = "scipy_stub_py",
+    testonly = 1,
+    srcs = [
+        "scipy_stub/scipy/__init__.py",
+        "scipy_stub/scipy/sparse/__init__.py",
+    ],
+    # N.B. We do not depend on ":module_py".
+    imports = ["scipy_stub"],
+)
+
 # Package roll-up (for Bazel dependencies).
 drake_py_library(
     name = "test_utilities",
@@ -81,6 +95,9 @@ drake_py_library(
         ":module_py",
         ":numpy_compare_py",
         ":pickle_compare_py",
+        # N.B. Do not add scipy_stub_py here; it inserts scipy as a top-level
+        # module. Developers should only do that with intent, not as a bonus
+        # dependency from a conveience roll-up module.
     ],
 )
 

--- a/bindings/pydrake/common/test_utilities/scipy_stub/scipy/__init__.py
+++ b/bindings/pydrake/common/test_utilities/scipy_stub/scipy/__init__.py
@@ -1,0 +1,4 @@
+"""A minimal implementation of scipy.sparse that's barely functional enough
+to support unit testing the Drake APIs that return Eigen::Sparse matrices.
+The pybind11 type caster for Eigen::Sparse maps it to scipy.sparse.
+"""

--- a/bindings/pydrake/common/test_utilities/scipy_stub/scipy/sparse/__init__.py
+++ b/bindings/pydrake/common/test_utilities/scipy_stub/scipy/sparse/__init__.py
@@ -1,0 +1,32 @@
+"""A minimal implementation of scipy.sparse that's barely functional enough
+to support unit testing the Drake APIs that return Eigen::Sparse matrices.
+The pybind11 type caster for Eigen::Sparse maps it to scipy.sparse.
+"""
+
+import numpy as np
+
+
+class csc_matrix:
+    """A minimal implementation of the scipy.sparse matrix type.
+    https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csc_matrix.html
+    """
+
+    def __init__(self, arg1, shape):
+        (self._data, self._indices, self._indptr) = arg1
+        self._shape = shape
+
+        # To sanity-check our arguments, convert the data to triplets.
+        self._triplets = []
+        for col in range(len(self._indptr) - 1):
+            start = self._indptr[col]
+            end = self._indptr[col+1]
+            rows = self._indices[start:end]
+            values = self._data[start:end]
+            for row, value in zip(rows, values):
+                self._triplets.append((row, col, value))
+
+    def todense(self):
+        result = np.zeros(shape=self._shape)
+        for row, col, value in self._triplets:
+            result[row, col] = value
+        return result

--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -377,6 +377,7 @@ drake_py_unittest(
     deps = [
         ":csdp_py",
         "//bindings/pydrake/common/test_utilities",
+        "//bindings/pydrake/common/test_utilities:scipy_stub_py",
     ],
 )
 
@@ -482,6 +483,7 @@ drake_py_unittest(
         ":snopt_py",
         "//bindings/pydrake:math_py",
         "//bindings/pydrake/common/test_utilities",
+        "//bindings/pydrake/common/test_utilities:scipy_stub_py",
     ],
 )
 

--- a/bindings/pydrake/solvers/test/csdp_solver_test.py
+++ b/bindings/pydrake/solvers/test/csdp_solver_test.py
@@ -50,7 +50,7 @@ class TestCsdpSolver(unittest.TestCase):
         z_expected[1, :2] = [-0.25, 0.25]
         z_expected[3:, 3:] = np.diag([2., 2., 0.75, 1.])
         np.testing.assert_allclose(
-            result.get_solver_details().Z_val.toarray(), z_expected, atol=1e-8)
+            result.get_solver_details().Z_val.todense(), z_expected, atol=1e-8)
 
         # Test removing free variables with a non-default method.
         solver = CsdpSolver(


### PR DESCRIPTION
In order to reduce our install footprint, pydrake will no longer depend on scipy on or after 2022-07-01.

Any users of the few scipy-returning methods in pydrake will need to add a direct dependency onto scipy to their own projects. The methods that return a sparse matrix will raise an ImportError when they are called when scipy is not installed.

Towards #16836 and #14691.  Plan detailed in https://github.com/RobotLocomotion/drake/issues/14691#issuecomment-1075658574.

Tested locally by `sudo apt remove python3-scipy` and confirming that this PR passes all pydrake tests, whereas the `master` branch fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16840)
<!-- Reviewable:end -->
