### PR TITLE
[visualization] Improve meldis error message

### DIFF
--- a/bindings/pydrake/visualization/BUILD.bazel
+++ b/bindings/pydrake/visualization/BUILD.bazel
@@ -89,6 +89,7 @@ install(
 drake_py_unittest(
     name = "meldis_test",
     data = [
+        "//examples/hydroelastic/spatula_slip_control:models",
         "//multibody/benchmarks/acrobot:models",
         "//multibody/meshcat:models",
     ],

--- a/bindings/pydrake/visualization/meldis.py
+++ b/bindings/pydrake/visualization/meldis.py
@@ -195,11 +195,23 @@ class _ViewerApplet:
         elif geom.type == lcmt_viewer_geometry_data.ELLIPSOID:
             (a, b, c) = geom.float_data
             shape = Ellipsoid(a=a, b=b, c=c)
-        elif geom.type == lcmt_viewer_geometry_data.MESH:
+        elif geom.type == lcmt_viewer_geometry_data.MESH and geom.string_data:
+            # A mesh to be loaded from a file.
             (scale_x, scale_y, scale_z) = geom.float_data
             filename = geom.string_data
             assert scale_x == scale_y and scale_y == scale_z
             shape = Mesh(absolute_filename=filename, scale=scale_x)
+        elif geom.type == lcmt_viewer_geometry_data.MESH:
+            assert not geom.string_data
+            # A mesh with the data inline, i.e.,
+            #   V | T | v0 | v1 | ... vN | t0 | t1 | ... | tM
+            # where
+            #   V: The number of vertices.
+            #   T: The number of triangles.
+            #   N: 3V, the number of floating point values for the V vertices.
+            #   M: 3T, the number of vertex indices for the T triangles.
+            _logger.warning("Meldis cannot yet display hydroelastic collision "
+                            "meshes; that geometry will be ignored.")
         elif geom.type == lcmt_viewer_geometry_data.SPHERE:
             (radius,) = geom.float_data
             shape = Sphere(radius=radius)


### PR DESCRIPTION
Meldis does not yet support hydroelastic meshes that are transmitted inline:

https://github.com/RobotLocomotion/drake/blob/dc6db5cd74163e67bb009aac0f79b0c69375e80d/geometry/drake_visualizer.cc#L96-L106

As #17641 is currently written (with `show_hydroelastic = true`), it crashes meldis.  With this change, it warns instead (but doesn't actually show the hydroelastic geometry).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17642)
<!-- Reviewable:end -->
