### PR TITLE
[workspace] Update realsense comment melodic => noetic.

### DIFF
--- a/tools/workspace/intel_realsense_ros/repository.bzl
+++ b/tools/workspace/intel_realsense_ros/repository.bzl
@@ -9,8 +9,10 @@ def intel_realsense_ros_repository(
         name = name,
         repository = "IntelRealSense/realsense-ros",
         # N.B. Even though 2.3.x series is not the highest-numbered release, we
-        # are using it here because it aligns with the ROS Melodic version
-        # released for Ubuntu 18.04.
+        # are using it here because it aligns with the ROS Noetic version
+        # released for Ubuntu 20.04.  See:
+        # https://index.ros.org/p/realsense2_camera/github-IntelRealSense-realsense-ros/#noetic
+        # https://github.com/IntelRealSense/realsense-ros/releases
         commit = "2.3.2",
         sha256 = "18c0f90eeea2b64889388e2e441221931e220d1fea06fe6eff8d70442c456459",  # noqa
         build_file = "@drake//tools/workspace/intel_realsense_ros:package.BUILD.bazel",  # noqa


### PR DESCRIPTION
- The version of intel_realsense_ros remains unchanged.
- Add links to enable faster discovery of next release.

Relates: #13391, #16931.

It does not appear like they are producing new releases for noetic, but since officially the [bionic / melodic version](https://github.com/IntelRealSense/realsense-ros/releases/tag/2.3.2) is still there this is not "removal of deprecated". (?)  Just updating the comment so that when we `grep` for bionic / 18.04 this folder no longer shows up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16965)
<!-- Reviewable:end -->
