### PR TITLE
[pydrake] Changing Python logging level also changes C++ level

### DIFF
--- a/bindings/pydrake/common/__init__.py
+++ b/bindings/pydrake/common/__init__.py
@@ -6,10 +6,79 @@ import logging as _logging
 import numpy as np
 
 from ._module_py import *
+from ._module_py import _set_log_level
 
 # When running from python, turn DRAKE_ASSERT and DRAKE_DEMAND failures into
 # SystemExit, instead of process aborts.  See RobotLocomotion/drake#5268.
 set_assertion_failure_to_throw_exception()
+
+_root_logger = _logging.getLogger()
+_drake_logger = _logging.getLogger("drake")
+
+
+def _python_level_to_spdlog(level: int):
+    """Returns the spdlog string level that enables C++ logging at the given
+    Python logging level, for use with pydrake.common._set_log_level.
+    """
+    if level >= _logging.CRITICAL:
+        return "critical"
+    if level >= _logging.ERROR:
+        return "err"
+    if level >= _logging.WARNING:
+        return "warn"
+    if level >= _logging.INFO:
+        return "info"
+    if level >= _logging.DEBUG:
+        return "debug"
+    return "trace"
+
+
+def _sync_spdlog_level():
+    """Updates Drake's C++ spdlog level threshold to match the effective level
+    of Drake's Python logger. This will either be the Drake Logger's level or
+    else the root Logger's level in case Drake Logger's level is NOTSET.
+
+    This only syncs the "effective" level, not the "enabled for" level. The
+    "enabled for" level would also incorporate the global "logging.disable"
+    setting, but we do not reflect that back into C++ spdlog at the moment.
+    """
+    level = _drake_logger.level or _root_logger.level
+    _set_log_level(_python_level_to_spdlog(level))
+
+
+def _monkey_patch_logger_level_events():
+    """Adds a hook into Drake's Python Logger object such that changes to
+    Python logging levels are reflected back into Drake's C++ spdlog level.
+    """
+    # To notice log level changes (whether to the root logger or our logger) we
+    # intercept calls to our logger's cache-clearing function. Specifically,
+    # when a user calls `Logger.setLevel(...)`, the logger tells the manager
+    # singleton to clear its cache ...
+    #
+    # https://github.com/python/cpython/blob/c2b57974/Lib/logging/__init__.py#L1457-L1462
+    #
+    # ... which asks each Logger in turn to clear its cache.
+    #
+    # https://github.com/python/cpython/blob/c2b57974/Lib/logging/__init__.py#L1412-L1423
+    #
+    # That notification is triggered for any logger level change, including
+    # both the root logger and Drake's own logger. Therefore, syncing the C++
+    # level based on cache-clearing events is sufficient to cover all cases.
+    #
+    # This relies on the implementation details of CPython's logging module,
+    # so we might need to adapt this technique to track CPython changes. Our
+    # CI testing will inform us in case this technique ever stops working.
+    class spdlog_syncing_dict(dict):
+        def clear(self):
+            super().clear()
+            _sync_spdlog_level()
+
+    _drake_logger._cache = spdlog_syncing_dict()
+
+
+# Reflect the Python level to C++ level iff the Python sink is fed by spdlog.
+if getattr(_drake_logger, "_tied_to_spdlog", False):
+    _monkey_patch_logger_level_events()
 
 
 def configure_logging():
@@ -20,12 +89,19 @@ def configure_logging():
     more spartan than Drake's C++ logging format (e.g., Python does not show
     message timestamps by default).
 
+    Note:
+        pydrake logs using Python's built-in ``logging`` module. To access
+        pydrake's ``logging.Logger``, use ``logging.getLogger("drake")``.
+        You can configure log settings using that object whether or not you
+        have called ``configure_logging()`` first.
+
     See also:
-       :py:func:`pydrake.common.set_log_level`
+        https://docs.python.org/3/library/logging.html
     """
     format = "[%(asctime)s] [%(name)s] [%(levelname)s] %(message)s"
     _logging.basicConfig(level=_logging.INFO, format=format)
-    _logging.getLogger("drake").setLevel(_logging.NOTSET)
+    _drake_logger.setLevel(_logging.NOTSET)
+    _logging.addLevelName(5, "TRACE")
 
 
 def _wrap_to_match_input_shape(f):

--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -101,18 +101,19 @@ PYBIND11_MODULE(_module_py, m) {
 
   m.attr("_HAVE_SPDLOG") = logging::kHaveSpdlog;
 
-  m.def("set_log_level", &logging::set_log_level, py::arg("level"),
-      (std::string(doc.logging.set_log_level.doc) + R"""(
-Warning:
-    When using pydrake, both the C++ level threshold and the Python logging
-    level threshold must be satisfied for a message to be displayed. This
-    function only adjusts the C++ level. Refer to the Python logging module
-    documentation for details on setting the Python level.
-
-See also:
-   :py:func:`pydrake.common.configure_logging`
-)""")
-          .c_str());
+  // Python users should not touch the C++ level; thus, we bind this privately.
+  m.def("_set_log_level", &logging::set_log_level, py::arg("level"),
+      doc.logging.set_log_level.doc);
+  {
+    const char* doc_deprecated =
+        "Deprecated:\n"
+        "    Do not use ``pydrake.common.set_log_level(...)``.\n"
+        "    Instead, use ``logging.getLogger('drake').setLevel(...)``.\n"
+        "    This function will be removed from Drake on or after 2022-09-01";
+    m.def("set_log_level",
+        WrapDeprecated(doc_deprecated, &logging::set_log_level),
+        py::arg("level"), doc_deprecated);
+  }
 
   internal::MaybeRedirectPythonLogging();
 

--- a/bindings/pydrake/common/test/module_test.py
+++ b/bindings/pydrake/common/test/module_test.py
@@ -54,8 +54,9 @@ class TestCommon(unittest.TestCase):
 
     def test_logging(self):
         self.assertTrue(mut._module_py._HAVE_SPDLOG)
-        self.assertIsInstance(
-            mut.set_log_level(level="unchanged"), str)
+        with catch_drake_warnings(expected_count=1) as w:
+            self.assertIsInstance(
+                mut.set_log_level(level="unchanged"), str)
 
     def test_random_generator(self):
         g1 = mut.RandomGenerator()

--- a/bindings/pydrake/common/test/text_logging_example.py
+++ b/bindings/pydrake/common/test/text_logging_example.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 
-from pydrake.common import configure_logging, set_log_level
+from pydrake.common import configure_logging
 from pydrake.common.test.text_logging_test import do_log_test
 
 
@@ -9,33 +9,23 @@ def main():
     # Parse our arguments.
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--python_level", metavar="INT", type=int, required=True,
-        help="Set Python Drake logger to this level, or use 0 as a no-op.")
-    parser.add_argument(
-        "--spdlog_level_name", metavar="STR", type=str, required=True,
-        help="Set C++ Drake to this log level, or use 'unchanged' as a no-op."
-             " Refer to set_log_level in drake/common for valid level names.")
-    parser.add_argument(
         "--use_nice_format", metavar="1|0", type=int, required=True,
         help="Switch on (or off) nicely formatted Python output.")
+    parser.add_argument(
+        "--root_level", metavar="INT", type=int, required=True,
+        help="Set Python root logger to this level, or use -1 for a no-op.")
+    parser.add_argument(
+        "--drake_level", metavar="INT", type=int, required=True,
+        help="Set Python Drake logger to this level, or use -1 for a no-op.")
     args = parser.parse_args()
 
-    # Configure Python logging (if requested).
-    if args.python_level != logging.NOTSET:
-        if args.use_nice_format:
-            configure_logging()
-            logging.getLogger().setLevel(args.python_level)
-        else:
-            logging.basicConfig(level=args.python_level)
-            logging.getLogger("drake").setLevel(logging.NOTSET)
-    else:
-        # Trying to use the "nice format" makes no sense when we're not even
-        # configuring Python logging in the first place.
-        assert args.use_nice_format == 0
-
-    # Configure C++ logging (if requested).
-    if args.spdlog_level_name != "unchanged":
-        set_log_level(args.spdlog_level_name)
+    # Configure logging as instructed.
+    if args.use_nice_format:
+        configure_logging()
+    if args.root_level >= 0:
+        logging.getLogger().setLevel(args.root_level)
+    if args.drake_level >= 0:
+        logging.getLogger("drake").setLevel(args.drake_level)
 
     # Emit a bunch of log messages from C++. Depending on the level filtering,
     # not all of them will be printed.

--- a/bindings/pydrake/common/text_logging_pybind.cc
+++ b/bindings/pydrake/common/text_logging_pybind.cc
@@ -34,6 +34,9 @@ class pylogging_sink final
     py::object logging = py::module::import("logging");
     py::object logger = logging.attr("getLogger")(name_);
 
+    // Annotate that the logger is alive (fed by spdlog).
+    py::setattr(logger, "_tied_to_spdlog", py::cast(true));
+
     // Match the C++ default level.
     logger.attr("setLevel")(to_py_level(drake::log()->level()));
 


### PR DESCRIPTION
Deprecate the confusing and now-superfluous pydrake `set_log_level` function.

Inspired by #16901 (as further discussed in #16941).  Closes #16942.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17069)
<!-- Reviewable:end -->
