### PR TITLE
[geometry/optimization] Fix corner case in HPolyhedron::UniformSample

### DIFF
--- a/bindings/pydrake/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry_py_optimization.cc
@@ -141,7 +141,7 @@ void DefineGeometryOptimization(py::module m) {
             py::arg("other"), cls_doc.PontryaginDifference.doc)
         .def("UniformSample",
             overload_cast_explicit<Eigen::VectorXd, RandomGenerator*,
-                const Eigen::Ref<Eigen::VectorXd>&>(
+                const Eigen::Ref<const Eigen::VectorXd>&>(
                 &HPolyhedron::UniformSample),
             py::arg("generator"), py::arg("previous_sample"),
             cls_doc.UniformSample.doc_2args)

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -157,7 +157,7 @@ class HPolyhedron final : public ConvexSet {
   */
   Eigen::VectorXd UniformSample(
       RandomGenerator* generator,
-      const Eigen::Ref<Eigen::VectorXd>& previous_sample) const;
+      const Eigen::Ref<const Eigen::VectorXd>& previous_sample) const;
 
   /** Variant of UniformSample that uses the ChebyshevCenter() as the
   previous_sample as a feasible point to start the Markov chain sampling. */


### PR DESCRIPTION
Previously, it was possible for the sampler to happily return points outside of the region, if the polytope was overspecified (points outside of the set where still inside some redudant half-planes). This provides the fix and adds a test.

+@mpetersen94 for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17982)
<!-- Reviewable:end -->
