### PR TITLE
Update the Jaco LCM systems

### DIFF
--- a/examples/kinova_jaco_arm/BUILD.bazel
+++ b/examples/kinova_jaco_arm/BUILD.bazel
@@ -15,9 +15,11 @@ package(
 drake_cc_binary(
     name = "jaco_controller",
     srcs = ["jaco_controller.cc"],
+    add_test_rule = 1,
     data = [
         "//manipulation/models/jaco_description:models",
     ],
+    test_rule_args = ["--build_only"],
     deps = [
         "//common:add_text_logging_gflags",
         "//common:find_resource",
@@ -53,6 +55,7 @@ drake_cc_binary(
         "//systems/analysis:simulator",
         "//systems/controllers:inverse_dynamics_controller",
         "//systems/primitives:demultiplexer",
+        "//systems/primitives:multiplexer",
         "@gflags",
     ],
 )

--- a/examples/kinova_jaco_arm/jaco_simulation.cc
+++ b/examples/kinova_jaco_arm/jaco_simulation.cc
@@ -23,6 +23,7 @@
 #include "drake/systems/lcm/lcm_publisher_system.h"
 #include "drake/systems/lcm/lcm_subscriber_system.h"
 #include "drake/systems/primitives/demultiplexer.h"
+#include "drake/systems/primitives/multiplexer.h"
 
 DEFINE_double(simulation_sec, std::numeric_limits<double>::infinity(),
               "Number of seconds to simulate.");
@@ -101,13 +102,15 @@ int DoMain() {
   auto command_receiver = builder.AddSystem<JacoCommandReceiver>();
   builder.Connect(command_sub->get_output_port(),
                   command_receiver->get_message_input_port());
-  auto plant_state_demux = builder.AddSystem<Demultiplexer>(
-      2 * num_positions, num_positions);
-  builder.Connect(jaco_plant->get_state_output_port(jaco_id),
-                  plant_state_demux->get_input_port());
-  builder.Connect(plant_state_demux->get_output_port(0),
-                  command_receiver->get_position_measured_input_port());
-  builder.Connect(command_receiver->get_output_port(),
+
+  auto mux = builder.AddSystem<systems::Multiplexer>(
+      std::vector<int>({kJacoDefaultArmNumJoints + kJacoDefaultArmNumFingers,
+              kJacoDefaultArmNumJoints + kJacoDefaultArmNumFingers}));
+  builder.Connect(command_receiver->get_commanded_position_output_port(),
+                  mux->get_input_port(0));
+  builder.Connect(command_receiver->get_commanded_velocity_output_port(),
+                  mux->get_input_port(1));
+  builder.Connect(mux->get_output_port(),
                   jaco_controller->get_input_port_desired_state());
   builder.Connect(jaco_controller->get_output_port_control(),
                   jaco_plant->get_actuation_input_port(jaco_id));
@@ -120,8 +123,17 @@ int DoMain() {
   // torques might want to wait until after #12631 is fixed or it could slow
   // down the simulation significantly.
   auto status_sender = builder.AddSystem<JacoStatusSender>();
+  auto demux = builder.AddSystem<systems::Demultiplexer>(
+      std::vector<int>({kJacoDefaultArmNumJoints + kJacoDefaultArmNumFingers,
+              kJacoDefaultArmNumJoints + kJacoDefaultArmNumFingers}));
   builder.Connect(jaco_plant->get_state_output_port(jaco_id),
-                  status_sender->get_state_input_port());
+                  demux->get_input_port());
+  builder.Connect(demux->get_output_port(0),
+                  status_sender->get_position_input_port());
+  builder.Connect(demux->get_output_port(0),
+                  command_receiver->get_position_measured_input_port());
+  builder.Connect(demux->get_output_port(1),
+                  status_sender->get_velocity_input_port());
   builder.Connect(status_sender->get_output_port(),
                   status_pub->get_input_port());
 

--- a/manipulation/kinova_jaco/jaco_command_sender.cc
+++ b/manipulation/kinova_jaco/jaco_command_sender.cc
@@ -1,40 +1,69 @@
 #include "drake/manipulation/kinova_jaco/jaco_command_sender.h"
 
+#include "drake/common/drake_assert.h"
+
 namespace drake {
 namespace manipulation {
 namespace kinova_jaco {
 
+using drake::systems::kVectorValued;
+
 JacoCommandSender::JacoCommandSender(int num_joints, int num_fingers)
     : num_joints_(num_joints),
       num_fingers_(num_fingers) {
-  this->DeclareInputPort(
-      "state", systems::kVectorValued, (num_joints_ + num_fingers_) * 2);
+  state_input_ = &DeclareInputPort(
+      "state", kVectorValued, (num_joints_ + num_fingers_) * 2);
+  position_input_ = &DeclareInputPort(
+      "position", kVectorValued, num_joints_ + num_fingers_);
+  velocity_input_ = &DeclareInputPort(
+      "velocity", kVectorValued, num_joints_ + num_fingers_);
+
   this->DeclareAbstractOutputPort(
       "lcmt_jaco_command", &JacoCommandSender::CalcOutput);
 }
 
 void JacoCommandSender::CalcOutput(
     const systems::Context<double>& context, lcmt_jaco_command* output) const {
-  const auto& state = get_input_port().Eval(context);
 
-  lcmt_jaco_command& command = *output;
-  command.utime = context.get_time() * 1e6;
+  output->utime = context.get_time() * 1e6;
+  output->num_joints = num_joints_;
+  output->joint_position.resize(num_joints_);
+  output->joint_velocity.resize(num_joints_);
 
-  command.num_joints = num_joints_;
-  command.joint_position.resize(num_joints_);
-  command.joint_velocity.resize(num_joints_);
-  for (int i = 0; i < num_joints_; ++i) {
-    command.joint_position[i] = state(i);
-    command.joint_velocity[i] = state(i + num_joints_ + num_fingers_);
+  output->num_fingers = num_fingers_;
+  output->finger_position.resize(num_fingers_);
+  output->finger_velocity.resize(num_fingers_);
+
+  if (state_input_->HasValue(context)) {
+    DRAKE_DEMAND(!position_input_->HasValue(context));
+    DRAKE_DEMAND(!velocity_input_->HasValue(context));
+
+    const auto& state = state_input_->Eval(context);
+    for (int i = 0; i < num_joints_; ++i) {
+      output->joint_position[i] = state(i);
+      output->joint_velocity[i] = state(i + num_joints_ + num_fingers_);
+    }
+
+    for (int i = 0; i < num_fingers_; ++i) {
+      output->finger_position[i] = state(i + num_joints_) * kFingerUrdfToSdk;
+      output->finger_velocity[i] =
+          state.tail(num_fingers_)(i) * kFingerUrdfToSdk;
+    }
+    return;
   }
 
-  command.num_fingers = num_fingers_;
-  command.finger_position.resize(num_fingers_);
-  command.finger_velocity.resize(num_fingers_);
+  const auto& position = position_input_->Eval(context);
+  const auto& velocity = velocity_input_->Eval(context);
+  for (int i = 0; i < num_joints_; ++i) {
+    output->joint_position[i] = position(i);
+    output->joint_velocity[i] = velocity(i);
+  }
+
   for (int i = 0; i < num_fingers_; ++i) {
-    command.finger_position[i] = state(i + num_joints_) * kFingerUrdfToSdk;
-    command.finger_velocity[i] =
-        state.tail(num_fingers_)(i) * kFingerUrdfToSdk;
+    output->finger_position[i] =
+        position(num_joints_ + i) * kFingerUrdfToSdk;
+    output->finger_velocity[i] =
+        velocity(num_joints_ + i) * kFingerUrdfToSdk;
   }
 }
 

--- a/manipulation/kinova_jaco/jaco_command_sender.h
+++ b/manipulation/kinova_jaco/jaco_command_sender.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/lcmt_jaco_command.hpp"
 #include "drake/manipulation/kinova_jaco/jaco_constants.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -9,8 +10,6 @@ namespace drake {
 namespace manipulation {
 namespace kinova_jaco {
 
-// TODO(sammy-tri) Add support for not sending finger commands.
-
 /// Creates and outputs lcmt_jaco_command messages.
 ///
 /// Note that this system does not actually send the message to an LCM
@@ -18,7 +17,7 @@ namespace kinova_jaco {
 /// connected to a
 /// systems::lcm::LcmPublisherSystem::Make<lcmt_jaco_command>().
 ///
-/// This system has one vector-valued input port containing the desired
+/// This system has two vector-valued input ports containing the desired
 /// position and velocity.  Finger velocities will be translated to the values
 /// used by the Kinova SDK from values appropriate for the finger joints in
 /// the Jaco description (see jaco_constants.h).
@@ -28,7 +27,8 @@ namespace kinova_jaco {
 /// @system
 /// name: JacoCommandSender
 /// input_ports:
-/// - state
+/// - position
+/// - velocity
 /// output_ports:
 /// - lcmt_jaco_command
 /// @endsystem
@@ -41,11 +41,26 @@ class JacoCommandSender : public systems::LeafSystem<double> {
   JacoCommandSender(int num_joints = kJacoDefaultArmNumJoints,
                     int num_fingers = kJacoDefaultArmNumFingers);
 
+  DRAKE_DEPRECATED("2022-08-01", "Use the other input ports instead.")
+  const systems::InputPort<double>& get_input_port() const {
+    return *state_input_;
+  }
+
+  const systems::InputPort<double>& get_position_input_port() const {
+    return *position_input_;
+  }
+  const systems::InputPort<double>& get_velocity_input_port() const {
+    return *velocity_input_;
+  }
+
  private:
   void CalcOutput(const systems::Context<double>&, lcmt_jaco_command*) const;
 
   const int num_joints_;
   const int num_fingers_;
+  const systems::InputPort<double>* state_input_{};
+  const systems::InputPort<double>* position_input_{};
+  const systems::InputPort<double>* velocity_input_{};
 };
 
 }  // namespace kinova_jaco

--- a/manipulation/kinova_jaco/jaco_status_receiver.cc
+++ b/manipulation/kinova_jaco/jaco_status_receiver.cc
@@ -12,36 +12,41 @@ using systems::Context;
 JacoStatusReceiver::JacoStatusReceiver(int num_joints, int num_fingers)
     : num_joints_(num_joints),
       num_fingers_(num_fingers) {
-  this->DeclareAbstractInputPort(
+  message_input_ = &DeclareAbstractInputPort(
       "lcmt_jaco_status", Value<lcmt_jaco_status>{});
-  this->DeclareVectorOutputPort("state", (num_joints_ + num_fingers_) * 2,
-                                &JacoStatusReceiver::CalcStateOutput);
-  this->DeclareVectorOutputPort(
-      "torque", num_joints_ + num_fingers_,
-      &JacoStatusReceiver::CalcLcmOutput<&lcmt_jaco_status::joint_torque,
-                                         &lcmt_jaco_status::finger_torque>);
-  this->DeclareVectorOutputPort("torque_external", num_joints_ + num_fingers_,
-                                &JacoStatusReceiver::CalcLcmOutput<
-                                    &lcmt_jaco_status::joint_torque_external,
-                                    &lcmt_jaco_status::finger_torque_external>);
-  this->DeclareVectorOutputPort(
+  state_output_ = &DeclareVectorOutputPort(
+      "state", (num_joints_ + num_fingers_) * 2,
+      &JacoStatusReceiver::CalcStateOutput);
+  position_measured_output_ = &DeclareVectorOutputPort(
+      "position_measured", num_joints_ + num_fingers_,
+      &JacoStatusReceiver::CalcJointOutput<
+      &lcmt_jaco_status::joint_position,
+      &lcmt_jaco_status::finger_position, 1>);
+  velocity_measured_output_ = &DeclareVectorOutputPort(
+      "velocity_measured", num_joints_ + num_fingers_,
+      &JacoStatusReceiver::CalcJointOutput<
+      &lcmt_jaco_status::joint_velocity,
+      &lcmt_jaco_status::finger_velocity, 1>);
+  torque_measured_output_ = &DeclareVectorOutputPort(
+      "torque_measured", num_joints_ + num_fingers_,
+      &JacoStatusReceiver::CalcJointOutput<
+      &lcmt_jaco_status::joint_torque,
+      &lcmt_jaco_status::finger_torque, 0>);
+  torque_external_output_ = &DeclareVectorOutputPort(
+      "torque_external", num_joints_ + num_fingers_,
+      &JacoStatusReceiver::CalcJointOutput<
+      &lcmt_jaco_status::joint_torque_external,
+      &lcmt_jaco_status::finger_torque_external, 0>);
+  current_output_ = &DeclareVectorOutputPort(
       "current", num_joints_ + num_fingers_,
-      &JacoStatusReceiver::CalcLcmOutput<&lcmt_jaco_status::joint_current,
-                                         &lcmt_jaco_status::finger_current>);
+      &JacoStatusReceiver::CalcJointOutput<
+      &lcmt_jaco_status::joint_current,
+      &lcmt_jaco_status::finger_current, 0>);
 }
 
-using OutPort = systems::OutputPort<double>;
-const OutPort& JacoStatusReceiver::get_state_output_port() const {
-  return LeafSystem<double>::get_output_port(0);
-}
-const OutPort& JacoStatusReceiver::get_torque_output_port() const {
-  return LeafSystem<double>::get_output_port(1);
-}
-const OutPort& JacoStatusReceiver::get_torque_external_output_port() const {
-  return LeafSystem<double>::get_output_port(2);
-}
-const OutPort& JacoStatusReceiver::get_current_output_port() const {
-  return LeafSystem<double>::get_output_port(3);
+const systems::OutputPort<double>&
+JacoStatusReceiver::get_state_output_port() const {
+  return *state_output_;
 }
 
 void JacoStatusReceiver::CalcStateOutput(
@@ -77,8 +82,9 @@ void JacoStatusReceiver::CalcStateOutput(
 }
 
 template <std::vector<double> drake::lcmt_jaco_status::* arm_ptr,
-          std::vector<double> drake::lcmt_jaco_status::* finger_ptr>
-void JacoStatusReceiver::CalcLcmOutput(
+          std::vector<double> drake::lcmt_jaco_status::* finger_ptr,
+          int finger_scale>
+void JacoStatusReceiver::CalcJointOutput(
     const Context<double>& context, BasicVector<double>* output) const {
   const auto& status = get_input_port().Eval<lcmt_jaco_status>(context);
 
@@ -89,15 +95,17 @@ void JacoStatusReceiver::CalcLcmOutput(
     return;
   }
 
-  Eigen::VectorXd state(num_joints_ + num_fingers_);
+  Eigen::VectorXd output_vec(num_joints_ + num_fingers_);
   const auto& arm_field = status.*arm_ptr;
-  state.head(num_joints_) = Eigen::Map<const Eigen::VectorXd>(
+  output_vec.head(num_joints_) = Eigen::Map<const Eigen::VectorXd>(
       arm_field.data(), arm_field.size());
-
-  const auto& finger_field = status.*finger_ptr;
-  state.tail(num_fingers_) = Eigen::Map<const Eigen::VectorXd>(
-      finger_field.data(), finger_field.size());
-  output->get_mutable_value() = state;
+  if (num_fingers_) {
+    constexpr double scale_factor = finger_scale ? kFingerSdkToUrdf : 1;
+    const auto& finger_field = status.*finger_ptr;
+    output_vec.tail(num_fingers_) = Eigen::Map<const Eigen::VectorXd>(
+        finger_field.data(), finger_field.size()) * scale_factor;
+  }
+  output->SetFromVector(output_vec);
 }
 
 }  // namespace kinova_jaco

--- a/manipulation/kinova_jaco/jaco_status_receiver.h
+++ b/manipulation/kinova_jaco/jaco_status_receiver.h
@@ -19,20 +19,19 @@ namespace kinova_jaco {
 ///
 /// This system has one abstract-valued input port of type lcmt_jaco_status.
 ///
-/// This system has many vector-valued ouput ports. The state output port (q,
-/// v) will have (num_joints + num_fingers) * 2 elements.  Torque, torque
-/// external and current output ports will have num_joints + num_fingers
-/// elements.  The ports will output zeros until an input message is received.
-/// Finger velocities will be translated from the values used by the Kinova
-/// SDK to values appropriate for the finger joints in the Jaco description
-/// (see jaco_constants.h.)
+/// This system has many vector-valued output ports.  All output ports are of
+/// size num_joints + num_fingers.  The ports will output zeros until an input
+/// message is received.  Finger velocities will be translated from the values
+/// used by the Kinova SDK to values appropriate for the finger joints in the
+/// Jaco description (see jaco_constants.h.)
 //
 /// @system
 /// name: JacoStatusReceiver
 /// input_ports:
 /// - lcmt_jaco_status
 /// output_ports:
-/// - state
+/// - position
+/// - velocity
 /// - torque
 /// - torque_external
 /// - current
@@ -46,24 +45,50 @@ class JacoStatusReceiver : public systems::LeafSystem<double> {
   JacoStatusReceiver(int num_joints = kJacoDefaultArmNumJoints,
                      int num_fingers = kJacoDefaultArmNumFingers);
 
+  DRAKE_DEPRECATED("2022-08-01", "Use position/velocity output ports instead.")
+  const systems::OutputPort<double>& get_state_output_port() const;
+  DRAKE_DEPRECATED("2022-08-01", "Use torque_measured output port instead.")
+  const systems::OutputPort<double>& get_torque_output_port() const {
+    return *torque_measured_output_;
+  }
+
   /// @name Named accessors for this System's input and output ports.
   //@{
-  const systems::OutputPort<double>& get_state_output_port() const;
-  const systems::OutputPort<double>& get_torque_output_port() const;
-  const systems::OutputPort<double>& get_torque_external_output_port() const;
-  const systems::OutputPort<double>& get_current_output_port() const;
+  const systems::OutputPort<double>& get_position_measured_output_port() const {
+    return *position_measured_output_;
+  }
+  const systems::OutputPort<double>& get_velocity_measured_output_port() const {
+    return *velocity_measured_output_;
+  }
+  const systems::OutputPort<double>& get_torque_measured_output_port() const {
+    return *torque_measured_output_;
+  }
+  const systems::OutputPort<double>& get_torque_external_output_port() const {
+    return *torque_external_output_;
+  }
+  const systems::OutputPort<double>& get_current_output_port() const {
+    return *current_output_;
+  }
   //@}
 
  private:
   void CalcStateOutput(const systems::Context<double>&,
                        systems::BasicVector<double>*) const;
   template <std::vector<double> drake::lcmt_jaco_status::*,
-            std::vector<double> drake::lcmt_jaco_status::*>
-  void CalcLcmOutput(const systems::Context<double>&,
-                     systems::BasicVector<double>*) const;
+            std::vector<double> drake::lcmt_jaco_status::*,
+            int>
+  void CalcJointOutput(const systems::Context<double>&,
+                       systems::BasicVector<double>*) const;
 
   const int num_joints_;
   const int num_fingers_;
+  const systems::InputPort<double>* message_input_{};
+  const systems::OutputPort<double>* state_output_{};
+  const systems::OutputPort<double>* position_measured_output_{};
+  const systems::OutputPort<double>* velocity_measured_output_{};
+  const systems::OutputPort<double>* torque_measured_output_{};
+  const systems::OutputPort<double>* torque_external_output_{};
+  const systems::OutputPort<double>* current_output_{};
 };
 
 }  // namespace kinova_jaco

--- a/manipulation/kinova_jaco/jaco_status_sender.cc
+++ b/manipulation/kinova_jaco/jaco_status_sender.cc
@@ -1,44 +1,41 @@
 #include "drake/manipulation/kinova_jaco/jaco_status_sender.h"
 
+#include "drake/common/text_logging.h"
+
 namespace drake {
 namespace manipulation {
 namespace kinova_jaco {
 
+using drake::systems::kVectorValued;
+
 JacoStatusSender::JacoStatusSender(int num_joints, int num_fingers)
     : num_joints_(num_joints),
       num_fingers_(num_fingers) {
-  this->DeclareInputPort(
-      "state", systems::kVectorValued, (num_joints_ + num_fingers_) * 2);
-  this->DeclareInputPort(
-      "torque", systems::kVectorValued, num_joints_ + num_fingers_);
-  this->DeclareInputPort(
-      "torque_external", systems::kVectorValued, num_joints_ + num_fingers_);
-  this->DeclareInputPort(
-      "current", systems::kVectorValued, num_joints_ + num_fingers_);
-  this->DeclareAbstractOutputPort(
+  state_input_ = &DeclareInputPort(
+      "state", kVectorValued, (num_joints_ + num_fingers_) * 2);
+  position_input_ = &DeclareInputPort(
+      "position", kVectorValued, num_joints_ + num_fingers_);
+  velocity_input_ = &DeclareInputPort(
+      "velocity", kVectorValued, num_joints_ + num_fingers_);
+  torque_input_ = &DeclareInputPort(
+      "torque", kVectorValued, num_joints_ + num_fingers_);
+  torque_external_input_ = &DeclareInputPort(
+      "torque_external", kVectorValued, num_joints_ + num_fingers_);
+  current_input_ = &DeclareInputPort(
+      "current", kVectorValued, num_joints_ + num_fingers_);
+  DeclareAbstractOutputPort(
       "lcmt_jaco_status", &JacoStatusSender::CalcOutput);
 }
 
-using InPort = systems::InputPort<double>;
-const InPort& JacoStatusSender::get_state_input_port() const {
-  return LeafSystem<double>::get_input_port(0);
-}
-const InPort& JacoStatusSender::get_torque_input_port() const {
-  return LeafSystem<double>::get_input_port(1);
-}
-const InPort& JacoStatusSender::get_torque_external_input_port() const {
-  return LeafSystem<double>::get_input_port(2);
-}
-const InPort& JacoStatusSender::get_current_input_port() const {
-  return LeafSystem<double>::get_input_port(3);
+const systems::InputPort<double>&
+JacoStatusSender::get_state_input_port() const {
+  return *state_input_;
 }
 
 void JacoStatusSender::CalcOutput(
     const systems::Context<double>& context, lcmt_jaco_status* output) const {
   const Eigen::VectorXd zero_state =
       Eigen::VectorXd::Zero(num_joints_ + num_fingers_);
-  const auto& state =
-      get_state_input_port().Eval(context);
   const auto& torque =
       get_torque_input_port().HasValue(context) ?
       get_torque_input_port().Eval(context) :
@@ -61,16 +58,6 @@ void JacoStatusSender::CalcOutput(
   status.joint_torque.resize(num_joints_, 0);
   status.joint_torque_external.resize(num_joints_, 0);
   status.joint_current.resize(num_joints_, 0);
-  for (int i = 0; i < num_joints_; ++i) {
-    status.joint_position[i] = state(i);
-    // It seems like the Jaco reports half of the actual angular
-    // velocity.  Fix that up here.  Note bug-for-bug compatibility
-    // implemented in JacoStatusReceiver.
-    status.joint_velocity[i] = state(i + num_joints_ + num_fingers_) / 2;
-    status.joint_torque[i] = torque(i);
-    status.joint_torque_external[i] = torque_external(i);
-    status.joint_current[i] = current(i);
-  }
 
   status.num_fingers = num_fingers_;
   status.finger_position.resize(num_fingers_, 0);
@@ -78,12 +65,52 @@ void JacoStatusSender::CalcOutput(
   status.finger_torque.resize(num_fingers_, 0);
   status.finger_torque_external.resize(num_fingers_, 0);
   status.finger_current.resize(num_fingers_, 0);
+
+  if (state_input_->HasValue(context)) {
+    const auto& state = state_input_->Eval(context);
+    for (int i = 0; i < num_joints_; ++i) {
+      status.joint_position[i] = state(i);
+      // It seems like the Jaco reports half of the actual angular
+      // velocity.  Fix that up here.  Note bug-for-bug compatibility
+      // implemented in JacoStatusReceiver.
+      status.joint_velocity[i] = state(i + num_joints_ + num_fingers_) / 2;
+      status.joint_torque[i] = torque(i);
+      status.joint_torque_external[i] = torque_external(i);
+      status.joint_current[i] = current(i);
+    }
+
+    for (int i = 0; i < num_fingers_; ++i) {
+      status.finger_position[i] = state(i + num_joints_) * kFingerUrdfToSdk;
+      status.finger_velocity[i] =
+          state.tail(num_fingers_)(i) * kFingerUrdfToSdk;
+      status.finger_torque[i] = torque(num_joints_ + i);
+      status.finger_torque_external[i] = torque_external(num_joints_ + i);
+      status.finger_current[i] = current(num_joints_ + i);
+    }
+
+    return;
+  }
+
+  const auto& position = position_input_->Eval(context);
+  const auto& velocity = velocity_input_->Eval(context);
+
+  for (int i = 0; i < num_joints_; ++i) {
+    status.joint_position[i] = position(i);
+    // It seems like the Jaco (at least for some models/firmwares) reports
+    // half of the actual angular velocity.  Fix that up here.  Note
+    // bug-for-bug compatibility implemented in JacoStatusReceiver.
+    status.joint_velocity[i] = velocity(i) / 2;
+    status.joint_torque[i] = torque(i);
+    status.joint_torque_external[i] = torque_external(i);
+    status.joint_current[i] = current(i);
+  }
+
   for (int i = 0; i < num_fingers_; ++i) {
-    status.finger_position[i] = state(i + num_joints_) * kFingerUrdfToSdk;
-    status.finger_velocity[i] = state.tail(num_fingers_)(i) * kFingerUrdfToSdk;
-    status.finger_torque[i] = torque(i + num_joints_);
-    status.finger_torque_external[i] = torque_external(i + num_joints_);
-    status.finger_current[i] = current(i + num_joints_);
+    status.finger_position[i] = position(num_joints_ + i) * kFingerUrdfToSdk;
+    status.finger_velocity[i] = velocity(num_joints_ + i) * kFingerUrdfToSdk;
+    status.finger_torque[i] = torque(num_joints_ + i);
+    status.finger_torque_external[i] = torque_external(num_joints_ + i);
+    status.finger_current[i] = current(num_joints_ + i);
   }
 }
 

--- a/manipulation/kinova_jaco/test/jaco_command_receiver_test.cc
+++ b/manipulation/kinova_jaco/test/jaco_command_receiver_test.cc
@@ -11,11 +11,16 @@ namespace kinova_jaco {
 namespace {
 
 using Eigen::VectorXd;
+constexpr int N = kJacoDefaultArmNumJoints;
+constexpr int N_F = kJacoDefaultArmNumFingers;
 
-class JacoCommandReceiverTest : public testing::Test {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+class JacoCommandReceiverTestBase : public testing::Test {
  public:
-  JacoCommandReceiverTest()
-      : dut_(),
+  JacoCommandReceiverTestBase(int num_joints, int num_fingers)
+      : dut_(num_joints, num_fingers),
         context_ptr_(dut_.CreateDefaultContext()),
         context_(*context_ptr_),
         fixed_input_(FixInput()) {}
@@ -37,6 +42,14 @@ class JacoCommandReceiverTest : public testing::Test {
     return dut_.get_output_port().Eval(context_);
   }
 
+  VectorXd position() const {
+    return dut_.get_commanded_position_output_port().Eval(context_);
+  }
+
+  VectorXd velocity() const {
+    return dut_.get_commanded_velocity_output_port().Eval(context_);
+  }
+
  protected:
   JacoCommandReceiver dut_;
   std::unique_ptr<systems::Context<double>> context_ptr_;
@@ -44,8 +57,19 @@ class JacoCommandReceiverTest : public testing::Test {
   systems::FixedInputPortValue& fixed_input_;
 };
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+class JacoCommandReceiverTest : public JacoCommandReceiverTestBase {
+ public:
+  JacoCommandReceiverTest()
+      : JacoCommandReceiverTestBase(
+            kJacoDefaultArmNumJoints, kJacoDefaultArmNumFingers) {}
+};
+
+class JacoCommandReceiverNoFingersTest : public JacoCommandReceiverTestBase {
+ public:
+  JacoCommandReceiverNoFingersTest()
+      : JacoCommandReceiverTestBase(
+            kJacoDefaultArmNumJoints, 0) {}
+};
 
 TEST_F(JacoCommandReceiverTest, DeprecatedInitialPositionTest) {
   constexpr int total_dof =
@@ -64,115 +88,171 @@ TEST_F(JacoCommandReceiverTest, DeprecatedInitialPositionTest) {
 
 #pragma GCC diagnostic pop
 
-TEST_F(JacoCommandReceiverTest, AcceptanceTest) {
-  constexpr int total_dof =
-      kJacoDefaultArmNumJoints + kJacoDefaultArmNumFingers;
-
-  // Check that the commanded pose starts out at zero.
-  EXPECT_TRUE(CompareMatrices(state(), VectorXd::Zero(total_dof * 2)));
-
-  // Check that we can set a different initial position.
-  const VectorXd q0 = VectorXd::LinSpaced(total_dof, 0.1, 0.2);
-  dut_.get_position_measured_input_port().FixValue(&context_, q0);
-  EXPECT_TRUE(CompareMatrices(state().head(total_dof), q0));
-  EXPECT_TRUE(CompareMatrices(state().tail(total_dof),
-                              VectorXd::Zero(total_dof)));
-
-  // Check that a real command trumps the initial position.
-  const VectorXd q1_arm =
-      VectorXd::LinSpaced(kJacoDefaultArmNumJoints, 0.3, 0.4);
-  const VectorXd v1_arm =
-      VectorXd::LinSpaced(kJacoDefaultArmNumJoints, 0.5, 0.6);
-  const VectorXd q1_finger =
-      VectorXd::LinSpaced(kJacoDefaultArmNumFingers, 1.3, 1.4) *
-      kFingerUrdfToSdk;
-  const VectorXd v1_finger =
-      VectorXd::LinSpaced(kJacoDefaultArmNumFingers, 1.5, 1.6) *
-      kFingerUrdfToSdk;
-  lcmt_jaco_command command{};
-  command.utime = 0;
-  command.num_joints = kJacoDefaultArmNumJoints;
-  command.joint_position = {q1_arm.data(), q1_arm.data() + q1_arm.size()};
-  command.joint_velocity = {v1_arm.data(), v1_arm.data() + v1_arm.size()};
-  command.num_fingers = kJacoDefaultArmNumFingers;
-  command.finger_position =
-      {q1_finger.data(), q1_finger.data() + q1_finger.size()};
-  command.finger_velocity =
-      {v1_finger.data(), v1_finger.data() + v1_finger.size()};
-  SetInput(command);
-  EXPECT_TRUE(CompareMatrices(state().head(kJacoDefaultArmNumJoints), q1_arm));
-  EXPECT_TRUE(CompareMatrices(state().segment(
-      total_dof, kJacoDefaultArmNumJoints), v1_arm));
-
-  EXPECT_TRUE(CompareMatrices(state().segment(
-      kJacoDefaultArmNumJoints, kJacoDefaultArmNumFingers), q1_finger *
-                              kFingerSdkToUrdf));
-  EXPECT_TRUE(
-      CompareMatrices(state().tail(kJacoDefaultArmNumFingers),
-                      v1_finger * kFingerSdkToUrdf));
+TEST_F(JacoCommandReceiverTest, AcceptanceTestWithoutMeasuredPositionInput) {
+  // When no message has been received and *no* position measurement is
+  // connected, the command is all zeros.
+  const VectorXd zero = VectorXd::Zero(N + N_F);
+  EXPECT_TRUE(CompareMatrices(position(), zero));
+  EXPECT_TRUE(CompareMatrices(velocity(), zero));
 }
 
-TEST_F(JacoCommandReceiverTest, AcceptanceTestWithLatching) {
-  constexpr int total_dof =
-      kJacoDefaultArmNumJoints + kJacoDefaultArmNumFingers;
+TEST_F(JacoCommandReceiverNoFingersTest,
+       AcceptanceTestWithoutMeasuredPositionInputNoFingers) {
+  // When no message has been received and *no* position measurement is
+  // connected, the command is all zeros.
+  const VectorXd zero = VectorXd::Zero(N);
+  EXPECT_TRUE(CompareMatrices(position(), zero));
+  EXPECT_TRUE(CompareMatrices(velocity(), zero));
+}
 
-  // Check that the commanded pose starts out at zero.
-  EXPECT_TRUE(CompareMatrices(state(), VectorXd::Zero(total_dof * 2)));
+TEST_F(JacoCommandReceiverNoFingersTest,
+       AcceptanceTestWithMeasuredPositionInputNoFingers) {
+  const VectorXd zero = VectorXd::Zero(N);
 
-  // Check that we can set a different initial position.
-  const VectorXd q0 = VectorXd::LinSpaced(total_dof, 0.1, 0.2);
+  // When no message has been received and a measurement *is* connected, the
+  // command is to hold at the current position.
+  const VectorXd q0 = VectorXd::LinSpaced(N, 0.2, 0.3);
   dut_.get_position_measured_input_port().FixValue(&context_, q0);
-  EXPECT_TRUE(CompareMatrices(state().head(total_dof), q0));
-  EXPECT_TRUE(CompareMatrices(state().tail(total_dof),
-                              VectorXd::Zero(total_dof)));
+  EXPECT_TRUE(CompareMatrices(position(), q0));
+  EXPECT_TRUE(CompareMatrices(velocity(), zero));
+
+  // Check that a real command trumps the initial position.
+  const VectorXd q1 = VectorXd::LinSpaced(N, 0.3, 0.4);
+  const VectorXd v1 = VectorXd::LinSpaced(N, 0.5, 0.6);
+  lcmt_jaco_command command{};
+  command.utime = 0;
+  command.num_joints = N;
+  command.joint_position = {q1.data(), q1.data() + q1.size()};
+  command.joint_velocity = {v1.data(), v1.data() + v1.size()};
+  SetInput(command);
+  EXPECT_TRUE(CompareMatrices(position(), q1));
+  EXPECT_TRUE(CompareMatrices(velocity(), v1));
+}
+
+TEST_F(JacoCommandReceiverNoFingersTest,
+       AcceptanceTestWithLatchingNoFingers) {
+  const VectorXd zero = VectorXd::Zero(N);
+
+  // When no message has been received and a measurement *is* connected, the
+  // command is to hold at the current position.
+  const VectorXd q0 = VectorXd::LinSpaced(N, 0.0, 0.1);
+  dut_.get_position_measured_input_port().FixValue(&context_, q0);
+  EXPECT_TRUE(CompareMatrices(position(), q0));
+  EXPECT_TRUE(CompareMatrices(velocity(), zero));
 
   // Prior to any update events, changes to position_measured feed through.
-  const VectorXd q1 = VectorXd::LinSpaced(total_dof, 0.2, 0.3);
+  const VectorXd q1 = VectorXd::LinSpaced(N, 0.1, 0.2);
   dut_.get_position_measured_input_port().FixValue(&context_, q1);
-  EXPECT_TRUE(CompareMatrices(state().head(total_dof), q1));
-  EXPECT_TRUE(CompareMatrices(state().tail(total_dof),
-                              VectorXd::Zero(total_dof)));
+  EXPECT_TRUE(CompareMatrices(position(), q1));
+  EXPECT_TRUE(CompareMatrices(velocity(), zero));
 
   // Once an update event occurs, further changes to position_measured have no
   // effect.
-  const VectorXd q2 = VectorXd::LinSpaced(total_dof, 0.3, 0.4);
+  dut_.LatchInitialPosition(&context_);
+  const VectorXd q2 = VectorXd::LinSpaced(N, 0.3, 0.4);
   dut_.get_position_measured_input_port().FixValue(&context_, q2);
-  EXPECT_TRUE(CompareMatrices(state().head(total_dof), q2));
-  EXPECT_TRUE(CompareMatrices(state().tail(total_dof),
-                              VectorXd::Zero(total_dof)));
+  EXPECT_TRUE(CompareMatrices(position(), q1));
+  EXPECT_TRUE(CompareMatrices(velocity(), zero));
 
   // Check that a real command trumps the initial position.
-  const VectorXd q3_arm =
-      VectorXd::LinSpaced(kJacoDefaultArmNumJoints, 1.3, 1.4);
-  const VectorXd v3_arm =
-      VectorXd::LinSpaced(kJacoDefaultArmNumJoints, 1.5, 1.6);
-  const VectorXd q3_finger =
-      VectorXd::LinSpaced(kJacoDefaultArmNumFingers, 2.3, 2.4) *
-      kFingerUrdfToSdk;
-  const VectorXd v3_finger =
-      VectorXd::LinSpaced(kJacoDefaultArmNumFingers, 2.5, 2.6) *
-      kFingerUrdfToSdk;
+  const VectorXd q3 = VectorXd::LinSpaced(N, 0.4, 0.5);
+  const VectorXd v3 = VectorXd::LinSpaced(N, 0.5, 0.6);
   lcmt_jaco_command command{};
   command.utime = 0;
-  command.num_joints = kJacoDefaultArmNumJoints;
-  command.joint_position = {q3_arm.data(), q3_arm.data() + q3_arm.size()};
-  command.joint_velocity = {v3_arm.data(), v3_arm.data() + v3_arm.size()};
-  command.num_fingers = kJacoDefaultArmNumFingers;
-  command.finger_position =
-      {q3_finger.data(), q3_finger.data() + q3_finger.size()};
-  command.finger_velocity =
-      {v3_finger.data(), v3_finger.data() + v3_finger.size()};
+  command.num_joints = N;
+  command.joint_position = {q3.data(), q3.data() + q3.size()};
+  command.joint_velocity = {v3.data(), v3.data() + v3.size()};
   SetInput(command);
-  EXPECT_TRUE(CompareMatrices(state().head(kJacoDefaultArmNumJoints), q3_arm));
-  EXPECT_TRUE(CompareMatrices(state().segment(
-      total_dof, kJacoDefaultArmNumJoints), v3_arm));
+  EXPECT_TRUE(CompareMatrices(position(), q3));
+  EXPECT_TRUE(CompareMatrices(velocity(), v3));
+}
 
-  EXPECT_TRUE(CompareMatrices(state().segment(
-      kJacoDefaultArmNumJoints, kJacoDefaultArmNumFingers), q3_finger *
-                              kFingerSdkToUrdf));
-  EXPECT_TRUE(
-      CompareMatrices(state().tail(kJacoDefaultArmNumFingers),
-                      v3_finger * kFingerSdkToUrdf));
+TEST_F(JacoCommandReceiverTest,
+       AcceptanceTestWithMeasuredPositionInput) {
+  const VectorXd zero = VectorXd::Zero(N + N_F);
+
+  // When no message has been received and a measurement *is* connected, the
+  // command is to hold at the current position.
+  const VectorXd q0 = VectorXd::LinSpaced(N + N_F, 0.2, 0.3);
+  dut_.get_position_measured_input_port().FixValue(&context_, q0);
+  EXPECT_TRUE(CompareMatrices(position(), q0));
+  EXPECT_TRUE(CompareMatrices(velocity(), zero));
+
+  // Check that a real command trumps the initial position.
+  const VectorXd q1 = VectorXd::LinSpaced(N, 0.3, 0.4);
+  const VectorXd v1 = VectorXd::LinSpaced(N, 0.5, 0.6);
+  const VectorXd f_q1 = VectorXd::LinSpaced(N_F, 1.3, 1.4);
+  const VectorXd f_v1 = VectorXd::LinSpaced(N_F, 1.5, 1.6);
+  lcmt_jaco_command command{};
+  command.utime = 0;
+  command.num_joints = N;
+  command.joint_position = {q1.data(), q1.data() + q1.size()};
+  command.joint_velocity = {v1.data(), v1.data() + v1.size()};
+  command.num_fingers = N_F;
+  command.finger_position = {f_q1.data(), f_q1.data() + f_q1.size()};
+  command.finger_velocity = {f_v1.data(), f_v1.data() + f_v1.size()};
+  SetInput(command);
+
+  VectorXd position_expected(N + N_F);
+  position_expected.head(N) = q1;
+  position_expected.tail(N_F) = f_q1 * kFingerSdkToUrdf;
+
+  VectorXd velocity_expected(N + N_F);
+  velocity_expected.head(N) = v1;
+  velocity_expected.tail(N_F) = f_v1 * kFingerSdkToUrdf;
+
+  EXPECT_TRUE(CompareMatrices(position(), position_expected));
+  EXPECT_TRUE(CompareMatrices(velocity(), velocity_expected));
+}
+
+TEST_F(JacoCommandReceiverTest, AcceptanceTestWithLatching) {
+  const VectorXd zero = VectorXd::Zero(N + N_F);
+
+  // When no message has been received and a measurement *is* connected, the
+  // command is to hold at the current position.
+  const VectorXd q0 = VectorXd::LinSpaced(N + N_F, 0.0, 0.1);
+  dut_.get_position_measured_input_port().FixValue(&context_, q0);
+  EXPECT_TRUE(CompareMatrices(position(), q0));
+  EXPECT_TRUE(CompareMatrices(velocity(), zero));
+
+  // Prior to any update events, changes to position_measured feed through.
+  const VectorXd q1 = VectorXd::LinSpaced(N + N_F, 0.1, 0.2);
+  dut_.get_position_measured_input_port().FixValue(&context_, q1);
+  EXPECT_TRUE(CompareMatrices(position(), q1));
+  EXPECT_TRUE(CompareMatrices(velocity(), zero));
+
+  // Once an update event occurs, further changes to position_measured have no
+  // effect.
+  dut_.LatchInitialPosition(&context_);
+  const VectorXd q2 = VectorXd::LinSpaced(N + N_F, 0.3, 0.4);
+  dut_.get_position_measured_input_port().FixValue(&context_, q2);
+  EXPECT_TRUE(CompareMatrices(position(), q1));
+  EXPECT_TRUE(CompareMatrices(velocity(), zero));
+
+  // Check that a real command trumps the initial position.
+  const VectorXd q3 = VectorXd::LinSpaced(N, 0.4, 0.5);
+  const VectorXd v3 = VectorXd::LinSpaced(N, 0.5, 0.6);
+  const VectorXd f_q3 = VectorXd::LinSpaced(N_F, 0.4, 0.5);
+  const VectorXd f_v3 = VectorXd::LinSpaced(N_F, 1.5, 1.6);
+  lcmt_jaco_command command{};
+  command.utime = 0;
+  command.num_joints = N;
+  command.num_fingers = N_F;
+  command.joint_position = {q3.data(), q3.data() + q3.size()};
+  command.joint_velocity = {v3.data(), v3.data() + v3.size()};
+  command.finger_position = {f_q3.data(), f_q3.data() + f_q3.size()};
+  command.finger_velocity = {f_v3.data(), f_v3.data() + f_v3.size()};
+  SetInput(command);
+
+  VectorXd position_expected(N + N_F);
+  position_expected.head(N) = q3;
+  position_expected.tail(N_F) = f_q3 * kFingerSdkToUrdf;
+
+  VectorXd velocity_expected(N + N_F);
+  velocity_expected.head(N) = v3;
+  velocity_expected.tail(N_F) = f_v3 * kFingerSdkToUrdf;
+  EXPECT_TRUE(CompareMatrices(position(), position_expected));
+  EXPECT_TRUE(CompareMatrices(velocity(), velocity_expected));
 }
 
 }  // namespace

--- a/manipulation/kinova_jaco/test/jaco_command_sender_test.cc
+++ b/manipulation/kinova_jaco/test/jaco_command_sender_test.cc
@@ -11,11 +11,13 @@ namespace kinova_jaco {
 namespace {
 
 using Eigen::VectorXd;
+constexpr int N = kJacoDefaultArmNumJoints;
+constexpr int N_F = kJacoDefaultArmNumFingers;
 
-class JacoCommandSenderTest : public testing::Test {
+class JacoCommandSenderTestBase : public testing::Test {
  public:
-  JacoCommandSenderTest()
-      : dut_(),
+  JacoCommandSenderTestBase(int num_joints, int num_fingers)
+      : dut_(num_joints, num_fingers),
         context_ptr_(dut_.CreateDefaultContext()),
         context_(*context_ptr_) {}
 
@@ -29,11 +31,28 @@ class JacoCommandSenderTest : public testing::Test {
   systems::Context<double>& context_;
 };
 
+class JacoCommandSenderTest : public JacoCommandSenderTestBase {
+ public:
+  JacoCommandSenderTest()
+      : JacoCommandSenderTestBase(
+            kJacoDefaultArmNumJoints, kJacoDefaultArmNumFingers) {}
+};
+
+class JacoCommandSenderNoFingersTest : public JacoCommandSenderTestBase {
+ public:
+  JacoCommandSenderNoFingersTest()
+      : JacoCommandSenderTestBase(
+            kJacoDefaultArmNumJoints, 0) {}
+};
+
 const std::vector<double> ToStdVec(const Eigen::VectorXd& in) {
   return std::vector<double>{in.data(), in.data() + in.size()};
 }
 
-TEST_F(JacoCommandSenderTest, AcceptanceTest) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+TEST_F(JacoCommandSenderTest, DeprecatedAcceptanceTest) {
   constexpr int total_dof =
       kJacoDefaultArmNumJoints + kJacoDefaultArmNumFingers;
   const VectorXd state =
@@ -52,6 +71,36 @@ TEST_F(JacoCommandSenderTest, AcceptanceTest) {
   EXPECT_EQ(output().finger_velocity,
             ToStdVec(state.tail(kJacoDefaultArmNumFingers)
                      * kFingerUrdfToSdk));
+}
+#pragma GCC diagnostic pop
+
+TEST_F(JacoCommandSenderTest, AcceptanceTestWithFingers) {
+  const VectorXd q0 = VectorXd::LinSpaced(N + N_F, 0.2, 0.3);
+  const VectorXd v0 = VectorXd::LinSpaced(N + N_F, 0.3, 0.4);
+
+  dut_.get_position_input_port().FixValue(&context_, q0);
+  dut_.get_velocity_input_port().FixValue(&context_, v0);
+
+  EXPECT_EQ(output().num_joints, kJacoDefaultArmNumJoints);
+  EXPECT_EQ(output().joint_position, ToStdVec(q0.head(N)));
+  EXPECT_EQ(output().joint_velocity, ToStdVec(v0.head(N)));
+  EXPECT_EQ(output().num_fingers, kJacoDefaultArmNumFingers);
+  EXPECT_EQ(output().finger_position,
+            ToStdVec(q0.tail(N_F) * kFingerUrdfToSdk));
+  EXPECT_EQ(output().finger_velocity,
+            ToStdVec(v0.tail(N_F) * kFingerUrdfToSdk));
+}
+
+TEST_F(JacoCommandSenderNoFingersTest, AcceptanceNoFingers) {
+  const VectorXd q0 = VectorXd::LinSpaced(N, 0.2, 0.3);
+  const VectorXd v0 = VectorXd::LinSpaced(N, 0.3, 0.4);
+
+  dut_.get_position_input_port().FixValue(&context_, q0);
+  dut_.get_velocity_input_port().FixValue(&context_, v0);
+
+  EXPECT_EQ(output().num_joints, kJacoDefaultArmNumJoints);
+  EXPECT_EQ(output().joint_position, ToStdVec(q0));
+  EXPECT_EQ(output().joint_velocity, ToStdVec(v0));
 }
 
 }  // namespace

--- a/manipulation/kinova_jaco/test/jaco_status_sender_test.cc
+++ b/manipulation/kinova_jaco/test/jaco_status_sender_test.cc
@@ -11,34 +11,18 @@ namespace kinova_jaco {
 namespace {
 
 using Eigen::VectorXd;
+constexpr int N = kJacoDefaultArmNumJoints;
+constexpr int N_F = kJacoDefaultArmNumFingers;
 
-class JacoStatusSenderTest : public testing::Test {
+class JacoStatusSenderTestBase : public testing::Test {
  public:
-  JacoStatusSenderTest()
-      : dut_(),
+  JacoStatusSenderTestBase(int num_joints, int num_fingers)
+      : dut_(num_joints, num_fingers),
         context_ptr_(dut_.CreateDefaultContext()),
         context_(*context_ptr_) {}
 
   const lcmt_jaco_status& output() const {
-    const lcmt_jaco_status& result =
-        dut_.get_output_port().Eval<lcmt_jaco_status>(context_);
-    DRAKE_DEMAND(result.num_joints == kJacoDefaultArmNumJoints);
-    DRAKE_DEMAND(result.joint_position.size() == kJacoDefaultArmNumJoints);
-    DRAKE_DEMAND(result.joint_velocity.size() == kJacoDefaultArmNumJoints);
-    DRAKE_DEMAND(result.joint_torque.size() == kJacoDefaultArmNumJoints);
-    DRAKE_DEMAND(
-        result.joint_torque_external.size() == kJacoDefaultArmNumJoints);
-    DRAKE_DEMAND(result.num_fingers == kJacoDefaultArmNumFingers);
-    DRAKE_DEMAND(result.finger_position.size() == kJacoDefaultArmNumFingers);
-    DRAKE_DEMAND(result.finger_velocity.size() == kJacoDefaultArmNumFingers);
-    DRAKE_DEMAND(result.finger_torque.size() == kJacoDefaultArmNumFingers);
-    DRAKE_DEMAND(
-        result.finger_torque_external.size() == kJacoDefaultArmNumFingers);
-    return result;
-  }
-
-  static std::vector<double> as_vector(const Eigen::VectorXd& v) {
-    return {v.data(), v.data() + v.size()};
+    return dut_.get_output_port().Eval<lcmt_jaco_status>(context_);
   }
 
   void Fix(const systems::InputPort<double>& port, const Eigen::VectorXd& v) {
@@ -51,9 +35,29 @@ class JacoStatusSenderTest : public testing::Test {
   systems::Context<double>& context_;
 };
 
-TEST_F(JacoStatusSenderTest, AcceptanceTest) {
-  constexpr int total_dof =
-      kJacoDefaultArmNumJoints + kJacoDefaultArmNumFingers;
+class JacoStatusSenderTest : public JacoStatusSenderTestBase {
+ public:
+  JacoStatusSenderTest()
+      : JacoStatusSenderTestBase(
+            kJacoDefaultArmNumJoints, kJacoDefaultArmNumFingers) {}
+};
+
+class JacoStatusSenderNoFingersTest : public JacoStatusSenderTestBase {
+ public:
+  JacoStatusSenderNoFingersTest()
+      : JacoStatusSenderTestBase(
+            kJacoDefaultArmNumJoints, 0) {}
+};
+
+const std::vector<double> ToStdVec(const Eigen::VectorXd& in) {
+  return std::vector<double>{in.data(), in.data() + in.size()};
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+TEST_F(JacoStatusSenderTest, DeprecatedAcceptanceTest) {
+  constexpr int total_dof = N + N_F;
 
   const VectorXd state = VectorXd::LinSpaced(total_dof * 2, 0.0, 1.0);
   const VectorXd torque = VectorXd::LinSpaced(total_dof, 2.0, 3.0);
@@ -65,15 +69,15 @@ TEST_F(JacoStatusSenderTest, AcceptanceTest) {
 
   // ... so that some outputs have passthrough values ...
   EXPECT_EQ(output().joint_position,
-            as_vector(state.head(kJacoDefaultArmNumJoints)));
+            ToStdVec(state.head(kJacoDefaultArmNumJoints)));
   EXPECT_EQ(output().joint_velocity,
-            as_vector(state.segment(total_dof, kJacoDefaultArmNumJoints) / 2));
+            ToStdVec(state.segment(total_dof, kJacoDefaultArmNumJoints) / 2));
   EXPECT_EQ(output().finger_position,
-            as_vector(
+            ToStdVec(
                 state.segment(kJacoDefaultArmNumJoints,
                               kJacoDefaultArmNumFingers) * kFingerUrdfToSdk));
   EXPECT_EQ(output().finger_velocity,
-            as_vector(
+            ToStdVec(
                 state.tail(kJacoDefaultArmNumFingers) * kFingerUrdfToSdk));
   // ... and some outputs have default values.
   EXPECT_EQ(output().joint_torque,
@@ -96,17 +100,72 @@ TEST_F(JacoStatusSenderTest, AcceptanceTest) {
 
   // ... so all ouputs have values.
   EXPECT_EQ(output().joint_torque,
-            as_vector(torque.head(kJacoDefaultArmNumJoints)));
+            ToStdVec(torque.head(kJacoDefaultArmNumJoints)));
   EXPECT_EQ(output().joint_torque_external,
-            as_vector(torque_external.head(kJacoDefaultArmNumJoints)));
+            ToStdVec(torque_external.head(kJacoDefaultArmNumJoints)));
   EXPECT_EQ(output().joint_current,
-            as_vector(current.head(kJacoDefaultArmNumJoints)));
+            ToStdVec(current.head(kJacoDefaultArmNumJoints)));
   EXPECT_EQ(output().finger_torque,
-            as_vector(torque.tail(kJacoDefaultArmNumFingers)));
+            ToStdVec(torque.tail(kJacoDefaultArmNumFingers)));
   EXPECT_EQ(output().finger_torque_external,
-            as_vector(torque_external.tail(kJacoDefaultArmNumFingers)));
+            ToStdVec(torque_external.tail(kJacoDefaultArmNumFingers)));
   EXPECT_EQ(output().finger_current,
-            as_vector(current.tail(kJacoDefaultArmNumFingers)));
+            ToStdVec(current.tail(kJacoDefaultArmNumFingers)));
+}
+
+#pragma GCC diagnostic pop
+
+TEST_F(JacoStatusSenderTest, AcceptanceTestWithFingers) {
+  const VectorXd q0 = VectorXd::LinSpaced(N + N_F, 0.2, 0.3);
+  const VectorXd v0 = VectorXd::LinSpaced(N + N_F, 0.3, 0.4);
+  const VectorXd zero = VectorXd::Zero(N);
+  const VectorXd finger_zero = VectorXd::Zero(N_F);
+
+  dut_.get_position_input_port().FixValue(&context_, q0);
+  dut_.get_velocity_input_port().FixValue(&context_, v0);
+
+  EXPECT_EQ(output().num_joints, kJacoDefaultArmNumJoints);
+  EXPECT_EQ(output().joint_position, ToStdVec(q0.head(N)));
+  EXPECT_EQ(output().joint_velocity, ToStdVec(v0.head(N) / 2));
+  EXPECT_EQ(output().num_fingers, kJacoDefaultArmNumFingers);
+  EXPECT_EQ(output().finger_position,
+            ToStdVec(q0.tail(N_F) * kFingerUrdfToSdk));
+  EXPECT_EQ(output().finger_velocity,
+            ToStdVec(v0.tail(N_F) * kFingerUrdfToSdk));
+  EXPECT_EQ(output().joint_torque, ToStdVec(zero));
+  EXPECT_EQ(output().joint_torque_external, ToStdVec(zero));
+  EXPECT_EQ(output().joint_current, ToStdVec(zero));
+  EXPECT_EQ(output().finger_torque, ToStdVec(finger_zero));
+  EXPECT_EQ(output().finger_torque_external, ToStdVec(finger_zero));
+  EXPECT_EQ(output().finger_current, ToStdVec(finger_zero));
+
+  const VectorXd t1 = VectorXd::LinSpaced(N + N_F, 0.4, 0.5);
+  const VectorXd t_ext1 = VectorXd::LinSpaced(N + N_F, 0.5, 0.6);
+  const VectorXd current1 = VectorXd::LinSpaced(N + N_F, 0.6, 0.7);
+
+  dut_.get_torque_input_port().FixValue(&context_, t1);
+  dut_.get_torque_external_input_port().FixValue(&context_, t_ext1);
+  dut_.get_current_input_port().FixValue(&context_, current1);
+
+  EXPECT_EQ(output().joint_torque, ToStdVec(t1.head(N)));
+  EXPECT_EQ(output().joint_torque_external, ToStdVec(t_ext1.head(N)));
+  EXPECT_EQ(output().joint_current, ToStdVec(current1.head(N)));
+  EXPECT_EQ(output().finger_torque, ToStdVec(t1.tail(N_F)));
+  EXPECT_EQ(output().finger_torque_external, ToStdVec(t_ext1.tail(N_F)));
+  EXPECT_EQ(output().finger_current, ToStdVec(current1.tail(N_F)));
+}
+
+TEST_F(JacoStatusSenderNoFingersTest, AcceptanceNoFingers) {
+  const VectorXd q0 = VectorXd::LinSpaced(N, 0.2, 0.3);
+  const VectorXd v0 = VectorXd::LinSpaced(N, 0.3, 0.4);
+
+  dut_.get_position_input_port().FixValue(&context_, q0);
+  dut_.get_velocity_input_port().FixValue(&context_, v0);
+
+  EXPECT_EQ(output().num_joints, kJacoDefaultArmNumJoints);
+  EXPECT_EQ(output().joint_position, ToStdVec(q0));
+  EXPECT_EQ(output().joint_velocity, ToStdVec(v0 / 2));
+  EXPECT_EQ(output().num_fingers, 0);
 }
 
 }  // namespace


### PR DESCRIPTION
Splits the position and velocity ports in the Jaco LCM interface to
better match other robots' LCM systems (e.g. iiwa).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16863)
<!-- Reviewable:end -->
