### PR TITLE
Work around PETSc 1180

### DIFF
--- a/tools/workspace/petsc/patches/mal.patch
+++ b/tools/workspace/petsc/patches/mal.patch
@@ -1,0 +1,23 @@
+diff --git a/src/sys/memory/mal.c b/src/sys/memory/mal.c
+index 87678c5f2f..eabd9b2b97 100644
+--- a/src/sys/memory/mal.c
++++ b/src/sys/memory/mal.c
+@@ -414,9 +414,15 @@ PetscErrorCode PetscMallocA(int n,PetscBool clear,int lineno,const char *functio
+   if (petscmalloccoalesce) {
+     char *p;
+     ierr = (*PetscTrMalloc)(sumbytes,clear,lineno,function,filename,(void**)&p);CHKERRQ(ierr);
+-    for (i=0; i<n; i++) {
+-      *ptr[i] = bytes[i] ? p : NULL;
+-      p = (char*)PetscAddrAlign(p + bytes[i]);
++    if (p == NULL) {
++      for (i=0; i<n; i++) {
++        *ptr[i] = NULL;
++      }
++    } else {
++      for (i=0; i<n; i++) {
++        *ptr[i] = bytes[i] ? p : NULL;
++        p = (char*)PetscAddrAlign(p + bytes[i]);
++      }
+     }
+   } else {
+     for (i=0; i<n; i++) {

--- a/tools/workspace/petsc/patches/mal.patch
+++ b/tools/workspace/petsc/patches/mal.patch
@@ -1,7 +1,7 @@
 diff --git a/src/sys/memory/mal.c b/src/sys/memory/mal.c
 index 87678c5f2f..eabd9b2b97 100644
---- a/src/sys/memory/mal.c
-+++ b/src/sys/memory/mal.c
+--- src/sys/memory/mal.c
++++ src/sys/memory/mal.c
 @@ -414,9 +414,15 @@ PetscErrorCode PetscMallocA(int n,PetscBool clear,int lineno,const char *functio
    if (petscmalloccoalesce) {
      char *p;

--- a/tools/workspace/petsc/repository.bzl
+++ b/tools/workspace/petsc/repository.bzl
@@ -13,6 +13,8 @@ def petsc_repository(
         build_file = "@drake//tools/workspace/petsc:package.BUILD.bazel",
         mirrors = mirrors,
         patches = [
+            # Cherry-picked from upstream (to be removed once we upgrade).
+            "@drake//tools/workspace/petsc:patches/mal.patch",
             # Patch to fix dangerous global state in PETSc.
             "@drake//tools/workspace/petsc:patches/destroy.patch",
             "@drake//tools/workspace/petsc:patches/inherit.patch",


### PR DESCRIPTION
Work around an undefined-behavior sanitizer runtime failure in PETSc, "applying zero offset to null pointer", by adjusting the logic for the case when no bytes are allocated.

Reported as https://gitlab.com/petsc/petsc/-/issues/1180.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17102)
<!-- Reviewable:end -->
