### PR TITLE
Deprecate math::saturate which is identical to std::clamp

### DIFF
--- a/common/symbolic/expression/expression.cc
+++ b/common/symbolic/expression/expression.cc
@@ -729,6 +729,12 @@ Expression max(const Expression& e1, const Expression& e2) {
   return Expression{make_unique<ExpressionMax>(e1, e2)};
 }
 
+Expression clamp(const Expression& v, const Expression& lo,
+                 const Expression& hi) {
+  DRAKE_ASSERT(!is_constant(lo) || !is_constant(hi) || (lo <= hi));
+  return min(hi, max(lo, v));
+}
+
 Expression ceil(const Expression& e) {
   // Simplification: constant folding.
   if (is_constant(e)) {

--- a/common/symbolic/expression/expression.h
+++ b/common/symbolic/expression/expression.h
@@ -452,6 +452,8 @@ class Expression {
   friend Expression tanh(const Expression& e);
   friend Expression min(const Expression& e1, const Expression& e2);
   friend Expression max(const Expression& e1, const Expression& e2);
+  friend Expression clamp(const Expression& v, const Expression& lo,
+                          const Expression& hi);
   friend Expression ceil(const Expression& e);
   friend Expression floor(const Expression& e);
 
@@ -655,6 +657,8 @@ Expression cosh(const Expression& e);
 Expression tanh(const Expression& e);
 Expression min(const Expression& e1, const Expression& e2);
 Expression max(const Expression& e1, const Expression& e2);
+Expression clamp(const Expression& v, const Expression& lo,
+                 const Expression& hi);
 Expression ceil(const Expression& e);
 Expression floor(const Expression& e);
 Expression if_then_else(const Formula& f_cond, const Expression& e_then,

--- a/common/symbolic/expression/test/expression_test.cc
+++ b/common/symbolic/expression/test/expression_test.cc
@@ -1726,6 +1726,26 @@ TEST_F(SymbolicExpressionTest, Max2) {
   EXPECT_EQ((max(x_, y_)).to_string(), "max(x, y)");
 }
 
+TEST_F(SymbolicExpressionTest, Clamp1) {
+  Expression result;
+  result = clamp(Expression{1.5}, one_, pi_);
+  EXPECT_EQ(result.to_string(), "1.5");
+  result = clamp(Expression::Zero(), one_, pi_);
+  EXPECT_EQ(result.to_string(), "1");
+  result = clamp(Expression{5.6}, one_, pi_);
+  const std::string kPi{"3.14"};
+  EXPECT_EQ(result.to_string().compare(0, kPi.length(), kPi), 0);
+}
+
+TEST_F(SymbolicExpressionTest, Clamp2) {
+  const Variable var_lo{"lo"};
+  const Variable var_hi{"hi"};
+  auto e = clamp(x_, var_lo, var_hi);
+  EXPECT_EQ(e.Evaluate({{var_x_, 0}, {var_lo, 3}, {var_hi, 10}}), 3);
+  EXPECT_EQ(e.Evaluate({{var_x_, 5}, {var_lo, 3}, {var_hi, 10}}), 5);
+  EXPECT_EQ(e.Evaluate({{var_x_, 12.3}, {var_lo, 3}, {var_hi, 10}}), 10);
+}
+
 TEST_F(SymbolicExpressionTest, Ceil) {
   EXPECT_DOUBLE_EQ(ceil(pi_).Evaluate(), std::ceil(M_PI));
   EXPECT_DOUBLE_EQ(ceil(one_).Evaluate(), std::ceil(1));

--- a/common/trajectories/bspline_trajectory.cc
+++ b/common/trajectories/bspline_trajectory.cc
@@ -33,10 +33,9 @@ std::unique_ptr<Trajectory<T>> BsplineTrajectory<T>::Clone() const {
 
 template <typename T>
 MatrixX<T> BsplineTrajectory<T>::value(const T& time) const {
-  using std::max;
-  using std::min;
+  using std::clamp;
   return basis().EvaluateCurve(control_points(),
-                               min(max(time, start_time()), end_time()));
+                               clamp(time, start_time(), end_time()));
 }
 
 template <typename T>

--- a/common/trajectories/path_parameterized_trajectory.cc
+++ b/common/trajectories/path_parameterized_trajectory.cc
@@ -24,10 +24,9 @@ std::unique_ptr<Trajectory<T>> PathParameterizedTrajectory<T>::Clone() const {
 
 template <typename T>
 MatrixX<T> PathParameterizedTrajectory<T>::value(const T& t) const {
-  using std::max;
-  using std::min;
+  using std::clamp;
   const T time =
-      min(max(t, time_scaling_->start_time()), time_scaling_->end_time());
+      clamp(t, time_scaling_->start_time(), time_scaling_->end_time());
   return path_->value(time_scaling_->value(time)(0, 0));
 }
 
@@ -51,10 +50,9 @@ T PathParameterizedTrajectory<T>::BellPolynomial(int n, int k,
 template <typename T>
 MatrixX<T> PathParameterizedTrajectory<T>::DoEvalDerivative(
     const T& t, int derivative_order) const {
-  using std::max;
-  using std::min;
+  using std::clamp;
   const T time =
-      min(max(t, time_scaling_->start_time()), time_scaling_->end_time());
+      clamp(t, time_scaling_->start_time(), time_scaling_->end_time());
   if (derivative_order == 0) {
     return value(time);
   } else if (derivative_order > 0) {

--- a/common/trajectories/piecewise_polynomial.cc
+++ b/common/trajectories/piecewise_polynomial.cc
@@ -14,7 +14,7 @@
 using std::runtime_error;
 using std::vector;
 using std::abs;
-using std::min;
+using std::clamp;
 using std::max;
 
 namespace drake {
@@ -119,7 +119,7 @@ template <typename T>
 MatrixX<T> PiecewisePolynomial<T>::DoEvalDerivative(
     const T& t, int derivative_order) const {
   const int segment_index = this->get_segment_index(t);
-  const T time = min(max(t, this->start_time()), this->end_time());
+  const T time = clamp(t, this->start_time(), this->end_time());
   Eigen::Matrix<T, PolynomialMatrix::RowsAtCompileTime,
                 PolynomialMatrix::ColsAtCompileTime>
       ret(rows(), cols());

--- a/common/trajectories/piecewise_trajectory.cc
+++ b/common/trajectories/piecewise_trajectory.cc
@@ -81,10 +81,8 @@ int PiecewiseTrajectory<T>::GetSegmentIndexRecursive(const T& time, int start,
 template <typename T>
 int PiecewiseTrajectory<T>::get_segment_index(const T& t) const {
   if (breaks_.empty()) return 0;
-  // clip to min/max times
-  using std::min;
-  using std::max;
-  T time = min(max(t, start_time()), end_time());
+  using std::clamp;
+  const T time = clamp(t, start_time(), end_time());
   return GetSegmentIndexRecursive(time, 0,
                                   static_cast<int>(breaks_.size() - 1));
 }

--- a/common/trajectories/test/bspline_trajectory_test.cc
+++ b/common/trajectories/test/bspline_trajectory_test.cc
@@ -118,10 +118,9 @@ TYPED_TEST(BsplineTrajectoryTests, ValueTest) {
                                        trajectory.end_time() + 0.1);
   for (int k = 0; k < num_times; ++k) {
     MatrixX<T> value = trajectory.value(t(k));
-    using std::max;
-    using std::min;
-    T t_clamped = min(max(t(k), trajectory.start_time()),
-                      trajectory.end_time());
+    using std::clamp;
+    const T t_clamped = clamp(
+        t(k), trajectory.start_time(), trajectory.end_time());
     MatrixX<T> expected_value = trajectory.basis().EvaluateCurve(
         trajectory.control_points(), t_clamped);
     EXPECT_TRUE(CompareMatrices(value, expected_value,

--- a/common/trajectories/test/path_parameterized_trajectory_test.cc
+++ b/common/trajectories/test/path_parameterized_trajectory_test.cc
@@ -1,5 +1,7 @@
 #include "drake/common/trajectories/path_parameterized_trajectory.h"
 
+#include <algorithm>
+
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
@@ -7,9 +9,6 @@
 namespace drake {
 namespace trajectories {
 namespace {
-
-using std::max;
-using std::min;
 
 class PathParameterizedTrajectoryTest : public ::testing::Test {
  protected:
@@ -43,7 +42,7 @@ TEST_F(PathParameterizedTrajectoryTest, TestConstructor) {
 TEST_F(PathParameterizedTrajectoryTest, TestValue) {
   for (double t = 0.88; t < 2.2; t += 0.12) {
     const double time =
-        min(max(t, time_scaling_.start_time()), time_scaling_.end_time());
+        std::clamp(t, time_scaling_.start_time(), time_scaling_.end_time());
     EXPECT_TRUE(CompareMatrices(
         dut_->value(t), path_.value(time_scaling_.scalarValue(time)), 1e-14));
   }
@@ -52,7 +51,7 @@ TEST_F(PathParameterizedTrajectoryTest, TestValue) {
 TEST_F(PathParameterizedTrajectoryTest, TestDerivatives) {
   for (double t = 0.88; t < 2.2; t += 0.12) {
     const double time =
-        min(max(t, time_scaling_.start_time()), time_scaling_.end_time());
+        std::clamp(t, time_scaling_.start_time(), time_scaling_.end_time());
 
     EXPECT_TRUE(
         CompareMatrices(dut_->EvalDerivative(t, 0), dut_->value(t), 1e-14));

--- a/manipulation/schunk_wsg/BUILD.bazel
+++ b/manipulation/schunk_wsg/BUILD.bazel
@@ -92,7 +92,6 @@ drake_cc_library(
     srcs = ["schunk_wsg_position_controller.cc"],
     hdrs = ["schunk_wsg_position_controller.h"],
     deps = [
-        "//math:saturate",
         "//systems/framework:leaf_system",
         "//systems/primitives:discrete_derivative",
     ],

--- a/manipulation/schunk_wsg/schunk_wsg_position_controller.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_position_controller.cc
@@ -1,6 +1,7 @@
 #include "drake/manipulation/schunk_wsg/schunk_wsg_position_controller.h"
 
-#include "drake/math/saturate.h"
+#include <algorithm>
+
 #include "drake/systems/framework/diagram_builder.h"
 
 namespace drake {
@@ -65,10 +66,11 @@ Vector2d SchunkWsgPdController::CalcGeneralizedForce(
                             kd_constraint_ * (state[2] + state[3]);
 
   // -f₀+f₁ = sat(kp_command*(q_d + q₀ - q₁) + kd_command*(v_d + v₀ - v₁)).
+  using std::clamp;
   const double neg_f0_plus_f1 =
-      math::saturate(kp_command_ * (desired_state[0] + state[0] - state[1]) +
-                         kd_command_ * (desired_state[1] + state[2] - state[3]),
-                     -force_limit, force_limit);
+      clamp(kp_command_ * (desired_state[0] + state[0] - state[1]) +
+                kd_command_ * (desired_state[1] + state[2] - state[3]),
+            -force_limit, force_limit);
 
   // f₀ = (f₀+f₁)/2 - (-f₀+f₁)/2,
   // f₁ = (f₀+f₁)/2 + (-f₀+f₁)/2.

--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -528,6 +528,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "saturate_test",
+    copts = ["-Wno-deprecated-declarations"],
     deps = [
         ":saturate",
         "//common:default_scalars",

--- a/math/saturate.h
+++ b/math/saturate.h
@@ -1,16 +1,15 @@
 #pragma once
 
-// TODO(jwnimmer-tri): Figure out how to remove this include.
 #include "drake/common/autodiff.h"
 #include "drake/common/cond.h"
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_deprecated.h"
 
 namespace drake {
 namespace math {
 
-/// Saturates the input `value` between upper and lower bounds. If `value` is
-/// within `[low, high]` then return it; else return the boundary.
 template <class T1, class T2, class T3>
+DRAKE_DEPRECATED("2023-01-01", "Use C++17's std::clamp instead")
 T1 saturate(const T1& value, const T2& low, const T3& high) {
   DRAKE_ASSERT(low <= high);
   return cond(

--- a/systems/primitives/BUILD.bazel
+++ b/systems/primitives/BUILD.bazel
@@ -253,7 +253,6 @@ drake_cc_library(
     srcs = ["saturation.cc"],
     hdrs = ["saturation.h"],
     deps = [
-        "//math:saturate",
         "//systems/framework",
     ],
 )

--- a/systems/primitives/saturation.cc
+++ b/systems/primitives/saturation.cc
@@ -1,9 +1,9 @@
 #include "drake/systems/primitives/saturation.h"
 
+#include <algorithm>
 #include <limits>
 
 #include "drake/common/default_scalars.h"
-#include "drake/math/saturate.h"
 
 namespace drake {
 namespace systems {
@@ -88,7 +88,8 @@ void Saturation<T>::CalcSaturatedOutput(const Context<T>& context,
 
   // Loop through and set the saturation values.
   for (int i = 0; i < u_min.size(); ++i) {
-    y[i] = math::saturate(u[i], u_min[i], u_max[i]);
+    using std::clamp;
+    y[i] = clamp(u[i], u_min[i], u_max[i]);
   }
 }
 


### PR DESCRIPTION
Prefer C++17 `clamp` over a pair of `min`,`max`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17942)
<!-- Reviewable:end -->
