### PR TITLE
Fix broken gfortran in macOS wheel build

### DIFF
--- a/tools/wheel/macos/build-wheel.sh
+++ b/tools/wheel/macos/build-wheel.sh
@@ -56,6 +56,12 @@ done < "$resource_root/image/known_hosts"
 
 chmod 600 ~/.ssh/known_hosts
 
+# gfortran hard-codes the path to the SDK with which it was built, which may
+# not match the SDK actually on the machine. This can result in the error
+# "ld: library not found for -lm", and can be fixed/overridden by setting
+# SDKROOT to the appropriate path.
+export SDKROOT="$(xcrun --show-sdk-path)"
+
 # -----------------------------------------------------------------------------
 # Build Drake's dependencies.
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
It appears that `gfortran` has a somewhat-well-known issue in that it hard-codes the SDK path that was used to build it, which results in it falling flat on its face (`ld: library not found for -lm` is especially popular) if the version of the installed SDK does not match exactly. While I have never encountered this personally, it appears to affect at least our Monterey CI machine(s).
    
Work around this by explicitly setting the `SDKROOT` to the appropriate path. (It appears we already do this for Bazel itself, but the macOS wheel builds need it set when we build dependencies, particularly MUMPS.)

See also https://github.com/xianyi/OpenBLAS/issues/3032#issuecomment-743805371.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17360)
<!-- Reviewable:end -->
