### PR TITLE
[common] Improve symbolic polynomial performance via is_expanded

### DIFF
--- a/common/symbolic_expression_cell.cc
+++ b/common/symbolic_expression_cell.cc
@@ -606,11 +606,18 @@ ostream& ExpressionAdd::DisplayTerm(ostream& os, const bool print_plus,
 
 ExpressionAddFactory::ExpressionAddFactory(
     const double constant, map<Expression, double> expr_to_coeff_map)
-    : constant_{constant}, expr_to_coeff_map_{std::move(expr_to_coeff_map)} {}
+    : is_expanded_(false), constant_{constant},
+      expr_to_coeff_map_{std::move(expr_to_coeff_map)} {
+  // Note that we set is_expanded_ to false to be conservative. We could imagine
+  // inspecting the expr_to_coeff_map to compute a more precise value, but it's
+  // not clear that doing so would improve our overall performance.
+}
 
 ExpressionAddFactory::ExpressionAddFactory(
     const ExpressionAdd& add)
-    : ExpressionAddFactory{add.get_constant(), add.get_expr_to_coeff_map()} {}
+    : ExpressionAddFactory{add.get_constant(), add.get_expr_to_coeff_map()} {
+  is_expanded_ = add.is_expanded();
+}
 
 void ExpressionAddFactory::AddExpression(const Expression& e) {
   if (is_constant(e)) {
@@ -643,6 +650,7 @@ void ExpressionAddFactory::Add(const ExpressionAdd& add) {
 
 ExpressionAddFactory& ExpressionAddFactory::operator=(
     const ExpressionAdd& add) {
+  is_expanded_ = add.is_expanded();
   constant_ = add.get_constant();
   expr_to_coeff_map_ = add.get_expr_to_coeff_map();
   return *this;
@@ -665,7 +673,11 @@ Expression ExpressionAddFactory::GetExpression() const {
     const auto it(expr_to_coeff_map_.cbegin());
     return it->first * it->second;
   }
-  return Expression{make_shared<ExpressionAdd>(constant_, expr_to_coeff_map_)};
+  auto result = make_shared<ExpressionAdd>(constant_, expr_to_coeff_map_);
+  if (is_expanded_) {
+    result->set_expanded();
+  }
+  return Expression{std::move(result)};
 }
 
 void ExpressionAddFactory::AddConstant(const double constant) {
@@ -686,11 +698,22 @@ void ExpressionAddFactory::AddTerm(const double coeff, const Expression& term) {
       // TODO(soonho-tri): The following operation is not sound since it cancels
       // `term` which might contain 0/0 problems.
       expr_to_coeff_map_.erase(it);
+     // Note that we leave is_expanded_ unchanged here. We could imagine
+     // inspecting the new expr_to_coeff_map_ to compute a more precise value,
+     // but it's not clear that doing so would improve our overall performance.
     }
   } else {
     // Case2: term is not found in expr_to_coeff_map_.
     // Add the entry (term, coeff).
     expr_to_coeff_map_.emplace(term, coeff);
+    // If the addend is not a leaf cell (i.e., if it's a cell type that nests
+    // another Expression inside of itself), then conservatively we can no
+    // longer be sure that our ExpressionAdd remains in expanded form. For
+    // example calling `AddTerm(5, 2 + 3 * y)` produces a non-expanded result
+    // `5 * (2 + 3 * y)`, i.e., `{2 + 3 * y} => 5` in the expr_to_coeff_map_.
+    if (!is_variable(term)) {
+      is_expanded_ = false;
+    }
   }
 }
 
@@ -897,12 +920,14 @@ ostream& ExpressionMul::DisplayTerm(ostream& os, const bool print_mul,
 
 ExpressionMulFactory::ExpressionMulFactory(
     const double constant, map<Expression, Expression> base_to_exponent_map)
-    : constant_{constant},
+    : is_expanded_{false}, constant_{constant},
       base_to_exponent_map_{std::move(base_to_exponent_map)} {}
 
 ExpressionMulFactory::ExpressionMulFactory(const ExpressionMul& mul)
     : ExpressionMulFactory{mul.get_constant(),
-                           mul.get_base_to_exponent_map()} {}
+                           mul.get_base_to_exponent_map()} {
+  is_expanded_ = mul.is_expanded();
+}
 
 void ExpressionMulFactory::AddExpression(const Expression& e) {
   if (constant_ == 0.0) {
@@ -932,12 +957,14 @@ void ExpressionMulFactory::Add(const ExpressionMul& mul) {
 }
 
 void ExpressionMulFactory::SetZero() {
+  is_expanded_ = true;
   constant_ = 0.0;
   base_to_exponent_map_.clear();
 }
 
 ExpressionMulFactory& ExpressionMulFactory::operator=(
     const ExpressionMul& mul) {
+  is_expanded_ = mul.is_expanded();
   constant_ = mul.get_constant();
   base_to_exponent_map_ = mul.get_base_to_exponent_map();
   return *this;
@@ -957,8 +984,11 @@ Expression ExpressionMulFactory::GetExpression() const {
     const auto it(base_to_exponent_map_.cbegin());
     return pow(it->first, it->second);
   }
-  return Expression{
-      make_shared<ExpressionMul>(constant_, base_to_exponent_map_)};
+  auto result = make_shared<ExpressionMul>(constant_, base_to_exponent_map_);
+  if (is_expanded_) {
+    result->set_expanded();
+  }
+  return Expression{result};
 }
 
 void ExpressionMulFactory::AddConstant(const double constant) {
@@ -994,11 +1024,28 @@ void ExpressionMulFactory::AddTerm(const Expression& base,
       // TODO(soonho-tri): The following operation is not sound since it can
       // cancels `base` which might include 0/0 problems.
       base_to_exponent_map_.erase(it);
+    } else {
+      // Conservatively, when adjusting an exponent we can no longer be sure
+      // that our ExpressionMul remains in expanded form. Note that it's very
+      // difficult to find a unit test where this line matters (is_expanded_
+      // is almost always "false" here already), but in any case setting this
+      // to false here is conservative (at worst, a performance loss).
+      is_expanded_ = false;
     }
   } else {
     // Product is not found in base_to_exponent_map_. Add the entry (base,
     // exponent).
     base_to_exponent_map_.emplace(base, exponent);
+    // Conservatively, unless the new term is a simple exponentiation between
+    // leaf expressions (i.e., constants or variables, not any cell type that
+    // nests another Expression inside of itself), we can no longer be sure
+    // that our ExpressionMul remains in expanded form.
+    const auto is_leaf_expression = [](const Expression& e) {
+      return is_constant(e) || is_variable(e);
+    };
+    if (!(is_leaf_expression(base) && is_leaf_expression(exponent))) {
+      is_expanded_ = false;
+    }
   }
 }
 

--- a/common/symbolic_expression_cell.h
+++ b/common/symbolic_expression_cell.h
@@ -317,6 +317,7 @@ class ExpressionAddFactory {
    * methods. */
   void AddMap(const std::map<Expression, double>& expr_to_coeff_map);
 
+  bool is_expanded_{true};
   double constant_{0.0};
   std::map<Expression, double> expr_to_coeff_map_;
 };
@@ -420,6 +421,7 @@ class ExpressionMulFactory {
   /* Sets to represent a zero expression. */
   void SetZero();
 
+  bool is_expanded_{true};
   double constant_{1.0};
   std::map<Expression, Expression> base_to_exponent_map_;
 };

--- a/common/test/symbolic_expansion_test.cc
+++ b/common/test/symbolic_expansion_test.cc
@@ -45,7 +45,7 @@ class SymbolicExpansionTest : public ::testing::Test {
     envs_.push_back({{var_x_, 2.2}, {var_y_, 4}, {var_z_, -2.3}});    // + + -
     envs_.push_back({{var_x_, -4.7}, {var_y_, -3}, {var_z_, 3.4}});   // - - +
     envs_.push_back({{var_x_, 3.1}, {var_y_, -3}, {var_z_, -2.5}});   // + - -
-    envs_.push_back({{var_x_, -2.8}, {var_y_, 2}, {var_z_, -2.6}});   // _ + -
+    envs_.push_back({{var_x_, -2.8}, {var_y_, 2}, {var_z_, -2.6}});   // - + -
     envs_.push_back({{var_x_, -2.2}, {var_y_, -4}, {var_z_, -2.3}});  // - - -
   }
 
@@ -57,9 +57,18 @@ class SymbolicExpansionTest : public ::testing::Test {
     });
   }
 
-  // Checks if e == e.Expand().
+  // Checks that e.is_expanded() is already true, and that the e == e.Expand()
+  // invariant holds.
   bool CheckAlreadyExpanded(const Expression& e) {
-    return e.EqualTo(e.Expand());
+    return e.is_expanded() && e.EqualTo(e.Expand());
+  }
+
+  // Checks that e.is_expanded() is conservatively detected as being false, but
+  // that the e == e.Expand() invariant still holds. This means that we could
+  // imagine having `e.is_expanded()` be improved to report `true` in this case,
+  // in the future if we found it helpful.
+  bool CheckUnchangedExpand(const Expression& e) {
+    return !e.is_expanded() && e.EqualTo(e.Expand());
   }
 
   // Checks if e.Expand() == e.Expand().Expand().
@@ -79,22 +88,30 @@ TEST_F(SymbolicExpansionTest, ExpressionAlreadyExpandedPolynomial) {
   EXPECT_TRUE(CheckAlreadyExpanded(-x_));
   EXPECT_TRUE(CheckAlreadyExpanded(3 * x_));
   EXPECT_TRUE(CheckAlreadyExpanded(-2 * x_));
+  EXPECT_TRUE(CheckAlreadyExpanded(-(2 * x_)));
+  EXPECT_TRUE(CheckAlreadyExpanded(x_ + y_));
+  EXPECT_TRUE(CheckAlreadyExpanded(-(x_ + y_)));
   EXPECT_TRUE(CheckAlreadyExpanded(3 * x_ * y_));               // 3xy
   EXPECT_TRUE(CheckAlreadyExpanded(3 * pow(x_, 2) * y_));       // 3x^2y
   EXPECT_TRUE(CheckAlreadyExpanded(3 / 10 * pow(x_, 2) * y_));  // 3/10*x^2y
   EXPECT_TRUE(CheckAlreadyExpanded(-7 + x_ + y_));              // -7 + x + y
   EXPECT_TRUE(CheckAlreadyExpanded(1 + 3 * x_ - 4 * y_));       // 1 + 3x -4y
+  EXPECT_TRUE(CheckAlreadyExpanded(2 * pow(x_, y_)));           // 2x^y
 }
 
 TEST_F(SymbolicExpansionTest, ExpressionAlreadyExpandedPow) {
-  // The following are all already expanded.
-  EXPECT_TRUE(CheckAlreadyExpanded(pow(x_, y_)));            // x^y
-  EXPECT_TRUE(CheckAlreadyExpanded(pow(x_, -1)));            // x^(-1)
-  EXPECT_TRUE(CheckAlreadyExpanded(pow(x_, -1)));            // x^(-1)
-  EXPECT_TRUE(CheckAlreadyExpanded(pow(x_ + y_, -1)));       // (x + y)^(-1)
-  EXPECT_TRUE(CheckAlreadyExpanded(pow(x_ + y_, 0.5)));      // (x + y)^(0.5)
-  EXPECT_TRUE(CheckAlreadyExpanded(pow(x_ + y_, 2.5)));      // (x + y)^(2.5)
-  EXPECT_TRUE(CheckAlreadyExpanded(pow(x_ + y_, x_ - y_)));  // (x + y)^(x - y)
+  EXPECT_TRUE(CheckAlreadyExpanded(3 * pow(2, y_)));         // 3*2^y
+
+  // The following are all already expanded. They do not yet detect and report
+  // `is_expanded() == true` upon construction, but in any case they must not
+  // change form when `Expand()` is called.
+  EXPECT_TRUE(CheckUnchangedExpand(pow(x_, y_)));            // x^y
+  EXPECT_TRUE(CheckUnchangedExpand(pow(x_, -1)));            // x^(-1)
+  EXPECT_TRUE(CheckUnchangedExpand(pow(x_, -1)));            // x^(-1)
+  EXPECT_TRUE(CheckUnchangedExpand(pow(x_ + y_, -1)));       // (x + y)^(-1)
+  EXPECT_TRUE(CheckUnchangedExpand(pow(x_ + y_, 0.5)));      // (x + y)^(0.5)
+  EXPECT_TRUE(CheckUnchangedExpand(pow(x_ + y_, 2.5)));      // (x + y)^(2.5)
+  EXPECT_TRUE(CheckUnchangedExpand(pow(x_ + y_, x_ - y_)));  // (x + y)^(x - y)
 }
 
 TEST_F(SymbolicExpansionTest, ExpressionExpansion) {
@@ -225,9 +242,8 @@ TEST_F(SymbolicExpansionTest, MathFunctions) {
       const Expression e2{f(e.Expand())};
 
       EXPECT_PRED2(ExprEqual, e1, e2);
-      EXPECT_TRUE(e1.is_expanded());
-      EXPECT_TRUE(e2.is_expanded());
       EXPECT_TRUE(CheckAlreadyExpanded(e1));
+      EXPECT_TRUE(CheckAlreadyExpanded(e2));
     }
   }
 }


### PR DESCRIPTION
Towards #16292.

In cases where we are operating on affine expressions over variables, notice when `is_expanded == true` must be true during construction, so that we don't need to re-expand it later.

This yields a ~2x speedup in `BenchmarkSosProgram1` (from approximately 9.8 seconds runtime to 4.3 seconds runtime, on my machine).

As of this change, all calls from the benchmark program to `Expression::Expand` are no-ops; the expression is always already known to be expanded.  Specifically, `bazel run //solvers/benchmarking:benchmark_mathematical_program` passes when using this patch to fail-fast on non-noops:

```patch
diff --git a/common/symbolic_expression.cc b/common/symbolic_expression.cc
index db191a6d0e..d12a617084 100644
--- a/common/symbolic_expression.cc
+++ b/common/symbolic_expression.cc
@@ -213,7 +213,7 @@ Expression Expression::Expand() const {
     // Expand() on the cell.
     return *this;
   }
-
+  DRAKE_UNREACHABLE();
   Expression result = cell().Expand();
   if (!result.is_expanded()) {
     result.mutable_cell().set_expanded();
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16980)
<!-- Reviewable:end -->
