### PR TITLE
[tools] Promote macro-redefined to an error

### DIFF
--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -24,6 +24,7 @@ CLANG_FLAGS = CXX_FLAGS + [
     "-Werror=inconsistent-missing-override",
     "-Werror=final-dtor-non-final-class",
     "-Werror=literal-conversion",
+    "-Werror=macro-redefined",
     "-Werror=non-virtual-dtor",
     "-Werror=range-loop-analysis",
     "-Werror=return-stack-address",


### PR DESCRIPTION
In support of #17250, we should fail-fast if the macro definitions change in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17256)
<!-- Reviewable:end -->
