### PR TITLE
[examples] Update manipulation station end_effector mouse Meshcat

### DIFF
--- a/examples/manipulation_station/end_effector_teleop_mouse.py
+++ b/examples/manipulation_station/end_effector_teleop_mouse.py
@@ -1,21 +1,20 @@
 import argparse
 import os
 import sys
+import webbrowser
 
 import numpy as np
 
 from pydrake.examples.manipulation_station import (
     ManipulationStation, ManipulationStationHardwareInterface,
     CreateClutterClearingYcbObjectList, SchunkCollisionModel)
-from pydrake.geometry import DrakeVisualizer
+from pydrake.geometry import DrakeVisualizer, Meshcat, MeshcatVisualizerCpp
 from pydrake.multibody.plant import MultibodyPlant
 from pydrake.manipulation.planner import (
     DifferentialInverseKinematicsParameters)
 from pydrake.math import RigidTransform, RollPitchYaw, RotationMatrix
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import DiagramBuilder, LeafSystem
-from pydrake.systems.meshcat_visualizer import (
-    ConnectMeshcatVisualizer, MeshcatVisualizer)
 from pydrake.systems.primitives import FirstOrderLowPassFilter
 
 from drake.examples.manipulation_station.differential_ik import DifferentialIK
@@ -275,8 +274,13 @@ def main():
         '--schunk_collision_model', type=str, default='box',
         help="The Schunk collision model to use for simulation. ",
         choices=['box', 'box_plus_fingertip_spheres'])
-
-    MeshcatVisualizer.add_argparse_argument(parser)
+    parser.add_argument(
+        "--meshcat", action="store_true", default=False,
+        help="Enable visualization with meshcat.")
+    parser.add_argument(
+        "-w", "--open-window", dest="browser_new",
+        action="store_const", const=1, default=None,
+        help="Open the MeshCat display in a new browser window.")
     args = parser.parse_args()
 
     if args.test:
@@ -317,14 +321,22 @@ def main():
                 station.AddManipulandFromFile(model_file, X_WObject)
 
         station.Finalize()
-        DrakeVisualizer.AddToBuilder(builder,
-                                     station.GetOutputPort("query_object"))
+        query_port = station.GetOutputPort("query_object")
+
+        DrakeVisualizer.AddToBuilder(builder, query_port)
         if args.meshcat:
-            meshcat = ConnectMeshcatVisualizer(
-                builder, output_port=station.GetOutputPort("geometry_query"),
-                zmq_url=args.meshcat, open_browser=args.open_browser)
+            meshcat = Meshcat()
+            meshcat_visualizer = MeshcatVisualizerCpp.AddToBuilder(
+                builder=builder,
+                query_object_port=query_port,
+                meshcat=meshcat)
+
             if args.setup == 'planar':
-                meshcat.set_planar_viewpoint()
+                meshcat.Set2dRenderMode()
+
+            if args.browser_new is not None:
+                url = meshcat.web_url()
+                webbrowser.open(url=url, new=args.browser_new)
 
     robot = station.get_controller_plant()
     params = DifferentialInverseKinematicsParameters(robot.num_positions(),


### PR DESCRIPTION
- Use C++ bound `pydrake.geometry.Meshcat` over the deprecated pure python Meshcat interface.
- Meshcat argument `--open_browser` is now `-w` or `--open-window` for consistency with the other examples.
- Meshcat argument `--meshcat` requests the meshcat interface, previous options related to ZMQ url etc are no longer available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17298)
<!-- Reviewable:end -->
