### PR TITLE
[manipulation/planner] Add optional use_robot_state port to Diff IK Integrator

### DIFF
--- a/manipulation/planner/differential_inverse_kinematics_integrator.cc
+++ b/manipulation/planner/differential_inverse_kinematics_integrator.cc
@@ -22,12 +22,17 @@ DifferentialInverseKinematicsIntegrator::
       time_step_(time_step) {
   parameters_.set_time_step(time_step);
 
-  // This is accessed as port 0 in the code below.
-  this->DeclareAbstractInputPort("X_WE_desired",
-                                 Value<math::RigidTransformd>{});
+  X_WE_desired_index_ = this->DeclareAbstractInputPort(
+                                "X_WE_desired", Value<math::RigidTransformd>{})
+                            .get_index();
 
-  // This is accessed as port 1 in the code below.
-  this->DeclareVectorInputPort("robot_state", robot.num_multibody_states());
+  robot_state_index_ =
+      this->DeclareVectorInputPort("robot_state", robot.num_multibody_states())
+          .get_index();
+
+  use_robot_state_index_ =
+      this->DeclareAbstractInputPort("use_robot_state", Value<bool>{})
+          .get_index();
 
   this->DeclarePeriodicDiscreteUpdateEvent(
       time_step, 0, &DifferentialInverseKinematicsIntegrator::Integrate);
@@ -54,8 +59,7 @@ DifferentialInverseKinematicsIntegrator::
   }
   robot_context_cache_entry_ = &this->DeclareCacheEntry(
       "robot context", *robot_context,
-      &DifferentialInverseKinematicsIntegrator::UpdateRobotContext,
-      {all_state_ticket()});
+      &DifferentialInverseKinematicsIntegrator::UpdateRobotContext);
 }
 
 void DifferentialInverseKinematicsIntegrator::SetPositions(
@@ -88,14 +92,23 @@ DifferentialInverseKinematicsIntegrator::get_mutable_parameters() {
 void DifferentialInverseKinematicsIntegrator::UpdateRobotContext(
     const Context<double>& context,
     Context<double>* robot_context) const {
-  robot_.SetPositions(robot_context,
-                      context.get_discrete_state(0).get_value());
+  if (this->get_input_port(robot_state_index_).HasValue(context) &&
+      this->get_input_port(use_robot_state_index_).HasValue(context) &&
+      this->get_input_port(use_robot_state_index_).Eval<bool>(context)) {
+    robot_.SetPositions(robot_context, this->get_input_port(robot_state_index_)
+                                           .Eval(context)
+                                           .head(robot_.num_positions()));
+  } else {
+    robot_.SetPositions(robot_context,
+                        context.get_discrete_state(0).get_value());
+  }
 }
 
 systems::EventStatus DifferentialInverseKinematicsIntegrator::Integrate(
     const Context<double>& context,
     systems::DiscreteValues<double>* discrete_state) const {
-  const AbstractValue* input = this->EvalAbstractInput(context, 0);
+  const AbstractValue* input =
+      this->EvalAbstractInput(context, X_WE_desired_index_);
   DRAKE_DEMAND(input != nullptr);
   DRAKE_THROW_UNLESS(parameters_.get_time_step() == time_step_);
   const math::RigidTransformd& X_WE_desired =
@@ -106,7 +119,7 @@ systems::EventStatus DifferentialInverseKinematicsIntegrator::Integrate(
   DifferentialInverseKinematicsResult result = DoDifferentialInverseKinematics(
       robot_, robot_context, X_WE_desired, frame_E_, parameters_);
 
-  const auto& positions = context.get_discrete_state(0).get_value();
+  const auto& positions = robot_.GetPositions(robot_context);
   if (result.status == DifferentialInverseKinematicsStatus::kNoSolutionFound) {
     if (this->num_discrete_state_groups() == 1) {
       drake::log()->warn(
@@ -164,8 +177,9 @@ void DifferentialInverseKinematicsIntegrator::CopyPositionsOut(
 systems::EventStatus DifferentialInverseKinematicsIntegrator::Initialize(
     const systems::Context<double>& context,
     systems::DiscreteValues<double>* discrete_state) const {
-  if (this->get_input_port(1).HasValue(context)) {
-    Eigen::VectorXd state = this->get_input_port(1).Eval(context);
+  if (this->get_input_port(robot_state_index_).HasValue(context)) {
+    Eigen::VectorXd state =
+        this->get_input_port(robot_state_index_).Eval(context);
     DRAKE_DEMAND(state.size() == robot_.num_multibody_states());
     discrete_state->set_value(0, state.head(robot_.num_positions()));
     return systems::EventStatus::Succeeded();

--- a/manipulation/planner/differential_inverse_kinematics_integrator.h
+++ b/manipulation/planner/differential_inverse_kinematics_integrator.h
@@ -22,6 +22,12 @@ hold the integrated position (with zero velocity); on kStuck the integration
 will continue (though "kStuck" implies that the achieved spatial velocity will
 be much smaller than what was commanded).
 
+The optional boolean (abstract-)valued input port `use_robot_state` can be used
+to reset the integrated state to the value obtained from the `robot_state`
+input (which must also be connected). Note: Using measured joint positions in a
+feedback loop can lead to undamped oscillations in the redundant joints; we
+hope to resolve this and are tracking it in #9773.
+
 Note: It is highly recommended that the user calls `SetPosition()` once to
 initialize the position commands to match the initial positions of the robot.
 Alternatively, one can connect the optional `robot_state` input port -- which
@@ -30,15 +36,13 @@ on this input port (the port accepts the state vector with positions and
 velocities for easy of use with MultibodyPlant, but only the positions are
 used).
 
-Note: Using measured joint positions in a feedback loop can lead to undamped
-oscillations in the redundant joints; we hope to resolve this and are tracking
-it in #9773.
 
 @system
 name: DifferentialInverseKinematicsIntegrator
 input_ports:
 - X_WE_desired
 - robot_state (optional)
+- use_robot_state (optional)
 output_ports:
 - joint_positions
 @endsystem
@@ -122,6 +126,9 @@ class DifferentialInverseKinematicsIntegrator
   DifferentialInverseKinematicsParameters parameters_;
   const double time_step_{0.0};
   const systems::CacheEntry* robot_context_cache_entry_{};
+  systems::InputPortIndex X_WE_desired_index_{};
+  systems::InputPortIndex robot_state_index_{};
+  systems::InputPortIndex use_robot_state_index_{};
 };
 
 }  // namespace planner

--- a/manipulation/planner/test/differential_inverse_kinematics_integrator_test.cc
+++ b/manipulation/planner/test/differential_inverse_kinematics_integrator_test.cc
@@ -30,7 +30,7 @@ std::unique_ptr<multibody::MultibodyPlant<double>> MakeIiwa(void) {
 
 
 // Tests that the LeafSystem behavior matches the function API.
-GTEST_TEST(DifferentialInverseKinematicsIntegatorTest, BasicTest) {
+GTEST_TEST(DifferentialInverseKinematicsIntegratorTest, BasicTest) {
   auto robot = MakeIiwa();
   auto robot_context = robot->CreateDefaultContext();
   const multibody::Frame<double>& frame_E =
@@ -103,7 +103,7 @@ GTEST_TEST(DifferentialInverseKinematicsIntegatorTest, BasicTest) {
   EXPECT_FALSE(CompareMatrices(discrete_state->get_value(0), last_q, 1e-12));
 }
 
-GTEST_TEST(DifferentialInverseKinematicsIntegatorTest, ParametersTest) {
+GTEST_TEST(DifferentialInverseKinematicsIntegratorTest, ParametersTest) {
   auto robot = MakeIiwa();
   auto robot_context = robot->CreateDefaultContext();
   const multibody::Frame<double>& frame_E =
@@ -122,7 +122,7 @@ GTEST_TEST(DifferentialInverseKinematicsIntegatorTest, ParametersTest) {
 
 // Confirm that we can act like a difference equation system when the warning
 // logic is disabled.
-GTEST_TEST(DifferentialInverseKinematicsIntegatorTest,
+GTEST_TEST(DifferentialInverseKinematicsIntegratorTest,
            DifferenceEquationSystemTest) {
   auto robot = MakeIiwa();
   auto robot_context = robot->CreateDefaultContext();
@@ -177,6 +177,70 @@ GTEST_TEST(DifferentialInverseKinematicsIntegratorTest,
   EXPECT_TRUE(
       CompareMatrices(diff_ik_context.get_discrete_state(0).get_value(),
                       robot->GetPositions(robot_context)));
+}
+
+GTEST_TEST(DifferentialInverseKinematicsIntegratorTest,
+           UseRobotStatePort) {
+  systems::DiagramBuilder<double> builder;
+  auto robot = builder.AddSystem(MakeIiwa());
+  const multibody::Frame<double>& frame_E =
+      robot->GetFrameByName("iiwa_link_7");
+
+  DifferentialInverseKinematicsParameters params(robot->num_positions(),
+                                                 robot->num_velocities());
+  const double time_step = 0.1;
+  auto diff_ik = builder.AddSystem<DifferentialInverseKinematicsIntegrator>(
+      *robot, frame_E, time_step, params);
+  builder.Connect(robot->get_state_output_port(),
+                  diff_ik->GetInputPort("robot_state"));
+  auto diagram = builder.Build();
+  systems::Simulator<double> simulator(*diagram);
+
+  systems::Context<double>& context = simulator.get_mutable_context();
+  systems::Context<double>& robot_context =
+      robot->GetMyMutableContextFromRoot(&context);
+  robot->SetPositions(&robot_context, Eigen::VectorXd::Constant(7, 0.1));
+  systems::Context<double>& diff_ik_context =
+      diff_ik->GetMyMutableContextFromRoot(&context);
+  const math::RigidTransform<double> X_G =
+      robot->GetBodyByName("iiwa_link_7").EvalPoseInWorld(robot_context);
+  diff_ik_context.FixInputPort(0, Value<math::RigidTransform<double>>(X_G));
+  auto discrete_state = diff_ik->AllocateDiscreteVariables();
+
+  // Note: we intentionally do not call simulator.Initialize() nor send an
+  // initialization event.
+
+  // use_robot_state port is unset.
+  for (const auto& [data, events] : diff_ik->GetPeriodicEvents()) {
+    dynamic_cast<const systems::DiscreteUpdateEvent<double>*>(events[0])
+        ->handle(*diff_ik, diff_ik_context, discrete_state.get());
+  }
+  EXPECT_FALSE(CompareMatrices(discrete_state->get_value(0),
+                               robot->GetPositions(robot_context)));
+
+  // use_robot_state port is set to false.
+  diff_ik_context.FixInputPort(
+      diff_ik->GetInputPort("use_robot_state").get_index(),
+      Value<bool>{false});
+  for (const auto& [data, events] : diff_ik->GetPeriodicEvents()) {
+    dynamic_cast<const systems::DiscreteUpdateEvent<double>*>(events[0])
+        ->handle(*diff_ik, diff_ik_context, discrete_state.get());
+  }
+  EXPECT_FALSE(CompareMatrices(discrete_state->get_value(0),
+                               robot->GetPositions(robot_context)));
+
+  // use_robot_state port is set to true.
+  diff_ik_context.FixInputPort(
+      diff_ik->GetInputPort("use_robot_state").get_index(),
+      Value<bool>{true});
+  for (const auto& [data, events] : diff_ik->GetPeriodicEvents()) {
+    dynamic_cast<const systems::DiscreteUpdateEvent<double>*>(events[0])
+        ->handle(*diff_ik, diff_ik_context, discrete_state.get());
+  }
+  // We set the desired pose to the current pose, so updating with true should
+  // result in the integrator positions matching the robot positions.
+  EXPECT_TRUE(CompareMatrices(discrete_state->get_value(0),
+                              robot->GetPositions(robot_context), 1e-12));
 }
 
 }  // namespace


### PR DESCRIPTION
This allows the DiffIK to use the current (optional) robot_state port instead of the integrated state, and to reset the integrator to that state.

I needed this because I had a more complicated controller that would switch between using DiffIK and using direct joint position commands. Without this port, switching *back* to the DiffIK controller resulted in the DiffIK integrator being far from the current true joint positions.  By setting `use_robot_state = true` during the joint position control mode, the DiffIK integrator keeps itself up to date with the current robot state.

+@siyuanfeng-tri for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18073)
<!-- Reviewable:end -->
