### PR TITLE
Fix meshcat_websocket_client.py on Jammy

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -497,6 +497,7 @@ drake_py_binary(
     testonly = True,
     srcs = ["test/meshcat_websocket_client.py"],
     visibility = ["//visibility:private"],
+    deps = ["@u_msgpack_python_internal//:u_msgpack_python"],
 )
 
 drake_cc_googletest(

--- a/setup/mac/binary_distribution/requirements.txt
+++ b/setup/mac/binary_distribution/requirements.txt
@@ -7,4 +7,3 @@ pydot
 PyYAML
 pyzmq
 tornado
-u-msgpack-python

--- a/setup/ubuntu/binary_distribution/packages-focal.txt
+++ b/setup/ubuntu/binary_distribution/packages-focal.txt
@@ -60,7 +60,6 @@ python3-pygame
 python3-scipy
 python3-tk
 python3-tornado
-python3-u-msgpack
 python3-yaml
 python3-zmq
 zlib1g

--- a/setup/ubuntu/binary_distribution/packages-jammy.txt
+++ b/setup/ubuntu/binary_distribution/packages-jammy.txt
@@ -60,7 +60,6 @@ python3-pygame
 python3-scipy
 python3-tk
 python3-tornado
-python3-u-msgpack
 python3-yaml
 python3-zmq
 zlib1g

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -89,6 +89,7 @@ load("@drake//tools/workspace/styleguide:repository.bzl", "styleguide_repository
 load("@drake//tools/workspace/suitesparse:repository.bzl", "suitesparse_repository")  # noqa
 load("@drake//tools/workspace/tinyobjloader:repository.bzl", "tinyobjloader_repository")  # noqa
 load("@drake//tools/workspace/tinyxml2:repository.bzl", "tinyxml2_repository")
+load("@drake//tools/workspace/u_msgpack_python_internal:repository.bzl", "u_msgpack_python_internal_repository")  # noqa
 load("@drake//tools/workspace/uritemplate_py_internal:repository.bzl", "uritemplate_py_internal_repository")  # noqa
 load("@drake//tools/workspace/usockets:repository.bzl", "usockets_repository")  # noqa
 load("@drake//tools/workspace/uwebsockets:repository.bzl", "uwebsockets_repository")  # noqa
@@ -343,6 +344,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         tinyobjloader_repository(name = "tinyobjloader", mirrors = mirrors)
     if "tinyxml2" not in excludes:
         tinyxml2_repository(name = "tinyxml2")
+    if "u_msgpack_python_internal" not in excludes:
+        u_msgpack_python_internal_repository(name = "u_msgpack_python_internal", mirrors = mirrors)  # noqa
     if "uritemplate_py" not in excludes:
         add_deprecation(
             name = "uritemplate_py",

--- a/tools/workspace/meshcat_python/BUILD.bazel
+++ b/tools/workspace/meshcat_python/BUILD.bazel
@@ -63,7 +63,10 @@ drake_py_unittest(
     name = "meshcat_server_test",
     args = ["$(location {})".format(_SERVER)],
     legacy_create_init = 0,
-    deps = [_SERVER],
+    deps = [
+        _SERVER,
+        "@u_msgpack_python_internal//:u_msgpack_python",
+    ],
 )
 
 add_lint_tests(

--- a/tools/workspace/meshcat_python/package.BUILD.bazel
+++ b/tools/workspace/meshcat_python/package.BUILD.bazel
@@ -24,6 +24,7 @@ py_library(
     ]),
     imports = ["src"],
     visibility = ["@drake//:__subpackages__"],
+    deps = ["@u_msgpack_python_internal//:u_msgpack_python"],
 )
 
 py_binary(

--- a/tools/workspace/u_msgpack_python_internal/BUILD.bazel
+++ b/tools/workspace/u_msgpack_python_internal/BUILD.bazel
@@ -1,0 +1,5 @@
+# -*- python -*-
+
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/workspace/u_msgpack_python_internal/package.BUILD.bazel
+++ b/tools/workspace/u_msgpack_python_internal/package.BUILD.bazel
@@ -1,0 +1,14 @@
+# -*- python -*-
+
+load("@drake//tools/skylark:py.bzl", "py_library")
+
+licenses(["notice"])  # BSD-3-Clause
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "u_msgpack_python",
+    srcs = ["umsgpack.py"],
+)

--- a/tools/workspace/u_msgpack_python_internal/repository.bzl
+++ b/tools/workspace/u_msgpack_python_internal/repository.bzl
@@ -1,0 +1,15 @@
+# -*- python -*-
+
+load("@drake//tools/workspace:github.bzl", "github_archive")
+
+def u_msgpack_python_internal_repository(
+        name,
+        mirrors = None):
+    github_archive(
+        name = name,
+        repository = "vsergeev/u-msgpack-python",
+        commit = "v2.7.1",
+        sha256 = "3cfb5a8fb0d784522c88cea2473b6f879f004118d23cdef29660d34a983d7c87",  # noqa
+        build_file = "@drake//tools/workspace/u_msgpack_python_internal:package.BUILD.bazel",  # noqa
+        mirrors = mirrors,
+    )


### PR DESCRIPTION
On Jammy, both `python3-u-msgpack` and `python3-websockets` (used only by `meshcat_websocket_client.py`, which in turn is only used by a meshcat test) are old versions which are not compatible with Python 3.10. As a result, `//geometry:meshcat_test` cannot succeed on Jammy.

Work around `u-msgpack-python` by vendoring our own, more recent version. As this is not very practical for `websockets`, work around that by monkey-patching `asyncio` in order to avoid the older version's use of deprecated API which causes Python 3.10 to otherwise raise exceptions.

See also:
https://bugs.launchpad.net/ubuntu/+source/python-websockets/+bug/1969902
https://bugs.launchpad.net/ubuntu/+source/u-msgpack-python/+bug/1979549

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17443)
<!-- Reviewable:end -->
