### PR TITLE
Remove LD_LIBRARY_PATH from apt instructions and Dockerfiles

### DIFF
--- a/doc/_pages/apt.md
+++ b/doc/_pages/apt.md
@@ -71,7 +71,6 @@ Most content installs to `/opt/drake`, so setting the following environment
 variables may be useful:
 
   ```bash
-  export LD_LIBRARY_PATH="/opt/drake/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
   export PATH="/opt/drake/bin${PATH:+:${PATH}}"
   export PYTHONPATH="/opt/drake/lib/python$(python3 -c 'import sys; print("{0}.{1}".format(*sys.version_info))')/site-packages${PYTHONPATH:+:${PYTHONPATH}}"
   ```

--- a/tools/install/dockerhub/focal/Dockerfile
+++ b/tools/install/dockerhub/focal/Dockerfile
@@ -17,6 +17,5 @@ echo "drake-visualizer is not supported on Docker containers.\n\
 Although not guaranteed to run, the executable is available to try as-is:\n\
 /opt/drake/bin/drake-visualizer.image"' > /opt/drake/bin/drake-visualizer\
   && chmod a+x /opt/drake/bin/drake-visualizer
-ENV LD_LIBRARY_PATH="/opt/drake/lib:${LD_LIBRARY_PATH}" \
-  PATH="/opt/drake/bin:${PATH}" \
+ENV PATH="/opt/drake/bin:${PATH}" \
   PYTHONPATH="/opt/drake/lib/python3.8/site-packages:${PYTHONPATH}"

--- a/tools/install/dockerhub/focal/README.md
+++ b/tools/install/dockerhub/focal/README.md
@@ -17,6 +17,5 @@ following command:
 docker run -it robotlocomotion/drake:focal
 ```
 
-The environment variables `LD_LIBRARY`, `PATH`, and `PYTHONPATH` are preset to
-suitable values for using Drake, including, in particular, its Python
-bindings.
+The environment variables `PATH` and `PYTHONPATH` are preset to suitable values
+for using Drake, including, in particular, its Python bindings.

--- a/tools/install/dockerhub/jammy/Dockerfile
+++ b/tools/install/dockerhub/jammy/Dockerfile
@@ -11,6 +11,5 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 # https://docs.deepnote.com/environment/custom-environments#custom-image-requirements
     python3-pip python-is-python3 \
   && rm -rf /var/lib/apt/lists/*
-ENV LD_LIBRARY_PATH="/opt/drake/lib:${LD_LIBRARY_PATH}" \
-  PATH="/opt/drake/bin:${PATH}" \
+ENV PATH="/opt/drake/bin:${PATH}" \
   PYTHONPATH="/opt/drake/lib/python3.10/site-packages:${PYTHONPATH}"

--- a/tools/install/dockerhub/jammy/README.md
+++ b/tools/install/dockerhub/jammy/README.md
@@ -17,6 +17,5 @@ following command:
 docker run -it robotlocomotion/drake:jammy
 ```
 
-The environment variables `LD_LIBRARY`, `PATH`, and `PYTHONPATH` are preset to
-suitable values for using Drake, including, in particular, its Python
-bindings.
+The environment variables `PATH` and `PYTHONPATH` are preset to suitable values
+for using Drake, including, in particular, its Python bindings.


### PR DESCRIPTION
Drake is properly rpath'd and modifying LD_LIBRARY_PATH for users
is no longer necessary.

Closes #16932.

For testing, a `Dockerfile` with the following contents was built:

```docker
# refs: http://fabiorehm.com/blog/2014/09/11/running-gui-apps-with-docker/
#
# docker build -t drakey .
#
# docker run -ti --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix drakey

FROM ubuntu:20.04

RUN apt-get update && apt-get install -y firefox

# Replace XXX with `id -u` and YYY with `id -g`
RUN export uid=XXX gid=YYY && \
    mkdir -p /home/developer && \
    echo "developer:x:${uid}:${gid}:Developer,,,:/home/developer:/bin/bash" >> /etc/passwd && \
    echo "developer:x:${uid}:" >> /etc/group && \
    mkdir /etc/sudoers.d && \
    echo "developer ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/developer && \
    chmod 0440 /etc/sudoers.d/developer && \
    chown ${uid}:${gid} -R /home/developer

ENV DEBIAN_FRONTEND=noninteractive
RUN apt-get install --no-install-recommends -y \
  ca-certificates gnupg lsb-release wget
RUN wget -qO- https://drake-apt.csail.mit.edu/drake.asc | gpg --dearmor - \
  | tee /etc/apt/trusted.gpg.d/drake.gpg >/dev/null
RUN echo "deb [arch=amd64] https://drake-apt.csail.mit.edu/$(lsb_release -cs) $(lsb_release -cs) main" \
  | tee /etc/apt/sources.list.d/drake.list >/dev/null
RUN apt-get update
RUN apt-get install --no-install-recommends -y drake-dev

USER developer
ENV HOME /home/developer
CMD /bin/bash

ENV PATH="/opt/drake/bin:${PATH}" \
  PYTHONPATH="/opt/drake/lib/python3.8/site-packages:${PYTHONPATH}"
```

With this container and the existing checklist:

- [X] Run `import pydrake.all` to check pydrake.
    - Works as expected without errors.
- [X] Check a few useful programs in `bin`:
  - [X] drake-visualizer: application can launch, but is not able to get a good enough OpenGL context:

    ```console
    $ drake-visualizer 
    QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-developer'
    libGL error: MESA-LOADER: failed to retrieve device information
    
    Drake Scripts:
      Specified: --use_builtin_scripts=all
      Available: --use_builtin_scripts=experimental_deformable_mesh,frame,hydroelastic_contact,image,point_cloud,point_pair_contact,time,grid_wireframe,limit_clipping_range

    DeformableVisualizer set_enabled True
    Deformable Mesh Visualizer subscribers added.
    Hydroelastic Contact Visualizer subscriber added.
    DrakeLcmImageViewer: Defer setup until 'DRAKE_RGBD_CAMERA_IMAGES' is received
    Point Pair Contact Visualizer subscriber added.
    ERROR: In /vtk/src/Rendering/OpenGL2/vtkOpenGLRenderWindow.cxx, line 747
    vtkGenericOpenGLRenderWindow (0x55d20cc14f70): Unable to find a valid OpenGL 3.2 or later implementation. Please update your video card driver to the latest version. If you are using Mesa please make sure you have version 11.2 or later and make sure your driver in Mesa supports OpenGL 3.2 such as llvmpipe or openswr. If you are on windows and using Microsoft remote desktop note that it only supports OpenGL 3.2 with nvidia quadro cards. You can use other remoting software such as nomachine to avoid this issue.

    Segmentation fault (core dumped)
    ```

    This is believed to be sufficient.  Docker and display sharing is tricky, if we want to stress test this further that can be done but will have to be checked outside of docker.  If the rpaths were wrong then it would not actually be able to load the program to eventually try and get the OpenGL context.
  - [X] drake-lcm-spy: launcher and window display, no traffic was inspected
  - [X] lcm-logplayer: program runs, I do not know how to use it.
  - [X] lcm-logplayer-gui: program runs and windows are displayed, no traffic was inspected.

Re: `Dockerfile` changes here, I believe these get tested via the packaging jobs:

- [X] [Focal packaging](https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-focal-unprovisioned-gcc-bazel-experimental-snopt-mosek-packaging/34/console)
- [X] [Jammy packaging](https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-jammy-unprovisioned-gcc-bazel-experimental-snopt-mosek-packaging/5/console)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17846)
<!-- Reviewable:end -->
