### PR TITLE
[workspace] Expose vtkDataReader and vtkUnstructuredGridReader

### DIFF
--- a/tools/workspace/vtk/repository.bzl
+++ b/tools/workspace/vtk/repository.bzl
@@ -378,6 +378,8 @@ licenses([
             "vtkExecutive.h",
             "vtkImageAlgorithm.h",
             "vtkPolyDataAlgorithm.h",
+            "vtkReaderAlgorithm.h",
+            "vtkSimpleReader.h",
             "vtkStreamingDemandDrivenPipeline.h",
         ],
         deps = [
@@ -712,10 +714,14 @@ licenses([
         ],
     )
 
-    # Indirect dependency: omit headers.
     file_content += _vtk_cc_library(
         os_result,
         "vtkIOLegacy",
+        hdrs = [
+            "vtkDataReader.h",
+            "vtkIOLegacyModule.h",
+            "vtkUnstructuredGridReader.h",
+        ],
         deps = [
             ":vtkCommonCore",
             ":vtkCommonDataModel",


### PR DESCRIPTION
Fixes #17767.

Relates: #17725 (AFAIU).

To test this locally, a reviewer should checkout or apply the changes locally.  Additionally, the following snippet will confirm that the classes can both compile _and_ link:

```diff
diff --git a/geometry/render_vtk/test/internal_render_engine_vtk_test.cc b/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
index a80cfd36d4..86d650d3c9 100644
--- a/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
@@ -11,8 +11,11 @@
 #include <Eigen/Dense>
 #include <fmt/format.h>
 #include <gtest/gtest.h>
+#include <vtkDataReader.h>
+#include <vtkNew.h>
 #include <vtkOpenGLTexture.h>
 #include <vtkProperty.h>
+#include <vtkUnstructuredGridReader.h>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/find_resource.h"
@@ -190,7 +193,13 @@ class RenderEngineVtkTest : public ::testing::Test {
         X_WC_(RotationMatrixd{AngleAxisd(M_PI, Vector3d::UnitY()) *
                               AngleAxisd(-M_PI_2, Vector3d::UnitZ())},
               {0, 0, kDefaultDistance}),
-        geometry_id_(GeometryId::get_new_id()) {}
+        geometry_id_(GeometryId::get_new_id()) {
+    vtkNew<vtkDataReader> vtk_reader;
+    vtk_reader->SetFileName("asdf.vtk");
+
+    vtkNew<vtkUnstructuredGridReader> grid_reader;
+    grid_reader->SetFileName("asdf.grid");
+  }
 
  protected:
   // Method to allow the normal case (render with the built-in renderer against
```

and run `bazel test //geometry/render_vtk:internal_render_engine_vtk_test`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17771)
<!-- Reviewable:end -->
