### PR TITLE
Enable MOSEK in wheel builds.

### DIFF
--- a/tools/wheel/image/build-drake.sh
+++ b/tools/wheel/image/build-drake.sh
@@ -14,5 +14,6 @@ bazel run \
     --repo_env=DRAKE_OS=manylinux \
     --define NO_DRAKE_VISUALIZER=ON \
     --define NO_DREAL=ON \
+    --define WITH_MOSEK=ON \
     --define WITH_SNOPT=ON \
     //:install -- /opt/drake

--- a/tools/wheel/image/build-wheel.sh
+++ b/tools/wheel/image/build-wheel.sh
@@ -27,11 +27,18 @@ cp -r -t /wheel/pydrake \
     /opt/drake/lib/python*/site-packages/pydrake/*
 
 cp -r -t /wheel/pydrake/lib \
-    /opt/drake/lib/libdrake*.so
+    /opt/drake/lib/libdrake*.so \
 
 # NOTE: build-vtk.sh also puts licenses in /opt/drake-dependencies/licenses.
 cp -r -t /wheel/pydrake/doc \
     /opt/drake-dependencies/licenses/*
+
+# MOSEK is "sort of" third party, but is procured as part of Drake's build and
+# ends up in /opt/drake. It needs to be copied somewhere where auditwheel can
+# find it.
+cp -r -t /opt/drake-dependencies/lib \
+    /opt/drake/lib/libmosek*.so* \
+    /opt/drake/lib/libcilkrts*.so*
 
 # TODO(mwoehlke-kitware) We need a different way of shipping non-arch files
 # (examples, models).

--- a/tools/wheel/test/test-wheel.sh
+++ b/tools/wheel/test/test-wheel.sh
@@ -24,5 +24,6 @@ python << EOF
 import pydrake.all
 print(pydrake.getDrakePath())
 print(pydrake.all.PackageMap().GetPath("drake"))
+assert pydrake.all.MosekSolver().available(), "Missing MOSEK"
 assert pydrake.all.SnoptSolver().available(), "Missing SNOPT"
 EOF


### PR DESCRIPTION
Towards #16439.

The wheel now additionally contains:
```
 29054680  2022-04-07 17:24   pydrake/lib/libmosek64.so.9.2
   718212  2022-04-07 17:24   pydrake/doc/mosek/mosek-eula.pdf
     1515  2022-04-07 17:24   pydrake/doc/mosek/LICENSE_CilkPlus
  3263032  2022-04-07 17:24   pydrake/solvers/mosek.cpython-38-x86_64-linux-gnu.so
```

(Maybe others; the above are just what matched `grep -i mosek`. Mostly to show/verify that license-related files are present.)

+@jwnimmer-tri for feature review, please

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16927)
<!-- Reviewable:end -->
