### PR TITLE
Increase timeout in mypy ModuleImport

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -695,11 +695,7 @@ drake_py_binary(
 
 drake_py_unittest(
     name = "stubgen_test",
-    tags = [
-        # TODO(jwnimmer-tri) Re-enable this test once Debug build timeouts
-        # have been fixed.
-        "manual",
-    ],
+    timeout = "moderate",
     deps = [
         ":all_py",
         "@mypy_internal//:mypy",

--- a/tools/workspace/mypy_internal/repository.bzl
+++ b/tools/workspace/mypy_internal/repository.bzl
@@ -9,8 +9,8 @@ def mypy_internal_repository(
         name = name,
         repository = "python/mypy",
         # TODO(mwoehlke-kitware): switch to a tag >= v0.980.
-        commit = "3ae19a25f0a39358ede1383e93d44ef9abf165e0",
-        sha256 = "866503aed58d7207c0fe4bca9a6a51c1eaa6668157b1c5ed61b40eda71af9175",  # noqa
+        commit = "7c6faf4c7a7bac6b126a30c5c61f5d209a4312c0",
+        sha256 = "f0ab4a26f0f75fc345865b17e4c21f34f13b7d9220eab663e96116dd326b9e48",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
Patch ModuleImport in mypy to increase the timeout before aborting an attempt to import a module. The default timeout of 5s is not long enough to import `pydrake` in some configurations.

Also increase the timeout on our `stubgen_test`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17552)
<!-- Reviewable:end -->
