### PR TITLE
GetInfeasibleConstraints: Only return infeasible constraint once

### DIFF
--- a/solvers/mathematical_program_result.cc
+++ b/solvers/mathematical_program_result.cc
@@ -176,7 +176,7 @@ MathematicalProgramResult::GetInfeasibleConstraints(
           val(i) > constraint->upper_bound()(i) + *tolerance ||
           val(i) < constraint->lower_bound()(i) - *tolerance) {
         infeasible_bindings.push_back(binding);
-        continue;
+        break;
       }
     }
   }


### PR DESCRIPTION
Came across this while debugging QP w/ collision avoidance in Anzu.
In this formulation, collision avoidance is formulated as a set of collision avoidance queries. When using 
`GetInfeasibleConstraints()`, I was surprised to see the collision constraint printed out many times.

I think this was the intended behavior?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17818)
<!-- Reviewable:end -->
