### PR TITLE
[workspace] Append WITH_MOSEK=OFF for arm64 macOS

### DIFF
--- a/tools/macos-arch-arm64.bazelrc
+++ b/tools/macos-arch-arm64.bazelrc
@@ -7,3 +7,6 @@ build --action_env=PATH=/opt/homebrew/bin:/usr/bin:/bin
 # to use x86 assembly code. Ideally, we should find a way to build it on ARM64
 # at which point we can re-enable IBEX and dReal.
 build --define NO_DREAL=ON
+
+# TODO(#17026) Mosek 10 is required for arm64.
+build:everything --define WITH_MOSEK=OFF


### PR DESCRIPTION
Relates: #17262, #17026.

Mosek < 10 do not support arm64 macOS.

~~Note: this PR is also being used to stress test m1 CI changes unrelated to the changes here.~~ (not possible https://github.com/RobotLocomotion/drake/pull/17269#issuecomment-1137593748)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17269)
<!-- Reviewable:end -->
