### PR TITLE
[common] Monomial.ToExpression.is_expanded is true

### DIFF
--- a/common/symbolic_expression_cell.h
+++ b/common/symbolic_expression_cell.h
@@ -374,10 +374,16 @@ class ExpressionMulFactory {
   /** Default constructor. */
   ExpressionMulFactory() = default;
 
-  /** Constructs ExpressionMulFactory with @p constant and @p
-   * base_to_exponent_map. */
+  /** Constructs ExpressionMulFactory with @p constant and Expression-valued
+   * @p base_to_exponent_map. Note that this constructor runs in constant-time
+   * because it moves the map into storage; it does not loop over the map. */
   ExpressionMulFactory(double constant,
                        std::map<Expression, Expression> base_to_exponent_map);
+
+  /** Constructs ExpressionMulFactory with a Monomial-like (Variable to integer
+   * power) @p base_to_exponent_map. */
+  explicit ExpressionMulFactory(
+      const std::map<Variable, int>& base_to_exponent_map);
 
   /** Constructs ExpressionMulFactory from @p mul. */
   explicit ExpressionMulFactory(const ExpressionMul& mul);

--- a/common/symbolic_monomial.cc
+++ b/common/symbolic_monomial.cc
@@ -238,15 +238,7 @@ pair<double, Monomial> Monomial::EvaluatePartial(const Environment& env) const {
 }
 
 Expression Monomial::ToExpression() const {
-  // It builds this base_to_exponent_map and uses ExpressionMulFactory to build
-  // a multiplication expression.
-  map<Expression, Expression> base_to_exponent_map;
-  for (const auto& p : powers_) {
-    const Variable& var{p.first};
-    const int exponent{p.second};
-    base_to_exponent_map.emplace(Expression{var}, exponent);
-  }
-  return ExpressionMulFactory{1.0, base_to_exponent_map}.GetExpression();
+  return ExpressionMulFactory(powers_).GetExpression();
 }
 
 Monomial& Monomial::operator*=(const Monomial& m) {

--- a/common/test/symbolic_expansion_test.cc
+++ b/common/test/symbolic_expansion_test.cc
@@ -101,13 +101,13 @@ TEST_F(SymbolicExpansionTest, ExpressionAlreadyExpandedPolynomial) {
 
 TEST_F(SymbolicExpansionTest, ExpressionAlreadyExpandedPow) {
   EXPECT_TRUE(CheckAlreadyExpanded(3 * pow(2, y_)));         // 3*2^y
+  EXPECT_TRUE(CheckAlreadyExpanded(pow(x_, y_)));            // x^y
+  EXPECT_TRUE(CheckAlreadyExpanded(pow(x_, -1)));            // x^(-1)
+  EXPECT_TRUE(CheckAlreadyExpanded(pow(x_, -1)));            // x^(-1)
 
   // The following are all already expanded. They do not yet detect and report
   // `is_expanded() == true` upon construction, but in any case they must not
   // change form when `Expand()` is called.
-  EXPECT_TRUE(CheckUnchangedExpand(pow(x_, y_)));            // x^y
-  EXPECT_TRUE(CheckUnchangedExpand(pow(x_, -1)));            // x^(-1)
-  EXPECT_TRUE(CheckUnchangedExpand(pow(x_, -1)));            // x^(-1)
   EXPECT_TRUE(CheckUnchangedExpand(pow(x_ + y_, -1)));       // (x + y)^(-1)
   EXPECT_TRUE(CheckUnchangedExpand(pow(x_ + y_, 0.5)));      // (x + y)^(0.5)
   EXPECT_TRUE(CheckUnchangedExpand(pow(x_ + y_, 2.5)));      // (x + y)^(2.5)


### PR DESCRIPTION
This makes almost no difference in the benchmarks for now, but could turn out to be important later (for #17160). In any case, it bothers my sense of aesthetics for a Monomial to claim to be un-expanded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17201)
<!-- Reviewable:end -->
