### PR TITLE
Implement macos_wheel platform

### DIFF
--- a/tools/wheel/image/build-dependencies.sh
+++ b/tools/wheel/image/build-dependencies.sh
@@ -11,7 +11,4 @@ cmake -G Ninja \
 
 ninja
 
-ln -s /opt/drake-dependencies/lib/pkgconfig /usr/local/lib
-ln -s /opt/drake-dependencies/share/pkgconfig /usr/local/share
-
 ln -s /opt/drake-dependencies/bin/patchelf /usr/local/bin/patchelf

--- a/tools/workspace/boost/repository.bzl
+++ b/tools/workspace/boost/repository.bzl
@@ -35,7 +35,7 @@ def _impl(repository_ctx):
     os_result = determine_os(repository_ctx)
     if os_result.error != None:
         fail(os_result.error)
-    elif os_result.is_macos:
+    elif os_result.is_macos or os_result.is_macos_wheel:
         prefix = "{}/opt/boost".format(os_result.homebrew_prefix)
     elif os_result.is_ubuntu or os_result.is_manylinux:
         prefix = "/usr"

--- a/tools/workspace/double_conversion/repository.bzl
+++ b/tools/workspace/double_conversion/repository.bzl
@@ -24,7 +24,7 @@ def _impl(repository_ctx):
             "/usr/include/double-conversion",
             "include/double-conversion",
         )
-    elif os_result.is_manylinux:
+    elif os_result.is_manylinux or os_result.is_macos_wheel:
         libdir = "/opt/drake-dependencies/lib"
         repository_ctx.symlink(
             "/opt/drake-dependencies/include/double-conversion",

--- a/tools/workspace/fmt/repository.bzl
+++ b/tools/workspace/fmt/repository.bzl
@@ -17,7 +17,7 @@ def _impl(repo_ctx):
     if os_result.is_macos:
         # On macOS, we use fmt from homebrew via pkg-config.
         error = setup_pkg_config_repository(repo_ctx).error
-    elif os_result.is_manylinux:
+    elif os_result.is_manylinux or os_result.is_macos_wheel:
         # Compile from downloaded github sources.
         error = setup_github_repository(repo_ctx).error
     elif os_result.ubuntu_release == "20.04":

--- a/tools/workspace/gfortran/repository.bzl
+++ b/tools/workspace/gfortran/repository.bzl
@@ -30,7 +30,7 @@ def _gfortran_impl(repo_ctx):
     os_result = determine_os(repo_ctx)
     if os_result.error != None:
         fail(os_result.error)
-    if os_result.is_macos:
+    if os_result.is_macos or os_result.is_macos_wheel:
         suffix = ".dylib"
     else:
         suffix = ".so"
@@ -38,7 +38,7 @@ def _gfortran_impl(repo_ctx):
     libgfortran_path = _find_library(repo_ctx, compiler, libgfortran)
 
     # The cc_library linking is different on Ubuntu vs macOS.
-    if os_result.is_macos:
+    if os_result.is_macos or os_result.is_macos_wheel:
         srcs = []
         linkopts = [
             "-L{}".format(repo_ctx.path(libgfortran_path).dirname),

--- a/tools/workspace/libjpeg/repository.bzl
+++ b/tools/workspace/libjpeg/repository.bzl
@@ -16,7 +16,7 @@ def _impl(repository_ctx):
             "{}/opt/jpeg/include".format(os_result.homebrew_prefix),
             "include",
         )
-    elif os_result.is_manylinux:
+    elif os_result.is_manylinux or os_result.is_macos_wheel:
         libdir = "/opt/drake-dependencies/lib"
         for hdr in noarch_hdrs + ["jconfig.h"]:
             repository_ctx.symlink(

--- a/tools/workspace/nlopt/repository.bzl
+++ b/tools/workspace/nlopt/repository.bzl
@@ -8,7 +8,7 @@ def _impl(repository_ctx):
     if os_result.error != None:
         fail(os_result.error)
 
-    if os_result.is_macos:
+    if os_result.is_macos or os_result.is_macos_wheel:
         build_flavor = "macos"
         repository_ctx.symlink(
             "{}/opt/nlopt/include/nlopt.h".format(os_result.homebrew_prefix),

--- a/tools/workspace/openblas/repository.bzl
+++ b/tools/workspace/openblas/repository.bzl
@@ -21,7 +21,7 @@ def _impl(repo_ctx):
     os_result = determine_os(repo_ctx)
     if os_result.error != None:
         fail(os_result.error)
-    if os_result.is_macos:
+    if os_result.is_macos or os_result.is_macos_wheel:
         error = setup_pkg_config_repository(repo_ctx).error
         if error != None:
             fail(error)

--- a/tools/workspace/opengl/repository.bzl
+++ b/tools/workspace/opengl/repository.bzl
@@ -8,7 +8,7 @@ def _impl(repository_ctx):
     if os_result.error != None:
         fail(os_result.error)
 
-    if os_result.is_macos:
+    if os_result.is_macos or os_result.is_macos_wheel:
         repository_ctx.symlink(
             Label("@drake//tools/workspace/opengl:package-macos.BUILD.bazel"),
             "BUILD.bazel",

--- a/tools/workspace/pkg_config.bzl
+++ b/tools/workspace/pkg_config.bzl
@@ -52,18 +52,25 @@ def setup_pkg_config_repository(repository_ctx):
         [],
     ))
 
-    # Find the desired homebrew search path, if any.
-    homebrew_prefix = determine_os(repository_ctx).homebrew_prefix
-    homebrew_subdir = getattr(
-        repository_ctx.attr,
-        "homebrew_subdir",
-        "",
-    )
-    if homebrew_prefix and homebrew_subdir:
-        pkg_config_paths.insert(0, "{}/{}".format(
-            homebrew_prefix,
-            homebrew_subdir,
-        ))
+    os_result = determine_os(repository_ctx)
+
+    if os_result.is_macos or os_result.is_macos_wheel:
+        # Find the desired homebrew search path, if any.
+        homebrew_prefix = os_result.homebrew_prefix
+        homebrew_subdir = getattr(
+            repository_ctx.attr,
+            "homebrew_subdir",
+            "",
+        )
+        if homebrew_prefix and homebrew_subdir:
+            pkg_config_paths.insert(0, "{}/{}".format(
+                homebrew_prefix,
+                homebrew_subdir,
+            ))
+
+    if os_result.is_manylinux or os_result.is_macos_wheel:
+        pkg_config_paths.insert(0, "/opt/drake-dependencies/share/pkgconfig")
+        pkg_config_paths.insert(0, "/opt/drake-dependencies/lib/pkgconfig")
 
     # Check if we can find the required *.pc file of any version.
     result = _run_pkg_config(repository_ctx, args, pkg_config_paths)

--- a/tools/workspace/python/repository.bzl
+++ b/tools/workspace/python/repository.bzl
@@ -50,6 +50,7 @@ load("@drake//tools/workspace:os.bzl", "determine_os")
 _VERSION_SUPPORT_MATRIX = {
     "ubuntu:20.04": ["3.8"],
     "macos": ["3.9"],
+    "macos_wheel": ["3.9"],
     "manylinux": ["3.8", "3.9"],
 }
 
@@ -69,7 +70,7 @@ def repository_python_info(repository_ctx):
         os_key += ":" + os_result.ubuntu_release
     versions_supported = _VERSION_SUPPORT_MATRIX[os_key]
 
-    if os_result.is_macos:
+    if os_result.is_macos or os_result.is_macos_wheel:
         # This value must match the interpreter_path in
         # @drake//tools/py_toolchain:macos_py3_runtime
         python = repository_ctx.attr.macos_interpreter_path

--- a/tools/workspace/snopt/repository.bzl
+++ b/tools/workspace/snopt/repository.bzl
@@ -198,7 +198,7 @@ def _impl(repo_ctx):
             Label("@drake//tools/workspace/snopt:fortran-ubuntu.bzl"),
             "fortran.bzl",
         )
-    elif os_result.is_macos:
+    elif os_result.is_macos or os_result.is_macos_wheel:
         repo_ctx.symlink(
             Label("@drake//tools/workspace/snopt:fortran-macos.bzl"),
             "fortran.bzl",

--- a/tools/workspace/spdlog/repository.bzl
+++ b/tools/workspace/spdlog/repository.bzl
@@ -17,7 +17,7 @@ def _impl(repo_ctx):
     if os_result.is_macos:
         # On macOS, we use spdlog from homebrew via pkg-config.
         error = setup_pkg_config_repository(repo_ctx).error
-    elif os_result.is_manylinux:
+    elif os_result.is_manylinux or os_result.is_macos_wheel:
         # Compile it from downloaded github sources.
         error = setup_github_repository(repo_ctx).error
     else:

--- a/tools/workspace/suitesparse/repository.bzl
+++ b/tools/workspace/suitesparse/repository.bzl
@@ -20,7 +20,7 @@ def _impl(repo_ctx):
         libdir = "{}/opt/suite-sparse/lib".format(
             os_result.homebrew_prefix,
         )
-    elif os_result.is_manylinux:
+    elif os_result.is_manylinux or os_result.is_macos_wheel:
         # TODO(jwnimmer-tri) Ideally, we wouldn't be hard-coding paths when
         # using manylinux.
         include = "/opt/drake-dependencies/include"


### PR DESCRIPTION
Add support for the recently added "macos_wheel" target/platform. Add ability to override the platform on macOS, which finishes implementing the "macos_wheel" target/platform that was recently introduced. Implement support for the same. This should, with a proper environment, allow Drake to be built in a mode that can be used to produce a wheel.

(Scripts to actually perform such a build, and particularly to establish the aforementioned "proper environment", will be added in subsequent commits.)

Also, explicitly add the pkg-config paths to Bazel's search paths to allow us to find dependencies built for wheels. This is required as we cannot inject these into /usr/local on macOS, as we would in the Ubuntu Docker containers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17301)
<!-- Reviewable:end -->
