### PR TITLE
[geometry] Update function comments to use indicative mood

### DIFF
--- a/geometry/render/dev/http_service.h
+++ b/geometry/render/dev/http_service.h
@@ -68,7 +68,7 @@ class HttpService {
 
   /* @name Server Interaction Interface */
   //@{
-  /* Post an HTML `<form>` to the specified `endpoint`.
+  /* Posts an HTML `<form>` to the specified `endpoint`.
 
    An HTML `<form>` may allow for a wide range of different kinds of `<input>`
    data.  For the full listing of available input `type`'s, see the
@@ -215,7 +215,7 @@ class HttpService {
   /* Throws `std::runtime_error` if `endpoint` starts or ends with a '/'. */
   void ThrowIfEndpointInvalid(const std::string& endpoint) const;
 
-  /* Verify that all file paths provided are regular files, throw if not.
+  /* Verifies that all file paths provided are regular files, throw if not.
 
    @param file_fields See HttpService::PostForm.
    @throws std::runtime_error

--- a/geometry/render/dev/http_service_curl.cc
+++ b/geometry/render/dev/http_service_curl.cc
@@ -28,7 +28,7 @@ namespace fs = drake::filesystem;
 
 // Curl callbacks --------------------------------------------------------------
 
-// Write callback for libcurl, assumes `userp` points to an std::ofstream.
+// Writes callback for libcurl, assumes `userp` points to an std::ofstream.
 // See: https://curl.se/libcurl/c/libcurl-tutorial.html
 size_t WriteFileData(void* buffer, size_t size, size_t nmemb, void* userp) {
   const size_t data_size = size * nmemb;
@@ -84,7 +84,7 @@ std::string CurlInfoTypeAsString(curl_infotype type) {
   return fmt::format("UNKNOWN_CURLINFO_TYPE={}", type);
 }
 
-/* Remove leading / trailing whitespace from message before logging.  Curl
+/* Removes leading / trailing whitespace from message before logging.  Curl
  includes newline characters in its entries, which are desirable for the
  accumulated interior message parts but the trailing whitespace in particular
  leads to cluttered logs (drake::log() adds a trailing newline). */
@@ -98,7 +98,7 @@ void LogIfTrimmedWhitespaceNonEmpty(curl_infotype type,
   }
 }
 
-/* Log the combined messages added to `debug_data` by the DebugCallback.
+/* Logs the combined messages added to `debug_data` by the DebugCallback.
  When curl calls the DebugCallback, it will do so with piecemeal components.  In
  the below walk-through, the "Accept: ..." statement was modified to add spaces
  between * and / to avoid ending the comment.

--- a/geometry/render/dev/render_client.cc
+++ b/geometry/render/dev/render_client.cc
@@ -38,8 +38,8 @@ namespace fs = drake::filesystem;
 // Convenience definitions for interacting with HttpService.
 using data_map_t = std::map<std::string, std::string>;
 
-/* Add field_name = field_data to the map, assumes data_map does **not** already
- have the key `field_name`. */
+/* Adds field_name = field_data to the map, assumes data_map does **not**
+ already have the key `field_name`. */
 void AddField(data_map_t* data_map, const std::string& field_name,
               const std::string& field_data) {
   (*data_map)[field_name] = field_data;
@@ -84,8 +84,8 @@ void AddField<RenderImageType>(data_map_t* data_map,
   // LCOV_EXCL_STOP
 }
 
-/* Verify the loaded image has the correct dimensions.  This includes verifying
- that the image is 2D (depth=1).
+/* Verifies the loaded image has the correct dimensions.  This includes
+ verifying that the image is 2D (depth=1).
 
  @param expected_width
    The expected width of the loaded image.
@@ -129,7 +129,7 @@ void VerifyImportedImageDimensions(int expected_width, int expected_height,
   }
 }
 
-/* Return '{url}' if port is <= 0, '{url}:{port}' otherwise.  Used for
+/* Returns '{url}' if port is <= 0, '{url}:{port}' otherwise.  Used for
  populating error messages. */
 std::string UrlWithPort(const std::string& url, int port) {
   if (port > 0) return fmt::format("{}:{}", url, port);

--- a/geometry/render/dev/render_client.h
+++ b/geometry/render/dev/render_client.h
@@ -59,8 +59,8 @@ class RenderClient {
   /* @name Server communication */
   //@{
 
-  /* Upload the scene file from `scene_path` to the render server, download
-   the image file response, and return the path to the image file.
+  /* Uploads the scene file from `scene_path` to the render server, downloads
+   the image file response, and returns the path to the image file.
    The returned file path may be used directly with any one of the helper
    methods LoadColorImage(), LoadDepthImage(), or LoadLabelImage().  The file
    path returned will be in temp_directory(), users do not need to delete the
@@ -108,13 +108,13 @@ class RenderClient {
   /* @name Server communication helpers */
   //@{
 
-  /* Compute and return the `sha256sum` of the specified `path`.
+  /* Computes and returns the `sha256sum` of the specified `path`.
    @throws std::runtime_error
      If the `path` cannot be opened or the hash fails to compute.
    */
   std::string ComputeSha256(const std::string& path) const;
 
-  /* Rename the specified file `response_data_path` to have the same name as
+  /* Renames the specified file `response_data_path` to have the same name as
    `reference_path`, with a new file extension provided by `extension`.
    Helper method for RetrieveRender() which will download files as
    `{temp_directory()}/{response_data_path}` and then rename the file
@@ -156,7 +156,7 @@ class RenderClient {
   /* @name Image loading helpers */
   //@{
 
-  /* Load the specified image file to a drake output buffer.
+  /* Loads the specified image file to a drake output buffer.
 
    This method only supports loading unsigned char PNG images with either three
    (RGB) or four (RGBA) channels.
@@ -175,7 +175,7 @@ class RenderClient {
       const std::string& path,
       drake::systems::sensors::ImageRgba8U* color_image_out) const;
 
-  /* Load the specified image file to a drake output buffer.
+  /* Loads the specified image file to a drake output buffer.
 
    This method supports loading:
 
@@ -198,7 +198,7 @@ class RenderClient {
       const std::string& path,
       drake::systems::sensors::ImageDepth32F* depth_image_out) const;
 
-  /* Load the specified image file to a drake output buffer.
+  /* Loads the specified image file to a drake output buffer.
 
    This method only supports loading single channel unsigned short PNG images.
 

--- a/geometry/render/dev/render_engine_gltf_client.cc
+++ b/geometry/render/dev/render_engine_gltf_client.cc
@@ -72,7 +72,7 @@ void SetGltfCameraPerspective(const RenderCameraCore& core, vtkCamera* camera) {
   camera->SetViewAngle(fy);
 }
 
-/* Convert the RenderEngineVtk ImageType to a RenderClient RenderImageType.
+/* Converts the RenderEngineVtk ImageType to a RenderClient RenderImageType.
  NOTE: if RenderImageType expands to have more image types, this logic will
  have to be revisited (e.g., two kinds of depth images supported). */
 RenderImageType VtkToClientRenderImageType(ImageType image_type) {
@@ -124,7 +124,8 @@ void LogFrameServerResponsePath(ImageType image_type, const std::string& path) {
       ImageTypeToString(image_type), path);
 }
 
-// Delete the file and log if verbose, only call if no_cleanup() == false.
+// Deletes the file and log if verbose. This function is called only when
+// no_cleanup() == false.
 void DeleteFileAndLogIfVerbose(const std::string& path, bool verbose) {
   try {
     fs::remove(path);

--- a/geometry/render/dev/render_engine_gltf_client.h
+++ b/geometry/render/dev/render_engine_gltf_client.h
@@ -61,7 +61,7 @@ class RenderEngineGltfClient : public RenderEngineVtk {
       const ColorRenderCamera& camera,
       systems::sensors::ImageLabel16I* label_image_out) const override;
 
-  /* Return the path to export a glTF scene file to for the specified
+  /* Returns the path to export a glTF scene file to for the specified
   `image_type` and `scene_id`.  The returned path is constructed as
   `{RenderClient::temp_directory()}/{scene_id}-{image_type}.gltf`. */
   std::string ExportPathFor(ImageType image_type, int64_t scene_id) const;
@@ -70,7 +70,7 @@ class RenderEngineGltfClient : public RenderEngineVtk {
   glTF file, returning the path to the newly exported file. */
   std::string ExportScene(ImageType image_type, int64_t scene_id) const;
 
-  /* Delete the files at the paths `scene_path` and `image_path`.  Should only
+  /* Deletes the files at the paths `scene_path` and `image_path`.  Should only
    be called when `!no_cleanup()`. */
   void CleanupFrame(const std::string& scene_path,
                     const std::string& image_path) const;

--- a/geometry/render/dev/render_engine_vtk_minimal_example.cc
+++ b/geometry/render/dev/render_engine_vtk_minimal_example.cc
@@ -144,7 +144,7 @@ RigidTransformd ParseCameraPose(const std::string& raw_input_str) {
   return X_WB;
 }
 
-// Make an instance of the given shape, at the given position, with the given
+// Makes an instance of the given shape, at the given position, with the given
 // material (named as indicated).
 std::unique_ptr<GeometryInstance> MakeInstance(const Shape& shape,
                                                const Vector3d& p_WS,

--- a/geometry/render/dev/test/render_client_test.cc
+++ b/geometry/render/dev/test/render_client_test.cc
@@ -184,7 +184,7 @@ class FieldCheckService : public HttpService {
         mime_type_{mime_type},
         depth_range_{depth_range} {}
 
-  /* Check all of the <form> fields.  Always respond with failure (http 500). */
+  // Checks all of the <form> fields.  Always respond with failure (http 500).
   HttpResponse PostForm(const std::string& /* temp_directory */,
                         const std::string& url, int /* port */,
                         const std::string& endpoint,

--- a/geometry/render/dev/test/render_engine_gltf_client_test.cc
+++ b/geometry/render/dev/test/render_engine_gltf_client_test.cc
@@ -39,7 +39,7 @@ class RenderEngineGltfClientTester {
     return engine_->render_client_->temp_directory();
   }
 
-  // Allow the HttpService backend to be swapped out.
+  // Allows the HttpService backend to be swapped out.
   void SetHttpService(std::unique_ptr<HttpService> service) {
     engine_->render_client_->SetHttpService(std::move(service));
   }
@@ -267,7 +267,7 @@ class FakeServer : public HttpService {
   }
 };
 
-/* Return all regular files found in directory (*NOT* recursive). */
+/* Returns all regular files found in directory (*NOT* recursive). */
 std::vector<fs::path> FindRegularFiles(const std::string& directory) {
   std::vector<fs::path> files;
   for (const auto& item : fs::directory_iterator(directory)) {

--- a/geometry/render/dev/test_utilities/test_png.cc
+++ b/geometry/render/dev/test_utilities/test_png.cc
@@ -15,7 +15,7 @@ namespace {
 
 using systems::sensors::ImageRgba8U;
 
-// Return the `color_type` for `png_set_IHDR`.
+// Returns the `color_type` for `png_set_IHDR`.
 template <int channels>
 int ColorType() {
   static_assert(channels == 1 || channels == 3 || channels == 4,

--- a/geometry/render/dev/test_utilities/test_png.h
+++ b/geometry/render/dev/test_utilities/test_png.h
@@ -85,7 +85,7 @@ class TestPng {
   // For when writing a single channel image.
   static constexpr ChannelType kGrayStart = static_cast<ChannelType>(0);
 
-  /* Create a TIFF image at the specified path with dimensions width x height,
+  /* Creates a PNG image at the specified path with dimensions width x height,
    generating the pattern described on the class documentation.  User is
    responsible for deleting the file after it is created. */
   TestPng(const std::string& path, int width, int height);

--- a/geometry/render/dev/test_utilities/test_tiff.h
+++ b/geometry/render/dev/test_utilities/test_tiff.h
@@ -73,7 +73,7 @@ class TestTiff {
           std::is_same_v<ChannelType, float>,
       "TestTiff: only uint8_t, uint16_t, and 32 bit float supported.");
 
-  /* Create a TIFF image at the specified path with dimensions width x height,
+  /* Creates a TIFF image at the specified path with dimensions width x height,
    generating the pattern described on the class documentation.  User is
    responsible for deleting the file after it is created. */
   TestTiff(const std::string& path, int width, int height);


### PR DESCRIPTION
Per discussion in Slack, went through the `geometry/render/dev` folder and updated the function comments to use indicative mood.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16855)
<!-- Reviewable:end -->
