### PR TITLE
[WIP] SapSolver is no longer a ContactSolver

### DIFF
--- a/multibody/contact_solvers/BUILD.bazel
+++ b/multibody/contact_solvers/BUILD.bazel
@@ -25,7 +25,6 @@ drake_cc_package_library(
         ":linear_operator",
         ":pgs_solver",
         ":point_contact_data",
-        ":sap_solver",
         ":sparse_linear_operator",
         ":supernodal_solver",
         ":system_dynamics_data",
@@ -138,21 +137,6 @@ drake_cc_library(
 )
 
 drake_cc_library(
-    name = "sap_solver",
-    srcs = ["sap_solver.cc"],
-    hdrs = ["sap_solver.h"],
-    deps = [
-        ":block_sparse_matrix",
-        ":contact_solver",
-        ":contact_solver_utils",
-        ":point_contact_data",
-        ":system_dynamics_data",
-        "//common:default_scalars",
-        "//common:essential",
-    ],
-)
-
-drake_cc_library(
     name = "sparse_linear_operator",
     srcs = ["sparse_linear_operator.cc"],
     hdrs = ["sparse_linear_operator.h"],
@@ -227,17 +211,6 @@ drake_cc_googletest(
         ":pgs_solver",
         ":sparse_linear_operator",
         "//common/test_utilities:eigen_matrix_compare",
-    ],
-)
-
-drake_cc_googletest(
-    name = "sap_solver_test",
-    deps = [
-        ":block_sparse_linear_operator",
-        ":block_sparse_matrix",
-        "//common/test_utilities:eigen_matrix_compare",
-        "//common/test_utilities:expect_throws_message",
-        "//multibody/contact_solvers:sap_solver",
     ],
 )
 

--- a/multibody/contact_solvers/sap/BUILD.bazel
+++ b/multibody/contact_solvers/sap/BUILD.bazel
@@ -24,6 +24,8 @@ drake_cc_package_library(
         ":sap_contact_problem",
         ":sap_friction_cone_constraint",
         ":sap_model",
+        ":sap_solver",
+        ":sap_solver_results",
     ],
 )
 
@@ -110,6 +112,28 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "sap_solver",
+    srcs = ["sap_solver.cc"],
+    hdrs = ["sap_solver.h"],
+    deps = [
+        ":sap_solver_results",
+        "//common:default_scalars",
+        "//common:essential",
+        "//multibody/contact_solvers:block_sparse_matrix",
+        "//multibody/contact_solvers:contact_solver_utils",
+        "//multibody/contact_solvers:point_contact_data",
+        "//multibody/contact_solvers:system_dynamics_data",
+    ],
+)
+
+drake_cc_library(
+    name = "sap_solver_results",
+    srcs = ["sap_solver_results.cc"],
+    hdrs = ["sap_solver_results.h"],
+    deps = ["//common:default_scalars"],
+)
+
 drake_cc_googletest(
     name = "partial_permutation_test",
     deps = [
@@ -173,6 +197,18 @@ drake_cc_googletest(
         ":sap_model",
         "//common/test_utilities:eigen_matrix_compare",
         "//math:gradient",
+    ],
+)
+
+drake_cc_googletest(
+    name = "sap_solver_test",
+    deps = [
+        ":sap_solver",
+        ":sap_solver_results",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+        "//multibody/contact_solvers:block_sparse_linear_operator",
+        "//multibody/contact_solvers:block_sparse_matrix",
     ],
 )
 

--- a/multibody/contact_solvers/sap/sap_solver_results.cc
+++ b/multibody/contact_solvers/sap/sap_solver_results.cc
@@ -1,0 +1,6 @@
+#include "drake/multibody/contact_solvers/sap/sap_solver_results.h"
+
+#include "drake/common/default_scalars.h"
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    struct ::drake::multibody::contact_solvers::internal::SapSolverResults)

--- a/multibody/contact_solvers/sap/sap_solver_results.h
+++ b/multibody/contact_solvers/sap/sap_solver_results.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+// This struct stores the results from a computation performed with
+// a SapSolver.
+template <class T>
+struct SapSolverResults {
+  // Resizes `this` object to store the contact results for a problem with
+  // `num_velocities` and `num_constraint_equations`.
+  void Resize(int num_velocities, int num_constraint_equations) {
+    v.resize(num_velocities);
+    gamma.resize(num_constraint_equations);
+    vc.resize(num_constraint_equations);
+    j.resize(num_velocities);
+  }
+
+  // Vector of generalized velocities at the next time step.
+  VectorX<T> v;
+
+  // Constraints' impulses, of size `num_constraint_equations`.
+  VectorX<T> gamma;
+
+  // Constraints' velocities vc = J⋅v, where J is the contact Jacobian. Of size
+  // `num_constraint_equations`.
+  VectorX<T> vc;
+
+  // Vector of generalized impulses j = Jᵀ⋅γ due to constraints, where J is the
+  // contact Jacobian. Of size `num_velocities`.
+  VectorX<T> j;
+};
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    struct ::drake::multibody::contact_solvers::internal::SapSolverResults)


### PR DESCRIPTION
  The ContactSolver abstraction has been very useful to prototype and test a number of solver technologies, including SAP. However the SapSolver has now been engineered to exploit the sparsity of contact problems and no longer fits the much narrower ContactSolver abstraction. For instance, ContactSolver does not support general constraints, while SapSolver does.

  In this PR:
    1. SapSolver no longer inherits from ContactSolver.
    2. Introduce SapSolverResults, instead of reusing the old ContactSolverResults, which does not support general constraints.
    3. Refactor SapSolver unit tests in terms of the new SapSolverResults.
    4. Move SapSolver files into `multibody/contact_solvers/sap`

Since Reviewable was smart enough to identify the moved files and differences, I decided to make this a single refactor PR.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16912)
<!-- Reviewable:end -->
