### PR TITLE
[geometry] Add Rgba::Serialize support

### DIFF
--- a/bindings/pydrake/geometry_py_common.cc
+++ b/bindings/pydrake/geometry_py_common.cc
@@ -317,8 +317,10 @@ void DoScalarIndependentDefinitions(py::module m) {
     constexpr auto& cls_doc = doc.Rgba;
     py::class_<Class> cls(m, "Rgba", cls_doc.doc);
     cls  // BR
+        .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init<double, double, double, double>(), py::arg("r"),
-            py::arg("g"), py::arg("b"), py::arg("a") = 1., cls_doc.ctor.doc)
+            py::arg("g"), py::arg("b"), py::arg("a") = 1.,
+            cls_doc.ctor.doc_4args)
         .def("r", &Class::r, cls_doc.r.doc)
         .def("g", &Class::g, cls_doc.g.doc)
         .def("b", &Class::b, cls_doc.b.doc)

--- a/bindings/pydrake/test/geometry_common_test.py
+++ b/bindings/pydrake/test/geometry_common_test.py
@@ -297,6 +297,8 @@ class TestGeometryCore(unittest.TestCase):
                                            "hydroelastic_modulus"), E)
 
     def test_rgba_api(self):
+        default_white = mut.Rgba()
+        self.assertEqual(default_white, mut.Rgba(1, 1, 1, 1))
         r, g, b, a = 0.75, 0.5, 0.25, 1.
         color = mut.Rgba(r=r, g=g, b=b)
         self.assertEqual(color.r(), r)

--- a/bindings/pydrake/visualization/test/config_test.py
+++ b/bindings/pydrake/visualization/test/config_test.py
@@ -3,6 +3,10 @@ import pydrake.visualization as mut
 import copy
 import unittest
 
+from pydrake.geometry import (
+    Rgba,
+)
+
 from pydrake.lcm import (
     DrakeLcm,
 )
@@ -18,6 +22,13 @@ from pydrake.systems.framework import (
 
 
 class TestConfig(unittest.TestCase):
+
+    def test_visualization_config(self):
+        """Confirms that the (slightly unusual) bindings of Rgba values operate
+        as expected.
+        """
+        dut = mut.VisualizationConfig()
+        self.assertIsInstance(dut.default_illustration_color, Rgba)
 
     def test_apply_visualization_config(self):
         """Exercises VisualizationConfig and ApplyVisualizationConfig.

--- a/examples/hardware_sim/test/test_scenarios.yaml
+++ b/examples/hardware_sim/test/test_scenarios.yaml
@@ -22,3 +22,5 @@ OneOfEverything:
   visualization:
     lcm_bus: extra_bus
     publish_period: 0.125
+    default_illustration_color:
+      rgba: [0.8, 0.8, 0.8]

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -392,6 +392,7 @@ drake_cc_library(
     hdrs = ["rgba.h"],
     deps = [
         "//common",
+        "@fmt",
     ],
 )
 
@@ -814,6 +815,7 @@ drake_cc_googletest(
     deps = [
         ":rgba",
         "//common/test_utilities",
+        "//common/yaml:yaml_io",
     ],
 )
 

--- a/visualization/BUILD.bazel
+++ b/visualization/BUILD.bazel
@@ -26,6 +26,7 @@ drake_cc_library(
     deps = [
         "//common:name_value",
         "//geometry:drake_visualizer_params",
+        "//geometry:rgba",
         "@eigen",
     ],
 )

--- a/visualization/visualization_config.h
+++ b/visualization/visualization_config.h
@@ -5,6 +5,7 @@
 #include <Eigen/Dense>
 
 #include "drake/common/name_value.h"
+#include "drake/geometry/rgba.h"
 
 namespace drake {
 namespace visualization {
@@ -25,9 +26,9 @@ struct VisualizationConfig {
     a->Visit(DRAKE_NVP(lcm_bus));
     a->Visit(DRAKE_NVP(publish_period));
     a->Visit(DRAKE_NVP(publish_illustration));
-    a->Visit(DRAKE_NVP(default_illustration_color_rgba));
+    a->Visit(DRAKE_NVP(default_illustration_color));
     a->Visit(DRAKE_NVP(publish_proximity));
-    a->Visit(DRAKE_NVP(default_proximity_color_rgba));
+    a->Visit(DRAKE_NVP(default_proximity_color));
     a->Visit(DRAKE_NVP(publish_contacts));
   }
 
@@ -45,16 +46,14 @@ struct VisualizationConfig {
 
   /** The color to apply to any illustration geometry that hasn't defined one.
   The vector must be of size three (rgb) or four (rgba). */
-  Eigen::VectorXd default_illustration_color_rgba{
-      Eigen::Vector3d{0.9, 0.9, 0.9}};
+  geometry::Rgba default_illustration_color{0.9, 0.9, 0.9};
 
   /** Whether to show proximity geometry. */
   bool publish_proximity{true};
 
   /** The color to apply to any proximity geometry that hasn't defined one.
   The vector must be of size three (rgb) or four (rgba). */
-  Eigen::VectorXd default_proximity_color_rgba{
-      Eigen::Vector4d{1, 0, 0, 0.5}};
+  geometry::Rgba default_proximity_color{1, 0, 0, 0.5};
 
   /** Whether to show contact forces. */
   bool publish_contacts{true};

--- a/visualization/visualization_config_functions.cc
+++ b/visualization/visualization_config_functions.cc
@@ -105,26 +105,6 @@ void AddDefaultVisualization(DiagramBuilder<double>* builder) {
   ApplyVisualizationConfig(VisualizationConfig{}, builder);
 }
 
-namespace {
-
-// TODO(jeremy.nimmer) Add a `Serialize()` function to `class Rgba` so that it
-// can be serialized directly, without this helper function.
-Rgba VectorToRgba(const Eigen::VectorXd& input) {
-  if (input.size() < 3) {
-    throw std::runtime_error("Rgba must have >= 3 values");
-  }
-  if (input.size() > 4) {
-    throw std::runtime_error("Rgba must have <= 4 values");
-  }
-  const double r = input(0);
-  const double g = input(1);
-  const double b = input(2);
-  const double a = (input.size() == 4) ? input(3) : 1.0;
-  return Rgba(r, g, b, a);
-}
-
-}  // namespace
-
 namespace internal {
 
 std::vector<DrakeVisualizerParams>
@@ -136,8 +116,7 @@ ConvertVisualizationConfigToParams(
     DrakeVisualizerParams illustration;
     illustration.role = Role::kIllustration;
     illustration.publish_period = config.publish_period;
-    illustration.default_color =
-        VectorToRgba(config.default_illustration_color_rgba);
+    illustration.default_color = config.default_illustration_color;
     result.push_back(illustration);
   }
 
@@ -145,8 +124,7 @@ ConvertVisualizationConfigToParams(
     DrakeVisualizerParams proximity;
     proximity.role = Role::kProximity;
     proximity.publish_period = config.publish_period;
-    proximity.default_color =
-        VectorToRgba(config.default_proximity_color_rgba);
+    proximity.default_color = config.default_proximity_color;
     proximity.show_hydroelastic = true;
     proximity.use_role_channel_suffix = true;
     result.push_back(proximity);


### PR DESCRIPTION
`Rgba` serializes as an array-like value. The contents must have either three or four values and must all lie in the range [0, 1].

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17762)
<!-- Reviewable:end -->
