### PR TITLE
Add a BenchmarkSosProgram3

### DIFF
--- a/solvers/benchmarking/benchmark_mathematical_program.cc
+++ b/solvers/benchmarking/benchmark_mathematical_program.cc
@@ -78,8 +78,44 @@ static void BenchmarkSosProgram2(benchmark::State& state) {  // NOLINT
   }
 }
 
+/**
+ * This program is reported in github issue
+ * https://github.com/RobotLocomotion/drake/issues/17160
+ * This program tries to find a lower bound for the cost-to-go that satisfies
+ * HJB inequality. Note that we create the right-hand side polynomial of the HJB
+ * inequality but don't impose any non-negative constraint on this polynomial.
+ * The reason is that this polynomial's coefficient isn't a linear expression of
+ * our decision variables. This benchmark program tests parsing a symbolic
+ * expression to a polynomial, but not imposing constraint on the polynomial.
+ */
+static void BenchmarkSosProgram3(benchmark::State& state) {  // NOLINT
+  for (auto _ : state) {
+    MathematicalProgram prog;
+    const int nz = 3;
+    const int degree = 8;
+
+    const auto z = prog.NewIndeterminates(nz, "z");
+    const symbolic::Polynomial J =
+        prog.NewFreePolynomial(symbolic::Variables(z), degree);
+    const symbolic::Expression J_expr = J.ToExpression();
+    const RowVectorX<symbolic::Expression> dJdz = J_expr.Jacobian(z);
+    const Eigen::Vector3d f2(0, 0, 1);
+    const symbolic::Expression u_opt = -0.5 * dJdz.dot(f2);
+
+    const Eigen::Vector3d z0(0, 1, 0);
+    using std::pow;
+    const symbolic::Expression one_step_cost =
+        (z - z0).dot(z - z0) + pow(u_opt, 2);
+    const Vector3<symbolic::Expression> f(z(1) + z(2), -z(0) + z(2),
+                                          (z(0) + u_opt - z(2)));
+    const symbolic::Expression rhs = one_step_cost + dJdz.dot(f);
+    const symbolic::Polynomial rhs_poly(rhs, symbolic::Variables(z));
+  }
+}
+
 BENCHMARK(BenchmarkSosProgram1);
 BENCHMARK(BenchmarkSosProgram2);
+BENCHMARK(BenchmarkSosProgram3);
 }  // namespace
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
As mentioned in #17160 

On my P15, here is the runtime
```
Run on (12 X 5100 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 256 KiB (x6)
  L3 Unified 12288 KiB (x1)
Load Average: 1.27, 0.77, 1.02
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
---------------------------------------------------------------
Benchmark                     Time             CPU   Iterations
---------------------------------------------------------------
BenchmarkSosProgram1 2562965393 ns   2562783619 ns            1
BenchmarkSosProgram2 6263067961 ns   6262941729 ns            1
BenchmarkSosProgram3 6136089087 ns   6135849605 ns            1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17195)
<!-- Reviewable:end -->
