### PR TITLE
[workspace] Disable int128 support for absl

### DIFF
--- a/tools/workspace/abseil_cpp_internal/patches/disable_int128_on_clang.patch
+++ b/tools/workspace/abseil_cpp_internal/patches/disable_int128_on_clang.patch
@@ -1,0 +1,15 @@
+Disable __int128 in Clang which triggers linker error under UBSan.
+See https://bugs.llvm.org/show_bug.cgi?id=16404
+
+--- absl/base/config.h
++++ absl/base/config.h
+@@ -317,8 +317,7 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
+ #ifdef ABSL_HAVE_INTRINSIC_INT128
+ #error ABSL_HAVE_INTRINSIC_INT128 cannot be directly set
+ #elif defined(__SIZEOF_INT128__)
+-#if (defined(__clang__) && !defined(_WIN32)) || \
+-    (defined(__CUDACC__) && __CUDACC_VER_MAJOR__ >= 9) ||                \
++#if (defined(__CUDACC__) && __CUDACC_VER_MAJOR__ >= 9) ||                \
+     (defined(__GNUC__) && !defined(__clang__) && !defined(__CUDACC__))
+ #define ABSL_HAVE_INTRINSIC_INT128 1
+ #elif defined(__CUDACC__)

--- a/tools/workspace/abseil_cpp_internal/repository.bzl
+++ b/tools/workspace/abseil_cpp_internal/repository.bzl
@@ -10,6 +10,7 @@ def abseil_cpp_internal_repository(
         commit = "518984e432e0597fd4e66a9c52148e8dec2bb46a",
         sha256 = "91f28c15ed3af1efe963eba665241a0aeeb1c36e6dab0affb0f81109469bf1be",  # noqa
         patches = [
+            ":patches/disable_int128_on_clang.patch",
             ":patches/hidden_visibility.patch",
             ":patches/inline_namespace.patch",
         ],


### PR DESCRIPTION
Hotfix for #17885 to resolve UBSan linker/loader errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17921)
<!-- Reviewable:end -->
