### PR TITLE
[manipulation/models] Fix colors on kinova jaco models

### DIFF
--- a/manipulation/models/jaco_description/LICENSE.TXT
+++ b/manipulation/models/jaco_description/LICENSE.TXT
@@ -10,5 +10,7 @@ https://github.com/Kinovarobotics/kinova-ros/blob/kinova-ros-beta/kinova_descrip
 
 Since obtaining the model files from the above source, they were modified for
 use by Drake. For example, the original DAE and STL mesh files were converted
-to OBJ files, and various collision models were modified. Our changes are
-covered by Drake's license terms (see LICENSE.TXT in Drake's root folder).
+to OBJ files, and various collision models were modified. Color values in the
+URDF were taken directly from the diffuse values in the .dae files contributed
+upstream in https://github.com/Kinovarobotics/kinova-ros/pull/222. Our changes
+are covered by Drake's license terms (see LICENSE.TXT in Drake's root folder).

--- a/manipulation/models/jaco_description/urdf/j2n6s300.urdf
+++ b/manipulation/models/jaco_description/urdf/j2n6s300.urdf
@@ -53,8 +53,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/base.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <collision>
@@ -82,14 +82,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/shoulder.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 -0.06"/>
@@ -125,14 +128,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <origin rpy="1.57079632679 0 0" xyz="0 -0.21 0"/>
@@ -168,14 +174,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/forearm.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <origin rpy="1.57079632679 0 0" xyz="0 0.12 0"/>
@@ -211,14 +220,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 -0.01 -0.02"/>
@@ -254,14 +266,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <geometry>
@@ -296,14 +311,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/hand_3finger.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <geometry>
@@ -347,8 +365,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -384,8 +402,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -411,8 +429,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -448,8 +466,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -475,8 +493,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -512,8 +530,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>

--- a/manipulation/models/jaco_description/urdf/j2s7s300.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300.urdf
@@ -27,8 +27,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/base.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <collision>
@@ -55,14 +55,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/shoulder.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <geometry>
@@ -101,14 +104,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm_half_1.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <geometry>
@@ -143,14 +149,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm_half_2.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <geometry>
@@ -185,14 +194,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/forearm.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <geometry>
@@ -227,14 +239,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist_spherical_1.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <geometry>
@@ -269,14 +284,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist_spherical_2.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <geometry>
@@ -311,14 +329,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/hand_3finger.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <geometry>
@@ -372,8 +393,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -409,8 +430,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -436,8 +457,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -473,8 +494,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -500,8 +521,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -537,8 +558,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>

--- a/manipulation/models/jaco_description/urdf/j2s7s300_arm.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300_arm.urdf
@@ -27,8 +27,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/base.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <collision>
@@ -55,14 +55,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/shoulder.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <geometry>
@@ -101,14 +104,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm_half_1.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <geometry>
@@ -143,14 +149,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm_half_2.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <geometry>
@@ -185,14 +194,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/forearm.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <geometry>
@@ -227,14 +239,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist_spherical_1.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <geometry>
@@ -269,14 +284,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist_spherical_2.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <geometry>

--- a/manipulation/models/jaco_description/urdf/j2s7s300_arm_sphere_collision.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300_arm_sphere_collision.urdf
@@ -27,8 +27,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/base.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <collision>
@@ -80,14 +80,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/shoulder.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0.0 -0.025 -0.14"/>
@@ -163,14 +166,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm_half_1.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0.025 -0.00 -0.025"/>
@@ -260,14 +266,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm_half_2.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0.0 0.028 -0.232"/>
@@ -363,14 +372,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/forearm.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0.0 -0.0"/>
@@ -472,14 +484,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist_spherical_1.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0.0 -0.00"/>
@@ -527,14 +542,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist_spherical_2.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0.0 -0.02"/>

--- a/manipulation/models/jaco_description/urdf/j2s7s300_hand.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300_hand.urdf
@@ -10,14 +10,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/hand_3finger.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <geometry>
@@ -54,8 +57,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -91,8 +94,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -118,8 +121,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -155,8 +158,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -182,8 +185,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -219,8 +222,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>

--- a/manipulation/models/jaco_description/urdf/j2s7s300_hand_sphere_collision.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300_hand_sphere_collision.urdf
@@ -10,14 +10,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/hand_3finger.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 -0.03"/>
@@ -97,8 +100,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -153,8 +156,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -205,8 +208,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -261,8 +264,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -313,8 +316,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -369,8 +372,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>

--- a/manipulation/models/jaco_description/urdf/j2s7s300_sphere_collision.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300_sphere_collision.urdf
@@ -27,8 +27,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/base.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <collision>
@@ -80,14 +80,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/shoulder.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0.0 -0.025 -0.14"/>
@@ -163,14 +166,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm_half_1.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0.025 -0.00 -0.025"/>
@@ -260,14 +266,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm_half_2.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0.0 0.028 -0.232"/>
@@ -363,14 +372,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/forearm.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0.0 -0.0"/>
@@ -472,14 +484,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist_spherical_1.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0.0 -0.00"/>
@@ -527,14 +542,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist_spherical_2.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0.0 -0.02"/>
@@ -582,14 +600,17 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/hand_3finger.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.1788232 0.1788232 0.1788232 1"/>
       </material>
     </visual>
     <visual>
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
+      <material>
+        <color rgba="0.627451 0.627451 0.627451 1"/>
+      </material>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 -0.03"/>
@@ -686,8 +707,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -742,8 +763,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -794,8 +815,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -850,8 +871,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -902,8 +923,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>
@@ -958,8 +979,8 @@
       <geometry>
         <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
-      <material name="carbon_fiber">
-        <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+      <material>
+        <color rgba="0.5960783 0.5960783 0.5960783 1"/>
       </material>
     </visual>
     <collision>

--- a/manipulation/util/BUILD.bazel
+++ b/manipulation/util/BUILD.bazel
@@ -128,6 +128,7 @@ drake_cc_library(
 drake_py_binary(
     name = "show_model",
     srcs = ["show_model.py"],
+    data = ["//manipulation/models/jaco_description:models"],
     deps = [
         ":module_py",
         "//bindings/pydrake",


### PR DESCRIPTION
These were fixed upstream in
https://github.com/Kinovarobotics/kinova-ros/pull/222. But that PR
only fixed the 6DOF model, and made the fix by completely replacing
the mesh files.  Here I've just taken the (diffuse) color from the
mesh file and applied it in the URDF.

Before:
![image](https://user-images.githubusercontent.com/6442292/188342838-fae7b034-0e5c-4e02-8d60-eadc61f29b2c.png)

After:
![image](https://user-images.githubusercontent.com/6442292/188342788-da1f49b1-1b50-4246-93cf-90b826f9791c.png)

+@sammy-tri for feature review, please (as the original contributor of these models).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17838)
<!-- Reviewable:end -->
