### PR TITLE
Add MUMPS to IPOPT when building wheels

### DIFF
--- a/tools/wheel/image/build-dependencies.sh
+++ b/tools/wheel/image/build-dependencies.sh
@@ -15,4 +15,10 @@ ninja
 
 if [ "$(uname)" == "Linux" ]; then
     ln -s /opt/drake-dependencies/bin/patchelf /usr/local/bin/patchelf
+
+    # Libraries we get from the distro that get bundled into the wheel need to
+    # have their licenses bundled also.
+    mkdir -p /opt/drake-dependencies/licenses/mumps
+    cp -t /opt/drake-dependencies/licenses/mumps \
+        /usr/share/doc/libmumps-seq-dev/copyright
 fi

--- a/tools/wheel/image/build-wheel.sh
+++ b/tools/wheel/image/build-wheel.sh
@@ -28,7 +28,10 @@ chrpath()
             patchelf --remove-rpath "$lib"
             patchelf --set-rpath "\$ORIGIN/$rpath" "$lib"
         else
-            strip_rpath --exclude="$HOMEBREW" "$lib"
+            strip_rpath \
+                --exclude="$HOMEBREW" \
+                --exclude=/opt/drake-dependencies/lib \
+                "$lib"
             install_name_tool -add_rpath "@loader_path/$rpath" "$lib"
         fi
     done

--- a/tools/wheel/image/dependencies/patches/mumps/patch.cmake
+++ b/tools/wheel/image/dependencies/patches/mumps/patch.cmake
@@ -1,0 +1,4 @@
+execute_process(
+    COMMAND git apply ${mumps_patch}/patch.diff
+    WORKING_DIRECTORY ${mumps_source}
+    )

--- a/tools/wheel/image/dependencies/patches/mumps/patch.diff
+++ b/tools/wheel/image/dependencies/patches/mumps/patch.diff
@@ -1,0 +1,73 @@
+The Makefile.macos.SEQ patch is largely adapted from Homebrew:
+https://github.com/Homebrew/homebrew-core/blob/c6d166f556351ecfade14930021e2217b59279ec/Formula/ipopt.rb#L31
+
+diff --git a/Make.inc/Makefile.inc.generic.SEQ b/Make.inc/Makefile.macos.SEQ
+similarity index 96%
+copy from Make.inc/Makefile.inc.generic.SEQ
+copy to Make.inc/Makefile.macos.SEQ
+index 2558f30..dac9334 100644
+--- a/Make.inc/Makefile.inc.generic.SEQ
++++ b/Make.inc/Makefile.macos.SEQ
+@@ -94,7 +94,7 @@ IORDERINGSC = $(IMETIS) $(IPORD) $(ISCOTCH)
+ PLAT    = 
+ # Library extension, + C and Fortran "-o" option
+ # may be different under Windows
+-LIBEXT  = .a
++LIBEXT  = .dylib
+ OUTC    = -o 
+ OUTF    = -o 
+ # RM : remove files
+@@ -102,16 +102,15 @@ RM      = /bin/rm -f
+ # CC : C compiler
+ CC      = cc
+ # FC : Fortran 90 compiler
+-FC      = f90
++FC      = gfortran
+ # FL : Fortran linker
+-FL      = f90
++FL      = $(FC)
+ # AR : Archive object in a library
+ #      keep a space at the end if options have to be separated from lib name
+-AR      = ar vr 
++AR      = $(FC) -dynamiclib -undefined dynamic_lookup -Wl,-install_name,@rpath/$(notdir $@) -o 
+ # RANLIB : generate index of an archive file
+ #   (optionnal use "RANLIB = echo" in case of problem)
+-RANLIB  = ranlib
+-#RANLIB  = echo
++RANLIB  = echo
+ 
+ # DEFINE HERE YOUR LAPACK LIBRARY
+ 
+@@ -143,8 +142,8 @@ LIBOTHERS = -lpthread
+ CDEFS = -DAdd_
+ 
+ #COMPILER OPTIONS
+-OPTF    = -O
+-OPTC    = -O -I.
++OPTF    = -fPIC -O -fallow-argument-mismatch
++OPTC    = -fPIC -O -I.
+ OPTL    = -O
+ 
+ #Sequential:
+diff --git a/Makefile b/Makefile
+index 3c0f645..55ac6ba 100644
+--- a/Makefile
++++ b/Makefile
+@@ -59,6 +59,17 @@ $(libdir)/libpord$(PLAT)$(LIBEXT):
+ 	  cp $(LPORDDIR)/libpord$(LIBEXT) $@; \
+ 	fi;
+ 
++install: d
++	if ( test ! -d $(PREFIX)/lib ) ; then mkdir -p $(PREFIX)/lib ; fi
++	if ( test ! -d $(PREFIX)/include ) ; then mkdir -p $(PREFIX)/include ; fi
++	if ( test ! -d $(PREFIX)/include/mumps_seq ) ; then mkdir -p $(PREFIX)/include/mumps_seq ; fi
++	for lib in libseq/*$(LIBEXT) $(libdir)/*$(LIBEXT) ; do \
++	  ginstall -t $(PREFIX)/lib $$lib; \
++	  install_name_tool -id $(PREFIX)/lib/$$(basename $$lib) $(PREFIX)/lib/$$(basename $$lib); \
++	done
++	ginstall -m 644 -t $(PREFIX)/include include/*.h
++	ginstall -m 644 -t $(PREFIX)/include/mumps_seq libseq/mpi.h
++
+ clean:
+ 	(cd src; $(MAKE) clean)
+ 	(cd examples; $(MAKE) clean)

--- a/tools/wheel/image/dependencies/projects.cmake
+++ b/tools/wheel/image/dependencies/projects.cmake
@@ -115,6 +115,14 @@ set(clp_md5 "f7c25af22d2f03398cbbdf38c8b4f6fd")
 set(clp_dlname "clp-${clp_version}.tar.gz")
 list(APPEND ALL_PROJECTS clp)
 
+if(APPLE)
+    set(mumps_version 5.4.0)  # Current version in Homebrew.
+    set(mumps_url "http://mumps.enseeiht.fr/MUMPS_${mumps_version}.tar.gz")
+    set(mumps_md5 "808178997dc571c748e9cf0cabf9a26e")
+    set(mumps_dlname "mumps-${mumps_version}.tar.gz")
+    list(APPEND ALL_PROJECTS mumps)
+endif()
+
 # ipopt
 set(ipopt_version 3.11.9)
 set(ipopt_url "https://github.com/coin-or/Ipopt/archive/refs/tags/releases/${ipopt_version}.tar.gz")

--- a/tools/wheel/image/dependencies/projects/ipopt.cmake
+++ b/tools/wheel/image/dependencies/projects/ipopt.cmake
@@ -1,8 +1,24 @@
+if(APPLE)
+    set(ipopt_extra_dependencies mumps)
+    set(ipopt_mumps_configure_args
+        --with-mumps-lib=-ldmumps\ -lmumps_common\ -lpord\ -lmpiseq
+        --with-mumps-incdir=${CMAKE_INSTALL_PREFIX}/include
+        CPPFLAGS=-I${CMAKE_INSTALL_PREFIX}/include/mumps_seq
+    )
+else()
+    set(ipopt_extra_dependencies)
+    set(ipopt_mumps_configure_args
+        --with-mumps-lib=-ldmumps_seq
+        --with-mumps-incdir=/usr/include
+        CPPFLAGS=-I/usr/include/mumps_seq
+    )
+endif()
+
 ExternalProject_Add(ipopt
     URL ${ipopt_url}
     URL_MD5 ${ipopt_md5}
     DOWNLOAD_NAME ${ipopt_dlname}
-    DEPENDS lapack
+    DEPENDS lapack ${ipopt_extra_dependencies}
     ${COMMON_EP_ARGS}
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND ./configure
@@ -12,6 +28,7 @@ ExternalProject_Add(ipopt
         CFLAGS=-fPIC
         CXXFLAGS=-fPIC
         LDFLAGS=-L${CMAKE_INSTALL_PREFIX}/lib
+        ${ipopt_mumps_configure_args}
     BUILD_COMMAND make
     INSTALL_COMMAND make install
     )

--- a/tools/wheel/image/dependencies/projects/mumps.cmake
+++ b/tools/wheel/image/dependencies/projects/mumps.cmake
@@ -1,0 +1,24 @@
+if(NOT APPLE)
+    message(FATAL_ERROR "mumps should only be built on macOS")
+endif()
+
+ExternalProject_Add(mumps
+    URL ${mumps_url}
+    URL_MD5 ${mumps_md5}
+    DOWNLOAD_NAME ${mumps_dlname}
+    ${COMMON_EP_ARGS}
+    BUILD_IN_SOURCE 1
+    PATCH_COMMAND ${CMAKE_COMMAND}
+        -Dmumps_patch=${CMAKE_SOURCE_DIR}/patches/mumps
+        -Dmumps_source=${CMAKE_BINARY_DIR}/src/mumps
+        -P ${CMAKE_SOURCE_DIR}/patches/mumps/patch.cmake
+    CONFIGURE_COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_BINARY_DIR}/src/mumps/Make.inc/Makefile.macos.SEQ
+        ${CMAKE_BINARY_DIR}/src/mumps/Makefile.inc
+    BUILD_COMMAND make d
+    INSTALL_COMMAND make PREFIX=${CMAKE_INSTALL_PREFIX} install
+    )
+
+extract_license(mumps
+    LICENSE
+)

--- a/tools/wheel/image/packages-focal
+++ b/tools/wheel/image/packages-focal
@@ -31,6 +31,7 @@ zip
 # Build dependencies (general).
 libgl1-mesa-dev
 libglib2.0-dev
+libmumps-seq-dev
 libxt-dev
 # Build dependencies (OpenCL).
 opencl-headers

--- a/tools/wheel/test/test-wheel.sh
+++ b/tools/wheel/test/test-wheel.sh
@@ -24,9 +24,23 @@ fi
 pip install "$1"
 
 python << EOF
+import numpy
 import pydrake.all
+
+# Basic sanity checks.
 print(pydrake.getDrakePath())
 print(pydrake.all.PackageMap().GetPath("drake"))
+
+# Check for presence of optional solvers.
 assert pydrake.all.MosekSolver().available(), "Missing MOSEK"
 assert pydrake.all.SnoptSolver().available(), "Missing SNOPT"
+
+# Check that IPOPT is working.
+prog = pydrake.all.MathematicalProgram()
+x = prog.NewContinuousVariables(2, "x")
+prog.AddLinearConstraint(x[0] >= 1)
+prog.AddLinearConstraint(x[1] >= 1)
+prog.AddQuadraticCost(numpy.eye(2), numpy.zeros(2), x)
+solver = pydrake.all.IpoptSolver()
+assert solver.Solve(prog, None, None).is_success(), "IPOPT is not usable"
 EOF


### PR DESCRIPTION
Point our wheel build of IPOPT at MUMPS. Because MUMPS is copyleft, we must consume it as a shared library. On Ubuntu, this means we can just use the distro-provided package. On macOS, we must build it from source, as it is not packaged separately in Homebrew. (Homebrew normally builds it as part of the IPOPT build.)

Fixes #17162.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17346)
<!-- Reviewable:end -->
