### PR TITLE
Use C++20 on macOS and Ubuntu 22

### DIFF
--- a/common/bit_cast.h
+++ b/common/bit_cast.h
@@ -1,5 +1,19 @@
 #pragma once
 
+#ifdef __cpp_lib_bit_cast
+
+#include <bit>
+
+namespace drake {
+namespace internal {
+
+using std::bit_cast;
+
+}  // namespace internal
+}  // namespace drake
+
+#else  // __cpp_lib_bit_cast
+
 #include <cstring>
 #include <type_traits>
 
@@ -23,3 +37,5 @@ To bit_cast(const From& from) noexcept {
 
 }  // namespace internal
 }  // namespace drake
+
+#endif  // __cpp_lib_bit_cast

--- a/doc/_pages/installation.md
+++ b/doc/_pages/installation.md
@@ -43,9 +43,9 @@ compiler as our releases:
 | Operating System                   | C/C++ Compiler                 | Std   |
 |------------------------------------|--------------------------------|-------|
 | Ubuntu 20.04 LTS (Focal Fossa)     | GCC 9.3                        | C++17 |
-| Ubuntu 22.04 LTS (Jammy Jellyfish) | GCC 11.2                       | C++17 |
-| macOS Big Sur (11)                 | Apple LLVM 12.0.5 (Xcode 12.5) | C++17 |
-| macOS Monterey (12) on x86_64      | Apple LLVM 13.0.0 (Xcode 13.1) | C++17 |
+| Ubuntu 22.04 LTS (Jammy Jellyfish) | GCC 11.2                       | C++20 |
+| macOS Big Sur (11)                 | Apple LLVM 12.0.5 (Xcode 12.5) | C++20 |
+| macOS Monterey (12) on x86_64      | Apple LLVM 13.0.0 (Xcode 13.1) | C++20 |
 
 ## Available Versions
 

--- a/tools/macos.bazelrc
+++ b/tools/macos.bazelrc
@@ -1,5 +1,9 @@
 # Common options for macOS, no matter the arch (x86 or arm).
 
+# Use C++20 by default.
+build --cxxopt=-std=c++20
+build --host_cxxopt=-std=c++20
+
 # Suppress numerous "'_FORTIFY_SOURCE' macro redefined" warnings when using
 # sanitizers.
 build:asan --copt=-Wno-macro-redefined

--- a/tools/ubuntu-jammy.bazelrc
+++ b/tools/ubuntu-jammy.bazelrc
@@ -1,3 +1,7 @@
+# Use C++20 by default.
+build --cxxopt=-std=c++20
+build --host_cxxopt=-std=c++20
+
 build --fission=dbg
 build --features=per_object_debug_info
 

--- a/tools/workspace/qhull_internal/package.BUILD.bazel
+++ b/tools/workspace/qhull_internal/package.BUILD.bazel
@@ -83,6 +83,7 @@ cc_library_vendored(
         x.replace("src/", "drake_src/drake_vendor/")
         for x in _SRCS_CPP
     ],
+    copts = ["-w"],
     linkstatic = 1,
     visibility = ["//visibility:public"],
     deps = [":qhull_r"],


### PR DESCRIPTION
Closes #14670.

We'd like to ensure that Drake's users who build in C++20 mode don't receive any errors. In order to get that covered by CI, the plan is to build Ubuntu 20.04 in C++17 mode (unchanged), but to upgrade Ubuntu 22.04 and macOS to C++20 mode. This PR handles the Ubuntu side of that change.

Prerequisites:
- [x] #17944
- [x] #17949
- [x] #17958
- [x] #17970
- [x] #17973
- [x] #17994
- [x] #17995

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17943)
<!-- Reviewable:end -->
