### PR TITLE
[geometry] Complete the deformable::Geometries data structure

### DIFF
--- a/geometry/proximity/deformable_contact_internal.cc
+++ b/geometry/proximity/deformable_contact_internal.cc
@@ -14,7 +14,19 @@ namespace geometry {
 namespace internal {
 namespace deformable {
 
+namespace {
+
+// Compare function to use with ordering results of
+// ComputeDeformableRigidContact.
+bool OrderDeformableRigidContact(const DeformableRigidContact<double>& c1,
+                                 const DeformableRigidContact<double>& c2) {
+  return c1.deformable_id() < c2.deformable_id();
+}
+
+}  // namespace
+
 void Geometries::RemoveGeometry(GeometryId id) {
+  deformable_geometries_.erase(id);
   rigid_geometries_.erase(id);
 }
 
@@ -37,6 +49,45 @@ void Geometries::UpdateRigidWorldPose(
   if (is_rigid(id)) {
     rigid_geometries_.at(id).set_pose_in_world(X_WG);
   }
+}
+
+void Geometries::AddDeformableGeometry(GeometryId id, VolumeMesh<double> mesh) {
+  deformable_geometries_.insert({id, DeformableGeometry(std::move(mesh))});
+}
+
+void Geometries::UpdateDeformableVertexPositions(
+    GeometryId id, const Eigen::Ref<const VectorX<double>>& q_WG) {
+  if (is_deformable(id)) {
+    deformable_geometries_.at(id).UpdateVertexPositions(q_WG);
+  }
+}
+
+void Geometries::ComputeDeformableRigidContact(
+    std::vector<DeformableRigidContact<double>>* deformable_rigid_contact)
+    const {
+  DRAKE_DEMAND(deformable_rigid_contact != nullptr);
+  deformable_rigid_contact->clear();
+  deformable_rigid_contact->reserve(deformable_geometries_.size());
+
+  for (const auto& [deformable_id, deformable_geometry] :
+       deformable_geometries_) {
+    const VolumeMesh<double>& deformable_mesh =
+        deformable_geometry.deformable_mesh().mesh();
+    DeformableRigidContact<double> contact_data(deformable_id,
+                                                deformable_mesh.num_vertices());
+    for (const auto& [rigid_id, rigid_geometry] : rigid_geometries_) {
+      const math::RigidTransform<double>& X_WR = rigid_geometry.pose_in_world();
+      const auto& rigid_bvh = rigid_geometry.rigid_mesh().bvh();
+      const auto& rigid_tri_mesh = rigid_geometry.rigid_mesh().mesh();
+      AppendDeformableRigidContact(deformable_geometry, rigid_id,
+                                   rigid_tri_mesh, rigid_bvh, X_WR,
+                                   &contact_data);
+    }
+    deformable_rigid_contact->emplace_back(std::move(contact_data));
+  }
+
+  std::sort(deformable_rigid_contact->begin(), deformable_rigid_contact->end(),
+            OrderDeformableRigidContact);
 }
 
 void Geometries::ImplementGeometry(const Sphere& sphere, void* user_data) {

--- a/geometry/proximity/deformable_contact_internal.h
+++ b/geometry/proximity/deformable_contact_internal.h
@@ -47,6 +47,12 @@ class Geometries final : public ShapeReifier {
     return rigid_geometries_.count(id) != 0;
   }
 
+  /* Returns true if a deformable geometry representation with the given `id`
+   exists. */
+  bool is_deformable(GeometryId id) const {
+    return deformable_geometries_.count(id) != 0;
+  }
+
   /* Removes the geometry (if it has a deformable contact representation). No-op
    if no geometry with a deformable contact representation exists with the
    provided id. */
@@ -78,6 +84,28 @@ class Geometries final : public ShapeReifier {
   void UpdateRigidWorldPose(GeometryId id,
                             const math::RigidTransform<double>& X_WG);
 
+  /* Adds a deformable geometry whose contact mesh representation is given by
+   `mesh`.
+
+   @param id     The unique identifier for the geometry.
+   @param mesh   The volume mesh representation of the deformable geometry.
+   @pre There is no previous representation associated with id. */
+  void AddDeformableGeometry(GeometryId id, VolumeMesh<double> mesh);
+
+  /* If a deformable geometry with `id` exists, updates the vertex positions
+   of the geometry (in the world frame) to `q_WG`. */
+  void UpdateDeformableVertexPositions(
+      GeometryId id, const Eigen::Ref<const VectorX<double>>& q_WG);
+
+  /* For each registered deformable geometry, computes the contact data of it
+   with respect to all registered rigid geometries. Assumes the vertex positions
+   and poses of all registered deformable and rigid geometries are up to date.
+   The results are sorted according to deformable id.
+   @pre deformable_rigid_contact != nullptr. */
+  void ComputeDeformableRigidContact(
+      std::vector<DeformableRigidContact<double>>* deformable_rigid_contact)
+      const;
+
  private:
   friend class GeometriesTester;
 
@@ -103,7 +131,8 @@ class Geometries final : public ShapeReifier {
   template <typename ShapeType>
   void AddRigidGeometry(const ShapeType& shape, const ReifyData& data);
 
-  // TODO(xuchenhan-tri): Add deformable geometries.
+  // The representations of all deformable geometries.
+  std::unordered_map<GeometryId, DeformableGeometry> deformable_geometries_;
 
   // The representations of all rigid geometries.
   std::unordered_map<GeometryId, RigidGeometry> rigid_geometries_;

--- a/geometry/proximity/test/deformable_contact_internal_test.cc
+++ b/geometry/proximity/test/deformable_contact_internal_test.cc
@@ -17,6 +17,15 @@ namespace deformable {
 
 class GeometriesTester {
  public:
+  /* Returns the deformable geometry with `deformable_id` registered in
+   `geometries`.
+   @pre a deformable representation with `deformable_id` exists in `geometries`.
+  */
+  static const DeformableGeometry& get_deformable_geometry(
+      const Geometries& geometries, GeometryId deformable_id) {
+    return geometries.deformable_geometries_.at(deformable_id);
+  }
+
   /* Returns the rigid geometry with `rigid_id` registered in `geometries`.
    @pre a rigid representation with `rigid_id` exists in `geometries`. */
   static const RigidGeometry& get_rigid_geometry(const Geometries& geometries,
@@ -29,6 +38,15 @@ namespace {
 
 using Eigen::Vector3d;
 using Eigen::VectorXd;
+
+/* Makes an arbitrary volume mesh. */
+VolumeMesh<double> MakeVolumeMesh() {
+  constexpr double kRadius = 0.5;
+  constexpr double kRezHint = 0.5;
+  Sphere sphere(kRadius);
+  return MakeSphereVolumeMesh<double>(
+      sphere, kRezHint, TessellationStrategy::kDenseInteriorVertices);
+}
 
 /* Makes a ProximityProperties with a resolution hint property in the hydro
  group.
@@ -44,6 +62,7 @@ GTEST_TEST(GeometriesTest, AddRigidGeometry) {
   GeometryId rigid_id = GeometryId::get_new_id();
   /* No geometries have been added yet. */
   EXPECT_FALSE(geometries.is_rigid(rigid_id));
+  EXPECT_FALSE(geometries.is_deformable(rigid_id));
 
   /* Add a rigid geometry with resolution hint property. */
   constexpr double kRadius = 0.5;
@@ -52,6 +71,7 @@ GTEST_TEST(GeometriesTest, AddRigidGeometry) {
   geometries.MaybeAddRigidGeometry(Sphere(kRadius), rigid_id, props);
 
   EXPECT_TRUE(geometries.is_rigid(rigid_id));
+  EXPECT_FALSE(geometries.is_deformable(rigid_id));
 
   /* Trying to a rigid geometry without the resolution hint property is a no-op.
    */
@@ -60,6 +80,7 @@ GTEST_TEST(GeometriesTest, AddRigidGeometry) {
   geometries.MaybeAddRigidGeometry(Sphere(kRadius), g_id, empty_props);
 
   EXPECT_FALSE(geometries.is_rigid(g_id));
+  EXPECT_FALSE(geometries.is_deformable(g_id));
 }
 
 /* Test coverage for all unsupported shapes as rigid geometries: MeshcatCone and
@@ -179,8 +200,25 @@ GTEST_TEST(GeometriesTest, UpdateRigidWorldPose) {
   }
 }
 
+GTEST_TEST(GeometriesTest, AddDeformableGeometry) {
+  Geometries geometries;
+  GeometryId deformable_id = GeometryId::get_new_id();
+  EXPECT_FALSE(geometries.is_rigid(deformable_id));
+  EXPECT_FALSE(geometries.is_deformable(deformable_id));
+
+  /* Add a deformable geometry. */
+  geometries.AddDeformableGeometry(deformable_id, MakeVolumeMesh());
+  EXPECT_FALSE(geometries.is_rigid(deformable_id));
+  EXPECT_TRUE(geometries.is_deformable(deformable_id));
+}
+
 GTEST_TEST(GeometriesTest, RemoveGeometry) {
   Geometries geometries;
+  /* Add a couple of deformable geometries. */
+  GeometryId deformable_id0 = GeometryId::get_new_id();
+  GeometryId deformable_id1 = GeometryId::get_new_id();
+  geometries.AddDeformableGeometry(deformable_id0, MakeVolumeMesh());
+  geometries.AddDeformableGeometry(deformable_id1, MakeVolumeMesh());
 
   /* Add a couple of rigid geometries. */
   GeometryId rigid_id0 = GeometryId::get_new_id();
@@ -191,24 +229,174 @@ GTEST_TEST(GeometriesTest, RemoveGeometry) {
   geometries.MaybeAddRigidGeometry(Sphere(kRadius), rigid_id0, props);
   geometries.MaybeAddRigidGeometry(Sphere(kRadius), rigid_id1, props);
 
+  /* Calling RemoveGeometry on an existing deformable geometry. */
+  geometries.RemoveGeometry(deformable_id0);
+  /* The geometry is indeed removed. */
+  EXPECT_FALSE(geometries.is_deformable(deformable_id0));
+  /* Other geometries are unaffected. */
+  EXPECT_TRUE(geometries.is_deformable(deformable_id1));
+  EXPECT_TRUE(geometries.is_rigid(rigid_id0));
+  EXPECT_TRUE(geometries.is_rigid(rigid_id1));
+
   /* Calling RemoveGeometry on an existing rigid geometry. */
-  {
-    geometries.RemoveGeometry(rigid_id0);
-    /* The geometry is indeed removed. */
-    EXPECT_FALSE(geometries.is_rigid(rigid_id0));
-    /* Other geometries are unaffected. */
-    EXPECT_TRUE(geometries.is_rigid(rigid_id1));
-  }
+  geometries.RemoveGeometry(rigid_id0);
+  /* The geometry is indeed removed. */
+  EXPECT_FALSE(geometries.is_rigid(rigid_id0));
+  /* Other geometries are unaffected. */
+  EXPECT_FALSE(geometries.is_deformable(deformable_id0));
+  EXPECT_TRUE(geometries.is_deformable(deformable_id1));
+  EXPECT_TRUE(geometries.is_rigid(rigid_id1));
+
   /* Calling RemoveGeometry on an invalid or already deleted geometry is a
    no-op. */
-  {
-    GeometryId invalid_id = GeometryId::get_new_id();
-    EXPECT_NO_THROW(geometries.RemoveGeometry(invalid_id));
-    EXPECT_NO_THROW(geometries.RemoveGeometry(rigid_id0));
+  GeometryId invalid_id = GeometryId::get_new_id();
+  EXPECT_NO_THROW(geometries.RemoveGeometry(invalid_id));
+  EXPECT_NO_THROW(geometries.RemoveGeometry(rigid_id0));
 
-    EXPECT_FALSE(geometries.is_rigid(rigid_id0));
-    EXPECT_TRUE(geometries.is_rigid(rigid_id1));
+  EXPECT_FALSE(geometries.is_rigid(rigid_id0));
+  EXPECT_FALSE(geometries.is_deformable(deformable_id0));
+  EXPECT_TRUE(geometries.is_rigid(rigid_id1));
+  EXPECT_TRUE(geometries.is_deformable(deformable_id1));
+}
+
+GTEST_TEST(GeometriesTest, UpdateDeformableVertexPositions) {
+  Geometries geometries;
+  /* Add a deformable geometry. */
+  GeometryId deformable_id = GeometryId::get_new_id();
+  const VolumeMesh<double> input_mesh = MakeVolumeMesh();
+  geometries.AddDeformableGeometry(deformable_id, input_mesh);
+  const int num_vertices = input_mesh.num_vertices();
+
+  /* Initially the vertex positions is the same as the registered mesh. */
+  {
+    ASSERT_TRUE(geometries.is_deformable(deformable_id));
+    const DeformableGeometry& geometry =
+        GeometriesTester::get_deformable_geometry(geometries, deformable_id);
+    EXPECT_TRUE(geometry.deformable_mesh().mesh().Equal(input_mesh));
   }
+  /* Update the vertex positions to some arbitrary value. */
+  const VectorXd q = VectorXd::LinSpaced(3 * num_vertices, 0.0, 1.0);
+  geometries.UpdateDeformableVertexPositions(deformable_id, q);
+  {
+    const DeformableGeometry& geometry =
+        GeometriesTester::get_deformable_geometry(geometries, deformable_id);
+    const VolumeMesh<double>& mesh = geometry.deformable_mesh().mesh();
+    for (int i = 0; i < num_vertices; ++i) {
+      const Vector3d& q_MV = mesh.vertex(i);
+      const Vector3d& reference_q_MV = input_mesh.vertex(i);
+      const Vector3d& expected_q_MV = q.segment<3>(3 * i);
+      EXPECT_EQ(q_MV, expected_q_MV);
+      EXPECT_NE(q_MV, reference_q_MV);
+    }
+  }
+}
+
+GTEST_TEST(GeometriesTest, ComputeDeformableRigidContact) {
+  Geometries geometries;
+  /* The contact data is empty when there is no deformable geometry. */
+  std::vector<DeformableRigidContact<double>> contact_data;
+  geometries.ComputeDeformableRigidContact(&contact_data);
+  EXPECT_EQ(contact_data.size(), 0);
+
+  /* Add a deformable unit cube. */
+  GeometryId deformable_id = GeometryId::get_new_id();
+  VolumeMesh<double> deformable_mesh =
+      MakeBoxVolumeMesh<double>(Box::MakeCube(1.0), 1.0);
+  const int num_vertices = deformable_mesh.num_vertices();
+  geometries.AddDeformableGeometry(deformable_id, std::move(deformable_mesh));
+
+  /* There is no rigid geometry to collide with the deformable geometry yet. */
+  geometries.ComputeDeformableRigidContact(&contact_data);
+  ASSERT_EQ(contact_data.size(), 1);
+  EXPECT_EQ(contact_data[0].num_rigid_geometries(), 0);
+  /* Add a rigid unit cube. */
+  GeometryId rigid_id = GeometryId::get_new_id();
+  ProximityProperties rigid_properties = MakeProximityPropsWithRezHint(1.0);
+  geometries.MaybeAddRigidGeometry(Box::MakeCube(1.0), rigid_id,
+                                   rigid_properties);
+  math::RigidTransform<double> X_WR(Vector3d(0, -2.0, 0));
+  geometries.UpdateRigidWorldPose(rigid_id, X_WR);
+
+  /* The deformable box and the rigid box are not in contact yet. */
+  geometries.ComputeDeformableRigidContact(&contact_data);
+  ASSERT_EQ(contact_data.size(), 1);
+  EXPECT_EQ(contact_data[0].num_rigid_geometries(), 0);
+
+  /* Now shift the rigid geometry closer to the deformable geometry.
+                                  +Z
+                                   |
+                                   |
+             rigid box             |      deformable box
+                   ----------+--+--+-------
+                   |         |  ●  |      |
+                   |         |  |  |      |
+            -Y-----+---------+--+--+------+-------+Y
+                   |         |  |  |      |
+                   |         |  ●  |      |
+                   ----------+--+--+-------
+                                   |
+                                   |
+                                   |
+                                  -Z
+    where the "●"s denote representative contact points. */
+  X_WR = math::RigidTransform<double>(Vector3d(0, -0.75, 0));
+  geometries.UpdateRigidWorldPose(rigid_id, X_WR);
+
+  /* Now there should be exactly one contact data. */
+  geometries.ComputeDeformableRigidContact(&contact_data);
+  ASSERT_EQ(contact_data.size(), 1);
+  const DeformableRigidContact<double>& box_box_contact_data = contact_data[0];
+
+  /* Verify that the contact surface is as expected. */
+  const auto& X_DR =
+      X_WR;  // The deformable mesh frame is always the world frame.
+  const DeformableGeometry& deformable_geometry =
+      GeometriesTester::get_deformable_geometry(geometries, deformable_id);
+  const RigidGeometry& rigid_geometry =
+      GeometriesTester::get_rigid_geometry(geometries, rigid_id);
+  DeformableRigidContact<double> expected_contact_data(deformable_id,
+                                                       num_vertices);
+  AppendDeformableRigidContact(
+      deformable_geometry, rigid_id, rigid_geometry.rigid_mesh().mesh(),
+      rigid_geometry.rigid_mesh().bvh(), X_DR, &expected_contact_data);
+
+  /* Verify that the contact data is the same as expected by checking a subset
+   of all data fields. */
+  ASSERT_EQ(box_box_contact_data.num_rigid_geometries(), 1);
+  ASSERT_EQ(expected_contact_data.num_rigid_geometries(), 1);
+  EXPECT_EQ(box_box_contact_data.rigid_ids()[0],
+            expected_contact_data.rigid_ids()[0]);
+  EXPECT_EQ(box_box_contact_data.deformable_id(),
+            expected_contact_data.deformable_id());
+  EXPECT_EQ(box_box_contact_data.num_contact_points(),
+            expected_contact_data.num_contact_points());
+  ASSERT_EQ(box_box_contact_data.contact_meshes_W().size(), 1);
+  ASSERT_EQ(expected_contact_data.contact_meshes_W().size(), 1);
+  EXPECT_TRUE(box_box_contact_data.contact_meshes_W()[0].Equal(
+      expected_contact_data.contact_meshes_W()[0]));
+}
+
+GTEST_TEST(GeometriesTest, DeformableRigidContactOrdering) {
+  Geometries geometries;
+
+  /* Add two deformable geometries. */
+  VolumeMesh<double> mesh = MakeBoxVolumeMesh<double>(Box::MakeCube(1.0), 1.0);
+  GeometryId id0 = GeometryId::get_new_id();
+  geometries.AddDeformableGeometry(id0, mesh);
+  GeometryId id1 = GeometryId::get_new_id();
+  geometries.AddDeformableGeometry(id1, mesh);
+
+  /* Verify that the contact results are sorted according to the deformable id
+   (even though each DeformableRigidContact is empty). */
+  std::vector<DeformableRigidContact<double>> contact_data;
+  /* Populate the vector with definitely unsorted DeformableRigidContact. */
+  contact_data.emplace_back(id1, mesh.num_vertices());
+  contact_data.emplace_back(id0, mesh.num_vertices());
+
+  geometries.ComputeDeformableRigidContact(&contact_data);
+  ASSERT_EQ(contact_data.size(), 2);
+  EXPECT_TRUE(contact_data[0].deformable_id() <
+              contact_data[1].deformable_id());
 }
 
 }  // namespace


### PR DESCRIPTION
Add the capability of adding, updating, and removing deformable geometries. 
Also add the function to compute all deformable vs. rigid geometry contact data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17606)
<!-- Reviewable:end -->
