### PR TITLE
[systems] Controllability and observability for discrete-time systems

### DIFF
--- a/systems/primitives/linear_system.cc
+++ b/systems/primitives/linear_system.cc
@@ -255,9 +255,6 @@ std::unique_ptr<AffineSystem<double>> FirstOrderTaylorApproximation(
 
 /// Returns the controllability matrix:  R = [B, AB, ..., A^{n-1}B].
 Eigen::MatrixXd ControllabilityMatrix(const LinearSystem<double>& sys) {
-  DRAKE_DEMAND(sys.time_period() == 0.0);
-  // TODO(russt): handle the discrete time case
-
   const int num_states = sys.B().rows(), num_inputs = sys.B().cols();
   Eigen::MatrixXd R(num_states, num_states * num_inputs);
   R.leftCols(num_inputs) = sys.B();
@@ -281,9 +278,6 @@ bool IsControllable(const LinearSystem<double>& sys,
 
 /// Returns the observability matrix: O = [ C; CA; ...; CA^{n-1} ].
 Eigen::MatrixXd ObservabilityMatrix(const LinearSystem<double>& sys) {
-  DRAKE_DEMAND(sys.time_period() == 0.0);
-  // TODO(russt): handle the discrete time case
-
   const int num_states = sys.C().cols(), num_outputs = sys.C().rows();
   Eigen::MatrixXd O(num_states * num_outputs, num_states);
   O.topRows(num_outputs) = sys.C();

--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -492,12 +492,18 @@ GTEST_TEST(TestLinearize, Controllability) {
 
   EXPECT_TRUE(IsControllable(sys1));
 
+  // The discrete-time controllability matrix is the same as the continuous time
+  // one.
+  LinearSystem<double> sys2(A, B, C, D, 1);
+  EXPECT_TRUE(CompareMatrices(ControllabilityMatrix(sys1),
+                              ControllabilityMatrix(sys2)));
+
   // Uncontrollable system: x1dot = u, x2dot = u.
   A << 0, 0, 0, 0;
   B << 1, 1;
-  LinearSystem<double> sys2(A, B, C, D);
+  LinearSystem<double> sys3(A, B, C, D);
 
-  EXPECT_FALSE(IsControllable(sys2));
+  EXPECT_FALSE(IsControllable(sys3));
 }
 
 // Test a few simple systems that are known to be observable (or not).
@@ -524,6 +530,22 @@ GTEST_TEST(TestLinearize, Observability) {
   // Observable: y = x1;
   LinearSystem<double> sys3(A, B, C.topRows(1), D.topRows(1));
   EXPECT_TRUE(IsObservable(sys3));
+}
+
+GTEST_TEST(TestLinearize, Observability2) {
+  Eigen::Matrix2d A;
+  A << 1, 2, 3, 4;
+  const Eigen::Matrix<double, 2, 0> B;
+  Eigen::Matrix<double, 1, 2> C;
+  C << 1, 2;
+  const Eigen::Matrix<double, 1, 0> D;
+  const double kTimeStep = 1;
+
+  const LinearSystem<double> sys(A, B, C, D, kTimeStep);
+
+  Eigen::Matrix2d O;
+  O << 1, 2, 7, 10;
+  EXPECT_TRUE(CompareMatrices(ObservabilityMatrix(sys), O, 1e-14));
 }
 
 class LinearSystemSymbolicTest : public ::testing::Test {


### PR DESCRIPTION
It's funny that we didn't claim to support them before.  After all, the controllability and observability matrices are the same as for continuous-time systems. 

+@hongkai-dai for feature review, please?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17029)
<!-- Reviewable:end -->
