### PR TITLE
[pydrake] Binding ContactSurface mesh fields

### DIFF
--- a/bindings/pydrake/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry_py_scene_graph.cc
@@ -550,11 +550,14 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("is_triangle", &Class::is_triangle, cls_doc.is_triangle.doc)
         .def("representation", &Class::representation,
             cls_doc.representation.doc)
-        .def("tri_mesh_W", &Class::tri_mesh_W, cls_doc.tri_mesh_W.doc)
-        // The tri_e_MN accessor is not bound yet.
+        .def("tri_mesh_W", &Class::tri_mesh_W, py_rvp::reference_internal,
+            cls_doc.tri_mesh_W.doc)
+        .def("tri_e_MN", &Class::tri_e_MN, py_rvp::reference_internal,
+            cls_doc.tri_e_MN.doc)
         .def("poly_mesh_W", &Class::poly_mesh_W, py_rvp::reference_internal,
             cls_doc.poly_mesh_W.doc)
-        // The poly_e_MN accessor is not bound yet.
+        .def("poly_e_MN", &Class::poly_e_MN, py_rvp::reference_internal,
+            cls_doc.poly_e_MN.doc)
         .def("HasGradE_M", &Class::HasGradE_M, cls_doc.HasGradE_M.doc)
         .def("HasGradE_N", &Class::HasGradE_N, cls_doc.HasGradE_N.doc)
         .def("EvaluateGradE_M_W", &Class::EvaluateGradE_M_W, py::arg("index"),


### PR DESCRIPTION
This accounts for a *portion* of the missing hydroelastic bindings. It is the minimum binding required to evaluate the pressure fields associated with `ContactSurface`. This doesn't bind the full public API for the various mesh field types. The determination of whether they should be bound can happen in the future.

1. Binding the underlying mesh field types:
  - `PolygonSurfaceMeshField`
  - `TriangleSurfaceMeshField`
2. Bind the missing methods on `ContactSurface`.
3. Unit tests on newly bound code.
  - Generally, unit tests on `ContactSurface` bindings were missing, and this adds them.

relates #17625

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17637)
<!-- Reviewable:end -->
