### PR TITLE
[parsing] Work around test error in coverage builds (kcov 339)

### DIFF
--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -28,6 +28,7 @@
 namespace drake {
 namespace multibody {
 namespace internal {
+namespace kcov339_avoidance_magic {
 namespace {
 
 using ::testing::MatchesRegex;
@@ -1546,6 +1547,7 @@ TEST_F(UrdfParserTest, UnsupportedMechanicalReductionIgnoredMaybe) {
 }
 
 }  // namespace
+}  // namespace kcov339_avoidance_magic
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake


### PR DESCRIPTION
Add a dummy namespace to perturb the elf header.

Closes #17070.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17071)
<!-- Reviewable:end -->
