### PR TITLE
[doc] Move macOS profiling instructions

### DIFF
--- a/doc/_pages/bazel.md
+++ b/doc/_pages/bazel.md
@@ -132,7 +132,7 @@ For a Python unittest that uses ``drake_py_unittest``, for example:
 bazel test bindings/pydrake:py/symbolic_test --test_output=streamed --nocache_test_results --test_arg=--trace=user --test_arg=TestSymbolicVariable
 ```
 
-## Debugging and profiling on macOS
+## Debugging on macOS
 
 On macOS, DWARF debug symbols are emitted to a ``.dSYM`` file.  The Bazel
 ``cc_binary`` and ``cc_test`` rules do not natively generate or expose this
@@ -143,15 +143,6 @@ This config turns off sandboxing, which allows a ``genrule`` to access the
 ```
 bazel build --config=apple_debug path/to/my:binary_or_test_dsym
 lldb ./bazel-bin/path/to/my/binary_or_test
-```
-
-Profiling on macOS can be done by building with the debug symbols and then running
-```
-xcrun xctrace record -t "Time Profiler" --launch ./bazel-bin/path/to/my/binary_or_test
-```
-This will generate a `.trace` file that can be opened in the Instruments app:
-```
-open -a Instruments myfile.trace
 ```
 
 For more information, see [https://github.com/bazelbuild/bazel/issues/2537](https://github.com/bazelbuild/bazel/issues/2537).

--- a/doc/_pages/profiling.md
+++ b/doc/_pages/profiling.md
@@ -80,3 +80,25 @@ iterations it runs on each benchmark, which will skew the performance metrics
 you see in the profiler. [You may want to manually specify the number of
 iterations to run on each
 benchmark](https://stackoverflow.com/questions/61843343/how-to-special-case-the-number-of-iterations-in-google-benchmark).
+
+# Debugging and profiling on macOS
+
+On macOS, DWARF debug symbols are emitted to a ``.dSYM`` file.  The Bazel
+``cc_binary`` and ``cc_test`` rules do not natively generate or expose this
+file, so we have implemented a workaround in Drake, ``--config=apple_debug``.
+This config turns off sandboxing, which allows a ``genrule`` to access the
+``.o`` files and process them into a ``.dSYM``.  Use as follows:
+
+```
+bazel build --config=apple_debug path/to/my:binary_or_test_dsym
+lldb ./bazel-bin/path/to/my/binary_or_test
+```
+
+Profiling on macOS can be done by building with the debug symbols and then running
+```
+xcrun xctrace record -t "Time Profiler" --launch ./bazel-bin/path/to/my/binary_or_test
+```
+This will generate a `.trace` file that can be opened in the Instruments app:
+```
+open -a Instruments myfile.trace
+```


### PR DESCRIPTION
Closes: #16856

Move the macOS profiling instructions from the bazel page to the profiling
instruction page; contents are otherwise unchanged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16957)
<!-- Reviewable:end -->
