### PR TITLE
[geometry/optimization] Fix preprocessing for GraphOfConvexSets

### DIFF
--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -308,13 +308,14 @@ std::set<EdgeId> GraphOfConvexSets::PreprocessShortestPath(
 
   int edge_count = 0;
   for (const auto& [edge_id, e] : edges_) {
-    outgoing_edges[e->u().id()].push_back(edge_count);
-    incoming_edges[e->v().id()].push_back(edge_count);
-
     // Turn off edges into source or out of target
     if (e->v().id() == source_id || e->u().id() == target_id) {
       unusable_edges.insert(edge_id);
+    } else {
+      outgoing_edges[e->u().id()].push_back(edge_count);
+      incoming_edges[e->v().id()].push_back(edge_count);
     }
+
     edge_count++;
   }
 
@@ -341,46 +342,55 @@ std::set<EdgeId> GraphOfConvexSets::PreprocessShortestPath(
     std::vector<int> Ev = Ev_in;
     Ev.insert(Ev.end(), Ev_out.begin(), Ev_out.end());
 
-    RowVectorXd A_flow(Ev.size());
-    A_flow << RowVectorXd::Ones(Ev_in.size()),
-        -1 * RowVectorXd::Ones(Ev_out.size());
-    VectorXDecisionVariable fv(Ev.size());
-    VectorXDecisionVariable gv(Ev.size());
-    for (size_t ii = 0; ii < Ev.size(); ++ii) {
-      fv(ii) = f(Ev[ii]);
-      gv(ii) = g(Ev[ii]);
-    }
+    if (Ev.size() > 0) {
+      RowVectorXd A_flow(Ev.size());
+      A_flow << RowVectorXd::Ones(Ev_in.size()),
+          -1 * RowVectorXd::Ones(Ev_out.size());
+      VectorXDecisionVariable fv(Ev.size());
+      VectorXDecisionVariable gv(Ev.size());
+      for (size_t ii = 0; ii < Ev.size(); ++ii) {
+        fv(ii) = f(Ev[ii]);
+        gv(ii) = g(Ev[ii]);
+      }
 
-    // Conservation of flow for f: ∑ f_in - ∑ f_out = -δ(is_source).
-    if (vertex_id == source_id) {
-      conservation_f.insert(
-          {vertex_id, prog.AddLinearEqualityConstraint(A_flow, -1, fv)});
-    } else {
-      conservation_f.insert(
-          {vertex_id, prog.AddLinearEqualityConstraint(A_flow, 0, fv)});
-    }
+      // Conservation of flow for f: ∑ f_in - ∑ f_out = -δ(is_source).
+      if (vertex_id == source_id) {
+        conservation_f.insert(
+            {vertex_id, prog.AddLinearEqualityConstraint(A_flow, -1, fv)});
+      } else {
+        conservation_f.insert(
+            {vertex_id, prog.AddLinearEqualityConstraint(A_flow, 0, fv)});
+      }
 
-    // Conservation of flow for g: ∑ g_in - ∑ g_out = δ(is_target).
-    if (vertex_id == target_id) {
-      conservation_g.insert(
-          {vertex_id, prog.AddLinearEqualityConstraint(A_flow, 1, gv)});
-    } else {
-      conservation_g.insert(
-          {vertex_id, prog.AddLinearEqualityConstraint(A_flow, 0, gv)});
+      // Conservation of flow for g: ∑ g_in - ∑ g_out = δ(is_target).
+      if (vertex_id == target_id) {
+        conservation_g.insert(
+            {vertex_id, prog.AddLinearEqualityConstraint(A_flow, 1, gv)});
+      } else {
+        conservation_g.insert(
+            {vertex_id, prog.AddLinearEqualityConstraint(A_flow, 0, gv)});
+      }
     }
 
     // Degree constraints (redundant if indegree of w is 0):
     // 0 <= ∑ f_in + ∑ g_in <= 1
-    RowVectorXd A_degree = RowVectorXd::Ones(2 * Ev_in.size());
-    VectorXDecisionVariable fgin(2 * Ev_in.size());
-    for (size_t ii = 0; ii < Ev_in.size(); ++ii) {
-      fgin(ii) = f(Ev_in[ii]);
-      fgin(Ev_in.size() + ii) = g(Ev_in[ii]);
+    if (Ev_in.size() > 0) {
+      RowVectorXd A_degree = RowVectorXd::Ones(2 * Ev_in.size());
+      VectorXDecisionVariable fgin(2 * Ev_in.size());
+      for (size_t ii = 0; ii < Ev_in.size(); ++ii) {
+        fgin(ii) = f(Ev_in[ii]);
+        fgin(Ev_in.size() + ii) = g(Ev_in[ii]);
+      }
+      degree.insert(
+          {vertex_id, prog.AddLinearConstraint(A_degree, 0, 1, fgin)});
     }
-    degree.insert({vertex_id, prog.AddLinearConstraint(A_degree, 0, 1, fgin)});
   }
 
   for (const auto& [edge_id, e] : edges_) {
+    if (unusable_edges.count(edge_id)) {
+      continue;
+    }
+
     // Update bounds of conservation of flow:
     // ∑ f_in,u - ∑ f_out,u = 1 - δ(is_source).
     if (e->u().id() == source_id) {
@@ -628,8 +638,7 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
   for (const auto& [edge_id, e] : edges_) {
     // If an edge is turned off (ϕ = 0) or excluded by preprocessing, don't
     // include it in the optimization.
-    if (!e->phi_value_.value_or(true) ||
-        unusable_edges.find(edge_id) != unusable_edges.end()) {
+    if (!e->phi_value_.value_or(true) || unusable_edges.count(edge_id)) {
       // Track excluded edges (ϕ = 0 and preprocessed) so that their variables
       // can be set in the optimization result.
       excluded_edges.emplace_back(e.get());

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -33,8 +33,10 @@ struct GraphOfConvexSetsOptions {
 
   /** Performs a preprocessing step to remove edges that cannot lie on the
   path from source to target. In most cases, preprocessing causes a net
-  reduction in computation by reducing the size of the optimization solved. */
-  bool preprocessing{true};
+  reduction in computation by reducing the size of the optimization solved.
+  Note that this preprocessing is not exact. There may be edges that cannot
+  lie on the path from source to target that this does not detect. */
+  bool preprocessing{false};
 
   /** Optimizer to be used to solve the shortest path optimization problem. If
   not set, the best solver for the given problem is selected. Note that if the

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -823,7 +823,7 @@ class ThreeBoxes : public ::testing::Test {
     subs_on_off_.emplace(e_on_->xv()[0], e_off_->xv()[0]);
     subs_on_off_.emplace(e_on_->xv()[1], e_off_->xv()[1]);
 
-    options.preprocessing = false;
+    options.preprocessing = true;
   }
 
   GraphOfConvexSets g_;
@@ -1149,21 +1149,21 @@ class PreprocessShortestPathTest : public ::testing::Test {
     }
 
     edges_.reserve(13);
-    edges_[0] = g_.AddEdge(vid_[0], vid_[2]);
-    edges_[1] = g_.AddEdge(vid_[2], vid_[3]);
-    edges_[2] = g_.AddEdge(vid_[2], vid_[4]);
-    edges_[3] = g_.AddEdge(vid_[3], vid_[4]);
-    edges_[4] = g_.AddEdge(vid_[4], vid_[3]);
-    edges_[5] = g_.AddEdge(vid_[3], vid_[5]);
-    edges_[6] = g_.AddEdge(vid_[4], vid_[5]);
+    edges_.push_back(g_.AddEdge(vid_[0], vid_[2]));
+    edges_.push_back(g_.AddEdge(vid_[2], vid_[3]));
+    edges_.push_back(g_.AddEdge(vid_[2], vid_[4]));
+    edges_.push_back(g_.AddEdge(vid_[3], vid_[4]));
+    edges_.push_back(g_.AddEdge(vid_[4], vid_[3]));
+    edges_.push_back(g_.AddEdge(vid_[3], vid_[5]));
+    edges_.push_back(g_.AddEdge(vid_[4], vid_[5]));
     // Useless backtracking edges
-    edges_[7] = g_.AddEdge(vid_[3], vid_[2]);
-    edges_[8] = g_.AddEdge(vid_[5], vid_[4]);
+    edges_.push_back(g_.AddEdge(vid_[3], vid_[2]));
+    edges_.push_back(g_.AddEdge(vid_[5], vid_[4]));
     // Useless nodes off source and target
-    edges_[9] = g_.AddEdge(vid_[0], vid_[1]);
-    edges_[10] = g_.AddEdge(vid_[1], vid_[0]);
-    edges_[11] = g_.AddEdge(vid_[5], vid_[6]);
-    edges_[12] = g_.AddEdge(vid_[6], vid_[5]);
+    edges_.push_back(g_.AddEdge(vid_[0], vid_[1]));
+    edges_.push_back(g_.AddEdge(vid_[1], vid_[0]));
+    edges_.push_back(g_.AddEdge(vid_[5], vid_[6]));
+    edges_.push_back(g_.AddEdge(vid_[6], vid_[5]));
 
     for (Edge* e : edges_) {
       e->AddCost(1.0);
@@ -1210,7 +1210,8 @@ TEST_F(PreprocessShortestPathTest, CheckResults) {
                                 result2.GetSolution(e->xu()), 1e-12));
     EXPECT_TRUE(CompareMatrices(result1.GetSolution(e->xv()),
                                 result2.GetSolution(e->xv()), 1e-12));
-    EXPECT_EQ(e->GetSolutionCost(result1), e->GetSolutionCost(result2));
+    EXPECT_NEAR(e->GetSolutionCost(result1), e->GetSolutionCost(result2),
+                1e-12);
   }
 }
 
@@ -1386,10 +1387,7 @@ GTEST_TEST(ShortestPathTest, Figure9) {
     e->AddCost(solvers::Binding(cost, {e->xu(), e->xv()}));
   }
 
-  GraphOfConvexSetsOptions options;
-  options.preprocessing = false;
-
-  auto result = spp.SolveShortestPath(source->id(), target->id(), options);
+  auto result = spp.SolveShortestPath(source->id(), target->id());
   ASSERT_TRUE(result.is_success());
 
   const double kTol = 2e-4;  // Gurobi required this large tolerance.
@@ -1413,7 +1411,7 @@ GTEST_TEST(ShortestPathTest, Graphviz) {
   g.AddEdge(*source, *target, "edge");
 
   GraphOfConvexSetsOptions options;
-  options.preprocessing = false;
+  options.preprocessing = true;
 
   // Note: Testing the entire string against a const string is too fragile,
   // since the VertexIds are Identifier<> and increment on a global counter.


### PR DESCRIPTION
Re-enables preprocessing in the tests changed in #17855 and fixes a bug with the preprocessing tests.
Fix to #17397 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17876)
<!-- Reviewable:end -->
