### PR TITLE
[workspace] Support fmt v9 on macOS wheel

### DIFF
--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -413,6 +413,9 @@ def _generate_pybind_documentation_header_impl(ctx):
 
     # TODO(jamiesnape): Remove this line when #14034 is resolved.
     args.add("-DDRAKE_COMMON_SYMBOLIC_EXPRESSION_DETAIL_HEADER")
+
+    # TODO(svenevs): Remove when drake uses fmt 9+ ostream behavior.
+    args.add("-DFMT_DEPRECATED_OSTREAM=1")
     args.add_all(
         targets.compile_flags + target_deps.compile_flags,
         uniquify = True,


### PR DESCRIPTION
Closes #17739.

Re: [#buildcop discussion](https://drakedevelopers.slack.com/archives/C270MN28G/p1660826162888139), wheel does its own thing for dependencies via CMake, this should fix the macOS wheel build failure.

TODO:

- [X] Let the current wheel jobs finish.
- [X] `bazel-bin/tools/lint/buildifier tools/skylark/pybind.bzl`...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17743)
<!-- Reviewable:end -->
