### PR TITLE
Suppress memcheck when VTK file reader compares header line with garbage

### DIFF
--- a/tools/dynamic_analysis/valgrind.supp
+++ b/tools/dynamic_analysis/valgrind.supp
@@ -231,3 +231,11 @@
    fun:_ZN19ClpSimplexNonlinear6primalEv
    fun:_ZN10ClpSimplex6primalEii
 }
+
+{
+   VTK: file reader compare header line vs garbage
+   Memcheck:Cond
+   fun:_ZN13vtkDataReader10ReadHeaderEPKc
+   ...
+   fun:_ZN5drake8geometry8internal19ReadVtkToVolumeMeshERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEd
+}


### PR DESCRIPTION
Fixed nightly CI problems found in 
https://drake-jenkins.csail.mit.edu/view/Production/job/linux-focal-clang-bazel-nightly-everything-valgrind-memcheck/209/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17863)
<!-- Reviewable:end -->
