### PR TITLE
[parsing] Warn about unsupported URDF features

### DIFF
--- a/examples/atlas/urdf/atlas_convex_hull.urdf
+++ b/examples/atlas/urdf/atlas_convex_hull.urdf
@@ -627,7 +627,6 @@
     <child link="utorso"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="300" lower="-0.523599" upper="0.523599" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10.5236" soft_upper_limit="10.5236"/>
   </joint>
   <joint name="back_bky" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0.162"/>
@@ -636,7 +635,6 @@
     <child link="mtorso"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="445" lower="-0.219388" upper="0.538783" velocity="9"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10.2194" soft_upper_limit="10.5388"/>
   </joint>
   <joint name="back_bkz" type="revolute">
     <origin rpy="0 0 0" xyz="-0.0125 0 0"/>
@@ -645,7 +643,6 @@
     <child link="ltorso"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="106" lower="-0.663225" upper="0.663225" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10.6632" soft_upper_limit="10.6632"/>
   </joint>
   <joint name="l_arm_elx" type="revolute">
     <origin rpy="0 0 0" xyz="0 -0.119 0.0092"/>
@@ -654,7 +651,6 @@
     <child link="l_larm"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="112" lower="0" upper="2.35619" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10" soft_upper_limit="12.3562"/>
   </joint>
   <joint name="l_arm_ely" type="revolute">
     <origin rpy="0 0 0" xyz="0 -0.187 -0.016"/>
@@ -663,7 +659,6 @@
     <child link="l_uarm"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="63" lower="0" upper="3.14159" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10" soft_upper_limit="13.1416"/>
   </joint>
   <joint name="l_arm_shx" type="revolute">
     <origin rpy="0 0 0" xyz="0 -0.11 -0.245"/>
@@ -672,7 +667,6 @@
     <child link="l_scap"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="99" lower="-1.5708" upper="1.5708" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-11.5708" soft_upper_limit="11.5708"/>
   </joint>
   <joint name="l_arm_shz" type="revolute">
     <origin rpy="0 0 3.14159265359" xyz="0.1406 0.2256 0.4776"/>
@@ -681,7 +675,6 @@
     <child link="l_clav"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="87" lower="-1.5708" upper="0.785398" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-11.5708" soft_upper_limit="10.7854"/>
   </joint>
   <joint name="l_arm_mwx" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -690,7 +683,6 @@
     <child link="l_lfarm"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="25" lower="-1.7628" upper="1.7628" velocity="10"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-11.7628" soft_upper_limit="11.7628"/>
   </joint>
   <joint name="l_arm_uwy" type="revolute">
     <origin rpy="0 3.14159265359 0" xyz="0 -0.29955 -0.00921"/>
@@ -699,7 +691,6 @@
     <child link="l_ufarm"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="25" lower="-3.011" upper="3.011" velocity="10"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-13.011" soft_upper_limit="13.011"/>
   </joint>
   <joint name="l_arm_lwy" type="revolute">
     <origin rpy="0 3.14159265359 0" xyz="0 0 0"/>
@@ -708,7 +699,6 @@
     <child link="l_hand"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="25" lower="-2.9671" upper="2.9671" velocity="10"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-12.9671" soft_upper_limit="12.9671"/>
   </joint>
   <joint name="l_leg_akx" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -717,7 +707,6 @@
     <child link="l_foot"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="360" lower="-0.8" upper="0.8" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10.8" soft_upper_limit="10.8"/>
   </joint>
   <joint name="l_leg_aky" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 -0.422"/>
@@ -726,7 +715,6 @@
     <child link="l_talus"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="740" lower="-1" upper="0.7" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-11" soft_upper_limit="10.7"/>
   </joint>
   <joint name="l_leg_hpx" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -735,7 +723,6 @@
     <child link="l_lglut"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="530" lower="-0.523599" upper="0.523599" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10.5236" soft_upper_limit="10.5236"/>
   </joint>
   <joint name="l_leg_hpy" type="revolute">
     <origin rpy="0 0 0" xyz="0.05 0.0225 -0.066"/>
@@ -744,7 +731,6 @@
     <child link="l_uleg"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="840" lower="-1.61234" upper="0.65764" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-11.6123" soft_upper_limit="10.6576"/>
   </joint>
   <joint name="l_leg_hpz" type="revolute">
     <origin rpy="0 0 0" xyz="0 0.089 0"/>
@@ -753,7 +739,6 @@
     <child link="l_uglut"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="275" lower="-0.174358" upper="0.786794" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10.1744" soft_upper_limit="10.7868"/>
   </joint>
   <joint name="l_leg_kny" type="revolute">
     <origin rpy="0 0 0" xyz="-0.05 0 -0.374"/>
@@ -762,7 +747,6 @@
     <child link="l_lleg"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="890" lower="0" upper="2.35637" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10" soft_upper_limit="12.3564"/>
   </joint>
   <joint name="neck_ay" type="revolute">
     <origin rpy="0 0 0" xyz="0.2546 0 0.6215"/>
@@ -771,7 +755,6 @@
     <child link="head"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="25" lower="-0.602139" upper="1.14319" velocity="6.28"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10.6021" soft_upper_limit="11.1432"/>
   </joint>
   <joint name="r_arm_elx" type="revolute">
     <origin rpy="0 0 0" xyz="0 -0.119 0.0092"/>
@@ -780,7 +763,6 @@
     <child link="r_larm"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="112" lower="-2.35619" upper="0" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-12.3562" soft_upper_limit="10"/>
   </joint>
   <joint name="r_arm_ely" type="revolute">
     <origin rpy="0 0 0" xyz="0 -0.187 -0.016"/>
@@ -789,7 +771,6 @@
     <child link="r_uarm"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="63" lower="0" upper="3.14159" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10" soft_upper_limit="13.1416"/>
   </joint>
   <joint name="r_arm_shx" type="revolute">
     <origin rpy="0 0 0" xyz="0 -0.11 -0.245"/>
@@ -798,7 +779,6 @@
     <child link="r_scap"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="99" lower="-1.5708" upper="1.5708" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-11.5708" soft_upper_limit="11.5708"/>
   </joint>
   <joint name="r_arm_shz" type="revolute">
     <origin rpy="0 0 0" xyz="0.1406 -0.2256 0.4776"/>
@@ -807,7 +787,6 @@
     <child link="r_clav"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="87" lower="-0.785398" upper="1.5708" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10.7854" soft_upper_limit="11.5708"/>
   </joint>
   <joint name="r_arm_mwx" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -816,7 +795,6 @@
     <child link="r_lfarm"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="25" lower="-1.7628" upper="1.7628" velocity="10"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-11.7628" soft_upper_limit="11.7628"/>
   </joint>
   <joint name="r_arm_uwy" type="revolute">
     <origin rpy="0 0 0" xyz="0 -0.29955 -0.00921"/>
@@ -825,7 +803,6 @@
     <child link="r_ufarm"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="25" lower="-3.011" upper="3.011" velocity="10"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-13.011" soft_upper_limit="13.011"/>
   </joint>
   <joint name="r_arm_lwy" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -834,7 +811,6 @@
     <child link="r_hand"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="25" lower="-2.9671" upper="2.9671" velocity="10"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-12.9671" soft_upper_limit="12.9671"/>
   </joint>
   <joint name="r_leg_akx" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -843,7 +819,6 @@
     <child link="r_foot"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="360" lower="-0.8" upper="0.8" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10.8" soft_upper_limit="10.8"/>
   </joint>
   <joint name="r_leg_aky" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 -0.422"/>
@@ -852,7 +827,6 @@
     <child link="r_talus"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="740" lower="-1" upper="0.7" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-11" soft_upper_limit="10.7"/>
   </joint>
   <joint name="r_leg_hpx" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -861,7 +835,6 @@
     <child link="r_lglut"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="530" lower="-0.523599" upper="0.523599" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10.5236" soft_upper_limit="10.5236"/>
   </joint>
   <joint name="r_leg_hpy" type="revolute">
     <origin rpy="0 0 0" xyz="0.05 -0.0225 -0.066"/>
@@ -870,7 +843,6 @@
     <child link="r_uleg"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="840" lower="-1.61234" upper="0.65764" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-11.6123" soft_upper_limit="10.6576"/>
   </joint>
   <joint name="r_leg_hpz" type="revolute">
     <origin rpy="0 0 0" xyz="0 -0.089 0"/>
@@ -879,7 +851,6 @@
     <child link="r_uglut"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="275" lower="-0.786794" upper="0.174358" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10.7868" soft_upper_limit="10.1744"/>
   </joint>
   <joint name="r_leg_kny" type="revolute">
     <origin rpy="0 0 0" xyz="-0.05 0 -0.374"/>
@@ -888,7 +859,6 @@
     <child link="r_lleg"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="890" lower="0" upper="2.35637" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10" soft_upper_limit="12.3564"/>
   </joint>
   <link name="r_situational_awareness_camera_link">
     <inertial>

--- a/examples/pr2/BUILD.bazel
+++ b/examples/pr2/BUILD.bazel
@@ -43,7 +43,9 @@ drake_cc_googletest(
 )
 
 install_data(
-    extra_prod_models = _OBJS,
+    extra_prod_models = _OBJS + [
+        "README.md",
+    ],
 )
 
 add_lint_tests()

--- a/examples/pr2/README.md
+++ b/examples/pr2/README.md
@@ -6,6 +6,10 @@ y, and theta, respectively), instead of wheels. The description also contains
 fully actuated finger joints, instead of a single prismatic joint that closes
 and opens finger joints that mimic each other.
 
+In addition, some tags unsupported by Drake have been removed, to reduce the
+burden of warning output. For URDF support details, see:
+https://drake.mit.edu/doxygen_cxx/group__multibody__parsing.html
+
 [1] To view or use the C++ passive simulation of a PR2 based on RigidBodyTree
 (removed as of 2020), you may use this commit:
 

--- a/examples/pr2/models/pr2_description/urdf/pr2_simplified.urdf
+++ b/examples/pr2/models/pr2_description/urdf/pr2_simplified.urdf
@@ -131,17 +131,14 @@
   <transmission name="x_transmission" type="SimpleTransmission">
     <actuator name="x_motor"/>
     <joint name="x"/>
-    <mechanicalReduction>-70000.0</mechanicalReduction>
   </transmission>
   <transmission name="y_transmission" type="SimpleTransmission">
     <actuator name="y_motor"/>
     <joint name="y"/>
-    <mechanicalReduction>-70000.0</mechanicalReduction>
   </transmission>
   <transmission name="theta_transmission" type="SimpleTransmission">
     <actuator name="theta_motor"/>
     <joint name="theta"/>
-    <mechanicalReduction>-70000.0</mechanicalReduction>
   </transmission>
   <link name="base_link">
     <inertial>
@@ -196,7 +193,7 @@
     <parent link="base_link"/>
     <child link="base_laser_link"/>
   </joint>
-  <link name="base_laser_link" type="laser">
+  <link name="base_laser_link">
     <inertial>
       <mass value="0.001"/>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -243,8 +240,6 @@
     <axis xyz="0 0 1"/>
     <limit effort="100" velocity="100"/>
     <!-- alpha tested velocity and effort limits -->
-    <safety_controller k_velocity="10"/>
-    <calibration reference_position="-0.785398163397" rising="-0.785398163397"/>
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
     <dynamics damping="0.0" friction="0.0"/>
     <origin rpy="0 0 0" xyz="0.2246 0.2246 0.0282"/>
@@ -274,13 +269,11 @@
   <transmission name="fl_caster_rotation_trans" type="SimpleTransmission">
     <actuator name="fl_caster_rotation_motor"/>
     <joint name="fl_caster_rotation_joint"/>
-    <mechanicalReduction>-79.2380952381</mechanicalReduction>
   </transmission>
   <joint name="fl_caster_l_wheel_joint" type="fixed">
     <axis xyz="0 1 0"/>
     <limit effort="100" velocity="100"/>
     <!-- alpha tested effort and velocity limits -->
-    <safety_controller k_velocity="10"/>
     <dynamics damping="0.0" friction="0.0"/>
     <origin rpy="0 0 0" xyz="0 0.049 0"/>
     <parent link="fl_caster_rotation_link"/>
@@ -317,13 +310,11 @@
   <transmission name="fl_caster_l_wheel_trans" type="SimpleTransmission">
     <actuator name="fl_caster_l_wheel_motor"/>
     <joint name="fl_caster_l_wheel_joint"/>
-    <mechanicalReduction>79.2380952381</mechanicalReduction>
   </transmission>
   <joint name="fl_caster_r_wheel_joint" type="fixed">
     <axis xyz="0 1 0"/>
     <limit effort="100" velocity="100"/>
     <!-- alpha tested effort and velocity limits -->
-    <safety_controller k_velocity="10"/>
     <dynamics damping="0.0" friction="0.0"/>
     <origin rpy="0 0 0" xyz="0 -0.049 0"/>
     <parent link="fl_caster_rotation_link"/>
@@ -360,7 +351,6 @@
   <transmission name="fl_caster_r_wheel_trans" type="SimpleTransmission">
     <actuator name="fl_caster_r_wheel_motor"/>
     <joint name="fl_caster_r_wheel_joint"/>
-    <mechanicalReduction>-79.2380952381</mechanicalReduction>
   </transmission>
   <gazebo reference="fl_caster_rotation_link">
     <material value="PR2/caster_texture"/>
@@ -369,8 +359,6 @@
     <axis xyz="0 0 1"/>
     <limit effort="100" velocity="100"/>
     <!-- alpha tested velocity and effort limits -->
-    <safety_controller k_velocity="10"/>
-    <calibration reference_position="-0.785398163397" rising="-0.785398163397"/>
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
     <dynamics damping="0.0" friction="0.0"/>
     <origin rpy="0 0 0" xyz="0.2246 -0.2246 0.0282"/>
@@ -400,13 +388,11 @@
   <transmission name="fr_caster_rotation_trans" type="SimpleTransmission">
     <actuator name="fr_caster_rotation_motor"/>
     <joint name="fr_caster_rotation_joint"/>
-    <mechanicalReduction>-79.2380952381</mechanicalReduction>
   </transmission>
   <joint name="fr_caster_l_wheel_joint" type="fixed">
     <axis xyz="0 1 0"/>
     <limit effort="100" velocity="100"/>
     <!-- alpha tested effort and velocity limits -->
-    <safety_controller k_velocity="10"/>
     <dynamics damping="0.0" friction="0.0"/>
     <origin rpy="0 0 0" xyz="0 0.049 0"/>
     <parent link="fr_caster_rotation_link"/>
@@ -443,13 +429,11 @@
   <transmission name="fr_caster_l_wheel_trans" type="SimpleTransmission">
     <actuator name="fr_caster_l_wheel_motor"/>
     <joint name="fr_caster_l_wheel_joint"/>
-    <mechanicalReduction>79.2380952381</mechanicalReduction>
   </transmission>
   <joint name="fr_caster_r_wheel_joint" type="fixed">
     <axis xyz="0 1 0"/>
     <limit effort="100" velocity="100"/>
     <!-- alpha tested effort and velocity limits -->
-    <safety_controller k_velocity="10"/>
     <dynamics damping="0.0" friction="0.0"/>
     <origin rpy="0 0 0" xyz="0 -0.049 0"/>
     <parent link="fr_caster_rotation_link"/>
@@ -486,7 +470,6 @@
   <transmission name="fr_caster_r_wheel_trans" type="SimpleTransmission">
     <actuator name="fr_caster_r_wheel_motor"/>
     <joint name="fr_caster_r_wheel_joint"/>
-    <mechanicalReduction>-79.2380952381</mechanicalReduction>
   </transmission>
   <gazebo reference="fr_caster_rotation_link">
     <material value="PR2/caster_texture"/>
@@ -495,8 +478,6 @@
     <axis xyz="0 0 1"/>
     <limit effort="100" velocity="100"/>
     <!-- alpha tested velocity and effort limits -->
-    <safety_controller k_velocity="10"/>
-    <calibration reference_position="2.35619449019" rising="2.35619449019"/>
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
     <dynamics damping="0.0" friction="0.0"/>
     <origin rpy="0 0 0" xyz="-0.2246 0.2246 0.0282"/>
@@ -526,13 +507,11 @@
   <transmission name="bl_caster_rotation_trans" type="SimpleTransmission">
     <actuator name="bl_caster_rotation_motor"/>
     <joint name="bl_caster_rotation_joint"/>
-    <mechanicalReduction>-79.2380952381</mechanicalReduction>
   </transmission>
   <joint name="bl_caster_l_wheel_joint" type="fixed">
     <axis xyz="0 1 0"/>
     <limit effort="100" velocity="100"/>
     <!-- alpha tested effort and velocity limits -->
-    <safety_controller k_velocity="10"/>
     <dynamics damping="0.0" friction="0.0"/>
     <origin rpy="0 0 0" xyz="0 0.049 0"/>
     <parent link="bl_caster_rotation_link"/>
@@ -569,13 +548,11 @@
   <transmission name="bl_caster_l_wheel_trans" type="SimpleTransmission">
     <actuator name="bl_caster_l_wheel_motor"/>
     <joint name="bl_caster_l_wheel_joint"/>
-    <mechanicalReduction>79.2380952381</mechanicalReduction>
   </transmission>
   <joint name="bl_caster_r_wheel_joint" type="fixed">
     <axis xyz="0 1 0"/>
     <limit effort="100" velocity="100"/>
     <!-- alpha tested effort and velocity limits -->
-    <safety_controller k_velocity="10"/>
     <dynamics damping="0.0" friction="0.0"/>
     <origin rpy="0 0 0" xyz="0 -0.049 0"/>
     <parent link="bl_caster_rotation_link"/>
@@ -612,7 +589,6 @@
   <transmission name="bl_caster_r_wheel_trans" type="SimpleTransmission">
     <actuator name="bl_caster_r_wheel_motor"/>
     <joint name="bl_caster_r_wheel_joint"/>
-    <mechanicalReduction>-79.2380952381</mechanicalReduction>
   </transmission>
   <gazebo reference="bl_caster_rotation_link">
     <material value="PR2/caster_texture"/>
@@ -621,8 +597,6 @@
     <axis xyz="0 0 1"/>
     <limit effort="100" velocity="100"/>
     <!-- alpha tested velocity and effort limits -->
-    <safety_controller k_velocity="10"/>
-    <calibration reference_position="2.35619449019" rising="2.35619449019"/>
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
     <dynamics damping="0.0" friction="0.0"/>
     <origin rpy="0 0 0" xyz="-0.2246 -0.2246 0.0282"/>
@@ -652,13 +626,11 @@
   <transmission name="br_caster_rotation_trans" type="SimpleTransmission">
     <actuator name="br_caster_rotation_motor"/>
     <joint name="br_caster_rotation_joint"/>
-    <mechanicalReduction>-79.2380952381</mechanicalReduction>
   </transmission>
   <joint name="br_caster_l_wheel_joint" type="fixed">
     <axis xyz="0 1 0"/>
     <limit effort="100" velocity="100"/>
     <!-- alpha tested effort and velocity limits -->
-    <safety_controller k_velocity="10"/>
     <dynamics damping="0.0" friction="0.0"/>
     <origin rpy="0 0 0" xyz="0 0.049 0"/>
     <parent link="br_caster_rotation_link"/>
@@ -695,13 +667,11 @@
   <transmission name="br_caster_l_wheel_trans" type="SimpleTransmission">
     <actuator name="br_caster_l_wheel_motor"/>
     <joint name="br_caster_l_wheel_joint"/>
-    <mechanicalReduction>79.2380952381</mechanicalReduction>
   </transmission>
   <joint name="br_caster_r_wheel_joint" type="fixed">
     <axis xyz="0 1 0"/>
     <limit effort="100" velocity="100"/>
     <!-- alpha tested effort and velocity limits -->
-    <safety_controller k_velocity="10"/>
     <dynamics damping="0.0" friction="0.0"/>
     <origin rpy="0 0 0" xyz="0 -0.049 0"/>
     <parent link="br_caster_rotation_link"/>
@@ -738,7 +708,6 @@
   <transmission name="br_caster_r_wheel_trans" type="SimpleTransmission">
     <actuator name="br_caster_r_wheel_motor"/>
     <joint name="br_caster_r_wheel_joint"/>
-    <mechanicalReduction>-79.2380952381</mechanicalReduction>
   </transmission>
   <gazebo reference="br_caster_rotation_link">
     <material value="PR2/caster_texture"/>
@@ -776,9 +745,7 @@
     <axis xyz="0 0 1"/>
     <limit effort="10000" lower="0.0" upper="0.31" velocity="0.013"/>
     <!-- alpha tested velocity and effort limits -->
-    <safety_controller k_position="100" k_velocity="2000000" soft_lower_limit="0.0115" soft_upper_limit="0.305"/>
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
-    <calibration falling="0.00536" reference_position="0.00536"/>
     <dynamics damping="20000.0"/>
     <!-- strictly tuned for sim only right now -->
     <origin rpy="0 0 0" xyz="-0.05 0 0.739675"/>
@@ -821,7 +788,6 @@
   <transmission name="torso_lift_trans" type="SimpleTransmission">
     <actuator name="torso_lift_motor"/>
     <joint name="torso_lift_joint"/>
-    <mechanicalReduction> -52143.33 </mechanicalReduction>
   </transmission>
   <joint name="imu_joint" type="fixed">
     <axis xyz="0 1 0"/>
@@ -867,9 +833,7 @@
     <axis xyz="0 0 1"/>
     <limit effort="2.645" lower="-3.007" upper="3.007" velocity="6"/>
     <!-- alpha tested velocity and effort limits -->
-    <safety_controller k_position="100" k_velocity="1.5" soft_lower_limit="-2.857" soft_upper_limit="2.857"/>
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
-    <calibration reference_position="0.0" rising="0.0"/>
     <dynamics damping="1.0"/>
     <origin rpy="0.0 0.0 0.0" xyz="-0.01707 0.0 0.38145"/>
     <parent link="torso_lift_link"/>
@@ -901,15 +865,12 @@
   <transmission name="head_pan_trans" type="SimpleTransmission">
     <actuator name="head_pan_motor"/>
     <joint name="head_pan_joint"/>
-    <mechanicalReduction>6.0</mechanicalReduction>
   </transmission>
   <joint name="head_tilt_joint" type="revolute">
     <axis xyz="0 1 0"/>
     <limit effort="15" lower="-0.471238" upper="1.39626" velocity="5"/>
     <!-- alpha tested velocity and effort limits -->
-    <safety_controller k_position="100" k_velocity="1.5" soft_lower_limit="-0.3712" soft_upper_limit="1.29626"/>
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
-    <calibration falling="0.0" reference_position="0.0"/>
     <dynamics damping="1.0"/>
     <origin rpy="0 0 0" xyz="0.068 0 0"/>
     <parent link="head_pan_link"/>
@@ -941,7 +902,6 @@
   <transmission name="head_tilt_trans" type="SimpleTransmission">
     <actuator name="head_tilt_motor"/>
     <joint name="head_tilt_joint"/>
-    <mechanicalReduction>6.0</mechanicalReduction>
   </transmission>
   <joint name="head_plate_frame_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0.0232 0 0.0645"/>
@@ -1140,7 +1100,7 @@
     <parent link="wide_stereo_link"/>
     <child link="wide_stereo_optical_frame"/>
   </joint>
-  <link name="wide_stereo_optical_frame" type="camera"/>
+  <link name="wide_stereo_optical_frame"/>
   <joint name="wide_stereo_gazebo_l_stereo_camera_frame_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <parent link="wide_stereo_link"/>
@@ -1305,7 +1265,7 @@
     <parent link="narrow_stereo_link"/>
     <child link="narrow_stereo_optical_frame"/>
   </joint>
-  <link name="narrow_stereo_optical_frame" type="camera"/>
+  <link name="narrow_stereo_optical_frame"/>
   <joint name="narrow_stereo_gazebo_l_stereo_camera_frame_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <parent link="narrow_stereo_link"/>
@@ -1442,9 +1402,7 @@
     <axis xyz="0 1 0"/>
     <limit effort="0.65" lower="-0.7854" upper="1.48353" velocity="10.0"/>
     <!-- alpha tested velocity and effort limits -->
-    <safety_controller k_position="100" k_velocity="0.05" soft_lower_limit="-0.7354" soft_upper_limit="1.43353"/>
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
-    <calibration falling="0.0" reference_position="0.0"/>
     <dynamics damping="0.008"/>
     <origin rpy="0 0 0" xyz="0.09893 0 0.227"/>
     <parent link="torso_lift_link"/>
@@ -1476,7 +1434,7 @@
     <parent link="laser_tilt_mount_link"/>
     <child link="laser_tilt_link"/>
   </joint>
-  <link name="laser_tilt_link" type="laser">
+  <link name="laser_tilt_link">
     <inertial>
       <mass value="0.001"/>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1525,7 +1483,6 @@
   <transmission name="laser_tilt_mount_trans" type="SimpleTransmission">
     <actuator name="laser_tilt_mount_motor"/>
     <joint name="laser_tilt_mount_joint"/>
-    <mechanicalReduction>-6.05</mechanicalReduction>
   </transmission>
   <!-- This is a common convention, to use a reflect parameter that equals +-1 to distinguish left from right -->
   <joint name="r_shoulder_pan_joint" type="revolute">
@@ -1537,10 +1494,8 @@
     <limit effort="30" lower="-2.2853981634" upper="0.714601836603" velocity="2.088"/>
     <!-- alpha tested velocity and effort limits -->
     <dynamics damping="10.0"/>
-    <safety_controller k_position="100" k_velocity="10" soft_lower_limit="-2.1353981634" soft_upper_limit="0.564601836603"/>
     <!-- joint angle when the rising or the falling flag is activated on PR2 -->
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
-    <calibration reference_position="-0.785398163397" rising="-0.785398163397"/>
   </joint>
   <link name="r_shoulder_pan_link">
     <inertial>
@@ -1567,9 +1522,7 @@
     <!-- Limits updated from Function's CAD values as of 2009_02_24 (link_data.xls) -->
     <limit effort="30" lower="-0.5236" upper="1.3963" velocity="2.082"/>
     <!-- alpha tested velocity and effort limits -->
-    <safety_controller k_position="100" k_velocity="10" soft_lower_limit="-0.3536" soft_upper_limit="1.2963"/>
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
-    <calibration falling="0.0" reference_position="0.0"/>
     <dynamics damping="10.0"/>
     <origin rpy="0 0 0" xyz="0.1 0 0"/>
     <parent link="r_shoulder_pan_link"/>
@@ -1602,9 +1555,7 @@
     <child link="r_upper_arm_roll_link"/>
     <limit effort="30" lower="-3.9" upper="0.8" velocity="3.27"/>
     <!-- alpha tested velocity and effort limits -->
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-3.75" soft_upper_limit="0.65"/>
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
-    <calibration reference_position="-1.57079632679" rising="-1.57079632679"/>
     <dynamics damping="0.1"/>
   </joint>
   <link name="r_upper_arm_roll_link">
@@ -1641,7 +1592,6 @@
   <transmission name="r_upper_arm_roll_trans" type="SimpleTransmission">
     <actuator name="r_upper_arm_roll_motor"/>
     <joint name="r_upper_arm_roll_joint"/>
-    <mechanicalReduction>32.6525111499</mechanicalReduction>
   </transmission>
   <gazebo reference="r_shoulder_pan_link">
     <sensor:contact name="r_shoulder_pan_contact_sensor">
@@ -1681,12 +1631,10 @@
   <transmission name="r_shoulder_pan_trans" type="SimpleTransmission">
     <actuator name="r_shoulder_pan_motor"/>
     <joint name="r_shoulder_pan_joint"/>
-    <mechanicalReduction>63.1552452977</mechanicalReduction>
   </transmission>
   <transmission name="r_shoulder_lift_trans" type="SimpleTransmission">
     <actuator name="r_shoulder_lift_motor"/>
     <joint name="r_shoulder_lift_joint"/>
-    <mechanicalReduction>61.8948225713</mechanicalReduction>
   </transmission>
   <joint name="r_upper_arm_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1733,9 +1681,7 @@
     <axis xyz="1 0 0"/>
     <limit effort="30" velocity="3.6"/>
     <!-- alpha tested velocity and effort limits -->
-    <safety_controller k_velocity="1"/>
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
-    <calibration reference_position="0.0" rising="0.0"/>
     <dynamics damping="0.1"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <parent link="r_elbow_flex_link"/>
@@ -1773,16 +1719,13 @@
   <transmission name="r_forearm_roll_trans" type="SimpleTransmission">
     <actuator name="r_forearm_roll_motor"/>
     <joint name="r_forearm_roll_joint"/>
-    <mechanicalReduction>-90.5142857143</mechanicalReduction>
   </transmission>
   <joint name="r_elbow_flex_joint" type="revolute">
     <axis xyz="0 1 0"/>
     <!-- Note: Overtravel limits are 140, -7 degrees instead of 133, 0 -->
     <limit effort="30" lower="-2.3213" upper="0.00" velocity="3.3"/>
     <!-- alpha tested velocity and effort limits -->
-    <safety_controller k_position="100" k_velocity="3" soft_lower_limit="-2.1213" soft_upper_limit="-0.15"/>
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
-    <calibration falling="-1.1606" reference_position="-1.1606"/>
     <dynamics damping="1.0"/>
     <origin rpy="0 0 0" xyz="0.4 0 0"/>
     <parent link="r_upper_arm_link"/>
@@ -1832,7 +1775,6 @@
   <transmission name="r_elbow_flex_trans" type="SimpleTransmission">
     <actuator name="r_elbow_flex_motor"/>
     <joint name="r_elbow_flex_joint"/>
-    <mechanicalReduction>-36.167452007</mechanicalReduction>
   </transmission>
   <joint name="r_forearm_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1864,10 +1806,8 @@
     <axis xyz="0 1 0"/>
     <limit effort="10" lower="-2.094" upper="0.0" velocity="3.078"/>
     <!-- alpha tested velocity and effort limits -->
-    <safety_controller k_position="20" k_velocity="4" soft_lower_limit="-1.994" soft_upper_limit="-0.1"/>
     <dynamics damping="0.1"/>
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
-    <calibration falling="-0.5410521" reference_position="-0.5410521"/>
     <origin rpy="0 0 0" xyz="0.321 0 0"/>
     <parent link="r_forearm_link"/>
     <child link="r_wrist_flex_link"/>
@@ -1897,10 +1837,8 @@
     <axis xyz="1 0 0"/>
     <limit effort="10" velocity="3.6"/>
     <!-- alpha tested velocity and effort limits -->
-    <safety_controller k_velocity="2"/>
     <dynamics damping="0.1"/>
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
-    <calibration reference_position="-1.57079632679" rising="-1.57079632679"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <parent link="r_wrist_flex_link"/>
     <child link="r_wrist_roll_link"/>
@@ -1924,7 +1862,6 @@
       <geometry>
         <mesh filename="package://drake/examples/pr2/models/pr2_description/meshes/forearm_v0/wrist_roll_L.obj"/>
       </geometry>
-      <verbose value="Yes"/>
     </collision>
   </link>
   <gazebo reference="r_forearm_link">
@@ -1986,12 +1923,10 @@
   <transmission name="r_wrist_flex_trans" type="SimpleTransmission">
     <actuator name="r_wrist_flex_motor"/>
     <joint name="r_wrist_flex_joint"/>
-    <mechanicalReduction>60.1714285714</mechanicalReduction>
   </transmission>
   <transmission name="r_wrist_roll_trans" type="SimpleTransmission">
     <actuator name="r_wrist_roll_motor"/>
     <joint name="r_wrist_roll_joint"/>
-    <mechanicalReduction>60.1714285714</mechanicalReduction>
   </transmission>
   <joint name="r_gripper_palm_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -2016,7 +1951,6 @@
       <geometry>
         <mesh filename="package://drake/examples/pr2/models/pr2_description/meshes/gripper_v0/gripper_palm.obj"/>
       </geometry>
-      <verbose value="Yes"/>
     </collision>
   </link>
   <joint name="r_gripper_led_joint" type="fixed">
@@ -2082,7 +2016,6 @@
       <geometry>
         <mesh filename="package://drake/examples/pr2/models/pr2_description/meshes/gripper_v0/l_finger.obj"/>
       </geometry>
-      <verbose value="Yes"/>
     </collision>
   </link>
   <joint name="r_gripper_r_finger_joint" type="revolute">
@@ -2090,7 +2023,6 @@
     <origin rpy="0 0 0" xyz="0.07691 -0.01 0"/>
     <limit effort="1000.0" lower="0.0" upper="0.548" velocity="0.5"/>
     <dynamics damping="0.2"/>
-    <mimic joint="r_gripper_l_finger_joint" multiplier="1" offset="0"/>
     <parent link="r_gripper_palm_link"/>
     <child link="r_gripper_r_finger_link"/>
   </joint>
@@ -2112,14 +2044,12 @@
       <geometry>
         <mesh filename="package://drake/examples/pr2/models/pr2_description/meshes/gripper_v0/l_finger.obj"/>
       </geometry>
-      <verbose value="Yes"/>
     </collision>
   </link>
   <joint name="r_gripper_l_parallel_root_joint" type="fixed">
     <axis xyz="0 0 1"/>
     <origin rpy="0 0 0" xyz="0.05891 0.031 0"/>
     <dynamics damping="0.2"/>
-    <mimic joint="r_gripper_l_finger_joint" multiplier="1" offset="0"/>
     <parent link="r_gripper_palm_link"/>
     <child link="r_gripper_l_parallel_link"/>
     <limit effort="1000.0" lower="0.0" upper="0.548" velocity="0.5"/>
@@ -2128,7 +2058,6 @@
     <axis xyz="0 0 -1"/>
     <origin rpy="0 0 0" xyz="0.05891 -0.031 0"/>
     <dynamics damping="0.2"/>
-    <mimic joint="r_gripper_l_finger_joint" multiplier="-1" offset="0"/>
     <parent link="r_gripper_palm_link"/>
     <child link="r_gripper_r_parallel_link"/>
     <limit effort="1000.0" lower="0.0" upper="0.548" velocity="0.5"/>
@@ -2153,7 +2082,6 @@
       <geometry>
         <box size="0.0914942479 0.005 0.005"/>
       </geometry>
-      <verbose value="Yes"/>
     </collision>
   </link>
   <link name="r_gripper_r_parallel_link">
@@ -2176,7 +2104,6 @@
       <geometry>
         <box size="0.0914942479 0.005 0.005"/>
       </geometry>
-      <verbose value="Yes"/>
     </collision>
   </link>
   <joint name="r_gripper_l_finger_tip_joint" type="revolute">
@@ -2184,7 +2111,6 @@
     <origin rpy="0 0 0" xyz="0.09137 0.00495 0"/>
     <limit effort="1000.0" lower="0.0" upper="0.548" velocity="0.5"/>
     <dynamics damping="0.01"/>
-    <mimic joint="r_gripper_l_finger_joint" multiplier="1" offset="0"/>
     <parent link="r_gripper_l_finger_link"/>
     <child link="r_gripper_l_finger_tip_link"/>
   </joint>
@@ -2206,7 +2132,6 @@
       <geometry>
         <mesh filename="package://drake/examples/pr2/models/pr2_description/meshes/gripper_v0/l_finger_tip.obj"/>
       </geometry>
-      <verbose value="Yes"/>
     </collision>
   </link>
   <joint name="r_gripper_r_finger_tip_joint" type="revolute">
@@ -2214,7 +2139,6 @@
     <origin rpy="0 0 0" xyz="0.09137 -0.00495 0"/>
     <limit effort="1000.0" lower="0.0" upper="0.548" velocity="0.5"/>
     <dynamics damping="0.01"/>
-    <mimic joint="r_gripper_l_finger_joint" multiplier="1" offset="0"/>
     <parent link="r_gripper_r_finger_link"/>
     <child link="r_gripper_r_finger_tip_link"/>
   </joint>
@@ -2236,7 +2160,6 @@
       <geometry>
         <mesh filename="package://drake/examples/pr2/models/pr2_description/meshes/gripper_v0/l_finger_tip.obj"/>
       </geometry>
-      <verbose value="Yes"/>
     </collision>
   </link>
   <gazebo reference="r_gripper_l_finger_link">
@@ -2470,10 +2393,8 @@
     <limit effort="30" lower="-0.714601836603" upper="2.2853981634" velocity="2.088"/>
     <!-- alpha tested velocity and effort limits -->
     <dynamics damping="10.0"/>
-    <safety_controller k_position="100" k_velocity="10" soft_lower_limit="-0.564601836603" soft_upper_limit="2.1353981634"/>
     <!-- joint angle when the rising or the falling flag is activated on PR2 -->
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
-    <calibration reference_position="0.785398163397" rising="0.785398163397"/>
   </joint>
   <link name="l_shoulder_pan_link">
     <inertial>
@@ -2500,9 +2421,7 @@
     <!-- Limits updated from Function's CAD values as of 2009_02_24 (link_data.xls) -->
     <limit effort="30" lower="-0.5236" upper="1.3963" velocity="2.082"/>
     <!-- alpha tested velocity and effort limits -->
-    <safety_controller k_position="100" k_velocity="10" soft_lower_limit="-0.3536" soft_upper_limit="1.2963"/>
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
-    <calibration falling="0.0" reference_position="0.0"/>
     <dynamics damping="10.0"/>
     <origin rpy="0 0 0" xyz="0.1 0 0"/>
     <parent link="l_shoulder_pan_link"/>
@@ -2535,9 +2454,7 @@
     <child link="l_upper_arm_roll_link"/>
     <limit effort="30" lower="-0.8" upper="3.9" velocity="3.27"/>
     <!-- alpha tested velocity and effort limits -->
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-0.65" soft_upper_limit="3.75"/>
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
-    <calibration reference_position="1.57079632679" rising="1.57079632679"/>
     <dynamics damping="0.1"/>
   </joint>
   <link name="l_upper_arm_roll_link">
@@ -2574,7 +2491,6 @@
   <transmission name="l_upper_arm_roll_trans" type="SimpleTransmission">
     <actuator name="l_upper_arm_roll_motor"/>
     <joint name="l_upper_arm_roll_joint"/>
-    <mechanicalReduction>32.6525111499</mechanicalReduction>
   </transmission>
   <gazebo reference="l_shoulder_pan_link">
     <sensor:contact name="l_shoulder_pan_contact_sensor">
@@ -2614,12 +2530,10 @@
   <transmission name="l_shoulder_pan_trans" type="SimpleTransmission">
     <actuator name="l_shoulder_pan_motor"/>
     <joint name="l_shoulder_pan_joint"/>
-    <mechanicalReduction>63.1552452977</mechanicalReduction>
   </transmission>
   <transmission name="l_shoulder_lift_trans" type="SimpleTransmission">
     <actuator name="l_shoulder_lift_motor"/>
     <joint name="l_shoulder_lift_joint"/>
-    <mechanicalReduction>61.8948225713</mechanicalReduction>
   </transmission>
   <joint name="l_upper_arm_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -2666,9 +2580,7 @@
     <axis xyz="1 0 0"/>
     <limit effort="30" velocity="3.6"/>
     <!-- alpha tested velocity and effort limits -->
-    <safety_controller k_velocity="1"/>
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
-    <calibration reference_position="0.0" rising="0.0"/>
     <dynamics damping="0.1"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <parent link="l_elbow_flex_link"/>
@@ -2706,16 +2618,13 @@
   <transmission name="l_forearm_roll_trans" type="SimpleTransmission">
     <actuator name="l_forearm_roll_motor"/>
     <joint name="l_forearm_roll_joint"/>
-    <mechanicalReduction>-90.5142857143</mechanicalReduction>
   </transmission>
   <joint name="l_elbow_flex_joint" type="revolute">
     <axis xyz="0 1 0"/>
     <!-- Note: Overtravel limits are 140, -7 degrees instead of 133, 0 -->
     <limit effort="30" lower="-2.3213" upper="0.00" velocity="3.3"/>
     <!-- alpha tested velocity and effort limits -->
-    <safety_controller k_position="100" k_velocity="3" soft_lower_limit="-2.1213" soft_upper_limit="-0.15"/>
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
-    <calibration falling="-1.1606" reference_position="-1.1606"/>
     <dynamics damping="1.0"/>
     <origin rpy="0 0 0" xyz="0.4 0 0"/>
     <parent link="l_upper_arm_link"/>
@@ -2765,7 +2674,6 @@
   <transmission name="l_elbow_flex_trans" type="SimpleTransmission">
     <actuator name="l_elbow_flex_motor"/>
     <joint name="l_elbow_flex_joint"/>
-    <mechanicalReduction>-36.167452007</mechanicalReduction>
   </transmission>
   <joint name="l_forearm_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -2797,10 +2705,8 @@
     <axis xyz="0 1 0"/>
     <limit effort="10" lower="-2.094" upper="0.0" velocity="3.078"/>
     <!-- alpha tested velocity and effort limits -->
-    <safety_controller k_position="20" k_velocity="4" soft_lower_limit="-1.994" soft_upper_limit="-0.1"/>
     <dynamics damping="0.1"/>
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
-    <calibration falling="-0.5410521" reference_position="-0.5410521"/>
     <origin rpy="0 0 0" xyz="0.321 0 0"/>
     <parent link="l_forearm_link"/>
     <child link="l_wrist_flex_link"/>
@@ -2830,10 +2736,8 @@
     <axis xyz="1 0 0"/>
     <limit effort="10" velocity="3.6"/>
     <!-- alpha tested velocity and effort limits -->
-    <safety_controller k_velocity="2"/>
     <dynamics damping="0.1"/>
     <!-- hold both reference_position and upper/lower for tick-tock, remove reference_positiion after verifying upper/lower works with calibration controllers.  if search velocity in pr2_calibration_controllers.yaml is +, the reference_position is rising, if - then it is falling -->
-    <calibration reference_position="-1.57079632679" rising="-1.57079632679"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <parent link="l_wrist_flex_link"/>
     <child link="l_wrist_roll_link"/>
@@ -2857,7 +2761,6 @@
       <geometry>
         <mesh filename="package://drake/examples/pr2/models/pr2_description/meshes/forearm_v0/wrist_roll_L.obj"/>
       </geometry>
-      <verbose value="Yes"/>
     </collision>
   </link>
   <gazebo reference="l_forearm_link">
@@ -2920,12 +2823,10 @@
   <transmission name="l_wrist_flex_trans" type="SimpleTransmission">
     <actuator name="l_wrist_flex_motor"/>
     <joint name="l_wrist_flex_joint"/>
-    <mechanicalReduction>60.1714285714</mechanicalReduction>
   </transmission>
   <transmission name="l_wrist_roll_trans" type="SimpleTransmission">
     <actuator name="l_wrist_roll_motor"/>
     <joint name="l_wrist_roll_joint"/>
-    <mechanicalReduction>60.1714285714</mechanicalReduction>
   </transmission>
   <joint name="l_gripper_palm_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -2950,7 +2851,6 @@
       <geometry>
         <mesh filename="package://drake/examples/pr2/models/pr2_description/meshes/gripper_v0/gripper_palm.obj"/>
       </geometry>
-      <verbose value="Yes"/>
     </collision>
   </link>
   <joint name="l_gripper_led_joint" type="fixed">
@@ -3016,7 +2916,6 @@
       <geometry>
         <mesh filename="package://drake/examples/pr2/models/pr2_description/meshes/gripper_v0/l_finger.obj"/>
       </geometry>
-      <verbose value="Yes"/>
     </collision>
   </link>
   <joint name="l_gripper_r_finger_joint" type="revolute">
@@ -3024,7 +2923,6 @@
     <origin rpy="0 0 0" xyz="0.07691 -0.01 0"/>
     <limit effort="1000.0" lower="0.0" upper="0.548" velocity="0.5"/>
     <dynamics damping="0.2"/>
-    <mimic joint="l_gripper_l_finger_joint" multiplier="1" offset="0"/>
     <parent link="l_gripper_palm_link"/>
     <child link="l_gripper_r_finger_link"/>
   </joint>
@@ -3046,14 +2944,12 @@
       <geometry>
         <mesh filename="package://drake/examples/pr2/models/pr2_description/meshes/gripper_v0/l_finger.obj"/>
       </geometry>
-      <verbose value="Yes"/>
     </collision>
   </link>
   <joint name="l_gripper_l_parallel_root_joint" type="fixed">
     <axis xyz="0 0 1"/>
     <origin rpy="0 0 0" xyz="0.05891 0.031 0"/>
     <dynamics damping="0.2"/>
-    <mimic joint="l_gripper_l_finger_joint" multiplier="1" offset="0"/>
     <parent link="l_gripper_palm_link"/>
     <child link="l_gripper_l_parallel_link"/>
     <limit effort="1000.0" lower="0.0" upper="0.548" velocity="0.5"/>
@@ -3062,7 +2958,6 @@
     <axis xyz="0 0 -1"/>
     <origin rpy="0 0 0" xyz="0.05891 -0.031 0"/>
     <dynamics damping="0.2"/>
-    <mimic joint="l_gripper_l_finger_joint" multiplier="-1" offset="0"/>
     <parent link="l_gripper_palm_link"/>
     <child link="l_gripper_r_parallel_link"/>
     <limit effort="1000.0" lower="0.0" upper="0.548" velocity="0.5"/>
@@ -3087,7 +2982,6 @@
       <geometry>
         <box size="0.0914942479 0.005 0.005"/>
       </geometry>
-      <verbose value="Yes"/>
     </collision>
   </link>
   <link name="l_gripper_r_parallel_link">
@@ -3110,7 +3004,6 @@
       <geometry>
         <box size="0.0914942479 0.005 0.005"/>
       </geometry>
-      <verbose value="Yes"/>
     </collision>
   </link>
   <joint name="l_gripper_l_finger_tip_joint" type="revolute">
@@ -3118,7 +3011,6 @@
     <origin rpy="0 0 0" xyz="0.09137 0.00495 0"/>
     <limit effort="1000.0" lower="0.0" upper="0.548" velocity="0.5"/>
     <dynamics damping="0.01"/>
-    <mimic joint="l_gripper_l_finger_joint" multiplier="1" offset="0"/>
     <parent link="l_gripper_l_finger_link"/>
     <child link="l_gripper_l_finger_tip_link"/>
   </joint>
@@ -3140,7 +3032,6 @@
       <geometry>
         <mesh filename="package://drake/examples/pr2/models/pr2_description/meshes/gripper_v0/l_finger_tip.obj"/>
       </geometry>
-      <verbose value="Yes"/>
     </collision>
   </link>
   <joint name="l_gripper_r_finger_tip_joint" type="revolute">
@@ -3148,7 +3039,6 @@
     <origin rpy="0 0 0" xyz="0.09137 -0.00495 0"/>
     <limit effort="1000.0" lower="0.0" upper="0.548" velocity="0.5"/>
     <dynamics damping="0.01"/>
-    <mimic joint="l_gripper_l_finger_joint" multiplier="1" offset="0"/>
     <parent link="l_gripper_r_finger_link"/>
     <child link="l_gripper_r_finger_tip_link"/>
   </joint>
@@ -3170,7 +3060,6 @@
       <geometry>
         <mesh filename="package://drake/examples/pr2/models/pr2_description/meshes/gripper_v0/l_finger_tip.obj"/>
       </geometry>
-      <verbose value="Yes"/>
     </collision>
   </link>
   <gazebo reference="l_gripper_l_finger_link">

--- a/manipulation/models/franka_description/BUILD.bazel
+++ b/manipulation/models/franka_description/BUILD.bazel
@@ -25,6 +25,7 @@ _FRANKA_DESCRIPTION_MESHES = forward_files(
 install_data(
     extra_prod_models = _FRANKA_DESCRIPTION_MESHES + [
         "LICENSE.TXT",
+        "README.md",
     ],
 )
 # === test/ ===

--- a/manipulation/models/franka_description/README.md
+++ b/manipulation/models/franka_description/README.md
@@ -1,0 +1,9 @@
+This folder contains a drake-compatible model of the Franka Emika Panda arm.
+
+The model differs from the original ROS model and the real robot. In this model
+the fingers are independently actuated, rather than using <mimic> tag, which
+Drake does not yet support.
+
+In addition, some tags unsupported by Drake have been removed, to reduce the
+burden of warning output. For URDF support details, see:
+https://drake.mit.edu/doxygen_cxx/group__multibody__parsing.html

--- a/manipulation/models/franka_description/urdf/hand.urdf
+++ b/manipulation/models/franka_description/urdf/hand.urdf
@@ -104,7 +104,6 @@
     <origin rpy="0 0 0" xyz="0 0 0.0584"/>
     <axis xyz="0 -1 0"/>
     <limit effort="20" lower="0.0" upper="0.04" velocity="0.2"/>
-    <mimic joint="panda_finger_joint1"/>
   </joint>
   <transmission name="panda_finger_tran1">
     <type>transmission_interface/SimpleTransmission</type>

--- a/manipulation/models/franka_description/urdf/panda_arm.urdf
+++ b/manipulation/models/franka_description/urdf/panda_arm.urdf
@@ -151,7 +151,6 @@
     </collision>
   </link>
   <joint name="panda_joint1" type="revolute">
-    <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-2.8973" soft_upper_limit="2.8973"/>
     <origin rpy="0 0 0" xyz="0 0 0.333"/>
     <parent link="panda_link0"/>
     <child link="panda_link1"/>
@@ -208,7 +207,6 @@
     </collision>
   </link>
   <joint name="panda_joint2" type="revolute">
-    <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-1.7628" soft_upper_limit="1.7628"/>
     <origin rpy="-1.57079632679 0 0" xyz="0 0 0"/>
     <parent link="panda_link1"/>
     <child link="panda_link2"/>
@@ -259,7 +257,6 @@
     </collision>
   </link>
   <joint name="panda_joint3" type="revolute">
-    <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-2.8973" soft_upper_limit="2.8973"/>
     <origin rpy="1.57079632679 0 0" xyz="0 -0.316 0"/>
     <parent link="panda_link2"/>
     <child link="panda_link3"/>
@@ -322,7 +319,6 @@
     </collision>
   </link>
   <joint name="panda_joint4" type="revolute">
-    <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-3.0718" soft_upper_limit="-0.0698"/>
     <origin rpy="1.57079632679 0 0" xyz="0.0825 0 0"/>
     <parent link="panda_link3"/>
     <child link="panda_link4"/>
@@ -415,7 +411,6 @@
     </collision>
   </link>
   <joint name="panda_joint5" type="revolute">
-    <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-2.8973" soft_upper_limit="2.8973"/>
     <origin rpy="-1.57079632679 0 0" xyz="-0.0825 0.384 0"/>
     <parent link="panda_link4"/>
     <child link="panda_link5"/>
@@ -466,7 +461,6 @@
     </collision>
   </link>
   <joint name="panda_joint6" type="revolute">
-    <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-0.0175" soft_upper_limit="3.7525"/>
     <origin rpy="1.57079632679 0 0" xyz="0 0 0"/>
     <parent link="panda_link5"/>
     <child link="panda_link6"/>
@@ -499,7 +493,6 @@
     </collision>
   </link>
   <joint name="panda_joint7" type="revolute">
-    <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-2.8973" soft_upper_limit="2.8973"/>
     <origin rpy="1.57079632679 0 0" xyz="0.088 0 0"/>
     <parent link="panda_link6"/>
     <child link="panda_link7"/>

--- a/manipulation/models/franka_description/urdf/panda_arm_hand.urdf
+++ b/manipulation/models/franka_description/urdf/panda_arm_hand.urdf
@@ -151,7 +151,6 @@
     </collision>
   </link>
   <joint name="panda_joint1" type="revolute">
-    <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-2.8973" soft_upper_limit="2.8973"/>
     <origin rpy="0 0 0" xyz="0 0 0.333"/>
     <parent link="panda_link0"/>
     <child link="panda_link1"/>
@@ -208,7 +207,6 @@
     </collision>
   </link>
   <joint name="panda_joint2" type="revolute">
-    <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-1.7628" soft_upper_limit="1.7628"/>
     <origin rpy="-1.57079632679 0 0" xyz="0 0 0"/>
     <parent link="panda_link1"/>
     <child link="panda_link2"/>
@@ -259,7 +257,6 @@
     </collision>
   </link>
   <joint name="panda_joint3" type="revolute">
-    <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-2.8973" soft_upper_limit="2.8973"/>
     <origin rpy="1.57079632679 0 0" xyz="0 -0.316 0"/>
     <parent link="panda_link2"/>
     <child link="panda_link3"/>
@@ -322,7 +319,6 @@
     </collision>
   </link>
   <joint name="panda_joint4" type="revolute">
-    <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-3.0718" soft_upper_limit="-0.0698"/>
     <origin rpy="1.57079632679 0 0" xyz="0.0825 0 0"/>
     <parent link="panda_link3"/>
     <child link="panda_link4"/>
@@ -415,7 +411,6 @@
     </collision>
   </link>
   <joint name="panda_joint5" type="revolute">
-    <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-2.8973" soft_upper_limit="2.8973"/>
     <origin rpy="-1.57079632679 0 0" xyz="-0.0825 0.384 0"/>
     <parent link="panda_link4"/>
     <child link="panda_link5"/>
@@ -466,7 +461,6 @@
     </collision>
   </link>
   <joint name="panda_joint6" type="revolute">
-    <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-0.0175" soft_upper_limit="3.7525"/>
     <origin rpy="1.57079632679 0 0" xyz="0 0 0"/>
     <parent link="panda_link5"/>
     <child link="panda_link6"/>
@@ -499,7 +493,6 @@
     </collision>
   </link>
   <joint name="panda_joint7" type="revolute">
-    <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-2.8973" soft_upper_limit="2.8973"/>
     <origin rpy="1.57079632679 0 0" xyz="0.088 0 0"/>
     <parent link="panda_link6"/>
     <child link="panda_link7"/>
@@ -694,7 +687,6 @@
     <origin rpy="0 0 0" xyz="0 0 0.0584"/>
     <axis xyz="0 -1 0"/>
     <limit effort="20" lower="0.0" upper="0.04" velocity="0.2"/>
-    <mimic joint="panda_finger_joint1"/>
   </joint>
   <transmission name="panda_finger_tran1">
     <type>transmission_interface/SimpleTransmission</type>

--- a/manipulation/models/iiwa_description/urdf/dual_iiwa14_polytope_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/dual_iiwa14_polytope_collision.urdf
@@ -78,7 +78,6 @@
     <origin rpy="0 0 0" xyz="0 0 0.1575"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.57" effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.93215314335" soft_upper_limit="2.93215314335"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="left_iiwa_link_1">
@@ -102,7 +101,6 @@
     <origin rpy="1.570796326794897   0 3.141592653589793" xyz="0 0 0.2025"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.57" effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="left_iiwa_link_2">
@@ -135,7 +133,6 @@
     <origin rpy="1.570796326794897 0 3.141592653589793" xyz="0 0.2045 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.74" effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="left_iiwa_link_3">
@@ -175,7 +172,6 @@
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="11.36" effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="left_iiwa_link_4">
@@ -208,7 +204,6 @@
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.1845 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="12.23" effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="left_iiwa_link_5">
@@ -248,7 +243,6 @@
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="15.72" effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="left_iiwa_link_6">
@@ -281,7 +275,6 @@
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.081 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="15.72" effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-3.01941960595" soft_upper_limit="3.01941960595"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="left_iiwa_link_7">
@@ -487,7 +480,6 @@
     <origin rpy="0 0 0" xyz="0 0 0.1575"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.57" effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.93215314335" soft_upper_limit="2.93215314335"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="right_iiwa_link_1">
@@ -511,7 +503,6 @@
     <origin rpy="1.570796326794897   0 3.141592653589793" xyz="0 0 0.2025"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.57" effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="right_iiwa_link_2">
@@ -544,7 +535,6 @@
     <origin rpy="1.570796326794897 0 3.141592653589793" xyz="0 0.2045 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.74" effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="right_iiwa_link_3">
@@ -584,7 +574,6 @@
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="11.36" effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="right_iiwa_link_4">
@@ -617,7 +606,6 @@
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.1845 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="12.23" effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="right_iiwa_link_5">
@@ -657,7 +645,6 @@
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="15.72" effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="right_iiwa_link_6">
@@ -690,7 +677,6 @@
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.081 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="15.72" effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-3.01941960595" soft_upper_limit="3.01941960595"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="right_iiwa_link_7">

--- a/manipulation/models/iiwa_description/urdf/iiwa14_no_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/iiwa14_no_collision.urdf
@@ -67,7 +67,6 @@
     <origin rpy="0 0 0" xyz="0 0 0.1575"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.57" effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.93215314335" soft_upper_limit="2.93215314335"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_1">
@@ -91,7 +90,6 @@
     <origin rpy="1.570796326794897   0 3.141592653589793" xyz="0 0 0.2025"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.57" effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_2">
@@ -124,7 +122,6 @@
     <origin rpy="1.570796326794897 0 3.141592653589793" xyz="0 0.2045 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.74" effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_3">
@@ -164,7 +161,6 @@
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="11.36" effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_4">
@@ -197,7 +193,6 @@
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.1845 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="12.23" effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_5">
@@ -237,7 +232,6 @@
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="15.72" effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_6">
@@ -270,7 +264,6 @@
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.081 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="15.72" effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-3.01941960595" soft_upper_limit="3.01941960595"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_7">

--- a/manipulation/models/iiwa_description/urdf/iiwa14_polytope_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/iiwa14_polytope_collision.urdf
@@ -73,7 +73,6 @@
     <origin rpy="0 0 0" xyz="0 0 0.1575"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.57" effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.93215314335" soft_upper_limit="2.93215314335"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_1">
@@ -97,7 +96,6 @@
     <origin rpy="1.570796326794897   0 3.141592653589793" xyz="0 0 0.2025"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.57" effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_2">
@@ -130,7 +128,6 @@
     <origin rpy="1.570796326794897 0 3.141592653589793" xyz="0 0.2045 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.74" effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_3">
@@ -170,7 +167,6 @@
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="11.36" effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_4">
@@ -203,7 +199,6 @@
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.1845 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="12.23" effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_5">
@@ -243,7 +238,6 @@
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="15.72" effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_6">
@@ -276,7 +270,6 @@
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.081 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="15.72" effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-3.01941960595" soft_upper_limit="3.01941960595"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_7">

--- a/manipulation/models/iiwa_description/urdf/iiwa14_primitive_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/iiwa14_primitive_collision.urdf
@@ -82,7 +82,6 @@
     <origin rpy="0 0 0" xyz="0 0 0.1575"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.57" effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.93215314335" soft_upper_limit="2.93215314335"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_1">
@@ -113,7 +112,6 @@
     <origin rpy="1.570796326794897   0 3.141592653589793" xyz="0 0 0.2025"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.57" effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_2">
@@ -153,7 +151,6 @@
     <origin rpy="1.570796326794897 0 3.141592653589793" xyz="0 0.2045 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.74" effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_3">
@@ -200,7 +197,6 @@
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="11.36" effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_4">
@@ -240,7 +236,6 @@
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.1845 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="12.23" effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_5">
@@ -287,7 +282,6 @@
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="15.72" effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_6">
@@ -329,7 +323,6 @@
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.081 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="15.72" effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-3.01941960595" soft_upper_limit="3.01941960595"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_7">

--- a/manipulation/models/iiwa_description/urdf/iiwa14_spheres_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/iiwa14_spheres_collision.urdf
@@ -82,7 +82,6 @@
     <origin rpy="0 0 0" xyz="0 0 0.1575"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.57" effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.93215314335" soft_upper_limit="2.93215314335"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_1">
@@ -113,7 +112,6 @@
     <origin rpy="1.570796326794897   0 3.141592653589793" xyz="0 0 0.2025"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.57" effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_2">
@@ -160,7 +158,6 @@
     <origin rpy="1.570796326794897 0 3.141592653589793" xyz="0 0.2045 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.74" effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_3">
@@ -221,7 +218,6 @@
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="11.36" effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_4">
@@ -268,7 +264,6 @@
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.1845 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="12.23" effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_5">
@@ -322,7 +317,6 @@
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="15.72" effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_6">
@@ -362,7 +356,6 @@
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.081 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="15.72" effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-3.01941960595" soft_upper_limit="3.01941960595"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_7">

--- a/manipulation/models/iiwa_description/urdf/iiwa14_spheres_dense_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/iiwa14_spheres_dense_collision.urdf
@@ -103,7 +103,6 @@
     <origin rpy="0 0 0" xyz="0 0 0.1575"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.57" effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.93215314335" soft_upper_limit="2.93215314335"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_1">
@@ -162,7 +161,6 @@
     <origin rpy="1.570796326794897   0 3.141592653589793" xyz="0 0 0.2025"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.57" effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_2">
@@ -258,7 +256,6 @@
     <origin rpy="1.570796326794897 0 3.141592653589793" xyz="0 0.2045 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.74" effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_3">
@@ -361,7 +358,6 @@
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="11.36" effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_4">
@@ -436,7 +432,6 @@
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.1845 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="12.23" effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_5">
@@ -539,7 +534,6 @@
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="15.72" effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_6">
@@ -593,7 +587,6 @@
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.081 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="15.72" effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-3.01941960595" soft_upper_limit="3.01941960595"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_7">

--- a/manipulation/models/iiwa_description/urdf/iiwa14_spheres_dense_elbow_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/iiwa14_spheres_dense_elbow_collision.urdf
@@ -82,7 +82,6 @@
     <origin rpy="0 0 0" xyz="0 0 0.1575"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.57" effort="320" lower="-2.96705972839" upper="2.96705972839" velocity="1.4835298641951802"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.93215314335" soft_upper_limit="2.93215314335"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_1">
@@ -113,7 +112,6 @@
     <origin rpy="1.570796326794897   0 3.141592653589793" xyz="0 0 0.2025"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.57" effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_2">
@@ -160,7 +158,6 @@
     <origin rpy="1.570796326794897 0 3.141592653589793" xyz="0 0.2045 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.74" effort="176" lower="-2.96705972839" upper="2.96705972839" velocity="1.7453292519943295"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_3">
@@ -263,7 +260,6 @@
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="11.36" effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_4">
@@ -338,7 +334,6 @@
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.1845 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="12.23" effort="110" lower="-2.96705972839" upper="2.96705972839" velocity="2.2689280275926285"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_5">
@@ -378,7 +373,6 @@
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="15.72" effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_6">
@@ -425,7 +419,6 @@
     <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.081 0"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="15.72" effort="40" lower="-3.05432619099" upper="3.05432619099" velocity="2.356194490192345"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-3.01941960595" soft_upper_limit="3.01941960595"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_7">

--- a/manipulation/models/iiwa_description/urdf/planar_iiwa14_spheres_dense_elbow_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/planar_iiwa14_spheres_dense_elbow_collision.urdf
@@ -84,7 +84,6 @@
     <origin rpy="1.570796326794897   0 3.141592653589793" xyz="0 0 0.2025"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="8.57" effort="320" lower="-2.09439510239" upper="2.09439510239" velocity="1.4835298641951802"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_2">
@@ -230,7 +229,6 @@
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
     <limit  drake:acceleration="11.36" effort="176" lower="-2.09439510239" upper="2.09439510239" velocity="1.3089969389957472"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_4">
@@ -341,7 +339,6 @@
     <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
     <axis xyz="0 0 1"/>
     <limit drake:acceleration="15.72" effort="40" lower="-2.09439510239" upper="2.09439510239" velocity="2.356194490192345"/>
-    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
     <dynamics damping="0.5"/>
   </joint>
   <link name="iiwa_link_6">

--- a/manipulation/models/jaco_description/BUILD.bazel
+++ b/manipulation/models/jaco_description/BUILD.bazel
@@ -36,6 +36,7 @@ drake_cc_googletest(
 install_data(
     extra_prod_models = _JACO_DESCRIPTION_MESHES + [
         "LICENSE.TXT",
+        "README.md",
     ],
 )
 

--- a/manipulation/models/jaco_description/README.md
+++ b/manipulation/models/jaco_description/README.md
@@ -1,6 +1,7 @@
 # Jaco models
 
-This folder contains models of Kinova Jaco robots, based originally on models from Kinova (see [`LICENSE.TXT`](./LICENSE.TXT) for more information).
+This folder contains models of Kinova Jaco robots, based originally on models
+from Kinova (see [`LICENSE.TXT`](./LICENSE.TXT) for more information).
 
 `urdf/j2n6s300*` are models related to the Jaco v2 6DOF non-spherical robot.
 
@@ -13,3 +14,7 @@ The versions with the `_sphere_collision` suffix use collision
 geometry defined entirely by sphere primitives.  These models were
 created by hand editing the urdf and verifiying the results using
 `//manipulation/util:geometry_inspector`.
+
+In addition, some tags unsupported by Drake have been removed, to reduce the
+burden of warning output. For URDF support details, see:
+https://drake.mit.edu/doxygen_cxx/group__multibody__parsing.html

--- a/manipulation/models/jaco_description/urdf/j2n6s300.urdf
+++ b/manipulation/models/jaco_description/urdf/j2n6s300.urdf
@@ -118,7 +118,6 @@
     </joint>
     <actuator name="j2n6s300_joint_1_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2n6s300_link_2">
@@ -162,7 +161,6 @@
     </joint>
     <actuator name="j2n6s300_joint_2_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2n6s300_link_3">
@@ -206,7 +204,6 @@
     </joint>
     <actuator name="j2n6s300_joint_3_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2n6s300_link_4">
@@ -250,7 +247,6 @@
     </joint>
     <actuator name="j2n6s300_joint_4_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2n6s300_link_5">
@@ -293,7 +289,6 @@
     </joint>
     <actuator name="j2n6s300_joint_5_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2n6s300_link_6">
@@ -336,7 +331,6 @@
     </joint>
     <actuator name="j2n6s300_joint_6_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2n6s300_end_effector">

--- a/manipulation/models/jaco_description/urdf/j2s7s300.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300.urdf
@@ -93,7 +93,6 @@
     </joint>
     <actuator name="j2s7s300_joint_1_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_2">
@@ -136,7 +135,6 @@
     </joint>
     <actuator name="j2s7s300_joint_2_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_3">
@@ -179,7 +177,6 @@
     </joint>
     <actuator name="j2s7s300_joint_3_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_4">
@@ -222,7 +219,6 @@
     </joint>
     <actuator name="j2s7s300_joint_4_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_5">
@@ -265,7 +261,6 @@
     </joint>
     <actuator name="j2s7s300_joint_5_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_6">
@@ -308,7 +303,6 @@
     </joint>
     <actuator name="j2s7s300_joint_6_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_7">
@@ -351,7 +345,6 @@
     </joint>
     <actuator name="j2s7s300_joint_7_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_end_effector">

--- a/manipulation/models/jaco_description/urdf/j2s7s300_arm.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300_arm.urdf
@@ -93,7 +93,6 @@
     </joint>
     <actuator name="j2s7s300_joint_1_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_2">
@@ -136,7 +135,6 @@
     </joint>
     <actuator name="j2s7s300_joint_2_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_3">
@@ -179,7 +177,6 @@
     </joint>
     <actuator name="j2s7s300_joint_3_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_4">
@@ -222,7 +219,6 @@
     </joint>
     <actuator name="j2s7s300_joint_4_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_5">
@@ -265,7 +261,6 @@
     </joint>
     <actuator name="j2s7s300_joint_5_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_6">
@@ -308,7 +303,6 @@
     </joint>
     <actuator name="j2s7s300_joint_6_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_7">
@@ -334,7 +328,6 @@
     </joint>
     <actuator name="j2s7s300_joint_7_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
 </robot>

--- a/manipulation/models/jaco_description/urdf/j2s7s300_arm_sphere_collision.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300_arm_sphere_collision.urdf
@@ -155,7 +155,6 @@
     </joint>
     <actuator name="j2s7s300_joint_1_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_2">
@@ -253,7 +252,6 @@
     </joint>
     <actuator name="j2s7s300_joint_2_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_3">
@@ -357,7 +355,6 @@
     </joint>
     <actuator name="j2s7s300_joint_3_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_4">
@@ -467,7 +464,6 @@
     </joint>
     <actuator name="j2s7s300_joint_4_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_5">
@@ -523,7 +519,6 @@
     </joint>
     <actuator name="j2s7s300_joint_5_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_6">
@@ -579,7 +574,6 @@
     </joint>
     <actuator name="j2s7s300_joint_6_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_7">
@@ -605,7 +599,6 @@
     </joint>
     <actuator name="j2s7s300_joint_7_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
 </robot>

--- a/manipulation/models/jaco_description/urdf/j2s7s300_sphere_collision.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300_sphere_collision.urdf
@@ -155,7 +155,6 @@
     </joint>
     <actuator name="j2s7s300_joint_1_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_2">
@@ -253,7 +252,6 @@
     </joint>
     <actuator name="j2s7s300_joint_2_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_3">
@@ -357,7 +355,6 @@
     </joint>
     <actuator name="j2s7s300_joint_3_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_4">
@@ -467,7 +464,6 @@
     </joint>
     <actuator name="j2s7s300_joint_4_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_5">
@@ -523,7 +519,6 @@
     </joint>
     <actuator name="j2s7s300_joint_5_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_6">
@@ -579,7 +574,6 @@
     </joint>
     <actuator name="j2s7s300_joint_6_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_link_7">
@@ -665,7 +659,6 @@
     </joint>
     <actuator name="j2s7s300_joint_7_actuator">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
-      <mechanicalReduction>160</mechanicalReduction>
     </actuator>
   </transmission>
   <link name="j2s7s300_end_effector">

--- a/multibody/parsing/detail_tinyxml2_diagnostic.cc
+++ b/multibody/parsing/detail_tinyxml2_diagnostic.cc
@@ -8,6 +8,7 @@ namespace internal {
 
 using drake::internal::DiagnosticDetail;
 using drake::internal::DiagnosticPolicy;
+using tinyxml2::XMLElement;
 using tinyxml2::XMLNode;
 
 TinyXml2Diagnostic::TinyXml2Diagnostic(
@@ -55,6 +56,25 @@ DiagnosticPolicy TinyXml2Diagnostic::MakePolicyForNode(
         diagnostic_->Error(MakeDetail(*location, detail.message));
       });
   return result;
+}
+
+void TinyXml2Diagnostic::WarnUnsupportedElement(
+    const XMLElement& node, const std::string& tag) const {
+  const XMLElement* subnode = node.FirstChildElement(tag.c_str());
+  if (subnode) {
+    Warning(*subnode, fmt::format(
+                "The tag '{}' found as a child of '{}' is currently"
+                " unsupported and will be ignored.", tag, node.Name()));
+  }
+}
+
+void TinyXml2Diagnostic::WarnUnsupportedAttribute(
+    const XMLElement& node, const std::string& attribute) const {
+  if (node.Attribute(attribute.c_str())) {
+    Warning(node, fmt::format(
+                "The attribute '{}' found in a '{}' tag is currently"
+                " unsupported and will be ignored.", attribute, node.Name()));
+  }
 }
 
 }  // namespace internal

--- a/multibody/parsing/detail_tinyxml2_diagnostic.h
+++ b/multibody/parsing/detail_tinyxml2_diagnostic.h
@@ -39,6 +39,14 @@ class TinyXml2Diagnostic {
   drake::internal::DiagnosticPolicy MakePolicyForNode(
       const tinyxml2::XMLNode* location) const;
 
+  // Warn about spec-documented elements ignored by Drake.
+  void WarnUnsupportedElement(const tinyxml2::XMLElement& node,
+                              const std::string& tag) const;
+
+  // Warn about spec-documented attributes ignored by Drake.
+  void WarnUnsupportedAttribute(const tinyxml2::XMLElement& node,
+                                const std::string& attribute) const;
+
  private:
   // Makes a diagnostic detail record based on an XMLNode.
   drake::internal::DiagnosticDetail MakeDetail(

--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -583,6 +583,9 @@ std::optional<geometry::GeometryInstance> ParseCollision(
                          parent_element_name, node->Name()));
     return {};
   }
+  // Seen in the ROS urdfdom XSD Schema.
+  // See https://github.com/ros/urdfdom/blob/dbecca0/xsd/urdf.xsd
+  diagnostic.WarnUnsupportedElement(*node, "verbose");
 
   // Ensures there is a geometry child element. Since this is a required
   // element, emits an error if a geometry element does not exist.

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -10,6 +10,7 @@
 #include <unordered_set>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include <Eigen/Dense>
 #include <fmt/format.h>
@@ -105,6 +106,8 @@ class UrdfParser {
         node, attribute_name, val,
         diagnostic_.MakePolicyForNode(node));
   }
+  void ParseMechanicalReduction(const XMLElement& node);
+
 
   void Warning(const XMLNode& location, std::string message) const {
     diagnostic_.Warning(location, std::move(message));
@@ -112,6 +115,17 @@ class UrdfParser {
 
   void Error(const XMLNode& location, std::string message) const {
     diagnostic_.Error(location, std::move(message));
+  }
+
+  // Warn about documented URDF elements ignored by Drake.
+  void WarnUnsupportedElement(const XMLElement& node, const std::string& tag) {
+    diagnostic_.WarnUnsupportedElement(node, tag);
+  }
+
+  // Warn about documented URDF attributes ignored by Drake.
+  void WarnUnsupportedAttribute(const XMLElement& node,
+                                const std::string& attribute) {
+    diagnostic_.WarnUnsupportedAttribute(node, attribute);
   }
 
  private:
@@ -187,6 +201,9 @@ void UrdfParser::ParseBody(XMLElement* node, MaterialMap* materials) {
       drake_ignore == std::string("true")) {
     return;
   }
+  // Seen in the ROS urdfdom XSD Schema.
+  // See https://github.com/ros/urdfdom/blob/dbecca0/xsd/urdf.xsd
+  WarnUnsupportedAttribute(*node, "type");
 
   std::string body_name;
   if (!ParseStringAttribute(node, "name", &body_name)) {
@@ -421,6 +438,9 @@ void UrdfParser::ParseJoint(
       drake_ignore == std::string("true")) {
     return;
   }
+  WarnUnsupportedElement(*node, "calibration");
+  WarnUnsupportedElement(*node, "mimic");
+  WarnUnsupportedElement(*node, "safety_controller");
 
   // Parses the parent and child link names.
   std::string name, type, parent_name, child_name;
@@ -549,9 +569,32 @@ void UrdfParser::ParseJoint(
   joint_effort_limits->emplace(name, effort);
 }
 
+void UrdfParser::ParseMechanicalReduction(const XMLElement& node) {
+  const XMLElement* child = node.FirstChildElement("mechanicalReduction");
+  if (!child) { return; }
+  const char* text = child->GetText();
+  if (!text) { return; }
+  std::vector<double> values = ConvertToDoubles(text);
+  if (values.size() == 1 && values[0] == 1) { return; }
+  Warning(*child, fmt::format(
+              "A '{}' element contains a mechanicalReduction element with a"
+              " value '{}' other than the default of 1. MultibodyPlant does"
+              " not currently support non-default mechanical reductions.",
+              node.Name(), text));
+}
+
 void UrdfParser::ParseTransmission(
     const JointEffortLimits& joint_effort_limits,
     XMLElement* node) {
+  WarnUnsupportedElement(*node, "leftActuator");
+  WarnUnsupportedElement(*node, "rightActuator");
+  WarnUnsupportedElement(*node, "flexJoint");
+  WarnUnsupportedElement(*node, "rollJoint");
+  WarnUnsupportedElement(*node, "gap_joint");
+  WarnUnsupportedElement(*node, "passive_joint");
+  WarnUnsupportedElement(*node, "use_simulated_gripper_joint");
+  ParseMechanicalReduction(*node);
+
   // Determines the transmission type.
   std::string type;
   XMLElement* type_node = node->FirstChildElement("type");
@@ -581,6 +624,8 @@ void UrdfParser::ParseTransmission(
     Error(*node, "Transmission is missing an actuator element.");
     return;
   }
+  ParseMechanicalReduction(*actuator_node);
+  // `actuator/hardwareInterface` child tags are silently ignored.
 
   std::string actuator_name;
   if (!ParseStringAttribute(actuator_node, "name", &actuator_name)) {
@@ -594,6 +639,8 @@ void UrdfParser::ParseTransmission(
     Error(*node, "Transmission is missing a joint element.");
     return;
   }
+  // `joint/hardwareInterface` child tags are silently ignored.
+
 
   std::string joint_name;
   if (!ParseStringAttribute(joint_node, "name", &joint_name)) {
@@ -751,6 +798,9 @@ std::optional<ModelInstanceIndex> UrdfParser::Parse() {
     Error(*xml_doc_, "URDF does not contain a robot tag.");
     return {};
   }
+  // See https://github.com/ros/urdfdom/blob/dbecca0/urdf_parser/src/model.cpp#L124-L131
+  WarnUnsupportedAttribute(*node, "version");
+  // <gazebo> child tags are silently ignored.
 
   std::string model_name = model_name_;
   if (model_name.empty() && !ParseStringAttribute(node, "name", &model_name)) {

--- a/multibody/parsing/parsing_doxygen.h
+++ b/multibody/parsing/parsing_doxygen.h
@@ -37,8 +37,47 @@ Drake supports URDF files as described here: http://wiki.ros.org/urdf/XML.
 For Drake extensions to URDF format files, see
 @ref multibody_parsing_drake_extensions.
 
-Drake's parser does not implement all of the features of URDF. In the future,
-we intend to update this documentation to itemize what isn't supported.
+@subsection multbody_parsing_urdf_unsupported URDF not supported by Drake
+
+Drake's parser does not implement all of the features of URDF. Here is a list
+of known URDF features that Drake does not use. For each, the parser applies
+one of several treaments:
+
+- Issue a warning that the tag is unsued.
+- Ignore silently, as documented below.
+- Apply special treatment, as documented below.
+
+@subsubsection urdf_ignored_warning Tags that provoke a warning
+
+- `/robot/@version`
+- `/robot/joint/calibration`
+- `/robot/joint/mimic`
+- `/robot/joint/safety_controller`
+- `/robot/link/@type`
+- `/robot/link/collision/verbose`
+- `/robot/transmission/@name`
+- `/robot/transmission/flexJoint`
+- `/robot/transmission/gap_joint`
+- `/robot/transmission/leftActuator`
+- `/robot/transmission/passive_joint`
+- `/robot/transmission/rightActuator`
+- `/robot/transmission/rollJoint`
+- `/robot/transmission/use_simulated_gripper_joint`
+
+@subsubsection urdf_ignored_silent Tags ignored silently
+
+- `/robot/gazebo`
+- `/robot/transmission/actuator/hardwareInterface`
+- `/robot/transmission/joint/hardwareInterface`
+
+@subsubsection urdf_ignored_special Tags given special treatment.
+
+- `/robot/transmission/actuator/mechanicalReduction`
+- `/robot/transmission/mechanicalReduction`
+
+Both versions of `mechanicalReduction` will be silently ignored if the supplied
+value is 1; otherwise the they will provoke a warning that the value is being
+ignored.
 
 @section multibody_parsing_drake_extensions Drake Extensions
 

--- a/multibody/parsing/test/detail_tinyxml2_diagnostic_test.cc
+++ b/multibody/parsing/test/detail_tinyxml2_diagnostic_test.cc
@@ -25,7 +25,9 @@ class TinyXml2DiagnosticTest : public test::DiagnosticPolicyTestBase {
 <?xml version="1.0"?>
 <stuff>
   <error/>
-  <warning/>
+  <warning unsupported_attribute='10'>
+    <unsupported_element/>
+  </warning>
 </stuff>
 )""";
   }
@@ -116,6 +118,22 @@ TEST_F(TinyXml2DiagnosticContentsTest, PolicyForNode) {
       diagnostic_.MakePolicyForNode(&GetFirstChildNamed("warning"));
   warning_policy.Warning("meh");
   EXPECT_EQ(TakeWarning(), "<literal-string>.stuff:5: warning: meh");
+}
+
+TEST_F(TinyXml2DiagnosticContentsTest, Unsuppported) {
+  diagnostic_.WarnUnsupportedElement(
+      GetFirstChildNamed("warning"), "unsupported_element");
+  EXPECT_EQ(TakeWarning(),
+            "<literal-string>.stuff:6: warning: The tag 'unsupported_element'"
+            " found as a child of 'warning' is currently unsupported and will"
+            " be ignored.");
+
+  diagnostic_.WarnUnsupportedAttribute(
+      GetFirstChildNamed("warning"), "unsupported_attribute");
+  EXPECT_EQ(TakeWarning(),
+            "<literal-string>.stuff:5: warning: The attribute"
+            " 'unsupported_attribute' found in a 'warning' tag is currently"
+            " unsupported and will be ignored.");
 }
 
 }  // namespace

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -1031,6 +1031,15 @@ TEST_F(UrdfGeometryTest, LegacyDrakeComplianceVsProxProperties) {
   VerifyFriction(properties, {4.5, 4.5});
 }
 
+TEST_F(UrdfGeometryTest, UnsupportedRosUrfdomStuff) {
+  // Not observed in the wild, but seen in the ROS urdfdom XSD Schema.  If
+  // anyone expects this to do something, the warning should make clear that
+  // Drake ignores it.
+  // See https://github.com/ros/urdfdom/blob/dbecca0/xsd/urdf.xsd
+  ParseCollisionDocGood("<verbose value='unknown'/>");
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*verbose.*ignored.*"));
+}
+
 // Confirms that the <drake:accepting_renderer> tag gets properly parsed.
 TEST_F(UrdfGeometryTest, AcceptingRenderers) {
   const std::string file_no_conflict_1 =

--- a/multibody/plant/test/atlas_with_fixed_joints.urdf
+++ b/multibody/plant/test/atlas_with_fixed_joints.urdf
@@ -642,7 +642,6 @@
     <child link="mtorso"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="445" lower="-0.219388" upper="0.538783" velocity="9"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10.2194" soft_upper_limit="10.5388"/>
   </joint>
   <!-- REPLACED revolute with fixed for test purposes. -->
   <joint name="back_bkz" type="fixed">
@@ -657,7 +656,6 @@
     <child link="l_larm"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="112" lower="0" upper="2.35619" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10" soft_upper_limit="12.3562"/>
   </joint>
   <joint name="l_arm_ely" type="revolute">
     <origin rpy="0 0 0" xyz="0 -0.187 -0.016"/>
@@ -666,7 +664,6 @@
     <child link="l_uarm"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="63" lower="0" upper="3.14159" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10" soft_upper_limit="13.1416"/>
   </joint>
   <joint name="l_arm_shx" type="revolute">
     <origin rpy="0 0 0" xyz="0 -0.11 -0.245"/>
@@ -675,7 +672,6 @@
     <child link="l_scap"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="99" lower="-1.5708" upper="1.5708" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-11.5708" soft_upper_limit="11.5708"/>
   </joint>
   <joint name="l_arm_shz" type="revolute">
     <origin rpy="0 0 3.14159265359" xyz="0.1406 0.2256 0.4776"/>
@@ -684,7 +680,6 @@
     <child link="l_clav"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="87" lower="-1.5708" upper="0.785398" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-11.5708" soft_upper_limit="10.7854"/>
   </joint>
   <joint name="l_arm_mwx" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -693,7 +688,6 @@
     <child link="l_lfarm"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="25" lower="-1.7628" upper="1.7628" velocity="10"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-11.7628" soft_upper_limit="11.7628"/>
   </joint>
   <joint name="l_arm_uwy" type="revolute">
     <origin rpy="0 3.14159265359 0" xyz="0 -0.29955 -0.00921"/>
@@ -702,7 +696,6 @@
     <child link="l_ufarm"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="25" lower="-3.011" upper="3.011" velocity="10"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-13.011" soft_upper_limit="13.011"/>
   </joint>
   <joint name="l_arm_lwy" type="revolute">
     <origin rpy="0 3.14159265359 0" xyz="0 0 0"/>
@@ -711,7 +704,6 @@
     <child link="l_hand"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="25" lower="-2.9671" upper="2.9671" velocity="10"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-12.9671" soft_upper_limit="12.9671"/>
   </joint>
   <joint name="l_leg_akx" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -720,7 +712,6 @@
     <child link="l_foot"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="360" lower="-0.8" upper="0.8" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10.8" soft_upper_limit="10.8"/>
   </joint>
   <joint name="l_leg_aky" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 -0.422"/>
@@ -729,7 +720,6 @@
     <child link="l_talus"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="740" lower="-1" upper="0.7" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-11" soft_upper_limit="10.7"/>
   </joint>
   <joint name="l_leg_hpx" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -738,7 +728,6 @@
     <child link="l_lglut"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="530" lower="-0.523599" upper="0.523599" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10.5236" soft_upper_limit="10.5236"/>
   </joint>
   <joint name="l_leg_hpy" type="revolute">
     <origin rpy="0 0 0" xyz="0.05 0.0225 -0.066"/>
@@ -747,7 +736,6 @@
     <child link="l_uleg"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="840" lower="-1.61234" upper="0.65764" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-11.6123" soft_upper_limit="10.6576"/>
   </joint>
   <joint name="l_leg_hpz" type="revolute">
     <origin rpy="0 0 0" xyz="0 0.089 0"/>
@@ -756,7 +744,6 @@
     <child link="l_uglut"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="275" lower="-0.174358" upper="0.786794" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10.1744" soft_upper_limit="10.7868"/>
   </joint>
   <joint name="l_leg_kny" type="revolute">
     <origin rpy="0 0 0" xyz="-0.05 0 -0.374"/>
@@ -765,7 +752,6 @@
     <child link="l_lleg"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="890" lower="0" upper="2.35637" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10" soft_upper_limit="12.3564"/>
   </joint>
   <joint name="neck_ay" type="revolute">
     <origin rpy="0 0 0" xyz="0.2546 0 0.6215"/>
@@ -774,7 +760,6 @@
     <child link="head"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="25" lower="-0.602139" upper="1.14319" velocity="6.28"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10.6021" soft_upper_limit="11.1432"/>
   </joint>
   <joint name="r_arm_elx" type="revolute">
     <origin rpy="0 0 0" xyz="0 -0.119 0.0092"/>
@@ -783,7 +768,6 @@
     <child link="r_larm"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="112" lower="-2.35619" upper="0" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-12.3562" soft_upper_limit="10"/>
   </joint>
   <joint name="r_arm_ely" type="revolute">
     <origin rpy="0 0 0" xyz="0 -0.187 -0.016"/>
@@ -792,7 +776,6 @@
     <child link="r_uarm"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="63" lower="0" upper="3.14159" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10" soft_upper_limit="13.1416"/>
   </joint>
   <joint name="r_arm_shx" type="revolute">
     <origin rpy="0 0 0" xyz="0 -0.11 -0.245"/>
@@ -801,7 +784,6 @@
     <child link="r_scap"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="99" lower="-1.5708" upper="1.5708" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-11.5708" soft_upper_limit="11.5708"/>
   </joint>
   <joint name="r_arm_shz" type="revolute">
     <origin rpy="0 0 0" xyz="0.1406 -0.2256 0.4776"/>
@@ -810,7 +792,6 @@
     <child link="r_clav"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="87" lower="-0.785398" upper="1.5708" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10.7854" soft_upper_limit="11.5708"/>
   </joint>
   <joint name="r_arm_mwx" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -819,7 +800,6 @@
     <child link="r_lfarm"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="25" lower="-1.7628" upper="1.7628" velocity="10"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-11.7628" soft_upper_limit="11.7628"/>
   </joint>
   <joint name="r_arm_uwy" type="revolute">
     <origin rpy="0 0 0" xyz="0 -0.29955 -0.00921"/>
@@ -828,7 +808,6 @@
     <child link="r_ufarm"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="25" lower="-3.011" upper="3.011" velocity="10"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-13.011" soft_upper_limit="13.011"/>
   </joint>
   <joint name="r_arm_lwy" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -837,7 +816,6 @@
     <child link="r_hand"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="25" lower="-2.9671" upper="2.9671" velocity="10"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-12.9671" soft_upper_limit="12.9671"/>
   </joint>
   <joint name="r_leg_akx" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -846,7 +824,6 @@
     <child link="r_foot"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="360" lower="-0.8" upper="0.8" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10.8" soft_upper_limit="10.8"/>
   </joint>
   <joint name="r_leg_aky" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 -0.422"/>
@@ -855,7 +832,6 @@
     <child link="r_talus"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="740" lower="-1" upper="0.7" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-11" soft_upper_limit="10.7"/>
   </joint>
   <joint name="r_leg_hpx" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -864,7 +840,6 @@
     <child link="r_lglut"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="530" lower="-0.523599" upper="0.523599" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10.5236" soft_upper_limit="10.5236"/>
   </joint>
   <joint name="r_leg_hpy" type="revolute">
     <origin rpy="0 0 0" xyz="0.05 -0.0225 -0.066"/>
@@ -873,7 +848,6 @@
     <child link="r_uleg"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="840" lower="-1.61234" upper="0.65764" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-11.6123" soft_upper_limit="10.6576"/>
   </joint>
   <joint name="r_leg_hpz" type="revolute">
     <origin rpy="0 0 0" xyz="0 -0.089 0"/>
@@ -882,7 +856,6 @@
     <child link="r_uglut"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="275" lower="-0.786794" upper="0.174358" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10.7868" soft_upper_limit="10.1744"/>
   </joint>
   <joint name="r_leg_kny" type="revolute">
     <origin rpy="0 0 0" xyz="-0.05 0 -0.374"/>
@@ -891,7 +864,6 @@
     <child link="r_lleg"/>
     <dynamics damping="0.1" friction="0"/>
     <limit effort="890" lower="0" upper="2.35637" velocity="12"/>
-    <safety_controller k_position="100" k_velocity="100" soft_lower_limit="-10" soft_upper_limit="12.3564"/>
   </joint>
   <link name="r_situational_awareness_camera_link">
     <inertial>


### PR DESCRIPTION
Closes: #16783

Based on study of the ROS urdfdom module sources, add warnings for
ignored URDF features. Implementation is similar to the in-progress
mujoco parser, with an eye to future integration of diagnostics there.

Adjust tests for existing files that emit new warnings, and add explicit
tests for each of the added warning types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16953)
<!-- Reviewable:end -->
