### PR TITLE
[doc] Document all nightly uploads and expiration policies

### DIFF
--- a/doc/_pages/apt.md
+++ b/doc/_pages/apt.md
@@ -68,3 +68,27 @@ variables may be useful:
   ```
 
 Refer to [Quickstart](/installation.html#quickstart) for next steps.
+
+## Nightly Releases
+
+Unsigned nightly apt packages of Drake for Ubuntu 20.04 (Focal) and Ubuntu 22.04
+(Jammy) are available to download at:
+
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_latest-1_amd64-focal.deb](https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_latest-1_amd64-focal.deb)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_latest-1_amd64-jammy.deb](https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_latest-1_amd64-jammy.deb)
+
+Older packages for specific dates are available by replacing ``latest`` with an
+8-digit date, e.g., ``20220721`` for July 21st, 2022.
+
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_0.0.20220721-1_amd64-focal.deb](https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_0.0.20220721-1_amd64-focal.deb)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_0.0.20220721-1_amd64-jammy.deb](https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_0.0.20220721-1_amd64-jammy.deb)
+
+Nightly packages are retained for 56 days from their date of creation.
+
+For installing a nightly apt package, download the archive and install it
+directly:
+
+  ```bash
+  wget https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_latest-1_amd64-focal.deb
+  sudo apt-get install --no-install-recommends ./drake-latest-focal.deb
+  ```

--- a/doc/_pages/from_binary.md
+++ b/doc/_pages/from_binary.md
@@ -77,18 +77,20 @@ Refer to [Quickstart](/installation.html#quickstart) for next steps.
 
 ## Nightly Releases
 
-Binary packages of Drake for Ubuntu 20.04 (Focal) and
+Binary packages of Drake for Ubuntu 20.04 (Focal), Ubuntu 22.04 (Jammy), and
 Mac are generated nightly and are available to download at:
 
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-focal.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-focal.tar.gz)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz)
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac.tar.gz)
 
 Older packages for specific dates are available by replacing ``latest`` with an
-8-digit date, e.g., ``20200102`` for January 2nd, 2020.
+8-digit date, e.g., ``20220721`` for July 21st, 2022.
 
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-20220714-focal.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-20220714-focal.tar.gz)
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-20220714-mac.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-20220714-mac.tar.gz)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-20220721-focal.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-20220721-focal.tar.gz)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-20220721-jammy.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-20220721-jammy.tar.gz)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-20220721-mac.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-20220721-mac.tar.gz)
 
-Individual packages are archived two years from their date of creation.
+Nightly archives are retained for 56 days from their date of creation.
 
 The installation instructions are identical to stable releases as shown above.

--- a/doc/_pages/installation.md
+++ b/doc/_pages/installation.md
@@ -87,8 +87,8 @@ All other packages support both C++ and/or Python.
 
 |                       | Ubuntu | macOS |
 |-----------------------|--------|-------|
-| Using pip             | [Stable](/pip.html#stable-releases) | |
-| Using apt (deb)       | [Stable](/apt.html#stable-releases) | |
+| Using pip             | [Stable](/pip.html#stable-releases) or [Nightly](/pip.html#nightly-releases) | [Nightly](/pip.html#nightly-releases) |
+| Using apt (deb)       | [Stable](/apt.html#stable-releases) or [Nightly](/apt.html#nightly-releases) | |
 | Using tar.gz download | [Stable](/from_binary.html#stable-releases) or [Nightly](/from_binary.html#nightly-releases) | [Stable](/from_binary.html#stable-releases) or [Nightly](/from_binary.html#nightly-releases) |
 | Using Docker Hub      | [Stable](/docker.html#stable-releases) or [Nightly](/docker.html#nightly-releases) | [Stable](/docker.html#stable-releases) or [Nightly](/docker.html#nightly-releases) |
 

--- a/doc/_pages/pip.md
+++ b/doc/_pages/pip.md
@@ -76,3 +76,33 @@ source env/bin/activate
 ````
 
 Refer to [Quickstart](/installation.html#quickstart) for next steps.
+
+## Nightly Releases
+
+Binary wheels of Drake for Ubuntu 20.04 (Focal) and
+Mac are generated nightly and are available to download at:
+
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp38-cp38-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp38-cp38-manylinux_2_31_x86_64.whl)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp39-cp39-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp39-cp39-manylinux_2_31_x86_64.whl)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp39-cp39-macosx_11_0_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp39-cp39-macosx_11_0_x86_64.whl)
+
+Older packages for specific dates are available by replacing ``latest`` with an
+8-digit date, e.g., ``20220721`` for July 21st, 2022.  The version number to
+replace ``latest`` with follows the pattern ``0.0.YYYYMMDD``.
+
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20220721-cp38-cp38-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20220721-cp38-cp38-manylinux_2_31_x86_64.whl)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20220721-cp39-cp39-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20220721-cp39-cp39-manylinux_2_31_x86_64.whl)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20220721-cp39-cp39-macosx_11_0_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20220721-cp39-cp39-macosx_11_0_x86_64.whl)
+
+Nightly wheels are retained for 56 days from their date of creation.
+
+To install nightly wheel, install from the URL directly:
+
+  ```bash
+  # Example for python 3.8 (cp38-cp38).
+  python3 -m venv env
+  env/bin/pip install --upgrade pip
+  env/bin/pip install https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp38-cp38-manylinux_2_31_x86_64.whl
+  ```
+
+Make sure you have the required runtime libraries described above.

--- a/doc/_release-notes/2016.md
+++ b/doc/_release-notes/2016.md
@@ -8,4 +8,4 @@ for reference.
 
 The last published package for Ubuntu 16.04 (Xenial) is available here:
 
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-xenial.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-xenial.tar.gz)
+* [https://github.com/RobotLocomotion/drake/releases/tag/v0.11.0](https://github.com/RobotLocomotion/drake/releases/tag/v0.11.0)

--- a/doc/_release-notes/v1.1.0.md
+++ b/doc/_release-notes/v1.1.0.md
@@ -17,6 +17,8 @@ released: 2022-03-28
     time.
   * Drake will add support for Ubuntu 22.04 "Jammy" as soon as possible
     after it's release date, most likely by June 1st, 2022.
+  * The last published package for Ubuntu 18.04 (Bionic) is available here:
+    * [https://github.com/RobotLocomotion/drake/releases/tag/v1.1.0](https://github.com/RobotLocomotion/drake/releases/tag/v1.1.0)
 * Reminder: Drake will no longer support Python 3.6 or Python 3.7 of
   April 1st, 2022 ([#13391][_#13391]).
   * Ubuntu users should plan to upgrade to Ubuntu 20.04 "Focal" before that

--- a/tools/workspace/vtk/README.md
+++ b/tools/workspace/vtk/README.md
@@ -74,6 +74,11 @@ where the artifacts from `build_binaries_with_docker` reside on your local
 machine.  You will additionally need to modify `repository.bzl` to update the
 `sha256` for the corresponding archives (search `sha256` in that file).
 
+VTK archives for compiling drake hosted at
+https://drake-packages.csail.mit.edu/vtk are accessible for 5 years after the
+date of creation.  Afterward they are moved to glacier storage on s3 and will
+not be available for public download.
+
 ### macOS
 
 Compiled artifacts are produced by


### PR DESCRIPTION
Fixes: #14938.

Possibly relates: #15958.

- Advertise nightly `.tar.gz`, `.deb`, and python wheel urls.
    - Download links with YYYYMMDD in their url are available for ~56 days after their upload.  Previously these were available
      for 2 years.
- Build artifacts for drake hosted in the drake-packages s3 bucket are available for 5 years from upload (e.g., ubuntu VTK tarballs).

- [X] Finalize desired expiration policies.
- [X] Unify AWS uploads (https://github.com/RobotLocomotion/drake-ci/pull/164).
- [X] s3 uploads of wheels (https://github.com/RobotLocomotion/drake-ci/pull/165).
    - [X] Rename uploads for nightlies (https://github.com/RobotLocomotion/drake-ci/pull/176).
- [X] s3 uploads of debian packages (https://github.com/RobotLocomotion/drake-ci/pull/157).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17413)
<!-- Reviewable:end -->
