### PR TITLE
Support end-effector velocity limits in DiffIK and integrate through kStuck

### DIFF
--- a/bindings/pydrake/manipulation/planner_py.cc
+++ b/bindings/pydrake/manipulation/planner_py.cc
@@ -98,7 +98,20 @@ PYBIND11_MODULE(planner, m) {
             cls_doc.get_maximum_scaling_to_report_stuck.doc)
         .def("set_maximum_scaling_to_report_stuck",
             &Class::set_maximum_scaling_to_report_stuck, py::arg("scaling"),
-            cls_doc.set_maximum_scaling_to_report_stuck.doc);
+            cls_doc.set_maximum_scaling_to_report_stuck.doc)
+        .def("get_end_effector_angular_speed_limit",
+            &Class::get_end_effector_angular_speed_limit,
+            cls_doc.get_end_effector_angular_speed_limit.doc)
+        .def("set_end_effector_angular_speed_limit",
+            &Class::set_end_effector_angular_speed_limit, py::arg("speed"),
+            cls_doc.set_end_effector_angular_speed_limit.doc)
+        .def("get_end_effector_translational_velocity_limits",
+            &Class::get_end_effector_translational_velocity_limits,
+            cls_doc.get_end_effector_translational_velocity_limits.doc)
+        .def("set_end_effector_translational_velocity_limits",
+            &Class::set_end_effector_translational_velocity_limits,
+            py::arg("lower"), py::arg("upper"),
+            cls_doc.set_end_effector_translational_velocity_limits.doc);
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"

--- a/bindings/pydrake/manipulation/test/planner_test.py
+++ b/bindings/pydrake/manipulation/test/planner_test.py
@@ -51,6 +51,16 @@ class TestPlanner(unittest.TestCase):
         params.set_joint_acceleration_limits
         params.set_maximum_scaling_to_report_stuck(scaling=0.1)
         self.assertEqual(params.get_maximum_scaling_to_report_stuck(), 0.1)
+        params.set_end_effector_angular_speed_limit(speed=0.12)
+        self.assertEqual(params.get_end_effector_angular_speed_limit(), 0.12)
+        params.set_end_effector_translational_velocity_limits([-1, -2, -3],
+                                                              [1, 2, 3])
+        np.testing.assert_equal(
+            params.get_end_effector_translational_velocity_limits()[0],
+            [-1, -2, -3])
+        np.testing.assert_equal(
+            params.get_end_effector_translational_velocity_limits()[1],
+            [1, 2, 3])
 
         # The following methods are deprecated, to be removed on or after
         # 2023-01-01.

--- a/manipulation/planner/differential_inverse_kinematics_integrator.cc
+++ b/manipulation/planner/differential_inverse_kinematics_integrator.cc
@@ -100,19 +100,14 @@ systems::EventStatus DifferentialInverseKinematicsIntegrator::Integrate(
   DRAKE_THROW_UNLESS(parameters_.get_time_step() == time_step_);
   const math::RigidTransformd& X_WE_desired =
       input->get_value<math::RigidTransformd>();
-  const math::RigidTransform<double> X_WE = ForwardKinematics(context);
-
-  const Vector6<double> V_WE_desired =
-      ComputePoseDiffInCommonFrame(X_WE, X_WE_desired) /
-      time_step_;
 
   const Context<double>& robot_context =
       robot_context_cache_entry_->Eval<Context<double>>(context);
   DifferentialInverseKinematicsResult result = DoDifferentialInverseKinematics(
-      robot_, robot_context, V_WE_desired, frame_E_, parameters_);
+      robot_, robot_context, X_WE_desired, frame_E_, parameters_);
 
   const auto& positions = context.get_discrete_state(0).get_value();
-  if (result.status != DifferentialInverseKinematicsStatus::kSolutionFound) {
+  if (result.status == DifferentialInverseKinematicsStatus::kNoSolutionFound) {
     if (this->num_discrete_state_groups() == 1) {
       drake::log()->warn(
           "Differential IK could not find a solution at time {}.",

--- a/manipulation/planner/differential_inverse_kinematics_integrator.h
+++ b/manipulation/planner/differential_inverse_kinematics_integrator.h
@@ -16,9 +16,11 @@ position commands.
 
 Rather than calling DoDifferentialInverseKinematics on the current measured
 positions of the robot, this System maintains its own internal state and
-integrates successive velocity commands open loop.  Using measured joint
-positions in a feedback loop can lead to undamped oscillations in the redundant
-joints; we hope to resolve this and are tracking it in #9773.
+integrates successive velocity commands open loop. If
+DoDifferentialInverseKinematics returns kNoSolution, then the integrator will
+hold the integrated position (with zero velocity); on kStuck the integration
+will continue (though "kStuck" implies that the achieved spatial velocity will
+be much smaller than what was commanded).
 
 Note: It is highly recommended that the user calls `SetPosition()` once to
 initialize the position commands to match the initial positions of the robot.
@@ -27,6 +29,10 @@ is only used at Initialization, and simply sets the positions to the positions
 on this input port (the port accepts the state vector with positions and
 velocities for easy of use with MultibodyPlant, but only the positions are
 used).
+
+Note: Using measured joint positions in a feedback loop can lead to undamped
+oscillations in the redundant joints; we hope to resolve this and are tracking
+it in #9773.
 
 @system
 name: DifferentialInverseKinematicsIntegrator

--- a/manipulation/planner/test/differential_inverse_kinematics_integrator_test.cc
+++ b/manipulation/planner/test/differential_inverse_kinematics_integrator_test.cc
@@ -91,6 +91,7 @@ GTEST_TEST(DifferentialInverseKinematicsIntegatorTest, BasicTest) {
   const auto b = Eigen::VectorXd::Zero(A.rows());
   diff_ik.get_mutable_parameters().AddLinearVelocityConstraint(
       std::make_shared<solvers::LinearConstraint>(A, b, b));
+  Eigen::VectorXd last_q = robot->GetPositions(*robot_context);
   for (const auto& [data, events] : diff_ik.GetPeriodicEvents()) {
     dynamic_cast<const systems::DiscreteUpdateEvent<double>*>(events[0])
         ->handle(diff_ik, *diff_ik_context, discrete_state.get());
@@ -98,6 +99,8 @@ GTEST_TEST(DifferentialInverseKinematicsIntegatorTest, BasicTest) {
   EXPECT_EQ(discrete_state->get_vector(1).GetAtIndex(0),
             static_cast<double>(
                 DifferentialInverseKinematicsStatus::kStuck));
+  // kStuck does *not* imply that the positions will not advance.
+  EXPECT_FALSE(CompareMatrices(discrete_state->get_value(0), last_q, 1e-12));
 }
 
 GTEST_TEST(DifferentialInverseKinematicsIntegatorTest, ParametersTest) {


### PR DESCRIPTION
Adds end-effector velocity limits for the entry point which takes a desired pose.

DiffIKIntegrator now continues to integrate even if DiffIK reports kStuck. Previously, kStuck (which means small velocity commands) resulted in the integrator commanding exactly zero velocity. This meant it was effectively impossible to get unstuck using DiffIK. The only reason for this before was because DiffIK did not return joint velocities when it was kStuck; but that limitaiton was resolved with my last PR.

Also adds a few minor improvements to the differential inverse kinematics tools:
- Minor touch-ups / todos in the documentation.
- Use the desired pose entry point in DiffIKIntegrator.
- Strengthens the TestLinearObjective test.

These changes will not impact the behavior for current users of DoDifferentialInverseKinematics; they only add new options.

+@siyuanfeng-tri for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18021)
<!-- Reviewable:end -->
