### PR TITLE
[workspace] Disable mosek tests on arm64 macOS

### DIFF
--- a/tools/macos-arch-arm64.bazelrc
+++ b/tools/macos-arch-arm64.bazelrc
@@ -10,3 +10,4 @@ build --define NO_DREAL=ON
 
 # TODO(#17026) Mosek 10 is required for arm64.
 build:everything --define WITH_MOSEK=OFF
+build:everything --test_tag_filters=-mosek,-no_everything


### PR DESCRIPTION
Followup to https://github.com/RobotLocomotion/drake/pull/17269, this disables the associated (failing) tests.

- [ ] Add note to #17026 to revert this commit with MOSEK 10.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17667)
<!-- Reviewable:end -->
