### PR TITLE
Refactor wheel build script(s)

### DIFF
--- a/tools/wheel/BUILD.bazel
+++ b/tools/wheel/BUILD.bazel
@@ -1,3 +1,22 @@
+load("@drake//tools/skylark:drake_py.bzl", "drake_py_binary")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
-add_lint_tests(python_lint_extra_srcs = ["build-wheels"])
+py_library(
+    name = "module_py",
+    srcs = ["__init__.py"],
+    visibility = [":__subpackages__"],
+    deps = ["//tools:module_py"],
+)
+
+drake_py_binary(
+    name = "builder",
+    srcs = [
+        "wheel_builder/common.py",
+        "wheel_builder/linux.py",
+        "wheel_builder/main.py",
+    ],
+    main = "wheel_builder/main.py",
+    deps = [":module_py"],
+)
+
+add_lint_tests()

--- a/tools/wheel/README.rst
+++ b/tools/wheel/README.rst
@@ -2,8 +2,8 @@ Drake Wheels
 ============
 
 This document briefly explains the process of building Drake wheels, focusing
-primarily on the build-wheels script. The process for publishing wheels is
-described at https://drake.mit.edu/release_playbook.html.
+primarily on the ``//tools/wheel:builder`` Bazel action. The process for
+publishing wheels is described at https://drake.mit.edu/release_playbook.html.
 
 Basic Usage
 -----------

--- a/tools/wheel/__init__.py
+++ b/tools/wheel/__init__.py
@@ -1,0 +1,1 @@
+# Empty Python module `__init__`, required to make this a module.

--- a/tools/wheel/wheel_builder/common.py
+++ b/tools/wheel/wheel_builder/common.py
@@ -1,0 +1,80 @@
+# This file contains shared logic used to build the PyPI wheels. See
+# //tools/wheel:builder for the user interface.
+
+import argparse
+import os
+import re
+import sys
+
+
+def gripe(message):
+    """
+    Prints a message to stderr.
+    """
+    print(message, file=sys.stderr)
+
+
+def die(message, result=1):
+    """
+    Prints a message to stderr and aborts.
+    """
+    gripe(message)
+    sys.exit(result)
+
+
+def _check_version(version):
+    """
+    Returns True iff the given version string matches PEP 440.
+    """
+    return re.match(
+        r'^([1-9][0-9]*!)?(0|[1-9][0-9]*)'
+        r'(\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?'
+        r'(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?'
+        r'([+][a-z0-9]+([-_\.][a-z0-9]+)*)?$',
+        version) is not None
+
+
+def do_main(args, platform):
+    """
+    Entry point; performs the build using the given CLI arguments, platform,
+    and resource root.
+
+    The `platform` must be either a `linux` or `macos` object which provides
+    platform-specific implementations of various operations necessary to
+    complete the build.
+    """
+    module_dir = os.path.dirname(os.path.realpath(__file__))
+    platform.resource_root = os.path.dirname(module_dir)
+
+    # Set up argument parser.
+    parser = argparse.ArgumentParser(
+        prog='build-wheels',
+        description='Build the Drake PyPI wheel(s).')
+
+    parser.add_argument(
+        'version',
+        help='PEP 440 version number with which to label the wheels')
+
+    parser.add_argument(
+        '-o', '--output-dir', metavar='DIR', default=os.path.realpath('.'),
+        help='directory into which to extract wheels (default: .)')
+    parser.add_argument(
+        '-n', '--no-extract', dest='extract', action='store_false',
+        help='build images but do not extract wheels')
+
+    platform.add_build_arguments(parser)
+
+    parser.add_argument(
+        '-t', '--test', action='store_true',
+        help='run tests on wheels')
+
+    platform.add_selection_arguments(parser)
+
+    # Parse arguments.
+    options = parser.parse_args(args)
+    platform.fixup_options(options)
+
+    if not _check_version(options.version):
+        die(f'Version \'{options.version}\' does not conform to PEP 440')
+
+    platform.build(options)

--- a/tools/wheel/wheel_builder/main.py
+++ b/tools/wheel/wheel_builder/main.py
@@ -1,0 +1,18 @@
+# Entry point for the wheel build machinery; run with --help for more details.
+# On Linux, wheels are build using Docker. On macOS, the host environment is
+# used.
+
+import sys
+
+from drake.tools.wheel.wheel_builder.common import die
+from drake.tools.wheel.wheel_builder.common import do_main as main
+
+
+if __name__ == '__main__':
+    if sys.platform == 'linux':
+        from drake.tools.wheel.wheel_builder import linux as platform
+    else:
+        die('Building wheels is not supported on this platform '
+            f'(\'{sys.platform}\')')
+
+    main(args=sys.argv[1:], platform=platform)


### PR DESCRIPTION
Refactor wheel build script(s)
    
Refactor build-wheels script, moving the logic into a "package". This will ultimately simplify things if and when we want to support different (i.e. non-Docker) paradigms for building wheels, by moving key functionality into an abstracted layer that can be replaced by different logic.
    
One major change is that the build-wheels front end has been replaced by `bazel run //tools/wheel:builder`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16996)
<!-- Reviewable:end -->
