### PR TITLE
Fix more ibex on Jammy issues

### DIFF
--- a/tools/workspace/ibex/include_limits.patch
+++ b/tools/workspace/ibex/include_limits.patch
@@ -1,3 +1,27 @@
+diff --git src/data/ibex_CovIBUList.cpp src/data/ibex_CovIBUList.cpp
+index 28e7fbef..3a7ce3ab 100644
+--- src/data/ibex_CovIBUList.cpp
++++ src/data/ibex_CovIBUList.cpp
+@@ -12,6 +12,7 @@
+ 
+ #include <sstream>
+ #include <algorithm>
++#include <limits>
+ 
+ using namespace std;
+ 
+diff --git src/data/ibex_CovIUList.cpp src/data/ibex_CovIUList.cpp
+index a15bd1a4..46e2f292 100644
+--- src/data/ibex_CovIUList.cpp
++++ src/data/ibex_CovIUList.cpp
+@@ -13,6 +13,7 @@
+ #include <sstream>
+ #include <cassert>
+ #include <algorithm>
++#include <limits>
+ 
+ using namespace std;
+ 
 diff --git src/operators/ibex_atanhc.h src/operators/ibex_atanhc.h
 index 741c1b1f..44f0eab3 100644
 --- src/operators/ibex_atanhc.h


### PR DESCRIPTION
Patch ibex to fix more places where it was using `std::numeric_limits` without including `<limits>`. The previous patch only covered spots hit in release builds; this also covers debug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17493)
<!-- Reviewable:end -->
