### PR TITLE
[plant] Remove fmt precision in error messages

### DIFF
--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -665,7 +665,7 @@ void CompliantContactManager<T>::DoCalcContactSolverResults(
       sap.SolveWithGuess(sap_problem, v0, &sap_results);
   if (status != SapSolverStatus::kSuccess) {
     const std::string msg = fmt::format(
-        "The SAP solver failed to converge at simulation time = {:7.3g}. "
+        "The SAP solver failed to converge at simulation time = {}. "
         "Reasons for divergence and possible solutions include:\n"
         "  1. Externally applied actuation values diverged due to external "
         "     reasons to the solver. Revise your control logic.\n"

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -2818,7 +2818,7 @@ void MultibodyPlant<T>::CallTamsiSolver(
   if (info != TamsiSolverResult::kSuccess) {
     const std::string msg = fmt::format(
         "MultibodyPlant's discrete update solver failed to converge at "
-        "simulation time = {:7.3g} with discrete update period = {:7.3g}. "
+        "simulation time = {} with discrete update period = {}. "
         "This usually means that the plant's discrete update period is too "
         "large to resolve the system's dynamics for the given simulation "
         "conditions. This is often the case during abrupt collisions or during "
@@ -2929,13 +2929,10 @@ void MultibodyPlant<T>::CallContactSolver(
                                     v0, &*results);
 
   if (info != contact_solvers::internal::ContactSolverStatus::kSuccess) {
-    const std::string msg =
-        fmt::format("MultibodyPlant's contact solver of type '" +
-                        NiceTypeName::Get(*contact_solver_) +
-                        "' failed to converge at "
-                        "simulation time = {:7.3g} with discrete update "
-                        "period = {:7.3g}.",
-                    time0, time_step());
+    const std::string msg = fmt::format(
+        "MultibodyPlant's contact solver of type '{}' failed to converge at "
+        "simulation time = {} with discrete update period = {}.",
+        NiceTypeName::Get(*contact_solver_), time0, time_step());
     throw std::runtime_error(msg);
   }
 }


### PR DESCRIPTION
When printing a simulation time of type T = AutoDiff, it's not possible to use format precision specifiers. In any case, we should always use the default (round-trip) precision anyway.

Towards #17943.

The CI for #17943 which incorporates this patch proves that it fully solves the problem.
The CI for #17957 (i.e., with this patch reverted) displays the error messages we are fixing here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17994)
<!-- Reviewable:end -->
