### PR TITLE
[tools] Add OpenMP to "Everything" CI config

### DIFF
--- a/tools/ubuntu-focal.bazelrc
+++ b/tools/ubuntu-focal.bazelrc
@@ -17,10 +17,11 @@ build --action_env=PATH=/usr/bin:/bin
 build --action_env=PYTHONNOUSERSITE=1
 build --test_env=PYTHONNOUSERSITE=1
 
-# Enable OpenMP (when requested via --config omp).
+# Enable OpenMP (when requested via --config=omp or --config=everything).
 build:omp --copt=-DEIGEN_DONT_PARALLELIZE
 build:omp --copt=-fopenmp
 build:omp --linkopt=-fopenmp
+build:everything --config=omp
 
 # -- Options for explicitly using Clang.
 common:clang --repo_env=CC=clang-12


### PR DESCRIPTION
Previously, it was only enabled manually for GCC only (https://github.com/RobotLocomotion/drake-ci/pull/154).  Now that we are up to Clang 12, we can enable it unconditionally (and thereafter revert that CI PR).