### PR TITLE
[parsing] Add API to set strict parsing

### DIFF
--- a/multibody/parsing/parser.cc
+++ b/multibody/parsing/parser.cc
@@ -11,6 +11,7 @@
 namespace drake {
 namespace multibody {
 
+using drake::internal::DiagnosticDetail;
 using internal::AddModelFromSdf;
 using internal::AddModelFromUrdf;
 using internal::AddModelsFromSdf;
@@ -26,6 +27,16 @@ Parser::Parser(
   if (scene_graph != nullptr && !plant->geometry_source_is_registered()) {
     plant->RegisterAsSourceForSceneGraph(scene_graph);
   }
+
+  auto warnings_maybe_strict =
+      [this](const DiagnosticDetail& detail) {
+        if (is_strict_) {
+          diagnostic_policy_.Error(detail);
+        } else {
+          diagnostic_policy_.WarningDefaultAction(detail);
+        }
+      };
+  diagnostic_policy_.SetActionForWarnings(warnings_maybe_strict);
 }
 
 namespace {

--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -38,6 +38,10 @@ class Parser final {
   /// Gets a mutable reference to the PackageMap used by this parser.
   PackageMap& package_map() { return package_map_; }
 
+  /// Cause all subsequent Add*Model*() operations to use strict parsing;
+  /// warnings will be treated as errors.
+  void SetStrictParsing() { is_strict_ = true; }
+
   /// Parses the SDF or URDF file named in @p file_name and adds all of its
   /// model(s) to @p plant.
   ///
@@ -92,6 +96,7 @@ class Parser final {
       const std::string& model_name = {});
 
  private:
+  bool is_strict_{false};
   PackageMap package_map_;
   drake::internal::DiagnosticPolicy diagnostic_policy_;
   MultibodyPlant<double>* const plant_;


### PR DESCRIPTION
Closes: #16954

Add a method to turn on strict parsing, and a test show it changes
diagnostic behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17017)
<!-- Reviewable:end -->
