### PR TITLE
Implement capability to define coupler constraints

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -172,6 +172,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("num_actuators", &Class::num_actuators, cls_doc.num_actuators.doc)
         .def("num_force_elements", &Class::num_force_elements,
             cls_doc.num_force_elements.doc)
+        .def("num_constraints", &Class::num_constraints,
+            cls_doc.num_constraints.doc)
         .def("num_model_instances", &Class::num_model_instances,
             cls_doc.num_model_instances.doc)
         .def("num_positions",
@@ -250,7 +252,10 @@ void DoScalarDependentDefinitions(py::module m, T) {
                   std::move(force_element));
             },
             py::arg("force_element"), py_rvp::reference_internal,
-            cls_doc.AddForceElement.doc);
+            cls_doc.AddForceElement.doc)
+        .def("AddCouplerConstraint", &Class::AddCouplerConstraint,
+            py::arg("joint0"), py::arg("joint1"), py::arg("gear_ratio"),
+            py::arg("offset") = 0.0, cls_doc.AddCouplerConstraint.doc);
     // Mathy bits
     cls  // BR
         .def(

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -103,6 +103,8 @@ void DoScalarIndependentDefinitions(py::module m) {
       m, "JointActuatorIndex", doc.JointActuatorIndex.doc);
   BindTypeSafeIndex<ModelInstanceIndex>(
       m, "ModelInstanceIndex", doc.ModelInstanceIndex.doc);
+  BindTypeSafeIndex<ConstraintIndex>(
+      m, "ConstraintIndex", doc.ConstraintIndex.doc);
   m.def("world_index", &world_index, doc.world_index.doc);
   m.def("world_model_instance", &world_model_instance,
       doc.world_model_instance.doc);

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -15,18 +15,19 @@
 #include "drake/multibody/plant/contact_results.h"
 #include "drake/multibody/plant/contact_results_to_lcm.h"
 #include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/multibody_plant_config_functions.h"
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/analysis/simulator_gflags.h"
 #include "drake/systems/analysis/simulator_print_stats.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/primitives/sine.h"
-
 namespace drake {
 namespace examples {
 namespace simple_gripper {
 namespace {
 
+using Eigen::Vector2d;
 using Eigen::Vector3d;
 using geometry::SceneGraph;
 using geometry::Sphere;
@@ -38,6 +39,7 @@ using multibody::ConnectContactResultsToDrakeVisualizer;
 using multibody::CoulombFriction;
 using multibody::ModelInstanceIndex;
 using multibody::MultibodyPlant;
+using multibody::MultibodyPlantConfig;
 using multibody::Parser;
 using multibody::PrismaticJoint;
 using systems::Sine;
@@ -86,8 +88,8 @@ DEFINE_double(rz, 0,
               "The z-rotation of the mug around its origin - the center "
               "of its bottom. [degrees]. Extrinsic rotation order: X, Y, Z");
 
-// Gripping force.
-DEFINE_double(gripper_force, 10,
+// Grip force. The amount of force we want to apply on the manipuland.
+DEFINE_double(grip_force, 10,
               "The force to be applied by the gripper. [N]. "
               "A value of 0 indicates a fixed grip width as set with option "
               "grip_width.");
@@ -99,6 +101,16 @@ DEFINE_double(amplitude, 0.15,
 DEFINE_double(frequency, 2.0,
               "The frequency of the harmonic oscillations "
               "carried out by the gripper. [Hz].");
+
+DEFINE_string(discrete_solver, "sap",
+              "Discrete contact solver. Options are: 'tamsi', 'sap'.");
+DEFINE_double(
+    coupler_gear_ratio, -1.0,
+    "When using SAP, the left finger's position qₗ is constrainted to qₗ = "
+    "ρ⋅qᵣ, where qᵣ is the right finger's position and ρ is this "
+    "coupler_gear_ration parameter (dimensionless). If TAMSI used, "
+    "then the right finger is locked, only the left finger moves and this "
+    "parameter is ignored.");
 
 // The pad was measured as a torus with the following major and minor radii.
 const double kPadMajorRadius = 14e-3;  // 14 mm.
@@ -154,8 +166,11 @@ int do_main() {
   DRAKE_DEMAND(FLAGS_simulator_max_time_step > 0);
   DRAKE_DEMAND(FLAGS_mbp_discrete_update_period >= 0);
 
-  auto [plant, scene_graph] = multibody::AddMultibodyPlantSceneGraph(
-      &builder, FLAGS_mbp_discrete_update_period);
+  MultibodyPlantConfig plant_config;
+  plant_config.time_step = FLAGS_mbp_discrete_update_period;
+  plant_config.discrete_contact_solver = FLAGS_discrete_solver;
+  auto [plant, scene_graph] =
+      multibody::AddMultibodyPlant(plant_config, &builder);
 
   Parser parser(&plant);
   std::string full_name =
@@ -193,7 +208,7 @@ int do_main() {
   // Pads offset from the center of a finger. pad_offset = 0 means the center of
   // the spheres is located right at the center of the finger.
   const double pad_offset = 0.0046;
-  if (FLAGS_gripper_force == 0) {
+  if (FLAGS_grip_force == 0) {
     // We then fix everything to the right finger and leave the left finger
     // "free" with no applied forces (thus we see it not moving).
     const double finger_width = 0.007;  // From the visual in the SDF file.
@@ -203,6 +218,19 @@ int do_main() {
   } else {
     AddGripperPads(&plant, -pad_offset, right_finger);
     AddGripperPads(&plant, +pad_offset, left_finger);
+  }
+
+  // Get joints so that we can set initial conditions.
+  const PrismaticJoint<double>& left_slider =
+      plant.GetJointByName<PrismaticJoint>("left_slider");
+  const PrismaticJoint<double>& right_slider =
+      plant.GetJointByName<PrismaticJoint>("right_slider");
+
+  // TAMSI does not support general constraints. If using TAMSI, we simplify the
+  // model to have the right finger locked.
+  if (FLAGS_discrete_solver != "tamsi") {
+    plant.AddCouplerConstraint(left_slider, right_slider,
+                               FLAGS_coupler_gear_ratio);
   }
 
   // Now the model is complete.
@@ -259,14 +287,40 @@ int do_main() {
   const double f0 = mass * a0;           // Force amplitude, Newton.
   fmt::print("Acceleration amplitude = {:8.4f} m/s²\n", a0);
 
+  // The actuation force that must be applied in order to attain a given grip
+  // force depends on how the gripper is modeled.
+  // When we model the gripper as having the right finger locked and only the
+  // actuated left finger moves, it is clear that the actuation force directly
+  // balances the grip force (as done when usint the TAMSI solver).
+  // When we model the gripper with two moving fingers coupled to move together
+  // with a constraint, the relationship is not as obvious. We can think of the
+  // constrained mechanism as a system of pulleys and therefore we'd need to
+  // consider a free-body diagram to find the relationship between forces. A
+  // much simpler approach however is to consider virtual displacements. When
+  // the object is in a steady grasp between the fingers, there is an equal and
+  // opposite force on each finger of magnitude equal to the grip force, G (or
+  // otherwise the mug would move). A small motion δqᵣ of the right finger
+  // then leads to a motion δqₗ = ρ⋅δqᵣ of the left finger. If U is the
+  // actuation on the right finger, the virtual work due to U is δWu = U⋅δqᵣ.
+  // The virtual work due to the contact forces (G on each finger) is δWg =
+  // -G⋅δqₗ + G⋅δqᵣ = G⋅(1-ρ)⋅δqᵣ. In equilibrium we must have δWu = δWg for
+  // arbitrary δqᵣ and therefore we find U = G⋅(1-ρ). For instance, when ρ = -1
+  // (fingers move in opposition) we find that U = 2 G and thus we must apply
+  // twice as much force as the grip force. This makes sense if we consider a
+  // system of pulleys for this mechanism.
+  const double grip_actuation_force =
+      FLAGS_discrete_solver == "tamsi"
+          ? FLAGS_grip_force
+          : (1.0 - FLAGS_coupler_gear_ratio) * FLAGS_grip_force;
+
   // Notice we are using the same Sine source to:
   //   1. Generate a harmonic forcing of the gripper with amplitude f0 and
   //      angular frequency omega.
   //   2. Impose a constant force to the left finger. That is, a harmonic
   //      forcing with "zero" frequency.
-  const Vector2<double> amplitudes(f0, FLAGS_gripper_force);
-  const Vector2<double> frequencies(omega, 0.0);
-  const Vector2<double> phases(0.0, M_PI_2);
+  const Vector2d amplitudes(f0, grip_actuation_force);
+  const Vector2d frequencies(omega, 0.0);
+  const Vector2d phases(0.0, M_PI_2);
   const auto& harmonic_force =
       *builder.AddSystem<Sine>(amplitudes, frequencies, phases);
 
@@ -282,12 +336,10 @@ int do_main() {
   systems::Context<double>& plant_context =
       diagram->GetMutableSubsystemContext(plant, diagram_context.get());
 
-  // Get joints so that we can set initial conditions.
-  const PrismaticJoint<double>& finger_slider =
-      plant.GetJointByName<PrismaticJoint>("finger_sliding_joint");
-
-  // Set initial position of the left finger.
-  finger_slider.set_translation(&plant_context, -FLAGS_grip_width);
+  // Set initial position of the fingers.
+  const double finger_offset = FLAGS_grip_width / 2.0;
+  left_slider.set_translation(&plant_context, -finger_offset);
+  right_slider.set_translation(&plant_context, finger_offset);
 
   // Initialize the mug pose to be right in the middle between the fingers.
   const Vector3d& p_WBr =
@@ -308,6 +360,14 @@ int do_main() {
   // around this initial position.
   translate_joint.set_translation(&plant_context, 0.0);
   translate_joint.set_translation_rate(&plant_context, v0);
+
+  if (FLAGS_discrete_solver == "tamsi") {
+    drake::log()->warn(
+        "discrete_solver = 'tamsi'. Since TAMSI does not support coupler "
+        "constraints to model the coupling of the fingers, this simple example "
+        "locks the right finger and only the left finger is allowed to move.");
+    right_slider.Lock(&plant_context);
+  }
 
   // Set up simulator.
   auto simulator =

--- a/examples/simple_gripper/simple_gripper.sdf
+++ b/examples/simple_gripper/simple_gripper.sdf
@@ -3,15 +3,22 @@
   <!-- Note: This is the accompaning SDF file for the example demo in
        simple_gripper.cc and therefore these two files must be kept in sync.
 
-         This file defines the model for a simple gripper having two fingers.
-       The right finger is fixed to the body of the gripper. The left finger
-       is attached to the main body by a prismatic joint that allows it to
-       perform a grip.
-         The frame of the gripper, G, has its x-axis pointing to the right
+       This file defines the model for a simple gripper having two fingers on
+       prismatic joints. Only the left finger is actuated. The modeler will want
+       to add a coupler constraint between the fingers (if the selected solver
+       supports it) or simply lock the right finger in place.
+
+       The frame of the gripper, G, has its x-axis pointing to the right
        of the gripper, its y-axis pointing "forward" (towards the fingers
        side) and, the z-axis pointing upwards. This file only defines visual
        geometry but not contact geometry, allowing the demo in
        simple_gripper.cc to add contact geometry programmatically.
+
+       simple_gripper.cc adds pads to the model programatically. Including the
+       thickness of these pads, 6 mm, and the offset from the center of the
+       corresponding finger, 4.6 mm, each finger is positioned along the x-axis
+       such that at q=0 the pads from each finger barely touch. This is 6 mm +
+       4.6 mm = 10.5 mm.
   -->
   <model name="simple_gripper">
     <!-- Pose X_WG of the gripper model frame G in the world frame W. -->
@@ -67,7 +74,10 @@
       </visual>
     </link>
     <link name="left_finger">
-      <pose>0.040 0.029 0 0 0 0</pose>
+      <!-- Each finger is positioned along the x-axis such that at q=0 the pads
+      of each finger barely touch each other. See notes at the top of this
+      file. -->
+      <pose>-0.0105 0.029 0 0 0 0</pose>
       <inertial>
         <mass>0.05</mass>
         <inertia>
@@ -88,7 +98,10 @@
       </visual>
     </link>
     <link name="right_finger">
-      <pose>0.047 0.029 0 0 0 0</pose>
+      <!-- Each finger is positioned along the x-axis such that at q=0 the pads
+      of each finger barely touch each other. See notes at the top of this
+      file. -->
+      <pose>0.0105 0.029 0 0 0 0</pose>
       <inertial>
         <mass>0.05</mass>
         <inertia>
@@ -108,12 +121,8 @@
         </geometry>
       </visual>
     </link>
-    <joint name="weld_right_finger" type="fixed">
+    <joint name="left_slider" type="prismatic">
       <parent>body</parent>
-      <child>right_finger</child>
-    </joint>
-    <joint name="finger_sliding_joint" type="prismatic">
-      <parent>right_finger</parent>
       <child>left_finger</child>
       <axis>
         <xyz>1 0 0</xyz>
@@ -121,6 +130,18 @@
              limit. We do want an actuator for this joint. -->
         <limit>
           <effort>500</effort>
+        </limit>
+      </axis>
+    </joint>
+    <joint name="right_slider" type="prismatic">
+      <parent>body</parent>
+      <child>right_finger</child>
+      <axis>
+        <xyz>1 0 0</xyz>
+        <!-- Drake attaches an actuator to all joints with a non-zero effort
+             limit. We do NOT want an actuator for this joint. -->
+        <limit>
+          <effort>0</effort>
         </limit>
       </axis>
     </joint>

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -18,6 +18,7 @@ drake_cc_package_library(
     visibility = ["//visibility:public"],
     deps = [
         ":calc_distance_and_time_derivative",
+        ":constraint_specs",
         ":contact_jacobians",
         ":contact_results",
         ":coulomb_friction",
@@ -35,6 +36,20 @@ drake_cc_package_library(
         ":propeller",
         ":tamsi_solver",
         ":wing",
+    ],
+)
+
+drake_cc_library(
+    name = "constraint_specs",
+    srcs = [
+        "constraint_specs.cc",
+    ],
+    hdrs = [
+        "constraint_specs.h",
+    ],
+    deps = [
+        "//common:default_scalars",
+        "//multibody/tree:multibody_tree_indexes",
     ],
 )
 
@@ -112,6 +127,7 @@ drake_cc_library(
     ],
     visibility = ["//visibility:private"],
     deps = [
+        ":constraint_specs",
         ":contact_jacobians",
         ":contact_results",
         ":coulomb_friction",

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -16,6 +16,7 @@
 #include "drake/multibody/contact_solvers/contact_solver_utils.h"
 #include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
 #include "drake/multibody/contact_solvers/sap/sap_friction_cone_constraint.h"
+#include "drake/multibody/contact_solvers/sap/sap_holonomic_constraint.h"
 #include "drake/multibody/contact_solvers/sap/sap_limit_constraint.h"
 #include "drake/multibody/contact_solvers/sap/sap_solver.h"
 #include "drake/multibody/contact_solvers/sap/sap_solver_results.h"
@@ -32,6 +33,7 @@ using drake::multibody::contact_solvers::internal::ExtractTangent;
 using drake::multibody::contact_solvers::internal::SapConstraint;
 using drake::multibody::contact_solvers::internal::SapContactProblem;
 using drake::multibody::contact_solvers::internal::SapFrictionConeConstraint;
+using drake::multibody::contact_solvers::internal::SapHolonomicConstraint;
 using drake::multibody::contact_solvers::internal::SapLimitConstraint;
 using drake::multibody::contact_solvers::internal::SapSolver;
 using drake::multibody::contact_solvers::internal::SapSolverResults;
@@ -877,6 +879,73 @@ void CompliantContactManager<T>::AddLimitConstraints(
 }
 
 template <typename T>
+void CompliantContactManager<T>::AddCouplerConstraints(
+    const systems::Context<T>& context, SapContactProblem<T>* problem) const {
+  DRAKE_DEMAND(problem != nullptr);
+
+  // Previous time step positions.
+  const VectorX<T> q0 = plant().GetPositions(context);
+
+  // Couplers do not have impulse limits, they are bi-lateral constraints. Each
+  // coupler constraint introduces a single constraint equation.
+  constexpr double kInfinity = std::numeric_limits<double>::infinity();
+  const Vector1<T> gamma_lower(-kInfinity);
+  const Vector1<T> gamma_upper(kInfinity);
+
+  // Stiffness and dissipation are set so that the constraint is in the
+  // "near-rigid" regime, [Castro et al., 2022].
+  const Vector1<T> stiffness(kInfinity);
+  const Vector1<T> relaxation_time(plant().time_step());
+
+  for (const CouplerConstraintSpecs<T>& info :
+       this->coupler_constraints_specs()) {
+    const Joint<T>& joint0 = plant().get_joint(info.joint0_index);
+    const Joint<T>& joint1 = plant().get_joint(info.joint1_index);
+    const int dof0 = joint0.velocity_start();
+    const int dof1 = joint1.velocity_start();
+    const TreeIndex tree0 = tree_topology().velocity_to_tree_index(dof0);
+    const TreeIndex tree1 = tree_topology().velocity_to_tree_index(dof1);
+
+    // Sanity check.
+    DRAKE_DEMAND(tree0.is_valid() && tree1.is_valid());
+
+    // DOFs local to their tree.
+    const int tree_dof0 = dof0 - tree_topology().tree_velocities_start(tree0);
+    const int tree_dof1 = dof1 - tree_topology().tree_velocities_start(tree1);
+
+    // Constraint function defined as g = q₀ - ρ⋅q₁ - Δq, with ρ the gear ratio
+    // and Δq a fixed position offset.
+    const Vector1<T> g0(q0[dof0] - info.gear_ratio * q0[dof1] - info.offset);
+
+    // TODO(amcastro-tri): consider exposing this parameter.
+    const double beta = 0.1;
+
+    const typename SapHolonomicConstraint<T>::Parameters parameters{
+        gamma_lower, gamma_upper, stiffness, relaxation_time, beta};
+
+    if (tree0 == tree1) {
+      const int nv = tree_topology().num_tree_velocities(tree0);
+      MatrixX<T> J = MatrixX<T>::Zero(1, nv);
+      // J = dg/dv
+      J(0, tree_dof0) = 1.0;
+      J(0, tree_dof1) = -info.gear_ratio;
+
+      problem->AddConstraint(std::make_unique<SapHolonomicConstraint<T>>(
+          tree0, g0, J, parameters));
+    } else {
+      const int nv0 = tree_topology().num_tree_velocities(tree0);
+      const int nv1 = tree_topology().num_tree_velocities(tree1);
+      MatrixX<T> J0 = MatrixX<T>::Zero(1, nv0);
+      MatrixX<T> J1 = MatrixX<T>::Zero(1, nv1);
+      J0(0, tree_dof0) = 1.0;
+      J1(0, tree_dof1) = -info.gear_ratio;
+      problem->AddConstraint(std::make_unique<SapHolonomicConstraint<T>>(
+          tree0, tree1, g0, J0, J1, parameters));
+    }
+  }
+}
+
+template <typename T>
 void CompliantContactManager<T>::CalcContactProblemCache(
     const systems::Context<T>& context, ContactProblemCache<T>* cache) const {
   SapContactProblem<T>& problem = *cache->sap_problem;
@@ -891,6 +960,7 @@ void CompliantContactManager<T>::CalcContactProblemCache(
   // Do not change this order here!
   cache->R_WC = AddContactConstraints(context, &problem);
   AddLimitConstraints(context, problem.v_star(), &problem);
+  AddCouplerConstraints(context, &problem);
 }
 
 template <typename T>

--- a/multibody/plant/compliant_contact_manager.h
+++ b/multibody/plant/compliant_contact_manager.h
@@ -324,6 +324,12 @@ class CompliantContactManager final
       const systems::Context<T>& context, const VectorX<T>& v_star,
       contact_solvers::internal::SapContactProblem<T>* problem) const;
 
+  // Adds holonomic constraints to model couplers specified in the
+  // MultibodyPlant.
+  void AddCouplerConstraints(
+      const systems::Context<T>& context,
+      contact_solvers::internal::SapContactProblem<T>* problem) const;
+
   // This method takes SAP results for a given `problem` and loads forces due to
   // contact only into `contact_results`. `contact_results` is properly resized
   // on output.

--- a/multibody/plant/constraint_specs.cc
+++ b/multibody/plant/constraint_specs.cc
@@ -1,0 +1,6 @@
+#include "drake/multibody/plant/constraint_specs.h"
+
+#include "drake/common/default_scalars.h"
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    struct ::drake::multibody::internal::CouplerConstraintSpecs);

--- a/multibody/plant/constraint_specs.h
+++ b/multibody/plant/constraint_specs.h
@@ -1,0 +1,33 @@
+#pragma once
+
+/// @file
+/// This files contains simple structs used to store constraint specifications
+/// defined by the user through MultibodyPlant API calls. These specifications
+/// are later on used by our discrete solvers to build a model.
+
+#include "drake/multibody/tree/multibody_tree_indexes.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Struct to store coupler constraint parameters.
+// Coupler constraints are modeled as a holonomic constraint of the form q₀ =
+// ρ⋅q₁ + Δq, where q₀ and q₁ are the positions of two one-DOF joints, ρ the
+// gear ratio and Δq a fixed offset. Per equation above, ρ has units of q₀/q₁
+// and Δq has units of q₀.
+template <typename T>
+struct CouplerConstraintSpecs {
+  // First joint with position q₀.
+  JointIndex joint0_index;
+  // Second joint with position q₁.
+  JointIndex joint1_index;
+  // Gear ratio ρ.
+  T gear_ratio{1.0};
+  // Offset Δq.
+  T offset{0.0};
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -161,6 +161,13 @@ DiscreteUpdateManager<T>::geometry_id_to_body_index() const {
       T>::geometry_id_to_body_index(*plant_);
 }
 
+template <typename T>
+const std::vector<internal::CouplerConstraintSpecs<T>>&
+DiscreteUpdateManager<T>::coupler_constraints_specs() const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<
+      T>::coupler_constraints_specs(*plant_);
+}
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -11,6 +11,7 @@
 #include "drake/geometry/query_results/contact_surface.h"
 #include "drake/multibody/contact_solvers/contact_solver.h"
 #include "drake/multibody/contact_solvers/contact_solver_results.h"
+#include "drake/multibody/plant/constraint_specs.h"
 #include "drake/multibody/plant/contact_jacobians.h"
 #include "drake/multibody/plant/coulomb_friction.h"
 #include "drake/multibody/plant/discrete_contact_pair.h"
@@ -216,6 +217,9 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
 
   const std::unordered_map<geometry::GeometryId, BodyIndex>&
   geometry_id_to_body_index() const;
+
+  const std::vector<internal::CouplerConstraintSpecs<T>>&
+  coupler_constraints_specs() const;
   /* @} */
 
   /* Concrete DiscreteUpdateManagers must override these NVI Calc methods to

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -21,6 +21,7 @@
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/contact_solvers/contact_solver.h"
 #include "drake/multibody/contact_solvers/contact_solver_results.h"
+#include "drake/multibody/plant/constraint_specs.h"
 #include "drake/multibody/plant/contact_jacobians.h"
 #include "drake/multibody/plant/contact_results.h"
 #include "drake/multibody/plant/coulomb_friction.h"
@@ -1145,6 +1146,51 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if the %MultibodyPlant has already been
   /// finalized.
   void Finalize();
+  /// @}
+
+  /// @anchor mbp_constraints
+  /// @name                      Constraints
+  ///
+  /// Set of APIs to define constraints. To mention a few important examples,
+  /// constraints can be used to couple the motion of joints, to create
+  /// kinematic loops, or to weld bodies together.
+  ///
+  /// Currently constraints are only supported for discrete %MultibodyPlant
+  /// models and not for all discrete solvers, see
+  /// set_discrete_contact_solver(). If the model contains constraints not
+  /// supported by the discrete solver, the plant will throw an exception at
+  /// Finalize() time. At this point the user has the option to either change
+  /// the contact solver with set_discrete_contact_solver() or in the
+  /// MultibodyPlantConfig, or to re-define the model so that such a constraint
+  /// is not needed.
+  /// @{
+
+  /// Returns the total number of constraints specified by the user.
+  int num_constraints() const { return coupler_constraints_specs_.size(); }
+
+  /// Defines a holonomic constraint between two single-dof joints `joint0`
+  /// and `joint1` with positions q₀ and q₁, respectively, such that q₀ = ρ⋅q₁ +
+  /// Δq, where ρ is the gear ratio and Δq is a fixed offset. The gear ratio
+  /// can have units if the units of q₀ and q₁ are different. For instance,
+  /// between a prismatic and a revolute joint the gear ratio will specify the
+  /// "pitch" of the resulting mechanism. As defined, `offset` has units of
+  /// `q₀`.
+  ///
+  /// @note joint0 and/or joint1 can still be actuated, regardless of whether we
+  /// have coupler constraint among them. That is, one or both of these joints
+  /// can have external actuation applied to them.
+  ///
+  /// @note Generally, to couple (q0, q1, q2), the user would define a coupler
+  /// between (q0, q1) and a second coupler between (q1, q2), or any
+  /// combination therein.
+  ///
+  /// @throws if joint0 and joint1 are not both single-dof joints.
+  /// @throws std::exception if the %MultibodyPlant has already been finalized.
+  ConstraintIndex AddCouplerConstraint(const Joint<T>& joint0,
+                                       const Joint<T>& joint1,
+                                       const T& gear_ratio,
+                                       const T& offset = 0.0);
+
   /// @}
 
   /// @anchor mbp_geometry
@@ -5039,6 +5085,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   // (Experimental) The vector of physical models owned by MultibodyPlant.
   std::vector<std::unique_ptr<internal::PhysicalModel<T>>> physical_models_;
+
+  // Vector of coupler constraints specifications.
+  std::vector<internal::CouplerConstraintSpecs<T>> coupler_constraints_specs_;
 
   // All MultibodyPlant cache indexes are stored in cache_indexes_.
   CacheIndexes cache_indexes_;

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -115,6 +115,11 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
   geometry_id_to_body_index(const MultibodyPlant<T>& plant) {
     return plant.geometry_id_to_body_index_;
   }
+
+  static const std::vector<internal::CouplerConstraintSpecs<T>>&
+  coupler_constraints_specs(const MultibodyPlant<T>& plant) {
+    return plant.coupler_constraints_specs_;
+  }
 };
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/plant/test/compliant_contact_manager_test.cc
+++ b/multibody/plant/test/compliant_contact_manager_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/plant/compliant_contact_manager.h"
 
+#include <algorithm>
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
@@ -11,6 +14,7 @@
 #include "drake/multibody/contact_solvers/contact_solver_utils.h"
 #include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
 #include "drake/multibody/contact_solvers/sap/sap_friction_cone_constraint.h"
+#include "drake/multibody/contact_solvers/sap/sap_holonomic_constraint.h"
 #include "drake/multibody/contact_solvers/sap/sap_limit_constraint.h"
 #include "drake/multibody/contact_solvers/sap/sap_solver.h"
 #include "drake/multibody/contact_solvers/sap/sap_solver_results.h"
@@ -36,6 +40,7 @@ using drake::multibody::contact_solvers::internal::ContactSolverResults;
 using drake::multibody::contact_solvers::internal::MergeNormalAndTangent;
 using drake::multibody::contact_solvers::internal::SapContactProblem;
 using drake::multibody::contact_solvers::internal::SapFrictionConeConstraint;
+using drake::multibody::contact_solvers::internal::SapHolonomicConstraint;
 using drake::multibody::contact_solvers::internal::SapLimitConstraint;
 using drake::multibody::contact_solvers::internal::SapSolver;
 using drake::multibody::contact_solvers::internal::SapSolverParameters;
@@ -389,9 +394,8 @@ class SpheresStack : public ::testing::Test {
 
       // Verify dissipation.
       const double tau1 = *sphere1_contact_params.relaxation_time;
-      const double tau2 = i == 0
-                              ? *sphere2_contact_params.relaxation_time
-                              : *hard_hydro_contact.relaxation_time;
+      const double tau2 = i == 0 ? *sphere2_contact_params.relaxation_time
+                                 : *hard_hydro_contact.relaxation_time;
       const double tau_expected = tau1 + tau2;
       EXPECT_NEAR(point_pair.dissipation_time_scale, tau_expected,
                   kEps * tau_expected);
@@ -573,8 +577,7 @@ class SpheresStack : public ::testing::Test {
 
     if (params.relaxation_time.has_value()) {
       properties.AddProperty(geometry::internal::kMaterialGroup,
-                             "relaxation_time",
-                             *params.relaxation_time);
+                             "relaxation_time", *params.relaxation_time);
     }
     return properties;
   }
@@ -1163,20 +1166,54 @@ class KukaIiwaArmTests : public ::testing::Test {
   // Setup model of the Kuka iiwa arm with Schunk gripper and allocate context
   // resources. The model includes reflected inertias. Input ports are fixed to
   // arbitrary non-zero values.
-  void SetUp() override {
-    LoadIiwaWithGripper(&plant_);
-    AddInReflectedInertia(&plant_, kRotorInertias, kGearRatios);
+  void SetSingleRobotModel() {
+    // Only SAP supports the modeling of constraints.
+    plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
 
+    // Load robot model from files.
+    const std::vector<ModelInstanceIndex> models = SetUpArmModel(1, &plant_);
     plant_.Finalize();
+
+    // The model has a single coupler constraint.
+    EXPECT_EQ(plant_.num_constraints(), 1);
 
     auto owned_contact_manager =
         std::make_unique<CompliantContactManager<double>>();
     manager_ = owned_contact_manager.get();
     plant_.SetDiscreteUpdateManager(std::move(owned_contact_manager));
+    // Model with a single robot and gripper. A single coupler constraint to
+    // model the gripper.
+    EXPECT_EQ(plant_.num_constraints(), 1);
 
     context_ = plant_.CreateDefaultContext();
-    SetArbitraryNonZeroActuation(plant_, context_.get());
+    SetArbitraryNonZeroActuation(plant_, models[0], models[1], context_.get());
     SetArbitraryState(plant_, context_.get());
+  }
+
+  // Setup model of the Kuka iiwa arm with Schunk gripper. The model includes
+  // reflected inertias. The gripper is modeled with a coupler constraint.
+  std::vector<ModelInstanceIndex> SetUpArmModel(
+      int robot_number, MultibodyPlant<double>* plant) const {
+    std::vector<ModelInstanceIndex> models =
+        LoadIiwaWithGripper(robot_number, plant);
+    AddInReflectedInertia(plant, models, kRotorInertias, kGearRatios);
+
+    // Constrain the gripper fingers to be coupled.
+    const ModelInstanceIndex gripper_model = models[1];
+    const Joint<double>& left_finger_slider =
+        plant->GetJointByName("left_finger_sliding_joint", gripper_model);
+    const Joint<double>& right_finger_slider =
+        plant->GetJointByName("right_finger_sliding_joint", gripper_model);
+    // While for a typical gripper most likely the gear ratio is one and the
+    // offset is zero, here we use an arbitrary set of values to verify later on
+    // in the test that the manager created a constraint consistent with these
+    // numbers.
+    const ConstraintIndex next_constraint_index(plant->num_constraints());
+    ConstraintIndex constraint_index =
+        plant->AddCouplerConstraint(left_finger_slider, right_finger_slider,
+                                    kCouplerGearRatio, kCouplerOffset);
+    EXPECT_EQ(constraint_index, next_constraint_index);
+    return models;
   }
 
   // The manager solves free motion velocities using a discrete scheme with
@@ -1219,13 +1256,11 @@ class KukaIiwaArmTests : public ::testing::Test {
       const MultibodyPlant<double>& plant,
       const std::vector<InitializePositionAt>& limits_specification,
       Context<double>* context) {
-    DRAKE_DEMAND(static_cast<int>(limits_specification.size()) == kNumJoints);
-
     // Arbitrary positive slop used for positions.
     const double kPositiveDeltaQ = M_PI / 10.0;
     const double dt = plant.time_step();
-    VectorXd v0(kNumJoints);
-    VectorXd q0(kNumJoints);
+    VectorXd v0(plant.num_velocities());
+    VectorXd q0(plant.num_positions());
 
     for (JointIndex joint_index(0); joint_index < plant.num_joints();
          ++joint_index) {
@@ -1282,8 +1317,23 @@ class KukaIiwaArmTests : public ::testing::Test {
     plant.SetVelocities(context, v0);
   }
 
+  // Fixes all input ports to have non-zero actuation.
+  void SetArbitraryNonZeroActuation(const MultibodyPlant<double>& plant,
+                                    ModelInstanceIndex arm_model,
+                                    ModelInstanceIndex gripper_model,
+                                    Context<double>* context) const {
+    const VectorX<double> tau_arm = VectorX<double>::LinSpaced(
+        plant.num_actuated_dofs(arm_model), 10.0, 1000.0);
+    const VectorX<double> tau_gripper = VectorX<double>::LinSpaced(
+        plant.num_actuated_dofs(gripper_model), 10.0, 1000.0);
+    plant.get_actuation_input_port(arm_model).FixValue(context, tau_arm);
+    plant.get_actuation_input_port(gripper_model)
+        .FixValue(context, tau_gripper);
+  }
+
  private:
-  void LoadIiwaWithGripper(MultibodyPlant<double>* plant) {
+  std::vector<ModelInstanceIndex> LoadIiwaWithGripper(
+      int robot_number, MultibodyPlant<double>* plant) const {
     DRAKE_DEMAND(plant != nullptr);
     const char kArmFilePath[] =
         "drake/manipulation/models/iiwa_description/urdf/"
@@ -1293,28 +1343,40 @@ class KukaIiwaArmTests : public ::testing::Test {
         "drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50.sdf";
 
     Parser parser(plant);
-    arm_model_ = parser.AddModelFromFile(FindResourceOrThrow(kArmFilePath));
+    ModelInstanceIndex arm_model =
+        parser.AddModelFromFile(FindResourceOrThrow(kArmFilePath),
+                                "robot_" + std::to_string(robot_number));
 
     // Add the gripper.
-    gripper_model_ =
-        parser.AddModelFromFile(FindResourceOrThrow(kWsg50FilePath));
+    ModelInstanceIndex gripper_model =
+        parser.AddModelFromFile(FindResourceOrThrow(kWsg50FilePath),
+                                "gripper_" + std::to_string(robot_number));
 
-    const auto& base_body = plant->GetBodyByName("base", arm_model_);
-    const auto& end_effector = plant->GetBodyByName("iiwa_link_7", arm_model_);
-    const auto& gripper_body = plant->GetBodyByName("body", gripper_model_);
+    const auto& base_body = plant->GetBodyByName("base", arm_model);
+    const auto& end_effector = plant->GetBodyByName("iiwa_link_7", arm_model);
+    const auto& gripper_body = plant->GetBodyByName("body", gripper_model);
     plant->WeldFrames(plant->world_frame(), base_body.body_frame());
     plant->WeldFrames(end_effector.body_frame(), gripper_body.body_frame());
+
+    return {arm_model, gripper_model};
   }
 
   void AddInReflectedInertia(MultibodyPlant<double>* plant,
+                             const std::vector<ModelInstanceIndex>& models,
                              const VectorX<double>& rotor_inertias,
-                             const VectorX<double>& gear_ratios) {
+                             const VectorX<double>& gear_ratios) const {
     DRAKE_DEMAND(plant != nullptr);
+    int local_joint_index = 0;
     for (JointActuatorIndex index(0); index < plant->num_actuators(); ++index) {
       JointActuator<double>& joint_actuator =
           plant->get_mutable_joint_actuator(index);
-      joint_actuator.set_default_rotor_inertia(rotor_inertias(int{index}));
-      joint_actuator.set_default_gear_ratio(gear_ratios(int{index}));
+      if (std::count(models.begin(), models.end(),
+                     joint_actuator.model_instance()) > 0) {
+        joint_actuator.set_default_rotor_inertia(
+            rotor_inertias(local_joint_index));
+        joint_actuator.set_default_gear_ratio(gear_ratios(local_joint_index));
+        local_joint_index++;
+      }
     }
   }
 
@@ -1351,33 +1413,22 @@ class KukaIiwaArmTests : public ::testing::Test {
     }
   }
 
-  // Fixes all input ports to have non-zero actuation.
-  void SetArbitraryNonZeroActuation(const MultibodyPlant<double>& plant,
-                                    Context<double>* context) const {
-    const VectorX<double> tau_arm = VectorX<double>::LinSpaced(
-        plant.num_actuated_dofs(arm_model_), 10.0, 1000.0);
-    const VectorX<double> tau_gripper = VectorX<double>::LinSpaced(
-        plant.num_actuated_dofs(gripper_model_), 10.0, 1000.0);
-    plant.get_actuation_input_port(arm_model_).FixValue(context, tau_arm);
-    plant.get_actuation_input_port(gripper_model_)
-        .FixValue(context, tau_gripper);
-  }
-
  protected:
   const int kNumJoints = 9;
   const double kTimeStep{0.015};
   const VectorXd kRotorInertias{VectorXd::LinSpaced(kNumJoints, 0.1, 12.0)};
   const VectorXd kGearRatios{VectorXd::LinSpaced(kNumJoints, 1.5, 100.0)};
+  const double kCouplerGearRatio{-1.5};
+  const double kCouplerOffset{3.1};
   MultibodyPlant<double> plant_{kTimeStep};
   CompliantContactManager<double>* manager_{nullptr};
   std::unique_ptr<Context<double>> context_;
-  ModelInstanceIndex arm_model_;
-  ModelInstanceIndex gripper_model_;
 };
 
 // This test verifies that the linear dynamics matrix is properly computed
 // according to A = ∂m/∂v = (M + dt⋅D).
 TEST_F(KukaIiwaArmTests, CalcLinearDynamicsMatrix) {
+  SetSingleRobotModel();
   const std::vector<MatrixXd> A =
       CompliantContactManagerTest::CalcLinearDynamicsMatrix(*manager_,
                                                             *context_);
@@ -1399,6 +1450,7 @@ TEST_F(KukaIiwaArmTests, CalcLinearDynamicsMatrix) {
 // This test verifies that the computation of free motion velocities v*
 // correctly include the effect of damping implicitly.
 TEST_F(KukaIiwaArmTests, CalcFreeMotionVelocities) {
+  SetSingleRobotModel();
   const VectorXd v_star = CompliantContactManagerTest::CalcFreeMotionVelocities(
       *manager_, *context_);
 
@@ -1423,6 +1475,7 @@ TEST_F(KukaIiwaArmTests, CalcFreeMotionVelocities) {
 // kinematics with the proper results. The correctness of the computations we
 // rely on in this test (computation of accelerations) are tested elsewhere.
 TEST_F(KukaIiwaArmTests, CalcAccelerationKinematicsCache) {
+  SetSingleRobotModel();
   const VectorXd& v0 = plant_.GetVelocities(*context_);
   ContactSolverResults<double> contact_results;
   manager_->CalcContactSolverResults(*context_, &contact_results);
@@ -1445,6 +1498,7 @@ TEST_F(KukaIiwaArmTests, CalcAccelerationKinematicsCache) {
 }
 
 TEST_F(KukaIiwaArmTests, LimitConstraints) {
+  SetSingleRobotModel();
   // Arbitrary selection of how positions and velocities are initialized.
   std::vector<InitializePositionAt> limits_specification(
       kNumJoints, InitializePositionAt::WellWithinLimits);
@@ -1480,8 +1534,10 @@ TEST_F(KukaIiwaArmTests, LimitConstraints) {
 
   // This model has no contact. We expect the number of constraints and
   // equations be consistent with limits_specification defined above.
-  EXPECT_EQ(problem.num_constraints(), kNumJointsWithLimits);
-  EXPECT_EQ(problem.num_constraint_equations(), kNumConstraintEquations);
+  // Recall the model has one additional constraint to model the coupler between
+  // the gripper fingers.
+  EXPECT_EQ(problem.num_constraints(), kNumJointsWithLimits + 1);
+  EXPECT_EQ(problem.num_constraint_equations(), kNumConstraintEquations + 1);
 
   // In this model we clearly have single tree, the arm with its gripper.
   const int tree_expected = 0;
@@ -1668,8 +1724,8 @@ class MultiDofJointWithLimits final : public Joint<T> {
 GTEST_TEST(CompliantContactManager, ThrowForUnsupportedJoints) {
   MultibodyPlant<double> plant(1.0e-3);
   // To avoid unnecessary warnings/errors, use a non-zero spatial inertia.
-  const RigidBody<double>& body = plant.AddRigidBody("DummyBody",
-      SpatialInertia<double>::MakeUnitary());
+  const RigidBody<double>& body =
+      plant.AddRigidBody("DummyBody", SpatialInertia<double>::MakeUnitary());
   plant.AddJoint(std::make_unique<MultiDofJointWithLimits<double>>(
       plant.world_frame(), body.body_frame(), -1.0, 2.0));
   plant.Finalize();
@@ -1697,8 +1753,8 @@ GTEST_TEST(CompliantContactManager,
            VerifyMultiDofJointsWithoutLimitsAreSupported) {
   MultibodyPlant<double> plant(1.0e-3);
   // To avoid unnecessary warnings/errors, use a non-zero spatial inertia.
-  const RigidBody<double>& body = plant.AddRigidBody("DummyBody",
-      SpatialInertia<double>::MakeUnitary());
+  const RigidBody<double>& body =
+      plant.AddRigidBody("DummyBody", SpatialInertia<double>::MakeUnitary());
   const double kInf = std::numeric_limits<double>::infinity();
   plant.AddJoint(std::make_unique<MultiDofJointWithLimits<double>>(
       plant.world_frame(), body.body_frame(), -kInf, kInf));
@@ -1718,6 +1774,157 @@ GTEST_TEST(CompliantContactManager,
   // No limit constraints are added since the only one joint in the model has
   // no limits.
   EXPECT_EQ(problem.num_constraints(), 0);
+}
+
+// This test verifies that the manager properly added holonomic constraints for
+// the coupler constraints specified in the MultibodyPlant model.
+TEST_F(KukaIiwaArmTests, CouplerConstraints) {
+  // Only SAP supports the modeling of constraints.
+  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+
+  // Load two robot models.
+  std::vector<ModelInstanceIndex> arm_gripper1 = SetUpArmModel(1, &plant_);
+  std::vector<ModelInstanceIndex> arm_gripper2 = SetUpArmModel(2, &plant_);
+
+  // For testing purposes, we'll add a coupler constraint between joints in two
+  // different arms.
+  const Joint<double>& arm1_joint3 =
+      plant_.GetJointByName("iiwa_joint_3", arm_gripper1[0]);
+  const Joint<double>& arm2_joint6 =
+      plant_.GetJointByName("iiwa_joint_6", arm_gripper2[0]);
+  ConstraintIndex constraint_index = plant_.AddCouplerConstraint(
+      arm1_joint3, arm2_joint6, kCouplerGearRatio, kCouplerOffset);
+  EXPECT_EQ(constraint_index, ConstraintIndex(2));
+
+  plant_.Finalize();
+
+  // There should be three coupler constraints: one for each gripper and a third
+  // one between the two arms.
+  EXPECT_EQ(plant_.num_constraints(), 3);
+
+  // Set manager using the experimental API so that we can bring it to scope.
+  auto owned_contact_manager =
+      std::make_unique<CompliantContactManager<double>>();
+  manager_ = owned_contact_manager.get();
+  plant_.SetDiscreteUpdateManager(std::move(owned_contact_manager));
+
+  context_ = plant_.CreateDefaultContext();
+  SetArbitraryNonZeroActuation(plant_, arm_gripper1[0], arm_gripper1[1],
+                               context_.get());
+  SetArbitraryNonZeroActuation(plant_, arm_gripper2[0], arm_gripper2[1],
+                               context_.get());
+
+  // Specify a state in which all kNumJoints are within limits so that we know
+  // the contact problem has no limit constraints.
+  std::vector<InitializePositionAt> limits_specification(
+      2 * kNumJoints, InitializePositionAt::WellWithinLimits);
+  SetArbitraryStateWithLimitsSpecification(plant_, limits_specification,
+                                           context_.get());
+
+  // We are assuming there is no contact. Assert this.
+  const std::vector<DiscreteContactPair<double>>& discrete_pairs =
+      CompliantContactManagerTest::EvalDiscreteContactPairs(*manager_,
+                                                            *context_);
+  const int num_contacts = discrete_pairs.size();
+  ASSERT_EQ(num_contacts, 0);
+
+  const ContactProblemCache<double>& problem_cache =
+      CompliantContactManagerTest::EvalContactProblemCache(*manager_,
+                                                           *context_);
+  const SapContactProblem<double>& problem = *problem_cache.sap_problem;
+
+  // This model has no contact and the configuration is set to be within joint
+  // limits. Therefore we expect the problem to have the three couple
+  // constraints we added to the model.
+  EXPECT_EQ(problem.num_constraints(), 3);
+  EXPECT_EQ(problem.num_constraint_equations(), 3);
+
+  std::vector<std::pair<JointIndex, JointIndex>> coupler_joints;
+  // Coupler on first robot's gripper.
+  coupler_joints.push_back({
+      plant_.GetJointByName("left_finger_sliding_joint", arm_gripper1[1])
+          .index(),
+      plant_.GetJointByName("right_finger_sliding_joint", arm_gripper1[1])
+          .index(),
+  });
+
+  // Coupler on second robot's gripper.
+  coupler_joints.push_back({
+      plant_.GetJointByName("left_finger_sliding_joint", arm_gripper2[1])
+          .index(),
+      plant_.GetJointByName("right_finger_sliding_joint", arm_gripper2[1])
+          .index(),
+  });
+
+  // Coupler between the two robots.
+  coupler_joints.push_back({
+      plant_.GetJointByName("iiwa_joint_3", arm_gripper1[0]).index(),
+      plant_.GetJointByName("iiwa_joint_6", arm_gripper2[0]).index(),
+  });
+
+  // Verify each of the coupler constraints.
+  for (int i = 0; i < 3; ++i) {
+    const auto* constraint =
+        dynamic_cast<const SapHolonomicConstraint<double>*>(
+            &problem.get_constraint(i));
+
+    // Verify it is a SapHolonomicConstraint as expected.
+    ASSERT_NE(constraint, nullptr);
+
+    // There are two cliques in this model, one for each robot arm.
+    const int num_cliques = i == 2 ? 2 : 1;
+    EXPECT_EQ(constraint->num_cliques(), num_cliques);
+    const int first_clique = i == 1 ? 1 : 0;
+    EXPECT_EQ(constraint->first_clique(), first_clique);
+    if (i == 2) {
+      // constraint between the two robots.
+      EXPECT_EQ(constraint->second_clique(), 1);
+    }
+
+    const Joint<double>& joint0 = plant_.get_joint(coupler_joints[i].first);
+    const Joint<double>& joint1 = plant_.get_joint(coupler_joints[i].second);
+
+    // Verify the value of the constraint function.
+    const double q0 = joint0.GetOnePosition(*context_);
+    const double q1 = joint1.GetOnePosition(*context_);
+    const Vector1d g0_expected(q0 - kCouplerGearRatio * q1 - kCouplerOffset);
+    const VectorXd& g0 = constraint->constraint_function();
+    EXPECT_EQ(g0, g0_expected);
+
+    if (i < 2) {
+      // For the grippers, fingers are the last two DOFs in their tree.
+      const int left_index = 7;
+      const int right_index = 8;
+      const MatrixXd J_expected =
+          (VectorXd::Unit(kNumJoints, left_index) -
+           kCouplerGearRatio * VectorXd::Unit(kNumJoints, right_index))
+              .transpose();
+      EXPECT_EQ(constraint->first_clique_jacobian(), J_expected);
+    } else {
+      // The third constraint couples the two robot arms.
+      const MatrixXd J0_expected =
+          VectorXd::Unit(kNumJoints, 2 /* third joint. */).transpose();
+      const MatrixXd J1_expected =
+          -kCouplerGearRatio *
+          VectorXd::Unit(kNumJoints, 5 /* sixth joint. */).transpose();
+      EXPECT_EQ(constraint->first_clique_jacobian(), J0_expected);
+      EXPECT_EQ(constraint->second_clique_jacobian(), J1_expected);
+    }
+
+    // N.B. Default values implemented in
+    // CompliantContactManager::AddCouplerConstraints(), keep these values in
+    // sync.
+    const Vector1d kInfinity =
+        Vector1d::Constant(std::numeric_limits<double>::infinity());
+    const SapHolonomicConstraint<double>::Parameters& params =
+        constraint->parameters();
+    EXPECT_EQ(params.impulse_lower_limits(), -kInfinity);
+    EXPECT_EQ(params.impulse_upper_limits(), kInfinity);
+    EXPECT_EQ(params.stiffnesses(), kInfinity);
+    EXPECT_EQ(params.relaxation_times(),
+              Vector1d::Constant(plant_.time_step()));
+    EXPECT_EQ(params.beta(), 0.1);
+  }
 }
 
 }  // namespace internal

--- a/multibody/tree/multibody_tree_indexes.h
+++ b/multibody/tree/multibody_tree_indexes.h
@@ -38,6 +38,9 @@ using JointIndex = TypeSafeIndex<class JointElementTag>;
 /// Type used to identify actuators by index within a multibody tree system.
 using JointActuatorIndex = TypeSafeIndex<class JointActuatorElementTag>;
 
+/// Type used to identify constraints by index within a multibody system.
+using ConstraintIndex = TypeSafeIndex<class ConstraintTag>;
+
 /// Type used to identify model instances by index within a multibody
 /// tree system.
 using ModelInstanceIndex = TypeSafeIndex<class ModelInstanceTag>;


### PR DESCRIPTION
In addition to the corresponding unit tests, this PR updates the simple gripper demo to use coupler constraints.

cc'ing @dmcconachie-tri 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17639)
<!-- Reviewable:end -->
