### PR TITLE
[examples] Remove MOSEK requirement for region_of_attraction demo

### DIFF
--- a/examples/cubic_polynomial/BUILD.bazel
+++ b/examples/cubic_polynomial/BUILD.bazel
@@ -8,8 +8,8 @@ drake_cc_binary(
     name = "region_of_attraction",
     srcs = ["region_of_attraction.cc"],
     add_test_rule = 1,
-    test_rule_tags = mosek_test_tags(),
     deps = [
+        "//common:add_text_logging_gflags",
         "//solvers:mathematical_program",
         "//solvers:solve",
         "//systems/framework:vector_system",

--- a/examples/cubic_polynomial/region_of_attraction.cc
+++ b/examples/cubic_polynomial/region_of_attraction.cc
@@ -10,6 +10,8 @@
 #include <cmath>
 #include <iostream>
 
+#include <gflags/gflags.h>
+
 #include "drake/common/symbolic/polynomial.h"
 #include "drake/common/unused.h"
 #include "drake/solvers/mathematical_program.h"
@@ -91,7 +93,9 @@ void ComputeRegionOfAttraction() {
 }
 }  // namespace drake
 
-int main() {
+int main(int argc, char* argv[]) {
+  // Process the add_text_logging_gflags from our BUILD file.
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
   drake::ComputeRegionOfAttraction();
   return 0;
 }


### PR DESCRIPTION
Add gflags support (to help see which solver is being used).

Amends #6715.
 
```
$ bazel-bin/examples/cubic_polynomial/region_of_attraction --spdlog_level=debug
[2022-08-01 14:04:22.325] [console] [debug] solvers::Solve will use CSDP
[2022-08-01 14:04:22.325] [console] [warning] The problem has free variables, and CSDP removes the free variables by computing the null space of linear constraint in the dual space. This step can be time consuming. Consider providing a lower and/or upper bound for each decision variable.
Verified that pow(x(0), 2) < 1 is in the region of attraction.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17666)
<!-- Reviewable:end -->
