### PR TITLE
Revert "[fem] Report status of Petsc solver"

### DIFF
--- a/multibody/fem/petsc_symmetric_block_sparse_matrix.h
+++ b/multibody/fem/petsc_symmetric_block_sparse_matrix.h
@@ -12,15 +12,6 @@ namespace multibody {
 namespace fem {
 namespace internal {
 
-// The result from PetscSymmetricBlockSparseMatrix::Solve() used to report the
-// success or failure of the solver.
-enum class PetscSolverStatus {
-  // Successful computation.
-  kSuccess = 0,
-  // The solver could not find a solution due to an internal failure.
-  kFailure = 1,
-};
-
 /* A symmetric block sparse matrix data structure that uses PETSc for storage
  and linear algebra operations. It provides supports for the inverse operator,
  i.e. one can solve for A*x = b where A is this matrix. It also supports
@@ -103,23 +94,19 @@ class PetscSymmetricBlockSparseMatrix {
    @warn The compatibility of the solver and preconditioner type with the
    problem at hand is not checked. Callers need to be careful to choose the
    reasonable combination of solver and preconditioner given the type of matrix.
-   If the solver fails, the value in x will be undefined.
    @pre b.size() == A.rows()
-   @pre x != nullptr and x->size() == b.size()
    @note The matrix/preconditioner will be refactored upon successive call to
    this method even if the matrix hasn't changed.
    @pre Matrix must be assembled. See AssembleIfNecessary(). */
-  [[nodiscard]] PetscSolverStatus Solve(SolverType solver_type,
-                                        PreconditionerType preconditioner_type,
-                                        const VectorX<double>& b,
-                                        EigenPtr<VectorX<double>> x) const;
+  VectorX<double> Solve(SolverType solver_type,
+                        PreconditionerType preconditioner_type,
+                        const VectorX<double>& b) const;
 
-  /* Similar to Solve(), but writes the solution, x, in `b` if the solve is
-   successful. The value in `b` is undefined if the solve fails.
+  /* Similar to Solve(), but writes the result in `b`.
    @pre Matrix must be assembled. See AssembleIfNecessary(). */
-  [[nodiscard]] PetscSolverStatus SolveInPlace(
-      SolverType solver_type, PreconditionerType preconditioner_type,
-      EigenPtr<VectorX<double>> b_in_x_out) const;
+  void SolveInPlace(SolverType solver_type,
+                    PreconditionerType preconditioner_type,
+                    EigenPtr<VectorX<double>> b) const;
 
   /* Sets all blocks to zeros while maintaining the sparsity pattern. */
   void SetZero();

--- a/multibody/fem/test/petsc_symmetric_block_sparse_matrix_test.cc
+++ b/multibody/fem/test/petsc_symmetric_block_sparse_matrix_test.cc
@@ -8,7 +8,6 @@
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
-#include "drake/common/unused.h"
 
 namespace drake {
 namespace multibody {
@@ -138,44 +137,34 @@ GTEST_TEST(PetscSymmetricBlockSparseMatrixTest, MinresSolve) {
   const MatrixXd A_eigen = MakeEigenDenseMatrix();
   const VectorXd b = MakeVector9d();
   const VectorXd x_expected = A_eigen.lu().solve(b);
-  VectorXd x(b.size());
   DRAKE_EXPECT_THROWS_MESSAGE(
-      unused(A->Solve(
-          PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
-          PetscSymmetricBlockSparseMatrix::PreconditionerType::kNone, b, &x)),
+      A->Solve(PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
+               PetscSymmetricBlockSparseMatrix::PreconditionerType::kNone, b),
       "PetscSymmetricBlockSparseMatrix::Solve.*: matrix is not yet "
       "assembled.*");
   A->AssembleIfNecessary();
   A->set_relative_tolerance(kEps);
 
-  x.setZero();
-  PetscSolverStatus status = A->Solve(
+  VectorXd x = A->Solve(
       PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
       PetscSymmetricBlockSparseMatrix::PreconditionerType::kIncompleteCholesky,
-      b, &x);
-  EXPECT_EQ(status, PetscSolverStatus::kSuccess);
+      b);
   EXPECT_TRUE(CompareMatrices(x, x_expected, b.norm() * kEps));
 
-  x.setZero();
-  status = A->Solve(
-      PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
-      PetscSymmetricBlockSparseMatrix::PreconditionerType::kCholesky, b, &x);
-  EXPECT_EQ(status, PetscSolverStatus::kSuccess);
+  x = A->Solve(PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
+               PetscSymmetricBlockSparseMatrix::PreconditionerType::kCholesky,
+               b);
   EXPECT_TRUE(CompareMatrices(x, x_expected, b.norm() * kEps));
 
-  x.setZero();
-  status = A->Solve(PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
-                    PetscSymmetricBlockSparseMatrix::PreconditionerType::kNone,
-                    b, &x);
-  EXPECT_EQ(status, PetscSolverStatus::kSuccess);
+  x = A->Solve(PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
+               PetscSymmetricBlockSparseMatrix::PreconditionerType::kNone, b);
   EXPECT_TRUE(CompareMatrices(x, x_expected, b.norm() * kEps));
 
   /* Test that the result of Solve and SolveInPlace agree with each other. */
   VectorXd x_in_place = b;
-  status = A->SolveInPlace(
-      PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
-      PetscSymmetricBlockSparseMatrix::PreconditionerType::kNone, &x_in_place);
-  EXPECT_EQ(status, PetscSolverStatus::kSuccess);
+  A->SolveInPlace(PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
+                  PetscSymmetricBlockSparseMatrix::PreconditionerType::kNone,
+                  &x_in_place);
   EXPECT_EQ(x, x_in_place);
 }
 
@@ -187,28 +176,22 @@ GTEST_TEST(PetscSymmetricBlockSparseMatrixTest, CgSolve) {
   const VectorXd x_expected = A_eigen.lu().solve(b);
   A->set_relative_tolerance(kEps);
   /* No preconditioning. */
-  VectorXd x(b.size());
-  PetscSolverStatus status = A->Solve(
-      PetscSymmetricBlockSparseMatrix::SolverType::kConjugateGradient,
-      PetscSymmetricBlockSparseMatrix::PreconditionerType::kNone, b, &x);
-  EXPECT_EQ(status, PetscSolverStatus::kSuccess);
+  VectorXd x =
+      A->Solve(PetscSymmetricBlockSparseMatrix::SolverType::kConjugateGradient,
+               PetscSymmetricBlockSparseMatrix::PreconditionerType::kNone, b);
   EXPECT_TRUE(CompareMatrices(x, x_expected, b.norm() * kEps));
 
   /* Cholesky preconditioning. */
-  x.setZero();
-  status = A->Solve(
-      PetscSymmetricBlockSparseMatrix::SolverType::kConjugateGradient,
-      PetscSymmetricBlockSparseMatrix::PreconditionerType::kCholesky, b, &x);
-  EXPECT_EQ(status, PetscSolverStatus::kSuccess);
+  x = A->Solve(PetscSymmetricBlockSparseMatrix::SolverType::kConjugateGradient,
+               PetscSymmetricBlockSparseMatrix::PreconditionerType::kCholesky,
+               b);
   EXPECT_TRUE(CompareMatrices(x, x_expected, b.norm() * kEps));
 
   /* Incomplete Cholesky preconditioning. */
-  x.setZero();
-  status = A->Solve(
+  x = A->Solve(
       PetscSymmetricBlockSparseMatrix::SolverType::kConjugateGradient,
       PetscSymmetricBlockSparseMatrix::PreconditionerType::kIncompleteCholesky,
-      b, &x);
-  EXPECT_EQ(status, PetscSolverStatus::kSuccess);
+      b);
   EXPECT_TRUE(CompareMatrices(x, x_expected, b.norm() * kEps));
 }
 
@@ -220,27 +203,10 @@ GTEST_TEST(PetscSymmetricBlockSparseMatrixTest, DirectSolve) {
   const MatrixXd A_eigen = A->MakeDenseMatrix();
   const VectorXd x_expected = A_eigen.lu().solve(b);
   /* No preconditioning. */
-  VectorXd x(b.size());
-  PetscSolverStatus status = A->Solve(
+  VectorXd x = A->Solve(
       PetscSymmetricBlockSparseMatrix::SolverType::kDirect,
-      PetscSymmetricBlockSparseMatrix::PreconditionerType::kCholesky, b, &x);
-  EXPECT_EQ(status, PetscSolverStatus::kSuccess);
+      PetscSymmetricBlockSparseMatrix::PreconditionerType::kCholesky, b);
   EXPECT_TRUE(CompareMatrices(x, x_expected, b.norm() * kEps));
-}
-
-GTEST_TEST(PetscSymmetricBlockSparseMatrixTest, FailedSolve) {
-  /* Make a non-SPD matrix. */
-  unique_ptr<PetscSymmetricBlockSparseMatrix> A = MakeBlockSparseMatrix();
-  A->set_relative_tolerance(kEps);
-  const VectorXd b = MakeVector3d();
-  A->AssembleIfNecessary();
-  VectorXd x(b.size());
-  PetscSolverStatus status = A->Solve(
-      PetscSymmetricBlockSparseMatrix::SolverType::kConjugateGradient,
-      PetscSymmetricBlockSparseMatrix::PreconditionerType::kIncompleteCholesky,
-      b, &x);
-  /* We expect CG to fail to converge on a non-spd matrix. */
-  EXPECT_EQ(status, PetscSolverStatus::kFailure);
 }
 
 GTEST_TEST(PetscSymmetricBlockSparseMatrixTest, ZeroRowsAndColumns) {
@@ -268,16 +234,13 @@ GTEST_TEST(PetscSymmetricBlockSparseMatrixTest, Clone) {
   A_clone->set_relative_tolerance(kEps);
   EXPECT_EQ(A->MakeDenseMatrix(), A_clone->MakeDenseMatrix());
   const VectorXd b = MakeVector9d();
-  VectorXd x(b.size());
-  PetscSolverStatus status = A->Solve(
+  const VectorXd x =
+      A->Solve(PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
+               PetscSymmetricBlockSparseMatrix::PreconditionerType::kNone, b);
+  const VectorXd x_clone = A_clone->Solve(
       PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
-      PetscSymmetricBlockSparseMatrix::PreconditionerType::kNone, b, &x);
-  VectorXd x_clone(b.size());
-  PetscSolverStatus status_clone = A_clone->Solve(
-      PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
-      PetscSymmetricBlockSparseMatrix::PreconditionerType::kNone, b, &x_clone);
+      PetscSymmetricBlockSparseMatrix::PreconditionerType::kNone, b);
   EXPECT_TRUE(CompareMatrices(x, x_clone, b.norm() * kEps));
-  EXPECT_EQ(status, status_clone);
 }
 
 /* Test if we can run several PETSc solves simultaneously on multiple threads.
@@ -295,11 +258,9 @@ GTEST_TEST(PetscSymmetricBlockSparseMatrixTest, MultiThreadTest) {
   auto run_solver = [](const VectorXd& b, VectorXd* x) {
     unique_ptr<PetscSymmetricBlockSparseMatrix> A = MakeBlockSparseMatrix();
     A->AssembleIfNecessary();
-    x->resize(b.size());
-    PetscSolverStatus status = A->Solve(
-        PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
-        PetscSymmetricBlockSparseMatrix::PreconditionerType::kNone, b, x);
-    EXPECT_EQ(status, PetscSolverStatus::kSuccess);
+    *x =
+        A->Solve(PetscSymmetricBlockSparseMatrix::SolverType::kMINRES,
+                 PetscSymmetricBlockSparseMatrix::PreconditionerType::kNone, b);
   };
 
   /* Solve without using threads. */


### PR DESCRIPTION
Reverts RobotLocomotion/drake#16961

Dear @xuchenhan-tri ,

 The (unofficial) build cop, @svenevs, believes that your PR #16961 may have
 broken one or more of Drake's continuous integration builds [1]. It is
 possible to break a build even if your PR passed continuous integration
 pre-merge because additional platforms are tested post-merge.

 The specific build failures under investigation are:

- https://drake-jenkins.csail.mit.edu/job/linux-focal-clang-bazel-continuous-everything-address-sanitizer/303/console

 Therefore, the build cop has created this revert PR and started a complete
 post-merge build to determine whether your PR was in fact the cause of the
 problem. If that build passes, this revert PR will be merged 60 minutes from
 now. You can then fix the problem at your leisure, and send a new PR to
 reinstate your change.

 If you believe your original PR did not actually break the build, please
 explain on this thread.

 If you believe you can fix the break promptly in lieu of a revert, please
 explain on this thread, and send a PR to the build cop for review ASAP.

 If you believe your original PR definitely did break the build and should be
 reverted, please review and LGTM this PR. This allows the build cop to merge
 without waiting for CI results.

 For advice on how to handle a build cop revert, see [2].

 Thanks!
 Your Friendly On-call Build Cop

 [1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
 [2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16974)
<!-- Reviewable:end -->
