### PR TITLE
[tools] Add more known-defects to header lint checks

### DIFF
--- a/tools/install/libdrake/header_lint.bzl
+++ b/tools/install/libdrake/header_lint.bzl
@@ -16,6 +16,7 @@ _ALLOWED_EXTERNALS = [
     "spdlog",
 
     # The entries that follow are defects; we should work to remove them.
+    "blas",
     "ccd",
     "cds",
     "clp",
@@ -33,8 +34,11 @@ _ALLOWED_EXTERNALS = [
     "ignition_math",
     "ignition_utils",
     "ipopt",
+    "lapack",
     "lcm",
+    "libblas",
     "libjpeg",
+    "liblapack",
     "liblz4",
     "liblzma",
     "libpng",


### PR DESCRIPTION
In certain configurations, libblas is shown as an interface deps.  Allow that for now.

Hotfix for #16774.

+@rpoyner-tri for both reviews, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16849)
<!-- Reviewable:end -->
