### PR TITLE
[control] Improve error message for planning and control input port selections

### DIFF
--- a/systems/controllers/dynamic_programming.cc
+++ b/systems/controllers/dynamic_programming.cc
@@ -53,6 +53,13 @@ FittedValueIteration(
       system.get_input_port_selection(options.input_port_index);
   DRAKE_DEMAND(input_port != nullptr);
   DRAKE_DEMAND(input_port->size() == input_size);
+  // Verify that the input port is not abstract valued.
+  if (input_port->get_data_type() == PortDataType::kAbstractValued) {
+    throw std::logic_error(
+        "The specified input port is abstract-valued, but FittedValueIteration "
+        "only supports vector-valued input ports.  Did you perhaps forget to "
+        "pass a non-default `options.input_port_index`?");
+  }
 
   DRAKE_DEMAND(timestep > 0.);
 

--- a/systems/controllers/finite_horizon_linear_quadratic_regulator.cc
+++ b/systems/controllers/finite_horizon_linear_quadratic_regulator.cc
@@ -50,6 +50,13 @@ class RiccatiSystem : public LeafSystem<double> {
         x0_(x0),
         u0_(u0),
         options_(options) {
+    if (input_port_->get_data_type() == PortDataType::kAbstractValued) {
+      throw std::logic_error(
+          "The specified input port is abstract-valued, but "
+          "FiniteHorizonLinearQuadraticRegulator only supports vector-valued "
+          "input ports.  Did you perhaps forget to pass a non-default "
+          "`options.input_port_index`?");
+    }
     DRAKE_DEMAND(input_port_->get_data_type() == PortDataType::kVectorValued);
 
     DRAKE_DEMAND(context_->has_only_continuous_state());

--- a/systems/primitives/linear_system.cc
+++ b/systems/primitives/linear_system.cc
@@ -117,9 +117,11 @@ std::unique_ptr<AffineSystem<double>> DoFirstOrderTaylorApproximation(
   // Verify that the input port is not abstract valued.
   if (input_port &&
       input_port->get_data_type() == PortDataType::kAbstractValued) {
-    throw std::logic_error(
-        "Port requested for differentiation is abstract, and differentiation "
-        "of abstract ports is not supported.");
+      throw std::logic_error(
+          "The specified input port is abstract-valued, but "
+          "FirstOrderTaylorApproximation only supports vector-valued "
+          "input ports.  Did you perhaps forget to pass a non-default "
+          "`input_port_index` argument?");
   }
 
   const int num_inputs = input_port ? input_port->size() : 0;

--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -447,8 +447,7 @@ GTEST_TEST(TestLinearize, LinearizingOnAbstractPortThrows) {
   EmptyStateSystemWithAbstractInput<double> system;
   auto context = system.CreateDefaultContext();
   DRAKE_EXPECT_THROWS_MESSAGE(Linearize(system, *context),
-      "Port requested for differentiation is abstract, and differentiation of "
-      "abstract ports is not supported.");
+      ".*only supports vector-valued.*");
 }
 
 // Test linearizing a system with mixed (vector and abstract) inputs.

--- a/systems/trajectory_optimization/direct_collocation.cc
+++ b/systems/trajectory_optimization/direct_collocation.cc
@@ -71,8 +71,9 @@ DirectCollocationConstraint::DirectCollocationConstraint(
     // Verify that the input port is not abstract valued.
     if (input_port_->get_data_type() == PortDataType::kAbstractValued) {
       throw std::logic_error(
-          "Port requested for differentiation is abstract, and differentiation "
-          "of abstract ports is not supported.");
+          "The specified input port is abstract-valued, and this constraint "
+          "only supports vector-valued input ports.  Did you perhaps forget to "
+          "pass a non-default `input_port_index` argument?");
     }
 
     // Provide a fixed value for the input port and keep an alias around.
@@ -179,6 +180,14 @@ DirectCollocation::DirectCollocation(
   }
 
   if (input_port_) {
+    // Verify that the input port is not abstract valued.
+    if (input_port_->get_data_type() == PortDataType::kAbstractValued) {
+      throw std::logic_error(
+          "The specified input port is abstract-valued, but DirectCollocation "
+          "only supports vector-valued input ports.  Did you perhaps forget to "
+          "pass a non-default `input_port_index` argument?");
+    }
+
     // Allocate the input port and keep an alias around.
     input_port_value_ = &input_port_->FixValue(
         context_.get(),

--- a/systems/trajectory_optimization/direct_transcription.cc
+++ b/systems/trajectory_optimization/direct_transcription.cc
@@ -327,8 +327,10 @@ void DirectTranscription::AddAutodiffDynamicConstraints(
     // Verify that the input port is not abstract valued.
     if (input_port_->get_data_type() == PortDataType::kAbstractValued) {
       throw std::logic_error(
-          "Port requested for differentiation is abstract, and differentiation "
-          "of abstract ports is not supported.");
+          "The specified input port is abstract-valued, but "
+          "DirectTranscription only supports vector-valued input ports.  Did "
+          "you perhaps forget to pass a non-default `input_port_index` "
+          "argument?");
     }
 
     // Provide a fixed value for the input port and keep an alias around.

--- a/systems/trajectory_optimization/test/direct_collocation_test.cc
+++ b/systems/trajectory_optimization/test/direct_collocation_test.cc
@@ -355,6 +355,20 @@ GTEST_TEST(DirectCollocation, InputPortSelection) {
   EXPECT_TRUE(result.is_success());
 }
 
+// Provide a helpful error if the user does *not* provide the
+// InputPortSelection.
+GTEST_TEST(DirectCollocation, InputPortSelectionError) {
+  const auto plant = multibody::benchmarks::pendulum::MakePendulumPlant();
+  auto context = plant->CreateDefaultContext();
+
+  const int kNumSamples = 5;
+  const double kMinStep = 0.05;
+  const double kMaxStep = 0.5;
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      DirectCollocation(plant.get(), *context, kNumSamples, kMinStep, kMaxStep),
+      ".*non-default `input_port_index`.*");
+}
+
 // The Rimless Wheel example has discrete state for book-keeping only.  The
 // following is a simple example of effectively simulating one "step" of the
 // wheel using direct collocation; this system was a motivating example for


### PR DESCRIPTION
If I had a nickel for every time somebody called,
e.g. DirectCollocation with a MultibodyPlant and did not understand
the error message...

Previously
```
from pydrake.all import MultibodyPlant, DirectCollocation, Parser, FindResourceOrThrow

plant = MultibodyPlant(0.0)
Parser(plant).AddModelFromFile(
    FindResourceOrThrow('drake/examples/multibody/cart_pole/cart_pole.sdf'))
plant.Finalize()
context = plant.CreateDefaultContext()
DirectCollocation(plant, context, 10, 0.1, 1.0)
```
would result in
```
Failure at systems/framework/system.cc:40 in AllocateInputVector(): condition 'input_port.get_data_type() == kVectorValued' failed.
```

Now DirectCollocation and the related methods provide a more helpful error message string.

+@hongkai-dai for feature review, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17191)
<!-- Reviewable:end -->
