### PR TITLE
[workspace] Update qdldl to latest release 0.1.6

### DIFF
--- a/tools/workspace/osqp/repository.bzl
+++ b/tools/workspace/osqp/repository.bzl
@@ -7,7 +7,7 @@ def osqp_repository(
         mirrors = None):
     github_archive(
         name = name,
-        repository = "oxfordcontrol/osqp",
+        repository = "osqp/osqp",
         # When updating this commit, see drake/tools/workspace/qdldl/README.md.
         commit = "v0.6.2",
         sha256 = "d973c33c3164caa381ed7387375347a46f7522523350a4e51989479b9d3b59c7",  # noqa

--- a/tools/workspace/qdldl/README.md
+++ b/tools/workspace/qdldl/README.md
@@ -6,13 +6,13 @@ tends to use stale copies of QDLDL and we can't really be expected to stick
 with those old versions just for the sake of SCS.)
 
 For example, if Drake pinned OSQP to commit = "v0.4.1" then look at
-https://github.com/oxfordcontrol/osqp/tree/v0.4.1/lin_sys/direct/qdldl
+https://github.com/osqp/osqp/tree/v0.4.1/lin_sys/direct/qdldl
 which shows that OSQP 0.4.1 prefers a pin of 7ab0fca for QDLDL.
 
-Looking at https://github.com/oxfordcontrol/qdldl/commit/7ab0fca we
-see that it was approximately the 0.1.3 release.  (The actual v0.1.3
-release tag on QDLDL is on the merge commit of 7ab0fca onto master.)
-So, Drake should ideally pin QDLDL commit = "v0.1.3".
+Looking at https://github.com/osqp/qdldl/commit/7ab0fca we see that it was
+approximately the 0.1.3 release.  (The actual v0.1.3 release tag on QDLDL is on
+the merge commit of 7ab0fca onto master.)  So, Drake should ideally pin QDLDL
+commit = "v0.1.3".
 
 Given the potential interactions of QDLDL, OSQP, and SCS it may not be possible
 to keep all of the versions aligned perfectly.  When in doubt, prefer to use

--- a/tools/workspace/qdldl/package.BUILD.bazel
+++ b/tools/workspace/qdldl/package.BUILD.bazel
@@ -15,22 +15,38 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-# Generates osqp_configure.h based on the defines= we want in Drake.
 cmake_configure_file(
-    name = "configure_file",
+    name = "configure_file_types",
     src = "configure/qdldl_types.h.in",
     out = "include/qdldl_types.h",
+    # https://github.com/osqp/qdldl/blob/v0.1.6/README.md#custom-types-for-integer-floats-and-booleans
     defines = [
         "QDLDL_BOOL_TYPE=unsigned char",
         # Keep the `int` type sync'd with the @osqp and @scs build.
         # See drake/tools/workspace/qdldl/README.md.
         "QDLDL_INT_TYPE=int",
+        "QDLDL_LONG=0",
         # Keep the `double` type sync'd with the @osqp and @scs build.
         # See drake/tools/workspace/qdldl/README.md.
         "QDLDL_FLOAT_TYPE=double",
+        "QDLDL_FLOAT=0",
         # Match this to QDLDL_INT_TYPE above.
         "QDLDL_INT_TYPE_MAX=INT_MAX",
     ],
+    strict = True,
+    visibility = ["//visibility:private"],
+)
+
+cmake_configure_file(
+    name = "configure_file_version",
+    src = "configure/qdldl_version.h.in",
+    out = "include/qdldl_version.h",
+    defines = [
+        "QDLDL_VERSION_MAJOR=0",
+        "QDLDL_VERSION_MINOR=0",
+        "QDLDL_VERSION_PATCH=0",
+    ],
+    strict = True,
     visibility = ["//visibility:private"],
 )
 
@@ -38,7 +54,8 @@ cc_library(
     name = "qdldl",
     hdrs = [
         "include/qdldl.h",
-        "include/qdldl_types.h",
+        ":include/qdldl_types.h",
+        ":include/qdldl_version.h",
     ],
     srcs = [
         "src/qdldl.c",

--- a/tools/workspace/qdldl/repository.bzl
+++ b/tools/workspace/qdldl/repository.bzl
@@ -7,10 +7,10 @@ def qdldl_repository(
         mirrors = None):
     github_archive(
         name = name,
-        repository = "oxfordcontrol/qdldl",
+        repository = "osqp/qdldl",
         # When updating this commit, see drake/tools/workspace/qdldl/README.md.
-        commit = "v0.1.5",
-        sha256 = "2868b0e61b7424174e9adef3cb87478329f8ab2075211ef28fe477f29e0e5c99",  # noqa
+        commit = "v0.1.6",
+        sha256 = "aeb1b2d76849c13e9803760a4c2e26194bf80dcc9614ae25ca6bcc404dc70d65",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
Even though the README advises not to upgrade qdldl past osqp's pin of qdldl (currently near 0.1.5), the [changes from 0.1.5 to 0.1.6](https://github.com/osqp/qdldl/compare/v0.1.5...v0.1.6) are only to the build system (and CI) so we might as well take them now to make any future feature-rich upgrades easier.

Adjust github paths to match relocated qdldl and osqp repositories.

Opt-in to strict mode for cmake configure variables.

Closes #17506.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18034)
<!-- Reviewable:end -->
