### PR TITLE
[geometry] Add test epsilon in preparation for new AutoDiff

### DIFF
--- a/geometry/proximity/test/contact_surface_test.cc
+++ b/geometry/proximity/test/contact_surface_test.cc
@@ -96,6 +96,8 @@ unique_ptr<MeshFieldLinear<typename MeshType::ScalarType, MeshType>> MakeField(
 // We also test the sugar mesh representation-independent APIs if
 // `test_return_value` is `true`. We don't test the mesh field internal values
 // directly. Instead, we evaluate the field at various positions.
+// The floating-point comparisions purposefully use a tolerance of zero because
+// all of the inputs and intermediate results are exactly representable.
 template <typename MeshType>
 ContactSurface<typename MeshType::ScalarType> TestContactSurface(
     bool test_return_value = true) {

--- a/geometry/proximity/test/distance_to_point_callback_test.cc
+++ b/geometry/proximity/test/distance_to_point_callback_test.cc
@@ -468,7 +468,7 @@ GTEST_TEST(DistanceToPoint, Halfspace) {
 //   Confirm that the derivative of distance (extracted from AutoDiff) matches
 //     the derivative computed by hand (grad_W).
 GTEST_TEST(DistanceToPoint, Sphere) {
-  const double kEps = 4 * std::numeric_limits<double>::epsilon();
+  const double kEps = 5 * std::numeric_limits<double>::epsilon();
 
   // Provide some arbitrary pose of the sphere in the world.
   const RotationMatrix<double> R_WG(


### PR DESCRIPTION
Towards #17492.

The new AutoDiff sometimes changes the floating point round-off, so the tests will need to adapt.  (To see the failures, fetch #17492 and revert this commit.)

The premise of merging this change now (rather than concurrently with #17492 itself) is that sensitivity to fold order means that the test is overly precise, whether or not we ever merge the new AutoDiff.

---

In detail ...

For `distance_to_point_callback_test`, the new AutoDiff folds derivative scaling as x' * ((a * b) * c) instead of ((x' * a) * b) * c).

~For `contact_surface_test`, we were testing floating-point arithmetic without any epsilon.  I didn't hunt down exactly where the new code changed something[1], but in any case I didn't see any justification for why we were testing doubles bitwise instead of ulp-toleranced.~

~[1] Best guess, it's the order of operations of (a + b + c) where the new move-enabled arithmetic overloads are forcing a particular associativity.~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17532)
<!-- Reviewable:end -->
