### PR TITLE
[atlas] Revert to a larger default time step

### DIFF
--- a/examples/atlas/atlas_run_dynamics.cc
+++ b/examples/atlas/atlas_run_dynamics.cc
@@ -18,7 +18,7 @@ DEFINE_double(stiction_tolerance, 1.0E-3,
               "Allowable drift speed during stiction (m/s).");
 
 DEFINE_double(
-    mbp_discrete_update_period, 5.0E-4,
+    mbp_discrete_update_period, 1.0E-3,
     "The fixed-time step period (in seconds) of discrete updates for the "
     "multibody plant modeled as a discrete system. Strictly positive. "
     "Set to zero for a continuous plant model.");


### PR DESCRIPTION
Reverts #15814. 
As a side effect, #16035 allows larger time step in the atlas example without making the simulation unstable, so we reverts to the original larger default timestep, 1e-3s.
Relates to #15782.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17049)
<!-- Reviewable:end -->
