### PR TITLE
[meshcat] Allow keyboard events to move sliders and click buttons

### DIFF
--- a/bindings/pydrake/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry_py_visualizers.cc
@@ -273,14 +273,15 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def("SetAnimation", &Class::SetAnimation, py::arg("animation"),
             +cls_doc.SetAnimation.doc)
         .def("AddButton", &Class::AddButton, py::arg("name"),
-            cls_doc.AddButton.doc)
+            py::arg("keycode") = "", cls_doc.AddButton.doc)
         .def("GetButtonClicks", &Class::GetButtonClicks, py::arg("name"),
             cls_doc.GetButtonClicks.doc)
         .def("DeleteButton", &Class::DeleteButton, py::arg("name"),
             cls_doc.DeleteButton.doc)
         .def("AddSlider", &Class::AddSlider, py::arg("name"), py::arg("min"),
             py::arg("max"), py::arg("step"), py::arg("value"),
-            cls_doc.AddSlider.doc)
+            py::arg("decrement_keycode") = "",
+            py::arg("increment_keycode") = "", cls_doc.AddSlider.doc)
         .def("SetSliderValue", &Class::SetSliderValue, py::arg("name"),
             py::arg("value"), cls_doc.SetSliderValue.doc)
         .def("GetSliderValue", &Class::GetSliderValue, py::arg("name"),

--- a/bindings/pydrake/test/geometry_visualizers_test.py
+++ b/bindings/pydrake/test/geometry_visualizers_test.py
@@ -140,10 +140,16 @@ class TestGeometryVisualizers(unittest.TestCase):
         meshcat.Set2dRenderMode(
             X_WC=RigidTransform(), xmin=-1, xmax=1, ymin=-1, ymax=1)
         meshcat.ResetRenderMode()
-        meshcat.AddButton(name="button")
+        meshcat.AddButton(name="button", keycode="KeyB")
         self.assertEqual(meshcat.GetButtonClicks(name="button"), 0)
         meshcat.DeleteButton(name="button")
-        meshcat.AddSlider(name="slider", min=0, max=1, step=0.01, value=0.5)
+        meshcat.AddSlider(name="slider",
+                          min=0,
+                          max=1,
+                          step=0.01,
+                          value=0.5,
+                          decrement_keycode="ArrowLeft",
+                          increment_keycode="ArrowRight")
         meshcat.SetSliderValue(name="slider", value=0.7)
         self.assertAlmostEqual(meshcat.GetSliderValue(
             name="slider"), 0.7, delta=1e-14)

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -1201,7 +1201,7 @@ class Meshcat::Impl {
   }
 
   // This function is public via the PIMPL.
-  void AddButton(std::string name) {
+  void AddButton(std::string name, std::string keycode) {
     DRAKE_DEMAND(IsThread(main_thread_id_));
 
     internal::SetButtonControl data;
@@ -1211,19 +1211,32 @@ class Meshcat::Impl {
   'type': 'button',
   'name': '{}'
 }})))""", data.name);
+    data.keycode1 = std::move(keycode);
 
     {
       std::lock_guard<std::mutex> lock(controls_mutex_);
-      auto iter = buttons_.find(data.name);
-      if (iter != buttons_.end()) {
-        iter->second.num_clicks = 0;
-        return;
-      }
       if (sliders_.find(data.name) != sliders_.end()) {
         throw std::logic_error(
             fmt::format("Meshcat already has a slider named {}.", data.name));
       }
-      controls_.emplace_back(data.name);
+      auto iter = buttons_.find(data.name);
+      if (iter == buttons_.end()) {
+        controls_.emplace_back(data.name);
+      } else {
+        iter->second.num_clicks = 0;
+        if (iter->second.keycode1.empty()) {
+          if (data.keycode1.empty()) {
+            // No need to publish to meshcat.
+            return;
+          }  // else fall through.
+        } else if (iter->second.keycode1 != data.keycode1) {
+          throw std::logic_error(fmt::format(
+              "Meshcat already has a button named `{}`, but the previously "
+              "assigned keycode `{}` does not match the current keycode `{}`. "
+              "To re-assign the keycode, you must first delete the button.",
+              data.name, iter->second.keycode1, data.keycode1));
+        }
+      }
       buttons_[data.name] = data;
       DRAKE_DEMAND(controls_.size() == (buttons_.size() + sliders_.size()));
     }
@@ -1278,8 +1291,9 @@ class Meshcat::Impl {
   }
 
   // This function is public via the PIMPL.
-  void AddSlider(std::string name, double min, double max,
-                               double step, double value) {
+  void AddSlider(std::string name, double min, double max, double step,
+                 double value, std::string decrement_keycode,
+                 std::string increment_keycode) {
     DRAKE_DEMAND(IsThread(main_thread_id_));
 
     internal::SetSliderControl data;
@@ -1297,8 +1311,10 @@ class Meshcat::Impl {
     // https://github.com/dataarts/dat.gui/blob/f720c729deca5d5c79da8464f8a05500d38b140c/src/dat/controllers/NumberController.js#L62
     value = std::max(value, min);
     value = std::min(value, max);
-    value = std::round(value/step)*step;
+    value = std::round(value / step) * step;
     data.value = value;
+    data.keycode1 = std::move(decrement_keycode);
+    data.keycode2 = std::move(increment_keycode);
 
     {
       std::lock_guard<std::mutex> lock(controls_mutex_);
@@ -2121,8 +2137,8 @@ void Meshcat::ResetRenderMode() {
   impl().ResetRenderMode();
 }
 
-void Meshcat::AddButton(std::string name) {
-  impl().AddButton(std::move(name));
+void Meshcat::AddButton(std::string name, std::string keycode) {
+  impl().AddButton(std::move(name), std::move(keycode));
 }
 
 int Meshcat::GetButtonClicks(std::string_view name) {
@@ -2133,9 +2149,11 @@ void Meshcat::DeleteButton(std::string name) {
   impl().DeleteButton(std::move(name));
 }
 
-void Meshcat::AddSlider(std::string name, double min, double max,
-                               double step, double value) {
-  impl().AddSlider(std::move(name), min, max, step, value);
+void Meshcat::AddSlider(std::string name, double min, double max, double step,
+                        double value, std::string decrement_keycode,
+                        std::string increment_keycode) {
+  impl().AddSlider(std::move(name), min, max, step, value,
+                   std::move(decrement_keycode), std::move(increment_keycode));
 }
 
 void Meshcat::SetSliderValue(std::string name, double value) {

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -499,10 +499,18 @@ class Meshcat {
   //@{
 
   /** Adds a button with the label `name` to the meshcat browser controls GUI.
-   If the button already existed, then resets its click count to zero instead.
-   @throws std::exception if `name` has already been added as any other type
-   of control (e.g., slider). */
-  void AddButton(std::string name);
+   If the optional @p keycode is set to a javascript string key code (such as
+   "KeyG" or "ArrowLeft", see
+   https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values),
+   then a keydown callback is registered in the GUI which will also `click` the
+   button. If the button already existed, then resets its click count to zero;
+   and sets the keycode if no keycode was set before.
+
+   @throws std::exception if `name` has already been added as any other type of
+   control (e.g., slider).
+   @throw std::exception if a button of the same `name` has already been
+   assigned a different keycode. */
+  void AddButton(std::string name, std::string keycode = "");
 
   /** Returns the number of times the button `name` has been clicked in the
    GUI, from the time that it was added to `this`.  If multiple browsers are
@@ -518,11 +526,18 @@ class Meshcat {
    The slider range is given by [`min`, `max`]. `step` is the smallest
    increment by which the slider can change values (and therefore send updates
    back to this Meshcat instance). `value` specifies the initial value; it will
-   be truncated to the slider range and rounded to the nearest increment.
+   be truncated to the slider range and rounded to the nearest increment. If
+   the optional @p decrement_keycode or @p increment_keycode are set to a
+   javascript string key code (such as "KeyG" or "ArrowLeft", see
+   https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values),
+   then keydown callbacks will be registered in the GUI that will move the
+   slider by @p step (within the limits) when those buttons are pressed.
+
    @throws std::exception if `name` has already been added as any type of
    control (e.g., either button or slider). */
   void AddSlider(std::string name, double min, double max, double step,
-                 double value);
+                 double value, std::string decrement_keycode = "",
+                 std::string increment_keycode = "");
 
   /** Sets the current `value` of the slider `name`. `value` will be truncated
    to the slider range and rounded to the nearest increment specified by the

--- a/geometry/meshcat_types.h
+++ b/geometry/meshcat_types.h
@@ -405,7 +405,8 @@ struct SetButtonControl {
   int num_clicks{0};
   std::string name;
   std::string callback;
-  MSGPACK_DEFINE_MAP(type, name, callback);
+  std::string keycode1{};
+  MSGPACK_DEFINE_MAP(type, name, callback, keycode1);
 };
 
 struct SetSliderControl {
@@ -416,7 +417,10 @@ struct SetSliderControl {
   double min{};
   double max{};
   double step{};
-  MSGPACK_DEFINE_MAP(type, name, callback, value, min, max, step);
+  std::string keycode1{};
+  std::string keycode2{};
+  MSGPACK_DEFINE_MAP(type, name, callback, value, min, max, step, keycode1,
+                     keycode2);
 };
 
 struct SetSliderValue {

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -350,11 +350,19 @@ Open up your browser to the URL above.
       << "Note: I've deleted the temporary HTML file (it's several Mb).\n\n";
 
   meshcat->AddButton("ButtonTest");
-  meshcat->AddSlider("SliderTest", 0, 1, 0.01, 0.5);
+  meshcat->AddButton("Press t Key");
+  meshcat->AddButton("Press t Key", "KeyT");  // Now the keycode is assigned.
+  meshcat->AddSlider("SliderTest", 0, 1, 0.01, 0.5, "ArrowLeft", "ArrowRight");
 
-  std::cout << "I've added a button and a slider to the controls menu.\n";
+  std::cout << "I've added two buttons and a slider to the controls menu.\n";
   std::cout << "- Click the ButtonTest button a few times.\n";
+  std::cout << "- Press the 't' key in the meshcat window, which "
+               "should be equivalent to pressing the second button.\n";
+  std::cout << "The buttons do nothing, but the total number of clicks for "
+               "each button will be reported after you press RETURN.\n";
   std::cout << "- Move SliderTest slider.\n";
+  std::cout << "- Confirm that the ArrowLeft and ArrowRight keys also move the "
+               "slider.\n";
   std::cout << "- Open a second browser (" << meshcat->web_url()
             << ") and confirm that moving the slider in one updates the slider "
                "in the other.\n";
@@ -364,6 +372,8 @@ Open up your browser to the URL above.
 
   std::cout << "Got " << meshcat->GetButtonClicks("ButtonTest")
             << " clicks on ButtonTest.\n"
+            << "Got " << meshcat->GetButtonClicks("Press t Key")
+            << " clicks on \"Press t Key\".\n"
             << "Got " << meshcat->GetSliderValue("SliderTest")
             << " value for SliderTest." << std::endl;
 

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -613,6 +613,30 @@ GTEST_TEST(MeshcatTest, Buttons) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       meshcat.GetButtonClicks("bob"),
       "Meshcat does not have any button named bob.");
+
+  // Adding a button with the keycode.
+  meshcat.AddButton("alice", "KeyT");
+  CheckWebsocketCommand(meshcat, R"""({
+      "type": "button",
+      "name": "alice"
+    })""", {}, {});
+  EXPECT_EQ(meshcat.GetButtonClicks("alice"), 1);
+  // Adding with the same keycode still resets.
+  meshcat.AddButton("alice", "KeyT");
+  EXPECT_EQ(meshcat.GetButtonClicks("alice"), 0);
+  // Adding the same button with an empty keycode throws.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      meshcat.AddButton("alice"),
+      ".*does not match the current keycode.*");
+  // Adding the same button with a different keycode throws.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      meshcat.AddButton("alice", "KeyR"),
+      ".*does not match the current keycode.*");
+  meshcat.DeleteButton("alice");
+
+  // Adding a button with the keycode empty, then populated works.
+  meshcat.AddButton("alice");
+  meshcat.AddButton("alice", "KeyT");
 }
 
 GTEST_TEST(MeshcatTest, Sliders) {
@@ -663,6 +687,9 @@ GTEST_TEST(MeshcatTest, DuplicateMixedControls) {
   // control by attempting to re-use its name.
   DRAKE_EXPECT_THROWS_MESSAGE(
       meshcat.AddButton("slider"),
+      "Meshcat already has a slider named slider.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      meshcat.AddButton("slider", "KeyR"),
       "Meshcat already has a slider named slider.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       meshcat.AddSlider("button", 0.2, 1.5, 0.1, 0.5),

--- a/tools/workspace/meshcat/repository.bzl
+++ b/tools/workspace/meshcat/repository.bzl
@@ -11,8 +11,8 @@ def meshcat_repository(
         repository = "rdeits/meshcat",
         # Updating this commit requires local testing; see
         # drake/tools/workspace/meshcat/README.md for details.
-        commit = "65781fcb064db536b99a66fe9fcf5bf0b6d1f790",
-        sha256 = "d55918a9d14b1f92b331e5d64df7be1572c670afcc4dd5f46372c186708b9e80",  # noqa
+        commit = "d1049e0d463cf3f5918ef6a3a714c894038b7d79",
+        sha256 = "caf1bbd6bea11ddfa468d0307155695e9500a2f67e04416a423c5bd376e38151",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
This will enable, for instance, keyboard teleop through Meshcat. It will make the Deepnote teleop demos much more ergonomic.

Upgrades meshcat to the latest commit to get this feature.

To see the new features, `bazel run
//geometry:meshcat_manual_test`. The last prompt (starting with "I've added two buttons..." will now ask you to press keys in addition to using the gui button / slider for the interaction.

+@jwnimmer-tri for feature review, please.  (and platform, too, if you feel it's reasonable)

See also https://github.com/rdeits/meshcat/pull/129.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17947)
<!-- Reviewable:end -->
