### PR TITLE
[geometry] Reject duplicate-named frames for same source

### DIFF
--- a/bindings/pydrake/test/geometry_scene_graph_test.py
+++ b/bindings/pydrake/test/geometry_scene_graph_test.py
@@ -32,10 +32,11 @@ class TestGeometrySceneGraph(unittest.TestCase):
         scene_graph = SceneGraph()
         global_source = scene_graph.RegisterSource("anchored")
         global_frame = scene_graph.RegisterFrame(
-            source_id=global_source, frame=mut.GeometryFrame("anchored_frame"))
+            source_id=global_source,
+            frame=mut.GeometryFrame("anchored_frame1"))
         scene_graph.RegisterFrame(
             source_id=global_source, parent_id=global_frame,
-            frame=mut.GeometryFrame("anchored_frame"))
+            frame=mut.GeometryFrame("anchored_frame2"))
         global_geometry = scene_graph.RegisterGeometry(
             source_id=global_source, frame_id=global_frame,
             geometry=mut.GeometryInstance(X_PG=RigidTransform_[float](),
@@ -194,7 +195,7 @@ class TestGeometrySceneGraph(unittest.TestCase):
         self.assertEqual(inspector.GetOwningSourceName(frame_id=global_frame),
                          "anchored")
         self.assertEqual(
-            inspector.GetName(frame_id=global_frame), "anchored_frame")
+            inspector.GetName(frame_id=global_frame), "anchored_frame1")
         self.assertEqual(inspector.GetFrameGroup(frame_id=global_frame), 0)
         self.assertEqual(
             inspector.NumGeometriesForFrame(frame_id=global_frame), 2)

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -32,6 +32,7 @@ namespace geometry {
 namespace internal {
 
 class GeometryVisualizationImpl;
+using FrameNameSet = std::unordered_set<std::string>;
 
 }  // namespace internal
 #endif
@@ -570,6 +571,7 @@ class GeometryState {
   explicit GeometryState(const GeometryState<U>& source)
       : self_source_(source.self_source_),
         source_frame_id_map_(source.source_frame_id_map_),
+        source_frame_name_map_(source.source_frame_name_map_),
         source_root_frame_map_(source.source_root_frame_map_),
         source_names_(source.source_names_),
         source_anchored_geometry_map_(source.source_anchored_geometry_map_),
@@ -787,6 +789,10 @@ class GeometryState {
   // The registered geometry sources and the frame ids that have been registered
   // on them.
   std::unordered_map<SourceId, FrameIdSet> source_frame_id_map_;
+
+  // The registered geometry sources and the frame names that have been
+  // registered on them. Only used to reject duplicate names.
+  std::unordered_map<SourceId, internal::FrameNameSet> source_frame_name_map_;
 
   // The registered geometry sources and the frame ids that have the world frame
   // as the parent frame. For a completely flat hierarchy, this contains the

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -405,9 +405,11 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @param frame         The frame to register.
    @returns A unique identifier for the added frame.
    @throws std::exception  if a) the `source_id` does _not_ map to a
-                           registered source, or
+                           registered source,
                            b) `frame` has an id that has already been
-                           registered.  */
+                           registered, or
+                           c) there is already a frame with the
+                           same name registered for the source.  */
   FrameId RegisterFrame(SourceId source_id, const GeometryFrame& frame);
 
   /** Registers a new frame F for this source. This hangs frame F on another
@@ -425,9 +427,11 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @throws std::exception  if a) the `source_id` does _not_ map to a
                            registered source,
                            b) the `parent_id` does _not_ map to a known
-                           frame or does not belong to the source, or
+                           frame or does not belong to the source,
                            c) `frame` has an id that has already been
-                           registered.  */
+                           registered, or
+                           d) there is already a frame with the
+                           same name registered for the source.  */
   FrameId RegisterFrame(SourceId source_id, FrameId parent_id,
                         const GeometryFrame& frame);
 

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -33,6 +33,7 @@ namespace geometry {
 using Eigen::Translation3d;
 using Eigen::Vector3d;
 using internal::DummyRenderEngine;
+using internal::FrameNameSet;
 using internal::InternalFrame;
 using internal::InternalGeometry;
 using internal::ProximityEngine;
@@ -74,6 +75,11 @@ class GeometryStateTester {
 
   const unordered_map<SourceId, FrameIdSet>& get_source_frame_id_map() const {
     return state_->source_frame_id_map_;
+  }
+
+  const unordered_map<SourceId, FrameNameSet>& get_source_frame_name_map()
+      const {
+    return state_->source_frame_name_map_;
   }
 
   const unordered_map<SourceId, FrameIdSet>& get_source_root_frame_map() const {
@@ -722,6 +728,9 @@ TEST_F(GeometryStateTest, Constructor) {
   // GeometryState always has a world frame.
   EXPECT_EQ(geometry_state_.get_num_frames(), 1);
   EXPECT_EQ(geometry_state_.get_num_geometries(), 0);
+  EXPECT_EQ(gs_tester_.get_source_frame_name_map().find(
+                gs_tester_.get_self_source_id())->second,
+            internal::FrameNameSet{"world"});
 }
 
 // Confirms that the registered shapes are correctly returned upon
@@ -856,6 +865,8 @@ void ExpectSuccessfulTransmogrification(
   EXPECT_EQ(T_tester.get_source_name_map(), d_tester.get_source_name_map());
   EXPECT_EQ(T_tester.get_source_frame_id_map(),
             d_tester.get_source_frame_id_map());
+  EXPECT_EQ(T_tester.get_source_frame_name_map(),
+            d_tester.get_source_frame_name_map());
   EXPECT_EQ(T_tester.get_source_root_frame_map(),
             d_tester.get_source_root_frame_map());
   EXPECT_EQ(T_tester.get_source_anchored_geometry_map(),
@@ -1223,6 +1234,25 @@ TEST_F(GeometryStateTest, AddFrameToInvalidSource) {
   DRAKE_ASSERT_THROWS_MESSAGE(
       geometry_state_.RegisterFrame(s_id, *frame_),
       "Referenced geometry source \\d+ is not registered.");
+}
+
+// Tests that a duplicate-named frame added to a valid source throws an
+// exception with a meaningful message.
+TEST_F(GeometryStateTest, DuplicateFrameName) {
+  const SourceId s_id = NewSource();
+  geometry_state_.RegisterFrame(s_id, *frame_);
+  DRAKE_ASSERT_THROWS_MESSAGE(
+      geometry_state_.RegisterFrame(s_id, GeometryFrame(frame_->name())),
+      ".*source 'default_source'.*duplicate name 'ref_frame'");
+}
+
+// Tests that adding another frame named "world" to the self source throws an
+// exception.
+TEST_F(GeometryStateTest, ManyWorldsRefuted) {
+  DRAKE_ASSERT_THROWS_MESSAGE(
+      geometry_state_.RegisterFrame(gs_tester_.get_self_source_id(),
+                                    GeometryFrame("world")),
+      ".*source 'SceneGraphInternal'.*duplicate name 'world'");
 }
 
 // Tests that a frame added to a valid source appears in the source's frames.

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -218,9 +218,9 @@ TEST_F(SceneGraphTest, TopologyAfterAllocation) {
   CreateDefaultContext();
 
   FrameId parent_frame_id =
-      scene_graph_.RegisterFrame(id, GeometryFrame("frame"));
+      scene_graph_.RegisterFrame(id, GeometryFrame("parent"));
   FrameId child_frame_id =
-      scene_graph_.RegisterFrame(id, parent_frame_id, GeometryFrame("frame"));
+      scene_graph_.RegisterFrame(id, parent_frame_id, GeometryFrame("child"));
   GeometryId parent_geometry_id = scene_graph_.RegisterGeometry(
       id, parent_frame_id, make_sphere_instance());
   GeometryId child_geometry_id = scene_graph_.RegisterGeometry(


### PR DESCRIPTION
Closes: #7122

Track the set of frame names for each source, and use that to reject
duplicates. Add a unit test for the new message, and adjust some other tests
that needlessly used duplicate names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17243)
<!-- Reviewable:end -->
