### PR TITLE
[misc] Clean up unsupported/Eigen/AutoDiff include and using

### DIFF
--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -2,6 +2,7 @@
 #include "pybind11/operators.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
+#include <unsupported/Eigen/AutoDiff>
 
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"

--- a/common/yaml/test/yaml_performance_test.cc
+++ b/common/yaml/test/yaml_performance_test.cc
@@ -1,9 +1,11 @@
 #include <vector>
 
+#include <Eigen/Core>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <unsupported/Eigen/AutoDiff>
 
-#include "drake/common/autodiff.h"
+#include "drake/common/eigen_types.h"
 #include "drake/common/name_value.h"
 #include "drake/common/test_utilities/limit_malloc.h"
 #include "drake/common/yaml/yaml_io.h"

--- a/examples/bead_on_a_wire/bead_on_a_wire.h
+++ b/examples/bead_on_a_wire/bead_on_a_wire.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <Eigen/Core>
+#include <unsupported/Eigen/AutoDiff>
 
-#include "drake/common/autodiff.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {

--- a/math/autodiff.h
+++ b/math/autodiff.h
@@ -10,6 +10,7 @@ Utilities for arithmetic on AutoDiffScalar. */
 #include <utility>
 
 #include <Eigen/Dense>
+#include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/autodiff.h"
 #include "drake/common/eigen_types.h"

--- a/math/jacobian.h
+++ b/math/jacobian.h
@@ -4,8 +4,7 @@
 #include <cmath>
 
 #include <Eigen/Dense>
-
-#include "drake/common/autodiff.h"
+#include <unsupported/Eigen/AutoDiff>
 
 namespace drake {
 namespace math {

--- a/math/test/autodiff_test.cc
+++ b/math/test/autodiff_test.cc
@@ -2,6 +2,7 @@
 
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
+#include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/autodiff.h"
 #include "drake/common/eigen_types.h"

--- a/math/test/differentiable_norm_test.cc
+++ b/math/test/differentiable_norm_test.cc
@@ -2,7 +2,7 @@
 
 #include <gtest/gtest.h>
 
-#include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/autodiff.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 

--- a/math/test/expmap_test.cc
+++ b/math/test/expmap_test.cc
@@ -7,7 +7,6 @@
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
 
-using Eigen::AutoDiffScalar;
 using Eigen::Matrix3d;
 using Eigen::Vector4d;
 

--- a/math/test/jacobian_test.cc
+++ b/math/test/jacobian_test.cc
@@ -3,7 +3,6 @@
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 
-#include "drake/common/autodiff.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/math/autodiff_gradient.h"

--- a/math/test/linear_solve_test.cc
+++ b/math/test/linear_solve_test.cc
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include <gtest/gtest.h>
+#include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -298,7 +298,7 @@ class RotationalInertia {
   ///          product absolute value in `other`.  Otherwise returns `false`.
   /// @note: This method only works if all moments of inertia with scalar type T
   ///    in `this` and `other` can be converted to a double (discarding
-  ///    supplemental scalar data such as derivatives of an AutoDiffScalar).
+  ///    supplemental scalar data such as derivatives of an AutoDiffXd).
   ///    It fails at runtime if type T cannot be converted to `double`.
   boolean<T> IsNearlyEqualTo(const RotationalInertia& other,
                              double precision) const {
@@ -526,7 +526,7 @@ class RotationalInertia {
   ///
   /// @note: This method only works for a rotational inertia with scalar type T
   ///        that can be converted to a double (discarding any supplemental
-  ///        scalar data such as derivatives of an AutoDiffScalar).
+  ///        scalar data such as derivatives of an AutoDiffXd).
   ///
   /// @retval principal_moments The vector of principal moments of inertia
   ///                           `[Ixx Iyy Izz]` sorted in ascending order.
@@ -534,7 +534,7 @@ class RotationalInertia {
   ///         cannot be converted to a double.
   Vector3<double> CalcPrincipalMomentsOfInertia() const {
     // Notes:
-    //   1. Eigen's SelfAdjointEigenSolver does not compile for AutoDiffScalar.
+    //   1. Eigen's SelfAdjointEigenSolver does not compile for AutoDiffXd.
     //      Therefore, convert `this` to a local copy of type Matrix3<double>.
     //   2. Eigen's SelfAdjointEigenSolver only uses the lower-triangular part
     //      of this symmetric matrix.

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -105,8 +105,8 @@ GTEST_TEST(SpatialInertia, ConstructionFromMassCmAndUnitInertia) {
 // Tests that we can correctly cast a SpatialInertia<double> to a
 // SpatialInertia<AutoDiffXd>.
 // The cast from a SpatialInertia<double>, a constant, results in a spatial
-// inertia with zero gradients. Since we are using a dynamic size
-// AutoDiffScalar type, this results in gradient vectors with zero size.
+// inertia with zero gradients. Since we are using AutoDiffXd with dynamic size
+// derivatives(), this results in gradient vectors with zero size.
 GTEST_TEST(SpatialInertia, CastToAutoDiff) {
   const double mass_double = 2.5;
   const Vector3d com_double(0.1, -0.2, 0.3);

--- a/multibody/tree/test/unit_inertia_test.cc
+++ b/multibody/tree/test/unit_inertia_test.cc
@@ -512,7 +512,7 @@ GTEST_TEST(UnitInertia, ShiftFromCenterOfMassInPlace) {
 }
 
 // Tests that we can correctly cast a UnitInertia<double> to a UnitInertia
-// templated on an AutoDiffScalar type.
+// templated on AutoDiffXd.
 GTEST_TEST(UnitInertia, CastToAutoDiff) {
   const UnitInertia<double> I_double(1, 2.718, 3.14);
 
@@ -529,8 +529,8 @@ GTEST_TEST(UnitInertia, CastToAutoDiff) {
                               Eigen::MatrixXd(9, 0)));
 }
 
-// Tests that we can instantiate a unit inertia with AutoDiffScalar and
-// we can perform some basic operations with it.
+// Tests that we can instantiate a unit inertia with AutoDiffXd and we can
+// perform some basic operations with it.
 // As an example, we define the unit inertia G_B of a body B. The
 // orientation of this body in the world frame W is given by the time dependent
 // rotation R_WB = Rz(theta(t)) about the z-axis with angle theta(t).

--- a/solvers/constraint.cc
+++ b/solvers/constraint.cc
@@ -513,7 +513,7 @@ void PositiveSemidefiniteConstraint::DoEval(
     const Eigen::Ref<const AutoDiffVecXd>&, AutoDiffVecXd*) const {
   throw std::logic_error(
       "The Eval function for positive semidefinite constraint is not defined, "
-      "since the eigen solver does not work for AutoDiffScalar.");
+      "since the eigen solver does not work for AutoDiffXd.");
 }
 
 void PositiveSemidefiniteConstraint::DoEval(
@@ -539,7 +539,7 @@ void LinearMatrixInequalityConstraint::DoEval(
     const Eigen::Ref<const AutoDiffVecXd>&, AutoDiffVecXd*) const {
   throw std::logic_error(
       "The Eval function for positive semidefinite constraint is not defined, "
-      "since the eigen solver does not work for AutoDiffScalar.");
+      "since the eigen solver does not work for AutoDiffXd.");
 }
 
 void LinearMatrixInequalityConstraint::DoEval(

--- a/solvers/constraint.h
+++ b/solvers/constraint.h
@@ -923,8 +923,7 @@ class PositiveSemidefiniteConstraint : public Constraint {
 
   /**
    * @param x The stacked columns of the symmetric matrix. This function is not
-   * supported yet, since Eigen's eigen value solver does not accept
-   * AutoDiffScalar.
+   * supported yet, since Eigen's eigen value solver does not accept AutoDiffXd.
    */
   void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
               AutoDiffVecXd* y) const override;
@@ -986,7 +985,7 @@ class LinearMatrixInequalityConstraint : public Constraint {
 
   /**
    * This function is not supported, since Eigen's eigen value solver does not
-   * accept AutoDiffScalar type.
+   * accept AutoDiffXd.
    */
   void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
               AutoDiffVecXd* y) const override;

--- a/solvers/moby_lcp_solver.cc
+++ b/solvers/moby_lcp_solver.cc
@@ -13,8 +13,8 @@
 #include <Eigen/LU>
 #include <Eigen/SparseCore>
 #include <Eigen/SparseLU>
+#include <unsupported/Eigen/AutoDiff>
 
-#include "drake/common/autodiff.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/never_destroyed.h"
 #include "drake/common/text_logging.h"

--- a/solvers/test/moby_lcp_solver_test.cc
+++ b/solvers/test/moby_lcp_solver_test.cc
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include <gtest/gtest.h>
+#include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -7,6 +7,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/autodiff.h"
 #include "drake/common/drake_assert.h"

--- a/tools/vector_gen/test/sample_test.cc
+++ b/tools/vector_gen/test/sample_test.cc
@@ -168,14 +168,14 @@ GTEST_TEST(SampleTest, IsValid) {
 
 // Cover Simple<AutoDiffXd>::IsValid.
 GTEST_TEST(SampleTest, AutoDiffXdIsValid) {
-  // A NaN in the AutoDiffScalar::value() makes us invalid.
+  // A NaN in the AutoDiffXd::value() makes us invalid.
   Sample<AutoDiffXd> dut;
   dut.set_unset(0.0);  // N.B. Sample<T>.unset is an invalid value by default.
   EXPECT_TRUE(dut.IsValid());
   dut.set_x(std::numeric_limits<double>::quiet_NaN());
   EXPECT_FALSE(dut.IsValid());
 
-  // A NaN in the AutoDiffScalar::derivatives() is still valid.
+  // A NaN in the AutoDiffXd::derivatives() is still valid.
   AutoDiffXd zero_with_nan_derivatives{0};
   zero_with_nan_derivatives.derivatives() =
       Vector1d(std::numeric_limits<double>::quiet_NaN());


### PR DESCRIPTION
Towards #17492.

When using `AutoDiffScalar` directly (not via the `drake::AutoDiffXd` alias), include the `unsupported/Eigen` header directly. This will enable `drake::AutoDiffXd` to alias to a different type in the future.

Tidy up some comments that refer to `AutoDiffScalar` where they really meant `AutoDiffXd`.

Fix a mistake including `eigen_autodiff_types` directly.

Remove some unused code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17620)
<!-- Reviewable:end -->
