### PR TITLE
Implement testing for macOS wheel

### DIFF
--- a/tools/wheel/macos/test-wheel.sh
+++ b/tools/wheel/macos/test-wheel.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# This script tests a wheel on macOS.
+
+set -eu -o pipefail
+
+readonly resource_root="$(cd "$(dirname "${BASH_SOURCE}")" && realpath ..)"
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <wheel>" >&2
+    exit 1
+fi
+
+readonly wheel="$(realpath "$1")"
+
+# -----------------------------------------------------------------------------
+# Clean up from old tests and prepare test environment.
+# -----------------------------------------------------------------------------
+
+rm -rf /opt/drake-wheel-test
+
+python3 -m venv /opt/drake-wheel-test/python
+
+cd /opt/drake-wheel-test/python
+
+# -----------------------------------------------------------------------------
+# Install the wheel and run the tests.
+# -----------------------------------------------------------------------------
+
+"$resource_root/test/test-wheel.sh" "$wheel"
+
+# -----------------------------------------------------------------------------
+# Remove the test environment.
+# -----------------------------------------------------------------------------
+
+cd /
+
+rm -rf /opt/drake-wheel-test

--- a/tools/wheel/test/provision.sh
+++ b/tools/wheel/test/provision.sh
@@ -17,4 +17,8 @@ apt-get -y install --no-install-recommends \
     python3-venv \
     libx11-6 libsm6 libxt6 libglib2.0-0
 
-${PYTHON} -m venv /opt/python
+${PYTHON} -m venv /opt/drake-wheel-test/python
+
+. /opt/drake-wheel-test/python/bin/activate
+
+pip install --upgrade pip

--- a/tools/wheel/test/test-wheel.sh
+++ b/tools/wheel/test/test-wheel.sh
@@ -2,10 +2,10 @@
 
 # This shell script tests a Drake wheel. It must be run inside of a container
 # which has been properly provisioned, e.g. by the accompanying test-wheels.sh
-# script (in particular, /opt/python must contain a Python virtual environment
-# which will be used to run the tests). The wheel must be accessible to the
-# container, and the container's path to the wheel should be given as an
-# argument to the script.
+# script (in particular, /opt/drake-wheel-test/python must contain a Python
+# virtual environment which will be used to run the tests). The wheel must be
+# accessible to the container, and the container's path to the wheel should be
+# given as an argument to the script.
 
 set -eu -o pipefail
 
@@ -14,9 +14,7 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-. /opt/python/bin/activate
-
-pip install --upgrade pip
+. /opt/drake-wheel-test/python/bin/activate
 
 pip install "$1"
 


### PR DESCRIPTION
Add a script to set up a test environment on macOS and run the existing test script on a macOS wheel. Modify Ubuntu/shared wheel test scripts to use `/opt/drake-wheel-test/python` for the virtualenv rather than `/opt/python`, in order to be more consistent with the recent build-related changes and to better avoid possible conflicts with user files.