### PR TITLE
[workspace] Support fmt v9 on macOS

### DIFF
--- a/tools/install/libdrake/header_lint.bzl
+++ b/tools/install/libdrake/header_lint.bzl
@@ -23,6 +23,7 @@ _ALLOWED_EXTERNALS = [
 # permitted here are definitions required by the _ALLOWED_EXTERNALS, above.
 _ALLOWED_DEFINES = [
     "EIGEN_MPL2_ONLY",
+    "FMT_DEPRECATED_OSTREAM=1",
     "FMT_HEADER_ONLY=1",
     "FMT_NO_FMT_STRING_ALIAS=1",
     "HAVE_SPDLOG",

--- a/tools/workspace/fmt/repository.bzl
+++ b/tools/workspace/fmt/repository.bzl
@@ -52,6 +52,9 @@ load("@drake//tools/install:install.bzl", "install")
 install(name = "install")
             """,
         ),
+        "extra_defines": attr.string_list(
+            default = ["FMT_DEPRECATED_OSTREAM=1"],
+        ),
         # The remaining attributes are used only when we take the branch for
         # setup_github_repository in the above logic.
         "repository": attr.string(


### PR DESCRIPTION
Fixes #17732.

See also `FMT_DEPRECATED_OSTREAM` in the release notes: https://github.com/fmtlib/fmt/releases/tag/9.0.0

Homebrew has updated to fmt 9, but drake's use of `fmt` relies on the deprecated ostream behavior.  Eventually drake will need to stop relying on fmt automatically discovering `std::ostream operator<<` and either specialize `fmt::formatter` to inherit from `ostream_formatter` or for simple things like `GeometryId id` we can use `id.get_value()`.

This should work with current provisioned AND unprovisioned macOS CI, currently provisioned macOS is using fmt 8.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17739)
<!-- Reviewable:end -->
