### PR TITLE
[geometry/optimization] Fix multiple Vertex costs bug

### DIFF
--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -123,6 +123,7 @@ drake_cc_googletest(
     deps = [
         ":graph_of_convex_sets",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
         "//solvers:choose_best_solver",
         "//solvers:clp_solver",

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -37,6 +37,7 @@ using solvers::LinearEqualityConstraint;
 using solvers::LInfNormCost;
 using solvers::MathematicalProgram;
 using solvers::MathematicalProgramResult;
+using solvers::MatrixXDecisionVariable;
 using solvers::PerspectiveQuadraticCost;
 using solvers::QuadraticCost;
 using solvers::SolutionResult;
@@ -643,7 +644,7 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
 
   std::map<VertexId, std::vector<Edge*>> incoming_edges;
   std::map<VertexId, std::vector<Edge*>> outgoing_edges;
-  std::map<VertexId, VectorXDecisionVariable> vertex_edge_ell;
+  std::map<VertexId, MatrixXDecisionVariable> vertex_edge_ell;
   std::vector<Edge*> excluded_edges;
 
   std::map<EdgeId, Variable> relaxed_phi;

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/geometry/optimization/hyperellipsoid.h"
@@ -484,6 +485,12 @@ TEST_F(ThreePoints, LinearCost5) {
   source_->AddCost(b);
   DRAKE_EXPECT_THROWS_MESSAGE(g_.SolveShortestPath(*source_, *target_, options),
                               "Constant costs must be non-negative.*");
+}
+
+TEST_F(ThreePoints, MultipleVertexCosts) {
+  source_->AddCost(1.0);
+  source_->AddCost(1.0);
+  DRAKE_EXPECT_NO_THROW(g_.SolveShortestPath(*source_, *target_, options));
 }
 
 TEST_F(ThreePoints, QuadraticCost) {


### PR DESCRIPTION
Prior to this fix adding more than one cost to the same vertex would cause the solve to fail.  Added test to confirm fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18043)
<!-- Reviewable:end -->
