### PR TITLE
[solvers] Fix UB in Gurobi bindings

### DIFF
--- a/solvers/gurobi_solver.cc
+++ b/solvers/gurobi_solver.cc
@@ -206,7 +206,7 @@ GurobiSolver::SolveStatusInfo GetGurobiSolveStatus(void* cbdata, int where) {
   GRBcbget(cbdata, where, GRB_CB_MIPNODE_OBJBND, &(solve_status.best_bound));
   GRBcbget(cbdata, where, GRB_CB_MIPNODE_SOLCNT,
            &(solve_status.feasible_solutions_count));
-  double explored_node_count_double;
+  double explored_node_count_double{};
   GRBcbget(cbdata, where, GRB_CB_MIPNODE_NODCNT, &explored_node_count_double);
   solve_status.explored_node_count = explored_node_count_double;
   return solve_status;


### PR DESCRIPTION
In the GurobiTest.TestCallbacks the cbget function was a no-op for some reason, leaving the double value uninitialized.

As of Clang 12 UBSan, this is detected now (sometimes).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17133)
<!-- Reviewable:end -->
