### PR TITLE
Implements HPolyhedron::Serialize()

### DIFF
--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -139,6 +139,7 @@ drake_cc_googletest(
         ":convex_set",
         ":test_utilities",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/yaml",
         "//geometry:meshcat",
         "//geometry/test_utilities:meshcat_environment",
     ],

--- a/geometry/optimization/convex_set.h
+++ b/geometry/optimization/convex_set.h
@@ -183,6 +183,12 @@ class ConvexSet : public ShapeReifier {
   ConvexSet(std::function<std::unique_ptr<ConvexSet>(const ConvexSet&)> cloner,
             int ambient_dimension);
 
+  // Implements non-virtual base class serialization.
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(ambient_dimension_));
+  }
+
   // Non-virtual interface implementations.
   virtual bool DoIsBounded() const = 0;
 

--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -102,14 +102,12 @@ bool IsRedundant(const Eigen::Ref<const MatrixXd>& c, double d,
 
 }  // namespace
 
+HPolyhedron::HPolyhedron() : ConvexSet(&ConvexSetCloner<HPolyhedron>, 0) {}
+
 HPolyhedron::HPolyhedron(const Eigen::Ref<const MatrixXd>& A,
                          const Eigen::Ref<const VectorXd>& b)
     : ConvexSet(&ConvexSetCloner<HPolyhedron>, A.cols()), A_{A}, b_{b} {
-  DRAKE_DEMAND(A.rows() == b.size());
-  // Note: If necessary, we could support infinite b, either by removing the
-  // corresponding rows of A (since the constraint is vacuous), or checking
-  // this explicitly in all relevant computations (like IsBounded).
-  DRAKE_DEMAND(b.array().isFinite().all());
+  CheckInvariants();
 }
 
 HPolyhedron::HPolyhedron(const QueryObject<double>& query_object,
@@ -583,6 +581,15 @@ HPolyhedron HPolyhedron::PontryaginDifference(const HPolyhedron& other) const {
     b_diff(i) = b_(i) + result.get_optimal_cost();
   }
   return {A_, b_diff};
+}
+
+void HPolyhedron::CheckInvariants() const {
+  DRAKE_DEMAND(this->ambient_dimension() == A_.cols());
+  DRAKE_DEMAND(A_.rows() == b_.size());
+  // Note: If necessary, we could support infinite b, either by removing the
+  // corresponding rows of A (since the constraint is vacuous), or checking
+  // this explicitly in all relevant computations (like IsBounded).
+  DRAKE_DEMAND(b_.array().isFinite().all());
 }
 
 }  // namespace optimization

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/name_value.h"
 #include "drake/geometry/optimization/convex_set.h"
 #include "drake/geometry/optimization/hyperellipsoid.h"
 
@@ -19,6 +20,9 @@ namespace optimization {
 class HPolyhedron final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(HPolyhedron)
+
+  /** Constructs a default (zero-dimensional) polyhedron. */
+  HPolyhedron();
 
   /** Constructs the polyhedron.
   @pre A.rows() == b.size().
@@ -155,9 +159,19 @@ class HPolyhedron final : public ConvexSet {
   static HPolyhedron MakeUnitBox(int dim);
 
   /** Constructs the L1-norm unit ball in @p dim dimensions, {x | |x|₁ <= 1 }.
-  This set is also known as the crosspolytope and is described by the 2ᵈⁱᵐ
+  This set is also known as the cross-polytope and is described by the 2ᵈⁱᵐ
   signed unit vectors. */
   static HPolyhedron MakeL1Ball(int dim);
+
+  /** Passes this object to an Archive.
+  Refer to @ref yaml_serialization "YAML Serialization" for background. */
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    ConvexSet::Serialize(a);
+    a->Visit(DRAKE_NVP(A_));
+    a->Visit(DRAKE_NVP(b_));
+    CheckInvariants();
+  }
 
  private:
   HPolyhedron DoIntersectionNoChecks(const HPolyhedron& other) const;
@@ -208,6 +222,8 @@ class HPolyhedron final : public ConvexSet {
   // TODO(russt): Support ImplementGeometry(const Convex& convex, ...), but
   // currently it would require e.g. digging ReadObjForConvex out of
   // proximity_engine.cc.
+
+  void CheckInvariants() const;
 
   Eigen::MatrixXd A_{};
   Eigen::VectorXd b_{};

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -6,6 +6,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/yaml/yaml_io.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/meshcat.h"
 #include "drake/geometry/optimization/test_utilities.h"
@@ -35,6 +36,13 @@ using math::RotationMatrixd;
 using solvers::Binding;
 using solvers::Constraint;
 using solvers::MathematicalProgram;
+
+GTEST_TEST(HPolyhedronTest, DefaultConstructor) {
+  HPolyhedron H;
+  EXPECT_EQ(H.ambient_dimension(), 0);
+  EXPECT_EQ(H.A().size(), 0);
+  EXPECT_EQ(H.b().size(), 0);
+}
 
 GTEST_TEST(HPolyhedronTest, UnitBoxTest) {
   Matrix<double, 6, 3> A;
@@ -698,6 +706,15 @@ GTEST_TEST(HPolyhedronTest, UniformSampleTest) {
                samples.row(1).array() >= -1.5 && samples.row(1).array() <= -1)
                   .count(),
               N / 10, kTol);
+}
+
+GTEST_TEST(HPolyhedronTest, Serialize) {
+  const HPolyhedron H = HPolyhedron::MakeL1Ball(3);
+  const std::string yaml = yaml::SaveYamlString(H);
+  const auto H2 = yaml::LoadYamlString<HPolyhedron>(yaml);
+  EXPECT_EQ(H.ambient_dimension(), H2.ambient_dimension());
+  EXPECT_TRUE(CompareMatrices(H.A(), H2.A()));
+  EXPECT_TRUE(CompareMatrices(H.b(), H2.b()));
 }
 
 }  // namespace optimization


### PR DESCRIPTION
I would imagine eventually supporting serialization for all of the
convex set classes, but HPolyhedron is a particularly important
special case since it is how we represent IRIS regions (which we
precompute offline).

+@ggould-tri for feature review, please?
fyi @mpetersen94 , @TobiaMarcucci .

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17783)
<!-- Reviewable:end -->
