### PR TITLE
[manipulation] Expose utime as an output from received iiwa status

### DIFF
--- a/bindings/pydrake/manipulation/kuka_iiwa_py.cc
+++ b/bindings/pydrake/manipulation/kuka_iiwa_py.cc
@@ -64,6 +64,9 @@ PYBIND11_MODULE(kuka_iiwa, m) {
     py::class_<Class, LeafSystem<double>>(m, "IiwaStatusReceiver", cls_doc.doc)
         .def(py::init<int>(), py::arg("num_joints") = kIiwaArmNumJoints,
             cls_doc.ctor.doc)
+        .def("get_time_measured_output_port",
+            &Class::get_time_measured_output_port, py_rvp::reference_internal,
+            cls_doc.get_time_measured_output_port.doc)
         .def("get_position_commanded_output_port",
             &Class::get_position_commanded_output_port,
             py_rvp::reference_internal,

--- a/bindings/pydrake/manipulation/test/kuka_iiwa_test.py
+++ b/bindings/pydrake/manipulation/test/kuka_iiwa_test.py
@@ -28,6 +28,8 @@ class TestKukaIiwa(unittest.TestCase):
 
         status_rec = mut.IiwaStatusReceiver()
         self.assertIsInstance(
+            status_rec.get_time_measured_output_port(), OutputPort)
+        self.assertIsInstance(
             status_rec.get_position_commanded_output_port(), OutputPort)
         self.assertIsInstance(
             status_rec.get_position_measured_output_port(), OutputPort)

--- a/manipulation/kuka_iiwa/iiwa_status_receiver.cc
+++ b/manipulation/kuka_iiwa/iiwa_status_receiver.cc
@@ -11,8 +11,9 @@ using systems::Context;
 
 IiwaStatusReceiver::IiwaStatusReceiver(int num_joints)
     : num_joints_(num_joints) {
-  this->DeclareAbstractInputPort(
-      "lcmt_iiwa_status", Value<lcmt_iiwa_status>{});
+  this->DeclareAbstractInputPort("lcmt_iiwa_status", Value<lcmt_iiwa_status>{});
+  this->DeclareVectorOutputPort("time_measured", 1,
+                                &IiwaStatusReceiver::CalcTimeOutput);
   this->DeclareVectorOutputPort(
       "position_commanded", num_joints_,
       &IiwaStatusReceiver::CalcLcmOutput<
@@ -39,23 +40,26 @@ IiwaStatusReceiver::IiwaStatusReceiver(int num_joints)
 IiwaStatusReceiver::~IiwaStatusReceiver() = default;
 
 using OutPort = systems::OutputPort<double>;
-const OutPort& IiwaStatusReceiver::get_position_commanded_output_port() const {
+const OutPort& IiwaStatusReceiver::get_time_measured_output_port() const {
   return LeafSystem<double>::get_output_port(0);
 }
-const OutPort& IiwaStatusReceiver::get_position_measured_output_port() const {
+const OutPort& IiwaStatusReceiver::get_position_commanded_output_port() const {
   return LeafSystem<double>::get_output_port(1);
 }
-const OutPort& IiwaStatusReceiver::get_velocity_estimated_output_port() const {
+const OutPort& IiwaStatusReceiver::get_position_measured_output_port() const {
   return LeafSystem<double>::get_output_port(2);
 }
-const OutPort& IiwaStatusReceiver::get_torque_commanded_output_port() const {
+const OutPort& IiwaStatusReceiver::get_velocity_estimated_output_port() const {
   return LeafSystem<double>::get_output_port(3);
 }
-const OutPort& IiwaStatusReceiver::get_torque_measured_output_port() const {
+const OutPort& IiwaStatusReceiver::get_torque_commanded_output_port() const {
   return LeafSystem<double>::get_output_port(4);
 }
-const OutPort& IiwaStatusReceiver::get_torque_external_output_port() const {
+const OutPort& IiwaStatusReceiver::get_torque_measured_output_port() const {
   return LeafSystem<double>::get_output_port(5);
+}
+const OutPort& IiwaStatusReceiver::get_torque_external_output_port() const {
+  return LeafSystem<double>::get_output_port(6);
 }
 
 template <std::vector<double> drake::lcmt_iiwa_status::* field_ptr>
@@ -73,6 +77,19 @@ void IiwaStatusReceiver::CalcLcmOutput(
     DRAKE_THROW_UNLESS(static_cast<int>(status_field.size()) == num_joints_);
     output->get_mutable_value() = Eigen::Map<const Eigen::VectorXd>(
         status_field.data(), num_joints_);
+  }
+}
+
+void IiwaStatusReceiver::CalcTimeOutput(const Context<double>& context,
+                                        BasicVector<double>* output) const {
+  const auto& status = get_input_port().Eval<lcmt_iiwa_status>(context);
+
+  // If we're using a default constructed message (i.e., we haven't received
+  // any status message yet), output zero.
+  if (status.num_joints == 0) {
+    output->get_mutable_value().setZero();
+  } else {
+    (*output)[0] = static_cast<double>(status.utime) / 1e6;
   }
 }
 

--- a/manipulation/kuka_iiwa/iiwa_status_receiver.h
+++ b/manipulation/kuka_iiwa/iiwa_status_receiver.h
@@ -19,15 +19,18 @@ namespace kuka_iiwa {
 ///
 /// This system has one abstract-valued input port of type lcmt_iiwa_status.
 ///
-/// This system has many vector-valued output ports, each of which has exactly
-/// num_joints elements.  The ports will output zeros until an input message is
-/// received.
+/// This system has many vector-valued output ports, most of which emit vector
+/// values of exactly `num_joints` elements. The exception is `time_measured`,
+/// which has a one-dimensional measured time output in seconds, i.e., the
+/// timestamp from the hardware in microseconds converted into seconds. All
+/// ports will output zeros until an input message is received.
 //
 /// @system
 /// name: IiwaStatusReceiver
 /// input_ports:
 /// - lcmt_iiwa_status
 /// output_ports:
+/// - time_measured
 /// - position_commanded
 /// - position_measured
 /// - velocity_estimated
@@ -46,6 +49,7 @@ class IiwaStatusReceiver final : public systems::LeafSystem<double> {
 
   /// @name Named accessors for this System's input and output ports.
   //@{
+  const systems::OutputPort<double>& get_time_measured_output_port() const;
   const systems::OutputPort<double>& get_position_commanded_output_port() const;
   const systems::OutputPort<double>& get_position_measured_output_port() const;
   const systems::OutputPort<double>& get_velocity_estimated_output_port() const;
@@ -58,6 +62,9 @@ class IiwaStatusReceiver final : public systems::LeafSystem<double> {
   template <std::vector<double> drake::lcmt_iiwa_status::*>
   void CalcLcmOutput(const systems::Context<double>&,
                      systems::BasicVector<double>*) const;
+
+  void CalcTimeOutput(const systems::Context<double>&,
+                      systems::BasicVector<double>*) const;
 
   const int num_joints_;
 };

--- a/manipulation/kuka_iiwa/test/iiwa_status_receiver_test.cc
+++ b/manipulation/kuka_iiwa/test/iiwa_status_receiver_test.cc
@@ -11,8 +11,8 @@ namespace manipulation {
 namespace kuka_iiwa {
 namespace {
 
-using Eigen::VectorXd;
 using drake::test::LimitMalloc;
+using Eigen::VectorXd;
 
 constexpr int N = kIiwaArmNumJoints;
 
@@ -40,23 +40,26 @@ class IiwaStatusReceiverTest : public testing::Test {
 TEST_F(IiwaStatusReceiverTest, AcceptanceTest) {
   // Confirm that output is zero for uninitialized lcm input.
   const int num_output_ports = dut_.num_output_ports();
-  EXPECT_EQ(num_output_ports, 6);
+  EXPECT_EQ(num_output_ports, 7);
   for (int i = 0; i < num_output_ports; ++i) {
     const systems::LeafSystem<double>& leaf = dut_;
     const auto& port = leaf.get_output_port(i);
-    EXPECT_TRUE(CompareMatrices(
-        port.Eval(context_),
-        VectorXd::Zero(N)));
+    if (i > 0) {
+      EXPECT_TRUE(CompareMatrices(port.Eval(context_), VectorXd::Zero(N)));
+    } else {
+      EXPECT_TRUE(CompareMatrices(port.Eval(context_), VectorXd::Zero(1)));
+    }
   }
 
   // Populate the status message with distinct values.
+  const int utime = 1661199485;
   const VectorXd position_commanded = VectorXd::LinSpaced(N, 0.0, 1.0);
   const VectorXd position_measured = VectorXd::LinSpaced(N, 2.0, 3.0);
   const VectorXd velocity_estimated = VectorXd::LinSpaced(N, 4.0, 5.0);
   const VectorXd torque_commanded = VectorXd::LinSpaced(N, 6.0, 7.0);
   const VectorXd torque_measured = VectorXd::LinSpaced(N, 8.0, 9.0);
   const VectorXd torque_external = VectorXd::LinSpaced(N, 10.0, 11.0);
-  status_.utime = 1;
+  status_.utime = utime;
   status_.num_joints = N;
   Copy(position_commanded, &status_.joint_position_commanded);
   Copy(position_measured, &status_.joint_position_measured);
@@ -65,28 +68,29 @@ TEST_F(IiwaStatusReceiverTest, AcceptanceTest) {
   Copy(torque_measured, &status_.joint_torque_measured);
   Copy(torque_external, &status_.joint_torque_external);
   // TODO(jwnimmer-tri) This systems framework API is not very ergonomic.
-  fixed_input_.GetMutableData()->
-      template get_mutable_value<lcmt_iiwa_status>() = status_;
+  fixed_input_.GetMutableData()
+      ->template get_mutable_value<lcmt_iiwa_status>() = status_;
 
   // Confirm that real message values are output correctly.
+  EXPECT_TRUE(
+      CompareMatrices(dut_.get_time_measured_output_port().Eval(context_),
+                      Vector1d(utime) / 1e6));
+  EXPECT_TRUE(
+      CompareMatrices(dut_.get_position_commanded_output_port().Eval(context_),
+                      position_commanded));
+  EXPECT_TRUE(
+      CompareMatrices(dut_.get_position_measured_output_port().Eval(context_),
+                      position_measured));
+  EXPECT_TRUE(
+      CompareMatrices(dut_.get_velocity_estimated_output_port().Eval(context_),
+                      velocity_estimated));
+  EXPECT_TRUE(
+      CompareMatrices(dut_.get_torque_commanded_output_port().Eval(context_),
+                      torque_commanded));
   EXPECT_TRUE(CompareMatrices(
-      dut_.get_position_commanded_output_port().Eval(context_),
-      position_commanded));
+      dut_.get_torque_measured_output_port().Eval(context_), torque_measured));
   EXPECT_TRUE(CompareMatrices(
-      dut_.get_position_measured_output_port().Eval(context_),
-      position_measured));
-  EXPECT_TRUE(CompareMatrices(
-      dut_.get_velocity_estimated_output_port().Eval(context_),
-      velocity_estimated));
-  EXPECT_TRUE(CompareMatrices(
-      dut_.get_torque_commanded_output_port().Eval(context_),
-      torque_commanded));
-  EXPECT_TRUE(CompareMatrices(
-      dut_.get_torque_measured_output_port().Eval(context_),
-      torque_measured));
-  EXPECT_TRUE(CompareMatrices(
-      dut_.get_torque_external_output_port().Eval(context_),
-      torque_external));
+      dut_.get_torque_external_output_port().Eval(context_), torque_external));
 }
 
 // This class is likely to be used on the critical path for robot control, so
@@ -102,8 +106,8 @@ TEST_F(IiwaStatusReceiverTest, MallocTest) {
   status_.joint_torque_measured.resize(N);
   status_.joint_torque_external.resize(N);
   // TODO(jwnimmer-tri) This systems framework API is not very ergonomic.
-  fixed_input_.GetMutableData()->
-      template get_mutable_value<lcmt_iiwa_status>() = status_;
+  fixed_input_.GetMutableData()
+      ->template get_mutable_value<lcmt_iiwa_status>() = status_;
 
   // Compute the output. No heap changes are allowed.
   {


### PR DESCRIPTION
- Adds utime as an output port to the iiwa status receiver
- Adds relevant python bindings

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17761)
<!-- Reviewable:end -->
