### PR TITLE
[geometry] Simplify deformable mesh generation code

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -699,8 +699,8 @@ drake_cc_googletest(
     name = "geometry_state_test",
     deps = [
         ":geometry_state",
-        ":make_mesh_for_deformable",
         "//common/test_utilities",
+        "//geometry/proximity:make_sphere_mesh",
         "//geometry/test_utilities:dummy_render_engine",
     ],
 )
@@ -726,9 +726,9 @@ drake_cc_googletest(
     name = "internal_geometry_test",
     deps = [
         ":internal_geometry",
-        ":make_mesh_for_deformable",
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
+        "//geometry/proximity:make_sphere_mesh",
     ],
 )
 

--- a/geometry/make_mesh_for_deformable.cc
+++ b/geometry/make_mesh_for_deformable.cc
@@ -20,100 +20,19 @@ std::unique_ptr<VolumeMesh<double>> MeshBuilderForDeformable::Build(
 void MeshBuilderForDeformable::ImplementGeometry(const Sphere& sphere,
                                                  void* user_data) {
   ReifyData& data = *static_cast<ReifyData*>(user_data);
-  data.mesh = std::make_unique<VolumeMesh<double>>(
-      MakeMeshForDeformable(sphere, data.resolution_hint));
-}
-void MeshBuilderForDeformable::ImplementGeometry(const Cylinder& cylinder,
-                                                 void* user_data) {
-  ReifyData& data = *static_cast<ReifyData*>(user_data);
-  data.mesh = std::make_unique<VolumeMesh<double>>(
-      MakeMeshForDeformable(cylinder, data.resolution_hint));
-}
-void MeshBuilderForDeformable::ImplementGeometry(const HalfSpace& half_space,
-                                                 void* user_data) {
-  ReifyData& data = *static_cast<ReifyData*>(user_data);
-  data.mesh = std::make_unique<VolumeMesh<double>>(
-      MakeMeshForDeformable(half_space, data.resolution_hint));
-}
-void MeshBuilderForDeformable::ImplementGeometry(const Box& box,
-                                                 void* user_data) {
-  ReifyData& data = *static_cast<ReifyData*>(user_data);
-  data.mesh = std::make_unique<VolumeMesh<double>>(
-      MakeMeshForDeformable(box, data.resolution_hint));
-}
-void MeshBuilderForDeformable::ImplementGeometry(const Capsule& capsule,
-                                                 void* user_data) {
-  ReifyData& data = *static_cast<ReifyData*>(user_data);
-  data.mesh = std::make_unique<VolumeMesh<double>>(
-      MakeMeshForDeformable(capsule, data.resolution_hint));
-}
-void MeshBuilderForDeformable::ImplementGeometry(const Ellipsoid& ellipsoid,
-                                                 void* user_data) {
-  ReifyData& data = *static_cast<ReifyData*>(user_data);
-  data.mesh = std::make_unique<VolumeMesh<double>>(
-      MakeMeshForDeformable(ellipsoid, data.resolution_hint));
-}
-void MeshBuilderForDeformable::ImplementGeometry(const Mesh& mesh,
-                                                 void* user_data) {
-  ReifyData& data = *static_cast<ReifyData*>(user_data);
-  data.mesh = std::make_unique<VolumeMesh<double>>(
-      MakeMeshForDeformable(mesh, data.resolution_hint));
-}
-void MeshBuilderForDeformable::ImplementGeometry(const Convex& convex,
-                                                 void* user_data) {
-  ReifyData& data = *static_cast<ReifyData*>(user_data);
-  data.mesh = std::make_unique<VolumeMesh<double>>(
-      MakeMeshForDeformable(convex, data.resolution_hint));
-}
-void MeshBuilderForDeformable::ImplementGeometry(const MeshcatCone& cone,
-                                                 void* user_data) {
-  ReifyData& data = *static_cast<ReifyData*>(user_data);
-  data.mesh = std::make_unique<VolumeMesh<double>>(
-      MakeMeshForDeformable(cone, data.resolution_hint));
+  DRAKE_DEMAND(data.resolution_hint > 0);
+  // Relying on move construction from r-value return from MakeSphereVolumeMesh.
+  data.mesh = std::make_unique<VolumeMesh<double>>(MakeSphereVolumeMesh<double>(
+      sphere, data.resolution_hint,
+      TessellationStrategy::kDenseInteriorVertices));
 }
 
-VolumeMesh<double> MakeMeshForDeformable(const Sphere& sphere,
-                                         double resolution_hint) {
-  DRAKE_DEMAND(resolution_hint > 0);
-  return MakeSphereVolumeMesh<double>(
-      sphere, resolution_hint, TessellationStrategy::kDenseInteriorVertices);
-}
-
-// TODO(xuchenhan-tri): Implement these shapes.
-VolumeMesh<double> MakeMeshForDeformable(const Cylinder&, double) {
+void MeshBuilderForDeformable::ThrowUnsupportedGeometry(
+    const std::string& shape_name) {
   throw std::logic_error(
-      "Cylinder shape is not supported in MakeMeshForDeformable().");
-}
-VolumeMesh<double> MakeMeshForDeformable(const HalfSpace&, double) {
-  throw std::logic_error(
-      "Half space shape is not supported in MakeMeshForDeformable().");
-}
-VolumeMesh<double> MakeMeshForDeformable(const Box&, double) {
-  throw std::logic_error(
-      "Box shape is not supported in MakeMeshForDeformable().");
-}
-VolumeMesh<double> MakeMeshForDeformable(const Capsule&, double) {
-  throw std::logic_error(
-      "Capsule shape is not supported in MakeMeshForDeformable().");
-}
-VolumeMesh<double> MakeMeshForDeformable(const Ellipsoid&, double) {
-  throw std::logic_error(
-      "Ellipsoid shape is not supported in MakeMeshForDeformable().");
-}
-VolumeMesh<double> MakeMeshForDeformable(const Mesh&, double) {
-  throw std::logic_error(
-      "Mesh shape is not supported in MakeMeshForDeformable().");
-}
-
-VolumeMesh<double> MakeMeshForDeformable(const Convex&, double) {
-  throw std::logic_error(
-      "Convex shape is not supported in MakeMeshForDeformable().");
-}
-
-/* Unsupported shapes. */
-VolumeMesh<double> MakeMeshForDeformable(const MeshcatCone&, double) {
-  throw std::logic_error(
-      "MeshcatCone shape is not supported in MakeMeshForDeformable().");
+      fmt::format("MeshBuilderForDeformable: We don't yet generate deformable "
+                  "meshes from {}.",
+                  shape_name));
 }
 
 }  // namespace internal

--- a/geometry/make_mesh_for_deformable.h
+++ b/geometry/make_mesh_for_deformable.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include "drake/geometry/proximity/volume_mesh.h"
 #include "drake/geometry/shape_specification.h"
@@ -29,42 +30,13 @@ class MeshBuilderForDeformable : public ShapeReifier {
     std::unique_ptr<VolumeMesh<double>> mesh;
   };
 
+  using ShapeReifier::ImplementGeometry;
   void ImplementGeometry(const Sphere& sphere, void* user_data) override;
-  void ImplementGeometry(const Cylinder& cylinder, void* user_data) override;
-  void ImplementGeometry(const HalfSpace& half_space, void* user_data) override;
-  void ImplementGeometry(const Box& box, void* user_data) override;
-  void ImplementGeometry(const Capsule& capsule, void* user_data) override;
-  void ImplementGeometry(const Ellipsoid& ellipsoid, void* user_data) override;
-  void ImplementGeometry(const Mesh& mesh, void* user_data) override;
-  void ImplementGeometry(const Convex& convex, void* user_data) override;
-  void ImplementGeometry(const MeshcatCone& cone, void* user_data) override;
-};
+  // TODO(xuchenhan-tri): As other shapes get supported, include their specific
+  //  overrides here.
 
-/* Returns a volume mesh suitable for deformable body simulation that
- discretizes the shape with the resolution provided at construction. There is a
- seperate function for each concrete shape derived from Shape.
- @pre resolution_hint > 0.
- @throws std::exception if `shape` doesn't support a mesh discretization. */
-//@{
-VolumeMesh<double> MakeMeshForDeformable(const Sphere& sphere,
-                                         double resolution_hint);
-VolumeMesh<double> MakeMeshForDeformable(const Cylinder& cylinder,
-                                         double resolution_hint);
-VolumeMesh<double> MakeMeshForDeformable(const HalfSpace& half_space,
-                                         double resolution_hint);
-VolumeMesh<double> MakeMeshForDeformable(const Box& box,
-                                         double resolution_hint);
-VolumeMesh<double> MakeMeshForDeformable(const Capsule& capsule,
-                                         double resolution_hint);
-VolumeMesh<double> MakeMeshForDeformable(const Ellipsoid& ellipsoid,
-                                         double resolution_hint);
-VolumeMesh<double> MakeMeshForDeformable(const Mesh& mesh,
-                                         double resolution_hint);
-VolumeMesh<double> MakeMeshForDeformable(const Convex& convex,
-                                         double resolution_hint);
-VolumeMesh<double> MakeMeshForDeformable(const MeshcatCone& cone,
-                                         double resolution_hint);
-//@}
+  void ThrowUnsupportedGeometry(const std::string& shape_name) override;
+};
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/test/internal_geometry_test.cc
+++ b/geometry/test/internal_geometry_test.cc
@@ -6,7 +6,7 @@
 
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
-#include "drake/geometry/make_mesh_for_deformable.h"
+#include "drake/geometry/proximity/make_sphere_mesh.h"
 
 namespace drake {
 namespace geometry {
@@ -142,14 +142,15 @@ GTEST_TEST(InternalGeometryTest, DeformableMeshedGeometry) {
   FrameId frame_id = FrameId::get_new_id();
   GeometryId deformable_geometry_id = GeometryId::get_new_id();
   std::string name = "sphere";
-  VolumeMesh<double> mesh = MakeMeshForDeformable(sphere, kRezHint);
+  const VolumeMesh<double> expected_mesh = MakeSphereVolumeMesh<double>(
+      sphere, kRezHint, TessellationStrategy::kDenseInteriorVertices);
 
   // Confirms that a meshed geometry can be constructed.
   InternalGeometry geometry(source_id, make_unique<Sphere>(sphere), frame_id,
                             deformable_geometry_id, name, kRezHint);
   const VolumeMesh<double>* reference_mesh = geometry.reference_mesh();
   ASSERT_NE(reference_mesh, nullptr);
-  EXPECT_TRUE(mesh.Equal(*reference_mesh));
+  EXPECT_TRUE(expected_mesh.Equal(*reference_mesh));
 
   // Deformable geometry doesn't have the notion of "fixed-in" frame. Those
   // values are set to identity.

--- a/geometry/test/make_mesh_for_deformable_test.cc
+++ b/geometry/test/make_mesh_for_deformable_test.cc
@@ -20,89 +20,49 @@ class MeshBuilderForDeformableTest : public ::testing::Test {
 TEST_F(MeshBuilderForDeformableTest, Sphere) {
   const Sphere sphere(1.0);
   std::unique_ptr<VolumeMesh<double>> mesh = builder_.Build(sphere, kRezHint);
-  const VolumeMesh<double> expected_mesh =
-      MakeMeshForDeformable(sphere, kRezHint);
+  const VolumeMesh<double> expected_mesh = MakeSphereVolumeMesh<double>(
+      sphere, kRezHint, TessellationStrategy::kDenseInteriorVertices);
   EXPECT_TRUE(mesh->Equal(expected_mesh));
 }
 
 TEST_F(MeshBuilderForDeformableTest, Cylinder) {
   const Cylinder c(1.25, 2.5);
-  DRAKE_EXPECT_THROWS_MESSAGE(builder_.Build(c, kRezHint),
-                              "Cylinder.*not supported.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      builder_.Build(c, kRezHint),
+      ".*don't yet generate deformable meshes.+ Cylinder.");
 }
 
 TEST_F(MeshBuilderForDeformableTest, Halfspace) {
   const HalfSpace h;
-  DRAKE_EXPECT_THROWS_MESSAGE(builder_.Build(h, kRezHint),
-                              "Half space.*not supported.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      builder_.Build(h, kRezHint),
+      ".*don't yet generate deformable meshes.+ HalfSpace.");
 }
 
 TEST_F(MeshBuilderForDeformableTest, Box) {
   const Box b(1.5, 2.5, 3.5);
   DRAKE_EXPECT_THROWS_MESSAGE(builder_.Build(b, kRezHint),
-                              "Box.*not supported.*");
+                              ".*don't yet generate deformable meshes.+ Box.");
 }
 
 TEST_F(MeshBuilderForDeformableTest, Capsule) {
   const Capsule c(1.25, 2.5);
-  DRAKE_EXPECT_THROWS_MESSAGE(builder_.Build(c, kRezHint),
-                              "Capsule.*not supported.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      builder_.Build(c, kRezHint),
+      ".*don't yet generate deformable meshes.+ Capsule.");
 }
 
 TEST_F(MeshBuilderForDeformableTest, Mesh) {
   const Mesh m("path/to/file", 1.5);
   DRAKE_EXPECT_THROWS_MESSAGE(builder_.Build(m, kRezHint),
-                              "Mesh.*not supported.*");
+                              ".*don't yet generate deformable meshes.+ Mesh.");
 }
 
 TEST_F(MeshBuilderForDeformableTest, Convex) {
   const Convex m("path/to/file", 1.5);
-  DRAKE_EXPECT_THROWS_MESSAGE(builder_.Build(m, kRezHint),
-                              "Convex.*not supported.*");
-}
-
-GTEST_TEST(MakeMeshForDeformable, Sphere) {
-  const Sphere sphere(1.0);
-  const VolumeMesh<double> mesh = MakeMeshForDeformable(sphere, kRezHint);
-  const VolumeMesh<double> expected_mesh = MakeSphereVolumeMesh<double>(
-      sphere, kRezHint, TessellationStrategy::kDenseInteriorVertices);
-  EXPECT_TRUE(mesh.Equal(expected_mesh));
-}
-
-GTEST_TEST(MakeMeshForDeformable, Cylinder) {
-  const Cylinder c(1.25, 2.5);
-  DRAKE_EXPECT_THROWS_MESSAGE(MakeMeshForDeformable(c, kRezHint),
-                              "Cylinder.*not supported.*");
-}
-
-GTEST_TEST(MakeMeshForDeformable, Halfspace) {
-  const HalfSpace h;
-  DRAKE_EXPECT_THROWS_MESSAGE(MakeMeshForDeformable(h, kRezHint),
-                              "Half space.*not supported.*");
-}
-
-GTEST_TEST(MakeMeshForDeformable, Box) {
-  const Box b(1.5, 2.5, 3.5);
-  DRAKE_EXPECT_THROWS_MESSAGE(MakeMeshForDeformable(b, kRezHint),
-                              "Box.*not supported.*");
-}
-
-GTEST_TEST(MakeMeshForDeformable, Capsule) {
-  const Capsule c(1.25, 2.5);
-  DRAKE_EXPECT_THROWS_MESSAGE(MakeMeshForDeformable(c, kRezHint),
-                              "Capsule.*not supported.*");
-}
-
-GTEST_TEST(MakeMeshForDeformable, Mesh) {
-  const Mesh m("path/to/file", 1.5);
-  DRAKE_EXPECT_THROWS_MESSAGE(MakeMeshForDeformable(m, kRezHint),
-                              "Mesh.*not supported.*");
-}
-
-GTEST_TEST(MakeMeshForDeformable, Convex) {
-  const Convex m("path/to/file", 1.5);
-  DRAKE_EXPECT_THROWS_MESSAGE(MakeMeshForDeformable(m, kRezHint),
-                              "Convex.*not supported.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      builder_.Build(m, kRezHint),
+      ".*don't yet generate deformable meshes.+ Convex.");
 }
 
 }  // namespace

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -350,7 +350,7 @@ TEST_F(SceneGraphTest, RegisterUnsupportedDeformableGeometry) {
       scene_graph_.RegisterDeformableGeometry(
           s_id, scene_graph_.world_frame_id(), std::move(geometry_instance),
           kRezHint),
-      "Cylinder shape is not supported in MakeMeshForDeformable.*");
+      ".*don't yet generate deformable meshes.+ Cylinder.");
 }
 
 template <typename T>


### PR DESCRIPTION
There was a great deal of code in place to handle geometries that aren't currently supported. This makes use of the `ShapeReifier` API to reduce the boilerplate. It eliminated a bunch of functions and reduced indirection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17484)
<!-- Reviewable:end -->
