### PR TITLE
Always import environment.bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,9 +2,7 @@
 import %workspace%/tools/bazel.rc
 
 # Import environment-specific configuration.
-# TODO(eric.cousineau): Make this required once CI is configured to always run
-# `install_prereqs_user_environment`.
-try-import %workspace%/gen/environment.bazelrc
+import %workspace%/gen/environment.bazelrc
 
 # Try to import user-specific configuration local to workspace.
 try-import %workspace%/user.bazelrc


### PR DESCRIPTION
Change `.bazelrc` to always and unconditionally import `environment.bazelrc`, which will ensure that this has been duly created by the setup process and is error-free.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17082)
<!-- Reviewable:end -->
