### PR TITLE
[SAP] Fixes bug with velocity permutations in SapModel

### DIFF
--- a/multibody/contact_solvers/sap/partial_permutation.cc
+++ b/multibody/contact_solvers/sap/partial_permutation.cc
@@ -80,6 +80,11 @@ int PartialPermutation::permuted_index(int i) const {
   return permutation_[i];
 }
 
+int PartialPermutation::domain_index(int i_permuted) const {
+  DRAKE_THROW_UNLESS(0 <= i_permuted && i_permuted < permuted_domain_size());
+  return inverse_permutation_[i_permuted];
+}
+
 bool PartialPermutation::participates(int i) const {
   DRAKE_THROW_UNLESS(0 <= i && i < domain_size());
   return permutation_[i] >= 0;

--- a/multibody/contact_solvers/sap/partial_permutation.h
+++ b/multibody/contact_solvers/sap/partial_permutation.h
@@ -80,11 +80,18 @@ class PartialPermutation {
   // i_permuted = P(i).
   // @throws a std::runtime_error if i does not particate in the permutation,
   // see participates().
+  // @throws exception if i is not in [0, domain_size()).
   int permuted_index(int i) const;
 
   // Returns `true` if the index i in the domain of the permutation participates
   // in the permutation.
+  // @throws exception if i is not in [0, domain_size()).
   bool participates(int i) const;
+
+  // Returns index i such that i_permuted = P(i), i.e. the inverse mapping from
+  // i_permuted to i.
+  // @throws if i_permuted is not in [0, permuted_domain_size()).
+  int domain_index(int i_permuted) const;
 
   // This method applies this permutation to the elements of x and writes them
   // into x_permuted. That is, x_permuted[permuted_index(i)] = x[i] for all

--- a/multibody/contact_solvers/sap/test/partial_permutation_test.cc
+++ b/multibody/contact_solvers/sap/test/partial_permutation_test.cc
@@ -66,11 +66,20 @@ GTEST_TEST(PartialPermutation, Construction) {
       "Index .* does not participate in this permutation.");
   EXPECT_EQ(p.permuted_index(5), 3);
 
+  // Unit test inverse mapping from the domain of permuted indexes to the domain
+  // of original indexes.
+  EXPECT_EQ(p.domain_index(0), 1);
+  EXPECT_EQ(p.domain_index(1), 3);
+  EXPECT_EQ(p.domain_index(2), 2);
+  EXPECT_EQ(p.domain_index(3), 5);
+
   // Argument index out of bounds.
   EXPECT_THROW(p.participates(6), std::exception);
   EXPECT_THROW(p.participates(-1), std::exception);
   EXPECT_THROW(p.permuted_index(6), std::exception);
   EXPECT_THROW(p.permuted_index(-1), std::exception);
+  EXPECT_THROW(p.domain_index(-1), std::exception);
+  EXPECT_THROW(p.domain_index(4), std::exception);
 }
 
 // Perform the permutation of a VectorXd.


### PR DESCRIPTION
Fixes bug in SapModel when making permutation in velocities and updates tests so that they lead to a non-trivial set of permutations.

@xuchenhan-tri, this fixes the clutter demo!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17004)
<!-- Reviewable:end -->
