### PR TITLE
Fix build error on Jammy

### DIFF
--- a/common/type_safe_index.h
+++ b/common/type_safe_index.h
@@ -2,6 +2,7 @@
 
 #include <functional>
 #include <limits>
+#include <stdexcept>
 #include <string>
 
 #include "drake/common/drake_assert.h"


### PR DESCRIPTION
Add missing `#include <stdexcept>` to `type_safe_index.h` (needed for `std::runtime_error`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17432)
<!-- Reviewable:end -->
