### PR TITLE
fix doxygen for ConvexSet::AddPointInNonnegativeScalingConstraints

### DIFF
--- a/geometry/optimization/convex_set.h
+++ b/geometry/optimization/convex_set.h
@@ -132,15 +132,18 @@ class ConvexSet : public ShapeReifier {
   c * t + d ≥ 0,
   @endverbatim
   where A is an n-by-m matrix (with n the ambient_dimension), b is a vector of
-  size n, c is a vector of size p, x is a point in ℜᵐ, and t is a point in ℜ^p.
+  size n, c is a vector of size p, x is a point in ℜᵐ, and t is a point in ℜᵖ.
 
   When S is unbounded, then the behavior is almost identical, except when c' *
-  t+d=0. In this case, the constraints imply c' * t + d ≥ 0, A * x + b ∈ (c' * t
-  + d) S ⊕ rec(S), where rec(S) is the recession cone of S (the asymptotic
-  directions in which S is not bounded) and ⊕ is the Minkowski sum.  For c' * t
-  + d > 0, this is equivalent
-  to A * x + b ∈ (c' * t + d) S, but for c' * t + d = 0, we have only A * x + b
-  ∈ rec(S). */
+  t+d=0. In this case, the constraints imply
+  @verbatim
+  A * x + b ∈ (c' * t + d) S ⊕ rec(S),
+  c' * t + d ≥ 0,
+  @endverbatim
+  where rec(S) is the recession cone of S (the asymptotic directions in which S
+  is not bounded) and ⊕ is the Minkowski sum.  For c' * t + d > 0, this is
+  equivalent to A * x + b ∈ (c' * t + d) S, but for c' * t + d = 0, we have
+  only A * x + b ∈ rec(S). */
   std::vector<solvers::Binding<solvers::Constraint>>
   AddPointInNonnegativeScalingConstraints(
       solvers::MathematicalProgram* prog,


### PR DESCRIPTION
Before:
![Screenshot from 2022-08-28 12-15-38](https://user-images.githubusercontent.com/6442292/187083966-7d39ac35-2c89-405c-ab46-88b6363b8ea4.png)

After:
![Screenshot from 2022-08-28 12-17-01](https://user-images.githubusercontent.com/6442292/187084007-3590a9be-a127-470e-8bb5-a20e420a8893.png)

+@sammy-tri for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17782)
<!-- Reviewable:end -->
