### PR TITLE
Check if influence_value_offset is strictly positive in MinimumValueConstrant

### DIFF
--- a/solvers/minimum_value_constraint.cc
+++ b/solvers/minimum_value_constraint.cc
@@ -136,6 +136,8 @@ MinimumValueConstraint::MinimumValueConstraint(
       minimum_value_{minimum_value},
       influence_value_{minimum_value + influence_value_offset},
       max_num_values_{max_num_values} {
+  DRAKE_DEMAND(influence_value_offset > 0);
+  DRAKE_DEMAND(std::isfinite(influence_value_offset));
   set_penalty_function(QuadraticallySmoothedHingeLoss);
 }
 


### PR DESCRIPTION
As discussed in https://tri-internal.slack.com/archives/C01R4DSPMCN/p1655311252815549?thread_ts=1655308892.342349&cid=C01R4DSPMCN

In the documentation of MinimumValueConstraint we said
```
This value must be finite and strictly positive, as it is used
  to scale the values returned by `value_function`
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17404)
<!-- Reviewable:end -->
