### PR TITLE
[hardware_sim] Move header to internal namespace

### DIFF
--- a/examples/hardware_sim/hardware_sim.cc
+++ b/examples/hardware_sim/hardware_sim.cc
@@ -38,6 +38,7 @@ DEFINE_string(scenario_text, "{}",
 namespace drake {
 namespace {
 
+using internal::Scenario;
 using lcm::DrakeLcmInterface;
 using multibody::ModelInstanceIndex;
 using multibody::parsing::ModelInstanceInfo;
@@ -110,7 +111,7 @@ void Simulation::Simulate() {
 }
 
 int main() {
-  const Scenario scenario = LoadScenario(
+  const Scenario scenario = internal::LoadScenario(
       FLAGS_scenario_file, FLAGS_scenario_name, FLAGS_scenario_text);
   Simulation sim(scenario);
   sim.Setup();

--- a/examples/hardware_sim/scenario.cc
+++ b/examples/hardware_sim/scenario.cc
@@ -5,6 +5,7 @@
 #include "drake/common/yaml/yaml_io.h"
 
 namespace drake {
+namespace internal {
 
 // N.B. This is in a cc file to reduce compilation time for the serialization-
 // related template classes and functions.
@@ -38,4 +39,5 @@ std::string SaveScenario(
   return drake::yaml::SaveYamlString(scenario, {scenario_name}, defaults);
 }
 
+}  // namespace internal
 }  // namespace drake

--- a/examples/hardware_sim/scenario.h
+++ b/examples/hardware_sim/scenario.h
@@ -17,6 +17,7 @@
 #include "drake/visualization/visualization_config.h"
 
 namespace drake {
+namespace internal {
 
 /* Defines the YAML format for a (possibly stochastic) scenario to be
 simulated. */
@@ -86,4 +87,5 @@ std::string SaveScenario(
     const std::string& scenario_name,
     bool verbose = false);
 
+}  // namespace internal
 }  // namespace drake


### PR DESCRIPTION
We don't want this to appear in our Doxygen anywhere.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17815)
<!-- Reviewable:end -->
