### PR TITLE
[meshcat] no crash from visualizing almost-zero hydroelastic force or moment

### DIFF
--- a/multibody/meshcat/BUILD.bazel
+++ b/multibody/meshcat/BUILD.bazel
@@ -62,6 +62,14 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_googletest(
+    name = "hydroelastic_contact_visualizer_test",
+    deps = [
+        ":hydroelastic_contact_visualizer",
+        "//common/test_utilities:expect_no_throw",
+    ],
+)
+
 drake_cc_library(
     name = "contact_visualizer_params",
     hdrs = ["contact_visualizer_params.h"],

--- a/multibody/meshcat/hydroelastic_contact_visualizer.cc
+++ b/multibody/meshcat/hydroelastic_contact_visualizer.cc
@@ -67,7 +67,7 @@ void HydroelasticContactVisualizer::Update(
     meshcat_->SetTransform(path, RigidTransformd(item.centroid_W));
 
     // Force vector.
-    {
+    if (force_norm >= params_.force_threshold) {
       meshcat_->SetTransform(path + "/force_C_W",
                              RigidTransformd(RotationMatrixd::MakeFromOneVector(
                                  item.force_C_W, 2)));
@@ -89,7 +89,7 @@ void HydroelasticContactVisualizer::Update(
                           Vector3d{0, 0, height + arrowhead_height}));
     }
     // Moment vector.
-    {
+    if (moment_norm >= params_.moment_threshold) {
       meshcat_->SetTransform(path + "/moment_C_W",
                              RigidTransformd(RotationMatrixd::MakeFromOneVector(
                                  item.moment_C_W, 2)));

--- a/multibody/meshcat/test/hydroelastic_contact_visualizer_test.cc
+++ b/multibody/meshcat/test/hydroelastic_contact_visualizer_test.cc
@@ -1,0 +1,68 @@
+#include "drake/multibody/meshcat/hydroelastic_contact_visualizer.h"
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_no_throw.h"
+
+namespace drake {
+namespace multibody {
+namespace meshcat {
+namespace {
+
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+using Eigen::Matrix3Xd;
+using Eigen::Matrix3Xi;
+using geometry::Meshcat;
+
+// Tests that zero force or moment doesn't crash.
+GTEST_TEST(HydroelasticContactVisualizer, TestZeroForceOrMoment) {
+  auto meshcat = std::make_shared<Meshcat>();
+  ContactVisualizerParams params{};
+  internal::HydroelasticContactVisualizer visualizer(meshcat, params);
+
+  // The centroid, the vertices, the faces, and the pressure values are less
+  // relevant to this test.
+  const Vector3d centroid_W = Vector3d::Zero();
+  // Vertices at the origin and one unit on three axes.
+  const Matrix3Xd p_WV = (Matrix3Xd(3, 4) << 0., 1., 0., 0.,
+                                             0., 0., 1., 0.,
+                                             0., 0., 0., 1.).finished();
+  // Make three faces by connecting the origin to vertices on two
+  // consecutive axes.
+  const Matrix3Xi faces = (Matrix3Xi(3, 3) << 0, 0, 0,
+                                              1, 2, 3,
+                                              2, 3, 1).finished();
+  // Pressure values at the vertices.
+  const VectorXd pressure = (VectorXd(4) << 1e4, 0., 0., 0.).finished();
+
+  // Control variables. We will use them for the four test cases.
+  const Vector3d zero_force_C_W = Vector3d::Zero();
+  const Vector3d non_zero_force_C_W = Vector3d::UnitX();
+  const Vector3d zero_moment_C_W = Vector3d::Zero();
+  const Vector3d non_zero_moment_C_W = Vector3d::UnitY();
+
+  // Non-zero force / zero moment
+  {
+    std::vector<internal::HydroelasticContactVisualizerItem> items;
+    items.push_back({"body_A", "body_B", centroid_W,
+                     non_zero_force_C_W, zero_moment_C_W,
+                     p_WV, faces, pressure});
+    DRAKE_EXPECT_NO_THROW(visualizer.Update(items));
+  }
+  // Zero force / non-zero moment
+  {
+    std::vector<internal::HydroelasticContactVisualizerItem> items;
+    items.push_back({"body_A", "body_B", centroid_W,
+                     zero_force_C_W, non_zero_moment_C_W,
+                     p_WV, faces, pressure});
+    DRAKE_EXPECT_NO_THROW(visualizer.Update(items));
+  }
+}
+
+}  // namespace
+}  // namespace meshcat
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
In a rare example, we probably had one of hydroelastic force or moment almost zero but not both. Then, the meshcat code crashed.

Previously there was a guard against **both** force and moment near zero.

Now we handle the case that one of them is near zero. We draw the good one and ignore the near-zero one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17757)
<!-- Reviewable:end -->
