### PR TITLE
Build wheels with self-built Python 3.10

### DIFF
--- a/tools/wheel/BUILD.bazel
+++ b/tools/wheel/BUILD.bazel
@@ -13,6 +13,7 @@ drake_py_binary(
     srcs = [
         "wheel_builder/common.py",
         "wheel_builder/linux.py",
+        "wheel_builder/linux_types.py",
         "wheel_builder/macos.py",
         "wheel_builder/main.py",
     ],

--- a/tools/wheel/Dockerfile
+++ b/tools/wheel/Dockerfile
@@ -37,10 +37,11 @@ RUN /image/build-vtk.sh
 FROM incubator AS clean
 
 ARG PYTHON=3
+ARG PYTHON_SHA=
 
-ADD image/provision-python.sh /image/
+ADD image/provision-python.sh image/build-python.sh /image/
 
-RUN /image/provision-python.sh ${PYTHON}
+RUN /image/provision-python.sh ${PYTHON} ${PYTHON_SHA}
 
 # -----------------------------------------------------------------------------
 # Inject the primary build scripts.

--- a/tools/wheel/image/build-python.sh
+++ b/tools/wheel/image/build-python.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Internal script to build Python.
+# Docker (Linux) only.
+
+set -eu -o pipefail
+
+readonly VERSION=$1
+readonly PREFIX=$2
+readonly SHA=$3
+
+apt-get -y update
+apt-get -y install --no-install-recommends \
+    build-essential \
+    libbz2-dev \
+    libc6-dev \
+    libssl-dev
+
+readonly ARCHIVE=Python-$VERSION.tar.xz
+readonly URL=https://www.python.org/ftp/python/$VERSION/$ARCHIVE
+readonly SRC_DIR=/opt/drake-wheel-build/python
+
+mkdir -p $SRC_DIR
+cd $SRC_DIR
+
+wget $URL
+echo "$SHA  $ARCHIVE" | sha256sum -c
+
+tar --strip-components=1 -xf $ARCHIVE
+rm $ARCHIVE
+
+./configure --prefix=$PREFIX
+make -j install

--- a/tools/wheel/test/provision.sh
+++ b/tools/wheel/test/provision.sh
@@ -4,7 +4,7 @@
 
 set -eu -o pipefail
 
-PYTHON=python${1:-3}
+readonly PYTHON=python${1:-3}
 
 export DEBIAN_FRONTEND=noninteractive
 

--- a/tools/wheel/wheel_builder/linux.py
+++ b/tools/wheel/wheel_builder/linux.py
@@ -8,11 +8,12 @@ import subprocess
 import sys
 import tarfile
 
-from collections import namedtuple
 from datetime import datetime, timezone
 
 from .common import die, gripe, wheel_name
 from .common import resource_root, wheelhouse
+
+from .linux_types import Platform, Role, Target, BUILD, TEST
 
 # Artifacts that need to be cleaned up. DO NOT MODIFY outside of this file.
 _files_to_remove = []
@@ -24,15 +25,20 @@ tag_base = 'pip-drake'
 # default, all targets are built, but the user may down-select from this set.
 # The platform alias is used for Docker tag names, and, when combined with the
 # Python version, must be unique.
-Target = namedtuple('Target', [
-    'python_version',
-    'platform_name',
-    'platform_version',
-    'platform_alias',
-])
 targets = (
-    Target('38', 'ubuntu', '20.04', 'focal'),
-    Target('39', 'ubuntu', '20.04', 'focal'),
+    Target(
+        build_platform=Platform('ubuntu', '20.04', 'focal'),
+        test_platform=None,
+        python_version_tuple=(3, 8)),
+    Target(
+        build_platform=Platform('ubuntu', '20.04', 'focal'),
+        test_platform=None,
+        python_version_tuple=(3, 9)),
+    Target(
+        build_platform=Platform('ubuntu', '20.04', 'focal'),
+        test_platform=Platform('ubuntu', '22.04', 'jammy'),
+        python_version_tuple=(3, 10, 6),
+        python_sha='f795ff87d11d4b0c7c33bc8851b0c28648d8a4583aa2100a98c22b4326b6d3f3'),  # noqa
 )
 glibc_versions = {
     'focal': '2_31',
@@ -142,12 +148,12 @@ def _create_source_tar(path):
     out.close()
 
 
-def _tagname(target, tag_prefix):
+def _tagname(target: Target, role: Role, tag_prefix: str):
     """
     Generates a Docker tag name for a target and tag prefix.
     """
-    platform = target.platform_alias
-    return f'{tag_base}:{tag_prefix}-{platform}-py{target.python_version}'
+    platform = target.platform(role).alias
+    return f'{tag_base}:{tag_prefix}-{platform}-py{target.python_tag}'
 
 
 def _build_stage(target, args, tag_prefix, stage=None):
@@ -156,7 +162,7 @@ def _build_stage(target, args, tag_prefix, stage=None):
     """
 
     # Generate canonical tag from target.
-    tag = _tagname(target, tag_prefix)
+    tag = _tagname(target, BUILD, tag_prefix)
 
     # Generate extra arguments to specify what stage to build.
     if stage is not None:
@@ -171,17 +177,27 @@ def _build_stage(target, args, tag_prefix, stage=None):
     return tag
 
 
-def _target_args(target):
+def _target_args(target: Target, role: Role):
     """
     Returns the docker build arguments for the specified platform target.
     """
-    platform_name = target.platform_name
-    platform_version = target.platform_version
+    platform_name = target.platform(role).name
+    platform_version = target.platform(role).version
     python_version = target.python_version
+
+    if role == BUILD and target.python_sha is not None:
+        python_args = [
+            '--build-arg', f'PYTHON=build:{target.python_version_full}',
+            '--build-arg', f'PYTHON_SHA={target.python_sha}',
+        ]
+    else:
+        python_args = [
+            '--build-arg', f'PYTHON={python_version}',
+        ]
+
     return [
-        '--build-arg', f'PYTHON={python_version[0]}.{python_version[1:]}',
         '--build-arg', f'PLATFORM={platform_name}:{platform_version}',
-    ]
+    ] + python_args
 
 
 def _build_image(target, identifier, options):
@@ -191,7 +207,7 @@ def _build_image(target, identifier, options):
     args = [
         '--ssh', 'default',
         '--build-arg', f'DRAKE_VERSION={options.version}',
-    ] + _target_args(target)
+    ] + _target_args(target, BUILD)
     if not options.keep_containers:
         args.append('--force-rm')
 
@@ -230,18 +246,18 @@ def _test_wheel(target, identifier, options):
     """
     Runs the test script for the wheel matching the specified target.
     """
-    glibc = glibc_versions[target.platform_alias]
-    wheel = wheel_name(python_version=target.python_version,
+    glibc = glibc_versions[target.platform(BUILD).alias]
+    wheel = wheel_name(python_version=target.python_tag,
                        wheel_version=options.version,
                        wheel_platform=f'manylinux_{glibc}_x86_64')
 
     if options.tag_stages:
-        container = _tagname(target, 'test')
+        container = _tagname(target, TEST, 'test')
     else:
-        container = _tagname(target, f'test-{identifier}')
+        container = _tagname(target, TEST, f'test-{identifier}')
     test_dir = os.path.join(resource_root, 'test')
 
-    _docker('build', '-t', container, *_target_args(target), test_dir)
+    _docker('build', '-t', container, *_target_args(target, TEST), test_dir)
     if not options.tag_stages:
         _images_to_remove.append(container)
 
@@ -260,8 +276,8 @@ def build(options):
     # Collect set of wheels to be built.
     targets_to_build = []
     for t in targets:
-        if t.platform_name in options.platforms:
-            if t.python_version in options.python_versions:
+        if t.platform(BUILD).name in options.platforms:
+            if t.python_tag in options.python_versions:
                 targets_to_build.append(t)
 
     # Check if there is anything to do.
@@ -308,12 +324,12 @@ def add_selection_arguments(parser):
     """
     parser.add_argument(
         '--platform', dest='platforms',
-        default=','.join(set([t.platform_name for t in targets])),
+        default=','.join(set([t.platform(BUILD).name for t in targets])),
         help='platform(s) to build; separate with \',\''
              ' (default: %(default)s)')
     parser.add_argument(
         '--python', dest='python_versions', metavar='VERSIONS',
-        default=','.join(sorted(set([t.python_version for t in targets]))),
+        default=','.join(sorted(set([t.python_tag for t in targets]))),
         help='python version(s) to build; separate with \',\''
              ' (default: %(default)s)')
 

--- a/tools/wheel/wheel_builder/linux_types.py
+++ b/tools/wheel/wheel_builder/linux_types.py
@@ -1,0 +1,39 @@
+# This file contains data types used by the Linux-specific build logic. See
+# //tools/wheel:builder for the user interface.
+
+from dataclasses import dataclass
+from typing import Tuple
+
+
+@dataclass
+class Role:
+    name: str
+
+
+@dataclass
+class Platform:
+    name: str
+    version: str
+    alias: str
+
+
+@dataclass
+class Target:
+    build_platform: Platform
+    test_platform: Platform
+    python_version_tuple: Tuple[int]
+    python_sha: str = None
+
+    def __post_init__(self):
+        pv_parts = tuple(map(str, self.python_version_tuple))
+        self.python_version_full = '.'.join(pv_parts)
+        self.python_version = '.'.join(pv_parts[:2])
+        self.python_tag = ''.join(pv_parts[:2])
+
+    def platform(self, role: Role):
+        p = getattr(self, f'{role.name}_platform')
+        return p if p is not None else self.build_platform
+
+
+BUILD = Role('build')
+TEST = Role('test')

--- a/tools/workspace/python/repository.bzl
+++ b/tools/workspace/python/repository.bzl
@@ -55,7 +55,7 @@ _VERSION_SUPPORT_MATRIX = {
     # - Update URLs on doc/_pages/pip.md (`cpXY-cpXY` components), and
     # - Tables on from_source.md and installation.md (python version number).
     "macos_wheel": ["3.10"],
-    "manylinux": ["3.8", "3.9"],
+    "manylinux": ["3.8", "3.9", "3.10"],
 }
 
 def repository_python_info(repository_ctx):

--- a/tools/workspace/vtk/repository.bzl
+++ b/tools/workspace/vtk/repository.bzl
@@ -735,6 +735,11 @@ licenses([
         ],
     )
 
+    if os_result.is_manylinux:
+        vtk_expat_libraries = []
+    else:
+        vtk_expat_libraries = ["@expat"]
+
     # Indirect dependency: omit headers.
     file_content += _vtk_cc_library(
         os_result,
@@ -744,8 +749,7 @@ licenses([
             ":vtkCommonDataModel",
             ":vtkIOCore",
             ":vtksys",
-            "@expat",
-        ],
+        ] + vtk_expat_libraries,
     )
 
     # Indirect dependency: omit headers.


### PR DESCRIPTION
Add ability to build Python during wheel build environment provisioning, rather than relying on system packages. Add ability to have separate build and test platforms for wheels. Add a 3.10 wheel, built on Focal using Python 3.10.6 built from source and tested on Jammy.

Towards #17483.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17778)
<!-- Reviewable:end -->
