### PR TITLE
[tools] Enable -fsanitize=pointer-overflow for UBSan Everything

### DIFF
--- a/tools/dynamic_analysis/bazel.rc
+++ b/tools/dynamic_analysis/bazel.rc
@@ -200,8 +200,7 @@ build:ubsan_everything --copt -g
 build:ubsan_everything --copt -fsanitize=undefined
 # Since Bazel uses clang instead of clang++, enabling -fsanitize=function,vptr
 # would require extra linkopts that cause segmentation faults on pure C code.
-# TODO(jamiesnape): Enable -fsanitize=pointer-overflow when SNOPT is fixed.
-build:ubsan_everything --copt -fno-sanitize=float-divide-by-zero,function,pointer-overflow,vptr
+build:ubsan_everything --copt -fno-sanitize=float-divide-by-zero,function,vptr
 build:ubsan_everything --copt -O1
 build:ubsan_everything --copt -fno-omit-frame-pointer
 # TODO(jamiesnape): Find a solution to using sanitizer blacklists with the


### PR DESCRIPTION
This TODO hails from a time when we were using the `f2c` build of SNOPT.  Now that we use the Fortran build of SNOPT, apparently we are sufficiently safe now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17134)
<!-- Reviewable:end -->
