### PR TITLE
[tools] Disable dReal and IBEX on ARM64

### DIFF
--- a/tools/macos-arch-arm64.bazelrc
+++ b/tools/macos-arch-arm64.bazelrc
@@ -2,3 +2,8 @@
 
 # N.B. Ensure this is consistent with `execute.bzl`.
 build --action_env=PATH=/opt/homebrew/bin:/usr/bin:/bin
+
+# TODO(jwnimmer-tri) At the moment, IBEX's vendored filib library is hard-coded
+# to use x86 assembly code. Ideally, we should find a way to build it on ARM64
+# at which point we can re-enable IBEX and dReal.
+build --define NO_DREAL=ON


### PR DESCRIPTION
Towards #17009.

At the moment, IBEX's vendored filib library is hard-coded to use x86 assembly code. Ideally, we should find a way to build it on ARM64 at which point we can re-enable IBEX and dReal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17122)
<!-- Reviewable:end -->
