### PR TITLE
[workspace] Remove bionic pygame, deprecate @pygame_py repository.

### DIFF
--- a/examples/manipulation_station/BUILD.bazel
+++ b/examples/manipulation_station/BUILD.bazel
@@ -195,7 +195,6 @@ drake_py_binary(
     deps = [
         ":differential_ik",
         "//bindings/pydrake",
-        "@pygame_py",
     ],
 )
 
@@ -213,7 +212,6 @@ drake_py_binary(
     deps = [
         ":differential_ik",
         "//bindings/pydrake",
-        "@pygame_py",
     ],
 )
 

--- a/tools/workspace/pygame_py/package-stub.BUILD.bazel
+++ b/tools/workspace/pygame_py/package-stub.BUILD.bazel
@@ -7,4 +7,10 @@ py_library(
     name = "pygame_py",
     srcs = [],
     visibility = ["//visibility:public"],
+    deprecation = (
+        "The @pygame_py repository in drake is deprecated, it no longer " +
+        "provides `pygame` for bionic.  Either use `apt` to install " +
+        "`python3-pygame` or `pip install pygame`.  This stub will be " +
+        "removed on or after 2022-08-01."
+    ),
 )

--- a/tools/workspace/pygame_py/repository.bzl
+++ b/tools/workspace/pygame_py/repository.bzl
@@ -1,36 +1,8 @@
 # -*- python -*-
 
-load("@drake//tools/workspace:os.bzl", "determine_os")
-load("@drake//tools/workspace:pypi_wheel.bzl", "setup_pypi_wheel")
-
 def _impl(repository_ctx):
-    os_result = determine_os(repository_ctx)
-    if os_result.error != None:
-        fail(os_result.error)
-
-    # On Ubuntu 18.04, python3-pygame is not available so we need to use a
-    # wheel.
-    if os_result.is_ubuntu and os_result.ubuntu_release == "18.04":
-        result = setup_pypi_wheel(
-            repository_ctx,
-            package = "pygame",
-            version = "1.9.6",
-            version_pin = True,  # It's not worth upgrading to 2.0.
-            pypi_tag = "cp36-cp36m-manylinux1_x86_64",
-            blake2_256 = "8e24ede6428359f913ed9cd1643dd5533aefeb5a2699cc95bea089de50ead586",  # noqa
-            sha256 = "c895cf9c1b6d1cbba8cb8cc3f5427febcf8aa41a9333697741abeea1c537a350",  # noqa
-            mirrors = repository_ctx.attr.mirrors,
-        )
-        if result.error != None:
-            fail("Unable to complete setup for @{} repository: {}".format(
-                # (forced line break)
-                repository_ctx.name,
-                result.error,
-            ))
-        return
-
-    # On newer Ubuntu, we use python3-pygame from apt.  On macOS, we do not
-    # offer a working @pygame repostory.  Either way, the BUILD is the same.
+    # On Ubuntu, we use python3-pygame from apt.  On macOS, we do not offer a
+    # working @pygame repostory.  Either way, the BUILD is the same.
     repository_ctx.symlink(
         Label("@drake//tools/workspace/pygame_py:package-stub.BUILD.bazel"),
         "BUILD.bazel",


### PR DESCRIPTION
- Bionic support removed, eliminating the need for the PyPI wheel to be obtained.
- As a result, the `@pygame_py` repository is no longer useful and is now deprecated.

For release notes:
- Release notes: removal of deprecated -- bionic support of `pygame` is removed.
- Release notes: newly deprecated -- `@pygame_py` repository is no longer meaningful and will be removed in the future.

Relates: #16945, #13391.  We should discuss this in the meeting, it also relates to #15958 and

https://github.com/RobotLocomotion/drake/blob/d57bec0c4cf87aa46604470fbe5311cd741bb903/tools/wheel/image/setup.py#L17

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16959)
<!-- Reviewable:end -->
