### PR TITLE
[wheel] manylinux 3.6 and 3.7 support dropped.

### DIFF
--- a/tools/workspace/python/repository.bzl
+++ b/tools/workspace/python/repository.bzl
@@ -50,7 +50,7 @@ load("@drake//tools/workspace:os.bzl", "determine_os")
 _VERSION_SUPPORT_MATRIX = {
     "ubuntu:20.04": ["3.8"],
     "macos": ["3.9"],
-    "manylinux": ["3.6", "3.7", "3.8", "3.9"],
+    "manylinux": ["3.8", "3.9"],
 }
 
 def repository_python_info(repository_ctx):


### PR DESCRIPTION
Currently supported: 3.8, 3.9.

Relates: #13391, #16929.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16973)
<!-- Reviewable:end -->
