### PR TITLE
Add symbolic::Variables::operator+=

### DIFF
--- a/common/symbolic_variables.cc
+++ b/common/symbolic_variables.cc
@@ -68,6 +68,16 @@ bool Variables::IsStrictSupersetOf(const Variables& vars) const {
   return IsSupersetOf(vars);
 }
 
+Variables& Variables::operator+=(const Variable& var) {
+  this->insert(var);
+  return *this;
+}
+
+Variables& Variables::operator+=(const Variables& vars) {
+  this->insert(vars);
+  return *this;
+}
+
 bool operator==(const Variables& vars1, const Variables& vars2) {
   return std::equal(vars1.vars_.begin(), vars1.vars_.end(), vars2.vars_.begin(),
                     vars2.vars_.end(), std::equal_to<Variable>{});
@@ -77,18 +87,6 @@ bool operator<(const Variables& vars1, const Variables& vars2) {
   return std::lexicographical_compare(vars1.vars_.begin(), vars1.vars_.end(),
                                       vars2.vars_.begin(), vars2.vars_.end(),
                                       std::less<Variable>{});
-}
-
-// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-Variables operator+=(Variables& vars1, const Variables& vars2) {
-  vars1.insert(vars2);
-  return vars1;
-}
-
-// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-Variables operator+=(Variables& vars, const Variable& var) {
-  vars.insert(var);
-  return vars;
 }
 
 Variables operator+(Variables vars1, const Variables& vars2) {

--- a/common/symbolic_variables.h
+++ b/common/symbolic_variables.h
@@ -137,6 +137,16 @@ class Variables {
 
   friend Variables intersect(const Variables& vars1, const Variables& vars2);
 
+  /**
+   * Updates this Variables with the result of set-union (@p this, @p var).
+   */
+  Variables& operator+=(const Variable& var);
+
+  /**
+   * Updates this Variables with the result of set-union (@p this, @p vars).
+   */
+  Variables& operator+=(const Variables& vars);
+
  private:
   /* Constructs from std::set<Variable>. */
   explicit Variables(std::set<Variable> vars);
@@ -144,12 +154,6 @@ class Variables {
   std::set<Variable> vars_;
 };
 
-/** Updates @p var1 with the result of set-union(@p var1, @p var2). */
-// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-Variables operator+=(Variables& vars1, const Variables& vars2);
-/** Updates @p vars with the result of set-union(@p vars, { @p var }). */
-// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-Variables operator+=(Variables& vars, const Variable& var);
 /** Returns set-union of @p var1 and @p var2. */
 Variables operator+(Variables vars1, const Variables& vars2);
 /** Returns set-union of @p vars and {@p var}. */


### PR DESCRIPTION
This replaces operator+=(symbolic::Variables vars1, symbolic::Variables vars) which unnecessarily calls copying inside the function. Speeds up operator+=.

In benchmark_mathematical_program.cc, sos1 time drops from 2.6s to 2.5s, and sos2 drops from 8s to 6.5s on my P15.

As discussed in https://drakedevelopers.slack.com/archives/C3L92BM2Q/p1650590014510329?thread_ts=1649977461.631799&cid=C3L92BM2Q