### PR TITLE
[pydrake] Deprecate bindings of internal-use functions of PolygonSurfaceMesh

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -514,6 +514,7 @@ drake_py_unittest(
     ],
     deps = [
         ":geometry_py",
+        "//bindings/pydrake/common/test_utilities",
     ],
 )
 

--- a/bindings/pydrake/geometry_py_hydro.cc
+++ b/bindings/pydrake/geometry_py_hydro.cc
@@ -3,6 +3,7 @@
  types. The can be found in the pydrake.geometry module. */
 
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"
 #include "drake/bindings/pydrake/common/type_safe_index_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
@@ -50,11 +51,20 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("num_elements", &Class::num_elements, cls_doc.num_elements.doc)
         .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init<std::vector<int>, std::vector<Vector3<T>>>(),
-            py::arg("face_data"), py::arg("vertices"), cls_doc.ctor.doc_2args)
-        .def("TransformVertices", &Class::TransformVertices, py::arg("X_NM"),
-            cls_doc.TransformVertices.doc)
-        .def("ReverseFaceWinding", &Class::ReverseFaceWinding,
-            cls_doc.ReverseFaceWinding.doc)
+            py::arg("face_data"), py::arg("vertices"), cls_doc.ctor.doc_2args);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    constexpr char kRemoved[] =
+        "Deprecated:\n    This function is strictly for internal use and will "
+        "be removed from Drake on or after 2022-12-01.";
+    cls  // BR
+        .def("TransformVertices",
+            WrapDeprecated(kRemoved, &Class::TransformVertices),
+            py::arg("X_NM"), kRemoved)
+        .def("ReverseFaceWinding",
+            WrapDeprecated(kRemoved, &Class::ReverseFaceWinding), kRemoved);
+#pragma GCC diagnostic pop
+    cls  // BR
         .def("num_faces", &Class::num_faces, cls_doc.num_faces.doc)
         .def("area", &Class::area, py::arg("f"), cls_doc.area.doc)
         .def("total_area", &Class::total_area, cls_doc.total_area.doc)

--- a/bindings/pydrake/test/geometry_hydro_test.py
+++ b/bindings/pydrake/test/geometry_hydro_test.py
@@ -7,6 +7,7 @@ import unittest
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.math import RigidTransform
 
 
@@ -94,8 +95,9 @@ class TestGeometryHydro(unittest.TestCase):
         copy.copy(dut)
 
         # Sanity check the mutators.
-        dut.TransformVertices(X_NM=RigidTransform())
-        dut.ReverseFaceWinding()
+        with catch_drake_warnings(expected_count=2):
+            dut.TransformVertices(X_NM=RigidTransform())
+            dut.ReverseFaceWinding()
 
         # Now check the SurfacePolygon bindings.
         polygon = dut.element(e=0)

--- a/geometry/proximity/polygon_surface_mesh.h
+++ b/geometry/proximity/polygon_surface_mesh.h
@@ -183,8 +183,8 @@ class PolygonSurfaceMesh {
   PolygonSurfaceMesh(std::vector<int> face_data,
                      std::vector<Vector3<T>> vertices);
 
-  /** Transforms the vertices of this mesh from its initial frame M to the new
-   frame N. */
+  /** (Internal use only) Transforms the vertices of this mesh from its
+   initial frame M to the new frame N. */
   void TransformVertices(const math::RigidTransform<T>& X_NM);
 
   // TODO(SeanCurtis-TRI): ContactResultsToLcm and HydroelasticContactInfo
@@ -200,7 +200,7 @@ class PolygonSurfaceMesh {
   //  Alternatively, there's a question about whether ContactSurface should be
   //  calling this method *at all*. Choosing that it's not necessary would
   //  likewise enable this implementation to move to the .cc file.
-  /** Reverses the ordering of all the faces' indices. */
+  /** (Internal use only) Reverses the ordering of all the faces' indices. */
   void ReverseFaceWinding() {
     for (const int f_index : poly_indices_) {
       const int v_count = face_data_[f_index];

--- a/geometry/proximity/triangle_surface_mesh.h
+++ b/geometry/proximity/triangle_surface_mesh.h
@@ -193,8 +193,8 @@ class TriangleSurfaceMesh {
   //  is misleading. It transforms more than just vertex positions. It should
   //  simply be called Transform and documented as "transforming the mesh's
   //  frame-dependent quantities from frame M to the new frame N".
-  /** Transforms the vertices of this mesh from its initial frame M to the new
-   frame N.
+  /** (Internal use only) Transforms the vertices of this mesh from its
+   initial frame M to the new frame N.
    */
   void TransformVertices(const math::RigidTransform<T>& X_NM) {
     for (auto& v : vertices_) {
@@ -206,8 +206,8 @@ class TriangleSurfaceMesh {
     p_MSc_ = X_NM * p_MSc_;
   }
 
-  /** Reverses the ordering of all the triangles' indices -- see
-    SurfaceTriangle::ReverseWinding().
+  /** (Internal use only) Reverses the ordering of all the triangles' indices
+   -- see SurfaceTriangle::ReverseWinding().
    */
   void ReverseFaceWinding() {
     for (auto& f : triangles_) {


### PR DESCRIPTION
Towards #17625.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17768)
<!-- Reviewable:end -->
