### PR TITLE
[multibody] Adds hydroelastic force and moment vector visualization.

### DIFF
--- a/bindings/pydrake/multibody/meshcat_py.cc
+++ b/bindings/pydrake/multibody/meshcat_py.cc
@@ -11,6 +11,7 @@
 #include "drake/multibody/meshcat/contact_visualizer_params.h"
 #include "drake/multibody/meshcat/joint_sliders.h"
 #include "drake/multibody/meshcat/point_contact_visualizer.h"
+#include "drake/multibody/meshcat/hydroelastic_contact_visualizer.h"
 
 using drake::multibody::MultibodyPlant;
 using drake::systems::LeafSystem;
@@ -87,6 +88,33 @@ void DoScalarIndependentDefinitions(py::module m) {
                  ContactVisualizerParams>(),
             py::arg("meshcat"), py::arg("params"), doc_internal)
         .def("Update", &Class::Update, py::arg("items"));
+  }
+
+  // HydroelasticContactVisualizerItem (internal)
+  {
+    using Class =
+        multibody::meshcat::internal::HydroelasticContactVisualizerItem;
+    constexpr char doc_internal[] = "(internal use only)";
+    py::class_<Class>(m, "_HydroelasticContactVisualizerItem",
+        py::dynamic_attr(), doc_internal)
+        .def(ParamInit<Class>())
+        .def_readwrite("body_A", &Class::body_A, doc_internal)
+        .def_readwrite("body_B", &Class::body_B, doc_internal)
+        .def_readwrite("centroid_W", &Class::centroid_W, doc_internal)
+        .def_readwrite("force_C_W", &Class::force_C_W, doc_internal)
+        .def_readwrite("moment_C_W", &Class::moment_C_W, doc_internal);
+  }
+
+  // HydroelasticContactVisualizer (internal)
+  {
+    using Class = multibody::meshcat::internal::HydroelasticContactVisualizer;
+    constexpr char doc_internal[] = "(internal use only)";
+    py::class_<Class>(m, "_HydroelasticContactVisualizer", doc_internal)
+        .def(py::init<std::shared_ptr<geometry::Meshcat>,
+                 ContactVisualizerParams>(),
+            py::arg("meshcat"), py::arg("params"), doc_internal)
+        .def("Update", &Class::Update, py::arg("items"))
+        .def("Delete", &Class::Delete);
   }
 }
 

--- a/bindings/pydrake/multibody/meshcat_py.cc
+++ b/bindings/pydrake/multibody/meshcat_py.cc
@@ -9,9 +9,9 @@
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/multibody/meshcat/contact_visualizer.h"
 #include "drake/multibody/meshcat/contact_visualizer_params.h"
+#include "drake/multibody/meshcat/hydroelastic_contact_visualizer.h"
 #include "drake/multibody/meshcat/joint_sliders.h"
 #include "drake/multibody/meshcat/point_contact_visualizer.h"
-#include "drake/multibody/meshcat/hydroelastic_contact_visualizer.h"
 
 using drake::multibody::MultibodyPlant;
 using drake::systems::LeafSystem;

--- a/bindings/pydrake/multibody/meshcat_py.cc
+++ b/bindings/pydrake/multibody/meshcat_py.cc
@@ -37,6 +37,12 @@ void DoScalarIndependentDefinitions(py::module m) {
             cls_doc.publish_period.doc)
         .def_readwrite(
             "color", &ContactVisualizerParams::color, cls_doc.color.doc)
+        .def_readwrite("hydro_force_color",
+            &ContactVisualizerParams::hydro_force_color,
+            cls_doc.hydro_force_color.doc)
+        .def_readwrite("hydro_moment_color",
+            &ContactVisualizerParams::hydro_moment_color,
+            cls_doc.hydro_moment_color.doc)
         .def_readwrite(
             "prefix", &ContactVisualizerParams::prefix, cls_doc.prefix.doc)
         .def_readwrite("delete_on_initialization_event",
@@ -45,9 +51,15 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def_readwrite("force_threshold",
             &ContactVisualizerParams::force_threshold,
             cls_doc.force_threshold.doc)
+        .def_readwrite("moment_threshold",
+            &ContactVisualizerParams::moment_threshold,
+            cls_doc.moment_threshold.doc)
         .def_readwrite("newtons_per_meter",
             &ContactVisualizerParams::newtons_per_meter,
             cls_doc.newtons_per_meter.doc)
+        .def_readwrite("newton_meters_per_meter",
+            &ContactVisualizerParams::newton_meters_per_meter,
+            cls_doc.newton_meters_per_meter.doc)
         .def_readwrite(
             "radius", &ContactVisualizerParams::radius, cls_doc.radius.doc)
         .def("__repr__", [](const Class& self) {
@@ -55,14 +67,20 @@ void DoScalarIndependentDefinitions(py::module m) {
               "ContactVisualizerParams("
               "publish_period={}, "
               "color={}, "
+              "hydro_force_color={}, "
+              "hydro_moment_color={} "
               "prefix={}, "
               "delete_on_initialization_event={}, "
               "force_threshold={}, "
+              "moment_threshold={} "
               "newtons_per_meter={}, "
+              "newton_meters_per_meter={} "
               "radius={})")
-              .format(self.publish_period, self.color, self.prefix,
+              .format(self.publish_period, self.color, self.hydro_force_color,
+                  self.hydro_moment_color, self.prefix,
                   self.delete_on_initialization_event, self.force_threshold,
-                  self.newtons_per_meter, self.radius);
+                  self.moment_threshold, self.newtons_per_meter,
+                  self.newton_meters_per_meter, self.radius);
         });
   }
 
@@ -72,7 +90,10 @@ void DoScalarIndependentDefinitions(py::module m) {
     constexpr char doc_internal[] = "(internal use only)";
     py::class_<Class>(
         m, "_PointContactVisualizerItem", py::dynamic_attr(), doc_internal)
-        .def(ParamInit<Class>())
+        .def(py::init<std::string, std::string, Eigen::Vector3d,
+                 Eigen::Vector3d>(),
+            py::arg("body_A"), py::arg("body_B"), py::arg("contact_force"),
+            py::arg("contact_point"), doc_internal)
         .def_readwrite("body_A", &Class::body_A, doc_internal)
         .def_readwrite("body_B", &Class::body_B, doc_internal)
         .def_readwrite("contact_force", &Class::contact_force, doc_internal)
@@ -97,7 +118,10 @@ void DoScalarIndependentDefinitions(py::module m) {
     constexpr char doc_internal[] = "(internal use only)";
     py::class_<Class>(m, "_HydroelasticContactVisualizerItem",
         py::dynamic_attr(), doc_internal)
-        .def(ParamInit<Class>())
+        .def(py::init<std::string, std::string, Eigen::Vector3d,
+                 Eigen::Vector3d, Eigen::Vector3d>(),
+            py::arg("body_A"), py::arg("body_B"), py::arg("centroid_W"),
+            py::arg("force_C_W"), py::arg("moment_C_W"), doc_internal)
         .def_readwrite("body_A", &Class::body_A, doc_internal)
         .def_readwrite("body_B", &Class::body_B, doc_internal)
         .def_readwrite("centroid_W", &Class::centroid_W, doc_internal)

--- a/bindings/pydrake/multibody/test/meshcat_test.py
+++ b/bindings/pydrake/multibody/test/meshcat_test.py
@@ -2,6 +2,7 @@ from pydrake.multibody.meshcat import (
     ContactVisualizer_,
     ContactVisualizerParams,
     JointSliders,
+    _HydroelasticContactVisualizer,
     _PointContactVisualizer,
 )
 
@@ -132,3 +133,11 @@ class TestMeshcat(unittest.TestCase):
         meshcat = Meshcat()
         params = ContactVisualizerParams()
         dut = _PointContactVisualizer(meshcat=meshcat, params=params)
+
+    def test_internal_hydroelastic_contact_visualizer(self):
+        """A very basic existance test, since this class is internal use only.
+        The pydrake-internal user (meldis) has additional acceptance tests.
+        """
+        meshcat = Meshcat()
+        params = ContactVisualizerParams()
+        dut = _HydroelasticContactVisualizer(meshcat=meshcat, params=params)

--- a/bindings/pydrake/visualization/BUILD.bazel
+++ b/bindings/pydrake/visualization/BUILD.bazel
@@ -90,6 +90,7 @@ drake_py_unittest(
     name = "meldis_test",
     data = [
         "//multibody/benchmarks/acrobot:models",
+        "//multibody/meshcat:models",
     ],
     deps = [
         ":meldis_py",

--- a/bindings/pydrake/visualization/meldis.py
+++ b/bindings/pydrake/visualization/meldis.py
@@ -186,7 +186,8 @@ class _ContactApplet:
 
     def on_contact_results(self, message):
         """Handler for lcmt_contact_results_for_viz. Note that only point
-        hydroelastic contact force and moment vectors are shown; contact surface and pressure are not shown."""
+           hydroelastic contact force and moment vectors are shown; contact
+           surface and pressure are not shown."""
 
         # Handle point contact pairs
         viz_items = []
@@ -207,7 +208,7 @@ class _ContactApplet:
                 centroid_W=lcm_item.centroid_W,
                 force_C_W=lcm_item.force_C_W,
                 moment_C_W=lcm_item.moment_C_W))
-        self._hydro_helper.Update(viz_items);
+        self._hydro_helper.Update(viz_items)
 
 
 class Meldis:

--- a/bindings/pydrake/visualization/meldis.py
+++ b/bindings/pydrake/visualization/meldis.py
@@ -59,6 +59,8 @@ from pydrake.math import (
     RotationMatrix,
 )
 from pydrake.multibody.meshcat import (
+    _HydroelasticContactVisualizer,
+    _HydroelasticContactVisualizerItem,
     _PointContactVisualizer,
     _PointContactVisualizerItem,
     ContactVisualizerParams,
@@ -175,11 +177,18 @@ class _ContactApplet:
         # Add point visualization.
         params = ContactVisualizerParams()
         params.prefix = "/CONTACT_RESULTS/point"
-        self._helper = _PointContactVisualizer(meshcat, params)
+        self._point_helper = _PointContactVisualizer(meshcat, params)
+
+        # Add hydroelastic visualization.
+        params = ContactVisualizerParams()
+        params.prefix = "/CONTACT_RESULTS/hydroelastic"
+        self._hydro_helper = _HydroelasticContactVisualizer(meshcat, params)
 
     def on_contact_results(self, message):
         """Handler for lcmt_contact_results_for_viz. Note that only point
-        contacts are shown so far; hydroelastic contacts are not shown."""
+        hydroelastic contact force and moment vectors are shown; contact surface and pressure are not shown."""
+
+        # Handle point contact pairs
         viz_items = []
         for lcm_item in message.point_pair_contact_info:
             viz_items.append(_PointContactVisualizerItem(
@@ -187,7 +196,18 @@ class _ContactApplet:
                 body_B=lcm_item.body2_name,
                 contact_force=lcm_item.contact_force,
                 contact_point=lcm_item.contact_point))
-        self._helper.Update(viz_items)
+        self._point_helper.Update(viz_items)
+
+        # Handle hydroelastic contact pairs
+        viz_items = []
+        for lcm_item in message.hydroelastic_contacts:
+            viz_items.append(_HydroelasticContactVisualizerItem(
+                body_A=lcm_item.body1_name,
+                body_B=lcm_item.body2_name,
+                centroid_W=lcm_item.centroid_W,
+                force_C_W=lcm_item.force_C_W,
+                moment_C_W=lcm_item.moment_C_W))
+        self._hydro_helper.Update(viz_items);
 
 
 class Meldis:

--- a/bindings/pydrake/visualization/test/meldis_test.py
+++ b/bindings/pydrake/visualization/test/meldis_test.py
@@ -60,8 +60,9 @@ class TestMeldis(unittest.TestCase):
         dut._invoke_subscriptions()
         self.assertEqual(meshcat.HasPath(link_path), True)
 
-    def test_contact_applet(self):
-        """Check that _ContactApplet doesn't crash when receiving messages.
+    def test_contact_applet_point_pair(self):
+        """Check that _ContactApplet doesn't crash when receiving point
+           contact messages.
         """
         # Create the device under test.
         dut = mut.Meldis()
@@ -101,3 +102,46 @@ class TestMeldis(unittest.TestCase):
         lcm.HandleSubscriptions(timeout_millis=0)
         dut._invoke_subscriptions()
         self.assertEqual(meshcat.HasPath(pair_path), True)
+
+    def test_contact_applet_hydroelastic(self):
+        """Check that _ContactApplet doesn't crash when receiving hydroelastic
+           messages.
+        """
+        # Create the device under test.
+        dut = mut.Meldis()
+        meshcat = dut.meshcat
+        lcm = dut._lcm
+
+        # Enqueue a hydroelastic contact message.
+        sdf_file = FindResourceOrThrow(
+            "drake/multibody/meshcat/test/hydroelastic.sdf")
+        builder = DiagramBuilder()
+        plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.001)
+        parser = Parser(plant=plant)
+        parser.AddModelFromFile(sdf_file)
+        body1 = plant.GetBodyByName("body1")
+        body2 = plant.GetBodyByName("body2")
+        plant.AddJoint(PrismaticJoint(
+            name="sphere1", frame_on_parent=plant.world_body().body_frame(),
+            frame_on_child=body1.body_frame(), axis=[1, 0, 0]))
+        plant.AddJoint(PrismaticJoint(
+            name="sphere2", frame_on_parent=plant.world_body().body_frame(),
+            frame_on_child=body2.body_frame(), axis=[1, 0, 0]))
+        plant.Finalize()
+        ConnectContactResultsToDrakeVisualizer(
+            builder=builder, plant=plant, scene_graph=scene_graph, lcm=lcm)
+        diagram = builder.Build()
+        context = diagram.CreateDefaultContext()
+        plant.SetPositions(plant.GetMyMutableContextFromRoot(context),
+                           [-0.05, 0.1])
+        diagram.Publish(context)
+
+        # The geometry isn't registered until the load is processed.
+        hydro_path = "/CONTACT_RESULTS/hydroelastic/body1+body2"
+        self.assertEqual(meshcat.HasPath(hydro_path), False)
+
+        # Process the load + draw; contact message should still not exist
+        # as geometries are not in contact.
+        lcm.HandleSubscriptions(timeout_millis=0)
+        dut._invoke_subscriptions()
+        self.assertEqual(meshcat.HasPath(hydro_path), True)

--- a/bindings/pydrake/visualization/test/meldis_test.py
+++ b/bindings/pydrake/visualization/test/meldis_test.py
@@ -140,8 +140,7 @@ class TestMeldis(unittest.TestCase):
         hydro_path = "/CONTACT_RESULTS/hydroelastic/body1+body2"
         self.assertEqual(meshcat.HasPath(hydro_path), False)
 
-        # Process the load + draw; contact message should still not exist
-        # as geometries are not in contact.
+        # Process the load + draw; contact results should now exist.
         lcm.HandleSubscriptions(timeout_millis=0)
         dut._invoke_subscriptions()
         self.assertEqual(meshcat.HasPath(hydro_path), True)

--- a/multibody/meshcat/BUILD.bazel
+++ b/multibody/meshcat/BUILD.bazel
@@ -27,6 +27,7 @@ drake_cc_library(
     hdrs = ["contact_visualizer.h"],
     deps = [
         ":contact_visualizer_params",
+        ":hydroelastic_contact_visualizer",
         ":point_contact_visualizer",
         "//common:essential",
         "//geometry:meshcat",
@@ -90,6 +91,18 @@ drake_cc_library(
     name = "point_contact_visualizer",
     srcs = ["point_contact_visualizer.cc"],
     hdrs = ["point_contact_visualizer.h"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":contact_visualizer_params",
+        "//geometry:meshcat",
+        "//math:geometric_transform",
+    ],
+)
+
+drake_cc_library(
+    name = "hydroelastic_contact_visualizer",
+    srcs = ["hydroelastic_contact_visualizer.cc"],
+    hdrs = ["hydroelastic_contact_visualizer.h"],
     visibility = ["//visibility:private"],
     deps = [
         ":contact_visualizer_params",

--- a/multibody/meshcat/BUILD.bazel
+++ b/multibody/meshcat/BUILD.bazel
@@ -10,6 +10,13 @@ load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])
 
+filegroup(
+    name = "models",
+    srcs = glob([
+        "**/*.sdf",
+    ]),
+)
+
 drake_cc_package_library(
     name = "meshcat",
     visibility = ["//visibility:public"],
@@ -43,6 +50,7 @@ drake_cc_googletest(
     name = "contact_visualizer_test",
     data = [
         "//examples/manipulation_station:models",
+        ":models",
     ],
     deps = [
         ":contact_visualizer",

--- a/multibody/meshcat/BUILD.bazel
+++ b/multibody/meshcat/BUILD.bazel
@@ -23,6 +23,7 @@ drake_cc_package_library(
     deps = [
         ":contact_visualizer",
         ":contact_visualizer_params",
+        ":hydroelastic_contact_visualizer",
         ":joint_sliders",
         ":point_contact_visualizer",
     ],
@@ -49,8 +50,8 @@ drake_cc_library(
 drake_cc_googletest(
     name = "contact_visualizer_test",
     data = [
-        "//examples/manipulation_station:models",
         ":models",
+        "//examples/manipulation_station:models",
     ],
     deps = [
         ":contact_visualizer",

--- a/multibody/meshcat/contact_visualizer.cc
+++ b/multibody/meshcat/contact_visualizer.cc
@@ -167,7 +167,7 @@ template <typename T>
 const GeometryNames& ContactVisualizer<T>::GetGeometryNames(
     const Context<T>& context, const MultibodyPlant<T>* plant) const {
   // TODO(joemasterjohn): Upgrade `geometry_names` to a real cache entry if/when
-  // MultibodyPlant adds the capbility to add/remove geometries after finalize.
+  // MultibodyPlant adds the capability to add/remove geometries after finalize.
   GeometryNames& geometry_names =
       this->get_cache_entry(geometry_names_scratch_)
           .get_mutable_cache_entry_value(context)

--- a/multibody/meshcat/contact_visualizer.cc
+++ b/multibody/meshcat/contact_visualizer.cc
@@ -7,8 +7,8 @@
 
 #include "drake/common/extract_double.h"
 #include "drake/math/rigid_transform.h"
-#include "drake/multibody/meshcat/point_contact_visualizer.h"
 #include "drake/multibody/meshcat/hydroelastic_contact_visualizer.h"
+#include "drake/multibody/meshcat/point_contact_visualizer.h"
 #include "drake/multibody/plant/contact_results.h"
 #include "drake/multibody/plant/internal_geometry_names.h"
 

--- a/multibody/meshcat/contact_visualizer.h
+++ b/multibody/meshcat/contact_visualizer.h
@@ -17,6 +17,9 @@ namespace internal {
 // Defined in point_contact_visualizer.h.
 class PointContactVisualizer;
 struct PointContactVisualizerItem;
+// Defined in hydroelastic_contact_visualizer.h
+class HydroelasticContactVisualizer;
+struct HydroelasticContactVisualizerItem;
 }  // namespace internal
 
 /** ContactVisualizer is a system that publishes a ContactResults to
@@ -123,6 +126,11 @@ class ContactVisualizer final : public systems::LeafSystem<T> {
       const systems::Context<T>&,
       std::vector<internal::PointContactVisualizerItem>*) const;
 
+  /* Calc function for the cache entry of visualized hydroelastic contacts. */
+  void CalcHydroelasticContacts(
+      const systems::Context<T>&,
+      std::vector<internal::HydroelasticContactVisualizerItem>*) const;
+
   /* Handles the initialization event. */
   systems::EventStatus OnInitialization(const systems::Context<T>&) const;
 
@@ -140,10 +148,16 @@ class ContactVisualizer final : public systems::LeafSystem<T> {
   operation) from a const System (e.g., during simulation). */
   std::unique_ptr<internal::PointContactVisualizer> point_visualizer_;
 
+  /* This helper class is mutable because we must update it (a non-const
+  operation) from a const System (e.g., during simulation). */
+  std::unique_ptr<internal::HydroelasticContactVisualizer>
+      hydroelastic_visualizer_;
+
   systems::InputPortIndex contact_results_input_port_;
   systems::InputPortIndex query_object_input_port_;
   systems::CacheIndex geometry_names_scratch_;
   systems::CacheIndex point_contacts_cache_;
+  systems::CacheIndex hydroelastic_contacts_cache_;
 };
 
 /** A convenient alias for the ContactVisualizer class when using

--- a/multibody/meshcat/contact_visualizer.h
+++ b/multibody/meshcat/contact_visualizer.h
@@ -29,8 +29,10 @@ the location of the contact force with length scaled by the magnitude of the
 contact force. For hydroelastic contact, it draws single-sided arrows at
 the centroid of the contact patch, one for force and one for the moment of the
 contact results. The length of these vectors are scaled by the magnitude of the
-contact force/moment. The most common use of this system is to connect its
-input port to the contact results output port of a MultibodyPlant.
+contact force/moment. The direction of the arrow is essentially arbitrary (based
+on the GeometryIds) but is stable during a simulation. The most common use of
+this system is to connect its input port to the contact results output port of a
+MultibodyPlant.
 
  @system
  name: ContactVisualizer
@@ -124,7 +126,7 @@ class ContactVisualizer final : public systems::LeafSystem<T> {
   systems::EventStatus UpdateMeshcat(const systems::Context<T>&) const;
 
   /* Obtains the geometry_names scratch entry. On the first call, queries
-  @p plant and the attached QueryObject and fills the returned GeometryNames */
+  @p plant and the attached QueryObject and fills the returned GeometryNames. */
   const multibody::internal::GeometryNames& GetGeometryNames(
       const systems::Context<T>&, const MultibodyPlant<T>*) const;
 

--- a/multibody/meshcat/contact_visualizer_params.h
+++ b/multibody/meshcat/contact_visualizer_params.h
@@ -16,10 +16,10 @@ struct ContactVisualizerParams {
    drake#15021 for details.) */
   double publish_period{1 / 32.0};
 
-  /** The color used to draw the contact force arrows. */
+  /** The color used to draw the point contact force arrows. */
   geometry::Rgba color{0, 1, 0, 1};
 
-  /** The color used to draw the hydrelastic contact force arrows. */
+  /** The color used to draw the hydroelastic contact force arrows. */
   geometry::Rgba hydro_force_color{1, 0, 0, 1};
 
   /** The color used to draw the hydroelastic contact moment arrows. */
@@ -38,16 +38,25 @@ struct ContactVisualizerParams {
    events" for more information. */
   bool delete_on_initialization_event{true};
 
-  /** The threshold below which forces will no longer be drawn.  The
-   ContactVisualizer constructor enforces that this must be strictly
-   positive; zero forces do not have a meaningful direction and cannot be
-   visualized. */
+  /** The threshold (in N) below which forces will no longer be drawn.
+   The ContactVisualizer constructor enforces that this must be strictly
+   positive; zero forces do not have a meaningful direction and cannot
+   be visualized. */
   double force_threshold{0.01};
+
+  /** The threshold (in N⋅m) below which moments will no longer be drawn.
+   The ContactVisualizer constructor enforces that this must be strictly
+   positive; zero moments do not have a meaningful direction and cannot
+   be visualized. */
+  double moment_threshold{0.01};
 
   /** Sets the length scale of the force vectors. */
   double newtons_per_meter{10};
 
-  /** The radius of cylinder geometry used in the force vector . */
+  /** Sets the length scale of the moment vectors. */
+  double newton_meters_per_meter{3};
+
+  /** The radius of cylinder geometry used in the force/moment vector. */
   double radius{0.002};
 };
 

--- a/multibody/meshcat/contact_visualizer_params.h
+++ b/multibody/meshcat/contact_visualizer_params.h
@@ -48,7 +48,7 @@ struct ContactVisualizerParams {
   double newtons_per_meter{10};
 
   /** The radius of cylinder geometry used in the force vector . */
-  double radius{0.01};
+  double radius{0.002};
 };
 
 }  // namespace meshcat

--- a/multibody/meshcat/contact_visualizer_params.h
+++ b/multibody/meshcat/contact_visualizer_params.h
@@ -19,6 +19,12 @@ struct ContactVisualizerParams {
   /** The color used to draw the contact force arrows. */
   geometry::Rgba color{0, 1, 0, 1};
 
+  /** The color used to draw the hydrelastic contact force arrows. */
+  geometry::Rgba hydro_force_color{1, 0, 0, 1};
+
+  /** The color used to draw the hydroelastic contact moment arrows. */
+  geometry::Rgba hydro_moment_color{0, 0, 1, 1};
+
   /** A prefix to add to the path for all objects and transforms curated by the
    ContactVisualizer. It can be an absolute path or relative path.
    If relative, this `prefix` will be appended to the geometry::Meshcat `prefix`

--- a/multibody/meshcat/hydroelastic_contact_visualizer.cc
+++ b/multibody/meshcat/hydroelastic_contact_visualizer.cc
@@ -73,15 +73,17 @@ void HydroelasticContactVisualizer::Update(
 
       // Stretch the cylinder in z.
       const double height = force_norm / params_.newtons_per_meter;
+      // clang-format off
       meshcat_->SetTransform(path + "/force_C_W/cylinder",
-                             Matrix4d(Vector4d{1, 1, height, 1}.asDiagonal()));
+          (Matrix4d() <<  1, 0, 0, 0,
+                          0, 1, 0, 0,
+                          0, 0, height, 0.5*height,
+                          0, 0, 0, 1).finished());
+      // clang-format on
       // Translate the arrowheads.
       const double arrowhead_height = params_.radius * 2.0;
       meshcat_->SetTransform(
           path + "/force_C_W/head",
-          RigidTransformd(Vector3d{0, 0, -height - arrowhead_height}));
-      meshcat_->SetTransform(
-          path + "/force_C_W/tail",
           RigidTransformd(RotationMatrixd::MakeXRotation(M_PI),
                           Vector3d{0, 0, height + arrowhead_height}));
     }
@@ -93,15 +95,17 @@ void HydroelasticContactVisualizer::Update(
 
       // Stretch the cylinder in z.
       const double height = std::sqrt(moment_norm / params_.newtons_per_meter);
+      // clang-format off
       meshcat_->SetTransform(path + "/moment_C_W/cylinder",
-                             Matrix4d(Vector4d{1, 1, height, 1}.asDiagonal()));
+          (Matrix4d() <<  1, 0, 0, 0,
+                          0, 1, 0, 0,
+                          0, 0, height, 0.5*height,
+                          0, 0, 0, 1).finished());
+      // clang-format on
       // Translate the arrowheads.
       const double arrowhead_height = params_.radius * 2.0;
       meshcat_->SetTransform(
           path + "/moment_C_W/head",
-          RigidTransformd(Vector3d{0, 0, -height - arrowhead_height}));
-      meshcat_->SetTransform(
-          path + "/moment_C_W/tail",
           RigidTransformd(RotationMatrixd::MakeXRotation(M_PI),
                           Vector3d{0, 0, height + arrowhead_height}));
     }
@@ -127,10 +131,8 @@ HydroelasticContactVisualizer::FindOrAdd(const std::string& path) {
   iter = path_visibility_status_.insert({path, {false, false}}).first;
   meshcat_->SetProperty(path, "visible", false);
 
-  // Add the geometry to meshcat. The height of the cylinder is 2 and gets
-  // scaled to twice the contact force length because we draw both (equal
-  // and opposite) forces.
-  const Cylinder cylinder(params_.radius, 2.0);
+  // Add the geometry to meshcat.
+  const Cylinder cylinder(params_.radius, 1.0);
   const double arrowhead_height = params_.radius * 2.0;
   const double arrowhead_width = params_.radius * 2.0;
   const MeshcatCone arrowhead(arrowhead_height, arrowhead_width,
@@ -140,15 +142,10 @@ HydroelasticContactVisualizer::FindOrAdd(const std::string& path) {
                       params_.hydro_force_color);
   meshcat_->SetObject(path + "/force_C_W/head", arrowhead,
                       params_.hydro_force_color);
-  meshcat_->SetObject(path + "/force_C_W/tail", arrowhead,
-                      params_.hydro_force_color);
   meshcat_->SetObject(path + "/moment_C_W/cylinder", cylinder,
                       params_.hydro_moment_color);
   meshcat_->SetObject(path + "/moment_C_W/head", arrowhead,
                       params_.hydro_moment_color);
-  meshcat_->SetObject(path + "/moment_C_W/tail", arrowhead,
-                      params_.hydro_moment_color);
-
   return iter->second;
 }
 

--- a/multibody/meshcat/hydroelastic_contact_visualizer.cc
+++ b/multibody/meshcat/hydroelastic_contact_visualizer.cc
@@ -1,10 +1,11 @@
+#include "drake/multibody/meshcat/hydroelastic_contact_visualizer.h"
+
 #include <utility>
 
 #include <fmt/format.h>
 
 #include "drake/common/unused.h"
 #include "drake/math/rigid_transform.h"
-#include "drake/multibody/meshcat/hydroelastic_contact_visualizer.h"
 
 namespace drake {
 namespace multibody {

--- a/multibody/meshcat/hydroelastic_contact_visualizer.cc
+++ b/multibody/meshcat/hydroelastic_contact_visualizer.cc
@@ -1,0 +1,157 @@
+#include <utility>
+
+#include <fmt/format.h>
+
+#include "drake/common/unused.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/meshcat/hydroelastic_contact_visualizer.h"
+
+namespace drake {
+namespace multibody {
+namespace meshcat {
+namespace internal {
+
+using Eigen::Matrix4d;
+using Eigen::Vector3d;
+using Eigen::Vector4d;
+using geometry::Cylinder;
+using geometry::Meshcat;
+using geometry::MeshcatCone;
+using math::RigidTransformd;
+using math::RotationMatrixd;
+
+HydroelasticContactVisualizer::HydroelasticContactVisualizer(
+    std::shared_ptr<Meshcat> meshcat, ContactVisualizerParams params)
+    : meshcat_(std::move(meshcat)), params_(std::move(params)) {
+  DRAKE_DEMAND(meshcat_ != nullptr);
+}
+
+HydroelasticContactVisualizer::~HydroelasticContactVisualizer() = default;
+
+void HydroelasticContactVisualizer::Delete() {
+  meshcat_->Delete(params_.prefix);
+  path_visibility_status_.clear();
+}
+
+void HydroelasticContactVisualizer::Update(
+    const std::vector<HydroelasticContactVisualizerItem>& items) {
+  // Set all contacts to be inactive. They will be re-activated as we loop over
+  // `items`, below. Anything that is not re-activated will be set to invisible
+  // in a final clean-up pass at the end.
+  for (auto& [path, status] : path_visibility_status_) {
+    unused(path);
+    status.active = false;
+  }
+
+  // Process the new contacts to find the active ones.
+  for (const HydroelasticContactVisualizerItem& item : items) {
+    // Find our meshcat state for this contact pair.
+    const std::string path =
+        fmt::format("{}/{}+{}", params_.prefix, item.body_A, item.body_B);
+
+    VisibilityStatus& status = FindOrAdd(path);
+
+    // Decide whether the contact should be shown.
+    const double force_norm = item.force_C_W.norm();
+    const double moment_norm = item.moment_C_W.norm();
+    status.active = (force_norm >= params_.force_threshold) ||
+                    (moment_norm >= params_.force_threshold);
+    if (!status.active) {
+      continue;
+    }
+
+    // Update this active contact's transforms.
+    // Position the centroid.
+    meshcat_->SetTransform(path, RigidTransformd(item.centroid_W));
+
+    // Force vector.
+    {
+      meshcat_->SetTransform(path + "/force_C_W",
+                             RigidTransformd(RotationMatrixd::MakeFromOneVector(
+                                 item.force_C_W, 2)));
+
+      // Stretch the cylinder in z.
+      const double height = force_norm / params_.newtons_per_meter;
+      meshcat_->SetTransform(path + "/force_C_W/cylinder",
+                             Matrix4d(Vector4d{1, 1, height, 1}.asDiagonal()));
+      // Translate the arrowheads.
+      const double arrowhead_height = params_.radius * 2.0;
+      meshcat_->SetTransform(
+          path + "/force_C_W/head",
+          RigidTransformd(Vector3d{0, 0, -height - arrowhead_height}));
+      meshcat_->SetTransform(
+          path + "/force_C_W/tail",
+          RigidTransformd(RotationMatrixd::MakeXRotation(M_PI),
+                          Vector3d{0, 0, height + arrowhead_height}));
+    }
+    // Moment vector.
+    {
+      meshcat_->SetTransform(path + "/moment_C_W",
+                             RigidTransformd(RotationMatrixd::MakeFromOneVector(
+                                 item.moment_C_W, 2)));
+
+      // Stretch the cylinder in z.
+      const double height = std::sqrt(moment_norm / params_.newtons_per_meter);
+      meshcat_->SetTransform(path + "/moment_C_W/cylinder",
+                             Matrix4d(Vector4d{1, 1, height, 1}.asDiagonal()));
+      // Translate the arrowheads.
+      const double arrowhead_height = params_.radius * 2.0;
+      meshcat_->SetTransform(
+          path + "/moment_C_W/head",
+          RigidTransformd(Vector3d{0, 0, -height - arrowhead_height}));
+      meshcat_->SetTransform(
+          path + "/moment_C_W/tail",
+          RigidTransformd(RotationMatrixd::MakeXRotation(M_PI),
+                          Vector3d{0, 0, height + arrowhead_height}));
+    }
+  }
+
+  // Update meshcat visiblity to match the active status.
+  for (auto& [path, status] : path_visibility_status_) {
+    if (status.visible != status.active) {
+      meshcat_->SetProperty(path, "visible", status.active);
+      status.visible = status.active;
+    }
+  }
+}
+
+HydroelasticContactVisualizer::VisibilityStatus&
+HydroelasticContactVisualizer::FindOrAdd(const std::string& path) {
+  auto iter = path_visibility_status_.find(path);
+  if (iter != path_visibility_status_.end()) {
+    return iter->second;
+  }
+
+  // Start with it invisible, to prevent flickering at the origin.
+  iter = path_visibility_status_.insert({path, {false, false}}).first;
+  meshcat_->SetProperty(path, "visible", false);
+
+  // Add the geometry to meshcat. The height of the cylinder is 2 and gets
+  // scaled to twice the contact force length because we draw both (equal
+  // and opposite) forces.
+  const Cylinder cylinder(params_.radius, 2.0);
+  const double arrowhead_height = params_.radius * 2.0;
+  const double arrowhead_width = params_.radius * 2.0;
+  const MeshcatCone arrowhead(arrowhead_height, arrowhead_width,
+                              arrowhead_width);
+
+  meshcat_->SetObject(path + "/force_C_W/cylinder", cylinder,
+                      params_.hydro_force_color);
+  meshcat_->SetObject(path + "/force_C_W/head", arrowhead,
+                      params_.hydro_force_color);
+  meshcat_->SetObject(path + "/force_C_W/tail", arrowhead,
+                      params_.hydro_force_color);
+  meshcat_->SetObject(path + "/moment_C_W/cylinder", cylinder,
+                      params_.hydro_moment_color);
+  meshcat_->SetObject(path + "/moment_C_W/head", arrowhead,
+                      params_.hydro_moment_color);
+  meshcat_->SetObject(path + "/moment_C_W/tail", arrowhead,
+                      params_.hydro_moment_color);
+
+  return iter->second;
+}
+
+}  // namespace internal
+}  // namespace meshcat
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/meshcat/hydroelastic_contact_visualizer.cc
+++ b/multibody/meshcat/hydroelastic_contact_visualizer.cc
@@ -132,7 +132,7 @@ HydroelasticContactVisualizer::FindOrAdd(const std::string& path) {
   meshcat_->SetProperty(path, "visible", false);
 
   // Add the geometry to meshcat.
-  // Set radisu 1.0 so that it can be scaled later by the force/moment norm in
+  // Set radius 1.0 so that it can be scaled later by the force/moment norm in
   // the path transform.
   const Cylinder cylinder(params_.radius, 1.0);
   const double arrowhead_height = params_.radius * 2.0;

--- a/multibody/meshcat/hydroelastic_contact_visualizer.h
+++ b/multibody/meshcat/hydroelastic_contact_visualizer.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "drake/geometry/meshcat.h"
+#include "drake/multibody/meshcat/contact_visualizer_params.h"
+
+namespace drake {
+namespace multibody {
+namespace meshcat {
+namespace internal {
+
+/* Like multibody::HydroelasticContactInfo, but only the visualization info.
+   TODO(joemasterjohn): Add the mesh geometry and pressure values. */
+struct HydroelasticContactVisualizerItem {
+  std::string body_A;
+  std::string body_B;
+  Eigen::Vector3d centroid_W;
+  Eigen::Vector3d force_C_W;
+  Eigen::Vector3d moment_C_W;
+};
+
+/* HydroelasticContactVisualizer publishes hydroelastic contact results in
+MeshCat. It draws double-sided arrows at the location of the contact force with
+length scaled by the magnitude of the contact force.
+
+This is unit tested via contact_visualizer_test overall; there is currently no
+hydroelastic-contact-specific unit test.
+*/
+class HydroelasticContactVisualizer {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(HydroelasticContactVisualizer)
+
+  /* Creates an instance of HydroelasticContactVisualizer.
+  Note that not all fields of `params` are relevant nor used. */
+  HydroelasticContactVisualizer(std::shared_ptr<geometry::Meshcat> meshcat,
+                         ContactVisualizerParams params);
+
+  ~HydroelasticContactVisualizer();
+
+  /* Update meshcat to show _only_ the given contacts.
+  Any previously-visualized contacts will no longer be visible. */
+  void Update(const std::vector<HydroelasticContactVisualizerItem>& items);
+
+  /* Calls geometry::Meshcat::Delete(path), with the path set to params.prefix.
+  Since this visualizer will only ever add geometry under this prefix, this will
+  remove all geometry/transforms added by the visualizer, or by a previous
+  instance of this visualizer using the same prefix. */
+  void Delete();
+
+ private:
+  /* When a contact disappears, we mark it invisible rather than deleting it
+  (to improve resposiveness). This struct tracks that state. */
+  struct VisibilityStatus {
+    /* Whether this path is currently visible in meshcat. */
+    bool visible{false};
+    /* Whether this contact was active as of the most recent Update(). */
+    bool active{false};
+  };
+
+  /* Find an entry in path_visibility_status_, or else add one and return it.
+  When an entry is added by this function, the arrow geometry is also added to
+  meshcat (with visible=false) as a side-effect. */
+  VisibilityStatus& FindOrAdd(const std::string& path);
+
+  const std::shared_ptr<geometry::Meshcat> meshcat_;
+  const ContactVisualizerParams params_;
+
+  /* Map of from a contact pair's path to its status. When the map has no key
+  for a given path, that indicates no geometry for that pair exists yet. */
+  std::unordered_map<std::string, VisibilityStatus> path_visibility_status_;
+};
+
+}  // namespace internal
+}  // namespace meshcat
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/meshcat/hydroelastic_contact_visualizer.h
+++ b/multibody/meshcat/hydroelastic_contact_visualizer.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "drake/geometry/meshcat.h"
@@ -16,6 +17,16 @@ namespace internal {
 /* Like multibody::HydroelasticContactInfo, but only the visualization info.
    TODO(joemasterjohn): Add the mesh geometry and pressure values. */
 struct HydroelasticContactVisualizerItem {
+  HydroelasticContactVisualizerItem(std::string body_A_, std::string body_B_,
+                                    Eigen::Vector3d centroid_W_,
+                                    Eigen::Vector3d force_C_W_,
+                                    Eigen::Vector3d moment_C_W_)
+      : body_A(std::move(body_A_)),
+        body_B(std::move(body_B_)),
+        centroid_W(centroid_W_),
+        force_C_W(force_C_W_),
+        moment_C_W(moment_C_W_) {}
+
   std::string body_A;
   std::string body_B;
   Eigen::Vector3d centroid_W;
@@ -23,9 +34,10 @@ struct HydroelasticContactVisualizerItem {
   Eigen::Vector3d moment_C_W;
 };
 
-/* HydroelasticContactVisualizer publishes hydroelastic contact results in
-MeshCat. It draws double-sided arrows at the location of the contact force with
-length scaled by the magnitude of the contact force.
+/* HydroelasticContactVisualizer publishes hydroelastic contact results for
+MeshCat. It draws two single-sided arrows, one for force and one for moment, at
+the centroid of the contact patch. The length of each vector is scaled by the
+magnitude of the contact force/moment.
 
 This is unit tested via contact_visualizer_test overall; there is currently no
 hydroelastic-contact-specific unit test.
@@ -35,9 +47,12 @@ class HydroelasticContactVisualizer {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(HydroelasticContactVisualizer)
 
   /* Creates an instance of HydroelasticContactVisualizer.
-  Note that not all fields of `params` are relevant nor used. */
+  Note that not all fields of `params` are relevant nor used.
+
+  @pre meshcat != nullptr
+  */
   HydroelasticContactVisualizer(std::shared_ptr<geometry::Meshcat> meshcat,
-                         ContactVisualizerParams params);
+                                ContactVisualizerParams params);
 
   ~HydroelasticContactVisualizer();
 
@@ -53,7 +68,7 @@ class HydroelasticContactVisualizer {
 
  private:
   /* When a contact disappears, we mark it invisible rather than deleting it
-  (to improve resposiveness). This struct tracks that state. */
+  (to improve responsiveness). This struct tracks that state. */
   struct VisibilityStatus {
     /* Whether this path is currently visible in meshcat. */
     bool visible{false};
@@ -63,7 +78,7 @@ class HydroelasticContactVisualizer {
 
   /* Find an entry in path_visibility_status_, or else add one and return it.
   When an entry is added by this function, the arrow geometry is also added to
-  meshcat (with visible=false) as a side-effect. */
+  meshcat (with visible=false and active=false) as a side-effect. */
   VisibilityStatus& FindOrAdd(const std::string& path);
 
   const std::shared_ptr<geometry::Meshcat> meshcat_;

--- a/multibody/meshcat/hydroelastic_contact_visualizer.h
+++ b/multibody/meshcat/hydroelastic_contact_visualizer.h
@@ -18,9 +18,9 @@ namespace internal {
    TODO(joemasterjohn): Add the mesh geometry and pressure values. */
 struct HydroelasticContactVisualizerItem {
   HydroelasticContactVisualizerItem(std::string body_A_, std::string body_B_,
-                                    Eigen::Vector3d centroid_W_,
-                                    Eigen::Vector3d force_C_W_,
-                                    Eigen::Vector3d moment_C_W_)
+                                    const Eigen::Vector3d& centroid_W_,
+                                    const Eigen::Vector3d& force_C_W_,
+                                    const Eigen::Vector3d& moment_C_W_)
       : body_A(std::move(body_A_)),
         body_B(std::move(body_B_)),
         centroid_W(centroid_W_),

--- a/multibody/meshcat/point_contact_visualizer.h
+++ b/multibody/meshcat/point_contact_visualizer.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "drake/geometry/meshcat.h"
@@ -15,6 +16,14 @@ namespace internal {
 
 /* Like multibody::PointPairContactInfo, but only the visualization info. */
 struct PointContactVisualizerItem {
+  PointContactVisualizerItem(std::string body_A_, std::string body_B_,
+                             Eigen::Vector3d contact_force_,
+                             Eigen::Vector3d contact_point_)
+      : body_A(std::move(body_A_)),
+        body_B(std::move(body_B_)),
+        contact_force(contact_force_),
+        contact_point(contact_point_) {}
+
   std::string body_A;
   std::string body_B;
   Eigen::Vector3d contact_force;

--- a/multibody/meshcat/point_contact_visualizer.h
+++ b/multibody/meshcat/point_contact_visualizer.h
@@ -17,8 +17,8 @@ namespace internal {
 /* Like multibody::PointPairContactInfo, but only the visualization info. */
 struct PointContactVisualizerItem {
   PointContactVisualizerItem(std::string body_A_, std::string body_B_,
-                             Eigen::Vector3d contact_force_,
-                             Eigen::Vector3d contact_point_)
+                             const Eigen::Vector3d& contact_force_,
+                             const Eigen::Vector3d& contact_point_)
       : body_A(std::move(body_A_)),
         body_B(std::move(body_B_)),
         contact_force(contact_force_),

--- a/multibody/meshcat/test/contact_visualizer_test.cc
+++ b/multibody/meshcat/test/contact_visualizer_test.cc
@@ -56,7 +56,7 @@ class ContactVisualizerTest : public ::testing::Test {
           multibody::CoulombFriction<double>());
     }
 
-    // Add the hydroelastic spheres and joints.
+    // Add the hydroelastic spheres and joints between them.
     const std::string hydro_sdf = FindResourceOrThrow(
         "drake/multibody/meshcat/test/hydroelastic.sdf");
     parser.AddModelFromFile(hydro_sdf);

--- a/multibody/meshcat/test/contact_visualizer_test.cc
+++ b/multibody/meshcat/test/contact_visualizer_test.cc
@@ -21,7 +21,8 @@ class ContactVisualizerTest : public ::testing::Test {
   ContactVisualizerTest() : meshcat_(std::make_shared<Meshcat>()) {}
 
   // Sets up a simple plant, scene graph, and visualizer.
-  // The plant has two spheres on prismatic joints.
+  // The plant has two spheres with point contact geometry on prismatic joints
+  // and two spheres with hydroelastic geometry on prismatic joints.
   //
   // @param add_to_builder_overload must be 0, 1, or 2 to select which
   // "AddToBuilder" overload will be used.
@@ -34,7 +35,7 @@ class ContactVisualizerTest : public ::testing::Test {
     auto [plant, scene_graph] =
         multibody::AddMultibodyPlantSceneGraph(&builder, 0.001);
 
-    // Add the spheres and joints.
+    // Add the point contact spheres and joints.
     multibody::Parser parser(&plant);
     const std::string sdf = FindResourceOrThrow(
         "drake/examples/manipulation_station/models/sphere.sdf");
@@ -54,6 +55,20 @@ class ContactVisualizerTest : public ::testing::Test {
       plant.RegisterCollisionGeometry(sphere2, X, *shape, "bonus",
           multibody::CoulombFriction<double>());
     }
+
+    // Add the hydroelastic spheres and joints.
+    const std::string hydro_sdf = FindResourceOrThrow(
+        "drake/multibody/meshcat/test/hydroelastic.sdf");
+    parser.AddModelFromFile(hydro_sdf);
+    const auto& body1 = plant.GetBodyByName("body1");
+    plant.AddJoint<multibody::PrismaticJoint>(
+        "body1", plant.world_body(), std::nullopt, body1, std::nullopt,
+        Eigen::Vector3d::UnitZ());
+    const auto& body2 = plant.GetBodyByName("body2");
+    plant.AddJoint<multibody::PrismaticJoint>(
+        "body2", plant.world_body(), std::nullopt, body2, std::nullopt,
+        Eigen::Vector3d::UnitZ());
+
     plant.Finalize();
 
     // Add the visualizer.
@@ -77,11 +92,12 @@ class ContactVisualizerTest : public ::testing::Test {
       DRAKE_UNREACHABLE();
     }
 
-    // Start the two spheres in contact, but not completely overlapping.
+    // Start the two point contact spheres in contact, but not completely
+    // overlapping. Start the two hydroelastic contact spheres overlapping.
     diagram_ = builder.Build();
     context_ = diagram_->CreateDefaultContext();
     plant.SetPositions(&plant.GetMyMutableContextFromRoot(context_.get()),
-                       Eigen::Vector2d{-0.03, 0.03});
+                       Eigen::Vector4d{-0.03, 0.03, -0.05, 0.1});
   }
 
   void PublishAndCheck(
@@ -94,6 +110,8 @@ class ContactVisualizerTest : public ::testing::Test {
       EXPECT_TRUE(meshcat_->HasPath(
           "contact_forces/point/sphere1.base_link+sphere2.base_link"));
     }
+
+    EXPECT_TRUE(meshcat_->HasPath("contact_forces/hydroelastic/body1+body2"));
   }
 
   std::shared_ptr<Meshcat> meshcat_;

--- a/multibody/meshcat/test/hydroelastic.sdf
+++ b/multibody/meshcat/test/hydroelastic.sdf
@@ -1,13 +1,14 @@
 <?xml version="1.0"?>
+<!-- A simple hydroelastic model with two bodies each with sphere geometry. The first sphere is of type "rigid_hydroelastic" and the second sphere is of type "compliant_hydroelastic". -->
 <sdf xmlns:drake="http://drake.mit.edu" version="1.7">
   <model name="two_bodies">
     <link name="body1">
       <inertial>
         <mass>1</mass>
         <inertia>
-          <ixx>0.001</ixx>
-          <iyy>0.001</iyy>
-          <izz>0.001</izz>
+          <ixx>0.016</ixx>
+          <iyy>0.016</iyy>
+          <izz>0.016</izz>
           <ixy>0</ixy>
           <ixz>0</ixz>
           <iyz>0</iyz>
@@ -31,9 +32,9 @@
       <inertial>
         <mass>1</mass>
         <inertia>
-          <ixx>0.001</ixx>
-          <iyy>0.001</iyy>
-          <izz>0.001</izz>
+          <ixx>0.016</ixx>
+          <iyy>0.016</iyy>
+          <izz>0.016</izz>
           <ixy>0</ixy>
           <ixz>0</ixz>
           <iyz>0</iyz>

--- a/multibody/meshcat/test/hydroelastic.sdf
+++ b/multibody/meshcat/test/hydroelastic.sdf
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<sdf xmlns:drake="http://drake.mit.edu" version="1.7">
+  <model name="two_bodies">
+    <link name="body1">
+      <inertial>
+        <mass>1</mass>
+        <inertia>
+          <ixx>0.001</ixx>
+          <iyy>0.001</iyy>
+          <izz>0.001</izz>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyz>0</iyz>
+        </inertia>
+      </inertial>
+      <collision name="body1_collision">
+        <geometry>
+          <sphere>
+            <radius>0.2</radius>
+          </sphere>
+        </geometry>
+        <drake:proximity_properties>
+          <drake:mu_dynamic>0.5</drake:mu_dynamic>
+          <drake:mu_static>0.5</drake:mu_static>
+          <drake:mesh_resolution_hint>0.1</drake:mesh_resolution_hint>
+          <drake:rigid_hydroelastic/>
+        </drake:proximity_properties>
+      </collision>
+    </link>
+    <link name="body2">
+      <inertial>
+        <mass>1</mass>
+        <inertia>
+          <ixx>0.001</ixx>
+          <iyy>0.001</iyy>
+          <izz>0.001</izz>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyz>0</iyz>
+        </inertia>
+      </inertial>
+      <collision name="body2_collision">
+        <geometry>
+          <sphere>
+            <radius>0.2</radius>
+          </sphere>
+        </geometry>
+        <drake:proximity_properties>
+          <drake:mu_dynamic>0.5</drake:mu_dynamic>
+          <drake:mu_static>0.5</drake:mu_static>
+          <drake:mesh_resolution_hint>0.2</drake:mesh_resolution_hint>
+          <drake:hydroelastic_modulus>180.0e9</drake:hydroelastic_modulus>
+          <drake:compliant_hydroelastic/>
+        </drake:proximity_properties>
+      </collision>
+    </link>
+  </model>
+</sdf>


### PR DESCRIPTION
This PR introduces the `HydroelasticContactVisualizer` helper class that publishes hydroelastic contacts to Meshcat. It does not depend on `struct ContactResults` directly and can thus be used by both `meldis` and `drake::multibody::meshcat::ContactVisualizer` for in-process Meshcat. In addition, this PR also hooks up this new class into the two consumer classes and is operational. This version currently publishes just the force and moment vectors for each hydroelastic contact.

For an easy way of visualizing the new feature, run:

```
bazel run //tools:meldis -- -w &
```
and 
```
bazel run //examples/hydroelastic/spatula_slip_control:spatula_slip_control
```
And in the meshcat controls make sure to turn on the contact results visualization by clicking the check box for  "CONTACT_RESULTS".

cc: @jwnimmer-tri @RussTedrake 

Towards #15738.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16913)
<!-- Reviewable:end -->
