### PR TITLE
[inverse_kinematics] Cleanup PositionCost implementation.

### DIFF
--- a/multibody/inverse_kinematics/kinematic_evaluator_utilities.h
+++ b/multibody/inverse_kinematics/kinematic_evaluator_utilities.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <limits>
+#include <string>
 
 #include "drake/math/autodiff_gradient.h"
 #include "drake/multibody/plant/multibody_plant.h"
@@ -83,6 +84,15 @@ const MultibodyPlant<T>& RefFromPtrOrThrow(
   if (plant == nullptr) throw std::invalid_argument("plant is nullptr.");
   return *plant;
 }
+
+template <typename T>
+T* PtrOrThrow(T* ptr, std::string_view error) {
+  if (ptr == nullptr) {
+    throw std::invalid_argument(std::string(error));
+  }
+  return ptr;
+}
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/position_cost.cc
+++ b/multibody/inverse_kinematics/position_cost.cc
@@ -4,6 +4,7 @@
 #include "drake/multibody/inverse_kinematics/kinematic_evaluator_utilities.h"
 
 using drake::multibody::internal::RefFromPtrOrThrow;
+using drake::multibody::internal::PtrOrThrow;
 using drake::multibody::internal::UpdateContextConfiguration;
 
 namespace drake {
@@ -17,98 +18,44 @@ PositionCost::PositionCost(const MultibodyPlant<double>* const plant,
                            const Eigen::Ref<const Eigen::Matrix3d>& C,
                            systems::Context<double>* plant_context)
     : solvers::Cost(RefFromPtrOrThrow(plant).num_positions()),
-      plant_double_(plant),
-      frameA_index_(frameA.index()),
-      p_AP_{p_AP},
-      frameB_index_(frameB.index()),
-      p_BQ_{p_BQ},
-      C_{C},
-      context_double_{plant_context},
-      plant_autodiff_(nullptr),
-      context_autodiff_(nullptr) {
-  if (plant_context == nullptr)
-    throw std::invalid_argument(
-        "PositionCost(): plant_context is nullptr.");
-}
+      constraint_(plant, frameA, p_AP, p_AP, frameB, p_BQ,
+                  PtrOrThrow(plant_context,
+                             "PositionCost(): plant_context is nullptr")),
+      C_{C} {}
 
-PositionCost::PositionCost(
-    const MultibodyPlant<AutoDiffXd>* const plant,
-    const Frame<AutoDiffXd>& frameA,
-    const Eigen::Ref<const Eigen::Vector3d>& p_AP,
-    const Frame<AutoDiffXd>& frameB,
-    const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
-    const Eigen::Ref<const Eigen::Matrix3d>& C,
-    systems::Context<AutoDiffXd>* plant_context)
+PositionCost::PositionCost(const MultibodyPlant<AutoDiffXd>* const plant,
+                           const Frame<AutoDiffXd>& frameA,
+                           const Eigen::Ref<const Eigen::Vector3d>& p_AP,
+                           const Frame<AutoDiffXd>& frameB,
+                           const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
+                           const Eigen::Ref<const Eigen::Matrix3d>& C,
+                           systems::Context<AutoDiffXd>* plant_context)
     : solvers::Cost(RefFromPtrOrThrow(plant).num_positions()),
-      plant_double_(nullptr),
-      frameA_index_(frameA.index()),
-      p_AP_{p_AP},
-      frameB_index_(frameB.index()),
-      p_BQ_{p_BQ},
-      C_{C},
-      context_double_{nullptr},
-      plant_autodiff_(plant),
-      context_autodiff_(plant_context) {
-  if (plant_context == nullptr)
-    throw std::invalid_argument("plant_context is nullptr.");
-}
+      constraint_(plant, frameA, p_AP, p_AP, frameB, p_BQ,
+                  PtrOrThrow(plant_context,
+                             "PositionCost(): plant_context is nullptr")),
+      C_{C} {}
 
 PositionCost::~PositionCost() = default;
 
-namespace {
-
-template <typename T, typename S>
-void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
-                   const FrameIndex frameA_index, const Eigen::Vector3d& p_AP,
-                   const FrameIndex frameB_index, const Eigen::Vector3d& p_BQ,
-                   const Eigen::Matrix3d& C,
-                   const Eigen::Ref<const VectorX<S>>& x, VectorX<S>* y) {
-  y->resize(1);
-  UpdateContextConfiguration(context, plant, x);
-  const Frame<T>& frameA = plant.get_frame(frameA_index);
-  const Frame<T>& frameB = plant.get_frame(frameB_index);
-  Vector3<T> p_AQ;
-  plant.CalcPointsPositions(*context, frameB, p_BQ.cast<T>(), frameA,
-                            &p_AQ);
-  const Vector3<T> err = p_AQ - p_AP;
-  if constexpr (std::is_same_v<T, S>) {
-    *y = err.transpose() * C * err;
-  } else {
-    static_assert(std::is_same_v<T, double>);
-    static_assert(std::is_same_v<S, AutoDiffXd>);
-    Eigen::Matrix3Xd Jq_v_ABq(3, plant.num_positions());
-    plant.CalcJacobianTranslationalVelocity(*context,
-                                            JacobianWrtVariable::kQDot, frameB,
-                                            p_BQ, frameA, frameA, &Jq_v_ABq);
-    const Vector3<S> err_ad =
-        math::InitializeAutoDiff(err, Jq_v_ABq * math::ExtractGradient(x));
-    *y = err_ad.transpose() * C * err_ad;
-  }
-}
-
-}  // namespace
-
 void PositionCost::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
                                 Eigen::VectorXd* y) const {
-  if (use_autodiff()) {
-    AutoDiffVecXd y_t;
-    Eval(x.cast<AutoDiffXd>(), &y_t);
-    *y = math::ExtractValue(y_t);
-  } else {
-    DoEvalGeneric(*plant_double_, context_double_, frameA_index_, p_AP_,
-                  frameB_index_, p_BQ_, C_, x, y);
-  }
+  y->resize(1);
+  Eigen::VectorXd p_AQ;
+  constraint_.Eval(x, &p_AQ);
+  const Eigen::VectorXd& p_AP = constraint_.lower_bound();
+  const Eigen::VectorXd err = p_AQ - p_AP;
+  (*y)[0] = err.dot(C_ * err);
 }
 
 void PositionCost::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
                                 AutoDiffVecXd* y) const {
-  if (!use_autodiff()) {
-    DoEvalGeneric(*plant_double_, context_double_, frameA_index_, p_AP_,
-                  frameB_index_, p_BQ_, C_, x, y);
-  } else {
-    DoEvalGeneric(*plant_autodiff_, context_autodiff_, frameA_index_, p_AP_,
-                  frameB_index_, p_BQ_, C_, x, y);
-  }
+  y->resize(1);
+  AutoDiffVecXd p_AQ;
+  constraint_.Eval(x, &p_AQ);
+  const Eigen::VectorXd& p_AP = constraint_.lower_bound();
+  const AutoDiffVecXd err = p_AQ - p_AP;
+  (*y)[0] = err.dot(C_ * err);
 }
 
 void PositionCost::DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>&,

--- a/multibody/inverse_kinematics/position_cost.h
+++ b/multibody/inverse_kinematics/position_cost.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "drake/multibody/inverse_kinematics/position_constraint.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/solvers/cost.h"
 #include "drake/systems/framework/context.h"
@@ -65,18 +66,8 @@ class PositionCost : public solvers::Cost {
   void DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>&,
               VectorX<symbolic::Expression>*) const override;
 
-  bool use_autodiff() const { return plant_autodiff_; }
-
-  const MultibodyPlant<double>* const plant_double_;
-  const FrameIndex frameA_index_;
-  const Eigen::Vector3d p_AP_;
-  const FrameIndex frameB_index_;
-  const Eigen::Vector3d p_BQ_;
+  const PositionConstraint constraint_;
   const Eigen::Matrix3d C_;
-  systems::Context<double>* const context_double_;
-
-  const MultibodyPlant<AutoDiffXd>* const plant_autodiff_;
-  systems::Context<AutoDiffXd>* const context_autodiff_;
 };
 }  // namespace multibody
 }  // namespace drake


### PR DESCRIPTION
During review of #17592, we decided that it was cleaner to have the
cost call the existing constraint implementation and only do the
incremental work.  This cleans up the PositionCost implementation to
use the same idea.

+@jwnimmer-tri for feature review (or both if you feel comfortable).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17601)
<!-- Reviewable:end -->
