### PR TITLE
Show bug when using std::map inside a pybound C++ schema

### DIFF
--- a/bindings/pydrake/common/test/serialize_pybind_test.py
+++ b/bindings/pydrake/common/test/serialize_pybind_test.py
@@ -36,14 +36,16 @@ class TestSerializePybind(unittest.TestCase):
         """Sanity checks the DefAttributesUsingSerialize overload that does not
         use docstrings.
         """
-        dut = MyData2(quux=1.0)
+        dut = MyData2(quux=1.0, bang={"bar": True})
         self.assertEqual(dut.quux, 1.0)
         dut.quux = -1.0
         self.assertEqual(dut.quux, -1.0)
+        dut.bang["bar"] = False
+        self.assertFalse(dut.bang["bar"])
         self.assertEqual(inspect.getdoc(MyData2.quux), "")
 
     def test_repr_using_serialize(self):
         self.assertEqual(repr(MyData(foo=1.0, bar=[2.0, 3.0])),
                          "MyData(foo=1.0, bar=[2.0, 3.0])")
         self.assertEqual(repr(MyData2(quux=1.0)),
-                         "MyData2(quux=1.0)")
+                         "MyData2(quux=1.0, bang={})")

--- a/bindings/pydrake/common/test/serialize_test_util_py.cc
+++ b/bindings/pydrake/common/test/serialize_test_util_py.cc
@@ -39,8 +39,10 @@ struct MyData2 {
   template <typename Archive>
   void Serialize(Archive* a) {
     a->Visit(DRAKE_NVP(quux));
+    a->Visit(DRAKE_NVP(bang));
   }
   double quux{0.0};
+  std::map<std::string, bool> bang;
 };
 
 }  // namespace


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17749)
<!-- Reviewable:end -->
