### PR TITLE
[geometry] Add HandleUnsupportedGeometry for Shape

### DIFF
--- a/geometry/make_mesh_for_deformable.cc
+++ b/geometry/make_mesh_for_deformable.cc
@@ -27,7 +27,7 @@ void MeshBuilderForDeformable::ImplementGeometry(const Sphere& sphere,
       TessellationStrategy::kDenseInteriorVertices));
 }
 
-void MeshBuilderForDeformable::ThrowUnsupportedGeometry(
+void MeshBuilderForDeformable::HandleUnsupportedGeometry(
     const std::string& shape_name) {
   throw std::logic_error(
       fmt::format("MeshBuilderForDeformable: We don't yet generate deformable "

--- a/geometry/make_mesh_for_deformable.h
+++ b/geometry/make_mesh_for_deformable.h
@@ -35,7 +35,7 @@ class MeshBuilderForDeformable : public ShapeReifier {
   // TODO(xuchenhan-tri): As other shapes get supported, include their specific
   //  overrides here.
 
-  void ThrowUnsupportedGeometry(const std::string& shape_name) override;
+  void HandleUnsupportedGeometry(const std::string& shape_name) override;
 };
 
 }  // namespace internal

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -151,43 +151,47 @@ MeshcatCone::MeshcatCone(double height, double a, double b)
 ShapeReifier::~ShapeReifier() = default;
 
 void ShapeReifier::ImplementGeometry(const Sphere&, void*) {
-  ThrowUnsupportedGeometry("Sphere");
+  HandleUnsupportedGeometry("Sphere");
 }
 
 void ShapeReifier::ImplementGeometry(const Cylinder&, void*) {
-  ThrowUnsupportedGeometry("Cylinder");
+  HandleUnsupportedGeometry("Cylinder");
 }
 
 void ShapeReifier::ImplementGeometry(const HalfSpace&, void*) {
-  ThrowUnsupportedGeometry("HalfSpace");
+  HandleUnsupportedGeometry("HalfSpace");
 }
 
 void ShapeReifier::ImplementGeometry(const Box&, void*) {
-  ThrowUnsupportedGeometry("Box");
+  HandleUnsupportedGeometry("Box");
 }
 
 void ShapeReifier::ImplementGeometry(const Capsule&, void*) {
-  ThrowUnsupportedGeometry("Capsule");
+  HandleUnsupportedGeometry("Capsule");
 }
 
 void ShapeReifier::ImplementGeometry(const Ellipsoid&, void*) {
-  ThrowUnsupportedGeometry("Ellipsoid");
+  HandleUnsupportedGeometry("Ellipsoid");
 }
 void ShapeReifier::ImplementGeometry(const Mesh&, void*) {
-  ThrowUnsupportedGeometry("Mesh");
+  HandleUnsupportedGeometry("Mesh");
 }
 
 void ShapeReifier::ImplementGeometry(const Convex&, void*) {
-  ThrowUnsupportedGeometry("Convex");
+  HandleUnsupportedGeometry("Convex");
 }
 
 void ShapeReifier::ImplementGeometry(const MeshcatCone&, void*) {
-  ThrowUnsupportedGeometry("MeshcatCone");
+  HandleUnsupportedGeometry("MeshcatCone");
 }
 
 void ShapeReifier::ThrowUnsupportedGeometry(const std::string& shape_name) {
   throw std::runtime_error(fmt::format("This class ({}) does not support {}.",
                                        NiceTypeName::Get(*this), shape_name));
+}
+
+void ShapeReifier::HandleUnsupportedGeometry(const std::string& shape_name) {
+  ThrowUnsupportedGeometry(shape_name);
 }
 
 ShapeName::ShapeName(const Shape& shape) {

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -6,6 +6,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/math/rigid_transform.h"
 
@@ -36,7 +37,7 @@ struct ShapeTag{};
   When you add a new subclass of Shape to Drake, you must:
 
   1. add a virtual function ImplementGeometry() for the new shape in
-     ShapeReifier that invokes the ThrowUnsupportedGeometry method, and add to
+     ShapeReifier that invokes the HandleUnsupportedGeometry method, and add to
      the test for it in shape_specification_test.cc.
   2. implement ImplementGeometry in derived ShapeReifiers to continue support
      if desired, otherwise ensure unimplemented functions are not hidden in new
@@ -420,10 +421,18 @@ class ShapeReifier {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ShapeReifier)
   ShapeReifier() = default;
 
+  // TODO(xuchenhan-tri): Find a way to deprecate this virtual function.
+  // Subclasses can override HandleUnsupportedGeometry() instead.
   /** Derived ShapeReifiers can replace the default message for unsupported
    geometries by overriding this method. The name of the unsupported shape type
    is given as the single parameter.  */
   virtual void ThrowUnsupportedGeometry(const std::string& shape_name);
+
+  /** Defaults to throwing an exception by calling ThrowUnsupportedGeometry.
+   Derived ShapeReifiers can replace the default behavior towards unsupported
+   geometries by overriding this method. The name of the unsupported shape type
+   is given as the single parameter.  */
+  virtual void HandleUnsupportedGeometry(const std::string& shape_name);
 };
 
 // TODO(SeanCurtis-TRI): Merge this into shape_to_string.h so that there's a


### PR DESCRIPTION
Give subclasses a choice for a softer response than throwing for unsupported geometries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17610)
<!-- Reviewable:end -->
