### PR TITLE
Set joint velocity limits for iiwa and jaco arms

### DIFF
--- a/manipulation/models/jaco_description/urdf/j2s7s300.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300.urdf
@@ -79,10 +79,11 @@
     <parent link="j2s7s300_link_base"/>
     <child link="j2s7s300_link_1"/>
     <axis xyz="0 0 1"/>
-    <!-- The upper and lower limits below are set based on the range
-         of +/- 10000 degrees listed in the "JACO2 Spherical 7 DOF
-         Advanced specification guide" from Kinova. -->
-    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="1"/>
+    <!-- The upper and lower limits below are set based on the range of +/-
+         10000 degrees listed in the "JACO2 Spherical 7 DOF Advanced
+         specification guide" from Kinova.  The velocity limit is set from
+         "Recommended maximum actuators utilization" in the same document. -->
+    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="0.63"/>
     <origin rpy="0 3.14159265359 0" xyz="0 0 0.15675"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -124,7 +125,7 @@
     <parent link="j2s7s300_link_1"/>
     <child link="j2s7s300_link_2"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="1"/>
+    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="0.63"/>
     <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.0016 -0.11875"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -166,7 +167,7 @@
     <parent link="j2s7s300_link_2"/>
     <child link="j2s7s300_link_3"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="1"/>
+    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="0.63"/>
     <origin rpy="-1.57079632679 0 0" xyz="0 -0.205 0"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -208,7 +209,7 @@
     <parent link="j2s7s300_link_3"/>
     <child link="j2s7s300_link_4"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="1"/>
+    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="0.63"/>
     <origin rpy="1.57079632679 0 3.14159265359" xyz="0 0 -0.205"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -250,7 +251,7 @@
     <parent link="j2s7s300_link_4"/>
     <child link="j2s7s300_link_5"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="1"/>
+    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="0.85"/>
     <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.2073 -0.0114"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -292,7 +293,7 @@
     <parent link="j2s7s300_link_5"/>
     <child link="j2s7s300_link_6"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="1"/>
+    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="0.85"/>
     <origin rpy="1.57079632679 0 3.14159265359" xyz="0 0 -0.10375"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -334,7 +335,7 @@
     <parent link="j2s7s300_link_6"/>
     <child link="j2s7s300_link_7"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="1"/>
+    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="0.85"/>
     <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.10375 0"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>

--- a/manipulation/models/jaco_description/urdf/j2s7s300_arm.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300_arm.urdf
@@ -79,10 +79,11 @@
     <parent link="j2s7s300_link_base"/>
     <child link="j2s7s300_link_1"/>
     <axis xyz="0 0 1"/>
-    <!-- The upper and lower limits below are set based on the range
-         of +/- 10000 degrees listed in the "JACO2 Spherical 7 DOF
-         Advanced specification guide" from Kinova. -->
-    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="1"/>
+    <!-- The upper and lower limits below are set based on the range of +/-
+         10000 degrees listed in the "JACO2 Spherical 7 DOF Advanced
+         specification guide" from Kinova.  The velocity limit is set from
+         "Recommended maximum actuators utilization" in the same document. -->
+    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="0.63"/>
     <origin rpy="0 3.14159265359 0" xyz="0 0 0.15675"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -124,7 +125,7 @@
     <parent link="j2s7s300_link_1"/>
     <child link="j2s7s300_link_2"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="1"/>
+    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="0.63"/>
     <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.0016 -0.11875"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -166,7 +167,7 @@
     <parent link="j2s7s300_link_2"/>
     <child link="j2s7s300_link_3"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="1"/>
+    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="0.63"/>
     <origin rpy="-1.57079632679 0 0" xyz="0 -0.205 0"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -208,7 +209,7 @@
     <parent link="j2s7s300_link_3"/>
     <child link="j2s7s300_link_4"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="1"/>
+    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="0.63"/>
     <origin rpy="1.57079632679 0 3.14159265359" xyz="0 0 -0.205"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -250,7 +251,7 @@
     <parent link="j2s7s300_link_4"/>
     <child link="j2s7s300_link_5"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="1"/>
+    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="0.85"/>
     <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.2073 -0.0114"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -292,7 +293,7 @@
     <parent link="j2s7s300_link_5"/>
     <child link="j2s7s300_link_6"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="1"/>
+    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="0.85"/>
     <origin rpy="1.57079632679 0 3.14159265359" xyz="0 0 -0.10375"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -317,7 +318,7 @@
     <parent link="j2s7s300_link_6"/>
     <child link="j2s7s300_link_7"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="1"/>
+    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="0.85"/>
     <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.10375 0"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>

--- a/manipulation/models/jaco_description/urdf/j2s7s300_arm_sphere_collision.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300_arm_sphere_collision.urdf
@@ -141,10 +141,11 @@
     <parent link="j2s7s300_link_base"/>
     <child link="j2s7s300_link_1"/>
     <axis xyz="0 0 1"/>
-    <!-- The upper and lower limits below are set based on the range
-         of +/- 10000 degrees listed in the "JACO2 Spherical 7 DOF
-         Advanced specification guide" from Kinova. -->
-    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="1"/>
+    <!-- The upper and lower limits below are set based on the range of +/-
+         10000 degrees listed in the "JACO2 Spherical 7 DOF Advanced
+         specification guide" from Kinova.  The velocity limit is set from
+         "Recommended maximum actuators utilization" in the same document. -->
+    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="0.63"/>
     <origin rpy="0 3.14159265359 0" xyz="0 0 0.15675"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -241,7 +242,7 @@
     <parent link="j2s7s300_link_1"/>
     <child link="j2s7s300_link_2"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="1"/>
+    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="0.63"/>
     <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.0016 -0.11875"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -344,7 +345,7 @@
     <parent link="j2s7s300_link_2"/>
     <child link="j2s7s300_link_3"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="1"/>
+    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="0.63"/>
     <origin rpy="-1.57079632679 0 0" xyz="0 -0.205 0"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -453,7 +454,7 @@
     <parent link="j2s7s300_link_3"/>
     <child link="j2s7s300_link_4"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="1"/>
+    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="0.63"/>
     <origin rpy="1.57079632679 0 3.14159265359" xyz="0 0 -0.205"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -508,7 +509,7 @@
     <parent link="j2s7s300_link_4"/>
     <child link="j2s7s300_link_5"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="1"/>
+    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="0.85"/>
     <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.2073 -0.0114"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -563,7 +564,7 @@
     <parent link="j2s7s300_link_5"/>
     <child link="j2s7s300_link_6"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="1"/>
+    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="0.85"/>
     <origin rpy="1.57079632679 0 3.14159265359" xyz="0 0 -0.10375"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -588,7 +589,7 @@
     <parent link="j2s7s300_link_6"/>
     <child link="j2s7s300_link_7"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="1"/>
+    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="0.85"/>
     <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.10375 0"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>

--- a/manipulation/models/jaco_description/urdf/j2s7s300_sphere_collision.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300_sphere_collision.urdf
@@ -141,10 +141,11 @@
     <parent link="j2s7s300_link_base"/>
     <child link="j2s7s300_link_1"/>
     <axis xyz="0 0 1"/>
-    <!-- The upper and lower limits below are set based on the range
-         of +/- 10000 degrees listed in the "JACO2 Spherical 7 DOF
-         Advanced specification guide" from Kinova. -->
-    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="1"/>
+    <!-- The upper and lower limits below are set based on the range of +/-
+         10000 degrees listed in the "JACO2 Spherical 7 DOF Advanced
+         specification guide" from Kinova.  The velocity limit is set from
+         "Recommended maximum actuators utilization" in the same document. -->
+    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="0.63"/>
     <origin rpy="0 3.14159265359 0" xyz="0 0 0.15675"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -241,7 +242,7 @@
     <parent link="j2s7s300_link_1"/>
     <child link="j2s7s300_link_2"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="1"/>
+    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="0.63"/>
     <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.0016 -0.11875"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -344,7 +345,7 @@
     <parent link="j2s7s300_link_2"/>
     <child link="j2s7s300_link_3"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="1"/>
+    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="0.63"/>
     <origin rpy="-1.57079632679 0 0" xyz="0 -0.205 0"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -453,7 +454,7 @@
     <parent link="j2s7s300_link_3"/>
     <child link="j2s7s300_link_4"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="1"/>
+    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="0.63"/>
     <origin rpy="1.57079632679 0 3.14159265359" xyz="0 0 -0.205"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -508,7 +509,7 @@
     <parent link="j2s7s300_link_4"/>
     <child link="j2s7s300_link_5"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="1"/>
+    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="0.85"/>
     <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.2073 -0.0114"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -563,7 +564,7 @@
     <parent link="j2s7s300_link_5"/>
     <child link="j2s7s300_link_6"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="1"/>
+    <limit effort="2000" lower="0.523598775598" upper="5.75958653158" velocity="0.85"/>
     <origin rpy="1.57079632679 0 3.14159265359" xyz="0 0 -0.10375"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -648,7 +649,7 @@
     <parent link="j2s7s300_link_6"/>
     <child link="j2s7s300_link_7"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="1"/>
+    <limit effort="2000" lower="-174.532925" upper="174.532925" velocity="0.85"/>
     <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.10375 0"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>


### PR DESCRIPTION
* The existing limits were placeholder values.
* For the jaco, we have documented limits from the manual.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17407)
<!-- Reviewable:end -->
