### PR TITLE
[inverse_kinematics] Add GlobalIK::SetInitialGuess and benchmark

### DIFF
--- a/bindings/pydrake/multibody/inverse_kinematics_py.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py.cc
@@ -721,7 +721,9 @@ PYBIND11_MODULE(inverse_kinematics, m) {
                   q_desired, body_position_cost, body_orientation_cost);
             },
             py::arg("q_desired"), py::arg("body_position_cost"),
-            py::arg("body_orientation_cost"), cls_doc.AddPostureCost.doc);
+            py::arg("body_orientation_cost"), cls_doc.AddPostureCost.doc)
+        .def("SetInitialGuess", &Class::SetInitialGuess, py::arg("q"),
+            cls_doc.SetInitialGuess.doc);
     // TODO(russt): Add bindings for Polytope3D struct and related methods
     // (or convert those methods to use ConvexSets).
   }

--- a/bindings/pydrake/multibody/test/inverse_kinematics_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_test.py
@@ -678,6 +678,7 @@ class TestGlobalInverseKinematics(unittest.TestCase):
             body_orientation_cost=[1] * plant.num_bodies())
         gurobi_solver = GurobiSolver()
         if gurobi_solver.available():
+            global_ik.SetInitialGuess(q=plant.GetPositions(context))
             result = gurobi_solver.Solve(global_ik.prog())
             self.assertTrue(result.is_success())
             global_ik.ReconstructGeneralizedPositionSolution(result=result)

--- a/multibody/benchmarking/BUILD.bazel
+++ b/multibody/benchmarking/BUILD.bazel
@@ -5,6 +5,10 @@ load(
     "drake_cc_googlebench_binary",
     "drake_py_experiment_binary",
 )
+load(
+    "@drake//tools/skylark:test_tags.bzl",
+    "gurobi_test_tags",
+)
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])
@@ -72,6 +76,31 @@ drake_cc_googlebench_binary(
 drake_py_experiment_binary(
     name = "iiwa_relaxed_pos_ik_experiment",
     googlebench_binary = ":iiwa_relaxed_pos_ik",
+)
+
+drake_cc_googlebench_binary(
+    name = "homecart_global_ik",
+    srcs = ["homecart_global_ik.cc"],
+    add_test_rule = True,
+    data = [
+        "//manipulation/models/tri_homecart:models",
+        "//manipulation/models/ur3e:models",
+        "//manipulation/models/wsg_50_description:models",
+    ],
+    test_tags = gurobi_test_tags(),
+    deps = [
+        "//common:find_resource",
+        "//multibody/inverse_kinematics",
+        "//multibody/parsing",
+        "//solvers:solve",
+        "//tools/performance:fixture_common",
+        "//tools/performance:gflags_main",
+    ],
+)
+
+drake_py_experiment_binary(
+    name = "homecart_global_ik_experiment",
+    googlebench_binary = ":homecart_global_ik",
 )
 
 drake_cc_googlebench_binary(

--- a/multibody/benchmarking/homecart_global_ik.cc
+++ b/multibody/benchmarking/homecart_global_ik.cc
@@ -1,0 +1,65 @@
+// @file
+// Benchmark for GlobalInverseKinematics on the dual-arm TRI Homecart.
+
+#include "drake/common/find_resource.h"
+#include "drake/multibody/inverse_kinematics/global_inverse_kinematics.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/parsing/process_model_directives.h"
+#include "drake/solvers/solve.h"
+#include "drake/tools/performance/fixture_common.h"
+
+namespace drake {
+namespace multibody {
+namespace inverse_kinematics {
+namespace {
+
+class HomecartGlobalIkBenchmark : public benchmark::Fixture {
+ public:
+  HomecartGlobalIkBenchmark() {
+    tools::performance::AddMinMaxStatistics(this);
+    this->Unit(benchmark::kSecond);
+
+    // Set a fixed seed for random generation.
+    std::srand(1234);
+  }
+};
+
+// This benchmark adds only the posture cost (joint limits are also added in
+// the constructor), so the optimal solution is the q0 passed to
+// AddPostureCost. Passing this solution to SetInitialGuess demonstrates a
+// limit on the speedup that can be obtained using SetInitialGuess; that
+// speedup is substantial.
+BENCHMARK_F(HomecartGlobalIkBenchmark, PostureCost)(benchmark::State& state) {  // NOLINT
+  multibody::MultibodyPlant<double> plant(0.0);
+  geometry::SceneGraph<double> scene_graph;
+  plant.RegisterAsSourceForSceneGraph(&scene_graph);
+  multibody::Parser parser(&plant);
+  multibody::parsing::ModelDirectives directives =
+      multibody::parsing::LoadModelDirectives(FindResourceOrThrow(
+          "drake/manipulation/models/tri_homecart/homecart_no_grippers.yaml"));
+  multibody::parsing::ProcessModelDirectives(directives, &plant, nullptr,
+                                             &parser);
+  plant.Finalize();
+
+  Eigen::VectorXd q0(plant.num_positions());
+  // A somewhat arbitrary configuration with the arms posed comfortably inside
+  // the workspace.
+  q0 << 1.75, -1.04, 1.27, -1.79, -2.75, 0.25, -1.45, -2.5, -1.04, -1.32, 3.11,
+      0;
+
+  GlobalInverseKinematics global_ik(plant);
+  global_ik.AddPostureCost(q0,
+                           Eigen::VectorXd::Constant(plant.num_bodies(), 1.0),
+                           Eigen::VectorXd::Constant(plant.num_bodies(), 1));
+
+  for (auto _ : state) {
+    global_ik.SetInitialGuess(q0);
+    auto result = solvers::Solve(global_ik.prog());
+    DRAKE_DEMAND(result.is_success());
+  }
+}
+
+}  // namespace
+}  // namespace inverse_kinematics
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -104,11 +104,13 @@ drake_cc_library(
         "global_inverse_kinematics.h",
     ],
     deps = [
+        "//common:scope_exit",
         "//multibody/plant",
         "//solvers:mathematical_program",
         "//solvers:mathematical_program_result",
         "//solvers:mixed_integer_rotation_constraint",
         "//solvers:rotation_constraint",
+        "//solvers:solve",
     ],
 )
 

--- a/multibody/inverse_kinematics/global_inverse_kinematics.h
+++ b/multibody/inverse_kinematics/global_inverse_kinematics.h
@@ -351,6 +351,7 @@ class GlobalInverseKinematics {
 
   /**
    * Adds joint limits on a specified joint.
+   * @note This method is called from the constructor.
    * @param body_index The joint connecting the parent link to this body will be
    * constrained.
    * @param joint_lower_bound The lower bound for the joint.
@@ -367,6 +368,16 @@ class GlobalInverseKinematics {
   void AddJointLimitConstraint(BodyIndex body_index, double joint_lower_bound,
                                double joint_upper_bound,
                                bool linear_constraint_approximation = false);
+
+  /**
+   * Sets an initial guess for all variables (including the binary variables)
+   * by evaluating the kinematics of the plant at `q`.  Currently, this is
+   * accomplished by solving the global IK problem subject to constraints that
+   * the positions and rotation matrices match the kinematics, which is
+   * dramatically faster than solving the original problem.
+   * @throws std::runtime_error if solving results in an infeasible program.
+   */
+  void SetInitialGuess(const Eigen::Ref<const Eigen::VectorXd>& q);
 
  private:
   // This is an utility function for `ReconstructGeneralizedPositionSolution`.


### PR DESCRIPTION
Towards #17507.

Adds a benchmark for GlobalInverseKinematics using the TRI Homecart
dual-arm manipulator.  The use of SetInitialGuess on the HomeCart
benchmark improves solve times on the benchmark from ~47s to ~7s.

Also fixes GlobalIK's use of WeldJoint::X_PC() as reported in #17600.

+@hongkai-dai for feature review, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17608)
<!-- Reviewable:end -->
