### PR TITLE
[plant] Fix precondition docs for CollectRegisteredGeometries

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1376,14 +1376,14 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @note There is a *very* specific order of operations:
   ///
   /// 1. Bodies and geometries must be added to the %MultibodyPlant.
-  /// 2. The %MultibodyPlant must be finalized (via Finalize()).
-  /// 3. Create GeometrySet instances from bodies (via this method).
-  /// 4. Invoke SceneGraph::ExcludeCollisions*() to filter collisions.
-  /// 5. Allocate context.
+  /// 2. Create GeometrySet instances from bodies (via this method).
+  /// 3. Invoke SceneGraph::ExcludeCollisions*() to filter collisions.
+  /// 4. Allocate context.
   ///
   /// Changing the order will cause exceptions to be thrown.
   ///
-  /// @throws std::exception if called pre-finalize.
+  /// @throws std::exception if `this` %MultibodyPlant was not
+  /// registered with a SceneGraph.
   geometry::GeometrySet CollectRegisteredGeometries(
       const std::vector<const Body<T>*>& bodies) const;
 

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1414,20 +1414,18 @@ GTEST_TEST(MultibodyPlantTest, FilterWeldedSubgraphs) {
 // Tests the error conditions for CollectRegisteredGeometries.
 GTEST_TEST(MultibodyPlantTest, CollectRegisteredGeometriesErrors) {
   MultibodyPlant<double> plant(0.0);
+  const RigidBody<double>& body = plant.AddRigidBody("body",
+      SpatialInertia<double>::MakeTestCube());
 
-  // A throw-away rigid body I can use to satisfy the function interface; it
-  // will never be used because the function will fail in a pre-requisite test.
-  RigidBody<double> body{SpatialInertia<double>()};
-  // The case where the plant has *not* been finalized.
+  // It's an error to call this without a SceneGraph.
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant.CollectRegisteredGeometries({&body}),
-      "Failure .* in CollectRegisteredGeometries.* failed.");
+      ".*geometry_source_is_registered.*failed.*");
 
-  // The case where the plant has *not* been registered as a source.
-  plant.Finalize();
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      plant.CollectRegisteredGeometries({&body}),
-      "Failure .* in CollectRegisteredGeometries.* failed.");
+  // With a scene graph, it passes.
+  SceneGraph<double> scene_graph;
+  plant.RegisterAsSourceForSceneGraph(&scene_graph);
+  EXPECT_NO_THROW(plant.CollectRegisteredGeometries({&body}));
 }
 
 // Tests the ability to accumulate the geometries associated with a set of


### PR DESCRIPTION
The claimed precondition (#8954) was that the MbP was finalized; this was true at the time, but as of today (#13281) is neither necessary nor enforced; now it's removed from the docs.

The actual precondition is that the MbP has an associated SceneGraph, which was enforced but not documented; now it's documented.

(There is a lot of code in Anzu that goes to great lengths to Finalize a MbP prior to working with collision filters.  All of that hassle is unnecessary.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17350)
<!-- Reviewable:end -->
