### PR TITLE
[parsing] Mitigate mujoco valgrind error with Clang 12

### DIFF
--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -84,14 +84,13 @@ class MujocoParser {
     ParseVectorAttribute(node, "pos", &pos);
 
     // Check that only one of the orientation variants are supplied:
-    std::vector<bool> orientation_attrs = {
-        static_cast<bool>(node->Attribute("quat")),
-        static_cast<bool>(node->Attribute("axisangle")),
-        static_cast<bool>(node->Attribute("euler")),
-        static_cast<bool>(node->Attribute("xyaxes")),
-        static_cast<bool>(node->Attribute("zaxis"))};
-    if (std::count(orientation_attrs.begin(), orientation_attrs.end(), true) >
-        1) {
+    const int num_orientation_attrs =
+        (node->Attribute("quat") != nullptr ? 1 : 0)
+        + (node->Attribute("axisangle") != nullptr ? 1 : 0)
+        + (node->Attribute("euler") != nullptr ? 1 : 0)
+        + (node->Attribute("xyaxes") != nullptr ? 1 : 0)
+        + (node->Attribute("zaxis") != nullptr ? 1 : 0);
+    if (num_orientation_attrs > 1) {
       throw std::logic_error(fmt::format(
           "Element {} has more than one orientation attribute specified "
           "(perhaps through defaults). There must be no more than one instance "

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -260,6 +260,23 @@ GTEST_TEST(MujocoParser, GeometryPose) {
       RigidTransformd(RollPitchYawd{M_PI / 6.0, M_PI / 4.0, M_PI / 3.0}, p));
 }
 
+GTEST_TEST(MujocoParser, GeometryPoseErrors) {
+  MultibodyPlant<double> plant(0.0);
+  SceneGraph<double> scene_graph;
+  plant.RegisterAsSourceForSceneGraph(&scene_graph);
+  const std::string xml = R"""(
+<mujoco model="test">
+  <worldbody>
+    <geom name="two_angles" type="sphere" size="0.1" pos="1 2 3"
+          quat="0 1 0 0" euler="30 45 60" />
+  </worldbody>
+</mujoco>
+)""";
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      AddModelFromMujocoXml({DataSource::kContents, &xml}, "test", {}, &plant),
+      ".*has more than one orientation attribute specified.*");
+}
+
 GTEST_TEST(MujocoParser, GeometryProperties) {
   MultibodyPlant<double> plant(0.0);
   SceneGraph<double> scene_graph;


### PR DESCRIPTION
Rewrite "count the attributes" to avoid `vector<bool>` and obey our style to always write out null checks literally.

Add a unit test that exercises the desired error condition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17091)
<!-- Reviewable:end -->
