### PR TITLE
Fix install RPATH mangling

### DIFF
--- a/tools/install/installer.py
+++ b/tools/install/installer.py
@@ -69,24 +69,6 @@ def is_relative_link(filepath):
         return None
 
 
-def is_relative_path(path):
-    """Test if a linker path is "relative".
-
-    When fixing linker paths, there are two types of paths we want to rewrite:
-    - Paths starting with `@loader_path`.
-    - Paths into Bazel's private build areas.
-
-    This function tries to identify both. Unfortunately, there does not appear
-    to be a great, reliable way to identify "Bazel's private build areas", so
-    we consider any path containing `/_bazel_` to be such a location.
-    """
-    if path.startswith("@loader_path"):
-        return True
-    if "/_bazel_" in path:
-        return True
-    return False
-
-
 def find_binary_executables():
     """Finds installed files that are binary executables to fix them up later.
 
@@ -235,9 +217,6 @@ def macos_fix_rpaths(basename, dst_full):
     for line in file_output.splitlines():
         # keep only file path, remove version information.
         relative_path = line.split(' (')[0].strip()
-        # If path is relative, it needs to be replaced by absolute path.
-        if not is_relative_path(relative_path):
-            continue
         dep_basename = os.path.basename(relative_path)
         # Look for the absolute path in the dictionary of fixup files to
         # find library paths.


### PR DESCRIPTION
Modify how we adjust RPATHs in installed libraries to rewrite paths to libraries that are being installed, regardless if they are already relative to `@loader_path`.

The reason for skipping already-absolute paths is unclear, since the absolute location is unlikely to be the desired path for the installed library. In particular, MOSEK, for reasons which are unclear, gets linked using an absolute path into the bowels of Bazel's private build area, which is certainly not going to exist on the machine of a user installing from a distribution tarball.

This replaces a previous, somewhat sketchy change that was rushed into production.

+@svenevs for feature review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16991)
<!-- Reviewable:end -->
