### PR TITLE
[parsing] Slightly improve joint parsing diagnostics

### DIFF
--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -605,9 +605,43 @@ void AddJointFromSpecification(
         child_body, X_CJ, damping);
       break;
     }
-    default: {
-      throw std::logic_error(
-          "Joint type not supported for joint '" + joint_spec.Name() + "'.");
+    case sdf::JointType::CONTINUOUS: {
+      // TODO(#14747) Use an unlimited multibody::RevoluteJoint here.
+      diagnostic.Error(fmt::format(
+          "Joint type (continuous) not supported for joint '{}'.",
+          joint_spec.Name()));
+      break;
+    }
+    case sdf::JointType::SCREW: {
+      // TODO(jwnimmer-tri) Use a multibody::ScrewJoint here.
+      diagnostic.Error(fmt::format(
+          "Joint type (screw) not supported for joint '{}'.",
+          joint_spec.Name()));
+      break;
+    }
+    case sdf::JointType::GEARBOX: {
+      // TODO(jwnimmer-tri) Demote this to a warning, possibly adding a
+      // RevoluteJoint as an approximation (stopgap) in that case.
+      diagnostic.Error(fmt::format(
+          "Joint type (gearbox) not supported for joint '{}'.",
+          joint_spec.Name()));
+      break;
+    }
+    case sdf::JointType::REVOLUTE2: {
+      // TODO(jwnimmer-tri) Demote this to a warning, possibly adding a
+      // UniversalJoint as an approximation (stopgap) in that case.
+      diagnostic.Error(fmt::format(
+          "Joint type (revolute2) not supported for joint '{}'.",
+          joint_spec.Name()));
+      break;
+    }
+    case sdf::JointType::INVALID: {
+      // N.B. It's not practical to reach this code via unit test.
+      // In (probably?) all cases, libsdformat will have already detected
+      // this error and so Drake won't even call this function.
+      diagnostic.Error(fmt::format(
+          "Unknown joint type for joint '{}'.", joint_spec.Name()));
+      break;
     }
   }
   joint_types->insert(joint_spec.Type());

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -931,6 +931,81 @@ TEST_F(SdfParserTest, JointParsingTest) {
   EXPECT_TRUE(CompareMatrices(planar_joint2.velocity_upper_limits(), inf3));
 }
 
+// Tests the error handling for an unsupported joint type.
+TEST_F(SdfParserTest, ContinuousJointParsingTest) {
+  ParseTestString(R"""(
+<model name="molly">
+  <link name="larry" />
+  <joint name="jerry" type="continuous">
+    <parent>world</parent>
+    <child>larry</child>
+  </joint>
+</model>)""");
+  EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
+      ".*continuous.*not supported.*jerry.*"));
+  ClearDiagnostics();
+}
+
+// Tests the error handling for an unsupported joint type.
+TEST_F(SdfParserTest, ScrewJointParsingTest) {
+  ParseTestString(R"""(
+<model name="molly">
+  <link name="larry" />
+  <joint name="jerry" type="screw">
+    <parent>world</parent>
+    <child>larry</child>
+  </joint>
+</model>)""");
+  EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
+      ".*screw.*not supported.*jerry.*"));
+  ClearDiagnostics();
+}
+
+// Tests the error handling for an unsupported joint type.
+TEST_F(SdfParserTest, GearboxJointParsingTest) {
+  ParseTestString(R"""(
+<model name="molly">
+  <link name="larry" />
+  <joint name="jerry" type="gearbox">
+    <parent>world</parent>
+    <child>larry</child>
+  </joint>
+</model>)""");
+  EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
+      ".*gearbox.*not supported.*jerry.*"));
+  ClearDiagnostics();
+}
+
+// Tests the error handling for an unsupported joint type.
+TEST_F(SdfParserTest, Revolute2JointParsingTest) {
+  ParseTestString(R"""(
+<model name="molly">
+  <link name="larry" />
+  <joint name="jerry" type="revolute2">
+    <parent>world</parent>
+    <child>larry</child>
+  </joint>
+</model>)""");
+  EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
+      ".*revolute2.*not supported.*jerry.*"));
+  ClearDiagnostics();
+}
+
+// Tests the error handling for a misspelled joint type.
+TEST_F(SdfParserTest, MisspelledJointParsingTest) {
+  ParseTestString(R"""(
+<model name="molly">
+  <link name="larry" />
+  <joint name="jerry" type="revoluteQQQ">
+    <parent>world</parent>
+    <child>larry</child>
+  </joint>
+</model>)""");
+  EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
+      ".*revoluteqqq is invalid.*"));
+  ClearDiagnostics();
+}
+
 // Verifies that the SDF parser parses the joint actuator limit correctly.
 TEST_F(SdfParserTest, JointActuatorParsingTest) {
   const std::string full_name = FindResourceOrThrow(


### PR DESCRIPTION
Mostly, just clarify our plans for future work, and be sure to notice when SDFormat adds new joint types (via C++ switch-enum warnings).

To provide more context for the TODOs -- as discussed in slack, to the extent that we can best-effort deal with unimplemented features (while warning about it to the user), that is probably the best UX.  It will allow the user to actually create a MbP and play with it, resolving the warnings later in due course.

Closes #16784.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17054)
<!-- Reviewable:end -->
