### PR TITLE
[inverse_kinematics] Add OrientationCost

### DIFF
--- a/bindings/pydrake/multibody/inverse_kinematics_py.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py.cc
@@ -14,6 +14,7 @@
 #include "drake/multibody/inverse_kinematics/inverse_kinematics.h"
 #include "drake/multibody/inverse_kinematics/minimum_distance_constraint.h"
 #include "drake/multibody/inverse_kinematics/orientation_constraint.h"
+#include "drake/multibody/inverse_kinematics/orientation_cost.h"
 #include "drake/multibody/inverse_kinematics/point_to_point_distance_constraint.h"
 #include "drake/multibody/inverse_kinematics/position_constraint.h"
 #include "drake/multibody/inverse_kinematics/position_cost.h"
@@ -89,6 +90,9 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             py::arg("frameAbar"), py::arg("R_AbarA"), py::arg("frameBbar"),
             py::arg("R_BbarB"), py::arg("theta_bound"),
             cls_doc.AddOrientationConstraint.doc)
+        .def("AddOrientationCost", &Class::AddOrientationCost,
+            py::arg("frameAbar"), py::arg("R_AbarA"), py::arg("frameBbar"),
+            py::arg("R_BbarB"), py::arg("c"), cls_doc.AddOrientationCost.doc)
         .def("AddGazeTargetConstraint", &Class::AddGazeTargetConstraint,
             py::arg("frameA"), py::arg("p_AS"), py::arg("n_A"),
             py::arg("frameB"), py::arg("p_BT"), py::arg("cone_half_angle"),
@@ -566,6 +570,46 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             // Keep alive, reference: `self` keeps `plant_context` alive.
             py::keep_alive<1, 8>(), cls_doc.ctor.doc_autodiff);
   }
+
+  {
+    using Class = OrientationCost;
+    constexpr auto& cls_doc = doc.OrientationCost;
+    using Ptr = std::shared_ptr<Class>;
+    py::class_<Class, solvers::Cost, Ptr>(m, "OrientationCost", cls_doc.doc)
+        .def(py::init([](const MultibodyPlant<double>* plant,
+                          const Frame<double>& frameAbar,
+                          const math::RotationMatrix<double>& R_AbarA,
+                          const Frame<double>& frameBbar,
+                          const math::RotationMatrix<double>& R_BbarB, double c,
+                          systems::Context<double>* plant_context) {
+          return std::make_unique<Class>(
+              plant, frameAbar, R_AbarA, frameBbar, R_BbarB, c, plant_context);
+        }),
+            py::arg("plant"), py::arg("frameAbar"), py::arg("R_AbarA"),
+            py::arg("frameBbar"), py::arg("R_BbarB"), py::arg("c"),
+            py::arg("plant_context"),
+            // Keep alive, reference: `self` keeps `plant` alive.
+            py::keep_alive<1, 2>(),
+            // Keep alive, reference: `self` keeps `plant_context` alive.
+            py::keep_alive<1, 8>(), cls_doc.ctor.doc_double)
+        .def(py::init([](const MultibodyPlant<AutoDiffXd>* plant,
+                          const Frame<AutoDiffXd>& frameAbar,
+                          const math::RotationMatrix<double>& R_AbarA,
+                          const Frame<AutoDiffXd>& frameBbar,
+                          const math::RotationMatrix<double>& R_BbarB, double c,
+                          systems::Context<AutoDiffXd>* plant_context) {
+          return std::make_unique<Class>(
+              plant, frameAbar, R_AbarA, frameBbar, R_BbarB, c, plant_context);
+        }),
+            py::arg("plant"), py::arg("frameAbar"), py::arg("R_AbarA"),
+            py::arg("frameBbar"), py::arg("R_BbarB"), py::arg("c"),
+            py::arg("plant_context"),
+            // Keep alive, reference: `self` keeps `plant` alive.
+            py::keep_alive<1, 2>(),
+            // Keep alive, reference: `self` keeps `plant_context` alive.
+            py::keep_alive<1, 8>(), cls_doc.ctor.doc_autodiff);
+  }
+
   {
     using Class = UnitQuaternionConstraint;
     constexpr auto& cls_doc = doc.UnitQuaternionConstraint;

--- a/bindings/pydrake/multibody/test/inverse_kinematics_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_test.py
@@ -199,6 +199,15 @@ class TestInverseKinematics(unittest.TestCase):
         self.assertGreater(R_AB.trace(),
                            1 + 2 * math.cos(theta_bound) - 1E-6)
 
+    def test_AddOrientationCost(self):
+        binding = self.ik_two_bodies.AddOrientationCost(
+            frameAbar=self.body1_frame,
+            R_AbarA=RotationMatrix(),
+            frameBbar=self.body2_frame,
+            R_BbarB=RotationMatrix(),
+            c=1.0)
+        self.assertIsInstance(binding, mp.Binding[mp.Cost])
+
     def test_AddGazeTargetConstraint(self):
         p_AS = np.array([0.1, 0.2, 0.3])
         n_A = np.array([0.3, 0.5, 1.2])
@@ -565,6 +574,17 @@ class TestConstraints(unittest.TestCase):
             frameBbar=variables.body2_frame, R_BbarB=RotationMatrix(),
             theta_bound=0.2 * math.pi, plant_context=variables.plant_context)
         self.assertIsInstance(constraint, mp.Constraint)
+
+    @check_type_variables
+    def test_orientation_cost(self, variables):
+        cost = ik.OrientationCost(plant=variables.plant,
+                                  frameAbar=variables.body1_frame,
+                                  R_AbarA=RotationMatrix(),
+                                  frameBbar=variables.body2_frame,
+                                  R_BbarB=RotationMatrix(),
+                                  c=1.0,
+                                  plant_context=variables.plant_context)
+        self.assertIsInstance(cost, mp.Cost)
 
     @check_type_variables
     def test_point_to_point_distance_constraint(self, variables):

--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -46,6 +46,7 @@ drake_cc_library(
         "kinematic_evaluator_utilities.cc",
         "minimum_distance_constraint.cc",
         "orientation_constraint.cc",
+        "orientation_cost.cc",
         "point_to_point_distance_constraint.cc",
         "position_constraint.cc",
         "position_cost.cc",
@@ -61,6 +62,7 @@ drake_cc_library(
         "kinematic_evaluator_utilities.h",
         "minimum_distance_constraint.h",
         "orientation_constraint.h",
+        "orientation_cost.h",
         "point_to_point_distance_constraint.h",
         "position_constraint.h",
         "position_cost.h",
@@ -173,6 +175,14 @@ drake_cc_googletest(
         ":inverse_kinematics_test_utilities",
         ":kinematic_evaluators",
         "//math:geometric_transform",
+    ],
+)
+
+drake_cc_googletest(
+    name = "orientation_cost_test",
+    deps = [
+        ":inverse_kinematics_test_utilities",
+        ":kinematic_evaluators",
     ],
 )
 

--- a/multibody/inverse_kinematics/inverse_kinematics.h
+++ b/multibody/inverse_kinematics/inverse_kinematics.h
@@ -174,6 +174,24 @@ class InverseKinematics {
       const Frame<double>& frameBbar,
       const math::RotationMatrix<double>& R_BbarB, double theta_bound);
 
+  /** Adds a cost of the form `c * (1 - cos(θ))`, where θ is the angle between
+   * the orientation of frame A and the orientation of frame B, and @p c is a
+   * cost scaling.
+   * @param frameAbar A frame on the MultibodyPlant.
+   * @param R_AbarA The rotation matrix describing the orientation of frame A
+   * relative to Abar.
+   * @param frameBbar A frame on the MultibodyPlant.
+   * @param R_BbarB The rotation matrix describing the orientation of frame B
+   * relative to Bbar.
+   * @param c A scalar cost weight.
+   */
+  solvers::Binding<solvers::Cost> AddOrientationCost(
+      const Frame<double>& frameAbar,
+      const math::RotationMatrix<double>& R_AbarA,
+      const Frame<double>& frameBbar,
+      const math::RotationMatrix<double>& R_BbarB,
+      double c);
+
   /**
    * Constrains a target point T to be within a cone K. The point T ("T" stands
    * for "target") is fixed in a frame B, with position p_BT. The cone

--- a/multibody/inverse_kinematics/orientation_cost.cc
+++ b/multibody/inverse_kinematics/orientation_cost.cc
@@ -1,0 +1,78 @@
+#include "drake/multibody/inverse_kinematics/orientation_cost.h"
+
+#include "drake/math/autodiff_gradient.h"
+#include "drake/multibody/inverse_kinematics/kinematic_evaluator_utilities.h"
+
+using drake::multibody::internal::RefFromPtrOrThrow;
+using drake::multibody::internal::UpdateContextConfiguration;
+
+namespace drake {
+namespace multibody {
+
+namespace {
+
+// TODO(russt): Consider moving this to kinematics_utilities (possibly by
+// generalizing RefWithPointerOrThrow).
+template <typename T>
+systems::Context<T>* ContextOrThrow(
+    systems::Context<T>* plant_context) {
+  if (plant_context == nullptr)
+    throw std::invalid_argument("OrientationCost(): plant_context is nullptr.");
+  return plant_context;
+}
+
+}  // namespace
+
+OrientationCost::OrientationCost(const MultibodyPlant<double>* const plant,
+                                 const Frame<double>& frameAbar,
+                                 const math::RotationMatrix<double>& R_AbarA,
+                                 const Frame<double>& frameBbar,
+                                 const math::RotationMatrix<double>& R_BbarB,
+                                 double c,
+                                 systems::Context<double>* plant_context)
+    : solvers::Cost(RefFromPtrOrThrow(plant).num_positions()),
+      constraint_(plant, frameAbar, R_AbarA, frameBbar, R_BbarB, 0,
+                  ContextOrThrow(plant_context)),
+      c_{c} {}
+
+OrientationCost::OrientationCost(const MultibodyPlant<AutoDiffXd>* const plant,
+                                 const Frame<AutoDiffXd>& frameAbar,
+                                 const math::RotationMatrix<double>& R_AbarA,
+                                 const Frame<AutoDiffXd>& frameBbar,
+                                 const math::RotationMatrix<double>& R_BbarB,
+                                 double c,
+                                 systems::Context<AutoDiffXd>* plant_context)
+    : solvers::Cost(RefFromPtrOrThrow(plant).num_positions()),
+      constraint_(plant, frameAbar, R_AbarA, frameBbar, R_BbarB, 0,
+                  ContextOrThrow(plant_context)),
+      c_{c} {}
+
+OrientationCost::~OrientationCost() = default;
+
+void OrientationCost::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+                             Eigen::VectorXd* y) const {
+  // OrientationConstraint computes  tr(R_AB) = 1 - 2cosθ
+  // So 1 - cosθ = (1 + tr(R_AB))/2
+  y->resize(1);
+  Eigen::VectorXd trace_R_AB(1);
+  constraint_.Eval(x, &trace_R_AB);
+  (*y)[0] = c_ * (1.0 + trace_R_AB[0]) / 2.0;
+}
+
+void OrientationCost::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+                             AutoDiffVecXd* y) const {
+  y->resize(1);
+  VectorX<AutoDiffXd> trace_R_AB(1);
+  constraint_.Eval(x, &trace_R_AB);
+  (*y)[0] = c_ * (1.0 + trace_R_AB[0]) / 2.0;
+}
+
+void OrientationCost::DoEval(
+    const Eigen::Ref<const VectorX<symbolic::Variable>>&,
+    VectorX<symbolic::Expression>*) const {
+  throw std::logic_error(
+      "OrientationCost::DoEval() does not work for symbolic variables.");
+}
+
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/inverse_kinematics/orientation_cost.h
+++ b/multibody/inverse_kinematics/orientation_cost.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "drake/multibody/inverse_kinematics/orientation_constraint.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/solvers/cost.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+namespace multibody {
+/**
+ * Implements a cost of the form `c * (1 - cos(θ))`, where θ is the angle
+ * between the orientation of frame A and the orientation of frame B, and `c`
+ * is a cost scaling.
+ *
+ * @ingroup solver_evaluators
+ */
+class OrientationCost : public solvers::Cost {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OrientationCost)
+
+  /**
+   * Constructs OrientationCost object.
+   * @param plant The MultibodyPlant on which the cost is implemented. `plant`
+   *   should be alive during the lifetime of this cost.
+   * @param frameAbar A frame on the MultibodyPlant.
+   * @param R_AbarA The rotation matrix describing the orientation of frame A
+   * relative to Abar.
+   * @param frameBbar A frame on the MultibodyPlant.
+   * @param R_BbarB The rotation matrix describing the orientation of frame B
+   * relative to Bbar.
+   * @param c A scalar cost weight.
+   * @param plant_context A context for the `plant`.
+   *
+   * @throws std::exception if `plant` is nullptr.
+   * @throws std::exception if `plant_context` is nullptr.
+   * @pydrake_mkdoc_identifier{double}
+   */
+  OrientationCost(const MultibodyPlant<double>* plant,
+                  const Frame<double>& frameAbar,
+                  const math::RotationMatrix<double>& R_AbarA,
+                  const Frame<double>& frameBbar,
+                  const math::RotationMatrix<double>& R_BbarB, double c,
+                  systems::Context<double>* plant_context);
+
+  /**
+   * Overloaded constructor. Same as the constructor with the double version
+   * (using MultibodyPlant<double> and Context<double>). Except the gradient of
+   * the cost is computed from autodiff.
+   * @pydrake_mkdoc_identifier{autodiff}
+   */
+  OrientationCost(const MultibodyPlant<AutoDiffXd>* plant,
+                  const Frame<AutoDiffXd>& frameAbar,
+                  const math::RotationMatrix<double>& R_AbarA,
+                  const Frame<AutoDiffXd>& frameBbar,
+                  const math::RotationMatrix<double>& R_BbarB, double c,
+                  systems::Context<AutoDiffXd>* plant_context);
+
+  ~OrientationCost() override;
+
+ private:
+  void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+              Eigen::VectorXd* y) const override;
+
+  void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+              AutoDiffVecXd* y) const override;
+
+  void DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>&,
+              VectorX<symbolic::Expression>*) const override;
+
+  const OrientationConstraint constraint_;
+  const double c_;
+};
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test.cc
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test.cc
@@ -5,6 +5,7 @@
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/math/rotation_matrix.h"
+#include "drake/math/wrap_to.h"
 #include "drake/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h"
 #include "drake/solvers/create_constraint.h"
 #include "drake/solvers/solve.h"
@@ -109,6 +110,31 @@ GTEST_TEST(InverseKinematicsTest, ConstructorWithJointLimits) {
   }
 }
 
+TEST_F(TwoFreeBodiesTest, ConstructorAddsUnitQuaterionConstraints) {
+  ik_.get_mutable_prog()->SetInitialGuess(ik_.q().head<4>(),
+                                          Eigen::Vector4d(1, 2, 3, 4));
+  ik_.get_mutable_prog()->SetInitialGuess(ik_.q().segment<4>(7),
+                                          Eigen::Vector4d(.1, .2, .3, .4));
+  const auto result = Solve(ik_.prog());
+  EXPECT_TRUE(result.is_success());
+  Eigen::VectorXd q = result.GetSolution(ik_.q());
+  EXPECT_NEAR(q.head<4>().squaredNorm(), 1.0, 1e-6);
+  EXPECT_NEAR(q.segment<4>(7).squaredNorm(), 1.0, 1e-6);
+
+  // Test the constructor which takes a Context.
+  auto context = two_bodies_plant_->CreateDefaultContext();
+  InverseKinematics ik2(*two_bodies_plant_, context.get());
+  ik2.get_mutable_prog()->SetInitialGuess(ik2.q().head<4>(),
+                                          Eigen::Vector4d(1, 2, 3, 4));
+  ik2.get_mutable_prog()->SetInitialGuess(
+      ik2.q().segment<4>(7), Eigen::Vector4d(.1, .2, .3, .4));
+  const auto result2 = Solve(ik2.prog());
+  EXPECT_TRUE(result2.is_success());
+  q = result2.GetSolution(ik2.q());
+  EXPECT_NEAR(q.head<4>().squaredNorm(), 1.0, 1e-6);
+  EXPECT_NEAR(q.segment<4>(7).squaredNorm(), 1.0, 1e-6);
+}
+
 TEST_F(TwoFreeBodiesTest, PositionConstraint) {
   const Eigen::Vector3d p_BQ(0.2, 0.3, 0.5);
   const Eigen::Vector3d p_AQ_lower(-0.1, -0.2, -0.3);
@@ -190,6 +216,40 @@ TEST_F(TwoFreeBodiesTest, OrientationConstraint) {
       R_AbarA.transpose() * R_AbarBbar * R_BbarB;
   const double angle = R_AB.ToAngleAxis().angle();
   EXPECT_LE(angle, angle_bound + 1E-6);
+}
+
+TEST_F(TwoFreeBodiesTest, OrientationCost) {
+  const math::RotationMatrix<double> R_AbarA(
+      math::RollPitchYaw<double>(1, 2, 3));
+  const math::RotationMatrix<double> R_BbarB(
+      math::RollPitchYaw<double>(4, 5, 6));
+  const double c{2.4};
+  auto binding =
+      ik_.AddOrientationCost(body1_frame_, R_AbarA, body2_frame_, R_BbarB, c);
+
+  // We don't need to test the cost implementation, only that the arguments are
+  // passed correctly.  Just set an arbitrary (but valid) q and evaluate the
+  // cost.
+  math::RigidTransform<double> X_WAbar(
+      math::RollPitchYaw<double>(0.32, -0.24, -0.51),
+      Eigen::Vector3d(0.1, 0.3, 0.72));
+  math::RigidTransform<double> X_WBbar(
+      math::RollPitchYaw<double>(8.1, 0.42, -0.2),
+      Eigen::Vector3d(-0.84, 0.2, 1.4));
+  auto context = two_bodies_plant_->CreateDefaultContext();
+  two_bodies_plant_->SetFreeBodyPose(
+      context.get(), two_bodies_plant_->GetBodyByName("body1"), X_WAbar);
+  two_bodies_plant_->SetFreeBodyPose(
+      context.get(), two_bodies_plant_->GetBodyByName("body2"), X_WBbar);
+  ik_.get_mutable_prog()->SetInitialGuess(
+      ik_.q(), two_bodies_plant_->GetPositions(*context));
+
+  const math::RotationMatrix<double> R_AB =
+      (X_WAbar.rotation() * R_AbarA).inverse() * X_WBbar.rotation() * R_BbarB;
+  const double theta =
+      math::wrap_to(R_AB.ToAngleAxis().angle(), -M_PI / 2.0, M_PI / 2.0);
+  EXPECT_NEAR(ik_.prog().EvalBindingAtInitialGuess(binding)[0],
+              c * (1.0 - cos(theta)), 1e-12);
 }
 
 TEST_F(TwoFreeBodiesTest, GazeTargetConstraint) {

--- a/multibody/inverse_kinematics/test/orientation_cost_test.cc
+++ b/multibody/inverse_kinematics/test/orientation_cost_test.cc
@@ -1,0 +1,122 @@
+#include "drake/multibody/inverse_kinematics/orientation_cost.h"
+
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "drake/math/wrap_to.h"
+#include "drake/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+using Eigen::Matrix3d;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+
+using math::InitializeAutoDiff;
+using math::RigidTransform;
+using math::RollPitchYaw;
+using math::RotationMatrix;
+using systems::Context;
+
+template <typename T>
+auto ConstructTwoFreeBodiesCost(const math::RotationMatrix<double>& R_AbarA,
+                                const math::RotationMatrix<double>& R_BbarB,
+                                double c) {
+  struct ReturnValues {
+    std::unique_ptr<MultibodyPlant<T>> plant;
+    std::unique_ptr<Context<T>> context;
+    const Body<T>* body1{};
+    const Body<T>* body2{};
+    std::unique_ptr<OrientationCost> cost;
+  };
+  ReturnValues v;
+
+  v.plant = ConstructTwoFreeBodiesPlant<T>();
+  v.context = v.plant->CreateDefaultContext();
+
+  v.body1 = &v.plant->GetBodyByName("body1");
+  v.body2 = &v.plant->GetBodyByName("body2");
+
+  v.cost = std::make_unique<OrientationCost>(
+      v.plant.get(), v.body1->body_frame(), R_AbarA, v.body2->body_frame(),
+      R_BbarB, c, v.context.get());
+
+  return v;
+}
+
+// Given two free bodies with some given poses, evaluate the position cost.
+GTEST_TEST(OrientationCostTest, TwoFreeBodies) {
+  const RotationMatrix<double> R_AbarA(RollPitchYaw<double>(1, 2, 3));
+  const RotationMatrix<double> R_BbarB(RollPitchYaw<double>(4, 5, 6));
+  const double c{2.4};
+
+  auto [plant, context, body1, body2, cost] =
+      ConstructTwoFreeBodiesCost<double>(R_AbarA, R_BbarB, c);
+  auto [plant_ad, context_ad, body1_ad, body2_ad, cost_ad] =
+      ConstructTwoFreeBodiesCost<AutoDiffXd>(R_AbarA, R_BbarB, c);
+
+  // Note: We are passing OrientationCost here instead of capturing them due to
+  // a known issue in C++:
+  // https://stackoverflow.com/questions/46114214/lambda-implicit-capture-fails-with-variable-declared-from-structured-binding
+  auto CheckCases = [](const OrientationCost& orientation_cost,
+                       const OrientationCost& orientation_cost_ad,
+                       const VectorXd& q, double y_expected) {
+    // MultibodyPlant double, Eval double.
+    VectorXd y(1);
+    orientation_cost.Eval(q, &y);
+    EXPECT_NEAR(y[0], y_expected, 1e-12);
+
+    // MultibodyPlant AutoDiffXd, Eval double.
+    VectorXd y_ad_d(1);
+    orientation_cost_ad.Eval(q, &y_ad_d);
+    EXPECT_NEAR(y_ad_d[0], y_expected, 1e-12);
+
+    // MultibodyPlant double, Eval AutoDiffXd
+    const VectorX<AutoDiffXd> q_ad = InitializeAutoDiff(q);
+    VectorX<AutoDiffXd> y_d_ad(1);
+    orientation_cost.Eval(q_ad, &y_d_ad);
+    EXPECT_NEAR(y_d_ad[0].value(), y_expected, 1e-12);
+
+    // MultibodyPlant AutoDiffXd, Eval AutoDiffXd
+    VectorX<AutoDiffXd> y_ad_ad(1);
+    orientation_cost_ad.Eval(q_ad, &y_ad_ad);
+    EXPECT_NEAR(y_ad_ad[0].value(), y_expected, 1e-12);
+
+    // Check that the two gradients match.
+    EXPECT_EQ(y_d_ad[0].derivatives().size(), q.size());
+    EXPECT_TRUE(CompareMatrices(y_d_ad[0].derivatives(),
+                                y_ad_ad[0].derivatives(), 1e-11));
+  };
+
+  // X_WA = X_WB = Identity;
+  plant->SetFreeBodyPose(context.get(), *body1, RigidTransform<double>());
+  plant->SetFreeBodyPose(context.get(), *body2, RigidTransform<double>());
+  VectorXd q = plant->GetPositions(*context);
+  RotationMatrix<double> R_AB = R_AbarA.inverse() * R_BbarB;  // because A == B.
+  // We use the explicit formula in the Cost implementation; we test this
+  // against Eigen's conversion from matrices to AngleAxis:
+  double theta =
+      math::wrap_to(R_AB.ToAngleAxis().angle(), -M_PI / 2.0, M_PI / 2.0);
+  CheckCases(*cost, *cost_ad, q, c * (1.0 - cos(theta)));
+
+  // X_WA, X_WB are arbitrary non-identity transforms.
+  RigidTransform<double> X_WAbar(RollPitchYaw<double>(0.32, -0.24, -0.51),
+                                 Vector3d(0.1, 0.3, 0.72));
+  RigidTransform<double> X_WBbar(RollPitchYaw<double>(8.1, 0.42, -0.2),
+                                 Vector3d(-0.84, 0.2, 1.4));
+  plant->SetFreeBodyPose(context.get(), *body1, X_WAbar);
+  plant->SetFreeBodyPose(context.get(), *body2, X_WBbar);
+  q = plant->GetPositions(*context);
+
+  R_AB =
+      (X_WAbar.rotation() * R_AbarA).inverse() * X_WBbar.rotation() * R_BbarB;
+  theta = math::wrap_to(R_AB.ToAngleAxis().angle(), -M_PI / 2.0, M_PI / 2.0);
+  CheckCases(*cost, *cost_ad, q, c * (1.0 - cos(theta)));
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Towards #17507.  This is the second half of supporting GlobalIK's
AddPostureCost in the nonlinear IK toolchain.

+@hongkai-dai for feature review, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17592)
<!-- Reviewable:end -->
