### PR TITLE
[multibody] Provide more feedback when MbP query object port is unconnected

### DIFF
--- a/doc/_pages/trouble_shooting.md
+++ b/doc/_pages/trouble_shooting.md
@@ -1,0 +1,40 @@
+---
+title: Troubleshooting common problems
+---
+
+This page contains a collection of tips and tricks for resolving common
+problems.
+
+# MultibodyPlant
+
+## Exception messages
+
+### Unconnected QueryObject port {#mbp-unconnected-query-object-port}
+
+The error message will include the message, "The provided context doesn't show a connection for the plant's query input port."
+
+MultibodyPlant requires a connection to SceneGraph in order to evaluate contact.
+Attempts to evaluate output ports which expose or depend on contact results
+will fail. Evaluating the time derivatives (e.g., when running a continuous
+simulation) will likewise fail.
+
+The connection can be reported as missing for several reasons:
+
+1. Was a [SceneGraph](https://drake.mit.edu/doxygen_cxx/classdrake_1_1geometry_1_1_scene_graph.html) instance created and connected?
+   - The simplest solution is to use [AddMultibodyPlantSceneGraph()](https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_multibody_plant.html#aac66563a5f3eb9e2041bd4fa8d438827). It will instantiate the plant and
+   scene_graph together and also connect them for you.
+2. Did you provide the right context?
+   - You've created and connected the systems in a Diagram and allocated a
+     Context for the Diagram.
+   - Make sure you extract the MultibodyPlant's context from the Diagram's
+     Context. Do not allocate a Context directly from the plant. Use
+     [GetMyContextFromRoot()](https://drake.mit.edu/doxygen_cxx/classdrake_1_1systems_1_1_system.html#ae7fa91d2b2102457ced3361207724e52)
+     to acquire the plant's Context from the Diagram's context; this will
+     preserve all of the necessary connections. E.g.,
+
+```c++
+  MultibodyPlant<double>* plant = ...;
+  std::unique_ptr<Diagram<double>> diagram = builder.Build();
+  std::unique_ptr<Context<double>> context = diagram->CreateDefaultContext();
+  Context<double>& plant_context = plant->GetMyContextFromRoot(*context);
+```

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -476,6 +476,16 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "multibody_plant_query_object_connect_test",
+    deps = [
+        ":plant",
+        "//common/test_utilities:expect_throws_message",
+        "//multibody/parsing",
+        "@fmt",
+    ],
+)
+
+drake_cc_googletest(
     name = "multibody_plant_symbolic_test",
     deps = [
         ":plant",

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -927,12 +927,10 @@ const geometry::QueryObject<T>& MultibodyPlant<T>::EvalGeometryQueryInput(
   this->ValidateContext(context);
   if (!get_geometry_query_input_port().HasValue(context)) {
     throw std::logic_error(
-        "The geometry query input port (see "
-        "MultibodyPlant::get_geometry_query_input_port()) "
-        "of this MultibodyPlant is not connected. Please connect the"
-        "geometry query output port of a SceneGraph object "
-        "(see SceneGraph::get_query_output_port()) to this plants input "
-        "port in a Diagram.");
+        "The provided context doesn't show a connection for the plant's "
+        "query input port (see MultibodyPlant::get_geometry_query_input_port())"
+        ". See https://drake.mit.edu/trouble_shooting.html"
+        "#mbp-unconnected-query-object-port for help.");
   }
   return get_geometry_query_input_port()
       .template Eval<geometry::QueryObject<T>>(context);

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -4168,8 +4168,17 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // Consolidates calls to Eval on the geometry query input port to have a
   // consistent and helpful error message in the situation where the
   // geometry_query_input_port is not connected, but is expected to be.
+  // Explanation provides some text to add to the error message explaining why
+  // the input port was being evaluated.
+  //
+  // Any public API that can ultimately depend on the QueryObject input port
+  // should invoke this method immediately, with an appropriate "explanation"
+  // of the invocation. This act of "priming" QueryObject will allow us to
+  // inform users of error conditions as close to their act as possible. For
+  // example, see the implementations of CopyContactResultsOutput() and ...
   const geometry::QueryObject<T>& EvalGeometryQueryInput(
-      const systems::Context<T>& context) const;
+      const systems::Context<T>& context,
+      std::string_view explanation) const;
 
   // Helper to acquire per-geometry contact parameters from SG.
   // Returns the pair (stiffness, dissipation)

--- a/multibody/plant/test/multibody_plant_hydroelastic_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_test.cc
@@ -632,9 +632,9 @@ TEST_F(ContactModelTest, HydroelasticWithFallbackDisconnectedPorts) {
   // should be invalid.
   DRAKE_EXPECT_THROWS_MESSAGE(
       GetContactResults(),
-      "The provided context doesn't show a connection for the plant's "
-      "query input port .see MultibodyPlant::get_geometry_query_input_port..."
-      ". See https://drake.mit.edu/trouble_shooting.html"
+      ".+ 'contact_results' output port[^]+The provided context doesn't show a "
+      "connection for the plant's query input port .+ See "
+      "https://drake.mit.edu/trouble_shooting.html"
       "#mbp-unconnected-query-object-port for help.");
 }
 

--- a/multibody/plant/test/multibody_plant_hydroelastic_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_test.cc
@@ -632,12 +632,10 @@ TEST_F(ContactModelTest, HydroelasticWithFallbackDisconnectedPorts) {
   // should be invalid.
   DRAKE_EXPECT_THROWS_MESSAGE(
       GetContactResults(),
-      "The geometry query input port \\(see "
-      "MultibodyPlant::get_geometry_query_input_port\\(\\)\\) "
-      "of this MultibodyPlant is not connected. Please connect the"
-      "geometry query output port of a SceneGraph object "
-      "\\(see SceneGraph::get_query_output_port\\(\\)\\) to this plants input "
-      "port in a Diagram.");
+      "The provided context doesn't show a connection for the plant's "
+      "query input port .see MultibodyPlant::get_geometry_query_input_port..."
+      ". See https://drake.mit.edu/trouble_shooting.html"
+      "#mbp-unconnected-query-object-port for help.");
 }
 
 // TODO(DamrongGuoy): Create an independent test fixture instead of using

--- a/multibody/plant/test/multibody_plant_query_object_connect_test.cc
+++ b/multibody/plant/test/multibody_plant_query_object_connect_test.cc
@@ -1,0 +1,222 @@
+/* @file This explicitly tests MultibodyPlant's response to the invocation of
+ various public APIs. Depending on various configuration, some APIs will throw
+ an exception if a scene graph's query object port hasn't been connected to
+ the MbP's input port.
+
+ This test serves as a regressiontest of the various behaviors (positive and
+ negative) across the related APIs and configurations. */
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/scene_graph.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+using geometry::SceneGraph;
+using systems::Context;
+using systems::DiagramBuilder;
+
+constexpr char kModelWithCollisions[] = R"""(
+<?xml version="1.0"?>
+<robot name="box">
+  <link name="box">
+    <inertial>
+      <mass value="1"/>
+      <inertia ixx="0.0108" ixy="0" ixz="0" iyy="0.0083" iyz="0" izz="0.0042"/>
+    </inertial>
+    <collision name="box">
+      <geometry>
+        <box size=".1 .2 .3"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>
+)""";
+
+constexpr char kModelWithoutCollisions[] = R"""(
+<?xml version="1.0"?>
+<robot name="box">
+  <link name="box">
+    <inertial>
+      <mass value="1"/>
+      <inertia ixx="0.0108" ixy="0" ixz="0" iyy="0.0083" iyz="0" izz="0.0042"/>
+    </inertial>
+  </link>
+</robot>
+)""";
+
+/* Popualtes the given diagram builder for the ConnectionError test based on
+ the particular test variable values (see documentation of that test for
+ details).
+
+ @returns a reference to the plant owned by the diagram builder. */
+MultibodyPlant<double>& PopulateTestDiagram(DiagramBuilder<double>* builder,
+                                            double time_step,
+                                            bool has_collision_geometry,
+                                            bool is_connected) {
+  MultibodyPlant<double>* plant{nullptr};
+
+  if (is_connected) {
+    auto [plant_ref, scene_graph] =
+        AddMultibodyPlantSceneGraph(builder, time_step);
+    plant = &plant_ref;
+  } else {
+    plant = builder->AddSystem<MultibodyPlant<double>>(time_step);
+    auto* scene_graph = builder->AddSystem<SceneGraph<double>>();
+    plant->RegisterAsSourceForSceneGraph(scene_graph);
+    builder->Connect(
+        plant->get_geometry_poses_output_port(),
+        scene_graph->get_source_pose_port(plant->get_source_id().value()));
+  }
+
+  Parser parser(plant);
+  if (has_collision_geometry) {
+    parser.AddModelFromString(kModelWithCollisions, "urdf");
+  } else {
+    parser.AddModelFromString(kModelWithoutCollisions, "urdf");
+  }
+
+  plant->Finalize();
+
+  return *plant;
+}
+
+/* What follows is a number of helper functios for exercising aspects of the
+ MbP's public API. */
+//@{
+
+void EvalContactResults(const MultibodyPlant<double>& plant,
+                        const Context<double>& context) {
+  plant.get_contact_results_output_port().Eval<ContactResults<double>>(context);
+}
+
+void EvalTimeDerivatives(const MultibodyPlant<double>& plant,
+                         const Context<double>& context) {
+  auto derivatives = plant.AllocateTimeDerivatives();
+  plant.CalcTimeDerivatives(context, derivatives.get());
+}
+
+void EvalTimeDerivativesResidual(const MultibodyPlant<double>& plant,
+                                 const Context<double>& context) {
+  auto derivatives = plant.AllocateTimeDerivatives();
+  Eigen::VectorXd residual = plant.AllocateImplicitTimeDerivativesResidual();
+  plant.CalcImplicitTimeDerivativesResidual(context, *derivatives, &residual);
+}
+
+void EvalForwardDynamics(const MultibodyPlant<double>& plant,
+                         const Context<double>& context) {
+  plant.EvalForwardDynamics(context);
+}
+
+void EvalGeneralizedContactForces(const MultibodyPlant<double>& plant,
+                                  const Context<double>& context) {
+  plant.get_generalized_contact_forces_output_port(ModelInstanceIndex(1))
+      .Eval(context);
+}
+
+void EvalReactionForces(const MultibodyPlant<double>& plant,
+                        const Context<double>& context) {
+  plant.get_reaction_forces_output_port().Eval<AbstractValue>(context);
+}
+
+//@}
+
+// The modes of the MbP for which a test configuration applies.
+enum class PlantMode {
+    kAll,
+    kDiscrete,
+    kContinuous,
+};
+
+/* For a given public API, this evaluates a function that exercises a particular
+ MbP API. The mode determines if the function is evaluated in discrete mode,
+ continuous mode, or both. */
+struct TestConfiguration {
+  std::function<void(const MultibodyPlant<double>& plant,
+                     const Context<double>& context)>
+      eval;
+  PlantMode modes{PlantMode::kAll};
+};
+
+/* For a number of public APIs that *may* ultimately depend on the query object
+ input port, this confirms that an exception is only thrown in specific
+ circumstances.
+
+ It is *not* the case that simply having an unconnected QueryObject input port
+ causes the APIs to throw. There must also be collision geometries registered.
+ The throwing behavior may or may not depend on whether the plant is discrete or
+ continuous.
+
+ So, this test iterates through the three variables (connected/disconnected, has
+ collision geometries/no collision geometries, and discrete/continuous) for each
+ API under test and confirms throwing/non-throwing bheaviors. */
+GTEST_TEST(MultibodySceneGraphConnection, ConnectionError) {
+  const std::vector<TestConfiguration> configurations{
+      // Ports don't depend on MbP mode.
+      {.eval = &EvalContactResults},
+      {.eval = &EvalGeneralizedContactForces},
+      {.eval = &EvalReactionForces},
+      // Time derivatives are only meaningful in continuous mode.
+      {.eval = &EvalTimeDerivatives, .modes = PlantMode::kContinuous},
+      {.eval = &EvalTimeDerivativesResidual, .modes = PlantMode::kContinuous},
+      // For forward dynamics, discrete and continuous are sufficiently
+      // different that evaluation of forward dynamics in continuous mode can
+      // only be detected by computation of derivatives.
+      {.eval = &EvalForwardDynamics, .modes = PlantMode::kContinuous},
+      {.eval = &EvalForwardDynamics, .modes = PlantMode::kDiscrete},
+  };
+
+  // Handle discrete/continuous variations.
+  for (double time_step : {1e-3, 0.0}) {
+    for (bool has_collision_geometry : {true, false}) {
+      for (bool connected : {true, false}) {
+        for (const auto& config : configurations) {
+          if ((time_step != 0 && config.modes == PlantMode::kContinuous) ||
+              (time_step == 0 && config.modes == PlantMode::kDiscrete)) {
+            continue;
+          }
+          DiagramBuilder<double> builder;
+          MultibodyPlant<double>& plant = PopulateTestDiagram(
+              &builder, time_step, has_collision_geometry, connected);
+          auto diagram = builder.Build();
+          auto context = diagram->CreateDefaultContext();
+          const auto& plant_context = plant.GetMyContextFromRoot(*context);
+
+          // Structurally, we should only throw if we are unconnected with
+          // registered collision geometry.
+          const bool expect_throw = !connected && has_collision_geometry;
+          SCOPED_TRACE(
+              fmt::format("\nConfiguration:\n  collision geometry: {}\n  "
+                          "discrete: {}\n  connected: {}",
+                          has_collision_geometry, time_step > 0, connected));
+          if (expect_throw) {
+            DRAKE_EXPECT_THROWS_MESSAGE(
+                config.eval(plant, plant_context),
+                "The provided context doesn't show a connection for the "
+                "plant's query input port.+ See "
+                "https://drake.mit.edu/trouble_shooting.html"
+                "#mbp-unconnected-query-object-port for help.");
+          } else {
+            EXPECT_NO_THROW(config.eval(plant, plant_context));
+          }
+        }
+      }
+    }
+  }
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -124,7 +124,7 @@ class MultibodyPlantTester {
   static const geometry::QueryObject<double>& EvalGeometryQueryInput(
       const MultibodyPlant<double>& plant,
       const systems::Context<double>& context) {
-    return plant.EvalGeometryQueryInput(context);
+    return plant.EvalGeometryQueryInput(context, "MultibodyPlantTester");
   }
 };
 
@@ -1904,7 +1904,7 @@ GTEST_TEST(MultibodyPlantTest, CalcPointPairPenetrationsDisconnectedPorts) {
   // should be invalid.
   DRAKE_EXPECT_THROWS_MESSAGE(
       MultibodyPlantTester::EvalGeometryQueryInput(plant, *context),
-      "The provided context doesn't show a connection for the plant's "
+      "[^]+The provided context doesn't show a connection for the plant's "
       "query input port .see MultibodyPlant::get_geometry_query_input_port..."
       ". See https://drake.mit.edu/trouble_shooting.html"
       "#mbp-unconnected-query-object-port for help.");

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1904,12 +1904,10 @@ GTEST_TEST(MultibodyPlantTest, CalcPointPairPenetrationsDisconnectedPorts) {
   // should be invalid.
   DRAKE_EXPECT_THROWS_MESSAGE(
       MultibodyPlantTester::EvalGeometryQueryInput(plant, *context),
-      "The geometry query input port \\(see "
-      "MultibodyPlant::get_geometry_query_input_port\\(\\)\\) "
-      "of this MultibodyPlant is not connected. Please connect the"
-      "geometry query output port of a SceneGraph object "
-      "\\(see SceneGraph::get_query_output_port\\(\\)\\) to this plants input "
-      "port in a Diagram.");
+      "The provided context doesn't show a connection for the plant's "
+      "query input port .see MultibodyPlant::get_geometry_query_input_port..."
+      ". See https://drake.mit.edu/trouble_shooting.html"
+      "#mbp-unconnected-query-object-port for help.");
 }
 
 GTEST_TEST(MultibodyPlantTest, LinearizePendulum) {


### PR DESCRIPTION
relates #11448

In response to the problem where `MultibodyPlant` mysteriously, suddenly complains about an unconnected `QueryObject` port, this PR provides two tactics to lessen the pain.

1. The error message now provides a URL that can contain arbitrary guidance and checklists for understanding and addressing the error message.
2. Do our best to understand what computation is being evaluated that led to caring about the state of the input port.
    - Add a test that confirms a number of public APIs that can trigger the exception and confirm the conditions under which they are sent.
    - For those same APIs, fail fast on the unconnected port error condition, providing more message as to which API triggered it (e.g., evaluating an output port, asking for derivatives, etc.) Note: this effort is *imperfect*.
        - First, the public API on `MultibodyPlant` is not necessarily the most obvious button pushed from the user's perspective. It might have been triggered by something external (e.g., evaluating forward dynamics from some arbitrary function).
        - Second, not all APIs are equally accessible. Forward dynamics for a *discrete* `MultibodyPlant` can be immediately flagged. The same is not true for the *continuous* plant. In the latter case, the issue can only be detected when the time derivatives get evaluated.

The two tactics are largely orthogonal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17471)
<!-- Reviewable:end -->
