### PR TITLE
[parsing] Invalid SDFormat syntax is now an error (not warning)

### DIFF
--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -161,17 +161,6 @@ RotationalInertia<double> ExtractRotationalInertiaAboutBcmExpressedInBi(
 // Returns true iff the given report indicates an error, or false for warnings.
 bool IsError(const sdf::Error& report) {
   switch (report.Code()) {
-    case sdf::ErrorCode::ELEMENT_INCORRECT_TYPE: {
-      // TODO(#15018): Change unrecognized elements to become an error ASAP.
-      // There is no error code dedicated solely to such elements, so we'll
-      // need to match the UnrecognizedElementsPolicy message output for its
-      // enforceConfigurablePolicyCondition.
-      const std::string& message = report.Message();
-      if (message.find("not defined in SDF. Copying") != std::string::npos) {
-        return false;
-      }
-      return true;
-    }
     case sdf::ErrorCode::ELEMENT_DEPRECATED:
     case sdf::ErrorCode::VERSION_DEPRECATED:
     case sdf::ErrorCode::NONE: {

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -1167,7 +1167,7 @@ TEST_F(SdfParserTest, TestSdformatParserPolicies) {
   <bad_element/>
 </model>
 )""");
-  EXPECT_THAT(FormatFirstWarning(), testing::MatchesRegex(
+  EXPECT_THAT(FormatFirstError(), testing::MatchesRegex(
       ".*XML Element\\[bad_element\\], child of"
       " element\\[model\\], not defined in SDF.*"));
   ClearDiagnostics();
@@ -1184,7 +1184,7 @@ TEST_F(SdfParserTest, TestSdformatParserPolicies) {
     </axis>
   </joint>
 </model>)""", "1.9");
-  EXPECT_THAT(FormatFirstWarning(), testing::MatchesRegex(
+  EXPECT_THAT(FormatFirstError(), testing::MatchesRegex(
       ".*XML Element\\[initial_position\\], child of element"
       "\\[axis\\], not defined in SDF.*"));
   ClearDiagnostics();


### PR DESCRIPTION
Closes #15018.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17060)
<!-- Reviewable:end -->
