### PR TITLE
[parsing] Extract ModelInstanceInfo to its own header file

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -41,6 +41,7 @@ drake_cc_package_library(
     visibility = ["//visibility:public"],
     deps = [
         ":model_directives",
+        ":model_instance_info",
         ":package_map",
         ":parser",
         ":process_model_directives",
@@ -242,12 +243,23 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "model_instance_info",
+    hdrs = ["model_instance_info.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//math:geometric_transform",
+        "//multibody/tree:multibody_tree_indexes",
+    ],
+)
+
+drake_cc_library(
     name = "process_model_directives",
     srcs = ["process_model_directives.cc"],
     hdrs = ["process_model_directives.h"],
     visibility = ["//visibility:public"],
     interface_deps = [
         ":model_directives",
+        ":model_instance_info",
         ":parser",
         "//multibody/plant",
     ],

--- a/multibody/parsing/model_instance_info.h
+++ b/multibody/parsing/model_instance_info.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <string>
+
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/tree/multibody_tree_indexes.h"
+
+namespace drake {
+namespace multibody {
+namespace parsing {
+
+// TODO(#13074): Burn this in a dumpster fire pending real model
+// composition / extraction in Drake.
+// TODO(#14084): This structure might combine with the implementation of 14084:
+// https://github.com/RobotLocomotion/drake/issues/14084#issuecomment-694394869
+/// Convenience structure to hold all of the information to add a model
+/// instance from a file.
+struct ModelInstanceInfo {
+  /// Model name (possibly scoped).
+  std::string model_name;
+  /// File path.
+  std::string model_path;
+  /// WARNING: This is the *unscoped* parent frame, assumed to be unique.
+  std::string parent_frame_name;
+  /// This is the unscoped frame name belonging to `model_instance`.
+  std::string child_frame_name;
+  drake::math::RigidTransformd X_PC;
+  drake::multibody::ModelInstanceIndex model_instance;
+};
+
+}  // namespace parsing
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/process_model_directives.h
+++ b/multibody/parsing/process_model_directives.h
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <optional>
 #include <string>
 #include <vector>
 
 #include "drake/multibody/parsing/model_directives.h"
+#include "drake/multibody/parsing/model_instance_info.h"
 #include "drake/multibody/parsing/package_map.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/multibody_plant.h"
-#include "drake/multibody/tree/multibody_tree_indexes.h"
 
 namespace drake {
 namespace multibody {
@@ -24,25 +23,6 @@ ModelDirectives LoadModelDirectives(const std::string& filename);
 std::string ResolveModelDirectiveUri(
     const std::string& uri,
     const drake::multibody::PackageMap& package_map);
-
-// TODO(#13074): Burn this in a dumpster fire pending real model
-// composition / extraction in Drake.
-// TODO(#14084): This structure might combine with the implementation of 14084:
-// https://github.com/RobotLocomotion/drake/issues/14084#issuecomment-694394869
-/// Convenience structure to hold all of the information to add a model
-/// instance from a file.
-struct ModelInstanceInfo {
-  /// Model name (possibly scoped).
-  std::string model_name;
-  /// File path.
-  std::string model_path;
-  /// WARNING: This is the *unscoped* parent frame, assumed to be unique.
-  std::string parent_frame_name;
-  /// This is the unscoped frame name belonging to `model_instance`.
-  std::string child_frame_name;
-  drake::math::RigidTransformd X_PC;
-  drake::multibody::ModelInstanceIndex model_instance;
-};
 
 /// Flatten model directives.
 void FlattenModelDirectives(const ModelDirectives& directives,


### PR DESCRIPTION
Relevant to: #17390, #17112

This patch opens up the physical design of model directives, clearing
the way for integration of model directives as a language for Parser
(#17390), and porting of various modules from Anzu to Drake (#17112).

There should be no changes to either functionality or existing API
surface; only the arrangement of files and dependencies is changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17631)
<!-- Reviewable:end -->
