### PR TITLE
Add Bazel config for compiler selection

### DIFF
--- a/doc/_pages/bazel.md
+++ b/doc/_pages/bazel.md
@@ -38,11 +38,11 @@ Cheat sheet for operating on the entire project:
 
 ```
 cd /path/to/drake
-bazel build //...                               # Build the entire project.
-bazel test //...                                # Build and test the entire project.
+bazel build //...                 # Build the entire project.
+bazel test //...                  # Build and test the entire project.
 
-CC=clang-9 CXX=clang++-9 bazel build //...      # Build using Clang 9 on Ubuntu.
-CC=clang-9 CXX=clang++-9 bazel test //...       # Build and test using Clang 9 on Ubuntu.
+bazel build --config=clang //...  # Build using Clang on Ubuntu.
+bazel test --config=clang //...   # Build and test using Clang on Ubuntu.
 ```
 
 * The "``//``" means "starting from the root of the project".
@@ -89,7 +89,7 @@ bazel test --config=kcov common:polynomial_test      # Run one test under kcov (
 bazel build -c dbg common:polynomial_test && \
   gdb bazel-bin/common/polynomial_test               # Run one test under gdb.
 
-CC=clang-9 CXX=clang++-9 bazel test -c dbg --config=asan common:polynomial_test  # Run one test under AddressSanitizer.
+bazel test -c dbg --config=clang --config=asan common:polynomial_test  # Run one test under AddressSanitizer.
 
 bazel test --config lint //...                       # Only run style checks; don't build or test anything else.
 ```

--- a/setup/ubuntu/install_prereqs.sh
+++ b/setup/ubuntu/install_prereqs.sh
@@ -28,12 +28,12 @@ while [ "${1:-}" != "" ]; do
     --with-kcov)
       source_distribution_args+=(--with-kcov)
       ;;
-    # Install prerequisites that are only needed to when CC=clang-9, i.e.,
+    # Install prerequisites that are only needed for --config clang, i.e.,
     # opts-in to the ability to compile Drake's C++ code using Clang.
     --with-clang)
       source_distribution_args+=(--with-clang)
       ;;
-    # Do NOT install prerequisites that are only needed to when CC=clang-9,
+    # Do NOT install prerequisites that are only needed for --config clang,
     # i.e., opts-out of the ability to compile Drake's C++ code using Clang.
     --without-clang)
       source_distribution_args+=(--without-clang)

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -30,12 +30,12 @@ while [ "${1:-}" != "" ]; do
     --with-kcov)
       with_kcov=1
       ;;
-    # Install prerequisites that are only needed to when CC=clang-9, i.e.,
+    # Install prerequisites that are only needed for --config clang, i.e.,
     # opts-in to the ability to compile Drake's C++ code using Clang.
     --with-clang)
       with_clang=1
       ;;
-    # Do NOT install prerequisites that are only needed to when CC=clang-9,
+    # Do NOT install prerequisites that are only needed for --config clang,
     # i.e., opts-out of the ability to compile Drake's C++ code using Clang.
     --without-clang)
       with_clang=0

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -86,3 +86,11 @@ build:everything --define=WITH_GUROBI=ON
 build:everything --define=WITH_MOSEK=ON
 # -- Options for SNOPT.
 build:everything --define=WITH_SNOPT=ON
+
+# -- Options for explicitly using GCC.
+common:gcc --repo_env=CC=gcc
+common:gcc --repo_env=CXX=g++
+build:gcc --action_env=CC=gcc
+build:gcc --action_env=CXX=g++
+build:gcc --host_action_env=CC=gcc
+build:gcc --host_action_env=CXX=g++

--- a/tools/macos.bazelrc
+++ b/tools/macos.bazelrc
@@ -11,3 +11,11 @@ build:ubsan_everything --copt=-Wno-macro-redefined
 
 # https://github.com/bazelbuild/bazel/issues/14294
 build --notrim_test_configuration
+
+# -- Options for explicitly using Clang.
+common:clang --repo_env=CC=clang
+common:clang --repo_env=CXX=clang++
+build:clang --action_env=CC=clang
+build:clang --action_env=CXX=clang++
+build:clang --host_action_env=CC=clang
+build:clang --host_action_env=CXX=clang++

--- a/tools/ubuntu-focal.bazelrc
+++ b/tools/ubuntu-focal.bazelrc
@@ -16,3 +16,11 @@ build --action_env=PATH=/usr/bin:/bin
 # https://github.com/RobotLocomotion/drake/issues/8475
 build --action_env=PYTHONNOUSERSITE=1
 build --test_env=PYTHONNOUSERSITE=1
+
+# -- Options for explicitly using Clang.
+common:clang --repo_env=CC=clang-9
+common:clang --repo_env=CXX=clang++-9
+build:clang --action_env=CC=clang-9
+build:clang --action_env=CXX=clang++-9
+build:clang --host_action_env=CC=clang-9
+build:clang --host_action_env=CXX=clang++-9


### PR DESCRIPTION
Add ability to select which compiler to use by passing an appropriate `--config` to Bazel. Update documentation accordingly.

In addition to being more convenient for users, this moves the specification of what clang version to use (only relevant on Ubuntu) to the Bazel configuration, rather than the user needing to specify this. This will also allow this information to be removed from the CI infrastructure.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17043)
<!-- Reviewable:end -->
