### PR TITLE
Add the smooth formulation of augmented Lagrangian.

### DIFF
--- a/bindings/pydrake/solvers/augmented_lagrangian_py.cc
+++ b/bindings/pydrake/solvers/augmented_lagrangian_py.cc
@@ -20,50 +20,93 @@ PYBIND11_MODULE(augmented_lagrangian, m) {
   py::module::import("pydrake.solvers.mathematicalprogram");
   py::module::import("pydrake.autodiffutils");
 
-  py::class_<AugmentedLagrangianNonsmooth>(
-      m, "AugmentedLagrangianNonsmooth", doc.AugmentedLagrangianNonsmooth.doc)
-      .def(py::init<const MathematicalProgram*, bool>(), py::arg("prog"),
-          py::arg("include_x_bounds"),
-          doc.AugmentedLagrangianNonsmooth.ctor.doc)
-      .def(
-          "Eval",
-          [](const AugmentedLagrangianNonsmooth* self,
-              const Eigen::Ref<const Eigen::VectorXd>& x,
-              const Eigen::VectorXd& lambda_val, double mu) {
-            Eigen::VectorXd constraint_residue;
-            double cost;
-            const double al_val = self->Eval<double>(
-                x, lambda_val, mu, &constraint_residue, &cost);
-            return std::make_tuple(al_val, constraint_residue, cost);
-          },
-          py::arg("x"), py::arg("lambda_val"), py::arg("mu"),
-          doc.AugmentedLagrangianNonsmooth.Eval.doc)
-      .def(
-          "Eval",
-          [](const AugmentedLagrangianNonsmooth* self,
-              const Eigen::Ref<const VectorX<AutoDiffXd>>& x,
-              const Eigen::VectorXd& lambda_val, double mu) {
-            VectorX<AutoDiffXd> constraint_residue;
-            AutoDiffXd cost;
-            const AutoDiffXd al_val = self->Eval<AutoDiffXd>(
-                x, lambda_val, mu, &constraint_residue, &cost);
-            return std::make_tuple(al_val, constraint_residue, cost);
-          },
-          py::arg("x"), py::arg("lambda_val"), py::arg("mu"),
-          doc.AugmentedLagrangianNonsmooth.Eval.doc)
-      .def("prog", &AugmentedLagrangianNonsmooth::prog, py_rvp::reference,
-          doc.AugmentedLagrangianNonsmooth.prog.doc)
-      .def("include_x_bounds", &AugmentedLagrangianNonsmooth::include_x_bounds,
-          doc.AugmentedLagrangianNonsmooth.include_x_bounds.doc)
-      .def("lagrangian_size", &AugmentedLagrangianNonsmooth::lagrangian_size,
-          doc.AugmentedLagrangianNonsmooth.lagrangian_size.doc)
-      .def("is_equality", &AugmentedLagrangianNonsmooth::is_equality,
-          doc.AugmentedLagrangianNonsmooth.is_equality.doc)
-      .def("x_lo", &AugmentedLagrangianNonsmooth::x_lo,
-          py_rvp::reference_internal, doc.AugmentedLagrangianNonsmooth.x_lo.doc)
-      .def("x_up", &AugmentedLagrangianNonsmooth::x_up,
-          py_rvp::reference_internal,
-          doc.AugmentedLagrangianNonsmooth.x_up.doc);
+  {
+    using Class = AugmentedLagrangianNonsmooth;
+    constexpr auto& cls_doc = doc.AugmentedLagrangianNonsmooth;
+    py::class_<AugmentedLagrangianNonsmooth>(
+        m, "AugmentedLagrangianNonsmooth", cls_doc.doc)
+        .def(py::init<const MathematicalProgram*, bool>(), py::arg("prog"),
+            py::arg("include_x_bounds"), cls_doc.ctor.doc)
+        .def(
+            "Eval",
+            [](const Class* self, const Eigen::Ref<const Eigen::VectorXd>& x,
+                const Eigen::VectorXd& lambda_val, double mu) {
+              Eigen::VectorXd constraint_residue;
+              double cost;
+              const double al_val = self->Eval<double>(
+                  x, lambda_val, mu, &constraint_residue, &cost);
+              return std::make_tuple(al_val, constraint_residue, cost);
+            },
+            py::arg("x"), py::arg("lambda_val"), py::arg("mu"),
+            cls_doc.Eval.doc)
+        .def(
+            "Eval",
+            [](const Class* self,
+                const Eigen::Ref<const VectorX<AutoDiffXd>>& x,
+                const Eigen::VectorXd& lambda_val, double mu) {
+              VectorX<AutoDiffXd> constraint_residue;
+              AutoDiffXd cost;
+              const AutoDiffXd al_val = self->Eval<AutoDiffXd>(
+                  x, lambda_val, mu, &constraint_residue, &cost);
+              return std::make_tuple(al_val, constraint_residue, cost);
+            },
+            py::arg("x"), py::arg("lambda_val"), py::arg("mu"),
+            cls_doc.Eval.doc)
+        .def("prog", &Class::prog, py_rvp::reference, cls_doc.prog.doc)
+        .def("include_x_bounds", &Class::include_x_bounds,
+            cls_doc.include_x_bounds.doc)
+        .def("lagrangian_size", &Class::lagrangian_size,
+            cls_doc.lagrangian_size.doc)
+        .def("is_equality", &Class::is_equality, cls_doc.is_equality.doc)
+        .def("x_lo", &Class::x_lo, py_rvp::reference_internal, cls_doc.x_lo.doc)
+        .def(
+            "x_up", &Class::x_up, py_rvp::reference_internal, cls_doc.x_up.doc);
+  }
+
+  {
+    using Class = AugmentedLagrangianSmooth;
+    constexpr auto& cls_doc = doc.AugmentedLagrangianSmooth;
+    py::class_<Class>(m, "AugmentedLagrangianSmooth", cls_doc.doc)
+        .def(py::init<const MathematicalProgram*, bool>(), py::arg("prog"),
+            py::arg("include_x_bounds"), cls_doc.ctor.doc)
+        .def(
+            "Eval",
+            [](const Class* self, const Eigen::Ref<const Eigen::VectorXd>& x,
+                const Eigen::Ref<const Eigen::VectorXd>& s,
+                const Eigen::VectorXd& lambda_val, double mu) {
+              Eigen::VectorXd constraint_residue;
+              double cost;
+              const double al_val = self->Eval<double>(
+                  x, s, lambda_val, mu, &constraint_residue, &cost);
+              return std::make_tuple(al_val, constraint_residue, cost);
+            },
+            py::arg("x"), py::arg("s"), py::arg("lambda_val"), py::arg("mu"),
+            cls_doc.Eval.doc)
+        .def(
+            "Eval",
+            [](const Class* self,
+                const Eigen::Ref<const VectorX<AutoDiffXd>>& x,
+                const Eigen::Ref<const VectorX<AutoDiffXd>>& s,
+                const Eigen::VectorXd& lambda_val, double mu) {
+              VectorX<AutoDiffXd> constraint_residue;
+              AutoDiffXd cost;
+              const AutoDiffXd al_val = self->Eval<AutoDiffXd>(
+                  x, s, lambda_val, mu, &constraint_residue, &cost);
+              return std::make_tuple(al_val, constraint_residue, cost);
+            },
+            py::arg("x"), py::arg("s"), py::arg("lambda_val"), py::arg("mu"),
+            cls_doc.Eval.doc)
+        .def("prog", &Class::prog, py_rvp::reference, cls_doc.prog.doc)
+        .def("include_x_bounds", &Class::include_x_bounds,
+            cls_doc.include_x_bounds.doc)
+        .def("s_size", &Class::s_size, cls_doc.s_size.doc)
+        .def("lagrangian_size", &Class::lagrangian_size,
+            cls_doc.lagrangian_size.doc)
+        .def("is_equality", &Class::is_equality, cls_doc.is_equality.doc)
+        .def("x_lo", &Class::x_lo, py_rvp::reference_internal, cls_doc.x_lo.doc)
+        .def(
+            "x_up", &Class::x_up, py_rvp::reference_internal, cls_doc.x_up.doc);
+  }
   ExecuteExtraPythonCode(m);
 }
 

--- a/bindings/pydrake/solvers/test/augmented_lagrangian_test.py
+++ b/bindings/pydrake/solvers/test/augmented_lagrangian_test.py
@@ -10,14 +10,14 @@ from pydrake.autodiffutils import InitializeAutoDiff, AutoDiffXd
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 
 
-class TestAugmentedLagrangianNonsmooth(unittest.TestCase):
+class TestAugmentedLagrangian(unittest.TestCase):
     def setUp(self):
         self.prog = mp.MathematicalProgram()
         x = self.prog.NewContinuousVariables(2)
         self.prog.AddQuadraticCost(x[0] * x[0] + 2 * x[1] * x[1])
         self.prog.AddLinearConstraint(x[0] + x[1] <= 3)
 
-    def test_eval_double(self):
+    def test_eval_double_nonsmooth(self):
         dut = al.AugmentedLagrangianNonsmooth(prog=self.prog,
                                               include_x_bounds=True)
         x_val = np.array([1., 3])
@@ -29,11 +29,39 @@ class TestAugmentedLagrangianNonsmooth(unittest.TestCase):
         self.assertIsInstance(constraint_residue, np.ndarray)
         self.assertIsInstance(cost, float)
 
-    def test_eval_ad(self):
+    def test_eval_double_smooth(self):
+        dut = al.AugmentedLagrangianSmooth(prog=self.prog,
+                                           include_x_bounds=True)
+        self.assertEqual(dut.s_size(), 1)
+        x_val = np.array([1., 3])
+        s_val = np.array([3.])
+        lambda_val = np.array([0.5])
+        al_val, constraint_residue, cost = dut.Eval(x=x_val,
+                                                    s=s_val,
+                                                    lambda_val=lambda_val,
+                                                    mu=0.1)
+        self.assertIsInstance(al_val, float)
+        self.assertIsInstance(constraint_residue, np.ndarray)
+        self.assertIsInstance(cost, float)
+
+    def test_eval_ad_nonsmooth(self):
         dut = al.AugmentedLagrangianNonsmooth(prog=self.prog,
                                               include_x_bounds=True)
         x_val = InitializeAutoDiff(np.array([1., 3]))
         al_val, constraint_residue, cost = dut.Eval(x=x_val,
+                                                    lambda_val=np.array([0.5]),
+                                                    mu=0.1)
+        self.assertIsInstance(al_val, AutoDiffXd)
+        self.assertIsInstance(constraint_residue, np.ndarray)
+        self.assertIsInstance(cost, AutoDiffXd)
+
+    def test_eval_ad_smooth(self):
+        dut = al.AugmentedLagrangianSmooth(prog=self.prog,
+                                           include_x_bounds=True)
+        x_val = InitializeAutoDiff(np.array([1., 3]))
+        s_val = np.array([AutoDiffXd(1.)])
+        al_val, constraint_residue, cost = dut.Eval(x=x_val,
+                                                    s=s_val,
                                                     lambda_val=np.array([0.5]),
                                                     mu=0.1)
         self.assertIsInstance(al_val, AutoDiffXd)
@@ -47,10 +75,19 @@ class TestAugmentedLagrangianNonsmooth(unittest.TestCase):
         self.assertEqual(
             al.AugmentedLagrangianNonsmooth(
                 prog=self.prog, include_x_bounds=False).lagrangian_size(), 1)
+        self.assertEqual(
+            al.AugmentedLagrangianSmooth(
+                prog=self.prog, include_x_bounds=True).lagrangian_size(), 1)
+        self.assertEqual(
+            al.AugmentedLagrangianSmooth(
+                prog=self.prog, include_x_bounds=False).lagrangian_size(), 1)
 
     def test_is_equality(self):
         self.assertEqual(
             al.AugmentedLagrangianNonsmooth(
+                prog=self.prog, include_x_bounds=True).is_equality(), [False])
+        self.assertEqual(
+            al.AugmentedLagrangianSmooth(
                 prog=self.prog, include_x_bounds=True).is_equality(), [False])
 
     def test_nonsmooth_augmented_lagrangian_deprecation(self):

--- a/solvers/augmented_lagrangian.cc
+++ b/solvers/augmented_lagrangian.cc
@@ -9,6 +9,7 @@
 namespace drake {
 namespace solvers {
 
+namespace {
 // This function psi is defined as equation 17.55 of Numerical Optimization by
 // Jorge Nocedal and Stephen Wright, Edition 1, 1999. (Note this equation is not
 // presented in Edition 2). Mathematically it equals psi(c, λ, μ) = -λc +
@@ -26,64 +27,71 @@ T psi(const T& c, double lambda_val, double mu) {
   }
 }
 
-AugmentedLagrangianNonsmooth::AugmentedLagrangianNonsmooth(
-    const MathematicalProgram* prog, bool include_x_bounds)
-    : prog_{prog}, include_x_bounds_{include_x_bounds} {
-  lagrangian_size_ = 0;
-  for (const auto& constraint : prog_->GetAllConstraints()) {
+// Compute the augmented lagrangian for the equality constraint c(x) = 0
+// The augmented Lagrangian is −λc+μ/2*c² where c is lhs.
+template <typename T>
+T al_for_equality(const T& lhs, double lambda_val, double mu) {
+  return -lambda_val * lhs + mu / 2 * lhs * lhs;
+}
+
+void ParseProgram(const MathematicalProgram* prog, bool include_x_bounds,
+                  int* lagrangian_size, std::vector<bool>* is_equality,
+                  Eigen::VectorXd* x_lo, Eigen::VectorXd* x_up) {
+  *lagrangian_size = 0;
+  for (const auto& constraint : prog->GetAllConstraints()) {
     if (!dynamic_cast<BoundingBoxConstraint*>(constraint.evaluator().get())) {
       const auto& lb = constraint.evaluator()->lower_bound();
       const auto& ub = constraint.evaluator()->upper_bound();
       for (int i = 0; i < constraint.evaluator()->num_constraints(); ++i) {
         if (lb(i) == ub(i)) {
-          lagrangian_size_++;
+          (*lagrangian_size)++;
         } else {
           if (!std::isinf(lb(i))) {
-            lagrangian_size_++;
+            (*lagrangian_size)++;
           }
           if (!std::isinf(ub(i))) {
-            lagrangian_size_++;
+            (*lagrangian_size)++;
           }
         }
       }
     }
   }
-  AggregateBoundingBoxConstraints(*prog_, &x_lo_, &x_up_);
+  AggregateBoundingBoxConstraints(*prog, x_lo, x_up);
   if (include_x_bounds) {
-    for (int i = 0; i < prog_->num_vars(); ++i) {
-      if (x_lo_(i) == x_up_(i)) {
-        lagrangian_size_++;
+    for (int i = 0; i < prog->num_vars(); ++i) {
+      if ((*x_lo)(i) == (*x_up)(i)) {
+        (*lagrangian_size)++;
       } else {
-        if (!std::isinf(x_lo_(i))) {
-          lagrangian_size_++;
+        if (!std::isinf((*x_lo)(i))) {
+          (*lagrangian_size)++;
         }
-        if (!std::isinf(x_up_(i))) {
-          lagrangian_size_++;
+        if (!std::isinf((*x_up)(i))) {
+          (*lagrangian_size)++;
         }
       }
     }
   }
-  is_equality_.resize(lagrangian_size_);
+  is_equality->resize(*lagrangian_size);
   // We loop through all the constraints again instead of combining this loop
   // with the previous loop when we find lagrangian_size_. The reason is that we
   // want to first find lagrangian_size_ and then allocate all the memory of
   // is_equality_.
   int constraint_row = 0;
-  for (const auto& constraint : prog_->GetAllConstraints()) {
+  for (const auto& constraint : prog->GetAllConstraints()) {
     if (!dynamic_cast<BoundingBoxConstraint*>(constraint.evaluator().get())) {
       const auto& lb = constraint.evaluator()->lower_bound();
       const auto& ub = constraint.evaluator()->upper_bound();
       for (int i = 0; i < constraint.evaluator()->num_constraints(); ++i) {
         if (lb(i) == ub(i)) {
-          is_equality_[constraint_row] = true;
+          (*is_equality)[constraint_row] = true;
           constraint_row++;
         } else {
           if (!std::isinf(lb(i))) {
-            is_equality_[constraint_row] = false;
+            (*is_equality)[constraint_row] = false;
             constraint_row++;
           }
           if (!std::isinf(ub(i))) {
-            is_equality_[constraint_row] = false;
+            (*is_equality)[constraint_row] = false;
             constraint_row++;
           }
         }
@@ -91,45 +99,58 @@ AugmentedLagrangianNonsmooth::AugmentedLagrangianNonsmooth(
     }
   }
   if (include_x_bounds) {
-    for (int i = 0; i < prog_->num_vars(); ++i) {
-      if (x_lo_(i) == x_up_(i)) {
-        is_equality_[constraint_row] = true;
+    for (int i = 0; i < prog->num_vars(); ++i) {
+      if ((*x_lo)(i) == (*x_up)(i)) {
+        (*is_equality)[constraint_row] = true;
         constraint_row++;
       } else {
-        if (!std::isinf(x_lo_(i))) {
-          is_equality_[constraint_row] = false;
+        if (!std::isinf((*x_lo)(i))) {
+          (*is_equality)[constraint_row] = false;
           constraint_row++;
         }
-        if (!std::isinf(x_up_(i))) {
-          is_equality_[constraint_row] = false;
+        if (!std::isinf((*x_up)(i))) {
+          (*is_equality)[constraint_row] = false;
           constraint_row++;
         }
       }
     }
   }
 }
+}  // namespace
 
-template <typename T>
-T AugmentedLagrangianNonsmooth::Eval(const Eigen::Ref<const VectorX<T>>& x,
-                                     const Eigen::VectorXd& lambda_val,
-                                     double mu, VectorX<T>* constraint_residue,
-                                     T* cost) const {
-  DRAKE_DEMAND(x.rows() == prog_->num_vars());
-  DRAKE_DEMAND(lambda_val.rows() == lagrangian_size_);
+AugmentedLagrangianNonsmooth::AugmentedLagrangianNonsmooth(
+    const MathematicalProgram* prog, bool include_x_bounds)
+    : prog_{prog}, include_x_bounds_{include_x_bounds} {
+  ParseProgram(prog_, include_x_bounds, &lagrangian_size_, &is_equality_,
+               &x_lo_, &x_up_);
+}
+
+namespace {
+template <typename AL, typename T>
+T EvalAugmentedLagrangian(const AL& al, const Eigen::Ref<const VectorX<T>>& x,
+                          const Eigen::Ref<const VectorX<T>>& s,
+                          const Eigen::VectorXd& lambda_val, double mu,
+                          VectorX<T>* constraint_residue, T* cost) {
+  DRAKE_DEMAND(x.rows() == al.prog().num_vars());
+  if constexpr (std::is_same_v<AL, AugmentedLagrangianSmooth>) {
+    DRAKE_DEMAND(al.s_size() == s.rows());
+  }
+  DRAKE_DEMAND(lambda_val.rows() == al.lagrangian_size());
   DRAKE_DEMAND(mu > 0);
   DRAKE_DEMAND(constraint_residue != nullptr);
   DRAKE_DEMAND(cost != nullptr);
   *cost = T{0};
   constraint_residue->resize(lambda_val.rows());
-  for (const auto& cost_binding : prog_->GetAllCosts()) {
-    *cost += prog_->EvalBinding(cost_binding, x)(0);
+  for (const auto& cost_binding : al.prog().GetAllCosts()) {
+    *cost += al.prog().EvalBinding(cost_binding, x)(0);
   }
-  T al = *cost;
+  T al_val = *cost;
   int lagrangian_count = 0;
+  int s_count = 0;
   // First evaluate all generic nonlinear constraints
-  for (const auto& constraint : prog_->GetAllConstraints()) {
+  for (const auto& constraint : al.prog().GetAllConstraints()) {
     if (!dynamic_cast<BoundingBoxConstraint*>(constraint.evaluator().get())) {
-      const VectorX<T> constraint_val = prog_->EvalBinding(constraint, x);
+      const VectorX<T> constraint_val = al.prog().EvalBinding(constraint, x);
       // Now check if each row of the constraint is equality or inequality.
       for (int i = 0; i < constraint.evaluator()->num_constraints(); ++i) {
         const double& lb = constraint.evaluator()->lower_bound()(i);
@@ -140,54 +161,126 @@ T AugmentedLagrangianNonsmooth::Eval(const Eigen::Ref<const VectorX<T>>& x,
         }
         if (lb == ub) {
           // We have one Lagrangian multiplier for the equality constraint. Add
-          // −λ h(x) + μ/2*h(x)² to the augmented Lagrangian.
-          al += -lambda_val(lagrangian_count) * (constraint_val(i) - lb) +
-                (mu / 2) * (constraint_val(i) - lb) * (constraint_val(i) - lb);
+          // −λ*h(x) + μ/2*h(x)² to the augmented Lagrangian.
+          al_val += al_for_equality(constraint_val(i) - lb,
+                                    lambda_val(lagrangian_count), mu);
           (*constraint_residue)(lagrangian_count) = constraint_val(i) - lb;
           lagrangian_count++;
         } else {
           if (!std::isinf(lb)) {
             // The constraint is constraint_val - lb >= 0.
-            al += psi(constraint_val(i) - lb, lambda_val(lagrangian_count), mu);
-            (*constraint_residue)(lagrangian_count) = constraint_val(i) - lb;
+            if constexpr (std::is_same_v<AL, AugmentedLagrangianNonsmooth>) {
+              al_val +=
+                  psi(constraint_val(i) - lb, lambda_val(lagrangian_count), mu);
+              (*constraint_residue)(lagrangian_count) = constraint_val(i) - lb;
+            } else {
+              al_val += al_for_equality(constraint_val(i) - s(s_count) - lb,
+                                        lambda_val(lagrangian_count), mu);
+              (*constraint_residue)(lagrangian_count) =
+                  constraint_val(i) - s(s_count) - lb;
+              s_count++;
+            }
             lagrangian_count++;
           }
           if (!std::isinf(ub)) {
             // The constraint is ub - constraint_val >= 0.
-            al += psi(ub - constraint_val(i), lambda_val(lagrangian_count), mu);
-            (*constraint_residue)(lagrangian_count) = ub - constraint_val(i);
+            if constexpr (std::is_same_v<AL, AugmentedLagrangianNonsmooth>) {
+              al_val +=
+                  psi(ub - constraint_val(i), lambda_val(lagrangian_count), mu);
+              (*constraint_residue)(lagrangian_count) = ub - constraint_val(i);
+            } else {
+              al_val += al_for_equality(ub - constraint_val(i) - s(s_count),
+                                        lambda_val(lagrangian_count), mu);
+              (*constraint_residue)(lagrangian_count) =
+                  ub - constraint_val(i) - s(s_count);
+              s_count++;
+            }
             lagrangian_count++;
           }
         }
       }
     }
   }
-  if (include_x_bounds_) {
-    for (int i = 0; i < prog_->num_vars(); ++i) {
-      if (x_lo_(i) == x_up_(i)) {
-        al += -lambda_val(lagrangian_count) * (x(i) - x_lo_(i)) +
-              (mu / 2) * (x(i) - x_lo_(i)) * (x(i) - x_lo_(i));
-        (*constraint_residue)(lagrangian_count) = x(i) - x_lo_(i);
+  if (al.include_x_bounds()) {
+    for (int i = 0; i < al.prog().num_vars(); ++i) {
+      if (al.x_lo()(i) == al.x_up()(i)) {
+        al_val += al_for_equality(x(i) - al.x_lo()(i),
+                                  lambda_val(lagrangian_count), mu);
+        (*constraint_residue)(lagrangian_count) = x(i) - al.x_lo()(i);
         lagrangian_count++;
       } else {
-        if (!std::isinf(x_lo_(i))) {
-          al += psi(x(i) - x_lo_(i), lambda_val(lagrangian_count), mu);
-          (*constraint_residue)(lagrangian_count) = x(i) - x_lo_(i);
+        if (!std::isinf(al.x_lo()(i))) {
+          if constexpr (std::is_same_v<AL, AugmentedLagrangianNonsmooth>) {
+            al_val +=
+                psi(x(i) - al.x_lo()(i), lambda_val(lagrangian_count), mu);
+            (*constraint_residue)(lagrangian_count) = x(i) - al.x_lo()(i);
+          } else {
+            al_val += al_for_equality(x(i) - al.x_lo()(i) - s(s_count),
+                                      lambda_val(lagrangian_count), mu);
+            (*constraint_residue)(lagrangian_count) =
+                x(i) - al.x_lo()(i) - s(s_count);
+          }
+          s_count++;
           lagrangian_count++;
         }
-        if (!std::isinf(x_up_(i))) {
-          al += psi(x_up_(i) - x(i), lambda_val(lagrangian_count), mu);
-          (*constraint_residue)(lagrangian_count) = x_up_(i) - x(i);
+        if (!std::isinf(al.x_up()(i))) {
+          if constexpr (std::is_same_v<AL, AugmentedLagrangianNonsmooth>) {
+            al_val +=
+                psi(al.x_up()(i) - x(i), lambda_val(lagrangian_count), mu);
+            (*constraint_residue)(lagrangian_count) = al.x_up()(i) - x(i);
+          } else {
+            al_val += al_for_equality(al.x_up()(i) - x(i) - s(s_count),
+                                      lambda_val(lagrangian_count), mu);
+            (*constraint_residue)(lagrangian_count) =
+                al.x_up()(i) - x(i) - s(s_count);
+            s_count++;
+          }
           lagrangian_count++;
         }
       }
     }
   }
-  return al;
+  return al_val;
+}
+}  // namespace
+
+template <typename T>
+T AugmentedLagrangianNonsmooth::Eval(const Eigen::Ref<const VectorX<T>>& x,
+                                     const Eigen::VectorXd& lambda_val,
+                                     double mu, VectorX<T>* constraint_residue,
+                                     T* cost) const {
+  Eigen::Matrix<T, 0, 1> s_dummy;
+  return EvalAugmentedLagrangian<AugmentedLagrangianNonsmooth, T>(
+      *this, x, s_dummy, lambda_val, mu, constraint_residue, cost);
+}
+
+AugmentedLagrangianSmooth::AugmentedLagrangianSmooth(
+    const MathematicalProgram* prog, bool include_x_bounds)
+    : prog_{prog}, include_x_bounds_{include_x_bounds} {
+  ParseProgram(prog_, include_x_bounds, &lagrangian_size_, &is_equality_,
+               &x_lo_, &x_up_);
+  // For each inequality constraint, we need one slack variable s.
+  s_size_ = 0;
+  for (auto flag : is_equality_) {
+    if (!flag) {
+      s_size_++;
+    }
+  }
+}
+
+template <typename T>
+T AugmentedLagrangianSmooth::Eval(const Eigen::Ref<const VectorX<T>>& x,
+                                  const Eigen::Ref<const VectorX<T>>& s,
+                                  const Eigen::VectorXd& lambda_val, double mu,
+                                  VectorX<T>* constraint_residue,
+                                  T* cost) const {
+  return EvalAugmentedLagrangian<AugmentedLagrangianSmooth, T>(
+      *this, x, s, lambda_val, mu, constraint_residue, cost);
 }
 
 // Explicit instantiation.
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
-    (&AugmentedLagrangianNonsmooth::Eval<T>))
+    (&AugmentedLagrangianNonsmooth::Eval<T>,
+     &AugmentedLagrangianSmooth::Eval<T>))
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/augmented_lagrangian.h
+++ b/solvers/augmented_lagrangian.h
@@ -127,7 +127,131 @@ using NonsmoothAugmentedLagrangian DRAKE_DEPRECATED(
     "AugmentedLagrangianNonsmooth. Use AugmentedLagrangianNonsmooth instead.") =
     AugmentedLagrangianNonsmooth;
 
-// TODO(hongkai.dai): add the alternative augmented Lagrangian using Lancelot
-// formulation.
+/**
+ * Compute the augmented Lagrangian (AL) of a given mathematical program
+ *
+ *     min f(x)
+ *     s.t h(x) = 0
+ *         l <= g(x) <= u
+ *         x_lo <= x <= x_up
+ *
+ * We first turn it into an equality constrained program with non-negative slack
+ * variable s as follows
+ *
+ *     min f(x)
+ *     s.t h(x) = 0
+ *         c(x) - s = 0
+ *         s >= 0
+ *
+ * We regard this as an optimization problem on variable (x, s), with equality
+ * constraints h(x) = 0, c(x)-s = 0, and the bound constraint s >= 0.
+ *
+ * Depending on the option include_x_bounds, the constraint h(x)=0, c(x)>=0 may
+ * or may not include the bounding box constraint x_lo <= x <= x_up.
+ *
+ * The (smooth) augmented Lagrangian is defined as
+ *
+ *     L(x, s, λ, μ) = f(x) − λ₁ᵀh(x) + μ/2 h(x)ᵀh(x)
+ *                  - λ₂ᵀ(c(x)-s) + μ/2 (c(x)-s)ᵀ(c(x)-s)
+ *
+ * For more details, refer to section 17.4 of Numerical Optimization by Jorge
+ * Nocedal and Stephen Wright, Edition 2, 2006.
+ * Note that the augmented Lagrangian L(x, s, λ, μ) is a smooth function of (x,
+ * s),
+ *
+ * This is the implementation used in LANCELOT. To solve the nonlinear
+ * optimization through this Augmented Lagrangian, the nonlinear solve should be
+ * able to handle bounding box constraints on the decision variables.
+ */
+class AugmentedLagrangianSmooth {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(AugmentedLagrangianSmooth)
+
+  /**
+   * @param prog The mathematical program we will evaluate.
+   * @param include_x_bounds. Whether the Lagrangian and the penalty for the
+   * bounds x_lo <= x <= x_up are included in the augmented Lagrangian L(x, s,
+   * λ, μ) or not.
+   */
+  AugmentedLagrangianSmooth(const MathematicalProgram* prog,
+                            bool include_x_bounds);
+
+  /**
+   * @param x The value of all the decision variables in prog().
+   * @param s The value of all slack variables s.
+   * @param lambda_val The estimated Lagrangian multipliers. The order of the
+   * Lagrangian multiplier is as follows: We first call to evaluate all
+   * constraints. Then for each row of the constraint, if it is an equality
+   * constraint, we append one single Lagrangian multiplier. Otherwise we
+   * append the Lagrangian multiplier for the lower and upper bounds (where the
+   * lower comes before the upper), if the corresponding bound is not ±∞. The
+   * order of evaluating all the constraints is the same as
+   * prog.GetAllConstraints() except for prog.bounding_box_constraints(). If
+   * include_x_bounds=true, then we aggregate all the bounding_box_constraints()
+   * and evaluate them at the end of all constraints.
+   * @param mu μ in the documentation above. The constant for penalty term
+   * weight. This should be a strictly positive number.
+   * @param[out] constraint_residue The value of the all the constraints. For an
+   * equality constraint c(x)=0, the residue is c(x); for an inequality
+   * constraint c(x)>=0, the residue is c(x)-s where s is the corresponding
+   * slack variable. Depending on include_x_bounds, `constraint_residue` may or
+   * may not contain the residue for bounding box constraints x_lo <= x <= x_up
+   * at the end.
+   * @param[out] cost The value of the cost function f(x).
+   * @return The evaluated Augmented Lagrangian (AL) L(x, s, λ, μ).
+   * @note This Eval function differs from AugmentedLagrangianNonsmooth::Eval()
+   * function as `s` is an input argument.
+   */
+  template <typename T>
+  T Eval(const Eigen::Ref<const VectorX<T>>& x,
+         const Eigen::Ref<const VectorX<T>>& s,
+         const Eigen::VectorXd& lambda_val, double mu,
+         VectorX<T>* constraint_residue, T* cost) const;
+
+  /**
+   * @return The mathematical program for which the augmented Lagrangian is
+   * computed.
+   */
+  const MathematicalProgram& prog() const { return *prog_; }
+
+  /**
+   * @return Whether the bounding box constraint x_lo <= x <=
+   * x_up is included in the augmented Lagrangian L(x, λ, μ).
+   */
+  [[nodiscard]] bool include_x_bounds() const { return include_x_bounds_; }
+
+  /**
+   * @return The size of the Lagrangian multiplier λ.
+   */
+  [[nodiscard]] int lagrangian_size() const { return lagrangian_size_; }
+
+  /**
+   * @return The size of the slack variable s.
+   */
+  [[nodiscard]] int s_size() const { return s_size_; }
+
+  /**
+   * @return Whether each constraint is equality or not. The order of the
+   * constraint is explained in the class documentation.
+   */
+  [[nodiscard]] const std::vector<bool>& is_equality() const {
+    return is_equality_;
+  }
+
+  /** @return All the lower bounds of x. */
+  [[nodiscard]] const Eigen::VectorXd& x_lo() const { return x_lo_; }
+
+  /** @return All the upper bounds of x. */
+  [[nodiscard]] const Eigen::VectorXd& x_up() const { return x_up_; }
+
+ private:
+  const MathematicalProgram* prog_;
+  bool include_x_bounds_;
+  int lagrangian_size_;
+  int s_size_{0};
+  std::vector<bool> is_equality_;
+  Eigen::VectorXd x_lo_;
+  Eigen::VectorXd x_up_;
+};
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/augmented_lagrangian_test.cc
+++ b/solvers/test/augmented_lagrangian_test.cc
@@ -14,11 +14,10 @@ namespace drake {
 namespace solvers {
 namespace {
 const double kInf = std::numeric_limits<double>::infinity();
-GTEST_TEST(AugmentedLagrangian, TestObjective1) {
-  // Construct an un-constrained program.
-  MathematicalProgram prog;
-  auto x = prog.NewContinuousVariables<2>();
-  const AugmentedLagrangianNonsmooth dut(&prog, false);
+
+// This function is only used in AugmentedLagrangian.TestEmptyProg.
+template <typename AL>
+void TestEmptyProg(const AL& dut) {
   EXPECT_EQ(dut.lagrangian_size(), 0);
   EXPECT_TRUE(dut.is_equality().empty());
 
@@ -27,13 +26,82 @@ GTEST_TEST(AugmentedLagrangian, TestObjective1) {
   // zero.
   Eigen::VectorXd constraint_residue;
   double cost;
-  EXPECT_EQ(dut.Eval<double>(x_val, Eigen::VectorXd(0), 0.5,
-                             &constraint_residue, &cost),
-            0);
+  double al_val;
+  if constexpr (std::is_same_v<AL, AugmentedLagrangianNonsmooth>) {
+    al_val = dut.template Eval<double>(x_val, Eigen::VectorXd(0), 0.5,
+                                       &constraint_residue, &cost);
+  } else {
+    al_val =
+        dut.template Eval<double>(x_val, Eigen::VectorXd(0), Eigen::VectorXd(0),
+                                  0.5, &constraint_residue, &cost);
+  }
+  EXPECT_EQ(al_val, 0);
   EXPECT_EQ(constraint_residue.rows(), 0);
   EXPECT_EQ(cost, 0);
   EXPECT_TRUE(CompareMatrices(dut.x_lo(), Eigen::Vector2d::Constant(-kInf)));
   EXPECT_TRUE(CompareMatrices(dut.x_up(), Eigen::Vector2d::Constant(kInf)));
+}
+
+GTEST_TEST(AugmentedLagrangian, TestEmptyProg) {
+  // Construct an un-constrained program.
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<2>();
+  const AugmentedLagrangianNonsmooth dut_nonsmooth(&prog, false);
+  TestEmptyProg(dut_nonsmooth);
+  const AugmentedLagrangianSmooth dut_smooth(&prog, false);
+  TestEmptyProg(dut_smooth);
+}
+
+template <typename AL>
+void TestObjective(const AL& dut) {
+  EXPECT_EQ(dut.lagrangian_size(), 0);
+  EXPECT_TRUE(dut.is_equality().empty());
+
+  // Now evaluate the augmented Lagrangian, it should just be the same as the
+  // costs.
+  Eigen::Vector2d x_val(1, 2);
+  double cost_expected = 0;
+  for (const auto& binding : dut.prog().GetAllCosts()) {
+    cost_expected += dut.prog().EvalBinding(binding, x_val)(0);
+  }
+  Eigen::VectorXd constraint_residue;
+  double cost;
+  double al_val;
+  if constexpr (std::is_same_v<AL, AugmentedLagrangianNonsmooth>) {
+    al_val = dut.template Eval<double>(x_val, Eigen::VectorXd(0), 0.5,
+                                       &constraint_residue, &cost);
+  } else {
+    al_val =
+        dut.template Eval<double>(x_val, Eigen::VectorXd(0), Eigen::VectorXd(0),
+                                  0.5, &constraint_residue, &cost);
+  }
+  EXPECT_EQ(al_val, cost_expected);
+  EXPECT_EQ(cost, cost_expected);
+  EXPECT_EQ(constraint_residue.rows(), 0);
+
+  // Now evaluate the augmented Lagrangian with autodiff.
+  VectorX<AutoDiffXd> constraint_residue_ad;
+  AutoDiffXd cost_ad;
+  AutoDiffXd al_ad;
+  const auto x_ad = math::InitializeAutoDiff(x_val);
+  if constexpr (std::is_same_v<AL, AugmentedLagrangianNonsmooth>) {
+    al_ad = dut.template Eval<AutoDiffXd>(x_ad, Eigen::VectorXd(0), 0.5,
+                                          &constraint_residue_ad, &cost_ad);
+  } else {
+    al_ad = dut.template Eval<AutoDiffXd>(x_ad, AutoDiffVecXd(0),
+                                          Eigen::VectorXd(0), 0.5,
+                                          &constraint_residue_ad, &cost_ad);
+  }
+  AutoDiffXd al_expected(0);
+  for (const auto& binding : dut.prog().GetAllCosts()) {
+    al_expected += dut.prog().EvalBinding(binding, x_ad)(0);
+  }
+  EXPECT_EQ(ExtractDoubleOrThrow(al_ad), ExtractDoubleOrThrow(al_expected));
+  EXPECT_TRUE(CompareMatrices(al_ad.derivatives(), al_expected.derivatives()));
+  EXPECT_EQ(cost_ad.value(), al_expected.value());
+  EXPECT_TRUE(
+      CompareMatrices(cost_ad.derivatives(), al_expected.derivatives()));
+  EXPECT_EQ(constraint_residue_ad.rows(), 0);
 }
 
 GTEST_TEST(AugmentedLagrangianNonsmooth, TestObjective2) {
@@ -44,38 +112,10 @@ GTEST_TEST(AugmentedLagrangianNonsmooth, TestObjective2) {
   auto cost1 = prog.AddQuadraticCost(x[0] * x[0] + 2 * x[1] + 3);
   auto cost2 = prog.AddLinearCost(x[0] * 3 + 4);
   for (bool include_x_bounds : {false, true}) {
-    const AugmentedLagrangianNonsmooth dut(&prog, include_x_bounds);
-
-    EXPECT_EQ(dut.lagrangian_size(), 0);
-    EXPECT_TRUE(dut.is_equality().empty());
-
-    // Now evaluate the augmented Lagrangian, it should just be the same as the
-    // costs.
-    Eigen::Vector2d x_val(1, 2);
-    double cost_expected =
-        prog.EvalBinding(cost1, x_val)(0) + prog.EvalBinding(cost2, x_val)(0);
-    Eigen::VectorXd constraint_residue;
-    double cost;
-    EXPECT_EQ(dut.Eval<double>(x_val, Eigen::VectorXd(0), 0.5,
-                               &constraint_residue, &cost),
-              cost_expected);
-    EXPECT_EQ(cost, cost_expected);
-    EXPECT_EQ(constraint_residue.rows(), 0);
-
-    // Now evaluate the augmented Lagrangian with autodiff.
-    VectorX<AutoDiffXd> constraint_residue_ad;
-    AutoDiffXd cost_ad;
-    const auto x_ad = math::InitializeAutoDiff(x_val);
-    const auto al = dut.Eval<AutoDiffXd>(x_ad, Eigen::VectorXd(0), 0.5,
-                                         &constraint_residue_ad, &cost_ad);
-    const auto al_expected =
-        prog.EvalBinding(cost1, x_ad)(0) + prog.EvalBinding(cost2, x_ad)(0);
-    EXPECT_EQ(ExtractDoubleOrThrow(al), ExtractDoubleOrThrow(al_expected));
-    EXPECT_TRUE(CompareMatrices(al.derivatives(), al_expected.derivatives()));
-    EXPECT_EQ(cost_ad.value(), al_expected.value());
-    EXPECT_TRUE(
-        CompareMatrices(cost_ad.derivatives(), al_expected.derivatives()));
-    EXPECT_EQ(constraint_residue_ad.rows(), 0);
+    const AugmentedLagrangianNonsmooth dut_nonsmooth(&prog, include_x_bounds);
+    TestObjective(dut_nonsmooth);
+    const AugmentedLagrangianSmooth dut_smooth(&prog, include_x_bounds);
+    TestObjective(dut_smooth);
   }
 }
 
@@ -138,6 +178,12 @@ void CompareAlResult(const T& al, const T& al_expected,
   }
 }
 
+template <typename T>
+T al_equality(const Eigen::Ref<const VectorX<T>>& lhs,
+              const Eigen::Ref<const Eigen::VectorXd>& lambda, double mu) {
+  return -lambda.dot(lhs) + mu / 2 * lhs.array().square().sum();
+}
+
 // This function is only used inside the test
 // AugmentedLagrangianNonsmooth.EqualityConstraints. Ideally I want to put it
 // inside the test as a templated lambda, but our current compiler on Bionic
@@ -146,23 +192,31 @@ template <typename T>
 void CheckAugmentedLagrangianEqualityConstraint(
     const MathematicalProgram& prog, const Binding<Constraint>& constraint,
     const Vector3<T>& x_val, const Eigen::Vector4d& lambda_val, double mu_val,
-    double tol_val) {
+    double tol_val, bool smooth_flag) {
   VectorX<T> constraint_residue;
   T cost;
   for (bool include_x_bounds : {false, true}) {
-    const AugmentedLagrangianNonsmooth dut(&prog, include_x_bounds);
-    EXPECT_EQ(dut.lagrangian_size(), 4);
-    EXPECT_EQ(dut.is_equality(), std::vector<bool>({true, true, true, true}));
-    const T al =
-        dut.Eval<T>(x_val, lambda_val, mu_val, &constraint_residue, &cost);
+    T al_val;
+    if (smooth_flag) {
+      const AugmentedLagrangianSmooth dut(&prog, include_x_bounds);
+      EXPECT_EQ(dut.lagrangian_size(), 4);
+      EXPECT_EQ(dut.is_equality(), std::vector<bool>({true, true, true, true}));
+      EXPECT_EQ(dut.s_size(), 0);
+      al_val = dut.Eval<T>(x_val, VectorX<T>(0), lambda_val, mu_val,
+                           &constraint_residue, &cost);
+    } else {
+      const AugmentedLagrangianNonsmooth dut(&prog, include_x_bounds);
+      EXPECT_EQ(dut.lagrangian_size(), 4);
+      EXPECT_EQ(dut.is_equality(), std::vector<bool>({true, true, true, true}));
+      al_val =
+          dut.Eval<T>(x_val, lambda_val, mu_val, &constraint_residue, &cost);
+    }
     const auto constraint_val = prog.EvalBinding(constraint, x_val);
     const auto& constraint_bound = constraint.evaluator()->lower_bound();
-    const T al_expected = -lambda_val.dot(constraint_val - constraint_bound) +
-                          mu_val / 2 *
-                              (constraint_val - constraint_bound)
-                                  .dot(constraint_val - constraint_bound);
+    const T al_expected =
+        al_equality<T>(constraint_val - constraint_bound, lambda_val, mu_val);
     EXPECT_EQ(constraint_residue.rows(), lambda_val.rows());
-    CompareAlResult<T>(al, al_expected, constraint_residue,
+    CompareAlResult<T>(al_val, al_expected, constraint_residue,
                        constraint_val - constraint_bound, cost, T{0}, tol_val);
   }
 }
@@ -175,16 +229,18 @@ GTEST_TEST(AugmentedLagrangian, EqualityConstraints) {
       prog.AddConstraint(std::make_shared<DummyConstraint>(), x.head<2>());
 
   const double tol = 1E-10;
-  CheckAugmentedLagrangianEqualityConstraint(
-      prog, constraint, Eigen::Vector3d(0.5, 1.5, 2),
-      Eigen::Vector4d(1, 3, -2, 4), 0.2, tol);
-  CheckAugmentedLagrangianEqualityConstraint(
-      prog, constraint, Eigen::Vector3d(-0.5, 2.5, 2),
-      Eigen::Vector4d(-1, 2, 3, -2), 0.6, tol);
-  CheckAugmentedLagrangianEqualityConstraint(
-      prog, constraint,
-      math::InitializeAutoDiff(Eigen::Vector3d(0.5, 0.3, 0.2)),
-      Eigen::Vector4d(1, 2, -3, -1), 0.5, tol);
+  for (bool smooth_flag : {false, true}) {
+    CheckAugmentedLagrangianEqualityConstraint(
+        prog, constraint, Eigen::Vector3d(0.5, 1.5, 2),
+        Eigen::Vector4d(1, 3, -2, 4), 0.2, tol, smooth_flag);
+    CheckAugmentedLagrangianEqualityConstraint(
+        prog, constraint, Eigen::Vector3d(-0.5, 2.5, 2),
+        Eigen::Vector4d(-1, 2, 3, -2), 0.6, tol, smooth_flag);
+    CheckAugmentedLagrangianEqualityConstraint(
+        prog, constraint,
+        math::InitializeAutoDiff(Eigen::Vector3d(0.5, 0.3, 0.2)),
+        Eigen::Vector4d(1, 2, -3, -1), 0.5, tol, smooth_flag);
+  }
 }
 
 // Refer to equation 17.55 of Numerical Optimization by Jorge Nocedal and
@@ -201,7 +257,7 @@ T psi(const T& c, double lambda, double mu) {
 }
 
 template <typename T>
-void CheckAugmentedLagrangianInequalityConstraint(
+void CheckAugmentedLagrangianNonsmoothInequalityConstraint(
     const MathematicalProgram& prog, const Binding<Constraint>& constraint,
     const Vector3<T>& x_val, const Eigen::Matrix<double, 5, 1>& lambda_val,
     double mu_val, double tol_val) {
@@ -235,6 +291,40 @@ void CheckAugmentedLagrangianInequalityConstraint(
   }
 }
 
+template <typename T>
+void CheckAugmentedLagrangianSmoothInequalityConstraint(
+    const MathematicalProgram& prog, const Binding<Constraint>& constraint,
+    const Vector3<T>& x_val, const Vector4<T>& s_val,
+    const Eigen::Matrix<double, 5, 1>& lambda_val, double mu_val,
+    double tol_val) {
+  VectorX<T> constraint_residue;
+  T cost;
+  for (const bool include_x_bounds : {false, true}) {
+    const AugmentedLagrangianSmooth dut(&prog, include_x_bounds);
+    EXPECT_EQ(dut.lagrangian_size(), 5);
+    EXPECT_EQ(dut.s_size(), 4);
+    EXPECT_EQ(dut.is_equality(),
+              std::vector<bool>({true, false, false, false, false}));
+
+    const T al = dut.Eval<T>(x_val, s_val, lambda_val, mu_val,
+                             &constraint_residue, &cost);
+    const auto constraint_val = prog.EvalBinding(constraint, x_val);
+    const auto& lb = constraint.evaluator()->lower_bound();
+    const auto& ub = constraint.evaluator()->upper_bound();
+    using std::pow;
+    Eigen::Matrix<T, 5, 1> lhs;
+    lhs << constraint_val(0) - lb(0), constraint_val(1) - lb(1) - s_val(0),
+        ub(1) - constraint_val(1) - s_val(1),
+        ub(2) - constraint_val(2) - s_val(2),
+        constraint_val(3) - lb(3) - s_val(3);
+    T al_expected = al_equality<T>(lhs, lambda_val, mu_val);
+    EXPECT_EQ(constraint_residue.rows(), lambda_val.rows());
+    VectorX<T> constraint_residue_expected = lhs;
+    CompareAlResult<T>(al, al_expected, constraint_residue,
+                       constraint_residue_expected, cost, T(0), tol_val);
+  }
+}
+
 GTEST_TEST(AugmentedLagrangian, InequalityConstraint) {
   // Test with inequality constraints.
   MathematicalProgram prog;
@@ -245,22 +335,33 @@ GTEST_TEST(AugmentedLagrangian, InequalityConstraint) {
   auto constraint = prog.AddConstraint(constraint_evaluator, x.tail<2>());
 
   const double tol = 1E-10;
-  CheckAugmentedLagrangianInequalityConstraint(
+  CheckAugmentedLagrangianNonsmoothInequalityConstraint(
       prog, constraint, Eigen::Vector3d(1, 3, 2),
       (Eigen::Matrix<double, 5, 1>() << 0.5, 0.4, 1.5, 0.2, 3).finished(), 0.5,
       tol);
-  CheckAugmentedLagrangianInequalityConstraint(
+  CheckAugmentedLagrangianNonsmoothInequalityConstraint(
       prog, constraint, Eigen::Vector3d(-1, 3, -5),
       (Eigen::Matrix<double, 5, 1>() << -.5, 1.4, 1.5, 0.5, 3).finished(), 0.2,
       tol);
-  CheckAugmentedLagrangianInequalityConstraint(
+  CheckAugmentedLagrangianNonsmoothInequalityConstraint(
       prog, constraint, math::InitializeAutoDiff(Eigen::Vector3d(-1, 3, -5)),
       (Eigen::Matrix<double, 5, 1>() << -.5, 1.4, 1.5, 0.5, 3).finished(), 0.2,
+      tol);
+
+  CheckAugmentedLagrangianSmoothInequalityConstraint(
+      prog, constraint, Eigen::Vector3d(1, 3, 2), Eigen::Vector4d(3, -1, -2, 1),
+      (Eigen::Matrix<double, 5, 1>() << 0.5, 0.4, 1.5, 0.2, 3).finished(), 0.5,
+      tol);
+  CheckAugmentedLagrangianSmoothInequalityConstraint(
+      prog, constraint, math::InitializeAutoDiff(Eigen::Vector3d(1, 3, 2)),
+      Vector4<AutoDiffXd>(AutoDiffXd(3), AutoDiffXd(-1), AutoDiffXd(-2),
+                          AutoDiffXd(1)),
+      (Eigen::Matrix<double, 5, 1>() << 0.5, 0.4, 1.5, 0.2, 3).finished(), 0.5,
       tol);
 }
 
 template <typename T>
-void CheckAugmentedLagrangianBoundingBoxConstraint(
+void CheckAugmentedLagrangianNonsmoothBoundingBoxConstraint(
     const MathematicalProgram& prog, const Vector4<T>& x_val,
     const Eigen::Matrix<double, 5, 1>& lambda, double mu, double tol_val) {
   const AugmentedLagrangianNonsmooth dut(&prog, true);
@@ -290,6 +391,65 @@ void CheckAugmentedLagrangianBoundingBoxConstraint(
   EXPECT_TRUE(CompareMatrices(dut.x_up(), x_up_expected));
 }
 
+template <typename T>
+void CheckAugmentedLagrangianSmoothBoundingBoxConstraint(
+    const MathematicalProgram& prog, const Vector4<T>& x_val,
+    const Vector4<T>& s_val, const Eigen::Matrix<double, 5, 1>& lambda,
+    double mu, double tol_val) {
+  const AugmentedLagrangianSmooth dut(&prog, true);
+  EXPECT_EQ(dut.lagrangian_size(), 5);
+  EXPECT_EQ(dut.s_size(), 4);
+  EXPECT_EQ(dut.is_equality(),
+            std::vector<bool>({true, false, false, false, false}));
+  VectorX<T> constraint_residue;
+  T cost;
+  const T al =
+      dut.Eval<T>(x_val, s_val, lambda, mu, &constraint_residue, &cost);
+  EXPECT_EQ(constraint_residue.rows(), lambda.rows());
+  Eigen::VectorXd x_lb, x_ub;
+  AggregateBoundingBoxConstraints(prog, &x_lb, &x_ub);
+  Eigen::Matrix<T, 5, 1> lhs;
+  lhs << x_val(0) - x_lb(0), x_val(1) - x_lb(1) - s_val(0),
+      x_ub(2) - x_val(2) - s_val(1), x_val(3) - x_lb(3) - s_val(2),
+      x_ub(3) - x_val(3) - s_val(3);
+  const T al_expected = al_equality<T>(lhs, lambda, mu);
+  Eigen::Matrix<T, 5, 1> constraint_residue_expected = lhs;
+  CompareAlResult<T>(al, al_expected, constraint_residue,
+                     constraint_residue_expected, cost, T(0), tol_val);
+  Eigen::VectorXd x_lo_expected, x_up_expected;
+  AggregateBoundingBoxConstraints(prog, &x_lo_expected, &x_up_expected);
+  EXPECT_TRUE(CompareMatrices(dut.x_lo(), x_lo_expected));
+  EXPECT_TRUE(CompareMatrices(dut.x_up(), x_up_expected));
+}
+
+// This function should only be called inside
+// EvalAugmentedLagrangian.BoundingBoxConstraint when include_x_bounds=false.
+template <typename AL>
+void CheckBoundingBoxConstraintEmpty(const AL& dut) {
+  DRAKE_DEMAND(dut.include_x_bounds() == false);
+  EXPECT_EQ(dut.lagrangian_size(), 0);
+  EXPECT_TRUE(dut.is_equality().empty());
+  VectorX<double> constraint_residue;
+  double cost;
+  double al_val;
+  if constexpr (std::is_same_v<AL, AugmentedLagrangianNonsmooth>) {
+    al_val = dut.template Eval<double>(Eigen::Vector4d(1, 2, 3, 4),
+                                       Eigen::VectorXd(0), 0.5,
+                                       &constraint_residue, &cost);
+  } else {
+    al_val = dut.template Eval<double>(Eigen::Vector4d(1, 2, 3, 4),
+                                       Eigen::VectorXd(0), Eigen::VectorXd(0),
+                                       0.5, &constraint_residue, &cost);
+    EXPECT_EQ(dut.s_size(), 0);
+  }
+  EXPECT_EQ(al_val, 0);
+  EXPECT_EQ(constraint_residue.rows(), 0);
+  Eigen::VectorXd x_lo_expected, x_up_expected;
+  AggregateBoundingBoxConstraints(dut.prog(), &x_lo_expected, &x_up_expected);
+  EXPECT_TRUE(CompareMatrices(dut.x_lo(), x_lo_expected));
+  EXPECT_TRUE(CompareMatrices(dut.x_up(), x_up_expected));
+}
+
 GTEST_TEST(EvalAugmentedLagrangian, BoundingBoxConstraint) {
   // Test with bounding box constraint.
   MathematicalProgram prog;
@@ -300,29 +460,29 @@ GTEST_TEST(EvalAugmentedLagrangian, BoundingBoxConstraint) {
       Eigen::Vector4d(2, 1, -kInf, 1), Eigen::Vector4d(5, kInf, -1, 3), x);
 
   const double tol = 1E-10;
-  CheckAugmentedLagrangianBoundingBoxConstraint(
+  CheckAugmentedLagrangianNonsmoothBoundingBoxConstraint(
       prog, Eigen::Vector4d(1, 3, 5, 2),
       (Eigen::Matrix<double, 5, 1>() << 0.5, 0.3, 1.5, 2, 1).finished(), 0.5,
       tol);
-  CheckAugmentedLagrangianBoundingBoxConstraint(
+  CheckAugmentedLagrangianNonsmoothBoundingBoxConstraint(
       prog, math::InitializeAutoDiff(Eigen::Vector4d(1, 3, 5, 2)),
+      (Eigen::Matrix<double, 5, 1>() << 0.5, 0.3, 1.5, 2, 1).finished(), 0.5,
+      tol);
+  CheckAugmentedLagrangianSmoothBoundingBoxConstraint(
+      prog, Eigen::Vector4d(1, 3, 5, 2), Eigen::Vector4d(2, 1, -2, 3),
+      (Eigen::Matrix<double, 5, 1>() << 0.5, 0.3, 1.5, 2, 1).finished(), 0.5,
+      tol);
+  CheckAugmentedLagrangianSmoothBoundingBoxConstraint(
+      prog, math::InitializeAutoDiff(Eigen::Vector4d(1, 3, 5, 2)),
+      math::InitializeAutoDiff(Eigen::Vector4d(2, 1, -2, 3)),
       (Eigen::Matrix<double, 5, 1>() << 0.5, 0.3, 1.5, 2, 1).finished(), 0.5,
       tol);
 
   // Test include_x_bounds = false, the augmented lagrangian is 0.
-  const AugmentedLagrangianNonsmooth dut(&prog, false);
-  EXPECT_EQ(dut.lagrangian_size(), 0);
-  EXPECT_TRUE(dut.is_equality().empty());
-  VectorX<double> constraint_residue;
-  double cost;
-  EXPECT_EQ(dut.Eval<double>(Eigen::Vector4d(1, 2, 3, 4), Eigen::VectorXd(0),
-                             0.5, &constraint_residue, &cost),
-            0);
-  EXPECT_EQ(constraint_residue.rows(), 0);
-  Eigen::VectorXd x_lo_expected, x_up_expected;
-  AggregateBoundingBoxConstraints(prog, &x_lo_expected, &x_up_expected);
-  EXPECT_TRUE(CompareMatrices(dut.x_lo(), x_lo_expected));
-  EXPECT_TRUE(CompareMatrices(dut.x_up(), x_up_expected));
+  const AugmentedLagrangianNonsmooth dut_nonsmooth(&prog, false);
+  CheckBoundingBoxConstraintEmpty(dut_nonsmooth);
+  const AugmentedLagrangianSmooth dut_smooth(&prog, false);
+  CheckBoundingBoxConstraintEmpty(dut_smooth);
 }
 
 #pragma GCC diagnostic push
@@ -431,7 +591,7 @@ GTEST_TEST(NonsmoothAugmentedLagrangian, EqualityConstraints) {
   const double tol = 1E-10;
   CheckAugmentedLagrangianEqualityConstraint(
       prog, constraint, Eigen::Vector3d(0.5, 1.5, 2),
-      Eigen::Vector4d(1, 3, -2, 4), 0.2, tol);
+      Eigen::Vector4d(1, 3, -2, 4), 0.2, tol, false);
   CheckNonsmoothAugmentedLagrangianEqualityConstraint(
       prog, constraint, Eigen::Vector3d(-0.5, 2.5, 2),
       Eigen::Vector4d(-1, 2, 3, -2), 0.6, tol);


### PR DESCRIPTION
The slack variable s becomes a decision variable in the augmented Lagrangian. This is the same formulation used in LANCELOT.

Towards #16442

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16845)
<!-- Reviewable:end -->
