### PR TITLE
 [geometry] Fix copy semantics of MeshFieldLinear

### DIFF
--- a/geometry/proximity/mesh_field_linear.h
+++ b/geometry/proximity/mesh_field_linear.h
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/reset_on_copy.h"
@@ -113,7 +112,14 @@ namespace geometry {
 template <class T, class MeshType>
 class MeshFieldLinear {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MeshFieldLinear)
+  /** @name Implements MoveConstructible, MoveAssignable
+
+   To copy a %MeshFieldLinear, use CloneAndSetMesh().
+  */
+  //@{
+  MeshFieldLinear(MeshFieldLinear&&) = default;
+  MeshFieldLinear& operator=(MeshFieldLinear&&) = default;
+  //@}
 
   /** Constructs a MeshFieldLinear.
    @param values  The field value at each vertex of the mesh.
@@ -348,10 +354,15 @@ class MeshFieldLinear {
   }
 
  private:
+  MeshFieldLinear(const MeshFieldLinear&) = default;
+  MeshFieldLinear& operator=(const MeshFieldLinear&) = default;
+
   // Clones MeshFieldLinear data under the assumption that the mesh
   // pointer is null.
   [[nodiscard]] std::unique_ptr<MeshFieldLinear<T, MeshType>>
-  CloneWithNullMesh() const { return std::make_unique<MeshFieldLinear>(*this); }
+  CloneWithNullMesh() const {
+    return std::unique_ptr<MeshFieldLinear>(new MeshFieldLinear(*this));
+  }
 
   void CalcGradientField() {
     gradients_.clear();

--- a/geometry/proximity/test/field_intersection_test.cc
+++ b/geometry/proximity/test/field_intersection_test.cc
@@ -170,7 +170,9 @@ TEST_F(FieldIntersectionLowLevelTest, CalcEquilibriumPlaneNone) {
   // that are nowhere equal.
   {
     const RigidTransformd X_ML(Vector3d(0.4, 0.3, 0.5));
-    VolumeMeshFieldLinear<double, double> field2_L(field0_M_);
+    std::unique_ptr<VolumeMeshFieldLinear<double, double>> field2_L_ptr =
+        field0_M_.CloneAndSetMesh(&field0_M_.mesh());
+    const VolumeMeshFieldLinear<double, double>& field2_L = *field2_L_ptr;
 
     // An arbitrary initial value of the plane.
     const Plane<double> init_plane_M{Vector3d::UnitX(), Vector3d(1, 2, 3)};

--- a/geometry/proximity/test/mesh_field_linear_test.cc
+++ b/geometry/proximity/test/mesh_field_linear_test.cc
@@ -151,14 +151,15 @@ GTEST_TEST(MeshFieldLinearTest, TestTransform) {
   // Create mesh and field. Both mesh vertices and field gradient are expressed
   // in frame M.
   auto mesh_M = GenerateMesh<double>();
-  std::vector<double> e_values = {0., 1., 2., 3.};
+  const std::vector<double> e_values = {0., 1., 2., 3.};
   MeshFieldLinear<double, TriangleSurfaceMesh<double>> mesh_field_M(
-      std::move(e_values), mesh_M.get(), true /* calc_gradients */);
+      std::vector<double>(e_values), mesh_M.get(), true /* calc_gradients */);
 
   RigidTransformd X_NM(RollPitchYawd(M_PI_2, M_PI_4, M_PI / 6.),
                        Vector3d(1.2, 1.3, -4.3));
   MeshFieldLinear<double, TriangleSurfaceMesh<double>> mesh_field_N(
-      mesh_field_M);
+      std::vector<double>(e_values), mesh_M.get(), true /* calc_gradients */);
+
   // NOTE: re-expressing the field like this (and subsequent calls to
   // EvaluateCartesian()) don't actually require the field's captured mesh to
   // have properly transformed vertex positions. That is not generally true and


### PR DESCRIPTION
Make copy constructors of MeshFieldLinear private.
Use CloneAndSetMesh() instead of the copy constructors.

Fixes #17638

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17670)
<!-- Reviewable:end -->
