### PR TITLE
[pydrake] Enable return-None cases for System event handlers

### DIFF
--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -606,6 +606,32 @@ class TestCustom(unittest.TestCase):
         self.assertTrue(system.called_reset)
         self.assertTrue(system.called_system_reset)
 
+    def test_event_handler_returns_none(self):
+        """Checks that a Python event handler callback function is allowed to
+        (implicitly) return None, instead of an EventStatus. Because of all the
+        setup boilerplate, we only test one specific event type and assume that
+        the other event types (which are implemented similarly) will likewise
+        behave the same.
+        """
+
+        class PublishReturnsNoneSystem(LeafSystem):
+            def __init__(self):
+                LeafSystem.__init__(self)
+                self.called_periodic_publish = False
+                self.DeclarePeriodicPublishEvent(
+                    period_sec=1.0, offset_sec=0.0,
+                    publish=self._on_periodic_publish)
+
+            def _on_periodic_publish(self, context):
+                self.called_periodic_publish = True
+                # There is no `return` statement here; Python implicitly treats
+                # this like a `return None`.
+
+        system = PublishReturnsNoneSystem()
+        simulator = Simulator(system)
+        simulator.AdvanceTo(0.25)
+        self.assertTrue(system.called_periodic_publish)
+
     def test_state_output_port_declarations(self):
         """Checks that DeclareStateOutputPort is bound."""
         dut = LeafSystem()


### PR DESCRIPTION
In cases where the user declared a System event handler in Python but forgot to return `EventStatus.Succeeded`, they would receive a confusing message like so:

```
    simulator.AdvanceTo(float(1.5))
TypeError: AdvanceTo(): incompatible function arguments. The following argument types are supported:
    1. (self: pydrake.systems.analysis.Simulator_[float], boundary_time: float) -> pydrake.systems.analysis.SimulatorStatus

Invoked with: <pydrake.systems.analysis.Simulator_[float] object at 0x7f59bbf169f0>, 1.5
``` 

(Taken from [here](https://stackoverflow.com/questions/73396876/pydrake-typeerror-in-advanceto-arguments) for example.)

We could try to improve the error message, but it's even better to just allow "no return value" to mean "everything is fine", i.e., presume success.  The C++ already does this with a `void` return value for the periodic event triggers; now Python accepts this as well, for all event triggers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17859)
<!-- Reviewable:end -->
