### PR TITLE
[examples] Only declare iiwa_velocities_log when args.test.

### DIFF
--- a/examples/manipulation_station/joint_teleop.py
+++ b/examples/manipulation_station/joint_teleop.py
@@ -120,7 +120,6 @@ def main():
 
     diagram = builder.Build()
     simulator = Simulator(diagram)
-    iiwa_velocities_log = iiwa_velocities.FindLog(simulator.get_context())
 
     # This is important to avoid duplicate publishes to the hardware interface:
     simulator.set_publish_every_time_step(False)
@@ -152,6 +151,7 @@ def main():
     # Ensure that our initialization logic was correct, by inspecting our
     # logged joint velocities.
     if args.test:
+        iiwa_velocities_log = iiwa_velocities.FindLog(simulator.get_context())
         for time, qdot in zip(iiwa_velocities_log.sample_times(),
                               iiwa_velocities_log.data().transpose()):
             # TODO(jwnimmer-tri) We should be able to do better than a 40


### PR DESCRIPTION
Running joint_teleop without `--test` will crash otherwise.

In one terminal, you can `bazel run //examples/manipulation_station:mock_station_simulation` to get the simulation running.

Prior to this change, the following will crash `bazel run //examples/manipulation_station:joint_teleop` since `iiwa_velocities` is only declared when `args.test` is `True`, otherwise it is `None`.  After this change the example will produce the desired sliders, and `--test` appears to work the same as it did before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17216)
<!-- Reviewable:end -->
