### PR TITLE
[workspace] Fix build recipe for sdformat_internal

### DIFF
--- a/tools/workspace/sdformat_internal/embed_sdf.py
+++ b/tools/workspace/sdformat_internal/embed_sdf.py
@@ -5,7 +5,7 @@ import sys
 assert __name__ == '__main__'
 
 print("""
-#include "src/EmbeddedSdf.hh"
+#include "EmbeddedSdf.hh"
 namespace sdf { inline namespace SDF_VERSION_NAMESPACE {
 const std::map<std::string, std::string>& GetEmbeddedSdf() {
   static const std::map<std::string, std::string> result{

--- a/tools/workspace/sdformat_internal/package.BUILD.bazel
+++ b/tools/workspace/sdformat_internal/package.BUILD.bazel
@@ -173,6 +173,7 @@ _SRCS = [
     "src/Cylinder.cc",
     "src/Element.cc",
     "src/Ellipsoid.cc",
+    "src/EmbeddedSdf.cc",  # N.B. Generated file.
     "src/EmbeddedSdf.hh",
     "src/Error.cc",
     "src/Exception.cc",
@@ -235,7 +236,6 @@ _SRCS = [
     "src/XmlUtils.hh",
     "src/parser.cc",
     "src/parser_private.hh",
-    ":src/EmbeddedSdf.cc",
 ]
 
 # Generates the library exported to users.


### PR DESCRIPTION
When the compilation sandbox is disabled (i.e., for coverage builds), it points out a misspelled include path.