### PR TITLE
Add System::EvalUniquePeriodicDiscreteUpdate()

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -325,13 +325,17 @@ void DoScalarDependentDefinitions(py::module m) {
       .def("SetDiscreteState",
           overload_cast_explicit<void, const Eigen::Ref<const VectorX<T>>&>(
               &Context<T>::SetDiscreteState),
-          py::arg("xd"), doc.Context.SetDiscreteState.doc_1args)
+          py::arg("xd"), doc.Context.SetDiscreteState.doc_single_group)
       .def("SetDiscreteState",
           overload_cast_explicit<void, int,
               const Eigen::Ref<const VectorX<T>>&>(
               &Context<T>::SetDiscreteState),
           py::arg("group_index"), py::arg("xd"),
-          doc.Context.SetDiscreteState.doc_2args)
+          doc.Context.SetDiscreteState.doc_select_one_group)
+      .def("SetDiscreteState",
+          overload_cast_explicit<void, const DiscreteValues<T>&>(
+              &Context<T>::SetDiscreteState),
+          py::arg("xd"), doc.Context.SetDiscreteState.doc_set_everything)
       .def(
           "SetAbstractState",
           [](py::object self, int index, py::object value) {

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -493,6 +493,11 @@ struct Impl {
         .def("GetUniquePeriodicDiscreteUpdateAttribute",
             &System<T>::GetUniquePeriodicDiscreteUpdateAttribute,
             doc.System.GetUniquePeriodicDiscreteUpdateAttribute.doc)
+        .def("EvalUniquePeriodicDiscreteUpdate",
+            &System<T>::EvalUniquePeriodicDiscreteUpdate, py_rvp::reference,
+            // Keep alive, ownership: `return` keeps `context` alive.
+            py::keep_alive<0, 2>(), py::arg("context"),
+            doc.System.EvalUniquePeriodicDiscreteUpdate.doc)
         .def(
             "IsDifferenceEquationSystem",
             [](const System<T>& self) {

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -234,6 +234,8 @@ class TestGeneral(unittest.TestCase):
         context.SetDiscreteState(group_index=0, xd=3 * x)
         np.testing.assert_equal(
             context.get_discrete_state_vector().CopyToVector(), 3 * x)
+        # Just verify that the third overload is present.
+        context.SetDiscreteState(context.get_discrete_state())
 
         def check_abstract_value_zero(context, expected_value):
             # Check through Context, State, and AbstractValues APIs.
@@ -296,6 +298,11 @@ class TestGeneral(unittest.TestCase):
         is_diff_eq, period = system1.IsDifferenceEquationSystem()
         self.assertTrue(is_diff_eq)
         self.assertEqual(period, periodic_data.period_sec())
+        context = system1.CreateDefaultContext()
+        system1.get_input_port(0).FixValue(context, 0.0)
+        updated_discrete = system1.EvalUniquePeriodicDiscreteUpdate(context)
+        self.assertEqual(updated_discrete.num_groups(),
+                         context.get_discrete_state().num_groups())
 
         # Simple continuous-time system.
         system2 = LinearSystem(A=[1], B=[1], C=[1], D=[1], time_period=0.0)

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -366,7 +366,8 @@ class Context : public ContextBase {
   discrete state. Sends out of date notifications for all
   discrete-state-dependent computations. Use the other signature for this
   method if you have multiple discrete state groups.
-  @pre There is exactly one discrete state group. */
+  @pre There is exactly one discrete state group.
+  @pydrake_mkdoc_identifier{single_group} */
   void SetDiscreteState(const Eigen::Ref<const VectorX<T>>& xd) {
     if (num_discrete_state_groups() != 1) {
       throw std::logic_error(fmt::format(
@@ -384,11 +385,22 @@ class Context : public ContextBase {
   state group. Sends out of date notifications for all computations that
   depend on this discrete state group.
   @pre `group_index` identifies an existing group.
-  @note Currently notifies dependents of _all_ groups. */
+  @note Currently notifies dependents of _all_ groups.
+  @pydrake_mkdoc_identifier{select_one_group} */
   void SetDiscreteState(int group_index,
                         const Eigen::Ref<const VectorX<T>>& xd) {
     get_mutable_discrete_state(DiscreteStateIndex(group_index))
         .SetFromVector(xd);
+  }
+
+  /** Sets all the discrete state variables in this %Context from a
+  compatible DiscreteValues object.
+
+  @throws std::exception unless the number of groups and size of each group
+  of `xd` matches those in this %Context.
+  @pydrake_mkdoc_identifier{set_everything} */
+  void SetDiscreteState(const DiscreteValues<T>& xd) {
+    get_mutable_discrete_state().SetFrom(xd);
   }
 
   // TODO(sherm1) Invalidate only dependents of this one abstract variable.

--- a/systems/framework/context_base.cc
+++ b/systems/framework/context_base.cc
@@ -300,6 +300,11 @@ void ContextBase::CreateBuiltInTrackers() {
   auto& pnc_tracker = graph.CreateNewDependencyTracker(
       DependencyTicket(internal::kPncTicket), "pnc");
   unused(pnc_tracker);
+
+  auto& xd_unique_periodic_update_tracker = graph.CreateNewDependencyTracker(
+      DependencyTicket(internal::kXdUniquePeriodicUpdateTicket),
+      "xd_unique_periodic_update");
+  unused(xd_unique_periodic_update_tracker);
 }
 
 void ContextBase::BuildTrackerPointerMap(

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -450,6 +451,11 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   std::map<PeriodicEventData, std::vector<const Event<T>*>,
            PeriodicEventDataComparator>
   DoMapPeriodicEventsByTiming(const Context<T>& context) const final;
+
+  void DoFindUniquePeriodicDiscreteUpdatesOrThrow(
+      const char* api_name, const Context<T>& context,
+      std::optional<PeriodicEventData>* timing,
+      EventCollection<DiscreteUpdateEvent<T>>* events) const final;
 
   void DoGetPeriodicEvents(
       const Context<T>& context,

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -286,15 +286,15 @@ enum BuiltInTicketNumbers {
   kKinematicsTicket     = 17,  // Configuration plus velocity-affecting values.
   kLastSourceTicket     = kKinematicsTicket,  // (Used in testing.)
 
-  // The rest of these are pre-defined computations with associated cache
-  // entries.
+  // These are pre-defined computations with associated cache entries.
   kXcdotTicket          = 18,  // d/dt xc = {qdot, vdot, zdot}.
   kPeTicket             = 19,  // Potential energy.
   kKeTicket             = 20,  // Kinetic energy.
   kPcTicket             = 21,  // Conservative power.
   kPncTicket            = 22,  // Non-conservative power.
+  kXdUniquePeriodicUpdateTicket = 23,  // Updated discrete (numeric) variables.
 
-  kNextAvailableTicket  = kPncTicket+1
+  kNextAvailableTicket  = kXdUniquePeriodicUpdateTicket+1
 };
 
 // Specifies the prerequisite of an output port. It will always be either

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -1906,6 +1906,11 @@ class LeafSystem : public System<T> {
            PeriodicEventDataComparator>
   DoMapPeriodicEventsByTiming(const Context<T>& context) const final;
 
+  void DoFindUniquePeriodicDiscreteUpdatesOrThrow(
+      const char* api_name, const Context<T>& context,
+      std::optional<PeriodicEventData>* timing,
+      EventCollection<DiscreteUpdateEvent<T>>* events) const final;
+
   // Calls DoPublish.
   // Assumes @param events is an instance of LeafEventCollection, throws
   // std::bad_cast otherwise.

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -535,6 +535,13 @@ class SystemBase : public internal::SystemMessageInterface {
     return DependencyTicket(internal::kPncTicket);
   }
 
+  /** (Internal use only) Returns a ticket for the cache entry that holds the
+  unique periodic discrete update computation.
+  @see System::EvalUniquePeriodicDiscreteUpdate() */
+  static DependencyTicket xd_unique_periodic_update_ticket() {
+    return DependencyTicket(internal::kXdUniquePeriodicUpdateTicket);
+  }
+
   /** (Internal use only) Returns a ticket indicating dependence on the output
   port indicated by `index`. No user-definable quantities in a system can
   meaningfully depend on that system's own output ports.

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -881,7 +881,19 @@ TEST_F(LeafContextTest, TestStateSettingSugar) {
       context_.SetDiscreteState(xd0_new),
       ".*SetDiscreteState.*: expected exactly 1.*but there were 2 groups.*");
 
-  // Change to just one group, then it should work.
+  // Check the signature that takes a DiscreteValues argument.
+  // Make a compatible DiscreteValues object.
+  std::unique_ptr<DiscreteValues<double>> xd_clone =
+      context_.get_discrete_state().Clone();
+  const Vector1d val0{-4.};
+  const Eigen::Vector2d val1{5., 6.};
+  xd_clone->get_mutable_value(0) = val0;
+  xd_clone->get_mutable_value(1) = val1;
+  context_.SetDiscreteState(*xd_clone);
+  EXPECT_EQ(context_.get_discrete_state(0).get_value(), val0);
+  EXPECT_EQ(context_.get_discrete_state(1).get_value(), val1);
+
+  // Change to just one group, then the single-argument signature works.
   std::vector<std::unique_ptr<BasicVector<double>>> xd;
   const Eigen::VectorXd xd_init = Eigen::Vector3d{1., 2., 3.};
   const Eigen::Vector3d xd_new{4., 5., 6.};

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -133,6 +133,13 @@ class TestSystemBase : public System<T> {
   void DoCalcTimeDerivatives(const Context<T>& context,
                              ContinuousState<T>* derivatives) const override {}
 
+  void DoFindUniquePeriodicDiscreteUpdatesOrThrow(
+      const char* api_name, const Context<T>& context,
+      std::optional<PeriodicEventData>* timing,
+      EventCollection<DiscreteUpdateEvent<T>>* events) const override {
+    ADD_FAILURE() << "A test called a method that was expected to be unused.";
+  }
+
   void DispatchPublishHandler(
       const Context<T>& context,
       const EventCollection<PublishEvent<T>>& event_info) const override {


### PR DESCRIPTION
Per request in #10909, adds a new System API: 
```c++
    const DiscreteValues& System::EvalUniquePeriodicDiscreteUpdate(const Context&);
```
that determines what the effect would be if this System's periodic discrete state updates were triggered now (_without_ actually updating the discrete state). It requires that there is a single unique timing for all the periodic discrete updates in the entire Diagram and throws an error if not. The result is returned as a reference to a preallocated cache entry in the Context,
automatically invalidated if anything changes.

In addition, this PR adds a third overload of Context's `SetDiscreteState()` that accepts an entire DiscreteValues object, in case a caller wants to actually update the discrete state from the value returned by the above API.
```c++
    void Context::SetDiscreteState(const DiscreteValues&);
```
Resolves #10909.
PR #18106 (in progress) will use this to clean up some of the call sites it identified.

### Implementation (for reviewers)
- Allocates a new discrete-state-sized cache entry in every Context.
- Adds a protected method to System called `FindUniquePeriodicDiscreteUpdatesOrThrow()` with Diagram and LeafSystem `final` implementations that together find all the like-timed periodic discrete updates or issue proper error messages if there are multiple timings.
- `EvalUniquePeriodicDiscreteUpdate()`'s calculation function invokes `FindUniquePeriodicDiscreteUpdatesOrThrow()` to find the relevant events, sets the cache entry to the current values of discrete state, and then uses the existing `CalcDiscreteVariableUpdate()` function to trigger the handlers to update the cached value.
- Adds `SetDiscreteState()` overload as described above.
- Adds unit tests for the two new public APIs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18048)
<!-- Reviewable:end -->
