### PR TITLE
[render_vtk] Restore most macOS m1 tests

### DIFF
--- a/geometry/render_vtk/BUILD.bazel
+++ b/geometry/render_vtk/BUILD.bazel
@@ -117,9 +117,10 @@ drake_cc_library(
 drake_cc_googletest(
     name = "internal_render_engine_vtk_test",
     args = select({
-        # Disable all test cases on Mac M1 CI.
-        # TODO(17566) Re-enable this when possible.
-        "@platforms//cpu:arm64": ["--gtest_filter=-*"],
+        # Disable test cases that break on Mac M1 CI.
+        "@platforms//cpu:arm64": [
+            "--gtest_filter=-*HorizonTest:*TerrainTest:*SphereTest",
+        ],
         "//conditions:default": [],
     }),
     data = [


### PR DESCRIPTION
All tests pass locally, however in CI the Horizon, Terrain, Sphere,
and TransparentSphere tests fail for undiagnosed reasons.

Closes https://github.com/RobotLocomotion/drake/issues/17566.

Note: we are going to run a handful of CI runs to try and stress test a bit given the erratic nature of the failures experienced by different audiences.

- [X] https://drake-jenkins.csail.mit.edu/view/Mac%20M1/job/mac-m1-monterey-provisioned-clang-bazel-experimental-release/34/consoleFull (status check associated with this PR)
- [X] https://drake-jenkins.csail.mit.edu/view/Mac%20M1/job/mac-m1-monterey-provisioned-clang-bazel-experimental-release/35/consoleFull
- [X] https://drake-jenkins.csail.mit.edu/view/Mac%20M1/job/mac-m1-monterey-provisioned-clang-bazel-experimental-release/36/consoleFull
- [X] https://drake-jenkins.csail.mit.edu/view/Mac%20M1/job/mac-m1-monterey-provisioned-clang-bazel-experimental-release/37/consoleFull 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17804)
<!-- Reviewable:end -->
