### PR TITLE
Add macOS support to wheel builder

### DIFF
--- a/tools/wheel/BUILD.bazel
+++ b/tools/wheel/BUILD.bazel
@@ -13,6 +13,7 @@ drake_py_binary(
     srcs = [
         "wheel_builder/common.py",
         "wheel_builder/linux.py",
+        "wheel_builder/macos.py",
         "wheel_builder/main.py",
     ],
     main = "wheel_builder/main.py",

--- a/tools/wheel/README.rst
+++ b/tools/wheel/README.rst
@@ -8,10 +8,16 @@ publishing wheels is described at https://drake.mit.edu/release_playbook.html.
 Basic Usage
 -----------
 
-Wheels are built in dedicated Docker containers, such that any host capable of
-executing the necessary containers may be used, with no local environment setup
-required. However, it is recommended to run the script on the most recent
-version of Ubuntu LTS that is supported by Drake.
+On Ubuntu, wheels are built in dedicated Docker containers, such that any host
+capable of executing the necessary containers may be used, with no local
+environment setup required. However, it is recommended to run the script on the
+most recent version of Ubuntu LTS that is supported by Drake.
+
+On macOS, Drake's dependencies must be installed already (i.e. by preparing an
+environment as one would to build Drake normally). There are a small number of
+additional dependencies that will be installed by the builder, so the builder
+must be able to run ``brew``. The builder must also be able to write to
+``/opt``, as this is where the build is performed.
 
 The script takes a single, required positional argument, which is used to
 specify the version with which the wheels should be tagged. The version number
@@ -20,7 +26,9 @@ should match the version of Drake being released, and must conform to
 
 The script builds the Drake code which is currently checked out, *including*
 any local, uncommitted changes. Most untracked files will also be included.
-This simplifies the process of testing changes locally.
+This simplifies the process of testing changes locally. On macOS, the current
+checkout is used directly. In some cases, it may be necessary to run
+``bazel clean`` before building a wheel.
 
 On successful completion, the requested set of wheels will be written to the
 specified output directory (by default, the current working directory, unless
@@ -29,10 +37,14 @@ overridden by ``--output-dir``), unless ``--no-extract`` was specified.
 Cleanup
 -------
 
-To reclaim disk space used by wheel builds, run the following commands::
+To reclaim disk space used by (Ubuntu) wheel builds, run the following
+commands::
 
   docker rmi $(docker image ls --filter=reference='pip-drake:*' -q)
   docker builder prune -f
+
+The macOS wheel builds clean up after themselves by default. The
+``--keep-build`` (``-k``) option may be used to suppress this behavior.
 
 Optional Arguments
 ------------------
@@ -42,8 +54,8 @@ available options exist for debugging purposes and should not be needed in
 ordinary use.
 
 ``-t``, ``--test``
-    Run some basic tests on the wheels after extracting them. For obvious
-    reasons, this is incompatible with ``--no-extract``.
+    Run some basic tests on the wheels after extracting them. On Ubuntu, this
+    this is incompatible with ``--no-extract`` for obvious reasons.
 
     Tests should always be run prior to publishing wheels. However, while
     debugging build issues, it may be expedient to skip the tests.
@@ -55,33 +67,47 @@ ordinary use.
 ``-n``, ``--no-extract``
     Do not extract the wheels after building. This is useful if the goal is
     simply to freshen the tags (``--tag-stages``) or while debugging build
-    issues. When used, the script itself will not write to the file system.
-    (The Docker cache and tagged images may still be altered.)
+    issues.
 
-``-s``, ``--tag-stages``
+    On Ubuntu, this will result in the script itself not writing to the file
+    system. (The Docker cache and tagged images may still be altered.)
+
+    On macOS, if ``--keep-build`` is used, the wheel will still be accessible
+    via its build location in ``//opt/drake-wheel-build/wheel/wheelhouse``.
+
+``-s``, ``--tag-stages`` (Ubuntu only)
     Build each stage independently and, on completion, assign it a permanent
     tag. This serves two functions; first, assignment of permanent tags ensures
     that Docker's cache won't expire early build stages. Second, it allows the
     individual stages contents to be examined, which can be useful for
     debugging, especially if later stages are failing.
 
-``-k``, ``--keep-containers``
+``-k``, ``--keep-containers`` (Ubuntu only)
     Do not delete intermediate containers in case of a build failure (i.e. do
     not pass ``--force-rm`` to ``docker build``). This has no effect unless
     the build fails. In case of a failed build, the container from the failed
     build step will be left, allowing for post-mortem examination. Don't forget
     to manually delete the container later.
 
+``-k``, ``--keep-containers`` (macOS only)
+    Do not delete the various build trees and artifacts, which can be found in
+    various subdirectories under ``/opt``.
+
+``--incremental`` (macOS only)
+    Do not build dependencies. This requires that dependencies were previously
+    built successfully and were not deleted (see ``--keep-build``). This should
+    normally be used only during debugging.
+
 Implementation Details
 ----------------------
 
-Wheels are built using Docker, in a number of stages. Rather than encoding
-everything about the build in the ``Dockerfile``, build instructions are split
-out into a number of helper scripts. In some cases, these in turn pull in
-additional files to specify things such as build arguments or packages to be
-installed. Where possible, earlier steps are designed such that the resulting
-images can be used for multiple wheels, in order to save space and reduce build
-times.
+On Ubuntu, wheels are built using Docker, in a number of stages. Rather than
+encoding everything about the build in the ``Dockerfile``, build instructions
+are split out into a number of helper scripts. In some cases, these in turn
+pull in additional files to specify things such as build arguments or packages
+to be installed. Where possible, earlier steps are designed such that the
+resulting images can be used for multiple wheels, in order to save space and
+reduce build times.
 
 Starting with a "bare" image, the first step is to provision the environment
 by installing common tools and dependencies, starting with those provided by
@@ -104,3 +130,26 @@ is used to install only the minimal prerequisites in a clean environment,
 after which the wheel is added to the image and installed, followed by the
 execution of a script which performs some basic tests to ensure that the wheel
 was successfully installed.
+
+On macOS, wheels must be built on the host system. The following directories
+are used:
+
+- ``/opt/drake-wheel-build``:
+  Contains most intermediate artifacts.
+
+- ``/opt/drake-dependencies``:
+  Contains installations of various dependencies needed to build Drake.
+
+- ``/opt/vtk``:
+  Contains the VTK installation used to build Drake.
+
+- ``/opt/drake``:
+  Contains the Drake installation used to build the wheel.
+
+- ``/opt/drake-wheel-test``:
+  Contains a Python virtual environment used to test the wheel.
+
+After performing wheel-specific provisioning using ``brew``, the builder
+invokes ``macos/build-wheel.sh``, optionally (and if the build succeeded)
+followed by ``macos/test-wheel.sh``. These scripts approximately replicate what
+would happen in Docker, and heavily reuse the same lower level scripts.

--- a/tools/wheel/image/packages-macos
+++ b/tools/wheel/image/packages-macos
@@ -1,0 +1,6 @@
+# Install anything needed to build the wheel that is NOT also needed to build
+# Drake itself. We assume that Drake's own prerequisites are already installed.
+brew 'bash'
+brew 'coreutils'
+brew 'ninja'
+brew 'yasm'

--- a/tools/wheel/macos/build-wheel.sh
+++ b/tools/wheel/macos/build-wheel.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-# This script builds a wheel on macOS. It requires an already-provisioned host.
+# This script builds a wheel on macOS. It can be run directly, but using the
+# //tools/wheel:builder Bazel action adds functionality. Running this script
+# directly also requires an already-provisioned host.
 #
 # Beware that this requires write permission to /opt and will nuke various
 # things therein. (Shouldn't affect ARM Homebrew, though.)
@@ -33,16 +35,7 @@ fi
 # -----------------------------------------------------------------------------
 
 rm -rf "/opt/drake-wheel-build/wheel"
-
-if [ -d /opt/drake ]; then
-    # We need to ensure there are no remnants of a prior build, but CI creates
-    # a wheel output directory in /opt/drake that we don't have permission to
-    # remove. Thus, we have to get a little creative...
-    find /opt/drake \
-        \! -path /opt/drake/wheelhouse \
-        \! -path /opt/drake \
-        -delete
-fi
+rm -rf "/opt/drake"
 
 mkdir -p ~/.ssh
 chmod 700 ~/.ssh

--- a/tools/wheel/macos/test-wheel.sh
+++ b/tools/wheel/macos/test-wheel.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-# This script tests a wheel on macOS.
+# This script tests a wheel on macOS. It can be run directly, but is normally
+# run using the //tools/wheel:builder Bazel action.
 
 set -eu -o pipefail
 

--- a/tools/wheel/wheel_builder/macos.py
+++ b/tools/wheel/wheel_builder/macos.py
@@ -1,0 +1,125 @@
+# This file contains macOS-specific logic used to build the PyPI wheels. See
+# build-wheels for the user interface.
+
+import glob
+import os
+import platform
+import shutil
+import subprocess
+
+from .common import die, wheel_name
+from .common import build_root, resource_root, wheelhouse
+
+
+def _find_wheel(path, version):
+    """
+    Returns name of built wheel. Uses `glob` to find it, since trying to
+    replicate the logic which determines the macOS platform name is not
+    accessible and is very non-trivial to replicate.
+    """
+    pattern = wheel_name(
+        python_version=''.join(platform.python_version_tuple()[:2]),
+        wheel_version=version,
+        wheel_platform='*')
+
+    candidates = glob.glob(os.path.join(path, pattern))
+
+    if len(candidates) != 1:
+        die('Build was expected to produce exactly 1 wheel, '
+            f'but {len(candidates)} were found!')
+
+    return candidates[0]
+
+
+def _assert_isdir(path, name):
+    """
+    Asserts that `path` is a directory. Shows an error otherwise, where `name`
+    describes what path is being asserted.
+    """
+    if not os.path.isdir(path):
+        die(f'{name} \'{path}\' is not a valid directory')
+
+
+def _provision():
+    """
+    Prepares wheel build environment.
+    """
+    packages_path = os.path.join(resource_root, 'image', 'packages-macos')
+    command = ['brew', 'bundle', f'--file={packages_path}', '--no-lock']
+    subprocess.check_call(command)
+
+
+def _test_wheel(path, env):
+    """
+    Runs the test script on the wheel at `path`.
+    """
+    test_script = os.path.join(resource_root, 'macos', 'test-wheel.sh')
+    subprocess.check_call(['bash', test_script, path], env=env)
+
+
+def build(options):
+    """
+    Builds wheel(s) with the provided options.
+    """
+    if options.extract:
+        _assert_isdir(options.output_dir, 'Output location')
+
+    _provision()
+
+    # Sanitize the build/test environment.
+    environment = os.environ.copy()
+    environment.pop('PYTHONPATH')
+    environment.pop('RUNFILES_MANIFEST_FILE')
+
+    # Build the wheel.
+    build_script = os.path.join(resource_root, 'macos', 'build-wheel.sh')
+    build_command = ['bash', build_script]
+    if options.incremental:
+        build_command.append('--no-deps')
+    build_command.append(options.version)
+
+    subprocess.check_call(build_command, env=environment)
+
+    # Find the built wheel and, if requested, test and/or extract it.
+    wheel = _find_wheel(path=wheelhouse, version=options.version)
+
+    if options.test:
+        _test_wheel(wheel, env=environment)
+
+    if options.extract:
+        shutil.copy2(wheel, options.output_dir)
+
+    if not options.keep_build:
+        shutil.rmtree('/opt/vtk')
+        shutil.rmtree('/opt/drake-dependencies')
+        shutil.rmtree('/opt/drake')
+        shutil.rmtree(build_root)
+
+
+def add_build_arguments(parser):
+    """
+    Adds arguments that control the build.
+    """
+    parser.add_argument(
+        '-k', '--keep-build', action='store_true',
+        help='do not delete build tree after successful build')
+    parser.add_argument(
+        '--incremental', action='store_true',
+        help='only build Drake itself '
+             '(requires previously built dependencies)')
+
+
+def add_selection_arguments(parser):
+    """
+    Adds arguments that control which wheel(s) to build.
+    (No-op on macOS.)
+    """
+    pass  # macOS can only build one wheel.
+
+
+def fixup_options(options):
+    """
+    Validates options and applies any necessary transformations.
+    (No-op on macOS.)
+    """
+    pass  # Not needed on macOS.

--- a/tools/wheel/wheel_builder/main.py
+++ b/tools/wheel/wheel_builder/main.py
@@ -11,6 +11,8 @@ from drake.tools.wheel.wheel_builder.common import do_main as main
 if __name__ == '__main__':
     if sys.platform == 'linux':
         from drake.tools.wheel.wheel_builder import linux as platform
+    elif sys.platform == 'darwin':
+        from drake.tools.wheel.wheel_builder import macos as platform
     else:
         die('Building wheels is not supported on this platform '
             f'(\'{sys.platform}\')')


### PR DESCRIPTION
Add a macOS platform module to Drake's wheel builder, using the previously created scripts. Add a new provisioning step (only via the builder). Modify the builder to run in the actual current working directory rather than wherever `bazel run` wants to run it (fixes misinterpretation of relative paths given as arguments, particularly to `--output-dir`). Improve reporting of default arguments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17347)
<!-- Reviewable:end -->
