### PR TITLE
[sap] Enable kinematic AutoDiffXd simulation with SAP

### DIFF
--- a/multibody/contact_solvers/sap/BUILD.bazel
+++ b/multibody/contact_solvers/sap/BUILD.bazel
@@ -227,6 +227,16 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "sap_solver_autodiff_test",
+    deps = [
+        ":sap_friction_cone_constraint",
+        ":sap_solver",
+        ":sap_solver_results",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
     name = "sap_solver_test",
     deps = [
         ":sap_friction_cone_constraint",

--- a/multibody/contact_solvers/sap/sap_solver.cc
+++ b/multibody/contact_solvers/sap/sap_solver.cc
@@ -83,11 +83,20 @@ void SapSolver<T>::CalcStoppingCriteriaResidual(const Context<T>& context,
 }
 
 template <typename T>
-SapSolverStatus SapSolver<T>::SolveWithGuess(const SapContactProblem<T>&,
-                                             const VectorX<T>&,
-                                             SapSolverResults<T>*) {
+SapSolverStatus SapSolver<T>::SolveWithGuess(
+    const SapContactProblem<T>& problem, const VectorX<T>&,
+    SapSolverResults<T>* results) {
+  if (problem.num_constraints() == 0) {
+    // In the absence of constraints the solution is trivially v = v*.
+    results->Resize(problem.num_velocities(),
+                    problem.num_constraint_equations());
+    results->v = problem.v_star();
+    results->j.setZero();
+    return SapSolverStatus::kSuccess;
+  }
   throw std::logic_error(
-      "SapSolver::SolveWithGuess(): Only T = double is supported.");
+      "SapSolver::SolveWithGuess(): Only T = double is supported when the set "
+      "of constraints is non-empty.");
 }
 
 template <>

--- a/multibody/contact_solvers/sap/sap_solver.h
+++ b/multibody/contact_solvers/sap/sap_solver.h
@@ -241,7 +241,8 @@ class SapSolver {
   SapSolver() = default;
 
   // Solve the contact problem specified by the input data. Currently, only `T =
-  // double` is supported. An exception is thrown if `T != double`.
+  // double` is fully supported. An exception is thrown if `T != double` and the
+  // set of constraints is non-empty.
   //
   // Convergence of the solver is controlled by set_parameters(). Refer to
   // SapSolverParameters for details on the convergence conditions.

--- a/multibody/contact_solvers/sap/test/sap_solver_autodiff_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_solver_autodiff_test.cc
@@ -1,0 +1,63 @@
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/contact_solvers/sap/sap_friction_cone_constraint.h"
+#include "drake/multibody/contact_solvers/sap/sap_solver.h"
+#include "drake/multibody/contact_solvers/sap/sap_solver_results.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+// Tests that SolveWithGuess returns the free motion velocities and zero
+// impulses if the constraints are empty and throws otherwise.
+GTEST_TEST(SapAutoDiffTest, SolveWithGuess) {
+  constexpr double kTimeStep = 0.001;
+  constexpr int kNumDofs = 5;
+  constexpr int kNumCliques = 1;
+  std::vector<MatrixX<AutoDiffXd>> A(kNumCliques);
+  A[0] = MatrixX<AutoDiffXd>::Identity(kNumDofs, kNumDofs);
+  VectorX<AutoDiffXd> v_star =
+      VectorX<AutoDiffXd>::LinSpaced(kNumDofs, 0.0, 1.0);
+  SapSolver<AutoDiffXd> sap;
+
+  // The case without constraints.
+  SapContactProblem<AutoDiffXd> contact_problem_without_constraint(
+      kTimeStep, std::move(A), v_star);
+  // Use NaN as the guess as it shouldn't be used at all in the early exit where
+  // there's no constraint.
+  const VectorX<AutoDiffXd> v_guess =
+      VectorX<AutoDiffXd>::Constant(kNumDofs, NAN);
+  SapSolverResults<AutoDiffXd> result;
+  const SapSolverStatus status =
+      sap.SolveWithGuess(contact_problem_without_constraint, v_guess, &result);
+  EXPECT_EQ(status, SapSolverStatus::kSuccess);
+  EXPECT_EQ(result.v, v_star);
+  EXPECT_EQ(result.j, VectorX<AutoDiffXd>::Zero(kNumDofs));
+
+  // The case with constraints.
+  constexpr int kCliqueIndex = 0;
+  constexpr int kNumConstraintEquations = 3;
+  // Dummy parameter to create an arbitrary constraint.
+  constexpr double kPhi0 = 0.1;
+  SapFrictionConeConstraint<AutoDiffXd>::Parameters parameters;
+  parameters.stiffness = 1.0;
+  MatrixX<AutoDiffXd> J =
+      MatrixX<AutoDiffXd>::Ones(kNumConstraintEquations, kNumDofs);
+  SapContactProblem<AutoDiffXd> contact_problem_with_constraint(
+      std::move(contact_problem_without_constraint));
+  contact_problem_with_constraint.AddConstraint(
+      std::make_unique<SapFrictionConeConstraint<AutoDiffXd>>(
+          kCliqueIndex, std::move(J), kPhi0, parameters));
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      sap.SolveWithGuess(contact_problem_with_constraint, v_guess, &result),
+      ".*Only.*double is supported.*");
+}
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -347,6 +347,16 @@ drake_cc_library(
 )
 
 drake_cc_googletest(
+    name = "compliant_contact_manager_scalar_conversion_test",
+    deps = [
+        ":plant",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+        "//systems/analysis:simulator",
+    ],
+)
+
+drake_cc_googletest(
     name = "compliant_contact_manager_test",
     data = [
         "//manipulation/models/iiwa_description:models",

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -928,6 +928,28 @@ void CompliantContactManager<T>::DoCalcDiscreteValues(
   updates->set_value(this->multibody_state_index(), x_next);
 }
 
+// TODO(xuchenhan-tri): Consider a scalar converting constructor to cut down
+// repeated code in CloneToDouble() and CloneToAutoDiffXd().
+template <typename T>
+std::unique_ptr<DiscreteUpdateManager<double>>
+CompliantContactManager<T>::CloneToDouble() const {
+  auto clone = std::make_unique<CompliantContactManager<double>>();
+  // N.B. we should copy all members except for those overwritten in
+  // ExtractModelInfo and DeclareCacheEntries.
+  clone->sap_parameters_ = this->sap_parameters_;
+  return clone;
+}
+
+template <typename T>
+std::unique_ptr<DiscreteUpdateManager<AutoDiffXd>>
+CompliantContactManager<T>::CloneToAutoDiffXd() const {
+  auto clone = std::make_unique<CompliantContactManager<AutoDiffXd>>();
+  // N.B. we should copy all members except for those overwritten in
+  // ExtractModelInfo and DeclareCacheEntries.
+  clone->sap_parameters_ = this->sap_parameters_;
+  return clone;
+}
+
 template <typename T>
 void CompliantContactManager<T>::ExtractModelInfo() {
   // Collect joint damping coefficients into a vector.

--- a/multibody/plant/compliant_contact_manager.h
+++ b/multibody/plant/compliant_contact_manager.h
@@ -143,6 +143,9 @@ class CompliantContactManager final
     sap_parameters_ = parameters;
   }
 
+  bool is_cloneable_to_double() const final { return true; }
+  bool is_cloneable_to_autodiff() const final { return true; }
+
  private:
   // Struct used to conglomerate the indexes of cache entries declared by the
   // manager.
@@ -152,12 +155,22 @@ class CompliantContactManager final
     systems::CacheIndex non_contact_forces_accelerations;
   };
 
+  // Allow different specializations to access each other's private data for
+  // scalar conversion.
+  template <typename U>
+  friend class CompliantContactManager;
+
   // Provide private access for unit testing only.
   friend class CompliantContactManagerTest;
 
   const MultibodyTreeTopology& tree_topology() const {
     return internal::GetInternalTree(this->plant()).get_topology();
   }
+
+  std::unique_ptr<DiscreteUpdateManager<double>> CloneToDouble()
+      const final;
+  std::unique_ptr<DiscreteUpdateManager<AutoDiffXd>> CloneToAutoDiffXd()
+      const final;
 
   // Extracts non state dependent model information from MultibodyPlant. See
   // DiscreteUpdateManager for details.

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -102,6 +102,12 @@ enum class ContactModel {
 
 /// The type of the contact solver used for a discrete MultibodyPlant model.
 ///
+/// Note: the SAP solver only fully supports scalar type `double`. For
+/// scalar type `AutoDiffXd`, the SAP solver throws if any constraint (including
+/// contact) is detected. As a consequence, one can only run dynamic simulations
+/// without any constraints under the combination of SAP and `AutoDiffXd`. The
+/// SAP solver does not support symbolic calculations.
+///
 /// <h2>References</h2>
 ///
 /// - [Castro et al., 2019] Castro, A.M, Qu, A., Kuppuswamy, N., Alspach, A.,

--- a/multibody/plant/test/compliant_contact_manager_scalar_conversion_test.cc
+++ b/multibody/plant/test/compliant_contact_manager_scalar_conversion_test.cc
@@ -1,0 +1,102 @@
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/plant/compliant_contact_manager.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/analysis/simulator.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+using drake::systems::Context;
+using drake::systems::Simulator;
+using Eigen::VectorXd;
+
+template <typename T>
+class CompliantContactManagerScalarConversionTest : public ::testing::Test {};
+
+using NonSymbolicScalars = ::testing::Types<double, AutoDiffXd>;
+
+TYPED_TEST_SUITE(CompliantContactManagerScalarConversionTest,
+                 NonSymbolicScalars);
+
+TYPED_TEST(CompliantContactManagerScalarConversionTest, ToDouble) {
+  using T = TypeParam;
+  CompliantContactManager<T> source;
+  EXPECT_TRUE(source.is_cloneable_to_double());
+  std::unique_ptr<DiscreteUpdateManager<double>> clone =
+      source.template CloneToScalar<double>();
+  ASSERT_NE(clone, nullptr);
+}
+
+TYPED_TEST(CompliantContactManagerScalarConversionTest, ToAutoDiffXd) {
+  using T = TypeParam;
+  CompliantContactManager<T> source;
+  EXPECT_TRUE(source.is_cloneable_to_autodiff());
+  std::unique_ptr<DiscreteUpdateManager<AutoDiffXd>> clone =
+      source.template CloneToScalar<AutoDiffXd>();
+  ASSERT_NE(clone, nullptr);
+}
+
+TYPED_TEST(CompliantContactManagerScalarConversionTest, ToSymbolic) {
+  using T = TypeParam;
+  CompliantContactManager<T> source;
+  EXPECT_FALSE(source.is_cloneable_to_symbolic());
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      source.template CloneToScalar<symbolic::Expression>(),
+      ".*symbolic.*not supported.*");
+}
+
+constexpr double kTimeStep = 0.001;
+
+// Constructs a plant with a free rigid body and uses the SAP solver.
+template <typename T>
+std::unique_ptr<MultibodyPlant<T>> MakePlant() {
+  auto plant = std::make_unique<MultibodyPlant<T>>(kTimeStep);
+  plant->AddRigidBody("Body", SpatialInertia<double>::MakeUnitary());
+  plant->set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant->Finalize();
+  return plant;
+}
+
+// Tests that a plant with compliant contact manager survives scalar
+// conversion from T to U, and that simulations results for models without
+// constraints stay the same.
+template <typename T, typename U>
+void TestPlantConversion() {
+  std::unique_ptr<MultibodyPlant<T>> source_plant = MakePlant<T>();
+  auto source_context = source_plant->CreateDefaultContext();
+  const VectorX<T> initial_state =
+      source_plant->GetPositionsAndVelocities(*source_context);
+  auto source_simulator =
+      std::make_unique<Simulator<T>>(*source_plant, std::move(source_context));
+  source_simulator->AdvanceTo(10 * kTimeStep);
+  const VectorX<T> source_final_state =
+      source_plant->GetPositionsAndVelocities(source_simulator->get_context());
+  // Verify something interesting happened in the sim.
+  EXPECT_FALSE(CompareMatrices(initial_state, source_final_state, 0.001));
+
+  // Scalar convert to U.
+  auto dest_plant = systems::System<T>::template ToScalarType<U>(*source_plant);
+  auto dest_context = dest_plant->CreateDefaultContext();
+  auto dest_simulator =
+      std::make_unique<Simulator<U>>(*dest_plant, std::move(dest_context));
+  dest_simulator->AdvanceTo(10 * kTimeStep);
+  const VectorX<U> dest_final_state =
+      dest_plant->GetPositionsAndVelocities(dest_simulator->get_context());
+  // Verify that the U results agree with T results.
+  EXPECT_TRUE(CompareMatrices(dest_final_state, source_final_state));
+}
+
+// We only tests the conversion between double and AutoDiffXd because
+// CompliantContactManager doesn't support symbolic.
+GTEST_TEST(CompliantContactManagerScalarConversionTest, PlantConversion) {
+  TestPlantConversion<double, AutoDiffXd>();
+  TestPlantConversion<AutoDiffXd, double>();
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
- Allow CompliantContactManager to scalar convert to double and AutoDiffXd.
- SapSolver supports AutoDiffXd for solving trivial contact problems (zero constraints).

With these two items, we enable kinematic simulation with SAP + AutoDiffXd.

Closes #17647

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17651)
<!-- Reviewable:end -->
