### PR TITLE
[config] Modify ApplyVisualizationConfig -- plant unnecessary for no contact

### DIFF
--- a/visualization/test/visualization_config_functions_test.cc
+++ b/visualization/test/visualization_config_functions_test.cc
@@ -178,12 +178,21 @@ GTEST_TEST(VisualizationConfigFunctionsTest, AddDefault) {
   simulator.AdvanceTo(0.25);
 }
 
-// A missing plant causes an exception.
+// A missing (or misnamed) plant causes an exception, but only if we're
+// attempting to visualize contact.
 GTEST_TEST(VisualizationConfigFunctionsTest, NoPlant) {
   DiagramBuilder<double> builder;
+  auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.0);
+  plant.Finalize();
+  plant.set_name("wrong_name");
+
   DRAKE_EXPECT_THROWS_MESSAGE(
       AddDefaultVisualization(&builder),
       ".*does not contain.*plant.*");
+
+  VisualizationConfig config;
+  config.publish_contacts = false;
+  EXPECT_NO_THROW(ApplyVisualizationConfig(config, &builder));
 }
 
 // A missing scene_graph causes an exception.

--- a/visualization/visualization_config_functions.h
+++ b/visualization/visualization_config_functions.h
@@ -51,9 +51,10 @@ drake::lcm::DrakeLcm object is constructed and used internally.
 @param[in] plant (Optional) The MultibodyPlant to visualize.
 In the common case where a MultibodyPlant has already been added to `builder`
 using either AddMultibodyPlant() or AddMultibodyPlantSceneGraph(), the default
-value (nullptr) here is suitable and generally should be preferred.
-When provided, it must be a System that's been added to the the given `builder`.
-When not provided, visualizes the system named "plant" in the given `builder`.
+value (nullptr) here is suitable and generally should be preferred. When
+`config.publish_contacts` is `true, then a non-null value for `plant` must be a
+System that's been added to the the given `builder`. When not provided,
+visualizes the system named "plant" in the given `builder`.
 
 @param[in] scene_graph (Optional) The SceneGraph to visualize.
 In the common case where a SceneGraph has already been added to `builder` using
@@ -72,8 +73,8 @@ the appropriate interface from `lcm_buses`.
 @pre Either the `config.lcm_bus` is set to "default", or else `lcm_buses` is
 non-null and contains a bus named `config.lcm_bus`, or else `lcm` is non-null.
 
-@pre Either the given `builder` contains a MultibodyPlant system named "plant"
-or else the provided `plant` is non-null.
+@pre Either `config.publish_contacts` is `false, the given `builder` contains a
+MultibodyPlant system named "plant" or else the provided `plant` is non-null.
 
 @pre Either the given `builder` contains a SceneGraph system named "scene_graph"
 or else the provided `scene_graph` is non-null.


### PR DESCRIPTION
This changes the semantics to align with the philosophy, "Not having what I don't need is not an error."

`ApplyVisualizationConfig` would unilaterally look for a `plant` in the `builder` (whether it needed it or not). The only time it needs the `plant` if there is a request to visualize contact. So, now, the search for a `plant` (and its concomitant potential error) is put behind a test on whether contact is requested at all.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17814)
<!-- Reviewable:end -->
