### PR TITLE
[tools] Suppress pybind11 clang warning globally (not via pragmas)

### DIFF
--- a/bindings/pydrake/multibody/math_py.cc
+++ b/bindings/pydrake/multibody/math_py.cc
@@ -12,17 +12,6 @@
 #include "drake/common/drake_deprecated.h"
 #include "drake/multibody/math/spatial_algebra.h"
 
-#pragma GCC diagnostic push
-// Similar to `symbolic_py.cc`, we must suppress `-Wself-assign-overloaded` to
-/// use operators for Apple's clang>=10. However, different than
-// `symbolic_py.cc`, we must also enable this for clang 9 on Bionic, as is
-// triggered on `py::self -= py::self` for some reason.
-// It is fine to use this at a file-wide scope since in practice we only
-// encounter these warnings in bindings due to pybind11's operators.
-#if (__clang__) && (__clang_major__ >= 9)
-#pragma GCC diagnostic ignored "-Wself-assign-overloaded"
-#endif
-
 namespace drake {
 namespace pydrake {
 
@@ -327,5 +316,3 @@ PYBIND11_MODULE(math, m) {
 
 }  // namespace pydrake
 }  // namespace drake
-
-#pragma GCC diagnostic pop

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -32,13 +32,6 @@
 #include "drake/multibody/tree/universal_joint.h"
 #include "drake/multibody/tree/weld_joint.h"
 
-#pragma GCC diagnostic push
-// It is fine to use this at a file-wide scope since in practice we only
-// encounter these warnings in bindings due to pybind11's operators.
-#if (__clang__) && (__clang_major__ >= 9)
-#pragma GCC diagnostic ignored "-Wself-assign-overloaded"
-#endif
-
 namespace drake {
 namespace pydrake {
 
@@ -1044,5 +1037,3 @@ PYBIND11_MODULE(tree, m) {
 
 }  // namespace pydrake
 }  // namespace drake
-
-#pragma GCC diagnostic pop

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -16,20 +16,6 @@
 #include "drake/common/symbolic_latex.h"
 #include "drake/common/symbolic_trigonometric_polynomial.h"
 
-#pragma GCC diagnostic push
-// Apple LLVM version 10.0.1 (clang-1001.0.46.3) and Clang version 7.0.0 add
-// `-Wself-assign-overloaded` to `-Wall`, which generates warnings on
-// Pybind11's operator-overloading idiom that is using py::self (example:
-// `def(py::self + py::self)`). Here, we suppress the warning using
-// `#pragma diagnostic`.
-#if defined(__clang__) &&                                          \
-    ((!(__apple_build_version__) && (__clang_major__ >= 7)) ||     \
-        ((__apple_build_version__) && (__clang_major__ >= 10) &&   \
-            !((__clang_major__ == 10) && (__clang_minor__ == 0) && \
-                (__clang_patchlevel__ == 0))))
-#pragma GCC diagnostic ignored "-Wself-assign-overloaded"
-#endif
-
 namespace drake {
 namespace pydrake {
 
@@ -997,5 +983,3 @@ PYBIND11_MODULE(symbolic, m) {
 }
 }  // namespace pydrake
 }  // namespace drake
-
-#pragma GCC diagnostic pop

--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -60,10 +60,16 @@ def pybind_py_library(
     # output a *.so, so that the target name is similar to what is provided.
     cc_so_target = cc_so_name + PYTHON_EXTENSION_SUFFIX
 
-    # GCC and Clang don't always agree / succeed when inferring storage
-    # duration (#9600). Workaround it for now.
     if COMPILER_ID.endswith("Clang"):
-        copts = ["-Wno-unused-lambda-capture"] + cc_copts
+        copts = cc_copts + [
+            # GCC and Clang don't always agree / succeed when inferring storage
+            # duration (#9600). Workaround it for now.
+            "-Wno-unused-lambda-capture",
+            # pybind11's operator overloading (e.g., .def(py::self + py::self))
+            # spuriously triggers this warning, so we'll suppress it anytime
+            # we're compiling pybind11 modules.
+            "-Wno-self-assign-overloaded",
+        ]
     else:
         copts = cc_copts
 


### PR DESCRIPTION
This is possible now that Clang 9 is our minimum supported version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17015)
<!-- Reviewable:end -->
