### PR TITLE
[perception] Fix PointCloud::Concatenate for XYZs only.

### DIFF
--- a/perception/point_cloud.cc
+++ b/perception/point_cloud.cc
@@ -377,7 +377,7 @@ PointCloud Concatenate(const std::vector<PointCloud>& clouds) {
   int index = 0;
   for (int i = 0; i < num_clouds; ++i) {
     const int s = clouds[i].size();
-    if (new_cloud.has_normals()) {
+    if (new_cloud.has_xyzs()) {
       new_cloud.mutable_xyzs().middleCols(index, s) = clouds[i].xyzs();
     }
     if (new_cloud.has_normals()) {


### PR DESCRIPTION
I had a bad typo in the code which only populated xyzs if has_normals() was true.  This fixes it and adds more test coverage.

(The updated test is only a minor refactor on the existing one, which runs multiple cases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17948)
<!-- Reviewable:end -->
