### PR TITLE
[doc] Add macOS stable releases for pip wheels

### DIFF
--- a/doc/_pages/installation.md
+++ b/doc/_pages/installation.md
@@ -87,7 +87,7 @@ All other packages support both C++ and/or Python.
 
 |                       | Ubuntu | macOS |
 |-----------------------|--------|-------|
-| Using pip             | [Stable](/pip.html#stable-releases) or [Nightly](/pip.html#nightly-releases) | [Nightly](/pip.html#nightly-releases) |
+| Using pip             | [Stable](/pip.html#stable-releases) or [Nightly](/pip.html#nightly-releases) | [Stable](/pip.html#stable-releases) or [Nightly](/pip.html#nightly-releases) |
 | Using apt (deb)       | [Stable](/apt.html#stable-releases) or [Nightly](/apt.html#nightly-releases) | |
 | Using tar.gz download | [Stable](/from_binary.html#stable-releases) or [Nightly](/from_binary.html#nightly-releases) | [Stable](/from_binary.html#stable-releases) or [Nightly](/from_binary.html#nightly-releases) |
 | Using Docker Hub      | [Stable](/docker.html#stable-releases) or [Nightly](/docker.html#nightly-releases) | [Stable](/docker.html#stable-releases) or [Nightly](/docker.html#nightly-releases) |

--- a/doc/_pages/pip.md
+++ b/doc/_pages/pip.md
@@ -27,11 +27,6 @@ Gurobi, you will need to [build Drake from source](/from_source.html).
 ## Stable Releases
 
 <div class="warning" markdown="1">
-Drake's pip wheels are only published for CPython 3.8 through CPython 3.9
-running on Linux.  In the future, we intend to publish macOS wheel builds.
-</div>
-
-<div class="warning" markdown="1">
 Drake does not support the Python environment supplied by Anaconda. Before
 installing or using Drake, please `conda deactivate` (repeatedly, until even
 the conda base environment has been deactivated) such that none of the paths
@@ -68,6 +63,8 @@ For Ubuntu 20.04, install these additional libraries:
 sudo apt-get install --no-install-recommends \
   libpython3.8 libx11-6 libsm6 libxt6 libglib2.0-0
 ```
+
+For macOS, ensure that you're using Homebrew Python (not Apple's system Python).
 
 Activate the virtual environment:
 

--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -271,6 +271,25 @@ If you haven't done so already, follow Drake's PyPI
 [account setup](https://docs.google.com/document/d/17D0yzyr0kGH44eWpiNY7E33A8hW1aiJRmADaoAlVISE/edit#)
 instructions to obtain a username and password.
 
+### Mac wheel builds
+
+1. Open the [Jenkins Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Wheel/job/mac-big-sur-unprovisioned-clang-wheel-staging-snopt-mosek-release/) page.
+2. In the upper right, click "log in" (unless you're already logged in). This
+   will use your GitHub credentials.
+3. Click "Build with Parameters".
+4. Change "sha1" to the full **git sha** corresponding to ``v1.N.0`` and
+   "release_version" to ``1.N.0``.
+5. Click "Build"; the build will finish after approximately 75 minutes.
+6. After it's finished, open the "Console Output" and scroll to the bottom to
+   find the URL of the built wheel, which will be something like
+   `https://drake-packages.csail.mit.edu/drake/staging/drake-1.N.0-cp39-cp39-macosx_11_0_x86_64.whl`.
+7. Download that wheel.
+8. Run ``twine upload <...>``, replacing the ``<...>`` placeholder with the path
+   to the file you downloaded.
+    1. You will need your PyPI username and password for this. (Do not use drake-robot.)
+
+### Linux wheel builds
+
 1. Use your Ubuntu 20.04 workstation for these steps.  (Do not use any other OS.)
 2. Create some empty scratch folder to use for these steps, and then ``cd`` into it.
 3. Run ``sudo apt install docker.io twine``


### PR DESCRIPTION
I've uploaded a v1.5.0 wheel using this process.

Closes #15958.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17619)
<!-- Reviewable:end -->
