### PR TITLE
[tools] benchmark_tool: Fail fast if we can't control turbo settings

### DIFF
--- a/tools/performance/benchmark_tool.py
+++ b/tools/performance/benchmark_tool.py
@@ -117,6 +117,13 @@ class CpuSpeedSettings:
 
 
 def do_benchmark(args):
+    if not CpuSpeedSettings().is_supported_cpu():
+        raise RuntimeError("""
+The intel_pstate Linux kernel driver is not running. Without it, there is no
+way to prevent Turbo Boost cpu frequency scaling, and experiment results will
+be invalid.
+""")
+
     command_prologue = []
     if is_default_ubuntu():
         kernel_name = subprocess.check_output(


### PR DESCRIPTION
Closes: #17369

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17371)
<!-- Reviewable:end -->
