### PR TITLE
[wheel] Teach setuptools about __init__.so files

### DIFF
--- a/tools/wheel/image/setup.py
+++ b/tools/wheel/image/setup.py
@@ -46,6 +46,14 @@ def find_data_files(*patterns):
     return result
 
 
+def _actually_find_packages():
+    """Work around broken(?!) setuptools."""
+    result = find_packages()
+    result.extend(["pydrake.examples", "pydrake.solvers"])
+    print(f"Using packages={result}")
+    return result
+
+
 setup(name='drake',
       version=DRAKE_VERSION,
       description='Model-based design and verification for robotics',
@@ -78,7 +86,7 @@ design/analysis.'''.strip(),
       # TODO Check this: do we need to add third-party licenses?
       license='BSD 3-Clause License',
       platforms=['linux_x86_64', 'macosx_x86_64'],
-      packages=find_packages(),
+      packages=_actually_find_packages(),
       # Add in any packaged data.
       include_package_data=True,
       package_data={


### PR DESCRIPTION
Hotfix for #17453 and #17454.

According to the internet, `setuptools.find_packages()` is like juggling knives, and we should stop using it.  (See, for example https://github.com/pypa/setuptools/issues/1509.)  In the meantime, we can add back what it's missed, to stop the bleeding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17556)
<!-- Reviewable:end -->
