### PR TITLE
[math] Move DifferentiableNorm to math; use it in Wing.

### DIFF
--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -176,12 +176,14 @@ drake_cc_library(
     name = "gradient",
     srcs = [
         "autodiff_gradient.cc",
+        "differentiable_norm.cc",
         "gradient.cc",
         "normalize_vector.cc",
         "rotation_conversion_gradient.cc",
     ],
     hdrs = [
         "autodiff_gradient.h",
+        "differentiable_norm.h",
         "gradient.h",
         "gradient_util.h",
         "normalize_vector.h",
@@ -359,6 +361,14 @@ drake_cc_googletest(
     name = "convert_time_derivative_test",
     deps = [
         ":vector3_util",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "differentiable_norm_test",
+    deps = [
+        ":gradient",
         "//common/test_utilities:eigen_matrix_compare",
     ],
 )

--- a/math/differentiable_norm.cc
+++ b/math/differentiable_norm.cc
@@ -1,0 +1,4 @@
+// For now, this is an empty .cc file that only serves to confirm
+// differentiable_norm.h is a stand-alone header.
+
+#include "drake/math/differentiable_norm.h"

--- a/math/differentiable_norm.h
+++ b/math/differentiable_norm.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <limits>
+
+#include <Eigen/Dense>
+
+#include "drake/math/autodiff.h"
+#include "drake/math/autodiff_gradient.h"
+
+namespace drake {
+namespace math {
+/** The 2-norm function |x| is not differentiable at x=0 (its gradient is
+ x/|x|, which has a division-by-zero problem). On the other hand, x=0 happens
+ very often. Hence we return a subgradient x/(|x| + ε) when x is
+ almost 0, and returns the original gradient, x/|x|, otherwise. */
+template <typename Derived>
+typename Derived::Scalar DifferentiableNorm(
+    const Eigen::MatrixBase<Derived>& x) {
+  // We only support vectors for now.
+  static_assert(Derived::ColsAtCompileTime == 1);
+
+  const double kEps = std::numeric_limits<double>::epsilon();
+  if constexpr (std::is_same_v<typename Derived::Scalar, AutoDiffXd>) {
+    const Eigen::Matrix<double, Derived::RowsAtCompileTime,
+                        Derived::ColsAtCompileTime>
+        x_val = ExtractValue(x);
+    const double norm_val = x_val.norm();
+    if (norm_val > 100 * kEps) {
+      return x.norm();
+    } else {
+      return AutoDiffXd(norm_val, ExtractGradient(x).transpose() * x_val /
+                                      (norm_val + 10 * kEps));
+    }
+  } else {
+    return x.norm();
+  }
+}
+}  // namespace math
+}  // namespace drake

--- a/math/test/differentiable_norm_test.cc
+++ b/math/test/differentiable_norm_test.cc
@@ -1,0 +1,38 @@
+#include "drake/math/differentiable_norm.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+namespace drake {
+namespace math {
+namespace {
+const double kEps = std::numeric_limits<double>::epsilon();
+
+GTEST_TEST(TestDifferentiableNorm, test_double) {
+  EXPECT_NEAR(DifferentiableNorm(Eigen::Vector3d(1, 0, 0)), 1., kEps);
+}
+
+GTEST_TEST(TestDifferentiableNorm, test_autodiff) {
+  Eigen::Matrix3Xd x_grad(3, 1);
+  x_grad << 1, 2, 3;
+  Vector3<AutoDiffXd> x = InitializeAutoDiff(
+      Eigen::Vector3d(1, 0, 0), x_grad);
+  AutoDiffXd norm = DifferentiableNorm(x);
+  AutoDiffXd norm_expected = x.norm();
+  EXPECT_NEAR(norm.value(), norm_expected.value(), 10 * kEps);
+  EXPECT_TRUE(CompareMatrices(norm.derivatives(), norm_expected.derivatives(),
+                              10 * kEps));
+
+  // Test when x is zero.
+  x = InitializeAutoDiff(Eigen::Vector3d::Zero(), x_grad);
+  norm = DifferentiableNorm(x);
+  EXPECT_NEAR(norm.value(), 0., 10 * kEps);
+  EXPECT_TRUE(CompareMatrices(norm.derivatives(), Vector1d::Zero(), 10 * kEps));
+}
+
+}  // namespace
+}  // namespace math
+}  // namespace drake

--- a/multibody/optimization/quaternion_integration_constraint.cc
+++ b/multibody/optimization/quaternion_integration_constraint.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/extract_double.h"
 #include "drake/math/autodiff_gradient.h"
+#include "drake/math/differentiable_norm.h"
 
 namespace drake {
 namespace multibody {
@@ -26,7 +27,7 @@ Vector1<T> EvalQuaternionIntegration(const Eigen::Quaternion<T>& quat1,
   // Now compute sin(|ω|h/2)/|ω|
   // when ω = 0, sin(|ω|h/2)/|ω|=h/2 (By taking the limit as |ω|-> 0)
   // otherwise, we compute sin(|ω|h/2)/|ω| directly.
-  const T angular_vel_norm = internal::DifferentiableNorm(angular_vel);
+  const T angular_vel_norm = math::DifferentiableNorm(angular_vel);
   // The "vector" part of Δz.
   Vector3<T> delta_z_vec;
   if (scalar_predicate<T>::is_bool &&

--- a/multibody/optimization/quaternion_integration_constraint.h
+++ b/multibody/optimization/quaternion_integration_constraint.h
@@ -17,9 +17,9 @@ namespace multibody {
  * ⊗ is the Hamiltonian product between quaternions.
  *
  * It is well-known that for any quaternion z, its element-wise negation -z
- * correspond to the same rotation matrix as z does. One way to undertand this
+ * correspond to the same rotation matrix as z does. One way to understand this
  * is that -z represents the rotation that first rotate the frame by a
- * quaternion z, and then continue to rotate about that axis for 360 degress. We
+ * quaternion z, and then continue to rotate about that axis for 360 degrees. We
  * provide the option @p allow_quaternion_negation flag, that if set to
  * true, then we require that the quaternion z₂ = ±Δz⊗z₁. Otherwise we require
  * z₂ = Δz⊗z₁. Mathematically, the constraint we impose is
@@ -90,27 +90,5 @@ class QuaternionEulerIntegrationConstraint final : public solvers::Constraint {
   bool allow_quaternion_negation_;
 };
 
-namespace internal {
-// The 2-norm function |x| is not differentiable at x=0 (its gradient is x/|x|,
-// which has a division-by-zero problem). On the other hand, x=0 happens very
-// often. Hence we use a "smoothed" gradient as x/(|x| + ε) when x is almost 0.
-template <typename T>
-T DifferentiableNorm(const Vector3<T>& x) {
-  const double kEps = std::numeric_limits<double>::epsilon();
-  if constexpr (std::is_same_v<T, AutoDiffXd>) {
-    const Eigen::Vector3d x_val = math::ExtractValue(x);
-    const double norm_val = x_val.norm();
-    if (norm_val > 100 * kEps) {
-      return x.norm();
-    } else {
-      return AutoDiffXd(norm_val, math::ExtractGradient(x).transpose() * x_val /
-                                      (norm_val + 10 * kEps));
-    }
-  } else {
-    return x.norm();
-  }
-}
-
-}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/optimization/test/quaternion_integration_constraint_test.cc
+++ b/multibody/optimization/test/quaternion_integration_constraint_test.cc
@@ -6,6 +6,7 @@
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/math/autodiff_gradient.h"
+#include "drake/math/differentiable_norm.h"
 #include "drake/multibody/inverse_kinematics/unit_quaternion_constraint.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/solve.h"
@@ -13,28 +14,6 @@
 namespace drake {
 namespace multibody {
 const double kEps = std::numeric_limits<double>::epsilon();
-
-GTEST_TEST(TestDiffferentiableNorm, test_double) {
-  EXPECT_NEAR(internal::DifferentiableNorm(Eigen::Vector3d(1, 0, 0)), 1., kEps);
-}
-
-GTEST_TEST(TestDiffferentiableNorm, test_autodiff) {
-  Eigen::Matrix3Xd x_grad(3, 1);
-  x_grad << 1, 2, 3;
-  Vector3<AutoDiffXd> x = math::InitializeAutoDiff(
-      Eigen::Vector3d(1, 0, 0), x_grad);
-  AutoDiffXd norm = internal::DifferentiableNorm(x);
-  AutoDiffXd norm_expected = x.norm();
-  EXPECT_NEAR(norm.value(), norm_expected.value(), 10 * kEps);
-  EXPECT_TRUE(CompareMatrices(norm.derivatives(), norm_expected.derivatives(),
-                              10 * kEps));
-
-  // Test when x is zero.
-  x = math::InitializeAutoDiff(Eigen::Vector3d::Zero(), x_grad);
-  norm = internal::DifferentiableNorm(x);
-  EXPECT_NEAR(norm.value(), 0., 10 * kEps);
-  EXPECT_TRUE(CompareMatrices(norm.derivatives(), Vector1d::Zero(), 10 * kEps));
-}
 
 // Evaluate the left-hand side of the constraint
 //
@@ -59,7 +38,7 @@ Vector1<T> EvalQuaternionIntegration(
   Vector1<T> ret;
   using std::cos;
   using std::sin;
-  const T angular_vel_norm = internal::DifferentiableNorm<T>(angular_vel);
+  const T angular_vel_norm = math::DifferentiableNorm(angular_vel);
   Matrix4<T> A;
   // clang-format off
   A << 0, -angular_vel(0), -angular_vel(1), -angular_vel(2),

--- a/multibody/plant/wing.cc
+++ b/multibody/plant/wing.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/plant/wing.h"
 
+#include "drake/math/differentiable_norm.h"
+
 namespace drake {
 namespace multibody {
 
@@ -82,8 +84,8 @@ void Wing<T>::CalcSpatialForce(
   // http://underactuated.csail.mit.edu/trajopt.html#perching and the
   // corresponding references.
   SpatialForce<T> F_Wing_Wing = SpatialForce<T>::Zero();
-  const T longitudinal_velocity_norm =
-      Vector2<T>(v_WindBody_Wing[0], v_WindBody_Wing[2]).norm();
+  const T longitudinal_velocity_norm = math::DifferentiableNorm(
+      Vector2<T>(v_WindBody_Wing[0], v_WindBody_Wing[2]));
   F_Wing_Wing.translational()[2] = -fluid_density * surface_area_ *
                                    v_WindBody_Wing[2] *
                                    longitudinal_velocity_norm;


### PR DESCRIPTION
As discussed in
https://stackoverflow.com/questions/72154972/trajectory-optimization-on-custom-quadrotor-system-nan-detected-during-differe/72160960
the `Wing` class implementation was using a vector `norm()` call that
is not differentiable at zero velocity.  For quadrotors, that's no
good.

I found `internal::DifferentiableNorm` hidden in the
`QuaternionIntegrationConstraint`. This is a gem.  I've moved it to
`math`, and called it from `Wing`.

+@hongkai-dai for feature review. 
I'm marking this as priority high, to see if it can land in time for the final project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17127)
<!-- Reviewable:end -->
