### PR TITLE
[workspace] MOSEK on macOS arm64, determine_os now saves macos_arch_result

### DIFF
--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -131,9 +131,9 @@ GTEST_TEST(TestSOCP, MaximizeGeometricMeanTrivialProblem2) {
 
 GTEST_TEST(TestSOCP, SmallestEllipsoidCoveringProblem) {
   MosekSolver solver;
-  // Mosek 10 returns a solution that is accurate up to 1.2E-5 for this specific
+  // Mosek 10 returns a solution that is accurate up to 1.3E-5 for this specific
   // problem. Might need to change the tolerance when we upgrade Mosek.
-  SolveAndCheckSmallestEllipsoidCoveringProblems(solver, {}, 1.2E-5);
+  SolveAndCheckSmallestEllipsoidCoveringProblems(solver, {}, 1.3E-5);
 }
 
 GTEST_TEST(TestSemidefiniteProgram, TrivialSDP) {

--- a/tools/macos-arch-arm64.bazelrc
+++ b/tools/macos-arch-arm64.bazelrc
@@ -7,6 +7,3 @@ build --action_env=PATH=/opt/homebrew/bin:/usr/bin:/bin
 # to use x86 assembly code. Ideally, we should find a way to build it on ARM64
 # at which point we can re-enable IBEX and dReal.
 build --define NO_DREAL=ON
-
-# TODO(#17026) Mosek 10 is required for arm64.
-build:everything --define WITH_MOSEK=OFF

--- a/tools/workspace/gfortran/repository.bzl
+++ b/tools/workspace/gfortran/repository.bzl
@@ -45,8 +45,7 @@ def _gfortran_impl(repo_ctx):
             "-ldl",
             "-lgfortran",
         ]
-        arch_result = execute_or_fail(repo_ctx, ["/usr/bin/arch"])
-        if arch_result.stdout.strip() != "arm64":
+        if os_result.macos_arch_result != "arm64":
             linkopts.append("-lquadmath")
     else:
         libquadmath = "libquadmath{}".format(suffix)

--- a/tools/workspace/mosek/repository.bzl
+++ b/tools/workspace/mosek/repository.bzl
@@ -23,6 +23,7 @@ Argument:
 """
 
 load("@drake//tools/workspace:execute.bzl", "which")
+load("@drake//tools/workspace:os.bzl", "determine_os")
 
 def _impl(repository_ctx):
     # When these values are updated:
@@ -33,10 +34,15 @@ def _impl(repository_ctx):
     mosek_minor_version = 0
     mosek_patch_version = 18
 
-    if repository_ctx.os.name == "mac os x":
-        mosek_platform = "osx64x86"
-        sha256 = "e3de2b99e5ab27a7c37356a7fe88f0a42c53ec04aeaba70abe8b5971fbcfc150"  # noqa
-    elif repository_ctx.os.name == "linux":
+    os_result = determine_os(repository_ctx)
+    if os_result.is_macos:
+        if os_result.macos_arch_result == "arm64":
+            mosek_platform = "osxaarch64"
+            sha256 = "99518b88c3bfc27edc92775eada349f7dd232c7bf7aa1cb7a8620603e05a6a6d"  # noqa
+        else:
+            mosek_platform = "osx64x86"
+            sha256 = "e3de2b99e5ab27a7c37356a7fe88f0a42c53ec04aeaba70abe8b5971fbcfc150"  # noqa
+    elif os_result.is_ubuntu:
         mosek_platform = "linux64x86"
         sha256 = "f778f6e5560cdb8a3b5001cb51f40ccba9b3ef73da09406dcd3c1a870433eb34"  # noqa
     else:

--- a/tools/workspace/os.bzl
+++ b/tools/workspace/os.bzl
@@ -55,7 +55,8 @@ def _make_result(
         macos_release = None,
         ubuntu_release = None,
         is_wheel = False,
-        homebrew_prefix = None):
+        homebrew_prefix = None,
+        macos_arch_result = None):
     """Return a fully-populated struct result for determine_os, below."""
     is_macos = (macos_release != None) and not is_wheel
     is_macos_wheel = (macos_release != None) and is_wheel
@@ -81,6 +82,7 @@ def _make_result(
         ubuntu_release = ubuntu_release,
         macos_release = macos_release,
         homebrew_prefix = homebrew_prefix,
+        macos_arch_result = macos_arch_result,
     )
 
 def _determine_linux(repository_ctx):
@@ -169,7 +171,8 @@ def _determine_macos(repository_ctx):
 
     # Check which arch we should be using.
     arch_result = exec_using_which(repository_ctx, ["/usr/bin/arch"])
-    if arch_result.stdout.strip() == "arm64":
+    macos_arch_result = arch_result.stdout.strip()
+    if macos_arch_result == "arm64":
         homebrew_prefix = "/opt/homebrew"
     else:
         homebrew_prefix = "/usr/local"
@@ -178,8 +181,9 @@ def _determine_macos(repository_ctx):
     if macos_release in ["11", "12"]:
         return _make_result(
             macos_release = macos_release,
-            homebrew_prefix = homebrew_prefix,
             is_wheel = is_macos_wheel,
+            homebrew_prefix = homebrew_prefix,
+            macos_arch_result = macos_arch_result,
         )
 
     # Nothing matched.

--- a/tools/workspace/python/repository.bzl
+++ b/tools/workspace/python/repository.bzl
@@ -79,8 +79,7 @@ def repository_python_info(repository_ctx):
         # @drake//tools/py_toolchain:macos_py3_runtime
         python = repository_ctx.attr.macos_interpreter_path
         if not python:
-            arch_result = execute_or_fail(repository_ctx, ["/usr/bin/arch"])
-            if arch_result.stdout.strip() == "arm64":
+            if os_result.macos_arch_result == "arm64":
                 python = MACOS_ARM64_INTERPRETER_PATH
             else:
                 python = MACOS_I386_INTERPRETER_PATH


### PR DESCRIPTION
- MOSEK 10 is now available in drake.  Reverts #17269, relates to #17026.  Toward #17869.
- Increase tolerance slightly for SmallestEllipsoidCoveringProblem.
- Bazel function `determine_os` now stores the results of `/usr/bin/arch` in `macos_arch_result` variable.
    - See [slack discussion](https://drakedevelopers.slack.com/archives/C2PMBJVAN/p1662661515354779) on consolidating, `/usr/bin/arch` is called in `os.bzl` and `execute.bzl` (cyclic dependency prevents removing from `execute.bzl`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17870)
<!-- Reviewable:end -->
