### PR TITLE
Allow the user to specify the print out name of the Gram matrix.

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -726,12 +726,14 @@ void BindMathematicalProgram(py::module m) {
           static_cast<std::pair<Polynomial, MatrixXDecisionVariable> (
               MathematicalProgram::*)(
               const Eigen::Ref<const VectorX<Monomial>>&,
-              MathematicalProgram::NonnegativePolynomial)>(
+              MathematicalProgram::NonnegativePolynomial,
+              const std::string& gram_name)>(
               &MathematicalProgram::NewSosPolynomial),
           py::arg("monomial_basis"),
           py::arg("type") = MathematicalProgram::NonnegativePolynomial::kSos,
+          py::arg("gram_name") = "S",
           doc.MathematicalProgram.NewSosPolynomial
-              .doc_2args_monomial_basis_type)
+              .doc_3args_monomial_basis_type_gram_name)
       .def("NewSosPolynomial",
           static_cast<Polynomial (MathematicalProgram::*)(
               const Eigen::Ref<const MatrixX<symbolic::Variable>>&,
@@ -745,12 +747,13 @@ void BindMathematicalProgram(py::module m) {
       .def("NewSosPolynomial",
           static_cast<std::pair<Polynomial, MatrixXDecisionVariable> (
               MathematicalProgram::*)(const Variables&, int,
-              MathematicalProgram::NonnegativePolynomial)>(
+              MathematicalProgram::NonnegativePolynomial, const std::string&)>(
               &MathematicalProgram::NewSosPolynomial),
           py::arg("indeterminates"), py::arg("degree"),
           py::arg("type") = MathematicalProgram::NonnegativePolynomial::kSos,
+          py::arg("gram_name") = "S",
           doc.MathematicalProgram.NewSosPolynomial
-              .doc_3args_indeterminates_degree_type)
+              .doc_4args_indeterminates_degree_type_gram_name)
       .def("NewEvenDegreeNonnegativePolynomial",
           &MathematicalProgram::NewEvenDegreeNonnegativePolynomial,
           py::arg("indeterminates"), py::arg("degree"), py::arg("type"),
@@ -1170,37 +1173,45 @@ void BindMathematicalProgram(py::module m) {
       .def("AddSosConstraint",
           static_cast<MatrixXDecisionVariable (MathematicalProgram::*)(
               const Polynomial&, const Eigen::Ref<const VectorX<Monomial>>&,
-              MathematicalProgram::NonnegativePolynomial)>(
+              MathematicalProgram::NonnegativePolynomial,
+              const std::string& gram_name)>(
               &MathematicalProgram::AddSosConstraint),
           py::arg("p"), py::arg("monomial_basis"),
           py::arg("type") = MathematicalProgram::NonnegativePolynomial::kSos,
+          py::arg("gram_name") = "S",
           doc.MathematicalProgram.AddSosConstraint
-              .doc_3args_p_monomial_basis_type)
+              .doc_4args_p_monomial_basis_type_gram_name)
       .def("AddSosConstraint",
           static_cast<std::pair<MatrixXDecisionVariable,
               VectorX<symbolic::Monomial>> (MathematicalProgram::*)(
-              const Polynomial&, MathematicalProgram::NonnegativePolynomial)>(
+              const Polynomial&, MathematicalProgram::NonnegativePolynomial,
+              const std::string& gram_name)>(
               &MathematicalProgram::AddSosConstraint),
           py::arg("p"),
           py::arg("type") = MathematicalProgram::NonnegativePolynomial::kSos,
-          doc.MathematicalProgram.AddSosConstraint.doc_2args_p_type)
+          py::arg("gram_name") = "S",
+          doc.MathematicalProgram.AddSosConstraint.doc_3args_p_type_gram_name)
       .def("AddSosConstraint",
           static_cast<MatrixXDecisionVariable (MathematicalProgram::*)(
               const Expression&, const Eigen::Ref<const VectorX<Monomial>>&,
-              MathematicalProgram::NonnegativePolynomial)>(
+              MathematicalProgram::NonnegativePolynomial,
+              const std::string& gram_name)>(
               &MathematicalProgram::AddSosConstraint),
           py::arg("e"), py::arg("monomial_basis"),
           py::arg("type") = MathematicalProgram::NonnegativePolynomial::kSos,
+          py::arg("gram_name") = "S",
           doc.MathematicalProgram.AddSosConstraint
-              .doc_3args_e_monomial_basis_type)
+              .doc_4args_e_monomial_basis_type_gram_name)
       .def("AddSosConstraint",
           static_cast<std::pair<MatrixXDecisionVariable,
               VectorX<symbolic::Monomial>> (MathematicalProgram::*)(
-              const Expression&, MathematicalProgram::NonnegativePolynomial)>(
+              const Expression&, MathematicalProgram::NonnegativePolynomial,
+              const std::string& gram_name)>(
               &MathematicalProgram::AddSosConstraint),
           py::arg("e"),
           py::arg("type") = MathematicalProgram::NonnegativePolynomial::kSos,
-          doc.MathematicalProgram.AddSosConstraint.doc_2args_e_type)
+          py::arg("gram_name") = "S",
+          doc.MathematicalProgram.AddSosConstraint.doc_3args_e_type_gram_name)
       .def("AddEqualityConstraintBetweenPolynomials",
           &MathematicalProgram::AddEqualityConstraintBetweenPolynomials,
           py::arg("p1"), py::arg("p2"),

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -643,7 +643,8 @@ class TestMathematicalProgram(unittest.TestCase):
         x = prog.NewIndeterminates(3, "x")
         (poly1, gramian1) = prog.NewSosPolynomial(
             indeterminates=sym.Variables(x), degree=4,
-            type=mp.MathematicalProgram.NonnegativePolynomial.kSdsos)
+            type=mp.MathematicalProgram.NonnegativePolynomial.kSdsos,
+            gram_name="M0")
         self.assertIsInstance(poly1, sym.Polynomial)
         self.assertIsInstance(gramian1, np.ndarray)
 
@@ -656,7 +657,8 @@ class TestMathematicalProgram(unittest.TestCase):
 
         poly3, gramian3 = prog.NewSosPolynomial(
             monomial_basis=(sym.Monomial(x[0]), sym.Monomial(x[1])),
-            type=mp.MathematicalProgram.NonnegativePolynomial.kSos)
+            type=mp.MathematicalProgram.NonnegativePolynomial.kSos,
+            gram_name="M2")
         self.assertIsInstance(poly3, sym.Polynomial)
         self.assertIsInstance(gramian3, np.ndarray)
 
@@ -681,10 +683,12 @@ class TestMathematicalProgram(unittest.TestCase):
         Q = prog.AddSosConstraint(
            p=sym.Polynomial(x[0]**2 + 1),
            monomial_basis=[sym.Monomial(x[0])],
-           type=mp.MathematicalProgram.NonnegativePolynomial.kSdsos)
+           type=mp.MathematicalProgram.NonnegativePolynomial.kSdsos,
+           gram_name="Q")
         Q, m = prog.AddSosConstraint(
             p=sym.Polynomial(x[0]**2 + 2),
-            type=mp.MathematicalProgram.NonnegativePolynomial.kSdsos)
+            type=mp.MathematicalProgram.NonnegativePolynomial.kSdsos,
+            gram_name="Q")
 
     def test_sos(self):
         # Find a,b,c,d subject to
@@ -699,16 +703,18 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertEqual(prog.indeterminates_index()[x[0].get_id()], 0)
         poly = prog.NewFreePolynomial(sym.Variables(x), 1)
         (poly, binding) = prog.NewSosPolynomial(
-            indeterminates=sym.Variables(x), degree=2)
+            indeterminates=sym.Variables(x), degree=2, gram_name="M0")
         even_poly = prog.NewEvenDegreeFreePolynomial(sym.Variables(x), 2)
         odd_poly = prog.NewOddDegreeFreePolynomial(sym.Variables(x), 3)
         y = prog.NewIndeterminates(1, "y")
         self.assertEqual(prog.indeterminates_index()[y[0].get_id()], 1)
         (poly, binding) = prog.NewSosPolynomial(
-            monomial_basis=(sym.Monomial(x[0]), sym.Monomial(y[0])))
+            monomial_basis=(sym.Monomial(x[0]), sym.Monomial(y[0])),
+            gram_name="M1")
         d = prog.NewContinuousVariables(2, "d")
-        prog.AddSosConstraint(d[0]*x.dot(x))
-        prog.AddSosConstraint(d[1]*x.dot(x), [sym.Monomial(x[0])])
+        prog.AddSosConstraint(d[0]*x.dot(x), gram_name="Q1")
+        prog.AddSosConstraint(
+            d[1]*x.dot(x), [sym.Monomial(x[0])], gram_name="Q2")
         prog.AddLinearEqualityConstraint(d[0] + d[1] == 1)
         result = mp.Solve(prog)
         self.assertTrue(result.is_success())

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -217,9 +217,9 @@ symbolic::Polynomial MathematicalProgram::NewOddDegreeFreePolynomial(
 pair<symbolic::Polynomial, MatrixXDecisionVariable>
 MathematicalProgram::NewSosPolynomial(
     const Eigen::Ref<const VectorX<symbolic::Monomial>>& monomial_basis,
-    NonnegativePolynomial type) {
+    NonnegativePolynomial type, const std::string& gram_name) {
   const MatrixXDecisionVariable Q =
-      NewSymmetricContinuousVariables(monomial_basis.size());
+      NewSymmetricContinuousVariables(monomial_basis.size(), gram_name);
   const symbolic::Polynomial p = NewSosPolynomial(Q, monomial_basis, type);
   return std::make_pair(p, Q);
 }
@@ -272,12 +272,13 @@ symbolic::Polynomial MathematicalProgram::NewSosPolynomial(
 
 pair<symbolic::Polynomial, MatrixXDecisionVariable>
 MathematicalProgram::NewSosPolynomial(const symbolic::Variables& indeterminates,
-                                      int degree, NonnegativePolynomial type) {
+                                      int degree, NonnegativePolynomial type,
+                                      const std::string& gram_name) {
   DRAKE_DEMAND(degree >= 0 && degree % 2 == 0);
   if (degree == 0) {
     // The polynomial only has a non-negative constant term.
     const symbolic::Variable poly_constant =
-        NewContinuousVariables<1>("poly_constant")(0);
+        NewContinuousVariables<1>(gram_name)(0);
     AddBoundingBoxConstraint(0, kInf, poly_constant);
     MatrixXDecisionVariable gram(1, 1);
     gram(0, 0) = poly_constant;
@@ -286,7 +287,7 @@ MathematicalProgram::NewSosPolynomial(const symbolic::Variables& indeterminates,
   } else {
     const drake::VectorX<symbolic::Monomial> x{
         MonomialBasis(indeterminates, degree / 2)};
-    return NewSosPolynomial(x, type);
+    return NewSosPolynomial(x, type, gram_name);
   }
 }
 
@@ -1356,8 +1357,9 @@ namespace {
 MatrixXDecisionVariable DoAddSosConstraint(
     MathematicalProgram* const prog, const symbolic::Polynomial& p,
     const Eigen::Ref<const VectorX<symbolic::Monomial>>& monomial_basis,
-    MathematicalProgram::NonnegativePolynomial type) {
-  const auto pair = prog->NewSosPolynomial(monomial_basis, type);
+    MathematicalProgram::NonnegativePolynomial type,
+    const std::string& gram_name) {
+  const auto pair = prog->NewSosPolynomial(monomial_basis, type, gram_name);
   const symbolic::Polynomial& sos_poly{pair.first};
   const MatrixXDecisionVariable& Q{pair.second};
 
@@ -1371,9 +1373,11 @@ MatrixXDecisionVariable DoAddSosConstraint(
 // Body of MathematicalProgram::AddSosConstraint(const symbolic::Polynomial&).
 pair<MatrixXDecisionVariable, VectorX<symbolic::Monomial>> DoAddSosConstraint(
     MathematicalProgram* const prog, const symbolic::Polynomial& p,
-    MathematicalProgram::NonnegativePolynomial type) {
+    MathematicalProgram::NonnegativePolynomial type,
+    const std::string& gram_name) {
   const VectorX<symbolic::Monomial> m = ConstructMonomialBasis(p);
-  const MatrixXDecisionVariable Q = prog->AddSosConstraint(p, m, type);
+  const MatrixXDecisionVariable Q =
+      prog->AddSosConstraint(p, m, type, gram_name);
   return std::make_pair(Q, m);
 }
 
@@ -1382,53 +1386,58 @@ pair<MatrixXDecisionVariable, VectorX<symbolic::Monomial>> DoAddSosConstraint(
 MatrixXDecisionVariable MathematicalProgram::AddSosConstraint(
     const symbolic::Polynomial& p,
     const Eigen::Ref<const VectorX<symbolic::Monomial>>& monomial_basis,
-    MathematicalProgram::NonnegativePolynomial type) {
+    MathematicalProgram::NonnegativePolynomial type,
+    const std::string& gram_name) {
   const Variables indeterminates_vars{indeterminates()};
   if (Variables(p.indeterminates()).IsSubsetOf(indeterminates_vars) &&
       intersect(indeterminates_vars, Variables(p.decision_variables()))
           .empty()) {
-    return DoAddSosConstraint(this, p, monomial_basis, type);
+    return DoAddSosConstraint(this, p, monomial_basis, type, gram_name);
   } else {
     // Need to reparse p, we first make a copy of p and reparse that.
     symbolic::Polynomial p_reparsed{p};
     Reparse(&p_reparsed);
-    return DoAddSosConstraint(this, p_reparsed, monomial_basis, type);
+    return DoAddSosConstraint(this, p_reparsed, monomial_basis, type,
+                              gram_name);
   }
 }
 
 pair<MatrixXDecisionVariable, VectorX<symbolic::Monomial>>
 MathematicalProgram::AddSosConstraint(
     const symbolic::Polynomial& p,
-    MathematicalProgram::NonnegativePolynomial type) {
+    MathematicalProgram::NonnegativePolynomial type,
+    const std::string& gram_name) {
   const Variables indeterminates_vars{indeterminates()};
   if (Variables(p.indeterminates()).IsSubsetOf(indeterminates_vars) &&
       intersect(indeterminates_vars, Variables(p.decision_variables()))
           .empty()) {
-    return DoAddSosConstraint(this, p, type);
+    return DoAddSosConstraint(this, p, type, gram_name);
   } else {
     // Need to reparse p, we first make a copy of p and reparse that.
     symbolic::Polynomial p_reparsed{p};
     Reparse(&p_reparsed);
-    return DoAddSosConstraint(this, p_reparsed, type);
+    return DoAddSosConstraint(this, p_reparsed, type, gram_name);
   }
 }
 
 MatrixXDecisionVariable MathematicalProgram::AddSosConstraint(
     const symbolic::Expression& e,
     const Eigen::Ref<const VectorX<symbolic::Monomial>>& monomial_basis,
-    MathematicalProgram::NonnegativePolynomial type) {
+    MathematicalProgram::NonnegativePolynomial type,
+    const std::string& gram_name) {
   return AddSosConstraint(
       symbolic::Polynomial{e, symbolic::Variables{this->indeterminates()}},
-      monomial_basis, type);
+      monomial_basis, type, gram_name);
 }
 
 pair<MatrixXDecisionVariable, VectorX<symbolic::Monomial>>
 MathematicalProgram::AddSosConstraint(
     const symbolic::Expression& e,
-    MathematicalProgram::NonnegativePolynomial type) {
+    MathematicalProgram::NonnegativePolynomial type,
+    const std::string& gram_name) {
   return AddSosConstraint(
       symbolic::Polynomial{e, symbolic::Variables{this->indeterminates()}},
-      type);
+      type, gram_name);
 }
 
 std::vector<Binding<LinearEqualityConstraint>>

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -479,12 +479,14 @@ class MathematicalProgram {
    * - if type = kSos, we impose the polynomial being SOS.
    * - if type = kSdsos, we impose the polynomial being SDSOS.
    * - if type = kDsos, we impose the polynomial being DSOS.
+   * @param gram_name The name of the gram matrix for print out.
    * @note Q is a symmetric monomial_basis.rows() x monomial_basis.rows()
    * matrix.
    */
   std::pair<symbolic::Polynomial, MatrixXDecisionVariable> NewSosPolynomial(
       const Eigen::Ref<const VectorX<symbolic::Monomial>>& monomial_basis,
-      NonnegativePolynomial type = NonnegativePolynomial::kSos);
+      NonnegativePolynomial type = NonnegativePolynomial::kSos,
+      const std::string& gram_name = "S");
 
   /**
    * Overloads NewSosPolynomial, except the Gramian matrix Q is an
@@ -508,13 +510,15 @@ class MathematicalProgram {
    * - if type = kSos, we impose the polynomial being SOS.
    * - if type = kSdsos, we impose the polynomial being SDSOS.
    * - if type = kDsos, we impose the polynomial being DSOS.
+   * @param gram_name The name of the gram matrix for print out.
    *
    * @throws std::exception if @p degree is not a positive even integer.
    * @see MonomialBasis.
    */
   std::pair<symbolic::Polynomial, MatrixXDecisionVariable> NewSosPolynomial(
       const symbolic::Variables& indeterminates, int degree,
-      NonnegativePolynomial type = NonnegativePolynomial::kSos);
+      NonnegativePolynomial type = NonnegativePolynomial::kSos,
+      const std::string& gram_name = "S");
 
   /**
    * @anchor even_degree_nonnegative_polynomial
@@ -2495,6 +2499,7 @@ class MathematicalProgram {
    * @param type The type of the polynomial. @default is kSos, but the user can
    * also use kSdsos and kDsos. Refer to NonnegativePolynomial for details on
    * different types of sos polynomials.
+   * @param gram_name The name of the gram matrix for print out.
    *
    * @note It calls `Reparse` to enforce `p` to have this MathematicalProgram's
    * indeterminates if necessary.
@@ -2502,7 +2507,8 @@ class MathematicalProgram {
   MatrixXDecisionVariable AddSosConstraint(
       const symbolic::Polynomial& p,
       const Eigen::Ref<const VectorX<symbolic::Monomial>>& monomial_basis,
-      NonnegativePolynomial type = NonnegativePolynomial::kSos);
+      NonnegativePolynomial type = NonnegativePolynomial::kSos,
+      const std::string& gram_name = "S");
 
   /**
    * Adds constraints that a given polynomial @p p is a sums-of-squares (SOS),
@@ -2514,13 +2520,15 @@ class MathematicalProgram {
    * @param type The type of the polynomial. @default is kSos, but the user can
    * also use kSdsos and kDsos. Refer to NonnegativePolynomial for the details
    * on different type of sos polynomials.
+   * @param gram_name The name of the gram matrix for print out.
    *
    * @note It calls `Reparse` to enforce `p` to have this MathematicalProgram's
    * indeterminates if necessary.
    */
   std::pair<MatrixXDecisionVariable, VectorX<symbolic::Monomial>>
   AddSosConstraint(const symbolic::Polynomial& p,
-                   NonnegativePolynomial type = NonnegativePolynomial::kSos);
+                   NonnegativePolynomial type = NonnegativePolynomial::kSos,
+                   const std::string& gram_name = "S");
 
   /**
    * Adds constraints that a given symbolic expression @p e is a
@@ -2530,11 +2538,13 @@ class MathematicalProgram {
    * program. It returns the coefficients matrix Q, which is positive
    * semidefinite.
    * @param type Refer to NonnegativePolynomial class documentation.
+   * @param gram_name The name of the gram matrix for print out.
    */
   MatrixXDecisionVariable AddSosConstraint(
       const symbolic::Expression& e,
       const Eigen::Ref<const VectorX<symbolic::Monomial>>& monomial_basis,
-      NonnegativePolynomial type = NonnegativePolynomial::kSos);
+      NonnegativePolynomial type = NonnegativePolynomial::kSos,
+      const std::string& gram_name = "S");
 
   /**
    * Adds constraints that a given symbolic expression @p e is a sums-of-squares
@@ -2544,10 +2554,12 @@ class MathematicalProgram {
    *  - The coefficients matrix Q, which is positive semidefinite.
    *  - The monomial basis m.
    * @param type Refer to NonnegativePolynomial class documentation.
+   * @param gram_name The name of the gram matrix for print out.
    */
   std::pair<MatrixXDecisionVariable, VectorX<symbolic::Monomial>>
   AddSosConstraint(const symbolic::Expression& e,
-                   NonnegativePolynomial type = NonnegativePolynomial::kSos);
+                   NonnegativePolynomial type = NonnegativePolynomial::kSos,
+                   const std::string& gram_name = "S");
 
   /**
    * Constraining that two polynomials are the same (i.e., they have the same

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -3300,9 +3300,10 @@ void CheckNewSosPolynomial(MathematicalProgram::NonnegativePolynomial type) {
   MathematicalProgram prog;
   auto t = prog.NewIndeterminates<4>();
   const auto m = symbolic::MonomialBasis<4, 2>(symbolic::Variables(t));
-  const auto pair = prog.NewSosPolynomial(m, type);
+  const auto pair = prog.NewSosPolynomial(m, type, "TestGram");
   const symbolic::Polynomial& p = pair.first;
   const MatrixXDecisionVariable& Q = pair.second;
+  EXPECT_NE(Q(0, 0).get_name().find("TestGram"), std::string::npos);
   MatrixX<symbolic::Polynomial> Q_poly(m.rows(), m.rows());
   const symbolic::Monomial monomial_one{};
   for (int i = 0; i < Q_poly.rows(); ++i) {
@@ -3634,8 +3635,10 @@ GTEST_TEST(TestMathematicalProgram, AddSosConstraint) {
   const Vector2<symbolic::Monomial> monomial_basis(symbolic::Monomial{},
                                                    symbolic::Monomial(x, 1));
 
-  const Matrix2<symbolic::Variable> Q_psd =
-      prog.AddSosConstraint(p1, monomial_basis);
+  const Matrix2<symbolic::Variable> Q_psd = prog.AddSosConstraint(
+      p1, monomial_basis, MathematicalProgram::NonnegativePolynomial::kSos,
+      "Q");
+  EXPECT_NE(Q_psd(0, 0).get_name().find("Q"), std::string::npos);
   EXPECT_EQ(prog.positive_semidefinite_constraints().size(), 1u);
   EXPECT_EQ(prog.lorentz_cone_constraints().size(), 0u);
   EXPECT_EQ(prog.rotated_lorentz_cone_constraints().size(), 0u);


### PR DESCRIPTION
When adding SOS polynomial constraint, set the name of the Gram matrix. This is useful for debugging SOS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17114)
<!-- Reviewable:end -->
