### PR TITLE
[geometry] Updates hydroelastic user guide for compliant convex feature.

### DIFF
--- a/multibody/hydroelastics/hydroelastic_user_guide_doxygen.h
+++ b/multibody/hydroelastics/hydroelastic_user_guide_doxygen.h
@@ -591,6 +591,7 @@ indicate what can and cannot be done with hydroelastic contact.
   includes arbitrary meshes defined as OBJs).
 - Drake primitive Shape types (Box, Capsule, Cylinder, Ellipsoid, HalfSpace,
   and Cylinder) can all be used to create compliant hydroelastic bodies.
+- The Drake Convex Shape type can be used as a compliant hydroelastic body.
 
 @subsection hug_not_yet_implemented What can’t you do with hydroelastic contact?
 
@@ -599,8 +600,11 @@ indicate what can and cannot be done with hydroelastic contact.
   supported. If you need rigid-rigid contact, consider hydroelastics with
   fallback (kHydroelasticWithFallback). See @ref hug_enabling on how to deal
   with contact in these cases.
-- Drake Mesh and Convex types cannot currently serve as a compliant
-  hydroelastic geometry.
+- The Drake Mesh Shape type cannot currently serve as a compliant
+  hydroelastic geometry. However, if the mesh is convex, one can use the
+  Drake Convex Shape type as a compliant hydroelastic geometry. To do so, add
+  the custom tag `<drake:declare_convex/>` tag under the `<mesh>` tag in either
+  an SDF or URDF file.
 - Hydroelastics cannot model true deformations given the model does not
   introduce state. Therefore effects such as tangential compliance or
   short time scale waves are not captured by the model.


### PR DESCRIPTION
Adds notes about being able to use the `Convex` type as a compliant geometry in the hydroelastic user guide.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16995)
<!-- Reviewable:end -->
