### PR TITLE
[geometry/optimization] Fix depth first search failure in GraphOfConvexSets rounding

### DIFF
--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -120,6 +120,8 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "graph_of_convex_sets_test",
+    timeout = "moderate",
+    shard_count = 8,
     deps = [
         ":graph_of_convex_sets",
         "//common/test_utilities:eigen_matrix_compare",

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -920,12 +920,14 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
             candidate_edges.emplace_back(e);
           }
         }
-        // Note: This rounding strategy should not end at a node with no
-        // candidate outbound edges. If it does, the right next step would be to
-        // pop the last` path_vertex_ids` and `new_path` edge. Since no examples
-        // of this happening have been observed, we use an assertion to detect a
-        // failure instead of adding an untested conditional.
-        DRAKE_DEMAND(candidate_edges.size() > 0);
+        // If the depth first search finds itself at a node with no candidate
+        // outbound edges, backtrack to the previous node and continue the
+        // search.
+        if (candidate_edges.size() == 0) {
+          path_vertex_ids.pop_back();
+          new_path.pop_back();
+          continue;
+        }
         Eigen::VectorXd candidate_flows(candidate_edges.size());
         for (size_t ii = 0; ii < candidate_edges.size(); ++ii) {
           candidate_flows(ii) = flows[candidate_edges[ii]->id()];


### PR DESCRIPTION
Fixes a corner case that was [initially discussed](https://reviewable.io/reviews/robotlocomotion/drake/17796#-NC1MIxy3bAQXnkq0BiX) when rounding was added to GraphOfConvexSets. At the time, an example that triggered the failure case could not be constructed for unit testing.

This adds a simple test that triggers the corner case as well as the fix previously discussed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18063)
<!-- Reviewable:end -->
