### PR TITLE
call_python: Allow defining functions with closures

### DIFF
--- a/common/proto/call_python_client.py
+++ b/common/proto/call_python_client.py
@@ -415,7 +415,12 @@ class CallPythonClient:
         if function_name == "exec":
             assert len(inputs) == 1
             assert kwargs is None or len(kwargs) == 0
-            exec(inputs[0], self.scope_globals, self.scope_locals)
+            # Merge globals and locals so that any functions or lambdas can
+            # have closures that refer to locals. For more information, see
+            # https://stackoverflow.com/a/28951271/7829525
+            globals_and_locals = _merge_dicts(
+                self.scope_globals, self.scope_locals)
+            exec(inputs[0], globals_and_locals, self.scope_locals)
             out = None
         else:
             out = eval(function_name + "(*_tmp_args, **_tmp_kwargs)",

--- a/common/proto/test/call_python_server_test.cc
+++ b/common/proto/test/call_python_server_test.cc
@@ -121,6 +121,15 @@ GTEST_TEST(TestCallPython, RemoteVarTest) {
   CallPython("setvar", "b1", 10);
   CallPython("exec", "b1 += 20");
   CallPython("exec", "assert b1 == 30");
+
+  // Test defining function with closure.
+  CallPython("exec", "def my_func(x): return x + b1");
+  CallPython("exec", "my_func(10) == 40");
+  // - with mutation (closure of mutable object by reference).
+  CallPython("exec", "items = []");
+  CallPython("exec", "def add_item(x): items.append(x)");
+  CallPython("exec", "add_item(1); add_item(2)");
+  CallPython("exec", "assert items == [1, 2]");
 }
 
 GTEST_TEST(TestCallPython, Plot2d) {


### PR DESCRIPTION
Ran into this when using `CallPython` in Anzu (for debugging robot stuff)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17672)
<!-- Reviewable:end -->
