### PR TITLE
Include additional diagonal inertias in forward dynamics

### DIFF
--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -906,9 +906,8 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
   //   The `6 x nm` hinge matrix that relates `V_PB_W` (body B's spatial
   //   velocity in its parent body P, expressed in world W) to this node's `nm`
   //   generalized velocities (or mobilities) `v_B` as `V_PB_W = H_PB_W * v_B`.
-  // @param[in] reflected_inertia
-  //   Vector of scalar reflected inertia values for each degree of freedon.
-  //   Used if this body node is the outboard body of a single-dof mobilizer.
+  // @param[in] diagonal_inertias
+  //   Vector of scalar diagonal inertia values for each degree of freedon.
   // @param[out] abic
   //   A pointer to a valid, non nullptr, articulated body cache.
   //
@@ -920,6 +919,8 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
   //
   // @throws std::exception when called on the _root_ node or `abic` is
   // nullptr.
+  // @throws if diagonal_inertias.size() does not much the number of generalized
+  // velocities in the model.
   // TODO(amcastro-tri): Consider specialized BodyNodeImpl implementations that
   // exploit the sparsity pattern of H_PB_W even at compile time. Most common
   // cases are:
@@ -931,11 +932,11 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
       const PositionKinematicsCache<T>& pc,
       const Eigen::Ref<const MatrixUpTo6<T>>& H_PB_W,
       const SpatialInertia<T>& M_B_W,
-      const VectorX<T>& reflected_inertia,
+      const VectorX<T>& diagonal_inertias,
       ArticulatedBodyInertiaCache<T>* abic) const {
     DRAKE_THROW_UNLESS(topology_.body != world_index());
     DRAKE_THROW_UNLESS(abic != nullptr);
-    DRAKE_THROW_UNLESS(reflected_inertia.size() ==
+    DRAKE_THROW_UNLESS(diagonal_inertias.size() ==
                        this->get_parent_tree().num_velocities());
 
     // As a guideline for developers, a summary of the computations performed in
@@ -1050,13 +1051,9 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
       MatrixUpTo6<T> D_B(nv, nv);
       D_B.template triangularView<Eigen::Lower>() = U_B_W * H_PB_W;
 
-      // Add the effect of reflected inertia.
-      // See JointActuator::reflected_inertia().
-      // Reminder: reflected_inertia is implemented only for revolute or
-      // prismatic joints (i.e., single degree-of-freedom joints, hence nv = 1).
-      if (nv == 1) {
-        D_B(0, 0) += reflected_inertia(this->velocity_start());
-      }
+      // Include the effect of additional diagonal inertias. See @ref
+      // additional_diagonal_inertias.
+      D_B.diagonal() += diagonal_inertias.segment(this->velocity_start(), nv);
 
       // Compute the LDLT factorization of D_B as ldlt_D_B.
       // TODO(bobbyluig): Test performance against inverse().

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1866,6 +1866,41 @@ class MultibodyTree {
     vdot_B = D_B⁻¹ * ej_B - g_B_Wᵀ * Aplus_WB,            [Jain, 2010. Alg. 7.2]
   </pre>
 
+  <h3> Additional Diagonal Inertias </h3>
+  @anchor additional_diagonal_inertias
+
+  We can model additional diagonal inertias by considering external generalized
+  forces of the form: <pre>
+    tau_B <-- -d_B * vdot_B + tau_B                                         (17)
+  </pre>
+  That is, we update tau_B to include the term -d_B * vdot_B, for the mobilities
+  of each body B. Such form of the generalized forces can be used to model fluid
+  virtual masses, reflected inertias and/or even effective inertias result of
+  discrete time stepping schemes.
+
+  When Eq. (17) is used into Eq. (14), the update for vdot_B in Eq. (15) remains
+  exactly the same but with D_B updated to: <pre>
+    D_B <-- D_B + d_B
+  </pre>
+  With this modification to D_B, the algorithm remains the same.
+
+  We remark that the modeling of this term is equivalent to adding a diagonal
+  term D = diag{d_B} (the concantenation of each d_B to form the diagonal matrix
+  D) to the mass matrix. This can be seen by considering the Newton-Euler
+  equations of motion: <pre>
+    M⋅v̇ + C⋅v = τ − D⋅v̇
+  </pre>
+  which can then rewritten as: <pre>
+    (M+D)⋅v̇ + C⋅v = τ
+  </pre>
+  resulting on the same Newton-Euler equations but with the updated mass matrix
+  M+D.
+
+  We have not made any assumptions on the sign of the coefficients of D.
+  However, physical models (e.g. reflected rotor inertias) will typically lead
+  to a positive D, making the effective mass matrix M+D more diagonally
+  dominant.
+
   <h3> Notation </h3>
   @anchor forward_dynamics_notation
 
@@ -1940,8 +1975,7 @@ class MultibodyTree {
   // contains `Ab_WB` for the body with node index `body_node_index`.
   void CalcSpatialAccelerationBias(
       const systems::Context<T>& context,
-      std::vector<SpatialAcceleration<T>>* Ab_WB_all)
-      const;
+      std::vector<SpatialAcceleration<T>>* Ab_WB_all) const;
 
   // Computes the articulated body force bias `Zb_Bo_W = Pplus_PB_W * Ab_WB`
   // for each articulated body B. On output `Zb_Bo_W_all[body_node_index]`
@@ -1950,7 +1984,40 @@ class MultibodyTree {
       const systems::Context<T>& context,
       std::vector<SpatialForce<T>>* Zb_Bo_W_all) const;
 
+  /*
+  @anchor forward_dynamics_with_diagonal_terms_apis
+  @name Alternative ABA Signatures to include diagonal inertia terms.
+  These "advanced" level alternative APIs are provided so that we can
+  include the modeling of additional diagonal inertias as discussed in @ref
+  additional_diagonal_inertias. The additional inertias affect both articulated
+  body inertias and bias terms, CalcArticulatedBodyInertiaCache() and
+  CalcArticulatedBodyForceBias() respectively. These in turn must be included in
+  CalcArticulatedBodyForceCache() to compute the ABA force cache needed to
+  finally compute accelerations with CalcArticulatedBodyAccelerations(). */
+  void CalcArticulatedBodyInertiaCache(
+      const systems::Context<T>& context, const VectorX<T>& diagonal_inertias,
+      ArticulatedBodyInertiaCache<T>* abic) const;
+
+  void CalcArticulatedBodyForceBias(
+      const systems::Context<T>& context,
+      const ArticulatedBodyInertiaCache<T>& abic,
+      std::vector<SpatialForce<T>>* Zb_Bo_W_all) const;
+
+  void CalcArticulatedBodyForceCache(
+      const systems::Context<T>& context,
+      const ArticulatedBodyInertiaCache<T>& abic,
+      const std::vector<SpatialForce<T>>& Zb_Bo_W_cache,
+      const MultibodyForces<T>& forces,
+      ArticulatedBodyForceCache<T>* aba_force_cache) const;
+
+  void CalcArticulatedBodyAccelerations(
+      const systems::Context<T>& context,
+      const ArticulatedBodyInertiaCache<T>& abic,
+      const ArticulatedBodyForceCache<T>& aba_force_cache,
+      AccelerationKinematicsCache<T>* ac) const;
   // @}
+
+  // @} Closes "Articulated Body Algorithm Forward Dynamics" Doxygen section.
 
   // @}
   // Closes "Computational methods" Doxygen section.


### PR DESCRIPTION
This PR provides an additional set of MultibodyTree APIs to allow including diagonal inertia terms in forward dynamics computations. That is, we want to solve `v̇` from `(M+D)⋅v̇ + C⋅v = τ`, where D is an additional diagonal term. This diagonal term `D` can be used to model: reflected inertias (continuous system), implicit joint damping (discrete system), implicit joint springs (discrete system), and maybe others.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17016)
<!-- Reviewable:end -->
