### PR TITLE
Improve error reporting when pydrake import fails

### DIFF
--- a/bindings/pydrake/__init__.py
+++ b/bindings/pydrake/__init__.py
@@ -35,8 +35,31 @@ except ImportError:
     pass
 
 # We specifically load `common` prior to loading any other pydrake modules,
-# in order to get assertion configuration done as early as possible.
-from . import common
+# in order to a) get assertion configuration done as early as possible, and b)
+# detect whether we are able to load the shared libraries.
+try:
+    from . import common
+except ImportError as e:
+    if ('/pydrake/' in e.path and 'cannot open shared object file' in e.msg):
+        message = f'''
+Drake failed to load a required library. This could indicate an installation
+problem, or that your system is missing required distro-provided packages.
+Please refer to the installation instructions to ensure that all required
+dependencies are installed.
+
+For more information, please see:
+    '''
+
+        doc = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                           'INSTALLATION')
+        if os.path.exists(doc):
+            message += f'{doc}\n'
+        else:
+            message += 'https://drake.mit.edu/installation.html\n'
+
+        print(message)
+
+    raise
 
 __all__ = ['common', 'getDrakePath']
 

--- a/bindings/pydrake/__init__.py
+++ b/bindings/pydrake/__init__.py
@@ -40,25 +40,23 @@ except ImportError:
 try:
     from . import common
 except ImportError as e:
-    if ('/pydrake/' in e.path and 'cannot open shared object file' in e.msg):
+    if '/pydrake/' in e.path and 'cannot open shared object file' in e.msg:
         message = f'''
 Drake failed to load a required library. This could indicate an installation
 problem, or that your system is missing required distro-provided packages.
 Please refer to the installation instructions to ensure that all required
 dependencies are installed.
-
-For more information, please see:
-    '''
-
-        doc = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                           'INSTALLATION')
-        if os.path.exists(doc):
-            message += f'{doc}\n'
-        else:
-            message += 'https://drake.mit.edu/installation.html\n'
-
+'''
+        # For wheel builds, we have a file with additional advice.
+        wheel_doc = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), 'INSTALLATION')
+        if os.path.exists(wheel_doc):
+            with open(wheel_doc) as f:
+                message += f.read()
+        message += '''
+For more information, please see https://drake.mit.edu/installation.html
+'''
         print(message)
-
     raise
 
 __all__ = ['common', 'getDrakePath']

--- a/doc/_pages/pip.md
+++ b/doc/_pages/pip.md
@@ -67,7 +67,13 @@ env/bin/pip install --upgrade pip
 env/bin/pip install drake
 ```
 
-(2) Drake requires certain basic runtime libraries from the host linux distribution.
+(2) Drake requires certain basic runtime libraries
+from the host Linux distribution.
+
+<!-- TODO(mwoehlke-kitware)
+On or after 2022-12-01 (once Drake 1.10.0 is released),
+remove these instructions and point to INSTALLATION instead.
+-->
 
 For Ubuntu 20.04, install these additional libraries:
 

--- a/tools/wheel/.dockerignore
+++ b/tools/wheel/.dockerignore
@@ -1,2 +1,3 @@
 /*
 !/image/
+!/content/

--- a/tools/wheel/Dockerfile
+++ b/tools/wheel/Dockerfile
@@ -65,6 +65,7 @@ RUN --mount=type=ssh \
 
 ADD image/build-wheel.sh /image/
 ADD image/setup.py /opt/drake-wheel-build/wheel/
+ADD content /opt/drake-wheel-content
 
 ENV DRAKE_VERSION=${DRAKE_VERSION}
 

--- a/tools/wheel/content/INSTALLATION
+++ b/tools/wheel/content/INSTALLATION
@@ -1,4 +1,3 @@
-Drake requires certain basic runtime libraries from the host Linux distribution.
 
 For Ubuntu 20.04, install these additional libraries:
 

--- a/tools/wheel/content/INSTALLATION
+++ b/tools/wheel/content/INSTALLATION
@@ -1,0 +1,13 @@
+Drake requires certain basic runtime libraries from the host Linux distribution.
+
+For Ubuntu 20.04, install these additional libraries:
+
+    sudo apt-get install --no-install-recommends \
+      libpython3.8 libx11-6 libsm6 libxt6 libglib2.0-0
+
+For Ubuntu 22.04, install these additional libraries:
+
+    sudo apt-get install --no-install-recommends \
+      libx11-6 libsm6 libglib2.0-0
+
+For macOS, ensure that you're using Homebrew Python (not Apple's system Python).

--- a/tools/wheel/image/build-wheel.sh
+++ b/tools/wheel/image/build-wheel.sh
@@ -58,6 +58,9 @@ cp -r -t ${WHEEL_DIR}/pydrake \
 cp -r -t ${WHEEL_DIR}/pydrake/lib \
     /opt/drake/lib/libdrake*.so
 
+cp -r -t ${WHEEL_DIR}/pydrake \
+    /opt/drake-wheel-content/*
+
 # NOTE: build-vtk.sh also puts licenses in /opt/drake-dependencies/licenses.
 cp -r -t ${WHEEL_DIR}/pydrake/doc \
     /opt/drake-dependencies/licenses/*

--- a/tools/wheel/image/setup.py
+++ b/tools/wheel/image/setup.py
@@ -86,6 +86,7 @@ See https://drake.mit.edu/pip.html for installation instructions and caveats.
               'pydrake/lib/**',
               'pydrake/doc/**',
               'pydrake/share/**',
+              'pydrake/INSTALLATION',
           )
       },
       python_requires='>=3.8',

--- a/tools/wheel/test/tests/hermetic/import-error-test.sh
+++ b/tools/wheel/test/tests/hermetic/import-error-test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+cd "$(mktemp -d)"
+
+root=/opt/drake-wheel-test/python/lib/python*/site-packages/pydrake
+
+# Remove libdrake.so so imports will fail.
+# (Note: Because this test tampers with the test environment, it should only be
+# run on Linux, where each test is run in a hermetic Docker container.)
+rm $root/lib/libdrake.so
+
+# Test that a failed import produces the expected error message.
+python > out << EOF || true
+import pydrake.common
+EOF
+
+trap 'cat out' ERR
+
+grep -q 'Drake failed to load a required library' out
+grep -q '/pydrake/INSTALLATION' out

--- a/tools/wheel/wheel_builder/linux.py
+++ b/tools/wheel/wheel_builder/linux.py
@@ -280,7 +280,7 @@ def _test_wheel(target, identifier, options):
 
     # Run individual tests.
     test_script = '/test/test-wheel.sh'
-    for test in find_tests():
+    for test in find_tests('hermetic'):
         print(f'[-] Executing test {test}')
         _docker('run', '--rm', '-t',
                 '-v' f'{test_dir}:/test',


### PR DESCRIPTION
Modify pydrake (at least, `import pydrake.all`) to detect when it can't be loaded due to failure to load a dynamic library, and to give a somewhat more user-friendly error message. Add a brief document listing what distro packages need to be installed, which is referenced by the aforementioned error.

Fixes #16383.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18015)
<!-- Reviewable:end -->
