### PR TITLE
[pydrake] Add a few missing `rvp_copy` attributes

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -1101,7 +1101,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
     cls  // BR
         .def(py::init<>())
         .def_readwrite("body_index", &Class::body_index, cls_doc.body_index.doc)
-        .def_readwrite("p_BoBq_B", &Class::p_BoBq_B, cls_doc.p_BoBq_B.doc)
+        .def_readwrite("p_BoBq_B", &Class::p_BoBq_B,
+            return_value_policy_for_scalar_type<T>(), cls_doc.p_BoBq_B.doc)
         .def_readwrite("F_Bq_W", &Class::F_Bq_W, cls_doc.F_Bq_W.doc);
     DefCopyAndDeepCopy(&cls);
     AddValueInstantiation<Class>(m);

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1167,6 +1167,8 @@ class TestPlant(unittest.TestCase):
                 test_force.F_Bq_W = SpatialForce_[T](
                     tau=[0., 0., 0.], f=[0., 0., 1.])
                 spatial_forces_vector.set_value([test_force])
+                numpy_compare.assert_float_equal(test_force.p_BoBq_B,
+                                                 np.zeros(3))
 
             def DoCalcVectorOutput(self, context, generalized_forces):
                 generalized_forces.SetFromVector(np.zeros(self.nv))

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -442,6 +442,7 @@ drake_py_unittest(
         ":framework_py",
         ":primitives_py",
         "//bindings/pydrake:trajectories_py",
+        "//bindings/pydrake/common/test_utilities",
     ],
 )
 

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -300,7 +300,8 @@ PYBIND11_MODULE(analysis, m) {
             doc.RegionOfAttractionOptions.lyapunov_candidate.doc)
         .def_readwrite("state_variables",
             &RegionOfAttractionOptions::state_variables,
-            doc.RegionOfAttractionOptions.state_variables.doc)
+            // dtype = object arrays must be copied, and cannot be referenced.
+            py_rvp::copy, doc.RegionOfAttractionOptions.state_variables.doc)
         .def_readwrite("use_implicit_dynamics",
             &RegionOfAttractionOptions::use_implicit_dynamics,
             doc.RegionOfAttractionOptions.use_implicit_dynamics.doc)

--- a/bindings/pydrake/systems/test/analysis_test.py
+++ b/bindings/pydrake/systems/test/analysis_test.py
@@ -1,6 +1,7 @@
 import copy
 import unittest
 
+from pydrake.common.test_utilities import numpy_compare
 from pydrake.symbolic import Variable, Expression
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.systems.primitives import (
@@ -35,6 +36,7 @@ class TestAnalysis(unittest.TestCase):
         options = RegionOfAttractionOptions()
         options.lyapunov_candidate = x*x
         options.state_variables = [x]
+        numpy_compare.assert_equal(options.state_variables, [x])
         options.use_implicit_dynamics = False
         V = RegionOfAttraction(system=sys, context=context, options=options)
         self.assertEqual(repr(options), "".join([


### PR DESCRIPTION
I ran into this error working with `ExternallyAppliedSpatialForce`:
```
dtype = object arrays must be copied, and cannot be referenced
```

Once I understood the fix, I scanned quickly for other
`.def_readwrite` statements that could have been missing the same, and
found one more on that pass.

+@jwnimmer-tri for both reviews, please?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17126)
<!-- Reviewable:end -->
