### PR TITLE
[workspace] Reduce the libsdformat footprint

### DIFF
--- a/tools/workspace/sdformat_internal/BUILD.bazel
+++ b/tools/workspace/sdformat_internal/BUILD.bazel
@@ -24,4 +24,4 @@ drake_py_unittest(
     data = [":ign_sdf"],
 )
 
-add_lint_tests()
+add_lint_tests(python_lint_extra_srcs = ["embed_sdf.py"])

--- a/tools/workspace/sdformat_internal/embed_sdf.py
+++ b/tools/workspace/sdformat_internal/embed_sdf.py
@@ -2,26 +2,50 @@
 
 import sys
 
+from lxml import etree
+
 assert __name__ == '__main__'
 
+
+def _minified_xml(*, filename):
+    """Given a filename for an `*.sdf` schema file, returns a minified xml
+    string with its contents, to conserve disk space in Drake's library.
+    """
+    parser = etree.XMLParser(remove_blank_text=True, remove_comments=True)
+    root = etree.parse(filename, parser)
+    for item in root.xpath("//description"):
+        item.getparent().remove(item)
+    for elem in root.iter('*'):
+        if elem.text is not None:
+            elem.text = elem.text.strip()
+        if elem.tail is not None:
+            elem.tail = elem.tail.strip()
+    return etree.tostring(root, encoding="utf-8", xml_declaration=False)
+
+
+filenames = sorted(sys.argv[1:])
 print("""
 #include "EmbeddedSdf.hh"
+#include "drake_vendor/ignition/utils/NeverDestroyed.hh"
 namespace sdf { inline namespace SDF_VERSION_NAMESPACE {
 const std::map<std::string, std::string>& GetEmbeddedSdf() {
-  static const std::map<std::string, std::string> result{
+  using Result = std::map<std::string, std::string>;
 """)
-for filename in sorted(sys.argv[1:]):
+print('  constexpr std::array<std::pair<const char*, const char*>, {}> pairs{{'
+      .format(len(filenames)))
+for filename in filenames:
     _, relative_path = filename.split('/sdf/')
-    print('{')
+    print('std::pair<const char*, const char*>{')
     print(f'"{relative_path}",')
-    with open(filename, 'r', encoding='utf-8') as data:
-        print('R"raw(')
-        sys.stdout.flush()
-        sys.stdout.buffer.write(data.read().encode('utf-8'))
-        print(')raw"')
+    print('R"raw(')
+    sys.stdout.flush()
+    sys.stdout.buffer.write(_minified_xml(filename=filename))
+    print(')raw"')
     print('},')
 print("""
   };
-  return result;
+  static const ignition::utils::NeverDestroyed<Result> result{
+      pairs.begin(), pairs.end()};
+  return result.Access();
 }}}
 """)


### PR DESCRIPTION
(The bloaty report names this file as the number one offender.)

When embedding the sdformat schema into our runtime library, minify the xml data first to save space (remove descriptions, comments, and whitespace).

Store the raw data in a constexpr array, to avoid unwanted inlined initialization code.

Use const char pairs when constructing the map; otherwise we get a bajilion map insertion overloads with various `char[]` array sizes.

Remove the global destructor from the resulting map (style guide).

For my current build, this reduces `libdrake.so` by 453 KiB (0.7%), or when zipped by 93 KiB (0.5%).

Relates to #17403 somewhat.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17414)
<!-- Reviewable:end -->
