### PR TITLE
[manipulation_station] Remove planar_scenegraph_visualizer

### DIFF
--- a/examples/manipulation_station/end_effector_teleop_sliders.py
+++ b/examples/manipulation_station/end_effector_teleop_sliders.py
@@ -27,8 +27,6 @@ from pydrake.systems.framework import (DiagramBuilder, LeafSystem,
 from pydrake.systems.lcm import LcmPublisherSystem
 from pydrake.systems.primitives import FirstOrderLowPassFilter, VectorLogSink
 from pydrake.systems.sensors import ImageToLcmImageArrayT, PixelType
-from pydrake.systems.planar_scenegraph_visualizer import \
-    ConnectPlanarSceneGraphVisualizer
 
 from drake.examples.manipulation_station.differential_ik import DifferentialIK
 from drake.examples.manipulation_station.schunk_wsg_buttons import \
@@ -241,8 +239,6 @@ def main():
         # Configure the planar visualization.
         if args.setup == 'planar':
             meshcat.Set2dRenderMode()
-            ConnectPlanarSceneGraphVisualizer(
-                builder, station.get_scene_graph(), geometry_query_port)
 
         # Connect and publish to drake visualizer.
         DrakeVisualizer.AddToBuilder(builder, geometry_query_port)

--- a/examples/manipulation_station/joint_teleop.py
+++ b/examples/manipulation_station/joint_teleop.py
@@ -23,8 +23,6 @@ from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.analysis import Simulator
 from pydrake.geometry import Meshcat, MeshcatVisualizerCpp
 from pydrake.systems.primitives import FirstOrderLowPassFilter, VectorLogSink
-from pydrake.systems.planar_scenegraph_visualizer import \
-    ConnectPlanarSceneGraphVisualizer
 
 
 def main():
@@ -102,8 +100,6 @@ def main():
 
         if args.setup == 'planar':
             meshcat.Set2dRenderMode()
-            pyplot_visualizer = ConnectPlanarSceneGraphVisualizer(
-                builder, station.get_scene_graph(), geometry_query_port)
 
     if args.browser_new is not None:
         url = meshcat.web_url()


### PR DESCRIPTION
The existing Meshcat display (using Set2dRenderMode) already fully covers this use case. There's no need to pop up extra windows.

Towards #14702. See #17438 for the big picture.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17436)
<!-- Reviewable:end -->
