### PR TITLE
[pydrake] Deprecate old Python-based meshcat implementation

### DIFF
--- a/bindings/pydrake/_geometry_extra.py
+++ b/bindings/pydrake/_geometry_extra.py
@@ -71,3 +71,11 @@ def StartMeshcat():
     if "DEEPNOTE_PROJECT_ID" in os.environ:
         return _start_meshcat_deepnote()
     return Meshcat()
+
+
+# TODO(jwnimmer-tri) Deprecate these legacy compatibility aliases on or after
+# 2022-07-01.
+MeshcatVisualizerCpp = MeshcatVisualizer
+MeshcatVisualizerCpp_ = MeshcatVisualizer_
+MeshcatPointCloudVisualizerCpp = MeshcatPointCloudVisualizer
+MeshcatPointCloudVisualizerCpp_ = MeshcatPointCloudVisualizer_

--- a/bindings/pydrake/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry_py_visualizers.cc
@@ -78,13 +78,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
   {
     using Class = MeshcatPointCloudVisualizer<T>;
     constexpr auto& cls_doc = doc.MeshcatPointCloudVisualizer;
-    auto cls = DefineTemplateClassWithDefault<Class, LeafSystem<T>>(m,
-        "MeshcatPointCloudVisualizerCpp", param,
-        (std::string(cls_doc.doc) + R"""(
-Note that we are temporarily re-mapping MeshcatPointCloudVisualizer =>
-MeshcatPointCloudVisualizerCpp to avoid collisions with the python
-MeshcatPointCloudVisualizer.  See #13038.)""")
-            .c_str());
+    auto cls = DefineTemplateClassWithDefault<Class, LeafSystem<T>>(
+        m, "MeshcatPointCloudVisualizer", param, cls_doc.doc);
     cls  // BR
         .def(py::init<std::shared_ptr<Meshcat>, std::string, double>(),
             py::arg("meshcat"), py::arg("path"),
@@ -106,13 +101,8 @@ MeshcatPointCloudVisualizer.  See #13038.)""")
   {
     using Class = MeshcatVisualizer<T>;
     constexpr auto& cls_doc = doc.MeshcatVisualizer;
-    auto cls = DefineTemplateClassWithDefault<Class, LeafSystem<T>>(m,
-        "MeshcatVisualizerCpp", param,
-        (std::string(cls_doc.doc) + R"""(
-Note that we are temporarily re-mapping MeshcatVisualizer =>
-MeshcatVisualizerCpp to avoid collisions with the python
-MeshcatVisualizer.  See #13038.)""")
-            .c_str());
+    auto cls = DefineTemplateClassWithDefault<Class, LeafSystem<T>>(
+        m, "MeshcatVisualizer", param, cls_doc.doc);
     cls  // BR
         .def(py::init<std::shared_ptr<Meshcat>, MeshcatVisualizerParams>(),
             py::arg("meshcat"), py::arg("params") = MeshcatVisualizerParams{},

--- a/bindings/pydrake/systems/all.py
+++ b/bindings/pydrake/systems/all.py
@@ -2,7 +2,6 @@ from .analysis import *
 from .controllers import *
 from .framework import *
 from .lcm import *
-from .meshcat_visualizer import *
 from .perception import *
 from .planar_scenegraph_visualizer import *
 from .primitives import *

--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -1,7 +1,8 @@
 """
-Provides utilities for communicating with the browser-based visualization
-package, Meshcat:
-      https://github.com/rdeits/meshcat
+Warning:
+    This module (the pure-Python implementation of MeshCat) is deprecated.
+    Please use pydrake.geometry.MeshcatVisualizerCpp and related instead.
+    The deprecated code will be removed from Drake on or after 2022-09-01.
 """
 import argparse
 import os
@@ -11,7 +12,10 @@ import webbrowser
 
 import numpy as np
 
-from pydrake.common.deprecation import _warn_deprecated
+from pydrake.common.deprecation import (
+    _warn_deprecated,
+    deprecated_callable,
+)
 from pydrake.common.value import AbstractValue
 from pydrake.geometry import (
     Box, ConvertVolumeToSurfaceMesh, Convex, Cylinder, Mesh, Sphere,
@@ -47,7 +51,14 @@ from meshcat.animation import Animation
 # exact representation in binary floating point; see drake#15021 for details.
 _DEFAULT_PUBLISH_PERIOD = 1 / 32.
 
+_DEPRECATION = """
+The module pydrake.systems.meshcat_visualizer (the pure-Python implementation
+of MeshCat) is deprecated. Please use pydrake.geometry.MeshcatVisualizerCpp
+instead.
+""".replace("\n", " ").strip()
 
+
+@deprecated_callable(_DEPRECATION, date="2022-09-01")
 def AddTriad(vis, name, prefix, length=1., radius=0.04, opacity=1.):
     """
     Initializes coordinate axes of a frame T. The x-axis is drawn red,
@@ -92,6 +103,7 @@ class StringToRoleAction(argparse.Action):
         if nargs is not None:
             raise ValueError("nargs not allowed")
         super().__init__(option_strings, dest, **kwargs)
+        _warn_deprecated(_DEPRECATION, date="2022-09-01", stacklevel=5)
 
     def __call__(self, parser, namespace, values, option_string=None):
         assert isinstance(values, str)
@@ -144,6 +156,7 @@ class HydroTriSurface(g.Geometry):
 
     def __init__(self, vertices, normals):
         super(HydroTriSurface, self).__init__()
+        _warn_deprecated(_DEPRECATION, date="2022-09-01")
 
         vertices = np.asarray(vertices, dtype=np.float32)
         normals = np.asarray(normals, dtype=np.float32)
@@ -169,6 +182,11 @@ class HydroTriSurface(g.Geometry):
 
 class MeshcatVisualizer(LeafSystem):
     """
+    Warning:
+        This module (the pure-Python implementation of MeshCat) is deprecated.
+        Please use pydrake.geometry.MeshcatVisualizerCpp and related instead.
+        The deprecated code will be removed from Drake on or after 2022-09-01.
+
     MeshcatVisualizer is a System block that connects to the query output port
     of a SceneGraph and visualizes the scene in Meshcat.
 
@@ -292,6 +310,7 @@ class MeshcatVisualizer(LeafSystem):
             ``meshcat-server``.
         """
         LeafSystem.__init__(self)
+        _warn_deprecated(_DEPRECATION, date="2022-09-01", stacklevel=3)
 
         self.set_name('meshcat_visualizer')
         self.DeclarePeriodicPublish(draw_period, 0.0)
@@ -642,6 +661,11 @@ class MeshcatVisualizer(LeafSystem):
 
 class MeshcatContactVisualizer(LeafSystem):
     """
+    Warning:
+        This module (the pure-Python implementation of MeshCat) is deprecated.
+        Please use pydrake.geometry.MeshcatVisualizerCpp and related instead.
+        The deprecated code will be removed from Drake on or after 2022-09-01.
+
     MeshcatContactVisualizer is a System block that visualizes contact
     forces. It is connected to the contact results output port of
     SceneGraph's associated MultibodyPlant.
@@ -670,6 +694,7 @@ class MeshcatContactVisualizer(LeafSystem):
                 to visualize the forces.
         """
         LeafSystem.__init__(self)
+        _warn_deprecated(_DEPRECATION, date="2022-09-01")
         assert plant is not None
         self._meshcat_viz = meshcat_viz
         self._force_threshold = force_threshold
@@ -786,6 +811,11 @@ def _get_native_visualizer(viz):
 
 class MeshcatPointCloudVisualizer(LeafSystem):
     """
+    Warning:
+        This module (the pure-Python implementation of MeshCat) is deprecated.
+        Please use pydrake.geometry.MeshcatVisualizerCpp and related instead.
+        The deprecated code will be removed from Drake on or after 2022-09-01.
+
     MeshcatPointCloudVisualizer is a System block that visualizes a
     PointCloud in meshcat. The PointCloud:
 
@@ -826,6 +856,7 @@ class MeshcatPointCloudVisualizer(LeafSystem):
                 not provide RGB values.
         """
         LeafSystem.__init__(self)
+        _warn_deprecated(_DEPRECATION, date="2022-09-01")
 
         self._meshcat_viz = _get_native_visualizer(meshcat_viz)
         self._X_WP = RigidTransform(X_WP)
@@ -871,6 +902,7 @@ class MeshcatPointCloudVisualizer(LeafSystem):
         self._meshcat_viz[self._name].set_transform(self._X_WP.GetAsMatrix4())
 
 
+@deprecated_callable(_DEPRECATION, date="2022-09-01")
 def ConnectMeshcatVisualizer(builder, scene_graph=None, output_port=None,
                              **kwargs):
     """Creates an instance of MeshcatVisualizer, adds it to the diagram, and

--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -21,7 +21,7 @@ import meshcat
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow
-from pydrake.common.test_utilities.deprecation import catch_drake_warnings
+from pydrake.common.deprecation import DrakeDeprecationWarning
 from pydrake.common.value import AbstractValue
 from pydrake.geometry import (
     Box,
@@ -54,6 +54,9 @@ ZMQ_URL = os.environ.get("TEST_ZMQ_URL")
 class TestMeshcat(unittest.TestCase):
     def setUp(self):
         np.random.seed(42)
+
+        # Our entire module is deprecated.
+        warnings.simplefilter("ignore", DrakeDeprecationWarning)
 
     def test_cart_pole(self):
         """Cart-Pole with simple geometry."""

--- a/bindings/pydrake/test/geometry_visualizers_test.py
+++ b/bindings/pydrake/test/geometry_visualizers_test.py
@@ -234,7 +234,7 @@ class TestGeometryVisualizers(unittest.TestCase):
         params.prefix = "py_visualizer"
         params.delete_on_initialization_event = False
         self.assertNotIn("object at 0x", repr(params))
-        vis = mut.MeshcatVisualizerCpp_[T](meshcat=meshcat, params=params)
+        vis = mut.MeshcatVisualizer_[T](meshcat=meshcat, params=params)
         vis.Delete()
         self.assertIsInstance(vis.query_object_input_port(), InputPort_[T])
         animation = vis.StartRecording(set_transforms_while_recording=True)
@@ -246,17 +246,25 @@ class TestGeometryVisualizers(unittest.TestCase):
 
         builder = DiagramBuilder_[T]()
         scene_graph = builder.AddSystem(mut.SceneGraph_[T]())
-        mut.MeshcatVisualizerCpp_[T].AddToBuilder(builder=builder,
-                                                  scene_graph=scene_graph,
-                                                  meshcat=meshcat,
-                                                  params=params)
-        mut.MeshcatVisualizerCpp_[T].AddToBuilder(
+        mut.MeshcatVisualizer_[T].AddToBuilder(builder=builder,
+                                               scene_graph=scene_graph,
+                                               meshcat=meshcat,
+                                               params=params)
+        mut.MeshcatVisualizer_[T].AddToBuilder(
             builder=builder,
             query_object_port=scene_graph.get_query_output_port(),
             meshcat=meshcat,
             params=params)
 
     def test_meshcat_visualizer_scalar_conversion(self):
+        meshcat = mut.Meshcat()
+        vis = mut.MeshcatVisualizer(meshcat)
+        vis_autodiff = vis.ToAutoDiffXd()
+        self.assertIsInstance(vis_autodiff,
+                              mut.MeshcatVisualizer_[AutoDiffXd])
+
+    def test_meshcat_visualizer_scalar_conversion_to_be_deprecated(self):
+        # This checks a legacy API spelling that will be deprecated eventually.
         meshcat = mut.Meshcat()
         vis = mut.MeshcatVisualizerCpp(meshcat)
         vis_autodiff = vis.ToAutoDiffXd()
@@ -266,7 +274,7 @@ class TestGeometryVisualizers(unittest.TestCase):
     @numpy_compare.check_nonsymbolic_types
     def test_meshcat_point_cloud_visualizer(self, T):
         meshcat = mut.Meshcat()
-        visualizer = mut.MeshcatPointCloudVisualizerCpp_[T](
+        visualizer = mut.MeshcatPointCloudVisualizer_[T](
             meshcat=meshcat, path="cloud", publish_period=1/12.0)
         visualizer.set_point_size(0.1)
         visualizer.set_default_rgba(mut.Rgba(0, 0, 1, 1))
@@ -281,7 +289,17 @@ class TestGeometryVisualizers(unittest.TestCase):
         if T == float:
             ad_visualizer = visualizer.ToAutoDiffXd()
             self.assertIsInstance(
-                ad_visualizer, mut.MeshcatPointCloudVisualizerCpp_[AutoDiffXd])
+                ad_visualizer, mut.MeshcatPointCloudVisualizer_[AutoDiffXd])
+
+    def test_meshcat_point_cloud_visualizer_to_be_deprecated(self):
+        # This checks a legacy API spelling that will be deprecated eventually.
+        meshcat = mut.Meshcat()
+        visualizer = mut.MeshcatPointCloudVisualizerCpp(
+            meshcat=meshcat, path="cloud", publish_period=1/12.0)
+        visualizer.set_point_size(0.1)
+        ad_visualizer = visualizer.ToAutoDiffXd()
+        self.assertIsInstance(
+            ad_visualizer, mut.MeshcatPointCloudVisualizerCpp_[AutoDiffXd])
 
     def test_start_meshcat(self):
         # StartMeshcat only performs interesting work on cloud notebook hosts.

--- a/manipulation/util/show_model.py
+++ b/manipulation/util/show_model.py
@@ -51,6 +51,8 @@ binary.
 
 import argparse
 import os
+import warnings
+
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow
@@ -129,7 +131,8 @@ def add_visualizers_argparse_arguments(args_parser):
     """
     Adds argparse arguments for visualizers.
     """
-    MeshcatVisualizer.add_argparse_argument(args_parser)
+    with warnings.catch_warnings(record=True) as w:
+        MeshcatVisualizer.add_argparse_argument(args_parser)
     args_parser.add_argument(
         "--pyplot", action="store_true",
         help="Opens a pyplot figure for rendering using "


### PR DESCRIPTION
Closes #16978.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17194)
<!-- Reviewable:end -->
