### PR TITLE
[workspace] Remove msgpack boost dependency

### DIFF
--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -32,6 +32,10 @@
 #include "drake/common/unused.h"
 #include "drake/geometry/meshcat_types.h"
 
+#ifdef BOOST_VERSION
+# error Drake should be using the non-boost flavor of msgpack.
+#endif
+
 // Steal one function declaration from usockets/src/internal/internal.h.
 extern "C" {
 void us_internal_free_closed_sockets(struct us_loop_t*);

--- a/tools/workspace/msgpack/repository.bzl
+++ b/tools/workspace/msgpack/repository.bzl
@@ -28,7 +28,10 @@ def _impl(repo_ctx):
         prefix = "{}/opt/msgpack-cxx/".format(os_result.homebrew_prefix)
         repo_ctx.symlink("{}/include".format(prefix), "msgpack")
 
-        hdrs_patterns = ["msgpack/**/*.hpp"]
+        hdrs_patterns = [
+            "msgpack/**/*.h",
+            "msgpack/**/*.hpp",
+        ]
 
         file_content = """# -*- python -*-
 
@@ -40,9 +43,8 @@ cc_library(
     name = "msgpack",
     hdrs = glob({}),
     includes = ["msgpack"],
+    defines = ["MSGPACK_NO_BOOST"],
     visibility = ["//visibility:public"],
-    deps = ["@boost//:boost_headers"],
-
 )
     """.format(hdrs_patterns)
 


### PR DESCRIPTION
Fixes an unwanted dependency added in #15694.  After this, we can finally deprecate and remove our dependency on Boost.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17286)
<!-- Reviewable:end -->
