### PR TITLE
[trajectory] PiecewiseQuaternion returns Vector4 as values

### DIFF
--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -379,22 +379,26 @@ class TestTrajectories(unittest.TestCase):
         # Test quaternion constructor.
         pq = PiecewiseQuaternionSlerp(breaks=t, quaternions=[q, q, q])
         self.assertEqual(pq.get_number_of_segments(), 2)
-        numpy_compare.assert_float_equal(pq.value(0.5), np.eye(3))
+        numpy_compare.assert_float_equal(pq.value(0.5),
+                                         [[1.], [0.], [0.], [0.]])
 
         # Test matrix constructor.
         pq = PiecewiseQuaternionSlerp(breaks=t, rotation_matrices=[m, m, m])
         self.assertEqual(pq.get_number_of_segments(), 2)
-        numpy_compare.assert_float_equal(pq.value(0.5), np.eye(3))
+        numpy_compare.assert_float_equal(pq.value(0.5),
+                                         [[1.], [0.], [0.], [0.]])
 
         # Test axis angle constructor.
         pq = PiecewiseQuaternionSlerp(breaks=t, angle_axes=[a, a, a])
         self.assertEqual(pq.get_number_of_segments(), 2)
-        numpy_compare.assert_float_equal(pq.value(0.5), np.eye(3))
+        numpy_compare.assert_float_equal(pq.value(0.5),
+                                         [[1.], [0.], [0.], [0.]])
 
         # Test rotation matrix constructor.
         pq = PiecewiseQuaternionSlerp(breaks=t, rotation_matrices=[R, R, R])
         self.assertEqual(pq.get_number_of_segments(), 2)
-        numpy_compare.assert_float_equal(pq.value(0.5), np.eye(3))
+        numpy_compare.assert_float_equal(pq.value(0.5),
+                                         [[1.], [0.], [0.], [0.]])
 
         # Test append operations.
         pq.Append(time=3., quaternion=q)

--- a/common/trajectories/piecewise_quaternion.h
+++ b/common/trajectories/piecewise_quaternion.h
@@ -26,6 +26,8 @@ namespace trajectories {
  * quaternion representations ensure that q_n.dot(q_{n+1}) >= 0.
  * Another intuitive way to think about this is that consecutive quaternions
  * have the shortest geodesic distance on the unit sphere.
+ * Note that the quarternion value is in w, x, y, z order when represented as
+ * a Vector4.
  *
  * @tparam_default_scalars
  */
@@ -91,7 +93,8 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
   Quaternion<T> orientation(const T& time) const;
 
   MatrixX<T> value(const T& time) const override {
-    return orientation(time).matrix();
+    const Quaternion<T> quat = orientation(time);
+    return Vector4<T>(quat.w(), quat.x(), quat.y(), quat.z());
   }
 
   /**

--- a/common/trajectories/test/piecewise_quaternion_test.cc
+++ b/common/trajectories/test/piecewise_quaternion_test.cc
@@ -239,6 +239,9 @@ GTEST_TEST(TestPiecewiseQuaternionSlerp, TestDerivatives) {
   const auto second_derivative = rot_spline.MakeDerivative(2);
 
   for (double t = -1.0; t < 4.0; t += 0.234) {
+    // Test that value() and rows() and cols() are compatible.
+    EXPECT_EQ(rot_spline.value(t).rows(), rot_spline.rows());
+    EXPECT_EQ(rot_spline.value(t).cols(), rot_spline.cols());
     // Test zeroth derivative.
     EXPECT_TRUE(CompareMatrices(
       rot_spline.value(t), zeroth_derivative->value(t), 1e-14));

--- a/systems/primitives/trajectory_source.h
+++ b/systems/primitives/trajectory_source.h
@@ -34,6 +34,8 @@ class TrajectorySource final : public SingleOutputVectorSource<T> {
   /// Must be greater than or equal to zero.
   /// @param zero_derivatives_beyond_limits All derivatives will be zero before
   /// the start time or after the end time of @p trajectory.
+  /// @pre The value of `trajectory` is a column vector. More precisely,
+  /// trajectory.cols() == 1.
   explicit TrajectorySource(const trajectories::Trajectory<T>& trajectory,
                             int output_derivative_order = 0,
                             bool zero_derivatives_beyond_limits = true);


### PR DESCRIPTION
The original implementation violates the contract set in the base class that the size of the result of value() is equal to rows()-by-cols().

closes #16909 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16914)
<!-- Reviewable:end -->
