### PR TITLE
Fixes documentation on the modeling of friction

### DIFF
--- a/multibody/plant/contact_model_doxygen.h
+++ b/multibody/plant/contact_model_doxygen.h
@@ -241,7 +241,7 @@ Next topic: @ref contact_engineering
    with Regularized Friction. arXiv:1909.05700 [cs.RO].
 
  @note For better numerical stability, the discrete model assumes
- both static and kinetic coefficients of friction to be equal, the kinetic
+ both static and kinetic coefficients of friction to be equal, the static
  coefficient of friction is ignored.
 
  <h3>Continuous MultibodyPlant</h3>
@@ -417,7 +417,7 @@ Next topic: @ref contact_engineering
  with an explicit integrator, or use of a more-stable implicit integrator.
 
  @note When modeling the multibody system as discrete (refer to the @ref
- time_advancement_strategy "Choice of Time Advancement Strategy" section), we
- regularize Coulomb friction and only use the static coefficient of friction μₛ
- for better numerical stability.
+ time_advancement_strategy "Choice of Time Advancement Strategy" section), the
+ model assumes both static and kinetic coefficients of friction to be equal and
+ the static coefficient of friction is ignored.
 */


### PR DESCRIPTION
When using MultibodyPlant's discrete dynamics, static and kinetic coefficients of friction are assumed to be equal and the coefficient of static friction is ignored.
This PR fixes the documentation to be consistent with our code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16858)
<!-- Reviewable:end -->
