### PR TITLE
[multibody/parsing] Add support for default positions in model directives

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -372,6 +372,7 @@ drake_cc_googletest(
     name = "process_model_directives_test",
     data = [
         ":process_model_directives_test_models",
+        "//multibody/benchmarks/acrobot:models",
     ],
     deps = [
         ":process_model_directives",

--- a/multibody/parsing/model_directives.h
+++ b/multibody/parsing/model_directives.h
@@ -8,6 +8,7 @@
 ///
 /// See `multibody/parsing/README_model_directives.md` for more info.
 
+#include <map>
 #include <optional>
 #include <string>
 #include <vector>
@@ -61,6 +62,22 @@ struct AddModel {
       drake::log()->error("add_model: `name` must be non-empty");
       return false;
     }
+    if (default_free_body_pose) {
+      for (const auto& [body_name, pose] : *default_free_body_pose) {
+        if (pose.base_frame) {
+          drake::log()->error(
+              "add_model: `default_free_body_pose` must not specify a "
+              "`base_frame`; the pose is always in the world frame.");
+          return false;
+        }
+        if (!pose.IsDeterministic()) {
+          drake::log()->error(
+              "add_model: `default_free_body_pose` must specify a "
+              "deterministic transform, not a distribution.");
+          return false;
+        }
+      }
+    }
     return true;
   }
 
@@ -68,12 +85,19 @@ struct AddModel {
   void Serialize(Archive* a) {
     a->Visit(DRAKE_NVP(file));
     a->Visit(DRAKE_NVP(name));
+    a->Visit(DRAKE_NVP(default_joint_positions));
+    a->Visit(DRAKE_NVP(default_free_body_pose));
   }
 
   /// The `package://` URI of the file to add.
   std::string file;
   /// The model instance name.
   std::string name;
+  /// Map of joint_name => default position vector.
+  std::optional<std::map<std::string, Eigen::VectorXd>> default_joint_positions;
+  /// Map of body_name => default free body pose.
+  std::optional<std::map<std::string, drake::schema::Transform>>
+      default_free_body_pose;
 };
 
 /// Directive to add an empty, named model instance to a scene.

--- a/multibody/parsing/process_model_directives.cc
+++ b/multibody/parsing/process_model_directives.cc
@@ -108,6 +108,21 @@ void ProcessModelDirectivesImpl(
           ResolveModelDirectiveUri(model.file, parser->package_map());
       drake::multibody::ModelInstanceIndex child_model_instance_id =
           composite->AddModelFromFile(file, name);
+      if (directive.add_model->default_joint_positions) {
+        for (const auto& [joint_name, positions] :
+             *directive.add_model->default_joint_positions) {
+          plant->GetMutableJointByName(joint_name, child_model_instance_id)
+              .set_default_positions(positions);
+        }
+      }
+      if (directive.add_model->default_free_body_pose) {
+        for (const auto& [body_name, pose] :
+             *directive.add_model->default_free_body_pose) {
+          plant->SetDefaultFreeBodyPose(
+              plant->GetBodyByName(body_name, child_model_instance_id),
+              pose.GetDeterministicValue());
+        }
+      }
       info.model_instance = child_model_instance_id;
       info.model_name = name;
       info.model_path = file;

--- a/multibody/parsing/test/model_directives_test.cc
+++ b/multibody/parsing/test/model_directives_test.cc
@@ -18,6 +18,16 @@ directives:
 - add_model:
     name: new_model
     file: base.sdf
+    default_joint_positions:
+      joint1: [0.3]
+      joint2: [0.4, 0.5]
+    default_free_body_pose:
+      body1:
+        translation: [1, 2, 3]
+        rotation: !Rpy { deg: [5, 6, 7] }
+      body2:
+        translation: [-1, -2, -3]
+        rotation: !Rpy { deg: [-5, -6, -7] }
 - add_weld:
     parent: parent_frame
     child: child_frame

--- a/multibody/parsing/test/process_model_directives_test/default_positions.dmd.yaml
+++ b/multibody/parsing/test/process_model_directives_test/default_positions.dmd.yaml
@@ -1,0 +1,19 @@
+# This file tests the default_joint_positions and default_free_body_pose
+# directives.
+
+directives:
+
+- add_model:
+    name: simple_model
+    file: package://process_model_directives_test/simple_model.sdf
+    default_free_body_pose:
+      base:
+        translation: [1, 2, 3]
+        rotation: !Rpy { deg: [5, 6, 7] }
+
+- add_model:
+    name: joint_parsing_test
+    file: package://drake/multibody/benchmarks/acrobot/acrobot.urdf
+    default_joint_positions:
+      ShoulderJoint: [ 0.1 ]
+      ElbowJoint: [ 0.2 ]


### PR DESCRIPTION
Adds the ability to set default joint positions and default free body
poses in the add_model directive. I would have liked to be able to
enable a tag like default_positions which takes a vector, but the
position vector is not defined until after Finalize(), so it
unavailable at parsing time.

Related to #13065, and this slack discussion:
https://drakedevelopers.slack.com/archives/C2WBPQDB7/p1601749507024400

+@rpoyner-tri for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17802)
<!-- Reviewable:end -->
