### PR TITLE
[geometry/optimization] Change GCS SolveShortestPath to take configuration options

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -147,6 +147,7 @@ drake_pybind_library(
     py_deps = [
         ":math_py",
         ":module_py",
+        "//bindings/pydrake/solvers",
         "//bindings/pydrake/systems:framework_py",
         "//bindings/pydrake/systems:lcm_py",
     ],

--- a/bindings/pydrake/test/geometry_optimization_test.py
+++ b/bindings/pydrake/test/geometry_optimization_test.py
@@ -418,26 +418,42 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertEqual(len(spp.Vertices()), 2)
         self.assertEqual(len(spp.Edges()), 2)
         result = spp.SolveShortestPath(
-            source_id=source.id(), target_id=target.id(),
-            convex_relaxation=True)
+            source_id=source.id(), target_id=target.id())
         self.assertIsInstance(result, MathematicalProgramResult)
+        self.assertIsInstance(
+            spp.SolveShortestPath(source=source, target=target),
+            MathematicalProgramResult)
+        options = mut.GraphOfConvexSetsOptions()
+        options.solver = ClpSolver()
         self.assertIsInstance(spp.SolveShortestPath(
-            source_id=source.id(), target_id=target.id(),
-            convex_relaxation=True, solver=ClpSolver()),
+            source_id=source.id(), target_id=target.id(), options=options),
             MathematicalProgramResult)
         self.assertIsInstance(spp.SolveShortestPath(
-            source_id=source.id(), target_id=target.id(),
-            convex_relaxation=True, solver_options=SolverOptions()),
+            source=source, target=target, options=options),
             MathematicalProgramResult)
-        self.assertIsInstance(spp.SolveShortestPath(
-            source=source, target=target, convex_relaxation=True),
-            MathematicalProgramResult)
-        self.assertIsInstance(spp.SolveShortestPath(
-            source=source, target=target, convex_relaxation=True,
-            solver=ClpSolver()), MathematicalProgramResult)
-        self.assertIsInstance(spp.SolveShortestPath(
-            source=source, target=target, convex_relaxation=True,
-            solver_options=SolverOptions()), MathematicalProgramResult)
+
+        with catch_drake_warnings(expected_count=6):
+            self.assertIsInstance(spp.SolveShortestPath(
+                source_id=source.id(), target_id=target.id(),
+                convex_relaxation=True), MathematicalProgramResult)
+            self.assertIsInstance(spp.SolveShortestPath(
+                source_id=source.id(), target_id=target.id(),
+                convex_relaxation=True, solver=ClpSolver()),
+                MathematicalProgramResult)
+            self.assertIsInstance(spp.SolveShortestPath(
+                source_id=source.id(), target_id=target.id(),
+                convex_relaxation=True, solver_options=SolverOptions()),
+                MathematicalProgramResult)
+            self.assertIsInstance(spp.SolveShortestPath(
+                source=source, target=target, convex_relaxation=True),
+                MathematicalProgramResult)
+            self.assertIsInstance(spp.SolveShortestPath(
+                source=source, target=target, convex_relaxation=True,
+                solver=ClpSolver()), MathematicalProgramResult)
+            self.assertIsInstance(spp.SolveShortestPath(
+                source=source, target=target, convex_relaxation=True,
+                solver_options=SolverOptions()), MathematicalProgramResult)
+
         self.assertIn("source", spp.GetGraphvizString(
             result=result, show_slacks=True, precision=2, scientific=False))
 

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/symbolic/expression.h"
 #include "drake/geometry/optimization/convex_set.h"
@@ -20,6 +21,25 @@
 namespace drake {
 namespace geometry {
 namespace optimization {
+
+struct GraphOfConvexSetsOptions {
+  GraphOfConvexSetsOptions() = default;
+
+  /** Flag to solve the relaxed version of the problem.  As discussed in the
+  paper, we know that this relaxation cannot solve the original NP-hard problem
+  for all instances, but there are also many instances for which the convex
+  relaxation is tight. */
+  bool convex_relaxation{true};
+
+  /** Optimizer to be used to solve the shortest path optimization problem. If
+  not set, the best solver for the given problem is selected. Note that if the
+  solver cannot handle the type of optimization problem generated, the calling
+  solve method will throw. */
+  const solvers::SolverInterface* solver{nullptr};
+
+  /** Options passed to the solver when solving the generated problem.*/
+  solvers::SolverOptions solver_options;
+};
 
 /**
 GraphOfConvexSets implements the design pattern and optimization problems first
@@ -352,6 +372,40 @@ class GraphOfConvexSets {
   set to the graph and using that as the source.
   @param target specifies the target set.  The solver will choose any point in
   that set.
+  @param options include all settings for solving the shortest path problem. See
+  `GraphOfConvexSetsOptions` for further details.
+
+  @throws std::exception if any of the costs or constraints in the graph are
+  incompatible with the shortest path formulation or otherwise unsupported.
+  All costs must be non-negative for all values of the continuous variables.
+
+  @pydrake_mkdoc_identifier{by_id}
+  */
+  solvers::MathematicalProgramResult SolveShortestPath(
+      VertexId source_id, VertexId target_id,
+      const GraphOfConvexSetsOptions& options =
+          GraphOfConvexSetsOptions()) const;
+
+  /** Convenience overload that takes const reference arguments for source and
+  target.
+  @pydrake_mkdoc_identifier{by_reference}
+  */
+  solvers::MathematicalProgramResult SolveShortestPath(
+      const Vertex& source, const Vertex& target,
+      const GraphOfConvexSetsOptions& options =
+          GraphOfConvexSetsOptions()) const;
+
+  /** Formulates and solves the mixed-integer convex formulation of the
+  shortest path problem on the graph, as discussed in detail in
+
+  "Shortest Paths in Graphs of Convex Sets" by Tobia Marcucci, Jack
+  Umenberger, Pablo A. Parrilo, Russ Tedrake. https://arxiv.org/abs/2101.11565
+
+  @param source specifies the source set.  The solver will choose any point in
+  that set; to start at a particular continuous state consider adding a Point
+  set to the graph and using that as the source.
+  @param target specifies the target set.  The solver will choose any point in
+  that set.
   @param convex_relaxation will solve the relaxed version of the problem.  As
   discussed in the paper, we know that this relaxation cannot solve the original
   NP-hard problem for all instances, but there are also many instances for which
@@ -365,23 +419,24 @@ class GraphOfConvexSets {
 
   @throws std::exception if any of the costs or constraints in the graph are
   incompatible with the shortest path formulation or otherwise unsupported.
-  All costs must be non-negative (for all values of the continuous variables).
+  All costs must be non-negative for all values of the continuous variables.
 
-  @pydrake_mkdoc_identifier{by_id}
+  @pydrake_mkdoc_identifier{deprecated_by_id}
   */
+  DRAKE_DEPRECATED("2022-12-01", "Use version with GraphOfConvexSetsOptions")
   solvers::MathematicalProgramResult SolveShortestPath(
-      VertexId source_id, VertexId target_id, bool convex_relaxation = false,
+      VertexId source_id, VertexId target_id, bool convex_relaxation,
       const solvers::SolverInterface* solver = nullptr,
       const std::optional<solvers::SolverOptions>& solver_options =
           std::nullopt) const;
 
   /** Convenience overload that takes const reference arguments for source and
   target.
-  @pydrake_mkdoc_identifier{by_reference}
+  @pydrake_mkdoc_identifier{deprecated_by_reference}
   */
+  DRAKE_DEPRECATED("2022-12-01", "Use version with GraphOfConvexSetsOptions")
   solvers::MathematicalProgramResult SolveShortestPath(
-      const Vertex& source, const Vertex& target,
-      bool convex_relaxation = false,
+      const Vertex& source, const Vertex& target, bool convex_relaxation,
       const solvers::SolverInterface* solver = nullptr,
       const std::optional<solvers::SolverOptions>& solver_options =
           std::nullopt) const;


### PR DESCRIPTION
Switches the default behavior of SolveShortestPath to `convex_relaxation=true`.

cc @RussTedrake @TobiaMarcucci

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17396)
<!-- Reviewable:end -->
