### PR TITLE
[planner] Clean up formulation of Differential IK

### DIFF
--- a/bindings/pydrake/manipulation/BUILD.bazel
+++ b/bindings/pydrake/manipulation/BUILD.bazel
@@ -50,6 +50,7 @@ drake_pybind_library(
     name = "planner_py",
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:eigen_pybind",
     ],
     cc_srcs = ["planner_py.cc"],
@@ -118,6 +119,7 @@ drake_py_unittest(
     ],
     deps = [
         ":planner_py",
+        "//bindings/pydrake/common/test_utilities",
         "//bindings/pydrake/multibody",
     ],
 )

--- a/bindings/pydrake/manipulation/planner_py.cc
+++ b/bindings/pydrake/manipulation/planner_py.cc
@@ -2,6 +2,7 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/manipulation/planner/differential_inverse_kinematics.h"
@@ -55,10 +56,11 @@ PYBIND11_MODULE(planner, m) {
     cls.def(py::init([](int num_positions, int num_velocities) {
          return Class{num_positions, num_velocities};
        }),
-           py::arg("num_positions") = 0, py::arg("num_velocities") = 0,
+           py::arg("num_positions"), py::arg("num_velocities") = std::nullopt,
            cls_doc.ctor.doc)
-        .def("get_timestep", &Class::get_timestep, cls_doc.get_timestep.doc)
-        .def("set_timestep", &Class::set_timestep, cls_doc.set_timestep.doc)
+        .def("get_time_step", &Class::get_time_step, cls_doc.get_time_step.doc)
+        .def("set_time_step", &Class::set_time_step, py::arg("dt"),
+            cls_doc.set_time_step.doc)
         .def("get_num_positions", &Class::get_num_positions,
             cls_doc.get_num_positions.doc)
         .def("get_num_velocities", &Class::get_num_velocities,
@@ -67,18 +69,16 @@ PYBIND11_MODULE(planner, m) {
             cls_doc.get_nominal_joint_position.doc)
         .def("set_nominal_joint_position", &Class::set_nominal_joint_position,
             cls_doc.set_nominal_joint_position.doc)
-        .def("get_end_effector_velocity_gain",
-            &Class::get_end_effector_velocity_gain,
-            cls_doc.get_end_effector_velocity_gain.doc)
-        .def("set_end_effector_velocity_gain",
-            &Class::set_end_effector_velocity_gain,
-            cls_doc.set_end_effector_velocity_gain.doc)
-        .def("get_unconstrained_degrees_of_freedom_velocity_limit",
-            &Class::get_unconstrained_degrees_of_freedom_velocity_limit,
-            cls_doc.get_unconstrained_degrees_of_freedom_velocity_limit.doc)
-        .def("set_unconstrained_degrees_of_freedom_velocity_limit",
-            &Class::set_unconstrained_degrees_of_freedom_velocity_limit,
-            cls_doc.set_unconstrained_degrees_of_freedom_velocity_limit.doc)
+        .def("get_joint_centering_gain", &Class::get_joint_centering_gain,
+            cls_doc.get_joint_centering_gain.doc)
+        .def("set_joint_centering_gain", &Class::set_joint_centering_gain,
+            py::arg("K"), cls_doc.set_joint_centering_gain.doc)
+        .def("get_end_effector_velocity_flag",
+            &Class::get_end_effector_velocity_flag,
+            cls_doc.get_end_effector_velocity_flag.doc)
+        .def("set_end_effector_velocity_flag",
+            &Class::set_end_effector_velocity_flag, py::arg("flag_E"),
+            cls_doc.set_end_effector_velocity_flag.doc)
         .def("get_joint_position_limits", &Class::get_joint_position_limits,
             cls_doc.get_joint_position_limits.doc)
         .def("set_joint_position_limits", &Class::set_joint_position_limits,
@@ -92,7 +92,51 @@ PYBIND11_MODULE(planner, m) {
             cls_doc.get_joint_acceleration_limits.doc)
         .def("set_joint_acceleration_limits",
             &Class::set_joint_acceleration_limits,
-            cls_doc.set_joint_acceleration_limits.doc);
+            cls_doc.set_joint_acceleration_limits.doc)
+        .def("get_maximum_scaling_to_report_stuck",
+            &Class::get_maximum_scaling_to_report_stuck,
+            cls_doc.get_maximum_scaling_to_report_stuck.doc)
+        .def("set_maximum_scaling_to_report_stuck",
+            &Class::set_maximum_scaling_to_report_stuck, py::arg("scaling"),
+            cls_doc.set_maximum_scaling_to_report_stuck.doc);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls.def(py_init_deprecated<Class>(cls_doc.ctor.doc_deprecated),
+           cls_doc.ctor.doc_deprecated)
+        .def("get_timestep",
+            WrapDeprecated(
+                cls_doc.get_timestep.doc_deprecated, &Class::get_timestep),
+            cls_doc.get_timestep.doc_deprecated)
+        .def("set_timestep",
+            WrapDeprecated(
+                cls_doc.set_timestep.doc_deprecated, &Class::set_timestep),
+            cls_doc.set_timestep.doc_deprecated)
+        .def("get_end_effector_velocity_gain",
+            WrapDeprecated(
+                cls_doc.get_end_effector_velocity_gain.doc_deprecated,
+                &Class::get_end_effector_velocity_gain),
+            cls_doc.get_end_effector_velocity_gain.doc_deprecated)
+        .def("set_end_effector_velocity_gain",
+            WrapDeprecated(
+                cls_doc.set_end_effector_velocity_gain.doc_deprecated,
+                &Class::set_end_effector_velocity_gain),
+            cls_doc.set_end_effector_velocity_gain.doc_deprecated)
+        .def("get_unconstrained_degrees_of_freedom_velocity_limit",
+            WrapDeprecated(
+                cls_doc.get_unconstrained_degrees_of_freedom_velocity_limit
+                    .doc_deprecated,
+                &Class::get_unconstrained_degrees_of_freedom_velocity_limit),
+            cls_doc.get_unconstrained_degrees_of_freedom_velocity_limit
+                .doc_deprecated)
+        .def("set_unconstrained_degrees_of_freedom_velocity_limit",
+            WrapDeprecated(
+                cls_doc.set_unconstrained_degrees_of_freedom_velocity_limit
+                    .doc_deprecated,
+                &Class::set_unconstrained_degrees_of_freedom_velocity_limit),
+            cls_doc.set_unconstrained_degrees_of_freedom_velocity_limit
+                .doc_deprecated);
+#pragma GCC diagnostic pop
   }
 
   m.def(

--- a/bindings/pydrake/manipulation/test/planner_test.py
+++ b/bindings/pydrake/manipulation/test/planner_test.py
@@ -6,6 +6,7 @@ import unittest
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.math import RigidTransform
 from pydrake.multibody.plant import MultibodyPlant
 from pydrake.multibody.parsing import Parser
@@ -29,23 +30,40 @@ class TestPlanner(unittest.TestCase):
         params_cls = mut.DifferentialInverseKinematicsParameters
         params = params_cls(num_positions=2, num_velocities=2)
         # Test existence.
-        params.get_timestep
-        params.set_timestep
+        params.set_time_step(dt=0.2)
+        self.assertEqual(params.get_time_step(), 0.2)
         params.get_num_positions
         params.get_nominal_joint_position
         params.get_num_velocities
         params.get_nominal_joint_position
         params.set_nominal_joint_position
-        params.get_end_effector_velocity_gain
-        params.set_end_effector_velocity_gain
-        params.get_unconstrained_degrees_of_freedom_velocity_limit
-        params.set_unconstrained_degrees_of_freedom_velocity_limit
+        params.set_joint_centering_gain(K=np.eye(2))
+        np.testing.assert_equal(params.get_joint_centering_gain(), np.eye(2))
+        flag_E = [False, True, True, False, False, True]
+        params.set_end_effector_velocity_flag(flag_E)
+        np.testing.assert_equal(params.get_end_effector_velocity_flag(),
+                                flag_E)
         params.get_joint_position_limits
         params.set_joint_position_limits
         params.get_joint_velocity_limits
         params.set_joint_velocity_limits
         params.get_joint_acceleration_limits
         params.set_joint_acceleration_limits
+        params.set_maximum_scaling_to_report_stuck(scaling=0.1)
+        self.assertEqual(params.get_maximum_scaling_to_report_stuck(), 0.1)
+
+        # The following methods are deprecated, to be removed on or after
+        # 2023-01-01.
+        with catch_drake_warnings(expected_count=7):
+            params.get_timestep()
+            params.set_timestep(0.2)
+            params.get_unconstrained_degrees_of_freedom_velocity_limit()
+            params.set_unconstrained_degrees_of_freedom_velocity_limit(0.1)
+            params.get_end_effector_velocity_gain()
+            params.set_end_effector_velocity_gain(np.ones(6))
+            # Deprecated default constructor
+            p2 = mut.DifferentialInverseKinematicsParameters()
+            self.assertEqual(p2.get_num_positions(), 1)
 
         # Test a basic call for the API. These values intentionally have no
         # physical meaning.
@@ -98,5 +116,5 @@ class TestPlanner(unittest.TestCase):
             robot_context=context,
             log_only_when_result_state_changes=True)
 
-        integrator.get_mutable_parameters().set_timestep(0.2)
-        self.assertEqual(integrator.get_parameters().get_timestep(), 0.2)
+        integrator.get_mutable_parameters().set_time_step(0.2)
+        self.assertEqual(integrator.get_parameters().get_time_step(), 0.2)

--- a/examples/manipulation_station/end_effector_teleop_dualshock4.py
+++ b/examples/manipulation_station/end_effector_teleop_dualshock4.py
@@ -369,7 +369,7 @@ def main():
     params = DifferentialInverseKinematicsParameters(robot.num_positions(),
                                                      robot.num_velocities())
 
-    params.set_timestep(args.time_step)
+    params.set_time_step(args.time_step)
     # True velocity limits for the IIWA14 (in rad/s, rounded down to the first
     # decimal)
     iiwa14_velocity_limits = np.array([1.4, 1.4, 1.7, 1.3, 2.2, 2.3, 2.3])

--- a/examples/manipulation_station/end_effector_teleop_mouse.py
+++ b/examples/manipulation_station/end_effector_teleop_mouse.py
@@ -343,7 +343,7 @@ def main():
                                                      robot.num_velocities())
 
     time_step = 0.005
-    params.set_timestep(time_step)
+    params.set_time_step(time_step)
     # True velocity limits for the IIWA14 (in rad, rounded down to the first
     # decimal)
     iiwa14_velocity_limits = np.array([1.4, 1.4, 1.7, 1.3, 2.2, 2.3, 2.3])

--- a/examples/manipulation_station/end_effector_teleop_sliders.py
+++ b/examples/manipulation_station/end_effector_teleop_sliders.py
@@ -275,7 +275,7 @@ def main():
                                                      robot.num_velocities())
 
     time_step = 0.005
-    params.set_timestep(time_step)
+    params.set_time_step(time_step)
     # True velocity limits for the IIWA14 (in rad, rounded down to the first
     # decimal)
     iiwa14_velocity_limits = np.array([1.4, 1.4, 1.7, 1.3, 2.2, 2.3, 2.3])

--- a/manipulation/planner/BUILD.bazel
+++ b/manipulation/planner/BUILD.bazel
@@ -42,6 +42,7 @@ drake_cc_library(
     hdrs = ["differential_inverse_kinematics.h"],
     deps = [
         "//multibody/plant",
+        "//solvers:clp_solver",
         "//solvers:mathematical_program",
         "//solvers:osqp_solver",
     ],

--- a/manipulation/planner/differential_inverse_kinematics.cc
+++ b/manipulation/planner/differential_inverse_kinematics.cc
@@ -6,6 +6,7 @@
 
 #include <fmt/format.h>
 
+#include "drake/solvers/clp_solver.h"
 #include "drake/solvers/osqp_solver.h"
 
 namespace drake {
@@ -31,21 +32,20 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
   J_WE_E.topRows<3>() = R_EW * J_WE_W.topRows<3>();
   J_WE_E.bottomRows<3>() = R_EW * J_WE_W.bottomRows<3>();
 
-  Vector6<double> V_WE_E_scaled;
-  MatrixX<double> J_WE_E_scaled{6, num_columns};
+  Vector6<double> V_WE_E_with_flags;
+  MatrixX<double> J_WE_E_with_flags{6, num_columns};
   int num_cart_constraints = 0;
   for (int i = 0; i < 6; i++) {
-    const double gain{parameters.get_end_effector_velocity_gain()(i)};
-    if (gain > 0) {
-      J_WE_E_scaled.row(num_cart_constraints) = gain * J_WE_E.row(i);
-      V_WE_E_scaled(num_cart_constraints) = gain * V_WE_E[i];
+    if (parameters.get_end_effector_velocity_flag()(i)) {
+      J_WE_E_with_flags.row(num_cart_constraints) = J_WE_E.row(i);
+      V_WE_E_with_flags(num_cart_constraints) = V_WE_E[i];
       num_cart_constraints++;
     }
   }
 
   return DoDifferentialInverseKinematics(
-      q_current, v_current, V_WE_E_scaled.head(num_cart_constraints),
-      J_WE_E_scaled.topRows(num_cart_constraints), parameters);
+      q_current, v_current, V_WE_E_with_flags.head(num_cart_constraints),
+      J_WE_E_with_flags.topRows(num_cart_constraints), parameters);
 }
 }  // namespace internal
 
@@ -99,12 +99,22 @@ Vector6<double> ComputePoseDiffInCommonFrame(
   return diff;
 }
 
+// Deprecated constructor.
+DifferentialInverseKinematicsParameters::
+    DifferentialInverseKinematicsParameters()
+    : DifferentialInverseKinematicsParameters(1, 1) {}
+
 DifferentialInverseKinematicsParameters::
     DifferentialInverseKinematicsParameters(int num_positions,
-                                            int num_velocities)
+                                            std::optional<int> num_velocities)
     : num_positions_(num_positions),
-      num_velocities_(num_velocities),
-      nominal_joint_position_(VectorX<double>::Zero(num_positions)) {}
+      num_velocities_(num_velocities.value_or(num_positions)),
+      nominal_joint_position_(VectorX<double>::Zero(num_positions)),
+      joint_centering_gain_(
+          MatrixX<double>::Zero(num_velocities_, num_positions)) {
+  DRAKE_DEMAND(num_positions > 0);
+  DRAKE_DEMAND(num_velocities > 0);
+}
 
 DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     const Eigen::Ref<const VectorX<double>>& q_current,
@@ -114,79 +124,54 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     const DifferentialInverseKinematicsParameters& parameters) {
   const int num_positions = parameters.get_num_positions();
   const int num_velocities = parameters.get_num_velocities();
+  const double dt = parameters.get_time_step();
   const int num_cart_constraints = V.size();
   DRAKE_DEMAND(q_current.size() == num_positions);
   DRAKE_DEMAND(v_current.size() == num_velocities);
   DRAKE_DEMAND(J.rows() == num_cart_constraints);
   DRAKE_DEMAND(J.cols() == num_velocities);
+  // A bunch of the operations below assume num_positions == num_velocities.
+  DRAKE_DEMAND(num_positions == num_velocities);
 
   const auto identity_num_positions =
       MatrixX<double>::Identity(num_positions, num_positions);
 
   solvers::MathematicalProgram prog;
+  bool quadratic_cost = false;
   solvers::VectorXDecisionVariable v_next =
       prog.NewContinuousVariables(num_velocities, "v_next");
   solvers::VectorDecisionVariable<1> alpha =
       prog.NewContinuousVariables<1>("alpha");
 
-  const solvers::QuadraticCost* cart_cost = nullptr;
+  // 100*alpha
+  const double kPrimaryObjectiveGain = 100;
+  prog.AddLinearCost(-Vector1d{kPrimaryObjectiveGain}, 0.0, alpha);
 
-  if (num_cart_constraints > 0) {
-    VectorX<double> V_dir = V.normalized();
-    double V_mag = V.norm();
+  // | P * (v_next - K * (q_nominal - q_current)) |^2
+  const Eigen::FullPivLU<MatrixX<double>> lu(J);
+  if (lu.rank() < num_velocities) {
+    const Eigen::MatrixXd P = lu.kernel().transpose();
+    prog.Add2NormSquaredCost(
+        P,
+        P * parameters.get_joint_centering_gain() *
+            (parameters.get_nominal_joint_position() - q_current),
+        v_next);
+    quadratic_cost = true;
+  }
 
-    // Constrain the end effector motion to be in the direction of V,
-    // and penalize magnitude difference from V.
+  // J * v_next = alpha * V
+  if (V.size() > 0) {
     MatrixX<double> A(num_cart_constraints, num_velocities + 1);
     A.leftCols(num_velocities) = J;
-    A.rightCols(1) = -V_dir;
+    A.rightCols(1) = -V;
     prog.AddLinearEqualityConstraint(
         A, VectorX<double>::Zero(num_cart_constraints), {v_next, alpha});
-    // TODO(russt): This should not be hard-coded.
-    const double kCartesianTrackingWeight = 100;
-    cart_cost =
-        prog.AddQuadraticErrorCost(Vector1<double>(kCartesianTrackingWeight),
-                                   Vector1<double>(V_mag), alpha)
-            .evaluator()
-            .get();
-
-    // Constrain the unconstrained DoFs velocity to be small, which is used
-    // to fulfill the regularization cost.  We use the svd of J = UΣV', in
-    // which the columns of V corresponding to the small/zero singular values
-    // in Σ are the "unconstrained" degrees of freedom.  Since JacobiSVD
-    // always sorts the singular values in decreasing order, we expect these
-    // to be the last columns.  We assume that J is full row-rank, so has
-    // num_cart_constraints non-zero singular values.
-    Eigen::JacobiSVD<MatrixX<double>> svd(J, Eigen::ComputeFullV);
-    if (parameters.get_unconstrained_degrees_of_freedom_velocity_limit()) {
-      const double uncon_v =
-          parameters.get_unconstrained_degrees_of_freedom_velocity_limit()
-              .value();
-      for (int i = num_cart_constraints; i < num_velocities; i++) {
-        prog.AddLinearConstraint(svd.matrixV().col(i).transpose(), -uncon_v,
-                                 uncon_v, v_next);
-      }
-    }
   }
 
-  for (const auto& constraint : parameters.get_linear_velocity_constraints()) {
-    prog.AddConstraint(
-        solvers::Binding<solvers::LinearConstraint>(constraint, v_next));
-  }
+  // 0 <= alpha <= 1
+  prog.AddBoundingBoxConstraint(0, 1, alpha);
 
-  // A bunch of the operations below assume num_positions == num_velocities.
-  // TODO(russt): Generalize this
-  DRAKE_DEMAND(num_positions == num_velocities);
-
-  // If redundant, add a small regularization term to q_nominal.
-  const double dt{parameters.get_timestep()};
-  if (num_cart_constraints < num_velocities) {
-    prog.AddQuadraticErrorCost(
-        identity_num_positions * dt * dt,
-        (parameters.get_nominal_joint_position() - q_current) / dt, v_next);
-  }
-
-  // Add q upper and lower joint limit.
+  // joint_lim_min <= q_current + v_next*dt <= joint_lim_max
   if (parameters.get_joint_position_limits()) {
     prog.AddBoundingBoxConstraint(
         (parameters.get_joint_position_limits()->first - q_current) / dt,
@@ -194,46 +179,49 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
         v_next);
   }
 
-  // Add v_next constraint.
+  // joint_vel_lim_min <= v_next <= joint_vel_lim_max
   if (parameters.get_joint_velocity_limits()) {
     prog.AddBoundingBoxConstraint(
         parameters.get_joint_velocity_limits()->first,
         parameters.get_joint_velocity_limits()->second, v_next);
   }
 
-  // Add vd constraint.
+  // joint_accel_lim_min <= (v_next - v_current)/dt <= joint_accel_lim_max
   if (parameters.get_joint_acceleration_limits()) {
     prog.AddLinearConstraint(
-        // TODO(russt): This should be num_velocities if we generalize the
-        // implementation.
         identity_num_positions,
         parameters.get_joint_acceleration_limits()->first * dt + v_current,
         parameters.get_joint_acceleration_limits()->second * dt + v_current,
         v_next);
   }
 
+  // additional linear velocity constraints
+  for (const auto& constraint : parameters.get_linear_velocity_constraints()) {
+    prog.AddConstraint(
+        solvers::Binding<solvers::LinearConstraint>(constraint, v_next));
+  }
+
   // Solve
-  solvers::OsqpSolver solver;
-  solvers::MathematicalProgramResult result = solver.Solve(prog, {}, {});
+  solvers::MathematicalProgramResult result;
+
+  if (quadratic_cost) {
+    solvers::OsqpSolver solver;
+    result = solver.Solve(prog, {}, {});
+  } else {
+    solvers::ClpSolver solver;
+    result = solver.Solve(prog, {}, {});
+  }
 
   if (!result.is_success()) {
     return {std::nullopt,
             DifferentialInverseKinematicsStatus::kNoSolutionFound};
   }
 
-  if (num_cart_constraints) {
-    VectorX<double> cost(1);
-    cart_cost->Eval(result.GetSolution(alpha), &cost);
-    const double kMaxTrackingError = 5;
-    const double kMinEndEffectorVel = 1e-2;
-    if (cost(0) > kMaxTrackingError &&
-        result.GetSolution(alpha)[0] <= kMinEndEffectorVel) {
-      // Not tracking the desired vel norm (large tracking error) and the
-      // computed vel is small.
-      log()->info("v_next = {}", result.GetSolution(v_next).transpose());
-      log()->info("alpha = {}", result.GetSolution(alpha).transpose());
-      return {std::nullopt, DifferentialInverseKinematicsStatus::kStuck};
-    }
+  const double alpha_sol = result.GetSolution(alpha[0]);
+  if (alpha_sol < parameters.get_maximum_scaling_to_report_stuck()) {
+    // The computed velocity is small compared to the desired.
+    return {result.GetSolution(v_next),
+            DifferentialInverseKinematicsStatus::kStuck};
   }
 
   return {result.GetSolution(v_next),
@@ -271,7 +259,7 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
       frame_E.CalcPoseInBodyFrame(context);
   const Vector6<double> V_WE_desired =
       ComputePoseDiffInCommonFrame(X_WE, X_WE_desired) /
-      parameters.get_timestep();
+      parameters.get_time_step();
   return DoDifferentialInverseKinematics(plant, context, V_WE_desired, frame_E,
                                          parameters);
 }

--- a/manipulation/planner/differential_inverse_kinematics_integrator.cc
+++ b/manipulation/planner/differential_inverse_kinematics_integrator.cc
@@ -20,7 +20,7 @@ DifferentialInverseKinematicsIntegrator::
       frame_E_(frame_E),
       parameters_(parameters),
       time_step_(time_step) {
-  parameters_.set_timestep(time_step);
+  parameters_.set_time_step(time_step);
 
   // This is accessed as port 0 in the code below.
   this->DeclareAbstractInputPort("X_WE_desired",
@@ -97,6 +97,7 @@ systems::EventStatus DifferentialInverseKinematicsIntegrator::Integrate(
     systems::DiscreteValues<double>* discrete_state) const {
   const AbstractValue* input = this->EvalAbstractInput(context, 0);
   DRAKE_DEMAND(input != nullptr);
+  DRAKE_THROW_UNLESS(parameters_.get_time_step() == time_step_);
   const math::RigidTransformd& X_WE_desired =
       input->get_value<math::RigidTransformd>();
   const math::RigidTransform<double> X_WE = ForwardKinematics(context);

--- a/manipulation/planner/test/differential_inverse_kinematics_integrator_test.cc
+++ b/manipulation/planner/test/differential_inverse_kinematics_integrator_test.cc
@@ -74,7 +74,7 @@ GTEST_TEST(DifferentialInverseKinematicsIntegatorTest, BasicTest) {
       discrete_state->get_vector(1).GetAtIndex(0),
       static_cast<double>(DifferentialInverseKinematicsStatus::kSolutionFound));
 
-  params.set_timestep(time_step);  // intentionally set this after diff_ik call
+  params.set_time_step(time_step);  // intentionally set this after diff_ik call
   DifferentialInverseKinematicsResult result = DoDifferentialInverseKinematics(
       *robot, *robot_context, X_WE_desired, frame_E, params);
 
@@ -112,9 +112,9 @@ GTEST_TEST(DifferentialInverseKinematicsIntegatorTest, ParametersTest) {
   DifferentialInverseKinematicsIntegrator diff_ik(
       *robot, frame_E, time_step, params);
 
-  EXPECT_EQ(diff_ik.get_parameters().get_timestep(), time_step);
-  diff_ik.get_mutable_parameters().set_timestep(0.2);
-  EXPECT_EQ(diff_ik.get_parameters().get_timestep(), 0.2);
+  EXPECT_EQ(diff_ik.get_parameters().get_time_step(), time_step);
+  diff_ik.get_mutable_parameters().set_time_step(0.2);
+  EXPECT_EQ(diff_ik.get_parameters().get_time_step(), 0.2);
 }
 
 // Confirm that we can act like a difference equation system when the warning

--- a/manipulation/planner/test/differential_inverse_kinematics_test.cc
+++ b/manipulation/planner/test/differential_inverse_kinematics_test.cc
@@ -28,6 +28,14 @@ using multibody::MultibodyPlant;
 using multibody::FixedOffsetFrame;
 using solvers::LinearConstraint;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+GTEST_TEST(DifferentialInverseKinematicsParameters, DeprecatedConstructor) {
+  DifferentialInverseKinematicsParameters params{};
+  EXPECT_EQ(params.get_num_positions(), 1);
+}
+#pragma GCC diagnostic pop
+
 class DifferentialInverseKinematicsTest : public ::testing::Test {
  protected:
   void SetUp() {
@@ -57,8 +65,11 @@ class DifferentialInverseKinematicsTest : public ::testing::Test {
     const int num_joints = plant_->num_positions();
     plant_->SetDefaultContext(context_);
     params_->set_nominal_joint_position(VectorX<double>::Zero(num_joints));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     params_->set_unconstrained_degrees_of_freedom_velocity_limit(0.6);
-    params_->set_timestep(1e-3);
+#pragma GCC diagnostic pop
+    params_->set_time_step(1e-3);
 
     // Get position and velocity limits.
     VectorXd pos_upper_limits = plant_->GetPositionUpperLimits();
@@ -115,7 +126,7 @@ class DifferentialInverseKinematicsTest : public ::testing::Test {
 
     const int num_velocities{plant_->num_velocities()};
     ASSERT_EQ(result.joint_velocities->size(), num_velocities);
-    const double dt = params_->get_timestep();
+    const double dt = params_->get_time_step();
     const auto& q_bounds = *(params_->get_joint_position_limits());
     const auto& v_bounds = *(params_->get_joint_velocity_limits());
     for (int i = 0; i < num_velocities; ++i) {
@@ -143,10 +154,10 @@ TEST_F(DifferentialInverseKinematicsTest, PositiveTest) {
   CheckPositiveResult(V_WE_W, result);
 
   // Test with additional linear constraints.
+  // -1 <= v_next[0] - v_next[1] <= 1
   const auto A = (MatrixX<double>(1, 7) << 1, -1, 0, 0, 0, 0, 0).finished();
-  const auto b = VectorXd::Zero(A.rows());
   params_->AddLinearVelocityConstraint(
-      std::make_shared<LinearConstraint>(A, b, b));
+      std::make_shared<LinearConstraint>(A, Vector1d{-1}, Vector1d{1}));
   result = DoDiffIKForSpatialVelocity(V_WE_W);
   drake::log()->info("result.status = {}", result.status);
   CheckPositiveResult(V_WE_W, result);
@@ -165,8 +176,7 @@ TEST_F(DifferentialInverseKinematicsTest, OverConstrainedTest) {
       std::make_shared<LinearConstraint>(A, b, b));
   const DifferentialInverseKinematicsResult result =
       DoDiffIKForSpatialVelocity(V_WE_W);
-  drake::log()->info("result.status = {}", result.status);
-  ASSERT_TRUE(result.joint_velocities == std::nullopt);
+  EXPECT_TRUE(result.status == DifferentialInverseKinematicsStatus::kStuck);
 }
 
 TEST_F(DifferentialInverseKinematicsTest, GainTest) {
@@ -178,31 +188,29 @@ TEST_F(DifferentialInverseKinematicsTest, GainTest) {
 
   const multibody::SpatialVelocity<double> V_WE_W_desired(
     Vector3d(0.1, -0.2, 0.3) / 2, Vector3d(-0.3, 0.2, -0.1) / 2);
+    // Transform the desired end effector velocity into the body frame.
+  const multibody::SpatialVelocity<double> V_WE_E_desired =
+      R_EW * V_WE_W_desired;
 
-  Vector6<double> gain_E = Vector6<double>::Constant(1);
+  Vector6<bool> flag_E = Vector6<bool>::Constant(true);
   for (int i = 0; i < 6; i++) {
-    gain_E(i) = 0;
-    params_->set_end_effector_velocity_gain(gain_E);
+    flag_E(i) = false;
+    params_->set_end_effector_velocity_flag(flag_E);
 
     const DifferentialInverseKinematicsResult result =
         DoDiffIKForSpatialVelocity(V_WE_W_desired);
-    ASSERT_TRUE(result.joint_velocities != std::nullopt);
+    ASSERT_TRUE(result.status ==
+                DifferentialInverseKinematicsStatus::kSolutionFound);
 
     // Transform the resulting end effector frame's velocity into body frame.
-    plant_->SetPositions(context_, q);
     plant_->SetVelocities(context_, result.joint_velocities.value());
 
-    const multibody::SpatialVelocity<double> V_WE_W =
-        frame_E_->CalcSpatialVelocityInWorld(*context_);
-    const multibody::SpatialVelocity<double> V_WE_E = R_EW * V_WE_W;
-
-    // Transform the desired end effector velocity into the body frame.
-    const multibody::SpatialVelocity<double> V_WE_E_desired =
-        R_EW * V_WE_W_desired;
+    const multibody::SpatialVelocity<double> V_WE_E =
+        R_EW * frame_E_->CalcSpatialVelocityInWorld(*context_);
 
     for (int j = 0; j < 6; j++) {
       // For the constrained dof, the velocity should match.
-      if (gain_E(j) > 0) {
+      if (flag_E(j) > 0) {
         EXPECT_NEAR(V_WE_E[j], V_WE_E_desired[j], 5e-3);
       }
     }
@@ -211,8 +219,8 @@ TEST_F(DifferentialInverseKinematicsTest, GainTest) {
   // All Cartesian tracking has been disabled, the resulting velocity should be
   // tracking q_nominal only.
   const auto& v_bounds = *(params_->get_joint_velocity_limits());
-  const double dt = params_->get_timestep();
-  VectorXd v_desired = (params_->get_nominal_joint_position() - q) / dt;
+  VectorXd v_desired = params_->get_joint_centering_gain() *
+                       (params_->get_nominal_joint_position() - q);
   for (int i = 0; i < v_desired.size(); i++) {
     v_desired(i) = std::max(v_desired(i), v_bounds.first(i));
     v_desired(i) = std::min(v_desired(i), v_bounds.second(i));
@@ -229,12 +237,12 @@ TEST_F(DifferentialInverseKinematicsTest, SimpleTracker) {
   for (int iteration = 0; iteration < 900; ++iteration) {
     const DifferentialInverseKinematicsResult result =
         DoDiffIKForRigidTransform(X_WE_desired);
-    EXPECT_EQ(result.status,
+    ASSERT_EQ(result.status,
               DifferentialInverseKinematicsStatus::kSolutionFound);
 
     const VectorXd q = plant_->GetPositions(*context_);
     const VectorXd v = result.joint_velocities.value();
-    const double dt = params_->get_timestep();
+    const double dt = params_->get_time_step();
     plant_->SetPositions(context_, q + v * dt);
   }
   X_WE = frame_E_->CalcPoseInWorld(*context_);
@@ -246,16 +254,26 @@ TEST_F(DifferentialInverseKinematicsTest, SimpleTracker) {
 GTEST_TEST(DifferentialInverseKinematicsParametersTest, TestSetter) {
   DifferentialInverseKinematicsParameters dut(1, 1);
 
-  EXPECT_THROW(dut.set_timestep(0), std::exception);
-  EXPECT_THROW(dut.set_timestep(-1), std::exception);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  dut.set_timestep(0.1);
+  EXPECT_EQ(dut.get_timestep(), 0.1);
+  EXPECT_EQ(dut.get_time_step(), 0.1);
+  dut.set_time_step(0.2);
+  EXPECT_EQ(dut.get_timestep(), 0.2);
+  EXPECT_EQ(dut.get_time_step(), 0.2);
   EXPECT_THROW(dut.set_unconstrained_degrees_of_freedom_velocity_limit(-0.1),
-               std::exception);
-
-  EXPECT_THROW(dut.set_nominal_joint_position(VectorXd(2)),
                std::exception);
 
   Vector6<double> gain = (Vector6<double>() << 1, 2, 3, -4, 5, 6).finished();
   EXPECT_THROW(dut.set_end_effector_velocity_gain(gain), std::exception);
+#pragma GCC diagnostic pop
+
+  EXPECT_THROW(dut.set_time_step(0), std::exception);
+  EXPECT_THROW(dut.set_time_step(-1), std::exception);
+
+  EXPECT_THROW(dut.set_nominal_joint_position(VectorXd(2)),
+               std::exception);
 
   VectorXd l = VectorXd::Constant(1, 2);
   VectorXd h = VectorXd::Constant(1, -2);
@@ -296,6 +314,59 @@ GTEST_TEST(DifferentialInverseKinematicsParametersTest, TestMutators) {
   // Test clearing constraints.
   dut.ClearLinearVelocityConstraints();
   EXPECT_EQ(dut.get_linear_velocity_constraints().size(), 0);
+}
+
+// Use the planar iiwa to test when the Jacobian is full rank. The quadratic
+// joint-centering costs will not be added to the program, resulting in a
+// linear objective, rather than a quadratic objective. We need to make sure
+// that OsqpSolver does not fall down.
+GTEST_TEST(AdditionalDifferentialInverseKinematicsTests, TestLinearObjective) {
+  MultibodyPlant<double> plant(0.0);
+  multibody::Parser parser(&plant);
+  const std::string filename = FindResourceOrThrow(
+      "drake/manipulation/models/iiwa_description/urdf/"
+      "planar_iiwa14_spheres_dense_elbow_collision.urdf");
+  parser.AddModelFromFile(filename, "iiwa");
+  plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("iiwa_link_0"));
+
+  // Add the EE frame.
+  const math::RigidTransformd X_7E(AngleAxis<double>(M_PI, Vector3d::UnitZ()),
+                                   Vector3d(0.1, 0, 0));
+  const FixedOffsetFrame<double>* frame_E =
+      &plant.AddFrame(std::make_unique<FixedOffsetFrame<double>>(
+          "E", plant.GetBodyByName("iiwa_link_7").body_frame(), X_7E));
+  plant.Finalize();
+  auto context = plant.CreateDefaultContext();
+
+  // Configure the Diff IK.
+  DifferentialInverseKinematicsParameters params(plant.num_positions(),
+                                                 plant.num_velocities());
+  const int num_joints = plant.num_positions();
+  params.set_nominal_joint_position(VectorX<double>::Zero(num_joints));
+  params.set_time_step(1e-3);
+  // The planar model can only move in x, z, and pitch.
+  params.set_end_effector_velocity_flag(
+      (Vector6<bool>() << false, true, false, true, false, true).finished());
+
+  // Set the initial plant state.  These values were randomly generated.
+  const Vector3d q{1.40, 0.90, -1.76};
+  const VectorXd v = VectorXd::Zero(plant.num_velocities());
+  plant.SetPositions(context.get(), q);
+  plant.SetVelocities(context.get(), v);
+
+  const multibody::SpatialVelocity<double> V_WE_W_desired(
+      Vector3d(0, 0.2, 0) / 2, Vector3d(0.1, 0, 0.3) / 2);
+  auto result = DoDifferentialInverseKinematics(
+      plant, *context, V_WE_W_desired.get_coeffs(), *frame_E, params);
+
+  EXPECT_TRUE(result.status ==
+              DifferentialInverseKinematicsStatus::kSolutionFound);
+  plant.SetVelocities(context.get(), result.joint_velocities.value());
+
+  const multibody::SpatialVelocity<double> V_WE_W_actual =
+      frame_E->CalcSpatialVelocityInWorld(*context);
+  EXPECT_TRUE(CompareMatrices(V_WE_W_actual.get_coeffs().normalized(),
+                              V_WE_W_desired.get_coeffs().normalized(), 1e-4));
 }
 
 }  // namespace

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -426,7 +426,7 @@ double GetEffortLimit(
 // the value is non-zero. In SDFormat, effort limits are specified in
 // <joint><axis><limit><effort>. In Drake, we understand that joints with an
 // effort limit of zero are not actuated. For joint types that do not have an
-// actuator implementation available in Drake, produces a dianostic warning.
+// actuator implementation available in Drake, produces a diagnostic warning.
 void AddJointActuatorFromSpecification(
     const DiagnosticPolicy& diagnostic,
     const sdf::Joint& joint_spec, const Joint<double>& joint,


### PR DESCRIPTION
Resolves #9773.

There were a number of issues with the previous implementation, discussed at some length in #9773.

One implication of the cleaner formulation is that it is possible that the resulting optimization problem is an LP instead of a QP. In this case, Clp is used as a solver instead of Osqp, because Osqp cannot solve linear programs.

This change deprecates the "unconstrained degrees of freedom velocity limit" methods of the diff IK parameters class. This limit was only needed before because the formulation was bad. Since I'm already changing things on users, I've taken the chance to also deprecate the "timestep" methods in favor of "time_step", which we have agreed is the preferred form in Drake.

This PR also changes the default arguments for the Diff IK Parameters class constructor; setting the default velocities to be the same as the number of positions (instead of zero), and removing zero as a default argument for num_positions. Nobody should call this method with zero positions or velocities, and those certainly shouldn't be our default values.


My plan for review is as follows:
1. +@hongkai-dai and +@siyuanfeng-tri for feature review, please.  Once we are happy with the formulation and implementation, then 
2. I would ask @siyuanfeng-tri and @IanTheEngineer to run it on some real robots.  (I've tested it on my manipulation notebooks) and consider any implications for Anzu.
3. Then we can finalize with platform review.  Probably @EricCousineau-TRI , since he's also expressed interest.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17977)
<!-- Reviewable:end -->
