### PR TITLE
[parsing] Enable multi-robot collision filter groups

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -60,6 +60,7 @@ drake_cc_library(
 drake_cc_library(
     name = "detail_misc",
     srcs = [
+        "detail_collision_filter_group_resolver.cc",
         "detail_common.cc",
         "detail_ignition.cc",
         "detail_path_utils.cc",
@@ -67,6 +68,7 @@ drake_cc_library(
         "detail_tinyxml2_diagnostic.cc",
     ],
     hdrs = [
+        "detail_collision_filter_group_resolver.h",
         "detail_common.h",
         "detail_ignition.h",
         "detail_path_utils.h",
@@ -77,6 +79,7 @@ drake_cc_library(
     visibility = ["//visibility:private"],
     deps = [
         ":package_map",
+        ":scoped_names",
         "//common:diagnostic_policy",
         "//common:essential",
         "//common:filesystem",
@@ -499,6 +502,14 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "detail_tinyxml2_diagnostic_test",
+    deps = [
+        ":detail_misc",
+        ":diagnostic_policy_test_base",
+    ],
+)
+
+drake_cc_googletest(
+    name = "detail_collision_filter_group_resolver_test",
     deps = [
         ":detail_misc",
         ":diagnostic_policy_test_base",

--- a/multibody/parsing/detail_collision_filter_group_resolver.cc
+++ b/multibody/parsing/detail_collision_filter_group_resolver.cc
@@ -1,0 +1,171 @@
+#include "drake/multibody/parsing/detail_collision_filter_group_resolver.h"
+
+#include "drake/multibody/parsing/scoped_names.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+using drake::internal::DiagnosticPolicy;
+using geometry::GeometrySet;
+using parsing::GetInstanceScopeName;
+using parsing::ParseScopedName;
+using parsing::PrefixName;
+using parsing::ScopedName;
+
+CollisionFilterGroupResolver::CollisionFilterGroupResolver(
+    MultibodyPlant<double>* plant) : plant_(plant) {
+  DRAKE_DEMAND(plant != nullptr);
+}
+
+CollisionFilterGroupResolver::~CollisionFilterGroupResolver() {}
+
+void CollisionFilterGroupResolver::AddGroup(
+    const DiagnosticPolicy& diagnostic,
+    const std::string& group_name,
+    const std::set<std::string>& body_names,
+    std::optional<ModelInstanceIndex> model_instance) {
+  if (model_instance) {
+    DRAKE_DEMAND(*model_instance < plant_->num_model_instances());
+  }
+  DRAKE_DEMAND(!group_name.empty());
+  if (!CheckLegalName(diagnostic, group_name, "group name")) { return; }
+  if (!ParseScopedName(group_name).instance_name.empty()) {
+    diagnostic.Error(fmt::format("group name '{}' cannot be a scoped name",
+                                 FullyQualify(group_name, model_instance)));
+    return;
+  }
+  if (body_names.empty()) {
+    diagnostic.Error(fmt::format("group '{}' has no members",
+                                 FullyQualify(group_name, model_instance)));
+    return;
+  }
+
+  geometry::GeometrySet geometry_set;
+  for (const auto& body_name : body_names) {
+    DRAKE_DEMAND(!body_name.empty());
+    if (!CheckLegalName(diagnostic, body_name, "body name")) { continue; }
+    const std::string qualified = FullyQualify(body_name, model_instance);
+    ScopedName scoped_name = ParseScopedName(qualified);
+
+    std::optional<ModelInstanceIndex> body_model;
+    if (!scoped_name.instance_name.empty()) {
+      if (plant_->HasModelInstanceNamed(scoped_name.instance_name)) {
+        body_model = plant_->GetModelInstanceByName(scoped_name.instance_name);
+      } else {
+        diagnostic.Error(fmt::format("body with name '{}' not found",
+                                     qualified));
+        continue;
+      }
+    }
+
+    const Body<double>* body = FindBody(scoped_name.name, body_model);
+    if (!body) {
+      diagnostic.Error(fmt::format("body with name '{}' not found", qualified));
+      continue;
+    }
+    geometry_set.Add(plant_->GetBodyFrameIdOrThrow(body->index()));
+  }
+  groups_.insert({FullyQualify(group_name, model_instance), geometry_set});
+}
+
+void CollisionFilterGroupResolver::AddPair(
+    const DiagnosticPolicy& diagnostic,
+    const std::string& group_name_a,
+    const std::string& group_name_b,
+    std::optional<ModelInstanceIndex> model_instance) {
+  DRAKE_DEMAND(!group_name_a.empty());
+  DRAKE_DEMAND(!group_name_b.empty());
+  if (model_instance) {
+    DRAKE_DEMAND(*model_instance < plant_->num_model_instances());
+  }
+  bool a_ok = CheckLegalName(diagnostic, group_name_a, "group name");
+  bool b_ok = CheckLegalName(diagnostic, group_name_b, "group name");
+  if (!(a_ok && b_ok)) {
+    return;
+  }
+
+  // Store group pairs by fully qualified name. The groups don't need to
+  // actually be defined until Resolve() time.
+  const std::string name_a = FullyQualify(group_name_a, model_instance);
+  const std::string name_b = FullyQualify(group_name_b, model_instance);
+
+  // These two group names are allowed to be identical, which means the
+  // bodies inside this collision filter group should be collision excluded
+  // among each other.
+  pairs_.insert({name_a, name_b});
+}
+
+void CollisionFilterGroupResolver::Resolve(const DiagnosticPolicy& diagnostic) {
+  DRAKE_DEMAND(!is_resolved_);
+  is_resolved_ = true;
+
+  for (const auto& [name_a, name_b] : pairs_) {
+    const GeometrySet* set_a = FindGroup(diagnostic, name_a);
+    const GeometrySet* set_b = FindGroup(diagnostic, name_b);
+    if (set_a == nullptr || set_b == nullptr) {
+      continue;
+    }
+    plant_->ExcludeCollisionGeometriesWithCollisionFilterGroupPair(
+        {name_a, *set_a}, {name_b, *set_b});
+  }
+}
+
+bool CollisionFilterGroupResolver::CheckLegalName(
+    const drake::internal::DiagnosticPolicy& diagnostic,
+    std::string_view name,
+    const std::string& description) const {
+  DRAKE_DEMAND(!name.empty());
+
+  const std::string_view delim(parsing::internal::kScopedNameDelim);
+  // The main objective here is to avoid aborting with a dubious message in
+  // ParseScope(). There are numerous other degenerate name cases, but those
+  // likely won't abort in ParseScope() and will be caught later on by full
+  // qualification and lookup.
+  bool legal = (name.front() != delim.front()) &&
+               (name.back() != delim.back());
+  if (!legal) {
+    diagnostic.Error(fmt::format("{} '{}' can neither begin nor end with '{}'",
+                                 description, name, delim));
+  }
+  return legal;
+}
+
+std::string CollisionFilterGroupResolver::FullyQualify(
+    const std::string& name,
+    std::optional<ModelInstanceIndex> model_instance) const {
+  if (!model_instance) {
+    // Names found in global scope are just themselves.
+    return name;
+  }
+
+  // Treat the name as relative and just prefix it with the model instance
+  // name. Misuses of scoping will fail in lookup.
+  return PrefixName(GetInstanceScopeName(*plant_, *model_instance), name);
+}
+
+const GeometrySet* CollisionFilterGroupResolver::FindGroup(
+    const DiagnosticPolicy& diagnostic, const std::string& group_name) const {
+  auto iter = groups_.find(group_name);
+  if (iter == groups_.end()) {
+    diagnostic.Error(
+        fmt::format("collision filter group with name '{}' not found",
+                    group_name));
+    return nullptr;
+  }
+  return &iter->second;
+}
+
+const Body<double>* CollisionFilterGroupResolver::FindBody(
+    const std::string& name,
+    std::optional<ModelInstanceIndex> model_instance) {
+  ModelInstanceIndex model = model_instance.value_or(default_model_instance());
+  if (plant_->HasBodyNamed(name, model)) {
+    return &plant_->GetBodyByName(name, model);
+  }
+  return {};
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/detail_collision_filter_group_resolver.h
+++ b/multibody/parsing/detail_collision_filter_group_resolver.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+
+#include "drake/common/diagnostic_policy.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/sorted_pair.h"
+#include "drake/geometry/geometry_set.h"
+#include "drake/multibody/plant/multibody_plant.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Collects and resolves collision filter group information, potentially across
+// multiple models. Uses the same scoped-name semantics as SDFormat and model
+// directives to allow reference and resolution of names across models.
+//
+// All methods use the supplied MultibodyPlant as the source of truth for
+// existence and naming of models and bodies.  The Resolve() step writes the
+// finished collision filtering rules to the plant.
+//
+// All methods may emit warnings or errors to a passed diagnostic policy
+// channel.
+//
+// @note model_instance: All methods use a model instance parameter to denote
+// the current scope where information is found during parsing. Its name is
+// used to expand the relative names found to absolute names for further
+// internal processing. If a model instance value is not provided, names are
+// evaluated with respect to the "root" of the plant.
+//
+// TODO(rpoyner-tri): clarify the roles of the world instance (0) and the
+// default model instance (1).
+//
+class CollisionFilterGroupResolver {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(CollisionFilterGroupResolver)
+
+  // The @p plant parameter is aliased, and must outlive the resolver.
+  // @pre plant is not nullptr.
+  explicit CollisionFilterGroupResolver(MultibodyPlant<double>* plant);
+
+  ~CollisionFilterGroupResolver();
+
+  // Adds a collision filter group. Locates bodies by name immediately, and
+  // emits errors for illegal names, empty groups, or missing bodies.
+  //
+  // @param diagnostic     The error-reporting channel.
+  // @param group_name     The name of the group being defined.
+  // @param body_names     The names of the bodies that are group members.
+  // @param model_instance The current model, for scoping purposes.
+  //                       @see model_instance note above.
+  //
+  // @pre group_name is not empty.
+  // @pre no member strings of body_names are empty.
+  // @pre model_instance has a valid index or else no value.
+  void AddGroup(
+      const drake::internal::DiagnosticPolicy& diagnostic,
+      const std::string& group_name,
+      const std::set<std::string>& body_names,
+      std::optional<ModelInstanceIndex> model_instance);
+
+  // Adds a group pair. Emits diagnostics for illegal names.  Two distinct
+  // names will resolve to an exclude-between-groups rule; identical names will
+  // resolve to an exclude-within-group rule. Group names may refer to a group
+  // not defined until later; group existence will be checked in the Resolve()
+  // step.
+  //
+  // @param diagnostic     The error-reporting channel.
+  // @param group_name_a   The name of a defined group.
+  // @param group_name_b   The name of a defined group.
+  // @param model_instance The current model, for scoping purposes.
+  //                       @see model_instance note above.
+  //
+  // @pre neither group_name_a nor group_name_b is empty.
+  // @pre model_instance has a valid index or else no value.
+  void AddPair(
+      const drake::internal::DiagnosticPolicy& diagnostic,
+      const std::string& group_name_a,
+      const std::string& group_name_b,
+      std::optional<ModelInstanceIndex> model_instance);
+
+  // Resolves group pairs to rules. Emits diagnostics for undefined groups.
+  //
+  // @pre cannot have be previously invoked on this instance.
+  void Resolve(const drake::internal::DiagnosticPolicy& diagnostic);
+
+ private:
+  bool CheckLegalName(const drake::internal::DiagnosticPolicy& diagnostic,
+                      std::string_view name,
+                      const std::string& description) const;
+
+  std::string FullyQualify(
+      const std::string& name,
+      std::optional<ModelInstanceIndex> model_instance) const;
+
+  const geometry::GeometrySet* FindGroup(
+      const drake::internal::DiagnosticPolicy& diagnostic,
+      const std::string& group_name) const;
+
+  const Body<double>* FindBody(
+      const std::string& name,
+      std::optional<ModelInstanceIndex> model_instance);
+
+  MultibodyPlant<double>* const plant_;
+  std::map<std::string, geometry::GeometrySet> groups_;
+  std::set<SortedPair<std::string>> pairs_;
+  bool is_resolved_{false};
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/detail_common.h
+++ b/multibody/parsing/detail_common.h
@@ -12,6 +12,7 @@
 #include "drake/common/diagnostic_policy.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/geometry/proximity_properties.h"
+#include "drake/multibody/parsing/detail_collision_filter_group_resolver.h"
 #include "drake/multibody/plant/coulomb_friction.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/linear_bushing_roll_pitch_yaw.h"
@@ -168,10 +169,14 @@ const LinearBushingRollPitchYaw<double>* ParseLinearBushingRollPitchYaw(
 // tag in both SDF and URDF can be controlled/modified in a single function.
 // Functors are allowed to throw an exception when the requested quantities
 // are not available.
+// @param diagnostic            The error-reporting channel.
 // @param model_instance        Model Instance that contains the bodies involved
 //                              in the collision filter groups.
 // @param model_node            Node used to parse for the
 //                              collision_gilter_group tag.
+// @param plant                 MultibodyPlant used to register the collision
+//                              filter groups.
+// @param resolver              Collects the collision filter group data.
 // @param next_child_element    Function that returns the next child element
 //                              with the specified tag in the ElementNode
 //                              provided.
@@ -188,11 +193,11 @@ const LinearBushingRollPitchYaw<double>* ParseLinearBushingRollPitchYaw(
 //                              name provided in the ElementNoded provided.
 // @param read_bool_attribute   Function that reads a boolean attribute with
 //                              the name provided in the ElementNode provided.
-// @param plant                 MultibodyPlant used to register the collision
-//                              filter groups.
 void ParseCollisionFilterGroupCommon(
+    const drake::internal::DiagnosticPolicy& diagnostic,
     ModelInstanceIndex model_instance, const ElementNode& model_node,
     MultibodyPlant<double>* plant,
+    internal::CollisionFilterGroupResolver* resolver,
     const std::function<ElementNode(const ElementNode&, const char*)>&
         next_child_element,
     const std::function<ElementNode(const ElementNode&, const char*)>&

--- a/multibody/parsing/detail_parsing_workspace.h
+++ b/multibody/parsing/detail_parsing_workspace.h
@@ -3,6 +3,7 @@
 #include "drake/common/diagnostic_policy.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/multibody/parsing/detail_collision_filter_group_resolver.h"
 #include "drake/multibody/parsing/package_map.h"
 #include "drake/multibody/plant/multibody_plant.h"
 
@@ -15,29 +16,32 @@ namespace internal {
 // elsewhere.
 //
 // Note that code using this struct may pass it via const-ref, but the
-// indicated plant will still be mutable; only its pointer within the struct is
-// const.
+// indicated plant and collision resolver objects will still be mutable; only
+// the pointer values within the struct are const.
 struct ParsingWorkspace {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ParsingWorkspace)
 
   // All parameters are aliased; they must have a lifetime greater than that of
   // this struct.
   ParsingWorkspace(
-    const PackageMap& package_map_in,
-    const drake::internal::DiagnosticPolicy& diagnostic_in,
-    MultibodyPlant<double>* plant_in)
+      const PackageMap& package_map_in,
+      const drake::internal::DiagnosticPolicy& diagnostic_in,
+      MultibodyPlant<double>* plant_in,
+      internal::CollisionFilterGroupResolver* collision_resolver_in)
       : package_map(package_map_in),
         diagnostic(diagnostic_in),
-        plant(plant_in) {
+        plant(plant_in),
+        collision_resolver(collision_resolver_in) {
     DRAKE_DEMAND(plant != nullptr);
+    DRAKE_DEMAND(collision_resolver != nullptr);
   }
 
   const PackageMap& package_map;
   const drake::internal::DiagnosticPolicy& diagnostic;
   MultibodyPlant<double>* const plant;
+  internal::CollisionFilterGroupResolver* const collision_resolver;
 };
 
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake
-

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -311,10 +311,11 @@ void UrdfParser::ParseCollisionFilterGroup(XMLElement* node) {
                          attribute_name, &attribute_value);
     return attribute_value == std::string("true") ? true : false;
   };
-  ParseCollisionFilterGroupCommon(model_instance_, node, w_.plant,
-                                  next_child_element, next_sibling_element,
-                                  has_attribute, get_string_attribute,
-                                  get_bool_attribute, get_string_attribute);
+  ParseCollisionFilterGroupCommon(
+      diagnostic_.MakePolicyForNode(node), model_instance_, node, w_.plant,
+      w_.collision_resolver, next_child_element, next_sibling_element,
+      has_attribute, get_string_attribute, get_bool_attribute,
+      get_string_attribute);
 }
 
 // Parses a joint URDF specification to obtain the names of the joint, parent

--- a/multibody/parsing/parsing_doxygen.h
+++ b/multibody/parsing/parsing_doxygen.h
@@ -31,6 +31,47 @@ For Drake extensions to SDFormat files, see
 Drake's parser does not implement all of the features of SDFormat. In the
 future, we intend to update this documentation to itemize what isn't supported.
 
+@subsection model_composition SDFormat model composition
+
+Drake's SDFormat parsing supports composing multiple models into a single
+model, via lexical nesting and file inclusion. The file inclusion feature
+supports both SDFormat files and URDF files. Note that included URDF files pass
+through the Drake URDF parser, with all of it's extensions and limitations.
+
+For full details, see the
+<a href='http://sdformat.org/tutorials?tut=composition_proposal#model-composition-proposed-behavior'>SDFormat documentation of model composition.</a>
+
+An important feature of SDFormat model composition is the ability to
+cross-reference features of other models. Cross-references are denoted by using
+scoped names.
+
+@subsubsection scoped_names Scoped names
+
+Scoped names allow referring to an element of a model nested within the current
+model. They take the form of some number of nested model names, plus the
+element name, all joined by the delimiter `::`. Names not using the `::`
+delimeter are not considered scoped names; they are used to define or refer to
+elements of the current model. For example, suppose that model A contains model
+B, which in turn contains model C. Here are some valid scoped names:
+
+- within A:
+  - `some_frame_in_A`
+  - `B::some_frame_in_B`
+  - `B::C::some_frame_in_C`
+- within B:
+  - `some_frame_in_B`
+  - `C::some_frame_in_C`
+- within C:
+  - `some_frame_in_C`
+
+Note that (deliberately) there is no way to refer to elements outward or upward
+from the current model; all names are relative to the current model and can
+only refer to the current or a nested model. In particular, names must not
+start with `::`; there is no way to denote any "outer" or "outermost" scope.
+
+For a detailed design discussion with examples, see the
+<a href='http://sdformat.org/tutorials?tut=composition_proposal#1-3-name-scoping-and-cross-referencing'>SDFormat documentation of name scoping.</a>
+
 @section multibody_parsing_urdf URDF Support
 Drake supports URDF files as described here: http://wiki.ros.org/urdf/XML.
 
@@ -293,8 +334,12 @@ with the child link of the joint being defined.
 
 This element names a group of bodies to participate in collision filtering
 rules. If the `ignore` attribute is present and true-valued, the entire element
-is ignored. The nested elements must included one or more `drake:member`
-elements, and zero or more `drake:ignored_collision_filter_group` elements.
+is skipped during parsing. The nested elements must included one or more
+`drake:member` elements, and zero or more
+`drake:ignored_collision_filter_group` elements.
+
+This element defines a new group name that is only available during parsing. It
+must not be a scoped name.
 
 Collision filtering rules are only constructed with **pairs** of groups, where
 both sides of the pair may name the same group. The
@@ -305,7 +350,7 @@ different collision groups excludes collisions between members of those groups
 naming the same group twice excludes collisions within the group (see
 drake::geometry::CollisionFilterDeclaration::ExcludeWithin()).
 
-@see @ref tag_drake_member, @ref tag_drake_ignored_collision_filter_group
+@see @ref tag_drake_member, @ref tag_drake_ignored_collision_filter_group, @ref scoped_names
 
 @subsection tag_drake_compliant_hydroelastic drake:compliant_hydroelastic
 
@@ -438,7 +483,10 @@ under `(hydroelastic, hydroelastic_modulus)`.
 The string names a collision filter group that will be paired with the parent
 group when constructing filtering rules. It may name the parent group.
 
-@see @ref tag_drake_collision_filter_group
+In SDFormat files only, the name may refer to a group within a nested model
+(either URDF or SDFormat) by using a scoped name.
+
+@see @ref tag_drake_collision_filter_group, @ref scoped_names
 
 @subsection tag_drake_joint drake:joint
 
@@ -491,7 +539,10 @@ This element adds a drake::multibody::LinearBushingRollPitchYaw to the model.
 This element names a link (defined elsewhere in the model) to be a member of
 the parent collision filter group.
 
-@see @ref tag_drake_collision_filter_group
+In SDFormat files only, the name may refer to a link within a nested model
+(either URDF or SDFormat) by using a scoped name.
+
+@see @ref tag_drake_collision_filter_group, @ref scoped_names
 
 @subsection tag_drake_mesh_resolution_hint drake:mesh_resolution_hint
 

--- a/multibody/parsing/scoped_names.cc
+++ b/multibody/parsing/scoped_names.cc
@@ -4,7 +4,7 @@ namespace drake {
 namespace multibody {
 namespace parsing {
 
-constexpr char const* kDelim = "::";
+using internal::kScopedNameDelim;
 
 const drake::multibody::Frame<double>*
 GetScopedFrameByNameMaybe(
@@ -34,7 +34,7 @@ std::string GetScopedFrameName(
 }
 
 ScopedName ParseScopedName(const std::string& full_name) {
-  size_t pos = full_name.rfind(kDelim);
+  size_t pos = full_name.rfind(kScopedNameDelim);
   ScopedName result;
   if (pos == std::string::npos) {
     result.name = full_name;
@@ -42,7 +42,7 @@ ScopedName ParseScopedName(const std::string& full_name) {
     result.instance_name = full_name.substr(0, pos);
     // "Global scope" (e.g. "::my_frame") not supported.
     DRAKE_DEMAND(!result.instance_name.empty());
-    result.name = full_name.substr(pos + std::string(kDelim).size());
+    result.name = full_name.substr(pos + std::string(kScopedNameDelim).size());
   }
   return result;
 }
@@ -53,7 +53,7 @@ std::string PrefixName(const std::string& namespace_, const std::string& name) {
   else if (name.empty())
     return namespace_;
   else
-    return namespace_ + kDelim + name;
+    return namespace_ + kScopedNameDelim + name;
 }
 
 std::string GetInstanceScopeName(

--- a/multibody/parsing/scoped_names.h
+++ b/multibody/parsing/scoped_names.h
@@ -11,6 +11,11 @@
 namespace drake {
 namespace multibody {
 namespace parsing {
+namespace internal {
+// Expose the delimeter string for reference, especially in tests.
+constexpr char kScopedNameDelim[] = "::";
+}  // namespace internal
+
 
 /// Finds an optionally model-scoped frame, using the naming rules of
 /// `ParseScopedName`.

--- a/multibody/parsing/test/detail_collision_filter_group_resolver_test.cc
+++ b/multibody/parsing/test/detail_collision_filter_group_resolver_test.cc
@@ -1,0 +1,152 @@
+#include "drake/multibody/parsing/detail_collision_filter_group_resolver.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/geometry/scene_graph.h"
+#include "drake/multibody/parsing/test/diagnostic_policy_test_base.h"
+#include "drake/multibody/plant/multibody_plant.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace {
+
+using ::testing::MatchesRegex;
+
+using geometry::GeometryId;
+using geometry::SceneGraph;
+using math::RigidTransformd;
+
+class CollisionFilterGroupResolverTest : public test::DiagnosticPolicyTestBase {
+ public:
+  CollisionFilterGroupResolverTest() {
+    plant_.RegisterAsSourceForSceneGraph(&scene_graph_);
+  }
+
+  // Add a body to a model, with collision geometry and return the geometry id.
+  GeometryId AddBody(const std::string& name,
+                     std::optional<ModelInstanceIndex> model_instance) {
+    auto model = model_instance.value_or(default_model_instance());
+    return plant_.RegisterCollisionGeometry(
+        plant_.AddRigidBody(name, model, SpatialInertia<double>()),
+        RigidTransformd::Identity(), geometry::Sphere(1.0), name,
+        CoulombFriction<double>());
+  }
+
+ protected:
+  MultibodyPlant<double> plant_{0.0};
+  SceneGraph<double> scene_graph_;
+  const geometry::SceneGraphInspector<double>& inspector_{
+      scene_graph_.model_inspector()};
+  internal::CollisionFilterGroupResolver resolver_{&plant_};
+};
+
+// These tests concentrate on name resolution details and responses to errors
+// in the parsed text.  TODO(rpoyner-tri) Migrate actual filter construction
+// tests here from detail_{urdf,sdf}_parser_test.
+
+TEST_F(CollisionFilterGroupResolverTest, IllegalPair) {
+  resolver_.AddPair(diagnostic_policy_, "::a", "b::", {});
+  resolver_.Resolve(diagnostic_policy_);
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'::a'.*neither begin nor end.*"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'b::'.*neither begin nor end.*"));
+}
+
+TEST_F(CollisionFilterGroupResolverTest, BogusPairScoped) {
+  ModelInstanceIndex r1 = plant_.AddModelInstance("r1");
+  resolver_.AddPair(diagnostic_policy_, "a", "sub::b", r1);
+  resolver_.Resolve(diagnostic_policy_);
+  EXPECT_THAT(TakeError(), MatchesRegex(".*group.*'r1::a'.*not found"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*group.*'r1::sub::b'.*not found"));
+}
+
+TEST_F(CollisionFilterGroupResolverTest, BogusPairGlobal) {
+  resolver_.AddPair(diagnostic_policy_, "a", "b", {});
+  resolver_.Resolve(diagnostic_policy_);
+  EXPECT_THAT(TakeError(), MatchesRegex(".*group.*'a'.*not found"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*group.*'b'.*not found"));
+}
+
+TEST_F(CollisionFilterGroupResolverTest, IllegalGroupName) {
+  resolver_.AddGroup(diagnostic_policy_, "::a", {}, {});
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'::a'.*neither begin nor end.*"));
+  resolver_.AddGroup(diagnostic_policy_, "b::", {}, {});
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'b::'.*neither begin nor end.*"));
+}
+
+TEST_F(CollisionFilterGroupResolverTest, IllegalBodies) {
+  resolver_.AddGroup(diagnostic_policy_, "g", {"::a", "b::"}, {});
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'::a'.*neither begin nor end.*"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'b::'.*neither begin nor end.*"));
+}
+
+TEST_F(CollisionFilterGroupResolverTest, BogusGroupName) {
+  resolver_.AddGroup(diagnostic_policy_, "haha::a", {}, {});
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'haha::a' cannot be.*scoped.*"));
+}
+
+TEST_F(CollisionFilterGroupResolverTest, EmptyGroupGlobal) {
+  resolver_.AddGroup(diagnostic_policy_, "a", {}, {});
+  EXPECT_THAT(TakeError(), MatchesRegex(".*group.*'a'.*no members"));
+}
+
+TEST_F(CollisionFilterGroupResolverTest, EmptyGroupsScoped) {
+  ModelInstanceIndex r1 = plant_.AddModelInstance("r1");
+  resolver_.AddGroup(diagnostic_policy_, "a", {}, r1);
+  EXPECT_THAT(TakeError(), MatchesRegex(".*group.*'r1::a'.*no members"));
+  ModelInstanceIndex r2 = plant_.AddModelInstance("r2");
+  resolver_.AddGroup(diagnostic_policy_, "b", {}, r2);
+  EXPECT_THAT(TakeError(), MatchesRegex(".*group.*'r2::b'.*no members"));
+}
+
+TEST_F(CollisionFilterGroupResolverTest, MissingBodyGlobal) {
+  plant_.AddModelInstance("r1");
+  resolver_.AddGroup(diagnostic_policy_, "a",
+                     {"abody", "r1::abody", "zzz::abody"}, {});
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'abody'.*not found"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'r1::abody'.*not found"));
+  // Note that AddGroup() doesn't choke on an instance name that doesn't exist.
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'zzz::abody'.*not found"));
+}
+
+TEST_F(CollisionFilterGroupResolverTest, MissingBodyScoped) {
+  ModelInstanceIndex r1 = plant_.AddModelInstance("r1");
+  plant_.AddModelInstance("r1::sub");
+  resolver_.AddGroup(diagnostic_policy_, "a",
+                     {"abody", "sub::abody", "zzz::abody"}, r1);
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'r1::abody'.*not found"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'r1::sub::abody'.*not found"));
+  // Note that AddGroup() doesn't choke on an instance name that doesn't exist.
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'r1::zzz::abody'.*not found"));
+}
+
+TEST_F(CollisionFilterGroupResolverTest, BodyGlobal) {
+  // Ensure body names can be resolved in the absence of any model scopes.
+  GeometryId b1 = AddBody("body1", {});
+  GeometryId b2 = AddBody("body2", {});
+  resolver_.AddGroup(diagnostic_policy_, "a", {"body1", "body2"}, {});
+  resolver_.AddPair(diagnostic_policy_, "a", "a", {});
+  resolver_.Resolve(diagnostic_policy_);
+  EXPECT_TRUE(inspector_.CollisionFiltered(b1, b2));
+}
+
+TEST_F(CollisionFilterGroupResolverTest, LinkScoped) {
+  // Ensure body names can be resolved in various model scopes.
+  ModelInstanceIndex r1 = plant_.AddModelInstance("r1");
+  GeometryId ra = AddBody("abody", r1);
+  ModelInstanceIndex sub = plant_.AddModelInstance("r1::sub");
+  GeometryId rsa = AddBody("abody", sub);
+
+  resolver_.AddGroup(diagnostic_policy_, "a", {"abody", "sub::abody"}, r1);
+  resolver_.AddPair(diagnostic_policy_, "a", "a", r1);
+  resolver_.Resolve(diagnostic_policy_);
+
+  // The expected filter gets created on the plant/scene_graph.
+  EXPECT_TRUE(inspector_.CollisionFiltered(ra, rsa));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -49,21 +49,29 @@ class UrdfParserTest : public test::DiagnosticPolicyTestBase {
   std::optional<ModelInstanceIndex> AddModelFromUrdfFile(
       const std::string& file_name,
       const std::string& model_name) {
-    return AddModelFromUrdf(
-        {DataSource::kFilename, &file_name}, model_name, {}, w_);
+    internal::CollisionFilterGroupResolver resolver{&plant_};
+    ParsingWorkspace w{package_map_, diagnostic_policy_, &plant_, &resolver};
+    auto result = AddModelFromUrdf(
+        {DataSource::kFilename, &file_name}, model_name, {}, w);
+    resolver.Resolve(diagnostic_policy_);
+    return result;
   }
 
   std::optional<ModelInstanceIndex> AddModelFromUrdfString(
       const std::string& file_contents,
       const std::string& model_name) {
-    return AddModelFromUrdf(
-        {DataSource::kContents, &file_contents}, model_name, {}, w_);
+    internal::CollisionFilterGroupResolver resolver{&plant_};
+    ParsingWorkspace w{package_map_, diagnostic_policy_, &plant_, &resolver};
+    auto result = AddModelFromUrdf(
+        {DataSource::kContents, &file_contents}, model_name, {}, w);
+    resolver.Resolve(diagnostic_policy_);
+    return result;
   }
+
  protected:
   PackageMap package_map_;
   MultibodyPlant<double> plant_{0.0};
   SceneGraph<double> scene_graph_;
-  ParsingWorkspace w_{package_map_, diagnostic_policy_, &plant_};
 };
 
 // Some tests contain deliberate typos to provoke parser errors or warnings. In
@@ -765,9 +773,7 @@ TEST_F(UrdfParserTest, AddingGeometriesToWorldLink) {
   </link>
 </robot>
 )""";
-  DataSource source{DataSource::kContents, &test_urdf};
-
-  AddModelFromUrdf(source, "urdf", {}, w_);
+  AddModelFromUrdfString(test_urdf, "urdf");
   EXPECT_THAT(TakeWarning(), MatchesRegex(
                   ".*<inertial> tag is being ignored.*"));
 
@@ -1337,10 +1343,6 @@ TEST_F(UrdfParserTest, CollisionFilterGroupParsingTest) {
   AddModelFromUrdfFile(full_name, "model2");
 }
 
-// TODO(marcoag) We might want to add some form of feedback for:
-// - ignore_collision_filter_groups with non-existing group names.
-// - Empty collision_filter_groups.
-
 TEST_F(UrdfParserTest, CollisionFilterGroupMissingName) {
   EXPECT_NE(AddModelFromUrdfString(R"""(
     <robot name='robot'>
@@ -1363,6 +1365,7 @@ TEST_F(UrdfParserTest, CollisionFilterGroupMissingLink) {
   EXPECT_THAT(TakeError(), MatchesRegex(
                   ".*The tag <drake:member> does not specify the required "
                   "attribute \"link\"."));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'robot::group_a'.*no members"));
 }
 
 TEST_F(UrdfParserTest, IgnoredCollisionFilterGroupMissingName) {
@@ -1373,6 +1376,7 @@ TEST_F(UrdfParserTest, IgnoredCollisionFilterGroupMissingName) {
         <drake:ignored_collision_filter_group/>
       </drake:collision_filter_group>
     </robot>)""", ""), std::nullopt);
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'robot::group_a'.*no members"));
   EXPECT_THAT(TakeError(), MatchesRegex(
                   ".*The tag <drake:ignored_collision_filter_group> does not"
                   " specify the required attribute \"name\"."));

--- a/multibody/parsing/test/sdf_parser_test/collision_filter_group_parsing_test/package.xml
+++ b/multibody/parsing/test/sdf_parser_test/collision_filter_group_parsing_test/package.xml
@@ -1,0 +1,5 @@
+<package format="2">
+  <name>collision_filter_group_parsing_test</name>
+  <version>0.0.1</version>
+</package>
+

--- a/multibody/parsing/test/sdf_parser_test/collision_filter_group_parsing_test/robot.sdf
+++ b/multibody/parsing/test/sdf_parser_test/collision_filter_group_parsing_test/robot.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <sdf xmlns:drake="http://drake.mit.edu" version='1.7'>
-  <model name='collision_filter_group_parsing_test'>
+  <model name='robot'>
     <link name='link1'>
       <collision name='link1_sphere'>
         <geometry>

--- a/multibody/parsing/test/sdf_parser_test/collision_filter_group_parsing_test/test.sdf
+++ b/multibody/parsing/test/sdf_parser_test/collision_filter_group_parsing_test/test.sdf
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<sdf xmlns:drake="http://drake.mit.edu" version='1.7'>
+  <model name='test'>
+    <include>
+      <name>robot1</name>
+      <uri>package://collision_filter_group_parsing_test/robot.sdf</uri>
+    </include>
+    <include>
+      <name>robot2</name>
+      <uri>package://collision_filter_group_parsing_test/robot.sdf</uri>
+    </include>
+    <drake:collision_filter_group name="group_6s">
+      <!-- Build a group from links of nested robots. -->
+      <drake:member>robot1::link6</drake:member>
+      <drake:member>robot2::link6</drake:member>
+      <drake:ignored_collision_filter_group>group_6s</drake:ignored_collision_filter_group>
+    </drake:collision_filter_group>
+    <drake:collision_filter_group name="group_3s">
+      <!-- Build a rule from links and collision filter groups of nested robots. -->
+      <drake:member>robot1::link3</drake:member>
+      <drake:ignored_collision_filter_group>robot2::group_link3</drake:ignored_collision_filter_group>
+    </drake:collision_filter_group>
+  </model>
+</sdf>

--- a/multibody/parsing/test/sdf_parser_test/interface_api_test/arm.forced_nesting_sdf
+++ b/multibody/parsing/test/sdf_parser_test/interface_api_test/arm.forced_nesting_sdf
@@ -1,7 +1,15 @@
 <?xml version="1.0"?>
 <sdf version="1.8">
   <model name="arm">
-    <link name="L1"/>
+    <link name="L1">
+      <collision name='L1'>
+        <geometry>
+          <sphere>
+            <radius>0.4</radius>
+          </sphere>
+        </geometry>
+      </collision>
+    </link>
     <joint name="J1" type="revolute">
       <pose relative_to="L1">0 0 1 0 0 0</pose>
       <parent>L1</parent>
@@ -13,10 +21,26 @@
 
     <frame name="mount" attached_to="L1"/>
 
-    <link name="L2"/>
+    <link name="L2">
+      <collision name='L2'>
+        <geometry>
+          <sphere>
+            <radius>0.4</radius>
+          </sphere>
+        </geometry>
+      </collision>
+    </link>
     <model name="flange">
       <pose relative_to="L2">0 2 1 0 0 0</pose>
-      <link name="L3"/>
+      <link name="L3">
+        <collision name='L3'>
+          <geometry>
+            <sphere>
+              <radius>0.4</radius>
+            </sphere>
+          </geometry>
+      </collision>
+      </link>
       <frame name="gripper_mount" attached_to="L3">
         <pose>0 0 2 0.1 0.2 0.3</pose>
       </frame>

--- a/multibody/parsing/test/sdf_parser_test/interface_api_test/arm.urdf
+++ b/multibody/parsing/test/sdf_parser_test/interface_api_test/arm.urdf
@@ -1,10 +1,22 @@
 <?xml version="1.0"?>
 <robot name="arm">
-  <link name="L1"/>
+  <link name="L1">
+    <collision name='L1'>
+      <geometry>
+        <sphere radius='0.4'/>
+      </geometry>
+    </collision>
+  </link>
   <joint name="J1" type="revolute">
     <origin xyz="1 2 3" rpy="0.1 0.2 0.3"/>
     <parent link="L1"/>
     <child link="L2"/>
   </joint>
-  <link name="L2"/>
+  <link name="L2">
+    <collision name='L2'>
+      <geometry>
+        <sphere radius='0.4'/>
+      </geometry>
+    </collision>
+  </link>
 </robot>

--- a/multibody/parsing/test/sdf_parser_test/interface_api_test/gripper.sdf
+++ b/multibody/parsing/test/sdf_parser_test/interface_api_test/gripper.sdf
@@ -1,7 +1,15 @@
 <?xml version="1.0"?>
 <sdf version="1.8">
   <model name="gripper">
-    <link name="gripper_link"/>
+    <link name="gripper_link">
+      <collision name='gripper_link'>
+        <geometry>
+          <sphere>
+            <radius>0.4</radius>
+          </sphere>
+        </geometry>
+      </collision>
+    </link>
     <frame name="grasp_frame" attached_to="gripper_link"/>
   </model>
 </sdf>

--- a/multibody/parsing/test/sdf_parser_test/interface_api_test/top.sdf
+++ b/multibody/parsing/test/sdf_parser_test/interface_api_test/top.sdf
@@ -1,7 +1,15 @@
 <?xml version="1.0"?>
-<sdf version="1.8">
+<sdf xmlns:drake="http://drake.mit.edu" version="1.8">
   <model name="top">
-    <link name="torso"/>
+    <link name="torso">
+      <collision name='torso'>
+        <geometry>
+          <sphere>
+            <radius>0.4</radius>
+          </sphere>
+        </geometry>
+      </collision>
+    </link>
 
     <model name="tactile_sensor">
       <pose relative_to="arm::gripper::grasp_frame"/>
@@ -35,5 +43,12 @@
       <uri>package://interface_api_test/table_and_mug.forced_nesting_sdf</uri>
       <name>table_and_mug</name>
     </include>
+    <drake:collision_filter_group name="g1">
+      <drake:member>torso</drake:member>
+      <drake:member>arm::L1</drake:member>
+      <drake:member>extra_arm::L2</drake:member>
+      <drake:member>arm::gripper::gripper_link</drake:member>
+      <drake:ignored_collision_filter_group>g1</drake:ignored_collision_filter_group>
+    </drake:collision_filter_group>
   </model>
 </sdf>


### PR DESCRIPTION
Relevant to: #14785

This patch extends the parsing of collision filter groups so that collision
filters can be defined across multiple robots by using SDFormat model
composition.

Summary of changes:
 * add CollisionFilterGroupResolver, with unit test
 * port existing parser modules to use it
   * modernize a few sdf_parser errors
 * demonstrate multi-robot filters in sdf_parser_test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17175)
<!-- Reviewable:end -->
