### PR TITLE
Add clang-12 on Focal, macOS

### DIFF
--- a/setup/mac/source_distribution/Brewfile
+++ b/setup/mac/source_distribution/Brewfile
@@ -5,3 +5,4 @@ tap 'robotlocomotion/director'
 
 brew 'bazel'
 brew 'robotlocomotion/director/clang-format@9'
+brew 'robotlocomotion/director/clang-format@12'

--- a/setup/ubuntu/source_distribution/packages-focal-clang.txt
+++ b/setup/ubuntu/source_distribution/packages-focal-clang.txt
@@ -1,2 +1,3 @@
 clang-9
-libomp-9-dev
+clang-12
+libomp-12-dev

--- a/setup/ubuntu/source_distribution/packages-focal-test-only.txt
+++ b/setup/ubuntu/source_distribution/packages-focal-test-only.txt
@@ -2,6 +2,7 @@ curl
 kcov
 libstdc++6-10-dbg
 llvm-9
+llvm-12
 python3-dateutil
 python3-dbg
 python3-flask

--- a/setup/ubuntu/source_distribution/packages-focal.txt
+++ b/setup/ubuntu/source_distribution/packages-focal.txt
@@ -1,4 +1,5 @@
 clang-format-9
+clang-format-12
 coinor-libclp-dev
 coinor-libcoinutils-dev
 coinor-libipopt-dev
@@ -9,6 +10,7 @@ git
 libblas-dev
 libbz2-dev
 libclang-9-dev
+libclang-12-dev
 libdouble-conversion-dev
 libexpat1-dev
 libgflags-dev


### PR DESCRIPTION
Modify setup scripts to also install clang-12. Ultimately, we want to get rid of clang-9, but this will allow us to switch CI builds to 12 without needing to lock-step changes in the main repo and CI.

+@jwnimmer-tri for feature review, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16943)
<!-- Reviewable:end -->
