### PR TITLE
[geometry/optimization] Add HPolyhedron::UniformSample

### DIFF
--- a/bindings/pydrake/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry_py_optimization.cc
@@ -131,6 +131,16 @@ void DefineGeometryOptimization(py::module m) {
             cls_doc.Intersection.doc)
         .def("PontryaginDifference", &HPolyhedron::PontryaginDifference,
             py::arg("other"), cls_doc.PontryaginDifference.doc)
+        .def("UniformSample",
+            overload_cast_explicit<Eigen::VectorXd, RandomGenerator*,
+                const Eigen::Ref<Eigen::VectorXd>&>(
+                &HPolyhedron::UniformSample),
+            py::arg("generator"), py::arg("previous_sample"),
+            cls_doc.UniformSample.doc_2args)
+        .def("UniformSample",
+            overload_cast_explicit<Eigen::VectorXd, RandomGenerator*>(
+                &HPolyhedron::UniformSample),
+            py::arg("generator"), cls_doc.UniformSample.doc_1args)
         .def_static("MakeBox", &HPolyhedron::MakeBox, py::arg("lb"),
             py::arg("ub"), cls_doc.MakeBox.doc)
         .def_static("MakeUnitBox", &HPolyhedron::MakeUnitBox, py::arg("dim"),

--- a/bindings/pydrake/test/geometry_optimization_test.py
+++ b/bindings/pydrake/test/geometry_optimization_test.py
@@ -4,6 +4,7 @@ import unittest
 
 import numpy as np
 
+from pydrake.common import RandomGenerator
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.common.test_utilities.pickle_compare import assert_pickle
 from pydrake.geometry import (
@@ -96,6 +97,13 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertIsInstance(h5, mut.HPolyhedron)
         np.testing.assert_array_equal(h5.A(), h_box.A())
         np.testing.assert_array_equal(h5.b(), np.zeros(6))
+
+        generator = RandomGenerator()
+        sample = h_box.UniformSample(generator=generator)
+        self.assertEqual(sample.shape, (3,))
+        self.assertEqual(
+            h_box.UniformSample(generator=generator,
+                                previous_sample=sample).shape, (3, ))
 
     def test_hyper_ellipsoid(self):
         ellipsoid = mut.Hyperellipsoid(A=self.A, center=self.b)

--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -139,6 +139,8 @@ drake_cc_googletest(
         ":convex_set",
         ":test_utilities",
         "//common/test_utilities:eigen_matrix_compare",
+        "//geometry:meshcat",
+        "//geometry/test_utilities:meshcat_environment",
     ],
 )
 

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -110,6 +110,26 @@ class HPolyhedron final : public ConvexSet {
    runtime error if `this` or `other` are ill-conditioned.*/
   HPolyhedron PontryaginDifference(const HPolyhedron& other) const;
 
+  /** Draw an (approximately) uniform sample from the set using the hit and run
+  Markov-chain Monte-Carlo strategy described at
+  https://mathoverflow.net/a/162327 and the cited paper.
+
+  To generate many samples, pass the output of one iteration in as the @p
+  previous_sample to the next; in this case the distribution of samples will
+  converge to the true uniform distribution in total variation at a geometric
+  rate.  If @p previous_sample is not set, then the ChebyshevCenter() will be
+  used to seed the algorithm.
+
+  @throws std::exception if previous_sample is not in the set.
+  */
+  Eigen::VectorXd UniformSample(
+      RandomGenerator* generator,
+      const Eigen::Ref<Eigen::VectorXd>& previous_sample) const;
+
+  /** Variant of UniformSample that uses the ChebyshevCenter() as the
+  previous_sample as a feasible point to start the Markov chain sampling. */
+  Eigen::VectorXd UniformSample(RandomGenerator* generator) const;
+
   /** Constructs a polyhedron as an axis-aligned box from the lower and upper
   corners. */
   static HPolyhedron MakeBox(const Eigen::Ref<const Eigen::VectorXd>& lb,

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -294,7 +294,7 @@ Open up your browser to the URL above.
             << std::endl;
 
   std::cout << "[Press RETURN to continue]." << std::endl;
-    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+  std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
   std::remove(html_filename.c_str());
   std::cout


### PR DESCRIPTION
Adds a method to perform hit-and-run MCMC to draw (approximately)
uniform samples from the interior of an HPolyhedron.

+@sadraddini for feature review, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17629)
<!-- Reviewable:end -->
