### PR TITLE
[multibody] Filter collisions within welded subgraphs

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -513,7 +513,7 @@ call to Finalize() must be performed. This call will:
 - declare the plant's input and output ports,
 - declare collision filters to ignore collisions:
   - between bodies connected by a joint,
-  - between bodies welded (directly or transitively) to the world.
+  - within subgraphs of welded bodies.
 
 <!-- TODO(#16422): ignore collisions within all groups of welded-together
      bodies -->
@@ -4227,10 +4227,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       geometry::GeometryId id,
       const geometry::SceneGraphInspector<T>& inspector) const;
 
-  // Helper method to apply collision filters based on body-adjacency. By
-  // default, we don't consider collisions between geometries affixed to
-  // bodies connected by a joint.
-  void FilterAdjacentBodies();
+  // Helper method to apply default collision filters. By default, we don't
+  // consider collisions:
+  // * between geometries affixed to bodies connected by a joint
+  // * within subgraphs of welded-together bodies
+  void ApplyDefaultCollisionFilters();
 
   // For discrete models, MultibodyPlant uses a penalty method to impose joint
   // limits. In this penalty method a force law of the form:


### PR DESCRIPTION
Closes: #16422

This is a generalization of the the already-existing code to filter
collisions within bodies welded to the world.  Now, we filter collisions
within any welded subgraph of the model.

On the way to constructing a test, remove some unused infrastructure and
(mostly) prefer method calls to multiple optional constructor
parameters.

Also, back-fill a test that should have accompanied PR #1116.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16920)
<!-- Reviewable:end -->
