### PR TITLE
[visualization] Enable multiple visualization channels

### DIFF
--- a/bindings/pydrake/visualization/test/meldis_test.py
+++ b/bindings/pydrake/visualization/test/meldis_test.py
@@ -35,7 +35,7 @@ class TestMeldis(unittest.TestCase):
         lcm = dut._lcm
 
         # The path is created by the constructor.
-        self.assertEqual(meshcat.HasPath("/DRAKE_VIEWER"), True)
+        self.assertEqual(meshcat.HasPath("/Visual Geometry"), True)
 
         # Enqueue the load + draw messages.
         sdf_file = FindResourceOrThrow(
@@ -52,7 +52,7 @@ class TestMeldis(unittest.TestCase):
         diagram.Publish(context)
 
         # The geometry isn't registered until the load is processed.
-        link_path = "/DRAKE_VIEWER/2/plant/acrobot/Link2/0"
+        link_path = "/Visual Geometry/2/plant/acrobot/Link2/0"
         self.assertEqual(meshcat.HasPath(link_path), False)
 
         # Process the load + draw; make sure the geometry exists now.

--- a/examples/kinova_jaco_arm/jaco_simulation.cc
+++ b/examples/kinova_jaco_arm/jaco_simulation.cc
@@ -95,6 +95,9 @@ int DoMain() {
   systems::lcm::LcmInterfaceSystem* lcm =
       builder.AddSystem<systems::lcm::LcmInterfaceSystem>();
   geometry::DrakeVisualizerd::AddToBuilder(&builder, *scene_graph, lcm);
+  geometry::DrakeVisualizerParams params;
+  params.role = geometry::Role::kProximity;
+  geometry::DrakeVisualizerd::AddToBuilder(&builder, *scene_graph, lcm, params);
 
   auto command_sub = builder.AddSystem(
       systems::lcm::LcmSubscriberSystem::Make<drake::lcmt_jaco_command>(

--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -27,6 +27,7 @@ namespace drake {
 namespace geometry {
 
 using Eigen::Quaterniond;
+using internal::MakeLcmChannelNameForRole;
 using internal::SortedTriplet;
 using math::RigidTransformd;
 using std::array;
@@ -465,6 +466,27 @@ class ShapeToLcm : public ShapeReifier {
 
 }  // namespace
 
+namespace internal {
+std::string MakeLcmChannelNameForRole(const std::string& channel, Role role) {
+  DRAKE_DEMAND(role != Role::kUnassigned);
+
+  // These channel name transformations must be kept in sync with message
+  // consumers (meldis, drake_visualizer) in order for visualization of all
+  // roles to work.
+  switch (role) {
+    case Role::kIllustration:
+      return channel;
+    case Role::kProximity:
+      return channel + "_PROXIMITY";
+    case Role::kPerception:
+      return channel + "_PERCEPTION";
+    case Role::kUnassigned:
+      DRAKE_UNREACHABLE();
+  }
+  DRAKE_UNREACHABLE();
+}
+}  // namespace internal
+
 template <typename T>
 DrakeVisualizer<T>::DrakeVisualizer(lcm::DrakeLcmInterface* lcm,
                                     DrakeVisualizerParams params)
@@ -584,7 +606,8 @@ EventStatus DrakeVisualizer<T>::SendGeometryMessage(
     RefreshDeformableMeshData(context);
   }
 
-  SendDrawNonDeformableMessage(query_object, EvalDynamicFrameData(context),
+  SendDrawNonDeformableMessage(query_object, params_,
+                               EvalDynamicFrameData(context),
                                ExtractDoubleOrThrow(context.get_time()), lcm_);
   SendDeformableGeometriesMessage(
       query_object, params_, EvalDeformableMeshData(context),
@@ -674,12 +697,15 @@ void DrakeVisualizer<T>::SendLoadNonDeformableMessage(
     ++link_index;
   }
 
-  lcm::Publish(lcm, "DRAKE_VIEWER_LOAD_ROBOT", message, time);
+  std::string channel = MakeLcmChannelNameForRole("DRAKE_VIEWER_LOAD_ROBOT",
+                                                  params.role);
+  lcm::Publish(lcm, channel, message, time);
 }
 
 template <typename T>
 void DrakeVisualizer<T>::SendDrawNonDeformableMessage(
     const QueryObject<T>& query_object,
+    const DrakeVisualizerParams& params,
     const vector<internal::DynamicFrameData>& dynamic_frames, double time,
     lcm::DrakeLcmInterface* lcm) {
   lcmt_viewer_draw message{};
@@ -714,7 +740,9 @@ void DrakeVisualizer<T>::SendDrawNonDeformableMessage(
     message.quaternion[i][3] = q.z();
   }
 
-  lcm::Publish(lcm, "DRAKE_VIEWER_DRAW", message, time);
+  std::string channel = MakeLcmChannelNameForRole("DRAKE_VIEWER_DRAW",
+                                                  params.role);
+  lcm::Publish(lcm, channel, message, time);
 }
 
 template <typename T>
@@ -744,7 +772,9 @@ void DrakeVisualizer<T>::SendDeformableGeometriesMessage(
     message.geom[i] =
         MakeDeformableSurfaceMesh(vertex_positions, data, params.default_color);
   }
-  lcm::Publish(lcm, "DRAKE_VIEWER_DEFORMABLE", message, time);
+  std::string channel = MakeLcmChannelNameForRole("DRAKE_VIEWER_DEFORMABLE",
+                                                  params.role);
+  lcm::Publish(lcm, channel, message, time);
 }
 
 template <typename T>

--- a/geometry/drake_visualizer.h
+++ b/geometry/drake_visualizer.h
@@ -51,6 +51,11 @@ struct DeformableMeshData {
   int volume_vertex_count{};
 };
 
+/* Maybe add a suffix to the provided LCM channel name, based on the geometry
+ role. Channel name results for the kIllustration role will be unchanged. The
+ passed role cannot be kUnassigned. */
+std::string MakeLcmChannelNameForRole(const std::string& channel, Role role);
+
 }  // namespace internal
 
 /** A system that publishes LCM messages compatible with the `drake_visualizer`
@@ -66,11 +71,19 @@ struct DeformableMeshData {
  The %DrakeVisualizer system broadcasts three kinds of LCM messages:
 
    - a message that defines the non-deformable geometries in the world on the
- lcm channel named "DRAKE_VIEWER_LOAD_ROBOT"
+     lcm channel named "DRAKE_VIEWER_LOAD_ROBOT"
    - a message that updates the poses of those non-deformable geometries on the
- lcm channel named "DRAKE_VIEWER_DRAW",
+     lcm channel named "DRAKE_VIEWER_DRAW",
    - a message that sets the world space vertex positions of the deformable
-    geometries on the lcm channel named "DRAKE_VIEWER_DEFORMABLE"
+     geometries on the lcm channel named "DRAKE_VIEWER_DEFORMABLE"
+
+   The above channel names are modified according to the role specified in
+   DrakeVisualizerParams. This allows simultaneous availability of geometry
+   from multiple roles, by using multiple DrakeVisualizer instances.
+
+   - kIllustration: channel names are unchanged from above.
+   - kProximity: channel names gain a "_PROXIMITY" suffix.
+   - kPerception: channel names gain a "_PERCEPTION" suffix.
 
  The system uses the versioning mechanism provided by SceneGraph to detect
  changes to the geometry so that a change in SceneGraph's data will propagate
@@ -244,6 +257,7 @@ class DrakeVisualizer final : public systems::LeafSystem<T> {
    definition of the poses of all non-deformable geometries. */
   static void SendDrawNonDeformableMessage(
       const QueryObject<T>& query_object,
+      const DrakeVisualizerParams& params,
       const std::vector<internal::DynamicFrameData>& dynamic_frames,
       double time, lcm::DrakeLcmInterface* lcm);
 

--- a/geometry/test/drake_visualizer_test.cc
+++ b/geometry/test/drake_visualizer_test.cc
@@ -32,6 +32,7 @@ namespace drake {
 namespace geometry {
 
 using Eigen::Vector3d;
+using internal::MakeLcmChannelNameForRole;
 using lcm::DrakeLcmInterface;
 using math::RigidTransform;
 using math::RigidTransformd;
@@ -220,17 +221,16 @@ class DrakeVisualizerTest : public ::testing::Test {
 
   /* Processes the message queue, reporting the number of load and draw messges
    and, if that number is non-zero, the last message of each type received.  */
-  MessageResults ProcessMessages() {
+  MessageResults ProcessMessages(Role role = Role::kIllustration) {
     lcm_.HandleSubscriptions(0);
-    const int num_draw = draw_subscriber_.count();
-    lcmt_viewer_draw draw_message = draw_subscriber_.message();
-    const int num_load = load_subscriber_.count();
-    lcmt_viewer_load_robot load_message = load_subscriber_.message();
-    const int num_deformable = deformable_subscriber_.count();
-    lcmt_viewer_link_data deformable_message = deformable_subscriber_.message();
-    draw_subscriber_.clear();
-    load_subscriber_.clear();
-    deformable_subscriber_.clear();
+    Subscribers& subs = *subscribers_[role];
+    const int num_draw = subs.draw.count();
+    lcmt_viewer_draw draw_message = subs.draw.message();
+    const int num_load = subs.load.count();
+    lcmt_viewer_load_robot load_message = subs.load.message();
+    const int num_deformable = subs.deformable.count();
+    lcmt_viewer_link_data deformable_message = subs.deformable.message();
+    subs.clear();
     // clang-format off
     return {num_load,       load_message,
             num_draw,       draw_message,
@@ -353,12 +353,6 @@ class DrakeVisualizerTest : public ::testing::Test {
   }
 
   static constexpr double kPublishPeriod = 1 / 64.0;
-  /* The LCM channel names. We are implicitly confirming that DrakeVisualizer
-   broadcasts on the right channels via the subscribers. The reception of
-   expected messages on those subscribers is proof.  */
-  static constexpr char kLoadChannel[] = "DRAKE_VIEWER_LOAD_ROBOT";
-  static constexpr char kDrawChannel[] = "DRAKE_VIEWER_DRAW";
-  static constexpr char kDeformableDrawChannel[] = "DRAKE_VIEWER_DEFORMABLE";
 
   /* The names of the sources registered with the SceneGraph.  */
   static constexpr char kPoseSourceName[] = "DrakeVisualizerTestPoseSource";
@@ -367,11 +361,41 @@ class DrakeVisualizerTest : public ::testing::Test {
 
   /* The LCM visualizer broadcasts messages on.  */
   lcm::DrakeLcm lcm_;
+
   /* The subscribers for draw and load messages.  */
-  lcm::Subscriber<lcmt_viewer_draw> draw_subscriber_{&lcm_, kDrawChannel};
-  lcm::Subscriber<lcmt_viewer_load_robot> load_subscriber_{&lcm_, kLoadChannel};
-  lcm::Subscriber<lcmt_viewer_link_data> deformable_subscriber_{
-      &lcm_, kDeformableDrawChannel};
+  struct Subscribers {
+    /* The LCM channel names. We are implicitly confirming that DrakeVisualizer
+       broadcasts on the right channels via the subscribers. The reception of
+       expected messages on those subscribers is proof.  */
+    static constexpr char kLoadChannel[] = "DRAKE_VIEWER_LOAD_ROBOT";
+    static constexpr char kDrawChannel[] = "DRAKE_VIEWER_DRAW";
+    static constexpr char kDeformableDrawChannel[] = "DRAKE_VIEWER_DEFORMABLE";
+
+    explicit Subscribers(lcm::DrakeLcm* lcm, Role role)
+        : draw(lcm, MakeLcmChannelNameForRole(kDrawChannel, role)),
+          load(lcm, MakeLcmChannelNameForRole(kLoadChannel, role)),
+          deformable(lcm, MakeLcmChannelNameForRole(kDeformableDrawChannel,
+                                                    role)) {
+    }
+
+    void clear() {
+      draw.clear();
+      load.clear();
+      deformable.clear();
+    }
+
+    lcm::Subscriber<lcmt_viewer_draw> draw;
+    lcm::Subscriber<lcmt_viewer_load_robot> load;
+    lcm::Subscriber<lcmt_viewer_link_data> deformable;
+  };
+  Subscribers illustration_subs_{&lcm_, Role::kIllustration};
+  Subscribers proximity_subs_{&lcm_, Role::kProximity};
+  Subscribers perception_subs_{&lcm_, Role::kPerception};
+  std::map<Role, Subscribers *> subscribers_{
+    {Role::kIllustration, &illustration_subs_},
+    {Role::kProximity, &proximity_subs_},
+    {Role::kPerception, &perception_subs_},
+  };
 
   /* Raw pointer into the diagram's scene graph.  */
   SceneGraph<T>* scene_graph_{};
@@ -511,7 +535,7 @@ TYPED_TEST(DrakeVisualizerTest, ConfigureDefaultDiffuse) {
     this->pose_source_->SetPoses({{f_id, RigidTransform<T>{}}});
     Simulator<T> simulator(*(this->diagram_));
     simulator.AdvanceTo(0.0);
-    MessageResults results = this->ProcessMessages();
+    MessageResults results = this->ProcessMessages(Role::kProximity);
     ASSERT_EQ(results.num_load, 1);
     ASSERT_EQ(results.load_message.num_links, 1);
     ASSERT_EQ(results.load_message.link[0].num_geom, 1);
@@ -555,7 +579,7 @@ TYPED_TEST(DrakeVisualizerTest, AnchoredAndDynamicGeometry) {
 
   Simulator<T> simulator(*(this->diagram_));
   simulator.AdvanceTo(0.0);
-  MessageResults results = this->ProcessMessages();
+  MessageResults results = this->ProcessMessages(Role::kProximity);
 
   // Confirm load message; three geometries on two links.
   ASSERT_EQ(results.num_load, 1);
@@ -597,7 +621,7 @@ TYPED_TEST(DrakeVisualizerTest, TargetRole) {
     this->PopulateScene();
     Simulator<T> simulator(*(this->diagram_));
     simulator.AdvanceTo(0.0);
-    MessageResults results = this->ProcessMessages();
+    MessageResults results = this->ProcessMessages(role);
 
     /* Confirm that messages were sent.  */
     ASSERT_EQ(results.num_load, 1);
@@ -652,7 +676,7 @@ TYPED_TEST(DrakeVisualizerTest, GeometryWithIllustrationFallback) {
   simulator.AdvanceTo(0.0);
 
   // We're just checking the load message for the right color.
-  MessageResults results = this->ProcessMessages();
+  MessageResults results = this->ProcessMessages(Role::kProximity);
   ASSERT_EQ(results.num_load, 1);
   ASSERT_EQ(results.load_message.num_links, 1);
   ASSERT_EQ(results.load_message.link[0].num_geom, 1);
@@ -688,7 +712,7 @@ TYPED_TEST(DrakeVisualizerTest, AllRolesCanDefineDiffuse) {
     simulator.AdvanceTo(0.0);
 
     // We're just checking the load message for the right color.
-    MessageResults results = this->ProcessMessages();
+    MessageResults results = this->ProcessMessages(role);
     ASSERT_EQ(results.num_load, 1);
     ASSERT_EQ(results.load_message.num_links, 1);
     ASSERT_EQ(results.load_message.link[0].num_geom, 1);
@@ -743,7 +767,7 @@ TYPED_TEST(DrakeVisualizerTest, ChangesInVersion) {
     double t = 0.0;
     simulator.AdvanceTo(t);
     // Confirm the initial load/draw message pair.
-    MessageResults results = this->ProcessMessages();
+    MessageResults results = this->ProcessMessages(role);
     ASSERT_EQ(results.num_load, 1);
     ASSERT_EQ(results.num_draw, 1);
     ASSERT_EQ(results.num_deformable, 1);
@@ -751,7 +775,7 @@ TYPED_TEST(DrakeVisualizerTest, ChangesInVersion) {
     t += this->kPublishPeriod;
     simulator.AdvanceTo(t);
     // Confirm draw only.
-    results = this->ProcessMessages();
+    results = this->ProcessMessages(role);
     ASSERT_EQ(results.num_load, 0);
     ASSERT_EQ(results.num_draw, 1);
     ASSERT_EQ(results.num_deformable, 1);
@@ -774,7 +798,7 @@ TYPED_TEST(DrakeVisualizerTest, ChangesInVersion) {
       }
       t += this->kPublishPeriod;
       simulator.AdvanceTo(t);
-      results = this->ProcessMessages();
+      results = this->ProcessMessages(role);
       EXPECT_EQ(results.num_load, modified_role == role ? 1 : 0)
           << "For visualized role '" << role << "' and modified role '" << role
           << "'\n";
@@ -931,7 +955,7 @@ TYPED_TEST(DrakeVisualizerTest, VisualizeHydroGeometry) {
   this->visualizer_->Publish(vis_context);
 
   /* Confirm that messages were sent.  */
-  MessageResults results = this->ProcessMessages();
+  MessageResults results = this->ProcessMessages(params.role);
   ASSERT_EQ(results.num_load, 1);
   ASSERT_EQ(results.load_message.num_links, 5);
 
@@ -1099,7 +1123,7 @@ TYPED_TEST(DrakeVisualizerTest, DispatchLoadMessageFromModel) {
     params.role = Role::kProximity;
     DrakeVisualizer<T>::DispatchLoadMessage(*(this->scene_graph_),
                                             &(this->lcm_), params);
-    MessageResults results = this->ProcessMessages();
+    MessageResults results = this->ProcessMessages(params.role);
     ASSERT_EQ(results.num_load, 1);
     ASSERT_EQ(results.load_message.num_links, 1);
     ASSERT_EQ(results.load_message.link[0].name,

--- a/manipulation/util/show_model.py
+++ b/manipulation/util/show_model.py
@@ -60,6 +60,7 @@ from pydrake.common import FindResourceOrThrow
 from pydrake.geometry import (
     Cylinder,
     DrakeVisualizer,
+    DrakeVisualizerParams,
     GeometryInstance,
     MakePhongIllustrationProperties,
     Meshcat,
@@ -313,6 +314,10 @@ def parse_visualizers(args_parser, args):
     def connect_visualizers(builder, plant, scene_graph):
         # Connect this to drake_visualizer.
         DrakeVisualizer.AddToBuilder(builder=builder, scene_graph=scene_graph)
+        params = DrakeVisualizerParams()
+        params.role = Role.kProximity
+        DrakeVisualizer.AddToBuilder(builder=builder, scene_graph=scene_graph,
+                                     params=params)
 
         # Connect to Meshcat.  If the consuming application needs to connect,
         # e.g., JointSliders, the meshcat instance is required.


### PR DESCRIPTION
Relevant to: #13673

This patch enables multi-role simultaneous visualization using
DrakeVisualizer systems, meldis, and meshcat. It ports some example
programs to use the new feature.

Summary of changes:

 * DrakeVisualizer uses per-role LCM channel names
 * Meldis:
   * receives illustration and proximity role channels
   * adds per-role transparency sliders to meshcat
 * Ported programs:
   * jaco_simulation
   * show_model.py
 * Adjusted tests