### PR TITLE
[multibody] test the inverse dynamics torque under gravity

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -832,4 +832,17 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_googletest(
+    name = "inverse_dynamics_R",
+    data = [
+        "test/inverse_dynamics_R.urdf",
+    ],
+    deps = [
+        ":plant",
+        "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//multibody/parsing",
+    ],
+)
+
 add_lint_tests()

--- a/multibody/plant/test/inverse_dynamics_R.cc
+++ b/multibody/plant/test/inverse_dynamics_R.cc
@@ -62,8 +62,9 @@ class InverseDynamicsRTests : public ::testing::Test {
     VectorXd expected_tau = VectorXd(1);
     expected_tau << mass * gravity * length / 2 * std::cos(angle);
 
-    EXPECT_TRUE(
-        CompareMatrices(expected_tau, tau, 0.01, MatrixCompareType::relative));
+    EXPECT_TRUE(CompareMatrices(expected_tau, tau,
+                                std::numeric_limits<double>::epsilon(),
+                                MatrixCompareType::relative));
   }
 };
 

--- a/multibody/plant/test/inverse_dynamics_R.cc
+++ b/multibody/plant/test/inverse_dynamics_R.cc
@@ -32,7 +32,7 @@ class InverseDynamicsRTests : public ::testing::Test {
   void test_inverse_dynamics(const double angle) {
     constexpr auto length = 1.0;
     constexpr auto mass = 2.0;
-    constexpr auto gravity = 9.81;
+    const double gravity = plant.gravity_field().gravity_vector().norm();
 
     auto plant_context = plant.CreateDefaultContext();
 

--- a/multibody/plant/test/inverse_dynamics_R.cc
+++ b/multibody/plant/test/inverse_dynamics_R.cc
@@ -1,0 +1,78 @@
+#include <cmath>
+#include <Eigen/Dense>
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
+
+namespace drake::multibody::multibody_plant {
+
+using drake::multibody::Parser;
+using Eigen::VectorXd;
+using systems::Context;
+
+namespace {
+
+constexpr auto pi = 3.14159265358979323846;
+
+class InverseDynamicsRTests : public ::testing::Test {
+ public:
+  MultibodyPlant<double> plant{0.0};
+
+  void load_model(const std::string& file_path) {
+    const std::string model_path = FindResourceOrThrow(file_path);
+    Parser parser(&plant);
+    parser.AddModelFromFile(model_path);
+    plant.Finalize();
+  }
+
+  void test_inverse_dynamics(const double angle) {
+    constexpr auto length = 1.0;
+    constexpr auto mass = 2.0;
+    constexpr auto gravity = 9.81;
+
+    auto plant_context = plant.CreateDefaultContext();
+    auto multibody_forces = MultibodyForces<double>(plant);
+
+    // add the gravity effect as a generalized force
+    const auto gravity_forces =
+        plant.CalcGravityGeneralizedForces(*plant_context);
+    multibody_forces.mutable_generalized_forces() += gravity_forces;
+
+    // set positions
+    auto positions = VectorXd(1);
+    positions << angle;
+    plant.SetPositions(plant_context.get(), positions);
+
+    // set velocities and accelerations to 0
+    VectorXd velocities = VectorXd::Zero(1);
+    plant.SetVelocities(plant_context.get(), velocities);
+
+    VectorXd known_vdot = VectorXd::Zero(1);
+
+    // calculate the joint torque
+    const auto tau =
+        plant.CalcInverseDynamics(*plant_context, known_vdot, multibody_forces);
+
+    // compare with the expected torque
+    VectorXd expected_tau = VectorXd(1);
+    expected_tau << mass * gravity * length / 2 * std::cos(angle);
+
+    EXPECT_TRUE(
+        CompareMatrices(expected_tau, tau, 0.01, MatrixCompareType::relative));
+  }
+};
+
+TEST_F(InverseDynamicsRTests, InverseDynamicsR) {
+  load_model("drake/multibody/plant/test/inverse_dynamics_R.urdf");
+
+  test_inverse_dynamics(pi / 4);
+  test_inverse_dynamics(0.0);
+  test_inverse_dynamics(pi / 2);
+  test_inverse_dynamics(pi);
+}
+
+}  // namespace
+}  // namespace drake::multibody::multibody_plant

--- a/multibody/plant/test/inverse_dynamics_R.cc
+++ b/multibody/plant/test/inverse_dynamics_R.cc
@@ -1,4 +1,5 @@
 #include <cmath>
+
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 
@@ -34,12 +35,6 @@ class InverseDynamicsRTests : public ::testing::Test {
     constexpr auto gravity = 9.81;
 
     auto plant_context = plant.CreateDefaultContext();
-    auto multibody_forces = MultibodyForces<double>(plant);
-
-    // add the gravity effect as a generalized force
-    const auto gravity_forces =
-        plant.CalcGravityGeneralizedForces(*plant_context);
-    multibody_forces.mutable_generalized_forces() += gravity_forces;
 
     // set positions
     auto positions = VectorXd(1);
@@ -51,6 +46,13 @@ class InverseDynamicsRTests : public ::testing::Test {
     plant.SetVelocities(plant_context.get(), velocities);
 
     VectorXd known_vdot = VectorXd::Zero(1);
+
+    auto multibody_forces = MultibodyForces<double>(plant);
+
+    // add the gravity effects. It should be after setting the positions.
+    const auto gravity_forces =
+        plant.CalcGravityGeneralizedForces(*plant_context);
+    multibody_forces.mutable_generalized_forces() += gravity_forces;
 
     // calculate the joint torque
     const auto tau =

--- a/multibody/plant/test/inverse_dynamics_R.cc
+++ b/multibody/plant/test/inverse_dynamics_R.cc
@@ -50,9 +50,14 @@ class InverseDynamicsRTests : public ::testing::Test {
     auto multibody_forces = MultibodyForces<double>(plant);
 
     // add the gravity effects. It should be after setting the positions.
-    const auto gravity_forces =
+    plant.CalcForceElementsContribution(plant_context, &multibody_forces);
+
+    // verify the calculated generalized gravity forces
+    const auto expected_gravity_forces =
         plant.CalcGravityGeneralizedForces(*plant_context);
-    multibody_forces.mutable_generalized_forces() += gravity_forces;
+    EXPECT_TRUE(CompareMatrices(
+        expected_gravity_forces, multibody_forces.generalized_forces(),
+        std::numeric_limits<double>::epsilon(), MatrixCompareType::relative));
 
     // calculate the joint torque
     const auto tau =

--- a/multibody/plant/test/inverse_dynamics_R.urdf
+++ b/multibody/plant/test/inverse_dynamics_R.urdf
@@ -25,18 +25,18 @@
   </link>
 
   <joint name="joint_1" type="revolute">
-    <origin xyz="0.0 0 0.0" rpy="1.5708 0.0 0" />
+    <origin xyz="0.0 0 0.0" rpy="1.5707963267948966 0.0 0" />
     <parent link="root_link" />
     <child link="link_1" />
     <axis xyz="0.0 0.0 1.0" />
-    <limit effort="0" velocity="0" lower="0" upper="3.14159" />
+    <limit effort="0" velocity="0" lower="0" upper="3.14159265358979323846" />
     <joint_properties friction="0.0" />
   </joint>
 
   <link name="link_e" />
 
   <joint name="joint_e" type="fixed">
-    <origin xyz="1 0.0 0" rpy="3.14159 -1.5708 0" />
+    <origin xyz="1 0.0 0" rpy="3.14159265358979323846 -1.5707963267948966 0" />
     <parent link="link_1" />
     <child link="link_e" />
   </joint>

--- a/multibody/plant/test/inverse_dynamics_R.urdf
+++ b/multibody/plant/test/inverse_dynamics_R.urdf
@@ -1,0 +1,43 @@
+<robot name="R">
+
+  <link name="world" />
+
+  <joint name="world_to_base" type="fixed">
+    <parent link="world" />
+    <child link="root_link" />
+    <origin rpy="0 0 0" xyz="0 0 0" />
+  </joint>
+
+  <link name="root_link">
+    <inertial>
+      <origin xyz="0.0 0.0 -0.00645398168514013" rpy="0 0 0" />
+      <mass value="0.161335" />
+      <inertia ixx="0.0002535023405530344" ixy="0.0" ixz="0.0" iyy="0.00014151860061501566" iyz="0.0" izz="0.00018331879898268654" />
+    </inertial>
+  </link>
+
+  <link name="link_1">
+    <inertial>
+      <origin xyz="0.48553997281970385 0.0 0.0" rpy="0 0 0" />
+      <mass value="2.0" />
+      <inertia ixx="0.0002563344974446631" ixy="0.0" ixz="0.0" iyy="0.17620690260768204" iyz="0.0" izz="0.17617212013884273" />
+    </inertial>
+  </link>
+
+  <joint name="joint_1" type="revolute">
+    <origin xyz="0.0 0 0.0" rpy="1.5708 0.0 0" />
+    <parent link="root_link" />
+    <child link="link_1" />
+    <axis xyz="0.0 0.0 1.0" />
+    <limit effort="0" velocity="0" lower="0" upper="3.14159" />
+    <joint_properties friction="0.0" />
+  </joint>
+
+  <link name="link_e" />
+
+  <joint name="joint_e" type="fixed">
+    <origin xyz="1 0.0 0" rpy="3.14159 -1.5708 0" />
+    <parent link="link_1" />
+    <child link="link_e" />
+  </joint>
+</robot>

--- a/multibody/plant/test/inverse_dynamics_R.urdf
+++ b/multibody/plant/test/inverse_dynamics_R.urdf
@@ -18,7 +18,7 @@
 
   <link name="link_1">
     <inertial>
-      <origin xyz="0.48553997281970385 0.0 0.0" rpy="0 0 0" />
+      <origin xyz="0.5 0.0 0.0" rpy="0 0 0" />
       <mass value="2.0" />
       <inertia ixx="0.0002563344974446631" ixy="0.0" ixz="0.0" iyy="0.17620690260768204" iyz="0.0" izz="0.17617212013884273" />
     </inertial>


### PR DESCRIPTION
I have noticed that the returned vector from `plant.CalcInverseDynamics` doesn't consider the gravity of the links.
Adding the gravity effect using `plant.CalcGravityGeneralizedForces` doesn't fix the issue if it is done before the state change. So, it is important to run this gravity calculation right before the inverse dynamics calculation. 

This added test demonstrates this. This is very useful as no test or example shows the relation between `CalcGravityGeneralizedForces` and `CalcInverseDynamics`, which causes a lot of confusion.

Related to https://stackoverflow.com/q/72179395/7910299

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17153)
<!-- Reviewable:end -->
