### PR TITLE
Fix some miscellaneous C++20 warnings

### DIFF
--- a/bindings/pydrake/systems/lcm_pybind.h
+++ b/bindings/pydrake/systems/lcm_pybind.h
@@ -38,7 +38,8 @@ py::object BindCppSerializer(const std::string& lcm_package) {
   py_cls.def(py::init());
   // We use move here because the type of py_class differs from our declared
   // return type.
-  return std::move(py_cls);
+  py::object result = std::move(py_cls);
+  return result;
 }
 
 }  // namespace pylcm

--- a/math/autodiff.h
+++ b/math/autodiff.h
@@ -205,7 +205,7 @@ auto InitializeAutoDiffTuple(const Eigen::MatrixBase<Deriveds>&... args) {
   // Refer to https://en.cppreference.com/w/cpp/language/fold for the syntax.
   constexpr int nq =
       ((Deriveds::SizeAtCompileTime != Eigen::Dynamic) && ...)
-          ? (Deriveds::SizeAtCompileTime + ...)
+          ? (static_cast<int>(Deriveds::SizeAtCompileTime) + ...)
           : Eigen::Dynamic;
 
   // Compute each deriv_num_start value and then the total runtime size.


### PR DESCRIPTION
Towards #17943.

The `std::move` thing is because the move is _required_ for the code to compile (we need to convert the type of the object), yet the compiler also spews a false positive "redundant move" warning when it's in a single line.  Splitting it into two lines splits the difference in a way where both angles are happy.

The enum thing is just the usual C++20 "can't do math on enums anymore" deprecation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/17995)
<!-- Reviewable:end -->
