### PR TITLE
Refactor to shorten into set/get_discrete_contact_solver().

### DIFF
--- a/examples/atlas/atlas_run_dynamics.cc
+++ b/examples/atlas/atlas_run_dynamics.cc
@@ -50,7 +50,7 @@ int do_main() {
   MultibodyPlantConfig plant_config;
   plant_config.time_step = FLAGS_mbp_discrete_update_period;
   plant_config.stiction_tolerance = FLAGS_stiction_tolerance;
-  plant_config.discrete_contact_solver_type = FLAGS_discrete_solver;
+  plant_config.discrete_contact_solver = FLAGS_discrete_solver;
   auto [plant, scene_graph] =
       multibody::AddMultibodyPlant(plant_config, &builder);
 

--- a/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
+++ b/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
@@ -139,7 +139,7 @@ int DoMain() {
   plant_config.time_step = FLAGS_mbp_discrete_update_period;
   plant_config.stiction_tolerance = FLAGS_stiction_tolerance;
   plant_config.contact_model = FLAGS_contact_model;
-  plant_config.discrete_contact_solver_type = FLAGS_discrete_solver;
+  plant_config.discrete_contact_solver = FLAGS_discrete_solver;
   plant_config.contact_surface_representation =
       FLAGS_contact_surface_representation;
 

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -365,8 +365,8 @@ MultibodyPlant<T>::MultibodyPlant(double time_step)
   DRAKE_DEMAND(contact_model_ == ContactModel::kHydroelasticWithFallback);
   DRAKE_DEMAND(MultibodyPlantConfig{}.contact_model ==
                "hydroelastic_with_fallback");
-  DRAKE_DEMAND(solver_type_ == DiscreteContactSolverType::kTamsi);
-  DRAKE_DEMAND(MultibodyPlantConfig{}.discrete_contact_solver_type == "tamsi");
+  DRAKE_DEMAND(solver_type_ == DiscreteContactSolver::kTamsi);
+  DRAKE_DEMAND(MultibodyPlantConfig{}.discrete_contact_solver == "tamsi");
 }
 
 template <typename T>
@@ -493,14 +493,14 @@ void MultibodyPlant<T>::set_contact_model(ContactModel model) {
 }
 
 template <typename T>
-void MultibodyPlant<T>::set_discrete_contact_solver_type(
-    DiscreteContactSolverType solver_type) {
+void MultibodyPlant<T>::set_discrete_contact_solver(
+    DiscreteContactSolver solver_type) {
   DRAKE_MBP_THROW_IF_FINALIZED();
   solver_type_ = solver_type;
 }
 
 template <typename T>
-DiscreteContactSolverType MultibodyPlant<T>::get_discrete_contact_solver_type()
+DiscreteContactSolver MultibodyPlant<T>::get_discrete_contact_solver()
     const {
   return solver_type_;
 }
@@ -831,12 +831,12 @@ void MultibodyPlant<T>::Finalize() {
   // contact, into CompliantContactManager.
   if (is_discrete()) {
     if constexpr (!std::is_same_v<T, symbolic::Expression>) {
-      if (solver_type_ == DiscreteContactSolverType::kSap) {
+      if (solver_type_ == DiscreteContactSolver::kSap) {
         SetDiscreteUpdateManager(
             std::make_unique<internal::CompliantContactManager<T>>());
       }
     } else {
-      if (solver_type_ == DiscreteContactSolverType::kSap) {
+      if (solver_type_ == DiscreteContactSolver::kSap) {
         throw std::runtime_error(
             "SAP solver not supported for scalar type T = "
             "symbolic::Expression.");

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -111,7 +111,7 @@ enum class ContactModel {
 /// - [Castro et al., 2022] Castro A., Permenter F. and Han X., 2022. An
 ///   Unconstrained Convex Formulation of Compliant Contact. Available online at
 ///   https://arxiv.org/abs/2110.10107.
-enum class DiscreteContactSolverType {
+enum class DiscreteContactSolver {
   /// TAMSI solver, see [Castro et al., 2019].
   kTamsi,
   /// SAP solver, see [Castro et al., 2022].
@@ -407,10 +407,10 @@ the following properties for point contact modeling:
 ⁴ We allow to specify both hunt_crossley_dissipation and dissipation_timescale
   for a given geometry. However only one of these will get used, depending on
   the configuration of the %MultibodyPlant. As an example, if the SAP solver is
-  specified (see set_discrete_contact_solver_type()) only the
+  specified (see set_discrete_contact_solver()) only the
   dissipation_timescale is used while hunt_crossley_dissipation is ignored.
   Conversely, if the TAMSI solver is used (see
-  set_discrete_contact_solver_type()) only hunt_crossley_dissipation is used
+  set_discrete_contact_solver()) only hunt_crossley_dissipation is used
   while dissipation_timescale is ignored. Currently, a continuous
   %MultibodyPlant model will always use the Hunt & Crossley model and
   dissipation_timescale will be ignored.
@@ -1625,10 +1625,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// Sets the contact solver type used for discrete %MultibodyPlant models.
   /// @throws std::exception iff called post-finalize.
-  void set_discrete_contact_solver_type(DiscreteContactSolverType solver_type);
+  void set_discrete_contact_solver(DiscreteContactSolver solver_type);
 
   /// Returns the contact solver type used for discrete %MultibodyPlant models.
-  DiscreteContactSolverType get_discrete_contact_solver_type() const;
+  DiscreteContactSolver get_discrete_contact_solver() const;
 
   /// Return the default value for contact representation, given the desired
   /// time step. Discrete systems default to use polygons; continuous systems
@@ -4917,7 +4917,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // The solver type used by a discrete plant. Keep this in sync
   // with the default value in multibody_plant_config.h; there are already
   // assertions in the cc file that enforce this.
-  DiscreteContactSolverType solver_type_{DiscreteContactSolverType::kTamsi};
+  DiscreteContactSolver solver_type_{DiscreteContactSolver::kTamsi};
 
   // User's choice of the representation of contact surfaces in discrete
   // systems. The default value is dependent on whether the system is

--- a/multibody/plant/multibody_plant_config.h
+++ b/multibody/plant/multibody_plant_config.h
@@ -18,7 +18,7 @@ struct MultibodyPlantConfig {
     a->Visit(DRAKE_NVP(penetration_allowance));
     a->Visit(DRAKE_NVP(stiction_tolerance));
     a->Visit(DRAKE_NVP(contact_model));
-    a->Visit(DRAKE_NVP(discrete_contact_solver_type));
+    a->Visit(DRAKE_NVP(discrete_contact_solver));
     a->Visit(DRAKE_NVP(contact_surface_representation));
   }
 
@@ -43,12 +43,12 @@ struct MultibodyPlantConfig {
   /// - "hydroelastic_with_fallback"
   std::string contact_model{"hydroelastic_with_fallback"};
 
-  /// Configures the MultibodyPlant::set_discrete_contact_solver_type().
-  /// Refer to drake::multibody::DiscreteContactSolverType for details.
+  /// Configures the MultibodyPlant::set_discrete_contact_solver().
+  /// Refer to drake::multibody::DiscreteContactSolver for details.
   /// Valid strings are:
   /// - "tamsi"
   /// - "sap"
-  std::string discrete_contact_solver_type{"tamsi"};
+  std::string discrete_contact_solver{"tamsi"};
 
   /// Configures the MultibodyPlant::set_contact_surface_representation().
   /// Refer to drake::geometry::HydroelasticContactRepresentation for details.

--- a/multibody/plant/multibody_plant_config_functions.cc
+++ b/multibody/plant/multibody_plant_config_functions.cc
@@ -19,9 +19,9 @@ AddResult AddMultibodyPlant(
   result.plant.set_stiction_tolerance(config.stiction_tolerance);
   result.plant.set_contact_model(
       internal::GetContactModelFromString(config.contact_model));
-  result.plant.set_discrete_contact_solver_type(
-      internal::GetDiscreteContactSolverTypeFromString(
-          config.discrete_contact_solver_type));
+  result.plant.set_discrete_contact_solver(
+      internal::GetDiscreteContactSolverFromString(
+          config.discrete_contact_solver));
   result.plant.set_contact_surface_representation(
       internal::GetContactSurfaceRepresentationFromString(
           config.contact_surface_representation));
@@ -57,26 +57,26 @@ constexpr std::array<std::pair<ContactModel, const char*>, 3> kContactModels{{
 
 // Use a switch() statement here, to ensure the compiler sends us a reminder
 // when somebody adds a new value to the enum. New values must be listed here
-// as well as in the list of kDiscreteContactSolverTypes below.
-constexpr const char* DiscreteContactSolverTypeToChars(
-    DiscreteContactSolverType type) {
+// as well as in the list of kDiscreteContactSolvers below.
+constexpr const char* DiscreteContactSolverToChars(
+    DiscreteContactSolver type) {
   switch (type) {
-    case DiscreteContactSolverType::kTamsi:
+    case DiscreteContactSolver::kTamsi:
       return "tamsi";
-    case DiscreteContactSolverType::kSap:
+    case DiscreteContactSolver::kSap:
       return "sap";
   }
 }
 
-constexpr auto MakeDiscreteContactSolverTypePair(
-    DiscreteContactSolverType value) {
-  return std::pair(value, DiscreteContactSolverTypeToChars(value));
+constexpr auto MakeDiscreteContactSolverPair(
+    DiscreteContactSolver value) {
+  return std::pair(value, DiscreteContactSolverToChars(value));
 }
 
-constexpr std::array<std::pair<DiscreteContactSolverType, const char*>, 2>
-    kDiscreteContactSolverTypes{{
-        MakeDiscreteContactSolverTypePair(DiscreteContactSolverType::kTamsi),
-        MakeDiscreteContactSolverTypePair(DiscreteContactSolverType::kSap),
+constexpr std::array<std::pair<DiscreteContactSolver, const char*>, 2>
+    kDiscreteContactSolvers{{
+        MakeDiscreteContactSolverPair(DiscreteContactSolver::kTamsi),
+        MakeDiscreteContactSolverPair(DiscreteContactSolver::kSap),
     }};
 
 // Take an alias to limit verbosity, especially in the constexpr boilerplate.
@@ -124,21 +124,21 @@ std::string GetStringFromContactModel(ContactModel contact_model) {
   DRAKE_UNREACHABLE();
 }
 
-DiscreteContactSolverType GetDiscreteContactSolverTypeFromString(
-    std::string_view discrete_contact_solver_type) {
-  for (const auto& [value, name] : kDiscreteContactSolverTypes) {
-    if (name == discrete_contact_solver_type) {
+DiscreteContactSolver GetDiscreteContactSolverFromString(
+    std::string_view discrete_contact_solver) {
+  for (const auto& [value, name] : kDiscreteContactSolvers) {
+    if (name == discrete_contact_solver) {
       return value;
     }
   }
   throw std::logic_error(
-      fmt::format("Unknown discrete_contact_solver_type: '{}'",
-                  discrete_contact_solver_type));
+      fmt::format("Unknown discrete_contact_solver: '{}'",
+                  discrete_contact_solver));
 }
 
-std::string GetStringFromDiscreteContactSolverType(
-    DiscreteContactSolverType contact_solver) {
-  for (const auto& [value, name] : kDiscreteContactSolverTypes) {
+std::string GetStringFromDiscreteContactSolver(
+    DiscreteContactSolver contact_solver) {
+  for (const auto& [value, name] : kDiscreteContactSolvers) {
     if (value == contact_solver) {
       return name;
     }

--- a/multibody/plant/multibody_plant_config_functions.h
+++ b/multibody/plant/multibody_plant_config_functions.h
@@ -33,13 +33,13 @@ std::string GetStringFromContactModel(ContactModel contact_model);
 // value. Valid string names are listed in MultibodyPlantConfig's class
 // overview.
 // @throws std::exception if an invalid string is passed in.
-DiscreteContactSolverType GetDiscreteContactSolverTypeFromString(
-    std::string_view discrete_contact_solver_type);
+DiscreteContactSolver GetDiscreteContactSolverFromString(
+    std::string_view discrete_contact_solver);
 
 // (Exposed for unit testing only.) Returns the string name of an enumerated
 // value for a discrete contact solver type.
-std::string GetStringFromDiscreteContactSolverType(
-    DiscreteContactSolverType discrete_contact_solver_type);
+std::string GetStringFromDiscreteContactSolver(
+    DiscreteContactSolver discrete_contact_solver);
 
 // (Exposed for unit testing only.)
 // Parses a string name for a contact representation and returns the enumerated

--- a/multibody/plant/test/multibody_plant_config_functions_test.cc
+++ b/multibody/plant/test/multibody_plant_config_functions_test.cc
@@ -36,7 +36,7 @@ time_step: 0.002
 penetration_allowance: 0.003
 stiction_tolerance: 0.004
 contact_model: hydroelastic
-discrete_contact_solver_type: sap
+discrete_contact_solver: sap
 contact_surface_representation: triangle
 )""";
 
@@ -49,8 +49,8 @@ GTEST_TEST(MultibodyPlantConfigFunctionsTest, YamlTest) {
             ContactModel::kHydroelasticsOnly);
   EXPECT_EQ(result.plant.get_contact_surface_representation(),
             geometry::HydroelasticContactRepresentation::kTriangle);
-  EXPECT_EQ(result.plant.get_discrete_contact_solver_type(),
-            DiscreteContactSolverType::kSap);
+  EXPECT_EQ(result.plant.get_discrete_contact_solver(),
+            DiscreteContactSolver::kSap);
   // There is no getter for penetration_allowance nor stiction_tolerance, so we
   // can't test them.
 }


### PR DESCRIPTION
Refactor to shorten from set/get_discrete_contact_solver_type() into set/get_discrete_contact_solver(). Similarly, the enum is refactored from `DiscreteContactSolverType` to `DiscreteContactSolver`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17545)
<!-- Reviewable:end -->
