### PR TITLE
Parse dissipation_time_scale for SAP.

### DIFF
--- a/geometry/proximity_properties.cc
+++ b/geometry/proximity_properties.cc
@@ -7,6 +7,7 @@ namespace internal {
 const char* const kMaterialGroup = "material";
 const char* const kFriction = "coulomb_friction";
 const char* const kHcDissipation = "hunt_crossley_dissipation";
+const char* const kDissipationTimescale = "dissipation_timescale";
 const char* const kPointStiffness = "point_contact_stiffness";
 
 const char* const kHydroGroup = "hydroelastic";

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -35,6 +35,8 @@ extern const char* const kFriction;        ///< Friction coefficients property
                                            ///< name.
 extern const char* const kHcDissipation;   ///< Hunt-Crossley dissipation
                                            ///< property name.
+extern const char* const kDissipationTimescale;   ///< Linear dissipation
+                                                  ///< property name.
 extern const char* const kPointStiffness;  ///< Point stiffness property
                                            ///< name.
 

--- a/multibody/parsing/detail_common.cc
+++ b/multibody/parsing/detail_common.cc
@@ -89,6 +89,9 @@ geometry::ProximityProperties ParseProximityProperties(
   std::optional<double> dissipation =
       read_double("drake:hunt_crossley_dissipation");
 
+  std::optional<double> dissipation_timescale =
+      read_double("drake:dissipation_timescale");
+
   std::optional<double> stiffness =
       read_double("drake:point_contact_stiffness");
 
@@ -106,6 +109,17 @@ geometry::ProximityProperties ParseProximityProperties(
   }
 
   geometry::AddContactMaterial(dissipation, stiffness, friction, &properties);
+
+  if (dissipation_timescale.has_value()) {
+    if (*dissipation_timescale < 0) {
+      throw std::logic_error(
+          fmt::format("The dissipation time scale can't be negative; given {}",
+                      *dissipation));
+    }
+    properties.AddProperty(geometry::internal::kMaterialGroup,
+                           geometry::internal::kDissipationTimescale,
+                           *dissipation_timescale);
+  }
 
   return properties;
 }

--- a/multibody/parsing/detail_sdf_geometry.cc
+++ b/multibody/parsing/detail_sdf_geometry.cc
@@ -485,6 +485,7 @@ ProximityProperties MakeProximityPropertiesForCollision(
       "drake:mesh_resolution_hint",
       "drake:hydroelastic_modulus",
       "drake:hunt_crossley_dissipation",
+      "drake:dissipation_timescale",
       "drake:point_contact_stiffness",
       "drake:mu_dynamic",
       "drake:mu_static"};

--- a/multibody/parsing/detail_sdf_geometry.h
+++ b/multibody/parsing/detail_sdf_geometry.h
@@ -153,11 +153,12 @@ math::RigidTransformd MakeGeometryPoseFromSdfCollision(
   @ref YET_TO_BE_WRITTEN_HYDROELASTIC_GEOMETRY_MODULE for details on the
  semantics of these properties.
 
-  | Tag                              | Group        | Property                  | Notes                                                                                                                            |
+ | Tag                              | Group        | Property                  | Notes                                                                                                                            |
  | :------------------------------: | :----------: | :-----------------------: | :------------------------------------------------------------------------------------------------------------------------------: |
  | drake:mesh_resolution_hint       | hydroelastic | resolution_hint           | Required for shapes that require tessellation to support hydroelastic contact.                                                   |
- | drake:hydroelastic_modulus       | hydroelastic | hydroelastic_modulus      | Finite positive value. Required for compliant hydroelastic representations.                                                           |
+ | drake:hydroelastic_modulus       | hydroelastic | hydroelastic_modulus      | Finite positive value. Required for compliant hydroelastic representations.                                                      |
  | drake:hunt_crossley_dissipation  | material     | hunt_crossley_dissipation |                                                                                                                                  |
+ | drake:dissipation_timescale     | material     | dissipation_timescale    | Required when using a linear model of dissipation, for instance with the SAP solver.                                              |
  | drake:mu_dynamic                 | material     | coulomb_friction          | See note below on friction.                                                                                                      |
  | drake:mu_static                  | material     | coulomb_friction          | See note below on friction.                                                                                                      |
  | drake:rigid_hydroelastic         | hydroelastic | compliance_type           | Requests a rigid hydroelastic representation. Cannot be combined *with* soft_hydroelastic.                                       |

--- a/multibody/parsing/detail_urdf_geometry.h
+++ b/multibody/parsing/detail_urdf_geometry.h
@@ -182,6 +182,7 @@ std::optional<geometry::GeometryInstance> ParseVisual(
  | drake:mesh_resolution_hint       | hydroelastic | resolution_hint           | Required for shapes that require tessellation to support hydroelastic contact.                                                   |
  | drake:hydroelastic_modulus       | hydroelastic | hydroelastic_modulus      | Finite positive value. Required for compliant hydroelastic representations.                                                      |
  | drake:hunt_crossley_dissipation  | material     | hunt_crossley_dissipation |                                                                                                                                  |
+ | drake:dissipation_timescale     | material     | dissipation_timescale    | Required when using a linear model of dissipation, for instance with the SAP solver.                                              |
  | drake:mu_dynamic                 | material     | coulomb_friction          | See note below on friction.                                                                                                      |
  | drake:mu_static                  | material     | coulomb_friction          | See note below on friction.                                                                                                      |
  | drake:rigid_hydroelastic         | hydroelastic | compliance_type           | Requests a rigid hydroelastic representation. Cannot be combined *with* soft_hydroelastic.                                       |

--- a/multibody/parsing/parsing_doxygen.h
+++ b/multibody/parsing/parsing_doxygen.h
@@ -151,6 +151,7 @@ Here is the full list of custom elements:
 - @ref tag_drake_damping
 - @ref tag_drake_declare_convex
 - @ref tag_drake_diffuse_map
+- @ref tag_drake_dissipation_timescale
 - @ref tag_drake_ellipsoid
 - @ref tag_drake_gear_ratio
 - @ref tag_drake_hunt_crossley_dissipation
@@ -454,6 +455,21 @@ ProximityProperties object under `(material, hunt_crossley_dissipation)`.
 
 @see drake::geometry::ProximityProperties,
 @ref mbp_hydroelastic_materials_properties "Hydroelastic contact",
+@ref mbp_dissipation_model "Modeling Dissipation"
+
+@subsection tag_drake_dissipation_timescale drake:dissipation_timescale
+
+- SDFormat path: `//model/link/collision/drake:proximity_properies/drake:dissipation_timescale`
+- URDF path: `/robot/link/collision/drake:proximity_properties/drake:dissipation_timescale/@value`
+- Syntax: Non-negative floating point value.
+
+@subsubsection tag_drake_dissipation_timescale_semantics Semantics
+
+If present, this element provides a value (units of time,
+i.e. seconds) for a linear model of dissipation. It is stored in a
+ProximityProperties object under `(material, dissipation_timescale)`.
+
+@see drake::geometry::ProximityProperties,
 @ref mbp_dissipation_model "Modeling Dissipation"
 
 @subsection tag_drake_hydroelastic_modulus drake:hydroelastic_modulus

--- a/multibody/parsing/test/detail_common_test.cc
+++ b/multibody/parsing/test/detail_common_test.cc
@@ -14,6 +14,7 @@ using geometry::GeometryProperties;
 using geometry::ProximityProperties;
 using geometry::internal::HydroelasticType;
 using geometry::internal::kComplianceType;
+using geometry::internal::kDissipationTimescale;
 using geometry::internal::kElastic;
 using geometry::internal::kFriction;
 using geometry::internal::kHcDissipation;
@@ -243,6 +244,19 @@ TEST_F(ParseProximityPropertiesTest, Dissipation) {
       param_read_double("drake:hunt_crossley_dissipation", kValue), !rigid,
       !compliant);
   EXPECT_TRUE(ExpectScalar(kMaterialGroup, kHcDissipation, kValue, properties));
+  // Dissipation is the only property.
+  EXPECT_EQ(properties.GetPropertiesInGroup(kMaterialGroup).size(), 1u);
+  EXPECT_EQ(properties.num_groups(), 2);  // Material and default groups.
+}
+
+// Confirms successful parsing of linear dissipation.
+TEST_F(ParseProximityPropertiesTest, LinearDissipation) {
+  const double kValue = 1.25;
+  ProximityProperties properties = ParseProximityProperties(
+      param_read_double("drake:dissipation_timescale", kValue), !rigid,
+      !compliant);
+  EXPECT_TRUE(
+      ExpectScalar(kMaterialGroup, kDissipationTimescale, kValue, properties));
   // Dissipation is the only property.
   EXPECT_EQ(properties.GetPropertiesInGroup(kMaterialGroup).size(), 1u);
   EXPECT_EQ(properties.num_groups(), 2);  // Material and default groups.

--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -1136,6 +1136,7 @@ TEST_F(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
     <drake:mesh_resolution_hint>2.5</drake:mesh_resolution_hint>
     <drake:hydroelastic_modulus>3.5</drake:hydroelastic_modulus>
     <drake:hunt_crossley_dissipation>4.5</drake:hunt_crossley_dissipation>
+    <drake:dissipation_timescale>3.1</drake:dissipation_timescale>
     <drake:mu_dynamic>4.5</drake:mu_dynamic>
     <drake:mu_static>4.75</drake:mu_static>
   </drake:proximity_properties>)""");
@@ -1147,6 +1148,8 @@ TEST_F(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
                            geometry::internal::kElastic, 3.5);
     assert_single_property(properties, geometry::internal::kMaterialGroup,
                            geometry::internal::kHcDissipation, 4.5);
+    assert_single_property(properties, geometry::internal::kMaterialGroup,
+                           geometry::internal::kDissipationTimescale, 3.1);
     assert_friction(properties, {4.75, 4.5});
   }
 

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -675,6 +675,7 @@ TEST_F(UrdfGeometryTest, CollisionSmokeTest) {
     <drake:mesh_resolution_hint value="2.5"/>
     <drake:hydroelastic_modulus value="3.5" />
     <drake:hunt_crossley_dissipation value="3.5" />
+    <drake:dissipation_timescale value="3.1" />
     <drake:mu_dynamic value="3.25" />
     <drake:mu_static value="3.5" />
   </drake:proximity_properties>)""");
@@ -684,6 +685,8 @@ TEST_F(UrdfGeometryTest, CollisionSmokeTest) {
                          geometry::internal::kElastic, 3.5);
   VerifySingleProperty(properties, geometry::internal::kMaterialGroup,
                        geometry::internal::kHcDissipation, 3.5);
+  VerifySingleProperty(properties, geometry::internal::kMaterialGroup,
+                       geometry::internal::kDissipationTimescale, 3.1);
   VerifyFriction(properties, {3.5, 3.25});
 }
 

--- a/multibody/plant/compliant_contact_manager.h
+++ b/multibody/plant/compliant_contact_manager.h
@@ -114,7 +114,7 @@ struct ContactProblemCache {
 // (in Newtons) is modeled as:
 //   fₙ = k⋅(x + τ⋅ẋ)₊
 // where k is the point contact stiffness, see GetPointContactStiffness(), τ is
-// the dissipation time scale, and ()₊ corresponds to the "positive part"
+// the dissipation timescale, and ()₊ corresponds to the "positive part"
 // operator.
 // Similarly, for hydroelastic contact the normal traction p (in Pascals) is:
 //   p = (p₀+τ⋅dp₀/dn⋅ẋ)₊
@@ -210,7 +210,7 @@ class CompliantContactManager final
   static T CombineStiffnesses(const T& k1, const T& k2);
 
   // Utility to combine linear dissipation time constants. Consider two
-  // spring-dampers with stiffnesses k₁ and k₂, and dissipation time scales τ₁
+  // spring-dampers with stiffnesses k₁ and k₂, and dissipation timescales τ₁
   // and τ₂, respectively. When these spring-dampers are connected in series,
   // they result in an equivalent spring-damper with stiffness k  =
   // k₁⋅k₂/(k₁+k₂) and dissipation τ = τ₁ + τ₂.

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -366,7 +366,9 @@ the following properties for point contact modeling:
 | :--------: | :--------------: | :------: | :----------------: | :------------------- |
 |  material  | coulomb_friction |   yes¹   | CoulombFriction<T> | Static and Dynamic friction. |
 |  material  | point_contact_stiffness |  no²  | T | Penalty method stiffness. |
-|  material  | hunt_crossley_dissipation |  no²  | T | Penalty method dissipation. |
+|  material  | hunt_crossley_dissipation |  no²⁴  | T | Penalty method dissipation. |
+|  material  | dissipation_timescale |  yes³⁴  | T | Linear dissipation parameter. |
+
 
 ¹ Collision geometry is required to be registered with a
   geometry::ProximityProperties object that contains the
@@ -377,6 +379,23 @@ the following properties for point contact modeling:
   a heuristic value as the default. Refer to the
   section @ref mbp_penalty_method "Penalty method point contact" for further
   details.
+
+³ When using a linear model of dissipation (for instance when selecting the SAP
+  solver), collision geometry is required to be registered with a
+  geometry::ProximityProperties object that contains the ("material",
+  "dissipation_timescale") property. If the property is missing, an exception
+  will be thrown.
+
+⁴ We allow to specify both hunt_crossley_dissipation and dissipation_timescale
+  for a given geometry. However only one of these will get used, depending on
+  the configuration of the %MultibodyPlant. As an example, if the SAP solver is
+  specified (see set_discrete_contact_solver_type()) only the
+  dissipation_timescale is used while hunt_crossley_dissipation is ignored.
+  Conversely, if the TAMSI solver is used (see
+  set_discrete_contact_solver_type()) only hunt_crossley_dissipation is used
+  while dissipation_timescale is ignored. Currently, a continuous
+  %MultibodyPlant model will always use the Hunt & Crossley model and
+  dissipation_timescale will be ignored.
 
 Accessing and modifying contact properties requires interfacing with
 geometry::SceneGraph's model inspector. Interfacing with a model inspector

--- a/multibody/plant/test/compliant_contact_manager_test.cc
+++ b/multibody/plant/test/compliant_contact_manager_test.cc
@@ -159,7 +159,9 @@ class SpheresStack : public ::testing::Test {
     std::optional<double> hydro_modulus;
     // Dissipation time constant τ is used to setup the linear dissipation model
     // where dissipation is c = τ⋅k, with k the point pair stiffness.
-    double dissipation_time_constant{nan()};
+    // If nullopt, no dissipation is specified, i.e. the corresponding
+    // ProximityProperties will not have dissipation defined.
+    std::optional<double> dissipation_timescale;
     // Coefficient of dynamic friction.
     double friction_coefficient{nan()};
   };
@@ -323,6 +325,32 @@ class SpheresStack : public ::testing::Test {
         EvalContactSurfaces(*plant_context_);
     ASSERT_EQ(surfaces.size(), 1u);
     const int num_hydro_pairs = surfaces[0].num_faces();
+
+    // In these tests ContactParameters::dissipation_timescale = nullopt
+    // indicates we want to build a model for which we forgot to specify the
+    // dissipation timescale in ProximityProperties. Here we verify this is
+    // required by the manager.
+    if (!sphere1_point_params.dissipation_timescale.has_value() ||
+        !sphere2_point_params.dissipation_timescale.has_value()) {
+      DRAKE_EXPECT_THROWS_MESSAGE(
+          EvalDiscreteContactPairs(*plant_context_),
+          "No `dissipation_timescale` specified. For geometry .* on body .*. "
+          "You are using a linear model of compliant contact that requires you "
+          "to specify dissipation explicitly.");
+      return;
+    }
+
+    // Verify that the manager throws an exception if a negative dissipation
+    // timescale is provided.
+    if (*sphere1_point_params.dissipation_timescale < 0 ||
+        *sphere2_point_params.dissipation_timescale < 0) {
+      DRAKE_EXPECT_THROWS_MESSAGE(EvalDiscreteContactPairs(*plant_context_),
+                                  "Dissipation timescale must be non-negative "
+                                  "and dissipation_timescale = .* was "
+                                  "provided. For geometry .* on body .*.");
+      return;
+    }
+
     const std::vector<DiscreteContactPair<double>>& pairs =
         EvalDiscreteContactPairs(*plant_context_);
     EXPECT_EQ(pairs.size(), num_point_pairs + num_hydro_pairs);
@@ -364,10 +392,10 @@ class SpheresStack : public ::testing::Test {
       EXPECT_TRUE(CompareMatrices(point_pair.nhat_BA_W, normal_expected));
 
       // Verify dissipation.
-      const double tau1 = sphere1_contact_params.dissipation_time_constant;
+      const double tau1 = *sphere1_contact_params.dissipation_timescale;
       const double tau2 = i == 0
-                              ? sphere2_contact_params.dissipation_time_constant
-                              : hard_hydro_contact.dissipation_time_constant;
+                              ? *sphere2_contact_params.dissipation_timescale
+                              : *hard_hydro_contact.dissipation_timescale;
       const double tau_expected = tau1 + tau2;
       EXPECT_NEAR(point_pair.dissipation_time_scale, tau_expected,
                   kEps * tau_expected);
@@ -523,6 +551,7 @@ class SpheresStack : public ::testing::Test {
   }
 
   // Utility to make ProximityProperties from ContactParameters.
+  // params.dissipation_timescale is ignored if nullopt.
   static ProximityProperties MakeProximityProperties(
       const ContactParameters& params) {
     DRAKE_DEMAND(params.point_stiffness || params.hydro_modulus);
@@ -545,9 +574,12 @@ class SpheresStack : public ::testing::Test {
         CoulombFriction<double>(params.friction_coefficient,
                                 params.friction_coefficient),
         &properties);
-    properties.AddProperty(geometry::internal::kMaterialGroup,
-                           "dissipation_time_constant",
-                           params.dissipation_time_constant);
+
+    if (params.dissipation_timescale.has_value()) {
+      properties.AddProperty(geometry::internal::kMaterialGroup,
+                             "dissipation_timescale",
+                             *params.dissipation_timescale);
+    }
     return properties;
   }
 };
@@ -556,6 +588,37 @@ class SpheresStack : public ::testing::Test {
 // different combinations of compliance.
 TEST_F(SpheresStack, VerifyDiscreteContactPairs) {
   ContactParameters soft_point_contact{1.0e3, std::nullopt, 0.01, 1.0};
+  ContactParameters hard_point_contact{1.0e40, std::nullopt, 0.0, 1.0};
+
+  // Hard sphere 1/soft sphere 2.
+  VerifyDiscreteContactPairs(hard_point_contact, soft_point_contact);
+
+  // Equally soft spheres.
+  VerifyDiscreteContactPairs(soft_point_contact, soft_point_contact);
+
+  // Soft sphere 1/hard sphere 2.
+  VerifyDiscreteContactPairs(soft_point_contact, hard_point_contact);
+}
+
+TEST_F(SpheresStack, DissipationTimeScaleIsRequired) {
+  ContactParameters soft_point_contact{
+      1.0e3, std::nullopt,
+      std::nullopt /* Dissipation not included in ProximityProperties */, 1.0};
+  ContactParameters hard_point_contact{1.0e40, std::nullopt, 0.0, 1.0};
+
+  // Hard sphere 1/soft sphere 2.
+  VerifyDiscreteContactPairs(hard_point_contact, soft_point_contact);
+
+  // Equally soft spheres.
+  VerifyDiscreteContactPairs(soft_point_contact, soft_point_contact);
+
+  // Soft sphere 1/hard sphere 2.
+  VerifyDiscreteContactPairs(soft_point_contact, hard_point_contact);
+}
+
+TEST_F(SpheresStack, DissipationTimeScaleMustBePositive) {
+  ContactParameters soft_point_contact{
+      1.0e3, std::nullopt, -1.0 /* Negative dissipation timescale */, 1.0};
   ContactParameters hard_point_contact{1.0e40, std::nullopt, 0.0, 1.0};
 
   // Hard sphere 1/soft sphere 2.


### PR DESCRIPTION
We need to update our documentation on the contact models. 
Places that need a pretty good revision because they are out of date are:
  1. `multibody_plant.h`, at mbp_contact_modeling.
  2. `contact_model_doxygen.h`, at drake_contacts.
Some of it is outdated and/or repeated.

This PR does not fix that documentation just yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17512)
<!-- Reviewable:end -->
