### PR TITLE
Fix some build errors on Jammy

### DIFF
--- a/common/yaml/test/yaml_performance_test.cc
+++ b/common/yaml/test/yaml_performance_test.cc
@@ -50,7 +50,7 @@ GTEST_TEST(YamlPerformanceTest, VectorNesting) {
   Map data;
   double dummy = 1.0;
   const std::vector keys{"a", "b", "c", "d", "e"};
-  for (const std::string& key : keys) {
+  for (const char* const key : keys) {
     Outer& outer = data.items[key];
     outer.inners.resize(kDim);
     for (Inner& inner : outer.inners) {
@@ -92,7 +92,7 @@ GTEST_TEST(YamlPerformanceTest, VectorNesting) {
 
   // Double-check that we actually did the work.
   ASSERT_EQ(new_data.items.size(), keys.size());
-  for (const std::string& key : keys) {
+  for (const char* const key : keys) {
     Outer& outer = new_data.items[key];
     ASSERT_EQ(outer.inners.size(), kDim);
     for (Inner& inner : outer.inners) {

--- a/examples/acrobot/test/multibody_dynamics_test.cc
+++ b/examples/acrobot/test/multibody_dynamics_test.cc
@@ -15,11 +15,11 @@ namespace {
 // Tests that the hand-derived dynamics (from the textbook) match the dynamics
 // generated from the urdf and sdf files via the MultibodyPlant class.
 GTEST_TEST(MultibodyDynamicsTest, AllTests) {
-  for (const std::string& ext : {"urdf", "sdf"}) {
+  for (const char* const ext : {"urdf", "sdf"}) {
     const double kTimeStep = 0.0;
     multibody::MultibodyPlant<double> mbp(kTimeStep);
-    multibody::Parser(&mbp).AddModelFromFile(
-        FindResourceOrThrow("drake/examples/acrobot/Acrobot." + ext));
+    multibody::Parser(&mbp).AddModelFromFile(FindResourceOrThrow(
+        fmt::format("drake/examples/acrobot/Acrobot.{}", ext)));
     mbp.Finalize();
 
     AcrobotPlant<double> p;

--- a/geometry/proximity/mesh_to_vtk.cc
+++ b/geometry/proximity/mesh_to_vtk.cc
@@ -30,7 +30,7 @@ void WriteVtkUnstructuredGrid(std::ofstream& out, const Mesh& mesh) {
   const int num_points = mesh.num_vertices();
   out << "DATASET UNSTRUCTURED_GRID\n";
   out << "POINTS " << num_points << " double\n";
-  for (const Vector3<double> p_MV : mesh.vertices()) {
+  for (const Vector3<double>& p_MV : mesh.vertices()) {
     out << fmt::format("{:12.8f} {:12.8f} {:12.8f}\n", p_MV.x(), p_MV.y(),
                        p_MV.z());
   }

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -2519,7 +2519,7 @@ TEST_F(GeometryStateTest, GeometryNameValidation) {
   // Case: Whitespace that SDF nevertheless considers not whitespace.
   // Update this when the following sdformat issue is resolved:
   // https://bitbucket.org/osrf/sdformat/issues/194/string-trimming-only-considers-space-and
-  for (const string& s : {"\n", " \n\t", " \f", "\v", "\r", "\ntest"}) {
+  for (const char* const s : {"\n", " \n\t", " \f", "\v", "\r", "\ntest"}) {
     EXPECT_TRUE(geometry_state_.IsValidGeometryName(frames_[0],
                                                     Role::kProximity, s));
   }

--- a/geometry/test/utilities_test.cc
+++ b/geometry/test/utilities_test.cc
@@ -30,8 +30,8 @@ GTEST_TEST(GeometryUtilities, CanonicalizeGeometryName) {
   };
 
   // Test various names -- including names with internal whitespace.
-  for (const std::string& canonical :
-       {"name", "with space", "with\ttab", "with\nnewline",
+  for (const std::string& canonical : std::initializer_list<std::string>{
+        "name", "with space", "with\ttab", "with\nnewline",
         "with\vvertical tab", "with\fformfeed"}) {
     // Confirms that the given name canonicalizes to the given canonical name.
     auto expect_canonical = [&canonical](const std::string& name) {
@@ -45,7 +45,7 @@ GTEST_TEST(GeometryUtilities, CanonicalizeGeometryName) {
     expect_unchanged(canonical);
 
     // Characters that *do* get trimmed off.
-    for (const std::string& whitespace : {" ", "\t"}) {
+    for (const char whitespace : {' ', '\t'}) {
       expect_canonical(whitespace + canonical);
       expect_canonical(whitespace + canonical + whitespace);
       expect_canonical(canonical + whitespace);
@@ -55,7 +55,7 @@ GTEST_TEST(GeometryUtilities, CanonicalizeGeometryName) {
     // These should be considered a defect in the SDF trimming logic. An issue
     // has been submitted and these tests should be updated when the sdformat
     // trimming logic has been updated.
-    for (const std::string& whitespace : {"\n", "\v", "\f"}) {
+    for (const char whitespace : {'\n', '\v', '\f'}) {
       expect_unchanged(whitespace + canonical + whitespace);
       expect_unchanged(whitespace + canonical);
       expect_unchanged(canonical + whitespace);

--- a/multibody/contact_solvers/sap/partial_permutation.cc
+++ b/multibody/contact_solvers/sap/partial_permutation.cc
@@ -1,5 +1,6 @@
 #include "drake/multibody/contact_solvers/sap/partial_permutation.h"
 
+#include <algorithm>
 #include <utility>
 
 #include "fmt/format.h"

--- a/multibody/fixed_fem/dev/deformable_rigid_mesh_intersection.cc
+++ b/multibody/fixed_fem/dev/deformable_rigid_mesh_intersection.cc
@@ -66,7 +66,7 @@ class Intersector {
     vector<ContactPolygonData<T>> out_poly_data;
 
     const math::RigidTransformd& X_DR_d = convert_to_double(X_DR);
-    for (const auto [tet_index, tri_index] :
+    for (const auto& [tet_index, tri_index] :
          tet_mesh_D.bvh().GetCollisionCandidates(bvh_R, X_DR_d)) {
       const vector<IntersectionVertex<T>>& poly_vertices_D =
           ClipTriangleByTetrahedron(tet_index, tet_mesh_D.mesh(), tri_index,

--- a/multibody/tree/test/weld_mobilizer_test.cc
+++ b/multibody/tree/test/weld_mobilizer_test.cc
@@ -75,8 +75,9 @@ TEST_F(WeldMobilizerTest, CalcAcrossMobilizerSpatialAcceleration) {
 
 TEST_F(WeldMobilizerTest, ProjectSpatialForce) {
   VectorXd zero_sized_vector(0);
-  const SpatialForce<double> F_Mo_F;  // value not important for this test.
-  // no-op, just tests we can call it with a zero sized vector.
+  // Value not important for this test.
+  const SpatialForce<double> F_Mo_F(Vector6d::Zero());
+  // No-op, just tests we can call it with a zero sized vector.
   weld_body_to_world_->ProjectSpatialForce(
       *context_, F_Mo_F, zero_sized_vector);
 }

--- a/systems/analysis/test/hermitian_dense_output_test.cc
+++ b/systems/analysis/test/hermitian_dense_output_test.cc
@@ -350,7 +350,7 @@ void TestScalarType() {
   EXPECT_EQ(ExtractDoubleOrThrow(hdo.end_time()),
             ExtractDoubleOrThrow(breaks(2)));
 
-  for (const T& time : {0.1, 0.4, 1.6}) {
+  for (const T& time : {T(0.1), T(0.4), T(1.6)}) {
     EXPECT_NEAR(ExtractDoubleOrThrow(hdo.Evaluate(time)(0)),
                 ExtractDoubleOrThrow(foh.value(time)(0)), 1e-14);
   }

--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -1337,7 +1337,7 @@ Diagram<T>::ConvertScalarType() const {
   // Make all the inputs, preserving index assignments.
   for (int k = 0; k < this->num_input_ports(); k++) {
     const auto name = this->get_input_port(k).get_name();
-    for (const auto id : GetInputPortLocators(InputPortIndex(k))) {
+    for (const auto& id : GetInputPortLocators(InputPortIndex(k))) {
       const System<NewType>* new_system = old_to_new_map[id.first];
       const InputPortIndex port = id.second;
       blueprint->input_port_ids.emplace_back(new_system, port);


### PR DESCRIPTION
Fix some code that's tripping `-Werror=range-loop-construct`. Fix a missing include. Fix a `-Werror=maybe-uninitialized`.

Specifically, new compilers don't like two things: taking a copy of the loop item where a reference will do, and taking a reference when the loop item's type is specified such as to force a conversion, since this is taking a reference to a temporary. (The latter is arguably poor form, anyway, as it effectively hides a conversion.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17378)
<!-- Reviewable:end -->
