### PR TITLE
py deprecation: Ignore warnings for dtype=object operations

### DIFF
--- a/bindings/pydrake/common/deprecation.py
+++ b/bindings/pydrake/common/deprecation.py
@@ -236,6 +236,14 @@ def install_numpy_warning_filters(force=False):
         "error", category=DeprecationWarning,
         message="elementwise comparison failed")
 
+    # TODO(#17898): This is not a deprecation per se, nor is it promoting the
+    # deprecation to warning. However, this warning currently does not incur
+    # a functional penalty, so we suppress the warning to minimize
+    # distractions. Root-cause investigation pending.
+    warnings.filterwarnings(
+        "ignore", category=RuntimeWarning,
+        message="invalid value encountered in")
+
 
 def deprecated_callable(message, *, date=None):
     """

--- a/bindings/pydrake/test/symbolic_test.py
+++ b/bindings/pydrake/test/symbolic_test.py
@@ -3,6 +3,7 @@
 import copy
 import itertools
 import unittest
+import warnings
 
 import numpy as np
 
@@ -2298,3 +2299,13 @@ class TestReplaceBilinearTerms(unittest.TestCase):
         e = x[0]*y[1] * 3 + x[1]*y[2] * 4
         e_replace = sym.ReplaceBilinearTerms(e=e, x=x, y=y, W=W)
         self.assertTrue(e_replace.EqualTo(W[0, 1]*3 + W[1, 2]*4))
+
+
+class TestIssue17898(unittest.TestCase):
+    def test(self):
+        with warnings.catch_warnings(record=True) as w:
+            v = sym.MakeVectorVariable(2, "v")
+            np.eye(2) @ v
+            np.sqrt(v)
+            # Ensure no user-visible warnings occur.
+            self.assertEqual(len(w), 0)

--- a/bindings/pydrake/test/symbolic_test.py
+++ b/bindings/pydrake/test/symbolic_test.py
@@ -2302,7 +2302,13 @@ class TestReplaceBilinearTerms(unittest.TestCase):
 
 
 class TestIssue17898(unittest.TestCase):
-    def test(self):
+    def test_numpy_dtype_object_operations_no_warnings(self):
+        """
+        Tests that operations like `np.matmul`, `np.sqrt`, etc. do not issue
+        warnings when using Drake-specified dtype=object types.
+
+        See #17898 for more context.
+        """
         with warnings.catch_warnings(record=True) as w:
             v = sym.MakeVectorVariable(2, "v")
             np.eye(2) @ v


### PR DESCRIPTION
Does not appear to impact functioning, but merits root-cause investigation

Towards #17898

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18017)
<!-- Reviewable:end -->
