### PR TITLE
[pydrake] Move import-error handling out of pydrake.all

### DIFF
--- a/bindings/pydrake/systems/all.py
+++ b/bindings/pydrake/systems/all.py
@@ -1,5 +1,6 @@
 from .analysis import *
 from .controllers import *
+from .drawing import *
 from .framework import *
 from .lcm import *
 from .perception import *
@@ -10,8 +11,3 @@ from .rendering import *
 from .scalar_conversion import *
 from .sensors import *
 from .trajectory_optimization import *
-
-try:
-    from .drawing import *
-except ImportError:
-    pass

--- a/bindings/pydrake/systems/drawing.py
+++ b/bindings/pydrake/systems/drawing.py
@@ -4,17 +4,46 @@ Provides general visualization utilities. This is NOT related to `rendering`.
 
 from tempfile import NamedTemporaryFile
 
-import matplotlib.pyplot as plt
-import pydot
-
 from pydrake.common import temp_directory
 
 # TODO(eric.cousineau): Move `plot_graphviz` to something more accessible to
 # `call_python_client`.
 
 
+def _plt():
+    """Deferred import of plt, so pydrake.all importing doesn't bomb out."""
+    # On Ubuntu the Debian package python3-tk is a recommended (but not
+    # required) dependency of python3-matplotlib; help users understand
+    # that by providing a nicer message upon a failure to import.
+    result = None
+    try:
+        import matplotlib.pyplot as __plt
+        result = __plt
+    except ImportError as e:
+        if e.name == 'tkinter':
+            result = None
+        else:
+            raise
+    if result is None:
+        raise NotImplementedError(
+            "On Ubuntu when using the default pyplot configuration (i.e.,"
+            " the TkAgg backend) you must 'sudo apt install python3-tk' to"
+            " obtain Tk support. Alternatively, you may set MPLBACKEND to"
+            " something else (e.g., Qt5Agg).")
+    return result
+
+
+def _pydot():
+    """Deferred import of pyplot, so pydrake.all importing doesn't bomb out."""
+    import pydot as __pydot
+    return __pydot
+
+
 def plot_graphviz(dot_text):
     """Renders a DOT graph in matplotlib."""
+    plt = _plt()
+    pydot = _pydot()
+
     # @ref https://stackoverflow.com/a/18522941/7829525
     # Tried (reason ignored): pydotplus (`pydot` works), networkx
     # (`read_dot` does not work robustly?), pygraphviz (coupled with


### PR DESCRIPTION
Defer the `pydrake.systems.drawing` imports of `pydot` and `plt` to function-call time instead of module-import time.

Even with the try-except handling, a broken `pyplot` import was still spamming the user's console with Xorg and GTK errors, which now is build-time console spam due to `stubgen`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18081)
<!-- Reviewable:end -->
