### PR TITLE
[common] Move constant Expression values inline

### DIFF
--- a/common/symbolic/expression/BUILD.bazel
+++ b/common/symbolic/expression/BUILD.bazel
@@ -49,6 +49,7 @@ drake_cc_library(
         "//common:essential",
         "//common:hash",
         "//common:random",
+        "//common:reset_after_move",
     ],
     deps = [
         "@fmt",

--- a/common/symbolic/expression/expression_cell.cc
+++ b/common/symbolic/expression/expression_cell.cc
@@ -382,48 +382,6 @@ Expression ExpressionVar::Differentiate(const Variable& x) const {
 
 ostream& ExpressionVar::Display(ostream& os) const { return os << var_; }
 
-ExpressionConstant::ExpressionConstant(const double v)
-    : ExpressionCell{ExpressionKind::Constant, true, true}, v_{v} {
-  DRAKE_ASSERT(!std::isnan(v));
-}
-
-void ExpressionConstant::HashAppendDetail(DelegatingHasher* hasher) const {
-  using drake::hash_append;
-  hash_append(*hasher, v_);
-}
-
-Variables ExpressionConstant::GetVariables() const { return Variables{}; }
-
-bool ExpressionConstant::EqualTo(const ExpressionCell& e) const {
-  // Expression::EqualTo guarantees the following assertion.
-  DRAKE_ASSERT(get_kind() == e.get_kind());
-  return v_ == static_cast<const ExpressionConstant&>(e).v_;
-}
-
-bool ExpressionConstant::Less(const ExpressionCell& e) const {
-  // Expression::Less guarantees the following assertion.
-  DRAKE_ASSERT(get_kind() == e.get_kind());
-  return v_ < static_cast<const ExpressionConstant&>(e).v_;
-}
-
-double ExpressionConstant::Evaluate(const Environment&) const {
-  DRAKE_DEMAND(!std::isnan(v_));
-  return v_;
-}
-
-Expression ExpressionConstant::Expand() const { return Expression{v_}; }
-
-Expression ExpressionConstant::Substitute(const Substitution&) const {
-  DRAKE_DEMAND(!std::isnan(v_));
-  return Expression{v_};
-}
-
-Expression ExpressionConstant::Differentiate(const Variable&) const {
-  return Expression::Zero();
-}
-
-ostream& ExpressionConstant::Display(ostream& os) const { return os << v_; }
-
 ExpressionNaN::ExpressionNaN()
     : ExpressionCell{ExpressionKind::NaN, false, false} {}
 
@@ -2139,16 +2097,6 @@ bool is_if_then_else(const ExpressionCell& c) {
 }
 bool is_uninterpreted_function(const ExpressionCell& c) {
   return c.get_kind() == ExpressionKind::UninterpretedFunction;
-}
-
-const ExpressionConstant& to_constant(const Expression& e) {
-  DRAKE_ASSERT(is_constant(e));
-  return static_cast<const ExpressionConstant&>(e.cell());
-}
-
-ExpressionConstant& to_constant(Expression* const e) {
-  DRAKE_ASSERT(e && is_constant(*e));
-  return static_cast<ExpressionConstant&>(e->mutable_cell());
 }
 
 const ExpressionVar& to_variable(const Expression& e) {

--- a/common/symbolic/expression/expression_cell.h
+++ b/common/symbolic/expression/expression_cell.h
@@ -182,25 +182,6 @@ class ExpressionVar : public ExpressionCell {
   const Variable var_;
 };
 
-/** Symbolic expression representing a constant. */
-class ExpressionConstant : public ExpressionCell {
- public:
-  explicit ExpressionConstant(double v);
-  [[nodiscard]] double get_value() const { return v_; }
-  void HashAppendDetail(DelegatingHasher*) const override;
-  [[nodiscard]] Variables GetVariables() const override;
-  [[nodiscard]] bool EqualTo(const ExpressionCell& e) const override;
-  [[nodiscard]] bool Less(const ExpressionCell& e) const override;
-  [[nodiscard]] double Evaluate(const Environment& env) const override;
-  [[nodiscard]] Expression Expand() const override;
-  [[nodiscard]] Expression Substitute(const Substitution& s) const override;
-  [[nodiscard]] Expression Differentiate(const Variable& x) const override;
-  std::ostream& Display(std::ostream& os) const override;
-
- private:
-  const double v_{};
-};
-
 /** Symbolic expression representing NaN (not-a-number). */
 class ExpressionNaN : public ExpressionCell {
  public:

--- a/common/symbolic/expression/test/expression_cell_test.cc
+++ b/common/symbolic/expression/test/expression_cell_test.cc
@@ -53,8 +53,6 @@ class SymbolicExpressionCellTest : public ::testing::Test {
 };
 
 TEST_F(SymbolicExpressionCellTest, CastFunctionsConst) {
-  EXPECT_EQ(to_constant(e_constant_).get_value(),
-            get_constant_value(e_constant_));
   EXPECT_EQ(to_variable(e_var_).get_variable(), get_variable(e_var_));
 
   EXPECT_EQ(to_addition(e_add_).get_constant(),
@@ -122,8 +120,6 @@ TEST_F(SymbolicExpressionCellTest, CastFunctionsConst) {
 }
 
 TEST_F(SymbolicExpressionCellTest, CastFunctionsNonConst) {
-  EXPECT_EQ(to_constant(Expression{e_constant_}).get_value(),
-            get_constant_value(e_constant_));
   EXPECT_EQ(to_variable(Expression{e_var_}).get_variable(),
             get_variable(e_var_));
 


### PR DESCRIPTION
This allows default initialization (memset) to operate correctly, shaves about 70% off the simple benchmarks, and paves the way for additional optimizations down the road (`intrusive_shared_ptr` and nanboxing; prototyped in #15369 to be resurrected soon).

---

Cassie results (for T=Expression).  Note that all expressions are constants in this benchmark; there are no variables.

![Expression SBO (time per call)](https://user-images.githubusercontent.com/17596505/177899741-5e0c2b42-de92-43fe-a867-0b0ca539204a.svg)
.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17527)
<!-- Reviewable:end -->
