### PR TITLE
Use kLorentzConeSlack in CsdpSolver when removing free variable.

### DIFF
--- a/solvers/csdp_solver_common.cc
+++ b/solvers/csdp_solver_common.cc
@@ -17,7 +17,7 @@ CsdpSolver::CsdpSolver(RemoveFreeVariableMethod method)
 
 CsdpSolver::CsdpSolver()
     : SolverBase(&id, &is_available, &is_enabled, &ProgramAttributesSatisfied),
-      method_{RemoveFreeVariableMethod::kNullspace} {}
+      method_{RemoveFreeVariableMethod::kLorentzConeSlack} {}
 
 CsdpSolver::~CsdpSolver() = default;
 

--- a/solvers/test/csdp_solver_test.cc
+++ b/solvers/test/csdp_solver_test.cc
@@ -12,6 +12,27 @@
 namespace drake {
 namespace solvers {
 namespace {
+GTEST_TEST(CsdpTest, TestNoLinearConstraintOnFreeVariable) {
+  // Solve a program with no linear constraint on the free variables.
+  // This program is reported in
+  // https://github.com/RobotLocomotion/drake/issues/16732#issuecomment-1214176554
+  MathematicalProgram prog;
+  const auto x = prog.NewIndeterminates<2>("x");
+  Eigen::Matrix2d P;
+  P << 1.5, -0.5, -0.5, 1;
+  const int l_degree = 4;
+  symbolic::Polynomial l;
+  std::tie(l, std::ignore) =
+      prog.NewSosPolynomial(symbolic::Variables(x), l_degree);
+  const auto rho = prog.NewContinuousVariables(1, "rho")(0);
+
+  CsdpSolver solver;
+  if (solver.available()) {
+    auto result = solver.Solve(prog);
+    EXPECT_TRUE(result.is_success());
+  }
+}
+
 GTEST_TEST(TestSemidefiniteProgram, SolveSDPwithOverlappingVariables) {
   CsdpSolver solver;
   if (solver.available()) {


### PR DESCRIPTION
Previously it uses kNullspace. While this approach might generate smaller-size SDP, it could lead to empty program when there is only free variable with no linear constraint. By removing these free variables the program has no constraints or variables, and CSDP will crash.

Resolves #16732

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17728)
<!-- Reviewable:end -->
