### PR TITLE
[parsing] Complete adding diagnostic policy in urdf_geometry

### DIFF
--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -220,7 +220,7 @@ void UrdfParser::ParseBody(XMLElement* node, MaterialMap* materials) {
          visual_node;
          visual_node = visual_node->NextSiblingElement("visual")) {
       std::optional<geometry::GeometryInstance> geometry_instance =
-          ParseVisual(body_name, w_.package_map, root_dir_,
+          ParseVisual(diagnostic_, body_name, w_.package_map, root_dir_,
                       visual_node, materials, &geometry_names);
       if (!geometry_instance) { continue; }
       // The parsing should *always* produce an IllustrationProperties
@@ -236,7 +236,7 @@ void UrdfParser::ParseBody(XMLElement* node, MaterialMap* materials) {
          collision_node;
          collision_node = collision_node->NextSiblingElement("collision")) {
       std::optional<geometry::GeometryInstance> geometry_instance =
-          ParseCollision(body_name, w_.package_map, root_dir_,
+          ParseCollision(diagnostic_, body_name, w_.package_map, root_dir_,
                          collision_node, &geometry_names);
       if (!geometry_instance) { continue; }
       DRAKE_DEMAND(geometry_instance->proximity_properties() != nullptr);
@@ -761,7 +761,7 @@ std::optional<ModelInstanceIndex> UrdfParser::Parse() {
   for (XMLElement* material_node = node->FirstChildElement("material");
        material_node;
        material_node = material_node->NextSiblingElement("material")) {
-    ParseMaterial(material_node, true /* name_required */,
+    ParseMaterial(diagnostic_, material_node, true /* name_required */,
                   w_.package_map, root_dir_, &materials);
   }
 


### PR DESCRIPTION
Relevant to: #16782

This patch finishes plumbing diagnostic policy through
detail_urdf_geometry. It also rewrites the existing tests to reduce
copy-paste, and adds numerous new tests to reach full coverage of all
the modified error and warning branches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16910)
<!-- Reviewable:end -->
