### PR TITLE
Removes anachronistic gflag declaration

### DIFF
--- a/common/test_utilities/drake_cc_googletest_main.cc
+++ b/common/test_utilities/drake_cc_googletest_main.cc
@@ -4,14 +4,6 @@
 #include <gflags/gflags.h>
 #include <gmock/gmock.h>
 
-// TODO(SeanCurtis-TRI): Remove this when CLion bazel plug-in no longer executes
-// its debugger with the --gunit_color flag. Most recent versions known to be
-// an issue:
-//    CLion: 2017.1.3
-//    Bazel plugin: 2017.07.05.0.2
-// Related issue: https://github.com/bazelbuild/intellij/issues/131
-DEFINE_string(gunit_color, "", "");
-
 int main(int argc, char** argv) {
   std::cout << "Using drake_cc_googletest_main.cc\n";
 


### PR DESCRIPTION
CLion was passing a "bad" flag into gtest executions for debugging. This code provided a shim to allow that flag to be processed for drake's unit tests.

Clion has updated their code such that this shim should not be necessary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17718)
<!-- Reviewable:end -->
