### PR TITLE
Reverse ApplySimulatorConfig parameter order

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -107,6 +107,7 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/common:cpp_template_pybind",
         "//bindings/pydrake/common:default_scalars_pybind",
+        "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:serialize_pybind",
         "//bindings/pydrake/common:wrap_pybind",
     ],

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -2,6 +2,7 @@
 
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
@@ -203,12 +204,24 @@ PYBIND11_MODULE(analysis, m) {
             doc.Simulator.get_system.doc);
 
     m  // BR
-        .def("ApplySimulatorConfig", &ApplySimulatorConfig<T>,
-            py::arg("simulator"), py::arg("config"),
-            pydrake_doc.drake.systems.ApplySimulatorConfig.doc)
+        .def("ApplySimulatorConfig",
+            py::overload_cast<const SimulatorConfig&,
+                drake::systems::Simulator<T>*>(&ApplySimulatorConfig<T>),
+            py::arg("config"), py::arg("simulator"),
+            pydrake_doc.drake.systems.ApplySimulatorConfig.doc_config_sim)
         .def("ExtractSimulatorConfig", &ExtractSimulatorConfig<T>,
             py::arg("simulator"),
             pydrake_doc.drake.systems.ExtractSimulatorConfig.doc);
+    m  // BR
+        .def("ApplySimulatorConfig",
+            WrapDeprecated(
+                pydrake_doc.drake.systems.ApplySimulatorConfig.doc_deprecated,
+                [](drake::systems::Simulator<T>* simulator,
+                    const SimulatorConfig& config) {
+                  ApplySimulatorConfig(config, simulator);
+                }),
+            py::arg("simulator"), py::arg("config"),
+            pydrake_doc.drake.systems.ApplySimulatorConfig.doc_deprecated);
   };
   type_visit(bind_nonsymbolic_scalar_types, NonSymbolicScalarPack{});
 

--- a/bindings/pydrake/systems/test/analysis_test.py
+++ b/bindings/pydrake/systems/test/analysis_test.py
@@ -2,6 +2,7 @@ import copy
 import unittest
 
 from pydrake.common.test_utilities import numpy_compare
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.symbolic import Variable, Expression
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.systems.primitives import (
@@ -130,7 +131,18 @@ class TestAnalysis(unittest.TestCase):
             simulator = Simulator_[T](source)
             config = ExtractSimulatorConfig(simulator)
             config.target_realtime_rate = 100.0
-            ApplySimulatorConfig(simulator, config)
+            ApplySimulatorConfig(config=config, simulator=simulator)
+            self.assertEqual(simulator.get_target_realtime_rate(), 100.0)
+
+    # TODO(2022-11-01) Delete this entire test
+    def test_simulator_config_functions_deprecated(self):
+        for T in (float, AutoDiffXd):
+            source = ConstantVectorSource_[T]([2, 3])
+            simulator = Simulator_[T](source)
+            config = ExtractSimulatorConfig(simulator)
+            config.target_realtime_rate = 100.0
+            with catch_drake_warnings(expected_count=1):
+                ApplySimulatorConfig(simulator, config)
             self.assertEqual(simulator.get_target_realtime_rate(), 100.0)
 
     def test_system_monitor(self):

--- a/examples/hardware_sim/hardware_sim.cc
+++ b/examples/hardware_sim/hardware_sim.cc
@@ -90,7 +90,7 @@ void Simulation::Setup() {
   // Build the diagram and its simulator.
   diagram_ = builder.Build();
   simulator_ = std::make_unique<Simulator<double>>(*diagram_);
-  ApplySimulatorConfig(simulator_.get(), scenario_.simulator_config);
+  ApplySimulatorConfig(scenario_.simulator_config, simulator_.get());
 
   // Sample the random elements of the context.
   RandomGenerator random(scenario_.random_seed);

--- a/examples/hydroelastic/python_ball_paddle/contact_sim_demo.py
+++ b/examples/hydroelastic/python_ball_paddle/contact_sim_demo.py
@@ -83,7 +83,7 @@ def simulate_diagram(diagram, ball_paddle_plant, state_logger,
                            target_realtime_rate=target_realtime_rate,
                            publish_every_time_step=True)
     simulator = Simulator(diagram)
-    ApplySimulatorConfig(simulator, simulator_config)
+    ApplySimulatorConfig(simulator_config, simulator)
 
     plant_context = diagram.GetSubsystemContext(ball_paddle_plant,
                                                 simulator.get_context())

--- a/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
+++ b/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
@@ -206,7 +206,7 @@ int DoMain() {
   sim_config.publish_every_time_step = false;
 
   systems::Simulator<double> simulator(*diagram);
-  ApplySimulatorConfig(&simulator, sim_config);
+  ApplySimulatorConfig(sim_config, &simulator);
 
   // Set the initial conditions for the spatula pose and the gripper finger
   // positions.

--- a/systems/analysis/simulator_config_functions.cc
+++ b/systems/analysis/simulator_config_functions.cc
@@ -180,6 +180,13 @@ template <typename T>
 void ApplySimulatorConfig(
     Simulator<T>* simulator,
     const SimulatorConfig& config) {
+  ApplySimulatorConfig(config, simulator);
+}
+
+template <typename T>
+void ApplySimulatorConfig(
+    const SimulatorConfig& config,
+    Simulator<T>* simulator) {
   DRAKE_THROW_UNLESS(simulator != nullptr);
   IntegratorBase<T>& integrator = ResetIntegratorFromFlags(
       simulator, config.integration_scheme, T(config.max_step_size));
@@ -219,10 +226,20 @@ SimulatorConfig ExtractSimulatorConfig(const Simulator<T>& simulator) {
   return result;
 }
 
+// TODO(2022-11-01) When the old ApplySimulatorConfig<T> has been deprecated,
+// remove these by-hand instantiationsand the ApplyFunc static_cast helper.
+template void ApplySimulatorConfig<double>(Simulator<double>*,
+                                           const SimulatorConfig&);
+template void ApplySimulatorConfig<AutoDiffXd>(Simulator<AutoDiffXd>*,
+                                               const SimulatorConfig&);
+
+template <typename T>
+using ApplyFunc = void (*)(const SimulatorConfig&, Simulator<T>*);
+
 // We can't support T=symbolic::Expression because Simulator doesn't support it.
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
       &ResetIntegratorFromFlags<T>,
-      &ApplySimulatorConfig<T>,
+      static_cast<ApplyFunc<T>>(&ApplySimulatorConfig<T>),
       &ExtractSimulatorConfig<T>
 ))
 }  // namespace systems

--- a/systems/analysis/simulator_config_functions.h
+++ b/systems/analysis/simulator_config_functions.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "drake/common/default_scalars.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/systems/analysis/integrator_base.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/analysis/simulator_config.h"
@@ -43,17 +44,36 @@ ResetIntegratorFromFlags() and SimulatorConfig::integration_scheme.
 @ingroup simulator_configuration */
 const std::vector<std::string>& GetIntegrationSchemes();
 
-/** Modifies the `simulator` to use the given config.  (Always replaces the
+/** Modifies the `simulator` based on the given `config`.  (Always replaces the
 Integrator with a new one; be careful not to keep old references around.)
 
+@param[in] config Configuration to be used. Contains values for both the
+  integrator and the simulator.
 @param[in,out] simulator On input, a valid pointer to a Simulator. On output
-  the integretor for `simulator` is reset according to the given `config`.
+  the integrator for `simulator` is reset according to the given `config`.
+@tparam_nonsymbolic_scalar
+
+@ingroup simulator_configuration
+@pydrake_mkdoc_identifier{config_sim} */
+template <typename T>
+void ApplySimulatorConfig(const SimulatorConfig& config,
+                          drake::systems::Simulator<T>* simulator);
+
+/** (Deprecated.) Modifies the `simulator` to use the given config.  (Always
+ replaces the Integrator with a new one; be careful not to keep old references
+ around.)
+
+@param[in,out] simulator On input, a valid pointer to a Simulator. On output
+  the integrator for `simulator` is reset according to the given `config`.
 @param[in] config Configuration to be used. Contains values for both the
   integrator and the simulator.
 @tparam_nonsymbolic_scalar
 
-@ingroup simulator_configuration */
+@ingroup simulator_configuration
+@pydrake_mkdoc_identifier{deprecated} */
 template <typename T>
+DRAKE_DEPRECATED("2022-11-01",
+                 "Call ApplySimulatorConfig with the config parameter first.")
 void ApplySimulatorConfig(
     drake::systems::Simulator<T>* simulator,
     const SimulatorConfig& config);

--- a/systems/analysis/simulator_gflags.cc
+++ b/systems/analysis/simulator_gflags.cc
@@ -101,7 +101,7 @@ std::unique_ptr<Simulator<T>> MakeSimulatorFromGflags(
     FLAGS_simulator_target_realtime_rate,
     FLAGS_simulator_publish_every_time_step
   };
-  ApplySimulatorConfig(simulator.get(), config);
+  ApplySimulatorConfig(config, simulator.get());
 
   return simulator;
 }

--- a/systems/analysis/test/simulator_config_functions_test.cc
+++ b/systems/analysis/test/simulator_config_functions_test.cc
@@ -99,7 +99,41 @@ TYPED_TEST(SimulatorConfigFunctionsTest, RoundTripTest) {
   // corrupt data.
   const DummySystem<T> dummy;
   Simulator<T> simulator(dummy);
+  ApplySimulatorConfig(bespoke, &simulator);
+  const SimulatorConfig readback = ExtractSimulatorConfig(simulator);
+  EXPECT_EQ(readback.integration_scheme, bespoke.integration_scheme);
+  EXPECT_EQ(readback.max_step_size, bespoke.max_step_size);
+  EXPECT_EQ(readback.accuracy, bespoke.accuracy);
+  EXPECT_EQ(readback.use_error_control, bespoke.use_error_control);
+  EXPECT_EQ(readback.target_realtime_rate, bespoke.target_realtime_rate);
+  EXPECT_EQ(readback.publish_every_time_step, bespoke.publish_every_time_step);
+}
+
+// TODO(2022-11-01) Delete the full test.
+TYPED_TEST(SimulatorConfigFunctionsTest, RoundTripTestDeprecated) {
+  using T = TypeParam;
+  const std::string bespoke_str = "integration_scheme: runge_kutta5\n"
+                                  "max_step_size: 0.003\n"
+                                  "accuracy: 0.03\n"
+                                  "use_error_control: true\n"
+                                  "target_realtime_rate: 3.0\n"
+                                  "publish_every_time_step: true\n";
+
+  // Ensure that the string and the struct have the same fields.
+  const auto bespoke = LoadYamlString<SimulatorConfig>(bespoke_str);
+
+  // Ensure that a round trip through the archive process does not corrupt data.
+  const std::string readback_str = SaveYamlString(bespoke);
+  EXPECT_EQ(bespoke_str, readback_str);
+
+  // Ensure that a roundtrip through the Accept and Extract functions does not
+  // corrupt data.
+  const DummySystem<T> dummy;
+  Simulator<T> simulator(dummy);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   ApplySimulatorConfig(&simulator, bespoke);
+#pragma GCC diagnostic pop
   const SimulatorConfig readback = ExtractSimulatorConfig(simulator);
   EXPECT_EQ(readback.integration_scheme, bespoke.integration_scheme);
   EXPECT_EQ(readback.max_step_size, bespoke.max_step_size);


### PR DESCRIPTION
As more and more `Apply***Config()` functions come into play, they all have a signature that takes the config struct as the first parameter. This brings the simulator configuration in line with the other components.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17654)
<!-- Reviewable:end -->
