### PR TITLE
[plant] Remove stacked actuation port

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -800,11 +800,6 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 &Class::get_actuation_input_port),
             py::arg("model_instance"), py_rvp::reference_internal,
             cls_doc.get_actuation_input_port.doc_1args)
-        .def("get_stacked_actuation_input_port",
-            overload_cast_explicit<const systems::InputPort<T>&>(
-                &Class::get_stacked_actuation_input_port),
-            py_rvp::reference_internal,
-            cls_doc.get_stacked_actuation_input_port.doc)
         .def("get_applied_generalized_force_input_port",
             overload_cast_explicit<const systems::InputPort<T>&>(
                 &Class::get_applied_generalized_force_input_port),

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -346,8 +346,6 @@ class TestPlant(unittest.TestCase):
         self.assertIsInstance(
             plant.get_actuation_input_port(), InputPort)
         self.assertIsInstance(
-            plant.get_stacked_actuation_input_port(), InputPort)
-        self.assertIsInstance(
             plant.get_state_output_port(), OutputPort)
         self.assertIsInstance(
             plant.get_generalized_acceleration_output_port(), OutputPort)

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -618,15 +618,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   const systems::InputPort<T>& get_actuation_input_port(
       ModelInstanceIndex model_instance) const;
 
-  /// Returns a constant reference to the input port for external actuation for
-  /// the case where only one model instance has actuated dofs.  This input
-  /// port is a vector valued port, which can be set with
-  /// JointActuator::set_actuation_vector().
-  /// @pre Finalize() was already called on `this` plant.
-  /// @throws std::exception if called before Finalize(), if the model does not
-  /// contain any actuators, or if multiple model instances have actuated dofs.
-  const systems::InputPort<T>& get_actuation_input_port() const;
-
   /// Returns a constant reference to the input port for external actuations for
   /// all actuated dofs regardless the number of model instances that have
   /// actuated dofs. The input actuation is assumed to be ordered according to
@@ -635,7 +626,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @pre Finalize() was already called on `this` plant.
   /// @throws std::exception if called before Finalize().
   /// @throws std::exception if individual actuation ports are connected.
-  const systems::InputPort<T>& get_stacked_actuation_input_port() const;
+  const systems::InputPort<T>& get_actuation_input_port() const;
 
   /// Returns a constant reference to the vector-valued input port for applied
   /// generalized forces, and the vector will be added directly into `tau` (see
@@ -4933,11 +4924,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   std::vector<systems::InputPortIndex> instance_actuation_ports_;
 
   // The actuation port for all actuated dofs.
-  systems::InputPortIndex stacked_actuation_port_;
-
-  // If only one model instance has actuated dofs, remember it here.  If
-  // multiple instances have actuated dofs, this index will not be valid.
-  ModelInstanceIndex actuated_instance_;
+  systems::InputPortIndex actuation_port_;
 
   // A port for externally applied generalized forces u.
   systems::InputPortIndex applied_generalized_force_input_port_;

--- a/multibody/plant/test/multibody_plant_reaction_forces_test.cc
+++ b/multibody/plant/test/multibody_plant_reaction_forces_test.cc
@@ -179,8 +179,7 @@ class LadderTest : public ::testing::Test {
 
     // Fix the actuation.
     const Vector1d tau_actuation = kActuationTorque * Vector1d::Ones();
-    plant_->get_stacked_actuation_input_port().FixValue(plant_context,
-                                                        tau_actuation);
+    plant_->get_actuation_input_port().FixValue(plant_context, tau_actuation);
 
     if (locked_joint) {
         joint_->Lock(plant_context);


### PR DESCRIPTION
Relates to #17059.
Change the semantic of the old `get_actuation_input_port()` from getting the one and only actuation input port to the input port for all actuated instances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17107)
<!-- Reviewable:end -->
