### PR TITLE
[install] Correct comment from #17105

### DIFF
--- a/tools/install/installer.py
+++ b/tools/install/installer.py
@@ -277,10 +277,9 @@ def linux_fix_rpaths(dst_full):
             # the library name without its possible version number.
             soname, version, _ = re_result.groups()
             if soname not in libraries_to_fix_rpath:
-                # TODO(svenevs): when drake-visualizer support is removed, the
-                # capture of `version` and secondary check for e.g.,
-                # libvtk*.so.1 (libraries_to_fix_rpath includes the .1 for
-                # VTK-8) can be removed.
+                # Some third party libraries that are copied rather than
+                # compiled such as mosek are stored as keys in
+                # libraries_to_fix_rpath with the version (e.g., libname.so.1).
                 soname = f'{soname}{version}'
                 if soname not in libraries_to_fix_rpath:
                     continue


### PR DESCRIPTION
This logic needs to remain after drake-visualizer is removed, mosek was also getting its rpath fix (incorrectly) skipped.

In #17105 we fixed the rpaths for drake-visualizer, but the included fix also repaired the rpath for libmosek.  In testing #17058 against the v1.2.0 tarball, in addition to resurrecting the changes in #17105 the following was needed to get past `shlibs`, it failed being unable to find `libcilkrts.so.5`:

```py
subprocess.check_call([
    "patchelf",
    "--set-rpath",
    "$ORIGIN",
    str(drake_lib / "libmosek64.so.9.2")
])
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17173)
<!-- Reviewable:end -->
