### PR TITLE
[parsing] Add missed check in SDFormat drake:proximity_properties

### DIFF
--- a/multibody/parsing/detail_sdf_geometry.cc
+++ b/multibody/parsing/detail_sdf_geometry.cc
@@ -486,8 +486,10 @@ ProximityProperties MakeProximityPropertiesForCollision(
       "drake:hydroelastic_modulus",
       "drake:hunt_crossley_dissipation",
       "drake:point_contact_stiffness",
-      "drake::mu_dynamic",
-      "drake::mu_static"};
+      "drake:mu_dynamic",
+      "drake:mu_static"};
+    CheckSupportedElements(diagnostic, drake_element,
+                           supported_proximity_elements);
 
     auto read_double =
         [drake_element](const char* element_name) -> std::optional<double> {

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -2450,6 +2450,7 @@ TEST_F(SdfParserTest, UnsupportedElements) {
   EXPECT_THAT(TakeWarning(), MatchesRegex(".*lighting"));
   EXPECT_THAT(TakeWarning(), MatchesRegex(".*script"));
   EXPECT_THAT(TakeWarning(), MatchesRegex(".*shader"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*drake:QQQ_dynamic"));
 }
 
 }  // namespace

--- a/multibody/parsing/test/sdf_parser_test/unsupported_elements.sdf
+++ b/multibody/parsing/test/sdf_parser_test/unsupported_elements.sdf
@@ -36,6 +36,9 @@
             <size>0.486 0.35 0.581</size>
           </box>
         </geometry>
+        <drake:proximity_properties>
+          <drake:QQQ_dynamic/>
+        </drake:proximity_properties>
       </collision>
       <drake:proximity_properties/>
     </link>


### PR DESCRIPTION
Relevant to: #16785 (already closed)

This patch adds a missed call to CheckSupportedElements() for the
SDFormat parsing of drake:proximity_properties. It fixes some typos in
the (previously unused) supported element data. It also adds new test
clauses to ensure the checking is executed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17510)
<!-- Reviewable:end -->
