### PR TITLE
[trajopt] Add `MultipleShooting::AddConstraintToAllKnotPoints` variants

### DIFF
--- a/bindings/pydrake/systems/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/systems/test/trajectory_optimization_test.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from pydrake.common.deprecation import DrakeDeprecationWarning
 from pydrake.examples.pendulum import PendulumPlant
+from pydrake.math import eq
 from pydrake.trajectories import PiecewisePolynomial
 from pydrake.solvers import mathematicalprogram as mp
 from pydrake.systems.framework import InputPortSelection
@@ -22,11 +23,16 @@ class TestTrajectoryOptimization(unittest.TestCase):
         plant = PendulumPlant()
         context = plant.CreateDefaultContext()
 
+        num_time_samples = 21
         dircol = DirectCollocation(
-            plant, context, num_time_samples=21, minimum_timestep=0.2,
+            plant,
+            context,
+            num_time_samples=num_time_samples,
+            minimum_timestep=0.2,
             maximum_timestep=0.5,
             input_port_index=InputPortSelection.kUseFirstInputIfItExists,
             assume_non_continuous_states_are_fixed=False)
+        prog = dircol.prog()
 
         # Spell out most of the methods, regardless of whether they make sense
         # as a consistent optimization.  The goal is to check the bindings,
@@ -88,19 +94,43 @@ class TestTrajectoryOptimization(unittest.TestCase):
         self.assertTrue(was_called["state"])
         self.assertTrue(was_called["complete"])
 
-        times = dircol.GetSampleTimes(result=result)
-        inputs = dircol.GetInputSamples(result=result)
-        states = dircol.GetStateSamples(result=result)
-        variables = dircol.GetSequentialVariableSamples(result=result,
-                                                        name="test")
-        input_traj = dircol.ReconstructInputTrajectory(result=result)
-        state_traj = dircol.ReconstructStateTrajectory(result=result)
+        dircol.GetSampleTimes(result=result)
+        dircol.GetInputSamples(result=result)
+        dircol.GetStateSamples(result=result)
+        dircol.GetSequentialVariableSamples(result=result, name="test")
+        dircol.ReconstructInputTrajectory(result=result)
+        dircol.ReconstructStateTrajectory(result=result)
 
         constraint = DirectCollocationConstraint(plant, context)
         AddDirectCollocationConstraint(constraint, dircol.timestep(0),
                                        dircol.state(0), dircol.state(1),
                                        dircol.input(0), dircol.input(1),
-                                       dircol.prog())
+                                       prog)
+
+        # Test AddConstraintToAllKnotPoints variants.
+        nc = len(prog.bounding_box_constraints())
+        c = dircol.AddConstraintToAllKnotPoints(
+            constraint=mp.BoundingBoxConstraint([0], [1]), vars=u)
+        self.assertIsInstance(c[0], mp.Binding[mp.BoundingBoxConstraint])
+        self.assertEqual(len(prog.bounding_box_constraints()),
+                         nc + num_time_samples)
+        nc = len(prog.linear_equality_constraints())
+        c = dircol.AddConstraintToAllKnotPoints(
+            constraint=mp.LinearEqualityConstraint([1], [0]), vars=u)
+        self.assertIsInstance(c[0], mp.Binding[mp.LinearEqualityConstraint])
+        self.assertEqual(len(prog.linear_equality_constraints()),
+                         nc + num_time_samples)
+        nc = len(prog.linear_constraints())
+        c = dircol.AddConstraintToAllKnotPoints(
+            constraint=mp.LinearConstraint([1], [0], [1]), vars=u)
+        self.assertIsInstance(c[0], mp.Binding[mp.LinearConstraint])
+        self.assertEqual(len(prog.linear_constraints()), nc + num_time_samples)
+        nc = len(prog.linear_equality_constraints())
+        # eq(x, 2) produces a 2-dimensional vector of Formula.
+        c = dircol.AddConstraintToAllKnotPoints(eq(x, 2))
+        self.assertIsInstance(c[0].evaluator(), mp.LinearEqualityConstraint)
+        self.assertEqual(len(prog.linear_equality_constraints()),
+                         nc + 2*num_time_samples)
 
     def test_direct_transcription(self):
         # Integrator.
@@ -143,7 +173,7 @@ class TestTrajectoryOptimization(unittest.TestCase):
         context = plant.CreateDefaultContext()
         dirtran = DirectTranscription(plant, context, num_time_samples=3,
                                       fixed_timestep=TimeStep(0.1))
-        with warnings.catch_warnings():
+        with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("once", DrakeDeprecationWarning)
             self.assertEqual(len(dirtran.linear_equality_constraints()), 3)
         self.assertEqual(len(dirtran.prog().linear_equality_constraints()), 3)

--- a/systems/trajectory_optimization/BUILD.bazel
+++ b/systems/trajectory_optimization/BUILD.bazel
@@ -31,6 +31,7 @@ drake_cc_library(
     deps = [
         "//common:essential",
         "//common:symbolic",
+        "//common:unused",
     ],
 )
 
@@ -137,6 +138,7 @@ drake_cc_googletest(
     name = "sequential_expression_manager_test",
     deps = [
         ":sequential_expression_manager",
+        "//common/test_utilities:expect_throws_message",
         "@fmt",
     ],
 )

--- a/systems/trajectory_optimization/multiple_shooting.cc
+++ b/systems/trajectory_optimization/multiple_shooting.cc
@@ -147,6 +147,19 @@ solvers::VectorXDecisionVariable MultipleShooting::GetSequentialVariableAtIndex(
                                                                     index));
 }
 
+std::vector<solvers::Binding<solvers::Constraint>>
+MultipleShooting::AddConstraintToAllKnotPoints(
+    const Eigen::Ref<const VectorX<symbolic::Formula>>& f) {
+  std::vector<solvers::Binding<solvers::Constraint>> bindings;
+  for (int i = 0; i < f.size(); ++i) {
+    std::vector<solvers::Binding<solvers::Constraint>> b =
+        AddConstraintToAllKnotPoints(f[i]);
+    bindings.insert(bindings.end(), std::make_move_iterator(b.begin()),
+                    std::make_move_iterator(b.end()));
+  }
+  return bindings;
+}
+
 solvers::Binding<solvers::BoundingBoxConstraint>
 MultipleShooting::AddTimeIntervalBounds(double lower_bound,
                                         double upper_bound) {

--- a/systems/trajectory_optimization/sequential_expression_manager.h
+++ b/systems/trajectory_optimization/sequential_expression_manager.h
@@ -13,7 +13,7 @@ namespace drake {
 namespace systems {
 namespace trajectory_optimization {
 namespace internal {
-/**
+/*
  * Represents a collection of sequential expression vectors (expression vectors
  * that take on different values for each index in {0, ..., `num_samples` - 1}).
  * Each sequential expression vector is identified by a name and has an
@@ -26,14 +26,14 @@ class SequentialExpressionManager {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SequentialExpressionManager);
 
-  /**
+  /*
    * @pre `num_samples` > 0
    */
   explicit SequentialExpressionManager(int num_samples);
 
   ~SequentialExpressionManager() = default;
 
-  /**
+  /*
    * Registers a sequential expression vector and returns a vector of
    * placeholder variables.
    * @param sequential_expressions [num_expressions x num_samples] matrix of
@@ -52,7 +52,7 @@ class SequentialExpressionManager {
           sequential_expressions,
       const std::string& name);
 
-  /**
+  /*
    * Registers a placeholder variables and the associated sequential expression
    * vector.
    *
@@ -75,7 +75,7 @@ class SequentialExpressionManager {
           sequential_expressions,
       const std::string& name);
 
-  /**
+  /*
    * Returns a symbolic::Substitution for replacing all placeholder variables
    * with their respective `index`-th expression.
    * @pre 0 <= index < num_samples()
@@ -83,7 +83,17 @@ class SequentialExpressionManager {
   symbolic::Substitution ConstructPlaceholderVariableSubstitution(
       int index) const;
 
-  /**
+  /*
+   * Returns a vector with each placeholder symbolic::Variable in `vars`
+   * replaced by the symbolic::Variable corresponding to that placeholder at
+   * `index`. @throws std::exception if the placeholder variable at `index` is
+   * an Expression which does not correspond to a single Variable.
+   */
+  VectorX<symbolic::Variable> GetVariables(
+      const Eigen::Ref<const VectorX<symbolic::Variable>>& vars,
+      int index) const;
+
+  /*
    * Returns the `index`-th vector of expressions for `name`.
    * @pre `name` is associated with a registered sequential expression vector.
    * @pre 0 <= index < num_samples()
@@ -91,17 +101,17 @@ class SequentialExpressionManager {
   VectorX<symbolic::Expression> GetSequentialExpressionsByName(
       const std::string& name, int index) const;
 
-  /** Returns all the sequential expression names in this manager.
+  /* Returns all the sequential expression names in this manager.
    */
   std::vector<std::string> GetSequentialExpressionNames() const;
 
-  /**
+  /*
    * Returns the number of samples for the sequential expressions managed by
    * `this`.
    */
   int num_samples() const { return num_samples_; }
 
-  /**
+  /*
    * Returns the number of rows for the sequential expression vector `name`.
    * @pre `name` is associated with a registered sequential expression vector.
    */
@@ -109,9 +119,10 @@ class SequentialExpressionManager {
 
  private:
   int num_samples_{};
-  std::unordered_map<std::string, std::pair<VectorX<symbolic::Variable>,
-                                            MatrixX<symbolic::Expression>>>
-      name_to_placeholders_and_sequential_expressions_;
+  std::unordered_map<std::string, VectorX<symbolic::Variable>>
+      name_to_placeholders_;
+  std::unordered_map<symbolic::Variable, RowVectorX<symbolic::Expression>>
+      placeholders_to_expressions_;
 };
 }  // namespace internal
 }  // namespace trajectory_optimization

--- a/systems/trajectory_optimization/test/multiple_shooting_test.cc
+++ b/systems/trajectory_optimization/test/multiple_shooting_test.cc
@@ -881,6 +881,21 @@ GTEST_TEST(MultipleShootingTest, ConstraintAllKnotsTest) {
   // u(2) = h(0)+h(1).
   EXPECT_NEAR(result.GetSolution(trajopt.input(2).coeff(0)),
               result.GetSolution(trajopt.h_vars()).sum(), 1e-6);
+
+  // Add the same constraint again using the shared_ptr variant.
+  std::vector<solvers::Binding<solvers::BoundingBoxConstraint>> c =
+      trajopt.AddConstraintToAllKnotPoints(
+          std::make_shared<solvers::BoundingBoxConstraint>(state_value,
+                                                           state_value),
+          trajopt.state());
+  EXPECT_EQ(c.size(), kNumSampleTimes);
+
+  // Add the same constraint again using the vector of formulas variant.
+  std::vector<solvers::Binding<solvers::Constraint>> c2 =
+      trajopt.AddConstraintToAllKnotPoints(
+          Vector2<symbolic::Formula>{trajopt.state()[0] == state_value[0],
+                                     trajopt.state()[1] == state_value[1]});
+  EXPECT_EQ(c2.size(), 2*kNumSampleTimes);
 }
 
 GTEST_TEST(MultipleShootingTest, FinalCostTest) {


### PR DESCRIPTION
This significantly improves the ergonomics in pydrake for adding, for
instance, bounding box constraints to the state or input at all knot
points.  (And it resolves a long-standing TODO in
`multiple_shooting.h`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16847)
<!-- Reviewable:end -->
