### PR TITLE
[SymbolicFormula] Make conversion to bool implicit (Eigen)

### DIFF
--- a/common/symbolic/expression/formula.h
+++ b/common/symbolic/expression/formula.h
@@ -101,13 +101,13 @@ that any duplicated conjunct/disjunct is removed. For example, both of `f1 &&
 simplified into `f1 && f2`. As a result, the two are identified as the same
 formula.
 
-\note Formula class has an explicit conversion operator to bool. It evaluates a
+\note Formula class has an implicit conversion operator to bool. It evaluates a
 symbolic formula under an empty environment. If a symbolic formula includes
 variables, the conversion operator throws an exception. This operator is only
 intended for third-party code doing things like `(imag(SymbolicExpression(0))
-== SymbolicExpression(0)) { ... };` that we found in Eigen3 codebase. In
-general, a user of this class should explicitly call `Evaluate` from within
-Drake for readability.
+== SymbolicExpression(0)) { ... };` and `return symbolic_expr_a <
+symbolic_expr_b;` that we found in Eigen3 codebase. In general, a user of this
+class should explicitly call `Evaluate` from within Drake for readability.
 
 */
 class Formula {
@@ -202,7 +202,7 @@ class Formula {
   static Formula False();
 
   /** Conversion to bool. */
-  explicit operator bool() const { return Evaluate(); }
+  /*implicit*/ operator bool() const { return Evaluate(); }
 
   /** Implements the @ref hash_append concept. */
   template <class HashAlgorithm>


### PR DESCRIPTION
This is to allow building with the latest version of Eigen. Several functions eventually lead to `return a < b` or `return a > b` which does not trigger explicit conversion.

Example issue:

```
external/eigen/Eigen/src/Core/Visitor.h:232:77: error: no viable conversion from returned value of type 'drake::symbolic::Formula' to function return type 'bool'
  static EIGEN_DEVICE_FUNC inline bool compare(Scalar a, Scalar b) { return a > b; }
                                                                            ^~~~~
external/eigen/Eigen/src/Core/Visitor.h:246:20: note: in instantiation of member function 'Eigen::internal::minmax_compare<drake::symbolic::Expression, 0, false>::compare' requested here
    if(Comparator::compare(value, this->res)) {
                   ^
external/eigen/Eigen/src/Core/Visitor.h:67:11: note: in instantiation of member function 'Eigen::internal::minmax_coeff_visitor<Eigen::CwiseUnaryOp<Eigen::internal::scalar_score_coeff_op<drake::symbolic::Expression>, const Eigen::Block<Eigen::Block<Eigen::Ref<Eigen::Matrix<drake::symbolic::Expression, -1, -1, 0>, 0, Eigen::OuterStride<-1>>, -1, 1, true>, -1, 1, false>>, false, 0>::operator()' requested here
          visitor(mat.coeff(0, i), 0, i);
          ^
external/eigen/Eigen/src/Core/Visitor.h:195:101: note: in instantiation of member function 'Eigen::internal::visitor_impl<Eigen::internal::minmax_coeff_visitor<Eigen::CwiseUnaryOp<Eigen::internal::scalar_score_coeff_op<drake::symbolic::Expression>, const Eigen::Block<Eigen::Block<Eigen::Ref<Eigen::Matrix<drake::symbolic::Expression, -1, -1, 0>, 0, Eigen::OuterStride<-1>>, -1, 1, true>, -1, 1, false>>, false, 0>, Eigen::internal::visitor_evaluator<Eigen::CwiseUnaryOp<Eigen::internal::scalar_score_coeff_op<drake::symbolic::Expression>, const Eigen::Block<Eigen::Block<Eigen::Ref<Eigen::Matrix<drake::symbolic::Expression, -1, -1, 0>, 0, Eigen::OuterStride<-1>>, -1, 1, true>, -1, 1, false>>>, -1, false>::run' requested here
  return internal::visitor_impl<Visitor, ThisEvaluator, unroll ? int(SizeAtCompileTime) : Dynamic>::run(thisEval, visitor);
                                                                                                    ^
external/eigen/Eigen/src/Core/Visitor.h:448:9: note: in instantiation of function template specialization 'Eigen::DenseBase<Eigen::CwiseUnaryOp<Eigen::internal::scalar_score_coeff_op<drake::symbolic::Expression>, const Eigen::Block<Eigen::Block<Eigen::Ref<Eigen::Matrix<drake::symbolic::Expression, -1, -1, 0>, 0, Eigen::OuterStride<-1>>, -1, 1, true>, -1, 1, false>>>::visit<Eigen::internal::minmax_coeff_visitor<Eigen::CwiseUnaryOp<Eigen::internal::scalar_score_coeff_op<drake::symbolic::Expression>, const Eigen::Block<Eigen::Block<Eigen::Ref<Eigen::Matrix<drake::symbolic::Expression, -1, -1, 0>, 0, Eigen::OuterStride<-1>>, -1, 1, true>, -1, 1, false>>, false, 0>>' requested here
  this->visit(maxVisitor);
        ^
external/eigen/Eigen/src/Core/DenseBase.h:490:14: note: in instantiation of function template specialization 'Eigen::DenseBase<Eigen::CwiseUnaryOp<Eigen::internal::scalar_score_coeff_op<drake::symbolic::Expression>, const Eigen::Block<Eigen::Block<Eigen::Ref<Eigen::Matrix<drake::symbolic::Expression, -1, -1, 0>, 0, Eigen::OuterStride<-1>>, -1, 1, true>, -1, 1, false>>>::maxCoeff<0, long>' requested here
      return maxCoeff<PropagateFast>(index);
             ^
external/eigen/Eigen/src/LU/PartialPivLU.h:376:55: note: (skipping 4 contexts in backtrace; use -ftemplate-backtrace-limit=0 to see all)
        = lu.col(k).tail(rows-k).unaryExpr(Scoring()).maxCoeff(&row_of_biggest_in_col);
                                                      ^
external/eigen/Eigen/src/LU/PartialPivLU.h:135:7: note: in instantiation of member function 'Eigen::PartialPivLU<Eigen::Matrix<drake::symbolic::Expression, -1, -1, 0>>::compute' requested here
      compute();
      ^
external/eigen/Eigen/src/LU/PartialPivLU.h:314:3: note: in instantiation of function template specialization 'Eigen::PartialPivLU<Eigen::Matrix<drake::symbolic::Expression, -1, -1, 0>>::compute<Eigen::Matrix<drake::symbolic::Expression, -1, -1, 0>>' requested here
  compute(matrix.derived());
  ^
external/linear_solve/drake/math/linear_solve.h:408:67: note: in instantiation of function template specialization 'Eigen::PartialPivLU<Eigen::Matrix<drake::symbolic::Expression, -1, -1, 0>>::PartialPivLU<Eigen::Matrix<drake::symbolic::Expression, -1, -1, 0>>' requested here
    const internal::EigenLinearSolver<LinearSolverType, DerivedA> linear_solver(
                                                                  ^
external/drake/math/linear_solve.h:582:30: note: in instantiation of function template specialization 'drake::math::GetLinearSolver<Eigen::PartialPivLU, Eigen::Matrix<drake::symbolic::Expression, -1, -1, 0>>' requested here
      : eigen_linear_solver_{GetLinearSolver<LinearSolverType>(A)} {
                             ^
external/drake/multibody/plant/tamsi_solver.cc:718:65: note: in instantiation of member function 'drake::math::LinearSolver<Eigen::PartialPivLU, Eigen::Matrix<drake::symbolic::Expression, -1, -1, 0>>::LinearSolver' requested here
      const math::LinearSolver<Eigen::PartialPivLU, MatrixX<T>> J_lu(J);
                                                                ^
external/drake/common/symbolic/expression/formula.h:205:12: note: explicit conversion function is not a candidate
  explicit operator bool() const { return Evaluate(); }
           ^

```



This one occurs in PartialPivLU. The same function or

```
external/eigen/Eigen/src/Core/Visitor.h:225:77: error: no viable conversion from returned value of type 'drake::symbolic::Formula' to function return type 'bool'
  static EIGEN_DEVICE_FUNC inline bool compare(Scalar a, Scalar b) { return a < b; }
                                                                            ^~~~~
```
is eventually reached by ColPivHouseholderQR, JacobiSVD.

Since the auto-conversion was introduced for Eigen support to begin with, make it implicit to support broader Eigen scenarios.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17850)
<!-- Reviewable:end -->
