### PR TITLE
[parsing] Plumb the last URDF error to diagnostic policy

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -562,6 +562,7 @@ drake_cc_googletest(
     name = "detail_tinyxml_test",
     deps = [
         ":detail_misc",
+        ":diagnostic_policy_test_base",
         "//common/test_utilities:eigen_matrix_compare",
     ],
 )

--- a/multibody/parsing/detail_tinyxml.cc
+++ b/multibody/parsing/detail_tinyxml.cc
@@ -40,18 +40,25 @@ bool ParseStringAttribute(const tinyxml2::XMLElement* node,
   return false;
 }
 
-bool ParseScalarAttribute(const tinyxml2::XMLElement* node,
-                          const char* attribute_name, double* val) {
+bool ParseScalarAttribute(
+    const tinyxml2::XMLElement* node,
+    const char* attribute_name, double* val,
+    std::optional<const drake::internal::DiagnosticPolicy> policy) {
+  if (!policy.has_value()) {
+    policy.emplace();
+  }
   const char* attr = node->Attribute(attribute_name);
   if (attr) {
     std::vector<double> vals = ConvertToDoubles(attr);
     if (vals.size() != 1) {
-      throw std::invalid_argument(
-          std::string("Expected single value for attribute ") + attribute_name +
-          " got " + attr);
+      policy->Error(
+          fmt::format("Expected single value for attribute '{}' got '{}'",
+                      attribute_name, attr));
     }
-    *val = vals[0];
-    return true;
+    if (!vals.empty()) {
+      *val = vals[0];
+    }
+    return !vals.empty();
   }
   return false;
 }

--- a/multibody/parsing/detail_tinyxml.h
+++ b/multibody/parsing/detail_tinyxml.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 
 #include <Eigen/Dense>
 #include <tinyxml2.h>
 
+#include "drake/common/diagnostic_policy.h"
 #include "drake/math/rigid_transform.h"
 
 namespace drake {
@@ -25,12 +27,19 @@ bool ParseStringAttribute(const tinyxml2::XMLElement* node,
 
 // Parses a scalar attribute of @p node named @p attribute_name into @p val.
 //
-// @returns false if the attribute is not present
+// @returns false if the attribute is not present, or if no numeric values were
+// found. Otherwise, returns true and sets @p val to the first value obtained.
 //
-// @throws std::exception if the attribute doesn't contain a
-// single numeric value.
-bool ParseScalarAttribute(const tinyxml2::XMLElement* node,
-                          const char* attribute_name, double* val);
+// If the attribute doesn't contain exactly one numeric value, the function
+// emits an error on @p policy, which may result in the policy throwing.
+//
+// If @p policy is empty, then the default policy will be used, which results
+// in a `throw` on error.
+bool ParseScalarAttribute(
+    const tinyxml2::XMLElement* node,
+    const char* attribute_name, double* val,
+    std::optional<const drake::internal::DiagnosticPolicy> policy =
+    std::nullopt);
 
 // Parses an attribute of @p node named @p attribute_name consisting of scalar
 // values into @p val.

--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -206,7 +206,8 @@ std::unique_ptr<geometry::Shape> ParseSphere(
     const TinyXml2Diagnostic& diagnostic,
     const XMLElement* shape_node) {
   double r = 0;
-  if (!ParseScalarAttribute(shape_node, "radius", &r)) {
+  if (!ParseScalarAttribute(shape_node, "radius", &r,
+                            diagnostic.MakePolicyForNode(shape_node))) {
     diagnostic.Error(*shape_node, "Missing sphere attribute: radius");
     return {};
   }
@@ -219,13 +220,15 @@ std::unique_ptr<geometry::Shape> ParseCylinder(
     const TinyXml2Diagnostic& diagnostic,
     const XMLElement* shape_node) {
   double r = 0;
-  if (!ParseScalarAttribute(shape_node, "radius", &r)) {
+  if (!ParseScalarAttribute(shape_node, "radius", &r,
+                            diagnostic.MakePolicyForNode(shape_node))) {
     diagnostic.Error(*shape_node, "Missing cylinder attribute: radius");
     return {};
   }
 
   double l = 0;
-  if (!ParseScalarAttribute(shape_node, "length", &l)) {
+  if (!ParseScalarAttribute(shape_node, "length", &l,
+                            diagnostic.MakePolicyForNode(shape_node))) {
     diagnostic.Error(*shape_node, "Missing cylinder attribute: length");
     return {};
   }
@@ -237,13 +240,15 @@ std::unique_ptr<geometry::Shape> ParseCapsule(
     const TinyXml2Diagnostic& diagnostic,
     const XMLElement* shape_node) {
   double r = 0;
-  if (!ParseScalarAttribute(shape_node, "radius", &r)) {
+  if (!ParseScalarAttribute(shape_node, "radius", &r,
+                            diagnostic.MakePolicyForNode(shape_node))) {
     diagnostic.Error(*shape_node, "Missing capsule attribute: radius");
     return {};
   }
 
   double l = 0;
-  if (!ParseScalarAttribute(shape_node, "length", &l)) {
+  if (!ParseScalarAttribute(shape_node, "length", &l,
+                            diagnostic.MakePolicyForNode(shape_node))) {
     diagnostic.Error(*shape_node, "Missing capsule attribute: length");
     return {};
   }
@@ -257,7 +262,8 @@ std::unique_ptr<geometry::Shape> ParseEllipsoid(
   double axes[3];
   const char* names[] = {"a", "b", "c"};
   for (int i = 0; i < 3; ++i) {
-    if (!ParseScalarAttribute(shape_node, names[i], &axes[i])) {
+    if (!ParseScalarAttribute(shape_node, names[i], &axes[i],
+                              diagnostic.MakePolicyForNode(shape_node))) {
       diagnostic.Error(*shape_node, fmt::format(
                            "Missing ellipsoid attribute: '{}'", names[i]));
       return {};
@@ -625,7 +631,8 @@ std::optional<geometry::GeometryInstance> ParseCollision(
           drake_element->FirstChildElement(element_name);
       if (value_node != nullptr) {
         double value{};
-        if (ParseScalarAttribute(value_node, "value", &value)) {
+        if (ParseScalarAttribute(value_node, "value", &value,
+                                 diagnostic.MakePolicyForNode(value_node))) {
           return value;
         } else {
           diagnostic.Error(*value_node, fmt::format(

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -96,6 +96,16 @@ class UrdfParser {
   SpatialInertia<double> ExtractSpatialInertiaAboutBoExpressedInB(
       XMLElement* node);
 
+  // A work-alike for internal::ParseScalarAttribute() that uses the local
+  // diagnostic policy.
+  bool ParseScalarAttribute(
+    const tinyxml2::XMLElement* node,
+    const char* attribute_name, double* val) {
+    return internal::ParseScalarAttribute(
+        node, attribute_name, val,
+        diagnostic_.MakePolicyForNode(node));
+  }
+
   void Warning(const XMLNode& location, std::string message) const {
     diagnostic_.Warning(location, std::move(message));
   }

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -746,15 +746,20 @@ TEST_F(UrdfGeometryTest, TestBadBox) {
 }
 
 TEST_F(UrdfGeometryTest, TestBadSphere) {
-  ParseUrdfGeometryString(R"""(
+  std::string base = R"""(
     <robot name='a'>
       <link name='b'>
         <collision>
-          <geometry><sphere/></geometry>
+          <geometry><sphere {}/></geometry>
         </collision>
       </link>
-    </robot>)""");
+    </robot>)""";
+
+  ParseUrdfGeometryString(fmt::format(base, ""));
   EXPECT_THAT(TakeError(), MatchesRegex(".*Missing sphere attribute.*"));
+
+  ParseUrdfGeometryString(fmt::format(base, "radius='1 2 3'"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*Expected single value.*"));
 }
 
 TEST_F(UrdfGeometryTest, TestBadCylinder) {
@@ -774,6 +779,12 @@ TEST_F(UrdfGeometryTest, TestBadCylinder) {
   ParseUrdfGeometryString(fmt::format(base, "radius='1'"));
   EXPECT_THAT(TakeError(), MatchesRegex(
                   ".*Missing cylinder attribute.*length.*"));
+
+  ParseUrdfGeometryString(fmt::format(base, "radius='1 2 3' length='1'"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*Expected single value.*radius.*"));
+
+  ParseUrdfGeometryString(fmt::format(base, "radius='1' length='1 2 3'"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*Expected single value.*length.*"));
 }
 
 TEST_F(UrdfGeometryTest, TestBadCapsule) {
@@ -788,21 +799,22 @@ TEST_F(UrdfGeometryTest, TestBadCapsule) {
       </link>
     </robot>)""";
 
-  // capsule
-  ParseUrdfGeometryString(fmt::format(base, "", ""));
-  EXPECT_THAT(TakeError(), MatchesRegex(
-                  ".*Missing capsule attribute.*radius.*"));
-  ParseUrdfGeometryString(fmt::format(base, "", "radius='1'"));
-  EXPECT_THAT(TakeError(), MatchesRegex(
-                  ".*Missing capsule attribute.*length.*"));
-
-  // drake:capsule
-  ParseUrdfGeometryString(fmt::format(base, "drake:", ""));
-  EXPECT_THAT(TakeError(), MatchesRegex(
-                  ".*Missing capsule attribute.*radius.*"));
-  ParseUrdfGeometryString(fmt::format(base, "drake:", "radius='1'"));
-  EXPECT_THAT(TakeError(), MatchesRegex(
-                  ".*Missing capsule attribute.*length.*"));
+  // Loop over capsule, drake:capsule.
+  for (const auto& prefix : std::array<std::string, 2>{"", "drake:"}) {
+    SCOPED_TRACE(prefix + "capsule");
+    ParseUrdfGeometryString(fmt::format(base, prefix, ""));
+    EXPECT_THAT(TakeError(), MatchesRegex(
+                    ".*Missing capsule attribute.*radius.*"));
+    ParseUrdfGeometryString(fmt::format(base, prefix, "radius='1'"));
+    EXPECT_THAT(TakeError(), MatchesRegex(
+                    ".*Missing capsule attribute.*length.*"));
+    ParseUrdfGeometryString(fmt::format(base, prefix,
+                                        "radius='1 2 3' length='1'"));
+    EXPECT_THAT(TakeError(), MatchesRegex(".*Expected single value.*radius.*"));
+    ParseUrdfGeometryString(fmt::format(base, prefix,
+                                        "radius='1' length='1 2 3'"));
+    EXPECT_THAT(TakeError(), MatchesRegex(".*Expected single value.*length.*"));
+  }
 }
 
 TEST_F(UrdfGeometryTest, TestBadEllipsoid) {
@@ -827,6 +839,15 @@ TEST_F(UrdfGeometryTest, TestBadEllipsoid) {
   ParseUrdfGeometryString(fmt::format(base, "a='1' b='2'"));
   EXPECT_THAT(TakeError(), MatchesRegex(
                   ".*Missing ellipsoid attribute.*'c'.*"));
+
+  ParseUrdfGeometryString(fmt::format(base, "a='1 1 1' b='2' c='3'"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*Expected single value.*'a'.*"));
+
+  ParseUrdfGeometryString(fmt::format(base, "a='1' b='2 1 1' c='3'"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*Expected single value.*'b'.*"));
+
+  ParseUrdfGeometryString(fmt::format(base, "a='1' b='2' c='3 1 1'"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*Expected single value.*'c'.*"));
 }
 
 TEST_F(UrdfGeometryTest, TestBadMesh) {
@@ -914,12 +935,15 @@ TEST_F(UrdfGeometryTest, TestBadShapeVisual) {
 }
 
 TEST_F(UrdfGeometryTest, TestBadProperty) {
-  ParseCollisionDoc(R"""(
+  std::string base = R"""(
   <drake:proximity_properties>
-    <drake:mu_dynamic/>
-  </drake:proximity_properties>)""");
+    <drake:mu_dynamic {}/>
+  </drake:proximity_properties>)""";
+  ParseCollisionDoc(fmt::format(base, ""));
   EXPECT_THAT(TakeError(), MatchesRegex(
                   ".*Unable to read.*attribute.*mu_dynamic.*"));
+  ParseCollisionDoc(fmt::format(base, "value='1 2 3'"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*Expected single value.*"));
 }
 
 TEST_F(UrdfGeometryTest, RigidHydroelastic) {


### PR DESCRIPTION
Relevant to: #16782

Based on my possibly flawed static analysis, this patch converts the
last message reachable from `AddModelFromUrdf()` via bad input.

Since this one routine is used many places, a few small changes require
a lot of new test cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16915)
<!-- Reviewable:end -->
