### PR TITLE
py common: Add example of configuring both log levels

### DIFF
--- a/bindings/pydrake/common/__init__.py
+++ b/bindings/pydrake/common/__init__.py
@@ -20,6 +20,11 @@ def configure_logging():
     more spartan than Drake's C++ logging format (e.g., Python does not show
     message timestamps by default).
 
+    This will ensure that the format is similar to spdlog C++ logging and
+    will also ensure that the Python logger will always emit message, meaning
+    users only need to configure log levels using
+    ``pydrake.common.set_log_level``.
+
     See also:
        :py:func:`pydrake.common.set_log_level`
     """

--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -109,6 +109,17 @@ Warning:
     function only adjusts the C++ level. Refer to the Python logging module
     documentation for details on setting the Python level.
 
+    For simplicity, consider using ``pydrake.common.configure_logging`` in
+    conjunction with this function.
+
+    .. code-block:: python
+
+        import logging
+        from pydrake.common import configure_logging, set_log_level
+        ...
+        configure_logging()
+        set_log_level("debug")
+
 See also:
    :py:func:`pydrake.common.configure_logging`
 )""")


### PR DESCRIPTION
Was working in Anzu, needed to trace through some model directives, and had forgotten this detail.
Just adding more docs.

Perhaps there's a better way, but at least this is a strict improvement over status quo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16901)
<!-- Reviewable:end -->
