### PR TITLE
[jupyter] Customize ExecutePreprocessor to fix ipywidget tests

### DIFF
--- a/tools/jupyter/jupyter_bazel.py
+++ b/tools/jupyter/jupyter_bazel.py
@@ -25,9 +25,12 @@ class _ExecutePreprocessorNoWidgets(ExecutePreprocessor):
 
     def preprocess_cell(self, *args, **kwargs):
         # Turn off some broken ipywidgets hooks.
-        self.comm_open_handlers.clear()
+        try:
+            self.comm_open_handlers.clear()
+        except AttributeError:
+            pass
         # Then, continue as usual.
-        super().preprocess_cell(*args, **kwargs)
+        return super().preprocess_cell(*args, **kwargs)
 
 
 def _jupyter_bazel_notebook_main(notebook_path, argv):

--- a/tools/jupyter/jupyter_bazel.py
+++ b/tools/jupyter/jupyter_bazel.py
@@ -18,6 +18,18 @@ For Drake developers:
 """
 
 
+class _ExecutePreprocessorNoWidgets(ExecutePreprocessor):
+    """Customizes ExecutePreprocessor so that ipywidgets works on Ubuntu 22.
+    See https://github.com/RobotLocomotion/drake/issues/17433.
+    """
+
+    def preprocess_cell(self, *args, **kwargs):
+        # Turn off some broken ipywidgets hooks.
+        self.comm_open_handlers.clear()
+        # Then, continue as usual.
+        super().preprocess_cell(*args, **kwargs)
+
+
 def _jupyter_bazel_notebook_main(notebook_path, argv):
     # This should *ONLY* be called by targets generated via `jupyter_py_*`
     # rules.
@@ -56,7 +68,7 @@ def _jupyter_bazel_notebook_main(notebook_path, argv):
         os.environ["_DRAKE_DEPRECATION_IS_ERROR"] = "1"
         # TODO(eric.cousineau): See if there is a way to redirect this to
         # stdout, rather than having the notebook capture the output.
-        ep = ExecutePreprocessor(timeout=600, kernel_name='python3')
+        ep = _ExecutePreprocessorNoWidgets(timeout=600, kernel_name='python3')
         try:
             ep.preprocess(nb, resources={'metadata': {'path': notebook_dir}})
         except RuntimeError as e:


### PR DESCRIPTION
Something odd is happening with ipywidgets on Ubuntu 22.
I have no idea what's going on, but this gets us passing CI.

Closes #17433.

This curtails the widget message processing just prior to hitting this line in the #17433 backtrace.

```
  File "/usr/lib/python3/dist-packages/nbclient/client.py", line 917, in process_message
    self.handle_comm_msg(cell.outputs, msg, cell_index)
```

https://github.com/jupyter/nbclient/blob/12c7f0492beb9306192b609fbdab67bbac2e2b4b/nbclient/client.py#L459-L461

The commits here will be squashed, not merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17451)
<!-- Reviewable:end -->
