### PR TITLE
[geometry] Fix a bug in deformable mesh intersection

### DIFF
--- a/geometry/proximity/deformable_contact_geometries.cc
+++ b/geometry/proximity/deformable_contact_geometries.cc
@@ -65,6 +65,14 @@ DeformableGeometry::DeformableGeometry(VolumeMesh<double> mesh)
       signed_distance_field_(
           ApproximateSignedDistanceField(&deformable_mesh_->mesh())) {}
 
+const VolumeMeshFieldLinear<double, double>&
+DeformableGeometry::CalcSignedDistanceField() const {
+  std::vector<double> values = signed_distance_field_->values();
+  *signed_distance_field_ = VolumeMeshFieldLinear<double, double>(
+      std::move(values), &deformable_mesh_->mesh());
+  return *signed_distance_field_;
+}
+
 std::optional<RigidGeometry> MakeRigidRepresentation(
     const HalfSpace&, const ProximityProperties&) {
   throw std::logic_error(

--- a/geometry/proximity/deformable_contact_geometries.h
+++ b/geometry/proximity/deformable_contact_geometries.h
@@ -56,16 +56,22 @@ class DeformableGeometry {
   }
 
   /* Returns the approximate signed distance field (sdf) for the deformable
-   geometry. More specifically, the sdf value at each vertex is equal to the
-   exact value (to the accuracy of the distance query algorithm) in their
-   reference configuration. The values in the interior of the mesh are linearly
-   interpolated from vertex values. */
-  const VolumeMeshFieldLinear<double, double>& signed_distance_field() const {
-    return *signed_distance_field_;
-  }
+   geometry evaluated with the deformable mesh at its *current* configuration.
+   More specifically, the sdf value at each vertex is equal to the exact value
+   (to the accuracy of the distance query algorithm) in their reference
+   configuration. The values in the interior of the mesh are linearly
+   interpolated from vertex values.
+   @warn The result may no longer be valid after calls to
+   UpdateVertexPositions(). Hence, the result should be used and discarded
+   instead of kept around. */
+  const VolumeMeshFieldLinear<double, double>& CalcSignedDistanceField() const;
 
  private:
   std::unique_ptr<DeformableVolumeMesh<double>> deformable_mesh_;
+  /* Note: we don't provide an accessor to `signed_distance_field_` as it may be
+   invalidated by calls to `UpdateVertexPositions()`. Instead, we provide
+   `CalcSignedDistanceField()` that guarantees to return the up-to-date mesh
+   field. */
   std::unique_ptr<VolumeMeshFieldLinear<double, double>> signed_distance_field_;
 };
 

--- a/geometry/proximity/deformable_mesh_intersection.cc
+++ b/geometry/proximity/deformable_mesh_intersection.cc
@@ -84,7 +84,7 @@ void AppendDeformableRigidContact(
 
   DeformableSurfaceVolumeIntersector intersect;
   intersect.SampleVolumeFieldOnSurface(
-      deformable_D.signed_distance_field(),
+      deformable_D.CalcSignedDistanceField(),
       deformable_D.deformable_mesh().bvh(), rigid_mesh_R, rigid_bvh_R, X_DR,
       false /* don't filter face normal along field gradient */);
 

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -4601,15 +4601,13 @@ TEST_F(ProximityEngineDeformableContactTest, ReplacePropertiesDeformable) {
       new_geometry.deformable_mesh().mesh()));
   EXPECT_TRUE(old_geometry.deformable_mesh().bvh().Equal(
       new_geometry.deformable_mesh().bvh()));
-  EXPECT_TRUE(old_geometry.signed_distance_field().Equal(
-      new_geometry.signed_distance_field()));
+  EXPECT_TRUE(old_geometry.CalcSignedDistanceField().Equal(
+      new_geometry.CalcSignedDistanceField()));
   // Verify that the address didn't change either; so it's indeed an no-op.
   EXPECT_EQ(&old_geometry.deformable_mesh().mesh(),
             &new_geometry.deformable_mesh().mesh());
   EXPECT_EQ(&old_geometry.deformable_mesh().bvh(),
             &new_geometry.deformable_mesh().bvh());
-  EXPECT_EQ(&old_geometry.signed_distance_field(),
-            &new_geometry.signed_distance_field());
 }
 
 TEST_F(ProximityEngineDeformableContactTest, AddAndRemoveDeformableGeometry) {


### PR DESCRIPTION
As the documentation of `SurfaceVolumeIntersector::SampleVolumeFieldOnSurface` states, the volume field to be sampled from should be based on the volume mesh in its current configuration, not any arbitrary configuration (e.g. the reference configuration). This is important because the gradient information used to interpolate values in the interior of tetrahedra depends on the configuration of the mesh.

In deformable mesh intersection, we incorrectly used the volume field based on the reference configuration of the deformable mesh and consequently were getting garbage penetration distances.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17789)
<!-- Reviewable:end -->
