### PR TITLE
[solvers] Deprecate fbstab

### DIFF
--- a/solvers/fbstab/BUILD.bazel
+++ b/solvers/fbstab/BUILD.bazel
@@ -27,6 +27,7 @@ drake_cc_library(
         "fbstab_dense.cc",
     ],
     hdrs = ["fbstab_dense.h"],
+    copts = ["-Wno-cpp"],
     deps = [
         ":fbstab_algorithm",
         "//common:essential",
@@ -45,6 +46,7 @@ drake_cc_library(
         "fbstab_mpc.cc",
     ],
     hdrs = ["fbstab_mpc.h"],
+    copts = ["-Wno-cpp"],
     deps = [
         ":fbstab_algorithm",
         "//common:essential",
@@ -60,6 +62,7 @@ drake_cc_library(
 drake_cc_library(
     name = "fbstab_algorithm",
     hdrs = ["fbstab_algorithm.h"],
+    copts = ["-Wno-cpp"],
     deps = [
         "//common:essential",
     ],
@@ -72,6 +75,7 @@ drake_cc_library(
         "test/ocp_generator.cc",
     ],
     hdrs = ["test/ocp_generator.h"],
+    copts = ["-Wno-cpp"],
     deps = [
         ":fbstab_mpc",
         "//common:essential",
@@ -83,6 +87,7 @@ drake_cc_library(
 drake_cc_googletest(
     name = "dense_unit_tests",
     srcs = ["test/fbstab_dense_unit_tests.cc"],
+    copts = ["-Wno-cpp"],
     deps = [
         ":fbstab_dense",
         "@eigen",
@@ -92,6 +97,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "mpc_unit_tests",
     srcs = ["test/fbstab_mpc_unit_tests.cc"],
+    copts = ["-Wno-cpp"],
     deps = [
         ":fbstab_mpc",
         ":ocp_generator",

--- a/solvers/fbstab/fbstab_algorithm.h
+++ b/solvers/fbstab/fbstab_algorithm.h
@@ -11,6 +11,9 @@
 
 #include "drake/common/drake_assert.h"
 
+// NOLINTNEXTLINE
+#warning The Drake copy of fbstab is deprecated and will be removed on or after 2022-10-01. Users should migrate to the upstream repository at github.com/dliaomcp/fbstab instead.
+
 namespace drake {
 namespace solvers {
 namespace fbstab {


### PR DESCRIPTION
It is unused within Drake and has forked into a [different upstream](https://github.com/dliaomcp/fbstab) which is being actively maintained, unlike the Drake copy.

+@hongkai-dai for feature review, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17416)
<!-- Reviewable:end -->
