### PR TITLE
[multibody] Add support for MJCF to Parser.

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -28,6 +28,13 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+_DM_CONTROL_MUJOCO_FILES = forward_files(
+    srcs = ["@dm_control_internal//:" + x for x in dm_control_mujoco_files()],
+    dest_prefix = "",
+    strip_prefix = "@dm_control_internal//:",
+    visibility = ["//visibility:private"],
+)
+
 drake_cc_package_library(
     name = "parsing",
     visibility = ["//visibility:public"],
@@ -213,6 +220,7 @@ drake_cc_library(
         "//multibody/plant",
     ],
     deps = [
+        ":detail_mujoco_parser",
         ":detail_parsing_workspace",
         ":detail_sdf_parser",
         ":detail_urdf_parser",
@@ -330,7 +338,7 @@ drake_cc_googletest(
     data = [
         ":test_models",
         "//multibody/benchmarks/acrobot:models",
-    ],
+    ] + _DM_CONTROL_MUJOCO_FILES,
     deps = [
         ":parser",
         "//common:filesystem",
@@ -421,13 +429,6 @@ drake_cc_googletest(
         "//multibody/benchmarks/acrobot",
         "//multibody/benchmarks/acrobot:make_acrobot_plant",
     ],
-)
-
-_DM_CONTROL_MUJOCO_FILES = forward_files(
-    srcs = ["@dm_control_internal//:" + x for x in dm_control_mujoco_files()],
-    dest_prefix = "",
-    strip_prefix = "@dm_control_internal//:",
-    visibility = ["//visibility:private"],
 )
 
 drake_cc_googletest(

--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -46,8 +46,8 @@ class Parser final {
   /// warnings will be treated as errors.
   void SetStrictParsing() { is_strict_ = true; }
 
-  /// Parses the SDF or URDF file named in @p file_name and adds all of its
-  /// model(s) to @p plant.
+  /// Parses the SDF, URDF, or MJCF file named in @p file_name and adds all of
+  /// its model(s) to @p plant.
   ///
   /// SDFormat files may contain multiple `<model>` elements.  New model
   /// instances will be added to @p plant for each `<model>` tag in the file.
@@ -59,15 +59,17 @@ class Parser final {
   /// URDF files contain a single `<robot>` element.  Only a single model
   /// instance will be added to @p plant.
   ///
-  /// @param file_name The name of the SDF or URDF file to be parsed.  The file
-  ///   type will be inferred from the extension.
-  /// @returns The set of model instance indices for the newly added models,
-  /// including nested models.
-  /// @throws std::exception in case of errors.
+  /// MJCF (MuJoCo XML) files typically contain many bodies, they will all be
+  /// added as a single model instance in the @p plant.
+  ///
+  /// @param file_name The name of the SDF, URDF, or MJCF file to be parsed.
+  /// The file type will be inferred from the extension. @returns The set of
+  /// model instance indices for the newly added models, including nested
+  /// models. @throws std::exception in case of errors.
   std::vector<ModelInstanceIndex> AddAllModelsFromFile(
       const std::string& file_name);
 
-  /// Parses the SDFormat or URDF file named in @p file_name and adds one
+  /// Parses the SDFormat, URDF, or MJCF file named in @p file_name and adds one
   /// top-level model to @p plant. It is an error to call this using an SDFormat
   /// file with more than one root-level `<model>` element.
   ///
@@ -88,7 +90,7 @@ class Parser final {
   /// @p file_type.
   ///
   /// @param file_contents The XML data to be parsed.
-  /// @param file_type The data format; must be either "sdf" or "urdf".
+  /// @param file_type The data format; must be either "sdf", "urdf", or "xml".
   /// @param model_name The name given to the newly created instance of this
   ///   model.  If empty, the "name" attribute from the `<model>` or `<robot>`
   ///   tag will be used.

--- a/multibody/parsing/test/parser_test.cc
+++ b/multibody/parsing/test/parser_test.cc
@@ -28,6 +28,8 @@ GTEST_TEST(FileParserTest, BasicTest) {
       "drake/multibody/benchmarks/acrobot/acrobot.sdf");
   const std::string urdf_name = FindResourceOrThrow(
       "drake/multibody/benchmarks/acrobot/acrobot.urdf");
+  const std::string xml_name = FindResourceOrThrow(
+      "drake/multibody/parsing/dm_control/suite/acrobot.xml");
 
   // Load from SDF using plural method.
   // Add a second one with an overridden model_name.
@@ -55,6 +57,19 @@ GTEST_TEST(FileParserTest, BasicTest) {
     dut.AddModelFromFile(sdf_name, "foo");
     dut.AddModelFromFile(urdf_name, "bar");
   }
+
+  // Load from XML using plural method.
+  // Add a second one with an overridden model_name.
+  {
+    MultibodyPlant<double> plant(0.0);
+    Parser dut(&plant);
+    const std::vector<ModelInstanceIndex> ids =
+        dut.AddAllModelsFromFile(xml_name);
+    EXPECT_EQ(ids.size(), 1);
+    EXPECT_EQ(plant.GetModelInstanceName(ids[0]), "acrobot");
+    const ModelInstanceIndex id = dut.AddModelFromFile(xml_name, "foo");
+    EXPECT_EQ(plant.GetModelInstanceName(id), "foo");
+  }
 }
 
 GTEST_TEST(FileParserTest, BasicStringTest) {
@@ -62,6 +77,8 @@ GTEST_TEST(FileParserTest, BasicStringTest) {
       "drake/multibody/benchmarks/acrobot/acrobot.sdf");
   const std::string urdf_name = FindResourceOrThrow(
       "drake/multibody/benchmarks/acrobot/acrobot.urdf");
+  const std::string xml_name = FindResourceOrThrow(
+      "drake/multibody/parsing/dm_control/suite/acrobot.xml");
 
   // Load an SDF via string.
   {
@@ -78,6 +95,15 @@ GTEST_TEST(FileParserTest, BasicStringTest) {
     MultibodyPlant<double> plant(0.0);
     Parser dut(&plant);
     const ModelInstanceIndex id = dut.AddModelFromString(urdf_contents, "urdf");
+    EXPECT_EQ(plant.GetModelInstanceName(id), "acrobot");
+  }
+
+  // Load an MJCF via string.
+  {
+    const std::string xml_contents = ReadEntireFile(xml_name);
+    MultibodyPlant<double> plant(0.0);
+    Parser dut(&plant);
+    const ModelInstanceIndex id = dut.AddModelFromString(xml_contents, "xml");
     EXPECT_EQ(plant.GetModelInstanceName(id), "acrobot");
   }
 }


### PR DESCRIPTION
This adds the plumbing to parse into the MuJoCo format (MJCF) from the
main Parser class.

Resolves #16369.

+@rpoyner-tri for feature review, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17358)
<!-- Reviewable:end -->
