### PR TITLE
[geometry] Update RenderEngineVtk and remove private friendship

### DIFF
--- a/geometry/render/dev/render_engine_gltf_client.h
+++ b/geometry/render/dev/render_engine_gltf_client.h
@@ -10,16 +10,14 @@
 namespace drake {
 namespace geometry {
 namespace render {
+namespace internal {
 
-// TODO(svenevs): The RenderEngineGltfClient class needs access to the private
-// rendering pipelines of RenderEngineVtk.  We should reconsider the need for
-// private friendship prior to promoting this class out of `dev`.
-/** A RenderClient that exports
+/* A RenderClient that exports
  <a href="https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html">glTF
  </a> scenes to upload to a render server. */
 class RenderEngineGltfClient : public RenderEngineVtk {
  public:
-  /** @name Does not allow copy, move, or assignment  */
+  /* @name Does not allow copy, move, or assignment  */
   //@{
 #ifdef DRAKE_DOXYGEN_CXX
   // Note: the copy constructor operator is actually protected to serve as the
@@ -31,7 +29,7 @@ class RenderEngineGltfClient : public RenderEngineVtk {
   RenderEngineGltfClient& operator=(RenderEngineGltfClient&&) = delete;
   //@}}
 
-  /** Constructs the render engine from the given `parameters`.  By default the
+  /* Constructs the render engine from the given `parameters`.  By default the
    %RenderEngineGltfClient will communicate with a local server.
    @sa RenderEngineGltfClientParams */
   RenderEngineGltfClient(const RenderEngineGltfClientParams& parameters =
@@ -41,7 +39,7 @@ class RenderEngineGltfClient : public RenderEngineVtk {
   void UpdateViewpoint(const math::RigidTransformd& X_WC) override;
 
  protected:
-  /** Copy constructor for the purpose of cloning. */
+  /* Copy constructor for the purpose of cloning. */
   RenderEngineGltfClient(const RenderEngineGltfClient& other);
 
  private:
@@ -66,13 +64,11 @@ class RenderEngineGltfClient : public RenderEngineVtk {
   /* Return the path to export a glTF scene file to for the specified
   `image_type` and `scene_id`.  The returned path is constructed as
   `{RenderClient::temp_directory()}/{scene_id}-{image_type}.gltf`. */
-  std::string ExportPathFor(internal::ImageType image_type,
-                            int64_t scene_id) const;
+  std::string ExportPathFor(ImageType image_type, int64_t scene_id) const;
 
   /* Exports the `RenderEngineVtk::pipelines_[image_type]` VTK scene to a
   glTF file, returning the path to the newly exported file. */
-  std::string ExportScene(internal::ImageType image_type,
-                          int64_t scene_id) const;
+  std::string ExportScene(ImageType image_type, int64_t scene_id) const;
 
   /* Delete the files at the paths `scene_path` and `image_path`.  Should only
    be called when `!no_cleanup()`. */
@@ -81,14 +77,14 @@ class RenderEngineGltfClient : public RenderEngineVtk {
 
   /* Helper access method for testing UpdateViewpoint matrix inversion for the
    specified image_type.  Only used for testing. */
-  Eigen::Matrix4d CameraModelViewTransformMatrix(
-      internal::ImageType image_type) const;
+  Eigen::Matrix4d CameraModelViewTransformMatrix(ImageType image_type) const;
 
  private:
   friend class RenderEngineGltfClientTester;
-  std::unique_ptr<internal::RenderClient> render_client_;
+  std::unique_ptr<RenderClient> render_client_;
 };
 
+}  // namespace internal
 }  // namespace render
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render/dev/render_engine_gltf_client_factory.cc
+++ b/geometry/render/dev/render_engine_gltf_client_factory.cc
@@ -8,7 +8,7 @@ namespace render {
 
 std::unique_ptr<RenderEngine> MakeRenderEngineGltfClient(
     const RenderEngineGltfClientParams& params) {
-  return std::make_unique<RenderEngineGltfClient>(params);
+  return std::make_unique<internal::RenderEngineGltfClient>(params);
 }
 
 }  // namespace render

--- a/geometry/render/dev/test/render_engine_gltf_client_test.cc
+++ b/geometry/render/dev/test/render_engine_gltf_client_test.cc
@@ -17,6 +17,7 @@
 namespace drake {
 namespace geometry {
 namespace render {
+namespace internal {
 
 // Exposes various private access methods and data members for validation.
 class RenderEngineGltfClientTester {
@@ -39,18 +40,16 @@ class RenderEngineGltfClientTester {
   }
 
   // Allow the HttpService backend to be swapped out.
-  void SetHttpService(std::unique_ptr<internal::HttpService> service) {
+  void SetHttpService(std::unique_ptr<HttpService> service) {
     engine_->render_client_->SetHttpService(std::move(service));
   }
 
   // RenderEngineGltfClient private method access.
-  std::string ExportPathFor(internal::ImageType image_type,
-                            int64_t scene_id) const {
+  std::string ExportPathFor(ImageType image_type, int64_t scene_id) const {
     return engine_->ExportPathFor(image_type, scene_id);
   }
 
-  std::string ExportScene(internal::ImageType image_type,
-                          int64_t scene_id) const {
+  std::string ExportScene(ImageType image_type, int64_t scene_id) const {
     return engine_->ExportScene(image_type, scene_id);
   }
 
@@ -59,8 +58,7 @@ class RenderEngineGltfClientTester {
     engine_->CleanupFrame(scene_path, image_path);
   }
 
-  Eigen::Matrix4d CameraModelViewTransformMatrix(
-      internal::ImageType image_type) const {
+  Eigen::Matrix4d CameraModelViewTransformMatrix(ImageType image_type) const {
     return engine_->CameraModelViewTransformMatrix(image_type);
   }
 
@@ -77,11 +75,6 @@ using Eigen::Matrix4d;
 using Eigen::Vector3d;
 using Eigen::Vector4d;
 
-using internal::HttpResponse;
-using internal::HttpService;
-using internal::TestPngGray16;
-using internal::TestPngRgb8;
-using internal::TestTiffGray32;
 using math::RigidTransformd;
 using math::RollPitchYawd;
 using systems::sensors::ImageDepth32F;
@@ -162,20 +155,20 @@ GTEST_TEST(RenderEngineGltfClient, UpdateViewpoint) {
   // First, use the RenderEngineVtk::UpdateViewpoint and gather matrices.
   engine.RenderEngineVtk::UpdateViewpoint(X_WB);
   Matrix4d vtk_color_mat =
-      tester.CameraModelViewTransformMatrix(internal::ImageType::kColor);
+      tester.CameraModelViewTransformMatrix(ImageType::kColor);
   Matrix4d vtk_depth_mat =
-      tester.CameraModelViewTransformMatrix(internal::ImageType::kDepth);
+      tester.CameraModelViewTransformMatrix(ImageType::kDepth);
   Matrix4d vtk_label_mat =
-      tester.CameraModelViewTransformMatrix(internal::ImageType::kLabel);
+      tester.CameraModelViewTransformMatrix(ImageType::kLabel);
 
   // Use the RenderEngineGltfClient::UpdateViewpoint and gather new matrices.
   engine.UpdateViewpoint(X_WB);
   Matrix4d gltf_color_mat =
-      tester.CameraModelViewTransformMatrix(internal::ImageType::kColor);
+      tester.CameraModelViewTransformMatrix(ImageType::kColor);
   Matrix4d gltf_depth_mat =
-      tester.CameraModelViewTransformMatrix(internal::ImageType::kDepth);
+      tester.CameraModelViewTransformMatrix(ImageType::kDepth);
   Matrix4d gltf_label_mat =
-      tester.CameraModelViewTransformMatrix(internal::ImageType::kLabel);
+      tester.CameraModelViewTransformMatrix(ImageType::kLabel);
 
   /* A ModelView transform can be inverted directly by inverting the rotation
    via transpose, and using this inverted rotation to rotate the negated
@@ -401,16 +394,15 @@ GTEST_TEST(RenderEngineGltfClient, Export) {
   Tester tester{&engine};
 
   for (const auto image_type :
-       {internal::ImageType::kColor, internal::ImageType::kDepth,
-        internal::ImageType::kLabel}) {
+       {ImageType::kColor, ImageType::kDepth, ImageType::kLabel}) {
     for (const int64_t scene_id : {1, 11, 111}) {  // validate name formatting
       // Reconstruct the expected export path.
       std::string image_type_str;
-      if (image_type == internal::ImageType::kColor) {
+      if (image_type == ImageType::kColor) {
         image_type_str = "color";
-      } else if (image_type == internal::ImageType::kDepth) {
+      } else if (image_type == ImageType::kDepth) {
         image_type_str = "depth";
-      } else {  // image_type := internal::ImageType::kLabel
+      } else {  // image_type := ImageType::kLabel
         image_type_str = "label";
       }
       const std::string basename =
@@ -476,6 +468,7 @@ GTEST_TEST(RenderEngineGltfClient, CleanupFrame) {
 }
 
 }  // namespace
+}  // namespace internal
 }  // namespace render
 }  // namespace geometry
 }  // namespace drake


### PR DESCRIPTION
Update RenderEngineVtk function access modifiers and remove private friendship between RenderEngineVtk and its derived class RenderEngineGltfClient.

Tested locally with the new changes by running the new client/server pipeline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16846)
<!-- Reviewable:end -->
