### PR TITLE
Disable kcov on multibody_parsing_detail_urdf_parser_test

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -465,6 +465,8 @@ drake_cc_googletest(
         "//manipulation/models/iiwa_description:models",
         "//multibody/benchmarks/acrobot:models",
     ],
+    # TODO(BetsyMcPhail) This test hit kcov#339; untag when we have kcov>=39.
+    tags = ["no_kcov"],
     deps = [
         ":detail_urdf_parser",
         ":diagnostic_policy_test_base",


### PR DESCRIPTION
multibody/parsing/detail_urdf_parser_test is failing on CI due to kcov issue https://github.com/RobotLocomotion/drake/pull/339.

Failing jobs:
https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-focal-gcc-bazel-nightly-everything-coverage/697/
https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-focal-gcc-bazel-nightly-everything-coverage/697/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17070)
<!-- Reviewable:end -->
