### PR TITLE
[multibody] Add meshcat JointSliders::SetPositions

### DIFF
--- a/bindings/pydrake/multibody/meshcat_py.cc
+++ b/bindings/pydrake/multibody/meshcat_py.cc
@@ -227,7 +227,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.ctor.doc)
         .def("Delete", &Class::Delete, cls_doc.Delete.doc)
         .def("Run", &Class::Run, py::arg("diagram"),
-            py::arg("timeout") = py::none(), cls_doc.Run.doc);
+            py::arg("timeout") = py::none(), cls_doc.Run.doc)
+        .def("SetPositions", &Class::SetPositions, py::arg("q"),
+            cls_doc.SetPositions.doc);
   }
 }
 }  // namespace

--- a/bindings/pydrake/multibody/test/meshcat_test.py
+++ b/bindings/pydrake/multibody/test/meshcat_test.py
@@ -126,6 +126,9 @@ class TestMeshcat(unittest.TestCase):
         diagram = builder.Build()
         dut.Run(diagram=diagram, timeout=1.0)
 
+        # The SetPositions function doesn't crash (Acrobot has two positions).
+        dut.SetPositions(q=[1, 2])
+
     def test_internal_point_contact_visualizer(self):
         """A very basic existance test, since this class is internal use only.
         The pydrake-internal user (meldis) has additional acceptance tests.

--- a/multibody/meshcat/BUILD.bazel
+++ b/multibody/meshcat/BUILD.bazel
@@ -84,11 +84,13 @@ drake_cc_googletest(
     name = "joint_sliders_test",
     data = [
         ":test/universal_joint.sdf",
+        "//manipulation/models/iiwa_description:models",
         "//multibody:models",
         "//multibody/benchmarks/acrobot:models",
     ],
     deps = [
         ":joint_sliders",
+        "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//geometry:meshcat_visualizer",
         "//geometry/test_utilities:meshcat_environment",

--- a/multibody/meshcat/joint_sliders.cc
+++ b/multibody/meshcat/joint_sliders.cc
@@ -271,6 +271,27 @@ void JointSliders<T>::Run(
   }
 }
 
+template <typename T>
+void JointSliders<T>::SetPositions(const Eigen::VectorXd& q) {
+  const int nq = plant_->num_positions();
+  if (q.size() != nq) {
+    throw std::logic_error(fmt::format(
+        "Expected q of size {}, but got size {} instead",
+        nq, q.size()));
+  }
+  /* For all positions provided in q, update their value in initial_value_
+    including items without an associated slider (e.g., a floating base). */
+  initial_value_ = q;
+  if (is_registered_) {
+    // For items with an associated slider, update the meshcat UI.
+    // TODO(jwnimmer-tri) If SetPositions is in flight concurrently with a
+    // call to Delete, we might race and ask for a deleted slider value.
+    for (const auto& [position_index, slider_name] : position_names_) {
+      meshcat_->SetSliderValue(slider_name, q[position_index]);
+    }
+  }
+}
+
 }  // namespace meshcat
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/meshcat/joint_sliders.h
+++ b/multibody/meshcat/joint_sliders.h
@@ -111,13 +111,25 @@ class JointSliders final : public systems::LeafSystem<T> {
       const systems::Diagram<T>& diagram,
       std::optional<double> timeout = std::nullopt) const;
 
+  /** Sets all robot positions (corresponding to joint positions and potentially
+  positions not associated with any joint) to the values in `q`.  The meshcat
+  sliders associated with any joint positions described by `q` will have their
+  value updated.  Additionally, the "initial state" vector of positions tracked
+  by this instance will be updated to the values in `q`.  This "initial state"
+  vector update will persist even if sliders are removed (e.g., via Delete).
+
+  @param q A vector whose length is equal to the associated
+  MultibodyPlant::num_positions().
+  */
+  void SetPositions(const Eigen::VectorXd& q);
+
  private:
   void CalcOutput(const systems::Context<T>&, systems::BasicVector<T>*) const;
 
   std::shared_ptr<geometry::Meshcat> meshcat_;
   const MultibodyPlant<T>* const plant_;
   const std::map<int, std::string> position_names_;
-  const Eigen::VectorXd initial_value_;
+  Eigen::VectorXd initial_value_;
   std::atomic<bool> is_registered_;
 };
 


### PR DESCRIPTION
Relates: #16816.

- Enable the sliders to be updated using a vector of positions the same length as the MultibodyPlant::num_positions(), indices that correspond to joint sliders will update the meshcat UI.
- Add corresponding python bindings and related tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17247)
<!-- Reviewable:end -->
