### PR TITLE
Work around test error in coverage builds (kcov 339)

### DIFF
--- a/multibody/contact_solvers/sap/test/sap_friction_cone_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_friction_cone_constraint_test.cc
@@ -24,6 +24,7 @@ namespace drake {
 namespace multibody {
 namespace contact_solvers {
 namespace internal {
+namespace kcov339_avoidance_magic {
 namespace {
 
 // These Jacobian matrices have arbitrary values for testing. We specify the
@@ -384,6 +385,7 @@ GTEST_TEST(SapFrictionConeConstraint, TwoCliquesConstraintClone) {
 }
 
 }  // namespace
+}  // namespace kcov339_avoidance_magic
 }  // namespace internal
 }  // namespace contact_solvers
 }  // namespace multibody


### PR DESCRIPTION
Add a dummy namespace to perturb the elf header.

Try same trick as #17071.

Fixes CI job: https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-focal-clang-bazel-nightly-coverage/801/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17724)
<!-- Reviewable:end -->
