### PR TITLE
Use std::vector instead of Eigen::Vector in ExtractAndAppendVariablesFromExpression

### DIFF
--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -928,9 +928,20 @@ PYBIND11_MODULE(symbolic, m) {
           },
           py::arg("expressions"), py::arg("vars"),
           doc.DecomposeAffineExpressions.doc_4args_expressions_vars_M_v)
-      .def("ExtractVariablesFromExpression",
-          &symbolic::ExtractVariablesFromExpression, py::arg("e"),
-          doc.ExtractVariablesFromExpression.doc)
+      .def(
+          "ExtractVariablesFromExpression",
+          [](const symbolic::Expression& e) {
+            return symbolic::ExtractVariablesFromExpression(e);
+          },
+          py::arg("e"), doc.ExtractVariablesFromExpression.doc_1args_e)
+      .def(
+          "ExtractVariablesFromExpression",
+          [](const Eigen::Ref<const VectorX<symbolic::Expression>>&
+                  expressions) {
+            return symbolic::ExtractVariablesFromExpression(expressions);
+          },
+          py::arg("expressions"),
+          doc.ExtractVariablesFromExpression.doc_1args_expressions)
       .def(
           "DecomposeQuadraticPolynomial",
           [](const symbolic::Polynomial& poly,

--- a/bindings/pydrake/test/symbolic_test.py
+++ b/bindings/pydrake/test/symbolic_test.py
@@ -1531,6 +1531,10 @@ class TestExtractVariablesFromExpression(unittest.TestCase):
         for i in range(2):
             self.assertEqual(map_var_to_index[variables[i].get_id()], i)
 
+        variables, map_var_to_index = sym.ExtractVariablesFromExpression(
+            expressions=np.array([x + x * y, y+1]))
+        self.assertEqual(variables.shape, (2,))
+
 
 class TestDecomposeAffineExpression(unittest.TestCase):
     def test(self):

--- a/common/symbolic_decompose.h
+++ b/common/symbolic_decompose.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/symbolic.h"
 
@@ -42,7 +43,11 @@ extracting expression `e`. As an output, the variables in `e` that were not
 included in `vars`, will be appended to the end of `vars`.
 @param[in,out] map_var_to_index. map_var_to_index is of the same size as
 `vars`, and map_var_to_index[vars(i).get_id()] = i. This invariance holds for
-map_var_to_index both as the input and as the output. */
+map_var_to_index both as the input and as the output.
+@note This function is very slow if you call this function within a loop as it
+involves repeated heap memory allocation. Consider using
+ExtractVariablesFromExpression.
+*/
 void ExtractAndAppendVariablesFromExpression(
     const symbolic::Expression& e, VectorX<Variable>* vars,
     std::unordered_map<symbolic::Variable::Id, int>* map_var_to_index);
@@ -54,6 +59,13 @@ void ExtractAndAppendVariablesFromExpression(
 pair.first, such that pair.second[pair.first(i).get_id()] = i */
 std::pair<VectorX<Variable>, std::unordered_map<symbolic::Variable::Id, int>>
 ExtractVariablesFromExpression(const symbolic::Expression& e);
+
+/**
+ * Overloads ExtractVariablesFromExpression but with a vector of expressions.
+ */
+std::pair<VectorX<Variable>, std::unordered_map<Variable::Id, int>>
+ExtractVariablesFromExpression(
+    const Eigen::Ref<const VectorX<Expression>>& expressions);
 
 /** Given a quadratic polynomial @p poly, decomposes it into the form 0.5 * x'
 * Q * x + b' * x + c

--- a/common/test/symbolic_decompose_test.cc
+++ b/common/test/symbolic_decompose_test.cc
@@ -190,15 +190,16 @@ void ExpectValidMapVarToIndex(const VectorX<Variable>& vars,
   }
 }
 
-GTEST_TEST(SymbolicExtraction, ExtractVariables) {
+GTEST_TEST(SymbolicExtraction, ExtractVariables1) {
+  // Test ExtractVariablesFromExpression with a single expression.
   const Variable x("x");
   const Variable y("y");
   Expression e = x + y;
   VectorX<Variable> vars_expected(2);
   vars_expected << x, y;
 
-  MapVarToIndex map_var_to_index;
   VectorX<Variable> vars;
+  MapVarToIndex map_var_to_index;
   std::tie(vars, map_var_to_index) = ExtractVariablesFromExpression(e);
   EXPECT_EQ(vars_expected, vars);
   ExpectValidMapVarToIndex(vars, map_var_to_index);
@@ -211,6 +212,30 @@ GTEST_TEST(SymbolicExtraction, ExtractVariables) {
 
   ExtractAndAppendVariablesFromExpression(e, &vars, &map_var_to_index);
   EXPECT_EQ(vars_expected, vars);
+  ExpectValidMapVarToIndex(vars, map_var_to_index);
+}
+
+GTEST_TEST(SymbolicExtraction, ExtractVariables2) {
+  // TestExtractVariablesFromExpression with a vector of expressions.
+  const Variable x("x");
+  const Variable y("y");
+  const Variable z("z");
+  Vector3<symbolic::Expression> expressions(x + y, y + 1, x + z);
+  VectorX<Variable> vars;
+  MapVarToIndex map_var_to_index;
+  std::tie(vars, map_var_to_index) =
+      ExtractVariablesFromExpression(expressions);
+  EXPECT_EQ(symbolic::Variables(vars), symbolic::Variables({x, y, z}));
+  ExpectValidMapVarToIndex(vars, map_var_to_index);
+
+  std::tie(vars, map_var_to_index) =
+      ExtractVariablesFromExpression(expressions.tail<2>());
+  EXPECT_EQ(symbolic::Variables(vars), symbolic::Variables({x, y, z}));
+  ExpectValidMapVarToIndex(vars, map_var_to_index);
+
+  std::tie(vars, map_var_to_index) =
+      ExtractVariablesFromExpression(expressions.head<2>());
+  EXPECT_EQ(symbolic::Variables(vars), symbolic::Variables({x, y}));
   ExpectValidMapVarToIndex(vars, map_var_to_index);
 }
 

--- a/solvers/constraint.cc
+++ b/solvers/constraint.cc
@@ -487,10 +487,8 @@ ExpressionConstraint::ExpressionConstraint(
       expressions_(v) {
   // Setup map_var_to_index_ and vars_ so that
   //   map_var_to_index_[vars_(i).get_id()] = i.
-  for (int i = 0; i < expressions_.size(); ++i) {
-    symbolic::ExtractAndAppendVariablesFromExpression(expressions_(i), &vars_,
-                                                      &map_var_to_index_);
-  }
+  std::tie(vars_, map_var_to_index_) =
+      symbolic::ExtractVariablesFromExpression(expressions_);
 
   derivatives_ = symbolic::Jacobian(expressions_, vars_);
 

--- a/solvers/create_constraint.cc
+++ b/solvers/create_constraint.cc
@@ -45,14 +45,12 @@ Binding<Constraint> ParseConstraint(
     return ParseLinearEqualityConstraint(v, lb);
   }
 
-  // Setup map_var_to_index and var_vec.
-  // such that map_var_to_index[var(i)] = i
+  // Setup map_var_to_index and vars.
+  // such that map_var_to_index[vars(i)] = i
+  VectorXDecisionVariable vars;
   unordered_map<Variable::Id, int> map_var_to_index;
-  VectorXDecisionVariable vars(0);
-  for (int i = 0; i < v.size(); ++i) {
-    symbolic::ExtractAndAppendVariablesFromExpression(v(i), &vars,
-                                                      &map_var_to_index);
-  }
+  std::tie(vars, map_var_to_index) =
+      symbolic::ExtractVariablesFromExpression(v);
 
   // Construct A, new_lb, new_ub. map_var_to_index is used here.
   Eigen::MatrixXd A{Eigen::MatrixXd::Zero(v.size(), vars.size())};
@@ -473,12 +471,10 @@ Binding<LinearEqualityConstraint> DoParseLinearEqualityConstraint(
     const Eigen::Ref<const VectorX<Expression>>& v,
     const Eigen::Ref<const Eigen::VectorXd>& b) {
   DRAKE_DEMAND(v.rows() == b.rows());
-  VectorXDecisionVariable vars(0);
+  VectorX<symbolic::Variable> vars;
   unordered_map<Variable::Id, int> map_var_to_index;
-  for (int i = 0; i < v.rows(); ++i) {
-    symbolic::ExtractAndAppendVariablesFromExpression(v(i), &vars,
-                                                      &map_var_to_index);
-  }
+  std::tie(vars, map_var_to_index) =
+      symbolic::ExtractVariablesFromExpression(v);
   // TODO(hongkai.dai): use sparse matrix.
   Eigen::MatrixXd A = Eigen::MatrixXd::Zero(v.rows(), vars.rows());
   Eigen::VectorXd beq = Eigen::VectorXd::Zero(v.rows());


### PR DESCRIPTION
Speed up parsing linear constraints by reducing number of heap memory allocation.

Resolves #16895

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16896)
<!-- Reviewable:end -->
