### PR TITLE
[multibody] Add an inverse kinematics benchmark

### DIFF
--- a/multibody/benchmarking/BUILD.bazel
+++ b/multibody/benchmarking/BUILD.bazel
@@ -1,0 +1,27 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/performance:defs.bzl",
+    "drake_cc_googlebench_binary",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+drake_cc_googlebench_binary(
+    name = "iiwa_relaxed_pos_ik",
+    srcs = ["iiwa_relaxed_pos_ik.cc"],
+    data = [
+        "//manipulation/models/iiwa_description:models",
+    ],
+    deps = [
+        "//common:find_resource",
+        "//multibody/inverse_kinematics",
+        "//multibody/parsing",
+        "//solvers:snopt_solver",
+        "//solvers:solve",
+        "//tools/performance:fixture_common",
+    ],
+)
+
+add_lint_tests()

--- a/multibody/benchmarking/iiwa_relaxed_pos_ik.cc
+++ b/multibody/benchmarking/iiwa_relaxed_pos_ik.cc
@@ -1,0 +1,139 @@
+// @file
+// Benchmark for InverseKinematics.
+//
+// This benchmark is intended to analyze the performance of nonlinear
+// optimization with position constraints.
+
+#include "drake/common/find_resource.h"
+#include "drake/multibody/inverse_kinematics/inverse_kinematics.h"
+#include "drake/multibody/inverse_kinematics/position_constraint.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/solvers/snopt_solver.h"
+#include "drake/solvers/solve.h"
+#include "drake/tools/performance/fixture_common.h"
+
+namespace drake {
+namespace multibody {
+namespace inverse_kinematics {
+namespace {
+
+class RelaxedPosIkBenchmark : public benchmark::Fixture {
+ public:
+  RelaxedPosIkBenchmark() {
+    tools::performance::AddMinMaxStatistics(this);
+
+    // Set a fixed seed for random generation.
+    std::srand(1234);
+  }
+};
+
+BENCHMARK_F(RelaxedPosIkBenchmark, Iiwa)(benchmark::State& state) {  // NOLINT
+  // Solve an inverse kinematics problem for Kuka iiwa considering only the
+  // translation component with relaxation. The objective of this benchmark is
+  // to run an A/B comparison for different gradient evaluations for
+  // position constraints when solving a nonlinear program.
+
+  // Define constants.
+  // A uniform relaxation for end-effector position.
+  const Eigen::Vector3d kPosTol = 1e-4 * Eigen::Vector3d::Ones();
+  // The number of random goals.
+  const int kNumRandGoals = 10;
+  // The number of random initial guesses for each goal.
+  const int kNumRandInitGuess = 3;
+  // The percentage of joint range to be used for goal pose generation.
+  const double kLimitedJointRange = 0.9;
+  // The tolerance for constraint satisfaction check.
+  const double kConstraintTol = 1e-5;
+
+  // Find the model file for Kuka iiwa.
+  const std::string iiwa_path = FindResourceOrThrow(
+      "drake/manipulation/models/iiwa_description/iiwa7/"
+      "iiwa7_no_collision.sdf");
+  // Create a continuous-time plant.
+  multibody::MultibodyPlant<double> plant(0.0);
+  // Create a parser for the plant.
+  multibody::Parser parser{&plant};
+  // Load the model into the parser.
+  const multibody::ModelInstanceIndex model_instance =
+      parser.AddModelFromFile(iiwa_path);
+  // Attach the base of the robot into the world frame.
+  plant.WeldFrames(plant.world_frame(),
+                   plant.GetFrameByName("iiwa_link_0", model_instance));
+  // Finalize the plant.
+  plant.Finalize();
+  // Create a context.
+  std::unique_ptr<systems::Context<double>> context =
+      plant.CreateDefaultContext();
+
+  // Define the end-effector link and get the corresponding body and frame.
+  const std::string ee_link_name = "iiwa_link_7";
+  const multibody::Body<double>& ee_body = plant.GetBodyByName(ee_link_name);
+  const multibody::Frame<double>& ee_frame = plant.GetFrameByName(ee_link_name);
+
+  // Create an IK object and get its mathetical program.
+  multibody::InverseKinematics relaxed_ik(plant, true);
+  solvers::MathematicalProgram* prog = relaxed_ik.get_mutable_prog();
+
+  // Get the joint position limits for random generation by leveraging the
+  // fact that iiwa has symmetric position limits.
+  const Eigen::VectorXd joint_pos_limits(plant.GetPositionUpperLimits());
+  // Generate random goal configurations.
+  std::vector<math::RigidTransformd> ee_pose_goal(kNumRandGoals);
+  for (int i = 0; i < kNumRandGoals; ++i) {
+    // Sample a random joint pose within a limited range since the solvers tend
+    // to fail when the goal is close to a boundary.
+    context->get_mutable_continuous_state()
+        .get_mutable_generalized_position()
+        .SetFromVector(
+            Eigen::VectorXd::Random(plant.num_positions())
+                .cwiseProduct(kLimitedJointRange * joint_pos_limits));
+    // Evaluate the corresponding end-effector pose.
+    ee_pose_goal[i] = plant.EvalBodyPoseInWorld(*context, ee_body);
+  }
+
+  // Sample random initial guesses assuming that the range [-1, 1] rad
+  // does not violate any of the joint position limits.
+  const Eigen::MatrixXd q0(
+      Eigen::MatrixXd::Random(plant.num_positions(), kNumRandInitGuess));
+
+  // Create the task in terms of position constraints on the end effector.
+  auto pos_constraint = std::make_shared<PositionConstraint>(
+      &plant, plant.world_frame(), -kPosTol, kPosTol, ee_frame,
+      Eigen::Vector3d::Zero(), context.get());
+  prog->AddConstraint(pos_constraint, relaxed_ik.q());
+
+  for (auto _ : state) {
+    // Solve the problem for each goal and initial guess.
+    for (int i = 0; i < kNumRandGoals; ++i) {
+      // Update the task constraint.
+      pos_constraint->set_bounds(ee_pose_goal[i].translation() - kPosTol,
+                                 ee_pose_goal[i].translation() + kPosTol);
+
+      for (int j = 0; j < kNumRandInitGuess; ++j) {
+        // Set the initial guess.
+        prog->SetInitialGuess(relaxed_ik.q(), q0.col(j));
+
+        // Solve the problem.
+        auto result = solvers::Solve(*prog);
+
+        // Confirm that the optimization has succeeded.
+        // This is done only for SNOPT b/c IPOPT exceeds the maximum number of
+        // iterations in a few cases while still meeting the task constraints.
+        if (result.get_solver_id() == solvers::SnoptSolver::id())
+          DRAKE_DEMAND(result.is_success());
+
+        // Check whether the task constraint is met by providing extra margin to
+        // account for solver tolerances.
+        DRAKE_DEMAND(pos_constraint->CheckSatisfied(result.GetSolution(),
+                                                    kConstraintTol));
+      }
+    }
+  }
+}
+
+}  // namespace
+}  // namespace inverse_kinematics
+}  // namespace multibody
+}  // namespace drake
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
- Adds an inverse kinematics benchmark to probe nonlinear programming performance with relaxed position constraints
- Aims to evaluate the impact of the analytical gradients proposed in https://reviewable.io/reviews/robotlocomotion/drake/16635 (i.e., only for position constraints and SNOPT)
- **Local** A/B results for running the benchmark using SNOPT (applying the changes with respect to https://github.com/RobotLocomotion/drake/commit/c37e81cb0ce85d5366d0bb88243d1b36e851e667, i.e., w/o rebasing w/ the latest master):
```
-------------------------------------------------------------------------------------
Derivative           Time            CPU            Iterations
-------------------------------------------------------------------------------------
AlgoDiff          23404360 ns     23393464 ns            32
Analytical        22090807 ns     22084137 ns            34
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17299)
<!-- Reviewable:end -->
