### PR TITLE
[hardware_sim] Adding perception cameras to hardware sim

### DIFF
--- a/examples/hardware_sim/BUILD.bazel
+++ b/examples/hardware_sim/BUILD.bazel
@@ -25,6 +25,7 @@ drake_cc_library(
         "//multibody/plant:multibody_plant_config",
         "//multibody/parsing:model_directives",
         "//systems/analysis:simulator_config",
+        "//systems/sensors:camera_config",
         "//visualization:visualization_config",
     ],
     deps = [
@@ -47,6 +48,7 @@ drake_cc_binary(
         "//systems/analysis:simulator",
         "//systems/analysis:simulator_config_functions",
         "//systems/lcm:lcm_config_functions",
+        "//systems/sensors:camera_config_functions",
         "//visualization:visualization_config_functions",
     ],
 )

--- a/examples/hardware_sim/example_scenarios.yaml
+++ b/examples/hardware_sim/example_scenarios.yaml
@@ -18,6 +18,12 @@ Demo:
   - add_weld:
       parent: iiwa_on_world
       child: iiwa::base
+  cameras:
+    oracular_view:
+      name: camera_0
+      X_PB:
+        translation: [1.5, 0.8, 1.25]
+        rotation: !Rpy { deg: [-120, 5, 125] }
   model_drivers:
     iiwa: !ZeroForceDriver {}
     wsg: !SchunkWsgDriver {}

--- a/examples/hardware_sim/hardware_sim.cc
+++ b/examples/hardware_sim/hardware_sim.cc
@@ -11,6 +11,7 @@ while some (separate) controller operates the robot, without extra hassle. */
 
 #include <gflags/gflags.h>
 
+#include "drake/common/unused.h"
 #include "drake/examples/hardware_sim/scenario.h"
 #include "drake/manipulation/schunk_wsg/schunk_wsg_driver_functions.h"
 #include "drake/manipulation/util/apply_driver_configs.h"
@@ -22,6 +23,7 @@ while some (separate) controller operates the robot, without extra hassle. */
 #include "drake/systems/analysis/simulator_config_functions.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/lcm/lcm_config_functions.h"
+#include "drake/systems/sensors/camera_config_functions.h"
 #include "drake/visualization/visualization_config_functions.h"
 
 DEFINE_string(scenario_file, "",
@@ -49,6 +51,7 @@ using systems::DiagramBuilder;
 using systems::Simulator;
 using systems::lcm::ApplyLcmBusConfig;
 using systems::lcm::LcmBuses;
+using systems::sensors::ApplyCameraConfig;
 using visualization::ApplyVisualizationConfig;
 
 /* Class that holds the configuration and data of a simulation. */
@@ -92,6 +95,13 @@ void Simulation::Setup() {
   // Add actuation inputs.
   ApplyDriverConfigs(scenario_.model_drivers, sim_plant, added_models,
                      lcm_buses, &builder);
+
+  // Add scene cameras.
+  DrakeLcmInterface* camera_lcm = lcm_buses.Find("Cameras", "default");
+  for (const auto& [yaml_name, camera] : scenario_.cameras) {
+    unused(yaml_name);
+    ApplyCameraConfig(camera, &sim_plant, &builder, &scene_graph, camera_lcm);
+  }
 
   // Add visualization.
   ApplyVisualizationConfig(scenario_.visualization, &builder, &lcm_buses);

--- a/examples/hardware_sim/scenario.h
+++ b/examples/hardware_sim/scenario.h
@@ -14,6 +14,7 @@
 #include "drake/multibody/parsing/model_directives.h"
 #include "drake/multibody/plant/multibody_plant_config.h"
 #include "drake/systems/analysis/simulator_config.h"
+#include "drake/systems/sensors/camera_config.h"
 #include "drake/visualization/visualization_config.h"
 
 namespace drake {
@@ -31,6 +32,7 @@ struct Scenario {
     a->Visit(DRAKE_NVP(directives));
     a->Visit(DRAKE_NVP(lcm_buses));
     a->Visit(DRAKE_NVP(model_drivers));
+    a->Visit(DRAKE_NVP(cameras));
     a->Visit(DRAKE_NVP(visualization));
   }
 
@@ -67,6 +69,12 @@ struct Scenario {
       manipulation::schunk_wsg::SchunkWsgDriver,
       manipulation::ZeroForceDriver>;
   std::map<std::string, DriverVariant> model_drivers;
+
+  /* Cameras to add to the scene (and broadcast over LCM). The key for each
+   camera is a helpful mnemonic, but does not serve a technical role. The
+   CameraConfig::name field is still the name that will appear in the Diagram
+   artifacts. */
+  std::map<std::string, systems::sensors::CameraConfig> cameras;
 
   visualization::VisualizationConfig visualization;
 };

--- a/examples/hardware_sim/test/test_scenarios.yaml
+++ b/examples/hardware_sim/test/test_scenarios.yaml
@@ -18,6 +18,9 @@ OneOfEverything:
     extra_bus: {}
   model_drivers:
     alice: !ZeroForceDriver {}
+  cameras:
+    arbitrary_camera_name:
+      name: camera_0
   visualization:
     lcm_bus: extra_bus
     publish_period: 0.125


### PR DESCRIPTION
Add the newly integrated `CameraConfig` into hardware sim. Also add an instance to the `OneOfEverything` test.

NOTE: the images produced by the hardware sim demo are *not* visible in `drake_visualizer`. The channel they are broadcast on is not the exact channel that `drake_visualizer` listens on for images.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17893)
<!-- Reviewable:end -->
