### PR TITLE
[fem] Simplify external force/gravity calculation

### DIFF
--- a/multibody/fem/fem_model.h
+++ b/multibody/fem/fem_model.h
@@ -41,9 +41,10 @@ namespace fem {
      R(X,t)J(X,t) = R(X,0),
      R(X,0)A(X,t) = fᵢₙₜ(X,t) + fₑₓₜ(X,t),
 
- where R is mass density, fᵢₙₜ and fₑₓₜ are internal and external force
- densities respectively, and J is the determinant of the deformation gradient.
- Using finite element method to discretize in space, one gets
+ where R is mass density, fᵢₙₜ and fₑₓₜ are internal and external force (only
+ gravity for now) densities respectively, and J is the determinant of the
+ deformation gradient. Using finite element method to discretize in space, one
+ gets
 
      ϕ(X,t) = ∑ᵢ xᵢ(t)Nᵢ(X)
      V(X,t) = ∑ᵢ vᵢ(t)Nᵢ(X)
@@ -165,6 +166,12 @@ class FemModel {
   std::unique_ptr<internal::PetscSymmetricBlockSparseMatrix>
   MakePetscSymmetricBlockSparseTangentMatrix() const;
 
+  /** Sets the gravity vector for all elements in this model. */
+  void set_gravity_vector(const Vector3<T>& gravity) { gravity_ = gravity; }
+
+  /** Returns the gravity vector for all elements in this model. */
+  const Vector3<T>& gravity_vector() const { return gravity_; }
+
  protected:
   /** Constructs an empty FEM model. */
   FemModel();
@@ -180,7 +187,7 @@ class FemModel {
   /** FemModelImpl must override this method to provide an implementation
    for the NVI CalcResidual(). The input `fem_state` is guaranteed to be
    compatible with `this` FEM model, and the input `residual` is guaranteed to
-   be non-null. */
+   be non-null and properly sized. */
   virtual void DoCalcResidual(const FemState<T>& fem_state,
                               EigenPtr<VectorX<T>> residual) const = 0;
 
@@ -217,6 +224,7 @@ class FemModel {
   /* The system that manages the states and cache entries of this FEM model.
    */
   std::unique_ptr<internal::FemStateSystem<T>> fem_state_system_;
+  Vector3<T> gravity_{0, 0, -9.81};
 };
 
 }  // namespace fem

--- a/multibody/fem/test/fem_model_test.cc
+++ b/multibody/fem/test/fem_model_test.cc
@@ -46,8 +46,10 @@ GTEST_TEST(FemModelTest, CalcResidual) {
   fem_state->SetVelocities(VectorXd::Zero(model.num_dofs()));
   fem_state->SetAccelerations(VectorXd::Zero(model.num_dofs()));
   VectorXd expected_residual = VectorXd::Zero(model.num_dofs());
-  expected_residual.head<DummyElement::kNumDofs>() += DummyElement::residual();
-  expected_residual.tail<DummyElement::kNumDofs>() += DummyElement::residual();
+  expected_residual.head<DummyElement::kNumDofs>() +=
+      DummyElement::inverse_dynamics_force();
+  expected_residual.tail<DummyElement::kNumDofs>() +=
+      DummyElement::inverse_dynamics_force();
 
   model.CalcResidual(*fem_state, &residual);
   /* The residual for each element is set to a dummy value if all states are
@@ -147,6 +149,13 @@ GTEST_TEST(FemModelTest, MultipleBuilders) {
   /* Reusing builder throws an exception. */
   DRAKE_EXPECT_THROWS_MESSAGE(builder0.AddElementWithDistinctNodes(),
                               "Build.* has been called.*");
+}
+
+GTEST_TEST(FemModelTest, Gravity) {
+  DummyModel model;
+  EXPECT_EQ(model.gravity_vector(), Vector3<double>(0, 0, -9.81));
+  model.set_gravity_vector(Vector3<double>(1, 2, 3));
+  EXPECT_EQ(model.gravity_vector(), Vector3<double>(1, 2, 3));
 }
 
 }  // namespace

--- a/multibody/fem/test/volumetric_element_test.cc
+++ b/multibody/fem/test/volumetric_element_test.cc
@@ -216,15 +216,6 @@ class VolumetricElementTest : public ::testing::Test {
     return mass_matrix;
   }
 
-  /* Returns the gravity force acting on the nodes of the only element with
-   the given `fem_state`. */
-  Vector<AD, kNumDofs> CalcGravityForce(const FemState<AD>& fem_state) const {
-    Vector<AD, kNumDofs> gravity_force = Vector<AD, kNumDofs>::Zero();
-    element().AddScaledGravityForce(EvalElementData(fem_state), 1.0,
-                                    &gravity_force);
-    return gravity_force;
-  }
-
   unique_ptr<FemStateSystem<AD>> fem_state_system_;
   systems::CacheIndex cache_index_;
   std::vector<ElementType> elements_;
@@ -354,24 +345,23 @@ TEST_F(VolumetricElementTest, MassMatrixSumUpToTotalMass) {
   EXPECT_NEAR(mass_matrix_sum, total_mass * kSpatialDimension, kEpsilon);
 }
 
-/* Tests that the gravity forces match the expected value. */
-TEST_F(VolumetricElementTest, Gravity) {
-  unique_ptr<FemState<AD>> reference_fem_state = MakeReferenceState();
-  const Eigen::Matrix<AD, kNumDofs, kNumDofs>& mass_matrix =
-      CalcMassMatrix(*reference_fem_state);
-  Vector<AD, kNumDofs> element_gravity_acceleration;
-  for (int i = 0; i < kNumNodes; ++i) {
-    element_gravity_acceleration.template segment<kSpatialDimension>(
-        i * kSpatialDimension) = element().gravity_vector();
-  }
-  const Vector<AD, kNumDofs> expected_gravity_force =
-      mass_matrix * element_gravity_acceleration;
-
-  EXPECT_TRUE(CompareMatrices(expected_gravity_force,
-                              CalcGravityForce(*reference_fem_state)));
-  unique_ptr<FemState<AD>> deformed_fem_state = MakeDeformedState();
-  EXPECT_TRUE(CompareMatrices(expected_gravity_force,
-                              CalcGravityForce(*deformed_fem_state)));
+TEST_F(VolumetricElementTest, AddScaledGravityForce) {
+  const Vector3<AD> gravity_vector(1, 2, 3);
+  VectorX<AD> scaled_gravity_force = VectorX<AD>::Zero(kNumDofs);
+  const double scale = 2.0;
+  unique_ptr<FemState<AD>> fem_state = MakeDeformedState();
+  const Data& data = EvalElementData(*fem_state);
+  /* Calculate the gravity force using the implementation in VolumetricElement.
+   */
+  element().AddScaledGravityForce(data, scale, gravity_vector,
+                                  &scaled_gravity_force);
+  /* Use the implementation in the base class as the reference. */
+  VectorX<AD> expected_scaled_gravity_force = VectorX<AD>::Zero(kNumDofs);
+  const FemElement<ElementType>& base_fem_element = element();
+  base_fem_element.AddScaledGravityForce(data, scale, gravity_vector,
+                                         &expected_scaled_gravity_force);
+  EXPECT_TRUE(CompareMatrices(expected_scaled_gravity_force,
+                              scaled_gravity_force, kEpsilon));
 }
 
 }  // namespace

--- a/multibody/fem/volumetric_element.h
+++ b/multibody/fem/volumetric_element.h
@@ -238,6 +238,21 @@ class VolumetricElement
     return elastic_energy;
   }
 
+  /* Computes the scaled gravity force on each node in the element using the
+   pre-calculated mass matrix with the given `gravity_vector`. */
+  void AddScaledGravityForce(const Data&, const T& scale,
+                             const Vector3<T>& gravity_vector,
+                             EigenPtr<Vector<T, num_dofs>> force) const {
+    constexpr int kDim = 3;
+    for (int a = 0; a < num_nodes; ++a) {
+      /* The following computation is equivalent to performing the matrix-vector
+       multiplication of the mass matrix and the stacked gravity vector. */
+      force->template segment<kDim>(kDim * a) +=
+          scale * lumped_mass_.template segment<kDim>(kDim * a).cwiseProduct(
+                      gravity_vector);
+    }
+  }
+
  private:
   /* Friend the base class so that FemElement::DoFoo() can reach its
    implementation. */
@@ -357,16 +372,14 @@ class VolumetricElement
     }
   }
 
-  /* Implements FemElement::CalcResidual(). */
-  void DoCalcResidual(const Data& data,
-                      EigenPtr<Vector<T, num_dofs>> residual) const {
-    /* residual = Ma-fₑ(x)-fᵥ(x, v)-fₑₓₜ, where M is the mass matrix, fₑ(x) is
-     the elastic force, fᵥ(x, v) is the damping force and fₑₓₜ is the external
-     force. */
+  /* Implements FemElement::CalcInternalResidual(). */
+  void DoCalcInternalResidual(const Data& data,
+                              EigenPtr<Vector<T, num_dofs>> residual) const {
+    /* residual = Ma-fₑ(x)-fᵥ(x, v), where M is the mass matrix, fₑ(x) is
+     the elastic force, and fᵥ(x, v) is the damping force. */
     *residual += mass_matrix_ * data.element_a;
     this->AddNegativeElasticForce(data, residual);
     AddNegativeDampingForce(data, residual);
-    this->AddScaledExternalForce(data, -1.0, residual);
   }
 
   /* Implements FemElement::DoAddScaledStiffnessMatrix().
@@ -464,20 +477,6 @@ class VolumetricElement
       }
     }
     return mass_matrix;
-  }
-
-  /* Computes the gravity force on each node in the element using the stored
-   mass and gravity vector. */
-  void AddScaledGravityForce(const Data&, const T& scale,
-                             EigenPtr<Vector<T, num_dofs>> force) const {
-    constexpr int kDim = 3;
-    for (int a = 0; a < num_nodes; ++a) {
-      /* The following computation is equivalent to performing the matrix-vector
-       multiplication of the mass matrix and the stacked gravity vector. */
-      force->template segment<kDim>(kDim * a) +=
-          scale * lumped_mass_.template segment<kDim>(kDim * a).cwiseProduct(
-                      this->gravity_vector());
-    }
   }
 
   // TODO(xuchenhan-tri): Consider bumping this up into FemElement when new


### PR DESCRIPTION
Remove gravity vector stored in FemElement and refer to the one in the FemModel for single source of truth.
Separate calculations for external forces and the rest of residual.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16883)
<!-- Reviewable:end -->
