### PR TITLE
[geometry] Compliant hydroelastic non-convex mesh in ProximityEngine 

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -68,6 +68,7 @@ drake_cc_library(
         "//geometry/proximity:collision_filter",
         "//geometry/proximity:deformable_contact_internal",
         "//geometry/proximity:hydroelastic_internal",
+        "//geometry/proximity:make_mesh_from_vtk",
         "//geometry/query_results",
         "//math",
         ":geometry_ids",
@@ -667,7 +668,10 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "proximity_engine_test",
-    data = [":test_obj_files"],
+    data = [
+        ":test_obj_files",
+        ":test_vtk_files",
+    ],
     deps = [
         ":proximity_engine",
         ":shape_specification",

--- a/geometry/proximity/test/hydroelastic_internal_test.cc
+++ b/geometry/proximity/test/hydroelastic_internal_test.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/proximity/hydroelastic_internal.h"
 
 #include <cmath>
+#include <filesystem>
 #include <functional>
 #include <limits>
 
@@ -8,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
+#include "drake/common/temp_directory.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/proximity/make_sphere_field.h"
@@ -602,8 +604,7 @@ TEST_F(HydroelasticRigidGeometryTest, Ellipsoid) {
 // origin along each axis) to confirm that the correct mesh got loaded. We also
 // confirm that the scale factor is included in the rigid representation.
 template <typename MeshType>
-void TestRigidMeshType() {
-  std::string file = FindResourceOrThrow("drake/geometry/test/quad_cube.obj");
+void TestRigidMeshTypeFromObj(const std::string& file) {
   // Empty props since its contents do not matter.
   ProximityProperties props;
 
@@ -637,15 +638,48 @@ void TestRigidMeshType() {
 // Confirm support for a rigid Mesh. Tests that a hydroelastic representation
 // is made.
 TEST_F(HydroelasticRigidGeometryTest, Mesh) {
-  SCOPED_TRACE("Rigid Mesh");
-  TestRigidMeshType<Mesh>();
+  const std::string file_lower_case =
+      FindResourceOrThrow("drake/geometry/test/quad_cube.obj");
+  {
+    SCOPED_TRACE("Rigid Mesh, lower-case obj extension");
+    TestRigidMeshTypeFromObj<Mesh>(file_lower_case);
+  }
+  {
+    SCOPED_TRACE("Rigid Mesh, upper-case OBJ extension");
+    const std::string file_upper_case = temp_directory() + "/quad_cube.OBJ";
+    std::filesystem::copy(file_lower_case, file_upper_case);
+    TestRigidMeshTypeFromObj<Mesh>(file_upper_case);
+  }
 }
 
 // Confirm support for a rigid Convex. Tests that a hydroelastic representation
 // is made.
 TEST_F(HydroelasticRigidGeometryTest, Convex) {
   SCOPED_TRACE("Rigid Convex");
-  TestRigidMeshType<Convex>();
+  std::string file = FindResourceOrThrow("drake/geometry/test/quad_cube.obj");
+  TestRigidMeshTypeFromObj<Convex>(file);
+}
+
+TEST_F(HydroelasticRigidGeometryTest, MeshFromVtk) {
+  const std::string file_lower_case =
+      FindResourceOrThrow("drake/geometry/test/non_convex_mesh.vtk");
+  const std::string file_upper_case = temp_directory() + "/non_convex_mesh.VTK";
+  std::filesystem::copy(file_lower_case, file_upper_case);
+  // Empty props since its contents do not matter.
+  const ProximityProperties props;
+  for (const std::string& file_name : {file_lower_case, file_upper_case}) {
+    SCOPED_TRACE(file_name);
+    std::optional<RigidGeometry> geometry =
+        MakeRigidRepresentation(Mesh(file_name), props);
+    ASSERT_NE(geometry, std::nullopt);
+
+    // We only check that the vtk file was read by verifying the number of
+    // vertices and triangles, which depend on the specific content of
+    // the vtk file.
+    const TriangleSurfaceMesh<double>& surface_mesh = geometry->mesh();
+    EXPECT_EQ(surface_mesh.num_vertices(), 5);
+    EXPECT_EQ(surface_mesh.num_triangles(), 6);
+  }
 }
 
 // Template magic to instantiate a particular kind of shape at compile time.

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -141,7 +141,8 @@ GTEST_TEST(ProximityEngineTests, AddDynamicGeometry) {
 // it's supported or not (note: this test doesn't depend on the choice of
 // rigid/compliant -- for each shape, we pick an arbitrary compliance type,
 // preferring one that is supported over one that is not. Otherwise, the
-// compliance choice is immaterial.)
+// compliance choice is immaterial.) One exception is that the rigid Mesh and
+// the compliant Mesh use two different kinds of files, so we test both of them.
 GTEST_TEST(ProximityEngineTests, ProcessHydroelasticProperties) {
   ProximityEngine<double> engine;
   // All of the geometries will have a scale comparable to edge_length, so that
@@ -217,6 +218,17 @@ GTEST_TEST(ProximityEngineTests, ProcessHydroelasticProperties) {
     engine.AddDynamicGeometry(mesh, {}, mesh_id, rigid_properties);
     EXPECT_EQ(ProximityEngineTester::hydroelastic_type(mesh_id, engine),
               HydroelasticType::kRigid);
+  }
+
+  // Case: compliant mesh.
+  {
+    Mesh mesh{
+        drake::FindResourceOrThrow("drake/geometry/test/non_convex_mesh.vtk"),
+        1.0 /* scale */};
+    const GeometryId mesh_id = GeometryId::get_new_id();
+    engine.AddDynamicGeometry(mesh, {}, mesh_id, soft_properties);
+    EXPECT_EQ(ProximityEngineTester::hydroelastic_type(mesh_id, engine),
+              HydroelasticType::kSoft);
   }
 
   // Case: rigid convex.
@@ -452,6 +464,17 @@ GTEST_TEST(ProximityEngineTests, MeshSupportAsConvex) {
       EXPECT_FALSE(engine.HasCollisions());
     }
   }
+}
+
+// Tests that passing VTK file in Mesh for Point contact will throw.
+GTEST_TEST(ProximityEngineTests, VtkForPointContactThrow) {
+  ProximityEngine<double> engine;
+  const Mesh vtk_mesh{
+      drake::FindResourceOrThrow("drake/geometry/test/non_convex_mesh.vtk")};
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      engine.AddAnchoredGeometry(vtk_mesh, RigidTransformd::Identity(),
+                                 GeometryId::get_new_id()),
+      "ProximityEngine: expect an Obj file for non-hydroelastics but get.*");
 }
 
 // Tests simple addition of anchored geometry.


### PR DESCRIPTION
- Also prevent a subtle problem that compliant hydroelastic geometries
  get into registration process of deformable geometries.

Support #17780 

Predecessor: #17836

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17837)
<!-- Reviewable:end -->
