### PR TITLE
[meshcat]: Adds hydroelastic contact surface to meshcat visualization

### DIFF
--- a/bindings/pydrake/multibody/meshcat_py.cc
+++ b/bindings/pydrake/multibody/meshcat_py.cc
@@ -74,14 +74,19 @@ void DoScalarIndependentDefinitions(py::module m) {
     py::class_<Class>(m, "_HydroelasticContactVisualizerItem",
         py::dynamic_attr(), doc_internal)
         .def(py::init<std::string, std::string, Eigen::Vector3d,
-                 Eigen::Vector3d, Eigen::Vector3d>(),
+                 Eigen::Vector3d, Eigen::Vector3d, Eigen::Matrix3Xd,
+                 Eigen::Matrix3Xi, Eigen::VectorXd>(),
             py::arg("body_A"), py::arg("body_B"), py::arg("centroid_W"),
-            py::arg("force_C_W"), py::arg("moment_C_W"), doc_internal)
+            py::arg("force_C_W"), py::arg("moment_C_W"), py::arg("p_WV"),
+            py::arg("faces"), py::arg("pressure"), doc_internal)
         .def_readwrite("body_A", &Class::body_A, doc_internal)
         .def_readwrite("body_B", &Class::body_B, doc_internal)
         .def_readwrite("centroid_W", &Class::centroid_W, doc_internal)
         .def_readwrite("force_C_W", &Class::force_C_W, doc_internal)
-        .def_readwrite("moment_C_W", &Class::moment_C_W, doc_internal);
+        .def_readwrite("moment_C_W", &Class::moment_C_W, doc_internal)
+        .def_readwrite("p_WV", &Class::p_WV, doc_internal)
+        .def_readwrite("faces", &Class::faces, doc_internal)
+        .def_readwrite("pressure", &Class::pressure, doc_internal);
   }
 
   // HydroelasticContactVisualizer (internal)

--- a/bindings/pydrake/visualization/meldis.py
+++ b/bindings/pydrake/visualization/meldis.py
@@ -268,7 +268,7 @@ class _ContactApplet:
             for i in range(1, ci-1):
                 v1 = poly_data[p0 + i]
                 v2 = poly_data[p0 + i+1]
-            faces.append([v0, v1, v2])
+                faces.append([v0, v1, v2])
             poly_index += ci + 1
         return np.array(faces).transpose()
 

--- a/bindings/pydrake/visualization/meldis.py
+++ b/bindings/pydrake/visualization/meldis.py
@@ -296,7 +296,6 @@ class _ContactApplet:
                 contact_point=lcm_item.contact_point))
         self._point_helper.Update(viz_items)
 
-
         # Handle hydroelastic contact pairs
         viz_items = []
         for lcm_item in message.hydroelastic_contacts:

--- a/bindings/pydrake/visualization/meldis.py
+++ b/bindings/pydrake/visualization/meldis.py
@@ -325,6 +325,8 @@ class _ContactApplet:
         viz_items = []
         for lcm_item in message.hydroelastic_contacts:
             (name1, name2) = self.get_full_names(lcm_item)
+            print("name1: {}", name1)
+            print("name2: {}", name2)
             viz_items.append(_HydroelasticContactVisualizerItem(
                 body_A=name1,
                 body_B=name2,

--- a/bindings/pydrake/visualization/meldis.py
+++ b/bindings/pydrake/visualization/meldis.py
@@ -325,8 +325,6 @@ class _ContactApplet:
         viz_items = []
         for lcm_item in message.hydroelastic_contacts:
             (name1, name2) = self.get_full_names(lcm_item)
-            print("name1: {}", name1)
-            print("name2: {}", name2)
             viz_items.append(_HydroelasticContactVisualizerItem(
                 body_A=name1,
                 body_B=name2,

--- a/bindings/pydrake/visualization/test/meldis_test.py
+++ b/bindings/pydrake/visualization/test/meldis_test.py
@@ -128,6 +128,7 @@ class TestMeldis(unittest.TestCase):
         # Process the load + draw; make sure the geometry exists now.
         lcm.HandleSubscriptions(timeout_millis=0)
         dut._invoke_subscriptions()
+
         self.assertEqual(meshcat.HasPath(pair_path), True)
 
     def test_contact_applet_hydroelastic(self):
@@ -156,7 +157,7 @@ class TestMeldis(unittest.TestCase):
             frame_on_child=body2.body_frame(), axis=[1, 0, 0]))
         plant.Finalize()
         ConnectContactResultsToDrakeVisualizer(
-            builder=builder, plant=plant, scene_graph=scene_graph)#, lcm=lcm)
+            builder=builder, plant=plant, scene_graph=scene_graph, lcm=lcm)
         diagram = builder.Build()
         context = diagram.CreateDefaultContext()
         plant.SetPositions(plant.GetMyMutableContextFromRoot(context),
@@ -164,8 +165,10 @@ class TestMeldis(unittest.TestCase):
         diagram.Publish(context)
 
         # The geometry isn't registered until the load is processed.
-        hydro_path = "/CONTACT_RESULTS/hydroelastic/body1.two_bodies::body1_collision+body2"
-        hydro_path2 = "/CONTACT_RESULTS/hydroelastic/body1.two_bodies::body1_collision2+body2"
+        hydro_path = "/CONTACT_RESULTS/hydroelastic/" + \
+                     "body1.two_bodies::body1_collision+body2"
+        hydro_path2 = "/CONTACT_RESULTS/hydroelastic/" + \
+                      "body1.two_bodies::body1_collision2+body2"
         self.assertEqual(meshcat.HasPath(hydro_path), False)
         self.assertEqual(meshcat.HasPath(hydro_path2), False)
 
@@ -173,6 +176,7 @@ class TestMeldis(unittest.TestCase):
         lcm.HandleSubscriptions(timeout_millis=0)
         dut._invoke_subscriptions()
 
-        self.assertEqual(meshcat.HasPath("/CONTACT_RESULTS/hydroelastic"), True)
+        self.assertEqual(meshcat.HasPath("/CONTACT_RESULTS/hydroelastic"),
+                         True)
         self.assertEqual(meshcat.HasPath(hydro_path), True)
         self.assertEqual(meshcat.HasPath(hydro_path2), True)

--- a/bindings/pydrake/visualization/test/meldis_test.py
+++ b/bindings/pydrake/visualization/test/meldis_test.py
@@ -173,7 +173,7 @@ class TestMeldis(unittest.TestCase):
         self.assertEqual(meshcat.HasPath(hydro_path2), False)
 
         # Process the load + draw; contact results should now exist.
-        lcm.HandleSubscriptions(timeout_millis=0)
+        lcm.HandleSubscriptions(timeout_millis=1)
         dut._invoke_subscriptions()
 
         self.assertEqual(meshcat.HasPath("/CONTACT_RESULTS/hydroelastic"),

--- a/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
+++ b/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
@@ -161,7 +161,6 @@ int DoMain() {
   const math::RigidTransform<double> X_WF0 = math::RigidTransform<double>(
       math::RollPitchYaw(0.0, -1.57, 0.0), Eigen::Vector3d(0, 0, 0.25));
   plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("gripper"), X_WF0);
-  plant.set_contact_surface_representation(geometry::HydroelasticContactRepresentation::kTriangle);
   plant.Finalize();
 
   // Construct the open loop square wave controller. To oscillate around a

--- a/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
+++ b/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
@@ -161,6 +161,7 @@ int DoMain() {
   const math::RigidTransform<double> X_WF0 = math::RigidTransform<double>(
       math::RollPitchYaw(0.0, -1.57, 0.0), Eigen::Vector3d(0, 0, 0.25));
   plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("gripper"), X_WF0);
+  plant.set_contact_surface_representation(geometry::HydroelasticContactRepresentation::kTriangle);
   plant.Finalize();
 
   // Construct the open loop square wave controller. To oscillate around a

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -509,8 +509,6 @@ drake_cc_binary(
     deps = [
         ":meshcat",
         ":meshcat_visualizer",
-        ":drake_visualizer",
-        "//multibody/plant:contact_results_to_lcm",
         "//multibody/meshcat:contact_visualizer",
         "//multibody/parsing",
         "//multibody/plant",

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -509,6 +509,8 @@ drake_cc_binary(
     deps = [
         ":meshcat",
         ":meshcat_visualizer",
+        ":drake_visualizer",
+        "//multibody/plant:contact_results_to_lcm",
         "//multibody/meshcat:contact_visualizer",
         "//multibody/parsing",
         "//multibody/plant",

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -503,6 +503,7 @@ drake_cc_binary(
         "//geometry/render:test_models",
         "//manipulation/models/iiwa_description:models",
         "//manipulation/models/ycb:models",
+        "//multibody/meshcat:models",
     ],
     visibility = ["//visibility:private"],
     deps = [

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -923,6 +923,7 @@ class Meshcat::Impl {
     material->wireframe = wireframe;
     material->wireframeLineWidth = wireframe_line_width;
     material->vertexColors = true;
+    material->side = internal::kDoubleSide;
     data.object.material = std::move(material);
 
     internal::MeshData mesh;

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -895,6 +895,52 @@ class Meshcat::Impl {
   }
 
   // This function is public via the PIMPL.
+  void SetTriangleMesh(std::string_view path,
+                       const Eigen::Ref<const Eigen::Matrix3Xd>& vertices,
+                       const Eigen::Ref<const Eigen::Matrix3Xi>& faces,
+                       const Rgba& rgba, bool wireframe,
+                       double wireframe_line_width) {
+    DRAKE_DEMAND(IsThread(main_thread_id_));
+
+    uuids::uuid_random_generator uuid_generator{generator_};
+    internal::SetObjectData data;
+    data.path = FullPath(path);
+
+    auto geometry = std::make_unique<internal::BufferGeometryData>();
+    geometry->uuid = uuids::to_string(uuid_generator());
+    geometry->position = vertices.cast<float>();
+    geometry->faces = faces.cast<uint32_t>();
+    data.object.geometry = std::move(geometry);
+
+    auto material = std::make_unique<internal::MaterialData>();
+    material->uuid = uuids::to_string(uuid_generator());
+    material->type = "MeshPhongMaterial";
+    material->color = ToMeshcatColor(rgba);
+    material->transparent = (rgba.a() != 1.0);
+    material->opacity = rgba.a();
+    material->wireframe = wireframe;
+    material->wireframeLineWidth = wireframe_line_width;
+    material->vertexColors = false;
+    data.object.material = std::move(material);
+
+    internal::MeshData mesh;
+    mesh.uuid = uuids::to_string(uuid_generator());
+    mesh.type = "Mesh";
+    mesh.geometry = data.object.geometry->uuid;
+    mesh.material = data.object.material->uuid;
+    data.object.object = std::move(mesh);
+
+    Defer([this, data = std::move(data)]() {
+      std::stringstream message_stream;
+      msgpack::pack(message_stream, data);
+      std::string message = message_stream.str();
+      app_->publish("all", message, uWS::OpCode::BINARY, false);
+      SceneTreeElement& e = scene_tree_root_[data.path];
+      e.object() = std::move(message);
+    });
+  }
+
+  // This function is public via the PIMPL.
   void SetTriangleColorMesh(std::string_view path,
                        const Eigen::Ref<const Eigen::Matrix3Xd>& vertices,
                        const Eigen::Ref<const Eigen::Matrix3Xi>& faces,
@@ -923,52 +969,6 @@ class Meshcat::Impl {
     material->wireframeLineWidth = wireframe_line_width;
     material->vertexColors = true;
     material->side = internal::kDoubleSide;
-    data.object.material = std::move(material);
-
-    internal::MeshData mesh;
-    mesh.uuid = uuids::to_string(uuid_generator());
-    mesh.type = "Mesh";
-    mesh.geometry = data.object.geometry->uuid;
-    mesh.material = data.object.material->uuid;
-    data.object.object = std::move(mesh);
-
-    Defer([this, data = std::move(data)]() {
-      std::stringstream message_stream;
-      msgpack::pack(message_stream, data);
-      std::string message = message_stream.str();
-      app_->publish("all", message, uWS::OpCode::BINARY, false);
-      SceneTreeElement& e = scene_tree_root_[data.path];
-      e.object() = std::move(message);
-    });
-  }
-
-  // This function is public via the PIMPL.
-  void SetTriangleMesh(std::string_view path,
-                       const Eigen::Ref<const Eigen::Matrix3Xd>& vertices,
-                       const Eigen::Ref<const Eigen::Matrix3Xi>& faces,
-                       const Rgba& rgba, bool wireframe,
-                       double wireframe_line_width) {
-    DRAKE_DEMAND(IsThread(main_thread_id_));
-
-    uuids::uuid_random_generator uuid_generator{generator_};
-    internal::SetObjectData data;
-    data.path = FullPath(path);
-
-    auto geometry = std::make_unique<internal::BufferGeometryData>();
-    geometry->uuid = uuids::to_string(uuid_generator());
-    geometry->position = vertices.cast<float>();
-    geometry->faces = faces.cast<uint32_t>();
-    data.object.geometry = std::move(geometry);
-
-    auto material = std::make_unique<internal::MaterialData>();
-    material->uuid = uuids::to_string(uuid_generator());
-    material->type = "MeshPhongMaterial";
-    material->color = ToMeshcatColor(rgba);
-    material->transparent = (rgba.a() != 1.0);
-    material->opacity = rgba.a();
-    material->wireframe = wireframe;
-    material->wireframeLineWidth = wireframe_line_width;
-    material->vertexColors = false;
     data.object.material = std::move(material);
 
     internal::MeshData mesh;

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -917,7 +917,6 @@ class Meshcat::Impl {
     auto material = std::make_unique<internal::MaterialData>();
     material->uuid = uuids::to_string(uuid_generator());
     material->type = "MeshPhongMaterial";
-    //material->color = ToMeshcatColor(rgba);
     material->transparent = false;
     material->opacity = 1.0;
     material->wireframe = wireframe;

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -271,6 +271,13 @@ class Meshcat {
                        bool wireframe = false,
                        double wireframe_line_width = 1.0);
 
+  void SetTriangleColorMesh(std::string_view path,
+                       const Eigen::Ref<const Eigen::Matrix3Xd>& vertices,
+                       const Eigen::Ref<const Eigen::Matrix3Xi>& faces,
+                       const Eigen::Ref<const Eigen::Matrix3Xd>& colors,
+                       bool wireframe = false,
+                       double wireframe_line_width = 1.0);
+
   // TODO(russt): Provide a more general SetObject(std::string_view path,
   // msgpack::object object) that would allow users to pass through anything
   // that meshcat.js / three.js can handle.  Possible this could use

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -254,7 +254,7 @@ class Meshcat {
               @ref meshcat_path "Meshcat paths" for the semantics.
   @param vertices is a 3-by-N matrix of 3D point defining the vertices of the
                   mesh.
-  @param faces is a 3-by-N integer matrix with each entry denoting an index
+  @param faces is a 3-by-M integer matrix with each entry denoting an index
                into vertices and each column denoting one face (aka
                SurfaceTriangle).
   @param rgba is the mesh face or wireframe color.
@@ -271,13 +271,13 @@ class Meshcat {
                        double wireframe_line_width = 1.0);
 
   /** Sets the "object" at `path` in the scene tree to a triangular mesh with
-   *  per-vertex coloring.
+      per-vertex coloring.
 
   @param path a "/"-delimited string indicating the path in the scene tree. See
               @ref meshcat_path "Meshcat paths" for the semantics.
   @param vertices is a 3-by-N matrix of 3D point defining the vertices of the
                   mesh.
-  @param faces is a 3-by-N integer matrix with each entry denoting an index
+  @param faces is a 3-by-M integer matrix with each entry denoting an index
                into vertices and each column denoting one face (aka
                SurfaceTriangle).
   @param colors is a 3-by-N matrix of color values, one color per vertex of the

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -248,7 +248,6 @@ class Meshcat {
                        double line_width = 1.0,
                        const Rgba& rgba = Rgba(0.1, 0.1, 0.1, 1.0));
 
-  // TODO(russt): Support per-vertex coloring (maybe rgba as std::variant).
   /** Sets the "object" at `path` in the scene tree to a triangular mesh.
 
   @param path a "/"-delimited string indicating the path in the scene tree. See
@@ -271,6 +270,23 @@ class Meshcat {
                        bool wireframe = false,
                        double wireframe_line_width = 1.0);
 
+  /** Sets the "object" at `path` in the scene tree to a triangular mesh with
+   *  per-vertex coloring.
+
+  @param path a "/"-delimited string indicating the path in the scene tree. See
+              @ref meshcat_path "Meshcat paths" for the semantics.
+  @param vertices is a 3-by-N matrix of 3D point defining the vertices of the
+                  mesh.
+  @param faces is a 3-by-N integer matrix with each entry denoting an index
+               into vertices and each column denoting one face (aka
+               SurfaceTriangle).
+  @param colors is a 3-by-N matrix of color values, one color per vertex of the
+                mesh.
+  @param wireframe if "true", then only the triangle edges are visualized, not
+                   the faces.
+  @param wireframe_line_width is the width in pixels.  Due to limitations in
+                              WebGL implementations, the line width may be 1
+                              regardless of the set value. */
   void SetTriangleColorMesh(std::string_view path,
                        const Eigen::Ref<const Eigen::Matrix3Xd>& vertices,
                        const Eigen::Ref<const Eigen::Matrix3Xi>& faces,

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -238,7 +238,7 @@ Open up your browser to the URL above.
     const auto& body2 = plant.GetBodyByName("body2");
     plant.AddJoint<multibody::PrismaticJoint>("body2", plant.world_body(),
                                               std::nullopt, body2, std::nullopt,
-                                              Eigen::Vector3d::UnitZ());
+                                              Eigen::Vector3d::UnitX());
 
     plant.Finalize();
 
@@ -256,7 +256,7 @@ Open up your browser to the URL above.
     auto context = diagram->CreateDefaultContext();
 
     plant.SetPositions(&plant.GetMyMutableContextFromRoot(context.get()),
-                       Eigen::Vector2d{-0.05, 0.1});
+                       Eigen::Vector2d{0.1, 0.2});
     diagram->Publish(*context);
     std::cout << "- Now you should see two colliding hydroelastic spheres."
               << std::endl;

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -268,68 +268,67 @@ Open up your browser to the URL above.
   }
 
   {
-  systems::DiagramBuilder<double> builder;
-  auto [plant, scene_graph] =
-      multibody::AddMultibodyPlantSceneGraph(&builder, 0.001);
-  multibody::Parser parser(&plant);
-  parser.AddModelFromFile(
-      FindResourceOrThrow("drake/manipulation/models/iiwa_description/urdf/"
-                          "iiwa14_spheres_collision.urdf"));
-  plant.WeldFrames(plant.world_frame(),
-                   plant.GetFrameByName("base"));
-  parser.AddModelFromFile(
-      FindResourceOrThrow("drake/examples/kuka_iiwa_arm/models/table/"
-                          "extra_heavy_duty_table_surface_only_collision.sdf"));
-  const double table_height = 0.7645;
-  plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("link"),
-                   RigidTransformd(Vector3d{0, 0, -table_height-.01}));
-  plant.Finalize();
+    systems::DiagramBuilder<double> builder;
+    auto [plant, scene_graph] =
+        multibody::AddMultibodyPlantSceneGraph(&builder, 0.001);
+    multibody::Parser parser(&plant);
+    parser.AddModelFromFile(
+        FindResourceOrThrow("drake/manipulation/models/iiwa_description/urdf/"
+                            "iiwa14_spheres_collision.urdf"));
+    plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("base"));
+    parser.AddModelFromFile(FindResourceOrThrow(
+        "drake/examples/kuka_iiwa_arm/models/table/"
+        "extra_heavy_duty_table_surface_only_collision.sdf"));
+    const double table_height = 0.7645;
+    plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("link"),
+                     RigidTransformd(Vector3d{0, 0, -table_height - .01}));
+    plant.Finalize();
 
-  builder.ExportInput(plant.get_actuation_input_port(), "actuation_input");
-  MeshcatVisualizerParams params;
-  params.delete_on_initialization_event = false;
-  auto& visualizer = MeshcatVisualizerd::AddToBuilder(
-      &builder, scene_graph, meshcat, std::move(params));
+    builder.ExportInput(plant.get_actuation_input_port(), "actuation_input");
+    MeshcatVisualizerParams params;
+    params.delete_on_initialization_event = false;
+    auto& visualizer = MeshcatVisualizerd::AddToBuilder(
+        &builder, scene_graph, meshcat, std::move(params));
 
-  multibody::meshcat::ContactVisualizerParams cparams;
-  cparams.newtons_per_meter = 60.0;
-  auto& contact = multibody::meshcat::ContactVisualizerd::AddToBuilder(
-      &builder, plant, meshcat, std::move(cparams));
+    multibody::meshcat::ContactVisualizerParams cparams;
+    cparams.newtons_per_meter = 60.0;
+    auto& contact = multibody::meshcat::ContactVisualizerd::AddToBuilder(
+        &builder, plant, meshcat, std::move(cparams));
 
-  auto diagram = builder.Build();
-  auto context = diagram->CreateDefaultContext();
-  diagram->get_input_port().FixValue(context.get(), Eigen::VectorXd::Zero(7));
+    auto diagram = builder.Build();
+    auto context = diagram->CreateDefaultContext();
+    diagram->get_input_port().FixValue(context.get(), Eigen::VectorXd::Zero(7));
 
-  diagram->Publish(*context);
-  std::cout
-      << "- Now you should see a kuka model (from MultibodyPlant/SceneGraph)"
-      << std::endl;
+    diagram->Publish(*context);
+    std::cout
+        << "- Now you should see a kuka model (from MultibodyPlant/SceneGraph)"
+        << std::endl;
 
-  std::cout << "[Press RETURN to continue]." << std::endl;
-  std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    std::cout << "[Press RETURN to continue]." << std::endl;
+    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
-  std::cout << "Now we'll run the simulation...\n"
-            << "- You should see the robot fall down and hit the table\n"
-            << "- You should see the contact force vectors (when it hits)\n"
-            << "- You will also see large forces near the wrist until we "
-               "resolve #15965\n"
-            << std::endl;
+    std::cout << "Now we'll run the simulation...\n"
+              << "- You should see the robot fall down and hit the table\n"
+              << "- You should see the contact force vectors (when it hits)\n"
+              << "- You will also see large forces near the wrist until we "
+                 "resolve #15965\n"
+              << std::endl;
 
-  systems::Simulator<double> simulator(*diagram, std::move(context));
-  simulator.set_target_realtime_rate(1.0);
-  visualizer.StartRecording();
-  simulator.AdvanceTo(4.0);
-  visualizer.PublishRecording();
-  contact.Delete();
+    systems::Simulator<double> simulator(*diagram, std::move(context));
+    simulator.set_target_realtime_rate(1.0);
+    visualizer.StartRecording();
+    simulator.AdvanceTo(4.0);
+    visualizer.PublishRecording();
+    contact.Delete();
 
-  std::cout << "The recorded simulation results should now be available as an "
-               "animation.  Use the animation GUI to confirm.  The contact "
-               "forces are not recorded (yet)."
-            << std::endl;
+    std::cout
+        << "The recorded simulation results should now be available as an "
+           "animation.  Use the animation GUI to confirm.  The contact "
+           "forces are not recorded (yet)."
+        << std::endl;
 
-  std::cout << "[Press RETURN to continue]." << std::endl;
-  std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-
+    std::cout << "[Press RETURN to continue]." << std::endl;
+    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
   }
 
   const std::string html_filename(temp_directory() + "/meshcat_static.html");

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -239,7 +239,6 @@ Open up your browser to the URL above.
     plant.AddJoint<multibody::PrismaticJoint>("body2", plant.world_body(),
                                               std::nullopt, body2, std::nullopt,
                                               Eigen::Vector3d::UnitX());
-
     plant.Finalize();
 
     MeshcatVisualizerParams params;
@@ -256,9 +255,9 @@ Open up your browser to the URL above.
     auto context = diagram->CreateDefaultContext();
 
     plant.SetPositions(&plant.GetMyMutableContextFromRoot(context.get()),
-                       Eigen::Vector2d{0.1, 0.2});
+                       Eigen::Vector2d{0.1, 0.3});
     diagram->Publish(*context);
-    std::cout << "- Now you should see two colliding hydroelastic spheres."
+    std::cout << "- Now you should see three colliding hydroelastic spheres."
               << std::endl;
     std::cout << "[Press RETURN to continue]." << std::endl;
     std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -17,9 +17,6 @@
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/systems/analysis/simulator.h"
 
-#include "drake/geometry/drake_visualizer.h"
-#include "drake/multibody/plant/contact_results_to_lcm.h"
-
 /* To test, you must manually run `bazel run //geometry:meshcat_manual_test`,
 then follow the instructions on your console. */
 
@@ -248,9 +245,6 @@ Open up your browser to the URL above.
     params.delete_on_initialization_event = false;
     auto& visualizer = MeshcatVisualizerd::AddToBuilder(
         &builder, scene_graph, meshcat, std::move(params));
-
-    DrakeVisualizerd::AddToBuilder(&builder, scene_graph);
-    ConnectContactResultsToDrakeVisualizer(&builder, plant, scene_graph);
 
     multibody::meshcat::ContactVisualizerParams cparams;
     cparams.newtons_per_meter = 60.0;

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -17,6 +17,9 @@
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/systems/analysis/simulator.h"
 
+#include "drake/geometry/drake_visualizer.h"
+#include "drake/multibody/plant/contact_results_to_lcm.h"
+
 /* To test, you must manually run `bazel run //geometry:meshcat_manual_test`,
 then follow the instructions on your console. */
 
@@ -245,6 +248,9 @@ Open up your browser to the URL above.
     params.delete_on_initialization_event = false;
     auto& visualizer = MeshcatVisualizerd::AddToBuilder(
         &builder, scene_graph, meshcat, std::move(params));
+
+    DrakeVisualizerd::AddToBuilder(&builder, scene_graph);
+    ConnectContactResultsToDrakeVisualizer(&builder, plant, scene_graph);
 
     multibody::meshcat::ContactVisualizerParams cparams;
     cparams.newtons_per_meter = 60.0;

--- a/multibody/meshcat/BUILD.bazel
+++ b/multibody/meshcat/BUILD.bazel
@@ -49,7 +49,7 @@ drake_cc_library(
 
 drake_cc_googletest(
     name = "contact_visualizer_test",
-    size = "medium",
+    timeout = "moderate",
     data = [
         ":models",
         "//examples/manipulation_station:models",

--- a/multibody/meshcat/BUILD.bazel
+++ b/multibody/meshcat/BUILD.bazel
@@ -49,6 +49,7 @@ drake_cc_library(
 
 drake_cc_googletest(
     name = "contact_visualizer_test",
+    size = "medium",
     data = [
         ":models",
         "//examples/manipulation_station:models",

--- a/multibody/meshcat/contact_visualizer.cc
+++ b/multibody/meshcat/contact_visualizer.cc
@@ -240,7 +240,7 @@ void ContactVisualizer<T>::CalcHydroelasticContacts(
       result->emplace_back(std::move(body_A), std::move(body_B), centroid_W,
                            force_C_W, moment_C_W, vertices, faces, pressure);
     } else {
-      const auto& mesh = contact_surface.tri_mesh_W();
+      const auto& mesh = contact_surface.poly_mesh_W();
       Eigen::Matrix3Xd vertices(3, contact_surface.num_vertices());
       for (int i = 0; i < contact_surface.num_vertices(); ++i) {
         vertices.col(i) = ExtractDoubleOrThrow(mesh.vertex(i));

--- a/multibody/meshcat/contact_visualizer.cc
+++ b/multibody/meshcat/contact_visualizer.cc
@@ -217,9 +217,6 @@ void ContactVisualizer<T>::CalcHydroelasticContacts(
     Vector3d moment_C_W = ExtractDoubleOrThrow(info.F_Ac_W().rotational());
 
     if (contact_surface.is_triangle()) {
-
-      std::cout << "TRIANGLE\n";
-
       const auto& mesh = contact_surface.tri_mesh_W();
 
       Eigen::Matrix3Xd vertices(3, contact_surface.num_vertices());
@@ -255,15 +252,14 @@ void ContactVisualizer<T>::CalcHydroelasticContacts(
       }
 
       Eigen::Matrix3Xi faces(3, num_triangles);
-      int x = 0;
+      int face_count = 0;
       for (int i = 0; i < mesh.num_elements(); ++i) {
         const auto& e = mesh.element(i);
         for (int j = 1; j < e.num_vertices()-1; ++j) {
-          const int k = j + 1;
-          faces(0, x) = e.vertex(0);
-          faces(1, x) = e.vertex(j);
-          faces(2, x) = e.vertex(k);
-          ++x;
+          faces(0, face_count) = e.vertex(0);
+          faces(1, face_count) = e.vertex(j);
+          faces(2, face_count) = e.vertex(j+1);
+          ++face_count;
         }
       }
 
@@ -275,7 +271,8 @@ void ContactVisualizer<T>::CalcHydroelasticContacts(
       const Eigen::VectorXd pressure = ExtractDoubleOrThrow(pressure_T);
 
       result->emplace_back(std::move(body_A), std::move(body_B), centroid_W,
-                           force_C_W, moment_C_W, vertices, faces, pressure);
+                           force_C_W, moment_C_W, std::move(vertices),
+                           std::move(faces), std::move(pressure));
     }
   }
 }

--- a/multibody/meshcat/contact_visualizer.cc
+++ b/multibody/meshcat/contact_visualizer.cc
@@ -252,14 +252,14 @@ void ContactVisualizer<T>::CalcHydroelasticContacts(
       }
 
       Eigen::Matrix3Xi faces(3, num_triangles);
-      int face_count = 0;
+      int f_index = 0;
       for (int i = 0; i < mesh.num_elements(); ++i) {
         const auto& e = mesh.element(i);
-        for (int j = 1; j < e.num_vertices()-1; ++j) {
-          faces(0, face_count) = e.vertex(0);
-          faces(1, face_count) = e.vertex(j);
-          faces(2, face_count) = e.vertex(j+1);
-          ++face_count;
+        for (int j = 1; j < e.num_vertices() - 1; ++j) {
+          faces(0, f_index) = e.vertex(0);
+          faces(1, f_index) = e.vertex(j);
+          faces(2, f_index) = e.vertex(j + 1);
+          ++f_index;
         }
       }
 

--- a/multibody/meshcat/contact_visualizer.cc
+++ b/multibody/meshcat/contact_visualizer.cc
@@ -217,6 +217,9 @@ void ContactVisualizer<T>::CalcHydroelasticContacts(
     Vector3d moment_C_W = ExtractDoubleOrThrow(info.F_Ac_W().rotational());
 
     if (contact_surface.is_triangle()) {
+
+      std::cout << "TRIANGLE\n";
+
       const auto& mesh = contact_surface.tri_mesh_W();
 
       Eigen::Matrix3Xd vertices(3, contact_surface.num_vertices());

--- a/multibody/meshcat/contact_visualizer.cc
+++ b/multibody/meshcat/contact_visualizer.cc
@@ -19,10 +19,10 @@ using Eigen::Vector3d;
 using geometry::GeometryId;
 using geometry::Meshcat;
 using geometry::QueryObject;
-using meshcat::internal::PointContactVisualizer;
-using meshcat::internal::PointContactVisualizerItem;
 using meshcat::internal::HydroelasticContactVisualizer;
 using meshcat::internal::HydroelasticContactVisualizerItem;
+using meshcat::internal::PointContactVisualizer;
+using meshcat::internal::PointContactVisualizerItem;
 using multibody::internal::GeometryNames;
 using systems::CacheEntry;
 using systems::Context;
@@ -35,8 +35,8 @@ using systems::System;
 using systems::ValueProducer;
 
 template <typename T>
-ContactVisualizer<T>::ContactVisualizer(
-    std::shared_ptr<Meshcat> meshcat, ContactVisualizerParams params)
+ContactVisualizer<T>::ContactVisualizer(std::shared_ptr<Meshcat> meshcat,
+                                        ContactVisualizerParams params)
     : systems::LeafSystem<T>(systems::SystemTypeTag<ContactVisualizer>{}),
       meshcat_(std::move(meshcat)),
       params_(std::move(params)) {
@@ -67,13 +67,13 @@ ContactVisualizer<T>::ContactVisualizer(
       "contact_results", Value<ContactResults<T>>());
   contact_results_input_port_ = contact_results.get_index();
 
-  const InputPort<T>& query_object = this->DeclareAbstractInputPort(
-      "query_object", Value<QueryObject<T>>());
+  const InputPort<T>& query_object =
+      this->DeclareAbstractInputPort("query_object", Value<QueryObject<T>>());
   query_object_input_port_ = query_object.get_index();
 
   const CacheEntry& geometry_names = this->DeclareCacheEntry(
-      "geometry_names", ValueProducer(
-          GeometryNames(), &ValueProducer::NoopCalc),
+      "geometry_names",
+      ValueProducer(GeometryNames(), &ValueProducer::NoopCalc),
       {this->nothing_ticket()});
   geometry_names_scratch_ = geometry_names.cache_index();
 
@@ -90,8 +90,7 @@ ContactVisualizer<T>::ContactVisualizer(
 
 template <typename T>
 template <typename U>
-ContactVisualizer<T>::ContactVisualizer(
-    const ContactVisualizer<U>& other)
+ContactVisualizer<T>::ContactVisualizer(const ContactVisualizer<U>& other)
     : ContactVisualizer(other.meshcat_, other.params_) {}
 
 template <typename T>
@@ -111,14 +110,13 @@ const ContactVisualizer<T>& ContactVisualizer<T>::AddToBuilder(
   DRAKE_THROW_UNLESS(builder != nullptr);
 
   // Delegate to another overload.
-  const auto& result = AddToBuilder(
-      builder, plant.get_contact_results_output_port(),
-      std::move(meshcat), std::move(params));
+  const auto& result =
+      AddToBuilder(builder, plant.get_contact_results_output_port(),
+                   std::move(meshcat), std::move(params));
 
   // Add the query connection (if the plant has a SceneGraph).
-  builder->ConnectToSame(
-      plant.get_geometry_query_input_port(),
-      result.query_object_input_port());
+  builder->ConnectToSame(plant.get_geometry_query_input_port(),
+                         result.query_object_input_port());
 
   return result;
 }
@@ -151,8 +149,8 @@ template <typename T>
 EventStatus ContactVisualizer<T>::UpdateMeshcat(
     const Context<T>& context) const {
   const auto& point_contacts =
-      this->get_cache_entry(point_contacts_cache_).
-      template Eval<std::vector<PointContactVisualizerItem>>(context);
+      this->get_cache_entry(point_contacts_cache_)
+          .template Eval<std::vector<PointContactVisualizerItem>>(context);
   point_visualizer_->Update(point_contacts);
 
   const auto& hydroelastic_contacts =
@@ -203,9 +201,9 @@ void ContactVisualizer<T>::CalcHydroelasticContacts(
   result->reserve(contact_results.num_hydroelastic_contacts());
 
   // Update our output vector of items.
-  for (int i = 0; i < contact_results.num_hydroelastic_contacts(); ++i) {
+  for (int ci = 0; ci < contact_results.num_hydroelastic_contacts(); ++ci) {
     const HydroelasticContactInfo<T>& info =
-        contact_results.hydroelastic_contact_info(i);
+        contact_results.hydroelastic_contact_info(ci);
 
     const geometry::ContactSurface<T>& contact_surface = info.contact_surface();
 
@@ -217,8 +215,65 @@ void ContactVisualizer<T>::CalcHydroelasticContacts(
     Vector3d centroid_W = ExtractDoubleOrThrow(contact_surface.centroid());
     Vector3d force_C_W = ExtractDoubleOrThrow(info.F_Ac_W().translational());
     Vector3d moment_C_W = ExtractDoubleOrThrow(info.F_Ac_W().rotational());
-    result->emplace_back(std::move(body_A), std::move(body_B), centroid_W,
-                       force_C_W, moment_C_W);
+
+    if (contact_surface.is_triangle()) {
+      const auto& mesh = contact_surface.tri_mesh_W();
+
+      Eigen::Matrix3Xd vertices(3, contact_surface.num_vertices());
+      for (int i = 0; i < contact_surface.num_vertices(); ++i) {
+        vertices.col(i) = ExtractDoubleOrThrow(mesh.vertex(i));
+      }
+      Eigen::Matrix3Xi faces(3, mesh.num_triangles());
+      for (int i = 0; i < mesh.num_triangles(); ++i) {
+        const auto& e = mesh.element(i);
+        for (int j = 0; j < 3; ++j) {
+          faces(j, i) = e.vertex(j);
+        }
+      }
+
+      const std::vector<T>& field_pressures =
+          contact_surface.tri_e_MN().values();
+      const VectorX<T> pressure_T =
+          Eigen::Map<const VectorX<T>, Eigen::Unaligned>(
+              field_pressures.data(), field_pressures.size());
+      const Eigen::VectorXd pressure = ExtractDoubleOrThrow(pressure_T);
+      result->emplace_back(std::move(body_A), std::move(body_B), centroid_W,
+                           force_C_W, moment_C_W, vertices, faces, pressure);
+    } else {
+      const auto& mesh = contact_surface.tri_mesh_W();
+      Eigen::Matrix3Xd vertices(3, contact_surface.num_vertices());
+      for (int i = 0; i < contact_surface.num_vertices(); ++i) {
+        vertices.col(i) = ExtractDoubleOrThrow(mesh.vertex(i));
+      }
+
+      int num_triangles = 0;
+      for (int i = 0; i < mesh.num_elements(); ++i) {
+        num_triangles += mesh.element(i).num_vertices() - 2;
+      }
+
+      Eigen::Matrix3Xi faces(3, num_triangles);
+      int x = 0;
+      for (int i = 0; i < mesh.num_elements(); ++i) {
+        const auto& e = mesh.element(i);
+        for (int j = 1; j < e.num_vertices()-1; ++j) {
+          const int k = j + 1;
+          faces(0, x) = e.vertex(0);
+          faces(1, x) = e.vertex(j);
+          faces(2, x) = e.vertex(k);
+          ++x;
+        }
+      }
+
+      const std::vector<T>& field_pressures =
+          contact_surface.poly_e_MN().values();
+      const VectorX<T> pressure_T =
+          Eigen::Map<const VectorX<T>, Eigen::Unaligned>(
+              field_pressures.data(), field_pressures.size());
+      const Eigen::VectorXd pressure = ExtractDoubleOrThrow(pressure_T);
+
+      result->emplace_back(std::move(body_A), std::move(body_B), centroid_W,
+                           force_C_W, moment_C_W, vertices, faces, pressure);
+    }
   }
 }
 
@@ -255,8 +310,7 @@ void ContactVisualizer<T>::CalcPointContacts(
 
 // N.B. This is only called if params_.delete_on_initialization_event was true.
 template <typename T>
-EventStatus ContactVisualizer<T>::OnInitialization(
-    const Context<T>&) const {
+EventStatus ContactVisualizer<T>::OnInitialization(const Context<T>&) const {
   Delete();
   return EventStatus::Succeeded();
 }

--- a/multibody/meshcat/hydroelastic_contact_visualizer.cc
+++ b/multibody/meshcat/hydroelastic_contact_visualizer.cc
@@ -109,6 +109,25 @@ void HydroelasticContactVisualizer::Update(
           RigidTransformd(RotationMatrixd::MakeXRotation(M_PI),
                           Vector3d{0, 0, height + arrowhead_height}));
     }
+
+    // Contact surface
+    {
+      double min_pressure = item.pressure.minCoeff();
+      double max_pressure = item.pressure.maxCoeff();
+
+      Eigen::Matrix3Xd colors(3, item.pressure.size());
+      for (int i = 0; i < item.pressure.size(); ++i) {
+        colors(0, i) = std::sqrt((item.pressure[i] - min_pressure) / max_pressure);
+        colors(1, i) = 0.0;
+        colors(2, i) = 0.0;
+      }
+
+      meshcat_->SetTriangleColorMesh(path + "/contact_surface", item.p_WV,
+                                item.faces, colors,
+                                true, 2.0);
+      meshcat_->SetTransform(path + "/contact_surface",
+                             RigidTransformd(-item.centroid_W));
+    }
   }
 
   // Update meshcat visibility to match the active status.

--- a/multibody/meshcat/hydroelastic_contact_visualizer.cc
+++ b/multibody/meshcat/hydroelastic_contact_visualizer.cc
@@ -51,6 +51,8 @@ void HydroelasticContactVisualizer::Update(
     const std::string path =
         fmt::format("{}/{}+{}", params_.prefix, item.body_A, item.body_B);
 
+    std::cout << "path: " << path << "\n";
+
     VisibilityStatus& status = FindOrAdd(path);
 
     // Decide whether the contact should be shown.

--- a/multibody/meshcat/hydroelastic_contact_visualizer.cc
+++ b/multibody/meshcat/hydroelastic_contact_visualizer.cc
@@ -1,7 +1,7 @@
 #include "drake/multibody/meshcat/hydroelastic_contact_visualizer.h"
 
-#include <utility>
 #include <algorithm>
+#include <utility>
 
 #include <fmt/format.h>
 

--- a/multibody/meshcat/hydroelastic_contact_visualizer.cc
+++ b/multibody/meshcat/hydroelastic_contact_visualizer.cc
@@ -117,15 +117,20 @@ void HydroelasticContactVisualizer::Update(
 
       Eigen::Matrix3Xd colors(3, item.pressure.size());
       for (int i = 0; i < item.pressure.size(); ++i) {
-        colors(0, i) = std::sqrt((item.pressure[i] - min_pressure) / max_pressure);
+        colors(0, i) =
+            std::sqrt((item.pressure[i] - min_pressure) / max_pressure);
         colors(1, i) = 0.0;
         colors(2, i) = 0.0;
       }
 
       meshcat_->SetTriangleColorMesh(path + "/contact_surface", item.p_WV,
-                                item.faces, colors,
-                                true, 2.0);
+                                     item.faces, colors, false);
       meshcat_->SetTransform(path + "/contact_surface",
+                             RigidTransformd(-item.centroid_W));
+      meshcat_->SetTriangleMesh(path + "/contact_surface_wireframe", item.p_WV,
+                                item.faces, geometry::Rgba(1.0, 1.0, 1.0, 1.0),
+                                true);
+      meshcat_->SetTransform(path + "/contact_surface_wireframe",
                              RigidTransformd(-item.centroid_W));
     }
   }

--- a/multibody/meshcat/hydroelastic_contact_visualizer.h
+++ b/multibody/meshcat/hydroelastic_contact_visualizer.h
@@ -17,21 +17,30 @@ namespace internal {
 /* Like multibody::HydroelasticContactInfo, but only the visualization info.
    TODO(joemasterjohn): Add the mesh geometry and pressure values. */
 struct HydroelasticContactVisualizerItem {
-  HydroelasticContactVisualizerItem(std::string body_A_, std::string body_B_,
-                                    const Eigen::Vector3d& centroid_W_,
-                                    const Eigen::Vector3d& force_C_W_,
-                                    const Eigen::Vector3d& moment_C_W_)
+  HydroelasticContactVisualizerItem(
+      std::string body_A_, std::string body_B_,
+      const Eigen::Vector3d& centroid_W_, const Eigen::Vector3d& force_C_W_,
+      const Eigen::Vector3d& moment_C_W_,
+      const Eigen::Matrix3Xd& p_WV_,
+      const Eigen::Matrix3Xi& faces_,
+      const Eigen::VectorXd& pressure_)
       : body_A(std::move(body_A_)),
         body_B(std::move(body_B_)),
         centroid_W(centroid_W_),
         force_C_W(force_C_W_),
-        moment_C_W(moment_C_W_) {}
+        moment_C_W(moment_C_W_),
+        p_WV(p_WV_),
+        faces(faces_),
+        pressure(pressure_) {}
 
   std::string body_A;
   std::string body_B;
   Eigen::Vector3d centroid_W;
   Eigen::Vector3d force_C_W;
   Eigen::Vector3d moment_C_W;
+  Eigen::Matrix3Xd p_WV;
+  Eigen::Matrix3Xi faces;
+  Eigen::VectorXd pressure;
 };
 
 /* HydroelasticContactVisualizer publishes hydroelastic contact results for

--- a/multibody/meshcat/hydroelastic_contact_visualizer.h
+++ b/multibody/meshcat/hydroelastic_contact_visualizer.h
@@ -21,17 +21,17 @@ struct HydroelasticContactVisualizerItem {
       std::string body_A_, std::string body_B_,
       const Eigen::Vector3d& centroid_W_, const Eigen::Vector3d& force_C_W_,
       const Eigen::Vector3d& moment_C_W_,
-      const Eigen::Matrix3Xd& p_WV_,
-      const Eigen::Matrix3Xi& faces_,
-      const Eigen::VectorXd& pressure_)
+      const Eigen::Matrix3Xd p_WV_,
+      const Eigen::Matrix3Xi faces_,
+      const Eigen::VectorXd pressure_)
       : body_A(std::move(body_A_)),
         body_B(std::move(body_B_)),
         centroid_W(centroid_W_),
         force_C_W(force_C_W_),
         moment_C_W(moment_C_W_),
-        p_WV(p_WV_),
-        faces(faces_),
-        pressure(pressure_) {}
+        p_WV(std::move(p_WV_)),
+        faces(std::move(faces_)),
+        pressure(std::move(pressure_)) {}
 
   std::string body_A;
   std::string body_B;

--- a/multibody/meshcat/test/contact_visualizer_test.cc
+++ b/multibody/meshcat/test/contact_visualizer_test.cc
@@ -67,7 +67,7 @@ class ContactVisualizerTest : public ::testing::Test {
     const auto& body2 = plant.GetBodyByName("body2");
     plant.AddJoint<multibody::PrismaticJoint>(
         "body2", plant.world_body(), std::nullopt, body2, std::nullopt,
-        Eigen::Vector3d::UnitZ());
+        Eigen::Vector3d::UnitX());
 
     plant.Finalize();
 
@@ -97,7 +97,7 @@ class ContactVisualizerTest : public ::testing::Test {
     diagram_ = builder.Build();
     context_ = diagram_->CreateDefaultContext();
     plant.SetPositions(&plant.GetMyMutableContextFromRoot(context_.get()),
-                       Eigen::Vector4d{-0.03, 0.03, -0.05, 0.1});
+                       Eigen::Vector4d{-0.03, 0.03, 0.1, 0.3});
   }
 
   void PublishAndCheck(
@@ -111,7 +111,10 @@ class ContactVisualizerTest : public ::testing::Test {
           "contact_forces/point/sphere1.base_link+sphere2.base_link"));
     }
 
-    EXPECT_TRUE(meshcat_->HasPath("contact_forces/hydroelastic/body1+body2"));
+    EXPECT_TRUE(meshcat_->HasPath(
+        "contact_forces/hydroelastic/body1.body1_collision+body2"));
+    EXPECT_TRUE(meshcat_->HasPath(
+        "contact_forces/hydroelastic/body1.body1_collision2+body2"));
   }
 
   std::shared_ptr<Meshcat> meshcat_;

--- a/multibody/meshcat/test/contact_visualizer_test.cc
+++ b/multibody/meshcat/test/contact_visualizer_test.cc
@@ -111,10 +111,20 @@ class ContactVisualizerTest : public ::testing::Test {
           "contact_forces/point/sphere1.base_link+sphere2.base_link"));
     }
 
-    EXPECT_TRUE(meshcat_->HasPath(
-        "contact_forces/hydroelastic/body1.body1_collision+body2"));
-    EXPECT_TRUE(meshcat_->HasPath(
-        "contact_forces/hydroelastic/body1.body1_collision2+body2"));
+    // If the query object port is not connected, the geometry names will
+    // be in their "basic" form (i.e. just Ids).
+    if (visualizer_->query_object_input_port().HasValue(
+            visualizer_->GetMyContextFromRoot(*context_))) {
+      EXPECT_TRUE(meshcat_->HasPath(
+          "contact_forces/hydroelastic/body1.body1_collision+body2"));
+      EXPECT_TRUE(meshcat_->HasPath(
+          "contact_forces/hydroelastic/body1.body1_collision2+body2"));
+    } else {
+      EXPECT_TRUE(
+          meshcat_->HasPath("contact_forces/hydroelastic/body1.Id(173)+body2"));
+      EXPECT_TRUE(
+          meshcat_->HasPath("contact_forces/hydroelastic/body1.Id(175)+body2"));
+    }
   }
 
   std::shared_ptr<Meshcat> meshcat_;

--- a/multibody/meshcat/test/contact_visualizer_test.cc
+++ b/multibody/meshcat/test/contact_visualizer_test.cc
@@ -69,6 +69,13 @@ class ContactVisualizerTest : public ::testing::Test {
         "body2", plant.world_body(), std::nullopt, body2, std::nullopt,
         Eigen::Vector3d::UnitX());
 
+    auto geometry_ids = plant.GetCollisionGeometriesForBody(body1);
+
+    DRAKE_ASSERT(geometry_ids.size() == 2);
+
+    body1_id1 = geometry_ids[0];
+    body1_id2 = geometry_ids[1];
+
     plant.Finalize();
 
     // Add the visualizer.
@@ -120,10 +127,10 @@ class ContactVisualizerTest : public ::testing::Test {
       EXPECT_TRUE(meshcat_->HasPath(
           "contact_forces/hydroelastic/body1.body1_collision2+body2"));
     } else {
-      EXPECT_TRUE(
-          meshcat_->HasPath("contact_forces/hydroelastic/body1.Id(173)+body2"));
-      EXPECT_TRUE(
-          meshcat_->HasPath("contact_forces/hydroelastic/body1.Id(175)+body2"));
+      EXPECT_TRUE(meshcat_->HasPath(fmt::format(
+          "contact_forces/hydroelastic/body1.Id({})+body2", body1_id1)));
+      EXPECT_TRUE(meshcat_->HasPath(fmt::format(
+          "contact_forces/hydroelastic/body1.Id({})+body2", body1_id2)));
     }
   }
 
@@ -131,6 +138,8 @@ class ContactVisualizerTest : public ::testing::Test {
   const ContactVisualizer<double>* visualizer_{};
   std::unique_ptr<systems::Diagram<double>> diagram_{};
   std::unique_ptr<systems::Context<double>> context_{};
+  geometry::GeometryId body1_id1{};
+  geometry::GeometryId body1_id2{};
 };
 
 // Tests the preferred spelling of AddToBuilder.

--- a/multibody/meshcat/test/hydroelastic.sdf
+++ b/multibody/meshcat/test/hydroelastic.sdf
@@ -14,6 +14,16 @@
           <iyz>0</iyz>
         </inertia>
       </inertial>
+      <visual name="body1_visual">
+        <geometry>
+          <sphere>
+            <radius>0.2</radius>
+          </sphere>
+        </geometry>
+        <material>
+          <diffuse>1.0 0.0 0.0 0.5</diffuse>
+        </material>
+      </visual>
       <collision name="body1_collision">
         <geometry>
           <sphere>
@@ -40,6 +50,16 @@
           <iyz>0</iyz>
         </inertia>
       </inertial>
+      <visual name="body2_visual">
+        <geometry>
+          <sphere>
+            <radius>0.2</radius>
+          </sphere>
+        </geometry>
+        <material>
+          <diffuse>0.0 0.0 1.0 0.5</diffuse>
+        </material>
+      </visual>
       <collision name="body2_collision">
         <geometry>
           <sphere>

--- a/multibody/meshcat/test/hydroelastic.sdf
+++ b/multibody/meshcat/test/hydroelastic.sdf
@@ -38,6 +38,33 @@
           <drake:compliant_hydroelastic/>
         </drake:proximity_properties>
       </collision>
+      <visual name="body1_visual2">
+        <pose>0.6 0 0.0 0 0 0</pose>
+        <geometry>
+          <sphere>
+            <radius>0.2</radius>
+          </sphere>
+        </geometry>
+        <material>
+          <diffuse>1.0 0.0 0.0 0.5</diffuse>
+        </material>
+      </visual>
+      <collision name="body1_collision2">
+        <pose>0.6 0 0.0 0 0 0</pose>
+        <geometry>
+          <sphere>
+            <radius>0.2</radius>
+          </sphere>
+        </geometry>
+        <drake:proximity_properties>
+          <drake:mu_dynamic>0.5</drake:mu_dynamic>
+          <drake:mu_static>0.5</drake:mu_static>
+          <drake:mesh_resolution_hint>0.05</drake:mesh_resolution_hint>
+          <drake:hydroelastic_modulus>1.0e7</drake:hydroelastic_modulus>
+          <drake:compliant_hydroelastic/>
+        </drake:proximity_properties>
+      </collision>
+
     </link>
     <link name="body2">
       <inertial>

--- a/multibody/meshcat/test/hydroelastic.sdf
+++ b/multibody/meshcat/test/hydroelastic.sdf
@@ -33,8 +33,9 @@
         <drake:proximity_properties>
           <drake:mu_dynamic>0.5</drake:mu_dynamic>
           <drake:mu_static>0.5</drake:mu_static>
-          <drake:mesh_resolution_hint>0.1</drake:mesh_resolution_hint>
-          <drake:rigid_hydroelastic/>
+          <drake:mesh_resolution_hint>0.05</drake:mesh_resolution_hint>
+          <drake:hydroelastic_modulus>1.0e7</drake:hydroelastic_modulus>
+          <drake:compliant_hydroelastic/>
         </drake:proximity_properties>
       </collision>
     </link>
@@ -69,8 +70,8 @@
         <drake:proximity_properties>
           <drake:mu_dynamic>0.5</drake:mu_dynamic>
           <drake:mu_static>0.5</drake:mu_static>
-          <drake:mesh_resolution_hint>0.2</drake:mesh_resolution_hint>
-          <drake:hydroelastic_modulus>180.0e9</drake:hydroelastic_modulus>
+          <drake:mesh_resolution_hint>0.05</drake:mesh_resolution_hint>
+          <drake:hydroelastic_modulus>1.0e9</drake:hydroelastic_modulus>
           <drake:compliant_hydroelastic/>
         </drake:proximity_properties>
       </collision>


### PR DESCRIPTION
This PR updates the `HydroelasticContactVisualizer` to send contact surface geometry to meshcat with each hydroelastic contact message. It also updates meldis and the in-process `ContactVisualizer` accordingly.

Related to #15738.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17599)
<!-- Reviewable:end -->
