### PR TITLE
[setup] Add xvfb init script for deepnote

### DIFF
--- a/setup/BUILD.bazel
+++ b/setup/BUILD.bazel
@@ -44,7 +44,9 @@ install_files(
         ],
         "//tools/cc_toolchain:linux": [
             "deepnote/install_nginx",
+            "deepnote/install_xvfb",
             "deepnote/nginx-meshcat-proxy.conf",
+            "deepnote/xvfb",
             "ubuntu/binary_distribution/install_prereqs.sh",
             "ubuntu/binary_distribution/packages-focal.txt",
         ],

--- a/setup/deepnote/README.md
+++ b/setup/deepnote/README.md
@@ -1,6 +1,9 @@
-These files are used by pydrake.geometry.SetupMeshcat() to configure a
-Deepnote notebook to allow for MeshCat traffic to flow.  Refer to the
-implementation in bindings/pydrake/_geometry_extra.py for details.
+The nginx-related files are used by pydrake.geometry.SetupMeshcat() to
+configure a Deepnote notebook to allow for MeshCat traffic to flow.  Refer
+to the implementation in bindings/pydrake/_geometry_extra.py for details.
+
+The xvfb-related files are used to launch an X display suitable for Drake's
+image rendering simulations.
 
 Even though these files are used on Ubuntu- or Debian-based systems,
 we don't place them under drake/setup/ubuntu/... because they are not

--- a/setup/deepnote/install_xvfb
+++ b/setup/deepnote/install_xvfb
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Installs and runs Xvfb as an Ubuntu system daemon at DISPLAY=:1.
+#
+# This is intended for use only on Deepnote, to allow VTK and GL rendering.
+
+set -euo pipefail
+
+# Install Xvfb.
+if [[ $(dpkg-query -W -f'${db:Status-Abbrev}' xvfb) != "ii " ]]; then
+  apt-get update
+  apt-get install -y --no-install-recommends xvfb
+fi
+
+# Run it as a service.
+ln -sf /opt/drake/share/drake/setup/deepnote/xvfb /etc/init.d/
+service xvfb start

--- a/setup/deepnote/xvfb
+++ b/setup/deepnote/xvfb
@@ -1,0 +1,35 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides: Xvfb
+# Required-Start: $local_fs $remote_fs
+# Required-Stop:
+# X-Start-Before:
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+# Short-Description: Loads X Virtual Frame Buffer
+### END INIT INFO
+
+XVFB=/usr/bin/Xvfb
+XVFBARGS=":1 -screen 0 1024x768x24 -ac +extension GLX +extension RANDR +render -noreset"
+PIDFILE=/var/run/xvfb.pid
+case "$1" in
+  start)
+    echo -n "Starting virtual X frame buffer: Xvfb"
+    start-stop-daemon --start --quiet --pidfile $PIDFILE --make-pidfile --background --exec $XVFB -- $XVFBARGS
+    echo "."
+    ;;
+  stop)
+    echo -n "Stopping virtual X frame buffer: Xvfb"
+    start-stop-daemon --stop --quiet --pidfile $PIDFILE
+    echo "."
+    ;;
+  restart)
+    $0 stop
+    $0 start
+    ;;
+  *)
+    echo "Usage: /etc/init.d/xvfb {start|stop|restart}"
+    exit 1
+esac
+
+exit 0

--- a/tools/install/bazel/generate_installed_files_manifest.bzl
+++ b/tools/install/bazel/generate_installed_files_manifest.bzl
@@ -17,7 +17,9 @@ def _impl(ctx):
         # These are installed in share/drake and are runfiles for certain
         # targets, but none of those targets are relevant for this use case.
         "setup/deepnote/install_nginx",
+        "setup/deepnote/install_xvfb",
         "setup/deepnote/nginx-meshcat-proxy.conf",
+        "setup/deepnote/xvfb",
     ]
     known_non_runfiles_basenames = [
         "LICENSE",


### PR DESCRIPTION
Towards #16866.

Based on a mix of https://gist.github.com/dloman/8303932 and https://github.com/RobotLocomotion/drake-ci/blob/49c6ccb2955a3a8fa6a68dcce26405eb54fdc898/setup/ubuntu/install_prereqs#L79-L88

One this is available in a nightly docker image, in order for the tutorial to work, we'll need to somehow shell out to `install_xvfb` prior to doing any rendering.  My best guess for now is that `init.ipynb` should do that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16948)
<!-- Reviewable:end -->
