### PR TITLE
LinearConstraint stores a sparse matrix A.

### DIFF
--- a/bindings/pydrake/common/test_utilities/scipy_stub/scipy/sparse/__init__.py
+++ b/bindings/pydrake/common/test_utilities/scipy_stub/scipy/sparse/__init__.py
@@ -12,21 +12,26 @@ class csc_matrix:
     """
 
     def __init__(self, arg1, shape):
-        (self._data, self._indices, self._indptr) = arg1
-        self._shape = shape
+        (self.data, self.indices, self.indptr) = arg1
+        self.shape = shape
 
         # To sanity-check our arguments, convert the data to triplets.
         self._triplets = []
-        for col in range(len(self._indptr) - 1):
-            start = self._indptr[col]
-            end = self._indptr[col+1]
-            rows = self._indices[start:end]
-            values = self._data[start:end]
+        for col in range(len(self.indptr) - 1):
+            start = self.indptr[col]
+            end = self.indptr[col+1]
+            rows = self.indices[start:end]
+            values = self.data[start:end]
             for row, value in zip(rows, values):
                 self._triplets.append((row, col, value))
 
+        self.nnz = 0
+        for _, _, value in self._triplets:
+            if value:
+                self.nnz += 1
+
     def todense(self):
-        result = np.zeros(shape=self._shape)
+        result = np.zeros(shape=self.shape)
         for row, col, value in self._triplets:
             result[row, col] = value
         return result

--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -1689,8 +1689,17 @@ void BindEvaluatorsAndBindings(py::module m) {
         return std::make_unique<LinearConstraint>(A, lb, ub);
       }),
           py::arg("A"), py::arg("lb"), py::arg("ub"),
-          doc.LinearConstraint.ctor.doc)
+          doc.LinearConstraint.ctor.doc_dense_A)
+      .def(py::init([](const Eigen::SparseMatrix<double>& A,
+                        const Eigen::Ref<const Eigen::VectorXd>& lb,
+                        const Eigen::Ref<const Eigen::VectorXd>& ub) {
+        return std::make_unique<LinearConstraint>(A, lb, ub);
+      }),
+          py::arg("A"), py::arg("lb"), py::arg("ub"),
+          doc.LinearConstraint.ctor.doc_sparse_A)
       .def("A", &LinearConstraint::A, doc.LinearConstraint.A.doc)
+      .def("get_sparse_A", &LinearConstraint::get_sparse_A,
+          doc.LinearConstraint.get_sparse_A.doc)
       .def(
           "UpdateCoefficients",
           [](LinearConstraint& self, const Eigen::MatrixXd& new_A,
@@ -1698,7 +1707,15 @@ void BindEvaluatorsAndBindings(py::module m) {
             self.UpdateCoefficients(new_A, new_lb, new_ub);
           },
           py::arg("new_A"), py::arg("new_lb"), py::arg("new_ub"),
-          doc.LinearConstraint.UpdateCoefficients.doc)
+          doc.LinearConstraint.UpdateCoefficients.doc_dense_A)
+      .def(
+          "UpdateCoefficients",
+          [](LinearConstraint& self, const Eigen::SparseMatrix<double>& new_A,
+              const Eigen::VectorXd& new_lb, const Eigen::VectorXd& new_ub) {
+            self.UpdateCoefficients(new_A, new_lb, new_ub);
+          },
+          py::arg("new_A"), py::arg("new_lb"), py::arg("new_ub"),
+          doc.LinearConstraint.UpdateCoefficients.doc_sparse_A)
       .def(
           "UpdateLowerBound",
           [](LinearConstraint& self, const Eigen::VectorXd& new_lb) {
@@ -1772,13 +1789,18 @@ void BindEvaluatorsAndBindings(py::module m) {
         return std::make_unique<LinearEqualityConstraint>(Aeq, beq);
       }),
           py::arg("Aeq"), py::arg("beq"),
-          doc.LinearEqualityConstraint.ctor
-              .doc_2args_constEigenMatrixBase_constEigenMatrixBase)
+          doc.LinearEqualityConstraint.ctor.doc_dense_Aeq)
+      .def(py::init([](const Eigen::SparseMatrix<double>& Aeq,
+                        const Eigen::VectorXd& beq) {
+        return std::make_unique<LinearEqualityConstraint>(Aeq, beq);
+      }),
+          py::arg("Aeq"), py::arg("beq"),
+          doc.LinearEqualityConstraint.ctor.doc_sparse_Aeq)
       .def(py::init([](const Eigen::RowVectorXd& a, double beq) {
         return std::make_unique<LinearEqualityConstraint>(a, beq);
       }),
           py::arg("a"), py::arg("beq"),
-          doc.LinearEqualityConstraint.ctor.doc_2args_a_beq)
+          doc.LinearEqualityConstraint.ctor.doc_row_a)
       .def(
           "UpdateCoefficients",
           [](LinearEqualityConstraint& self,  // BR

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -162,6 +162,7 @@ drake_cc_library(
     deps = [
         ":decision_variable",
         ":evaluator_base",
+        ":sparse_and_dense_matrix",
         "//common:autodiff",
         "//common:essential",
         "//common:polynomial",

--- a/solvers/constraint.h
+++ b/solvers/constraint.h
@@ -15,12 +15,14 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/polynomial.h"
 #include "drake/common/symbolic.h"
 #include "drake/solvers/decision_variable.h"
 #include "drake/solvers/evaluator_base.h"
 #include "drake/solvers/function.h"
+#include "drake/solvers/sparse_and_dense_matrix.h"
 
 namespace drake {
 namespace solvers {
@@ -555,26 +557,42 @@ class LinearConstraint : public Constraint {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LinearConstraint)
 
-  template <typename DerivedA, typename DerivedLB, typename DerivedUB>
-  LinearConstraint(const Eigen::MatrixBase<DerivedA>& a,
-                   const Eigen::MatrixBase<DerivedLB>& lb,
-                   const Eigen::MatrixBase<DerivedUB>& ub)
-      : Constraint(a.rows(), a.cols(), lb, ub), A_(a) {
-    DRAKE_DEMAND(a.rows() == lb.rows());
-    DRAKE_DEMAND(A_.array().isFinite().all());
-  }
+  /**
+   * Construct the linear constraint lb <= A*x <= ub
+   * @pydrake_mkdoc_identifier{dense_A}
+   */
+  LinearConstraint(const Eigen::Ref<const Eigen::MatrixXd>& A,
+                   const Eigen::Ref<const Eigen::VectorXd>& lb,
+                   const Eigen::Ref<const Eigen::VectorXd>& ub);
+
+  /**
+   * Overloads constructor with a sparse A matrix.
+   * @pydrake_mkdoc_identifier{sparse_A}
+   */
+  LinearConstraint(const Eigen::SparseMatrix<double>& A,
+                   const Eigen::Ref<const Eigen::VectorXd>& lb,
+                   const Eigen::Ref<const Eigen::VectorXd>& ub);
 
   ~LinearConstraint() override {}
 
+  DRAKE_DEPRECATED("2022-08-01",
+                   "Use get_sparse_A() instead of GetSparseMatrix()")
   virtual Eigen::SparseMatrix<double> GetSparseMatrix() const {
     // TODO(eric.cousineau): Consider storing or caching sparse matrix, such
     // that we can return a const lvalue reference.
-    return A_.sparseView();
+    return A_.get_as_sparse();
   }
-  virtual const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& A()
-      const {
-    return A_;
+
+  const Eigen::SparseMatrix<double>& get_sparse_A() const {
+    return A_.get_as_sparse();
   }
+
+  /**
+   * Gets the coefficient matrix A as a dense matrix.
+   * @note This function will allocate new memory on the heap. For better
+   * performance you should call get_sparse_A() which returns a sparse matrix.
+   */
+  virtual const Eigen::MatrixXd& A() const { return A_.GetAsDense(); }
 
   /**
    * Updates the linear term, upper and lower bounds in the linear constraint.
@@ -585,24 +603,19 @@ class LinearConstraint : public Constraint {
    * @param new_A new linear term
    * @param new_lb new lower bound
    * @param new_up new upper bound
+   * @pydrake_mkdoc_identifier{dense_A}
    */
-  template <typename DerivedA, typename DerivedL, typename DerivedU>
-  void UpdateCoefficients(const Eigen::MatrixBase<DerivedA>& new_A,
-                          const Eigen::MatrixBase<DerivedL>& new_lb,
-                          const Eigen::MatrixBase<DerivedU>& new_ub) {
-    if (new_A.rows() != new_lb.rows() || new_lb.rows() != new_ub.rows() ||
-        new_lb.cols() != 1 || new_ub.cols() != 1) {
-      throw std::runtime_error("New constraints have invalid dimensions");
-    }
+  void UpdateCoefficients(const Eigen::Ref<const Eigen::MatrixXd>& new_A,
+                          const Eigen::Ref<const Eigen::VectorXd>& new_lb,
+                          const Eigen::Ref<const Eigen::VectorXd>& new_ub);
 
-    if (new_A.cols() != A_.cols()) {
-      throw std::runtime_error("Can't change the number of decision variables");
-    }
-
-    A_ = new_A;
-    set_num_outputs(A_.rows());
-    set_bounds(new_lb, new_ub);
-  }
+  /**
+   * Overloads UpdateCoefficients but with a sparse A matrix.
+   * @pydrake_mkdoc_identifier{sparse_A}
+   */
+  void UpdateCoefficients(const Eigen::SparseMatrix<double>& new_A,
+                          const Eigen::Ref<const Eigen::VectorXd>& new_lb,
+                          const Eigen::Ref<const Eigen::VectorXd>& new_ub);
 
   using Constraint::set_bounds;
   using Constraint::UpdateLowerBound;
@@ -621,7 +634,7 @@ class LinearConstraint : public Constraint {
   std::ostream& DoDisplay(std::ostream&,
                           const VectorX<symbolic::Variable>&) const override;
 
-  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> A_;
+  internal::SparseAndDenseMatrix A_;
 
  private:
   template <typename DerivedX, typename ScalarY>
@@ -640,20 +653,28 @@ class LinearEqualityConstraint : public LinearConstraint {
 
   /**
    * Constructs the linear equality constraint Aeq * x = beq
+   * @pydrake_mkdoc_identifier{dense_Aeq}
    */
-  template <typename DerivedA, typename DerivedB>
-  LinearEqualityConstraint(const Eigen::MatrixBase<DerivedA>& Aeq,
-                           const Eigen::MatrixBase<DerivedB>& beq)
+  LinearEqualityConstraint(const Eigen::Ref<const Eigen::MatrixXd>& Aeq,
+                           const Eigen::Ref<const Eigen::VectorXd>& beq)
+      : LinearConstraint(Aeq, beq, beq) {}
+
+  /**
+   * Overloads the constructor with a sparse matrix Aeq.
+   * @pydrake_mkdoc_identifier{sparse_Aeq}
+   */
+  LinearEqualityConstraint(
+      const Eigen::SparseMatrix<double>& Aeq,
+      const Eigen::Ref<const Eigen::VectorXd>& beq)
       : LinearConstraint(Aeq, beq, beq) {}
 
   /**
    * Constructs the linear equality constraint a.dot(x) = beq
+   * @pydrake_mkdoc_identifier{row_a}
    */
   LinearEqualityConstraint(const Eigen::Ref<const Eigen::RowVectorXd>& a,
                            double beq)
       : LinearEqualityConstraint(a, Vector1d(beq)) {}
-
-  ~LinearEqualityConstraint() override {}
 
   /*
    * @brief change the parameters of the constraint (A and b), but not the
@@ -662,9 +683,17 @@ class LinearEqualityConstraint : public LinearConstraint {
    * note that A and b can change size in the rows only (representing a
    *different number of linear constraints, but on the same decision variables)
    */
-  template <typename DerivedA, typename DerivedB>
-  void UpdateCoefficients(const Eigen::MatrixBase<DerivedA>& Aeq,
-                          const Eigen::MatrixBase<DerivedB>& beq) {
+  void UpdateCoefficients(const Eigen::Ref<const Eigen::MatrixXd>& Aeq,
+                          const Eigen::Ref<const Eigen::VectorXd>& beq) {
+    LinearConstraint::UpdateCoefficients(Aeq, beq, beq);
+  }
+
+  /**
+   * Overloads UpdateCoefficients but with a sparse A matrix.
+   */
+  void UpdateCoefficients(
+      const Eigen::SparseMatrix<double>& Aeq,
+      const Eigen::Ref<const Eigen::VectorXd>& beq) {
     LinearConstraint::UpdateCoefficients(Aeq, beq, beq);
   }
 
@@ -701,11 +730,8 @@ class BoundingBoxConstraint : public LinearConstraint {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BoundingBoxConstraint)
 
-  template <typename DerivedLB, typename DerivedUB>
-  BoundingBoxConstraint(const Eigen::MatrixBase<DerivedLB>& lb,
-                        const Eigen::MatrixBase<DerivedUB>& ub)
-      : LinearConstraint(Eigen::MatrixXd::Identity(lb.rows(), lb.rows()), lb,
-                         ub) {}
+  BoundingBoxConstraint(const Eigen::Ref<const Eigen::VectorXd>& lb,
+                        const Eigen::Ref<const Eigen::VectorXd>& ub);
 
   ~BoundingBoxConstraint() override {}
 

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -407,7 +407,7 @@ MSKrescodee AddLinearConstraintsFromBindings(
   MSKrescodee rescode{MSK_RES_OK};
   for (const auto& binding : constraint_list) {
     const auto& constraint = binding.evaluator();
-    const Eigen::MatrixXd& A = constraint->A();
+    const Eigen::SparseMatrix<double>& A = constraint->get_sparse_A();
     const Eigen::VectorXd& lb = constraint->lower_bound();
     const Eigen::VectorXd& ub = constraint->upper_bound();
     Eigen::SparseMatrix<double> B_zero(A.rows(), 0);
@@ -418,8 +418,8 @@ MSKrescodee AddLinearConstraintsFromBindings(
       return rescode;
     }
     rescode = AddLinearConstraintToMosek(
-        prog, A.sparseView(), B_zero, lb, ub, binding.variables(), {},
-        bound_type, decision_variable_index_to_mosek_matrix_variable,
+        prog, A, B_zero, lb, ub, binding.variables(), {}, bound_type,
+        decision_variable_index_to_mosek_matrix_variable,
         decision_variable_index_to_mosek_nonmatrix_variable,
         matrix_variable_entry_to_selection_matrix_id, *task);
     if (rescode != MSK_RES_OK) {

--- a/solvers/osqp_solver.cc
+++ b/solvers/osqp_solver.cc
@@ -127,7 +127,7 @@ void ParseLinearConstraints(
     const std::vector<int> x_indices =
         prog.FindDecisionVariableIndices(constraint.variables());
     const std::vector<Eigen::Triplet<double>> Ai_triplets =
-        math::SparseMatrixToTriplets(constraint.evaluator()->A());
+        math::SparseMatrixToTriplets(constraint.evaluator()->get_sparse_A());
     const Binding<Constraint> constraint_cast =
         internal::BindingDynamicCast<Constraint>(constraint);
     constraint_start_row->emplace(constraint_cast, *num_A_rows);

--- a/solvers/scs_solver.cc
+++ b/solvers/scs_solver.cc
@@ -220,8 +220,8 @@ void ParseLinearEqualityConstraint(
   // A x + s = b. s in zero cone.
   for (const auto& linear_equality_constraint :
        prog.linear_equality_constraints()) {
-    const Eigen::SparseMatrix<double> Ai =
-        linear_equality_constraint.evaluator()->GetSparseMatrix();
+    const Eigen::SparseMatrix<double>& Ai =
+        linear_equality_constraint.evaluator()->get_sparse_A();
     const std::vector<Eigen::Triplet<double>> Ai_triplets =
         math::SparseMatrixToTriplets(Ai);
     A_triplets->reserve(A_triplets->size() + Ai_triplets.size());

--- a/solvers/snopt_solver.cc
+++ b/solvers/snopt_solver.cc
@@ -702,7 +702,14 @@ void UpdateConstraintBoundsAndGradients<LinearComplementarityConstraint>(
 
 template <typename C>
 Eigen::SparseMatrix<double> LinearEvaluatorA(const C& evaluator) {
-  return evaluator.GetSparseMatrix();
+  if constexpr (std::is_same_v<C, LinearComplementarityConstraint>) {
+    // TODO(hongkai.dai): change LinearComplementarityConstraint to store a
+    // sparse matrix M, and change the return type here to const
+    // SparseMatrix<double>&.
+    return evaluator.M().sparseView();
+  } else {
+    return evaluator.get_sparse_A();
+  }
 }
 
 // Return the number of rows in the linear constraint
@@ -719,12 +726,6 @@ template <>
 int LinearConstraintSize<LinearComplementarityConstraint>(
     const LinearComplementarityConstraint& constraint) {
   return constraint.M().rows();
-}
-
-template <>
-Eigen::SparseMatrix<double> LinearEvaluatorA<LinearComplementarityConstraint>(
-    const LinearComplementarityConstraint& constraint) {
-  return constraint.M().sparseView();
 }
 
 template <typename C>


### PR DESCRIPTION
It can optionally also store a dense matrix A.
BoundingBoxConstraint stores the sparse identity matrix.

Since we are removing scipy dependency, I don't add the python binding for functions using sparse matrices.

The following solvers still use dense A matrix internally. I will fix them in separate PRs

- [ ] ScsSolver
- [ ] GurobiSolver
- [ ] ClpSolver
- [ ] CsdpSolver

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16894)
<!-- Reviewable:end -->
