### PR TITLE
DecomposeAffineExpression passes coeffs as a pointer.

### DIFF
--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -1023,7 +1023,7 @@ PYBIND11_MODULE(symbolic, m) {
             Eigen::RowVectorXd coeffs(map_var_to_index.size());
             double constant_term;
             symbolic::DecomposeAffineExpression(
-                e, map_var_to_index, coeffs, &constant_term);
+                e, map_var_to_index, &coeffs, &constant_term);
             return std::make_pair(coeffs, constant_term);
           },
           py::arg("e"), py::arg("map_var_to_index"),

--- a/common/symbolic_decompose.cc
+++ b/common/symbolic_decompose.cc
@@ -215,10 +215,52 @@ void DecomposeAffineExpressions(const Eigen::Ref<const VectorX<Expression>>& v,
   // v = A * vars + b
   *A = Eigen::MatrixXd::Zero(v.rows(), vars->rows());
   *b = Eigen::VectorXd::Zero(v.rows());
+  Eigen::RowVectorXd Ai(A->cols());
   for (int i{0}; i < v.size(); ++i) {
     const Expression& e_i{v(i)};
-    DecomposeAffineExpression(e_i, map_var_to_index, A->row(i), b->data() + i);
+    DecomposeAffineExpression(e_i, map_var_to_index, &Ai, b->data() + i);
+    A->row(i) = Ai;
   }
+}
+
+int DecomposeAffineExpression(
+    const symbolic::Expression& e,
+    const std::unordered_map<symbolic::Variable::Id, int>& map_var_to_index,
+    EigenPtr<Eigen::RowVectorXd> coeffs, double* constant_term) {
+  DRAKE_DEMAND(coeffs->cols() == static_cast<int>(map_var_to_index.size()));
+  coeffs->setZero();
+  *constant_term = 0;
+  if (!e.is_polynomial()) {
+    std::ostringstream oss;
+    oss << "Expression " << e << "is not a polynomial.\n";
+    throw std::runtime_error(oss.str());
+  }
+  const symbolic::Polynomial poly{e};
+  int num_variable = 0;
+  for (const auto& p : poly.monomial_to_coefficient_map()) {
+    const auto& p_monomial = p.first;
+    DRAKE_ASSERT(is_constant(p.second));
+    const double p_coeff = symbolic::get_constant_value(p.second);
+    if (p_monomial.total_degree() > 1) {
+      std::stringstream oss;
+      oss << "Expression " << e << " is non-linear.";
+      throw std::runtime_error(oss.str());
+    } else if (p_monomial.total_degree() == 1) {
+      // Linear coefficient.
+      const auto& p_monomial_powers = p_monomial.get_powers();
+      DRAKE_DEMAND(p_monomial_powers.size() == 1);
+      const symbolic::Variable::Id var_id =
+          p_monomial_powers.begin()->first.get_id();
+      (*coeffs)(map_var_to_index.at(var_id)) = p_coeff;
+      if (p_coeff != 0) {
+        ++num_variable;
+      }
+    } else {
+      // Constant term.
+      *constant_term = p_coeff;
+    }
+  }
+  return num_variable;
 }
 
 namespace {

--- a/common/symbolic_decompose.h
+++ b/common/symbolic_decompose.h
@@ -110,6 +110,37 @@ combination.
    @c map_var_to_index.
 2. e.is_polynomial() is true.
 3. e is an affine expression.
+4. all values in `map_var_to_index` should be in the range [0,
+map_var_to_index.size())
+
+@param[in] e The symbolic affine expression
+@param[in] map_var_to_index A mapping from variable ID to variable index, such
+that map_var_to_index[vi.get_ID()] = i.
+@param[out] coeffs A row vector. coeffs(i) = ci.
+@param[out] constant_term c0 in the equation above.
+@return num_variable. Number of variables in the expression. 2 * x(0) + 3 has 1
+variable, 2 * x(0) + 3 * x(1) - 2 * x(0) has 1 variable. */
+int DecomposeAffineExpression(
+    const symbolic::Expression& e,
+    const std::unordered_map<symbolic::Variable::Id, int>& map_var_to_index,
+    EigenPtr<Eigen::RowVectorXd> coeffs, double* constant_term);
+
+/** Decomposes an affine combination @p e = c0 + c1 * v1 + ... cn * vn into the
+following:
+
+     constant term      : c0
+     coefficient vector : [c1, ..., cn]
+     variable vector    : [v1, ..., vn]
+
+Then, it extracts the coefficient and the constant term. A map from variable ID
+to int, @p map_var_to_index, is used to decide a variable's index in a linear
+combination.
+
+\pre
+1. @c coeffs is a row vector of double, whose length matches with the size of
+   @c map_var_to_index.
+2. e.is_polynomial() is true.
+3. e is an affine expression.
 
 @tparam Derived An Eigen row vector type with Derived::Scalar == double.
 @param[in] e The symbolic affine expression
@@ -120,46 +151,24 @@ that map_var_to_index[vi.get_ID()] = i.
 @return num_variable. Number of variables in the expression. 2 * x(0) + 3 has 1
 variable, 2 * x(0) + 3 * x(1) - 2 * x(0) has 1 variable. */
 template <typename Derived>
-typename std::enable_if_t<std::is_same_v<typename Derived::Scalar, double>, int>
-DecomposeAffineExpression(
-    const symbolic::Expression& e,
-    const std::unordered_map<symbolic::Variable::Id, int>& map_var_to_index,
-    const Eigen::MatrixBase<Derived>& coeffs, double* constant_term) {
-  DRAKE_DEMAND(coeffs.rows() == 1);
-  DRAKE_DEMAND(coeffs.cols() == static_cast<int>(map_var_to_index.size()));
-  if (!e.is_polynomial()) {
-    std::ostringstream oss;
-    oss << "Expression " << e << "is not a polynomial.\n";
-    throw std::runtime_error(oss.str());
-  }
-  const symbolic::Polynomial poly{e};
-  int num_variable = 0;
-  for (const auto& p : poly.monomial_to_coefficient_map()) {
-    const auto& p_monomial = p.first;
-    DRAKE_ASSERT(is_constant(p.second));
-    const double p_coeff = symbolic::get_constant_value(p.second);
-    if (p_monomial.total_degree() > 1) {
-      std::stringstream oss;
-      oss << "Expression " << e << " is non-linear.";
-      throw std::runtime_error(oss.str());
-    } else if (p_monomial.total_degree() == 1) {
-      // Linear coefficient.
-      const auto& p_monomial_powers = p_monomial.get_powers();
-      DRAKE_DEMAND(p_monomial_powers.size() == 1);
-      const symbolic::Variable::Id var_id =
-          p_monomial_powers.begin()->first.get_id();
-      // TODO(eric.cousineau): Avoid using const_cast.
-      const_cast<Eigen::MatrixBase<Derived>&>(coeffs)(
-          map_var_to_index.at(var_id)) = p_coeff;
-      if (p_coeff != 0) {
-        ++num_variable;
-      }
-    } else {
-      // Constant term.
-      *constant_term = p_coeff;
-    }
-  }
-  return num_variable;
+DRAKE_DEPRECATED("2022-11-01",
+                 "Use the overloaded DecomposeAffineExpression which takes "
+                 "coeffs as a pointer.")
+typename std::enable_if_t<
+    std::is_same_v<typename Derived::Scalar, double>,
+    int> DecomposeAffineExpression(const symbolic::Expression& e,
+                                   const std::unordered_map<
+                                       symbolic::Variable::Id, int>&
+                                       map_var_to_index,
+                                   const Eigen::MatrixBase<Derived>& coeffs,
+                                   double* constant_term) {
+  Eigen::MatrixBase<Derived>& coeffs_ref =
+      const_cast<Eigen::MatrixBase<Derived>&>(coeffs);
+  Eigen::RowVectorXd coeffs_row(coeffs.cols());
+  const int num_vars = DecomposeAffineExpression(e, map_var_to_index,
+                                                 &coeffs_row, constant_term);
+  coeffs_ref = coeffs_row;
+  return num_vars;
 }
 
 /** Given a vector of Expressions @p f and a list of @p parameters we define

--- a/common/symbolic_polynomial.cc
+++ b/common/symbolic_polynomial.cc
@@ -623,7 +623,7 @@ void Polynomial::EvaluateWithAffineCoefficients(
     a_coeff.setZero();
     b_coeff = 0;
     const symbolic::Expression monomial_coeff_expand = monomial_coeff.Expand();
-    DecomposeAffineExpression(monomial_coeff_expand, map_var_to_index, a_coeff,
+    DecomposeAffineExpression(monomial_coeff_expand, map_var_to_index, &a_coeff,
                               &b_coeff);
     const Eigen::VectorXd monomial_vals =
         monomial.Evaluate(indeterminates, indeterminates_values);

--- a/solvers/create_constraint.cc
+++ b/solvers/create_constraint.cc
@@ -59,10 +59,12 @@ Binding<Constraint> ParseConstraint(
   // We will determine if lb <= v <= ub is a bounding box constraint, namely
   // x_lb <= x <= x_ub.
   bool is_v_bounding_box = true;
+  Eigen::RowVectorXd Ai(A.cols());
   for (int i = 0; i < v.size(); ++i) {
     double constant_term = 0;
     int num_vi_variables = symbolic::DecomposeAffineExpression(
-        v(i), map_var_to_index, A.row(i), &constant_term);
+        v(i), map_var_to_index, &Ai, &constant_term);
+    A.row(i) = Ai;
     if (num_vi_variables == 0 &&
         !(lb(i) <= constant_term && constant_term <= ub(i))) {
       // Unsatisfiable constraint with no variables, such as 1 <= 0 <= 2
@@ -478,10 +480,12 @@ Binding<LinearEqualityConstraint> DoParseLinearEqualityConstraint(
   // TODO(hongkai.dai): use sparse matrix.
   Eigen::MatrixXd A = Eigen::MatrixXd::Zero(v.rows(), vars.rows());
   Eigen::VectorXd beq = Eigen::VectorXd::Zero(v.rows());
+  Eigen::RowVectorXd Ai(A.cols());
   for (int i = 0; i < v.rows(); ++i) {
     double constant_term(0);
-    symbolic::DecomposeAffineExpression(v(i), map_var_to_index, A.row(i),
+    symbolic::DecomposeAffineExpression(v(i), map_var_to_index, &Ai,
                                         &constant_term);
+    A.row(i) = Ai;
     beq(i) = b(i) - constant_term;
   }
   return CreateBinding(make_shared<LinearEqualityConstraint>(A, beq), vars);

--- a/solvers/create_cost.cc
+++ b/solvers/create_cost.cc
@@ -50,7 +50,7 @@ Binding<LinearCost> DoParseLinearCost(
     const unordered_map<Variable::Id, int>& map_var_to_index) {
   Eigen::RowVectorXd c(vars_vec.size());
   double constant_term{};
-  symbolic::DecomposeAffineExpression(e, map_var_to_index, c, &constant_term);
+  symbolic::DecomposeAffineExpression(e, map_var_to_index, &c, &constant_term);
   return CreateBinding(make_shared<LinearCost>(c.transpose(), constant_term),
                        vars_vec);
 }


### PR DESCRIPTION
Previously we pass coeffs as a const reference, and use const_cast to modify the value of coeffs. This violates GSG.

As discussed in slack https://drakedevelopers.slack.com/archives/C2ETTRXT7/p1654617805286029

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17348)
<!-- Reviewable:end -->
