### PR TITLE
Remove -lquadmath when building on mac arm64

### DIFF
--- a/tools/workspace/gfortran/repository.bzl
+++ b/tools/workspace/gfortran/repository.bzl
@@ -35,21 +35,22 @@ def _gfortran_impl(repo_ctx):
     else:
         suffix = ".so"
     libgfortran = "libgfortran{}".format(suffix)
-    libquadmath = "libquadmath{}".format(suffix)
     libgfortran_path = _find_library(repo_ctx, compiler, libgfortran)
-    libquadmath_path = _find_library(repo_ctx, compiler, libquadmath)
 
     # The cc_library linking is different on Ubuntu vs macOS.
     if os_result.is_macos:
         srcs = []
         linkopts = [
             "-L{}".format(repo_ctx.path(libgfortran_path).dirname),
-            "-L{}".format(repo_ctx.path(libquadmath_path).dirname),
             "-ldl",
             "-lgfortran",
-            "-lquadmath",
         ]
+        arch_result = execute_or_fail(repo_ctx, ["/usr/bin/arch"])
+        if arch_result.stdout.strip() != "arm64":
+            linkopts.append("-lquadmath")
     else:
+        libquadmath = "libquadmath{}".format(suffix)
+        libquadmath_path = _find_library(repo_ctx, compiler, libquadmath)
         repo_ctx.symlink(libgfortran_path, libgfortran)
         repo_ctx.symlink(libquadmath_path, libquadmath)
         srcs = [libgfortran, libquadmath]


### PR DESCRIPTION
Towards #17009, where @jwnimmer-tri commented "I just peeked at
https://packages.ubuntu.com/focal/libgfortran5 and can confirm that
quadmath is [amd64, i386] only. When we're building on ARM64, we
should neither try to find -lquadmath, nor link to it."

+@jwnimmer-tri for platform review please (both if you're ok with it).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17196)
<!-- Reviewable:end -->
