### PR TITLE
[doc] Improve documentation on Drake units

### DIFF
--- a/multibody/multibody_doxygen.h
+++ b/multibody/multibody_doxygen.h
@@ -405,6 +405,30 @@ vset_E     | vlist_E      |  Set of generic vectors v = {v₀,  v₁,  v₂} exp
 mesh_B                    || A mesh whose underlying vertices' positions are from Bo (frame B's origin), expressed in frame B
 point_cloud_B             || A point cloud whose underlying points' positions are from Bo (frame B's origin), expressed in frame B
 
+ Next topic: @ref multibody_quantities_units
+*/
+
+//------------------------------------------------------------------------------
+/** @defgroup multibody_quantities_units Units of Multibody Quantities
+ @ingroup multibody_notation
+
+ Drake uses
+ <a href="https://en.wikipedia.org/wiki/International_System_of_Units">
+ SI units</a> by default (also known as MKS -- meters, kilograms, and
+ seconds). Attempts to scale to different units may be fraught with
+ difficulties (for example, the
+ @ref drake::multibody::UniformGravityFieldElement::kDefaultStrength
+ "default gravity" is given as 9.81 m/s²). You will be best served if you stick
+ with SI.
+
+ Rotations may be radians or degrees, as documented for the relevant API.
+
+ The @ref drake::multibody::Parser "Parser class" documents how quantity units
+ are handled for external configuration files. The <a
+ href="https://github.com/RobotLocomotion/drake/blob/master/multibody/parsing/README_model_directives.md">
+ model directives</a> specification language likewise makes use of SI plus
+ radians in interpreting quantities.
+
  Next topic: @ref Dt_multibody_quantities
 */
 

--- a/multibody/parsing/README_model_directives.md
+++ b/multibody/parsing/README_model_directives.md
@@ -81,6 +81,9 @@ Thus:
 - `top_level::my_model::my_frame`: The model instance is
   `top_level::my_model`, the frame is `my_frame`.
 
+## Units
+
+We use SI units plus radians for all physical quantities.
 
 ## Conditions for deprecation
 

--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -18,6 +18,11 @@ class CompositeParse;
 /// Parses SDF and URDF input files into a MultibodyPlant and (optionally) a
 /// SceneGraph. For documentation of Drake-specific extensions and limitations,
 /// see @ref multibody_parsing.
+///
+/// When parsing literal quantities, %Parser assumes SI units and radians in the
+/// absence of units specified by the format itself. This includes the literals
+/// in the specified files (URDF or SDFormat) as well as referenced files such
+/// as OBJ or other data files.
 class Parser final {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Parser)


### PR DESCRIPTION
1. Expand multibody quantities documentation to be explicit about units.
2. Cross reference to `Parser` and `ModelDirectives` with similar notes.