### PR TITLE
[sensors] Add lcm_bus name to CameraConfig

### DIFF
--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -267,11 +267,17 @@ PYBIND11_MODULE(sensors, m) {
     DefReprUsingSerialize(&focal_class);
     DefCopyAndDeepCopy(&focal_class);
 
-    m.def("ApplyCameraConfig", &ApplyCameraConfig, py::arg("config"),
-        py::arg("plant"), py::arg("builder"), py::arg("scene_graph"),
-        py::arg("lcm"),
+    m.def("ApplyCameraConfig",
+        py::overload_cast<const CameraConfig&, DiagramBuilder<double>*,
+            const systems::lcm::LcmBuses*,
+            const multibody::MultibodyPlant<double>*,
+            geometry::SceneGraph<double>*, drake::lcm::DrakeLcmInterface*>(
+            &ApplyCameraConfig),
+        py::arg("config"), py::arg("builder"), py::arg("lcm_buses") = nullptr,
+        py::arg("plant") = nullptr, py::arg("scene_graph") = nullptr,
+        py::arg("lcm") = nullptr,
         // Keep alive, reference: `builder` keeps `lcm` alive.
-        py::keep_alive<3, 5>(), doc.ApplyCameraConfig.doc);
+        py::keep_alive<2, 6>(), doc.ApplyCameraConfig.doc);
   }
 
   {

--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -31,6 +31,7 @@ from pydrake.systems.framework import (
     InputPort,
     OutputPort,
     )
+from pydrake.systems.lcm import LcmBuses
 
 # Shorthand aliases, to reduce verbosity.
 pt = mut.PixelType
@@ -205,6 +206,21 @@ class TestSensors(unittest.TestCase):
         mut.ApplyCameraConfig(config=config, plant=plant, builder=builder,
                               scene_graph=scene_graph, lcm=lcm)
         # Systems have been added.
+        self.assertGreater(len(builder.GetSystems()), system_count)
+
+    def test_camera_config_lcm_buses(self):
+        builder = DiagramBuilder()
+        plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
+        system_count = len(builder.GetSystems())
+
+        # We'll call the Apply function using lcm_buses= instead of lcm=.
+        lcm_buses = LcmBuses()
+        lcm_buses.Add("fancy", DrakeLcm())
+        config = mut.CameraConfig(lcm_bus="fancy")
+        mut.ApplyCameraConfig(config=config, builder=builder,
+                              lcm_buses=lcm_buses)
+
+        # Check that systems were added.
         self.assertGreater(len(builder.GetSystems()), system_count)
 
     def test_camera_info(self):

--- a/examples/hardware_sim/hardware_sim.cc
+++ b/examples/hardware_sim/hardware_sim.cc
@@ -100,10 +100,9 @@ void Simulation::Setup() {
                      lcm_buses, &builder);
 
   // Add scene cameras.
-  DrakeLcmInterface* camera_lcm = lcm_buses.Find("Cameras", "default");
   for (const auto& [yaml_name, camera] : scenario_.cameras) {
     unused(yaml_name);
-    ApplyCameraConfig(camera, &sim_plant, &builder, &scene_graph, camera_lcm);
+    ApplyCameraConfig(camera, &builder, &lcm_buses);
   }
 
   // Add visualization.

--- a/examples/hardware_sim/hardware_sim.py
+++ b/examples/hardware_sim/hardware_sim.py
@@ -132,14 +132,11 @@ def run(*, scenario):
         builder=builder)
 
     # Add scene cameras.
-    camera_lcm = lcm_buses.Find("Cameras", "default")
     for _, camera in scenario.cameras.items():
         ApplyCameraConfig(
             config=camera,
-            plant=sim_plant,
             builder=builder,
-            scene_graph=scene_graph,
-            lcm=camera_lcm)
+            lcm_buses=lcm_buses)
 
     # Add visualization.
     ApplyVisualizationConfig(scenario.visualization, builder, lcm_buses)

--- a/examples/hardware_sim/test/hardware_sim_py_test.py
+++ b/examples/hardware_sim/test/hardware_sim_py_test.py
@@ -35,7 +35,7 @@ class HardwareSimTest(unittest.TestCase):
         scenario.directives = [self.make_add_model_directive()]
         scenario.lcm_buses["extra_bus"] = DrakeLcmParams()
         scenario.model_drivers["alice"] = ZeroForceDriver()
-        # TODO(jwnimmer-tri) The scenario.cameras doesn't work yet.
+        scenario.cameras["arbitrary_camera_name"] = CameraConfig()
         scenario.visualization.publish_period = 0.125
         return scenario
 

--- a/examples/hardware_sim/test/test_scenarios.yaml
+++ b/examples/hardware_sim/test/test_scenarios.yaml
@@ -21,6 +21,7 @@ OneOfEverything:
   cameras:
     arbitrary_camera_name:
       name: camera_0
+      lcm_bus: extra_bus
   visualization:
     lcm_bus: extra_bus
     publish_period: 0.125

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -91,19 +91,23 @@ drake_cc_library(
     name = "camera_config_functions",
     srcs = ["camera_config_functions.cc"],
     hdrs = ["camera_config_functions.h"],
-    deps = [
+    interface_deps = [
         ":camera_config",
+        "//geometry:scene_graph",
+        "//lcm:interface",
+        "//multibody/plant",
+        "//systems/framework:diagram_builder",
+        "//systems/lcm:lcm_buses",
+    ],
+    deps = [
         ":camera_info",
         ":rgbd_sensor",
         ":sim_rgbd_sensor",
-        "//geometry:scene_graph",
         "//geometry/render_gl",
         "//geometry/render_vtk",
-        "//lcm:interface",
         "//math:geometric_transform",
         "//multibody/parsing:scoped_names",
-        "//multibody/plant",
-        "//systems/framework:diagram_builder",
+        "//systems/lcm:lcm_config_functions",
     ],
 )
 
@@ -346,9 +350,13 @@ drake_cc_googletest(
     tags = vtk_test_tags(),
     deps = [
         ":camera_config_functions",
+        ":image_to_lcm_image_array_t",
+        ":sim_rgbd_sensor",
         "//common/test_utilities:expect_throws_message",
         "//common/yaml:yaml_io",
         "//geometry/render_gl",
+        "//lcm:drake_lcm",
+        "//systems/lcm:lcm_publisher_system",
     ],
 )
 

--- a/systems/sensors/camera_config.h
+++ b/systems/sensors/camera_config.h
@@ -57,6 +57,7 @@ struct CameraConfig {
     a->Visit(DRAKE_NVP(depth));
     a->Visit(DRAKE_NVP(show_rgb));
     a->Visit(DRAKE_NVP(do_compress));
+    a->Visit(DRAKE_NVP(lcm_bus));
     ValidateOrThrow();
   }
 
@@ -301,6 +302,10 @@ struct CameraConfig {
 
   /** Controls whether the images are broadcast in a compressed format. */
   bool do_compress{true};
+
+  /** Which LCM URL to use.
+  @see drake::systems::lcm::LcmBuses */
+  std::string lcm_bus{"default"};
 
   //@}
 

--- a/systems/sensors/camera_config_functions.h
+++ b/systems/sensors/camera_config_functions.h
@@ -1,22 +1,73 @@
 #pragma once
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/lcm/lcm_buses.h"
 #include "drake/systems/sensors/camera_config.h"
 
 namespace drake {
 namespace systems {
 namespace sensors {
 
-/** Constructs a camera network (rgbd sensor and publishing systems) connected
- to `scene_graph`. As specified, the RGB and/or depth images from the camera are
- published via `lcm` on the channel
+/** Constructs a simulated camera sensor (rgbd sensor and publishing systems)
+ within `builder`. As specified, the RGB and/or depth images from the camera
+ are published via `lcm` on the channel
  <tt>DRAKE_RGBD_CAMERA_IMAGES_{camera_config.name}</tt>.
 
- @pre `plant` and `scene_graph` both belong to the `builder`.
- @throws std::exception if camera_config contains invalid values. */
+
+@param[in] config The camera configuration.
+
+@param[in,out] builder The diagram to add sensor and publishing systems into.
+
+@param[in] lcm_buses (Optional) The available LCM buses to use for camera
+message publication. When not provided, uses the `lcm` interface if provided, or
+else the `config.lcm_bus` must be set to "default" in which case an appropriate
+drake::lcm::DrakeLcm object is constructed and used internally.
+
+@param[in] plant (Optional) The MultibodyPlant to use for kinematics.
+In the common case where a MultibodyPlant has already been added to `builder`
+using either AddMultibodyPlant() or AddMultibodyPlantSceneGraph(), the default
+value (nullptr) here is suitable and generally should be preferred.
+When provided, it must be a System that's been added to the the given `builder`.
+When not provided, uses the system named "plant" in the given `builder`.
+
+@param[in] scene_graph (Optional) The SceneGraph to use for rendering.
+In the common case where a SceneGraph has already been added to `builder` using
+either AddMultibodyPlant() or AddMultibodyPlantSceneGraph(), the default value
+(nullptr) here is suitable and generally should be preferred.
+When provided, it must be a System that's been added to the the given `builder`.
+When not provided, uses the system named "scene_graph" in the given `builder`.
+
+@param[in] lcm (Optional) The LCM interface used for visualization message
+publication. When not provided, uses the `config.lcm_bus` value to look up
+the appropriate interface from `lcm_buses`.
+
+@throws std::exception if camera_config contains invalid values.
+
+@pre The `builder` is non-null.
+
+@pre Either the `config.lcm_bus` is set to "default", or else `lcm_buses` is
+non-null and contains a bus named `config.lcm_bus`, or else `lcm` is non-null.
+
+@pre Either the given `builder` contains a MultibodyPlant system named "plant"
+or else the provided `plant` is non-null.
+
+@pre Either the given `builder` contains a SceneGraph system named "scene_graph"
+or else the provided `scene_graph` is non-null.
+
+@see drake::multibody::AddMultibodyPlant()
+@see drake::systems::lcm::ApplyLcmBusConfig() */
+void ApplyCameraConfig(const CameraConfig& config,
+                       DiagramBuilder<double>* builder,
+                       const systems::lcm::LcmBuses* lcm_buses = nullptr,
+                       const multibody::MultibodyPlant<double>* plant = nullptr,
+                       geometry::SceneGraph<double>* scene_graph = nullptr,
+                       drake::lcm::DrakeLcmInterface* lcm = nullptr);
+
+DRAKE_DEPRECATED("2022-02-01", "Use the LcmBuses-related overload instead.")
 void ApplyCameraConfig(const CameraConfig& config,
                        multibody::MultibodyPlant<double>* plant,
                        DiagramBuilder<double>* builder,

--- a/systems/sensors/test/camera_config_functions_test.cc
+++ b/systems/sensors/test/camera_config_functions_test.cc
@@ -25,6 +25,7 @@ using drake::geometry::render::DepthRenderCamera;
 using drake::geometry::Rgba;
 using drake::geometry::SceneGraph;
 using drake::lcm::DrakeLcm;
+using drake::lcm::DrakeLcmInterface;
 using drake::math::RigidTransformd;
 using drake::multibody::AddMultibodyPlantSceneGraph;
 using drake::multibody::FixedOffsetFrame;
@@ -32,6 +33,7 @@ using drake::multibody::MultibodyPlant;
 using drake::multibody::SpatialInertia;
 using drake::schema::Transform;
 using drake::systems::DiagramBuilder;
+using drake::systems::lcm::LcmBuses;
 using drake::systems::lcm::LcmPublisherSystem;
 using drake::systems::sensors::ImageToLcmImageArrayT;
 using drake::systems::sensors::RgbdSensor;
@@ -61,7 +63,8 @@ CameraConfig MakeConfig() {
                       .rgb = false,
                       .depth = true,
                       .show_rgb = true,
-                      .do_compress = false};
+                      .do_compress = false,
+                      .lcm_bus = "test_lcm_bus"};
   // drake::scheme::Transform cannot be constructed with a base frame.
   config.X_PB.base_frame = "test_frame";
   return config;
@@ -107,7 +110,6 @@ class CameraConfigFunctionsTest : public ::testing::Test {
   DiagramBuilder<double> builder_;
   MultibodyPlant<double>* plant_{};
   SceneGraph<double>* scene_graph_{};
-  DrakeLcm lcm_;
   FrameId body_frame_id_;
 };
 
@@ -119,7 +121,7 @@ TEST_F(CameraConfigFunctionsTest, EarlyExit) {
   // requesting rgb or depth publication.
   config.rgb = config.depth = false;
   const int system_count = static_cast<int>(builder_.GetSystems().size());
-  ApplyCameraConfig(config, plant_, &builder_, scene_graph_, &lcm_);
+  ApplyCameraConfig(config, &builder_);
   // We haven't added anything to the builder.
   EXPECT_EQ(builder_.GetSystems().size(), system_count);
 }
@@ -136,7 +138,7 @@ GTEST_TEST(CameraConfigFunctionsTestAux, DefaultConfigRenders) {
 TEST_F(CameraConfigFunctionsTest, ParentBaseFrameDefaultToWorld) {
   CameraConfig config;
   config.X_PB.base_frame = std::nullopt;
-  ApplyCameraConfig(config, plant_, &builder_, scene_graph_, &lcm_);
+  ApplyCameraConfig(config, &builder_);
 
   const auto* sensor =
       GetSystem<RgbdSensor>(builder_, "rgbd_sensor_preview_camera");
@@ -149,7 +151,7 @@ TEST_F(CameraConfigFunctionsTest, ParentBaseFrameDefaultToWorld) {
 TEST_F(CameraConfigFunctionsTest, ParentBaseFrameSpecified) {
   CameraConfig config;
   config.X_PB.base_frame = "test_frame";
-  ApplyCameraConfig(config, plant_, &builder_, scene_graph_, &lcm_);
+  ApplyCameraConfig(config, &builder_);
 
   const auto* sensor =
       GetSystem<RgbdSensor>(builder_, "rgbd_sensor_preview_camera");
@@ -168,7 +170,7 @@ TEST_F(CameraConfigFunctionsTest, InvalidParentBaseFrame) {
   CameraConfig config;
   config.X_PB.base_frame = "invalid_frame";
   DRAKE_EXPECT_THROWS_MESSAGE(
-      ApplyCameraConfig(config, plant_, &builder_, scene_graph_, &lcm_),
+      ApplyCameraConfig(config, &builder_),
       "Could not find frame.+");
 }
 
@@ -182,7 +184,7 @@ TEST_F(CameraConfigFunctionsTest, RenderEngine) {
   ASSERT_EQ(scene_graph_->RendererCount(), 0);
 
   CameraConfig config;
-  ApplyCameraConfig(config, plant_, &builder_, scene_graph_, &lcm_);
+  ApplyCameraConfig(config, &builder_);
   ASSERT_EQ(scene_graph_->RendererCount(), 1);
 
   const auto* sensor1 =
@@ -196,7 +198,7 @@ TEST_F(CameraConfigFunctionsTest, RenderEngine) {
   // Now add second camera which uses the same name.
   size_t previous_system_count = builder_.GetSystems().size();
   config.name = config.name + "_the_other_one";
-  ApplyCameraConfig(config, plant_, &builder_, scene_graph_, &lcm_);
+  ApplyCameraConfig(config, &builder_);
 
   // No new render engine added.
   ASSERT_EQ(scene_graph_->RendererCount(), 1);
@@ -214,7 +216,7 @@ TEST_F(CameraConfigFunctionsTest, RenderEngine) {
   // Third camera uses a unique name creates a unique render engine.
   config.name = "just_for_test";
   config.renderer_name = "just_for_test";
-  ApplyCameraConfig(config, plant_, &builder_, scene_graph_, &lcm_);
+  ApplyCameraConfig(config, &builder_);
   ASSERT_EQ(scene_graph_->RendererCount(), 2);
   // New RgbdSensor added.
   EXPECT_GT(builder_.GetSystems().size(), previous_system_count);
@@ -245,7 +247,14 @@ TEST_F(CameraConfigFunctionsTest, AllParametersCount) {
   // "not default" config file has at least one image enabled.
   ASSERT_EQ(config.depth || config.rgb, true);
 
-  ApplyCameraConfig(config, plant_, &builder_, scene_graph_, &lcm_);
+  // Prepare the LCM dictionary, based on the bus name from MakeConfig().
+  LcmBuses lcm_buses;
+  DRAKE_DEMAND(config.lcm_bus != "default");
+  DrakeLcm non_default_lcm;
+  lcm_buses.Add(config.lcm_bus, &non_default_lcm);
+
+  // Add the camera and then read back its properties to confirm.
+  ApplyCameraConfig(config, &builder_, &lcm_buses);
   const auto* sensor =
       GetSystem<RgbdSensor>(builder_, "rgbd_sensor_test_camera");
   ASSERT_NE(sensor, nullptr);
@@ -292,15 +301,31 @@ TEST_F(CameraConfigFunctionsTest, AllParametersCount) {
       builder_, "LcmPublisherSystem(DRAKE_RGBD_CAMERA_IMAGES_test_camera)");
   ASSERT_NE(publisher, nullptr);
   EXPECT_DOUBLE_EQ(publisher->get_publish_period(), 1.0 / config.fps);
+
+  // Publishing destination.
+  const DrakeLcmInterface& actual_lcm =
+      const_cast<LcmPublisherSystem*>(publisher)->lcm();
+  EXPECT_TRUE(&actual_lcm == &non_default_lcm);
+}
+
+// The user can pass a plant and scene_graph explicitly.
+TEST_F(CameraConfigFunctionsTest, SubsystemPointers) {
+  // We'll prove that the arguments are obeyed by using non-standard names,
+  // and checking that nothing throws.
+  plant_->set_name("Is it secret?");
+  scene_graph_->set_name("Is it safe?");
+  EXPECT_NO_THROW(ApplyCameraConfig(
+      CameraConfig{}, &builder_, {}, plant_, scene_graph_));
 }
 
 // Confirms that if only rgb is specified, only rgb is published.
 TEST_F(CameraConfigFunctionsTest, PublishingRgb) {
   CameraConfig config = MakeConfig();
+  config.lcm_bus = "default";
   config.rgb = true;
   config.depth = false;
 
-  ApplyCameraConfig(config, plant_, &builder_, scene_graph_, &lcm_);
+  ApplyCameraConfig(config, &builder_);
 
   // Rgb and depth ports.
   const auto* images =
@@ -313,10 +338,11 @@ TEST_F(CameraConfigFunctionsTest, PublishingRgb) {
 // Confirms that if only depth is specified, only depth is published.
 TEST_F(CameraConfigFunctionsTest, PublishingDepth) {
   CameraConfig config = MakeConfig();
+  config.lcm_bus = "default";
   config.rgb = false;
   config.depth = true;
 
-  ApplyCameraConfig(config, plant_, &builder_, scene_graph_, &lcm_);
+  ApplyCameraConfig(config, &builder_);
 
   // Rgb and depth ports.
   const auto* images =
@@ -329,10 +355,11 @@ TEST_F(CameraConfigFunctionsTest, PublishingDepth) {
 // Confirms that if both rgb and depth are specified, both are published.
 TEST_F(CameraConfigFunctionsTest, PublishingRgbAndDepth) {
   CameraConfig config = MakeConfig();
+  config.lcm_bus = "default";
   config.rgb = true;
   config.depth = true;
 
-  ApplyCameraConfig(config, plant_, &builder_, scene_graph_, &lcm_);
+  ApplyCameraConfig(config, &builder_);
 
   // Rgb and depth ports.
   const auto* images =
@@ -349,8 +376,18 @@ TEST_F(CameraConfigFunctionsTest, Validation) {
   CameraConfig config = MakeConfig();
   config.fps = -10;
   EXPECT_THROW(
-      ApplyCameraConfig(config, plant_, &builder_, scene_graph_, &lcm_),
+      ApplyCameraConfig(config, &builder_),
       std::exception);
+}
+
+// When the user requests a non-standard LCM bus, it is an error to omit an
+// LcmBuses object from the argument list.
+TEST_F(CameraConfigFunctionsTest, BadLcmBus) {
+  CameraConfig config;
+  config.lcm_bus = "special_request";
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      ApplyCameraConfig(config, &builder_),
+      ".*non-default.*special_request.*");
 }
 
 // Confirms that the render engine implementation follows the requested type
@@ -362,7 +399,7 @@ TEST_F(CameraConfigFunctionsTest, RenderEngineRequest) {
   // Unspecified class produces RenderEngineVtk.
   const CameraConfig default_config{.renderer_name = "default"};
   ASSERT_FALSE(scene_graph_->HasRenderer(default_config.renderer_name));
-  ApplyCameraConfig(default_config, plant_, &builder_, scene_graph_, &lcm_);
+  ApplyCameraConfig(default_config, &builder_);
   ASSERT_EQ(NiceTypeName::RemoveNamespaces(scene_graph_->GetRendererTypeName(
                 default_config.renderer_name)),
             "RenderEngineVtk");
@@ -371,7 +408,7 @@ TEST_F(CameraConfigFunctionsTest, RenderEngineRequest) {
   const CameraConfig vtk_config{.renderer_name = "vtk_renderer",
                                 .renderer_class = "RenderEngineVtk"};
   ASSERT_FALSE(scene_graph_->HasRenderer(vtk_config.renderer_name));
-  ApplyCameraConfig(vtk_config, plant_, &builder_, scene_graph_, &lcm_);
+  ApplyCameraConfig(vtk_config, &builder_);
   ASSERT_EQ(NiceTypeName::RemoveNamespaces(scene_graph_->GetRendererTypeName(
                 vtk_config.renderer_name)),
             "RenderEngineVtk");
@@ -381,7 +418,7 @@ TEST_F(CameraConfigFunctionsTest, RenderEngineRequest) {
       ApplyCameraConfig(
           CameraConfig{.renderer_name = default_config.renderer_name,
                        .renderer_class = "RenderEngineGl"},
-          plant_, &builder_, scene_graph_, &lcm_),
+          &builder_),
       ".*The name is already used with a different type.+");
 
   // Using existing name but *no* render engine uses existing engine. Call to
@@ -389,8 +426,7 @@ TEST_F(CameraConfigFunctionsTest, RenderEngineRequest) {
   // This test assumes that this behavior doesn't depend on the type of the
   // RenderEngine.
   const int renderer_count = scene_graph_->RendererCount();
-  ApplyCameraConfig(CameraConfig{.renderer_name = "vtk_renderer"}, plant_,
-                    &builder_, scene_graph_, &lcm_);
+  ApplyCameraConfig(CameraConfig{.renderer_name = "vtk_renderer"}, &builder_);
   EXPECT_EQ(renderer_count, scene_graph_->RendererCount());
 
   // Now explicitly request a new RenderEngineGl -- whether it throws depends
@@ -399,16 +435,36 @@ TEST_F(CameraConfigFunctionsTest, RenderEngineRequest) {
                                .renderer_class = "RenderEngineGl"};
   if (geometry::render::kHasRenderEngineGl) {
     ASSERT_FALSE(scene_graph_->HasRenderer(gl_config.renderer_name));
-    ApplyCameraConfig(gl_config, plant_, &builder_, scene_graph_, &lcm_);
+    ApplyCameraConfig(gl_config, &builder_);
     ASSERT_EQ(NiceTypeName::RemoveNamespaces(
                   scene_graph_->GetRendererTypeName(gl_config.renderer_name)),
               "RenderEngineGl");
   } else {
     DRAKE_EXPECT_THROWS_MESSAGE(
-        ApplyCameraConfig(gl_config, plant_, &builder_, scene_graph_, &lcm_),
+        ApplyCameraConfig(gl_config, &builder_),
         ".*'RenderEngineGl' is not supported.*");
   }
 }
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+TEST_F(CameraConfigFunctionsTest, DeprecatedOverload) {
+  CameraConfig config;
+  config.name = "test_camera";
+
+  DrakeLcm expected_lcm;
+  const size_t previous_count = builder_.GetSystems().size();
+  ApplyCameraConfig(config, plant_, &builder_, scene_graph_, &expected_lcm);
+  EXPECT_GT(builder_.GetSystems().size(), previous_count);
+
+  const auto* publisher = GetSystem<LcmPublisherSystem>(
+      builder_, "LcmPublisherSystem(DRAKE_RGBD_CAMERA_IMAGES_test_camera)");
+  ASSERT_NE(publisher, nullptr);
+  const DrakeLcmInterface& actual_lcm =
+      const_cast<LcmPublisherSystem*>(publisher)->lcm();
+  EXPECT_TRUE(&actual_lcm == &expected_lcm);
+}
+#pragma GCC diagnostic pop
 
 }  // namespace
 }  // namespace sensors

--- a/visualization/visualization_config.h
+++ b/visualization/visualization_config.h
@@ -32,7 +32,8 @@ struct VisualizationConfig {
     a->Visit(DRAKE_NVP(publish_contacts));
   }
 
-  /** Which LCM URL to use. */
+  /** Which LCM URL to use.
+  @see drake::systems::lcm::LcmBuses */
   std::string lcm_bus{"default"};
 
   /** The duration (in seconds) between published LCM messages that update


### PR DESCRIPTION
Towards #17112.

Requires:
- [x] #18078
- [x] #18090

This brings the nice optional argument sugar from visualization config over to camera config as well.

Update hardware_sim examples to use the new spelling.  This allows the Python enable to sucessfully use cameras now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18069)
<!-- Reviewable:end -->
