### PR TITLE
Use constexpr (not just const) for fmt strings

### DIFF
--- a/common/trajectories/discrete_time_trajectory.cc
+++ b/common/trajectories/discrete_time_trajectory.cc
@@ -86,7 +86,7 @@ template <typename T>
 MatrixX<T> DiscreteTimeTrajectory<T>::value(const T& t) const {
   using std::abs;
   const double time = ExtractDoubleOrThrow(t);
-  static const char* kNoMatchingTimeStr =
+  static constexpr const char* kNoMatchingTimeStr =
       "Value requested at time {} does not match any of the trajectory times "
       "within tolerance {}.";
   for (int i = 0; i < static_cast<int>(times_.size()); ++i) {

--- a/geometry/render/test/render_camera_test.cc
+++ b/geometry/render/test/render_camera_test.cc
@@ -32,7 +32,7 @@ GTEST_TEST(ClippingRangeTest, Constructor) {
 
   {
     // Case: Bad values.
-    const char* error_message =
+    constexpr const char* error_message =
         "The clipping range values must both be positive and finite and far "
         "must be greater than near. Instantiated with near = {} and far = {}";
     DRAKE_EXPECT_THROWS_MESSAGE(ClippingRange(-0.1, 10),
@@ -230,7 +230,7 @@ GTEST_TEST(DepthRangeTest, Constructor) {
 
   {
     // Case: Bad values.
-    const char* error_message =
+    constexpr const char* error_message =
         "The depth range values must both be positive and finite and the "
         "maximum depth must be greater than the minimum depth. Instantiated "
         "with min = {} and max = {}";

--- a/geometry/render/test/render_engine_test.cc
+++ b/geometry/render/test/render_engine_test.cc
@@ -309,7 +309,7 @@ GTEST_TEST(RenderEngine, ValidateIntrinsicsAndImage) {
       "Can't render a label image. The given output image is nullptr");
 
   // Image size doesn't match.
-  const char* error_message =
+  constexpr const char* error_message =
       "The {} image to write has a size different from that specified in "
       "the camera intrinsics. Image: \\({}, {}\\), intrinsics: \\({}, {}\\)";
 

--- a/geometry/render_gl/internal_opengl_context.cc
+++ b/geometry/render_gl/internal_opengl_context.cc
@@ -53,7 +53,7 @@ GLXContext glXCreateContextAttribsARB(
 
 void GlDebugCallback(GLenum, GLenum type, GLuint, GLenum severity, GLsizei,
                      const GLchar* message, const void*) {
-  const char* output =
+  constexpr const char* output =
       "GL CALLBACK: {:s} type = 0x{:x}, severity = 0x{:x}, message = {:s}";
   if (type == GL_DEBUG_TYPE_ERROR) {
     drake::log()->error(output, "** GL_ERROR **", type, severity, message);

--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -499,7 +499,7 @@ TEST_F(SceneGraphParserDetail, VisualGeometryNameRequirements) {
 
   // A fmt::format-compatible string for testing various permutations of visual
   // names.
-  const std::string visual_tag =
+  constexpr const char* visual_tag =
       "<visual name='{}'>"
       "  <pose>1.0 2.0 3.0 3.14 6.28 1.57</pose>"
       "  <geometry>"
@@ -1090,7 +1090,7 @@ TEST_F(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
   // It contains a `{}` place holder such that child tags of <collision> can be
   // injected to test various expressions of collision properties --
   // substitution via fmt::format.
-  const std::string collision_xml = R"""(
+  constexpr const char* collision_xml = R"""(
 <collision name="some_geo">
   <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
   <geometry>

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -1650,7 +1650,7 @@ TEST_F(SdfParserTest, BushingParsingBad3) {
 TEST_F(SdfParserTest, ReflectedInertiaParametersParsing) {
   AddSceneGraph();
   // Common SDF string with format options for the two custom tags.
-  const std::string test_string = R"""(
+  constexpr const char* test_string = R"""(
     <model name='ReflectedInertiaModel_{2}'>
       <link name='A'/>
       <link name='B'/>

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -239,7 +239,7 @@ class UrdfGeometryTest : public test::DiagnosticPolicyTestBase {
   // <collision> tag.
   void MakeCollisionDocFromString(
       const std::string& collision_spec) {
-    const std::string urdf_harness = R"""(
+    constexpr const char* urdf_harness = R"""(
 <?xml version="1.0"?>
   <collision>
     <geometry>
@@ -749,7 +749,7 @@ TEST_F(UrdfGeometryTest, TestBadBox) {
 }
 
 TEST_F(UrdfGeometryTest, TestBadSphere) {
-  std::string base = R"""(
+  constexpr const char* base = R"""(
     <robot name='a'>
       <link name='b'>
         <collision>
@@ -766,7 +766,7 @@ TEST_F(UrdfGeometryTest, TestBadSphere) {
 }
 
 TEST_F(UrdfGeometryTest, TestBadCylinder) {
-  std::string base = R"""(
+  constexpr const char* base = R"""(
     <robot name='a'>
       <link name='b'>
         <collision>
@@ -791,7 +791,7 @@ TEST_F(UrdfGeometryTest, TestBadCylinder) {
 }
 
 TEST_F(UrdfGeometryTest, TestBadCapsule) {
-  std::string base = R"""(
+  constexpr const char* base = R"""(
     <robot name='a'>
       <link name='b'>
         <collision>
@@ -821,7 +821,7 @@ TEST_F(UrdfGeometryTest, TestBadCapsule) {
 }
 
 TEST_F(UrdfGeometryTest, TestBadEllipsoid) {
-  std::string base = R"""(
+  constexpr const char* base = R"""(
     <robot name='a'>
       <link name='b'>
         <collision>
@@ -854,7 +854,7 @@ TEST_F(UrdfGeometryTest, TestBadEllipsoid) {
 }
 
 TEST_F(UrdfGeometryTest, TestBadMesh) {
-  std::string base = R"""(
+  constexpr const char* base = R"""(
     <robot name='a'>
       <link name='b'>
         <collision>
@@ -889,7 +889,7 @@ TEST_F(UrdfGeometryTest, TestBadShapeCollision) {
 }
 
 TEST_F(UrdfGeometryTest, TestLegacyDrakeCompliance) {
-  std::string base = R"""(
+  constexpr const char* base = R"""(
     <robot name='a'>
       <link name='b'>
         <collision>
@@ -938,7 +938,7 @@ TEST_F(UrdfGeometryTest, TestBadShapeVisual) {
 }
 
 TEST_F(UrdfGeometryTest, TestBadProperty) {
-  std::string base = R"""(
+  constexpr const char* base = R"""(
   <drake:proximity_properties>
     <drake:mu_dynamic {}/>
   </drake:proximity_properties>)""";

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -209,7 +209,7 @@ TEST_F(UrdfParserTest, JointChildLinkBroken) {
 }
 
 TEST_F(UrdfParserTest, JointBadDynamicsAttributes) {
-  std::string base = R"""(
+  constexpr const char* base = R"""(
     <robot name='a'>
       <link name='parent'/>
       <link name='child'/>
@@ -444,7 +444,7 @@ TEST_F(UrdfParserTest, TransmissionJointNotExist) {
 }
 
 TEST_F(UrdfParserTest, TransmissionJointBadLimits) {
-  std::string base = R"""(
+  constexpr const char* base = R"""(
     <robot name='a'>
       <link name='parent'/>
       <link name='child'/>
@@ -963,7 +963,7 @@ TEST_F(UrdfParserTest, PointMass) {
 
 TEST_F(UrdfParserTest, BadInertia) {
   // Test various mis-formatted inputs.
-  std::string base = R"""(
+  constexpr const char* base = R"""(
     <robot name='point_mass'>
       <link name='point_mass'>
         <inertial>
@@ -1192,7 +1192,7 @@ class ReflectedInertiaTest : public UrdfParserTest {
                         double rotor_inertia,
                         double gear_ratio) {
     std::string text =
-        fmt::format(test_string_, rotor_inertia_text, gear_ratio_text);
+        fmt::format(kTestString, rotor_inertia_text, gear_ratio_text);
     EXPECT_NE(AddModelFromUrdfString(text, ""), std::nullopt);
 
     const JointActuator<double>& actuator =
@@ -1206,14 +1206,14 @@ class ReflectedInertiaTest : public UrdfParserTest {
                     const std::string& gear_ratio_text,
                     const std::string& error_pattern) {
     std::string text =
-        fmt::format(test_string_, rotor_inertia_text, gear_ratio_text);
+        fmt::format(kTestString, rotor_inertia_text, gear_ratio_text);
     EXPECT_NE(AddModelFromUrdfString(text, ""), std::nullopt);
     EXPECT_THAT(TakeError(), MatchesRegex(error_pattern));
   }
 
  protected:
   // Common URDF string with format options for the two custom tags.
-  const std::string test_string_ = R"""(
+  static constexpr const char* kTestString = R"""(
     <robot name='reflected_inertia_test'>
       <link name='A'/>
       <link name='B'/>
@@ -1498,7 +1498,7 @@ TEST_F(UrdfParserTest, UnsupportedTransmissionJointStuffIgnoredSilent) {
 
 TEST_F(UrdfParserTest, UnsupportedMechanicalReductionIgnoredMaybe) {
   // Two substitution slots: actuator, then transmission.
-  constexpr char robot_template[] = R"""(
+  constexpr const char* robot_template = R"""(
     <robot>
       <link name='parent'/>
       <link name='child'/>

--- a/solvers/program_attribute.cc
+++ b/solvers/program_attribute.cc
@@ -61,10 +61,10 @@ bool AreRequiredAttributesSupported(const ProgramAttributes& required,
     noun_phrase += to_string(unsupported_enums[i]);
   }
   *unsupported_message = fmt::format(
-      (size == 1) ?
-          "a {} was declared but is not supported" :
-          "a {} were declared but are not supported",
-      noun_phrase);
+      "a {} {} declared but {} not supported",
+      noun_phrase,
+      (size == 1) ? "was" : "were",
+      (size == 1) ? "is" : "are");
   return false;
 }
 


### PR DESCRIPTION
This enables the (soon to be required) compile-time checking of the pattern string by default.

Towards #17943.

+@SeanCurtis-TRI for both reviews per schedule, please +(status: single reviewer ok) +(priority: medium).

We'll use +(release notes: none) saving the release note for #17943 itself.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17949)
<!-- Reviewable:end -->
