### PR TITLE
[visualization] Meschat 2D mode saved images now have have opaque backgrounds

### DIFF
--- a/bindings/pydrake/visualization/meldis.py
+++ b/bindings/pydrake/visualization/meldis.py
@@ -350,8 +350,9 @@ class Meldis:
     Refer to the pydrake.visualization.meldis module docs for details.
     """
 
-    def __init__(self, *, meshcat_host=None, meshcat_port=None):
-        # Bookkeeping for update throtting.
+    def __init__(self, *, meshcat_host=None, meshcat_port=None,
+                 flat_background=Rgba(1, 1, 1)):
+        # Bookkeeping for update throttling.
         self._last_update_time = time.time()
 
         # Bookkeeping for subscriptions, keyed by LCM channel name.
@@ -367,7 +368,8 @@ class Meldis:
 
         params = MeshcatParams(host=meshcat_host or "localhost",
                                port=meshcat_port,
-                               show_stats_plot=False)
+                               show_stats_plot=False,
+                               flat_background=flat_background)
         self.meshcat = Meshcat(params=params)
 
         default_viewer = _ViewerApplet(meshcat=self.meshcat,
@@ -534,8 +536,16 @@ def _main():
         "--idle-timeout", metavar="TIME", type=float, default=15*60,
         help="When no web browser has been connected for this many seconds,"
         " this program will automatically exit. Set to 0 to run indefinitely.")
+    parser.add_argument(
+        "--flat_background", action="store", nargs=3, type=float,
+        default=[1, 1, 1],
+        help="An RGB triple for specifying the flat background color. Values "
+             "must be in the range [0, 1]")
     args = parser.parse_args()
-    meldis = Meldis(meshcat_host=args.host, meshcat_port=args.port)
+    bg_rgb = Rgba(args.flat_background[0], args.flat_background[1],
+                  args.flat_background[2])
+    meldis = Meldis(meshcat_host=args.host, meshcat_port=args.port,
+                    flat_background=bg_rgb)
     if args.browser_new is not None:
         url = meldis.meshcat.web_url()
         webbrowser.open(url=url, new=args.browser_new)

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -1164,6 +1164,26 @@ class Meshcat::Impl {
         });
   }
 
+  void SetFlatBackground() {
+    // Setting the background visibility to false causes saved images to have
+    // a transparent background (which typically renders as black). This
+    // changes the background to a rgb-to-rgb gradient (as specified by the
+    // params).
+    const Rgba& bg = params_.flat_background;
+    const std::vector<double> bg_rgb{bg.r(), bg.g(), bg.b()};
+    SetProperty("/Background", "top_color", bg_rgb);
+    SetProperty("/Background", "bottom_color", bg_rgb);
+    SetProperty("/Background", "visible", true);
+  }
+
+  void SetGradientBackground() {
+    // Restore the default gradient. See meshcat.html
+    SetProperty("/Background", "top_color", std::vector<double>{.95, .95, 1.0});
+    SetProperty("/Background", "bottom_color",
+                std::vector<double>{.32, .32, .35});
+    SetProperty("/Background", "visible", true);
+  }
+
   // This function is public via the PIMPL.
   void Set2dRenderMode(const math::RigidTransformd& X_WC, double xmin,
                       double xmax, double ymin, double ymax) {
@@ -1181,7 +1201,7 @@ class Meshcat::Impl {
     SetProperty("/Cameras/default/rotated/<object>", "position",
                 std::vector<double>{0.0, 0.0, 0.0});
 
-    SetProperty("/Background", "visible", false);
+    SetFlatBackground();
     SetProperty("/Grid", "visible", false);
     SetProperty("/Axes", "visible", false);
   }
@@ -1195,7 +1215,8 @@ class Meshcat::Impl {
     // Lock orbit controls.
     SetProperty("/Cameras/default/rotated/<object>", "position",
                 std::vector<double>{0.0, 1.0, 3.0});
-    SetProperty("/Background", "visible", true);
+
+    SetGradientBackground();
     SetProperty("/Grid", "visible", true);
     SetProperty("/Axes", "visible", true);
   }
@@ -2111,6 +2132,10 @@ void Meshcat::SetProperty(std::string_view path, std::string property,
 void Meshcat::SetAnimation(const MeshcatAnimation& animation) {
   impl().SetAnimation(animation);
 }
+
+void Meshcat::SetFlatBackground() { impl().SetFlatBackground(); }
+
+void Meshcat::SetGradientBackground() { impl().SetGradientBackground(); }
 
 void Meshcat::Set2dRenderMode(const math::RigidTransformd& X_WC, double xmin,
                               double xmax, double ymin, double ymax) {

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -30,6 +30,7 @@ struct MeshcatParams {
     a->Visit(DRAKE_NVP(port));
     a->Visit(DRAKE_NVP(web_url_pattern));
     a->Visit(DRAKE_NVP(show_stats_plot));
+    a->Visit(DRAKE_NVP(flat_background));
   }
 
   /** Meshcat will listen only on the given hostname (e.g., "localhost").
@@ -63,6 +64,11 @@ struct MeshcatParams {
   user interface. This plot including realtime rate and WebGL render
   statistics. */
   bool show_stats_plot{true};
+
+  /** The background color to used as a "flat" background color. This is used
+   in the 2D render mode and by invoking Meshcat::SetFlatBackground().
+   N.B. The *alpha* channel is ignored by Meshcat. */
+  Rgba flat_background{1.0, 1.0, 1.0};
 };
 
 /** Provides an interface to %Meshcat (https://github.com/rdeits/meshcat).
@@ -362,6 +368,17 @@ class Meshcat {
    */
   void SetCamera(OrthographicCamera camera,
                  std::string path = "/Cameras/default/rotated");
+
+  /** Sets the background to be the "flat background" color specified in the
+   MeshcatParams. When capturing images from meshcat, prefer using this over
+   setting the "/Background" to invisible. Setting the "/Background" invisible
+   will cause the output images to have transparent backgrounds. That's good
+   for compositing, but bad if you just want the images to reflect what you see
+   in the viewer. */
+  void SetFlatBackground();
+
+  /** Sets the background to the default gradient color. */
+  void SetGradientBackground();
 
   /** Applies a number of settings to make Meshcat act as a 2D renderer. The
    camera is set to an orthographic camera with `X_WC` specifying the pose of

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -28,7 +28,9 @@ using math::RigidTransformd;
 using math::RotationMatrixd;
 
 int do_main() {
-  auto meshcat = std::make_shared<Meshcat>();
+  // Use a non-default 2d background color to make sure it gets fed through.
+  auto meshcat = std::make_shared<Meshcat>(
+      MeshcatParams{.flat_background = Rgba(0.5, 0.7, 0.8)});
 
   meshcat->SetObject("sphere", Sphere(.25), Rgba(1.0, 0, 0, 1));
   meshcat->SetTransform("sphere", RigidTransformd(Vector3d{-3, 0, 0}));
@@ -207,13 +209,18 @@ Open up your browser to the URL above.
   std::cout
       << "- The blue box should have disappeared\n"
       << "- The lights should have dimmed.\n"
-      << "- The background should have been disabled (it will appear white)"
+      << "- The background should have been disabled (it will appear white)\n"
+      << "  If you save an image, it will have a transparent background."
       << std::endl;
   std::cout << "[Press RETURN to continue]." << std::endl;
   std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
   meshcat->Delete();
-  std::cout << "- Everything else should have disappeared." << std::endl;
+  meshcat->SetFlatBackground();
+  std::cout << "- Everything else should have disappeared\n."
+            << "- The background will now be a sky blue color\n."
+            << "  Saved images will now have an opaque, sky blue background."
+            << std::endl;
 
   std::cout << "[Press RETURN to continue]." << std::endl;
   std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -865,7 +865,11 @@ GTEST_TEST(MeshcatTest, Set2dRenderMode) {
   EXPECT_FALSE(
       meshcat.GetPackedProperty("/Cameras/default/rotated/<object>", "position")
           .empty());
+  // This serves as in indirect test of SetFlatBackground().
   EXPECT_FALSE(meshcat.GetPackedProperty("/Background", "visible").empty());
+  EXPECT_FALSE(meshcat.GetPackedProperty("/Background", "top_color").empty());
+  EXPECT_FALSE(
+      meshcat.GetPackedProperty("/Background", "bottom_color").empty());
   EXPECT_FALSE(meshcat.GetPackedProperty("/Grid", "visible").empty());
   EXPECT_FALSE(meshcat.GetPackedProperty("/Axes", "visible").empty());
 }
@@ -881,7 +885,11 @@ GTEST_TEST(MeshcatTest, ResetRenderMode) {
   EXPECT_FALSE(
       meshcat.GetPackedProperty("/Cameras/default/rotated/<object>", "position")
           .empty());
+  // This serves as in indirect test of SetGradientBackground().
   EXPECT_FALSE(meshcat.GetPackedProperty("/Background", "visible").empty());
+  EXPECT_FALSE(meshcat.GetPackedProperty("/Background", "top_color").empty());
+  EXPECT_FALSE(
+      meshcat.GetPackedProperty("/Background", "bottom_color").empty());
   EXPECT_FALSE(meshcat.GetPackedProperty("/Grid", "visible").empty());
   EXPECT_FALSE(meshcat.GetPackedProperty("/Axes", "visible").empty());
 }


### PR DESCRIPTION
Previous behavior would toggle the background to when in 2D mode. In the 3D viewer, this produced a white background (because the clear color is apparently (1, 1, 1, 0) (note alpha value is zero). When screen captures are made, the resulting images have a completely transparent background (again, alpha = 0). In most applications, that transparent background turns into black.

This changes the following:

 - The behavior of explicitly setting "/Background", "visible", false remains unchanged.
 - Calling Set2dRenderMode() now has an opaque, (by default) white background. (The "opaque" is new.)
 - The user can change the background color for 2D render mode in the MeshcatParams.
 - The user can explicitly change the background color to the parameterized color (or back to the default gradient).

To consider:
 - Is this the right API? The flat background param facilitates the simple act of switching render modes, or setting an arbitrary background color that will survive image saving.
 - Should the newly provided APIs not admit the possibility of passing any color -- a color that hasn't been defined in the params?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17866)
<!-- Reviewable:end -->
