### PR TITLE
[pydrake] Hotfix for broken sensors_test on macOS

### DIFF
--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -203,7 +203,7 @@ class TestSensors(unittest.TestCase):
             self.assertEqual(info.center_x(), center_x)
             self.assertEqual(info.center_y(), center_y)
             self.assertIsInstance(info.fov_x(), float)
-            self.assertEqual(info.fov_y(), fov_y)
+            self.assertIsInstance(info.fov_y(), float)
             self.assertTrue(
                 (info.intrinsic_matrix() == intrinsic_matrix).all())
             assert_pickle(self, info, mut.CameraInfo.intrinsic_matrix)


### PR DESCRIPTION
Hotfix for for #17428.  Tested locally on macOS.

Here's the error from a build of `master`:

https://drake-jenkins.csail.mit.edu/view/Production/job/mac-monterey-clang-bazel-continuous-release/721/

```
[2022-06-21T19:41:42.403Z] ==================== Test output for //bindings/pydrake/systems:py/sensors_test:
[2022-06-21T19:41:42.403Z] 
[2022-06-21T19:41:42.403Z] Running tests...
[2022-06-21T19:41:42.403Z] ----------------------------------------------------------------------
[2022-06-21T19:41:42.403Z] F.....
[2022-06-21T19:41:42.403Z] ======================================================================
[2022-06-21T19:41:42.403Z] FAIL [0.004s]: test_camera_info (sensors_test.TestSensors)
[2022-06-21T19:41:42.403Z] ----------------------------------------------------------------------
[2022-06-21T19:41:42.403Z] Traceback (most recent call last):
[2022-06-21T19:41:42.403Z]   File "/Users/monterey/workspace/mac-monterey-clang-bazel-continuous-release/_bazel_monterey/943e38b51a7dbf0d1df21c404627d7b7/execroot/drake/bazel-out/darwin-opt/bin/bindings/pydrake/systems/py/sensors_test.runfiles/drake/bindings/pydrake/systems/test/sensors_test.py", line 206, in test_camera_info
[2022-06-21T19:41:42.403Z]     self.assertEqual(info.fov_y(), fov_y)
[2022-06-21T19:41:42.403Z] AssertionError: 0.7853981633974485 != 0.7853981633974483
[2022-06-21T19:41:42.403Z] 
[2022-06-21T19:41:42.403Z] ----------------------------------------------------------------------
[2022-06-21T19:41:42.403Z] Ran 6 tests in 0.136s
[2022-06-21T19:41:42.403Z] 
[2022-06-21T19:41:42.403Z] FAILED (failures=1)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17434)
<!-- Reviewable:end -->
