### PR TITLE
Option to choose the SAP solver

### DIFF
--- a/examples/atlas/atlas_run_dynamics.cc
+++ b/examples/atlas/atlas_run_dynamics.cc
@@ -8,6 +8,7 @@
 #include "drake/lcm/drake_lcm.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/contact_results_to_lcm.h"
+#include "drake/multibody/plant/multibody_plant_config_functions.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/analysis/simulator_gflags.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -18,10 +19,13 @@ DEFINE_double(stiction_tolerance, 1.0E-3,
               "Allowable drift speed during stiction (m/s).");
 
 DEFINE_double(
-    mbp_discrete_update_period, 1.0E-3,
+    mbp_discrete_update_period, 0.01,
     "The fixed-time step period (in seconds) of discrete updates for the "
     "multibody plant modeled as a discrete system. Strictly positive. "
-    "Set to zero for a continuous plant model.");
+    "Set to zero for a continuous plant model. When using TAMSI, a smaller "
+    "time step of 1.0e-3 is recommended.");
+DEFINE_string(discrete_solver, "sap",
+              "Discrete contact solver. Options are: 'tamsi', 'sap'.");
 
 namespace drake {
 namespace examples {
@@ -30,6 +34,7 @@ namespace {
 
 using drake::math::RigidTransformd;
 using drake::multibody::MultibodyPlant;
+using drake::multibody::MultibodyPlantConfig;
 using Eigen::Translation3d;
 using Eigen::VectorXd;
 
@@ -41,10 +46,13 @@ int do_main() {
 
   // Build a generic multibody plant.
   systems::DiagramBuilder<double> builder;
-  auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(
-      &builder,
-      std::make_unique<MultibodyPlant<double>>(
-          FLAGS_mbp_discrete_update_period));
+
+  MultibodyPlantConfig plant_config;
+  plant_config.time_step = FLAGS_mbp_discrete_update_period;
+  plant_config.stiction_tolerance = FLAGS_stiction_tolerance;
+  plant_config.discrete_contact_solver_type = FLAGS_discrete_solver;
+  auto [plant, scene_graph] =
+      multibody::AddMultibodyPlant(plant_config, &builder);
 
   const std::string full_name =
       FindResourceOrThrow("drake/examples/atlas/urdf/atlas_convex_hull.urdf");

--- a/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
+++ b/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
@@ -42,6 +42,8 @@ DEFINE_string(contact_model, "hydroelastic",
 DEFINE_string(contact_surface_representation, "polygon",
               "Contact-surface representation for hydroelastics. "
               "Options are: 'triangle' or 'polygon'.");
+DEFINE_string(discrete_solver, "tamsi",
+              "Discrete contact solver. Options are: 'tamsi', 'sap'.");
 
 // Simulator settings.
 DEFINE_double(realtime_rate, 1,
@@ -137,6 +139,7 @@ int DoMain() {
   plant_config.time_step = FLAGS_mbp_discrete_update_period;
   plant_config.stiction_tolerance = FLAGS_stiction_tolerance;
   plant_config.contact_model = FLAGS_contact_model;
+  plant_config.discrete_contact_solver_type = FLAGS_discrete_solver;
   plant_config.contact_surface_representation =
       FLAGS_contact_surface_representation;
 

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -18,7 +18,6 @@ drake_cc_package_library(
     visibility = ["//visibility:public"],
     deps = [
         ":calc_distance_and_time_derivative",
-        ":compliant_contact_manager",
         ":contact_jacobians",
         ":contact_results",
         ":coulomb_friction",
@@ -36,21 +35,6 @@ drake_cc_package_library(
         ":propeller",
         ":tamsi_solver",
         ":wing",
-    ],
-)
-
-drake_cc_library(
-    name = "compliant_contact_manager",
-    srcs = ["compliant_contact_manager.cc"],
-    hdrs = ["compliant_contact_manager.h"],
-    deps = [
-        ":multibody_plant_core",
-        "//multibody/contact_solvers:contact_solver_utils",
-        "//multibody/contact_solvers/sap:sap_contact_problem",
-        "//multibody/contact_solvers/sap:sap_friction_cone_constraint",
-        "//multibody/contact_solvers/sap:sap_limit_constraint",
-        "//multibody/contact_solvers/sap:sap_solver",
-        "//multibody/triangle_quadrature",
     ],
 )
 
@@ -112,11 +96,13 @@ drake_cc_library(
 drake_cc_library(
     name = "multibody_plant_core",
     srcs = [
+        "compliant_contact_manager.cc",
         "discrete_update_manager.cc",
         "multibody_plant.cc",
         "physical_model.cc",
     ],
     hdrs = [
+        "compliant_contact_manager.h",
         "discrete_update_manager.h",
         "multibody_plant.h",
         "multibody_plant_discrete_update_manager_attorney.h",
@@ -142,6 +128,7 @@ drake_cc_library(
         "//math:geometric_transform",
         "//multibody/contact_solvers:contact_solver",
         "//multibody/contact_solvers:sparse_linear_operator",
+        "//multibody/contact_solvers/sap",
         "//multibody/hydroelastics:hydroelastic_engine",
         "//multibody/topology:multibody_graph",
         "//multibody/tree",
@@ -366,7 +353,6 @@ drake_cc_googletest(
         "//manipulation/models/wsg_50_description:models",
     ],
     deps = [
-        ":compliant_contact_manager",
         ":plant",
         "//common:find_resource",
         "//common/test_utilities:eigen_matrix_compare",

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -22,6 +22,7 @@
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/contact_solvers/sparse_linear_operator.h"
 #include "drake/multibody/hydroelastics/hydroelastic_engine.h"
+#include "drake/multibody/plant/compliant_contact_manager.h"
 #include "drake/multibody/plant/discrete_contact_pair.h"
 #include "drake/multibody/plant/externally_applied_spatial_force.h"
 #include "drake/multibody/plant/hydroelastic_traction_calculator.h"
@@ -364,6 +365,8 @@ MultibodyPlant<T>::MultibodyPlant(double time_step)
   DRAKE_DEMAND(contact_model_ == ContactModel::kHydroelasticWithFallback);
   DRAKE_DEMAND(MultibodyPlantConfig{}.contact_model ==
                "hydroelastic_with_fallback");
+  DRAKE_DEMAND(solver_type_ == DiscreteContactSolverType::kTamsi);
+  DRAKE_DEMAND(MultibodyPlantConfig{}.discrete_contact_solver_type == "tamsi");
 }
 
 template <typename T>
@@ -487,6 +490,19 @@ template <typename T>
 void MultibodyPlant<T>::set_contact_model(ContactModel model) {
   DRAKE_MBP_THROW_IF_FINALIZED();
   contact_model_ = model;
+}
+
+template <typename T>
+void MultibodyPlant<T>::set_discrete_contact_solver_type(
+    DiscreteContactSolverType solver_type) {
+  DRAKE_MBP_THROW_IF_FINALIZED();
+  solver_type_ = solver_type;
+}
+
+template <typename T>
+DiscreteContactSolverType MultibodyPlant<T>::get_discrete_contact_solver_type()
+    const {
+  return solver_type_;
 }
 
 template <typename T>
@@ -806,6 +822,27 @@ void MultibodyPlant<T>::Finalize() {
     ExcludeCollisionsWithVisualGeometry();
   }
   FinalizePlantOnly();
+
+  // Set discrete update manager. Currently, CompliantContactManager does not
+  // support T = symbolic::Expression.
+  // N.B. Unlike SAP, currently the TAMSI solver is incorporated directly into
+  // MultibodyPlant's source, rather than in CompliantContactManager. The plan
+  // is to move TAMSI, as well as the entirety of the discrete handling of
+  // contact, into CompliantContactManager.
+  if (is_discrete()) {
+    if constexpr (!std::is_same_v<T, symbolic::Expression>) {
+      if (solver_type_ == DiscreteContactSolverType::kSap) {
+        SetDiscreteUpdateManager(
+            std::make_unique<internal::CompliantContactManager<T>>());
+      }
+    } else {
+      if (solver_type_ == DiscreteContactSolverType::kSap) {
+        throw std::runtime_error(
+            "SAP solver not supported for scalar type T = "
+            "symbolic::Expression.");
+      }
+    }
+  }
 }
 
 template<typename T>
@@ -1193,6 +1230,7 @@ void MultibodyPlant<T>::SetDiscreteUpdateManager(
   // least to build the contact problem. However, here we play safe and demand
   // finalization right here.
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  DRAKE_DEMAND(is_discrete());
   DRAKE_DEMAND(manager != nullptr);
   manager->SetOwningMultibodyPlant(this);
   discrete_update_manager_ = std::move(manager);

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -100,6 +100,24 @@ enum class ContactModel {
   kPointContactOnly = kPoint,
 };
 
+/// The type of the contact solver used for a discrete MultibodyPlant model.
+///
+/// <h2>References</h2>
+///
+/// - [Castro et al., 2019] Castro, A.M, Qu, A., Kuppuswamy, N., Alspach, A.,
+///   Sherman, M.A., 2019. A Transition-Aware Method for the Simulation of
+///   Compliant Contact with Regularized Friction. Available online at
+///   https://arxiv.org/abs/1909.05700.
+/// - [Castro et al., 2022] Castro A., Permenter F. and Han X., 2022. An
+///   Unconstrained Convex Formulation of Compliant Contact. Available online at
+///   https://arxiv.org/abs/2110.10107.
+enum class DiscreteContactSolverType {
+  /// TAMSI solver, see [Castro et al., 2019].
+  kTamsi,
+  /// SAP solver, see [Castro et al., 2022].
+  kSap,
+};
+
 /// @cond
 // Helper macro to throw an exception within methods that should not be called
 // post-finalize.
@@ -1586,6 +1604,12 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception iff called post-finalize.
   void set_contact_model(ContactModel model);
 
+  /// Sets the contact solver type used for discrete %MultibodyPlant models.
+  /// @throws std::exception iff called post-finalize.
+  void set_discrete_contact_solver_type(DiscreteContactSolverType solver_type);
+
+  /// Returns the contact solver type used for discrete %MultibodyPlant models.
+  DiscreteContactSolverType get_discrete_contact_solver_type() const;
 
   /// Return the default value for contact representation, given the desired
   /// time step. Discrete systems default to use polygons; continuous systems
@@ -1649,6 +1673,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///
   /// @param manager
   ///   After this call the new manager is used to advance discrete states.
+  /// @pre this %MultibodyPlant is discrete.
   /// @pre manager != nullptr.
   /// @throws std::exception if called pre-finalize. See Finalize().
   /// @note `this` MultibodyPlant will no longer support scalar conversion to or
@@ -4869,6 +4894,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // with the default value in multibody_plant_config.h; there are already
   // assertions in the cc file that enforce this.
   ContactModel contact_model_{ContactModel::kHydroelasticWithFallback};
+
+  // The solver type used by a discrete plant. Keep this in sync
+  // with the default value in multibody_plant_config.h; there are already
+  // assertions in the cc file that enforce this.
+  DiscreteContactSolverType solver_type_{DiscreteContactSolverType::kTamsi};
 
   // User's choice of the representation of contact surfaces in discrete
   // systems. The default value is dependent on whether the system is

--- a/multibody/plant/multibody_plant_config.h
+++ b/multibody/plant/multibody_plant_config.h
@@ -18,6 +18,7 @@ struct MultibodyPlantConfig {
     a->Visit(DRAKE_NVP(penetration_allowance));
     a->Visit(DRAKE_NVP(stiction_tolerance));
     a->Visit(DRAKE_NVP(contact_model));
+    a->Visit(DRAKE_NVP(discrete_contact_solver_type));
     a->Visit(DRAKE_NVP(contact_surface_representation));
   }
 
@@ -41,6 +42,13 @@ struct MultibodyPlantConfig {
   /// - "hydroelastic"
   /// - "hydroelastic_with_fallback"
   std::string contact_model{"hydroelastic_with_fallback"};
+
+  /// Configures the MultibodyPlant::set_discrete_contact_solver_type().
+  /// Refer to drake::multibody::DiscreteContactSolverType for details.
+  /// Valid strings are:
+  /// - "tamsi"
+  /// - "sap"
+  std::string discrete_contact_solver_type{"tamsi"};
 
   /// Configures the MultibodyPlant::set_contact_surface_representation().
   /// Refer to drake::geometry::HydroelasticContactRepresentation for details.

--- a/multibody/plant/multibody_plant_config_functions.cc
+++ b/multibody/plant/multibody_plant_config_functions.cc
@@ -19,6 +19,9 @@ AddResult AddMultibodyPlant(
   result.plant.set_stiction_tolerance(config.stiction_tolerance);
   result.plant.set_contact_model(
       internal::GetContactModelFromString(config.contact_model));
+  result.plant.set_discrete_contact_solver_type(
+      internal::GetDiscreteContactSolverTypeFromString(
+          config.discrete_contact_solver_type));
   result.plant.set_contact_surface_representation(
       internal::GetContactSurfaceRepresentationFromString(
           config.contact_surface_representation));
@@ -51,6 +54,30 @@ constexpr std::array<std::pair<ContactModel, const char*>, 3> kContactModels{{
   MakeContactModelPair(ContactModel::kHydroelasticsOnly),
   MakeContactModelPair(ContactModel::kHydroelasticWithFallback),
 }};
+
+// Use a switch() statement here, to ensure the compiler sends us a reminder
+// when somebody adds a new value to the enum. New values must be listed here
+// as well as in the list of kDiscreteContactSolverTypes below.
+constexpr const char* DiscreteContactSolverTypeToChars(
+    DiscreteContactSolverType type) {
+  switch (type) {
+    case DiscreteContactSolverType::kTamsi:
+      return "tamsi";
+    case DiscreteContactSolverType::kSap:
+      return "sap";
+  }
+}
+
+constexpr auto MakeDiscreteContactSolverTypePair(
+    DiscreteContactSolverType value) {
+  return std::pair(value, DiscreteContactSolverTypeToChars(value));
+}
+
+constexpr std::array<std::pair<DiscreteContactSolverType, const char*>, 2>
+    kDiscreteContactSolverTypes{{
+        MakeDiscreteContactSolverTypePair(DiscreteContactSolverType::kTamsi),
+        MakeDiscreteContactSolverTypePair(DiscreteContactSolverType::kSap),
+    }};
 
 // Take an alias to limit verbosity, especially in the constexpr boilerplate.
 using ContactRep = geometry::HydroelasticContactRepresentation;
@@ -91,6 +118,28 @@ ContactModel GetContactModelFromString(std::string_view contact_model) {
 std::string GetStringFromContactModel(ContactModel contact_model) {
   for (const auto& [value, name] : kContactModels) {
     if (value == contact_model) {
+      return name;
+    }
+  }
+  DRAKE_UNREACHABLE();
+}
+
+DiscreteContactSolverType GetDiscreteContactSolverTypeFromString(
+    std::string_view discrete_contact_solver_type) {
+  for (const auto& [value, name] : kDiscreteContactSolverTypes) {
+    if (name == discrete_contact_solver_type) {
+      return value;
+    }
+  }
+  throw std::logic_error(
+      fmt::format("Unknown discrete_contact_solver_type: '{}'",
+                  discrete_contact_solver_type));
+}
+
+std::string GetStringFromDiscreteContactSolverType(
+    DiscreteContactSolverType contact_solver) {
+  for (const auto& [value, name] : kDiscreteContactSolverTypes) {
+    if (value == contact_solver) {
       return name;
     }
   }

--- a/multibody/plant/multibody_plant_config_functions.h
+++ b/multibody/plant/multibody_plant_config_functions.h
@@ -29,6 +29,19 @@ ContactModel GetContactModelFromString(std::string_view contact_model);
 std::string GetStringFromContactModel(ContactModel contact_model);
 
 // (Exposed for unit testing only.)
+// Parses a string name for a contact solver type and returns the enumerated
+// value. Valid string names are listed in MultibodyPlantConfig's class
+// overview.
+// @throws std::exception if an invalid string is passed in.
+DiscreteContactSolverType GetDiscreteContactSolverTypeFromString(
+    std::string_view discrete_contact_solver_type);
+
+// (Exposed for unit testing only.) Returns the string name of an enumerated
+// value for a discrete contact solver type.
+std::string GetStringFromDiscreteContactSolverType(
+    DiscreteContactSolverType discrete_contact_solver_type);
+
+// (Exposed for unit testing only.)
 // Parses a string name for a contact representation and returns the enumerated
 // value.  Valid string names are listed in MultibodyPlantConfig's class
 // overview.

--- a/multibody/plant/test/multibody_plant_config_functions_test.cc
+++ b/multibody/plant/test/multibody_plant_config_functions_test.cc
@@ -36,6 +36,7 @@ time_step: 0.002
 penetration_allowance: 0.003
 stiction_tolerance: 0.004
 contact_model: hydroelastic
+discrete_contact_solver_type: sap
 contact_surface_representation: triangle
 )""";
 
@@ -48,6 +49,8 @@ GTEST_TEST(MultibodyPlantConfigFunctionsTest, YamlTest) {
             ContactModel::kHydroelasticsOnly);
   EXPECT_EQ(result.plant.get_contact_surface_representation(),
             geometry::HydroelasticContactRepresentation::kTriangle);
+  EXPECT_EQ(result.plant.get_discrete_contact_solver_type(),
+            DiscreteContactSolverType::kSap);
   // There is no getter for penetration_allowance nor stiction_tolerance, so we
   // can't test them.
 }


### PR DESCRIPTION
Draft PR to set SAP as the contact solver in MultibodyPlant.
The user would set the solver in the `MultibodyPlantConfig::discrete_contact_solver_type`.
Two examples here show how to use it: `examples/hydroelastic/spatula_slip_control` and `examples/atlas`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17400)
<!-- Reviewable:end -->
