### PR TITLE
[gl_renderer] Stop polluting downstream include paths with opengl

### DIFF
--- a/geometry/render/gl_renderer/BUILD.bazel
+++ b/geometry/render/gl_renderer/BUILD.bazel
@@ -4,6 +4,7 @@ load(
     "@drake//tools/skylark:drake_cc.bzl",
     "drake_cc_googletest",
     "drake_cc_library",
+    "drake_cc_package_library",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load("//tools/skylark:test_tags.bzl", "vtk_test_tags")
@@ -11,7 +12,6 @@ load(
     "//tools/skylark:drake_cc_per_os.bzl",
     "drake_cc_googletest_ubuntu_only",
     "drake_cc_library_ubuntu_only",
-    "drake_cc_package_library_per_os",
 )
 
 # This gl_renderer package is only implemented on Ubuntu.  For macOS, only the
@@ -28,25 +28,13 @@ load(
 
 package(default_visibility = ["//visibility:private"])
 
-drake_cc_package_library_per_os(
+drake_cc_package_library(
     name = "gl_renderer",
-    macos_deps = [
-        ":render_engine_gl_factory",
-        ":render_engine_gl_params",
-    ],
-    ubuntu_deps = [
-        ":gl_common",
-        ":opengl_context",
-        ":opengl_geometry",
-        ":render_engine_gl",
-        ":render_engine_gl_factory",
-        ":render_engine_gl_params",
-        ":shader_program",
-        ":shader_program_data",
-        ":shape_meshes",
-        ":texture_library",
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        ":render_engine_gl_factory",
+        ":render_engine_gl_params",
+    ],
 )
 
 drake_cc_library_ubuntu_only(
@@ -119,6 +107,10 @@ drake_cc_library(
     hdrs = [
         "render_engine_gl_factory.h",
     ],
+    interface_deps = [
+        ":render_engine_gl_params",
+        "//geometry/render:render_engine",
+    ],
     deps = select({
         "//tools/cc_toolchain:apple": [
             ":apple_only_no_render_engine_gl_factory",
@@ -151,6 +143,7 @@ drake_cc_library(
     hdrs = ["render_engine_gl_params.h"],
     deps = [
         "//geometry:rgba",
+        "//geometry/render:render_label",
     ],
 )
 

--- a/tools/install/libdrake/header_lint.bzl
+++ b/tools/install/libdrake/header_lint.bzl
@@ -19,7 +19,6 @@ _ALLOWED_EXTERNALS = [
     "double_conversion",
     "glew",
     "glib",
-    "glx",
     "libjpeg",
     "liblz4",
     "liblzma",

--- a/tools/skylark/drake_cc_per_os.bzl
+++ b/tools/skylark/drake_cc_per_os.bzl
@@ -46,25 +46,14 @@ def drake_cc_library_ubuntu_only(
     Otherwise, does nothing.
 
     Because this library is not cross-platform, the visibility defaults to
-    private and the headers are excluded from the installation.
+    private and internal is forced to True (so that, e.g., the headers are
+    excluded from the installation).
     """
     if UBUNTU_RELEASE != None:
         drake_cc_library(
             name = name,
             hdrs = hdrs,
             visibility = visibility,
-            install_hdrs_exclude = hdrs,
+            internal = True,
             **kwargs
         )
-
-def drake_cc_package_library_per_os(
-        macos_deps = [],
-        ubuntu_deps = [],
-        **kwargs):
-    """Declares a drake_cc_package_library, where the deps of the library are
-    conditioned on whether we are building on macOS or Ubuntu.
-    """
-    if MACOS_RELEASE != None:
-        drake_cc_package_library(deps = macos_deps, **kwargs)
-    if UBUNTU_RELEASE != None:
-        drake_cc_package_library(deps = ubuntu_deps, **kwargs)


### PR DESCRIPTION
In #17377 coming up next, we can finally retire a lot of library pollution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17376)
<!-- Reviewable:end -->
