### PR TITLE
[multibody] Add DoGetOnePosition and DoGetOneVelocity to ScrewJoint

### DIFF
--- a/multibody/tree/screw_joint.h
+++ b/multibody/tree/screw_joint.h
@@ -131,7 +131,7 @@ class ScrewJoint final : public Joint<T> {
   /// @param[in] context The context of the model this joint belongs to.
   /// @retval theta The angle of `this` joint stored in the `context`. See class
   ///               documentation for details.
-  T get_rotation(const systems::Context<T>& context) const {
+  const T& get_rotation(const systems::Context<T>& context) const {
     return get_mobilizer()->get_angle(context);
   }
 
@@ -152,8 +152,7 @@ class ScrewJoint final : public Joint<T> {
   /// @param[in] context The context of the model this joint belongs to.
   /// @retval vz The translational velocity of `this` joint as stored in the
   ///            `context`.
-  T get_translational_velocity(
-      const systems::Context<T>& context) const {
+  T get_translational_velocity(const systems::Context<T>& context) const {
     return get_mobilizer()->get_translation_rate(context);
   }
 
@@ -177,7 +176,7 @@ class ScrewJoint final : public Joint<T> {
   /// @param[in] context The context of the model this joint belongs to.
   /// @retval theta_dot The rate of change of `this` joint's angle θ as
   ///                   stored in the `context`.
-  T get_angular_velocity(const systems::Context<T>& context) const {
+  const T& get_angular_velocity(const systems::Context<T>& context) const {
     return get_mobilizer()->get_angular_rate(context);
   }
 
@@ -199,7 +198,7 @@ class ScrewJoint final : public Joint<T> {
 
   /// Gets the default position for `this` joint.
   /// @retval z The default position of `this` joint.
-  T get_default_translation() const {
+  double get_default_translation() const {
     return internal::get_screw_translation_from_rotation(
         this->default_positions()[0], screw_pitch());
   }
@@ -295,6 +294,14 @@ class ScrewJoint final : public Joint<T> {
     if (this->has_implementation()) {
       get_mutable_mobilizer()->set_default_position(default_positions);
     }
+  }
+
+  const T& DoGetOnePosition(const systems::Context<T>& context) const override {
+    return get_rotation(context);
+  }
+
+  const T& DoGetOneVelocity(const systems::Context<T>& context) const override {
+    return get_angular_velocity(context);
   }
 
   // Joint<T> overrides:

--- a/multibody/tree/screw_mobilizer.cc
+++ b/multibody/tree/screw_mobilizer.cc
@@ -31,8 +31,7 @@ double ScrewMobilizer<T>::screw_pitch() const {
 }
 
 template <typename T>
-T ScrewMobilizer<T>::get_translation(
-    const systems::Context<T>& context) const {
+T ScrewMobilizer<T>::get_translation(const systems::Context<T>& context) const {
   auto q = this->get_positions(context);
   DRAKE_ASSERT(q.size() == kNq);
   return get_screw_translation_from_rotation(q[0], screw_pitch_);
@@ -53,11 +52,11 @@ const ScrewMobilizer<T>& ScrewMobilizer<T>::set_translation(
 }
 
 template <typename T>
-T ScrewMobilizer<T>::get_angle(
+const T& ScrewMobilizer<T>::get_angle(
     const systems::Context<T>& context) const {
   auto q = this->get_positions(context);
   DRAKE_ASSERT(q.size() == kNq);
-  return q[0];
+  return q.coeffRef(0);
 }
 
 template <typename T>
@@ -92,11 +91,11 @@ const ScrewMobilizer<T>& ScrewMobilizer<T>::set_translation_rate(
 }
 
 template <typename T>
-T ScrewMobilizer<T>::get_angular_rate(
+const T& ScrewMobilizer<T>::get_angular_rate(
     const systems::Context<T>& context) const {
   auto v = this->get_velocities(context);
   DRAKE_ASSERT(v.size() == kNv);
-  return v[0];
+  return v.coeffRef(0);
 }
 
 template <typename T>

--- a/multibody/tree/screw_mobilizer.h
+++ b/multibody/tree/screw_mobilizer.h
@@ -48,17 +48,16 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
                           revolute joint, i.e. producing zero translation for
                           any value of the generalized coordinate. */
   ScrewMobilizer(const Frame<T>& inboard_frame_F,
-                 const Frame<T>& outboard_frame_M,
-                 double screw_pitch)
-      : MobilizerBase(inboard_frame_F, outboard_frame_M)
-      , screw_pitch_(screw_pitch) {}
+                 const Frame<T>& outboard_frame_M, double screw_pitch)
+      : MobilizerBase(inboard_frame_F, outboard_frame_M),
+        screw_pitch_(screw_pitch) {}
 
   // Overloads to define the suffix names for the position and velocity
   // elements.
   std::string position_suffix(int position_index_in_mobilizer) const final;
   std::string velocity_suffix(int velocity_index_in_mobilizer) const final;
 
-  bool can_rotate() const final    { return true; }
+  bool can_rotate() const final { return true; }
   bool can_translate() const final { return true; }
 
   /* @returns the screw pitch, which is used to relate rotational
@@ -83,16 +82,15 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
    @returns A constant reference to `this` mobilizer.
    @throws std::exception if the screw_pitch is very near zero and
            |translation| > kEpsilon. */
-  const ScrewMobilizer<T>& set_translation(
-      systems::Context<T>* context,
-      const T& translation) const;
+  const ScrewMobilizer<T>& set_translation(systems::Context<T>* context,
+                                           const T& translation) const;
 
   /* Retrieves from `context` the angle θ which describes the orientation for
    `this` mobilizer as documented in this class's documentation.
 
    @param[in] context The context of the model this mobilizer belongs to.
    @returns The angle θ of the mobilizer. */
-  T get_angle(const systems::Context<T>& context) const;
+  const T& get_angle(const systems::Context<T>& context) const;
 
   /* Sets in `context` the orientation for `this` mobilizer to the angle θ
    provided by the input argument `angle`.
@@ -101,7 +99,7 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
    @param[in] angle The desired angle in radians.
    @returns a constant reference to `this` mobilizer. */
   const ScrewMobilizer<T>& set_angle(systems::Context<T>* context,
-                                      const T& angle) const;
+                                     const T& angle) const;
 
   /* Retrieves from `context` the rate of change, in meters per second, of
    `this` mobilizer's translation (see get_translation()).
@@ -120,15 +118,14 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
    @returns A constant reference to `this` mobilizer.
    @throws std::exception if the screw_pitch is very near zero and
            |vz| > kEpsilon. */
-  const ScrewMobilizer<T>& set_translation_rate(
-      systems::Context<T>* context,
-      const T& vz) const;
+  const ScrewMobilizer<T>& set_translation_rate(systems::Context<T>* context,
+                                                const T& vz) const;
 
   /* Retrieves from `context` the rate of change, in radians per second, of
    `this` mobilizer's angle (see get_angle()).
    @param[in] context The context of the model this mobilizer belongs to.
    @returns The rate of change of `this` mobilizer's angle. */
-  T get_angular_rate(const systems::Context<T>& context) const;
+  const T& get_angular_rate(const systems::Context<T>& context) const;
 
   /* Sets in `context` the rate of change, in radians per second, of `this`
    mobilizer's angle (see angle()) to `theta_dot`.
@@ -137,7 +134,7 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
                         in radians per second.
    @returns A constant reference to `this` mobilizer. */
   const ScrewMobilizer<T>& set_angular_rate(systems::Context<T>* context,
-                                             const T& theta_dot) const;
+                                            const T& theta_dot) const;
 
   /* Computes the across-mobilizer transform `X_FM(q)` between the inboard
    frame F and the outboard frame M as a function of the configuration q stored
@@ -227,21 +224,20 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
   const double screw_pitch_;
 };
 
-  /* `get_screw_translation_from_rotation`,
-   `get_screw_rotation_from_translation` are used for position, velocity,
-   and acceleration conversions.  All of these are governed by
-   the same relation, depended on the `screw_pitch` of a screw mobilizer. */
+/* `get_screw_translation_from_rotation`,
+ `get_screw_rotation_from_translation` are used for position, velocity,
+ and acceleration conversions.  All of these are governed by
+ the same relation, depended on the `screw_pitch` of a screw mobilizer. */
 template <typename T>
 inline T get_screw_translation_from_rotation(const T& theta,
                                              double screw_pitch) {
-  const T revolution_amount{theta / (2 * M_PI)};
+  T revolution_amount{theta / (2 * M_PI)};
   return screw_pitch * revolution_amount;
 }
 
 template <typename T>
-inline T get_screw_rotation_from_translation(const T& z,
-                                             double screw_pitch) {
-  const T revolution_amount{z / screw_pitch};
+inline T get_screw_rotation_from_translation(const T& z, double screw_pitch) {
+  T revolution_amount{z / screw_pitch};
   return revolution_amount * 2 * M_PI;
 }
 

--- a/multibody/tree/test/screw_joint_test.cc
+++ b/multibody/tree/test/screw_joint_test.cc
@@ -121,12 +121,14 @@ TEST_F(ScrewJointTest, ContextDependentAccess) {
   EXPECT_EQ(joint_->get_translation(*context_), translation1);
   joint_->set_rotation(context_.get(), angle1);
   EXPECT_EQ(joint_->get_rotation(*context_), angle1);
+  EXPECT_EQ(joint_->GetOnePosition(*context_), angle1);
 
   // Velocity access:
   joint_->set_translational_velocity(context_.get(), translation1);
   EXPECT_EQ(joint_->get_translational_velocity(*context_), translation1);
   joint_->set_angular_velocity(context_.get(), angle1);
   EXPECT_EQ(joint_->get_angular_velocity(*context_), angle1);
+  EXPECT_EQ(joint_->GetOneVelocity(*context_), angle1);
 
   // Joint locking.
   joint_->Lock(context_.get());


### PR DESCRIPTION
Fixes a bug when simulating a screw joint caused by screw joint being a single dof joint but not having these methods implemented.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18039)
<!-- Reviewable:end -->
