### PR TITLE
[workspace] Remove bionic doxygen build.

### DIFF
--- a/doc/_pages/documentation_instructions.md
+++ b/doc/_pages/documentation_instructions.md
@@ -16,7 +16,7 @@ The website infrastructure uses a combination of
 # Prerequisites
 
 Documentation generation and preview as described in this document are
-supported on **Ubuntu only**.
+supported on Ubuntu **20.04** only.
 
 Before getting started, install Drake's prerequisites with the additional
 ``--with-doc-only`` command line option, i.e.:

--- a/tools/workspace/doxygen/Dockerfile
+++ b/tools/workspace/doxygen/Dockerfile
@@ -3,7 +3,7 @@
 # during the build. They are neither called during the build nor expected to be
 # called by most developers or users of the project.
 
-ARG UBUNTU_CODENAME=bionic
+ARG UBUNTU_CODENAME=focal
 FROM ubuntu:${UBUNTU_CODENAME}
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update --quiet --quiet \

--- a/tools/workspace/doxygen/build_binaries_with_docker
+++ b/tools/workspace/doxygen/build_binaries_with_docker
@@ -9,18 +9,10 @@ set -euxo pipefail
 
 rm -f doxygen-*-*-x86_64.tar.gz doxygen-*-x86_64.tar.gz.sha256
 
-docker build --build-arg UBUNTU_CODENAME=bionic --tag doxygen-bionic "${BASH_SOURCE%/*}"
-trap 'docker rmi doxygen-bionic' EXIT
-docker run --detach --name doxygen-bionic-build --tty doxygen-bionic
-trap 'docker rm -f doxygen-bionic-build && docker rmi doxygen-bionic' EXIT
-docker cp doxygen-bionic-build:$(docker exec doxygen-bionic-build find /opt/doxygen/bin/ -maxdepth 1 -name 'doxygen-*-bionic-x86_64.tar.gz') .
-
-shasum --algorithm 256 doxygen-*-bionic-x86_64.tar.gz | tee doxygen-bionic-x86_64.tar.gz.sha256
-
 docker build --build-arg UBUNTU_CODENAME=focal --tag doxygen-focal "${BASH_SOURCE%/*}"
-trap 'docker rm -f doxygen-bionic-build && docker rmi doxygen-bionic doxygen-focal' EXIT
+trap 'docker rmi doxygen-focal' EXIT
 docker run --detach --name doxygen-focal-build --tty doxygen-focal
-trap 'docker rm -f doxygen-bionic-build doxygen-focal-build && docker rmi doxygen-bionic doxygen-focal' EXIT
+trap 'docker rm -f doxygen-focal-build && docker rmi doxygen-focal' EXIT
 docker cp doxygen-focal-build:$(docker exec doxygen-focal-build find /opt/doxygen/bin/ -maxdepth 1 -name 'doxygen-*-focal-x86_64.tar.gz') .
 
 shasum --algorithm 256 doxygen-*-focal-x86_64.tar.gz | tee doxygen-focal-x86_64.tar.gz.sha256

--- a/tools/workspace/doxygen/repository.bzl
+++ b/tools/workspace/doxygen/repository.bzl
@@ -17,33 +17,23 @@ def _impl(repo_ctx):
         "BUILD.bazel",
     )
 
-    if os_result.is_macos:
-        # On macOS, documentation builds are not supported, so just provide a
-        # dummy binary.
-        repo_ctx.file("doxygen", "# Doxygen is not supported on macOS")
-    elif os_result.is_ubuntu:
-        # On Ubuntu, download and extract Drake's pre-compiled Doxygen binary.
-        archive = "doxygen-1.8.15-{codename}-x86_64.tar.gz".format(
-            codename = {
-                "18.04": "bionic",
-                "20.04": "focal",
-            }[os_result.ubuntu_release],
-        )
+    if os_result.ubuntu_release == "20.04":
+        # Download and extract Drake's pre-compiled Doxygen binary.
+        archive = "doxygen-1.8.15-focal-x86_64.tar.gz"
         url = [
             pattern.format(archive = archive)
             for pattern in repo_ctx.attr.mirrors.get("doxygen")
         ]
-        sha256 = {
-            "18.04": "16b4ce1fcee27495c0de23dc4a2ab9bd24ee218800a2fb0db17a9c5bf8955e4e",  # noqa
-            "20.04": "3c4886763ec27e1797b0fd5bfe576602f5e408649c0e282936e17bde5c7ed7e6",  # noqa
-        }[os_result.ubuntu_release]
+        sha256 = "3c4886763ec27e1797b0fd5bfe576602f5e408649c0e282936e17bde5c7ed7e6"  # noqa
         repo_ctx.download_and_extract(
             url = url,
             sha256 = sha256,
             type = "tar.gz",
         )
     else:
-        fail("Operating system is NOT supported {}".format(os_result))
+        # On other platforms, documentation builds are not supported, so just
+        # provide a dummy binary.
+        repo_ctx.file("doxygen", "# Doxygen is not supported on this platform")
 
 doxygen_repository = repository_rule(
     attrs = {


### PR DESCRIPTION
Relates: #13391.

After running `./build_binaries_with_docker` the archives extract with a usable `doxygen` executable in a vanilla container:

```console
$ docker run --rm -it --volume "$(pwd):/data" ubuntu:focal               
root@e9fac7783533:/# tar -xf /data/doxygen-1.8.15-focal-x86_64.tar.gz              
root@e9fac7783533:/# ./doxygen --version
1.8.15

$ docker run --rm -it --volume "$(pwd):/data" ubuntu:jammy
root@c501096c7073:/# tar -xf /data/doxygen-1.8.15-jammy-x86_64.tar.gz 
root@c501096c7073:/# ./doxygen --version
1.8.15
```

Note: it may be advantageous to update to a new doxygen version at the same time that we add in jammy support.  Depending on #14670 and how quickly concepts become available in drake, it is advisable to target at least doxygen 1.9.2 (adds support for concepts).  Currently jammy is shipping with 1.9.1 but that may change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16946)
<!-- Reviewable:end -->
