### PR TITLE
[perception] Normalize normals in PointCloud::VoxelizedDownSample

### DIFF
--- a/perception/point_cloud.cc
+++ b/perception/point_cloud.cc
@@ -476,7 +476,7 @@ PointCloud PointCloud::VoxelizedDownSample(double voxel_size) const {
         (xyz / indices_in_this.size()).cast<T>();
     if (has_normals()) {
       down_sampled.mutable_normals().col(index_in_down_sampled) =
-          (normal / num_normals).cast<T>();
+          (normal / num_normals).normalized().cast<T>();
     }
     if (has_rgbs()) {
       down_sampled.mutable_rgbs().col(index_in_down_sampled) =

--- a/perception/test/point_cloud_test.cc
+++ b/perception/test/point_cloud_test.cc
@@ -373,6 +373,7 @@ GTEST_TEST(PointCloudTest, VoxelizedDownSample) {
         }
         xyz /= indices.size();
         normal /= indices.size();
+        normal.normalize();
         rgb /= indices.size();
         descriptor /= indices.size();
 
@@ -392,6 +393,7 @@ GTEST_TEST(PointCloudTest, VoxelizedDownSample) {
 
         EXPECT_TRUE(CompareMatrices(down_sampled.normal(i),
                                     normal.cast<float>(), kTol));
+        EXPECT_NEAR(down_sampled.normal(i).norm(), 1.0, 1e-6);
         EXPECT_EQ(down_sampled.rgb(i), rgb.cast<u_int8_t>());
         EXPECT_TRUE(CompareMatrices(down_sampled.descriptor(i),
                                     descriptor.cast<float>(), kTol));


### PR DESCRIPTION
The average of normals is not in general unit length. This fix adds the extra normalization.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17945)
<!-- Reviewable:end -->
