### PR TITLE
[geometry/optimization] Make `IrisOptions.enable_ibex = false` by default

### DIFF
--- a/geometry/optimization/iris.h
+++ b/geometry/optimization/iris.h
@@ -49,11 +49,11 @@ struct IrisOptions {
   */
   double configuration_space_margin{1e-2};
 
-  /** For IRIS in configuration space, we use IbexSolver to rigorously confirm
-  that regions are collision-free. This step may be computationally
-  demanding, so we allow it to be disabled for a faster algorithm for obtaining
-  regions without the rigorous guarantee. */
-  bool enable_ibex = true;
+  /** For IRIS in configuration space, we can optionally use IbexSolver to
+  rigorously confirm that regions are collision-free. This step may be
+  computationally demanding, so we disable it by default for a faster
+  algorithm for obtaining regions without the rigorous guarantee. */
+  bool enable_ibex = false;
 };
 
 /** The IRIS (Iterative Region Inflation by Semidefinite programming) algorithm,

--- a/geometry/optimization/test/iris_in_configuration_space_test.cc
+++ b/geometry/optimization/test/iris_in_configuration_space_test.cc
@@ -3,6 +3,7 @@
 #include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/geometry/optimization/iris.h"
 #include "drake/multibody/parsing/parser.h"
+#include "drake/solvers/ibex_solver.h"
 #include "drake/systems/framework/diagram_builder.h"
 
 namespace drake {
@@ -358,6 +359,12 @@ GTEST_TEST(IrisInConfigurationSpaceTest, BlockOnGround) {
 // In addition to testing the convex space, this is a test for which Ibex finds
 // counter-examples that Snopt misses.
 GTEST_TEST(IrisInConfigurationSpaceTest, ConvexConfigurationSpace) {
+  if (!solvers::IbexSolver::is_available() ||
+      !solvers::IbexSolver::is_enabled()) {
+    // This test requires Ibex.
+    return;
+  }
+
   const double l = 1.5;
   const double r = 0.1;
   const std::string convex_urdf = fmt::format(


### PR DESCRIPTION
Previously the default was to have Ibex enabled, but this has fallen
out of favor -- we find that Ibex cannot solve many problems of
interest.

In addition, we allow the test that requires Ibex to pass quietly if
IbexSolver is not available + enabled.  This is required for tests to
pass on mac arm64.

+@hongkai-dai for feature review, please.
fyi @mpetersen94, @AlexandreAmice

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17198)
<!-- Reviewable:end -->
