### PR TITLE
Sap relaxation time

### DIFF
--- a/geometry/proximity_properties.cc
+++ b/geometry/proximity_properties.cc
@@ -7,7 +7,7 @@ namespace internal {
 const char* const kMaterialGroup = "material";
 const char* const kFriction = "coulomb_friction";
 const char* const kHcDissipation = "hunt_crossley_dissipation";
-const char* const kDissipationTimescale = "dissipation_timescale";
+const char* const kRelaxationTime = "relaxation_time";
 const char* const kPointStiffness = "point_contact_stiffness";
 
 const char* const kHydroGroup = "hydroelastic";

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -35,8 +35,8 @@ extern const char* const kFriction;        ///< Friction coefficients property
                                            ///< name.
 extern const char* const kHcDissipation;   ///< Hunt-Crossley dissipation
                                            ///< property name.
-extern const char* const kDissipationTimescale;   ///< Linear dissipation
-                                                  ///< property name.
+extern const char* const kRelaxationTime;  ///< Linear dissipation
+                                           ///< property name.
 extern const char* const kPointStiffness;  ///< Point stiffness property
                                            ///< name.
 

--- a/multibody/parsing/detail_common.cc
+++ b/multibody/parsing/detail_common.cc
@@ -89,8 +89,8 @@ geometry::ProximityProperties ParseProximityProperties(
   std::optional<double> dissipation =
       read_double("drake:hunt_crossley_dissipation");
 
-  std::optional<double> dissipation_timescale =
-      read_double("drake:dissipation_timescale");
+  std::optional<double> relaxation_time =
+      read_double("drake:relaxation_time");
 
   std::optional<double> stiffness =
       read_double("drake:point_contact_stiffness");
@@ -110,15 +110,15 @@ geometry::ProximityProperties ParseProximityProperties(
 
   geometry::AddContactMaterial(dissipation, stiffness, friction, &properties);
 
-  if (dissipation_timescale.has_value()) {
-    if (*dissipation_timescale < 0) {
+  if (relaxation_time.has_value()) {
+    if (*relaxation_time < 0) {
       throw std::logic_error(
           fmt::format("The dissipation time scale can't be negative; given {}",
                       *dissipation));
     }
     properties.AddProperty(geometry::internal::kMaterialGroup,
-                           geometry::internal::kDissipationTimescale,
-                           *dissipation_timescale);
+                           geometry::internal::kRelaxationTime,
+                           *relaxation_time);
   }
 
   return properties;

--- a/multibody/parsing/detail_sdf_geometry.cc
+++ b/multibody/parsing/detail_sdf_geometry.cc
@@ -485,7 +485,7 @@ ProximityProperties MakeProximityPropertiesForCollision(
       "drake:mesh_resolution_hint",
       "drake:hydroelastic_modulus",
       "drake:hunt_crossley_dissipation",
-      "drake:dissipation_timescale",
+      "drake:relaxation_time",
       "drake:point_contact_stiffness",
       "drake:mu_dynamic",
       "drake:mu_static"};

--- a/multibody/parsing/detail_sdf_geometry.h
+++ b/multibody/parsing/detail_sdf_geometry.h
@@ -158,7 +158,7 @@ math::RigidTransformd MakeGeometryPoseFromSdfCollision(
  | drake:mesh_resolution_hint       | hydroelastic | resolution_hint           | Required for shapes that require tessellation to support hydroelastic contact.                                                   |
  | drake:hydroelastic_modulus       | hydroelastic | hydroelastic_modulus      | Finite positive value. Required for compliant hydroelastic representations.                                                      |
  | drake:hunt_crossley_dissipation  | material     | hunt_crossley_dissipation |                                                                                                                                  |
- | drake:dissipation_timescale     | material     | dissipation_timescale    | Required when using a linear model of dissipation, for instance with the SAP solver.                                              |
+ | drake:relaxation_time            | material     | relaxation_time           | Required when using a linear model of dissipation, for instance with the SAP solver.                                             |
  | drake:mu_dynamic                 | material     | coulomb_friction          | See note below on friction.                                                                                                      |
  | drake:mu_static                  | material     | coulomb_friction          | See note below on friction.                                                                                                      |
  | drake:rigid_hydroelastic         | hydroelastic | compliance_type           | Requests a rigid hydroelastic representation. Cannot be combined *with* soft_hydroelastic.                                       |

--- a/multibody/parsing/detail_urdf_geometry.h
+++ b/multibody/parsing/detail_urdf_geometry.h
@@ -182,7 +182,7 @@ std::optional<geometry::GeometryInstance> ParseVisual(
  | drake:mesh_resolution_hint       | hydroelastic | resolution_hint           | Required for shapes that require tessellation to support hydroelastic contact.                                                   |
  | drake:hydroelastic_modulus       | hydroelastic | hydroelastic_modulus      | Finite positive value. Required for compliant hydroelastic representations.                                                      |
  | drake:hunt_crossley_dissipation  | material     | hunt_crossley_dissipation |                                                                                                                                  |
- | drake:dissipation_timescale     | material     | dissipation_timescale    | Required when using a linear model of dissipation, for instance with the SAP solver.                                              |
+ | drake:relaxation_time            | material     | relaxation_time           | Required when using a linear model of dissipation, for instance with the SAP solver.                                             |
  | drake:mu_dynamic                 | material     | coulomb_friction          | See note below on friction.                                                                                                      |
  | drake:mu_static                  | material     | coulomb_friction          | See note below on friction.                                                                                                      |
  | drake:rigid_hydroelastic         | hydroelastic | compliance_type           | Requests a rigid hydroelastic representation. Cannot be combined *with* soft_hydroelastic.                                       |

--- a/multibody/parsing/parsing_doxygen.h
+++ b/multibody/parsing/parsing_doxygen.h
@@ -151,7 +151,7 @@ Here is the full list of custom elements:
 - @ref tag_drake_damping
 - @ref tag_drake_declare_convex
 - @ref tag_drake_diffuse_map
-- @ref tag_drake_dissipation_timescale
+- @ref tag_drake_relaxation_time
 - @ref tag_drake_ellipsoid
 - @ref tag_drake_gear_ratio
 - @ref tag_drake_hunt_crossley_dissipation
@@ -457,17 +457,17 @@ ProximityProperties object under `(material, hunt_crossley_dissipation)`.
 @ref mbp_hydroelastic_materials_properties "Hydroelastic contact",
 @ref mbp_dissipation_model "Modeling Dissipation"
 
-@subsection tag_drake_dissipation_timescale drake:dissipation_timescale
+@subsection tag_drake_relaxation_time drake:relaxation_time
 
-- SDFormat path: `//model/link/collision/drake:proximity_properies/drake:dissipation_timescale`
-- URDF path: `/robot/link/collision/drake:proximity_properties/drake:dissipation_timescale/@value`
+- SDFormat path: `//model/link/collision/drake:proximity_properies/drake:relaxation_time`
+- URDF path: `/robot/link/collision/drake:proximity_properties/drake:relaxation_time/@value`
 - Syntax: Non-negative floating point value.
 
-@subsubsection tag_drake_dissipation_timescale_semantics Semantics
+@subsubsection tag_drake_relaxation_time_semantics Semantics
 
-If present, this element provides a value (units of time,
-i.e. seconds) for a linear model of dissipation. It is stored in a
-ProximityProperties object under `(material, dissipation_timescale)`.
+If present, this element provides a value (units of time, i.e. seconds) for a
+linear Kelvin-Voigt model of dissipation. It is stored in a ProximityProperties
+object under `(material, relaxation_time)`.
 
 @see drake::geometry::ProximityProperties,
 @ref mbp_dissipation_model "Modeling Dissipation"

--- a/multibody/parsing/test/detail_common_test.cc
+++ b/multibody/parsing/test/detail_common_test.cc
@@ -14,7 +14,7 @@ using geometry::GeometryProperties;
 using geometry::ProximityProperties;
 using geometry::internal::HydroelasticType;
 using geometry::internal::kComplianceType;
-using geometry::internal::kDissipationTimescale;
+using geometry::internal::kRelaxationTime;
 using geometry::internal::kElastic;
 using geometry::internal::kFriction;
 using geometry::internal::kHcDissipation;
@@ -253,10 +253,10 @@ TEST_F(ParseProximityPropertiesTest, Dissipation) {
 TEST_F(ParseProximityPropertiesTest, LinearDissipation) {
   const double kValue = 1.25;
   ProximityProperties properties = ParseProximityProperties(
-      param_read_double("drake:dissipation_timescale", kValue), !rigid,
+      param_read_double("drake:relaxation_time", kValue), !rigid,
       !compliant);
   EXPECT_TRUE(
-      ExpectScalar(kMaterialGroup, kDissipationTimescale, kValue, properties));
+      ExpectScalar(kMaterialGroup, kRelaxationTime, kValue, properties));
   // Dissipation is the only property.
   EXPECT_EQ(properties.GetPropertiesInGroup(kMaterialGroup).size(), 1u);
   EXPECT_EQ(properties.num_groups(), 2);  // Material and default groups.

--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -1136,7 +1136,7 @@ TEST_F(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
     <drake:mesh_resolution_hint>2.5</drake:mesh_resolution_hint>
     <drake:hydroelastic_modulus>3.5</drake:hydroelastic_modulus>
     <drake:hunt_crossley_dissipation>4.5</drake:hunt_crossley_dissipation>
-    <drake:dissipation_timescale>3.1</drake:dissipation_timescale>
+    <drake:relaxation_time>3.1</drake:relaxation_time>
     <drake:mu_dynamic>4.5</drake:mu_dynamic>
     <drake:mu_static>4.75</drake:mu_static>
   </drake:proximity_properties>)""");
@@ -1149,7 +1149,7 @@ TEST_F(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
     assert_single_property(properties, geometry::internal::kMaterialGroup,
                            geometry::internal::kHcDissipation, 4.5);
     assert_single_property(properties, geometry::internal::kMaterialGroup,
-                           geometry::internal::kDissipationTimescale, 3.1);
+                           geometry::internal::kRelaxationTime, 3.1);
     assert_friction(properties, {4.75, 4.5});
   }
 

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -675,7 +675,7 @@ TEST_F(UrdfGeometryTest, CollisionSmokeTest) {
     <drake:mesh_resolution_hint value="2.5"/>
     <drake:hydroelastic_modulus value="3.5" />
     <drake:hunt_crossley_dissipation value="3.5" />
-    <drake:dissipation_timescale value="3.1" />
+    <drake:relaxation_time value="3.1" />
     <drake:mu_dynamic value="3.25" />
     <drake:mu_static value="3.5" />
   </drake:proximity_properties>)""");
@@ -686,7 +686,7 @@ TEST_F(UrdfGeometryTest, CollisionSmokeTest) {
   VerifySingleProperty(properties, geometry::internal::kMaterialGroup,
                        geometry::internal::kHcDissipation, 3.5);
   VerifySingleProperty(properties, geometry::internal::kMaterialGroup,
-                       geometry::internal::kDissipationTimescale, 3.1);
+                       geometry::internal::kRelaxationTime, 3.1);
   VerifyFriction(properties, {3.5, 3.25});
 }
 

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -226,21 +226,11 @@ T CompliantContactManager<T>::GetDissipationTimeConstant(
                        inspector.GetName(geometry_id), body.name());
   };
 
-  if (!prop->HasProperty(geometry::internal::kMaterialGroup,
-                         "relaxation_time")) {
-    const std::string message = "No `relaxation_time` specified. " +
-                                provide_context_string(id) +
-                                " You are using a linear model of "
-                                "compliant contact that requires you "
-                                "to specify dissipation explicitly.";
-    throw std::runtime_error(message);
-  }
-
   // N.B. Here we rely on the resolution of #13289 and #5454 to get properties
   // with the proper scalar type T. This will not work on scalar converted
   // models until those issues are resolved.
-  const T relaxation_time = prop->template GetProperty<T>(
-      geometry::internal::kMaterialGroup, "relaxation_time");
+  const T relaxation_time = prop->template GetPropertyOrDefault<double>(
+      geometry::internal::kMaterialGroup, "relaxation_time", 0.1);
   if (relaxation_time < 0.0) {
     const std::string message = fmt::format(
         "Relaxation time must be non-negative and relaxation_time "

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -227,27 +227,28 @@ T CompliantContactManager<T>::GetDissipationTimeConstant(
   };
 
   if (!prop->HasProperty(geometry::internal::kMaterialGroup,
-                         "dissipation_timescale")) {
-    const std::string message =
-        "No `dissipation_timescale` specified. " + provide_context_string(id) +
-        " You are using a linear model of compliant contact that requires you "
-        "to specify dissipation explicitly.";
+                         "relaxation_time")) {
+    const std::string message = "No `relaxation_time` specified. " +
+                                provide_context_string(id) +
+                                " You are using a linear model of "
+                                "compliant contact that requires you "
+                                "to specify dissipation explicitly.";
     throw std::runtime_error(message);
   }
 
   // N.B. Here we rely on the resolution of #13289 and #5454 to get properties
   // with the proper scalar type T. This will not work on scalar converted
   // models until those issues are resolved.
-  const T dissipation_timescale = prop->template GetProperty<T>(
-      geometry::internal::kMaterialGroup, "dissipation_timescale");
-  if (dissipation_timescale < 0.0) {
+  const T relaxation_time = prop->template GetProperty<T>(
+      geometry::internal::kMaterialGroup, "relaxation_time");
+  if (relaxation_time < 0.0) {
     const std::string message = fmt::format(
-        "Dissipation timescale must be non-negative and dissipation_timescale "
+        "Relaxation time must be non-negative and relaxation_time "
         "= {} was provided. {}",
-        dissipation_timescale, provide_context_string(id));
+        relaxation_time, provide_context_string(id));
     throw std::runtime_error(message);
   }
-  return dissipation_timescale;
+  return relaxation_time;
 }
 
 template <typename T>

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -385,7 +385,7 @@ the following properties for point contact modeling:
 |  material  | coulomb_friction |   yes¹   | CoulombFriction<T> | Static and Dynamic friction. |
 |  material  | point_contact_stiffness |  no²  | T | Penalty method stiffness. |
 |  material  | hunt_crossley_dissipation |  no²⁴  | T | Penalty method dissipation. |
-|  material  | dissipation_timescale |  yes³⁴  | T | Linear dissipation parameter. |
+|  material  | relaxation_time |  yes³⁴  | T | Parameter for a linear Kelvin–Voigt model of dissipation. |
 
 
 ¹ Collision geometry is required to be registered with a
@@ -398,22 +398,22 @@ the following properties for point contact modeling:
   section @ref mbp_penalty_method "Penalty method point contact" for further
   details.
 
-³ When using a linear model of dissipation (for instance when selecting the SAP
-  solver), collision geometry is required to be registered with a
-  geometry::ProximityProperties object that contains the ("material",
-  "dissipation_timescale") property. If the property is missing, an exception
-  will be thrown.
+³ When using a linear Kelvin–Voigt model of dissipation (for instance when
+  selecting the SAP solver), collision geometry is required to be registered
+  with a geometry::ProximityProperties object that contains the ("material",
+  "relaxation_time") property. If the property is missing, an exception will be
+  thrown.
 
-⁴ We allow to specify both hunt_crossley_dissipation and dissipation_timescale
+⁴ We allow to specify both hunt_crossley_dissipation and relaxation_time
   for a given geometry. However only one of these will get used, depending on
   the configuration of the %MultibodyPlant. As an example, if the SAP solver is
   specified (see set_discrete_contact_solver_type()) only the
-  dissipation_timescale is used while hunt_crossley_dissipation is ignored.
+  relaxation_time is used while hunt_crossley_dissipation is ignored.
   Conversely, if the TAMSI solver is used (see
   set_discrete_contact_solver_type()) only hunt_crossley_dissipation is used
-  while dissipation_timescale is ignored. Currently, a continuous
+  while relaxation_time is ignored. Currently, a continuous
   %MultibodyPlant model will always use the Hunt & Crossley model and
-  dissipation_timescale will be ignored.
+  relaxation_time will be ignored.
 
 Accessing and modifying contact properties requires interfacing with
 geometry::SceneGraph's model inspector. Interfacing with a model inspector

--- a/multibody/plant/test/compliant_contact_manager_test.cc
+++ b/multibody/plant/test/compliant_contact_manager_test.cc
@@ -328,20 +328,16 @@ class SpheresStack : public ::testing::Test {
 
     // In these tests ContactParameters::relaxation_time = nullopt
     // indicates we want to build a model for which we forgot to specify the
-    // relaxation time in ProximityProperties. Here we verify this is
-    // required by the manager.
+    // relaxation time in ProximityProperties. Here we verify this is not
+    // required by the manager, since the manager specifies a default value.
     if (!sphere1_point_params.relaxation_time.has_value() ||
         !sphere2_point_params.relaxation_time.has_value()) {
-      DRAKE_EXPECT_THROWS_MESSAGE(
-          EvalDiscreteContactPairs(*plant_context_),
-          "No `relaxation_time` specified. For geometry .* on body .*. "
-          "You are using a linear model of compliant contact that requires you "
-          "to specify dissipation explicitly.");
+      EXPECT_NO_THROW(EvalDiscreteContactPairs(*plant_context_));
       return;
     }
 
-    // Verify that the manager throws an exception if a negative dissipation
-    // timescale is provided.
+    // Verify that the manager throws an exception if a negative relaxation
+    // times is provided.
     if (*sphere1_point_params.relaxation_time < 0 ||
         *sphere2_point_params.relaxation_time < 0) {
       DRAKE_EXPECT_THROWS_MESSAGE(EvalDiscreteContactPairs(*plant_context_),
@@ -600,7 +596,7 @@ TEST_F(SpheresStack, VerifyDiscreteContactPairs) {
   VerifyDiscreteContactPairs(soft_point_contact, hard_point_contact);
 }
 
-TEST_F(SpheresStack, DissipationTimeScaleIsRequired) {
+TEST_F(SpheresStack, RelaxationTimeIsNotRequired) {
   ContactParameters soft_point_contact{
       1.0e3, std::nullopt,
       std::nullopt /* Dissipation not included in ProximityProperties */, 1.0};
@@ -616,7 +612,7 @@ TEST_F(SpheresStack, DissipationTimeScaleIsRequired) {
   VerifyDiscreteContactPairs(soft_point_contact, hard_point_contact);
 }
 
-TEST_F(SpheresStack, DissipationTimeScaleMustBePositive) {
+TEST_F(SpheresStack, RelaxationTimeMustBePositive) {
   ContactParameters soft_point_contact{
       1.0e3, std::nullopt, -1.0 /* Negative dissipation timescale */, 1.0};
   ContactParameters hard_point_contact{1.0e40, std::nullopt, 0.0, 1.0};

--- a/multibody/plant/test/compliant_contact_manager_test.cc
+++ b/multibody/plant/test/compliant_contact_manager_test.cc
@@ -157,11 +157,11 @@ class SpheresStack : public ::testing::Test {
     // Hydroelastic modulus. If nullopt, this property is not added to the
     // model.
     std::optional<double> hydro_modulus;
-    // Dissipation time constant τ is used to setup the linear dissipation model
+    // Relaxation time constant τ is used to setup the linear dissipation model
     // where dissipation is c = τ⋅k, with k the point pair stiffness.
     // If nullopt, no dissipation is specified, i.e. the corresponding
     // ProximityProperties will not have dissipation defined.
-    std::optional<double> dissipation_timescale;
+    std::optional<double> relaxation_time;
     // Coefficient of dynamic friction.
     double friction_coefficient{nan()};
   };
@@ -326,15 +326,15 @@ class SpheresStack : public ::testing::Test {
     ASSERT_EQ(surfaces.size(), 1u);
     const int num_hydro_pairs = surfaces[0].num_faces();
 
-    // In these tests ContactParameters::dissipation_timescale = nullopt
+    // In these tests ContactParameters::relaxation_time = nullopt
     // indicates we want to build a model for which we forgot to specify the
-    // dissipation timescale in ProximityProperties. Here we verify this is
+    // relaxation time in ProximityProperties. Here we verify this is
     // required by the manager.
-    if (!sphere1_point_params.dissipation_timescale.has_value() ||
-        !sphere2_point_params.dissipation_timescale.has_value()) {
+    if (!sphere1_point_params.relaxation_time.has_value() ||
+        !sphere2_point_params.relaxation_time.has_value()) {
       DRAKE_EXPECT_THROWS_MESSAGE(
           EvalDiscreteContactPairs(*plant_context_),
-          "No `dissipation_timescale` specified. For geometry .* on body .*. "
+          "No `relaxation_time` specified. For geometry .* on body .*. "
           "You are using a linear model of compliant contact that requires you "
           "to specify dissipation explicitly.");
       return;
@@ -342,11 +342,11 @@ class SpheresStack : public ::testing::Test {
 
     // Verify that the manager throws an exception if a negative dissipation
     // timescale is provided.
-    if (*sphere1_point_params.dissipation_timescale < 0 ||
-        *sphere2_point_params.dissipation_timescale < 0) {
+    if (*sphere1_point_params.relaxation_time < 0 ||
+        *sphere2_point_params.relaxation_time < 0) {
       DRAKE_EXPECT_THROWS_MESSAGE(EvalDiscreteContactPairs(*plant_context_),
-                                  "Dissipation timescale must be non-negative "
-                                  "and dissipation_timescale = .* was "
+                                  "Relaxation time must be non-negative "
+                                  "and relaxation_time = .* was "
                                   "provided. For geometry .* on body .*.");
       return;
     }
@@ -392,10 +392,10 @@ class SpheresStack : public ::testing::Test {
       EXPECT_TRUE(CompareMatrices(point_pair.nhat_BA_W, normal_expected));
 
       // Verify dissipation.
-      const double tau1 = *sphere1_contact_params.dissipation_timescale;
+      const double tau1 = *sphere1_contact_params.relaxation_time;
       const double tau2 = i == 0
-                              ? *sphere2_contact_params.dissipation_timescale
-                              : *hard_hydro_contact.dissipation_timescale;
+                              ? *sphere2_contact_params.relaxation_time
+                              : *hard_hydro_contact.relaxation_time;
       const double tau_expected = tau1 + tau2;
       EXPECT_NEAR(point_pair.dissipation_time_scale, tau_expected,
                   kEps * tau_expected);
@@ -551,7 +551,7 @@ class SpheresStack : public ::testing::Test {
   }
 
   // Utility to make ProximityProperties from ContactParameters.
-  // params.dissipation_timescale is ignored if nullopt.
+  // params.relaxation_time is ignored if nullopt.
   static ProximityProperties MakeProximityProperties(
       const ContactParameters& params) {
     DRAKE_DEMAND(params.point_stiffness || params.hydro_modulus);
@@ -575,10 +575,10 @@ class SpheresStack : public ::testing::Test {
                                 params.friction_coefficient),
         &properties);
 
-    if (params.dissipation_timescale.has_value()) {
+    if (params.relaxation_time.has_value()) {
       properties.AddProperty(geometry::internal::kMaterialGroup,
-                             "dissipation_timescale",
-                             *params.dissipation_timescale);
+                             "relaxation_time",
+                             *params.relaxation_time);
     }
     return properties;
   }


### PR DESCRIPTION
Refactors dissipation parameter name to "relaxation_time", per discussion in #17087.

Per discussion in #17525 this PR introduces a default non-zero value for the relaxation time, `relaxation_time=0.1 secs`.