### PR TITLE
[examples/quadrotor] hotfix: fix segfault when QuadrotorPlant input port was not connected

### DIFF
--- a/examples/quadrotor/BUILD.bazel
+++ b/examples/quadrotor/BUILD.bazel
@@ -106,6 +106,7 @@ drake_cc_googletest(
     name = "quadrotor_plant_test",
     deps = [
         ":quadrotor_plant",
+        "//common/test_utilities:expect_no_throw",
         "//systems/framework/test_utilities",
     ],
 )

--- a/examples/quadrotor/quadrotor_plant.cc
+++ b/examples/quadrotor/quadrotor_plant.cc
@@ -34,8 +34,8 @@ QuadrotorPlant<T>::QuadrotorPlant(double m_arg, double L_arg,
                                   double kM_arg)
     : systems::LeafSystem<T>(systems::SystemTypeTag<QuadrotorPlant>{}),
       g_{9.81}, m_(m_arg), L_(L_arg), kF_(kF_arg), kM_(kM_arg), I_(I_arg) {
-  // Four inputs -- one for each propellor.
-  this->DeclareInputPort("propellor_force", systems::kVectorValued, 4);
+  // Four inputs -- one for each propeller.
+  this->DeclareInputPort("propeller_force", systems::kVectorValued, 4);
   // State is x ,y , z, roll, pitch, yaw + velocities.
   auto state_index = this->DeclareContinuousState(12);
   this->DeclareStateOutputPort("state", state_index);
@@ -56,7 +56,8 @@ void QuadrotorPlant<T>::DoCalcTimeDerivatives(
     const systems::Context<T> &context,
     systems::ContinuousState<T> *derivatives) const {
   // Get the input value characterizing each of the 4 rotor's aerodynamics.
-  const Vector4<T> u = this->EvalVectorInput(context, 0)->value();
+  const systems::BasicVector<T>* u_vec = this->EvalVectorInput(context, 0);
+  const Vector4<T> u = u_vec ? u_vec->value() : Vector4<T>::Zero();
 
   // For each rotor, calculate the Bz measure of its aerodynamic force on B.
   // Note: B is the quadrotor body and Bz is parallel to each rotor's spin axis.

--- a/examples/quadrotor/quadrotor_plant.h
+++ b/examples/quadrotor/quadrotor_plant.h
@@ -19,10 +19,13 @@ namespace quadrotor {
 /// @system
 /// name: QuadrotorPlant
 /// input_ports:
-/// - propellor_force
+/// - propeller_force
 /// output_ports:
 /// - state
 /// @endsystem
+///
+/// Note: If the propeller_force input port is not connected, then the force is
+/// taken to be zero.
 ///
 /// @tparam_nonsymbolic_scalar
 template <typename T>

--- a/examples/quadrotor/test/quadrotor_plant_test.cc
+++ b/examples/quadrotor/test/quadrotor_plant_test.cc
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/systems/framework/test_utilities/scalar_conversion.h"
 
 namespace drake {
@@ -22,6 +23,15 @@ GTEST_TEST(QuadrotorPlantTest, ToAutoDiff) {
 GTEST_TEST(QuadrotorPlantTest, ToSymbolic) {
   const QuadrotorPlant<double> plant;
   EXPECT_FALSE(is_symbolic_convertible(plant));
+}
+
+// Ensure that DoCalcTimeDerivatives succeeds even if the input port is
+// disconnected.
+GTEST_TEST(QuadrotorPlantTest, NoInput) {
+  const QuadrotorPlant<double> plant;
+  auto context = plant.CreateDefaultContext();
+
+  DRAKE_EXPECT_NO_THROW(plant.EvalTimeDerivatives(*context));
 }
 
 }  // namespace


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17025)
<!-- Reviewable:end -->
