### PR TITLE
[MathematicalProgram] Add convex quadratic constraint as rotated Lorentz cone constraint.

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -1101,6 +1101,18 @@ void BindMathematicalProgram(py::module m) {
           py::arg("A"), py::arg("b"), py::arg("vars"),
           doc.MathematicalProgram.AddRotatedLorentzConeConstraint
               .doc_3args_A_b_vars)
+      .def(
+          "AddQuadraticAsRotatedLorentzConeConstraint",
+          [](MathematicalProgram* self,
+              const Eigen::Ref<const Eigen::MatrixXd>& Q,
+              const Eigen::Ref<const Eigen::VectorXd>& b, double c,
+              const Eigen::Ref<const VectorXDecisionVariable>& vars) {
+            return self->AddQuadraticAsRotatedLorentzConeConstraint(
+                Q, b, c, vars);
+          },
+          py::arg("Q"), py::arg("b"), py::arg("c"), py::arg("vars"),
+          doc.MathematicalProgram.AddQuadraticAsRotatedLorentzConeConstraint
+              .doc)
       .def("AddLinearComplementarityConstraint",
           static_cast<Binding<LinearComplementarityConstraint> (
               MathematicalProgram::*)(const Eigen::Ref<const Eigen::MatrixXd>&,

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -1272,6 +1272,16 @@ class TestMathematicalProgram(unittest.TestCase):
             linear_expression1=x[0]+1, linear_expression2=x[0]+x[1],
             quadratic_expression=x[0]*x[0] + 2*x[0] + x[1]*x[1] + 5)
 
+    def test_add_quadratic_as_rotated_lorentz_cone_constraint(self):
+        prog = mp.MathematicalProgram()
+        x = prog.NewContinuousVariables(2)
+        dut = prog.AddQuadraticAsRotatedLorentzConeConstraint(
+            Q=np.array([[1, 2.], [2., 10.]]),
+            b=np.array([1., 3.]),
+            c=0.5,
+            vars=x)
+        self.assertIsInstance(dut.evaluator(), mp.RotatedLorentzConeConstraint)
+
     def test_add_linear_matrix_inequality_constraint(self):
         prog = mp.MathematicalProgram()
         F = [np.eye(2), np.array([[0, 1], [1., 0.]])]

--- a/solvers/create_constraint.cc
+++ b/solvers/create_constraint.cc
@@ -643,6 +643,50 @@ Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
   expr.tail(C.rows()) = C * quadratic_vars + d;
   return ParseRotatedLorentzConeConstraint(expr);
 }
+
+std::shared_ptr<RotatedLorentzConeConstraint>
+ParseQuadraticAsRotatedLorentzConeConstraint(
+    const Eigen::Ref<const Eigen::MatrixXd>& Q,
+    const Eigen::Ref<const Eigen::VectorXd>& b, double c) {
+  // [-bᵀx-c, 1, Fx] is in the rotated Lorentz cone, where FᵀF = Q
+  Eigen::MatrixXd F;
+  // First try Cholesky decomposition
+  Eigen::LLT<Eigen::MatrixXd> llt((Q + Q.transpose()) / 4.);
+  if (llt.info() == Eigen::Success) {
+    F = llt.matrixU();
+  } else {
+    Eigen::LDLT<Eigen::MatrixXd> ldlt((Q + Q.transpose()) / 4.);
+    if (ldlt.info() == Eigen::Success) {
+      if (!ldlt.isPositive()) {
+        throw std::runtime_error(
+            "ParseQuadraticAsRotatedLorentzConeConstraint: ldlt.isPositive() "
+            "is false. The matrix Q is not positive semidefinite.");
+      }
+      const Eigen::MatrixXd D_sqrt =
+          ldlt.vectorD().array().sqrt().matrix().asDiagonal();
+      F = D_sqrt * ldlt.matrixL().transpose() * ldlt.transpositionsP();
+      // Only need to keep the top rank(Q) rows of P.
+      int rank_Q = 0;
+      for (int i = 0; i < Q.rows(); ++i) {
+        if (ldlt.vectorD()(i) > 0) {
+          ++rank_Q;
+        }
+      }
+      F.conservativeResize(rank_Q, F.cols());
+    } else {
+      throw std::runtime_error(
+          "ParseQuadraticAsRotatedLorentzConeConstraint: ldlt fails.");
+    }
+  }
+  // A_lorentz * x + b_lorentz = [-bᵀx-c, 1, Fx]
+  Eigen::MatrixXd A_lorentz = Eigen::MatrixXd::Zero(2 + F.rows(), F.cols());
+  Eigen::VectorXd b_lorentz = Eigen::VectorXd::Zero(2 + F.rows());
+  A_lorentz.row(0) = -b.transpose();
+  b_lorentz(0) = -c;
+  b_lorentz(1) = 1;
+  A_lorentz.bottomRows(F.rows()) = F;
+  return std::make_shared<RotatedLorentzConeConstraint>(A_lorentz, b_lorentz);
+}
 }  // namespace internal
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/create_constraint.h
+++ b/solvers/create_constraint.h
@@ -229,6 +229,20 @@ Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
     const symbolic::Expression& linear_expr2,
     const symbolic::Expression& quadratic_expr, double tol = 0);
 
+/** For a convex quadratic constraint 0.5xᵀQx + bᵀx + c <= 0, we parse it as a
+ * rotated Lorentz cone constraint [-bᵀx-c, 1, Fx] is in the rotated Lorentz
+ * cone where FᵀF = Q
+ * @throw exception if this quadratic constraint is not convex (Q is not
+ * positive semidefinite)
+ *
+ * You could refer to
+ * https://docs.mosek.com/latest/pythonapi/advanced-toconic.html for derivation.
+ */
+std::shared_ptr<RotatedLorentzConeConstraint>
+ParseQuadraticAsRotatedLorentzConeConstraint(
+    const Eigen::Ref<const Eigen::MatrixXd>& Q,
+    const Eigen::Ref<const Eigen::VectorXd>& b, double c);
+
 // TODO(eric.cousineau): Implement this if variable creation is separated.
 // Format would be (tuple(linear_binding, psd_binding), new_vars)
 // ParsePositiveSemidefiniteConstraint(

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -969,6 +969,16 @@ MathematicalProgram::AddRotatedLorentzConeConstraint(
   return AddConstraint(constraint, vars);
 }
 
+Binding<RotatedLorentzConeConstraint>
+MathematicalProgram::AddQuadraticAsRotatedLorentzConeConstraint(
+    const Eigen::Ref<const Eigen::MatrixXd>& Q,
+    const Eigen::Ref<const Eigen::VectorXd>& b, double c,
+    const Eigen::Ref<const VectorXDecisionVariable>& vars) {
+  auto constraint =
+      internal::ParseQuadraticAsRotatedLorentzConeConstraint(Q, b, c);
+  return AddConstraint(constraint, vars);
+}
+
 Binding<BoundingBoxConstraint> MathematicalProgram::AddBoundingBoxConstraint(
     const Eigen::Ref<const Eigen::MatrixXd>& lb,
     const Eigen::Ref<const Eigen::MatrixXd>& ub,

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2336,6 +2336,26 @@ class MathematicalProgram {
     return AddRotatedLorentzConeConstraint(A, b, vars);
   }
 
+  /** Add the convex quadratic constraint 0.5xᵀQx + bᵀx + c <= 0 as a
+   * rotated Lorentz cone constraint [rᵀx+s, 1, Px+q] is in the rotated Lorentz
+   * cone. When solving the optimization problem using conic solvers (like
+   * Mosek, Gurobi, SCS, etc), it is numerically preferrable to impose the
+   * convex quadratic constraint as rotated Lorentz cone constraint. See
+   * https://docs.mosek.com/latest/capi/prob-def-quadratic.html#a-recommendation
+   * @throw exception if this quadratic constraint is not convex (Q is not
+   * positive semidefinite)
+   * @param Q The Hessian of the quadratic constraint. Should be positive
+   * semidefinite.
+   * @param b The linear coefficient of the quadratic constraint.
+   * @param c The constant term of the quadratic constraint.
+   * @param vars x in the documentation above.
+   */
+  Binding<RotatedLorentzConeConstraint>
+  AddQuadraticAsRotatedLorentzConeConstraint(
+      const Eigen::Ref<const Eigen::MatrixXd>& Q,
+      const Eigen::Ref<const Eigen::VectorXd>& b, double c,
+      const Eigen::Ref<const VectorX<symbolic::Variable>>& vars);
+
   /**
    * Adds a linear complementarity constraints referencing a subset of
    * the decision variables.


### PR DESCRIPTION
The conic solvers prefer rotated Lorentz cone constraint rather than the non-conic quadratic constraint.

resolves #16918 

cc @lujieyang

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16921)
<!-- Reviewable:end -->
