### PR TITLE
[parsing] Hotfix unit test for macOS

### DIFF
--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -464,7 +464,7 @@ TEST_F(UrdfParserTest, TransmissionJointZeroEffortLimit) {
     </robot>)""", ""), std::nullopt);
   EXPECT_THAT(TakeWarning(), MatchesRegex(
                   ".*Skipping transmission since it's attached to joint \"a\""
-                  " which has a zero effort limit 0.0."));
+                  " which has a zero effort limit 0.*"));
 }
 
 TEST_F(UrdfParserTest, TransmissionJointNegativeEffortLimit) {


### PR DESCRIPTION
Hotfix for #16829 ([failure](https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/mac-monterey-clang-bazel-continuous-release/446/)).

Tested locally on `macsim` already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16853)
<!-- Reviewable:end -->
