### PR TITLE
[perception] Fixed link error reported by thread sanitizer

### DIFF
--- a/perception/BUILD.bazel
+++ b/perception/BUILD.bazel
@@ -41,7 +41,6 @@ drake_cc_library(
     ],
     deps = [
         "//common:unused",
-        "@abseil_cpp_internal//absl/container:flat_hash_map",
     ],
 )
 

--- a/perception/point_cloud.cc
+++ b/perception/point_cloud.cc
@@ -2,10 +2,10 @@
 
 #include <algorithm>
 #include <functional>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
-#include "absl/container/flat_hash_map.h"
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
@@ -419,7 +419,7 @@ PointCloud PointCloud::VoxelizedDownSample(double voxel_size) const {
   }
 
   // Create a map from voxel coordinate to a set of points.
-  absl::flat_hash_map<Eigen::Vector3i, std::vector<int>, Vector3iHash>
+  std::unordered_map<Eigen::Vector3i, std::vector<int>, Vector3iHash>
       voxel_map;
   for (int i = 0; i < size_; ++i) {
     if (xyz(i).array().isFinite().all()) {


### PR DESCRIPTION
- Test case:
```
bazel test --config=clang --compilation_mode=dbg --config=tsan \
                   //tools/install/libdrake:drake_shared_library_test
```
- The link error was introduced by absl/container:flat_hash_map as reported by https://drake-cdash.csail.mit.edu/viewBuildError.php?buildid=1633056
- Use std::unordered_map instead (advice from Jeremy Nimmer).

Slack chat: https://drakedevelopers.slack.com/archives/C270MN28G/p1663249102991329

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17925)
<!-- Reviewable:end -->
