### PR TITLE
Clarify `channel_suffix` semantics for `SubscribeAllChannels`

### DIFF
--- a/lcm/drake_lcm_params.h
+++ b/lcm/drake_lcm_params.h
@@ -23,8 +23,8 @@ struct DrakeLcmParams {
   When provided, calls to DrakeLcm::Publish() or DrakeLcm::Subscribe() will
   append this string to the `channel` name requested for publish or subscribe.
 
-  This has no effect on DrakeLcm::SubscribeAllChannels(); the channel names
-  reported there will remain unmodified.
+  The callback of DrakeLcm::SubscribeAllChannels() will receive the "fully
+  qualified" channel name including this suffix.
   */
   std::string channel_suffix;
 

--- a/lcm/test/drake_lcm_test.cc
+++ b/lcm/test/drake_lcm_test.cc
@@ -382,6 +382,26 @@ TEST_F(DrakeLcmTest, Suffix) {
   });
 }
 
+// Tests the channel name suffix feature.
+TEST_F(DrakeLcmTest, SuffixInSubscribeAllChannels) {
+  DrakeLcmParams params;
+  params.channel_suffix = "_SUFFIX";
+  dut_ = std::make_unique<DrakeLcm>(params);
+
+  // SubscribeAll using Drake LCM, expecting to see the fully qualified
+  // channel name.
+  lcmt_drake_signal received_drake{};
+  auto subscription = dut_->SubscribeAllChannels([&received_drake](
+      std::string_view channel_name, const void* data, int size) {
+    EXPECT_EQ(channel_name, "SuffixDrakeLcmTest_SUFFIX");
+    received_drake.decode(data, 0, size);
+  });
+  LoopUntilDone(&received_drake, 20 /* retries */, [&]() {
+    Publish(dut_.get(), "SuffixDrakeLcmTest", message_);
+    dut_->HandleSubscriptions(50 /* millis */);
+  });
+}
+
 }  // namespace
 }  // namespace lcm
 }  // namespace drake


### PR DESCRIPTION
* The previous documentation said the channel name is "unchanged"
  but this could mean either "unchanged by the suffix mechanism"
  or "unchanged from its suffixed form".
* Clarify that the callback does receive the suffix.
* Nail this down with a test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17455)
<!-- Reviewable:end -->
