### PR TITLE
[performance] Add gflags support to benchmarks

### DIFF
--- a/geometry/benchmarking/BUILD.bazel
+++ b/geometry/benchmarking/BUILD.bazel
@@ -6,6 +6,7 @@ load(
     "drake_cc_googlebench_binary",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
+load("//tools/skylark:test_tags.bzl", "vtk_test_tags")
 
 drake_cc_googlebench_binary(
     name = "mesh_intersection_benchmark",
@@ -22,26 +23,25 @@ drake_cc_googlebench_binary(
     ],
 )
 
-# TODO(jwnimmer-tri) Change this to a drake_cc_googlebench_binary (i.e., add
-# a unit test here) once we figure out how to mate googlebench with gflags.
-drake_cc_binary(
+drake_cc_googlebench_binary(
     name = "render_benchmark",
     srcs = ["render_benchmark.cc"],
-    add_test_rule = False,
-    defines = select({
-        "//tools/cc_toolchain:apple": [
-        ],
-        "//conditions:default": ["RENDER_ENGINE_GL_SUPPORTED"],
-    }),
+    add_test_rule = True,
+    test_args = [
+        # To save time, only run the low-resolution tests in CI.
+        "--benchmark_filter=.*/1/1/320/240",
+    ],
+    test_tags = vtk_test_tags(),
     deps = [
+        "//common:add_text_logging_gflags",
         "//common:filesystem",
         "//geometry/render",
         "//geometry/render_gl",
         "//geometry/render_vtk",
         "//systems/sensors:image_writer",
+        "//tools/performance:gflags_main",
         "@fmt",
         "@gflags",
-        "@googlebenchmark//:benchmark",
     ],
 )
 

--- a/geometry/benchmarking/mesh_intersection_benchmark.cc
+++ b/geometry/benchmarking/mesh_intersection_benchmark.cc
@@ -275,6 +275,9 @@ void ReportContactSurfaces() {
 }  // namespace geometry
 }  // namespace drake
 
+// TODO(jwnimmer-tri) Port this to use //tools/performance:gflags_main instead
+// or writing one by hand.  Add the ReportContactSurfaces to the benchmark
+// output data using the googlebenchmark API instead of bespoke code.
 int main(int argc, char** argv) {
   benchmark::Initialize(&argc, argv);
   benchmark::RunSpecifiedBenchmarks();

--- a/geometry/benchmarking/render_benchmark.cc
+++ b/geometry/benchmarking/render_benchmark.cc
@@ -28,13 +28,21 @@ class RenderEngineTester {
   }
 };
 
-namespace render_benchmark {
-namespace internal {
+}  // namespace render
+
 namespace {
 
 using Eigen::Vector3d;
 using math::RigidTransformd;
 using math::RotationMatrixd;
+using render::ColorRenderCamera;
+using render::DepthRange;
+using render::DepthRenderCamera;
+using render::RenderCameraCore;
+using render::RenderEngine;
+using render::RenderEngineGlParams;
+using render::RenderEngineTester;
+using render::RenderLabel;
 using systems::sensors::ImageDepth32F;
 using systems::sensors::ImageLabel16I;
 using systems::sensors::ImageRgba8U;
@@ -57,12 +65,18 @@ const double kFovY = M_PI_4;
  renderers are supported by all operating systems.  */
 enum class EngineType { Vtk, Gl };
 
-/* Creates a render engine of the given type with the given background color.
- For each supported render engine type, this must be specialized. (See below.
- */
+/* Creates a render engine of the given type with the given background color. */
 template <EngineType engine_type>
 std::unique_ptr<RenderEngine> MakeEngine(const Vector3d& bg_rgb) {
-  throw std::runtime_error("Not implemented!");
+  if constexpr (engine_type == EngineType::Vtk) {
+    RenderEngineVtkParams params{{}, {}, bg_rgb};
+    return MakeRenderEngineVtk(params);
+  }
+  if constexpr (engine_type == EngineType::Gl) {
+    RenderEngineGlParams params;
+    params.default_clear_color.set(bg_rgb[0], bg_rgb[1], bg_rgb[2], 1.0);
+    return MakeRenderEngineGl(params);
+  }
 }
 
 class RenderBenchmark : public benchmark::Fixture {
@@ -105,7 +119,6 @@ class RenderBenchmark : public benchmark::Fixture {
     if (!FLAGS_save_image_path.empty()) {
       const std::string path_name = image_path_name(name, state, "png");
       SaveToPng(color_image, path_name);
-      saved_image_paths.insert(path_name);
     }
   }
 
@@ -135,7 +148,6 @@ class RenderBenchmark : public benchmark::Fixture {
     if (!FLAGS_save_image_path.empty()) {
       const std::string path_name = image_path_name(name, state, "tiff");
       SaveToTiff(depth_image, path_name);
-      saved_image_paths.insert(path_name);
     }
   }
 
@@ -169,7 +181,6 @@ class RenderBenchmark : public benchmark::Fixture {
     if (!FLAGS_save_image_path.empty()) {
       const std::string path_name = image_path_name(name, state, "png");
       SaveToPng(label_image, path_name);
-      saved_image_paths.insert(path_name);
     }
   }
 
@@ -310,18 +321,12 @@ class RenderBenchmark : public benchmark::Fixture {
                                                 engine);
   }
 
-  // Keep track of the paths to the saved images. We use a static set because
-  // Google Benchmark runs these benchmarks multiple times with unique instances
-  // of the fixture, and we want to avoid duplicate path names.
-  static std::set<std::string> saved_image_paths;
-
   std::vector<DepthRenderCamera> depth_cameras_;
   PerceptionProperties material_;
   const Vector3d bg_rgb_{200 / 255., 0, 250 / 255.};
   const Rgba sphere_rgba_{0, 0.8, 0.5, 1};
   std::unordered_map<GeometryId, RigidTransformd> poses_;
 };
-std::set<std::string> RenderBenchmark::saved_image_paths;
 
 /* These macros serve the purpose of allowing compact and *consistent*
  declarations of benchmarks. The goal is to create a benchmark for each
@@ -335,9 +340,8 @@ std::set<std::string> RenderBenchmark::saved_image_paths;
 
    MAKE_BENCHMARK(Foo, ImageType)
 
- such that there must be a `RenderEngineFoo` type (e.g., RenderEngineVtk) and
- ImageType must be one of (Color, Depth, or Label). Capitalization matters.
- There must also be a specialization of MakeEngine<EngineType::Foo> (see below).
+ such that there must be a `EngineType::Foo` enum and mageType must be one of
+ (Color, Depth, or Label). Capitalization matters.
 
  N.B. The macro STR converts a single macro parameter into a string and we use
  it to make a string out of the concatenation of two macro parameters (i.e., we
@@ -368,51 +372,16 @@ BENCHMARK_REGISTER_F(RenderBenchmark, Renderer##ImageT) \
     ->Args({1200, 1, 1280, 960}) \
     ->Args({1200, 1, 2560, 1920})
 
-
-template <>
-std::unique_ptr<RenderEngine> MakeEngine<EngineType::Vtk>(
-    const Vector3d& bg_rgb) {
-  geometry::RenderEngineVtkParams params{{}, {}, bg_rgb};
-  return geometry::MakeRenderEngineVtk(params);
-}
-
 MAKE_BENCHMARK(Vtk, Color);
 MAKE_BENCHMARK(Vtk, Depth);
 MAKE_BENCHMARK(Vtk, Label);
 
-#ifdef RENDER_ENGINE_GL_SUPPORTED
-template <>
-std::unique_ptr<RenderEngine> MakeEngine<EngineType::Gl>(
-    const Vector3d& bg_rgb) {
-  RenderEngineGlParams params;
-  params.default_clear_color.set(bg_rgb[0], bg_rgb[1], bg_rgb[2], 1.0);
-  return MakeRenderEngineGl(params);
-}
-
+#ifndef __APPLE__
 MAKE_BENCHMARK(Gl, Color);
 MAKE_BENCHMARK(Gl, Depth);
 MAKE_BENCHMARK(Gl, Label);
 #endif
 
-void Cleanup() {
-  if (!RenderBenchmark::saved_image_paths.empty()) {
-    std::cout << "Saved rendered images to:" << std::endl;
-    for (const auto& path : RenderBenchmark::saved_image_paths) {
-      std::cout << fmt::format(" - {}", path) << std::endl;
-    }
-  }
-}
-
 }  // namespace
-}  // namespace internal
-}  // namespace render_benchmark
-}  // namespace render
 }  // namespace geometry
 }  // namespace drake
-
-int main(int argc, char** argv) {
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
-  benchmark::Initialize(&argc, argv);
-  benchmark::RunSpecifiedBenchmarks();
-  drake::geometry::render::render_benchmark::internal::Cleanup();
-}

--- a/multibody/benchmarking/BUILD.bazel
+++ b/multibody/benchmarking/BUILD.bazel
@@ -36,11 +36,13 @@ drake_cc_googlebench_binary(
     add_test_rule = True,
     data = ["cassie_v2.urdf"],
     deps = [
+        "//common:add_text_logging_gflags",
         "//common:essential",
         "//common:find_resource",
         "//math:gradient",
         "//multibody/parsing:parser",
         "//tools/performance:fixture_common",
+        "//tools/performance:gflags_main",
     ],
 )
 
@@ -57,11 +59,13 @@ drake_cc_googlebench_binary(
         "//manipulation/models/iiwa_description:models",
     ],
     deps = [
+        "//common:add_text_logging_gflags",
         "//common:find_resource",
         "//multibody/inverse_kinematics",
         "//multibody/parsing",
         "//solvers:solve",
         "//tools/performance:fixture_common",
+        "//tools/performance:gflags_main",
     ],
 )
 

--- a/multibody/benchmarking/cassie.cc
+++ b/multibody/benchmarking/cassie.cc
@@ -364,5 +364,3 @@ BENCHMARK_REGISTER_F(CassieExpression, ForwardDynamics)
 }  // namespace
 }  // namespace multibody
 }  // namespace drake
-
-BENCHMARK_MAIN();

--- a/multibody/benchmarking/iiwa_relaxed_pos_ik.cc
+++ b/multibody/benchmarking/iiwa_relaxed_pos_ik.cc
@@ -116,5 +116,3 @@ BENCHMARK_F(RelaxedPosIkBenchmark, Iiwa)(benchmark::State& state) {  // NOLINT
 }  // namespace inverse_kinematics
 }  // namespace multibody
 }  // namespace drake
-
-BENCHMARK_MAIN();

--- a/solvers/benchmarking/BUILD.bazel
+++ b/solvers/benchmarking/BUILD.bazel
@@ -13,8 +13,10 @@ drake_cc_googlebench_binary(
     add_test_rule = True,
     test_timeout = "moderate",
     deps = [
+        "//common:add_text_logging_gflags",
         "//solvers:mathematical_program",
         "//tools/performance:fixture_common",
+        "//tools/performance:gflags_main",
     ],
 )
 

--- a/solvers/benchmarking/benchmark_mathematical_program.cc
+++ b/solvers/benchmarking/benchmark_mathematical_program.cc
@@ -119,5 +119,3 @@ BENCHMARK(BenchmarkSosProgram3);
 }  // namespace
 }  // namespace solvers
 }  // namespace drake
-
-BENCHMARK_MAIN();

--- a/systems/benchmarking/BUILD.bazel
+++ b/systems/benchmarking/BUILD.bazel
@@ -18,9 +18,11 @@ drake_cc_googlebench_binary(
     srcs = ["framework_benchmarks.cc"],
     add_test_rule = True,
     deps = [
+        "//common:add_text_logging_gflags",
         "//systems/framework:diagram_builder",
         "//systems/primitives:pass_through",
         "//tools/performance:fixture_common",
+        "//tools/performance:gflags_main",
     ],
 )
 
@@ -34,6 +36,7 @@ drake_cc_binary(
     srcs = ["multilayer_perceptron_performance.cc"],
     add_test_rule = True,
     deps = [
+        "//common:add_text_logging_gflags",
         "//systems/primitives:multilayer_perceptron",
         "@gflags",
     ],

--- a/systems/benchmarking/framework_benchmarks.cc
+++ b/systems/benchmarking/framework_benchmarks.cc
@@ -66,4 +66,3 @@ BENCHMARK_F(BasicFixture, PassThrough3)(benchmark::State& state) {
 }  // namespace systems
 }  // namespace drake
 
-BENCHMARK_MAIN();

--- a/systems/benchmarking/multilayer_perceptron_performance.cc
+++ b/systems/benchmarking/multilayer_perceptron_performance.cc
@@ -17,6 +17,7 @@ using Eigen::MatrixXd;
 using Eigen::RowVectorXd;
 using Eigen::VectorXd;
 
+// TODO(jwnimmer-tri) Rewrite these to use googlebench Args().
 DEFINE_int32(batch_size, 2, "Number of batch evaluations.");
 DEFINE_int32(width, 256, "Number of units in each hidden layer.");
 DEFINE_int32(iterations, 2, "Number of times to call the method.");

--- a/tools/performance/BUILD.bazel
+++ b/tools/performance/BUILD.bazel
@@ -27,6 +27,15 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "gflags_main",
+    srcs = ["gflags_main.cc"],
+    deps = [
+        "@gflags",
+        "@googlebenchmark//:benchmark",
+    ],
+)
+
 drake_py_binary(
     name = "benchmark_tool",
     testonly = True,

--- a/tools/performance/README.md
+++ b/tools/performance/README.md
@@ -4,15 +4,13 @@ This directory contains tools to help with careful performance measurement and
 analysis of Drake programs.
 
 Fully worked examples that integrate this tooling are available at:
-- drake/geometry/benchmarking   (still TODO; see below)
+- drake/geometry/benchmarking
 - drake/multibody/benchmarking
 - drake/solvers/benchmarking
 - drake/systems/benchmarking
 
 Some of the history of attempts to drive variance out of benchmark results is
 captured in #13902.
-
-TODO(jwnimmer-tri): Port //geometry/benchmarking to use this tooling as well.
 
 TODO(rpoyner-tri): explain how to use compare.py from the googlebenchmark
 package to compare stored results from different experiments.

--- a/tools/performance/defs.bzl
+++ b/tools/performance/defs.bzl
@@ -14,7 +14,9 @@ def drake_cc_googlebench_binary(
         data = None,
         add_test_rule,
         test_size = "small",
-        test_timeout = None):
+        test_timeout = None,
+        test_args = None,
+        test_tags = None):
     """Declares a testonly binary that uses google benchmark.  Automatically
     adds appropriate deps and ensures it either has an automated smoke test
     (via 'add_test_rule = True'), or else explicitly opts-out ('= False').
@@ -54,7 +56,8 @@ def drake_cc_googlebench_binary(
                 # save time. (Once should be sufficient to prove the lack of
                 # runtime errors.)
                 "--benchmark_min_time=0",
-            ],
+            ] + (test_args or []),
+            tags = test_tags,
         )
 
 def drake_py_experiment_binary(name, *, googlebench_binary, **kwargs):

--- a/tools/performance/gflags_main.cc
+++ b/tools/performance/gflags_main.cc
@@ -1,0 +1,24 @@
+#include <iostream>
+#include <string_view>
+
+#include <benchmark/benchmark.h>
+#include <gflags/gflags.h>
+
+int main(int argc, char** argv) {
+  gflags::SetUsageMessage("see drake/tools/performance/README.md");
+  for (int i = 1; i < argc; ++i) {
+    if (std::string_view(argv[i]) == "--help") {
+      gflags::ShowUsageWithFlags(argv[0]);
+      std::cout << "\n\n";
+      std::cout << "Flags from @googlebenchmark:\n";
+      benchmark::Initialize(&argc, argv);
+      return 0;
+    }
+  }
+  benchmark::Initialize(&argc, argv);
+  gflags::ParseCommandLineNonHelpFlags(&argc, &argv, true);
+  if (::benchmark::ReportUnrecognizedArguments(argc, argv)) return 1;
+  benchmark::RunSpecifiedBenchmarks();
+  benchmark::Shutdown();
+  return 0;
+}


### PR DESCRIPTION
Drop the feature of render_benchmark where it prints filenames to the console (via a mutable global variable). Instead, users should begin from an empty output directory, so that whatever ends up there was what was written.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17581)
<!-- Reviewable:end -->
