### PR TITLE
[geometry] QueryObject returns deformable contact results

### DIFF
--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -502,7 +502,7 @@ class GeometryState {
 
   /** Implementation of QueryObject::ComputeDeformableRigidContact().  */
   template <typename T1 = T>
-  typename std::enable_if_t<scalar_predicate<T1>::is_bool, void>
+  typename std::enable_if_t<std::is_same_v<T1, double>, void>
   ComputeDeformableRigidContact(
       std::vector<internal::DeformableRigidContact<T>>*
           deformable_rigid_contact) const {
@@ -753,6 +753,14 @@ class GeometryState {
   // Method that updates the proximity engine and the render engines with the
   // up-to-date _pose_ data in `kinematics_data`.
   void FinalizePoseUpdate(
+      const internal::KinematicsData<T>& kinematics_data,
+      internal::ProximityEngine<T>* proximity_engine,
+      std::vector<render::RenderEngine*> render_engines) const;
+
+  // Method that updates the proximity engine and the render engines with the
+  // up-to-date _configuration_ data in `kinematics_data`. Currently, nothing is
+  // propagated to the render engines yet.
+  void FinalizeConfigurationUpdate(
       const internal::KinematicsData<T>& kinematics_data,
       internal::ProximityEngine<T>* proximity_engine,
       std::vector<render::RenderEngine*> render_engines) const;

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -281,6 +281,16 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
 
   void AddDeformableGeometry(const VolumeMesh<double>& mesh_W, GeometryId id) {
     geometries_for_deformable_contact_.AddDeformableGeometry(id, mesh_W);
+    // Currently, even though no collision filtering is done for deformable
+    // geometries, the collision filter still needs to be aware of the existence
+    // of deformable geometries. This is because collision filters implicitly
+    // assumes that it is aware of all geometries registered with the proximity
+    // engine.
+    // Currently, all deformable geometries are registered with the world
+    // frame, if the collision filter isn't aware of the geometry, we will
+    // trigger an assertion when adding geometries whose collision with
+    // world-framed geometries are filtered out.
+    collision_filter_.AddGeometry(id);
   }
 
   void UpdateRepresentationForNewProperties(

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -496,9 +496,10 @@ void SceneGraph<T>::CalcConfigurationUpdate(const Context<T>& context,
       }
     }
   }
-  // TODO(xuchenhan-tri): Similar to the implementation of CalcPoseUpdate, a
-  // FinalizeConfigurationUpdate() is needed to propagate the change to
-  // proximity engine and render engine.
+
+  state.FinalizeConfigurationUpdate(kinematics_data,
+                                    &state.mutable_proximity_engine(),
+                                    state.GetMutableRenderEngines());
 }
 
 template <typename T>

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -88,6 +88,10 @@ class QueryObject;
  See the details in KinematicsVector for details on how to provide values for
  this port.
 
+ <!-- TODO(xuchenhan-tri): Consider adding some clarification about
+  "configuration" as in "deformable vertex positions" compared to
+  "configuration" as in articulated rigid-body configurations (and that we use
+  the word to exclusively mean the former in SceneGraph). -->
  __configuration port__: An abstract-valued port providing an instance of
  GeometryConfigurationVector. For each registered deformable geometry, this
  "configuration vector" maps the registered GeometryId to its world space
@@ -842,7 +846,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
    Rather than modifying %SceneGraph's model, it modifies the copy of the model
    stored in the provided context.  */
   int RemoveRole(systems::Context<T>* context, SourceId source_id,
-                  FrameId frame_id, Role role) const;
+                 FrameId frame_id, Role role) const;
 
   /** Removes the indicated `role` from the geometry indicated by `geometry_id`.
    Potentially modifies the proximity, perception, or illustration version based
@@ -864,7 +868,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
    geometries. Rather than modifying %SceneGraph's model, it modifies the copy
    of the model stored in the provided context.  */
   int RemoveRole(systems::Context<T>* context, SourceId source_id,
-                  GeometryId geometry_id, Role role) const;
+                 GeometryId geometry_id, Role role) const;
 
   //@}
 

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -9,6 +9,7 @@
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/geometry_state.h"
+#include "drake/geometry/internal_frame.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/math/rigid_transform.h"
 
@@ -175,6 +176,10 @@ TEST_F(QueryObjectTest, DefaultQueryThrows) {
   std::vector<PenetrationAsPointPair<double>> point_pairs;
   EXPECT_DEFAULT_ERROR(default_object.ComputeContactSurfacesWithFallback(
       representation, &surfaces, &point_pairs));
+  std::vector<internal::DeformableRigidContact<double>>
+      deformable_rigid_contact;
+  EXPECT_DEFAULT_ERROR(
+      default_object.ComputeDeformableRigidContact(&deformable_rigid_contact));
 
   // Signed distance queries.
   EXPECT_DEFAULT_ERROR(
@@ -231,45 +236,70 @@ TEST_F(QueryObjectTest, CreateValidInspector) {
   EXPECT_EQ(inspector.GetFrameId(geometry_id), frame_id);
 }
 
-// This test confirms that the copied (aka baked) query object has its pose
-// data properly baked. This is confirmed by a great deal of convoluted
-// trickery.
+// This test confirms that the copied (aka baked) query object has its pose and
+// configuration data properly baked. This is confirmed by a great deal of
+// convoluted trickery.
 TEST_F(QueryObjectTest, BakedCopyHasFullUpdate) {
   SourceId s_id = scene_graph_.RegisterSource("BakeTest");
   FrameId frame_id = scene_graph_.RegisterFrame(s_id, GeometryFrame("frame"));
+
+  auto deformable_geometry = make_unique<GeometryInstance>(
+      RigidTransformd::Identity(), make_unique<Sphere>(1.0), "deformable");
+  // Make sure the resolution hint is large enough so that we know that the
+  // volume mesh is a octahedron.
+  GeometryId g_id = scene_graph_.RegisterDeformableGeometry(
+      s_id, internal::InternalFrame::world_frame_id(),
+      std::move(deformable_geometry), 10.0);
   unique_ptr<Context<double>> context = scene_graph_.CreateDefaultContext();
+
   RigidTransformd X_WF{Vector3d{1, 2, 3}};
   FramePoseVector<double> poses{{frame_id, X_WF}};
   scene_graph_.get_source_pose_port(s_id).FixValue(context.get(), poses);
+
+  const int kNumVertices = 7;
+  const int kNumDofs = kNumVertices * 3;
+  const VectorX<double> q_WG = Eigen::VectorXd::LinSpaced(0.0, 1.0, kNumDofs);
+  GeometryConfigurationVector<double> configurations{{g_id, q_WG}};
+  scene_graph_.get_source_configuration_port(s_id).FixValue(context.get(),
+                                                            configurations);
+
   const auto& query_object =
       scene_graph_.get_query_output_port().Eval<QueryObject<double>>(*context);
   EXPECT_TRUE(is_live(query_object));
 
   // Here's the convoluted trickery. We examine the state that's embedded in
-  // the context of the live query object. It *hasn't* updated poses at all.
-  // So, if we ask for the world pose of frame_id, it will *not* be at X_WF.
-  // However, when we copy the query_object, the same query on its state
-  // *will* return that value (showing that the copy has the updated poses).
-
+  // the context of the live query object. It *hasn't* updated
+  // poses/configurations at all. So, if we ask for the world pose of frame_id,
+  // it will *not* be at X_WF. Similarly, if we ask for the configuration of
+  // g_id, it will *not* be q_WG. However, when we copy the query_object, the
+  // same query on its state *will* return those values (showing that the copy
+  // has the updated poses).
   const GeometryState<double>& state = get_state(query_object);
   const auto& stale_pose = state.get_pose_in_world(frame_id);
+  const auto& stale_configuration = state.get_configurations_in_world(g_id);
   // Confirm the live state hasn't been updated yet.
   EXPECT_FALSE(
       CompareMatrices(stale_pose.GetAsMatrix34(), X_WF.GetAsMatrix34()));
+  EXPECT_FALSE(CompareMatrices(stale_configuration, q_WG));
 
   const QueryObject<double> baked(query_object);
 
   const GeometryState<double>& baked_state = get_state(baked);
   const auto& baked_pose = baked_state.get_pose_in_world(frame_id);
+  const auto& baked_configuration =
+      baked_state.get_configurations_in_world(g_id);
   EXPECT_TRUE(
       CompareMatrices(baked_pose.GetAsMatrix34(), X_WF.GetAsMatrix34()));
-  // And the previously stale pose is now updated as a pre-cursor to the baked
-  // copy.
+  EXPECT_TRUE(CompareMatrices(baked_configuration, q_WG));
+  // And the previously stale pose/configuration is now updated as a pre-cursor
+  // to the baked copy.
   EXPECT_TRUE(
       CompareMatrices(stale_pose.GetAsMatrix34(), X_WF.GetAsMatrix34()));
+  EXPECT_TRUE(CompareMatrices(stale_configuration, q_WG));
 
   // These really are different objects.
   EXPECT_NE(&stale_pose, &baked_pose);
+  EXPECT_NE(&stale_configuration, &baked_configuration);
 }
 
 // Ensure that I can construct a QueryObject with the default scalar types.


### PR DESCRIPTION
Towards #16875.

- Add ComputeDeformableRigidContact() function to QueryObject.
- Add GeometryState::FinalizeConfigurationUpdate() that propagates any configuration changes to ProximityEngine.
- Inform collision filters of deformable geometries even though no deformable contact is ever filtered.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17705)
<!-- Reviewable:end -->
