### PR TITLE
[lcm] De-flake a unit test

### DIFF
--- a/lcm/test/drake_lcm_test.cc
+++ b/lcm/test/drake_lcm_test.cc
@@ -400,10 +400,10 @@ TEST_F(DrakeLcmTest, SuffixInSubscribeAllChannels) {
     EXPECT_EQ(channel_name, "SuffixDrakeLcmTest");
     received_drake.decode(data, 0, size);
   });
-  LoopUntilDone(&received_drake, 20 /* retries */, [&]() {
+  LoopUntilDone(&received_drake, 200 /* retries */, [&]() {
     Publish(publisher.get(), "SuffixDrakeLcmTest_ShouldBeDiscarded", message_);
     Publish(publisher.get(), "SuffixDrakeLcmTest_SUFFIX", message_);
-    dut_->HandleSubscriptions(50 /* millis */);
+    dut_->HandleSubscriptions(5 /* millis */);
   });
 }
 


### PR DESCRIPTION
Hotfix for #17470.

Locally, this gets me from a 20% flake rate down to 0% over 1000 retries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17558)
<!-- Reviewable:end -->
