### PR TITLE
[parsing] Unify parsing package visibility

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -277,6 +277,7 @@ drake_cc_library(
     name = "scoped_names",
     srcs = ["scoped_names.cc"],
     hdrs = ["scoped_names.h"],
+    visibility = ["//visibility:public"],
     deps = [
         "//multibody/plant",
     ],


### PR DESCRIPTION
`multibody/parsing/BUILD.bazel` hides a lot of its implementation in the build (with visible = private). The package library includes six dependencies. Of those six dependencies, *five* have been explicitly declared to be public (so they can be accessed directly). This changes the sixth so it is treated the same.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17795)
<!-- Reviewable:end -->
