### PR TITLE
[geometry/render_gltf_client] remove port struct data member

### DIFF
--- a/geometry/render/dev/render_gltf_client/internal_render_client.h
+++ b/geometry/render/dev/render_gltf_client/internal_render_client.h
@@ -212,9 +212,8 @@ class RenderClient {
    construction.  Note that `default_label` is not relevant for RenderClient
    class, so it's always set to std::nullopt. */
   RenderEngineGltfClientParams get_params() const {
-    return RenderEngineGltfClientParams{base_url_,          port_,
-                                        render_endpoint_,   std::nullopt,
-                                        verbose_,           no_cleanup_};
+    return RenderEngineGltfClientParams{base_url_, render_endpoint_,
+                                        std::nullopt, verbose_, no_cleanup_};
   }
 
   /* The temporary directory used for scratch space, including but not limited
@@ -228,11 +227,6 @@ class RenderClient {
   /* The base url of the server. The full url to communicate with is constructed
    as `base_url()/render_endpoint()`. */
   const std::string& base_url() const { return base_url_; }
-
-  /** The port to communicate on.  A value less than or equal to `0` will let
-   `base_url_` to decide which port to use.  If a different port is needed
-   instead, specify `port` to override that. */
-  int port() const { return port_; }
 
   /* The render endpoint of the server, used in RetrieveRender().
    Should **not** include a preceding slash. */
@@ -254,7 +248,6 @@ class RenderClient {
   friend class RenderClientTester;
   const std::string temp_directory_;
   const std::string base_url_;
-  const int port_;
   const std::string render_endpoint_;
   const bool verbose_;
   const bool no_cleanup_;

--- a/geometry/render/dev/render_gltf_client/test/internal_render_engine_gltf_client_test.cc
+++ b/geometry/render/dev/render_gltf_client/test/internal_render_engine_gltf_client_test.cc
@@ -47,7 +47,6 @@ class RenderEngineGltfClientTester {
   const std::string& base_url() const {
     return engine_->render_client_->base_url();
   }
-  int port() const { return engine_->render_client_->port(); }
   const std::string& render_endpoint() const {
     return engine_->render_client_->render_endpoint();
   }
@@ -103,7 +102,6 @@ GTEST_TEST(RenderEngineGltfClient, Constructor) {
     EXPECT_NE(actual_engine, nullptr);
     Tester tester{actual_engine};
     EXPECT_EQ(tester.base_url(), "http://127.0.0.1:8000");
-    EXPECT_EQ(tester.port(), 0);
     EXPECT_EQ(tester.render_endpoint(), "render");
     EXPECT_EQ(tester.verbose(), false);
     EXPECT_EQ(tester.no_cleanup(), false);
@@ -115,11 +113,11 @@ GTEST_TEST(RenderEngineGltfClient, Constructor) {
 
   {
     // Make sure that alternative values are passed to the underlying client.
-    const Params params{"0.0.0.0", 0, "super_render", std::nullopt, true, true};
+    const Params params{"0.0.0.0:8000", "super_render", std::nullopt, true,
+                        true};
     Engine engine{params};
     Tester tester{&engine};
-    EXPECT_EQ(tester.base_url(), "0.0.0.0");
-    EXPECT_EQ(tester.port(), 0);
+    EXPECT_EQ(tester.base_url(), "0.0.0.0:8000");
     EXPECT_EQ(tester.render_endpoint(), "super_render");
     EXPECT_EQ(tester.verbose(), true);
     EXPECT_EQ(tester.no_cleanup(), true);
@@ -132,7 +130,7 @@ GTEST_TEST(RenderEngineGltfClient, Constructor) {
 }
 
 GTEST_TEST(RenderEngineGltfClient, Clone) {
-  const Params params{"192.168.1.1", 2222, "endpoint",
+  const Params params{"192.168.1.1:2222", "endpoint",
                       std::nullopt,  true, false};
   Engine engine{params};
   Tester tester{&engine};
@@ -143,7 +141,6 @@ GTEST_TEST(RenderEngineGltfClient, Clone) {
   Tester clone_tester{actual_engine};
 
   EXPECT_EQ(tester.base_url(), clone_tester.base_url());
-  EXPECT_EQ(tester.port(), clone_tester.port());
   EXPECT_EQ(tester.render_endpoint(), clone_tester.render_endpoint());
   EXPECT_EQ(tester.verbose(), clone_tester.verbose());
   EXPECT_EQ(tester.no_cleanup(), clone_tester.no_cleanup());
@@ -239,7 +236,7 @@ class FakeServer : public HttpService {
    depth.response, or label.response.  It will overwrite the file if it already
    exists. */
   HttpResponse DoPostForm(const std::string& temp_directory,
-                          const std::string& url, int /* port */,
+                          const std::string& url,
                           const DataFieldsMap& data_fields,
                           const FileFieldsMap& file_fields,
                           bool /* verbose */ = false) override {

--- a/geometry/render_gltf_client/internal_http_service.cc
+++ b/geometry/render_gltf_client/internal_http_service.cc
@@ -32,14 +32,12 @@ void ThrowIfFilesMissing(const FileFieldsMap& file_fields) {
 }  // namespace
 
 HttpResponse HttpService::PostForm(
-    const std::string& temp_directory, const std::string& url, int port,
+    const std::string& temp_directory, const std::string& url,
     const DataFieldsMap& data_fields,
     const FileFieldsMap& file_fields,
     bool verbose) {
-
   ThrowIfFilesMissing(file_fields);
-  return DoPostForm(temp_directory, url, port, data_fields, file_fields,
-                    verbose);
+  return DoPostForm(temp_directory, url, data_fields, file_fields, verbose);
 }
 
 }  // namespace internal

--- a/geometry/render_gltf_client/internal_http_service.h
+++ b/geometry/render_gltf_client/internal_http_service.h
@@ -126,15 +126,15 @@ class HttpService {
    //   <!-- NOTE: often, the `value` is irrelevant. -->
    //   <input type="submit" name="submit" value="Submit">
    // <form>
-   // Submit form to /hello:
+   // Submit form to /hello:port/endpoint:
    auto response_1 = http_service_->PostForm(
-       temp_dir, "/hello", port,
+       temp_dir, "/hello:port/endpoint",
        {{"name", "Sue"}, {"age", "34"}, {"submit", "Submit"}},
        {});  // No file fields.
    // Suppose `<input type="file" name="photo">` and
    // `<input type="file" name="id">` were added.
    auto response_2 = http_service->PostForm(
-       temp_dir, "/hello", port,
+       temp_dir, "/hello:port/endpoint",
        {{"name", "Bo"}, {"age", "49"}, {"submit", "Submit"}},
        {{"photo", {"/path/to/bo-profile.jpg", "image/jpeg"}},
         // No mime-type for this file, std::nullopt indicates this.
@@ -150,10 +150,6 @@ class HttpService {
      for deleting it.  No validity checks on this directory are performed.
    @param url
      The url this HTTP service will communicate with.
-   @param port
-     The port to communicate on.  A value less than or equal to `0` will let
-     `url` to decide which port to use.  If a different port is needed instead,
-     specify `port` to override that.
    @param data_fields
      The entries for the `<input>` elements of the form.  Keys are the field
      name, and values are the field values.  For example:
@@ -193,17 +189,17 @@ class HttpService {
      encode this information in the returned HttpResponse for the caller to
      determine how to proceed. */
   HttpResponse PostForm(
-      const std::string& temp_directory, const std::string& url, int port,
+      const std::string& temp_directory, const std::string& url,
       const DataFieldsMap& data_fields,
       const FileFieldsMap& file_fields,
       bool verbose = false);
 
  protected:
   /* The NVI-function for posting an HTML form to a render server. When
-   PostForm calls this, it has already validated the url, and the existence of
-   the files in `file_fields`. */
+   PostForm calls this, it has already validated the existence of the files in
+   `file_fields`. */
   virtual HttpResponse DoPostForm(
-      const std::string& temp_directory, const std::string& url, int port,
+      const std::string& temp_directory, const std::string& url,
       const DataFieldsMap& data_fields,
       const FileFieldsMap& file_fields,
       bool verbose) = 0;

--- a/geometry/render_gltf_client/internal_http_service_curl.cc
+++ b/geometry/render_gltf_client/internal_http_service_curl.cc
@@ -202,7 +202,7 @@ HttpServiceCurl::HttpServiceCurl() : HttpService() {
 HttpServiceCurl::~HttpServiceCurl() {}
 
 HttpResponse HttpServiceCurl::DoPostForm(
-    const std::string& temp_directory, const std::string& url, int port,
+    const std::string& temp_directory, const std::string& url,
     const DataFieldsMap& data_fields,
     const FileFieldsMap& file_fields,
     bool verbose) {
@@ -234,7 +234,6 @@ HttpResponse HttpServiceCurl::DoPostForm(
   // Setup the POST url.
   curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
-  if (port > 0) curl_easy_setopt(curl, CURLOPT_PORT, port);
 
   // Add all of the data fields.
   for (const auto& [field_name, field_data] : data_fields) {

--- a/geometry/render_gltf_client/internal_http_service_curl.h
+++ b/geometry/render_gltf_client/internal_http_service_curl.h
@@ -22,7 +22,7 @@ class HttpServiceCurl : public HttpService {
  protected:
   /* @see HttpService::DoPostForm */
   HttpResponse DoPostForm(
-      const std::string& temp_directory, const std::string& url, int port,
+      const std::string& temp_directory, const std::string& url,
       const DataFieldsMap& data_fields,
       const FileFieldsMap& file_fields,
       bool verbose = false) override;

--- a/geometry/render_gltf_client/render_engine_gltf_client_params.h
+++ b/geometry/render_gltf_client/render_engine_gltf_client_params.h
@@ -12,20 +12,14 @@ namespace geometry {
  client as part of the @ref render_engine_gltf_client_server_api. */
 struct RenderEngineGltfClientParams {
   /** The base url of the server communicate with.
-  See GetUrl() for details.*/
+   See GetUrl() for details. */
   std::string base_url{"http://127.0.0.1:8000"};
 
-  // TODO(zachfang): consider removing `port`.
-  /** The port to communicate on.  A value less than or equal to `0` will let
-   `base_url` to decide which port to use.  If a different port is needed
-   instead, specify `port` to override that. */
-  int port{0};
-
   /** (Advanced) The server endpoint to retrieve renderings from.
-  See GetUrl() for details.*/
+   See GetUrl() for details. */
   std::string render_endpoint{"render"};
 
-  /** The (optional) label to apply when none is otherwise specified.  */
+  /** The (optional) label to apply when none is otherwise specified. */
   std::optional<render::RenderLabel> default_label{};
 
   /** Whether or not the client should log information about which files are

--- a/geometry/render_gltf_client/test/README.md
+++ b/geometry/render_gltf_client/test/README.md
@@ -50,8 +50,9 @@ As a comparison, you can also render with the normal VTK by setting
 $ bazel run //geometry/render/dev/render_gltf_client:run_simulation_and_render -- --render_engine vtk
 ```
 
-Note that if you ran your server on an alternate `--port`, you will need to
-provide this `--port` to the `run_simulation_and_render` executable as well.
+Note that if you ran your server on an alternate `--host` or `--port`, you will
+need to specify that in `--server_base_url` when running
+`run_simulation_and_render` executable as well.
 
 ### (Optional) Run Drake Visualizer
 

--- a/geometry/render_gltf_client/test/internal_http_service_curl_test.cc
+++ b/geometry/render_gltf_client/test/internal_http_service_curl_test.cc
@@ -22,8 +22,7 @@ GTEST_TEST(HttpServiceCurlTest, PostForm) {
   /* NOTE: do not use a URL / port that may be active...
    Use verbose=true (last parameter) to increase coverage via curl callbacks. */
   const std::string temp_dir = drake::temp_directory();
-  const std::string url{"notawebsite/render"};
-  const int port{1};
+  const std::string url{"notawebsite:1234/render"};
   const bool verbose{true};
   HttpServiceCurl service;
 
@@ -36,7 +35,7 @@ GTEST_TEST(HttpServiceCurlTest, PostForm) {
     temp_file << "this file exists\n";
     temp_file.close();
     DRAKE_EXPECT_THROWS_MESSAGE(
-        service.PostForm(temp_dir, url, port, {}, {}, verbose),
+        service.PostForm(temp_dir, url, {}, {}, verbose),
         fmt::format(
             "HttpServiceCurl: refusing to overwrite temporary file '{}' that "
             "already exists, please cleanup temporary directory '{}'.",
@@ -51,7 +50,7 @@ GTEST_TEST(HttpServiceCurlTest, PostForm) {
                            fs::perms::others_write;
     fs::permissions(temp_dir, all_write, fs::perm_options::remove);
     DRAKE_EXPECT_THROWS_MESSAGE(
-        service.PostForm(temp_dir, url, port, {}, {}, verbose),
+        service.PostForm(temp_dir, url, {}, {}, verbose),
         fmt::format(
             "HttpServiceCurl: unable to open temporary file '{}.*\\.curl'.",
             temp_dir));
@@ -60,7 +59,7 @@ GTEST_TEST(HttpServiceCurlTest, PostForm) {
 
   {
     // Validate that the response indicates failure in absence of server.
-    const auto res_1 = service.PostForm(temp_dir, url, port, {}, {}, verbose);
+    const auto res_1 = service.PostForm(temp_dir, url, {}, {}, verbose);
     EXPECT_FALSE(res_1.Good());
     EXPECT_FALSE(res_1.data_path.has_value());
     EXPECT_TRUE(res_1.service_error_message.has_value());
@@ -83,7 +82,7 @@ GTEST_TEST(HttpServiceCurlTest, PostForm) {
     test_binary.close();
 
     const auto res_2 = service.PostForm(
-        temp_dir, url, port, {{"width", "640"}, {"height", "480"}},
+        temp_dir, url, {{"width", "640"}, {"height", "480"}},
         {{"json", {test_json_path, test_json_mime}},
          {"binary", {test_binary_path, test_binary_mime}}},
         verbose);

--- a/geometry/render_gltf_client/test/internal_http_service_test.cc
+++ b/geometry/render_gltf_client/test/internal_http_service_test.cc
@@ -26,7 +26,6 @@ class EmptyService : public HttpService {
  protected:
   HttpResponse DoPostForm(
       const std::string& /* temp_directory */, const std::string& /* url */,
-      int /* port */,
       const DataFieldsMap& /* data_fields */,
       const FileFieldsMap& /* file_fields */,
       bool /* verbose */ = false) override {
@@ -59,10 +58,9 @@ class HttpServicePostFormTest : public ::testing::Test {
       actual_fields.emplace(field_name, std::move(payload));
     }
     EmptyService empty_service;
-    const std::string url = "http://127.0.0.1/render";
-    const int port = 8000;
+    const std::string url = "http://127.0.0.1:8000/render";
     const DataFieldsMap string_fields;
-    empty_service.PostForm(temp_dir_, url, port, string_fields, actual_fields);
+    empty_service.PostForm(temp_dir_, url, string_fields, actual_fields);
   }
 
  protected:


### PR DESCRIPTION
Another prerequisite for #17449, we decided to drop `port` data member and use `base_url` as the sole place to store that information. By that, it's less error-prone and more straightforward for users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17478)
<!-- Reviewable:end -->
