### PR TITLE
[geometry] Improve ComputeSignedDistancePairClosestPoints feedback

### DIFF
--- a/bindings/pydrake/test/geometry_scene_graph_test.py
+++ b/bindings/pydrake/test/geometry_scene_graph_test.py
@@ -473,9 +473,8 @@ class TestGeometrySceneGraph(unittest.TestCase):
         # populating the SceneGraph, we look for the exception thrown in
         # response to invalid ids as evidence of correct binding.
         with self.assertRaisesRegex(
-            RuntimeError,
-            r"The geometry given by id \d+ does not reference a geometry"
-                + " that can be used in a signed distance query"):
+                RuntimeError,
+                "Referenced geometry .+ has not been registered."):
             query_object.ComputeSignedDistancePairClosestPoints(
                 geometry_id_A=mut.GeometryId.get_new_id(),
                 geometry_id_B=mut.GeometryId.get_new_id())

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -1027,6 +1027,33 @@ int GeometryState<T>::RemoveFromRenderer(const std::string& renderer_name,
   return RemoveFromRendererUnchecked(renderer_name, geometry_id) ? 1 : 0;
 }
 
+namespace {
+
+void ThrowForNonProximity(const internal::InternalGeometry& g,
+                          const char* purpose) {
+  if (!g.has_proximity_role()) {
+    const char* role_description =
+        g.has_illustration_role()
+            ? "the illustration role"
+            : (g.has_perception_role() ? "the perception role" : "no role");
+    throw std::logic_error(
+        fmt::format("The geometry {} cannot be used in {}; it does not have a "
+                    "proximity role. It has {}.",
+                    g.id(), purpose, role_description));
+  }
+}
+
+}  // namespace
+
+template <typename T>
+SignedDistancePair<T> GeometryState<T>::ComputeSignedDistancePairClosestPoints(
+      GeometryId id_A, GeometryId id_B) const {
+    ThrowForNonProximity(GetValueOrThrow(id_A, geometries_), __func__);
+    ThrowForNonProximity(GetValueOrThrow(id_B, geometries_), __func__);
+    return geometry_engine_->ComputeSignedDistancePairClosestPoints(
+        id_A, id_B, kinematics_data_.X_WGs);
+  }
+
 template <typename T>
 void GeometryState<T>::AddRenderer(
     std::string name, std::unique_ptr<render::RenderEngine> renderer) {

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -549,10 +549,7 @@ class GeometryState {
   /** Implementation of
    QueryObject::ComputeSignedDistancePairClosestPoints().  */
   SignedDistancePair<T> ComputeSignedDistancePairClosestPoints(
-      GeometryId id_A, GeometryId id_B) const {
-    return geometry_engine_->ComputeSignedDistancePairClosestPoints(
-        id_A, id_B, kinematics_data_.X_WGs);
-  }
+      GeometryId id_A, GeometryId id_B) const;
 
   /** Implementation of QueryObject::ComputeSignedDistanceToPoint().  */
   std::vector<SignedDistanceToPoint<T>> ComputeSignedDistanceToPoint(

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -604,8 +604,10 @@ class QueryObject {
    Refer to @ref query_object_compute_pairwise_distance_table
    "the table for ComputeSignedDistancePairwiseClosestPoints()" for details.
 
-   @throws std::exception if either geometry id is invalid, the pair (A, B) has
-                          been marked as filtered, or according to the scalar
+   @throws std::exception if either geometry id is invalid (e.g., doesn't refer
+                          to an existing geometry, lacking proximity role,
+                          etc.), the pair (A, B) has been marked as filtered, or
+                          otherwise unsupported as indicated by the the scalar
                           support table.
    @warning For Mesh shapes, their convex hulls are used in this query. It is
             *not* computationally efficient or particularly accurate.  */


### PR DESCRIPTION
`ComputeSignedDistancePairClosestPoints()` is the only `QueryObject` API that takes `GeometryId`s. This puts the burden on the user to pass the *right* `GeometryId`s (e.g., properly registered with proximity roles). Prior to this, if they failed, they'd simply get the message:

> The geometry given by id 63 does not reference a geometry that can be used in a signed distance query

This now provides additional insight, indicating *why* it can't be used and giving insight into why they have the wrong one (e.g., it has an illustration role instead). This should help guide the user to change how they select their geometry ids.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17826)
<!-- Reviewable:end -->
