### PR TITLE
[geometry] Camera specification does more rigorous validation

### DIFF
--- a/geometry/render/render_camera.cc
+++ b/geometry/render/render_camera.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/render/render_camera.h"
 
+#include <cmath>
 #include <utility>
 
 #include <fmt/format.h>
@@ -12,10 +13,10 @@ using math::RigidTransformd;
 using systems::sensors::CameraInfo;
 
 ClippingRange::ClippingRange(double near, double far) : near_(near), far_(far) {
-  if (near <= 0 || far <= 0 || far <= near) {
+  if (near <= 0 || far <= 0 || far <= near || !std::isfinite(near + far)) {
     throw std::runtime_error(fmt::format(
-        "The clipping range values must both be positive and far must be "
-        "greater than near. Instantiated with near = {} and far = {}",
+        "The clipping range values must both be positive and finite and far "
+        "must be greater than near. Instantiated with near = {} and far = {}",
         near, far));
   }
 }
@@ -55,11 +56,12 @@ Eigen::Matrix4d RenderCameraCore::CalcProjectionMatrix() const {
 
 DepthRange::DepthRange(double min_in, double max_in)
     : min_depth_(min_in), max_depth_(max_in) {
-  if (min_depth_ <= 0 || max_depth_ <= 0 || max_depth_ <= min_depth_) {
+  if (min_in <= 0 || max_in <= 0 || max_in <= min_in ||
+      !std::isfinite(min_in + max_in)) {
     throw std::runtime_error(
-        fmt::format("The depth range values must both be positive and "
-                    "the maximum depth must be greater than the minimum depth. "
-                    "Instantiated with min = {} and max = {}",
+        fmt::format("The depth range values must both be positive and finite "
+                    "and the maximum depth must be greater than the minimum "
+                    "depth. Instantiated with min = {} and max = {}",
                     min_depth_, max_depth_));
   }
 }

--- a/geometry/render/render_camera.h
+++ b/geometry/render/render_camera.h
@@ -67,7 +67,7 @@ class ClippingRange {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ClippingRange);
 
   /** Constructs the %ClippingRange.
-   @throws std::exception if either value isn't positive, or if
+   @throws std::exception if either value isn't finite and positive, or if
                           `near >= far`.  */
   ClippingRange(double near, double far);
 
@@ -182,7 +182,7 @@ class DepthRange {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DepthRange);
 
   /** Constructs the %DepthRange.
-   @throws std::exception if either value isn't positive, or if
+   @throws std::exception if either value isn't finite and positive, or if
                           `min_in >= max_in`.  */
   DepthRange(double min_in, double max_in);
 

--- a/geometry/render/test/render_camera_test.cc
+++ b/geometry/render/test/render_camera_test.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/render/render_camera.h"
 
+#include <limits>
 #include <stdexcept>
 
 #include <fmt/format.h>
@@ -18,6 +19,9 @@ using Eigen::Vector3d;
 using math::RigidTransformd;
 using systems::sensors::CameraInfo;
 
+constexpr double kInf = std::numeric_limits<double>::infinity();
+constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+
 GTEST_TEST(ClippingRangeTest, Constructor) {
   {
     // Case: Valid values.
@@ -29,14 +33,22 @@ GTEST_TEST(ClippingRangeTest, Constructor) {
   {
     // Case: Bad values.
     const char* error_message =
-        "The clipping range values must both be positive and far must be "
-        "greater than near. Instantiated with near = {} and far = {}";
+        "The clipping range values must both be positive and finite and far "
+        "must be greater than near. Instantiated with near = {} and far = {}";
     DRAKE_EXPECT_THROWS_MESSAGE(ClippingRange(-0.1, 10),
                                 fmt::format(error_message, -0.1, 10.));
     DRAKE_EXPECT_THROWS_MESSAGE(ClippingRange(0.1, -10),
                                 fmt::format(error_message, 0.1, -10.0));
     DRAKE_EXPECT_THROWS_MESSAGE(ClippingRange(1.5, 1.0),
                                 fmt::format(error_message, 1.5, 1.0));
+    DRAKE_EXPECT_THROWS_MESSAGE(ClippingRange(kInf, 1.0),
+                                fmt::format(error_message, kInf, 1.0));
+    DRAKE_EXPECT_THROWS_MESSAGE(ClippingRange(kNaN, 1.0),
+                                fmt::format(error_message, kNaN, 1.0));
+    DRAKE_EXPECT_THROWS_MESSAGE(ClippingRange(1.0, kInf),
+                                fmt::format(error_message, 1.0, kInf));
+    DRAKE_EXPECT_THROWS_MESSAGE(ClippingRange(1.0, kNaN),
+                                fmt::format(error_message, 1.0, kNaN));
   }
 }
 
@@ -219,15 +231,23 @@ GTEST_TEST(DepthRangeTest, Constructor) {
   {
     // Case: Bad values.
     const char* error_message =
-        "The depth range values must both be positive and the maximum depth "
-        "must be greater than the minimum depth. Instantiated with min = {} "
-        "and max = {}";
+        "The depth range values must both be positive and finite and the "
+        "maximum depth must be greater than the minimum depth. Instantiated "
+        "with min = {} and max = {}";
     DRAKE_EXPECT_THROWS_MESSAGE(DepthRange(-0.1, 10),
                                 fmt::format(error_message, -0.1, 10.));
     DRAKE_EXPECT_THROWS_MESSAGE(DepthRange(0.1, -10),
                                 fmt::format(error_message, 0.1, -10.0));
     DRAKE_EXPECT_THROWS_MESSAGE(DepthRange(1.5, 1.0),
                                 fmt::format(error_message, 1.5, 1.0));
+    DRAKE_EXPECT_THROWS_MESSAGE(DepthRange(kInf, 1.0),
+                                fmt::format(error_message, kInf, 1.0));
+    DRAKE_EXPECT_THROWS_MESSAGE(DepthRange(kNaN, 1.0),
+                                fmt::format(error_message, kNaN, 1.0));
+    DRAKE_EXPECT_THROWS_MESSAGE(DepthRange(1.0, kInf),
+                                fmt::format(error_message, 1.0, kInf));
+    DRAKE_EXPECT_THROWS_MESSAGE(DepthRange(1.0, kNaN),
+                                fmt::format(error_message, 1.0, kNaN));
   }
 }
 

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -283,6 +283,7 @@ drake_cc_googletest(
     deps = [
         ":camera_info",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/systems/sensors/camera_info.h
+++ b/systems/sensors/camera_info.h
@@ -142,14 +142,19 @@ class CameraInfo final {
    Constructor that directly sets the image size, principal point, and focal
    lengths.
 
-   @param width    The image width in pixels, must be greater than zero.
-   @param height   The image height in pixels, must be greater than zero.
-   @param focal_x  The _model_ "focal length" x in pixels (as documented above).
-   @param focal_y  The _model_ "focal length" y in pixels (as documented above).
-   @param center_x The x coordinate of the principal point in pixels (as
-                   documented above).
-   @param center_y The y coordinate of the principal point in pixels (as
-                   documented above).
+   @param width      The image width in pixels, must be positive.
+   @param height     The image height in pixels, must be positive.
+   @param focal_x    The _model_ "focal length" x in pixels (see above), must be
+                     positive and finite.
+   @param focal_y    The _model_ "focal length" y in pixels (see above), must be
+                     positive and finite.
+   @param center_x   The x coordinate of the principal point in pixels (see
+                     above), must lie in the range 0 < center_x < width.
+   @param center_y   The y coordinate of the principal point in pixels (see
+                     above), must lie in the range 0 < center_y < height.
+
+   @throws std::exception if the provided values don't satisfy the listed
+   requirements.
   */
   CameraInfo(int width, int height, double focal_x, double focal_y,
              double center_x, double center_y);
@@ -158,9 +163,15 @@ class CameraInfo final {
    Constructs this instance by extracting focal_x, focal_y, center_x, and
    center_y from the provided intrinsic_matrix.
 
+   @param width             The image width in pixels, must be positive.
+   @param height            The image height in pixels, must be positive.
+   @param intrinsic_matrix  The intrinsic matrix (K) as documented above. Where
+                            K is defined to be non-zero, the values must be
+                            finite and the focal length values must be positive.
+
    @throws std::exception if intrinsic_matrix is not of the form indicated
    above for the pinhole camera model (representing an affine / homogeneous
-   transform).
+   transform) or the non-zero values don't meet the documented requirements.
   */
   CameraInfo(int width, int height, const Eigen::Matrix3d& intrinsic_matrix);
 
@@ -174,9 +185,13 @@ class CameraInfo final {
 
         focal_x = focal_y = height * 0.5 / tan(0.5 * fov_y)
 
-   @param width The image width in pixels, must be greater than zero.
-   @param height The image height in pixels, must be greater than zero.
-   @param fov_y The vertical field of view in radians.
+   @param width    The image width in pixels, must be positive.
+   @param height   The image height in pixels, must be positive.
+   @param fov_y    The vertical field of view in radians, must be positive and
+                   finite.
+
+   @throws std::exception if the provided values don't satisfy the listed
+   requirements.
   */
   CameraInfo(int width, int height, double fov_y);
 

--- a/systems/sensors/test/camera_info_test.cc
+++ b/systems/sensors/test/camera_info_test.cc
@@ -1,16 +1,23 @@
 #include "drake/systems/sensors/camera_info.h"
 
 #include <limits>
+#include <utility>
+#include <vector>
 
 #include <Eigen/Dense>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 
 namespace drake {
 namespace systems {
 namespace sensors {
 namespace {
+
+using Eigen::Matrix3d;
+
 // This is because there is a precision difference between Ubuntu and Mac.
 const double kTolerance = 1e-12;
 
@@ -22,7 +29,7 @@ const double kCx = kWidth * 0.5 - 0.5;
 const double kCy = kHeight * 0.5 - 0.5;
 const double kVerticalFov = 0.78539816339744828;  // 45.0 degrees.
 
-void Verify(const Eigen::Matrix3d& expected, const CameraInfo& dut) {
+void Verify(const Matrix3d& expected, const CameraInfo& dut) {
   EXPECT_EQ(kWidth, dut.width());
   EXPECT_EQ(kHeight, dut.height());
   EXPECT_NEAR(expected(0, 0), dut.focal_x(), kTolerance);
@@ -33,8 +40,8 @@ void Verify(const Eigen::Matrix3d& expected, const CameraInfo& dut) {
 }
 
 GTEST_TEST(TestCameraInfo, ConstructionTest) {
-  const Eigen::Matrix3d expected(
-      (Eigen::Matrix3d() << kFx, 0., kCx, 0., kFy, kCy, 0., 0., 1.).finished());
+  const Matrix3d expected(
+      (Matrix3d() << kFx, 0., kCx, 0., kFy, kCy, 0., 0., 1.).finished());
 
   {
     SCOPED_TRACE("Spelled out");
@@ -50,11 +57,100 @@ GTEST_TEST(TestCameraInfo, ConstructionTest) {
 
 // The focal lengths become identical with this constructor.
 GTEST_TEST(TestCameraInfo, ConstructionWithFovTest) {
-  const Eigen::Matrix3d expected(
-      (Eigen::Matrix3d() << kFy, 0., kCx, 0., kFy, kCy, 0., 0., 1.).finished());
+  const Matrix3d expected(
+      (Matrix3d() << kFy, 0., kCx, 0., kFy, kCy, 0., 0., 1.).finished());
 
   CameraInfo dut(kWidth, kHeight, kVerticalFov);
   Verify(expected, dut);
+}
+
+// Confirms that values that lie outside of the valid range throw. We're largely
+// going to focus on using the parameterized constructor (w, h, fx, fy, cx, cz)
+// even though the throwing happens in the matrix-based constructor.
+//
+//  1. It's simpler to iterate over different kinds of bad values via this
+//     constructor compactly.
+//  2. We know it simply constructs a matrix and forwards it along, so we'll be
+//     exercising that constructor.
+//
+// We will evaluate the matrix-based constructor to test for the "malformed
+// matrix condition".
+GTEST_TEST(TestCameraInfo, BadConstructionThrows) {
+  constexpr double kInf = std::numeric_limits<double>::infinity();
+  constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+  constexpr double kW = kWidth;
+  constexpr double kH = kHeight;
+
+  // Bad image size.
+  DRAKE_EXPECT_THROWS_MESSAGE(CameraInfo(-13, kH, kFx, kFy, kCx, kCy),
+                              "[^]*Width.+-13[^]*");
+  DRAKE_EXPECT_THROWS_MESSAGE(CameraInfo(kW, -17, kFx, kFy, kCx, kCy),
+                              "[^]*Height.+-17[^]*");
+  // Bad focal length.
+  DRAKE_EXPECT_THROWS_MESSAGE(CameraInfo(kW, kH, 0, kFy, kCx, kCy),
+                              "[^]*Focal X.+0[^]*");
+  DRAKE_EXPECT_THROWS_MESSAGE(CameraInfo(kW, kH, -10, kFy, kCx, kCy),
+                              "[^]*Focal X.+-10[^]*");
+  DRAKE_EXPECT_THROWS_MESSAGE(CameraInfo(kW, kH, kInf, kFy, kCx, kCy),
+                              "[^]*Focal X.+inf[^]*");
+  DRAKE_EXPECT_THROWS_MESSAGE(CameraInfo(kW, kH, kNaN, kFy, kCx, kCy),
+                              "[^]*Focal X.+nan[^]*");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(CameraInfo(kW, kH, kFx, 0, kCx, kCy),
+                              "[^]*Focal Y.+0[^]*");
+  DRAKE_EXPECT_THROWS_MESSAGE(CameraInfo(kW, kH, kFx, -10, kCx, kCy),
+                              "[^]*Focal Y.+-10[^]*");
+  DRAKE_EXPECT_THROWS_MESSAGE(CameraInfo(kW, kH, kFx, kInf, kCx, kCy),
+                              "[^]*Focal Y.+inf[^]*");
+  DRAKE_EXPECT_THROWS_MESSAGE(CameraInfo(kW, kH, kFx, kNaN, kCx, kCy),
+                              "[^]*Focal Y.+nan[^]*");
+
+  // Bad principal point.
+  DRAKE_EXPECT_THROWS_MESSAGE(CameraInfo(kW, kH, kFx, kFy, 0, kCy),
+                              "[^]*Center X.+0[^]*");
+  DRAKE_EXPECT_THROWS_MESSAGE(CameraInfo(kW, kH, kFx, kFy, -10, kCy),
+                              "[^]*Center X.+-10[^]*");
+  DRAKE_EXPECT_THROWS_MESSAGE(CameraInfo(kW, kH, kFx, kFy, kW, kCy),
+                              "[^]*Center X.+\\d+[^]*");
+  DRAKE_EXPECT_THROWS_MESSAGE(CameraInfo(kW, kH, kFx, kFy, kW + 1, kCy),
+                              "[^]*Center X.+\\d+[^]*");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(CameraInfo(kW, kH, kFx, kFy, kCx, 0),
+                              "[^]*Center Y.+0[^]*");
+  DRAKE_EXPECT_THROWS_MESSAGE(CameraInfo(kW, kH, kFx, kFy, kCx, -10),
+                              "[^]*Center Y.+-10[^]*");
+  DRAKE_EXPECT_THROWS_MESSAGE(CameraInfo(kW, kH, kFx, kFy, kCx, kH),
+                              "[^]*Center Y.+\\d+[^]*");
+  DRAKE_EXPECT_THROWS_MESSAGE(CameraInfo(kW, kH, kFx, kFy, kCx, kH + 1),
+                              "[^]*Center Y.+\\d+[^]*");
+
+  // All bad values get independently enumerated.
+  try {
+    CameraInfo(-1, -1, -1, -1, -1, -1);
+    GTEST_FAIL() << "Didn't throw an exception!";
+  } catch (std::exception& e) {
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("Width")) << e.what();
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("Height")) << e.what();
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("Focal X")) << e.what();
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("Focal Y")) << e.what();
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("Center X")) << e.what();
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("Center Y")) << e.what();
+  }
+
+  // Test for a malformed matrix; we'll start with an otherwise valid matrix and
+  // perturb the off-diagonal and homogeneous row entries to become "malformed".
+  const Matrix3d K_valid(
+      (Matrix3d() << kFy, 0., kCx, 0., kFy, kCy, 0., 0., 1.).finished());
+  EXPECT_NO_THROW(CameraInfo(kW, kH, K_valid));
+
+  const std::vector<std::pair<int, int>> indices{
+      {0, 1}, {1, 0}, {2, 0}, {2, 1}, {2, 2}};
+  for (auto [i, j] : indices) {
+    Matrix3d K = K_valid;
+    K(i, j) = -1;
+    DRAKE_EXPECT_THROWS_MESSAGE(CameraInfo(kW, kH, K),
+                              "[^]*intrinsic matrix is malformed[^]*");
+  }
 }
 
 // Confirms that the reported field of view (in radians) is the same as is


### PR DESCRIPTION
1. `CameraInfo`
    - Documented to throw even though it didn't.
    - Throwing conditions have been extended and implementation supports it.
    - Test extended to support documentation.
2. `ClippingRange` and `DepthRange`
    - Previously tested for positive, now also test for finite.
    - Testing supports documentation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17750)
<!-- Reviewable:end -->
