### PR TITLE
[multibody] MultibodyPlant::SetDefaultPositions

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -959,8 +959,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 const Eigen::Ref<const VectorX<T>>& q) {
               self->SetPositions(context, q);
             },
-            py_rvp::reference, py::arg("context"), py::arg("q"),
-            cls_doc.SetPositions.doc_2args)
+            py::arg("context"), py::arg("q"), cls_doc.SetPositions.doc_2args)
         .def(
             "SetPositions",
             [](const MultibodyPlant<T>* self, Context<T>* context,
@@ -968,8 +967,24 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 const Eigen::Ref<const VectorX<T>>& q) {
               self->SetPositions(context, model_instance, q);
             },
-            py_rvp::reference, py::arg("context"), py::arg("model_instance"),
-            py::arg("q"), cls_doc.SetPositions.doc_2args)
+            py::arg("context"), py::arg("model_instance"), py::arg("q"),
+            cls_doc.SetPositions.doc_2args)
+        .def(
+            "SetDefaultPositions",
+            [](MultibodyPlant<T>* self,
+                const Eigen::Ref<const VectorX<double>>& q) {
+              self->SetDefaultPositions(q);
+            },
+            py::arg("q"), cls_doc.SetDefaultPositions.doc_1args)
+        .def(
+            "SetDefaultPositions",
+            [](MultibodyPlant<T>* self,
+                multibody::ModelInstanceIndex model_instance,
+                const Eigen::Ref<const VectorX<double>>& q_instance) {
+              self->SetDefaultPositions(model_instance, q_instance);
+            },
+            py::arg("model_instance"), py::arg("q_instance"),
+            cls_doc.SetDefaultPositions.doc_2args)
         .def(
             "GetVelocities",
             [](const MultibodyPlant<T>* self, const Context<T>& context)

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -978,7 +978,7 @@ class TestPlant(unittest.TestCase):
         file_name = FindResourceOrThrow(
             "drake/multibody/benchmarks/acrobot/acrobot.sdf")
         # N.B. `Parser` only supports `MultibodyPlant_[float]`.
-        Parser(plant_f).AddModelFromFile(file_name)
+        instance = Parser(plant_f).AddModelFromFile(file_name)
         plant_f.Finalize()
         plant = to_type(plant_f, T)
         context = plant.CreateDefaultContext()
@@ -1043,6 +1043,10 @@ class TestPlant(unittest.TestCase):
         plant.SetPositionsAndVelocities(context, x0)
         numpy_compare.assert_float_allclose(
             plant.GetPositionsAndVelocities(context), x0)
+
+        # Test SetDefaultPositions
+        plant.SetDefaultPositions(q=q0)
+        plant.SetDefaultPositions(model_instance=instance, q_instance=q0)
 
         # Test existence of context resetting methods.
         plant.SetDefaultState(context, state=context.get_mutable_state())

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2111,6 +2111,24 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     internal_tree().SetPositionsInArray(model_instance, q_instance, &q);
   }
 
+  /// Sets the default positions for the plant.  Calls to CreateDefaultContext
+  /// or SetDefaultContext/SetDefaultState will return a Context populated with
+  /// these position values. They have no other effects on the dynamics of the
+  /// system.
+  /// @throws std::exception if the plant is not finalized or if q is
+  /// not of size num_positions().
+  void SetDefaultPositions(const Eigen::Ref<const Eigen::VectorXd>& q);
+
+  /// Sets the default positions for the model instance.  Calls to
+  /// CreateDefaultContext or SetDefaultContext/SetDefaultState will return a
+  /// Context populated with these position values. They have no other effects
+  /// on the dynamics of the system.
+  /// @throws std::exception if the plant is not
+  /// finalized, if the model_instance is invalid, or if the length of
+  /// `q_instance` is not equal to `num_positions(model_instance)`.
+  void SetDefaultPositions(ModelInstanceIndex model_instance,
+                    const Eigen::Ref<const Eigen::VectorXd>& q_instance);
+
   /// Returns a const vector reference to the generalized velocities v in a
   /// given Context.
   /// @note This method returns a reference to existing data, exhibits constant


### PR DESCRIPTION
Add sugar methods for setting the default position vector for all
joints / floating-bodies in a plant or model instance.

+@joemasterjohn for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17793)
<!-- Reviewable:end -->
