### PR TITLE
[plant] Move scalar conversion constructor to cc file

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -387,6 +387,70 @@ MultibodyPlant<T>::MultibodyPlant(
 }
 
 template <typename T>
+template <typename U>
+MultibodyPlant<T>::MultibodyPlant(const MultibodyPlant<U>& other)
+    : internal::MultibodyTreeSystem<T>(
+          systems::SystemTypeTag<MultibodyPlant>{},
+          other.internal_tree().template CloneToScalar<T>(),
+          other.is_discrete()) {
+  DRAKE_THROW_UNLESS(other.is_finalized());
+  time_step_ = other.time_step_;
+  // Copy of all members related with geometry registration.
+  source_id_ = other.source_id_;
+  body_index_to_frame_id_ = other.body_index_to_frame_id_;
+  frame_id_to_body_index_ = other.frame_id_to_body_index_;
+  geometry_id_to_body_index_ = other.geometry_id_to_body_index_;
+  visual_geometries_ = other.visual_geometries_;
+  num_visual_geometries_ = other.num_visual_geometries_;
+  collision_geometries_ = other.collision_geometries_;
+  num_collision_geometries_ = other.num_collision_geometries_;
+  X_WB_default_list_ = other.X_WB_default_list_;
+  contact_model_ = other.contact_model_;
+  contact_surface_representation_ =
+      other.contact_surface_representation_;
+  penetration_allowance_ = other.penetration_allowance_;
+  // Note: The physical models must be cloned before `FinalizePlantOnly()` is
+  // called because `FinalizePlantOnly()` has to allocate system resources
+  // requested by physical models.
+  for (auto& model : other.physical_models_) {
+    auto cloned_model = model->template CloneToScalar<T>();
+    // TODO(xuchenhan-tri): Rework physical model and discrete update manager
+    //  to eliminate the requirement on the order that they are called with
+    //  respect to Finalize().
+
+    // AddPhysicalModel can't be called here because it's post-finalize. We
+    // have to manually disable scalars that the cloned physical model do not
+    // support.
+    RemoveUnsupportedScalars(*cloned_model);
+    physical_models_.emplace_back(std::move(cloned_model));
+  }
+
+  DeclareSceneGraphPorts();
+
+  // Do accounting for MultibodyGraph
+  for (BodyIndex index(0); index < num_bodies(); ++index) {
+    const Body<T>& body = get_body(index);
+    multibody_graph_.AddBody(body.name(), body.model_instance());
+  }
+
+  for (JointIndex index(0); index < num_joints(); ++index) {
+    RegisterJointInGraph(get_joint(index));
+  }
+
+  // MultibodyTree::CloneToScalar() already called MultibodyTree::Finalize()
+  // on the new MultibodyTree on U. Therefore we only Finalize the plant's
+  // internals (and not the MultibodyTree).
+  FinalizePlantOnly();
+
+  // Note: The discrete update manager needs to be copied *after* the plant is
+  // finalized.
+  if (other.discrete_update_manager_ != nullptr) {
+    SetDiscreteUpdateManager(
+        other.discrete_update_manager_->template CloneToScalar<T>());
+  }
+}
+
+template <typename T>
 std::string MultibodyPlant<T>::GetTopologyGraphvizString() const {
   std::string graphviz = "digraph MultibodyPlant {\n";
   graphviz += "label=\"" + this->get_name() + "\";\n";

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -2205,10 +2205,8 @@ GTEST_TEST(MultibodyPlantTest, ScalarConversionConstructor) {
   Parser(&plant, &scene_graph).AddModelFromFile(full_name);
 
   // Try scalar-converting pre-finalize - error.
-  // N.B. Use extra parentheses; otherwise, compiler may think this is a
-  // declaration.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      (MultibodyPlant<AutoDiffXd>(plant)),
+      systems::System<double>::ToAutoDiffXd(plant),
       ".*MultibodyTree with an invalid topology.*");
 
   plant.Finalize();
@@ -2239,26 +2237,27 @@ GTEST_TEST(MultibodyPlantTest, ScalarConversionConstructor) {
   ASSERT_EQ(link3_num_visuals, 0);
 
   // Scalar convert the plant and verify invariants.
-  MultibodyPlant<AutoDiffXd> plant_autodiff(plant);
-  EXPECT_TRUE(plant_autodiff.geometry_source_is_registered());
-  EXPECT_EQ(plant_autodiff.num_collision_geometries(),
+  std::unique_ptr<MultibodyPlant<AutoDiffXd>> plant_autodiff =
+      systems::System<double>::ToAutoDiffXd(plant);
+  EXPECT_TRUE(plant_autodiff->geometry_source_is_registered());
+  EXPECT_EQ(plant_autodiff->num_collision_geometries(),
             plant.num_collision_geometries());
-  EXPECT_EQ(plant_autodiff.GetCollisionGeometriesForBody(
-      plant_autodiff.GetBodyByName("link1")).size(), link1_num_collisions);
-  EXPECT_EQ(plant_autodiff.GetCollisionGeometriesForBody(
-      plant_autodiff.GetBodyByName("link2")).size(), link2_num_collisions);
-  EXPECT_EQ(plant_autodiff.GetCollisionGeometriesForBody(
-      plant_autodiff.GetBodyByName("link3")).size(), link3_num_collisions);
-  EXPECT_EQ(plant_autodiff.GetVisualGeometriesForBody(
-      plant_autodiff.GetBodyByName("link1")).size(), link1_num_visuals);
-  EXPECT_EQ(plant_autodiff.GetVisualGeometriesForBody(
-      plant_autodiff.GetBodyByName("link2")).size(), link2_num_visuals);
-  EXPECT_EQ(plant_autodiff.GetVisualGeometriesForBody(
-      plant_autodiff.GetBodyByName("link3")).size(), link3_num_visuals);
+  EXPECT_EQ(plant_autodiff->GetCollisionGeometriesForBody(
+      plant_autodiff->GetBodyByName("link1")).size(), link1_num_collisions);
+  EXPECT_EQ(plant_autodiff->GetCollisionGeometriesForBody(
+      plant_autodiff->GetBodyByName("link2")).size(), link2_num_collisions);
+  EXPECT_EQ(plant_autodiff->GetCollisionGeometriesForBody(
+      plant_autodiff->GetBodyByName("link3")).size(), link3_num_collisions);
+  EXPECT_EQ(plant_autodiff->GetVisualGeometriesForBody(
+      plant_autodiff->GetBodyByName("link1")).size(), link1_num_visuals);
+  EXPECT_EQ(plant_autodiff->GetVisualGeometriesForBody(
+      plant_autodiff->GetBodyByName("link2")).size(), link2_num_visuals);
+  EXPECT_EQ(plant_autodiff->GetVisualGeometriesForBody(
+      plant_autodiff->GetBodyByName("link3")).size(), link3_num_visuals);
 
   // Make sure the geometry ports were included in the autodiffed plant.
-  DRAKE_EXPECT_NO_THROW(plant_autodiff.get_geometry_query_input_port());
-  DRAKE_EXPECT_NO_THROW(plant_autodiff.get_geometry_poses_output_port());
+  DRAKE_EXPECT_NO_THROW(plant_autodiff->get_geometry_query_input_port());
+  DRAKE_EXPECT_NO_THROW(plant_autodiff->get_geometry_poses_output_port());
 }
 
 // This test is used to verify the correctness of the methods to compute the

--- a/multibody/tree/test/door_hinge_test.cc
+++ b/multibody/tree/test/door_hinge_test.cc
@@ -199,16 +199,17 @@ TEST_F(DoorHingeTest, CloneTest) {
   config.motion_threshold = 0.125;
 
   BuildDoorHinge(config);
-  MultibodyPlant<AutoDiffXd> plant_ad(plant());
+  std::unique_ptr<MultibodyPlant<AutoDiffXd>> plant_ad =
+      systems::System<double>::ToAutoDiffXd(plant());
 
-  EXPECT_EQ(plant_ad.num_positions(), 1);
-  EXPECT_EQ(plant_ad.num_velocities(), 1);
-  EXPECT_EQ(plant_ad.num_actuated_dofs(), 0);
+  EXPECT_EQ(plant_ad->num_positions(), 1);
+  EXPECT_EQ(plant_ad->num_velocities(), 1);
+  EXPECT_EQ(plant_ad->num_actuated_dofs(), 0);
 
   // Should include gravity and the door hinge.
-  EXPECT_EQ(plant_ad.num_force_elements(), 2);
+  EXPECT_EQ(plant_ad->num_force_elements(), 2);
   const DoorHinge<AutoDiffXd>& door_hinge_ad =
-      plant_ad.GetForceElement<DoorHinge>(ForceElementIndex(1));
+      plant_ad->GetForceElement<DoorHinge>(ForceElementIndex(1));
 
   EXPECT_EQ(door_hinge_ad.config().spring_zero_angle_rad,
             config.spring_zero_angle_rad);

--- a/systems/framework/system_scalar_conversion_doxygen.h
+++ b/systems/framework/system_scalar_conversion_doxygen.h
@@ -57,6 +57,20 @@ code sample compiles and runs successfully.
 For a more thorough example, refer to the implementation of
 drake::systems::Linearize.
 
+@warning The supported method to perform scalar conversion uses the member
+functions on System, e.g., `System::ToAutoDiffXd`. The scalar-converting
+copy constructor (described below) is intended for internal use only.
+For example:
+@code
+PendulumPlant<double> plant;
+
+// WRONG
+PendulumPlant<AutoDiffXd> plant_autodiff(plant);
+
+// CORRECT
+std::unique_ptr<PendulumPlant<AutoDiffXd>> autodiff_plant =
+    System<double>::ToAutoDiffXd(plant);
+@endcode
 
 @anchor system_scalar_conversion_how_to_write_a_system
 <h2>How to write a System that supports scalar conversion</h2>


### PR DESCRIPTION
This should be in the cc file per https://drake.mit.edu/styleguide/cppguide.html#Inline_Functions.

This is a breaking change in the sense that anyone who has accidentally called this internal-use only constructor (when building with Clang) might now receive a linker error.

C++ users should call, e.g., `System::ToAutoDiffXd` instead of this constructor. Python users are unaffected.

---

The Doxygen now says this:

> The supported method to perform scalar conversion uses the member functions on System, e.g., `System::ToAutoDiffXd`. The scalar-converting copy constructor (described below) is intended for internal use only.

The reason we need to steer people that way is because the constructor is incomplete.  The `ToAutoDiffXd` does extra work beyond the constructor:
- copies the system's name
- copies the system's external constraints

We might add more attribute copying over time as well.  We don't want users relying on an internal constructor which is unreliable, and might become moreso.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17354)
<!-- Reviewable:end -->
