### PR TITLE
[geometry/optimization] Hotfix for graph_of_convex_sets_test

### DIFF
--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -1292,12 +1292,12 @@ GTEST_TEST(ShortestPathTest, RoundedSolution) {
   const auto& edges = spp.Edges();
   for (size_t ii = 0; ii < edges.size(); ++ii) {
     if (ii < 6) {
-      if (relaxed_result.get_solver_id() == solvers::CsdpSolver::id()) {
-        // Csdp does not balance the two paths as closely as other solvers.
-        EXPECT_NEAR(relaxed_result.GetSolution(edges[ii]->phi()), 0.5, 1e-2);
-      } else {
-        EXPECT_NEAR(relaxed_result.GetSolution(edges[ii]->phi()), 0.5, 1e-6);
-      }
+      // Some solvers do not balance the two paths as closely as other solvers.
+      const double tol =
+          (relaxed_result.get_solver_id() == solvers::GurobiSolver::id()) ? 1e-1
+          : (relaxed_result.get_solver_id() == solvers::CsdpSolver::id()) ? 1e-2
+          : 1e-6;
+      EXPECT_NEAR(relaxed_result.GetSolution(edges[ii]->phi()), 0.5, tol);
     } else if (ii < 10) {
       EXPECT_LT(relaxed_result.GetSolution(edges[ii]->phi()), 0.5);
       EXPECT_GT(relaxed_result.GetSolution(edges[ii]->phi()), 0);


### PR DESCRIPTION
The Gurobi tolerance was set too tight.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17950)
<!-- Reviewable:end -->
