### PR TITLE
[math] Remove some pointer-offset UB

### DIFF
--- a/math/autodiff_gradient.h
+++ b/math/autodiff_gradient.h
@@ -77,6 +77,9 @@ ExtractGradient(const Eigen::MatrixBase<Derived>& auto_diff_matrix,
   Eigen::Matrix<typename Derived::Scalar::Scalar, Derived::SizeAtCompileTime,
                 Eigen::Dynamic>
       gradient(auto_diff_matrix.size(), *num_derivatives);
+  if (gradient.size() == 0) {
+    return gradient;
+  }
   for (int row = 0; row < auto_diff_matrix.rows(); ++row) {
     for (int col = 0; col < auto_diff_matrix.cols(); ++col) {
       auto gradient_row =

--- a/solvers/moby_lcp_solver.cc
+++ b/solvers/moby_lcp_solver.cc
@@ -84,7 +84,9 @@ void selectSubMat(const Eigen::MatrixBase<Derived>& in,
   const int num_rows = rows.size();
   const int num_cols = cols.size();
   out->resize(num_rows, num_cols);
-
+  if (out->size() == 0) {
+    return;
+  }
   for (int i = 0; i < num_rows; i++) {
     const auto row_in = in.row(rows[i]);
     auto row_out = out->row(i);


### PR DESCRIPTION
Towards #16937.

Refer to https://reviews.llvm.org/D67122 for details.

We are not allowed (for example) to form zero-sized blocks into zero-sized matrices, at least not with Eigen 3.3.7.

Here is the relevant Eigen upstream code, same as what we have today on Ubuntu:

https://gitlab.com/libeigen/eigen/-/blob/c2f15edc43367c3a11aacbb51c7431ccb5a31bb5/Eigen/src/Core/Block.h#L349-350

In the problematic cases, we have `xpr.data() == nullptr` yet we also have `i > 0`, such that we're computing non-zero pointer offsets from null, which is UB.

This fault is detected by our forthcoming Clang 12 UBSan builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17094)
<!-- Reviewable:end -->
