### PR TITLE
[solvers] Port MobyLCPSolver to drake logging

### DIFF
--- a/solvers/moby_lcp_solver.h
+++ b/solvers/moby_lcp_solver.h
@@ -3,12 +3,8 @@
 
 #pragma once
 
-#include <fstream>
 #include <limits>
-#include <string>
 #include <vector>
-
-#include <Eigen/SparseCore>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/solvers/mathematical_program.h"
@@ -74,7 +70,8 @@ class MobyLCPSolver final : public SolverBase {
   MobyLCPSolver();
   ~MobyLCPSolver() final;
 
-  void SetLoggingEnabled(bool enabled);
+  DRAKE_DEPRECATED("2022-10-01", "This function no longer has any effect.")
+  void SetLoggingEnabled(bool) {}
 
   /// Calculates the zero tolerance that the solver would compute if the user
   /// does not specify a tolerance.
@@ -293,12 +290,6 @@ class MobyLCPSolver final : public SolverBase {
   template <typename MatrixType, typename Scalar>
   void FinishLemkeSolution(const MatrixType& M, const VectorX<Scalar>& q,
                            const VectorX<Scalar>& x, VectorX<Scalar>* z) const;
-
-  // TODO(sammy-tri) replace this with a proper logging hookup
-  std::ostream& Log() const;
-
-  bool log_enabled_{false};
-  mutable std::ofstream null_stream_;
 
   // Records the number of pivoting operations used during the last solve.
   mutable unsigned pivots_{0};

--- a/solvers/test/moby_lcp_solver_test.cc
+++ b/solvers/test/moby_lcp_solver_test.cc
@@ -12,7 +12,6 @@ namespace solvers {
 namespace {
 
 const double epsilon = 1e-6;
-const bool verbose = false;
 
 /// Run all non-regularized solvers.  If @p expected_z is an empty
 /// vector, outputs will only be compared against each other.
@@ -20,7 +19,6 @@ template <typename Derived>
 void RunBasicLcp(const Eigen::MatrixBase<Derived>& M, const Eigen::VectorXd& q,
                  const Eigen::VectorXd& expected_z_in, bool expect_fast_pass) {
   MobyLCPSolver<double> l;
-  l.SetLoggingEnabled(verbose);
 
   Eigen::VectorXd expected_z = expected_z_in;
 
@@ -59,7 +57,6 @@ void RunRegularizedLcp(const Eigen::MatrixBase<Derived>& M,
                        const Eigen::VectorXd& expected_z_in,
                        bool expect_fast_pass) {
   MobyLCPSolver<double> l;
-  l.SetLoggingEnabled(verbose);
 
   Eigen::VectorXd expected_z = expected_z_in;
 
@@ -145,7 +142,6 @@ GTEST_TEST(testMobyLCP, testAutoDiffTrivial) {
 
   // Attempt to compute the solution using both "fast" and Lemke algorithms.
   MobyLCPSolver<Scalar> l;
-  l.SetLoggingEnabled(verbose);
   bool result = l.SolveLcpFast(M, q, &fast_z);
   EXPECT_TRUE(result);
   result = l.SolveLcpLemke(M, q, &lemke_z);
@@ -266,7 +262,6 @@ GTEST_TEST(testMobyLCP, testProblem4) {
   z << 1. / 90., 2. / 45., 1. / 90., 2. / 45.;
 
   MobyLCPSolver<double> l;
-  l.SetLoggingEnabled(verbose);
 
   Eigen::VectorXd fast_z;
   bool result = l.SolveLcpFast(M, q, &fast_z);
@@ -326,7 +321,6 @@ GTEST_TEST(testMobyLCP, testEmpty) {
   Eigen::VectorXd empty_q(0);
   Eigen::VectorXd z;
   MobyLCPSolver<double> l;
-  l.SetLoggingEnabled(verbose);
 
   bool result = l.SolveLcpFast(empty_M, empty_q, &z);
   EXPECT_TRUE(result);
@@ -356,7 +350,6 @@ GTEST_TEST(testMobyLCP, testFailure) {
   neg_q[0] = -1;
   Eigen::VectorXd z;
   MobyLCPSolver<double> l;
-  l.SetLoggingEnabled(verbose);
 
   bool result = l.SolveLcpFast(neg_M, neg_q, &z);
   EXPECT_FALSE(result);


### PR DESCRIPTION
Confirmed locally that `bazel-bin/solvers/moby_lcp_solver_test --spdlog_level=trace` displays a lot of stuff.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17418)
<!-- Reviewable:end -->
