### PR TITLE
[geometry] Improve KinematicsVector

### DIFF
--- a/bindings/pydrake/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry_py_scene_graph.cc
@@ -346,7 +346,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
             doc.KinematicsVector.value.doc)
         .def("has_id", &FramePoseVector<T>::has_id, py::arg("id"),
             doc.KinematicsVector.has_id.doc)
-        .def("ids", &FramePoseVector<T>::ids, doc.KinematicsVector.ids.doc);
+        .def("GetAllIds", &FramePoseVector<T>::GetAllIds,
+            doc.KinematicsVector.GetAllIds.doc);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     cls.def("frame_ids",

--- a/bindings/pydrake/test/geometry_scene_graph_test.py
+++ b/bindings/pydrake/test/geometry_scene_graph_test.py
@@ -370,8 +370,8 @@ class TestGeometrySceneGraph(unittest.TestCase):
         with catch_drake_warnings(expected_count=2):
             self.assertIsInstance(obj.frame_ids(), list)
             self.assertIsInstance(obj.frame_ids()[0], mut.FrameId)
-        self.assertIsInstance(obj.ids(), list)
-        self.assertIsInstance(obj.ids()[0], mut.FrameId)
+        self.assertIsInstance(obj.GetAllIds(), list)
+        self.assertIsInstance(obj.GetAllIds()[0], mut.FrameId)
         obj.clear()
         self.assertEqual(obj.size(), 0)
 

--- a/examples/pendulum/test/pendulum_geometry_test.cc
+++ b/examples/pendulum/test/pendulum_geometry_test.cc
@@ -23,7 +23,7 @@ using math::RigidTransformd;
 math::RigidTransformd ExtractSinglePose(
     const geometry::FramePoseVector<double>& pose_vector) {
   DRAKE_THROW_UNLESS(pose_vector.size() == 1);
-  for (const auto& id : pose_vector.ids()) {
+  for (const geometry::FrameId& id : pose_vector.GetAllIds()) {
     return pose_vector.value(id);
   }
   DRAKE_UNREACHABLE();

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -157,13 +157,16 @@ drake_cc_library(
     hdrs = [
         "kinematics_vector.h",
     ],
-    deps = [
+    interface_deps = [
         ":geometry_ids",
         "//common:autodiff",
         "//common:essential",
         "//common:nice_type_name",
         "//common:symbolic",
         "//math:geometric_transform",
+    ],
+    deps = [
+        "@abseil_cpp_internal//absl/container:flat_hash_map",
     ],
 )
 

--- a/geometry/kinematics_vector.cc
+++ b/geometry/kinematics_vector.cc
@@ -1,41 +1,129 @@
 #include "drake/geometry/kinematics_vector.h"
 
-#include <stdexcept>
+#include <algorithm>
 
-#include <fmt/format.h>
+#include "absl/container/flat_hash_map.h"
 
 #include "drake/common/autodiff.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/symbolic.h"
+#include "drake/math/rigid_transform.h"
 
 namespace drake {
 namespace geometry {
 
+template <class Id, class KinematicsValue>
+class __attribute__((visibility("hidden")))
+KinematicsVector<Id, KinematicsValue>::Impl {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Impl);
+
+  Impl() = default;
+  ~Impl() = default;
+
+  void clear() {
+    /* We don't use map_.clear() to ensure the memory isn't released. */
+    map_.erase(map_.begin(), map_.end());
+  }
+
+  void set_value(Id id, const KinematicsValue& value) {
+    map_.insert_or_assign(id, value);
+  }
+
+  int size() const { return map_.size(); }
+
+  const KinematicsValue& value(const Id& id) const {
+    const auto& it = map_.find(id);
+    if (it != map_.end()) return it->second;
+
+    throw std::runtime_error(
+        fmt::format("No such {}: {}.",
+                    NiceTypeName::RemoveNamespaces(NiceTypeName::Get<Id>()),
+                    to_string(id)));
+  }
+
+  bool has_id(const Id& id) const { return map_.contains(id); }
+
+  std::vector<Id> GetAllIds() const {
+    std::vector<Id> results(map_.size());
+    int index = 0;
+    for (const auto& it : map_) {
+      results[index++] = it.first;
+    }
+    // Sort the results to ensure it's deterministic.
+    std::sort(results.begin(), results.end());
+    return results;
+  }
+
+ private:
+  absl::flat_hash_map<Id, KinematicsValue> map_;
+};
+
 template <typename Id, typename KinematicsValue>
-KinematicsVector<Id, KinematicsValue>::KinematicsVector() {
-  DRAKE_ASSERT_VOID(CheckInvariants());
+typename KinematicsVector<Id, KinematicsValue>::Impl&
+KinematicsVector<Id, KinematicsValue>::impl() {
+  DRAKE_ASSERT(pimpl_ != nullptr);
+  return *static_cast<Impl*>(pimpl_.get());
 }
 
 template <typename Id, typename KinematicsValue>
+const typename KinematicsVector<Id, KinematicsValue>::Impl&
+KinematicsVector<Id, KinematicsValue>::impl() const {
+  DRAKE_ASSERT(pimpl_ != nullptr);
+  return *static_cast<Impl*>(pimpl_.get());
+}
+
+template <typename Id, typename KinematicsValue>
+KinematicsVector<Id, KinematicsValue>::KinematicsVector()
+    : pimpl_(std::make_shared<Impl>()) {}
+
+template <typename Id, typename KinematicsValue>
 KinematicsVector<Id, KinematicsValue>::KinematicsVector(
-    std::initializer_list<std::pair<const Id, KinematicsValue>> init) {
-  values_.insert(init.begin(), init.end());
-  size_ = init.size();
-  DRAKE_ASSERT_VOID(CheckInvariants());
+    std::initializer_list<std::pair<const Id, KinematicsValue>> init)
+    : KinematicsVector() {
+  for (const auto& item : init) {
+    set_value(item.first, item.second);
+  }
 }
 
 template <typename Id, typename KinematicsValue>
 KinematicsVector<Id, KinematicsValue>&
 KinematicsVector<Id, KinematicsValue>::operator=(
     std::initializer_list<std::pair<const Id, KinematicsValue>> init) {
-  // N.B. We can't use unordered_map::insert in our operator= implementation
-  // because it does not overwrite pre-existing keys.  (Our clear() doesn't
-  // remove the keys, it only nulls the values.)
   clear();
   for (const auto& item : init) {
     set_value(item.first, item.second);
   }
-  DRAKE_ASSERT_VOID(CheckInvariants());
+  return *this;
+}
+
+template <typename Id, typename KinematicsValue>
+KinematicsVector<Id, KinematicsValue>::KinematicsVector(
+    const KinematicsVector<Id, KinematicsValue>& other)
+    : KinematicsVector() {
+  *this = other;
+}
+
+template <typename Id, typename KinematicsValue>
+KinematicsVector<Id, KinematicsValue>::KinematicsVector(
+    KinematicsVector<Id, KinematicsValue>&& other)
+    : KinematicsVector() {
+  *this = std::move(other);
+}
+
+template <typename Id, typename KinematicsValue>
+KinematicsVector<Id, KinematicsValue>&
+KinematicsVector<Id, KinematicsValue>::operator=(
+    const KinematicsVector<Id, KinematicsValue>& other) {
+  pimpl_ = std::make_shared<Impl>(other.impl());
+  return *this;
+}
+
+template <typename Id, typename KinematicsValue>
+KinematicsVector<Id, KinematicsValue>&
+KinematicsVector<Id, KinematicsValue>::operator=(
+    KinematicsVector<Id, KinematicsValue>&& other) {
+  std::swap(pimpl_, other.pimpl_);
   return *this;
 }
 
@@ -44,71 +132,39 @@ KinematicsVector<Id, KinematicsValue>::~KinematicsVector() = default;
 
 template <typename Id, typename KinematicsValue>
 void KinematicsVector<Id, KinematicsValue>::clear() {
-  for (auto& item : values_) {
-    item.second = std::nullopt;
-  }
-  size_ = 0;
+  impl().clear();
 }
 
 template <typename Id, typename KinematicsValue>
 void KinematicsVector<Id, KinematicsValue>::set_value(
     Id id, const KinematicsValue& value) {
-  auto& map_value = values_[id];
-  if (!map_value.has_value()) {
-    ++size_;
-  }
-  map_value = value;
+  impl().set_value(id, value);
+}
+
+template <typename Id, typename KinematicsValue>
+int KinematicsVector<Id, KinematicsValue>::size() const {
+  return impl().size();
 }
 
 template <typename Id, typename KinematicsValue>
 const KinematicsValue& KinematicsVector<Id, KinematicsValue>::value(
     Id id) const {
-  using std::to_string;
-  auto iter = values_.find(id);
-  if (iter != values_.end()) {
-    const std::optional<KinematicsValue>& map_value = iter->second;
-    if (map_value.has_value()) {
-      return *map_value;
-    }
-  }
-  throw std::runtime_error(fmt::format(
-      "No such {}: {}.",
-      NiceTypeName::RemoveNamespaces(NiceTypeName::Get<Id>()), to_string(id)));
+  return impl().value(id);
 }
 
 template <typename Id, typename KinematicsValue>
 bool KinematicsVector<Id, KinematicsValue>::has_id(Id id) const {
-  auto iter = values_.find(id);
-  return (iter != values_.end()) && iter->second.has_value();
+  return impl().has_id(id);
 }
 
 template <typename Id, typename KinematicsValue>
 std::vector<Id> KinematicsVector<Id, KinematicsValue>::frame_ids() const {
-  return ids();
+  return GetAllIds();
 }
 
 template <typename Id, typename KinematicsValue>
-std::vector<Id> KinematicsVector<Id, KinematicsValue>::ids() const {
-  std::vector<Id> result;
-  result.reserve(size_);
-  for (const auto& item : values_) {
-    if (item.second.has_value()) {
-      result.emplace_back(item.first);
-    }
-  }
-  DRAKE_ASSERT(static_cast<int>(result.size()) == size_);
-  return result;
-}
-
-template <typename Id, typename KinematicsValue>
-void KinematicsVector<Id, KinematicsValue>::CheckInvariants() const {
-  int num_nonnull = 0;
-  for (const auto& item : values_) {
-    if (item.second.has_value()) {
-      ++num_nonnull;
-    }
-  }
-  DRAKE_DEMAND(num_nonnull == size_);
+std::vector<Id> KinematicsVector<Id, KinematicsValue>::GetAllIds() const {
+  return impl().GetAllIds();
 }
 
 // Explicitly instantiates on the most common scalar types.

--- a/geometry/test/kinematics_vector_test.cc
+++ b/geometry/test/kinematics_vector_test.cc
@@ -214,9 +214,9 @@ GTEST_TEST(KinematicsVector, FrameIdRange) {
   }
 
   std::set<FrameId> actual_ids;
-  for (FrameId id : poses.ids()) actual_ids.insert(id);
+  for (const FrameId& id : poses.GetAllIds()) actual_ids.insert(id);
   EXPECT_EQ(ids.size(), actual_ids.size());
-  for (FrameId id : ids) EXPECT_EQ(actual_ids.count(id), 1);
+  for (const FrameId& id : ids) EXPECT_EQ(actual_ids.count(id), 1);
 }
 
 #pragma GCC diagnostic push
@@ -224,7 +224,7 @@ GTEST_TEST(KinematicsVector, FrameIdRange) {
 GTEST_TEST(KinematicsVector, DeprecatedFrameIds) {
   FramePoseVector<double> poses;
   poses.set_value(FrameId::get_new_id(), RigidTransformd::Identity());
-  EXPECT_EQ(poses.frame_ids(), poses.ids());
+  EXPECT_EQ(poses.frame_ids(), poses.GetAllIds());
 }
 #pragma GCC diagnostic pop
 

--- a/systems/rendering/test/multibody_position_to_geometry_pose_test.cc
+++ b/systems/rendering/test/multibody_position_to_geometry_pose_test.cc
@@ -151,7 +151,7 @@ GTEST_TEST(MultibodyPositionToGeometryPoseTest, FullStateInput) {
           *state_context);
 
   EXPECT_EQ(position_output.size(), state_output.size());
-  for (const auto& id : position_output.ids()) {
+  for (const geometry::FrameId& id : position_output.GetAllIds()) {
     EXPECT_TRUE(
         position_output.value(id).IsExactlyEqualTo(state_output.value(id)));
   }

--- a/tools/workspace/abseil_cpp_internal/patches/disable_int128_on_clang.patch
+++ b/tools/workspace/abseil_cpp_internal/patches/disable_int128_on_clang.patch
@@ -1,0 +1,15 @@
+Disable __int128 in Clang which triggers linker error under UBSan.
+See https://bugs.llvm.org/show_bug.cgi?id=16404
+
+--- absl/base/config.h
++++ absl/base/config.h
+@@ -317,8 +317,7 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
+ #ifdef ABSL_HAVE_INTRINSIC_INT128
+ #error ABSL_HAVE_INTRINSIC_INT128 cannot be directly set
+ #elif defined(__SIZEOF_INT128__)
+-#if (defined(__clang__) && !defined(_WIN32)) || \
+-    (defined(__CUDACC__) && __CUDACC_VER_MAJOR__ >= 9) ||                \
++#if (defined(__CUDACC__) && __CUDACC_VER_MAJOR__ >= 9) ||                \
+     (defined(__GNUC__) && !defined(__clang__) && !defined(__CUDACC__))
+ #define ABSL_HAVE_INTRINSIC_INT128 1
+ #elif defined(__CUDACC__)

--- a/tools/workspace/abseil_cpp_internal/patches/fix_constexpr_storage_deprecation.patch
+++ b/tools/workspace/abseil_cpp_internal/patches/fix_constexpr_storage_deprecation.patch
@@ -1,0 +1,33 @@
+Remove redundant declarations to suppress deprecation warnings
+See upstream issue: https://github.com/abseil/abseil-cpp/issues/1191
+
+--- absl/container/fixed_array.h
++++ absl/container/fixed_array.h
+@@ -489,12 +489,14 @@ class FixedArray {
+   Storage storage_;
+ };
+ 
++#if  __cplusplus < 201703L
+ template <typename T, size_t N, typename A>
+ constexpr size_t FixedArray<T, N, A>::kInlineBytesDefault;
+ 
+ template <typename T, size_t N, typename A>
+ constexpr typename FixedArray<T, N, A>::size_type
+     FixedArray<T, N, A>::inline_elements;
++#endif
+ 
+ template <typename T, size_t N, typename A>
+ void FixedArray<T, N, A>::NonEmptyInlinedStorage::AnnotateConstruct(
+--- absl/strings/internal/string_constant.h
++++ absl/strings/internal/string_constant.h
+@@ -50,8 +50,10 @@ struct StringConstant {
+                 "The input string_view must point to constant data.");
+ };
+ 
++#if  __cplusplus < 201703L
+ template <typename T>
+ constexpr absl::string_view StringConstant<T>::value;  // NOLINT
++#endif
+ 
+ // Factory function for `StringConstant` instances.
+ // It supports callables that have a constexpr default constructor and a

--- a/tools/workspace/abseil_cpp_internal/repository.bzl
+++ b/tools/workspace/abseil_cpp_internal/repository.bzl
@@ -10,6 +10,8 @@ def abseil_cpp_internal_repository(
         commit = "ef799d337201e02688c6e07b0cac8912b86f505d",
         sha256 = "9f841741770fd773c8109f23fed60ec1e758ce12a52fbb298eeaf891b1dbb1cd",  # noqa
         patches = [
+            "@drake//tools/workspace/abseil_cpp_internal:patches/disable_int128_on_clang.patch",  # noqa
+            "@drake//tools/workspace/abseil_cpp_internal:patches/fix_constexpr_storage_deprecation.patch",  # noqa
             "@drake//tools/workspace/abseil_cpp_internal:patches/hidden_visibility.patch",  # noqa
             "@drake//tools/workspace/abseil_cpp_internal:patches/inline_namespace.patch",  # noqa
         ],


### PR DESCRIPTION
Change the implementation of KinematicsVector to use a absl::flat_hash_map.
    
Rename KinematicsVector::ids() to KinematicsVector::GetAllIds() without
deprecation (since ids() was introduced in between releases).

The original PR was reverted due to post-merge CI failures. This reverts the reverting
PR and fixes the UBSan failures.
    
Co-authored-by: Jeremy Nimmer <jeremy.nimmer@tri.global>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17394)
<!-- Reviewable:end -->
