### PR TITLE
[workspace] Use sdformat hidden visibility

### DIFF
--- a/multibody/parsing/detail_common.h
+++ b/multibody/parsing/detail_common.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <variant>
 
-#include <sdf/Element.hh>
+#include <drake_vendor/sdf/Element.hh>
 #include <tinyxml2.h>
 
 #include "drake/common/diagnostic_policy.h"

--- a/multibody/parsing/detail_ignition.h
+++ b/multibody/parsing/detail_ignition.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ignition/math/Pose3.hh>
+#include <drake_vendor/ignition/math/Pose3.hh>
 
 #include "drake/common/eigen_types.h"
 #include "drake/math/rigid_transform.h"

--- a/multibody/parsing/detail_sdf_diagnostic.h
+++ b/multibody/parsing/detail_sdf_diagnostic.h
@@ -3,7 +3,7 @@
 #include <set>
 #include <string>
 
-#include <sdf/Element.hh>
+#include <drake_vendor/sdf/Element.hh>
 
 #include "drake/common/diagnostic_policy.h"
 

--- a/multibody/parsing/detail_sdf_geometry.cc
+++ b/multibody/parsing/detail_sdf_geometry.cc
@@ -7,13 +7,13 @@
 #include <string>
 #include <utility>
 
-#include <sdf/Box.hh>
-#include <sdf/Capsule.hh>
-#include <sdf/Cylinder.hh>
-#include <sdf/Element.hh>
-#include <sdf/Ellipsoid.hh>
-#include <sdf/Plane.hh>
-#include <sdf/Sphere.hh>
+#include <drake_vendor/sdf/Box.hh>
+#include <drake_vendor/sdf/Capsule.hh>
+#include <drake_vendor/sdf/Cylinder.hh>
+#include <drake_vendor/sdf/Element.hh>
+#include <drake_vendor/sdf/Ellipsoid.hh>
+#include <drake_vendor/sdf/Plane.hh>
+#include <drake_vendor/sdf/Sphere.hh>
 
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/proximity_properties.h"

--- a/multibody/parsing/detail_sdf_geometry.h
+++ b/multibody/parsing/detail_sdf_geometry.h
@@ -3,9 +3,9 @@
 #include <memory>
 #include <string>
 
-#include <sdf/Collision.hh>
-#include <sdf/Geometry.hh>
-#include <sdf/Visual.hh>
+#include <drake_vendor/sdf/Collision.hh>
+#include <drake_vendor/sdf/Geometry.hh>
+#include <drake_vendor/sdf/Visual.hh>
 
 #include "drake/common/diagnostic_policy.h"
 #include "drake/geometry/geometry_instance.h"

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -10,15 +10,15 @@
 #include <variant>
 #include <vector>
 
-#include <sdf/Error.hh>
-#include <sdf/Frame.hh>
-#include <sdf/Joint.hh>
-#include <sdf/JointAxis.hh>
-#include <sdf/Link.hh>
-#include <sdf/Model.hh>
-#include <sdf/ParserConfig.hh>
-#include <sdf/Root.hh>
-#include <sdf/World.hh>
+#include <drake_vendor/sdf/Error.hh>
+#include <drake_vendor/sdf/Frame.hh>
+#include <drake_vendor/sdf/Joint.hh>
+#include <drake_vendor/sdf/JointAxis.hh>
+#include <drake_vendor/sdf/Link.hh>
+#include <drake_vendor/sdf/Model.hh>
+#include <drake_vendor/sdf/ParserConfig.hh>
+#include <drake_vendor/sdf/Root.hh>
+#include <drake_vendor/sdf/World.hh>
 
 #include "drake/geometry/geometry_instance.h"
 #include "drake/math/rigid_transform.h"

--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -7,10 +7,10 @@
 #include <vector>
 
 #include "fmt/ostream.h"
+#include <drake_vendor/sdf/Root.hh>
+#include <drake_vendor/sdf/parser.hh>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <sdf/Root.hh>
-#include <sdf/parser.hh>
 
 #include "drake/common/filesystem.h"
 #include "drake/common/find_resource.h"

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -5,9 +5,9 @@
 #include <sstream>
 #include <stdexcept>
 
+#include <drake_vendor/sdf/parser.hh>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <sdf/parser.hh>
 
 #include "drake/common/filesystem.h"
 #include "drake/common/find_resource.h"

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -49,8 +49,11 @@ drake_py_binary(
     srcs = ["vendor_cxx.py"],
     visibility = [
         # These should all be of the form "@foo_internal//:__pkg__".
+        "@gz_math_internal//:__pkg__",
+        "@gz_utils_internal//:__pkg__",
         "@nlopt_internal//:__pkg__",
         "@qhull_internal//:__pkg__",
+        "@sdformat_internal//:__pkg__",
         "@yaml_cpp_internal//:__pkg__",
     ],
     deps = [":module_py"],

--- a/tools/workspace/gz_math_internal/package.BUILD.bazel
+++ b/tools/workspace/gz_math_internal/package.BUILD.bazel
@@ -13,12 +13,12 @@ load(
     "check_lists_consistency",
 )
 load(
-    "@drake//third_party:com_github_bazelbuild_rules_cc/whole_archive.bzl",
-    "cc_whole_archive_library",
-)
-load(
     "@drake//tools/install:install.bzl",
     "install",
+)
+load(
+    "@drake//tools/workspace:vendor_cxx.bzl",
+    "cc_library_vendored",
 )
 load("@drake//tools/workspace:generate_file.bzl", "generate_file")
 
@@ -31,12 +31,6 @@ config_setting(
     values = {"cpu": "k8"},
 )
 
-PROJECT_MAJOR = 6
-
-PROJECT_MINOR = 10
-
-PROJECT_PATCH = 0
-
 # Generates config.hh based on the version numbers in CMake code.
 cmake_configure_file(
     name = "config",
@@ -45,11 +39,11 @@ cmake_configure_file(
     cmakelists = ["CMakeLists.txt"],
     defines = [
         "IGN_DESIGNATION=math",
-        "PROJECT_VERSION_MAJOR=%d" % (PROJECT_MAJOR),
-        "PROJECT_VERSION_MINOR=%d" % (PROJECT_MINOR),
-        "PROJECT_VERSION_PATCH=%d" % (PROJECT_PATCH),
-        "PROJECT_VERSION=%d.%d" % (PROJECT_MAJOR, PROJECT_MINOR),
-        "PROJECT_VERSION_FULL=%d.%d.%d" % (PROJECT_MAJOR, PROJECT_MINOR, PROJECT_PATCH),  # noqa
+        "PROJECT_VERSION_MAJOR=0",
+        "PROJECT_VERSION_MINOR=0",
+        "PROJECT_VERSION_PATCH=0",
+        "PROJECT_VERSION=0.0",
+        "PROJECT_VERSION_FULL=0.0.0",
         "PROJECT_NAME_NO_VERSION=ignition-math",
     ],
 )
@@ -59,12 +53,12 @@ generate_file(
     content = """
 #pragma once
 // Simplified version of visibility and deprecation macros.
-#define IGNITION_MATH_VISIBLE __attribute__ ((visibility("default")))
+#define IGNITION_MATH_VISIBLE
 #define IGN_DEPRECATED(version) __attribute__ ((__deprecated__))
     """,
 )
 
-public_headers_no_gen = [
+_MOST_HDRS = [
     "include/ignition/math/Angle.hh",
     "include/ignition/math/AxisAlignedBox.hh",
     "include/ignition/math/Box.hh",
@@ -121,7 +115,7 @@ public_headers_no_gen = [
     "include/ignition/math/graph/Vertex.hh",
 ]
 
-private_headers = [
+_HDRS_PRIVATE = [
     "src/FrustumPrivate.hh",
     "src/KmeansPrivate.hh",
     "src/MaterialType.hh",
@@ -131,67 +125,62 @@ private_headers = [
     "src/Vector3StatsPrivate.hh",
 ]
 
-# Generates math.hh, which consists of #include statements for all of the
-# public headers in the library.  The first line is
-# '#include <ignition/math/config.hh>' followed by one line like
-# '#include <ignition/math/Angle.hh>' for each non-generated header.
-drake_generate_include_header(
-    name = "mathhh_genrule",
-    out = "include/ignition/math.hh",
-    hdrs = public_headers_no_gen + [
-        "include/ignition/math/config.hh",
-        "include/ignition/math/Export.hh",
-    ],
-)
-
 check_lists_consistency(
-    files = private_headers + public_headers_no_gen,
+    files = _MOST_HDRS + _HDRS_PRIVATE,
     glob_include = ["include/**/*.hh"],
 )
 
-public_headers = public_headers_no_gen + [
+_HDRS = _MOST_HDRS + [
     "include/ignition/math/config.hh",
     "include/ignition/math/Export.hh",
-    "include/ignition/math.hh",
 ]
 
-# Generates the library.  The explicitly listed srcs= matches upstream's
-# explicitly listed sources plus private headers.  The explicitly listed
-# hdrs= matches upstream's public headers.
-cc_library(
+# The explicitly listed srcs= matches upstream's explicitly listed sources plus
+# private headers.
+_SRCS = [
+    "src/Angle.cc",
+    "src/AxisAlignedBox.cc",
+    "src/Color.cc",
+    "src/DiffDriveOdometry.cc",
+    "src/Frustum.cc",
+    "src/GaussMarkovProcess.cc",
+    "src/Helpers.cc",
+    "src/Kmeans.cc",
+    "src/Material.cc",
+    "src/PID.cc",
+    "src/Rand.cc",
+    "src/RollingMean.cc",
+    "src/RotationSpline.cc",
+    "src/RotationSplinePrivate.cc",
+    "src/SemanticVersion.cc",
+    "src/SignalStats.cc",
+    "src/SpeedLimiter.cc",
+    "src/SphericalCoordinates.cc",
+    "src/Spline.cc",
+    "src/SplinePrivate.cc",
+    "src/Stopwatch.cc",
+    "src/Temperature.cc",
+    "src/Vector3Stats.cc",
+] + _HDRS_PRIVATE
+
+cc_library_vendored(
     name = "gz_math",
-    srcs = [
-        "src/Angle.cc",
-        "src/AxisAlignedBox.cc",
-        "src/Color.cc",
-        "src/DiffDriveOdometry.cc",
-        "src/Frustum.cc",
-        "src/GaussMarkovProcess.cc",
-        "src/Helpers.cc",
-        "src/Kmeans.cc",
-        "src/Material.cc",
-        "src/PID.cc",
-        "src/Rand.cc",
-        "src/RollingMean.cc",
-        "src/RotationSpline.cc",
-        "src/RotationSplinePrivate.cc",
-        "src/SemanticVersion.cc",
-        "src/SignalStats.cc",
-        "src/SpeedLimiter.cc",
-        "src/SphericalCoordinates.cc",
-        "src/Spline.cc",
-        "src/SplinePrivate.cc",
-        "src/Stopwatch.cc",
-        "src/Temperature.cc",
-        "src/Vector3Stats.cc",
-    ] + private_headers + public_headers,
-    copts = [
-        # TODO(jwnimmer-tri) Ideally, we should use hidden visibility for the
-        # private builds of our dependencies.
-        "-w",
+    srcs = _SRCS,
+    srcs_vendored = [
+        x.replace("src/", "drake_src/src/")
+        for x in _SRCS
     ],
+    hdrs = _HDRS,
+    hdrs_vendored = [
+        x.replace("include/ignition/", "drake_src/drake_vendor/ignition/")
+        for x in _HDRS
+    ],
+    edit_include = {
+        "ignition/": "drake_vendor/ignition/",
+    },
+    copts = ["-w"],
     linkstatic = True,
-    includes = ["include"],
+    includes = ["drake_src"],
     visibility = ["//visibility:public"],
 )
 

--- a/tools/workspace/gz_math_internal/repository.bzl
+++ b/tools/workspace/gz_math_internal/repository.bzl
@@ -5,8 +5,6 @@ load("//tools/workspace:github.bzl", "github_archive")
 def gz_math_internal_repository(
         name,
         mirrors = None):
-    # When updating this commit, also remember to adjust the PROJECT_*
-    # constants in ./package.BUILD.bazel to match the new version number.
     github_archive(
         name = name,
         repository = "gazebosim/gz-math",

--- a/tools/workspace/gz_utils_internal/package.BUILD.bazel
+++ b/tools/workspace/gz_utils_internal/package.BUILD.bazel
@@ -5,10 +5,6 @@ load(
     "cmake_configure_file",
 )
 load(
-    "@drake//tools/workspace:generate_include_header.bzl",
-    "drake_generate_include_header",
-)
-load(
     "@drake//tools/workspace:check_lists_consistency.bzl",
     "check_lists_consistency",
 )
@@ -16,17 +12,15 @@ load(
     "@drake//tools/install:install.bzl",
     "install",
 )
+load(
+    "@drake//tools/workspace:vendor_cxx.bzl",
+    "cc_library_vendored",
+)
 load("@drake//tools/workspace:generate_file.bzl", "generate_file")
 
 licenses(["notice"])  # Apache-2.0
 
 package(default_visibility = ["//visibility:private"])
-
-PROJECT_MAJOR = 1
-
-PROJECT_MINOR = 0
-
-PROJECT_PATCH = 0
 
 cmake_configure_file(
     name = "config",
@@ -35,11 +29,11 @@ cmake_configure_file(
     cmakelists = ["CMakeLists.txt"],
     defines = [
         "IGN_DESIGNATION=utils",
-        "PROJECT_VERSION_MAJOR=%d" % (PROJECT_MAJOR),
-        "PROJECT_VERSION_MINOR=%d" % (PROJECT_MINOR),
-        "PROJECT_VERSION_PATCH=%d" % (PROJECT_PATCH),
-        "PROJECT_VERSION=%d.%d" % (PROJECT_MAJOR, PROJECT_MINOR),
-        "PROJECT_VERSION_FULL=%d.%d.%d" % (PROJECT_MAJOR, PROJECT_MINOR, PROJECT_PATCH),  # noqa
+        "PROJECT_VERSION_MAJOR=0",
+        "PROJECT_VERSION_MINOR=0",
+        "PROJECT_VERSION_PATCH=0",
+        "PROJECT_VERSION=0.0",
+        "PROJECT_VERSION_FULL=0.0.0",
         "PROJECT_NAME_NO_VERSION=ignition-utils",
     ],
 )
@@ -49,12 +43,12 @@ generate_file(
     content = """
 #pragma once
 // Simplified version of visibility and deprecation macros.
-#define IGNITION_UTILS_VISIBLE __attribute__ ((visibility("default")))
+#define IGNITION_UTILS_VISIBLE
 #define IGN_DEPRECATED(version) __attribute__ ((__deprecated__))
     """,
 )
 
-public_headers_no_gen = [
+_MOST_PUBLIC_HDRS = [
     "include/ignition/utils/ImplPtr.hh",
     "include/ignition/utils/SuppressWarning.hh",
     "include/ignition/utils/detail/DefaultOps.hh",
@@ -62,35 +56,27 @@ public_headers_no_gen = [
     "include/ignition/utils/detail/SuppressWarning.hh",
 ]
 
-private_headers = [
-    # Nothing here yet.
-]
-
-drake_generate_include_header(
-    name = "utilshh_genrule",
-    out = "include/ignition/utils.hh",
-    hdrs = public_headers_no_gen + [
-        "include/ignition/utils/config.hh",
-        "include/ignition/utils/Export.hh",
-    ],
-)
-
 check_lists_consistency(
-    files = private_headers + public_headers_no_gen,
+    files = _MOST_PUBLIC_HDRS,
     glob_include = ["include/**/*.hh"],
 )
 
-public_headers = public_headers_no_gen + [
+_HDRS = _MOST_PUBLIC_HDRS + [
     "include/ignition/utils/config.hh",
     "include/ignition/utils/Export.hh",
-    "include/ignition/utils.hh",
 ]
 
-cc_library(
+cc_library_vendored(
     name = "gz_utils",
-    srcs = private_headers,
-    hdrs = public_headers,
-    includes = ["include"],
+    hdrs = _HDRS,
+    hdrs_vendored = [
+        x.replace("include/ignition/", "drake_src/drake_vendor/ignition/")
+        for x in _HDRS
+    ],
+    edit_include = {
+        "ignition/": "drake_vendor/ignition/",
+    },
+    includes = ["drake_src"],
     visibility = ["//visibility:public"],
 )
 

--- a/tools/workspace/gz_utils_internal/repository.bzl
+++ b/tools/workspace/gz_utils_internal/repository.bzl
@@ -8,8 +8,6 @@ def gz_utils_internal_repository(
     github_archive(
         name = name,
         repository = "gazebosim/gz-utils",
-        # When updating this commit, also remember to adjust the PROJECT_*
-        # constants in ./package.BUILD.bazel to match the new version number.
         commit = "ignition-utils1_1.0.0",
         sha256 = "55d3285692392f9493a35b680f275ec116584baedeef90de57d2b03dfd952d9d",  # noqa
         build_file = "@drake//tools/workspace/gz_utils_internal:package.BUILD.bazel",  # noqa

--- a/tools/workspace/sdformat_internal/BUILD.bazel
+++ b/tools/workspace/sdformat_internal/BUILD.bazel
@@ -15,7 +15,7 @@ drake_cc_binary(
     deps = [
         "//common:essential",
         "@gflags",
-        "@sdformat_internal//:ign_sdf_cmdline",
+        "@sdformat_internal//:ign_cmdline",
     ],
 )
 

--- a/tools/workspace/sdformat_internal/package.BUILD.bazel
+++ b/tools/workspace/sdformat_internal/package.BUILD.bazel
@@ -13,14 +13,22 @@ load(
     "drake_generate_include_header",
 )
 load(
+    "@drake//tools/workspace:check_lists_consistency.bzl",
+    "check_lists_consistency",
+)
+load(
     "@drake//tools/install:install.bzl",
     "install",
+)
+load(
+    "@drake//tools/workspace:vendor_cxx.bzl",
+    "cc_library_vendored",
 )
 load("@drake//tools/workspace:generate_file.bzl", "generate_file")
 
 licenses(["notice"])  # Apache-2.0 AND BSD-3-Clause AND BSL-1.0
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//visibility:private"])
 
 # Generates config.h based on the version numbers in CMake code.
 cmake_configure_file(
@@ -55,7 +63,7 @@ generate_file(
 )
 
 # Public headers are indicated in sdformat's `include/sdf/CMakeLists.txt`.
-SDFORMAT_MOST_PUBLIC_HDRS = [
+_MOST_HDRS = [
     "include/sdf/Actor.hh",
     "include/sdf/AirPressure.hh",
     "include/sdf/Altimeter.hh",
@@ -139,107 +147,120 @@ py_binary(
     srcs_version = "PY3",
 )
 
-SDFORMAT_ALL_PUBLIC_HDRS = SDFORMAT_MOST_PUBLIC_HDRS + [
+_HDRS = _MOST_HDRS + [
     "include/sdf/config.hh",  # from cmake_configure_file above
     "include/sdf/sdf_config.h",  # alias to config.hh
     "include/sdf/Export.hh",  # from generate_file above
 ]
 
-# Generates the library exported to users. The explicitly listed srcs= matches
-# upstream's explicitly listed sources (sdformat/src/CMakeLists.txt), with two
-# exceptions: ign.hh and ign.cc are not incorporated in this library, but are
-# incorporated into the `ign_sdf_cmdline` library defined below; and the
-# parser_urdf.hh and parser_urdf.cc are excluded because we don't use them.
-cc_library(
+# This list of sources matches upstream's explicitly listed sources
+# (sdformat/src/CMakeLists.txt), with two exceptions: ign.hh and ign.cc are not
+# incorporated in this library, but are incorporated into the `ign_sdf_cmdline`
+# library defined below; and the parser_urdf.hh and parser_urdf.cc are excluded
+# because we don't use them.
+_SRCS = [
+    "src/Actor.cc",
+    "src/AirPressure.cc",
+    "src/Altimeter.cc",
+    "src/Atmosphere.cc",
+    "src/Box.cc",
+    "src/Camera.cc",
+    "src/Capsule.cc",
+    "src/Collision.cc",
+    "src/Console.cc",
+    "src/Converter.cc",
+    "src/Converter.hh",
+    "src/Cylinder.cc",
+    "src/Element.cc",
+    "src/Ellipsoid.cc",
+    "src/EmbeddedSdf.hh",
+    "src/Error.cc",
+    "src/Exception.cc",
+    "src/Filesystem.cc",
+    "src/ForceTorque.cc",
+    "src/Frame.cc",
+    "src/FrameSemantics.cc",
+    "src/FrameSemantics.hh",
+    "src/Geometry.cc",
+    "src/Gui.cc",
+    "src/Heightmap.cc",
+    "src/Imu.cc",
+    "src/InterfaceElements.cc",
+    "src/InterfaceFrame.cc",
+    "src/InterfaceJoint.cc",
+    "src/InterfaceLink.cc",
+    "src/InterfaceModel.cc",
+    "src/InterfaceModelPoseGraph.cc",
+    "src/Joint.cc",
+    "src/JointAxis.cc",
+    "src/Lidar.cc",
+    "src/Light.cc",
+    "src/Link.cc",
+    "src/Magnetometer.cc",
+    "src/Material.cc",
+    "src/Mesh.cc",
+    "src/Model.cc",
+    "src/NavSat.cc",
+    "src/Noise.cc",
+    "src/OutputConfig.cc",
+    "src/Param.cc",
+    "src/ParamPassing.cc",
+    "src/ParamPassing.hh",
+    "src/ParserConfig.cc",
+    "src/ParticleEmitter.cc",
+    "src/Pbr.cc",
+    "src/Physics.cc",
+    "src/Plane.cc",
+    "src/Plugin.cc",
+    "src/Polyline.cc",
+    "src/PrintConfig.cc",
+    "src/Root.cc",
+    "src/SDF.cc",
+    "src/SDFExtension.cc",
+    "src/SDFExtension.hh",
+    "src/SDFImplPrivate.hh",
+    "src/Scene.cc",
+    "src/ScopedGraph.hh",
+    "src/SemanticPose.cc",
+    "src/Sensor.cc",
+    "src/Sky.cc",
+    "src/Sphere.cc",
+    "src/Surface.cc",
+    "src/Types.cc",
+    "src/Utils.cc",
+    "src/Utils.hh",
+    "src/Visual.cc",
+    "src/World.cc",
+    "src/XmlUtils.cc",
+    "src/XmlUtils.hh",
+    "src/parser.cc",
+    "src/parser_private.hh",
+    ":src/EmbeddedSdf.cc",
+]
+
+# Generates the library exported to users.
+cc_library_vendored(
     name = "sdformat",
-    srcs = [
-        "src/Actor.cc",
-        "src/AirPressure.cc",
-        "src/Altimeter.cc",
-        "src/Atmosphere.cc",
-        "src/Box.cc",
-        "src/Camera.cc",
-        "src/Capsule.cc",
-        "src/Collision.cc",
-        "src/Console.cc",
-        "src/Converter.cc",
-        "src/Converter.hh",
-        "src/Cylinder.cc",
-        "src/Element.cc",
-        "src/Ellipsoid.cc",
-        "src/EmbeddedSdf.hh",
-        "src/Error.cc",
-        "src/Exception.cc",
-        "src/Filesystem.cc",
-        "src/ForceTorque.cc",
-        "src/Frame.cc",
-        "src/FrameSemantics.cc",
-        "src/FrameSemantics.hh",
-        "src/Geometry.cc",
-        "src/Gui.cc",
-        "src/Heightmap.cc",
-        "src/Imu.cc",
-        "src/InterfaceElements.cc",
-        "src/InterfaceFrame.cc",
-        "src/InterfaceJoint.cc",
-        "src/InterfaceLink.cc",
-        "src/InterfaceModel.cc",
-        "src/InterfaceModelPoseGraph.cc",
-        "src/Joint.cc",
-        "src/JointAxis.cc",
-        "src/Lidar.cc",
-        "src/Light.cc",
-        "src/Link.cc",
-        "src/Magnetometer.cc",
-        "src/Material.cc",
-        "src/Mesh.cc",
-        "src/Model.cc",
-        "src/NavSat.cc",
-        "src/Noise.cc",
-        "src/OutputConfig.cc",
-        "src/Param.cc",
-        "src/ParamPassing.cc",
-        "src/ParamPassing.hh",
-        "src/ParserConfig.cc",
-        "src/ParticleEmitter.cc",
-        "src/Pbr.cc",
-        "src/Physics.cc",
-        "src/Plane.cc",
-        "src/Plugin.cc",
-        "src/Polyline.cc",
-        "src/PrintConfig.cc",
-        "src/Root.cc",
-        "src/SDF.cc",
-        "src/SDFExtension.cc",
-        "src/SDFExtension.hh",
-        "src/SDFImplPrivate.hh",
-        "src/Scene.cc",
-        "src/ScopedGraph.hh",
-        "src/SemanticPose.cc",
-        "src/Sensor.cc",
-        "src/Sky.cc",
-        "src/Sphere.cc",
-        "src/Surface.cc",
-        "src/Types.cc",
-        "src/Utils.cc",
-        "src/Utils.hh",
-        "src/Visual.cc",
-        "src/World.cc",
-        "src/XmlUtils.cc",
-        "src/XmlUtils.hh",
-        "src/parser.cc",
-        "src/parser_private.hh",
-        ":src/EmbeddedSdf.cc",
+    srcs = _SRCS,
+    srcs_vendored = [
+        x.replace("src/", "drake_src/src/")
+        for x in _SRCS
     ],
-    hdrs = SDFORMAT_ALL_PUBLIC_HDRS,
-    # TODO(jamiesnape): Enable visibility after resolving warnings such as
-    # "Direct access in function means the weak symbol cannot be overridden at
-    # runtime. This was likely caused by different translation units being
-    # compiled with different visibility settings."
+    hdrs = _HDRS,
+    hdrs_vendored = [
+        x.replace("include/sdf/", "drake_src/drake_vendor/sdf/")
+        for x in _HDRS
+    ],
+    edit_include = {
+        "sdf/": "drake_vendor/sdf/",
+        "ignition/math/": "drake_vendor/ignition/math/",
+        "ignition/utils/": "drake_vendor/ignition/utils/",
+    },
+    includes = ["drake_src"],
     copts = ["-w"],
     defines = ["SDFORMAT_STATIC_DEFINE", "SDFORMAT_DISABLE_CONSOLE_LOGFILE"],
-    includes = ["include"],
     linkstatic = 1,
+    visibility = ["//visibility:public"],
     deps = [
         "@gz_math_internal//:gz_math",
         "@gz_utils_internal//:gz_utils",
@@ -251,21 +272,50 @@ cc_library(
     ],
 )
 
-cc_library(
-    name = "ign_sdf_cmdline",
-    srcs = [
-        "src/ign.cc",
-        "src/ign.hh",
+_IGN_CMDLINE_SRCS = [
+    "src/ign.cc",
+    "src/ign.hh",
+]
+
+cc_library_vendored(
+    name = "ign_cmdline",
+    srcs = _IGN_CMDLINE_SRCS,
+    srcs_vendored = [
+        x.replace("src/", "drake_src/src/")
+        for x in _IGN_CMDLINE_SRCS
     ],
+    edit_include = {
+        "sdf/": "drake_vendor/sdf/",
+        "ignition/math/": "drake_vendor/ignition/math/",
+    },
     copts = ["-w"],
     linkstatic = 1,
+    visibility = ["@drake//tools/workspace/sdformat_internal:__pkg__"],
     deps = [
         ":sdformat",
     ],
 )
 
+check_lists_consistency(
+    files = _MOST_HDRS + _SRCS + _IGN_CMDLINE_SRCS,
+    glob_include = [
+        "include/**/*.hh",
+        "src/**/*.hh",
+        "src/**/*.cc",
+    ],
+    glob_exclude = [
+        # We ignore this backwards-compatibility stub file.
+        "include/sdf/sdf.hh",
+        # Drake doesn't use sdformat's URDF parser; we have our own.
+        "src/parser_urdf.*",
+        # These are test code, not library code.
+        "**/*TEST*",
+    ],
+)
+
 install(
     name = "install",
+    visibility = ["//visibility:public"],
     docs = [
         "COPYING",
         "LICENSE",

--- a/tools/workspace/sdformat_internal/patches/1043.patch
+++ b/tools/workspace/sdformat_internal/patches/1043.patch
@@ -1,0 +1,31 @@
+Cherry-pick of https://github.com/gazebosim/sdformat/pull/1043
+
+We can remove this file once we upgrade to a sufficiently new sdformat
+release that already incorporates this patch.
+
+--- include/sdf/Link.hh
++++ include/sdf/Link.hh
+@@ -19,6 +19,7 @@
+ 
+ #include <memory>
+ #include <string>
++#include <ignition/math/Inertial.hh>
+ #include <ignition/math/Pose3.hh>
+ #include <ignition/utils/ImplPtr.hh>
+ #include "sdf/Element.hh"
+--- include/sdf/Param.hh
++++ include/sdf/Param.hh
+@@ -33,7 +33,12 @@
+ #include <variant>
+ #include <vector>
+ 
+-#include <ignition/math.hh>
++#include <ignition/math/Angle.hh>
++#include <ignition/math/Color.hh>
++#include <ignition/math/Pose3.hh>
++#include <ignition/math/Quaternion.hh>
++#include <ignition/math/Vector2.hh>
++#include <ignition/math/Vector3.hh>
+ 
+ #include "sdf/Console.hh"
+ #include "sdf/PrintConfig.hh"

--- a/tools/workspace/sdformat_internal/repository.bzl
+++ b/tools/workspace/sdformat_internal/repository.bzl
@@ -12,6 +12,7 @@ def sdformat_internal_repository(
         build_file = "@drake//tools/workspace/sdformat_internal:package.BUILD.bazel",  # noqa
         sha256 = "3896772db68b7ca7b18bbf1945a72206885b03d3f0caf29491be5b53b79a7124",  # noqa
         patches = [
+            "@drake//tools/workspace/sdformat_internal:patches/1043.patch",
             "@drake//tools/workspace/sdformat_internal:patches/console.patch",
             "@drake//tools/workspace/sdformat_internal:patches/deprecation_unit_testing.patch",  # noqa
             "@drake//tools/workspace/sdformat_internal:patches/no_global_config.patch",  # noqa


### PR DESCRIPTION
When building C++ code, we can't use `-fvisibility=hidden` because it infects all #included code, even the standard library. Instead, we should wrap the third-party C++ code in a inline hidden namespace. That way, only the third-party code itself is hidden.

Towards #17231.

Requires:
- [x] #17278
- [x] #17303
- [x] #17334

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17230)
<!-- Reviewable:end -->
