### PR TITLE
[fem] Rename FemModel::ThrowModelDataIncompatible

### DIFF
--- a/multibody/fem/fem_model.cc
+++ b/multibody/fem/fem_model.cc
@@ -31,7 +31,7 @@ void FemModel<T>::CalcResidual(const FemState<T>& fem_state,
                                EigenPtr<VectorX<T>> residual) const {
   DRAKE_DEMAND(residual != nullptr);
   DRAKE_DEMAND(residual->size() == num_dofs());
-  ThrowIfModelDataIncompatible(__func__, fem_state);
+  ThrowIfModelStateIncompatible(__func__, fem_state);
   DoCalcResidual(fem_state, residual);
 }
 
@@ -42,7 +42,7 @@ void FemModel<T>::CalcTangentMatrix(
   DRAKE_DEMAND(tangent_matrix != nullptr);
   DRAKE_DEMAND(tangent_matrix->rows() == num_dofs());
   DRAKE_DEMAND(tangent_matrix->cols() == num_dofs());
-  ThrowIfModelDataIncompatible(__func__, fem_state);
+  ThrowIfModelStateIncompatible(__func__, fem_state);
   DoCalcTangentMatrix(fem_state, weights, tangent_matrix);
 }
 
@@ -58,7 +58,7 @@ FemModel<T>::FemModel()
           VectorX<T>(0), VectorX<T>(0), VectorX<T>(0))) {}
 
 template <typename T>
-void FemModel<T>::ThrowIfModelDataIncompatible(
+void FemModel<T>::ThrowIfModelStateIncompatible(
     const char* func, const FemState<T>& fem_state) const {
   if (!fem_state.is_created_from_system(*fem_state_system_)) {
     throw std::logic_error(std::string(func) +

--- a/multibody/fem/fem_model.h
+++ b/multibody/fem/fem_model.h
@@ -171,8 +171,8 @@ class FemModel {
 
   /** (Internal use only) Throws std::exception to report a mismatch between
   the FEM model and state that were passed to API method `func`. */
-  void ThrowIfModelDataIncompatible(const char* func,
-                                    const FemState<T>& fem_state) const;
+  void ThrowIfModelStateIncompatible(const char* func,
+                                     const FemState<T>& fem_state) const;
 
   /** Returns the reference positions of this model. */
   virtual VectorX<T> MakeReferencePositions() const = 0;


### PR DESCRIPTION
In a recent refactor, we abandoned FemData in favor of FemState. The name of this function was accidentally left behind.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16888)
<!-- Reviewable:end -->
