### PR TITLE
Avoid <iostream> in library code whenever possible

### DIFF
--- a/common/copyable_unique_ptr.h
+++ b/common/copyable_unique_ptr.h
@@ -11,8 +11,8 @@ copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
 #include <cstddef>
-#include <iostream>
 #include <memory>
+#include <ostream>
 #include <utility>
 
 #include "drake/common/drake_assert.h"

--- a/common/hash.h
+++ b/common/hash.h
@@ -3,7 +3,6 @@
 #include <cmath>
 #include <cstddef>
 #include <functional>
-#include <iostream>
 #include <map>
 #include <optional>
 #include <set>

--- a/common/sorted_pair.h
+++ b/common/sorted_pair.h
@@ -2,7 +2,7 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <iostream>
+#include <ostream>
 #include <type_traits>
 #include <utility>
 

--- a/common/symbolic_environment.cc
+++ b/common/symbolic_environment.cc
@@ -1,7 +1,7 @@
 // NOLINTNEXTLINE(build/include): Its header file is included in symbolic.h.
 #include <cmath>
 #include <initializer_list>
-#include <iostream>
+#include <ostream>
 #include <random>
 #include <sstream>
 #include <stdexcept>

--- a/common/symbolic_formula.cc
+++ b/common/symbolic_formula.cc
@@ -1,8 +1,8 @@
 // NOLINTNEXTLINE(build/include): Its header file is included in symbolic.h.
 #include <cstddef>
-#include <iostream>
 #include <limits>
 #include <memory>
+#include <ostream>
 #include <set>
 #include <sstream>
 

--- a/common/symbolic_formula_cell.cc
+++ b/common/symbolic_formula_cell.cc
@@ -3,8 +3,8 @@
 #undef DRAKE_COMMON_SYMBOLIC_DETAIL_HEADER
 
 #include <algorithm>
-#include <iostream>
 #include <memory>
+#include <ostream>
 #include <set>
 #include <sstream>
 #include <stdexcept>

--- a/common/symbolic_variable.cc
+++ b/common/symbolic_variable.cc
@@ -1,7 +1,7 @@
 // NOLINTNEXTLINE(build/include): Its header file is included in symbolic.h.
 #include <atomic>
-#include <iostream>
 #include <memory>
+#include <ostream>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/examples/acrobot/run_lqr_w_estimator.cc
+++ b/examples/acrobot/run_lqr_w_estimator.cc
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <iostream>
 #include <memory>
 
 #include <gflags/gflags.h>

--- a/examples/allegro_hand/joint_control/run_twisting_mug.cc
+++ b/examples/allegro_hand/joint_control/run_twisting_mug.cc
@@ -10,6 +10,8 @@
 /// has finished the current motion, either by reaching the target position or
 /// get stuck by collisions.
 
+#include <iostream>
+
 #include "lcm/lcm-cpp.hpp"
 #include <Eigen/Dense>
 #include <gflags/gflags.h>

--- a/examples/cubic_polynomial/backward_reachability.cc
+++ b/examples/cubic_polynomial/backward_reachability.cc
@@ -8,7 +8,7 @@
 //
 // TODO(jadecastro) Transcribe this example into Python.
 #include <cmath>
-#include <ostream>
+#include <iostream>
 
 #include "drake/common/proto/call_python.h"
 #include "drake/common/symbolic.h"

--- a/examples/cubic_polynomial/region_of_attraction.cc
+++ b/examples/cubic_polynomial/region_of_attraction.cc
@@ -8,7 +8,7 @@
 // example.
 
 #include <cmath>
-#include <ostream>
+#include <iostream>
 
 #include "drake/common/symbolic.h"
 #include "drake/common/unused.h"

--- a/examples/manipulation_station/manipulation_station_hardware_interface.cc
+++ b/examples/manipulation_station/manipulation_station_hardware_interface.cc
@@ -1,5 +1,6 @@
 #include "drake/examples/manipulation_station/manipulation_station_hardware_interface.h"
 
+#include <iostream>
 #include <utility>
 
 #include "drake/common/find_resource.h"

--- a/examples/manipulation_station/proof_of_life.cc
+++ b/examples/manipulation_station/proof_of_life.cc
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include <gflags/gflags.h>
 
 #include "drake/common/eigen_types.h"

--- a/examples/multibody/inclined_plane_with_body/inclined_plane_with_body.cc
+++ b/examples/multibody/inclined_plane_with_body/inclined_plane_with_body.cc
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <memory>
 
 #include <gflags/gflags.h>

--- a/examples/rod2d/rod2d_sim.cc
+++ b/examples/rod2d/rod2d_sim.cc
@@ -1,5 +1,6 @@
 #include <cmath>
 #include <iomanip>
+#include <iostream>
 #include <limits>
 #include <memory>
 

--- a/geometry/benchmarking/mesh_intersection_benchmark.cc
+++ b/geometry/benchmarking/mesh_intersection_benchmark.cc
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include "fmt/format.h"
 #include <benchmark/benchmark.h>
 

--- a/geometry/benchmarking/render_benchmark.cc
+++ b/geometry/benchmarking/render_benchmark.cc
@@ -1,5 +1,7 @@
 #include <unistd.h>
 
+#include <iostream>
+
 #include "fmt/format.h"
 #include <benchmark/benchmark.h>
 #include <gflags/gflags.h>

--- a/geometry/geometry_roles.h
+++ b/geometry/geometry_roles.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <iostream>
+#include <ostream>
 #include <string>
 
 #include "drake/common/drake_copyable.h"

--- a/geometry/render/render_label.h
+++ b/geometry/render/render_label.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <cstdint>
-#include <iostream>
 #include <limits>
+#include <ostream>
 #include <string>
 
 #include "drake/common/drake_copyable.h"

--- a/geometry/render_gl/internal_shape_meshes.cc
+++ b/geometry/render_gl/internal_shape_meshes.cc
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <fstream>
-#include <iostream>
+#include <istream>
 #include <limits>
 #include <map>
 #include <string>

--- a/lcm/drake_lcm_log.cc
+++ b/lcm/drake_lcm_log.cc
@@ -1,7 +1,6 @@
 #include "drake/lcm/drake_lcm_log.h"
 
 #include <chrono>
-#include <iostream>
 #include <limits>
 #include <map>
 #include <stdexcept>

--- a/manipulation/planner/differential_inverse_kinematics.h
+++ b/manipulation/planner/differential_inverse_kinematics.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <iostream>
 #include <limits>
 #include <memory>
 #include <optional>
+#include <ostream>
 #include <stdexcept>
 #include <string>
 #include <utility>

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -2,9 +2,9 @@
 
 #include <algorithm>
 #include <cmath>
-#include <iostream>
 #include <limits>
 #include <memory>
+#include <ostream>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -2,8 +2,8 @@
 
 #include <algorithm>
 #include <exception>
-#include <iostream>
 #include <limits>
+#include <ostream>
 #include <string>
 
 #include "drake/common/default_scalars.h"

--- a/perception/point_cloud_flags.h
+++ b/perception/point_cloud_flags.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <iostream>
+#include <ostream>
 #include <stdexcept>
 #include <string>
 

--- a/solvers/common_solver_option.h
+++ b/solvers/common_solver_option.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <iostream>
+#include <ostream>
 
 namespace drake {
 namespace solvers {

--- a/solvers/fbstab/components/dense_residual.cc
+++ b/solvers/fbstab/components/dense_residual.cc
@@ -1,7 +1,6 @@
 #include "drake/solvers/fbstab/components/dense_residual.h"
 
 #include <cmath>
-#include <iostream>
 
 #include <Eigen/Dense>
 

--- a/solvers/fbstab/components/mpc_data.cc
+++ b/solvers/fbstab/components/mpc_data.cc
@@ -1,6 +1,5 @@
 #include "drake/solvers/fbstab/components/mpc_data.h"
 
-#include <iostream>
 #include <stdexcept>
 
 #include <Eigen/Dense>

--- a/solvers/fbstab/components/riccati_linear_solver.cc
+++ b/solvers/fbstab/components/riccati_linear_solver.cc
@@ -1,7 +1,6 @@
 #include "drake/solvers/fbstab/components/riccati_linear_solver.h"
 
 #include <cmath>
-#include <iostream>
 #include <stdexcept>
 
 #include <Eigen/Dense>

--- a/solvers/fbstab/fbstab_algorithm.h
+++ b/solvers/fbstab/fbstab_algorithm.h
@@ -6,7 +6,6 @@
 #include <cmath>
 #include <cstdio>
 #include <cstring>
-#include <iostream>
 #include <stdexcept>
 
 #include "drake/common/drake_assert.h"

--- a/solvers/integer_inequality_solver.cc
+++ b/solvers/integer_inequality_solver.cc
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <functional>
-#include <iostream>
 #include <vector>
 
 #include <Eigen/Dense>

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2,12 +2,12 @@
 
 #include <array>
 #include <cstddef>
-#include <iostream>
 #include <limits>
 #include <list>
 #include <map>
 #include <memory>
 #include <optional>
+#include <ostream>
 #include <set>
 #include <stdexcept>
 #include <string>

--- a/solvers/sdpa_free_format.cc
+++ b/solvers/sdpa_free_format.cc
@@ -13,6 +13,8 @@
 #include <Eigen/Sparse>
 #include <Eigen/SparseQR>
 
+#include "drake/common/text_logging.h"
+
 namespace drake {
 namespace solvers {
 namespace internal {
@@ -937,8 +939,8 @@ bool GenerateSdpaImpl(const std::vector<BlockInX>& X_blocks,
     }
 
   } else {
-    std::cout << "GenerateSDPA(): Cannot open the file " << file_name
-              << ".dat-s\n";
+    drake::log()->warn(
+        "GenerateSDPA(): Cannot open the file {}.dat-s", file_name);
     return false;
   }
   sdpa_file.close();

--- a/solvers/test/plot_feasible_rotation_matrices.cc
+++ b/solvers/test/plot_feasible_rotation_matrices.cc
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <limits>
 
 #include "drake/common/proto/call_python.h"

--- a/solvers/unrevised_lemke_solver.cc
+++ b/solvers/unrevised_lemke_solver.cc
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <cmath>
 #include <functional>
-#include <iostream>
 #include <limits>
 #include <memory>
 #include <sstream>

--- a/systems/lcm/lcm_subscriber_system.cc
+++ b/systems/lcm/lcm_subscriber_system.cc
@@ -1,7 +1,6 @@
 #include "drake/systems/lcm/lcm_subscriber_system.h"
 
 #include <functional>
-#include <iostream>
 #include <utility>
 
 #include "drake/common/drake_assert.h"

--- a/tools/install/libdrake/test/header_dependency_test.py
+++ b/tools/install/libdrake/test/header_dependency_test.py
@@ -40,6 +40,11 @@ class HeaderDependencyTest(unittest.TestCase):
             return True
         (target,) = match.groups()
 
+        # We specifically disallow this header. It pollutes downstream
+        # translation units with global initializers.
+        if target == 'iostream':
+            return False
+
         # Check for allowed patterns.
         for matcher in self._valid_filenames:
             if matcher.match(target):


### PR DESCRIPTION
The use of `<iostream>` induces global constructors in every translation unit to initialize `std::cout` and `std::cerr`. We shouldn't do that unless we're actually going to use `std::cout` or `std::cerr`.

Reference: https://en.cppreference.com/w/cpp/header/iostream

See also https://github.com/gazebosim/gz-math/pull/287.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17415)
<!-- Reviewable:end -->
