### PR TITLE
[math] Fix SparseMatrixToTriplets to only permit sparse matrices

### DIFF
--- a/math/eigen_sparse_triplet.h
+++ b/math/eigen_sparse_triplet.h
@@ -14,14 +14,15 @@ namespace math {
  * See https://eigen.tuxfamily.org/dox/group__TutorialSparse.html for more
  * information on the triplet
  */
-template <typename Derived>
-std::vector<Eigen::Triplet<typename Derived::Scalar>> SparseMatrixToTriplets(
-    const Derived& matrix) {
-  using Scalar = typename Derived::Scalar;
+template <typename Scalar, int Options, typename StorageIndex>
+std::vector<Eigen::Triplet<Scalar>> SparseMatrixToTriplets(
+    const Eigen::SparseMatrix<Scalar, Options, StorageIndex>& matrix) {
+  using InnerIterator = typename Eigen::SparseMatrix<
+      Scalar, Options, StorageIndex>::InnerIterator;
   std::vector<Eigen::Triplet<Scalar>> triplets;
   triplets.reserve(matrix.nonZeros());
   for (int i = 0; i < matrix.outerSize(); i++) {
-    for (typename Derived::InnerIterator it(matrix, i); it; ++it) {
+    for (InnerIterator it(matrix, i); it; ++it) {
       triplets.push_back(
           Eigen::Triplet<Scalar>(it.row(), it.col(), it.value()));
     }

--- a/solvers/osqp_solver.cc
+++ b/solvers/osqp_solver.cc
@@ -28,18 +28,18 @@ void ParseQuadraticCosts(const MathematicalProgram& prog,
     const std::vector<int> x_indices = prog.FindDecisionVariableIndices(x);
 
     // Add quadratic_cost.Q to the Hessian P.
-    const std::vector<Eigen::Triplet<double>> Qi_triplets =
-        math::SparseMatrixToTriplets(quadratic_cost.evaluator()->Q());
-    P_triplets.reserve(P_triplets.size() + Qi_triplets.size());
-    for (int i = 0; i < static_cast<int>(Qi_triplets.size()); ++i) {
-      // Unpack the field of the triplet (for clarity below).
-      const int row = x_indices[Qi_triplets[i].row()];
-      const int col = x_indices[Qi_triplets[i].col()];
-      const double value = Qi_triplets[i].value();
-      // Since OSQP 0.6.0 the P matrix is required to be upper triangular, so
-      // we only add upper triangular entries to P_triplets.
-      if (row <= col) {
-        P_triplets.emplace_back(row, col, static_cast<c_float>(value));
+    // Since OSQP 0.6.0 the P matrix is required to be upper triangular, so
+    // we only add upper triangular entries to P_triplets.
+    const Eigen::MatrixXd& Q = quadratic_cost.evaluator()->Q();
+    for (int col = 0; col < Q.cols(); ++col) {
+      for (int row = 0; (row <= col) && (row < Q.rows()); ++row) {
+        const double value = Q(row, col);
+        if (value == 0.0) {
+          continue;
+        }
+        const int x_row = x_indices[row];
+        const int x_col = x_indices[col];
+        P_triplets.emplace_back(x_row, x_col, static_cast<c_float>(value));
       }
     }
 


### PR DESCRIPTION
When it was given a dense matrix by mistake, it included all of the zeros in the returned triplets (and induces a compilation error vs Eigen trunk).

Fix OsqpSolver to not try to pass a dense matrix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17331)
<!-- Reviewable:end -->
