### PR TITLE
[planning] Add initialization event to DiffIK Integrator

### DIFF
--- a/manipulation/planner/BUILD.bazel
+++ b/manipulation/planner/BUILD.bazel
@@ -107,6 +107,7 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//manipulation/kuka_iiwa:iiwa_constants",
         "//multibody/parsing",
+        "//systems/analysis:simulator",
     ],
 )
 

--- a/manipulation/planner/differential_inverse_kinematics_integrator.h
+++ b/manipulation/planner/differential_inverse_kinematics_integrator.h
@@ -22,14 +22,21 @@ joints; we hope to resolve this and are tracking it in #9773.
 
 Note: It is highly recommended that the user calls `SetPosition()` once to
 initialize the position commands to match the initial positions of the robot.
+Alternatively, one can connect the optional `robot_state` input port -- which
+is only used at Initialization, and simply sets the positions to the positions
+on this input port (the port accepts the state vector with positions and
+velocities for easy of use with MultibodyPlant, but only the positions are
+used).
 
 @system
 name: DifferentialInverseKinematicsIntegrator
 input_ports:
 - X_WE_desired
+- robot_state (optional)
 output_ports:
 - joint_positions
 @endsystem
+
 
 @ingroup manipulation_systems */
 class DifferentialInverseKinematicsIntegrator
@@ -90,14 +97,19 @@ class DifferentialInverseKinematicsIntegrator
                           systems::Context<double>* robot_context) const;
 
   // Calls DoDifferentialInverseKinematics and performs one integration step.
-  void DoCalcDiscreteVariableUpdates(
+  systems::EventStatus Integrate(
       const systems::Context<double>& context,
-      const std::vector<const systems::DiscreteUpdateEvent<double>*>& events,
-      systems::DiscreteValues<double>* discrete_state) const override;
+      systems::DiscreteValues<double>* discrete_state) const;
 
   // Outputs the current position value.
   void CopyPositionsOut(const systems::Context<double>& context,
                         systems::BasicVector<double>* output) const;
+
+  // If the state input port is connected, then this method sets the integrator
+  // state to match the positions on the input port.
+  systems::EventStatus Initialize(
+      const systems::Context<double>& context,
+      systems::DiscreteValues<double>* values) const;
 
   const multibody::MultibodyPlant<double>& robot_;
   const multibody::Frame<double>& frame_E_;

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -870,7 +870,7 @@ class LeafSystem : public System<T> {
 
   @see DeclareInitializationPublishEvent()
   @see DeclareInitializationDiscreteUpdateEvent()
-  @see DeclareInitializationUnrestrictedUpdate()
+  @see DeclareInitializationUnrestrictedUpdateEvent()
 
   See @ref declare_initialization_events "Declare initialization events" for
   more information.


### PR DESCRIPTION
The integrator in Diff IK needs to be set to the initial state of the
robot in order to avoid a large delta at time zero. Previously, users
had to call SetPositions() manually; and this has to happen after
Diagram is built (when a context is created, etc). Because this occurs
in a different part of the code from where the Diff IK system is
created and the parameters configured, I often saw people copying part
of the code and forgetting the initialization, leading to strange
errors.

This PR offers a cleaner workflow where an additional port is
connected at the time that DiffIK is constructed and added to the
builder; then an Initialization event takes care of setting the
initial integrator state.

+@sherm1 for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17824)
<!-- Reviewable:end -->
