### PR TITLE
Move Joint::type_name() to their source files

### DIFF
--- a/multibody/tree/ball_rpy_joint.cc
+++ b/multibody/tree/ball_rpy_joint.cc
@@ -9,6 +9,12 @@ namespace drake {
 namespace multibody {
 
 template <typename T>
+const std::string& BallRpyJoint<T>::type_name() const {
+  static const never_destroyed<std::string> name{kTypeName};
+  return name.access();
+}
+
+template <typename T>
 template <typename ToScalar>
 std::unique_ptr<Joint<ToScalar>> BallRpyJoint<T>::TemplatedDoCloneToScalar(
     const internal::MultibodyTree<ToScalar>& tree_clone) const {

--- a/multibody/tree/ball_rpy_joint.h
+++ b/multibody/tree/ball_rpy_joint.h
@@ -71,10 +71,7 @@ class BallRpyJoint final : public Joint<T> {
     DRAKE_THROW_UNLESS(damping >= 0);
   }
 
-  const std::string& type_name() const override {
-    static const never_destroyed<std::string> name{kTypeName};
-    return name.access();
-  }
+  const std::string& type_name() const override;
 
   /// Returns `this` joint's damping constant in N⋅m⋅s. The damping torque
   /// (in N⋅m) is modeled as `τ = -damping⋅ω`, i.e. opposing motion, with ω the

--- a/multibody/tree/planar_joint.cc
+++ b/multibody/tree/planar_joint.cc
@@ -8,6 +8,12 @@ namespace drake {
 namespace multibody {
 
 template <typename T>
+const std::string& PlanarJoint<T>::type_name() const {
+  static const never_destroyed<std::string> name{kTypeName};
+  return name.access();
+}
+
+template <typename T>
 template <typename ToScalar>
 std::unique_ptr<Joint<ToScalar>> PlanarJoint<T>::TemplatedDoCloneToScalar(
     const internal::MultibodyTree<ToScalar>& tree_clone) const {

--- a/multibody/tree/planar_joint.h
+++ b/multibody/tree/planar_joint.h
@@ -74,10 +74,7 @@ class PlanarJoint final : public Joint<T> {
     DRAKE_THROW_UNLESS((damping.array() >= 0).all());
   }
 
-  const std::string& type_name() const final {
-    static const never_destroyed<std::string> name{kTypeName};
-    return name.access();
-  }
+  const std::string& type_name() const final;
 
   /// Returns `this` joint's damping constant in N⋅s/m for the translational
   /// degrees and N⋅m⋅s for the rotational degree. The damping force (in N) is

--- a/multibody/tree/prismatic_joint.cc
+++ b/multibody/tree/prismatic_joint.cc
@@ -37,9 +37,14 @@ PrismaticJoint<T>::PrismaticJoint(
 }
 
 template <typename T>
+const std::string& PrismaticJoint<T>::type_name() const {
+  static const never_destroyed<std::string> name{kTypeName};
+  return name.access();
+}
+
+template <typename T>
 template <typename ToScalar>
-std::unique_ptr<Joint<ToScalar>>
-PrismaticJoint<T>::TemplatedDoCloneToScalar(
+std::unique_ptr<Joint<ToScalar>> PrismaticJoint<T>::TemplatedDoCloneToScalar(
     const internal::MultibodyTree<ToScalar>& tree_clone) const {
   const Frame<ToScalar>& frame_on_parent_body_clone =
       tree_clone.get_variant(this->frame_on_parent());

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -71,10 +71,7 @@ class PrismaticJoint final : public Joint<T> {
       double pos_upper_limit = std::numeric_limits<double>::infinity(),
       double damping = 0);
 
-  const std::string& type_name() const override {
-    static const never_destroyed<std::string> name{kTypeName};
-    return name.access();
-  }
+  const std::string& type_name() const override;
 
   /// Returns the axis of translation for `this` joint as a unit vector.
   /// Since the measures of this axis in either frame F or M are the same (see

--- a/multibody/tree/revolute_joint.cc
+++ b/multibody/tree/revolute_joint.cc
@@ -37,6 +37,12 @@ RevoluteJoint<T>::RevoluteJoint(const std::string& name,
 }
 
 template <typename T>
+const std::string& RevoluteJoint<T>::type_name() const {
+  static const never_destroyed<std::string> name{kTypeName};
+  return name.access();
+}
+
+template <typename T>
 template <typename ToScalar>
 std::unique_ptr<Joint<ToScalar>> RevoluteJoint<T>::TemplatedDoCloneToScalar(
     const internal::MultibodyTree<ToScalar>& tree_clone) const {

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -105,10 +105,7 @@ class RevoluteJoint final : public Joint<T> {
                 double pos_lower_limit, double pos_upper_limit,
                 double damping = 0);
 
-  const std::string& type_name() const override {
-    static const never_destroyed<std::string> name{kTypeName};
-    return name.access();
-  }
+  const std::string& type_name() const override;
 
   /// Returns the axis of revolution of `this` joint as a unit vector.
   /// Since the measures of this axis in either frame F or M are the same (see

--- a/multibody/tree/screw_joint.cc
+++ b/multibody/tree/screw_joint.cc
@@ -38,6 +38,12 @@ ScrewJoint<T>::ScrewJoint(const std::string& name,
 }
 
 template <typename T>
+const std::string& ScrewJoint<T>::type_name() const {
+  static const never_destroyed<std::string> name{kTypeName};
+  return name.access();
+}
+
+template <typename T>
 template <typename ToScalar>
 std::unique_ptr<Joint<ToScalar>> ScrewJoint<T>::TemplatedDoCloneToScalar(
     const internal::MultibodyTree<ToScalar>& tree_clone) const {

--- a/multibody/tree/screw_joint.h
+++ b/multibody/tree/screw_joint.h
@@ -110,10 +110,7 @@ class ScrewJoint final : public Joint<T> {
               double screw_pitch,
               double damping);
 
-  const std::string& type_name() const final {
-    static const never_destroyed<std::string> name{kTypeName};
-    return name.access();
-  }
+  const std::string& type_name() const final;
 
   /// Returns the normalized axis of motion of `this` joint as a unit vector.
   /// Since the measures of this axis in either frame F or M are the same (see

--- a/multibody/tree/universal_joint.cc
+++ b/multibody/tree/universal_joint.cc
@@ -8,6 +8,12 @@ namespace drake {
 namespace multibody {
 
 template <typename T>
+const std::string& UniversalJoint<T>::type_name() const {
+  static const never_destroyed<std::string> name{kTypeName};
+  return name.access();
+}
+
+template <typename T>
 template <typename ToScalar>
 std::unique_ptr<Joint<ToScalar>> UniversalJoint<T>::TemplatedDoCloneToScalar(
     const internal::MultibodyTree<ToScalar>& tree_clone) const {

--- a/multibody/tree/universal_joint.h
+++ b/multibody/tree/universal_joint.h
@@ -87,10 +87,7 @@ class UniversalJoint final : public Joint<T> {
     DRAKE_THROW_UNLESS(damping >= 0);
   }
 
-  const std::string& type_name() const override {
-    static const never_destroyed<std::string> name{kTypeName};
-    return name.access();
-  }
+  const std::string& type_name() const override;
 
   /// Returns `this` joint's damping constant in N⋅m⋅s. The damping torque
   /// (in N⋅m) is modeled as `τᵢ = -damping⋅ωᵢ, i = 1, 2` i.e. opposing motion,

--- a/multibody/tree/weld_joint.cc
+++ b/multibody/tree/weld_joint.cc
@@ -8,6 +8,12 @@ namespace drake {
 namespace multibody {
 
 template <typename T>
+const std::string& WeldJoint<T>::type_name() const {
+  static const never_destroyed<std::string> name{kTypeName};
+  return name.access();
+}
+
+template <typename T>
 template <typename ToScalar>
 std::unique_ptr<Joint<ToScalar>>
 WeldJoint<T>::TemplatedDoCloneToScalar(

--- a/multibody/tree/weld_joint.h
+++ b/multibody/tree/weld_joint.h
@@ -44,10 +44,7 @@ class WeldJoint final : public Joint<T> {
                  VectorX<double>() /* no acc upper limits */),
         X_FM_(X_FM) {}
 
-  const std::string& type_name() const override {
-    static const never_destroyed<std::string> name{kTypeName};
-    return name.access();
-  }
+  const std::string& type_name() const override;
 
   /// Returns the pose X_FM of frame M in F.
   const math::RigidTransform<double>& X_FM() const { return X_FM_; }


### PR DESCRIPTION
Excellent explanation from @rpoyner-tri in #18019:

Because this function body is in a header file and uses static never_destroyed, it in effect creates global storage that could end up having definitions in multiple object files. Having consulted the local C++ experts, we believe that a pure C++ environment could handle this hazard, but that it could potentially cause subtle multiple-definition problems for Drake's python bindings shared libraries. That is, individual libraries might build, but have symbol conflicts when loaded together in a single program.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18101)
<!-- Reviewable:end -->
