### PR TITLE
[inverse_kinematics] Add PositionCost

### DIFF
--- a/bindings/pydrake/multibody/test/inverse_kinematics_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_test.py
@@ -151,6 +151,17 @@ class TestInverseKinematics(unittest.TestCase):
         self.assertIs(self.ik_two_bodies.get_mutable_context(),
                       self.ik_two_bodies.context())
 
+    def test_AddPositionCost(self):
+        p_BQ = np.array([0.2, 0.3, 0.5])
+        p_AP = np.array([-0.1, -0.2, -0.3])
+
+        binding = self.ik_two_bodies.AddPositionCost(frameA=self.body1_frame,
+                                                     p_AP=p_AP,
+                                                     frameB=self.body2_frame,
+                                                     p_BQ=p_BQ,
+                                                     C=np.eye(3))
+        self.assertIsInstance(binding, mp.Binding[mp.Cost])
+
     def test_AddOrientationConstraint(self):
         theta_bound = 0.2 * math.pi
         R_AbarA = RotationMatrix(quaternion=Quaternion(0.5, -0.5, 0.5, 0.5))
@@ -513,6 +524,17 @@ class TestConstraints(unittest.TestCase):
         constraint.UpdateLowerBound(new_lb=np.array([-2, -3, -0.5]))
         constraint.UpdateUpperBound(new_ub=np.array([10., 0.5, 2.]))
         constraint.set_bounds(new_lb=[-1, -2, -2.], new_ub=[1., 2., 3.])
+
+    @check_type_variables
+    def test_position_cost(self, variables):
+        cost = ik.PositionCost(plant=variables.plant,
+                               frameA=variables.body1_frame,
+                               p_AP=[-0.1, -0.2, -0.3],
+                               frameB=variables.body2_frame,
+                               p_BQ=[0.2, 0.3, 0.5],
+                               C=np.eye(3),
+                               plant_context=variables.plant_context)
+        self.assertIsInstance(cost, mp.Cost)
 
     @check_type_variables
     def test_com_position_constraint(self, variables):

--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -48,6 +48,7 @@ drake_cc_library(
         "orientation_constraint.cc",
         "point_to_point_distance_constraint.cc",
         "position_constraint.cc",
+        "position_cost.cc",
         "unit_quaternion_constraint.cc",
     ],
     hdrs = [
@@ -62,6 +63,7 @@ drake_cc_library(
         "orientation_constraint.h",
         "point_to_point_distance_constraint.h",
         "position_constraint.h",
+        "position_cost.h",
         "unit_quaternion_constraint.h",
     ],
     deps = [
@@ -134,6 +136,14 @@ drake_cc_library(
 
 drake_cc_googletest(
     name = "position_constraint_test",
+    deps = [
+        ":inverse_kinematics_test_utilities",
+        ":kinematic_evaluators",
+    ],
+)
+
+drake_cc_googletest(
+    name = "position_cost_test",
     deps = [
         ":inverse_kinematics_test_utilities",
         ":kinematic_evaluators",

--- a/multibody/inverse_kinematics/global_inverse_kinematics.h
+++ b/multibody/inverse_kinematics/global_inverse_kinematics.h
@@ -221,13 +221,13 @@ class GlobalInverseKinematics {
       double angle_tol);
 
   /** Penalizes the deviation to the desired posture.
+   *
    * For each body (except the world) in the kinematic tree, we add the cost
    *
    *     ∑ᵢ body_position_cost(i) * body_position_error(i) +
    *     body_orientation_cost(i) * body_orientation_error(i)
    * where `body_position_error(i)` is computed as the Euclidean distance error
-   * |p_WBo(i) - p_WBo_desired(i)|
-   * where
+   * |p_WBo(i) - p_WBo_desired(i)| where
    * - p_WBo(i)        : position of body i'th origin `Bo` in the world frame
    *                     `W`.
    * - p_WBo_desired(i): position of body i'th origin `Bo` in the world frame
@@ -236,22 +236,21 @@ class GlobalInverseKinematics {
    * body_orientation_error(i) is computed as (1 - cos(θ)), where θ is the
    * angle between the orientation of body i'th frame and body i'th frame using
    * the desired posture. Notice that 1 - cos(θ) = θ²/2 + O(θ⁴), so this cost
-   * is on the square of θ, when θ is small.
-   * Notice that since body 0 is the world, the cost on that body is always 0,
-   * no matter what value `body_position_cost(0)` and `body_orientation_cost(0)`
-   * take.
+   * is on the square of θ, when θ is small. Notice that since body 0 is the
+   * world, the cost on that body is always 0, no matter what value
+   * `body_position_cost(0)` and `body_orientation_cost(0)` take.
    * @param q_desired  The desired posture.
-   * @param body_position_cost  The cost for each body's position error. Unit is
-   * [1/m] (one over meters).
+   * @param body_position_cost  The cost for each body's position error. Unit
+   * is [1/m] (one over meters).
    * @pre
-   * 1. body_position_cost.rows() == plant.num_bodies(), where `plant`
-   *    is the input argument in the constructor of the class.
+   * 1. body_position_cost.rows() == plant.num_bodies(), where `plant` is the
+   *    input argument in the constructor of the class.
    * 2. body_position_cost(i) is non-negative.
    * @throws std::exception if the precondition is not satisfied.
    * @param body_orientation_cost The cost for each body's orientation error.
    * @pre
-   * 1. body_orientation_cost.rows() == plant.num_bodies() , where
-   *    `plant` is the input argument in the constructor of the class.
+   * 1. body_orientation_cost.rows() == plant.num_bodies() , where `plant` is
+   *    the input argument in the constructor of the class.
    * 2. body_position_cost(i) is non-negative.
    * @throws std::exception if the precondition is not satisfied.
    */

--- a/multibody/inverse_kinematics/inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/inverse_kinematics.cc
@@ -9,6 +9,7 @@
 #include "drake/multibody/inverse_kinematics/orientation_constraint.h"
 #include "drake/multibody/inverse_kinematics/point_to_point_distance_constraint.h"
 #include "drake/multibody/inverse_kinematics/position_constraint.h"
+#include "drake/multibody/inverse_kinematics/position_cost.h"
 #include "drake/multibody/inverse_kinematics/unit_quaternion_constraint.h"
 
 namespace drake {
@@ -65,6 +66,15 @@ solvers::Binding<solvers::Constraint> InverseKinematics::AddPositionConstraint(
       &plant_, frameAbar, X_AbarA, p_AQ_lower, p_AQ_upper, frameB, p_BQ,
       get_mutable_context());
   return prog_->AddConstraint(constraint, q_);
+}
+
+solvers::Binding<solvers::Cost> InverseKinematics::AddPositionCost(
+    const Frame<double>& frameA, const Eigen::Ref<const Eigen::Vector3d>& p_AP,
+    const Frame<double>& frameB, const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
+    const Eigen::Ref<const Eigen::Matrix3d>& C) {
+  auto cost = std::make_shared<PositionCost>(&plant_, frameA, p_AP, frameB,
+                                             p_BQ, C, get_mutable_context());
+  return prog_->AddCost(cost, q_);
 }
 
 solvers::Binding<solvers::Constraint>

--- a/multibody/inverse_kinematics/inverse_kinematics.h
+++ b/multibody/inverse_kinematics/inverse_kinematics.h
@@ -10,8 +10,6 @@
 
 namespace drake {
 namespace multibody {
-// TODO(hongkai.dai) The bounds on the generalized positions (i.e., joint
-// limits) should be imposed automatically.
 /**
  * Solves an inverse kinematics (IK) problem on a MultibodyPlant, to find the
  * postures of the robot satisfying certain constraints.
@@ -110,7 +108,7 @@ class InverseKinematics {
    * measured and expressed in frame B.
    * @param frameAbar We will compute frame A from frame Abar. The bounding box
    * p_AQ_lower <= p_AQ <= p_AQ_upper is expressed in frame A.
-   * @param X_AbarAThe relative transform between frame Abar and A. If empty,
+   * @param X_AbarA The relative transform between frame Abar and A. If empty,
    * then we use the identity transform.
    * @param p_AQ_lower The lower bound on the position of point Q, measured and
    * expressed in frame A.
@@ -124,6 +122,22 @@ class InverseKinematics {
       const std::optional<math::RigidTransformd>& X_AbarA,
       const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
       const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper);
+
+  /** Adds a cost of the form (p_AP - p_AQ)ᵀ C (p_AP - p_AQ), where point P is
+   * specified relative to frame A and point Q is specified relative to frame
+   * B, and the cost is evaluated in frame A.
+   * @param frameA The frame in which point P's position is measured.
+   * @param p_AP The point P.
+   * @param frameB The frame in which point Q's position is measured.
+   * @param p_BQ The point Q.
+   * @param C A 3x3 matrix representing the cost in quadratic form.
+   */
+  solvers::Binding<solvers::Cost> AddPositionCost(
+      const Frame<double>& frameA,
+      const Eigen::Ref<const Eigen::Vector3d>& p_AP,
+      const Frame<double>& frameB,
+      const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
+      const Eigen::Ref<const Eigen::Matrix3d>& C);
 
   /**
    * Constrains that the angle difference θ between the orientation of frame A

--- a/multibody/inverse_kinematics/position_cost.cc
+++ b/multibody/inverse_kinematics/position_cost.cc
@@ -1,0 +1,121 @@
+#include "drake/multibody/inverse_kinematics/position_cost.h"
+
+#include "drake/math/autodiff_gradient.h"
+#include "drake/multibody/inverse_kinematics/kinematic_evaluator_utilities.h"
+
+using drake::multibody::internal::RefFromPtrOrThrow;
+using drake::multibody::internal::UpdateContextConfiguration;
+
+namespace drake {
+namespace multibody {
+
+PositionCost::PositionCost(const MultibodyPlant<double>* const plant,
+                           const Frame<double>& frameA,
+                           const Eigen::Ref<const Eigen::Vector3d>& p_AP,
+                           const Frame<double>& frameB,
+                           const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
+                           const Eigen::Ref<const Eigen::Matrix3d>& C,
+                           systems::Context<double>* plant_context)
+    : solvers::Cost(RefFromPtrOrThrow(plant).num_positions()),
+      plant_double_(plant),
+      frameA_index_(frameA.index()),
+      p_AP_{p_AP},
+      frameB_index_(frameB.index()),
+      p_BQ_{p_BQ},
+      C_{C},
+      context_double_{plant_context},
+      plant_autodiff_(nullptr),
+      context_autodiff_(nullptr) {
+  if (plant_context == nullptr)
+    throw std::invalid_argument(
+        "PositionCost(): plant_context is nullptr.");
+}
+
+PositionCost::PositionCost(
+    const MultibodyPlant<AutoDiffXd>* const plant,
+    const Frame<AutoDiffXd>& frameA,
+    const Eigen::Ref<const Eigen::Vector3d>& p_AP,
+    const Frame<AutoDiffXd>& frameB,
+    const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
+    const Eigen::Ref<const Eigen::Matrix3d>& C,
+    systems::Context<AutoDiffXd>* plant_context)
+    : solvers::Cost(RefFromPtrOrThrow(plant).num_positions()),
+      plant_double_(nullptr),
+      frameA_index_(frameA.index()),
+      p_AP_{p_AP},
+      frameB_index_(frameB.index()),
+      p_BQ_{p_BQ},
+      C_{C},
+      context_double_{nullptr},
+      plant_autodiff_(plant),
+      context_autodiff_(plant_context) {
+  if (plant_context == nullptr)
+    throw std::invalid_argument("plant_context is nullptr.");
+}
+
+PositionCost::~PositionCost() = default;
+
+namespace {
+
+template <typename T, typename S>
+void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
+                   const FrameIndex frameA_index, const Eigen::Vector3d& p_AP,
+                   const FrameIndex frameB_index, const Eigen::Vector3d& p_BQ,
+                   const Eigen::Matrix3d& C,
+                   const Eigen::Ref<const VectorX<S>>& x, VectorX<S>* y) {
+  y->resize(1);
+  UpdateContextConfiguration(context, plant, x);
+  const Frame<T>& frameA = plant.get_frame(frameA_index);
+  const Frame<T>& frameB = plant.get_frame(frameB_index);
+  Vector3<T> p_AQ;
+  plant.CalcPointsPositions(*context, frameB, p_BQ.cast<T>(), frameA,
+                            &p_AQ);
+  const Vector3<T> err = p_AQ - p_AP;
+  if constexpr (std::is_same_v<T, S>) {
+    *y = err.transpose() * C * err;
+  } else {
+    static_assert(std::is_same_v<T, double>);
+    static_assert(std::is_same_v<S, AutoDiffXd>);
+    Eigen::Matrix3Xd Jq_v_ABq(3, plant.num_positions());
+    plant.CalcJacobianTranslationalVelocity(*context,
+                                            JacobianWrtVariable::kQDot, frameB,
+                                            p_BQ, frameA, frameA, &Jq_v_ABq);
+    const Vector3<S> err_ad =
+        math::InitializeAutoDiff(err, Jq_v_ABq * math::ExtractGradient(x));
+    *y = err_ad.transpose() * C * err_ad;
+  }
+}
+
+}  // namespace
+
+void PositionCost::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+                                Eigen::VectorXd* y) const {
+  if (use_autodiff()) {
+    AutoDiffVecXd y_t;
+    Eval(x.cast<AutoDiffXd>(), &y_t);
+    *y = math::ExtractValue(y_t);
+  } else {
+    DoEvalGeneric(*plant_double_, context_double_, frameA_index_, p_AP_,
+                  frameB_index_, p_BQ_, C_, x, y);
+  }
+}
+
+void PositionCost::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+                                AutoDiffVecXd* y) const {
+  if (!use_autodiff()) {
+    DoEvalGeneric(*plant_double_, context_double_, frameA_index_, p_AP_,
+                  frameB_index_, p_BQ_, C_, x, y);
+  } else {
+    DoEvalGeneric(*plant_autodiff_, context_autodiff_, frameA_index_, p_AP_,
+                  frameB_index_, p_BQ_, C_, x, y);
+  }
+}
+
+void PositionCost::DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>&,
+                          VectorX<symbolic::Expression>*) const {
+  throw std::logic_error(
+      "PositionCost::DoEval() does not work for symbolic variables.");
+}
+
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/inverse_kinematics/position_cost.h
+++ b/multibody/inverse_kinematics/position_cost.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/solvers/cost.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+namespace multibody {
+/**
+ * Implements a cost of the form (p_AP - p_AQ)ᵀ C (p_AP - p_AQ), where point P
+ * is specified relative to frame A and point Q is specified relative to frame
+ * B, and the cost is evaluated in frame A.
+ *
+ * @ingroup solver_evaluators
+ */
+class PositionCost : public solvers::Cost {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PositionCost)
+
+  /**
+   * Constructs PositionCost object.
+   * @param plant The MultibodyPlant on which the cost is implemented. `plant`
+   *   should be alive during the lifetime of this cost.
+   * @param frameA The frame in which point P's position is measured.
+   * @param p_AP The point P.
+   * @param frameB The frame in which point Q's position is measured.
+   * @param p_BQ The point Q.
+   * @param C A 3x3 matrix representing the cost in quadratic form.
+   * @param plant_context A context for the `plant`.
+   *
+   * @throws std::exception if `plant` is nullptr.
+   * @throws std::exception if `plant_context` is nullptr.
+   * @pydrake_mkdoc_identifier{double}
+   */
+  PositionCost(const MultibodyPlant<double>* plant, const Frame<double>& frameA,
+               const Eigen::Ref<const Eigen::Vector3d>& p_AP,
+               const Frame<double>& frameB,
+               const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
+               const Eigen::Ref<const Eigen::Matrix3d>& C,
+               systems::Context<double>* plant_context);
+
+  /**
+   * Overloaded constructor. Same as the constructor with the double version
+   * (using MultibodyPlant<double> and Context<double>). Except the gradient of
+   * the cost is computed from autodiff.
+   * @pydrake_mkdoc_identifier{autodiff}
+   */
+  PositionCost(const MultibodyPlant<AutoDiffXd>* plant,
+               const Frame<AutoDiffXd>& frameA,
+               const Eigen::Ref<const Eigen::Vector3d>& p_AP,
+               const Frame<AutoDiffXd>& frameB,
+               const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
+               const Eigen::Ref<const Eigen::Matrix3d>& C,
+               systems::Context<AutoDiffXd>* plant_context);
+
+  ~PositionCost() override;
+
+ private:
+  void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+              Eigen::VectorXd* y) const override;
+
+  void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+              AutoDiffVecXd* y) const override;
+
+  void DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>&,
+              VectorX<symbolic::Expression>*) const override;
+
+  bool use_autodiff() const { return plant_autodiff_; }
+
+  const MultibodyPlant<double>* const plant_double_;
+  const FrameIndex frameA_index_;
+  const Eigen::Vector3d p_AP_;
+  const FrameIndex frameB_index_;
+  const Eigen::Vector3d p_BQ_;
+  const Eigen::Matrix3d C_;
+  systems::Context<double>* const context_double_;
+
+  const MultibodyPlant<AutoDiffXd>* const plant_autodiff_;
+  systems::Context<AutoDiffXd>* const context_autodiff_;
+};
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/inverse_kinematics/test/position_cost_test.cc
+++ b/multibody/inverse_kinematics/test/position_cost_test.cc
@@ -1,0 +1,117 @@
+#include "drake/multibody/inverse_kinematics/position_cost.h"
+
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "drake/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+using Eigen::Matrix3d;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+
+using math::InitializeAutoDiff;
+using math::RigidTransform;
+using math::RollPitchYaw;
+using systems::Context;
+
+template <typename T>
+auto ConstructTwoFreeBodiesCost(
+    const Eigen::Ref<const Vector3d>& p_AP,
+    const Eigen::Ref<const Vector3d>& p_BQ,
+    const Eigen::Ref<const Matrix3d>& C) {
+  struct ReturnValues {
+    std::unique_ptr<MultibodyPlant<T>> plant;
+    std::unique_ptr<Context<T>> context;
+    const Body<T>* body1{};
+    const Body<T>* body2{};
+    std::unique_ptr<PositionCost> cost;
+  };
+  ReturnValues v;
+
+  v.plant = ConstructTwoFreeBodiesPlant<T>();
+  v.context = v.plant->CreateDefaultContext();
+
+  v.body1 = &v.plant->GetBodyByName("body1");
+  v.body2 = &v.plant->GetBodyByName("body2");
+
+  v.cost = std::make_unique<PositionCost>(v.plant.get(), v.body1->body_frame(),
+                                          p_AP, v.body2->body_frame(), p_BQ, C,
+                                          v.context.get());
+
+  return v;
+}
+
+// Given two free bodies with some given poses, evaluate the position cost.
+GTEST_TEST(PositionCostTest, TwoFreeBodies) {
+  const Vector3d p_AP(1, 2, 3);
+  const Vector3d p_BQ(4, 5, 6);
+  Matrix3d C;
+  C << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+
+  auto [plant, context, body1, body2, cost] =
+      ConstructTwoFreeBodiesCost<double>(p_AP, p_BQ, C);
+  auto [plant_ad, context_ad, body1_ad, body2_ad, cost_ad] =
+      ConstructTwoFreeBodiesCost<AutoDiffXd>(p_AP, p_BQ, C);
+
+  // Note: We are passing PositionCost here instead of capturing them due to a
+  // known issue in C++:
+  // https://stackoverflow.com/questions/46114214/lambda-implicit-capture-fails-with-variable-declared-from-structured-binding
+  auto CheckCases = [](const PositionCost& position_cost,
+                       const PositionCost& position_cost_ad, const VectorXd& q,
+                       double y_expected) {
+    // MultibodyPlant double, Eval double.
+    VectorXd y(1);
+    position_cost.Eval(q, &y);
+    EXPECT_NEAR(y[0], y_expected, 1e-12);
+
+    // MultibodyPlant AutoDiffXd, Eval double.
+    VectorXd y_ad_d(1);
+    position_cost_ad.Eval(q, &y_ad_d);
+    EXPECT_NEAR(y_ad_d[0], y_expected, 1e-12);
+
+    // MultibodyPlant double, Eval AutoDiffXd
+    const VectorX<AutoDiffXd> q_ad = InitializeAutoDiff(q);
+    VectorX<AutoDiffXd> y_d_ad(1);
+    position_cost.Eval(q_ad, &y_d_ad);
+    EXPECT_NEAR(y_d_ad[0].value(), y_expected, 1e-12);
+
+    // MultibodyPlant AutoDiffXd, Eval AutoDiffXd
+    VectorX<AutoDiffXd> y_ad_ad(1);
+    position_cost_ad.Eval(q_ad, &y_ad_ad);
+    EXPECT_NEAR(y_ad_ad[0].value(), y_expected, 1e-12);
+
+    // Check that the two gradients match.
+    EXPECT_EQ(y_d_ad[0].derivatives().size(), q.size());
+    EXPECT_TRUE(CompareMatrices(y_d_ad[0].derivatives(),
+                                y_ad_ad[0].derivatives(), 1e-11));
+  };
+
+  // X_WA = X_WB = Identity;
+  plant->SetFreeBodyPose(context.get(), *body1, RigidTransform<double>());
+  plant->SetFreeBodyPose(context.get(), *body2, RigidTransform<double>());
+  VectorXd q = plant->GetPositions(*context);
+  Vector3d err = p_BQ - p_AP;  // because A == B.
+  CheckCases(*cost, *cost_ad, q, err.dot(C * err));
+
+  // X_WA, X_WB are arbitrary non-indentity transforms.
+  RigidTransform<double> X_WA(RollPitchYaw<double>(0.32, -0.24, -0.51),
+                              Vector3d(0.1, 0.3, 0.72));
+  RigidTransform<double> X_WB(RollPitchYaw<double>(8.1, 0.42, -0.2),
+                              Vector3d(-0.84, 0.2, 1.4));
+  plant->SetFreeBodyPose(context.get(), *body1, X_WA);
+  plant->SetFreeBodyPose(context.get(), *body2, X_WB);
+  q = plant->GetPositions(*context);
+
+  const Vector3d p_AQ = X_WA.inverse() * X_WB * p_BQ;
+  err = p_AQ - p_AP;
+  CheckCases(*cost, *cost_ad, q, err.dot(C * err));
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Towards #17507.  This is the first half of supporting GlobalIK's
AddPostureCost in the nonlinear IK toolchain.

+@hongkai-dai for feature review, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17587)
<!-- Reviewable:end -->
