### PR TITLE
ScrewJoint: accept axis unit vector in constructor

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1598,10 +1598,20 @@ class TestPlant(unittest.TestCase):
             )
 
         def make_screw_joint(plant, P, C):
+            # First, check that the no-axis overload works.
+            ScrewJoint_[T](
+                name="screw",
+                frame_on_parent=P,
+                frame_on_child=C,
+                screw_pitch=0.005,
+                damping=damping,
+            )
+            # Then, create one with an explicit axis.
             return ScrewJoint_[T](
                 name="screw",
                 frame_on_parent=P,
                 frame_on_child=C,
+                axis=x_axis,
                 screw_pitch=0.005,
                 damping=damping,
             )

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -568,7 +568,12 @@ void DoScalarDependentDefinitions(py::module m, T) {
                  double>(),
             py::arg("name"), py::arg("frame_on_parent"),
             py::arg("frame_on_child"), py::arg("screw_pitch") = 0,
-            py::arg("damping") = 0, cls_doc.ctor.doc)
+            py::arg("damping") = 0, cls_doc.ctor.doc_5args)
+        .def(py::init<const string&, const Frame<T>&, const Frame<T>&,
+                 const Vector3<double>&, double, double>(),
+            py::arg("name"), py::arg("frame_on_parent"),
+            py::arg("frame_on_child"), py::arg("axis"), py::arg("screw_pitch"),
+            py::arg("damping"), cls_doc.ctor.doc_6args)
         .def("screw_pitch", &Class::screw_pitch, cls_doc.screw_pitch.doc)
         .def("damping", &Class::damping, cls_doc.damping.doc)
         .def("get_default_translation", &Class::get_default_translation,

--- a/multibody/plant/test/multibody_plant_reaction_forces_test.cc
+++ b/multibody/plant/test/multibody_plant_reaction_forces_test.cc
@@ -104,7 +104,7 @@ class LadderTest : public ::testing::Test {
     // that we can evaluate the reaction force right at the middle.
     // We define body frame Bl and Bu for the lower and upper portions of the
     // ladder respectively.
-    // Both of these frames's origins are located at the lower end of each half.
+    // Both of these frame origins are located at the lower end of each half.
     // In particular, the lower frame Bl attaches to the ground with the pin
     // joint.
     const Vector3<double> p_BoBcm_B(0.0, 0.0, kLadderLength / 4.0);

--- a/multibody/tree/prismatic_joint.cc
+++ b/multibody/tree/prismatic_joint.cc
@@ -1,11 +1,40 @@
 #include "drake/multibody/tree/prismatic_joint.h"
 
 #include <memory>
+#include <stdexcept>
 
 #include "drake/multibody/tree/multibody_tree.h"
 
 namespace drake {
 namespace multibody {
+
+template <typename T>
+PrismaticJoint<T>::PrismaticJoint(
+    const std::string& name, const Frame<T>& frame_on_parent,
+    const Frame<T>& frame_on_child, const Vector3<double>& axis,
+    double pos_lower_limit, double pos_upper_limit, double damping)
+    : Joint<T>(name, frame_on_parent, frame_on_child,
+               VectorX<double>::Constant(1, damping),
+               VectorX<double>::Constant(1, pos_lower_limit),
+               VectorX<double>::Constant(1, pos_upper_limit),
+               VectorX<double>::Constant(
+                   1, -std::numeric_limits<double>::infinity()),
+               VectorX<double>::Constant(
+                   1, std::numeric_limits<double>::infinity()),
+               VectorX<double>::Constant(
+                   1, -std::numeric_limits<double>::infinity()),
+               VectorX<double>::Constant(
+                   1, std::numeric_limits<double>::infinity())) {
+  const double kEpsilon = std::sqrt(std::numeric_limits<double>::epsilon());
+  if (axis.isZero(kEpsilon)) {
+    throw std::logic_error("Prismatic joint axis vector must have nonzero "
+                           "length.");
+  }
+  if (damping < 0) {
+    throw std::logic_error("Prismatic joint damping must be nonnegative.");
+  }
+  axis_ = axis.normalized();
+}
 
 template <typename T>
 template <typename ToScalar>

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -69,24 +69,7 @@ class PrismaticJoint final : public Joint<T> {
       const Frame<T>& frame_on_child, const Vector3<double>& axis,
       double pos_lower_limit = -std::numeric_limits<double>::infinity(),
       double pos_upper_limit = std::numeric_limits<double>::infinity(),
-      double damping = 0)
-      : Joint<T>(name, frame_on_parent, frame_on_child,
-                 VectorX<double>::Constant(1, damping),
-                 VectorX<double>::Constant(1, pos_lower_limit),
-                 VectorX<double>::Constant(1, pos_upper_limit),
-                 VectorX<double>::Constant(
-                     1, -std::numeric_limits<double>::infinity()),
-                 VectorX<double>::Constant(
-                     1, std::numeric_limits<double>::infinity()),
-                 VectorX<double>::Constant(
-                     1, -std::numeric_limits<double>::infinity()),
-                 VectorX<double>::Constant(
-                     1, std::numeric_limits<double>::infinity())) {
-    const double kEpsilon = std::sqrt(std::numeric_limits<double>::epsilon());
-    DRAKE_THROW_UNLESS(!axis.isZero(kEpsilon));
-    DRAKE_THROW_UNLESS(damping >= 0);
-    axis_ = axis.normalized();
-  }
+      double damping = 0);
 
   const std::string& type_name() const override {
     static const never_destroyed<std::string> name{kTypeName};
@@ -95,7 +78,7 @@ class PrismaticJoint final : public Joint<T> {
 
   /// Returns the axis of translation for `this` joint as a unit vector.
   /// Since the measures of this axis in either frame F or M are the same (see
-  /// this class's documentation for frames's definitions) then,
+  /// this class's documentation for frame definitions) then,
   /// `axis = axis_F = axis_M`.
   const Vector3<double>& translation_axis() const {
     return axis_;

--- a/multibody/tree/prismatic_mobilizer.h
+++ b/multibody/tree/prismatic_mobilizer.h
@@ -49,7 +49,7 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
                      const Vector3<double>& axis_F) :
       MobilizerBase(inboard_frame_F, outboard_frame_M), axis_F_(axis_F) {
     double kEpsilon = std::sqrt(std::numeric_limits<double>::epsilon());
-    DRAKE_THROW_UNLESS(!axis_F.isZero(kEpsilon));
+    DRAKE_DEMAND(!axis_F.isZero(kEpsilon));
     axis_F_.normalize();
   }
 

--- a/multibody/tree/revolute_joint.cc
+++ b/multibody/tree/revolute_joint.cc
@@ -9,6 +9,34 @@ namespace drake {
 namespace multibody {
 
 template <typename T>
+RevoluteJoint<T>::RevoluteJoint(const std::string& name,
+              const Frame<T>& frame_on_parent, const Frame<T>& frame_on_child,
+              const Vector3<double>& axis, double pos_lower_limit,
+              double pos_upper_limit, double damping)
+    : Joint<T>(name, frame_on_parent, frame_on_child,
+               VectorX<double>::Constant(1, damping),
+               VectorX<double>::Constant(1, pos_lower_limit),
+               VectorX<double>::Constant(1, pos_upper_limit),
+               VectorX<double>::Constant(
+                   1, -std::numeric_limits<double>::infinity()),
+               VectorX<double>::Constant(
+                   1, std::numeric_limits<double>::infinity()),
+               VectorX<double>::Constant(
+                   1, -std::numeric_limits<double>::infinity()),
+               VectorX<double>::Constant(
+                   1, std::numeric_limits<double>::infinity())) {
+  const double kEpsilon = std::numeric_limits<double>::epsilon();
+  if (axis.isZero(kEpsilon)) {
+    throw std::logic_error("Revolute joint axis vector must have nonzero "
+                           "length.");
+  }
+  if (damping < 0) {
+    throw std::logic_error("Revolute joint damping must be nonnegative.");
+  }
+  axis_ = axis.normalized();
+}
+
+template <typename T>
 template <typename ToScalar>
 std::unique_ptr<Joint<ToScalar>> RevoluteJoint<T>::TemplatedDoCloneToScalar(
     const internal::MultibodyTree<ToScalar>& tree_clone) const {

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -84,8 +84,7 @@ class RevoluteJoint final : public Joint<T> {
   ///   are exactly the same, that is, `axis_F = axis_M`. In other words,
   ///   `axis_F` (or `axis_M`) is the eigenvector of `R_FM` with eigenvalue
   ///   equal to one.
-  ///   This vector can have any length, only the direction is used. This method
-  ///   aborts if `axis` is the zero vector.
+  ///   This vector can have any length, only the direction is used.
   /// @param[in] pos_lower_limit
   ///   Lower position limit, in radians, for the rotation coordinate
   ///   (see get_angle()).
@@ -97,29 +96,14 @@ class RevoluteJoint final : public Joint<T> {
   ///   joint. The damping torque (in N⋅m) is modeled as `τ = -damping⋅ω`, i.e.
   ///   opposing motion, with ω the angular rate for `this` joint (see
   ///   get_angular_rate()).
+  /// @throws std::exception if the L2 norm of `axis` is less than the square
+  /// root of machine epsilon.
   /// @throws std::exception if damping is negative.
   /// @throws std::exception if pos_lower_limit > pos_upper_limit.
   RevoluteJoint(const std::string& name, const Frame<T>& frame_on_parent,
                 const Frame<T>& frame_on_child, const Vector3<double>& axis,
                 double pos_lower_limit, double pos_upper_limit,
-                double damping = 0)
-      : Joint<T>(name, frame_on_parent, frame_on_child,
-                 VectorX<double>::Constant(1, damping),
-                 VectorX<double>::Constant(1, pos_lower_limit),
-                 VectorX<double>::Constant(1, pos_upper_limit),
-                 VectorX<double>::Constant(
-                     1, -std::numeric_limits<double>::infinity()),
-                 VectorX<double>::Constant(
-                     1, std::numeric_limits<double>::infinity()),
-                 VectorX<double>::Constant(
-                     1, -std::numeric_limits<double>::infinity()),
-                 VectorX<double>::Constant(
-                     1, std::numeric_limits<double>::infinity())) {
-    const double kEpsilon = std::numeric_limits<double>::epsilon();
-    DRAKE_DEMAND(!axis.isZero(kEpsilon));
-    DRAKE_THROW_UNLESS(damping >= 0);
-    axis_ = axis.normalized();
-  }
+                double damping = 0);
 
   const std::string& type_name() const override {
     static const never_destroyed<std::string> name{kTypeName};
@@ -128,7 +112,7 @@ class RevoluteJoint final : public Joint<T> {
 
   /// Returns the axis of revolution of `this` joint as a unit vector.
   /// Since the measures of this axis in either frame F or M are the same (see
-  /// this class's documentation for frames's definitions) then,
+  /// this class's documentation for frame definitions) then,
   /// `axis = axis_F = axis_M`.
   const Vector3<double>& revolute_axis() const {
     return axis_;

--- a/multibody/tree/revolute_mobilizer.h
+++ b/multibody/tree/revolute_mobilizer.h
@@ -45,14 +45,12 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
   // @pre `axis_F` must be a non-zero vector with norm at least root square of
   // machine epsilon. This vector can have any length (subject to the norm
   // restriction above), only the direction is used.
-  // @throws std::exception if the L2 norm of `axis_F` is less than the square
-  // root of machine epsilon.
   RevoluteMobilizer(const Frame<T>& inboard_frame_F,
                     const Frame<T>& outboard_frame_M,
                     const Vector3<double>& axis_F) :
       MobilizerBase(inboard_frame_F, outboard_frame_M), axis_F_(axis_F) {
     double kEpsilon = std::sqrt(std::numeric_limits<double>::epsilon());
-    DRAKE_THROW_UNLESS(!axis_F.isZero(kEpsilon));
+    DRAKE_DEMAND(!axis_F_.isZero(kEpsilon));
     axis_F_.normalize();
   }
 

--- a/multibody/tree/screw_mobilizer.cc
+++ b/multibody/tree/screw_mobilizer.cc
@@ -112,10 +112,9 @@ math::RigidTransform<T> ScrewMobilizer<T>::CalcAcrossMobilizerTransform(
     const systems::Context<T>& context) const {
   const auto& q = this->get_positions(context);
   DRAKE_ASSERT(q.size() == kNq);
-  const Vector3<T> X_FM_translation(0.0, 0.0,
+  const Vector3<T> p_FM(axis_ *
       get_screw_translation_from_rotation(q[0], screw_pitch_));
-  return math::RigidTransform<T>(math::RotationMatrix<T>::MakeZRotation(q[0]),
-                                 X_FM_translation);
+  return math::RigidTransform<T>(Eigen::AngleAxis<T>(q[0], axis_), p_FM);
 }
 
 template <typename T>
@@ -124,8 +123,8 @@ SpatialVelocity<T> ScrewMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
   DRAKE_ASSERT(v.size() == kNv);
   Vector6<T> V_FM_vector;
   V_FM_vector <<
-    0.0, 0.0, get_screw_rotation_from_translation(v[0], screw_pitch_),
-    0.0, 0.0, v[0];
+    (axis_ * v[0]),
+    (axis_ * get_screw_translation_from_rotation(v[0], screw_pitch_));
   return SpatialVelocity<T>(V_FM_vector);
 }
 
@@ -136,8 +135,9 @@ ScrewMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
     const Eigen::Ref<const VectorX<T>>& vdot) const {
   DRAKE_ASSERT(vdot.size() == kNv);
   Vector6<T> A_FM_vector;
-  A_FM_vector << 0.0, 0.0, vdot[0], 0.0, 0.0,
-                 get_screw_translation_from_rotation(vdot[0], screw_pitch_);
+  A_FM_vector <<
+    (axis_ * vdot[0]),
+    (axis_ * get_screw_translation_from_rotation(vdot[0], screw_pitch_));
   return SpatialAcceleration<T>(A_FM_vector);
 }
 
@@ -146,7 +146,8 @@ void ScrewMobilizer<T>::ProjectSpatialForce(const systems::Context<T>&,
                                              const SpatialForce<T>& F_Mo_F,
                                              Eigen::Ref<VectorX<T>> tau) const {
   DRAKE_ASSERT(tau.size() == kNv);
-  tau[0] = F_Mo_F.rotational()[2] + screw_pitch() * F_Mo_F.translational()[2];
+  tau[0] = F_Mo_F.rotational().dot(axis_) +
+           F_Mo_F.translational().dot(axis_) / (2 * M_PI) * screw_pitch_;
 }
 
 template <typename T>
@@ -192,6 +193,7 @@ ScrewMobilizer<T>::TemplatedDoCloneToScalar(
       tree_clone.get_variant(this->outboard_frame());
   return std::make_unique<ScrewMobilizer<ToScalar>>(inboard_frame_clone,
                                                     outboard_frame_clone,
+                                                    this->screw_axis(),
                                                     this->screw_pitch());
 }
 


### PR DESCRIPTION
Closes #17882.

## New Features

* Adds a constructor to `ScrewJoint` that accepts a `Vector3<double>` for the axis unit vector and a `screw_axis()` accessor method to the class. The current constructor that assumes the axis unit vector is the Z-axis is retained but may be considered for deprecation in the future. I adapted the documentation based on the `revolute_joint.h` header file.
* Adds a `Vector3<double>` argument for the axis unit vector to the `ScrewMobilizer` constructor and updates the mobilizer math in [34a2dab](https://github.com/RobotLocomotion/drake/pull/18019/commits/34a2dab8c57fbf3a19419ad0ea334b6175fef631) to use this unit vector instead of the Z-axis.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18019)
<!-- Reviewable:end -->
