### PR TITLE
Remove some unneeded clang version checks

### DIFF
--- a/bindings/pydrake/multibody/math_py.cc
+++ b/bindings/pydrake/multibody/math_py.cc
@@ -19,7 +19,7 @@
 // triggered on `py::self -= py::self` for some reason.
 // It is fine to use this at a file-wide scope since in practice we only
 // encounter these warnings in bindings due to pybind11's operators.
-#if (__clang__) && (__clang_major__ >= 9)
+#if (__clang__)
 #pragma GCC diagnostic ignored "-Wself-assign-overloaded"
 #endif
 

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -35,7 +35,7 @@
 #pragma GCC diagnostic push
 // It is fine to use this at a file-wide scope since in practice we only
 // encounter these warnings in bindings due to pybind11's operators.
-#if (__clang__) && (__clang_major__ >= 9)
+#if (__clang__)
 #pragma GCC diagnostic ignored "-Wself-assign-overloaded"
 #endif
 


### PR DESCRIPTION
Remove checks for clang ≥ 9; we have not supported older versions for some time.

I suspect the comment in `math_py.cc` also needs tweaking, but I don't understand what's going on enough to have a proposal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16966)
<!-- Reviewable:end -->
