### PR TITLE
[geometry/optimization] Enable rounding of GCS solution when solving convex relaxation of ShortestPath

### DIFF
--- a/bindings/pydrake/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry_py_optimization.cc
@@ -348,15 +348,32 @@ void DefineGeometryOptimization(py::module m) {
             cls_doc.convex_relaxation.doc)
         .def_readwrite("preprocessing",
             &GraphOfConvexSetsOptions::preprocessing, cls_doc.preprocessing.doc)
+        .def_readwrite("max_rounded_paths",
+            &GraphOfConvexSetsOptions::max_rounded_paths,
+            cls_doc.max_rounded_paths.doc)
+        .def_readwrite("max_rounding_trials",
+            &GraphOfConvexSetsOptions::max_rounding_trials,
+            cls_doc.max_rounding_trials.doc)
+        .def_readwrite("flow_tolerance",
+            &GraphOfConvexSetsOptions::flow_tolerance,
+            cls_doc.flow_tolerance.doc)
+        .def_readwrite("rounding_seed",
+            &GraphOfConvexSetsOptions::rounding_seed, cls_doc.rounding_seed.doc)
         .def("__repr__", [](const GraphOfConvexSetsOptions& self) {
           return py::str(
               "GraphOfConvexSetsOptions("
               "convex_relaxation={}, "
               "preprocessing={}, "
+              "max_rounded_paths={}, "
+              "max_rounding_trials={}, "
+              "flow_tolerance={}, "
+              "rounding_seed={}, "
               "solver={}, "
               "solver_options={}, "
               ")")
-              .format(self.convex_relaxation, self.preprocessing, self.solver,
+              .format(self.convex_relaxation, self.preprocessing,
+                  self.max_rounded_paths, self.max_rounding_trials,
+                  self.flow_tolerance, self.rounding_seed, self.solver,
                   self.solver_options);
         });
 

--- a/bindings/pydrake/test/geometry_optimization_test.py
+++ b/bindings/pydrake/test/geometry_optimization_test.py
@@ -414,6 +414,10 @@ class TestGeometryOptimization(unittest.TestCase):
         options = mut.GraphOfConvexSetsOptions()
         options.convex_relaxation = True
         options.preprocessing = False
+        options.max_rounded_paths = 2
+        options.max_rounding_trials = 5
+        options.flow_tolerance = 1e-6
+        options.rounding_seed = 1
         options.solver = ClpSolver()
         options.solver_options = SolverOptions()
         self.assertIn("convex_relaxation", repr(options))

--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -127,6 +127,7 @@ drake_cc_googletest(
         "//common/test_utilities:expect_throws_message",
         "//solvers:choose_best_solver",
         "//solvers:clp_solver",
+        "//solvers:csdp_solver",
         "//solvers:gurobi_solver",
         "//solvers:ipopt_solver",
         "//solvers:mosek_solver",

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -38,6 +38,25 @@ struct GraphOfConvexSetsOptions {
   lie on the path from source to target that this does not detect. */
   bool preprocessing{false};
 
+  /** Maximum number of distinct paths to compare during random rounding; only
+  the lowest cost path is returned. If convex_relaxation is false or this is
+  less than or equal to zero, rounding is not performed. */
+  int max_rounded_paths{0};
+
+  /** Maximum number of trials to find a novel path during random rounding. If
+  convex_relaxation is false or max_rounded_paths is less than or equal to zero,
+  this option is ignored. */
+  int max_rounding_trials{100};
+
+  /** Tolerance for ignoring flow along a given edge during random rounding. If
+  convex_relaxation is false or max_rounded_paths is less than or equal to zero,
+  this option is ignored. */
+  double flow_tolerance{1e-5};
+
+  /** Random seed to use for random rounding. If convex_relaxation is false or
+  max_rounded_paths is less than or equal to zero, this option is ignored. */
+  int rounding_seed{0};
+
   /** Optimizer to be used to solve the shortest path optimization problem. If
   not set, the best solver for the given problem is selected. Note that if the
   solver cannot handle the type of optimization problem generated, the calling


### PR DESCRIPTION
Adds an optional rounding step to the SolveShortestPath. Currently off by default to preserve the current behaviors.

Depends on #17396 

+@RussTedrake for feature review
cc @TobiaMarcucci

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17796)
<!-- Reviewable:end -->
