### PR TITLE
[sensors] Add infrastructure to support applying CameraConfig

### DIFF
--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -40,6 +40,7 @@ drake_cc_package_library(
         ":optitrack_sender",
         ":rgbd_sensor",
         ":rotary_encoders",
+        ":sim_rgbd_sensor",
     ],
 )
 
@@ -265,6 +266,20 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "sim_rgbd_sensor",
+    srcs = ["sim_rgbd_sensor.cc"],
+    hdrs = ["sim_rgbd_sensor.h"],
+    deps = [
+        ":image_to_lcm_image_array_t",
+        ":rgbd_sensor",
+        "//lcm",
+        "//multibody/plant",
+        "//systems/framework:diagram_builder",
+        "//systems/lcm:lcm_publisher_system",
+    ],
+)
+
 # === test/ ===
 
 drake_cc_googletest(
@@ -398,6 +413,21 @@ drake_cc_googletest(
     deps = [
         ":optitrack_sender",
         "@optitrack_driver//lcmtypes:optitrack_lcmtypes",
+    ],
+)
+
+drake_cc_googletest(
+    name = "sim_rgbd_sensor_test",
+    deps = [
+        ":image_to_lcm_image_array_t",
+        ":rgbd_sensor",
+        ":sim_rgbd_sensor",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//lcm:drake_lcm",
+        "//multibody/plant",
+        "//systems/framework:diagram_builder",
+        "//systems/lcm:lcm_publisher_system",
+        "@fmt",
     ],
 )
 

--- a/systems/sensors/sim_rgbd_sensor.cc
+++ b/systems/sensors/sim_rgbd_sensor.cc
@@ -1,0 +1,90 @@
+#include "drake/systems/sensors/sim_rgbd_sensor.h"
+
+#include <memory>
+#include <optional>
+#include <regex>
+
+#include "drake/systems/lcm/lcm_publisher_system.h"
+#include "drake/systems/sensors/image_to_lcm_image_array_t.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+namespace internal {
+
+using geometry::SceneGraph;
+using geometry::render::ColorRenderCamera;
+using geometry::render::DepthRenderCamera;
+using math::RigidTransformd;
+using multibody::MultibodyPlant;
+
+RgbdSensor* AddSimRgbdSensor(const SceneGraph<double>& scene_graph,
+                             const MultibodyPlant<double>& plant,
+                             const SimRgbdSensor& sim_rgbd_sensor,
+                             DiagramBuilder<double>* builder) {
+  DRAKE_DEMAND(builder != nullptr);
+  // TODO(eric.cousineau): Simplify this if drake#10247 is resolved.
+
+  // 'A' is the body for the parent sensor frame.
+  // `P` is the parent of the sensor frame.
+  // `B` is the sensor frame.
+
+  const auto& frame_P = sim_rgbd_sensor.frame();
+  const auto& body_A = frame_P.body();
+  const std::optional<geometry::FrameId> body_A_id =
+      plant.GetBodyFrameIdIfExists(body_A.index());
+  DRAKE_THROW_UNLESS(body_A_id.has_value());
+
+  // We must include the offset of the body to ensure that we posture the camera
+  // appropriately.
+  const RigidTransformd X_AP = frame_P.GetFixedPoseInBodyFrame();
+  const RigidTransformd X_AB = X_AP * sim_rgbd_sensor.X_PB();
+
+  auto* rgbd_sensor_sys = builder->AddSystem<RgbdSensor>(
+      *body_A_id, X_AB, sim_rgbd_sensor.color_properties(),
+      sim_rgbd_sensor.depth_properties());
+  // `set_name` is only used for debugging.
+  rgbd_sensor_sys->set_name("rgbd_sensor_" + sim_rgbd_sensor.serial());
+  builder->Connect(scene_graph.get_query_output_port(),
+                   rgbd_sensor_sys->query_object_input_port());
+  return rgbd_sensor_sys;
+}
+
+void AddSimRgbdSensorLcmPublisher(const SimRgbdSensor& sim_rgbd_sensor,
+                                  const OutputPort<double>* rgb_port,
+                                  const OutputPort<double>* depth_16u_port,
+                                  bool do_compress,
+                                  DiagramBuilder<double>* builder,
+                                  drake::lcm::DrakeLcmInterface* lcm) {
+  DRAKE_DEMAND(builder != nullptr);
+  DRAKE_DEMAND(lcm != nullptr);
+  if (!rgb_port && !depth_16u_port) return;
+
+  auto image_to_lcm_image_array =
+      builder->AddSystem<ImageToLcmImageArrayT>(do_compress);
+  image_to_lcm_image_array->set_name("image_to_lcm_" +
+                                     sim_rgbd_sensor.serial());
+  if (depth_16u_port) {
+    const auto& lcm_depth_port =
+        image_to_lcm_image_array->DeclareImageInputPort<PixelType::kDepth16U>(
+            "depth");
+    builder->Connect(*depth_16u_port, lcm_depth_port);
+  }
+  if (rgb_port) {
+    const auto& lcm_rgb_port =
+        image_to_lcm_image_array->DeclareImageInputPort<PixelType::kRgba8U>(
+            "rgb");
+    builder->Connect(*rgb_port, lcm_rgb_port);
+  }
+  auto image_array_lcm_publisher =
+      builder->AddSystem(lcm::LcmPublisherSystem::Make<lcmt_image_array>(
+          "DRAKE_RGBD_CAMERA_IMAGES_" + sim_rgbd_sensor.serial(), lcm,
+          1. / sim_rgbd_sensor.rate_hz()));
+  builder->Connect(image_to_lcm_image_array->image_array_t_msg_output_port(),
+                   image_array_lcm_publisher->get_input_port());
+}
+
+}  // namespace internal
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/sim_rgbd_sensor.h
+++ b/systems/sensors/sim_rgbd_sensor.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <string>
+
+#include "drake/geometry/scene_graph.h"
+#include "drake/lcm/drake_lcm_interface.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/sensors/rgbd_sensor.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+namespace internal {
+
+/* Specification of an RGB-D sensor: its sensor properties, how it connects into
+ the plant, and publication configuration. */
+class SimRgbdSensor {
+ public:
+  // TODO(sean-curtis): The name "serial" has some issues.
+  //  - "Serial" as a noun, doesn't mean serial number. Strictly speaking, its
+  //    actual meaning is inappropriate for this context.
+  //  - In practice, it's merely a suffix that gets applied to LCM channels
+  //    and system names. It need not be a "serial number". It could be any
+  //    value convenient to the author of the model.
+  //  - The main interface (CameraConfig) has the field `name` which gets
+  //    mapped to serial in its construction of SimRgbdSensor. So, we have
+  //    "name" vs "serial" consistency problems.
+  //  We should pick and document the name that we want with intention.
+  /*
+    RgbdSensor is a meta sensor that contains multiple cameras. Please refer
+    to `drake/systems/sensors/rgbd_sensor.h` for more details.
+
+    @param serial           The identifier for the sensor - this is used in the
+                            name of the RgbdSensor as well as to provide names
+                            for the image LCM channels.
+    @param frame_P          The parent frame P in MultibodyPlant the sensor is
+                            affixed to. This frame gets aliased by `this`.
+    @param rate_hz          The publishing rate for the sensor.
+    @param X_PB             The pose of the sensor frame B expressed with
+                            respect to its parent frame P.
+    @param color_properties The properties of the color camera.
+    @param depth_properties The properties of the depth camera.
+
+    @warning Note that frame P may not have a *direct* analog in a SceneGraph;
+    instead, SceneGraph will have a frame for body A (the body that parent frame
+    P is attached to). In this case, usages must account for X_AP when adding a
+    camera. For example, see the implementation of `AddSimRgbdSensor`.
+   */
+  SimRgbdSensor(const std::string& serial,
+                const multibody::Frame<double>& frame_P, double rate_hz,
+                const math::RigidTransformd& X_PB,
+                const geometry::render::ColorRenderCamera& color_properties,
+                const geometry::render::DepthRenderCamera& depth_properties)
+      : serial_(serial),
+        frame_(&frame_P),
+        rate_hz_(rate_hz),
+        X_PB_(X_PB),
+        color_properties_(color_properties),
+        depth_properties_(depth_properties) {}
+
+  const std::string& serial() const { return serial_; }
+
+  const multibody::Frame<double>& frame() const { return *frame_; }
+
+  const math::RigidTransform<double>& X_PB() const { return X_PB_; }
+
+  const geometry::render::ColorRenderCamera& color_properties() const {
+    return color_properties_;
+  }
+
+  const geometry::render::DepthRenderCamera& depth_properties()
+      const {
+    return depth_properties_;
+  }
+
+  double rate_hz() const { return rate_hz_; }
+
+ private:
+  std::string serial_;
+  const multibody::Frame<double>* frame_{};
+  double rate_hz_{};
+  math::RigidTransformd X_PB_;
+  geometry::render::ColorRenderCamera color_properties_;
+  geometry::render::DepthRenderCamera depth_properties_;
+};
+
+// TODO(eric.cousineau): Ew... Is there a way to not need the plant?
+/* Adds an RGB-D camera, as described by `sim_camera`, to the diagram.
+ @param scene_graph       The SceneGraph that supplies the rendered image for
+                          the camera.
+ @param plant             The plant that owns the frame the sensor will be
+                          affixed to.
+ @param sim_camera        The description of the camera.
+ @param[in,out] builder   The new RgbdSensor will be added to this builder's
+                          diagram.
+ @pre The description in `sim_camera` is compatible with the configuration in
+      SceneGraph (e.g., camera properties refer to an existing RenderEngine).
+ */
+RgbdSensor* AddSimRgbdSensor(const geometry::SceneGraph<double>& scene_graph,
+                             const multibody::MultibodyPlant<double>& plant,
+                             const SimRgbdSensor& sim_camera,
+                             DiagramBuilder<double>* builder);
+
+// TODO(eric.cousineau): Add something for label stuff? Meh.
+/* Adds LCM publishers for images (RGB and/or Depth), at the camera's specified
+  rate.
+
+ @param sim_camera       The description of the camera whose data will be
+                         published.
+ @param rgb_port         The (optional) port for color images.
+ @param depth_16u_port   The (optional) port for depth images.
+ @param do_compress      If true, the published images will be compressed.
+ @param[in,out] builder  The publishing infrastructure will be added to this
+                         builder's diagram.
+ @param[in,out] lcm      The lcm interface to use. This interface object must
+                         remain alive at least as long as the systems added
+                         to `builder`.
+
+ @pre lcm != nullptr.
+ @pre builder != nullptr.
+ @pre rgb_port is null or ImageRgba8U-valued.
+ @pre depth_16u_port is null or ImageDepth16U-valued. */
+void AddSimRgbdSensorLcmPublisher(const SimRgbdSensor& sim_camera,
+                                  const OutputPort<double>* rgb_port,
+                                  const OutputPort<double>* depth_16u_port,
+                                  bool do_compress,
+                                  DiagramBuilder<double>* builder,
+                                  drake::lcm::DrakeLcmInterface* lcm);
+
+}  // namespace internal
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/test/sim_rgbd_sensor_test.cc
+++ b/systems/sensors/test/sim_rgbd_sensor_test.cc
@@ -1,0 +1,306 @@
+#include "drake/systems/sensors/sim_rgbd_sensor.h"
+
+#include <string>
+#include <utility>
+
+#include <fmt/format.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/scene_graph.h"
+#include "drake/lcm/drake_lcm.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/lcm/lcm_publisher_system.h"
+#include "drake/systems/sensors/image_to_lcm_image_array_t.h"
+#include "drake/systems/sensors/rgbd_sensor.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+namespace internal {
+namespace {
+
+// We need drake:: because there's also a systems::lcm namespace.
+using drake::lcm::DrakeLcm;
+using geometry::SceneGraph;
+using geometry::render::ClippingRange;
+using geometry::render::ColorRenderCamera;
+using geometry::render::DepthRange;
+using geometry::render::DepthRenderCamera;
+using geometry::render::RenderCameraCore;
+using math::RigidTransformd;
+using multibody::AddMultibodyPlantSceneGraph;
+using multibody::FixedOffsetFrame;
+using multibody::Frame;
+using multibody::MultibodyPlant;
+using multibody::RigidBody;
+using multibody::SpatialInertia;
+using systems::lcm::LcmPublisherSystem;
+using Eigen::Vector3d;
+
+/* Returns a pointer to the named instance of TargetSystem (if it exists). */
+template <typename TargetSystem>
+const TargetSystem* GetSystem(const DiagramBuilder<double>& builder,
+                              const std::string& name) {
+  for (const auto* system : builder.GetSystems()) {
+    if (system->get_name() == name) {
+      const TargetSystem* result = dynamic_cast<const TargetSystem*>(system);
+      EXPECT_NE(result, nullptr);
+      return result;
+    }
+  }
+  return nullptr;
+}
+
+std::pair<ColorRenderCamera, DepthRenderCamera> MakeCameras() {
+  const RenderCameraCore core("dummy_renderer", CameraInfo(320, 240, 0.75),
+                              ClippingRange{10, 20}, {});
+  return {ColorRenderCamera(core, true),
+          DepthRenderCamera(core, DepthRange{11.5, 13.5})};
+}
+
+class SimRgbdSensorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    std::tie(plant_, scene_graph_) =
+        AddMultibodyPlantSceneGraph(&builder_, 1e-2);
+    bodyA_ =
+        &plant_->AddRigidBody("bodyA", SpatialInertia<double>::MakeUnitary());
+    bodyB_ =
+        &plant_->AddRigidBody("bodyB", SpatialInertia<double>::MakeUnitary());
+
+    X_AF_ = RigidTransformd(Vector3d(-0.5, 0.5, 0.75));
+    frame_F_ = &plant_->AddFrame(std::make_unique<FixedOffsetFrame<double>>(
+        "test_frame", *bodyA_, X_AF_));
+
+    plant_->Finalize();
+  }
+
+  /* Constructs a default sensor specification. If no frame is given, the sensor
+   is affixed to body A (bodyA_). */
+  SimRgbdSensor MakeSensorSpec(const Frame<double>* frame = nullptr) {
+    const RigidTransformd X_AB(Vector3d(1, 2, 3));
+    const auto [color, depth] = MakeCameras();
+    return SimRgbdSensor("test1", frame ? *frame : bodyA_->body_frame(), 32.0,
+                         X_AB, color, depth);
+  }
+
+  /* Adds an RgbdSensor to builder_. Returns a pointer to the RgbdSensor and
+   the SimRgbdSensor that created it. If no frame is given, the sensor is
+   affixed to body A (bodyA_).
+   @throws std::exception if the RgbdSensor wasn't added. */
+  const std::pair<SimRgbdSensor, const RgbdSensor*> MakeSensorOrThrow(
+      const Frame<double>* frame = nullptr) {
+    SimRgbdSensor sensor = MakeSensorSpec(frame);
+
+    AddSimRgbdSensor(*scene_graph_, *plant_, sensor, &builder_);
+
+    // Get the RgbdSensor from the builder.
+    const auto* rgbd =
+        GetSystem<RgbdSensor>(builder_, "rgbd_sensor_" + sensor.serial());
+    if (rgbd == nullptr) {
+      throw std::logic_error("Failed to instantiate RgbdSensor");
+    }
+    return {sensor, rgbd};
+  }
+
+  /* Test helper for determining whether specifying an image port produces the
+   expected connections. */
+  void AssertPublishedPorts(bool rgb, bool depth) {
+    auto [sensor, rgbd] = MakeSensorOrThrow();
+    const size_t old_system_count = builder_.GetSystems().size();
+    AddSimRgbdSensorLcmPublisher(
+        sensor, rgb ? &rgbd->color_image_output_port() : nullptr,
+        depth ? &rgbd->depth_image_16U_output_port() : nullptr, false,
+        &builder_, &lcm_);
+    EXPECT_LT(old_system_count, builder_.GetSystems().size());
+
+    const auto* images = GetSystem<ImageToLcmImageArrayT>(
+        builder_, "image_to_lcm_" + sensor.serial());
+    ASSERT_NE(images, nullptr);
+    if (rgb) {
+      EXPECT_NO_THROW(images->GetInputPort("rgb"));
+    } else {
+      EXPECT_THROW(images->GetInputPort("rgb"), std::exception);
+    }
+    if (depth) {
+      EXPECT_NO_THROW(images->GetInputPort("depth"));
+    } else {
+      EXPECT_THROW(images->GetInputPort("depth"), std::exception);
+    }
+  }
+
+  DiagramBuilder<double> builder_;
+  MultibodyPlant<double>* plant_{};
+  SceneGraph<double>* scene_graph_{};
+  const RigidBody<double>* bodyA_{};
+  const RigidBody<double>* bodyB_{};
+  const Frame<double>* frame_F_{};
+  RigidTransformd X_AF_;
+  DrakeLcm lcm_;
+};
+
+/* Simply tests that all values passed in are available. We'll create two
+ different instances with arbitrarily different values and confirm that the
+ values are returned. */
+TEST_F(SimRgbdSensorTest, SimRgbdSensorValues) {
+  // The values for the camera core are irrelevant to the test -- to confirm
+  // that camera properties get copied, we'll just look for unique values
+  // at the highest level (i.e., color and depth) and assume that if *those*
+  // values get copied, then all of the values got copied.
+  const RenderCameraCore core("dummy_renderer", CameraInfo(320, 240, 0.75),
+                              ClippingRange{10, 20}, {});
+  {
+    const ColorRenderCamera color(core, true);
+    const DepthRenderCamera depth(core, DepthRange{11.5, 13.5});
+    const RigidTransformd X_PB(Vector3d(1, 2, 3));
+    const Frame<double>& frame = bodyA_->body_frame();
+    SimRgbdSensor sensor("test1", frame, 32.0, X_PB, color, depth);
+    EXPECT_EQ("test1", sensor.serial());
+    EXPECT_EQ(&frame, &sensor.frame());
+    EXPECT_TRUE(drake::CompareMatrices(X_PB.GetAsMatrix34(),
+                                       sensor.X_PB().GetAsMatrix34()));
+    EXPECT_TRUE(sensor.color_properties().show_window());
+    EXPECT_EQ(11.5, sensor.depth_properties().depth_range().min_depth());
+    EXPECT_EQ(32.0, sensor.rate_hz());
+  }
+
+  {
+    const ColorRenderCamera color(core, false);
+    const DepthRenderCamera depth(core, DepthRange{13.5, 15.5});
+    const RigidTransformd X_PB(Vector3d(10, 20, 30));
+    const Frame<double>& frame = bodyB_->body_frame();
+    SimRgbdSensor sensor("test2", frame, 64.0, X_PB, color, depth);
+    EXPECT_EQ("test2", sensor.serial());
+    EXPECT_EQ(&frame, &sensor.frame());
+    EXPECT_TRUE(drake::CompareMatrices(X_PB.GetAsMatrix34(),
+                                       sensor.X_PB().GetAsMatrix34()));
+    EXPECT_FALSE(sensor.color_properties().show_window());
+    EXPECT_EQ(13.5, sensor.depth_properties().depth_range().min_depth());
+    EXPECT_EQ(64.0, sensor.rate_hz());
+  }
+}
+
+/* Confirms that when the frame is a body frame, that the RgbdSensor is affixed
+ to the expected *geometry* frame with the expected pose. */
+TEST_F(SimRgbdSensorTest, AddSensorWithBodyFrameSpecification) {
+  auto [sensor, rgbd] = MakeSensorOrThrow();
+  EXPECT_EQ(rgbd->parent_frame_id(),
+            plant_->GetBodyFrameIdOrThrow(bodyA_->index()));
+
+  auto diagram = builder_.Build();
+  auto context = diagram->CreateDefaultContext();
+  auto& plant_context = plant_->GetMyMutableContextFromRoot(context.get());
+  const RigidTransformd X_WA(Vector3d(-3, -4, -5));
+  plant_->SetFreeBodyPose(&plant_context, *bodyA_, X_WA);
+
+  const auto& rgbd_context = rgbd->GetMyContextFromRoot(*context);
+  const auto& X_WB =
+      rgbd->body_pose_in_world_output_port().Eval<RigidTransformd>(
+          rgbd_context);
+
+  const RigidTransformd& X_AB = sensor.X_PB();
+  EXPECT_TRUE(drake::CompareMatrices(X_WB.GetAsMatrix34(),
+                                     (X_WA * X_AB).GetAsMatrix34()));
+}
+
+/* Confirms that when the frame is a secondary frame P, that the RgbdSensor is
+ affixed to the *geometry* frame associated with the secondary frame's body A
+ and with a pose that accounts for both X_PB and X_AP. */
+TEST_F(SimRgbdSensorTest, AddSensorWithBodyOffsetFrameSpecification) {
+  auto [sensor, rgbd] = MakeSensorOrThrow(frame_F_);
+  EXPECT_EQ(rgbd->parent_frame_id(),
+            plant_->GetBodyFrameIdOrThrow(bodyA_->index()));
+
+  auto diagram = builder_.Build();
+  auto context = diagram->CreateDefaultContext();
+  auto& plant_context = plant_->GetMyMutableContextFromRoot(context.get());
+  const RigidTransformd X_WA(Vector3d(-3, -4, -5));
+  plant_->SetFreeBodyPose(&plant_context, *bodyA_, X_WA);
+
+  const auto& rgbd_context = rgbd->GetMyContextFromRoot(*context);
+  const auto& X_WB =
+      rgbd->body_pose_in_world_output_port().Eval<RigidTransformd>(
+          rgbd_context);
+
+  const RigidTransformd& X_FB = sensor.X_PB();
+  EXPECT_TRUE(drake::CompareMatrices(X_WB.GetAsMatrix34(),
+                                     (X_WA * X_AF_ * X_FB).GetAsMatrix34()));
+}
+
+/* Confirms that the added RgbdSensor has been properly configured:
+
+     - it has been named based on serial,
+     - its query object port is connected, and
+     - the camera properties match the input specification. */
+TEST_F(SimRgbdSensorTest, AddSensorForRgbdSensorConfiguration) {
+  auto [sensor, rgbd] = MakeSensorOrThrow();
+
+  // Test criteria.
+  EXPECT_THAT(rgbd->get_name(), ::testing::HasSubstr(sensor.serial()));
+  EXPECT_TRUE(builder_.IsConnectedOrExported(rgbd->query_object_input_port()));
+  // Relying on glass-box testing, the cameras should simply use copy semantics.
+  // So, we'll test one field (renderer_name) and infer that the whole thing
+  // got copied.
+  EXPECT_EQ(rgbd->color_render_camera().core().renderer_name(),
+            sensor.color_properties().core().renderer_name());
+  EXPECT_EQ(rgbd->depth_render_camera().core().renderer_name(),
+            sensor.depth_properties().core().renderer_name());
+}
+
+/* Confirms that if no ports have been provided in the invocation, that the
+ builder remains unchanged. In fact, we don't even have to have an RgbdSensor
+ instantiated. */
+TEST_F(SimRgbdSensorTest, AddPublisherNoPortIsNoOp) {
+  const size_t old_system_count = builder_.GetSystems().size();
+  SimRgbdSensor sensor = MakeSensorSpec();
+  AddSimRgbdSensorLcmPublisher(sensor, nullptr, nullptr, false, &builder_,
+                                &lcm_);
+  EXPECT_EQ(old_system_count, builder_.GetSystems().size());
+}
+
+/* Confirms that if only the rgb port is provided, only the rgb port is
+ connected. */
+TEST_F(SimRgbdSensorTest, AddPublisherRgbOnly) {
+  AssertPublishedPorts(true /* rgb */, false /* depth */);
+}
+
+/* Confirms that if only the depth port is provided, only the depth port is
+ connected. */
+TEST_F(SimRgbdSensorTest, AddPublisherDepthOnly) {
+  AssertPublishedPorts(false /* rgb */, true /* depth */);
+}
+
+/* Confirms that if only the depth port is provided, only the depth port is
+ connected. */
+TEST_F(SimRgbdSensorTest, AddPublisherRgbAndDepth) {
+  AssertPublishedPorts(true /* rgb */, true /* depth */);
+}
+
+/* Confirms that publisher is configured properly (channel name and period). We
+ don't test that `do_compress` is passed because the ImageToLcmImageArrayT class
+ provides no introspection. */
+TEST_F(SimRgbdSensorTest, AddPublisherTestProperties) {
+  const auto [sensor, rgbd] = MakeSensorOrThrow();
+  const size_t old_system_count = builder_.GetSystems().size();
+  AddSimRgbdSensorLcmPublisher(sensor, &rgbd->color_image_output_port(),
+                               &rgbd->depth_image_16U_output_port(), false,
+                               &builder_, &lcm_);
+  EXPECT_LT(old_system_count, builder_.GetSystems().size());
+
+  const auto* publisher = GetSystem<LcmPublisherSystem>(
+      builder_, fmt::format("LcmPublisherSystem(DRAKE_RGBD_CAMERA_IMAGES_{})",
+                            sensor.serial()));
+  ASSERT_NE(publisher, nullptr);
+  EXPECT_DOUBLE_EQ(publisher->get_publish_period(), 1.0 / sensor.rate_hz());
+  EXPECT_THAT(publisher->get_channel_name(),
+              ::testing::HasSubstr(sensor.serial()));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This introduces the `SimRgbdSensor` type and associated functions. For now, they are strictly internal, to be exercised by the `ApplyCameraConfig` (coming in a subsequent PR). In the future, it may come out of `internal::` namespace.

Relates #17112

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17797)
<!-- Reviewable:end -->
