### PR TITLE
[multibody] Remove some pointer-offset UB

### DIFF
--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -344,7 +344,11 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
     //          = H_PB_W * vm
     // where H_PB_W = R_WF * phiT_MB_F * H_FM.
     SpatialVelocity<T>& V_PB_W = get_mutable_V_PB_W(vc);
-    V_PB_W.get_coeffs() = H_PB_W * vm;
+    if (get_num_mobilizer_velocities() > 0) {
+      V_PB_W.get_coeffs() = H_PB_W * vm;
+    } else {
+      V_PB_W.get_coeffs().setZero();
+    }
 
     // =========================================================================
     // Computation of V_WPb in Eq. (1). See summary at the top of this method.


### PR DESCRIPTION
Towards #16937 and #17113.

Refer to https://reviews.llvm.org/D67122 for details.

We are not allowed (for example) to form zero-sized blocks into zero-sized matrices, at least not with Eigen 3.3.7.

This fault is detected by our forthcoming Clang 12 UBSan builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17095)
<!-- Reviewable:end -->
