### PR TITLE
DO NOT MERGE - macOS fission test

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -13,6 +13,7 @@ build -c opt
 build --force_pic
 build --strip=never
 build --strict_system_includes
+build --fission=yes
 
 # Default test options.
 test --test_output=errors


### PR DESCRIPTION
Unilaterally enable fission builds.

# **DO NOT MERGE THIS**

This is just to test disk usage on a macOS debug build. A proper implementation would only enable fission on the `apple_debug` configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16907)
<!-- Reviewable:end -->
