### PR TITLE
DRAKE_EXPECT_THROWS_MESSAGE now requires an expression

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -904,7 +904,6 @@ drake_cc_googletest(
     deps = [
         ":identifier",
         ":sorted_pair",
-        ":unused",
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
     ],
@@ -1450,7 +1449,6 @@ drake_cc_googletest(
     name = "type_safe_index_test",
     deps = [
         ":type_safe_index",
-        ":unused",
         "//common:sorted_pair",
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",

--- a/common/test/identifier_test.cc
+++ b/common/test/identifier_test.cc
@@ -11,7 +11,6 @@
 #include "drake/common/sorted_pair.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
-#include "drake/common/unused.h"
 
 namespace drake {
 namespace {
@@ -227,7 +226,7 @@ TEST_F(IdentifierTests, InvalidGetValueCall) {
   if (kDrakeAssertIsDisarmed) { return; }
   AId invalid;
   DRAKE_EXPECT_THROWS_MESSAGE(
-      unused(invalid.get_value()),
+      invalid.get_value(),
       ".*is_valid.*failed.*");
 }
 
@@ -235,14 +234,14 @@ TEST_F(IdentifierTests, InvalidGetValueCall) {
 TEST_F(IdentifierTests, InvalidEqualityCompare) {
   if (kDrakeAssertIsDisarmed) { return; }
   AId invalid;
-  DRAKE_EXPECT_THROWS_MESSAGE(unused(invalid == a1_), ".*is_valid.*failed.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(invalid == a1_, ".*is_valid.*failed.*");
 }
 
 // Comparison of invalid ids is an error.
 TEST_F(IdentifierTests, InvalidInequalityCompare) {
   if (kDrakeAssertIsDisarmed) { return; }
   AId invalid;
-  DRAKE_EXPECT_THROWS_MESSAGE(unused(invalid != a1_), ".*is_valid.*failed.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(invalid != a1_, ".*is_valid.*failed.*");
 }
 
 // Comparison of invalid ids is an error.
@@ -251,7 +250,7 @@ TEST_F(IdentifierTests, BadInvalidOrSameComparison) {
     return;
   }
   AId invalid;
-  DRAKE_EXPECT_THROWS_MESSAGE(unused(a1_.is_same_as_valid_id(invalid)),
+  DRAKE_EXPECT_THROWS_MESSAGE(a1_.is_same_as_valid_id(invalid),
                               ".*is_valid.*failed.*");
 }
 
@@ -270,7 +269,7 @@ TEST_F(IdentifierTests, InvalidStream) {
   if (kDrakeAssertIsDisarmed) { return; }
   AId invalid;
   std::stringstream ss;
-  DRAKE_EXPECT_THROWS_MESSAGE(unused(ss << invalid), ".*is_valid.*failed.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(ss << invalid, ".*is_valid.*failed.*");
 }
 
 }  // namespace

--- a/common/test/type_safe_index_test.cc
+++ b/common/test/type_safe_index_test.cc
@@ -15,7 +15,6 @@
 #include "drake/common/sorted_pair.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
-#include "drake/common/unused.h"
 
 namespace drake {
 namespace common {
@@ -46,8 +45,7 @@ GTEST_TEST(TypeSafeIndex, Constructor) {
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
       AIndex(-1),
       "Explicitly constructing an invalid index.+");
-  DRAKE_EXPECT_NO_THROW(
-      unused(AIndex(invalid)));  // Copy construct invalid index.
+  DRAKE_EXPECT_NO_THROW(AIndex{invalid});  // Copy construct invalid index.
 }
 
 // Verifies the constructor behavior -- in debug and release modes.
@@ -114,7 +112,7 @@ GTEST_TEST(TypeSafeIndex, ConversionToInt) {
   EXPECT_EQ(four, index);
 
   AIndex invalid;
-  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(unused(static_cast<int>(invalid)),
+  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(static_cast<int>(invalid),
                                       "Converting to an int.+");
 }
 
@@ -146,29 +144,29 @@ GTEST_TEST(TypeSafeIndex, InvalidIndexComparisonOperators) {
   AIndex invalid;
 
   // Comparison operators.
-  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(unused(invalid == valid),
+  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(invalid == valid,
                                       "Testing == with invalid LHS.+");
-  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(unused(valid == invalid),
+  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(valid == invalid,
                                       "Testing == with invalid RHS.+");
-  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(unused(invalid != valid),
+  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(invalid != valid,
                                       "Testing != with invalid LHS.+");
-  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(unused(valid != invalid),
+  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(valid != invalid,
                                       "Testing != with invalid RHS.+");
-  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(unused(invalid < valid),
+  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(invalid < valid,
                                       "Testing < with invalid LHS.+");
-  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(unused(valid < invalid),
+  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(valid < invalid,
                                       "Testing < with invalid RHS.+");
-  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(unused(invalid <= valid),
+  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(invalid <= valid,
                                       "Testing <= with invalid LHS.+");
-  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(unused(valid <= invalid),
+  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(valid <= invalid,
                                       "Testing <= with invalid RHS.+");
-  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(unused(invalid > valid),
+  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(invalid > valid,
                                       "Testing > with invalid LHS.+");
-  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(unused(valid > invalid),
+  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(valid > invalid,
                                       "Testing > with invalid RHS.+");
-  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(unused(invalid >= valid),
+  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(invalid >= valid,
                                       "Testing >= with invalid LHS.+");
-  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(unused(valid >= invalid),
+  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(valid >= invalid,
                                       "Testing >= with invalid RHS.+");
 }
 
@@ -478,7 +476,7 @@ GTEST_TEST(IntegralComparisons, CompareSizeT) {
   const size_t small_overflow_value = 2300000000;
   EXPECT_LT(static_cast<int>(small_overflow_value), 0);
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
-      AIndex junk(small_overflow_value),
+      AIndex(small_overflow_value),
       "Explicitly constructing an invalid index. Type .* has an invalid "
           "value; it must lie in the range .*");
 
@@ -487,7 +485,7 @@ GTEST_TEST(IntegralComparisons, CompareSizeT) {
   const size_t big_overflow_value = (1L << 48) | 0x1;
   EXPECT_GT(static_cast<int>(big_overflow_value), 0);
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
-      AIndex junk(big_overflow_value),
+      AIndex(big_overflow_value),
       "Explicitly constructing an invalid index. Type .* has an invalid "
           "value; it must lie in the range .*");
 

--- a/common/test_utilities/expect_throws_message.h
+++ b/common/test_utilities/expect_throws_message.h
@@ -60,7 +60,7 @@ whenever `DRAKE_ENABLE_ASSERTS` is defined, which Debug builds do by default.
     expression, regexp, must_throw, fatal_failure) \
 do { \
 try { \
-  expression; \
+  static_cast<void>(expression); \
   if (must_throw) { \
     std::string message = "\tExpected: " #expression " throws an exception.\n" \
                           " Actual: it throws nothing"; \

--- a/geometry/render/dev/render_gltf_client/test/internal_render_client_test.cc
+++ b/geometry/render/dev/render_gltf_client/test/internal_render_client_test.cc
@@ -541,7 +541,7 @@ GTEST_TEST(RenderClient, RenderOnServer) {
         });
     DRAKE_EXPECT_THROWS_MESSAGE(
         client.RenderOnServer(color_camera.core(),
-                              RenderImageType::kColorRgba8U, fake_scene_path);
+                              RenderImageType::kColorRgba8U, fake_scene_path)
         ,
         fmt::format(
             "ERROR with POST /{} response from server, base_url={}:{}, HTTP "

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -110,7 +110,7 @@ GTEST_TEST(MeshcatTest, Ports) {
   EXPECT_EQ(meshcat.port(), 7050);
 
   // Can't open the same port twice.
-  DRAKE_EXPECT_THROWS_MESSAGE(Meshcat m2(7050),
+  DRAKE_EXPECT_THROWS_MESSAGE(Meshcat(7050),
                               "Meshcat failed to open a websocket port.");
 
   // The default constructor gets a default port.

--- a/multibody/contact_solvers/sap/test/partial_permutation_test.cc
+++ b/multibody/contact_solvers/sap/test/partial_permutation_test.cc
@@ -118,7 +118,7 @@ GTEST_TEST(PartialPermutation, PermutedDomainIsLargerThanOriginalDomain) {
   // The input permutation is invalid since index = 4 is out-of-bounds for a
   // domain of size 4.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      PartialPermutation p({0, -1, 4, 1}),
+      PartialPermutation({0, -1, 4, 1}),
       "The size of the permuted domain must be smaller or equal than that of "
       "the original domian. Index 4, larger or equal than the domain size, "
       "appears in the input permutation.");
@@ -126,13 +126,13 @@ GTEST_TEST(PartialPermutation, PermutedDomainIsLargerThanOriginalDomain) {
 
 // Verifies the constructor throws if there are repeated indexes.
 GTEST_TEST(PartialPermutation, RepeatedIndex) {
-  DRAKE_EXPECT_THROWS_MESSAGE(PartialPermutation dut({0, -1, 2, 2}),
+  DRAKE_EXPECT_THROWS_MESSAGE(PartialPermutation({0, -1, 2, 2}),
                               "Index 2 appears at least twice in the input "
                               "permutation. At 2 and at 3.");
 }
 
 GTEST_TEST(PartialPermutation, MissingIndex) {
-  DRAKE_EXPECT_THROWS_MESSAGE(PartialPermutation dut({0, -1, -1, 4, 1}),
+  DRAKE_EXPECT_THROWS_MESSAGE(PartialPermutation({0, -1, -1, 4, 1}),
                               "Index 2 not present in the permutation. However "
                               "the maximum specified permuted index is 4.");
 }

--- a/multibody/contact_solvers/test/supernodal_solver_test.cc
+++ b/multibody/contact_solvers/test/supernodal_solver_test.cc
@@ -213,7 +213,7 @@ GTEST_TEST(SupernodalSolver, EmptyJacobianColumn) {
   // clang-format on
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      SuperNodalSolver solver(num_row_blocks_of_J, Jtriplets, blocks_of_M),
+      SuperNodalSolver(num_row_blocks_of_J, Jtriplets, blocks_of_M),
       "Invalid Jacobian triplets: no triplet provided for column 1.");
 }
 
@@ -244,7 +244,7 @@ GTEST_TEST(SupernodalSolver, MoreThanTwoBlocksPerRowInTheJacobian) {
   // clang-format on
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      SuperNodalSolver solver(num_row_blocks_of_J, Jtriplets, blocks_of_M),
+      SuperNodalSolver(num_row_blocks_of_J, Jtriplets, blocks_of_M),
       "Jacobian can only be nonzero on at most two column blocks.");
 }
 

--- a/multibody/tree/test/articulated_body_inertia_test.cc
+++ b/multibody/tree/test/articulated_body_inertia_test.cc
@@ -202,7 +202,7 @@ GTEST_TEST(ArticulatedBodyInertia, Symbolic) {
   DRAKE_EXPECT_NO_THROW(ArticulatedBodyInertia<symbolic::Expression> Ds(
       -Matrix6<symbolic::Expression>::Identity()));
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
-      ArticulatedBodyInertia<double> Ds(-Matrix6<double>::Identity()),
+      ArticulatedBodyInertia<double>(-Matrix6<double>::Identity()),
       "The resulting articulated body inertia is not physically "
       "valid.[\\s\\S]*");
 }

--- a/systems/analysis/test/antiderivative_function_deprecated_test.cc
+++ b/systems/analysis/test/antiderivative_function_deprecated_test.cc
@@ -116,33 +116,33 @@ GTEST_TEST(AntiderivativeFunctionTest, EvaluatePreconditionValidation) {
           kInvalidUpperIntegrationBound),
       kInvalidIntegrationBoundErrorMessage);
 
-  DRAKE_EXPECT_THROWS_MESSAGE({
+  DRAKE_EXPECT_THROWS_MESSAGE([&]() {
       AntiderivativeFunction<double>::IntegrableFunctionContext values;
       values.k = kInvalidParameters;
       antiderivative_function.Evaluate(
           kValidUpperIntegrationBound, values);
-    }, kInvalidParametersErrorMessage);
+    }(), kInvalidParametersErrorMessage);
 
-  DRAKE_EXPECT_THROWS_MESSAGE({
+  DRAKE_EXPECT_THROWS_MESSAGE([&]() {
       AntiderivativeFunction<double>::IntegrableFunctionContext values;
       values.k = kInvalidParameters;
       antiderivative_function.MakeDenseEvalFunction(
           kValidUpperIntegrationBound, values);
-    }, kInvalidParametersErrorMessage);
+    }(), kInvalidParametersErrorMessage);
 
-  DRAKE_EXPECT_THROWS_MESSAGE({
+  DRAKE_EXPECT_THROWS_MESSAGE([&]() {
     AntiderivativeFunction<double>::IntegrableFunctionContext values;
     values.k = kValidParameters;
     antiderivative_function.Evaluate(
         kInvalidUpperIntegrationBound, values);
-    }, kInvalidIntegrationBoundErrorMessage);
+    }(), kInvalidIntegrationBoundErrorMessage);
 
-  DRAKE_EXPECT_THROWS_MESSAGE({
+  DRAKE_EXPECT_THROWS_MESSAGE([&]() {
     AntiderivativeFunction<double>::IntegrableFunctionContext values;
     values.k = kValidParameters;
     antiderivative_function.MakeDenseEvalFunction(
         kInvalidUpperIntegrationBound, values);
-    }, kInvalidIntegrationBoundErrorMessage);
+    }(), kInvalidIntegrationBoundErrorMessage);
 }
 
 class AntiderivativeFunctionAccuracyTest

--- a/systems/analysis/test/initial_value_problem_deprecated_test.cc
+++ b/systems/analysis/test/initial_value_problem_deprecated_test.cc
@@ -86,39 +86,39 @@ GTEST_TEST(InitialValueProblemTest, ConstructionPreconditionsValidation) {
     return -x * t;
   };
 
-  DRAKE_EXPECT_THROWS_MESSAGE({
+  DRAKE_EXPECT_THROWS_MESSAGE([&]() {
       const InitialValueProblem<double>::
           OdeContext no_values;
       const InitialValueProblem<double> ivp(
           dummy_ode_function, no_values);
-    }, "No default.*");
+    }(), "No default.*");
 
-  DRAKE_EXPECT_THROWS_MESSAGE({
+  DRAKE_EXPECT_THROWS_MESSAGE([&]() {
       InitialValueProblem<double>::
           OdeContext values_without_t0;
       values_without_t0.k = VectorX<double>();
       values_without_t0.x0 = VectorX<double>::Zero(2).eval();
       const InitialValueProblem<double> ivp(
           dummy_ode_function, values_without_t0);
-    }, "No default initial time.*");
+    }(), "No default initial time.*");
 
-  DRAKE_EXPECT_THROWS_MESSAGE({
+  DRAKE_EXPECT_THROWS_MESSAGE([&]() {
       InitialValueProblem<double>::
           OdeContext values_without_x0;
       values_without_x0.t0 = 0.0;
       values_without_x0.k = VectorX<double>();
       const InitialValueProblem<double> ivp(
           dummy_ode_function, values_without_x0);
-    }, "No default initial state.*");
+    }(), "No default initial state.*");
 
-  DRAKE_EXPECT_THROWS_MESSAGE({
+  DRAKE_EXPECT_THROWS_MESSAGE([&]() {
       InitialValueProblem<double>::
           OdeContext values_without_k;
       values_without_k.t0 = 0.0;
       values_without_k.x0 = VectorX<double>();
       const InitialValueProblem<double> ivp(
           dummy_ode_function, values_without_k);
-    }, "No default parameters.*");
+    }(), "No default parameters.*");
 }
 
 // Validates preconditions when solving any given IVP.

--- a/systems/analysis/test/scalar_initial_value_problem_deprecated_test.cc
+++ b/systems/analysis/test/scalar_initial_value_problem_deprecated_test.cc
@@ -83,39 +83,39 @@ GTEST_TEST(ScalarInitialValueProblemTest, ConstructionPreconditionsValidation) {
     return -x * t;
   };
 
-  DRAKE_EXPECT_THROWS_MESSAGE({
+  DRAKE_EXPECT_THROWS_MESSAGE([&]() {
       const ScalarInitialValueProblem<double>::
           ScalarOdeContext no_values;
       const ScalarInitialValueProblem<double> ivp(
           dummy_scalar_ode_function, no_values);
-    }, "No default.*");
+    }(), "No default.*");
 
-  DRAKE_EXPECT_THROWS_MESSAGE({
+  DRAKE_EXPECT_THROWS_MESSAGE([&]() {
       ScalarInitialValueProblem<double>::
           ScalarOdeContext values_without_t0;
       values_without_t0.k = VectorX<double>();
       values_without_t0.x0 = 0.0;
       const ScalarInitialValueProblem<double> ivp(
           dummy_scalar_ode_function, values_without_t0);
-    }, "No default initial time.*");
+    }(), "No default initial time.*");
 
-  DRAKE_EXPECT_THROWS_MESSAGE({
+  DRAKE_EXPECT_THROWS_MESSAGE([&]() {
       ScalarInitialValueProblem<double>::
           ScalarOdeContext values_without_x0;
       values_without_x0.t0 = 0.0;
       values_without_x0.k = VectorX<double>();
       const ScalarInitialValueProblem<double> ivp(
           dummy_scalar_ode_function, values_without_x0);
-    }, "No default initial state.*");
+    }(), "No default initial state.*");
 
-  DRAKE_EXPECT_THROWS_MESSAGE({
+  DRAKE_EXPECT_THROWS_MESSAGE([&]() {
       ScalarInitialValueProblem<double>::
           ScalarOdeContext values_without_k;
       values_without_k.t0 = 0.0;
       values_without_k.x0 = 0.0;
       const ScalarInitialValueProblem<double> ivp(
           dummy_scalar_ode_function, values_without_k);
-    }, "No default parameters.*");
+    }(), "No default parameters.*");
 }
 
 // Validates preconditions when solving any given IVP.

--- a/systems/analysis/test/scalar_view_dense_output_test.cc
+++ b/systems/analysis/test/scalar_view_dense_output_test.cc
@@ -52,14 +52,14 @@ TYPED_TEST_SUITE(ScalarViewDenseOutputTest, ExtensionTypes);
 TYPED_TEST(ScalarViewDenseOutputTest, ExtensionConsistency) {
   // Verifies that passing a null base dense output results in an error.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      ScalarViewDenseOutput<TypeParam> dense_output(
+      ScalarViewDenseOutput<TypeParam>(
           std::unique_ptr<HermitianDenseOutput<TypeParam>>(),
           this->kValidElementIndex),
       ".*dense output.*is null.*");
 
   // Verifies that views to invalid elements result in an error.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      ScalarViewDenseOutput<TypeParam> dense_output(
+      ScalarViewDenseOutput<TypeParam>(
           this->CreateDummyDenseOutput(), this->kInvalidElementIndex),
       ".*out of.*dense output.*range.*");
 


### PR DESCRIPTION
The documentation required an expression, but the implementation accidentally allowed for a block instead. Now it fails-fast.

Also suppresses "unused result" warnings for the expressions in question. This is helpful when a function is marked "nodiscard".

Towards #17330.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17341)
<!-- Reviewable:end -->
