### PR TITLE
Add mirror for MUMPS (when building wheel)

### DIFF
--- a/tools/wheel/image/dependencies/projects.cmake
+++ b/tools/wheel/image/dependencies/projects.cmake
@@ -117,7 +117,10 @@ list(APPEND ALL_PROJECTS clp)
 
 if(APPLE)
     set(mumps_version 5.5.0)  # Current version in Homebrew.
-    set(mumps_url "http://mumps.enseeiht.fr/MUMPS_${mumps_version}.tar.gz")
+    set(mumps_url
+        "https://drake-mirror.csail.mit.edu/other/mumps/MUMPS_${mumps_version}.tar.gz"
+        "http://mumps.enseeiht.fr/MUMPS_${mumps_version}.tar.gz"
+    )
     set(mumps_md5 "08eb0887bfd1e570ce7faecbd8bf97c0")
     set(mumps_dlname "mumps-${mumps_version}.tar.gz")
     list(APPEND ALL_PROJECTS mumps)


### PR DESCRIPTION
MUMPS recently yanked (and later restored) the tarball for the older 5.4.0 version (current, as of writing, is 5.5.x), resulting in the CI wheel builds being broken for two days. In order to be less dependent on upstream in the future, add our own S3 mirrors as a preferred source for the tarball.

It's arguable whether we should be doing this for all packages, or alternatively using e.g. the Ubuntu mirrors. However, most of our other wheel dependencies come from reputable sites and don't have a known history of purging old versions. MUMPS expects potential users to fill out a request form before disclosing the download URI, which is already dodgy. (We actually obtained the URIs from [Homebrew](https://github.com/Homebrew/homebrew-core/blob/486abde86557685ac4775404e5b966be31784945/Formula/ipopt.rb#L25).)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17640)
<!-- Reviewable:end -->
