### PR TITLE
[geometry/optimization] Improve GraphOfConvexSets handling of infeasible problems

### DIFF
--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -39,6 +39,7 @@ using solvers::MathematicalProgram;
 using solvers::MathematicalProgramResult;
 using solvers::PerspectiveQuadraticCost;
 using solvers::QuadraticCost;
+using solvers::SolutionResult;
 using solvers::VariableRefList;
 using solvers::VectorXDecisionVariable;
 using symbolic::Expression;
@@ -884,7 +885,8 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
   // Implements the rounding scheme put forth in Section 4.2 of
   // "Motion Planning around Obstacles with Convex Optimization":
   // https://arxiv.org/abs/2205.04422
-  if (options.convex_relaxation && options.max_rounded_paths > 0) {
+  if (options.convex_relaxation && options.max_rounded_paths > 0 &&
+      result.is_success()) {
     DRAKE_THROW_UNLESS(options.max_rounding_trials > 0);
     RandomGenerator generator(options.rounding_seed);
     std::uniform_real_distribution<double> uniform;
@@ -898,7 +900,7 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
       }
     }
     int num_trials = 0;
-    MathematicalProgramResult best_result;
+    MathematicalProgramResult best_rounded_result;
     while (static_cast<int>(paths.size()) < options.max_rounded_paths &&
            num_trials < options.max_rounding_trials) {
       ++num_trials;
@@ -969,18 +971,23 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
 
       MathematicalProgramResult rounded_result = Solve(prog, options);
 
-      // Check path quality and early termination.
+      // Check path quality.
       if (rounded_result.is_success() &&
-          (num_trials == 1 || rounded_result.get_optimal_cost() <
-                                  best_result.get_optimal_cost())) {
-        best_result = rounded_result;
+          (!best_rounded_result.is_success() ||
+           rounded_result.get_optimal_cost() <
+               best_rounded_result.get_optimal_cost())) {
+        best_rounded_result = rounded_result;
       }
 
       for (Binding<Constraint>& con : added_constraints) {
         prog.RemoveConstraint(con);
       }
     }
-    result = best_result;
+    if (best_rounded_result.is_success()) {
+      result = best_rounded_result;
+    } else {
+      result.set_solution_result(SolutionResult::kIterationLimit);
+    }
   }
 
   // Push the placeholder variables and excluded edge variables into the result,


### PR DESCRIPTION
Handles the case where the convex relaxation is infeasible and rounding is requested as well as the case where the relaxation is feasible but all rounded solutions tried are infeasible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17974)
<!-- Reviewable:end -->
