### PR TITLE
[proximity] Improve/fix obb hierarchy construction

### DIFF
--- a/geometry/proximity/obb.h
+++ b/geometry/proximity/obb.h
@@ -50,14 +50,7 @@ class Obb {
                         and Bz directions.
    @pre half_width.x(), half_width.y(), half_width.z() are not negative.
   */
-  Obb(const math::RigidTransformd& X_HB, const Vector3<double>& half_width)
-      : pose_(X_HB), half_width_(half_width) {
-    DRAKE_DEMAND(half_width.x() >= 0.0);
-    DRAKE_DEMAND(half_width.y() >= 0.0);
-    DRAKE_DEMAND(half_width.z() >= 0.0);
-
-    PadBoundary();
-  }
+  Obb(const math::RigidTransformd& X_HB, const Vector3<double>& half_width);
 
   /* Returns the center of the box -- equivalent to the position vector from
    the hierarchy frame's origin Ho to `this` box's origin Bo: `p_HoBo_H`. */

--- a/geometry/proximity/test/obb_test.cc
+++ b/geometry/proximity/test/obb_test.cc
@@ -495,6 +495,25 @@ GTEST_TEST(ObbMakerTest, TestOptimizeObbVolume) {
   // Empirically we saw about 22% improvement for this particular example.
   // This check make sure the future code will not degrade this optimization.
   EXPECT_GT(percent_improvement, 22.0);
+
+  // Now repeat the test, but with a mesh that is so small that there's no point
+  // in optimizing it. The resulting "optimized" Obb should be identical to the
+  // original Obb.
+
+  // The whole mesh is much smaller than 1mm -- that should be sufficient.
+  TriangleSurfaceMesh<double> mesh2_M =
+      MakeEllipsoidSurfaceMesh<double>(Ellipsoid(1e-5, 2e-5, 3e-5), 6);
+  mesh2_M.TransformVertices(X_ME);
+  const Obb initial_obb2_M(X_ME, Vector3d(1e-5, 2e-5, 3e-5));
+  const Obb optimized_obb2_M =
+      ObbMakerTester<TriangleSurfaceMesh<double>>(mesh2_M, test_vertices)
+          .OptimizeObbVolume(initial_obb2_M);
+  // The pose and half_width will be bit identical as evidence that no work was
+  // done when the volume would not change appreciably.
+  EXPECT_TRUE(CompareMatrices(initial_obb2_M.half_width(),
+                              optimized_obb2_M.half_width()));
+  EXPECT_TRUE(CompareMatrices(initial_obb2_M.pose().GetAsMatrix34(),
+                              optimized_obb2_M.pose().GetAsMatrix34()));
 }
 
 // TODO(DamrongGuoy): Update the tests when we improve the algorithm


### PR DESCRIPTION
We fit an OBB to a mesh (or cluster of features) using PCA analysis. It provides a reasonable estimate of a good OBB orientation. We have an optimization step that attempts to create a *better* orientation (and, thereby, a better fit). To optimize, we compute the partial derivative of OBB volume w.r.t. orientation of the box.

Previously, it was possible for that partial to have *zero* magnitude. This led to failures because the optimization algorithm would end up with infinite values (which could, in turn, lead to NaN values). So, we have to protect ourselves against that.

But beyond that, if the magnitude of the partial derivative is sufficiently small, there's really very little value in trying to further optimize the fit. So, we apply a threshold test for optimization to skip the effort if it doesn't seem worth it, and protect ourselves from introducing bad inf and NaN values.

Incidentally, also moved the constructor to the .cc file where it belonged all along.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17937)
<!-- Reviewable:end -->
