### PR TITLE
[doc] Remove broken cloudfront stylesheet links

### DIFF
--- a/doc/doxygen_cxx/doxygen_extra.css
+++ b/doc/doxygen_cxx/doxygen_extra.css
@@ -1,6 +1,3 @@
-/* s3://drake-web/fonts/stylesheet.css */
-@import url('https://dmn3132s4wr9m.cloudfront.net/fonts/stylesheet.css');
-
 /* user agent html.css */
 
 tt, code, kbd, samp {

--- a/doc/pydrake/_static/css/custom.css
+++ b/doc/pydrake/_static/css/custom.css
@@ -1,6 +1,3 @@
-/* s3://drake-web/fonts/stylesheet.css */
-@import url('https://dmn3132s4wr9m.cloudfront.net/fonts/stylesheet.css');
-
 /* user agent html.css */
 
 tt, code, kbd, samp {


### PR DESCRIPTION
I don't know if these ever did anything, but as of today the only thing they do is slow down page loads with repeated DNS NACKs.

Towards #16993.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17005)
<!-- Reviewable:end -->
