### PR TITLE
[multibody] remove joint locking from reaction forces test

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -779,6 +779,7 @@ drake_cc_googletest(
     name = "joint_locking_test",
     deps = [
         ":plant",
+        "//systems/analysis:simulator",
     ],
 )
 

--- a/multibody/plant/test/joint_locking_test.cc
+++ b/multibody/plant/test/joint_locking_test.cc
@@ -1,3 +1,4 @@
+#include <limits>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -5,16 +6,21 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "drake/math/rigid_transform.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/multibody/tree/rigid_body.h"
 #include "drake/multibody/tree/spatial_inertia.h"
+#include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/context.h"
 
 namespace drake {
 
 using Eigen::Vector3d;
+using math::RigidTransform;
+using math::RigidTransformd;
 using systems::Context;
+using systems::Simulator;
 
 namespace multibody {
 
@@ -29,13 +35,19 @@ class MultibodyPlantTester {
 };
 
 namespace {
+
+const double kTimestep = 0.01;
+// Allow 6 bits of error.
+const double kEps = (1 << 6) * std::numeric_limits<double>::epsilon();
+const int kNumTimesteps = 100;
+
 // Set up a plant with 2 trees, one tree having a single floating body, the
 // second tree a serial chain of two bodies attached to each other and world by
 // revolute joints.
 class JointLockingTest : public ::testing::TestWithParam<int> {
  public:
   void SetUp() {
-    plant_ = std::make_unique<MultibodyPlant<double>>(0.1);
+    plant_ = std::make_unique<MultibodyPlant<double>>(kTimestep);
 
     // Each permutation of adding trees (children of world body) to the plant.
     switch (GetParam()) {
@@ -165,6 +177,124 @@ TEST_P(JointLockingTest, JointLockingIndicesTest) {
 
 INSTANTIATE_TEST_SUITE_P(IndexPermutations, JointLockingTest,
                          ::testing::Values(0, 1));
+
+// Create a plant with a XZ-planar double pendulum where the masses are
+// concentrated at the lower ends of the two links. The 0-configuration has the
+// upper arm sticking out horizontally in the x direction and the longer lower
+// arm oriented in the (0.1, 0, 0.1) direction from the end of the upper arm. If
+// the `weld_elbow` parameter is true, then the revolute joint between bodies
+// `upper_arm` and `lower_arm` is replaced with a fixed weld at the
+// 0-configuration.
+std::unique_ptr<MultibodyPlant<double>> MakeDoublePendulumPlant(
+    bool weld_elbow) {
+  std::unique_ptr<MultibodyPlant<double>> plant;
+  plant = std::make_unique<MultibodyPlant<double>>(kTimestep);
+
+  const RigidBody<double>& body1 =
+      plant->AddRigidBody("upper_arm", SpatialInertia<double>::MakeUnitary());
+  const RigidBody<double>& body2 =
+      plant->AddRigidBody("lower_arm", SpatialInertia<double>::MakeUnitary());
+
+  plant->AddJoint<RevoluteJoint>("shoulder", plant->world_body(), {}, body1,
+                                 RigidTransformd(Vector3d(0.1, 0, 0)),
+                                 Vector3d::UnitY());
+
+  if (weld_elbow) {
+    plant->WeldFrames(body1.body_frame(), body2.body_frame(),
+                      RigidTransformd(Vector3d(-0.1, 0, -0.1)));
+  } else {
+    plant->AddJoint<RevoluteJoint>("elbow", body1, {}, body2,
+                                   RigidTransformd(Vector3d(0.1, 0, 0.1)),
+                                   Vector3d::UnitY());
+  }
+  plant->Finalize();
+  return plant;
+}
+
+// To verify that the physical behavior of a locked joint is identical to a weld
+// joint, we construct two plants. Each plant consists of a double pendulum with
+// the shoulder welded to the world. The elbow joint of `plant_welded` is a
+// WeldJoint fixed at the 0-configuration. The elbow joint of `plant_locked` is
+// a revolute joint that has been locked at the 0-configuration. We verify that
+// the generalized accelerations,
+GTEST_TEST(JointLockingTest, AccelerationTest) {
+  auto plant_welded = MakeDoublePendulumPlant(true);
+  auto plant_locked = MakeDoublePendulumPlant(false);
+
+  std::unique_ptr<systems::Context<double>> context_welded =
+      plant_welded->CreateDefaultContext();
+  std::unique_ptr<systems::Context<double>> context_locked =
+      plant_locked->CreateDefaultContext();
+
+  // Lock the elbow in the unwelded plant
+  plant_locked->GetJointByName<RevoluteJoint>("elbow").Lock(
+      context_locked.get());
+
+  // Sanity check
+  ASSERT_EQ(plant_welded->num_velocities(), 1);
+  ASSERT_EQ(plant_locked->num_velocities(), 2);
+
+  auto simulator_welded = std::make_unique<Simulator<double>>(
+      *plant_welded, std::move(context_welded));
+  auto simulator_locked = std::make_unique<Simulator<double>>(
+      *plant_locked, std::move(context_locked));
+  simulator_welded->Initialize();
+  simulator_locked->Initialize();
+
+  // Simulate for kNumTimesteps and verify acceleration, velocity, and positions
+  // at each iteration.
+  for (int i = 1; i <= kNumTimesteps; ++i) {
+    simulator_welded->AdvanceTo(i * kTimestep);
+    simulator_locked->AdvanceTo(i * kTimestep);
+
+    const auto& welded_context =
+        plant_welded->GetMyContextFromRoot(simulator_welded->get_context());
+    const auto& locked_context =
+        plant_locked->GetMyContextFromRoot(simulator_locked->get_context());
+
+    int shoulder_index_welded =
+        plant_welded->GetJointByName<RevoluteJoint>("shoulder")
+            .velocity_start();
+    int shoulder_index_locked =
+        plant_locked->GetJointByName<RevoluteJoint>("shoulder")
+            .velocity_start();
+
+    // The welded plant has only one dof which corresponds to dof 0 of the
+    // locked plant. Their accelerations should match.
+    const auto welded_accelerations =
+        plant_welded->get_generalized_acceleration_output_port().Eval(
+            welded_context);
+    const auto locked_accelerations =
+        plant_locked->get_generalized_acceleration_output_port().Eval(
+            locked_context);
+    EXPECT_NEAR(welded_accelerations[shoulder_index_welded],
+                locked_accelerations[shoulder_index_locked], kEps);
+    // The welded dof should have 0 acceleration.
+    int elbow_index_locked =
+        plant_locked->GetJointByName<RevoluteJoint>("elbow").velocity_start();
+    EXPECT_EQ(locked_accelerations[elbow_index_locked], 0);
+
+    // Check that the velocities and positions of corresponding dofs match.
+    const auto welded_positions_and_velocities =
+        plant_welded->GetPositionsAndVelocities(welded_context);
+    const auto locked_positions_and_velocities =
+        plant_locked->GetPositionsAndVelocities(locked_context);
+
+    EXPECT_NEAR(welded_positions_and_velocities[shoulder_index_welded],
+                locked_positions_and_velocities[shoulder_index_locked], kEps);
+    EXPECT_NEAR(welded_positions_and_velocities[plant_welded->num_positions() +
+                                                shoulder_index_welded],
+                locked_positions_and_velocities[plant_locked->num_positions() +
+                                                shoulder_index_locked],
+                kEps);
+
+    // Position and velocity of the locked joint should be identically 0.
+    EXPECT_EQ(locked_positions_and_velocities[elbow_index_locked], 0);
+    EXPECT_EQ(locked_positions_and_velocities[plant_locked->num_positions() +
+                                              elbow_index_locked],
+              0);
+  }
+}
 }  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/test/joint_locking_test.cc
+++ b/multibody/plant/test/joint_locking_test.cc
@@ -39,6 +39,7 @@ namespace {
 
 const double kTimestep = 0.01;
 const double kElbowPosition = 0.3;
+const double kArmLength = 0.1;
 
 // Set up a plant with 2 trees, one tree having a single floating body, the
 // second tree a serial chain of two bodies attached to each other and world by
@@ -179,8 +180,8 @@ INSTANTIATE_TEST_SUITE_P(IndexPermutations, JointLockingTest,
 
 // Create a plant with a XZ-planar double pendulum where the masses are
 // concentrated at the lower ends of the two links. The 0-configuration has the
-// upper arm sticking out horizontally at (-0.1, 0, 0) and the longer lower
-// arm placed at (-0.1, 0, 0.0) relative to the upper arm's frame. If the
+// upper arm sticking out horizontally at (-kArmLength, 0, 0) and the lower
+// arm placed at (-kArmLength, 0, 0.0) relative to the upper arm's frame. If the
 // `weld_elbow` parameter is true, then the revolute joint between bodies
 // `upper_arm` and `lower_arm` is replaced with a fixed weld corresponding to
 // the configuration (0, kElbowPosition) in the model with two joints.
@@ -195,18 +196,18 @@ std::unique_ptr<MultibodyPlant<double>> MakeDoublePendulumPlant(
       plant->AddRigidBody("lower_arm", SpatialInertia<double>::MakeUnitary());
 
   plant->AddJoint<RevoluteJoint>("shoulder", plant->world_body(), {}, body1,
-                                 RigidTransformd(Vector3d(0.1, 0, 0)),
+                                 RigidTransformd(Vector3d(kArmLength, 0, 0)),
                                  Vector3d::UnitY());
 
   if (weld_elbow) {
-    plant->WeldFrames(body1.body_frame(), body2.body_frame(),
-                      RigidTransformd(Vector3d(-0.1 * cos(kElbowPosition),
-                                                0.0,
-                                                0.1 * sin(kElbowPosition))));
+    plant->WeldFrames(
+        body1.body_frame(), body2.body_frame(),
+        RigidTransformd(Vector3d(-kArmLength * cos(kElbowPosition), 0.0,
+                                  kArmLength * sin(kElbowPosition))));
   } else {
-    plant->AddJoint<RevoluteJoint>("elbow", body1, {}, body2,
-                                   RigidTransformd(Vector3d(0.1, 0, 0.0)),
-                                   Vector3d::UnitY());
+    plant->AddJoint<RevoluteJoint>(
+        "elbow", body1, {}, body2,
+        RigidTransformd(Vector3d(kArmLength, 0, 0.0)), Vector3d::UnitY());
   }
   plant->Finalize();
   return plant;


### PR DESCRIPTION
This PR refactors testing of joint locking by removing lock/unlock parameters from `multibody_reaction_forces_test` and adding a new test to `joint_locking_test` that verifies the physics of a locked joint matches that of a weld.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18051)
<!-- Reviewable:end -->
