### PR TITLE
[examples] Reduce smoke test time for hardware_sim demo

### DIFF
--- a/examples/hardware_sim/test/hardware_sim_test.py
+++ b/examples/hardware_sim/test/hardware_sim_test.py
@@ -30,7 +30,7 @@ class HardwareSimTest(unittest.TestCase):
             "drake/examples/hardware_sim/test/test_scenarios.yaml")
         self._default_extra = {
             # For our smoke test, exit fairly quickly.
-            "simulation_duration": 0.25,
+            "simulation_duration": 0.0625,
         }
 
     def _dict_to_single_line_yaml(self, *, data):


### PR DESCRIPTION
In Debug builds it was flirting with the 60s timeout.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17864)
<!-- Reviewable:end -->
