### PR TITLE
[geometry] Set pose of rigid geometry at registration

### DIFF
--- a/geometry/proximity/deformable_contact_internal.cc
+++ b/geometry/proximity/deformable_contact_internal.cc
@@ -30,8 +30,9 @@ void Geometries::RemoveGeometry(GeometryId id) {
   rigid_geometries_.erase(id);
 }
 
-void Geometries::MaybeAddRigidGeometry(const Shape& shape, GeometryId id,
-                                       const ProximityProperties& props) {
+void Geometries::MaybeAddRigidGeometry(
+    const Shape& shape, GeometryId id, const ProximityProperties& props,
+    const math::RigidTransform<double>& X_WG) {
   // TODO(xuchenhan-tri): Right now, rigid geometries participating in
   // deformable contact share the property "kRezHint" with hydroelastics. It's
   // reasonable to use the contact mesh with the same resolution for both hydro
@@ -41,6 +42,7 @@ void Geometries::MaybeAddRigidGeometry(const Shape& shape, GeometryId id,
   if (props.HasProperty(kHydroGroup, kRezHint)) {
     ReifyData data{id, props};
     shape.Reify(this, &data);
+    UpdateRigidWorldPose(id, X_WG);
   }
 }
 

--- a/geometry/proximity/deformable_contact_internal.h
+++ b/geometry/proximity/deformable_contact_internal.h
@@ -72,12 +72,14 @@ class Geometries final : public ShapeReifier {
    @param id            The unique identifier for the geometry.
    @param properties    The proximity properties that specifies the properties
                         of the rigid representation.
+   @param X_WG          The pose of the geometry in the world frame.
    @throws std::exception if resolution hint <= 0 for the following shapes: Box,
            Sphere, Cylinder, Capsule, and Ellipsoid. Note that Mesh and Convex
            don't restrict the range of resolution_hint.
    @pre There is no previous representation associated with id.  */
   void MaybeAddRigidGeometry(const Shape& shape, GeometryId id,
-                             const ProximityProperties& props);
+                             const ProximityProperties& props,
+                             const math::RigidTransform<double>& X_WG);
 
   /* Updates the world pose of the rigid geometry with the given id, if it
    exists, to `X_WG`. */

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -315,9 +315,10 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     hydroelastic_geometries_.RemoveGeometry(id);
     hydroelastic_geometries_.MaybeAddGeometry(geometry.shape(), id,
                                               new_properties);
+    const RigidTransformd X_WG = GetX_WG(id, geometry.is_dynamic());
     geometries_for_deformable_contact_.RemoveGeometry(id);
     geometries_for_deformable_contact_.MaybeAddRigidGeometry(
-        geometry.shape(), id, new_properties);
+        geometry.shape(), id, new_properties, X_WG);
   }
 
   // Returns true if the geometry with the given Id has been registered in
@@ -419,13 +420,8 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
                                              void* user_data) {
     const ReifyData& data = *static_cast<ReifyData*>(user_data);
 
-    geometries_for_deformable_contact_.MaybeAddRigidGeometry(shape, data.id,
-                                                             data.properties);
-    // TODO(xuchenhan-tri): Update MaybeAddRigidGeometry to take in an X_WG
-    // argument to initialize the pose.
-    // Ensure that the rigid pose is up-to-date at registration because anchored
-    // geometries don't update their poses before proximity queries.
-    geometries_for_deformable_contact_.UpdateRigidWorldPose(data.id, data.X_WG);
+    geometries_for_deformable_contact_.MaybeAddRigidGeometry(
+        shape, data.id, data.properties, data.X_WG);
   }
 
   void ImplementGeometry(const Sphere& sphere, void* user_data) override {


### PR DESCRIPTION
This also fixes a previously undetected issue that the pose of the deformable contact representation of a non-deformable geometry is quietly changed when the proximity property is replaced.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17691)
<!-- Reviewable:end -->
