### PR TITLE
[yaml] Output special floating point values correctly

### DIFF
--- a/common/yaml/test/yaml_write_archive_test.cc
+++ b/common/yaml/test/yaml_write_archive_test.cc
@@ -56,6 +56,11 @@ TEST_F(YamlWriteArchiveTest, Double) {
   test(5.6e-12, "5.6e-12");
   test(-5.6e+16, "-5.6e+16");
   test(-5.6e-12, "-5.6e-12");
+
+  // See https://yaml.org/spec/1.2.2/#10214-floating-point for the specs.
+  test(std::numeric_limits<double>::quiet_NaN(), ".nan");
+  test(std::numeric_limits<double>::infinity(), ".inf");
+  test(-std::numeric_limits<double>::infinity(), ".-inf");
 }
 
 TEST_F(YamlWriteArchiveTest, String) {

--- a/common/yaml/yaml_write_archive.h
+++ b/common/yaml/yaml_write_archive.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cmath>
 #include <map>
 #include <optional>
 #include <stdexcept>
@@ -214,13 +215,17 @@ class YamlWriteArchive final {
   void VisitScalar(const NVP& nvp) {
     using T = typename NVP::value_type;
     const T& value = *nvp.value();
-    // Different versions of fmt disagree on whether to omit the trailing
-    // ".0" when formatting integer-valued floating-point numbers.  Force
-    // the ".0" in all cases by using the "#" option for floats.
-    constexpr std::string_view pattern =
-        std::is_floating_point_v<T> ? "{:#}" : "{}";
+    if constexpr (std::is_floating_point_v<T>) {
+      // Different versions of fmt disagree on whether to omit the trailing
+      // ".0" when formatting integer-valued floating-point numbers.  Force
+      // the ".0" in all cases by using the "#" option for floats.  Also be
+      // sure to add the required leading period for special values.
+      root_.Add(nvp.name(), internal::Node::MakeScalar(
+          fmt::format("{}{:#}", std::isfinite(value) ? "" : ".", value)));
+      return;
+    }
     root_.Add(nvp.name(), internal::Node::MakeScalar(
-        fmt::format(pattern, value)));
+        fmt::format("{}", value)));
   }
 
   // This is used for std::optional or similar.


### PR DESCRIPTION
The YAML syntax requires that they begin with a leading period, e.g., `.inf` instead of `inf`.

Closes #17503.

+@dmcconachie-tri would you like to feature-review?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17517)
<!-- Reviewable:end -->
