### PR TITLE
[solvers] Remove some pointer-offset UB

### DIFF
--- a/solvers/integer_inequality_solver.cc
+++ b/solvers/integer_inequality_solver.cc
@@ -81,8 +81,13 @@ std::vector<ColumnType> ProcessInputs(const Eigen::MatrixXi& A,
  * the Cartesian product (v, z) for all v ∈ V */
 SolutionList CartesianProduct(const SolutionList& V, int z) {
   SolutionList cart_products(V.rows(), V.cols() + 1);
-  cart_products << V, SolutionList::Constant(V.rows(), 1, z);
-
+  if (V.rows() > 0) {
+    if (V.cols() == 0) {
+      cart_products.setConstant(z);
+    } else {
+      cart_products << V, SolutionList::Constant(V.rows(), 1, z);
+    }
+  }
   return cart_products;
 }
 


### PR DESCRIPTION
Towards #16937 and #17113.

Refer to https://reviews.llvm.org/D67122 for details.

We are not allowed (for example) to form zero-sized blocks into zero-sized matrices, at least not with Eigen 3.3.7.

This fault is detected by our forthcoming Clang 12 UBSan builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17096)
<!-- Reviewable:end -->
