### PR TITLE
[IRIS] New termination conditions for IrisInConfigurationSpace

### DIFF
--- a/bindings/pydrake/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry_py_optimization.cc
@@ -292,8 +292,9 @@ void DefineGeometryOptimization(py::module m) {
       .def_readwrite("configuration_space_margin",
           &IrisOptions::configuration_space_margin,
           doc.IrisOptions.configuration_space_margin.doc)
-      .def_readwrite("enable_ibex", &IrisOptions::enable_ibex,
-          doc.IrisOptions.enable_ibex.doc)
+      .def_readwrite("num_collision_infeasible_samples",
+          &IrisOptions::num_collision_infeasible_samples,
+          doc.IrisOptions.num_collision_infeasible_samples.doc)
       .def_readwrite("prog_with_additional_constraints",
           &IrisOptions::prog_with_additional_constraints,
           doc.IrisOptions.prog_with_additional_constraints.doc)
@@ -310,7 +311,7 @@ void DefineGeometryOptimization(py::module m) {
             "termination_threshold={}, "
             "relative_termination_threshold={}, "
             "configuration_space_margin={}, "
-            "enable_ibex={}, "
+            "num_collision_infeasible_samples={}, "
             "prog_with_additional_constraints {}, "
             "num_additional_constraint_infeasible_samples={}, "
             "random_seed={}"
@@ -318,7 +319,8 @@ void DefineGeometryOptimization(py::module m) {
             .format(self.require_sample_point_is_contained,
                 self.iteration_limit, self.termination_threshold,
                 self.relative_termination_threshold,
-                self.configuration_space_margin, self.enable_ibex,
+                self.configuration_space_margin,
+                self.num_collision_infeasible_samples,
                 self.prog_with_additional_constraints ? "is set" : "is not set",
                 self.num_additional_constraint_infeasible_samples,
                 self.random_seed);

--- a/bindings/pydrake/test/geometry_optimization_test.py
+++ b/bindings/pydrake/test/geometry_optimization_test.py
@@ -398,6 +398,7 @@ class TestGeometryOptimization(unittest.TestCase):
         diagram = builder.Build()
         context = diagram.CreateDefaultContext()
         options = mut.IrisOptions()
+        options.num_collision_infeasible_samples = 3
         ik = InverseKinematics(plant)
         options.prog_with_additional_constraints = ik.prog()
         options.num_additional_constraint_infeasible_samples = 2

--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -82,7 +82,6 @@ drake_cc_library(
         "//geometry:scene_graph",
         "//multibody/plant",
         "//solvers:choose_best_solver",
-        "//solvers:ibex_solver",
         "//solvers:ipopt_solver",
         "//solvers:snopt_solver",
     ],
@@ -175,6 +174,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "iris_in_configuration_space_test",
+    timeout = "moderate",
     shard_count = 8,
     # Most of these tests take an exceptionally long time under
     # instrumentation, resulting in timeouts, and so are excluded.
@@ -184,6 +184,7 @@ drake_cc_googletest(
     ],
     deps = [
         ":iris",
+        "//common/test_utilities:expect_throws_message",
         "//geometry:meshcat",
         "//geometry/test_utilities:meshcat_environment",
         "//multibody/inverse_kinematics",


### PR DESCRIPTION
Adds options.num_infeasible_samples to support a probabilistic guarantee of correctness (with probability one as the number of samples goes to infinity) for the nonlinear-optimization-based version of IRIS.

Because this requires solving potentially many more (nearly identical) MathematicalPrograms, I've finally done the refactor which reuses the allocated programs and just updated the constraints.

BREAKING CHANGE: We have elected to remove support for Ibex from IRIS; it proved to only be useful for exceptionally toy problems and has become a footgun for users that turn it on (and wait forever). Rather than carry it through this refactor, I have elected to remove it.

+@mpetersen94 for feature review
+@cohnt for additional feature review

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17987)
<!-- Reviewable:end -->
