### PR TITLE
[examples] fix segfaults when input ports were not connected.

### DIFF
--- a/examples/acrobot/BUILD.bazel
+++ b/examples/acrobot/BUILD.bazel
@@ -348,6 +348,7 @@ drake_cc_googletest(
     deps = [
         ":acrobot_plant",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_no_throw",
     ],
 )
 

--- a/examples/acrobot/acrobot_plant.h
+++ b/examples/acrobot/acrobot_plant.h
@@ -27,10 +27,13 @@ namespace acrobot {
 /// @system
 /// name: AcrobotPlant
 /// input_ports:
-/// - elbow_torque
+/// - elbow_torque (optional)
 /// output_ports:
 /// - acrobot_state
 /// @endsystem
+///
+/// Note: If the elbow_torque input port is not connected, then the torque is
+/// taken to be zero.
 ///
 /// @tparam_default_scalar
 /// @ingroup acrobot_systems
@@ -62,10 +65,12 @@ class AcrobotPlant : public systems::LeafSystem<T> {
   Matrix2<T> MassMatrix(const systems::Context<T> &context) const;
   ///@}
 
-  /// Evaluates the input port and returns the scalar value
-  /// of the commanded torque.
-  const T& get_tau(const systems::Context<T>& context) const {
-    return this->EvalVectorInput(context, 0)->GetAtIndex(0);
+  /// Evaluates the input port and returns the scalar value of the commanded
+  /// torque.  If the input port is not connected, then the torque is taken to
+  /// be zero.
+  const T get_tau(const systems::Context<T>& context) const {
+    const systems::BasicVector<T>* u_vec = this->EvalVectorInput(context, 0);
+    return u_vec ? u_vec->GetAtIndex(0) : 0.0;
   }
 
   static const AcrobotState<T>& get_state(

--- a/examples/acrobot/test/acrobot_plant_test.cc
+++ b/examples/acrobot/test/acrobot_plant_test.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_no_throw.h"
 
 namespace drake {
 namespace examples {
@@ -30,6 +31,15 @@ GTEST_TEST(AcrobotPlantTest, ImplicitTimeDerivatives) {
   // here to permit this to be done symbolically, which is not the most
   // accurate method. 100ε (~2e-14) should be achievable.
   EXPECT_LT(residual.lpNorm<Eigen::Infinity>(), 100*kEpsilon);
+}
+
+// Ensure that DoCalcTimeDerivatives succeeds even if the input port is
+// disconnected.
+GTEST_TEST(AcrobotPlantTest, NoInput) {
+  const AcrobotPlant<double> plant;
+  auto context = plant.CreateDefaultContext();
+
+  DRAKE_EXPECT_NO_THROW(plant.EvalTimeDerivatives(*context));
 }
 
 }  // namespace

--- a/examples/compass_gait/compass_gait.cc
+++ b/examples/compass_gait/compass_gait.cc
@@ -297,7 +297,8 @@ void CompassGait<T>::DoCalcTimeDerivatives(
   const Matrix2<T> M = MassMatrix(context);
   const Vector2<T> bias = DynamicsBiasTerm(context);
   const Vector2<T> B(-1, 1);
-  const Vector1<T> u = this->get_input_port(0).Eval(context);
+  const systems::BasicVector<T>* u_vec = this->EvalVectorInput(context, 0);
+  const Vector1<T> u = u_vec ? u_vec->value() : Vector1<T>::Zero();
 
   Vector4<T> xdot;
   // clang-format off

--- a/examples/compass_gait/compass_gait.h
+++ b/examples/compass_gait/compass_gait.h
@@ -35,7 +35,7 @@ namespace compass_gait {
 /// @system
 /// name: CompassGait
 /// input_ports:
-/// - hip_torque
+/// - hip_torque (optional)
 /// output_ports:
 /// - minimal_state
 /// - floating_base_state
@@ -44,6 +44,9 @@ namespace compass_gait {
 /// Continuous States: stance, swing, stancedot, swingdot.<br/>
 /// Discrete State: stance toe position.<br/>
 /// Abstract State: left support indicator.<br/>
+///
+/// Note: If the hip_torque input port is not connected, then the torque is
+/// taken to be zero.
 ///
 /// @tparam_default_scalar
 template <typename T>

--- a/examples/compass_gait/test/compass_gait_test.cc
+++ b/examples/compass_gait/test/compass_gait_test.cc
@@ -286,6 +286,15 @@ GTEST_TEST(CompassGaitTest, TestFloatBaseOutput) {
       cg.get_floating_base_state_output_port().get_index()));
 }
 
+// Ensure that DoCalcTimeDerivatives succeeds even if the input port is
+// disconnected.
+GTEST_TEST(CompassGaitTest, NoInput) {
+  const CompassGait<double> plant;
+  auto context = plant.CreateDefaultContext();
+
+  DRAKE_EXPECT_NO_THROW(plant.EvalTimeDerivatives(*context));
+}
+
 }  // namespace
 }  // namespace compass_gait
 }  // namespace examples

--- a/examples/pendulum/BUILD.bazel
+++ b/examples/pendulum/BUILD.bazel
@@ -180,6 +180,7 @@ drake_cc_googletest(
     deps = [
         ":pendulum_plant",
         "//common:autodiff",
+        "//common/test_utilities:expect_no_throw",
     ],
 )
 

--- a/examples/pendulum/pendulum_plant.h
+++ b/examples/pendulum/pendulum_plant.h
@@ -15,10 +15,13 @@ namespace pendulum {
 /// @system
 /// name: PendulumPlant
 /// input_ports:
-/// - tau
+/// - tau (optional)
 /// output_ports:
 /// - state
 /// @endsystem
+///
+/// Note: If the tau input port is not connected, then the torque is
+/// taken to be zero.
 ///
 /// @tparam_default_scalar
 template <typename T>
@@ -41,10 +44,12 @@ class PendulumPlant final : public systems::LeafSystem<T> {
   /// Calculates the kinetic + potential energy.
   T CalcTotalEnergy(const systems::Context<T>& context) const;
 
-  /// Evaluates the input port and returns the scalar value
-  /// of the commanded torque.
+  /// Evaluates the input port and returns the scalar value of the commanded
+  /// torque. If the input port is not connected, then the torque is taken to
+  /// be zero.
   T get_tau(const systems::Context<T>& context) const {
-    return this->get_input_port().Eval(context)(0);
+    const systems::BasicVector<T>* u_vec = this->EvalVectorInput(context, 0);
+    return u_vec ? u_vec->GetAtIndex(0) : 0.0;
   }
 
   static const PendulumState<T>& get_state(

--- a/examples/pendulum/test/pendulum_plant_test.cc
+++ b/examples/pendulum/test/pendulum_plant_test.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"
+#include "drake/common/test_utilities/expect_no_throw.h"
 
 namespace drake {
 namespace examples {
@@ -69,6 +70,15 @@ GTEST_TEST(PendulumPlantTest, CalcTotalEnergy) {
   state->set_thetadot(1.0);
   EXPECT_NEAR(plant.CalcTotalEnergy(*context),
               0.5 * params->mass() * std::pow(params->length(), 2), kTol);
+}
+
+// Ensure that DoCalcTimeDerivatives succeeds even if the input port is
+// disconnected.
+GTEST_TEST(PendulumPlantTest, NoInput) {
+  const PendulumPlant<double> plant;
+  auto context = plant.CreateDefaultContext();
+
+  DRAKE_EXPECT_NO_THROW(plant.EvalTimeDerivatives(*context));
 }
 
 }  // namespace

--- a/examples/quadrotor/quadrotor_plant.h
+++ b/examples/quadrotor/quadrotor_plant.h
@@ -19,7 +19,7 @@ namespace quadrotor {
 /// @system
 /// name: QuadrotorPlant
 /// input_ports:
-/// - propeller_force
+/// - propeller_force (optional)
 /// output_ports:
 /// - state
 /// @endsystem


### PR DESCRIPTION
The PendulumPlant, AcrobotPlant, and CompassGait examples all crashed
if the input port was not properly connected.  I've provided default
input values for them here.

Related to #17025.

Note: In jupyter (both deepnote and locally), then were manifesting as
just completely silent kernel crashes, with absolutely no
hint/diagnositics.

+@jwnimmer-tri for both reviews, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17145)
<!-- Reviewable:end -->
