### PR TITLE
fix #17576 -- incorrect use of InitializeAutoDiff when gradients are not needed

### DIFF
--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
@@ -130,7 +130,7 @@ void AngleBetweenVectorsConstraint::DoEval(
     const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd* y) const {
   if (use_autodiff()) {
     AutoDiffVecXd y_t;
-    Eval(math::InitializeAutoDiff(x), &y_t);
+    Eval(x.cast<AutoDiffXd>(), &y_t);
     *y = math::ExtractValue(y_t);
   } else {
     DoEvalGeneric(*plant_double_, context_double_, frameA_index_, frameB_index_,

--- a/multibody/inverse_kinematics/gaze_target_constraint.cc
+++ b/multibody/inverse_kinematics/gaze_target_constraint.cc
@@ -132,7 +132,7 @@ void GazeTargetConstraint::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
                                   Eigen::VectorXd* y) const {
   if (use_autodiff()) {
     AutoDiffVecXd y_t;
-    Eval(math::InitializeAutoDiff(x), &y_t);
+    Eval(x.cast<AutoDiffXd>(), &y_t);
     *y = math::ExtractValue(y_t);
   } else {
     DoEvalGeneric(*plant_double_, context_double_, frameA_index_, frameB_index_,

--- a/multibody/inverse_kinematics/orientation_constraint.cc
+++ b/multibody/inverse_kinematics/orientation_constraint.cc
@@ -133,7 +133,7 @@ void OrientationConstraint::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
                                    Eigen::VectorXd* y) const {
   if (use_autodiff()) {
     AutoDiffVecXd y_t;
-    Eval(math::InitializeAutoDiff(x), &y_t);
+    Eval(x.cast<AutoDiffXd>(), &y_t);
     *y = math::ExtractValue(y_t);
   } else {
     DoEvalGeneric(*plant_double_, context_double_, frameAbar_index_,

--- a/multibody/inverse_kinematics/point_to_point_distance_constraint.cc
+++ b/multibody/inverse_kinematics/point_to_point_distance_constraint.cc
@@ -102,7 +102,7 @@ void PointToPointDistanceConstraint::DoEval(
     const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd* y) const {
   if (use_autodiff()) {
     AutoDiffVecXd y_t;
-    Eval(math::InitializeAutoDiff(x), &y_t);
+    Eval(x.cast<AutoDiffXd>(), &y_t);
     *y = math::ExtractValue(y_t);
   } else {
     DoEvalGeneric(*plant_double_, context_double_, frame1_index_, p_B1P1_,

--- a/multibody/inverse_kinematics/position_constraint.cc
+++ b/multibody/inverse_kinematics/position_constraint.cc
@@ -118,7 +118,7 @@ void PositionConstraint::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
                                 Eigen::VectorXd* y) const {
   if (use_autodiff()) {
     AutoDiffVecXd y_t;
-    Eval(math::InitializeAutoDiff(x), &y_t);
+    Eval(x.cast<AutoDiffXd>(), &y_t);
     *y = math::ExtractValue(y_t);
   } else {
     DoEvalGeneric(*plant_double_, context_double_, frameAbar_index_, X_AAbar_,

--- a/solvers/minimum_value_constraint.cc
+++ b/solvers/minimum_value_constraint.cc
@@ -154,10 +154,9 @@ void MinimumValueConstraint::set_penalty_function(
 template <>
 VectorX<double> MinimumValueConstraint::Values(
     const Eigen::Ref<const VectorX<double>>& x) const {
-  return value_function_double_
-             ? value_function_double_(x, influence_value_)
-             : math::ExtractValue(value_function_(math::InitializeAutoDiff(x),
-                                                  influence_value_));
+  return value_function_double_ ? value_function_double_(x, influence_value_)
+                                : math::ExtractValue(value_function_(
+                                      x.cast<AutoDiffXd>(), influence_value_));
 }
 
 template <>

--- a/systems/trajectory_optimization/direct_collocation.cc
+++ b/systems/trajectory_optimization/direct_collocation.cc
@@ -97,7 +97,7 @@ void DirectCollocationConstraint::dynamics(const AutoDiffVecXd& state,
 void DirectCollocationConstraint::DoEval(
     const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd* y) const {
   AutoDiffVecXd y_t;
-  Eval(math::InitializeAutoDiff(x), &y_t);
+  Eval(x.cast<AutoDiffXd>(), &y_t);
   *y = math::ExtractValue(y_t);
 }
 

--- a/systems/trajectory_optimization/direct_transcription.cc
+++ b/systems/trajectory_optimization/direct_transcription.cc
@@ -82,7 +82,7 @@ class DirectTranscriptionConstraint : public solvers::Constraint {
   void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
               Eigen::VectorXd* y) const override {
     AutoDiffVecXd y_t;
-    Eval(math::InitializeAutoDiff(x), &y_t);
+    Eval(x.cast<AutoDiffXd>(), &y_t);
     *y = math::ExtractValue(y_t);
   }
 


### PR DESCRIPTION
Resolves #17576.

+@hongkai-dai for feature review, please.
(I tried to read all instances of InitializeAutoDiff in non-test files; but a second set of eyes on this would be highly appreciated).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17577)
<!-- Reviewable:end -->
