### PR TITLE
[multibody] Provide more feedback when MbP query object port is unconnected

### DIFF
--- a/doc/_pages/troubleshooting.md
+++ b/doc/_pages/troubleshooting.md
@@ -1,0 +1,84 @@
+---
+title: Troubleshooting common problems
+---
+
+This page contains a collection of tips and tricks for resolving common
+problems.
+
+# MultibodyPlant
+
+## Exception messages
+
+### Unconnected QueryObject port {#mbp-unconnected-query-object-port}
+
+The error message will include the message, "The provided context doesn't show a
+connection for the plant's query input port."
+
+`MultibodyPlant` ([C++][c_MultibodyPlant], [Python][p_MultibodyPlant])
+requires a connection to `SceneGraph` ([C++][c_SceneGraph],
+[Python][p_SceneGraph]) in order to evaluate contact via its  `QueryObject`
+([C++][c_QueryObject], [Python][p_QueryObject]). Attempts to evaluate output
+ports that expose or depend on contact results (the geometric data and/or forces
+that arise from the contact between bodies' collision geometries) will fail.
+Evaluating the time derivatives (e.g., when running a continuous simulation)
+will likewise fail.
+
+The connection can be reported as missing for several reasons:
+
+1. Was a `SceneGraph` instance created and connected?
+   - The simplest solution is to use `AddMultibodyPlantSceneGraph()`
+     ([C++][c_AddMultibodyPlantSceneGraph],
+     [Python][p_AddMultibodyPlantSceneGraph]). It will construct and connect
+     the plant and scene graph together for you.
+2. Did you provide the right context?
+   - You've created and connected the systems in a `Diagram`
+     ([C++][c_Diagram], [Python][p_Diagram]) and allocated a `Context`
+     ([C++][c_Context], [Python][p_Context]) for the `Diagram`.
+   - Make sure you extract the `MultibodyPlant`'s context from the `Diagram`'s
+     `Context`. Do not allocate a `Context` directly from the plant. Use
+     `System::GetMyContextFromRoot()` ([C++][c_GetMyContextFromRoot],
+     [Python][p_GetMyContextFromRoot]) to acquire the plant's `Context` from the
+     `Diagram`'s context; this will preserve all of the necessary connections.
+     E.g.,
+
+    ```py
+      builder = DiagramBuilder()
+      # Build plant and scene graph and automatically connect them.
+      plant, scene_graph = AddMultibodyPlantSceneGraph(
+          builder=builder, time_step=1e-3)
+      ...
+      diagram = builder.Build()
+
+      # WRONG.  This will create a Context for the plant only (no connected
+      # SceneGraph).
+      xdot = plant.EvalTimeDerivatives(context=plant.CreateDefaultContext())
+
+      context = diagram.CreateDefaultContext()
+      # Extract the plant's context from the diagram's to invoke plant methods.
+      plant_context = plant.GetMyContextFromRoot(root_context=context)
+      xdot = plant.EvalTimeDerivatives(context=plant_context)
+    ```
+
+<!-- Links to the various Drake doxygen pages.
+     Order determined by directory structure first and names second.
+-->
+
+<!-- drake/geometry -->
+[c_QueryObject]: https://drake.mit.edu/doxygen_cxx/classdrake_1_1geometry_1_1_query_object.html
+[p_QueryObject]: https://drake.mit.edu/pydrake/pydrake.geometry.html#pydrake.geometry.QueryObject_
+[c_SceneGraph]: https://drake.mit.edu/doxygen_cxx/classdrake_1_1geometry_1_1_scene_graph.html
+[p_SceneGraph]: https://drake.mit.edu/pydrake/pydrake.geometry.html#pydrake.geometry.SceneGraph_
+
+<!-- drake/multibody/plant -->
+[c_AddMultibodyPlantSceneGraph]: https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_multibody_plant.html#aac66563a5f3eb9e2041bd4fa8d438827
+[p_AddMultibodyPlantSceneGraph]: https://drake.mit.edu/pydrake/pydrake.multibody.plant.html#pydrake.multibody.plant.AddMultibodyPlantSceneGraph
+[c_MultibodyPlant]: https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_multibody_plant.html
+[p_MultibodyPlant]: https://drake.mit.edu/pydrake/pydrake.multibody.plant.html#pydrake.multibody.plant.MultibodyPlant
+
+<!-- drake/systems/framework -->
+[c_Context]: https://drake.mit.edu/doxygen_cxx/classdrake_1_1systems_1_1_context.html
+[p_Context]: https://drake.mit.edu/pydrake/pydrake.systems.framework.html#pydrake.systems.framework.Context
+[c_Diagram]: https://drake.mit.edu/doxygen_cxx/classdrake_1_1systems_1_1_diagram.html
+[p_Diagram]: https://drake.mit.edu/pydrake/pydrake.systems.framework.html#pydrake.systems.framework.Diagram
+[c_GetMyContextFromRoot]: https://drake.mit.edu/doxygen_cxx/classdrake_1_1systems_1_1_system.html#ae7fa91d2b2102457ced3361207724e52
+[p_GetMyContextFromRoot]: https://drake.mit.edu/pydrake/pydrake.systems.framework.html#pydrake.systems.framework.System_.System_[float].GetMyContextFromRoot

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -462,6 +462,16 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "multibody_plant_query_object_connect_test",
+    deps = [
+        ":plant",
+        "//common/test_utilities:expect_throws_message",
+        "//multibody/parsing",
+        "@fmt",
+    ],
+)
+
+drake_cc_googletest(
     name = "multibody_plant_symbolic_test",
     deps = [
         ":plant",

--- a/multibody/plant/test/multibody_plant_hydroelastic_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_test.cc
@@ -625,21 +625,6 @@ TEST_F(ContactModelTest, HydroelasticWithFallback) {
   }
 }
 
-TEST_F(ContactModelTest, HydroelasticWithFallbackDisconnectedPorts) {
-  this->Configure(ContactModel::kHydroelasticWithFallback, false);
-
-  // Plant was not connected to the SceneGraph in a diagram, so its input port
-  // should be invalid.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      GetContactResults(),
-      "The geometry query input port \\(see "
-      "MultibodyPlant::get_geometry_query_input_port\\(\\)\\) "
-      "of this MultibodyPlant is not connected. Please connect the"
-      "geometry query output port of a SceneGraph object "
-      "\\(see SceneGraph::get_query_output_port\\(\\)\\) to this plants input "
-      "port in a Diagram.");
-}
-
 // TODO(DamrongGuoy): Create an independent test fixture instead of using
 //  inheritance and consider using parameter-value tests.
 

--- a/multibody/plant/test/multibody_plant_query_object_connect_test.cc
+++ b/multibody/plant/test/multibody_plant_query_object_connect_test.cc
@@ -1,0 +1,269 @@
+/* @file This file explicitly tests MultibodyPlant's response to the invocation
+ of various public APIs in relation to a query object connection being present.
+ In some configurations, it throws. In others, it does not.
+
+ This test serves as a regression test of both throwing and non-throwing APIs.
+ */
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/scene_graph.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+using geometry::SceneGraph;
+using systems::Context;
+using systems::DiagramBuilder;
+
+constexpr char kModelWithCollisions[] = R"""(
+<?xml version="1.0"?>
+<robot name="box">
+  <link name="box">
+    <inertial>
+      <mass value="1"/>
+      <inertia ixx="0.0108" ixy="0" ixz="0" iyy="0.0083" iyz="0" izz="0.0042"/>
+    </inertial>
+    <collision name="box">
+      <geometry>
+        <box size=".1 .2 .3"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>
+)""";
+
+constexpr char kModelWithoutCollisions[] = R"""(
+<?xml version="1.0"?>
+<robot name="box">
+  <link name="box">
+    <inertial>
+      <mass value="1"/>
+      <inertia ixx="0.0108" ixy="0" ixz="0" iyy="0.0083" iyz="0" izz="0.0042"/>
+    </inertial>
+  </link>
+</robot>
+)""";
+
+/* Populates the given diagram builder for the ConnectionError test based on
+ the particular test variable values (see documentation of that test for
+ details).
+
+ @returns a reference to the plant owned by the diagram builder. */
+MultibodyPlant<double>& PopulateTestDiagram(DiagramBuilder<double>* builder,
+                                            double time_step,
+                                            bool has_collision_geometry,
+                                            bool is_connected) {
+  MultibodyPlant<double>* plant{nullptr};
+
+  if (is_connected) {
+    auto [plant_ref, scene_graph] =
+        AddMultibodyPlantSceneGraph(builder, time_step);
+    plant = &plant_ref;
+  } else {
+    plant = builder->AddSystem<MultibodyPlant<double>>(time_step);
+    auto* scene_graph = builder->AddSystem<SceneGraph<double>>();
+    plant->RegisterAsSourceForSceneGraph(scene_graph);
+    builder->Connect(
+        plant->get_geometry_poses_output_port(),
+        scene_graph->get_source_pose_port(plant->get_source_id().value()));
+  }
+
+  Parser parser(plant);
+  if (has_collision_geometry) {
+    parser.AddModelFromString(kModelWithCollisions, "urdf");
+  } else {
+    parser.AddModelFromString(kModelWithoutCollisions, "urdf");
+  }
+
+  plant->Finalize();
+
+  return *plant;
+}
+
+/* What follows is a number of helper functions for exercising aspects of the
+ MbP's public API. */
+//@{
+
+void EvalContactResults(const MultibodyPlant<double>& plant,
+                        const Context<double>& context) {
+  plant.get_contact_results_output_port().Eval<ContactResults<double>>(context);
+}
+
+void EvalTimeDerivatives(const MultibodyPlant<double>& plant,
+                         const Context<double>& context) {
+  auto derivatives = plant.AllocateTimeDerivatives();
+  plant.CalcTimeDerivatives(context, derivatives.get());
+}
+
+void EvalTimeDerivativesResidual(const MultibodyPlant<double>& plant,
+                                 const Context<double>& context) {
+  auto derivatives = plant.AllocateTimeDerivatives();
+  Eigen::VectorXd residual = plant.AllocateImplicitTimeDerivativesResidual();
+  plant.CalcImplicitTimeDerivativesResidual(context, *derivatives, &residual);
+}
+
+void EvalForwardDynamics(const MultibodyPlant<double>& plant,
+                         const Context<double>& context) {
+  plant.EvalForwardDynamics(context);
+}
+
+void EvalGeneralizedContactForces(const MultibodyPlant<double>& plant,
+                                  const Context<double>& context) {
+  plant.get_generalized_contact_forces_output_port(ModelInstanceIndex(1))
+      .Eval(context);
+}
+
+void EvalReactionForces(const MultibodyPlant<double>& plant,
+                        const Context<double>& context) {
+  plant.get_reaction_forces_output_port().Eval<AbstractValue>(context);
+}
+
+//@}
+
+// The modes of the MbP for which a test configuration applies.
+enum class PlantMode {
+  kAll,
+  kDiscrete,
+  kContinuous,
+};
+
+/* For a given public API, this evaluates a function that exercises a particular
+ MbP API. It also carries a key phrase that must be matched in the thrown
+ exception. The mode determines if the function is evaluated in discrete mode,
+ continuous mode, or both. For a given API, we create a set of instances,
+ spanning the combinations of continuous/discrete, with or without collision
+ geometries, and connected/unconnected. */
+struct TestConfiguration {
+  std::string key_phrase;
+  std::function<void(const MultibodyPlant<double>& plant,
+                     const Context<double>& context)>
+      eval;
+  double time_step{};
+  bool has_collision_geometry{};
+  bool connected{};
+  PlantMode modes{PlantMode::kAll};
+};
+
+/* In the event of failure, prints the test configuration nicely. */
+std::ostream& operator<<(std::ostream& out, const TestConfiguration& c) {
+  out << "\nConfiguration:";
+  out << "\n  key phrase: " << c.key_phrase;
+  out << "\n  collision geometry: " << c.has_collision_geometry;
+  out << "\n  discrete: " << (c.time_step > 0);
+  out << "\n  connected: " << c.connected;
+  return out;
+}
+
+class MultibodySceneGraphConnectionTest
+    : public testing::TestWithParam<TestConfiguration> {};
+
+/* For a given public API that *may* ultimately depend on the query object
+ input port, this confirms two things:
+
+   1. evaluating the API only throws when we expect, and
+   2. the error message always has an expected key phrase alluding to the API
+      exercised.
+
+ It is *not* the case that simply having an unconnected QueryObject input port
+ causes the APIs to throw. There must also be collision geometries registered.
+ The throwing behavior should be largely independent of whether the plant is
+ discrete or continuous. */
+TEST_P(MultibodySceneGraphConnectionTest, ConnectionError) {
+  const TestConfiguration& config = GetParam();
+
+  const double time_step = config.time_step;
+  const bool has_collision_geometry = config.has_collision_geometry;
+  const bool connected = config.connected;
+
+  DiagramBuilder<double> builder;
+  const MultibodyPlant<double>& plant = PopulateTestDiagram(
+      &builder, time_step, has_collision_geometry, connected);
+  auto diagram = builder.Build();
+  auto context = diagram->CreateDefaultContext();
+  const auto& plant_context = plant.GetMyContextFromRoot(*context);
+
+  // Structurally, we should only throw if we are unconnected with
+  // registered collision geometry.
+  const bool expect_throw = !connected && has_collision_geometry;
+  if (expect_throw) {
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        config.eval(plant, plant_context),
+        fmt::format(".*{}[^]+#mbp-unconnected-query-object-port for help.",
+                    config.key_phrase));
+  } else {
+    EXPECT_NO_THROW(config.eval(plant, plant_context));
+  }
+}
+
+// We need to populate evaluations of APIs with almost *all* combinations of
+// continuous mode, connection, collision geometry, etc. Exceptions are noted
+// below.
+std::vector<TestConfiguration> MakeTestConfigurations() {
+  std::vector<TestConfiguration> ref_configurations{
+      // Ports don't depend on MbP mode.
+      {.key_phrase = "'contact_results'", .eval = &EvalContactResults},
+      {.key_phrase = "'DefaultModelInstance_generalized_contact_forces'",
+       .eval = &EvalGeneralizedContactForces},
+      {.key_phrase = "'reaction_forces'", .eval = &EvalReactionForces},
+      // Time derivatives are only meaningful in continuous mode.
+      {.key_phrase = "time derivatives",
+       .eval = &EvalTimeDerivatives,
+       .modes = PlantMode::kContinuous},
+      {.key_phrase = "time derivatives .*residual",
+       .eval = &EvalTimeDerivativesResidual,
+       .modes = PlantMode::kContinuous},
+      // For forward dynamics, discrete and continuous are sufficiently
+      // different that evaluation of forward dynamics in continuous mode can
+      // only be detected by computation of derivatives.
+      {.key_phrase = "time derivatives",
+       .eval = &EvalForwardDynamics,
+       .modes = PlantMode::kContinuous},
+      {.key_phrase = "discrete forward dynamics",
+       .eval = &EvalForwardDynamics,
+       .modes = PlantMode::kDiscrete},
+  };
+
+  std::vector<TestConfiguration> configurations;
+  for (auto& ref_config : ref_configurations) {
+    for (double time_step : {1e-3, 0.0}) {
+      const bool is_continuous = time_step == 0.0;
+      // If the configuration has been declared as incompatible with this
+      // continuous/discrete mode, skip it.
+      if ((!is_continuous && ref_config.modes == PlantMode::kContinuous) ||
+          (is_continuous && ref_config.modes == PlantMode::kDiscrete)) {
+        continue;
+      }
+      for (bool has_collision_geometry : {true, false}) {
+        for (bool connected : {true, false}) {
+          configurations.push_back(
+              {.key_phrase = ref_config.key_phrase,
+               .eval = ref_config.eval,
+               .time_step = time_step,
+               .has_collision_geometry = has_collision_geometry,
+               .connected = connected,
+               .modes = ref_config.modes});
+        }
+      }
+    }
+  }
+  return configurations;
+}
+
+INSTANTIATE_TEST_SUITE_P(Suite, MultibodySceneGraphConnectionTest,
+                         testing::ValuesIn(MakeTestConfigurations()));
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -120,12 +120,6 @@ class MultibodyPlantTester {
     plant.CalcNormalAndTangentContactJacobians(
         context, discrete_pairs, Jn, Jt, R_WC_set);
   }
-
-  static const geometry::QueryObject<double>& EvalGeometryQueryInput(
-      const MultibodyPlant<double>& plant,
-      const systems::Context<double>& context) {
-    return plant.EvalGeometryQueryInput(context);
-  }
 };
 
 namespace {
@@ -1886,30 +1880,6 @@ GTEST_TEST(MultibodyPlantTest, AutoDiffCalcPointPairPenetrations) {
   // This test case contains no collisions, and hence we should not throw.
   DRAKE_EXPECT_NO_THROW(
       autodiff_pendulum->EvalPointPairPenetrations(*autodiff_context.get()));
-}
-
-GTEST_TEST(MultibodyPlantTest, CalcPointPairPenetrationsDisconnectedPorts) {
-  // Creates a plant and register geometry with a SceneGraph, but does not
-  // connect their respective ports in a Diagram. MultibodyPlant will know
-  // that it is registered as a source for geometry, but will fail to Eval
-  // its geometry_query_input_port(). Check that this failure happens as
-  // expected.
-  SceneGraph<double> scene_graph;
-  MultibodyPlant<double> plant(0.0);
-  plant.RegisterAsSourceForSceneGraph(&scene_graph);
-  plant.Finalize();
-  std::unique_ptr<Context<double>> context = plant.CreateDefaultContext();
-
-  // Plant was not connected to the SceneGraph in a diagram, so its input port
-  // should be invalid.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      MultibodyPlantTester::EvalGeometryQueryInput(plant, *context),
-      "The geometry query input port \\(see "
-      "MultibodyPlant::get_geometry_query_input_port\\(\\)\\) "
-      "of this MultibodyPlant is not connected. Please connect the"
-      "geometry query output port of a SceneGraph object "
-      "\\(see SceneGraph::get_query_output_port\\(\\)\\) to this plants input "
-      "port in a Diagram.");
 }
 
 GTEST_TEST(MultibodyPlantTest, LinearizePendulum) {


### PR DESCRIPTION
relates #11448

In response to the problem where `MultibodyPlant` mysteriously, suddenly complains about an unconnected `QueryObject` port, this PR provides two tactics to lessen the pain.

1. The error message now provides a URL that can contain arbitrary guidance and checklists for understanding and addressing the error message.
2. Do our best to understand what computation is being evaluated that led to caring about the state of the input port.
    - Add a test that confirms a number of public APIs that can trigger the exception and confirm the conditions under which they are sent.
    - For those same APIs, fail fast on the unconnected port error condition, providing more message as to which API triggered it (e.g., evaluating an output port, asking for derivatives, etc.) Note: this effort is imperfect.
        - First, the public API on MultibodyPlant is not necessarily the most obvious button pushed from the user's perspective. It might have been triggered by something external (e.g., evaluating forward dynamics from some arbitrary function).
        - Second, not all APIs are equally accessible. Forward dynamics for a discrete MultibodyPlant can be immediately flagged. The same is not true for the continuous plant. In the latter case, the issue can only be detected when the time derivatives get evaluated.

The two tactics are largely orthogonal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17485)
<!-- Reviewable:end -->
