### PR TITLE
[doc] Update from_binary to use venv not virtualenv

### DIFF
--- a/doc/_pages/from_binary.md
+++ b/doc/_pages/from_binary.md
@@ -61,7 +61,7 @@ Create and activate the envionment:
 ```bash
 mkdir -p env
 tar -xvzf drake.tar.gz -C env --strip-components=1
-python3 -m virtualenv -p python3 env --system-site-packages
+python3 -m venv env --system-site-packages
 source env/bin/activate
 ```
 


### PR DESCRIPTION
This matches what our pip instructions suggest, and seems like it's the preferred way for Python 3.

The original `-m virtualenv` documentation was per #10512 circa 2019 using Python 2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17469)
<!-- Reviewable:end -->
