### PR TITLE
[lcm] Remove build-time transitive dependency on LCM headers

### DIFF
--- a/lcm/BUILD.bazel
+++ b/lcm/BUILD.bazel
@@ -62,10 +62,12 @@ drake_cc_library(
     name = "drake_lcm",
     srcs = ["drake_lcm.cc"],
     hdrs = ["drake_lcm.h"],
-    deps = [
+    interface_deps = [
         ":drake_lcm_params",
         ":interface",
         "//common:essential",
+    ],
+    deps = [
         "//common:scope_exit",
         "@glib",
         "@lcm",
@@ -76,9 +78,11 @@ drake_cc_library(
     name = "lcm_log",
     srcs = ["drake_lcm_log.cc"],
     hdrs = ["drake_lcm_log.h"],
-    deps = [
+    interface_deps = [
         ":interface",
         "//common:essential",
+    ],
+    deps = [
         "@lcm",
     ],
 )
@@ -122,6 +126,7 @@ drake_cc_googletest(
         ":drake_lcm",
         ":lcmt_drake_signal_utils",
         "//common/test_utilities:expect_throws_message",
+        "@lcm",
     ],
 )
 
@@ -131,6 +136,7 @@ drake_cc_googletest(
     deps = [
         ":drake_lcm",
         ":lcmt_drake_signal_utils",
+        "@lcm",
     ],
 )
 

--- a/lcm/drake_lcm.cc
+++ b/lcm/drake_lcm.cc
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include <glib.h>
+#include <lcm/lcm-cpp.hpp>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"

--- a/lcm/drake_lcm.h
+++ b/lcm/drake_lcm.h
@@ -4,12 +4,19 @@
 #include <optional>
 #include <string>
 
-#include "lcm/lcm-cpp.hpp"
-
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/lcm/drake_lcm_params.h"
+
+#ifndef DRAKE_DOXYGEN_CXX
+namespace lcm {
+// We don't want to pollute our Drake headers with the include paths for either
+// @lcm or @glib, so we forward-declare the `class ::lcm::LCM` for use only by
+// DrakeLcm::get_lcm_instance() -- an advanced function that is rarely used.
+class LCM;
+}  // namespace lcm
+#endif
 
 namespace drake {
 namespace lcm {

--- a/tools/install/libdrake/header_lint.bzl
+++ b/tools/install/libdrake/header_lint.bzl
@@ -16,7 +16,6 @@ _ALLOWED_EXTERNALS = [
     "spdlog",
 
     # The entries that follow are defects; we should work to remove them.
-    "glib",
     "zlib",
 ]
 

--- a/tools/install/libdrake/test/header_dependency_test.py
+++ b/tools/install/libdrake/test/header_dependency_test.py
@@ -24,7 +24,6 @@ class HeaderDependencyTest(unittest.TestCase):
         re_thirds = [
             re.compile(r'^(Eigen|unsupported/Eigen)/.*$'),
             re.compile(r'^(fmt|spdlog)/.*$'),
-            re.compile(r'^lcm/.*$'),
             re.compile(r'^optitrack/.*$'),
         ]
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17442)
<!-- Reviewable:end -->
