### PR TITLE
[workspace] Remove nlopt_internal build console spam

### DIFF
--- a/tools/workspace/nlopt_internal/package.BUILD.bazel
+++ b/tools/workspace/nlopt_internal/package.BUILD.bazel
@@ -301,7 +301,7 @@ genrule(
     cmd = " ".join([
         "cp $(execpath src/api/nlopt-in.hpp) $@",
         "&&",
-        "patch $@ $(execpath @drake//tools/workspace/nlopt_internal:patches/gen_enums.patch)",  # noqa
+        "patch --quiet $@ $(execpath @drake//tools/workspace/nlopt_internal:patches/gen_enums.patch)",  # noqa
     ]),
     visibility = ["@drake//tools/workspace/nlopt_internal:__pkg__"],
 )

--- a/tools/workspace/nlopt_internal/patches/gen_enums.patch
+++ b/tools/workspace/nlopt_internal/patches/gen_enums.patch
@@ -6,7 +6,7 @@ CMake script both produce consistent results.
 
 --- src/api/nlopt-in.hpp.orig
 +++ src/api/nlopt-in.hpp
-@@ -39,4 +34,66 @@
+@@ -46,6 +46,68 @@
    // nlopt::* namespace versions of the C enumerated types
    //          AUTOMATICALLY GENERATED, DO NOT EDIT
    // GEN_ENUMS_HERE
@@ -73,3 +73,5 @@ CMake script both produce consistent results.
 +    NUM_RESULTS           /* not a result, just the number of possible successes */
 +  };
    //////////////////////////////////////////////////////////////////////
+
+   typedef nlopt_func func; // nlopt::func synoynm


### PR DESCRIPTION
The spam used to look like this:
```
[8:15:20 AM]  INFO: From Executing genrule @nlopt_internal//:nlopt_hpp_genrule:
[8:15:20 AM]  patching file bazel-out/k8-dbg/bin/external/nlopt_internal/genrule/nlopt.hpp
[8:15:20 AM]  Hunk #1 succeeded at 46 with fuzz 2 (offset 7 lines).
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17367)
<!-- Reviewable:end -->
