### PR TITLE
[install] Add eigen support to the drake_bazel_installed workflow

### DIFF
--- a/tools/install/bazel/drake.BUILD.bazel
+++ b/tools/install/bazel/drake.BUILD.bazel
@@ -73,6 +73,7 @@ cc_library(
     name = ".fmt_headers",
     hdrs = glob([".include/fmt/**"], allow_empty = True),
     strip_include_prefix = ".include/fmt",
+    visibility = ["@fmt//:__pkg__"],
 )
 
 [
@@ -87,7 +88,8 @@ cc_library(
     name = "drake_shared_library",
     deps = [
         ":.drake_headers",
-        ":.fmt_headers",
+        "@eigen",
+        "@fmt",
     ] + [
         ":.imported{}".format(shlib)
         for shlib in _DRAKE_SHLIBS

--- a/tools/install/bazel/repo_template.bzl
+++ b/tools/install/bazel/repo_template.bzl
@@ -4,25 +4,32 @@
 # * # Comment lines beginning with a "# * #" are stripped out as part of the
 # * # conversion from repo_template.bzl to repo.bzl via the repo_gen tool.
 
-def _call_drake_impl(*args):  # Akin to a forward declaration.
-    _drake_impl(*args)
+def drake_repository(name, *, excludes = [], **kwargs):
+    """Declares the @drake repository based on an installed Drake binary image,
+    along with repositories for its dependencies @eigen and @fmt.
 
-drake_repository = repository_rule(
-    implementation = _call_drake_impl,
-    local = True,
-    doc = """
-Declares the @drake repository based on an installed Drake binary image.
+    This enables downstream BUILD files to refer to certain Drake targets when
+    using precompiled Drake releases.
 
-This enables downstream BUILD files to refer to Drake targets such as
-@drake//bindings/pydrake even when using precompiled Drake releases.
+    Only a limited number of targets are supported, currently only:
+    - @drake//bindings/pydrake
+    - @drake//:drake_shared_library
 
-Only a limited number of targets are supported, currently only:
-- @drake//bindings/pydrake
+    For an example of proper use, see
+    https://github.com/RobotLocomotion/drake-external-examples/tree/master/drake_bazel_installed
 
-For an example of proper use, see
-https://github.com/RobotLocomotion/drake-external-examples/tree/master/drake_bazel_installed
-""",
-)
+    The `excludes` argument may be used to skip over @eigen and/or @fmt (by
+    passing, e.g., `excludes = ["eigen"]`, in which case you are responsible
+    for providing your own definition of those repositories.
+    """
+    _drake_repository(name = name, **kwargs)
+
+    # The list of external repositories here is roughly consistent with Drake's
+    # allowed list of public headers as seen in header_dependency_test.py.
+    if "eigen" not in excludes:
+        _eigen_repository(name = "eigen")
+    if "fmt" not in excludes:
+        _fmt_repository(name = "fmt", drake_name = name)
 
 def _drake_impl(repo_ctx):
     # Obtain the root of the @drake_loader repository (i.e., wherever this
@@ -96,6 +103,41 @@ def _drake_impl(repo_ctx):
     # Annotate the OS for use by our BUILD files.
     os_bzl = "NAME = \"{}\"\n".format(repo_ctx.os.name)
     repo_ctx.file(".os.bzl", content = os_bzl, executable = False)
+
+def _eigen_repository(name):
+    native.new_local_repository(
+        name = name,
+        path = "/usr/include/eigen3",
+        build_file_content = """
+cc_library(
+    name = "eigen",
+    hdrs = glob(["Eigen/**"], allow_empty = False),
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)
+""",
+    )
+
+_drake_repository = repository_rule(
+    implementation = _drake_impl,
+    local = True,
+)
+
+def _fmt_impl(repo_ctx):
+    repo_ctx.file("BUILD.bazel", """
+cc_library(
+    name = "fmt",
+    deps = ["@{}//:.fmt_headers"],
+    visibility = ["//visibility:public"],
+)
+""".format(repo_ctx.attr.drake_name, executable = False))
+
+_fmt_repository = repository_rule(
+    implementation = _fmt_impl,
+    attrs = {
+        "drake_name": attr.string(mandatory = True),
+    },
+)
 
 # * # This placeholder definition in repo_template.bzl is rewritten by repo_gen
 # * # during the Drake source build.  Its new contents will be the bodies of


### PR DESCRIPTION
Closes #17965.

---

I've tested this locally by adding this patch atop https://github.com/RobotLocomotion/drake-external-examples/pull/237 ...
```
--- a/drake_bazel_installed/WORKSPACE
+++ b/drake_bazel_installed/WORKSPACE
@@ -48,7 +48,7 @@
 
 # To use a local unpacked Drake binary release instead of an http download, set
 # this variable to the correct path, e.g., "/opt/drake".
-INSTALLED_DRAKE_DIR = None
+INSTALLED_DRAKE_DIR = "/home/jwnimmer/tmp/wakka"
 
 # This is only relevant when INSTALLED_DRAKE_DIR is set.
 new_local_repository(
```

... and then running this command:

```
(bazel run //:install -- /home/jwnimmer/tmp/wakka 2>&1 | tail) \
  && (cd ~/drake-external-examples/drake_bazel_installed && bazel test //...)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17968)
<!-- Reviewable:end -->
