### PR TITLE
[pydrake/common] Bind default constructor for TypeSafeIndex

### DIFF
--- a/bindings/pydrake/common/test/type_safe_index_pybind_test.cc
+++ b/bindings/pydrake/common/test/type_safe_index_pybind_test.cc
@@ -41,6 +41,8 @@ GTEST_TEST(TypeSafeIndexTest, CheckCasting) {
     return x;
   });
   SynchronizeGlobalsForPython3(m);
+  CheckValue("Index(10).is_valid()", true);
+  CheckValue("Index().is_valid()", false);
   CheckValue("pass_thru_int(10)", 10);
   CheckValue("pass_thru_int(Index(10))", 10);
   // TypeSafeIndex<> is not implicitly constructible from an int.

--- a/bindings/pydrake/common/type_safe_index_pybind.h
+++ b/bindings/pydrake/common/type_safe_index_pybind.h
@@ -18,7 +18,9 @@ auto BindTypeSafeIndex(
     py::module m, const std::string& name, const std::string& class_doc = "") {
   py::class_<Class> cls(m, name.c_str(), class_doc.c_str());
   cls  // BR
-      .def(py::init<int>(), pydrake_doc.drake.TypeSafeIndex.ctor.doc_0args)
+      .def(py::init<>(), pydrake_doc.drake.TypeSafeIndex.ctor.doc_0args)
+      .def(
+          py::init<int>(), pydrake_doc.drake.TypeSafeIndex.ctor.doc_1args_index)
       .def("__int__", &Class::operator int)
       .def("__index__", &Class::operator int)
       .def(py::self == py::self)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17825)
<!-- Reviewable:end -->
