### PR TITLE
[geometry] Data structure for geometries in deformable contact

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -20,6 +20,7 @@ drake_cc_package_library(
         ":collision_filter",
         ":contact_surface_utility",
         ":deformable_contact_geometries",
+        ":deformable_contact_internal",
         ":deformable_mesh_intersection",
         ":deformable_volume_mesh",
         ":field_intersection",
@@ -158,6 +159,19 @@ drake_cc_library(
         "//geometry:geometry_ids",
         "//geometry:proximity_properties",
         "//geometry:shape_specification",
+    ],
+)
+
+drake_cc_library(
+    name = "deformable_contact_internal",
+    srcs = ["deformable_contact_internal.cc"],
+    hdrs = ["deformable_contact_internal.h"],
+    deps = [
+        ":deformable_mesh_intersection",
+        "//common:essential",
+        "//geometry:geometry_ids",
+        "//geometry:shape_specification",
+        "//geometry/query_results:deformable_rigid_contact",
     ],
 )
 
@@ -828,6 +842,22 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//math:autodiff",
+    ],
+)
+
+drake_cc_googletest(
+    name = "deformable_contact_internal_test",
+    data = [
+        "//geometry:test_obj_files",
+    ],
+    deps = [
+        ":deformable_contact_internal",
+        ":make_box_mesh",
+        ":make_sphere_mesh",
+        "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_no_throw",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/geometry/proximity/deformable_contact_internal.cc
+++ b/geometry/proximity/deformable_contact_internal.cc
@@ -1,0 +1,101 @@
+#include "drake/geometry/proximity/deformable_contact_internal.h"
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+
+#include "drake/common/drake_assert.h"
+#include "drake/geometry/proximity/deformable_contact_geometries.h"
+#include "drake/geometry/proximity/deformable_mesh_intersection.h"
+#include "drake/geometry/proximity/hydroelastic_internal.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace deformable {
+
+void Geometries::RemoveGeometry(GeometryId id) {
+  rigid_geometries_.erase(id);
+}
+
+void Geometries::MaybeAddRigidGeometry(const Shape& shape, GeometryId id,
+                                       const ProximityProperties& props) {
+  // TODO(xuchenhan-tri): Right now, rigid geometries participating in
+  // deformable contact share the property "kRezHint" with hydroelastics. It's
+  // reasonable to use the contact mesh with the same resolution for both hydro
+  // and deformable contact. Consider reorganizing the proximity properties to
+  // make this sharing more explicit. We should also avoid having two copies of
+  // the same rigid geometry for both hydro and deformable contact.
+  if (props.HasProperty(kHydroGroup, kRezHint)) {
+    ReifyData data{id, props};
+    shape.Reify(this, &data);
+  }
+}
+
+void Geometries::UpdateRigidWorldPose(
+    GeometryId id, const math::RigidTransform<double>& X_WG) {
+  if (is_rigid(id)) {
+    rigid_geometries_.at(id).set_pose_in_world(X_WG);
+  }
+}
+
+void Geometries::ImplementGeometry(const Sphere& sphere, void* user_data) {
+  AddRigidGeometry(sphere, *static_cast<ReifyData*>(user_data));
+}
+
+void Geometries::ImplementGeometry(const Cylinder& cylinder, void* user_data) {
+  AddRigidGeometry(cylinder, *static_cast<ReifyData*>(user_data));
+}
+
+void Geometries::ImplementGeometry(const Box& box, void* user_data) {
+  AddRigidGeometry(box, *static_cast<ReifyData*>(user_data));
+}
+
+void Geometries::ImplementGeometry(const Capsule& capsule, void* user_data) {
+  AddRigidGeometry(capsule, *static_cast<ReifyData*>(user_data));
+}
+
+void Geometries::ImplementGeometry(const Ellipsoid& ellipsoid,
+                                   void* user_data) {
+  AddRigidGeometry(ellipsoid, *static_cast<ReifyData*>(user_data));
+}
+
+void Geometries::ImplementGeometry(const Mesh& mesh, void* user_data) {
+  AddRigidGeometry(mesh, *static_cast<ReifyData*>(user_data));
+}
+
+void Geometries::ImplementGeometry(const Convex& convex, void* user_data) {
+  AddRigidGeometry(convex, *static_cast<ReifyData*>(user_data));
+}
+
+void Geometries::ImplementGeometry(const HalfSpace&, void*) {
+  static const logging::Warn log_once(
+      "Rigid (non-deformable) half spaces are not currently supported for "
+      "deformable contact; registration is allowed, but no contact data will "
+      "be reported.");
+}
+
+void Geometries::ImplementGeometry(const MeshcatCone&, void*) {
+  static const logging::Warn log_once(
+      "Rigid (non-deformable) Meshcat cones are not currently supported for "
+      "deformable contact; registration is allowed, but no contact data will "
+      "be reported.");
+}
+
+template <typename ShapeType>
+void Geometries::AddRigidGeometry(const ShapeType& shape,
+                                  const ReifyData& data) {
+  /* Forward to hydroelastics to construct the geometry. */
+  std::optional<internal::hydroelastic::RigidGeometry> hydro_rigid_geometry =
+      internal::hydroelastic::MakeRigidRepresentation(shape, data.properties);
+  /* Unsupported geometries will be handle through the
+   `ThrowUnsupportedGeometry()` code path. */
+  DRAKE_DEMAND(hydro_rigid_geometry.has_value());
+  rigid_geometries_.insert(
+      {data.id, RigidGeometry(hydro_rigid_geometry->release_mesh())});
+}
+
+}  // namespace deformable
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/deformable_contact_internal.h
+++ b/geometry/proximity/deformable_contact_internal.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/proximity/deformable_contact_geometries.h"
+#include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/geometry/query_results/deformable_rigid_contact.h"
+#include "drake/geometry/shape_specification.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace deformable {
+
+/* This class stores all instantiated representations of declared geometries for
+ deformable contact. They are keyed by the geometry's global GeometryId.
+
+ In order for a geometry with id `g_id` to have a representation in this
+ collection, it must:
+
+   - be declared via successful calls to MaybeAddRigidGeometry() (for
+     non-deformable geometries) or AddDeformableGeometry() (for deformable
+     geometries);
+   - the geometry cannot have been subsequently removed via a call to
+     RemoveGeometry().
+
+ If a geometry satisfies the requirements above, we say that the geometry has a
+ "deformable contact representation". If two geometries are in contact, in order
+ to produce the corresponding contact data, both ids must have a valid
+ representation in this data structure. Right now, we only support deformable
+ vs. rigid contact. In the future, we will also support deformable vs.
+ deformable contact. Rigid vs. rigid contact is handled through point contact or
+ hydroelastics outside of this class. */
+class Geometries final : public ShapeReifier {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Geometries);
+
+  Geometries() = default;
+
+  /* Returns true if a rigid (non-deformable) geometry representation with the
+   given `id` exists. */
+  bool is_rigid(GeometryId id) const {
+    return rigid_geometries_.count(id) != 0;
+  }
+
+  /* Removes the geometry (if it has a deformable contact representation). No-op
+   if no geometry with a deformable contact representation exists with the
+   provided id. */
+  void RemoveGeometry(GeometryId id);
+
+  /* Examines the given shape and properties, adding a rigid geometry
+   representation if
+   1. `props` specifies the resolution hint for the mesh representation of the
+      rigid geometry.
+   2. The `shape` type is supported for rigid representation for deformable
+      contact. The set of supported geometries is the set of all supported hydro
+      rigid geometries minus half space. We use the same implementation that the
+      hydro-rigid reifier is using for supported shapes.
+   This function is a no-op if the resolution_hint property is not specified.
+
+   @param shape         The shape to possibly represent.
+   @param id            The unique identifier for the geometry.
+   @param properties    The proximity properties that specifies the properties
+                        of the rigid representation.
+   @throws std::exception if resolution hint <= 0 for the following shapes: Box,
+           Sphere, Cylinder, Capsule, and Ellipsoid. Note that Mesh and Convex
+           don't restrict the range of resolution_hint.
+   @pre There is no previous representation associated with id.  */
+  void MaybeAddRigidGeometry(const Shape& shape, GeometryId id,
+                             const ProximityProperties& props);
+
+  /* Updates the world pose of the rigid geometry with the given id, if it
+   exists, to `X_WG`. */
+  void UpdateRigidWorldPose(GeometryId id,
+                            const math::RigidTransform<double>& X_WG);
+
+ private:
+  friend class GeometriesTester;
+
+  /* Data to be used during reification. It is passed as the `user_data`
+   parameter in the ImplementGeometry API. */
+  struct ReifyData {
+    GeometryId id;
+    const ProximityProperties& properties;
+  };
+
+  void ImplementGeometry(const Sphere& sphere, void* user_data) override;
+  void ImplementGeometry(const Cylinder& cylinder, void* user_data) override;
+  void ImplementGeometry(const Box& box, void* user_data) override;
+  void ImplementGeometry(const Capsule& capsule, void* user_data) override;
+  void ImplementGeometry(const Ellipsoid& ellipsoid, void* user_data) override;
+  void ImplementGeometry(const Mesh& mesh, void* user_data) override;
+  void ImplementGeometry(const Convex& convex, void* user_data) override;
+  void ImplementGeometry(const HalfSpace& half_space, void* user_data) override;
+  void ImplementGeometry(const MeshcatCone& cone, void* user_data) override;
+
+  /* Makes a rigid (non-deformable) geometry from a supported shape type using
+   the given `data`. */
+  template <typename ShapeType>
+  void AddRigidGeometry(const ShapeType& shape, const ReifyData& data);
+
+  // TODO(xuchenhan-tri): Add deformable geometries.
+
+  // The representations of all rigid geometries.
+  std::unordered_map<GeometryId, RigidGeometry> rigid_geometries_;
+};
+
+}  // namespace deformable
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/hydroelastic_internal.h
+++ b/geometry/proximity/hydroelastic_internal.h
@@ -234,6 +234,14 @@ class RigidGeometry {
     return geometry_->mesh();
   }
 
+  /* Releases the RigidMesh representation of this `RigidGeometry`, rendering
+   `this` RigidGeometry invalid.
+   @pre is_half_space() == false. */
+  std::unique_ptr<RigidMesh> release_mesh() {
+    DRAKE_DEMAND(!is_half_space());
+    return std::make_unique<RigidMesh>(std::move(*geometry_));
+  }
+
   /* Returns a reference to the bounding volume hierarchy -- calling this will
    throw unless is_half_space() returns false.  */
   const Bvh<Obb, TriangleSurfaceMesh<double>>& bvh() const {

--- a/geometry/proximity/test/deformable_contact_internal_test.cc
+++ b/geometry/proximity/test/deformable_contact_internal_test.cc
@@ -1,0 +1,218 @@
+#include "drake/geometry/proximity/deformable_contact_internal.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_no_throw.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/proximity/deformable_mesh_intersection.h"
+#include "drake/geometry/proximity/make_box_mesh.h"
+#include "drake/geometry/proximity/make_sphere_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace deformable {
+
+class GeometriesTester {
+ public:
+  /* Returns the rigid geometry with `rigid_id` registered in `geometries`.
+   @pre a rigid representation with `rigid_id` exists in `geometries`. */
+  static const RigidGeometry& get_rigid_geometry(const Geometries& geometries,
+                                                 GeometryId rigid_id) {
+    return geometries.rigid_geometries_.at(rigid_id);
+  }
+};
+
+namespace {
+
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+
+/* Makes a ProximityProperties with a resolution hint property in the hydro
+ group.
+ @pre resolution_hint > 0. */
+ProximityProperties MakeProximityPropsWithRezHint(double resolution_hint) {
+  ProximityProperties props;
+  props.AddProperty(internal::kHydroGroup, internal::kRezHint, resolution_hint);
+  return props;
+}
+
+GTEST_TEST(GeometriesTest, AddRigidGeometry) {
+  Geometries geometries;
+  GeometryId rigid_id = GeometryId::get_new_id();
+  /* No geometries have been added yet. */
+  EXPECT_FALSE(geometries.is_rigid(rigid_id));
+
+  /* Add a rigid geometry with resolution hint property. */
+  constexpr double kRadius = 0.5;
+  constexpr double kRezHint = 0.5;
+  ProximityProperties props = MakeProximityPropsWithRezHint(kRezHint);
+  geometries.MaybeAddRigidGeometry(Sphere(kRadius), rigid_id, props);
+
+  EXPECT_TRUE(geometries.is_rigid(rigid_id));
+
+  /* Trying to a rigid geometry without the resolution hint property is a no-op.
+   */
+  GeometryId g_id = GeometryId::get_new_id();
+  ProximityProperties empty_props;
+  geometries.MaybeAddRigidGeometry(Sphere(kRadius), g_id, empty_props);
+
+  EXPECT_FALSE(geometries.is_rigid(g_id));
+}
+
+/* Test coverage for all unsupported shapes as rigid geometries: MeshcatCone and
+ * HalfSpace. */
+GTEST_TEST(GeometriesTest, UnsupportedRigidShapes) {
+  constexpr double kRezHint = 0.5;
+  ProximityProperties props = MakeProximityPropsWithRezHint(kRezHint);
+  Geometries geometries;
+
+  /* Unsupported shapes: MeshcatCone, HalfSpace. */
+  /* MeshcatCone */
+  {
+    GeometryId cone_id = GeometryId::get_new_id();
+    const double height = 2.0;
+    const double a = 1.0;
+    const double b = 1.0;
+    EXPECT_NO_THROW(geometries.MaybeAddRigidGeometry(MeshcatCone(height, a, b),
+                                                     cone_id, props));
+    EXPECT_FALSE(geometries.is_rigid(cone_id));
+  }
+  /* HalfSpace */
+  {
+    GeometryId hs_id = GeometryId::get_new_id();
+    EXPECT_NO_THROW(
+        geometries.MaybeAddRigidGeometry(HalfSpace(), hs_id, props));
+    EXPECT_FALSE(geometries.is_rigid(hs_id));
+  }
+}
+
+/* Test coverage for all supported shapes as rigid geometries: Box, Sphere,
+ Cylinder, Capsule, Ellipsoid, Mesh, Convex. */
+GTEST_TEST(GeometriesTest, SupportedRigidShapes) {
+  constexpr double kRezHint = 0.5;
+  ProximityProperties props = MakeProximityPropsWithRezHint(kRezHint);
+  Geometries geometries;
+
+  /* Box */
+  {
+    GeometryId box_id = GeometryId::get_new_id();
+    geometries.MaybeAddRigidGeometry(Box::MakeCube(1.0), box_id, props);
+    EXPECT_TRUE(geometries.is_rigid(box_id));
+  }
+  /* Sphere */
+  {
+    const double radius = 1.0;
+    GeometryId box_id = GeometryId::get_new_id();
+    geometries.MaybeAddRigidGeometry(Sphere(radius), box_id, props);
+    EXPECT_TRUE(geometries.is_rigid(box_id));
+  }
+  /* Cylinder */
+  {
+    GeometryId cylinder_id = GeometryId::get_new_id();
+    const double radius = 1.0;
+    const double length = 2.0;
+    geometries.MaybeAddRigidGeometry(Cylinder(radius, length), cylinder_id,
+                                     props);
+    EXPECT_TRUE(geometries.is_rigid(cylinder_id));
+  }
+  /* Capsule */
+  {
+    GeometryId capsule_id = GeometryId::get_new_id();
+    const double radius = 1.0;
+    const double length = 2.0;
+    geometries.MaybeAddRigidGeometry(Capsule(radius, length), capsule_id,
+                                     props);
+    EXPECT_TRUE(geometries.is_rigid(capsule_id));
+  }
+  /* Ellipsoid */
+  {
+    GeometryId ellipsoid_id = GeometryId::get_new_id();
+    const double a = 0.5;
+    const double b = 0.8;
+    const double c = 0.3;
+    geometries.MaybeAddRigidGeometry(Ellipsoid(a, b, c), ellipsoid_id, props);
+    EXPECT_TRUE(geometries.is_rigid(ellipsoid_id));
+  }
+  /* Mesh */
+  {
+    GeometryId mesh_id = GeometryId::get_new_id();
+    std::string file = FindResourceOrThrow("drake/geometry/test/quad_cube.obj");
+    geometries.MaybeAddRigidGeometry(Mesh(file, 1.0), mesh_id, props);
+    EXPECT_TRUE(geometries.is_rigid(mesh_id));
+  }
+  /* Convex */
+  {
+    GeometryId convex_id = GeometryId::get_new_id();
+    std::string file = FindResourceOrThrow("drake/geometry/test/quad_cube.obj");
+    geometries.MaybeAddRigidGeometry(Convex(file, 1.0), convex_id, props);
+    EXPECT_TRUE(geometries.is_rigid(convex_id));
+  }
+}
+
+GTEST_TEST(GeometriesTest, UpdateRigidWorldPose) {
+  Geometries geometries;
+
+  /* Add a rigid geometry. */
+  GeometryId rigid_id = GeometryId::get_new_id();
+  constexpr double kRadius = 0.5;
+  constexpr double kRezHint = 0.5;
+  ProximityProperties props = MakeProximityPropsWithRezHint(kRezHint);
+  geometries.MaybeAddRigidGeometry(Sphere(kRadius), rigid_id, props);
+
+  /* Initially the pose is identity. */
+  {
+    const RigidGeometry& rigid_geometry =
+        GeometriesTester::get_rigid_geometry(geometries, rigid_id);
+    EXPECT_TRUE(rigid_geometry.pose_in_world().IsExactlyIdentity());
+  }
+  /* Update the pose to some arbitrary value. */
+  const math::RigidTransform<double> X_WG(
+      math::RollPitchYaw<double>(-1.57, 0, 3), Vector3d(-0.3, -0.55, 0.36));
+  geometries.UpdateRigidWorldPose(rigid_id, X_WG);
+  {
+    const RigidGeometry& rigid_geometry =
+        GeometriesTester::get_rigid_geometry(geometries, rigid_id);
+    EXPECT_TRUE(rigid_geometry.pose_in_world().IsExactlyEqualTo(X_WG));
+  }
+}
+
+GTEST_TEST(GeometriesTest, RemoveGeometry) {
+  Geometries geometries;
+
+  /* Add a couple of rigid geometries. */
+  GeometryId rigid_id0 = GeometryId::get_new_id();
+  GeometryId rigid_id1 = GeometryId::get_new_id();
+  constexpr double kRadius = 0.5;
+  constexpr double kRezHint = 0.5;
+  ProximityProperties props = MakeProximityPropsWithRezHint(kRezHint);
+  geometries.MaybeAddRigidGeometry(Sphere(kRadius), rigid_id0, props);
+  geometries.MaybeAddRigidGeometry(Sphere(kRadius), rigid_id1, props);
+
+  /* Calling RemoveGeometry on an existing rigid geometry. */
+  {
+    geometries.RemoveGeometry(rigid_id0);
+    /* The geometry is indeed removed. */
+    EXPECT_FALSE(geometries.is_rigid(rigid_id0));
+    /* Other geometries are unaffected. */
+    EXPECT_TRUE(geometries.is_rigid(rigid_id1));
+  }
+  /* Calling RemoveGeometry on an invalid or already deleted geometry is a
+   no-op. */
+  {
+    GeometryId invalid_id = GeometryId::get_new_id();
+    EXPECT_NO_THROW(geometries.RemoveGeometry(invalid_id));
+    EXPECT_NO_THROW(geometries.RemoveGeometry(rigid_id0));
+
+    EXPECT_FALSE(geometries.is_rigid(rigid_id0));
+    EXPECT_TRUE(geometries.is_rigid(rigid_id1));
+  }
+}
+
+}  // namespace
+}  // namespace deformable
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
This PR does half of the job: currently deformable::Geometries
only supports adding, updating, and removing rigid (non-deformable)
geometries. The ability to add, update, and remove deformable geometries
and calculating the contact data will come in a separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17605)
<!-- Reviewable:end -->
