### PR TITLE
[hardware_sim] Switch demo to use IIWA instead of UR3e

### DIFF
--- a/examples/hardware_sim/BUILD.bazel
+++ b/examples/hardware_sim/BUILD.bazel
@@ -49,32 +49,33 @@ drake_cc_binary(
 drake_py_unittest(
     name = "hardware_sim_test",
     data = [
-        "example_scenarios.yaml",
         "test/test_scenarios.yaml",
+        ":demo",
         ":hardware_sim",
-        ":homecart",
     ],
+    shard_count = 3,
     deps = [
         "@bazel_tools//tools/python/runfiles",
     ],
 )
 
-# Binds the hardware_sim program to the data files required for the Homecart
+# Binds the hardware_sim program to the data files required for the Demo
 # example scenario.
 sh_binary(
-    name = "homecart",
+    name = "demo",
     srcs = [":hardware_sim"],
     args = [
         "--scenario_file=examples/hardware_sim/example_scenarios.yaml",
-        "--scenario_name=Homecart",
+        "--scenario_name=Demo",
     ],
     data = [
+        ":example_iiwa_wsg.yaml",
         ":example_scenarios.yaml",
-        "//manipulation/models/tri_homecart:prod_models",
-        "//manipulation/models/ur3e:prod_models",
+        "//examples/manipulation_station:prod_models",
+        "//manipulation/models/iiwa_description:prod_models",
         "//manipulation/models/wsg_50_description:prod_models",
     ],
-    # Use the runfiles of the ":homecart", not of the ":hardware_sim".
+    # Use the runfiles of the ":demo", not of the ":hardware_sim".
     env = {"RUNFILES_DIR": "../"},
 )
 

--- a/examples/hardware_sim/README.md
+++ b/examples/hardware_sim/README.md
@@ -6,7 +6,7 @@ To see the demo, run:
 
 $ cd drake
 $ bazel run //tools:meldis -- -w &
-$ bazel run //examples/hardware_sim:homecart
+$ bazel run //examples/hardware_sim:demo
 
 At the moment, the capabilities demonstrated by the example are somewhat
 limited. We will be adding more features in the near future.

--- a/examples/hardware_sim/example_iiwa_wsg.yaml
+++ b/examples/hardware_sim/example_iiwa_wsg.yaml
@@ -1,0 +1,16 @@
+directives:
+- add_model:
+    name: iiwa
+    file: package://drake/manipulation/models/iiwa_description/urdf/iiwa14_primitive_collision.urdf
+- add_model:
+    name: wsg
+    file: package://drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_with_tip.sdf
+- add_frame:
+    name: wsg_on_iiwa
+    X_PF:
+      base_frame: iiwa_link_7
+      translation: [0, 0, 0.114]
+      rotation: !Rpy { deg: [90, 0, 90] }
+- add_weld:
+    parent: wsg_on_iiwa
+    child: wsg::body

--- a/examples/hardware_sim/example_scenarios.yaml
+++ b/examples/hardware_sim/example_scenarios.yaml
@@ -1,5 +1,20 @@
-# This simulation loads the "TRI homecart" model (two arms and a countertop).
-Homecart:
+# This demo simulation shows an IIWA arm with an attached WSG gripper.
+Demo:
   directives:
+  - add_model:
+      name: amazon_table
+      file: package://drake/examples/manipulation_station/models/amazon_table_simplified.sdf
+  - add_weld:
+      parent: world
+      child: amazon_table::amazon_table
   - add_directives:
-      file: package://drake/manipulation/models/tri_homecart/homecart.yaml
+      file: package://drake/examples/hardware_sim/example_iiwa_wsg.yaml
+  - add_frame:
+      name: iiwa_on_world
+      X_PF:
+        base_frame: world
+        translation: [0, -0.7, 0]
+        rotation: !Rpy { deg: [0, 0, 90] }
+  - add_weld:
+      parent: iiwa_on_world
+      child: iiwa::base

--- a/examples/hardware_sim/hardware_sim.cc
+++ b/examples/hardware_sim/hardware_sim.cc
@@ -25,7 +25,7 @@ DEFINE_string(scenario_file, "",
     "Scenario filename, e.g., "
     "drake/examples/hardware_sim/example_scenarios.yaml");
 DEFINE_string(scenario_name, "",
-    "Scenario name within the scenario_file, e.g., Homecart in the "
+    "Scenario name within the scenario_file, e.g., Demo in the "
     "example_scenarios.yaml; scenario names appears as the keys of the "
     "YAML document's top-level mapping item");
 DEFINE_string(scenario_text, "{}",

--- a/examples/hardware_sim/test/hardware_sim_test.py
+++ b/examples/hardware_sim/test/hardware_sim_test.py
@@ -30,7 +30,7 @@ class HardwareSimTest(unittest.TestCase):
             "drake/examples/hardware_sim/test/test_scenarios.yaml")
         self._default_extra = {
             # For our smoke test, exit fairly quickly.
-            "simulation_duration": 1.0,
+            "simulation_duration": 0.25,
         }
 
     def _dict_to_single_line_yaml(self, *, data):
@@ -68,6 +68,6 @@ class HardwareSimTest(unittest.TestCase):
         """Tests the OneOfEverything test scenario."""
         self._run(self._test_scenarios, "OneOfEverything")
 
-    def test_Homecart(self):
-        """Tests the Homecart example."""
-        self._run(self._example_scenarios, "Homecart")
+    def test_Demo(self):
+        """Tests the Demo example."""
+        self._run(self._example_scenarios, "Demo")


### PR DESCRIPTION
We don't have any ID control / communication code for UR3e's in Drake.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17693)
<!-- Reviewable:end -->
