### PR TITLE
Use reference `&` to fix errors in CI mac-monterey-clang-bazel-continuous-release

### DIFF
--- a/multibody/parsing/test/diagnostic_policy_test_base.h
+++ b/multibody/parsing/test/diagnostic_policy_test_base.h
@@ -53,7 +53,7 @@ class DiagnosticPolicyTestBase : public ::testing::Test {
  protected:
   std::string DumpErrors() {
     std::stringstream stream;
-    for (const DiagnosticDetail record : error_records_) {
+    for (const DiagnosticDetail& record : error_records_) {
       stream << record.FormatError() << '\n';
     }
     return stream.str();
@@ -61,7 +61,7 @@ class DiagnosticPolicyTestBase : public ::testing::Test {
 
   std::string DumpWarnings() {
     std::stringstream stream;
-    for (const DiagnosticDetail record : warning_records_) {
+    for (const DiagnosticDetail& record : warning_records_) {
       stream << record.FormatWarning() << '\n';
     }
     return stream.str();


### PR DESCRIPTION
Fix errors in [mac-monterey-clang-bazel-continuous-release/474](https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/mac-monterey-clang-bazel-continuous-release/474/)

```
bazel-out/darwin-opt/bin/multibody/parsing/_virtual_includes/diagnostic_policy_test_base/drake/multibody/parsing/test/diagnostic_policy_test_base.h:56:33: error: loop variable 'record' creates a copy from type 'const drake::internal::DiagnosticDetail' [-Werror,-Wrange-loop-construct]
    for (const DiagnosticDetail record : error_records_) {
                                ^
bazel-out/darwin-opt/bin/multibody/parsing/_virtual_includes/diagnostic_policy_test_base/drake/multibody/parsing/test/diagnostic_policy_test_base.h:64:33: error: loop variable 'record' creates a copy from type 'const drake::internal::DiagnosticDetail' [-Werror,-Wrange-loop-construct]
    for (const DiagnosticDetail record : warning_records_) {
                                ^
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16905)
<!-- Reviewable:end -->
