### PR TITLE
[manipulation/models] Zap now irrelevant README

### DIFF
--- a/manipulation/models/README.md
+++ b/manipulation/models/README.md
@@ -1,7 +1,0 @@
-# Manipulation Models
-
-At present, some of these model directories are inconsistently organized such
-that they could potentially be included via Gazebo or ROS, but in such a way
-that could shadow other ROS packages.
-
-After the resolution of #10531, this should be simplified and more compatible.


### PR DESCRIPTION
As discussed in #10531, the issue that this README was referring to
has been closed; the README is no longer relevant.

+@sammy-tri for both reviews, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17384)
<!-- Reviewable:end -->
