### PR TITLE
[geometry] Build deformable sdf from distance to surface mesh

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -163,6 +163,7 @@ drake_cc_library(
     srcs = ["deformable_contact_geometries.cc"],
     hdrs = ["deformable_contact_geometries.h"],
     deps = [
+        ":calc_distance_to_surface_mesh",
         ":deformable_volume_mesh",
         ":hydroelastic_internal",
         ":triangle_surface_mesh",

--- a/geometry/proximity/deformable_contact_geometries.h
+++ b/geometry/proximity/deformable_contact_geometries.h
@@ -20,85 +20,29 @@ namespace geometry {
 namespace internal {
 namespace deformable {
 
-/* Definition of a deformable body's geometry at the reference configuration.
- It includes a volume mesh and a scalar field approximating the signed distance
- to the surface of the mesh defined on the interior of the geometry. This class
- is similar to geometry::internal::hydroelastic::SoftMesh with two distinctions:
- 1. This class doesn't provide a bounding volume hierarchy.
- 2. This class calculates an approximate signed distance field (meters, negative
-    inside) instead of taking a prescribed pressure field (Pascals, positive
-    inside). */
-class ReferenceDeformableGeometry : public ShapeReifier {
- public:
-  // TODO(xuchenhan-tri): Consider if it's possible to take a const pointer to
-  // the mesh instead of owning a copy of the mesh.
-  /* Constructs a deformable geometry at reference configuration with the given
-  `shape` and its spatial discretization `mesh`. An internal approximate signed
-  distance field in the `mesh` (to the surface of `shape`) is created at
-  construction.
-  @param shape  The shape of the deformable geometry in reference configuration.
-  @param mesh   A reasonable tetrahedral tessellation of the given `shape`. */
-  ReferenceDeformableGeometry(const Shape& shape, VolumeMesh<double> mesh);
-
-  /* Custom copy assign and construct. */
-  ReferenceDeformableGeometry& operator=(const ReferenceDeformableGeometry&);
-  ReferenceDeformableGeometry(const ReferenceDeformableGeometry&);
-  /* Default move assign and construct. */
-  ReferenceDeformableGeometry(ReferenceDeformableGeometry&&) = default;
-  ReferenceDeformableGeometry& operator=(ReferenceDeformableGeometry&&) =
-      default;
-
-  /* Returns the volume mesh representation of the deformable geometry at
-   reference configuration. */
-  const VolumeMesh<double>& mesh() const {
-    DRAKE_DEMAND(mesh_ != nullptr);
-    return *mesh_;
-  }
-
-  /* Returns the approximate signed distance field (sdf) to the surface of the
-   deformable geometry in the reference configuration. More specifically, the
-   sdf value at each vertex is exact (to the accuracy of the distance query
-   algorithm), and the values in the interior of the mesh are linearly
-   interpolated from vertex values. */
-  const VolumeMeshFieldLinear<double, double>& signed_distance_field() const {
-    DRAKE_DEMAND(signed_distance_field_ != nullptr);
-    return *signed_distance_field_;
-  }
-
- private:
-  /* Data to be used during reification. It is passed as the `user_data`
-   parameter in the ImplementGeometry API. */
-  struct ReifyData {
-    std::vector<double> signed_distance;
-  };
-
-  std::vector<double> ComputeSignedDistanceOfVertices(const Shape& shape);
-
-  using ShapeReifier::ImplementGeometry;
-  void ImplementGeometry(const Sphere& sphere, void* user_data) override;
-  void ImplementGeometry(const Box& box, void* user_data) override;
-
-  std::unique_ptr<VolumeMesh<double>> mesh_{nullptr};
-  std::unique_ptr<VolumeMeshFieldLinear<double, double>> signed_distance_field_{
-      nullptr};
-};
-
-/* Definition of a deformable geometry for contact implementations. To be a
- deformable geometry, a shape must be associated with both:
+// TODO(xuchenhan-tri): Consider supporting AutoDiffXd.
+/* Definition of a deformable geometry for contact evaluations. To be
+ considered as deformable, a geometry must be associated with both:
    - a deformable volume mesh, and
    - an approximate signed distance field in the interior of the mesh. */
 class DeformableGeometry {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DeformableGeometry)
+  DeformableGeometry(const DeformableGeometry& other);
+  DeformableGeometry& operator=(const DeformableGeometry& other);
+  DeformableGeometry(DeformableGeometry&&) = default;
+  DeformableGeometry& operator=(DeformableGeometry&&) = default;
 
-  /* Constructs a deformable geometry. */
-  DeformableGeometry(const Shape& shape, VolumeMesh<double> mesh)
-      : reference_geometry_(shape, mesh), deformable_mesh_(std::move(mesh)) {}
+  /* Constructs a deformable geometry from the given mesh. Also computes an
+   approximate signed distance field for the mesh. */
+  explicit DeformableGeometry(VolumeMesh<double> mesh);
+
+  // TODO(xuchenhan-tri): Consider adding another constructor that takes in both
+  // a mesh and a precomputed (approximated) sign distance field.
 
   /* Returns the volume mesh representation of the deformable geometry at
    current configuration. */
   const DeformableVolumeMesh<double>& deformable_mesh() const {
-    return deformable_mesh_;
+    return *deformable_mesh_;
   }
 
   /* Updates the vertex positions of the underlying deformable mesh.
@@ -108,7 +52,7 @@ class DeformableGeometry {
   @pre q.size() == 3 * deformable_mesh().num_vertices(). */
   void UpdateVertexPositions(const Eigen::Ref<const VectorX<double>>& q) {
     DRAKE_DEMAND(q.size() == 3 * deformable_mesh().mesh().num_vertices());
-    deformable_mesh_.UpdateVertexPositions(q);
+    deformable_mesh_->UpdateVertexPositions(q);
   }
 
   /* Returns the approximate signed distance field (sdf) for the deformable
@@ -117,12 +61,12 @@ class DeformableGeometry {
    reference configuration. The values in the interior of the mesh are linearly
    interpolated from vertex values. */
   const VolumeMeshFieldLinear<double, double>& signed_distance_field() const {
-    return reference_geometry_.signed_distance_field();
+    return *signed_distance_field_;
   }
 
  private:
-  ReferenceDeformableGeometry reference_geometry_;
-  DeformableVolumeMesh<double> deformable_mesh_;
+  std::unique_ptr<DeformableVolumeMesh<double>> deformable_mesh_;
+  std::unique_ptr<VolumeMeshFieldLinear<double, double>> signed_distance_field_;
 };
 
 /* Defines a rigid geometry -- a rigid hydroelastic mesh repurposed to compute
@@ -131,11 +75,11 @@ class DeformableGeometry {
  aren't relying on FCL's broadphase. */
 class RigidGeometry {
  public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RigidGeometry)
+
   explicit RigidGeometry(
       std::unique_ptr<internal::hydroelastic::RigidMesh> rigid_mesh)
       : rigid_mesh_(std::move(rigid_mesh)) {}
-
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RigidGeometry)
 
   const internal::hydroelastic::RigidMesh& rigid_mesh() const {
     DRAKE_DEMAND(rigid_mesh_ != nullptr);

--- a/geometry/proximity/deformable_mesh_intersection.cc
+++ b/geometry/proximity/deformable_mesh_intersection.cc
@@ -81,28 +81,12 @@ void AppendDeformableRigidContact(
     const math::RigidTransform<double>& X_DR,
     DeformableRigidContact<double>* deformable_rigid_contact) {
   DRAKE_DEMAND(deformable_rigid_contact != nullptr);
-  const VolumeMesh<double>& mesh = deformable_D.deformable_mesh().mesh();
-  // TODO(DamrongGuoy) Is there a better way than creating a new
-  //  VolumeMeshFieldLinear here? We do it here, so we can reuse
-  //  SurfaceVolumeIntersector. These are some ideas that Xuchen and Damrong
-  //  consider for future refactoring:
-  //  1. Change the type parameter MeshBuilder of SurfaceVolumeIntersector<>
-  //     to provide the tetrahedral mesh. This includes TriMeshBuilder and
-  //     PolyMeshBuilder.
-  //  Or 2. Allow VolumeMeshFieldLinear to switch to a different tetrahedral
-  //        mesh while keeping the same field values at vertices. Assume that
-  //        the new mesh has the same connectivity.
-  //  Or 3. Pass an additional parameter for the tetrahedral mesh to
-  //        SampleVolumeFieldOnSurface(). Right now it uses the mesh of the
-  //        given VolumeMeshFieldLinear.
-  VolumeMeshFieldLinear<double, double> field_D(
-      std::vector<double>(deformable_D.signed_distance_field().values()), &mesh,
-      true /*calculate gradient*/);
 
   DeformableSurfaceVolumeIntersector intersect;
   intersect.SampleVolumeFieldOnSurface(
-      field_D, deformable_D.deformable_mesh().bvh(), rigid_mesh_R, rigid_bvh_R,
-      X_DR, false /* don't filter face normal along field gradient */);
+      deformable_D.signed_distance_field(),
+      deformable_D.deformable_mesh().bvh(), rigid_mesh_R, rigid_bvh_R, X_DR,
+      false /* don't filter face normal along field gradient */);
 
   if (intersect.has_intersection()) {
     std::unique_ptr<PolygonSurfaceMesh<double>> contact_mesh_W =
@@ -120,6 +104,7 @@ void AppendDeformableRigidContact(
           i, contact_mesh_W->element_centroid(i));
     }
 
+    const VolumeMesh<double>& mesh = deformable_D.deformable_mesh().mesh();
     std::vector<int>& participating_tetrahedra =
         intersect.mutable_tetrahedron_index_of_polygons();
     std::unordered_set<int> participating_vertices;

--- a/geometry/proximity/test/deformable_contact_geometries_test.cc
+++ b/geometry/proximity/test/deformable_contact_geometries_test.cc
@@ -19,27 +19,93 @@ using Eigen::VectorXd;
 using std::make_unique;
 using std::move;
 
-GTEST_TEST(ReferenceDeformableGeometryTest, TestCopyAssignConstruct) {
-  const Sphere sphere(1.0);
-  const double resolution_hint = 0.5;
-  VolumeMesh<double> mesh = MakeSphereVolumeMesh<double>(
-      sphere, resolution_hint, TessellationStrategy::kSingleInteriorVertex);
+/* Constructs a coarse sphere (octahedron) whose vertices are transformed from
+ the canonical sphere frame S to some arbitrary frame F. */
+VolumeMesh<double> MakeTransformedSphere(double radius,
+                                         const math::RigidTransformd& X_FS) {
+  const Sphere sphere = Sphere(radius);
+  const VolumeMesh<double> mesh_S = MakeSphereVolumeMesh<double>(
+      sphere, radius * 2, TessellationStrategy::kSingleInteriorVertex);
+  const int num_vertices = mesh_S.num_vertices();
 
-  const ReferenceDeformableGeometry original(sphere, mesh);
+  std::vector<Vector3d> vertices_F;
+  vertices_F.reserve(num_vertices);
+  for (int v = 0; v < num_vertices; ++v) {
+    vertices_F.push_back(X_FS * mesh_S.vertex(v));
+  }
+  std::vector<VolumeElement> tets_F(mesh_S.tetrahedra());
+  return VolumeMesh<double>(move(tets_F), move(vertices_F));
+}
+
+GTEST_TEST(DeformableGeometryTest, Constructor) {
+  constexpr double kRadius = 1;
+  // This arbitrary transform (with the particularly oddly spelled rotation),
+  // stresses the distance computation on the surface. Another transform may not
+  // be so taxing.
+  math::RigidTransformd X_WS(math::RotationMatrixd::MakeXRotation(0.5) *
+                                 math::RotationMatrixd::MakeYRotation(0.3) *
+                                 math::RotationMatrixd::MakeZRotation(0.9),
+                             Vector3d(0.5, 0.7, 0.9));
+
+  VolumeMesh<double> mesh_W = MakeTransformedSphere(kRadius, X_WS);
+  // We leverage our knowledge about sphere mesh generation -- because the
+  // the sphere is the coarsest possible, it is an octahedron with 8 tets and
+  // 7 vertices (where the center vertex is at index 0).
+  const int num_vertices = mesh_W.num_vertices();
+  ASSERT_EQ(num_vertices, 7);
+  const int kCenterVertexIndex = 0;
+
+  DeformableGeometry deformable_geometry(move(mesh_W));
+
+  auto verify_sdf = [num_vertices](const DeformableGeometry& geometry) {
+    const VolumeMeshFieldLinear<double, double>& sdf =
+        geometry.signed_distance_field();
+    EXPECT_DOUBLE_EQ(sdf.EvaluateAtVertex(kCenterVertexIndex),
+                     -kRadius / std::sqrt(3));
+    // Skipping center vertex = 0.
+    for (int i = 1; i < num_vertices; ++i) {
+      EXPECT_NEAR(sdf.EvaluateAtVertex(i), 0.0,
+                  std::numeric_limits<double>::epsilon());
+    }
+  };
+  verify_sdf(deformable_geometry);
+
+  // Verify that the distance field is unaffected by deformation of the mesh.
+  const VectorXd q = VectorXd::LinSpaced(3 * num_vertices, 0.0, 1.0);
+  deformable_geometry.UpdateVertexPositions(q);
+  verify_sdf(deformable_geometry);
+}
+
+GTEST_TEST(DeformableGeometryTest, TestCopyAndMoveSemantics) {
+  constexpr double kEdgeLength = 1.0;
+  const Box box = Box::MakeCube(kEdgeLength);
+  const double kRezHint = 0.5;
+  VolumeMesh<double> mesh = MakeBoxVolumeMesh<double>(box, kRezHint);
+  DeformableGeometry original(mesh);
+
+  std::vector<Vector3d> dummy_vertices = {Vector3d(0, 0, 0), Vector3d(1, 0, 0),
+                                          Vector3d(0, 1, 0), Vector3d(0, 0, 1)};
+  std::vector<VolumeElement> dummy_elements = {VolumeElement(0, 1, 2, 3)};
+  VolumeMesh dummy_mesh(std::move(dummy_elements), std::move(dummy_vertices));
 
   // Test copy-assignment operator.
   {
-    /* There is no default constructor so we initialize copy to be different
-     from `original`. */
-    const Sphere sphere2(2.0);
-    const double resolution_hint2 = 1.0;
-    VolumeMesh<double> mesh2 = MakeSphereVolumeMesh<double>(
-        sphere2, resolution_hint2, TessellationStrategy::kSingleInteriorVertex);
-    ReferenceDeformableGeometry copy(sphere2, mesh2);
-
+    DeformableGeometry copy(dummy_mesh);
+    EXPECT_FALSE(
+        copy.deformable_mesh().mesh().Equal(original.deformable_mesh().mesh()));
     copy = original;
+
     // Test for uniqueness.
+    EXPECT_NE(&original.deformable_mesh(), &copy.deformable_mesh());
+    EXPECT_NE(&original.deformable_mesh().mesh(),
+              &copy.deformable_mesh().mesh());
+    EXPECT_NE(&copy.deformable_mesh().bvh(), &original.deformable_mesh().bvh());
     EXPECT_NE(&original.signed_distance_field(), &copy.signed_distance_field());
+
+    EXPECT_TRUE(
+        copy.deformable_mesh().mesh().Equal(original.deformable_mesh().mesh()));
+    EXPECT_TRUE(
+        copy.deformable_mesh().bvh().Equal(original.deformable_mesh().bvh()));
 
     const VolumeMeshFieldLinear<double, double>& copy_sdf =
         copy.signed_distance_field();
@@ -50,9 +116,19 @@ GTEST_TEST(ReferenceDeformableGeometryTest, TestCopyAssignConstruct) {
 
   // Test copy constructor.
   {
-    ReferenceDeformableGeometry copy(original);
+    DeformableGeometry copy(original);
+
     // Test for uniqueness.
+    EXPECT_NE(&original.deformable_mesh(), &copy.deformable_mesh());
+    EXPECT_NE(&original.deformable_mesh().mesh(),
+              &copy.deformable_mesh().mesh());
+    EXPECT_NE(&copy.deformable_mesh().bvh(), &original.deformable_mesh().bvh());
     EXPECT_NE(&original.signed_distance_field(), &copy.signed_distance_field());
+
+    EXPECT_TRUE(
+        copy.deformable_mesh().mesh().Equal(original.deformable_mesh().mesh()));
+    EXPECT_TRUE(
+        copy.deformable_mesh().bvh().Equal(original.deformable_mesh().bvh()));
 
     const VolumeMeshFieldLinear<double, double>& copy_sdf =
         copy.signed_distance_field();
@@ -60,58 +136,33 @@ GTEST_TEST(ReferenceDeformableGeometryTest, TestCopyAssignConstruct) {
         original.signed_distance_field();
     EXPECT_TRUE(copy_sdf.Equal(original_sdf));
   }
-}
 
-GTEST_TEST(ReferenceDeformableGeometryTest, Sphere) {
-  const Sphere sphere(1.0);
-  VolumeMesh<double> mesh = MakeSphereVolumeMesh<double>(
-      sphere, 100 /* ensure we get the coarsest possible mesh. */,
-      TessellationStrategy::kDenseInteriorVertices);
-  const int num_vertices = mesh.num_vertices();
-  // We leverage our knowledge about sphere mesh generation -- the targeted edge
-  // length is set to the coarsest possible, so the generated mesh is an
-  // octahedron. So we expect 7 vertices: 6 on the surface of the sphere and 1
-  // at the center.
-  ASSERT_EQ(num_vertices, 7);
-  ReferenceDeformableGeometry reference_geometry(sphere, move(mesh));
-  const VolumeMeshFieldLinear<double, double>& sdf =
-      reference_geometry.signed_distance_field();
-  EXPECT_DOUBLE_EQ(sdf.EvaluateAtVertex(0), -1.0);
-  for (int i = 1; i < num_vertices; ++i) {
-    EXPECT_DOUBLE_EQ(sdf.EvaluateAtVertex(i), 0.0);
+  // Test move constructor and move-assignment operator.
+  // We will move the content from `start` to `move_constructed` to
+  // `move_assigned`, each time confirming that the target of the move has taken
+  // ownership.
+  {
+    DeformableGeometry start(
+        original);  // Assume the copy constructor is correct.
+
+    // Grab raw pointers so we can determine that their ownership changes due to
+    // move semantics.
+    const DeformableVolumeMesh<double>* const mesh_ptr =
+        &start.deformable_mesh();
+    const VolumeMeshFieldLinear<double, double>* const sdf_ptr =
+        &start.signed_distance_field();
+
+    // Test move constructor.
+    DeformableGeometry move_constructed(std::move(start));
+    EXPECT_EQ(&move_constructed.deformable_mesh(), mesh_ptr);
+    EXPECT_EQ(&move_constructed.signed_distance_field(), sdf_ptr);
+
+    // Test move-assignment operator.
+    DeformableGeometry move_assigned(dummy_mesh);
+    move_assigned = std::move(move_constructed);
+    EXPECT_EQ(&move_assigned.deformable_mesh(), mesh_ptr);
+    EXPECT_EQ(&move_assigned.signed_distance_field(), sdf_ptr);
   }
-}
-
-GTEST_TEST(ReferenceDeformableGeometryTest, Box) {
-  const Box box = Box::MakeCube(1.0);
-  VolumeMesh<double> mesh = MakeBoxVolumeMesh<double>(box, 0.5);
-  const int num_vertices = mesh.num_vertices();
-  // We leverage our knowledge about box mesh generation -- the targeted edge
-  // length is set to half the edge length, so we expect 8 subcubes to be
-  // created with a total of 27 vertices.
-  ASSERT_EQ(num_vertices, 27);
-  const int center_vertex_index = 13;
-
-  ReferenceDeformableGeometry reference_geometry(box, move(mesh));
-  const VolumeMeshFieldLinear<double, double>& sdf =
-      reference_geometry.signed_distance_field();
-  EXPECT_DOUBLE_EQ(sdf.EvaluateAtVertex(center_vertex_index), -0.5);
-  for (int i = 0; i < num_vertices; ++i) {
-    if (i == center_vertex_index) continue;
-    EXPECT_DOUBLE_EQ(sdf.EvaluateAtVertex(i), 0.0);
-  }
-}
-
-GTEST_TEST(DeformableGeometryTest, Constructor) {
-  const Sphere sphere(1.0);
-  VolumeMesh<double> mesh = MakeSphereVolumeMesh<double>(
-      sphere, 0.5, TessellationStrategy::kDenseInteriorVertices);
-  ReferenceDeformableGeometry reference_geometry(sphere, mesh);
-  DeformableGeometry deformable_geometry(sphere, mesh);
-
-  EXPECT_TRUE(deformable_geometry.signed_distance_field().Equal(
-      reference_geometry.signed_distance_field()));
-  EXPECT_TRUE(deformable_geometry.deformable_mesh().mesh().Equal(mesh));
 }
 
 GTEST_TEST(DeformableGeometryTest, UpdateVertexPositions) {
@@ -119,7 +170,7 @@ GTEST_TEST(DeformableGeometryTest, UpdateVertexPositions) {
   VolumeMesh<double> mesh = MakeSphereVolumeMesh<double>(
       sphere, 0.5, TessellationStrategy::kDenseInteriorVertices);
   const int num_vertices = mesh.num_vertices();
-  DeformableGeometry deformable_geometry(sphere, move(mesh));
+  DeformableGeometry deformable_geometry(move(mesh));
   const VectorXd q = VectorXd::LinSpaced(3 * num_vertices, 0.0, 1.0);
   deformable_geometry.UpdateVertexPositions(q);
   const VolumeMesh<double> deformed_mesh =


### PR DESCRIPTION
Remove the ReferenceDeformableGeometry class and instead stores the approximate signed distance field directly in deformable geometry. With this, we unlock arbitrary volume mesh (with potentially non-convex surface mesh) as deformable geomtries. 

While doing that, we ensure that the mesh inside the SDF points to the deformable mesh held by DeformableGeometry so that we don't have to create local copies in deformable_mesh_intersection.cc. 

Towards #16875.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17603)
<!-- Reviewable:end -->
