### PR TITLE
[SAP] CompliantContactManager makes the SapContactProblem.

### DIFF
--- a/multibody/contact_solvers/sap/sap_friction_cone_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_friction_cone_constraint.cc
@@ -1,6 +1,7 @@
 #include "drake/multibody/contact_solvers/sap/sap_friction_cone_constraint.h"
 
 #include <algorithm>
+#include <utility>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/eigen_types.h"
@@ -12,10 +13,10 @@ namespace internal {
 
 template <typename T>
 SapFrictionConeConstraint<T>::SapFrictionConeConstraint(int clique,
-                                                        const MatrixX<T>& J,
+                                                        MatrixX<T> J,
                                                         const T& phi0,
                                                         const Parameters& p)
-    : SapConstraint<T>(clique, Vector3<T>(0.0, 0.0, phi0), J),
+    : SapConstraint<T>(clique, Vector3<T>(0.0, 0.0, phi0), std::move(J)),
       parameters_(p),
       phi0_(phi0) {
   DRAKE_DEMAND(clique >= 0);
@@ -29,9 +30,10 @@ SapFrictionConeConstraint<T>::SapFrictionConeConstraint(int clique,
 
 template <typename T>
 SapFrictionConeConstraint<T>::SapFrictionConeConstraint(
-    int clique0, int clique1, const MatrixX<T>& J0, const MatrixX<T>& J1,
-    const T& phi0, const Parameters& p)
-    : SapConstraint<T>(clique0, clique1, Vector3<T>(0.0, 0.0, phi0), J0, J1),
+    int clique0, int clique1, MatrixX<T> J0, MatrixX<T> J1, const T& phi0,
+    const Parameters& p)
+    : SapConstraint<T>(clique0, clique1, Vector3<T>(0.0, 0.0, phi0),
+                       std::move(J0), std::move(J1)),
       parameters_(p),
       phi0_(phi0) {
   DRAKE_DEMAND(clique0 >= 0);

--- a/multibody/contact_solvers/sap/sap_friction_cone_constraint.h
+++ b/multibody/contact_solvers/sap/sap_friction_cone_constraint.h
@@ -93,7 +93,7 @@ class SapFrictionConeConstraint final : public SapConstraint<T> {
    exception is thrown.
    @param[in] phi0 The value of the signed distance at the previous time step.
    @param[in] parameters Constraint parameters. See Parameters for details. */
-  SapFrictionConeConstraint(int clique, const MatrixX<T>& J, const T& phi0,
+  SapFrictionConeConstraint(int clique, MatrixX<T> J, const T& phi0,
                             const Parameters& parameters);
 
   /* Constructs a contact constraint for the case in which two cliques
@@ -108,9 +108,8 @@ class SapFrictionConeConstraint final : public SapConstraint<T> {
    velocities. It must have three rows or an exception is thrown.
    @param[in] phi0 The value of the signed distance at the previous time step.
    @param[in] parameters Constraint parameters. See Parameters for details. */
-  SapFrictionConeConstraint(int clique0, int clique1, const MatrixX<T>& J0,
-                            const MatrixX<T>& J1, const T& phi0,
-                            const Parameters& p);
+  SapFrictionConeConstraint(int clique0, int clique1, MatrixX<T> J0,
+                            MatrixX<T> J1, const T& phi0, const Parameters& p);
 
   /* Returns the coefficient of friction for this constraint. */
   const T& mu() const { return parameters_.mu; }

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -44,6 +44,8 @@ drake_cc_library(
     deps = [
         ":multibody_plant_core",
         "//multibody/contact_solvers:contact_solver",
+        "//multibody/contact_solvers/sap:sap_contact_problem",
+        "//multibody/contact_solvers/sap:sap_friction_cone_constraint",
         "//multibody/triangle_quadrature",
     ],
 )

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -13,6 +13,8 @@
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/contact_solvers/contact_solver.h"
+#include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
+#include "drake/multibody/contact_solvers/sap/sap_friction_cone_constraint.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/triangle_quadrature/gaussian_triangle_quadrature_rule.h"
 #include "drake/systems/framework/context.h"
@@ -20,6 +22,8 @@
 using drake::geometry::GeometryId;
 using drake::geometry::PenetrationAsPointPair;
 using drake::math::RotationMatrix;
+using drake::multibody::contact_solvers::internal::SapContactProblem;
+using drake::multibody::contact_solvers::internal::SapFrictionConeConstraint;
 using drake::multibody::internal::MultibodyTreeTopology;
 using drake::systems::Context;
 
@@ -61,37 +65,19 @@ void CompliantContactManager<T>::DeclareCacheEntries() {
   cache_indexes_.discrete_contact_pairs =
       discrete_contact_pairs_cache_entry.cache_index();
 
-  // Contact Jacobian for the discrete pairs computed with
-  // CompliantContactManager::CalcDiscreteContactPairs().
-  auto& contact_jacobian_cache_entry = this->DeclareCacheEntry(
-      std::string("Contact Jacobian."),
-      systems::ValueProducer(
-          this, &CompliantContactManager<T>::CalcContactJacobianCache),
-      {systems::System<T>::xd_ticket(),
-       systems::System<T>::all_parameters_ticket()});
-  cache_indexes_.contact_jacobian = contact_jacobian_cache_entry.cache_index();
-
-  auto& free_motion_velocities_cache_entry = this->DeclareCacheEntry(
-      std::string("Free motion velocities, v*."),
-      systems::ValueProducer(
-          this, &CompliantContactManager<T>::CalcFreeMotionVelocities),
-      {systems::System<T>::xd_ticket(),
-       systems::System<T>::all_parameters_ticket()});
-  cache_indexes_.free_motion_velocities =
-      free_motion_velocities_cache_entry.cache_index();
-
   // Due to issue #12786, we cannot mark
   // CacheIndexes::non_contact_forces_accelerations dependent on the
   // MultibodyPlant's inputs, as it should. However if we remove this
   // dependency, we run the risk of having an undetected algebraic loop. We use
   // this cache entry to signal when the computation of non-contact forces is in
   // progress so that we can detect an algebraic loop.
-  auto& non_contact_forces_evaluation_in_progress = this->DeclareCacheEntry(
-      "Evaluation of non-contact forces and accelerations is in progress.",
-      // N.B. This flag is set to true only when the computation is in progress.
-      // Therefore its default value is `false`.
-      systems::ValueProducer(false, &systems::ValueProducer::NoopCalc),
-      {systems::System<T>::nothing_ticket()});
+  const auto& non_contact_forces_evaluation_in_progress =
+      this->DeclareCacheEntry(
+          "Evaluation of non-contact forces and accelerations is in progress.",
+          // N.B. This flag is set to true only when the computation is in
+          // progress. Therefore its default value is `false`.
+          systems::ValueProducer(false, &systems::ValueProducer::NoopCalc),
+          {systems::System<T>::nothing_ticket()});
   cache_indexes_.non_contact_forces_evaluation_in_progress =
       non_contact_forces_evaluation_in_progress.cache_index();
 
@@ -100,43 +86,46 @@ void CompliantContactManager<T>::DeclareCacheEntries() {
   // AccelerationsDueToExternalForcesCache.
   AccelerationsDueToExternalForcesCache<T> non_contact_forces_accelerations(
       this->internal_tree().get_topology());
-  auto& non_contact_forces_accelerations_cache_entry = this->DeclareCacheEntry(
-      std::string("Non-contact forces accelerations."),
-      systems::ValueProducer(
-          this, non_contact_forces_accelerations,
-          &CompliantContactManager<
-              T>::CalcAccelerationsDueToNonContactForcesCache),
-      // Due to issue #12786, we cannot properly mark this entry dependent on
-      // inputs. CalcAccelerationsDueToNonContactForcesCache() uses
-      // CacheIndexes::non_contact_forces_evaluation_in_progress to guard
-      // against algebraic loops.
-      {systems::System<T>::xd_ticket(),
-       systems::System<T>::all_parameters_ticket()});
+  const auto& non_contact_forces_accelerations_cache_entry =
+      this->DeclareCacheEntry(
+          "Non-contact forces accelerations.",
+          systems::ValueProducer(
+              this, non_contact_forces_accelerations,
+              &CompliantContactManager<
+                  T>::CalcAccelerationsDueToNonContactForcesCache),
+          // Due to issue #12786, we cannot properly mark this entry dependent
+          // on inputs. CalcAccelerationsDueToNonContactForcesCache() uses
+          // CacheIndexes::non_contact_forces_evaluation_in_progress to guard
+          // against algebraic loops.
+          {systems::System<T>::xd_ticket(),
+           systems::System<T>::all_parameters_ticket()});
   cache_indexes_.non_contact_forces_accelerations =
       non_contact_forces_accelerations_cache_entry.cache_index();
+
+  const auto& contact_problem_cache_entry = this->DeclareCacheEntry(
+      "Contact Problem.",
+      systems::ValueProducer(
+          this, ContactProblemCache<T>(plant().time_step()),
+          &CompliantContactManager<T>::CalcContactProblemCache),
+      {plant().cache_entry_ticket(cache_indexes_.discrete_contact_pairs)});
+  cache_indexes_.contact_problem = contact_problem_cache_entry.cache_index();
 }
 
 template <typename T>
-void CompliantContactManager<T>::CalcContactJacobianCache(
-    const systems::Context<T>& context,
-    internal::ContactJacobianCache<T>* cache) const {
-  DRAKE_DEMAND(cache != nullptr);
-
+std::vector<ContactPairKinematics<T>>
+CompliantContactManager<T>::CalcContactKinematics(
+    const systems::Context<T>& context) const {
   const std::vector<internal::DiscreteContactPair<T>>& contact_pairs =
       EvalDiscreteContactPairs(context);
   const int num_contacts = contact_pairs.size();
-
-  std::vector<ContactPairKinematics<T>>& contact_kinematics =
-      cache->contact_kinematics;
-  contact_kinematics.clear();
+  std::vector<ContactPairKinematics<T>> contact_kinematics;
   contact_kinematics.reserve(num_contacts);
 
   // Quick no-op exit.
-  if (num_contacts == 0) return;
-
-  const int nv = plant().num_velocities();
+  if (num_contacts == 0) return contact_kinematics;
 
   // Scratch workspace variables.
+  const int nv = plant().num_velocities();
   Matrix3X<T> Jv_WAc_W(3, nv);
   Matrix3X<T> Jv_WBc_W(3, nv);
   Matrix3X<T> Jv_AcBc_W(3, nv);
@@ -171,7 +160,7 @@ void CompliantContactManager<T>::CalcContactJacobianCache(
     // Define a contact frame C at the contact point such that the z-axis Cz
     // equals nhat_W. The tangent vectors are arbitrary, with the only
     // requirement being that they form a valid right handed basis with nhat_W.
-    const math::RotationMatrix<T> R_WC =
+    math::RotationMatrix<T> R_WC =
         math::RotationMatrix<T>::MakeFromOneVector(nhat_W, 2);
 
     const TreeIndex& treeA_index =
@@ -209,6 +198,8 @@ void CompliantContactManager<T>::CalcContactJacobianCache(
     contact_kinematics.emplace_back(point_pair.phi0, std::move(jacobian_blocks),
                                     std::move(R_WC));
   }
+
+  return contact_kinematics;
 }
 
 template <typename T>
@@ -239,6 +230,21 @@ T CompliantContactManager<T>::GetDissipationTimeConstant(
   return prop->template GetPropertyOrDefault<T>(
       geometry::internal::kMaterialGroup, "dissipation_time_constant",
       plant().time_step());
+}
+
+template <typename T>
+double CompliantContactManager<T>::GetCoulombFriction(
+    geometry::GeometryId id,
+    const geometry::SceneGraphInspector<T>& inspector) const {
+  const geometry::ProximityProperties* prop =
+      inspector.GetProximityProperties(id);
+  DRAKE_DEMAND(prop != nullptr);
+  DRAKE_THROW_UNLESS(prop->HasProperty(geometry::internal::kMaterialGroup,
+                                       geometry::internal::kFriction));
+  return prop
+      ->GetProperty<CoulombFriction<double>>(geometry::internal::kMaterialGroup,
+                                             geometry::internal::kFriction)
+      .dynamic_friction();
 }
 
 template <typename T>
@@ -321,6 +327,12 @@ void CompliantContactManager<T>::AppendDiscreteContactPairsForPointContact(
           .template Eval<geometry::QueryObject<T>>(context);
   const geometry::SceneGraphInspector<T>& inspector = query_object.inspector();
 
+  // Simple utility to detect 0 / 0. As it is used in this method, denom
+  // can only be zero if num is also zero, so we'll simply return zero.
+  auto safe_divide = [](const T& num, const T& denom) {
+    return denom == 0.0 ? T(0.0) : num / denom;
+  };
+
   // Fill in the point contact pairs.
   const std::vector<PenetrationAsPointPair<T>>& point_pairs =
       plant().EvalPointPairPenetrations(context);
@@ -331,7 +343,11 @@ void CompliantContactManager<T>::AppendDiscreteContactPairsForPointContact(
     const T tauA = GetDissipationTimeConstant(pair.id_A, inspector);
     const T tauB = GetDissipationTimeConstant(pair.id_B, inspector);
     const T tau = CombineDissipationTimeConstant(tauA, tauB);
-    const T d = tau * k;
+
+    // Combine friction coefficients.
+    const double muA = GetCoulombFriction(pair.id_A, inspector);
+    const double muB = GetCoulombFriction(pair.id_B, inspector);
+    const T mu = T(safe_divide(2.0 * muA * muB, muA + muB));
 
     // We compute the position of the point contact based on Hertz's theory
     // for contact between two elastic bodies.
@@ -341,9 +357,10 @@ void CompliantContactManager<T>::AppendDiscreteContactPairsForPointContact(
     const Vector3<T> p_WC = wA * pair.p_WCa + wB * pair.p_WCb;
 
     const T phi0 = -pair.depth;
-    const T fn0 = -k * phi0;
+    const T fn0 = NAN;  // not used.
+    const T d = NAN;    // not used.
     contact_pairs.push_back(
-        {pair.id_A, pair.id_B, p_WC, pair.nhat_BA_W, phi0, fn0, k, d});
+        {pair.id_A, pair.id_B, p_WC, pair.nhat_BA_W, phi0, fn0, k, d, tau, mu});
   }
 }
 
@@ -355,6 +372,12 @@ void CompliantContactManager<T>::
         const systems::Context<T>& context,
         std::vector<internal::DiscreteContactPair<T>>* result) const {
   std::vector<internal::DiscreteContactPair<T>>& contact_pairs = *result;
+
+  // Simple utility to detect 0 / 0. As it is used in this method, denom
+  // can only be zero if num is also zero, so we'll simply return zero.
+  auto safe_divide = [](const T& num, const T& denom) {
+    return denom == 0.0 ? 0.0 : num / denom;
+  };
 
   // N.B. For discrete hydro we use a first order quadrature rule. As such,
   // the per-face quadrature point is the face's centroid and the weight is 1.
@@ -374,9 +397,15 @@ void CompliantContactManager<T>::
     const bool N_is_compliant = s.HasGradE_N();
     DRAKE_DEMAND(M_is_compliant || N_is_compliant);
 
+    // Combine dissipation.
     const T tau_M = GetDissipationTimeConstant(s.id_M(), inspector);
     const T tau_N = GetDissipationTimeConstant(s.id_N(), inspector);
     const T tau = CombineDissipationTimeConstant(tau_M, tau_N);
+
+    // Combine friction coefficients.
+    const double muA = GetCoulombFriction(s.id_M(), inspector);
+    const double muB = GetCoulombFriction(s.id_N(), inspector);
+    const T mu = T(safe_divide(2.0 * muA * muB, muA + muB));
 
     for (int face = 0; face < s.num_faces(); ++face) {
       const T& Ae = s.area(face);  // Face element area.
@@ -402,11 +431,11 @@ void CompliantContactManager<T>::
         // [Masterjohn et al., 2021] Discrete Approximation of Pressure
         // Field Contact Patches.
         const T gM = M_is_compliant
-                     ? s.EvaluateGradE_M_W(face).dot(nhat_W)
-                     : T(std::numeric_limits<double>::infinity());
+                         ? s.EvaluateGradE_M_W(face).dot(nhat_W)
+                         : T(std::numeric_limits<double>::infinity());
         const T gN = N_is_compliant
-                     ? -s.EvaluateGradE_N_W(face).dot(nhat_W)
-                     : T(std::numeric_limits<double>::infinity());
+                         ? -s.EvaluateGradE_N_W(face).dot(nhat_W)
+                         : T(std::numeric_limits<double>::infinity());
 
         constexpr double kGradientEpsilon = 1.0e-14;
         if (gM < kGradientEpsilon || gN < kGradientEpsilon) {
@@ -437,12 +466,8 @@ void CompliantContactManager<T>::
         const Vector3<T> tri_centroid_barycentric(1 / 3., 1 / 3., 1 / 3.);
         // Pressure at the quadrature point.
         const T p0 = s.is_triangle()
-                     ? s.tri_e_MN().Evaluate(
-                face, tri_centroid_barycentric)
-                     : s.poly_e_MN().EvaluateCartesian(face, p_WQ);
-
-        // Force contribution by this quadrature point.
-        const T fn0 = Ae * p0;
+                         ? s.tri_e_MN().Evaluate(face, tri_centroid_barycentric)
+                         : s.poly_e_MN().EvaluateCartesian(face, p_WQ);
 
         // Effective compliance in the normal direction for the given
         // discrete patch, refer to [Masterjohn et al., 2021] for details.
@@ -455,9 +480,10 @@ void CompliantContactManager<T>::
         const T phi0 = -p0 / g;
 
         if (k > 0) {
-          const T dissipation = tau * k;
+          const T fn0 = NAN;  // not used.
+          const T d = NAN;    // not used.
           contact_pairs.push_back(
-              {s.id_M(), s.id_N(), p_WQ, nhat_W, phi0, fn0, k, dissipation});
+              {s.id_M(), s.id_N(), p_WQ, nhat_W, phi0, fn0, k, d, tau, mu});
         }
       }
     }
@@ -532,29 +558,34 @@ void CompliantContactManager<T>::CalcFreeMotionVelocities(
 }
 
 template <typename T>
+void CompliantContactManager<T>::CalcLinearDynamicsMatrix(
+    const systems::Context<T>& context, std::vector<MatrixX<T>>* A) const {
+  DRAKE_DEMAND(A != nullptr);
+  A->resize(tree_topology().num_trees());
+  const int nv = plant().num_velocities();
+
+  // TODO(amcastro-tri): implicitly include force elements such as joint
+  // dissipation and/or stiffness.
+  // TODO(amcastro-tri): consider placing the computation of the dense mass
+  // matrix in a cache entry to minimize heap allocations or better yet,
+  // implement a MultibodyPlant method to compute the per-tree mass matrices.
+  MatrixX<T> M(nv, nv);
+  plant().CalcMassMatrix(context, &M);
+
+  for (TreeIndex t(0); t < tree_topology().num_trees(); ++t) {
+    const int tree_start = tree_topology().tree_velocities_start(t);
+    const int tree_nv = tree_topology().num_tree_velocities(t);
+    (*A)[t] = M.block(tree_start, tree_start, tree_nv, tree_nv);
+  }
+}
+
+template <typename T>
 const std::vector<internal::DiscreteContactPair<T>>&
 CompliantContactManager<T>::EvalDiscreteContactPairs(
     const systems::Context<T>& context) const {
   return plant()
       .get_cache_entry(cache_indexes_.discrete_contact_pairs)
       .template Eval<std::vector<internal::DiscreteContactPair<T>>>(context);
-}
-
-template <typename T>
-const internal::ContactJacobianCache<T>&
-CompliantContactManager<T>::EvalContactJacobianCache(
-    const systems::Context<T>& context) const {
-  return plant()
-      .get_cache_entry(cache_indexes_.contact_jacobian)
-      .template Eval<internal::ContactJacobianCache<T>>(context);
-}
-
-template <typename T>
-const VectorX<T>& CompliantContactManager<T>::EvalFreeMotionVelocities(
-    const systems::Context<T>& context) const {
-  return plant()
-      .get_cache_entry(cache_indexes_.free_motion_velocities)
-      .template Eval<VectorX<T>>(context);
 }
 
 template <typename T>
@@ -578,9 +609,85 @@ void CompliantContactManager<T>::DoCalcContactSolverResults(
       EvalDiscreteContactPairs(context);
   DRAKE_DEMAND(discrete_pairs.size() == 0u);
 
+  const ContactProblemCache<T>& contact_problem_cache =
+      EvalContactProblemCache(context);
+  const SapContactProblem<T>& sap_problem = *contact_problem_cache.sap_problem;
+
   // In the absence of contact, v_next = v*.
-  results->v_next = EvalFreeMotionVelocities(context);
+  results->v_next = sap_problem.v_star();
   results->tau_contact.setZero();
+}
+
+template <typename T>
+std::vector<RotationMatrix<T>>
+CompliantContactManager<T>::AddContactConstraints(
+    const systems::Context<T>& context, SapContactProblem<T>* problem) const {
+  DRAKE_DEMAND(problem != nullptr);
+
+  // Parameters used by SAP to estimate regularization, see [Castro et al.,
+  // 2021].
+  // TODO(amcastro-tri): consider exposing these parameters.
+  constexpr double beta = 1.0;
+  constexpr double sigma = 1.0e-3;
+
+  const std::vector<internal::DiscreteContactPair<T>>& contact_pairs =
+      EvalDiscreteContactPairs(context);
+  const int num_contacts = contact_pairs.size();
+
+  // Quick no-op exit.
+  if (num_contacts == 0) return std::vector<RotationMatrix<T>>();
+
+  std::vector<ContactPairKinematics<T>> contact_kinematics =
+      CalcContactKinematics(context);
+
+  std::vector<RotationMatrix<T>> R_WC;
+  R_WC.reserve(num_contacts);
+  for (int icontact = 0; icontact < num_contacts; ++icontact) {
+    const auto& discrete_pair = contact_pairs[icontact];
+
+    const T stiffness = discrete_pair.stiffness;
+    const T dissipation_time_scale = discrete_pair.dissipation_time_scale;
+    const T friction = discrete_pair.friction_coefficient;
+    const T phi = contact_kinematics[icontact].phi;
+    const auto& jacobian_blocks = contact_kinematics[icontact].jacobian;
+
+    const typename SapFrictionConeConstraint<T>::Parameters parameters{
+        friction, stiffness, dissipation_time_scale, beta, sigma};
+
+    if (jacobian_blocks.size() == 1) {
+      problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<T>>(
+          jacobian_blocks[0].tree, std::move(jacobian_blocks[0].J), phi,
+          parameters));
+    } else {
+      problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<T>>(
+          jacobian_blocks[0].tree, jacobian_blocks[1].tree,
+          std::move(jacobian_blocks[0].J), std::move(jacobian_blocks[1].J), phi,
+          parameters));
+    }
+    R_WC.emplace_back(std::move(contact_kinematics[icontact].R_WC));
+  }
+  return R_WC;
+}
+
+template <typename T>
+void CompliantContactManager<T>::CalcContactProblemCache(
+    const systems::Context<T>& context, ContactProblemCache<T>* cache) const {
+  SapContactProblem<T>& problem = *cache->sap_problem;
+  std::vector<MatrixX<T>> A;
+  CalcLinearDynamicsMatrix(context, &A);
+  VectorX<T> v_star;
+  CalcFreeMotionVelocities(context, &v_star);
+  problem.Reset(std::move(A), std::move(v_star));
+  cache->R_WC = AddContactConstraints(context, &problem);
+}
+
+template <typename T>
+const ContactProblemCache<T>&
+CompliantContactManager<T>::EvalContactProblemCache(
+    const systems::Context<T>& context) const {
+  return plant()
+      .get_cache_entry(cache_indexes_.contact_problem)
+      .template Eval<ContactProblemCache<T>>(context);
 }
 
 }  // namespace internal

--- a/multibody/plant/compliant_contact_manager.h
+++ b/multibody/plant/compliant_contact_manager.h
@@ -4,11 +4,13 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/scene_graph_inspector.h"
 #include "drake/math/rotation_matrix.h"
+#include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
 #include "drake/multibody/plant/discrete_update_manager.h"
 #include "drake/systems/framework/context.h"
 
@@ -37,7 +39,7 @@ struct ContactPairKinematics {
   };
 
   ContactPairKinematics(T phi_in, std::vector<JacobianTreeBlock> jacobian_in,
-                        drake::math::RotationMatrix<T> R_WC_in)
+                        math::RotationMatrix<T> R_WC_in)
       : phi(std::move(phi_in)),
         jacobian(std::move(jacobian_in)),
         R_WC(std::move(R_WC_in)) {}
@@ -54,7 +56,7 @@ struct ContactPairKinematics {
   std::vector<JacobianTreeBlock> jacobian;
 
   // Rotation matrix to re-express between contact frame C and world frame W.
-  drake::math::RotationMatrix<T> R_WC;
+  math::RotationMatrix<T> R_WC;
 };
 
 // CompliantContactManager computes the contact Jacobian J_AcBc_C for the
@@ -79,6 +81,19 @@ struct AccelerationsDueToExternalForcesCache {
   MultibodyForces<T> forces;  // The external forces causing accelerations.
   multibody::internal::ArticulatedBodyForceCache<T> aba_forces;  // ABA cache.
   multibody::internal::AccelerationKinematicsCache<T> ac;  // Accelerations.
+};
+
+template <typename T>
+struct ContactProblemCache {
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ContactProblemCache);
+  explicit ContactProblemCache(double time_step) {
+    sap_problem =
+        std::make_unique<contact_solvers::internal::SapContactProblem<T>>(
+            time_step);
+  }
+  copyable_unique_ptr<contact_solvers::internal::SapContactProblem<T>>
+      sap_problem;
+  std::vector<math::RotationMatrix<T>> R_WC;
 };
 
 // This class implements the interface given by DiscreteUpdateManager so that
@@ -125,9 +140,8 @@ class CompliantContactManager final
   // Struct used to conglomerate the indexes of cache entries declared by the
   // manager.
   struct CacheIndexes {
-    systems::CacheIndex contact_jacobian;
+    systems::CacheIndex contact_problem;
     systems::CacheIndex discrete_contact_pairs;
-    systems::CacheIndex free_motion_velocities;
     systems::CacheIndex non_contact_forces_accelerations;
     systems::CacheIndex non_contact_forces_evaluation_in_progress;
   };
@@ -142,8 +156,8 @@ class CompliantContactManager final
   }
 
   // TODO(amcastro-tri): Implement these methods in future PRs.
-  void DoCalcDiscreteValues(const drake::systems::Context<T>&,
-                            drake::systems::DiscreteValues<T>*) const final {
+  void DoCalcDiscreteValues(const systems::Context<T>&,
+                            systems::DiscreteValues<T>*) const final {
     throw std::runtime_error(
         "CompliantContactManager::DoCalcDiscreteValues() must be "
         "implemented.");
@@ -176,6 +190,16 @@ class CompliantContactManager final
   // "dissipation_time_constant". If not present, it returns
   // plant().time_step().
   T GetDissipationTimeConstant(
+      geometry::GeometryId id,
+      const geometry::SceneGraphInspector<T>& inspector) const;
+
+  // Helper to acquire per-geometry Coulomb friction coefficients from
+  // SceneGraph. Discrete models cannot make a distinction between static and
+  // dynamic coefficients of friction. Therefore this method returns the
+  // coefficient of dynamic friction stored by SceneGraph while the coefficient
+  // of static friction is ignored.
+  // @pre id is a valid GeometryId in the inspector.
+  double GetCoulombFriction(
       geometry::GeometryId id,
       const geometry::SceneGraphInspector<T>& inspector) const;
 
@@ -219,13 +243,9 @@ class CompliantContactManager final
   const std::vector<internal::DiscreteContactPair<T>>& EvalDiscreteContactPairs(
       const systems::Context<T>& context) const;
 
-  // Given the configuration stored in `context`, this method computes the
-  // contact Jacobian cache. See ContactJacobianCache for details.
-  void CalcContactJacobianCache(const systems::Context<T>& context,
-                                internal::ContactJacobianCache<T>* cache) const;
-
-  // Eval version of CalcContactJacobianCache().
-  const internal::ContactJacobianCache<T>& EvalContactJacobianCache(
+  // This method computes the kinematics information for each contact pair at
+  // the given configuration stored in `context`.
+  std::vector<ContactPairKinematics<T>> CalcContactKinematics(
       const systems::Context<T>& context) const;
 
   // Given the previous state x0 stored in `context`, this method computes the
@@ -233,9 +253,11 @@ class CompliantContactManager final
   void CalcFreeMotionVelocities(const systems::Context<T>& context,
                                 VectorX<T>* v_star) const;
 
-  // Eval version of CalcFreeMotionVelocities().
-  const VectorX<T>& EvalFreeMotionVelocities(
-      const systems::Context<T>& context) const;
+  // Computes the linearized momentum equation matrix A to build the SAP
+  // contact problem. Refer to SapContactProblem's class documentation for
+  // details.
+  void CalcLinearDynamicsMatrix(const systems::Context<T>& context,
+                                std::vector<MatrixX<T>>* A) const;
 
   // Calc non-contact forces and the accelerations they induce.
   void CalcAccelerationsDueToNonContactForcesCache(
@@ -248,6 +270,27 @@ class CompliantContactManager final
   EvalAccelerationsDueToNonContactForcesCache(
       const systems::Context<T>& context) const;
 
+  // Computes the necessary data to describe the SAP contact problem. Additional
+  // information such as the orientation of each contact frame in the world is
+  // also computed here so that it can be used at a later stage to compute
+  // contact results.
+  void CalcContactProblemCache(const systems::Context<T>& context,
+                               ContactProblemCache<T>* cache) const;
+
+  // Eval version of CalcContactProblemCache().
+  const ContactProblemCache<T>& EvalContactProblemCache(
+      const systems::Context<T>& context) const;
+
+  // Add contact constraints for the configuration stored in `context` into
+  // `problem`. This method returns the orientation of the contact frame in the
+  // world frame for each contact constraint added to `problem`. That is, the
+  // i-th entry in the return vector corresponds to the orientation R_WC contact
+  // frame in the world frame for the i-th contact constraint added to
+  // `problem`.
+  std::vector<math::RotationMatrix<T>> AddContactConstraints(
+      const systems::Context<T>& context,
+      contact_solvers::internal::SapContactProblem<T>* problem) const;
+
   std::unique_ptr<contact_solvers::internal::ContactSolver<T>> contact_solver_;
   CacheIndexes cache_indexes_;
 };
@@ -256,5 +299,5 @@ class CompliantContactManager final
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class ::drake::multibody::internal::CompliantContactManager);

--- a/multibody/plant/discrete_contact_pair.h
+++ b/multibody/plant/discrete_contact_pair.h
@@ -38,6 +38,12 @@ struct DiscreteContactPair {
   T stiffness{0.0};
   /* The effective damping of the contact pair. */
   T damping{0.0};
+  /* Dissipation time scale, in seconds. For linear models of dissipation. It's
+   always initialized to NAN here and remains set to NAN if unused. */
+  T dissipation_time_scale{NAN};
+  /* Coefficient of friction. It's always initialized to NAN here and remains
+   set to NAN if unused. */
+  T friction_coefficient{NAN};
 };
 
 }  // namespace internal

--- a/multibody/plant/test/compliant_contact_manager_test.cc
+++ b/multibody/plant/test/compliant_contact_manager_test.cc
@@ -7,6 +7,8 @@
 #include "drake/geometry/proximity/volume_mesh_field.h"
 #include "drake/geometry/proximity_properties.h"
 #include "drake/multibody/contact_solvers/pgs_solver.h"
+#include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
+#include "drake/multibody/contact_solvers/sap/sap_friction_cone_constraint.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/systems/primitives/pass_through.h"
@@ -22,6 +24,8 @@ using drake::geometry::VolumeMeshFieldLinear;
 using drake::math::RigidTransformd;
 using drake::math::RotationMatrixd;
 using drake::multibody::contact_solvers::internal::PgsSolver;
+using drake::multibody::contact_solvers::internal::SapContactProblem;
+using drake::multibody::contact_solvers::internal::SapFrictionConeConstraint;
 using drake::multibody::internal::DiscreteContactPair;
 using drake::systems::Context;
 using drake::systems::PassThrough;
@@ -29,6 +33,8 @@ using drake::systems::ZeroOrderHold;
 using Eigen::MatrixXd;
 using Eigen::Vector3d;
 using Eigen::VectorXd;
+
+// TODO(amcastro-tri): Implement AutoDiffXd testing.
 
 namespace drake {
 namespace multibody {
@@ -178,7 +184,7 @@ class CompliantContactManagerTest : public ::testing::Test {
   // hydroelastic contact model.
   // Point contact stiffness must be provided for both spheres in
   // sphere1_point_params and sphere2_point_params.
-  void VerifyDiscreteContactPairsFromPointContact(
+  void VerifyDiscreteContactPairs(
       const ContactParameters& sphere1_point_params,
       const ContactParameters& sphere2_point_params) {
     // This test is specific to point contact. Both spheres must have point
@@ -213,53 +219,68 @@ class CompliantContactManagerTest : public ::testing::Test {
 
     constexpr double kEps = std::numeric_limits<double>::epsilon();
 
-    // Here we use our knowledge that we always place point contact pairs
-    // followed by hydroelastic contact pairs.
-    const DiscreteContactPair<double>& point_pair = pairs[0];
-
     const GeometryId sphere2_geometry =
         plant_->GetCollisionGeometriesForBody(*sphere2_)[0];
 
-    const int sign = point_pair.id_A == sphere2_geometry ? 1 : -1;
-    const Vector3d normal_expected = sign * Vector3d::UnitZ();
-    EXPECT_TRUE(CompareMatrices(point_pair.nhat_BA_W, normal_expected));
+    for (int i = 0; i < static_cast<int>(pairs.size()); ++i) {
+      const DiscreteContactPair<double>& point_pair = pairs[i];
 
-    const double phi_expected = -penetration_distance_;
-    // The geometry engine computes absolute values of penetration to machine
-    // epsilon (at least for sphere vs. sphere contact).
-    EXPECT_NEAR(point_pair.phi0, phi_expected, kEps);
+      if (i == 0) {
+        // Unit tests for point contact only.
+        // Here we use our knowledge that we always place point contact pairs
+        // followed by hydroelastic contact pairs.
+        const double phi_expected = -penetration_distance_;
+        // The geometry engine computes absolute values of penetration to
+        // machine epsilon (at least for sphere vs. sphere contact).
+        EXPECT_NEAR(point_pair.phi0, phi_expected, kEps);
 
-    const double k1 = *sphere1_contact_params.point_stiffness;
-    const double k2 = *sphere2_contact_params.point_stiffness;
-    const double stiffness_expected = (k1 * k2) / (k1 + k2);
-    EXPECT_NEAR(point_pair.stiffness, stiffness_expected,
-                kEps * stiffness_expected);
+        const double k1 = *sphere1_contact_params.point_stiffness;
+        const double k2 = *sphere2_contact_params.point_stiffness;
+        const double stiffness_expected = (k1 * k2) / (k1 + k2);
+        EXPECT_NEAR(point_pair.stiffness, stiffness_expected,
+                    kEps * stiffness_expected);
 
-    const double tau1 = sphere1_contact_params.dissipation_time_constant;
-    const double tau2 = sphere2_contact_params.dissipation_time_constant;
-    const double dissipation_expected = stiffness_expected * (tau1 + tau2);
-    EXPECT_NEAR(point_pair.damping, dissipation_expected,
-                kEps * dissipation_expected);
+        // Verify contact location.
+        const double pz_WS1 =
+            plant_->GetFreeBodyPose(*plant_context_, *sphere1_)
+                .translation()
+                .z();
+        const double pz_WC = -k2 / (k1 + k2) * penetration_distance_ + pz_WS1 +
+                             sphere1_params.radius;
+        EXPECT_NEAR(point_pair.p_WC.z(), pz_WC, 1.0e-14);
+      }
 
-    const double pz_WS1 =
-        plant_->GetFreeBodyPose(*plant_context_, *sphere1_).translation().z();
-    const double pz_WC = -k2 / (k1 + k2) * penetration_distance_ + pz_WS1 +
-                         sphere1_params.radius;
-    EXPECT_NEAR(point_pair.p_WC.z(), pz_WC, 1.0e-14);
+      // Unit tests for both point and hydroelastic discrete pairs.
+      const int sign = point_pair.id_A == sphere2_geometry ? 1 : -1;
+      const Vector3d normal_expected = sign * Vector3d::UnitZ();
+      EXPECT_TRUE(CompareMatrices(point_pair.nhat_BA_W, normal_expected));
 
-    // A little error propagation here. The expected relative error in fn0 is:
-    //   |Δfₙ₀/fₙ₀| = |Δϕ/ϕ| + |Δk/k|
-    // In this case the error in ϕ dominates, since Δϕ is computed to machine
-    // epsilon by the geometry engine and ϕ = 10⁻³. Then we expect |Δfₙ₀/fₙ₀| ≈
-    // 10⁻¹³.
-    constexpr double fn0_tolerance = 1.0e-13;
-    const double fn0_expected = -stiffness_expected * phi_expected;
-    EXPECT_NEAR(point_pair.fn0, fn0_expected, fn0_tolerance * fn0_expected);
+      // Verify dissipation.
+      const double tau1 = sphere1_contact_params.dissipation_time_constant;
+      const double tau2 = i == 0
+                              ? sphere2_contact_params.dissipation_time_constant
+                              : hard_hydro_contact.dissipation_time_constant;
+      const double tau_expected = tau1 + tau2;
+      EXPECT_NEAR(point_pair.dissipation_time_scale, tau_expected,
+                  kEps * tau_expected);
+
+      // Verify friction.
+      const double mu1 = sphere1_contact_params.friction_coefficient;
+      const double mu2 = i == 0 ? sphere2_contact_params.friction_coefficient
+                                : hard_hydro_contact.friction_coefficient;
+      const double mu_expected = 2.0 * (mu1 * mu2) / (mu1 + mu2);
+      EXPECT_NEAR(point_pair.friction_coefficient, mu_expected,
+                  kEps * mu_expected);
+    }
   }
 
   // In the functions below we use CompliantContactManagerTest's friendship with
   // CompliantContactManager to provide access to private functions for unit
   // testing.
+
+  const internal::MultibodyTreeTopology& topology() const {
+    return contact_manager_->tree_topology();
+  }
 
   const std::vector<PenetrationAsPointPair<double>>& EvalPointPairPenetrations(
       const Context<double>& context) const {
@@ -276,9 +297,14 @@ class CompliantContactManagerTest : public ::testing::Test {
     return contact_manager_->EvalDiscreteContactPairs(context);
   }
 
-  const internal::ContactJacobianCache<double>& EvalContactJacobianCache(
-      const systems::Context<double>& context) const {
-    return contact_manager_->EvalContactJacobianCache(context);
+  std::vector<ContactPairKinematics<double>> CalcContactKinematics(
+      const Context<double>& context) const {
+    return contact_manager_->CalcContactKinematics(context);
+  }
+
+  const ContactProblemCache<double>& EvalContactProblemCache(
+      const Context<double>& context) const {
+    return contact_manager_->EvalContactProblemCache(context);
   }
 
   VectorXd CalcFreeMotionVelocities(
@@ -288,14 +314,19 @@ class CompliantContactManagerTest : public ::testing::Test {
     return v_star;
   }
 
-  // Helper function to unit test EvalContactJacobianCache().
-  // This function takes the Jacobian blocks evaluated with
+  std::vector<MatrixXd> CalcLinearDynamicsMatrix(
+      const systems::Context<double>& context) const {
+    std::vector<MatrixXd> A;
+    contact_manager_->CalcLinearDynamicsMatrix(context, &A);
+    return A;
+  }
+
+  // Helper method to unit test EvalContactJacobianCache().
+  // This method takes the Jacobian blocks evaluated with
   // EvalContactJacobianCache() and assembles them into a dense Jacobian matrix.
   MatrixXd CalcDenseJacobianMatrix(
-      const internal::ContactJacobianCache<double>& cache) const {
-    const std::vector<ContactPairKinematics<double>>& contact_kinematics =
-        cache.contact_kinematics;
-    const MultibodyTreeTopology& topology = contact_manager_->tree_topology();
+      const std::vector<ContactPairKinematics<double>>& contact_kinematics)
+      const {
     const int nc = contact_kinematics.size();
     MatrixXd J_AcBc_W(3 * nc, contact_manager_->plant().num_velocities());
     J_AcBc_W.setZero();
@@ -308,8 +339,8 @@ class CompliantContactManagerTest : public ::testing::Test {
         // If added to the Jacobian, it must have a valid index.
         EXPECT_TRUE(tree_jacobian.tree.is_valid());
         const int col_offset =
-            topology.tree_velocities_start(tree_jacobian.tree);
-        const int tree_nv = topology.num_tree_velocities(tree_jacobian.tree);
+            topology().tree_velocities_start(tree_jacobian.tree);
+        const int tree_nv = topology().num_tree_velocities(tree_jacobian.tree);
         J_AcBc_W.block(row_offset, col_offset, 3, tree_nv) =
             pair_kinematics.R_WC.matrix() * tree_jacobian.J;
       }
@@ -389,22 +420,18 @@ class CompliantContactManagerTest : public ::testing::Test {
 
 // Unit test to verify discrete contact pairs computed by the manager for
 // different combinations of compliance.
-TEST_F(CompliantContactManagerTest,
-       VerifyDiscreteContactPairsFromPointContact) {
+TEST_F(CompliantContactManagerTest, VerifyDiscreteContactPairs) {
   ContactParameters soft_point_contact{1.0e3, std::nullopt, 0.01, 1.0};
   ContactParameters hard_point_contact{1.0e40, std::nullopt, 0.0, 1.0};
 
   // Hard sphere 1/soft sphere 2.
-  VerifyDiscreteContactPairsFromPointContact(hard_point_contact,
-                                             soft_point_contact);
+  VerifyDiscreteContactPairs(hard_point_contact, soft_point_contact);
 
   // Equally soft spheres.
-  VerifyDiscreteContactPairsFromPointContact(soft_point_contact,
-                                             soft_point_contact);
+  VerifyDiscreteContactPairs(soft_point_contact, soft_point_contact);
 
   // Soft sphere 1/hard sphere 2.
-  VerifyDiscreteContactPairsFromPointContact(soft_point_contact,
-                                             hard_point_contact);
+  VerifyDiscreteContactPairs(soft_point_contact, hard_point_contact);
 }
 
 // Unit test to verify discrete contact pairs computed by the manager for
@@ -427,16 +454,16 @@ TEST_F(CompliantContactManagerTest,
 }
 
 // Unit test to verify the computation of the contact Jacobian.
-TEST_F(CompliantContactManagerTest, EvalContactJacobianCache) {
+TEST_F(CompliantContactManagerTest, CalcContactKinematics) {
   SetupRigidGroundCompliantSphereAndNonHydroSphere();
   const double radius = 0.2;  // Spheres's radii in the default setup.
   const double kTolerance = std::numeric_limits<double>::epsilon();
 
   const std::vector<DiscreteContactPair<double>>& pairs =
       EvalDiscreteContactPairs(*plant_context_);
-  const internal::ContactJacobianCache<double>& jacobian_cache =
-      EvalContactJacobianCache(*plant_context_);
-  const MatrixXd& J_AcBc_W = CalcDenseJacobianMatrix(jacobian_cache);
+  const std::vector<ContactPairKinematics<double>> contact_kinematics =
+      CalcContactKinematics(*plant_context_);
+  const MatrixXd& J_AcBc_W = CalcDenseJacobianMatrix(contact_kinematics);
 
   // Arbitrary velocity of sphere 1.
   const Vector3d v_WS1(1, 2, 3);
@@ -476,7 +503,7 @@ TEST_F(CompliantContactManagerTest, EvalContactJacobianCache) {
                                 MatrixCompareType::relative));
 
     // Verify we loaded phi correctly.
-    EXPECT_EQ(pairs[0].phi0, jacobian_cache.contact_kinematics[0].phi);
+    EXPECT_EQ(pairs[0].phi0, contact_kinematics[0].phi);
   }
 
   // Verify contact Jacobian for hydroelastic pairs.
@@ -495,8 +522,74 @@ TEST_F(CompliantContactManagerTest, EvalContactJacobianCache) {
                                   MatrixCompareType::relative));
 
       // Verify we loaded phi correctly.
-      EXPECT_EQ(pairs[q].phi0, jacobian_cache.contact_kinematics[q].phi);
+      EXPECT_EQ(pairs[q].phi0, contact_kinematics[q].phi);
     }
+  }
+}
+
+// This test verifies that the SapContactProblem built by the manager is
+// consistent with the contact kinematics computed with CalcContactKinematics().
+TEST_F(CompliantContactManagerTest, EvalContactProblemCache) {
+  SetupRigidGroundCompliantSphereAndNonHydroSphere();
+  const ContactProblemCache<double>& problem_cache =
+      EvalContactProblemCache(*plant_context_);
+  const SapContactProblem<double>& problem = *problem_cache.sap_problem;
+  const std::vector<drake::math::RotationMatrix<double>>& R_WC =
+      problem_cache.R_WC;
+
+  const std::vector<DiscreteContactPair<double>>& pairs =
+      EvalDiscreteContactPairs(*plant_context_);
+  const int num_contacts = pairs.size();
+
+  // Verify sizes.
+  EXPECT_EQ(problem.num_cliques(), topology().num_trees());
+  EXPECT_EQ(problem.num_velocities(), plant_->num_velocities());
+  EXPECT_EQ(problem.num_constraints(), num_contacts);
+  EXPECT_EQ(problem.num_constraint_equations(), 3 * num_contacts);
+  EXPECT_EQ(problem.time_step(), plant_->time_step());
+  ASSERT_EQ(R_WC.size(), num_contacts);
+
+  // Verify dynamics data.
+  const VectorXd& v_star = CalcFreeMotionVelocities(*plant_context_);
+  const std::vector<MatrixXd>& A = CalcLinearDynamicsMatrix(*plant_context_);
+  EXPECT_EQ(problem.v_star(), v_star);
+  EXPECT_EQ(problem.dynamics_matrix(), A);
+
+  // Verify each of the contact constraints.
+  const std::vector<ContactPairKinematics<double>> contact_kinematics =
+      CalcContactKinematics(*plant_context_);
+  for (size_t i = 0; i < contact_kinematics.size(); ++i) {
+    const DiscreteContactPair<double>& discrete_pair = pairs[i];
+    const ContactPairKinematics<double>& pair_kinematics =
+        contact_kinematics[i];
+    const auto* constraint =
+        dynamic_cast<const SapFrictionConeConstraint<double>*>(
+            &problem.get_constraint(i));
+    // In this test we do know all constraints are contact constraints.
+    ASSERT_NE(constraint, nullptr);
+    EXPECT_EQ(constraint->constraint_function(),
+              Vector3d(0., 0., pair_kinematics.phi));
+    EXPECT_EQ(constraint->num_cliques(), pair_kinematics.jacobian.size());
+    EXPECT_EQ(constraint->first_clique(), pair_kinematics.jacobian[0].tree);
+    EXPECT_EQ(constraint->first_clique_jacobian(),
+              pair_kinematics.jacobian[0].J);
+    if (constraint->num_cliques() == 2) {
+      EXPECT_EQ(constraint->second_clique(), pair_kinematics.jacobian[1].tree);
+      EXPECT_EQ(constraint->second_clique_jacobian(),
+                pair_kinematics.jacobian[1].J);
+    }
+    EXPECT_EQ(constraint->parameters().mu, discrete_pair.friction_coefficient);
+    EXPECT_EQ(constraint->parameters().stiffness, discrete_pair.stiffness);
+    EXPECT_EQ(constraint->parameters().dissipation_time_scale,
+              discrete_pair.dissipation_time_scale);
+    // These two parameters, beta and sigma, are for now hard-code in the
+    // manager to these values. Here we simply tests they are consistent with
+    // those hard-coded values.
+    EXPECT_EQ(constraint->parameters().beta, 1.0);
+    EXPECT_EQ(constraint->parameters().sigma, 1.0e-3);
+
+    // Verify contact frame orientation matrix R_WC.
+    EXPECT_EQ(R_WC[i].matrix(), pair_kinematics.R_WC.matrix());
   }
 }
 
@@ -540,8 +633,7 @@ TEST_F(CompliantContactManagerTest, CalcFreeMotionVelocitiesWithJointLimits) {
   // In this model sphere 1 is attached to the world by a prismatic joint with
   // lower limit z = 0.
   const bool sphere1_on_prismatic_joint = true;
-  SetupRigidGroundCompliantSphereAndNonHydroSphere(
-      sphere1_on_prismatic_joint);
+  SetupRigidGroundCompliantSphereAndNonHydroSphere(sphere1_on_prismatic_joint);
 
   const int nv = plant_->num_velocities();
 
@@ -581,6 +673,23 @@ TEST_F(CompliantContactManagerTest, CalcFreeMotionVelocitiesWithJointLimits) {
   // Therefore we only check the force limits have the effect of making the
   // slider velocity larger than if not present.
   EXPECT_GT(v_slider_star, v_slider_no_limits);
+}
+
+TEST_F(CompliantContactManagerTest, CalcLinearDynamicsMatrix) {
+  SetupRigidGroundCompliantSphereAndNonHydroSphere();
+  const std::vector<MatrixXd> A = CalcLinearDynamicsMatrix(*plant_context_);
+  const int nv = plant_->num_velocities();
+  MatrixXd Adense = MatrixXd::Zero(nv, nv);
+  for (TreeIndex t(0); t < topology().num_trees(); ++t) {
+    const int tree_start = topology().tree_velocities_start(t);
+    const int tree_nv = topology().num_tree_velocities(t);
+    Adense.block(tree_start, tree_start, tree_nv, tree_nv) = A[t];
+  }
+  MatrixXd Aexpected(nv, nv);
+  plant_->CalcMassMatrix(*plant_context_, &Aexpected);
+  EXPECT_TRUE(CompareMatrices(Adense, Aexpected,
+                              std::numeric_limits<double>::epsilon(),
+                              MatrixCompareType::relative));
 }
 
 // CompliantContactManager implements a workaround for issue #12786 which might


### PR DESCRIPTION
The contact manager builds the contact problem to be solved each time step.

Notice that in order to be able to `std::move` Jacobian data into the problem, this PR gets rid of `CalcContactJacobianCache()` and instead computes the Jacobian information **locally** where its needed (in `AddContactConstraints()`) with `CalcContactKinematics()`.

Towards landing the [SapSolver](https://github.com/RobotLocomotion/drake/projects/10). Full working prototype in https://github.com/RobotLocomotion/drake/pull/16543.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16903)
<!-- Reviewable:end -->
