### PR TITLE
[sensors] Migrate CameraConfig from anzu

### DIFF
--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -27,6 +27,7 @@ drake_cc_package_library(
         ":accelerometer",
         ":beam_model",
         ":beam_model_params",
+        ":camera_config",
         ":camera_info",
         ":color_palette",
         ":gyroscope",
@@ -68,6 +69,19 @@ drake_cc_library(
         ":beam_model_params",
         "//common:unused",
         "//systems/framework",
+    ],
+)
+
+drake_cc_library(
+    name = "camera_config",
+    srcs = ["camera_config.cc"],
+    hdrs = ["camera_config.h"],
+    deps = [
+        ":camera_info",
+        "//common:name_value",
+        "//common/schema:transform",
+        "//geometry:rgba",
+        "//geometry/render:render_camera",
     ],
 )
 
@@ -275,6 +289,19 @@ drake_cc_googletest(
         "//systems/primitives:constant_vector_source",
         "//systems/primitives:random_source",
         "//systems/primitives:vector_log_sink",
+    ],
+)
+
+drake_cc_googletest(
+    name = "camera_config_test",
+    deps = [
+        ":camera_config",
+        "//common/schema:transform",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+        "//common/yaml:yaml_io",
+        "//geometry/render/gl_renderer",
+        "@fmt",
     ],
 )
 

--- a/systems/sensors/camera_config.cc
+++ b/systems/sensors/camera_config.cc
@@ -1,0 +1,136 @@
+#include "sim/common/camera_config.h"
+
+#include <cmath>
+#include <iostream>
+
+#include "drake/systems/sensors/camera_info.h"
+
+namespace anzu {
+namespace sim {
+
+using drake::geometry::render::ClippingRange;
+using drake::geometry::render::ColorRenderCamera;
+using drake::geometry::render::DepthRange;
+using drake::geometry::render::DepthRenderCamera;
+using drake::geometry::render::RenderCameraCore;
+using drake::math::RigidTransform;
+using drake::systems::sensors::CameraInfo;
+using drake::Vector2;
+
+void CameraConfig::FovDegrees::ValidateOrThrow() const {
+  if (!x.has_value() && !y.has_value()) {
+    throw std::logic_error(
+        "Invalid camera configuration; you must define at least x or y "
+        "for FovDegrees.");
+  }
+}
+
+namespace {
+
+// Computes the focal length along a single axis based on the the image
+// dimension and field of view (in a degrees) in that direction.
+// This computation must be kept in agreement with that in CameraInfo.
+double CalcFocalLength(int image_dimension, double fov_degrees) {
+  const double fov_rad = M_PI * fov_degrees / 180.0;
+  return image_dimension * 0.5 / std::tan(0.5 * fov_rad);
+}
+
+}  // namespace
+
+double CameraConfig::FovDegrees::focal_x(int width, int height) const {
+  ValidateOrThrow();
+  if (x.has_value()) {
+    return CalcFocalLength(width, *x);
+  } else {
+    return focal_y(width, height);
+  }
+}
+
+double CameraConfig::FovDegrees::focal_y(int width, int height) const {
+  ValidateOrThrow();
+  if (y.has_value()) {
+    return CalcFocalLength(height, *y);
+  } else {
+    return focal_x(width, height);
+  }
+}
+
+double CameraConfig::focal_x() const {
+  if (std::holds_alternative<double>(focal)) {
+    return std::get<double>(focal);
+  } else if (std::holds_alternative<Anisotropic>(focal)) {
+    return std::get<Anisotropic>(focal).x;
+  } else {
+    return std::get<FovDegrees>(focal).focal_x(width, height);
+  }
+}
+
+double CameraConfig::focal_y() const {
+  if (std::holds_alternative<double>(focal)) {
+    return std::get<double>(focal);
+  } else if (std::holds_alternative<Anisotropic>(focal)) {
+    return std::get<Anisotropic>(focal).y;
+  } else {
+    return std::get<FovDegrees>(focal).focal_y(width, height);
+  }
+}
+
+std::pair<ColorRenderCamera, DepthRenderCamera> CameraConfig::MakeCameras()
+    const {
+  const Vector2<double> center = principal_point();
+  CameraInfo intrinsics(width, height, focal_x(), focal_y(), center.x(),
+                        center.y());
+  ClippingRange clipping_range(clipping_near, clipping_far);
+  RenderCameraCore color_core(renderer_name, intrinsics, clipping_range,
+                              X_BC.GetDeterministicValue());
+  RenderCameraCore depth_core(renderer_name, intrinsics, clipping_range,
+                              X_BD.GetDeterministicValue());
+  DepthRange depth_range(z_near, z_far);
+  return {ColorRenderCamera(color_core, show_rgb),
+          DepthRenderCamera(depth_core, depth_range)};
+}
+
+void CameraConfig::ValidateOrThrow() const {
+  // If we haven't specified color or depth, it is trivially valid.
+  if (!(rgb || depth)) {
+    return;
+  }
+
+  // This throws for us if we have bad bad numerical camera values (or an empty
+  // renderer_name).
+  MakeCameras();
+
+  if (name.empty()) {
+    throw std::logic_error(
+        "Invalid camera configuration; name cannot be empty.");
+  }
+
+  if (renderer_name.empty()) {
+    throw std::logic_error(
+        "Invalid camera configuration; renderer_name cannot be empty.");
+  }
+
+  // We need to check the quantities unique to CameraConfig.
+  if (fps <= 0 || !std::isfinite(fps)) {
+    throw std::logic_error(
+        fmt::format("Invalid camera configuration; FPS ({}) must be a finite, "
+                    "positive value.",
+                    fps));
+  }
+
+  if (X_BC.base_frame.has_value() && !X_BC.base_frame->empty()) {
+    throw std::logic_error(
+        fmt::format("Invalid camera configuration; X_BC must not specify a "
+                    "base frame. '{}' found.",
+                    *X_BC.base_frame));
+  }
+
+  if (X_BD.base_frame.has_value() && !X_BD.base_frame->empty()) {
+    throw std::logic_error(
+        fmt::format("Invalid camera configuration; X_BD must not specify a "
+                    "base frame. '{}' found.",
+                    *X_BD.base_frame));
+  }
+}
+}  // namespace sim
+}  // namespace anzu

--- a/systems/sensors/camera_config.h
+++ b/systems/sensors/camera_config.h
@@ -1,0 +1,279 @@
+#pragma once
+
+#include <cmath>
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+
+#include "drake/common/name_value.h"
+#include "drake/common/never_destroyed.h"
+#include "drake/common/schema/transform.h"
+#include "drake/geometry/render/render_camera.h"
+#include "drake/geometry/rgba.h"
+
+namespace anzu {
+namespace sim {
+
+/** Configuration of a camera. This covers all of the parameters for both
+ color (see drake::geometry::render::ColorRenderCamera) and depth (see
+ drake::geometry::render::DepthRenderCamera) cameras.
+
+ The various properties have restrictions on what they can be.
+
+     - Values must be finite.
+     - Some values must be positive (see notes on individual properties).
+     - Ranges must be specified such that the "minimum" value is less than or
+       equal to the "maximum" value. This includes the clipping range
+       [`clipping_near`, `clipping_far`] and depth range [`z_near`, `z_far`].
+     - The depth range must lie *entirely* within the clipping range.
+
+ The values are only checked when the configuration is operated on: during
+ serialization, after deserialization, and when applying the configuration (see
+ ApplyCameraConfig().) */
+struct CameraConfig {
+  /** Passes this object to an Archive.
+   Refer to @ref yaml_serialization "YAML Serialization" for background. */
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(width));
+    a->Visit(DRAKE_NVP(height));
+    a->Visit(DRAKE_NVP(focal));
+    a->Visit(DRAKE_NVP(center_x));
+    a->Visit(DRAKE_NVP(center_y));
+    a->Visit(DRAKE_NVP(clipping_near));
+    a->Visit(DRAKE_NVP(clipping_far));
+    a->Visit(DRAKE_NVP(z_near));
+    a->Visit(DRAKE_NVP(z_far));
+    a->Visit(DRAKE_NVP(X_PB));
+    a->Visit(DRAKE_NVP(X_BC));
+    a->Visit(DRAKE_NVP(X_BD));
+    a->Visit(DRAKE_NVP(renderer_name));
+    a->Visit(DRAKE_NVP(background));
+    a->Visit(DRAKE_NVP(name));
+    a->Visit(DRAKE_NVP(fps));
+    a->Visit(DRAKE_NVP(rgb));
+    a->Visit(DRAKE_NVP(depth));
+    a->Visit(DRAKE_NVP(show_rgb));
+    a->Visit(DRAKE_NVP(do_compress));
+    ValidateOrThrow();
+  }
+
+  /** Specification of an anisotropic focal length (in pixels), where the
+   measure in the x- and y-directions can be different. */
+  struct Anisotropic {
+    /** Passes this object to an Archive.
+     Refer to @ref yaml_serialization "YAML Serialization" for background. */
+    template <typename Archive>
+    void Serialize(Archive* a) {
+      a->Visit(DRAKE_NVP(x));
+      a->Visit(DRAKE_NVP(y));
+    }
+    double x{};
+    double y{};
+  };
+
+  /** Specification of focal length via fields of view (in degrees). */
+  struct FovDegrees {
+    /** Passes this object to an Archive.
+     Refer to @ref yaml_serialization "YAML Serialization" for background. */
+    template <typename Archive>
+    void Serialize(Archive* a) {
+      a->Visit(DRAKE_NVP(x));
+      a->Visit(DRAKE_NVP(y));
+      ValidateOrThrow();
+    }
+
+    /** If specified, compute focal length along this axis; otherwise, use
+     focal length given computation for `y`. */
+    std::optional<double> x;
+
+    /** If specified, compute focal length along this axis; otherwise, use
+     focal length given computation for `x`. */
+    std::optional<double> y;
+
+    void ValidateOrThrow() const;
+
+    /** Resolves focal length along x-axis based on image dimensions and defined
+     value for `x` and/or `y`.
+     @throws std::exception if both `x` and `y` are null. */
+    double focal_x(int width, int height) const;
+
+    /** Resolves focal length along y-axis based on image dimensions and defined
+     value for `y` and/or `x`.
+     @throws std::exception if both `x` and `y` are null. */
+    double focal_y(int width, int height) const;
+  };
+
+  /** @name Camera intrinsics
+   See drake::systems::sensors::CameraInfo.
+   */
+  //@{
+
+  /** Image width (in pixels). @pre width > 0. */
+  int width{640};
+
+  /** Image height (in pixels). @pre height > 0. */
+  int height{480};
+
+  /** Focal length(s) of the camera (in pixels). If a single value is given, the
+   lens is symmetric. Otherwise the anisotropic values are used in the x- and
+   y-directions. @pre focal length(s) is a/are finite, positive number(s). */
+  std::variant<double, Anisotropic, FovDegrees> focal{500};
+
+  /** Returns the focal length (in pixels) in the x-direction. */
+  double focal_x() const;
+
+  /** Returns the focal length (in pixels) in the y-direction. */
+  double focal_y() const;
+
+  /** The x-position of the principal point (in pixels). To query what the
+   current value is, use principal_point().
+   @pre 0 < center_x < width or is std::nullopt. */
+  std::optional<double> center_x{};
+
+  /** The y-position of the principal point (in pixels). To query what the
+   current value is, use principal_point().
+   @pre 0 < center_y < height or is std::nullopt. */
+  std::optional<double> center_y{};
+
+  /** Returns the position of the principal point. This respects the semantics
+   that undefined center_x and center_y place the principal point in the center
+   of the image. */
+  drake::Vector2<double> principal_point() const {
+    // This calculation should be kept in agreement with CameraInfo's.
+    return {center_x.has_value() ? *center_x : width * 0.5 - 0.5,
+            center_y.has_value() ? *center_y : height * 0.5 - 0.5};
+  }
+
+  //@}
+
+  /** @name Frustum-based camera properties
+   See drake::geometry::render::ClippingRange.
+   */
+  //@{
+
+  /** The distance (in meters) from sensor origin to near clipping plane.
+   @pre clipping_near is a positive, finite number. */
+  double clipping_near{0.01};
+
+  /** The distance (in meters) from sensor origin to far clipping plane.
+   @pre clipping_far is a positive, finite number. */
+  double clipping_far{500.0};
+
+  //@}
+
+  /** @name Depth camera range
+   See drake::geometry::render::DepthRange.
+   */
+  //@{
+
+  /** The distance (in meters) from sensor origin to closest measurable plane.
+   @pre z_near is a positive, finite number. */
+  double z_near{0.1};
+
+  /** The distance (in meters) from sensor origin to farthest measurable plane.
+   @pre z_near is a positive, finite number. */
+  double z_far{5.0};
+
+  //@}
+
+  /** @name Camera extrinsics
+
+   As documented in drake::systems::sensors::RgbdSensor, the camera has four
+   associated frames: P, B, C, D. The frames of the parent (to which the camera
+   body is rigidly affixed), the camera body, color sensor, and depth sensor,
+   respectively. Typically, the body is posed w.r.t. the parent (X_PB) and the
+   sensors are posed w.r.t. the body (X_BC and X_BD).
+
+   When unspecified, X_BD = X_BC = I by default. */
+  //@{
+
+  /** The pose of the body camera relative to a parent frame P. If
+   `X_PB.base_frame` is unspecified, then the world frame is assumed to be
+   the parent frame.
+   @pre `X_PB.base_frame` is empty *or* refers to a valid, unique frame. */
+  drake::schema::Transform X_PB;
+
+  /** The pose of the color sensor relative to the camera body frame.
+   @pre `X_BC.base_frame` is empty. */
+  drake::schema::Transform X_BC;
+
+  /** The pose of the depth sensor relative to the camera body frame.
+   @pre `X_BD.base_frame` is empty. */
+  drake::schema::Transform X_BD;
+
+  //@}
+
+  /** @name Renderer properties
+
+   Every camera is supported by a drake::geometry::render::RenderEngine
+   instance. These properties configure the render engine for this camera. */
+  //@{
+
+  /** The name of the drake::geometry::render::RenderEngine that this camera
+   uses. Generally, it is more efficient for multiple cameras to share a single
+   render engine instance; they should, therefore, share a common renderer_name
+   value.
+   @pre `renderer_name` is not empty. */
+  std::string renderer_name{"default"};
+
+  /** The "background" color. This is the color drawn where there are no objects
+   visible. Its default value matches the default value for
+   drake::render::RenderEngineGlParams::default_clear_color. See the
+   documentation for drake::geometry::Rgba::Serialize for how to define this
+   value in YAML.
+
+   N.B. If two different cameras are configured to use the same renderer (having
+   identical values for `renderer_name`) but *different* values for
+   `background`, the render engine instance will be configured with one of the
+   set of values. Which one is undefined. */
+  drake::geometry::Rgba background{204 / 255.0, 229 / 255.0, 255 / 255.0, 1.0};
+
+  //@}
+
+  /** @name Publishing properties */
+  //@{
+
+  // TODO(dale.mcconachie) Find a better default name. This name is used as part
+  // of the drake system name, and part of the LCM channel name.
+  /** The camera name. This `name` is used as part of the corresponding
+   drake::systems::sensorRgbdSensor system's name and serves as a suffix of the
+   LCM channel name.
+   @pre `name` is not empty.*/
+  std::string name{"preview_camera"};
+
+  /** Publishing rate (in Hz) for both RGB and depth cameras (as requested).
+   @pre fps is a positive, finite number. */
+  double fps{10.0};
+
+  /** If true, RGB images will be produced and published via LCM. */
+  bool rgb{true};
+
+  /** If true, depth images will be produced and published via LCM. */
+  bool depth{false};
+
+  /** Controls whether the rendered RGB images are displayed (in a separate
+   window controlled by the thread in which the camera images are rendered).
+   Only applies to color images and depends on whether the RenderEngine instance
+   supports it. */
+  bool show_rgb{false};
+
+  /** Controls whether the images are broadcast in a compressed format. */
+  bool do_compress{true};
+
+  //@}
+
+  /** Creates color and depth camera data from this configuration.
+   @throws std::exception if configuration values do not satisfy the documented
+                          prerequisites. */
+  std::pair<drake::geometry::render::ColorRenderCamera,
+            drake::geometry::render::DepthRenderCamera>
+  MakeCameras() const;
+
+  /** Throws if the values are inconsistent. */
+  void ValidateOrThrow() const;
+};
+
+}  // namespace sim
+}  // namespace anzu

--- a/systems/sensors/camera_config.h
+++ b/systems/sensors/camera_config.h
@@ -1,32 +1,32 @@
 #pragma once
 
-#include <cmath>
 #include <optional>
 #include <string>
 #include <utility>
 #include <variant>
 
+#include "drake/common/eigen_types.h"
 #include "drake/common/name_value.h"
-#include "drake/common/never_destroyed.h"
 #include "drake/common/schema/transform.h"
 #include "drake/geometry/render/render_camera.h"
 #include "drake/geometry/rgba.h"
 
-namespace anzu {
-namespace sim {
+namespace drake {
+namespace systems {
+namespace sensors {
 
 /** Configuration of a camera. This covers all of the parameters for both
- color (see drake::geometry::render::ColorRenderCamera) and depth (see
- drake::geometry::render::DepthRenderCamera) cameras.
+ color (see geometry::render::ColorRenderCamera) and depth (see
+ geometry::render::DepthRenderCamera) cameras.
 
  The various properties have restrictions on what they can be.
 
-     - Values must be finite.
-     - Some values must be positive (see notes on individual properties).
-     - Ranges must be specified such that the "minimum" value is less than or
-       equal to the "maximum" value. This includes the clipping range
-       [`clipping_near`, `clipping_far`] and depth range [`z_near`, `z_far`].
-     - The depth range must lie *entirely* within the clipping range.
+   - Values must be finite.
+   - Some values must be positive (see notes on individual properties).
+   - Ranges must be specified such that the "minimum" value is less than or
+     equal to the "maximum" value. This includes the clipping range
+     [`clipping_near`, `clipping_far`] and depth range [`z_near`, `z_far`].
+   - The depth range must lie *entirely* within the clipping range.
 
  The values are only checked when the configuration is operated on: during
  serialization, after deserialization, and when applying the configuration (see
@@ -59,18 +59,36 @@ struct CameraConfig {
     ValidateOrThrow();
   }
 
-  /** Specification of an anisotropic focal length (in pixels), where the
-   measure in the x- and y-directions can be different. */
-  struct Anisotropic {
+  /** Specification of a camera's intrinsic focal properties as focal *length*
+   (in pixels). One or both values can be given. When only one value is given,
+   the other is assumed to match. At least one value must be provided. */
+  struct FocalLength {
     /** Passes this object to an Archive.
      Refer to @ref yaml_serialization "YAML Serialization" for background. */
     template <typename Archive>
     void Serialize(Archive* a) {
       a->Visit(DRAKE_NVP(x));
       a->Visit(DRAKE_NVP(y));
+      ValidateOrThrow();
     }
-    double x{};
-    double y{};
+
+    /** If specified, the focal length along this axis; otherwise, use
+     focal length in the y-direction. */
+    std::optional<double> x;
+
+    /** If specified, the focal length along this axis; otherwise, use
+     focal length in the x-direction. */
+    std::optional<double> y;
+
+    void ValidateOrThrow() const;
+
+    /** Reports focal length along x-axis.
+     @throws std::exception if both `x` and `y` are null. */
+    double focal_x() const;
+
+    /** Resolves focal length along y-axis.
+     @throws std::exception if both `x` and `y` are null. */
+    double focal_y() const;
   };
 
   /** Specification of focal length via fields of view (in degrees). */
@@ -106,20 +124,29 @@ struct CameraConfig {
   };
 
   /** @name Camera intrinsics
-   See drake::systems::sensors::CameraInfo.
+   See CameraInfo.
    */
   //@{
 
-  /** Image width (in pixels). @pre width > 0. */
+  /** %Image width (in pixels). @pre width > 0. */
   int width{640};
 
-  /** Image height (in pixels). @pre height > 0. */
+  /** %Image height (in pixels). @pre height > 0. */
   int height{480};
 
-  /** Focal length(s) of the camera (in pixels). If a single value is given, the
-   lens is symmetric. Otherwise the anisotropic values are used in the x- and
-   y-directions. @pre focal length(s) is a/are finite, positive number(s). */
-  std::variant<double, Anisotropic, FovDegrees> focal{500};
+  /** The focal properties of the camera. It can be specified in one of two
+   ways:
+
+     - A FocalLength which specifies the focal lengths (in pixels) in the x-
+       and y-directions.
+     - An FovDegrees which defines focal length *implicitly* by deriving it from
+       field of view measures (in degrees).
+
+   For both specifications, if only one value is given (in either direction),
+   the focal length (as reported by focal_x() and focal_y()) is determined by
+   that single value and is assumed to be symmetric for both directions.
+   @pre focal length(s) is a/are finite, positive number(s). */
+  std::variant<FocalLength, FovDegrees> focal{FovDegrees{.y = 45}};
 
   /** Returns the focal length (in pixels) in the x-direction. */
   double focal_x() const;
@@ -140,7 +167,7 @@ struct CameraConfig {
   /** Returns the position of the principal point. This respects the semantics
    that undefined center_x and center_y place the principal point in the center
    of the image. */
-  drake::Vector2<double> principal_point() const {
+  Vector2<double> principal_point() const {
     // This calculation should be kept in agreement with CameraInfo's.
     return {center_x.has_value() ? *center_x : width * 0.5 - 0.5,
             center_y.has_value() ? *center_y : height * 0.5 - 0.5};
@@ -149,7 +176,7 @@ struct CameraConfig {
   //@}
 
   /** @name Frustum-based camera properties
-   See drake::geometry::render::ClippingRange.
+   See geometry::render::ClippingRange.
    */
   //@{
 
@@ -164,7 +191,7 @@ struct CameraConfig {
   //@}
 
   /** @name Depth camera range
-   See drake::geometry::render::DepthRange.
+   See geometry::render::DepthRange.
    */
   //@{
 
@@ -179,12 +206,13 @@ struct CameraConfig {
   //@}
 
   /** @name Camera extrinsics
+   The pose of the camera.
 
-   As documented in drake::systems::sensors::RgbdSensor, the camera has four
-   associated frames: P, B, C, D. The frames of the parent (to which the camera
-   body is rigidly affixed), the camera body, color sensor, and depth sensor,
-   respectively. Typically, the body is posed w.r.t. the parent (X_PB) and the
-   sensors are posed w.r.t. the body (X_BC and X_BD).
+   As documented in RgbdSensor, the camera has four associated frames: P, B, C,
+   D. The frames of the parent (to which the camera body is rigidly affixed),
+   the camera body, color sensor, and depth sensor, respectively. Typically, the
+   body is posed w.r.t. the parent (X_PB) and the sensors are posed w.r.t. the
+   body (X_BC and X_BD).
 
    When unspecified, X_BD = X_BC = I by default. */
   //@{
@@ -193,25 +221,25 @@ struct CameraConfig {
    `X_PB.base_frame` is unspecified, then the world frame is assumed to be
    the parent frame.
    @pre `X_PB.base_frame` is empty *or* refers to a valid, unique frame. */
-  drake::schema::Transform X_PB;
+  schema::Transform X_PB;
 
   /** The pose of the color sensor relative to the camera body frame.
    @pre `X_BC.base_frame` is empty. */
-  drake::schema::Transform X_BC;
+  schema::Transform X_BC;
 
   /** The pose of the depth sensor relative to the camera body frame.
    @pre `X_BD.base_frame` is empty. */
-  drake::schema::Transform X_BD;
+  schema::Transform X_BD;
 
   //@}
 
   /** @name Renderer properties
 
-   Every camera is supported by a drake::geometry::render::RenderEngine
+   Every camera is supported by a geometry::render::RenderEngine
    instance. These properties configure the render engine for this camera. */
   //@{
 
-  /** The name of the drake::geometry::render::RenderEngine that this camera
+  /** The name of the geometry::render::RenderEngine that this camera
    uses. Generally, it is more efficient for multiple cameras to share a single
    render engine instance; they should, therefore, share a common renderer_name
    value.
@@ -220,26 +248,23 @@ struct CameraConfig {
 
   /** The "background" color. This is the color drawn where there are no objects
    visible. Its default value matches the default value for
-   drake::render::RenderEngineGlParams::default_clear_color. See the
-   documentation for drake::geometry::Rgba::Serialize for how to define this
+   render::RenderEngineGlParams::default_clear_color. See the
+   documentation for geometry::Rgba::Serialize for how to define this
    value in YAML.
 
    N.B. If two different cameras are configured to use the same renderer (having
    identical values for `renderer_name`) but *different* values for
    `background`, the render engine instance will be configured with one of the
    set of values. Which one is undefined. */
-  drake::geometry::Rgba background{204 / 255.0, 229 / 255.0, 255 / 255.0, 1.0};
+  geometry::Rgba background{204 / 255.0, 229 / 255.0, 255 / 255.0, 1.0};
 
   //@}
 
   /** @name Publishing properties */
   //@{
 
-  // TODO(dale.mcconachie) Find a better default name. This name is used as part
-  // of the drake system name, and part of the LCM channel name.
   /** The camera name. This `name` is used as part of the corresponding
-   drake::systems::sensorRgbdSensor system's name and serves as a suffix of the
-   LCM channel name.
+   RgbdSensor system's name and serves as a suffix of the LCM channel name.
    @pre `name` is not empty.*/
   std::string name{"preview_camera"};
 
@@ -267,13 +292,14 @@ struct CameraConfig {
   /** Creates color and depth camera data from this configuration.
    @throws std::exception if configuration values do not satisfy the documented
                           prerequisites. */
-  std::pair<drake::geometry::render::ColorRenderCamera,
-            drake::geometry::render::DepthRenderCamera>
+  std::pair<geometry::render::ColorRenderCamera,
+            geometry::render::DepthRenderCamera>
   MakeCameras() const;
 
   /** Throws if the values are inconsistent. */
   void ValidateOrThrow() const;
 };
 
-}  // namespace sim
-}  // namespace anzu
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/test/camera_config_test.cc
+++ b/systems/sensors/test/camera_config_test.cc
@@ -1,0 +1,367 @@
+#include "sim/common/camera_config.h"
+
+#include <vector>
+
+#include <fmt/format.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/schema/transform.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/yaml/yaml_io.h"
+#include "drake/geometry/render_gl/render_engine_gl_params.h"
+#include "drake/geometry/rgba.h"
+#include "drake/systems/sensors/camera_info.h"
+
+namespace anzu {
+namespace sim {
+namespace {
+
+using drake::geometry::render::ColorRenderCamera;
+using drake::geometry::render::DepthRenderCamera;
+using drake::geometry::render::RenderCameraCore;
+using drake::geometry::render::RenderEngineGlParams;
+using drake::geometry::Rgba;
+using drake::math::RigidTransformd;
+using drake::schema::Transform;
+using drake::systems::sensors::CameraInfo;
+using drake::yaml::LoadYamlString;
+using drake::yaml::SaveYamlString;
+using Eigen::Vector3d;
+
+// Confirms that a default-constructed camera config has valid values.
+GTEST_TEST(CameraConfigTest, DefaultValues) {
+  CameraConfig config;
+  ASSERT_NO_THROW(config.ValidateOrThrow());
+
+  // The default background color is documented as matching the color in
+  // RenderEngineGlParams. Confirm they match. If either changes, this test
+  // will fail and we'll have to decide what to do about it.
+  RenderEngineGlParams params;
+  EXPECT_EQ(config.background, params.default_clear_color);
+}
+
+// Tests the principal point logic.
+GTEST_TEST(CameraConfigTest, PrincipalPoint) {
+  const CameraConfig kDefault;
+
+  {
+    // If we never set the principal point, it always remains centered on
+    // the image (even as we change image size). The computed center should
+    // always match the center computed by CameraInfo.
+
+    // Two arbitrary image sizes to confirm that it respects image size. We'll
+    // use an arbitrary focal length value that doesn't affect the outcome.
+    constexpr double kFovY = 1.5;
+    {
+      int w = 328, h = 488;
+      CameraConfig c{.width = w, .height = h};
+      const drake::Vector2<double> center = c.principal_point();
+      CameraInfo intrinsics(c.width, c.height, kFovY);
+      EXPECT_EQ(center.x(), intrinsics.center_x());
+      EXPECT_EQ(center.y(), intrinsics.center_y());
+    }
+
+    {
+      int w = 207, h = 833;
+      CameraConfig c{.width = w, .height = h};
+      const drake::Vector2<double> center = c.principal_point();
+      CameraInfo intrinsics(c.width, c.height, kFovY);
+      EXPECT_EQ(center.x(), intrinsics.center_x());
+      EXPECT_EQ(center.y(), intrinsics.center_y());
+    }
+  }
+
+  // Confirm that the x- and y-components of the principal point are independent
+  // and, after setting them, they no longer change w.r.t. image size.
+  {
+    // Center x.
+    CameraConfig c;
+    c.center_x = 17;
+    EXPECT_EQ(*c.center_x, 17);
+    const drake::Vector2<double> center1 = c.principal_point();
+    EXPECT_EQ(center1.x(), 17);
+    // The y-position of the principal point hasn't moved.
+    EXPECT_NEAR(center1.y(), c.height / 2, 0.5);
+    // Doesn't change when the width changes.
+    c.width = 180;
+    const drake::Vector2<double> center2 = c.principal_point();
+    EXPECT_EQ(center2.x(), 17);
+    EXPECT_EQ(center2.y(), center1.y());
+  }
+
+  {
+    // Center y.
+    CameraConfig c;
+    c.center_y = 19;
+    EXPECT_EQ(*c.center_y, 19);
+    const drake::Vector2<double> center1 = c.principal_point();
+    // The x-position of the principal point hasn't moved.
+    EXPECT_NEAR(center1.x(), c.width / 2, 0.5);
+    EXPECT_EQ(center1.y(), 19);
+    // Doesn't change when the height changes.
+    c.height = 123;
+    const drake::Vector2<double> center2 = c.principal_point();
+    EXPECT_EQ(center2.x(), center1.x());
+    EXPECT_EQ(center2.y(), 19);
+  }
+}
+
+GTEST_TEST(CameraConfigTest, FovDegrees) {
+  constexpr int kWidth = 640;
+  constexpr int kHeight = 480;
+  constexpr double kFocalX = 250;
+  constexpr double kFocalY = 250;
+  const CameraInfo intrinsics(kWidth, kHeight, kFocalX, kFocalY, kWidth * 0.5,
+                              kHeight * 0.5);
+  const double kFovXDeg = intrinsics.fov_x() * 180 / M_PI;
+  const double kFovYDeg = intrinsics.fov_y() * 180 / M_PI;
+  {
+    // Just specifying fov_x a) computes the right focal length and the same
+    // value for x and y.
+    CameraConfig::FovDegrees fov;
+    fov.x = kFovXDeg;
+    EXPECT_DOUBLE_EQ(fov.focal_x(kWidth, kHeight), kFocalX);
+    EXPECT_DOUBLE_EQ(fov.focal_y(kWidth, kHeight), kFocalX);
+  }
+  {
+    // Just specifying fov_y a) computes the right focal length and the same
+    // value for x and y.
+    CameraConfig::FovDegrees fov;
+    fov.y = kFovYDeg;
+    EXPECT_DOUBLE_EQ(fov.focal_x(kWidth, kHeight), kFocalY);
+    EXPECT_DOUBLE_EQ(fov.focal_y(kWidth, kHeight), kFocalY);
+  }
+  {
+    // Specifying both right focal length for each direction independently.
+    const CameraConfig::FovDegrees fov{kFovXDeg, kFovYDeg};
+    EXPECT_DOUBLE_EQ(fov.focal_x(kWidth, kHeight), kFocalX);
+    EXPECT_DOUBLE_EQ(fov.focal_y(kWidth, kHeight), kFocalY);
+  }
+  {
+    // Specifying no values throws.
+    CameraConfig::FovDegrees null_fov;
+    DRAKE_EXPECT_THROWS_MESSAGE(null_fov.focal_x(kWidth, kHeight),
+                                ".*you must define .* for FovDegrees.");
+    DRAKE_EXPECT_THROWS_MESSAGE(null_fov.focal_y(kWidth, kHeight),
+                                ".*you must define .* for FovDegrees.");
+  }
+}
+
+// Tests the focal length semantics.
+GTEST_TEST(CameraConfigTest, FocalLength) {
+  {
+    // Both values match by default.
+    CameraConfig c;
+    EXPECT_EQ(c.focal_x(), c.focal_y());
+  }
+
+  {
+    // Both change when assigning a single value.
+    CameraConfig c;
+    const double old_focal = c.focal_x();
+    const double new_focal = old_focal * 1.3;
+    c.focal = new_focal;
+    EXPECT_EQ(c.focal_x(), new_focal);
+    EXPECT_EQ(c.focal_y(), new_focal);
+  }
+
+  {
+    // Both change independently when assigning an Anisotropic value.
+    CameraConfig c;
+    const double old_focal = c.focal_x();
+    const double new_focal_x = old_focal + 10;
+    const double new_focal_y = old_focal - 10;
+    c.focal = CameraConfig::Anisotropic{new_focal_x, new_focal_y};
+    EXPECT_EQ(c.focal_x(), new_focal_x);
+    EXPECT_EQ(c.focal_y(), new_focal_y);
+  }
+
+  {
+    // Both change independently when assigning a FovDegrees value. We'll
+    // create field of view angles from target focal lengths, and make sure we
+    // get back the expected focal lengths.
+    CameraConfig c;
+    const double target_focal_x = 250;
+    const double target_focal_y = 275;
+    // We'll use CameraInfo to convert focal lengths into fovs; the center point
+    // doesn't contribute to this calculation.)
+    const CameraInfo intrinsics(c.width, c.height, target_focal_x,
+                                target_focal_y, 0.5 * c.width, 0.5 * c.height);
+    const double fov_x_rad = intrinsics.fov_x();
+    const double fov_y_rad = intrinsics.fov_y();
+
+    c.focal = CameraConfig::FovDegrees{fov_x_rad * 180 / M_PI,
+                                       fov_y_rad * 180 / M_PI};
+    EXPECT_DOUBLE_EQ(c.focal_x(), target_focal_x);
+    EXPECT_DOUBLE_EQ(c.focal_y(), target_focal_y);
+  }
+}
+
+// Confirm that serialization happens the right way:
+//    background:
+//      rgba: [r, g, b, a]
+// We don't have to worry about malformed specifications, that is handled by
+// the Rgba's logic and tests. We just need to make sure we're invoking it
+// correctly.
+GTEST_TEST(CameraConfigTest, SerializeBackgroundRgba) {
+  CameraConfig config;
+  config.background = Rgba(0.1, 0.2, 0.3, 0.4);
+  // Serialize so that only background gets written by providing default.
+  const std::string yaml =
+      SaveYamlString<CameraConfig>(config, {}, CameraConfig());
+  EXPECT_EQ(yaml, "background:\n  rgba: [0.1, 0.2, 0.3, 0.4]\n");
+}
+
+// Helper functions for validating a render camera.
+
+void CoreIsValid(const RenderCameraCore& core, const CameraConfig& config,
+                 const RigidTransformd& X_BS) {
+  EXPECT_EQ(core.renderer_name(), config.renderer_name);
+  EXPECT_EQ(core.intrinsics().width(), config.width);
+  EXPECT_EQ(core.intrinsics().height(), config.height);
+  EXPECT_EQ(core.intrinsics().focal_x(), config.focal_x());
+  EXPECT_EQ(core.intrinsics().focal_y(), config.focal_y());
+  EXPECT_EQ(core.intrinsics().center_x(), *config.center_x);
+  EXPECT_EQ(core.intrinsics().center_y(), *config.center_y);
+  EXPECT_EQ(core.clipping().near(), config.clipping_near);
+  EXPECT_EQ(core.clipping().far(), config.clipping_far);
+  EXPECT_TRUE(core.sensor_pose_in_camera_body().IsExactlyEqualTo(X_BS));
+}
+
+void ColorIsValid(const ColorRenderCamera& camera, const CameraConfig& config) {
+  EXPECT_EQ(camera.show_window(), config.show_rgb);
+  // X_BS = I by convention for CameraConfig.
+  CoreIsValid(camera.core(), config, {});
+}
+
+void DepthIsValid(const DepthRenderCamera& camera, const CameraConfig& config) {
+  EXPECT_EQ(camera.depth_range().min_depth(), config.z_near);
+  EXPECT_EQ(camera.depth_range().max_depth(), config.z_far);
+  CoreIsValid(camera.core(), config, config.X_BD.GetDeterministicValue());
+}
+
+// Tests the logic for creating the pair of cameras. Generally, it confirms
+// that valid config values propagate through.
+GTEST_TEST(CameraConfigTest, MakeCameras) {
+  // These values are *supposed* to be different from the default values except
+  // for X_PB, fps, rgb, depth, and do_compress. None of those contribute
+  // to
+  CameraConfig config{.width = 320,
+                      .height = 240,
+                      .focal = CameraConfig::Anisotropic{470.0, 480.0},
+                      .center_x = 237,
+                      .center_y = 233,
+                      .clipping_near = 0.075,
+                      .clipping_far = 17.5,
+                      .z_near = 0.15,
+                      .z_far = 4.75,
+                      .X_PB = {},
+                      .X_BD = Transform{RigidTransformd{Vector3d::UnitX()}},
+                      .renderer_name = "test_renderer",
+                      .background = Rgba(0.1, 0.2, 0.3, 0.4),
+                      .name = "test_camera",
+                      .fps = 17,
+                      .rgb = false,
+                      .depth = true,
+                      .show_rgb = true};
+
+  // Check that all the values have propagated.
+  const auto [color, depth] = config.MakeCameras();
+  SCOPED_TRACE("Fully specified values");
+  ColorIsValid(color, config);
+  DepthIsValid(depth, config);
+}
+
+// CameraConfig explicitly validates several things:
+//    - X_BD.base_frame is empty,
+//    - X_BC.base_frame is empty,
+//    - name is not empty,
+//    - renderer_name is not empty, and
+//    - fps is a positive, finite value.
+// It relies on Drake's geometry::render artifacts to validate the other
+// restricted values. Finally, validation should be part of serialization.
+//
+// This test confirms CameraConfigs *specific* validation responsibilities,
+// and provides smoke tests that indicate that the other fields are validated
+// and that Serialize validates.
+GTEST_TEST(CameraConfigTest, Validation) {
+  const CameraConfig kDefault;
+  // Reality check that the default configuration is valid.
+  EXPECT_NO_THROW(kDefault.ValidateOrThrow());
+
+  {
+    CameraConfig config;
+    config.X_BD.base_frame = "error";
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        config.ValidateOrThrow(),
+        ".*X_BD must not specify a base frame. 'error' found.");
+  }
+
+  {
+    CameraConfig config;
+    config.X_BC.base_frame = "error";
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        config.ValidateOrThrow(),
+        ".*X_BC must not specify a base frame. 'error' found.");
+  }
+
+  {
+    CameraConfig config;
+    config.name = "";
+    DRAKE_EXPECT_THROWS_MESSAGE(config.ValidateOrThrow(),
+                                ".* name cannot be empty.");
+  }
+
+  {
+    CameraConfig config;
+    config.renderer_name = "";
+    DRAKE_EXPECT_THROWS_MESSAGE(config.ValidateOrThrow(),
+                                ".*renderer_name cannot be empty.");
+  }
+
+  {
+    CameraConfig config;
+    config.fps = 0;
+    DRAKE_EXPECT_THROWS_MESSAGE(config.ValidateOrThrow(), ".*FPS.*");
+
+    config.fps = -11;
+    DRAKE_EXPECT_THROWS_MESSAGE(config.ValidateOrThrow(), ".*FPS.*");
+
+    config.fps = std::numeric_limits<double>::infinity();
+    DRAKE_EXPECT_THROWS_MESSAGE(config.ValidateOrThrow(), ".*FPS.*");
+
+    config.fps = std::numeric_limits<double>::quiet_NaN();
+    DRAKE_EXPECT_THROWS_MESSAGE(config.ValidateOrThrow(), ".*FPS.*");
+  }
+
+  {
+    // Indicator that drake::geometry::render is being exercised to validate
+    // other values.
+    CameraConfig config;
+    config.width = -5;
+    EXPECT_THROW(config.ValidateOrThrow(), std::exception);
+  }
+
+  {
+    // An invalid configuration should throw when serializing.
+    CameraConfig config;
+    config.renderer_name = "";
+    DRAKE_EXPECT_THROWS_MESSAGE(SaveYamlString(config),
+                                ".*renderer_name cannot be empty.");
+  }
+
+  {
+    // However, if rgb = depth = false, then the configuration is by definition
+    // valid, even with otherwise bad values elsewhere.
+    CameraConfig config;
+    config.rgb = config.depth = false;
+    config.width = -10;
+    EXPECT_NO_THROW(config.ValidateOrThrow());
+  }
+}
+
+}  // namespace
+}  // namespace sim
+}  // namespace anzu


### PR DESCRIPTION
This introduces the `CameraConfig` class into Drake. This is predominantly a copy and clean up operation from Anzu.

Relates #17112

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17787)
<!-- Reviewable:end -->
