### PR TITLE
[symbolic] Speed up Expression via nanboxing

### DIFF
--- a/common/symbolic/expression/expression.cc
+++ b/common/symbolic/expression/expression.cc
@@ -4,17 +4,9 @@
 /* clang-format on */
 
 #include <algorithm>
-#include <cmath>
-#include <cstddef>
 #include <ios>
-#include <map>
-#include <memory>
 #include <stdexcept>
-#include <string>
-#include <type_traits>
-#include <vector>
 
-#include <Eigen/Core>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
@@ -28,14 +20,14 @@ namespace drake {
 namespace symbolic {
 
 using std::logic_error;
-using std::make_shared;
+using std::make_unique;
 using std::map;
 using std::numeric_limits;
 using std::ostream;
 using std::ostringstream;
 using std::pair;
 using std::runtime_error;
-using std::shared_ptr;
+using std::unique_ptr;
 using std::streamsize;
 using std::string;
 using std::vector;
@@ -56,104 +48,78 @@ Expression NegateMultiplication(const Expression& e) {
 }
 }  // namespace
 
-shared_ptr<ExpressionCell> Expression::make_cell(const double d) {
-  if (d == 0.0) {
-    // The objects created by `Expression(0.0)` share the unique
-    // `ExpressionConstant` object created in `Expression::Zero()`.
-    //
-    // See https://github.com/RobotLocomotion/drake/issues/12453 for details.
-    //
-    // Typically we should never access a ptr_ directly, but here we know it
-    // poses no risk because ExpressionConstant has no non-const member fields
-    // of any consequence (only "is_expanded_" is non-const, and it can never
-    // be reset to false).
-    return Expression::Zero().ptr_;
-  }
-  if (std::isnan(d)) {
-    return make_shared<ExpressionNaN>();
-  }
-  return make_shared<ExpressionConstant>(d);
-}
-
 Expression::Expression(const Variable& var)
-    : Expression{make_shared<ExpressionVar>(var)} {}
+    : Expression{make_unique<ExpressionVar>(var)} {}
 
-Expression::Expression(const double constant)
-    : Expression{make_cell(constant)} {}
-
-Expression::Expression(std::shared_ptr<ExpressionCell> ptr)
-    : ptr_{std::move(ptr)} {
-  DRAKE_ASSERT(ptr_ != nullptr);
+// Constructs this taking ownership of the given call.
+Expression::Expression(std::unique_ptr<ExpressionCell> cell) {
+  boxed_.SetSharedCell(cell.release());
 }
 
-ExpressionKind Expression::get_kind() const {
-  return cell().get_kind();
+// Implements the Expression(double) constructor when the constant is NaN.
+// Note that this uses the ExpressionNaN cell type to denote NaN, not a
+// constant NaN value in an ExpressionKind::Constant.
+void Expression::ConstructExpressionCellNaN() {
+  *this = NaN();
+}
+
+ExpressionCell& Expression::mutable_cell() {
+  ExpressionCell& result = const_cast<ExpressionCell&>(cell());
+  // This is an invariant of Drake's symbolic library. If this ever trips,
+  // that indicates an implementation defect within Drake; please file a bug.
+  DRAKE_DEMAND(result.use_count() == 1);
+  return result;
 }
 
 void Expression::HashAppend(DelegatingHasher* hasher) const {
   using drake::hash_append;
-  hash_append(*hasher, get_kind());
-  cell().HashAppendDetail(hasher);
-}
-
-ExpressionCell& Expression::mutable_cell() {
-  DRAKE_ASSERT(ptr_ != nullptr);
-  DRAKE_DEMAND(ptr_.use_count() == 1);
-  return *ptr_;
-}
-
-Expression Expression::Zero() {
-  static const never_destroyed<Expression> zero{
-      Expression{make_shared<ExpressionConstant>(0.0)}};
-  return zero.access();
-}
-
-Expression Expression::One() {
-  static const never_destroyed<Expression> one{
-      Expression{make_shared<ExpressionConstant>(1.0)}};
-  return one.access();
-}
-
-Expression Expression::Pi() {
-  static const never_destroyed<Expression> pi{
-      Expression{make_shared<ExpressionConstant>(M_PI)}};
-  return pi.access();
-}
-
-Expression Expression::E() {
-  static const never_destroyed<Expression> e{
-      Expression{make_shared<ExpressionConstant>(M_E)}};
-  return e.access();
+  if (is_constant(*this)) {
+    hash_append(*hasher, ExpressionKind::Constant);
+    hash_append(*hasher, get_constant_value(*this));
+  } else {
+    hash_append(*hasher, get_kind());
+    cell().HashAppendDetail(hasher);
+  }
 }
 
 Expression Expression::NaN() {
-  static const never_destroyed<Expression> nan{
-      Expression{make_shared<ExpressionNaN>()}};
-  return nan.access();
+  // This global cell is initialized upon first use and never destroyed.
+  static const ExpressionNaN* const flyweight = []() {
+    ExpressionNaN* initial_value = new ExpressionNaN;
+    ++initial_value->use_count();
+    return initial_value;
+  }();
+  Expression result;
+  result.boxed_.SetSharedCell(flyweight);
+  return result;
 }
 
 Variables Expression::GetVariables() const {
+  if (is_constant(*this)) {
+    return {};
+  }
   return cell().GetVariables();
 }
 
 bool Expression::EqualTo(const Expression& e) const {
-  const auto& this_cell = cell();
-  const auto& other_cell = e.cell();
-  if (&this_cell == &other_cell) {
+  if (boxed_.trivially_equals(e.boxed_)) {
     return true;
   }
-  if (get_kind() != e.get_kind()) {
+  const ExpressionKind k1{get_kind()};
+  const ExpressionKind k2{e.get_kind()};
+  if (k1 != k2) {
     return false;
+  }
+  if (k1 == ExpressionKind::Constant) {
+    return get_constant_value(*this) == get_constant_value(e);
   }
   // Check structural equality.
   return cell().EqualTo(e.cell());
 }
 
 bool Expression::Less(const Expression& e) const {
-  const auto& this_cell = cell();
-  const auto& other_cell = e.cell();
-  if (&this_cell == &other_cell) {
-    return false;  // this equals to e, not less-than.
+  if (boxed_.trivially_equals(e.boxed_)) {
+    return false;
   }
   const ExpressionKind k1{get_kind()};
   const ExpressionKind k2{e.get_kind()};
@@ -164,19 +130,31 @@ bool Expression::Less(const Expression& e) const {
     return false;
   }
   // k1 == k2
-  return this_cell.Less(other_cell);
+  if (k1 == ExpressionKind::Constant) {
+    return get_constant_value(*this) < get_constant_value(e);
+  }
+  return cell().Less(e.cell());
 }
 
 bool Expression::is_polynomial() const {
+  if (is_constant(*this)) {
+    return true;
+  }
   return cell().is_polynomial();
 }
 
 bool Expression::is_expanded() const {
+  if (is_constant(*this)) {
+    return true;
+  }
   return cell().is_expanded();
 }
 
 double Expression::Evaluate(const Environment& env,
                             RandomGenerator* const random_generator) const {
+  if (is_constant(*this)) {
+    return get_constant_value(*this);
+  }
   if (random_generator == nullptr) {
     return cell().Evaluate(env);
   } else {
@@ -186,6 +164,9 @@ double Expression::Evaluate(const Environment& env,
 }
 
 double Expression::Evaluate(RandomGenerator* const random_generator) const {
+  if (is_constant(*this)) {
+    return get_constant_value(*this);
+  }
   return Evaluate(Environment{}, random_generator);
 }
 
@@ -207,6 +188,9 @@ Expression Expression::EvaluatePartial(const Environment& env) const {
 }
 
 Expression Expression::Expand() const {
+  if (is_constant(*this)) {
+    return *this;
+  }
   if (cell().is_expanded()) {
     // If it is already expanded, return the current expression without calling
     // Expand() on the cell.
@@ -222,10 +206,16 @@ Expression Expression::Expand() const {
 
 Expression Expression::Substitute(const Variable& var,
                                   const Expression& e) const {
+  if (is_constant(*this)) {
+    return *this;
+  }
   return cell().Substitute({{var, e}});
 }
 
 Expression Expression::Substitute(const Substitution& s) const {
+  if (is_constant(*this)) {
+    return *this;
+  }
   if (!s.empty()) {
     return cell().Substitute(s);
   }
@@ -233,6 +223,9 @@ Expression Expression::Substitute(const Substitution& s) const {
 }
 
 Expression Expression::Differentiate(const Variable& x) const {
+  if (is_constant(*this)) {
+    return 0.0;
+  }
   return cell().Differentiate(x);
 }
 
@@ -251,26 +244,23 @@ string Expression::to_string() const {
   return oss.str();
 }
 
-Expression operator+(Expression lhs, const Expression& rhs) {
-  lhs += rhs;
-  return lhs;
-}
-
-// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-Expression& operator+=(Expression& lhs, const Expression& rhs) {
+void Expression::AddImpl(const Expression& rhs) {
+  Expression& lhs = *this;
   // Simplification: 0 + x => x
   if (is_zero(lhs)) {
     lhs = rhs;
-    return lhs;
+    return;
   }
   // Simplification: x + 0 => x
   if (is_zero(rhs)) {
-    return lhs;
+    return;
   }
-  // Simplification: Expression(c1) + Expression(c2) => Expression(c1 + c2)
+  // If both terms were constants, our header file `operator+=` function would
+  // have already tried to add them, but got a speculative_result of NaN. If
+  // we reach here, that means the floating-point result really was NaN.
   if (is_constant(lhs) && is_constant(rhs)) {
-    lhs = get_constant_value(lhs) + get_constant_value(rhs);
-    return lhs;
+    ConstructExpressionCellNaN();
+    return;
   }
   // Simplification: flattening. To build a new expression, we use
   // ExpressionAddFactory which holds intermediate terms and does
@@ -295,7 +285,6 @@ Expression& operator+=(Expression& lhs, const Expression& rhs) {
   }
   // Extract an expression from factory
   lhs = add_factory.GetExpression();
-  return lhs;
 }
 
 Expression& Expression::operator++() {
@@ -311,32 +300,27 @@ Expression Expression::operator++(int) {
 
 Expression operator+(const Expression& e) { return e; }
 
-Expression operator-(Expression lhs, const Expression& rhs) {
-  lhs -= rhs;
-  return lhs;
-}
-
-// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-Expression& operator-=(Expression& lhs, const Expression& rhs) {
+void Expression::SubImpl(const Expression& rhs) {
+  Expression& lhs = *this;
   // Simplification: E - E => 0
   // TODO(soonho-tri): This simplification is not sound since it cancels `E`
   // which might cause 0/0 during evaluation.
   if (lhs.EqualTo(rhs)) {
     lhs = Expression::Zero();
-    return lhs;
+    return;
   }
   // Simplification: x - 0 => x
   if (is_zero(rhs)) {
-    return lhs;
+    return;
   }
-  // Simplification: Expression(c1) - Expression(c2) => Expression(c1 - c2)
-  if (is_constant(lhs) && is_constant(rhs)) {
-    lhs = get_constant_value(lhs) - get_constant_value(rhs);
-    return lhs;
-  }
+  // If both terms were constants, our header file `operator-=` function would
+  // have already tried to subtract them, but got a speculative_result of NaN.
+  // If we reach here, that means the floating-point result really was NaN.
+  // However, that should only happen with inf-inf or (-inf)-(-inf), which
+  // we've handled already.
+  DRAKE_ASSERT(!(is_constant(lhs) && is_constant(rhs)));
   // x - y => x + (-y)
   lhs += -rhs;
-  return lhs;
 }
 
 Expression operator-(const Expression& e) {
@@ -369,50 +353,45 @@ Expression Expression::operator--(int) {
   return copy;
 }
 
-Expression operator*(Expression lhs, const Expression& rhs) {
-  lhs *= rhs;
-  return lhs;
-}
-
-// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-Expression& operator*=(Expression& lhs, const Expression& rhs) {
+void Expression::MulImpl(const Expression& rhs) {
+  Expression& lhs = *this;
   // Simplification: 1 * x => x
   if (is_one(lhs)) {
     lhs = rhs;
-    return lhs;
+    return;
   }
   // Simplification: x * 1 => x
   if (is_one(rhs)) {
-    return lhs;
+    return;
   }
   // Simplification: (E1 / E2) * (E3 / E4) => (E1 * E3) / (E2 * E4)
   if (is_division(lhs) && is_division(rhs)) {
     lhs = (get_first_argument(lhs) * get_first_argument(rhs)) /
           (get_second_argument(lhs) * get_second_argument(rhs));
-    return lhs;
+    return;
   }
   // Simplification: lhs * (c / E) => (c * lhs) / E
   if (is_division(rhs) && is_constant(get_first_argument(rhs))) {
     lhs = (get_first_argument(rhs) * lhs) / get_second_argument(rhs);
-    return lhs;
+    return;
   }
   // Simplification: (c / E) * rhs => (c * rhs) / E
   if (is_division(lhs) && is_constant(get_first_argument(lhs))) {
     lhs = (get_first_argument(lhs) * rhs) / get_second_argument(lhs);
-    return lhs;
+    return;
   }
   if (is_neg_one(lhs)) {
     if (is_addition(rhs)) {
       // Simplification: push '-' inside over '+'.
       // -1 * (E_1 + ... + E_n) => (-E_1 + ... + -E_n)
       lhs = NegateAddition(rhs);
-      return lhs;
+      return;
     }
     if (is_multiplication(rhs)) {
       // Simplification: push '-' inside over '*'.
       // -1 * (c0 * E_1 * ... * E_n) => (-c0 * E_1 * ... * E_n)
       lhs = NegateMultiplication(rhs);
-      return lhs;
+      return;
     }
   }
 
@@ -421,13 +400,13 @@ Expression& operator*=(Expression& lhs, const Expression& rhs) {
       // Simplification: push '-' inside over '+'.
       // (E_1 + ... + E_n) * -1 => (-E_1 + ... + -E_n)
       lhs = NegateAddition(lhs);
-      return lhs;
+      return;
     }
     if (is_multiplication(lhs)) {
       // Simplification: push '-' inside over '*'.
       // (c0 * E_1 * ... * E_n) * -1 => (-c0 * E_1 * ... * E_n)
       lhs = NegateMultiplication(lhs);
-      return lhs;
+      return;
     }
   }
 
@@ -435,14 +414,14 @@ Expression& operator*=(Expression& lhs, const Expression& rhs) {
   // TODO(soonho-tri): This simplification is not sound since it cancels `E`
   // which might cause 0/0 during evaluation.
   if (is_zero(lhs)) {
-    return lhs;
+    return;
   }
   // Simplification: E * 0 => 0
   // TODO(soonho-tri): This simplification is not sound since it cancels `E`
   // which might cause 0/0 during evaluation.
   if (is_zero(rhs)) {
     lhs = Expression::Zero();
-    return lhs;
+    return;
   }
   // Pow-related simplifications.
   if (is_pow(lhs)) {
@@ -458,7 +437,7 @@ Expression& operator*=(Expression& lhs, const Expression& rhs) {
         const Expression& e2{get_second_argument(lhs)};
         const Expression& e4{get_second_argument(rhs)};
         lhs = pow(e1, e2 + e4);
-        return lhs;
+        return;
       }
     }
     if (e1.EqualTo(rhs)) {
@@ -466,7 +445,7 @@ Expression& operator*=(Expression& lhs, const Expression& rhs) {
       // TODO(soonho-tri): This simplification is not sound.
       const Expression& e2{get_second_argument(lhs)};
       lhs = pow(e1, e2 + 1);
-      return lhs;
+      return;
     }
   } else {
     if (is_pow(rhs)) {
@@ -476,15 +455,16 @@ Expression& operator*=(Expression& lhs, const Expression& rhs) {
         // TODO(soonho-tri): This simplification is not sound.
         const Expression& e2{get_second_argument(rhs)};
         lhs = pow(e1, 1 + e2);
-        return lhs;
+        return;
       }
     }
   }
-  if (is_constant(lhs) && is_constant(rhs)) {
-    // Simplification: Expression(c1) * Expression(c2) => Expression(c1 * c2)
-    lhs = Expression{get_constant_value(lhs) * get_constant_value(rhs)};
-    return lhs;
-  }
+  // If both terms were constants, our header file `operator*=` function would
+  // have already tried to multiply them, but got a speculative_result of NaN.
+  // If we reach here, that means the floating-point result really was NaN.
+  // However, that should only happen with 0*inf or inf*0, which we've handled
+  // already.
+  DRAKE_ASSERT(!(is_constant(lhs) && is_constant(rhs)));
   // Simplification: flattening
   ExpressionMulFactory mul_factory{};
   if (is_multiplication(lhs)) {
@@ -505,7 +485,7 @@ Expression& operator*=(Expression& lhs, const Expression& rhs) {
       // Simplification: x * x => x^2 (=pow(x,2))
       if (lhs.EqualTo(rhs)) {
         lhs = pow(lhs, 2.0);
-        return lhs;
+        return;
       }
       // nothing to flatten
       mul_factory.AddExpression(lhs);
@@ -513,41 +493,35 @@ Expression& operator*=(Expression& lhs, const Expression& rhs) {
     }
   }
   lhs = mul_factory.GetExpression();
-  return lhs;
 }
 
-Expression operator/(Expression lhs, const Expression& rhs) {
-  lhs /= rhs;
-  return lhs;
-}
-
-// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-Expression& operator/=(Expression& lhs, const Expression& rhs) {
+void Expression::DivImpl(const Expression& rhs) {
+  Expression& lhs = *this;
   // Simplification: x / 1 => x
   if (is_one(rhs)) {
-    return lhs;
+    return;
   }
-  // Simplification: Expression(c1) / Expression(c2) => Expression(c1 / c2)
+  // If both terms were constants, our header file `operator/=` function would
+  // have already tried to divide them, but if it wasn't able to commit to a
+  // result that means that either the divisor was zero or else the result
+  // really is NaN.
   if (is_constant(lhs) && is_constant(rhs)) {
-    const double v1{get_constant_value(lhs)};
-    const double v2{get_constant_value(rhs)};
-    if (v2 == 0.0) {
+    if (is_zero(rhs)) {
       ostringstream oss{};
-      oss << "Division by zero: " << v1 << "/" << v2;
+      oss << "Division by zero: " << lhs << "/0";
       throw runtime_error(oss.str());
     }
-    lhs = Expression{v1 / v2};
-    return lhs;
+    ConstructExpressionCellNaN();
+    return;
   }
   // Simplification: E / E => 1
   // TODO(soonho-tri): This simplification is not sound since it cancels `E`
   // which might contain 0/0 problems.
   if (lhs.EqualTo(rhs)) {
     lhs = Expression::One();
-    return lhs;
+    return;
   }
-  lhs = Expression{make_shared<ExpressionDiv>(lhs, rhs)};
-  return lhs;
+  lhs = Expression{make_unique<ExpressionDiv>(lhs, rhs)};
 }
 
 namespace {
@@ -572,7 +546,12 @@ class PrecisionGuard {
 ostream& operator<<(ostream& os, const Expression& e) {
   const PrecisionGuard precision_guard{&os,
                                        numeric_limits<double>::max_digits10};
-  return e.cell().Display(os);
+  if (is_constant(e)) {
+    os << get_constant_value(e);
+  } else {
+    e.cell().Display(os);
+  }
+  return os;
 }
 
 Expression log(const Expression& e) {
@@ -582,7 +561,7 @@ Expression log(const Expression& e) {
     ExpressionLog::check_domain(v);
     return Expression{std::log(v)};
   }
-  return Expression{make_shared<ExpressionLog>(e)};
+  return Expression{make_unique<ExpressionLog>(e)};
 }
 
 Expression abs(const Expression& e) {
@@ -590,7 +569,7 @@ Expression abs(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::fabs(get_constant_value(e))};
   }
-  return Expression{make_shared<ExpressionAbs>(e)};
+  return Expression{make_unique<ExpressionAbs>(e)};
 }
 
 Expression exp(const Expression& e) {
@@ -598,7 +577,7 @@ Expression exp(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::exp(get_constant_value(e))};
   }
-  return Expression{make_shared<ExpressionExp>(e)};
+  return Expression{make_unique<ExpressionExp>(e)};
 }
 
 Expression sqrt(const Expression& e) {
@@ -614,7 +593,7 @@ Expression sqrt(const Expression& e) {
       return abs(get_first_argument(e));
     }
   }
-  return Expression{make_shared<ExpressionSqrt>(e)};
+  return Expression{make_unique<ExpressionSqrt>(e)};
 }
 
 Expression pow(const Expression& e1, const Expression& e2) {
@@ -642,9 +621,9 @@ Expression pow(const Expression& e1, const Expression& e2) {
     // pow(base, exponent) ^ e2 => pow(base, exponent * e2)
     const Expression& base{get_first_argument(e1)};
     const Expression& exponent{get_second_argument(e1)};
-    return Expression{make_shared<ExpressionPow>(base, exponent * e2)};
+    return Expression{make_unique<ExpressionPow>(base, exponent * e2)};
   }
-  return Expression{make_shared<ExpressionPow>(e1, e2)};
+  return Expression{make_unique<ExpressionPow>(e1, e2)};
 }
 
 Expression sin(const Expression& e) {
@@ -652,7 +631,7 @@ Expression sin(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::sin(get_constant_value(e))};
   }
-  return Expression{make_shared<ExpressionSin>(e)};
+  return Expression{make_unique<ExpressionSin>(e)};
 }
 
 Expression cos(const Expression& e) {
@@ -661,7 +640,7 @@ Expression cos(const Expression& e) {
     return Expression{std::cos(get_constant_value(e))};
   }
 
-  return Expression{make_shared<ExpressionCos>(e)};
+  return Expression{make_unique<ExpressionCos>(e)};
 }
 
 Expression tan(const Expression& e) {
@@ -669,7 +648,7 @@ Expression tan(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::tan(get_constant_value(e))};
   }
-  return Expression{make_shared<ExpressionTan>(e)};
+  return Expression{make_unique<ExpressionTan>(e)};
 }
 
 Expression asin(const Expression& e) {
@@ -679,7 +658,7 @@ Expression asin(const Expression& e) {
     ExpressionAsin::check_domain(v);
     return Expression{std::asin(v)};
   }
-  return Expression{make_shared<ExpressionAsin>(e)};
+  return Expression{make_unique<ExpressionAsin>(e)};
 }
 
 Expression acos(const Expression& e) {
@@ -689,7 +668,7 @@ Expression acos(const Expression& e) {
     ExpressionAcos::check_domain(v);
     return Expression{std::acos(v)};
   }
-  return Expression{make_shared<ExpressionAcos>(e)};
+  return Expression{make_unique<ExpressionAcos>(e)};
 }
 
 Expression atan(const Expression& e) {
@@ -697,7 +676,7 @@ Expression atan(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::atan(get_constant_value(e))};
   }
-  return Expression{make_shared<ExpressionAtan>(e)};
+  return Expression{make_unique<ExpressionAtan>(e)};
 }
 
 Expression atan2(const Expression& e1, const Expression& e2) {
@@ -706,7 +685,7 @@ Expression atan2(const Expression& e1, const Expression& e2) {
     return Expression{
         std::atan2(get_constant_value(e1), get_constant_value(e2))};
   }
-  return Expression{make_shared<ExpressionAtan2>(e1, e2)};
+  return Expression{make_unique<ExpressionAtan2>(e1, e2)};
 }
 
 Expression sinh(const Expression& e) {
@@ -714,7 +693,7 @@ Expression sinh(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::sinh(get_constant_value(e))};
   }
-  return Expression{make_shared<ExpressionSinh>(e)};
+  return Expression{make_unique<ExpressionSinh>(e)};
 }
 
 Expression cosh(const Expression& e) {
@@ -722,7 +701,7 @@ Expression cosh(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::cosh(get_constant_value(e))};
   }
-  return Expression{make_shared<ExpressionCosh>(e)};
+  return Expression{make_unique<ExpressionCosh>(e)};
 }
 
 Expression tanh(const Expression& e) {
@@ -730,7 +709,7 @@ Expression tanh(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::tanh(get_constant_value(e))};
   }
-  return Expression{make_shared<ExpressionTanh>(e)};
+  return Expression{make_unique<ExpressionTanh>(e)};
 }
 
 Expression min(const Expression& e1, const Expression& e2) {
@@ -742,7 +721,7 @@ Expression min(const Expression& e1, const Expression& e2) {
   if (is_constant(e1) && is_constant(e2)) {
     return Expression{std::min(get_constant_value(e1), get_constant_value(e2))};
   }
-  return Expression{make_shared<ExpressionMin>(e1, e2)};
+  return Expression{make_unique<ExpressionMin>(e1, e2)};
 }
 
 Expression max(const Expression& e1, const Expression& e2) {
@@ -754,7 +733,7 @@ Expression max(const Expression& e1, const Expression& e2) {
   if (is_constant(e1) && is_constant(e2)) {
     return Expression{std::max(get_constant_value(e1), get_constant_value(e2))};
   }
-  return Expression{make_shared<ExpressionMax>(e1, e2)};
+  return Expression{make_unique<ExpressionMax>(e1, e2)};
 }
 
 Expression ceil(const Expression& e) {
@@ -762,7 +741,7 @@ Expression ceil(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::ceil(get_constant_value(e))};
   }
-  return Expression{make_shared<ExpressionCeiling>(e)};
+  return Expression{make_unique<ExpressionCeiling>(e)};
 }
 
 Expression floor(const Expression& e) {
@@ -770,7 +749,7 @@ Expression floor(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::floor(get_constant_value(e))};
   }
-  return Expression{make_shared<ExpressionFloor>(e)};
+  return Expression{make_unique<ExpressionFloor>(e)};
 }
 
 Expression if_then_else(const Formula& f_cond, const Expression& e_then,
@@ -783,56 +762,14 @@ Expression if_then_else(const Formula& f_cond, const Expression& e_then,
   if (f_cond.EqualTo(Formula::False())) {
     return e_else;
   }
-  return Expression{make_shared<ExpressionIfThenElse>(f_cond, e_then, e_else)};
+  return Expression{make_unique<ExpressionIfThenElse>(f_cond, e_then, e_else)};
 }
 
 Expression uninterpreted_function(string name, vector<Expression> arguments) {
-  return Expression{make_shared<ExpressionUninterpretedFunction>(
+  return Expression{make_unique<ExpressionUninterpretedFunction>(
       std::move(name), std::move(arguments))};
 }
 
-bool is_constant(const Expression& e) { return is_constant(e.cell()); }
-bool is_constant(const Expression& e, const double v) {
-  return is_constant(e) && (to_constant(e).get_value() == v);
-}
-bool is_zero(const Expression& e) { return is_constant(e, 0.0); }
-bool is_one(const Expression& e) { return is_constant(e, 1.0); }
-bool is_neg_one(const Expression& e) { return is_constant(e, -1.0); }
-bool is_two(const Expression& e) { return is_constant(e, 2.0); }
-bool is_nan(const Expression& e) { return e.get_kind() == ExpressionKind::NaN; }
-bool is_variable(const Expression& e) { return is_variable(e.cell()); }
-bool is_addition(const Expression& e) { return is_addition(e.cell()); }
-bool is_multiplication(const Expression& e) {
-  return is_multiplication(e.cell());
-}
-bool is_division(const Expression& e) { return is_division(e.cell()); }
-bool is_log(const Expression& e) { return is_log(e.cell()); }
-bool is_abs(const Expression& e) { return is_abs(e.cell()); }
-bool is_exp(const Expression& e) { return is_exp(e.cell()); }
-bool is_sqrt(const Expression& e) { return is_sqrt(e.cell()); }
-bool is_pow(const Expression& e) { return is_pow(e.cell()); }
-bool is_sin(const Expression& e) { return is_sin(e.cell()); }
-bool is_cos(const Expression& e) { return is_cos(e.cell()); }
-bool is_tan(const Expression& e) { return is_tan(e.cell()); }
-bool is_asin(const Expression& e) { return is_asin(e.cell()); }
-bool is_acos(const Expression& e) { return is_acos(e.cell()); }
-bool is_atan(const Expression& e) { return is_atan(e.cell()); }
-bool is_atan2(const Expression& e) { return is_atan2(e.cell()); }
-bool is_sinh(const Expression& e) { return is_sinh(e.cell()); }
-bool is_cosh(const Expression& e) { return is_cosh(e.cell()); }
-bool is_tanh(const Expression& e) { return is_tanh(e.cell()); }
-bool is_min(const Expression& e) { return is_min(e.cell()); }
-bool is_max(const Expression& e) { return is_max(e.cell()); }
-bool is_ceil(const Expression& e) { return is_ceil(e.cell()); }
-bool is_floor(const Expression& e) { return is_floor(e.cell()); }
-bool is_if_then_else(const Expression& e) { return is_if_then_else(e.cell()); }
-bool is_uninterpreted_function(const Expression& e) {
-  return is_uninterpreted_function(e.cell());
-}
-
-double get_constant_value(const Expression& e) {
-  return to_constant(e).get_value();
-}
 const Variable& get_variable(const Expression& e) {
   return to_variable(e).get_variable();
 }

--- a/common/symbolic/expression/expression.h
+++ b/common/symbolic/expression/expression.h
@@ -5,6 +5,7 @@
 #endif
 
 #include <algorithm>  // for cpplint only
+#include <cmath>
 #include <cstddef>
 #include <functional>
 #include <limits>
@@ -35,7 +36,6 @@ namespace drake {
 namespace symbolic {
 
 class ExpressionCell;                   // In expression_cell.h
-class ExpressionConstant;               // In expression_cell.h
 class ExpressionVar;                    // In expression_cell.h
 class UnaryExpressionCell;              // In expression_cell.h
 class BinaryExpressionCell;             // In expression_cell.h
@@ -82,13 +82,11 @@ Its syntax tree is as follows:
        | NaN | uninterpreted_function(name, {v_1, ..., v_n})
 @endverbatim
 
-In the implementation, Expression is a simple wrapper including a shared pointer
-to ExpressionCell class which is a super-class of different kinds of symbolic
-expressions (i.e. ExpressionAdd, ExpressionMul, ExpressionLog,
-ExpressionSin). Note that it includes a shared pointer, not a unique pointer, to
-allow sharing sub-expressions.
-
-@note The sharing of sub-expressions is not yet implemented.
+In the implementation, Expression directly stores Constant values inline, but in
+all other cases stores a shared pointer to a const ExpressionCell class that is
+a super-class of different kinds of symbolic expressions (i.e., ExpressionAdd,
+ExpressionMul, ExpressionLog, ExpressionSin), which makes it efficient to copy,
+move, and assign to an Expression.
 
 @note -E is represented as -1 * E internally.
 
@@ -132,7 +130,8 @@ symbolic::Formula instead of bool. Those operations are declared in formula.h
 file. To check structural equality between two expressions a separate function,
 Expression::EqualTo, is provided.
 
-Regarding NaN, we have the following rules:
+Regarding the arithmetic of an Expression when operating on NaNs, we have the
+following rules:
  1. NaN values are extremely rare during typical computations. Because they are
     difficult to handle symbolically, we will round that up to "must never
     occur". We allow the user to form ExpressionNaN cells in a symbolic
@@ -152,6 +151,10 @@ Regarding NaN, we have the following rules:
     appears in an evaluated trunk. That goes against rule (1) where a NaN
     anywhere in a computation (other than dead code) is an error.
 
+@internal note for Drake developers: under the hood of Expression, we have an
+internal::BoxedCell helper class that uses NaN for pointer tagging; that's a
+distinct concept from the Expression::NaN() rules enumerated just above.
+
 symbolic::Expression can be used as a scalar type of Eigen types.
 */
 class Expression {
@@ -160,18 +163,28 @@ class Expression {
   ~Expression() = default;
 
   /** Default constructor. It constructs Zero(). */
-  Expression() { *this = Zero(); }
+  Expression() = default;
 
   /** Constructs a constant. */
   // NOLINTNEXTLINE(runtime/explicit): This conversion is desirable.
-  Expression(double constant);
+  Expression(double constant)
+      : boxed_(std::isnan(constant) ? 0.0 : constant) {
+    if (std::isnan(constant)) {
+      ConstructExpressionCellNaN();
+    }
+  }
+
   /** Constructs an expression from @p var.
    * @pre @p var is neither a dummy nor a BOOLEAN variable.
    */
   // NOLINTNEXTLINE(runtime/explicit): This conversion is desirable.
   Expression(const Variable& var);
+
   /** Returns expression kind. */
-  [[nodiscard]] ExpressionKind get_kind() const;
+  [[nodiscard]] ExpressionKind get_kind() const {
+    return boxed_.get_kind();
+  }
+
   /** Collects variables in expression. */
   [[nodiscard]] Variables GetVariables() const;
 
@@ -298,13 +311,13 @@ class Expression {
   [[nodiscard]] std::string to_string() const;
 
   /** Returns zero. */
-  static Expression Zero();
+  static Expression Zero() { return 0.0; }
   /** Returns one. */
-  static Expression One();
+  static Expression One() { return 1.0; }
   /** Returns Pi, the ratio of a circle’s circumference to its diameter. */
-  static Expression Pi();
+  static Expression Pi() { return M_PI; }
   /** Return e, the base of natural logarithms. */
-  static Expression E();
+  static Expression E() { return M_E; }
   /** Returns NaN (Not-a-Number). */
   static Expression NaN();
 
@@ -319,9 +332,35 @@ class Expression {
     item.HashAppend(&delegating_hasher);
   }
 
-  friend Expression operator+(Expression lhs, const Expression& rhs);
+  friend Expression operator+(Expression lhs, const Expression& rhs) {
+    lhs += rhs;
+    return lhs;
+  }
   // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-  friend Expression& operator+=(Expression& lhs, const Expression& rhs);
+  friend Expression& operator+=(Expression& lhs, const Expression& rhs) {
+    // Simplification: Expression(c1) + Expression(c2) => Expression(c1 + c2)
+    //
+    // Recall that BoxedCell can efficiently provide us with a `double` that is
+    // either the Constant stored inside the box, or else is NaN.
+    //
+    // When both the lhs and rhs are constants, we need to perform the addition
+    // inline, for performance. For that case, it's more efficient to perform
+    // the sum and then check for NaN afterward (returning immediately in case
+    // it wasn't, i.e., terms were Constant) rather that doing two separate
+    // checks for lhs.is_constant() and rhs.is_constant() ahead of time.
+    //
+    // Note that operations on infinities might also produce a NaN as the
+    // speculative value. That's fine, we'll handle it during AddImpl; that
+    // case is rare, so doesn't need to be inline.
+    const double speculative_value =
+        lhs.boxed_.constant_or_nan() + rhs.boxed_.constant_or_nan();
+    if (!std::isnan(speculative_value)) {
+      lhs.boxed_.update_constant(speculative_value);
+    } else {
+      lhs.AddImpl(rhs);
+    }
+    return lhs;
+  }
 
   /** Provides prefix increment operator (i.e. ++x). */
   Expression& operator++();
@@ -330,9 +369,23 @@ class Expression {
   /** Provides unary plus operator. */
   friend Expression operator+(const Expression& e);
 
-  friend Expression operator-(Expression lhs, const Expression& rhs);
+  friend Expression operator-(Expression lhs, const Expression& rhs) {
+    lhs -= rhs;
+    return lhs;
+  }
   // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-  friend Expression& operator-=(Expression& lhs, const Expression& rhs);
+  friend Expression& operator-=(Expression& lhs, const Expression& rhs) {
+    // Simplification: Expression(c1) - Expression(c2) => Expression(c1 - c2)
+    // Refer to operator+= comment for how the speculative_value works here.
+    const double speculative_value =
+        lhs.boxed_.constant_or_nan() - rhs.boxed_.constant_or_nan();
+    if (!std::isnan(speculative_value)) {
+      lhs.boxed_.update_constant(speculative_value);
+    } else {
+      lhs.SubImpl(rhs);
+    }
+    return lhs;
+  }
 
   /** Provides unary minus operator. */
   friend Expression operator-(const Expression& e);
@@ -341,13 +394,46 @@ class Expression {
   /** Provides postfix decrement operator (i.e. x--). */
   Expression operator--(int);
 
-  friend Expression operator*(Expression lhs, const Expression& rhs);
+  friend Expression operator*(Expression lhs, const Expression& rhs) {
+    lhs *= rhs;
+    return lhs;
+  }
   // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-  friend Expression& operator*=(Expression& lhs, const Expression& rhs);
+  friend Expression& operator*=(Expression& lhs, const Expression& rhs) {
+    // Simplification: Expression(c1) * Expression(c2) => Expression(c1 * c2)
+    // Refer to operator+= comment for how the speculative_value works here.
+    const double speculative_value =
+        lhs.boxed_.constant_or_nan() * rhs.boxed_.constant_or_nan();
+    if (!std::isnan(speculative_value)) {
+      lhs.boxed_.update_constant(speculative_value);
+    } else {
+      lhs.MulImpl(rhs);
+    }
+    return lhs;
+  }
 
-  friend Expression operator/(Expression lhs, const Expression& rhs);
+  friend Expression operator/(Expression lhs, const Expression& rhs) {
+    lhs /= rhs;
+    return lhs;
+  }
   // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-  friend Expression& operator/=(Expression& lhs, const Expression& rhs);
+  friend Expression& operator/=(Expression& lhs, const Expression& rhs) {
+    // Simplification: Expression(c1) / Expression(c2) => Expression(c1 / c2)
+    // Refer to operator+= comment for how the speculative_value works here.
+    //
+    // We check rhs for zero here because DivImpl needs to throw an exception
+    // in that case. TODO(jwnimmer-tri) I don't understand why we need to throw
+    // during division by zero. The result is typically well-defined (infinity).
+    const double rhs_or_nan = rhs.boxed_.constant_or_nan();
+    const double speculative_value =
+        lhs.boxed_.constant_or_nan() / rhs_or_nan;
+    if ((rhs_or_nan != 0.0) && !std::isnan(speculative_value)) {
+      lhs.boxed_.update_constant(speculative_value);
+    } else {
+      lhs.DivImpl(rhs);
+    }
+    return lhs;
+  }
 
   friend Expression log(const Expression& e);
   friend Expression abs(const Expression& e);
@@ -413,9 +499,13 @@ class Expression {
                                            std::vector<Expression> arguments);
 
   friend std::ostream& operator<<(std::ostream& os, const Expression& e);
-  friend void swap(Expression& a, Expression& b) { std::swap(a.ptr_, b.ptr_); }
+  friend void swap(Expression& a, Expression& b) {
+    std::swap(a.boxed_, b.boxed_);
+  }
 
   friend bool is_constant(const Expression& e);
+  friend bool is_constant(const Expression& e, double value);
+  friend bool is_nan(const Expression& e);
   friend bool is_variable(const Expression& e);
   friend bool is_addition(const Expression& e);
   friend bool is_multiplication(const Expression& e);
@@ -441,11 +531,11 @@ class Expression {
   friend bool is_floor(const Expression& e);
   friend bool is_if_then_else(const Expression& e);
   friend bool is_uninterpreted_function(const Expression& e);
+  friend double get_constant_value(const Expression& e);
 
   // Note that the following cast functions are only for low-level operations
   // and not exposed to the user of drake/common/symbolic/expression.h header.
   // These functions are declared in the expression_cell.h header.
-  friend const ExpressionConstant& to_constant(const Expression& e);
   friend const ExpressionVar& to_variable(const Expression& e);
   friend const UnaryExpressionCell& to_unary(const Expression& e);
   friend const BinaryExpressionCell& to_binary(const Expression& e);
@@ -476,7 +566,6 @@ class Expression {
   to_uninterpreted_function(const Expression& e);
 
   // Cast functions which takes a pointer to a non-const Expression.
-  friend ExpressionConstant& to_constant(Expression* e);
   friend ExpressionVar& to_variable(Expression* e);
   friend UnaryExpressionCell& to_unary(Expression* e);
   friend BinaryExpressionCell& to_binary(Expression* e);
@@ -510,29 +599,28 @@ class Expression {
   friend class ExpressionMulFactory;
 
  private:
-  // This is a helper function used to handle `Expression(double)` constructor.
-  static std::shared_ptr<ExpressionCell> make_cell(double d);
-
-  explicit Expression(std::shared_ptr<ExpressionCell> ptr);
+  explicit Expression(std::unique_ptr<ExpressionCell> cell);
+  void ConstructExpressionCellNaN();
 
   void HashAppend(DelegatingHasher* hasher) const;
 
+  void AddImpl(const Expression& rhs);
+  void SubImpl(const Expression& rhs);
+  void MulImpl(const Expression& rhs);
+  void DivImpl(const Expression& rhs);
+
   // Returns a const reference to the owned cell.
+  // @pre This expression is not a Constant.
   const ExpressionCell& cell() const {
-    DRAKE_ASSERT(ptr_ != nullptr);
-    return *ptr_;
+    return boxed_.cell();
   }
 
   // Returns a mutable reference to the owned cell. This function may only be
-  // called when this object is the sole owner of the cell.
+  // called when this object is the sole owner of the cell (use_count == 1).
+  // @pre This expression is not an ExpressionKind::Constant.
   ExpressionCell& mutable_cell();
 
-  // Note: We use "non-const" ExpressionCell type. This allows us to perform
-  // destructive updates on the pointed cell if the cell is not shared with
-  // other Expressions (that is, ptr_.use_count() == 1). However, because that
-  // pattern needs careful attention, our library code should never access
-  // ptr_ directly, it should always use cell() or mutable_cell().
-  std::shared_ptr<ExpressionCell> ptr_;
+  internal::BoxedCell boxed_;
 };
 
 Expression operator+(Expression lhs, const Expression& rhs);
@@ -586,74 +674,142 @@ void swap(Expression& a, Expression& b);
 std::ostream& operator<<(std::ostream& os, const Expression& e);
 
 /** Checks if @p e is a constant expression. */
-bool is_constant(const Expression& e);
+inline bool is_constant(const Expression& e) {
+  return e.boxed_.is_constant();
+}
 /** Checks if @p e is a constant expression representing @p v. */
-bool is_constant(const Expression& e, double v);
+inline bool is_constant(const Expression& e, double v) {
+  // N.B. This correctly returns `false` even when comparing e's cell against
+  // a `v` value of NaN, because NaN == NaN is false.
+  return e.boxed_.constant_or_nan() == v;
+}
 /** Checks if @p e is 0.0. */
-bool is_zero(const Expression& e);
+inline bool is_zero(const Expression& e) {
+  return is_constant(e, 0.0);
+}
 /** Checks if @p e is 1.0. */
-bool is_one(const Expression& e);
+inline bool is_one(const Expression& e) {
+  return is_constant(e, 1.0);
+}
 /** Checks if @p e is -1.0. */
-bool is_neg_one(const Expression& e);
+inline bool is_neg_one(const Expression& e) {
+  return is_constant(e, -1.0);
+}
 /** Checks if @p e is 2.0. */
-bool is_two(const Expression& e);
+inline bool is_two(const Expression& e) {
+  return is_constant(e, 2.0);
+}
 /** Checks if @p e is NaN. */
-bool is_nan(const Expression& e);
+inline bool is_nan(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::NaN>();
+}
 /** Checks if @p e is a variable expression. */
-bool is_variable(const Expression& e);
+inline bool is_variable(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Var>();
+}
 /** Checks if @p e is an addition expression. */
-bool is_addition(const Expression& e);
+inline bool is_addition(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Add>();
+}
 /** Checks if @p e is a multiplication expression. */
-bool is_multiplication(const Expression& e);
+inline bool is_multiplication(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Mul>();
+}
 /** Checks if @p e is a division expression. */
-bool is_division(const Expression& e);
+inline bool is_division(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Div>();
+}
 /** Checks if @p e is a log expression. */
-bool is_log(const Expression& e);
+inline bool is_log(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Log>();
+}
 /** Checks if @p e is an abs expression. */
-bool is_abs(const Expression& e);
+inline bool is_abs(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Abs>();
+}
 /** Checks if @p e is an exp expression. */
-bool is_exp(const Expression& e);
+inline bool is_exp(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Exp>();
+}
 /** Checks if @p e is a square-root expression. */
-bool is_sqrt(const Expression& e);
+inline bool is_sqrt(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Sqrt>();
+}
 /** Checks if @p e is a power-function expression. */
-bool is_pow(const Expression& e);
+inline bool is_pow(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Pow>();
+}
 /** Checks if @p e is a sine expression. */
-bool is_sin(const Expression& e);
+inline bool is_sin(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Sin>();
+}
 /** Checks if @p e is a cosine expression. */
-bool is_cos(const Expression& e);
+inline bool is_cos(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Cos>();
+}
 /** Checks if @p e is a tangent expression. */
-bool is_tan(const Expression& e);
+inline bool is_tan(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Tan>();
+}
 /** Checks if @p e is an arcsine expression. */
-bool is_asin(const Expression& e);
+inline bool is_asin(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Asin>();
+}
 /** Checks if @p e is an arccosine expression. */
-bool is_acos(const Expression& e);
+inline bool is_acos(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Acos>();
+}
 /** Checks if @p e is an arctangent expression. */
-bool is_atan(const Expression& e);
+inline bool is_atan(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Atan>();
+}
 /** Checks if @p e is an arctangent2 expression. */
-bool is_atan2(const Expression& e);
+inline bool is_atan2(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Atan2>();
+}
 /** Checks if @p e is a hyperbolic-sine expression. */
-bool is_sinh(const Expression& e);
+inline bool is_sinh(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Sinh>();
+}
 /** Checks if @p e is a hyperbolic-cosine expression. */
-bool is_cosh(const Expression& e);
+inline bool is_cosh(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Cosh>();
+}
 /** Checks if @p e is a hyperbolic-tangent expression. */
-bool is_tanh(const Expression& e);
+inline bool is_tanh(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Tanh>();
+}
 /** Checks if @p e is a min expression. */
-bool is_min(const Expression& e);
+inline bool is_min(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Min>();
+}
 /** Checks if @p e is a max expression. */
-bool is_max(const Expression& e);
+inline bool is_max(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Max>();
+}
 /** Checks if @p e is a ceil expression. */
-bool is_ceil(const Expression& e);
+inline bool is_ceil(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Ceil>();
+}
 /** Checks if @p e is a floor expression. */
-bool is_floor(const Expression& e);
+inline bool is_floor(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::Floor>();
+}
 /** Checks if @p e is an if-then-else expression. */
-bool is_if_then_else(const Expression& e);
+inline bool is_if_then_else(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::IfThenElse>();
+}
 /** Checks if @p e is an uninterpreted-function expression. */
-bool is_uninterpreted_function(const Expression& e);
+inline bool is_uninterpreted_function(const Expression& e) {
+  return e.boxed_.is_kind<ExpressionKind::UninterpretedFunction>();
+}
 
 /** Returns the constant value of the constant expression @p e.
  *  \pre{@p e is a constant expression.}
  */
-double get_constant_value(const Expression& e);
+inline double get_constant_value(const Expression& e) {
+  return e.boxed_.constant();
+}
 /** Returns the embedded variable in the variable expression @p e.
  *  \pre{@p e is a variable expression.}
  */

--- a/common/symbolic/expression/expression_cell.cc
+++ b/common/symbolic/expression/expression_cell.cc
@@ -27,7 +27,7 @@ using std::domain_error;
 using std::endl;
 using std::equal;
 using std::lexicographical_compare;
-using std::make_shared;
+using std::make_unique;
 using std::map;
 using std::numeric_limits;
 using std::ostream;
@@ -384,48 +384,6 @@ Expression ExpressionVar::Differentiate(const Variable& x) const {
 
 ostream& ExpressionVar::Display(ostream& os) const { return os << var_; }
 
-ExpressionConstant::ExpressionConstant(const double v)
-    : ExpressionCell{ExpressionKind::Constant, true, true}, v_{v} {
-  DRAKE_ASSERT(!std::isnan(v));
-}
-
-void ExpressionConstant::HashAppendDetail(DelegatingHasher* hasher) const {
-  using drake::hash_append;
-  hash_append(*hasher, v_);
-}
-
-Variables ExpressionConstant::GetVariables() const { return Variables{}; }
-
-bool ExpressionConstant::EqualTo(const ExpressionCell& e) const {
-  // Expression::EqualTo guarantees the following assertion.
-  DRAKE_ASSERT(get_kind() == e.get_kind());
-  return v_ == static_cast<const ExpressionConstant&>(e).v_;
-}
-
-bool ExpressionConstant::Less(const ExpressionCell& e) const {
-  // Expression::Less guarantees the following assertion.
-  DRAKE_ASSERT(get_kind() == e.get_kind());
-  return v_ < static_cast<const ExpressionConstant&>(e).v_;
-}
-
-double ExpressionConstant::Evaluate(const Environment&) const {
-  DRAKE_DEMAND(!std::isnan(v_));
-  return v_;
-}
-
-Expression ExpressionConstant::Expand() const { return Expression{v_}; }
-
-Expression ExpressionConstant::Substitute(const Substitution&) const {
-  DRAKE_DEMAND(!std::isnan(v_));
-  return Expression{v_};
-}
-
-Expression ExpressionConstant::Differentiate(const Variable&) const {
-  return Expression::Zero();
-}
-
-ostream& ExpressionConstant::Display(ostream& os) const { return os << v_; }
-
 ExpressionNaN::ExpressionNaN()
     : ExpressionCell{ExpressionKind::NaN, false, false} {}
 
@@ -683,7 +641,7 @@ Expression ExpressionAddFactory::GetExpression() const {
     const auto it(expr_to_coeff_map_.cbegin());
     return it->first * it->second;
   }
-  auto result = make_shared<ExpressionAdd>(constant_, expr_to_coeff_map_);
+  auto result = make_unique<ExpressionAdd>(constant_, expr_to_coeff_map_);
   if (is_expanded_) {
     result->set_expanded();
   }
@@ -1002,11 +960,11 @@ Expression ExpressionMulFactory::GetExpression() const {
     const auto it(base_to_exponent_map_.cbegin());
     return pow(it->first, it->second);
   }
-  auto result = make_shared<ExpressionMul>(constant_, base_to_exponent_map_);
+  auto result = make_unique<ExpressionMul>(constant_, base_to_exponent_map_);
   if (is_expanded_) {
     result->set_expanded();
   }
-  return Expression{result};
+  return Expression{std::move(result)};
 }
 
 void ExpressionMulFactory::AddConstant(const double constant) {
@@ -2064,9 +2022,6 @@ ostream& ExpressionUninterpretedFunction::Display(ostream& os) const {
   return os << ")";
 }
 
-bool is_constant(const ExpressionCell& c) {
-  return c.get_kind() == ExpressionKind::Constant;
-}
 bool is_variable(const ExpressionCell& c) {
   return c.get_kind() == ExpressionKind::Var;
 }
@@ -2141,16 +2096,6 @@ bool is_if_then_else(const ExpressionCell& c) {
 }
 bool is_uninterpreted_function(const ExpressionCell& c) {
   return c.get_kind() == ExpressionKind::UninterpretedFunction;
-}
-
-const ExpressionConstant& to_constant(const Expression& e) {
-  DRAKE_ASSERT(is_constant(e));
-  return static_cast<const ExpressionConstant&>(e.cell());
-}
-
-ExpressionConstant& to_constant(Expression* const e) {
-  DRAKE_ASSERT(e && is_constant(*e));
-  return static_cast<ExpressionConstant&>(e->mutable_cell());
 }
 
 const ExpressionVar& to_variable(const Expression& e) {

--- a/common/symbolic/expression/expression_cell.h
+++ b/common/symbolic/expression/expression_cell.h
@@ -46,8 +46,7 @@ class ExpressionCell {
 
   virtual ~ExpressionCell();
 
-  /** Returns the intrusive use count (ala boost::intrusive_ptr).
-  @warning This value is currently UNUSED except in unit tests; ignore it. */
+  /** Returns the intrusive use count (ala boost::intrusive_ptr). */
   std::atomic<int>& use_count() const { return use_count_; }
 
   /** Returns expression kind. */
@@ -186,25 +185,6 @@ class ExpressionVar : public ExpressionCell {
 
  private:
   const Variable var_;
-};
-
-/** Symbolic expression representing a constant. */
-class ExpressionConstant : public ExpressionCell {
- public:
-  explicit ExpressionConstant(double v);
-  [[nodiscard]] double get_value() const { return v_; }
-  void HashAppendDetail(DelegatingHasher*) const override;
-  [[nodiscard]] Variables GetVariables() const override;
-  [[nodiscard]] bool EqualTo(const ExpressionCell& e) const override;
-  [[nodiscard]] bool Less(const ExpressionCell& e) const override;
-  [[nodiscard]] double Evaluate(const Environment& env) const override;
-  [[nodiscard]] Expression Expand() const override;
-  [[nodiscard]] Expression Substitute(const Substitution& s) const override;
-  [[nodiscard]] Expression Differentiate(const Variable& x) const override;
-  std::ostream& Display(std::ostream& os) const override;
-
- private:
-  const double v_{};
 };
 
 /** Symbolic expression representing NaN (not-a-number). */
@@ -786,8 +766,6 @@ class ExpressionUninterpretedFunction : public ExpressionCell {
   const std::vector<Expression> arguments_;
 };
 
-/** Checks if @p c is a constant expression. */
-bool is_constant(const ExpressionCell& c);
 /** Checks if @p c is a variable expression. */
 bool is_variable(const ExpressionCell& c);
 /** Checks if @p c is a unary expression. */

--- a/common/symbolic/expression/test/expression_cell_test.cc
+++ b/common/symbolic/expression/test/expression_cell_test.cc
@@ -53,8 +53,6 @@ class SymbolicExpressionCellTest : public ::testing::Test {
 };
 
 TEST_F(SymbolicExpressionCellTest, CastFunctionsConst) {
-  EXPECT_EQ(to_constant(e_constant_).get_value(),
-            get_constant_value(e_constant_));
   EXPECT_EQ(to_variable(e_var_).get_variable(), get_variable(e_var_));
 
   EXPECT_EQ(to_addition(e_add_).get_constant(),
@@ -122,8 +120,6 @@ TEST_F(SymbolicExpressionCellTest, CastFunctionsConst) {
 }
 
 TEST_F(SymbolicExpressionCellTest, CastFunctionsNonConst) {
-  EXPECT_EQ(to_constant(Expression{e_constant_}).get_value(),
-            get_constant_value(e_constant_));
   EXPECT_EQ(to_variable(Expression{e_var_}).get_variable(),
             get_variable(e_var_));
 


### PR DESCRIPTION
Finally resurrected from the initial attempt in #15369 last year.

This substantially speeds up symbolic evaluation by storing both the ExpressionKind and the constant literal value (if present) directly inline within the Expression object.

Piotr Duperas has a [nice overview on nanboxing](https://piotrduperas.com/posts/nan-boxing) for those who haven't seen it before.

---

Performance report (using the updated benchmark from #17539):

![For T=Expression, comparing Master vs Nanboxing PR](https://user-images.githubusercontent.com/17596505/180101811-3865d967-bfd3-4f2f-b9c5-edbbbe091ca1.svg)

Benchmark name | Change in throughput | New throughput relative to T=double
--|--|--
CassieExpression/MassMatrix/0 | 7.0x | 1/20
CassieExpression/MassMatrix/3 | 1.5x
CassieExpression/InverseDynamics/0 | 8.7x | 1/16
CassieExpression/InverseDynamics/7 | 1.3x
CassieExpression/ForwardDynamics/0 | 6.8x | 1/15
CassieExpression/ForwardDynamics/10 | 1.5x
BenchmarkSosProgram1 | 1.0x
BenchmarkSosProgram2 | 1.4x
BenchmarkSosProgram3 | 1.5x

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17544)
<!-- Reviewable:end -->
