### PR TITLE
[doc] Remove references to Ubuntu CI builds and artifacts

### DIFF
--- a/doc/_pages/docker.md
+++ b/doc/_pages/docker.md
@@ -56,11 +56,9 @@ docker pull robotlocomotion/drake:latest
 
 The docker tags for Drake's nightly releases are spelled like:
 
-* ``bionic-YYYYMMDD`` for the Ubuntu 18.04 image of Drake as of date YYYY-MM-DD.
-* ``bionic`` is a synonym for the most recent ``bionic-YYYYMMDD``.
 * ``focal-YYYYMMDD`` for the Ubuntu 20.04 image of Drake as of date YYYY-MM-DD.
 * ``focal`` is a synonym for the most recent ``focal-YYYYMMDD``.
-* ``YYYYMMDD`` is a synonym for one of the above, currently ``bionic-YYYYMMDD``.
+* ``YYYYMMDD`` is a synonym for the most recent ``focal-YYYYMMDD``.
 * ``latest`` is a synonym for the most recent ``YYYYMMDD``.
 
 Refer to [Quickstart](/installation.html#quickstart) for next steps.

--- a/doc/_pages/from_binary.md
+++ b/doc/_pages/from_binary.md
@@ -78,17 +78,15 @@ Refer to [Quickstart](/installation.html#quickstart) for next steps.
 
 ## Nightly Releases
 
-Binary packages of Drake for Ubuntu 18.04 (Bionic), Ubuntu 20.04 (Focal) and
+Binary packages of Drake for Ubuntu 20.04 (Focal) and
 Mac are generated nightly and are available to download at:
 
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-bionic.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-bionic.tar.gz)
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-focal.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-focal.tar.gz)
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac.tar.gz)
 
 Older packages for specific dates are available by replacing ``latest`` with an
 8-digit date, e.g., ``20200102`` for January 2nd, 2020.
 
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-YYYYMMDD-bionic.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-YYYYMMDD-bionic.tar.gz)
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-YYYYMMDD-focal.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-YYYYMMDD-focal.tar.gz)
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-YYYYMMDD-mac.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-YYYYMMDD-mac.tar.gz)
 

--- a/doc/_pages/jenkins.md
+++ b/doc/_pages/jenkins.md
@@ -104,7 +104,6 @@ When updating prerequisites with these scripts, the normal experimental CI will
 most likely fail. To test new prerequisites, you should first request
 unprovisioned experimental builds, e.g.:
 
-* ``@drake-jenkins-bot linux-bionic-unprovisioned-gcc-bazel-experimental-release please``
 * ``@drake-jenkins-bot linux-focal-unprovisioned-gcc-bazel-experimental-release please``
 * ``@drake-jenkins-bot mac-big-sur-unprovisioned-clang-bazel-experimental-release please``
 
@@ -117,7 +116,6 @@ updated. She will then respond on when it is appropriate to merge the PR.
 To schedule an "experimental" build of the [binary packages](/from_binary.html),
 comment on an open pull request as follows:
 
-* ``@drake-jenkins-bot linux-bionic-unprovisioned-gcc-bazel-experimental-snopt-packaging please``
 * ``@drake-jenkins-bot linux-focal-unprovisioned-gcc-bazel-experimental-snopt-packaging please``
 * ``@drake-jenkins-bot mac-big-sur-unprovisioned-clang-bazel-experimental-snopt-packaging please``
 
@@ -125,7 +123,6 @@ or follow the [instructions above](#scheduling-builds-via-the-jenkins-user-inter
 to schedule a build of one of the following jobs from the Jenkins user
 interface:
 
-* linux-bionic-unprovisioned-gcc-bazel-experimental-snopt-packaging
 * linux-focal-unprovisioned-gcc-bazel-experimental-snopt-packaging
 * mac-big-sur-unprovisioned-clang-bazel-experimental-snopt-packaging
 
@@ -142,4 +139,4 @@ upload: drake-<yyymmddhhmmss>-<commit>-<platform>.tar.gz to s3://drake-packages/
 upload: drake-<yyymmddhhmmss>-<commit>-<platform>.tar.gz.sha512 to s3://drake-packages/drake/experimental/drake-<yyymmddhhmmss>-<commit>-<platform>.tar.gz.sha512
 ```
 
-where ``<platform>`` is ``bionic``, ``focal``, or ``mac``.
+where ``<platform>`` is ``focal``, or ``mac``.

--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -110,8 +110,7 @@ the main body of the document:
       ignore)
    3. Open the latest builds from the following builds:
       1. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/mac-big-sur-unprovisioned-clang-bazel-nightly-snopt-packaging/>
-      2. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-bionic-unprovisioned-gcc-bazel-nightly-snopt-packaging/>
-      3. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-focal-unprovisioned-gcc-bazel-nightly-snopt-packaging/>
+      2. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-focal-unprovisioned-gcc-bazel-nightly-snopt-packaging/>
    4. Check the logs for those packaging builds and find the URLs they posted
       to (open the latest build, go to "View as plain text", and search for
       ``drake/nightly/drake-20``), and find the date.  It will be ``YYYYMMDD``


### PR DESCRIPTION
Working towards #16842.

The merging of this PR needs to be coordinated with[ drake-ci #145](https://github.com/RobotLocomotion/drake-ci/pull/145) and the removal of Ubuntu jobs from CI.