### PR TITLE
[bindings/optimization] Fix binding for solver_options in GraphOfConvexSetsOptions

### DIFF
--- a/bindings/pydrake/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry_py_optimization.cc
@@ -361,6 +361,17 @@ void DefineGeometryOptimization(py::module m) {
             cls_doc.flow_tolerance.doc)
         .def_readwrite("rounding_seed",
             &GraphOfConvexSetsOptions::rounding_seed, cls_doc.rounding_seed.doc)
+        .def_property("solver_options",
+            py::cpp_function(
+                [](GraphOfConvexSetsOptions& self) {
+                  return &(self.solver_options);
+                },
+                py_rvp::reference_internal),
+            py::cpp_function([](GraphOfConvexSetsOptions& self,
+                                 solvers::SolverOptions solver_options) {
+              self.solver_options = std::move(solver_options);
+            }),
+            cls_doc.solver_options.doc)
         .def("__repr__", [](const GraphOfConvexSetsOptions& self) {
           return py::str(
               "GraphOfConvexSetsOptions("
@@ -381,8 +392,6 @@ void DefineGeometryOptimization(py::module m) {
 
     DefReadWriteKeepAlive(&gcs_options, "solver",
         &GraphOfConvexSetsOptions::solver, cls_doc.solver.doc);
-    DefReadWriteKeepAlive(&gcs_options, "solver_options",
-        &GraphOfConvexSetsOptions::solver_options, cls_doc.solver_options.doc);
   }
 
   // GraphOfConvexSets

--- a/bindings/pydrake/test/geometry_optimization_test.py
+++ b/bindings/pydrake/test/geometry_optimization_test.py
@@ -421,6 +421,9 @@ class TestGeometryOptimization(unittest.TestCase):
         options.rounding_seed = 1
         options.solver = ClpSolver()
         options.solver_options = SolverOptions()
+        options.solver_options.SetOption(ClpSolver.id(), "scaling", 2)
+        self.assertIn("scaling",
+                      options.solver_options.GetOptions(ClpSolver.id()))
         self.assertIn("convex_relaxation", repr(options))
 
         spp = mut.GraphOfConvexSets()


### PR DESCRIPTION
Previous getter for solver_options returned a copy, preventing the user from setting individual options directly. These bindings fix the problem and add a test to confirm behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18040)
<!-- Reviewable:end -->
