### PR TITLE
[workspace] Ignore old ignition tags when checking for a new_release

### DIFF
--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -65,8 +65,8 @@ _IGNORED_REPOSITORIES = [
 # (This can be used to pin to a given major or major.minor release series.)
 _OVERLOOK_RELEASE_REPOSITORIES = {
     "github3_py_internal": r"^(\d+.)",
-    "gz_math_internal": "",
-    "gz_utils_internal": "",
+    "gz_math_internal": "^(gz)",
+    "gz_utils_internal": "^(gz)",
     "intel_realsense_ros_internal": r"^(\d+\.\d+\.)",
     "petsc": r"^(v)",
     "pycodestyle": "",


### PR DESCRIPTION
Somehow, the GitHub "newest first" iterator on the tags of a moved repository list the _old_ repo's tags first (from newest to oldest) followed by the _new_ repo's tags (from newest to oldest).  So, we need to filter the `gz` repositories' tags to start with `gz` in order to skip over the old tags.

I've manually tested with this PR that demoting our `gz-math` pin to the prior patch version (7.0.1) causes the tool to find 7.0.2, but running with 7.0.2 says "no upgrade required".

Closes #18033.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18036)
<!-- Reviewable:end -->
