### PR TITLE
[multibody] Correct WeldJoint frame notation

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -107,6 +107,7 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/common:cpp_template_pybind",
         "//bindings/pydrake/common:default_scalars_pybind",
+        "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:eigen_geometry_pybind",
         "//bindings/pydrake/common:eigen_pybind",
         "//bindings/pydrake/common:serialize_pybind",

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -241,8 +241,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("WeldFrames",
             py::overload_cast<const Frame<T>&, const Frame<T>&,
                 const RigidTransform<double>&>(&Class::WeldFrames),
-            py::arg("frame_on_parent_P"), py::arg("frame_on_child_C"),
-            py::arg("X_PC") = RigidTransform<double>::Identity(),
+            py::arg("frame_on_parent_F"), py::arg("frame_on_child_M"),
+            py::arg("X_FM") = RigidTransform<double>::Identity(),
             py_rvp::reference_internal, cls_doc.WeldFrames.doc)
         .def(
             "AddForceElement",

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -4,6 +4,7 @@
 
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_geometry_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
@@ -238,10 +239,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 const SpatialInertia<double>&>(&Class::AddRigidBody),
             py::arg("name"), py::arg("model_instance"), py::arg("M_BBo_B"),
             py_rvp::reference_internal, cls_doc.AddRigidBody.doc_3args)
-        .def("WeldFrames",
-            py::overload_cast<const Frame<T>&, const Frame<T>&,
-                const RigidTransform<double>&>(&Class::WeldFrames),
-            py::arg("frame_on_parent_F"), py::arg("frame_on_child_M"),
+        .def("WeldFrames", &Class::WeldFrames, py::arg("frame_on_parent_F"),
+            py::arg("frame_on_child_M"),
             py::arg("X_FM") = RigidTransform<double>::Identity(),
             py_rvp::reference_internal, cls_doc.WeldFrames.doc)
         .def(
@@ -256,6 +255,19 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("AddCouplerConstraint", &Class::AddCouplerConstraint,
             py::arg("joint0"), py::arg("joint1"), py::arg("gear_ratio"),
             py::arg("offset") = 0.0, cls_doc.AddCouplerConstraint.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    constexpr char kWeldFramesDeprecated[] =
+        "Deprecated:\n    Frame notation for `WeldFrames` has changed. Use the "
+        "version that uses `frame_on_parent_F`, `frame_on_child_M`, and "
+        "`X_FM`. The deprecated code will be removed from Drake on or after "
+        "2022-12-01.";
+    cls.def("WeldFrames",
+        WrapDeprecated(kWeldFramesDeprecated, &Class::WeldFrames),
+        py::arg("frame_on_parent_P"), py::arg("frame_on_child_C"),
+        py::arg("X_PC") = RigidTransform<double>::Identity(),
+        py_rvp::reference_internal, kWeldFramesDeprecated);
+#pragma GCC diagnostic pop
     // Mathy bits
     cls  // BR
         .def(

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from cmath import exp
 import collections
 import copy
 import itertools
-from tkinter import E
 import unittest
 
 import numpy as np

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1797,7 +1797,7 @@ class TestPlant(unittest.TestCase):
               ", and `X_FM`. The deprecated code will be removed from Drake "\
               "on or after 2022-12-01."
 
-        # Old constructor arguments raise a warning.
+        # Old keyword arguments raise a warning.
         with self.assertWarns(DrakeDeprecationWarning) as cm:
             world_body1 = WeldJoint_[float](
                 name="world_body1",
@@ -1828,7 +1828,7 @@ class TestPlant(unittest.TestCase):
               "`frame_on_child_M`, and `X_FM`. The deprecated code will be "\
               "removed from Drake on or after 2022-12-01."
 
-        # Old constructor arguments raise a warning.
+        # Old keyword arguments raise a warning.
         with self.assertWarns(DrakeDeprecationWarning) as cm:
             plant.WeldFrames(
                 frame_on_parent_P=plant.world_frame(),

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
+from cmath import exp
 import collections
 import copy
 import itertools
+from tkinter import E
 import unittest
 
 import numpy as np
@@ -78,8 +80,7 @@ from pydrake.multibody.benchmarks.acrobot import (
 )
 from pydrake.common.cpp_param import List
 from pydrake.common import FindResourceOrThrow
-from pydrake.common.deprecation import DrakeDeprecationWarning, \
-    install_numpy_warning_filters
+from pydrake.common.deprecation import install_numpy_warning_filters
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.common.test_utilities.pickle_compare import assert_pickle
@@ -1792,19 +1793,14 @@ class TestPlant(unittest.TestCase):
             name="body2",
             M_BBo_B=SpatialInertia_[float]())
 
-        msg = "Deprecated:\n    WeldJoint frame notation has changed. Use the"\
-              " constructor that uses `frame_on_parent_F`, `frame_on_child_M`"\
-              ", and `X_FM`. The deprecated code will be removed from Drake "\
-              "on or after 2022-12-01."
-
         # Old keyword arguments raise a warning.
-        with self.assertWarns(DrakeDeprecationWarning) as cm:
+        with catch_drake_warnings(expected_count=1) as w:
             world_body1 = WeldJoint_[float](
                 name="world_body1",
                 frame_on_parent_P=plant.world_frame(),
                 frame_on_child_C=body1.body_frame(),
                 X_PC=RigidTransform_[float].Identity())
-        self.assertEqual(str(cm.warning), msg)
+            self.assertIn("2022-12-01", str(w[0].message))
 
         # No keywords defaults to the first constructor defined in the binding.
         # No warning.
@@ -1823,18 +1819,13 @@ class TestPlant(unittest.TestCase):
             name="body2",
             M_BBo_B=SpatialInertia_[float]())
 
-        msg = "Deprecated:\n    Frame notation for `WeldFrames` has changed. "\
-              "Use the version that uses `frame_on_parent_F`, "\
-              "`frame_on_child_M`, and `X_FM`. The deprecated code will be "\
-              "removed from Drake on or after 2022-12-01."
-
         # Old keyword arguments raise a warning.
-        with self.assertWarns(DrakeDeprecationWarning) as cm:
+        with catch_drake_warnings(expected_count=1) as w:
             plant.WeldFrames(
                 frame_on_parent_P=plant.world_frame(),
                 frame_on_child_C=body1.body_frame(),
                 X_PC=RigidTransform_[float].Identity())
-        self.assertEqual(str(cm.warning), msg)
+            self.assertIn("2022-12-01", str(w[0].message))
 
         # No keywords defaults to the first function named `WeldFrames` defined
         # in the binding. No warning.

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1258,9 +1258,9 @@ class TestPlant(unittest.TestCase):
         X_EeGripper = RigidTransform_[float](
             RollPitchYaw_[float](np.pi / 2, 0, np.pi / 2), [0, 0, 0.081])
         plant_f.WeldFrames(
-            frame_on_parent_P=plant_f.world_frame(),
-            frame_on_child_C=plant_f.GetFrameByName("iiwa_link_0", iiwa_model),
-            X_PC=RigidTransform_[float]())
+            frame_on_parent_F=plant_f.world_frame(),
+            frame_on_child_M=plant_f.GetFrameByName("iiwa_link_0", iiwa_model),
+            X_FM=RigidTransform_[float]())
         # Perform the second weld without named arguments to ensure that the
         # proper binding gets invoked.
         plant_f.WeldFrames(
@@ -1407,13 +1407,13 @@ class TestPlant(unittest.TestCase):
         X_EeGripper = RigidTransform_[float](
             RollPitchYaw_[float](np.pi / 2, 0, np.pi / 2), [0, 0, 0.081])
         plant_f.WeldFrames(
-            frame_on_parent_P=plant_f.world_frame(),
-            frame_on_child_C=plant_f.GetFrameByName("iiwa_link_0", iiwa_model))
+            frame_on_parent_F=plant_f.world_frame(),
+            frame_on_child_M=plant_f.GetFrameByName("iiwa_link_0", iiwa_model))
         plant_f.WeldFrames(
-            frame_on_parent_P=plant_f.GetFrameByName(
+            frame_on_parent_F=plant_f.GetFrameByName(
                 "iiwa_link_7", iiwa_model),
-            frame_on_child_C=plant_f.GetFrameByName("body", gripper_model),
-            X_PC=X_EeGripper)
+            frame_on_child_M=plant_f.GetFrameByName("body", gripper_model),
+            X_FM=X_EeGripper)
         plant_f.Finalize()
         plant = to_type(plant_f, T)
 
@@ -1602,9 +1602,9 @@ class TestPlant(unittest.TestCase):
         def make_weld_joint(plant, P, C):
             return WeldJoint_[T](
                 name="weld",
-                frame_on_parent_P=P,
-                frame_on_child_C=C,
-                X_PC=X_PC,
+                frame_on_parent_F=P,
+                frame_on_child_M=C,
+                X_FM=X_PC,
             )
 
         make_joint_list = [
@@ -1771,7 +1771,7 @@ class TestPlant(unittest.TestCase):
                 joint.set_default_angles(angles=[1.0, 2.0])
             elif joint.name() == "weld":
                 numpy_compare.assert_float_equal(
-                    joint.X_PC().GetAsMatrix4(),
+                    joint.X_FM().GetAsMatrix4(),
                     X_PC.GetAsMatrix4())
             else:
                 raise TypeError(

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -645,15 +645,20 @@ void DoScalarDependentDefinitions(py::module m, T) {
                  const RigidTransform<double>&>(),
             py::arg("name"), py::arg("frame_on_parent_F"),
             py::arg("frame_on_child_M"), py::arg("X_FM"), cls_doc.ctor.doc)
-        .def(py_init_deprecated<Class, const string&, const Frame<T>&,
-                 const Frame<T>&, const RigidTransform<double>&>(
-                 "DRAKE DEPRECATED: WeldJoint frame notation has changed. Use "
-                 "the constructor that uses `frame_on_parent_F`, "
-                 "`frame_on_child_M`, and `X_FM`. The deprecated code will be "
-                 "removed from Drake on or after 2022-12-01."),
-            py::arg("name"), py::arg("frame_on_parent_P"),
-            py::arg("frame_on_child_C"), py::arg("X_PC"), cls_doc.ctor.doc)
         .def("X_FM", &Class::X_FM, cls_doc.X_FM.doc);
+
+    // Deprecated definitions
+    constexpr char kInitDeprecated[] =
+        "Deprecated:\n    WeldJoint frame notation has changed. Use "
+        "the constructor that uses `frame_on_parent_F`, "
+        "`frame_on_child_M`, and `X_FM`. The deprecated code will be "
+        "removed from Drake on or after 2022-12-01.";
+    cls.def(
+        py_init_deprecated<Class, const string&, const Frame<T>&,
+            const Frame<T>&, const RigidTransform<double>&>(kInitDeprecated),
+        py::arg("name"), py::arg("frame_on_parent_P"),
+        py::arg("frame_on_child_C"), py::arg("X_PC"), kInitDeprecated);
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     cls.def("X_PC", WrapDeprecated(cls_doc.X_PC.doc_deprecated, &Class::X_PC),

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -645,8 +645,20 @@ void DoScalarDependentDefinitions(py::module m, T) {
                  const RigidTransform<double>&>(),
             py::arg("name"), py::arg("frame_on_parent_F"),
             py::arg("frame_on_child_M"), py::arg("X_FM"), cls_doc.ctor.doc)
-        .def("X_PC", &Class::X_PC, cls_doc.X_PC.doc)
+        .def(py_init_deprecated<Class, const string&, const Frame<T>&,
+                 const Frame<T>&, const RigidTransform<double>&>(
+                 "DRAKE DEPRECATED: WeldJoint frame notation has changed. Use "
+                 "the constructor that uses `frame_on_parent_F`, "
+                 "`frame_on_child_M`, and `X_FM`. The deprecated code will be "
+                 "removed from Drake on or after 2022-12-01."),
+            py::arg("name"), py::arg("frame_on_parent_P"),
+            py::arg("frame_on_child_C"), py::arg("X_PC"), cls_doc.ctor.doc)
         .def("X_FM", &Class::X_FM, cls_doc.X_FM.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls.def("X_PC", WrapDeprecated(cls_doc.X_PC.doc_deprecated, &Class::X_PC),
+        cls_doc.X_PC.doc_deprecated);
+#pragma GCC diagnostic pop
   }
 
   // Actuators.

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -643,9 +643,10 @@ void DoScalarDependentDefinitions(py::module m, T) {
     cls  // BR
         .def(py::init<const string&, const Frame<T>&, const Frame<T>&,
                  const RigidTransform<double>&>(),
-            py::arg("name"), py::arg("frame_on_parent_P"),
-            py::arg("frame_on_child_C"), py::arg("X_PC"), cls_doc.ctor.doc)
-        .def("X_PC", &Class::X_PC, cls_doc.X_PC.doc);
+            py::arg("name"), py::arg("frame_on_parent_F"),
+            py::arg("frame_on_child_M"), py::arg("X_FM"), cls_doc.ctor.doc)
+        .def("X_PC", &Class::X_PC, cls_doc.X_PC.doc)
+        .def("X_FM", &Class::X_FM, cls_dox.X_FM.doc);
   }
 
   // Actuators.

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -646,7 +646,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("name"), py::arg("frame_on_parent_F"),
             py::arg("frame_on_child_M"), py::arg("X_FM"), cls_doc.ctor.doc)
         .def("X_PC", &Class::X_PC, cls_doc.X_PC.doc)
-        .def("X_FM", &Class::X_FM, cls_dox.X_FM.doc);
+        .def("X_FM", &Class::X_FM, cls_doc.X_FM.doc);
   }
 
   // Actuators.

--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -267,9 +267,9 @@ class TestMeshcat(unittest.TestCase):
 
         # Weld table to world.
         plant.WeldFrames(
-            frame_on_parent_P=plant.world_frame(),
-            frame_on_child_C=plant.GetFrameByName("link", table_model),
-            X_PC=RigidTransform(RotationMatrix.MakeXRotation(0.2)))
+            frame_on_parent_F=plant.world_frame(),
+            frame_on_child_M=plant.GetFrameByName("link", table_model),
+            X_FM=RigidTransform(RotationMatrix.MakeXRotation(0.2)))
 
         plant.Finalize()
 

--- a/examples/hydroelastic/python_ball_paddle/contact_sim_demo.py
+++ b/examples/hydroelastic/python_ball_paddle/contact_sim_demo.py
@@ -43,9 +43,9 @@ def make_ball_paddle(contact_model, contact_surface_representation,
                             "/paddle.sdf")
     paddle = parser.AddModelFromFile(paddle_sdf_file_name, model_name="paddle")
     plant.WeldFrames(
-        frame_on_parent_P=plant.world_frame(),
-        frame_on_child_C=plant.GetFrameByName("paddle", paddle),
-        X_PC=p_WPaddle_fixed
+        frame_on_parent_F=plant.world_frame(),
+        frame_on_child_M=plant.GetFrameByName("paddle", paddle),
+        X_FM=p_WPaddle_fixed
     )
     ball_sdf_file_name = \
         FindResourceOrThrow("drake/examples/hydroelastic/python_ball_paddle"

--- a/multibody/inverse_kinematics/global_inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/global_inverse_kinematics.cc
@@ -132,9 +132,8 @@ GlobalInverseKinematics::GlobalInverseKinematics(
           const WeldJoint<double>* weld_joint =
               dynamic_cast<const WeldJoint<double>*>(joint);
 
-          const RigidTransformd X_JpJc = weld_joint->X_PC();  // see #17600.
-          const RigidTransformd X_PC =
-              X_PJp * X_JpJc * X_CJc.inverse();
+          const RigidTransformd X_PC = weld_joint->X_PC();
+
           // Fixed to the parent body.
 
           // The position can be computed from the parent body pose.

--- a/multibody/inverse_kinematics/global_inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/global_inverse_kinematics.cc
@@ -132,8 +132,9 @@ GlobalInverseKinematics::GlobalInverseKinematics(
           const WeldJoint<double>* weld_joint =
               dynamic_cast<const WeldJoint<double>*>(joint);
 
-          const RigidTransformd X_PC = weld_joint->X_PC();
-
+          const RigidTransformd X_JpJc = weld_joint->X_FM();
+          const RigidTransformd X_PC =
+              X_PJp * X_JpJc * X_CJc.inverse();
           // Fixed to the parent body.
 
           // The position can be computed from the parent body pose.

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -686,7 +686,7 @@ GTEST_TEST(MujocoParser, Joint) {
           X_WB, 1e-14));
   const WeldJoint<double>& weld_joint =
       plant.GetJointByName<WeldJoint>("WorldBody_welds_to_weld");
-  EXPECT_TRUE(weld_joint.X_PC().IsNearlyEqualTo(X_WB, 1e-14));
+  EXPECT_TRUE(weld_joint.X_FM().IsNearlyEqualTo(X_WB, 1e-14));
 }
 
 GTEST_TEST(MujocoParser, JointThrows) {

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -563,10 +563,12 @@ void MultibodyPlant<T>::SetFreeBodyRandomRotationDistributionToUniform(
 
 template <typename T>
 const WeldJoint<T>& MultibodyPlant<T>::WeldFrames(
-    const Frame<T>& A, const Frame<T>& B,
-    const math::RigidTransform<double>& X_AB) {
-  const std::string joint_name = A.name() + "_welds_to_" + B.name();
-  return AddJoint(std::make_unique<WeldJoint<T>>(joint_name, A, B, X_AB));
+    const Frame<T>& frame_on_parent_F, const Frame<T>& frame_on_child_M,
+    const math::RigidTransform<double>& X_FM) {
+  const std::string joint_name =
+      frame_on_parent_F.name() + "_welds_to_" + frame_on_child_M.name();
+  return AddJoint(std::make_unique<WeldJoint<T>>(joint_name, frame_on_parent_F,
+                                                 frame_on_child_M, X_FM));
 }
 
 template <typename T>

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1048,17 +1048,18 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     return joint;
   }
 
-  /// Welds `frame_on_parent_P` and `frame_on_child_C` with relative pose
-  /// `X_PC`. That is, the pose of frame C in frame P is fixed, with value
-  /// `X_PC`.  If `X_PC` is omitted, the identity transform will be used. The
+  /// Welds `frame_on_parent_F` and `frame_on_child_M` with relative pose
+  /// `X_FM`. That is, the pose of frame M in frame F is fixed, with value
+  /// `X_FM`.  If `X_FM` is omitted, the identity transform will be used. The
   /// call to this method creates and adds a new WeldJoint to the model.  The
-  /// new WeldJoint is named as: P.name() + "_welds_to_" + C.name().
+  /// new WeldJoint is named as:
+  ///     frame_on_parent_F.name() + "_welds_to_" + frame_on_child_M.name().
   /// @returns a constant reference to the WeldJoint welding frames
-  /// P and C.
+  /// F and M.
   /// @throws std::exception if the weld produces a duplicate joint name.
-  const WeldJoint<T>& WeldFrames(const Frame<T>& frame_on_parent_P,
-                                 const Frame<T>& frame_on_child_C,
-                                 const math::RigidTransform<double>& X_PC =
+  const WeldJoint<T>& WeldFrames(const Frame<T>& frame_on_parent_F,
+                                 const Frame<T>& frame_on_child_M,
+                                 const math::RigidTransform<double>& X_FM =
                                      math::RigidTransform<double>::Identity());
 
   /// Adds a new force element model of type `ForceElementType` to `this`

--- a/multibody/tree/test/weld_joint_test.cc
+++ b/multibody/tree/test/weld_joint_test.cc
@@ -32,11 +32,8 @@ class WeldJointTest : public ::testing::Test {
     // Add a body so we can add a joint to it.
     body_ = &model->AddBody<RigidBody>("body", M_B);
 
-    joint_ = &model->AddJoint<WeldJoint>(
-        "Welder",
-        model->world_body(), X_PF_,  // X_PF
-        *body_, X_CM_,               // X_CM
-        X_FM_);                      // X_FM
+    joint_ = &model->AddJoint<WeldJoint>("Welder", model->world_body(), X_PF_,
+                                         *body_, X_CM_, X_FM_);
 
     // We are done adding modeling elements. Transfer tree to system for
     // computation.

--- a/multibody/tree/test/weld_joint_test.cc
+++ b/multibody/tree/test/weld_joint_test.cc
@@ -85,12 +85,6 @@ TEST_F(WeldJointTest, GetX_FM) {
   EXPECT_TRUE(joint_->X_FM().IsExactlyEqualTo(X_FM_));
 }
 
-// Verify that the convenience function X_PC() gives the correct pose.
-TEST_F(WeldJointTest, GetX_PC) {
-  EXPECT_FALSE(joint_->X_PC().IsExactlyEqualTo(X_FM_));
-  EXPECT_TRUE(joint_->X_PC().IsExactlyEqualTo(X_PF_ * X_FM_ * X_CM_.inverse()));
-}
-
 TEST_F(WeldJointTest, GetJointLimits) {
   EXPECT_EQ(joint_->position_lower_limits().size(), 0);
   EXPECT_EQ(joint_->position_upper_limits().size(), 0);

--- a/multibody/tree/weld_joint.cc
+++ b/multibody/tree/weld_joint.cc
@@ -20,7 +20,7 @@ WeldJoint<T>::TemplatedDoCloneToScalar(
   // Make the Joint<T> clone.
   auto joint_clone = std::make_unique<WeldJoint<ToScalar>>(
       this->name(),
-      frame_on_parent_body_clone, frame_on_child_body_clone, X_PC());
+      frame_on_parent_body_clone, frame_on_child_body_clone, X_FM());
 
   return joint_clone;
 }
@@ -52,7 +52,7 @@ WeldJoint<T>::MakeImplementationBlueprint() const {
   auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
   blue_print->mobilizers_.push_back(
       std::make_unique<internal::WeldMobilizer<T>>(
-          this->frame_on_parent(), this->frame_on_child(), X_PC_));
+          this->frame_on_parent(), this->frame_on_child(), X_FM_));
   return blue_print;
 }
 

--- a/multibody/tree/weld_joint.h
+++ b/multibody/tree/weld_joint.h
@@ -49,16 +49,14 @@ class WeldJoint final : public Joint<T> {
     return name.access();
   }
 
+  /// Returns the pose X_FM of frame M in F.
+  const math::RigidTransform<double>& X_FM() const { return X_FM_; }
+
   /// Returns the pose X_PC of frame C in P.
   DRAKE_DEPRECATED(
       "2022-12-01",
       "WeldJoint frame notation has changed. Use `X_FM()` instead.")
   const math::RigidTransform<double>& X_PC() const { return X_FM_; }
-
-  /// Returns the pose X_FM of frame M in F.
-  const math::RigidTransform<double>& X_FM() const {
-    return X_FM_;
-  }
 
  protected:
   /// Joint<T> override called through public NVI, Joint::AddInForce().

--- a/multibody/tree/weld_joint.h
+++ b/multibody/tree/weld_joint.h
@@ -7,6 +7,7 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/multibody/tree/joint.h"
 #include "drake/multibody/tree/multibody_forces.h"
 #include "drake/multibody/tree/weld_mobilizer.h"
@@ -48,15 +49,11 @@ class WeldJoint final : public Joint<T> {
     return name.access();
   }
 
-  /// Returns the pose X_PC of this joint's child body frame C in this joint's
-  /// parent body frame P.
-  math::RigidTransform<T> X_PC() const {
-    const math::RigidTransform<T> X_PF =
-        this->frame_on_parent().GetFixedPoseInBodyFrame();
-    const math::RigidTransform<T> X_MC =
-        this->frame_on_child().GetFixedPoseInBodyFrame().inverse();
-    return X_PF * X_FM_.template cast<T>() * X_MC;
-  }
+  /// Returns the pose X_PC of frame C in P.
+  DRAKE_DEPRECATED(
+      "2022-12-01",
+      "WeldJoint frame notation has changed. Use `X_FM()` instead.")
+  const math::RigidTransform<double>& X_PC() const { return X_FM_; }
 
   /// Returns the pose X_FM of frame M in F.
   const math::RigidTransform<double>& X_FM() const {

--- a/multibody/tree/weld_joint.h
+++ b/multibody/tree/weld_joint.h
@@ -28,34 +28,44 @@ class WeldJoint final : public Joint<T> {
 
   static const char kTypeName[];
 
-  /// Constructor for a %WeldJoint between a `frame_on_parent_P` and a
-  /// `frame_on_child_C` so that their relative pose `X_PC` is fixed as if
+  /// Constructor for a %WeldJoint between a `frame_on_parent_F` and a
+  /// `frame_on_child_M` so that their relative pose `X_FM` is fixed as if
   /// they were "welded" together.
-  WeldJoint(const std::string& name, const Frame<T>& frame_on_parent_P,
-            const Frame<T>& frame_on_child_C,
-            const math::RigidTransform<double>& X_PC)
-      : Joint<T>(name, frame_on_parent_P, frame_on_child_C,
+  WeldJoint(const std::string& name, const Frame<T>& frame_on_parent_F,
+            const Frame<T>& frame_on_child_M,
+            const math::RigidTransform<double>& X_FM)
+      : Joint<T>(name, frame_on_parent_F, frame_on_child_M,
                  VectorX<double>() /* no pos lower limits */,
                  VectorX<double>() /* no pos upper limits */,
                  VectorX<double>() /* no vel lower limits */,
                  VectorX<double>() /* no vel upper limits */,
                  VectorX<double>() /* no acc lower limits */,
                  VectorX<double>() /* no acc upper limits */),
-        X_PC_(X_PC) {}
+        X_FM_(X_FM) {}
 
   const std::string& type_name() const override {
     static const never_destroyed<std::string> name{kTypeName};
     return name.access();
   }
 
-  /// Returns the pose X_PC of frame C in P.
-  const math::RigidTransform<double>& X_PC() const {
-    return X_PC_;
+  /// Returns the pose X_PC of this joint's child body frame C in this joint's
+  /// parent body frame P.
+  math::RigidTransform<T> X_PC() const {
+    const math::RigidTransform<T> X_PF =
+        this->frame_on_parent().GetFixedPoseInBodyFrame();
+    const math::RigidTransform<T> X_MC =
+        this->frame_on_child().GetFixedPoseInBodyFrame().inverse();
+    return X_PF * X_FM_.template cast<T>() * X_MC;
+  }
+
+  /// Returns the pose X_FM of frame M in F.
+  const math::RigidTransform<double>& X_FM() const {
+    return X_FM_;
   }
 
  protected:
   /// Joint<T> override called through public NVI, Joint::AddInForce().
-  /// Since frame P and C are welded together, it is physically not possible to
+  /// Since frame F and M are welded together, it is physically not possible to
   /// apply forces between them. Therefore this method throws an exception if
   /// invoked.
   void DoAddInOneForce(
@@ -142,8 +152,8 @@ class WeldJoint final : public Joint<T> {
   std::unique_ptr<Joint<ToScalar>> TemplatedDoCloneToScalar(
       const internal::MultibodyTree<ToScalar>& tree_clone) const;
 
-  // The pose of frame C in P.
-  const math::RigidTransform<double> X_PC_;
+  // The pose of frame M in F.
+  const math::RigidTransform<double> X_FM_;
 };
 
 template <typename T> const char WeldJoint<T>::kTypeName[] = "weld";

--- a/tutorials/rendering_multibody_plant.ipynb
+++ b/tutorials/rendering_multibody_plant.ipynb
@@ -234,9 +234,9 @@
    "source": [
     "iiwa_2 = parser.AddModelFromFile(iiwa_file, model_name=\"iiwa_2\")\n",
     "plant.WeldFrames(\n",
-    "    frame_on_parent_P=plant.world_frame(),\n",
-    "    frame_on_child_C=plant.GetFrameByName(\"iiwa_link_0\", iiwa_2),\n",
-    "    X_PC=xyz_rpy_deg([0, 0.5, 0], [0, 0, 0]),\n",
+    "    frame_on_parent_F=plant.world_frame(),\n",
+    "    frame_on_child_M=plant.GetFrameByName(\"iiwa_link_0\", iiwa_2),\n",
+    "    X_FM=xyz_rpy_deg([0, 0.5, 0], [0, 0, 0]),\n",
     ")"
    ]
   },

--- a/tutorials/rendering_multibody_plant.ipynb
+++ b/tutorials/rendering_multibody_plant.ipynb
@@ -213,9 +213,9 @@
    "source": [
     "iiwa_1 = parser.AddModelFromFile(iiwa_file, model_name=\"iiwa_1\")\n",
     "plant.WeldFrames(\n",
-    "    frame_on_parent_P=plant.world_frame(),\n",
-    "    frame_on_child_C=plant.GetFrameByName(\"iiwa_link_0\", iiwa_1),\n",
-    "    X_PC=xyz_rpy_deg([0, -0.5, 0], [0, 0, 0]),\n",
+    "    frame_on_parent_F=plant.world_frame(),\n",
+    "    frame_on_child_M=plant.GetFrameByName(\"iiwa_link_0\", iiwa_1),\n",
+    "    X_FM=xyz_rpy_deg([0, -0.5, 0], [0, 0, 0]),\n",
     ")"
    ]
   },


### PR DESCRIPTION
Closes #17600

Updates `WeldJoint` to use the notation `F` for the frame on parent and `M` for the frame on child to match the notation in `Joint`.
Updates the arguments of `MultibodyPlant::WeldFrames()` to match.
Update argument names in python call sites.
Turn `WeldJoint::X_PC()` into a convenience function that returns `X_PF * X_FM * X_MC`

cc: @RussTedrake

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17696)
<!-- Reviewable:end -->
