### PR TITLE
[geometry/optimization] Enable preprocessing GCS before solving ShortestPath

### DIFF
--- a/bindings/pydrake/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry_py_optimization.cc
@@ -345,14 +345,18 @@ void DefineGeometryOptimization(py::module m) {
         .def_readwrite("convex_relaxation",
             &GraphOfConvexSetsOptions::convex_relaxation,
             cls_doc.convex_relaxation.doc)
+        .def_readwrite("preprocessing",
+            &GraphOfConvexSetsOptions::preprocessing, cls_doc.preprocessing.doc)
         .def("__repr__", [](const GraphOfConvexSetsOptions& self) {
           return py::str(
               "GraphOfConvexSetsOptions("
               "convex_relaxation={}, "
+              "preprocessing={}, "
               "solver={}, "
               "solver_options={}, "
               ")")
-              .format(self.convex_relaxation, self.solver, self.solver_options);
+              .format(self.convex_relaxation, self.preprocessing, self.solver,
+                  self.solver_options);
         });
 
     DefReadWriteKeepAlive(&gcs_options, "solver",
@@ -426,6 +430,9 @@ void DefineGeometryOptimization(py::module m) {
                   return out;
                 },
                 cls_doc.Edges.doc)
+            .def("ClearAllPhiConstraints",
+                &GraphOfConvexSets::ClearAllPhiConstraints,
+                cls_doc.ClearAllPhiConstraints.doc)
             .def("GetGraphvizString", &GraphOfConvexSets::GetGraphvizString,
                 py::arg("result") = std::nullopt, py::arg("show_slacks") = true,
                 py::arg("precision") = 3, py::arg("scientific") = false,

--- a/bindings/pydrake/test/geometry_optimization_test.py
+++ b/bindings/pydrake/test/geometry_optimization_test.py
@@ -410,6 +410,13 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertFalse(region.PointInSet([3.0]))
 
     def test_graph_of_convex_sets(self):
+        options = mut.GraphOfConvexSetsOptions()
+        options.convex_relaxation = True
+        options.preprocessing = False
+        options.solver = ClpSolver()
+        options.solver_options = SolverOptions()
+        self.assertIn("convex_relaxation", repr(options))
+
         spp = mut.GraphOfConvexSets()
         source = spp.AddVertex(set=mut.Point([0.1]), name="source")
         target = spp.AddVertex(set=mut.Point([0.2]), name="target")
@@ -423,8 +430,6 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertIsInstance(
             spp.SolveShortestPath(source=source, target=target),
             MathematicalProgramResult)
-        options = mut.GraphOfConvexSetsOptions()
-        options.solver = ClpSolver()
         self.assertIsInstance(spp.SolveShortestPath(
             source_id=source.id(), target_id=target.id(), options=options),
             MathematicalProgramResult)
@@ -493,6 +498,8 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertEqual(len(edge0.GetConstraints()), 2)
         edge0.AddPhiConstraint(phi_value=False)
         edge0.ClearPhiConstraints()
+        edge1.AddPhiConstraint(phi_value=True)
+        spp.ClearAllPhiConstraints()
 
         # Remove Edges
         self.assertEqual(len(spp.Edges()), 2)

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -31,6 +31,11 @@ struct GraphOfConvexSetsOptions {
   relaxation is tight. */
   bool convex_relaxation{true};
 
+  /** Performs a preprocessing step to remove edges that cannot lie on the
+  path from source to target. In most cases, preprocessing causes a net
+  reduction in computation by reducing the size of the optimization solved. */
+  bool preprocessing{true};
+
   /** Optimizer to be used to solve the shortest path optimization problem. If
   not set, the best solver for the given problem is selected. Note that if the
   solver cannot handle the type of optimization problem generated, the calling
@@ -345,6 +350,9 @@ class GraphOfConvexSets {
   @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.} */
   std::vector<const Edge*> Edges() const;
 
+  /** Removes all constraints added to any edge with AddPhiConstraint. */
+  void ClearAllPhiConstraints();
+
   /** Returns a Graphviz string describing the graph vertices and edges.  If
   `results` is supplied, then the graph will be annotated with the solution
   values.
@@ -442,6 +450,12 @@ class GraphOfConvexSets {
           std::nullopt) const;
 
  private:
+  /* Facilitates testing. */
+  friend class PreprocessShortestPathTest;
+
+  std::set<EdgeId> PreprocessShortestPath(VertexId source_id,
+                                          VertexId target_id) const;
+
   std::map<VertexId, std::unique_ptr<Vertex>> vertices_{};
   std::map<EdgeId, std::unique_ptr<Edge>> edges_{};
 };


### PR DESCRIPTION
Adds an optional preprocessing step to the `SolveShortestPath`.  Currently off by default to preserve the current behaviors and it on average doubles the time to run on simple test problems.

Depends on #17396 

cc @TobiaMarcucci @RussTedrake

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17397)
<!-- Reviewable:end -->
