### PR TITLE
[examples/rimless_wheel] Improve meshcat animation

### DIFF
--- a/examples/rimless_wheel/rimless_wheel.cc
+++ b/examples/rimless_wheel/rimless_wheel.cc
@@ -179,6 +179,7 @@ void RimlessWheel<T>::FloatingBaseStateOut(
       get_continuous_state(context);
   const RimlessWheelParams<T>& params = get_parameters(context);
   const T toe = get_toe_position(context);
+  const T alpha = calc_alpha(params);
 
   // x, y, z.
   output->SetAtIndex(
@@ -189,7 +190,11 @@ void RimlessWheel<T>::FloatingBaseStateOut(
 
   // roll, pitch, yaw.
   output->SetAtIndex(3, 0.);
-  output->SetAtIndex(4, rw_state.theta());
+  // Unroll theta (add 2 alpha * number of steps, where number of steps = toe /
+  // stance length)
+  const T theta =
+      rw_state.theta() + alpha * toe / (params.length() * sin(alpha));
+  output->SetAtIndex(4, theta);
   output->SetAtIndex(5, 0.);
 
   // x, y, z derivatives.

--- a/examples/rimless_wheel/rimless_wheel.h
+++ b/examples/rimless_wheel/rimless_wheel.h
@@ -54,7 +54,7 @@ class RimlessWheel final : public systems::LeafSystem<T> {
 
   /// Return reference to the output port that publishes only [theta,
   /// thetatdot].
-  const systems::OutputPort<T>& get_minimal_state_output_port() {
+  const systems::OutputPort<T>& get_minimal_state_output_port() const {
     return this->get_output_port(0);
   }
 
@@ -64,7 +64,7 @@ class RimlessWheel final : public systems::LeafSystem<T> {
   /// of the floating base (rotation around global y), and downhill moves toward
   /// positive x.  As always, we use vehicle coordinates (x-y on the ground, z
   /// is up).
-  const systems::OutputPort<T>& get_floating_base_state_output_port() {
+  const systems::OutputPort<T>& get_floating_base_state_output_port() const {
     return this->get_output_port(1);
   }
 

--- a/examples/rimless_wheel/test/rimless_wheel_test.cc
+++ b/examples/rimless_wheel/test/rimless_wheel_test.cc
@@ -74,6 +74,10 @@ GTEST_TEST(RimlessWheelTest, StepTest) {
   // Should still have the same energy (dissipation energy lost = potential
   // energy gained). The error tolerance below seems to work well.
   EXPECT_NEAR(rw.CalcTotalEnergy(context), steady_state_energy, 1e-5);
+  // Floating-base state should unroll theta (pitch).
+  Eigen::VectorXd floating_base_state =
+      rw.get_floating_base_state_output_port().Eval(context);
+  EXPECT_GT(floating_base_state[4], params.slope() + alpha);
 
   // Lose at least this much energy (chosen as an arbitrary small positive
   // number).


### PR DESCRIPTION
Previously, the floating-base pose that was sent to the visualizer
changed discontinuously at each step.  This is fine for forward
simulation, but in meshcat's animation the interpolation effects of
scrubbing through frames caused visual artifacts.  This PR simply
unwraps the pitch angle to make it continuous during a simulation.

It also adds some missing const specifier to the accessor functions
(which were needed to write the test).

+@aykut-tri for feature review, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16906)
<!-- Reviewable:end -->
