### PR TITLE
[workspace] Skip drake-visualizer wrapper install on unsupported platforms

### DIFF
--- a/tools/workspace/drake_visualizer/BUILD.bazel
+++ b/tools/workspace/drake_visualizer/BUILD.bazel
@@ -66,7 +66,9 @@ install_files(
         # participate in the install target.  Nerf the linter warning for that.
         "no_install_lint",
     ],
-    files = ["drake_visualizer_installed.py"],
+    files = [
+        "drake_visualizer_installed.py",
+    ] if _DRAKE_VISUALIZER_ENABLED else [],
     rename = {
         "bin/drake_visualizer_installed.py": "drake-visualizer",
     },


### PR DESCRIPTION
Currently the wrapper script is installed and will fail when run since ${prefix}/bin/.drake-visualizer-real is not available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17553)
<!-- Reviewable:end -->
