### PR TITLE
[doc] Upgrade recommended Bazel version to 5.1 on Mac

### DIFF
--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -12,8 +12,8 @@ integration. Any other configurations are provided on a best-effort basis.
 |----------------------------------|--------------|---------|-------|-------|------------------------------------|-------------------------------|
 | Ubuntu 18.04 LTS (Bionic Beaver) | x86_64 ⁽¹⁾   | 3.6 ⁽³⁾ | 5.1   | 3.10  | GCC 7.5 (default) or Clang 9   | OpenJDK 11                    |
 | Ubuntu 20.04 LTS (Focal Fossa)   | x86_64 ⁽¹⁾   | 3.8 ⁽³⁾ | 5.1   | 3.16  | GCC 9.3 (default) or Clang 9   | OpenJDK 11                    |
-| macOS Big Sur (11)               | x86_64 ⁽²⁾   | 3.9 ⁽³⁾ | 5.0   | 3.19  | Apple LLVM 12.0.0 (Xcode 12.4) | AdoptOpenJDK 15 (HotSpot JVM) |
-| macOS Monterey (12)              | x86_64 ⁽²⁾   | 3.9 ⁽³⁾ | 5.0   | 3.19  | Apple LLVM 12.0.0 (Xcode 12.4) | AdoptOpenJDK 15 (HotSpot JVM) |
+| macOS Big Sur (11)               | x86_64 ⁽²⁾   | 3.9 ⁽³⁾ | 5.1   | 3.19  | Apple LLVM 12.0.0 (Xcode 12.4) | AdoptOpenJDK 15 (HotSpot JVM) |
+| macOS Monterey (12)              | x86_64 ⁽²⁾   | 3.9 ⁽³⁾ | 5.1   | 3.19  | Apple LLVM 12.0.0 (Xcode 12.4) | AdoptOpenJDK 15 (HotSpot JVM) |
 
 ⁽¹⁾ Drake Ubuntu builds assume support for Intel's AVX2 and FMA instructions,
 introduced with the Haswell architecture in 2013 with substantial performance


### PR DESCRIPTION
Resolves #16865.

The unprovisioned Mac builds switched to 5.1 over the weekend. For example (search for bazel 5.1 in the console ouput):

https://drake-jenkins.csail.mit.edu/view/Mac%20Monterey%20Unprovisioned/job/mac-monterey-unprovisioned-clang-cmake-weekly-release/14/consoleFull
https://drake-jenkins.csail.mit.edu/view/Mac%20Big%20Sur%20Unprovisioned/job/mac-big-sur-unprovisioned-clang-bazel-nightly-release/427/consoleFull

The provisioned Mac images are being updated now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16926)
<!-- Reviewable:end -->
