### PR TITLE
Refactory installer.py

### DIFF
--- a/tools/install/test/install_meta_test.py
+++ b/tools/install/test/install_meta_test.py
@@ -5,7 +5,7 @@ import io
 import os
 from os.path import isdir, join, relpath
 import unittest
-from subprocess import STDOUT, check_call, check_output
+from subprocess import STDOUT, check_output
 import sys
 
 import drake.tools.install.installer as installer
@@ -41,10 +41,6 @@ class TestInstallMeta(unittest.TestCase):
         """Invoke installation of dummy files by direct import and call to
         installer.
         """
-        # Forcibly reset globals.
-        # TODO(rpoyner-tri): get rid of installer globals; see #7331.
-        installer.libraries_installed.clear()
-
         stream = io.StringIO()
         with redirect_stdout(stream), redirect_stderr(stream):
             installer.main(


### PR DESCRIPTION
Refactor the install helper script to encapsulate state information in a class instance. Mostly, this allows us to remove the ugly hack in the unit test which imports the installer and uses it multiple times.

While we're at it, simplify the implementation of `_may_be_binary`.

+@rpoyner-tri for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17794)
<!-- Reviewable:end -->
