### PR TITLE
[parsing] Handle unknown packages gracefully while processing model directives

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -254,6 +254,7 @@ drake_cc_library(
     deps = [
         ":detail_misc",
         ":scoped_names",
+        "//common:diagnostic_policy",
         "//common:filesystem",
         "//common:find_resource",
         "//common/yaml",

--- a/multibody/parsing/test/process_model_directives_test.cc
+++ b/multibody/parsing/test/process_model_directives_test.cc
@@ -284,6 +284,17 @@ GTEST_TEST(ProcessModelDirectivesTest, ErrorMessages) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       LoadModelDirectives("no-such-file.yaml"),
       ".*no-such-file.yaml.*");
+
+  // User specifies a package that hasn't been properly registered.
+  {
+    MultibodyPlant<double> plant(0.0);
+    ModelDirectives directives = LoadModelDirectives(
+        FindResourceOrThrow(std::string(kTestDir) + "/bad_package_uri.yaml"));
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        ProcessModelDirectives(directives, &plant, nullptr,
+                               make_parser(&plant).get()),
+        ".*unknown package 'nonexistant'.*");
+  }
 }
 
 }  // namespace

--- a/multibody/parsing/test/process_model_directives_test/bad_package_uri.yaml
+++ b/multibody/parsing/test/process_model_directives_test/bad_package_uri.yaml
@@ -1,0 +1,4 @@
+directives:
+- add_model:
+    name: homecart_bimanual
+    file: package://nonexistant/model.urdf


### PR DESCRIPTION
The old behavior would attempt to resolve directive URIs by hand. This defers to the the utility function. Now, processing the directives no longer aborts, but throws an intelligible message.

closes #17386
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17604)
<!-- Reviewable:end -->
