### PR TITLE
[geometry, doc] Move unrelated accessor out of a doc group

### DIFF
--- a/geometry/internal_geometry.h
+++ b/geometry/internal_geometry.h
@@ -263,12 +263,6 @@ class InternalGeometry {
     return nullptr;
   }
 
-  /* Returns a pointer to the geometry's reference mesh if the geometry is
-   deformable, or nullptr otherwise.  */
-  const VolumeMesh<double>* reference_mesh() const {
-    return reference_mesh_.get();
-  }
-
   /* Removes the proximity role assigned to this geometry -- if there was
    no proximity role previously, this has no effect.  */
   void RemoveProximityRole() {
@@ -288,6 +282,12 @@ class InternalGeometry {
   }
 
   //@}
+
+  /* Returns a pointer to the geometry's reference mesh if the geometry is
+   deformable, or nullptr otherwise.  */
+  const VolumeMesh<double>* reference_mesh() const {
+    return reference_mesh_.get();
+  }
 
  private:
   // The specification for this instance's shape.


### PR DESCRIPTION
I know, I know, internal headers don't get doxygen doc generated. Still,
our doxygen mimickry should be consistent and not misleading.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17314)
<!-- Reviewable:end -->
