### PR TITLE
[pydrake] Ignore Eigen::Sparse overloads when scipy is missing

### DIFF
--- a/bindings/pydrake/common/test_utilities/BUILD.bazel
+++ b/bindings/pydrake/common/test_utilities/BUILD.bazel
@@ -72,6 +72,17 @@ drake_py_library(
     ],
 )
 
+# A library that force-disables scipy, even if it's installed system-wide.
+drake_py_library(
+    name = "scipy_none_py",
+    testonly = 1,
+    srcs = [
+        "scipy_none/scipy/__init__.py",
+    ],
+    # N.B. We do not depend on ":module_py".
+    imports = ["scipy_none"],
+)
+
 # A minimal of implementation scipy.sparse that's barely functional enough
 # to support unit testing the Drake APIs that return Eigen::Sparse matrices.
 # The pybind11 type caster for Eigen::Sparse maps it to scipy.sparse.

--- a/bindings/pydrake/common/test_utilities/scipy_none/scipy/__init__.py
+++ b/bindings/pydrake/common/test_utilities/scipy_none/scipy/__init__.py
@@ -1,0 +1,6 @@
+"""When used during unit testing, this module disables scipy -- as if it wasn't
+installed. This helps developers check what happens for users who don't have
+scipy, even if the developer does have scipy installed system-wide.
+"""
+
+raise ModuleNotFoundError("No module named 'scipy'")

--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -199,6 +199,14 @@ drake_py_unittest(
 )
 
 drake_py_unittest(
+    name = "noscipy_test",
+    deps = [
+        ":solvers",
+        "//bindings/pydrake/common/test_utilities:scipy_none_py",
+    ],
+)
+
+drake_py_unittest(
     name = "nlopt_solver_test",
     args = select({
         "//tools:no_nlopt": ["TestNloptSolver.unavailable"],

--- a/bindings/pydrake/solvers/test/noscipy_test.py
+++ b/bindings/pydrake/solvers/test/noscipy_test.py
@@ -1,0 +1,55 @@
+import unittest
+import warnings
+
+import numpy as np
+
+from pydrake.solvers.mathematicalprogram import (
+    LinearConstraint,
+)
+
+
+class TestMathematicalProgram(unittest.TestCase):
+    """Confirms that solvers code may be used without scipy, as long as
+    the user does not call a sparse-matrix function specifically.
+
+    Note that this test is only effective at finding bugs when scipy is not
+    actually available. If you have scipy installed system-wide (e.g., as
+    python3-scipy on Ubuntu) then you will need to uninstall that package
+    before you can trust the results of this test.
+    """
+
+    def test_linear_constraint(self):
+        # The LinearConstraint constructor is overloaded to accept the A matrix
+        # as either sparse or dense. If the user doesn't have scipy installed
+        # they should still be able to call the dense overload, even when the
+        # matrix requires conversion (from numpy's row-major default to the
+        # col-major requirement for passing a `const Eigen::MatrixXd`).
+        A = np.array([[1, 3, 4], [2., 4., 5]])
+        lb = np.array([1, 2.])
+        ub = np.array([3., 4.])
+        dut = LinearConstraint(A=A, lb=lb, ub=ub)
+        self.assertEqual(dut.num_constraints(), 2)
+        self.assertEqual(dut.num_vars(), 3)
+
+        # UpdateCoefficients is similarily overloaded for sparse or dense, and
+        # the user should be able to invoke the dense overload without scipy.
+        dut.UpdateCoefficients(
+            new_A=np.array([[1E-10, 0, 0], [0, 1, 1]]),
+            new_lb=np.array([2, 3]), new_ub=np.array([3, 4]))
+        dut.RemoveTinyCoefficient(tol=1E-5)
+        np.testing.assert_array_equal(
+            dut.GetDenseA(), np.array([[0, 0, 0], [0, 1, 1]]))
+
+        # When testing in Drake CI, scipy will not be installed. When drake
+        # developers run this test locally, they might have scipy installed
+        # for use outside of Drake. In that case, we should double-check
+        # that our Bazel logic for disabling scipy is working properly.
+        try:
+            import scipy
+            self.assertNotIn(
+                "/scipy_stub/", scipy.__file__,
+                "The BUILD dependencies for this test MUST NOT depend on"
+                " :scipy_stub_py, either directly or transitively.")
+            self.fail("Somehow, the scipy_none dependency isn't working?!")
+        except ModuleNotFoundError:
+            pass

--- a/tools/workspace/pybind11/repository.bzl
+++ b/tools/workspace/pybind11/repository.bzl
@@ -10,9 +10,9 @@ _REPOSITORY = "RobotLocomotion/pybind11"
 #  https://github.com/RobotLocomotion/pybind11/blob/drake/include/pybind11/detail/common.h
 # and if it has changed, then update the version number in the two
 # pybind11-*.cmake files in the current directory to match.
-_COMMIT = "25eac331ce222f7cd6cca5f3e023daa0ab1cb475"
+_COMMIT = "50c47be457b7663a96d5f1a7297ccc1453318829"
 
-_SHA256 = "2736e9407efb1243c76f32261fdb29625657ff53f74469505e47d6340dc60a9f"
+_SHA256 = "a972b2c876c0c88cdf40a978fc895241d67bc43b7641ffcfe1f779052867df31"
 
 def pybind11_repository(
         name,


### PR DESCRIPTION
See the tutorials test failure in #17559.

The scenario we have here is that there is an overloaded function, accepting either a sparse or dense matrix .

The [overload resolution order](https://pybind11.readthedocs.io/en/stable/advanced/functions.html#overload-resolution-order) of pybind11 means that unless the user passes _exactly_ the correct kind of ndarray (for the dense case), pybind11 will try to convert the argument into _all_ of the possible overloads, triggering the import of scipy, triggering a ModuleNotFound error.

Since our goal with Drake is to only use sparse matrices sparingly, we should skip overloads that need scipy, rather than hard-fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17570)
<!-- Reviewable:end -->
