### PR TITLE
[solvers] Disable building certain tests when solvers are disabled

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -10,6 +10,7 @@ load(
 )
 load(
     ":defs.bzl",
+    "drake_cc_optional_googletest",
     "drake_cc_optional_library",
     "drake_cc_variant_library",
 )
@@ -1230,8 +1231,9 @@ drake_cc_googletest(
     ],
 )
 
-drake_cc_googletest(
+drake_cc_optional_googletest(
     name = "csdp_solver_internal_test",
+    opt_out_condition = "//tools:no_csdp",
     deps = [
         ":csdp_solver_internal",
         ":csdp_test_examples",
@@ -1239,8 +1241,9 @@ drake_cc_googletest(
     ],
 )
 
-drake_cc_googletest(
+drake_cc_optional_googletest(
     name = "csdp_cpp_wrapper_test",
+    opt_out_condition = "//tools:no_csdp",
     tags = [
         # The longjmp handling definitely leaks memory, and we've decided to
         # just live with that. If we see the longjmp handler triggering when
@@ -1357,8 +1360,9 @@ drake_cc_googletest(
     ],
 )
 
-drake_cc_googletest(
+drake_cc_optional_googletest(
     name = "ibex_converter_test",
+    opt_out_condition = "//tools:no_dreal",
     deps = [
         ":ibex_converter",
     ],


### PR DESCRIPTION
Most solver unit tests can still build in the absence of the third-party dependency (because the test only uses SolverInterface), but tests of utility wrappers often directly use the missing third-party header(s), so we can't even compile them.

Towards #17009 to enable `--define=NO_DREAL` to pass CI.

Tested locally on Ubuntu via `bazel test //solvers/... --define=NO_DREAL=ON`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17164)
<!-- Reviewable:end -->
