### PR TITLE
[config] Allow specification of render engine type in CameraConfig

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -300,6 +300,7 @@ drake_cc_library(
         ":geometry_state",
         ":scene_graph_inspector",
         "//common:essential",
+        "//common:nice_type_name",
         "//geometry/query_results:contact_surface",
         "//geometry/query_results:penetration_as_point_pair",
         "//geometry/query_results:signed_distance_pair",

--- a/geometry/render_gl/factory.cc
+++ b/geometry/render_gl/factory.cc
@@ -8,6 +8,10 @@ namespace drake {
 namespace geometry {
 namespace render {
 
+// Definition of extern bool in factory.h. When we build against *this* .cc file
+// RenderEngineGl is always available.
+const bool kHasRenderEngineGl = true;
+
 std::unique_ptr<RenderEngine> MakeRenderEngineGl(RenderEngineGlParams params) {
   return std::make_unique<internal::RenderEngineGl>(std::move(params));
 }

--- a/geometry/render_gl/factory.h
+++ b/geometry/render_gl/factory.h
@@ -9,9 +9,12 @@ namespace drake {
 namespace geometry {
 namespace render {
 
+/** Reports the availability of the RenderEngineGl implementation. */
+extern const bool kHasRenderEngineGl;
+
 /** Constructs a RenderEngine implementation which uses a purely OpenGL
  renderer. The engine only works under Ubuntu. If called on a Mac, it will
- produce a "dummy" implementation.
+ throw.
 
  @note %RenderEngineGl behaves a bit differently from other RenderEngine
  implementations (e.g., RenderEngineVtk) with respect to displayed images.
@@ -24,7 +27,9 @@ namespace render {
 
  @warning %RenderEngineGl is not threadsafe. If a SceneGraph is instantiated
  with a RenderEngineGl and there are multiple Context instances for that
- SceneGraph, rendering in multiple threads may exhibit issues.  */
+ SceneGraph, rendering in multiple threads may exhibit issues.
+
+ @throws std::exception if kHasRenderEngineGl is false. */
 std::unique_ptr<RenderEngine> MakeRenderEngineGl(
     RenderEngineGlParams params = {});
 

--- a/geometry/render_gl/no_factory.cc
+++ b/geometry/render_gl/no_factory.cc
@@ -5,6 +5,10 @@ namespace drake {
 namespace geometry {
 namespace render {
 
+// Definition of extern bool in factory.h. When we build against *this* .cc file
+// RenderEngineGl is not available.
+const bool kHasRenderEngineGl = false;
+
 std::unique_ptr<RenderEngine> MakeRenderEngineGl(RenderEngineGlParams) {
   throw std::runtime_error(
       "RenderEngineGl was not compiled. You'll need to use a different render "

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -7,6 +7,7 @@
 #include <fmt/format.h>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/nice_type_name.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/geometry_state.h"
 #include "drake/systems/framework/context.h"
@@ -255,6 +256,16 @@ void SceneGraph<T>::AddRenderer(
 template <typename T>
 bool SceneGraph<T>::HasRenderer(const std::string& name) const {
   return model_.HasRenderer(name);
+}
+
+template <typename T>
+std::string SceneGraph<T>::GetRendererTypeName(const std::string& name) const {
+  const render::RenderEngine* engine = model_.GetRenderEngineByName(name);
+  if (engine == nullptr) {
+    return {};
+  }
+
+  return NiceTypeName::Get(*engine);
 }
 
 template <typename T>

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -652,9 +652,17 @@ class SceneGraph final : public systems::LeafSystem<T> {
   void AddRenderer(std::string name,
                    std::unique_ptr<render::RenderEngine> renderer);
 
-  /** Reports if this %SceneGraph has a renderer registered to the given name.
-   */
+  /** Reports true if this %SceneGraph has a renderer registered with the given
+   name. */
   bool HasRenderer(const std::string& name) const;
+
+  /** Reports the type name for the RenderEngine registered with the given
+   `name`.
+
+   @returns the name of the RenderEngine's most derived type (as produced by
+            NiceTypeName::Get()). An empty string if there is no RenderEngine
+            registered with the given `name`. */
+  std::string GetRendererTypeName(const std::string& name) const;
 
   /** Reports the number of renderers registered to this %SceneGraph.  */
   int RendererCount() const;

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -6,6 +6,7 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
+#include "drake/common/nice_type_name.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/geometry_frame.h"
@@ -497,6 +498,22 @@ TEST_F(SceneGraphTest, RendererSmokeTest) {
   EXPECT_EQ(scene_graph_.RendererCount(), 1);
   EXPECT_EQ(scene_graph_.RegisteredRendererNames()[0], kRendererName);
   EXPECT_TRUE(scene_graph_.HasRenderer(kRendererName));
+}
+
+// Query the type name of a render engine. This logic is unique to SceneGraph
+// so we test it here.
+TEST_F(SceneGraphTest, GetRendererTypeName) {
+  const std::string kRendererName = "bob";
+
+  DRAKE_EXPECT_NO_THROW(scene_graph_.AddRenderer(
+      kRendererName, make_unique<DummyRenderEngine>()));
+
+  // If no renderer has the name, the type doesn't matter.
+  EXPECT_EQ(scene_graph_.GetRendererTypeName("non-existent"), "");
+
+  // Get the expected name.
+  EXPECT_EQ(scene_graph_.GetRendererTypeName(kRendererName),
+            NiceTypeName::Get<DummyRenderEngine>());
 }
 
 // SceneGraph provides a thin wrapper on the GeometryState role manipulation

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -97,6 +97,7 @@ drake_cc_library(
         ":rgbd_sensor",
         ":sim_rgbd_sensor",
         "//geometry:scene_graph",
+        "//geometry/render_gl",
         "//geometry/render_vtk",
         "//lcm:interface",
         "//math:geometric_transform",
@@ -346,6 +347,7 @@ drake_cc_googletest(
         ":camera_config_functions",
         "//common/test_utilities:expect_throws_message",
         "//common/yaml:yaml_io",
+        "//geometry/render_gl",
     ],
 )
 

--- a/systems/sensors/camera_config.cc
+++ b/systems/sensors/camera_config.cc
@@ -128,6 +128,15 @@ void CameraConfig::ValidateOrThrow() const {
     child.ValidateOrThrow();
   }, focal);
 
+  if (!renderer_class.empty() && !(renderer_class == "RenderEngineVtk" ||
+                                   renderer_class == "RenderEngineGl")) {
+    throw std::logic_error(fmt::format(
+        "Invalid camera configuration; the given renderer_class value '{}' "
+        "must be empty (to use the default) or be one of 'RenderEngineVtk' or "
+        "'RenderEngineGl'.",
+        renderer_class));
+  }
+
   // This throws for us if we have bad bad numerical camera values (or an empty
   // renderer_name).
   MakeCameras();

--- a/systems/sensors/camera_config.h
+++ b/systems/sensors/camera_config.h
@@ -49,6 +49,7 @@ struct CameraConfig {
     a->Visit(DRAKE_NVP(X_BC));
     a->Visit(DRAKE_NVP(X_BD));
     a->Visit(DRAKE_NVP(renderer_name));
+    a->Visit(DRAKE_NVP(renderer_class));
     a->Visit(DRAKE_NVP(background));
     a->Visit(DRAKE_NVP(name));
     a->Visit(DRAKE_NVP(fps));
@@ -243,6 +244,22 @@ struct CameraConfig {
    value.
    @pre `renderer_name` is not empty. */
   std::string renderer_name{"default"};
+
+  /** The choice of render engine implementation to use. The value should be
+   one of empty, '"RenderEngineVtk"', or '"RenderEngineGl"'. An `empty` string
+   signals, in essence, "don't care". If a render engine with that name has
+   already been configured, the camera will use it (regardless of type). If
+   the name doesn't already exist, the default, slower, more portable, and more
+   robust RenderEngineVtk will be instantiated. RenderEngineGl can be selected
+   if you are on Ubuntu and need the improved performance (at the *possible*
+   cost of lesser image fidelity).
+
+   @pre `renderer_class` is empty or one of '"RenderEngineVtk"' or
+        '"RenderEngineGl"'.
+   @pre For two cameras with the same `renderer_name` value, they must also
+        specify the same `renderer_class` (either implicitly or explicitly).
+   @sa drake::geometry::SceneGraph::GetRendererTypeName(). */
+  std::string renderer_class;
 
   /** The "background" color. This is the color drawn where there are no objects
    visible. Its default value matches the default value for

--- a/systems/sensors/camera_config_functions.cc
+++ b/systems/sensors/camera_config_functions.cc
@@ -1,9 +1,16 @@
 #include "drake/systems/sensors/camera_config_functions.h"
 
+#include <initializer_list>
+#include <map>
 #include <string>
 
+#include <fmt/format.h>
+
 #include "drake/common/eigen_types.h"
+#include "drake/common/never_destroyed.h"
+#include "drake/common/nice_type_name.h"
 #include "drake/geometry/render/render_camera.h"
+#include "drake/geometry/render_gl/factory.h"
 #include "drake/geometry/render_vtk/factory.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/parsing/scoped_names.h"
@@ -16,6 +23,8 @@ namespace sensors {
 
 using drake::lcm::DrakeLcmInterface;
 using Eigen::Vector3d;
+using geometry::render::MakeRenderEngineGl;
+using geometry::render::RenderEngineGlParams;
 using geometry::MakeRenderEngineVtk;
 using geometry::RenderEngineVtkParams;
 using geometry::SceneGraph;
@@ -29,16 +38,85 @@ using multibody::Frame;
 using multibody::MultibodyPlant;
 using multibody::parsing::GetScopedFrameByName;
 
+namespace {
+
+// Validates the render engine specification in `config`. If the specification
+// is valid, upon return, the specified RenderEngine is defined in `scene_graph`
+// (this may require creating the RenderEngine instance). Throws if the
+// specification is invalid.
+// @pre we already know that config.renderer_class has a "supported" value.
+void ValidateEngineAndMaybeAdd(const CameraConfig& config,
+                               SceneGraph<double>* scene_graph) {
+  using Dict = std::map<std::string, std::string>;
+  static const never_destroyed<Dict> type_lookup(
+      std::initializer_list<Dict::value_type>{
+          {"RenderEngineVtk", "drake::geometry::render::RenderEngineVtk"},
+          {"RenderEngineGl",
+           "drake::geometry::render::internal::RenderEngineGl"}});
+
+  DRAKE_DEMAND(scene_graph != nullptr);
+
+  // Querying for the type_name of the named renderer will simultaneously tell
+  // if a render engine already exists (non-empty value) *and* give us a string
+  // to match against config.renderer_class.
+  const std::string type_name =
+      scene_graph->GetRendererTypeName(config.renderer_name);
+
+  // Non-empty type name says that it already exists.
+  bool already_exists = !type_name.empty();
+  if (already_exists && !config.renderer_class.empty()) {
+    if (type_lookup.access().at(config.renderer_class) != type_name) {
+      throw std::logic_error(
+          fmt::format("Invalid camera configuration; requested "
+                      "renderer_name = '{}' and renderer_class = '{}'. The "
+                      "name is already used with a different type: {}.",
+                      config.renderer_name, config.renderer_class, type_name));
+    }
+  }
+
+  if (already_exists) return;
+
+  // Now we know we need to add one. Confirm we can add the specified class.
+  if (config.renderer_class == "RenderEngineGl") {
+    if (!geometry::render::kHasRenderEngineGl) {
+      throw std::logic_error(
+          "Invalid camera configuration; renderer_class = 'RenderEngineGl' "
+          "is not supported in current build.");
+    }
+    RenderEngineGlParams params{.default_clear_color = config.background};
+    scene_graph->AddRenderer(config.renderer_name,
+                              MakeRenderEngineGl(params));
+    return;
+  }
+  // Note: if we add *other* supported render engine implementations, add the
+  // logic for detecting and instantiating those types here.
+
+  // Fall through to the default render engine type (name is either empty or
+  // the only remaining possible value: "RenderEngineVtk").
+  DRAKE_DEMAND(config.renderer_class.empty() ||
+               config.renderer_class == "RenderEngineVtk");
+  RenderEngineVtkParams params;
+  const geometry::Rgba& rgba = config.background;
+  params.default_clear_color = Vector3d{rgba.r(), rgba.g(), rgba.b()};
+  scene_graph->AddRenderer(config.renderer_name, MakeRenderEngineVtk(params));
+}
+
+}  // namespace
+
 void ApplyCameraConfig(const CameraConfig& config,
                        MultibodyPlant<double>* plant,
                        DiagramBuilder<double>* builder,
                        SceneGraph<double>* scene_graph,
                        DrakeLcmInterface* lcm) {
+  DRAKE_DEMAND(plant != nullptr);
+  DRAKE_DEMAND(scene_graph != nullptr);
   if (!(config.rgb || config.depth)) {
     return;
   }
 
   config.ValidateOrThrow();
+
+  ValidateEngineAndMaybeAdd(config, scene_graph);
 
   // Extract the camera extrinsics from the config struct.
   const Frame<double>& base_frame =
@@ -46,20 +124,6 @@ void ApplyCameraConfig(const CameraConfig& config,
           ? GetScopedFrameByName(*plant, *config.X_PB.base_frame)
           : plant->world_frame();
   const RigidTransformd X_PB = config.X_PB.GetDeterministicValue();
-
-  // Confirm presence of RenderEngine for this camera, adding one as necessary.
-  if (!scene_graph->HasRenderer(config.renderer_name)) {
-    // TODO(SeanCurtis-TRI): Vtk is the always supportable render engine
-    // implementation. Provide a mechanism to allow for other render engine
-    // types to be instantiated. This might be a bit tricky if multiple cameras
-    // declare a renderer of the same *name* but different types. This will
-    // have to be reconciled.
-    RenderEngineVtkParams vtk_params;
-    const geometry::Rgba& rgba = config.background;
-    vtk_params.default_clear_color = Vector3d{rgba.r(), rgba.g(), rgba.b()};
-    scene_graph->AddRenderer(config.renderer_name,
-                             MakeRenderEngineVtk(vtk_params));
-  }
 
   // Extract camera intrinsics from the config struct.
   const auto [color_camera, depth_camera] = config.MakeCameras();

--- a/systems/sensors/test/camera_config_functions_test.cc
+++ b/systems/sensors/test/camera_config_functions_test.cc
@@ -8,6 +8,7 @@
 
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/yaml/yaml_io.h"
+#include "drake/geometry/render_gl/factory.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/systems/lcm/lcm_publisher_system.h"
 #include "drake/systems/sensors/image_to_lcm_image_array_t.h"
@@ -53,6 +54,7 @@ CameraConfig MakeConfig() {
                       .X_BC = Transform{RigidTransformd{Vector3d::UnitX()}},
                       .X_BD = Transform{RigidTransformd{Vector3d::UnitX()}},
                       .renderer_name = "test_renderer",
+                      .renderer_class = "RenderEngineVtk",
                       .background = Rgba(0.25, 0.5, 0.75),
                       .name = "test_camera",
                       .fps = 17,
@@ -349,6 +351,63 @@ TEST_F(CameraConfigFunctionsTest, Validation) {
   EXPECT_THROW(
       ApplyCameraConfig(config, plant_, &builder_, scene_graph_, &lcm_),
       std::exception);
+}
+
+// Confirms that the render engine implementation follows the requested type
+// (when supported). We already know that the config gets validated, so we
+// don't need to test cases where an invalid renderer_class value is passed.
+// However, we do have to worry about requesting RenderEngineGl when it isn't
+// available.
+TEST_F(CameraConfigFunctionsTest, RenderEngineRequest) {
+  // Unspecified class produces RenderEngineVtk.
+  const CameraConfig default_config{.renderer_name = "default"};
+  ASSERT_FALSE(scene_graph_->HasRenderer(default_config.renderer_name));
+  ApplyCameraConfig(default_config, plant_, &builder_, scene_graph_, &lcm_);
+  ASSERT_EQ(NiceTypeName::RemoveNamespaces(scene_graph_->GetRendererTypeName(
+                default_config.renderer_name)),
+            "RenderEngineVtk");
+
+  // Explicitly specifying *new* VTK class produces VTK render engine.
+  const CameraConfig vtk_config{.renderer_name = "vtk_renderer",
+                                .renderer_class = "RenderEngineVtk"};
+  ASSERT_FALSE(scene_graph_->HasRenderer(vtk_config.renderer_name));
+  ApplyCameraConfig(vtk_config, plant_, &builder_, scene_graph_, &lcm_);
+  ASSERT_EQ(NiceTypeName::RemoveNamespaces(scene_graph_->GetRendererTypeName(
+                vtk_config.renderer_name)),
+            "RenderEngineVtk");
+
+  // Using an existing name but the wrong render engine type throws.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      ApplyCameraConfig(
+          CameraConfig{.renderer_name = default_config.renderer_name,
+                       .renderer_class = "RenderEngineGl"},
+          plant_, &builder_, scene_graph_, &lcm_),
+      ".*The name is already used with a different type.+");
+
+  // Using existing name but *no* render engine uses existing engine. Call to
+  // ApplyCameraConfig doesn't throw, and the renderer count doesn't change.
+  // This test assumes that this behavior doesn't depend on the type of the
+  // RenderEngine.
+  const int renderer_count = scene_graph_->RendererCount();
+  ApplyCameraConfig(CameraConfig{.renderer_name = "vtk_renderer"}, plant_,
+                    &builder_, scene_graph_, &lcm_);
+  EXPECT_EQ(renderer_count, scene_graph_->RendererCount());
+
+  // Now explicitly request a new RenderEngineGl -- whether it throws depends
+  // on whether GL is available.
+  const CameraConfig gl_config{.renderer_name = "gl_renderer",
+                               .renderer_class = "RenderEngineGl"};
+  if (geometry::render::kHasRenderEngineGl) {
+    ASSERT_FALSE(scene_graph_->HasRenderer(gl_config.renderer_name));
+    ApplyCameraConfig(gl_config, plant_, &builder_, scene_graph_, &lcm_);
+    ASSERT_EQ(NiceTypeName::RemoveNamespaces(
+                  scene_graph_->GetRendererTypeName(gl_config.renderer_name)),
+              "RenderEngineGl");
+  } else {
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        ApplyCameraConfig(gl_config, plant_, &builder_, scene_graph_, &lcm_),
+        ".*'RenderEngineGl' is not supported.*");
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
1. `SceneGraph` supports a query to find out if a render engine *of a particular type* already exists.
2. `render_gl/factory.h` now provides a build-time `constexpr bool` reporting whether the engine is available or not.
   - Incidentally cleaned up erroneous documentation.
3. `ApplyCameraConfig` extends its logic to instantiate `RenderEngine`s.
   - Uses the new `SceneGraph` API and `constexpr bool kHasGl`.
   - Implements default render engine type, handles availability of `RenderEngineGl`, and throws for any inconsistent act.
4. Incidentally cleans up some tests related to the units modified.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17927)
<!-- Reviewable:end -->
