### PR TITLE
[multibody] DeformableDriver computes ContactPairKinematics

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -822,6 +822,15 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "deformable_driver_contact_kinematics_test",
+    deps = [
+        ":multibody_plant_core",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//systems/framework:diagram_builder",
+    ],
+)
+
+drake_cc_googletest(
     name = "deformable_driver_multiplexer_test",
     deps = [
         ":multibody_plant_core",

--- a/multibody/plant/compliant_contact_manager.h
+++ b/multibody/plant/compliant_contact_manager.h
@@ -45,15 +45,17 @@ struct AccelerationsDueToExternalForcesCache {
 // This class implements the interface given by DiscreteUpdateManager so that
 // contact computations can be consumed by MultibodyPlant.
 //
-// In particular, this manager sets up a contact problem where each of the
-// bodies in the MultibodyPlant model is compliant without introducing state.
-// Supported models include point contact with a linear model of compliance, see
+// In particular, this manager sets up a contact problem where each rigid body
+// in the MultibodyPlant model is compliant without introducing state. Supported
+// models include point contact with a linear model of compliance, see
 // GetPointContactStiffness() and the hydroelastic contact model, see @ref
 // mbp_hydroelastic_materials_properties in MultibodyPlant's Doxygen
-// documentation.
-// Dissipation is modeled using a linear model. For point contact, given the
-// penetration distance x and its time derivative ẋ, the normal contact force
-// (in Newtons) is modeled as:
+// documentation. Dynamics of deformable bodies (if any exists) are calculated
+// in DeformableDriver. Deformable body contacts are modeled as near-rigid point
+// contacts where compliance is added as a means of stabilization without
+// introducing additional states (i.e. the penetration distance x and its time
+// derivative ẋ are not states). Dissipation is modeled using a linear model.
+// For point contact, the normal contact force (in Newtons) is modeled as:
 //   fₙ = k⋅(x + τ⋅ẋ)₊
 // where k is the point contact stiffness, see GetPointContactStiffness(), τ is
 // the dissipation timescale, and ()₊ corresponds to the "positive part"

--- a/multibody/plant/deformable_model.h
+++ b/multibody/plant/deformable_model.h
@@ -102,10 +102,20 @@ class DeformableModel final : public multibody::internal::PhysicalModel<T> {
    deformable bodies. */
   DeformableBodyId GetBodyId(DeformableBodyIndex index) const;
 
+  /* Returns the DeformableBodyIndex of the body with the given id.
+   @throws std::exception if MultibodyPlant::Finalize() has not been called yet
+   or if no body with the given `id` has been registered. */
+  DeformableBodyIndex GetBodyIndex(DeformableBodyId id) const;
+
   /* Returns the GeometryId of the geometry associated with the body with the
    given `id`.
    @throws std::exception if no body with the given `id` has been registered. */
   geometry::GeometryId GetGeometryId(DeformableBodyId id) const;
+
+  /* Returns the DeformableBodyId associated with the given `geometry_id`.
+   @throws std::exception if the given `geometry_id` does not correspond to a
+   deformable body registered with this model. */
+  DeformableBodyId GetBodyId(geometry::GeometryId geometry_id) const;
 
   /* Returns the output port of the vertex positions for all registered
    deformable bodies.
@@ -160,9 +170,12 @@ class DeformableModel final : public multibody::internal::PhysicalModel<T> {
       discrete_state_indexes_;
   std::unordered_map<DeformableBodyId, geometry::GeometryId>
       body_id_to_geometry_id_;
+  std::unordered_map<geometry::GeometryId, DeformableBodyId>
+      geometry_id_to_body_id_;
   std::unordered_map<DeformableBodyId, std::unique_ptr<fem::FemModel<T>>>
       fem_models_;
   std::vector<DeformableBodyId> body_ids_;
+  std::unordered_map<DeformableBodyId, DeformableBodyIndex> body_id_to_index_;
   systems::OutputPortIndex vertex_positions_port_index_;
 };
 

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -20,6 +20,25 @@ systems::CacheEntry& DiscreteUpdateManager<T>::DeclareCacheEntry(
 }
 
 template <typename T>
+double DiscreteUpdateManager<T>::default_contact_stiffness() const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<
+      T>::default_contact_stiffness(plant());
+}
+
+template <typename T>
+double DiscreteUpdateManager<T>::default_contact_dissipation() const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<
+      T>::default_contact_dissipation(plant());
+}
+
+template <typename T>
+const std::unordered_map<geometry::GeometryId, BodyIndex>&
+DiscreteUpdateManager<T>::geometry_id_to_body_index() const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<
+      T>::geometry_id_to_body_index(*plant_);
+}
+
+template <typename T>
 std::unique_ptr<DiscreteUpdateManager<double>>
 DiscreteUpdateManager<T>::CloneToDouble() const {
   throw std::logic_error(
@@ -123,25 +142,6 @@ const std::vector<std::vector<geometry::GeometryId>>&
 DiscreteUpdateManager<T>::collision_geometries() const {
   return MultibodyPlantDiscreteUpdateManagerAttorney<T>::collision_geometries(
       plant());
-}
-
-template <typename T>
-double DiscreteUpdateManager<T>::default_contact_stiffness() const {
-  return MultibodyPlantDiscreteUpdateManagerAttorney<
-      T>::default_contact_stiffness(plant());
-}
-
-template <typename T>
-double DiscreteUpdateManager<T>::default_contact_dissipation() const {
-  return MultibodyPlantDiscreteUpdateManagerAttorney<
-      T>::default_contact_dissipation(plant());
-}
-
-template <typename T>
-const std::unordered_map<geometry::GeometryId, BodyIndex>&
-DiscreteUpdateManager<T>::geometry_id_to_body_index() const {
-  return MultibodyPlantDiscreteUpdateManagerAttorney<
-      T>::geometry_id_to_body_index(*plant_);
 }
 
 template <typename T>

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -140,6 +140,8 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   // N.B. Keep the spelling and order of declarations here identical to the
   // MultibodyPlantDiscreteUpdateManagerAttorney spelling and order of same.
 
+  const MultibodyTree<T>& internal_tree() const;
+
   systems::CacheEntry& DeclareCacheEntry(std::string description,
                                          systems::ValueProducer,
                                          std::set<systems::DependencyTicket>);
@@ -192,8 +194,6 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
 
   // N.B. Keep the spelling and order of declarations here identical to the
   // MultibodyPlantDiscreteUpdateManagerAttorney spelling and order of same.
-
-  const MultibodyTree<T>& internal_tree() const;
 
   const contact_solvers::internal::ContactSolverResults<T>&
   EvalContactSolverResults(const systems::Context<T>& context) const;

--- a/multibody/plant/test/deformable_driver_contact_kinematics_test.cc
+++ b/multibody/plant/test/deformable_driver_contact_kinematics_test.cc
@@ -1,0 +1,246 @@
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity_properties.h"
+#include "drake/math/roll_pitch_yaw.h"
+#include "drake/multibody/plant/compliant_contact_manager.h"
+#include "drake/multibody/plant/deformable_driver.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+using drake::geometry::GeometryId;
+using drake::geometry::GeometryInstance;
+using drake::geometry::SceneGraph;
+using drake::geometry::Sphere;
+using drake::geometry::internal::DeformableContact;
+using drake::geometry::internal::DeformableContactSurface;
+using drake::math::RigidTransformd;
+using drake::math::RollPitchYawd;
+using drake::systems::Context;
+using drake::systems::DiscreteStateIndex;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+using std::make_unique;
+using std::move;
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+/* Friend class used to provide access to a selection of private functions in
+ CompliantContactManager for testing purposes. */
+class CompliantContactManagerTester {
+ public:
+  static const DeformableDriver<double>* deformable_driver(
+      const CompliantContactManager<double>& manager) {
+    return manager.deformable_driver_.get();
+  }
+};
+
+/* Test fixure to test DeformableDriver::AppendContactKinematics.
+ In particular, this fixture sets up a deformable octahedron centered at world
+ origin with 8 elements, 7 vertices, and 21 dofs. A rigid rectangle is added so
+ that its top face intersects the bottom half of the deformable octahedron. The
+ rigid rectangle can be configured to be dynamic or static to provide coverage
+ for the cases with one and two Jacobian blocks. We compare rotation matrix from
+ world to the contact frame and contact velocities to expected values. */
+class DeformableDriverContactKinematicsTest : public ::testing::Test {
+ protected:
+  void SetUp() {}
+
+  /* Sets up the scene described in the class documentation. The rigid body is
+   dynamic if `dynamic_rigid_body` is true. Otherwise, a collision geometry
+   bound to the world body with the same shape is added. The pose/configuration
+   of the bodies are set so that the contact normal in an arbitrarily chosen F
+   frame is (0, 0, 1). Velocities of the body are set so that the contact
+   velocity in the contact frame is (0, 0, 1). */
+  void MakeScene(bool dynamic_rigid_body) {
+    systems::DiagramBuilder<double> builder;
+    constexpr double kDt = 0.01;
+    std::tie(plant_, scene_graph_) = AddMultibodyPlantSceneGraph(&builder, kDt);
+    auto deformable_model = make_unique<DeformableModel<double>>(plant_);
+    deformable_body_id_ =
+        RegisterDeformableOctahedron(deformable_model.get(), "deformable");
+    model_ = deformable_model.get();
+    plant_->AddPhysicalModel(move(deformable_model));
+
+    /* Define proximity properties for all rigid geometries. */
+    geometry::ProximityProperties rigid_proximity_props;
+    geometry::AddContactMaterial({}, {}, CoulombFriction<double>(1.0, 1.0),
+                                 &rigid_proximity_props);
+    // TODO(xuchenhan-tri): Modify this when resolution hint is no longer used
+    //  as the trigger for contact with deformable bodies.
+    rigid_proximity_props.AddProperty(geometry::internal::kHydroGroup,
+                                      geometry::internal::kRezHint, 1.0);
+
+    const RigidTransformd X_FB(Vector3<double>(0, 0, -0.75));
+    const RigidTransformd X_WB = X_WF_ * X_FB;
+    if (dynamic_rigid_body) {
+      /* Register a dynamic rigid body intersecting with the bottom half of the
+       deformable octahedron. */
+      const RigidBody<double>& rigid_body =
+          plant_->AddRigidBody("rigid_body", SpatialInertia<double>());
+      rigid_geometry_id_ = plant_->RegisterCollisionGeometry(
+          rigid_body, X_WB, geometry::Box(10, 10, 1),
+          "dynamic_collision_geometry", rigid_proximity_props);
+      rigid_body_index_ = rigid_body.index();
+    } else {
+      /* Register a rigid static collision geometry intersecting with the bottom
+       half of the deformable octahedron. */
+      rigid_geometry_id_ = plant_->RegisterCollisionGeometry(
+          plant_->world_body(), X_WB, geometry::Box(10, 10, 1),
+          "static_collision_geometry", rigid_proximity_props);
+    }
+
+    plant_->set_discrete_contact_solver(DiscreteContactSolver::kSap);
+    plant_->Finalize();
+    auto contact_manager = make_unique<CompliantContactManager<double>>();
+    manager_ = contact_manager.get();
+    plant_->SetDiscreteUpdateManager(move(contact_manager));
+    driver_ = CompliantContactManagerTester::deformable_driver(*manager_);
+
+    builder.Connect(model_->vertex_positions_port(),
+                    scene_graph_->get_source_configuration_port(
+                        plant_->get_source_id().value()));
+    diagram_ = builder.Build();
+    context_ = diagram_->CreateDefaultContext();
+
+    /* Set up the deformable body velocity and the rigid body velocity so that
+     the contact velocities in the contact frame are (0, 0, 1). */
+    if (dynamic_rigid_body) {
+      SetVelocity(deformable_body_id_, Vector3d(0, 0, -0.5));
+      Context<double>& mutable_plant_context =
+          plant_->GetMyMutableContextFromRoot(context_.get());
+      plant_->SetFreeBodySpatialVelocity(
+          &mutable_plant_context, plant_->get_body(rigid_body_index_),
+          SpatialVelocity<double>(Vector3d(0, 0, 0), Vector3d(0, 0, 0.5)));
+    } else {
+      SetVelocity(deformable_body_id_, Vector3d(0, 0, -1.0));
+    }
+  }
+
+  /* Verifies contact kinematics data are as expected.
+   @param[in] dynamic_rigid_body  True if a rigid body is registered in the
+   setup (instead of a static body with a collision geometry). */
+  void ValidateContactKinematics(bool dynamic_rigid_body) {
+    /* Each discrete contact pair should create a contact kinematics pair. */
+    const Context<double>& plant_context =
+        plant_->GetMyContextFromRoot(*context_);
+    std::vector<ContactPairKinematics<double>> contact_kinematics;
+    driver_->AppendContactKinematics(plant_context, &contact_kinematics);
+    const int num_contact_points = GetNumContactPoints(plant_context);
+    ASSERT_EQ(contact_kinematics.size(), num_contact_points);
+
+    /* The contact surfaces are parallel to the xy-plane in frame F and the
+     contact normal points from the deformable body into the rigid body. */
+    const Vector3d nhat_F(0, 0, -1);
+    const Vector3d nhat_W = X_WF_.rotation() * nhat_F;
+    constexpr int kZAxis = 2;
+    const math::RotationMatrixd expected_R_WC =
+        math::RotationMatrixd::MakeFromOneUnitVector(nhat_W, kZAxis);
+    const Vector3d expected_vc(0, 0, -1);
+    for (int i = 0; i < num_contact_points; ++i) {
+      const ContactPairKinematics<double>& contact_kinematic =
+          contact_kinematics[i];
+      EXPECT_LT(contact_kinematic.phi, 0.0);
+      EXPECT_TRUE(contact_kinematic.R_WC.IsNearlyEqualTo(
+          expected_R_WC, std::numeric_limits<double>::epsilon()));
+      if (dynamic_rigid_body) {
+        ASSERT_EQ(contact_kinematic.jacobian.size(), 2);
+        const Matrix3X<double> J0 = contact_kinematic.jacobian[0].J;
+        const VectorXd v0 = driver_->EvalParticipatingVelocities(plant_context);
+        ASSERT_EQ(v0.size(), J0.cols());
+        const Matrix3X<double> J1 = contact_kinematic.jacobian[1].J;
+        Vector6<double> v1;
+        v1 << 0, 0, 0, 0, 0, 0.5;
+        ASSERT_EQ(v1.size(), J1.cols());
+        EXPECT_TRUE(CompareMatrices(J0 * v0 + J1 * v1, expected_vc));
+      } else {
+        ASSERT_EQ(contact_kinematic.jacobian.size(), 1);
+        const Matrix3X<double> J0 = contact_kinematic.jacobian[0].J;
+        const VectorXd v0 = driver_->EvalParticipatingVelocities(plant_context);
+        ASSERT_EQ(v0.size(), J0.cols());
+        EXPECT_TRUE(CompareMatrices(J0 * v0, expected_vc));
+      }
+    }
+  }
+
+  const math::RigidTransformd X_WF_{RollPitchYawd(1, 2, 3), Vector3d(4, 5, 6)};
+  MultibodyPlant<double>* plant_{nullptr};
+  SceneGraph<double>* scene_graph_{nullptr};
+  std::unique_ptr<systems::Diagram<double>> diagram_;
+  DeformableModel<double>* model_{nullptr};
+  const CompliantContactManager<double>* manager_{nullptr};
+  const DeformableDriver<double>* driver_{nullptr};
+  std::unique_ptr<Context<double>> context_;
+  DeformableBodyId deformable_body_id_;
+  BodyIndex rigid_body_index_;
+  GeometryId rigid_geometry_id_;
+
+ private:
+  DeformableBodyId RegisterDeformableOctahedron(DeformableModel<double>* model,
+                                                std::string name) {
+    auto geometry = make_unique<GeometryInstance>(
+        X_WF_, make_unique<Sphere>(1.0), move(name));
+    geometry::ProximityProperties props;
+    geometry::AddContactMaterial({}, {}, CoulombFriction<double>(1.0, 1.0),
+                                 &props);
+    geometry->set_proximity_properties(move(props));
+    fem::DeformableBodyConfig<double> body_config;
+    /* Make the resolution hint large enough so that we get an octahedron. */
+    constexpr double kRezHint = 10.0;
+    DeformableBodyId body_id =
+        model->RegisterDeformableBody(move(geometry), body_config, kRezHint);
+    return body_id;
+  }
+
+  /* Sets all vertices of the deformable body to have the given velocity in
+   world frame. */
+  void SetVelocity(DeformableBodyId id, const Vector3d& v_WB) {
+    Context<double>& plant_context =
+        plant_->GetMyMutableContextFromRoot(context_.get());
+    const DiscreteStateIndex state_index = model_->GetDiscreteStateIndex(id);
+    VectorXd state = plant_context.get_discrete_state(state_index).value();
+    DRAKE_DEMAND(state.size() % 3 == 0);  // q, v, a all the same length.
+    const int num_dofs = state.size() / 3;
+    DRAKE_DEMAND(num_dofs % 3 == 0);  // Each vertex needs a 3-vector.
+    const int num_vertices = num_dofs / 3;
+    VectorXd velocities(num_dofs);
+    for (int i = 0; i < num_vertices; ++i) {
+      velocities.segment<3>(3 * i) = v_WB;
+    }
+    state.segment(num_dofs, num_dofs) = velocities;
+    plant_context.SetDiscreteState(state_index, state);
+  }
+
+  /* Gets the total number of contact points between deformable bodies and rigid
+   bodies. */
+  int GetNumContactPoints(const Context<double>& plant_context) const {
+    const DeformableContact<double>& contact_data =
+        driver_->EvalDeformableContact(plant_context);
+    int num_contact_points = 0;
+    for (const DeformableContactSurface<double>& surface :
+         contact_data.contact_surfaces()) {
+      num_contact_points += surface.num_contact_points();
+    }
+    return num_contact_points;
+  }
+};
+
+namespace {
+
+TEST_F(DeformableDriverContactKinematicsTest,
+       AppendContactKinematicsStaticRigid) {
+  MakeScene(false);
+  ValidateContactKinematics(false);
+}
+
+TEST_F(DeformableDriverContactKinematicsTest,
+       AppendContactKinematicsDynamicRigid) {
+  MakeScene(true);
+  ValidateContactKinematics(true);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/deformable_model_test.cc
+++ b/multibody/plant/test/deformable_model_test.cc
@@ -127,13 +127,28 @@ TEST_F(DeformableModelTest, GetBodyIdFromBodyIndex) {
       deformable_model_ptr_->GetBodyId(DeformableBodyIndex(0)),
       ".*GetBodyId.*before system resources have been declared.*");
   plant_->Finalize();
-  EXPECT_EQ(deformable_model_ptr_->GetBodyId(DeformableBodyIndex(0)),
-            body_id);
+  EXPECT_EQ(deformable_model_ptr_->GetBodyId(DeformableBodyIndex(0)), body_id);
   // Throws for invalid indexes.
   EXPECT_THROW(deformable_model_ptr_->GetBodyId(DeformableBodyIndex(1)),
                std::exception);
   EXPECT_THROW(deformable_model_ptr_->GetBodyId(DeformableBodyIndex()),
                std::exception);
+}
+
+TEST_F(DeformableModelTest, GetBodyIndex) {
+  constexpr double kRezHint = 0.5;
+  const DeformableBodyId body_id = RegisterSphere(kRezHint);
+  /* Throws for pre-finalize call. */
+  DRAKE_EXPECT_THROWS_MESSAGE(deformable_model_ptr_->GetBodyIndex(body_id),
+                              ".*before system resources.*declared.*");
+  plant_->Finalize();
+  EXPECT_EQ(deformable_model_ptr_->GetBodyIndex(body_id),
+            DeformableBodyIndex(0));
+  /* Throws for unregistered body id. */
+  const DeformableBodyId fake_body_id = DeformableBodyId::get_new_id();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      deformable_model_ptr_->GetBodyIndex(fake_body_id),
+      fmt::format(".*No.*id.*{}.*registered.*", fake_body_id));
 }
 
 TEST_F(DeformableModelTest, GetGeometryId) {
@@ -145,16 +160,32 @@ TEST_F(DeformableModelTest, GetGeometryId) {
       scene_graph_->model_inspector();
   EXPECT_TRUE(inspector.IsDeformableGeometry(geometry_id));
   DeformableBodyId fake_id = DeformableBodyId::get_new_id();
+  DRAKE_EXPECT_THROWS_MESSAGE(deformable_model_ptr_->GetGeometryId(fake_id),
+                              "GetGeometryId.*No deformable body with id.*");
+}
+
+TEST_F(DeformableModelTest, GetBodyIdFromGeometryId) {
+  constexpr double kRezHint = 0.5;
+  const DeformableBodyId body_id = RegisterSphere(kRezHint);
+  geometry::GeometryId geometry_id =
+      deformable_model_ptr_->GetGeometryId(body_id);
+  /* Test pre-finalize call. */
+  EXPECT_EQ(deformable_model_ptr_->GetBodyId(geometry_id), body_id);
+  plant_->Finalize();
+  /* Test post-finalize call. */
+  EXPECT_EQ(deformable_model_ptr_->GetBodyId(geometry_id), body_id);
+  /* Throws for unregistered geometry id. */
+  const geometry::GeometryId fake_geometry_id =
+      geometry::GeometryId::get_new_id();
   DRAKE_EXPECT_THROWS_MESSAGE(
-      deformable_model_ptr_->GetGeometryId(fake_id),
-      "GetGeometryId.*No deformable body with id.*");
+      deformable_model_ptr_->GetBodyId(fake_geometry_id),
+      ".*GeometryId.*not.*registered.*");
 }
 
 TEST_F(DeformableModelTest, ToPhysicalModelPointerVariant) {
   PhysicalModelPointerVariant<double> variant =
       deformable_model_ptr_->ToPhysicalModelPointerVariant();
-  EXPECT_TRUE(
-      std::holds_alternative<const DeformableModel<double>*>(variant));
+  EXPECT_TRUE(std::holds_alternative<const DeformableModel<double>*>(variant));
 }
 
 TEST_F(DeformableModelTest, VertexPositionsOutputPort) {


### PR DESCRIPTION
In support of that
- Make vertex permutation a cache entry to avoid thrashing the results.
- Provide conversions from body id to body index and from geometry id to body id.
- Move related functions in DiscreteUpdateManager from protected to public.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18047)
<!-- Reviewable:end -->
