### PR TITLE
Expand the polynomial before computing the monomial basis for sos constraint

### DIFF
--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -1375,9 +1375,10 @@ pair<MatrixXDecisionVariable, VectorX<symbolic::Monomial>> DoAddSosConstraint(
     MathematicalProgram* const prog, const symbolic::Polynomial& p,
     MathematicalProgram::NonnegativePolynomial type,
     const std::string& gram_name) {
-  const VectorX<symbolic::Monomial> m = ConstructMonomialBasis(p);
+  const symbolic::Polynomial p_expanded = p.Expand();
+  const VectorX<symbolic::Monomial> m = ConstructMonomialBasis(p_expanded);
   const MatrixXDecisionVariable Q =
-      prog->AddSosConstraint(p, m, type, gram_name);
+      prog->AddSosConstraint(p_expanded, m, type, gram_name);
   return std::make_pair(Q, m);
 }
 

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -3661,6 +3661,16 @@ GTEST_TEST(TestMathematicalProgram, AddSosConstraint) {
                 prog.rotated_lorentz_cone_constraints().size(),
             0u);
   EXPECT_EQ(prog.positive_semidefinite_constraints().size(), 1u);
+
+  // p2 = (a+1)x² + 0 has some coefficient equal to 0. The constructed monomial
+  // should remove that 0-term. Hence the returned monomial basis should only
+  // contain [x].
+  const symbolic::Polynomial p2{
+      {{symbolic::Monomial(), 0}, {symbolic::Monomial(x, 2), a + 1}}};
+  const auto [gram2, monomial_basis2] = prog.AddSosConstraint(p2);
+  EXPECT_EQ(monomial_basis2.rows(), 1);
+  EXPECT_EQ(monomial_basis2(0), symbolic::Monomial(x));
+  EXPECT_EQ(gram2.rows(), 1);
 }
 
 template <typename C>


### PR DESCRIPTION
This removes 0-term in the polynomial, so potentially could reduce the size of the monomial basis and the resulting psd matrix if there were 0-term.

As discussed in https://github.com/RobotLocomotion/drake/pull/17123#pullrequestreview-965343278

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17187)
<!-- Reviewable:end -->
