### PR TITLE
[geometry] Compute contact surfaces for deformables

### DIFF
--- a/geometry/benchmarking/mesh_intersection_benchmark.cc
+++ b/geometry/benchmarking/mesh_intersection_benchmark.cc
@@ -236,9 +236,9 @@ BENCHMARK_DEFINE_F(MeshIntersectionBenchmark, RigidSoftMesh)
   std::unique_ptr<TriangleSurfaceMesh<double>> surface_SR;
   std::unique_ptr<TriangleSurfaceMeshFieldLinear<double, double>> e_SR;
   for (auto _ : state) {
-    SurfaceVolumeIntersector<TriangleSurfaceMesh<double>> intersector;
+    SurfaceVolumeIntersector<TriMeshBuilder<double>, Obb> intersector;
     intersector.SampleVolumeFieldOnSurface(field_S_, bvh_S, mesh_R_, bvh_R,
-                                           X_SR_, TriMeshBuilder<double>());
+                                           X_SR_);
     surface_SR = intersector.release_mesh();
     e_SR = intersector.release_field();
   }

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -21,6 +21,7 @@ drake_cc_package_library(
         ":contact_surface_utility",
         ":deformable_contact_geometries",
         ":deformable_contact_surface",
+        ":deformable_mesh_intersection",
         ":deformable_rigid_contact_pair",
         ":deformable_volume_mesh",
         ":field_intersection",
@@ -170,6 +171,21 @@ drake_cc_library(
     ],
     deps = [
         "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "deformable_mesh_intersection",
+    srcs = ["deformable_mesh_intersection.cc"],
+    hdrs = ["deformable_mesh_intersection.h"],
+    deps = [
+        ":bvh",
+        ":deformable_contact_geometries",
+        ":deformable_volume_mesh",
+        ":mesh_intersection",
+        ":triangle_surface_mesh",
+        "//geometry/query_results:contact_surface",
+        "//math:geometric_transform",
     ],
 )
 
@@ -847,6 +863,16 @@ drake_cc_googletest(
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
         "//geometry:proximity_properties",
+    ],
+)
+
+drake_cc_googletest(
+    name = "deformable_mesh_intersection_test",
+    deps = [
+        ":deformable_mesh_intersection",
+        ":make_box_mesh",
+        ":make_sphere_mesh",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/geometry/proximity/contact_surface_utility.h
+++ b/geometry/proximity/contact_surface_utility.h
@@ -54,6 +54,8 @@ class TriMeshBuilder {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(TriMeshBuilder);
 
   using ScalarType = T;
+  using MeshType = TriangleSurfaceMesh<T>;
+  using FieldType = TriangleSurfaceMeshFieldLinear<T, T>;
 
   TriMeshBuilder() = default;
 
@@ -95,8 +97,7 @@ class TriMeshBuilder {
 
   /* Create a mesh and field from the mesh data that has been aggregated by
    this builder. */
-  std::pair<std::unique_ptr<TriangleSurfaceMesh<T>>,
-            std::unique_ptr<TriangleSurfaceMeshFieldLinear<T, T>>>
+  std::pair<std::unique_ptr<MeshType>, std::unique_ptr<FieldType>>
   MakeMeshAndField();
 
  private:
@@ -118,6 +119,8 @@ class PolyMeshBuilder {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PolyMeshBuilder);
 
   using ScalarType = T;
+  using MeshType = PolygonSurfaceMesh<T>;
+  using FieldType = PolygonSurfaceMeshFieldLinear<T, T>;
 
   PolyMeshBuilder();
 
@@ -159,13 +162,18 @@ class PolyMeshBuilder {
 
   /* Create a mesh and field from the mesh data that has been aggregated by
    this builder. */
-  std::pair<std::unique_ptr<PolygonSurfaceMesh<T>>,
-            std::unique_ptr<PolygonSurfaceMeshFieldLinear<T, T>>>
+  std::pair<std::unique_ptr<MeshType>, std::unique_ptr<FieldType>>
   MakeMeshAndField();
 
   /* Expose the accumulated, per-face gradients for testing. */
   std::vector<Vector3<T>>& mutable_per_element_gradients() {
     return grad_e_MN_B_per_face_;
+  }
+
+  /* Expose the accumulated vertices measured and expressed in the
+   builder's frame B. */
+  const std::vector<Vector3<T>>& vertices() const {
+    return vertices_B_;
   }
 
  private:

--- a/geometry/proximity/deformable_mesh_intersection.cc
+++ b/geometry/proximity/deformable_mesh_intersection.cc
@@ -1,0 +1,136 @@
+#include "drake/geometry/proximity/deformable_mesh_intersection.h"
+
+#include <utility>
+#include <vector>
+
+#include "drake/geometry/proximity/contact_surface_utility.h"
+#include "drake/geometry/proximity/deformable_volume_mesh.h"
+#include "drake/geometry/proximity/mesh_intersection.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+// TODO(DamrongGuoy) Declare DeformableSurfaceVolumeIntersector in the header
+//  file to test it directly and for future code re-use.
+
+class DeformableSurfaceVolumeIntersector
+    : public SurfaceVolumeIntersector<PolyMeshBuilder<double>, Aabb> {
+ public:
+  /* Returns the indices of tetrahedra containing the contact polygons.
+   @pre Call it after SampleVolumeFieldOnSurface() finishes.  */
+  std::vector<int>& mutable_tetrahedron_index_of_polygons() {
+    return tetrahedron_index_of_polygons_;
+  }
+
+  /* Returns barycentric coordinates of the centroids of the contact polygons.
+   @pre Call it after SampleVolumeFieldOnSurface() finishes.  */
+  std::vector<VolumeMesh<double>::Barycentric<double>>&
+  mutable_barycentric_centroids() {
+    return barycentric_centroids_;
+  }
+
+ protected:
+  /* Override the parent class's virtual function to store additional
+   data for deformables. */
+  void CalcContactPolygon(
+      const VolumeMeshFieldLinear<double, double>& volume_field_D,
+      const TriangleSurfaceMesh<double>& surface_R,
+      const math::RigidTransform<T>& X_DR,
+      const math::RigidTransform<double>& X_DR_d,
+      PolyMeshBuilder<double>* builder_D,
+      bool filter_face_normal_along_field_gradient, int tet_index,
+      int tri_index) override {
+    const int num_vertices_before = builder_D->num_vertices();
+    // N.B. we must invoke the base implementation before recording any new
+    // data.
+    SurfaceVolumeIntersector<PolyMeshBuilder<double>, Aabb>::CalcContactPolygon(
+        volume_field_D, surface_R, X_DR, X_DR_d, builder_D,
+        filter_face_normal_along_field_gradient, tet_index, tri_index);
+    const int num_vertices_after = builder_D->num_vertices();
+    const int num_new_vertices = num_vertices_after - num_vertices_before;
+    if (num_new_vertices == 0) {
+      return;
+    }
+    tetrahedron_index_of_polygons_.push_back(tet_index);
+
+    // TODO(xuchenhan-tri): Consider accessing the newly added polygon from
+    //  the builder. Here we assume internal knowledge how the function
+    //  SurfaceVolumeIntersector::CalcContactPolygon works, i.e., the list of
+    //  new vertices form the new polygon in that order.
+    std::vector<int> polygon(num_vertices_after - num_vertices_before);
+    std::iota(polygon.begin(), polygon.end(), num_vertices_before);
+
+    barycentric_centroids_.push_back(volume_field_D.mesh().CalcBarycentric(
+        CalcPolygonCentroid(
+            polygon, X_DR_d.rotation() * surface_R.face_normal(tri_index),
+            builder_D->vertices()),
+        tet_index));
+  }
+
+ private:
+  std::vector<int> tetrahedron_index_of_polygons_{};
+  std::vector<VolumeMesh<double>::Barycentric<double>> barycentric_centroids_{};
+};
+
+std::unique_ptr<ContactSurface<double>>
+ComputeContactSurfaceFromDeformableVolumeRigidSurface(
+    const GeometryId deformable_id,
+    const deformable::DeformableGeometry& deformable_D,
+    const GeometryId rigid_id, const TriangleSurfaceMesh<double>& rigid_mesh_R,
+    const Bvh<Obb, TriangleSurfaceMesh<double>>& rigid_bvh_R,
+    const math::RigidTransform<double>& X_DR,
+    std::vector<int>* tetrahedron_index_of_polygons,
+    std::vector<VolumeMesh<double>::Barycentric<double>>*
+        barycentric_centroids) {
+  DRAKE_DEMAND(tetrahedron_index_of_polygons != nullptr);
+  DRAKE_DEMAND(barycentric_centroids != nullptr);
+  tetrahedron_index_of_polygons->clear();
+  barycentric_centroids->clear();
+
+  // TODO(DamrongGuoy) Is there a better way than creating a new
+  //  VolumeMeshFieldLinear here? We do it here, so we can reuse
+  //  SurfaceVolumeIntersector. These are some ideas that Xuchen and Damrong
+  //  consider for future refactoring:
+  //  1. Change the type parameter MeshBuilder of SurfaceVolumeIntersector<>
+  //     to provide the tetrahedral mesh. This includes TriMeshBuilder and
+  //     PolyMeshBuilder.
+  //  Or 2. Allow VolumeMeshFieldLinear to switch to a different tetrahedral
+  //        mesh while keeping the same field values at vertices. Assume that
+  //        the new mesh has the same connectivity.
+  //  Or 3. Pass an additional parameter for the tetrahedral mesh to
+  //        SampleVolumeFieldOnSurface(). Right now it uses the mesh of the
+  //        given VolumeMeshFieldLinear.
+  VolumeMeshFieldLinear<double, double> field_D(
+      std::vector<double>(deformable_D.signed_distance_field().values()),
+      &deformable_D.deformable_mesh().mesh(), true /*calculate gradient*/);
+
+  DeformableSurfaceVolumeIntersector intersect;
+  intersect.SampleVolumeFieldOnSurface(
+      field_D, deformable_D.deformable_mesh().bvh(), rigid_mesh_R, rigid_bvh_R,
+      X_DR, false /* don't filter face normal along field gradient */);
+
+  if (!intersect.has_intersection()) {
+    return {};
+  }
+
+  tetrahedron_index_of_polygons->swap(
+      intersect.mutable_tetrahedron_index_of_polygons());
+  barycentric_centroids->swap(intersect.mutable_barycentric_centroids());
+  // The contact surface is documented as having the normals pointing *out*
+  // of the second surface and into the first. This mesh intersection
+  // creates a surface mesh with normals pointing out of the rigid surface,
+  // so we make sure the ids are ordered so that the rigid is the second id.
+  auto contact_surface = std::make_unique<ContactSurface<double>>(
+      deformable_id, rigid_id, intersect.release_mesh(),
+      intersect.release_field(),
+      std::make_unique<std::vector<Vector3<double>>>(
+          std::move(intersect.mutable_grad_eM_M())),
+      nullptr);
+
+  return contact_surface;
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/deformable_mesh_intersection.h
+++ b/geometry/proximity/deformable_mesh_intersection.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "drake/geometry/proximity/bvh.h"
+#include "drake/geometry/proximity/deformable_contact_geometries.h"
+#include "drake/geometry/proximity/triangle_surface_mesh.h"
+#include "drake/geometry/query_results/contact_surface.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+// TODO(DamrongGuoy): Redefine DeformableContactSurface to have
+//  {ContactSurface, tetrahedron indices of polygons, and
+//  barycentric coordinates of centroids of polygons}. Then, return the
+//  DeformableContactSurface instead of returning ContactSurface with two
+//  output parameters. Possibly do it as a part of
+//  https://github.com/RobotLocomotion/drake/pull/17383.
+
+/* Computes the contact surface between a deformable geometry and a rigid
+ geometry.
+ @param[in] deformable_id
+     Id of the deformable geometry.
+ @param[in] deformable_D
+     A deformable geometry expressed in frame D. It provides the
+     deformed tetrahedral mesh and the approximated signed distance field.
+ @param[in] rigid_id
+     Id of the rigid geometry.
+ @param[in] rigid_mesh_R
+     The rigid geometry is represented as a surface mesh, whose vertices are
+     measusured and expressed in frame R. We assume that triangles are oriented
+     outward.
+ @param[in] rigid_bvh_R
+     A bounding volume hierarchy built on the geometry contained in
+     rigid_mesh_R.
+ @param[in] X_DR
+     The pose of the rigid geometry's frame R in deformable geometry's frame D.
+ @param[out] tetrahedron_index_of_polygons
+     Each contact polygon is completely contained within one tetrahedron of the
+     deformable mesh. For the i-th contact polygon in the contact surface,
+     tetrahedron_index_of_polygons[i] contains the index of the containing
+     tetrahedron.
+ @param[out] barycentric_centroids
+     Barycentric coordinates of centroids of contact polygons with respect to
+     their containing tetrahedra with the same index semantics as
+     `tetrahedron_index_of_poloygons`.
+
+ @retval contact_surface_W
+     The contact surface expressed in World frame with surface normals pointing
+     in the direction as described in the documentation for ContactSurface's
+     constructors.
+
+ @note contact_surface_W.num_faces() == tetrahedron_index_of_polygons.size().
+       contact_surface_W.num_faces() == barycentric_centroids.size().
+ @pre  tetrahedron_index_of_polygons is not nullptr.
+ @pre  barycentric_centroids is not nullptr.  */
+std::unique_ptr<ContactSurface<double>>
+ComputeContactSurfaceFromDeformableVolumeRigidSurface(
+    const GeometryId deformable_id,
+    const deformable::DeformableGeometry& deformable_D,
+    const GeometryId rigid_id,
+    const TriangleSurfaceMesh<double>& rigid_mesh_R,
+    const Bvh<Obb, TriangleSurfaceMesh<double>>& rigid_bvh_R,
+    const math::RigidTransform<double>& X_DR,
+    std::vector<int>* tetrahedron_index_of_polygons,
+    std::vector<VolumeMesh<double>::Barycentric<double>>*
+        barycentric_centroids);
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/deformable_mesh_intersection_test.cc
+++ b/geometry/proximity/test/deformable_mesh_intersection_test.cc
@@ -1,0 +1,157 @@
+#include "drake/geometry/proximity/deformable_mesh_intersection.h"
+
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity/deformable_contact_geometries.h"
+#include "drake/geometry/proximity/make_box_mesh.h"
+#include "drake/geometry/proximity/make_sphere_mesh.h"
+#include "drake/geometry/shape_specification.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+GTEST_TEST(ComputeContactSurfaceDeformableRigid, NoContact) {
+  const GeometryId deformable_id = GeometryId::get_new_id();
+  const Sphere unit_sphere(1.0);
+  const deformable::DeformableGeometry deformable_W(
+      unit_sphere, MakeSphereVolumeMesh<double>(
+                       unit_sphere, 10.0 /* very coarse resolution */,
+                       TessellationStrategy::kDenseInteriorVertices));
+
+  const GeometryId rigid_id = GeometryId::get_new_id();
+  // The cube of edge length 2.0 occupies the space [-1,1]x[-1,1]x[-1,1].
+  const TriangleSurfaceMesh<double> rigid_mesh_R = MakeBoxSurfaceMesh<double>(
+      Box::MakeCube(2.0), 10.0 /* very coarse resolution */);
+  const Bvh<Obb, TriangleSurfaceMesh<double>> rigid_bvh_R(rigid_mesh_R);
+
+  /* We use the knowledge that the coarsest sphere volume mesh is a octahedron
+   to pose the rigid surface so that
+     1. it does not intersect the deformable geometry, and
+     2. it does intersect the bounding volume (AABB) of at least one
+     tetrahedron.
+   Projected to the xy-plane, the setup of the two geometries looks like
+                                 ______
+                                |      |
+                          /|\   |      |  box surface (OBB)
+                        /  |  \ |______|
+      sphere volume   /____|____\
+      as octeherdron  \    |    /
+      (AABB)            \  |  /
+                          \|/
+   This setup helps us verify that when `CalcContactPolygon()` is called, but
+   there is no new intersection polygon, the code does the right thing. */
+  const double kEps = 1e-10;
+  math::RigidTransform<double> X_WR(
+      Vector3<double>{4.0 / 3 + kEps, 4.0 / 3 + kEps, 4.0 / 3 + kEps});
+
+  // Verify that the two BVHs have indeed collided.
+  bool bvhs_collide = false;
+  deformable_W.deformable_mesh().bvh().Collide(
+      rigid_bvh_R, X_WR, [&bvhs_collide](int, int) {
+        bvhs_collide = true;
+        return BvttCallbackResult::Terminate;
+      });
+  ASSERT_TRUE(bvhs_collide);
+
+  // Initialize these two variables as non-empty sequences of nonsense
+  // values expected to be become empty later.
+  std::vector<int> tetrahedron_index_of_polygons{2022, 6, 9};
+  std::vector<VolumeMesh<double>::Barycentric<double>> barycentric_centroids{
+      {0.1, 1.2, 2.3, 3.4}};
+  std::unique_ptr<ContactSurface<double>> contact_surface_W =
+      ComputeContactSurfaceFromDeformableVolumeRigidSurface(
+          deformable_id, deformable_W,
+          rigid_id, rigid_mesh_R, rigid_bvh_R, X_WR,
+          &tetrahedron_index_of_polygons,
+          &barycentric_centroids);
+
+  EXPECT_EQ(contact_surface_W, nullptr);
+  // Confirm that they become empty.
+  EXPECT_EQ(tetrahedron_index_of_polygons.size(), 0);
+  EXPECT_EQ(barycentric_centroids.size(), 0);
+}
+
+// Note that the deformable rigid contact surface computation largely utilizes
+// previously tested code in mesh_intersection.cc. The only thing it adds is the
+// detection and addition of tet indices and centroid coordinates. We only test
+// the newly added operations here in this test.
+GTEST_TEST(ComputeContactSurfaceDeformableRigid, OnePolygon) {
+  const GeometryId deformable_id = GeometryId::get_new_id();
+  const Sphere unit_sphere(1.0);
+  // We use only one tetrahedron for simplicity. The fact that it doesn't cover
+  // the sphere is irrelevant to this test.
+  const VolumeMesh<double> single_tetrahedron_mesh_W(
+      {{0, 1, 2, 3}}, {Vector3<double>::Zero(), Vector3<double>::UnitX(),
+                       Vector3<double>::UnitY(), Vector3<double>::UnitZ()});
+  const deformable::DeformableGeometry deformable_W(
+      unit_sphere, single_tetrahedron_mesh_W);
+
+  const GeometryId rigid_id = GeometryId::get_new_id();
+  // Single-triangle surface mesh with the triangle large enough to intersect
+  // the tetrahedron well.
+  const TriangleSurfaceMesh<double> rigid_mesh_R(
+      {{0, 1, 2}}, {Vector3<double>(-1, -1, 0), Vector3<double>(3, -1, 0),
+                    Vector3<double>(-1, 3, 0)});
+  const Bvh<Obb, TriangleSurfaceMesh<double>> rigid_bvh_R(rigid_mesh_R);
+
+  // Pose the rigid surface at Wz=0.5 so that it intersects the deformable
+  // octahedron somewhere on that surface (since the triangle is parallel to the
+  // xy-plane).
+  const math::RigidTransform<double> X_WR(Vector3<double>{0, 0, 0.5});
+
+  std::vector<int> tetrahedron_index_of_polygons;
+  std::vector<VolumeMesh<double>::Barycentric<double>> barycentric_centroids;
+  std::unique_ptr<ContactSurface<double>> contact_surface_W =
+      ComputeContactSurfaceFromDeformableVolumeRigidSurface(
+          deformable_id, deformable_W,
+          rigid_id, rigid_mesh_R, rigid_bvh_R, X_WR,
+          &tetrahedron_index_of_polygons,
+          &barycentric_centroids);
+
+  const int kExpectedNumPolygons = 1;
+  ASSERT_EQ(tetrahedron_index_of_polygons.size(), kExpectedNumPolygons);
+  ASSERT_EQ(barycentric_centroids.size(), kExpectedNumPolygons);
+
+  const std::vector<int> kExpectedTetrahedronIndexOfPolygons{0};
+  EXPECT_EQ(tetrahedron_index_of_polygons, kExpectedTetrahedronIndexOfPolygons);
+
+  // Since the triangle is quite large, its intersection with the
+  // tetrahedron is an isosceles right triangle with two edges of length 0.5.
+  // Its three vertices are at (0, 0, 0.5), (0.5, 0, 0.5), (0, 0.5, 0.5), not
+  // necessarily in this order. Its centroid is at (1/6, 1/6, 1/2).
+  const Vector3<double> kExpectedCentroid_W(1.0 / 6, 1.0 / 6, 1.0 / 2);
+  const VolumeMesh<double>::Barycentric<double> expected_barycentric =
+      single_tetrahedron_mesh_W.CalcBarycentric(kExpectedCentroid_W, 0);
+
+  const double kEps = 1e-14;
+  EXPECT_TRUE(
+      CompareMatrices(barycentric_centroids[0], expected_barycentric, kEps));
+
+  ASSERT_NE(contact_surface_W, nullptr);
+  EXPECT_EQ(contact_surface_W->num_faces(), kExpectedNumPolygons);
+  // Area of the isosceles right triangle with two edges of length 0.5 is
+  // 0.5 * 0.5 / 2 = 0.125.
+  EXPECT_NEAR(contact_surface_W->area(0), 0.125, kEps);
+  EXPECT_EQ(contact_surface_W->face_normal(0), Vector3<double>::UnitZ());
+  EXPECT_TRUE(CompareMatrices(contact_surface_W->centroid(0),
+                              kExpectedCentroid_W, kEps));
+
+  const double signed_distance_at_centroid_of_polygon0 =
+      contact_surface_W->poly_e_MN().EvaluateCartesian(
+          0, contact_surface_W->centroid(0));
+  // The approximated signed distance function on the tetrahedron is
+  // s(x,y,z) = x + y + z - 1.  Therefore, the centroid (1/6, 1/6, 1/2) has
+  // the signed distance = 1/6 + 1/6 + 1/2 - 1 = -1/6
+  EXPECT_NEAR(signed_distance_at_centroid_of_polygon0,
+              -1.0 / 6, kEps);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/mesh_intersection_test.cc
+++ b/geometry/proximity/test/mesh_intersection_test.cc
@@ -31,10 +31,10 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
-template<typename MeshType>
+template<typename MeshBuilder>
 class SurfaceVolumeIntersectorTester {
  public:
-  using T = typename MeshType::ScalarType;
+  using T = typename MeshBuilder::ScalarType;
 
   const std::vector<Vector3<T>>& ClipTriangleByTetrahedron(
       int element, const VolumeMesh<double>& volume_M, int face,
@@ -52,7 +52,7 @@ class SurfaceVolumeIntersectorTester {
   }
 
  private:
-  SurfaceVolumeIntersector<MeshType> intersect_;
+  SurfaceVolumeIntersector<MeshBuilder, Obb> intersect_;
 };
 
 namespace {
@@ -503,9 +503,9 @@ bool CompareConvexPolygon(const std::vector<Vector3<T>>& polygon0,
 }
 
 /* This test is independent of ContactSurface mesh representation; so we'll
- simply use TriangleSurfaceMesh. */
+ simply use TriangleMeshBuilder. */
 GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
-  using MeshType = TriangleSurfaceMesh<double>;
+  using MeshBuilder = TriMeshBuilder<double>;
 
   auto volume_M = TrivialVolumeMesh<double>();
   auto surface_N = TrivialSurfaceMesh<double>();
@@ -525,7 +525,7 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
   {
     const auto X_MN = RigidTransformd(Vector3d::UnitX());
     const std::vector<Vector3d> polygon =
-        SurfaceVolumeIntersectorTester<MeshType>().ClipTriangleByTetrahedron(
+        SurfaceVolumeIntersectorTester<MeshBuilder>().ClipTriangleByTetrahedron(
             element0, *volume_M, face, *surface_N, X_MN);
     const std::vector<Vector3d> expect_empty_polygon;
     EXPECT_TRUE(CompareConvexPolygon(expect_empty_polygon, polygon));
@@ -537,7 +537,7 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
     const auto X_MN = RigidTransformd(RollPitchYawd(0, 0, M_PI_2),
                                              Vector3d::Zero());
     const std::vector<Vector3d> polygon =
-        SurfaceVolumeIntersectorTester<MeshType>().ClipTriangleByTetrahedron(
+        SurfaceVolumeIntersectorTester<MeshBuilder>().ClipTriangleByTetrahedron(
             element0, *volume_M, face, *surface_N, X_MN);
     EXPECT_TRUE(CompareConvexPolygon(empty_polygon, polygon));
   }
@@ -550,10 +550,10 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
   {
     const auto X_MN = RigidTransformd::Identity();
     const std::vector<Vector3d> polygon0_M =
-        SurfaceVolumeIntersectorTester<MeshType>().ClipTriangleByTetrahedron(
+        SurfaceVolumeIntersectorTester<MeshBuilder>().ClipTriangleByTetrahedron(
             element0, *volume_M, face, *surface_N, X_MN);
     const std::vector<Vector3d> polygon1_M =
-        SurfaceVolumeIntersectorTester<MeshType>().ClipTriangleByTetrahedron(
+        SurfaceVolumeIntersectorTester<MeshBuilder>().ClipTriangleByTetrahedron(
             element1, *volume_M, face, *surface_N, X_MN);
     // clang-format off
     const std::vector<Vector3d> expect_triangle_M{
@@ -570,7 +570,7 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
   {
     const auto X_MN = RigidTransformd(Vector3d(0, 0, 0.5));
     const std::vector<Vector3d> polygon0_M =
-        SurfaceVolumeIntersectorTester<MeshType>().ClipTriangleByTetrahedron(
+        SurfaceVolumeIntersectorTester<MeshBuilder>().ClipTriangleByTetrahedron(
             element0, *volume_M, face, *surface_N, X_MN);
     // clang-format off
     const std::vector<Vector3d> expect_triangle_M{
@@ -586,7 +586,7 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
   {
     const auto X_MN = RigidTransformd(Vector3d(0, 0, 0.5));
     const std::vector<Vector3d> polygon1_M =
-        SurfaceVolumeIntersectorTester<MeshType>().ClipTriangleByTetrahedron(
+        SurfaceVolumeIntersectorTester<MeshBuilder>().ClipTriangleByTetrahedron(
             element1, *volume_M, face, *surface_N, X_MN);
     EXPECT_TRUE(CompareConvexPolygon(empty_polygon, polygon1_M));
   }
@@ -597,7 +597,7 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
     const auto X_MN = RigidTransformd(RollPitchYawd(0, 0, M_PI),
                                              Vector3d(0.5, 0.5, 0));
     const std::vector<Vector3d> polygon0_M =
-        SurfaceVolumeIntersectorTester<MeshType>().ClipTriangleByTetrahedron(
+        SurfaceVolumeIntersectorTester<MeshBuilder>().ClipTriangleByTetrahedron(
             element0, *volume_M, face, *surface_N, X_MN);
     // clang-format off
     const std::vector<Vector3d> expect_square_M{
@@ -661,9 +661,9 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
 //    t2(0,-1.5,0) will do. See the above picture.
 //
 // This test is independent of ContactSurface mesh representation; so we'll
-// simply use TriangleSurfaceMesh.
+// simply use TriMeshBuilder.
 GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedronIntoHeptagon) {
-  using MeshType = TriangleSurfaceMesh<double>;
+  using MeshBuilder = TriMeshBuilder<double>;
 
   unique_ptr<VolumeMesh<double>> volume_M;
   {
@@ -697,7 +697,7 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedronIntoHeptagon) {
   const int triangle = 0;
   const auto X_MN = RigidTransformd::Identity();
   const std::vector<Vector3d> polygon_M =
-      SurfaceVolumeIntersectorTester<MeshType>().ClipTriangleByTetrahedron(
+      SurfaceVolumeIntersectorTester<MeshBuilder>().ClipTriangleByTetrahedron(
           tetrahedron, *volume_M, triangle, *surface_N, X_MN);
   // clang-format off
   const std::vector<Vector3d> expect_heptagon_M{
@@ -714,9 +714,9 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedronIntoHeptagon) {
 }
 
 /* This test is independent of ContactSurface mesh representation; so we'll
- simply use TriangleSurfaceMesh. */
+ simply use TriMeshBuilder. */
 GTEST_TEST(MeshIntersectionTest, IsFaceNormalAlongPressureGradient) {
-  using MeshType = TriangleSurfaceMesh<double>;
+  using MeshBuilder = TriMeshBuilder<double>;
 
   // It is ok to use the trivial mesh and trivial mesh field in this test.
   // The function under test asks for the gradient values and operates on it.
@@ -762,7 +762,7 @@ GTEST_TEST(MeshIntersectionTest, IsFaceNormalAlongPressureGradient) {
     // general X_MN as an argument to the tested function
     // IsFaceNormalAlongPressureGradient().
     const auto X_MN = X_MF * X_FN;
-    EXPECT_EQ(t.expect_result, SurfaceVolumeIntersectorTester<MeshType>()
+    EXPECT_EQ(t.expect_result, SurfaceVolumeIntersectorTester<MeshBuilder>()
                                    .IsFaceNormalAlongPressureGradient(
                                        *volume_field_M, *rigid_N, X_MN,
                                        0 /*tet_index*/, 0 /*tri_index*/));
@@ -800,19 +800,12 @@ int GetTetForFace(
       f));
 }
 
-template <typename MeshType>
-using MeshBuilderForMesh = std::conditional_t<
-    std::is_same_v<MeshType,
-                   TriangleSurfaceMesh<typename MeshType::ScalarType>>,
-    TriMeshBuilder<typename MeshType::ScalarType>,
-    PolyMeshBuilder<typename MeshType::ScalarType>>;
-
 // This fixture will test SampleVolumeFieldOnSurface() and
 // ComputeContactSurfaceFromSoftVolumeRigidSurface(). The latter is the main API
 // of this module and calls the former. They share many parameters. This
 // fixture uses `double` for checking the algorithm. There is another fixture
 // that uses `AutoDiffXd` for checking derivatives.
-template <typename MeshType>
+template <typename MeshBuilder>
 class MeshIntersectionFixture : public testing::Test {
  protected:
   void SetUp() override {
@@ -835,8 +828,8 @@ class MeshIntersectionFixture : public testing::Test {
   // This helper function verifies the output (surface_S, e_field, and
   // grad_eS_S) of SampleVolumeFieldOnSurface().
   void VerifySampleVolumeFieldOnSurface(
-      const MeshType& surface_S,
-      const typename SurfaceVolumeIntersector<MeshType>::FieldType& e_field,
+      const typename MeshBuilder::MeshType& surface_S,
+      const typename MeshBuilder::FieldType& e_field,
       const vector<Vector3<double>>& grad_eS_S) {
     // The two geometries intersect such that both tets get sliced into
     // identical right, isosceles triangles (with a leg length of 0.25m). The
@@ -914,14 +907,14 @@ class MeshIntersectionFixture : public testing::Test {
       const ContactSurface<double>& contact_SR,
       const ContactSurface<double>& contact_RS,
       const RigidTransformd& X_WS) {
-    using FieldType = typename SurfaceVolumeIntersector<MeshType>::FieldType;
-    const MeshType* mesh_SR_raw{};
+    using FieldType = typename MeshBuilder::FieldType;
+    const typename MeshBuilder::MeshType* mesh_SR_raw{};
     const FieldType* field_SR_raw{};
-    const MeshType* mesh_RS_raw{};
+    const typename MeshBuilder::MeshType* mesh_RS_raw{};
     const FieldType* field_RS_raw{};
-    if constexpr (std::is_same_v<
-                      MeshType,
-                      TriangleSurfaceMesh<typename MeshType::ScalarType>>) {
+    if constexpr (std::is_same_v<typename MeshBuilder::MeshType,
+                                 TriangleSurfaceMesh<
+                                     typename MeshBuilder::ScalarType>>) {
       mesh_SR_raw = &contact_SR.tri_mesh_W();
       field_SR_raw = &contact_SR.tri_e_MN();
       mesh_RS_raw = &contact_RS.tri_mesh_W();
@@ -932,9 +925,9 @@ class MeshIntersectionFixture : public testing::Test {
       mesh_RS_raw = &contact_RS.poly_mesh_W();
       field_RS_raw = &contact_RS.poly_e_MN();
     }
-    const MeshType& mesh_SR_W = *mesh_SR_raw;
+    const typename MeshBuilder::MeshType& mesh_SR_W = *mesh_SR_raw;
     const FieldType& field_SR_W = *field_SR_raw;
-    const MeshType& mesh_RS_W = *mesh_RS_raw;
+    const typename MeshBuilder::MeshType& mesh_RS_W = *mesh_RS_raw;
     const FieldType& field_RS_W = *field_RS_raw;
 
     // Mesh invariants:
@@ -985,26 +978,27 @@ class MeshIntersectionFixture : public testing::Test {
   static constexpr double kEps = std::numeric_limits<double>::epsilon();
 };
 
-using MeshTypes =
-    ::testing::Types<TriangleSurfaceMesh<double>, PolygonSurfaceMesh<double>>;
-TYPED_TEST_SUITE(MeshIntersectionFixture, MeshTypes);
+using MeshBuilders =
+    ::testing::Types<TriMeshBuilder<double>, PolyMeshBuilder<double>>;
+TYPED_TEST_SUITE(MeshIntersectionFixture, MeshBuilders);
 
 // A simple smoke test. We perform the collision, confirm the face count of the
 // contact surface's mesh, and then confirm that the we've sampled the compliant
 // mesh's pressure field.
 TYPED_TEST(MeshIntersectionFixture, SampleVolumeFieldOnSurface) {
-  using MeshType = TypeParam;
-  using T = typename MeshType::ScalarType;
+  using MeshBuilder = TypeParam;
 
-  SurfaceVolumeIntersector<MeshType> intersector;
+  SurfaceVolumeIntersector<MeshBuilder, Obb> intersector;
   intersector.SampleVolumeFieldOnSurface(
       *this->field_S_, *this->bvh_mesh_S_, *this->surface_R_,
-      *this->bvh_surface_R_, this->X_SR_, MeshBuilderForMesh<MeshType>());
+      *this->bvh_surface_R_, this->X_SR_);
 
   const auto& surface_S = intersector.mutable_mesh();
   // The two meshes intersected forming two triangles. Each mesh type responds
   // slightly differently.
-  if constexpr (std::is_same_v<MeshType, TriangleSurfaceMesh<T>>) {
+  if constexpr (std::is_same_v<
+                    typename MeshBuilder::MeshType,
+                    TriangleSurfaceMesh<typename MeshBuilder::ScalarType>>) {
     // Two triangles tesselate around centroids into six in TriangleSurfaceMesh.
     EXPECT_EQ(6, surface_S.num_elements());
   } else {
@@ -1033,12 +1027,11 @@ TYPED_TEST(MeshIntersectionFixture, TestComputeContactSurfaceSoftRigid) {
   const RigidTransformd X_WS = RigidTransformd::Identity();
   const RigidTransformd X_WR = X_WS * this->X_SR_;
 
-  using MeshType = TypeParam;
-  using T = typename MeshType::ScalarType;
-
+  using MeshBuilder = TypeParam;
   HydroelasticContactRepresentation representation =
       HydroelasticContactRepresentation::kTriangle;
-  if (!std::is_same_v<MeshType, TriangleSurfaceMesh<T>>) {
+  if (!std::is_same_v<typename MeshBuilder::MeshType,
+                      TriangleSurfaceMesh<typename MeshBuilder::ScalarType>>) {
     representation = HydroelasticContactRepresentation::kPolygon;
   }
 


### PR DESCRIPTION
Resolve #17318 

  - Reuse hydroelastic SurfaceVolumeIntersector<> for deformables.
  - Its template parameter MeshBuilder specifies output MeshType and FieldType.
  - Add template parameter BvType to use Obb for compliant hydroelastic geometry
    and Aabb for deformable geometry.
  - Factor out the virtual CalcContactPolygon() for hydroelastics. It is overridden
    for deformables to collect more deformable-specific data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17339)
<!-- Reviewable:end -->
