### PR TITLE
[pydrake/systems] Add binding for State.get_abstract_state(index)

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -833,6 +833,13 @@ void DoScalarDependentDefinitions(py::module m) {
               &State<T>::get_abstract_state),
           py_rvp::reference_internal, doc.State.get_abstract_state.doc)
       .def(
+          "get_abstract_state",
+          [](State<T>* self, int index) -> const AbstractValue& {
+            return self->get_abstract_state().get_value(index);
+          },
+          py::arg("index"), py_rvp::reference_internal,
+          doc.State.get_abstract_state.doc)
+      .def(
           "get_mutable_abstract_state",
           [](State<T>* self) -> AbstractValues& {
             return self->get_mutable_abstract_state();

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -739,6 +739,9 @@ class TestCustom(unittest.TestCase):
             state.get_mutable_discrete_state(index=0) is
             state.get_mutable_discrete_state().get_vector(index=0))
         self.assertTrue(
+            state.get_abstract_state(index=0) is
+            state.get_abstract_state().get_value(index=0))
+        self.assertTrue(
             state.get_mutable_abstract_state(index=0) is
             state.get_mutable_abstract_state().get_value(index=0))
 


### PR DESCRIPTION
This one was somehow missing from the State API.

+@rpoyner-tri for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18070)
<!-- Reviewable:end -->
