### PR TITLE
[systems] Use InitializeAutoDiff instead of manual looping

### DIFF
--- a/systems/analysis/implicit_integrator.cc
+++ b/systems/analysis/implicit_integrator.cc
@@ -36,12 +36,8 @@ void ImplicitIntegrator<T>::ComputeAutoDiffJacobian(
   // math::jacobian(), if possible.
 
   // Create AutoDiff versions of the state vector.
-  VectorX<AutoDiffXd> a_xt = xt;
-
   // Set the size of the derivatives and prepare for Jacobian calculation.
-  const int n_state_dim = a_xt.size();
-  for (int i = 0; i < n_state_dim; ++i)
-    a_xt[i].derivatives() = VectorX<T>::Unit(n_state_dim, i);
+  VectorX<AutoDiffXd> a_xt = math::InitializeAutoDiff(xt);
 
   // Get the system and the context in AutoDiffable format. Inputs must also
   // be copied to the context used by the AutoDiff'd system (which is
@@ -72,7 +68,7 @@ void ImplicitIntegrator<T>::ComputeAutoDiffJacobian(
   // segfault when forming Newton iteration matrices); if it is, we set it equal
   // to an n x n zero matrix.
   if (J->cols() == 0) {
-    *J = MatrixX<T>::Zero(n_state_dim, n_state_dim);
+    *J = MatrixX<T>::Zero(xt.size(), xt.size());
   }
 }
 

--- a/systems/analysis/velocity_implicit_euler_integrator.cc
+++ b/systems/analysis/velocity_implicit_euler_integrator.cc
@@ -8,6 +8,7 @@
 #include "drake/common/autodiff.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"
+#include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/math/compute_numerical_gradient.h"
 #include "drake/systems/analysis/implicit_integrator.h"
@@ -164,11 +165,7 @@ void VelocityImplicitEulerIntegrator<T>::ComputeAutoDiffVelocityJacobian(
   }
 
   // Initialize an AutoDiff version of the variable y.
-  const int ny = y.size();
-  VectorX<AutoDiffXd> y_ad = y;
-  for (int i = 0; i < ny; ++i) {
-    y_ad(i).derivatives() = VectorX<T>::Unit(ny, i);
-  }
+  VectorX<AutoDiffXd> y_ad = math::InitializeAutoDiff(y);
 
   // Evaluate the AutoDiff system with y_ad.
   const VectorX<AutoDiffXd> result = this->ComputeLOfY(
@@ -181,6 +178,7 @@ void VelocityImplicitEulerIntegrator<T>::ComputeAutoDiffVelocityJacobian(
   // when ℓ(y) depends only on t. In this case, make sure that the Jacobian
   // isn't a n ✕ 0 matrix (this will cause a segfault when forming Newton
   // iteration matrices); if it is, we set it equal to an n x n zero matrix.
+  const int ny = y.size();
   if (Jy->cols() == 0) {
     *Jy = MatrixX<T>::Zero(ny, ny);
   }


### PR DESCRIPTION
`InitializeAutoDiff` is our canonical function for this purpose, and is carefully documented and optimized for performance.

These were the only two places I could find via `grep` that were failing to use the sugar.

Towards #17492.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17502)
<!-- Reviewable:end -->
