### PR TITLE
Speedup MathematicalProgram::NewFreePolynomial.

### DIFF
--- a/common/symbolic_polynomial.cc
+++ b/common/symbolic_polynomial.cc
@@ -342,7 +342,7 @@ Variables GetIndeterminates(const Polynomial::MapType& m) {
   Variables vars;
   for (const pair<const Monomial, Expression>& p : m) {
     const Monomial& m_i{p.first};
-    vars += m_i.GetVariables();
+    vars.insert(m_i.GetVariables());
   }
   return vars;
 }
@@ -351,7 +351,7 @@ Variables GetDecisionVariables(const Polynomial::MapType& m) {
   Variables vars;
   for (const pair<const Monomial, Expression>& p : m) {
     const Expression& e_i{p.second};
-    vars += e_i.GetVariables();
+    vars.insert(e_i.GetVariables());
   }
   return vars;
 }

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -180,11 +180,13 @@ symbolic::Polynomial MathematicalProgram::NewFreePolynomialImpl(
           indeterminates, degree, degree_type);
   const VectorXDecisionVariable coeffs{
       this->NewContinuousVariables(m.size(), coeff_name)};
-  symbolic::Polynomial p;
-  for (int i = 0; i < m.size(); ++i) {
-    p.AddProduct(coeffs(i), m(i));  // p += coeffs(i) * m(i);
+  symbolic::Polynomial::MapType p_map;
+  // Since each entry in m is unique, we construct the polynomial using a map
+  // with m(i) being the map key.
+  for (int i = 0; i < coeffs.rows(); ++i) {
+    p_map.emplace(m(i), coeffs(i));
   }
-  return p;
+  return symbolic::Polynomial(std::move(p_map));
 }
 
 symbolic::Polynomial MathematicalProgram::NewFreePolynomial(


### PR DESCRIPTION
1. Construct the polynomial using map instead of adding each terms.
2. Use Variables.insert instead of += to avoid redundant copying

Before this PR, BenchmarkSosProgram3 takes 14.5s. After this PR it takes 7.1s on my Puget.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17011)
<!-- Reviewable:end -->
