### PR TITLE
Try to avoid mypy timing out

### DIFF
--- a/bindings/pydrake/stubgen.py
+++ b/bindings/pydrake/stubgen.py
@@ -4,5 +4,10 @@ import sys
 
 from mypy import stubgen
 
+# Mypy can time out if importing takes an inordinate length of time. Try to
+# avoid this by importing ourselves up front when the import isn't being run
+# under a timeout.
+import pydrake.all
+
 if __name__ == "__main__":
     sys.exit(stubgen.main())

--- a/bindings/pydrake/test/stubgen_test.py
+++ b/bindings/pydrake/test/stubgen_test.py
@@ -5,6 +5,11 @@ import unittest
 
 from mypy import stubgen
 
+# Mypy can time out if importing takes an inordinate length of time. Try to
+# avoid this by importing ourselves up front when the import isn't being run
+# under a timeout.
+import pydrake.all
+
 
 class TestStubgen(unittest.TestCase):
     # TODO(mwoehlke-kitware): test the already-generated files instead.


### PR DESCRIPTION
Mypy has a timeout in its `ModuleInspect` that will trip if importing a module takes an inordinate (>30s) amount of time. This is usually not an issue, but it seems (possibly due to AWS storage quirks) that we're hitting this sometimes, more or less at random.

In order to hopefully mitigate this issue, import ourselves (i.e. `pydrake.all`) up front, so that everything is hopefully "hot" when mypy goes to do its importing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17584)
<!-- Reviewable:end -->
