### PR TITLE
lcmtypes: Denote ordering for quaternion vectors

### DIFF
--- a/lcmtypes/lcmt_viewer_draw.lcm
+++ b/lcmtypes/lcmt_viewer_draw.lcm
@@ -7,6 +7,6 @@ struct lcmt_viewer_draw {
   int32_t num_links;
   string link_name[num_links];
   int32_t robot_num[num_links];
-  float position[num_links][3];
-  float quaternion[num_links][4];
+  float position[num_links][3];  // x, y, z
+  float quaternion[num_links][4];  // w, x, y, z
 }

--- a/lcmtypes/lcmt_viewer_geometry_data.lcm
+++ b/lcmtypes/lcmt_viewer_geometry_data.lcm
@@ -12,9 +12,9 @@ struct lcmt_viewer_geometry_data {
   const int8_t ELLIPSOID    = 6;
 
 
-  float position[3];
-  float quaternion[4];
-  float color[4];
+  float position[3];  // x, y, z
+  float quaternion[4];  // w, x, y, z
+  float color[4];  // r, g, b, a
 
   string string_data;
 


### PR DESCRIPTION
Also denote for position and color

Came across in #17848
Dunno how long these types will live, but useful and quick?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17867)
<!-- Reviewable:end -->
