### PR TITLE
Add snippets to set the compiler, for CI

### DIFF
--- a/tools/ci/use-clang.cmake
+++ b/tools/ci/use-clang.cmake
@@ -1,0 +1,2 @@
+set(ENV{CC} "clang-9")
+set(ENV{CXX} "clang++-9")

--- a/tools/ci/use-gcc.cmake
+++ b/tools/ci/use-gcc.cmake
@@ -1,0 +1,2 @@
+set(ENV{CC} "gcc")
+set(ENV{CXX} "g++")


### PR DESCRIPTION
Create a pair of small CMake files that can contain the necessary actions to set up the appropriate compiler for CI. This will allow us to move that logic out of the CI repository, which will in turn allow us to make changes (e.g. upgrading to Clang 12) without having to synchronize them across two different repositories.

As of writing, this isn't used yet; it needs to land here first before CI can start to make use of it.

+@svenevs for feature review, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17031)
<!-- Reviewable:end -->
