### PR TITLE
[meshcat] Add capsule support

### DIFF
--- a/geometry/meshcat_types.h
+++ b/geometry/meshcat_types.h
@@ -191,10 +191,14 @@ struct SphereGeometryData : public GeometryData {
 };
 
 struct CapsuleGeometryData : public GeometryData {
+  // For a complete description of these parameters see:
+  // https://threejs.org/docs/#api/en/geometries/CapsuleGeometry
   double radius{};
   double length{};
-  double radialSegments{50};
-  double capSegments{20};
+  double radialSegments{20};  // Number of curve segments used to build
+                              // the caps.
+  double capSegments{10};     // Number of segmented faces around the
+                              // circumference of the capsule.
 
   // NOLINTNEXTLINE(runtime/references) cpplint disapproves of msgpack choices.
   void msgpack_pack(msgpack::packer<std::stringstream>& o) const override {

--- a/geometry/meshcat_types.h
+++ b/geometry/meshcat_types.h
@@ -195,10 +195,10 @@ struct CapsuleGeometryData : public GeometryData {
   // https://threejs.org/docs/#api/en/geometries/CapsuleGeometry
   double radius{};
   double length{};
-  double radialSegments{20};  // Number of curve segments used to build
-                              // the caps.
-  double capSegments{10};     // Number of segmented faces around the
+  double radialSegments{20};  // Number of segmented faces around the
                               // circumference of the capsule.
+  double capSegments{10};     // Number of curve segments used to build
+                              // the caps.
 
   // NOLINTNEXTLINE(runtime/references) cpplint disapproves of msgpack choices.
   void msgpack_pack(msgpack::packer<std::stringstream>& o) const override {

--- a/geometry/meshcat_types.h
+++ b/geometry/meshcat_types.h
@@ -190,6 +190,25 @@ struct SphereGeometryData : public GeometryData {
   }
 };
 
+struct CapsuleGeometryData : public GeometryData {
+  double radius{};
+  double length{};
+  double radialSegments{50};
+  double capSegments{20};
+
+  // NOLINTNEXTLINE(runtime/references) cpplint disapproves of msgpack choices.
+  void msgpack_pack(msgpack::packer<std::stringstream>& o) const override {
+    o.pack_map(6);
+    o.pack("type");
+    o.pack("CapsuleGeometry");
+    PACK_MAP_VAR(o, uuid);
+    PACK_MAP_VAR(o, radius);
+    PACK_MAP_VAR(o, length);
+    PACK_MAP_VAR(o, radialSegments);
+    PACK_MAP_VAR(o, capSegments);
+  }
+};
+
 struct CylinderGeometryData : public GeometryData {
   double radiusBottom{};
   double radiusTop{};

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -31,16 +31,19 @@ int do_main() {
   auto meshcat = std::make_shared<Meshcat>();
 
   meshcat->SetObject("sphere", Sphere(.25), Rgba(1.0, 0, 0, 1));
-  meshcat->SetTransform("sphere", RigidTransformd(Vector3d{-3, 0, 0}));
+  meshcat->SetTransform("sphere", RigidTransformd(Vector3d{-4, 0, 0}));
 
   meshcat->SetObject("cylinder", Cylinder(.25, .5), Rgba(0.0, 1.0, 0, 1));
-  meshcat->SetTransform("cylinder", RigidTransformd(Vector3d{-2, 0, 0}));
+  meshcat->SetTransform("cylinder", RigidTransformd(Vector3d{-3, 0, 0}));
 
   meshcat->SetObject("ellipsoid", Ellipsoid(.25, .25, .5), Rgba(1., 0, 1, .5));
-  meshcat->SetTransform("ellipsoid", RigidTransformd(Vector3d{-1, 0, 0}));
+  meshcat->SetTransform("ellipsoid", RigidTransformd(Vector3d{-2, 0, 0}));
 
   meshcat->SetObject("box", Box(.25, .25, .5), Rgba(0, 0, 1, 1));
-  meshcat->SetTransform("box", RigidTransformd(Vector3d{0, 0, 0}));
+  meshcat->SetTransform("box", RigidTransformd(Vector3d{-1, 0, 0}));
+
+  meshcat->SetObject("capsule", Capsule(.25, .5), Rgba(0, 1, 1, 1));
+  meshcat->SetTransform("capsule", RigidTransformd(Vector3d{0, 0, 0}));
 
   // Note that height (in z) is the first argument.
   meshcat->SetObject("cone", MeshcatCone(.5, .25, .5), Rgba(1, 0, 0, 1));
@@ -149,6 +152,7 @@ Open up your browser to the URL above.
   - a green cylinder (with the long axis in z)
   - a pink semi-transparent ellipsoid (long axis in z)
   - a blue box (long axis in z)
+  - a teal capsule (long axis in z)
   - a red cone (expanding in +z, twice as wide in y than in x)
   - a bright green cube (the green comes from a texture map)
   - a yellow mustard bottle w/ label

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -286,9 +286,8 @@ GTEST_TEST(MeshcatTest, SetObjectWithShape) {
   EXPECT_FALSE(meshcat.GetPackedObject("box").empty());
   meshcat.SetObject("ellipsoid", Ellipsoid(.25, .25, .5), Rgba(1., 0, 1, 1));
   EXPECT_FALSE(meshcat.GetPackedObject("ellipsoid").empty());
-  // Capsules are not supported yet; this should only log a warning.
   meshcat.SetObject("capsule", Capsule(.25, .5));
-  EXPECT_TRUE(meshcat.GetPackedObject("capsule").empty());
+  EXPECT_FALSE(meshcat.GetPackedObject("capsule").empty());
   meshcat.SetObject(
       "mesh", Mesh(FindResourceOrThrow(
                        "drake/geometry/render/test/meshes/box.obj"),


### PR DESCRIPTION
Fixes #17149

Depends on rdeits/meshcat#116 before merging.

THREE.js added native capsule shape support in mrdoob/three.js#23586. This PR adds capsule support to the in process meshcat class and temporarily points to a fork of meshcat with an updated THREE.js version.

cc: @JoseBarreiros-TRI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17319)
<!-- Reviewable:end -->
