### PR TITLE
[tools] Force the OpenBLAS CPU when running under TSan

### DIFF
--- a/tools/dynamic_analysis/bazel.rc
+++ b/tools/dynamic_analysis/bazel.rc
@@ -140,6 +140,7 @@ build:tsan --noforce_pic
 build:tsan --linkopt -fsanitize=thread
 build:tsan --run_under=//tools/dynamic_analysis:tsan
 build:tsan --test_env=TSAN_OPTIONS
+build:tsan --test_env=OPENBLAS_CORETYPE=CORE2
 build:tsan --test_tag_filters=-gurobi,-mosek,-snopt,-no_tsan
 build:tsan --test_lang_filters=-sh,-py
 # Typical slowdown introduced by ThreadSanitizer is about 5x-15x
@@ -165,6 +166,7 @@ build:tsan_everything --linkopt -fsanitize=thread
 build:tsan_everything --test_tag_filters=-no_tsan
 build:tsan_everything --run_under=//tools/dynamic_analysis:tsan
 build:tsan_everything --test_env=TSAN_OPTIONS
+build:tsan_everything --test_env=OPENBLAS_CORETYPE=CORE2
 build:tsan_everything --test_lang_filters=-sh,-py
 # Typical slowdown introduced by ThreadSanitizer is about 5x-15x
 # See https://clang.llvm.org/docs/ThreadSanitizer.html


### PR DESCRIPTION
Drake's Ubuntu 22.04 Jammy prereqs choose OpenBLAS as our libblas.

The OpenBLAS kernels for the auto-detected CPUs these days (SKYLAKE, HASWELL, etc.) cause problems when inter-operating with TSan's memory tracking.

For the TSan builds only, we'll force the CPU detection down to a much older CPU (Core 2). TSan does not appear to fight with those BLAS kernels.

Closes https://github.com/RobotLocomotion/drake/issues/17562.

Note that we do not run TSan tests on macOS, so forcing "Core 2" is of no consequence there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18098)
<!-- Reviewable:end -->
