### PR TITLE
Add a check of the wheel size

### DIFF
--- a/tools/wheel/test/test-wheel.sh
+++ b/tools/wheel/test/test-wheel.sh
@@ -44,3 +44,13 @@ prog.AddQuadraticCost(numpy.eye(2), numpy.zeros(2), x)
 solver = pydrake.all.IpoptSolver()
 assert solver.Solve(prog, None, None).is_success(), "IPOPT is not usable"
 EOF
+
+python - "$1" << EOF
+import os
+import sys
+
+# Check that wheel size is within PyPI's per-wheel size quota.
+wheel_size = os.path.getsize(sys.argv[1])
+pypi_wheel_max_size = 100 << 20  # 100 MiB
+assert wheel_size < pypi_wheel_max_size, "Wheel is too large for PyPI"
+EOF


### PR DESCRIPTION
Add an additional test to the wheel test script which checks if the wheel size is greater than PyPI's per-wheel size limit. This will give us earlier warning if the wheel grows too large (which it is, as of writing).

Fixes #17395.