### PR TITLE
[ad] Add unit test for -0.0 unary negation signbit

### DIFF
--- a/common/ad/test/standard_operations_sub_test.cc
+++ b/common/ad/test/standard_operations_sub_test.cc
@@ -27,6 +27,17 @@ TEST_F(StandardOperationsTest, UnaryNegation) {
   CHECK_UNARY_FUNCTION(unary_negate, y, x, -1.0);
 }
 
+TEST_F(StandardOperationsTest, UnaryNegationZero) {
+  const Eigen::Vector3d derivatives = Eigen::Vector3d::LinSpaced(1.0, 3.0);
+  const AutoDiffDut positive_zero{+0.0, derivatives};
+  EXPECT_FALSE(std::signbit(positive_zero.value()));
+
+  const AutoDiffDut negative_zero = -positive_zero;
+  EXPECT_EQ(negative_zero.value(), 0);
+  EXPECT_TRUE(std::signbit(negative_zero.value()));
+  EXPECT_EQ(negative_zero.derivatives(), -derivatives);
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace drake


### PR DESCRIPTION
Amends #17622. Towards #17492.

It would be easy to make a mistake in the implementation that lost the sign of zero; this test guards against that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17658)
<!-- Reviewable:end -->
