### PR TITLE
[geometry/optimization] Minor cleanup of `GraphOfConvexSets::GetGraphvizString`

### DIFF
--- a/bindings/pydrake/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry_py_optimization.cc
@@ -369,7 +369,7 @@ void DefineGeometryOptimization(py::module m) {
                 },
                 cls_doc.Edges.doc)
             .def("GetGraphvizString", &GraphOfConvexSets::GetGraphvizString,
-                py::arg("result"), py::arg("show_slacks") = true,
+                py::arg("result") = std::nullopt, py::arg("show_slacks") = true,
                 py::arg("precision") = 3, py::arg("scientific") = false,
                 cls_doc.GetGraphvizString.doc)
             .def("SolveShortestPath",

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -232,9 +232,9 @@ std::string GraphOfConvexSets::GetGraphvizString(
   for (const auto& [v_id, v] : vertices_) {
     graphviz << "v" << v_id << " [label=\"" << v->name();
     if (result) {
-      graphviz << "\n x = [" << result->GetSolution(v->x()).transpose();
+      graphviz << "\n x = [" << result->GetSolution(v->x()).transpose() << "]";
     }
-    graphviz << "]\"]\n";
+    graphviz << "\"]\n";
   }
   for (const auto& [e_id, e] : edges_) {
     unused(e_id);


### PR DESCRIPTION
Previously, when one called `GraphOfConvexSets::GetGraphvizString`
with `result=None`, they would see a spurious `]` in the vertex
labels. The parenthesis is now placed properly inside the conditional.

Also adds a missing default for `result` in the python binding.

+@jwnimmer-tri for both reviews, please (for Monday, per rotation).
fyi @mpetersen94 , @TobiaMarcucci

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17190)
<!-- Reviewable:end -->
