### PR TITLE
[workspace] Fix MOSEK wheel support for archive URLs

### DIFF
--- a/tools/workspace/mosek/repository.bzl
+++ b/tools/workspace/mosek/repository.bzl
@@ -35,14 +35,14 @@ def _impl(repository_ctx):
     mosek_patch_version = 18
 
     os_result = determine_os(repository_ctx)
-    if os_result.is_macos:
+    if os_result.is_macos or os_result.is_macos_wheel:
         if os_result.macos_arch_result == "arm64":
             mosek_platform = "osxaarch64"
             sha256 = "99518b88c3bfc27edc92775eada349f7dd232c7bf7aa1cb7a8620603e05a6a6d"  # noqa
         else:
             mosek_platform = "osx64x86"
             sha256 = "e3de2b99e5ab27a7c37356a7fe88f0a42c53ec04aeaba70abe8b5971fbcfc150"  # noqa
-    elif os_result.is_ubuntu:
+    elif os_result.is_ubuntu or os_result.is_manylinux:
         mosek_platform = "linux64x86"
         sha256 = "f778f6e5560cdb8a3b5001cb51f40ccba9b3ef73da09406dcd3c1a870433eb34"  # noqa
     else:


### PR DESCRIPTION
Followup to #17870 which broke the macOS and linux wheel builds. Closes #17900.

From [slack #buildcop discussion](https://drakedevelopers.slack.com/archives/C270MN28G/p1663076706005239).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17901)
<!-- Reviewable:end -->
