### PR TITLE
[manipulation] Add UR3e model and TRI Homecart

### DIFF
--- a/doc/_pages/model_version_control.md
+++ b/doc/_pages/model_version_control.md
@@ -27,12 +27,12 @@ See below for the suggested workflow.
 1. Clone ``RobotLocomotion/models`` locally
 2. Create a Git branch in your local checkouts of *both* ``models`` and
    ``drake``.
-3. Update ``drake/tools/workspace/models/repository.bzl`` to point to your
+3. Update ``drake/tools/workspace/models_internal/repository.bzl`` to point to your
    ``models`` checkout using
    ``github_archive(..., local_repository_override = <path>)``.
-4. Update ``drake/tools/workspace/models/files.bzl`` to incorporate the models
+4. Update ``drake/tools/workspace/models_internal/files.bzl`` to incorporate the models
    you want.
-5. Update ``drake/tools/workspace/models/package.BUILD.bazel`` to export the
+5. Update ``drake/tools/workspace/models_internal/package.BUILD.bazel`` to export the
    models.
 6. Ensure that you use ``forward_files`` to make the files available inside
    the Drake bazel workspace. For an example, see
@@ -42,7 +42,7 @@ See below for the suggested workflow.
 ## Submit Changes in a Pull Request
 
 1. Push your changes to your fork of ``RobotLocomotion/models``. Make a PR.
-2. Update ``drake/tools/workspace/models/models/repository.bzl`` to use the
+2. Update ``drake/tools/workspace/models_internal/repository.bzl`` to use the
    commit you pushed.
 3. Submit a PR to Drake, and add a self-blocking discussion thread, such as
    ``"Working temporary SHA1 until the models PR <LINK> is merged."``,
@@ -51,6 +51,6 @@ See below for the suggested workflow.
    request review for your ``models`` PR.
 5. Once both PRs are approved:
    1. Merge your ``models`` PR.
-   2. Update ``drake/tools/workspace/models/repository.bzl`` to the latest
+   2. Update ``drake/tools/workspace/models_internal/repository.bzl`` to the latest
       merge commit on ``master`` for ``RobotLocomotion/models``.
    3. Merge your ``drake`` PR.

--- a/manipulation/models/BUILD.bazel
+++ b/manipulation/models/BUILD.bazel
@@ -12,6 +12,8 @@ install(
         "//manipulation/models/iiwa_description:install_data",
         "//manipulation/models/jaco_description:install_data",
         "//manipulation/models/realsense2_description:install_data",
+        "//manipulation/models/tri_homecart:install_data",
+        "//manipulation/models/ur3e:install_data",
         "//manipulation/models/wsg_50_description:install_data",
         "//manipulation/models/ycb:install_data",
     ],

--- a/manipulation/models/tri_homecart/BUILD.bazel
+++ b/manipulation/models/tri_homecart/BUILD.bazel
@@ -1,0 +1,62 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_googletest",
+)
+load("//tools/install:install_data.bzl", "install_data")
+load("//tools/lint:lint.bzl", "add_lint_tests")
+load("@drake//tools/workspace/ros_xacro_internal:defs.bzl", "xacro_file")
+load("@drake//tools/workspace:forward_files.bzl", "forward_files")
+load("//tools/workspace/models_internal:files.bzl", "tri_homecart_mesh_files")
+
+# This package is public so that other packages can refer to
+# individual files in these models from their bazel rules.
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+# === test/ ===
+
+drake_cc_googletest(
+    name = "parse_homecart_test",
+    srcs = ["test/parse_homecart_test.cc"],
+    data = [
+        ":models",
+        "//manipulation/models/ur3e:models",
+        "//manipulation/models/wsg_50_description:models",
+    ],
+    deps = [
+        "//common:find_resource",
+        "//multibody/parsing",
+    ],
+)
+
+xacro_file(
+    name = "homecart_bimanual.urdf",
+    src = "homecart_bimanual.urdf.xacro",
+)
+
+xacro_file(
+    name = "homecart_cutting_board.sdf",
+    src = "homecart_cutting_board.sdf.xacro",
+)
+
+_TRI_HOMECART_MESHES = forward_files(
+    srcs = ["@models_internal//:" + x for x in tri_homecart_mesh_files()],
+    dest_prefix = "",
+    strip_prefix = "@models_internal//:tri_homecart/",
+    visibility = ["//visibility:private"],
+)
+
+install_data(
+    extra_prod_models = [
+        "homecart_bimanual.urdf",
+        "homecart_cutting_board.sdf",
+        "homecart_grippers.yaml",
+        "homecart_no_grippers.yaml",
+        "homecart.yaml",
+    ] + _TRI_HOMECART_MESHES,
+)
+
+add_lint_tests()

--- a/manipulation/models/tri_homecart/README.md
+++ b/manipulation/models/tri_homecart/README.md
@@ -1,0 +1,7 @@
+# TRI HomeCart
+
+The HomeCart is a bimanual manipulation station developed at the Toyota
+Research Institute (TRI).  The model files contained here are all developed by TRI
+and distributed under Drake's license.  They represent a slightly simplified
+version of the model files used internally at TRI (most notably they are using
+a simplified version of the grippers). 

--- a/manipulation/models/tri_homecart/homecart.yaml
+++ b/manipulation/models/tri_homecart/homecart.yaml
@@ -1,0 +1,5 @@
+directives:
+- add_directives:
+    file: package://drake/manipulation/models/tri_homecart/homecart_no_grippers.yaml
+- add_directives:
+    file: package://drake/manipulation/models/tri_homecart/homecart_grippers.yaml

--- a/manipulation/models/tri_homecart/homecart_bimanual.urdf.xacro
+++ b/manipulation/models/tri_homecart/homecart_bimanual.urdf.xacro
@@ -1,0 +1,422 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://wiki.ros.org/xacro" name="homecart_bimanual">
+  <!-- homecart's origin is homecart_base_link. This link is placed at the
+       center of the table along the table's long axis, offset along the
+       table's short axis between both robot arms on surface of the metal
+       base plate -->
+  <!-- The Left UR3e robot's ur_base_link is joined to left_arm_base_link -->
+  <!-- The Right UR3e robot's ur_base_link is joined to
+       right_arm_base_link -->
+  <!-- homecart_base_link ==>
+         left_arm_mount_cantilever_link ==>
+            left_arm_mount_stack_link ==>
+              left_arm_base_link ==>
+                ur3_left::ur_base_link (for UR3e arm model, with model
+                                        prefix "ur3_left")
+         right_arm_mount_cantilever_link ==>
+            right_arm_mount_stack_link ==>
+              right_arm_base_link ==>
+                ur3_right::ur_base_link (for UR3e arm model, with model
+                                         prefix "ur3_right")
+      The homecart_origin to "homecart_base_link" frames are zero translation
+      and identity rotation transforms to easily connect the models.
+      +z up, +x along the short axis of the table, +y along the long table axis
+      Positive origin axes eminate "forward" for X and "left" for Y, with
+      respect to the robot arm origins.
+  -->
+  <link name="homecart_base_link">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </link>
+  <xacro:property name="arm_mount_cantilever_length" value="0.254"/>
+  <xacro:property name="arm_mount_cantilever_height" value="0.015"/>
+  <xacro:property name="arm_mount_stack_plate_side" value="0.1275"/>
+  <xacro:property name="arm_mount_stack_plate_height" value="0.02"/>
+  <!-- Macro to build mounting cantelever, plates, and frames for robot arms.
+       Arguments include "side": prefix for arm
+                         "num_plate": the number of plates to stack
+                         "arm_mount_origin": full transform for origin with
+                                             respect to homecart_base_link -->
+  <xacro:macro name="arm_mount_xacro"
+               params="side num_plates *arm_mount_origin">
+    <!-- Private, recursive macro to stack visual plate meshes.
+         Arguments include "num_plate": the number of plates to stack -->
+    <xacro:macro name="arm_mount_visual_plates_xacro"
+                params="num_plates">
+      <visual>
+        <origin xyz="0 0 ${(num_plates-1)*arm_mount_stack_plate_height}"
+                rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://drake/manipulation/models/tri_homecart/homecart_arm_mount_stack.obj"/>
+        </geometry>
+      </visual>
+      <xacro:if value="${num_plates>1}">
+        <xacro:arm_mount_visual_plates_xacro num_plates="${num_plates-1}"/>
+      </xacro:if>
+    </xacro:macro>
+    <link name="${side}arm_mount_cantilever_link">
+      <visual>
+        <origin xyz="0 0 0.0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://drake/manipulation/models/tri_homecart/homecart_arm_mount_cantilever.obj"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="${arm_mount_cantilever_length/4}
+                     0
+                     ${arm_mount_cantilever_height/2.0}"
+                rpy="0 0 0"/>
+        <geometry>
+          <box size="${arm_mount_cantilever_length}
+                     ${arm_mount_stack_plate_side}
+                     ${arm_mount_cantilever_height}"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <!-- TODO(imcmahon) add valid mass and inertial properties here -->
+        <mass value="1.0"/>
+        <inertia ixx="100" ixy="0" ixz="0" iyy="100" iyz="0" izz="100"/>
+      </inertial>
+    </link>
+    <joint name="${side}arm_mount_cantilever_joint" type="fixed">
+      <xacro:insert_block name="arm_mount_origin"/>
+      <parent link="homecart_base_link"/>
+      <child link="${side}arm_mount_cantilever_link"/>
+    </joint>
+    <link name="${side}arm_mount_stack_link">
+      <xacro:arm_mount_visual_plates_xacro num_plates="${num_plates}"/>
+        <collision>
+        <origin xyz="0 0 ${(num_plates*arm_mount_stack_plate_height)/2.0}"
+                rpy="0 0 0"/>
+        <geometry>
+          <box size="${arm_mount_stack_plate_side}
+                     ${arm_mount_stack_plate_side}
+                     ${num_plates*arm_mount_stack_plate_height}"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <!-- TODO(imcmahon) add valid mass and inertial properties here -->
+        <mass value="1.0"/>
+        <inertia ixx="100" ixy="0" ixz="0" iyy="100" iyz="0" izz="100"/>
+      </inertial>
+    </link>
+    <joint name="${side}arm_mount_stack_joint" type="fixed">
+      <origin xyz="0 0 ${arm_mount_cantilever_height}" rpy="0 0 0"/>
+      <parent link="${side}arm_mount_cantilever_link"/>
+      <child link="${side}arm_mount_stack_link"/>
+    </joint>
+    <link name="${side}arm_base_link">
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+    </link>
+    <joint name="${side}arm_base_joint" type="fixed">
+      <origin xyz="0 0 ${num_plates*0.02}" rpy="0 0 0"/>
+      <parent link="${side}arm_mount_stack_link"/>
+      <child link="${side}arm_base_link"/>
+    </joint>
+  </xacro:macro>
+
+  <xacro:property name="arm_mount_pin_delta" value="0.02"/>
+  <!-- Valid pin locations (center outward): 0, 1, 2, 3, 4, 5 -->
+  <xacro:property name="arm_mount_pin_location" value="5"/>
+  <!-- Valid stack values: [0, 10] -->
+  <xacro:property name="num_plates" value="10"/>
+  <xacro:property name="homecart_base_link_center_x_offset" value="0.2775"/>
+  <xacro:property name="homecart_base_link_arm_y_offset" value="0.1"/>
+  <xacro:arm_mount_xacro side="left_" num_plates="${num_plates}">
+      <origin xyz="0
+                   ${homecart_base_link_arm_y_offset+
+                     (arm_mount_pin_location*arm_mount_pin_delta)}
+                   0"
+              rpy="0 0 0"/>
+  </xacro:arm_mount_xacro>
+  <xacro:arm_mount_xacro side="right_" num_plates="${num_plates}">
+      <origin xyz="0
+                   ${-homecart_base_link_arm_y_offset-
+                     (arm_mount_pin_location*arm_mount_pin_delta)}
+                   0"
+              rpy="0 0 0"/>
+  </xacro:arm_mount_xacro>
+  <xacro:property name="homecart_baseplate_width" value="0.6816"/>
+  <xacro:property name="homecart_baseplate_length" value="0.9864"/>
+  <xacro:property name="homecart_baseplate_height" value="0.0065"/>
+  <joint name="homecart_base_link" type="fixed">
+    <origin xyz="${homecart_base_link_center_x_offset} 0 0" rpy="0 0 0"/>
+    <parent link="homecart_base_link"/>
+    <child link="homecart_baseplate_link"/>
+  </joint>
+  <link name="homecart_baseplate_link">
+    <visual>
+      <origin xyz="0 0 0.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://drake/manipulation/models/tri_homecart/homecart_baseplate.obj"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 ${-homecart_baseplate_height/2.0}"
+              rpy="0 0 0"/>
+      <geometry>
+        <box size="${homecart_baseplate_width}
+                   ${homecart_baseplate_length}
+                   ${homecart_baseplate_height}"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <!-- TODO(imcmahon) add valid mass and inertial properties here -->
+      <mass value="1.0"/>
+      <inertia ixx="100" ixy="0" ixz="0" iyy="100" iyz="0" izz="100"/>
+    </inertial>
+  </link>
+  <xacro:property name="homecart_cart_length" value="0.93"/>
+  <xacro:property name="homecart_cart_width" value="0.62"/>
+  <xacro:property name="homecart_cart_height" value="1.0275"/>
+  <link name="homecart_cart_link">
+    <visual>
+      <origin xyz="0 0 0.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://drake/manipulation/models/tri_homecart/homecart_basecart.obj"/>
+      </geometry>
+    </visual>
+    <collision>
+      <!-- The collision shape geometry is specified with respect to its
+           geometric center, from the visual origin -->
+      <origin xyz="0 0 ${-homecart_cart_height/2.0}" rpy="0 0 0"/>
+      <geometry>
+        <box size="${homecart_cart_width}
+                   ${homecart_cart_length}
+                   ${homecart_cart_height}"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <!-- TODO(imcmahon) add valid mass and inertial properties here -->
+      <mass value="1.0"/>
+      <inertia ixx="100" ixy="0" ixz="0" iyy="100" iyz="0" izz="100"/>
+    </inertial>
+  </link>
+  <joint name="homecart_cart_joint" type="fixed">
+    <origin xyz="0 0 ${-homecart_baseplate_height}" rpy="0 0 0"/>
+    <parent link="homecart_baseplate_link"/>
+    <child link="homecart_cart_link"/>
+  </joint>
+  <!-- Add the upper structure board centered on the top leftmost
+       corner (from the robot's perspective) nearest to the
+       homecart_base_link side of the model. The origin is oriented
+       with +X along the long edge of the homecart, and +Y along the
+       short edge for ease of camera placement on this structure.-->
+  <xacro:property name="upper_structure_height" value="0.937"/>
+  <xacro:property name="upper_structure_length" value="0.9864"/>
+  <xacro:property name="upper_structure_width" value="0.6816"/>
+  <xacro:property name="upper_structure_beam_side" value="0.023"/>
+  <xacro:property name="upper_structure_angle_bracket_radius" value="0.054"/>
+  <xacro:property name="base_plate_thickness" value="0.0065"/>
+  <!-- This block contains the upper aluminum beam structures, along with
+        their angle connectors. There is a single link (and mesh) to
+        to encapsulate the struture, but several basic geometry collision
+        shapes for individual beams and connectors. -->
+  <xacro:property name="upper_structure_lower_z_origin"
+    value="${-upper_structure_height+
+             upper_structure_beam_side-
+             base_plate_thickness}"/>
+  <link name="homecart_upper_structure_link">
+    <inertial>
+      <!-- TODO(imcmahon) add valid mass and inertial properties here -->
+      <mass value="1.0"/>
+      <inertia ixx="100" ixy="0" ixz="0" iyy="100" iyz="0" izz="100"/>
+    </inertial>
+    <visual>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://drake/manipulation/models/tri_homecart/homecart_bimanual_upper_structure.obj"/>
+      </geometry>
+    </visual>
+
+    <!-- upper angle collision spheres -->
+    <collision>
+      <origin xyz="${upper_structure_beam_side/2.0}
+                   ${upper_structure_beam_side/2.0}
+                   ${-upper_structure_beam_side/2.0}"
+              rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="${upper_structure_angle_bracket_radius}"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="${upper_structure_length-upper_structure_beam_side/2.0}
+                   ${upper_structure_beam_side/2.0}
+                   ${-upper_structure_beam_side/2.0}"
+              rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="${upper_structure_angle_bracket_radius}"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="${upper_structure_length-upper_structure_beam_side/2.0}
+                   ${upper_structure_width-upper_structure_beam_side/2.0}
+                   ${-upper_structure_beam_side/2.0}"
+              rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="${upper_structure_angle_bracket_radius}"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="${upper_structure_beam_side/2.0}
+                   ${upper_structure_width-upper_structure_beam_side/2.0}
+                   ${-upper_structure_beam_side/2.0}"
+              rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="${upper_structure_angle_bracket_radius}"/>
+      </geometry>
+    </collision>
+    <!-- lower angle collision spheres -->
+    <collision>
+      <origin xyz="${upper_structure_length-upper_structure_beam_side/2.0}
+                   ${upper_structure_width-upper_structure_beam_side/2.0}
+                   ${upper_structure_lower_z_origin}"
+              rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="${upper_structure_angle_bracket_radius}"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="${upper_structure_length-upper_structure_beam_side/2.0}
+                   ${upper_structure_beam_side/2.0}
+                   ${upper_structure_lower_z_origin}"
+              rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="${upper_structure_angle_bracket_radius}"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="${upper_structure_beam_side/2.0}
+                   ${upper_structure_width-upper_structure_beam_side/2.0}
+                   ${upper_structure_lower_z_origin}"
+              rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="${upper_structure_angle_bracket_radius}"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="${upper_structure_beam_side/2.0}
+                   ${upper_structure_beam_side/2.0}
+                   ${upper_structure_lower_z_origin}"
+              rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="${upper_structure_angle_bracket_radius}"/>
+      </geometry>
+    </collision>
+    <!-- Macro for building horizontal, square collision bars.
+         Arguments include "z_origin": the mounting point along the
+                                       parent frame's Z axis -->
+    <xacro:macro name="upper_structure_horizontal_collision_bars"
+                 params="z_origin">
+      <collision>
+        <origin xyz="${upper_structure_length/2.0}
+                     ${upper_structure_beam_side/2.0}
+                     ${z_origin}"
+                rpy="0 0 0"/>
+        <geometry>
+          <box size="${upper_structure_length}
+                     ${upper_structure_beam_side}
+                     ${upper_structure_beam_side}"/>
+        </geometry>
+      </collision>
+      <collision>
+        <origin xyz="${upper_structure_beam_side/2.0}
+                     ${upper_structure_width/2.0}
+                     ${z_origin}"
+                rpy="0 0 0"/>
+        <geometry>
+          <box size="${upper_structure_beam_side}
+                     ${upper_structure_width}
+                     ${upper_structure_beam_side}"/>
+        </geometry>
+      </collision>
+      <collision>
+        <origin xyz="${upper_structure_length/2.0}
+                     ${upper_structure_width-upper_structure_beam_side/2.0}
+                     ${z_origin}"
+                rpy="0 0 0"/>
+        <geometry>
+          <box size="${upper_structure_length}
+                     ${upper_structure_beam_side}
+                     ${upper_structure_beam_side}"/>
+        </geometry>
+      </collision>
+      <collision>
+        <origin xyz="${upper_structure_length-upper_structure_beam_side/2.0}
+                     ${upper_structure_width/2.0}
+                     ${z_origin}"
+                rpy="0 0 0"/>
+        <geometry>
+          <box size="${upper_structure_beam_side}
+                     ${upper_structure_width}
+                     ${upper_structure_beam_side}"/>
+        </geometry>
+      </collision>
+    </xacro:macro>
+    <!-- Upper horizontal aluminum beam collision boxes -->
+    <xacro:upper_structure_horizontal_collision_bars
+      z_origin="${-upper_structure_beam_side/2.0}" />
+    <!-- Lower horizontal aluminum beam collision boxes -->
+    <xacro:upper_structure_horizontal_collision_bars
+      z_origin="${upper_structure_lower_z_origin}" />
+    <!-- Vertical aluminum beam collision boxes -->
+    <collision>
+      <origin xyz="${upper_structure_beam_side/2.0}
+                   ${upper_structure_width-upper_structure_beam_side/2.0}
+                   ${-upper_structure_height/2.0}"
+              rpy="0 0 0"/>
+      <geometry>
+        <box size="${upper_structure_beam_side}
+                   ${upper_structure_beam_side}
+                   ${upper_structure_height}"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="${upper_structure_beam_side/2.0}
+                   ${upper_structure_beam_side/2.0}
+                   ${-upper_structure_height/2.0}"
+              rpy="0 0 0"/>
+      <geometry>
+        <box size="${upper_structure_beam_side}
+                   ${upper_structure_beam_side}
+                   ${upper_structure_height}"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="${upper_structure_length-upper_structure_beam_side/2.0}
+                   ${upper_structure_beam_side/2.0}
+                   ${-upper_structure_height/2.0}"
+              rpy="0 0 0"/>
+      <geometry>
+        <box size="${upper_structure_beam_side}
+                   ${upper_structure_beam_side}
+                   ${upper_structure_height}"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="${upper_structure_length-upper_structure_beam_side/2.0}
+                   ${upper_structure_width-upper_structure_beam_side/2.0}
+                   ${-upper_structure_height/2.0}"
+              rpy="0 0 0"/>
+      <geometry>
+        <box size="${upper_structure_beam_side}
+                   ${upper_structure_beam_side}
+                   ${upper_structure_height}"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="homecart_upper_structure_joint" type="fixed">
+    <!-- Translation from homecart_base_link between robot arms to
+          the top rear corner of the upper structure. This location
+          on the upper structure simplifies collision shape calculation,
+          and transforms adding cameras to this level. -->
+    <origin xyz="${homecart_base_link_center_x_offset-
+                   upper_structure_width/2.0}
+                 ${upper_structure_length/2.0}
+                 ${upper_structure_height-
+                   upper_structure_beam_side-
+                   base_plate_thickness}"
+            rpy="0 0 ${3*pi/2.0}"/>
+    <parent link="homecart_base_link"/>
+    <child link="homecart_upper_structure_link"/>
+  </joint>
+</robot>

--- a/manipulation/models/tri_homecart/homecart_collision_walls.sdf
+++ b/manipulation/models/tri_homecart/homecart_collision_walls.sdf
@@ -1,0 +1,105 @@
+<?xml version="1.0"?>
+<sdf version="1.7">
+  <model name="homecart_collision_walls">
+    <link name="homecart_collision_walls">
+      <pose>0 0 0 0 0 0</pose>
+      <!-- Computed assuming uniform density box -->
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>0.1</mass>
+        <inertia>
+          <ixx> 0.00004166666 </ixx>
+          <ixy> 0 </ixy>
+          <ixz> 0 </ixz>
+          <iyy> 0.00004166666 </iyy>
+          <iyz> 0 </iyz>
+          <izz> 0.00004166666 </izz>
+        </inertia>
+      </inertial>
+
+      <visual name="right_visual">
+        <pose>1.0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.5 2.0 2.0</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0 0 0 0</diffuse>
+        </material>
+      </visual>
+
+      <collision name="right_collision">
+        <pose>1.0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.5 2.0 2.0</size>
+          </box>
+        </geometry>
+      </collision>
+
+      <visual name="left_visual">
+        <pose>-1.0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.5 2.0 2.0</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0 0 0 0</diffuse>
+        </material>
+      </visual>
+
+      <collision name="left_collision">
+        <pose>-1.0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.5 2.0 2.0</size>
+          </box>
+        </geometry>
+      </collision>
+
+      <visual name="front_visual">
+        <pose>0 1.0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>2.0 0.5 2.0</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0 0 0 0</diffuse>
+        </material>
+      </visual>
+
+      <collision name="front_collision">
+        <pose>0 1.0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>2.0 0.5 2.0</size>
+          </box>
+        </geometry>
+      </collision>
+
+      <visual name="back_visual">
+        <pose>0 -1.0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>2.0 0.5 2.0</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0 0 0 0</diffuse>
+        </material>
+      </visual>
+
+      <collision name="back_collision">
+        <pose>0 -1.0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>2.0 0.5 2.0</size>
+          </box>
+        </geometry>
+      </collision>
+    </link>
+  </model>
+</sdf>

--- a/manipulation/models/tri_homecart/homecart_cutting_board.sdf.xacro
+++ b/manipulation/models/tri_homecart/homecart_cutting_board.sdf.xacro
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<sdf version="1.7"
+     xmlns:xacro="http://wiki.ros.org/xacro"
+     xmlns:drake="https://drake.mit.edu">
+  <model name="homecart_cutting_board">
+    <!--
+    Axes:
+      +X - Pointing towards front
+      +Y - Pointing to left side
+      +Z - Up
+    Origin:
+      (0, 0, 0)
+    A custom cutting board centered on the homecart baseplate center with the
+    same X,Y origin point.
+    The large double cutting board's origin is at the center of the homecart
+    offset from the table by the height of the cutting board, with the
+    Z axis upward from the table. The Y axis is facing along the long axis
+    of the table, and X axis along the short axis of the table.
+    -->
+    <xacro:property name="homecart_cutting_board_height" value="0.0254"/>
+    <xacro:property name="homecart_cutting_board_width" value="0.9864"/>
+    <xacro:property name="homecart_cutting_board_length" value="0.6816"/>
+    <link name="homecart_cutting_board_link">
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>1.0</mass>
+        <inertia>
+          <ixx>100</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>100</iyy>
+          <iyz>0</iyz>
+          <izz>100</izz>
+        </inertia>
+      </inertial>
+      <visual name="visual">
+        <pose>0 0 0 0 0 0</pose>
+        <geometry>
+          <mesh>
+            <uri>homecart_cutting_board.obj</uri>
+            <scale>1.0 1.0 1.0</scale>
+          </mesh>
+        </geometry>
+      </visual>
+      <!-- At the suggestion of the dynamics team, we define both a compliant
+           and a rigid surface, with the rigid one slightly inset.  This means
+           that:
+            * user code can assign different items to the different
+              collision styles, but
+            * Objects without special collision filtering will not penetrate
+              far enough into the cutting board to cause pathological collision
+              shapes.
+      -->
+      <collision name="collision_compliant">
+        <pose>0 0 ${-homecart_cutting_board_height/2.0} 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>
+              ${homecart_cutting_board_length}
+              ${homecart_cutting_board_width}
+              ${homecart_cutting_board_height}
+            </size>
+          </box>
+        </geometry>
+        <drake:proximity_properties>
+          <drake:mu_dynamic>0.3</drake:mu_dynamic>
+          <drake:mu_static>0.3</drake:mu_static>
+          <drake:hydroelastic_modulus>20.0e3</drake:hydroelastic_modulus>
+          <drake:hunt_crossley_dissipation>200</drake:hunt_crossley_dissipation>
+          <drake:compliant_hydroelastic/>
+        </drake:proximity_properties>
+      </collision>
+      <collision name="collision_rigid">
+        <pose>0 0 ${-homecart_cutting_board_height/2.0} 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>
+              ${homecart_cutting_board_length}
+              ${homecart_cutting_board_width}
+              ${homecart_cutting_board_height - 0.001}
+            </size>
+          </box>
+        </geometry>
+        <drake:proximity_properties>
+          <drake:mu_dynamic>0.3</drake:mu_dynamic>
+          <drake:mu_static>0.3</drake:mu_static>
+          <drake:hunt_crossley_dissipation>200</drake:hunt_crossley_dissipation>
+          <drake:rigid_hydroelastic/>
+        </drake:proximity_properties>
+      </collision>
+    </link>
+  </model>
+</sdf>

--- a/manipulation/models/tri_homecart/homecart_grippers.yaml
+++ b/manipulation/models/tri_homecart/homecart_grippers.yaml
@@ -1,0 +1,41 @@
+directives:
+# Left Gripper
+- add_frame:
+    name: gripper_left_origin
+    X_PF:
+      base_frame: ur3_left::ur_ee_link
+      translation: [0.06, 0, 0]
+      rotation: !Rpy { deg: [0, 0, -90] }
+- add_model:
+    name: gripper_left
+    file: package://drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_with_tip.sdf
+- add_weld:
+    parent: gripper_left_origin
+    child: gripper_left::body
+# Right Gripper
+- add_frame:
+    name: gripper_right_origin
+    X_PF:
+      base_frame: ur3_right::ur_ee_link
+      translation: [0.06, 0, 0]
+      rotation: !Rpy { deg: [0, 0, -90] }
+- add_model:
+    name: gripper_right
+    file: package://drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_with_tip.sdf
+- add_weld:
+    parent: gripper_right_origin
+    child: gripper_right::body
+
+# Grasp frames
+- add_frame:
+    name: gripper_left::grasp_frame
+    X_PF:
+      base_frame: gripper_left::body_frame
+      translation: [0.0, 0.11, 0.0]
+      rotation: !Rpy { deg: [0, 0, 0] }
+- add_frame:
+    name: gripper_right::grasp_frame
+    X_PF:
+      base_frame: gripper_right::body_frame
+      translation: [0.0, 0.11, 0.0]
+      rotation: !Rpy { deg: [0, 0, 0] }

--- a/manipulation/models/tri_homecart/homecart_no_grippers.yaml
+++ b/manipulation/models/tri_homecart/homecart_no_grippers.yaml
@@ -1,0 +1,119 @@
+directives:
+- add_frame:
+    name: homecart_on_world
+    X_PF:
+      base_frame: world
+      translation: [0, 0, 0]
+      rotation: !Rpy { deg: [0, 0, 0] }
+
+# Homecart
+- add_model:
+    name: homecart_bimanual
+    file: package://drake/manipulation/models/tri_homecart/homecart_bimanual.urdf
+- add_weld:
+    parent: homecart_on_world
+    child: homecart_bimanual::homecart_base_link
+
+# Homecart Collision Walls
+- add_frame:
+    name: homecart_collision_walls_on_world
+    X_PF:
+      base_frame: world
+      translation: [0.25, 0, 0]
+      rotation: !Rpy { deg: [0, 0, -90] }
+- add_model:
+    name: homecart_collision_walls
+    file: package://drake/manipulation/models/tri_homecart/homecart_collision_walls.sdf
+- add_weld:
+    parent: homecart_collision_walls_on_world
+    child: homecart_collision_walls
+
+# Left Robot
+- add_frame:
+    name: ur3_left_origin
+    X_PF:
+      base_frame: homecart_bimanual::left_arm_base_link
+      translation: [0, 0, 0]
+      rotation: !Rpy { deg: [0, 0, 270] }
+- add_model:
+    name: ur3_left
+    file: package://drake/manipulation/models/ur3e/ur3e_cylinders_collision.urdf
+- add_weld:
+    parent: ur3_left_origin
+    child: ur3_left::ur_base_link
+
+# Right Robot
+- add_frame:
+    name: ur3_right_origin
+    X_PF:
+      base_frame: homecart_bimanual::right_arm_base_link
+      translation: [0, 0, 0]
+      rotation: !Rpy { deg: [0, 0, 270] }
+- add_model:
+    name: ur3_right
+    file: package://drake/manipulation/models/ur3e/ur3e_cylinders_collision.urdf
+- add_weld:
+    parent: ur3_right_origin
+    child: ur3_right::ur_base_link
+
+# Cutting Board
+- add_frame:
+    name: homecart_cutting_board_origin
+    X_PF:
+      base_frame: homecart_bimanual::homecart_baseplate_link
+      translation: [0, 0, 0.0254]
+      rotation: !Rpy { deg: [0, 0, 0] }
+- add_model:
+    name: homecart_cutting_board
+    file: package://drake/manipulation/models/tri_homecart/homecart_cutting_board.sdf
+- add_weld:
+    parent: homecart_cutting_board_origin
+    child: homecart_cutting_board::homecart_cutting_board_link
+
+# Central cutting board frame
+- add_frame:
+    name: cutting_board_center
+    X_PF:
+      base_frame: homecart_cutting_board::homecart_cutting_board_link
+      translation: [0, 0, 0]
+      rotation: !Rpy { deg: [0, 0, 0] }
+
+# Scene camera frames
+- add_frame:
+    name: left_scene_camera
+    X_PF:
+      base_frame: homecart_on_world
+      translation: [0.5, 0.4, 0.97]
+      rotation: !Rpy { deg: [-145, 0, 180] }
+- add_frame:
+    name: right_scene_camera
+    X_PF:
+      base_frame: homecart_on_world
+      translation: [0.5, -0.4, 0.97]
+      rotation: !Rpy { deg: [-145, 0, 0] }
+- add_frame:
+    name: center_scene_camera
+    X_PF:
+      base_frame: homecart_on_world
+      translation: [-0.02, 0.0, 0.97]
+      rotation: !Rpy { deg: [-145, 0, -90] }
+
+# Helpful frames for areas of good manipulability
+- add_frame:
+    name: assembly_area
+    X_PF:
+      base_frame: homecart_on_world
+      translation: [0.35, 0.0, 0.0254]
+      rotation: !Rpy { deg: [0, 0, 0] }
+- add_frame:
+    name: left_pick_area
+    X_PF:
+      base_frame: homecart_on_world
+      translation: [0.35, 0.27, 0.0254]
+      rotation: !Rpy { deg: [0, 0, 0] }
+- add_frame:
+    name: right_pick_area
+    X_PF:
+      base_frame: homecart_on_world
+      translation: [0.35, -0.27, 0.0254]
+      rotation: !Rpy { deg: [0, 0, 0] }

--- a/manipulation/models/tri_homecart/test/parse_homecart_test.cc
+++ b/manipulation/models/tri_homecart/test/parse_homecart_test.cc
@@ -1,0 +1,32 @@
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/parsing/process_model_directives.h"
+#include "drake/multibody/plant/multibody_plant.h"
+
+namespace drake {
+namespace manipulation {
+namespace {
+
+GTEST_TEST(ParseHomecartTest, BasicTest) {
+  multibody::MultibodyPlant<double> plant(0.0);
+  geometry::SceneGraph<double> scene_graph;
+  plant.RegisterAsSourceForSceneGraph(&scene_graph);
+  multibody::Parser parser(&plant);
+  multibody::parsing::ModelDirectives directives =
+      multibody::parsing::LoadModelDirectives(FindResourceOrThrow(
+          "drake/manipulation/models/tri_homecart/homecart.yaml"));
+  multibody::parsing::ProcessModelDirectives(directives, &plant, nullptr,
+                                             &parser);
+  plant.Finalize();
+
+  // 6 positions per ur3e and 2 per wsg.
+  EXPECT_EQ(plant.num_positions(), 6 + 2 + 6 + 2);
+}
+
+}  // namespace
+}  // namespace manipulation
+}  // namespace drake

--- a/manipulation/models/ur3e/BUILD.bazel
+++ b/manipulation/models/ur3e/BUILD.bazel
@@ -1,0 +1,65 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_googletest",
+)
+load("//tools/install:install_data.bzl", "install_data")
+load("//tools/lint:lint.bzl", "add_lint_tests")
+load("@drake//tools/workspace/ros_xacro_internal:defs.bzl", "xacro_file")
+load("@drake//tools/workspace:forward_files.bzl", "forward_files")
+load("//tools/workspace/models_internal:files.bzl", "ur3e_mesh_files")
+
+# This package is public so that other packages can refer to
+# individual files in these models from their bazel rules.
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+# === test/ ===
+
+drake_cc_googletest(
+    name = "parse_test",
+    srcs = ["test/parse_test.cc"],
+    data = [
+        ":models",
+    ],
+    deps = [
+        "//common:find_resource",
+        "//multibody/parsing",
+    ],
+)
+
+xacro_file(
+    name = "ur3e_spheres_collision.urdf",
+    src = "ur3e_spheres_collision.urdf.xacro",
+    data = [
+        "ur.transmission.xacro",
+        "ur3e.urdf.xacro",
+    ],
+)
+
+xacro_file(
+    name = "ur3e_cylinders_collision.urdf",
+    src = "ur3e_cylinders_collision.urdf.xacro",
+    data = [
+        "ur.transmission.xacro",
+        "ur3e.urdf.xacro",
+    ],
+)
+
+_UR3E_MESHES = forward_files(
+    srcs = ["@models_internal//:" + x for x in ur3e_mesh_files()],
+    dest_prefix = "",
+    strip_prefix = "@models_internal//:ur3e/",
+    visibility = ["//visibility:private"],
+)
+
+install_data(
+    extra_prod_models = _UR3E_MESHES + [
+        "ur3e_spheres_collision.urdf",
+        "ur3e_cylinders_collision.urdf",
+    ],
+)
+
+add_lint_tests()

--- a/manipulation/models/ur3e/README.md
+++ b/manipulation/models/ur3e/README.md
@@ -1,0 +1,12 @@
+# ur3e model
+
+The UR3e models were originally imported from <https://github.com/ros-industrial/universal_robot/tree/melodic-devel/ur_description>,
+exact commit unknown but probably near
+<https://github.com/ros-industrial/universal_robot/commit/c8c27c15579fad1d817cc6cfac7a8e62a3da081d>.
+
+High-level changes:
+- Converted the mesh format from DAE to OBJ. 
+- Added two new sets of collision geometries (which can be selected via xacro):
+  - Cylinders + spheres 
+  - Spheres only (which works better w/ some collision checking frameworks)
+  

--- a/manipulation/models/ur3e/test/parse_test.cc
+++ b/manipulation/models/ur3e/test/parse_test.cc
@@ -1,0 +1,41 @@
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
+
+namespace drake {
+namespace manipulation {
+namespace {
+
+GTEST_TEST(ParseTest, SpheresCollision) {
+  multibody::MultibodyPlant<double> plant(0.0);
+  geometry::SceneGraph<double> scene_graph;
+  plant.RegisterAsSourceForSceneGraph(&scene_graph);
+  multibody::Parser parser(&plant);
+  parser.AddModelFromFile(FindResourceOrThrow(
+          "drake/manipulation/models/ur3e/ur3e_spheres_collision.urdf"));
+  plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("ur_base_link"));
+  plant.Finalize();
+
+  EXPECT_EQ(plant.num_positions(), 6);
+}
+
+GTEST_TEST(ParseTest, CylindersCollision) {
+  multibody::MultibodyPlant<double> plant(0.0);
+  geometry::SceneGraph<double> scene_graph;
+  plant.RegisterAsSourceForSceneGraph(&scene_graph);
+  multibody::Parser parser(&plant);
+  parser.AddModelFromFile(FindResourceOrThrow(
+          "drake/manipulation/models/ur3e/ur3e_cylinders_collision.urdf"));
+  plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("ur_base_link"));
+  plant.Finalize();
+
+  EXPECT_EQ(plant.num_positions(), 6);
+}
+
+}  // namespace
+}  // namespace manipulation
+}  // namespace drake

--- a/manipulation/models/ur3e/ur.transmission.xacro
+++ b/manipulation/models/ur3e/ur.transmission.xacro
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+
+  <xacro:macro name="ur_arm_transmission" params="prefix">
+
+    <transmission name="${prefix}shoulder_pan_trans">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}shoulder_pan_joint">
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}shoulder_pan_motor">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+
+    <transmission name="${prefix}shoulder_lift_trans">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}shoulder_lift_joint">
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}shoulder_lift_motor">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+
+    <transmission name="${prefix}elbow_trans">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}elbow_joint">
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}elbow_motor">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+
+    <transmission name="${prefix}wrist_1_trans">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}wrist_1_joint">
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}wrist_1_motor">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+
+    <transmission name="${prefix}wrist_2_trans">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}wrist_2_joint">
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}wrist_2_motor">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+
+    <transmission name="${prefix}wrist_3_trans">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}wrist_3_joint">
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}wrist_3_motor">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+
+  </xacro:macro>
+
+</robot>

--- a/manipulation/models/ur3e/ur3e.urdf.xacro
+++ b/manipulation/models/ur3e/ur3e.urdf.xacro
@@ -1,0 +1,688 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro" xmlns:drake="https://drake.mit.edu">
+
+<!--
+  Author: Felix Messmer
+
+  Per https://github.com/ros-industrial/universal_robot/blob/melodic-devel/ur_description/package.xml
+  the ur_description package from which these files are derived is BSD licensed.
+-->
+
+<!--
+  TODO(calderpg-tri, sammy-tri, ggould-tri) The acceleration limits in this
+  file are wrong. Try to find the right value.
+-->
+
+  <xacro:include filename="ur.transmission.xacro" />
+
+   <xacro:macro name="cylinder_inertial" params="radius length mass *origin">
+    <inertial>
+      <mass value="${mass}" />
+      <xacro:insert_block name="origin" />
+      <inertia ixx="${0.0833333 * mass * (3 * radius * radius + length * length)}" ixy="0.0" ixz="0.0"
+        iyy="${0.0833333 * mass * (3 * radius * radius + length * length)}" iyz="0.0"
+        izz="${0.5 * mass * radius * radius}" />
+    </inertial>
+  </xacro:macro>
+
+  <xacro:macro name="ur3e_robot" params="prefix joint_limited
+    shoulder_pan_lower_limit:=${-pi}    shoulder_pan_upper_limit:=${pi}
+    shoulder_lift_lower_limit:=${-pi}    shoulder_lift_upper_limit:=${pi}
+    elbow_joint_lower_limit:=${-pi}    elbow_joint_upper_limit:=${pi}
+    wrist_1_lower_limit:=${-pi}    wrist_1_upper_limit:=${pi}
+    wrist_2_lower_limit:=${-pi}    wrist_2_upper_limit:=${pi}
+    wrist_3_lower_limit:=${-pi}    wrist_3_upper_limit:=${pi}
+    transmission_hw_interface:=hardware_interface/PositionJointInterface
+    safety_limits:=false safety_pos_margin:=0.15
+    safety_k_position:=20
+    sphere_only_collision_shapes:=False">
+
+    <!-- Inertia parameters -->
+    <xacro:property name="base_mass" value="2.0" />  <!-- This mass might be incorrect -->
+    <xacro:property name="shoulder_mass" value="2.0" />
+    <xacro:property name="upper_arm_mass" value="3.42" />
+    <xacro:property name="forearm_mass" value="1.26" />
+    <xacro:property name="wrist_1_mass" value="0.8" />
+    <xacro:property name="wrist_2_mass" value="0.8" />
+    <xacro:property name="wrist_3_mass" value="0.35" />
+
+    <!-- These parameters are borrowed from the urcontrol.conf file
+        but are not verified for the correct permutation.
+        The permutation was guessed by looking at the ur5e parameters.
+        Serious use of these parameters needs further inspection. -->
+    <xacro:property name="shoulder_cog" value="0.0 -0.02 0.0" />
+    <xacro:property name="upper_arm_cog" value="0.13 0.0 0.1157" />
+    <xacro:property name="forearm_cog" value="0.05 0.0 0.0238" />
+    <xacro:property name="wrist_1_cog" value="0.0 0.0 0.01" />
+    <xacro:property name="wrist_2_cog" value="0.0 0.0 0.01" />
+    <xacro:property name="wrist_3_cog" value="0.0 0.0 -0.02" />
+
+    <!-- Kinematic model -->
+    <!-- Properties from urcontrol.conf -->
+    <xacro:property name="d1" value="0.152" />
+    <xacro:property name="a2" value="-0.244" />
+    <xacro:property name="a3" value="-0.213" />
+    <xacro:property name="d4" value="0.104" />
+    <xacro:property name="d5" value="0.085" />
+    <xacro:property name="d6" value="0.092" />
+
+    <!-- Arbitrary offsets for shoulder/elbow joints -->
+    <xacro:property name="shoulder_offset" value="0.120" />  <!-- measured from model -->
+    <xacro:property name="elbow_offset" value="-0.093" /> <!-- measured from model -->
+
+    <!-- link lengths used in model -->
+    <xacro:property name="shoulder_height" value="${d1}" />
+    <xacro:property name="upper_arm_length" value="${-a2}" />
+    <xacro:property name="forearm_length" value="${-a3}" />
+    <xacro:property name="wrist_1_length" value="${d4}" />
+    <xacro:property name="wrist_2_length" value="${d5}" />
+    <xacro:property name="wrist_3_length" value="${d6}" />
+
+    <link name="${prefix}base_link" >
+      <visual>
+        <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
+        <geometry>
+          <mesh filename="base.obj"/>
+        </geometry>
+        <material name="LightGrey">
+          <color rgba="0.7 0.7 0.7 1.0"/>
+        </material>
+      </visual>
+      <xacro:if value="${sphere_only_collision_shapes}">
+        <!-- Base joint -->
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
+          <geometry>
+            <sphere radius="0.065"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.0 0.02"/>
+          <geometry>
+            <sphere radius="0.065"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.0 0.07"/>
+          <geometry>
+            <sphere radius="0.055"/>
+          </geometry>
+        </collision>
+        <!-- Cable connector -->
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 -0.08 0.02"/>
+          <geometry>
+            <sphere radius="0.03"/>
+          </geometry>
+        </collision>
+      </xacro:if>
+      <xacro:unless value="${sphere_only_collision_shapes}">
+        <!-- Base joint -->
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.0 0.012"/>
+          <geometry>
+            <sphere radius="0.07"/>
+          </geometry>
+        </collision>
+        <!-- Cable connector -->
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 -0.08 0.02"/>
+          <geometry>
+            <sphere radius="0.03"/>
+          </geometry>
+        </collision>
+      </xacro:unless>
+      <xacro:cylinder_inertial radius="0.075" length="0.038" mass="${base_mass}">
+        <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
+      </xacro:cylinder_inertial>
+    </link>
+
+    <joint name="${prefix}shoulder_pan_joint" type="revolute">
+      <parent link="${prefix}base_link" />
+      <child link = "${prefix}shoulder_link" />
+      <origin xyz="0.0 0.0 ${shoulder_height}" rpy="0.0 0.0 0.0" />
+      <axis xyz="0 0 1" />
+      <xacro:unless value="${joint_limited}">
+        <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="330.0" velocity="3.14" drake:acceleration="2.5"/>
+        <xacro:if value="${safety_limits}">
+          <safety_controller soft_lower_limit="${-2.0 * pi + safety_pos_margin}" soft_upper_limit="${2.0 * pi - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
+        </xacro:if>
+      </xacro:unless>
+      <xacro:if value="${joint_limited}">
+        <limit lower="${shoulder_pan_lower_limit}" upper="${shoulder_pan_upper_limit}" effort="330.0" velocity="3.14" drake:acceleration="2.5"/>
+        <xacro:if value="${safety_limits}">
+          <safety_controller soft_lower_limit="${shoulder_pan_lower_limit + safety_pos_margin}" soft_upper_limit="${shoulder_pan_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
+        </xacro:if>
+      </xacro:if>
+      <dynamics damping="0.0" friction="0.0"/>
+    </joint>
+
+    <link name="${prefix}shoulder_link">
+      <visual>
+        <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
+        <geometry>
+          <mesh filename="shoulder.obj"/>
+        </geometry>
+        <material name="LightGrey">
+          <color rgba="0.7 0.7 0.7 1.0"/>
+        </material>
+      </visual>
+      <xacro:if value="${sphere_only_collision_shapes}">
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.01 0.00"/>
+          <geometry>
+            <sphere radius="0.07"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.06 0.00"/>
+          <geometry>
+            <sphere radius="0.0525"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.11 0.00"/>
+          <geometry>
+            <sphere radius="0.0525"/>
+          </geometry>
+        </collision>
+      </xacro:if>
+      <xacro:unless value="${sphere_only_collision_shapes}">
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.0 -0.02"/>
+          <geometry>
+            <cylinder radius="0.05" length="0.16"/>
+          </geometry>
+        </collision>
+      </xacro:unless>
+      <xacro:cylinder_inertial radius="0.075" length="0.178" mass="${shoulder_mass}">
+        <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
+      </xacro:cylinder_inertial>
+    </link>
+
+    <joint name="${prefix}shoulder_lift_joint" type="revolute">
+      <parent link="${prefix}shoulder_link" />
+      <child link = "${prefix}upper_arm_link" />
+      <origin xyz="0.0 ${shoulder_offset} 0.0" rpy="0.0 ${pi / 2.0} 0.0" />
+      <axis xyz="0 1 0" />
+      <xacro:unless value="${joint_limited}">
+        <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="330.0" velocity="3.14" drake:acceleration="2.5"/>
+        <xacro:if value="${safety_limits}">
+          <safety_controller soft_lower_limit="${-2.0 * pi + safety_pos_margin}" soft_upper_limit="${2.0 * pi - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
+        </xacro:if>
+      </xacro:unless>
+      <xacro:if value="${joint_limited}">
+        <limit lower="${shoulder_lift_lower_limit}" upper="${shoulder_lift_upper_limit}" effort="330.0" velocity="3.14" drake:acceleration="2.5"/>
+        <xacro:if value="${safety_limits}">
+          <safety_controller soft_lower_limit="${shoulder_lift_lower_limit + safety_pos_margin}" soft_upper_limit="${shoulder_lift_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
+        </xacro:if>
+      </xacro:if>
+      <dynamics damping="0.0" friction="0.0"/>
+    </joint>
+
+    <link name="${prefix}upper_arm_link">
+      <visual>
+        <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
+        <geometry>
+          <mesh filename="upperarm.obj"/>
+        </geometry>
+        <material name="LightGrey">
+          <color rgba="0.7 0.7 0.7 1.0"/>
+        </material>
+      </visual>
+      <xacro:if value="${sphere_only_collision_shapes}">
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.02 0.01"/>
+          <geometry>
+            <sphere radius="0.06"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.00 0.05"/>
+          <geometry>
+            <sphere radius="0.05"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.00 0.09"/>
+          <geometry>
+            <sphere radius="0.04"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.00 0.12"/>
+          <geometry>
+            <sphere radius="0.04"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.00 0.15"/>
+          <geometry>
+            <sphere radius="0.04"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.00 0.18"/>
+          <geometry>
+            <sphere radius="0.04"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.00 0.21"/>
+          <geometry>
+            <sphere radius="0.045"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.02 ${upper_arm_length - 0.005}"/>
+          <geometry>
+            <sphere radius="0.05"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 -0.02 ${upper_arm_length - 0.005}"/>
+          <geometry>
+            <sphere radius="0.05"/>
+          </geometry>
+        </collision>
+      </xacro:if>
+      <xacro:unless value="${sphere_only_collision_shapes}">
+        <collision>
+          <origin rpy="${pi/2.0} 0 0" xyz="0.0 -0.02 0.0"/>
+          <geometry>
+            <cylinder radius="0.05" length="0.16"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.0 0.045"/>
+          <geometry>
+            <cylinder radius="0.05" length="0.051"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.0 ${upper_arm_length/2.0 + 0.005}"/>
+          <geometry>
+            <cylinder radius="0.04" length="0.21"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="${pi/2.0} 0 0" xyz="0.0 0.005 ${upper_arm_length - 0.001}"/>
+          <geometry>
+            <cylinder radius="0.041" length="0.11"/>
+          </geometry>
+        </collision>
+      </xacro:unless>
+      <xacro:cylinder_inertial radius="0.075" length="${-a2}" mass="${upper_arm_mass}">
+        <origin xyz="0.0 0.0 ${-a2/2.0}" rpy="0 0 0" />
+      </xacro:cylinder_inertial>
+    </link>
+
+    <joint name="${prefix}elbow_joint" type="revolute">
+      <parent link="${prefix}upper_arm_link" />
+      <child link = "${prefix}forearm_link" />
+      <origin xyz="0.0 ${elbow_offset} ${upper_arm_length}" rpy="0.0 0.0 0.0" />
+      <axis xyz="0 1 0" />
+      <xacro:unless value="${joint_limited}">
+        <limit lower="${-pi}" upper="${pi}" effort="150.0" velocity="3.14" drake:acceleration="2.5"/>
+        <xacro:if value="${safety_limits}">
+          <safety_controller soft_lower_limit="${-2.0 * pi + safety_pos_margin}" soft_upper_limit="${2.0 * pi - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
+        </xacro:if>
+      </xacro:unless>
+      <xacro:if value="${joint_limited}">
+        <limit lower="${elbow_joint_lower_limit}" upper="${elbow_joint_upper_limit}" effort="150.0" velocity="3.14" drake:acceleration="2.5"/>
+        <xacro:if value="${safety_limits}">
+          <safety_controller soft_lower_limit="${elbow_joint_lower_limit + safety_pos_margin}" soft_upper_limit="${elbow_joint_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
+        </xacro:if>
+      </xacro:if>
+      <dynamics damping="0.0" friction="0.0"/>
+    </joint>
+
+    <link name="${prefix}forearm_link">
+      <visual>
+        <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
+        <geometry>
+          <mesh filename="forearm.obj"/>
+        </geometry>
+        <material name="LightGrey">
+          <color rgba="0.7 0.7 0.7 1.0"/>
+        </material>
+      </visual>
+      <xacro:if value="${sphere_only_collision_shapes}">
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.03 0.00"/>
+          <geometry>
+            <sphere radius="0.04"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.0 0.02"/>
+          <geometry>
+            <sphere radius="0.04"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.0 0.05"/>
+          <geometry>
+            <sphere radius="0.035"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.0 0.075"/>
+          <geometry>
+            <sphere radius="0.03"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.0 0.095"/>
+          <geometry>
+            <sphere radius="0.03"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.0 0.115"/>
+          <geometry>
+            <sphere radius="0.03"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.0 0.135"/>
+          <geometry>
+            <sphere radius="0.03"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.0 0.155"/>
+          <geometry>
+            <sphere radius="0.03"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.0 0.18"/>
+          <geometry>
+            <sphere radius="0.035"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 -0.02 0.2125"/>
+          <geometry>
+            <sphere radius="0.0375"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.00 0.2125"/>
+          <geometry>
+            <sphere radius="0.0375"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.02 0.2125"/>
+          <geometry>
+            <sphere radius="0.0375"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.03 0.2125"/>
+          <geometry>
+            <sphere radius="0.0375"/>
+          </geometry>
+        </collision>
+      </xacro:if>
+      <xacro:unless value="${sphere_only_collision_shapes}">
+        <collision>
+          <origin rpy="${pi/2.0} 0 0" xyz="0.0 0.02 0.005"/>
+          <geometry>
+            <sphere radius="0.05"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.0 ${forearm_length/2.0 + 0.005}"/>
+          <geometry>
+            <cylinder radius="0.034" length="0.185"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="${pi/2.0} 0 0" xyz="0.0 0.022 ${forearm_length}"/>
+          <geometry>
+            <cylinder radius="0.034" length="0.14"/>
+          </geometry>
+        </collision>
+      </xacro:unless>
+      <xacro:cylinder_inertial radius="0.075" length="${-a3}" mass="${forearm_mass}">
+        <origin xyz="0.0 0.0 ${-a3/2.0}" rpy="0 0 0" />
+      </xacro:cylinder_inertial>
+    </link>
+
+    <joint name="${prefix}wrist_1_joint" type="revolute">
+      <parent link="${prefix}forearm_link" />
+      <child link = "${prefix}wrist_1_link" />
+      <origin xyz="0.0 0.0 ${forearm_length}" rpy="0.0 ${pi / 2.0} 0.0" />
+      <axis xyz="0 1 0" />
+      <xacro:unless value="${joint_limited}">
+        <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="6.28" drake:acceleration="2.5"/>
+        <xacro:if value="${safety_limits}">
+          <safety_controller soft_lower_limit="${-2.0 * pi + safety_pos_margin}" soft_upper_limit="${2.0 * pi - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
+        </xacro:if>
+      </xacro:unless>
+      <xacro:if value="${joint_limited}">
+        <limit lower="${wrist_1_lower_limit}" upper="${wrist_1_upper_limit}" effort="54.0" velocity="6.28" drake:acceleration="2.5"/>
+        <xacro:if value="${safety_limits}">
+          <safety_controller soft_lower_limit="${wrist_1_lower_limit + safety_pos_margin}" soft_upper_limit="${wrist_1_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
+        </xacro:if>
+      </xacro:if>
+      <dynamics damping="0.0" friction="0.0"/>
+    </joint>
+
+    <link name="${prefix}wrist_1_link">
+      <visual>
+        <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
+        <geometry>
+          <mesh filename="wrist1.obj"/>
+        </geometry>
+        <material name="LightGrey">
+          <color rgba="0.7 0.7 0.7 1.0"/>
+        </material>
+      </visual>
+      <xacro:if value="${sphere_only_collision_shapes}">
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.05 0.0"/>
+          <geometry>
+            <sphere radius="0.0375"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.075 0.0"/>
+          <geometry>
+            <sphere radius="0.0375"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.1 0.0"/>
+          <geometry>
+            <sphere radius="0.0375"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.1 -0.025"/>
+          <geometry>
+            <sphere radius="0.0375"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.105 0.0275"/>
+          <geometry>
+            <sphere radius="0.0375"/>
+          </geometry>
+        </collision>
+      </xacro:if>
+      <xacro:unless value="${sphere_only_collision_shapes}">
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.105 0.012"/>
+          <geometry>
+            <cylinder radius="0.034" length="0.12"/>
+          </geometry>
+        </collision>
+      </xacro:unless>
+      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${wrist_1_mass}">
+        <origin xyz="0.0 ${wrist_1_length} 0.0" rpy="0 0 0" />
+      </xacro:cylinder_inertial>
+    </link>
+
+    <joint name="${prefix}wrist_2_joint" type="revolute">
+      <parent link="${prefix}wrist_1_link" />
+      <child link = "${prefix}wrist_2_link" />
+      <origin xyz="0.0 ${wrist_1_length} 0.0" rpy="0.0 0.0 0.0" />
+      <axis xyz="0 0 1" />
+      <xacro:unless value="${joint_limited}">
+        <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="6.28" drake:acceleration="2.5"/>
+        <xacro:if value="${safety_limits}">
+          <safety_controller soft_lower_limit="${-2.0 * pi + safety_pos_margin}" soft_upper_limit="${2.0 * pi - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
+        </xacro:if>
+      </xacro:unless>
+      <xacro:if value="${joint_limited}">
+        <limit lower="${wrist_2_lower_limit}" upper="${wrist_2_upper_limit}" effort="54.0" velocity="6.28" drake:acceleration="2.5"/>
+        <xacro:if value="${safety_limits}">
+          <safety_controller soft_lower_limit="${wrist_2_lower_limit + safety_pos_margin}" soft_upper_limit="${wrist_2_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
+        </xacro:if>
+      </xacro:if>
+      <dynamics damping="0.0" friction="0.0"/>
+    </joint>
+
+    <link name="${prefix}wrist_2_link">
+      <origin rpy="${pi / 2} 0 0" xyz="0.0 0.0 0.0"/>
+      <visual>
+        <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
+        <geometry>
+          <mesh filename="wrist2.obj"/>
+        </geometry>
+        <material name="LightGrey">
+          <color rgba="0.7 0.7 0.7 1.0"/>
+        </material>
+      </visual>
+      <xacro:if value="${sphere_only_collision_shapes}">
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.0 0.07"/>
+          <geometry>
+            <sphere radius="0.04"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 -0.02 0.085"/>
+          <geometry>
+            <sphere radius="0.0375"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.0 0.085"/>
+          <geometry>
+            <sphere radius="0.0375"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.02 0.085"/>
+          <geometry>
+            <sphere radius="0.0375"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.04 0.085"/>
+          <geometry>
+            <sphere radius="0.0375"/>
+          </geometry>
+        </collision>
+      </xacro:if>
+      <xacro:unless value="${sphere_only_collision_shapes}">
+        <collision>
+          <origin rpy="${pi/2} 0 0" xyz="0.0 -0.001 0.086"/>
+          <geometry>
+            <cylinder radius="0.034" length="0.092"/>
+          </geometry>
+        </collision>
+      </xacro:unless>
+      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${wrist_2_mass}">
+        <origin xyz="0.0 0.0 ${wrist_2_length}" rpy="0 0 0" />
+      </xacro:cylinder_inertial>
+    </link>
+
+    <joint name="${prefix}wrist_3_joint" type="revolute">
+      <parent link="${prefix}wrist_2_link" />
+      <child link = "${prefix}wrist_3_link" />
+      <origin xyz="0.0 0.0 ${wrist_2_length}" rpy="0.0 0.0 0.0" />
+      <axis xyz="0 1 0" />
+      <xacro:unless value="${joint_limited}">
+        <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="6.28" drake:acceleration="2.5"/>
+        <xacro:if value="${safety_limits}">
+          <safety_controller soft_lower_limit="${-2.0 * pi + safety_pos_margin}" soft_upper_limit="${2.0 * pi - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
+        </xacro:if>
+      </xacro:unless>
+      <xacro:if value="${joint_limited}">
+        <limit lower="${wrist_3_lower_limit}" upper="${wrist_3_upper_limit}" effort="54.0" velocity="6.28" drake:acceleration="2.5"/>
+        <xacro:if value="${safety_limits}">
+          <safety_controller soft_lower_limit="${wrist_3_lower_limit + safety_pos_margin}" soft_upper_limit="${wrist_3_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
+        </xacro:if>
+      </xacro:if>
+      <dynamics damping="0.0" friction="0.0"/>
+    </joint>
+
+    <link name="${prefix}wrist_3_link">
+      <visual>
+        <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
+        <geometry>
+          <mesh filename="wrist3.obj"/>
+        </geometry>
+        <material name="LightGrey">
+          <color rgba="0.7 0.7 0.7 1.0"/>
+        </material>
+      </visual>
+      <xacro:if value="${sphere_only_collision_shapes}">
+        <collision>
+          <origin rpy="0 0 0" xyz="0.0 0.07 0.0"/>
+          <geometry>
+            <sphere radius="0.02"/>
+          </geometry>
+        </collision>
+      </xacro:if>
+      <xacro:unless value="${sphere_only_collision_shapes}">
+        <collision>
+          <origin rpy="${pi/2} 0 0" xyz="0.0 0.07 0.0"/>
+          <geometry>
+            <cylinder radius="0.034" length="0.05"/>
+          </geometry>
+        </collision>
+      </xacro:unless>
+      <xacro:cylinder_inertial radius="0.032" length="0.042" mass="${wrist_3_mass}">
+        <origin xyz="0.0 ${wrist_3_length - 0.021} 0.0" rpy="${pi/2} 0 0" />
+      </xacro:cylinder_inertial>
+    </link>
+
+    <joint name="${prefix}ee_fixed_joint" type="fixed">
+      <parent link="${prefix}wrist_3_link" />
+      <child link = "${prefix}ee_link" />
+      <origin xyz="0.0 ${wrist_3_length} 0.0" rpy="0.0 0.0 ${pi/2.0}" />
+    </joint>
+
+    <link name="${prefix}ee_link"/>
+
+    <xacro:ur_arm_transmission prefix="${prefix}" />
+
+    <!-- ROS base_link to UR 'Base' Coordinates transform -->
+    <link name="${prefix}base"/>
+    <joint name="${prefix}base_link-base_fixed_joint" type="fixed">
+      <!-- NOTE: this rotation is only needed as long as base_link itself is
+                 not corrected wrt the real robot (ie: rotated over 180
+                 degrees)
+      -->
+      <origin xyz="0 0 0" rpy="0 0 ${-pi}"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+
+    <!-- Frame coincident with all-zeros TCP on UR controller -->
+    <link name="${prefix}tool0"/>
+    <joint name="${prefix}wrist_3_link-tool0_fixed_joint" type="fixed">
+      <origin xyz="0 ${wrist_3_length} 0" rpy="${pi/-2.0} 0 0"/>
+      <parent link="${prefix}wrist_3_link"/>
+      <child link="${prefix}tool0"/>
+    </joint>
+
+  </xacro:macro>
+</robot>

--- a/manipulation/models/ur3e/ur3e_cylinders_collision.urdf.xacro
+++ b/manipulation/models/ur3e/ur3e_cylinders_collision.urdf.xacro
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro"
+       name="ur3e" >
+
+  <!--
+  Per https://github.com/ros-industrial/universal_robot/blob/melodic-devel/ur_description/package.xml
+  the ur_description package from which these files are derived is BSD licensed.
+-->
+
+  <!-- ur3e -->
+  <xacro:include filename="ur3e.urdf.xacro" />
+
+  <!-- arm -->
+  <!-- Do not limit all collision shapes to be spheres -->
+  <!-- We limit joint limits to [-pi, pi] rather than the full range [-2pi, 2pi]
+       since the larger limits cause problems with planning. -->
+  <xacro:ur3e_robot prefix="ur_" joint_limited="true"
+  sphere_only_collision_shapes="false" />
+</robot>

--- a/manipulation/models/ur3e/ur3e_spheres_collision.urdf.xacro
+++ b/manipulation/models/ur3e/ur3e_spheres_collision.urdf.xacro
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro"
+       name="ur3e" >
+
+  <!--
+  Per https://github.com/ros-industrial/universal_robot/blob/melodic-devel/ur_description/package.xml
+  the ur_description package from which these files are derived is BSD licensed.
+-->
+
+  <!-- ur3e -->
+  <xacro:include filename="ur3e.urdf.xacro" />
+
+  <!-- arm -->
+  <!-- Limit all collision shapes to be spheres -->
+  <!-- We limit joint limits to [-pi, pi] rather than the full range [-2pi, 2pi]
+       since the larger limits cause problems with planning. -->
+  <xacro:ur3e_robot prefix="ur_" joint_limited="true"
+  sphere_only_collision_shapes="true" />
+</robot>

--- a/tools/wheel/image/build-wheel.sh
+++ b/tools/wheel/image/build-wheel.sh
@@ -98,6 +98,11 @@ fi
 # wheel.
 rm -rf \
     ${WHEEL_DATA_DIR}/manipulation/models/franka_description/meshes \
+    ${WHEEL_DATA_DIR}/manipulation/models/tri-homecart/*.obj \
+    ${WHEEL_DATA_DIR}/manipulation/models/tri-homecart/*.png \
+    ${WHEEL_DATA_DIR}/manipulation/models/ur3e/*.obj \
+    ${WHEEL_DATA_DIR}/manipulation/models/ur3e/*.png \
+    ${WHEEL_DATA_DIR}/manipulation/models/ycb/meshes \
     ${WHEEL_DATA_DIR}/manipulation/models/ycb/meshes \
     ${WHEEL_DATA_DIR}/examples/atlas \
     ${WHEEL_DATA_DIR}/examples/hydroelastic/spatula_slip_control

--- a/tools/workspace/models_internal/files.bzl
+++ b/tools/workspace/models_internal/files.bzl
@@ -63,6 +63,47 @@ def skydio_2_mesh_files():
         "skydio_2/LICENSE",
     ]
 
+def tri_homecart_mesh_files():
+    return [
+        "tri_homecart/LICENSE.txt",
+        "tri_homecart/homecart_arm_mount_cantilever.mtl",
+        "tri_homecart/homecart_arm_mount_cantilever.obj",
+        "tri_homecart/homecart_arm_mount_stack.mtl",
+        "tri_homecart/homecart_arm_mount_stack.obj",
+        "tri_homecart/homecart_basecart.mtl",
+        "tri_homecart/homecart_basecart.obj",
+        "tri_homecart/homecart_basecart_wood_color.png",
+        "tri_homecart/homecart_baseplate.mtl",
+        "tri_homecart/homecart_baseplate.obj",
+        "tri_homecart/homecart_bimanual_upper_structure.mtl",
+        "tri_homecart/homecart_bimanual_upper_structure.obj",
+        "tri_homecart/homecart_cutting_board.mtl",
+        "tri_homecart/homecart_cutting_board.obj",
+        "tri_homecart/homecart_cutting_board_color.png",
+    ]
+
+def ur3e_mesh_files():
+    return [
+        "ur3e/LICENSE.TXT",
+        "ur3e/base.mtl",
+        "ur3e/base.obj",
+        "ur3e/forearm.mtl",
+        "ur3e/forearm.obj",
+        "ur3e/shoulder.mtl",
+        "ur3e/shoulder.obj",
+        "ur3e/upperarm.mtl",
+        "ur3e/upperarm.obj",
+        "ur3e/ur3e_color.png",
+        "ur3e/ur3e_normal.png",
+        "ur3e/ur3e_occlusion_roughness_metallic.png",
+        "ur3e/wrist1.mtl",
+        "ur3e/wrist1.obj",
+        "ur3e/wrist2.mtl",
+        "ur3e/wrist2.obj",
+        "ur3e/wrist3.mtl",
+        "ur3e/wrist3.obj",
+    ]
+
 def wsg_50_description_mesh_files():
     return [
         "wsg_50_description/meshes/finger_without_tip.obj",

--- a/tools/workspace/models_internal/package.BUILD.bazel
+++ b/tools/workspace/models_internal/package.BUILD.bazel
@@ -9,6 +9,8 @@ exports_files(
         "franka_description/**",
         "jaco_description/**",
         "skydio_2/**",
+        "tri_homecart/**",
+        "ur3e/**",
         "wsg_50_description/**",
         "wsg_50_hydro_bubble/**",
         "ycb/meshes/**",

--- a/tools/workspace/models_internal/repository.bzl
+++ b/tools/workspace/models_internal/repository.bzl
@@ -8,8 +8,8 @@ def models_internal_repository(
     github_archive(
         name = name,
         repository = "RobotLocomotion/models",
-        commit = "fbc442f5bb609ecd8c32d8ab6e033b998a929692",
-        sha256 = "104662b08af4e2681cefa309de5c47c25a6b82531a1cda5f8e554c7b8c296831",  # noqa
+        commit = "e6bb254c786ef4d67aea7e88d141b3bb2618e964",
+        sha256 = "e246342c6d4e895dbc9d4d7206889114e6a6c99857987708f01066d839978beb",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
This PR only contains a test that verifies that the model can be
parsed correctly (through model directives, etc). But in a follow-up
PR I will use this as a Drake example of bimanual motion planning with
Graph of Convex Sets.

These models were derived from the Anzu versions; with a few changes:
- Anzu has "left/right" variants of the ur3e models, which set tighter
joint limits for the homecart configuration.  I felt that it was a
little inelegant to put those in the ur3e directory (they should be
homecart specific).  We can add them later if need be.

- I've used the simple wsg gripper models that were already in Drake
instead of the fancier models in anzu.

- I've named the directory `tri_homecart` instead of `homecart`.  

+@rcory for feature review, please.
fyi @ToffeeAlbina-TRI , @BenBurchfiel-TRI

<img width="490" alt="image" src="https://user-images.githubusercontent.com/6442292/173234863-aba80481-8b31-40f3-98ae-350ae612b2f3.png">


This image confirms that the grasp frames are correct
<img width="808" alt="image" src="https://user-images.githubusercontent.com/6442292/173234827-9fa1d57f-4453-4105-aabe-0f43bc4ea94c.png">


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17387)
<!-- Reviewable:end -->
