### PR TITLE
[multibody] DeformableDriver uses contact solver results

### DIFF
--- a/multibody/contact_solvers/sap/sap_contact_problem.cc
+++ b/multibody/contact_solvers/sap/sap_contact_problem.cc
@@ -29,7 +29,7 @@ SapContactProblem<T>::SapContactProblem(const T& time_step,
   DRAKE_THROW_UNLESS(time_step > 0.0);
   nv_ = 0;
   for (const auto& Ac : A_) {
-    DRAKE_THROW_UNLESS(Ac.size() > 0);
+    DRAKE_THROW_UNLESS(Ac.size() >= 0);
     DRAKE_THROW_UNLESS(Ac.rows() == Ac.cols());
     nv_ += Ac.rows();
   }
@@ -43,7 +43,7 @@ void SapContactProblem<T>::Reset(std::vector<MatrixX<T>> A, VectorX<T> v_star) {
   graph_.ResetNumCliques(num_cliques());
   nv_ = 0;
   for (const auto& Ac : A_) {
-    DRAKE_THROW_UNLESS(Ac.size() > 0);
+    DRAKE_THROW_UNLESS(Ac.size() >= 0);
     DRAKE_THROW_UNLESS(Ac.rows() == Ac.cols());
     nv_ += Ac.rows();
   }
@@ -83,6 +83,12 @@ int SapContactProblem<T>::AddConstraint(std::unique_ptr<SapConstraint<T>> c) {
         "The number of columns in the constraint's "
         "Jacobian does not match the number of velocities in this problem for "
         "the second clique.");
+  }
+  if (num_velocities(c->first_clique()) == 0 ||
+      (c->num_cliques() == 2 && num_velocities(c->second_clique()) == 0)) {
+    throw std::runtime_error(
+        "Adding constraint to a clique with zero number of velocities is not "
+        "allowed.");
   }
 
   // Update graph.

--- a/multibody/contact_solvers/sap/sap_contact_problem.h
+++ b/multibody/contact_solvers/sap/sap_contact_problem.h
@@ -86,7 +86,7 @@ class SapContactProblem {
      ordering implicitly induced by A.
 
    @throws exception if time_step is not strictly positive.
-   @throws exception if the blocks in A are not square or have zero size.
+   @throws exception if the blocks in A are not square.
    @throws exception if the size of v_star is not nv = ∑A[c].rows(). */
   SapContactProblem(const T& time_step, std::vector<MatrixX<T>> A,
                     VectorX<T> v_star);
@@ -110,7 +110,7 @@ class SapContactProblem {
      Free-motion velocities, of size nv. DOFs in v_star must match the
      ordering implicitly induced by A.
 
-   @throws exception if the blocks in A are not square or have zero size.
+   @throws exception if the blocks in A are not square.
    @throws exception if the size of v_star is not nv = ∑A[c].rows(). */
   void Reset(std::vector<MatrixX<T>> A, VectorX<T> v_star);
 
@@ -125,7 +125,7 @@ class SapContactProblem {
    the range [0, num_cliques()).
    @throws exception if the number of columns of the Jacobian matrices in
    `constraint` is not consistent with the number of velocities for the cliques
-   in this problem referenced by `constraint`.
+   in this problem referenced by `constraint` or if they are both zero.
    @returns the index to the newly added constraint. */
   int AddConstraint(std::unique_ptr<SapConstraint<T>> constraint);
 

--- a/multibody/contact_solvers/sap/test/sap_contact_problem_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_contact_problem_test.cc
@@ -17,6 +17,7 @@ namespace {
 
 // Useful SPD matrices for testing. The numbers specify their size.
 // clang-format off
+const Eigen::MatrixXd S00 = Eigen::MatrixXd::Zero(0, 0);
 const Eigen::Matrix2d S22 =
     (Eigen::Matrix2d() << 2, 1,
                           1, 2).finished();
@@ -101,7 +102,7 @@ GTEST_TEST(ContactProblem, Construction) {
 // are wrong.
 GTEST_TEST(ContactProblem, AddConstraintWithWrongArguments) {
   const double time_step = 0.01;
-  const std::vector<MatrixXd> A{S22, S33, S44, S22};
+  const std::vector<MatrixXd> A{S22, S33, S44, S22, S00};
   const VectorXd v_star = VectorXd::LinSpaced(11, 1.0, 11.0);
   SapContactProblem<double> problem(time_step, A, v_star);
 
@@ -129,6 +130,11 @@ GTEST_TEST(ContactProblem, AddConstraintWithWrongArguments) {
           1 /* second_clique */, 6 /* (wrong) second_clique_nv */)),
       ".* does not match the number of velocities in this problem for "
       "the second clique.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      problem.AddConstraint(std::make_unique<TestConstraint>(
+          3 /* num_equations */, 0 /* first_clique */, 2 /* first_clique_nv */,
+          4 /* (empty) second_clique */, 0 /* second_clique_nv */)),
+      ".*Adding constraint.*zero.*velocities.*");
 }
 
 /* We test ContactProblem with the graph setup sketched below where each

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -808,6 +808,7 @@ drake_cc_googletest(
         ":multibody_plant_core",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+        "//systems/analysis:simulator",
         "//systems/framework:diagram_builder",
     ],
 )

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -552,8 +552,8 @@ void CompliantContactManager<T>::DoCalcDiscreteValues(
       context.get_discrete_state(this->multibody_state_index()).value();
   const auto q0 = x0.topRows(nq);
 
-  // Retrieve the solution velocity for the next time step.
-  const VectorX<T>& v_next = results.v_next;
+  // Retrieve the rigid velocity for the next time step.
+  const VectorX<T>& v_next = results.v_next.head(plant().num_velocities());
 
   // Update generalized positions.
   VectorX<T> qdot_next(plant().num_positions());
@@ -563,6 +563,12 @@ void CompliantContactManager<T>::DoCalcDiscreteValues(
   VectorX<T> x_next(plant().num_multibody_states());
   x_next << q_next, v_next;
   updates->set_value(this->multibody_state_index(), x_next);
+
+  if constexpr (std::is_same_v<T, double>) {
+    if (deformable_driver_ != nullptr) {
+      deformable_driver_->CalcDiscreteStates(context, updates);
+    }
+  }
 }
 
 // TODO(xuchenhan-tri): Consider a scalar converting constructor to cut down

--- a/multibody/plant/deformable_model.h
+++ b/multibody/plant/deformable_model.h
@@ -48,8 +48,7 @@ class DeformableModel final : public multibody::internal::PhysicalModel<T> {
 
   // TODO(xuchenhan-tri): Document the minimal requirement on the geometry
   //  instance. For example, it must have a friction proximity property to be
-  //  simulated with an MbP that involves contact. Also, move resolution_hint
-  //  into the properties of the instance.
+  //  simulated with an MbP that involves contact.
   // TODO(xuchenhan-tri): Consider allowing registering deformable bodies with
   //  non-world frames.
   /* Registers a deformable body in `this` DeformableModel with the given

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -146,6 +146,10 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
                                          systems::ValueProducer,
                                          std::set<systems::DependencyTicket>);
 
+  // TODO(#16955): Remove this function when the referenced issue is resolved.
+  const contact_solvers::internal::ContactSolverResults<T>&
+  EvalContactSolverResults(const systems::Context<T>& context) const;
+
   double default_contact_stiffness() const;
   double default_contact_dissipation() const;
 
@@ -194,9 +198,6 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
 
   // N.B. Keep the spelling and order of declarations here identical to the
   // MultibodyPlantDiscreteUpdateManagerAttorney spelling and order of same.
-
-  const contact_solvers::internal::ContactSolverResults<T>&
-  EvalContactSolverResults(const systems::Context<T>& context) const;
 
   const internal::ContactJacobians<T>& EvalContactJacobians(
       const systems::Context<T>& context) const;

--- a/multibody/plant/test/compliant_contact_manager_test.cc
+++ b/multibody/plant/test/compliant_contact_manager_test.cc
@@ -71,13 +71,13 @@ class SapDriverTest {
   }
 
   static void PackContactSolverResults(
-      const SapDriver<double>& driver,
+      const Context<double>& context, const SapDriver<double>& driver,
       const contact_solvers::internal::SapContactProblem<double>& problem,
       int num_contacts,
       const contact_solvers::internal::SapSolverResults<double>& sap_results,
       contact_solvers::internal::ContactSolverResults<double>*
           contact_results) {
-    driver.PackContactSolverResults(problem, num_contacts, sap_results,
+    driver.PackContactSolverResults(context, problem, num_contacts, sap_results,
                                     contact_results);
   }
 };
@@ -457,9 +457,9 @@ TEST_F(SpheresStackTest, DoCalcContactSolverResults) {
   ContactSolverResults<double> contact_results_expected;
   const auto& sap_driver =
       CompliantContactManagerTester::sap_driver(*contact_manager_);
-  SapDriverTest::PackContactSolverResults(sap_driver, sap_problem, num_contacts,
-                                          sap_results,
-                                          &contact_results_expected);
+  SapDriverTest::PackContactSolverResults(
+      *plant_context_, sap_driver, sap_problem, num_contacts, sap_results,
+      &contact_results_expected);
 
   // Verify the expected result.
   EXPECT_TRUE(CompareMatrices(contact_results.v_next,

--- a/multibody/plant/test/deformable_driver_multiplexer_test.cc
+++ b/multibody/plant/test/deformable_driver_multiplexer_test.cc
@@ -5,62 +5,46 @@
 namespace drake {
 namespace multibody {
 namespace internal {
-
-class DeformableDriverMultiplexerTest : public ::testing::Test {
- protected:
-  /* Sets `dut_` to a DeformableDriver::Multiplexer with the given sizes. */
-  void MakeMultiplexer(std::vector<int> sizes) {
-    dut_ = DeformableDriver<double>::Multiplexer(std::move(sizes));
-  }
-
-  /* Sets `dut_` to an empty DeformableDriver::Multiplexer. */
-  void MakeEmptyMultiplexer() {
-    dut_ = DeformableDriver<double>::Multiplexer();
-  }
-
-  DeformableDriver<double>::Multiplexer dut_;
-};
-
 namespace {
 
-TEST_F(DeformableDriverMultiplexerTest, Constructors) {
+GTEST_TEST(DeformableDriverMultiplexerTest, Constructors) {
   /* Valid constructions. */
-  EXPECT_NO_THROW(MakeEmptyMultiplexer());
-  EXPECT_EQ(dut_.num_vectors(), 0);
-  EXPECT_NO_THROW(MakeMultiplexer({1, 2, 3}));
-  EXPECT_EQ(dut_.num_vectors(), 3);
+  Multiplexer<double> dut;
+  EXPECT_EQ(dut.num_vectors(), 0);
+  dut = Multiplexer<double>({1, 2, 3});
+  EXPECT_EQ(dut.num_vectors(), 3);
   /* Invalid constructions. */
-  EXPECT_THROW(MakeMultiplexer({}), std::exception);
-  EXPECT_THROW(MakeMultiplexer({-1}), std::exception);
+  EXPECT_THROW(Multiplexer<double>{{}}, std::exception);
+  EXPECT_THROW(Multiplexer<double>{{-1}}, std::exception);
 }
 
-TEST_F(DeformableDriverMultiplexerTest, Multiplex) {
+GTEST_TEST(DeformableDriverMultiplexerTest, Multiplex) {
   const Eigen::Vector2d v2(0.1, 0.2);
   const Eigen::Vector3d v3(0.1, 0.2, 0.3);
   const Eigen::Vector4d v4(0.1, 0.2, 0.3, 0.4);
-  MakeMultiplexer({2, 3});
-  const VectorX<double> result = dut_.Multiplex({v2, v3});
+  Multiplexer<double> dut({2, 3});
+  const VectorX<double> result = dut.Multiplex({v2, v3});
   VectorX<double> expected_result(5);
   expected_result << v2, v3;
   EXPECT_EQ(result, expected_result);
 
-  EXPECT_THROW(dut_.Multiplex({v2}), std::exception);
-  EXPECT_THROW(dut_.Multiplex({v2, v4}), std::exception);
+  EXPECT_THROW(dut.Multiplex({v2}), std::exception);
+  EXPECT_THROW(dut.Multiplex({v2, v4}), std::exception);
 }
 
-TEST_F(DeformableDriverMultiplexerTest, Demultiplex) {
+GTEST_TEST(DeformableDriverMultiplexerTest, Demultiplex) {
   const Eigen::Vector2d v2(0.1, 0.2);
   const Eigen::Vector3d v3(0.1, 0.2, 0.3);
-  MakeMultiplexer({2, 3});
+  Multiplexer<double> dut({2, 3});
   VectorX<double> mux(5);
   mux << v2, v3;
-  EXPECT_EQ(dut_.Demultiplex(mux, 0), v2);
-  EXPECT_EQ(dut_.Demultiplex(mux, 1), v3);
+  EXPECT_EQ(dut.Demultiplex(mux, 0), v2);
+  EXPECT_EQ(dut.Demultiplex(mux, 1), v3);
 
   const Eigen::Vector4d bad_vector(0.1, 0.2, 0.3, 0.4);
-  EXPECT_THROW(dut_.Demultiplex(mux, -1), std::exception);
-  EXPECT_THROW(dut_.Demultiplex(mux, 2), std::exception);
-  EXPECT_THROW(dut_.Demultiplex(bad_vector, 0), std::exception);
+  EXPECT_THROW(dut.Demultiplex(mux, -1), std::exception);
+  EXPECT_THROW(dut.Demultiplex(mux, 2), std::exception);
+  EXPECT_THROW(dut.Demultiplex(bad_vector, 0), std::exception);
 }
 
 }  // namespace

--- a/multibody/plant/test/deformable_driver_test.cc
+++ b/multibody/plant/test/deformable_driver_test.cc
@@ -4,8 +4,10 @@
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/proximity_properties.h"
 #include "drake/multibody/plant/compliant_contact_manager.h"
 #include "drake/multibody/plant/test/compliant_contact_manager_tester.h"
+#include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
 
 using drake::geometry::GeometryId;
@@ -28,8 +30,8 @@ class DeformableDriverTest : public ::testing::Test {
   static constexpr double kDt = 0.01;
 
   void SetUp() override {
-    std::tie(plant_, scene_graph_) =
-        AddMultibodyPlantSceneGraph(&builder_, kDt);
+    systems::DiagramBuilder<double> builder;
+    std::tie(plant_, scene_graph_) = AddMultibodyPlantSceneGraph(&builder, kDt);
     auto deformable_model = make_unique<DeformableModel<double>>(plant_);
     constexpr double kRezHint = 0.5;
     body_id_ = RegisterSphere(deformable_model.get(), kRezHint);
@@ -42,15 +44,21 @@ class DeformableDriverTest : public ::testing::Test {
     manager_ = contact_manager.get();
     plant_->SetDiscreteUpdateManager(move(contact_manager));
     driver_ = CompliantContactManagerTester::deformable_driver(*manager_);
-    context_ = plant_->CreateDefaultContext();
+
+    builder.Connect(model_->vertex_positions_port(),
+                    scene_graph_->get_source_configuration_port(
+                        plant_->get_source_id().value()));
+    diagram_ = builder.Build();
+    diagram_context_ = diagram_->CreateDefaultContext();
+    plant_context_ =
+        &plant_->GetMyMutableContextFromRoot(diagram_context_.get());
   }
 
   /* Forwarding calls to private member functions in DeformableDriver with the
    same name.
    @{ */
-  const FemState<double>& EvalFemState(
-      const systems::Context<double>& context,
-      DeformableBodyIndex index) const {
+  const FemState<double>& EvalFemState(const systems::Context<double>& context,
+                                       DeformableBodyIndex index) const {
     return driver_->EvalFemState(context, index);
   }
 
@@ -67,13 +75,14 @@ class DeformableDriverTest : public ::testing::Test {
   }
   /* @} */
 
-  systems::DiagramBuilder<double> builder_;
   MultibodyPlant<double>* plant_{nullptr};
   SceneGraph<double>* scene_graph_{nullptr};
   const DeformableModel<double>* model_{nullptr};
   const CompliantContactManager<double>* manager_{nullptr};
   const DeformableDriver<double>* driver_{nullptr};
-  std::unique_ptr<Context<double>> context_{nullptr};
+  std::unique_ptr<systems::Diagram<double>> diagram_;
+  std::unique_ptr<Context<double>> diagram_context_;
+  Context<double>* plant_context_{nullptr};
   DeformableBodyId body_id_;
 
  private:
@@ -81,6 +90,10 @@ class DeformableDriverTest : public ::testing::Test {
                                   double resolution_hint) {
     auto geometry = make_unique<GeometryInstance>(
         RigidTransformd(), make_unique<Sphere>(1), "sphere");
+    geometry::ProximityProperties props;
+    geometry::AddContactMaterial({}, {}, CoulombFriction<double>(1.0, 1.0),
+                                 &props);
+    geometry->set_proximity_properties(move(props));
     fem::DeformableBodyConfig<double> body_config;
     body_config.set_youngs_modulus(1e6);
     DeformableBodyId body_id = model->RegisterDeformableBody(
@@ -109,9 +122,9 @@ TEST_F(DeformableDriverTest, FemState) {
   state_value << q, v, a;
   const systems::DiscreteStateIndex state_index =
       model_->GetDiscreteStateIndex(body_id_);
-  context_->SetDiscreteState(state_index, state_value);
+  plant_context_->SetDiscreteState(state_index, state_value);
   const FemState<double>& fem_state =
-      EvalFemState(*context_, DeformableBodyIndex(0));
+      EvalFemState(*plant_context_, DeformableBodyIndex(0));
   EXPECT_EQ(fem_state.GetPositions(), q);
   EXPECT_EQ(fem_state.GetVelocities(), v);
   EXPECT_EQ(fem_state.GetAccelerations(), a);
@@ -123,7 +136,7 @@ TEST_F(DeformableDriverTest, FreeMotionFemState) {
   const VectorX<double> v = VectorX<double>::Zero(num_dofs);
   const VectorX<double> a = VectorX<double>::Zero(num_dofs);
   const FemState<double>& free_motion_fem_state =
-      EvalFreeMotionFemState(*context_, DeformableBodyIndex(0));
+      EvalFreeMotionFemState(*plant_context_, DeformableBodyIndex(0));
   const Vector3<double> kGravity(0, 0, -9.81);
   VectorX<double> next_a = a;
   for (int dof = 0; dof < num_dofs; dof += 3) {
@@ -145,17 +158,35 @@ TEST_F(DeformableDriverTest, FreeMotionFemState) {
 
 TEST_F(DeformableDriverTest, NextFemState) {
   const FemState<double>& free_motion_fem_state =
-      EvalFreeMotionFemState(*context_, DeformableBodyIndex(0));
+      EvalFreeMotionFemState(*plant_context_, DeformableBodyIndex(0));
   const FemState<double>& next_fem_state =
-      EvalNextFemState(*context_, DeformableBodyIndex(0));
+      EvalNextFemState(*plant_context_, DeformableBodyIndex(0));
   /* The next state should be the same as the free motion state in the absence
-   * of contact or constraints. */
+   of contact or constraints. */
   EXPECT_EQ(free_motion_fem_state.GetPositions(),
             next_fem_state.GetPositions());
   EXPECT_EQ(free_motion_fem_state.GetVelocities(),
             next_fem_state.GetVelocities());
   EXPECT_EQ(free_motion_fem_state.GetAccelerations(),
             next_fem_state.GetAccelerations());
+}
+
+/* Verifies that the discrete states are updated to match the FEM states. */
+TEST_F(DeformableDriverTest, CalcDiscreteStates) {
+  systems::Simulator<double> simulator(*diagram_, move(diagram_context_));
+  simulator.Initialize();
+  simulator.AdvanceTo(3 * kDt);
+  const systems::DiscreteStateIndex state_index =
+      model_->GetDiscreteStateIndex(body_id_);
+  const VectorX<double>& discrete_state =
+      plant_context_->get_discrete_state(state_index).value();
+  const int num_dofs = model_->GetFemModel(body_id_).num_dofs();
+  const FemState<double>& fem_state =
+      EvalFemState(*plant_context_, DeformableBodyIndex(0));
+  EXPECT_EQ(discrete_state.head(num_dofs), fem_state.GetPositions());
+  EXPECT_EQ(discrete_state.segment(num_dofs, num_dofs),
+            fem_state.GetVelocities());
+  EXPECT_EQ(discrete_state.tail(num_dofs), fem_state.GetAccelerations());
 }
 
 }  // namespace

--- a/multibody/plant/test/sap_driver_test.cc
+++ b/multibody/plant/test/sap_driver_test.cc
@@ -60,13 +60,13 @@ class SapDriverTest {
   }
 
   static void PackContactSolverResults(
-      const SapDriver<double>& driver,
+      const SapDriver<double>& driver, const Context<double>& context,
       const contact_solvers::internal::SapContactProblem<double>& problem,
       int num_contacts,
       const contact_solvers::internal::SapSolverResults<double>& sap_results,
       contact_solvers::internal::ContactSolverResults<double>*
           contact_results) {
-    driver.PackContactSolverResults(problem, num_contacts, sap_results,
+    driver.PackContactSolverResults(context, problem, num_contacts, sap_results,
                                     contact_results);
   }
 };
@@ -99,13 +99,15 @@ class SpheresStackTest : public SpheresStack, public ::testing::Test {
   }
 
   void PackContactSolverResults(
+      const Context<double>& context,
       const contact_solvers::internal::SapContactProblem<double>& problem,
       int num_contacts,
       const contact_solvers::internal::SapSolverResults<double>& sap_results,
       contact_solvers::internal::ContactSolverResults<double>* contact_results)
       const {
-    SapDriverTest::PackContactSolverResults(sap_driver(), problem, num_contacts,
-                                            sap_results, contact_results);
+    SapDriverTest::PackContactSolverResults(sap_driver(), context, problem,
+                                            num_contacts, sap_results,
+                                            contact_results);
   }
 
   // The functions below provide access to private CompliantContactManager
@@ -308,8 +310,8 @@ TEST_F(SpheresStackTest, PackContactSolverResults) {
   const SapContactProblem<double>& sap_problem =
       *EvalContactProblemCache(*plant_context_).sap_problem;
   ContactSolverResults<double> contact_results;
-  PackContactSolverResults(sap_problem, num_contacts, sap_results,
-                           &contact_results);
+  PackContactSolverResults(*plant_context_, sap_problem, num_contacts,
+                           sap_results, &contact_results);
 
   // Verify against expected values.
   VectorXd gamma(3 * num_contacts);


### PR DESCRIPTION
- Add DeformableDriver::CalcDiscreteStates().
- Update DeformableDriver::CalcNextFemState() to account for contact.
- Use deformable v0, v*, and tangent matrix A in CompliantContactManager
- Move Multiplexer out of DeformableDriver.
- Add a mutable variant of Multiplexer::Demultiplex.
- Modify SapDriver::PackContactSolverResults() to account for deformable bodies.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18067)
<!-- Reviewable:end -->
