### PR TITLE
[multibody] implements a Wing class to provide basic aerodynamics

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -277,6 +277,7 @@ drake_py_unittest(
         ":models",
         "//manipulation/models/iiwa_description:models",
         "//manipulation/models/wsg_50_description:models",
+        "//multibody:models",
         "//multibody/benchmarks/acrobot:models",
         "//multibody/benchmarks/free_body:models",
     ],

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -23,6 +23,7 @@
 #include "drake/multibody/plant/multibody_plant_config_functions.h"
 #include "drake/multibody/plant/point_pair_contact_info.h"
 #include "drake/multibody/plant/propeller.h"
+#include "drake/multibody/plant/wing.h"
 #include "drake/multibody/tree/spatial_inertia.h"
 
 namespace drake {
@@ -1110,20 +1111,59 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("body_index"),
             py::arg("X_BP") = math::RigidTransform<double>::Identity(),
             py::arg("thrust_ratio") = 1.0, py::arg("moment_ratio") = 0.0,
-            doc.Propeller.ctor.doc_4args)
+            cls_doc.ctor.doc_4args)
         .def(py::init<const std::vector<PropellerInfo>&>(),
-            py::arg("propeller_info"), doc.Propeller.ctor.doc_1args)
+            py::arg("propeller_info"), cls_doc.ctor.doc_1args)
         .def("num_propellers", &Class::num_propellers,
-            doc.Propeller.num_propellers.doc)
+            cls_doc.num_propellers.doc)
         .def("get_command_input_port", &Class::get_command_input_port,
-            py_rvp::reference_internal,
-            doc.Propeller.get_command_input_port.doc)
+            py_rvp::reference_internal, cls_doc.get_command_input_port.doc)
         .def("get_body_poses_input_port", &Class::get_body_poses_input_port,
-            py_rvp::reference_internal,
-            doc.Propeller.get_body_poses_input_port.doc)
+            py_rvp::reference_internal, cls_doc.get_body_poses_input_port.doc)
         .def("get_spatial_forces_output_port",
             &Class::get_spatial_forces_output_port, py_rvp::reference_internal,
-            doc.Propeller.get_spatial_forces_output_port.doc);
+            cls_doc.get_spatial_forces_output_port.doc);
+  }
+
+  // Wing
+  {
+    using Class = Wing<T>;
+    constexpr auto& cls_doc = doc.Wing;
+    auto cls = DefineTemplateClassWithDefault<Class, systems::LeafSystem<T>>(
+        m, "Wing", param, cls_doc.doc);
+    cls  // BR
+        .def(py::init<const BodyIndex&, double,
+                 const math::RigidTransform<double>&, double>(),
+            py::arg("body_index"), py::arg("surface_area"),
+            py::arg("X_BodyWing") = math::RigidTransform<double>::Identity(),
+            py::arg("fluid_density") = Wing<T>::kDefaultFluidDensity,
+            cls_doc.ctor.doc)
+        .def("get_body_poses_input_port", &Class::get_body_poses_input_port,
+            py_rvp::reference_internal, cls_doc.get_body_poses_input_port.doc)
+        .def("get_body_spatial_velocities_input_port",
+            &Class::get_body_spatial_velocities_input_port,
+            py_rvp::reference_internal,
+            cls_doc.get_body_spatial_velocities_input_port.doc)
+        .def("get_wind_velocity_input_port",
+            &Class::get_wind_velocity_input_port, py_rvp::reference_internal,
+            cls_doc.get_wind_velocity_input_port.doc)
+        .def("get_fluid_density_input_port",
+            &Class::get_fluid_density_input_port, py_rvp::reference_internal,
+            cls_doc.get_fluid_density_input_port.doc)
+        .def("get_spatial_force_output_port",
+            &Class::get_spatial_force_output_port, py_rvp::reference_internal,
+            cls_doc.get_spatial_force_output_port.doc)
+        .def("get_aerodynamic_center_output_port",
+            &Class::get_aerodynamic_center_output_port,
+            py_rvp::reference_internal,
+            cls_doc.get_aerodynamic_center_output_port.doc)
+        .def_static("AddToBuilder", &Class::AddToBuilder, py::arg("builder"),
+            py::arg("plant"), py::arg("body_index"), py::arg("surface_area"),
+            py::arg("X_BodyWing") = math::RigidTransform<double>::Identity(),
+            py::arg("fluid_density") = Wing<T>::kDefaultFluidDensity,
+            // Keep alive, ownership: `return` keeps `builder` alive.
+            py::keep_alive<0, 1>(), py_rvp::reference,
+            cls_doc.AddToBuilder.doc);
   }
 
   // NOLINTNEXTLINE(readability/fn_size)

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -66,11 +66,13 @@ from pydrake.multibody.plant import (
     ContactResultsToMeshcat_,
     CoulombFriction_,
     ExternallyAppliedSpatialForce_,
+    MultibodyPlant,
     MultibodyPlant_,
     MultibodyPlantConfig,
     PointPairContactInfo_,
     PropellerInfo,
     Propeller_,
+    Wing,
 )
 from pydrake.multibody.parsing import Parser
 from pydrake.multibody.benchmarks.acrobot import (
@@ -104,6 +106,7 @@ from pydrake.math import (
 )
 from pydrake.systems.analysis import Simulator_
 from pydrake.systems.framework import (
+    DiagramBuilder,
     DiagramBuilder_,
     System_,
     LeafSystem_,
@@ -2196,6 +2199,44 @@ class TestPlant(unittest.TestCase):
 
         prop2 = Propeller_[float]([info, info])
         self.assertEqual(prop2.num_propellers(), 2)
+
+    def test_wing(self):
+        builder = DiagramBuilder()
+        plant = builder.AddSystem(MultibodyPlant(0.0))
+        Parser(plant).AddModelFromFile(
+            FindResourceOrThrow("drake/multibody/models/box.urdf"))
+        plant.Finalize()
+
+        body = plant.GetBodyByName("box")
+
+        # Constructor
+        Wing(body_index=body.index(),
+             surface_area=1.0,
+             X_BodyWing=RigidTransform(),
+             fluid_density=1.0)
+
+        # AddToBuilder
+        wing = Wing.AddToBuilder(builder=builder,
+                                 plant=plant,
+                                 body_index=body.index(),
+                                 surface_area=1.0,
+                                 X_BodyWing=RigidTransform(),
+                                 fluid_density=1.0)
+
+        self.assertIsInstance(wing.get_body_poses_input_port(),
+                              InputPort_[float])
+        self.assertIsInstance(wing.get_body_spatial_velocities_input_port(),
+                              InputPort_[float])
+        self.assertIsInstance(wing.get_body_poses_input_port(),
+                              InputPort_[float])
+        self.assertIsInstance(wing.get_wind_velocity_input_port(),
+                              InputPort_[float])
+        self.assertIsInstance(wing.get_fluid_density_input_port(),
+                              InputPort_[float])
+        self.assertIsInstance(wing.get_spatial_force_output_port(),
+                              OutputPort_[float])
+        self.assertIsInstance(wing.get_aerodynamic_center_output_port(),
+                              OutputPort_[float])
 
     def test_hydroelastic_contact_results(self):
         time_steps = [

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -34,6 +34,7 @@ drake_cc_package_library(
         ":point_pair_contact_info",
         ":propeller",
         ":tamsi_solver",
+        ":wing",
     ],
 )
 
@@ -324,6 +325,15 @@ drake_cc_library(
     name = "propeller",
     srcs = ["propeller.cc"],
     hdrs = ["propeller.h"],
+    deps = [
+        ":multibody_plant_core",
+    ],
+)
+
+drake_cc_library(
+    name = "wing",
+    srcs = ["wing.cc"],
+    hdrs = ["wing.h"],
     deps = [
         ":multibody_plant_core",
     ],
@@ -796,6 +806,18 @@ drake_cc_googletest(
         ":propeller",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+        "//systems/framework",
+    ],
+)
+
+drake_cc_googletest(
+    name = "wing_test",
+    data = ["//multibody:models"],
+    deps = [
+        ":wing",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+        "//multibody/parsing",
         "//systems/framework",
     ],
 )

--- a/multibody/plant/test/wing_test.cc
+++ b/multibody/plant/test/wing_test.cc
@@ -1,0 +1,165 @@
+#include "drake/multibody/plant/wing.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+using Eigen::Vector3d;
+
+GTEST_TEST(WingTest, BasicTest) {
+  MultibodyPlant<double> plant(0.0);
+  Parser(&plant).AddModelFromFile(
+      FindResourceOrThrow("drake/multibody/models/box.urdf"));
+  plant.Finalize();
+
+  const Body<double>& body = plant.GetBodyByName("box");
+  Wing<double> wing(body.index(), 1.0);
+
+  EXPECT_EQ(wing.num_input_ports(), 4);
+  EXPECT_EQ(wing.num_output_ports(), 2);
+}
+
+// A falling box with a flat plate wing.
+GTEST_TEST(WingTest, FallingFlatPlate) {
+  const double kRho = 1.3;
+  const double kSurfaceArea = 4.15;
+  systems::DiagramBuilder<double> builder;
+
+  auto* plant = builder.AddSystem<MultibodyPlant<double>>(0);
+  Parser(plant).AddModelFromFile(
+      FindResourceOrThrow("drake/multibody/models/box.urdf"));
+  plant->Finalize();
+
+  const Body<double>& body = plant->GetBodyByName("box");
+  Wing<double>* wing = Wing<double>::AddToBuilder(
+      &builder, plant, body.index(), kSurfaceArea,
+      math::RigidTransform<double>::Identity(), kRho);
+
+  auto diagram = builder.Build();
+  auto context = diagram->CreateDefaultContext();
+
+  systems::Context<double>& plant_context =
+      plant->GetMyMutableContextFromRoot(context.get());
+  const Vector6<double> vdot_gravity_only =
+      plant->CalcGravityGeneralizedForces(plant_context);
+
+  systems::Context<double>& wing_context =
+      wing->GetMyMutableContextFromRoot(context.get());
+
+  EXPECT_EQ(wing->get_aerodynamic_center_output_port().Eval(wing_context),
+            Vector3d::Zero());
+
+  {  // Zero velocity.
+    const SpatialVelocity<double> V_WB(Vector3d::Zero(), Vector3d::Zero());
+    plant->SetFreeBodySpatialVelocity(&plant_context, body, V_WB);
+
+    const Vector6<double> vdot_expected = vdot_gravity_only;
+    EXPECT_TRUE(CompareMatrices(plant->EvalTimeDerivatives(plant_context)
+                                    .get_generalized_velocity()
+                                    .CopyToVector(),
+                                vdot_expected, 1e-14));
+  }
+
+  {  // Falling straight down.
+    const double zdot = -1.23;
+    const SpatialVelocity<double> V_WB(Vector3d::Zero(), Vector3d{0, 0, zdot});
+    plant->SetFreeBodySpatialVelocity(&plant_context, body, V_WB);
+
+    Vector6<double> vdot_expected = vdot_gravity_only;
+    vdot_expected[5] += kRho * kSurfaceArea * zdot * zdot;
+    EXPECT_TRUE(CompareMatrices(plant->EvalTimeDerivatives(plant_context)
+                                    .get_generalized_velocity()
+                                    .CopyToVector(),
+                                vdot_expected, 1e-14));
+  }
+
+  {  // Falling straight up.
+    const double zdot = 1.23;
+    const SpatialVelocity<double> V_WB(Vector3d::Zero(), Vector3d{0, 0, zdot});
+    plant->SetFreeBodySpatialVelocity(&plant_context, body, V_WB);
+
+    Vector6<double> vdot_expected = vdot_gravity_only;
+    vdot_expected[5] -= kRho * kSurfaceArea * zdot * zdot;
+    EXPECT_TRUE(CompareMatrices(plant->EvalTimeDerivatives(plant_context)
+                                    .get_generalized_velocity()
+                                    .CopyToVector(),
+                                vdot_expected, 1e-14));
+  }
+
+  {  // Falling straight down, with orientation.
+    const math::RotationMatrix<double> R_WB(
+        math::RollPitchYaw<double>(0.1, 0.2, 0.3));
+    plant->SetFreeBodyPose(&plant_context, body,
+                           math::RigidTransform<double>(R_WB));
+    const double zdot = -1.23;
+    const SpatialVelocity<double> V_WB(Vector3d::Zero(), Vector3d{0, 0, zdot});
+    plant->SetFreeBodySpatialVelocity(&plant_context, body, V_WB);
+
+    Vector6<double> vdot_expected = vdot_gravity_only;
+    Vector3<double> v_WindBody_Wing  = R_WB.transpose()*V_WB.translational();
+    const double longitudinal_velocity_norm =
+      Eigen::Vector2d(v_WindBody_Wing[0], v_WindBody_Wing[2]).norm();
+    vdot_expected.tail<3>() +=
+        R_WB * Vector3d{0, 0,
+                        -kRho * kSurfaceArea * v_WindBody_Wing[2] *
+                            longitudinal_velocity_norm};
+    EXPECT_TRUE(CompareMatrices(plant->EvalTimeDerivatives(plant_context)
+                                    .get_generalized_velocity()
+                                    .CopyToVector(),
+                                vdot_expected, 1e-14));
+  }
+
+  {  // Zero ground velocity, but with wind.
+    const math::RotationMatrix<double> R_WWind(
+        math::RollPitchYaw<double>(0.4, 0.5, 0.6));
+    const double kWindMagnitude = 1.23;
+    Vector3d v_wind = R_WWind * Vector3d{0, 0, kWindMagnitude};
+    wing->get_wind_velocity_input_port().FixValue(&wing_context, v_wind);
+    plant->SetFreeBodyPose(&plant_context, body,
+                           math::RigidTransform<double>());
+    const SpatialVelocity<double> V_WB(Vector3d::Zero(), Vector3d::Zero());
+    plant->SetFreeBodySpatialVelocity(&plant_context, body, V_WB);
+
+    Vector6<double> vdot_expected = vdot_gravity_only;
+    // force in z = ρ S (normal⋅v) |v|, where the normal here is (0, 0, 1).
+    const double longitudinal_velocity_norm =
+        Eigen::Vector2d(v_wind[0], v_wind[2]).norm();
+    vdot_expected.tail<3>() += Vector3d{
+        0, 0, kRho * kSurfaceArea * v_wind[2] * longitudinal_velocity_norm};
+    EXPECT_TRUE(CompareMatrices(plant->EvalTimeDerivatives(plant_context)
+                                    .get_generalized_velocity()
+                                    .CopyToVector(),
+                                vdot_expected, 1e-14));
+  }
+}
+
+// Test that I can perform scalar conversion.
+GTEST_TEST(WingTest, ScalarConversion) {
+  systems::DiagramBuilder<double> builder;
+
+  auto* plant = builder.AddSystem<MultibodyPlant<double>>(0);
+  Parser(plant).AddModelFromFile(
+      FindResourceOrThrow("drake/multibody/models/box.urdf"));
+  plant->Finalize();
+
+  const Body<double>& body = plant->GetBodyByName("box");
+  Wing<double>::AddToBuilder(&builder, plant, body.index(), 1.0);
+
+  auto diagram = builder.Build();
+
+  diagram->ToAutoDiffXd();
+  diagram->ToSymbolic();
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/wing.cc
+++ b/multibody/plant/wing.cc
@@ -1,0 +1,113 @@
+#include "drake/multibody/plant/wing.h"
+
+namespace drake {
+namespace multibody {
+
+using math::RigidTransform;
+
+template <typename T>
+Wing<T>::Wing(BodyIndex body_index, double surface_area,
+              const math::RigidTransform<double>& X_BodyWing,
+              double fluid_density)
+    : systems::LeafSystem<T>(systems::SystemTypeTag<Wing>{}),
+      body_index_(body_index),
+      X_BodyWing_(X_BodyWing),
+      surface_area_(surface_area),
+      default_fluid_density_(fluid_density) {
+  const systems::InputPortIndex body_poses_index =
+      this->DeclareAbstractInputPort("body_poses",
+                                     Value<std::vector<RigidTransform<T>>>())
+          .get_index();
+
+  this->DeclareAbstractInputPort("body_spatial_velocities",
+                                 Value<std::vector<SpatialVelocity<T>>>());
+
+  this->DeclareVectorInputPort("wind_velocity_at_aerodynamic_center", 3);
+
+  this->DeclareVectorInputPort("fluid_density", 1);
+
+  this->DeclareAbstractOutputPort("spatial_force", &Wing<T>::CalcSpatialForce);
+
+  this->DeclareVectorOutputPort("aerodynamic_center", 3,
+                                &Wing<T>::CalcAerodynamicCenter,
+                                {this->input_port_ticket(body_poses_index)});
+}
+
+template <typename T>
+Wing<T>* Wing<T>::AddToBuilder(systems::DiagramBuilder<T>* builder,
+                               const multibody::MultibodyPlant<T>* plant,
+                               const BodyIndex& body_index, double surface_area,
+                               const math::RigidTransform<double>& X_BodyWing,
+                               double fluid_density) {
+  Wing<T>* wing = builder->template AddSystem<Wing<T>>(
+      body_index, surface_area, X_BodyWing, fluid_density);
+  builder->Connect(plant->get_body_poses_output_port(),
+                   wing->get_body_poses_input_port());
+  builder->Connect(plant->get_body_spatial_velocities_output_port(),
+                   wing->get_body_spatial_velocities_input_port());
+  builder->Connect(wing->get_spatial_force_output_port(),
+                   plant->get_applied_spatial_force_input_port());
+  return wing;
+}
+
+template <typename T>
+void Wing<T>::CalcSpatialForce(
+    const systems::Context<T>& context,
+    std::vector<ExternallyAppliedSpatialForce<T>>* spatial_force) const {
+  spatial_force->resize(1);
+  const RigidTransform<T>& X_WorldBody =
+      get_body_poses_input_port().template Eval<std::vector<RigidTransform<T>>>(
+          context)[body_index_];
+  const SpatialVelocity<T>& V_WorldBody =
+      get_body_spatial_velocities_input_port()
+          .template Eval<std::vector<SpatialVelocity<T>>>(context)[body_index_];
+
+  const T fluid_density = get_fluid_density_input_port().HasValue(context)
+                              ? get_fluid_density_input_port().Eval(context)[0]
+                              : default_fluid_density_;
+  Vector3<T> v_WorldWind = Vector3<T>::Zero();
+  if (get_wind_velocity_input_port().HasValue(context)) {
+    v_WorldWind = get_wind_velocity_input_port().Eval(context);
+  }
+  const Vector3<T> v_WindBody_World =
+      -v_WorldWind + V_WorldBody.translational();
+
+  const math::RotationMatrix<T> R_WorldWing =
+      X_WorldBody.rotation() * X_BodyWing_.rotation().template cast<T>();
+
+  const Vector3<T> v_WindBody_Wing = R_WorldWing.transpose() * v_WindBody_World;
+
+  // The aerodynamic force from a flat plate is summarized by a single force at
+  // the aerodynamic center acting normal to the wing.  See
+  // http://underactuated.csail.mit.edu/trajopt.html#perching and the
+  // corresponding references.
+  SpatialForce<T> F_Wing_Wing = SpatialForce<T>::Zero();
+  const T longitudinal_velocity_norm =
+      Vector2<T>(v_WindBody_Wing[0], v_WindBody_Wing[2]).norm();
+  F_Wing_Wing.translational()[2] = -fluid_density * surface_area_ *
+                                   v_WindBody_Wing[2] *
+                                   longitudinal_velocity_norm;
+
+  ExternallyAppliedSpatialForce<T>& force = spatial_force->at(0);
+  force.body_index = body_index_;
+  force.p_BoBq_B = X_BodyWing_.translation();
+  force.F_Bq_W = R_WorldWing * F_Wing_Wing;
+}
+
+template <typename T>
+void Wing<T>::CalcAerodynamicCenter(
+    const systems::Context<T>& context,
+    systems::BasicVector<T>* aerodynamic_center) const {
+  const RigidTransform<T>& X_WorldBody =
+      get_body_poses_input_port().template Eval<std::vector<RigidTransform<T>>>(
+          context)[body_index_];
+
+  aerodynamic_center->SetFromVector(
+      X_WorldBody * X_BodyWing_.translation().template cast<T>());
+}
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::multibody::Wing)

--- a/multibody/plant/wing.h
+++ b/multibody/plant/wing.h
@@ -1,0 +1,196 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/plant/externally_applied_spatial_force.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/tree/body.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace multibody {
+
+/** A System that connects to the MultibodyPlant in order to model the
+simplified dynamics of an airfoil (or hydrofoil).  Currently it only supports
+a particular model of flat-plate aerodynamics with
+  lift coefficient = 2 sinα cosα,
+  drag coefficient = 2 sin²α,
+  moment coefficient = 0,
+as documented in
+
+[Cory08] Rick Cory and Russ Tedrake, "Experiments in Fixed-Wing {UAV} Perching",
+Proceedings of the AIAA Guidance, Navigation, and Control Conference , pp. 1-12,
+2008.
+
+This model was empirically validated for a bird-scale UAV with flat-plate wings,
+and may generalize well as a model for other wings in the post-stall regime, but
+it should only be viewed as a very simple / coarse approximation.  We aim
+generalize this class to general lift/drag/moment coefficients soon.
+
+@system
+name: Wing
+input_ports:
+- body_poses
+- body_spatial_velocities
+- wind_velocity_at_aerodynamic_center (optional)
+- fluid_density (optional)
+output_ports:
+- spatial_force
+- aerodynamic_center
+@endsystem
+
+- The optional wind velocity input is a three-element BasicVector<T>
+  representing the translational velocity of the wind in world coordinates at
+  the aerodynamic center relative to the world origin.  See
+  get_aerodynamic_center_output_port() for more details.
+- It is expected that the body_poses input should be connected to the
+  @ref MultibodyPlant::get_body_poses_output_port() "MultibodyPlant body_poses
+  output port" and that body_spatial_velocities input should be connected to
+  the @ref MultibodyPlant::get_body_spatial_velocities_output_port()
+  "MultibodyPlant body_spatial_velocities output port"
+- The output is of type std::vector<ExternallyAppliedSpatialForce<T>>; it is
+  expected that this output will be connected to the @ref
+  MultibodyPlant::get_applied_spatial_force_input_port()
+  "externally_applied_spatial_force input port" of the MultibodyPlant.
+
+@tparam_default_scalar
+@ingroup multibody_systems
+*/
+template <typename T>
+class Wing final : public systems::LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Wing);
+
+  /// The density of dry air at 20 deg Celsius at sea-level.
+  static constexpr double kDefaultFluidDensity{1.204};
+
+  /** Constructs a system describing a single wing using flat-plate
+   aerodynamics as described in the class documentation.
+   @param body_index indicates the body on which the aerodynamic forces are
+   applied.
+   @param surface_area is the total surface area of the wing in meters squared.
+   @param X_BodyWing is the pose of wing frame relative to the body frame,
+   whose origin is at the aerodynamic center of the wing, the positive x-axis
+   points along the chord towards the leading edge (e.g. towards the nose of
+   the plane), the positive y-axis points along the span, and the z-axis points
+   up. According to thin airfoil theory, the aerodynamic center of a symmetric
+   wing (like this flat plate), is located at a quarter-chord position behind
+   the leading edge.
+   @param fluid_density is the density of the fluid in kg/m^3. The default
+   value is the density of dry air at 20 deg Celsius at sea-level. This value
+   is only used if the optional fluid_density input port is not connected.
+  */
+  Wing(BodyIndex body_index, double surface_area,
+       const math::RigidTransform<double>& X_BodyWing =
+           math::RigidTransform<double>::Identity(),
+       double fluid_density = kDefaultFluidDensity);
+
+  /** Scalar-converting copy constructor.  See @ref system_scalar_conversion. */
+  template <typename U>
+  explicit Wing(const Wing<U>& other)
+      : Wing<T>(other.body_index_, other.surface_area_, other.X_BodyWing_,
+                other.default_fluid_density_) {}
+
+  /** Returns a reference to the body_poses input port.  It is anticipated
+  that this port will be connected the body_poses output port of a
+  MultibodyPlant. */
+  const systems::InputPort<T>& get_body_poses_input_port() const {
+    return this->get_input_port(0);
+  }
+
+  /** Returns a reference to the body_spatial_velocities input port.  It is
+  anticipated that this port will be connected the body_spatial_velocities
+  output port of a MultibodyPlant. */
+  const systems::InputPort<T>& get_body_spatial_velocities_input_port() const {
+    return this->get_input_port(1);
+  }
+
+  /** Returns a reference to the input port for the optional three-element
+  BasicVector<T> representing the translational velocity of the wind in world
+  coordinates at the aerodynamic center relative to the world origin. If this
+  port is not connected, then the wind velocity is taken to be zero. */
+  const systems::InputPort<T>& get_wind_velocity_input_port() const {
+    return this->get_input_port(2);
+  }
+
+  /** Returns a reference to the optional fluid_density input port, which
+   accepts a scalar vector in units kg/m^3. This port is provided to support
+   vehicles which must take into account variations in atmospheric density;
+   such as a spacecraft during re-entry.  If left unconnected, the aerodynamic
+   forces will be calculated using the default fluid density passed in the
+   constructor. */
+  const systems::InputPort<T>& get_fluid_density_input_port() const {
+    return this->get_input_port(3);
+  }
+
+  /** Returns a reference to the spatial_forces output port.  It is anticipated
+  that this port will be connected to the @ref
+  MultibodyPlant::get_applied_spatial_force_input_port() "applied_spatial_force"
+  input port of a MultibodyPlant. */
+  const systems::OutputPort<T>& get_spatial_force_output_port() const {
+    return this->get_output_port(0);
+  }
+
+  /** Returns a 3-element position of the aerodynamic center of the wing in
+   world coordinates. This output port does not depend on the optional wind
+   velocity input port, so it may be used to compute the wind velocity at the
+   aerodynamic center without causing any algebraic loops in the Diagram. For
+   instance, the following (sub-)Diagram could be used to implement a wind
+   field:
+                         ┌────────────┐
+                      ┌──┤ Wind Field │◄─┐
+                      │  └────────────┘  │
+                      │   ┌──────────┐   │
+                      └──►│   Wing   ├───┘
+         wind_velocity_at_└──────────┘aerodynamic_center
+         aerodynamic_center
+   */
+  const systems::OutputPort<T>& get_aerodynamic_center_output_port() const {
+    return this->get_output_port(1);
+  }
+
+  /** Helper method that constructs a Wing and connects the input and output
+   ports to the MultibodyPlant.
+
+   @param builder is a DiagramBuilder that the Wing will be added to.
+   @param plant is the MultibodyPlant containing the body referenced by
+   `body_index`, which the wing ports will be connected to.
+
+   See the Wing constructor for details on the remaining parameters.
+   */
+  static Wing<T>* AddToBuilder(systems::DiagramBuilder<T>* builder,
+                               const multibody::MultibodyPlant<T>* plant,
+                               const BodyIndex& body_index, double surface_area,
+                               const math::RigidTransform<double>& X_BodyWing =
+                                   math::RigidTransform<double>::Identity(),
+                               double fluid_density = kDefaultFluidDensity);
+
+ private:
+  // Calculates the spatial forces in the world frame as expected by the
+  // applied_spatial_force input port of MultibodyPlant.
+  void CalcSpatialForce(
+      const systems::Context<T>& context,
+      std::vector<ExternallyAppliedSpatialForce<T>>* spatial_force) const;
+
+  // Calculates the aerodynamic center output port.
+  void CalcAerodynamicCenter(const systems::Context<T>& context,
+                             systems::BasicVector<T>* aerodynamic_center) const;
+
+  // Declare friendship to enable scalar conversion.
+  template <typename U>
+  friend class Wing;
+
+  const BodyIndex body_index_;
+  const math::RigidTransform<double> X_BodyWing_;
+  const double surface_area_;
+  const double default_fluid_density_;
+};
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::multibody::Wing)


### PR DESCRIPTION
This initial implementation only provides flat plate aerodynamics for
now, but is written with an interface that will allow it to be
extended.

This is an updated implementation of a similar functionality that we
had in the matlab version of Drake:
https://github.com/RobotLocomotion/drake/blob/last_sha_with_original_matlab/drake/matlab/systems/plants/%40RigidBodyWing/RigidBodyWing.m

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17027)
<!-- Reviewable:end -->
