### PR TITLE
Clean up typos in yaml error messages

### DIFF
--- a/common/yaml/test/yaml_read_archive_test.cc
+++ b/common/yaml/test/yaml_read_archive_test.cc
@@ -756,8 +756,8 @@ doc:
         AcceptIntoDummy<OuterStruct>(node),
         "YAML node of type Mapping"
         " \\(with size 1 and keys \\{inner_value_TYPO\\}\\)"
-        " key inner_value_TYPO did not match any visited value entry for <root>"
-        " while accepting YAML node of type Mapping"
+        " key 'inner_value_TYPO' did not match any visited value entry for"
+        " <root> while accepting YAML node of type Mapping"
         " \\(with size 2 and keys \\{inner_struct, outer_value\\}\\)"
         " while visiting [^ ]*InnerStruct inner_struct\\.");
   } else {

--- a/common/yaml/yaml_node.cc
+++ b/common/yaml/yaml_node.cc
@@ -180,7 +180,7 @@ void Node::Add(std::string key, Node value) {
         // for the error message we need to dig the existing key out of the map.
         const std::string& old_key = result.first->first;
         throw std::logic_error(fmt::format(
-            "Cannot Node::Add(key, value) usign duplicate key '{}'", old_key));
+            "Cannot Node::Add(key, value) using duplicate key '{}'", old_key));
       }
     },
     [](auto&& data) -> void {

--- a/common/yaml/yaml_read_archive.cc
+++ b/common/yaml/yaml_read_archive.cc
@@ -324,7 +324,7 @@ void YamlReadArchive::CheckAllAccepted() const {
     unused(value);
     if (visited_names_.count(key) == 0) {
       ReportError(fmt::format(
-          "key {} did not match any visited value", key));
+          "key '{}' did not match any visited value", key));
     }
   }
 }


### PR DESCRIPTION
 - s/usign/using
 - Typically the formatting is ...key 'key_name'...; one error message was missing the ticks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17773)
<!-- Reviewable:end -->
