### PR TITLE
[workspace] Remove globbing from qhull build

### DIFF
--- a/tools/workspace/qhull/package.BUILD.bazel
+++ b/tools/workspace/qhull/package.BUILD.bazel
@@ -7,35 +7,66 @@ load(
 
 licenses(["notice"])  # Qhull
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//visibility:private"])
+
+_HDRS_C = glob([
+    "src/libqhull_r/*.h",
+])
+
+_HDRS_CPP = glob([
+    "src/libqhullcpp/*.h",
+])
+
+_SRCS_C = [
+    "src/libqhull_r/geom2_r.c",
+    "src/libqhull_r/geom_r.c",
+    "src/libqhull_r/global_r.c",
+    "src/libqhull_r/io_r.c",
+    "src/libqhull_r/libqhull_r.c",
+    "src/libqhull_r/mem_r.c",
+    "src/libqhull_r/merge_r.c",
+    "src/libqhull_r/poly2_r.c",
+    "src/libqhull_r/poly_r.c",
+    "src/libqhull_r/qset_r.c",
+    "src/libqhull_r/random_r.c",
+    "src/libqhull_r/stat_r.c",
+    "src/libqhull_r/user_r.c",
+    "src/libqhull_r/usermem_r.c",
+]
+
+_SRCS_CPP = [
+    "src/libqhullcpp/Qhull.cpp",
+    "src/libqhullcpp/QhullFacet.cpp",
+    "src/libqhullcpp/QhullFacetList.cpp",
+    "src/libqhullcpp/QhullFacetSet.cpp",
+    "src/libqhullcpp/QhullHyperplane.cpp",
+    "src/libqhullcpp/QhullPoint.cpp",
+    "src/libqhullcpp/QhullPointSet.cpp",
+    "src/libqhullcpp/QhullQh.cpp",
+    "src/libqhullcpp/QhullRidge.cpp",
+    "src/libqhullcpp/QhullSet.cpp",
+    "src/libqhullcpp/QhullUser.cpp",
+    "src/libqhullcpp/QhullVertex.cpp",
+    "src/libqhullcpp/QhullVertexSet.cpp",
+    "src/libqhullcpp/RoadError.cpp",
+    "src/libqhullcpp/RoadLogEvent.cpp",
+]
 
 cc_library(
     name = "qhull",
-    hdrs = glob([
-        "src/libqhullcpp/*.h",
-        "src/libqhull_r/*.h",
-    ]),
+    hdrs = _HDRS_C + _HDRS_CPP,
     copts = [
         "-fvisibility=hidden",
     ],
     includes = ["src"],
-    srcs = glob(
-        [
-            "src/libqhullcpp/*.cpp",
-            "src/libqhull_r/*.c",
-        ],
-        exclude = [
-            "src/libqhullcpp/qt-qhull.cpp",
-            "src/libqhullcpp/usermem_r-cpp.cpp",
-            "src/libqhull_r/userprintf_r.c",
-            "src/libqhull_r/userprintf_rbox_r.c",
-        ],
-    ),
+    srcs = _SRCS_C + _SRCS_CPP,
     linkstatic = 1,
+    visibility = ["//visibility:public"],
 )
 
 # Install the license file.
 install(
     name = "install",
     docs = ["COPYING.txt"],
+    visibility = ["//visibility:public"],
 )

--- a/tools/workspace/qhull/patches/disable_dead_code.patch
+++ b/tools/workspace/qhull/patches/disable_dead_code.patch
@@ -1,0 +1,35 @@
+Don't try to compile functions that require sources files
+that we've omitted from the build.
+
+--- src/libqhullcpp/Qhull.cpp.orig	2020-09-03 19:33:16.000000000 -0700
++++ src/libqhullcpp/Qhull.cpp	2022-05-18 20:26:48.858174235 -0700
+@@ -114,6 +114,7 @@
+     }
+ }//checkIfQhullInitialized
+ 
++#if 0
+ //! Return feasiblePoint for halfspace intersection
+ //! If called before runQhull(), then it returns the value from setFeasiblePoint.  qh.feasible_string overrides this value if it is defined.
+ Coordinates Qhull::
+@@ -127,6 +128,7 @@
+     }
+     return result;
+ }//feasiblePoint
++#endif
+ 
+ //! Return origin point for qh.input_dim
+ QhullPoint Qhull::
+@@ -188,11 +190,13 @@
+     return QhullFacetList(beginFacet(), endFacet());
+ }//facetList
+ 
++#if 0
+ QhullPoints Qhull::
+ points() const
+ {
+     return QhullPoints(qh_qh, qh_qh->hull_dim, qh_qh->num_points*qh_qh->hull_dim, qh_qh->first_point);
+ }//points
++#endif
+ 
+ QhullPointSet Qhull::
+ otherPoints() const

--- a/tools/workspace/qhull/repository.bzl
+++ b/tools/workspace/qhull/repository.bzl
@@ -11,5 +11,8 @@ def qhull_repository(
         commit = "2020.2",
         sha256 = "59356b229b768e6e2b09a701448bfa222c37b797a84f87f864f97462d8dbc7c5",  # noqa
         build_file = "@drake//tools/workspace/qhull:package.BUILD.bazel",
+        patches = [
+            "@drake//tools/workspace/qhull:patches/disable_dead_code.patch",
+        ],
         mirrors = mirrors,
     )


### PR DESCRIPTION
Don't build unnecessary files: Coordinates.cpp, PointCoordinates.cpp, QhullPoints.cpp, QhullStat.cpp, RboxPoints.cpp, rboxlib_r.c.

This makes our build and object code footprint smaller, and enables a [future commit](https://github.com/jwnimmer-tri/drake/commits/vendoring) to use a better technique for C++ symbol visibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17227)
<!-- Reviewable:end -->
