### PR TITLE
Fix install RPATH munging

### DIFF
--- a/tools/install/test/install_meta_test.py
+++ b/tools/install/test/install_meta_test.py
@@ -43,7 +43,7 @@ class TestInstallMeta(unittest.TestCase):
         """
         # Forcibly reset globals.
         # TODO(rpoyner-tri): get rid of installer globals; see #7331.
-        installer.libraries_to_fix_rpath.clear()
+        installer.libraries_installed.clear()
 
         stream = io.StringIO()
         with redirect_stdout(stream), redirect_stderr(stream):


### PR DESCRIPTION
Modify `installer.py` to separately track all installed libraries versus libraries which need RPATH fixing. The former includes libraries that were already installed ("up-to-date"), which still need to be considered when fixing RPATHs for anything being (re)installed.

This fixes RPATH breakage in some instances when installing to the same location multiple times, especially if nothing else has changed in the interim.

Fixes #14224.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17779)
<!-- Reviewable:end -->
