### PR TITLE
[geometry] Support compliant non-convex mesh in hydroelastic_internal.

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -333,6 +333,8 @@ drake_cc_library(
         ":make_cylinder_mesh",
         ":make_ellipsoid_field",
         ":make_ellipsoid_mesh",
+        ":make_mesh_field",
+        ":make_mesh_from_vtk",
         ":make_sphere_field",
         ":make_sphere_mesh",
         ":obj_to_surface_mesh",
@@ -1035,6 +1037,7 @@ drake_cc_googletest(
     name = "hydroelastic_internal_test",
     data = [
         "//geometry:test_obj_files",
+        "//geometry:test_vtk_files",
     ],
     deps = [
         ":hydroelastic_internal",

--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -14,6 +14,8 @@
 #include "drake/geometry/proximity/make_cylinder_mesh.h"
 #include "drake/geometry/proximity/make_ellipsoid_field.h"
 #include "drake/geometry/proximity/make_ellipsoid_mesh.h"
+#include "drake/geometry/proximity/make_mesh_field.h"
+#include "drake/geometry/proximity/make_mesh_from_vtk.h"
 #include "drake/geometry/proximity/make_sphere_field.h"
 #include "drake/geometry/proximity/make_sphere_mesh.h"
 #include "drake/geometry/proximity/obj_to_surface_mesh.h"
@@ -384,6 +386,23 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
 
   return SoftGeometry(SoftMesh(move(mesh), move(pressure)));
 }
+
+std::optional<SoftGeometry> MakeSoftRepresentation(
+    const Mesh& mesh_specification, const ProximityProperties& props) {
+  PositiveDouble validator("Mesh", "soft");
+
+  auto mesh = make_unique<VolumeMesh<double>>(
+      MakeVolumeMeshFromVtk<double>(mesh_specification));
+
+  const double hydroelastic_modulus =
+      validator.Extract(props, kHydroGroup, kElastic);
+
+  auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
+      MakeVolumeMeshPressureField(mesh.get(), hydroelastic_modulus));
+
+  return SoftGeometry(SoftMesh(move(mesh), move(pressure)));
+}
+
 
 }  // namespace hydroelastic
 }  // namespace internal

--- a/geometry/proximity/hydroelastic_internal.h
+++ b/geometry/proximity/hydroelastic_internal.h
@@ -483,6 +483,12 @@ have sufficient information). Requires the
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Convex& convex_spec, const ProximityProperties& props);
 
+/* Creates a compliant (generally) non-convex mesh (assuming the proximity
+ properties have sufficient information). Requires the ('hydroelastic',
+ 'hydroelastic_modulus') properties. */
+std::optional<SoftGeometry> MakeSoftRepresentation(
+    const Mesh& mesh_specification, const ProximityProperties& props);
+
 //@}
 
 }  // namespace hydroelastic


### PR DESCRIPTION
Support #17780.

Predecessors: #17828 and #17820.
Successor: #17837.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17836)
<!-- Reviewable:end -->
