### PR TITLE
[doc] Update macOS arm64 instructions

### DIFF
--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -13,37 +13,26 @@ integration. Any other configurations are provided on a best-effort basis.
 <!-- The minimum compiler versions should match those listed in both the root
      CMakeLists.txt and tools/workspace/cc/repository.bzl. -->
 
-| Operating System ⁽⁴⁾               | Architecture | Python   | Bazel | CMake | C/C++ Compiler ⁽⁵⁾             | Java                          |
+| Operating System ⁽³⁾               | Architecture | Python   | Bazel | CMake | C/C++ Compiler ⁽⁴⁾             | Java                          |
 |------------------------------------|--------------|----------|-------|-------|--------------------------------|-------------------------------|
-| Ubuntu 20.04 LTS (Focal Fossa)     | x86_64 ⁽¹⁾   | 3.8 ⁽³⁾  | 5.1   | 3.16  | GCC 9.3 (default) or Clang 12  | OpenJDK 11                    |
-| Ubuntu 22.04 LTS (Jammy Jellyfish) | x86_64 ⁽¹⁾   | 3.10 ⁽³⁾ | 5.1   | 3.22  | GCC 11.2 (default) or Clang 12 | OpenJDK 11                    |
-| macOS Big Sur (11)                 | x86_64 ⁽²⁾   | 3.10 ⁽³⁾ | 5.1   | 3.24  | Apple LLVM 12.0.5 (Xcode 12.5) | AdoptOpenJDK 16 (HotSpot JVM) |
-| macOS Monterey (12)                | x86_64 ⁽²⁾   | 3.10 ⁽³⁾ | 5.1   | 3.24  | Apple LLVM 13.0.0 (Xcode 13.1) | AdoptOpenJDK 16 (HotSpot JVM) |
-| macOS Monterey (12)                | arm64 ⁽²⁾    | 3.10 ⁽³⁾ | 5.1   | 3.24  | Apple LLVM 13.1.6 (Xcode 13.4) | AdoptOpenJDK 16 (HotSpot JVM) |
+| Ubuntu 20.04 LTS (Focal Fossa)     | x86_64       | 3.8 ⁽²⁾  | 5.1   | 3.16  | GCC 9.3 (default) or Clang 12  | OpenJDK 11                    |
+| Ubuntu 22.04 LTS (Jammy Jellyfish) | x86_64       | 3.10 ⁽²⁾ | 5.1   | 3.22  | GCC 11.2 (default) or Clang 12 | OpenJDK 11                    |
+| macOS Big Sur (11)                 | x86_64       | 3.10 ⁽²⁾ | 5.1   | 3.24  | Apple LLVM 12.0.5 (Xcode 12.5) | AdoptOpenJDK 16 (HotSpot JVM) |
+| macOS Monterey (12)                | x86_64       | 3.10 ⁽²⁾ | 5.1   | 3.24  | Apple LLVM 13.0.0 (Xcode 13.1) | AdoptOpenJDK 16 (HotSpot JVM) |
+| macOS Monterey (12)                | arm64 ⁽¹⁾    | 3.10 ⁽²⁾ | 5.1   | 3.24  | Apple LLVM 13.1.6 (Xcode 13.4) | AdoptOpenJDK 16 (HotSpot JVM) |
 
-⁽¹⁾ Drake Ubuntu builds assume support for Intel's AVX2 and FMA instructions,
-introduced with the Haswell architecture in 2013 with substantial performance
-improvements in the Broadwell architecture in 2014. Drake is compiled with
-`-march=broadwell` to exploit these instructions (that also works for Haswell
-machines). Drake can be used on older machines if necessary by building from
-source with that
-[flag](https://github.com/RobotLocomotion/drake/blob/77642cc9/math/BUILD.bazel#L288)
-removed.
+⁽¹⁾ For users running on Apple's newer arm64 hardware, you may run Drake in
+native arm64 mode when building from source. However, to use Drake's
+pre-compiled binaries, refer to [Running under Rosetta 2](/rosetta2.html) for
+instructions on running using x86_64 emulation.
 
-⁽²⁾ For users running on Apple's newer arm64 hardware, refer to
-[Running under Rosetta 2](/rosetta2.html)
-for instructions on running using x86_64 emulation.
-Building and running directly on arm64 is not yet supported; plans
-for any future arm64 support on macOS and/or Ubuntu are discussed in
-[issue #13514](https://github.com/RobotLocomotion/drake/issues/13514).
+⁽²⁾ CPython is the only Python implementation supported.
 
-⁽³⁾ CPython is the only Python implementation supported.
-
-⁽⁴⁾ Drake features that perform image rendering (e.g., camera simulation)
+⁽³⁾ Drake features that perform image rendering (e.g., camera simulation)
 require a working display server.  Most personal computers will have this
 already built in, but some cloud or docker environments may not.
 
-⁽⁵⁾ Drake requires a compiler running in C++17 or C++20 mode.
+⁽⁴⁾ Drake requires a compiler running in C++17 or C++20 mode.
 
 # Getting Drake
 

--- a/doc/_pages/installation.md
+++ b/doc/_pages/installation.md
@@ -14,40 +14,29 @@ notebooks. See the [Tutorials](/index.html#tutorials) page for details.
 The following table shows the configurations and platforms that Drake
 officially supports:
 
-| Operating System ⁽⁴⁾⁽⁵⁾            | Architecture | Python   |
-|------------------------------------|--------------|----------|
-| Ubuntu 20.04 LTS (Focal Fossa)     | x86_64 ⁽¹⁾   | 3.8 ⁽³⁾  |
-| Ubuntu 22.04 LTS (Jammy Jellyfish) | x86_64 ⁽¹⁾   | 3.10 ⁽³⁾ |
-| macOS Big Sur (11)                 | x86_64 ⁽²⁾   | 3.10 ⁽³⁾ |
-| macOS Monterey (12)                | x86_64 ⁽²⁾   | 3.10 ⁽³⁾ |
+| Operating System ⁽³⁾⁽⁴⁾            | Architecture          | Python   |
+|------------------------------------|-----------------------|----------|
+| Ubuntu 20.04 LTS (Focal Fossa)     | x86_64                | 3.8 ⁽²⁾  |
+| Ubuntu 22.04 LTS (Jammy Jellyfish) | x86_64                | 3.10 ⁽²⁾ |
+| macOS Big Sur (11)                 | x86_64                | 3.10 ⁽²⁾ |
+| macOS Monterey (12)                | x86_64 or arm64 ⁽¹⁾   | 3.10 ⁽²⁾ |
 
-⁽¹⁾ Drake Ubuntu builds assume support for Intel's AVX2 and FMA instructions,
-introduced with the Haswell architecture in 2013 with substantial performance
-improvements in the Broadwell architecture in 2014. Drake is compiled with
-`-march=broadwell` to exploit these instructions (that also works for Haswell
-machines). Drake can be used on older machines if necessary by building from
-source with that
-[flag](https://github.com/RobotLocomotion/drake/blob/77642cc9/math/BUILD.bazel#L288)
-removed.
+⁽¹⁾ For users running on Apple's newer arm64 hardware, to use Drake's
+pre-compiled releases refer to [Running under Rosetta 2](/rosetta2.html) for
+instructions on running using x86_64 emulation. Running natively on arm64 is
+currently only supported by [building Drake from source](/from_source.html).
 
-⁽²⁾ For users running on Apple's newer arm64 hardware, refer to
-[Running under Rosetta 2](/rosetta2.html)
-for instructions on running using x86_64 emulation.
-Building and running directly on arm64 is not yet supported; plans
-for any future arm64 support on macOS and/or Ubuntu are discussed in
-[issue #13514](https://github.com/RobotLocomotion/drake/issues/13514).
-
-⁽³⁾ CPython is the only Python implementation supported.
+⁽²⁾ CPython is the only Python implementation supported.
 Drake does not support the Python environment supplied by Anaconda. Before
 installing or using Drake, please `conda deactivate` (repeatedly, until even
 the conda base environment has been deactivated) such that none of the paths
 reported `which -a python python3` refer to conda.
 
-⁽⁴⁾ Drake features that perform image rendering (e.g., camera simulation)
+⁽³⁾ Drake features that perform image rendering (e.g., camera simulation)
 require a working display server.  Most personal computers will have this
 already built in, but some cloud or docker environments may not.
 
-⁽⁵⁾ Ubuntu 22.04 (Jammy Jellyfish) pre-built binaries are not yet available
+⁽⁴⁾ Ubuntu 22.04 (Jammy Jellyfish) pre-built binaries are not yet available
 for pip.
 
 Additionally, if you are compiling your own C++ code against Drake's C++ code
@@ -59,8 +48,7 @@ compiler as our releases:
 | Ubuntu 20.04 LTS (Focal Fossa)     | GCC 9.3                        |
 | Ubuntu 22.04 LTS (Jammy Jellyfish) | GCC 11.2                       |
 | macOS Big Sur (11)                 | Apple LLVM 12.0.5 (Xcode 12.5) |
-| macOS Monterey (12)                | Apple LLVM 13.0.0 (Xcode 13.1) |
-| macOS Monterey (12)                | Apple LLVM 13.1.6 (Xcode 13.4) |
+| macOS Monterey (12) on x86_64      | Apple LLVM 13.0.0 (Xcode 13.1) |
 
 ## Available Versions
 

--- a/doc/_pages/rosetta2.md
+++ b/doc/_pages/rosetta2.md
@@ -4,16 +4,15 @@ title: Running Drake on macOS ARM hardware via Rosetta 2
 
 # Overview
 
-Building or running Drake directly on arm64 is not yet supported; plans
-for any future arm64 support on macOS and/or Ubuntu are discussed in
-[issue #13514](https://github.com/RobotLocomotion/drake/issues/13514).
-
-In the meantime, running Drake using Apple's x86_64 emulation should work.
+For users running on Apple's newer arm64 hardware, to use Drake's pre-compiled
+releases you must run Drake's x86_64 binaries using Apple's Rosetta 2 emulation.
+Running natively on arm64 is currently only supported by [building Drake from
+source](/from_source.html).
 
 # Instructions
 
-To use Drake on Apple's newer ARM hardware, **you must do all of your work in
-an x86_64 shell**:
+To run pre-compiled Drake on Apple's newer arm64 hardware, **you must do all of
+your work in an x86_64 shell**:
 
 1. Use ``arch -x86_64 /bin/bash`` to obtain a shell.
 1. In that shell, run ``arch`` (with no arguments).


### PR DESCRIPTION
Also removes the "AVX2" disclaimer, which was obsolete as of #17760.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17868)
<!-- Reviewable:end -->
