### PR TITLE
[visualization] Auto reconnect to meshcat server

### DIFF
--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -1388,41 +1388,9 @@ class Meshcat::Impl {
 
     // Replace the javascript code in the original html file which connects via
     // websockets with the static javascript commands.
-    // Note: If the html code changes, the DRAKE_DEMAND will fail, and the code
-    // string here will need to be updated to once again match the html.
-    const std::string html_connect = R"""(// When the connection closes, try creating a new connection automatically.
-    function make_connection(url, reconnect_ms) {
-      try {
-        connection = new WebSocket(url);
-        connection.binaryType = "arraybuffer";
-        connection.onmessage = (msg) => handle_message(msg);
-        connection.onopen = (evt) => {
-          if (!fresh_connection) location.reload(); };
-        connection.onclose = function(evt) {
-          fresh_connection = false;
-          // Immediately schedule an attempt to reconnect.
-          setTimeout(() => {make_connection(url, reconnect_ms);}, reconnect_ms);
-        }
-        viewer.connection = connection
-      } catch (e) {
-        console.info("Not connected to MeshCat websocket server: ", e);
-        setTimeout(() => {make_connection(url, reconnect_ms);}, reconnect_ms);
-      }
-    }
-
-    const queryString = window.location.search;
-    const urlParams = new URLSearchParams(queryString);
-    reconnect_ms = parseInt(urlParams.get('reconnect_ms')) || 1000;
-
-    url = location.toString();
-    url = url.replace("http://", "ws://")
-    url = url.replace("https://", "wss://")
-    url = url.replace("/index.html", "/")
-    url = url.replace("/meshcat.html", "/")
-    make_connection(url, reconnect_ms);)""";
-    const size_t pos = html.find(html_connect);
-    DRAKE_DEMAND(pos != std::string::npos);
-    html.replace(pos, html_connect.size(), std::move(f.get()));
+    std::regex block_re(
+        "<!-- CONNECTION BLOCK BEGIN [^]+ CONNECTION BLOCK END -->\n");
+    html = std::regex_replace(html, block_re, f.get());
 
     // Insert the javascript directly into the html.
     std::vector<std::pair<std::string, std::string>> js_paths{

--- a/geometry/meshcat.html
+++ b/geometry/meshcat.html
@@ -63,22 +63,35 @@
     // Set the initial view looking up the y-axis.
     viewer.set_property(['Cameras', 'default', 'rotated', '<object>'],
                         "position", [0.0, 1.0, 3.0])
-    try {
-      url = location.toString();
-      url = url.replace("http://", "ws://")
-      url = url.replace("https://", "wss://")
-      url = url.replace("/index.html", "/")
-      url = url.replace("/meshcat.html", "/")
-      connection = new WebSocket(url);
-      connection.binaryType = "arraybuffer";
-      connection.onmessage = (msg) => handle_message(msg);
-      connection.onclose = function(evt) {
-        console.log("onclose:", evt);
+
+    // When the connection closes, try creating a new connection automatically.
+    function make_connection(url, reconnect_ms) {
+      try {
+        connection = new WebSocket(url);
+        connection.binaryType = "arraybuffer";
+        connection.onmessage = (msg) => handle_message(msg);
+        connection.onclose = function(evt) {
+          // Immediately schedule an attempt to reconnect.
+          setTimeout(() => {make_connection(url, reconnect_ms);}, reconnect_ms);
+        }
+        viewer.connection = connection
+      } catch (e) {
+        console.info("Not connected to MeshCat websocket server: ", e);
+        setTimeout(() => {make_connection(url, reconnect_ms);}, reconnect_ms);
       }
-      viewer.connection = connection
-    } catch (e) {
-      console.info("Not connected to MeshCat websocket server: ", e);
     }
+
+    const queryString = window.location.search;
+    const urlParams = new URLSearchParams(queryString);
+    reconnect_ms = parseInt(urlParams.get('reconnect_ms')) || 1000;
+
+    url = location.toString();
+    url = url.replace("http://", "ws://")
+    url = url.replace("https://", "wss://")
+    url = url.replace("/index.html", "/")
+    url = url.replace("/meshcat.html", "/")
+    make_connection(url, reconnect_ms);
+
   </script>
 
   <style>

--- a/geometry/meshcat.html
+++ b/geometry/meshcat.html
@@ -64,13 +64,28 @@
     viewer.set_property(['Cameras', 'default', 'rotated', '<object>'],
                         "position", [0.0, 1.0, 3.0])
 
+    // The lifespan of the server may be much shorter than this visualizer
+    // client. We'd like the user to not have to explicitly reload when they
+    // start a new server. So, we automatically try to reconnect at some given
+    // rate. However, due to the split of visualizer state between server and
+    // client, simply reconnecting may leave the *existing* visualizer in a
+    // strange state with various stale artifacts. So, when we detect a
+    // *reconnection*, we simply reload the page, so that every *meaningful*
+    // connection is accompanied by a fresh client state. This
+    // `fresh_connection` variable allows us to distinguish between a server
+    // connection from a clean client state versus a reconnection after the
+    // original connection was lost.
+    var fresh_connection = true;
     // When the connection closes, try creating a new connection automatically.
     function make_connection(url, reconnect_ms) {
       try {
         connection = new WebSocket(url);
         connection.binaryType = "arraybuffer";
         connection.onmessage = (msg) => handle_message(msg);
+        connection.onopen = (evt) => {
+          if (!fresh_connection) location.reload(); };
         connection.onclose = function(evt) {
+          fresh_connection = false;
           // Immediately schedule an attempt to reconnect.
           setTimeout(() => {make_connection(url, reconnect_ms);}, reconnect_ms);
         }

--- a/geometry/meshcat.html
+++ b/geometry/meshcat.html
@@ -8,6 +8,9 @@
 </head>
 
 <body>
+  <div id="status-message">
+    No connection to server.
+  </div>
   <div id="meshcat-pane">
   </div>
 
@@ -64,6 +67,7 @@
     viewer.set_property(['Cameras', 'default', 'rotated', '<object>'],
                         "position", [0.0, 1.0, 3.0])
 
+    <!-- CONNECTION BLOCK BEGIN -->
     // The lifespan of the server may be much shorter than this visualizer
     // client. We'd like the user to not have to explicitly reload when they
     // start a new server. So, we automatically try to reconnect at some given
@@ -71,11 +75,11 @@
     // client, simply reconnecting may leave the *existing* visualizer in a
     // strange state with various stale artifacts. So, when we detect a
     // *reconnection*, we simply reload the page, so that every *meaningful*
-    // connection is accompanied by a fresh client state. This
-    // `fresh_connection` variable allows us to distinguish between a server
-    // connection from a clean client state versus a reconnection after the
-    // original connection was lost.
-    var fresh_connection = true;
+    // connection is accompanied by a fresh client state. Upon loading the
+    // page, it can accept a connection. After that first connection, any
+    // new connection is interpreted as a signal to reload.
+    var accepting_connections = true;
+    status_dom = document.getElementById("status-message");
     // When the connection closes, try creating a new connection automatically.
     function make_connection(url, reconnect_ms) {
       try {
@@ -83,22 +87,32 @@
         connection.binaryType = "arraybuffer";
         connection.onmessage = (msg) => handle_message(msg);
         connection.onopen = (evt) => {
-          if (!fresh_connection) location.reload(); };
+          if (!accepting_connections) location.reload();
+          accepting_connections = false
+        };
         connection.onclose = function(evt) {
-          fresh_connection = false;
-          // Immediately schedule an attempt to reconnect.
-          setTimeout(() => {make_connection(url, reconnect_ms);}, reconnect_ms);
+          status_dom.style.display = "block";
+          if (do_reconnect) {
+            // Immediately schedule an attempt to reconnect.
+            setTimeout(() => {make_connection(url, reconnect_ms);}, reconnect_ms);
+          }
         }
         viewer.connection = connection
       } catch (e) {
         console.info("Not connected to MeshCat websocket server: ", e);
-        setTimeout(() => {make_connection(url, reconnect_ms);}, reconnect_ms);
+        if (do_reconnect) {
+          setTimeout(() => {make_connection(url, reconnect_ms);}, reconnect_ms);
+        }
       }
     }
 
     const queryString = window.location.search;
     const urlParams = new URLSearchParams(queryString);
     reconnect_ms = parseInt(urlParams.get('reconnect_ms')) || 1000;
+    var do_reconnect = reconnect_ms > 0;
+    if (do_reconnect) {
+      status_dom.textContent = "No connection to server. Attempting to reconnect...";
+    }
 
     url = location.toString();
     url = url.replace("http://", "ws://")
@@ -106,6 +120,7 @@
     url = url.replace("/index.html", "/")
     url = url.replace("/meshcat.html", "/")
     make_connection(url, reconnect_ms);
+    <!-- CONNECTION BLOCK END -->
 
   </script>
 
@@ -118,6 +133,16 @@
       width: 100vw;
       height: 100vh;
       overflow: hidden;
+    }
+
+    #status-message{
+      width: 50vw;
+      text-align: center;
+      font-weight: bold;
+      background-color: yellow;
+      position: fixed;
+      left: 25%;
+      display: none;
     }
 
     #stats-plot {

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -900,13 +900,18 @@ GTEST_TEST(MeshcatTest, StaticHtml) {
                          RigidTransformd(RotationMatrixd::MakeZRotation(M_PI)));
 
   const std::string html = meshcat.StaticHtml();
-  // Confirm that I have some base64 content.
-  EXPECT_THAT(html, HasSubstr("data:application/octet-binary;base64"));
 
   // Confirm that the js source links were replaced.
   EXPECT_THAT(html, ::testing::Not(HasSubstr("meshcat.js")));
   EXPECT_THAT(html, ::testing::Not(HasSubstr("stats.min.js")));
   EXPECT_THAT(html, ::testing::Not(HasSubstr("msgpack.min.js")));
+  // The static html replaces the javascript web socket connection code with
+  // direct invocation of MeshCat with all of the data. We'll confirm that
+  // this appears to have happened by testing for the presence of the injected
+  // tree (base64 content) and the absence of what is *believed* to be the
+  // delimiting text of the connection block.
+  EXPECT_THAT(html, HasSubstr("data:application/octet-binary;base64"));
+  EXPECT_THAT(html, ::testing::Not(HasSubstr("CONNECTION BLOCK")));
 }
 
 // Check MeshcatParams.hide_stats_plot sends a hide_realtime_rate message


### PR DESCRIPTION
The client will automatically attempt to reconnect to the meshcat url at a default 1-second cadence. The reconnect period can be tweaked by changing the url.

   http://localhost:7000/?reconnect_ms=10000

sets the reconnect period to 10,000 ms.

The C++ `MeshCat` server adds the following to facilitate reconnection:
  - When connecting to a client, it deletes everything in the `prefix_` path.
  - While the server broadcasts the current state to a new connection, any value not *explicitly* stored in the current state doesn't get broadcast. Properties related to changing render mode have been explicitly added to the state. Previously, the initial values were implicit.

What this does *not* do: overwrite the lighting.

Closes #17085

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17685)
<!-- Reviewable:end -->
