### PR TITLE
[multibody] Reformulate cassie benchmark case permutations

### DIFF
--- a/multibody/benchmarking/BUILD.bazel
+++ b/multibody/benchmarking/BUILD.bazel
@@ -38,7 +38,6 @@ drake_cc_googlebench_binary(
     deps = [
         "//common:essential",
         "//common:find_resource",
-        "//common/test_utilities:limit_malloc",
         "//math:gradient",
         "//multibody/parsing:parser",
         "//tools/performance:fixture_common",


### PR DESCRIPTION
Rewrite the fixture to be templated on scalar type, remove redundant member fields, and pre-allocate all function inputs and outputs.

Avoid using zeros for any state or input; math on a zero might have a different performance profile than non-zero. This is already the case for Expression, and might be the case for AutoDiff down the road.

---

The LimitMalloc heap ceilings are no longer part of the benchmark; see #17538 for the new home.

The LimitMalloc heap telemetry is dropped from the benchmark; it will be re-added in a much better form in #17518 (to all benchmarks, not just cassie).

---

Sample output:
```
------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations
------------------------------------------------------------------------------
CassieDouble/MassMatrix/0                 13.0 us         13.0 us        49293
CassieDouble/InverseDynamics/0            17.9 us         17.9 us        41831
CassieDouble/ForwardDynamics/0            36.4 us         36.4 us        19242
CassieAutoDiff/MassMatrix/0                375 us          375 us         1820
CassieAutoDiff/MassMatrix/1               1206 us         1205 us          575
CassieAutoDiff/MassMatrix/2                376 us          376 us         1857
CassieAutoDiff/MassMatrix/3               1492 us         1491 us          470
CassieAutoDiff/InverseDynamics/0           481 us          481 us         1397
CassieAutoDiff/InverseDynamics/1          1452 us         1452 us          487
CassieAutoDiff/InverseDynamics/2           825 us          824 us          852
CassieAutoDiff/InverseDynamics/3          1859 us         1858 us          379
CassieAutoDiff/InverseDynamics/4           687 us          687 us         1021
CassieAutoDiff/InverseDynamics/5          1832 us         1831 us          376
CassieAutoDiff/InverseDynamics/6           990 us          989 us          702
CassieAutoDiff/InverseDynamics/7          2214 us         2213 us          318
CassieAutoDiff/ForwardDynamics/0           780 us          779 us          899
CassieAutoDiff/ForwardDynamics/1          2557 us         2556 us          274
CassieAutoDiff/ForwardDynamics/2          1161 us         1160 us          595
CassieAutoDiff/ForwardDynamics/3          3310 us         3308 us          212
CassieAutoDiff/ForwardDynamics/8           863 us          863 us          818
CassieAutoDiff/ForwardDynamics/9          2957 us         2956 us          235
CassieAutoDiff/ForwardDynamics/10         1202 us         1201 us          592
CassieAutoDiff/ForwardDynamics/11         3537 us         3536 us          196
CassieExpression/MassMatrix/0             1689 us         1688 us          413
CassieExpression/MassMatrix/1             8247 us         8242 us           87
CassieExpression/MassMatrix/2             1695 us         1694 us          414
CassieExpression/MassMatrix/3             8262 us         8257 us           86
CassieExpression/InverseDynamics/0        2209 us         2208 us          317
CassieExpression/InverseDynamics/1       28820 us        28802 us           25
CassieExpression/InverseDynamics/2        7301 us         7298 us           95
CassieExpression/InverseDynamics/3       26212 us        26196 us           27
CassieExpression/InverseDynamics/4        4208 us         4206 us          166
CassieExpression/InverseDynamics/5       26708 us        26693 us           26
CassieExpression/InverseDynamics/6       10459 us        10452 us           68
CassieExpression/InverseDynamics/7       24177 us        24163 us           29
CassieExpression/ForwardDynamics/0        3488 us         3486 us          202
CassieExpression/ForwardDynamics/2       16405 us        16396 us           44
CassieExpression/ForwardDynamics/8        4546 us         4542 us          156
CassieExpression/ForwardDynamics/10      16561 us        16550 us           43
```

Observations:

(a) The `/0` cases across the scalars should use _exactly_ the same number of flops no matter the scalar.  It's the same math in every case.  The increased cost for non-double scalars shows the accumulated penalties from all of the representational de-optimizations (more copies, more branching, worse memory layout, losing simd, reference counting, etc.).  For example:

```
CassieDouble/MassMatrix/0                  14 us
CassieAutoDiff/MassMatrix/0               437 us  # worse layout, but still no per-scalar mallocs
CassieExpression/MassMatrix/0            2026 us  # per-scalar mallocs and refcounting
```

(b) The `Foo/*` cases within a given Foo show the relative cost of using `x`, `vdot`, and/or `u` as the gradient (or variable).  This helps illustrate the throughput's dependence on some combination of the count of derivatives (or variables) and/or any sparsity in the math for those quantities.

For example:

```
CassieAutoDiff/InverseDynamics/0          604 us  # base cost
CassieAutoDiff/InverseDynamics/4          818 us  # nv partials; sparsity
CassieAutoDiff/InverseDynamics/3         2109 us  # nq + nv partials
CassieAutoDiff/InverseDynamics/7         2545 us  # nq + 2nv partials
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17539)
<!-- Reviewable:end -->
