### PR TITLE
[perception] Implement PointCloud::VoxelizedDownSample

### DIFF
--- a/bindings/pydrake/perception_py.cc
+++ b/bindings/pydrake/perception_py.cc
@@ -120,7 +120,9 @@ void init_perception(py::module m) {
             },
             py::arg("other"), cls_doc.SetFrom.doc)
         .def("Crop", &Class::Crop, py::arg("lower_xyz"), py::arg("upper_xyz"),
-            cls_doc.Crop.doc);
+            cls_doc.Crop.doc)
+        .def("VoxelizedDownSample", &Class::VoxelizedDownSample,
+            py::arg("voxel_size"), cls_doc.VoxelizedDownSample.doc);
   }
 
   AddValueInstantiation<PointCloud>(m);

--- a/bindings/pydrake/test/perception_test.py
+++ b/bindings/pydrake/test/perception_test.py
@@ -91,6 +91,9 @@ class TestPerception(unittest.TestCase):
         pc_merged = mut.Concatenate(clouds=[pc, pc_new])
         self.assertEqual(pc_merged.size(), pc.size() + pc_new.size())
 
+        pc_downsampled = pc_merged.VoxelizedDownSample(voxel_size=2.0)
+        self.assertIsInstance(pc_downsampled, mut.PointCloud)
+
     def test_depth_image_to_point_cloud_api(self):
         camera_info = CameraInfo(width=640, height=480, fov_y=np.pi / 4)
         dut = mut.DepthImageToPointCloud(camera_info=camera_info)

--- a/perception/BUILD.bazel
+++ b/perception/BUILD.bazel
@@ -35,9 +35,13 @@ drake_cc_library(
     name = "point_cloud",
     srcs = ["point_cloud.cc"],
     hdrs = ["point_cloud.h"],
-    deps = [
+    interface_deps = [
         ":point_cloud_flags",
         "//common:essential",
+    ],
+    deps = [
+        "//common:unused",
+        "@abseil_cpp_internal//absl/container:flat_hash_map",
     ],
 )
 

--- a/perception/point_cloud.h
+++ b/perception/point_cloud.h
@@ -238,11 +238,11 @@ class PointCloud final {
 
   /// Returns access to a descriptor value.
   /// @pre `has_descriptors()` must be true.
-  VectorX<T> descriptor(int i) const { return descriptors().col(i); }
+  VectorX<D> descriptor(int i) const { return descriptors().col(i); }
 
   /// Returns mutable access to a descriptor value.
   /// @pre `has_descriptors()` must be true.
-  Eigen::Ref<VectorX<T>> mutable_descriptor(int i) {
+  Eigen::Ref<VectorX<D>> mutable_descriptor(int i) {
     return mutable_descriptors().col(i);
   }
 
@@ -318,6 +318,17 @@ class PointCloud final {
 
   // TODO(eric.cousineau): Add mechanism for handling organized / unorganized
   // point clouds.
+
+  /// Returns a down-sampled point cloud by grouping all xyzs in this cloud
+  /// into a 3D grid with cells of dimension voxel_size. Each occupied voxel
+  /// will result in one point in the downsampled cloud, with a location
+  /// corresponding to the centroid of the points in that voxel. Points with
+  /// non-finite xyz values are ignored. All other fields (e.g. rgbs, normals,
+  /// and descriptors) with finite values will also be averaged across the
+  /// points in a voxel.
+  /// @throws std::exception if has_xyzs() is false.
+  /// @throws std::exception if voxel_size <= 0.
+  PointCloud VoxelizedDownSample(double voxel_size) const;
 
  private:
   void SetDefault(int start, int num);


### PR DESCRIPTION
Provide a simple, narrow, no-frills implementation of the voxel_down_sample algorithm in Open3d and/or the down-sampling by a VoxelGrid filter in PCL.

Towards https://github.com/RussTedrake/manipulation/issues/130.

+@calderpg-tri for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17885)
<!-- Reviewable:end -->
