### PR TITLE
[workspace] Install libpython for consumers

### DIFF
--- a/setup/ubuntu/binary_distribution/packages-focal.txt
+++ b/setup/ubuntu/binary_distribution/packages-focal.txt
@@ -32,6 +32,7 @@ libnlopt-cxx0
 libogg0
 libopengl0
 libpng16-16
+libpython3.8
 libqt5core5a
 libqt5gui5
 libqt5printsupport5


### PR DESCRIPTION
Relates: #17161.

If consumers do a tar or deb install with --no-install-recommends
they will not be able to run the python code without libpython.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17294)
<!-- Reviewable:end -->
