### PR TITLE
[install] Add mirrors to bazel acceptance test

### DIFF
--- a/tools/install/bazel/test/drake_bazel_installed_test.py
+++ b/tools/install/bazel/test/drake_bazel_installed_test.py
@@ -19,7 +19,10 @@ def main():
     # The commit (version) here should be identical to the commit listed in
     # drake/tools/workspace/rules_python/repository.bzl.
     rules_python_commit = "0.10.2"
-    rules_python_url = f"https://github.com/bazelbuild/rules_python/archive/{rules_python_commit}.tar.gz"  # noqa
+    rules_python_urls = [
+        f"https://github.com/bazelbuild/rules_python/archive/{rules_python_commit}.tar.gz",  # noqa
+        f"https://drake-mirror.csail.mit.edu/github/bazelbuild/rules_python/{rules_python_commit}.tar.gz",  # noqa
+    ]
     rules_python_sha256 = "a3a6e99f497be089f81ec082882e40246bfd435f52f4e82f37e89449b04573f6"  # noqa
 
     with open(join(scratch_dir, "WORKSPACE"), "w") as f:
@@ -34,7 +37,7 @@ http_archive(
     name = "rules_python",
     sha256 = "{rules_python_sha256}",
     strip_prefix = "rules_python-{rules_python_commit}",
-    url = "{rules_python_url}",
+    urls = {rules_python_urls!r},
 )
 
 new_local_repository(


### PR DESCRIPTION
The github.com URL occasionally flakes out, leading to spurious test failures.

Manually tested by re-running the test while commenting out each of the other URLs in turn.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17891)
<!-- Reviewable:end -->
