### PR TITLE
[doc] x86_64 macOS monterey uses Xcode 14

### DIFF
--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -13,13 +13,13 @@ integration. Any other configurations are provided on a best-effort basis.
 <!-- The minimum compiler versions should match those listed in both the root
      CMakeLists.txt and tools/workspace/cc/repository.bzl. -->
 
-| Operating System ⁽³⁾               | Architecture | Python   | Bazel | CMake | C/C++ Compiler ⁽⁴⁾             | Java                          |
-|------------------------------------|--------------|----------|-------|-------|--------------------------------|-------------------------------|
-| Ubuntu 20.04 LTS (Focal Fossa)     | x86_64       | 3.8 ⁽²⁾  | 5.3   | 3.16  | GCC 9.3 (default) or Clang 12  | OpenJDK 11                    |
-| Ubuntu 22.04 LTS (Jammy Jellyfish) | x86_64       | 3.10 ⁽²⁾ | 5.3   | 3.22  | GCC 11.2 (default) or Clang 12 | OpenJDK 11                    |
-| macOS Big Sur (11)                 | x86_64       | 3.10 ⁽²⁾ | 5.3   | 3.24  | Apple LLVM 12.0.5 (Xcode 12.5) | AdoptOpenJDK 16 (HotSpot JVM) |
-| macOS Monterey (12)                | x86_64       | 3.10 ⁽²⁾ | 5.3   | 3.24  | Apple LLVM 13.0.0 (Xcode 13.1) | AdoptOpenJDK 16 (HotSpot JVM) |
-| macOS Monterey (12)                | arm64 ⁽¹⁾    | 3.10 ⁽²⁾ | 5.3   | 3.24  | Apple LLVM 13.1.6 (Xcode 13.4) | AdoptOpenJDK 16 (HotSpot JVM) |
+| Operating System ⁽³⁾               | Architecture | Python   | Bazel | CMake | C/C++ Compiler ⁽⁴⁾           | Java                          |
+|------------------------------------|--------------|----------|-------|-------|------------------------------|-------------------------------|
+| Ubuntu 20.04 LTS (Focal Fossa)     | x86_64       | 3.8 ⁽²⁾  | 5.3   | 3.16  | GCC 9 (default) or Clang 12  | OpenJDK 11                    |
+| Ubuntu 22.04 LTS (Jammy Jellyfish) | x86_64       | 3.10 ⁽²⁾ | 5.3   | 3.22  | GCC 11 (default) or Clang 12 | OpenJDK 11                    |
+| macOS Big Sur (11)                 | x86_64       | 3.10 ⁽²⁾ | 5.3   | 3.24  | Apple LLVM 12 (Xcode 12)     | AdoptOpenJDK 16 (HotSpot JVM) |
+| macOS Monterey (12)                | x86_64       | 3.10 ⁽²⁾ | 5.3   | 3.24  | Apple LLVM 14 (Xcode 14)     | AdoptOpenJDK 16 (HotSpot JVM) |
+| macOS Monterey (12)                | arm64 ⁽¹⁾    | 3.10 ⁽²⁾ | 5.3   | 3.24  | Apple LLVM 13 (Xcode 13)     | AdoptOpenJDK 16 (HotSpot JVM) |
 
 ⁽¹⁾ For users running on Apple's newer arm64 hardware, you may run Drake in
 native arm64 mode when building from source. However, to use Drake's

--- a/doc/_pages/installation.md
+++ b/doc/_pages/installation.md
@@ -40,12 +40,12 @@ Additionally, if you are compiling your own C++ code against Drake's C++ code
 and are using Drake's pre-compiled binaries, then you must use the same
 compiler as our releases:
 
-| Operating System                   | C/C++ Compiler                 | Std   |
-|------------------------------------|--------------------------------|-------|
-| Ubuntu 20.04 LTS (Focal Fossa)     | GCC 9.3                        | C++17 |
-| Ubuntu 22.04 LTS (Jammy Jellyfish) | GCC 11.2                       | C++20 |
-| macOS Big Sur (11)                 | Apple LLVM 12.0.5 (Xcode 12.5) | C++20 |
-| macOS Monterey (12) on x86_64      | Apple LLVM 13.0.0 (Xcode 13.1) | C++20 |
+| Operating System                   | C/C++ Compiler           | Std   |
+|------------------------------------|--------------------------|-------|
+| Ubuntu 20.04 LTS (Focal Fossa)     | GCC 9                    | C++17 |
+| Ubuntu 22.04 LTS (Jammy Jellyfish) | GCC 11                   | C++20 |
+| macOS Big Sur (11)                 | Apple LLVM 12 (Xcode 12) | C++20 |
+| macOS Monterey (12) on x86_64      | Apple LLVM 14 (Xcode 14) | C++20 |
 
 ## Available Versions
 

--- a/doc/_pages/mac.md
+++ b/doc/_pages/mac.md
@@ -4,7 +4,7 @@ title: macOS
 
 We assume that you have already installed:
 
-* Xcode 10 or above ([from the Mac App Store](https://itunes.apple.com/us/app/xcode/id497799835))
+* Xcode ([from the Mac App Store](https://itunes.apple.com/us/app/xcode/id497799835))
 
 Prerequisite setup is otherwise automated. Simply run:
 


### PR DESCRIPTION
Binary artifacts produced by drake (nightly `.tar.gz` and releases) are now being compiled with Xcode 14.0.1.

Relates: #17985.

Note: release notes label may be incorrect here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18005)
<!-- Reviewable:end -->
