### PR TITLE
[ad] Add AutoDiff replacement class for AutoDiffXd

### DIFF
--- a/common/ad/BUILD.bazel
+++ b/common/ad/BUILD.bazel
@@ -1,0 +1,64 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+    "drake_cc_package_library",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:private"])
+
+drake_cc_package_library(
+    name = "ad",
+    visibility = ["//visibility:private"],
+    deps = [
+        ":auto_diff",
+    ],
+)
+
+drake_cc_library(
+    name = "auto_diff",
+    srcs = [
+        "internal/partials.cc",
+        "internal/standard_operations.cc",
+    ],
+    hdrs = [
+        "auto_diff.h",
+        "internal/partials.h",
+        "internal/standard_operations.h",
+    ],
+    deps = [
+        "//common:essential",
+    ],
+)
+
+drake_cc_googletest(
+    name = "auto_diff_basic_test",
+    deps = [
+        ":auto_diff",
+    ],
+)
+
+drake_cc_googletest(
+    name = "partials_test",
+    deps = [
+        ":auto_diff",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "standard_operations_test",
+    # The test is split into multiple source files to improve compilation time.
+    srcs = [
+        "test/standard_operations_stream_test.cc",
+    ],
+    deps = [
+        ":auto_diff",
+    ],
+)
+
+add_lint_tests()

--- a/common/ad/README.md
+++ b/common/ad/README.md
@@ -1,0 +1,15 @@
+
+Drake's AutoDiff implementation
+-------------------------------
+
+This directory is a work-in-progress for Drake's forthcoming replacement of
+`Eigen::AutoDiffScalar<Eigen::VectorXd>`.
+
+The `namespace ad { ... }` is chosen for it's compact size in debugging traces,
+but is not otherwise exposed to users.
+
+Users should continue to `#include <drake/common/autodiff.h>` and refer to
+`drake::AutoDiffXd` in their code.
+
+Once we are confident with our replacement implementation, we will switch that
+alias to refer to this new code instead of Eigen's AutoDiffScalar.

--- a/common/ad/auto_diff.h
+++ b/common/ad/auto_diff.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "drake/common/ad/internal/partials.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace ad {
+
+/** A scalar type that performs automatic differentiation, similar to
+`Eigen::AutoDiffScalar<Eigen::VectorXd>`. Unlike `Eigen::AutoDiffScalar`,
+Drake's AutoDiff is not templated; it only supports dynamically-sized
+derivatives using floating-point doubles.
+
+At the moment, the features of this class are similar to Eigen::AutoDiffScalar,
+but in the future Drake will further customize this class to optimize its
+runtime performance and better integrate it with our optimization tools. */
+class AutoDiff {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(AutoDiff);
+
+  /** Compatibility alias to mimic Eigen::AutoDiffScalar. */
+  using DerType = Eigen::VectorXd;
+
+  /** Compatibility alias to mimic Eigen::AutoDiffScalar. */
+  using Scalar = double;
+
+  /** Constructs zero. */
+  AutoDiff() = default;
+
+  /** Constructs a value with empty derivatives. */
+  // NOLINTNEXTLINE(runtime/explicit): This conversion is desirable.
+  AutoDiff(double value) : value_{value} {}
+
+  /** Constructs a value with a single partial derivative of 1.0 at the given
+  `offset` in a vector of `size` otherwise-zero derivatives. */
+  AutoDiff(double value, Eigen::Index size, Eigen::Index offset)
+      : value_{value},
+        partials_{size, offset} {}
+
+  /** Constructs a value with the given derivatives. */
+  AutoDiff(
+      double value,
+      const Eigen::Ref<const Eigen::VectorXd>& derivatives)
+      : value_{value},
+        partials_{derivatives} {}
+
+  /** Assigns a value and clears the derivatives. */
+  AutoDiff& operator=(double value) {
+    value_ = value;
+    partials_.SetZero();
+    return *this;
+  }
+
+  ~AutoDiff() = default;
+
+  /** Returns the value part of this %AutoDiff (readonly). */
+  double value() const { return value_; }
+
+  /** (Advanced) Returns the value part of this %AutoDiff (mutable).
+  Operations on this value will NOT alter the derivatives. */
+  double& value() { return value_; }
+
+  /** Returns a view of the derivatives part of this %AutoDiff (readonly).
+
+  Do not presume any specific C++ type for the the return value. It will act
+  like an Eigen column-vector expression (e.g., Eigen::Block<const VectorXd>),
+  but we reserve the right to change the return type for efficiency down the
+  road. */
+  const Eigen::VectorXd& derivatives() const {
+    return partials_.make_const_xpr();
+  }
+
+  /** (Advanced) Returns a mutable view of the derivatives part of this
+  %AutoDiff.
+
+  Instead of mutating the derivatives after construction, it's generally
+  preferable to set them directly in the constructor if possible.
+
+  Do not presume any specific C++ type for the the return value. It will act
+  like a mutable Eigen column-vector expression (e.g., Eigen::Block<VectorXd>)
+  that also allows for assignment and resizing, but we reserve the right to
+  change the return type for efficiency down the road. */
+  Eigen::VectorXd& derivatives() {
+    return partials_.get_raw_storage_mutable();
+  }
+
+ private:
+  double value_{0.0};
+  internal::Partials partials_;
+};
+
+}  // namespace ad
+}  // namespace drake
+
+/* clang-format off to disable clang-format-includes */
+// These further refine our AutoDiff type and must appear in exactly this order.
+#include "drake/common/ad/internal/standard_operations.h"

--- a/common/ad/internal/partials.cc
+++ b/common/ad/internal/partials.cc
@@ -1,0 +1,69 @@
+#include "drake/common/ad/internal/partials.h"
+
+#include <stdexcept>
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+namespace drake {
+namespace ad {
+namespace internal {
+
+namespace {
+
+// Narrow an Eigen::Index to a plain int index, throwing when out-of-range.
+int IndexToInt(Eigen::Index index) {
+  if (index < 0) {
+    throw std::out_of_range(fmt::format(
+        "AutoDiff derivatives size or offset {} is negative",
+        index));
+  }
+  if (index > INT32_MAX) {
+    throw std::out_of_range(fmt::format(
+        "AutoDiff derivatives size or offset {} is too large",
+        index));
+  }
+  return static_cast<int>(index);
+}
+
+}  // namespace
+
+Partials::Partials(Eigen::Index size, Eigen::Index offset, double coeff)
+    : derivatives_{Eigen::VectorXd::Zero(IndexToInt(size))} {
+  if (IndexToInt(offset) >= size) {
+    throw std::out_of_range(fmt::format(
+        "AutoDiff offset {} must be strictly less than size {}",
+        offset, size));
+  }
+  derivatives_[offset] = coeff;
+}
+
+Partials::Partials(const Eigen::Ref<const Eigen::VectorXd>& value)
+    : derivatives_{value} {}
+
+void Partials::Add(const Partials& other) {
+  AddScaled(1.0, other);
+}
+
+void Partials::AddScaled(double scale, const Partials& other) {
+  if (other.size() == 0) {
+    return;
+  }
+  if (size() == 0) {
+    derivatives_ = scale * other.derivatives_;
+    return;
+  }
+  if (size() != other.size()) {
+    throw std::logic_error(fmt::format(
+        "The size of AutoDiff partial derivative vectors must be uniform"
+        " throughout the computation, but two different sizes ({} and {})"
+        " were encountered at runtime. The derivatives were {} and {}.",
+        size(), other.size(), derivatives_.transpose(),
+        other.derivatives_.transpose()));
+  }
+  derivatives_ += scale * other.derivatives_;
+}
+
+}  // namespace internal
+}  // namespace ad
+}  // namespace drake

--- a/common/ad/internal/partials.h
+++ b/common/ad/internal/partials.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace ad {
+namespace internal {
+
+/* A vector of partial derivatives, for use with Drake's AutoDiff.
+
+Partials are dynamically sized, and can have size() == 0.
+
+When adding two Partials, they must have a compatible size(). A Partials with
+size() == 0 may be freely combined with any other size, and is treated as-if
+it were filled with all zeros. When adding two Partials where each one has a
+non-zero size, the two sizes must be identical.
+
+Note that a Partials object with non-zero size might still be filled with zeros
+for its values. Once a non-zero size() has been established, it is "sticky" and
+never returns back to being zero-sized (unless the Partials is moved-from).
+
+In particular, note that the result of a binary operation takes on the size from
+either operand, e.g., foo.Add(bar) with foo.size() == 0 and bar.size() == 4 will
+will result in foo.size() == 4 after the addition, and that's true even if bar's
+vector was all zeros. */
+class Partials {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Partials);
+
+  /* Constructs an empty vector. */
+  Partials() = default;
+
+  /* Constructs a single partial derivative of `coeff` at the given `offset` in
+  a vector of `size` otherwise-zero derivatives.
+  @throws std::exception if offset >= size */
+  Partials(Eigen::Index size, Eigen::Index offset, double coeff = 1.0);
+
+  /* Constructs a vector with a copy of the given value. */
+  explicit Partials(const Eigen::Ref<const Eigen::VectorXd>& value);
+
+  ~Partials() = default;
+
+  /* Returns the size of this vector. */
+  int size() const {
+    return derivatives_.size();
+  }
+
+  /* Set this to zero. */
+  void SetZero() {
+    derivatives_.setZero();
+  }
+
+  /* Scales this vector by the given amount. */
+  void Mul(double factor) {
+    derivatives_ *= factor;
+  }
+
+  /* Scales this vector by the reciprocal of the given amount. */
+  void Div(double factor) {
+    derivatives_ /= factor;
+  }
+
+  /* Adds `other` into `this`. */
+  void Add(const Partials& other);
+
+  /* Adds `scale * other` into `this`. */
+  void AddScaled(double scale, const Partials& other);
+
+  /* Returns the underlying storage vector (readonly).
+  TODO(jwnimmer-tri) Use a more Xpr-like return type. By "Xpr", we mean what
+  Eigen calls an XprType, e.g., something like Eigen::CwiseBinaryOp. */
+  const Eigen::VectorXd& make_const_xpr() const {
+    return derivatives_;
+  }
+
+  /* Returns the underlying storage vector (mutable). */
+  Eigen::VectorXd& get_raw_storage_mutable() {
+    return derivatives_;
+  }
+
+ private:
+  // TODO(jwnimmer-tri) Replace this implementation with a more efficient
+  // representation.
+  Eigen::VectorXd derivatives_;
+};
+
+}  // namespace internal
+}  // namespace ad
+}  // namespace drake

--- a/common/ad/internal/standard_operations.cc
+++ b/common/ad/internal/standard_operations.cc
@@ -1,0 +1,21 @@
+// Our header file doesn't stand on its own; it should only ever be included
+// indirectly via auto_diff.h
+
+/* clang-format off to disable clang-format-includes */
+// NOLINTNEXTLINE(build/include)
+#include "drake/common/ad/auto_diff.h"
+/* clang-format on */
+
+#include <ostream>
+
+#include <fmt/format.h>
+
+namespace drake {
+namespace ad {
+
+std::ostream& operator<<(std::ostream& s, const AutoDiff& x) {
+  return s << fmt::format("{}", x.value());
+}
+
+}  // namespace ad
+}  // namespace drake

--- a/common/ad/internal/standard_operations.h
+++ b/common/ad/internal/standard_operations.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <iosfwd>
+
+/* This file contains free function operators for Drake's AutoDiff type.
+
+NOTE: This file should never be included directly, rather only from
+auto_diff.h in a very specific order. */
+
+namespace drake {
+namespace ad {
+
+/// @name Miscellaneous functions
+//@{
+
+/** Outputs the `value()` part of x to the stream.
+To output the derivatives use `<< x.derivatives().transpose()`. */
+std::ostream& operator<<(std::ostream& s, const AutoDiff& x);
+
+//@}
+
+}  // namespace ad
+}  // namespace drake

--- a/common/ad/test/auto_diff_basic_test.cc
+++ b/common/ad/test/auto_diff_basic_test.cc
@@ -1,0 +1,54 @@
+#include <gtest/gtest.h>
+
+#include "drake/common/ad/auto_diff.h"
+#include "drake/common/eigen_types.h"
+
+// This file contains only the very most basic unit tests for AutoDiffXd, e.g.,
+// construction and assignment. Tests for the derivative math are elsewhere.
+
+namespace drake {
+namespace ad {
+namespace {
+
+using Eigen::VectorXd;
+
+GTEST_TEST(AutodiffBasicTest, DefaultCtor) {
+  const AutoDiff dut;
+  EXPECT_EQ(dut.value(), 0.0);
+  EXPECT_EQ(dut.derivatives().size(), 0);
+}
+
+GTEST_TEST(AutodiffBasicTest, ConvertingCtor) {
+  const AutoDiff dut{1.0};
+  EXPECT_EQ(dut.value(), 1.0);
+  EXPECT_EQ(dut.derivatives().size(), 0);
+}
+
+GTEST_TEST(AutodiffBasicTest, UnitCtor) {
+  const AutoDiff dut{1.0, 4, 2};
+  EXPECT_EQ(dut.value(), 1.0);
+  EXPECT_EQ(dut.derivatives().size(), 4);
+  EXPECT_EQ(dut.derivatives()[2], 1.0);
+}
+
+GTEST_TEST(AutodiffBasicTest, VectorCtor) {
+  const Eigen::VectorXd derivs = Eigen::VectorXd::LinSpaced(3, 1.0, 3.0);
+  const AutoDiff dut{1.0, derivs};
+  EXPECT_EQ(dut.value(), 1.0);
+  EXPECT_EQ(dut.derivatives().size(), 3);
+  EXPECT_EQ(dut.derivatives(), derivs);
+}
+
+GTEST_TEST(AutodiffBasicTest, AssignConstant) {
+  AutoDiff dut{1.0, 4, 2};
+  EXPECT_EQ(dut.value(), 1.0);
+  EXPECT_EQ(dut.derivatives().size(), 4);
+  dut = -1.0;
+  EXPECT_EQ(dut.value(), -1.0);
+  EXPECT_EQ(dut.derivatives().size(), 4);
+  EXPECT_TRUE(dut.derivatives().isZero(0.0));
+}
+
+}  // namespace
+}  // namespace ad
+}  // namespace drake

--- a/common/ad/test/partials_test.cc
+++ b/common/ad/test/partials_test.cc
@@ -1,0 +1,207 @@
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/ad/auto_diff.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace ad {
+namespace internal {
+namespace {
+
+using Eigen::VectorXd;
+using Eigen::Vector2d;
+using Eigen::Vector4d;
+
+// An empty fixture for later expansion.
+class PartialsTest : public ::testing::Test {};
+
+TEST_F(PartialsTest, DefaultCtor) {
+  const Partials dut;
+  EXPECT_EQ(dut.size(), 0);
+  EXPECT_EQ(dut.make_const_xpr().size(), 0);
+}
+
+TEST_F(PartialsTest, UnitCtor2Arg) {
+  const Partials dut{4, 2};
+  EXPECT_EQ(dut.size(), 4);
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector4d::Unit(2)));
+}
+
+TEST_F(PartialsTest, UnitCtor3Arg) {
+  const Partials dut{4, 2, -1.0};
+  EXPECT_EQ(dut.size(), 4);
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), -Vector4d::Unit(2)));
+}
+
+TEST_F(PartialsTest, UnitCtorZeroCoeff) {
+  const Partials dut{4, 2, 0.0};
+  EXPECT_EQ(dut.size(), 4);
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector4d::Zero()));
+}
+
+TEST_F(PartialsTest, UnitCtorInsanelyLarge) {
+  const Eigen::Index terabyte = Eigen::Index{1} << 40;
+  DRAKE_EXPECT_THROWS_MESSAGE(Partials(terabyte, 0), ".*too large.*");
+}
+
+TEST_F(PartialsTest, UnitCtorMisuse) {
+  DRAKE_EXPECT_THROWS_MESSAGE(Partials(4, -1), ".*is negative.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(Partials(-1, 0), ".*is negative.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(Partials(2, 2), ".*strictly less.*");
+}
+
+TEST_F(PartialsTest, FullCtor) {
+  const Partials dut{Vector4d::LinSpaced(10.0, 13.0)};
+  EXPECT_EQ(dut.size(), 4);
+  EXPECT_TRUE(CompareMatrices(
+      dut.make_const_xpr(), Vector4d::LinSpaced(10.0, 13.0)));
+}
+
+TEST_F(PartialsTest, FullCtorEmpty) {
+  const Partials dut{VectorXd{}};
+  EXPECT_EQ(dut.size(), 0);
+  EXPECT_EQ(dut.make_const_xpr().size(), 0);
+}
+
+TEST_F(PartialsTest, FullCtorZeros) {
+  const Partials dut{Vector4d::Zero()};
+  EXPECT_EQ(dut.size(), 4);
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector4d::Zero()));
+}
+
+TEST_F(PartialsTest, SetZeroFromDefaultCtor) {
+  Partials dut;
+  dut.SetZero();
+  EXPECT_EQ(dut.size(), 0);
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), VectorXd{}));
+}
+
+TEST_F(PartialsTest, SetZeroFromUnitCtor) {
+  Partials dut{4, 2};
+  dut.SetZero();
+  EXPECT_EQ(dut.size(), 4);
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector4d::Zero()));
+}
+
+TEST_F(PartialsTest, SetZeroFromFullCtor) {
+  Partials dut{Vector4d::LinSpaced(10.0, 13.0)};
+  dut.SetZero();
+  EXPECT_EQ(dut.size(), 4);
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector4d::Zero()));
+}
+
+TEST_F(PartialsTest, Mul) {
+  Partials dut{4, 2};
+
+  dut.Mul(-2.0);
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), -2 * Vector4d::Unit(2)));
+
+  dut.Mul(0.0);
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector4d::Zero()));
+
+  dut = Partials{Vector2d{1.0, 2.0}};
+
+  dut.Mul(-2.0);
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector2d{-2.0, -4.0}));
+
+  dut.Mul(0.0);
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector2d::Zero()));
+}
+
+TEST_F(PartialsTest, Div) {
+  Partials dut{4, 2};
+  dut.Div(-0.5);
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), -2 * Vector4d::Unit(2)));
+  dut.SetZero();
+  dut.Div(-0.5);
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), -Vector4d::Zero()));
+}
+
+TEST_F(PartialsTest, DivZero) {
+  Partials dut{4, 2};
+  dut.Div(0.0);
+  const double kInf = std::numeric_limits<double>::infinity();
+  const double kNaN = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(),
+                              Vector4d(kNaN, kNaN, kInf, kNaN)));
+}
+
+TEST_F(PartialsTest, Add) {
+  Partials dut{4, 0};
+  dut.Add(Partials(4, 1));
+  dut.Add(Partials(4, 2));
+  dut.Add(Partials(4, 3));
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector4d::Ones()));
+}
+
+TEST_F(PartialsTest, AddScaled) {
+  Partials dut{4, 0};
+  dut.AddScaled(2.0, Partials(4, 1));
+  dut.AddScaled(3.0, Partials(4, 2));
+  dut.AddScaled(4.0, Partials(4, 3));
+  EXPECT_TRUE(CompareMatrices(
+      dut.make_const_xpr(), Vector4d::LinSpaced(1.0, 4.0)));
+}
+
+TEST_F(PartialsTest, AddRhsEmpty) {
+  Partials dut{4, 2};
+  dut.Add(Partials{});
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector4d::Unit(2)));
+}
+
+TEST_F(PartialsTest, AddScaledRhsEmpty) {
+  Partials dut{4, 2};
+  dut.AddScaled(1.0, Partials{});
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector4d::Unit(2)));
+}
+
+TEST_F(PartialsTest, AddLhsEmpty) {
+  Partials dut;
+  dut.Add(Partials(4, 2));
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector4d::Unit(2)));
+}
+
+TEST_F(PartialsTest, AddScaledLhsEmpty) {
+  Partials dut;
+  dut.AddScaled(-1.0, Partials(4, 2));
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), -Vector4d::Unit(2)));
+}
+
+TEST_F(PartialsTest, AddBothEmpty) {
+  Partials dut;
+  dut.Add(dut);
+  EXPECT_EQ(dut.size(), 0);
+}
+
+TEST_F(PartialsTest, AddScaledBothEmpty) {
+  Partials dut;
+  dut.AddScaled(1.0, dut);
+  EXPECT_EQ(dut.size(), 0);
+}
+
+TEST_F(PartialsTest, AddDifferentSizes) {
+  Partials dut{4, 2};
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.Add(Partials(2, 0)),
+      ".*different sizes.*");
+}
+
+TEST_F(PartialsTest, AddScaledDifferentSizes) {
+  Partials dut{4, 2};
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.AddScaled(-1.0, Partials(2, 0)),
+      ".*different sizes.*");
+}
+
+TEST_F(PartialsTest, DefaultCtorMutableGetter) {
+  Partials dut;
+  EXPECT_EQ(dut.get_raw_storage_mutable().size(), 0);
+  dut.get_raw_storage_mutable().resize(4);
+  EXPECT_EQ(dut.get_raw_storage_mutable().size(), 4);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace ad
+}  // namespace drake

--- a/common/ad/test/standard_operations_stream_test.cc
+++ b/common/ad/test/standard_operations_stream_test.cc
@@ -1,0 +1,20 @@
+#include <sstream>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/ad/auto_diff.h"
+
+namespace drake {
+namespace test {
+namespace {
+
+GTEST_TEST(StandardOperationsTest, Stream) {
+  const ad::AutoDiff x{0.25, 10, 0};
+  std::stringstream stream;
+  stream << x;
+  EXPECT_EQ(stream.str(), "0.25");
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace drake


### PR DESCRIPTION
Towards https://github.com/RobotLocomotion/drake/pull/17492.

This is private for now; it is not used outside of its unit tests.

See #17622 for how we'll start to add actual operations (and their unit tests).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17621)
<!-- Reviewable:end -->
