### PR TITLE
[WIP, autodiff] Russ's rotation matrix autodiff hacks with some fixes

### DIFF
--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -60,7 +60,6 @@ class Matrix3dWithDerivatives {
   const Eigen::Matrix3d& value() const { return value_; }
 
  private:
-  friend class Matrix3dWithDerivatives;
   friend bool IsNearlyEqualTo(const Matrix3dWithDerivatives& m1,
                               const Matrix3dWithDerivatives& m2,
                               double tolerance);
@@ -466,7 +465,7 @@ class RotationMatrix {
 
   template <typename T1=T>
   std::enable_if_t<std::is_same_v<T1, AutoDiffXd>,
-                 const Eigen::RowVector3<AutoDiffXd>>
+                 const RowVector3<AutoDiffXd>>
   row(int index) const {
     DRAKE_ASSERT(0 <= index && index <= 2);
     // TODO(russt): Make this more efficient!
@@ -500,7 +499,7 @@ class RotationMatrix {
 
   template <typename T1=T>
   std::enable_if_t<std::is_same_v<T1, AutoDiffXd>,
-                 const Eigen::Vector3<AutoDiffXd>>
+                 const Vector3<AutoDiffXd>>
   col(int index) const {
     DRAKE_ASSERT(0 <= index && index <= 2);
     // TODO(russt): Make this more efficient!

--- a/multibody/benchmarking/position_constraint.cc
+++ b/multibody/benchmarking/position_constraint.cc
@@ -32,7 +32,7 @@ class IiwaPositionConstraintFixture : public benchmark::Fixture {
   void SetUp(const ::benchmark::State&) override {
     tools::performance::AddMinMaxStatistics(this);
 
-    const int kNumIiwas = 1;
+    const int kNumIiwas = 10;
 
     const std::string iiwa_path = FindResourceOrThrow(
         "drake/manipulation/models/iiwa_description/sdf/"

--- a/multibody/benchmarking/position_constraint.cc
+++ b/multibody/benchmarking/position_constraint.cc
@@ -24,10 +24,15 @@ using systems::Context;
 class IiwaPositionConstraintFixture : public benchmark::Fixture {
  public:
   using benchmark::Fixture::SetUp;
+
+  IiwaPositionConstraintFixture() {
+    Iterations(1000);
+  }
+
   void SetUp(const ::benchmark::State&) override {
     tools::performance::AddMinMaxStatistics(this);
 
-    const int kNumIiwas = 10;
+    const int kNumIiwas = 1;
 
     const std::string iiwa_path = FindResourceOrThrow(
         "drake/manipulation/models/iiwa_description/sdf/"

--- a/multibody/benchmarking/position_constraint.cc
+++ b/multibody/benchmarking/position_constraint.cc
@@ -26,7 +26,7 @@ class IiwaPositionConstraintFixture : public benchmark::Fixture {
   using benchmark::Fixture::SetUp;
 
   IiwaPositionConstraintFixture() {
-    Iterations(1000);
+    Iterations(10000);
   }
 
   void SetUp(const ::benchmark::State&) override {


### PR DESCRIPTION
(do not review) Russ hacked RotationMatrix with a bespoke 3x3 differentiable matrix type and reported impressive speedups in #16877. However some unit tests were failing, shedding some doubt on the alleged speedups. I added a narrow unit test here and found that transpose() was unconditionally setting the gradients to zero. With that fixed, tests I ran locally passed. 

My hope is to use this as a performance baseline for a cleaned-up implementation along similar lines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17236)
<!-- Reviewable:end -->
