### PR TITLE
[workspace] Fix drake-visualizer install rpath entries.

### DIFF
--- a/tools/install/installer.py
+++ b/tools/install/installer.py
@@ -275,9 +275,15 @@ def linux_fix_rpaths(dst_full):
             re_result = re.match(dylib_match, ldd_result[0])
             # Look for the absolute path in the dictionary of libraries using
             # the library name without its possible version number.
-            soname, _, _ = re_result.groups()
+            soname, version, _ = re_result.groups()
             if soname not in libraries_to_fix_rpath:
-                continue
+                # TODO(svenevs): when drake-visualizer support is removed, the
+                # capture of `version` and secondary check for e.g.,
+                # libvtk*.so.1 (libraries_to_fix_rpath includes the .1 for
+                # VTK-8) can be removed.
+                soname = f'{soname}{version}'
+                if soname not in libraries_to_fix_rpath:
+                    continue
             lib_dirname = os.path.dirname(dst_full)
             diff_path = os.path.dirname(
                 os.path.relpath(libraries_to_fix_rpath[soname], lib_dirname)

--- a/tools/workspace/drake_visualizer/drake_visualizer_installed.py.in
+++ b/tools/workspace/drake_visualizer/drake_visualizer_installed.py.in
@@ -25,9 +25,6 @@ from _drake_visualizer_builtin_scripts import (  # noqa
     _exec_drake_visualizer_with_plugins,
 )
 
-# Ensure that we can load the necessary shared libraries, when on Linux.
-os.environ["LD_LIBRARY_PATH"] = join(PREFIX_DIR, "lib")
-
 
 def main():
     # Execute wrapper.

--- a/tools/workspace/drake_visualizer/image/build-lcm.sh
+++ b/tools/workspace/drake_visualizer/image/build-lcm.sh
@@ -17,6 +17,12 @@ git clone --depth 1 \
     https://github.com/RobotLocomotion/drake.git /drake
 
 cd /drake
+# Drake requires the setup script to be installed in order to load
+# drake/gen/environment.bazelrc, this command generates this file.
+./setup/ubuntu/source_distribution/install_prereqs_user_environment.sh
+
+# Patch command is required to build lcm.
+apt-get install -y --no-install-recommends patch
 
 bazel run \
     --copt=-fstack-protector-strong \

--- a/tools/workspace/drake_visualizer/image/package.sh
+++ b/tools/workspace/drake_visualizer/image/package.sh
@@ -39,8 +39,38 @@ cp -r \
 strip \
     /opt/director/bin/drake-visualizer \
     /opt/director/lib/*.so \
+    /opt/director/lib/*.so.1 \
     /opt/director/lib/${python}/site-packages/director/*.so \
     /opt/director/lib/python3.*/site-packages/director/thirdparty/*.so
+
+# Fix the rpath entries so that components can find their corresponding VTK-8
+# counterparts.  This includes ensuring that VTK-8 libraries can find one
+# another ($ORIGIN), as well as python site-packages/{module}/*.so can find
+# the original VTK-8 libraries ($ORIGIN/../../..).
+find /opt/director/lib -type f -name "libvtk*-8.2.so.1" \
+    -mindepth 1 -maxdepth 1 \
+    -printf 'patchelf on %p\n' \
+    -exec patchelf --set-rpath '$ORIGIN' {} \;
+readonly site_packages="/opt/director/lib/${python}/site-packages"
+find "${site_packages}/vtkmodules" -type f -name "*.so" \
+    -mindepth 1 -maxdepth 1 \
+    -printf 'patchelf on %p\n' \
+    -exec patchelf --set-rpath '$ORIGIN/../../..' {} \;
+find "${site_packages}/director" -type f -name "vtk*.so" \
+    -mindepth 1 -maxdepth 1 \
+    -printf 'patchelf on %p\n' \
+    -exec patchelf --set-rpath '$ORIGIN/../../..' {} \;
+# Additionally, the rpath entries for the director components get set to
+# /opt/director/lib:/opt/vtk/lib:/opt/drake/lib which can create conflicts
+# when the machine where drake is being installed has these directories.
+# Overwrite them to refer to the components within this tarball.
+patchelf --set-rpath '$ORIGIN' /opt/director/lib/libddApp.so
+patchelf --set-rpath '$ORIGIN/../lib' /opt/director/bin/drake-visualizer
+# Lastly, _transformations.so has an rpath leading to /opt as well.  This
+# library depends on system components only, but we remove its rpath for
+# posterity and to avoid potential collisions.
+patchelf --remove-rpath \
+    "${site_packages}/director/thirdparty/_transformations.so"
 
 # Get various version numbers.
 readonly dv_tag=dv-$(cd /director/src; git describe)
@@ -59,7 +89,7 @@ readonly platform=$(lsb_release --codename --short)-$(uname --processor)
 #     -<build_number>.tar.gz
 #
 # The <build_number> was introduced to distinguish VTK-8/VTK-9 director split.
-readonly archive=${dv_tag}-${py_tag}-${qt_tag}-${vtk_tag}-${platform}-4.tar.gz
+readonly archive=${dv_tag}-${py_tag}-${qt_tag}-${vtk_tag}-${platform}-5.tar.gz
 
 cd /opt/director
 

--- a/tools/workspace/drake_visualizer/repository.bzl
+++ b/tools/workspace/drake_visualizer/repository.bzl
@@ -38,8 +38,8 @@ def _impl(repository_ctx):
         fail(os_result.error)
 
     if os_result.ubuntu_release == "20.04":
-        archive = "dv-0.1.0-406-g4c3e570a-python-3.8.10-qt-5.12.8-vtk-8.2.0-focal-x86_64-4.tar.gz"  # noqa
-        sha256 = "f149a13bbb3966f4004584e843f03a80075e671d6c7d25edd0acb83f4a0fc694"  # noqa
+        archive = "dv-0.1.0-406-g4c3e570a-python-3.8.10-qt-5.12.8-vtk-8.2.0-focal-x86_64-5.tar.gz"  # noqa
+        sha256 = "ddf85e332c0b7be8b13e81e6627a94f09a70517b7f82d7a49e50367b20cede87"  # noqa
         python_version = "3.8"
     else:
         repository_ctx.file("defs.bzl", "ENABLED = False")


### PR DESCRIPTION
- Inbound .deb packaging updates require the VTK-8 libraries to be able to resolve to their counterparts, this fixes it for the install
  logic and therefore in the .tar.gz package as well.
- Previously installer.py was skipping the VTK-8 libraries due to their .so.1 suffix, this is now fixed.
- rpath entries in the director tarball have been fixed, including removing entries to /opt that create conflicts when the system being installed on contains the same paths.
- Installed drake-visualizer no longer needs to modify LD_LIBRARY_PATH to run bin/.drake-visualizer-real as the rpaths have been fixed.
- New director tarball uploaded to S3.

NOTE: this is the only one that seems required to fix, `shlibdeps` gives a hard error on these ones.

The S3 archive is likely to be overwritten pending some unresolved changes, I need to test the packaging build here via CI.

Relates: #16932, #17058.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17105)
<!-- Reviewable:end -->
