### PR TITLE
Revert "[geometry/optimization] Fix preprocessing for GraphOfConvexSets"

### DIFF
--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -33,10 +33,8 @@ struct GraphOfConvexSetsOptions {
 
   /** Performs a preprocessing step to remove edges that cannot lie on the
   path from source to target. In most cases, preprocessing causes a net
-  reduction in computation by reducing the size of the optimization solved.
-  Note that this preprocessing is not exact. There may be edges that cannot
-  lie on the path from source to target that this does not detect. */
-  bool preprocessing{false};
+  reduction in computation by reducing the size of the optimization solved. */
+  bool preprocessing{true};
 
   /** Optimizer to be used to solve the shortest path optimization problem. If
   not set, the best solver for the given problem is selected. Note that if the

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -823,7 +823,7 @@ class ThreeBoxes : public ::testing::Test {
     subs_on_off_.emplace(e_on_->xv()[0], e_off_->xv()[0]);
     subs_on_off_.emplace(e_on_->xv()[1], e_off_->xv()[1]);
 
-    options.preprocessing = true;
+    options.preprocessing = false;
   }
 
   GraphOfConvexSets g_;
@@ -1149,21 +1149,21 @@ class PreprocessShortestPathTest : public ::testing::Test {
     }
 
     edges_.reserve(13);
-    edges_.push_back(g_.AddEdge(vid_[0], vid_[2]));
-    edges_.push_back(g_.AddEdge(vid_[2], vid_[3]));
-    edges_.push_back(g_.AddEdge(vid_[2], vid_[4]));
-    edges_.push_back(g_.AddEdge(vid_[3], vid_[4]));
-    edges_.push_back(g_.AddEdge(vid_[4], vid_[3]));
-    edges_.push_back(g_.AddEdge(vid_[3], vid_[5]));
-    edges_.push_back(g_.AddEdge(vid_[4], vid_[5]));
+    edges_[0] = g_.AddEdge(vid_[0], vid_[2]);
+    edges_[1] = g_.AddEdge(vid_[2], vid_[3]);
+    edges_[2] = g_.AddEdge(vid_[2], vid_[4]);
+    edges_[3] = g_.AddEdge(vid_[3], vid_[4]);
+    edges_[4] = g_.AddEdge(vid_[4], vid_[3]);
+    edges_[5] = g_.AddEdge(vid_[3], vid_[5]);
+    edges_[6] = g_.AddEdge(vid_[4], vid_[5]);
     // Useless backtracking edges
-    edges_.push_back(g_.AddEdge(vid_[3], vid_[2]));
-    edges_.push_back(g_.AddEdge(vid_[5], vid_[4]));
+    edges_[7] = g_.AddEdge(vid_[3], vid_[2]);
+    edges_[8] = g_.AddEdge(vid_[5], vid_[4]);
     // Useless nodes off source and target
-    edges_.push_back(g_.AddEdge(vid_[0], vid_[1]));
-    edges_.push_back(g_.AddEdge(vid_[1], vid_[0]));
-    edges_.push_back(g_.AddEdge(vid_[5], vid_[6]));
-    edges_.push_back(g_.AddEdge(vid_[6], vid_[5]));
+    edges_[9] = g_.AddEdge(vid_[0], vid_[1]);
+    edges_[10] = g_.AddEdge(vid_[1], vid_[0]);
+    edges_[11] = g_.AddEdge(vid_[5], vid_[6]);
+    edges_[12] = g_.AddEdge(vid_[6], vid_[5]);
 
     for (Edge* e : edges_) {
       e->AddCost(1.0);
@@ -1210,8 +1210,7 @@ TEST_F(PreprocessShortestPathTest, CheckResults) {
                                 result2.GetSolution(e->xu()), 1e-12));
     EXPECT_TRUE(CompareMatrices(result1.GetSolution(e->xv()),
                                 result2.GetSolution(e->xv()), 1e-12));
-    EXPECT_NEAR(e->GetSolutionCost(result1), e->GetSolutionCost(result2),
-                1e-12);
+    EXPECT_EQ(e->GetSolutionCost(result1), e->GetSolutionCost(result2));
   }
 }
 
@@ -1387,7 +1386,10 @@ GTEST_TEST(ShortestPathTest, Figure9) {
     e->AddCost(solvers::Binding(cost, {e->xu(), e->xv()}));
   }
 
-  auto result = spp.SolveShortestPath(source->id(), target->id());
+  GraphOfConvexSetsOptions options;
+  options.preprocessing = false;
+
+  auto result = spp.SolveShortestPath(source->id(), target->id(), options);
   ASSERT_TRUE(result.is_success());
 
   const double kTol = 2e-4;  // Gurobi required this large tolerance.
@@ -1411,7 +1413,7 @@ GTEST_TEST(ShortestPathTest, Graphviz) {
   g.AddEdge(*source, *target, "edge");
 
   GraphOfConvexSetsOptions options;
-  options.preprocessing = true;
+  options.preprocessing = false;
 
   // Note: Testing the entire string against a const string is too fragile,
   // since the VertexIds are Identifier<> and increment on a global counter.


### PR DESCRIPTION
Reverts RobotLocomotion/drake#17876.

Dear @mpetersen94 ,

 The on-call build cop, @svenevs , believes that your PR #17876  may have
 broken one or more of Drake's continuous integration builds [1]. It is
 possible to break a build even if your PR passed continuous integration
 pre-merge because additional platforms are tested post-merge.

 The specific build failures under investigation are:

- https://drake-jenkins.csail.mit.edu/job/linux-focal-clang-bazel-weekly-mosek-address-sanitizer/33/consoleFull

```
[6:44:40 PM]  geometry/optimization/test/graph_of_convex_sets_test.cc:1214: Failure
[6:44:40 PM]  The difference between e->GetSolutionCost(result1) and e->GetSolutionCost(result2) is 3.8959502290936143e-11, which exceeds 1e-12, where
[6:44:40 PM]  e->GetSolutionCost(result1) evaluates to 3.8959502290936143e-11,
[6:44:40 PM]  e->GetSolutionCost(result2) evaluates to -0, and
[6:44:40 PM]  1e-12 evaluates to 9.9999999999999998e-13.
[6:44:40 PM]  geometry/optimization/test/graph_of_convex_sets_test.cc:1212: Failure
[6:44:40 PM]  Value of: CompareMatrices(result1.GetSolution(e->xv()), result2.GetSolution(e->xv()), 1e-12)
[6:44:40 PM]    Actual: false (NaN mismatch at (0, 0):
[6:44:40 PM]  m1 =
[6:44:40 PM]  0
[6:44:40 PM]  m2 =
[6:44:40 PM]  nan)
```

 Therefore, the build cop has created this revert PR and started a complete
 post-merge build to determine whether your PR was in fact the cause of the
 problem. If that build passes, this revert PR will be merged 60 minutes from
 now. You can then fix the problem at your leisure, and send a new PR to
 reinstate your change.

 If you believe your original PR did not actually break the build, please
 explain on this thread.

 If you believe you can fix the break promptly in lieu of a revert, please
 explain on this thread, and send a PR to the build cop for review ASAP.

 If you believe your original PR definitely did break the build and should be
 reverted, please review and LGTM this PR. This allows the build cop to merge
 without waiting for CI results.

 For advice on how to handle a build cop revert, see [2].

 Thanks!
 Your Friendly On-call Build Cop

 [1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
 [2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17912)
<!-- Reviewable:end -->
