### PR TITLE
[inverse_kinematics] Use pydrake_mkdoc_identifier

### DIFF
--- a/bindings/pydrake/multibody/inverse_kinematics_py.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py.cc
@@ -23,9 +23,6 @@ namespace pydrake {
 namespace {
 
 using solvers::Constraint;
-constexpr char ctor_doc_ad[] =
-    "Overloaded constructor. Constructs the constraint using "
-    "MultibodyPlant<AutoDiffXd>";
 
 PYBIND11_MODULE(inverse_kinematics, m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
@@ -140,7 +137,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 9>(), cls_doc.ctor.doc)
+            py::keep_alive<1, 9>(), cls_doc.ctor.doc_double)
         .def(py::init([](const MultibodyPlant<AutoDiffXd>* plant,
                           const Frame<AutoDiffXd>& frameA,
                           const Eigen::Ref<const Eigen::Vector3d>& a_A,
@@ -157,7 +154,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 9>(), ctor_doc_ad);
+            py::keep_alive<1, 9>(), cls_doc.ctor.doc_autodiff);
   }
   {
     using Class = PointToPointDistanceConstraint;
@@ -181,7 +178,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 9>(), cls_doc.ctor.doc)
+            py::keep_alive<1, 9>(), cls_doc.ctor.doc_double)
         .def(py::init(
                  [](const multibody::MultibodyPlant<AutoDiffXd>* const plant,
                      const multibody::Frame<AutoDiffXd>& frame1,
@@ -199,7 +196,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 9>(), ctor_doc_ad);
+            py::keep_alive<1, 9>(), cls_doc.ctor.doc_autodiff);
   }
   {
     using Class = DistanceConstraint;
@@ -219,7 +216,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 4>(), cls_doc.ctor.doc)
+            py::keep_alive<1, 4>(), cls_doc.ctor.doc_double)
         .def(py::init(
                  [](const multibody::MultibodyPlant<AutoDiffXd>* const plant,
                      SortedPair<geometry::GeometryId> geometry_pair,
@@ -234,7 +231,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 4>(), ctor_doc_ad);
+            py::keep_alive<1, 4>(), cls_doc.ctor.doc_autodiff);
   }
 
   {
@@ -259,7 +256,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 9>(), cls_doc.ctor.doc)
+            py::keep_alive<1, 9>(), cls_doc.ctor.doc_double)
         .def(py::init([](const MultibodyPlant<AutoDiffXd>* plant,
                           const Frame<AutoDiffXd>& frameA,
                           const Eigen::Ref<const Eigen::Vector3d>& p_AS,
@@ -277,7 +274,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 9>(), ctor_doc_ad);
+            py::keep_alive<1, 9>(), cls_doc.ctor.doc_autodiff);
   }
 
   {
@@ -301,7 +298,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 4>(), cls_doc.ctor.doc)
+            py::keep_alive<1, 4>(), cls_doc.ctor.doc_double)
         .def(py::init(
                  [](const multibody::MultibodyPlant<AutoDiffXd>* const plant,
                      double minimum_distance,
@@ -319,7 +316,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 4>(), ctor_doc_ad);
+            py::keep_alive<1, 4>(), cls_doc.ctor.doc_autodiff);
   }
 
   {
@@ -343,7 +340,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 8>(), cls_doc.ctor.doc_7args)
+            py::keep_alive<1, 8>(), cls_doc.ctor.doc_double)
         .def(py::init([](const MultibodyPlant<double>* plant,
                           const Frame<double>& frameAbar,
                           const std::optional<math::RigidTransformd>& X_AbarA,
@@ -361,7 +358,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 9>(), cls_doc.ctor.doc_8args)
+            py::keep_alive<1, 9>(), cls_doc.ctor.doc_double_Abar)
         .def(py::init([](const MultibodyPlant<AutoDiffXd>* plant,
                           const Frame<AutoDiffXd>& frameA,
                           const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
@@ -378,7 +375,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 8>(), ctor_doc_ad)
+            py::keep_alive<1, 8>(), cls_doc.ctor.doc_autodiff)
         .def(py::init([](const MultibodyPlant<AutoDiffXd>* plant,
                           const Frame<AutoDiffXd>& frameAbar,
                           const std::optional<math::RigidTransformd>& X_AbarA,
@@ -396,7 +393,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 9>(), ctor_doc_ad)
+            py::keep_alive<1, 9>(), cls_doc.ctor.doc_autodiff_Abar)
         .def("set_bounds", &Class::set_bounds, py::arg("new_lb"),
             py::arg("new_ub"), constraint_doc.set_bounds.doc)
         .def("UpdateLowerBound", &Class::UpdateLowerBound, py::arg("new_lb"),
@@ -423,7 +420,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 5>(), cls_doc.ctor.doc_ctor_double)
+            py::keep_alive<1, 5>(), cls_doc.ctor.doc_double)
         .def(py::init([](const MultibodyPlant<AutoDiffXd>* plant,
                           const std::optional<std::vector<ModelInstanceIndex>>&
                               model_instances,
@@ -437,7 +434,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 5>(), cls_doc.ctor.doc_ctor_autodiff);
+            py::keep_alive<1, 5>(), cls_doc.ctor.doc_autodiff);
   }
 
   {
@@ -463,7 +460,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 8>(), cls_doc.ctor.doc)
+            py::keep_alive<1, 8>(), cls_doc.ctor.doc_double)
         .def(py::init([](const MultibodyPlant<AutoDiffXd>* plant,
                           std::optional<std::vector<ModelInstanceIndex>>
                               model_instances,
@@ -481,7 +478,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 8>(), ctor_doc_ad);
+            py::keep_alive<1, 8>(), cls_doc.ctor.doc_autodiff);
   }
 
   {
@@ -505,7 +502,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 8>(), cls_doc.ctor.doc)
+            py::keep_alive<1, 8>(), cls_doc.ctor.doc_double)
         .def(py::init([](const MultibodyPlant<AutoDiffXd>* const plant,
                           const Frame<AutoDiffXd>& frameAbar,
                           const math::RotationMatrix<double>& R_AbarA,
@@ -522,7 +519,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
-            py::keep_alive<1, 8>(), ctor_doc_ad);
+            py::keep_alive<1, 8>(), cls_doc.ctor.doc_autodiff);
   }
   {
     using Class = UnitQuaternionConstraint;

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.h
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.h
@@ -44,6 +44,7 @@ class AngleBetweenVectorsConstraint : public solvers::Constraint {
    * @throws std::exception if `angle_lower` is negative.
    * @throws std::exception if `angle_upper` ∉ [`angle_lower`, π].
    * @throws std::exception if `plant_context` is nullptr.
+   * @pydrake_mkdoc_identifier{double}
    */
   AngleBetweenVectorsConstraint(const MultibodyPlant<double>* plant,
                                 const Frame<double>& frameA,
@@ -56,8 +57,7 @@ class AngleBetweenVectorsConstraint : public solvers::Constraint {
   /**
    * Overloaded constructor. Use MultibodyPlant<AutoDiffXd> instead of
    * MultibodyPlant<double>.
-   * @exclude_from_pydrake_mkdoc{Suppressed due to ambiguity in mkdoc.
-   * Documentation string is manually recreated in Python.}
+   * @pydrake_mkdoc_identifier{autodiff}
    */
   AngleBetweenVectorsConstraint(const MultibodyPlant<AutoDiffXd>* plant,
                                 const Frame<AutoDiffXd>& frameA,

--- a/multibody/inverse_kinematics/com_in_polyhedron_constraint.h
+++ b/multibody/inverse_kinematics/com_in_polyhedron_constraint.h
@@ -38,6 +38,7 @@ class ComInPolyhedronConstraint : public solvers::Constraint {
    * @param plant_context The Context that has been allocated for this
    * `plant`. We will update the context when evaluating the constraint.
    * `plant_context` must be alive during the lifetime of this constraint.
+   * @pydrake_mkdoc_identifier{double}
    */
   ComInPolyhedronConstraint(
       const MultibodyPlant<double>* plant,
@@ -54,8 +55,7 @@ class ComInPolyhedronConstraint : public solvers::Constraint {
    * the constraint is computed from autodiff.
    * @pre if model_instances is not std::nullopt, then all indices in
    * `model_instances` refer to valid model instances in `plant`.
-   * @exclude_from_pydrake_mkdoc{Suppressed due to ambiguity in mkdoc.
-   * Documentation string is manually recreated in Python.}
+   * @pydrake_mkdoc_identifier{autodiff}
    */
   ComInPolyhedronConstraint(
       const MultibodyPlant<AutoDiffXd>* plant,

--- a/multibody/inverse_kinematics/com_position_constraint.h
+++ b/multibody/inverse_kinematics/com_position_constraint.h
@@ -34,7 +34,7 @@ class ComPositionConstraint final : public solvers::Constraint {
    *   `plant`. We will update the context when evaluating the constraint.
    *   `plant_context` should be alive during the lifetime of this constraint.
    * @throws std::exception if `plant` or `plant_context` is nullptr.
-   * @pydrake_mkdoc_identifier{ctor_double}
+   * @pydrake_mkdoc_identifier{double}
    */
   ComPositionConstraint(
       const MultibodyPlant<double>* const plant,
@@ -48,7 +48,7 @@ class ComPositionConstraint final : public solvers::Constraint {
    * It is preferrable to use the constructor with MBP<double> and
    * Context<double>. But if you only have MBP<AutoDiffXd> and
    * Context<AutoDiffXd>, then use this constructor.
-   * @pydrake_mkdoc_identifier{ctor_autodiff}
+   * @pydrake_mkdoc_identifier{autodiff}
    */
   ComPositionConstraint(
       const MultibodyPlant<AutoDiffXd>* const plant,

--- a/multibody/inverse_kinematics/distance_constraint.h
+++ b/multibody/inverse_kinematics/distance_constraint.h
@@ -30,6 +30,7 @@ class DistanceConstraint : public solvers::Constraint {
    * outlive this DistanceConstraint object.
    * @param distance_lower The lower bound on the distance.
    * @param distance_upper The upper bound on the distance.
+   * @pydrake_mkdoc_identifier{double}
    */
   DistanceConstraint(const multibody::MultibodyPlant<double>* const plant,
                      SortedPair<geometry::GeometryId> geometry_pair,
@@ -39,8 +40,7 @@ class DistanceConstraint : public solvers::Constraint {
   /**
    * Overloaded constructor. Constructs the constraint with
    * MultibodyPlant<AutoDiffXd>.
-   * @exclude_from_pydrake_mkdoc{Suppressed due to ambiguity in mkdoc.
-   * Documentation string is manually recreated in Python.}
+   * @pydrake_mkdoc_identifier{autodiff}
    */
   DistanceConstraint(const multibody::MultibodyPlant<AutoDiffXd>* const plant,
                      SortedPair<geometry::GeometryId> geometry_pair,

--- a/multibody/inverse_kinematics/gaze_target_constraint.h
+++ b/multibody/inverse_kinematics/gaze_target_constraint.h
@@ -49,6 +49,7 @@ class GazeTargetConstraint : public solvers::Constraint {
    * @throws std::exception if `n_A` is close to zero.
    * @throws std::exception if `cone_half_angle` ∉ [0, π/2].
    * @throws std::exception if `plant_context` is nullptr.
+   * @pydrake_mkdoc_identifier{double}
    */
   GazeTargetConstraint(const MultibodyPlant<double>* plant,
                        const Frame<double>& frameA,
@@ -63,8 +64,7 @@ class GazeTargetConstraint : public solvers::Constraint {
    * Overloaded constructor.
    * Construct from MultibodyPlant<AutoDiffXd> instead of
    * MultibodyPlant<double>.
-   * @exclude_from_pydrake_mkdoc{Suppressed due to ambiguity in mkdoc.
-   * Documentation string is manually recreated in Python.}
+   * @pydrake_mkdoc_identifier{autodiff}
    */
   GazeTargetConstraint(const MultibodyPlant<AutoDiffXd>* plant,
                        const Frame<AutoDiffXd>& frameA,

--- a/multibody/inverse_kinematics/minimum_distance_constraint.h
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.h
@@ -88,6 +88,7 @@ class MinimumDistanceConstraint final : public solvers::Constraint {
   a SceneGraph object.
   @throws std::exception if influence_distance_offset = ∞.
   @throws std::exception if influence_distance_offset ≤ 0.
+  @pydrake_mkdoc_identifier{double}
   */
   MinimumDistanceConstraint(
       const multibody::MultibodyPlant<double>* const plant,
@@ -98,8 +99,7 @@ class MinimumDistanceConstraint final : public solvers::Constraint {
   /**
   Overloaded constructor.
   Constructs the constraint using MultibodyPlant<AutoDiffXd>.
-  @exclude_from_pydrake_mkdoc{Suppressed due to ambiguity in mkdoc.
-  Documentation string is manually recreated in Python.}
+  @pydrake_mkdoc_identifier{autodiff}
   */
   MinimumDistanceConstraint(
       const multibody::MultibodyPlant<AutoDiffXd>* const plant,

--- a/multibody/inverse_kinematics/orientation_constraint.h
+++ b/multibody/inverse_kinematics/orientation_constraint.h
@@ -57,6 +57,7 @@ class OrientationConstraint : public solvers::Constraint {
    *   `plant`.
    * @throws std::exception if angle_bound < 0.
    * @throws std::exception if `plant_context` is nullptr.
+   * @pydrake_mkdoc_identifier{double}
    */
   OrientationConstraint(
       const MultibodyPlant<double>* const plant,
@@ -69,8 +70,7 @@ class OrientationConstraint : public solvers::Constraint {
   /**
    * Overloaded constructor.
    * Constructs the constraint using MultibodyPlant<AutoDiffXd>
-   * @exclude_from_pydrake_mkdoc{Suppressed due to ambiguity in mkdoc.
-   * Documentation string is manually recreated in Python.}
+   * @pydrake_mkdoc_identifier{autodiff}
    */
   OrientationConstraint(const MultibodyPlant<AutoDiffXd>* const plant,
                         const Frame<AutoDiffXd>& frameAbar,

--- a/multibody/inverse_kinematics/point_to_point_distance_constraint.h
+++ b/multibody/inverse_kinematics/point_to_point_distance_constraint.h
@@ -41,6 +41,7 @@ class PointToPointDistanceConstraint : public solvers::Constraint {
    * @param plant_context The Context that has been allocated for this
    *   `plant`. We will update the context when evaluating the constraint.
    *   `plant_context` should be alive during the lifetime of this constraint.
+   * @pydrake_mkdoc_identifier{double}
    */
   PointToPointDistanceConstraint(
       const MultibodyPlant<double>* plant, const Frame<double>& frame1,
@@ -53,8 +54,7 @@ class PointToPointDistanceConstraint : public solvers::Constraint {
    * Overloaded constructor. Same as the constructor with the double version
    * (using MultibodyPlant<double> and Context<double>), except the gradient of
    * the constraint is computed from autodiff.
-   * @exclude_from_pydrake_mkdoc{Suppressed due to ambiguity in mkdoc.
-   * Documentation string is manually recreated in Python.}
+   * @pydrake_mkdoc_identifier{autodiff}
    */
   PointToPointDistanceConstraint(
       const MultibodyPlant<AutoDiffXd>* plant, const Frame<AutoDiffXd>& frame1,

--- a/multibody/inverse_kinematics/position_constraint.h
+++ b/multibody/inverse_kinematics/position_constraint.h
@@ -39,6 +39,7 @@ class PositionConstraint : public solvers::Constraint {
    * @pre p_AQ_lower(i) <= p_AQ_upper(i) for i = 1, 2, 3.
    * @throws std::exception if `plant` is nullptr.
    * @throws std::exception if `plant_context` is nullptr.
+   * @pydrake_mkdoc_identifier{double}
    */
   PositionConstraint(const MultibodyPlant<double>* plant,
                      const Frame<double>& frameA,
@@ -52,8 +53,7 @@ class PositionConstraint : public solvers::Constraint {
    * Overloaded constructor. Same as the constructor with the double version
    * (using MultibodyPlant<double> and Context<double>). Except the gradient of
    * the constraint is computed from autodiff.
-   * @exclude_from_pydrake_mkdoc{Suppressed due to ambiguity in mkdoc.
-   * Documentation string is manually recreated in Python.}
+   * @pydrake_mkdoc_identifier{autodiff}
    */
   PositionConstraint(const MultibodyPlant<AutoDiffXd>* plant,
                      const Frame<AutoDiffXd>& frameA,
@@ -86,6 +86,7 @@ class PositionConstraint : public solvers::Constraint {
    * @pre p_AQ_lower(i) <= p_AQ_upper(i) for i = 1, 2, 3.
    * @throws std::exception if `plant` is nullptr.
    * @throws std::exception if `plant_context` is nullptr.
+   * @pydrake_mkdoc_identifier{double_Abar}
    */
   PositionConstraint(const MultibodyPlant<double>* plant,
                      const Frame<double>& frameAbar,
@@ -100,8 +101,7 @@ class PositionConstraint : public solvers::Constraint {
    * Overloaded constructor. Same as the constructor with the double version
    * (using MultibodyPlant<double> and Context<double>). Except the gradient of
    * the constraint is computed from autodiff.
-   * @exclude_from_pydrake_mkdoc{Suppressed due to ambiguity in mkdoc.
-   * Documentation string is manually recreated in Python.}
+   * @pydrake_mkdoc_identifier{autodiff_Abar}
    */
   PositionConstraint(const MultibodyPlant<AutoDiffXd>* plant,
                      const Frame<AutoDiffXd>& frameAbar,


### PR DESCRIPTION
The python bindings for many of the kinematic constraints used hard-coded doc strings in the bindings file due to a limitation in mkdoc.  That is no longer a limitation.  This updates the doc strings to use the standard workflow.

+@EricCousineau-TRI for both reviews, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17574)
<!-- Reviewable:end -->
