### PR TITLE
[workspace] Remove bionic support for drake_visualizer.

### DIFF
--- a/tools/workspace/drake_visualizer/Dockerfile
+++ b/tools/workspace/drake_visualizer/Dockerfile
@@ -4,7 +4,7 @@
 # the build nor expected to be called by most developers or users of the
 # project.
 
-ARG PLATFORM=ubuntu:18.04
+ARG PLATFORM=ubuntu:20.04
 
 # -----------------------------------------------------------------------------
 # Create a base provisioned image.

--- a/tools/workspace/drake_visualizer/build_binaries_with_docker
+++ b/tools/workspace/drake_visualizer/build_binaries_with_docker
@@ -45,8 +45,5 @@ extract()
 
 rm -f dv-*.tar.gz{,.sha256}
 
-build bionic --build-arg PLATFORM=ubuntu:18.04
-extract bionic
-
 build focal --build-arg PLATFORM=ubuntu:20.04
 extract focal

--- a/tools/workspace/drake_visualizer/image/package.sh
+++ b/tools/workspace/drake_visualizer/image/package.sh
@@ -59,7 +59,7 @@ readonly platform=$(lsb_release --codename --short)-$(uname --processor)
 #     -<build_number>.tar.gz
 #
 # The <build_number> was introduced to distinguish VTK-8/VTK-9 director split.
-readonly archive=${dv_tag}-${py_tag}-${qt_tag}-${vtk_tag}-${platform}-3.tar.gz
+readonly archive=${dv_tag}-${py_tag}-${qt_tag}-${vtk_tag}-${platform}-4.tar.gz
 
 cd /opt/director
 

--- a/tools/workspace/drake_visualizer/image/prereqs
+++ b/tools/workspace/drake_visualizer/image/prereqs
@@ -1,4 +1,5 @@
 ca-certificates
+cmake
 default-jdk
 file
 g++
@@ -36,6 +37,7 @@ libxt-dev
 lsb-release
 ninja-build
 patchelf
+python-is-python3
 python3-dev
 python3-lxml
 python3-numpy

--- a/tools/workspace/drake_visualizer/image/provision.sh
+++ b/tools/workspace/drake_visualizer/image/provision.sh
@@ -13,31 +13,9 @@ apt-get -y upgrade
 
 xargs -d$'\n' apt-get -y install --no-install-recommends < /image/prereqs
 
-# Install CMake.
-# To find the right OpenGL library (GLVND) on bionic we need an updated CMake.
-# See: https://apt.kitware.com/
-# TODO(svenevs) Use distro version of CMake when we drop Bionic support.
-apt-get -y install --no-install-recommends gpg lsb-release wget
-readonly KW_ASC="https://apt.kitware.com/keys/kitware-archive-latest.asc"
-wget -O - "$KW_ASC" 2>/dev/null | \
-    gpg --dearmor - | \
-    tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] " \
-    "https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" | \
-    tee /etc/apt/sources.list.d/kitware.list >/dev/null
-apt-get -y update
-apt-get -y install --no-install-recommends kitware-archive-keyring
-apt-get -y install --no-install-recommends \
-    "cmake-data=3.16.3-*" "cmake=3.16.3-*"
-
 # Install Bazel.
-apt-get -y install --no-install-recommends unzip
+apt-get -y install --no-install-recommends unzip wget
 cd /tmp
 wget ${BAZEL_ROOT}/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
 bash /tmp/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
 rm /tmp/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
-
-# TODO(svenevs): the manual symlink of /usr/bin/python can be removed when
-# bionic support is dropped and the `python-is-python3` package therefore
-# available unconditionally.
-ln -s /usr/bin/python3 /usr/bin/python

--- a/tools/workspace/drake_visualizer/repository.bzl
+++ b/tools/workspace/drake_visualizer/repository.bzl
@@ -37,13 +37,9 @@ def _impl(repository_ctx):
     if os_result.error != None:
         fail(os_result.error)
 
-    if os_result.ubuntu_release == "18.04":
-        archive = "dv-0.1.0-406-g4c3e570a-python-3.6.9-qt-5.9.5-vtk-8.2.0-bionic-x86_64-3.tar.gz"  # noqa
-        sha256 = "634e208ca23edf8b8e3a6dfed06ff5dff0265b615db9762a2fef815c45fd2e72"  # noqa
-        python_version = "3.6"
-    elif os_result.ubuntu_release == "20.04":
-        archive = "dv-0.1.0-406-g4c3e570a-python-3.8.10-qt-5.12.8-vtk-8.2.0-focal-x86_64-3.tar.gz"  # noqa
-        sha256 = "ccff41d115edfa04fe08856bba7bd80100ea1ec068f5d5c1216fbc9a943df817"  # noqa
+    if os_result.ubuntu_release == "20.04":
+        archive = "dv-0.1.0-406-g4c3e570a-python-3.8.10-qt-5.12.8-vtk-8.2.0-focal-x86_64-4.tar.gz"  # noqa
+        sha256 = "f149a13bbb3966f4004584e843f03a80075e671d6c7d25edd0acb83f4a0fc694"  # noqa
         python_version = "3.8"
     else:
         repository_ctx.file("defs.bzl", "ENABLED = False")


### PR DESCRIPTION
- Any non-focal distribution uses the fail-fast stub.
- Remove references to bionic artifacts.
- Rebuild and deploy new focal drake_visualizer tarball.

Relates: #13391, #16931.

Tested the new archive locally on focal and it works as expected.  In a vanilla docker container for jammy which I just installed `bazel` and a couple of packages (`lsb-release`, `gcc`, `g++`, and `python3-dev` iirc) I will get

```console
$ bazel run //tools:drake_visualizer
DEBUG: /data/tools/workspace/python/repository.bzl:127:14: 

WARNING: Python 3.10 is not a supported / tested version for use with Drake.
  Supported versions on manylinux: ["3.6", "3.7", "3.8", "3.9"]
  From interpreter: /usr/bin/python3

INFO: Analyzed target //tools:drake_visualizer (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tools:drake_visualizer up-to-date:
  bazel-bin/tools/drake_visualizer
INFO: Elapsed time: 0.062s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
error: drake-visualizer was disabled in this build of Drake
```

with the following hack applied to let it build (why it states it is `manylinux`):

```diff
--- a/tools/workspace/drake_visualizer/repository.bzl
+++ b/tools/workspace/drake_visualizer/repository.bzl
@@ -34,8 +34,8 @@ load("@drake//tools/workspace:os.bzl", "determine_os")
 
 def _impl(repository_ctx):
     os_result = determine_os(repository_ctx)
-    if os_result.error != None:
-        fail(os_result.error)
+    # if os_result.error != None:
+    #     fail(os_result.error)
 
     if os_result.ubuntu_release == "20.04":
         archive = "dv-0.1.0-406-g4c3e570a-python-3.8.10-qt-5.12.8-vtk-8.2.0-focal-x86_64-4.tar.gz"  # noqa
diff --git a/tools/workspace/python/repository.bzl b/tools/workspace/python/repository.bzl
index 891f6d12f4..471a4347f9 100644
--- a/tools/workspace/python/repository.bzl
+++ b/tools/workspace/python/repository.bzl
@@ -62,8 +62,8 @@ def repository_python_info(repository_ctx):
     # - `version_major` - major version
     # - `os` - results from `determine_os(...)`
     os_result = determine_os(repository_ctx)
-    if os_result.error != None:
-        fail(os_result.error)
+    # if os_result.error != None:
+    #     fail(os_result.error)
     if os_result.is_macos:
         os_key = os_result.distribution
     elif os_result.is_ubuntu:
```

>   Supported versions on manylinux: ["3.6", "3.7", "3.8", "3.9"]

That should get updated in an unrelated PR: #16973.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16972)
<!-- Reviewable:end -->
