### PR TITLE
[fem] Remove element index from FemElement

### DIFF
--- a/multibody/fem/fem_element.h
+++ b/multibody/fem/fem_element.h
@@ -94,9 +94,6 @@ class FemElement {
     }
   }
 
-  /* The FemElementIndex of this element within the model. */
-  FemElementIndex element_index() const { return element_index_; }
-
   /* Computes the per-element, state-dependent data associated with this
    `DerivedElement` given the `state`. */
   Data ComputeData(const FemState<T>& state) const {
@@ -231,20 +228,15 @@ class FemElement {
   /* Constructs a new FEM element. The constructor is made protected because
    FemElement should not be constructed directly. Use the constructor of the
    derived classes instead.
-   @param[in] element_index  The index of the new element within the model.
    @param[in] node_indices   The node indices of the nodes of this element
                              within the model.
-   @pre element_index is valid.
    @pre Entries in node_indices are valid. */
-  FemElement(FemElementIndex element_index,
-             const std::array<FemNodeIndex, num_nodes>& node_indices,
+  FemElement(const std::array<FemNodeIndex, num_nodes>& node_indices,
              ConstitutiveModel constitutive_model,
              DampingModel<T> damping_model)
-      : element_index_(element_index),
-        node_indices_(node_indices),
+      : node_indices_(node_indices),
         constitutive_model_(std::move(constitutive_model)),
         damping_model_(std::move(damping_model)) {
-    DRAKE_ASSERT(element_index.is_valid());
     for (int i = 0; i < num_nodes; ++i) {
       DRAKE_ASSERT(node_indices[i].is_valid());
     }
@@ -331,8 +323,6 @@ class FemElement {
                              std::string(source_method) + "().");
   }
 
-  /* The index of this element within the model. */
-  FemElementIndex element_index_;
   /* The node indices of this element within the model. */
   std::array<FemNodeIndex, num_nodes> node_indices_;
   /* The constitutive model that describes the stress-strain relationship

--- a/multibody/fem/fem_indexes.h
+++ b/multibody/fem/fem_indexes.h
@@ -7,9 +7,6 @@ namespace drake {
 namespace multibody {
 namespace fem {
 
-/** Type used to index FEM elements. */
-using FemElementIndex = TypeSafeIndex<class FemElementTag>;
-
 /** Type used to index FEM nodes. */
 using FemNodeIndex = TypeSafeIndex<class FemNodeTag>;
 

--- a/multibody/fem/fem_model_impl.h
+++ b/multibody/fem/fem_model_impl.h
@@ -182,7 +182,7 @@ class FemModelImpl : public FemModel<typename Element::T> {
     DRAKE_DEMAND(data != nullptr);
     data->resize(num_elements());
     const FemState<T> fem_state(&(this->fem_state_system()), &context);
-    for (FemElementIndex i(0); i < num_elements(); ++i) {
+    for (int i = 0; i < num_elements(); ++i) {
       (*data)[i] = elements_[i].ComputeData(fem_state);
     }
   }

--- a/multibody/fem/test/dummy_element.h
+++ b/multibody/fem/test/dummy_element.h
@@ -47,11 +47,10 @@ class DummyElement final : public FemElement<DummyElement> {
   using T = typename Base::T;
   static constexpr int kNumDofs = Traits::num_dofs;
 
-  DummyElement(FemElementIndex element_index,
-               const std::array<FemNodeIndex, Traits::num_nodes>& node_indices,
+  DummyElement(const std::array<FemNodeIndex, Traits::num_nodes>& node_indices,
                ConstitutiveModel constitutive_model,
                DampingModel<T> damping_model)
-      : Base(element_index, node_indices, std::move(constitutive_model),
+      : Base(node_indices, std::move(constitutive_model),
              std::move(damping_model)) {}
 
   /* Provides a fixed return value for CalcResidual(). */

--- a/multibody/fem/test/dummy_model.cc
+++ b/multibody/fem/test/dummy_model.cc
@@ -26,8 +26,6 @@ void DummyModel::DummyBuilder::DoBuild() {
 
 void DummyModel::DummyBuilder::AddTwoElementsWithSharedNodes() {
   ThrowIfBuilt();
-  const FemElementIndex kElementIndex0 = FemElementIndex(0);
-  const FemElementIndex kElementIndex1 = FemElementIndex(1);
   const std::array<FemNodeIndex, Traits::num_nodes> kNodeIndices0 = {
       FemNodeIndex(0), FemNodeIndex(1), FemNodeIndex(2), FemNodeIndex(3)};
   const std::array<FemNodeIndex, Traits::num_nodes> kNodeIndices1 = {
@@ -35,10 +33,8 @@ void DummyModel::DummyBuilder::AddTwoElementsWithSharedNodes() {
   const Traits::ConstitutiveModel kConstitutiveModel(kYoungsModulus,
                                                      kPoissonsRatio);
   const DampingModel<T> kDampingModel(kMassDamping, kStiffnessDamping);
-  DummyElement element0(kElementIndex0, kNodeIndices0, kConstitutiveModel,
-                        kDampingModel);
-  DummyElement element1(kElementIndex1, kNodeIndices1, kConstitutiveModel,
-                        kDampingModel);
+  DummyElement element0(kNodeIndices0, kConstitutiveModel, kDampingModel);
+  DummyElement element1(kNodeIndices1, kConstitutiveModel, kDampingModel);
 
   const int num_existing_nodes = reference_positions_.size() / 3;
   element0.OffsetNodeIndex(FemNodeIndex(num_existing_nodes));
@@ -59,14 +55,12 @@ void DummyModel::DummyBuilder::AddTwoElementsWithSharedNodes() {
 
 void DummyModel::DummyBuilder::AddElementWithDistinctNodes() {
   ThrowIfBuilt();
-  const FemElementIndex kElementIndex0 = FemElementIndex(0);
   const std::array<FemNodeIndex, Traits::num_nodes> kNodeIndices0 = {
       FemNodeIndex(0), FemNodeIndex(1), FemNodeIndex(2), FemNodeIndex(3)};
   const Traits::ConstitutiveModel kConstitutiveModel(kYoungsModulus,
                                                      kPoissonsRatio);
   const DampingModel<T> kDampingModel(kMassDamping, kStiffnessDamping);
-  DummyElement element0(kElementIndex0, kNodeIndices0, kConstitutiveModel,
-                        kDampingModel);
+  DummyElement element0(kNodeIndices0, kConstitutiveModel, kDampingModel);
 
   const int num_existing_nodes = reference_positions_.size() / 3;
   element0.OffsetNodeIndex(FemNodeIndex(num_existing_nodes));

--- a/multibody/fem/test/fem_element_test.cc
+++ b/multibody/fem/test/fem_element_test.cc
@@ -17,7 +17,6 @@ using DummyElementTraits = FemElementTraits<DummyElement>;
 using T = DummyElementTraits::T;
 using Data = DummyElementTraits::Data;
 constexpr int kNumNodes = DummyElementTraits::num_nodes;
-const FemElementIndex kZeroIndex = FemElementIndex(0);
 const std::array<FemNodeIndex, kNumNodes> kNodeIndices = {
     {FemNodeIndex(0), FemNodeIndex(1), FemNodeIndex(3), FemNodeIndex(2)}};
 const DummyElementTraits::ConstitutiveModel kConstitutiveModel(5e4, 0.4);
@@ -76,14 +75,12 @@ class FemElementTest : public ::testing::Test {
   std::unique_ptr<internal::FemStateSystem<T>> fem_state_system_;
   std::unique_ptr<FemState<T>> fem_state_;
   /* FemElement under test. */
-  DummyElement element_{kZeroIndex, kNodeIndices, kConstitutiveModel,
-                        kDampingModel};
+  DummyElement element_{kNodeIndices, kConstitutiveModel, kDampingModel};
   systems::CacheIndex cache_index_;
 };
 
 TEST_F(FemElementTest, Constructor) {
   EXPECT_EQ(element_.node_indices(), kNodeIndices);
-  EXPECT_EQ(element_.element_index(), kZeroIndex);
 }
 
 /* Tests that the element data logic is correctly executed through

--- a/multibody/fem/test/volumetric_element_test.cc
+++ b/multibody/fem/test/volumetric_element_test.cc
@@ -23,7 +23,6 @@ constexpr int kNaturalDimension = 3;
 constexpr int kSpatialDimension = 3;
 constexpr int kQuadratureOrder = 1;
 constexpr double kEpsilon = 1e-14;
-const FemElementIndex kZeroIndex(0);
 using AD = AutoDiffXd;
 using QuadratureType =
     internal::SimplexGaussianQuadrature<kNaturalDimension, kQuadratureOrder>;
@@ -76,9 +75,8 @@ class VolumetricElementTest : public ::testing::Test {
     Eigen::Matrix<AD, kSpatialDimension, kNumNodes> X = reference_positions();
     ConstitutiveModelType constitutive_model(kYoungsModulus, kPoissonRatio);
     DampingModel<AD> damping_model(0, 0);
-    elements_.emplace_back(kZeroIndex, kNodeIndices,
-                           std::move(constitutive_model), X, kDensity,
-                           std::move(damping_model));
+    elements_.emplace_back(kNodeIndices, std::move(constitutive_model), X,
+                           kDensity, std::move(damping_model));
   }
 
   /* Makes an FemState to be consumed by the unit tests with the given q, v, and
@@ -236,11 +234,9 @@ namespace {
 
 TEST_F(VolumetricElementTest, Constructor) {
   EXPECT_EQ(element().node_indices(), kNodeIndices);
-  EXPECT_EQ(element().element_index(), kZeroIndex);
   EXPECT_EQ(density(element()), kDensity);
   ElementType move_constructed_element(std::move(elements_[0]));
   EXPECT_EQ(move_constructed_element.node_indices(), kNodeIndices);
-  EXPECT_EQ(move_constructed_element.element_index(), kZeroIndex);
   EXPECT_EQ(density(move_constructed_element), kDensity);
 }
 

--- a/multibody/fem/volumetric_element.h
+++ b/multibody/fem/volumetric_element.h
@@ -165,7 +165,6 @@ class VolumetricElement
 
   /* Constructs a new VolumetricElement. In that process, precomputes the mass
    matrix and the gravity force acting on the element.
-   @param[in] element_index        The index of the new element.
    @param[in] node_indices         The node indices of the nodes of this
                                    element.
    @param[in] constitutive_model   The ConstitutiveModel to be used for this
@@ -180,14 +179,12 @@ class VolumetricElement
    @param[in] damping_model        The DampingModel to be used for this element.
    @pre element_index and node_indices are valid.
    @pre density > 0. */
-  VolumetricElement(FemElementIndex element_index,
-                    const std::array<FemNodeIndex, num_nodes>& node_indices,
+  VolumetricElement(const std::array<FemNodeIndex, num_nodes>& node_indices,
                     ConstitutiveModelType constitutive_model,
                     const Eigen::Ref<const Eigen::Matrix<T, 3, num_nodes>>&
                         reference_positions,
                     T density, DampingModel<T> damping_model)
-      : FemElement<ElementType>(element_index, node_indices,
-                                std::move(constitutive_model),
+      : FemElement<ElementType>(node_indices, std::move(constitutive_model),
                                 std::move(damping_model)),
         density_(std::move(density)) {
     DRAKE_DEMAND(density_ > 0);


### PR DESCRIPTION
They used to be important in the bespoke caching mechanism in the previous design.
We don't need them anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16843)
<!-- Reviewable:end -->
