### PR TITLE
[misc] Tidy up weird spellings of AutoDiffXd

### DIFF
--- a/geometry/proximity/distance_to_point_callback.h
+++ b/geometry/proximity/distance_to_point_callback.h
@@ -240,8 +240,8 @@ struct ScalarSupport<double> {
 };
 
 /* Primitive support for AutoDiff-valued query.  */
-template <typename DerType>
-struct ScalarSupport<Eigen::AutoDiffScalar<DerType>> {
+template <>
+struct ScalarSupport<AutoDiffXd> {
   static bool is_supported(fcl::NODE_TYPE node_type) {
     switch (node_type) {
       case fcl::GEOM_SPHERE:

--- a/geometry/proximity/distance_to_shape_callback.h
+++ b/geometry/proximity/distance_to_shape_callback.h
@@ -242,8 +242,8 @@ struct ScalarSupport<double> {
 };
 
 /* Primitive support for AutoDiff-valued query.  */
-template <typename DerType>
-struct ScalarSupport<Eigen::AutoDiffScalar<DerType>> {
+template <>
+struct ScalarSupport<AutoDiffXd> {
   static bool is_supported(fcl::NODE_TYPE node1, fcl::NODE_TYPE node2) {
     // TODO(SeanCurtis-TRI): Confirm derivatives for sphere-capsule.
     // Explicitly permit the following pair types (with ordering

--- a/geometry/proximity/penetration_as_point_pair_callback.cc
+++ b/geometry/proximity/penetration_as_point_pair_callback.cc
@@ -343,8 +343,8 @@ struct ScalarSupport<double> {
 };
 
 /* Primitive support for AutoDiff-valued query.  */
-template <typename DerType>
-struct ScalarSupport<Eigen::AutoDiffScalar<DerType>> {
+template <>
+struct ScalarSupport<AutoDiffXd> {
   static bool is_supported(fcl::NODE_TYPE node1, fcl::NODE_TYPE node2) {
     // Explicitly permit the following pair types (with ordering permutations):
     //  (sphere, sphere)

--- a/geometry/utilities.h
+++ b/geometry/utilities.h
@@ -101,9 +101,8 @@ inline const math::RigidTransformd& convert_to_double(
   return X_AB;
 }
 
-template <class VectorType>
-math::RigidTransformd convert_to_double(
-    const math::RigidTransform<Eigen::AutoDiffScalar<VectorType>>& X_AB) {
+inline math::RigidTransformd convert_to_double(
+    const math::RigidTransform<AutoDiffXd>& X_AB) {
   Matrix3<double> R_converted;
   Vector3<double> p_converted;
   for (int r = 0; r < 3; ++r) {

--- a/multibody/benchmarks/acrobot/acrobot.cc
+++ b/multibody/benchmarks/acrobot/acrobot.cc
@@ -8,7 +8,6 @@ namespace drake {
 namespace multibody {
 namespace benchmarks {
 
-using Eigen::AutoDiffScalar;
 using math::RigidTransform;
 
 template <typename T>

--- a/systems/analysis/test/explicit_euler_integrator_test.cc
+++ b/systems/analysis/test/explicit_euler_integrator_test.cc
@@ -12,9 +12,8 @@ namespace systems {
 namespace {
 
 GTEST_TEST(IntegratorTest, MiscAPI) {
-  typedef Eigen::AutoDiffScalar<Eigen::VectorXd> AScalar;
   SpringMassSystem<double> spring_mass_dbl(1., 1., 0.);
-  SpringMassSystem<AScalar> spring_mass_ad(1., 1., 0.);
+  SpringMassSystem<AutoDiffXd> spring_mass_ad(1., 1., 0.);
 
   // Setup the integration step size.
   const double h = 1e-3;
@@ -26,7 +25,8 @@ GTEST_TEST(IntegratorTest, MiscAPI) {
   // Create the integrator as a double and as an autodiff type
   ExplicitEulerIntegrator<double> int_dbl(spring_mass_dbl, h,
                                           context_dbl.get());
-  ExplicitEulerIntegrator<AScalar> int_ad(spring_mass_ad, h, context_ad.get());
+  ExplicitEulerIntegrator<AutoDiffXd> int_ad(spring_mass_ad, h,
+                                             context_ad.get());
 
   // Test that setting the target accuracy or initial step size target fails.
   EXPECT_THROW(int_dbl.set_target_accuracy(1.0), std::logic_error);

--- a/systems/controllers/test/inverse_dynamics_test.cc
+++ b/systems/controllers/test/inverse_dynamics_test.cc
@@ -6,7 +6,6 @@
 
 #include <gtest/gtest.h>
 
-#include "drake/common/autodiff.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/find_resource.h"
@@ -18,7 +17,6 @@
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/fixed_input_port_value.h"
 
-using Eigen::AutoDiffScalar;
 using Eigen::VectorXd;
 using std::make_unique;
 using drake::multibody::MultibodyPlant;

--- a/systems/primitives/test/demultiplexer_test.cc
+++ b/systems/primitives/test/demultiplexer_test.cc
@@ -9,7 +9,6 @@
 #include "drake/systems/framework/fixed_input_port_value.h"
 #include "drake/systems/framework/test_utilities/scalar_conversion.h"
 
-using Eigen::AutoDiffScalar;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
 using std::make_unique;


### PR DESCRIPTION
This code only supports `AutoDiffXd` but spells it as `AutoDiffScalar`. The conventional `AutoDiffXd` is clearer for readers in any case, but also paves the way to moving away from `AutoDiffScalar` down the road.

Relatedly, also remove unused using directives and include statements for the odd spelling.

Towards #17492.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17500)
<!-- Reviewable:end -->
