### PR TITLE
Fix C++20 errors on macOS

### DIFF
--- a/bindings/pydrake/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry_py_scene_graph.cc
@@ -510,7 +510,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     auto cls = DefineTemplateClassWithDefault<Class>(
         m, "PenetrationAsPointPair", param, doc.PenetrationAsPointPair.doc);
     cls  // BR
-        .def(ParamInit<Class>(), doc.PenetrationAsPointPair.ctor.doc)
+        .def(ParamInit<Class>())
         .def_readwrite("id_A", &PenetrationAsPointPair<T>::id_A,
             doc.PenetrationAsPointPair.id_A.doc)
         .def_readwrite("id_B", &PenetrationAsPointPair<T>::id_B,

--- a/common/test/eigen_types_test.cc
+++ b/common/test/eigen_types_test.cc
@@ -220,8 +220,10 @@ GTEST_TEST(EigenTypesTest, FixedSizeVector) {
 GTEST_TEST(EigenTypesTest, LikewiseStorageOrder) {
   using LikewiseCol = MatrixLikewise<float, Vector3<double>>;
   using LikewiseRow = MatrixLikewise<float, RowVector3<double>>;
-  EXPECT_EQ(LikewiseCol::Options & Eigen::ColMajor, Eigen::ColMajor);
-  EXPECT_EQ(LikewiseRow::Options & Eigen::RowMajor, Eigen::RowMajor);
+  EXPECT_EQ(static_cast<int>(LikewiseCol::Options) & Eigen::ColMajor,
+            Eigen::ColMajor);
+  EXPECT_EQ(static_cast<int>(LikewiseRow::Options) & Eigen::RowMajor,
+            Eigen::RowMajor);
 }
 
 }  // namespace

--- a/doc/_pages/installation.md
+++ b/doc/_pages/installation.md
@@ -43,12 +43,12 @@ Additionally, if you are compiling your own C++ code against Drake's C++ code
 and are using Drake's pre-compiled binaries, then you must use the same
 compiler as our releases:
 
-| Operating System                   | C/C++ Compiler                 |
-|------------------------------------|--------------------------------|
-| Ubuntu 20.04 LTS (Focal Fossa)     | GCC 9.3                        |
-| Ubuntu 22.04 LTS (Jammy Jellyfish) | GCC 11.2                       |
-| macOS Big Sur (11)                 | Apple LLVM 12.0.5 (Xcode 12.5) |
-| macOS Monterey (12) on x86_64      | Apple LLVM 13.0.0 (Xcode 13.1) |
+| Operating System                   | C/C++ Compiler                 | Std   |
+|------------------------------------|--------------------------------|-------|
+| Ubuntu 20.04 LTS (Focal Fossa)     | GCC 9.3                        | C++17 |
+| Ubuntu 22.04 LTS (Jammy Jellyfish) | GCC 11.2                       | C++17 |
+| macOS Big Sur (11)                 | Apple LLVM 12.0.5 (Xcode 12.5) | C++17 |
+| macOS Monterey (12) on x86_64      | Apple LLVM 13.0.0 (Xcode 13.1) | C++17 |
 
 ## Available Versions
 

--- a/geometry/query_results/penetration_as_point_pair.h
+++ b/geometry/query_results/penetration_as_point_pair.h
@@ -2,7 +2,6 @@
 
 #include <utility>
 
-#include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_ids.h"
 
@@ -23,9 +22,6 @@ namespace geometry {
  @tparam T The underlying scalar type. Must be a valid Eigen scalar. */
 template <typename T>
 struct PenetrationAsPointPair {
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PenetrationAsPointPair)
-  PenetrationAsPointPair() = default;
-
   /** Swaps the interpretation of geometries A and B. */
   void SwapAAndB() {
     // Leave depth unchanged.

--- a/manipulation/kuka_iiwa/iiwa_driver.h
+++ b/manipulation/kuka_iiwa/iiwa_driver.h
@@ -16,9 +16,6 @@ role that driver software and control cabinets would take in real life.
 It creates an LCM publisher on the `IIWA_STATUS` channel and an LCM subscriber
 on the `IIWA_COMMAND` channel. */
 struct IiwaDriver {
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(IiwaDriver)
-  IiwaDriver() = default;
-
   /** The name of the model (`name` element of the `add_model` directive) in
   the simulation that the driver will analyze to compute end effector inertia
   for its copy of the arm in inverse dynamics. */

--- a/manipulation/schunk_wsg/schunk_wsg_driver.h
+++ b/manipulation/schunk_wsg/schunk_wsg_driver.h
@@ -18,9 +18,6 @@ role that driver software and control cabinets would take in real life.
 It creates an LCM publisher on the `SCHUNK_WSG_STATUS` channel and an LCM
 subscriber on the `SCHUNK_WSG_COMMAND` channel. */
 struct SchunkWsgDriver {
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SchunkWsgDriver)
-  SchunkWsgDriver() = default;
-
   /** Gains to apply to the the WSG fingers.  The p term corresponds
   approximately to the elastic modulus of the belt, the d term to the viscous
   friction of the geartrain.  The i term is nonphysical. */


### PR DESCRIPTION
Fix deprecated-anon-enum-enum-conversion warning.
Fix aggregate initialization for C++20 semantics.
Add placeholder documentation for the C++ version we use.

Towards #14670.

We'd like to ensure that Drake's users who build in C++20 mode don't receive any errors.  In order to get that covered by CI, the plan is to build Ubuntu 20.04 in C++17 mode (unchanged), but to upgrade Ubuntu 22.04 and macOS to C++20 mode.  This PR handles the macOS side of that change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17918)
<!-- Reviewable:end -->
