### PR TITLE
[plant] Factor MakeDiscreteUpdateManager out into a separate header

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -98,12 +98,14 @@ drake_cc_library(
     srcs = [
         "compliant_contact_manager.cc",
         "discrete_update_manager.cc",
+        "make_discrete_update_manager.cc",
         "multibody_plant.cc",
         "physical_model.cc",
     ],
     hdrs = [
         "compliant_contact_manager.h",
         "discrete_update_manager.h",
+        "make_discrete_update_manager.h",
         "multibody_plant.h",
         "multibody_plant_discrete_update_manager_attorney.h",
         "multibody_plant_model_attorney.h",
@@ -862,6 +864,15 @@ drake_cc_googletest(
         ":multibody_plant_config_functions",
         "//common/test_utilities:expect_throws_message",
         "//common/yaml",
+    ],
+)
+
+drake_cc_googletest(
+    name = "make_discrete_update_manager_test",
+    deps = [
+        ":multibody_plant_core",
+        "//common/test_utilities:expect_throws_message",
+        "//common/test_utilities:is_dynamic_castable",
     ],
 )
 

--- a/multibody/plant/make_discrete_update_manager.cc
+++ b/multibody/plant/make_discrete_update_manager.cc
@@ -1,0 +1,32 @@
+#include "drake/multibody/plant/make_discrete_update_manager.h"
+
+#include "drake/multibody/plant/compliant_contact_manager.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+template <typename T>
+std::unique_ptr<DiscreteUpdateManager<T>> MakeDiscreteUpdateManager(
+    DiscreteContactSolver contact_solver) {
+  switch (contact_solver) {
+    case DiscreteContactSolver::kSap:
+      if constexpr (std::is_same_v<T, symbolic::Expression>) {
+        throw std::runtime_error(
+            "SAP solver is not supported for scalar type T = "
+            "symbolic::Expression.");
+      } else {
+        return std::make_unique<CompliantContactManager<T>>();
+      }
+    case DiscreteContactSolver::kTamsi:
+      return nullptr;
+  }
+  DRAKE_UNREACHABLE();
+}
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    (&MakeDiscreteUpdateManager<T>))
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/make_discrete_update_manager.h
+++ b/multibody/plant/make_discrete_update_manager.h
@@ -1,0 +1,37 @@
+#pragma once
+
+// @file
+// The purpose of this header and its corresponding cc file is to reduce the
+// cycle time for edit-compile-test as we develop new functionalities for
+// discrete updates. This header only depends on discrete_update_manager.h which
+// contains the (rarely modified) virtual base class, DiscreteUpdateManager,
+// whereas the cc file depends on concrete derived classes such as
+// CompliantContactManager that are currently under development. By including
+// this header (instead of directly including headers of concrete derived
+// classes) in multibody_plant.cc, we avoid recompiling MultibodyPlant every
+// time some concrete update manager changes. Instead, we only need to relink
+// them.
+
+#include <memory>
+
+#include "drake/common/default_scalars.h"
+#include "drake/multibody/plant/discrete_update_manager.h"
+#include "drake/multibody/plant/multibody_plant.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+/* Constructs and returns a suitable discrete update manager for a
+ MultibodyPlant given the type of contact solver. Returns `nullptr` if the
+ contact solver type is `kTamsi`.
+ @throws std::exception if invoked with incompatible contact solver and scalar
+ type.
+ @tparam_default_scalar */
+template <typename T>
+std::unique_ptr<DiscreteUpdateManager<T>> MakeDiscreteUpdateManager(
+    DiscreteContactSolver contact_solver);
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -22,10 +22,10 @@
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/contact_solvers/sparse_linear_operator.h"
 #include "drake/multibody/hydroelastics/hydroelastic_engine.h"
-#include "drake/multibody/plant/compliant_contact_manager.h"
 #include "drake/multibody/plant/discrete_contact_pair.h"
 #include "drake/multibody/plant/externally_applied_spatial_force.h"
 #include "drake/multibody/plant/hydroelastic_traction_calculator.h"
+#include "drake/multibody/plant/make_discrete_update_manager.h"
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/multibody/triangle_quadrature/gaussian_triangle_quadrature_rule.h"
@@ -830,17 +830,10 @@ void MultibodyPlant<T>::Finalize() {
   // is to move TAMSI, as well as the entirety of the discrete handling of
   // contact, into CompliantContactManager.
   if (is_discrete()) {
-    if constexpr (!std::is_same_v<T, symbolic::Expression>) {
-      if (contact_solver_enum_ == DiscreteContactSolver::kSap) {
-        SetDiscreteUpdateManager(
-            std::make_unique<internal::CompliantContactManager<T>>());
-      }
-    } else {
-      if (contact_solver_enum_ == DiscreteContactSolver::kSap) {
-        throw std::runtime_error(
-            "SAP solver not supported for scalar type T = "
-            "symbolic::Expression.");
-      }
+    std::unique_ptr<internal::DiscreteUpdateManager<T>> manager =
+        internal::MakeDiscreteUpdateManager<T>(contact_solver_enum_);
+    if (manager) {
+      SetDiscreteUpdateManager(std::move(manager));
     }
   }
 }

--- a/multibody/plant/test/make_discrete_update_manager_test.cc
+++ b/multibody/plant/test/make_discrete_update_manager_test.cc
@@ -1,0 +1,42 @@
+#include "drake/multibody/plant/make_discrete_update_manager.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/test_utilities/is_dynamic_castable.h"
+#include "drake/multibody/plant/compliant_contact_manager.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace {
+
+GTEST_TEST(MakeDiscreteUpdateManagerTest, Sap) {
+  std::unique_ptr<DiscreteUpdateManager<double>> double_manager =
+      MakeDiscreteUpdateManager<double>(DiscreteContactSolver::kSap);
+  EXPECT_TRUE(
+      is_dynamic_castable<CompliantContactManager<double>>(double_manager));
+
+  std::unique_ptr<DiscreteUpdateManager<AutoDiffXd>> autodiff_manager =
+      MakeDiscreteUpdateManager<AutoDiffXd>(DiscreteContactSolver::kSap);
+  EXPECT_TRUE(is_dynamic_castable<CompliantContactManager<AutoDiffXd>>(
+      autodiff_manager));
+
+  DRAKE_EXPECT_THROWS_MESSAGE(MakeDiscreteUpdateManager<symbolic::Expression>(
+                                  DiscreteContactSolver::kSap),
+                              "SAP.*not supported.*symbolic::Expression.");
+}
+
+GTEST_TEST(MakeDiscreteUpdateManagerTest, Tamsi) {
+  EXPECT_EQ(nullptr,
+            MakeDiscreteUpdateManager<double>(DiscreteContactSolver::kTamsi));
+  EXPECT_EQ(nullptr, MakeDiscreteUpdateManager<AutoDiffXd>(
+                         DiscreteContactSolver::kTamsi));
+  EXPECT_EQ(nullptr, MakeDiscreteUpdateManager<symbolic::Expression>(
+                         DiscreteContactSolver::kTamsi));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
As a result changes in CompliantContactManager and SAP related changes won't trigger recompiling MultibodyPlant all together.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17677)
<!-- Reviewable:end -->
