### PR TITLE
[tutorials] Remove now-unnecessary EventStatus

### DIFF
--- a/tutorials/dynamical_systems.ipynb
+++ b/tutorials/dynamical_systems.ipynb
@@ -126,7 +126,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pydrake.systems.framework import LeafSystem, EventStatus\n",
+    "from pydrake.systems.framework import LeafSystem\n",
     "\n",
     "# Define the system.\n",
     "class SimpleContinuousTimeSystem(LeafSystem):\n",
@@ -163,7 +163,6 @@
     "        x = context.get_discrete_state_vector().GetAtIndex(0)\n",
     "        xnext = x**3\n",
     "        discrete_state.get_mutable_vector().SetAtIndex(0, xnext)\n",
-    "        return EventStatus.Succeeded()\n",
     "\n",
     "# Instantiate the System\n",
     "discrete_system = SimpleDiscreteTimeSystem()"


### PR DESCRIPTION
Follow-up from https://github.com/RobotLocomotion/drake/pull/17859#issuecomment-1247463948.

(This was the only non-test-coverage EventStatus.Succeeded in all of Drake.)