### PR TITLE
[workspace] For sdformat and related, use gazebosim not ignition

### DIFF
--- a/tools/workspace/ignition_math/repository.bzl
+++ b/tools/workspace/ignition_math/repository.bzl
@@ -2,6 +2,7 @@
 
 load("//tools/workspace:github.bzl", "github_archive")
 
+# TODO(jwnimmer-tri) Rename this to match upstream gz-math.
 def ignition_math_repository(
         name,
         mirrors = None):
@@ -9,9 +10,9 @@ def ignition_math_repository(
     # constants in ./package.BUILD.bazel to match the new version number.
     github_archive(
         name = name,
-        repository = "ignitionrobotics/ign-math",
+        repository = "gazebosim/gz-math",
         commit = "ignition-math6_6.10.0",
-        sha256 = "9e00284cd6d51afe190165b2b44258e19bd4a28781cbacf21fd6b0bae43c16aa",  # noqa
+        sha256 = "94e853e1dfba97ebec4b6152691a89af1e94660b02f4ecdf04356b763c2848bd",  # noqa
         build_file = "@drake//tools/workspace/ignition_math:package.BUILD.bazel",  # noqa
         mirrors = mirrors,
     )

--- a/tools/workspace/ignition_utils/repository.bzl
+++ b/tools/workspace/ignition_utils/repository.bzl
@@ -2,16 +2,17 @@
 
 load("//tools/workspace:github.bzl", "github_archive")
 
+# TODO(jwnimmer-tri) Rename this to match upstream gz-utils.
 def ignition_utils_repository(
         name,
         mirrors = None):
     github_archive(
         name = name,
-        repository = "ignitionrobotics/ign-utils",
+        repository = "gazebosim/gz-utils",
         # When updating this commit, also remember to adjust the PROJECT_*
         # constants in ./package.BUILD.bazel to match the new version number.
         commit = "ignition-utils1_1.0.0",
-        sha256 = "bd024164f12f66e125b544602ec481f6760d5a710aeb62d34a015fb598ee5a0a",  # noqa
+        sha256 = "55d3285692392f9493a35b680f275ec116584baedeef90de57d2b03dfd952d9d",  # noqa
         build_file = "@drake//tools/workspace/ignition_utils:package.BUILD.bazel",  # noqa
         mirrors = mirrors,
     )

--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -60,15 +60,19 @@ _IGNORED_REPOSITORIES = [
 
 # For these repositories, we only look at tags, not releases.  For the dict
 # value, use a blank value to match the latest tag or a regex to only select
-# tags that share the match with the tag currently in use.  (This can be used
-# to pin to a given major or major.minor release series.)
+# tags that share the match with the tag currently in use; the parentheses
+# group in the regex denotes the portion of the tag to lock as invariant.
+# (This can be used to pin to a given major or major.minor release series.)
 _OVERLOOK_RELEASE_REPOSITORIES = {
     "github3_py": r"^(\d+.)",
+    "ignition_math": "",
+    "ignition_utils": "",
     "intel_realsense_ros": r"^(\d+\.\d+\.)",
     "petsc": r"^(v)",
     "pycodestyle": "",
-    "ros_xacro": r"^(\d+\.\d+\.)",
     "qhull": r"^(2)",
+    "ros_xacro": r"^(\d+\.\d+\.)",
+    "sdformat": "",
 }
 
 

--- a/tools/workspace/sdformat/repository.bzl
+++ b/tools/workspace/sdformat/repository.bzl
@@ -7,7 +7,7 @@ def sdformat_repository(
         mirrors = None):
     github_archive(
         name = name,
-        repository = "ignitionrobotics/sdformat",
+        repository = "gazebosim/sdformat",
         commit = "sdformat12_12.0.0",
         sha256 = "b3f44b7bc4530ca40ca120489d791d8ee9295beb30a16406926fb2ae42b3fba8",  # noqa
         build_file = "@drake//tools/workspace/sdformat:package.BUILD.bazel",


### PR DESCRIPTION
The ignitionrobotics organization is now empty; development has moved to the gazebosim organization, so we should to update github_archive to point to the new organization.  For the math and utils libraries, the repository name also changed from ign to gz; that requires a checksum update as well, because the source tarballs embed that name.

Upstream also no longer uses GitHub release announcements for minor releases. Therefore, we need to use tags when checking for new releases.

Closes #17235.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17240)
<!-- Reviewable:end -->
