### PR TITLE
[manipulation] add visualization of frames in show_model.py

### DIFF
--- a/manipulation/util/show_model.py
+++ b/manipulation/util/show_model.py
@@ -184,7 +184,7 @@ def add_triad(
     Adds illustration geometry representing the coordinate frame, with the
     x-axis drawn in red, the y-axis in green and the z-axis in blue. The axes
     point in +x, +y and +z directions, respectively.
-    Based on [code permalink](https://github.com/RussTedrake/manipulation/blob/5e5981147079e69f03d1b42707b8db0386dc8824/manipulation/scenarios.py#L367-L414).
+    Based on [code permalink](https://github.com/RussTedrake/manipulation/blob/5e59811/manipulation/scenarios.py#L367-L414).# noqa
     Args:
     source_id: The source registered with SceneGraph.
     frame_id: A geometry::frame_id registered with scene_graph.
@@ -196,7 +196,10 @@ def add_triad(
     name: the added geometry will have names name + " x-axis", etc.
     """
     # x-axis
-    X_TG = RigidTransform(RotationMatrix.MakeYRotation(np.pi / 2), [length / 2.0, 0, 0])
+    X_TG = RigidTransform(
+        RotationMatrix.MakeYRotation(np.pi / 2), 
+        [length / 2.0, 0, 0],
+    )
     geom = GeometryInstance(
         X_FT.multiply(X_TG), Cylinder(radius, length), name + " x-axis"
     )
@@ -206,7 +209,10 @@ def add_triad(
     scene_graph.RegisterGeometry(source_id, frame_id, geom)
 
     # y-axis
-    X_TG = RigidTransform(RotationMatrix.MakeXRotation(np.pi / 2), [0, length / 2.0, 0])
+    X_TG = RigidTransform(
+        RotationMatrix.MakeXRotation(np.pi / 2), 
+        [0, length / 2.0, 0],
+    )
     geom = GeometryInstance(
         X_FT.multiply(X_TG), Cylinder(radius, length), name + " y-axis"
     )
@@ -224,6 +230,7 @@ def add_triad(
         MakePhongIllustrationProperties([0, 0, 1, opacity])
     )
     scene_graph.RegisterGeometry(source_id, frame_id, geom)
+
 
 def parse_visualizers(args_parser, args):
     """
@@ -244,32 +251,23 @@ def parse_visualizers(args_parser, args):
                 if inspector.GetIllustrationProperties(geometry_id) is None:
                     scene_graph.AssignRole(
                         source_id, geometry_id, red_illustration)
-        
+
         if args.visualize_frames:
             # Visualize frames
-            # Find all the frames and plots them using add_triad().
-            # The frames are ploted using the parsed length.
+            # Find all the frames and plot them using add_triad().
+            # The frames are drawn using the parsed length.
             # The world frame is plotted thicker than the rest.
             inspector = scene_graph.model_inspector()
             for frame_id in inspector.GetAllFrameIds():
-                if frame_id == scene_graph.world_frame_id():
-                    add_triad(
-                        plant.get_source_id(),
-                        frame_id,
-                        scene_graph,
-                        length=args.triad_length,
-                        radius=args.triad_radius * 3,
-                        opacity=args.triad_opacity,
-                    )
-                else:
-                    add_triad(
-                        plant.get_source_id(),
-                        frame_id,
-                        scene_graph,
-                        length=args.triad_length,
-                        radius=args.triad_radius,
-                        opacity=args.triad_opacity,
-                    )
+                radius=args.triad_radius * (3 if frame_id == scene_graph.world_frame_id() else 1)
+                add_triad(
+                    plant.get_source_id(),
+                    frame_id,
+                    scene_graph,
+                    length=args.triad_length,
+                    radius=radius,
+                    opacity=args.triad_opacity,
+                )
 
     def connect_visualizers(builder, plant, scene_graph):
         # Connect this to drake_visualizer.

--- a/manipulation/util/show_model.py
+++ b/manipulation/util/show_model.py
@@ -197,7 +197,7 @@ def add_triad(
     """
     # x-axis
     X_TG = RigidTransform(
-        RotationMatrix.MakeYRotation(np.pi / 2), 
+        RotationMatrix.MakeYRotation(np.pi / 2),
         [length / 2.0, 0, 0],
     )
     geom = GeometryInstance(
@@ -210,7 +210,7 @@ def add_triad(
 
     # y-axis
     X_TG = RigidTransform(
-        RotationMatrix.MakeXRotation(np.pi / 2), 
+        RotationMatrix.MakeXRotation(np.pi / 2),
         [0, length / 2.0, 0],
     )
     geom = GeometryInstance(
@@ -259,7 +259,9 @@ def parse_visualizers(args_parser, args):
             # The world frame is plotted thicker than the rest.
             inspector = scene_graph.model_inspector()
             for frame_id in inspector.GetAllFrameIds():
-                radius=args.triad_radius * (3 if frame_id == scene_graph.world_frame_id() else 1)
+                radius = args.triad_radius * (
+                    3 if frame_id == scene_graph.world_frame_id() else 1
+                    )
                 add_triad(
                     plant.get_source_id(),
                     frame_id,

--- a/manipulation/util/show_model.py
+++ b/manipulation/util/show_model.py
@@ -51,6 +51,7 @@ binary.
 
 import argparse
 import os
+import numpy as np
 
 from pydrake.common import FindResourceOrThrow
 from pydrake.geometry import MakePhongIllustrationProperties
@@ -64,7 +65,12 @@ from pydrake.systems.meshcat_visualizer import (
 from pydrake.systems.planar_scenegraph_visualizer import (
     ConnectPlanarSceneGraphVisualizer,
 )
-
+from pydrake.all import (
+    AddMultibodyPlantSceneGraph, Cylinder,
+    DiagramBuilder, 
+    FindResourceOrThrow, GeometryInstance, 
+    MakePhongIllustrationProperties,  Parser, RigidTransform, 
+    RotationMatrix)
 
 def add_filename_and_parser_argparse_arguments(args_parser):
     """
@@ -133,15 +139,63 @@ def add_visualizers_argparse_arguments(args_parser):
         help="Visualize the collision geometry in the visualizer. The "
         "collision geometries will be shown in red to differentiate "
         "them from the visual geometries.")
-
+    args_parser.add_argument(
+        "--visualize_frames", nargs='?',
+        type=float,
+        dest='triad_length', const=1,default=0,
+        help="Visualize the frames as triads for all links.")
 
 def parse_visualizers(args_parser, args):
     """
-    Parses argparse arguments for visualizers, returning update_visualization
+    Parses argparse arguments for visualizers, returning update_visualization,
     and connect_visualizers.
     """
 
     def update_visualization(plant, scene_graph):
+        def AddTriad(source_id, frame_id,
+            scene_graph, length=.25,
+            radius=0.01, opacity=1.,
+            X_FT=RigidTransform(), name="frame"):
+            """
+            Adds illustration geometry representing the coordinate frame, with the
+            x-axis drawn in red, the y-axis in green and the z-axis in blue. The axes
+            point in +x, +y and +z directions, respectively.
+            Args:
+            source_id: The source registered with SceneGraph.
+            frame_id: A geometry::frame_id registered with scene_graph.
+            scene_graph: The SceneGraph with which we will register the geometry.
+            length: the length of each axis in meters.
+            radius: the radius of each axis in meters.
+            opacity: the opacity of the coordinate axes, between 0 and 1.
+            X_FT: a RigidTransform from the triad frame T to the frame_id frame F
+            name: the added geometry will have names name + " x-axis", etc.
+            """
+            # x-axis
+            X_TG = RigidTransform(RotationMatrix.MakeYRotation(np.pi / 2),
+                                [length / 2., 0, 0])
+            geom = GeometryInstance(X_FT.multiply(X_TG), Cylinder(radius, length),
+                                    name + " x-axis")
+            geom.set_illustration_properties(
+                MakePhongIllustrationProperties([1, 0, 0, opacity]))
+            scene_graph.RegisterGeometry(source_id, frame_id, geom)
+
+            # y-axis
+            X_TG = RigidTransform(RotationMatrix.MakeXRotation(np.pi / 2),
+                                [0, length / 2., 0])
+            geom = GeometryInstance(X_FT.multiply(X_TG), Cylinder(radius, length),
+                                    name + " y-axis")
+            geom.set_illustration_properties(
+                MakePhongIllustrationProperties([0, 1, 0, opacity]))
+            scene_graph.RegisterGeometry(source_id, frame_id, geom)
+
+            # z-axis
+            X_TG = RigidTransform([0, 0, length / 2.])
+            geom = GeometryInstance(X_FT.multiply(X_TG), Cylinder(radius, length),
+                                    name + " z-axis")
+            geom.set_illustration_properties(
+                MakePhongIllustrationProperties([0, 0, 1, opacity]))
+            scene_graph.RegisterGeometry(source_id, frame_id, geom)
+    
         if args.visualize_collisions:
             # Find all the geometries that have not already been marked as
             # 'illustration' (visual) and assume they are collision geometries.
@@ -155,6 +209,20 @@ def parse_visualizers(args_parser, args):
                 if inspector.GetIllustrationProperties(geometry_id) is None:
                     scene_graph.AssignRole(
                         source_id, geometry_id, red_illustration)
+        
+        if args.triad_length!=0:
+            # Visualize frames 
+            # Find all the frames and plots them using AddTriad().
+            # The frames are ploted using the parsed length. 
+            # The world frame is plotted thicker than the rest. 
+            length=args.triad_length
+            inspector = scene_graph.model_inspector()
+            for i,frame_id in enumerate(inspector.GetAllFrameIds()):
+                #The world frame is the last in the list
+                if i<len(inspector.GetAllFrameIds())-1:
+                    AddTriad(plant.get_source_id(),frame_id,scene_graph,length)      
+                else:
+                    AddTriad(plant.get_source_id(),frame_id,scene_graph,length, radius=0.03)   
 
     def connect_visualizers(builder, plant, scene_graph):
         # Connect this to drake_visualizer.

--- a/manipulation/util/show_model.py
+++ b/manipulation/util/show_model.py
@@ -254,7 +254,7 @@ def parse_visualizers(args_parser, args):
 
         if args.visualize_frames:
             # Visualize frames
-            # Find all the frames and plot them using add_triad().
+            # Find all the frames and draw them using add_triad().
             # The frames are drawn using the parsed length.
             # The world frame is drawn thicker than the rest.
             inspector = scene_graph.model_inspector()

--- a/manipulation/util/show_model.py
+++ b/manipulation/util/show_model.py
@@ -55,8 +55,10 @@ import numpy as np
 
 from pydrake.common import FindResourceOrThrow
 from pydrake.geometry import (
-    Cylinder, DrakeVisualizer,
-    GeometryInstance, MakePhongIllustrationProperties,
+    Cylinder,
+    DrakeVisualizer,
+    GeometryInstance,
+    MakePhongIllustrationProperties,
 )
 from pydrake.math import RigidTransform, RotationMatrix
 from pydrake.multibody.parsing import Parser
@@ -64,7 +66,9 @@ from pydrake.multibody.plant import AddMultibodyPlantSceneGraph
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.meshcat_visualizer import (
-    ConnectMeshcatVisualizer, MeshcatVisualizer)
+    ConnectMeshcatVisualizer,
+    MeshcatVisualizer,
+)
 from pydrake.systems.planar_scenegraph_visualizer import (
     ConnectPlanarSceneGraphVisualizer,
 )
@@ -138,23 +142,32 @@ def add_visualizers_argparse_arguments(args_parser):
         "collision geometries will be shown in red to differentiate "
         "them from the visual geometries.")
     args_parser.add_argument(
-        "--visualize_frames", action="store_true",
-        help="Visualize the frames as triads for all links.")
+        "--visualize_frames",
+        action="store_true",
+        help="Visualize the frames as triads for all links.",
+    )
     args_parser.add_argument(
-        "--triad_length", 
+        "--triad_length",
         type=float,
-        dest='triad_length', default=0.5,
-        help="Triad length for frame visualization.")
+        dest="triad_length",
+        default=0.5,
+        help="Triad length for frame visualization.",
+    )
     args_parser.add_argument(
-        "--triad_radius", 
+        "--triad_radius",
         type=float,
-        dest='triad_radius', default=0.01,
-        help="Triad radius for frame visualization.")
+        dest="triad_radius",
+        default=0.01,
+        help="Triad radius for frame visualization.",
+    )
     args_parser.add_argument(
-        "--triad_opacity", 
+        "--triad_opacity",
         type=float,
-        dest='triad_opacity', default=1,
-        help="Triad opacity for frame visualization.")
+        dest="triad_opacity",
+        default=1,
+        help="Triad opacity for frame visualization.",
+    )
+
 
 def add_triad(
     source_id,
@@ -239,10 +252,24 @@ def parse_visualizers(args_parser, args):
             # The world frame is plotted thicker than the rest.
             inspector = scene_graph.model_inspector()
             for frame_id in inspector.GetAllFrameIds():
-                if frame_id==scene_graph.world_frame_id():
-                    add_triad(plant.get_source_id(),frame_id,scene_graph,length=args.triad_length, radius=args.triad_radius*3,opacity=args.triad_opacity)    
+                if frame_id == scene_graph.world_frame_id():
+                    add_triad(
+                        plant.get_source_id(),
+                        frame_id,
+                        scene_graph,
+                        length=args.triad_length,
+                        radius=args.triad_radius * 3,
+                        opacity=args.triad_opacity,
+                    )
                 else:
-                    add_triad(plant.get_source_id(),frame_id,scene_graph,length=args.triad_length, radius=args.triad_radius,opacity=args.triad_opacity)  
+                    add_triad(
+                        plant.get_source_id(),
+                        frame_id,
+                        scene_graph,
+                        length=args.triad_length,
+                        radius=args.triad_radius,
+                        opacity=args.triad_opacity,
+                    )
 
     def connect_visualizers(builder, plant, scene_graph):
         # Connect this to drake_visualizer.

--- a/manipulation/util/show_model.py
+++ b/manipulation/util/show_model.py
@@ -256,7 +256,7 @@ def parse_visualizers(args_parser, args):
             # Visualize frames
             # Find all the frames and plot them using add_triad().
             # The frames are drawn using the parsed length.
-            # The world frame is plotted thicker than the rest.
+            # The world frame is drawn thicker than the rest.
             inspector = scene_graph.model_inspector()
             for frame_id in inspector.GetAllFrameIds():
                 radius = args.triad_radius * (

--- a/manipulation/util/show_model.py
+++ b/manipulation/util/show_model.py
@@ -156,10 +156,16 @@ def add_visualizers_argparse_arguments(args_parser):
         dest='triad_opacity', default=1,
         help="Triad opacity for frame visualization.")
 
-def AddTriad(source_id, frame_id,
-    scene_graph, length=.25,
-    radius=0.01, opacity=1.,
-    X_FT=RigidTransform(), name="frame"):
+def AddTriad(
+    source_id,
+    frame_id,
+    scene_graph,
+    length=0.25,
+    radius=0.01,
+    opacity=1.0,
+    X_FT=RigidTransform(),
+    name="frame",
+):
     """
     Adds illustration geometry representing the coordinate frame, with the
     x-axis drawn in red, the y-axis in green and the z-axis in blue. The axes
@@ -175,29 +181,33 @@ def AddTriad(source_id, frame_id,
     name: the added geometry will have names name + " x-axis", etc.
     """
     # x-axis
-    X_TG = RigidTransform(RotationMatrix.MakeYRotation(np.pi / 2),
-                        [length / 2., 0, 0])
-    geom = GeometryInstance(X_FT.multiply(X_TG), Cylinder(radius, length),
-                            name + " x-axis")
+    X_TG = RigidTransform(RotationMatrix.MakeYRotation(np.pi / 2), [length / 2.0, 0, 0])
+    geom = GeometryInstance(
+        X_FT.multiply(X_TG), Cylinder(radius, length), name + " x-axis"
+    )
     geom.set_illustration_properties(
-        MakePhongIllustrationProperties([1, 0, 0, opacity]))
+        MakePhongIllustrationProperties([1, 0, 0, opacity])
+    )
     scene_graph.RegisterGeometry(source_id, frame_id, geom)
 
     # y-axis
-    X_TG = RigidTransform(RotationMatrix.MakeXRotation(np.pi / 2),
-                        [0, length / 2., 0])
-    geom = GeometryInstance(X_FT.multiply(X_TG), Cylinder(radius, length),
-                            name + " y-axis")
+    X_TG = RigidTransform(RotationMatrix.MakeXRotation(np.pi / 2), [0, length / 2.0, 0])
+    geom = GeometryInstance(
+        X_FT.multiply(X_TG), Cylinder(radius, length), name + " y-axis"
+    )
     geom.set_illustration_properties(
-        MakePhongIllustrationProperties([0, 1, 0, opacity]))
+        MakePhongIllustrationProperties([0, 1, 0, opacity])
+    )
     scene_graph.RegisterGeometry(source_id, frame_id, geom)
 
     # z-axis
-    X_TG = RigidTransform([0, 0, length / 2.])
-    geom = GeometryInstance(X_FT.multiply(X_TG), Cylinder(radius, length),
-                            name + " z-axis")
+    X_TG = RigidTransform([0, 0, length / 2.0])
+    geom = GeometryInstance(
+        X_FT.multiply(X_TG), Cylinder(radius, length), name + " z-axis"
+    )
     geom.set_illustration_properties(
-        MakePhongIllustrationProperties([0, 0, 1, opacity]))
+        MakePhongIllustrationProperties([0, 0, 1, opacity])
+    )
     scene_graph.RegisterGeometry(source_id, frame_id, geom)
 
 def parse_visualizers(args_parser, args):
@@ -221,10 +231,10 @@ def parse_visualizers(args_parser, args):
                         source_id, geometry_id, red_illustration)
         
         if args.visualize_frames:
-            # Visualize frames 
+            # Visualize frames
             # Find all the frames and plots them using AddTriad().
-            # The frames are ploted using the parsed length. 
-            # The world frame is plotted thicker than the rest. 
+            # The frames are ploted using the parsed length.
+            # The world frame is plotted thicker than the rest.
             length=args.triad_length
             radius=args.triad_radius
             opacity=args.triad_opacity

--- a/manipulation/util/show_model.py
+++ b/manipulation/util/show_model.py
@@ -170,6 +170,7 @@ def AddTriad(
     Adds illustration geometry representing the coordinate frame, with the
     x-axis drawn in red, the y-axis in green and the z-axis in blue. The axes
     point in +x, +y and +z directions, respectively.
+    Based on [code permalink](https://github.com/RussTedrake/manipulation/blob/master/manipulation/scenarios.py#L367).
     Args:
     source_id: The source registered with SceneGraph.
     frame_id: A geometry::frame_id registered with scene_graph.


### PR DESCRIPTION
Added a visualization to `show_model.py` for link and world frames.
This is based on Russ' [AddTriad() method](https://github.com/RussTedrake/manipulation/blob/master/manipulation/scenarios.py#L367)
![image](https://user-images.githubusercontent.com/103549637/167515606-f9247fe6-f9e7-4cd9-aef3-ce1dd4b30b06.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17141)
<!-- Reviewable:end -->
