### PR TITLE
[parsing] Restructure parsers for format-agnostic recursion

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -181,6 +181,7 @@ drake_cc_library(
     visibility = ["//visibility:private"],
     deps = [
         ":detail_misc",
+        ":detail_parsing_workspace",
         ":scoped_names",
         "//multibody/plant",
         "@fmt",
@@ -197,6 +198,20 @@ drake_cc_library(
         ":package_map",
         "//common:diagnostic_policy",
         "//multibody/plant",
+    ],
+)
+
+drake_cc_library(
+    name = "detail_select_parser",
+    srcs = ["detail_select_parser.cc"],
+    hdrs = ["detail_select_parser.h"],
+    internal = True,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":detail_mujoco_parser",
+        ":detail_parsing_workspace",
+        ":detail_sdf_parser",
+        ":detail_urdf_parser",
     ],
 )
 
@@ -222,10 +237,8 @@ drake_cc_library(
         "//multibody/plant",
     ],
     deps = [
-        ":detail_mujoco_parser",
         ":detail_parsing_workspace",
-        ":detail_sdf_parser",
-        ":detail_urdf_parser",
+        ":detail_select_parser",
         "//common:filesystem",
     ],
 )
@@ -265,6 +278,7 @@ drake_cc_library(
     ],
     deps = [
         ":detail_misc",
+        ":detail_parsing_workspace",
         ":scoped_names",
         "//common:diagnostic_policy",
         "//common:filesystem",
@@ -409,6 +423,14 @@ drake_cc_googletest(
     name = "detail_common_test",
     deps = [
         ":detail_misc",
+    ],
+)
+
+drake_cc_googletest(
+    name = "detail_select_parser_test",
+    deps = [
+        ":detail_select_parser",
+        ":diagnostic_policy_test_base",
     ],
 )
 

--- a/multibody/parsing/detail_common.cc
+++ b/multibody/parsing/detail_common.cc
@@ -9,6 +9,12 @@ namespace internal {
 
 using drake::internal::DiagnosticPolicy;
 
+bool EndsWithCaseInsensitive(std::string_view str, std::string_view ext) {
+  if (ext.size() > str.size()) { return false; }
+  return std::equal(str.end() - ext.size(), str.end(), ext.begin(),
+                    [](char a, char b) { return tolower(a) == tolower(b); });
+}
+
 DataSource::DataSource(DataSourceType type, const std::string* data)
     : type_(type), data_(data) {
   DRAKE_DEMAND(IsFilename() != IsContents());

--- a/multibody/parsing/detail_common.h
+++ b/multibody/parsing/detail_common.h
@@ -23,6 +23,9 @@ namespace internal {
 
 using ElementNode = std::variant<sdf::ElementPtr, tinyxml2::XMLElement*>;
 
+// @returns true if @p str ends with @p ext. The match is case-insensitive.
+bool EndsWithCaseInsensitive(std::string_view str, std::string_view ext);
+
 // Helper class that provides for either a file name xor file contents to be
 // passed between our various parsing functions.
 class DataSource {

--- a/multibody/parsing/detail_composite_parse.cc
+++ b/multibody/parsing/detail_composite_parse.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/parsing/detail_composite_parse.h"
 
+#include "drake/multibody/parsing/detail_select_parser.h"
+
 namespace drake {
 namespace multibody {
 namespace internal {
@@ -12,19 +14,12 @@ std::unique_ptr<CompositeParse> CompositeParse::MakeCompositeParse(
 }
 
 CompositeParse::CompositeParse(Parser* parser)
-    : parser_(parser), resolver_(&parser->plant()) {}
+    : resolver_(&parser->plant()),
+      workspace_(parser->package_map(), parser->diagnostic_policy_,
+                 &parser->plant(), &resolver_, SelectParser) {}
 
 CompositeParse::~CompositeParse() {
-  resolver_.Resolve(parser_->diagnostic_policy_);
-}
-
-CollisionFilterGroupResolver& CompositeParse::collision_resolver() {
-  return resolver_;
-}
-
-ModelInstanceIndex CompositeParse::AddModelFromFile(
-    const std::string& file_name, const std::string& model_name) {
-  return parser_->CompositeAddModelFromFile(file_name, model_name, this);
+  resolver_.Resolve(workspace_.diagnostic);
 }
 
 }  // namespace internal

--- a/multibody/parsing/detail_composite_parse.h
+++ b/multibody/parsing/detail_composite_parse.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "drake/multibody/parsing/detail_collision_filter_group_resolver.h"
+#include "drake/multibody/parsing/detail_parsing_workspace.h"
 #include "drake/multibody/parsing/parser.h"
 
 namespace drake {
@@ -22,19 +23,17 @@ class CompositeParse {
 
   ~CompositeParse();
 
-  CollisionFilterGroupResolver& collision_resolver();
-  // TODO(rpoyner-tri): add some way to get more expressive diagnostics.
+  // @returns a const reference to a workspace. Note that some objects pointed
+  // to by the workspace may still be mutated; see ParsingWorkspace for
+  // details.
+  const ParsingWorkspace& workspace() const { return workspace_; }
 
-  ModelInstanceIndex AddModelFromFile(
-    const std::string& file_name,
-    const std::string& model_name);
-  // TODO(rpoyner-tri): add model parsing methods as needed.
 
  private:
   explicit CompositeParse(Parser* parser);
 
-  Parser* const parser_;
   CollisionFilterGroupResolver resolver_;
+  const ParsingWorkspace workspace_;
 };
 
 }  // namespace internal

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -979,6 +979,30 @@ ModelInstanceIndex AddModelFromMujocoXml(
   return parser.Parse(model_name_in, parent_model_name, &xml_doc);
 }
 
+MujocoParserWrapper::MujocoParserWrapper() {}
+
+MujocoParserWrapper::~MujocoParserWrapper() {}
+
+std::optional<ModelInstanceIndex> MujocoParserWrapper::AddModel(
+    const DataSource& data_source, const std::string& model_name,
+    const std::optional<std::string>& parent_model_name,
+    const ParsingWorkspace& workspace) {
+  return AddModelFromMujocoXml(data_source, model_name, parent_model_name,
+                               workspace.plant);
+}
+
+std::vector<ModelInstanceIndex> MujocoParserWrapper::AddAllModels(
+    const DataSource& data_source,
+    const std::optional<std::string>& parent_model_name,
+    const ParsingWorkspace& workspace) {
+  auto maybe_model = AddModel(data_source, {}, parent_model_name, workspace);
+  if (maybe_model.has_value()) {
+    return {*maybe_model};
+  } else {
+    return {};
+  }
+}
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/detail_mujoco_parser.h
+++ b/multibody/parsing/detail_mujoco_parser.h
@@ -2,8 +2,10 @@
 
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "drake/multibody/parsing/detail_common.h"
+#include "drake/multibody/parsing/detail_parsing_workspace.h"
 #include "drake/multibody/parsing/package_map.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/multibody_tree_indexes.h"
@@ -40,6 +42,22 @@ ModelInstanceIndex AddModelFromMujocoXml(
     const DataSource& data_source, const std::string& model_name,
     const std::optional<std::string>& parent_model_name,
     MultibodyPlant<double>* plant);
+
+class MujocoParserWrapper final : public ParserInterface {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MujocoParserWrapper)
+  MujocoParserWrapper();
+  ~MujocoParserWrapper() final;
+  std::optional<ModelInstanceIndex> AddModel(
+      const DataSource& data_source, const std::string& model_name,
+      const std::optional<std::string>& parent_model_name,
+      const ParsingWorkspace& workspace) final;
+
+  std::vector<ModelInstanceIndex> AddAllModels(
+      const DataSource& data_source,
+      const std::optional<std::string>& parent_model_name,
+      const ParsingWorkspace& workspace) final;
+};
 
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/parsing/detail_sdf_parser.h
+++ b/multibody/parsing/detail_sdf_parser.h
@@ -12,7 +12,7 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-// Parses a `<model>` element from the SDF file specified by `file_name` and
+// Parses a `<model>` element from the SDF file specified by `data_source` and
 // adds it to `plant`. The SDF file can only contain a single `<model>`
 // element. `<world>` elements (used for instance to specify gravity) are
 // ignored by this method.  A new model instance will be added to @p plant.
@@ -40,10 +40,10 @@ std::optional<ModelInstanceIndex> AddModelFromSdf(
     const std::string& model_name,
     const ParsingWorkspace& workspace);
 
-// Parses all `<model>` elements from the SDF file specified by `file_name`
+// Parses all `<model>` elements from the SDF file specified by `data_source`
 // and adds them to `plant`. The SDF file can contain multiple `<model>`
-// elements. New model instances will be added to @p plant for each
-// `<model>` tag in the SDF file.
+// elements. New model instances will be added to @p plant for each `<model>`
+// tag in the SDF file.
 //
 // @throws std::exception if the file is not in accordance with the SDF
 // specification containing a message with a list of errors encountered while
@@ -62,6 +62,22 @@ std::optional<ModelInstanceIndex> AddModelFromSdf(
 std::vector<ModelInstanceIndex> AddModelsFromSdf(
     const DataSource& data_source,
     const ParsingWorkspace& workspace);
+
+class SdfParserWrapper final : public ParserInterface {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SdfParserWrapper)
+  SdfParserWrapper();
+  ~SdfParserWrapper() final;
+  std::optional<ModelInstanceIndex> AddModel(
+      const DataSource& data_source, const std::string& model_name,
+      const std::optional<std::string>& parent_model_name,
+      const ParsingWorkspace& workspace) final;
+
+  std::vector<ModelInstanceIndex> AddAllModels(
+      const DataSource& data_source,
+      const std::optional<std::string>& parent_model_name,
+      const ParsingWorkspace& workspace) final;
+};
 
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/parsing/detail_select_parser.cc
+++ b/multibody/parsing/detail_select_parser.cc
@@ -1,0 +1,79 @@
+#include "drake/multibody/parsing/detail_select_parser.h"
+
+#include <optional>
+#include <vector>
+
+#include "drake/common/never_destroyed.h"
+#include "drake/multibody/parsing/detail_mujoco_parser.h"
+#include "drake/multibody/parsing/detail_sdf_parser.h"
+#include "drake/multibody/parsing/detail_urdf_parser.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+using drake::internal::DiagnosticPolicy;
+
+namespace {
+
+enum class FileType { kUnknown, kSdf, kUrdf, kMjcf };
+FileType DetermineFileType(const DiagnosticPolicy& policy,
+                           const std::string& filename) {
+  if (EndsWithCaseInsensitive(filename, ".urdf")) {
+    return FileType::kUrdf;
+  }
+  if (EndsWithCaseInsensitive(filename, ".sdf")) {
+    return FileType::kSdf;
+  }
+  if (EndsWithCaseInsensitive(filename, ".xml")) {
+    return FileType::kMjcf;
+  }
+  policy.Error(fmt::format(
+      "The file '{}' is not a recognized type."
+      " Known types are: .urdf, .sdf, .xml (Mujoco)",
+      filename));
+  return FileType::kUnknown;
+}
+
+// This stub allows continued partial operation when Error() does not throw.
+class UnknownParserWrapper final : public ParserInterface {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(UnknownParserWrapper)
+  UnknownParserWrapper() {}
+  ~UnknownParserWrapper() final {}
+  std::optional<ModelInstanceIndex> AddModel(
+      const DataSource&, const std::string&,
+      const std::optional<std::string>&,
+      const ParsingWorkspace&) final { return {}; }
+
+  std::vector<ModelInstanceIndex> AddAllModels(
+      const DataSource&,
+      const std::optional<std::string>&,
+      const ParsingWorkspace&) final { return {}; }
+};
+
+}  // namespace
+
+ParserInterface& SelectParser(const DiagnosticPolicy& policy,
+                              const std::string& filename) {
+  static never_destroyed<internal::UrdfParserWrapper> urdf;
+  static never_destroyed<internal::SdfParserWrapper> sdf;
+  static never_destroyed<internal::MujocoParserWrapper> mujoco;
+  static never_destroyed<internal::UnknownParserWrapper> unknown;
+  const FileType type = DetermineFileType(policy, filename);
+  switch (type) {
+    case FileType::kUrdf:
+      return urdf.access();
+    case FileType::kSdf:
+      return sdf.access();
+    case FileType::kMjcf:
+      return mujoco.access();
+    case FileType::kUnknown:
+      return unknown.access();
+  }
+  DRAKE_UNREACHABLE();
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/detail_select_parser.h
+++ b/multibody/parsing/detail_select_parser.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+
+#include "drake/common/diagnostic_policy.h"
+#include "drake/multibody/parsing/detail_parsing_workspace.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// This function matches the drake::multibody::internal::ParserSelector functor
+// type. If a matching parser can't be found, this implementation emits an
+// error and returns a do-nothing object, whose methods do nothing at all.
+ParserInterface& SelectParser(const drake::internal::DiagnosticPolicy& policy,
+                              const std::string& filename);
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -921,6 +921,29 @@ std::optional<ModelInstanceIndex> AddModelFromUrdf(
   return parser.Parse();
 }
 
+UrdfParserWrapper::UrdfParserWrapper() {}
+
+UrdfParserWrapper::~UrdfParserWrapper() {}
+
+std::optional<ModelInstanceIndex> UrdfParserWrapper::AddModel(
+    const DataSource& data_source, const std::string& model_name,
+    const std::optional<std::string>& parent_model_name,
+    const ParsingWorkspace& workspace) {
+  return AddModelFromUrdf(data_source, model_name, parent_model_name,
+                          workspace);
+}
+
+std::vector<ModelInstanceIndex> UrdfParserWrapper::AddAllModels(
+    const DataSource& data_source,
+    const std::optional<std::string>& parent_model_name,
+    const ParsingWorkspace& workspace) {
+  auto result = AddModel(data_source, {}, parent_model_name, workspace);
+  if (result.has_value()) {
+    return {*result};
+  }
+  return {};
+}
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/detail_urdf_parser.h
+++ b/multibody/parsing/detail_urdf_parser.h
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "drake/multibody/parsing/detail_common.h"
 #include "drake/multibody/parsing/detail_parsing_workspace.h"
@@ -11,8 +12,8 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-// Parses a `<robot>` element from the URDF file specified by @p file_name and
-// adds it to @p plant.  A new model instance will be added to @p plant.
+// Parses a `<robot>` element from the URDF file specified by @p data_source
+// and adds it to @p plant.  A new model instance will be added to @p plant.
 //
 // @throws std::exception if the file is not in accordance with the URDF
 // specification.  The exception contains a message with a list of errors
@@ -48,6 +49,22 @@ std::optional<ModelInstanceIndex> AddModelFromUrdf(
     const std::string& model_name,
     const std::optional<std::string>& parent_model_name,
     const ParsingWorkspace& workspace);
+
+class UrdfParserWrapper final : public ParserInterface {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(UrdfParserWrapper)
+  UrdfParserWrapper();
+  ~UrdfParserWrapper() final;
+  std::optional<ModelInstanceIndex> AddModel(
+      const DataSource& data_source, const std::string& model_name,
+      const std::optional<std::string>& parent_model_name,
+      const ParsingWorkspace& workspace) final;
+
+  std::vector<ModelInstanceIndex> AddAllModels(
+      const DataSource& data_source,
+      const std::optional<std::string>& parent_model_name,
+      const ParsingWorkspace& workspace) final;
+};
 
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/parsing/parser.cc
+++ b/multibody/parsing/parser.cc
@@ -7,22 +7,19 @@
 #include "drake/multibody/parsing/detail_collision_filter_group_resolver.h"
 #include "drake/multibody/parsing/detail_common.h"
 #include "drake/multibody/parsing/detail_composite_parse.h"
-#include "drake/multibody/parsing/detail_mujoco_parser.h"
 #include "drake/multibody/parsing/detail_parsing_workspace.h"
-#include "drake/multibody/parsing/detail_sdf_parser.h"
-#include "drake/multibody/parsing/detail_urdf_parser.h"
+#include "drake/multibody/parsing/detail_select_parser.h"
 
 namespace drake {
 namespace multibody {
 
 using drake::internal::DiagnosticDetail;
 using drake::internal::DiagnosticPolicy;
-using internal::AddModelFromSdf;
-using internal::AddModelFromUrdf;
-using internal::AddModelsFromSdf;
 using internal::CollisionFilterGroupResolver;
 using internal::DataSource;
+using internal::ParserInterface;
 using internal::ParsingWorkspace;
+using internal::SelectParser;
 
 Parser::Parser(
     MultibodyPlant<double>* plant,
@@ -45,88 +42,27 @@ Parser::Parser(
   diagnostic_policy_.SetActionForWarnings(warnings_maybe_strict);
 }
 
-namespace {
-enum class FileType { kSdf, kUrdf, kMjcf };
-FileType DetermineFileType(const std::string& file_name) {
-  const std::string ext = filesystem::path(file_name).extension().string();
-  if ((ext == ".urdf") || (ext == ".URDF")) {
-    return FileType::kUrdf;
-  }
-  if ((ext == ".sdf") || (ext == ".SDF")) {
-    return FileType::kSdf;
-  }
-  if ((ext == ".xml") || (ext == ".XML")) {
-    return FileType::kMjcf;
-  }
-  throw std::runtime_error(fmt::format(
-      "The file type '{}' is not supported for '{}'",
-      ext, file_name));
-}
-}  // namespace
-
 std::vector<ModelInstanceIndex> Parser::AddAllModelsFromFile(
     const std::string& file_name) {
-  return CompositeAddAllModelsFromFile(file_name, {});
-}
-
-std::vector<ModelInstanceIndex> Parser::CompositeAddAllModelsFromFile(
-    const std::string& file_name,
-    internal::CompositeParse* composite) {
   DataSource data_source(DataSource::kFilename, &file_name);
-  CollisionFilterGroupResolver resolver{plant_};
-  ParsingWorkspace workspace{
-    package_map_, diagnostic_policy_, plant_,
-    composite ? &composite->collision_resolver() : &resolver};
-  const FileType type = DetermineFileType(file_name);
-  std::vector<ModelInstanceIndex> result;
-  if (type == FileType::kSdf) {
-    result = AddModelsFromSdf(data_source, workspace);
-  } else if (type == FileType::kUrdf) {
-    const std::optional<ModelInstanceIndex> maybe_model =
-        AddModelFromUrdf(data_source, {}, {}, workspace);
-    if (maybe_model.has_value()) {
-      result = {*maybe_model};
-    } else {
-      throw std::runtime_error(
-          fmt::format("{}: URDF model file parsing failed", file_name));
-    }
-  } else {  // type == FileType::kMjcf
-    result = {AddModelFromMujocoXml(data_source, {}, {}, plant_)};
-  }
-  if (!composite) { resolver.Resolve(diagnostic_policy_); }
-  return result;
+  ParserInterface& parser = SelectParser(diagnostic_policy_, file_name);
+  auto composite = internal::CompositeParse::MakeCompositeParse(this);
+  return parser.AddAllModels(data_source, {}, composite->workspace());
 }
 
 ModelInstanceIndex Parser::AddModelFromFile(
     const std::string& file_name,
     const std::string& model_name) {
-  return CompositeAddModelFromFile(file_name, model_name, {});
-}
-
-ModelInstanceIndex Parser::CompositeAddModelFromFile(
-    const std::string& file_name,
-    const std::string& model_name,
-    internal::CompositeParse* composite) {
   DataSource data_source(DataSource::kFilename, &file_name);
-  CollisionFilterGroupResolver resolver{plant_};
-  ParsingWorkspace workspace{
-    package_map_, diagnostic_policy_, plant_,
-    composite ? &composite->collision_resolver() : &resolver};
-  const FileType type = DetermineFileType(file_name);
+  ParserInterface& parser = SelectParser(diagnostic_policy_, file_name);
+  auto composite = internal::CompositeParse::MakeCompositeParse(this);
   std::optional<ModelInstanceIndex> maybe_model;
-  if (type == FileType::kSdf) {
-    maybe_model = AddModelFromSdf(data_source, model_name, workspace);
-  } else if (type == FileType::kUrdf) {
-    maybe_model = AddModelFromUrdf(data_source, model_name, {}, workspace);
-  } else {
-    maybe_model =
-        AddModelFromMujocoXml(data_source, model_name, {}, plant_);
-  }
+  maybe_model = parser.AddModel(data_source, model_name, {},
+                                 composite->workspace());
   if (!maybe_model.has_value()) {
     throw std::runtime_error(
         fmt::format("{}: parsing failed", file_name));
   }
-  if (!composite) { resolver.Resolve(diagnostic_policy_); }
   return *maybe_model;
 }
 
@@ -134,34 +70,17 @@ ModelInstanceIndex Parser::AddModelFromString(
     const std::string& file_contents,
     const std::string& file_type,
     const std::string& model_name) {
-  return CompositeAddModelFromString(file_contents, file_type, model_name, {});
-}
-
-ModelInstanceIndex Parser::CompositeAddModelFromString(
-    const std::string& file_contents,
-    const std::string& file_type,
-    const std::string& model_name,
-    internal::CompositeParse* composite) {
   DataSource data_source(DataSource::kContents, &file_contents);
   const std::string pseudo_name(data_source.GetStem() + "." + file_type);
-  CollisionFilterGroupResolver resolver{plant_};
-  ParsingWorkspace workspace{
-    package_map_, diagnostic_policy_, plant_,
-    composite ? &composite->collision_resolver() : &resolver};
-  const FileType type = DetermineFileType(pseudo_name);
+  ParserInterface& parser = SelectParser(diagnostic_policy_, pseudo_name);
+  auto composite = internal::CompositeParse::MakeCompositeParse(this);
   std::optional<ModelInstanceIndex> maybe_model;
-  if (type == FileType::kSdf) {
-    maybe_model = AddModelFromSdf(data_source, model_name, workspace);
-  } else if (type == FileType::kUrdf) {
-    maybe_model = AddModelFromUrdf(data_source, model_name, {}, workspace);
-  } else {  // FileType::kMjcf
-    maybe_model = AddModelFromMujocoXml(data_source, model_name, {}, plant_);
-  }
+  maybe_model = parser.AddModel(data_source, model_name, {},
+                                 composite->workspace());
   if (!maybe_model.has_value()) {
     throw std::runtime_error(
         fmt::format("{}: parsing failed", pseudo_name));
   }
-  if (!composite) { resolver.Resolve(diagnostic_policy_); }
   return *maybe_model;
 }
 

--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -15,8 +15,33 @@ namespace internal {
 class CompositeParse;
 }  // namespace internal
 
-/// Parses SDF and URDF input files into a MultibodyPlant and (optionally) a
-/// SceneGraph. For documentation of Drake-specific extensions and limitations,
+/// Parses model description input into a MultibodyPlant and (optionally) a
+/// SceneGraph. A variety of input formats are supported, and are recognized by
+/// filename suffixes:
+///
+/// File format              | Filename suffix
+/// ------------------------ | ---------------
+/// URDF                     | ".urdf"
+/// SDFormat                 | ".sdf"
+/// MJCF (Mujoco XML)        | ".xml"
+///
+/// The output of parsing is one or more model instances added to the
+/// MultibodyPlant provided to the parser at construction.
+///
+/// SDFormat files may contain multiple `<model>` elements.  New model
+/// instances will be added to @p plant for each `<model>` tag in the file.
+///
+/// @note Adding multiple root-level models, i.e, `<model>`s directly under
+/// `<sdf>`, is deprecated. If you need multiple models in a single file,
+/// please use an SDFormat world tag.
+///
+/// URDF files contain a single `<robot>` element.  Only a single model
+/// instance will be added to @p plant.
+///
+/// MJCF (MuJoCo XML) files typically contain many bodies, they will all be
+/// added as a single model instance in the @p plant.
+///
+/// For more documentation of Drake-specific treatment of these input formats,
 /// see @ref multibody_parsing.
 ///
 /// When parsing literal quantities, %Parser assumes SI units and radians in the
@@ -51,38 +76,28 @@ class Parser final {
   /// warnings will be treated as errors.
   void SetStrictParsing() { is_strict_ = true; }
 
-  /// Parses the SDF, URDF, or MJCF file named in @p file_name and adds all of
-  /// its model(s) to @p plant.
+  /// Parses the input file named in @p file_name and adds all of its model(s)
+  /// to @p plant.
   ///
-  /// SDFormat files may contain multiple `<model>` elements.  New model
-  /// instances will be added to @p plant for each `<model>` tag in the file.
-  ///
-  /// @note Adding multiple root-level models, i.e, `<model>`s directly under
-  /// `<sdf>`, is deprecated. If you need multiple models in a single file,
-  /// please use an SDFormat world file.
-  ///
-  /// URDF files contain a single `<robot>` element.  Only a single model
-  /// instance will be added to @p plant.
-  ///
-  /// MJCF (MuJoCo XML) files typically contain many bodies, they will all be
-  /// added as a single model instance in the @p plant.
-  ///
-  /// @param file_name The name of the SDF, URDF, or MJCF file to be parsed.
-  /// The file type will be inferred from the extension. @returns The set of
-  /// model instance indices for the newly added models, including nested
-  /// models. @throws std::exception in case of errors.
+  /// @param file_name The name of the file to be parsed. The file type will be
+  /// inferred from the extension.
+  /// @returns The set of model instance indices for the newly added models,
+  /// including nested models.
+  /// @throws std::exception in case of errors.
   std::vector<ModelInstanceIndex> AddAllModelsFromFile(
       const std::string& file_name);
 
-  /// Parses the SDFormat, URDF, or MJCF file named in @p file_name and adds one
-  /// top-level model to @p plant. It is an error to call this using an SDFormat
-  /// file with more than one root-level `<model>` element.
+  // TODO(rpoyner-tri): add documentation of nesting in model directives in
+  // text below?
+  /// Parses the input file named in @p file_name and adds one top-level model
+  /// to @p plant. It is an error to call this using any file that adds more
+  /// than one model instance.
   ///
   /// @note This function might create additional model instances corresponding
-  /// to nested models found in the top level SDFormat model. This means that
-  /// elements contained by the returned model instance may not comprise all of
-  /// the added elements due to how model instances are mutually exclusive and
-  /// not hierarchical (#14043).
+  /// to nested models found in the top level file. This means that elements
+  /// contained by the returned model instance may not comprise all of the
+  /// added elements due to how model instances are mutually exclusive and not
+  /// hierarchical (#14043).
   ///
   /// @sa http://sdformat.org/tutorials?tut=composition&ver=1.7 for details on
   /// nesting in SDFormat.
@@ -91,14 +106,14 @@ class Parser final {
       const std::string& model_name = {});
 
   /// Provides same functionality as AddModelFromFile, but instead parses the
-  /// SDFormat or URDF XML data via @p file_contents with type dictated by
+  /// model description text data via @p file_contents with format dictated by
   /// @p file_type.
   ///
-  /// @param file_contents The XML data to be parsed.
-  /// @param file_type The data format; must be either "sdf", "urdf", or "xml".
+  /// @param file_contents The model data to be parsed.
+  /// @param file_type The data format; must be one of the filename suffixes
+  /// listed above, *without* the leading dot (.) .
   /// @param model_name The name given to the newly created instance of this
-  ///   model.  If empty, the "name" attribute from the `<model>` or `<robot>`
-  ///   tag will be used.
+  /// model. If empty, the model name provided by the input text will be used.
   /// @returns The instance index for the newly added model.
   /// @throws std::exception in case of errors.
   ModelInstanceIndex AddModelFromString(
@@ -108,21 +123,6 @@ class Parser final {
 
  private:
   friend class internal::CompositeParse;
-
-  std::vector<ModelInstanceIndex> CompositeAddAllModelsFromFile(
-      const std::string& file_name,
-      internal::CompositeParse* composite);
-
-  ModelInstanceIndex CompositeAddModelFromFile(
-      const std::string& file_name,
-      const std::string& model_name,
-      internal::CompositeParse* composite);
-
-  ModelInstanceIndex CompositeAddModelFromString(
-      const std::string& file_contents,
-      const std::string& file_type,
-      const std::string& model_name,
-      internal::CompositeParse* composite);
 
   bool is_strict_{false};
   PackageMap package_map_;

--- a/multibody/parsing/parsing_doxygen.h
+++ b/multibody/parsing/parsing_doxygen.h
@@ -5,11 +5,9 @@
 @defgroup multibody_parsing Parsing Models for Multibody Dynamics
 @ingroup multibody
 
-Drake's drake::multibody::Parser accepts model files written in either SDFormat
-or URDF. In both formats, however, there are Drake-specific extensions and
-Drake-specific limitations.
-
-<!-- TODO(rpoyner-tri): document mujoco format support -->
+Drake's drake::multibody::Parser accepts model files written in a variety of
+input formats. Drake's parsing of URDF, SDFormat, and MJCF (Mujoco XML) has
+Drake-specific extensions and limitations.
 
 The result of the parse is an in-memory model realized within
 drake::multibody::MultibodyPlant and (optionally)
@@ -17,8 +15,17 @@ drake::geometry::SceneGraph. Note that parses that do not use a `SceneGraph`
 will effectively ignore geometric model elements, especially `//visual` and
 `//collision` elements.
 
-In the reference sections below, the relevant usage paths for various tags
-are indicated using [XPath](https://www.w3.org/TR/xpath-31/) notation.
+In the reference sections below, when discussing XML formats, the relevant
+usage paths for various tags are indicated using
+[XPath](https://www.w3.org/TR/xpath-31/) notation.
+
+@section multibody_parsing_mjcf MJCF (Mujoco XML) Support
+
+There is limited, undocumented support for parsing MJCF (Mujoco XML) files. The
+files are recognized by an .xml file extension. The scope of features that are
+actually supported still need to be documented.
+
+<!-- TODO(rpoyner-tri): document mujoco format support -->
 
 @section multibody_parsing_sdf SDFormat Support
 Drake supports SDFormat files following the specification at

--- a/multibody/parsing/test/detail_common_test.cc
+++ b/multibody/parsing/test/detail_common_test.cc
@@ -24,6 +24,17 @@ using geometry::internal::kMaterialGroup;
 using geometry::internal::kRezHint;
 using std::optional;
 
+GTEST_TEST(EndsWithCaseInsensitiveTest, BasicTests) {
+  EXPECT_TRUE(EndsWithCaseInsensitive("something", "thing"));
+  EXPECT_TRUE(EndsWithCaseInsensitive("something", "THING"));
+  EXPECT_TRUE(EndsWithCaseInsensitive("something", "Thing"));
+  EXPECT_TRUE(EndsWithCaseInsensitive("thing", "thing"));
+  EXPECT_TRUE(EndsWithCaseInsensitive("thing", "THING"));
+  EXPECT_TRUE(EndsWithCaseInsensitive("thing", "Thing"));
+  EXPECT_FALSE(EndsWithCaseInsensitive("something", "some"));
+  EXPECT_FALSE(EndsWithCaseInsensitive("thing", "something"));
+}
+
 class DataSourceTest : public ::testing::Test {
  protected:
   const std::string relative_path_{"relative.txt"};

--- a/multibody/parsing/test/detail_select_parser_test.cc
+++ b/multibody/parsing/test/detail_select_parser_test.cc
@@ -1,0 +1,67 @@
+#include "drake/multibody/parsing/detail_select_parser.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/multibody/parsing/test/diagnostic_policy_test_base.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace {
+
+using testing::MatchesRegex;
+
+class SelectParserTest : public test::DiagnosticPolicyTestBase {
+ protected:
+  MultibodyPlant<double> plant_{0.0};
+  CollisionFilterGroupResolver resolver_{&plant_};
+  ParsingWorkspace w_{{}, diagnostic_policy_, &plant_,
+                      &resolver_, SelectParser};
+};
+
+// File names may use any mix of upper and lower case. A recognized extension
+// selects a parser, and does not emit an unknown file type error.
+TEST_F(SelectParserTest, CaseInsensitiveMatch) {
+  SelectParser(diagnostic_policy_, "foo.URDF");
+  FlushDiagnostics();
+  SelectParser(diagnostic_policy_, "foo.Urdf");
+  FlushDiagnostics();
+  SelectParser(diagnostic_policy_, "foo.urdf");
+  FlushDiagnostics();
+  SelectParser(diagnostic_policy_, "foo.SDF");
+  FlushDiagnostics();
+  SelectParser(diagnostic_policy_, "foo.Sdf");
+  FlushDiagnostics();
+  SelectParser(diagnostic_policy_, "foo.sdf");
+  FlushDiagnostics();
+  SelectParser(diagnostic_policy_, "foo.XML");
+  FlushDiagnostics();
+  SelectParser(diagnostic_policy_, "foo.Xml");
+  FlushDiagnostics();
+  SelectParser(diagnostic_policy_, "foo.xml");
+  FlushDiagnostics();
+}
+
+// Unknown file type emits an error.
+TEST_F(SelectParserTest, UnknownFileType) {
+  ParserInterface& parser = SelectParser(diagnostic_policy_, "nope");
+  EXPECT_THAT(TakeError(), MatchesRegex(".*not a recognized type.*"));
+
+  // The resulting parser ignores input, does not emit errors or warnings, and
+  // does not crash.
+  std::string empty;
+  EXPECT_EQ(
+      parser.AddModel({DataSource::kContents, &empty}, "", {}, w_),
+      std::nullopt);
+  EXPECT_EQ(
+      parser.AddAllModels({DataSource::kContents, &empty}, "", w_).size(),
+      0);
+  FlushDiagnostics();
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -50,7 +50,8 @@ class UrdfParserTest : public test::DiagnosticPolicyTestBase {
       const std::string& file_name,
       const std::string& model_name) {
     internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{package_map_, diagnostic_policy_, &plant_, &resolver};
+    ParsingWorkspace w{package_map_, diagnostic_policy_,
+                       &plant_, &resolver, NoSelect};
     auto result = AddModelFromUrdf(
         {DataSource::kFilename, &file_name}, model_name, {}, w);
     resolver.Resolve(diagnostic_policy_);
@@ -61,11 +62,18 @@ class UrdfParserTest : public test::DiagnosticPolicyTestBase {
       const std::string& file_contents,
       const std::string& model_name) {
     internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{package_map_, diagnostic_policy_, &plant_, &resolver};
+    ParsingWorkspace w{package_map_, diagnostic_policy_,
+                       &plant_, &resolver, NoSelect};
     auto result = AddModelFromUrdf(
         {DataSource::kContents, &file_contents}, model_name, {}, w);
     resolver.Resolve(diagnostic_policy_);
     return result;
+  }
+
+  // URDF cannot delegate to any other parsers.
+  static ParserInterface& NoSelect(
+      const drake::internal::DiagnosticPolicy&, const std::string&) {
+    DRAKE_UNREACHABLE();
   }
 
  protected:

--- a/multibody/parsing/test/parser_test.cc
+++ b/multibody/parsing/test/parser_test.cc
@@ -185,10 +185,10 @@ GTEST_TEST(FileParserTest, ExtensionMatchTest) {
   MultibodyPlant<double> plant(0.0);
   DRAKE_EXPECT_THROWS_MESSAGE(
       Parser(&plant).AddModelFromFile("acrobot.foo"),
-      ".*file type '\\.foo' is not supported .*");
+      ".*file.*\\.foo.* is not.*recognized.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       Parser(&plant).AddAllModelsFromFile("acrobot.foo"),
-      ".*file type '\\.foo' is not supported .*");
+      ".*file.*\\.foo.* is not.*recognized.*");
 
   // Uppercase extensions are accepted (i.e., still call the underlying SDF or
   // URDF parser, shown here by it generating a different exception message).
@@ -217,7 +217,7 @@ GTEST_TEST(FileParserTest, BadStringTest) {
   // Unknown extension is an error.
   DRAKE_EXPECT_THROWS_MESSAGE(
       Parser(&plant).AddModelFromString("<bad/>", "weird-ext"),
-      ".*file type '\\.weird-ext' is not supported .*");
+      ".*file.*\\.weird-ext.* is not.*recognized.*");
 }
 
 // If a non-Drake URDF or SDF file uses package URIs, this confirms that it is


### PR DESCRIPTION
Make parser selection a general mechanism, so that (in future) model directives will not have to depend on Parser APIs directly. This is a preparation for making model directives files usable with the regular Parser APIs.

As a consesquence, this mechanism in principle allows files of any format to consume files of any other format, using Drake's parsers. This PR does not attempt to expand the currently supported combinations.

Also, public documentation is reorganized, in anticipation of support for more formats.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18003)
<!-- Reviewable:end -->
