### PR TITLE
[SAP] SapSolver uses SapModel

### DIFF
--- a/multibody/contact_solvers/sap/BUILD.bazel
+++ b/multibody/contact_solvers/sap/BUILD.bazel
@@ -117,11 +117,11 @@ drake_cc_library(
     srcs = ["sap_solver.cc"],
     hdrs = ["sap_solver.h"],
     deps = [
+        ":sap_model",
         ":sap_solver_results",
         "//common:default_scalars",
         "//common:essential",
         "//multibody/contact_solvers:block_sparse_matrix",
-        "//multibody/contact_solvers:contact_solver_utils",
         "//multibody/contact_solvers:point_contact_data",
         "//multibody/contact_solvers:system_dynamics_data",
     ],
@@ -203,12 +203,14 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "sap_solver_test",
     deps = [
+        ":sap_friction_cone_constraint",
         ":sap_solver",
         ":sap_solver_results",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//multibody/contact_solvers:block_sparse_linear_operator",
         "//multibody/contact_solvers:block_sparse_matrix",
+        "//multibody/contact_solvers:contact_solver_utils",
     ],
 )
 

--- a/multibody/contact_solvers/sap/sap_solver.cc
+++ b/multibody/contact_solvers/sap/sap_solver.cc
@@ -5,315 +5,67 @@
 #include <utility>
 #include <vector>
 
-#include "drake/multibody/contact_solvers/contact_solver_utils.h"
+#include "drake/common/default_scalars.h"
 
 namespace drake {
 namespace multibody {
 namespace contact_solvers {
 namespace internal {
 
+using drake::systems::Context;
+
 template <typename T>
-void SapSolver<T>::Cache::Resize(int nv, int nc) {
-  velocities_cache_.Resize(nc);
-  momentum_cache_.Resize(nv);
-  impulses_cache_.Resize(nc);
-  gradients_cache_.Resize(nv, nc);
-  search_direction_cache_.Resize(nv, nc);
+void SapSolver<T>::set_parameters(const SapSolverParameters& parameters) {
+  parameters_ = parameters;
 }
 
 template <typename T>
-SapSolverStatus SapSolver<T>::SolveWithGuess(
-    const T& time_step, const SystemDynamicsData<T>& dynamics_data,
-    const PointContactData<T>& contact_data, const VectorX<T>& v_guess,
-    SapSolverResults<T>* results) {
-  // The primal method needs the inverse dynamics data.
-  DRAKE_DEMAND(dynamics_data.has_inverse_dynamics());
-  // User code should only call the solver for problems with constraints.
-  // Otherwise the solution is trivially v = v*.
-  DRAKE_DEMAND(contact_data.num_contacts() != 0);
-  PreProcessData(time_step, dynamics_data, contact_data, &data_);
-  return DoSolveWithGuess(v_guess, results);
+const typename SapSolver<T>::SolverStats& SapSolver<T>::get_statistics() const {
+  return stats_;
 }
 
 template <typename T>
-Vector3<T> SapSolver<T>::ProjectSingleImpulse(
-    const T& mu, const Eigen::Ref<const Vector3<T>>& R,
-    const Eigen::Ref<const Vector3<T>>& y, Matrix3<T>* dPdy) const {
-  // Computes the "soft norm" ‖x‖ₛ defined by ‖x‖ₛ² = ‖x‖² + ε², where ε =
-  // soft_tolerance. Using the soft norm we define the tangent vector as t̂ =
-  // γₜ/‖γₜ‖ₛ, which is well defined even for γₜ = 0. Also gradients are well
-  // defined and follow the same equations presented in [Castro et al., 2021]
-  // where regular norms are simply replaced by soft norms.
-  // N.B. soft_norm() is not a norm in the mathematical sense. In particular
-  // soft_norm(VectorX<T>::Zero()) = ε, different from zero.
-  auto soft_norm = [eps = parameters_.soft_tolerance](
-                       const Eigen::Ref<const VectorX<T>>& x) -> T {
-    using std::sqrt;
-    return sqrt(x.squaredNorm() + eps * eps);
-  };
-
-  // We assume a regularization of the form R = (Rt, Rt, Rn).
-  const T& Rt = R(0);
-  const T& Rn = R(2);
-  const T mu_hat = mu * Rt / Rn;
-
-  const auto yt = y.template head<2>();
-  const T yr = soft_norm(yt);
-  const T yn = y(2);
-  const Vector2<T> t_hat = yt / yr;
-
-  // N.B. The expressions implemented below are also valid for mu = 0. The
-  // projection below reduces to gamma = [0, 0, max(0, yn)] when mu = 0, as it
-  // should. The gradient also reduces to the correct expression:
-  //     | 0 0 0 |
-  // G = | 0 0 0 |
-  //     | 0 0 1 |
-
-  Vector3<T> gamma;
-  // Analytical projection of y onto the friction cone ℱ using the R norm.
-  if (yr < mu * yn) {
-    // Region I, stiction.
-    gamma = y;
-    if (dPdy) dPdy->setIdentity();
-  } else if (-mu_hat * yr < yn && mu * yn <= yr) {
-    // Region II, sliding.
-
-    // Common terms in both the projection and its gradient.
-    const T mu_tilde_squared = mu * mu_hat;  // mu_tilde = mu * sqrt(Rt/Rn).
-    const T factor = 1.0 / (1.0 + mu_tilde_squared);
-
-    // Projection P(y).
-    const T gn = (yn + mu_hat * yr) * factor;
-    const Vector2<T> gt = mu * gn * t_hat;
-    gamma.template head<2>() = gt;
-    gamma(2) = gn;
-
-    // Gradient.
-    if (dPdy) {
-      const Matrix2<T> P = t_hat * t_hat.transpose();
-      const Matrix2<T> Pperp = Matrix2<T>::Identity() - P;
-
-      // We split dPdy into separate blocks:
-      //
-      // dPdy = |dgt_dyt dgt_dyn|
-      //        |dgn_dyt dgn_dyn|
-      // where dgt_dyt ∈ ℝ²ˣ², dgt_dyn ∈ ℝ², dgn_dyt ∈ ℝ²ˣ¹ and dgn_dyn ∈ ℝ.
-      const Matrix2<T> dgt_dyt = mu * (gn / yr * Pperp + mu_hat * factor * P);
-      const Vector2<T> dgt_dyn = mu * factor * t_hat;
-      const RowVector2<T> dgn_dyt = mu_hat * factor * t_hat.transpose();
-      const T dgn_dyn = factor;
-
-      dPdy->template topLeftCorner<2, 2>() = dgt_dyt;
-      dPdy->template topRightCorner<2, 1>() = dgt_dyn;
-      dPdy->template bottomLeftCorner<1, 2>() = dgn_dyt;
-      (*dPdy)(2, 2) = dgn_dyn;
-    }
-  } else {  // yn <= -mu_hat * yr
-    // Region III, no contact.
-    gamma.setZero();
-    if (dPdy) dPdy->setZero();
-  }
-
-  return gamma;
-}
-
-template <typename T>
-void SapSolver<T>::ProjectAllImpulses(const VectorX<T>& y,
-                                      VectorX<T>* gamma) const {
-  const int nc = data_.nc;
-  const int nc3 = 3 * nc;
-  DRAKE_DEMAND(y.size() == nc3);
-  DRAKE_DEMAND(gamma->size() == nc3);
-
-  // Data.
-  const auto& R = data_.R;
-  const auto& mu = data_.mu;
-
-  for (int ic = 0; ic < nc; ++ic) {
-    const int ic3 = 3 * ic;
-    const auto& R_ic = R.template segment<3>(ic3);
-    const T& mu_ic = mu(ic);
-    const auto& y_ic = y.template segment<3>(ic3);
-    // Analytical projection of y onto the friction cone ℱ using the R norm.
-    gamma->template segment<3>(ic3) =
-        ProjectSingleImpulse(mu_ic, R_ic, y_ic);
-  }
-}
-
-template <typename T>
-void SapSolver<T>::CalcAllProjectionsGradients(
-    const VectorX<T>& y, std::vector<Matrix3<T>>* dPdy) const {
-  const int nc = data_.nc;
-  const int nc3 = 3 * nc;
-  DRAKE_DEMAND(y.size() == nc3);
-  DRAKE_DEMAND(static_cast<int>(dPdy->size()) == nc);
-
-  // Data.
-  const auto& R = data_.R;
-  const auto& mu = data_.mu;
-
-  for (int ic = 0; ic < nc; ++ic) {
-    const int ic3 = 3 * ic;
-    const auto& R_ic = R.template segment<3>(ic3);
-    const T& mu_ic = mu(ic);
-    const auto& y_ic = y.template segment<3>(ic3);
-
-    // Analytical projection of y onto the friction cone ℱ using the R norm.
-    auto& dPdy_ic = (*dPdy)[ic];
-    ProjectSingleImpulse(mu_ic, R_ic, y_ic, &dPdy_ic);
-  }
-}
-
-template <typename T>
-void SapSolver<T>::CalcDelassusDiagonalApproximation(
-    int nc, const std::vector<MatrixX<T>>& At, const BlockSparseMatrix<T>& J,
-    VectorX<T>* delassus_diagonal) const {
-  DRAKE_DEMAND(delassus_diagonal != nullptr);
-  DRAKE_DEMAND(delassus_diagonal->size() == nc);
-  const int nt = At.size();  // Number of trees.
-
-  // We compute a factorization of A once so we can re-use it multiple times
-  // below.
-  std::vector<Eigen::LDLT<MatrixX<T>>> A_ldlt;
-  A_ldlt.resize(nt);
-  for (int t = 0; t < nt; ++t) {
-    const auto& At_local = At[t];
-    A_ldlt[t] = At_local.ldlt();
-  }
-
-  // We compute a diagonal approximation to the Delassus operator W. We
-  // initialize it to zero and progressively add contributions in an O(n) pass.
-  std::vector<Matrix3<T>> W(nc, Matrix3<T>::Zero());
-  for (auto [p, t, Jpt] : J.get_blocks()) {
-    // Verify assumption that this indeed is a contact Jacobian.
-    DRAKE_DEMAND(J.row_start(p) % 3 == 0);
-    DRAKE_DEMAND(Jpt.rows() % 3 == 0);
-    // ic_start is the first contact point of patch p.
-    const int ic_start = J.row_start(p) / 3;
-    // k-th contact within patch p.
-    for (int k = 0; k < Jpt.rows() / 3; ++k) {
-      const int ic = ic_start + k;
-      const auto& Jkt = Jpt.template middleRows<3>(3 * k);
-      // This effectively computes Jₖₜ⋅A⁻¹⋅Jₖₜᵀ.
-      W[ic] += Jkt * A_ldlt[t].solve(Jkt.transpose());
-    }
-  }
-
-  // Compute delassus_diagonal as the rms norm of k-th diagonal block.
-  for (int k = 0; k < nc; ++k) {
-    (*delassus_diagonal)[k] = W[k].norm() / 3;
-  }
-}
-
-template <typename T>
-void SapSolver<T>::PreProcessData(const T& time_step,
-                                  const SystemDynamicsData<T>& dynamics_data,
-                                  const PointContactData<T>& contact_data,
-                                  PreProcessedData* data) const {
-  DRAKE_DEMAND(data != nullptr);
-  using std::max;
-  using std::min;
-  using std::sqrt;
-
-  data->Resize(dynamics_data.num_velocities(), contact_data.num_contacts());
-  data->time_step = time_step;
-
-  // Aliases to data.
-  const VectorX<T>& mu = contact_data.get_mu();
-  const VectorX<T>& phi0 = contact_data.get_phi0();
-  const VectorX<T>& stiffness = contact_data.get_stiffness();
-  const VectorX<T>& dissipation = contact_data.get_dissipation();
-
-  // Aliases to mutable pre-processed data.
-  VectorX<T>& R = data->R;
-  VectorX<T>& vhat = data->vhat;
-  VectorX<T>& inv_sqrt_A = data->inv_sqrt_A;
-
-  // Store operators as block-sparse matrices.
-  dynamics_data.get_A().AssembleMatrix(&data->A);
-  contact_data.get_Jc().AssembleMatrix(&data->J);
-
-  // Extract momentum matrix's per-tree diagonal blocks. Compute diagonal
-  // scaling inv_sqrt_A.
-  data->At.clear();
-  data->At.reserve(data->A.num_blocks());
-  for (const auto& block : data->A.get_blocks()) {
-    const int t1 = std::get<0>(block);
-    const int t2 = std::get<1>(block);
-    const MatrixX<T>& Aij = std::get<2>(block);
-    // We verify the assumption that M is block diagonal.
-    DRAKE_DEMAND(t1 == t2);
-    // Each block must be square.
-    DRAKE_DEMAND(Aij.rows() == Aij.cols());
-
-    const int nt = Aij.rows();  // Number of DOFs in the tree.
-    data->At.push_back(Aij);
-
-    const int start = data->A.row_start(t1);
-    DRAKE_DEMAND(start == data->A.col_start(t2));
-    inv_sqrt_A.segment(start, nt) = Aij.diagonal().cwiseInverse().cwiseSqrt();
-  }
-
-  // Computation of a diagonal approximation to the Delassus operator. N.B. This
-  // must happen before the computation of the regularization R below.
-  const int nc = phi0.size();
-  CalcDelassusDiagonalApproximation(nc, data->At, data->J,
-                                    &data->delassus_diagonal);
-
-  // We use the Delassus scaling computed above to estimate regularization
-  // parameters in the matrix R.
-  const VectorX<T>& delassus_diagonal = data->delassus_diagonal;
-  const double beta = parameters_.beta;
-  const double sigma = parameters_.sigma;
-
-  // Rigid approximation constant: Rₙ = β²/(4π²)⋅wᵢ when the contact frequency
-  // ωₙ is below the limit ωₙ⋅δt ≤ 2π. That is, the period is Tₙ = β⋅δt. See
-  // [Castro et al., 2021] for details.
-  const T beta_factor = beta * beta / (4.0 * M_PI * M_PI);
-  for (int ic = 0; ic < nc; ++ic) {
-    const int ic3 = 3 * ic;
-    const T& k = stiffness(ic);
-    const T& c = dissipation(ic);
-    DRAKE_DEMAND(k > 0 && c >= 0);
-    const T& wi = delassus_diagonal(ic);
-    const T taud = c / k;  // Damping time scale.
-    const T Rn =
-        max(beta_factor * wi, 1.0 / (time_step * k * (time_step + taud)));
-    const T Rt = sigma * wi;
-    R.template segment<3>(ic3) = Vector3<T>(Rt, Rt, Rn);
-
-    // Stabilization velocity.
-    const T vn_hat = -phi0(ic) / (time_step + taud);
-    vhat.template segment<3>(ic3) = Vector3<T>(0, 0, vn_hat);
-  }
-
-  data->Rinv = R.cwiseInverse();
-  data->v_star = dynamics_data.get_v_star();
-  data->mu = mu;
-  data->A.Multiply(data->v_star, &data->p_star);
-}
-
-template <typename T>
-void SapSolver<T>::PackSapSolverResults(const State& state,
+void SapSolver<T>::PackSapSolverResults(const systems::Context<T>& context,
                                         SapSolverResults<T>* results) const {
   DRAKE_DEMAND(results != nullptr);
-  results->Resize(data_.nv, 3 * data_.nc);
-  results->v = state.v();
-  results->gamma = EvalImpulsesCache(state).gamma;
-  results->vc = EvalVelocitiesCache(state).vc;
-  data_.J.MultiplyByTranspose(results->gamma, &results->j);
+  results->Resize(model_->problem().num_velocities(),
+                  model_->num_constraint_equations());
+
+  // For non-participating velocities the solutions is v = v*. Therefore we
+  // first initialize to v = v* and overwrite with the non-trivial participating
+  // values in the following line.
+  results->v = model_->problem().v_star();
+  const VectorX<T>& v_participating = model_->GetVelocities(context);
+  model_->velocities_permutation().ApplyInverse(v_participating, &results->v);
+
+  // Constraints equations are clustered (essentially their order is permuted
+  // for a better sparsity structure). Therefore constraint velocities and
+  // impulses are evaluated in this clustered order and permuted into the
+  // original order described by the model right after.
+  const VectorX<T>& vc_clustered = model_->EvalConstraintVelocities(context);
+  model_->impulses_permutation().ApplyInverse(vc_clustered, &results->vc);
+  const VectorX<T>& gamma_clustered = model_->EvalImpulses(context);
+  model_->impulses_permutation().ApplyInverse(gamma_clustered, &results->gamma);
+
+  // For non-participating velocities we have v=v* and the generalized impulses
+  // are zero. Therefore we first zero-out all generalized impulses and
+  // overwrite with the non-trivial non-zero values for the participating DOFs
+  // right after.
+  const VectorX<T>& tau_participating =
+      model_->EvalGeneralizedImpulses(context);
+  results->j.setZero();
+  model_->velocities_permutation().ApplyInverse(tau_participating, &results->j);
 }
 
 template <typename T>
-void SapSolver<T>::CalcStoppingCriteriaResidual(const State& state,
+void SapSolver<T>::CalcStoppingCriteriaResidual(const Context<T>& context,
                                                 T* momentum_residual,
                                                 T* momentum_scale) const {
   using std::max;
-  const auto& inv_sqrt_A = data_.inv_sqrt_A;
-  const auto& momentum_cache = EvalMomentumCache(state);
-  const VectorX<T>& p = momentum_cache.p;
-  const VectorX<T>& jc = momentum_cache.jc;
-  const VectorX<T>& ell_grad = EvalGradientsCache(state).ell_grad_v;
+  const VectorX<T>& inv_sqrt_A = model_->inv_sqrt_dynamics_matrix();
+  const VectorX<T>& p = model_->EvalMomentum(context);
+  const VectorX<T>& jc = model_->EvalGeneralizedImpulses(context);
+  const VectorX<T>& ell_grad = model_->EvalCostGradient(context);
 
   // Scale generalized momentum quantities using inv_sqrt_A so that all entries
   // have the same units and we can weigh them equally.
@@ -326,34 +78,57 @@ void SapSolver<T>::CalcStoppingCriteriaResidual(const State& state,
 }
 
 template <typename T>
-SapSolverStatus SapSolver<T>::DoSolveWithGuess(
-    const VectorX<T>& v_guess, SapSolverResults<T>* result) {
+SapSolverStatus SapSolver<T>::SolveWithGuess(const SapContactProblem<T>&,
+                                             const VectorX<T>&,
+                                             SapSolverResults<T>*) {
   throw std::logic_error(
-      "SapSolver::DoSolveWithGuess(): Only T = double is supported.");
+      "SapSolver::SolveWithGuess(): Only T = double is supported.");
 }
 
 template <>
-SapSolverStatus SapSolver<double>::DoSolveWithGuess(
-    const VectorX<double>& v_guess, SapSolverResults<double>* results) {
+SapSolverStatus SapSolver<double>::SolveWithGuess(
+    const SapContactProblem<double>& problem, const VectorX<double>& v_guess,
+    SapSolverResults<double>* results) {
   using std::abs;
   using std::max;
 
-  const int nv = data_.nv;
-  const int nc = data_.nc;
-  State state(nv, nc);
+  if (problem.num_constraints() == 0) {
+    // In the absence of constraints the solution is trivially v = v*.
+    results->Resize(problem.num_velocities(),
+                    problem.num_constraint_equations());
+    results->v = problem.v_star();
+    results->j.setZero();
+    return SapSolverStatus::kSuccess;
+  }
+
+  // Make model for the given contact problem.
+  model_ = std::make_unique<SapModel<double>>(&problem);
+  const int nv = model_->num_velocities();
+  const int nk = model_->num_constraint_equations();
+
+  // Allocate the necessary memory to work with.
+  auto context = model_->MakeContext();
+  auto scratch = model_->MakeContext();
+  SearchDirectionData search_direction_data(nv, nk);
   stats_ = SolverStats();
 
-  state.mutable_v() = v_guess;
+  {
+    // We limit the lifetime of this reference, v, to within this scope where we
+    // immediately need it.
+    Eigen::VectorBlock<VectorX<double>> v =
+        model_->GetMutableVelocities(context.get());
+    model_->velocities_permutation().Apply(v_guess, &v);
+  }
 
   // Start Newton iterations.
   int k = 0;
-  double ell_previous = EvalCostCache(state).ell;
+  double ell_previous = model_->EvalCost(*context);
   bool converged = false;
   for (;; ++k) {
     // We first verify the stopping criteria. If satisfied, we skip expensive
     // factorizations.
     double momentum_residual, momentum_scale;
-    CalcStoppingCriteriaResidual(state, &momentum_residual, &momentum_scale);
+    CalcStoppingCriteriaResidual(*context, &momentum_residual, &momentum_scale);
     stats_.optimality_criterion_reached =
         momentum_residual <=
         parameters_.abs_tolerance + parameters_.rel_tolerance * momentum_scale;
@@ -374,15 +149,17 @@ SapSolverStatus SapSolver<double>::DoSolveWithGuess(
 
     // This is the most expensive update: it performs the factorization of H to
     // solve for the search direction dv.
-    const VectorX<double>& dv = EvalSearchDirectionCache(state).dv;
+    CalcSearchDirectionData(*context, &search_direction_data);
+    const VectorX<double>& dv = search_direction_data.dv;
 
-    const auto [alpha, ls_iters] = PerformBackTrackingLineSearch(state, dv);
+    const auto [alpha, ls_iters] = PerformBackTrackingLineSearch(
+        *context, search_direction_data, scratch.get());
     stats_.num_line_search_iters += ls_iters;
 
     // Update state.
-    state.mutable_v() += alpha * dv;
+    model_->GetMutableVelocities(context.get()) += alpha * dv;
 
-    const double ell = EvalCostCache(state).ell;
+    const double ell = model_->EvalCost(*context);
     const double ell_scale = (ell + ell_previous) / 2.0;
     // N.B. Even though theoretically we expect ell < ell_previous, round-off
     // errors might make the difference ell_previous - ell negative, within
@@ -403,7 +180,7 @@ SapSolverStatus SapSolver<double>::DoSolveWithGuess(
     // parameter.
     stats_.cost_criterion_reached =
         ell_decrement < parameters_.cost_abs_tolerance +
-                        parameters_.cost_rel_tolerance * ell_scale &&
+                            parameters_.cost_rel_tolerance * ell_scale &&
         alpha > 0.5;
 
     ell_previous = ell;
@@ -411,7 +188,7 @@ SapSolverStatus SapSolver<double>::DoSolveWithGuess(
 
   if (!converged) return SapSolverStatus::kFailure;
 
-  PackSapSolverResults(state, results);
+  PackSapSolverResults(*context, results);
 
   // N.B. If the stopping criteria is satisfied for k = 0, the solver is not
   // even instantiated and no factorizations are performed (the expensive part
@@ -422,24 +199,26 @@ SapSolverStatus SapSolver<double>::DoSolveWithGuess(
 }
 
 template <typename T>
-T SapSolver<T>::CalcLineSearchCost(const State& state_v, const T& alpha,
-                                   State* state_alpha) const {
+T SapSolver<T>::CalcCostAlongLine(
+    const systems::Context<T>& context,
+    const SearchDirectionData& search_direction_data, const T& alpha,
+    systems::Context<T>* scratch) const {
   // Data.
-  const VectorX<T>& R = data_.R;
-  const VectorX<T>& v_star = data_.v_star;
+  const VectorX<T>& R = model_->constraints_bundle().R();
+  const VectorX<T>& v_star = model_->v_star();
 
-  // Cached quantities at state v.
-  const typename Cache::SearchDirectionCache& search_direction_cache =
-      EvalSearchDirectionCache(state_v);
-  const VectorX<T>& dv = search_direction_cache.dv;
-  const VectorX<T>& dp = search_direction_cache.dp;
-  const T& d2ellA_dalpha2 = search_direction_cache.d2ellA_dalpha2;
+  // Search direction quantities at state v.
+  const VectorX<T>& dv = search_direction_data.dv;
+  const VectorX<T>& dp = search_direction_data.dp;
+  const T& d2ellA_dalpha2 = search_direction_data.d2ellA_dalpha2;
 
   // State at v(alpha).
-  state_alpha->mutable_v() = state_v.v() + alpha * dv;
+  Context<T>& context_alpha = *scratch;
+  const VectorX<T>& v = model_->GetVelocities(context);
+  model_->GetMutableVelocities(&context_alpha) = v + alpha * dv;
 
   // Update velocities and impulses at v(alpha).
-  const VectorX<T>& gamma = EvalImpulsesCache(*state_alpha).gamma;
+  const VectorX<T>& gamma = model_->EvalImpulses(context_alpha);
 
   // Regularizer cost.
   const T ellR = 0.5 * gamma.dot(R.asDiagonal() * gamma);
@@ -453,8 +232,8 @@ T SapSolver<T>::CalcLineSearchCost(const State& state_v, const T& alpha,
   //  - dpᵀ = Δvᵀ⋅A
   //  - ellA(v) = 0.5‖v−v*‖²
   //  - d2ellA_dalpha2 = 0.5‖Δv‖²α², see [Castro et al., 2021; §VIII.C].
-  T ellA = EvalCostCache(state_v).ellA;
-  ellA += alpha * dp.dot(state_v.v() - v_star);
+  T ellA = model_->EvalMomentumCost(context);
+  ellA += alpha * dp.dot(v - v_star);
   ellA += 0.5 * alpha * alpha * d2ellA_dalpha2;
   const T ell = ellA + ellR;
 
@@ -463,7 +242,9 @@ T SapSolver<T>::CalcLineSearchCost(const State& state_v, const T& alpha,
 
 template <typename T>
 std::pair<T, int> SapSolver<T>::PerformBackTrackingLineSearch(
-    const State& state, const VectorX<T>& dv) const {
+    const systems::Context<T>& context,
+    const SearchDirectionData& search_direction_data,
+    systems::Context<T>* scratch) const {
   using std::abs;
   // Line search parameters.
   const double rho = parameters_.ls_rho;
@@ -471,16 +252,15 @@ std::pair<T, int> SapSolver<T>::PerformBackTrackingLineSearch(
   const int max_iterations = parameters_.ls_max_iterations;
 
   // Quantities at alpha = 0.
-  const T& ell0 = EvalCostCache(state).ell;
-  const auto& ell_grad_v0 = EvalGradientsCache(state).ell_grad_v;
+  const T& ell0 = model_->EvalCost(context);
+  const VectorX<T>& ell_grad_v0 = model_->EvalCostGradient(context);
 
   // dℓ/dα(α = 0) = ∇ᵥℓ(α = 0)⋅Δv.
+  const VectorX<T>& dv = search_direction_data.dv;
   const T dell_dalpha0 = ell_grad_v0.dot(dv);
 
   T alpha = parameters_.ls_alpha_max;
-  // TODO(amcastro-tri): Consider removing this heap allocation from this scope.
-  State state_aux(state);  // Auxiliary workspace.
-  T ell = CalcLineSearchCost(state, alpha, &state_aux);
+  T ell = CalcCostAlongLine(context, search_direction_data, alpha, scratch);
 
   const double kTolerance = 50 * std::numeric_limits<double>::epsilon();
   // N.B. We expect ell_scale != 0 since otherwise SAP's optimality condition
@@ -522,7 +302,7 @@ std::pair<T, int> SapSolver<T>::PerformBackTrackingLineSearch(
   int iteration = 1;
   for (; iteration <= max_iterations; ++iteration) {
     alpha *= rho;
-    ell = CalcLineSearchCost(state, alpha, &state_aux);
+    ell = CalcCostAlongLine(context, search_direction_data, alpha, scratch);
     // We scan discrete values of alpha from alpha_max to zero and seek for the
     // minimum value of the cost evaluated at those discrete values. Since we
     // know the cost is convex, we detect this minimum by checking the condition
@@ -553,33 +333,39 @@ std::pair<T, int> SapSolver<T>::PerformBackTrackingLineSearch(
 }
 
 template <typename T>
-void SapSolver<T>::CallDenseSolver(const State& state, VectorX<T>* dv) const {
-  const auto& gradients_cache = EvalGradientsCache(state);
+void SapSolver<T>::CallDenseSolver(const Context<T>& context,
+                                   VectorX<T>* dv) const {
   // Explicitly build dense Hessian.
   // These matrices could be saved in the cache. However this method is only
   // intended as an alternative for debugging and optimizing it might not be
   // worth it.
-  const int nv = data_.nv;
-  MatrixX<T> H(nv, nv);
-  {
-    const int nc = data_.nc;
-    const auto& A = data_.A;
-    const auto& J = data_.J;
-    const auto& G = gradients_cache.G;
+  const int nv = model_->num_velocities();
+  const int nk = model_->num_constraint_equations();
 
-    const MatrixX<T> Jdense = J.MakeDenseMatrix();
-    MatrixX<T> Adense(nv, nv);
-    Adense = A.MakeDenseMatrix();
-
-    MatrixX<T> GJ(3 * nc, nv);
-    for (int ic = 0; ic < nc; ++ic) {
-      const int ic3 = 3 * ic;
-      const MatrixX<T>& G_ic = G[ic];
-      GJ.template middleRows<3>(ic3) =
-          G_ic * Jdense.template middleRows<3>(ic3);
-    }
-    H = Adense + Jdense.transpose() * GJ;
+  // Make dense dynamics matrix.
+  const std::vector<MatrixX<T>>& Acliques = model_->dynamics_matrix();
+  MatrixX<T> Adense = MatrixX<T>::Zero(nv, nv);
+  int offset = 0;
+  for (const auto& Ac : Acliques) {
+    const int nv_clique = Ac.rows();
+    Adense.block(offset, offset, nv_clique, nv_clique) = Ac;
+    offset += nv_clique;
   }
+
+  // Make dense Jacobian matrix.
+  const MatrixX<T> Jdense = model_->constraints_bundle().J().MakeDenseMatrix();
+
+  // Make dense Hessian matrix G.
+  const std::vector<MatrixX<T>>& G = model_->EvalConstraintsHessian(context);
+  MatrixX<T> Gdense = MatrixX<T>::Zero(nk, nk);
+  offset = 0;
+  for (const auto& Gi : G) {
+    const int ni = Gi.rows();
+    Gdense.block(offset, offset, ni, ni) = Gi;
+    offset += ni;
+  }
+
+  const MatrixX<T> H = Adense + Jdense.transpose() * Gdense * Jdense;
 
   // Factorize Hessian.
   // TODO(amcastro-tri): Make use of mat::SolveLinearSystem() for a quick and
@@ -591,143 +377,21 @@ void SapSolver<T>::CallDenseSolver(const State& state, VectorX<T>* dv) const {
   }
 
   // Compute search direction.
-  const VectorX<T> rhs = -gradients_cache.ell_grad_v;
+  const VectorX<T> rhs = -model_->EvalCostGradient(context);
   *dv = Hldlt.solve(rhs);
 }
 
 template <typename T>
-const typename SapSolver<T>::Cache::VelocitiesCache&
-SapSolver<T>::EvalVelocitiesCache(const State& state) const {
-  // This method must not depend on any other eval method. If you change it, you
-  // must update the Cache dependency diagram and matching code.
-  if (state.cache().velocities_cache().valid)
-    return state.cache().velocities_cache();
-  typename Cache::VelocitiesCache& cache =
-      state.mutable_cache().mutable_velocities_cache();
-  const auto& Jc = data_.J;
-  Jc.Multiply(state.v(), &cache.vc);
-  cache.valid = true;
-  return cache;
-}
-
-template <typename T>
-const typename SapSolver<T>::Cache::ImpulsesCache&
-SapSolver<T>::EvalImpulsesCache(const State& state) const {
-  // This method must only depend on EvalVelocitiesCache(). If you change it,
-  // you must update the Cache dependency diagram and matching code.
-  if (state.cache().impulses_cache().valid)
-    return state.cache().impulses_cache();
-  typename Cache::ImpulsesCache& cache =
-      state.mutable_cache().mutable_impulses_cache();
-  const VectorX<T>& vc = EvalVelocitiesCache(state).vc;
-  const VectorX<T>& Rinv = data_.Rinv;
-  const VectorX<T>& vhat = data_.vhat;
-  cache.y = vhat - vc;
-  // The (unprojected) impulse y=−R⁻¹⋅(vc − v̂).
-  cache.y.array() *= Rinv.array();
-  ProjectAllImpulses(cache.y, &cache.gamma);
-  ++stats_.num_impulses_cache_updates;
-  cache.valid = true;
-  return cache;
-}
-
-template <typename T>
-const typename SapSolver<T>::Cache::MomentumCache&
-SapSolver<T>::EvalMomentumCache(const State& state) const {
-  // This method must only depend on EvalImpulsesCache(). If you change it,
-  // you must update the Cache dependency diagram and matching code.
-  if (state.cache().momentum_cache().valid)
-    return state.cache().momentum_cache();
-  typename Cache::MomentumCache& cache =
-      state.mutable_cache().mutable_momentum_cache();
-  data_.A.Multiply(state.v(), &cache.p);  // p = A⋅v.
-  const VectorX<T>& gamma = EvalImpulsesCache(state).gamma;
-  data_.J.MultiplyByTranspose(gamma, &cache.jc);
-  // = p - p* = A⋅(v−v*).
-  cache.momentum_change = cache.p - data_.p_star;
-  cache.valid = true;
-  return cache;
-}
-
-template <typename T>
-const typename SapSolver<T>::Cache::CostCache& SapSolver<T>::EvalCostCache(
-    const State& state) const {
-  // This method must only depend on EvalImpulsesCache() and
-  // EvalMomentumCache(). If you change it, you must update the Cache dependency
-  // diagram and matching code.
-  if (state.cache().cost_cache().valid) return state.cache().cost_cache();
-  typename Cache::CostCache& cache =
-      state.mutable_cache().mutable_cost_cache();
-  const auto& R = data_.R;
-  const auto& v_star = data_.v_star;
-  const VectorX<T>& v = state.v();
-  const VectorX<T>& gamma = EvalImpulsesCache(state).gamma;
-  const auto& Adv = EvalMomentumCache(state).momentum_change;
-  cache.ellA = 0.5 * Adv.dot(v - v_star);
-  cache.ellR = 0.5 * gamma.dot(R.asDiagonal() * gamma);
-  cache.ell = cache.ellA + cache.ellR;
-  cache.valid = true;
-  return cache;
-}
-
-template <typename T>
-const typename SapSolver<T>::Cache::GradientsCache&
-SapSolver<T>::EvalGradientsCache(const State& state) const {
-  // This method must only depend on EvalImpulsesCache() and
-  // EvalMomentumCache(). If you change it, you must update the Cache dependency
-  // diagram and matching code.
-  if (state.cache().gradients_cache().valid)
-    return state.cache().gradients_cache();
-  typename Cache::GradientsCache& cache =
-      state.mutable_cache().mutable_gradients_cache();
-
-  // Update ∇ᵥℓ = A⋅(v−v*) - Jᵀ⋅γ
-  const auto& momentum_cache = EvalMomentumCache(state);
-  const VectorX<T>& Adv = momentum_cache.momentum_change;  // = A⋅(v−v*)
-  const VectorX<T>& jc = momentum_cache.jc;  // = Jᵀ⋅γ
-  cache.ell_grad_v = Adv - jc;
-
-  // Update dPdy and G. G = -∂γ/∂vc = dP/dy⋅R⁻¹.
-  const VectorX<T>& y = EvalImpulsesCache(state).y;
-  CalcAllProjectionsGradients(y, &cache.dPdy);
-
-  const int nc = data_.nc;
-  const auto& R = data_.R;
-  const auto& dPdy = cache.dPdy;
-  for (int ic = 0; ic < nc; ++ic) {
-    const int ic3 = 3 * ic;
-    const auto& R_ic = R.template segment<3>(ic3);
-    const Vector3<T> Rinv_ic = R_ic.cwiseInverse();
-    const Matrix3<T>& dPdy_ic = dPdy[ic];
-    MatrixX<T>& G_ic = cache.G[ic];
-    G_ic = dPdy_ic * Rinv_ic.asDiagonal();
-  }
-
-  ++stats_.num_gradients_cache_updates;
-  cache.valid = true;
-  return cache;
-}
-
-template <typename T>
-const typename SapSolver<T>::Cache::SearchDirectionCache&
-SapSolver<T>::EvalSearchDirectionCache(const State& state) const {
-  // This method must only depend on EvalGradientsCache(). If you change it, you
-  // must update the Cache dependency diagram and matching code.
-  if (state.cache().search_direction_cache().valid)
-    return state.cache().search_direction_cache();
-  typename Cache::SearchDirectionCache& cache =
-      state.mutable_cache().mutable_search_direction_cache();
-
+void SapSolver<T>::CalcSearchDirectionData(
+    const systems::Context<T>& context,
+    SapSolver<T>::SearchDirectionData* data) const {
   // Update search direction dv.
-  CallDenseSolver(state, &cache.dv);
+  CallDenseSolver(context, &data->dv);
 
   // Update Δp, Δvc and d²ellA/dα².
-  data_.J.Multiply(cache.dv, &cache.dvc);
-  data_.A.Multiply(cache.dv, &cache.dp);
-  cache.d2ellA_dalpha2 = cache.dv.dot(cache.dp);
-
-  cache.valid = true;
-  return cache;
+  model_->constraints_bundle().J().Multiply(data->dv, &data->dvc);
+  model_->MultiplyByDynamicsMatrix(data->dv, &data->dp);
+  data->d2ellA_dalpha2 = data->dv.dot(data->dp);
 }
 
 }  // namespace internal
@@ -735,4 +399,5 @@ SapSolver<T>::EvalSearchDirectionCache(const State& state) const {
 }  // namespace multibody
 }  // namespace drake
 
-template class ::drake::multibody::contact_solvers::internal::SapSolver<double>;
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::internal::SapSolver)

--- a/multibody/contact_solvers/sap/sap_solver.h
+++ b/multibody/contact_solvers/sap/sap_solver.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <memory>
 #include <utility>
 #include <vector>
 
-#include "drake/multibody/contact_solvers/block_sparse_matrix.h"
-#include "drake/multibody/contact_solvers/point_contact_data.h"
+#include "drake/multibody/contact_solvers/sap/sap_model.h"
 #include "drake/multibody/contact_solvers/sap/sap_solver_results.h"
-#include "drake/multibody/contact_solvers/system_dynamics_data.h"
+#include "drake/systems/framework/context.h"
 
 namespace drake {
 namespace multibody {
@@ -68,7 +68,7 @@ struct SapSolverParameters {
   // SolverStats::optimality_condition_reached indicates if this condition was
   // reached.
   double abs_tolerance{1.e-14};  // Absolute tolerance εₐ, square root of Joule.
-  double rel_tolerance{1.e-6};   // Relative tolerance εᵣ.
+  double rel_tolerance{1.e-6};  // Relative tolerance εᵣ.
 
   // Cost condition criterion: We monitor the decrease of the cost on each
   // iteration. It is not worth it to keep iterating if round-off errors do not
@@ -98,23 +98,13 @@ struct SapSolverParameters {
   //    square root of Joule) squared.
   double cost_abs_tolerance{1.e-30};  // Absolute tolerance εₐ, in Joules.
   double cost_rel_tolerance{1.e-15};  // Relative tolerance εᵣ.
-  int max_iterations{100};  // Maximum number of Newton iterations.
+  int max_iterations{100};            // Maximum number of Newton iterations.
 
   // Line-search parameters.
   double ls_alpha_max{1.5};   // Maximum line search parameter allowed.
   int ls_max_iterations{40};  // Maximum number of line search iterations.
   double ls_c{1.0e-4};        // Armijo's criterion parameter.
   double ls_rho{0.8};         // Backtracking search parameter.
-
-  // Rigid approximation constant: Rₙ = β²/(4π²)⋅w when the contact frequency ωₙ
-  // is below the limit ωₙ⋅δt ≤ 2π. That is, the period is Tₙ = β⋅δt. w
-  // corresponds to a diagonal approximation of the Delassuss operator for each
-  // contact. See [Castro et al., 2021. §IX.A] for details.
-  double beta{1.0};
-
-  // Dimensionless parameterization of the regularization of friction. An
-  // approximation for the bound on the slip velocity is vₛ ≈ σ⋅δt⋅g.
-  double sigma{1.0e-3};
 
   // Tolerance used in impulse soft norms. In Ns.
   double soft_tolerance{1.0e-7};
@@ -145,7 +135,7 @@ struct SapSolverParameters {
 //
 // TODO(amcastro-tri): enable AutoDiffXd support, if only for dense matrices so
 // that we can test the long term performant solution.
-// @tparam_double_only
+// @tparam_nonsymbolic_scalar
 template <typename T>
 class SapSolver {
  public:
@@ -157,18 +147,11 @@ class SapSolver {
     void Reset() {
       num_iters = 0;
       num_line_search_iters = 0;
-      num_impulses_cache_updates = 0;
-      num_gradients_cache_updates = 0;
+      optimality_criterion_reached = false;
+      cost_criterion_reached = false;
     }
     int num_iters{0};              // Number of Newton iterations.
     int num_line_search_iters{0};  // Total number of line search iterations.
-
-    // Number of impulse updates. This also includes dP/dy updates, when
-    // gradients are updated.
-    int num_impulses_cache_updates{0};
-
-    // Number of times the gradients cache is updated.
-    int num_gradients_cache_updates{0};
 
     // Indicates if the optimality condition was reached.
     bool optimality_criterion_reached{false};
@@ -179,394 +162,54 @@ class SapSolver {
 
   SapSolver() = default;
 
-  // Solve the contact problem specified by the input data. See
-  // ContactSolver::SolveWithGuess() for details. Currently, only `T = double`
-  // is supported. An exception is thrown if `T != double`.
-  //
-  // @pre dynamics_data must contain data for inverse dynamics, i.e.
-  // dynamics_data.has_inverse_dynamics() is true.
-  // @pre contact_data Must contain a non-zero number of contact constraints.
+  // Solve the contact problem specified by the input data. Currently, only `T =
+  // double` is supported. An exception is thrown if `T != double`.
   //
   // Convergence of the solver is controlled by set_parameters(). Refer to
   // SapSolverParameters for details on the convergence conditions.
   //
-  // N.B. SolveWithGuess() is a non-const method and thefore changes to the
+  // N.B. SolveWithGuess() is a non-const method and therefore changes to the
   // state of the SapSolver object are allowed. This means that when using this
   // solver in MultibodyPlant (or a DiscreteUpdateManager), it must either be
   // instantiated locally or stored within a Context cache entry to ensure
   // thread safety.
-  SapSolverStatus SolveWithGuess(const T& time_step,
-                                     const SystemDynamicsData<T>& dynamics_data,
-                                     const PointContactData<T>& contact_data,
-                                     const VectorX<T>& v_guess,
-                                     SapSolverResults<T>* result);
+  SapSolverStatus SolveWithGuess(const SapContactProblem<T>& problem,
+                                 const VectorX<T>& v_guess,
+                                 SapSolverResults<T>* result);
 
   // New parameters will affect the next call to SolveWithGuess().
-  void set_parameters(const SapSolverParameters& parameters) {
-    parameters_ = parameters;
-  }
+  void set_parameters(const SapSolverParameters& parameters);
 
   // Returns solver statistics from the last call to SolveWithGuess().
   // Statistics are reset with SolverStats::Reset() on each new call to
   // SolveWithGuess().
-  const SolverStats& get_statistics() const {
-    return stats_;
-  }
+  const SolverStats& get_statistics() const;
 
  private:
   friend class SapSolverTester;
 
-  // This class is used to store quantities that are a function of the
-  // generalized velocities in the State of the solver. This class does not
-  // provide a generic caching mechanism, but the dependencies are harcoded into
-  // the implementation. These dependencies are sketched below:
-  //
-  //      ┌───┐   ┌──┐   ┌────────┐   ┌───┐   ┌────┐   ┌────────────────┐
-  //      │ v │◄──┤vc│◄──┤Impulses│◄──┤Mom│◄──┤Grad│◄──┤Search Direction│
-  //      └───┘   └──┘   └────────┘   └───┘   └────┘   └────────────────┘
-  //                                    ▲
-  //                                    │     ┌────┐
-  //                                    └─────┤Cost│
-  //                                          └────┘
-  // Entries in the schematic correspond to cache entries with type:
-  //  - vc: VelocitiesCache
-  //  - Impulses: ImpulsesCache
-  //  - Mom: MomentumCache
-  //  - Grad: GradientsCache
-  //  - Search Direction: SearchDirectionCache
-  //
-  // The SapSolver class provides methods to "evaluate" these cache entries and
-  // always return an up-to-date reference (the computation is performed only if
-  // the cache entry is not up-to-date.) As an example, consider the evaluation
-  // of the constraints velocity vc. This is accomplished with:
-  //   const VectorX<T>& vc = EvalVelocitiesCache(state).vc;
-  // Notice that the call site does not mention the cache directly but it uses
-  // the corresponding Eval method.
-  // An eval method will always return a reference to an up-to-date cache entry.
-  // When a cache entry is not up-to-date, then the eval method will perform the
-  // necessary computation to update it. When this update computation takes
-  // place, downstream cache entries are invalidated in accordance to the
-  // diagram above. In the example above, calling EvalVelocitiesCache() on a
-  // valid velocities cache entry simply returns a reference to that entry. When
-  // the entry is invalid, stored values are updated (computed), downstream
-  // dependents marked invalid, the updated entry is marked valid, and finally a
-  // reference to the updated entry is returned. Mutating the state's velocity
-  // with State::mutable_v() will invalidate all cache entries.
-  //
-  // N.B. The schematic above must be kept in sync with the implementation.
-  //
-  // For mathematical quantities, we attempt follow the notation introduced in
-  // [Castro et al., 2021] as best as we can, though with ASCII and Unicode
-  // characters.
-  class Cache {
-   public:
-    DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Cache);
-    Cache() = default;
-
-    // Each of these cache entries must know who depends on it and must make
-    // sure those get invalidated when it does.
-
-    struct VelocitiesCache {
-      void Resize(int nc) { vc.resize(3 * nc); }
-      void Invalidate(Cache* cache) {
-        valid = false;
-        cache->mutable_impulses_cache();
-      }
-      bool valid{false};
-      VectorX<T> vc;  // constraint velocities vc = J⋅v.
-    };
-
-    struct ImpulsesCache {
-      void Resize(int nc) {
-        y.resize(3 * nc);
-        gamma.resize(3 * nc);
-      }
-      void Invalidate(Cache* cache) {
-        valid = false;
-        cache->mutable_momentum_cache();
-      }
-      bool valid{false};
-      VectorX<T> y;      // The (unprojected) impulse y = −R⁻¹⋅(vc − v̂).
-      VectorX<T> gamma;  // Impulse γ = P(y), with P(y) the projection operator.
-    };
-
-    struct MomentumCache {
-      void Resize(int nv) {
-        p.resize(nv);
-        jc.resize(nv);
-        momentum_change.resize(nv);
-      }
-      void Invalidate(Cache* cache) {
-        valid = false;
-        cache->mutable_cost_cache();
-        cache->mutable_gradients_cache();
-      }
-      bool valid{false};
-      VectorX<T> p;                // Generalized momentum p = A⋅v
-      VectorX<T> jc;               // Generalized impulse jc = Jᵀ⋅γ
-      VectorX<T> momentum_change;  // = A⋅(v−v*)
-    };
-
-    struct CostCache {
-      void Invalidate(Cache*) { valid = false; }
-      bool valid{false};
-      T ell{NAN};   // Total primal cost, = ellA + ellR.
-      T ellA{NAN};  // Velocities cost, = 1/2⋅(v−v*)ᵀ⋅A⋅(v−v*).
-      T ellR{NAN};  // Regularizer cost, = 1/2⋅γᵀ⋅R⋅γ.
-    };
-
-    struct GradientsCache {
-      void Resize(int nv, int nc) {
-        ell_grad_v.resize(nv);
-        dPdy.resize(nc);
-        G.resize(nc, Matrix3<T>::Zero());
-      }
-      void Invalidate(Cache* cache) {
-        valid = false;
-        cache->mutable_search_direction_cache();
-      }
-      bool valid{false};
-      VectorX<T> ell_grad_v;         // Gradient of the cost in v.
-      std::vector<Matrix3<T>> dPdy;  // Gradient of the projection, ∂P/∂y.
-      std::vector<MatrixX<T>> G;     // G = -∂γ/∂vc = dP/dy⋅R⁻¹.
-    };
-
-    struct SearchDirectionCache {
-      void Resize(int nv, int nc) {
-        dv.resize(nv);
-        dp.resize(nv);
-        dvc.resize(3 * nc);
-        d2ellA_dalpha2 = NAN;
-      }
-      void Invalidate(Cache*) { valid = false; }
-      bool valid{false};
-      VectorX<T> dv;          // Search direction.
-      VectorX<T> dp;          // Momentum update Δp = A⋅Δv.
-      VectorX<T> dvc;         // Constraints velocities update, Δvc=J⋅Δv.
-      T d2ellA_dalpha2{NAN};  // d²ellA/dα² = Δvᵀ⋅A⋅Δv.
-    };
-
-    // Resizes all the cache entries to store quantities for a problem with nv
-    // generalized velocities and nc contact constraints. All existing
-    // data is lost.
-    void Resize(int nv, int nc);
-
-    // Marks the cache as invalid. This is meant to be called by State when
-    // mutating its internal state.
-    void Invalidate() {
-      velocities_cache_.Invalidate(this);
+  // Struct used to store the result of computing the search direction. We store
+  // the search direction in the generalized velocities, dv, as well as
+  // additional derived quantities such as the generalized momentum update dp
+  // and the constraints' velocities update dvc.
+  struct SearchDirectionData {
+    SearchDirectionData(int num_velocities, int num_constraint_equations) {
+      dv.resize(num_velocities);
+      dp.resize(num_velocities);
+      dvc.resize(num_constraint_equations);
+      d2ellA_dalpha2 = NAN;
     }
-
-   private:
-    friend class SapSolver<T>;
-
-    // Dangerous methods for const access of cache entries; you must check the
-    // valid bit before using. These methods are meant to be used only within
-    // SapSolver's Eval methods. Cache entries must be accessed through the
-    // corresponding Eval.
-    const VelocitiesCache& velocities_cache() const {
-      return velocities_cache_;
-    }
-    const ImpulsesCache& impulses_cache() const { return impulses_cache_; }
-    const MomentumCache& momentum_cache() const { return momentum_cache_; }
-    const CostCache& cost_cache() const { return cost_cache_; }
-    const GradientsCache& gradients_cache() const { return gradients_cache_; }
-    const SearchDirectionCache& search_direction_cache() const {
-      return search_direction_cache_;
-    }
-
-    // Methods for mutable access of cache entries. The specific cache entry and
-    // its dependents are marked invalid before it is returned. External use of
-    // these methods must be only within SapSolver's Eval methods. (Internally
-    // we use them for the invalidation side effect.)
-    VelocitiesCache& mutable_velocities_cache() {
-      velocities_cache_.Invalidate(this);
-      return velocities_cache_;
-    }
-    ImpulsesCache& mutable_impulses_cache() {
-      impulses_cache_.Invalidate(this);
-      return impulses_cache_;
-    }
-    MomentumCache& mutable_momentum_cache() {
-      momentum_cache_.Invalidate(this);
-      return momentum_cache_;
-    }
-    CostCache& mutable_cost_cache() {
-      cost_cache_.Invalidate(this);
-      return cost_cache_;
-    }
-    GradientsCache& mutable_gradients_cache() {
-      gradients_cache_.Invalidate(this);
-      return gradients_cache_;
-    }
-    SearchDirectionCache& mutable_search_direction_cache() {
-      search_direction_cache_.Invalidate(this);
-      return search_direction_cache_;
-    }
-
-    // SapSolver must never access these members directly.
-    VelocitiesCache velocities_cache_;
-    ImpulsesCache impulses_cache_;
-    MomentumCache momentum_cache_;
-    CostCache cost_cache_;
-    GradientsCache gradients_cache_;
-    SearchDirectionCache search_direction_cache_;
+    VectorX<T> dv;          // Search direction.
+    VectorX<T> dp;          // Momentum update Δp = A⋅Δv.
+    VectorX<T> dvc;         // Constraints velocities update, Δvc=J⋅Δv.
+    T d2ellA_dalpha2{NAN};  // d²ellA/dα² = Δvᵀ⋅A⋅Δv.
   };
-
-  // Everything in this solver is a function of the generalized velocities v;
-  // cost ℓ(v), gradient ∇ℓ(v), Hessian H(v), intermediate quantities used for
-  // their computation and even search direction Δv(v) and Hessian
-  // factorization. State stores generalized velocities v and cached quantities
-  // that are functions of v. The purpose of cached quantities is twofold; 1) to
-  // allow reusing already computed quantities and 2) to centralize and
-  // minimize (costly) heap allocations.
-  class State {
-   public:
-    DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(State);
-
-    State() = default;
-
-    // Constructs a state for a problem with nv generalized velocities and nc
-    // contact constraints.
-    State(int nv, int nc) { Resize(nv, nc); }
-
-    // Resizes the state for a problem with nv generalized velocities and nc
-    // contact constraints.
-    void Resize(int nv, int nc) {
-      v_.resize(nv);
-      cache_.Resize(nv, nc);
-    }
-
-    const VectorX<T>& v() const { return v_; }
-
-    VectorX<T>& mutable_v() {
-      // Mark all cache quantities as invalid since they all are a function of
-      // velocity.
-      cache_.Invalidate();
-      return v_;
-    }
-
-    const Cache& cache() const { return cache_; }
-
-    // The state of the solver is fully described by the generalized velocities
-    // v. Therefore mutating the cache does not change the state of the solver
-    // and we mark this method "const". Mutable access to the cache is provided
-    // to allow updating expensive quantities that are reused in multiple
-    // places.
-    Cache& mutable_cache() const { return cache_; }
-
-   private:
-    VectorX<T> v_;
-    // N.B. State objects are only created within the scope of SolveWithGuess()
-    // and therefore the implementation is thread safe. That is, SapSolver does
-    // not have State members.
-    mutable Cache cache_;
-  };
-
-  // Structure used to store input data pre-processed for computation. For
-  // mathematical quantities, we attempt to follow the notation introduced in
-  // [Castro et al., 2021] as best as we can, though with ASCII and Unicode
-  // symbols.
-  struct PreProcessedData {
-    // Constructs an empty data.
-    PreProcessedData() = default;
-
-    // @param nv Number of generalized velocities.
-    // @param nc Number of contact constraints.
-    // @param dt The discrete time step used for simulation.
-    PreProcessedData(double dt, int nv_in, int nc_in) : time_step(dt) {
-      Resize(nv_in, nc_in);
-    }
-
-    // Resizes this PreProcessedData to store data for a problem with nv_in
-    // generalized velocities and nc_in contact constraints. A call to this
-    // method causes loss of all previously existing data.
-    // @param nv_in Number of generalized velocities.
-    // @param nc_in Number of contact constraints.
-    void Resize(int nv_in, int nc_in) {
-      nv = nv_in;
-      nc = nc_in;
-      const int nc3 = 3 * nc;
-      R.resize(nc3);
-      Rinv.resize(nc3);
-      vhat.resize(nc3);
-      mu.resize(nc);
-      inv_sqrt_A.resize(nv);
-      v_star.resize(nv);
-      p_star.resize(nv);
-      delassus_diagonal.resize(nc);
-    }
-
-    T time_step{NAN};        // Discrete time step used by the solver.
-    int nv{0};               // Number of generalized velocities.
-    int nc{0};               // Number of contacts.
-    VectorX<T> R;            // (Diagonal) Regularization matrix, of size 3nc.
-    VectorX<T> Rinv;         // Inverse of regularization matrix, of size 3nc.
-    VectorX<T> vhat;         // Constraints stabilization velocity, of size 3nc.
-    VectorX<T> mu;           // Friction coefficients, of size nc.
-    BlockSparseMatrix<T> J;  // Jacobian as block-sparse matrix.
-    BlockSparseMatrix<T> A;  // Momentum matrix as block-sparse matrix.
-    std::vector<MatrixX<T>> At;  // Per-tree blocks of the momentum matrix.
-
-    // Inverse of the diagonal matrix formed with the square root of the
-    // diagonal entries of the momentum matrix, i.e. inv_sqrt_A =
-    // diag(A)^{-1/2}. This matrix is used to compute a scaled momentum
-    // residual, see discussion on tolerances in SapSolverParameters for
-    // details.
-    VectorX<T> inv_sqrt_A;
-
-    VectorX<T> v_star;  // Free-motion generalized velocities.
-    VectorX<T> p_star;  // Free motion generalized impulse, i.e. p* = M⋅v*.
-    VectorX<T> delassus_diagonal;  // Delassus operator diagonal approximation.
-  };
-
-  // Computes a diagonal approximation of the Delassus operator used to compute
-  // a per constraint diagonal scaling into delassus_diagonal. Given an
-  // approximation Wₖₖ of the block diagonal element corresponding to the k-th
-  // constraint, the scaling is computed as delassus_diagonal[k] = ‖Wₖₖ‖ᵣₘₛ =
-  // ‖Wₖₖ‖/3. See [Castro et al. 2021] for details.
-  // @pre Matrix entries stored in `At` are SPD.
-  void CalcDelassusDiagonalApproximation(int nc,
-                                         const std::vector<MatrixX<T>>& At,
-                                         const BlockSparseMatrix<T>& Jblock,
-                                         VectorX<T>* delassus_diagonal) const;
-
-  // This method extracts and pre-processes input data into a format that is
-  // more convenient for computation. In particular, it computes quantities
-  // directly appearing in the optimization problem such as R, v̂, W, among
-  // others.
-  void PreProcessData(const T& time_step,
-                      const SystemDynamicsData<T>& dynamics_data,
-                      const PointContactData<T>& contact_data,
-                      PreProcessedData* data) const;
-
-  // Computes gamma = P(y) where P(y) is the projection of y onto the friction
-  // cone defined by `mu` using the norm defined by `R`. The gradient dP/dy of
-  // the operator is computed if dPdy != nullptr.
-  // See [Castro et al., 2021] for details on the projection operator (Section
-  // VII) and its gradients (Appendix E).
-  //
-  // @pre R has the form R = (Rt, Rt, Rn).
-  Vector3<T> ProjectSingleImpulse(
-      const T& mu, const Eigen::Ref<const Vector3<T>>& R,
-      const Eigen::Ref<const Vector3<T>>& y, Matrix3<T>* dPdy = nullptr) const;
-
-  // Computes the projection gamma = P(y) for all impulses.
-  // @pre gamma must already be properly sized.
-  void ProjectAllImpulses(const VectorX<T>& y, VectorX<T>* gamma) const;
-
-  // Computes the gradient dP/dy of the projection gamma = P(y) computed by
-  // ProjectAllImpulses().
-  // @pre dPdy must already be properly sized.
-  // TODO(amcastro-tri): consider caching common terms computed by
-  // ProjectAllImpulses() so that they can be re-used by this method.
-  void CalcAllProjectionsGradients(const VectorX<T>& y,
-                                   std::vector<Matrix3<T>>* dPdy) const;
 
   // Pack solution into SapSolverResults. Where v is the vector of
   // generalized velocities, vc is the vector of contact velocities and gamma is
   // the vector of generalized contact impulses.
-  void PackSapSolverResults(const State& state,
+  // @pre context was created by the underlying SapModel.
+  void PackSapSolverResults(const systems::Context<T>& context,
                             SapSolverResults<T>* results) const;
 
   // We monitor the optimality condition (for SAP, balance of momentum), i.e.
@@ -576,20 +219,19 @@ class SapSolver {
   // the same units (square root of Joules).
   // This method computes momentum_residual = ‖∇ℓ‖ and momentum_scale =
   // max(‖p‖,‖j‖). See [Castro et al., 2021] for further details.
-  void CalcStoppingCriteriaResidual(const State& state, T* momentum_residual,
+  // @pre context was created by the underlying SapModel.
+  void CalcStoppingCriteriaResidual(const systems::Context<T>& context,
+                                    T* momentum_residual,
                                     T* momentum_scale) const;
-
-  // Solves the contact problem from initial guess `v_guess` into `result`.
-  // @pre PreProcessData() has already been called.
-  SapSolverStatus DoSolveWithGuess(const VectorX<T>& v_guess,
-                                       SapSolverResults<T>* result);
 
   // Computes the cost ℓ(α) = ℓ(vᵐ + αΔvᵐ) for line search, where vᵐ and Δvᵐ are
   // the last Newton iteration values of generalized velocities and search
   // direction, respectively. This methods uses the O(n) strategy described in
   // [Castro et al., 2021].
-  T CalcLineSearchCost(const State& state_v, const T& alpha,
-                       State* state_alpha) const;
+  // @pre context was created by the underlying SapModel.
+  T CalcCostAlongLine(const systems::Context<T>& context,
+                      const SearchDirectionData& search_direction_data,
+                      const T& alpha, systems::Context<T>* scratch) const;
 
   // Approximation to the 1D minimization problem α = argmin ℓ(α) = ℓ(v + αΔv)
   // over α. We define ϕ(α) = ℓ₀ + α c ℓ₀', where ℓ₀ = ℓ(0), ℓ₀' = dℓ/dα(0) and
@@ -605,43 +247,48 @@ class SapSolver {
   //
   // @returns A pair (α, num_iterations) where α satisfies Armijo's criterion
   // and num_iterations is the number of backtracking iterations performed.
-  std::pair<T, int> PerformBackTrackingLineSearch(const State& state,
-                                                  const VectorX<T>& dv) const;
+  // @pre both context and scratch_workspace were created by the underlying
+  // SapModel.
+  std::pair<T, int> PerformBackTrackingLineSearch(
+      const systems::Context<T>& context,
+      const SearchDirectionData& search_direction_data,
+      systems::Context<T>* scratch_workspace) const;
 
   // Solves for dv using dense algebra, for debugging.
+  // @pre context was created by the underlying SapModel.
   // TODO(amcastro-tri): Add AutoDiffXd support.
-  void CallDenseSolver(const State& s, VectorX<T>* dv) const;
+  void CallDenseSolver(const systems::Context<T>& context,
+                       VectorX<T>* dv) const;
 
-  // Methods used to evaluate cached quantities.
-  const typename Cache::VelocitiesCache& EvalVelocitiesCache(
-      const State& state) const;
-  const typename Cache::ImpulsesCache& EvalImpulsesCache(
-      const State& state) const;
-  const typename Cache::CostCache& EvalCostCache(const State& state) const;
-  const typename Cache::MomentumCache& EvalMomentumCache(
-      const State& state) const;
-  const typename Cache::GradientsCache& EvalGradientsCache(
-      const State& state) const;
-  const typename Cache::SearchDirectionCache& EvalSearchDirectionCache(
-      const State& state) const;
+  // This method performs one iteration of the SAP solver. It updates gradient
+  // of the primal cost ∇ℓₚ, the cost's Hessian H and solves for the velocity
+  // search direction dv = −H⁻¹⋅∇ℓₚ. The result is stored in `data` along with
+  // additional derived quantities from dv.
+  // @pre context was created by the underlying SapModel.
+  void CalcSearchDirectionData(const systems::Context<T>& context,
+                               SearchDirectionData* data) const;
 
+  std::unique_ptr<SapModel<T>> model_;
   SapSolverParameters parameters_;
-  PreProcessedData data_;
   // Stats are mutable so we can update them from within const methods (e.g.
   // Eval() methods). Nothing in stats is allowed to affect the computation; it
   // is purely a passive observer.
-  // TODO(amcastro-tri): Consider moving stats into the State.
+  // TODO(amcastro-tri): Consider moving stats into the solver's state stored as
+  // part of the model's context.
   mutable SolverStats stats_;
 };
 
+// Forward-declare specializations, prior to DRAKE_DECLARE... below.
 template <>
-SapSolverStatus SapSolver<double>::DoSolveWithGuess(
-    const VectorX<double>&, SapSolverResults<double>*);
+SapSolverStatus SapSolver<double>::SolveWithGuess(
+    const SapContactProblem<double>&, const VectorX<double>&,
+    SapSolverResults<double>*);
 
 }  // namespace internal
 }  // namespace contact_solvers
 }  // namespace multibody
 }  // namespace drake
 
-extern template class ::drake::multibody::contact_solvers::internal::SapSolver<
-    double>;
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::internal::SapSolver);
+

--- a/multibody/contact_solvers/sap/test/sap_solver_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_solver_test.cc
@@ -15,6 +15,7 @@
 #include "drake/multibody/contact_solvers/block_sparse_linear_operator.h"
 #include "drake/multibody/contact_solvers/block_sparse_matrix.h"
 #include "drake/multibody/contact_solvers/contact_solver_utils.h"
+#include "drake/multibody/contact_solvers/sap/sap_friction_cone_constraint.h"
 #include "drake/multibody/contact_solvers/sap/sap_solver_results.h"
 #include "drake/multibody/contact_solvers/system_dynamics_data.h"
 
@@ -30,197 +31,10 @@ namespace multibody {
 namespace contact_solvers {
 namespace internal {
 
-class SapSolverTester {
- public:
-  using PreProcessedData = SapSolver<double>::PreProcessedData;
-
-  static PreProcessedData PreProcessData(
-      const SapSolver<double>& solver, double time_step,
-      const SystemDynamicsData<double>& dynamics_data,
-      const PointContactData<double>& contact_data) {
-    PreProcessedData data;
-    solver.PreProcessData(time_step, dynamics_data, contact_data, &data);
-    return data;
-  }
-};
-
-// We place data consumed by the contact solver in a single struct.
-struct ProblemData {
-  ProblemData(int nv, int nc) {
-    M.resize(nv, nv);
-    J.resize(3 * nc, nv);
-    v_star.resize(nv);
-    phi0.resize(nc);
-    stiffness.resize(nc);
-    dissipation.resize(nc);
-    mu.resize(nc);
-  }
-
-  double time_step;
-
-  // For this problem we have that A = M, i.e. the momentum matrix equals the
-  // mass matrix. Mass matrix in different formats:
-  MatrixXd M;
-  BlockSparseMatrix<double> Ablock;
-  std::unique_ptr<BlockSparseLinearOperator<double>> Mop;
-
-  // Jacobian in different formats:
-  MatrixXd J;
-  BlockSparseMatrix<double> Jblock;
-  std::unique_ptr<BlockSparseLinearOperator<double>> Jop;
-
-  // Free motion velocities.
-  VectorXd v_star;
-
-  // Contact data.
-  VectorXd phi0;
-  VectorXd stiffness;
-  VectorXd dissipation;
-  VectorXd mu;
-
-  // Contact solver data.
-  std::unique_ptr<SystemDynamicsData<double>> dynamics_data;
-  std::unique_ptr<PointContactData<double>> contact_data;
-};
-
-// Simple problem configuration where 3 particles (with three translational DOFs
-// each) are stacked on top of each other; particle 2 is on the ground, particle
-// 1 is placed on top of particle 2 and particle 0 is placed on top of particle
-// 1. The problem is setup with arbitrary (though non-zero) values in order to
-// verify the computation of intermediate quantities such as the pre-processed
-// data in SAP.
-class ParticlesStackProblem {
- public:
-  static constexpr int kNumParticles = 3;   // Number of particles.
-  static constexpr int kNumVelocities = 9;  // Three particles in 3D.
-  static constexpr int kNumContacts = 3;    // Vertical stack.
-
-  // Arbitrary non-zero free-motion velocities.
-  VectorXd MakeFreeMotionVelocities() const {
-    return VectorXd::LinSpaced(kNumVelocities, 0, kNumVelocities);
-  }
-
-  // Arbitrary particle masses.
-  VectorXd GetParticleMasses() const {
-    return 1.5 * VectorXd::LinSpaced(kNumParticles, 1, kNumParticles);
-  }
-
-  // Mass matrix for the system of three particles.
-  void CalcMassMatrix(BlockSparseMatrix<double>* M) const {
-    const VectorXd masses = GetParticleMasses();
-    BlockSparseMatrixBuilder<double> builder(3, 3, 3);
-    // Each particle is a block.
-    for (int p = 0; p < kNumParticles; ++p) {
-      builder.PushBlock(p, p, masses[p] * Matrix3d::Identity());
-    }
-    *M = builder.Build();
-  }
-
-  // Contact Jacobian representing the configuration in which the particles form
-  // a stack. Particle 2 on the ground, particle 1 on 2 and particle 0 on 1.
-  void MakeContactJacobian(BlockSparseMatrix<double>* J) const {
-    const MatrixXd Jblock = MatrixXd::Identity(3, 3);
-    BlockSparseMatrixBuilder<double> builder(kNumContacts, kNumParticles, 5);
-    // Contact between particles 0 and 1.
-    builder.PushBlock(0, 0, Jblock);
-    builder.PushBlock(0, 1, Jblock);
-    // Contact between particles 1 and 2.
-    builder.PushBlock(1, 1, Jblock);
-    builder.PushBlock(1, 2, Jblock);
-    // Contact between particle 2 and the ground.
-    builder.PushBlock(2, 2, Jblock);
-    *J = builder.Build();
-  }
-
-  std::unique_ptr<ProblemData> MakeProblemData() const {
-    // Set system dynamics data:
-    auto data = std::make_unique<ProblemData>(kNumVelocities, kNumContacts);
-    data->time_step = 5.0e-3;
-    CalcMassMatrix(&data->Ablock);
-    data->M = data->Ablock.MakeDenseMatrix();
-    data->Mop =
-        std::make_unique<BlockSparseLinearOperator<double>>("M", &data->Ablock);
-
-    data->v_star = MakeFreeMotionVelocities();
-
-    data->dynamics_data = std::make_unique<SystemDynamicsData<double>>(
-        data->Mop.get(), nullptr, &data->v_star);
-
-    MakeContactJacobian(&data->Jblock);
-    data->J = data->Jblock.MakeDenseMatrix();
-    data->Jop =
-        std::make_unique<BlockSparseLinearOperator<double>>("J", &data->Jblock);
-
-    data->phi0.setLinSpaced(kNumContacts, 1., kNumContacts);
-    data->stiffness.setLinSpaced(kNumContacts, 1., kNumContacts);
-    data->dissipation.setLinSpaced(kNumContacts, 1., kNumContacts);
-    data->mu.setLinSpaced(kNumContacts, 1., kNumContacts);
-
-    data->contact_data = std::make_unique<PointContactData<double>>(
-        &data->phi0, data->Jop.get(), &data->stiffness, &data->dissipation,
-        &data->mu);
-
-    return data;
-  }
-};
-
-GTEST_TEST(SapSolver, PreProcessedData) {
-  ParticlesStackProblem problem;
-  auto problem_data = problem.MakeProblemData();
-  SapSolver<double> sap;
-  SapSolverParameters parameters;
-  sap.set_parameters(parameters);
-  SapSolverTester::PreProcessedData data = SapSolverTester::PreProcessData(
-      sap, problem_data->time_step, *problem_data->dynamics_data,
-      *problem_data->contact_data);
-
-  EXPECT_EQ(data.time_step, problem_data->time_step);
-  EXPECT_EQ(data.nv, problem.kNumVelocities);
-  EXPECT_EQ(data.nc, problem.kNumContacts);
-  EXPECT_EQ(data.mu, problem_data->mu);
-  EXPECT_EQ(data.J.MakeDenseMatrix(), problem_data->J);
-  EXPECT_EQ(data.A.MakeDenseMatrix(), problem_data->M);
-  EXPECT_EQ(data.At[0], (problem_data->M.block<3, 3>(0, 0)));
-  EXPECT_EQ(data.At[1], (problem_data->M.block<3, 3>(3, 3)));
-  EXPECT_EQ(data.At[2], (problem_data->M.block<3, 3>(6, 6)));
-  const VectorXd expected_inv_sqrt_A =
-      problem_data->M.diagonal().cwiseInverse().cwiseSqrt();
-  EXPECT_TRUE(CompareMatrices(data.inv_sqrt_A, expected_inv_sqrt_A,
-                              std::numeric_limits<double>::epsilon(),
-                              MatrixCompareType::relative));
-  EXPECT_EQ(data.v_star, problem_data->v_star);  // This should just be a copy.
-  EXPECT_TRUE(CompareMatrices(
-      data.p_star, problem_data->M * problem_data->v_star,
-      std::numeric_limits<double>::epsilon(), MatrixCompareType::relative));
-
-  // For this simple configuration, we can verify analytically that the
-  // effective (inverse of the) mass of each contact point is: sqrt(3)/3*(1/m1 +
-  // 1/m2), for the contact between particles masses m1 and m2. For the ground,
-  // we take the mass to be infinity.
-  const VectorXd masses = problem.GetParticleMasses();
-  const double Wdiag0 = std::sqrt(3) / 3 * (1.0 / masses(0) + 1.0 / masses(1));
-  const double Wdiag1 = std::sqrt(3) / 3 * (1.0 / masses(1) + 1.0 / masses(2));
-  const double Wdiag2 = std::sqrt(3) / 3 * (1.0 / masses(2));
-  const Vector3d Wdiag_expected(Wdiag0, Wdiag1, Wdiag2);
-  EXPECT_TRUE(CompareMatrices(data.delassus_diagonal, Wdiag_expected,
-                              std::numeric_limits<double>::epsilon(),
-                              MatrixCompareType::relative));
-  const VectorXd& k = problem_data->stiffness;
-  const VectorXd& c = problem_data->dissipation;
-  const double dt = problem_data->time_step;
-  const VectorXd taud = c.array() / k.array();
-  const VectorXd Rn_expected =
-      ((dt + taud.array()) * k.array() * dt).cwiseInverse();
-  const VectorXd Rt_expected = parameters.sigma * Wdiag_expected;
-  VectorXd R_expected(3 * problem.kNumContacts);
-  for (int i = 0; i < problem.kNumContacts; ++i) {
-    R_expected.segment<3>(3 * i) =
-        Vector3d(Rt_expected(i), Rt_expected(i), Rn_expected(i));
-  }
-  EXPECT_TRUE(CompareMatrices(data.R, R_expected,
-                              std::numeric_limits<double>::epsilon(),
-                              MatrixCompareType::relative));
-}
+constexpr double kEps = std::numeric_limits<double>::epsilon();
+// Suggested value for the dimensionless parameter used in the regularization of
+// friction, see [Castro et al. 2021].
+constexpr double kDefaultSigma = 1.0e-3;
 
 /* Model of a "pizza saver":
 
@@ -338,50 +152,47 @@ class PizzaSaverProblem {
     // clang-format on
   }
 
-  // Makes the problem data to advance the dynamics of the pizza saver from
+  // Makes contact problem to advance the dynamics of the pizza saver from
   // state x0 = [q0, v0], with applied forces tau = (fx, fy, fz, Mz).
-  std::unique_ptr<ProblemData> MakeProblemData(const VectorXd& q0,
-                                               const VectorXd& v0,
-                                               const VectorXd& tau) const {
-    // Set system dynamics data:
-    auto data = std::make_unique<ProblemData>(kNumVelocities, kNumContacts);
-    CalcMassMatrix(&data->M);
-    {
-      // A single block size.
-      BlockSparseMatrixBuilder<double> builder(1, 1, 1);
-      builder.PushBlock(0, 0, data->M);
-      data->Ablock = builder.Build();
-    }
-    data->Mop =
-        std::make_unique<BlockSparseLinearOperator<double>>("M", &data->Ablock);
+  // beta is the dimensionless near-rigid regime parameter and sigma the
+  // dimensionless parameter for the regularization of friction, see [Castro et
+  // al. 2021] for details.
+  std::unique_ptr<SapContactProblem<double>> MakeContactProblem(
+      const VectorXd& q0, const VectorXd& v0, const VectorXd& tau, double beta,
+      double sigma) const {
+    std::unique_ptr<SapContactProblem<double>> problem =
+        MakeContactProblemWithoutConstraints(q0, v0, tau);
 
-    data->v_star.resize(kNumVelocities);
-    data->v_star = v0 + time_step_ * data->M.ldlt().solve(tau);
+    // Add contact constraints.
+    const double phi0 = q0(2);
+    const SapFrictionConeConstraint<double>::Parameters parameters{
+        mu_, stiffness_, taud_, beta, 1.0e-3};
+    MatrixXd J;  // Full system Jacobian for the three contacts.
+    CalcContactJacobian(q0(3), &J);
+    problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<double>>(
+        0, J.middleRows(0, 3), phi0, parameters));
+    problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<double>>(
+        0, J.middleRows(3, 3), phi0, parameters));
+    problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<double>>(
+        0, J.middleRows(6, 3), phi0, parameters));
 
-    data->dynamics_data = std::make_unique<SystemDynamicsData<double>>(
-        data->Mop.get(), nullptr, &data->v_star);
+    return problem;
+  }
 
-    // Set contact data:
-    CalcContactJacobian(q0(3), &data->J);
-    {
-      // A single block size.
-      BlockSparseMatrixBuilder<double> builder(1, 1, 1);
-      builder.PushBlock(0, 0, data->J);
-      data->Jblock = builder.Build();
-    }
-    data->Jop =
-        std::make_unique<BlockSparseLinearOperator<double>>("J", &data->Jblock);
+  std::unique_ptr<SapContactProblem<double>>
+  MakeContactProblemWithoutConstraints(const VectorXd& q0, const VectorXd& v0,
+                                       const VectorXd& tau) const {
+    // For this problem there is a single clique for the pizza saver.
+    std::vector<MatrixXd> A(1);
+    CalcMassMatrix(&A[0]);
 
-    data->phi0.setConstant(kNumContacts, q0(2));
-    data->stiffness.setConstant(kNumContacts, stiffness_);
-    data->dissipation.setConstant(kNumContacts, taud_ * stiffness_);
-    data->mu.setConstant(kNumContacts, mu_);
+    // Compute free motion velocities.
+    VectorXd v_star = v0 + time_step_ * A[0].ldlt().solve(tau);
 
-    data->contact_data = std::make_unique<PointContactData<double>>(
-        &data->phi0, data->Jop.get(), &data->stiffness, &data->dissipation,
-        &data->mu);
+    auto problem = std::make_unique<SapContactProblem<double>>(
+        time_step_, std::move(A), std::move(v_star));
 
-    return data;
+    return problem;
   }
 
  private:
@@ -410,6 +221,7 @@ class PizzaSaverProblem {
 SapSolverResults<double> AdvanceNumSteps(const PizzaSaverProblem& problem,
                                          const VectorXd& tau, int num_steps,
                                          const SapSolverParameters& params,
+                                         double beta = 1.0,
                                          bool cost_criterion_reached = false) {
   SapSolver<double> sap;
   sap.set_parameters(params);
@@ -426,10 +238,10 @@ SapSolverResults<double> AdvanceNumSteps(const PizzaSaverProblem& problem,
   VectorXd v = VectorXd::Zero(problem.kNumVelocities);
 
   for (int i = 0; i < num_steps; ++i) {
-    const auto data = problem.MakeProblemData(q, v, tau);
+    const auto contact_problem =
+        problem.MakeContactProblem(q, v, tau, beta, kDefaultSigma);
     const SapSolverStatus status =
-        sap.SolveWithGuess(problem.time_step(), *data->dynamics_data,
-                           *data->contact_data, v_guess, &result);
+        sap.SolveWithGuess(*contact_problem, v_guess, &result);
     EXPECT_EQ(status, SapSolverStatus::kSuccess);
     v = result.v;
     q += problem.time_step() * v;
@@ -442,22 +254,6 @@ SapSolverResults<double> AdvanceNumSteps(const PizzaSaverProblem& problem,
     } else {
       EXPECT_TRUE(stats.optimality_criterion_reached);
     }
-
-    // N.B. We only count iterations that perform factorizations. Since impulses
-    // need to be computed in order to evaluate the termination criteria (before
-    // a factorization might be carried out), the expected number of gradients
-    // update equals the number of iterations plus one.
-    EXPECT_EQ(stats.num_gradients_cache_updates, stats.num_iters + 1);
-
-    // Impulses are evaluated:
-    //  - At the very beginning of an iteration, to evaluate stopping criteria
-    //    (num_iters+1 since the last iteration does not perform factorization.)
-    //  - At the very beginning of line search iterations, i.e. num_iters.
-    //  - Once per line search iteration.
-    //    Therefore we expect impulses to be evaluated
-    //    num_line_search_iters+2*num_iters+1 times.
-    EXPECT_EQ(stats.num_impulses_cache_updates,
-              stats.num_line_search_iters + 2 * stats.num_iters + 1);
   }
 
   return result;
@@ -474,12 +270,12 @@ GTEST_TEST(PizzaSaver, NoAppliedTorque) {
 
   SapSolverParameters params;
   params.rel_tolerance = 1.0e-6;
-  params.beta = 0;  // No near-rigid regime.
   params.ls_max_iterations = 40;
+  const double beta = kEps;  // No near-rigid regime.
 
   const Vector4d tau(0.0, 0.0, -problem.mass() * problem.g(), 0.0);
   const SapSolverResults<double> result =
-      AdvanceNumSteps(problem, tau, 30, params);
+      AdvanceNumSteps(problem, tau, 30, params, beta);
 
   // N.B. The accuracy of the solutions is significantly higher when using exact
   // line search.
@@ -515,9 +311,9 @@ GTEST_TEST(PizzaSaver, ConvergenceWithExactGuess) {
 
   SapSolverParameters params;
   params.rel_tolerance = 1.0e-6;
-  params.beta = 0;  // No near-rigid regime.
   params.ls_max_iterations = 40;
   params.max_iterations = 0;
+  const double beta = kEps;  // No near-rigid regime.
 
   const double weight = problem.mass() * problem.g();
   const Vector4d tau(0.0, 0.0, -weight, 0.0);
@@ -529,13 +325,13 @@ GTEST_TEST(PizzaSaver, ConvergenceWithExactGuess) {
   VectorXd q = Vector4d(0.0, 0.0, z, theta);
   VectorXd v = VectorXd::Zero(problem.kNumVelocities);
 
-  const auto data = problem.MakeProblemData(q, v, tau);
+  const auto contact_problem =
+      problem.MakeContactProblem(q, v, tau, beta, kDefaultSigma);
   SapSolver<double> sap;
   sap.set_parameters(params);
   SapSolverResults<double> result;
   const SapSolverStatus status =
-      sap.SolveWithGuess(problem.time_step(), *data->dynamics_data,
-                         *data->contact_data, v, &result);
+      sap.SolveWithGuess(*contact_problem, v, &result);
   EXPECT_EQ(status, SapSolverStatus::kSuccess);
 
   // Verify no iterations were performed.
@@ -570,8 +366,9 @@ void VerifyStictionSolution(const SapSolverParameters& params,
 
   const double Mz = 20.0;
   const Vector4d tau(0.0, 0.0, -problem.mass() * problem.g(), Mz);
+  const double beta = 1.0;  // Enable near-rigid regime.
   const SapSolverResults<double> result =
-      AdvanceNumSteps(problem, tau, 40, params, cost_criterion_reached);
+      AdvanceNumSteps(problem, tau, 40, params, beta, cost_criterion_reached);
 
   // Expected generalized impulse.
   const Vector4d j_expected =
@@ -580,7 +377,7 @@ void VerifyStictionSolution(const SapSolverParameters& params,
 
   // Maximum expected slip. See Castro et al. 2021 for details (Eq. 22).
   const double max_slip_expected =
-      params.sigma * problem.time_step() * problem.g();
+      kDefaultSigma * problem.time_step() * problem.g();
 
   EXPECT_TRUE(CompareMatrices(result.v.head<3>(), Vector3d::Zero(), 1.0e-10));
   EXPECT_TRUE((result.j - j_expected).norm() / j_expected.norm() <
@@ -619,7 +416,6 @@ GTEST_TEST(PizzaSaver, Stiction) {
   SapSolverParameters params;
   params.abs_tolerance = 1.0e-14;
   params.rel_tolerance = 1.0e-6;
-  params.beta = 0;  // No near-rigid regime.
   params.ls_max_iterations = 40;
   // For the tolerances specified, we expect the solver to reach the optimality
   // condition for all time steps.
@@ -645,7 +441,6 @@ GTEST_TEST(PizzaSaver, StictionAtTightOptimalityTolerance) {
   // Extremely tight tolerances to trigger the cost stopping criterion.
   params.abs_tolerance = 1.0e-20;
   params.rel_tolerance = 1.0e-20;
-  params.beta = 0;  // No near-rigid regime.
   params.ls_max_iterations = 40;
   // Inform the unit test we want to verify this condition.
   const bool cost_criterion_reached = true;
@@ -665,13 +460,13 @@ GTEST_TEST(PizzaSaver, NoFriction) {
 
   SapSolverParameters params;
   params.rel_tolerance = 1.0e-6;
-  params.beta = 0;  // No near-rigid regime.
   params.ls_max_iterations = 40;
+  const double beta = kEps;  // No near-rigid regime.
 
   const double fx = 1.0;
   const Vector4d tau(fx, 0.0, -problem.mass() * problem.g(), 0.0);
   const SapSolverResults<double> result =
-      AdvanceNumSteps(problem, tau, num_steps, params);
+      AdvanceNumSteps(problem, tau, num_steps, params, beta);
 
   // Expected generalized impulse.
   const Vector4d j_expected(0.0, 0.0, dt * problem.mass() * problem.g(), 0.0);
@@ -710,15 +505,15 @@ GTEST_TEST(PizzaSaver, Sliding) {
 
   SapSolverParameters params;
   params.rel_tolerance = 1.0e-6;
-  params.beta = 0;  // No near-rigid regime.
   params.ls_max_iterations = 40;
+  const double beta = kEps;  // No near-rigid regime.
 
   const double Mz = 40.0;
   const double weight = problem.mass() * problem.g();
   const Vector4d tau(0.0, 0.0, -weight, Mz);
 
   const SapSolverResults<double> result =
-      AdvanceNumSteps(problem, tau, 10, params);
+      AdvanceNumSteps(problem, tau, 10, params, beta);
 
   EXPECT_GT(result.v(3), 0.0);  // It's accelerating.
   for (int i = 0; i < 3; ++i) {
@@ -758,23 +553,23 @@ GTEST_TEST(PizzaSaver, NearRigidStiction) {
 
   // We first verify that if we don't use the near-rigid regime strategy the
   // solver fails to converge.
-  params.beta = 0.0;  // near-rigid regime disabled.
-  EXPECT_THROW(AdvanceNumSteps(problem, tau, 30, params), std::exception);
+  double beta = kEps;  // No near-rigid regime.
+  EXPECT_THROW(AdvanceNumSteps(problem, tau, 30, params, beta), std::exception);
 
   // We try again the same problem but with with near-rigid transition enabled.
   // N.B. AdvanceNumSteps() creates a new SAP solver every time. Therefore it is
   // impossible that results from the previous computation affect this new
   // computation.
-  params.beta = 1.0;  // Enable near-rigid regime with default value of beta.
+  beta = 1.0;  // Enable near-rigid regime with default value of beta.
   const SapSolverResults<double> result =
-      AdvanceNumSteps(problem, tau, 30, params);
+      AdvanceNumSteps(problem, tau, 30, params, beta);
 
   // Expected generalized force.
   const Vector4d j_expected(0.0, 0.0, dt * problem.mass() * problem.g(),
-                             -dt * Mz);
+                            -dt * Mz);
 
   // Maximum expected slip. See Castro et al. 2021 for details (Eq. 22).
-  const double max_slip_expected = params.sigma * dt * problem.g();
+  const double max_slip_expected = kDefaultSigma * dt * problem.g();
 
   EXPECT_TRUE(CompareMatrices(result.v.head<3>(), Vector3d::Zero(), 1.0e-9));
   EXPECT_TRUE((result.j - j_expected).norm() / j_expected.norm() <
@@ -801,6 +596,39 @@ GTEST_TEST(PizzaSaver, NearRigidStiction) {
                 params.rel_tolerance * friction_impulse_expected);
     EXPECT_LE(slip, max_slip_expected);
   }
+}
+
+GTEST_TEST(PizzaSaver, NoConstraints) {
+  const double dt = 0.01;
+  const double mu = NAN;    // not used in this problem.
+  const double k = NAN;     // not used in this problem.
+  const double taud = NAN;  // not used in this problem.
+  const PizzaSaverProblem problem(dt, mu, k, taud);
+
+  const double weight = problem.mass() * problem.g();
+  const Vector4d tau(0.0, 0.0, -weight, 0.0);
+
+  const double theta = M_PI / 5;  // Arbitrary orientation.
+  VectorXd q = Vector4d(0.0, 0.0, 0.0, theta);
+  VectorXd v = VectorXd::Zero(problem.kNumVelocities);
+
+  const auto contact_problem =
+      problem.MakeContactProblemWithoutConstraints(q, v, tau);
+  SapSolver<double> sap;
+  SapSolverResults<double> result;
+  const SapSolverStatus status =
+      sap.SolveWithGuess(*contact_problem, v, &result);
+  EXPECT_EQ(status, SapSolverStatus::kSuccess);
+
+  // Verify no iterations were performed.
+  const SapSolver<double>::SolverStats& stats = sap.get_statistics();
+  EXPECT_EQ(stats.num_iters, 0);
+
+  // The solution is trivial since constraint impulses are zero and v = v*.
+  EXPECT_EQ(result.v, contact_problem->v_star());
+  EXPECT_EQ(result.j, VectorXd::Zero(contact_problem->num_velocities()));
+  EXPECT_EQ(result.gamma.size(), 0);
+  EXPECT_EQ(result.vc.size(), 0);
 }
 
 }  // namespace internal


### PR DESCRIPTION
This PR updates the internal workings of `SapSolver` to use the better unit tested `SapModel`.

Things to note:
 1. We do not unit test for pre-processed data anymore. PreProcessedData is effectively replaced by SapModel, which is much better tested elsewhere.
 2. We do not unit test for number of evaluations, since SapModel now uses the `systems::` framework caching, which is also much better tested elsewhere.
 3. This PR is mostly a refactor, and removes more code than what it adds new!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16930)
<!-- Reviewable:end -->
