### PR TITLE
Bump CRU and VGT to address Clang warnings

### DIFF
--- a/tools/workspace/common_robotics_utilities/repository.bzl
+++ b/tools/workspace/common_robotics_utilities/repository.bzl
@@ -16,8 +16,8 @@ def common_robotics_utilities_repository(
         # package.BUILD.bazel and BUILD.bazel in drake. Tests may have been
         # updated in ToyotaResearchInstitute/common_robotics_utilities/test/ or
         # ToyotaResearchInstitute/common_robotics_utilities/CMakeLists.txt.ros2
-        commit = "052ef48fe047ee5d17ca14c82947f360a92032c5",
-        sha256 = "14a95b168575d05494a0132747531bcba159371be8718ec2a35d429ce35229fa",  # noqa
+        commit = "433d858ccc3f6781d979d12ca81b2ec8a99a5792",
+        sha256 = "b7e715792661019258ffe48bc8c67e71b2f4c08ef08cc6743f47d6935727a227",  # noqa
         build_file = "@drake//tools/workspace/common_robotics_utilities:package.BUILD.bazel",  # noqa
         mirrors = mirrors,
     )

--- a/tools/workspace/voxelized_geometry_tools/repository.bzl
+++ b/tools/workspace/voxelized_geometry_tools/repository.bzl
@@ -14,8 +14,8 @@ def voxelized_geometry_tools_repository(
         repository = "ToyotaResearchInstitute/voxelized_geometry_tools",
         # When updating, ensure that any new unit tests are reflected in
         # package.BUILD.bazel and BUILD.bazel in drake.
-        commit = "ebd71490406ec74ea6db0b63237890559170f169",
-        sha256 = "fdca3120809f5c2d3248a011e3f78bd54a466d737e2a1705833fb375db5b995e",  # noqa
+        commit = "c940ec07ecb4f109712d2be071798a00646823ca",
+        sha256 = "b7718ca30b46c6d4420b3ed2f7890bce998bee659d056954c9051a9cba202404",  # noqa
         build_file = "@drake//tools/workspace/voxelized_geometry_tools:package.BUILD.bazel",  # noqa
         mirrors = mirrors,
     )


### PR DESCRIPTION
Upstream changes bring CRU & VGT warning-free with Clang on their set of warnings (somewhat different than Drake, including -Wconversion that Clang is pickier about).

+@jwnimmer-tri  for review, thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17359)
<!-- Reviewable:end -->
