### PR TITLE
[parsing] Add ProcessModelDirectives overload for simplicity

### DIFF
--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -117,17 +117,23 @@ PYBIND11_MODULE(parsing, m) {
         .def_readonly("X_PF", &Class::X_PF, cls_doc.X_PF.doc);
   }
 
+  m.def("ProcessModelDirectives",
+      py::overload_cast<const parsing::ModelDirectives&, Parser*>(
+          &parsing::ProcessModelDirectives),
+      py::arg("directives"), py::arg("parser"),
+      doc.parsing.ProcessModelDirectives.doc_2args);
+
   m.def(
       "ProcessModelDirectives",
       [](const parsing::ModelDirectives& directives,
-          MultibodyPlant<double>* plant, Parser* parser = nullptr) {
+          MultibodyPlant<double>* plant, Parser* parser) {
         std::vector<parsing::ModelInstanceInfo> added_models;
         parsing::ProcessModelDirectives(
             directives, plant, &added_models, parser);
         return added_models;
       },
-      py::arg("directives"), py::arg("plant"), py::arg("parser"),
-      doc.parsing.ProcessModelDirectives.doc);
+      py::arg("directives"), py::arg("plant"), py::arg("parser") = nullptr,
+      doc.parsing.ProcessModelDirectives.doc_4args);
 
   m.def("GetScopedFrameByName", &parsing::GetScopedFrameByName,
       py::arg("plant"), py::arg("full_name"),

--- a/bindings/pydrake/multibody/test/parsing_test.py
+++ b/bindings/pydrake/multibody/test/parsing_test.py
@@ -117,7 +117,27 @@ class TestParsing(unittest.TestCase):
         match = re.match(pattern, message)
         self.assertTrue(match, f'"{message}" does not match "{pattern}"')
 
-    def test_model_directives(self):
+    def test_model_instance_info(self):
+        """Checks that ModelInstanceInfo bindings exist."""
+        ModelInstanceInfo.model_name
+        ModelInstanceInfo.model_path
+        ModelInstanceInfo.parent_frame_name
+        ModelInstanceInfo.child_frame_name
+        ModelInstanceInfo.X_PC
+        ModelInstanceInfo.model_instance
+
+    def test_add_frame(self):
+        """Checks that AddFrame bindings exist."""
+        AddFrame.name
+        AddFrame.X_PF
+
+    def test_scoped_frame_names(self):
+        plant = MultibodyPlant(time_step=0.01)
+        frame = GetScopedFrameByName(plant, "world")
+        self.assertIsNotNone(GetScopedFrameName(plant, frame))
+
+    def _make_plant_parser_directives(self):
+        """Returns a tuple (plant, parser, directives) for later testing."""
         model_dir = os.path.dirname(FindResourceOrThrow(
             "drake/multibody/parsing/test/"
             "process_model_directives_test/package.xml"))
@@ -126,20 +146,22 @@ class TestParsing(unittest.TestCase):
         parser.package_map().PopulateFromFolder(model_dir)
         directives_file = model_dir + "/add_scoped_top.yaml"
         directives = LoadModelDirectives(directives_file)
+        return (plant, parser, directives)
+
+    def test_process_model_directives(self):
+        """Check the Process... overload using a Parser."""
+        (plant, parser, directives) = self._make_plant_parser_directives()
         added_models = ProcessModelDirectives(
-            directives=directives, plant=plant, parser=parser)
-        # Check for an instance.
+            directives=directives, parser=parser)
         model_names = [model.model_name for model in added_models]
         self.assertIn("extra_model", model_names)
         plant.GetModelInstanceByName("extra_model")
-        # Test that other bound symbols exist.
-        ModelInstanceInfo.model_name
-        ModelInstanceInfo.model_path
-        ModelInstanceInfo.parent_frame_name
-        ModelInstanceInfo.child_frame_name
-        ModelInstanceInfo.X_PC
-        ModelInstanceInfo.model_instance
-        AddFrame.name
-        AddFrame.X_PF
-        frame = GetScopedFrameByName(plant, "world")
-        self.assertIsNotNone(GetScopedFrameName(plant, frame))
+
+    def test_process_model_directives_dispreferred(self):
+        """Check the Process... overload that also passes a MbP."""
+        (plant, parser, directives) = self._make_plant_parser_directives()
+        added_models = ProcessModelDirectives(
+            directives=directives, plant=plant, parser=parser)
+        model_names = [model.model_name for model in added_models]
+        self.assertIn("extra_model", model_names)
+        plant.GetModelInstanceByName("extra_model")

--- a/multibody/parsing/process_model_directives.cc
+++ b/multibody/parsing/process_model_directives.cc
@@ -239,6 +239,15 @@ void ProcessModelDirectives(
                              composite.get(), model_namespace);
 }
 
+std::vector<ModelInstanceInfo> ProcessModelDirectives(
+    const ModelDirectives& directives,
+    drake::multibody::Parser* parser) {
+  DRAKE_THROW_UNLESS(parser != nullptr);
+  std::vector<ModelInstanceInfo> added_models;
+  ProcessModelDirectives(directives, &parser->plant(), &added_models, parser);
+  return added_models;
+}
+
 ModelDirectives LoadModelDirectives(const std::string& filename) {
   drake::log()->debug("LoadModelDirectives: {}", filename);
 

--- a/multibody/parsing/process_model_directives.h
+++ b/multibody/parsing/process_model_directives.h
@@ -49,6 +49,14 @@ void FlattenModelDirectives(const ModelDirectives& directives,
                             const drake::multibody::PackageMap& package_map,
                             ModelDirectives* out);
 
+/// Parses the given model directives using the given parser.
+/// The MultibodyPlant (and optionally SceneGraph) being modified are
+/// implicitly associated with the Parser object.
+/// Returns the list of added models.
+std::vector<ModelInstanceInfo> ProcessModelDirectives(
+    const ModelDirectives& directives,
+    drake::multibody::Parser* parser);
+
 /// Processes model directives for a given MultibodyPlant.
 void ProcessModelDirectives(
     const ModelDirectives& directives,

--- a/multibody/parsing/test/process_model_directives_test.cc
+++ b/multibody/parsing/test/process_model_directives_test.cc
@@ -92,6 +92,25 @@ GTEST_TEST(ProcessModelDirectivesTest, BasicSmokeTest) {
   EXPECT_TRUE(plant.HasFrameNamed("sub_added_frame_explicit"));
 }
 
+// Simple smoke test of the simpler function signature.
+GTEST_TEST(ProcessModelDirectivesTest, SugarSmokeTest) {
+  const ModelDirectives station_directives = LoadModelDirectives(
+      FindResourceOrThrow(std::string(kTestDir) + "/add_scoped_sub.yaml"));
+
+  MultibodyPlant<double> plant(0.0);
+  std::vector<ModelInstanceInfo> added_models =
+      ProcessModelDirectives(station_directives, make_parser(&plant).get());
+  plant.Finalize();
+
+  // Check that the directives were loaded.
+  EXPECT_TRUE(plant.HasFrameNamed("sub_added_frame"));
+
+  // Check that the added models were returned.
+  ASSERT_EQ(added_models.size(), 2);
+  EXPECT_EQ(added_models[0].model_name, "simple_model");
+  EXPECT_EQ(added_models[1].model_name, "extra_model");
+}
+
 // Acceptance tests for the ModelDirectives name scoping, including acceptance
 // testing its interaction with SceneGraph.
 GTEST_TEST(ProcessModelDirectivesTest, AddScopedSmokeTest) {


### PR DESCRIPTION
There's no need to pass a MultibodyPlant when we already have a Parser.
There's no need to use an output argument instead of a return value.

For sample use cases, see Anzu PR 9070.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17450)
<!-- Reviewable:end -->
