### PR TITLE
PolynomialEqualAfterExpansion calls Polynomial::Expand().

### DIFF
--- a/common/symbolic_polynomial.cc
+++ b/common/symbolic_polynomial.cc
@@ -740,7 +740,7 @@ bool Polynomial::EqualTo(const Polynomial& p) const {
 }
 
 bool Polynomial::EqualToAfterExpansion(const Polynomial& p) const {
-  return PolynomialEqual(*this, p, true);
+  return this->Expand().EqualTo(p.Expand());
 }
 
 bool Polynomial::CoefficientsAlmostEqual(const Polynomial& p,

--- a/common/symbolic_polynomial.h
+++ b/common/symbolic_polynomial.h
@@ -260,7 +260,8 @@ class Polynomial {
   bool EqualTo(const Polynomial& p) const;
 
   /// Returns true if this polynomial and @p p are equal, after expanding the
-  /// coefficients.
+  /// coefficients of both polynomials, namely
+  /// p.Expand().EqualTo(this->Expand())
   bool EqualToAfterExpansion(const Polynomial& p) const;
 
   /// Returns true if this polynomial and @p p are almost equal (the difference

--- a/common/test/symbolic_polynomial_test.cc
+++ b/common/test/symbolic_polynomial_test.cc
@@ -1063,6 +1063,13 @@ TEST_F(SymbolicPolynomialTest, EqualToAfterExpansion) {
 
   // p1 * p2 is not equal to p2 * p3 after expansion.
   EXPECT_PRED2(test::PolyNotEqualAfterExpansion, p1 * p2, p2 * p3);
+
+  // p4 has some coefficients equal to 0 after expansion, p5 doesn't.
+  const symbolic::Polynomial p4{
+      {{symbolic::Monomial(), pow(a_, 2) - 1 - (a_ + 1) * (a_ - 1)}}};
+  const symbolic::Polynomial p5{};
+  EXPECT_TRUE(p4.EqualToAfterExpansion(p5));
+  EXPECT_TRUE(p5.EqualToAfterExpansion(p4));
 }
 
 // Checks if internal::CompareMonomial implements the lexicographical order.


### PR DESCRIPTION
The previous implementation didn't handle when the coefficient is zero after expansion.

As discussed in https://github.com/RobotLocomotion/drake/issues/17130#issuecomment-1121192718

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17186)
<!-- Reviewable:end -->
