### PR TITLE
[workspace] Remove bionic vtk support.

### DIFF
--- a/tools/workspace/vtk/Dockerfile
+++ b/tools/workspace/vtk/Dockerfile
@@ -3,7 +3,7 @@
 # downloaded during the build. They are neither called during the build nor
 # expected to be called by most developers or users of the project.
 
-ARG PLATFORM=ubuntu:18.04
+ARG PLATFORM=ubuntu:20.04
 
 # -----------------------------------------------------------------------------
 # Create a base provisioned image.

--- a/tools/workspace/vtk/build_binaries_with_docker
+++ b/tools/workspace/vtk/build_binaries_with_docker
@@ -45,8 +45,10 @@ extract()
 
 rm -f vtk-*.tar.gz{,.sha256}
 
-build bionic --build-arg PLATFORM=ubuntu:18.04
-extract bionic
-
 build focal --build-arg PLATFORM=ubuntu:20.04
 extract focal
+
+# TODO(#16217): package and distribute jammy archive when it is released.  Make
+# sure to update (1) image/package.sh <build_number> and (2) repository.bzl.
+# build jammy --build-arg PLATFORM=ubuntu:22.04
+# extract jammy

--- a/tools/workspace/vtk/image/package.sh
+++ b/tools/workspace/vtk/image/package.sh
@@ -6,7 +6,7 @@ set -eu -o pipefail
 readonly vtk_tag=vtk-9.1.0
 # To re-package, increase build_number by 1 and update repository.bzl to avoid
 # overwriting artifacts thus breaking historical builds.
-readonly build_number=1
+readonly build_number=2
 readonly platform=$(lsb_release --codename --short)-$(uname --processor)
 
 # Create archive named:

--- a/tools/workspace/vtk/image/prereqs
+++ b/tools/workspace/vtk/image/prereqs
@@ -1,4 +1,5 @@
 ca-certificates
+cmake
 g++
 gcc
 git
@@ -27,5 +28,6 @@ libxml2-dev
 libxt-dev
 lsb-release
 ninja-build
+python-is-python3
 wget
 zlib1g-dev

--- a/tools/workspace/vtk/image/provision.sh
+++ b/tools/workspace/vtk/image/provision.sh
@@ -9,25 +9,3 @@ apt-get -y update
 apt-get -y upgrade
 
 xargs -d$'\n' apt-get -y install --no-install-recommends < /image/prereqs
-
-# Install CMake.
-# To find the right OpenGL library (GLVND) on bionic we need an updated CMake.
-# See: https://apt.kitware.com/
-# TODO(svenevs) Use distro version of CMake when we drop Bionic support.
-apt-get -y install --no-install-recommends gpg lsb-release wget
-readonly KW_ASC="https://apt.kitware.com/keys/kitware-archive-latest.asc"
-wget -O - "$KW_ASC" 2>/dev/null | \
-    gpg --dearmor - | \
-    tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] " \
-    "https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" | \
-    tee /etc/apt/sources.list.d/kitware.list >/dev/null
-apt-get -y update
-apt-get -y install --no-install-recommends kitware-archive-keyring
-apt-get -y install --no-install-recommends \
-    "cmake-data=3.16.3-*" "cmake=3.16.3-*"
-
-# TODO(svenevs): the manual symlink of /usr/bin/python can be removed when
-# bionic support is dropped and the `python-is-python3` package therefore
-# available unconditionally.
-ln -s /usr/bin/python3 /usr/bin/python

--- a/tools/workspace/vtk/repository.bzl
+++ b/tools/workspace/vtk/repository.bzl
@@ -117,12 +117,10 @@ def _impl(repository_ctx):
             VTK_MAJOR_MINOR_PATCH_VERSION,
         ), "include")
     elif os_result.is_ubuntu:
-        if os_result.ubuntu_release == "18.04":
-            archive = "vtk-9.1.0-1-bionic-x86_64.tar.gz"
-            sha256 = "1b51691d09c9fa77a74ad237fe320fed606e071f732f10645efeffa859352bb6"  # noqa
-        elif os_result.ubuntu_release == "20.04":
-            archive = "vtk-9.1.0-1-focal-x86_64.tar.gz"
-            sha256 = "b21e8b98ad71da205305bc074d8e3d4208e9dff307ae716384cefb4d1e606d2f"  # noqa
+        # TODO(#16217): package and distribute 22.04 when released.
+        if os_result.ubuntu_release == "20.04":
+            archive = "vtk-9.1.0-2-focal-x86_64.tar.gz"
+            sha256 = "cd46df9032b67b3bb0c5e1af5c184b2986273911f11b13b08b6222cabff80693"  # noqa
         else:
             fail("Operating system is NOT supported {}".format(os_result))
 


### PR DESCRIPTION
- Rebuild focal VTK archive with updated image setup.
- Stub in preparations for Ubuntu 22.04 Jammy support.
    - In this PR it is commented out in `build_binaries_with_docker`, but the build is successful in producing a `jammy` vtk archive (when uncommenting).

Relates: #13391.

Given that the build setup scripts have been modified (to remove bypasses for needing different things on bionic), the focal archive has been rebuilt and uploaded.  I confirmed that the new VTK build works with an example using `RenderEngineVtk` as expected.