### PR TITLE
[multibody] All bodies and frames must have a non-empty name

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -656,9 +656,10 @@ class TestPlant(unittest.TestCase):
         RigidBody = RigidBody_[T]
         M = SpatialInertia_[float]()
         i = ModelInstanceIndex(0)
-        RigidBody(M_BBo_B=M)
         RigidBody(body_name="body_name", M_BBo_B=M)
         RigidBody(body_name="body_name", model_instance=i, M_BBo_B=M)
+        with catch_drake_warnings(expected_count=1):
+            RigidBody(M_BBo_B=M)
 
     @numpy_compare.check_all_types
     def test_multibody_force_element(self, T):
@@ -1884,12 +1885,14 @@ class TestPlant(unittest.TestCase):
     def test_fixed_offset_frame_api(self, T):
         FixedOffsetFrame = FixedOffsetFrame_[T]
         P = MultibodyPlant_[T](0.0).world_frame()
-        B = RigidBody_[T](SpatialInertia_[float]())
+        B = RigidBody_[T]("body", SpatialInertia_[float]())
         X = RigidTransform_[float].Identity()
         FixedOffsetFrame(name="name", P=P, X_PF=X, model_instance=None)
-        FixedOffsetFrame(P=P, X_PF=X)
         FixedOffsetFrame(name="name", bodyB=B, X_BF=X)
-        FixedOffsetFrame(bodyB=B, X_BF=X)
+        with catch_drake_warnings(expected_count=1):
+            FixedOffsetFrame(P=P, X_PF=X)
+        with catch_drake_warnings(expected_count=1):
+            FixedOffsetFrame(bodyB=B, X_BF=X)
 
     @numpy_compare.check_all_types
     def test_multibody_dynamics(self, T):

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -241,15 +241,22 @@ void DoScalarDependentDefinitions(py::module m, T) {
                  const RigidTransform<double>&,
                  std::optional<ModelInstanceIndex>>(),
             py::arg("name"), py::arg("P"), py::arg("X_PF"),
-            py::arg("model_instance") = std::nullopt, cls_doc.ctor.doc_4args)
-        .def(py::init<const Frame<T>&, const math::RigidTransform<double>&>(),
-            py::arg("P"), py::arg("X_PF"), cls_doc.ctor.doc_2args)
+            py::arg("model_instance") = std::nullopt,
+            cls_doc.ctor.doc_4args_name_P_X_PF_model_instance)
+        .def(py_init_deprecated<Class, const Frame<T>&,
+                 const math::RigidTransform<double>&>(
+                 cls_doc.ctor.doc_deprecated_deprecated_2args_P_X_PF),
+            py::arg("P"), py::arg("X_PF"),
+            cls_doc.ctor.doc_deprecated_deprecated_2args_P_X_PF)
         .def(py::init<const std::string&, const Body<T>&,
                  const math::RigidTransform<double>&>(),
             py::arg("name"), py::arg("bodyB"), py::arg("X_BF"),
-            cls_doc.ctor.doc_3args)
-        .def(py::init<const Body<T>&, const math::RigidTransform<double>&>(),
-            py::arg("bodyB"), py::arg("X_BF"), cls_doc.ctor.doc_2args)
+            cls_doc.ctor.doc_3args_name_bodyB_X_BF)
+        .def(py_init_deprecated<Class, const Body<T>&,
+                 const math::RigidTransform<double>&>(
+                 cls_doc.ctor.doc_deprecated_deprecated_2args_bodyB_X_BF),
+            py::arg("bodyB"), py::arg("X_BF"),
+            cls_doc.ctor.doc_deprecated_deprecated_2args_bodyB_X_BF)
         .def("SetPoseInBodyFrame", &Class::SetPoseInBodyFrame,
             py::arg("context"), py::arg("X_PF"),
             cls_doc.SetPoseInBodyFrame.doc);
@@ -323,8 +330,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
     auto cls = DefineTemplateClassWithDefault<Class, Body<T>>(
         m, "RigidBody", param, cls_doc.doc);
     cls  // BR
-        .def(py::init<const SpatialInertia<double>&>(), py::arg("M_BBo_B"),
-            cls_doc.ctor.doc_1args)
+        .def(py_init_deprecated<Class, const SpatialInertia<double>&>(
+                 cls_doc.ctor.doc_deprecated_1args),
+            py::arg("M_BBo_B"), cls_doc.ctor.doc_deprecated_1args)
         .def(py::init<const std::string&, const SpatialInertia<double>&>(),
             py::arg("body_name"), py::arg("M_BBo_B"), cls_doc.ctor.doc_2args)
         .def(py::init<const std::string&, ModelInstanceIndex,

--- a/manipulation/planner/test/differential_inverse_kinematics_test.cc
+++ b/manipulation/planner/test/differential_inverse_kinematics_test.cc
@@ -46,7 +46,7 @@ class DifferentialInverseKinematicsTest : public ::testing::Test {
     const math::RigidTransformd X_7E(AngleAxis<double>(M_PI, Vector3d::UnitZ()),
                                      Vector3d(0.1, 0, 0));
     frame_E_ = &plant_->AddFrame(std::make_unique<FixedOffsetFrame<double>>(
-        plant_->GetBodyByName("iiwa_link_7").body_frame(), X_7E));
+        "E", plant_->GetBodyByName("iiwa_link_7").body_frame(), X_7E));
     plant_->Finalize();
     owned_context_ = plant_->CreateDefaultContext();
     context_ = owned_context_.get();

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -1403,13 +1403,13 @@ void AddFramesToInterfaceModel(const MultibodyPlant<double>& plant,
     if (frame.model_instance() != model_instance) {
       continue;
     }
-    if (frame.name().empty() || frame.name() == "__model__" ||
+    if (frame.name() == "__model__" ||
         plant.HasBodyNamed(frame.name(), model_instance)) {
-      // Skip unnamed frames, and __model__ since it's already added.  Also
-      // skip frames with the same name as a link since those are frames added
-      // by Drake and are considered implicit by SDFormat. Sending such frames
-      // to SDFormat would imply that these frames are explicit (i.e., frames
-      // created using the <frame> tag).
+      // Skip __model__ since it's already added.  Also skip frames with the
+      // same name as a link since those are frames added by Drake and are
+      // considered implicit by SDFormat. Sending such frames to SDFormat would
+      // imply that these frames are explicit (i.e., frames created using the
+      // <frame> tag).
       continue;
     }
     interface_model->AddFrame(

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -957,7 +957,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///   braces `{}` imply that frame F **is** the same body frame P. If instead
   ///   your intention is to make a frame F with pose `X_PF` equal to the
   ///   identity pose, provide `RigidTransform<double>::Identity()` as your
-  ///   input.
+  ///   input. When non-nullopt, adds a FixedOffsetFrame named `{name}_parent`.
   /// @param[in] child
   ///   The child body connected by the new joint.
   /// @param[in] X_BM
@@ -966,7 +966,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///   braces `{}` imply that frame M **is** the same body frame B. If instead
   ///   your intention is to make a frame M with pose `X_BM` equal to the
   ///   identity pose, provide `RigidTransform<double>::Identity()` as your
-  ///   input.
+  ///   input.  When non-nullopt, adds a FixedOffsetFrame named `{name}_child`.
   /// @param[in] args
   ///   Zero or more parameters provided to the constructor of the new joint. It
   ///   must be the case that
@@ -1018,7 +1018,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     const Frame<T>* frame_on_parent{nullptr};
     if (X_PF) {
       frame_on_parent = &this->AddFrame(
-          std::make_unique<FixedOffsetFrame<T>>(parent, *X_PF));
+          std::make_unique<FixedOffsetFrame<T>>(
+              name + "_parent", parent, *X_PF));
     } else {
       frame_on_parent = &parent.body_frame();
     }
@@ -1026,7 +1027,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     const Frame<T>* frame_on_child{nullptr};
     if (X_BM) {
       frame_on_child = &this->AddFrame(
-          std::make_unique<FixedOffsetFrame<T>>(child, *X_BM));
+          std::make_unique<FixedOffsetFrame<T>>(
+              name + "_child", child, *X_BM));
     } else {
       frame_on_child = &child.body_frame();
     }

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -2152,7 +2152,8 @@ TEST_F(SplitPendulum, GetMultibodyPlantFromElement) {
   // Create an element-owning MBTreeSystem that _is not_ an MBPlant.
   struct MyMBSystem : public internal::MultibodyTreeSystem<double> {
     MyMBSystem() {
-      rigid_body = &mutable_tree().AddBody<RigidBody>(SpatialInertia<double>());
+      rigid_body = &mutable_tree().AddBody<RigidBody>(
+          "Body", SpatialInertia<double>());
       Finalize();
     }
     const RigidBody<double>* rigid_body{};

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -104,6 +104,7 @@ drake_cc_library(
         "body_node_impl.cc",
         "door_hinge.cc",
         "fixed_offset_frame.cc",
+        "frame.cc",
         "joint.cc",
         "joint_actuator.cc",
         "linear_bushing_roll_pitch_yaw.cc",

--- a/multibody/tree/body.h
+++ b/multibody/tree/body.h
@@ -185,7 +185,7 @@ class Body : public MultibodyElement<Body, T, BodyIndex> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Body)
 
-  /// Gets the `name` associated with `this` body.
+  /// Gets the `name` associated with `this` body. The name will never be empty.
   const std::string& name() const { return name_; }
 
   /// Returns the number of generalized positions q describing flexible
@@ -477,9 +477,11 @@ class Body : public MultibodyElement<Body, T, BodyIndex> {
 
  protected:
   /// Creates a %Body named `name` in model instance `model_instance`.
+  /// The `name` must not be empty.
   Body(const std::string& name, ModelInstanceIndex model_instance)
       : MultibodyElement<Body, T, BodyIndex>(model_instance),
-        name_(name), body_frame_(*this) {}
+        name_(internal::DeprecateWhenEmptyName(name, "Body")),
+        body_frame_(*this) {}
 
   /// @name Methods to make a clone templated on different scalar types.
   ///
@@ -554,7 +556,7 @@ class Body : public MultibodyElement<Body, T, BodyIndex> {
   // A string identifying the body in its model.
   // Within a MultibodyPlant model this string is guaranteed to be unique by
   // MultibodyPlant's API.
-  std::string name_;
+  const std::string name_;
 
   // Body frame associated with this body.
   BodyFrame<T> body_frame_;

--- a/multibody/tree/fixed_offset_frame.h
+++ b/multibody/tree/fixed_offset_frame.h
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "drake/common/default_scalars.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/tree/frame.h"
 #include "drake/multibody/tree/multibody_tree_topology.h"
@@ -40,7 +41,7 @@ class FixedOffsetFrame final : public Frame<T> {
   /// see class documentation for more information.
   ///
   /// @param[in] name
-  ///   The name of this frame.
+  ///   The name of this frame. Cannot be empty.
   /// @param[in] P
   ///   The frame to which this frame is attached with a fixed pose.
   /// @param[in] X_PF
@@ -54,8 +55,8 @@ class FixedOffsetFrame final : public Frame<T> {
       const math::RigidTransform<double>& X_PF,
       std::optional<ModelInstanceIndex> model_instance = {});
 
-  /// Creates an unnamed material Frame F. See overload with name for more
-  /// information.
+  DRAKE_DEPRECATED("2022-12-01",
+      "The name parameter to the FixedOffsetFrame constructor is now required.")
   FixedOffsetFrame(
       const Frame<T>& P, const math::RigidTransform<double>& X_PF)
       : FixedOffsetFrame("", P, X_PF) {}
@@ -65,15 +66,14 @@ class FixedOffsetFrame final : public Frame<T> {
   /// The pose is given by a spatial transform `X_BF`; see class documentation
   /// for more information.
   ///
-  /// @param[in] name  The name of this frame.
+  /// @param[in] name  The name of this frame. Cannot be empty.
   /// @param[in] bodyB The body whose BodyFrame B is to be F's parent frame.
   /// @param[in] X_BF  The transform giving the pose of F in B.
   FixedOffsetFrame(
       const std::string& name, const Body<T>& bodyB,
       const math::RigidTransform<double>& X_BF);
 
-  /// Creates an unnamed material Frame F. See overload with name for more
-  /// information.
+  DRAKE_DEPRECATED("2022-12-01", "FixedOffsetFrame must always have name")
   FixedOffsetFrame(
       const Body<T>& bodyB, const math::RigidTransform<double>& X_BF)
       : FixedOffsetFrame("", bodyB, X_BF) {}

--- a/multibody/tree/frame.cc
+++ b/multibody/tree/frame.cc
@@ -1,0 +1,25 @@
+#include "drake/multibody/tree/frame.h"
+
+#include "drake/common/identifier.h"
+#include "drake/common/text_logging.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// On 2022-12-01 when deprecation expires, this should change to throwing on
+// empty names, instead of just logging.
+std::string DeprecateWhenEmptyName(std::string name, std::string_view type) {
+  if (!name.empty()) {
+    return name;
+  }
+  static const logging::Warn log_once(
+      "The name parameter to the {} constructor is now required. "
+      "This will become a runtime exception on or after 2022-12-01.", type);
+  return fmt::format("unnamed_{}_{}",
+      type, drake::internal::get_new_identifier());
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "drake/common/autodiff.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/multibody/math/spatial_algebra.h"
 #include "drake/multibody/tree/frame_base.h"
@@ -13,6 +14,10 @@
 
 namespace drake {
 namespace multibody {
+
+namespace internal {
+std::string DeprecateWhenEmptyName(std::string name, std::string_view type);
+}  // namespace internal
 
 // Forward declarations.
 template<typename T> class Body;
@@ -64,8 +69,7 @@ class Frame : public FrameBase<T> {
     return this->index() == body_.body_frame().index();
   }
 
-
-  /// Returns the name of this frame. It may be empty if unnamed.
+  /// Returns the name of this frame. The name will never be empty.
   const std::string& name() const {
     return name_;
   }
@@ -589,9 +593,10 @@ class Frame : public FrameBase<T> {
       const std::string& name, const Body<T>& body,
       std::optional<ModelInstanceIndex> model_instance = {})
       : FrameBase<T>(model_instance.value_or(body.model_instance())),
-        name_(name), body_(body) {}
+        name_(internal::DeprecateWhenEmptyName(name, "Frame")), body_(body) {}
 
-  /// Overload to permit constructing an unnamed frame.
+  DRAKE_DEPRECATED("2022-12-01",
+      "The name parameter to the Frame constructor is now required.")
   explicit Frame(const Body<T>& body)
       : Frame("", body) {}
 
@@ -627,7 +632,7 @@ class Frame : public FrameBase<T> {
     DRAKE_ASSERT(topology_.index == this->index());
   }
 
-  std::string name_;
+  const std::string name_;
 
   // The body associated with this frame.
   const Body<T>& body_;

--- a/multibody/tree/multibody_tree-inl.h
+++ b/multibody/tree/multibody_tree-inl.h
@@ -323,14 +323,16 @@ const JointType<T>& MultibodyTree<T>::AddJoint(
 
   const Frame<T>* frame_on_parent{nullptr};
   if (X_PF) {
-    frame_on_parent = &this->AddFrame<FixedOffsetFrame>(parent, *X_PF);
+    frame_on_parent = &this->AddFrame<FixedOffsetFrame>(
+       name + "_parent", parent, *X_PF);
   } else {
     frame_on_parent = &parent.body_frame();
   }
 
   const Frame<T>* frame_on_child{nullptr};
   if (X_BM) {
-    frame_on_child = &this->AddFrame<FixedOffsetFrame>(child, *X_BM);
+    frame_on_child = &this->AddFrame<FixedOffsetFrame>(
+        name + "_child", child, *X_BM);
   } else {
     frame_on_child = &child.body_frame();
   }

--- a/multibody/tree/rigid_body.cc
+++ b/multibody/tree/rigid_body.cc
@@ -7,6 +7,7 @@
 namespace drake {
 namespace multibody {
 
+// (This overload is deprecated.)
 template <typename T>
 RigidBody<T>::RigidBody(const SpatialInertia<double>& M)
     : Body<T>("", default_model_instance()),

--- a/multibody/tree/rigid_body.h
+++ b/multibody/tree/rigid_body.h
@@ -7,6 +7,7 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/unused.h"
 #include "drake/multibody/tree/acceleration_kinematics_cache.h"
 #include "drake/multibody/tree/body.h"
@@ -46,14 +47,6 @@ class RigidBody : public Body<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RigidBody)
 
-  /// Constructs a %RigidBody with the given default SpatialInertia.
-  /// @param[in] M_BBo_B
-  ///   Spatial inertia of `this` body B about the frame's origin `Bo` and
-  ///   expressed in the body frame B.
-  /// @note See @ref multibody_spatial_inertia for details on the monogram
-  /// notation used for spatial inertia quantities.
-  explicit RigidBody(const SpatialInertia<double>& M_BBo_B);
-
   /// Constructs a %RigidBody named `body_name` with the given default
   /// SpatialInertia.
   ///
@@ -66,6 +59,10 @@ class RigidBody : public Body<T> {
   /// notation used for spatial inertia quantities.
   RigidBody(const std::string& body_name,
             const SpatialInertia<double>& M_BBo_B);
+
+  DRAKE_DEPRECATED("2022-12-01",
+      "The body_name parameter to the RigidBody constructor is now required.")
+  explicit RigidBody(const SpatialInertia<double>& M_BBo_B);
 
   /// Constructs a %RigidBody named `body_name` with the given default
   /// SpatialInertia.

--- a/multibody/tree/test/articulated_body_algorithm_test.cc
+++ b/multibody/tree/test/articulated_body_algorithm_test.cc
@@ -208,14 +208,14 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, FeatherstoneExample) {
   auto& tree = *tree_owned;
 
   // Add box body and SpaceXYZ mobilizer.
-  const RigidBody<double>& box_link = tree.AddBody<RigidBody>(M_Bcm);
+  const RigidBody<double>& box_link = tree.AddBody<RigidBody>("box", M_Bcm);
   const Frame<double>& world_frame = tree.world_frame();
   const Frame<double>& box_frame = box_link.body_frame();
   tree.AddMobilizer<SpaceXYZMobilizer>(world_frame, box_frame);
 
   // Add cylinder body and Featherstone mobilizer.
   const RigidBody<double>& cylinder_link =
-      tree.AddBody<RigidBody>(M_Ccm);
+      tree.AddBody<RigidBody>("cylinder", M_Ccm);
   const Frame<double>& cylinder_frame = cylinder_link.body_frame();
   tree.AddMobilizer<FeatherstoneMobilizer>(box_frame, cylinder_frame);
 
@@ -285,14 +285,16 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, ModifiedFeatherstoneExample) {
   auto& tree = *tree_owned;
 
   // Add box body and SpaceXYZ mobilizer.
-  const RigidBody<double>& box_link = tree.AddBody<RigidBody>(M_Bcm);
+  const RigidBody<double>& box_link = tree.AddBody<RigidBody>(
+      "Box", M_Bcm);
   const Frame<double>& world_frame = tree.world_frame();
   const Frame<double>& box_frame = box_link.body_frame();
   const SpaceXYZMobilizer<double>& WB_mobilizer =
       tree.AddMobilizer<SpaceXYZMobilizer>(world_frame, box_frame);
 
   // Add cylinder body and Featherstone mobilizer.
-  const RigidBody<double>& cylinder_link = tree.AddBody<RigidBody>(M_Ccm);
+  const RigidBody<double>& cylinder_link = tree.AddBody<RigidBody>(
+      "Cylinder", M_Ccm);
   const Frame<double>& cylinder_frame = cylinder_link.body_frame();
   const FeatherstoneMobilizer<double>& BC_mobilizer =
       tree.AddMobilizer<FeatherstoneMobilizer>(box_frame, cylinder_frame);

--- a/multibody/tree/test/ball_rpy_joint_test.cc
+++ b/multibody/tree/test/ball_rpy_joint_test.cc
@@ -38,7 +38,7 @@ class BallRpyJointTest : public ::testing::Test {
     auto model = std::make_unique<internal::MultibodyTree<double>>();
 
     // Add some bodies so we can add joints between them:
-    body_ = &model->AddBody<RigidBody>(M_B);
+    body_ = &model->AddBody<RigidBody>("Body", M_B);
 
     // Add a ball rpy joint between the world and body:
     joint_ = &model->AddJoint<BallRpyJoint>("Joint", model->world_body(),

--- a/multibody/tree/test/free_rotating_body_plant.cc
+++ b/multibody/tree/test/free_rotating_body_plant.cc
@@ -33,7 +33,7 @@ void FreeRotatingBodyPlant<T>::BuildMultibodyTreeModel() {
   const double kMass = 1.0;
   SpatialInertia<double> M_Bcm(kMass, Vector3<double>::Zero(), G_Bcm);
 
-  body_ = &this->mutable_tree().template AddBody<RigidBody>(M_Bcm);
+  body_ = &this->mutable_tree().template AddBody<RigidBody>("B", M_Bcm);
   mobilizer_ = &this->mutable_tree().template AddMobilizer<
       internal::SpaceXYZMobilizer>(
           tree().world_frame(), body_->body_frame());

--- a/multibody/tree/test/joint_actuator_test.cc
+++ b/multibody/tree/test/joint_actuator_test.cc
@@ -28,9 +28,9 @@ GTEST_TEST(JointActuatorTest, JointActuatorLimitTest) {
   const SpatialInertia<double> M_B;  // Default construction is ok for this.
 
   // Add bodies so we can add joints to them.
-  const auto body1 = &tree.AddBody<RigidBody>(M_B);
-  const auto body2 = &tree.AddBody<RigidBody>(M_B);
-  const auto body3 = &tree.AddBody<RigidBody>(M_B);
+  const auto body1 = &tree.AddBody<RigidBody>("body1", M_B);
+  const auto body2 = &tree.AddBody<RigidBody>("body2", M_B);
+  const auto body3 = &tree.AddBody<RigidBody>("body3", M_B);
 
   // Add a prismatic joint between the world and body1:
   const Joint<double>& body1_world =
@@ -66,7 +66,7 @@ GTEST_TEST(JointActuatorTest, JointActuatorLimitTest) {
   DRAKE_EXPECT_THROWS_MESSAGE(actuator1.num_inputs(),
                               ".*after the MultibodyPlant is finalized.");
 
-  const auto body4 = &tree.AddBody<RigidBody>(M_B);
+  const auto body4 = &tree.AddBody<RigidBody>("body4", M_B);
   const Joint<double>& body4_world =
       tree.AddJoint(std::make_unique<PlanarJoint<double>>(
           "planar4", tree.world_body().body_frame(), body4->body_frame(),

--- a/multibody/tree/test/mobilizer_tester.h
+++ b/multibody/tree/test/mobilizer_tester.h
@@ -32,7 +32,7 @@ class MobilizerTester : public ::testing::Test {
     tree_ = owned_tree_.get();
 
     // Add a body so we can add a mobilizer to it.
-    body_ = &owned_tree_->AddBody<RigidBody>(M_B);
+    body_ = &owned_tree_->AddBody<RigidBody>("body", M_B);
   }
 
   template <template <typename> class MobilizerType>

--- a/multibody/tree/test/multibody_forces_test.cc
+++ b/multibody/tree/test/multibody_forces_test.cc
@@ -29,8 +29,8 @@ class MultibodyForcesTests : public ::testing::Test {
   // MultibodyForces objects for this model.
   void SetUp() override {
     SpatialInertia<double> M;
-    const RigidBody<double>& body1 = model_.AddBody<RigidBody>(M);
-    const RigidBody<double>& body2 = model_.AddBody<RigidBody>(M);
+    const RigidBody<double>& body1 = model_.AddBody<RigidBody>("Body1", M);
+    const RigidBody<double>& body2 = model_.AddBody<RigidBody>("Body2", M);
     model_.AddJoint<RevoluteJoint>("Joint1", model_.world_body(), std::nullopt,
                                    body1, std::nullopt, Vector3d::UnitZ());
     model_.AddJoint<RevoluteJoint>("Joint2", body1, std::nullopt, body2,

--- a/multibody/tree/test/multibody_tree_creation_test.cc
+++ b/multibody/tree/test/multibody_tree_creation_test.cc
@@ -75,7 +75,8 @@ GTEST_TEST(MultibodyTree, BasicAPIToAddBodiesAndMobilizers) {
   SpatialInertia<double> M_Bo_B;
 
   // Adds a new body to the world.
-  const RigidBody<double>& pendulum = model->AddBody<RigidBody>(M_Bo_B);
+  const RigidBody<double>& pendulum = model->AddBody<RigidBody>(
+      "pendulum", M_Bo_B);
 
   // Adds a revolute mobilizer.
   DRAKE_EXPECT_NO_THROW((model->AddMobilizer<RevoluteMobilizer>(
@@ -97,7 +98,8 @@ GTEST_TEST(MultibodyTree, BasicAPIToAddBodiesAndMobilizers) {
       Vector3d::UnitZ())), std::runtime_error);
 
   // Adds a second pendulum.
-  const RigidBody<double>& pendulum2 = model->AddBody<RigidBody>(M_Bo_B);
+  const RigidBody<double>& pendulum2 = model->AddBody<RigidBody>(
+      "pendulum2", M_Bo_B);
   model->AddMobilizer<RevoluteMobilizer>(
       model->world_frame(), pendulum2.body_frame(), Vector3d::UnitZ());
 
@@ -139,7 +141,7 @@ GTEST_TEST(MultibodyTree, BasicAPIToAddBodiesAndMobilizers) {
   EXPECT_THROW(model->Finalize(), std::logic_error);
 
   // Verifies that after compilation no more bodies can be added.
-  EXPECT_THROW(model->AddBody<RigidBody>(M_Bo_B), std::logic_error);
+  EXPECT_THROW(model->AddBody<RigidBody>("B", M_Bo_B), std::logic_error);
 }
 
 // Tests the correctness of MultibodyElement checks to verify one or more
@@ -155,8 +157,8 @@ GTEST_TEST(MultibodyTree, MultibodyElementChecks) {
   // expressed in the body frame B.
   SpatialInertia<double> M_Bo_B;
 
-  const RigidBody<double>& body1 = model1->AddBody<RigidBody>(M_Bo_B);
-  const RigidBody<double>& body2 = model2->AddBody<RigidBody>(M_Bo_B);
+  const RigidBody<double>& body1 = model1->AddBody<RigidBody>("body1", M_Bo_B);
+  const RigidBody<double>& body2 = model2->AddBody<RigidBody>("body2", M_Bo_B);
 
   // Verifies we can add a mobilizer between body1 and the world of model1.
   const RevoluteMobilizer<double>& pin1 =
@@ -254,8 +256,8 @@ class TreeTopologyTests : public ::testing::Test {
 
     const int kNumBodies = 10;
     bodies_.push_back(&model_->world_body());
-    for (int i =1; i < kNumBodies; ++i)
-      AddTestBody();
+    for (int i = 1; i < kNumBodies; ++i)
+      AddTestBody(i);
 
     // Adds mobilizers to connect bodies according to the following diagram:
     ConnectBodies(*bodies_[1], *bodies_[6]);  // mob. 0
@@ -269,11 +271,12 @@ class TreeTopologyTests : public ::testing::Test {
     WeldBodies(*bodies_[9], *bodies_[8]);     // mob. 8
   }
 
-  const RigidBody<double>* AddTestBody() {
+  const RigidBody<double>* AddTestBody(int i) {
     // NaN SpatialInertia to instantiate the RigidBody objects.
     // It is safe here since this tests only focus on topological information.
     const SpatialInertia<double> M_Bo_B;
-    const RigidBody<double>* body = &model_->AddBody<RigidBody>(M_Bo_B);
+    const RigidBody<double>* body = &model_->AddBody<RigidBody>(
+       fmt::format("TestBody_{}", i), M_Bo_B);
     bodies_.push_back(body);
     return body;
   }

--- a/multibody/tree/test/multibody_tree_test.cc
+++ b/multibody/tree/test/multibody_tree_test.cc
@@ -306,7 +306,7 @@ class BadDerivedMBSystem : public MultibodyTreeSystem<double> {
  public:
   explicit BadDerivedMBSystem(bool double_finalize)
       : MultibodyTreeSystem<double>() {
-    mutable_tree().AddBody<RigidBody>(SpatialInertia<double>());
+    mutable_tree().AddBody<RigidBody>("body", SpatialInertia<double>());
     Finalize();
     if (double_finalize) {
       Finalize();
@@ -1509,8 +1509,8 @@ class WeldMobilizerTest : public ::testing::Test {
     // Create an empty model.
     auto model = std::make_unique<MultibodyTree<double>>();
 
-    body1_ = &model->AddBody<RigidBody>(M_B);
-    body2_ = &model->AddBody<RigidBody>(M_B);
+    body1_ = &model->AddBody<RigidBody>("body1", M_B);
+    body2_ = &model->AddBody<RigidBody>("body2", M_B);
 
     model->AddMobilizer<WeldMobilizer>(model->world_body().body_frame(),
                                        body1_->body_frame(), X_WB1_);
@@ -1518,9 +1518,9 @@ class WeldMobilizerTest : public ::testing::Test {
     // Add a weld joint between bodies 1 and 2 by welding together inboard
     // frame F (on body 1) with outboard frame M (on body 2).
     const auto& frame_F =
-        model->AddFrame<FixedOffsetFrame>(*body1_, X_B1F_);
+        model->AddFrame<FixedOffsetFrame>("F", *body1_, X_B1F_);
     const auto& frame_M =
-        model->AddFrame<FixedOffsetFrame>(*body2_, X_B2M_);
+        model->AddFrame<FixedOffsetFrame>("M", *body2_, X_B2M_);
     model->AddMobilizer<WeldMobilizer>(frame_F, frame_M, X_FM_);
 
     // We are done adding modeling elements. Transfer tree to system and get

--- a/multibody/tree/test/planar_joint_test.cc
+++ b/multibody/tree/test/planar_joint_test.cc
@@ -40,7 +40,7 @@ class PlanarJointTest : public ::testing::Test {
     auto model = std::make_unique<internal::MultibodyTree<double>>();
 
     // Add a body so we can add a joint between it and the world:
-    body_ = &model->AddBody<RigidBody>(M_B);
+    body_ = &model->AddBody<RigidBody>("Body", M_B);
 
     // Add a planar joint between the world and body1:
     joint_ = &model->AddJoint<PlanarJoint>("Joint", model->world_body(),

--- a/multibody/tree/test/prismatic_joint_test.cc
+++ b/multibody/tree/test/prismatic_joint_test.cc
@@ -47,7 +47,7 @@ class PrismaticJointTest : public ::testing::Test {
     auto model = std::make_unique<internal::MultibodyTree<double>>();
 
     // Add a body so we can add joint to it.
-    body1_ = &model->AddBody<RigidBody>(M_B);
+    body1_ = &model->AddBody<RigidBody>("Body", M_B);
 
     // Add a prismatic joint between the world and body1:
     joint1_ = &model->AddJoint<PrismaticJoint>(

--- a/multibody/tree/test/revolute_joint_test.cc
+++ b/multibody/tree/test/revolute_joint_test.cc
@@ -49,7 +49,7 @@ class RevoluteJointTest : public ::testing::Test {
     auto model = std::make_unique<internal::MultibodyTree<double>>();
 
     // Add some bodies so we can add joints between them:
-    body1_ = &model->AddBody<RigidBody>(M_B);
+    body1_ = &model->AddBody<RigidBody>("Body1", M_B);
 
     // Add a revolute joint between the world and body1:
     joint1_ = &model->AddJoint<RevoluteJoint>(

--- a/multibody/tree/test/rigid_body_test.cc
+++ b/multibody/tree/test/rigid_body_test.cc
@@ -19,7 +19,7 @@ GTEST_TEST(RigidBody, RigidBodyConstructor) {
   const Vector3d p_BoBcm_B(0.4, 0.3, 0.2);
   const UnitInertia<double> U_BBo_B(6, 7, 8);
   const SpatialInertia<double> M_Bo_B(mass, p_BoBcm_B, U_BBo_B);
-  const RigidBody<double> B(M_Bo_B);
+  const RigidBody<double> B("B", M_Bo_B);
 
   // Test that after construction, RigidBody class properly returns its default
   // spatial inertia or parts of it.

--- a/multibody/tree/test/screw_joint_test.cc
+++ b/multibody/tree/test/screw_joint_test.cc
@@ -32,7 +32,7 @@ class ScrewJointTest : public ::testing::Test {
   // screw joint.
   void SetUp() override {
     auto model = std::make_unique<internal::MultibodyTree<double>>();
-    body_ = &model->AddBody<RigidBody>(SpatialInertia<double>{});
+    body_ = &model->AddBody<RigidBody>("Body", SpatialInertia<double>{});
 
     // Add a screw joint between the world and body1:
     joint_ = &model->AddJoint<ScrewJoint>("Joint", model->world_body(),

--- a/multibody/tree/test/tree_from_joints_test.cc
+++ b/multibody/tree/test/tree_from_joints_test.cc
@@ -126,8 +126,8 @@ class DoublePendulumModel {
     SpatialInertia<double> M2_L2 = M2_L2cm.Shift(-p_L2oL2cm);
 
     // Adds the upper and lower links of the pendulum:
-    link1_ = &model->template AddBody<RigidBody>(M1_L1);
-    link2_ = &model->template AddBody<RigidBody>(M2_L2);
+    link1_ = &model->template AddBody<RigidBody>("Link1", M1_L1);
+    link2_ = &model->template AddBody<RigidBody>("Link2", M2_L2);
     world_body_ = &model->world_body();
 
     // The shoulder joint connects the world with link 1.

--- a/multibody/tree/test/tree_from_mobilizers_test.cc
+++ b/multibody/tree/test/tree_from_mobilizers_test.cc
@@ -160,9 +160,9 @@ class PendulumTests : public ::testing::Test {
     // Adds the upper and lower links of the pendulum.
     // Using: const BodyType& AddBody(std::unique_ptr<BodyType> body).
     upper_link_ =
-        &model_->AddBody(make_unique<RigidBody<double>>(M_U));
+        &model_->AddBody(make_unique<RigidBody<double>>("UpperLink", M_U));
     // Using: const BodyType<T>& AddBody(Args&&... args)
-    lower_link_ = &model_->AddBody<RigidBody>(M_L);
+    lower_link_ = &model_->AddBody<RigidBody>("LowerLink", M_L);
 
     // The shoulder is the mobilizer that connects the world to the upper link.
     // Its inboard frame, Si, is the world frame. Its outboard frame, So, a
@@ -177,7 +177,8 @@ class PendulumTests : public ::testing::Test {
     // In this case the frame is created explicitly from the body frame of
     // upper_link.
     shoulder_outboard_frame_ =
-        &model_->AddFrame<FixedOffsetFrame>(upper_link_->body_frame(), X_USo_);
+        &model_->AddFrame<FixedOffsetFrame>(
+            "So", upper_link_->body_frame(), X_USo_);
 
     // Adds the shoulder and elbow mobilizers of the pendulum.
     // Using:
@@ -429,9 +430,9 @@ TEST_F(PendulumTests, Finalize) {
 
   // Asserts that no more multibody elements can be added after finalize.
   SpatialInertia<double> M_Bo_B;
-  EXPECT_THROW(model_->AddBody<RigidBody>(M_Bo_B), std::logic_error);
+  EXPECT_THROW(model_->AddBody<RigidBody>("B", M_Bo_B), std::logic_error);
   EXPECT_THROW(
-      model_->AddFrame<FixedOffsetFrame>(*lower_link_, X_LEo_),
+      model_->AddFrame<FixedOffsetFrame>("F", *lower_link_, X_LEo_),
       std::logic_error);
   EXPECT_THROW(model_->AddMobilizer<RevoluteMobilizer>(
       *shoulder_inboard_frame_, *shoulder_outboard_frame_,

--- a/multibody/tree/test/universal_joint_test.cc
+++ b/multibody/tree/test/universal_joint_test.cc
@@ -38,7 +38,7 @@ class UniversalJointTest : public ::testing::Test {
     auto model = std::make_unique<internal::MultibodyTree<double>>();
 
     // Add some bodies so we can add joints between them:
-    body_ = &model->AddBody<RigidBody>(M_B);
+    body_ = &model->AddBody<RigidBody>("Body", M_B);
 
     // Add a universal joint between the world and body1:
     joint_ = &model->AddJoint<UniversalJoint>("Joint", model->world_body(),

--- a/multibody/tree/test/weld_joint_test.cc
+++ b/multibody/tree/test/weld_joint_test.cc
@@ -30,7 +30,7 @@ class WeldJointTest : public ::testing::Test {
     auto model = std::make_unique<internal::MultibodyTree<double>>();
 
     // Add a body so we can add joint to it.
-    body_ = &model->AddBody<RigidBody>(M_B);
+    body_ = &model->AddBody<RigidBody>("body", M_B);
 
     // Add a prismatic joint between the world and the body.
     joint_ = &model->AddJoint<WeldJoint>(


### PR DESCRIPTION
Names are not essential for the MbT itself, but they are essential for all of the related accouterments -- logging, visualization, export, etc.

Rather than make all of that code add special cases for empty names, it's easier to enforce that names are non-empty.

We could do that by inventing dummy names under the hood (indeed, we do that here for the deprecation period) but the names will be much better if force the user to provide them.

The deprecation timeline here errs on the side of being slightly longer than usual.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17632)
<!-- Reviewable:end -->
