### PR TITLE
Add temporary Doxygen doc for glTF client-sever API

### DIFF
--- a/geometry/render_gltf_client/render_gltf_client_doxygen.h
+++ b/geometry/render_gltf_client/render_gltf_client_doxygen.h
@@ -89,8 +89,8 @@ server with the following field entries:
     <td><b>scene</b></td>
     <td>
       The scene file contents.  Sent as if from
-      `<input type="file" name="scene">`.  By default, glTF scenes will have a
-      mime type of [`model/gltf+json`][gltf_mimetypes].
+      `<input type="file" name="scene">`.  glTF scenes will have a mime type of
+      [`model/gltf+json`][gltf_mimetypes].
     </td>
   </tr>
   <tr>
@@ -324,22 +324,16 @@ required, the user of the server will have no hints as to what is going wrong
 with the client-server communication.  When the file response is provided, this
 information will be included in the exception message produced by the client.
 
-
 <h2 id="developing-your-own-server">Developing your own Server</h2>
 <hr>
 
-A [testing suite][testing_suite], including a sample [flask][flask]
-[server][test_server] and a VTK server backend, is provided as a working example
-that can be used with minimal change for your development.
+To test the basic client-server communication and rendering, Drake provides a
+simple server implementation as a reference. For more information about
+developing your own server or running the prototype, refer to the
+[README][render_gltf_client_test] of the `//geometry/render_gltf_client/test`.
 
-[testing_suite]: https://github.com/RobotLocomotion/drake/blob/master/geometry/render/dev/render_gltf_client/test
-[flask]: https://flask.palletsprojects.com/en/2.0.x/
-[test_server]: https://github.com/RobotLocomotion/drake/blob/master/geometry/render/dev/render_gltf_client/test/gltf_render_server.py
+[render_gltf_client_test]: https://github.com/RobotLocomotion/drake/blob/master/geometry/render_gltf_client/test
 
-For more information about developing a server or running the prototype
-client-server communication, refer to the [README][render_gltf_client_readme].
-
-[render_gltf_client_readme]: https://github.com/RobotLocomotion/drake/blob/master/geometry/render_gltf_client/test/README.md
 */
 
 }  // namespace render_gltf_client

--- a/geometry/render_gltf_client/render_gltf_client_doxygen.h
+++ b/geometry/render_gltf_client/render_gltf_client_doxygen.h
@@ -330,7 +330,7 @@ information will be included in the exception message produced by the client.
 To test the basic client-server communication and rendering, Drake provides a
 simple server implementation as a reference. For more information about
 developing your own server or running the prototype, refer to the
-[README][render_gltf_client_test] of the `//geometry/render_gltf_client/test`.
+[README][render_gltf_client_test] under `//geometry/render_gltf_client/test`.
 
 [render_gltf_client_test]: https://github.com/RobotLocomotion/drake/blob/master/geometry/render_gltf_client/test
 

--- a/geometry/render_gltf_client/render_gltf_client_doxygen.h
+++ b/geometry/render_gltf_client/render_gltf_client_doxygen.h
@@ -12,6 +12,14 @@ namespace render_gltf_client {
 Currently, the content of this page is primarily for facilitating code reviews
 and is subject to change during upcoming pull requests.
 
+Drake offers built-in renderers (RenderEngineVtk, RenderEngineGl), but in some
+cases users may want to use their own custom rendering implementations.  One way
+to accomplish that is to subclass RenderEngine with a custom implementation and
+link that into Drake, but sometimes that leads to linker compatibility problems.
+Thus, we also offer another option: rendering using a remote procedure call
+(RPC). This document specifies the network API for servicing those requests.
+<hr>
+
 The [glTF][glTF] render server API consists of two components: a client, and a
 server. The client generates and transmits glTF scene files to the server, which
 then renders and returns an image file back to the client.  Drake implements the

--- a/geometry/render_gltf_client/render_gltf_client_doxygen.h
+++ b/geometry/render_gltf_client/render_gltf_client_doxygen.h
@@ -5,8 +5,14 @@ namespace drake {
 namespace geometry {
 namespace render_gltf_client {
 
-/** @defgroup render_engine_gltf_client_server_api glTF Render Client-Server API
+/** @defgroup render_engine_gltf_client_server_api (Experimental) glTF Render Client-Server API
     @ingroup render_engines
+
+<h2 id="disclaimer">DISCLAIMER</h2>
+The implementation of the glTF Render Client-Server API is still a work in
+progress.  Currently, the content of this page is primarily for facilitating
+code reviews and is subject to change during upcoming pull requests.
+<hr>
 
 The [glTF][glTF] render server API consists of two components: a client, and a
 server. The client generates and transmits glTF scene files to the server, which
@@ -55,8 +61,8 @@ in particular, if you do not return the code yourself the default response is
 always `200` which indicates success.  When in doubt, have your server respond
 with `200` for a success, `400` for any failure related to bad requests (e.g.,
 missing `min_depth` or `max_depth` for an `image_type="depth"`), and `500` for
-any unhandled errors.  The HTTP response code (**only**) is what is used by the
-client to determine if the interaction was successful.
+any unhandled errors.  The HTTP response code is used by the client to determine
+if the interaction was successful.
 
 [html_form]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form
 [html_post]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST
@@ -338,7 +344,7 @@ that can be used with minimal change (please see the documentation at the top of
 the file) for your own uses.
 
 [flask]: https://flask.palletsprojects.com/en/2.0.x/
-[test_server]: https://github.com/RobotLocomotion/drake/blob/master/geometry/render/dev/test/gltf_render_server.py
+[test_server]: https://github.com/RobotLocomotion/drake/blob/master/geometry/render/dev/render_gltf_client/test/gltf_render_server.py
 
 <h3 id="prototype-server-installation">Prototype Server Installation</h3>
 <hr>
@@ -359,32 +365,37 @@ python package on your own with however you manage your python installation
 <hr>
 
 For development purposes, you may run
-`bazel run //geometry/render/dev:gltf_render_server` to launch a single threaded
-/ single worker flask development server.  By default this will run the server
-on host `127.0.0.1` and port `8000`, you may specify `--host x.y.z.w` or
-`--port XYZW` to change the host or port.  There is also a `--debug` option
-available to support reloading the server automatically, see the documentation
-in `gltf_render_server.py` for more information on flask debug targets.
+`bazel run //geometry/render/dev/render_gltf_client:gltf_render_server` to
+launch a single threaded / single worker flask development server.  By default
+this will run the server on host `127.0.0.1` and port `8000`, you may specify
+`--host x.y.z.w` or `--port XYZW` to change the host or port.  There is also a
+`--debug` option available to support reloading the server automatically, see
+the documentation in `gltf_render_server.py` for more information on flask debug
+targets.
 
 @code{.console}
 # Run on the default host and port.
-$ bazel run //geometry/render/dev:gltf_render_server
+$ bazel run //geometry/render/dev/render_gltf_client:gltf_render_server
 
 # Run on custom host and port.
-$ bazel run //geometry/render/dev:gltf_render_server -- --host 0.0.0.0 --port 8192
+$ bazel run //geometry/render/dev/render_gltf_client:gltf_render_server -- --host 0.0.0.0 --port 8192
 @endcode
 
-Now that the server is running,
+Now that the server is running, you can launch the client and drake_visualizer.
 
-- In a separate terminal, run `bazel run //tools:drake_visualizer`
-- In a separate terminal, run the test simulation:
-    - To see the scene with the normal VTK rendering:
-      `bazel run //geometry/render/dev:run_simulation_and_render -- --render_engine vtk`
-    - To render over the server:
-      `bazel run //geometry/render/dev:run_simulation_and_render -- --render_engine client`
-    - Note that if you ran your server on an alternate `--port`, you will need
-      to provide this `--port` to the `run_simulation_and_render` executable
-      as well.
+@code{.console}
+# In a separate terminal, launch drake_visualizer.
+$ bazel run //tools:drake_visualizer
+
+# In another terminal, run the test simulation and the client.
+$ bazel run //geometry/render/dev/render_gltf_client:run_simulation_and_render -- --render_engine client
+
+# To render with the normal VTK, set --render_engine to vtk instead.
+$ bazel run //geometry/render/dev/render_gltf_client:run_simulation_and_render -- --render_engine vtk
+@endcode
+
+Note that if you ran your server on an alternate `--port`, you will need to
+provide this `--port` to the `run_simulation_and_render` executable as well.
 
 If everything is running as expected, then you can begin changing the
 implementation of `render_callback` in `gltf_render_server.py` to invoke the

--- a/geometry/render_gltf_client/test/README.md
+++ b/geometry/render_gltf_client/test/README.md
@@ -7,17 +7,13 @@ is provided as a working example that can be used with minimal change for your
 development.
 
 ## Install Dependencies
-The prototype test server dependencies may or may not have been installed
-depending on how you ran drake's `setup/` scripts and which platform you are on.
-`flask` is required to run the test server, and is a "test-only" requirement
-for drake.
 
-The easiest way to install the requirements is to run
-`setup/ubuntu/install_prereqs.sh` (or `setup/mac/install_prereqs.sh`) making
-sure that you do **not** provide the flag `--without-test-only` (which will
-skip installing the testing requirements).  Alternatively, install the `flask`
-python package on your own with however you manage your python installation
-(e.g., `sudo apt-get install python3-flask` or `pip install flask`).
+The test server uses `flask`, so be sure that you've run
+`setup/ubuntu/install_prereqs.sh` (or `setup/mac/install_prereqs.sh`) to install
+it before proceeding.
+
+**Note:** `flask` is a "test-only" requirement, so don't provide
+`--without-test-only` flag when running the `install_prereqs.sh` script.
 
 ## Run the Client-Server Testing Suite
 There are three commands to run to launch the client, the server, and optionally
@@ -65,7 +61,7 @@ In a separate terminal, launch drake_visualizer.
 $ bazel run //tools:drake_visualizer
 ```
 
-## Develop and Deploy your own Server
+## Prototyping your own Server
 If everything is running as expected, then you can begin changing the
 implementation of `render_callback` in `gltf_render_server.py` to invoke the
 renderer you desire.
@@ -115,7 +111,7 @@ if __name__ == "__main__":
     app.run()
 ```
 
-On Ubuntu, to make the `gunicorn` executable available you will want to
-`sudo apt-get install gunicorn` (not `python3-gunicorn`).  If using a virtual
+**Note:** On Ubuntu, to make the `gunicorn` executable available you will want
+to `sudo apt-get install gunicorn` (not `python3-gunicorn`).  If using a virtual
 environment or `pip` directly, `pip install gunicorn` will make the `gunicorn`
 executable available.

--- a/geometry/render_gltf_client/test/README.md
+++ b/geometry/render_gltf_client/test/README.md
@@ -1,0 +1,121 @@
+# Developing your own Server
+A [testing suite](../../render/dev/render_gltf_client/test), including a sample
+[flask](https://flask.palletsprojects.com/en/2.0.x/)
+[server](../../render/dev/render_gltf_client/test/gltf_render_server.py) and a
+[VTK server backend](../../render/dev/render_gltf_client/test/gltf_render_server_backend.cc),
+is provided as a working example that can be used with minimal change for your
+development.
+
+## Install Dependencies
+The prototype test server dependencies may or may not have been installed
+depending on how you ran drake's `setup/` scripts and which platform you are on.
+`flask` is required to run the test server, and is a "test-only" requirement
+for drake.
+
+The easiest way to install the requirements is to run
+`setup/ubuntu/install_prereqs.sh` (or `setup/mac/install_prereqs.sh`) making
+sure that you do **not** provide the flag `--without-test-only` (which will
+skip installing the testing requirements).  Alternatively, install the `flask`
+python package on your own with however you manage your python installation
+(e.g., `sudo apt-get install python3-flask` or `pip install flask`).
+
+## Run the Client-Server Testing Suite
+There are three commands to run to launch the client, the server, and optionally
+Drake Visualizer for displaying rendered images.
+
+### Run the Server
+A single threaded / single worker flask development server on host `127.0.0.1`
+and port `8000` can be launched by:
+
+```
+$ bazel run //geometry/render/dev/render_gltf_client:gltf_render_server
+```
+
+You may specify host and port by supplying extra arguments.
+
+```
+$ bazel run //geometry/render/dev/render_gltf_client:gltf_render_server -- --host 0.0.0.0 --port 8192
+```
+
+There is also a `--debug` option available to support reloading the server
+automatically, see the documentation in `gltf_render_server.py` for more
+information on flask debug targets.
+
+### Run the Client
+In another terminal, run the test simulation and the client.
+
+```
+$ bazel run //geometry/render/dev/render_gltf_client:run_simulation_and_render -- --render_engine client
+```
+As a comparison, you can also render with the normal VTK by setting
+--render_engine to vtk instead.
+
+```
+$ bazel run //geometry/render/dev/render_gltf_client:run_simulation_and_render -- --render_engine vtk
+```
+
+Note that if you ran your server on an alternate `--port`, you will need to
+provide this `--port` to the `run_simulation_and_render` executable as well.
+
+### (Optional) Run Drake Visualizer
+
+In a separate terminal, launch drake_visualizer.
+
+```
+$ bazel run //tools:drake_visualizer
+```
+
+## Develop and Deploy your own Server
+If everything is running as expected, then you can begin changing the
+implementation of `render_callback` in `gltf_render_server.py` to invoke the
+renderer you desire.
+
+### Notes on Deploying your Server
+
+A single threaded worker flask server is not a good idea to run in production,
+as it will not be able to handle concurrent requests.  You may use any number
+of WSGI runners, in the example below we use [gunicorn](https://gunicorn.org/):
+
+```
+$ gunicorn --timeout 0 --workers 8 --bind 127.0.0.1:8000 wsgi:app
+```
+
+This will spawn a server with:
+
+- No timeout.  If your rendering is going to take any sizable amount of time,
+  by default `gunicorn` will kill and restart workers that have gone silent.
+  Setting the `timeout` to `0` disables this behavior, at the expense of never
+  being able to kill a worker that truly has been stuck.  If you know your
+  rendering backend will take a maximum time, choose that instead.
+- 8 workers to receive client communications.  This means that 8 requests can
+  be processed at once.  Depending on your server capabilities and expected
+  demand, adjust the number of workers accordingly.  **Note** that in the API
+  the worker does not respond until the rendering is complete -- so if 8 workers
+  are being used actively, the ninth request will not be able to be handled
+  until all previous requests are finished.
+  [See the discussion here](https://github.com/benoitc/gunicorn/issues/1492#issuecomment-294436705)
+  for more information about _request timeouts_ as they pertain to `gunicorn` --
+  the amount of requests able to wait in the queue of requests to be processed
+  while all the workers are tied up depend entirely on your server backend and
+  architecture.
+- `--bind` to the URL and (optional) port.  What your final choice will be
+  depends on your configurations for the tool you are using to expose your
+  server (e.g., nginx or apache).
+
+For the last part, `wsgi:app`, this is assuming you have a file named `wsgi.py`
+in the same directory as where you are running the command `gunicorn` with the
+contents:
+
+```
+# NOTE: you may need to update sys.path to import your server implementation
+# depending on your directory structure.
+from gltf_render_server import app
+
+if __name__ == "__main__":
+    app.run()
+```
+
+On Ubuntu, to make the `gunicorn` executable available you will want to
+`sudo apt-get install gunicorn` (not `python3-gunicorn`).  If using a virtual
+environment or `pip` directly, `pip install gunicorn` will make the `gunicorn`
+executable available.


### PR DESCRIPTION
This is one of the PRs to migrate RenderRpc development code from `//geometry/render/dev` to `//geometry/render_gltf_client`. This PR promotes the high-level Doxygen file and marks it as `experimental` to provide the context of the project and facilitate code reviews. Note that the content of the file is subject to change during the upcoming pull requests.

For more information, please see the [Drake project board](https://github.com/RobotLocomotion/drake/projects/8), especially [this ticket](https://github.com/RobotLocomotion/drake/issues/15915).

Relates #16750

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17040)
<!-- Reviewable:end -->
