### PR TITLE
[parsing] Remove unnecessary optional

### DIFF
--- a/multibody/parsing/model_directives.h
+++ b/multibody/parsing/model_directives.h
@@ -80,20 +80,18 @@ struct AddModel {
       drake::log()->error("add_model: `name` must be non-empty");
       return false;
     }
-    if (default_free_body_pose) {
-      for (const auto& [body_name, pose] : *default_free_body_pose) {
-        if (pose.base_frame) {
-          drake::log()->error(
-              "add_model: `default_free_body_pose` must not specify a "
-              "`base_frame`; the pose is always in the world frame.");
-          return false;
-        }
-        if (!pose.IsDeterministic()) {
-          drake::log()->error(
-              "add_model: `default_free_body_pose` must specify a "
-              "deterministic transform, not a distribution.");
-          return false;
-        }
+    for (const auto& [body_name, pose] : default_free_body_pose) {
+      if (pose.base_frame) {
+        drake::log()->error(
+            "add_model: `default_free_body_pose` must not specify a "
+            "`base_frame`; the pose is always in the world frame.");
+        return false;
+      }
+      if (!pose.IsDeterministic()) {
+        drake::log()->error(
+            "add_model: `default_free_body_pose` must specify a "
+            "deterministic transform, not a distribution.");
+        return false;
       }
     }
     return true;
@@ -112,10 +110,9 @@ struct AddModel {
   /// The model instance name.
   std::string name;
   /// Map of joint_name => default position vector.
-  std::optional<std::map<std::string, Eigen::VectorXd>> default_joint_positions;
+  std::map<std::string, Eigen::VectorXd> default_joint_positions;
   /// Map of body_name => default free body pose.
-  std::optional<std::map<std::string, drake::schema::Transform>>
-      default_free_body_pose;
+  std::map<std::string, drake::schema::Transform> default_free_body_pose;
 };
 
 /// Directive to add an empty, named model instance to a scene.

--- a/multibody/parsing/process_model_directives.cc
+++ b/multibody/parsing/process_model_directives.cc
@@ -110,20 +110,16 @@ void ProcessModelDirectivesImpl(
           ResolveModelDirectiveUri(model.file, parser->package_map());
       drake::multibody::ModelInstanceIndex child_model_instance_id =
           composite->AddModelFromFile(file, name);
-      if (directive.add_model->default_joint_positions) {
-        for (const auto& [joint_name, positions] :
-             *directive.add_model->default_joint_positions) {
-          plant->GetMutableJointByName(joint_name, child_model_instance_id)
-              .set_default_positions(positions);
-        }
+      for (const auto& [joint_name, positions] :
+           directive.add_model->default_joint_positions) {
+        plant->GetMutableJointByName(joint_name, child_model_instance_id)
+            .set_default_positions(positions);
       }
-      if (directive.add_model->default_free_body_pose) {
-        for (const auto& [body_name, pose] :
-             *directive.add_model->default_free_body_pose) {
-          plant->SetDefaultFreeBodyPose(
-              plant->GetBodyByName(body_name, child_model_instance_id),
-              pose.GetDeterministicValue());
-        }
+      for (const auto& [body_name, pose] :
+           directive.add_model->default_free_body_pose) {
+        plant->SetDefaultFreeBodyPose(
+            plant->GetBodyByName(body_name, child_model_instance_id),
+            pose.GetDeterministicValue());
       }
       info.model_instance = child_model_instance_id;
       info.model_name = name;

--- a/multibody/parsing/test/model_directives_test.cc
+++ b/multibody/parsing/test/model_directives_test.cc
@@ -56,7 +56,11 @@ directives:
     members: [new_model::link, right::robot::link]
     ignored_collision_filter_groups: [group1, right::robot::group]
 )""";
-  const auto directives = LoadYamlString<ModelDirectives>(contents);
+  // Here we copy-paste the code from LoadModelDirectivesFromString so that we
+  // can check IsValid with a test assertion, instead of a DRAKE_DEMAND.
+  const ModelDirectives defaults;
+  const auto directives = LoadYamlString<ModelDirectives>(
+      contents, std::nullopt /* child_name */, defaults);
   EXPECT_TRUE(directives.IsValid());
 }
 


### PR DESCRIPTION
Amends #17802.

The `LoadModelDirectives()` retains the default values of `struct AddModel` in case the YAML doesn't mention it.  It's OK for the YAML data to be missing fields -- they will remain at their default values.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17822)
<!-- Reviewable:end -->
