### PR TITLE
Move HttpServiceCurl to //geometry/render_gltf_client

### DIFF
--- a/geometry/render/dev/render_gltf_client/BUILD.bazel
+++ b/geometry/render/dev/render_gltf_client/BUILD.bazel
@@ -15,21 +15,6 @@ load("//tools/skylark:test_tags.bzl", "vtk_test_tags")
 package(default_visibility = ["//visibility:private"])
 
 drake_cc_library(
-    name = "internal_http_service_curl",
-    srcs = ["internal_http_service_curl.cc"],
-    hdrs = ["internal_http_service_curl.h"],
-    internal = True,
-    visibility = ["//visibility:private"],
-    deps = [
-        "//common:filesystem",
-        "//common:unused",
-        "//geometry/render_gltf_client:internal_http_service",
-        "@fmt",
-        "@libcurl",
-    ],
-)
-
-drake_cc_library(
     name = "internal_render_client",
     srcs = [
         "internal_render_client.cc",
@@ -42,13 +27,13 @@ drake_cc_library(
     internal = True,
     visibility = ["//visibility:private"],
     deps = [
-        ":internal_http_service_curl",
         "//common:filesystem",
         "//common:nice_type_name",
         "//common:temp_directory",
         "//geometry/render:render_camera",
         "//geometry/render:render_engine",
         "//geometry/render_gltf_client:internal_http_service",
+        "//geometry/render_gltf_client:internal_http_service_curl",
         "//systems/sensors:image",
         "@picosha2",
         "@vtk//:vtkIOImage",
@@ -80,15 +65,6 @@ drake_cc_library(
 )
 
 # === test/ ===
-
-drake_cc_googletest(
-    name = "internal_http_service_curl_test",
-    deps = [
-        ":internal_http_service_curl",
-        "//common:temp_directory",
-        "//common/test_utilities:expect_throws_message",
-    ],
-)
 
 drake_cc_library(
     name = "internal_test_png",

--- a/geometry/render/dev/render_gltf_client/internal_render_client.cc
+++ b/geometry/render/dev/render_gltf_client/internal_render_client.cc
@@ -21,7 +21,7 @@
 #include "drake/common/nice_type_name.h"
 #include "drake/common/temp_directory.h"
 #include "drake/common/text_logging.h"
-#include "drake/geometry/render/dev/render_gltf_client/internal_http_service_curl.h"
+#include "drake/geometry/render_gltf_client/internal_http_service_curl.h"
 
 namespace drake {
 namespace geometry {

--- a/geometry/render_gltf_client/BUILD.bazel
+++ b/geometry/render_gltf_client/BUILD.bazel
@@ -37,6 +37,21 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "internal_http_service_curl",
+    srcs = ["internal_http_service_curl.cc"],
+    hdrs = ["internal_http_service_curl.h"],
+    internal = True,
+    visibility = _VISIBILITY,
+    deps = [
+        ":internal_http_service",
+        "//common:filesystem",
+        "//common:unused",
+        "@fmt",
+        "@libcurl",
+    ],
+)
+
 # === test/ ===
 
 drake_cc_googletest(
@@ -46,6 +61,15 @@ drake_cc_googletest(
         "//common:filesystem",
         "//common:temp_directory",
         "//common/test_utilities:expect_no_throw",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "internal_http_service_curl_test",
+    deps = [
+        ":internal_http_service_curl",
+        "//common:temp_directory",
         "//common/test_utilities:expect_throws_message",
     ],
 )

--- a/geometry/render_gltf_client/internal_http_service_curl.h
+++ b/geometry/render_gltf_client/internal_http_service_curl.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <cstdint>
 #include <map>
-#include <memory>
 #include <optional>
 #include <string>
 #include <utility>
@@ -22,7 +20,7 @@ class HttpServiceCurl : public HttpService {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(HttpServiceCurl);
 
  protected:
-  /* @see HttpService::PostForm */
+  /* @see HttpService::DoPostForm */
   HttpResponse DoPostForm(
       const std::string& temp_directory, const std::string& url, int port,
       const DataFieldsMap& data_fields,

--- a/geometry/render_gltf_client/test/internal_http_service_curl_test.cc
+++ b/geometry/render_gltf_client/test/internal_http_service_curl_test.cc
@@ -1,4 +1,4 @@
-#include "drake/geometry/render/dev/render_gltf_client/internal_http_service_curl.h"
+#include "drake/geometry/render_gltf_client/internal_http_service_curl.h"
 
 #include <fstream>
 
@@ -45,7 +45,7 @@ GTEST_TEST(HttpServiceCurlTest, PostForm) {
   }
 
   {
-    // Case 2: cannot create temporary file that can be written to.
+    // Case 2: cannot create temporary file without write permission.
     const auto orig_perms = fs::status(temp_dir).permissions();
     const auto all_write = fs::perms::owner_write | fs::perms::group_write |
                            fs::perms::others_write;

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -44,7 +44,6 @@ LIBDRAKE_COMPONENTS = [
     "//geometry/render",
     "//geometry/render/gl_renderer",
     "//geometry/render/shaders",
-    "//geometry/render_gltf_client",
     "//lcm",
     "//manipulation/kinova_jaco",
     "//manipulation/kuka_iiwa",


### PR DESCRIPTION
This PR is part of the [RenderRpc project](https://github.com/RobotLocomotion/drake/projects/8) that moves the development code of `HttpServiceCurl` class and its tests to `//geometry/render_gltf_client`. The class derives from `HttpService` and utilizes `libcurl` to transfer the data and files (if any) to a render server for rendering.

Since the code is moved out of a dev folder, please review the full file of  `render_gltf_client/internal_http_service_curl.{h, cc}` and `render_gltf_client/test/internal_http_service_curl_test.cc`.

A high-level project overview can be found [here](https://drake.mit.edu/doxygen_cxx/group__render__engine__gltf__client__server__api.html).

Close #16745

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17176)
<!-- Reviewable:end -->
