### PR TITLE
[perception] Implement PointCloud::EstimateNormals

### DIFF
--- a/bindings/pydrake/perception_py.cc
+++ b/bindings/pydrake/perception_py.cc
@@ -122,7 +122,9 @@ void init_perception(py::module m) {
         .def("Crop", &Class::Crop, py::arg("lower_xyz"), py::arg("upper_xyz"),
             cls_doc.Crop.doc)
         .def("VoxelizedDownSample", &Class::VoxelizedDownSample,
-            py::arg("voxel_size"), cls_doc.VoxelizedDownSample.doc);
+            py::arg("voxel_size"), cls_doc.VoxelizedDownSample.doc)
+        .def("EstimateNormals", &Class::EstimateNormals, py::arg("radius"),
+            py::arg("num_closest"), cls_doc.EstimateNormals.doc);
   }
 
   AddValueInstantiation<PointCloud>(m);

--- a/bindings/pydrake/test/perception_test.py
+++ b/bindings/pydrake/test/perception_test.py
@@ -94,6 +94,10 @@ class TestPerception(unittest.TestCase):
         pc_downsampled = pc_merged.VoxelizedDownSample(voxel_size=2.0)
         self.assertIsInstance(pc_downsampled, mut.PointCloud)
 
+        self.assertFalse(pc_merged.has_normals())
+        pc_merged.EstimateNormals(radius=1, num_closest=50)
+        self.assertTrue(pc_merged.has_normals())
+
     def test_depth_image_to_point_cloud_api(self):
         camera_info = CameraInfo(width=640, height=480, fov_y=np.pi / 4)
         dut = mut.DepthImageToPointCloud(camera_info=camera_info)

--- a/perception/BUILD.bazel
+++ b/perception/BUILD.bazel
@@ -41,6 +41,7 @@ drake_cc_library(
     ],
     deps = [
         "//common:unused",
+        "@nanoflann_internal//:nanoflann",
     ],
 )
 
@@ -90,6 +91,7 @@ drake_cc_googletest(
     name = "point_cloud_test",
     deps = [
         ":point_cloud",
+        "//common:random",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_no_throw",
     ],

--- a/perception/point_cloud.h
+++ b/perception/point_cloud.h
@@ -330,6 +330,23 @@ class PointCloud final {
   /// @throws std::exception if voxel_size <= 0.
   PointCloud VoxelizedDownSample(double voxel_size) const;
 
+  /// Estimates the normal vectors in `this` by fitting a plane at each point
+  /// in the cloud using up to `num_closest` points within Euclidean distance
+  /// `radius` from the point. If has_normals() is false, then new normals will
+  /// be allocated (and has_normals() will become true). Points for which the
+  /// normals cannot be estimated (because the `this` has less than two closest
+  /// points within the @p radius), will receive normal [NaN, NaN, NaN].
+  /// Normals estimated from two closest points will be orthogonal to the
+  /// vector between those points, but can be arbitrary in the last
+  /// dimension.
+  ///
+  /// @returns true iff all points were assigned normals by having at least
+  /// *three* closest points within @p radius.
+  ///
+  /// @pre @p radius > 0 and @p num_closest >= 3.
+  /// @throws std::exception if has_xyzs() is false.
+  bool EstimateNormals(double radius, int num_closest);
+
  private:
   void SetDefault(int start, int num);
 
@@ -339,7 +356,7 @@ class PointCloud final {
   // Represents the size of the point cloud.
   int size_{};
   // Represents which fields are enabled for this point cloud.
-  const pc_flags::Fields fields_{pc_flags::kXYZs};
+  pc_flags::Fields fields_{pc_flags::kXYZs};
   // Owns storage used for the point cloud.
   std::unique_ptr<Storage> storage_;
 };

--- a/perception/test/point_cloud_test.cc
+++ b/perception/test/point_cloud_test.cc
@@ -1,15 +1,16 @@
 #include "drake/perception/point_cloud.h"
 
-#include <iostream>
 #include <stdexcept>
 
 #include <gtest/gtest.h>
 
+#include "drake/common/random.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 
 using Eigen::Matrix3Xf;
 using Eigen::Matrix4Xf;
+using Eigen::Vector3f;
 
 using ::testing::AssertionResult;
 using ::testing::AssertionSuccess;
@@ -381,10 +382,7 @@ GTEST_TEST(PointCloudTest, VoxelizedDownSample) {
         double kTol = 1e-8;
         bool found_match = false;
         int i = 0;
-        std::cout << xyz.transpose() << std::endl;
         for (; i < down_sampled.size(); ++i) {
-          std::cout << i << ": " << down_sampled.xyz(i).transpose()
-                    << std::endl;
           if (CompareMatrices(down_sampled.xyz(i), xyz.cast<float>(), kTol)) {
             found_match = true;
             break;
@@ -407,9 +405,108 @@ GTEST_TEST(PointCloudTest, VoxelizedDownSample) {
   cloud.mutable_xyz(3)[0] = std::numeric_limits<float>::quiet_NaN();
   cloud.mutable_xyz(4)[1] = std::numeric_limits<float>::infinity();
 
+  // Check that voxels with only NaN normals still return NaN.
+  cloud.mutable_normal(0)[1] = std::numeric_limits<float>::quiet_NaN();
+
   down_sampled = cloud.VoxelizedDownSample(1.0);
   EXPECT_EQ(down_sampled.size(), 3);
   CheckHasPointAveragedFrom({5});
+
+  // Check the NaN normal obtained from cloud index 0.
+  bool found_match_for_cloud_0 = false;
+  for (int i = 0; i < down_sampled.size(); ++i) {
+    if (down_sampled.xyz(i) == cloud.xyz(0)) {
+      // Confirm that the normal is now [nan, nan, nan].
+      EXPECT_TRUE(down_sampled.normal(i).array().isNaN().all());
+      found_match_for_cloud_0 = true;
+    }
+  }
+  EXPECT_TRUE(found_match_for_cloud_0);
+}
+
+// Checks that normal has unit magnitude and that normal == expected up to a
+// sign flip.
+void CheckNormal(const Eigen::Ref<const Eigen::Vector3f>& normal,
+                 const Eigen::Ref<const Eigen::Vector3f>& expected,
+                 double tolerance) {
+  EXPECT_NEAR(normal.norm(), 1.0, tolerance)
+      << "Normal " << normal << " does not have unit length.";
+  EXPECT_NEAR(std::abs(normal.dot(expected)), 1.0, tolerance)
+      << "normal.dot(expected) = " << normal.dot(expected);
+}
+
+// Test that point clouds that consist of three points (defining a plane)
+// get estimated normals that match their closed-form solution.
+GTEST_TEST(PointCloudTest, EstimateNormalsPlane) {
+  PointCloud cloud(3);
+
+  cloud.mutable_xyzs().transpose() << 0, 0, 0, 0, 0, 1, 0, 1, 1;
+
+  EXPECT_FALSE(cloud.has_normals());
+  cloud.EstimateNormals(10, 3);
+  EXPECT_TRUE(cloud.has_normals());
+
+  double kTol = 1e-6;
+  for (int i = 0; i < 3; ++i) {
+    CheckNormal(cloud.normal(i), Vector3f{1, 0, 0}, kTol);
+  }
+
+  cloud.mutable_xyzs().transpose() << 0, 0, 0, 1, 0, 0, 1, 0, 1;
+
+  cloud.EstimateNormals(10, 3);
+  for (int i = 0; i < 3; ++i) {
+    CheckNormal(cloud.normal(i), Vector3f{0, 1, 0}, kTol);
+  }
+
+  cloud.mutable_xyzs().transpose() << 0, 0, 0, 1, 0, 0, 0, 1, 1;
+  cloud.EstimateNormals(10, 3);
+  for (int i = 0; i < 3; ++i) {
+    CheckNormal(cloud.normal(i),
+                Vector3f{0, 1.0 / std::sqrt(2.0), -1.0 / std::sqrt(2.0)}, kTol);
+  }
+}
+
+// Test that points uniformly randomly distributed on the surface of the sphere
+// get normals close to the true normal of the sphere.
+GTEST_TEST(PointCloudTest, EstimateNormalsSphere) {
+  const int kSize{10000};
+  PointCloud cloud(kSize);
+
+  // Sample from a Gaussian and project it onto the sphere.
+  RandomGenerator generator(1234);
+  std::normal_distribution<double> distribution(0, 1.0);
+  for (int i = 0; i < 3 * kSize; ++i) {
+    cloud.mutable_xyzs().data()[i] = distribution(generator);
+  }
+  for (int i = 0; i < kSize; ++i) {
+    cloud.mutable_xyz(i).normalize();
+  }
+
+  cloud.EstimateNormals(0.1, 30);
+
+  double kTol = 1e-3;  // This will be loose unless kSize gets very large.
+  for (int i = 0; i < kSize; ++i) {
+    CheckNormal(cloud.normal(i), cloud.xyz(i), kTol);
+  }
+}
+
+// Tests that you can compute normals with just two neighbors; the normal is
+// ambiguous, but the computed normal will at least be orthogonal.
+GTEST_TEST(PointCloudTest, EstimateNormalsTwoPoints) {
+  PointCloud cloud(2);
+  // clang-format off
+  cloud.mutable_xyzs().transpose() <<
+    0, 0, 0,
+    1, 1, 0;
+  // clang-format on
+  cloud.EstimateNormals(10, 3);
+
+  double kTolerance = 1e-6;
+  for (int i = 0; i < 2; ++i) {
+    EXPECT_NEAR(cloud.normal(i).norm(), 1.0, kTolerance);
+    EXPECT_NEAR(cloud.normal(i).dot(cloud.xyz(1) - cloud.xyz(0)), 0.0,
+                kTolerance);
+  }
 }
 
 }  // namespace

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -90,6 +90,7 @@ _DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "meshcat_python",
     "msgpack_lite_js",
     "net_sf_jchart2d",
+    "nanoflann_internal",
     "nlopt_internal",
     "org_apache_xmlgraphics_commons",
     "petsc",

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -63,6 +63,7 @@ load("@drake//tools/workspace/msgpack:repository.bzl", "msgpack_repository")
 load("@drake//tools/workspace/msgpack_lite_js:repository.bzl", "msgpack_lite_js_repository")  # noqa
 load("@drake//tools/workspace/mypy_extensions_internal:repository.bzl", "mypy_extensions_internal_repository")  # noqa
 load("@drake//tools/workspace/mypy_internal:repository.bzl", "mypy_internal_repository")  # noqa
+load("@drake//tools/workspace/nanoflann_internal:repository.bzl", "nanoflann_internal_repository")  # noqa
 load("@drake//tools/workspace/net_sf_jchart2d:repository.bzl", "net_sf_jchart2d_repository")  # noqa
 load("@drake//tools/workspace/nlopt:repository.bzl", "nlopt_repository")
 load("@drake//tools/workspace/nlopt_internal:repository.bzl", "nlopt_internal_repository")  # noqa
@@ -277,6 +278,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         mypy_extensions_internal_repository(name = "mypy_extensions_internal", mirrors = mirrors)  # noqa
     if "mypy_internal" not in excludes:
         mypy_internal_repository(name = "mypy_internal", mirrors = mirrors)
+    if "nanoflann_internal" not in excludes:
+        nanoflann_internal_repository(name = "nanoflann_internal", mirrors = mirrors)  # noqa
     if "net_sf_jchart2d" not in excludes:
         net_sf_jchart2d_repository(name = "net_sf_jchart2d", mirrors = mirrors)
     if "nlopt" not in excludes:

--- a/tools/workspace/nanoflann_internal/BUILD.bazel
+++ b/tools/workspace/nanoflann_internal/BUILD.bazel
@@ -1,0 +1,5 @@
+# -*- python -*-
+
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/workspace/nanoflann_internal/package.BUILD.bazel
+++ b/tools/workspace/nanoflann_internal/package.BUILD.bazel
@@ -1,0 +1,24 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/install:install.bzl",
+    "install",
+)
+
+licenses(["notice"])  # BSD
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "nanoflann",
+    hdrs = ["include/nanoflann.hpp"],
+    include_prefix = "drake_vendor",
+    strip_include_prefix = "include",
+    linkstatic = 1,
+)
+
+# Install the license file.
+install(
+    name = "install",
+    docs = ["COPYING"],
+)

--- a/tools/workspace/nanoflann_internal/patches/namespace.patch
+++ b/tools/workspace/nanoflann_internal/patches/namespace.patch
@@ -1,0 +1,21 @@
+Add a drake_vendor namespace ala tools/workspace/vendor_cxx
+
+This prevents link-time symbol conflicts in case code downstream of
+Drake wants to use a different build of nanoflann.
+
+--- include/nanoflann.hpp.orig
++++ include/nanoflann.hpp
+@@ -70,6 +70,7 @@
+ #endif
+ #endif
+ 
++inline namespace drake_vendor __attribute__ ((visibility ("hidden"))) {
+ namespace nanoflann
+ {
+ /** @addtogroup nanoflann_grp nanoflann C++ library for ANN
+@@ -2414,3 +2415,4 @@
+ 
+ /** @} */  // end of grouping
+ }  // namespace nanoflann
++}  // namespace drake_vendor
+\ No newline at end of file

--- a/tools/workspace/nanoflann_internal/repository.bzl
+++ b/tools/workspace/nanoflann_internal/repository.bzl
@@ -1,0 +1,18 @@
+# -*- python -*-
+
+load("@drake//tools/workspace:github.bzl", "github_archive")
+
+def nanoflann_internal_repository(
+        name,
+        mirrors = None):
+    github_archive(
+        name = name,
+        repository = "jlblancoc/nanoflann",
+        commit = "v1.4.3",
+        sha256 = "cbcecf22bec528a8673a113ee9b0e134f91f1f96be57e913fa1f74e98e4449fa",  # noqa
+        build_file = ":package.BUILD.bazel",
+        patches = [
+            ":patches/namespace.patch",
+        ],
+        mirrors = mirrors,
+    )


### PR DESCRIPTION
Adds nanoflann as a (header-only) dependency, and implements the basic normal estimation algorithm for PointCloud, as seen in PCL and/or Open3d.

Towards https://github.com/RussTedrake/manipulation/issues/130.

+@jwnimmer-tri for feature review of the changes underneath `//tools`, please
+@calderpg-tri for feature review of the changes NOT underneath `//tools`, please

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17914)
<!-- Reviewable:end -->
