### PR TITLE
[geometry/optimization] Enable adding costs to vertices in GraphOfConvexSets

### DIFF
--- a/bindings/pydrake/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry_py_optimization.cc
@@ -506,6 +506,30 @@ void DefineGeometryOptimization(py::module m) {
             vertex_doc.x.doc)
         .def("set", &GraphOfConvexSets::Vertex::set, py_rvp::reference_internal,
             vertex_doc.set.doc)
+        .def("AddCost",
+            py::overload_cast<const symbolic::Expression&>(
+                &GraphOfConvexSets::Vertex::AddCost),
+            py::arg("e"), vertex_doc.AddCost.doc_expression)
+        .def("AddCost",
+            py::overload_cast<const solvers::Binding<solvers::Cost>&>(
+                &GraphOfConvexSets::Vertex::AddCost),
+            py::arg("binding"), vertex_doc.AddCost.doc_binding)
+        .def("AddConstraint",
+            overload_cast_explicit<solvers::Binding<solvers::Constraint>,
+                const symbolic::Formula&>(
+                &GraphOfConvexSets::Vertex::AddConstraint),
+            py::arg("f"), vertex_doc.AddConstraint.doc_formula)
+        .def("AddConstraint",
+            overload_cast_explicit<solvers::Binding<solvers::Constraint>,
+                const solvers::Binding<solvers::Constraint>&>(
+                &GraphOfConvexSets::Vertex::AddConstraint),
+            py::arg("binding"), vertex_doc.AddCost.doc_binding)
+        .def("GetCosts", &GraphOfConvexSets::Vertex::GetCosts,
+            vertex_doc.GetCosts.doc)
+        .def("GetConstraints", &GraphOfConvexSets::Vertex::GetConstraints,
+            vertex_doc.GetConstraints.doc)
+        .def("GetSolutionCost", &GraphOfConvexSets::Vertex::GetSolutionCost,
+            py::arg("result"), vertex_doc.GetSolutionCost.doc)
         .def("GetSolution", &GraphOfConvexSets::Vertex::GetSolution,
             py::arg("result"), vertex_doc.GetSolution.doc);
 

--- a/bindings/pydrake/test/geometry_optimization_test.py
+++ b/bindings/pydrake/test/geometry_optimization_test.py
@@ -463,13 +463,27 @@ class TestGeometryOptimization(unittest.TestCase):
             result=result, show_slacks=True, precision=2, scientific=False))
 
         # Vertex
+        self.assertAlmostEqual(
+            source.GetSolutionCost(result=result), 0.0, 1e-6)
+        np.testing.assert_array_almost_equal(
+            source.GetSolution(result), [0.1], 1e-6)
         self.assertIsInstance(source.id(), mut.GraphOfConvexSets.VertexId)
         self.assertEqual(source.ambient_dimension(), 1)
         self.assertEqual(source.name(), "source")
         self.assertIsInstance(source.x()[0], Variable)
         self.assertIsInstance(source.set(), mut.Point)
-        np.testing.assert_array_almost_equal(
-            source.GetSolution(result), [0.1], 1e-6)
+        var, binding = source.AddCost(e=1.0+source.x()[0])
+        self.assertIsInstance(var, Variable)
+        self.assertIsInstance(binding, Binding[Cost])
+        var, binding = source.AddCost(binding=binding)
+        self.assertIsInstance(var, Variable)
+        self.assertIsInstance(binding, Binding[Cost])
+        self.assertEqual(len(source.GetCosts()), 2)
+        binding = source.AddConstraint(f=(source.x()[0] <= 1.0))
+        self.assertIsInstance(binding, Binding[Constraint])
+        binding = source.AddConstraint(binding=binding)
+        self.assertIsInstance(binding, Binding[Constraint])
+        self.assertEqual(len(source.GetConstraints()), 2)
 
         # Edge
         self.assertAlmostEqual(edge0.GetSolutionCost(result=result), 0.0, 1e-6)

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -456,6 +456,21 @@ class GraphOfConvexSets {
   std::set<EdgeId> PreprocessShortestPath(VertexId source_id,
                                           VertexId target_id) const;
 
+  // Adds a perspective constraint to the mathematical program to upper bound
+  // the cost below a slack variable. `vars` consists of the slack variable ℓ, ϕ
+  // and ϕ times the variables in the original cost.
+  void AddPerspectiveCost(solvers::MathematicalProgram* prog,
+                          const solvers::Binding<solvers::Cost>& binding,
+                          const solvers::VectorXDecisionVariable& vars) const;
+
+  // Adds a perspective version of the constraint to the mathematical program
+  // where `vars` consists of ϕ and ϕ times the variables in the original
+  // constraint.
+  void AddPerspectiveConstraint(
+      solvers::MathematicalProgram* prog,
+      const solvers::Binding<solvers::Constraint>& binding,
+      const solvers::VectorXDecisionVariable& vars) const;
+
   std::map<VertexId, std::unique_ptr<Vertex>> vertices_{};
   std::map<EdgeId, std::unique_ptr<Edge>> edges_{};
 };

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -228,30 +228,43 @@ TEST_F(TwoPoints, AddCost) {
   auto [ell0, b0] = e_->AddCost((e_->xv().head<2>() - e_->xu()).squaredNorm());
   auto cost = std::make_shared<LinearCost>(Vector2d::Zero(), 0.1);
   auto [ell1, b1] = e_->AddCost(Binding(cost, e_->xu()));
+  auto [v_ell0, v_b0] = v_->AddCost((v_->x() + Vector3d::Ones()).squaredNorm());
+  auto [v_ell1, v_b1] = v_->AddCost(Binding(cost, v_->x().head<2>()));
 
   // Confirm that they are down-castable.
   auto quadratic = dynamic_cast<QuadraticCost*>(b0.evaluator().get());
   EXPECT_TRUE(quadratic != nullptr);
   auto linear = dynamic_cast<LinearCost*>(b1.evaluator().get());
   EXPECT_TRUE(linear != nullptr);
+  quadratic = dynamic_cast<QuadraticCost*>(v_b0.evaluator().get());
+  EXPECT_TRUE(quadratic != nullptr);
+  linear = dynamic_cast<LinearCost*>(v_b1.evaluator().get());
+  EXPECT_TRUE(linear != nullptr);
 
   // Confirm that they are all accessible.
   const auto& edge_costs = e_->GetCosts();
   EXPECT_EQ(edge_costs[0], b0);
   EXPECT_EQ(edge_costs[1], b1);
+  const auto& vertex_costs = v_->GetCosts();
+  EXPECT_EQ(vertex_costs[0], v_b0);
+  EXPECT_EQ(vertex_costs[1], v_b1);
 
   MathematicalProgramResult result;
   std::unordered_map<symbolic::Variable::Id, int> map;
   map.emplace(ell0.get_id(), 0);
   map.emplace(ell1.get_id(), 1);
-  const Vector2d ell{1.2, 3.4};
+  map.emplace(v_ell0.get_id(), 2);
+  map.emplace(v_ell1.get_id(), 3);
+  const Vector4d ell{1.2, 3.4, 5.6, 7.8};
   result.set_decision_variable_index(map);
   result.set_x_val(ell);
 
-  EXPECT_NEAR(e_->GetSolutionCost(result), ell.sum(), 1e-16);
+  EXPECT_NEAR(e_->GetSolutionCost(result), ell.head<2>().sum(), 1e-16);
+  EXPECT_NEAR(v_->GetSolutionCost(result), ell.tail<2>().sum(), 1e-16);
 
   symbolic::Variable other_var("x");
   DRAKE_EXPECT_THROWS_MESSAGE(e_->AddCost(other_var), ".*IsSubsetOf.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(v_->AddCost(other_var), ".*IsSubsetOf.*");
 }
 
 // Confirms that I can add constraints (both ways).
@@ -262,6 +275,8 @@ TEST_F(TwoPoints, AddConstraint) {
   auto constraint = std::make_shared<LinearConstraint>(
       Matrix2d::Identity(), Vector2d::Zero(), Vector2d{1.2, 3.4});
   auto b1 = e_->AddConstraint(Binding(constraint, e_->xu()));
+  auto u_b0 = u_->AddConstraint(u_->x() == pu_.x());
+  auto u_b1 = u_->AddConstraint(Binding(constraint, u_->x()));
 
   // Confirm that they are down-castable.
   auto linear_equality =
@@ -269,14 +284,24 @@ TEST_F(TwoPoints, AddConstraint) {
   EXPECT_TRUE(linear_equality != nullptr);
   auto linear = dynamic_cast<LinearConstraint*>(b1.evaluator().get());
   EXPECT_TRUE(linear != nullptr);
+  linear_equality =
+      dynamic_cast<LinearEqualityConstraint*>(u_b0.evaluator().get());
+  EXPECT_TRUE(linear_equality != nullptr);
+  linear = dynamic_cast<LinearConstraint*>(u_b1.evaluator().get());
+  EXPECT_TRUE(linear != nullptr);
 
   // Confirm that they are all accessible.
   const auto& edge_constraints = e_->GetConstraints();
   EXPECT_EQ(edge_constraints[0], b0);
   EXPECT_EQ(edge_constraints[1], b1);
+  const auto& vertex_constraints = u_->GetConstraints();
+  EXPECT_EQ(vertex_constraints[0], u_b0);
+  EXPECT_EQ(vertex_constraints[1], u_b1);
 
   symbolic::Variable other_var("x");
   DRAKE_EXPECT_THROWS_MESSAGE(e_->AddConstraint(other_var == 1),
+                              ".*IsSubsetOf.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(u_->AddConstraint(other_var == 1),
                               ".*IsSubsetOf.*");
 }
 
@@ -326,10 +351,14 @@ class ThreePoints : public ::testing::Test {
 TEST_F(ThreePoints, LinearCost1) {
   e_on_->AddCost(1.0);
   e_off_->AddCost(1.0);
+  source_->AddCost(1.0);
   auto result = g_.SolveShortestPath(source_->id(), target_->id(), options);
   ASSERT_TRUE(result.is_success());
   EXPECT_NEAR(e_on_->GetSolutionCost(result), 1.0, 1e-6);
   EXPECT_NEAR(e_off_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(source_->GetSolutionCost(result), 1.0, 1e-6);
+  EXPECT_NEAR(target_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(sink_->GetSolutionCost(result), 0.0, 1e-6);
 
   EXPECT_TRUE(
       CompareMatrices(e_on_->GetSolutionPhiXu(result), p_source_.x(), 1e-6));
@@ -345,12 +374,18 @@ TEST_F(ThreePoints, LinearCost1) {
   ASSERT_TRUE(result2.is_success());
   EXPECT_NEAR(e_on_->GetSolutionCost(result2), 1.0, 1e-6);
   EXPECT_NEAR(e_off_->GetSolutionCost(result2), 0.0, 1e-6);
+  EXPECT_NEAR(source_->GetSolutionCost(result2), 1.0, 1e-6);
+  EXPECT_NEAR(target_->GetSolutionCost(result2), 0.0, 1e-6);
+  EXPECT_NEAR(sink_->GetSolutionCost(result2), 0.0, 1e-6);
 
   options.solver_options = SolverOptions();
   auto result4 = g_.SolveShortestPath(*source_, *target_, options);
   ASSERT_TRUE(result4.is_success());
   EXPECT_NEAR(e_on_->GetSolutionCost(result4), 1.0, 1e-6);
   EXPECT_NEAR(e_off_->GetSolutionCost(result4), 0.0, 1e-6);
+  EXPECT_NEAR(source_->GetSolutionCost(result4), 1.0, 1e-6);
+  EXPECT_NEAR(target_->GetSolutionCost(result4), 0.0, 1e-6);
+  EXPECT_NEAR(sink_->GetSolutionCost(result4), 0.0, 1e-6);
 
   EXPECT_TRUE(
       CompareMatrices(source_->GetSolution(result4), p_source_.x(), 1e-6));
@@ -365,12 +400,18 @@ TEST_F(ThreePoints, LinearCost1) {
     ASSERT_TRUE(result3.is_success());
     EXPECT_NEAR(e_on_->GetSolutionCost(result3), 1.0, 1e-6);
     EXPECT_NEAR(e_off_->GetSolutionCost(result3), 0.0, 1e-6);
+    EXPECT_NEAR(source_->GetSolutionCost(result3), 1.0, 1e-6);
+    EXPECT_NEAR(target_->GetSolutionCost(result3), 0.0, 1e-6);
+    EXPECT_NEAR(sink_->GetSolutionCost(result3), 0.0, 1e-6);
   }
 }
 
 TEST_F(ThreePoints, ConvexRelaxation) {
   e_on_->AddCost(1.0);
   e_off_->AddCost(1.0);
+  source_->AddCost(1.0);
+  e_on_->AddConstraint(e_on_->xv()[0] <= 0.0);
+  source_->AddConstraint(source_->x()[0] >= 1.0);
   auto result = g_.SolveShortestPath(*source_, *target_, options);
   ASSERT_TRUE(result.is_success());
   EXPECT_NEAR(result.GetSolution(e_on_->phi()), 1.0, 1e-6);
@@ -390,6 +431,12 @@ TEST_F(ThreePoints, ConvexRelaxation) {
               1e-6);
   EXPECT_NEAR(e_off_->GetSolutionCost(result), e_off_->GetSolutionCost(result2),
               1e-6);
+  EXPECT_NEAR(source_->GetSolutionCost(result),
+              source_->GetSolutionCost(result2), 1e-6);
+  EXPECT_NEAR(target_->GetSolutionCost(result),
+              target_->GetSolutionCost(result2), 1e-6);
+  EXPECT_NEAR(sink_->GetSolutionCost(result), sink_->GetSolutionCost(result2),
+              1e-6);
 }
 
 TEST_F(ThreePoints, LinearCost2) {
@@ -398,10 +445,14 @@ TEST_F(ThreePoints, LinearCost2) {
   auto cost = std::make_shared<solvers::LinearCost>(a, b);
   e_on_->AddCost(solvers::Binding(cost, {}));
   e_off_->AddCost(solvers::Binding(cost, {}));
+  source_->AddCost(solvers::Binding(cost, {}));
   auto result = g_.SolveShortestPath(*source_, *target_, options);
   ASSERT_TRUE(result.is_success());
   EXPECT_NEAR(e_on_->GetSolutionCost(result), b, 1e-6);
   EXPECT_NEAR(e_off_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(source_->GetSolutionCost(result), b, 1e-6);
+  EXPECT_NEAR(target_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(sink_->GetSolutionCost(result), 0.0, 1e-6);
 }
 
 TEST_F(ThreePoints, LinearCost3) {
@@ -409,10 +460,14 @@ TEST_F(ThreePoints, LinearCost3) {
   const double b = 1.23;
   e_on_->AddCost(a.dot(e_on_->xu()) + b);
   e_off_->AddCost(a.dot(e_off_->xu()) + b);
+  source_->AddCost(a.dot(source_->x()) + b);
   auto result = g_.SolveShortestPath(*source_, *target_, options);
   ASSERT_TRUE(result.is_success());
   EXPECT_NEAR(e_on_->GetSolutionCost(result), a.dot(p_source_.x()) + b, 1e-6);
   EXPECT_NEAR(e_off_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(source_->GetSolutionCost(result), a.dot(p_source_.x()) + b, 1e-6);
+  EXPECT_NEAR(target_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(sink_->GetSolutionCost(result), 0.0, 1e-6);
 }
 
 TEST_F(ThreePoints, LinearCost4) {
@@ -422,9 +477,18 @@ TEST_F(ThreePoints, LinearCost4) {
                               "Constant costs must be non-negative.*");
 }
 
+TEST_F(ThreePoints, LinearCost5) {
+  const double b = -1.23;
+  source_->AddCost(b);
+  DRAKE_EXPECT_THROWS_MESSAGE(g_.SolveShortestPath(*source_, *target_, options),
+                              "Constant costs must be non-negative.*");
+}
+
 TEST_F(ThreePoints, QuadraticCost) {
   e_on_->AddCost((e_on_->xu() - e_on_->xv()).squaredNorm());
   e_off_->AddCost((e_off_->xu() - e_off_->xv()).squaredNorm());
+  source_->AddCost(
+      static_cast<const VectorX<Expression>>(source_->x()).squaredNorm());
 
   auto result = g_.SolveShortestPath(*source_, *target_, options);
   if (result.get_solver_id() == solvers::IpoptSolver::id()) {
@@ -434,6 +498,10 @@ TEST_F(ThreePoints, QuadraticCost) {
   EXPECT_NEAR(e_on_->GetSolutionCost(result),
               (p_source_.x() - p_target_.x()).squaredNorm(), 1e-6);
   EXPECT_NEAR(e_off_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(source_->GetSolutionCost(result), p_source_.x().squaredNorm(),
+              1e-6);
+  EXPECT_NEAR(target_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(sink_->GetSolutionCost(result), 0.0, 1e-6);
 }
 
 TEST_F(ThreePoints, QuadraticCost2) {
@@ -446,6 +514,9 @@ TEST_F(ThreePoints, QuadraticCost2) {
                         .squaredNorm();
   e_on_->AddCost(cost);
   e_off_->AddCost(cost.Substitute(subs_on_off_));
+  Expression vertex_cost =
+      (A * (source_->x() - Vector2d{.54, -.23})).squaredNorm();
+  source_->AddCost(vertex_cost);
   auto result = g_.SolveShortestPath(*source_, *target_, options);
   if (result.get_solver_id() == solvers::IpoptSolver::id()) {
     return;  // See IpoptTest for details.
@@ -456,6 +527,10 @@ TEST_F(ThreePoints, QuadraticCost2) {
   env.insert(e_on_->xv(), p_target_.x());
   EXPECT_NEAR(e_on_->GetSolutionCost(result), cost.Evaluate(env), 1e-5);
   EXPECT_NEAR(e_off_->GetSolutionCost(result), 0.0, 4e-6);
+  EXPECT_NEAR(source_->GetSolutionCost(result), vertex_cost.Evaluate(env),
+              1e-6);
+  EXPECT_NEAR(target_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(sink_->GetSolutionCost(result), 0.0, 1e-6);
 }
 
 TEST_F(ThreePoints, QuadraticCost3) {
@@ -468,6 +543,9 @@ TEST_F(ThreePoints, QuadraticCost3) {
                     4.2;
   e_on_->AddCost(cost);
   e_off_->AddCost(cost.Substitute(subs_on_off_));
+  Expression vertex_cost =
+      (A * (source_->x() - Vector2d{.54, -.23})).squaredNorm() + 4.2;
+  source_->AddCost(vertex_cost);
   auto result = g_.SolveShortestPath(*source_, *target_, options);
   ASSERT_TRUE(result.is_success());
   Environment env{};
@@ -475,15 +553,24 @@ TEST_F(ThreePoints, QuadraticCost3) {
   env.insert(e_on_->xv(), p_target_.x());
   EXPECT_NEAR(e_on_->GetSolutionCost(result), cost.Evaluate(env), 1e-5);
   EXPECT_NEAR(e_off_->GetSolutionCost(result), 0.0, 4e-6);
+  EXPECT_NEAR(source_->GetSolutionCost(result), vertex_cost.Evaluate(env),
+              1e-6);
+  EXPECT_NEAR(target_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(sink_->GetSolutionCost(result), 0.0, 1e-6);
 }
 
 TEST_F(ThreePoints, QuadraticCost4) {
-  const Matrix4d R = Vector4d(3.2, 4.3, 6.4, 7.1).asDiagonal();
+  const Matrix4d R = Vector4d(1.2, 2.3, 3.4, 4.5).asDiagonal();
   const Vector4d d = Vector4d(0.1, 0.2, 0.3, 0.4);
   auto cost = std::make_shared<solvers::QuadraticCost>(
       2.0 * R.transpose() * R, 2.0 * R.transpose() * d, d.dot(d));
   e_on_->AddCost(solvers::Binding(cost, {e_on_->xu(), e_on_->xv()}));
   e_off_->AddCost(solvers::Binding(cost, {e_off_->xu(), e_off_->xv()}));
+  const Matrix2d R_v = R.topLeftCorner<2, 2>();
+  const Vector2d d_v = d.head<2>();
+  auto vertex_cost = std::make_shared<solvers::QuadraticCost>(
+      2.0 * R_v.transpose() * R_v, 2.0 * R_v.transpose() * d_v, d_v.dot(d_v));
+  source_->AddCost(solvers::Binding(vertex_cost, source_->x()));
   auto result = g_.SolveShortestPath(*source_, *target_, options);
   if (result.get_solver_id() == solvers::IpoptSolver::id()) {
     return;  // See IpoptTest for details.
@@ -493,12 +580,25 @@ TEST_F(ThreePoints, QuadraticCost4) {
   x << p_source_.x(), p_target_.x();
   EXPECT_NEAR(e_on_->GetSolutionCost(result), (R * x + d).squaredNorm(), 1e-5);
   EXPECT_NEAR(e_off_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(source_->GetSolutionCost(result),
+              (R_v * p_source_.x() + d_v).squaredNorm(), 1e-5);
+  EXPECT_NEAR(target_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(sink_->GetSolutionCost(result), 0.0, 1e-6);
 }
 
 // Costs must be strictly positive.
 TEST_F(ThreePoints, QuadraticCost5) {
   e_on_->AddCost((e_on_->xu() - e_on_->xv()).squaredNorm() - 2.0);
   e_off_->AddCost((e_off_->xu() - e_off_->xv()).squaredNorm() - 2.0);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(g_.SolveShortestPath(*source_, *target_, options),
+                              ".* must be strictly non-negative.*");
+}
+
+// Costs must be strictly positive.
+TEST_F(ThreePoints, QuadraticCost6) {
+  source_->AddCost(
+      static_cast<const VectorX<Expression>>(source_->x()).squaredNorm() - 2.0);
 
   DRAKE_EXPECT_THROWS_MESSAGE(g_.SolveShortestPath(*source_, *target_, options),
                               ".* must be strictly non-negative.*");
@@ -512,6 +612,10 @@ TEST_F(ThreePoints, L1NormCost) {
   auto cost = std::make_shared<solvers::L1NormCost>(A, Vector2d::Zero());
   e_on_->AddCost(solvers::Binding(cost, {e_on_->xu(), e_on_->xv()}));
   e_off_->AddCost(solvers::Binding(cost, {e_off_->xu(), e_off_->xv()}));
+  RowVector2d A_v(1, -1);
+  auto vertex_cost =
+      std::make_shared<solvers::L1NormCost>(A_v, Vector1d::Zero());
+  source_->AddCost(solvers::Binding(vertex_cost, source_->x()));
   auto result = g_.SolveShortestPath(*source_, *target_, options);
   if (result.get_solver_id() == solvers::IpoptSolver::id()) {
     return;  // See IpoptTest for details.
@@ -520,6 +624,9 @@ TEST_F(ThreePoints, L1NormCost) {
   EXPECT_NEAR(e_on_->GetSolutionCost(result),
               (p_source_.x() - p_target_.x()).cwiseAbs().sum(), 1e-6);
   EXPECT_NEAR(e_off_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(source_->GetSolutionCost(result), abs(A_v * p_source_.x()), 1e-6);
+  EXPECT_NEAR(target_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(sink_->GetSolutionCost(result), 0.0, 1e-6);
 }
 
 TEST_F(ThreePoints, L1NormCost2) {
@@ -533,6 +640,10 @@ TEST_F(ThreePoints, L1NormCost2) {
   auto cost = std::make_shared<solvers::L1NormCost>(A, b);
   e_on_->AddCost(solvers::Binding(cost, {e_on_->xu(), e_on_->xv()}));
   e_off_->AddCost(solvers::Binding(cost, {e_off_->xu(), e_off_->xv()}));
+  RowVector2d A_v(4.3, -0.4);
+  auto vertex_cost =
+      std::make_shared<solvers::L1NormCost>(A_v, Vector1d::Zero());
+  source_->AddCost(solvers::Binding(vertex_cost, source_->x()));
   auto result = g_.SolveShortestPath(*source_, *target_, options);
   if (result.get_solver_id() == solvers::IpoptSolver::id()) {
     return;  // See IpoptTest for details.
@@ -545,6 +656,9 @@ TEST_F(ThreePoints, L1NormCost2) {
           .sum(),
       1e-6);
   EXPECT_NEAR(e_off_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(source_->GetSolutionCost(result), abs(A_v * p_source_.x()), 1e-6);
+  EXPECT_NEAR(target_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(sink_->GetSolutionCost(result), 0.0, 1e-6);
 }
 
 TEST_F(ThreePoints, L2NormCost) {
@@ -555,6 +669,10 @@ TEST_F(ThreePoints, L2NormCost) {
   auto cost = std::make_shared<solvers::L2NormCost>(A, Vector2d::Zero());
   e_on_->AddCost(solvers::Binding(cost, {e_on_->xu(), e_on_->xv()}));
   e_off_->AddCost(solvers::Binding(cost, {e_off_->xu(), e_off_->xv()}));
+  RowVector2d A_v(1, -1);
+  auto vertex_cost =
+      std::make_shared<solvers::L2NormCost>(A_v, Vector1d::Zero());
+  source_->AddCost(solvers::Binding(vertex_cost, source_->x()));
   auto result = g_.SolveShortestPath(*source_, *target_, options);
   if (result.get_solver_id() == solvers::IpoptSolver::id()) {
     return;  // See IpoptTest for details.
@@ -563,6 +681,10 @@ TEST_F(ThreePoints, L2NormCost) {
   EXPECT_NEAR(e_on_->GetSolutionCost(result),
               (p_source_.x() - p_target_.x()).norm(), 1e-6);
   EXPECT_NEAR(e_off_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(source_->GetSolutionCost(result), (A_v * p_source_.x()).norm(),
+              1e-6);
+  EXPECT_NEAR(target_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(sink_->GetSolutionCost(result), 0.0, 1e-6);
 }
 
 TEST_F(ThreePoints, L2NormCost2) {
@@ -576,6 +698,10 @@ TEST_F(ThreePoints, L2NormCost2) {
   auto cost = std::make_shared<solvers::L2NormCost>(A, b);
   e_on_->AddCost(solvers::Binding(cost, {e_on_->xu(), e_on_->xv()}));
   e_off_->AddCost(solvers::Binding(cost, {e_off_->xu(), e_off_->xv()}));
+  RowVector2d A_v(4.3, -0.4);
+  auto vertex_cost =
+      std::make_shared<solvers::L2NormCost>(A_v, Vector1d::Zero());
+  source_->AddCost(solvers::Binding(vertex_cost, source_->x()));
   auto result = g_.SolveShortestPath(*source_, *target_, options);
   if (result.get_solver_id() == solvers::IpoptSolver::id()) {
     return;  // See IpoptTest for details.
@@ -587,6 +713,10 @@ TEST_F(ThreePoints, L2NormCost2) {
           .norm(),
       1e-6);
   EXPECT_NEAR(e_off_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(source_->GetSolutionCost(result), (A_v * p_source_.x()).norm(),
+              1e-6);
+  EXPECT_NEAR(target_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(sink_->GetSolutionCost(result), 0.0, 1e-6);
 }
 
 TEST_F(ThreePoints, LInfNormCost) {
@@ -597,6 +727,10 @@ TEST_F(ThreePoints, LInfNormCost) {
   auto cost = std::make_shared<solvers::LInfNormCost>(A, Vector2d::Zero());
   e_on_->AddCost(solvers::Binding(cost, {e_on_->xu(), e_on_->xv()}));
   e_off_->AddCost(solvers::Binding(cost, {e_off_->xu(), e_off_->xv()}));
+  RowVector2d A_v(1, -1);
+  auto vertex_cost =
+      std::make_shared<solvers::LInfNormCost>(A_v, Vector1d::Zero());
+  source_->AddCost(solvers::Binding(vertex_cost, source_->x()));
   auto result = g_.SolveShortestPath(*source_, *target_, options);
   if (result.get_solver_id() == solvers::IpoptSolver::id()) {
     return;  // See IpoptTest for details.
@@ -605,6 +739,9 @@ TEST_F(ThreePoints, LInfNormCost) {
   EXPECT_NEAR(e_on_->GetSolutionCost(result),
               (p_source_.x() - p_target_.x()).cwiseAbs().maxCoeff(), 1e-6);
   EXPECT_NEAR(e_off_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(source_->GetSolutionCost(result), abs(A_v * p_source_.x()), 1e-6);
+  EXPECT_NEAR(target_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(sink_->GetSolutionCost(result), 0.0, 1e-6);
 }
 
 TEST_F(ThreePoints, LInfNormCost2) {
@@ -618,6 +755,10 @@ TEST_F(ThreePoints, LInfNormCost2) {
   auto cost = std::make_shared<solvers::LInfNormCost>(A, b);
   e_on_->AddCost(solvers::Binding(cost, {e_on_->xu(), e_on_->xv()}));
   e_off_->AddCost(solvers::Binding(cost, {e_off_->xu(), e_off_->xv()}));
+  RowVector2d A_v(4.3, -0.4);
+  auto vertex_cost =
+      std::make_shared<solvers::LInfNormCost>(A_v, Vector1d::Zero());
+  source_->AddCost(solvers::Binding(vertex_cost, source_->x()));
   auto result = g_.SolveShortestPath(*source_, *target_, options);
   if (result.get_solver_id() == solvers::IpoptSolver::id()) {
     return;  // See IpoptTest for details.
@@ -630,6 +771,9 @@ TEST_F(ThreePoints, LInfNormCost2) {
           .maxCoeff(),
       1e-6);
   EXPECT_NEAR(e_off_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(source_->GetSolutionCost(result), abs(A_v * p_source_.x()), 1e-6);
+  EXPECT_NEAR(target_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(sink_->GetSolutionCost(result), 0.0, 1e-6);
 }
 
 TEST_F(ThreePoints, PerspectiveQuadraticCost) {
@@ -642,6 +786,11 @@ TEST_F(ThreePoints, PerspectiveQuadraticCost) {
   auto cost = std::make_shared<solvers::PerspectiveQuadraticCost>(A, b);
   e_on_->AddCost(solvers::Binding(cost, {e_on_->xu(), e_on_->xv()}));
   e_off_->AddCost(solvers::Binding(cost, {e_off_->xu(), e_off_->xv()}));
+  Matrix<double, 2, 2> A_v;
+  A_v << -1, 1, 1, 1;
+  auto vertex_cost =
+      std::make_shared<solvers::PerspectiveQuadraticCost>(A_v, b);
+  source_->AddCost(solvers::Binding(vertex_cost, source_->x()));
   auto result = g_.SolveShortestPath(*source_, *target_, options);
   if (result.get_solver_id() == solvers::IpoptSolver::id()) {
     return;  // See IpoptTest for details.
@@ -652,6 +801,12 @@ TEST_F(ThreePoints, PerspectiveQuadraticCost) {
       (p_source_.x()(1) - p_source_.x()(0) + b(0));
   EXPECT_NEAR(e_on_->GetSolutionCost(result), expected_cost, 1e-6);
   EXPECT_NEAR(e_off_->GetSolutionCost(result), 0.0, 1e-6);
+  const double vertex_expected_cost =
+      std::pow(p_source_.x()(0) + p_source_.x()(1) + b(1), 2) /
+      (p_source_.x()(1) - p_source_.x()(0) + b(0));
+  EXPECT_NEAR(source_->GetSolutionCost(result), vertex_expected_cost, 1e-6);
+  EXPECT_NEAR(target_->GetSolutionCost(result), 0.0, 1e-6);
+  EXPECT_NEAR(sink_->GetSolutionCost(result), 0.0, 1e-6);
 }
 
 // Like the ThreePoints, but with boxes for each vertex instead of points.
@@ -707,8 +862,10 @@ TEST_F(ThreeBoxes, LinearEqualityConstraint) {
   const Vector2d b{.5, .3};
   e_on_->AddConstraint(e_on_->xv() == b);
   e_off_->AddConstraint(e_off_->xv() == b);
+  source_->AddConstraint(source_->x() == -b);
   auto result = g_.SolveShortestPath(*source_, *target_, options);
   ASSERT_TRUE(result.is_success());
+  EXPECT_TRUE(CompareMatrices(source_->GetSolution(result), -b, 1e-6));
   EXPECT_TRUE(CompareMatrices(target_->GetSolution(result), b, 1e-6));
   EXPECT_TRUE(sink_->GetSolution(result).hasNaN());
 }
@@ -726,8 +883,14 @@ TEST_F(ThreeBoxes, LinearEqualityConstraint2) {
       solvers::Binding(constraint, {e_on_->xu(), e_on_->xv()}));
   e_off_->AddConstraint(
       solvers::Binding(constraint, {e_off_->xu(), e_off_->xv()}));
+  Matrix<double, 2, 2> Aeq_v;
+  Aeq_v << 4.5, 0.7, 0.3, 0.6;
+  auto vertex_constraint =
+      std::make_shared<solvers::LinearEqualityConstraint>(Aeq_v, beq);
+  source_->AddConstraint(solvers::Binding(vertex_constraint, source_->x()));
   auto result = g_.SolveShortestPath(*source_, *target_, options);
   ASSERT_TRUE(result.is_success());
+  EXPECT_TRUE(CompareMatrices(Aeq_v * source_->GetSolution(result), beq, 1e-6));
   EXPECT_TRUE(
       CompareMatrices(Aeq.leftCols(2) * source_->GetSolution(result) +
                           Aeq.rightCols(2) * target_->GetSolution(result),
@@ -739,8 +902,10 @@ TEST_F(ThreeBoxes, LinearConstraint) {
   const Vector2d b{.5, .3};
   e_on_->AddConstraint(e_on_->xv() >= b);
   e_off_->AddConstraint(e_off_->xv() >= b);
+  source_->AddConstraint(source_->x() <= -b);
   auto result = g_.SolveShortestPath(*source_, *target_, options);
   ASSERT_TRUE(result.is_success());
+  EXPECT_TRUE((source_->GetSolution(result).array() <= b.array() - 1e-6).all());
   EXPECT_TRUE((target_->GetSolution(result).array() >= b.array() - 1e-6).all());
   EXPECT_TRUE(sink_->GetSolution(result).hasNaN());
 }
@@ -757,8 +922,19 @@ TEST_F(ThreeBoxes, LinearConstraint2) {
       solvers::Binding(constraint, {e_on_->xu(), e_on_->xv()}));
   e_off_->AddConstraint(
       solvers::Binding(constraint, {e_off_->xu(), e_off_->xv()}));
+  Matrix<double, 2, 2> A_v;
+  A_v << 4.5, 0.7, 0.3, 0.6;
+  auto vertex_constraint =
+      std::make_shared<solvers::LinearConstraint>(A_v, lb, ub);
+  source_->AddConstraint(solvers::Binding(vertex_constraint, source_->x()));
   auto result = g_.SolveShortestPath(*source_, *target_, options);
   ASSERT_TRUE(result.is_success());
+  EXPECT_TRUE(
+      ((A_v * source_->GetSolution(result)).array() <= ub.array() + 1e-6)
+          .all());
+  EXPECT_TRUE(
+      ((A_v * source_->GetSolution(result)).array() >= lb.array() - 1e-6)
+          .all());
   EXPECT_TRUE(((A.leftCols(2) * source_->GetSolution(result) +
                 A.rightCols(2) * target_->GetSolution(result))
                    .array() <= ub.array() + 1e-6)


### PR DESCRIPTION
Resolves a previous TODO and lays the ground work to make the implementation of the GCS planner cleaner.

cc @TobiaMarcucci

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17844)
<!-- Reviewable:end -->
