### PR TITLE
Add macOS wheel build scripts

### DIFF
--- a/tools/install/BUILD.bazel
+++ b/tools/install/BUILD.bazel
@@ -20,7 +20,7 @@ py_library(
 py_library(
     name = "otool",
     srcs = ["otool.py"],
-    visibility = [":__subpackages__"],
+    visibility = ["//tools:__subpackages__"],
     deps = [":module_py"],
 )
 

--- a/tools/wheel/BUILD.bazel
+++ b/tools/wheel/BUILD.bazel
@@ -19,4 +19,16 @@ drake_py_binary(
     deps = [":module_py"],
 )
 
+drake_py_binary(
+    name = "strip_rpath",
+    srcs = ["macos/strip_rpath.py"],
+    deps = ["//tools/install:otool"],
+)
+
+drake_py_binary(
+    name = "change_lpath",
+    srcs = ["macos/change_lpath.py"],
+    deps = ["//tools/install:otool"],
+)
+
 add_lint_tests()

--- a/tools/wheel/Dockerfile
+++ b/tools/wheel/Dockerfile
@@ -20,13 +20,13 @@ RUN /image/provision-base.sh
 
 FROM base AS incubator
 
-ADD image/dependencies/ /dependencies/src/
+ADD image/dependencies/ /opt/drake-wheel-build/dependencies/src/
 ADD image/build-dependencies.sh /image/
 
 RUN /image/build-dependencies.sh
 
+ADD image/vtk-args /opt/drake-wheel-build/vtk/
 ADD image/build-vtk.sh /image/
-ADD image/vtk-args /vtk/
 
 RUN /image/build-vtk.sh
 
@@ -48,7 +48,7 @@ RUN /image/provision-python.sh ${PYTHON}
 
 ADD image/build-drake.sh /image/
 ADD image/pip-drake.patch /image/
-ADD image/drake-src.tar.xz /drake/
+ADD image/drake-src.tar.xz /opt/drake-wheel-build/drake/
 
 # -----------------------------------------------------------------------------
 # Build the Drake wheel.
@@ -63,7 +63,7 @@ RUN --mount=type=ssh \
     /image/build-drake.sh
 
 ADD image/build-wheel.sh /image/
-ADD image/setup.py /wheel/
+ADD image/setup.py /opt/drake-wheel-build/wheel/
 
 ENV DRAKE_VERSION=${DRAKE_VERSION}
 

--- a/tools/wheel/image/build-dependencies.sh
+++ b/tools/wheel/image/build-dependencies.sh
@@ -1,14 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Internal script to build dependencies for a Drake wheel.
 
 set -eu -o pipefail
 
-mkdir -p /dependencies/build
-cd /dependencies/build
+mkdir -p /opt/drake-wheel-build/dependencies/build
+cd /opt/drake-wheel-build/dependencies/build
 
 cmake -G Ninja \
-  -DCMAKE_INSTALL_PREFIX=/opt/drake-dependencies \
-  /dependencies/src
+    -DCMAKE_INSTALL_PREFIX=/opt/drake-dependencies \
+    /opt/drake-wheel-build/dependencies/src
 
 ninja
 
-ln -s /opt/drake-dependencies/bin/patchelf /usr/local/bin/patchelf
+if [ "$(uname)" == "Linux" ]; then
+    ln -s /opt/drake-dependencies/bin/patchelf /usr/local/bin/patchelf
+fi

--- a/tools/wheel/image/build-drake.sh
+++ b/tools/wheel/image/build-drake.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+# Internal script to build a Drake from which a wheel will be created.
+# Docker (Linux) only.
+
 set -eu -o pipefail
 
-cd /drake
+cd /opt/drake-wheel-build/drake
 
 git apply < /image/pip-drake.patch
 

--- a/tools/wheel/image/build-vtk.sh
+++ b/tools/wheel/image/build-vtk.sh
@@ -1,25 +1,29 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
+# Internal script to build VTK for use in a Drake wheel.
+#
 # NOTE: If you need to update this file, please refer to
 #       tools/workspace/vtk/README for important details.
 
 set -eu -o pipefail
 
+readonly VTK_DIR=/opt/drake-wheel-build/vtk
 readonly VTK_VERSION=9.1.0
 
-mkdir -p /vtk
-cd /vtk
+mkdir -p ${VTK_DIR}
+cd ${VTK_DIR}
 
 git clone \
     --branch v${VTK_VERSION} --depth 1 \
     https://gitlab.kitware.com/vtk/vtk.git src
 
-mkdir -p /vtk/build
-cd /vtk/build
+mkdir -p ${VTK_DIR}/build
+cd ${VTK_DIR}/build
 
-mapfile -t VTK_CMAKE_ARGS < <(sed -e '/^#/d' -e 's/^/-D/' < /vtk/vtk-args)
+mapfile -t VTK_CMAKE_ARGS < \
+    <(sed -e '/^#/d' -e 's/^/-D/' < ${VTK_DIR}/vtk-args)
 
-cmake "${VTK_CMAKE_ARGS[@]}" -GNinja -Wno-dev /vtk/src
+cmake "${VTK_CMAKE_ARGS[@]}" -GNinja -Wno-dev ${VTK_DIR}/src
 
 ninja install/strip
 

--- a/tools/wheel/image/build-wheel.sh
+++ b/tools/wheel/image/build-wheel.sh
@@ -1,48 +1,81 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Internal script to build a wheel from a Drake installation.
 
 set -eu -o pipefail
 
+if [ "$(uname)" == "Darwin" ]; then
+    HOMEBREW="$(brew config | \grep -E '^HOMEBREW_PREFIX' | cut -c18-)"
+
+    # Use GNU 'cp' on macOS so we have a consistent CLI.
+    cp()
+    {
+        gcp "$@"
+    }
+fi
+
+# Helper function to change the RPATH of libraries. The first argument is the
+# (origin-relative) new RPATH to be added. Remaining arguments are libraries to
+# be modified. Note that existing RPATH(s) are removed (except for homebrew
+# RPATHs on macOS).
 chrpath()
 {
     rpath=$1
     shift 1
 
     for lib in "$@"; do
-        patchelf --remove-rpath "$lib"
-        patchelf --set-rpath "$rpath" "$lib"
+        if [ "$(uname)" == "Linux" ]; then
+            patchelf --remove-rpath "$lib"
+            patchelf --set-rpath "\$ORIGIN/$rpath" "$lib"
+        else
+            strip_rpath --exclude="$HOMEBREW" "$lib"
+            install_name_tool -add_rpath "@loader_path/$rpath" "$lib"
+        fi
     done
 }
 
-# TODO(mwoehlke-kitware) Most of this should move to Bazel.
-mkdir -p /wheel/drake
-mkdir -p /wheel/pydrake/lib
-mkdir -p /wheel/pydrake/share/drake
-cd /wheel
+###############################################################################
 
-cp -r -t /wheel/drake \
+readonly WHEEL_DIR=/opt/drake-wheel-build/wheel
+
+# TODO(mwoehlke-kitware) Most of this should move to Bazel.
+mkdir -p ${WHEEL_DIR}/drake
+mkdir -p ${WHEEL_DIR}/pydrake/lib
+mkdir -p ${WHEEL_DIR}/pydrake/share/drake
+cd ${WHEEL_DIR}
+
+cp -r -t ${WHEEL_DIR}/drake \
     /opt/drake/lib/python*/site-packages/drake/*
 
-cp -r -t /wheel/pydrake \
+cp -r -t ${WHEEL_DIR}/pydrake \
     /opt/drake/share/doc \
     /opt/drake/lib/python*/site-packages/pydrake/*
 
-cp -r -t /wheel/pydrake/lib \
-    /opt/drake/lib/libdrake*.so \
+cp -r -t ${WHEEL_DIR}/pydrake/lib \
+    /opt/drake/lib/libdrake*.so
 
 # NOTE: build-vtk.sh also puts licenses in /opt/drake-dependencies/licenses.
-cp -r -t /wheel/pydrake/doc \
+cp -r -t ${WHEEL_DIR}/pydrake/doc \
     /opt/drake-dependencies/licenses/*
 
 # MOSEK is "sort of" third party, but is procured as part of Drake's build and
-# ends up in /opt/drake. It needs to be copied somewhere where auditwheel can
-# find it.
-cp -r -t /opt/drake-dependencies/lib \
-    /opt/drake/lib/libmosek*.so* \
-    /opt/drake/lib/libcilkrts*.so*
+# ends up in /opt/drake.
+if [ "$(uname)" == "Darwin" ]; then
+    # On macOS, it is explicitly referenced by @loader_path, and thus must be
+    # copied to the same place as libdrake.so.
+    cp -r -t ${WHEEL_DIR}/pydrake/lib \
+        /opt/drake/lib/libmosek*.dylib \
+        /opt/drake/lib/libcilkrts*.dylib
+else
+    # On Linux, it needs to be copied somewhere where auditwheel can find it.
+    cp -r -t /opt/drake-dependencies/lib \
+        /opt/drake/lib/libmosek*.so* \
+        /opt/drake/lib/libcilkrts*.so*
+fi
 
 # TODO(mwoehlke-kitware) We need a different way of shipping non-arch files
 # (examples, models).
-cp -r -t /wheel/pydrake/share/drake \
+cp -r -t ${WHEEL_DIR}/pydrake/share/drake \
     /opt/drake/share/drake/.drake-find_resource-sentinel \
     /opt/drake/share/drake/package.xml \
     /opt/drake/share/drake/examples \
@@ -50,23 +83,43 @@ cp -r -t /wheel/pydrake/share/drake \
     /opt/drake/share/drake/manipulation \
     /opt/drake/share/drake/tutorials
 
-mkdir -p /wheel/pydrake/share/drake/setup
-cp -r -t /wheel/pydrake/share/drake/setup \
-    /opt/drake/share/drake/setup/deepnote
+if [ "$(uname)" == "Linux" ]; then
+    mkdir -p ${WHEEL_DIR}/pydrake/share/drake/setup
+    cp -r -t ${WHEEL_DIR}/pydrake/share/drake/setup \
+        /opt/drake/share/drake/setup/deepnote
+fi
 
 # TODO(mwoehlke-kitware) We need to remove these to keep the wheel from being
 # too large, but (per above), the whole of share/drake shouldn't be in the
 # wheel.
-rm /wheel/pydrake/share/drake/manipulation/models/ycb/meshes/*.png
-rm -r /wheel/pydrake/share/drake/examples/atlas
+rm -rf \
+    ${WHEEL_DIR}/pydrake/share/drake/manipulation/models/ycb/meshes/*.png \
+    ${WHEEL_DIR}/pydrake/share/drake/examples/atlas
 
-export LD_LIBRARY_PATH=/wheel/pydrake/lib:/opt/drake-dependencies/lib
+if [ "$(uname)" == "Linux" ]; then
+    export LD_LIBRARY_PATH=${WHEEL_DIR}/pydrake/lib:/opt/drake-dependencies/lib
+fi
 
-chrpath '$ORIGIN/lib' pydrake/*.so
-chrpath '$ORIGIN/../lib' pydrake/*/*.so
+chrpath lib pydrake/*.so
+chrpath ../lib pydrake/*/*.so
+
+if [ "$(uname)" == "Darwin" ]; then
+    change_lpath \
+        --old='@loader_path/../../../' \
+        --new='@rpath/' \
+        pydrake/*.so
+    change_lpath \
+        --old='@loader_path/../../../../' \
+        --new='@rpath/' \
+        pydrake/*/*.so
+fi
 
 python setup.py bdist_wheel
 
-GLIBC_VERSION=$(ldd --version | sed -n '1{s/.* //;s/[.]/_/p}')
+if [ "$(uname)" == "Darwin" ]; then
+    delocate-wheel -w wheelhouse -v dist/drake*.whl
+else
+    GLIBC_VERSION=$(ldd --version | sed -n '1{s/.* //;s/[.]/_/p}')
 
-auditwheel repair --plat manylinux_${GLIBC_VERSION}_x86_64 dist/drake*.whl
+    auditwheel repair --plat manylinux_${GLIBC_VERSION}_x86_64 dist/drake*.whl
+fi

--- a/tools/wheel/image/dependencies/patches/suitesparse/patch.cmake
+++ b/tools/wheel/image/dependencies/patches/suitesparse/patch.cmake
@@ -1,3 +1,24 @@
+if(APPLE)
+    execute_process(
+        COMMAND gfortran --print-file-name=libgfortran.dylib
+        OUTPUT_VARIABLE _gfortran_lib
+        RESULT_VARIABLE _gfortran_result
+        )
+
+    if(NOT _gfortran_result EQUAL 0)
+        message(FATAL_ERROR "gfortran was not found")
+    endif()
+
+    get_filename_component(_gfortran_lib "${_gfortran_lib}" REALPATH)
+    get_filename_component(_gfortran_libdir "${_gfortran_lib}" DIRECTORY)
+
+    set(LIBRT)
+    set(LDFLAGS_GFORTRAN "-L${_gfortran_libdir} -lgfortran")
+else()
+    set(LIBRT "-lrt")
+    set(LDFLAGS_GFORTRAN "-lgfortran")
+endif()
+
 file(
     RENAME
     ${suitesparse_source}/SuiteSparse_config/SuiteSparse_config.mk

--- a/tools/wheel/image/dependencies/patches/suitesparse/patch.diff
+++ b/tools/wheel/image/dependencies/patches/suitesparse/patch.diff
@@ -1,5 +1,5 @@
 diff --git a/SuiteSparse_config/SuiteSparse_config.mk.in b/SuiteSparse_config/SuiteSparse_config.mk.in
-index 3ab813cc..9cb77955 100644
+index 3ab813c..e5cba3e 100644
 --- a/SuiteSparse_config/SuiteSparse_config.mk.in
 +++ b/SuiteSparse_config/SuiteSparse_config.mk.in
 @@ -61,7 +61,7 @@
@@ -11,7 +11,13 @@ index 3ab813cc..9cb77955 100644
  # CFLAGS = -g
  # for the icc compiler and OpenMP:
  # CFLAGS = -openmp
-@@ -95,8 +95,8 @@ F77LIB =
+@@ -90,13 +90,13 @@ F77FLAGS = $(FFLAGS) -O
+ F77LIB =
+ 
+ # C and Fortran libraries.  Remove -lrt if you don't have it.
+-  LIB = -lm -lrt
++  LIB = -lm @LIBRT@
+ # Using the following requires CF = ... -DNTIMER on POSIX C systems.
  # LIB = -lm
  
  # For "make install"
@@ -28,7 +34,7 @@ index 3ab813cc..9cb77955 100644
  # This is probably slow ... it might connect to the Standard Reference BLAS:
 -# BLAS = -lblas -lgfortran
 -  LAPACK = -llapack
-+BLAS = -L@INSTALL_PREFIX@/lib -lblas -lgfortran
++BLAS = -L@INSTALL_PREFIX@/lib -lblas @LDFLAGS_GFORTRAN@
 +LAPACK = -L@INSTALL_PREFIX@/lib -llapack
  
  # MKL 

--- a/tools/wheel/image/dependencies/projects.cmake
+++ b/tools/wheel/image/dependencies/projects.cmake
@@ -1,14 +1,16 @@
-# patchelf
-set(patchelf_version 0.12)
-set(patchelf_url "https://github.com/NixOS/patchelf/archive/${patchelf_version}/patchelf-${patchelf_version}.tar.gz")
-set(patchelf_md5 "b9d1161e52e2f342598deabf7d85ed24")
-list(APPEND ALL_PROJECTS patchelf)
+if(NOT APPLE)
+    # patchelf
+    set(patchelf_version 0.12)
+    set(patchelf_url "https://github.com/NixOS/patchelf/archive/${patchelf_version}/patchelf-${patchelf_version}.tar.gz")
+    set(patchelf_md5 "b9d1161e52e2f342598deabf7d85ed24")
+    list(APPEND ALL_PROJECTS patchelf)
 
-# libxcrypt
-set(libxcrypt_version 4.4.25)
-set(libxcrypt_url "https://github.com/besser82/libxcrypt/archive/v${libxcrypt_version}/libxcrypt-${libxcrypt_version}.tar.gz")
-set(libxcrypt_md5 "4828b1530f5bf35af0b45b35acc4db1d")
-list(APPEND ALL_PROJECTS libxcrypt)
+    # libxcrypt
+    set(libxcrypt_version 4.4.25)
+    set(libxcrypt_url "https://github.com/besser82/libxcrypt/archive/v${libxcrypt_version}/libxcrypt-${libxcrypt_version}.tar.gz")
+    set(libxcrypt_md5 "4828b1530f5bf35af0b45b35acc4db1d")
+    list(APPEND ALL_PROJECTS libxcrypt)
+endif()
 
 # zlib
 set(zlib_version 1.2.11)

--- a/tools/wheel/image/provision-base.sh
+++ b/tools/wheel/image/provision-base.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Internal script to install common (non-Python) build dependencies.
+# Docker (Linux) only.
+
 set -eu -o pipefail
 
 readonly BAZEL_VERSION=5.1.0

--- a/tools/wheel/image/provision-python.sh
+++ b/tools/wheel/image/provision-python.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Internal script to install Python and required Python packages.
+# Docker (Linux) only.
+
 set -eu -o pipefail
 
 readonly PYTHON=python${1:-3}

--- a/tools/wheel/image/setup.py
+++ b/tools/wheel/image/setup.py
@@ -18,6 +18,17 @@ python_required = [
     'scipy',
 ]
 
+if os.uname()[0].lower() == 'linux':
+    # This is intended to help force a binary, rather than platform-agnostic,
+    # wheel, but only works on Ubuntu; clang is not happy about being asked to
+    # make a library with no sources.
+    ext_modules = [
+        setuptools.Extension(name='drake',
+                             sources=[]),
+    ]
+else:
+    ext_modules = []
+
 
 # Distribution which always forces a binary package with platform name.
 class BinaryDistribution(Distribution):
@@ -66,7 +77,7 @@ design/analysis.'''.strip(),
       distclass=BinaryDistribution,
       # TODO Check this: do we need to add third-party licenses?
       license='BSD 3-Clause License',
-      platforms=['linux_x86_64'],
+      platforms=['linux_x86_64', 'macosx_x86_64'],
       packages=find_packages(),
       # Add in any packaged data.
       include_package_data=True,
@@ -80,8 +91,6 @@ design/analysis.'''.strip(),
       },
       python_requires='>=3.8',
       install_requires=python_required,
-      ext_modules=[
-           setuptools.Extension(name='drake',
-                                sources=[])],
+      ext_modules=ext_modules,
       zip_safe=False
       )

--- a/tools/wheel/macos/build-wheel.sh
+++ b/tools/wheel/macos/build-wheel.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+# This script builds a wheel on macOS. It requires an already-provisioned host.
+#
+# Beware that this requires write permission to /opt and will nuke various
+# things therein. (Shouldn't affect ARM Homebrew, though.)
+
+set -eu -o pipefail
+
+readonly resource_root="$(
+    cd "$(dirname "${BASH_SOURCE}")" && \
+    realpath ..
+)"
+
+readonly git_root="$(
+    cd "$resource_root" && \
+    realpath ./$(git rev-parse --show-cdup)
+)"
+
+build_deps=1
+if [ "$1" == "--no-deps" ]; then
+    build_deps=
+    shift 1
+fi
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <drake-version>" >&2
+    exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Clean up from old builds and prepare build environment.
+# -----------------------------------------------------------------------------
+
+rm -rf "/opt/drake-wheel-build/wheel"
+
+if [ -d /opt/drake ]; then
+    # We need to ensure there are no remnants of a prior build, but CI creates
+    # a wheel output directory in /opt/drake that we don't have permission to
+    # remove. Thus, we have to get a little creative...
+    find /opt/drake \
+        \! -path /opt/drake/wheelhouse \
+        \! -path /opt/drake \
+        -delete
+fi
+
+mkdir -p ~/.ssh
+chmod 700 ~/.ssh
+
+# Merge image/known_hosts into the user's known_hosts. Primarily, this ensures
+# that GitHub's SSH fingerprint is known.
+while read host proto fingerprint; do
+    grep -qE '^github.com' ~/.ssh/known_hosts && continue
+    echo "$host $proto $fingerprint" >> ~/.ssh/known_hosts
+done < "$resource_root/image/known_hosts"
+
+chmod 600 ~/.ssh/known_hosts
+
+# -----------------------------------------------------------------------------
+# Build Drake's dependencies.
+# -----------------------------------------------------------------------------
+
+if [ -n "$build_deps" ]; then
+    rm -rf /opt/drake-dependencies
+
+    rm -rf "/opt/drake-wheel-build/dependencies"
+    mkdir -p "/opt/drake-wheel-build/dependencies"
+
+    cp -R \
+        "$resource_root/image/dependencies" \
+        "/opt/drake-wheel-build/dependencies/src"
+
+    "$resource_root/image/build-dependencies.sh"
+
+    rm -rf /opt/vtk
+
+    rm -rf "/opt/drake-wheel-build/vtk"
+    mkdir -p "/opt/drake-wheel-build/vtk"
+
+    cp \
+        "$resource_root/image/vtk-args" \
+        "/opt/drake-wheel-build/vtk/vtk-args"
+
+    "$resource_root/image/build-vtk.sh"
+fi
+
+# -----------------------------------------------------------------------------
+# Build and "install" Drake.
+# -----------------------------------------------------------------------------
+
+cd "$git_root"
+
+export SNOPT_PATH=git
+
+declare -a bazel_args=(
+    --repo_env=DRAKE_OS=macos_wheel
+    --define NO_DRAKE_VISUALIZER=ON
+    --define NO_DREAL=ON
+    --define WITH_MOSEK=ON
+    --define WITH_SNOPT=ON
+)
+
+bazel build "${bazel_args[@]}" //tools/wheel:strip_rpath
+bazel build "${bazel_args[@]}" //tools/wheel:change_lpath
+
+bazel run "${bazel_args[@]}" //:install -- /opt/drake
+
+# -----------------------------------------------------------------------------
+# Set up a Python virtual environment with the latest setuptools.
+# -----------------------------------------------------------------------------
+
+rm -rf  "/opt/drake-wheel-build/python"
+
+python3 -m venv "/opt/drake-wheel-build/python"
+
+. "/opt/drake-wheel-build/python/bin/activate"
+
+pip install --upgrade \
+    delocate \
+    setuptools \
+    wheel
+
+ln -s \
+    "$git_root/bazel-bin/tools/wheel/strip_rpath" \
+    "/opt/drake-wheel-build/python/bin/strip_rpath"
+
+ln -s \
+    "$git_root/bazel-bin/tools/wheel/change_lpath" \
+    "/opt/drake-wheel-build/python/bin/change_lpath"
+
+# -----------------------------------------------------------------------------
+# Build the Drake wheel.
+# -----------------------------------------------------------------------------
+
+mkdir -p "/opt/drake-wheel-build/wheel"
+
+cp \
+    "$resource_root/image/setup.py" \
+    "/opt/drake-wheel-build/wheel/setup.py"
+
+export DRAKE_VERSION="$1"
+
+"$resource_root/image/build-wheel.sh"

--- a/tools/wheel/macos/change_lpath.py
+++ b/tools/wheel/macos/change_lpath.py
@@ -1,0 +1,59 @@
+"""
+Given an input artifact (binary or library), apply a specified change to the
+path prefix of all libraries to which the artifact is linked.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+
+from drake.tools.install import otool
+
+
+def _chlpath(path, libs, old, new):
+    """
+    Builds and applies a set of changes to a library's load paths.
+
+    Given the set of linked libraries `libs` of the library at `path`, for each
+    linked library whose path starts with `old`, replace `old` with `new`.
+    """
+    changes = []
+
+    for lib in libs:
+        if lib.path.startswith(old):
+            changes += ['-change', lib.path, new + lib.path[len(old):]]
+
+    if len(changes):
+        subprocess.check_call(
+            ['install_name_tool'] + changes + [path],
+        )
+
+
+def main(args):
+    # Set up argument parser.
+    parser = argparse.ArgumentParser(
+        description='Change the prefix of dependent shared libraries.')
+    parser.add_argument(
+        '--old', required=True,
+        help='Old prefix to be replaced')
+    parser.add_argument(
+        '--new', required=True,
+        help='Replacement prefix')
+    parser.add_argument(
+        'library', nargs='+',
+        help='Dynamic library to modify')
+
+    # Parse arguments.
+    options = parser.parse_args(args)
+
+    # Get list of dependent libraries and modify their prefixes.
+    for path in options.library:
+        libs = otool.linked_libraries(path)
+        _chlpath(path, libs=libs, old=options.old, new=options.new)
+
+
+# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/tools/wheel/macos/strip_rpath.py
+++ b/tools/wheel/macos/strip_rpath.py
@@ -1,0 +1,63 @@
+"""
+Remove RPATH commands from an artifact (binary or library).
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+
+from drake.tools.install import otool
+
+
+def _filter_rpaths(paths, exclusions):
+    """
+    Returns `paths`, less any items that start with any of `exclusions`.
+    """
+    def _filter(path):
+        for x in exclusions:
+            if path.startswith(x):
+                return False
+        return True
+
+    return list(filter(_filter, paths))
+
+
+def _strip_rpaths(path, rpaths):
+    """
+    Removes RPATHs `rpaths` from binary/library `path`.
+    """
+    for rpath in rpaths:
+        subprocess.check_call(
+            ['install_name_tool', '-delete_rpath', rpath, path],
+        )
+
+
+def main(args):
+    # Set up argument parser.
+    parser = argparse.ArgumentParser(
+        description='Strip RPATH(s) from a library.')
+    parser.add_argument(
+        '-x', '--exclude', metavar='PREFIX', action='append',
+        help='leave any RPATH that starts with the specified prefix')
+    parser.add_argument(
+        'library',
+        help='dynamic library to modify')
+
+    # Parse arguments.
+    options = parser.parse_args(args)
+
+    # Extract RPATH entries from load commands.
+    commands = otool.load_commands(options.library)
+    rpaths = _filter_rpaths(
+        [c['path'] for c in commands if c['cmd'] == 'LC_RPATH'],
+        options.exclude)
+
+    # Remove the RPATH load commands.
+    _strip_rpaths(options.library, rpaths)
+
+
+# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/tools/wheel/wheel_builder/linux.py
+++ b/tools/wheel/wheel_builder/linux.py
@@ -204,11 +204,11 @@ def _build_image(target, identifier, options):
     if options.extract:
         print('[-] Extracting wheel(s) from', tag)
 
-        command = 'tar -cf - /wheel/wheelhouse/*.whl'
+        command = 'tar -cf - /opt/drake-wheel-build/wheel/wheelhouse/*.whl'
         extractor = _docker(
             'run', '--rm', tag, 'bash', '-c', command, pipe=True)
         subprocess.check_call(
-            ['tar', '--strip-components=2', '-xf', '-'],
+            ['tar', '--strip-components=4', '-xvf', '-'],
             stdin=extractor.stdout, cwd=options.output_dir)
 
         extractor_result = extractor.wait()


### PR DESCRIPTION
Create a script to build a wheel on macOS. Update various Bazel logic to support the `macos_wheel` platform. Add scripts to mangle library load paths on macOS. Update inner wheel build script to support macOS as well as `manylinux`. Update various inner build scripts to support a build root other than `/`, since macOS does not permit creation of arbitrary top-level directories.

Note that the wheel build requires that the user running the scripts is able to use `brew`, and has write access to `/opt`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17307)
<!-- Reviewable:end -->
