### PR TITLE
[viz] 2nd prototype of multi-role visualization

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -17,6 +17,7 @@
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/plant/contact_results.h"
 #include "drake/multibody/plant/contact_results_to_lcm.h"
+#include "drake/multibody/plant/drake_visualizer_config_functions.h"
 #include "drake/multibody/plant/externally_applied_spatial_force.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/plant/multibody_plant_config.h"
@@ -1235,6 +1236,33 @@ PYBIND11_MODULE(plant, m) {
       // Keep alive, transitive: `lcm` keeps `builder` alive.
       py::keep_alive<4, 1>(),
       doc.ConnectContactResultsToDrakeVisualizer.doc_5args);
+
+  {
+    using Class = DrakeVisualizerConfig;
+    constexpr auto& cls_doc = doc.DrakeVisualizerConfig;
+    py::class_<Class> cls(m, "DrakeVisualizerConfig", cls_doc.doc);
+    cls  // BR
+        .def(py::init<>())
+        .def(ParamInit<Class>())
+        .def_readwrite("geometry_config", &Class::geometry_config,
+            cls_doc.geometry_config.doc)
+        .def_readwrite("show_contact_results", &Class::show_contact_results,
+            cls_doc.show_contact_results.doc);
+    DefCopyAndDeepCopy(&cls);
+  }
+
+  m.def(
+      "ApplyDrakeVisualizerConfig",
+      [](drake::systems::DiagramBuilder<double>* builder,
+          const drake::multibody::MultibodyPlant<double>& plant,
+          const drake::geometry::SceneGraph<double>& scene_graph,
+          lcm::DrakeLcmInterface* lcm, const DrakeVisualizerConfig& config) {
+        return drake::multibody::ApplyDrakeVisualizerConfig(
+            builder, plant, scene_graph, lcm, config);
+      },
+      py::arg("builder"), py::arg("plant"), py::arg("scene_graph"),
+      py::arg("lcm") = nullptr, py::arg("config") = DrakeVisualizerConfig{},
+      doc.ApplyDrakeVisualizerConfig.doc);
 
   {
     using Class = PropellerInfo;

--- a/bindings/pydrake/visualization/test/meldis_test.py
+++ b/bindings/pydrake/visualization/test/meldis_test.py
@@ -35,7 +35,7 @@ class TestMeldis(unittest.TestCase):
         lcm = dut._lcm
 
         # The path is created by the constructor.
-        self.assertEqual(meshcat.HasPath("/DRAKE_VIEWER"), True)
+        self.assertEqual(meshcat.HasPath("/Visual Geometry"), True)
 
         # Enqueue the load + draw messages.
         sdf_file = FindResourceOrThrow(
@@ -52,7 +52,7 @@ class TestMeldis(unittest.TestCase):
         diagram.Publish(context)
 
         # The geometry isn't registered until the load is processed.
-        link_path = "/DRAKE_VIEWER/2/plant/acrobot/Link2/0"
+        link_path = "/Visual Geometry/2/plant/acrobot/Link2/0"
         self.assertEqual(meshcat.HasPath(link_path), False)
 
         # Process the load + draw; make sure the geometry exists now.

--- a/examples/atlas/BUILD.bazel
+++ b/examples/atlas/BUILD.bazel
@@ -27,7 +27,7 @@ drake_cc_binary(
         "//common:find_resource",
         "//geometry:drake_visualizer",
         "//multibody/parsing",
-        "//multibody/plant:contact_results_to_lcm",
+        "//multibody/plant:drake_visualizer_config_functions",
         "//systems/analysis:simulator",
         "//systems/analysis:simulator_gflags",
         "//systems/framework:diagram",

--- a/examples/atlas/atlas_run_dynamics.cc
+++ b/examples/atlas/atlas_run_dynamics.cc
@@ -7,7 +7,7 @@
 #include "drake/geometry/scene_graph.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/multibody/parsing/parser.h"
-#include "drake/multibody/plant/contact_results_to_lcm.h"
+#include "drake/multibody/plant/drake_visualizer_config_functions.h"
 #include "drake/multibody/plant/multibody_plant_config_functions.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/analysis/simulator_gflags.h"
@@ -97,9 +97,7 @@ int do_main() {
   DRAKE_DEMAND(pelvis.floating_velocities_start() == plant.num_positions());
 
   // Publish contact results for visualization.
-  ConnectContactResultsToDrakeVisualizer(&builder, plant, scene_graph);
-
-  geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph);
+  ApplyDrakeVisualizerConfig(&builder, plant, scene_graph);
   auto diagram = builder.Build();
 
   // Create a context for this system:

--- a/examples/hydroelastic/ball_plate/BUILD.bazel
+++ b/examples/hydroelastic/ball_plate/BUILD.bazel
@@ -44,7 +44,7 @@ drake_cc_binary(
         ":make_ball_plate_plant",
         "//common:add_text_logging_gflags",
         "//geometry:drake_visualizer",
-        "//multibody/plant:contact_results_to_lcm",
+        "//multibody/plant:drake_visualizer_config_functions",
         "//systems/analysis:simulator",
         "//systems/analysis:simulator_gflags",
         "//systems/analysis:simulator_print_stats",

--- a/examples/hydroelastic/ball_plate/ball_plate_run_dynamics.cc
+++ b/examples/hydroelastic/ball_plate/ball_plate_run_dynamics.cc
@@ -6,7 +6,7 @@
 #include "drake/examples/hydroelastic/ball_plate/make_ball_plate_plant.h"
 #include "drake/geometry/drake_visualizer.h"
 #include "drake/geometry/scene_graph.h"
-#include "drake/multibody/plant/contact_results_to_lcm.h"
+#include "drake/multibody/plant/drake_visualizer_config_functions.h"
 #include "drake/multibody/plant/multibody_plant_config.h"
 #include "drake/multibody/plant/multibody_plant_config_functions.h"
 #include "drake/systems/analysis/simulator.h"
@@ -99,9 +99,7 @@ int do_main() {
   DRAKE_DEMAND(plant.num_velocities() == 12);
   DRAKE_DEMAND(plant.num_positions() == 14);
 
-  geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph);
-  ConnectContactResultsToDrakeVisualizer(&builder, plant, scene_graph,
-                                         /* lcm */ nullptr);
+  multibody::ApplyDrakeVisualizerConfig(&builder, plant, scene_graph);
 
   auto diagram = builder.Build();
   auto simulator = MakeSimulatorFromGflags(*diagram);

--- a/examples/hydroelastic/spatula_slip_control/BUILD.bazel
+++ b/examples/hydroelastic/spatula_slip_control/BUILD.bazel
@@ -38,7 +38,7 @@ drake_cc_binary(
     deps = [
         "//geometry:drake_visualizer",
         "//multibody/parsing",
-        "//multibody/plant:contact_results_to_lcm",
+        "//multibody/plant:drake_visualizer_config_functions",
         "//multibody/plant:multibody_plant_config_functions",
         "//systems/analysis:simulator",
         "//systems/analysis:simulator_config_functions",

--- a/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
+++ b/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
@@ -5,7 +5,7 @@
 #include "drake/common/find_resource.h"
 #include "drake/geometry/drake_visualizer.h"
 #include "drake/multibody/parsing/parser.h"
-#include "drake/multibody/plant/contact_results_to_lcm.h"
+#include "drake/multibody/plant/drake_visualizer_config_functions.h"
 #include "drake/multibody/plant/multibody_plant_config_functions.h"
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/systems/analysis/simulator.h"
@@ -24,10 +24,6 @@ DEFINE_double(amplitude, 5,
               "carried out by the gripper. [N].");
 DEFINE_double(duty_cycle, 0.5, "Duty cycle of the control signal.");
 DEFINE_double(period, 3, "Period of the control signal. [s].");
-
-// DrakeVisualizer Settings.
-DEFINE_bool(visualize_collision, false,
-            "Visualize collision instead of visual geometries.");
 
 // MultibodyPlant settings.
 DEFINE_double(stiction_tolerance, 1e-4, "Default stiction tolerance. [m/s].");
@@ -186,14 +182,7 @@ int DoMain() {
 
   // Create a visualizer for the system and ensure contact results are
   // visualized.
-  geometry::DrakeVisualizerParams params;
-  params.role = FLAGS_visualize_collision ? geometry::Role::kProximity
-                                          : geometry::Role::kIllustration;
-  geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph,
-                                           /* lcm */ nullptr, params);
-  multibody::ConnectContactResultsToDrakeVisualizer(&builder, plant,
-                                                    scene_graph,
-                                                    /* lcm */ nullptr);
+  multibody::ApplyDrakeVisualizerConfig(&builder, plant, scene_graph);
 
   // Construct a simulator.
   std::unique_ptr<systems::Diagram<double>> diagram = builder.Build();

--- a/examples/kinova_jaco_arm/jaco_simulation.cc
+++ b/examples/kinova_jaco_arm/jaco_simulation.cc
@@ -94,7 +94,7 @@ int DoMain() {
 
   systems::lcm::LcmInterfaceSystem* lcm =
       builder.AddSystem<systems::lcm::LcmInterfaceSystem>();
-  geometry::DrakeVisualizerd::AddToBuilder(&builder, *scene_graph, lcm);
+  geometry::DrakeVisualizerd::AddToBuilderForRoles(&builder, *scene_graph, lcm);
 
   auto command_sub = builder.AddSystem(
       systems::lcm::LcmSubscriberSystem::Make<drake::lcmt_jaco_command>(

--- a/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -74,7 +74,7 @@ int DoMain() {
 
   // Creates and adds LCM publisher for visualization.
   auto lcm = builder.AddSystem<systems::lcm::LcmInterfaceSystem>();
-  geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph, lcm);
+  geometry::DrakeVisualizerd::AddToBuilderForRoles(&builder, scene_graph, lcm);
 
   // Since we welded the model to the world above, the only remaining joints
   // should be those in the arm.

--- a/examples/manipulation_station/end_effector_teleop_mouse.py
+++ b/examples/manipulation_station/end_effector_teleop_mouse.py
@@ -323,7 +323,7 @@ def main():
         station.Finalize()
         query_port = station.GetOutputPort("query_object")
 
-        DrakeVisualizer.AddToBuilder(builder, query_port)
+        DrakeVisualizer.AddToBuilderForRoles(builder, query_port)
         if args.meshcat:
             meshcat = Meshcat()
             meshcat_visualizer = MeshcatVisualizer.AddToBuilder(

--- a/examples/manipulation_station/end_effector_teleop_sliders.py
+++ b/examples/manipulation_station/end_effector_teleop_sliders.py
@@ -241,7 +241,7 @@ def main():
             meshcat.Set2dRenderMode()
 
         # Connect and publish to drake visualizer.
-        DrakeVisualizer.AddToBuilder(builder, geometry_query_port)
+        DrakeVisualizer.AddToBuilderForRoles(builder, geometry_query_port)
         image_to_lcm_image_array = builder.AddSystem(
             ImageToLcmImageArrayT())
         image_to_lcm_image_array.set_name("converter")

--- a/examples/multibody/rolling_sphere/BUILD.bazel
+++ b/examples/multibody/rolling_sphere/BUILD.bazel
@@ -40,7 +40,7 @@ drake_cc_binary(
         ":make_rolling_sphere_plant",
         "//common:add_text_logging_gflags",
         "//geometry:drake_visualizer",
-        "//multibody/plant:contact_results_to_lcm",
+        "//multibody/plant:drake_visualizer_config_functions",
         "//systems/analysis:simulator",
         "//systems/analysis:simulator_gflags",
         "//systems/analysis:simulator_print_stats",

--- a/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
+++ b/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
@@ -12,7 +12,7 @@
 #include "drake/lcm/drake_lcm.h"
 #include "drake/math/random_rotation.h"
 #include "drake/multibody/math/spatial_algebra.h"
-#include "drake/multibody/plant/contact_results_to_lcm.h"
+#include "drake/multibody/plant/drake_visualizer_config_functions.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/analysis/simulator_gflags.h"
 #include "drake/systems/analysis/simulator_print_stats.h"
@@ -183,14 +183,12 @@ int do_main() {
       scene_graph.get_source_pose_port(plant.get_source_id().value()));
 
   if (FLAGS_visualize) {
-    geometry::DrakeVisualizerParams params;
+    drake::multibody::DrakeVisualizerConfig config;
     if (FLAGS_vis_hydro) {
-      params.role = geometry::Role::kProximity;
-      params.show_hydroelastic = true;
+      config.geometry_config.show_hydroelastic = true;
     }
-    geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph, nullptr,
-                                             params);
-    ConnectContactResultsToDrakeVisualizer(&builder, plant, scene_graph);
+    drake::multibody::ApplyDrakeVisualizerConfig(
+        &builder, plant, scene_graph, {}, config);
   }
   auto diagram = builder.Build();
 

--- a/examples/multibody/strandbeest/BUILD.bazel
+++ b/examples/multibody/strandbeest/BUILD.bazel
@@ -27,7 +27,7 @@ drake_cc_binary(
         "//multibody/inverse_kinematics",
         "//multibody/parsing",
         "//multibody/plant",
-        "//multibody/plant:contact_results_to_lcm",
+        "//multibody/plant:drake_visualizer_config_functions",
         "//multibody/tree",
         "//solvers",
         "//systems/analysis:simulator",

--- a/examples/multibody/strandbeest/run_with_motor.cc
+++ b/examples/multibody/strandbeest/run_with_motor.cc
@@ -18,7 +18,7 @@ a way to model kinematic loops. It shows:
 #include "drake/geometry/drake_visualizer.h"
 #include "drake/multibody/inverse_kinematics/inverse_kinematics.h"
 #include "drake/multibody/parsing/parser.h"
-#include "drake/multibody/plant/contact_results_to_lcm.h"
+#include "drake/multibody/plant/drake_visualizer_config_functions.h"
 #include "drake/multibody/tree/linear_bushing_roll_pitch_yaw.h"
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/solvers/solve.h"
@@ -139,8 +139,7 @@ int do_main() {
   strandbeest.set_penetration_allowance(FLAGS_penetration_allowance);
   strandbeest.set_stiction_tolerance(FLAGS_stiction_tolerance);
 
-  geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph);
-  ConnectContactResultsToDrakeVisualizer(&builder, strandbeest, scene_graph);
+  ApplyDrakeVisualizerConfig(&builder, strandbeest, scene_graph);
 
   // Create a DesiredVelocityMotor where the proportional term is directly
   // proportional to the mass of the model.

--- a/examples/planar_gripper/BUILD.bazel
+++ b/examples/planar_gripper/BUILD.bazel
@@ -120,7 +120,7 @@ drake_cc_binary(
         "//geometry:drake_visualizer",
         "//multibody/parsing",
         "//multibody/plant",
-        "//multibody/plant:contact_results_to_lcm",
+        "//multibody/plant:drake_visualizer_config_functions",
         "//systems/analysis:simulator",
         "//systems/controllers:inverse_dynamics_controller",
         "//systems/framework:diagram",

--- a/examples/planar_gripper/gripper_brick.cc
+++ b/examples/planar_gripper/gripper_brick.cc
@@ -37,7 +37,7 @@ template <>
 void AddDrakeVisualizer<double>(
     systems::DiagramBuilder<double>* builder,
     const geometry::SceneGraph<double>& scene_graph) {
-  geometry::DrakeVisualizerd::AddToBuilder(builder, scene_graph);
+  geometry::DrakeVisualizerd::AddToBuilderForRoles(builder, scene_graph);
 }
 
 template <typename T>

--- a/examples/planar_gripper/planar_gripper_simulation.cc
+++ b/examples/planar_gripper/planar_gripper_simulation.cc
@@ -59,7 +59,7 @@
 #include "drake/geometry/drake_visualizer.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/multibody/parsing/parser.h"
-#include "drake/multibody/plant/contact_results_to_lcm.h"
+#include "drake/multibody/plant/drake_visualizer_config_functions.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/multibody/tree/revolute_joint.h"
@@ -76,7 +76,6 @@ namespace planar_gripper {
 namespace {
 
 using geometry::SceneGraph;
-using multibody::ConnectContactResultsToDrakeVisualizer;
 using multibody::JointActuatorIndex;
 using multibody::ModelInstanceIndex;
 using multibody::MultibodyPlant;
@@ -349,12 +348,10 @@ int DoMain() {
                     plant.get_actuation_input_port());
   }
 
-  geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph, lcm);
-
-  // Publish contact results for visualization.
-  if (FLAGS_visualize_contacts) {
-    ConnectContactResultsToDrakeVisualizer(&builder, plant, scene_graph, lcm);
-  }
+  multibody::DrakeVisualizerConfig config;
+  config.show_contact_results = FLAGS_visualize_contacts;
+  multibody::ApplyDrakeVisualizerConfig(
+      &builder, plant, scene_graph, lcm, config);
 
   // Publish planar gripper status via LCM.
   auto status_pub = builder.AddSystem(

--- a/examples/rimless_wheel/simulate.cc
+++ b/examples/rimless_wheel/simulate.cc
@@ -35,7 +35,7 @@ int DoMain() {
   RimlessWheelGeometry::AddToBuilder(
       &builder, rimless_wheel->get_floating_base_state_output_port(),
       scene_graph);
-  geometry::DrakeVisualizerd::AddToBuilder(&builder, *scene_graph);
+  geometry::DrakeVisualizerd::AddToBuilderForRoles(&builder, *scene_graph);
   auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);

--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -426,7 +426,7 @@ int do_main() {
   DrakeLcm lcm;
 
   // Visualize geometry.
-  DrakeVisualizerd::AddToBuilder(&builder, scene_graph, &lcm);
+  DrakeVisualizerd::AddToBuilderForRoles(&builder, scene_graph, &lcm);
 
   // Visualize contacts.
   auto& contact_to_lcm =

--- a/examples/simple_gripper/BUILD.bazel
+++ b/examples/simple_gripper/BUILD.bazel
@@ -42,7 +42,7 @@ drake_cc_binary(
         "//math:geometric_transform",
         "//multibody/parsing",
         "//multibody/plant",
-        "//multibody/plant:contact_results_to_lcm",
+        "//multibody/plant:drake_visualizer_config_functions",
         "//systems/analysis:simulator",
         "//systems/analysis:simulator_gflags",
         "//systems/analysis:simulator_print_stats",

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -8,12 +8,11 @@
 #include "drake/common/find_resource.h"
 #include "drake/geometry/drake_visualizer.h"
 #include "drake/geometry/scene_graph.h"
-#include "drake/lcm/drake_lcm.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/contact_results.h"
-#include "drake/multibody/plant/contact_results_to_lcm.h"
+#include "drake/multibody/plant/drake_visualizer_config_functions.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/systems/analysis/simulator.h"
@@ -30,11 +29,9 @@ namespace {
 using Eigen::Vector3d;
 using geometry::SceneGraph;
 using geometry::Sphere;
-using lcm::DrakeLcm;
 using math::RigidTransformd;
 using math::RollPitchYawd;
 using multibody::Body;
-using multibody::ConnectContactResultsToDrakeVisualizer;
 using multibody::CoulombFriction;
 using multibody::ModelInstanceIndex;
 using multibody::MultibodyPlant;
@@ -244,14 +241,12 @@ int do_main() {
   builder.Connect(scene_graph.get_query_output_port(),
                   plant.get_geometry_query_input_port());
 
-  DrakeLcm lcm;
-  geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph, &lcm);
   builder.Connect(
       plant.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(plant.get_source_id().value()));
 
   // Publish contact results for visualization.
-  ConnectContactResultsToDrakeVisualizer(&builder, plant, scene_graph, &lcm);
+  multibody::ApplyDrakeVisualizerConfig(&builder, plant, scene_graph);
 
   // Sinusoidal force input. We want the gripper to follow a trajectory of the
   // form x(t) = X0 * sin(ω⋅t). By differentiating once, we can compute the

--- a/geometry/drake_visualizer.h
+++ b/geometry/drake_visualizer.h
@@ -51,6 +51,11 @@ struct DeformableMeshData {
   int volume_vertex_count{};
 };
 
+/* Maybe add a suffix to the provided LCM channel name, based on the geometry
+ role. Channel name results for the kIllustration role will be unchanged. The
+ passed role cannot be kUnassigned. */
+std::string MakeLcmChannelNameForRole(const std::string& channel, Role role);
+
 }  // namespace internal
 
 /** A system that publishes LCM messages compatible with the `drake_visualizer`
@@ -66,11 +71,19 @@ struct DeformableMeshData {
  The %DrakeVisualizer system broadcasts three kinds of LCM messages:
 
    - a message that defines the non-deformable geometries in the world on the
- lcm channel named "DRAKE_VIEWER_LOAD_ROBOT"
+     lcm channel named "DRAKE_VIEWER_LOAD_ROBOT"
    - a message that updates the poses of those non-deformable geometries on the
- lcm channel named "DRAKE_VIEWER_DRAW",
+     lcm channel named "DRAKE_VIEWER_DRAW",
    - a message that sets the world space vertex positions of the deformable
-    geometries on the lcm channel named "DRAKE_VIEWER_DEFORMABLE"
+     geometries on the lcm channel named "DRAKE_VIEWER_DEFORMABLE"
+
+   The above channel names are modified according to the role specified in
+   DrakeVisualizerParams. This allows simultaneous availability of geometry
+   from multiple roles, by using multiple DrakeVisualizer instances.
+
+   - kIllustration: channel names are unchanged from above.
+   - kProximity: channel names gain a "_PROXIMITY" suffix.
+   - kPerception: channel names gain a "_PERCEPTION" suffix.
 
  The system uses the versioning mechanism provided by SceneGraph to detect
  changes to the geometry so that a change in SceneGraph's data will propagate
@@ -167,6 +180,9 @@ class DrakeVisualizer final : public systems::LeafSystem<T> {
     return this->get_input_port(query_object_input_port_);
   }
 
+  /** Returns the params data passed to the constructor. */
+  const DrakeVisualizerParams& params() { return this->params_; }
+
   /** @name Utility functions for instantiating and connecting a visualizer
 
    These methods provide a convenient mechanism for adding a DrakeVisualizer
@@ -197,6 +213,19 @@ class DrakeVisualizer final : public systems::LeafSystem<T> {
       const systems::OutputPort<T>& query_object_port,
       lcm::DrakeLcmInterface* lcm = nullptr, DrakeVisualizerParams params = {});
   //@}
+
+  /** Executes AddToBuilder() for multiple geometry roles. */
+  static std::vector<const DrakeVisualizer<T>*> AddToBuilderForRoles(
+      systems::DiagramBuilder<T>* builder, const SceneGraph<T>& scene_graph,
+      lcm::DrakeLcmInterface* lcm = nullptr,
+      DrakeVisualizerMultiRoleParams params = {});
+
+  /** Executes AddToBuilder() for multiple geometry roles. */
+  static std::vector<const DrakeVisualizer<T>*> AddToBuilderForRoles(
+      systems::DiagramBuilder<T>* builder,
+      const systems::OutputPort<T>& query_object_port,
+      lcm::DrakeLcmInterface* lcm = nullptr,
+      DrakeVisualizerMultiRoleParams params = {});
 
   // TODO(#7820) When we can easily bind lcmt_* messages, then replace
   //  the DispatchLoadMessage API with something like:
@@ -244,6 +273,7 @@ class DrakeVisualizer final : public systems::LeafSystem<T> {
    definition of the poses of all non-deformable geometries. */
   static void SendDrawNonDeformableMessage(
       const QueryObject<T>& query_object,
+      const DrakeVisualizerParams& params,
       const std::vector<internal::DynamicFrameData>& dynamic_frames,
       double time, lcm::DrakeLcmInterface* lcm);
 

--- a/geometry/drake_visualizer_params.h
+++ b/geometry/drake_visualizer_params.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/rgba.h"
 
@@ -28,6 +30,49 @@ struct DrakeVisualizerParams {
 
    To visualize these representations it is necessary to request visualization
    of geometries with the Role::kProximity role (see the role field). It is
+   further necessary to explicitly request the hydroelastic meshes where
+   available (setting show_hydroelastic to `true`).
+
+   Setting this `show_hydroelastic` to `true` will have no apparent effect if
+   none of the collision meshes have a hydroelastic mesh associated with them.
+   */
+  bool show_hydroelastic{false};
+};
+
+
+/** Data specifying a geometry role and its visualization parameters. */
+struct DrakeVisualizerRoleParams {
+  /** The role of the geometries to be sent to the visualizer.  */
+  Role role{Role::kIllustration};
+
+  /** The color to apply to any geometry that hasn't defined one.  */
+  Rgba default_color{0.9, 0.9, 0.9, 1.0};
+};
+
+/** Parameters for configuring multiple DrakeVisualizer systems for different
+ geometry roles. */
+struct DrakeVisualizerMultiRoleParams {
+  /** The roles (and their parameters) for which DrakeVisualizer systems will
+   * be realized and connected. While it is possible to encode redundant roles,
+   * only the first role entry for a given role will be obeyed. The rest will
+   * be ignored. */
+  std::vector<DrakeVisualizerRoleParams> roles{{Role::kIllustration},
+                                               {Role::kProximity}};
+
+  /** The duration (in seconds) between published LCM messages that update the
+   poses of the scene's geometry. (To help avoid small simulation timesteps, we
+   use a default period that has an exact representation in binary floating
+   point; see drake#15021 for details.) */
+  double publish_period{1 / 64.0};
+
+  /** When using the hydroelastic contact model, collision geometries that are
+   _declared_ as geometric primitives are frequently represented by some
+   discretely tessellated mesh when computing contact. It can be quite helpful
+   in assessing contact behavior to visualize these discrete meshes (in place of
+   the idealized primitives).
+
+   To visualize these representations it is necessary to request visualization
+   of geometries with the Role::kProximity role (see the roles field). It is
    further necessary to explicitly request the hydroelastic meshes where
    available (setting show_hydroelastic to `true`).
 

--- a/manipulation/util/show_model.py
+++ b/manipulation/util/show_model.py
@@ -60,6 +60,7 @@ from pydrake.common import FindResourceOrThrow
 from pydrake.geometry import (
     Cylinder,
     DrakeVisualizer,
+    DrakeVisualizerParams,
     GeometryInstance,
     MakePhongIllustrationProperties,
     Meshcat,
@@ -312,7 +313,7 @@ def parse_visualizers(args_parser, args):
 
     def connect_visualizers(builder, plant, scene_graph):
         # Connect this to drake_visualizer.
-        DrakeVisualizer.AddToBuilder(builder=builder, scene_graph=scene_graph)
+        DrakeVisualizer.AddToBuilderForRoles(builder, scene_graph)
 
         # Connect to Meshcat.  If the consuming application needs to connect,
         # e.g., JointSliders, the meshcat instance is required.

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -72,6 +72,28 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "drake_visualizer_config_functions",
+    srcs = ["drake_visualizer_config_functions.cc"],
+    hdrs = [
+        "drake_visualizer_config.h",
+        "drake_visualizer_config_functions.h",
+    ],
+    tags = [
+        # Don't add this library into the ":plant" package library.
+        # Use of MBP doesn't imply use of contact visualization so this
+        # dependency should be invoked explicitly.
+        "exclude_from_package",
+    ],
+    deps = [
+        ":contact_results_to_lcm",
+        ":multibody_plant_core",
+        "//geometry:drake_visualizer",
+        "//geometry:scene_graph",
+        "//systems/framework:diagram_builder",
+    ],
+)
+
+drake_cc_library(
     name = "tamsi_solver",
     srcs = ["tamsi_solver.cc"],
     hdrs = ["tamsi_solver.h"],

--- a/multibody/plant/drake_visualizer_config.h
+++ b/multibody/plant/drake_visualizer_config.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "drake/geometry/drake_visualizer_params.h"
+
+namespace drake {
+namespace multibody {
+
+/// The set of configurable properties for (potentially multiple)
+/// DrakeVisualizer systems in a multibody diagram.
+///
+// TODO(rpoyner-tri): serialization?
+struct DrakeVisualizerConfig {
+  /// Geometry roles.
+  geometry::DrakeVisualizerMultiRoleParams geometry_config;
+
+  /// Contact results.
+  // Note: Use the publish period already within geometry_config.
+  bool show_contact_results{true};
+};
+
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/drake_visualizer_config_functions.cc
+++ b/multibody/plant/drake_visualizer_config_functions.cc
@@ -1,0 +1,26 @@
+#include "drake/multibody/plant/drake_visualizer_config_functions.h"
+
+#include "drake/geometry/drake_visualizer.h"
+#include "drake/multibody/plant/contact_results_to_lcm.h"
+
+namespace drake {
+namespace multibody {
+
+void ApplyDrakeVisualizerConfig(
+    drake::systems::DiagramBuilder<double>* builder,
+    const drake::multibody::MultibodyPlant<double>& plant,
+    const drake::geometry::SceneGraph<double>& scene_graph,
+    lcm::DrakeLcmInterface* lcm,
+    const DrakeVisualizerConfig& config) {
+  geometry::DrakeVisualizerd::AddToBuilderForRoles(
+      builder, scene_graph, lcm, config.geometry_config);
+  if (config.show_contact_results) {
+    ConnectContactResultsToDrakeVisualizer(
+        builder, plant, scene_graph, lcm,
+        config.geometry_config.publish_period);
+  }
+}
+
+}  // namespace multibody
+}  // namespace drake
+

--- a/multibody/plant/drake_visualizer_config_functions.h
+++ b/multibody/plant/drake_visualizer_config_functions.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "drake/geometry/scene_graph.h"
+#include "drake/multibody/plant/drake_visualizer_config.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/lcm/lcm_publisher_system.h"
+
+namespace drake {
+namespace multibody {
+
+void ApplyDrakeVisualizerConfig(
+    drake::systems::DiagramBuilder<double>* builder,
+    const drake::multibody::MultibodyPlant<double>& plant,
+    const drake::geometry::SceneGraph<double>& scene_graph,
+    lcm::DrakeLcmInterface* lcm = nullptr,
+    const DrakeVisualizerConfig& config = {});
+
+}  // namespace multibody
+}  // namespace drake

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -72,6 +72,7 @@ LIBDRAKE_COMPONENTS = [
     "//multibody/parsing",
     "//multibody/plant",
     "//multibody/plant:contact_results_to_lcm",  # unpackaged
+    "//multibody/plant:drake_visualizer_config_functions",  # unpackaged
     "//multibody/topology:multibody_graph",  # unpackaged
     "//multibody/tree",
     "//multibody/triangle_quadrature",


### PR DESCRIPTION
Relevant issue: #13673
Contrasting prototype patch: #17311

This patch achieves multi-role visualization by allocating more lcm channel
names, and using multiple DrakeVisualizer systems to drive them. It patches
meldis to receive the new channels, and adds meldis-meshcat-specific sliders to
control alpha (transparency) of the various roles' geometries.

Usual caveats apply: questionable choices, lacks tests and doc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17328)
<!-- Reviewable:end -->
