### PR TITLE
[primitives] Spell ternary operator compatibly with new AutoDiff

### DIFF
--- a/systems/primitives/test/linear_transform_density_test.cc
+++ b/systems/primitives/test/linear_transform_density_test.cc
@@ -330,7 +330,7 @@ void CheckDensityGradient(RandomDistribution distribution,
        -A_val.inverse())
           .transpose();
   Eigen::VectorXd density_grad = density.derivatives().rows() == 0
-                                     ? Eigen::Vector2d::Zero()
+                                     ? Eigen::VectorXd::Zero(2).eval()
                                      : density.derivatives();
   EXPECT_TRUE(CompareMatrices(density_grad, ddensity_db_expected, 10 * kEps));
 

--- a/systems/primitives/test/multilayer_perceptron_test.cc
+++ b/systems/primitives/test/multilayer_perceptron_test.cc
@@ -243,7 +243,7 @@ void BackpropTest(PerceptronActivationType type, bool use_sin_cos = false) {
   EXPECT_TRUE(CompareMatrices(dloss_dparams,
                               loss_ad.derivatives().size()
                                   ? loss_ad.derivatives()
-                                  : Eigen::VectorXd::Zero(mlp.num_parameters()),
+                                  : VectorXd::Zero(mlp.num_parameters()).eval(),
                               1e-14));
 
   {  // A second call with the same size input should not allocate.
@@ -312,7 +312,7 @@ GTEST_TEST(MultilayerPereceptronTest, BatchOutputWithGradients) {
       // (e.g. for ReLU the input might be truncated before reaching the
       // output).
       dYdX_desired.col(i) =
-          y.derivatives().size() ? y.derivatives() : Eigen::Vector2d::Zero();
+          y.derivatives().size() ? y.derivatives() : VectorXd::Zero(2).eval();
     }
     mlp.BatchOutput(*context, X, &Y, &dYdX);
 
@@ -392,7 +392,7 @@ GTEST_TEST(MultilayerPerceptronTest, SinCosFeatures) {
     AutoDiffXd y = mlp_ad.get_output_port().Eval(*context_ad)[0];
     Y_desired(0, i) = y.value();
     dYdX_desired.col(i) =
-        y.derivatives().size() ? y.derivatives() : Eigen::Vector2d::Zero();
+        y.derivatives().size() ? y.derivatives() : VectorXd::Zero(2).eval();
   }
   mlp.BatchOutput(*context, X, &Y, &dYdX);
 


### PR DESCRIPTION
The new AutoDiff will have a breaking change: its `derivatives()` mutable accessor will no longer guide the conditional ternary operator to construct a temporary `Eigen::VectorXd`. There is no longer a "common type" between a constant-expression eigen xpr vector and a mutable AutoDiff derivatives vector (both a will be eigen xprs, of different types).

We plan to add sugar to make this easier down the road (i.e., without a ternary operator), but in any case forcing the constant vector to materialize in test code is not any great loss, and it's easier for the commit train to land this now and get it out of the way.

(We can't merge the sugar until we merge the new `derivatives()` first, so it's a bit of a Catch-22.)

Towards #17492.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17533)
<!-- Reviewable:end -->
