### PR TITLE
[pydrake] Add bindings for PortSwitch and Value instantiations for TypeSafeIndex

### DIFF
--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -325,6 +325,7 @@ drake_cc_library(
     declare_installed_headers = 0,
     visibility = ["//visibility:public"],
     deps = [
+        ":value_pybind",
         "//:drake_shared_library",
         "//bindings/pydrake:documentation_pybind",
     ],
@@ -675,6 +676,9 @@ drake_pybind_cc_googletest(
     cc_deps = [
         ":type_safe_index_pybind",
         "//bindings/pydrake:test_util_pybind",
+    ],
+    py_deps = [
+        "//bindings/pydrake/common:value_py",
     ],
 )
 

--- a/bindings/pydrake/common/test/type_safe_index_pybind_test.cc
+++ b/bindings/pydrake/common/test/type_safe_index_pybind_test.cc
@@ -88,6 +88,11 @@ GTEST_TEST(TypeSafeIndexTest, CheckCasting) {
 
   // Check string representation.
   CheckValue("repr(Index(10)) == 'Index(10)'", true);
+
+  // Check value instantiation.
+  py::exec("from pydrake.common.value import AbstractValue");
+  CheckValue(
+      "isinstance(AbstractValue.Make(Index(11)).get_value(), Index)", true);
 }
 
 int main(int argc, char** argv) {

--- a/bindings/pydrake/common/type_safe_index_pybind.h
+++ b/bindings/pydrake/common/type_safe_index_pybind.h
@@ -5,6 +5,7 @@
 #include "pybind11/operators.h"
 #include "pybind11/pybind11.h"
 
+#include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/type_safe_index.h"
@@ -12,7 +13,8 @@
 namespace drake {
 namespace pydrake {
 
-/// Binds a TypeSafeIndex instantiation.
+/// Binds a TypeSafeIndex instantiation along with its Value[Class]
+/// type-erasure wrapper.
 template <typename Class>
 auto BindTypeSafeIndex(
     py::module m, const std::string& name, const std::string& class_doc = "") {
@@ -33,6 +35,7 @@ auto BindTypeSafeIndex(
       .def("__repr__", [name](const Class& self) {
         return py::str("{}({})").format(name, static_cast<int>(self));
       });
+  AddValueInstantiation<Class>(m);
   return cls;
 }
 

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -24,6 +24,7 @@
 #include "drake/systems/primitives/multilayer_perceptron.h"
 #include "drake/systems/primitives/multiplexer.h"
 #include "drake/systems/primitives/pass_through.h"
+#include "drake/systems/primitives/port_switch.h"
 #include "drake/systems/primitives/random_source.h"
 #include "drake/systems/primitives/saturation.h"
 #include "drake/systems/primitives/shared_pointer_system.h"
@@ -353,6 +354,19 @@ PYBIND11_MODULE(primitives, m) {
             doc.PassThrough.ctor.doc_1args_value)
         .def(py::init<const AbstractValue&>(), py::arg("abstract_model_value"),
             doc.PassThrough.ctor.doc_1args_abstract_model_value);
+
+    DefineTemplateClassWithDefault<PortSwitch<T>, LeafSystem<T>>(
+        m, "PortSwitch", GetPyParam<T>(), doc.PortSwitch.doc)
+        .def(py::init<int>(), py::arg("vector_size"), doc.PortSwitch.ctor.doc)
+        // TODO(russt): implement AbstractValue version of the constructor and
+        // bind it here.
+        .def("get_port_selector_input_port",
+            &PortSwitch<T>::get_port_selector_input_port,
+            py_rvp::reference_internal,
+            doc.PortSwitch.get_port_selector_input_port.doc)
+        .def("DeclareInputPort", &PortSwitch<T>::DeclareInputPort,
+            py::arg("name"), py_rvp::reference_internal,
+            doc.PortSwitch.DeclareInputPort.doc);
 
     DefineTemplateClassWithDefault<Saturation<T>, LeafSystem<T>>(
         m, "Saturation", GetPyParam<T>(), doc.Saturation.doc)

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -11,6 +11,7 @@ from pydrake.systems.framework import (
     BasicVector,
     DiagramBuilder,
     DiagramBuilder_,
+    InputPort,
     TriggerType,
     VectorBase,
 )
@@ -43,6 +44,7 @@ from pydrake.systems.primitives import (
     ObservabilityMatrix,
     PassThrough, PassThrough_,
     PerceptronActivationType,
+    PortSwitch, PortSwitch_,
     RandomSource,
     Saturation, Saturation_,
     SharedPointerSystem, SharedPointerSystem_,
@@ -95,6 +97,7 @@ class TestGeneral(unittest.TestCase):
         self._check_instantiations(Multiplexer_)
         self._check_instantiations(MultilayerPerceptron_)
         self._check_instantiations(PassThrough_)
+        self._check_instantiations(PortSwitch_)
         self._check_instantiations(Saturation_)
         self._check_instantiations(SharedPointerSystem_)
         self._check_instantiations(Sine_)
@@ -286,6 +289,14 @@ class TestGeneral(unittest.TestCase):
         system.CalcOutput(context, output)
         output_value = output.get_data(0)
         compare_value(self, output_value, model_value)
+
+    def test_port_switch(self):
+        system = PortSwitch(vector_size=2)
+        a = system.DeclareInputPort(name="a")
+        system.DeclareInputPort(name="b")
+        context = system.CreateDefaultContext()
+        self.assertIsInstance(a, InputPort)
+        system.get_port_selector_input_port().FixValue(context, a.get_index())
 
     def test_first_order_low_pass_filter(self):
         filter1 = FirstOrderLowPassFilter(time_constant=3.0, size=4)

--- a/systems/primitives/port_switch.h
+++ b/systems/primitives/port_switch.h
@@ -50,7 +50,8 @@ class PortSwitch final : public LeafSystem<T> {
 
   /** Constructs a %PortSwitch using the type of `model_value` as the model for
   the output port.  All input ports declared via DeclareInputPort() will be
-  abstract-valued ports using the same `model_value`. */
+  abstract-valued ports using the same `model_value`.
+  @exclude_from_pydrake_mkdoc{not bound in pydrake} */
   template <typename OutputType>
   explicit PortSwitch(const OutputType& model_value)
       : PortSwitch(-1, AbstractValue::Make<OutputType>(model_value), nullptr,
@@ -60,7 +61,8 @@ class PortSwitch final : public LeafSystem<T> {
   the output port.  This version provides support for input/output values
   that are templated on scalar type; the scalar type on the port is kept
   consistent with the scalar type of the System (even through scalar
-  conversion). The type of `dummy_value` must be default constructible.  */
+  conversion). The type of `dummy_value` must be default constructible.
+  @exclude_from_pydrake_mkdoc{not bound in pydrake} */
   template <template <typename> class OutputType>
   explicit PortSwitch(const OutputType<T>& dummy_value)
       : PortSwitch(
@@ -76,6 +78,8 @@ class PortSwitch final : public LeafSystem<T> {
   template <typename U>
   explicit PortSwitch(const PortSwitch<U>& other);
 
+  /** Returns the port-selector input port, which is an abstract-valued port of
+  type InputPortIndex. */
   const InputPort<T>& get_port_selector_input_port() const {
     return this->get_input_port(0);
   }


### PR DESCRIPTION
These two go together; without the value instantiation, test_port_switch fails with

```
  File "/home/russt/.cache/bazel/_bazel_russt/a0bdb2099cb05916281dea472bfce61b/sandbox/linux-sandbox/4037/execroot/drake/bazel-out/k8-opt/bin/bindings/pydrake/systems/py/primitives_test.runfiles/drake/bindings/pydrake/systems/test/primitives_test.py", line 299, in test_port_switch
    system.get_port_selector_input_port().FixValue(context, a.get_index())
RuntimeError: This derived class of `AbstractValue`, `drake::Value<drake::TypeSafeIndex<drake::systems::InputPortTag>>`, is not exposed to pybind11, so `set_value` cannot be called. See `AddValueInstantiation` for how to bind it.
```

+@jwnimmer-tri for feature review, please

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18072)
<!-- Reviewable:end -->
