### PR TITLE
AddQuadraticAsRotatedLorentzConeConstraint takes optinal psd_tol

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -1106,11 +1106,13 @@ void BindMathematicalProgram(py::module m) {
           [](MathematicalProgram* self,
               const Eigen::Ref<const Eigen::MatrixXd>& Q,
               const Eigen::Ref<const Eigen::VectorXd>& b, double c,
-              const Eigen::Ref<const VectorXDecisionVariable>& vars) {
+              const Eigen::Ref<const VectorXDecisionVariable>& vars,
+              double psd_tol) {
             return self->AddQuadraticAsRotatedLorentzConeConstraint(
-                Q, b, c, vars);
+                Q, b, c, vars, psd_tol);
           },
           py::arg("Q"), py::arg("b"), py::arg("c"), py::arg("vars"),
+          py::arg("psd_tol") = 0.,
           doc.MathematicalProgram.AddQuadraticAsRotatedLorentzConeConstraint
               .doc)
       .def("AddLinearComplementarityConstraint",

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -1272,7 +1272,8 @@ class TestMathematicalProgram(unittest.TestCase):
             Q=np.array([[1, 2.], [2., 10.]]),
             b=np.array([1., 3.]),
             c=0.5,
-            vars=x)
+            vars=x,
+            psd_tol=0.)
         self.assertIsInstance(dut.evaluator(), mp.RotatedLorentzConeConstraint)
 
     def test_add_linear_matrix_inequality_constraint(self):

--- a/math/quadratic_form.cc
+++ b/math/quadratic_form.cc
@@ -31,10 +31,10 @@ Eigen::MatrixXd DecomposePSDmatrixIntoXtransposeTimesX(
       int X_row_count = 0;
       for (int i = 0; i < es_Y.eigenvalues().rows(); ++i) {
         if (es_Y.eigenvalues()(i) < -zero_tol) {
-          throw std::runtime_error(
-              fmt::format("Y is not positive definite. It has an eigenvalue {} "
-                          "that is more negative than the tolerance {}.",
-                          es_Y.eigenvalues()(i), zero_tol));
+          throw std::runtime_error(fmt::format(
+              "Y is not positive semidefinite. It has an eigenvalue {} "
+              "that is less than the tolerance {}.",
+              es_Y.eigenvalues()(i), -zero_tol));
         } else if (es_Y.eigenvalues()(i) > zero_tol) {
           X.row(X_row_count++) = std::sqrt(es_Y.eigenvalues()(i)) *
                                  es_Y.eigenvectors().col(i).transpose();

--- a/math/test/quadratic_form_test.cc
+++ b/math/test/quadratic_form_test.cc
@@ -84,8 +84,8 @@ GTEST_TEST(TestDecomposePSDmatrixIntoXtransposeTimesX, negativeY) {
   // Y is a negative definite matrix.
   DRAKE_EXPECT_THROWS_MESSAGE(
       DecomposePSDmatrixIntoXtransposeTimesX(-Eigen::Matrix3d::Identity(), 0),
-      "Y is not positive definite. It has an eigenvalue -1.* that is more "
-      "negative than the tolerance 0.*.");
+      "Y is not positive semidefinite. It has an eigenvalue -1.0 that is less"
+      " than the tolerance -0.*.");
 }
 
 GTEST_TEST(TestDecomposePSDmatrixIntoXtransposeTimesX, indefiniteY) {

--- a/solvers/create_constraint.cc
+++ b/solvers/create_constraint.cc
@@ -643,37 +643,10 @@ Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
 std::shared_ptr<RotatedLorentzConeConstraint>
 ParseQuadraticAsRotatedLorentzConeConstraint(
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
-    const Eigen::Ref<const Eigen::VectorXd>& b, double c) {
-  // [-bᵀx-c, 1, Fx] is in the rotated Lorentz cone, where FᵀF = Q
-  Eigen::MatrixXd F;
-  // First try Cholesky decomposition
-  Eigen::LLT<Eigen::MatrixXd> llt((Q + Q.transpose()) / 4.);
-  if (llt.info() == Eigen::Success) {
-    F = llt.matrixU();
-  } else {
-    Eigen::LDLT<Eigen::MatrixXd> ldlt((Q + Q.transpose()) / 4.);
-    if (ldlt.info() == Eigen::Success) {
-      if (!ldlt.isPositive()) {
-        throw std::runtime_error(
-            "ParseQuadraticAsRotatedLorentzConeConstraint: ldlt.isPositive() "
-            "is false. The matrix Q is not positive semidefinite.");
-      }
-      const Eigen::MatrixXd D_sqrt =
-          ldlt.vectorD().array().sqrt().matrix().asDiagonal();
-      F = D_sqrt * ldlt.matrixL().transpose() * ldlt.transpositionsP();
-      // Only need to keep the top rank(Q) rows of P.
-      int rank_Q = 0;
-      for (int i = 0; i < Q.rows(); ++i) {
-        if (ldlt.vectorD()(i) > 0) {
-          ++rank_Q;
-        }
-      }
-      F.conservativeResize(rank_Q, F.cols());
-    } else {
-      throw std::runtime_error(
-          "ParseQuadraticAsRotatedLorentzConeConstraint: ldlt fails.");
-    }
-  }
+    const Eigen::Ref<const Eigen::VectorXd>& b, double c, double zero_tol) {
+  // [-bᵀx-c, 1, Fx] is in the rotated Lorentz cone, where FᵀF = 0.5 * Q
+  const Eigen::MatrixXd F = math::DecomposePSDmatrixIntoXtransposeTimesX(
+      (Q + Q.transpose()) / 4, zero_tol);
   // A_lorentz * x + b_lorentz = [-bᵀx-c, 1, Fx]
   Eigen::MatrixXd A_lorentz = Eigen::MatrixXd::Zero(2 + F.rows(), F.cols());
   Eigen::VectorXd b_lorentz = Eigen::VectorXd::Zero(2 + F.rows());

--- a/solvers/create_constraint.h
+++ b/solvers/create_constraint.h
@@ -231,7 +231,10 @@ Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
 
 /** For a convex quadratic constraint 0.5xᵀQx + bᵀx + c <= 0, we parse it as a
  * rotated Lorentz cone constraint [-bᵀx-c, 1, Fx] is in the rotated Lorentz
- * cone where FᵀF = Q
+ * cone where FᵀF = 0.5 * Q
+ * @param zero_tol The tolerance to determine if Q is a positive semidefinite
+ * matrix. Check math::DecomposePSDmatrixIntoXtransposeTimesX for a detailed
+ * explanation. zero_tol should be non-negative. @default is 0.
  * @throw exception if this quadratic constraint is not convex (Q is not
  * positive semidefinite)
  *
@@ -241,7 +244,7 @@ Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
 std::shared_ptr<RotatedLorentzConeConstraint>
 ParseQuadraticAsRotatedLorentzConeConstraint(
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
-    const Eigen::Ref<const Eigen::VectorXd>& b, double c);
+    const Eigen::Ref<const Eigen::VectorXd>& b, double c, double zero_tol = 0.);
 
 // TODO(eric.cousineau): Implement this if variable creation is separated.
 // Format would be (tuple(linear_binding, psd_binding), new_vars)

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -961,9 +961,9 @@ Binding<RotatedLorentzConeConstraint>
 MathematicalProgram::AddQuadraticAsRotatedLorentzConeConstraint(
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
     const Eigen::Ref<const Eigen::VectorXd>& b, double c,
-    const Eigen::Ref<const VectorXDecisionVariable>& vars) {
+    const Eigen::Ref<const VectorXDecisionVariable>& vars, double psd_tol) {
   auto constraint =
-      internal::ParseQuadraticAsRotatedLorentzConeConstraint(Q, b, c);
+      internal::ParseQuadraticAsRotatedLorentzConeConstraint(Q, b, c, psd_tol);
   return AddConstraint(constraint, vars);
 }
 

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2254,12 +2254,15 @@ class MathematicalProgram {
    * @param b The linear coefficient of the quadratic constraint.
    * @param c The constant term of the quadratic constraint.
    * @param vars x in the documentation above.
+   * @param psd_tol If the minimal eigenvalue of Q is smaller than -psd_tol,
+   * then throw an exception. @default = 0.
    */
   Binding<RotatedLorentzConeConstraint>
   AddQuadraticAsRotatedLorentzConeConstraint(
       const Eigen::Ref<const Eigen::MatrixXd>& Q,
       const Eigen::Ref<const Eigen::VectorXd>& b, double c,
-      const Eigen::Ref<const VectorX<symbolic::Variable>>& vars);
+      const Eigen::Ref<const VectorX<symbolic::Variable>>& vars,
+      double psd_tol = 0.);
 
   /**
    * Adds a linear complementarity constraints referencing a subset of


### PR DESCRIPTION
When the minimal eigen value of Q is smaller than -psd_tol, then we throw an error.
This helps when Q is computed numerically and being marginally psd.

cc @lujieyang

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17125)
<!-- Reviewable:end -->
