### PR TITLE
[parsing] Add collision filters via model directives

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -189,10 +189,21 @@ drake_cc_library(
     ],
 )
 
+# The composite parse module and parser depend on one another, but the
+# detail_composite_parse header should remain private.
 drake_cc_library(
     name = "parser",
-    srcs = ["parser.cc"],
-    hdrs = ["parser.h"],
+    srcs = [
+        "detail_composite_parse.cc",
+        "parser.cc",
+    ],
+    hdrs = [
+        "detail_composite_parse.h",
+        "parser.h",
+    ],
+    install_hdrs_exclude = [
+        "detail_composite_parse.h",
+    ],
     visibility = ["//visibility:public"],
     interface_deps = [
         ":package_map",
@@ -230,6 +241,7 @@ drake_cc_library(
         "//multibody/plant",
     ],
     deps = [
+        ":detail_misc",
         ":scoped_names",
         "//common:filesystem",
         "//common:find_resource",

--- a/multibody/parsing/detail_composite_parse.cc
+++ b/multibody/parsing/detail_composite_parse.cc
@@ -1,0 +1,32 @@
+#include "drake/multibody/parsing/detail_composite_parse.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+std::unique_ptr<CompositeParse> CompositeParse::MakeCompositeParse(
+    Parser* parser) {
+  DRAKE_DEMAND(parser != nullptr);
+  // This slightly odd spelling allows access to the private constructor.
+  return std::unique_ptr<CompositeParse>(new CompositeParse(parser));
+}
+
+CompositeParse::CompositeParse(Parser* parser)
+    : parser_(parser), resolver_(&parser->plant()) {}
+
+CompositeParse::~CompositeParse() {
+  resolver_.Resolve(parser_->diagnostic_policy_);
+}
+
+CollisionFilterGroupResolver& CompositeParse::collision_resolver() {
+  return resolver_;
+}
+
+ModelInstanceIndex CompositeParse::AddModelFromFile(
+    const std::string& file_name, const std::string& model_name) {
+  return parser_->CompositeAddModelFromFile(file_name, model_name, this);
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/detail_composite_parse.h
+++ b/multibody/parsing/detail_composite_parse.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "drake/multibody/parsing/detail_collision_filter_group_resolver.h"
+#include "drake/multibody/parsing/parser.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// An object that contains bookkeeping that should span the parsing of
+// multiple models. Since it internally references the parser passed to it at
+// construction, its lifetime must be shorter than that of the parser.
+class CompositeParse {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(CompositeParse)
+
+  // Build and return a new composite parse object.
+  static std::unique_ptr<CompositeParse> MakeCompositeParse(Parser* parser);
+
+  ~CompositeParse();
+
+  CollisionFilterGroupResolver& collision_resolver();
+  // TODO(rpoyner-tri): add some way to get more expressive diagnostics.
+
+  ModelInstanceIndex AddModelFromFile(
+    const std::string& file_name,
+    const std::string& model_name);
+  // TODO(rpoyner-tri): add model parsing methods as needed.
+
+ private:
+  explicit CompositeParse(Parser* parser);
+
+  Parser* const parser_;
+  CollisionFilterGroupResolver resolver_;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/parser.cc
+++ b/multibody/parsing/parser.cc
@@ -1,10 +1,12 @@
 #include "drake/multibody/parsing/parser.h"
 
 #include <optional>
+#include <set>
 
 #include "drake/common/filesystem.h"
 #include "drake/multibody/parsing/detail_collision_filter_group_resolver.h"
 #include "drake/multibody/parsing/detail_common.h"
+#include "drake/multibody/parsing/detail_composite_parse.h"
 #include "drake/multibody/parsing/detail_parsing_workspace.h"
 #include "drake/multibody/parsing/detail_sdf_parser.h"
 #include "drake/multibody/parsing/detail_urdf_parser.h"
@@ -60,10 +62,17 @@ FileType DetermineFileType(const std::string& file_name) {
 
 std::vector<ModelInstanceIndex> Parser::AddAllModelsFromFile(
     const std::string& file_name) {
+  return CompositeAddAllModelsFromFile(file_name, {});
+}
+
+std::vector<ModelInstanceIndex> Parser::CompositeAddAllModelsFromFile(
+    const std::string& file_name,
+    internal::CompositeParse* composite) {
   DataSource data_source(DataSource::kFilename, &file_name);
   CollisionFilterGroupResolver resolver{plant_};
-  ParsingWorkspace workspace{package_map_, diagnostic_policy_, plant_,
-                             &resolver};
+  ParsingWorkspace workspace{
+    package_map_, diagnostic_policy_, plant_,
+    composite ? &composite->collision_resolver() : &resolver};
   const FileType type = DetermineFileType(file_name);
   std::vector<ModelInstanceIndex> result;
   if (type == FileType::kSdf) {
@@ -78,17 +87,25 @@ std::vector<ModelInstanceIndex> Parser::AddAllModelsFromFile(
           fmt::format("{}: URDF model file parsing failed", file_name));
     }
   }
-  resolver.Resolve(diagnostic_policy_);
+  if (!composite) { resolver.Resolve(diagnostic_policy_); }
   return result;
 }
 
 ModelInstanceIndex Parser::AddModelFromFile(
     const std::string& file_name,
     const std::string& model_name) {
+  return CompositeAddModelFromFile(file_name, model_name, {});
+}
+
+ModelInstanceIndex Parser::CompositeAddModelFromFile(
+    const std::string& file_name,
+    const std::string& model_name,
+    internal::CompositeParse* composite) {
   DataSource data_source(DataSource::kFilename, &file_name);
   CollisionFilterGroupResolver resolver{plant_};
-  ParsingWorkspace workspace{package_map_, diagnostic_policy_, plant_,
-                             &resolver};
+  ParsingWorkspace workspace{
+    package_map_, diagnostic_policy_, plant_,
+    composite ? &composite->collision_resolver() : &resolver};
   const FileType type = DetermineFileType(file_name);
   std::optional<ModelInstanceIndex> maybe_model;
   if (type == FileType::kSdf) {
@@ -100,7 +117,7 @@ ModelInstanceIndex Parser::AddModelFromFile(
     throw std::runtime_error(
         fmt::format("{}: parsing failed", file_name));
   }
-  resolver.Resolve(diagnostic_policy_);
+  if (!composite) { resolver.Resolve(diagnostic_policy_); }
   return *maybe_model;
 }
 
@@ -108,11 +125,20 @@ ModelInstanceIndex Parser::AddModelFromString(
     const std::string& file_contents,
     const std::string& file_type,
     const std::string& model_name) {
+  return CompositeAddModelFromString(file_contents, file_type, model_name, {});
+}
+
+ModelInstanceIndex Parser::CompositeAddModelFromString(
+    const std::string& file_contents,
+    const std::string& file_type,
+    const std::string& model_name,
+    internal::CompositeParse* composite) {
   DataSource data_source(DataSource::kContents, &file_contents);
   const std::string pseudo_name(data_source.GetStem() + "." + file_type);
   CollisionFilterGroupResolver resolver{plant_};
-  ParsingWorkspace workspace{package_map_, diagnostic_policy_, plant_,
-                             &resolver};
+  ParsingWorkspace workspace{
+    package_map_, diagnostic_policy_, plant_,
+    composite ? &composite->collision_resolver() : &resolver};
   const FileType type = DetermineFileType(pseudo_name);
   std::optional<ModelInstanceIndex> maybe_model;
   if (type == FileType::kSdf) {
@@ -124,7 +150,7 @@ ModelInstanceIndex Parser::AddModelFromString(
     throw std::runtime_error(
         fmt::format("{}: parsing failed", pseudo_name));
   }
-  resolver.Resolve(diagnostic_policy_);
+  if (!composite) { resolver.Resolve(diagnostic_policy_); }
   return *maybe_model;
 }
 

--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -11,6 +11,10 @@
 namespace drake {
 namespace multibody {
 
+namespace internal {
+class CompositeParse;
+}  // namespace internal
+
 /// Parses SDF and URDF input files into a MultibodyPlant and (optionally) a
 /// SceneGraph. For documentation of Drake-specific extensions and limitations,
 /// see @ref multibody_parsing.
@@ -96,6 +100,23 @@ class Parser final {
       const std::string& model_name = {});
 
  private:
+  friend class internal::CompositeParse;
+
+  std::vector<ModelInstanceIndex> CompositeAddAllModelsFromFile(
+      const std::string& file_name,
+      internal::CompositeParse* composite);
+
+  ModelInstanceIndex CompositeAddModelFromFile(
+      const std::string& file_name,
+      const std::string& model_name,
+      internal::CompositeParse* composite);
+
+  ModelInstanceIndex CompositeAddModelFromString(
+      const std::string& file_contents,
+      const std::string& file_type,
+      const std::string& model_name,
+      internal::CompositeParse* composite);
+
   bool is_strict_{false};
   PackageMap package_map_;
   drake::internal::DiagnosticPolicy diagnostic_policy_;

--- a/multibody/parsing/process_model_directives.cc
+++ b/multibody/parsing/process_model_directives.cc
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <optional>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -10,6 +11,8 @@
 #include "drake/common/find_resource.h"
 #include "drake/common/schema/transform.h"
 #include "drake/common/yaml/yaml_io.h"
+#include "drake/multibody/parsing/detail_collision_filter_group_resolver.h"
+#include "drake/multibody/parsing/detail_composite_parse.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/parsing/scoped_names.h"
 
@@ -24,6 +27,8 @@ using drake::FindResourceOrThrow;
 using drake::math::RigidTransformd;
 using drake::multibody::FixedOffsetFrame;
 using drake::multibody::Frame;
+using drake::multibody::internal::CollisionFilterGroupResolver;
+using drake::multibody::internal::CompositeParse;
 using drake::multibody::ModelInstanceIndex;
 using drake::multibody::MultibodyPlant;
 using drake::multibody::PackageMap;
@@ -75,6 +80,7 @@ void AddWeld(
 void ProcessModelDirectivesImpl(
     const ModelDirectives& directives, MultibodyPlant<double>* plant,
     std::vector<ModelInstanceInfo>* added_models, Parser* parser,
+    CompositeParse* composite,
     const std::string& model_namespace) {
   drake::log()->debug("ProcessModelDirectives(MultibodyPlant)");
   DRAKE_DEMAND(plant != nullptr);
@@ -99,7 +105,7 @@ void ProcessModelDirectivesImpl(
       const std::string file =
           ResolveModelDirectiveUri(model.file, parser->package_map());
       drake::multibody::ModelInstanceIndex child_model_instance_id =
-          parser->AddModelFromFile(file, name);
+          composite->AddModelFromFile(file, name);
       info.model_instance = child_model_instance_id;
       info.model_name = name;
       info.model_path = file;
@@ -140,6 +146,27 @@ void ProcessModelDirectivesImpl(
           get_scoped_frame(directive.add_weld->child),
           plant, added_models);
 
+    } else if (directive.add_collision_filter_group) {
+      // Find the model instance index that corresponds to model_namespace, if
+      // the name is non-empty.
+      std::optional<ModelInstanceIndex> model_instance;
+      if (!model_namespace.empty()) {
+        DRAKE_DEMAND(plant->HasModelInstanceNamed(model_namespace));
+        model_instance = plant->GetModelInstanceByName(model_namespace);
+      }
+
+      auto& resolver = composite->collision_resolver();
+      auto& group = *directive.add_collision_filter_group;
+      drake::log()->debug("  add_collision_filter_group: {}", group.name);
+      std::set<std::string> member_set(group.members.begin(),
+                                       group.members.end());
+      // TODO(rpoyner-tri) obey parser policy? Improve error location clues?
+      drake::internal::DiagnosticPolicy d;
+      resolver.AddGroup(d, group.name, member_set, model_instance);
+      for (const auto& ignored_group : group.ignored_collision_filter_groups) {
+        resolver.AddPair(d, group.name, ignored_group, model_instance);
+      }
+
     } else {
       // Recurse.
       auto& sub = *directive.add_directives;
@@ -157,8 +184,8 @@ void ProcessModelDirectivesImpl(
       auto sub_directives =
           LoadModelDirectives(
               ResolveModelDirectiveUri(sub.file, parser->package_map()));
-      ProcessModelDirectivesImpl(
-          sub_directives, plant, added_models, parser, new_model_namespace);
+      ProcessModelDirectivesImpl(sub_directives, plant, added_models, parser,
+                                 composite, new_model_namespace);
     }
   }
 }
@@ -204,11 +231,12 @@ void ProcessModelDirectives(
     std::vector<ModelInstanceInfo>* added_models,
     drake::multibody::Parser* parser) {
   auto tmp_parser = ConstructIfNullAndReassign<Parser>(&parser, plant);
+  auto composite = CompositeParse::MakeCompositeParse(parser);
   auto tmp_added_model =
       ConstructIfNullAndReassign<std::vector<ModelInstanceInfo>>(&added_models);
   const std::string model_namespace = "";
-  ProcessModelDirectivesImpl(
-      directives, plant, added_models, parser, model_namespace);
+  ProcessModelDirectivesImpl(directives, plant, added_models, parser,
+                             composite.get(), model_namespace);
 }
 
 ModelDirectives LoadModelDirectives(const std::string& filename) {

--- a/multibody/parsing/test/model_directives_test.cc
+++ b/multibody/parsing/test/model_directives_test.cc
@@ -38,6 +38,10 @@ directives:
 - add_directives:
     file: child.yaml
     model_namespace: right
+- add_collision_filter_group:
+    name: group1
+    members: [new_model::link, right::robot::link]
+    ignored_collision_filter_groups: [group1, right::robot::group]
 )""";
   const auto directives = LoadYamlString<ModelDirectives>(contents);
   EXPECT_TRUE(directives.IsValid());

--- a/multibody/parsing/test/process_model_directives_test.cc
+++ b/multibody/parsing/test/process_model_directives_test.cc
@@ -19,6 +19,7 @@ namespace {
 
 using std::optional;
 using Eigen::Vector3d;
+using drake::geometry::GeometryId;
 using drake::math::RigidTransformd;
 using drake::multibody::AddMultibodyPlantSceneGraph;
 using drake::multibody::Frame;
@@ -37,6 +38,35 @@ std::unique_ptr<Parser> make_parser(MultibodyPlant<double>* plant) {
       std::string(kTestDir) + "/package.xml");
   parser->package_map().AddPackageXml(abspath_xml.string());
   return parser;
+}
+
+using CollisionPair = SortedPair<std::string>;
+void VerifyCollisionFilters(
+    const geometry::SceneGraph<double>& scene_graph,
+    const std::set<CollisionPair>& expected_filters) {
+  const auto& inspector = scene_graph.model_inspector();
+  // Get the collision geometry ids.
+  const std::vector<GeometryId> all_ids = inspector.GetAllGeometryIds();
+  geometry::GeometrySet id_set(all_ids);
+  auto collision_id_set = inspector.GetGeometryIds(
+      id_set, geometry::Role::kProximity);
+  std::vector<GeometryId> ids(collision_id_set.begin(),
+                              collision_id_set.end());
+  const int num_links = ids.size();
+  for (int m = 0; m < num_links; ++m) {
+    const std::string& m_name = inspector.GetName(ids[m]);
+    for (int n = m + 1; n < num_links; ++n) {
+      const std::string& n_name = inspector.GetName(ids[n]);
+      CollisionPair names{m_name, n_name};
+      SCOPED_TRACE(fmt::format("{} vs {}", names.first(), names.second()));
+      auto contains =
+          [&expected_filters](const CollisionPair& key) {
+            return expected_filters.count(key) > 0;
+          };
+      EXPECT_EQ(inspector.CollisionFiltered(ids[m], ids[n]),
+                contains(names));
+    }
+  }
 }
 
 // Simple smoke test of the most basic model directives.
@@ -194,6 +224,38 @@ GTEST_TEST(ProcessModelDirectivesTest, InjectFrames) {
       .CalcPoseInWorld(*context)
       .translation()
       .isApprox(Vector3d(2, 4, 6)));
+}
+
+// Test collision filter groups in ModelDirectives.
+GTEST_TEST(ProcessModelDirectivesTest, CollisionFilterGroupSmokeTest) {
+  ModelDirectives directives = LoadModelDirectives(
+      FindResourceOrThrow(std::string(kTestDir) +
+                          "/collision_filter_group.yaml"));
+
+  // Ensure that we have a SceneGraph present so that we test relevant visual
+  // pieces.
+  DiagramBuilder<double> builder;
+  auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.);
+  ProcessModelDirectives(directives, &plant,
+                         nullptr, make_parser(&plant).get());
+
+  // Make sure the plant is not finalized such that the Finalize() default
+  // filtering has not taken into effect yet. This guarantees that the
+  // collision filtering is applied due to the collision filter group parsing.
+  ASSERT_FALSE(plant.is_finalized());
+
+  std::set<CollisionPair> expected_filters = {
+    // From group 'across_models'.
+    {"model1::collision",             "model2::collision"},
+    // From group 'nested_members'.
+    {"model1::collision",             "nested::sub_model2::collision"},
+    // From group 'nested_group'.
+    {"model3::collision",             "nested::sub_model1::collision"},
+    {"model3::collision",             "nested::sub_model2::collision"},
+    // From group 'across_sub_models'.
+    {"nested::sub_model1::collision", "nested::sub_model2::collision"},
+  };
+  VerifyCollisionFilters(scene_graph, expected_filters);
 }
 
 // Make sure we have good error messages.

--- a/multibody/parsing/test/process_model_directives_test/collision_filter_group.yaml
+++ b/multibody/parsing/test/process_model_directives_test/collision_filter_group.yaml
@@ -1,0 +1,38 @@
+directives:
+
+- add_model:
+    name: model1
+    file: package://process_model_directives_test/simple_model.sdf
+
+- add_model:
+    name: model2
+    file: package://process_model_directives_test/simple_model.sdf
+
+# Make a collision filter group across bodies from different models.
+- add_collision_filter_group:
+    name: across_models
+    members: [model1::base, model2::base]
+    ignored_collision_filter_groups: [across_models]
+
+- add_model_instance:
+    name: nested
+- add_directives:
+    file: package://process_model_directives_test/sub_collision.yaml
+    model_namespace: nested
+
+# Make a group with members from different nested directive levels.
+- add_collision_filter_group:
+    name: nested_members
+    members: [model1::base, nested::sub_model2::base]
+    ignored_collision_filter_groups: [nested_members]
+
+- add_model:
+    name: model3
+    file: package://process_model_directives_test/simple_model.sdf
+
+# Make a group with ignored groups from different nested directive levels.
+- add_collision_filter_group:
+    name: nested_group
+    members: [model3::base]
+    ignored_collision_filter_groups: [nested::across_sub_models]
+

--- a/multibody/parsing/test/process_model_directives_test/simple_model.sdf
+++ b/multibody/parsing/test/process_model_directives_test/simple_model.sdf
@@ -5,6 +5,13 @@
       <inertial>
         <mass>1</mass>
       </inertial>
+      <collision name="collision">
+        <geometry>
+          <box>
+            <size>0.2 0.2 2.2</size>
+          </box>
+        </geometry>
+      </collision>
       <visual name="visual">
         <geometry>
           <box>

--- a/multibody/parsing/test/process_model_directives_test/sub_collision.yaml
+++ b/multibody/parsing/test/process_model_directives_test/sub_collision.yaml
@@ -1,0 +1,20 @@
+directives:
+
+- add_model:
+    name: sub_model1
+    file: package://process_model_directives_test/simple_model.sdf
+
+- add_model:
+    name: sub_model2
+    file: package://process_model_directives_test/simple_model.sdf
+
+# This model does not participate in any collision filters.
+- add_model:
+    name: sub_model3
+    file: package://process_model_directives_test/simple_model.sdf
+
+- add_collision_filter_group:
+    name: across_sub_models
+    members: [sub_model1::base, sub_model2::base]
+    ignored_collision_filter_groups: [across_sub_models]
+


### PR DESCRIPTION
Closes: #17242

Define a new directive for collision filters (equivalent to current XML
formats), and enable multi-model collision filter processing in
ProcessModelDirectives.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17270)
<!-- Reviewable:end -->
