### PR TITLE
Fix missing internal::enable_if. Replace with std::enable_if

### DIFF
--- a/common/autodiffxd.h
+++ b/common/autodiffxd.h
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <limits>
 #include <ostream>
+#include <type_traits>
 
 #include <Eigen/Dense>
 

--- a/common/autodiffxd.h
+++ b/common/autodiffxd.h
@@ -106,7 +106,7 @@ class AutoDiffScalar<VectorXd>
       const AutoDiffScalar<OtherDerType>& other
 #ifndef EIGEN_PARSED_BY_DOXYGEN
       ,
-      typename internal::enable_if<
+      typename std::enable_if<
           internal::is_same<
               Scalar, typename internal::traits<typename internal::remove_all<
                           OtherDerType>::type>::Scalar>::value,


### PR DESCRIPTION
This was an internal type_trait from Eigen, to support compilations
below C++11. Eigen is dropping support for old C++ version, and
removed this type_trait:
https://gitlab.com/libeigen/eigen/-/merge_requests/732

Per https://drake.mit.edu/from_source.html
Drake requires C++17/20 and already uses std::enable_if(_t)
in other places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17590)
<!-- Reviewable:end -->
