### PR TITLE
[meshcat] Add optional on_publish_callback to JointSliders::Run

### DIFF
--- a/bindings/pydrake/multibody/meshcat_py.cc
+++ b/bindings/pydrake/multibody/meshcat_py.cc
@@ -186,8 +186,16 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::keep_alive<1, 3>(),  // BR
             cls_doc.ctor.doc)
         .def("Delete", &Class::Delete, cls_doc.Delete.doc)
-        .def("Run", &Class::Run, py::arg("diagram"),
-            py::arg("timeout") = py::none(), cls_doc.Run.doc)
+        .def("Run",
+            WrapCallbacks(
+                [](JointSliders<T>* self, const systems::Diagram<T>& diagram,
+                    std::optional<double> timeout,
+                    const std::function<void(const systems::Context<T>&
+                            diagram_context)>& on_publish_callback) {
+                  self->Run(diagram, timeout, on_publish_callback);
+                }),
+            py::arg("diagram"), py::arg("timeout") = py::none(),
+            py::arg("on_publish_callback") = nullptr, cls_doc.Run.doc)
         .def("SetPositions", &Class::SetPositions, py::arg("q"),
             cls_doc.SetPositions.doc);
   }

--- a/bindings/pydrake/multibody/test/meshcat_test.py
+++ b/bindings/pydrake/multibody/test/meshcat_test.py
@@ -126,7 +126,16 @@ class TestMeshcat(unittest.TestCase):
         # The Run function doesn't crash.
         builder.AddSystem(dut)
         diagram = builder.Build()
-        dut.Run(diagram=diagram, timeout=1.0)
+
+        count = 0
+
+        def callback(context):
+            diagram.ValidateContext(context)
+            nonlocal count
+            count += 1
+
+        dut.Run(diagram=diagram, timeout=1.0, on_publish_callback=callback)
+        self.assertGreaterEqual(count, 1)
 
         # The SetPositions function doesn't crash (Acrobot has two positions).
         dut.SetPositions(q=[1, 2])

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -1163,6 +1163,7 @@ void DoScalarIndependentDefinitions(py::module m) {
             py::arg("index"), cls_doc.numeric_parameter_ticket.doc)
         .def("get_cache_entry", &Class::get_cache_entry, py::arg("index"),
             py_rvp::reference_internal, cls_doc.get_cache_entry.doc)
+        .def("ValidateContext", overload_cast_explicit<void, const ContextBase&>(&Class::ValidateContext), py::arg("context"), cls_doc.ValidateContext.doc)
         // N.B. Since this method has template overloads, we must specify the
         // types `overload_cast_explicit`; we must also specify Class.
         // We do not use `static_cast<>` to avoid accidental type mixing.

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -137,6 +137,7 @@ class TestGeneral(unittest.TestCase):
         system = Adder(3, 10)
         context = system.AllocateContext()
         self.assertIsInstance(context, ContextBase)
+        system.ValidateContext(context=context)
         self.assertEqual(context.num_input_ports(), 3)
         self.assertEqual(context.num_output_ports(), 1)
         context.DisableCaching()

--- a/multibody/meshcat/joint_sliders.h
+++ b/multibody/meshcat/joint_sliders.h
@@ -102,14 +102,20 @@ class JointSliders final : public systems::LeafSystem<T> {
   will return promptly, without waiting for the timeout. When no timeout is
   given, this function will block indefinitely.
 
+  @param on_publish_callback (Optional) This function will be called immediately
+  after each Publish, with the Diagram Context passed as an argument. It can be
+  used, for instance, to implement additional visualizations.
+
   @pre `diagram` must be a top-level (i.e., "root") diagram.
   @pre `diagram` must contain this JointSliders system.
-  @pre `diagarm` must contain the `plant` that was passed into this
+  @pre `diagram` must contain the `plant` that was passed into this
   JointSliders system's constructor.
   */
   void Run(
       const systems::Diagram<T>& diagram,
-      std::optional<double> timeout = std::nullopt) const;
+      std::optional<double> timeout = std::nullopt,
+      const std::function<void(const systems::Context<T>& diagram_context)>&
+          on_publish_callback = nullptr) const;
 
   /** Sets all robot positions (corresponding to joint positions and potentially
   positions not associated with any joint) to the values in `q`.  The meshcat

--- a/multibody/meshcat/test/joint_sliders_test.cc
+++ b/multibody/meshcat/test/joint_sliders_test.cc
@@ -296,6 +296,16 @@ TEST_F(JointSlidersTest, Run) {
   const std::string updated = meshcat_->GetPackedTransform(geometry_path);
   ASSERT_FALSE(updated.empty());
   EXPECT_NE(updated, original);
+
+  int count = 0;
+  auto callback = [&diagram, &count](const systems::Context<double>& context) {
+    EXPECT_NO_THROW(diagram->ValidateContext(&context));
+    count++;
+  };
+
+  // Run for a while, with a callback.
+  dut->Run(*diagram, timeout, callback);
+  EXPECT_GE(count, 1);
 }
 
 // Tests that SetPositions diagnoses num_positions mismatches.

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -606,7 +606,8 @@ class SystemBase : public internal::SystemMessageInterface {
   /** Checks whether the given context was created for this system.
   @note This method is sufficiently fast for performance sensitive code.
   @throws std::exception if the System Ids don't match.
-  @throws std::exception if `context` is null. */
+  @throws std::exception if `context` is null.
+  @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.} */
   void ValidateContext(const ContextBase* context) const {
     DRAKE_THROW_UNLESS(context != nullptr);
     ValidateContext(*context);


### PR DESCRIPTION
This is generally useful, and is needed immediately if I'm to replace
the original `MeshcatJointSliders` class in my manipulation repo with
this Drake version.

Also adds a missing binding to `SystemBase::ValidateContext`.

+@jwnimmer-tri for feature review, please.
fyi @trowell-tri

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17840)
<!-- Reviewable:end -->
