### PR TITLE
Use Ubuntu mirror for MUMPS (wheel builds)

### DIFF
--- a/tools/wheel/image/dependencies/patches/mumps/patch.diff
+++ b/tools/wheel/image/dependencies/patches/mumps/patch.diff
@@ -50,15 +50,13 @@ index 2558f30..dac9334 100644
  
  #Sequential:
 diff --git a/Makefile b/Makefile
-index 59d74d7..4a2b467 100644
+index 3c0f645..55ac6ba 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -103,8 +103,16 @@ $(libdir)/libpord$(PLAT)$(LIBEXT_SHARED):
- 	  cp $(LPORDDIR)/libpord$(LIBEXT_SHARED) $@; \
+@@ -59,6 +59,17 @@ $(libdir)/libpord$(PLAT)$(LIBEXT):
+ 	  cp $(LPORDDIR)/libpord$(LIBEXT) $@; \
  	fi;
  
--
--
 +install: d
 +	if ( test ! -d $(PREFIX)/lib ) ; then mkdir -p $(PREFIX)/lib ; fi
 +	if ( test ! -d $(PREFIX)/include ) ; then mkdir -p $(PREFIX)/include ; fi
@@ -69,6 +67,7 @@ index 59d74d7..4a2b467 100644
 +	done
 +	ginstall -m 644 -t $(PREFIX)/include include/*.h
 +	ginstall -m 644 -t $(PREFIX)/include/mumps_seq libseq/mpi.h
- 
++
  clean:
  	(cd src; $(MAKE) clean)
+ 	(cd examples; $(MAKE) clean)

--- a/tools/wheel/image/dependencies/projects.cmake
+++ b/tools/wheel/image/dependencies/projects.cmake
@@ -116,9 +116,12 @@ set(clp_dlname "clp-${clp_version}.tar.gz")
 list(APPEND ALL_PROJECTS clp)
 
 if(APPLE)
-    set(mumps_version 5.5.0)  # Current version in Homebrew.
-    set(mumps_url "http://mumps.enseeiht.fr/MUMPS_${mumps_version}.tar.gz")
-    set(mumps_md5 "08eb0887bfd1e570ce7faecbd8bf97c0")
+    set(mumps_version 5.4.1)  # Latest available in Ubuntu.
+    set(mumps_url
+         "http://archive.ubuntu.com/ubuntu/pool/universe/m/mumps/mumps_${mumps_version}.orig.tar.gz"
+        "http://mumps.enseeiht.fr/MUMPS_${mumps_version}.tar.gz"
+    )
+    set(mumps_md5 "93be789bf9c6c341a78c16038da3241b")
     set(mumps_dlname "mumps-${mumps_version}.tar.gz")
     list(APPEND ALL_PROJECTS mumps)
 endif()


### PR DESCRIPTION
MUMPS has recently become unreliable as far as providing tarballs. In order to be less dependent on upstream, switch to using Ubuntu's source mirror as the preferred source for the tarball.

Note that, because Ubuntu only ships a limited set of versions, this requires downgrading to 5.4.1, which as far as I can tell has never been shipped by Homebrew. Thus, in this respect, the macOS wheels will be more similar to the Ubuntu wheels than the macOS non-wheels.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17646)
<!-- Reviewable:end -->
