### PR TITLE
Improve the speed of Polynomial::EvaluatePartial

### DIFF
--- a/common/symbolic/benchmarking/BUILD.bazel
+++ b/common/symbolic/benchmarking/BUILD.bazel
@@ -1,0 +1,32 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/performance:defs.bzl",
+    "drake_cc_googlebench_binary",
+    "drake_py_experiment_binary",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+drake_cc_googlebench_binary(
+    name = "benchmark_polynomial",
+    srcs = ["benchmark_polynomial.cc"],
+    add_test_rule = True,
+    test_timeout = "moderate",
+    deps = [
+        "//common:add_text_logging_gflags",
+        "//common/symbolic:monomial_util",
+        "//common/symbolic:polynomial",
+        "//tools/performance:fixture_common",
+        "//tools/performance:gflags_main",
+        "@fmt",
+    ],
+)
+
+package(default_visibility = ["//visibility:public"])
+
+drake_py_experiment_binary(
+    name = "polynomial_experiment",
+    googlebench_binary = ":benchmark_polynomial",
+)
+
+add_lint_tests()

--- a/common/symbolic/benchmarking/benchmark_polynomial.cc
+++ b/common/symbolic/benchmarking/benchmark_polynomial.cc
@@ -1,0 +1,50 @@
+#include <fmt/format.h>
+
+#include "drake/common/symbolic/monomial_util.h"
+#include "drake/common/symbolic/polynomial.h"
+#include "drake/tools/performance/fixture_common.h"
+
+namespace drake {
+namespace symbolic {
+namespace {
+static void BenchmarkPolynomialEvaluatePartial(
+    benchmark::State& state) {  // NOLINT
+  Eigen::Matrix<symbolic::Variable, 12, 1> x;
+  for (int i = 0; i < 12; ++i) {
+    x(i) = symbolic::Variable("x" + std::to_string(i));
+  }
+  const symbolic::Variables x_set(x);
+  const auto monomial_basis =
+      internal::ComputeMonomialBasis<Eigen::Dynamic>(x_set, 2);
+  MatrixX<symbolic::Variable> S(monomial_basis.rows(), monomial_basis.rows());
+  VectorX<symbolic::Variable> S_upper((S.rows() + 1) * S.rows() / 2);
+  int upper_count = 0;
+  for (int i = 0; i < monomial_basis.rows(); ++i) {
+    S(i, i) = symbolic::Variable(fmt::format("S({}, {})", i, i));
+    S_upper(upper_count++) = S(i, i);
+    for (int j = i + 1; j < monomial_basis.rows(); ++j) {
+      S(i, j) = symbolic::Variable(fmt::format("S({}, {})", i, j));
+      S_upper(upper_count++) = S(i, j);
+      S(j, i) = S(i, j);
+    }
+  }
+
+  symbolic::Polynomial p;
+  for (int i = 0; i < S.rows(); ++i) {
+    p.AddProduct(S(i, i), symbolic::pow(monomial_basis(i), 2));
+    for (int j = i + 1; j < S.cols(); ++j) {
+      p.AddProduct(2 * S(i, j), monomial_basis(i) * monomial_basis(j));
+    }
+  }
+  Eigen::MatrixXd S_val = Eigen::MatrixXd::Ones(S.rows(), S.cols());
+  symbolic::Environment env;
+  env.insert(S_upper, Eigen::VectorXd::Ones(S_upper.rows()));
+  for (auto _ : state) {
+    const auto p_evaluate = p.EvaluatePartial(env);
+  }
+}
+
+BENCHMARK(BenchmarkPolynomialEvaluatePartial);
+}  // namespace
+}  // namespace symbolic
+}  // namespace drake

--- a/common/symbolic/polynomial.cc
+++ b/common/symbolic/polynomial.cc
@@ -563,9 +563,16 @@ double Polynomial::Evaluate(const Environment& env) const {
 
 Polynomial Polynomial::EvaluatePartial(const Environment& env) const {
   MapType new_map;  // Will use this to construct the return value.
+
+  // Create a substitution that will be used for all coefficients in this
+  // polynomial.
+  symbolic::Substitution subst;
+  for (const auto& [var, val] : env) {
+    subst.emplace(var, val);
+  }
   for (const auto& product_i : monomial_to_coefficient_map_) {
     const Expression& coeff_i{product_i.second};
-    const Expression coeff_i_partial_evaluated{coeff_i.EvaluatePartial(env)};
+    const Expression coeff_i_partial_evaluated{coeff_i.Substitute(subst)};
     const Monomial& monomial_i{product_i.first};
     const pair<double, Monomial> partial_eval_result{
         monomial_i.EvaluatePartial(env)};

--- a/tools/performance/BUILD.bazel
+++ b/tools/performance/BUILD.bazel
@@ -12,6 +12,7 @@ load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = [
     # All benchmarks should be in folders named "benchmarking".
+    "//common/symbolic/benchmarking:__pkg__",
     "//geometry/benchmarking:__pkg__",
     "//multibody/benchmarking:__pkg__",
     "//solvers/benchmarking:__pkg__",


### PR DESCRIPTION
Resolves #17700

Also add benchmark Polynomial::EvaluatePartial.

Before this change
```
-----------------------------------------------------------------------------
Benchmark                                   Time             CPU   Iterations
-----------------------------------------------------------------------------
BenchmarkPolynomialEvaluatePartial  731970787 ns    731922688 ns            1
-----------------------------------------------------------------------------
```
After this change
```
Benchmark                                   Time             CPU   Iterations
-----------------------------------------------------------------------------
BenchmarkPolynomialEvaluatePartial    2896414 ns      2896364 ns          246
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17701)
<!-- Reviewable:end -->
