### PR TITLE
Replace 0xa0 character with space

### DIFF
--- a/multibody/inverse_kinematics/minimum_distance_constraint.h
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.h
@@ -62,8 +62,8 @@ allowable distance, d_influence is the "influence distance" (the distance below
 which a pair of geometries influences the constraint), φ is a
 multibody::MinimumDistancePenaltyFunction, and SmoothMax(d) is smooth
 approximation of max(d). We require that dₘᵢₙ < d_influence. The input scaling
-(dᵢ(q) - d_influence)/(d_influence - dₘᵢₙ) ensures that at the boundary of the
-feasible set (when dᵢ(q) == dₘᵢₙ), we evaluate the penalty function at -1,
+(dᵢ(q) - d_influence)/(d_influence - dₘᵢₙ) ensures that at the boundary of the
+feasible set (when dᵢ(q) == dₘᵢₙ), we evaluate the penalty function at -1,
 where it is required to have a non-zero gradient.
 
 @ingroup solver_evaluators

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3327,7 +3327,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// spatial velocity Jacobian in frame A with respect to "speeds" 𝑠.
   /// <pre>
   ///      J𝑠_V_ABp ≜ [ ∂(V_ABp)/∂𝑠₁,  ...  ∂(V_ABp)/∂𝑠ₙ ]    (n is j or k)
-  ///      V_ABp = J𝑠_V_ABp ⋅ 𝑠          V_ABp is linear in 𝑠 ≜ [𝑠₁ ... 𝑠ₙ]ᵀ
+  ///      V_ABp = J𝑠_V_ABp ⋅ 𝑠          V_ABp is linear in 𝑠 ≜ [𝑠₁ ... 𝑠ₙ]ᵀ
   /// </pre>
   /// `V_ABp` is Bp's spatial velocity in frame A and "speeds" 𝑠 is either
   /// q̇ ≜ [q̇₁ ... q̇ⱼ]ᵀ (time-derivatives of j generalized positions) or
@@ -3381,7 +3381,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// with respect to "speeds" 𝑠.
   /// <pre>
   ///      J𝑠_w_AB ≜ [ ∂(w_AB)/∂𝑠₁,  ...  ∂(w_AB)/∂𝑠ₙ ]    (n is j or k)
-  ///      w_AB = J𝑠_w_AB ⋅ 𝑠          w_AB is linear in 𝑠 ≜ [𝑠₁ ... 𝑠ₙ]ᵀ
+  ///      w_AB = J𝑠_w_AB ⋅ 𝑠          w_AB is linear in 𝑠 ≜ [𝑠₁ ... 𝑠ₙ]ᵀ
   /// </pre>
   /// `w_AB` is B's angular velocity in frame A and "speeds" 𝑠 is either
   /// q̇ ≜ [q̇₁ ... q̇ⱼ]ᵀ (time-derivatives of j generalized positions) or
@@ -3418,7 +3418,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// translational velocity Jacobian in frame A with respect to "speeds" 𝑠.
   /// <pre>
   ///      J𝑠_v_ABi ≜ [ ∂(v_ABi)/∂𝑠₁,  ...  ∂(v_ABi)/∂𝑠ₙ ]    (n is j or k)
-  ///      v_ABi = J𝑠_v_ABi ⋅ 𝑠          v_ABi is linear in 𝑠 ≜ [𝑠₁ ... 𝑠ₙ]ᵀ
+  ///      v_ABi = J𝑠_v_ABi ⋅ 𝑠          v_ABi is linear in 𝑠 ≜ [𝑠₁ ... 𝑠ₙ]ᵀ
   /// </pre>
   /// `v_ABi` is Bi's translational velocity in frame A and "speeds" 𝑠 is either
   /// q̇ ≜ [q̇₁ ... q̇ⱼ]ᵀ (time-derivatives of j generalized positions) or

--- a/solvers/minimum_value_constraint.cc
+++ b/solvers/minimum_value_constraint.cc
@@ -29,7 +29,7 @@ template <typename T>
 T SmoothMax(const std::vector<T>& x) {
   // We compute the smooth max of x as smoothmax(x) = log(∑ᵢ exp(αxᵢ)) / α.
   // This smooth max approaches max(x) as α increases. We choose α = 100, as
-  // that gives a qualitatively good fit for xᵢ ∈ [0, 1], which is the range of
+  // that gives a qualitatively good fit for xᵢ ∈ [0, 1], which is the range of
   // potential penalty values when the MinimumValueConstraint is feasible.
   DRAKE_ASSERT(x.size() > 0);
   const double alpha{100};

--- a/solvers/minimum_value_constraint.h
+++ b/solvers/minimum_value_constraint.h
@@ -60,8 +60,8 @@ which an element influences the constraint or, conversely, the value above which
 an element is ignored), φ is a solvers::MinimumValuePenaltyFunction, and
 SmoothMax(v) is a smooth, conservative approximation of max(v) (i.e.
 SmoothMax(v) >= max(v), for all v). We require that vₘᵢₙ < v_influence. The
-input scaling (vᵢ - v_influence)/(v_influence - vₘᵢₙ) ensures that at the
-boundary of the feasible set (when vᵢ == vₘᵢₙ), we evaluate the penalty function
+input scaling (vᵢ - v_influence)/(v_influence - vₘᵢₙ) ensures that at the
+boundary of the feasible set (when vᵢ == vₘᵢₙ), we evaluate the penalty function
 at -1, where it is required to have a non-zero gradient. The user-provided
 function may return a vector with up to `max_num_values` elements. If it returns
 a vector with fewer than `max_num_values` elements, the remaining elements are
@@ -147,8 +147,8 @@ class MinimumValueConstraint final : public solvers::Constraint {
   const double minimum_value_;
   const double influence_value_;
   /** Stores the value of
-  1 / φ((vₘᵢₙ - v_influence)/(v_influence - vₘᵢₙ)) = 1 / φ(-1). This is
-  used to scale the output of the penalty function to be 1 when v == vₘᵢₙ. */
+  1 / φ((vₘᵢₙ - v_influence)/(v_influence - vₘᵢₙ)) = 1 / φ(-1). This is
+  used to scale the output of the penalty function to be 1 when v == vₘᵢₙ. */
   double penalty_output_scaling_;
   int max_num_values_{};
   MinimumValuePenaltyFunction penalty_function_{};


### PR DESCRIPTION
Came across while reading `MinimumValueConstraint` to understand how some of Anzu's min-distance stuff works

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17939)
<!-- Reviewable:end -->
