### PR TITLE
[performance] Add allocation reporting

### DIFF
--- a/multibody/benchmarking/cassie.cc
+++ b/multibody/benchmarking/cassie.cc
@@ -7,6 +7,7 @@
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/tools/performance/fixture_common.h"
+#include "drake/tools/performance/fixture_memory.h"
 
 namespace drake {
 namespace multibody {
@@ -50,6 +51,7 @@ class Cassie : public benchmark::Fixture {
   void SetUp(BenchmarkStateRef state) override {
     SetUpNonZeroState();
     SetUpGradientsOrVariables(state);
+    tools::performance::TareMemoryManager();
   }
 
  protected:

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -85,6 +85,16 @@ config_setting(
     values = {"define": "WITH_SNOPT=ON"},
 )
 
+config_setting(
+    name = "using_sanitizer",
+    values = {"define": "USING_SANITIZER=ON"},
+)
+
+config_setting(
+    name = "using_memcheck",
+    values = {"define": "USING_MEMCHECK=ON"},
+)
+
 # CLP is an open-source solver, and is included in the Drake build by
 # default. The CLP solver is irrelevant to some users of MathematicalProgram,
 # so we provide a hidden switch to shut it off for developers who don't

--- a/tools/dynamic_analysis/bazel.rc
+++ b/tools/dynamic_analysis/bazel.rc
@@ -59,6 +59,7 @@ build:asan --test_lang_filters=-sh,-py
 # Typical slowdown introduced by AddressSanitizer is 2x.
 # See https://clang.llvm.org/docs/AddressSanitizer.html
 build:asan --test_timeout=150,750,2250,9000  # 2.5x
+build:asan --define=USING_SANITIZER=ON
 
 ### ASan everything build. Clang only. ###
 build:asan_everything --build_tests_only
@@ -91,6 +92,7 @@ build:asan_everything --test_lang_filters=-sh,-py
 # Typical slowdown introduced by AddressSanitizer is 2x.
 # See https://clang.llvm.org/docs/AddressSanitizer.html
 build:asan_everything --test_timeout=150,750,2250,9000  # 2.5x
+build:asan_everything --define=USING_SANITIZER=ON
 
 ### LSan build. Clang only. ###
 build:lsan --build_tests_only
@@ -106,6 +108,7 @@ build:lsan --test_env=LSAN_OPTIONS
 build:lsan --test_env=LSAN_SYMBOLIZER_PATH
 build:lsan --test_tag_filters=-gurobi,-mosek,-snopt,-no_lsan
 build:lsan --test_lang_filters=-sh,-py
+build:lsan --define=USING_SANITIZER=ON
 
 ### LSan everything build. Clang only. ###
 build:lsan_everything --build_tests_only
@@ -124,6 +127,7 @@ build:lsan_everything --run_under=//tools/dynamic_analysis:lsan
 build:lsan_everything --test_env=LSAN_OPTIONS
 build:lsan_everything --test_env=LSAN_SYMBOLIZER_PATH
 build:lsan_everything --test_lang_filters=-sh,-py
+build:lsan_everything --define=USING_SANITIZER=ON
 
 ### TSan build. ###
 build:tsan --build_tests_only
@@ -145,6 +149,7 @@ build:tsan --test_lang_filters=-sh,-py
 # Typical slowdown introduced by ThreadSanitizer is about 5x-15x
 # See https://clang.llvm.org/docs/ThreadSanitizer.html
 build:tsan --test_timeout=300,1500,5400,18000
+build:tsan --define=USING_SANITIZER=ON
 
 ### TSan everything build. ###
 build:tsan_everything --build_tests_only
@@ -169,6 +174,7 @@ build:tsan_everything --test_lang_filters=-sh,-py
 # Typical slowdown introduced by ThreadSanitizer is about 5x-15x
 # See https://clang.llvm.org/docs/ThreadSanitizer.html
 build:tsan_everything --test_timeout=300,1500,5400,18000
+build:tsan_everything --define=USING_SANITIZER=ON
 
 ### UBSan build. ###
 build:ubsan --build_tests_only
@@ -190,6 +196,7 @@ build:ubsan --test_lang_filters=-sh,-py
 # Typical slowdown introduced by UBSan is 1.2x, increasing timeouts to 2x.
 # See https://developer.apple.com/documentation/code_diagnostics/undefined_behavior_sanitizer
 build:ubsan --test_timeout=120,600,1800,7200
+build:ubsan --define=USING_SANITIZER=ON
 
 ### UBSan everything build. ###
 build:ubsan_everything --build_tests_only
@@ -214,6 +221,7 @@ build:ubsan_everything --test_lang_filters=-sh,-py
 # Typical slowdown introduced by UBSan is 1.2x, increasing timeouts to 2x.
 # See https://developer.apple.com/documentation/code_diagnostics/undefined_behavior_sanitizer
 build:ubsan_everything --test_timeout=120,600,1800,7200
+build:ubsan_everything --define=USING_SANITIZER=ON
 
 ### Memcheck build. ###
 build:memcheck --build_tests_only
@@ -232,6 +240,7 @@ build:memcheck --test_tag_filters=-gurobi,-mosek,-snopt,-lint,-no_memcheck,-no_v
 # See http://valgrind.org/info/about.html
 build:memcheck --test_timeout=1500,7500,22500,90000  # 25x
 build:memcheck --test_env=VALGRIND_OPTS
+build:memcheck --define=USING_MEMCHECK=ON
 
 ### Memcheck everything build. ###
 build:memcheck_everything --build_tests_only
@@ -249,6 +258,7 @@ build:memcheck_everything --test_lang_filters=-sh,-py
 # Slowdown factor can range from 5-100.
 # See http://valgrind.org/info/about.html
 build:memcheck_everything --test_timeout=1500,7500,22500,90000  # 25x
+build:memcheck_everything --define=USING_MEMCHECK=ON
 
 # Fast memcheck.
 #
@@ -264,6 +274,7 @@ build:fastmemcheck --test_lang_filters=-sh,-py
 # Slowdown factor can range from 5-100.
 # See http://valgrind.org/info/about.html
 build:fastmemcheck --test_timeout=1500,7500,22500,90000  # 25x
+build:fastmemcheck --define=USING_MEMCHECK=ON
 
 ### DRD: A Valgrind thread error detector ###
 # Not tested in continuous integration so may fail, even on master.

--- a/tools/performance/BUILD.bazel
+++ b/tools/performance/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load(
     "@drake//tools/skylark:drake_cc.bzl",
     "drake_cc_library",
@@ -26,10 +27,38 @@ drake_cc_library(
     ],
 )
 
+config_setting(
+    name = "apple",
+    constraint_values = ["@platforms//os:osx"],
+)
+
+selects.config_setting_group(
+    name = "fixture_memory_no",
+    match_any = [
+        ":apple",
+        "//tools:using_memcheck",
+        "//tools:using_sanitizer",
+    ],
+)
+
+drake_cc_library(
+    name = "fixture_memory",
+    srcs = select({
+        ":fixture_memory_no": ["fixture_memory_no.cc"],
+        "//conditions:default": ["fixture_memory_yes.cc"],
+    }),
+    hdrs = ["fixture_memory.h"],
+    deps = [
+        "//common:essential",
+        "@googlebenchmark//:benchmark",
+    ],
+)
+
 drake_cc_library(
     name = "gflags_main",
     srcs = ["gflags_main.cc"],
     deps = [
+        ":fixture_memory",
         "@gflags",
         "@googlebenchmark//:benchmark",
     ],
@@ -44,4 +73,9 @@ drake_py_binary(
     ],
 )
 
-add_lint_tests()
+add_lint_tests(
+    cpplint_extra_srcs = [
+        "fixture_memory_no.cc",
+        "fixture_memory_yes.cc",
+    ],
+)

--- a/tools/performance/fixture_memory.h
+++ b/tools/performance/fixture_memory.h
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace drake {
+namespace tools {
+namespace performance {
+
+/** Globally enables memory reporting (for all suites within this program).
+This is not thread-safe, so should only be called on main thread.
+
+Note that the allocation counting implementation is not thread-safe. (To reduce
+the instrumentation cost, it does not use buslocked additions.) Therefore, the
+allocation statistics might under-count on multi-threaded programs. */
+void EnableMemoryManager();
+
+/** Zeros out all memory stats. This useful when you don't want allocations
+from SetUp amortized over the state iterations. This is not thread-safe, so
+should only be called on main thread. */
+void TareMemoryManager();
+
+}  // namespace performance
+}  // namespace tools
+}  // namespace drake

--- a/tools/performance/fixture_memory_no.cc
+++ b/tools/performance/fixture_memory_no.cc
@@ -1,0 +1,13 @@
+#include "drake/tools/performance/fixture_memory.h"
+
+namespace drake {
+namespace tools {
+namespace performance {
+
+void EnableMemoryManager() {}
+
+void TareMemoryManager() {}
+
+}  // namespace performance
+}  // namespace tools
+}  // namespace drake

--- a/tools/performance/fixture_memory_yes.cc
+++ b/tools/performance/fixture_memory_yes.cc
@@ -1,0 +1,115 @@
+/* clang-format off to disable clang-format-includes */
+#include "drake/tools/performance/fixture_memory.h"
+/* clang-format on */
+
+#include <type_traits>
+
+#include <benchmark/benchmark.h>
+#include <malloc.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/never_destroyed.h"
+
+// TODO(jwnimmer-tri) We can drop this compat macro once we drop support for
+// Ubuntu 20.04 Focal.
+#if (__GLIBC__ == 2) && (__GLIBC_MINOR__ < 33)
+#define mallinfo2 mallinfo
+#endif
+
+namespace {
+
+using benchmark::MemoryManager;
+using Result = MemoryManager::Result;
+
+/* This class is a singleton (via EnableMemoryManager). */
+class GlibcMemoryManager final : public MemoryManager {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(GlibcMemoryManager);
+  GlibcMemoryManager() = default;
+
+  void Start() final { Tare(); }
+  void Stop(Result* result) final;
+  void Stop(Result& result) final { this->Stop(&result); }  // NOLINT
+
+  // Resets all counters back to zero.
+  static void Tare() {
+    g_num_allocs = 0;
+    g_total_allocated_bytes = 0;
+    g_mallinfo_tare = ::mallinfo2();
+  }
+
+  // Since this class is a singleton, we can use static fields instead of
+  // instance fields, for convenience.
+  static int64_t g_num_allocs;
+  static int64_t g_total_allocated_bytes;
+  static struct mallinfo2 g_mallinfo_tare;
+};
+
+int64_t GlibcMemoryManager::g_num_allocs = 0;
+int64_t GlibcMemoryManager::g_total_allocated_bytes = 0;
+static_assert(std::is_trivially_constructible<struct mallinfo2>());
+static_assert(std::is_trivially_destructible<struct mallinfo2>());
+struct mallinfo2 GlibcMemoryManager::g_mallinfo_tare = {};
+
+void GlibcMemoryManager::Stop(Result* result) {
+  DRAKE_DEMAND(result != nullptr);
+
+  struct mallinfo2 report = ::mallinfo2();
+
+  result->num_allocs = g_num_allocs;
+  result->total_allocated_bytes = g_total_allocated_bytes;
+  result->net_heap_growth = report.uordblks - g_mallinfo_tare.uordblks;
+
+  // There's no easy way to collect this data.
+  result->max_bytes_used = 0;
+}
+
+}  // namespace
+
+namespace drake {
+namespace tools {
+namespace performance {
+
+void EnableMemoryManager() {
+  // Even though our manager subclass doesn't have any member fields, we don't
+  // know if the base class has any. Therefore, we can't use a static global,
+  // we need to create the manager on demand (just once).
+  static const never_destroyed<GlibcMemoryManager> singleton;
+  benchmark::RegisterMemoryManager(
+      const_cast<GlibcMemoryManager*>(&singleton.access()));
+}
+
+void TareMemoryManager() {
+  GlibcMemoryManager::Tare();
+}
+
+}  // namespace performance
+}  // namespace tools
+}  // namespace drake
+
+// https://www.gnu.org/software/libc/manual/html_node/Replacing-malloc.html#Replacing-malloc
+extern "C" void* __libc_malloc(size_t);
+extern "C" void* __libc_free(void*);
+extern "C" void* __libc_calloc(size_t, size_t);
+extern "C" void* __libc_realloc(void*, size_t);
+void* malloc(size_t size) {
+  // Note the disclaimer on EnableMemoryManager() on counting vs threading.
+  GlibcMemoryManager::g_num_allocs += 1;
+  GlibcMemoryManager::g_total_allocated_bytes += size;
+  return __libc_malloc(size);
+}
+void free(void* ptr) {
+  __libc_free(ptr);
+}
+void* calloc(size_t nmemb, size_t size) {
+  // Note the disclaimer on EnableMemoryManager() on counting vs threading.
+  GlibcMemoryManager::g_num_allocs += 1;
+  GlibcMemoryManager::g_total_allocated_bytes += nmemb * size;
+  return __libc_calloc(nmemb, size);
+}
+void* realloc(void* ptr, size_t size) {
+  // Note the disclaimer on EnableMemoryManager() on counting vs threading.
+  GlibcMemoryManager::g_num_allocs += 1;
+  GlibcMemoryManager::g_total_allocated_bytes += size;
+  return __libc_realloc(ptr, size);
+}

--- a/tools/performance/gflags_main.cc
+++ b/tools/performance/gflags_main.cc
@@ -4,6 +4,10 @@
 #include <benchmark/benchmark.h>
 #include <gflags/gflags.h>
 
+#include "drake/tools/performance/fixture_memory.h"
+
+DEFINE_bool(memory_manager, true, "Enable memory reporting");
+
 int main(int argc, char** argv) {
   gflags::SetUsageMessage("see drake/tools/performance/README.md");
   for (int i = 1; i < argc; ++i) {
@@ -18,6 +22,9 @@ int main(int argc, char** argv) {
   benchmark::Initialize(&argc, argv);
   gflags::ParseCommandLineNonHelpFlags(&argc, &argv, true);
   if (::benchmark::ReportUnrecognizedArguments(argc, argv)) return 1;
+  if (FLAGS_memory_manager) {
+    drake::tools::performance::EnableMemoryManager();
+  }
   benchmark::RunSpecifiedBenchmarks();
   benchmark::Shutdown();
   return 0;

--- a/tools/workspace/googlebenchmark/patches/console_allocs.patch
+++ b/tools/workspace/googlebenchmark/patches/console_allocs.patch
@@ -1,0 +1,30 @@
+If a memory manager is installed then shows allocs in the summary table.
+
+--- src/console_reporter.cc
++++ src/console_reporter.cc
+@@ -53,9 +53,11 @@ bool ConsoleReporter::ReportContext(const Context& context) {
+ }
+ 
+ void ConsoleReporter::PrintHeader(const Run& run) {
++  const bool show_allocs = (run.memory_result != nullptr);
+   std::string str =
+-      FormatString("%-*s %13s %15s %12s", static_cast<int>(name_field_width_),
+-                   "Benchmark", "Time", "CPU", "Iterations");
++      FormatString("%-*s %13s %15s %*s%12s", static_cast<int>(name_field_width_),
++                   "Benchmark", "Time", "CPU", show_allocs ? 10 : 0,
++                   show_allocs ? "Allocs " : "", "Iterations");
+   if (!run.counters.empty()) {
+     if (output_options_ & OO_Tabular) {
+       for (auto const& c : run.counters) {
+@@ -163,6 +165,11 @@ void ConsoleReporter::PrintRunData(const Run& result) {
+   }
+ 
+   if (!result.report_big_o && !result.report_rms) {
++    const bool show_allocs = (result.memory_result != nullptr);
++    if (show_allocs) {
++      const std::string s = HumanReadableNumber(result.allocs_per_iter, Counter::kIs1000);
++      printer(Out, COLOR_YELLOW, "%7s   ", s.c_str());
++    }
+     printer(Out, COLOR_CYAN, "%10lld", result.iterations);
+   }
+ 

--- a/tools/workspace/googlebenchmark/patches/string_precision.patch
+++ b/tools/workspace/googlebenchmark/patches/string_precision.patch
@@ -1,0 +1,13 @@
+Actually respect the requested human-readable precision.
+
+--- src/string_util.cc
++++ src/string_util.cc
+@@ -55,6 +61,8 @@ void ToExponentAndMantissa(double val, double thresh, int precision,
+     for (size_t i = 0; i < arraysize(kBigSIUnits); ++i) {
+       scaled /= one_k;
+       if (scaled <= big_threshold) {
++        mantissa_stream << std::fixed;
++        mantissa_stream.precision(precision);
+         mantissa_stream << scaled;
+         *exponent = i + 1;
+         *mantissa = mantissa_stream.str();

--- a/tools/workspace/googlebenchmark/repository.bzl
+++ b/tools/workspace/googlebenchmark/repository.bzl
@@ -9,4 +9,8 @@ def googlebenchmark_repository(
         commit = "v1.7.1",
         sha256 = "6430e4092653380d9dc4ccb45a1e2dc9259d581f4866dc0759713126056bc1d7",  # noqa
         mirrors = mirrors,
+        patches = [
+            ":patches/console_allocs.patch",
+            ":patches/string_precision.patch",
+        ],
     )


### PR DESCRIPTION
Follow-up from #17487 to restore heap reporting.

Looking carefully at the `compare.py` report for the `CassieAutoDiff/MassMatrix/1` data with repetitions=100, it definitively shows that this new instrumentation costs exactly 3 extra CPU cycles per allocation.  On my 3 GHz machine, that's +1 ns per allocation, scaled up by 31,400 allocations is a difference of +31us on benchmark (~2%).

This probably the most extreme case; of all the benchmarks, MassMatrix has one of the highest fraction of allocations per instruction.

We could imagine automatically offering benchmark binaries that do not link in the malloc hooks, but for me the 3 cycle penalty is a reasonable enough one to leave unconditionally enabled.  Any relative before/after measurements for performance improvements should still hold true.

---

Sample output for cassie now:
```
----------------------------------------------------------------------------------------
Benchmark                                    Time             CPU    Allocs   Iterations
----------------------------------------------------------------------------------------
CassieDouble/MassMatrix/0                 12.8 us         12.8 us         0        49308
CassieDouble/InverseDynamics/0            16.5 us         16.5 us         3        42641
CassieDouble/ForwardDynamics/0            35.9 us         35.9 us         5        19442
CassieAutoDiff/MassMatrix/0                402 us          402 us         0         1753
CassieAutoDiff/MassMatrix/1               1256 us         1255 us     31.4k          530
CassieAutoDiff/MassMatrix/2                410 us          410 us         0         1707
CassieAutoDiff/MassMatrix/3               1491 us         1491 us     31.4k          467
CassieAutoDiff/InverseDynamics/0           504 us          503 us         3         1358
CassieAutoDiff/InverseDynamics/1          1492 us         1491 us     36.9k          475
CassieAutoDiff/InverseDynamics/2           858 us          858 us     10.8k          817
CassieAutoDiff/InverseDynamics/3          1897 us         1896 us     37.4k          377
CassieAutoDiff/InverseDynamics/4           720 us          719 us      6.9k          981
CassieAutoDiff/InverseDynamics/5          1856 us         1855 us     37.5k          376
CassieAutoDiff/InverseDynamics/6          1011 us         1010 us     12.0k          686
CassieAutoDiff/InverseDynamics/7          2287 us         2285 us     38.0k          309
CassieAutoDiff/ForwardDynamics/0           821 us          820 us        73          856
CassieAutoDiff/ForwardDynamics/1          2563 us         2562 us     55.9k          274
CassieAutoDiff/ForwardDynamics/2          1209 us         1209 us     11.6k          581
CassieAutoDiff/ForwardDynamics/3          3278 us         3276 us     57.4k          215
CassieAutoDiff/ForwardDynamics/8           897 us          897 us      3.4k          775
CassieAutoDiff/ForwardDynamics/9          2964 us         2962 us     56.2k          238
CassieAutoDiff/ForwardDynamics/10         1225 us         1224 us     11.6k          567
CassieAutoDiff/ForwardDynamics/11         3524 us         3521 us     57.7k          198
CassieExpression/MassMatrix/0             1772 us         1771 us      7.0k          397
CassieExpression/MassMatrix/1             8557 us         8552 us     48.2k           83
CassieExpression/MassMatrix/2             1769 us         1768 us      7.0k          399
CassieExpression/MassMatrix/3             8468 us         8465 us     48.2k           83
CassieExpression/InverseDynamics/0        2275 us         2274 us      8.4k          308
CassieExpression/InverseDynamics/1       29690 us        29675 us     73.4k           24
CassieExpression/InverseDynamics/2        7509 us         7502 us     48.6k           91
CassieExpression/InverseDynamics/3       27136 us        27115 us     74.5k           26
CassieExpression/InverseDynamics/4        4294 us         4291 us     32.5k          162
CassieExpression/InverseDynamics/5       27763 us        27745 us     74.2k           26
CassieExpression/InverseDynamics/6       10374 us        10368 us     50.3k           64
CassieExpression/InverseDynamics/7       26030 us        26011 us     75.2k           28
CassieExpression/ForwardDynamics/0        3625 us         3623 us     13.8k          189
CassieExpression/ForwardDynamics/2       17187 us        17175 us     88.3k           41
CassieExpression/ForwardDynamics/8        4738 us         4736 us     29.6k          147
CassieExpression/ForwardDynamics/10      16944 us        16932 us     88.4k           42
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17518)
<!-- Reviewable:end -->
