### PR TITLE
Refactors SAP code outside of CompliantContactManager

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -20,6 +20,7 @@ drake_cc_package_library(
         ":calc_distance_and_time_derivative",
         ":constraint_specs",
         ":contact_jacobians",
+        ":contact_pair_kinematics",
         ":contact_results",
         ":coulomb_friction",
         ":discrete_contact_pair",
@@ -94,6 +95,7 @@ drake_cc_library(
         "make_discrete_update_manager.cc",
         "multibody_plant.cc",
         "physical_model.cc",
+        "sap_driver.cc",
     ],
     hdrs = [
         "compliant_contact_manager.h",
@@ -105,12 +107,14 @@ drake_cc_library(
         "multibody_plant_discrete_update_manager_attorney.h",
         "multibody_plant_model_attorney.h",
         "physical_model.h",
+        "sap_driver.h",
         "scalar_convertible_component.h",
     ],
     visibility = ["//visibility:private"],
     deps = [
         ":constraint_specs",
         ":contact_jacobians",
+        ":contact_pair_kinematics",
         ":contact_results",
         ":coulomb_friction",
         ":discrete_contact_pair",
@@ -147,6 +151,32 @@ drake_cc_library(
     deps = [
         "//common:default_scalars",
         "//geometry/query_results:penetration_as_point_pair",
+        "//multibody/tree:multibody_tree_indexes",
+    ],
+)
+
+drake_cc_library(
+    name = "compliant_contact_manager_tester",
+    testonly = 1,
+    srcs = [],
+    hdrs = ["test/compliant_contact_manager_tester.h"],
+    deps = [
+        ":multibody_plant_core",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "contact_pair_kinematics",
+    srcs = [
+        "contact_pair_kinematics.cc",
+    ],
+    hdrs = [
+        "contact_pair_kinematics.h",
+    ],
+    deps = [
+        "//common:default_scalars",
+        "//math:geometric_transform",
         "//multibody/tree:multibody_tree_indexes",
     ],
 )
@@ -345,6 +375,18 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "spheres_stack",
+    testonly = 1,
+    srcs = [],
+    hdrs = ["test/spheres_stack.h"],
+    deps = [
+        ":multibody_plant_config",
+        ":multibody_plant_core",
+        "//systems/framework:diagram_builder",
+    ],
+)
+
 drake_cc_googletest(
     name = "compliant_contact_manager_scalar_conversion_test",
     deps = [
@@ -357,18 +399,51 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "compliant_contact_manager_test",
-    data = [
-        "//manipulation/models/iiwa_description:models",
-        "//manipulation/models/wsg_50_description:models",
-    ],
     deps = [
+        ":compliant_contact_manager_tester",
         ":plant",
+        ":spheres_stack",
         "//common:find_resource",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//multibody/parsing",
         "//systems/primitives:pass_through",
         "//systems/primitives:zero_order_hold",
+    ],
+)
+
+drake_cc_googletest(
+    name = "sap_driver_test",
+    deps = [
+        ":compliant_contact_manager_tester",
+        ":plant",
+        ":spheres_stack",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "sap_driver_joint_limits_test",
+    data = [
+        "//manipulation/models/iiwa_description:models",
+        "//manipulation/models/wsg_50_description:models",
+    ],
+    deps = [
+        ":compliant_contact_manager_tester",
+        ":plant",
+        "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//multibody/parsing",
+    ],
+)
+
+drake_cc_googletest(
+    name = "sap_driver_multidof_joints_test",
+    deps = [
+        ":compliant_contact_manager_tester",
+        ":plant",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 
@@ -704,6 +779,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "deformable_driver_test",
     deps = [
+        ":compliant_contact_manager_tester",
         ":multibody_plant_core",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -5,7 +5,6 @@
 #include <memory>
 #include <string>
 #include <utility>
-#include <variant>
 #include <vector>
 
 #include "drake/common/eigen_types.h"
@@ -13,33 +12,14 @@
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/proximity_properties.h"
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
-#include "drake/math/rotation_matrix.h"
-#include "drake/multibody/contact_solvers/contact_solver_utils.h"
-#include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
-#include "drake/multibody/contact_solvers/sap/sap_friction_cone_constraint.h"
-#include "drake/multibody/contact_solvers/sap/sap_holonomic_constraint.h"
-#include "drake/multibody/contact_solvers/sap/sap_limit_constraint.h"
-#include "drake/multibody/contact_solvers/sap/sap_solver.h"
-#include "drake/multibody/contact_solvers/sap/sap_solver_results.h"
-#include "drake/multibody/plant/deformable_model.h"
 #include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/sap_driver.h"
 #include "drake/multibody/triangle_quadrature/gaussian_triangle_quadrature_rule.h"
 #include "drake/systems/framework/context.h"
 
 using drake::geometry::GeometryId;
 using drake::geometry::PenetrationAsPointPair;
-using drake::math::RotationMatrix;
 using drake::multibody::contact_solvers::internal::ContactSolverResults;
-using drake::multibody::contact_solvers::internal::ExtractNormal;
-using drake::multibody::contact_solvers::internal::ExtractTangent;
-using drake::multibody::contact_solvers::internal::SapConstraint;
-using drake::multibody::contact_solvers::internal::SapContactProblem;
-using drake::multibody::contact_solvers::internal::SapFrictionConeConstraint;
-using drake::multibody::contact_solvers::internal::SapHolonomicConstraint;
-using drake::multibody::contact_solvers::internal::SapLimitConstraint;
-using drake::multibody::contact_solvers::internal::SapSolver;
-using drake::multibody::contact_solvers::internal::SapSolverResults;
-using drake::multibody::contact_solvers::internal::SapSolverStatus;
 using drake::multibody::internal::DiscreteContactPair;
 using drake::multibody::internal::MultibodyTreeTopology;
 using drake::systems::Context;
@@ -58,7 +38,17 @@ AccelerationsDueToExternalForcesCache<T>::AccelerationsDueToExternalForcesCache(
       ac(topology) {}
 
 template <typename T>
-CompliantContactManager<T>::~CompliantContactManager() {}
+CompliantContactManager<T>::CompliantContactManager() = default;
+
+template <typename T>
+CompliantContactManager<T>::~CompliantContactManager() = default;
+
+template <typename T>
+void CompliantContactManager<T>::set_sap_solver_parameters(
+    const contact_solvers::internal::SapSolverParameters& parameters) {
+  DRAKE_DEMAND(sap_driver_ != nullptr);
+  sap_driver_->set_sap_solver_parameters(parameters);
+}
 
 template <typename T>
 void CompliantContactManager<T>::DeclareCacheEntries() {
@@ -98,19 +88,13 @@ void CompliantContactManager<T>::DeclareCacheEntries() {
   cache_indexes_.non_contact_forces_accelerations =
       non_contact_forces_accelerations_cache_entry.cache_index();
 
-  const auto& contact_problem_cache_entry = this->DeclareCacheEntry(
-      "Contact Problem.",
-      systems::ValueProducer(
-          this, ContactProblemCache<T>(plant().time_step()),
-          &CompliantContactManager<T>::CalcContactProblemCache),
-      {plant().cache_entry_ticket(cache_indexes_.discrete_contact_pairs)});
-  cache_indexes_.contact_problem = contact_problem_cache_entry.cache_index();
-
   if constexpr (std::is_same_v<T, double>) {
     if (deformable_driver_ != nullptr) {
       deformable_driver_->DeclareCacheEntries(this);
     }
   }
+
+  if (sap_driver_ != nullptr) sap_driver_->DeclareCacheEntries(this);
 }
 
 template <typename T>
@@ -118,7 +102,7 @@ std::vector<ContactPairKinematics<T>>
 CompliantContactManager<T>::CalcContactKinematics(
     const systems::Context<T>& context) const {
   const std::vector<DiscreteContactPair<T>>& contact_pairs =
-      EvalDiscreteContactPairs(context);
+      this->EvalDiscreteContactPairs(context);
   const int num_contacts = contact_pairs.size();
   std::vector<ContactPairKinematics<T>> contact_kinematics;
   contact_kinematics.reserve(num_contacts);
@@ -523,8 +507,7 @@ void CompliantContactManager<T>::CalcNonContactForcesExcludingJointLimits(
 template <typename T>
 void CompliantContactManager<T>::CalcAccelerationsDueToNonContactForcesCache(
     const systems::Context<T>& context,
-    AccelerationsDueToExternalForcesCache<T>* forward_dynamics_cache)
-    const {
+    AccelerationsDueToExternalForcesCache<T>* forward_dynamics_cache) const {
   DRAKE_DEMAND(forward_dynamics_cache != nullptr);
   ScopeExit guard = this->ThrowIfNonContactForceInProgress(context);
 
@@ -580,52 +563,6 @@ void CompliantContactManager<T>::CalcAccelerationsDueToNonContactForcesCache(
 }
 
 template <typename T>
-void CompliantContactManager<T>::CalcFreeMotionVelocities(
-    const systems::Context<T>& context, VectorX<T>* v_star) const {
-  DRAKE_DEMAND(v_star != nullptr);
-  // N.B. Forces are evaluated at the previous time step state. This is
-  // consistent with the explicit Euler and symplectic Euler schemes.
-  // TODO(amcastro-tri): Implement free-motion velocities update based on the
-  // theta-method, as in the SAP paper.
-  const VectorX<T>& vdot0 =
-      EvalAccelerationsDueToNonContactForcesCache(context).get_vdot();
-  const double dt = this->plant().time_step();
-  const VectorX<T>& x0 =
-      context.get_discrete_state(this->multibody_state_index()).value();
-  const auto v0 = x0.bottomRows(this->plant().num_velocities());
-  *v_star = v0 + dt * vdot0;
-}
-
-template <typename T>
-void CompliantContactManager<T>::CalcLinearDynamicsMatrix(
-    const systems::Context<T>& context, std::vector<MatrixX<T>>* A) const {
-  DRAKE_DEMAND(A != nullptr);
-  A->resize(tree_topology().num_trees());
-  const int nv = plant().num_velocities();
-
-  // TODO(amcastro-tri): consider placing the computation of the dense mass
-  // matrix in a cache entry to minimize heap allocations or better yet,
-  // implement a MultibodyPlant method to compute the per-tree mass matrices.
-  MatrixX<T> M(nv, nv);
-  plant().CalcMassMatrix(context, &M);
-
-  // The manager solves free motion velocities using a discrete scheme with
-  // implicit joint dissipation. That is, it solves the momentum valance:
-  //   m(v) = (M + dt⋅D)⋅(v-v₀)/dt - k(x₀) = 0
-  // where k(x₀) are all the non-constraint forces such as Coriolis terms and
-  // external actuation, evaluated at the previous state x₀.
-  // The dynamics matrix is defined as:
-  //   A = ∂m/∂v = (M + dt⋅D)
-  M.diagonal() += plant().time_step() * joint_damping_;
-
-  for (TreeIndex t(0); t < tree_topology().num_trees(); ++t) {
-    const int tree_start = tree_topology().tree_velocities_start(t);
-    const int tree_nv = tree_topology().num_tree_velocities(t);
-    (*A)[t] = M.block(tree_start, tree_start, tree_nv, tree_nv);
-  }
-}
-
-template <typename T>
 const std::vector<DiscreteContactPair<T>>&
 CompliantContactManager<T>::EvalDiscreteContactPairs(
     const systems::Context<T>& context) const {
@@ -648,336 +585,12 @@ template <typename T>
 void CompliantContactManager<T>::DoCalcContactSolverResults(
     const systems::Context<T>& context,
     ContactSolverResults<T>* contact_results) const {
-  const ContactProblemCache<T>& contact_problem_cache =
-      EvalContactProblemCache(context);
-  const SapContactProblem<T>& sap_problem = *contact_problem_cache.sap_problem;
-
-  // We use the velocity stored in the current context as initial guess.
-  const VectorX<T>& x0 =
-      context.get_discrete_state(this->multibody_state_index()).value();
-  const auto v0 = x0.bottomRows(this->plant().num_velocities());
-
-  // Solve contact problem.
-  SapSolver<T> sap;
-  sap.set_parameters(sap_parameters_);
-  SapSolverResults<T> sap_results;
-  const SapSolverStatus status =
-      sap.SolveWithGuess(sap_problem, v0, &sap_results);
-  if (status != SapSolverStatus::kSuccess) {
-    const std::string msg = fmt::format(
-        "The SAP solver failed to converge at simulation time = {}. "
-        "Reasons for divergence and possible solutions include:\n"
-        "  1. Externally applied actuation values diverged due to external "
-        "     reasons to the solver. Revise your control logic.\n"
-        "  2. External force elements such as spring or bushing elements can "
-        "     lead to unstable temporal dynamics if too stiff. Revise your "
-        "     model and consider whether these forces can be better modeled "
-        "     using one of SAP's compliant constraints. E.g., use a distance "
-        "     constraint instead of a spring element.\n"
-        "  3. Numerical ill conditioning of the model caused by, for instance, "
-        "     extremely large mass ratios. Revise your model and consider "
-        "     whether very small objects can be removed or welded to larger "
-        "     objects in the model.",
-        context.get_time());
-    throw std::runtime_error(msg);
-  }
-
-  const std::vector<DiscreteContactPair<T>>& discrete_pairs =
-      EvalDiscreteContactPairs(context);
-  const int num_contacts = discrete_pairs.size();
-
-  PackContactSolverResults(sap_problem, num_contacts, sap_results,
-                           contact_results);
-}
-
-template <typename T>
-void CompliantContactManager<T>::PackContactSolverResults(
-    const SapContactProblem<T>& problem, int num_contacts,
-    const SapSolverResults<T>& sap_results,
-    ContactSolverResults<T>* contact_results) const {
-  DRAKE_DEMAND(contact_results != nullptr);
-  contact_results->Resize(plant().num_velocities(), num_contacts);
-  contact_results->v_next = sap_results.v;
-  // The manager adds all contact constraints first and therefore we know the
-  // head of the impulses corresponds to contact impulses.
-  const Eigen::VectorBlock<const VectorX<T>> contact_impulses =
-      sap_results.gamma.head(3 * num_contacts);
-  const Eigen::VectorBlock<const VectorX<T>> contact_velocities =
-      sap_results.vc.head(3 * num_contacts);
-  const double time_step = plant().time_step();
-  ExtractNormal(contact_impulses, &contact_results->fn);
-  ExtractTangent(contact_impulses, &contact_results->ft);
-  contact_results->fn /= time_step;
-  contact_results->ft /= time_step;
-  ExtractNormal(contact_velocities, &contact_results->vn);
-  ExtractTangent(contact_velocities, &contact_results->vt);
-
-  auto& tau_contact = contact_results->tau_contact;
-  tau_contact.setZero();
-  for (int i = 0; i < num_contacts; ++i) {
-    const SapConstraint<T>& c = problem.get_constraint(i);
-    {
-      const TreeIndex t(c.first_clique());
-      const MatrixX<T>& Jic = c.first_clique_jacobian();
-      const int v_start = tree_topology().tree_velocities_start(t);
-      const int nv = tree_topology().num_tree_velocities(t);
-      const auto impulse = contact_impulses.template segment<3>(3 * i);
-      tau_contact.segment(v_start, nv) += Jic.transpose() * impulse;
-    }
-
-    if (c.num_cliques() == 2) {
-      const TreeIndex t(c.second_clique());
-      const MatrixX<T>& Jic = c.second_clique_jacobian();
-      const int v_start = tree_topology().tree_velocities_start(t);
-      const int nv = tree_topology().num_tree_velocities(t);
-      const auto impulse = contact_impulses.template segment<3>(3 * i);
-      tau_contact.segment(v_start, nv) += Jic.transpose() * impulse;
-    }
-  }
-  tau_contact /= time_step;
-}
-
-template <typename T>
-std::vector<RotationMatrix<T>>
-CompliantContactManager<T>::AddContactConstraints(
-    const systems::Context<T>& context, SapContactProblem<T>* problem) const {
-  DRAKE_DEMAND(problem != nullptr);
-
-  // Parameters used by SAP to estimate regularization, see [Castro et al.,
-  // 2021].
-  // TODO(amcastro-tri): consider exposing these parameters.
-  constexpr double beta = 1.0;
-  constexpr double sigma = 1.0e-3;
-
-  const std::vector<DiscreteContactPair<T>>& contact_pairs =
-      EvalDiscreteContactPairs(context);
-  const int num_contacts = contact_pairs.size();
-
-  // Quick no-op exit.
-  if (num_contacts == 0) return std::vector<RotationMatrix<T>>();
-
-  std::vector<ContactPairKinematics<T>> contact_kinematics =
-      CalcContactKinematics(context);
-
-  std::vector<RotationMatrix<T>> R_WC;
-  R_WC.reserve(num_contacts);
-  for (int icontact = 0; icontact < num_contacts; ++icontact) {
-    const auto& discrete_pair = contact_pairs[icontact];
-
-    const T stiffness = discrete_pair.stiffness;
-    const T dissipation_time_scale = discrete_pair.dissipation_time_scale;
-    const T friction = discrete_pair.friction_coefficient;
-    const T phi = contact_kinematics[icontact].phi;
-    const auto& jacobian_blocks = contact_kinematics[icontact].jacobian;
-
-    const typename SapFrictionConeConstraint<T>::Parameters parameters{
-        friction, stiffness, dissipation_time_scale, beta, sigma};
-
-    if (jacobian_blocks.size() == 1) {
-      problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<T>>(
-          jacobian_blocks[0].tree, std::move(jacobian_blocks[0].J), phi,
-          parameters));
-    } else {
-      problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<T>>(
-          jacobian_blocks[0].tree, jacobian_blocks[1].tree,
-          std::move(jacobian_blocks[0].J), std::move(jacobian_blocks[1].J), phi,
-          parameters));
-    }
-    R_WC.emplace_back(std::move(contact_kinematics[icontact].R_WC));
-  }
-  return R_WC;
-}
-
-template <typename T>
-void CompliantContactManager<T>::AddLimitConstraints(
-    const systems::Context<T>& context, const VectorX<T>& v_star,
-    SapContactProblem<T>* problem) const {
-  DRAKE_DEMAND(problem != nullptr);
-
-  constexpr double kInf = std::numeric_limits<double>::infinity();
-
-  // TODO(amcastro-tri): consider exposing these parameters.
-  // "Near-rigid" parameter. See [Castro et al., 2021].
-  constexpr double kBeta = 0.1;
-  // Parameter used to estimate the size of a window [w_l, w_u] within which we
-  // expect the configuration q for a given joint to be in the next time step.
-  // See notes below for details. Dimensionless.
-  constexpr double kLimitWindowFactor = 2.0;
-
-  const double dt = plant().time_step();
-
-  // N.B. MultibodyPlant estimates very conservative (soft) stiffness and
-  // damping parameters to ensure that the explicit treatment of the compliant
-  // forces used to impose limits does not become unstable. SAP however treats
-  // these forces implicitly and therefore these parameters can be tighten for
-  // stiffer limits. Here we set the stiffness parameter to a very high value so
-  // that SAP works in the "near-rigid" regime as described in the SAP paper,
-  // [Castro et al., 2021]. As shown in the SAP paper, a dissipation timescale
-  // of the order of the time step leads to a critically damped constraint.
-  // TODO(amcastro-tri): allow users to specify joint limits stiffness and
-  // damping.
-  const double stiffness = 1.0e12;
-  const double dissipation_time_scale = dt;
-
-  for (JointIndex joint_index(0); joint_index < plant().num_joints();
-       ++joint_index) {
-    const Joint<T>& joint = plant().get_joint(joint_index);
-    // We only support limits for 1 DOF joints for which we know that q̇ = v.
-    if (joint.num_positions() == 1 && joint.num_velocities() == 1) {
-      const double lower_limit = joint.position_lower_limits()[0];
-      const double upper_limit = joint.position_upper_limits()[0];
-      const int velocity_start = joint.velocity_start();
-      const TreeIndex tree_index =
-          tree_topology().velocity_to_tree_index(velocity_start);
-      const int tree_nv = tree_topology().num_tree_velocities(tree_index);
-      const int tree_velocity_start =
-          tree_topology().tree_velocities_start(tree_index);
-      const int tree_dof = velocity_start - tree_velocity_start;
-
-      // Current configuration position.
-      const T& q0 = joint.GetOnePosition(context);
-      const T& v0 = joint.GetOneVelocity(context);
-
-      // Estimate a window size around q0. In order to build a smaller
-      // optimization problem, we only add a constraint if the joint
-      // limits are within this window.
-      using std::abs;
-      using std::max;
-      // delta_q estimates how much q changes in a single time step.
-      // We use the maximum of v0 and v* for a conservative estimation.
-      const T delta_q = dt * max(abs(v0), abs(v_star(velocity_start)));
-      // We use a factor kLimitWindowFactor to look into a larger window. A very
-      // large kLimitWindowFactor means that constraints will always be added
-      // even if they are inactive at the end of the computation. A smaller
-      // kLimitWindowFactor will result in a smaller problem, faster to solve,
-      // though constraints could be missed until the next time step.
-      const T window_lower = q0 - kLimitWindowFactor * delta_q;
-      const T window_upper = q0 + kLimitWindowFactor * delta_q;
-
-      // N.B. window_lower < window_upper by definition.
-      const double ql = lower_limit < window_lower ? -kInf : lower_limit;
-      const double qu = upper_limit > window_upper ? kInf : upper_limit;
-
-      // Constraint is added only when one of ql and qu is finite.
-      if (!std::isinf(ql) || !std::isinf(qu)) {
-        // Create constraint for the current configuration q0.
-        typename SapLimitConstraint<T>::Parameters parameters{
-            ql, qu, stiffness, dissipation_time_scale, kBeta};
-        problem->AddConstraint(std::make_unique<SapLimitConstraint<T>>(
-            tree_index, tree_dof, tree_nv, q0, std::move(parameters)));
-      }
-    } else {
-      // TODO(amcastro-tri): Thus far in Drake we don't have multi-dof joints
-      // with limits, only 1-DOF joints have limits. Therefore here throw an
-      // exception to ensure that when we implement a multi-dof joint with
-      // limits we don't forget to update this code.
-      const VectorX<double>& lower_limits = joint.position_lower_limits();
-      const VectorX<double>& upper_limits = joint.position_upper_limits();
-      if ((lower_limits.array() != -kInf).any() ||
-          (upper_limits.array() != kInf).any()) {
-        throw std::runtime_error(
-            "Limits for joints with more than one degree of freedom are not "
-            "supported. You are getting this exception because a new joint "
-            "type must have been introduced. "
-            "CompliantContactManager::AddLimitConstraints() must be updated to "
-            "support this feature.");
-      }
-    }
-  }
-}
-
-template <typename T>
-void CompliantContactManager<T>::AddCouplerConstraints(
-    const systems::Context<T>& context, SapContactProblem<T>* problem) const {
-  DRAKE_DEMAND(problem != nullptr);
-
-  // Previous time step positions.
-  const VectorX<T> q0 = plant().GetPositions(context);
-
-  // Couplers do not have impulse limits, they are bi-lateral constraints. Each
-  // coupler constraint introduces a single constraint equation.
-  constexpr double kInfinity = std::numeric_limits<double>::infinity();
-  const Vector1<T> gamma_lower(-kInfinity);
-  const Vector1<T> gamma_upper(kInfinity);
-
-  // Stiffness and dissipation are set so that the constraint is in the
-  // "near-rigid" regime, [Castro et al., 2022].
-  const Vector1<T> stiffness(kInfinity);
-  const Vector1<T> relaxation_time(plant().time_step());
-
-  for (const CouplerConstraintSpecs<T>& info :
-       this->coupler_constraints_specs()) {
-    const Joint<T>& joint0 = plant().get_joint(info.joint0_index);
-    const Joint<T>& joint1 = plant().get_joint(info.joint1_index);
-    const int dof0 = joint0.velocity_start();
-    const int dof1 = joint1.velocity_start();
-    const TreeIndex tree0 = tree_topology().velocity_to_tree_index(dof0);
-    const TreeIndex tree1 = tree_topology().velocity_to_tree_index(dof1);
-
-    // Sanity check.
-    DRAKE_DEMAND(tree0.is_valid() && tree1.is_valid());
-
-    // DOFs local to their tree.
-    const int tree_dof0 = dof0 - tree_topology().tree_velocities_start(tree0);
-    const int tree_dof1 = dof1 - tree_topology().tree_velocities_start(tree1);
-
-    // Constraint function defined as g = q₀ - ρ⋅q₁ - Δq, with ρ the gear ratio
-    // and Δq a fixed position offset.
-    const Vector1<T> g0(q0[dof0] - info.gear_ratio * q0[dof1] - info.offset);
-
-    // TODO(amcastro-tri): consider exposing this parameter.
-    const double beta = 0.1;
-
-    const typename SapHolonomicConstraint<T>::Parameters parameters{
-        gamma_lower, gamma_upper, stiffness, relaxation_time, beta};
-
-    if (tree0 == tree1) {
-      const int nv = tree_topology().num_tree_velocities(tree0);
-      MatrixX<T> J = MatrixX<T>::Zero(1, nv);
-      // J = dg/dv
-      J(0, tree_dof0) = 1.0;
-      J(0, tree_dof1) = -info.gear_ratio;
-
-      problem->AddConstraint(std::make_unique<SapHolonomicConstraint<T>>(
-          tree0, g0, J, parameters));
-    } else {
-      const int nv0 = tree_topology().num_tree_velocities(tree0);
-      const int nv1 = tree_topology().num_tree_velocities(tree1);
-      MatrixX<T> J0 = MatrixX<T>::Zero(1, nv0);
-      MatrixX<T> J1 = MatrixX<T>::Zero(1, nv1);
-      J0(0, tree_dof0) = 1.0;
-      J1(0, tree_dof1) = -info.gear_ratio;
-      problem->AddConstraint(std::make_unique<SapHolonomicConstraint<T>>(
-          tree0, tree1, g0, J0, J1, parameters));
-    }
-  }
-}
-
-template <typename T>
-void CompliantContactManager<T>::CalcContactProblemCache(
-    const systems::Context<T>& context, ContactProblemCache<T>* cache) const {
-  SapContactProblem<T>& problem = *cache->sap_problem;
-  std::vector<MatrixX<T>> A;
-  CalcLinearDynamicsMatrix(context, &A);
-  VectorX<T> v_star;
-  CalcFreeMotionVelocities(context, &v_star);
-  problem.Reset(std::move(A), std::move(v_star));
-  // N.B. All contact constraints must be added before any other constraint
-  // types. This manager assumes this ordering of the constraints in order to
-  // extract contact impulses for reporting contact results.
-  // Do not change this order here!
-  cache->R_WC = AddContactConstraints(context, &problem);
-  AddLimitConstraints(context, problem.v_star(), &problem);
-  AddCouplerConstraints(context, &problem);
-}
-
-template <typename T>
-const ContactProblemCache<T>&
-CompliantContactManager<T>::EvalContactProblemCache(
-    const systems::Context<T>& context) const {
-  return plant()
-      .get_cache_entry(cache_indexes_.contact_problem)
-      .template Eval<ContactProblemCache<T>>(context);
+  // TODO(amcastro-tri): Remove this DRAKE_DEMAND when other solvers are
+  // supported.
+  DRAKE_DEMAND(plant().get_discrete_contact_solver() ==
+                   DiscreteContactSolver::kSap &&
+               sap_driver_ != nullptr);
+  sap_driver_->CalcContactSolverResults(context, contact_results);
 }
 
 template <typename T>
@@ -1011,20 +624,22 @@ void CompliantContactManager<T>::DoCalcDiscreteValues(
 template <typename T>
 std::unique_ptr<DiscreteUpdateManager<double>>
 CompliantContactManager<T>::CloneToDouble() const {
+  // Create a manager with default SAP parameters.
   auto clone = std::make_unique<CompliantContactManager<double>>();
-  // N.B. we should copy all members except for those overwritten in
+  // N.B. we should copy/clone all members except for those overwritten in
   // ExtractModelInfo and DeclareCacheEntries.
-  clone->sap_parameters_ = this->sap_parameters_;
+  // E.g. SapParameters for SapDriver won't be the same after the clone.
   return clone;
 }
 
 template <typename T>
 std::unique_ptr<DiscreteUpdateManager<AutoDiffXd>>
 CompliantContactManager<T>::CloneToAutoDiffXd() const {
+  // Create a manager with default SAP parameters.
   auto clone = std::make_unique<CompliantContactManager<AutoDiffXd>>();
-  // N.B. we should copy all members except for those overwritten in
+  // N.B. we should copy/clone all members except for those overwritten in
   // ExtractModelInfo and DeclareCacheEntries.
-  clone->sap_parameters_ = this->sap_parameters_;
+  // E.g. SapParameters for SapDriver won't be the same after the clone.
   return clone;
 }
 
@@ -1038,6 +653,14 @@ void CompliantContactManager<T>::ExtractModelInfo() {
     const int nv = joint.num_velocities();
     joint_damping_.segment(velocity_start, nv) = joint.damping_vector();
   }
+
+  // TODO(amcastro-tri): Remove this DRAKE_DEMAND when other solvers are
+  // supported.
+  DRAKE_DEMAND(plant().get_discrete_contact_solver() ==
+                   DiscreteContactSolver::kSap &&
+               sap_driver_ == nullptr);
+  sap_driver_ = std::make_unique<SapDriver<T>>(this);
+
   // Collect information from each PhysicalModel owned by the plant.
   const std::vector<std::unique_ptr<multibody::internal::PhysicalModel<T>>>&
       physical_models = this->plant().physical_models();
@@ -1060,7 +683,8 @@ void CompliantContactManager<T>::ExtractConcreteModel(
     if (deformable_driver_ != nullptr) {
       throw std::logic_error(
           fmt::format("{}: A deformable model has already been registered. "
-                      "Repeated registration is not allowed.", __func__));
+                      "Repeated registration is not allowed.",
+                      __func__));
     }
     deformable_driver_ =
         std::make_unique<DeformableDriver<double>>(model, this);

--- a/multibody/plant/compliant_contact_manager.h
+++ b/multibody/plant/compliant_contact_manager.h
@@ -4,74 +4,28 @@
 #include <utility>
 #include <vector>
 
-#include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/scene_graph_inspector.h"
-#include "drake/math/rotation_matrix.h"
-#include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
-#include "drake/multibody/contact_solvers/sap/sap_solver.h"
-#include "drake/multibody/contact_solvers/sap/sap_solver_results.h"
+#include "drake/multibody/plant/contact_pair_kinematics.h"
 #include "drake/multibody/plant/deformable_driver.h"
 #include "drake/multibody/plant/discrete_update_manager.h"
 #include "drake/systems/framework/context.h"
 
 namespace drake {
 namespace multibody {
+namespace contact_solvers {
+namespace internal {
+// Forward declaration.
+struct SapSolverParameters;
+}  // namespace internal
+}  // namespace contact_solvers
 namespace internal {
 
-template <typename T>
-struct ContactPairKinematics {
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ContactPairKinematics);
-
-  // Struct to store the block contribution from a given tree to the contact
-  // Jacobian for a contact pair.
-  struct JacobianTreeBlock {
-    DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(JacobianTreeBlock);
-
-    JacobianTreeBlock(TreeIndex tree_in, Matrix3X<T> J_in)
-        : tree(tree_in), J(std::move(J_in)) {}
-
-    // Index of the tree for this block.
-    TreeIndex tree;
-
-    // J.cols() must equal the number of generalized velocities for
-    // the corresponding tree.
-    Matrix3X<T> J;
-  };
-
-  ContactPairKinematics(T phi_in, std::vector<JacobianTreeBlock> jacobian_in,
-                        math::RotationMatrix<T> R_WC_in)
-      : phi(std::move(phi_in)),
-        jacobian(std::move(jacobian_in)),
-        R_WC(std::move(R_WC_in)) {}
-
-  // Signed distance for the given pair. Defined negative for overlapping
-  // bodies.
-  T phi{};
-
-  // TODO(amcastro-tri): consider using absl::InlinedVector since here we know
-  // this has a size of at most 2.
-  // Jacobian for a discrete contact pair stored as individual blocks for each
-  // of the trees participating in the contact. Only one or two trees can
-  // participate in a given contact.
-  std::vector<JacobianTreeBlock> jacobian;
-
-  // Rotation matrix to re-express between contact frame C and world frame W.
-  math::RotationMatrix<T> R_WC;
-};
-
-// CompliantContactManager computes the contact Jacobian J_AcBc_C for the
-// relative velocity at a contact point Co between two geometries A and B,
-// expressed in a contact frame C with Cz coincident with the contact normal.
-// This structure is used to cache the kinematics associated with the contact
-// pairs for a given configuration.
-template <typename T>
-struct ContactJacobianCache {
-  // Vector to store the kinematics for each of the discrete contact pairs.
-  std::vector<ContactPairKinematics<T>> contact_kinematics;
-};
+// Forward declaration.
+template <typename>
+class SapDriver;
 
 // To compute accelerations due to external forces (in particular non-contact
 // forces), we pack forces, ABA cache and accelerations into a single struct
@@ -86,19 +40,6 @@ struct AccelerationsDueToExternalForcesCache {
   std::vector<SpatialForce<T>> Zb_Bo_W;  // Articulated body biases cache.
   multibody::internal::ArticulatedBodyForceCache<T> aba_forces;  // ABA cache.
   multibody::internal::AccelerationKinematicsCache<T> ac;  // Accelerations.
-};
-
-template <typename T>
-struct ContactProblemCache {
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ContactProblemCache);
-  explicit ContactProblemCache(double time_step) {
-    sap_problem =
-        std::make_unique<contact_solvers::internal::SapContactProblem<T>>(
-            time_step);
-  }
-  copyable_unique_ptr<contact_solvers::internal::SapContactProblem<T>>
-      sap_problem;
-  std::vector<math::RotationMatrix<T>> R_WC;
 };
 
 // This class implements the interface given by DiscreteUpdateManager so that
@@ -134,24 +75,27 @@ class CompliantContactManager final
 
   using internal::DiscreteUpdateManager<T>::plant;
 
-  CompliantContactManager() = default;
+  CompliantContactManager();
 
   ~CompliantContactManager() final;
 
   // Sets the parameters to be used by the SAP solver.
+  // @pre plant().get_discrete_contact_solver() == DiscreteContactSolver::kSap.
   void set_sap_solver_parameters(
-      const contact_solvers::internal::SapSolverParameters& parameters) {
-    sap_parameters_ = parameters;
-  }
+      const contact_solvers::internal::SapSolverParameters& parameters);
 
   bool is_cloneable_to_double() const final { return true; }
   bool is_cloneable_to_autodiff() const final { return true; }
 
  private:
+  // TODO(amcastro-tri): Instead of friendship consider another set of class(es)
+  // with tighter functionality. For instance, a class that takes care of
+  // getting proximity properties and creating DiscreteContactPairs.
+  friend class SapDriver<T>;
+
   // Struct used to conglomerate the indexes of cache entries declared by the
   // manager.
   struct CacheIndexes {
-    systems::CacheIndex contact_problem;
     systems::CacheIndex discrete_contact_pairs;
     systems::CacheIndex non_contact_forces_accelerations;
   };
@@ -162,14 +106,13 @@ class CompliantContactManager final
   friend class CompliantContactManager;
 
   // Provide private access for unit testing only.
-  friend class CompliantContactManagerTest;
+  friend class CompliantContactManagerTester;
 
   const MultibodyTreeTopology& tree_topology() const {
     return internal::GetInternalTree(this->plant()).get_topology();
   }
 
-  std::unique_ptr<DiscreteUpdateManager<double>> CloneToDouble()
-      const final;
+  std::unique_ptr<DiscreteUpdateManager<double>> CloneToDouble() const final;
   std::unique_ptr<DiscreteUpdateManager<AutoDiffXd>> CloneToAutoDiffXd()
       const final;
 
@@ -196,6 +139,11 @@ class CompliantContactManager final
   void DoCalcAccelerationKinematicsCache(
       const systems::Context<T>&,
       multibody::internal::AccelerationKinematicsCache<T>*) const final;
+
+  // This method computes sparse kinematics information for each contact pair at
+  // the given configuration stored in `context`.
+  std::vector<ContactPairKinematics<T>> CalcContactKinematics(
+      const systems::Context<T>& context) const;
 
   // Returns the point contact stiffness stored in group
   // geometry::internal::kMaterialGroup with property
@@ -265,22 +213,6 @@ class CompliantContactManager final
   const std::vector<internal::DiscreteContactPair<T>>& EvalDiscreteContactPairs(
       const systems::Context<T>& context) const;
 
-  // This method computes the kinematics information for each contact pair at
-  // the given configuration stored in `context`.
-  std::vector<ContactPairKinematics<T>> CalcContactKinematics(
-      const systems::Context<T>& context) const;
-
-  // Given the previous state x0 stored in `context`, this method computes the
-  // "free motion" velocities, denoted v*.
-  void CalcFreeMotionVelocities(const systems::Context<T>& context,
-                                VectorX<T>* v_star) const;
-
-  // Computes the linearized momentum equation matrix A to build the SAP
-  // contact problem. Refer to SapContactProblem's class documentation for
-  // details.
-  void CalcLinearDynamicsMatrix(const systems::Context<T>& context,
-                                std::vector<MatrixX<T>>* A) const;
-
   // Computes all continuous forces in the MultibodyPlant model. Joint limits
   // are not included as continuous compliant forces but rather as constraints
   // in the solver, and therefore must be excluded.
@@ -300,83 +232,18 @@ class CompliantContactManager final
   EvalAccelerationsDueToNonContactForcesCache(
       const systems::Context<T>& context) const;
 
-  // Computes the necessary data to describe the SAP contact problem. Additional
-  // information such as the orientation of each contact frame in the world is
-  // also computed here so that it can be used at a later stage to compute
-  // contact results.
-  // All contact constraints are added before any other constraint types. This
-  // manager assumes this ordering of the constraints in order to extract
-  // contact impulses for reporting contact results.
-  void CalcContactProblemCache(const systems::Context<T>& context,
-                               ContactProblemCache<T>* cache) const;
-
-  // Eval version of CalcContactProblemCache().
-  const ContactProblemCache<T>& EvalContactProblemCache(
-      const systems::Context<T>& context) const;
-
-  // Add contact constraints for the configuration stored in `context` into
-  // `problem`. This method returns the orientation of the contact frame in the
-  // world frame for each contact constraint added to `problem`. That is, the
-  // i-th entry in the return vector corresponds to the orientation R_WC contact
-  // frame in the world frame for the i-th contact constraint added to
-  // `problem`.
-  std::vector<math::RotationMatrix<T>> AddContactConstraints(
-      const systems::Context<T>& context,
-      contact_solvers::internal::SapContactProblem<T>* problem) const;
-
-  // Add limit constraints for the configuration stored in `context` into
-  // `problem`. Limit constraints are only added when the state q₀ for a
-  // particular joint is "close" to the joint's limits (qₗ,qᵤ). To decide when
-  // the state q₀ is close to the joint's limits, this method estimates a window
-  // (wₗ,wᵤ) for the expected value of the configuration q at the next time
-  // step. Lower constraints are considered whenever qₗ > wₗ and upper
-  // constraints are considered whenever qᵤ < wᵤ. This window (wₗ,wᵤ) is
-  // estimated based on the current velocity v₀ and the free motion velocities
-  // v*, provided with `v_star`.
-  // Since the implementation uses the current velocity v₀ to estimate whether
-  // the constraint should be enabled, it is at least as good as a typical
-  // continuous collision detection method. It could mispredict under conditions
-  // of strong acceleration (it is assuming constant velocity across a step).
-  // Still, at typical robotics step sizes and rates it would be surprising to
-  // see that happen, and if it did the limit would come on in the next step.
-  // TODO(amcastro-tri): Consider using the acceleration at t₀ to get a second
-  // order prediction for the configuration at the next time step.
-  // @pre problem must not be nullptr.
-  void AddLimitConstraints(
-      const systems::Context<T>& context, const VectorX<T>& v_star,
-      contact_solvers::internal::SapContactProblem<T>* problem) const;
-
-  // Adds holonomic constraints to model couplers specified in the
-  // MultibodyPlant.
-  void AddCouplerConstraints(
-      const systems::Context<T>& context,
-      contact_solvers::internal::SapContactProblem<T>* problem) const;
-
-  // This method takes SAP results for a given `problem` and loads forces due to
-  // contact only into `contact_results`. `contact_results` is properly resized
-  // on output.
-  // @pre contact_results is not nullptr.
-  // @pre All `num_contacts` contact constraints in `problem` were added before
-  // any other SAP constraint. This requirement is imposed by this manager which
-  // adds constraints (with AddContactConstraints()) to the contact problem
-  // before any other constraints are added. See the implementation of
-  // CalcContactProblemCache(), who is responsible for adding constraints in
-  // this particular order.
-  void PackContactSolverResults(
-      const contact_solvers::internal::SapContactProblem<T>& problem,
-      int num_contacts,
-      const contact_solvers::internal::SapSolverResults<T>& sap_results,
-      contact_solvers::internal::ContactSolverResults<T>* contact_results)
-      const;
-
   CacheIndexes cache_indexes_;
-  contact_solvers::internal::SapSolverParameters sap_parameters_;
   // Vector of joint damping coefficients, of size plant().num_velocities().
   // This information is extracted during the call to ExtractModelInfo().
   VectorX<T> joint_damping_;
+
   // deformable_driver_ computes the information on all deformable bodies needed
   // to advance the discrete states.
   std::unique_ptr<DeformableDriver<double>> deformable_driver_;
+
+  // Specific contact solver drivers are created at ExtractModelInfo() time,
+  // when the manager retrieves modeling information from MultibodyPlant.
+  std::unique_ptr<SapDriver<T>> sap_driver_;
 };
 
 }  // namespace internal

--- a/multibody/plant/contact_pair_kinematics.cc
+++ b/multibody/plant/contact_pair_kinematics.cc
@@ -1,0 +1,6 @@
+#include "drake/multibody/plant/contact_pair_kinematics.h"
+
+#include "drake/common/default_scalars.h"
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    struct ::drake::multibody::internal::ContactPairKinematics)

--- a/multibody/plant/contact_pair_kinematics.h
+++ b/multibody/plant/contact_pair_kinematics.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/math/rotation_matrix.h"
+#include "drake/multibody/tree/multibody_tree_indexes.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Struct to store kinematics information for each contact pair. For each
+// contact pair this struct stores signed distance, Jacobian w.r.t. velocities
+// for each participating tree and rotation matrix between world frame and
+// contact frame.
+template <typename T>
+struct ContactPairKinematics {
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ContactPairKinematics);
+
+  // Struct to store the block contribution from a given tree to the contact
+  // Jacobian for a contact pair.
+  struct JacobianTreeBlock {
+    DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(JacobianTreeBlock);
+
+    JacobianTreeBlock(TreeIndex tree_in, Matrix3X<T> J_in)
+        : tree(tree_in), J(std::move(J_in)) {}
+
+    // Index of the tree for this block.
+    TreeIndex tree;
+
+    // J.cols() must equal the number of generalized velocities for
+    // the corresponding tree.
+    Matrix3X<T> J;
+  };
+
+  ContactPairKinematics(T phi_in, std::vector<JacobianTreeBlock> jacobian_in,
+                        math::RotationMatrix<T> R_WC_in)
+      : phi(std::move(phi_in)),
+        jacobian(std::move(jacobian_in)),
+        R_WC(std::move(R_WC_in)) {}
+
+  // Signed distance for the given pair. Defined negative for overlapping
+  // bodies.
+  T phi{};
+
+  // TODO(amcastro-tri): consider using absl::InlinedVector since here we know
+  // this has a size of at most 2.
+  // Jacobian for a discrete contact pair stored as individual blocks for each
+  // of the trees participating in the contact. Only one or two trees can
+  // participate in a given contact.
+  std::vector<JacobianTreeBlock> jacobian;
+
+  // Rotation matrix to re-express between contact frame C and world frame W.
+  math::RotationMatrix<T> R_WC;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    struct ::drake::multibody::internal::ContactPairKinematics)

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -80,28 +80,11 @@ DiscreteUpdateManager<T>::EvalContactJacobians(
 }
 
 template <typename T>
-const std::vector<internal::DiscreteContactPair<T>>&
-DiscreteUpdateManager<T>::EvalDiscreteContactPairs(
-    const systems::Context<T>& context) const {
-  return MultibodyPlantDiscreteUpdateManagerAttorney<
-      T>::EvalDiscreteContactPairs(plant(), context);
-}
-
-template <typename T>
 const std::vector<geometry::ContactSurface<T>>&
 DiscreteUpdateManager<T>::EvalContactSurfaces(
     const systems::Context<T>& context) const {
   return MultibodyPlantDiscreteUpdateManagerAttorney<T>::EvalContactSurfaces(
       plant(), context);
-}
-
-template <typename T>
-std::vector<CoulombFriction<double>>
-DiscreteUpdateManager<T>::CalcCombinedFrictionCoefficients(
-    const systems::Context<T>& context,
-    const std::vector<internal::DiscreteContactPair<T>>& contact_pairs) const {
-  return MultibodyPlantDiscreteUpdateManagerAttorney<
-      T>::CalcCombinedFrictionCoefficients(plant(), context, contact_pairs);
 }
 
 template <typename T>

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -194,15 +194,8 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   const internal::ContactJacobians<T>& EvalContactJacobians(
       const systems::Context<T>& context) const;
 
-  const std::vector<internal::DiscreteContactPair<T>>& EvalDiscreteContactPairs(
-      const systems::Context<T>& context) const;
-
   const std::vector<geometry::ContactSurface<T>>& EvalContactSurfaces(
       const systems::Context<T>& context) const;
-
-  std::vector<CoulombFriction<double>> CalcCombinedFrictionCoefficients(
-      const systems::Context<T>& context,
-      const std::vector<internal::DiscreteContactPair<T>>& contact_pairs) const;
 
   void AddInForcesFromInputPorts(const drake::systems::Context<T>& context,
                                  MultibodyForces<T>* forces) const;

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -53,21 +53,9 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
     return plant.EvalContactJacobians(context);
   }
 
-  static const std::vector<internal::DiscreteContactPair<T>>&
-  EvalDiscreteContactPairs(const MultibodyPlant<T>& plant,
-                           const systems::Context<T>& context) {
-    return plant.EvalDiscreteContactPairs(context);
-  }
-
   static const std::vector<geometry::ContactSurface<T>>& EvalContactSurfaces(
       const MultibodyPlant<T>& plant, const systems::Context<T>& context) {
     return plant.EvalContactSurfaces(context);
-  }
-
-  static std::vector<CoulombFriction<double>> CalcCombinedFrictionCoefficients(
-      const MultibodyPlant<T>& plant, const systems::Context<T>& context,
-      const std::vector<internal::DiscreteContactPair<T>>& contact_pairs) {
-    return plant.CalcCombinedFrictionCoefficients(context, contact_pairs);
   }
 
   static void AddInForcesFromInputPorts(const MultibodyPlant<T>& plant,

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -1,0 +1,461 @@
+#include "drake/multibody/plant/sap_driver.h"
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "drake/multibody/contact_solvers/contact_solver_utils.h"
+#include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
+#include "drake/multibody/contact_solvers/sap/sap_friction_cone_constraint.h"
+#include "drake/multibody/contact_solvers/sap/sap_holonomic_constraint.h"
+#include "drake/multibody/contact_solvers/sap/sap_limit_constraint.h"
+#include "drake/multibody/contact_solvers/sap/sap_solver.h"
+#include "drake/multibody/contact_solvers/sap/sap_solver_results.h"
+#include "drake/multibody/plant/compliant_contact_manager.h"
+#include "drake/multibody/plant/multibody_plant.h"
+
+using drake::geometry::GeometryId;
+using drake::math::RotationMatrix;
+using drake::multibody::contact_solvers::internal::ContactSolverResults;
+using drake::multibody::contact_solvers::internal::ExtractNormal;
+using drake::multibody::contact_solvers::internal::ExtractTangent;
+using drake::multibody::contact_solvers::internal::SapConstraint;
+using drake::multibody::contact_solvers::internal::SapContactProblem;
+using drake::multibody::contact_solvers::internal::SapFrictionConeConstraint;
+using drake::multibody::contact_solvers::internal::SapHolonomicConstraint;
+using drake::multibody::contact_solvers::internal::SapLimitConstraint;
+using drake::multibody::contact_solvers::internal::SapSolver;
+using drake::multibody::contact_solvers::internal::SapSolverResults;
+using drake::multibody::contact_solvers::internal::SapSolverStatus;
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+template <typename T>
+SapDriver<T>::SapDriver(const CompliantContactManager<T>* manager)
+    : manager_(manager) {
+  // Collect joint damping coefficients into a vector.
+  joint_damping_ = VectorX<T>::Zero(plant().num_velocities());
+  for (JointIndex j(0); j < plant().num_joints(); ++j) {
+    const Joint<T>& joint = plant().get_joint(j);
+    const int velocity_start = joint.velocity_start();
+    const int nv = joint.num_velocities();
+    joint_damping_.segment(velocity_start, nv) = joint.damping_vector();
+  }
+}
+
+template <typename T>
+void SapDriver<T>::set_sap_solver_parameters(
+    const contact_solvers::internal::SapSolverParameters& parameters) {
+  sap_parameters_ = parameters;
+}
+
+template <typename T>
+void SapDriver<T>::DeclareCacheEntries(
+    CompliantContactManager<T>* mutable_manager) {
+  DRAKE_DEMAND(mutable_manager == manager_);
+  const auto& contact_problem_cache_entry = mutable_manager->DeclareCacheEntry(
+      "contact problem",
+      systems::ValueProducer(this, ContactProblemCache<T>(plant().time_step()),
+                             &SapDriver<T>::CalcContactProblemCache),
+      {plant().cache_entry_ticket(
+          manager().cache_indexes_.discrete_contact_pairs)});
+  contact_problem_ = contact_problem_cache_entry.cache_index();
+}
+
+template <typename T>
+const ContactProblemCache<T>& SapDriver<T>::EvalContactProblemCache(
+    const systems::Context<T>& context) const {
+  return plant()
+      .get_cache_entry(contact_problem_)
+      .template Eval<ContactProblemCache<T>>(context);
+}
+
+template <typename T>
+void SapDriver<T>::CalcLinearDynamicsMatrix(const systems::Context<T>& context,
+                                            std::vector<MatrixX<T>>* A) const {
+  DRAKE_DEMAND(A != nullptr);
+  A->resize(tree_topology().num_trees());
+  const int nv = plant().num_velocities();
+
+  // TODO(amcastro-tri): consider placing the computation of the dense mass
+  // matrix in a cache entry to minimize heap allocations or better yet,
+  // implement a MultibodyPlant method to compute the per-tree mass matrices.
+  MatrixX<T> M(nv, nv);
+  plant().CalcMassMatrix(context, &M);
+
+  // The driver solves free motion velocities using a discrete scheme with
+  // implicit joint dissipation. That is, it solves the momentum balance:
+  //   m(v) = (M + dt⋅D)⋅(v-v₀)/dt - k(x₀) = 0
+  // where k(x₀) are all the non-constraint forces such as Coriolis terms and
+  // external actuation, evaluated at the previous state x₀.
+  // The dynamics matrix is defined as:
+  //   A = ∂m/∂v = (M + dt⋅D)
+  M.diagonal() += plant().time_step() * joint_damping_;
+
+  for (TreeIndex t(0); t < tree_topology().num_trees(); ++t) {
+    const int tree_start = tree_topology().tree_velocities_start(t);
+    const int tree_nv = tree_topology().num_tree_velocities(t);
+    (*A)[t] = M.block(tree_start, tree_start, tree_nv, tree_nv);
+  }
+}
+
+template <typename T>
+void SapDriver<T>::CalcFreeMotionVelocities(const systems::Context<T>& context,
+                                            VectorX<T>* v_star) const {
+  DRAKE_DEMAND(v_star != nullptr);
+  // N.B. Forces are evaluated at the previous time step state. This is
+  // consistent with the explicit Euler and symplectic Euler schemes.
+  // TODO(amcastro-tri): Implement free-motion velocities update based on the
+  // theta-method, as in the SAP paper.
+  const VectorX<T>& vdot0 =
+      manager().EvalAccelerationsDueToNonContactForcesCache(context).get_vdot();
+  const double dt = this->plant().time_step();
+  const VectorX<T>& x0 =
+      context.get_discrete_state(manager().multibody_state_index()).value();
+  const auto v0 = x0.bottomRows(this->plant().num_velocities());
+  *v_star = v0 + dt * vdot0;
+}
+
+template <typename T>
+std::vector<RotationMatrix<T>> SapDriver<T>::AddContactConstraints(
+    const systems::Context<T>& context, SapContactProblem<T>* problem) const {
+  DRAKE_DEMAND(problem != nullptr);
+
+  // Parameters used by SAP to estimate regularization, see [Castro et al.,
+  // 2021].
+  // TODO(amcastro-tri): consider exposing these parameters.
+  constexpr double beta = 1.0;
+  constexpr double sigma = 1.0e-3;
+
+  const std::vector<DiscreteContactPair<T>>& contact_pairs =
+      manager().EvalDiscreteContactPairs(context);
+  const int num_contacts = contact_pairs.size();
+
+  // Quick no-op exit.
+  if (num_contacts == 0) return std::vector<RotationMatrix<T>>();
+
+  std::vector<ContactPairKinematics<T>> contact_kinematics =
+      manager().CalcContactKinematics(context);
+
+  std::vector<RotationMatrix<T>> R_WC;
+  R_WC.reserve(num_contacts);
+  for (int icontact = 0; icontact < num_contacts; ++icontact) {
+    const auto& discrete_pair = contact_pairs[icontact];
+
+    const T stiffness = discrete_pair.stiffness;
+    const T dissipation_time_scale = discrete_pair.dissipation_time_scale;
+    const T friction = discrete_pair.friction_coefficient;
+    const T phi = contact_kinematics[icontact].phi;
+    const auto& jacobian_blocks = contact_kinematics[icontact].jacobian;
+
+    const typename SapFrictionConeConstraint<T>::Parameters parameters{
+        friction, stiffness, dissipation_time_scale, beta, sigma};
+
+    if (jacobian_blocks.size() == 1) {
+      problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<T>>(
+          jacobian_blocks[0].tree, std::move(jacobian_blocks[0].J), phi,
+          parameters));
+    } else {
+      problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<T>>(
+          jacobian_blocks[0].tree, jacobian_blocks[1].tree,
+          std::move(jacobian_blocks[0].J), std::move(jacobian_blocks[1].J), phi,
+          parameters));
+    }
+    R_WC.emplace_back(std::move(contact_kinematics[icontact].R_WC));
+  }
+  return R_WC;
+}
+
+template <typename T>
+void SapDriver<T>::AddLimitConstraints(const systems::Context<T>& context,
+                                       const VectorX<T>& v_star,
+                                       SapContactProblem<T>* problem) const {
+  DRAKE_DEMAND(problem != nullptr);
+
+  constexpr double kInf = std::numeric_limits<double>::infinity();
+
+  // TODO(amcastro-tri): consider exposing these parameters.
+  // "Near-rigid" parameter. See [Castro et al., 2021].
+  constexpr double kBeta = 0.1;
+  // Parameter used to estimate the size of a window [w_l, w_u] within which we
+  // expect the configuration q for a given joint to be in the next time step.
+  // See notes below for details. Dimensionless.
+  constexpr double kLimitWindowFactor = 2.0;
+
+  const double dt = plant().time_step();
+
+  // N.B. MultibodyPlant estimates very conservative (soft) stiffness and
+  // damping parameters to ensure that the explicit treatment of the compliant
+  // forces used to impose limits does not become unstable. SAP however treats
+  // these forces implicitly and therefore these parameters can be tighten for
+  // stiffer limits. Here we set the stiffness parameter to a very high value so
+  // that SAP works in the "near-rigid" regime as described in the SAP paper,
+  // [Castro et al., 2021]. As shown in the SAP paper, a dissipation timescale
+  // of the order of the time step leads to a critically damped constraint.
+  // N.B. Units of stiffness (say N/m for a translational q) are consistent
+  // with the units of the corresponding generalized coordinate (say m for a
+  // translational q) so that their product has units of the corresponding
+  // generalized force (say N for a translational q).
+  // TODO(amcastro-tri): allow users to specify joint limits stiffness and
+  // damping.
+  const double stiffness = 1.0e12;
+  const double dissipation_time_scale = dt;
+
+  for (JointIndex joint_index(0); joint_index < plant().num_joints();
+       ++joint_index) {
+    const Joint<T>& joint = plant().get_joint(joint_index);
+    // We only support limits for 1 DOF joints for which we know that q̇ = v.
+    if (joint.num_positions() == 1 && joint.num_velocities() == 1) {
+      const double lower_limit = joint.position_lower_limits()[0];
+      const double upper_limit = joint.position_upper_limits()[0];
+      const int velocity_start = joint.velocity_start();
+      const TreeIndex tree_index =
+          tree_topology().velocity_to_tree_index(velocity_start);
+      const int tree_nv = tree_topology().num_tree_velocities(tree_index);
+      const int tree_velocity_start =
+          tree_topology().tree_velocities_start(tree_index);
+      const int tree_dof = velocity_start - tree_velocity_start;
+
+      // Current configuration position.
+      const T& q0 = joint.GetOnePosition(context);
+      const T& v0 = joint.GetOneVelocity(context);
+
+      // Estimate a window size around q0. In order to build a smaller
+      // optimization problem, we only add a constraint if the joint
+      // limits are within this window.
+      using std::abs;
+      using std::max;
+      // delta_q estimates how much q changes in a single time step.
+      // We use the maximum of v0 and v* for a conservative estimation.
+      const T delta_q = dt * max(abs(v0), abs(v_star(velocity_start)));
+      // We use a factor kLimitWindowFactor to look into a larger window. A very
+      // large kLimitWindowFactor means that constraints will always be added
+      // even if they are inactive at the end of the computation. A smaller
+      // kLimitWindowFactor will result in a smaller problem, faster to solve,
+      // though constraints could be missed until the next time step.
+      const T window_lower = q0 - kLimitWindowFactor * delta_q;
+      const T window_upper = q0 + kLimitWindowFactor * delta_q;
+
+      // N.B. window_lower < window_upper by definition.
+      const double ql = lower_limit < window_lower ? -kInf : lower_limit;
+      const double qu = upper_limit > window_upper ? kInf : upper_limit;
+
+      // Constraint is added only when one of ql and qu is finite.
+      if (!std::isinf(ql) || !std::isinf(qu)) {
+        // Create constraint for the current configuration q0.
+        typename SapLimitConstraint<T>::Parameters parameters{
+            ql, qu, stiffness, dissipation_time_scale, kBeta};
+        problem->AddConstraint(std::make_unique<SapLimitConstraint<T>>(
+            tree_index, tree_dof, tree_nv, q0, std::move(parameters)));
+      }
+    } else {
+      // TODO(amcastro-tri): Thus far in Drake we don't have multi-dof joints
+      // with limits, only 1-DOF joints have limits. Therefore here throw an
+      // exception to ensure that when we implement a multi-dof joint with
+      // limits we don't forget to update this code.
+      const VectorX<double>& lower_limits = joint.position_lower_limits();
+      const VectorX<double>& upper_limits = joint.position_upper_limits();
+      if ((lower_limits.array() != -kInf).any() ||
+          (upper_limits.array() != kInf).any()) {
+        throw std::runtime_error(
+            "Limits for joints with more than one degree of freedom are not "
+            "supported. You are getting this exception because a new joint "
+            "type must have been introduced. "
+            "SapDriver::AddLimitConstraints() must be updated to support this "
+            "feature. Please file an issue at "
+            "https://github.com/RobotLocomotion/drake.");
+      }
+    }
+  }
+}
+
+template <typename T>
+void SapDriver<T>::AddCouplerConstraints(const systems::Context<T>& context,
+                                         SapContactProblem<T>* problem) const {
+  DRAKE_DEMAND(problem != nullptr);
+
+  // Previous time step positions.
+  const VectorX<T> q0 = plant().GetPositions(context);
+
+  // Couplers do not have impulse limits, they are bi-lateral constraints. Each
+  // coupler constraint introduces a single constraint equation.
+  constexpr double kInfinity = std::numeric_limits<double>::infinity();
+  const Vector1<T> gamma_lower(-kInfinity);
+  const Vector1<T> gamma_upper(kInfinity);
+
+  // Stiffness and dissipation are set so that the constraint is in the
+  // "near-rigid" regime, [Castro et al., 2022].
+  const Vector1<T> stiffness(kInfinity);
+  const Vector1<T> relaxation_time(plant().time_step());
+
+  for (const CouplerConstraintSpecs<T>& info :
+       manager().coupler_constraints_specs()) {
+    const Joint<T>& joint0 = plant().get_joint(info.joint0_index);
+    const Joint<T>& joint1 = plant().get_joint(info.joint1_index);
+    const int dof0 = joint0.velocity_start();
+    const int dof1 = joint1.velocity_start();
+    const TreeIndex tree0 = tree_topology().velocity_to_tree_index(dof0);
+    const TreeIndex tree1 = tree_topology().velocity_to_tree_index(dof1);
+
+    // Sanity check.
+    DRAKE_DEMAND(tree0.is_valid() && tree1.is_valid());
+
+    // DOFs local to their tree.
+    const int tree_dof0 = dof0 - tree_topology().tree_velocities_start(tree0);
+    const int tree_dof1 = dof1 - tree_topology().tree_velocities_start(tree1);
+
+    // Constraint function defined as g = q₀ - ρ⋅q₁ - Δq, with ρ the gear ratio
+    // and Δq a fixed position offset.
+    const Vector1<T> g0(q0[dof0] - info.gear_ratio * q0[dof1] - info.offset);
+
+    // TODO(amcastro-tri): consider exposing this parameter.
+    const double beta = 0.1;
+
+    const typename SapHolonomicConstraint<T>::Parameters parameters{
+        gamma_lower, gamma_upper, stiffness, relaxation_time, beta};
+
+    if (tree0 == tree1) {
+      const int nv = tree_topology().num_tree_velocities(tree0);
+      MatrixX<T> J = MatrixX<T>::Zero(1, nv);
+      // J = dg/dv
+      J(0, tree_dof0) = 1.0;
+      J(0, tree_dof1) = -info.gear_ratio;
+
+      problem->AddConstraint(std::make_unique<SapHolonomicConstraint<T>>(
+          tree0, g0, J, parameters));
+    } else {
+      const int nv0 = tree_topology().num_tree_velocities(tree0);
+      const int nv1 = tree_topology().num_tree_velocities(tree1);
+      MatrixX<T> J0 = MatrixX<T>::Zero(1, nv0);
+      MatrixX<T> J1 = MatrixX<T>::Zero(1, nv1);
+      J0(0, tree_dof0) = 1.0;
+      J1(0, tree_dof1) = -info.gear_ratio;
+      problem->AddConstraint(std::make_unique<SapHolonomicConstraint<T>>(
+          tree0, tree1, g0, J0, J1, parameters));
+    }
+  }
+}
+
+template <typename T>
+void SapDriver<T>::CalcContactProblemCache(
+    const systems::Context<T>& context, ContactProblemCache<T>* cache) const {
+  SapContactProblem<T>& problem = *cache->sap_problem;
+  std::vector<MatrixX<T>> A;
+  CalcLinearDynamicsMatrix(context, &A);
+  VectorX<T> v_star;
+  CalcFreeMotionVelocities(context, &v_star);
+  problem.Reset(std::move(A), std::move(v_star));
+  // N.B. All contact constraints must be added before any other constraint
+  // types. This driver assumes this ordering of the constraints in order to
+  // extract contact impulses for reporting contact results.
+  // Do not change this order here!
+  cache->R_WC = AddContactConstraints(context, &problem);
+  AddLimitConstraints(context, problem.v_star(), &problem);
+  AddCouplerConstraints(context, &problem);
+}
+
+template <typename T>
+void SapDriver<T>::PackContactSolverResults(
+    const SapContactProblem<T>& problem, int num_contacts,
+    const SapSolverResults<T>& sap_results,
+    ContactSolverResults<T>* contact_results) const {
+  DRAKE_DEMAND(contact_results != nullptr);
+  contact_results->Resize(plant().num_velocities(), num_contacts);
+  contact_results->v_next = sap_results.v;
+  // The driver adds all contact constraints first and therefore we know the
+  // head of the impulses corresponds to contact impulses.
+  const Eigen::VectorBlock<const VectorX<T>> contact_impulses =
+      sap_results.gamma.head(3 * num_contacts);
+  const Eigen::VectorBlock<const VectorX<T>> contact_velocities =
+      sap_results.vc.head(3 * num_contacts);
+  const double time_step = plant().time_step();
+  ExtractNormal(contact_impulses, &contact_results->fn);
+  ExtractTangent(contact_impulses, &contact_results->ft);
+  contact_results->fn /= time_step;
+  contact_results->ft /= time_step;
+  ExtractNormal(contact_velocities, &contact_results->vn);
+  ExtractTangent(contact_velocities, &contact_results->vt);
+
+  auto& tau_contact = contact_results->tau_contact;
+  tau_contact.setZero();
+  for (int i = 0; i < num_contacts; ++i) {
+    const SapConstraint<T>& c = problem.get_constraint(i);
+    {
+      const TreeIndex t(c.first_clique());
+      const MatrixX<T>& Jic = c.first_clique_jacobian();
+      const int v_start = tree_topology().tree_velocities_start(t);
+      const int nv = tree_topology().num_tree_velocities(t);
+      const auto impulse = contact_impulses.template segment<3>(3 * i);
+      tau_contact.segment(v_start, nv) += Jic.transpose() * impulse;
+    }
+
+    if (c.num_cliques() == 2) {
+      const TreeIndex t(c.second_clique());
+      const MatrixX<T>& Jic = c.second_clique_jacobian();
+      const int v_start = tree_topology().tree_velocities_start(t);
+      const int nv = tree_topology().num_tree_velocities(t);
+      const auto impulse = contact_impulses.template segment<3>(3 * i);
+      tau_contact.segment(v_start, nv) += Jic.transpose() * impulse;
+    }
+  }
+  tau_contact /= time_step;
+}
+
+template <typename T>
+void SapDriver<T>::CalcContactSolverResults(
+    const systems::Context<T>& context,
+    contact_solvers::internal::ContactSolverResults<T>* results) const {
+  const ContactProblemCache<T>& contact_problem_cache =
+      EvalContactProblemCache(context);
+  const SapContactProblem<T>& sap_problem = *contact_problem_cache.sap_problem;
+
+  // We use the velocity stored in the current context as initial guess.
+  const VectorX<T>& x0 =
+      context.get_discrete_state(manager().multibody_state_index()).value();
+  const auto v0 = x0.bottomRows(this->plant().num_velocities());
+
+  // Solve contact problem.
+  SapSolver<T> sap;
+  sap.set_parameters(sap_parameters_);
+  SapSolverResults<T> sap_results;
+  const SapSolverStatus status =
+      sap.SolveWithGuess(sap_problem, v0, &sap_results);
+  if (status != SapSolverStatus::kSuccess) {
+    const std::string msg = fmt::format(
+        "The SAP solver failed to converge at simulation time = {}. "
+        "Reasons for divergence and possible solutions include:\n"
+        "  1. Externally applied actuation values diverged due to external "
+        "     reasons to the solver. Revise your control logic.\n"
+        "  2. External force elements such as spring or bushing elements can "
+        "     lead to unstable temporal dynamics if too stiff. Revise your "
+        "     model and consider whether these forces can be better modeled "
+        "     using one of SAP's compliant constraints. E.g., use a distance "
+        "     constraint instead of a spring element.\n"
+        "  3. Numerical ill conditioning of the model caused by, for instance, "
+        "     extremely large mass ratios. Revise your model and consider "
+        "     whether very small objects can be removed or welded to larger "
+        "     objects in the model."
+        "  4. Some other cause. You may want to use Stack Overflow (#drake "
+        "     tag) to request some assistance.",
+        context.get_time());
+    throw std::runtime_error(msg);
+  }
+
+  const std::vector<DiscreteContactPair<T>>& discrete_pairs =
+      manager().EvalDiscreteContactPairs(context);
+  const int num_contacts = discrete_pairs.size();
+
+  PackContactSolverResults(sap_problem, num_contacts, sap_results, results);
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::SapDriver);

--- a/multibody/plant/sap_driver.h
+++ b/multibody/plant/sap_driver.h
@@ -1,0 +1,186 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/common/copyable_unique_ptr.h"
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/math/rotation_matrix.h"
+#include "drake/multibody/contact_solvers/contact_solver_results.h"
+#include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
+#include "drake/multibody/contact_solvers/sap/sap_solver.h"
+#include "drake/multibody/plant/contact_pair_kinematics.h"
+#include "drake/multibody/tree/multibody_tree_topology.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+namespace multibody {
+
+// Forward declaration.
+template <typename>
+class MultibodyPlant;
+
+namespace internal {
+
+// Forward declaration.
+template <typename>
+class CompliantContactManager;
+
+template <typename T>
+struct ContactProblemCache {
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ContactProblemCache);
+  explicit ContactProblemCache(double time_step) {
+    sap_problem =
+        std::make_unique<contact_solvers::internal::SapContactProblem<T>>(
+            time_step);
+  }
+  copyable_unique_ptr<contact_solvers::internal::SapContactProblem<T>>
+      sap_problem;
+
+  // TODO(amcastro-tri): consider removing R_WC from the contact problem cache
+  // and instead cache ContactPairKinematics separately.
+  std::vector<math::RotationMatrix<T>> R_WC;
+};
+
+// Performs the computations needed by CompliantContactManager for discrete
+// updates using the SAP solver. A const manager is provided at construction so
+// that the driver has access to the const model and computation services
+// agnostic to the solver type, such as geometry queries and/or kinematics.
+// Mutable access to the manager is provided during DeclareCacheEntries() to
+// allow the declaration of system-level cache entries.
+// @tparam_nonsymbolic_scalar
+template <typename T>
+class SapDriver {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SapDriver);
+
+  // The newly constructed driver is used in the given `manager` to perform
+  // discrete updates using the SAP solver. This driver will user manager
+  // services to perform solver-agnostic multibody computations, e.g. contact
+  // kinematics. The given `manager` must outlive this driver.
+  // @pre manager != nullptr.
+  explicit SapDriver(const CompliantContactManager<T>* manager);
+
+  void set_sap_solver_parameters(
+      const contact_solvers::internal::SapSolverParameters& parameters);
+
+  // With this function the manager provided at construction gives `this` driver
+  // the opportunity to declare system level cache entries.
+  // @pre `mutable_manager` must point to the same manager provided at
+  // construction.
+  void DeclareCacheEntries(CompliantContactManager<T>* mutable_manager);
+
+  void CalcContactSolverResults(
+      const systems::Context<T>&,
+      contact_solvers::internal::ContactSolverResults<T>*) const;
+
+ private:
+  // Provide private access for unit testing only.
+  friend class SapDriverTest;
+
+  const CompliantContactManager<T>& manager() const { return *manager_; }
+
+  const MultibodyPlant<T>& plant() const { return manager().plant(); }
+
+  const MultibodyTreeTopology& tree_topology() const {
+    return manager().tree_topology();
+  }
+
+  // Computes the linearized momentum equation matrix A to build the SAP
+  // contact problem. Refer to SapContactProblem's class documentation for
+  // details.
+  void CalcLinearDynamicsMatrix(const systems::Context<T>& context,
+                                std::vector<MatrixX<T>>* A) const;
+
+  // Given the previous state x0 stored in `context`, this method computes the
+  // "free motion" velocities, denoted v*.
+  void CalcFreeMotionVelocities(const systems::Context<T>& context,
+                                VectorX<T>* v_star) const;
+
+  // Adds contact constraints for the configuration stored in `context` into
+  // `problem`. This method returns the orientation of the contact frame in the
+  // world frame for each contact constraint added to `problem`. That is, the
+  // i-th entry in the return vector corresponds to the orientation R_WC contact
+  // frame in the world frame for the i-th contact constraint added to
+  // `problem`.
+  std::vector<math::RotationMatrix<T>> AddContactConstraints(
+      const systems::Context<T>& context,
+      contact_solvers::internal::SapContactProblem<T>* problem) const;
+
+  // Adds limit constraints for the configuration stored in `context` into
+  // `problem`. Limit constraints are only added when the state q₀ for a
+  // particular joint is "close" to the joint's limits (qₗ,qᵤ). To decide when
+  // the state q₀ is close to the joint's limits, this method estimates a window
+  // (wₗ,wᵤ) for the expected value of the configuration q at the next time
+  // step. Lower constraints are considered whenever qₗ > wₗ and upper
+  // constraints are considered whenever qᵤ < wᵤ. This window (wₗ,wᵤ) is
+  // estimated based on the current velocity v₀ and the free motion velocities
+  // v*, provided with `v_star`.
+  // Since the implementation uses the current velocity v₀ to estimate whether
+  // the constraint should be enabled, it is at least as good as a typical
+  // continuous collision detection method. It could mispredict under conditions
+  // of strong acceleration (it is assuming constant velocity across a step).
+  // Still, at typical robotics step sizes and rates it would be surprising to
+  // see that happen, and if it did the limit would come on in the next step.
+  // TODO(amcastro-tri): Consider using the acceleration at t₀ to get a second
+  // order prediction for the configuration at the next time step.
+  // @pre problem must not be nullptr.
+  void AddLimitConstraints(
+      const systems::Context<T>& context, const VectorX<T>& v_star,
+      contact_solvers::internal::SapContactProblem<T>* problem) const;
+
+  // Adds holonomic constraints to model couplers specified in the
+  // MultibodyPlant.
+  void AddCouplerConstraints(
+      const systems::Context<T>& context,
+      contact_solvers::internal::SapContactProblem<T>* problem) const;
+
+  // This method takes SAP results for a given `problem` and loads forces due to
+  // contact only into `contact_results`. `contact_results` is properly resized
+  // on output.
+  // @pre contact_results is not nullptr.
+  // @pre All `num_contacts` contact constraints in `problem` were added before
+  // any other SAP constraint. This requirement is imposed by this driver which
+  // adds constraints (with AddContactConstraints()) to the contact problem
+  // before any other constraints are added. See the implementation of
+  // CalcContactProblemCache(), which is responsible for adding constraints in
+  // this particular order.
+  void PackContactSolverResults(
+      const contact_solvers::internal::SapContactProblem<T>& problem,
+      int num_contacts,
+      const contact_solvers::internal::SapSolverResults<T>& sap_results,
+      contact_solvers::internal::ContactSolverResults<T>* contact_results)
+      const;
+
+  // Computes the necessary data to describe the SAP contact problem. Additional
+  // information such as the orientation of each contact frame in the world is
+  // also computed here so that it can be used at a later stage to compute
+  // contact results.
+  // All contact constraints are added before any other constraint types. This
+  // manager assumes this ordering of the constraints in order to extract
+  // contact impulses for reporting contact results.
+  void CalcContactProblemCache(const systems::Context<T>& context,
+                               ContactProblemCache<T>* cache) const;
+
+  // Eval version of CalcContactProblemCache()
+  const ContactProblemCache<T>& EvalContactProblemCache(
+      const systems::Context<T>& context) const;
+
+  // The driver only has mutable access at construction time, when it can
+  // declare additional state, cache entries, ports, etc. After construction,
+  // the driver only has const access to the manager.
+  const CompliantContactManager<T>* const manager_{nullptr};
+  systems::CacheIndex contact_problem_;
+  // Vector of joint damping coefficients, of size plant().num_velocities().
+  // This information is extracted during the call to ExtractModelInfo().
+  VectorX<T> joint_damping_;
+  // Parameters for SAP.
+  contact_solvers::internal::SapSolverParameters sap_parameters_;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/compliant_contact_manager_test.cc
+++ b/multibody/plant/test/compliant_contact_manager_test.cc
@@ -13,13 +13,13 @@
 #include "drake/multibody/contact_solvers/contact_solver_results.h"
 #include "drake/multibody/contact_solvers/contact_solver_utils.h"
 #include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
-#include "drake/multibody/contact_solvers/sap/sap_friction_cone_constraint.h"
-#include "drake/multibody/contact_solvers/sap/sap_holonomic_constraint.h"
-#include "drake/multibody/contact_solvers/sap/sap_limit_constraint.h"
 #include "drake/multibody/contact_solvers/sap/sap_solver.h"
 #include "drake/multibody/contact_solvers/sap/sap_solver_results.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/sap_driver.h"
+#include "drake/multibody/plant/test/compliant_contact_manager_tester.h"
+#include "drake/multibody/plant/test/spheres_stack.h"
 #include "drake/multibody/tree/joint_actuator.h"
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/multibody/tree/revolute_joint.h"
@@ -39,9 +39,6 @@ using drake::math::RotationMatrixd;
 using drake::multibody::contact_solvers::internal::ContactSolverResults;
 using drake::multibody::contact_solvers::internal::MergeNormalAndTangent;
 using drake::multibody::contact_solvers::internal::SapContactProblem;
-using drake::multibody::contact_solvers::internal::SapFrictionConeConstraint;
-using drake::multibody::contact_solvers::internal::SapHolonomicConstraint;
-using drake::multibody::contact_solvers::internal::SapLimitConstraint;
 using drake::multibody::contact_solvers::internal::SapSolver;
 using drake::multibody::contact_solvers::internal::SapSolverParameters;
 using drake::multibody::contact_solvers::internal::SapSolverResults;
@@ -62,87 +59,26 @@ namespace internal {
 
 constexpr double kEps = std::numeric_limits<double>::epsilon();
 
-// Helper function for NaN initialization.
-static constexpr double nan() {
-  return std::numeric_limits<double>::quiet_NaN();
-}
-
 // Friend class used to provide access to a selection of private functions in
-// CompliantContactManager for testing purposes.
-class CompliantContactManagerTest {
+// SapDriver for testing purposes.
+// TODO(amcastro-tri): Consider how to split SapDriver tests from
+// CompliantContactManager tests.
+class SapDriverTest {
  public:
-  static const internal::MultibodyTreeTopology& topology(
-      const CompliantContactManager<double>& manager) {
-    return manager.tree_topology();
-  }
-
-  static const std::vector<geometry::ContactSurface<double>>&
-  EvalContactSurfaces(const CompliantContactManager<double>& manager,
-                      const Context<double>& context) {
-    return manager.EvalContactSurfaces(context);
-  }
-
-  static const std::vector<DiscreteContactPair<double>>&
-  EvalDiscreteContactPairs(const CompliantContactManager<double>& manager,
-                           const Context<double>& context) {
-    return manager.EvalDiscreteContactPairs(context);
-  }
-
-  static std::vector<ContactPairKinematics<double>> CalcContactKinematics(
-      const CompliantContactManager<double>& manager,
-      const Context<double>& context) {
-    return manager.CalcContactKinematics(context);
-  }
-
   static const ContactProblemCache<double>& EvalContactProblemCache(
-      const CompliantContactManager<double>& manager,
-      const Context<double>& context) {
-    return manager.EvalContactProblemCache(context);
-  }
-
-  static VectorXd CalcFreeMotionVelocities(
-      const CompliantContactManager<double>& manager,
-      const Context<double>& context) {
-    VectorXd v_star(manager.plant().num_velocities());
-    manager.CalcFreeMotionVelocities(context, &v_star);
-    return v_star;
-  }
-
-  static std::vector<MatrixXd> CalcLinearDynamicsMatrix(
-      const CompliantContactManager<double>& manager,
-      const Context<double>& context) {
-    std::vector<MatrixXd> A;
-    manager.CalcLinearDynamicsMatrix(context, &A);
-    return A;
+      const SapDriver<double>& driver, const Context<double>& context) {
+    return driver.EvalContactProblemCache(context);
   }
 
   static void PackContactSolverResults(
-      const CompliantContactManager<double>& manager,
+      const SapDriver<double>& driver,
       const contact_solvers::internal::SapContactProblem<double>& problem,
       int num_contacts,
       const contact_solvers::internal::SapSolverResults<double>& sap_results,
       contact_solvers::internal::ContactSolverResults<double>*
           contact_results) {
-    manager.PackContactSolverResults(problem, num_contacts, sap_results,
-                                     contact_results);
-  }
-
-  static void CalcNonContactForces(
-      const CompliantContactManager<double>& manager,
-      const Context<double>& context, MultibodyForces<double>* forces) {
-    manager.CalcNonContactForces(context, forces);
-  }
-
-  static void AddLimitConstraints(
-      const CompliantContactManager<double>& manager,
-      const Context<double>& context, const VectorXd& v_star,
-      SapContactProblem<double>* problem) {
-    manager.AddLimitConstraints(context, v_star, problem);
-  }
-
-  static const DeformableDriver<double>* deformable_driver(
-      const CompliantContactManager<double>& manager) {
-    return manager.deformable_driver_.get();
+    driver.PackContactSolverResults(problem, num_contacts, sap_results,
+                                    contact_results);
   }
 };
 
@@ -150,17 +86,19 @@ class CompliantContactManagerTest {
 // cause a DeformableDriver to be instantiated in the manager.
 GTEST_TEST(CompliantContactManagerTest, ExtractModelInfo) {
   CompliantContactManager<double> manager;
-  EXPECT_EQ(CompliantContactManagerTest::deformable_driver(manager), nullptr);
+  EXPECT_EQ(CompliantContactManagerTester::deformable_driver(manager), nullptr);
   MultibodyPlant<double> plant(0.01);
   auto deformable_model = std::make_unique<DeformableModel<double>>(&plant);
   plant.AddPhysicalModel(std::move(deformable_model));
+  // N.B. Currently the manager only supports SAP.
+  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
   plant.Finalize();
   auto contact_manager = std::make_unique<CompliantContactManager<double>>();
   const CompliantContactManager<double>* contact_manager_ptr =
       contact_manager.get();
   plant.SetDiscreteUpdateManager(std::move(contact_manager));
   EXPECT_NE(
-      CompliantContactManagerTest::deformable_driver(*contact_manager_ptr),
+      CompliantContactManagerTester::deformable_driver(*contact_manager_ptr),
       nullptr);
 }
 
@@ -175,149 +113,8 @@ GTEST_TEST(CompliantContactManagerTest, ExtractModelInfo) {
 // on top the first sphere. They are assigned to be rigid-hydroelastic,
 // compliant-hydroelastic, or non-hydroelastic to test various cases of
 // contact quantities computed by the CompliantContactManager.
-class SpheresStack : public ::testing::Test {
+class SpheresStackTest : public SpheresStack, public ::testing::Test {
  public:
-  // Contact model parameters.
-  struct ContactParameters {
-    // Point contact stiffness. If nullopt, this property is not added to the
-    // model.
-    std::optional<double> point_stiffness;
-    // Hydroelastic modulus. If nullopt, this property is not added to the
-    // model.
-    std::optional<double> hydro_modulus;
-    // Relaxation time constant τ is used to setup the linear dissipation model
-    // where dissipation is c = τ⋅k, with k the point pair stiffness.
-    // If nullopt, no dissipation is specified, i.e. the corresponding
-    // ProximityProperties will not have dissipation defined.
-    std::optional<double> relaxation_time;
-    // Coefficient of dynamic friction.
-    double friction_coefficient{nan()};
-  };
-
-  // Parameters used to setup the model of a compliant sphere.
-  struct SphereParameters {
-    const std::string name;
-    double mass;
-    double radius;
-    // No contact geometry is registered if nullopt.
-    std::optional<ContactParameters> contact_parameters;
-  };
-
-  // Sets up this fixture to have:
-  //   - A rigid-hydroelastic half-space for the ground.
-  //   - A compliant-hydroelastic sphere on top of the ground.
-  //   - A non-hydroelastic sphere on top of the first sphere.
-  //   - Both spheres also have point contact compliance.
-  //   - We set MultibodyPlant to use hydroelastic contact with fallback.
-  //   - Sphere 1 penetrates into the ground penetration_distance_.
-  //   - Sphere 1 and 2 penetrate penetration_distance_.
-  //   - Velocities are zero.
-  void SetupRigidGroundCompliantSphereAndNonHydroSphere(
-      bool sphere1_on_prismatic_joint = false) {
-    const ContactParameters compliant_contact{1.0e5, 1.0e5, 0.01, 1.0};
-    const ContactParameters non_hydro_contact{1.0e5, {}, 0.01, 1.0};
-    const ContactParameters rigid_hydro_contact{
-        std::nullopt, std::numeric_limits<double>::infinity(), 0.0, 1.0};
-    const SphereParameters sphere1_params{"Sphere1", 10.0 /* mass */,
-                                          0.2 /* size */, compliant_contact};
-    const SphereParameters sphere2_params{"Sphere2", 10.0 /* mass */,
-                                          0.2 /* size */, non_hydro_contact};
-    MakeModel(rigid_hydro_contact, sphere1_params, sphere2_params,
-              sphere1_on_prismatic_joint);
-  }
-
-  void SetupFreeFloatingSpheresWithNoContact() {
-    const bool sphere1_on_prismatic_joint = false;
-    const SphereParameters sphere1_params{"Sphere1", 10.0 /* mass */,
-                                          0.2 /* size */,
-                                          std::nullopt /* no contact */};
-    const SphereParameters sphere2_params{"Sphere2", 10.0 /* mass */,
-                                          0.2 /* size */,
-                                          std::nullopt /* no contact */};
-    MakeModel(std::nullopt /* no ground */, sphere1_params, sphere2_params,
-              sphere1_on_prismatic_joint);
-  }
-
-  // Sets up a model with two spheres and the ground.
-  // Spheres are defined by their SphereParameters. Ground contact is defined by
-  // `ground_params`, no ground is added if std::nullopt.
-  // Sphere 1 is mounted on a prismatic joint about the z axis if
-  // sphere1_on_prismatic_joint = true.
-  void MakeModel(const std::optional<ContactParameters>& ground_params,
-                 const SphereParameters& sphere1_params,
-                 const SphereParameters& sphere2_params,
-                 bool sphere1_on_prismatic_joint = false) {
-    systems::DiagramBuilder<double> builder;
-    std::tie(plant_, scene_graph_) =
-        AddMultibodyPlantSceneGraph(&builder, time_step_);
-
-    // Add model of the ground.
-    if (ground_params) {
-      const ProximityProperties ground_properties =
-          MakeProximityProperties(*ground_params);
-      plant_->RegisterCollisionGeometry(plant_->world_body(), RigidTransformd(),
-                                        geometry::HalfSpace(),
-                                        "ground_collision", ground_properties);
-      const Vector4<double> green(0.5, 1.0, 0.5, 1.0);
-      plant_->RegisterVisualGeometry(plant_->world_body(), RigidTransformd(),
-                                     geometry::HalfSpace(), "ground_visual",
-                                     green);
-    }
-
-    // Add models of the spheres.
-    sphere1_ = &AddSphere(sphere1_params);
-    sphere2_ = &AddSphere(sphere2_params);
-
-    // Model with sphere 1 mounted on a prismatic joint with lower limits.
-    if (sphere1_on_prismatic_joint) {
-      slider1_ = &plant_->AddJoint<PrismaticJoint>(
-          "Sphere1Slider", plant_->world_body(), std::nullopt, *sphere1_,
-          std::nullopt, Vector3<double>::UnitZ(),
-          sphere1_params.radius /* lower limit */);
-    }
-
-    plant_->mutable_gravity_field().set_gravity_vector(-gravity_ *
-                                                       Vector3d::UnitZ());
-
-    plant_->set_contact_model(
-        drake::multibody::ContactModel::kHydroelasticWithFallback);
-
-    plant_->Finalize();
-    auto owned_contact_manager =
-        std::make_unique<CompliantContactManager<double>>();
-    contact_manager_ = owned_contact_manager.get();
-    plant_->SetDiscreteUpdateManager(std::move(owned_contact_manager));
-
-    diagram_ = builder.Build();
-    diagram_context_ = diagram_->CreateDefaultContext();
-    plant_context_ =
-        &plant_->GetMyMutableContextFromRoot(diagram_context_.get());
-
-    SetContactState(sphere1_params, sphere2_params);
-  }
-
-  // Sphere 1 is set on top of the ground and sphere 2 sits right on top of
-  // sphere 1. We set the state of the model so that sphere 1 penetrates into
-  // the ground a distance penetration_distance_ and so that sphere 1 and 2 also
-  // interpenetrate a distance penetration_distance_.
-  // MakeModel() must have already been called.
-  void SetContactState(const SphereParameters& sphere1_params,
-                       const SphereParameters& sphere2_params) const {
-    DRAKE_DEMAND(plant_ != nullptr);
-    const double sphere1_com_z = sphere1_params.radius - penetration_distance_;
-    if (slider1_ != nullptr) {
-      slider1_->set_translation(plant_context_, sphere1_com_z);
-    } else {
-      const RigidTransformd X_WB1(Vector3d(0, 0, sphere1_com_z));
-      plant_->SetFreeBodyPose(plant_context_, *sphere1_, X_WB1);
-    }
-    const double sphere2_com_z = 2.0 * sphere1_params.radius +
-                                 sphere2_params.radius -
-                                 2.0 * penetration_distance_;
-    const RigidTransformd X_WB2(Vector3d(0, 0, sphere2_com_z));
-    plant_->SetFreeBodyPose(plant_context_, *sphere2_, X_WB2);
-  }
-
   // This function makes a model with the specified sphere 1 and sphere 2
   // properties and verifies the resulting contact pairs.
   // In this model sphere 1 always interacts with the ground using the
@@ -433,83 +230,12 @@ class SpheresStack : public ::testing::Test {
     }
   }
 
-  // In the functions below we use CompliantContactManagerTest to provide access
-  // to private functions for unit testing.
-
-  const internal::MultibodyTreeTopology& topology() const {
-    return CompliantContactManagerTest::topology(*contact_manager_);
-  }
-
-  const std::vector<geometry::ContactSurface<double>>& EvalContactSurfaces(
-      const Context<double>& context) const {
-    return CompliantContactManagerTest::EvalContactSurfaces(*contact_manager_,
-                                                            context);
-  }
-
-  const std::vector<DiscreteContactPair<double>>& EvalDiscreteContactPairs(
-      const Context<double>& context) const {
-    return CompliantContactManagerTest::EvalDiscreteContactPairs(
-        *contact_manager_, context);
-  }
-
+  // Helper to provide access to private method
+  // CompliantContactManager::CalcContactKinematics().
   std::vector<ContactPairKinematics<double>> CalcContactKinematics(
       const Context<double>& context) const {
-    return CompliantContactManagerTest::CalcContactKinematics(*contact_manager_,
-                                                              context);
-  }
-
-  const ContactProblemCache<double>& EvalContactProblemCache(
-      const Context<double>& context) const {
-    return CompliantContactManagerTest::EvalContactProblemCache(
+    return CompliantContactManagerTester::CalcContactKinematics(
         *contact_manager_, context);
-  }
-
-  VectorXd CalcFreeMotionVelocities(const Context<double>& context) const {
-    VectorXd v_star(plant_->num_velocities());
-    return CompliantContactManagerTest::CalcFreeMotionVelocities(
-        *contact_manager_, context);
-  }
-
-  std::vector<MatrixXd> CalcLinearDynamicsMatrix(
-      const Context<double>& context) const {
-    return CompliantContactManagerTest::CalcLinearDynamicsMatrix(
-        *contact_manager_, context);
-  }
-
-  void PackContactSolverResults(
-      const contact_solvers::internal::SapContactProblem<double>& problem,
-      int num_contacts,
-      const contact_solvers::internal::SapSolverResults<double>& sap_results,
-      contact_solvers::internal::ContactSolverResults<double>* contact_results)
-      const {
-    CompliantContactManagerTest::PackContactSolverResults(
-        *contact_manager_, problem, num_contacts, sap_results, contact_results);
-  }
-
-  // Returns the Jacobian J_AcBc_C. This method takes the Jacobian blocks
-  // evaluated with EvalContactJacobianCache() and assembles them into a dense
-  // Jacobian matrix.
-  MatrixXd CalcDenseJacobianMatrixInContactFrame(
-      const std::vector<ContactPairKinematics<double>>& contact_kinematics)
-      const {
-    const int nc = contact_kinematics.size();
-    MatrixXd J_AcBc_C(3 * nc, contact_manager_->plant().num_velocities());
-    J_AcBc_C.setZero();
-    for (int i = 0; i < nc; ++i) {
-      const int row_offset = 3 * i;
-      const ContactPairKinematics<double>& pair_kinematics =
-          contact_kinematics[i];
-      for (const ContactPairKinematics<double>::JacobianTreeBlock&
-               tree_jacobian : pair_kinematics.jacobian) {
-        // If added to the Jacobian, it must have a valid index.
-        EXPECT_TRUE(tree_jacobian.tree.is_valid());
-        const int col_offset =
-            topology().tree_velocities_start(tree_jacobian.tree);
-        const int tree_nv = topology().num_tree_velocities(tree_jacobian.tree);
-        J_AcBc_C.block(row_offset, col_offset, 3, tree_nv) = tree_jacobian.J;
-      }
-    }
-    return J_AcBc_C;
   }
 
   // Helper method to test EvalContactJacobianCache().
@@ -519,7 +245,8 @@ class SpheresStack : public ::testing::Test {
       const {
     const int nc = contact_kinematics.size();
     const MatrixXd J_AcBc_C =
-        CalcDenseJacobianMatrixInContactFrame(contact_kinematics);
+        CompliantContactManagerTester::CalcDenseJacobianMatrixInContactFrame(
+            *contact_manager_, contact_kinematics);
     MatrixXd J_AcBc_W(3 * nc, contact_manager_->plant().num_velocities());
     J_AcBc_W.setZero();
     for (int i = 0; i < nc; ++i) {
@@ -531,149 +258,36 @@ class SpheresStack : public ::testing::Test {
     return J_AcBc_W;
   }
 
- protected:
-  // Arbitrary positive value so that the model is discrete.
-  double time_step_{0.001};
+  // In the functions below we use CompliantContactManagerTester to provide
+  // access to private functions for unit testing.
 
-  const double gravity_{10.0};  // Acceleration of gravity, in m/s².
-
-  // Default penetration distance. The configuration of the model is set so that
-  // ground/sphere1 and sphere1/sphere2 interpenetrate by this amount.
-  const double penetration_distance_{1.0e-3};
-
-  std::unique_ptr<systems::Diagram<double>> diagram_;
-  MultibodyPlant<double>* plant_{nullptr};
-  SceneGraph<double>* scene_graph_{nullptr};
-  const RigidBody<double>* sphere1_{nullptr};
-  const RigidBody<double>* sphere2_{nullptr};
-  const PrismaticJoint<double>* slider1_{nullptr};
-  CompliantContactManager<double>* contact_manager_{nullptr};
-  std::unique_ptr<Context<double>> diagram_context_;
-  Context<double>* plant_context_{nullptr};
-
- private:
-  // Helper to add a spherical body into the model.
-  const RigidBody<double>& AddSphere(const SphereParameters& params) {
-    // Add rigid body.
-    const Vector3<double> p_BoBcm_B = Vector3<double>::Zero();
-    const UnitInertia<double> G_BBcm_B =
-        UnitInertia<double>::SolidSphere(params.radius);
-    const SpatialInertia<double> M_BBcm_B(params.mass, p_BoBcm_B, G_BBcm_B);
-    const RigidBody<double>& body = plant_->AddRigidBody(params.name, M_BBcm_B);
-
-    // Add collision geometry.
-    if (params.contact_parameters) {
-      const geometry::Sphere shape(params.radius);
-      const ProximityProperties properties =
-          MakeProximityProperties(*params.contact_parameters);
-      plant_->RegisterCollisionGeometry(body, RigidTransformd(), shape,
-                                        params.name + "_collision", properties);
-    }
-
-    return body;
+  const internal::MultibodyTreeTopology& topology() const {
+    return CompliantContactManagerTester::topology(*contact_manager_);
   }
 
-  // Utility to make ProximityProperties from ContactParameters.
-  // params.relaxation_time is ignored if nullopt.
-  static ProximityProperties MakeProximityProperties(
-      const ContactParameters& params) {
-    DRAKE_DEMAND(params.point_stiffness || params.hydro_modulus);
-    ProximityProperties properties;
-    if (params.hydro_modulus) {
-      if (params.hydro_modulus == std::numeric_limits<double>::infinity()) {
-        geometry::AddRigidHydroelasticProperties(/* resolution_hint */ 1.0,
-                                                 &properties);
-      } else {
-        geometry::AddCompliantHydroelasticProperties(
-            /* resolution_hint */ 1.0, *params.hydro_modulus, &properties);
-      }
-      // N.B. Add the slab thickness property by default so that we can model a
-      // half space (either compliant or rigid).
-      properties.AddProperty(geometry::internal::kHydroGroup,
-                             geometry::internal::kSlabThickness, 1.0);
-    }
-    geometry::AddContactMaterial(
-        /* "hunt_crossley_dissipation" */ {}, params.point_stiffness,
-        CoulombFriction<double>(params.friction_coefficient,
-                                params.friction_coefficient),
-        &properties);
+  const std::vector<DiscreteContactPair<double>>& EvalDiscreteContactPairs(
+      const Context<double>& context) const {
+    return CompliantContactManagerTester::EvalDiscreteContactPairs(
+        *contact_manager_, context);
+  }
 
-    if (params.relaxation_time.has_value()) {
-      properties.AddProperty(geometry::internal::kMaterialGroup,
-                             "relaxation_time", *params.relaxation_time);
-    }
-    return properties;
+  const std::vector<geometry::ContactSurface<double>>& EvalContactSurfaces(
+      const Context<double>& context) const {
+    return CompliantContactManagerTester::EvalContactSurfaces(*contact_manager_,
+                                                            context);
+  }
+
+  const SapContactProblem<double>& EvalSapContactProblem(
+      const Context<double>& context) const {
+    const auto& sap_driver =
+        CompliantContactManagerTester::sap_driver(*contact_manager_);
+    return *SapDriverTest::EvalContactProblemCache(sap_driver, *plant_context_)
+                .sap_problem;
   }
 };
 
-// Unit test to verify discrete contact pairs computed by the manager for
-// different combinations of compliance.
-TEST_F(SpheresStack, VerifyDiscreteContactPairs) {
-  ContactParameters soft_point_contact{1.0e3, std::nullopt, 0.01, 1.0};
-  ContactParameters hard_point_contact{1.0e40, std::nullopt, 0.0, 1.0};
-
-  // Hard sphere 1/soft sphere 2.
-  VerifyDiscreteContactPairs(hard_point_contact, soft_point_contact);
-
-  // Equally soft spheres.
-  VerifyDiscreteContactPairs(soft_point_contact, soft_point_contact);
-
-  // Soft sphere 1/hard sphere 2.
-  VerifyDiscreteContactPairs(soft_point_contact, hard_point_contact);
-}
-
-TEST_F(SpheresStack, RelaxationTimeIsNotRequired) {
-  ContactParameters soft_point_contact{
-      1.0e3, std::nullopt,
-      std::nullopt /* Dissipation not included in ProximityProperties */, 1.0};
-  ContactParameters hard_point_contact{1.0e40, std::nullopt, 0.0, 1.0};
-
-  // Hard sphere 1/soft sphere 2.
-  VerifyDiscreteContactPairs(hard_point_contact, soft_point_contact);
-
-  // Equally soft spheres.
-  VerifyDiscreteContactPairs(soft_point_contact, soft_point_contact);
-
-  // Soft sphere 1/hard sphere 2.
-  VerifyDiscreteContactPairs(soft_point_contact, hard_point_contact);
-}
-
-TEST_F(SpheresStack, RelaxationTimeMustBePositive) {
-  ContactParameters soft_point_contact{
-      1.0e3, std::nullopt, -1.0 /* Negative dissipation timescale */, 1.0};
-  ContactParameters hard_point_contact{1.0e40, std::nullopt, 0.0, 1.0};
-
-  // Hard sphere 1/soft sphere 2.
-  VerifyDiscreteContactPairs(hard_point_contact, soft_point_contact);
-
-  // Equally soft spheres.
-  VerifyDiscreteContactPairs(soft_point_contact, soft_point_contact);
-
-  // Soft sphere 1/hard sphere 2.
-  VerifyDiscreteContactPairs(soft_point_contact, hard_point_contact);
-}
-
-// Unit test to verify discrete contact pairs computed by the manager for
-// rigid-compliant hydroelastic contact with point-contact fall back.
-TEST_F(SpheresStack,
-       VerifyDiscreteContactPairsFromRigidCompliantHydroelasticContact) {
-  SetupRigidGroundCompliantSphereAndNonHydroSphere();
-
-  const std::vector<PenetrationAsPointPair<double>>& point_pairs =
-      plant_->EvalPointPairPenetrations(*plant_context_);
-  const int num_point_pairs = point_pairs.size();
-  EXPECT_EQ(num_point_pairs, 1);
-  const std::vector<DiscreteContactPair<double>>& pairs =
-      EvalDiscreteContactPairs(*plant_context_);
-
-  const std::vector<geometry::ContactSurface<double>>& surfaces =
-      EvalContactSurfaces(*plant_context_);
-  ASSERT_EQ(surfaces.size(), 1);
-  EXPECT_EQ(pairs.size(), surfaces[0].num_faces() + num_point_pairs);
-}
-
-// Unit test to verify the computation of the contact Jacobian.
-TEST_F(SpheresStack, CalcContactKinematics) {
+// Unit test to verify the computation of the contact kinematics.
+TEST_F(SpheresStackTest, CalcContactKinematics) {
   SetupRigidGroundCompliantSphereAndNonHydroSphere();
   const double radius = 0.2;  // Spheres's radii in the default setup.
 
@@ -746,227 +360,80 @@ TEST_F(SpheresStack, CalcContactKinematics) {
   }
 }
 
-// This test verifies that the SapContactProblem built by the manager is
-// consistent with the contact kinematics computed with CalcContactKinematics().
-TEST_F(SpheresStack, EvalContactProblemCache) {
-  SetupRigidGroundCompliantSphereAndNonHydroSphere();
-  const ContactProblemCache<double>& problem_cache =
-      EvalContactProblemCache(*plant_context_);
-  const SapContactProblem<double>& problem = *problem_cache.sap_problem;
-  const std::vector<drake::math::RotationMatrix<double>>& R_WC =
-      problem_cache.R_WC;
+// Unit test to verify discrete contact pairs computed by the manager for
+// different combinations of compliance.
+TEST_F(SpheresStackTest, VerifyDiscreteContactPairs) {
+  ContactParameters soft_point_contact{1.0e3, std::nullopt, 0.01, 1.0};
+  ContactParameters hard_point_contact{1.0e40, std::nullopt, 0.0, 1.0};
 
+  // Hard sphere 1/soft sphere 2.
+  VerifyDiscreteContactPairs(hard_point_contact, soft_point_contact);
+
+  // Equally soft spheres.
+  VerifyDiscreteContactPairs(soft_point_contact, soft_point_contact);
+
+  // Soft sphere 1/hard sphere 2.
+  VerifyDiscreteContactPairs(soft_point_contact, hard_point_contact);
+}
+
+TEST_F(SpheresStackTest, RelaxationTimeIsNotRequired) {
+  ContactParameters soft_point_contact{
+      1.0e3, std::nullopt,
+      std::nullopt /* Dissipation not included in ProximityProperties */, 1.0};
+  ContactParameters hard_point_contact{1.0e40, std::nullopt, 0.0, 1.0};
+
+  // Hard sphere 1/soft sphere 2.
+  VerifyDiscreteContactPairs(hard_point_contact, soft_point_contact);
+
+  // Equally soft spheres.
+  VerifyDiscreteContactPairs(soft_point_contact, soft_point_contact);
+
+  // Soft sphere 1/hard sphere 2.
+  VerifyDiscreteContactPairs(soft_point_contact, hard_point_contact);
+}
+
+TEST_F(SpheresStackTest, RelaxationTimeMustBePositive) {
+  ContactParameters soft_point_contact{
+      1.0e3, std::nullopt, -1.0 /* Negative dissipation timescale */, 1.0};
+  ContactParameters hard_point_contact{1.0e40, std::nullopt, 0.0, 1.0};
+
+  // Hard sphere 1/soft sphere 2.
+  VerifyDiscreteContactPairs(hard_point_contact, soft_point_contact);
+
+  // Equally soft spheres.
+  VerifyDiscreteContactPairs(soft_point_contact, soft_point_contact);
+
+  // Soft sphere 1/hard sphere 2.
+  VerifyDiscreteContactPairs(soft_point_contact, hard_point_contact);
+}
+
+// Unit test to verify discrete contact pairs computed by the manager for
+// rigid-compliant hydroelastic contact with point-contact fall back.
+TEST_F(SpheresStackTest,
+       VerifyDiscreteContactPairsFromRigidCompliantHydroelasticContact) {
+  SetupRigidGroundCompliantSphereAndNonHydroSphere();
+
+  const std::vector<PenetrationAsPointPair<double>>& point_pairs =
+      plant_->EvalPointPairPenetrations(*plant_context_);
+  const int num_point_pairs = point_pairs.size();
+  EXPECT_EQ(num_point_pairs, 1);
   const std::vector<DiscreteContactPair<double>>& pairs =
       EvalDiscreteContactPairs(*plant_context_);
-  const int num_contacts = pairs.size();
 
-  // Verify sizes.
-  EXPECT_EQ(problem.num_cliques(), topology().num_trees());
-  EXPECT_EQ(problem.num_velocities(), plant_->num_velocities());
-  EXPECT_EQ(problem.num_constraints(), num_contacts);
-  EXPECT_EQ(problem.num_constraint_equations(), 3 * num_contacts);
-  EXPECT_EQ(problem.time_step(), plant_->time_step());
-  ASSERT_EQ(R_WC.size(), num_contacts);
-
-  // Verify dynamics data.
-  const VectorXd& v_star = CalcFreeMotionVelocities(*plant_context_);
-  const std::vector<MatrixXd>& A = CalcLinearDynamicsMatrix(*plant_context_);
-  EXPECT_EQ(problem.v_star(), v_star);
-  EXPECT_EQ(problem.dynamics_matrix(), A);
-
-  // Verify each of the contact constraints.
-  const std::vector<ContactPairKinematics<double>> contact_kinematics =
-      CalcContactKinematics(*plant_context_);
-  for (size_t i = 0; i < contact_kinematics.size(); ++i) {
-    const DiscreteContactPair<double>& discrete_pair = pairs[i];
-    const ContactPairKinematics<double>& pair_kinematics =
-        contact_kinematics[i];
-    const auto* constraint =
-        dynamic_cast<const SapFrictionConeConstraint<double>*>(
-            &problem.get_constraint(i));
-    // In this test we do know all constraints are contact constraints.
-    ASSERT_NE(constraint, nullptr);
-    EXPECT_EQ(constraint->constraint_function(),
-              Vector3d(0., 0., pair_kinematics.phi));
-    EXPECT_EQ(constraint->num_cliques(), pair_kinematics.jacobian.size());
-    EXPECT_EQ(constraint->first_clique(), pair_kinematics.jacobian[0].tree);
-    EXPECT_EQ(constraint->first_clique_jacobian(),
-              pair_kinematics.jacobian[0].J);
-    if (constraint->num_cliques() == 2) {
-      EXPECT_EQ(constraint->second_clique(), pair_kinematics.jacobian[1].tree);
-      EXPECT_EQ(constraint->second_clique_jacobian(),
-                pair_kinematics.jacobian[1].J);
-    }
-    EXPECT_EQ(constraint->parameters().mu, discrete_pair.friction_coefficient);
-    EXPECT_EQ(constraint->parameters().stiffness, discrete_pair.stiffness);
-    EXPECT_EQ(constraint->parameters().dissipation_time_scale,
-              discrete_pair.dissipation_time_scale);
-    // These two parameters, beta and sigma, are for now hard-code in the
-    // manager to these values. Here we simply tests they are consistent with
-    // those hard-coded values.
-    EXPECT_EQ(constraint->parameters().beta, 1.0);
-    EXPECT_EQ(constraint->parameters().sigma, 1.0e-3);
-
-    // Verify contact frame orientation matrix R_WC.
-    EXPECT_EQ(R_WC[i].matrix(), pair_kinematics.R_WC.matrix());
-  }
-}
-
-// Verifies the correctness of the computation of free motion velocities when
-// external forces are applied.
-TEST_F(SpheresStack, CalcFreeMotionVelocitiesWithExternalForces) {
-  SetupRigidGroundCompliantSphereAndNonHydroSphere();
-
-  // We set an arbitrary non-zero external force to the plant to verify it gets
-  // properly applied as part of the computation.
-  const int nv = plant_->num_velocities();
-  const VectorXd tau = VectorXd::LinSpaced(nv, 1.0, 2.0);
-  plant_->get_applied_generalized_force_input_port().FixValue(plant_context_,
-                                                              tau);
-
-  // Set arbitrary non-zero velocities.
-  const VectorXd v0 = VectorXd::LinSpaced(nv, 2.0, 3.0);
-  plant_->SetVelocities(plant_context_, v0);
-
-  // Since the spheres's frames are located at their COM and since their
-  // rotational inertias are triaxially symmetric, the Coriolis term is zero.
-  // Therefore the momentum equation reduces to: M * (v-v0)/dt = tau_g + tau.
-  const double dt = plant_->time_step();
-  const VectorXd tau_g = plant_->CalcGravityGeneralizedForces(*plant_context_);
-  MatrixXd M(nv, nv);
-  plant_->CalcMassMatrix(*plant_context_, &M);
-  const VectorXd v_expected = v0 + dt * M.ldlt().solve(tau_g + tau);
-
-  // Compute the velocities the system would have next time step in the absence
-  // of constraints.
-  const VectorXd v_star = CalcFreeMotionVelocities(*plant_context_);
-
-  EXPECT_TRUE(
-      CompareMatrices(v_star, v_expected, kEps, MatrixCompareType::relative));
-}
-
-// Verifies that joint limit forces are applied.
-TEST_F(SpheresStack, CalcFreeMotionVelocitiesWithJointLimits) {
-  // In this model sphere 1 is attached to the world by a prismatic joint with
-  // lower limit z = 0.
-  const bool sphere1_on_prismatic_joint = true;
-  SetupRigidGroundCompliantSphereAndNonHydroSphere(sphere1_on_prismatic_joint);
-
-  const int nv = plant_->num_velocities();
-
-  // Set arbitrary non-zero velocities.
-  const VectorXd non_zero_vs = VectorXd::LinSpaced(nv, 2.0, 3.0);
-  plant_->SetVelocities(plant_context_, non_zero_vs);
-
-  // The slider velocity is set to be negative to ensure the joint limit is
-  // active. That is, the position was set to be below the lower limit and in
-  // addition it is decreasing.
-  slider1_->set_translation_rate(plant_context_, -1.0);
-
-  // Initial velocities.
-  const VectorXd v0 = plant_->GetVelocities(*plant_context_);
-
-  // Compute slider1's velocity in the absence of joint limits. This is
-  // equivalent to computing the free motion velocities before constraints are
-  // applied.
-  const VectorXd v_expected = CalcFreeMotionVelocities(*plant_context_);
-  const double v_slider_no_limits = v_expected(slider1_->velocity_start());
-
-  // Compute slider1's velocity with constraints applied. This corresponds to
-  // the full discrete update computation.
-  ContactSolverResults<double> contact_results;
-  contact_manager_->CalcContactSolverResults(*plant_context_, &contact_results);
-  const VectorXd v_star = contact_results.v_next;
-  const double v_slider_star = v_star(slider1_->velocity_start());
-
-  // While other solver specific tests verify the correctness of joint limit
-  // forces, this test is simply limited to verifying the manager applied them.
-  // Therefore we only check the force limits have the effect of making the
-  // slider velocity larger than if not present.
-  EXPECT_GT(v_slider_star, v_slider_no_limits);
-}
-
-TEST_F(SpheresStack, CalcLinearDynamicsMatrix) {
-  SetupRigidGroundCompliantSphereAndNonHydroSphere();
-  const std::vector<MatrixXd> A = CalcLinearDynamicsMatrix(*plant_context_);
-  const int nv = plant_->num_velocities();
-  MatrixXd Adense = MatrixXd::Zero(nv, nv);
-  for (TreeIndex t(0); t < topology().num_trees(); ++t) {
-    const int tree_start = topology().tree_velocities_start(t);
-    const int tree_nv = topology().num_tree_velocities(t);
-    Adense.block(tree_start, tree_start, tree_nv, tree_nv) = A[t];
-  }
-  MatrixXd Aexpected(nv, nv);
-  plant_->CalcMassMatrix(*plant_context_, &Aexpected);
-  EXPECT_TRUE(
-      CompareMatrices(Adense, Aexpected, kEps, MatrixCompareType::relative));
-}
-
-// Here we test the function CompliantContactManager::PackContactSolverResults()
-// which takes SapSolverResults and packs them into ContactSolverResults as
-// consumed by MultibodyPlant.
-TEST_F(SpheresStack, PackContactSolverResults) {
-  SetupRigidGroundCompliantSphereAndNonHydroSphere();
-
-  // We form an arbitrary set of SAP results consistent with the contact
-  // kinematics for the configuration of our model.
-  const std::vector<ContactPairKinematics<double>> contact_kinematics =
-      CalcContactKinematics(*plant_context_);
-  const int num_contacts = contact_kinematics.size();
-  const int nv = plant_->num_velocities();
-  SapSolverResults<double> sap_results;
-  sap_results.Resize(nv, 3 * num_contacts);
-  sap_results.v = VectorXd::LinSpaced(nv, -3.0, 14.0);
-  sap_results.gamma = VectorXd::LinSpaced(3 * num_contacts, -12.0, 8.0);
-  sap_results.vc = VectorXd::LinSpaced(3 * num_contacts, -1.0, 11.0);
-  // Not used to pack contact results.
-  sap_results.j = VectorXd::Constant(nv, NAN);
-
-  // Pack SAP results into contact results.
-  const SapContactProblem<double>& sap_problem =
-      *EvalContactProblemCache(*plant_context_).sap_problem;
-  ContactSolverResults<double> contact_results;
-  PackContactSolverResults(sap_problem, num_contacts, sap_results,
-                           &contact_results);
-
-  // Verify against expected values.
-  VectorXd gamma(3 * num_contacts);
-  MergeNormalAndTangent(contact_results.fn, contact_results.ft, &gamma);
-  gamma *= plant_->time_step();
-  EXPECT_TRUE(CompareMatrices(gamma, sap_results.gamma, kEps,
-                              MatrixCompareType::relative));
-  VectorXd vc(3 * num_contacts);
-  MergeNormalAndTangent(contact_results.vn, contact_results.vt, &vc);
-  EXPECT_TRUE(
-      CompareMatrices(vc, sap_results.vc, kEps, MatrixCompareType::relative));
-  const MatrixXd J_AcBc_C =
-      CalcDenseJacobianMatrixInContactFrame(contact_kinematics);
-  const VectorXd tau_expected =
-      J_AcBc_C.transpose() * sap_results.gamma / plant_->time_step();
-  EXPECT_TRUE(CompareMatrices(contact_results.tau_contact, tau_expected,
-                              2.0 * kEps, MatrixCompareType::relative));
-}
-
-// Unit test that the manager throws an exception whenever SAP fails to
-// converge.
-TEST_F(SpheresStack, SapFailureException) {
-  SetupRigidGroundCompliantSphereAndNonHydroSphere();
-  ContactSolverResults<double> contact_results;
-  // To trigger SAP's failure, we limit the maximum number of iterations to
-  // zero.
-  SapSolverParameters parameters;
-  parameters.max_iterations = 0;
-  contact_manager_->set_sap_solver_parameters(parameters);
-  DRAKE_EXPECT_THROWS_MESSAGE(contact_manager_->CalcContactSolverResults(
-                                  *plant_context_, &contact_results),
-                              "The SAP solver failed to converge(.|\n)*");
+  const std::vector<geometry::ContactSurface<double>>& surfaces =
+      EvalContactSurfaces(*plant_context_);
+  ASSERT_EQ(surfaces.size(), 1);
+  EXPECT_EQ(pairs.size(), surfaces[0].num_faces() + num_point_pairs);
 }
 
 // The purpose of this test is not to verify the correctness of the computation,
 // but rather to verify that data flows correctly. That is, that
 // CalcContactSolverResults() loads the expected computation into the contact
 // results.
-TEST_F(SpheresStack, DoCalcContactSolverResults) {
+// TODO(amcastro-tri): The correctness of the computation should be moved into
+// the SapDriver tests. Here we should only test that the manager invokes the
+// SapDriver counterpart.
+TEST_F(SpheresStackTest, DoCalcContactSolverResults) {
   SetupRigidGroundCompliantSphereAndNonHydroSphere();
   // N.B. We make sure both the manager and the manual invocations of the SAP
   // solver in this test both use the same set of parameters.
@@ -978,7 +445,7 @@ TEST_F(SpheresStack, DoCalcContactSolverResults) {
   // Generate contact results here locally to verify that
   // CalcContactSolverResults() loads them properly.
   const SapContactProblem<double>& sap_problem =
-      *EvalContactProblemCache(*plant_context_).sap_problem;
+      EvalSapContactProblem(*plant_context_);
   const int num_contacts = sap_problem.num_constraints();  // Only contacts.
   SapSolver<double> sap;
   sap.set_parameters(params);
@@ -988,8 +455,11 @@ TEST_F(SpheresStack, DoCalcContactSolverResults) {
   ASSERT_EQ(status, SapSolverStatus::kSuccess);
 
   ContactSolverResults<double> contact_results_expected;
-  PackContactSolverResults(sap_problem, num_contacts, sap_results,
-                           &contact_results_expected);
+  const auto& sap_driver =
+      CompliantContactManagerTester::sap_driver(*contact_manager_);
+  SapDriverTest::PackContactSolverResults(sap_driver, sap_problem, num_contacts,
+                                          sap_results,
+                                          &contact_results_expected);
 
   // Verify the expected result.
   EXPECT_TRUE(CompareMatrices(contact_results.v_next,
@@ -1016,7 +486,7 @@ TEST_F(SpheresStack, DoCalcContactSolverResults) {
 // state update by hand, under the assumption the manager is using a symplectic
 // Euler scheme. This assumping might need to be updated in the future when
 // other schemes are supported.
-TEST_F(SpheresStack, DoCalcDiscreteValues) {
+TEST_F(SpheresStackTest, DoCalcDiscreteValues) {
   SetupFreeFloatingSpheresWithNoContact();
 
   // Both spheres accelerate from zero velocity in a single time step with
@@ -1074,6 +544,8 @@ class AlgebraicLoopDetection : public ::testing::Test {
   void MakeDiagram(bool with_algebraic_loop) {
     systems::DiagramBuilder<double> builder;
     plant_ = builder.AddSystem<MultibodyPlant>(1.0e-3);
+    // N.B. Currently only SAP goes through the manager.
+    plant_->set_discrete_contact_solver(DiscreteContactSolver::kSap);
     plant_->Finalize();
     auto owned_contact_manager =
         std::make_unique<CompliantContactManager<double>>();
@@ -1165,789 +637,6 @@ TEST_F(AlgebraicLoopDetection, VerifyNoFalsePositivesWhenCachingIsDisabled) {
   // Even if the computation is not cached, the loop detection is not triggered,
   // as desired.
   VerifyNoLoopIsDetected();
-}
-
-// Fixture to set up a Kuka iiwa arm model with a Schunk wsg gripper and welded
-// to the world at the base link. This fixture is used to stress test the
-// implementation of CompliantContactManager with a model of practical relevance
-// to robotics. In particular, we unit test the implementation of damping and
-// joint limits.
-class KukaIiwaArmTests : public ::testing::Test {
- public:
-  // Enum used to specify how we'd like to initialize the state for limit
-  // constraints unit tests.
-  enum class InitializePositionAt {
-    BelowLowerLimit,  // q₀ < qₗ
-    // Current position is above limit, though predicted position is below.
-    AboveLowerLimitThoughPredictionBelow,  // q₀+δt⋅v₀ < qₗ < q₀
-    AboveUpperLimit,                       // q₀ > qᵤ
-    // Current position is below limit, though predicted position is above.
-    BelowUpperLimitThoughPredictionAbove,  // q₀ < qᵤ < q₀+δt⋅v₀
-    WellWithinLimits,  // Both q0 and q₀ + δt⋅v₀ are in (qₗ, qᵤ)
-  };
-
-  // Setup model of the Kuka iiwa arm with Schunk gripper and allocate context
-  // resources. The model includes reflected inertias. Input ports are fixed to
-  // arbitrary non-zero values.
-  void SetSingleRobotModel() {
-    // Only SAP supports the modeling of constraints.
-    plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
-
-    // Load robot model from files.
-    const std::vector<ModelInstanceIndex> models = SetUpArmModel(1, &plant_);
-    plant_.Finalize();
-
-    // The model has a single coupler constraint.
-    EXPECT_EQ(plant_.num_constraints(), 1);
-
-    auto owned_contact_manager =
-        std::make_unique<CompliantContactManager<double>>();
-    manager_ = owned_contact_manager.get();
-    plant_.SetDiscreteUpdateManager(std::move(owned_contact_manager));
-    // Model with a single robot and gripper. A single coupler constraint to
-    // model the gripper.
-    EXPECT_EQ(plant_.num_constraints(), 1);
-
-    context_ = plant_.CreateDefaultContext();
-    SetArbitraryNonZeroActuation(plant_, models[0], models[1], context_.get());
-    SetArbitraryState(plant_, context_.get());
-  }
-
-  // Setup model of the Kuka iiwa arm with Schunk gripper. The model includes
-  // reflected inertias. The gripper is modeled with a coupler constraint.
-  std::vector<ModelInstanceIndex> SetUpArmModel(
-      int robot_number, MultibodyPlant<double>* plant) const {
-    std::vector<ModelInstanceIndex> models =
-        LoadIiwaWithGripper(robot_number, plant);
-    AddInReflectedInertia(plant, models, kRotorInertias, kGearRatios);
-
-    // Constrain the gripper fingers to be coupled.
-    const ModelInstanceIndex gripper_model = models[1];
-    const Joint<double>& left_finger_slider =
-        plant->GetJointByName("left_finger_sliding_joint", gripper_model);
-    const Joint<double>& right_finger_slider =
-        plant->GetJointByName("right_finger_sliding_joint", gripper_model);
-    // While for a typical gripper most likely the gear ratio is one and the
-    // offset is zero, here we use an arbitrary set of values to verify later on
-    // in the test that the manager created a constraint consistent with these
-    // numbers.
-    const ConstraintIndex next_constraint_index(plant->num_constraints());
-    ConstraintIndex constraint_index =
-        plant->AddCouplerConstraint(left_finger_slider, right_finger_slider,
-                                    kCouplerGearRatio, kCouplerOffset);
-    EXPECT_EQ(constraint_index, next_constraint_index);
-    return models;
-  }
-
-  // The manager solves free motion velocities using a discrete scheme with
-  // implicit joint dissipation. That is, it solves the momentum balance:
-  //   m(v) = (M + dt⋅D)⋅(v-v₀) - dt⋅k(x₀)
-  // where k(x₀) are all the non-constraint forces such as Coriolis terms and
-  // external actuation, evaluated at the previous state x₀.
-  // The dynamics matrix is defined as:
-  //   A = ∂m/∂v = (M + dt⋅D)
-  // This method computes A, including the contribution to implicit damping.
-  MatrixXd CalcLinearDynamicsMatrixIncludingImplicitDampingContribution()
-      const {
-    const int nv = plant_.num_velocities();
-    MatrixXd A(nv, nv);
-    plant_.CalcMassMatrix(*context_, &A);
-    // Include term due to the implicit treatment of dissipation.
-    VectorXd damping = VectorXd::Zero(plant_.num_velocities());
-    for (JointIndex joint_index(0); joint_index < plant_.num_joints();
-         ++joint_index) {
-      const Joint<double>& joint = plant_.get_joint(joint_index);
-      if (joint.num_velocities() > 0) {  // skip welds.
-        const VectorXd& joint_damping = joint.damping_vector();
-        // For this model we expect 1 DOF revolute and prismatic joints only.
-        EXPECT_EQ(joint_damping.size(), 1);
-        EXPECT_EQ(joint.num_velocities(), 1);
-        damping(joint.velocity_start()) = joint_damping(0);
-      }
-    }
-    A.diagonal() += plant_.time_step() * damping;
-    return A;
-  }
-
-  // Initializes `context` to store arbitrary values of state that abide by the
-  // given specification in `limits_specification`. This allows us to test how
-  // the manager adds constraints to the problem at different configurations.
-  // limits_specification are indexed by joint dofs.
-  // TODO(amcastro-tri): our testing strategy using these specifications can be
-  // further improved as discussed in the review of #17083, tracked in #17137.
-  void SetArbitraryStateWithLimitsSpecification(
-      const MultibodyPlant<double>& plant,
-      const std::vector<InitializePositionAt>& limits_specification,
-      Context<double>* context) {
-    // Arbitrary positive slop used for positions.
-    const double kPositiveDeltaQ = M_PI / 10.0;
-    const double dt = plant.time_step();
-    VectorXd v0(plant.num_velocities());
-    VectorXd q0(plant.num_positions());
-
-    for (JointIndex joint_index(0); joint_index < plant.num_joints();
-         ++joint_index) {
-      const Joint<double>& joint = plant.get_joint(joint_index);
-
-      if (joint.num_velocities() == 1) {  // skip welds in the model.
-        const int v_index = joint.velocity_start();
-        const InitializePositionAt limit_spec = limits_specification[v_index];
-        const double ql = joint.position_lower_limits()[0];
-        const double qu = joint.position_upper_limits()[0];
-
-        double joint_q0 = 0.;
-        double joint_v0 = 0.;
-        switch (limit_spec) {
-          case InitializePositionAt::BelowLowerLimit: {
-            joint_q0 = ql > 0 ? 0.8 * ql : 1.2 * ql;
-            joint_v0 = joint_index * 2.3;  // Arbitrary.
-            break;
-          }
-          case InitializePositionAt::AboveLowerLimitThoughPredictionBelow: {
-            // We initialize a state s.t. q₀+δt⋅v₀ < qₗ < q₀.
-            joint_q0 = ql + kPositiveDeltaQ;
-            const double qp = ql - kPositiveDeltaQ;
-            joint_v0 = (qp - joint_q0) / dt;
-            break;
-          }
-          case InitializePositionAt::AboveUpperLimit: {
-            joint_q0 = qu > 0 ? 1.2 * qu : 0.8 * qu;
-            joint_v0 = joint_index * 2.3;  // Arbitrary.
-            break;
-          }
-          case InitializePositionAt::BelowUpperLimitThoughPredictionAbove: {
-            // We initialize a state s.t. q₀ < qᵤ < q₀+δt⋅v₀.
-            joint_q0 = qu - kPositiveDeltaQ;
-            const double qp = qu + kPositiveDeltaQ;
-            joint_v0 = (qp - joint_q0) / dt;
-            break;
-          }
-          case InitializePositionAt::WellWithinLimits: {
-            joint_q0 = 0.5 * (ql + qu);  // q in (ql, qu)
-            joint_v0 = 0.0;
-            break;
-          }
-          default:
-            DRAKE_UNREACHABLE();
-        }
-
-        q0(v_index) = joint_q0;
-        v0(v_index) = joint_v0;
-      }
-    }
-
-    plant.SetPositions(context, q0);
-    plant.SetVelocities(context, v0);
-  }
-
-  // Fixes all input ports to have non-zero actuation.
-  void SetArbitraryNonZeroActuation(const MultibodyPlant<double>& plant,
-                                    ModelInstanceIndex arm_model,
-                                    ModelInstanceIndex gripper_model,
-                                    Context<double>* context) const {
-    const VectorX<double> tau_arm = VectorX<double>::LinSpaced(
-        plant.num_actuated_dofs(arm_model), 10.0, 1000.0);
-    const VectorX<double> tau_gripper = VectorX<double>::LinSpaced(
-        plant.num_actuated_dofs(gripper_model), 10.0, 1000.0);
-    plant.get_actuation_input_port(arm_model).FixValue(context, tau_arm);
-    plant.get_actuation_input_port(gripper_model)
-        .FixValue(context, tau_gripper);
-  }
-
- private:
-  std::vector<ModelInstanceIndex> LoadIiwaWithGripper(
-      int robot_number, MultibodyPlant<double>* plant) const {
-    DRAKE_DEMAND(plant != nullptr);
-    const char kArmFilePath[] =
-        "drake/manipulation/models/iiwa_description/urdf/"
-        "iiwa14_no_collision.urdf";
-
-    const char kWsg50FilePath[] =
-        "drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50.sdf";
-
-    Parser parser(plant);
-    ModelInstanceIndex arm_model =
-        parser.AddModelFromFile(FindResourceOrThrow(kArmFilePath),
-                                "robot_" + std::to_string(robot_number));
-
-    // Add the gripper.
-    ModelInstanceIndex gripper_model =
-        parser.AddModelFromFile(FindResourceOrThrow(kWsg50FilePath),
-                                "gripper_" + std::to_string(robot_number));
-
-    const auto& base_body = plant->GetBodyByName("base", arm_model);
-    const auto& end_effector = plant->GetBodyByName("iiwa_link_7", arm_model);
-    const auto& gripper_body = plant->GetBodyByName("body", gripper_model);
-    plant->WeldFrames(plant->world_frame(), base_body.body_frame());
-    plant->WeldFrames(end_effector.body_frame(), gripper_body.body_frame());
-
-    return {arm_model, gripper_model};
-  }
-
-  void AddInReflectedInertia(MultibodyPlant<double>* plant,
-                             const std::vector<ModelInstanceIndex>& models,
-                             const VectorX<double>& rotor_inertias,
-                             const VectorX<double>& gear_ratios) const {
-    DRAKE_DEMAND(plant != nullptr);
-    int local_joint_index = 0;
-    for (JointActuatorIndex index(0); index < plant->num_actuators(); ++index) {
-      JointActuator<double>& joint_actuator =
-          plant->get_mutable_joint_actuator(index);
-      if (std::count(models.begin(), models.end(),
-                     joint_actuator.model_instance()) > 0) {
-        joint_actuator.set_default_rotor_inertia(
-            rotor_inertias(local_joint_index));
-        joint_actuator.set_default_gear_ratio(gear_ratios(local_joint_index));
-        local_joint_index++;
-      }
-    }
-  }
-
-  // Set arbitrary state, though within joint limits.
-  void SetArbitraryState(const MultibodyPlant<double>& plant,
-                         Context<double>* context) {
-    for (JointIndex joint_index(0); joint_index < plant.num_joints();
-         ++joint_index) {
-      const Joint<double>& joint = plant.get_joint(joint_index);
-      // This model only has weld, prismatic, and revolute joints.
-      if (joint.type_name() == "revolute") {
-        const RevoluteJoint<double>& revolute_joint =
-            dynamic_cast<const RevoluteJoint<double>&>(joint);
-        // Arbitrary position within position limits.
-        const double ql = revolute_joint.position_lower_limit();
-        const double qu = revolute_joint.position_upper_limit();
-        const double w = joint_index / kNumJoints;  // Number in (0,1).
-        const double q = w * ql + (1.0 - w) * qu;   // q in (ql, qu)
-        revolute_joint.set_angle(context, q);
-        // Arbitrary velocity.
-        revolute_joint.set_angular_rate(context, 0.5 * joint_index);
-      } else if (joint.type_name() == "prismatic") {
-        const PrismaticJoint<double>& prismatic_joint =
-            dynamic_cast<const PrismaticJoint<double>&>(joint);
-        // Arbitrary position within position limits.
-        const double ql = prismatic_joint.position_lower_limit();
-        const double qu = prismatic_joint.position_upper_limit();
-        const double w = joint_index / kNumJoints;  // Number in (0,1).
-        const double q = w * ql + (1.0 - w) * qu;   // q in (ql, qu)
-        prismatic_joint.set_translation(context, q);
-        // Arbitrary velocity.
-        prismatic_joint.set_translation_rate(context, 0.5 * joint_index);
-      }
-    }
-  }
-
- protected:
-  const int kNumJoints = 9;
-  const double kTimeStep{0.015};
-  const VectorXd kRotorInertias{VectorXd::LinSpaced(kNumJoints, 0.1, 12.0)};
-  const VectorXd kGearRatios{VectorXd::LinSpaced(kNumJoints, 1.5, 100.0)};
-  const double kCouplerGearRatio{-1.5};
-  const double kCouplerOffset{3.1};
-  MultibodyPlant<double> plant_{kTimeStep};
-  CompliantContactManager<double>* manager_{nullptr};
-  std::unique_ptr<Context<double>> context_;
-};
-
-// This test verifies that the linear dynamics matrix is properly computed
-// according to A = ∂m/∂v = (M + dt⋅D).
-TEST_F(KukaIiwaArmTests, CalcLinearDynamicsMatrix) {
-  SetSingleRobotModel();
-  const std::vector<MatrixXd> A =
-      CompliantContactManagerTest::CalcLinearDynamicsMatrix(*manager_,
-                                                            *context_);
-  const int nv = plant_.num_velocities();
-  MatrixXd Adense = MatrixXd::Zero(nv, nv);
-  const MultibodyTreeTopology& topology =
-      CompliantContactManagerTest::topology(*manager_);
-  for (TreeIndex t(0); t < topology.num_trees(); ++t) {
-    const int tree_start = topology.tree_velocities_start(t);
-    const int tree_nv = topology.num_tree_velocities(t);
-    Adense.block(tree_start, tree_start, tree_nv, tree_nv) = A[t];
-  }
-  const MatrixXd Aexpected =
-      CalcLinearDynamicsMatrixIncludingImplicitDampingContribution();
-  EXPECT_TRUE(
-      CompareMatrices(Adense, Aexpected, kEps, MatrixCompareType::relative));
-}
-
-// This test verifies that the computation of free motion velocities v*
-// correctly include the effect of damping implicitly.
-TEST_F(KukaIiwaArmTests, CalcFreeMotionVelocities) {
-  SetSingleRobotModel();
-  const VectorXd v_star = CompliantContactManagerTest::CalcFreeMotionVelocities(
-      *manager_, *context_);
-
-  MultibodyForces<double> forces(plant_);
-  CompliantContactManagerTest::CalcNonContactForces(*manager_, *context_,
-                                                    &forces);
-  const VectorXd zero_vdot = VectorXd::Zero(plant_.num_velocities());
-  const VectorXd k0 = -plant_.CalcInverseDynamics(*context_, zero_vdot, forces);
-
-  // A = M + dt*D
-  const MatrixXd A =
-      CalcLinearDynamicsMatrixIncludingImplicitDampingContribution();
-  const VectorXd a = A.ldlt().solve(k0);
-  const VectorXd& v0 = plant_.GetVelocities(*context_);
-  const VectorXd v_star_expected = v0 + plant_.time_step() * a;
-
-  EXPECT_TRUE(CompareMatrices(v_star, v_star_expected, 5.0 * kEps,
-                              MatrixCompareType::relative));
-}
-
-// This unit test simply verifies that the manager is loading acceleration
-// kinematics with the proper results. The correctness of the computations we
-// rely on in this test (computation of accelerations) are tested elsewhere.
-TEST_F(KukaIiwaArmTests, CalcAccelerationKinematicsCache) {
-  SetSingleRobotModel();
-  const VectorXd& v0 = plant_.GetVelocities(*context_);
-  ContactSolverResults<double> contact_results;
-  manager_->CalcContactSolverResults(*context_, &contact_results);
-  const VectorXd a_expected =
-      (contact_results.v_next - v0) / plant_.time_step();
-  std::vector<SpatialAcceleration<double>> A_WB_expected(plant_.num_bodies());
-  plant_.CalcSpatialAccelerationsFromVdot(*context_, a_expected,
-                                          &A_WB_expected);
-
-  // Verify CompliantContactManager loads the acceleration kinematics with the
-  // proper results.
-  AccelerationKinematicsCache<double> ac(
-      CompliantContactManagerTest::topology(*manager_));
-  manager_->CalcAccelerationKinematicsCache(*context_, &ac);
-  EXPECT_TRUE(CompareMatrices(ac.get_vdot(), a_expected));
-  for (BodyIndex b(0); b < plant_.num_bodies(); ++b) {
-    const auto& body = plant_.get_body(b);
-    EXPECT_TRUE(ac.get_A_WB(body.node_index()).IsApprox(A_WB_expected[b]));
-  }
-}
-
-TEST_F(KukaIiwaArmTests, LimitConstraints) {
-  SetSingleRobotModel();
-  // Arbitrary selection of how positions and velocities are initialized.
-  std::vector<InitializePositionAt> limits_specification(
-      kNumJoints, InitializePositionAt::WellWithinLimits);
-  limits_specification[0] = InitializePositionAt::BelowLowerLimit;
-  limits_specification[1] = InitializePositionAt::AboveUpperLimit;
-  limits_specification[2] =
-      InitializePositionAt::AboveLowerLimitThoughPredictionBelow;
-  limits_specification[3] =
-      InitializePositionAt::BelowUpperLimitThoughPredictionAbove;
-  limits_specification[4] = InitializePositionAt::WellWithinLimits;
-  limits_specification[5] = InitializePositionAt::BelowLowerLimit;
-  limits_specification[6] = InitializePositionAt::AboveUpperLimit;
-  limits_specification[7] = InitializePositionAt::WellWithinLimits;
-  limits_specification[8] = InitializePositionAt::WellWithinLimits;
-
-  // Three joints are WellWithinLimits.
-  const int kNumJointsWithLimits = 6;
-  const int kNumConstraintEquations = 6;
-  SetArbitraryStateWithLimitsSpecification(plant_, limits_specification,
-                                           context_.get());
-
-  const std::vector<DiscreteContactPair<double>>& discrete_pairs =
-      CompliantContactManagerTest::EvalDiscreteContactPairs(*manager_,
-                                                            *context_);
-  const int num_contacts = discrete_pairs.size();
-  // We are assuming there is no contact. Assert this.
-  ASSERT_EQ(num_contacts, 0);
-
-  const ContactProblemCache<double>& problem_cache =
-      CompliantContactManagerTest::EvalContactProblemCache(*manager_,
-                                                           *context_);
-  const SapContactProblem<double>& problem = *problem_cache.sap_problem;
-
-  // This model has no contact. We expect the number of constraints and
-  // equations be consistent with limits_specification defined above.
-  // Recall the model has one additional constraint to model the coupler between
-  // the gripper fingers.
-  EXPECT_EQ(problem.num_constraints(), kNumJointsWithLimits + 1);
-  EXPECT_EQ(problem.num_constraint_equations(), kNumConstraintEquations + 1);
-
-  // In this model we clearly have single tree, the arm with its gripper.
-  const int tree_expected = 0;
-
-  int num_constraints = 0;  // count number of constraints visited.
-  // The manager adds limit constraints in the order joints are specified.
-  // Therefore we verify the limit constrant for each joint.
-  for (JointIndex joint_index(0); joint_index < plant_.num_joints();
-       ++joint_index) {
-    const Joint<double>& joint = plant_.get_joint(joint_index);
-    if (joint.num_velocities() == 1) {
-      const int v_index = joint.velocity_start();
-      const InitializePositionAt limit_spec = limits_specification[v_index];
-
-      if (limit_spec != InitializePositionAt::WellWithinLimits) {
-        // Get limit constraint for the specific joint.
-        const auto* constraint =
-            dynamic_cast<const SapLimitConstraint<double>*>(
-                &problem.get_constraint(num_constraints++));
-        // Since the spec is not WellWithinLimits, we expect a constraint added.
-        ASSERT_NE(constraint, nullptr);
-
-        // Limit constraints always apply to a single tree in the multibody
-        // forest.
-        EXPECT_EQ(constraint->num_cliques(), 1);
-
-        // There is a single tree in this model, the arm with gripper.
-        EXPECT_EQ(constraint->first_clique(), tree_expected);
-
-        EXPECT_EQ(constraint->clique_dof(), v_index);
-
-        // Each constraints acts on the same tree (the arm+gripper) with a total
-        // of kNumJoint DOFs in that tree.
-        EXPECT_EQ(constraint->first_clique_jacobian().cols(), kNumJoints);
-
-        // Verify the plant's state is consistent with the constraint's state.
-        const double q0 = joint.GetOnePosition(*context_);
-        EXPECT_EQ(constraint->position(), q0);
-
-        // N.B. Default values implemented in
-        // CompliantContactManager::AddLimitConstraints(), keep these values in
-        // sync.
-        const SapLimitConstraint<double>::Parameters& params =
-            constraint->parameters();
-        EXPECT_EQ(params.stiffness(), 1.0e12);
-        EXPECT_EQ(params.dissipation_time_scale(), plant_.time_step());
-        EXPECT_EQ(params.beta(), 0.1);
-
-        const bool lower_limit_expected =
-            limit_spec == InitializePositionAt::BelowLowerLimit ||
-            limit_spec ==
-                InitializePositionAt::AboveLowerLimitThoughPredictionBelow;
-        const bool upper_limit_expected =
-            limit_spec == InitializePositionAt::AboveUpperLimit ||
-            limit_spec ==
-                InitializePositionAt::BelowUpperLimitThoughPredictionAbove;
-
-        const int expected_num_equations =
-            lower_limit_expected && upper_limit_expected ? 2 : 1;
-        EXPECT_EQ(constraint->num_constraint_equations(),
-                  expected_num_equations);
-        EXPECT_EQ(constraint->first_clique_jacobian().rows(),
-                  expected_num_equations);
-
-        const double kInf = std::numeric_limits<double>::infinity();
-        const double ql_expected =
-            lower_limit_expected ? joint.position_lower_limits()[0] : -kInf;
-        const double qu_expected =
-            upper_limit_expected ? joint.position_upper_limits()[0] : kInf;
-
-        EXPECT_EQ(params.lower_limit(), ql_expected);
-        EXPECT_EQ(params.upper_limit(), qu_expected);
-      }
-    }
-  }
-  EXPECT_EQ(num_constraints, kNumJointsWithLimits);
-}
-
-// This joint is used to verify the support of multi-DOF joints with/without
-// joint limits. In particular, CompliantContactManager does not support limits
-// for constraints with more than 1 DOF and therefore we expect the manager to
-// throw an exception when building the problem.
-// The implementation for this joint is incomplete. Only the strictly necessary
-// overrides for the unit tests in this file are implemented.
-template <typename T>
-class MultiDofJointWithLimits final : public Joint<T> {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MultiDofJointWithLimits)
-
-  // Arbitrary number of DOFs, though larger than one for these tests.
-  static constexpr int kNumDofs = 3;
-
-  // The constructor allows to specify finite joint limits.
-  MultiDofJointWithLimits(const Frame<T>& frame_on_parent,
-                          const Frame<T>& frame_on_child,
-                          double pos_lower_limit, double pos_upper_limit)
-      : Joint<T>("MultiDofJointWithLimits", frame_on_parent, frame_on_child,
-                 VectorX<double>::Zero(kNumDofs),
-                 VectorX<double>::Constant(kNumDofs, pos_lower_limit),
-                 VectorX<double>::Constant(kNumDofs, pos_upper_limit),
-                 VectorX<double>::Constant(
-                     kNumDofs, -std::numeric_limits<double>::infinity()),
-                 VectorX<double>::Constant(
-                     kNumDofs, std::numeric_limits<double>::infinity()),
-                 VectorX<double>::Constant(
-                     kNumDofs, -std::numeric_limits<double>::infinity()),
-                 VectorX<double>::Constant(
-                     kNumDofs, std::numeric_limits<double>::infinity())) {
-    DRAKE_DEMAND(pos_lower_limit <= pos_upper_limit);
-  }
-
-  const std::string& type_name() const override {
-    static const never_destroyed<std::string> name{"MultiDofJointWithLimits"};
-    return name.access();
-  }
-
- private:
-  // Make MultiDofJointWithLimits templated on every other scalar type a friend
-  // of MultiDofJointWithLimits<T> so that CloneToScalar<ToAnyOtherScalar>() can
-  // access private members of MultiDofJointWithLimits<T>.
-  template <typename>
-  friend class MultiDofJointWithLimits;
-
-  int do_get_num_velocities() const override { return kNumDofs; }
-  int do_get_num_positions() const override { return kNumDofs; }
-  // Dummy implementation, knowing our unit tests below have a single joint of
-  // this type.
-  int do_get_velocity_start() const override { return 0; }
-  int do_get_position_start() const override { return 0; }
-
-  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint()
-      const override {
-    auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
-    // The only restriction here relevant for these tests is that we provide a
-    // mobilizer with kNumDofs postions and velocities, so that indexes are
-    // consistent during MultibodyPlant::Finalize().
-    auto revolute_mobilizer = std::make_unique<internal::SpaceXYZMobilizer<T>>(
-        this->frame_on_parent(), this->frame_on_child());
-    blue_print->mobilizers_.push_back(std::move(revolute_mobilizer));
-    return blue_print;
-  }
-
-  // We do not need an implementation for the methods below since the unit tests
-  // do not exercise them. We mark them as "unreachable".
-
-  void DoAddInOneForce(const Context<T>&, int, const T&,
-                       MultibodyForces<T>*) const override {
-    DRAKE_UNREACHABLE();
-  }
-  void DoAddInDamping(const Context<T>&, MultibodyForces<T>*) const override {
-    DRAKE_UNREACHABLE();
-  }
-  std::string do_get_position_suffix(int) const override {
-    DRAKE_UNREACHABLE();
-  }
-  std::string do_get_velocity_suffix(int) const override {
-    DRAKE_UNREACHABLE();
-  }
-  void do_set_default_positions(const VectorX<double>&) override {
-    DRAKE_UNREACHABLE();
-  }
-  const T& DoGetOnePosition(const Context<T>&) const override {
-    DRAKE_UNREACHABLE();
-  }
-  const T& DoGetOneVelocity(const Context<T>&) const override {
-    DRAKE_UNREACHABLE();
-  }
-  std::unique_ptr<Joint<double>> DoCloneToScalar(
-      const internal::MultibodyTree<double>& tree_clone) const override {
-    DRAKE_UNREACHABLE();
-  }
-  std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
-      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override {
-    DRAKE_UNREACHABLE();
-  }
-  std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
-      const internal::MultibodyTree<symbolic::Expression>&) const override {
-    DRAKE_UNREACHABLE();
-  }
-};
-
-// Verify that CompliantContactManager throws when the model contains multi-DOF
-// joints with finite limits.
-GTEST_TEST(CompliantContactManager, ThrowForUnsupportedJoints) {
-  MultibodyPlant<double> plant(1.0e-3);
-  // To avoid unnecessary warnings/errors, use a non-zero spatial inertia.
-  const RigidBody<double>& body =
-      plant.AddRigidBody("DummyBody", SpatialInertia<double>::MakeUnitary());
-  plant.AddJoint(std::make_unique<MultiDofJointWithLimits<double>>(
-      plant.world_frame(), body.body_frame(), -1.0, 2.0));
-  plant.Finalize();
-  auto owned_contact_manager =
-      std::make_unique<CompliantContactManager<double>>();
-  CompliantContactManager<double>* contact_manager =
-      owned_contact_manager.get();
-  plant.SetDiscreteUpdateManager(std::move(owned_contact_manager));
-  auto context = plant.CreateDefaultContext();
-
-  // Dummy v* and problem.
-  const VectorXd v_star = Vector3d::Zero();
-  SapContactProblem<double> problem(plant.time_step());
-
-  // We verify the manager throws for the right reasons.
-  DRAKE_EXPECT_THROWS_MESSAGE(CompliantContactManagerTest::AddLimitConstraints(
-                                  *contact_manager, *context, v_star, &problem),
-                              "Limits for joints with more than one degree of "
-                              "freedom are not supported(.|\n)*");
-}
-
-// Verify that CompliantContactManager allows multi-DOF joints whenever these do
-// not specify finite limits.
-GTEST_TEST(CompliantContactManager,
-           VerifyMultiDofJointsWithoutLimitsAreSupported) {
-  MultibodyPlant<double> plant(1.0e-3);
-  // To avoid unnecessary warnings/errors, use a non-zero spatial inertia.
-  const RigidBody<double>& body =
-      plant.AddRigidBody("DummyBody", SpatialInertia<double>::MakeUnitary());
-  const double kInf = std::numeric_limits<double>::infinity();
-  plant.AddJoint(std::make_unique<MultiDofJointWithLimits<double>>(
-      plant.world_frame(), body.body_frame(), -kInf, kInf));
-  plant.Finalize();
-  auto owned_contact_manager =
-      std::make_unique<CompliantContactManager<double>>();
-  CompliantContactManager<double>* contact_manager =
-      owned_contact_manager.get();
-  plant.SetDiscreteUpdateManager(std::move(owned_contact_manager));
-  auto context = plant.CreateDefaultContext();
-
-  const VectorXd v_star = Vector3d::Zero();
-  SapContactProblem<double> problem(plant.time_step());
-  EXPECT_NO_THROW(CompliantContactManagerTest::AddLimitConstraints(
-      *contact_manager, *context, v_star, &problem));
-
-  // No limit constraints are added since the only one joint in the model has
-  // no limits.
-  EXPECT_EQ(problem.num_constraints(), 0);
-}
-
-// This test verifies that the manager properly added holonomic constraints for
-// the coupler constraints specified in the MultibodyPlant model.
-TEST_F(KukaIiwaArmTests, CouplerConstraints) {
-  // Only SAP supports the modeling of constraints.
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
-
-  // Load two robot models.
-  std::vector<ModelInstanceIndex> arm_gripper1 = SetUpArmModel(1, &plant_);
-  std::vector<ModelInstanceIndex> arm_gripper2 = SetUpArmModel(2, &plant_);
-
-  // For testing purposes, we'll add a coupler constraint between joints in two
-  // different arms.
-  const Joint<double>& arm1_joint3 =
-      plant_.GetJointByName("iiwa_joint_3", arm_gripper1[0]);
-  const Joint<double>& arm2_joint6 =
-      plant_.GetJointByName("iiwa_joint_6", arm_gripper2[0]);
-  ConstraintIndex constraint_index = plant_.AddCouplerConstraint(
-      arm1_joint3, arm2_joint6, kCouplerGearRatio, kCouplerOffset);
-  EXPECT_EQ(constraint_index, ConstraintIndex(2));
-
-  plant_.Finalize();
-
-  // There should be three coupler constraints: one for each gripper and a third
-  // one between the two arms.
-  EXPECT_EQ(plant_.num_constraints(), 3);
-
-  // Set manager using the experimental API so that we can bring it to scope.
-  auto owned_contact_manager =
-      std::make_unique<CompliantContactManager<double>>();
-  manager_ = owned_contact_manager.get();
-  plant_.SetDiscreteUpdateManager(std::move(owned_contact_manager));
-
-  context_ = plant_.CreateDefaultContext();
-  SetArbitraryNonZeroActuation(plant_, arm_gripper1[0], arm_gripper1[1],
-                               context_.get());
-  SetArbitraryNonZeroActuation(plant_, arm_gripper2[0], arm_gripper2[1],
-                               context_.get());
-
-  // Specify a state in which all kNumJoints are within limits so that we know
-  // the contact problem has no limit constraints.
-  std::vector<InitializePositionAt> limits_specification(
-      2 * kNumJoints, InitializePositionAt::WellWithinLimits);
-  SetArbitraryStateWithLimitsSpecification(plant_, limits_specification,
-                                           context_.get());
-
-  // We are assuming there is no contact. Assert this.
-  const std::vector<DiscreteContactPair<double>>& discrete_pairs =
-      CompliantContactManagerTest::EvalDiscreteContactPairs(*manager_,
-                                                            *context_);
-  const int num_contacts = discrete_pairs.size();
-  ASSERT_EQ(num_contacts, 0);
-
-  const ContactProblemCache<double>& problem_cache =
-      CompliantContactManagerTest::EvalContactProblemCache(*manager_,
-                                                           *context_);
-  const SapContactProblem<double>& problem = *problem_cache.sap_problem;
-
-  // This model has no contact and the configuration is set to be within joint
-  // limits. Therefore we expect the problem to have the three couple
-  // constraints we added to the model.
-  EXPECT_EQ(problem.num_constraints(), 3);
-  EXPECT_EQ(problem.num_constraint_equations(), 3);
-
-  std::vector<std::pair<JointIndex, JointIndex>> coupler_joints;
-  // Coupler on first robot's gripper.
-  coupler_joints.push_back({
-      plant_.GetJointByName("left_finger_sliding_joint", arm_gripper1[1])
-          .index(),
-      plant_.GetJointByName("right_finger_sliding_joint", arm_gripper1[1])
-          .index(),
-  });
-
-  // Coupler on second robot's gripper.
-  coupler_joints.push_back({
-      plant_.GetJointByName("left_finger_sliding_joint", arm_gripper2[1])
-          .index(),
-      plant_.GetJointByName("right_finger_sliding_joint", arm_gripper2[1])
-          .index(),
-  });
-
-  // Coupler between the two robots.
-  coupler_joints.push_back({
-      plant_.GetJointByName("iiwa_joint_3", arm_gripper1[0]).index(),
-      plant_.GetJointByName("iiwa_joint_6", arm_gripper2[0]).index(),
-  });
-
-  // Verify each of the coupler constraints.
-  for (int i = 0; i < 3; ++i) {
-    const auto* constraint =
-        dynamic_cast<const SapHolonomicConstraint<double>*>(
-            &problem.get_constraint(i));
-
-    // Verify it is a SapHolonomicConstraint as expected.
-    ASSERT_NE(constraint, nullptr);
-
-    // There are two cliques in this model, one for each robot arm.
-    const int num_cliques = i == 2 ? 2 : 1;
-    EXPECT_EQ(constraint->num_cliques(), num_cliques);
-    const int first_clique = i == 1 ? 1 : 0;
-    EXPECT_EQ(constraint->first_clique(), first_clique);
-    if (i == 2) {
-      // constraint between the two robots.
-      EXPECT_EQ(constraint->second_clique(), 1);
-    }
-
-    const Joint<double>& joint0 = plant_.get_joint(coupler_joints[i].first);
-    const Joint<double>& joint1 = plant_.get_joint(coupler_joints[i].second);
-
-    // Verify the value of the constraint function.
-    const double q0 = joint0.GetOnePosition(*context_);
-    const double q1 = joint1.GetOnePosition(*context_);
-    const Vector1d g0_expected(q0 - kCouplerGearRatio * q1 - kCouplerOffset);
-    const VectorXd& g0 = constraint->constraint_function();
-    EXPECT_EQ(g0, g0_expected);
-
-    if (i < 2) {
-      // For the grippers, fingers are the last two DOFs in their tree.
-      const int left_index = 7;
-      const int right_index = 8;
-      const MatrixXd J_expected =
-          (VectorXd::Unit(kNumJoints, left_index) -
-           kCouplerGearRatio * VectorXd::Unit(kNumJoints, right_index))
-              .transpose();
-      EXPECT_EQ(constraint->first_clique_jacobian(), J_expected);
-    } else {
-      // The third constraint couples the two robot arms.
-      const MatrixXd J0_expected =
-          VectorXd::Unit(kNumJoints, 2 /* third joint. */).transpose();
-      const MatrixXd J1_expected =
-          -kCouplerGearRatio *
-          VectorXd::Unit(kNumJoints, 5 /* sixth joint. */).transpose();
-      EXPECT_EQ(constraint->first_clique_jacobian(), J0_expected);
-      EXPECT_EQ(constraint->second_clique_jacobian(), J1_expected);
-    }
-
-    // N.B. Default values implemented in
-    // CompliantContactManager::AddCouplerConstraints(), keep these values in
-    // sync.
-    const Vector1d kInfinity =
-        Vector1d::Constant(std::numeric_limits<double>::infinity());
-    const SapHolonomicConstraint<double>::Parameters& params =
-        constraint->parameters();
-    EXPECT_EQ(params.impulse_lower_limits(), -kInfinity);
-    EXPECT_EQ(params.impulse_upper_limits(), kInfinity);
-    EXPECT_EQ(params.stiffnesses(), kInfinity);
-    EXPECT_EQ(params.relaxation_times(),
-              Vector1d::Constant(plant_.time_step()));
-    EXPECT_EQ(params.beta(), 0.1);
-  }
 }
 
 }  // namespace internal

--- a/multibody/plant/test/compliant_contact_manager_tester.h
+++ b/multibody/plant/test/compliant_contact_manager_tester.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/plant/compliant_contact_manager.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Helper class for the testing of CompliantContactManager. It provides access
+// to a selection of private functions in CompliantContactManager and a number
+// of helper methods.
+class CompliantContactManagerTester {
+ public:
+  static const internal::MultibodyTreeTopology& topology(
+      const CompliantContactManager<double>& manager) {
+    return manager.tree_topology();
+  }
+
+  static const std::vector<geometry::ContactSurface<double>>&
+  EvalContactSurfaces(const CompliantContactManager<double>& manager,
+                      const drake::systems::Context<double>& context) {
+    return manager.EvalContactSurfaces(context);
+  }
+
+  static const std::vector<DiscreteContactPair<double>>&
+  EvalDiscreteContactPairs(const CompliantContactManager<double>& manager,
+                           const drake::systems::Context<double>& context) {
+    return manager.EvalDiscreteContactPairs(context);
+  }
+
+  static void CalcNonContactForces(
+      const CompliantContactManager<double>& manager,
+      const drake::systems::Context<double>& context,
+      MultibodyForces<double>* forces) {
+    manager.CalcNonContactForces(context, forces);
+  }
+
+  static std::vector<ContactPairKinematics<double>> CalcContactKinematics(
+      const CompliantContactManager<double>& manager,
+      const drake::systems::Context<double>& context) {
+    return manager.CalcContactKinematics(context);
+  }
+
+  static const DeformableDriver<double>* deformable_driver(
+      const CompliantContactManager<double>& manager) {
+    return manager.deformable_driver_.get();
+  }
+
+  static const SapDriver<double>& sap_driver(
+      const CompliantContactManager<double>& manager) {
+    return *manager.sap_driver_;
+  }
+
+  // Returns the Jacobian J_AcBc_C. This method takes the Jacobian blocks
+  // evaluated with EvalContactJacobianCache() and assembles them into a dense
+  // Jacobian matrix.
+  static Eigen::MatrixXd CalcDenseJacobianMatrixInContactFrame(
+      const CompliantContactManager<double>& manager,
+      const std::vector<ContactPairKinematics<double>>& contact_kinematics) {
+    const int nc = contact_kinematics.size();
+    Eigen::MatrixXd J_AcBc_C(3 * nc, manager.plant().num_velocities());
+    J_AcBc_C.setZero();
+    const auto& topology = CompliantContactManagerTester::topology(manager);
+    for (int i = 0; i < nc; ++i) {
+      const int row_offset = 3 * i;
+      const ContactPairKinematics<double>& pair_kinematics =
+          contact_kinematics[i];
+      for (const ContactPairKinematics<double>::JacobianTreeBlock&
+               tree_jacobian : pair_kinematics.jacobian) {
+        // If added to the Jacobian, it must have a valid index.
+        EXPECT_TRUE(tree_jacobian.tree.is_valid());
+        const int col_offset =
+            topology.tree_velocities_start(tree_jacobian.tree);
+        const int tree_nv = topology.num_tree_velocities(tree_jacobian.tree);
+        J_AcBc_C.block(row_offset, col_offset, 3, tree_nv) = tree_jacobian.J;
+      }
+    }
+    return J_AcBc_C;
+  }
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/deformable_driver_test.cc
+++ b/multibody/plant/test/deformable_driver_test.cc
@@ -5,6 +5,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/multibody/plant/compliant_contact_manager.h"
+#include "drake/multibody/plant/test/compliant_contact_manager_tester.h"
 #include "drake/systems/framework/diagram_builder.h"
 
 using drake::geometry::GeometryId;
@@ -22,16 +23,6 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-// Friend class used to provide access to a selection of private functions in
-// CompliantContactManager for testing purposes.
-class CompliantContactManagerTest {
- public:
-  static const DeformableDriver<double>* deformable_driver(
-      const CompliantContactManager<double>& manager) {
-    return manager.deformable_driver_.get();
-  }
-};
-
 class DeformableDriverTest : public ::testing::Test {
  protected:
   static constexpr double kDt = 0.01;
@@ -44,11 +35,13 @@ class DeformableDriverTest : public ::testing::Test {
     body_id_ = RegisterSphere(deformable_model.get(), kRezHint);
     model_ = deformable_model.get();
     plant_->AddPhysicalModel(move(deformable_model));
+    // N.B. Currently the manager only supports SAP.
+    plant_->set_discrete_contact_solver(DiscreteContactSolver::kSap);
     plant_->Finalize();
     auto contact_manager = make_unique<CompliantContactManager<double>>();
     manager_ = contact_manager.get();
     plant_->SetDiscreteUpdateManager(move(contact_manager));
-    driver_ = CompliantContactManagerTest::deformable_driver(*manager_);
+    driver_ = CompliantContactManagerTester::deformable_driver(*manager_);
     context_ = plant_->CreateDefaultContext();
   }
 

--- a/multibody/plant/test/sap_driver_joint_limits_test.cc
+++ b/multibody/plant/test/sap_driver_joint_limits_test.cc
@@ -1,0 +1,687 @@
+#include <algorithm>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/multibody/contact_solvers/contact_solver_results.h"
+#include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
+#include "drake/multibody/contact_solvers/sap/sap_holonomic_constraint.h"
+#include "drake/multibody/contact_solvers/sap/sap_limit_constraint.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/compliant_contact_manager.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/sap_driver.h"
+#include "drake/multibody/plant/test/compliant_contact_manager_tester.h"
+#include "drake/multibody/tree/joint_actuator.h"
+#include "drake/multibody/tree/prismatic_joint.h"
+#include "drake/multibody/tree/revolute_joint.h"
+
+/* @file This file tests SapDriver's support for joint limits. */
+
+using drake::multibody::contact_solvers::internal::ContactSolverResults;
+using drake::multibody::contact_solvers::internal::SapContactProblem;
+using drake::multibody::contact_solvers::internal::SapHolonomicConstraint;
+using drake::multibody::contact_solvers::internal::SapLimitConstraint;
+using drake::multibody::internal::DiscreteContactPair;
+using drake::systems::Context;
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+constexpr double kEps = std::numeric_limits<double>::epsilon();
+
+// Friend class used to provide access to a selection of private functions in
+// SapDriver for testing purposes.
+class SapDriverTest {
+ public:
+  static const ContactProblemCache<double>& EvalContactProblemCache(
+      const SapDriver<double>& driver, const Context<double>& context) {
+    return driver.EvalContactProblemCache(context);
+  }
+
+  static VectorXd CalcFreeMotionVelocities(const SapDriver<double>& driver,
+                                           const Context<double>& context) {
+    VectorXd v_star(driver.plant().num_velocities());
+    driver.CalcFreeMotionVelocities(context, &v_star);
+    return v_star;
+  }
+
+  static std::vector<MatrixXd> CalcLinearDynamicsMatrix(
+      const SapDriver<double>& driver, const Context<double>& context) {
+    std::vector<MatrixXd> A;
+    driver.CalcLinearDynamicsMatrix(context, &A);
+    return A;
+  }
+};
+
+// Fixture to set up a Kuka iiwa arm model with a Schunk wsg gripper and welded
+// to the world at the base link. This fixture is used to stress test the
+// implementation of SapDriver with a model of practical relevance to robotics.
+// In particular, we unit test the implementation of damping, joint limits and
+// coupler constraints.
+class KukaIiwaArmTests : public ::testing::Test {
+ public:
+  const SapDriver<double>& sap_driver() const {
+    return CompliantContactManagerTester::sap_driver(*manager_);
+  }
+
+  // Enum used to specify how we'd like to initialize the state for limit
+  // constraints unit tests.
+  enum class InitializePositionAt {
+    BelowLowerLimit,  // q₀ < qₗ
+    // Current position is above limit, though predicted position is below.
+    AboveLowerLimitThoughPredictionBelow,  // q₀+δt⋅v₀ < qₗ < q₀
+    AboveUpperLimit,                       // q₀ > qᵤ
+    // Current position is below limit, though predicted position is above.
+    BelowUpperLimitThoughPredictionAbove,  // q₀ < qᵤ < q₀+δt⋅v₀
+    WellWithinLimits,  // Both q0 and q₀ + δt⋅v₀ are in (qₗ, qᵤ)
+  };
+
+  // Sets up model of the Kuka iiwa arm with Schunk gripper and allocate context
+  // resources. The model includes reflected inertias. Input ports are fixed to
+  // arbitrary non-zero values.
+  void SetSingleRobotModel() {
+    // Only SAP supports the modeling of constraints.
+    plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+
+    // Load robot model from files.
+    const std::vector<ModelInstanceIndex> models = SetUpArmModel(1, &plant_);
+    plant_.Finalize();
+
+    // The model has a single coupler constraint.
+    EXPECT_EQ(plant_.num_constraints(), 1);
+
+    auto owned_contact_manager =
+        std::make_unique<CompliantContactManager<double>>();
+    manager_ = owned_contact_manager.get();
+    plant_.SetDiscreteUpdateManager(std::move(owned_contact_manager));
+    // Model with a single robot and gripper. A single coupler constraint to
+    // model the gripper.
+    EXPECT_EQ(plant_.num_constraints(), 1);
+
+    context_ = plant_.CreateDefaultContext();
+    SetArbitraryNonZeroActuation(plant_, models[0], models[1], context_.get());
+    SetArbitraryState(plant_, context_.get());
+  }
+
+  // Sets up model of the Kuka iiwa arm with Schunk gripper. The model includes
+  // reflected inertias. The gripper is modeled with a coupler constraint.
+  std::vector<ModelInstanceIndex> SetUpArmModel(
+      int robot_number, MultibodyPlant<double>* plant) const {
+    std::vector<ModelInstanceIndex> models =
+        LoadIiwaWithGripper(robot_number, plant);
+    AddInReflectedInertia(plant, models, kRotorInertias, kGearRatios);
+
+    // Constrain the gripper fingers to be coupled.
+    const ModelInstanceIndex gripper_model = models[1];
+    const Joint<double>& left_finger_slider =
+        plant->GetJointByName("left_finger_sliding_joint", gripper_model);
+    const Joint<double>& right_finger_slider =
+        plant->GetJointByName("right_finger_sliding_joint", gripper_model);
+    // While for a typical gripper most likely the gear ratio is one and the
+    // offset is zero, here we use an arbitrary set of values to verify later on
+    // in the test that the manager created a constraint consistent with these
+    // numbers.
+    const ConstraintIndex next_constraint_index(plant->num_constraints());
+    ConstraintIndex constraint_index =
+        plant->AddCouplerConstraint(left_finger_slider, right_finger_slider,
+                                    kCouplerGearRatio, kCouplerOffset);
+    EXPECT_EQ(constraint_index, next_constraint_index);
+    return models;
+  }
+
+  // The manager solves free motion velocities using a discrete scheme with
+  // implicit joint dissipation. That is, it solves the momentum balance:
+  //   m(v) = (M + dt⋅D)⋅(v-v₀) - dt⋅k(x₀)
+  // where k(x₀) are all the non-constraint forces such as Coriolis terms and
+  // external actuation, evaluated at the previous state x₀.
+  // The dynamics matrix is defined as:
+  //   A = ∂m/∂v = (M + dt⋅D)
+  // This method computes A, including the contribution to implicit damping.
+  MatrixXd CalcLinearDynamicsMatrixIncludingImplicitDampingContribution()
+      const {
+    const int nv = plant_.num_velocities();
+    MatrixXd A(nv, nv);
+    plant_.CalcMassMatrix(*context_, &A);
+    // Include term due to the implicit treatment of dissipation.
+    VectorXd damping = VectorXd::Zero(plant_.num_velocities());
+    for (JointIndex joint_index(0); joint_index < plant_.num_joints();
+         ++joint_index) {
+      const Joint<double>& joint = plant_.get_joint(joint_index);
+      if (joint.num_velocities() > 0) {  // skip welds.
+        const VectorXd& joint_damping = joint.damping_vector();
+        // For this model we expect 1 DOF revolute and prismatic joints only.
+        EXPECT_EQ(joint_damping.size(), 1);
+        EXPECT_EQ(joint.num_velocities(), 1);
+        damping(joint.velocity_start()) = joint_damping(0);
+      }
+    }
+    A.diagonal() += plant_.time_step() * damping;
+    return A;
+  }
+
+  // Initializes `context` to store arbitrary values of state that abide by the
+  // given specification in `limits_specification`. This allows us to test how
+  // the manager adds constraints to the problem at different configurations.
+  // limits_specification are indexed by joint dofs.
+  // TODO(amcastro-tri): our testing strategy using these specifications can be
+  // further improved as discussed in the review of #17083, tracked in #17137.
+  void SetArbitraryStateWithLimitsSpecification(
+      const MultibodyPlant<double>& plant,
+      const std::vector<InitializePositionAt>& limits_specification,
+      Context<double>* context) {
+    // Arbitrary positive slop used for positions.
+    const double kPositiveDeltaQ = M_PI / 10.0;
+    const double dt = plant.time_step();
+    VectorXd v0(plant.num_velocities());
+    VectorXd q0(plant.num_positions());
+
+    for (JointIndex joint_index(0); joint_index < plant.num_joints();
+         ++joint_index) {
+      const Joint<double>& joint = plant.get_joint(joint_index);
+
+      if (joint.num_velocities() == 1) {  // skip welds in the model.
+        const int v_index = joint.velocity_start();
+        const InitializePositionAt limit_spec = limits_specification[v_index];
+        const double ql = joint.position_lower_limits()[0];
+        const double qu = joint.position_upper_limits()[0];
+
+        double joint_q0 = 0.;
+        double joint_v0 = 0.;
+        switch (limit_spec) {
+          case InitializePositionAt::BelowLowerLimit: {
+            joint_q0 = ql > 0 ? 0.8 * ql : 1.2 * ql;
+            joint_v0 = joint_index * 2.3;  // Arbitrary.
+            break;
+          }
+          case InitializePositionAt::AboveLowerLimitThoughPredictionBelow: {
+            // We initialize a state s.t. q₀+δt⋅v₀ < qₗ < q₀.
+            joint_q0 = ql + kPositiveDeltaQ;
+            const double qp = ql - kPositiveDeltaQ;
+            joint_v0 = (qp - joint_q0) / dt;
+            break;
+          }
+          case InitializePositionAt::AboveUpperLimit: {
+            joint_q0 = qu > 0 ? 1.2 * qu : 0.8 * qu;
+            joint_v0 = joint_index * 2.3;  // Arbitrary.
+            break;
+          }
+          case InitializePositionAt::BelowUpperLimitThoughPredictionAbove: {
+            // We initialize a state s.t. q₀ < qᵤ < q₀+δt⋅v₀.
+            joint_q0 = qu - kPositiveDeltaQ;
+            const double qp = qu + kPositiveDeltaQ;
+            joint_v0 = (qp - joint_q0) / dt;
+            break;
+          }
+          case InitializePositionAt::WellWithinLimits: {
+            joint_q0 = 0.5 * (ql + qu);  // q in (ql, qu)
+            joint_v0 = 0.0;
+            break;
+          }
+          default:
+            DRAKE_UNREACHABLE();
+        }
+
+        q0(v_index) = joint_q0;
+        v0(v_index) = joint_v0;
+      }
+    }
+
+    plant.SetPositions(context, q0);
+    plant.SetVelocities(context, v0);
+  }
+
+  // Fixes all input ports to have non-zero actuation.
+  void SetArbitraryNonZeroActuation(const MultibodyPlant<double>& plant,
+                                    ModelInstanceIndex arm_model,
+                                    ModelInstanceIndex gripper_model,
+                                    Context<double>* context) const {
+    const VectorX<double> tau_arm = VectorX<double>::LinSpaced(
+        plant.num_actuated_dofs(arm_model), 10.0, 1000.0);
+    const VectorX<double> tau_gripper = VectorX<double>::LinSpaced(
+        plant.num_actuated_dofs(gripper_model), 10.0, 1000.0);
+    plant.get_actuation_input_port(arm_model).FixValue(context, tau_arm);
+    plant.get_actuation_input_port(gripper_model)
+        .FixValue(context, tau_gripper);
+  }
+
+ private:
+  std::vector<ModelInstanceIndex> LoadIiwaWithGripper(
+      int robot_number, MultibodyPlant<double>* plant) const {
+    DRAKE_DEMAND(plant != nullptr);
+    const char kArmFilePath[] =
+        "drake/manipulation/models/iiwa_description/urdf/"
+        "iiwa14_no_collision.urdf";
+
+    const char kWsg50FilePath[] =
+        "drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50.sdf";
+
+    Parser parser(plant);
+    ModelInstanceIndex arm_model =
+        parser.AddModelFromFile(FindResourceOrThrow(kArmFilePath),
+                                "robot_" + std::to_string(robot_number));
+
+    // Add the gripper.
+    ModelInstanceIndex gripper_model =
+        parser.AddModelFromFile(FindResourceOrThrow(kWsg50FilePath),
+                                "gripper_" + std::to_string(robot_number));
+
+    const auto& base_body = plant->GetBodyByName("base", arm_model);
+    const auto& end_effector = plant->GetBodyByName("iiwa_link_7", arm_model);
+    const auto& gripper_body = plant->GetBodyByName("body", gripper_model);
+    plant->WeldFrames(plant->world_frame(), base_body.body_frame());
+    plant->WeldFrames(end_effector.body_frame(), gripper_body.body_frame());
+
+    return {arm_model, gripper_model};
+  }
+
+  void AddInReflectedInertia(MultibodyPlant<double>* plant,
+                             const std::vector<ModelInstanceIndex>& models,
+                             const VectorX<double>& rotor_inertias,
+                             const VectorX<double>& gear_ratios) const {
+    DRAKE_DEMAND(plant != nullptr);
+    int local_joint_index = 0;
+    for (JointActuatorIndex index(0); index < plant->num_actuators(); ++index) {
+      JointActuator<double>& joint_actuator =
+          plant->get_mutable_joint_actuator(index);
+      if (std::count(models.begin(), models.end(),
+                     joint_actuator.model_instance()) > 0) {
+        joint_actuator.set_default_rotor_inertia(
+            rotor_inertias(local_joint_index));
+        joint_actuator.set_default_gear_ratio(gear_ratios(local_joint_index));
+        local_joint_index++;
+      }
+    }
+  }
+
+  // Set arbitrary state, though within joint limits.
+  void SetArbitraryState(const MultibodyPlant<double>& plant,
+                         Context<double>* context) {
+    for (JointIndex joint_index(0); joint_index < plant.num_joints();
+         ++joint_index) {
+      const Joint<double>& joint = plant.get_joint(joint_index);
+      // This model only has weld, prismatic, and revolute joints.
+      if (joint.type_name() == "revolute") {
+        const RevoluteJoint<double>& revolute_joint =
+            dynamic_cast<const RevoluteJoint<double>&>(joint);
+        // Arbitrary position within position limits.
+        const double ql = revolute_joint.position_lower_limit();
+        const double qu = revolute_joint.position_upper_limit();
+        const double w = joint_index / kNumJoints;  // Number in (0,1).
+        const double q = w * ql + (1.0 - w) * qu;   // q in (ql, qu)
+        revolute_joint.set_angle(context, q);
+        // Arbitrary velocity.
+        revolute_joint.set_angular_rate(context, 0.5 * joint_index);
+      } else if (joint.type_name() == "prismatic") {
+        const PrismaticJoint<double>& prismatic_joint =
+            dynamic_cast<const PrismaticJoint<double>&>(joint);
+        // Arbitrary position within position limits.
+        const double ql = prismatic_joint.position_lower_limit();
+        const double qu = prismatic_joint.position_upper_limit();
+        const double w = joint_index / kNumJoints;  // Number in (0,1).
+        const double q = w * ql + (1.0 - w) * qu;   // q in (ql, qu)
+        prismatic_joint.set_translation(context, q);
+        // Arbitrary velocity.
+        prismatic_joint.set_translation_rate(context, 0.5 * joint_index);
+      }
+    }
+  }
+
+ protected:
+  const int kNumJoints = 9;
+  const double kTimeStep{0.015};
+  const VectorXd kRotorInertias{VectorXd::LinSpaced(kNumJoints, 0.1, 12.0)};
+  const VectorXd kGearRatios{VectorXd::LinSpaced(kNumJoints, 1.5, 100.0)};
+  const double kCouplerGearRatio{-1.5};
+  const double kCouplerOffset{3.1};
+  MultibodyPlant<double> plant_{kTimeStep};
+  CompliantContactManager<double>* manager_{nullptr};
+  std::unique_ptr<Context<double>> context_;
+};
+
+// This test verifies that the linear dynamics matrix is properly computed
+// according to A = ∂m/∂v = (M + dt⋅D).
+TEST_F(KukaIiwaArmTests, CalcLinearDynamicsMatrix) {
+  SetSingleRobotModel();
+  const std::vector<MatrixXd> A =
+      SapDriverTest::CalcLinearDynamicsMatrix(sap_driver(), *context_);
+  const int nv = plant_.num_velocities();
+  MatrixXd Adense = MatrixXd::Zero(nv, nv);
+  const MultibodyTreeTopology& topology =
+      CompliantContactManagerTester::topology(*manager_);
+  for (TreeIndex t(0); t < topology.num_trees(); ++t) {
+    const int tree_start = topology.tree_velocities_start(t);
+    const int tree_nv = topology.num_tree_velocities(t);
+    Adense.block(tree_start, tree_start, tree_nv, tree_nv) = A[t];
+  }
+  const MatrixXd Aexpected =
+      CalcLinearDynamicsMatrixIncludingImplicitDampingContribution();
+  EXPECT_TRUE(
+      CompareMatrices(Adense, Aexpected, kEps, MatrixCompareType::relative));
+}
+
+// This test verifies that the computation of free motion velocities v*
+// correctly include the effect of damping implicitly.
+TEST_F(KukaIiwaArmTests, CalcFreeMotionVelocities) {
+  SetSingleRobotModel();
+  const VectorXd v_star =
+      SapDriverTest::CalcFreeMotionVelocities(sap_driver(), *context_);
+
+  MultibodyForces<double> forces(plant_);
+  CompliantContactManagerTester::CalcNonContactForces(*manager_, *context_,
+                                                      &forces);
+  const VectorXd zero_vdot = VectorXd::Zero(plant_.num_velocities());
+  const VectorXd k0 = -plant_.CalcInverseDynamics(*context_, zero_vdot, forces);
+
+  // A = M + dt*D
+  const MatrixXd A =
+      CalcLinearDynamicsMatrixIncludingImplicitDampingContribution();
+  const VectorXd a = A.ldlt().solve(k0);
+  const VectorXd& v0 = plant_.GetVelocities(*context_);
+  const VectorXd v_star_expected = v0 + plant_.time_step() * a;
+
+  EXPECT_TRUE(CompareMatrices(v_star, v_star_expected, 5.0 * kEps,
+                              MatrixCompareType::relative));
+}
+
+// This unit test simply verifies that the manager is loading acceleration
+// kinematics with the proper results. The correctness of the computations we
+// rely on in this test (computation of accelerations) are tested elsewhere.
+TEST_F(KukaIiwaArmTests, CalcAccelerationKinematicsCache) {
+  SetSingleRobotModel();
+  const VectorXd& v0 = plant_.GetVelocities(*context_);
+  ContactSolverResults<double> contact_results;
+  manager_->CalcContactSolverResults(*context_, &contact_results);
+  const VectorXd a_expected =
+      (contact_results.v_next - v0) / plant_.time_step();
+  std::vector<SpatialAcceleration<double>> A_WB_expected(plant_.num_bodies());
+  plant_.CalcSpatialAccelerationsFromVdot(*context_, a_expected,
+                                          &A_WB_expected);
+
+  // Verify CompliantContactManager loads the acceleration kinematics with the
+  // proper results.
+  AccelerationKinematicsCache<double> ac(
+      CompliantContactManagerTester::topology(*manager_));
+  manager_->CalcAccelerationKinematicsCache(*context_, &ac);
+  EXPECT_TRUE(CompareMatrices(ac.get_vdot(), a_expected));
+  for (BodyIndex b(0); b < plant_.num_bodies(); ++b) {
+    const auto& body = plant_.get_body(b);
+    EXPECT_TRUE(ac.get_A_WB(body.node_index()).IsApprox(A_WB_expected[b]));
+  }
+}
+
+TEST_F(KukaIiwaArmTests, LimitConstraints) {
+  SetSingleRobotModel();
+  // Arbitrary selection of how positions and velocities are initialized.
+  std::vector<InitializePositionAt> limits_specification(
+      kNumJoints, InitializePositionAt::WellWithinLimits);
+  limits_specification[0] = InitializePositionAt::BelowLowerLimit;
+  limits_specification[1] = InitializePositionAt::AboveUpperLimit;
+  limits_specification[2] =
+      InitializePositionAt::AboveLowerLimitThoughPredictionBelow;
+  limits_specification[3] =
+      InitializePositionAt::BelowUpperLimitThoughPredictionAbove;
+  limits_specification[4] = InitializePositionAt::WellWithinLimits;
+  limits_specification[5] = InitializePositionAt::BelowLowerLimit;
+  limits_specification[6] = InitializePositionAt::AboveUpperLimit;
+  limits_specification[7] = InitializePositionAt::WellWithinLimits;
+  limits_specification[8] = InitializePositionAt::WellWithinLimits;
+
+  // Three joints are WellWithinLimits.
+  const int kNumJointsWithLimits = 6;
+  const int kNumConstraintEquations = 6;
+  SetArbitraryStateWithLimitsSpecification(plant_, limits_specification,
+                                           context_.get());
+
+  const std::vector<DiscreteContactPair<double>>& discrete_pairs =
+      CompliantContactManagerTester::EvalDiscreteContactPairs(*manager_,
+                                                              *context_);
+  const int num_contacts = discrete_pairs.size();
+  // We are assuming there is no contact. Assert this.
+  ASSERT_EQ(num_contacts, 0);
+
+  const ContactProblemCache<double>& problem_cache =
+      SapDriverTest::EvalContactProblemCache(sap_driver(), *context_);
+  const SapContactProblem<double>& problem = *problem_cache.sap_problem;
+
+  // This model has no contact. We expect the number of constraints and
+  // equations be consistent with limits_specification defined above.
+  // Recall the model has one additional constraint to model the coupler between
+  // the gripper fingers.
+  EXPECT_EQ(problem.num_constraints(), kNumJointsWithLimits + 1);
+  EXPECT_EQ(problem.num_constraint_equations(), kNumConstraintEquations + 1);
+
+  // In this model we clearly have single tree, the arm with its gripper.
+  const int tree_expected = 0;
+
+  int num_constraints = 0;  // count number of constraints visited.
+  // The manager adds limit constraints in the order joints are specified.
+  // Therefore we verify the limit constrant for each joint.
+  for (JointIndex joint_index(0); joint_index < plant_.num_joints();
+       ++joint_index) {
+    const Joint<double>& joint = plant_.get_joint(joint_index);
+    if (joint.num_velocities() == 1) {
+      const int v_index = joint.velocity_start();
+      const InitializePositionAt limit_spec = limits_specification[v_index];
+
+      if (limit_spec != InitializePositionAt::WellWithinLimits) {
+        // Get limit constraint for the specific joint.
+        const auto* constraint =
+            dynamic_cast<const SapLimitConstraint<double>*>(
+                &problem.get_constraint(num_constraints++));
+        // Since the spec is not WellWithinLimits, we expect a constraint added.
+        ASSERT_NE(constraint, nullptr);
+
+        // Limit constraints always apply to a single tree in the multibody
+        // forest.
+        EXPECT_EQ(constraint->num_cliques(), 1);
+
+        // There is a single tree in this model, the arm with gripper.
+        EXPECT_EQ(constraint->first_clique(), tree_expected);
+
+        EXPECT_EQ(constraint->clique_dof(), v_index);
+
+        // Each constraints acts on the same tree (the arm+gripper) with a total
+        // of kNumJoint DOFs in that tree.
+        EXPECT_EQ(constraint->first_clique_jacobian().cols(), kNumJoints);
+
+        // Verify the plant's state is consistent with the constraint's state.
+        const double q0 = joint.GetOnePosition(*context_);
+        EXPECT_EQ(constraint->position(), q0);
+
+        // N.B. Default values implemented in
+        // SapDriver::AddLimitConstraints(), keep these values in
+        // sync.
+        const SapLimitConstraint<double>::Parameters& params =
+            constraint->parameters();
+        EXPECT_EQ(params.stiffness(), 1.0e12);
+        EXPECT_EQ(params.dissipation_time_scale(), plant_.time_step());
+        EXPECT_EQ(params.beta(), 0.1);
+
+        const bool lower_limit_expected =
+            limit_spec == InitializePositionAt::BelowLowerLimit ||
+            limit_spec ==
+                InitializePositionAt::AboveLowerLimitThoughPredictionBelow;
+        const bool upper_limit_expected =
+            limit_spec == InitializePositionAt::AboveUpperLimit ||
+            limit_spec ==
+                InitializePositionAt::BelowUpperLimitThoughPredictionAbove;
+
+        const int expected_num_equations =
+            lower_limit_expected && upper_limit_expected ? 2 : 1;
+        EXPECT_EQ(constraint->num_constraint_equations(),
+                  expected_num_equations);
+        EXPECT_EQ(constraint->first_clique_jacobian().rows(),
+                  expected_num_equations);
+
+        const double kInf = std::numeric_limits<double>::infinity();
+        const double ql_expected =
+            lower_limit_expected ? joint.position_lower_limits()[0] : -kInf;
+        const double qu_expected =
+            upper_limit_expected ? joint.position_upper_limits()[0] : kInf;
+
+        EXPECT_EQ(params.lower_limit(), ql_expected);
+        EXPECT_EQ(params.upper_limit(), qu_expected);
+      }
+    }
+  }
+  EXPECT_EQ(num_constraints, kNumJointsWithLimits);
+}
+
+// This test verifies that the manager properly added holonomic constraints for
+// the coupler constraints specified in the MultibodyPlant model.
+TEST_F(KukaIiwaArmTests, CouplerConstraints) {
+  // Only SAP supports the modeling of constraints.
+  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+
+  // Load two robot models.
+  std::vector<ModelInstanceIndex> arm_gripper1 = SetUpArmModel(1, &plant_);
+  std::vector<ModelInstanceIndex> arm_gripper2 = SetUpArmModel(2, &plant_);
+
+  // For testing purposes, we'll add a coupler constraint between joints in two
+  // different arms.
+  const Joint<double>& arm1_joint3 =
+      plant_.GetJointByName("iiwa_joint_3", arm_gripper1[0]);
+  const Joint<double>& arm2_joint6 =
+      plant_.GetJointByName("iiwa_joint_6", arm_gripper2[0]);
+  ConstraintIndex constraint_index = plant_.AddCouplerConstraint(
+      arm1_joint3, arm2_joint6, kCouplerGearRatio, kCouplerOffset);
+  EXPECT_EQ(constraint_index, ConstraintIndex(2));
+
+  plant_.Finalize();
+
+  // There should be three coupler constraints: one for each gripper and a third
+  // one between the two arms.
+  EXPECT_EQ(plant_.num_constraints(), 3);
+
+  // Set manager using the experimental API so that we can bring it to scope.
+  auto owned_contact_manager =
+      std::make_unique<CompliantContactManager<double>>();
+  manager_ = owned_contact_manager.get();
+  plant_.SetDiscreteUpdateManager(std::move(owned_contact_manager));
+
+  context_ = plant_.CreateDefaultContext();
+  SetArbitraryNonZeroActuation(plant_, arm_gripper1[0], arm_gripper1[1],
+                               context_.get());
+  SetArbitraryNonZeroActuation(plant_, arm_gripper2[0], arm_gripper2[1],
+                               context_.get());
+
+  // Specify a state in which all kNumJoints are within limits so that we know
+  // the contact problem has no limit constraints.
+  std::vector<InitializePositionAt> limits_specification(
+      2 * kNumJoints, InitializePositionAt::WellWithinLimits);
+  SetArbitraryStateWithLimitsSpecification(plant_, limits_specification,
+                                           context_.get());
+
+  // We are assuming there is no contact. Assert this.
+  const std::vector<DiscreteContactPair<double>>& discrete_pairs =
+      CompliantContactManagerTester::EvalDiscreteContactPairs(*manager_,
+                                                              *context_);
+  const int num_contacts = discrete_pairs.size();
+  ASSERT_EQ(num_contacts, 0);
+
+  const ContactProblemCache<double>& problem_cache =
+      SapDriverTest::EvalContactProblemCache(sap_driver(), *context_);
+  const SapContactProblem<double>& problem = *problem_cache.sap_problem;
+
+  // This model has no contact and the configuration is set to be within joint
+  // limits. Therefore we expect the problem to have the three couple
+  // constraints we added to the model.
+  EXPECT_EQ(problem.num_constraints(), 3);
+  EXPECT_EQ(problem.num_constraint_equations(), 3);
+
+  std::vector<std::pair<JointIndex, JointIndex>> coupler_joints;
+  // Coupler on first robot's gripper.
+  coupler_joints.push_back({
+      plant_.GetJointByName("left_finger_sliding_joint", arm_gripper1[1])
+          .index(),
+      plant_.GetJointByName("right_finger_sliding_joint", arm_gripper1[1])
+          .index(),
+  });
+
+  // Coupler on second robot's gripper.
+  coupler_joints.push_back({
+      plant_.GetJointByName("left_finger_sliding_joint", arm_gripper2[1])
+          .index(),
+      plant_.GetJointByName("right_finger_sliding_joint", arm_gripper2[1])
+          .index(),
+  });
+
+  // Coupler between the two robots.
+  coupler_joints.push_back({
+      plant_.GetJointByName("iiwa_joint_3", arm_gripper1[0]).index(),
+      plant_.GetJointByName("iiwa_joint_6", arm_gripper2[0]).index(),
+  });
+
+  // Verify each of the coupler constraints.
+  for (int i = 0; i < 3; ++i) {
+    const auto* constraint =
+        dynamic_cast<const SapHolonomicConstraint<double>*>(
+            &problem.get_constraint(i));
+
+    // Verify it is a SapHolonomicConstraint as expected.
+    ASSERT_NE(constraint, nullptr);
+
+    // There are two cliques in this model, one for each robot arm.
+    const int num_cliques = i == 2 ? 2 : 1;
+    EXPECT_EQ(constraint->num_cliques(), num_cliques);
+    const int first_clique = i == 1 ? 1 : 0;
+    EXPECT_EQ(constraint->first_clique(), first_clique);
+    if (i == 2) {
+      // constraint between the two robots.
+      EXPECT_EQ(constraint->second_clique(), 1);
+    }
+
+    const Joint<double>& joint0 = plant_.get_joint(coupler_joints[i].first);
+    const Joint<double>& joint1 = plant_.get_joint(coupler_joints[i].second);
+
+    // Verify the value of the constraint function.
+    const double q0 = joint0.GetOnePosition(*context_);
+    const double q1 = joint1.GetOnePosition(*context_);
+    const Vector1d g0_expected(q0 - kCouplerGearRatio * q1 - kCouplerOffset);
+    const VectorXd& g0 = constraint->constraint_function();
+    EXPECT_EQ(g0, g0_expected);
+
+    if (i < 2) {
+      // For the grippers, fingers are the last two DOFs in their tree.
+      const int left_index = 7;
+      const int right_index = 8;
+      const MatrixXd J_expected =
+          (VectorXd::Unit(kNumJoints, left_index) -
+           kCouplerGearRatio * VectorXd::Unit(kNumJoints, right_index))
+              .transpose();
+      EXPECT_EQ(constraint->first_clique_jacobian(), J_expected);
+    } else {
+      // The third constraint couples the two robot arms.
+      const MatrixXd J0_expected =
+          VectorXd::Unit(kNumJoints, 2 /* third joint. */).transpose();
+      const MatrixXd J1_expected =
+          -kCouplerGearRatio *
+          VectorXd::Unit(kNumJoints, 5 /* sixth joint. */).transpose();
+      EXPECT_EQ(constraint->first_clique_jacobian(), J0_expected);
+      EXPECT_EQ(constraint->second_clique_jacobian(), J1_expected);
+    }
+
+    // N.B. Default values implemented in
+    // SapDriver::AddCouplerConstraints(), keep these values in sync.
+    const Vector1d kInfinity =
+        Vector1d::Constant(std::numeric_limits<double>::infinity());
+    const SapHolonomicConstraint<double>::Parameters& params =
+        constraint->parameters();
+    EXPECT_EQ(params.impulse_lower_limits(), -kInfinity);
+    EXPECT_EQ(params.impulse_upper_limits(), kInfinity);
+    EXPECT_EQ(params.stiffnesses(), kInfinity);
+    EXPECT_EQ(params.relaxation_times(),
+              Vector1d::Constant(plant_.time_step()));
+    EXPECT_EQ(params.beta(), 0.1);
+  }
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/sap_driver_multidof_joints_test.cc
+++ b/multibody/plant/test/sap_driver_multidof_joints_test.cc
@@ -1,0 +1,209 @@
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/plant/compliant_contact_manager.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/sap_driver.h"
+#include "drake/multibody/plant/test/compliant_contact_manager_tester.h"
+#include "drake/multibody/tree/space_xyz_mobilizer.h"
+
+/* @file This file provides testing for the SapDriver's limited support for
+joint limits on joints with multiple degrees of freedom. */
+
+using drake::multibody::contact_solvers::internal::SapContactProblem;
+using drake::systems::Context;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Friend class used to provide access to a selection of private functions in
+// SapDriver for testing purposes.
+class SapDriverTest {
+ public:
+  static void AddLimitConstraints(const SapDriver<double>& driver,
+                                  const Context<double>& context,
+                                  const VectorXd& v_star,
+                                  SapContactProblem<double>* problem) {
+    driver.AddLimitConstraints(context, v_star, problem);
+  }
+};
+
+// This joint is used to verify the support of multi-DOF joints with/without
+// joint limits. In particular, SapDriver does not support limits
+// for constraints with more than 1 DOF and therefore we expect the driver to
+// throw an exception when building the problem.
+// The implementation for this joint is incomplete. Only the strictly necessary
+// overrides for the unit tests in this file are implemented.
+template <typename T>
+class MultiDofJointWithLimits final : public Joint<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MultiDofJointWithLimits)
+
+  // Arbitrary number of DOFs, though larger than one for these tests.
+  static constexpr int kNumDofs = 3;
+
+  // The constructor allows to specify finite joint limits.
+  MultiDofJointWithLimits(const Frame<T>& frame_on_parent,
+                          const Frame<T>& frame_on_child,
+                          double pos_lower_limit, double pos_upper_limit)
+      : Joint<T>("MultiDofJointWithLimits", frame_on_parent, frame_on_child,
+                 VectorX<double>::Zero(kNumDofs),
+                 VectorX<double>::Constant(kNumDofs, pos_lower_limit),
+                 VectorX<double>::Constant(kNumDofs, pos_upper_limit),
+                 VectorX<double>::Constant(
+                     kNumDofs, -std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     kNumDofs, std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     kNumDofs, -std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     kNumDofs, std::numeric_limits<double>::infinity())) {
+    DRAKE_DEMAND(pos_lower_limit <= pos_upper_limit);
+  }
+
+  const std::string& type_name() const override {
+    static const never_destroyed<std::string> name{"MultiDofJointWithLimits"};
+    return name.access();
+  }
+
+ private:
+  // Make MultiDofJointWithLimits templated on every other scalar type a friend
+  // of MultiDofJointWithLimits<T> so that CloneToScalar<ToAnyOtherScalar>() can
+  // access private members of MultiDofJointWithLimits<T>.
+  template <typename>
+  friend class MultiDofJointWithLimits;
+
+  int do_get_num_velocities() const override { return kNumDofs; }
+  int do_get_num_positions() const override { return kNumDofs; }
+  // Dummy implementation, knowing our unit tests below have a single joint of
+  // this type.
+  int do_get_velocity_start() const override { return 0; }
+  int do_get_position_start() const override { return 0; }
+
+  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint()
+      const override {
+    auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
+    // The only restriction here relevant for these tests is that we provide a
+    // mobilizer with kNumDofs postions and velocities, so that indexes are
+    // consistent during MultibodyPlant::Finalize().
+    auto revolute_mobilizer = std::make_unique<internal::SpaceXYZMobilizer<T>>(
+        this->frame_on_parent(), this->frame_on_child());
+    blue_print->mobilizers_.push_back(std::move(revolute_mobilizer));
+    return blue_print;
+  }
+
+  // We do not need an implementation for the methods below since the unit tests
+  // do not exercise them. We mark them as "unreachable".
+
+  void DoAddInOneForce(const Context<T>&, int, const T&,
+                       MultibodyForces<T>*) const override {
+    DRAKE_UNREACHABLE();
+  }
+  void DoAddInDamping(const Context<T>&, MultibodyForces<T>*) const override {
+    DRAKE_UNREACHABLE();
+  }
+  std::string do_get_position_suffix(int) const override {
+    DRAKE_UNREACHABLE();
+  }
+  std::string do_get_velocity_suffix(int) const override {
+    DRAKE_UNREACHABLE();
+  }
+  void do_set_default_positions(const VectorX<double>&) override {
+    DRAKE_UNREACHABLE();
+  }
+  const T& DoGetOnePosition(const Context<T>&) const override {
+    DRAKE_UNREACHABLE();
+  }
+  const T& DoGetOneVelocity(const Context<T>&) const override {
+    DRAKE_UNREACHABLE();
+  }
+  std::unique_ptr<Joint<double>> DoCloneToScalar(
+      const internal::MultibodyTree<double>& tree_clone) const override {
+    DRAKE_UNREACHABLE();
+  }
+  std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
+      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override {
+    DRAKE_UNREACHABLE();
+  }
+  std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
+      const internal::MultibodyTree<symbolic::Expression>&) const override {
+    DRAKE_UNREACHABLE();
+  }
+};
+
+// Verify that SapDriver throws when the model contains multi-DOF
+// joints with finite limits.
+GTEST_TEST(MultiDofJointWithLimitsTest, ThrowForUnsupportedJoints) {
+  MultibodyPlant<double> plant(1.0e-3);
+  // N.B. Currently only SAP goes through the manager.
+  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  // To avoid unnecessary warnings/errors, use a non-zero spatial inertia.
+  const RigidBody<double>& body =
+      plant.AddRigidBody("DummyBody", SpatialInertia<double>::MakeUnitary());
+  plant.AddJoint(std::make_unique<MultiDofJointWithLimits<double>>(
+      plant.world_frame(), body.body_frame(), -1.0, 2.0));
+  plant.Finalize();
+  auto owned_contact_manager =
+      std::make_unique<CompliantContactManager<double>>();
+  CompliantContactManager<double>* contact_manager =
+      owned_contact_manager.get();
+  plant.SetDiscreteUpdateManager(std::move(owned_contact_manager));
+  auto context = plant.CreateDefaultContext();
+
+  // Dummy v* and problem.
+  const VectorXd v_star = Vector3d::Zero();
+  SapContactProblem<double> problem(plant.time_step());
+
+  const SapDriver<double>& driver =
+      CompliantContactManagerTester::sap_driver(*contact_manager);
+
+  // We verify the driver throws for the right reasons.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SapDriverTest::AddLimitConstraints(driver, *context, v_star, &problem),
+      "Limits for joints with more than one degree of "
+      "freedom are not supported(.|\n)*");
+}
+
+// Verify that SapDriver allows multi-DOF joints whenever these do
+// not specify finite limits.
+GTEST_TEST(MultiDofJointWithLimitsTest,
+           VerifyMultiDofJointsWithoutLimitsAreSupported) {
+  MultibodyPlant<double> plant(1.0e-3);
+  // N.B. Currently only SAP goes through the manager.
+  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  // To avoid unnecessary warnings/errors, use a non-zero spatial inertia.
+  const RigidBody<double>& body =
+      plant.AddRigidBody("DummyBody", SpatialInertia<double>::MakeUnitary());
+  const double kInf = std::numeric_limits<double>::infinity();
+  plant.AddJoint(std::make_unique<MultiDofJointWithLimits<double>>(
+      plant.world_frame(), body.body_frame(), -kInf, kInf));
+  plant.Finalize();
+  auto owned_contact_manager =
+      std::make_unique<CompliantContactManager<double>>();
+  CompliantContactManager<double>* contact_manager =
+      owned_contact_manager.get();
+  plant.SetDiscreteUpdateManager(std::move(owned_contact_manager));
+  auto context = plant.CreateDefaultContext();
+
+  const VectorXd v_star = Vector3d::Zero();
+  SapContactProblem<double> problem(plant.time_step());
+
+  const SapDriver<double>& driver =
+      CompliantContactManagerTester::sap_driver(*contact_manager);
+
+  EXPECT_NO_THROW(
+      SapDriverTest::AddLimitConstraints(driver, *context, v_star, &problem));
+
+  // No limit constraints are added since the only one joint in the model has
+  // no limits.
+  EXPECT_EQ(problem.num_constraints(), 0);
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/sap_driver_test.cc
+++ b/multibody/plant/test/sap_driver_test.cc
@@ -1,0 +1,350 @@
+#include "drake/multibody/plant/sap_driver.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/contact_solvers/contact_solver_results.h"
+#include "drake/multibody/contact_solvers/contact_solver_utils.h"
+#include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
+#include "drake/multibody/contact_solvers/sap/sap_friction_cone_constraint.h"
+#include "drake/multibody/contact_solvers/sap/sap_solver.h"
+#include "drake/multibody/contact_solvers/sap/sap_solver_results.h"
+#include "drake/multibody/plant/compliant_contact_manager.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/test/compliant_contact_manager_tester.h"
+#include "drake/multibody/plant/test/spheres_stack.h"
+
+using drake::multibody::contact_solvers::internal::ContactSolverResults;
+using drake::multibody::contact_solvers::internal::MergeNormalAndTangent;
+using drake::multibody::contact_solvers::internal::SapContactProblem;
+using drake::multibody::contact_solvers::internal::SapFrictionConeConstraint;
+using drake::multibody::contact_solvers::internal::SapSolver;
+using drake::multibody::contact_solvers::internal::SapSolverParameters;
+using drake::multibody::contact_solvers::internal::SapSolverResults;
+using drake::multibody::internal::DiscreteContactPair;
+using drake::systems::Context;
+using Eigen::MatrixXd;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+
+// TODO(amcastro-tri): Implement AutoDiffXd testing.
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+constexpr double kEps = std::numeric_limits<double>::epsilon();
+
+// Friend class used to provide access to a selection of private functions in
+// SapDriver for testing purposes.
+class SapDriverTest {
+ public:
+  static const ContactProblemCache<double>& EvalContactProblemCache(
+      const SapDriver<double>& driver, const Context<double>& context) {
+    return driver.EvalContactProblemCache(context);
+  }
+
+  static VectorXd CalcFreeMotionVelocities(const SapDriver<double>& driver,
+                                           const Context<double>& context) {
+    VectorXd v_star(driver.plant().num_velocities());
+    driver.CalcFreeMotionVelocities(context, &v_star);
+    return v_star;
+  }
+
+  static std::vector<MatrixXd> CalcLinearDynamicsMatrix(
+      const SapDriver<double>& driver, const Context<double>& context) {
+    std::vector<MatrixXd> A;
+    driver.CalcLinearDynamicsMatrix(context, &A);
+    return A;
+  }
+
+  static void PackContactSolverResults(
+      const SapDriver<double>& driver,
+      const contact_solvers::internal::SapContactProblem<double>& problem,
+      int num_contacts,
+      const contact_solvers::internal::SapSolverResults<double>& sap_results,
+      contact_solvers::internal::ContactSolverResults<double>*
+          contact_results) {
+    driver.PackContactSolverResults(problem, num_contacts, sap_results,
+                                    contact_results);
+  }
+};
+
+// Test fixture to test the functionality provided by SapDriver, with the
+// problem configuration implemented in SpheresStack (refer to that testing
+// class for details on the configuration.)
+class SpheresStackTest : public SpheresStack, public ::testing::Test {
+ public:
+  const SapDriver<double>& sap_driver() const {
+    return CompliantContactManagerTester::sap_driver(*contact_manager_);
+  }
+
+  // The functions below provide access to private SapDriver functions for unit
+  // testing.
+
+  const ContactProblemCache<double>& EvalContactProblemCache(
+      const Context<double>& context) const {
+    return SapDriverTest::EvalContactProblemCache(sap_driver(), context);
+  }
+
+  VectorXd CalcFreeMotionVelocities(const Context<double>& context) const {
+    VectorXd v_star(plant_->num_velocities());
+    return SapDriverTest::CalcFreeMotionVelocities(sap_driver(), context);
+  }
+
+  std::vector<MatrixXd> CalcLinearDynamicsMatrix(
+      const Context<double>& context) const {
+    return SapDriverTest::CalcLinearDynamicsMatrix(sap_driver(), context);
+  }
+
+  void PackContactSolverResults(
+      const contact_solvers::internal::SapContactProblem<double>& problem,
+      int num_contacts,
+      const contact_solvers::internal::SapSolverResults<double>& sap_results,
+      contact_solvers::internal::ContactSolverResults<double>* contact_results)
+      const {
+    SapDriverTest::PackContactSolverResults(sap_driver(), problem, num_contacts,
+                                            sap_results, contact_results);
+  }
+
+  // The functions below provide access to private CompliantContactManager
+  // functions for unit testing.
+
+  const internal::MultibodyTreeTopology& topology() const {
+    return CompliantContactManagerTester::topology(*contact_manager_);
+  }
+
+  const std::vector<DiscreteContactPair<double>>& EvalDiscreteContactPairs(
+      const Context<double>& context) const {
+    return CompliantContactManagerTester::EvalDiscreteContactPairs(
+        *contact_manager_, context);
+  }
+
+  std::vector<ContactPairKinematics<double>> CalcContactKinematics(
+      const Context<double>& context) const {
+    return CompliantContactManagerTester::CalcContactKinematics(
+        *contact_manager_, context);
+  }
+};
+
+// This test verifies that the SapContactProblem built by the driver is
+// consistent with the contact kinematics computed with CalcContactKinematics().
+TEST_F(SpheresStackTest, EvalContactProblemCache) {
+  SetupRigidGroundCompliantSphereAndNonHydroSphere();
+  const ContactProblemCache<double>& problem_cache =
+      EvalContactProblemCache(*plant_context_);
+  const SapContactProblem<double>& problem = *problem_cache.sap_problem;
+  const std::vector<drake::math::RotationMatrix<double>>& R_WC =
+      problem_cache.R_WC;
+
+  const std::vector<DiscreteContactPair<double>>& pairs =
+      EvalDiscreteContactPairs(*plant_context_);
+  const int num_contacts = pairs.size();
+
+  // Verify sizes.
+  EXPECT_EQ(problem.num_cliques(), topology().num_trees());
+  EXPECT_EQ(problem.num_velocities(), plant_->num_velocities());
+  EXPECT_EQ(problem.num_constraints(), num_contacts);
+  EXPECT_EQ(problem.num_constraint_equations(), 3 * num_contacts);
+  EXPECT_EQ(problem.time_step(), plant_->time_step());
+  ASSERT_EQ(R_WC.size(), num_contacts);
+
+  // Verify dynamics data.
+  const VectorXd& v_star = CalcFreeMotionVelocities(*plant_context_);
+  const std::vector<MatrixXd>& A = CalcLinearDynamicsMatrix(*plant_context_);
+  EXPECT_EQ(problem.v_star(), v_star);
+  EXPECT_EQ(problem.dynamics_matrix(), A);
+
+  // Verify each of the contact constraints.
+  const std::vector<ContactPairKinematics<double>> contact_kinematics =
+      CalcContactKinematics(*plant_context_);
+  for (size_t i = 0; i < contact_kinematics.size(); ++i) {
+    const DiscreteContactPair<double>& discrete_pair = pairs[i];
+    const ContactPairKinematics<double>& pair_kinematics =
+        contact_kinematics[i];
+    const auto* constraint =
+        dynamic_cast<const SapFrictionConeConstraint<double>*>(
+            &problem.get_constraint(i));
+    // In this test we do know all constraints are contact constraints.
+    ASSERT_NE(constraint, nullptr);
+    EXPECT_EQ(constraint->constraint_function(),
+              Vector3d(0., 0., pair_kinematics.phi));
+    EXPECT_EQ(constraint->num_cliques(), pair_kinematics.jacobian.size());
+    EXPECT_EQ(constraint->first_clique(), pair_kinematics.jacobian[0].tree);
+    EXPECT_EQ(constraint->first_clique_jacobian(),
+              pair_kinematics.jacobian[0].J);
+    if (constraint->num_cliques() == 2) {
+      EXPECT_EQ(constraint->second_clique(), pair_kinematics.jacobian[1].tree);
+      EXPECT_EQ(constraint->second_clique_jacobian(),
+                pair_kinematics.jacobian[1].J);
+    }
+    EXPECT_EQ(constraint->parameters().mu, discrete_pair.friction_coefficient);
+    EXPECT_EQ(constraint->parameters().stiffness, discrete_pair.stiffness);
+    EXPECT_EQ(constraint->parameters().dissipation_time_scale,
+              discrete_pair.dissipation_time_scale);
+    // These two parameters, beta and sigma, are for now hard-code in the
+    // manager to these values. Here we simply tests they are consistent with
+    // those hard-coded values.
+    EXPECT_EQ(constraint->parameters().beta, 1.0);
+    EXPECT_EQ(constraint->parameters().sigma, 1.0e-3);
+
+    // Verify contact frame orientation matrix R_WC.
+    EXPECT_EQ(R_WC[i].matrix(), pair_kinematics.R_WC.matrix());
+  }
+}
+
+// Verifies the correctness of the computation of free motion velocities when
+// external forces are applied.
+TEST_F(SpheresStackTest, CalcFreeMotionVelocitiesWithExternalForces) {
+  SetupRigidGroundCompliantSphereAndNonHydroSphere();
+
+  // We set an arbitrary non-zero external force to the plant to verify it gets
+  // properly applied as part of the computation.
+  const int nv = plant_->num_velocities();
+  const VectorXd tau = VectorXd::LinSpaced(nv, 1.0, 2.0);
+  plant_->get_applied_generalized_force_input_port().FixValue(plant_context_,
+                                                              tau);
+
+  // Set arbitrary non-zero velocities.
+  const VectorXd v0 = VectorXd::LinSpaced(nv, 2.0, 3.0);
+  plant_->SetVelocities(plant_context_, v0);
+
+  // Since the spheres's frames are located at their COM and since their
+  // rotational inertias are triaxially symmetric, the Coriolis term is zero.
+  // Therefore the momentum equation reduces to: M * (v-v0)/dt = tau_g + tau.
+  const double dt = plant_->time_step();
+  const VectorXd tau_g = plant_->CalcGravityGeneralizedForces(*plant_context_);
+  MatrixXd M(nv, nv);
+  plant_->CalcMassMatrix(*plant_context_, &M);
+  const VectorXd v_expected = v0 + dt * M.ldlt().solve(tau_g + tau);
+
+  // Compute the velocities the system would have next time step in the absence
+  // of constraints.
+  const VectorXd v_star = CalcFreeMotionVelocities(*plant_context_);
+
+  EXPECT_TRUE(
+      CompareMatrices(v_star, v_expected, kEps, MatrixCompareType::relative));
+}
+
+// Verifies that joint limit forces are applied.
+TEST_F(SpheresStackTest, CalcFreeMotionVelocitiesWithJointLimits) {
+  // In this model sphere 1 is attached to the world by a prismatic joint with
+  // lower limit z = 0.
+  const bool sphere1_on_prismatic_joint = true;
+  SetupRigidGroundCompliantSphereAndNonHydroSphere(sphere1_on_prismatic_joint);
+
+  const int nv = plant_->num_velocities();
+
+  // Set arbitrary non-zero velocities.
+  const VectorXd non_zero_vs = VectorXd::LinSpaced(nv, 2.0, 3.0);
+  plant_->SetVelocities(plant_context_, non_zero_vs);
+
+  // The slider velocity is set to be negative to ensure the joint limit is
+  // active. That is, the position was set to be below the lower limit and in
+  // addition it is decreasing.
+  slider1_->set_translation_rate(plant_context_, -1.0);
+
+  // Initial velocities.
+  const VectorXd v0 = plant_->GetVelocities(*plant_context_);
+
+  // Compute slider1's velocity in the absence of joint limits. This is
+  // equivalent to computing the free motion velocities before constraints are
+  // applied.
+  const VectorXd v_expected = CalcFreeMotionVelocities(*plant_context_);
+  const double v_slider_no_limits = v_expected(slider1_->velocity_start());
+
+  // Compute slider1's velocity with constraints applied. This corresponds to
+  // the full discrete update computation.
+  ContactSolverResults<double> contact_results;
+  contact_manager_->CalcContactSolverResults(*plant_context_, &contact_results);
+  const VectorXd v_star = contact_results.v_next;
+  const double v_slider_star = v_star(slider1_->velocity_start());
+
+  // While other solver specific tests verify the correctness of joint limit
+  // forces, this test is simply limited to verifying the manager applied them.
+  // Therefore we only check the force limits have the effect of making the
+  // slider velocity larger than if not present.
+  EXPECT_GT(v_slider_star, v_slider_no_limits);
+}
+
+TEST_F(SpheresStackTest, CalcLinearDynamicsMatrix) {
+  SetupRigidGroundCompliantSphereAndNonHydroSphere();
+  const std::vector<MatrixXd> A = CalcLinearDynamicsMatrix(*plant_context_);
+  const int nv = plant_->num_velocities();
+  MatrixXd Adense = MatrixXd::Zero(nv, nv);
+  for (TreeIndex t(0); t < topology().num_trees(); ++t) {
+    const int tree_start = topology().tree_velocities_start(t);
+    const int tree_nv = topology().num_tree_velocities(t);
+    Adense.block(tree_start, tree_start, tree_nv, tree_nv) = A[t];
+  }
+  MatrixXd Aexpected(nv, nv);
+  plant_->CalcMassMatrix(*plant_context_, &Aexpected);
+  EXPECT_TRUE(
+      CompareMatrices(Adense, Aexpected, kEps, MatrixCompareType::relative));
+}
+
+// Here we test the function CompliantContactManager::PackContactSolverResults()
+// which takes SapSolverResults and packs them into ContactSolverResults as
+// consumed by MultibodyPlant.
+TEST_F(SpheresStackTest, PackContactSolverResults) {
+  SetupRigidGroundCompliantSphereAndNonHydroSphere();
+
+  // We form an arbitrary set of SAP results consistent with the contact
+  // kinematics for the configuration of our model.
+  const std::vector<ContactPairKinematics<double>> contact_kinematics =
+      CalcContactKinematics(*plant_context_);
+  const int num_contacts = contact_kinematics.size();
+  const int nv = plant_->num_velocities();
+  SapSolverResults<double> sap_results;
+  sap_results.Resize(nv, 3 * num_contacts);
+  sap_results.v = VectorXd::LinSpaced(nv, -3.0, 14.0);
+  sap_results.gamma = VectorXd::LinSpaced(3 * num_contacts, -12.0, 8.0);
+  sap_results.vc = VectorXd::LinSpaced(3 * num_contacts, -1.0, 11.0);
+  // Not used to pack contact results.
+  sap_results.j = VectorXd::Constant(nv, NAN);
+
+  // Pack SAP results into contact results.
+  const SapContactProblem<double>& sap_problem =
+      *EvalContactProblemCache(*plant_context_).sap_problem;
+  ContactSolverResults<double> contact_results;
+  PackContactSolverResults(sap_problem, num_contacts, sap_results,
+                           &contact_results);
+
+  // Verify against expected values.
+  VectorXd gamma(3 * num_contacts);
+  MergeNormalAndTangent(contact_results.fn, contact_results.ft, &gamma);
+  gamma *= plant_->time_step();
+  EXPECT_TRUE(CompareMatrices(gamma, sap_results.gamma, kEps,
+                              MatrixCompareType::relative));
+  VectorXd vc(3 * num_contacts);
+  MergeNormalAndTangent(contact_results.vn, contact_results.vt, &vc);
+  EXPECT_TRUE(
+      CompareMatrices(vc, sap_results.vc, kEps, MatrixCompareType::relative));
+  const MatrixXd J_AcBc_C =
+      CompliantContactManagerTester::CalcDenseJacobianMatrixInContactFrame(
+          *contact_manager_, contact_kinematics);
+  const VectorXd tau_expected =
+      J_AcBc_C.transpose() * sap_results.gamma / plant_->time_step();
+  EXPECT_TRUE(CompareMatrices(contact_results.tau_contact, tau_expected,
+                              2.0 * kEps, MatrixCompareType::relative));
+}
+
+// Unit test that the manager throws an exception whenever SAP fails to
+// converge.
+TEST_F(SpheresStackTest, SapFailureException) {
+  SetupRigidGroundCompliantSphereAndNonHydroSphere();
+  ContactSolverResults<double> contact_results;
+  // To trigger SAP's failure, we limit the maximum number of iterations to
+  // zero.
+  SapSolverParameters parameters;
+  parameters.max_iterations = 0;
+  contact_manager_->set_sap_solver_parameters(parameters);
+  DRAKE_EXPECT_THROWS_MESSAGE(contact_manager_->CalcContactSolverResults(
+                                  *plant_context_, &contact_results),
+                              "The SAP solver failed to converge(.|\n)*");
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/spheres_stack.h
+++ b/multibody/plant/test/spheres_stack.h
@@ -1,0 +1,272 @@
+#pragma once
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "drake/geometry/proximity_properties.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/tree/prismatic_joint.h"
+
+using drake::geometry::ProximityProperties;
+using drake::geometry::SceneGraph;
+using drake::math::RigidTransformd;
+using drake::systems::Context;
+using Eigen::MatrixXd;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+
+// TODO(amcastro-tri): Implement AutoDiffXd testing.
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Helper function for NaN initialization.
+static constexpr double nan() {
+  return std::numeric_limits<double>::quiet_NaN();
+}
+
+// TODO(amcastro-tri): This testing class grew to cover a wide range of
+// functionalities that used to be part of CompliantContactManger previous to
+// #17741. Now this functionality has been split among driver classes such as
+// SapDriver, and more will be introduced. Therefore there is a chance here to
+// simplify the setup to only test functionality specific to each driver and/or
+// manager.
+
+// In this fixture we set a simple model consisting of a flat ground,
+// a sphere (sphere 1) on top of the ground, and another sphere (sphere 2)
+// on top the first sphere. They are assigned to be rigid-hydroelastic,
+// compliant-hydroelastic, or non-hydroelastic to test various cases of
+// contact quantities computed by the CompliantContactManager.
+class SpheresStack {
+ public:
+  // Contact model parameters.
+  struct ContactParameters {
+    // Point contact stiffness. If nullopt, this property is not added to the
+    // model.
+    std::optional<double> point_stiffness;
+    // Hydroelastic modulus. If nullopt, this property is not added to the
+    // model.
+    std::optional<double> hydro_modulus;
+    // Relaxation time constant τ is used to setup the linear dissipation model
+    // where dissipation is c = τ⋅k, with k the point pair stiffness.
+    // If nullopt, no dissipation is specified, i.e. the corresponding
+    // ProximityProperties will not have dissipation defined.
+    std::optional<double> relaxation_time;
+    // Coefficient of dynamic friction.
+    double friction_coefficient{nan()};
+  };
+
+  // Parameters used to setup the model of a compliant sphere.
+  struct SphereParameters {
+    const std::string name;
+    double mass;
+    double radius;
+    // No contact geometry is registered if nullopt.
+    std::optional<ContactParameters> contact_parameters;
+  };
+
+  // Sets up this fixture to have:
+  //   - A rigid-hydroelastic half-space for the ground.
+  //   - A compliant-hydroelastic sphere on top of the ground.
+  //   - A non-hydroelastic sphere on top of the first sphere.
+  //   - Both spheres also have point contact compliance.
+  //   - We set MultibodyPlant to use hydroelastic contact with fallback.
+  //   - Sphere 1 penetrates into the ground penetration_distance_.
+  //   - Sphere 1 and 2 penetrate penetration_distance_.
+  //   - Velocities are zero.
+  void SetupRigidGroundCompliantSphereAndNonHydroSphere(
+      bool sphere1_on_prismatic_joint = false) {
+    const ContactParameters compliant_contact{1.0e5, 1.0e5, 0.01, 1.0};
+    const ContactParameters non_hydro_contact{1.0e5, {}, 0.01, 1.0};
+    const ContactParameters rigid_hydro_contact{
+        std::nullopt, std::numeric_limits<double>::infinity(), 0.0, 1.0};
+    const SphereParameters sphere1_params{"Sphere1", 10.0 /* mass */,
+                                          0.2 /* size */, compliant_contact};
+    const SphereParameters sphere2_params{"Sphere2", 10.0 /* mass */,
+                                          0.2 /* size */, non_hydro_contact};
+    MakeModel(rigid_hydro_contact, sphere1_params, sphere2_params,
+              sphere1_on_prismatic_joint);
+  }
+
+  void SetupFreeFloatingSpheresWithNoContact() {
+    const bool sphere1_on_prismatic_joint = false;
+    const SphereParameters sphere1_params{"Sphere1", 10.0 /* mass */,
+                                          0.2 /* size */,
+                                          std::nullopt /* no contact */};
+    const SphereParameters sphere2_params{"Sphere2", 10.0 /* mass */,
+                                          0.2 /* size */,
+                                          std::nullopt /* no contact */};
+    MakeModel(std::nullopt /* no ground */, sphere1_params, sphere2_params,
+              sphere1_on_prismatic_joint);
+  }
+
+  // Sets up a model with two spheres and the ground.
+  // Spheres are defined by their SphereParameters. Ground contact is defined by
+  // `ground_params`, no ground is added if std::nullopt.
+  // Sphere 1 is mounted on a prismatic joint about the z axis if
+  // sphere1_on_prismatic_joint = true.
+  void MakeModel(const std::optional<ContactParameters>& ground_params,
+                 const SphereParameters& sphere1_params,
+                 const SphereParameters& sphere2_params,
+                 bool sphere1_on_prismatic_joint = false) {
+    systems::DiagramBuilder<double> builder;
+    std::tie(plant_, scene_graph_) =
+        AddMultibodyPlantSceneGraph(&builder, time_step_);
+    // N.B. Currently only SAP goes through the manager.
+    plant_->set_discrete_contact_solver(DiscreteContactSolver::kSap);
+
+    // Add model of the ground.
+    if (ground_params) {
+      const ProximityProperties ground_properties =
+          MakeProximityProperties(*ground_params);
+      plant_->RegisterCollisionGeometry(plant_->world_body(), RigidTransformd(),
+                                        geometry::HalfSpace(),
+                                        "ground_collision", ground_properties);
+      const Vector4<double> green(0.5, 1.0, 0.5, 1.0);
+      plant_->RegisterVisualGeometry(plant_->world_body(), RigidTransformd(),
+                                     geometry::HalfSpace(), "ground_visual",
+                                     green);
+    }
+
+    // Add models of the spheres.
+    sphere1_ = &AddSphere(sphere1_params);
+    sphere2_ = &AddSphere(sphere2_params);
+
+    // Model with sphere 1 mounted on a prismatic joint with lower limits.
+    if (sphere1_on_prismatic_joint) {
+      slider1_ = &plant_->AddJoint<PrismaticJoint>(
+          "Sphere1Slider", plant_->world_body(), std::nullopt, *sphere1_,
+          std::nullopt, Vector3<double>::UnitZ(),
+          sphere1_params.radius /* lower limit */);
+    }
+
+    plant_->mutable_gravity_field().set_gravity_vector(-gravity_ *
+                                                       Vector3d::UnitZ());
+
+    plant_->set_contact_model(
+        drake::multibody::ContactModel::kHydroelasticWithFallback);
+
+    plant_->Finalize();
+    auto owned_contact_manager =
+        std::make_unique<CompliantContactManager<double>>();
+    contact_manager_ = owned_contact_manager.get();
+    plant_->SetDiscreteUpdateManager(std::move(owned_contact_manager));
+
+    diagram_ = builder.Build();
+    diagram_context_ = diagram_->CreateDefaultContext();
+    plant_context_ =
+        &plant_->GetMyMutableContextFromRoot(diagram_context_.get());
+
+    SetContactState(sphere1_params, sphere2_params);
+  }
+
+  // Sphere 1 is set on top of the ground and sphere 2 sits right on top of
+  // sphere 1. We set the state of the model so that sphere 1 penetrates into
+  // the ground a distance penetration_distance_ and so that sphere 1 and 2 also
+  // interpenetrate a distance penetration_distance_.
+  // MakeModel() must have already been called.
+  void SetContactState(const SphereParameters& sphere1_params,
+                       const SphereParameters& sphere2_params) const {
+    DRAKE_DEMAND(plant_ != nullptr);
+    const double sphere1_com_z = sphere1_params.radius - penetration_distance_;
+    if (slider1_ != nullptr) {
+      slider1_->set_translation(plant_context_, sphere1_com_z);
+    } else {
+      const RigidTransformd X_WB1(Vector3d(0, 0, sphere1_com_z));
+      plant_->SetFreeBodyPose(plant_context_, *sphere1_, X_WB1);
+    }
+    const double sphere2_com_z = 2.0 * sphere1_params.radius +
+                                 sphere2_params.radius -
+                                 2.0 * penetration_distance_;
+    const RigidTransformd X_WB2(Vector3d(0, 0, sphere2_com_z));
+    plant_->SetFreeBodyPose(plant_context_, *sphere2_, X_WB2);
+  }
+
+  const MultibodyPlant<double>& plant() const { return *plant_; }
+  const CompliantContactManager<double>& manager() const {
+    return *contact_manager_;
+  }
+
+ protected:
+  // Arbitrary positive value so that the model is discrete.
+  double time_step_{0.001};
+
+  const double gravity_{10.0};  // Acceleration of gravity, in m/s².
+
+  // Default penetration distance. The configuration of the model is set so that
+  // ground/sphere1 and sphere1/sphere2 interpenetrate by this amount.
+  const double penetration_distance_{1.0e-3};
+
+  std::unique_ptr<systems::Diagram<double>> diagram_;
+  MultibodyPlant<double>* plant_{nullptr};
+  SceneGraph<double>* scene_graph_{nullptr};
+  const RigidBody<double>* sphere1_{nullptr};
+  const RigidBody<double>* sphere2_{nullptr};
+  const PrismaticJoint<double>* slider1_{nullptr};
+  CompliantContactManager<double>* contact_manager_{nullptr};
+  std::unique_ptr<Context<double>> diagram_context_;
+  Context<double>* plant_context_{nullptr};
+
+ private:
+  // Helper to add a spherical body into the model.
+  const RigidBody<double>& AddSphere(const SphereParameters& params) {
+    // Add rigid body.
+    const Vector3<double> p_BoBcm_B = Vector3<double>::Zero();
+    const UnitInertia<double> G_BBcm_B =
+        UnitInertia<double>::SolidSphere(params.radius);
+    const SpatialInertia<double> M_BBcm_B(params.mass, p_BoBcm_B, G_BBcm_B);
+    const RigidBody<double>& body = plant_->AddRigidBody(params.name, M_BBcm_B);
+
+    // Add collision geometry.
+    if (params.contact_parameters) {
+      const geometry::Sphere shape(params.radius);
+      const ProximityProperties properties =
+          MakeProximityProperties(*params.contact_parameters);
+      plant_->RegisterCollisionGeometry(body, RigidTransformd(), shape,
+                                        params.name + "_collision", properties);
+    }
+
+    return body;
+  }
+
+  // Utility to make ProximityProperties from ContactParameters.
+  // params.relaxation_time is ignored if nullopt.
+  static ProximityProperties MakeProximityProperties(
+      const ContactParameters& params) {
+    DRAKE_DEMAND(params.point_stiffness || params.hydro_modulus);
+    ProximityProperties properties;
+    if (params.hydro_modulus) {
+      if (params.hydro_modulus == std::numeric_limits<double>::infinity()) {
+        geometry::AddRigidHydroelasticProperties(/* resolution_hint */ 1.0,
+                                                 &properties);
+      } else {
+        geometry::AddCompliantHydroelasticProperties(
+            /* resolution_hint */ 1.0, *params.hydro_modulus, &properties);
+      }
+      // N.B. Add the slab thickness property by default so that we can model a
+      // half space (either compliant or rigid).
+      properties.AddProperty(geometry::internal::kHydroGroup,
+                             geometry::internal::kSlabThickness, 1.0);
+    }
+    geometry::AddContactMaterial(
+        /* "hunt_crossley_dissipation" */ {}, params.point_stiffness,
+        CoulombFriction<double>(params.friction_coefficient,
+                                params.friction_coefficient),
+        &properties);
+
+    if (params.relaxation_time.has_value()) {
+      properties.AddProperty(geometry::internal::kMaterialGroup,
+                             "relaxation_time", *params.relaxation_time);
+    }
+    return properties;
+  }
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
The purpose of this PR is to move everything related to the computation of discrete updates with SAP outside of the manager, which already contains significant functionality to evaluate discrete pairs (There might be an opportunity to split this functionality into another class, and let DiscreteUpdateManager be a thin shell that talks to MultibodyPlant).

Thus far in this PR I focused on taking all the code related to SAP into its own class.

Notes for platform review:
  1. With the move of SAP related code into SapDriver, the unit tests were also split between manager specific and driver specific tests. No new functionality nor new tests were added, simply moved to new files.
  2. SapDriver tests in turn were split into different files to group them into different "themes". Once again, no new code here, just the move of existing tests into new files to make the testing strategy more clear.

All in all, the only new concept introduced is that of a `SapDriver`, a class used to perform all computations specific to SAP (like building the contact problem for instance) and we let the driver do more solver-agnostic computations (like computing contact kinematics) and talk to the MBP to report the results of the discrete update.

Future PRs would focus on:
 1. A TamsiDriver, which would accomplish the same functionality but using the TAMSI solver.
 4. Removal of all TAMSI and discrete contact handling code from MultibodyPlant.
 5. Addressing the proper API design of DiscreteUpdateManager, towards #16955.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17741)
<!-- Reviewable:end -->
