### PR TITLE
[multibody] DeformableDriver computes discrete contact pairs 

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -21,6 +21,7 @@ drake_cc_package_library(
         ":constraint_specs",
         ":contact_jacobians",
         ":contact_pair_kinematics",
+        ":contact_properties",
         ":contact_results",
         ":coulomb_friction",
         ":discrete_contact_pair",
@@ -115,6 +116,7 @@ drake_cc_library(
         ":constraint_specs",
         ":contact_jacobians",
         ":contact_pair_kinematics",
+        ":contact_properties",
         ":contact_results",
         ":coulomb_friction",
         ":discrete_contact_pair",
@@ -384,6 +386,20 @@ drake_cc_library(
         ":multibody_plant_config",
         ":multibody_plant_core",
         "//systems/framework:diagram_builder",
+    ],
+)
+
+drake_cc_library(
+    name = "contact_properties",
+    srcs = [
+        "contact_properties.cc",
+    ],
+    hdrs = [
+        "contact_properties.h",
+    ],
+    deps = [
+        "//common:default_scalars",
+        "//geometry:scene_graph_inspector",
     ],
 )
 
@@ -757,6 +773,15 @@ drake_cc_googletest(
     name = "constraint_specs_test",
     deps = [
         ":constraint_specs",
+    ],
+)
+
+drake_cc_googletest(
+    name = "contact_properties_test",
+    deps = [
+        ":contact_properties",
+        "//common/test_utilities:expect_throws_message",
+        "//geometry:scene_graph",
     ],
 )
 

--- a/multibody/plant/compliant_contact_manager.h
+++ b/multibody/plant/compliant_contact_manager.h
@@ -145,48 +145,6 @@ class CompliantContactManager final
   std::vector<ContactPairKinematics<T>> CalcContactKinematics(
       const systems::Context<T>& context) const;
 
-  // Returns the point contact stiffness stored in group
-  // geometry::internal::kMaterialGroup with property
-  // geometry::internal::kPointStiffness for the specified geometry.
-  // If the stiffness property is absent, it returns MultibodyPlant's default
-  // stiffness.
-  // GeometryId `id` must exist in the model or an exception is thrown.
-  T GetPointContactStiffness(
-      geometry::GeometryId id,
-      const geometry::SceneGraphInspector<T>& inspector) const;
-
-  // Returns the dissipation time constant stored in group
-  // geometry::internal::kMaterialGroup with property
-  // "dissipation_time_constant". If not present, it returns
-  // plant().time_step().
-  T GetDissipationTimeConstant(
-      geometry::GeometryId id,
-      const geometry::SceneGraphInspector<T>& inspector) const;
-
-  // Helper to acquire per-geometry Coulomb friction coefficients from
-  // SceneGraph. Discrete models cannot make a distinction between static and
-  // dynamic coefficients of friction. Therefore this method returns the
-  // coefficient of dynamic friction stored by SceneGraph while the coefficient
-  // of static friction is ignored.
-  // @pre id is a valid GeometryId in the inspector.
-  double GetCoulombFriction(
-      geometry::GeometryId id,
-      const geometry::SceneGraphInspector<T>& inspector) const;
-
-  // Utility to combine stiffnesses k1 and k2 according to the rule:
-  //   k  = k₁⋅k₂/(k₁+k₂)
-  // In other words, the combined compliance (the inverse of stiffness) is the
-  // sum of the individual compliances.
-  static T CombineStiffnesses(const T& k1, const T& k2);
-
-  // Utility to combine linear dissipation time constants. Consider two
-  // spring-dampers with stiffnesses k₁ and k₂, and dissipation timescales τ₁
-  // and τ₂, respectively. When these spring-dampers are connected in series,
-  // they result in an equivalent spring-damper with stiffness k  =
-  // k₁⋅k₂/(k₁+k₂) and dissipation τ = τ₁ + τ₂.
-  // This method returns tau1 + tau2.
-  static T CombineDissipationTimeConstant(const T& tau1, const T& tau2);
-
   // Given the configuration stored in `context`, this method appends discrete
   // pairs corresponding to point contact into `pairs`.
   // @pre pairs != nullptr.
@@ -202,9 +160,10 @@ class CompliantContactManager final
       std::vector<internal::DiscreteContactPair<T>>* pairs) const;
 
   // Given the configuration stored in `context`, this method computes all
-  // discrete contact pairs, including point and hydroelastic contact, into
-  // `pairs.`
-  // Throws an exception if `pairs` is nullptr.
+  // discrete contact pairs, including point, hydroelastic, and deformable
+  // contact, into `pairs`. Contact pairs including deformable bodies are
+  // guaranteed to come after point and hydroelastic contact pairs. Throws an
+  // exception if `pairs` is nullptr.
   void CalcDiscreteContactPairs(
       const systems::Context<T>& context,
       std::vector<internal::DiscreteContactPair<T>>* pairs) const;

--- a/multibody/plant/contact_properties.cc
+++ b/multibody/plant/contact_properties.cc
@@ -1,0 +1,109 @@
+#include "drake/multibody/plant/contact_properties.h"
+
+#include <string>
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace {
+
+/* Helper divide function that detects 0 / 0. Returns zero if the denominator is
+ zero. */
+template <typename T>
+T safe_divide(const T& num, const T& denom) {
+  return denom == 0.0 ? 0.0 : num / denom;
+}
+
+}  // namespace
+
+template <typename T>
+T GetPointContactStiffness(geometry::GeometryId id, double default_value,
+                           const geometry::SceneGraphInspector<T>& inspector) {
+  DRAKE_DEMAND(default_value >= 0.0);
+  const geometry::ProximityProperties* prop =
+      inspector.GetProximityProperties(id);
+  DRAKE_DEMAND(prop != nullptr);
+  return prop->template GetPropertyOrDefault<T>(
+      geometry::internal::kMaterialGroup, geometry::internal::kPointStiffness,
+      default_value);
+}
+
+template <typename T>
+T GetDissipationTimeConstant(geometry::GeometryId id, double default_value,
+                             const geometry::SceneGraphInspector<T>& inspector,
+                             std::string_view body_name) {
+  DRAKE_DEMAND(default_value >= 0.0);
+  const geometry::ProximityProperties* prop =
+      inspector.GetProximityProperties(id);
+  DRAKE_DEMAND(prop != nullptr);
+
+  auto provide_context_string =
+      [&inspector,
+       &body_name](geometry::GeometryId geometry_id) -> std::string {
+    return fmt::format("For geometry {} on body {}.",
+                       inspector.GetName(geometry_id), body_name);
+  };
+  const T relaxation_time = prop->template GetPropertyOrDefault<double>(
+      geometry::internal::kMaterialGroup, "relaxation_time", default_value);
+  if (relaxation_time < 0.0) {
+    const std::string message = fmt::format(
+        "Relaxation time must be non-negative and relaxation_time "
+        "= {} was provided. {}",
+        relaxation_time, provide_context_string(id));
+    throw std::runtime_error(message);
+  }
+  return relaxation_time;
+}
+
+template <typename T>
+const CoulombFriction<double>& GetCoulombFriction(
+    geometry::GeometryId id,
+    const geometry::SceneGraphInspector<T>& inspector) {
+  const geometry::ProximityProperties* prop =
+      inspector.GetProximityProperties(id);
+  DRAKE_DEMAND(prop != nullptr);
+  DRAKE_THROW_UNLESS(prop->HasProperty(geometry::internal::kMaterialGroup,
+                                       geometry::internal::kFriction));
+  return prop->GetProperty<CoulombFriction<double>>(
+      geometry::internal::kMaterialGroup, geometry::internal::kFriction);
+}
+
+template <typename T>
+T GetCombinedPointContactStiffness(
+    geometry::GeometryId id_A, geometry::GeometryId id_B, double default_value,
+    const geometry::SceneGraphInspector<T>& inspector) {
+  const T k1 = GetPointContactStiffness(id_A, default_value, inspector);
+  const T k2 = GetPointContactStiffness(id_B, default_value, inspector);
+  return safe_divide(k1 * k2, k1 + k2);
+}
+
+template <typename T>
+T GetCombinedDissipationTimeConstant(
+    geometry::GeometryId id_A, geometry::GeometryId id_B, double default_value,
+    std::string_view body_A_name, std::string_view body_B_name,
+    const geometry::SceneGraphInspector<T>& inspector) {
+  return GetDissipationTimeConstant(id_A, default_value, inspector,
+                                    body_A_name) +
+         GetDissipationTimeConstant(id_B, default_value, inspector,
+                                    body_B_name);
+}
+
+template <typename T>
+double GetCombinedDynamicCoulombFriction(
+    geometry::GeometryId id_A, geometry::GeometryId id_B,
+    const geometry::SceneGraphInspector<T>& inspector) {
+  const auto& mu_A = GetCoulombFriction(id_A, inspector);
+  const auto& mu_B = GetCoulombFriction(id_B, inspector);
+  return CalcContactFrictionFromSurfaceProperties(mu_A, mu_B)
+      .dynamic_friction();
+}
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    (&GetPointContactStiffness<T>, &GetDissipationTimeConstant<T>,
+     &GetCoulombFriction<T>, &GetCombinedPointContactStiffness<T>,
+     &GetCombinedDissipationTimeConstant<T>,
+     &GetCombinedDynamicCoulombFriction<T>))
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/contact_properties.h
+++ b/multibody/plant/contact_properties.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity_properties.h"
+#include "drake/geometry/scene_graph_inspector.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+/* Returns the point contact stiffness stored in group
+ geometry::internal::kMaterialGroup with property
+ geometry::internal::kPointStiffness for the specified geometry.
+ If the stiffness property is absent, it returns the supplied default value.
+ @pre id is a valid GeometryId in the inspector that has proximity properties.
+ @pre default_value >= 0. */
+template <typename T>
+T GetPointContactStiffness(geometry::GeometryId id, double default_value,
+                           const geometry::SceneGraphInspector<T>& inspector);
+
+/* Returns the dissipation time constant stored in group
+ geometry::internal::kMaterialGroup with property
+ "dissipation_time_constant". If the property is absent, it returns the
+ supplied default value.
+ @throws std::exception if the dissipation time constant is negative.
+ @pre id is a valid GeometryId in the inspector that has proximity properties.
+ @pre default_value >= 0. */
+template <typename T>
+T GetDissipationTimeConstant(geometry::GeometryId id, double default_value,
+                             const geometry::SceneGraphInspector<T>& inspector,
+                             std::string_view body_name);
+
+/* Returns the Coulomb's law coefficient of friction for the geometry with the
+ given id stored by SceneGraph.
+ @pre id is a valid GeometryId in the inspector that has friction properties. */
+template <typename T>
+const CoulombFriction<double>& GetCoulombFriction(
+    geometry::GeometryId id, const geometry::SceneGraphInspector<T>& inspector);
+
+/* Returns the combined stiffnesses k₁ (of geometry A) and k₂ (of geometry B)
+ according to the rule:
+   k  = k₁⋅k₂/(k₁+k₂)
+ In other words, the combined compliance (the inverse of stiffness) is the
+ sum of the individual compliances. k₁ and k₂ are set to the given default value
+ if they are not specified in SceneGraph.
+ @pre id_A and id_B are valid GeometryIds in the inspector that have proximity
+ properties.
+ @pre default_value >= 0. */
+template <typename T>
+T GetCombinedPointContactStiffness(
+    geometry::GeometryId id_A, geometry::GeometryId id_B, double default_value,
+    const geometry::SceneGraphInspector<T>& inspector);
+
+/* Returns the combined dissipation time constant τ₁ (of geometry A) and τ₂ (of
+ geometry B) according to the rule: τ = τ₁ + τ₂. τ₁ and τ₂ are set to the given
+ default value if they are not specified in SceneGraph.
+ @pre id_A and id_B are valid GeometryIds in the inspector that have proximity
+ properties.
+ @pre default_value >= 0. */
+template <typename T>
+T GetCombinedDissipationTimeConstant(
+    geometry::GeometryId id_A, geometry::GeometryId id_B, double default_value,
+    std::string_view body_A_name, std::string_view body_B_name,
+    const geometry::SceneGraphInspector<T>& inspector);
+
+/* Returns the dynamic Coulomb's law coefficients of friction characterizing the
+ interaction by friction of the given geometry pair A and B.
+ @pre id_A and id_B are both valid GeometryIds in the inspector and their
+ corresponding geometries have the friction property. */
+template <typename T>
+double GetCombinedDynamicCoulombFriction(
+    geometry::GeometryId id_A, geometry::GeometryId id_B,
+    const geometry::SceneGraphInspector<T>& inspector);
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/deformable_driver.h
+++ b/multibody/plant/deformable_driver.h
@@ -81,6 +81,13 @@ class DeformableDriver : public ScalarConvertibleComponent<T> {
   void AppendLinearDynamicsMatrix(const systems::Context<T>& context,
                                   std::vector<MatrixX<T>>* A) const;
 
+  /* Given the configuration stored in `context`, appends discrete pairs in
+   which one of the body in contact is deformable to the given `pairs`.
+   @pre pairs != nullptr. */
+  void AppendDiscreteContactPairs(
+      const systems::Context<T>& context,
+      std::vector<DiscreteContactPair<T>>* pairs) const;
+
  private:
   friend class DeformableDriverTest;
   friend class DeformableDriverContactTest;

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -143,6 +143,13 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   systems::CacheEntry& DeclareCacheEntry(std::string description,
                                          systems::ValueProducer,
                                          std::set<systems::DependencyTicket>);
+
+  double default_contact_stiffness() const;
+  double default_contact_dissipation() const;
+
+  const std::unordered_map<geometry::GeometryId, BodyIndex>&
+  geometry_id_to_body_index() const;
+
   /* @} */
 
  protected:
@@ -213,12 +220,6 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   //  geometries.
   const std::vector<std::vector<geometry::GeometryId>>& collision_geometries()
       const;
-
-  double default_contact_stiffness() const;
-  double default_contact_dissipation() const;
-
-  const std::unordered_map<geometry::GeometryId, BodyIndex>&
-  geometry_id_to_body_index() const;
 
   const std::vector<internal::CouplerConstraintSpecs<T>>&
   coupler_constraints_specs() const;

--- a/multibody/plant/test/contact_properties_test.cc
+++ b/multibody/plant/test/contact_properties_test.cc
@@ -1,0 +1,139 @@
+#include "drake/multibody/plant/contact_properties.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/scene_graph.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace {
+
+using geometry::FrameId;
+using geometry::GeometryFrame;
+using geometry::GeometryId;
+using geometry::GeometryInstance;
+using geometry::SceneGraph;
+using geometry::SceneGraphInspector;
+using geometry::SourceId;
+using geometry::Sphere;
+using math::RigidTransformd;
+using std::make_unique;
+using std::move;
+using std::unique_ptr;
+
+const CoulombFriction<double> kMuA(1.0, 1.0);
+const CoulombFriction<double> kMuB(2.0, 2.0);
+const CoulombFriction<double> kMuC(3.0, 3.0);
+const CoulombFriction<double> kMuD(4.0, 4.0);
+constexpr double kKA = 1e4;
+constexpr double kKC = 2e4;
+constexpr double kKDefault = 3e4;
+constexpr double kTauA = 0.1;
+constexpr double kTauB = 0.2;
+constexpr double kTauD = -0.2;
+constexpr double kTauDefault = 0.3;
+
+class ContactPropertiesTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    const SourceId s_id = scene_graph_.RegisterSource("source");
+    const FrameId f_id =
+        scene_graph_.RegisterFrame(s_id, GeometryFrame("frame"));
+    unique_ptr<GeometryInstance> geometry_A =
+        MakeGeometryInstance("A", kMuA, kKA, kTauA);
+    unique_ptr<GeometryInstance> geometry_B =
+        MakeGeometryInstance("B", kMuB, std::nullopt, kTauB);
+    unique_ptr<GeometryInstance> geometry_C =
+        MakeGeometryInstance("C", kMuC, kKC, std::nullopt);
+    unique_ptr<GeometryInstance> geometry_D =
+        MakeGeometryInstance("D", kMuD, std::nullopt, kTauD);
+
+    g_A_ = scene_graph_.RegisterGeometry(s_id, f_id, move(geometry_A));
+    g_B_ = scene_graph_.RegisterGeometry(s_id, f_id, move(geometry_B));
+    g_C_ = scene_graph_.RegisterGeometry(s_id, f_id, move(geometry_C));
+    g_D_ = scene_graph_.RegisterGeometry(s_id, f_id, move(geometry_D));
+  }
+
+  GeometryId g_A_;  // Has mu, k, tau.
+  GeometryId g_B_;  // Has mu, tau.
+  GeometryId g_C_;  // Has mu, k.
+  GeometryId g_D_;  // Has mu, invalid tau.
+
+  const SceneGraphInspector<double>& inspector() const {
+    return scene_graph_.model_inspector();
+  }
+
+  unique_ptr<GeometryInstance> MakeGeometryInstance(
+      const std::string& name, const CoulombFriction<double>& mu,
+      const std::optional<double>& k, const std::optional<double>& tau) {
+    auto sphere = make_unique<Sphere>(1.0);
+    auto result =
+        make_unique<GeometryInstance>(RigidTransformd(), move(sphere), name);
+    geometry::ProximityProperties props;
+    geometry::AddContactMaterial({}, k, mu, &props);
+    if (tau.has_value()) {
+      props.AddProperty(geometry::internal::kMaterialGroup,
+                        geometry::internal::kRelaxationTime, *tau);
+    }
+    result->set_proximity_properties(move(props));
+    return result;
+  }
+
+ private:
+  SceneGraph<double> scene_graph_{};
+};
+
+TEST_F(ContactPropertiesTest, GetPointContactStiffness) {
+  EXPECT_EQ(GetPointContactStiffness(g_A_, kKDefault, inspector()), kKA);
+  EXPECT_EQ(GetPointContactStiffness(g_B_, kKDefault, inspector()), kKDefault);
+  EXPECT_EQ(GetPointContactStiffness(g_C_, kKDefault, inspector()), kKC);
+}
+
+TEST_F(ContactPropertiesTest, GetDissipationTimeConstant) {
+  EXPECT_EQ(GetDissipationTimeConstant(g_A_, kTauDefault, inspector(), "A"),
+            kTauA);
+  EXPECT_EQ(GetDissipationTimeConstant(g_C_, kTauDefault, inspector(), "C"),
+            kTauDefault);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      GetDissipationTimeConstant(g_D_, kTauDefault, inspector(), "D"),
+      ".*relaxation_time = -0.2.*D.*");
+}
+
+TEST_F(ContactPropertiesTest, GetCoulombFriction) {
+  EXPECT_EQ(GetCoulombFriction(g_A_, inspector()), kMuA);
+}
+
+TEST_F(ContactPropertiesTest, GetCombinedPointContactStiffness) {
+  EXPECT_EQ(
+      GetCombinedPointContactStiffness(g_A_, g_C_, kKDefault, inspector()),
+      kKA * kKC / (kKA + kKC));
+  EXPECT_EQ(
+      GetCombinedPointContactStiffness(g_A_, g_B_, kKDefault, inspector()),
+      kKA * kKDefault / (kKA + kKDefault));
+}
+
+TEST_F(ContactPropertiesTest, GetCombinedDissipationTimeConstant) {
+  EXPECT_EQ(GetCombinedDissipationTimeConstant(g_A_, g_B_, kTauDefault, "A",
+                                               "B", inspector()),
+            kTauA + kTauB);
+  EXPECT_EQ(GetCombinedDissipationTimeConstant(g_A_, g_C_, kTauDefault, "A",
+                                               "C", inspector()),
+            kTauA + kTauDefault);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      GetCombinedDissipationTimeConstant(g_A_, g_D_, kTauDefault, "A", "D",
+                                         inspector()),
+      ".*relaxation_time = -0.2.*D.*");
+}
+
+TEST_F(ContactPropertiesTest, GetCombinedDynamicCoulombFriction) {
+  EXPECT_EQ(
+      GetCombinedDynamicCoulombFriction(g_A_, g_D_, inspector()),
+      CalcContactFrictionFromSurfaceProperties(kMuA, kMuD).dynamic_friction());
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
In support of discrete contact pair calculation, move the logic of getting and combining point contact stiffness, dissipation time scale, and coulomb friction coefficient out from CompliantContactManager into free functions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18029)
<!-- Reviewable:end -->
