### PR TITLE
[parsing] Route package deprecations into the diagnostic channel

### DIFF
--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -41,8 +41,14 @@ PYBIND11_MODULE(parsing, m) {
         .def("size", &Class::size, cls_doc.size.doc)
         .def("GetPackageNames", &Class::GetPackageNames,
             cls_doc.GetPackageNames.doc)
-        .def("GetPath", &Class::GetPath, py::arg("package_name"),
-            cls_doc.GetPath.doc)
+        .def(
+            "GetPath",
+            [](const PackageMap& self, const std::string& package_name) {
+              // Python does not support output arguments, so we cannot bind the
+              // deprecated_message here.
+              return self.GetPath(package_name);
+            },
+            py::arg("package_name"), cls_doc.GetPath.doc)
         .def("AddPackageXml", &Class::AddPackageXml, py::arg("filename"),
             cls_doc.AddPackageXml.doc)
         .def("PopulateFromFolder", &Class::PopulateFromFolder, py::arg("path"),

--- a/multibody/parsing/detail_path_utils.cc
+++ b/multibody/parsing/detail_path_utils.cc
@@ -41,7 +41,13 @@ string ResolveUri(const DiagnosticPolicy& diagnostic, const string& uri,
             "URI '{}' refers to unknown package '{}'", uri, uri_package));
         return {};
       }
-      const std::string& package_path = package_map.GetPath(uri_package);
+      std::optional<string> deprecation;
+      const std::string& package_path = package_map.GetPath(
+          uri_package, &deprecation);
+      if (deprecation.has_value()) {
+        diagnostic.Warning(fmt::format(
+            "In URI '{}': {}", uri, *deprecation));
+      }
       result = filesystem::path(package_path) / std::string(uri_path);
     } else {
       diagnostic.Error(fmt::format(

--- a/multibody/parsing/package_map.h
+++ b/multibody/parsing/package_map.h
@@ -63,7 +63,16 @@ class PackageMap final {
 
   /// Obtains the path associated with package @p package_name. Aborts if no
   /// package named @p package_name exists in this PackageMap.
-  const std::string& GetPath(const std::string& package_name) const;
+  ///
+  /// @param[out] deprecated_message When passed as nullptr (it's default
+  /// value), then in case the @p package_name is deprecated a deprecation
+  /// message will be logged. When passed as non-nullptr the deprecation
+  /// message will be output into this argument and will not be logged;
+  /// if the @p package_name is not deprecated, the message will be set to
+  /// nullopt.
+  const std::string& GetPath(
+      const std::string& package_name,
+      std::optional<std::string>* deprecated_message = nullptr) const;
 
   /// Adds an entry into this PackageMap for the given `package.xml` filename.
   /// Throws if @p filename does not exist or its embedded name already exists
@@ -77,6 +86,7 @@ class PackageMap final {
   /// directory's path is the value.
   /// If a package already known by the PackageMap is found again with a
   /// conflicting path, a warning is logged and the original path is kept.
+  /// If the path does not exist or is unreadable, a warning is logged.
   void PopulateFromFolder(const std::string& path);
 
   /// Obtains one or more paths from environment variable
@@ -92,6 +102,7 @@ class PackageMap final {
   /// conflicting path, a warning is logged and the original path is kept. This
   /// accomodates the expected behavior using ROS_PACKAGE_PATH, where a package
   /// path corresponds to the "highest" overlay in which that package is found.
+  /// If a path does not exist or is unreadable, a warning is logged.
   void PopulateFromEnvironment(const std::string& environment_variable);
 
   /// Crawls up the directory tree from @p model_file to `drake`
@@ -123,9 +134,6 @@ class PackageMap final {
 
   // Recursively crawls through @p path looking for package.xml files. Adds
   // the packages defined by these package.xml files to this PackageMap.
-  // Multiple paths can be searched by separating them using the ':' symbol. In
-  // other words, @p path can be [path 1]:[path 2]:[path 3] to crawl through
-  // three different paths.
   void CrawlForPackages(const std::string& path);
 
   // This method is the same as Add() except if package_name is already present

--- a/multibody/parsing/test/package_map_test.cc
+++ b/multibody/parsing/test/package_map_test.cc
@@ -32,7 +32,16 @@ void VerifyMatch(const PackageMap& package_map,
   EXPECT_EQ(package_map.size(), static_cast<int>(expected_packages.size()));
   for (const auto& [package_name, package_path] : expected_packages) {
     ASSERT_TRUE(package_map.Contains(package_name));
-    EXPECT_EQ(package_map.GetPath(package_name), package_path);
+    std::optional<string> deprecation;
+    EXPECT_EQ(package_map.GetPath(package_name, &deprecation), package_path);
+
+    const bool should_be_deprecated =
+        (package_name == "package_map_test_package_b") ||
+        (package_name == "package_map_test_package_d");
+    EXPECT_EQ(deprecation.has_value(), should_be_deprecated)
+        << "for " << package_name;
+    EXPECT_EQ(!deprecation.value_or("").empty(), should_be_deprecated)
+        << "for " << package_name;
   }
 
   std::map<std::string, int> package_name_counts;


### PR DESCRIPTION
Towards #16784.

The objective here is to allow the user to opt-in to throwing exceptions for deprecations via #17017.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17047)
<!-- Reviewable:end -->
