### PR TITLE
Remove duplicate command in build-wheel.sh

### DIFF
--- a/tools/wheel/image/build-wheel.sh
+++ b/tools/wheel/image/build-wheel.sh
@@ -103,7 +103,6 @@ rm -rf \
     ${WHEEL_DATA_DIR}/manipulation/models/ur3e/*.obj \
     ${WHEEL_DATA_DIR}/manipulation/models/ur3e/*.png \
     ${WHEEL_DATA_DIR}/manipulation/models/ycb/meshes \
-    ${WHEEL_DATA_DIR}/manipulation/models/ycb/meshes \
     ${WHEEL_DATA_DIR}/examples/atlas \
     ${WHEEL_DATA_DIR}/examples/hydroelastic/spatula_slip_control
 


### PR DESCRIPTION
5969b87e1df98c6895adf32d69565cd93ec02859 added a duplicate entry to the set of data files that are excluded from the wheel. Since this has no effect other than to potentially confuse the reader, remove it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17613)
<!-- Reviewable:end -->
