### PR TITLE
[tools/dev] Install alien and fakeroot for maintainers.

### DIFF
--- a/setup/ubuntu/source_distribution/packages-focal-maintainer-only.txt
+++ b/setup/ubuntu/source_distribution/packages-focal-maintainer-only.txt
@@ -1,3 +1,5 @@
+alien
 diffstat
+fakeroot
 patchutils
 python3-boto3


### PR DESCRIPTION
.tar.gz => .deb repackaging needs these tools.

Slack discussion [here](https://drakedevelopers.slack.com/archives/C01JSGRR1QS/p1652195119814329), relates to https://github.com/RobotLocomotion/drake-ci/pull/157 and https://github.com/RobotLocomotion/drake/issues/17177.

Builds testing that `--with-maintainer-only` correctly installs `alien` and `fakeroot` can be found in the description of https://github.com/RobotLocomotion/drake-ci/pull/157: successful `linux-focal-unprovisioned-gcc-bazel-experimental-snopt-mosek-packaging` builds there are built in jenkins with both PRs together, `repack_deb` would fail if `--with-maintainer-only` packages here were not working as expected).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17184)
<!-- Reviewable:end -->
