### PR TITLE
Update clang-cindex-python3 to the latest version.

### DIFF
--- a/tools/workspace/clang_cindex_python3_internal/repository.bzl
+++ b/tools/workspace/clang_cindex_python3_internal/repository.bzl
@@ -8,8 +8,8 @@ def clang_cindex_python3_internal_repository(
     github_archive(
         name = name,
         repository = "wjakob/clang-cindex-python3",
-        commit = "9dcf4f16757c9b6446910e4de51ed27ee962b81b",
-        sha256 = "65c26ec7fe09c54479ce5f375ccd5dd11e4e8bb11e47681c254be0d9bcd79164",  # noqa
+        commit = "b0b92c9395f3927af6a96ac8915e700259d2f55b",
+        sha256 = "a09d12a4303dffe9f53e62149d829e651d79e6848a712fab1d77bed382efc37b",  # noqa
         build_file = "@drake//tools/workspace/clang_cindex_python3_internal:package.BUILD.bazel",  # noqa
         mirrors = mirrors,
         patch_cmds = ["mkdir clang && mv *.py clang"],

--- a/tools/workspace/pybind11/pybind_coverage_libclang_parser.py
+++ b/tools/workspace/pybind11/pybind_coverage_libclang_parser.py
@@ -172,8 +172,8 @@ def get_tokens(filename):
     en = cindex.SourceLocation.from_position(tu, FILE, lines, cols)
     extent = cindex.SourceRange.from_locations(st, en)
     tokens = tu.get_tokens(extent=extent)
-    token_spellings = [t.spelling.decode('utf-8') for t in tokens if t.kind is
-                       not cindex.TokenKind.COMMENT]
+    token_spellings = [t.spelling for t in tokens
+                       if t.kind is not cindex.TokenKind.COMMENT]
 
     return token_spellings
 


### PR DESCRIPTION
The version of clang-cindex-python3 we were using breaks with Python 3.10, which will prevent us from adding Jammy support (or if we want to add 3.10 support for macOS, which we'll probably want to do eventually). Update to the "latest" upstream version (which is already almost two years old!), which works with Python 3.10.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17315)
<!-- Reviewable:end -->
