### PR TITLE
[framework] Updating context-system mismatch error messages

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -978,6 +978,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "system_base_test",
     deps = [
+        ":discrete_values",
         ":system_base",
         "//common:essential",
         "//common/test_utilities:expect_no_throw",

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -791,6 +791,34 @@ TEST_F(DiagramTest, Path) {
             diagram_->GetSystemPathname());
 }
 
+// Tests the special cases in ValidateContext() that recognize if the context
+// or system is the root.
+TEST_F(DiagramTest, ValidateContext) {
+  // Root diagram given root context.
+  DRAKE_EXPECT_NO_THROW(diagram_->ValidateContext(*context_));
+
+  // Internal system given root diagram's context.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      adder0()->ValidateContext(*context_),
+      ".*was passed the root Diagram's Context.+GetMyContextFromRoot"
+      "[^]*troubleshooting.html.+");
+
+  // Root diagram given context for internal system.
+  const auto& adder_context = adder0()->GetMyContextFromRoot(*context_);
+  DRAKE_EXPECT_THROWS_MESSAGE(diagram_->ValidateContext(adder_context),
+                              ".*root Diagram was passed a subcontext"
+                              "[^]*troubleshooting.html.+");
+
+  // And for the sake of completeness, one leaf system's context passed to
+  // another leaf system.
+  const auto& integrator0_context =
+      integrator0()->GetMyContextFromRoot(*context_);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      integrator1()->ValidateContext(integrator0_context),
+      "A function call on .+ system named '.+' was passed the Context of a "
+      "system named '.+'[^]*troubleshooting.html.+");
+}
+
 TEST_F(DiagramTest, Graphviz) {
   const std::string id = std::to_string(
       reinterpret_cast<int64_t>(diagram_.get()));

--- a/systems/framework/test/system_base_test.cc
+++ b/systems/framework/test/system_base_test.cc
@@ -75,8 +75,9 @@ GTEST_TEST(SystemBaseTest, NameAndMessageSupport) {
   // Test specialized ValidateContext() and more-general
   // ValidateCreatedForThisSystem() which can check anything that supports
   // a get_system_id() method (we'll just use Context here for that also
-  // since it qualifies). Both methods have pointer and non-pointer variants
-  // but should ignore that distinction in the error message.
+  // since it qualifies). We should ignore the differences in the error messages
+  // between the two functions. Both methods have pointer and non-pointer
+  // variants, so we exercise both.
 
   std::unique_ptr<ContextBase> context = system.AllocateContext();
   DRAKE_EXPECT_NO_THROW(system.ValidateContext(*context));
@@ -86,10 +87,14 @@ GTEST_TEST(SystemBaseTest, NameAndMessageSupport) {
 
   MySystemBase other_system;
   auto other_context = other_system.AllocateContext();
+  // N.B. the error message we're looking for in ValidateContext() should *not*
+  // indicate that the system (or the context) is a root system/context.
   DRAKE_EXPECT_THROWS_MESSAGE(system.ValidateContext(*other_context),
-                              ".*Context.*was not created for.*");
+                              ".+call on a .+ system.+was passed the Context "
+                              "of[^]*#framework-context-system-mismatch.*");
   DRAKE_EXPECT_THROWS_MESSAGE(system.ValidateContext(other_context.get()),
-                              ".*Context.*was not created for.*");
+                              ".+call on a .+ system.+was passed the Context "
+                              "of[^]*#framework-context-system-mismatch.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       system.ValidateCreatedForThisSystem(*other_context),
       ".*ContextBase.*was not created for.*MySystemBase.*any_name_will_do.*");

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -289,9 +289,9 @@ TEST_F(SystemTest, ContextBelongsWithSystem) {
   // These just uses a couple of arbitrary methods to test that a Context not
   // created by a System throws the appropriate exception.
   DRAKE_EXPECT_THROWS_MESSAGE(system2.Publish(*context_),
-                              "Context was not created for.*");
+                              "[^]*#framework-context-system-mismatch.*");
   DRAKE_EXPECT_THROWS_MESSAGE(system2.SetDefaultContext(context_.get()),
-                              "Context was not created for.*");
+                              "[^]*#framework-context-system-mismatch.*");
 }
 
 TEST_F(SystemTest, MapVelocityToConfigurationDerivatives) {

--- a/systems/primitives/test/vector_log_sink_test.cc
+++ b/systems/primitives/test/vector_log_sink_test.cc
@@ -40,7 +40,7 @@ GTEST_TEST(TestVectorLogSink, LogFinders) {
             &(dut->FindMutableLog(diagram_context.get())));
 
   DRAKE_EXPECT_THROWS_MESSAGE(dut->GetLog(*diagram_context),
-                              ".*Context was not created for.*");
+                              ".*was passed the root Diagram's Context[^]*");
   DRAKE_EXPECT_THROWS_MESSAGE(dut->FindLog(logger_context),
                               ".*given context must be a root context.*");
 }
@@ -59,9 +59,9 @@ GTEST_TEST(TestVectorLogSink, LogFindersWrongContext) {
 
   // Both access methods fail context validation.
   DRAKE_EXPECT_THROWS_MESSAGE(dut->GetLog(*wrong_diagram_context),
-                              ".*Context was not created for.*");
+                              ".*was passed the Context of .+ instead[^]*");
   DRAKE_EXPECT_THROWS_MESSAGE(dut->FindLog(*wrong_diagram_context),
-                              ".*Context was not created for.*");
+                              ".*was passed the Context of .+ instead[^]*");
 }
 
 // Log the output of a simple linear system (with a known solution).


### PR DESCRIPTION
When validating contexts against systems, we've added a bit more analysis for recognizing whether the system or the context are the root and provide custom messages reflecting that.

Furthermore, all error messages for `Context` validation include a URL in the troubleshooting webpage to provide elaboration.

To that end:
 - Change logic in `ValidateContext()` for special cases.
 - Change `ValidateCreatedForThisSystem()` to redirect to `ValidateContext()` for contexts.
 - Write the troubleshooting entry.
 - Tests
   - For dependency reasons, the testing is distributed over two test files. `system_base_test.cc` avoids dependencies on diagram-level constructs. So, `diagram_test.cc` gets those tests.

closes #17265

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17711)
<!-- Reviewable:end -->
