### PR TITLE
[viz] prototype of multi-role visualization

### DIFF
--- a/bindings/pydrake/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry_py_visualizers.cc
@@ -161,7 +161,8 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def(ParamInit<Class>())
         .def_readwrite("publish_period", &DrakeVisualizerParams::publish_period,
             cls_doc.publish_period.doc)
-        .def_readwrite("role", &DrakeVisualizerParams::role, cls_doc.role.doc)
+        .def_readwrite(
+            "roles", &DrakeVisualizerParams::roles, cls_doc.roles.doc)
         .def_readwrite("default_color", &DrakeVisualizerParams::default_color,
             cls_doc.default_color.doc)
         .def_readwrite("show_hydroelastic",
@@ -171,10 +172,10 @@ void DoScalarIndependentDefinitions(py::module m) {
           return py::str(
               "DrakeVisualizerParams("
               "publish_period={}, "
-              "role={}, "
+              "roles={}, "
               "default_color={}, "
               "show_hydroelastic={})")
-              .format(self.publish_period, self.role, self.default_color,
+              .format(self.publish_period, self.roles, self.default_color,
                   self.show_hydroelastic);
         });
   }

--- a/bindings/pydrake/test/geometry_visualizers_test.py
+++ b/bindings/pydrake/test/geometry_visualizers_test.py
@@ -25,13 +25,13 @@ class TestGeometryVisualizers(unittest.TestCase):
         lcm = DrakeLcm()
         role = mut.Role.kIllustration
         params = mut.DrakeVisualizerParams(
-            publish_period=0.1, role=mut.Role.kIllustration,
+            publish_period=0.1, roles={mut.Role.kIllustration},
             default_color=mut.Rgba(0.1, 0.2, 0.3, 0.4),
             show_hydroelastic=False)
         self.assertEqual(repr(params), "".join([
             "DrakeVisualizerParams("
             "publish_period=0.1, "
-            "role=Role.kIllustration, "
+            "roles={<Role.kIllustration: 2>}, "
             "default_color=Rgba(r=0.1, g=0.2, b=0.3, a=0.4), "
             "show_hydroelastic=False)"]))
 
@@ -229,7 +229,7 @@ class TestGeometryVisualizers(unittest.TestCase):
         meshcat = mut.Meshcat()
         params = mut.MeshcatVisualizerParams()
         params.publish_period = 0.123
-        params.role = mut.Role.kIllustration
+        params.roles = {mut.Role.kIllustration}
         params.default_color = mut.Rgba(0.5, 0.5, 0.5)
         params.prefix = "py_visualizer"
         params.delete_on_initialization_event = False

--- a/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
+++ b/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
@@ -25,10 +25,6 @@ DEFINE_double(amplitude, 5,
 DEFINE_double(duty_cycle, 0.5, "Duty cycle of the control signal.");
 DEFINE_double(period, 3, "Period of the control signal. [s].");
 
-// DrakeVisualizer Settings.
-DEFINE_bool(visualize_collision, false,
-            "Visualize collision instead of visual geometries.");
-
 // MultibodyPlant settings.
 DEFINE_double(stiction_tolerance, 1e-4, "Default stiction tolerance. [m/s].");
 DEFINE_double(mbp_discrete_update_period, 4.0e-2,
@@ -184,8 +180,7 @@ int DoMain() {
   // Create a visualizer for the system and ensure contact results are
   // visualized.
   geometry::DrakeVisualizerParams params;
-  params.role = FLAGS_visualize_collision ? geometry::Role::kProximity
-                                          : geometry::Role::kIllustration;
+  params.roles = {geometry::Role::kProximity, geometry::Role::kIllustration};
   geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph,
                                            /* lcm */ nullptr, params);
   multibody::ConnectContactResultsToDrakeVisualizer(&builder, plant,

--- a/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
+++ b/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
@@ -185,7 +185,7 @@ int do_main() {
   if (FLAGS_visualize) {
     geometry::DrakeVisualizerParams params;
     if (FLAGS_vis_hydro) {
-      params.role = geometry::Role::kProximity;
+      params.roles = {geometry::Role::kProximity};
       params.show_hydroelastic = true;
     }
     geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph, nullptr,

--- a/geometry/drake_visualizer.h
+++ b/geometry/drake_visualizer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -28,7 +29,7 @@ namespace internal {
  read from for a pose message.  */
 struct DynamicFrameData {
   FrameId frame_id;
-  int num_geometry{};
+  std::map<Role, int> geometry_counts{};
   std::string name;
 };
 
@@ -222,6 +223,7 @@ class DrakeVisualizer final : public systems::LeafSystem<T> {
    loaded.  */
   static void SendDrawMessage(
       const QueryObject<T>& query_object,
+      const DrakeVisualizerParams& params,
       const std::vector<internal::DynamicFrameData>& dynamic_frames,
       double time, lcm::DrakeLcmInterface* lcm);
 

--- a/geometry/drake_visualizer_params.h
+++ b/geometry/drake_visualizer_params.h
@@ -15,7 +15,7 @@ struct DrakeVisualizerParams {
   double publish_period{1 / 64.0};
 
   /** The role of the geometries to be sent to the visualizer.  */
-  Role role{Role::kIllustration};
+  Roles roles{Role::kIllustration};
 
   /** The color to apply to any geometry that hasn't defined one.  */
   Rgba default_color{0.9, 0.9, 0.9, 1.0};

--- a/geometry/geometry_roles.h
+++ b/geometry/geometry_roles.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iostream>
+#include <set>
 #include <string>
 
 #include "drake/common/drake_copyable.h"
@@ -184,12 +185,16 @@ class IllustrationProperties final : public GeometryProperties {
 
 /** General enumeration for indicating geometry role.  */
 enum class Role {
+  // XXX TODO the following statement is a lie.
   // Bitmask-able values so they can be OR'd together.
   kUnassigned = 0x0,
   kProximity = 0x1,
   kIllustration = 0x2,
   kPerception = 0x4
 };
+
+/** The maximumum number of simultaneous non-vacuous roles. */
+constexpr int kMaxRoles = 3;
 
 // NOTE: Currently this only includes new and replace; but someday it could also
 // include other operations: merge, subtract, etc.
@@ -212,6 +217,8 @@ std::string to_string(const Role& role);
 std::ostream& operator<<(std::ostream& out, const Role& role);
 
 //@}
+
+using Roles = std::set<Role>;
 
 /** @name  Convenience functions
 


### PR DESCRIPTION
This patch is a prototype of achieving multi-role visualization via the
drake_visualizer message protocol. It uses additional robot_num allocations and
naming tricks to allow viewer-side control of what geometries are visible.

Fair warning: this patch "works" at a demo level, but is riddled with
questionable choices, and lacks tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17311)
<!-- Reviewable:end -->
