### PR TITLE
[systems/lcm] Factor out magical lcm_buses lookup for reuse

### DIFF
--- a/systems/lcm/BUILD.bazel
+++ b/systems/lcm/BUILD.bazel
@@ -147,6 +147,8 @@ drake_cc_googletest(
     name = "lcm_config_functions_test",
     deps = [
         ":lcm_config_functions",
+        "//common/test_utilities:expect_throws_message",
+        "//lcm:drake_lcm",
     ],
 )
 

--- a/systems/lcm/lcm_buses.cc
+++ b/systems/lcm/lcm_buses.cc
@@ -32,7 +32,7 @@ DrakeLcmInterface* LcmBuses::Find(
     return result;
   }
   throw std::runtime_error(fmt::format(
-      "{} requested lcm bus {} that does not exist",
+      "{} requested an LCM bus '{}' that does not exist",
       description_of_caller, bus_name));
 }
 
@@ -50,7 +50,7 @@ void LcmBuses::Add(std::string bus_name, DrakeLcmInterface* bus) {
   const bool inserted = buses_.emplace(std::move(bus_name), bus).second;
   if (!inserted) {
     throw std::runtime_error(fmt::format(
-        "An LCM bus with name {} has already been defined",
+        "An LCM bus with name '{}' has already been defined",
         bus_name));
   }
 }

--- a/systems/lcm/lcm_buses.h
+++ b/systems/lcm/lcm_buses.h
@@ -31,8 +31,9 @@ class LcmBuses final {
   int size() const;
 
   /** Finds the bus of the given name, or throws if there is no such bus.
-  The return value is an alias into memory owned by the DiagramBuilder,
-  and is never nullptr.
+
+  The return value is an alias into memory owned elsewhere (typically by a
+  DiagramBuilder or a Diagram) and is never nullptr.
 
   @param description_of_caller is a noun phrase that will be used when creating
   an error message. A typical value would be something like "Camera 5", "Robot

--- a/systems/lcm/lcm_config_functions.h
+++ b/systems/lcm/lcm_config_functions.h
@@ -29,6 +29,33 @@ LcmBuses ApplyLcmBusConfig(
     const std::map<std::string, drake::lcm::DrakeLcmParams>& lcm_buses,
     systems::DiagramBuilder<double>* builder);
 
+/** (Advanced) Returns an LCM interface based on a convenient set of heuristics.
+
+If the `forced_result` is non-null, then returns `forced_result` and does
+nothing else.
+
+Otherwise, if `lcm_buses` is null and `bus_name` is "default", then creates a
+new DrakeLcm object owned by the `builder` and returns a pointer to it.
+
+Otherwise, if `lcm_buses` is null, then throws an exception.
+
+Otherwise, returns the `lcm_buses->Find(description_of_caller, bus_name)`
+which might throw if there is so such `bus_name`.
+
+The return value is an alias into memory owned elsewhere (typically by a
+DiagramBuilder or a Diagram) and is never nullptr.
+
+@param forced_result can be null
+@param lcm_buses can be null
+@param builder must not be null
+*/
+drake::lcm::DrakeLcmInterface* FindOrCreateLcmBus(
+    drake::lcm::DrakeLcmInterface* forced_result,
+    const LcmBuses* lcm_buses,
+    DiagramBuilder<double>* builder,
+    std::string_view description_of_caller,
+    const std::string& bus_name);
+
 }  // namespace lcm
 }  // namespace systems
 }  // namespace drake

--- a/systems/lcm/test/lcm_config_functions_test.cc
+++ b/systems/lcm/test/lcm_config_functions_test.cc
@@ -3,8 +3,12 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/lcm/drake_lcm.h"
 #include "drake/lcm/drake_lcm_params.h"
 
+using drake::lcm::DrakeLcm;
+using drake::lcm::DrakeLcmInterface;
 using drake::lcm::DrakeLcmParams;
 using drake::systems::DiagramBuilder;
 
@@ -43,6 +47,71 @@ GTEST_TEST(LcmConfigFunctionsTest, Basic) {
   // TODO(jwnimmer-tri) It might be worth trying to pub/sub some messages
   // here to confirm the wiring? But the risk of a bug seems low, at least
   // for now. We can revisit later, if we ever have doubts.
+}
+
+// Check the sunny-day case of looking up a bus_name.
+GTEST_TEST(LcmConfigFunctionsFindOrCreateTest, FindBus) {
+  DrakeLcm* const forced_result = nullptr;
+  LcmBuses lcm_buses;
+  DiagramBuilder<double> builder;
+  const std::string description = "Find Bus";
+  std::string bus_name = "special";
+  DrakeLcm special;
+  lcm_buses.Add(bus_name, &special);
+
+  // We successfully look up the bus_name.
+  DrakeLcmInterface* result = FindOrCreateLcmBus(
+      forced_result, &lcm_buses, &builder, description, bus_name);
+  EXPECT_EQ(result, &special);
+
+  // It's an error to use a non-existent bus_name.
+  bus_name = "missing";
+  DRAKE_EXPECT_THROWS_MESSAGE(FindOrCreateLcmBus(
+          forced_result, &lcm_buses, &builder, description, bus_name),
+      ".*missing.*does not exist.*");
+}
+
+// When the forced_result pointer is directly provided, then the lcm_buses and
+// bus_name are ignored (i.e., nothing crashes)
+GTEST_TEST(LcmConfigFunctionsFindOrCreateTest, IgnoredLcmBuses) {
+  DrakeLcm forced_result;
+  DiagramBuilder<double> builder;
+  const std::string description = "Ignored Lcm Buses";
+  const std::string bus_name = "will_be_ignored";
+
+  DrakeLcmInterface* result = FindOrCreateLcmBus(
+      &forced_result, nullptr /* lcm_buses */, &builder, description, bus_name);
+  EXPECT_EQ(result, &forced_result);
+  EXPECT_EQ(builder.GetSystems().size(), 0);
+
+  // The same holds true even when an lcm_buses has been provided.
+  const LcmBuses empty_lcm_buses;
+  result = FindOrCreateLcmBus(
+      &forced_result, &empty_lcm_buses, &builder, description, bus_name);
+  EXPECT_EQ(result, &forced_result);
+  EXPECT_EQ(builder.GetSystems().size(), 0);
+}
+
+// When the forced_result and lcm_buses are both null, then the bus_name must
+// be "default" and a new object will be created.
+GTEST_TEST(LcmConfigFunctionsFindOrCreateTest, CreateNew) {
+  DrakeLcm* const forced_result = nullptr;
+  const LcmBuses* const lcm_buses = nullptr;
+  DiagramBuilder<double> builder;
+  const std::string description = "Create New";
+  std::string bus_name = "default";
+
+  // A new bus gets created.
+  DrakeLcmInterface* result = FindOrCreateLcmBus(
+      forced_result, lcm_buses, &builder, description, bus_name);
+  EXPECT_NE(result, nullptr);
+  EXPECT_EQ(builder.GetSystems().size(), 1);
+
+  // It's an error to use a different bus_name.
+  bus_name = "special";
+  DRAKE_EXPECT_THROWS_MESSAGE(FindOrCreateLcmBus(
+          forced_result, lcm_buses, &builder, description, bus_name),
+      ".*non-default.*special.*");
 }
 
 }  // namespace

--- a/visualization/BUILD.bazel
+++ b/visualization/BUILD.bazel
@@ -45,9 +45,8 @@ drake_cc_library(
     ],
     deps = [
         "//geometry:drake_visualizer",
-        "//lcm:drake_lcm",
         "//multibody/plant:contact_results_to_lcm",
-        "//systems/primitives:shared_pointer_system",
+        "//systems/lcm:lcm_config_functions",
     ],
 )
 

--- a/visualization/test/visualization_config_functions_test.cc
+++ b/visualization/test/visualization_config_functions_test.cc
@@ -137,37 +137,6 @@ GTEST_TEST(VisualizationConfigFunctionsTest, ApplyNothing) {
   drake_lcm.HandleSubscriptions(1);
 }
 
-// When the lcm pointer is directly provided, the lcm_buses can be nullptr
-// and nothing crashes.
-GTEST_TEST(VisualizationConfigFunctionsTest, IgnoredLcmBuses) {
-  DrakeLcm drake_lcm;
-  DiagramBuilder<double> builder;
-  auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.0);
-  plant.Finalize();
-  VisualizationConfig config;
-  config.lcm_bus = "will_be_ignored";
-  ApplyVisualizationConfig(config, &builder, nullptr, nullptr, nullptr,
-      &drake_lcm);
-  // Guard against any crashes or dangling pointers during diagram construction.
-  builder.Build();
-}
-
-// When the lcm pointer is directly provided, the lcm_bus config string can
-// refer to a missing bus_name and nothing crashes.
-GTEST_TEST(VisualizationConfigFunctionsTest, IgnoredLcmBusName) {
-  DrakeLcm drake_lcm;
-  const LcmBuses empty_lcm_buses;
-  DiagramBuilder<double> builder;
-  auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.0);
-  plant.Finalize();
-  VisualizationConfig config;
-  config.lcm_bus = "will_be_ignored";
-  ApplyVisualizationConfig(config, &builder, &empty_lcm_buses, nullptr, nullptr,
-      &drake_lcm);
-  // Guard against any crashes or dangling pointers during diagram construction.
-  builder.Build();
-}
-
 // The AddDefault... sugar shouldn't crash.
 GTEST_TEST(VisualizationConfigFunctionsTest, AddDefault) {
   DiagramBuilder<double> builder;


### PR DESCRIPTION
Towards #18069.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18090)
<!-- Reviewable:end -->
