### PR TITLE
Use new CalcSpatialInertia() function in manipulation_station

### DIFF
--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -50,12 +50,13 @@ namespace internal {
 
 // Calculate the spatial inertia of the set S of bodies that make up the gripper
 // about Go (the gripper frame's origin), expressed in the gripper frame G.
-// The rigid bodies in the gripper consist of the gripper body G, the left
-// finger L, and the right finger R.  For this calculation, the sliding joints
-// associated with the fingers are regarded as being in a "zero" configuration.
+// The rigid bodies in set S consist of the gripper body G, the left finger, and
+// the right finger. For this calculation, the sliding joints associated with
+// the fingers are regarded as being in a "zero" configuration.
 // @param[in] wsg_sdf_path path to sdf file that when parsed creates the model.
-// @param[in] gripper_body_frame_name Name of frame attached to the gripper's
-//            main body.
+// @param[in] gripper_body_frame_name Name of the frame attached to the
+//            gripper's main body.
+// @retval M_SGo_G, spatial inertia of set S about Go, expressed in frame G.
 SpatialInertia<double> CalcGripperSpatialInertia(
     const std::string& wsg_sdf_path,
     const std::string& gripper_body_frame_name) {
@@ -69,6 +70,7 @@ SpatialInertia<double> CalcGripperSpatialInertia(
   auto context = plant.CreateDefaultContext();
   plant.SetDefaultState(*context, &context->get_mutable_state());
 
+  // Get references to gripper frame, gripper body, and the two fingers.
   const multibody::Frame<double>& gripper_frame =
       plant.GetFrameByName(gripper_body_frame_name);
   const multibody::RigidBody<double>& gripper_body =
@@ -78,12 +80,13 @@ SpatialInertia<double> CalcGripperSpatialInertia(
   const multibody::RigidBody<double>& right_finger =
       plant.GetRigidBodyByName("right_finger");
 
-  // Add the BodyIndex for each of the relevant rigid bodies G, L, R..
+  // Form a vector with the BodyIndex for the gripper body and the two fingers.
   std::vector<multibody::BodyIndex> body_indexes;
-  body_indexes.push_back(gripper_body.index());  // Rigid body G.
-  body_indexes.push_back(left_finger.index());   // Rigid body L.
-  body_indexes.push_back(right_finger.index());  // Rigid body R.
+  body_indexes.push_back(gripper_body.index());
+  body_indexes.push_back(left_finger.index());
+  body_indexes.push_back(right_finger.index());
 
+  // Calculate and return the spatial inertia of set S about Go, expressed in G.
   const SpatialInertia<double> M_SGo_G =
       plant.CalcSpatialInertia(*context, gripper_frame, body_indexes);
   return M_SGo_G;

--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -433,7 +433,7 @@ void ManipulationStation<T>::MakeIiwaControllerModel() {
   // on the hardware to be so precise, so we simply ignore the inertia
   // contribution from the fingers here.
   const multibody::SpatialInertia<double> wsg_spatial_inertial =
-    internal::CalcGripperSpatialInertia(controller_model_path());
+    internal::CalcGripperSpatialInertia(wsg_model_.model_path);
   const multibody::RigidBody<T>& wsg_equivalent =
       owned_controller_plant_->AddRigidBody(
           "wsg_equivalent", controller_iiwa_model, wsg_spatial_inertial);

--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -48,12 +48,15 @@ using multibody::SpatialInertia;
 
 namespace internal {
 
-// TODO(amcastro-tri): Refactor this into schunk_wsg directory, and cover it
-// with a unit test.  Potentially tighten the tolerance in
-// station_simulation_test.
-// @param gripper_body_frame_name Name of a frame that's attached to the
-// gripper's main body.
-SpatialInertia<double> MakeCompositeGripperInertia(
+// Calculate the spatial inertia of the set S of bodies that make up the gripper
+// about Go (the gripper frame's origin), expressed in the gripper frame G.
+// The rigid bodies in the gripper consist of the gripper body G, the left
+// finger L, and the right finger R.  For this calculation, the sliding joints
+// associated with the fingers are regarded as being in a "zero" configuration.
+// @param[in] wsg_sdf_path path to sdf file that when parsed creates the model.
+// @param[in] gripper_body_frame_name Name of frame attached to the gripper's
+//            main body.
+SpatialInertia<double> CalcGripperSpatialInertia(
     const std::string& wsg_sdf_path,
     const std::string& gripper_body_frame_name) {
   // Set timestep to 1.0 since it is arbitrary, to quiet joint limit warnings.
@@ -61,55 +64,29 @@ SpatialInertia<double> MakeCompositeGripperInertia(
   multibody::Parser parser(&plant);
   parser.AddModelFromFile(wsg_sdf_path);
   plant.Finalize();
-  const auto& frame = plant.GetFrameByName(gripper_body_frame_name);
-  const auto& gripper_body = plant.GetRigidBodyByName(frame.body().name());
-  const auto& left_finger = plant.GetRigidBodyByName("left_finger");
-  const auto& right_finger = plant.GetRigidBodyByName("right_finger");
-  const auto& left_slider = plant.GetJointByName("left_finger_sliding_joint");
-  const auto& right_slider = plant.GetJointByName("right_finger_sliding_joint");
-  const SpatialInertia<double>& M_GGo_G =
-      gripper_body.default_spatial_inertia();
-  const SpatialInertia<double>& M_LLo_L = left_finger.default_spatial_inertia();
-  const SpatialInertia<double>& M_RRo_R =
-      right_finger.default_spatial_inertia();
-  auto CalcFingerPoseInGripperFrame = [](const Joint<double>& slider) {
-    // Pose of the joint's parent frame P (attached on gripper body G) in the
-    // frame of the gripper G.
-    const RigidTransform<double> X_GP(
-        slider.frame_on_parent().GetFixedPoseInBodyFrame());
-    // Pose of the joint's child frame C (attached on the slider's finger body)
-    // in the frame of the slider's finger F.
-    const RigidTransform<double> X_FC(
-        slider.frame_on_child().GetFixedPoseInBodyFrame());
-    // When the slider's translational dof is zero, then P coincides with C.
-    // Therefore:
-    const RigidTransform<double> X_GF = X_GP * X_FC.inverse();
-    return X_GF;
-  };
-  // Pose of left finger L in gripper frame G when the slider's dof is zero.
-  const RigidTransform<double> X_GL(CalcFingerPoseInGripperFrame(left_slider));
-  // Pose of right finger R in gripper frame G when the slider's dof is zero.
-  const RigidTransform<double> X_GR(CalcFingerPoseInGripperFrame(right_slider));
-  // Helper to compute the spatial inertia of a finger F in about the gripper's
-  // origin Go, expressed in G.
-  auto CalcFingerSpatialInertiaInGripperFrame =
-      [](const SpatialInertia<double>& M_FFo_F,
-         const RigidTransform<double>& X_GF) {
-        const auto M_FFo_G = M_FFo_F.ReExpress(X_GF.rotation());
-        const auto p_FoGo_G = -X_GF.translation();
-        const auto M_FGo_G = M_FFo_G.Shift(p_FoGo_G);
-        return M_FGo_G;
-      };
-  // Shift and re-express in G frame the finger's spatial inertias.
-  const auto M_LGo_G = CalcFingerSpatialInertiaInGripperFrame(M_LLo_L, X_GL);
-  const auto M_RGo_G = CalcFingerSpatialInertiaInGripperFrame(M_RRo_R, X_GR);
-  // With everything about the same point Go and expressed in the same frame G,
-  // proceed to compose into composite body C:
-  // TODO(amcastro-tri): Implement operator+() in SpatialInertia.
-  SpatialInertia<double> M_CGo_G = M_GGo_G;
-  M_CGo_G += M_LGo_G;
-  M_CGo_G += M_RGo_G;
-  return M_CGo_G;
+
+  // Set bodies to have zero translation, zero rotation, zero velocity, etc.
+  auto context = plant.CreateDefaultContext();
+  plant.SetDefaultState(*context, &context->get_mutable_state());
+
+  const multibody::Frame<double>& gripper_frame =
+      plant.GetFrameByName(gripper_body_frame_name);
+  const multibody::RigidBody<double>& gripper_body =
+      plant.GetRigidBodyByName(gripper_frame.body().name());
+  const multibody::RigidBody<double>& left_finger =
+      plant.GetRigidBodyByName("left_finger");
+  const multibody::RigidBody<double>& right_finger =
+      plant.GetRigidBodyByName("right_finger");
+
+  // Add the BodyIndex for each of the relevant rigid bodies G, L, R..
+  std::vector<multibody::BodyIndex> body_indexes;
+  body_indexes.push_back(gripper_body.index());  // Rigid body G.
+  body_indexes.push_back(left_finger.index());   // Rigid body L.
+  body_indexes.push_back(right_finger.index());  // Rigid body R.
+
+  const SpatialInertia<double> M_SGo_G =
+      plant.CalcSpatialInertia(*context, gripper_frame, body_indexes);
+  return M_SGo_G;
 }
 
 // TODO(russt): Get these from SDF instead of having them hard-coded (#10022).
@@ -453,11 +430,12 @@ void ManipulationStation<T>::MakeIiwaControllerModel() {
   // (according to the sdf)... and we don't believe our inertia calibration
   // on the hardware to be so precise, so we simply ignore the inertia
   // contribution from the fingers here.
+  const multibody::SpatialInertia<double> wsg_spatial_inertial =
+    internal::CalcGripperSpatialInertia(controller_model_path(),
+                                        controller_model_child_frame_name());
   const multibody::RigidBody<T>& wsg_equivalent =
       owned_controller_plant_->AddRigidBody(
-          "wsg_equivalent", controller_iiwa_model,
-          internal::MakeCompositeGripperInertia(
-              wsg_model_.model_path, wsg_model_.child_frame->name()));
+          "wsg_equivalent", controller_iiwa_model, wsg_spatial_inertial);
 
   // TODO(siyuan.feng@tri.global): when we handle multiple IIWA and WSG, this
   // part need to deal with the parent's (iiwa's) model instance id.

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -477,16 +477,6 @@ class ManipulationStation : public systems::Diagram<T> {
     iiwa_ki_ = ki;
   }
 
-#ifndef DRAKE_DOXYGEN_CXX
-  /// (Internal use only) Returns the path to the sdf file that contains the
-  /// controller model.
-  /// @throws std::exception if Finalize() has not been called.
-  const std::string& controller_model_path() {
-    DRAKE_THROW_UNLESS(wsg_model_.model_instance.is_valid());
-    return wsg_model_.model_path;
-  }
-#endif
-
  private:
   // Struct defined to store information about the how to parse and add a model.
   struct ModelInformation {

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -477,6 +477,20 @@ class ManipulationStation : public systems::Diagram<T> {
     iiwa_ki_ = ki;
   }
 
+  /// Returns the model path for the controller model.
+  /// @throws std::exception if Finalize() has not been called.
+  std::string controller_model_path() {
+    DRAKE_THROW_UNLESS(wsg_model_.model_instance.is_valid());
+    return wsg_model_.model_path;
+  }
+
+  /// Returns the child frame name for the controller model.
+  /// @throws std::exception if Finalize() has not been called.
+  std::string controller_model_child_frame_name() {
+    DRAKE_THROW_UNLESS(wsg_model_.model_instance.is_valid());
+    return wsg_model_.child_frame->name();
+  }
+
  private:
   // Struct defined to store information about the how to parse and add a model.
   struct ModelInformation {

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -477,7 +477,7 @@ class ManipulationStation : public systems::Diagram<T> {
     iiwa_ki_ = ki;
   }
 
-  /// Returns the model path for the controller model.
+  /// Returns the path to the sdf file that contains the controller model.
   /// @throws std::exception if Finalize() has not been called.
   std::string controller_model_path() {
     DRAKE_THROW_UNLESS(wsg_model_.model_instance.is_valid());

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -477,19 +477,15 @@ class ManipulationStation : public systems::Diagram<T> {
     iiwa_ki_ = ki;
   }
 
-  /// Returns the path to the sdf file that contains the controller model.
+#ifndef DRAKE_DOXYGEN_CXX
+  /// (Internal use only) Returns the path to the sdf file that contains the
+  /// controller model.
   /// @throws std::exception if Finalize() has not been called.
-  std::string controller_model_path() {
+  const std::string& controller_model_path() {
     DRAKE_THROW_UNLESS(wsg_model_.model_instance.is_valid());
     return wsg_model_.model_path;
   }
-
-  /// Returns the child frame name for the controller model.
-  /// @throws std::exception if Finalize() has not been called.
-  std::string controller_model_child_frame_name() {
-    DRAKE_THROW_UNLESS(wsg_model_.model_instance.is_valid());
-    return wsg_model_.child_frame->name();
-  }
+#endif
 
  private:
   // Struct defined to store information about the how to parse and add a model.

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -36,11 +36,13 @@ using systems::BasicVector;
 // @retval M_SGo_G spatial inertia of set S about Go, expressed in frame G.
 // @note This function helps unit test the calculation of the gripper's spatial
 //   inertia done in CalcGripperSpatialInertia() in manipulation_station.cc.
-multibody::SpatialInertia<double> MakeCompositeGripperInertia(
-    const std::string& wsg_sdf_path) {
+multibody::SpatialInertia<double> MakeCompositeGripperInertia() {
   // Set timestep to 1.0 since it is arbitrary, to quiet joint limit warnings.
   multibody::MultibodyPlant<double> plant(1.0);
   multibody::Parser parser(&plant);
+  const std::string& wsg_sdf_path = FindResourceOrThrow(
+      "drake/manipulation/models/wsg_50_description/sdf/"
+      "schunk_wsg_50_no_tip.sdf");
   parser.AddModelFromFile(wsg_sdf_path);
   plant.Finalize();
   const std::string gripper_body_frame_name = "body";
@@ -213,7 +215,7 @@ GTEST_TEST(ManipulationStationTest, CheckPlantBasics) {
   const multibody::SpatialInertia<double> M_SGo_G_actual =
       composite_gripper.default_spatial_inertia();
   const multibody::SpatialInertia<double> M_SGo_G_expected =
-      MakeCompositeGripperInertia(station.controller_model_path());
+      MakeCompositeGripperInertia();
 
   const Matrix6<double> M6_actual = M_SGo_G_actual.CopyToFullMatrix6();
   const Matrix6<double> M6_expected = M_SGo_G_expected.CopyToFullMatrix6();

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -95,7 +95,9 @@ multibody::SpatialInertia<double> MakeCompositeGripperInertia(
   // With everything about the same point Go and expressed in the same frame G,
   // proceed to compose into composite body C:
   // TODO(amcastro-tri): Implement operator+() in SpatialInertia.
-  multibody::SpatialInertia<double> M_CGo_G = M_GGo_G += M_LGo_G += M_RGo_G;
+  multibody::SpatialInertia<double> M_CGo_G = M_GGo_G;
+  M_CGo_G += M_LGo_G;
+  M_CGo_G += M_RGo_G;
   return M_CGo_G;
 }
 


### PR DESCRIPTION
Test new calculations in manipulation_station.cc that employ CalcSpatialInertia() against old function MakeCompositeGripperInertia() that previously was in manipulation_station.cc and has now been moved to manipulation_station_test.cc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17847)
<!-- Reviewable:end -->
