### PR TITLE
[framework] Deprecate problematic Event API names, replace with better ones

### DIFF
--- a/bindings/pydrake/multibody/jupyter_widgets.py
+++ b/bindings/pydrake/multibody/jupyter_widgets.py
@@ -201,7 +201,7 @@ def MakeJointSlidersThatPublishOnCallback(
     positions = plant.GetPositions(plant_context)
 
     # Publish once immediately.
-    publishing_system.Publish(publishing_context)
+    publishing_system.ForcedPublish(publishing_context)
     if my_callback:
         my_callback(plant_context)
 

--- a/bindings/pydrake/systems/pyplot_visualizer.py
+++ b/bindings/pydrake/systems/pyplot_visualizer.py
@@ -54,7 +54,7 @@ class PyPlotVisualizer(LeafSystem):
 
         self.set_name('pyplot_visualization')
         self.timestep = draw_period or default_draw_period
-        self.DeclarePeriodicPublish(self.timestep, 0.0)
+        self.DeclarePeriodicPublishNoHandler(self.timestep, 0.0)
 
         if ax is None:
             self.fig = self._plt.figure(facecolor=facecolor, figsize=figsize)

--- a/bindings/pydrake/systems/test/lcm_test.py
+++ b/bindings/pydrake/systems/test/lcm_test.py
@@ -198,7 +198,7 @@ class TestSystemsLcm(unittest.TestCase):
     def _fix_and_publish(self, dut, value):
         context = dut.CreateDefaultContext()
         dut.get_input_port(0).FixValue(context, value)
-        dut.Publish(context)
+        dut.ForcedPublish(context)
 
     def test_publisher(self):
         lcm = DrakeLcm()
@@ -270,7 +270,7 @@ class TestSystemsLcm(unittest.TestCase):
                 publish_period=0.05))
         builder.Connect(source.get_output_port(), publisher.get_input_port())
         diagram = builder.Build()
-        diagram.Publish(diagram.CreateDefaultContext())
+        diagram.ForcedPublish(diagram.CreateDefaultContext())
 
     def test_lcm_scope(self):
         builder = DiagramBuilder()

--- a/bindings/pydrake/systems/test/pyplot_visualizer_test.py
+++ b/bindings/pydrake/systems/test/pyplot_visualizer_test.py
@@ -111,7 +111,7 @@ class TestPyplotVisualizer(unittest.TestCase):
         context = visualizer.AllocateContext()
         for time in times:
             context.SetTime(time)
-            visualizer.Publish(context)
+            visualizer.ForcedPublish(context)
 
         # Check that there are now recorded contexts with matching times.
         visualizer.stop_recording()

--- a/bindings/pydrake/systems/test/test_util_py.cc
+++ b/bindings/pydrake/systems/test/test_util_py.cc
@@ -109,11 +109,11 @@ PYBIND11_MODULE(test_util, m) {
       system.CalcTimeDerivatives(*context, state_dot.get());
     }
     {
-      // Call `CalcDiscreteVariableUpdates` to test
+      // Call `CalcForcedDiscreteVariableUpdate` to test
       // `DoCalcDiscreteVariableUpdates`.
       auto& state = context->get_mutable_discrete_state();
       auto state_copy = state.Clone();
-      system.CalcDiscreteVariableUpdates(*context, state_copy.get());
+      system.CalcForcedDiscreteVariableUpdate(*context, state_copy.get());
 
       // From t=0, return next update time for testing discrete time.
       // If there is an abstract / unrestricted update, this assumes that
@@ -134,7 +134,7 @@ PYBIND11_MODULE(test_util, m) {
         if (is_discrete) {
           auto& state = context->get_mutable_discrete_state();
           auto state_copy = state.Clone();
-          system.CalcDiscreteVariableUpdates(*context, state_copy.get());
+          system.CalcForcedDiscreteVariableUpdate(*context, state_copy.get());
           state.SetFrom(*state_copy);
         } else {
           auto& state = context->get_mutable_continuous_state();

--- a/bindings/pydrake/test/geometry_visualizers_test.py
+++ b/bindings/pydrake/test/geometry_visualizers_test.py
@@ -285,7 +285,7 @@ class TestGeometryVisualizers(unittest.TestCase):
         visualizer.cloud_input_port().FixValue(
           context, AbstractValue.Make(cloud))
         self.assertIsInstance(visualizer.pose_input_port(), InputPort_[T])
-        visualizer.Publish(context)
+        visualizer.ForcedPublish(context)
         visualizer.Delete()
         if T == float:
             ad_visualizer = visualizer.ToAutoDiffXd()

--- a/bindings/pydrake/visualization/_model_visualizer.py
+++ b/bindings/pydrake/visualization/_model_visualizer.py
@@ -239,7 +239,7 @@ class ModelVisualizer:
         # TODO(eric.cousineau): Simplify as part of #13776 (was #10015).
         Simulator(self._diagram).Initialize()
         # Publish draw messages with current state.
-        self._diagram.Publish(self._context)
+        self._diagram.ForcedPublish(self._context)
 
         # Disable the collision geometry at the start; it can be enabled by
         # the checkbox in the meshcat controls.
@@ -269,7 +269,7 @@ class ModelVisualizer:
         elif position is not None:
             self._plant.SetPositions(self._plant_context, position)
             self._sliders.SetPositions(position)
-            self._diagram.Publish(self._context)
+            self._diagram.ForcedPublish(self._context)
 
         assert all([x is None for x in (
             self._builder,
@@ -296,7 +296,7 @@ class ModelVisualizer:
                 time.sleep(1 / 32.0)
                 q = self._sliders.get_output_port().Eval(sliders_context)
                 self._plant.SetPositions(self._plant_context, q)
-                self._diagram.Publish(self._context)
+                self._diagram.ForcedPublish(self._context)
                 if loop_once or self._meshcat.GetButtonClicks(button_name) > 0:
                     return
         except KeyboardInterrupt:

--- a/bindings/pydrake/visualization/test/meldis_test.py
+++ b/bindings/pydrake/visualization/test/meldis_test.py
@@ -75,7 +75,7 @@ class TestMeldis(unittest.TestCase):
             visualizer_params=DrakeVisualizerParams(),
             lcm=lcm)
         context = diagram.CreateDefaultContext()
-        diagram.Publish(context)
+        diagram.ForcedPublish(context)
 
         # The geometry isn't registered until the load is processed.
         self.assertEqual(meshcat.HasPath("/DRAKE_VIEWER"), False)
@@ -102,7 +102,7 @@ class TestMeldis(unittest.TestCase):
                 role=Role.kProximity),
             lcm=lcm)
         context = diagram.CreateDefaultContext()
-        diagram.Publish(context)
+        diagram.ForcedPublish(context)
         lcm.HandleSubscriptions(timeout_millis=0)
         dut._invoke_subscriptions()
 
@@ -138,7 +138,7 @@ class TestMeldis(unittest.TestCase):
         context = diagram.CreateDefaultContext()
         plant.SetPositions(plant.GetMyMutableContextFromRoot(context),
                            [-0.03, 0.03])
-        diagram.Publish(context)
+        diagram.ForcedPublish(context)
 
         # The geometry isn't registered until the load is processed.
         pair_path = "/CONTACT_RESULTS/point/base_link(2)+base_link(3)"
@@ -181,7 +181,7 @@ class TestMeldis(unittest.TestCase):
         context = diagram.CreateDefaultContext()
         plant.SetPositions(plant.GetMyMutableContextFromRoot(context),
                            [0.1, 0.3])
-        diagram.Publish(context)
+        diagram.ForcedPublish(context)
 
         # The geometry isn't registered until the load is processed.
         hydro_path = "/CONTACT_RESULTS/hydroelastic/" + \

--- a/examples/allegro_hand/allegro_lcm.cc
+++ b/examples/allegro_hand/allegro_lcm.cc
@@ -35,7 +35,7 @@ AllegroCommandReceiver::AllegroCommandReceiver(int num_joints,
                 this->CopyStateToOutput(c, num_joints_ * 2, num_joints_, o);
               })
           .get_index();
-  this->DeclarePeriodicDiscreteUpdate(lcm_period_);
+  this->DeclarePeriodicDiscreteUpdateNoHandler(lcm_period_);
   // State + torque
   this->DeclareDiscreteState(num_joints_ * 3);
 }

--- a/examples/allegro_hand/allegro_lcm.cc
+++ b/examples/allegro_hand/allegro_lcm.cc
@@ -35,7 +35,8 @@ AllegroCommandReceiver::AllegroCommandReceiver(int num_joints,
                 this->CopyStateToOutput(c, num_joints_ * 2, num_joints_, o);
               })
           .get_index();
-  this->DeclarePeriodicDiscreteUpdateNoHandler(lcm_period_);
+  this->DeclarePeriodicDiscreteUpdateEvent(
+      lcm_period_, 0.0, &AllegroCommandReceiver::UpdateDiscreteVariables);
   // State + torque
   this->DeclareDiscreteState(num_joints_ * 3);
 }
@@ -49,9 +50,8 @@ void AllegroCommandReceiver::set_initial_position(
   state_value.head(num_joints_) = x;
 }
 
-void AllegroCommandReceiver::DoCalcDiscreteVariableUpdates(
+void AllegroCommandReceiver::UpdateDiscreteVariables(
     const Context<double>& context,
-    const std::vector<const DiscreteUpdateEvent<double>*>&,
     DiscreteValues<double>* discrete_state) const {
   const AbstractValue* input = this->EvalAbstractInput(context, 0);
   DRAKE_ASSERT(input != nullptr);

--- a/examples/allegro_hand/allegro_lcm.h
+++ b/examples/allegro_hand/allegro_lcm.h
@@ -69,12 +69,10 @@ class AllegroCommandReceiver : public systems::LeafSystem<double> {
                          int length,
                          systems::BasicVector<double>* output) const;
 
-  void DoCalcDiscreteVariableUpdates(
+  void UpdateDiscreteVariables(
       const systems::Context<double>& context,
-      const std::vector<const systems::DiscreteUpdateEvent<double>*>&,
-      systems::DiscreteValues<double>* discrete_state) const override;
+      systems::DiscreteValues<double>* discrete_state) const;
 
- private:
   int state_output_port_ = 0;
   int torque_output_port_ = 0;
   const int num_joints_ = 16;

--- a/examples/allegro_hand/test/allegro_lcm_test.cc
+++ b/examples/allegro_hand/test/allegro_lcm_test.cc
@@ -59,7 +59,7 @@ GTEST_TEST(AllegroLcmTest, AllegroCommandReceiver) {
   std::unique_ptr<systems::DiscreteValues<double>> update =
       dut.AllocateDiscreteVariables();
   update->SetFrom(context->get_mutable_discrete_state());
-  dut.CalcDiscreteVariableUpdates(*context, update.get());
+  dut.CalcForcedDiscreteVariableUpdate(*context, update.get());
   context->get_mutable_discrete_state().SetFrom(*update);
 
   dut.CalcOutput(*context, output.get());

--- a/examples/allegro_hand/test/allegro_lcm_test.cc
+++ b/examples/allegro_hand/test/allegro_lcm_test.cc
@@ -56,11 +56,8 @@ GTEST_TEST(AllegroLcmTest, AllegroCommandReceiver) {
 
   dut.get_input_port(0).FixValue(context.get(), command);
 
-  std::unique_ptr<systems::DiscreteValues<double>> update =
-      dut.AllocateDiscreteVariables();
-  update->SetFrom(context->get_mutable_discrete_state());
-  dut.CalcForcedDiscreteVariableUpdate(*context, update.get());
-  context->get_mutable_discrete_state().SetFrom(*update);
+  // Manually trigger the discrete update event.
+  context->SetDiscreteState(dut.EvalUniquePeriodicDiscreteUpdate(*context));
 
   dut.CalcOutput(*context, output.get());
   EXPECT_TRUE(CompareMatrices(

--- a/examples/kinova_jaco_arm/jaco_controller.cc
+++ b/examples/kinova_jaco_arm/jaco_controller.cc
@@ -189,7 +189,7 @@ int DoMain() {
     simulator.AdvanceTo(time);
     // Force-publish the lcmt_jaco_command (via the command_pub system within
     // the diagram).
-    diagram->Publish(diagram_context);
+    diagram->ForcedPublish(diagram_context);
   }
 
   // We should never reach here.

--- a/examples/kuka_iiwa_arm/iiwa_controller.cc
+++ b/examples/kuka_iiwa_arm/iiwa_controller.cc
@@ -140,7 +140,7 @@ int DoMain() {
     simulator.AdvanceTo(time);
     // Force-publish the lcmt_iiwa_command (via the command_pub system within
     // the diagram).
-    diagram.Publish(diagram_context);
+    diagram.ForcedPublish(diagram_context);
   }
 
   // We should never reach here.

--- a/examples/manipulation_station/end_effector_teleop_dualshock4.py
+++ b/examples/manipulation_station/end_effector_teleop_dualshock4.py
@@ -171,7 +171,7 @@ class DualShock4Teleop(LeafSystem):
 
         # Note: This timing affects the keyboard teleop performance. A larger
         #       time step causes more lag in the response.
-        self.DeclarePeriodicPublish(1.0, 0.0)
+        self.DeclarePeriodicPublishNoHandler(1.0, 0.0)
 
         self.teleop_manager = TeleopDualShock4Manager(joystick)
         self.roll = self.pitch = self.yaw = 0

--- a/examples/manipulation_station/end_effector_teleop_mouse.py
+++ b/examples/manipulation_station/end_effector_teleop_mouse.py
@@ -142,7 +142,7 @@ class MouseKeyboardTeleop(LeafSystem):
 
         # Note: This timing affects the keyboard teleop performance. A larger
         #       time step causes more lag in the response.
-        self.DeclarePeriodicPublish(0.01, 0.0)
+        self.DeclarePeriodicPublishNoHandler(0.01, 0.0)
 
         self.teleop_manager = TeleopMouseKeyboardManager(grab_focus=grab_focus)
         self.roll = self.pitch = self.yaw = 0

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -269,7 +269,7 @@ GTEST_TEST(ManipulationStationTest, CheckDynamics) {
                   .isZero());
 
   auto next_state = station.AllocateDiscreteVariables();
-  station.CalcDiscreteVariableUpdates(*context, next_state.get());
+  station.CalcForcedDiscreteVariableUpdate(*context, next_state.get());
 
   // Check that vdot ≈ 0 by checking that next velocity ≈ velocity.
   const auto& base_joint =

--- a/examples/planar_gripper/run_planar_gripper_trajectory_publisher.cc
+++ b/examples/planar_gripper/run_planar_gripper_trajectory_publisher.cc
@@ -151,7 +151,7 @@ int DoMain() {
     simulator.AdvanceTo(time);
     // Force-publish the lcmt_planar_gripper_command (via the command_pub system
     // within the diagram).
-    diagram->Publish(diagram_context);
+    diagram->ForcedPublish(diagram_context);
   }
 
   // We should never reach here.

--- a/examples/planar_gripper/test/planar_gripper_lcm_test.cc
+++ b/examples/planar_gripper/test/planar_gripper_lcm_test.cc
@@ -50,7 +50,7 @@ GTEST_TEST(GripperLcmTest, GripperCommandPassthroughTest) {
   std::unique_ptr<systems::DiscreteValues<double>> update =
       diagram->AllocateDiscreteVariables();
   update->SetFrom(context->get_mutable_discrete_state());
-  diagram->CalcDiscreteVariableUpdates(*context, update.get());
+  diagram->CalcForcedDiscreteVariableUpdate(*context, update.get());
   context->get_mutable_discrete_state().SetFrom(*update);
 
   lcmt_planar_gripper_command command_out =
@@ -103,7 +103,7 @@ GTEST_TEST(GripperLcmTest, GripperStatusPassthroughTest) {
   std::unique_ptr<systems::DiscreteValues<double>> update =
       diagram->AllocateDiscreteVariables();
   update->SetFrom(context->get_mutable_discrete_state());
-  diagram->CalcDiscreteVariableUpdates(*context, update.get());
+  diagram->CalcForcedDiscreteVariableUpdate(*context, update.get());
   context->get_mutable_discrete_state().SetFrom(*update);
 
   lcmt_planar_gripper_status status_out =

--- a/examples/planar_gripper/test/planar_manipuland_lcm_test.cc
+++ b/examples/planar_gripper/test/planar_manipuland_lcm_test.cc
@@ -36,7 +36,7 @@ GTEST_TEST(PlanarManipulandLcmTest, PlanarManipulandStatusPassthroughTest) {
   std::unique_ptr<systems::DiscreteValues<double>> update =
       diagram->AllocateDiscreteVariables();
   update->SetFrom(context->get_mutable_discrete_state());
-  diagram->CalcDiscreteVariableUpdates(*context, update.get());
+  diagram->CalcForcedDiscreteVariableUpdate(*context, update.get());
   context->get_mutable_discrete_state().SetFrom(*update);
   diagram->CalcOutput(*context, output.get());
 

--- a/examples/rod2d/rod2d.cc
+++ b/examples/rod2d/rod2d.cc
@@ -30,7 +30,7 @@ Rod2D<T>::Rod2D(SystemType system_type, double dt)
 
     // Discretization approach requires three position variables and
     // three velocity variables, all discrete, and periodic update.
-    this->DeclarePeriodicDiscreteUpdate(dt);
+    this->DeclarePeriodicDiscreteUpdateNoHandler(dt);
     auto state_index = this->DeclareDiscreteState(6);
     state_output_port_ = &this->DeclareStateOutputPort(
         "state_output", state_index);

--- a/geometry/test/drake_visualizer_test.cc
+++ b/geometry/test/drake_visualizer_test.cc
@@ -674,7 +674,7 @@ TYPED_TEST(DrakeVisualizerTest, ForcePublish) {
   this->PopulateScene();
   auto context = this->diagram_->CreateDefaultContext();
   const auto& vis_context = this->visualizer_->GetMyContextFromRoot(*context);
-  this->visualizer_->Publish(vis_context);
+  this->visualizer_->ForcedPublish(vis_context);
 
   /* Confirm that messages were sent.  */
   MessageResults results = this->ProcessMessages();
@@ -875,7 +875,7 @@ TYPED_TEST(DrakeVisualizerTest, VisualizeDeformableGeometry) {
   /* Dispatch a load message. */
   auto context = this->diagram_->CreateDefaultContext();
   const auto& vis_context = this->visualizer_->GetMyContextFromRoot(*context);
-  this->visualizer_->Publish(vis_context);
+  this->visualizer_->ForcedPublish(vis_context);
 
   /* Confirm that messages were sent.  */
   MessageResults results = this->ProcessMessages();
@@ -985,7 +985,7 @@ TYPED_TEST(DrakeVisualizerTest, VisualizeHydroGeometry) {
   /* Dispatch a load message. */
   auto context = this->diagram_->CreateDefaultContext();
   const auto& vis_context = this->visualizer_->GetMyContextFromRoot(*context);
-  this->visualizer_->Publish(vis_context);
+  this->visualizer_->ForcedPublish(vis_context);
 
   /* Confirm that messages were sent.  */
   MessageResults results = this->ProcessMessages(params.role);

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -288,7 +288,7 @@ Open up your browser to the URL above.
 
     plant.SetPositions(&plant.GetMyMutableContextFromRoot(context.get()),
                        Eigen::Vector2d{0.1, 0.3});
-    diagram->Publish(*context);
+    diagram->ForcedPublish(*context);
     std::cout << "- Now you should see three colliding hydroelastic spheres."
               << std::endl;
     std::cout << "[Press RETURN to continue]." << std::endl;
@@ -330,7 +330,7 @@ Open up your browser to the URL above.
     auto context = diagram->CreateDefaultContext();
     diagram->get_input_port().FixValue(context.get(), Eigen::VectorXd::Zero(7));
 
-    diagram->Publish(*context);
+    diagram->ForcedPublish(*context);
     std::cout
         << "- Now you should see a kuka model (from MultibodyPlant/SceneGraph)"
         << std::endl;

--- a/geometry/test/meshcat_point_cloud_visualizer_test.cc
+++ b/geometry/test/meshcat_point_cloud_visualizer_test.cc
@@ -60,7 +60,7 @@ TEST_F(MeshcatPointCloudVisualizerTest, Publish) {
 
   EXPECT_TRUE(meshcat_->GetPackedObject("cloud").empty());
   EXPECT_TRUE(meshcat_->GetPackedTransform("cloud").empty());
-  diagram_->Publish(*context_);
+  diagram_->ForcedPublish(*context_);
   EXPECT_FALSE(meshcat_->GetPackedObject("cloud").empty());
   EXPECT_FALSE(meshcat_->GetPackedTransform("cloud").empty());
 }
@@ -70,7 +70,7 @@ TEST_F(MeshcatPointCloudVisualizerTest, NoPose) {
 
   EXPECT_TRUE(meshcat_->GetPackedObject("cloud").empty());
   EXPECT_TRUE(meshcat_->GetPackedTransform("cloud").empty());
-  diagram_->Publish(*context_);
+  diagram_->ForcedPublish(*context_);
   EXPECT_FALSE(meshcat_->GetPackedObject("cloud").empty());
   // It still publishes a transform; but it publishes the identity.
   EXPECT_FALSE(meshcat_->GetPackedTransform("cloud").empty());
@@ -91,7 +91,7 @@ TEST_F(MeshcatPointCloudVisualizerTest, PublishPeriod) {
 TEST_F(MeshcatPointCloudVisualizerTest, Delete) {
   SetUpDiagram();
 
-  diagram_->Publish(*context_);
+  diagram_->ForcedPublish(*context_);
   EXPECT_FALSE(meshcat_->GetPackedObject("cloud").empty());
 
   visualizer_->Delete();
@@ -115,7 +115,7 @@ TEST_F(MeshcatPointCloudVisualizerTest, ScalarConversion) {
 
   // Call publish to provide code coverage for the AutoDiffXd version of
   // UpdateMeshcat.  We simply confirm that the code doesn't blow up.
-  ad_diagram->Publish(*ad_context);
+  ad_diagram->ForcedPublish(*ad_context);
 }
 
 

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -71,7 +71,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, BasicTest) {
   SetUpDiagram();
 
   EXPECT_FALSE(meshcat_->HasPath("/drake/visualizer/iiwa14"));
-  diagram_->Publish(*context_);
+  diagram_->ForcedPublish(*context_);
   EXPECT_TRUE(meshcat_->HasPath("/drake/visualizer/iiwa14"));
   for (int link = 0; link < 8; link++) {
     EXPECT_NE(meshcat_->GetPackedTransform(
@@ -108,7 +108,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Roles) {
     params.role = role;
     SetUpDiagram(params);
     EXPECT_FALSE(meshcat_->HasPath("visualizer/iiwa14/iiwa_link_7"));
-    diagram_->Publish(*context_);
+    diagram_->ForcedPublish(*context_);
     EXPECT_TRUE(meshcat_->HasPath("visualizer/iiwa14/iiwa_link_7"));
     auto& inspector = scene_graph_->model_inspector();
     FrameId iiwa_link_7 = plant_->GetBodyFrameIdOrThrow(
@@ -132,7 +132,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Prefix) {
   params.prefix = "/foo";
   SetUpDiagram(params);
   EXPECT_FALSE(meshcat_->HasPath("/foo/iiwa14"));
-  diagram_->Publish(*context_);
+  diagram_->ForcedPublish(*context_);
   EXPECT_TRUE(meshcat_->HasPath("/foo/iiwa14"));
   EXPECT_FALSE(meshcat_->HasPath("/drake/visualizer"));
 
@@ -140,7 +140,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Prefix) {
   params.prefix = "foo";
   EXPECT_FALSE(meshcat_->HasPath("/drake/foo/iiwa14"));
   SetUpDiagram(params);
-  diagram_->Publish(*context_);
+  diagram_->ForcedPublish(*context_);
   EXPECT_TRUE(meshcat_->HasPath("/drake/foo/iiwa14"));
   EXPECT_FALSE(meshcat_->HasPath("/drake/visualizer"));
 }
@@ -178,7 +178,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, DeletePrefixOnInitialization) {
 
 TEST_F(MeshcatVisualizerWithIiwaTest, Delete) {
   SetUpDiagram();
-  diagram_->Publish(*context_);
+  diagram_->ForcedPublish(*context_);
   EXPECT_TRUE(meshcat_->HasPath("/drake/visualizer"));
   visualizer_->Delete();
   EXPECT_FALSE(meshcat_->HasPath("/drake/visualizer"));
@@ -201,12 +201,12 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Recording) {
 
   // Publish once without recording and confirm that we don't have the iiwa
   // frame.
-  diagram_->Publish(*context_);
+  diagram_->ForcedPublish(*context_);
   EXPECT_FALSE(has_iiwa_frame(*animation, 0));
 
   // Publish again *with* recording and confirm that we do now have the frame.
   visualizer_->StartRecording();
-  diagram_->Publish(*context_);
+  diagram_->ForcedPublish(*context_);
   EXPECT_TRUE(has_iiwa_frame(*animation, 0));
 
   // Deleting the recording removes that frame.
@@ -215,7 +215,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Recording) {
   EXPECT_FALSE(has_iiwa_frame(*animation, 0));
 
   // We are still recording, so publish *will* add it.
-  diagram_->Publish(*context_);
+  diagram_->ForcedPublish(*context_);
   EXPECT_TRUE(has_iiwa_frame(*animation, 0));
 
   // But if we stop recording, then it's not added.
@@ -223,14 +223,14 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Recording) {
   visualizer_->DeleteRecording();
   animation = visualizer_->get_mutable_recording();
   EXPECT_FALSE(has_iiwa_frame(*animation, 0));
-  diagram_->Publish(*context_);
+  diagram_->ForcedPublish(*context_);
   EXPECT_FALSE(has_iiwa_frame(*animation, 0));
 
   // Now publish a time 0.0 and time = 1.0 and confirm we have the frames.
   animation = visualizer_->StartRecording();
-  diagram_->Publish(*context_);
+  diagram_->ForcedPublish(*context_);
   context_->SetTime(1.0);
-  diagram_->Publish(*context_);
+  diagram_->ForcedPublish(*context_);
   EXPECT_TRUE(has_iiwa_frame(*animation, 0));
   EXPECT_TRUE(
       has_iiwa_frame(*animation, std::floor(1.0 / params.publish_period)));
@@ -242,7 +242,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Recording) {
 
 TEST_F(MeshcatVisualizerWithIiwaTest, RecordingWithoutSetTransform) {
   SetUpDiagram();
-  diagram_->Publish(*context_);
+  diagram_->ForcedPublish(*context_);
   std::string X_7_message =
       meshcat_->GetPackedTransform("/drake/visualizer/iiwa14/iiwa_link_7");
 
@@ -253,7 +253,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, RecordingWithoutSetTransform) {
   bool set_transforms_while_recording = false;
   visualizer_->StartRecording(set_transforms_while_recording);
   // This publish should *not* change the transform in the Meshcat scene tree.
-  diagram_->Publish(*context_);
+  diagram_->ForcedPublish(*context_);
   EXPECT_EQ(
       meshcat_->GetPackedTransform("/drake/visualizer/iiwa14/iiwa_link_7"),
       X_7_message);
@@ -261,7 +261,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, RecordingWithoutSetTransform) {
   set_transforms_while_recording = true;
   visualizer_->StartRecording(set_transforms_while_recording);
   // This publish *should* change the transform in the Meshcat scene tree.
-  diagram_->Publish(*context_);
+  diagram_->ForcedPublish(*context_);
   EXPECT_NE(
       meshcat_->GetPackedTransform("/drake/visualizer/iiwa14/iiwa_link_7"),
       X_7_message);
@@ -276,7 +276,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, ScalarConversion) {
   // Call publish to provide code coverage for the AutoDiffXd version of
   // UpdateMeshcat / SetObjects SetTransforms.  We simply confirm that the code
   // doesn't blow up.
-  ad_diagram->Publish(*ad_context);
+  ad_diagram->ForcedPublish(*ad_context);
 }
 
 GTEST_TEST(MeshcatVisualizerTest, MultipleModels) {
@@ -313,7 +313,7 @@ GTEST_TEST(MeshcatVisualizerTest, MultipleModels) {
   EXPECT_FALSE(meshcat->HasPath("/drake/visualizer/iiwa14"));
   EXPECT_FALSE(meshcat->HasPath("/drake/visualizer/second_iiwa"));
 
-  diagram->Publish(*context);
+  diagram->ForcedPublish(*context);
 
   EXPECT_TRUE(meshcat->HasPath("/drake/visualizer/iiwa14"));
   EXPECT_TRUE(meshcat->HasPath("/drake/visualizer/second_iiwa"));

--- a/manipulation/models/realsense2_description/test/realsense_parse_test.cc
+++ b/manipulation/models/realsense2_description/test/realsense_parse_test.cc
@@ -69,7 +69,7 @@ TEST_P(ParseTest, ParsesUrdfAndVisualizes) {
     drake::log()->info("Visualize: {}", object_name);
     Simulator<double> simulator(*diagram);
     simulator.Initialize();
-    diagram->Publish(simulator.get_context());
+    diagram->ForcedPublish(simulator.get_context());
   }
 }
 

--- a/manipulation/models/ycb/test/parse_test.cc
+++ b/manipulation/models/ycb/test/parse_test.cc
@@ -91,7 +91,7 @@ TEST_P(ParseTest, Quantities) {
   // Display the object; optionally wait for user input.
   drake::log()->info("Visualize: {}", object_name);
   auto context = diagram->CreateDefaultContext();
-  diagram->Publish(*context);
+  diagram->ForcedPublish(*context);
   if (FLAGS_pause) {
     WaitForNextButtonClick();
   }

--- a/manipulation/planner/robot_plan_interpolator.cc
+++ b/manipulation/planner/robot_plan_interpolator.cc
@@ -93,19 +93,11 @@ RobotPlanInterpolator::RobotPlanInterpolator(
   // Flag indicating whether RobotPlanInterpolator::Initialize has been called.
   init_flag_index_ = this->DeclareAbstractState(Value<bool>(false));
 
-  this->DeclarePeriodicUnrestrictedUpdateNoHandler(update_interval, 0);
+  this->DeclarePeriodicUnrestrictedUpdateEvent(
+      update_interval, 0, &RobotPlanInterpolator::UpdatePlanOnNewMessage);
 }
 
 RobotPlanInterpolator::~RobotPlanInterpolator() {}
-
-void RobotPlanInterpolator::SetDefaultState(
-    const systems::Context<double>&,
-    systems::State<double>* state) const {
-  PlanData& plan =
-      state->get_mutable_abstract_state<PlanData>(plan_index_);
-  plan = PlanData();
-  state->get_mutable_abstract_state<bool>(init_flag_index_) = false;
-}
 
 void RobotPlanInterpolator::OutputState(const systems::Context<double>& context,
                                   systems::BasicVector<double>* output) const {
@@ -167,9 +159,8 @@ void RobotPlanInterpolator::Initialize(double plan_start_time,
   state->get_mutable_abstract_state<bool>(init_flag_index_) = true;
 }
 
-void RobotPlanInterpolator::DoCalcUnrestrictedUpdate(
+systems::EventStatus RobotPlanInterpolator::UpdatePlanOnNewMessage(
     const systems::Context<double>& context,
-    const std::vector<const systems::UnrestrictedUpdateEvent<double>*>&,
     systems::State<double>* state) const {
   PlanData& plan =
       state->get_mutable_abstract_state<PlanData>(plan_index_);
@@ -181,63 +172,67 @@ void RobotPlanInterpolator::DoCalcUnrestrictedUpdate(
   // this is the best I've got.
   std::vector<char> encoded_msg(plan_input.getEncodedSize());
   plan_input.encode(encoded_msg.data(), 0, encoded_msg.size());
-  if (encoded_msg != plan.encoded_msg) {
-    plan.encoded_msg.swap(encoded_msg);
-    if (plan_input.num_states == 0) {
-      // The plan is empty.  Encode a plan for the current planned position.
-      const double current_plan_time = context.get_time() - plan.start_time;
-      MakeFixedPlan(context.get_time(),
-                    plan.pp.value(current_plan_time),
-                    state);
-    } else if (plan_input.num_states == 1) {
-      drake::log()->info("Ignoring plan with only one knot point.");
-    } else {
-      plan.start_time = context.get_time();
-      std::vector<Eigen::MatrixXd> knots(
-          plan_input.num_states,
-          Eigen::MatrixXd::Zero(plant_.num_positions(), 1));
-      for (int i = 0; i < plan_input.num_states; ++i) {
-        const auto& plan_state = plan_input.plan[i];
-        for (int j = 0; j < plan_state.num_joints; ++j) {
-          if (!plant_.HasJointNamed(plan_state.joint_name[j])) {
-            continue;
-          }
-          const auto joint_index = plant_.GetJointByName(
-              plan_state.joint_name[j]).position_start();
-          knots[i](joint_index, 0) = plan_state.joint_position[j];
-        }
-      }
-
-      std::vector<double> input_time;
-      for (int k = 0; k < static_cast<int>(plan_input.plan.size()); ++k) {
-        input_time.push_back(plan_input.plan[k].utime / 1e6);
-      }
-
-      const Eigen::MatrixXd knot_dot =
-          Eigen::MatrixXd::Zero(plant_.num_velocities(), 1);
-      switch (interp_type_) {
-        case InterpolatorType::ZeroOrderHold :
-          plan.pp = PiecewisePolynomial<double>::ZeroOrderHold(
-              input_time, knots);
-          break;
-        case InterpolatorType::FirstOrderHold :
-          plan.pp = PiecewisePolynomial<double>::FirstOrderHold(
-              input_time, knots);
-          break;
-        case InterpolatorType::Pchip :
-          plan.pp = PiecewisePolynomial<double>::CubicShapePreserving(
-              input_time, knots, true);
-          break;
-        case InterpolatorType::Cubic :
-          plan.pp =
-              PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
-                  input_time, knots, knot_dot, knot_dot);
-          break;
-      }
-      plan.pp_deriv = plan.pp.derivative();
-      plan.pp_double_deriv = plan.pp_deriv.derivative();
-    }
+  if (encoded_msg == plan.encoded_msg) {
+    return systems::EventStatus::DidNothing();
   }
+
+  plan.encoded_msg.swap(encoded_msg);
+  if (plan_input.num_states == 0) {
+    // The plan is empty.  Encode a plan for the current planned position.
+    const double current_plan_time = context.get_time() - plan.start_time;
+    MakeFixedPlan(context.get_time(),
+                  plan.pp.value(current_plan_time),
+                  state);
+  } else if (plan_input.num_states == 1) {
+    drake::log()->info("Ignoring plan with only one knot point.");
+  } else {
+    plan.start_time = context.get_time();
+    std::vector<Eigen::MatrixXd> knots(
+        plan_input.num_states,
+        Eigen::MatrixXd::Zero(plant_.num_positions(), 1));
+    for (int i = 0; i < plan_input.num_states; ++i) {
+      const auto& plan_state = plan_input.plan[i];
+      for (int j = 0; j < plan_state.num_joints; ++j) {
+        if (!plant_.HasJointNamed(plan_state.joint_name[j])) {
+          continue;
+        }
+        const auto joint_index = plant_.GetJointByName(
+            plan_state.joint_name[j]).position_start();
+        knots[i](joint_index, 0) = plan_state.joint_position[j];
+      }
+    }
+
+    std::vector<double> input_time;
+    for (int k = 0; k < static_cast<int>(plan_input.plan.size()); ++k) {
+      input_time.push_back(plan_input.plan[k].utime / 1e6);
+    }
+
+    const Eigen::MatrixXd knot_dot =
+        Eigen::MatrixXd::Zero(plant_.num_velocities(), 1);
+    switch (interp_type_) {
+      case InterpolatorType::ZeroOrderHold :
+        plan.pp = PiecewisePolynomial<double>::ZeroOrderHold(
+            input_time, knots);
+        break;
+      case InterpolatorType::FirstOrderHold :
+        plan.pp = PiecewisePolynomial<double>::FirstOrderHold(
+            input_time, knots);
+        break;
+      case InterpolatorType::Pchip :
+        plan.pp = PiecewisePolynomial<double>::CubicShapePreserving(
+            input_time, knots, true);
+        break;
+      case InterpolatorType::Cubic :
+        plan.pp =
+            PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+                input_time, knots, knot_dot, knot_dot);
+        break;
+    }
+    plan.pp_deriv = plan.pp.derivative();
+    plan.pp_double_deriv = plan.pp_deriv.derivative();
+  }
+
+  return systems::EventStatus::Succeeded();
 }
 
 }  // namespace planner

--- a/manipulation/planner/robot_plan_interpolator.cc
+++ b/manipulation/planner/robot_plan_interpolator.cc
@@ -93,7 +93,7 @@ RobotPlanInterpolator::RobotPlanInterpolator(
   // Flag indicating whether RobotPlanInterpolator::Initialize has been called.
   init_flag_index_ = this->DeclareAbstractState(Value<bool>(false));
 
-  this->DeclarePeriodicUnrestrictedUpdate(update_interval, 0);
+  this->DeclarePeriodicUnrestrictedUpdateNoHandler(update_interval, 0);
 }
 
 RobotPlanInterpolator::~RobotPlanInterpolator() {}

--- a/manipulation/planner/robot_plan_interpolator.h
+++ b/manipulation/planner/robot_plan_interpolator.h
@@ -73,18 +73,24 @@ class RobotPlanInterpolator : public systems::LeafSystem<double> {
   void Initialize(double plan_start_time, const VectorX<double>& q0,
                   systems::State<double>* state) const;
 
+  /**
+   * Updates the plan if there is a new message on the input port.
+   * Normally this is done automatically by a Simulator; here we invoke
+   * the same periodic event handler that the Simulator would use.
+   */
+  void UpdatePlan(systems::Context<double>* context) const {
+    UpdatePlanOnNewMessage(*context, &context->get_mutable_state());
+  }
+
   const multibody::MultibodyPlant<double>& plant() { return plant_; }
-
- protected:
-  void SetDefaultState(const systems::Context<double>& context,
-                       systems::State<double>* state) const override;
-
-  void DoCalcUnrestrictedUpdate(const systems::Context<double>& context,
-            const std::vector<const systems::UnrestrictedUpdateEvent<double>*>&,
-            systems::State<double>* state) const override;
 
  private:
   struct PlanData;
+
+  // Updates plan when a new message arrives.
+  systems::EventStatus UpdatePlanOnNewMessage(
+      const systems::Context<double>& context,
+      systems::State<double>* state) const;
 
   // Calculator method for the state output port.
   void OutputState(const systems::Context<double>& context,

--- a/manipulation/planner/test/robot_plan_interpolator_test.cc
+++ b/manipulation/planner/test/robot_plan_interpolator_test.cc
@@ -113,7 +113,7 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
   dut.Initialize(0, Eigen::VectorXd::Zero(kNumJoints),
                  &context->get_mutable_state());
 
-  dut.CalcUnrestrictedUpdate(*context, &context->get_mutable_state());
+  dut.CalcForcedUnrestrictedUpdate(*context, &context->get_mutable_state());
 
   // Test we're running the plan through time by watching the
   // positions, velocities, and acceleration change.
@@ -152,7 +152,7 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
 
   for (const TrajectoryTestCase& kase : cases) {
     context->SetTime(kase.time);
-    dut.CalcUnrestrictedUpdate(*context, &context->get_mutable_state());
+    dut.CalcForcedUnrestrictedUpdate(*context, &context->get_mutable_state());
     dut.CalcOutput(*context, output.get());
     const double position =
         output->get_vector_data(dut.get_state_output_port().get_index())
@@ -178,7 +178,7 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
       interp_type == InterpolatorType::ZeroOrderHold ||
       interp_type == InterpolatorType::Pchip) {
     context->SetTime(t.back() + 0.01);
-    dut.CalcUnrestrictedUpdate(*context, &context->get_mutable_state());
+    dut.CalcForcedUnrestrictedUpdate(*context, &context->get_mutable_state());
     dut.CalcOutput(*context, output.get());
     const double velocity =
         output->get_vector_data(dut.get_state_output_port().get_index())
@@ -195,7 +195,7 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
   // Check that sending an empty plan causes us to continue to output
   // the same commanded position.
   context->SetTime(1);
-  dut.CalcUnrestrictedUpdate(*context, &context->get_mutable_state());
+  dut.CalcForcedUnrestrictedUpdate(*context, &context->get_mutable_state());
   dut.CalcOutput(*context, output.get());
   double position =
       output->get_vector_data(dut.get_state_output_port().get_index())
@@ -206,7 +206,7 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
   plan.num_states = 0;
   plan.plan.clear();
   dut.get_plan_input_port().FixValue(context.get(), plan);
-  dut.CalcUnrestrictedUpdate(*context, &context->get_mutable_state());
+  dut.CalcForcedUnrestrictedUpdate(*context, &context->get_mutable_state());
   dut.CalcOutput(*context, output.get());
   position = output->get_vector_data(
       dut.get_state_output_port().get_index())->GetAtIndex(0);

--- a/manipulation/planner/test/robot_plan_interpolator_test.cc
+++ b/manipulation/planner/test/robot_plan_interpolator_test.cc
@@ -113,7 +113,7 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
   dut.Initialize(0, Eigen::VectorXd::Zero(kNumJoints),
                  &context->get_mutable_state());
 
-  dut.CalcForcedUnrestrictedUpdate(*context, &context->get_mutable_state());
+  dut.UpdatePlan(context.get());
 
   // Test we're running the plan through time by watching the
   // positions, velocities, and acceleration change.
@@ -152,7 +152,7 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
 
   for (const TrajectoryTestCase& kase : cases) {
     context->SetTime(kase.time);
-    dut.CalcForcedUnrestrictedUpdate(*context, &context->get_mutable_state());
+    dut.UpdatePlan(context.get());
     dut.CalcOutput(*context, output.get());
     const double position =
         output->get_vector_data(dut.get_state_output_port().get_index())
@@ -178,7 +178,7 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
       interp_type == InterpolatorType::ZeroOrderHold ||
       interp_type == InterpolatorType::Pchip) {
     context->SetTime(t.back() + 0.01);
-    dut.CalcForcedUnrestrictedUpdate(*context, &context->get_mutable_state());
+    dut.UpdatePlan(context.get());
     dut.CalcOutput(*context, output.get());
     const double velocity =
         output->get_vector_data(dut.get_state_output_port().get_index())
@@ -195,7 +195,7 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
   // Check that sending an empty plan causes us to continue to output
   // the same commanded position.
   context->SetTime(1);
-  dut.CalcForcedUnrestrictedUpdate(*context, &context->get_mutable_state());
+  dut.UpdatePlan(context.get());
   dut.CalcOutput(*context, output.get());
   double position =
       output->get_vector_data(dut.get_state_output_port().get_index())
@@ -206,7 +206,7 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
   plan.num_states = 0;
   plan.plan.clear();
   dut.get_plan_input_port().FixValue(context.get(), plan);
-  dut.CalcForcedUnrestrictedUpdate(*context, &context->get_mutable_state());
+  dut.UpdatePlan(context.get());
   dut.CalcOutput(*context, output.get());
   position = output->get_vector_data(
       dut.get_state_output_port().get_index())->GetAtIndex(0);

--- a/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.cc
@@ -33,7 +33,7 @@ SchunkWsgTrajectoryGenerator::SchunkWsgTrajectoryGenerator(int input_size,
       SchunkWsgTrajectoryGeneratorStateVector<double>());
   // The update period below matches the polling rate from
   // drake-schunk-driver.
-  this->DeclarePeriodicDiscreteUpdate(0.05);
+  this->DeclarePeriodicDiscreteUpdateNoHandler(0.05);
 }
 
 void SchunkWsgTrajectoryGenerator::OutputTarget(

--- a/multibody/meshcat/joint_sliders.cc
+++ b/multibody/meshcat/joint_sliders.cc
@@ -283,7 +283,7 @@ Eigen::VectorXd JointSliders<T>::Run(const Diagram<T>& diagram,
                        this->get_output_port().Eval(sliders_context));
 
   // Loop until the button is clicked, or the timeout (when given) is reached.
-  diagram.Publish(diagram_context);
+  diagram.ForcedPublish(diagram_context);
   while (meshcat_->GetButtonClicks(kButtonName) < 1) {
     if (timeout.has_value()) {
       const auto elapsed = Duration(Clock::now() - start_time).count();
@@ -302,7 +302,7 @@ Eigen::VectorXd JointSliders<T>::Run(const Diagram<T>& diagram,
 
     // Publish the new positions.
     plant_->SetPositions(&plant_context, new_positions);
-    diagram.Publish(diagram_context);
+    diagram.ForcedPublish(diagram_context);
   }
 
   return ExtractDoubleOrThrow(plant_->GetPositions(plant_context).eval());

--- a/multibody/meshcat/test/contact_visualizer_test.cc
+++ b/multibody/meshcat/test/contact_visualizer_test.cc
@@ -109,7 +109,7 @@ class ContactVisualizerTest : public ::testing::Test {
 
   void PublishAndCheck(
       bool expect_geometry_names = false) {
-    diagram_->Publish(*context_);
+    diagram_->ForcedPublish(*context_);
     if (expect_geometry_names) {
       EXPECT_TRUE(meshcat_->HasPath(
           "contact_forces/point/sphere1.base_link+sphere2.base_link.bonus"));
@@ -192,7 +192,7 @@ TEST_F(ContactVisualizerTest, Parameters) {
   // visualization; they are partially covered by meshcat_manual_test.
   SetUpDiagram(0, false, params);
 
-  diagram_->Publish(*context_);
+  diagram_->ForcedPublish(*context_);
   EXPECT_FALSE(meshcat_->HasPath("contact_forces"));
   EXPECT_TRUE(meshcat_->HasPath("test_prefix"));
 
@@ -207,13 +207,13 @@ TEST_F(ContactVisualizerTest, Parameters) {
 TEST_F(ContactVisualizerTest, Delete) {
   SetUpDiagram();
 
-  diagram_->Publish(*context_);
+  diagram_->ForcedPublish(*context_);
   EXPECT_TRUE(meshcat_->HasPath("contact_forces"));
 
   visualizer_->Delete();
   EXPECT_FALSE(meshcat_->HasPath("contact_forces"));
 
-  diagram_->Publish(*context_);
+  diagram_->ForcedPublish(*context_);
   EXPECT_TRUE(meshcat_->HasPath("contact_forces"));
 }
 
@@ -240,7 +240,7 @@ TEST_F(ContactVisualizerTest, ScalarConversion) {
 
   // Call publish to provide code coverage for the AutoDiffXd version of
   // UpdateMeshcat.  We simply confirm that the code doesn't blow up.
-  ad_diagram->Publish(*ad_context);
+  ad_diagram->ForcedPublish(*ad_context);
 }
 
 }  // namespace

--- a/multibody/optimization/test/static_equilibrium_problem_test.cc
+++ b/multibody/optimization/test/static_equilibrium_problem_test.cc
@@ -175,7 +175,7 @@ GTEST_TEST(TestStaticEquilibriumProblem, TwoSpheresWithinBin) {
 
           free_spheres_double.plant().SetPositions(
               free_spheres_double.get_mutable_plant_context(), q_sol);
-          free_spheres_double.get_mutable_diagram()->Publish(
+          free_spheres_double.get_mutable_diagram()->ForcedPublish(
               free_spheres_double.diagram_context());
           const double tol = 2E-5;
           EXPECT_NEAR(q_sol.head<4>().squaredNorm(), 1, tol);

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -3012,7 +3012,7 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
   DRAKE_DEMAND(this->is_finalized());
 
   if (is_discrete()) {
-    this->DeclarePeriodicDiscreteUpdate(time_step_);
+    this->DeclarePeriodicDiscreteUpdateNoHandler(time_step_);
   }
 
   DeclareCacheEntries();

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -2968,10 +2968,9 @@ void MultibodyPlant<T>::DoCalcForwardDynamicsDiscrete(
 }
 
 template<typename T>
-void MultibodyPlant<T>::DoCalcDiscreteVariableUpdates(
-    const drake::systems::Context<T>& context0,
-    const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>&,
-    drake::systems::DiscreteValues<T>* updates) const {
+systems::EventStatus MultibodyPlant<T>::CalcDiscreteStep(
+    const systems::Context<T>& context0,
+    systems::DiscreteValues<T>* updates) const {
   this->ValidateContext(context0);
 
   // TODO(amcastro-tri): remove the entirety of the code we are bypassing here.
@@ -2979,7 +2978,7 @@ void MultibodyPlant<T>::DoCalcDiscreteVariableUpdates(
   // MultibodyPlant manager.
   if (discrete_update_manager_) {
     discrete_update_manager_->CalcDiscreteValues(context0, updates);
-    return;
+    return systems::EventStatus::Succeeded();
   }
 
   // Get the system state as raw Eigen vectors
@@ -3004,6 +3003,8 @@ void MultibodyPlant<T>::DoCalcDiscreteVariableUpdates(
   VectorX<T> x_next(this->num_multibody_states());
   x_next << q_next, v_next;
   updates->set_value(0, x_next);
+
+  return systems::EventStatus::Succeeded();
 }
 
 template<typename T>
@@ -3012,7 +3013,12 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
   DRAKE_DEMAND(this->is_finalized());
 
   if (is_discrete()) {
-    this->DeclarePeriodicDiscreteUpdateNoHandler(time_step_);
+    this->DeclarePeriodicDiscreteUpdateEvent(
+        time_step_, 0.0, &MultibodyPlant<T>::CalcDiscreteStep);
+
+    // Also permit triggering a step via a Forced update.
+    this->DeclareForcedDiscreteUpdateEvent(
+        &MultibodyPlant<T>::CalcDiscreteStep);
   }
 
   DeclareCacheEntries();

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -4529,10 +4529,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // shown to be exactly conserved and to be within O(dt) of the real energy of
   // the mechanical system.)
   // TODO(amcastro-tri): Update this docs when contact is added.
-  void DoCalcDiscreteVariableUpdates(
-      const drake::systems::Context<T>& context0,
-      const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>& events,
-      drake::systems::DiscreteValues<T>* updates) const override;
+  systems::EventStatus CalcDiscreteStep(
+      const systems::Context<T>& context0,
+      systems::DiscreteValues<T>* updates) const;
 
   // Helper method used within DoCalcDiscreteVariableUpdates() to update
   // generalized velocities from previous step value v0 to next step value v.

--- a/multibody/plant/test/applied_generalized_force_test.cc
+++ b/multibody/plant/test/applied_generalized_force_test.cc
@@ -135,7 +135,8 @@ TEST_P(MultibodyPlantGeneralizedAppliedForceTest,
     auto new_discrete_state = diagram().AllocateDiscreteVariables();
     const VectorBase<double>& new_discrete_state_vector =
         new_discrete_state->get_vector();
-    diagram().CalcDiscreteVariableUpdates(context(), new_discrete_state.get());
+    diagram().CalcForcedDiscreteVariableUpdate(context(),
+                                               new_discrete_state.get());
 
     // Velocities start immediately after positions in the discrete state
     // vector.

--- a/multibody/plant/test/externally_applied_spatial_force_test.cc
+++ b/multibody/plant/test/externally_applied_spatial_force_test.cc
@@ -168,7 +168,7 @@ TEST_F(ExternallyAppliedForcesTest, DiscretePlant) {
   MakePlantWithGravityCompensator(1.0e-3);
 
   auto updates = diagram_->AllocateDiscreteVariables();
-  diagram_->CalcDiscreteVariableUpdates(*context_, updates.get());
+  diagram_->CalcForcedDiscreteVariableUpdate(*context_, updates.get());
 
   // Copies to plain Eigen vectors to verify the math.
   auto& acrobot_context =

--- a/multibody/plant/test/multibody_plant_hydroelastic_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_test.cc
@@ -206,7 +206,7 @@ class HydroelasticModelTests : public ::testing::Test {
     // Set initial condition.
     const RigidTransformd X_WB(Vector3d(0.0, 0.0, kSphereRadius));
     plant_->SetFreeBodyPose(&plant_context, *body_, X_WB);
-    diagram_->Publish(diagram_context);
+    diagram_->ForcedPublish(diagram_context);
 
     // Run simulation for long enough to reach the steady state.
     simulator.AdvanceTo(0.5);

--- a/multibody/plant/test/multibody_plant_tamsi_test.cc
+++ b/multibody/plant/test/multibody_plant_tamsi_test.cc
@@ -66,8 +66,8 @@ GTEST_TEST(MbpWithTamsiSolver, FixedWorld) {
   EXPECT_EQ(new_discrete_state_vector.size(), 0);
 
   // Verify we can to do discrete updates even if we have zero DOFs.
-  DRAKE_EXPECT_NO_THROW(
-      diagram->CalcDiscreteVariableUpdates(*context, new_discrete_state.get()));
+  DRAKE_EXPECT_NO_THROW(diagram->CalcForcedDiscreteVariableUpdate(
+      *context, new_discrete_state.get()));
 }
 
 }  // namespace

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -495,7 +495,8 @@ GTEST_TEST(MultibodyPlantTest, EmptyWorldDiscrete) {
       new_discrete_state->get_vector();
   EXPECT_EQ(new_discrete_state_vector.size(), 0);
   DRAKE_EXPECT_NO_THROW(
-      plant.CalcDiscreteVariableUpdates(*context, new_discrete_state.get()));
+      plant.CalcForcedDiscreteVariableUpdate(*context,
+                                             new_discrete_state.get()));
 }
 
 GTEST_TEST(MultibodyPlantTest, EmptyWorldContinuous) {
@@ -845,7 +846,7 @@ class AcrobotPlantTests : public ::testing::Test {
 
     diagram_->CalcTimeDerivatives(*context_, derivatives_.get());
     auto updates = discrete_plant_->AllocateDiscreteVariables();
-    discrete_plant_->CalcDiscreteVariableUpdates(
+    discrete_plant_->CalcForcedDiscreteVariableUpdate(
         *discrete_context_, updates.get());
 
     // Copies to plain Eigen vectors to verify the math.

--- a/systems/analysis/simulator.cc
+++ b/systems/analysis/simulator.cc
@@ -131,7 +131,7 @@ SimulatorStatus Simulator<T>::Initialize(const InitializeParams& params) {
   // TODO(siyuan): transfer publish entirely to individual systems.
   // Do a force-publish before the simulation starts.
   if (publish_at_initialization_) {
-    system_.Publish(*context_);
+    system_.ForcedPublish(*context_);
     ++num_publishes_;
   }
 
@@ -168,7 +168,7 @@ void Simulator<T>::HandleDiscreteUpdate(
     const EventCollection<DiscreteUpdateEvent<T>>& events) {
   if (events.HasEvents()) {
     // First, compute the discrete updates into a temporary buffer.
-    system_.CalcDiscreteVariableUpdates(*context_, events,
+    system_.CalcDiscreteVariableUpdate(*context_, events,
         discrete_updates_.get());
     // Then, write them back into the context.
     system_.ApplyDiscreteVariableUpdate(events, discrete_updates_.get(),
@@ -298,7 +298,7 @@ SimulatorStatus Simulator<T>::AdvanceTo(const T& boundary_time) {
     // TODO(siyuan): transfer per step publish entirely to individual systems.
     // Allow System a chance to produce some output.
     if (get_publish_every_time_step()) {
-      system_.Publish(*context_);
+      system_.ForcedPublish(*context_);
       ++num_publishes_;
     }
 

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -2107,7 +2107,7 @@ GTEST_TEST(SimulatorTest, Initialization) {
       DeclareInitializationEvent(UnrestrictedUpdateEvent<double>(
           TriggerType::kInitialization));
 
-      DeclarePeriodicDiscreteUpdate(0.1);
+      DeclarePeriodicDiscreteUpdateNoHandler(0.1);
       DeclarePerStepEvent<UnrestrictedUpdateEvent<double>>(
           UnrestrictedUpdateEvent<double>(
               TriggerType::kPerStep));

--- a/systems/controllers/linear_model_predictive_controller.cc
+++ b/systems/controllers/linear_model_predictive_controller.cc
@@ -62,7 +62,7 @@ LinearModelPredictiveController<T>::LinearModelPredictiveController(
     throw std::runtime_error("R must be positive definite");
   }
 
-  this->DeclarePeriodicDiscreteUpdate(time_period_);
+  this->DeclarePeriodicDiscreteUpdateNoHandler(time_period_);
 
   if (base_context_ != nullptr) {
     linear_model_ = Linearize(*model_, *base_context_);

--- a/systems/controllers/test/linear_model_predictive_controller_test.cc
+++ b/systems/controllers/test/linear_model_predictive_controller_test.cc
@@ -95,7 +95,7 @@ class CubicPolynomialSystem final : public LeafSystem<T> {
                                   &CubicPolynomialSystem::OutputState,
                                   {this->all_state_ticket()});
     this->DeclareDiscreteState(2);
-    this->DeclarePeriodicDiscreteUpdate(time_step);
+    this->DeclarePeriodicDiscreteUpdateNoHandler(time_step);
   }
 
   template <typename U>

--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -1191,7 +1191,7 @@ void Diagram<T>::DispatchDiscreteVariableUpdateHandler(
       DiscreteValues<T>& subdiscrete =
           diagram_discrete->get_mutable_subdiscrete(i);
 
-      registered_systems_[i]->CalcDiscreteVariableUpdates(
+      registered_systems_[i]->CalcDiscreteVariableUpdate(
           subcontext, subevents, &subdiscrete);
     }
   }

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -389,7 +389,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
       const EventCollection<PublishEvent<T>>& event_info) const final;
 
   // For each subsystem, if there is a discrete update event in its
-  // corresponding subevent collection, calls its CalcDiscreteVariableUpdates
+  // corresponding subevent collection, calls its CalcDiscreteVariableUpdate()
   // method with the appropriate subcontext, subevent collection and
   // substate.
   void DispatchDiscreteVariableUpdateHandler(

--- a/systems/framework/event_collection.h
+++ b/systems/framework/event_collection.h
@@ -82,7 +82,7 @@ namespace systems {
  * <pre>
  *   sys.CalcUnrestrictedUpdate(context,
  *       all_events.get_unrestricted_update_events(), state);
- *   sys.CalcDiscreteVariableUpdates(context,
+ *   sys.CalcDiscreteVariableUpdate(context,
  *       all_events.get_discrete_update_events(), discrete_state);
  *   sys.Publish(context, all_events.get_publish_events())
  * </pre>

--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -519,19 +519,19 @@ int LeafSystem<T>::DeclareAbstractParameter(const AbstractValue& model_value) {
 }
 
 template <typename T>
-void LeafSystem<T>::DeclarePeriodicPublish(
+void LeafSystem<T>::DeclarePeriodicPublishNoHandler(
     double period_sec, double offset_sec) {
   DeclarePeriodicEvent(period_sec, offset_sec, PublishEvent<T>());
 }
 
 template <typename T>
-void LeafSystem<T>::DeclarePeriodicDiscreteUpdate(
+void LeafSystem<T>::DeclarePeriodicDiscreteUpdateNoHandler(
     double period_sec, double offset_sec) {
   DeclarePeriodicEvent(period_sec, offset_sec, DiscreteUpdateEvent<T>());
 }
 
 template <typename T>
-void LeafSystem<T>::DeclarePeriodicUnrestrictedUpdate(
+void LeafSystem<T>::DeclarePeriodicUnrestrictedUpdateNoHandler(
     double period_sec, double offset_sec) {
   DeclarePeriodicEvent(period_sec, offset_sec, UnrestrictedUpdateEvent<T>());
 }

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -190,7 +190,7 @@ void System<T>::Publish(const Context<T>& context,
 }
 
 template <typename T>
-void System<T>::Publish(const Context<T>& context) const {
+void System<T>::ForcedPublish(const Context<T>& context) const {
   Publish(context, this->get_forced_publish_events());
 }
 
@@ -272,7 +272,7 @@ void System<T>::CalcImplicitTimeDerivativesResidual(
 }
 
 template <typename T>
-void System<T>::CalcDiscreteVariableUpdates(
+void System<T>::CalcDiscreteVariableUpdate(
     const Context<T>& context,
     const EventCollection<DiscreteUpdateEvent<T>>& events,
     DiscreteValues<T>* discrete_state) const {
@@ -292,10 +292,10 @@ void System<T>::ApplyDiscreteVariableUpdate(
 }
 
 template <typename T>
-void System<T>::CalcDiscreteVariableUpdates(
+void System<T>::CalcForcedDiscreteVariableUpdate(
     const Context<T>& context,
     DiscreteValues<T>* discrete_state) const {
-  CalcDiscreteVariableUpdates(
+  CalcDiscreteVariableUpdate(
       context, this->get_forced_discrete_update_events(), discrete_state);
 }
 
@@ -330,8 +330,8 @@ void System<T>::ApplyUnrestrictedUpdate(
 }
 
 template <typename T>
-void System<T>::CalcUnrestrictedUpdate(const Context<T>& context,
-                                       State<T>* state) const {
+void System<T>::CalcForcedUnrestrictedUpdate(const Context<T>& context,
+                                             State<T>* state) const {
   CalcUnrestrictedUpdate(
       context, this->get_forced_unrestricted_update_events(), state);
 }
@@ -417,7 +417,7 @@ void System<T>::CalcUniquePeriodicDiscreteUpdate(
   discrete_values->SetFrom(context.get_discrete_state());
 
   // Then let the event handlers modify them or not.
-  this->CalcDiscreteVariableUpdates(
+  this->CalcDiscreteVariableUpdate(
       context, collection->get_discrete_update_events(), discrete_values);
 }
 

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -599,7 +599,7 @@ class System : public SystemBase {
   }
 
   /** This method is the public entry point for dispatching all unrestricted
-  update event handlers. Using all the unrestricted update handers in
+  update event handlers. Using all the unrestricted update handlers in
   @p events, it updates *any* state variables in the @p context, and
   outputs the results to @p state. It does not allow the dimensionality
   of the state variables to change. See the documentation for

--- a/systems/framework/system_symbolic_inspector.cc
+++ b/systems/framework/system_symbolic_inspector.cc
@@ -55,7 +55,7 @@ SystemSymbolicInspector::SystemSymbolicInspector(
 
   // Discrete updates.
   if (context_->num_discrete_state_groups() > 0) {
-    system.CalcDiscreteVariableUpdates(*context_, discrete_updates_.get());
+    system.CalcForcedDiscreteVariableUpdate(*context_, discrete_updates_.get());
   }
 
   // Constraints.

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -295,7 +295,7 @@ TEST_F(SystemTest, ContextBelongsWithSystem) {
 
   // These just uses a couple of arbitrary methods to test that a Context not
   // created by a System throws the appropriate exception.
-  DRAKE_EXPECT_THROWS_MESSAGE(system2.Publish(*context_),
+  DRAKE_EXPECT_THROWS_MESSAGE(system2.ForcedPublish(*context_),
                               "[^]*#framework-context-system-mismatch.*");
   DRAKE_EXPECT_THROWS_MESSAGE(system2.SetDefaultContext(context_.get()),
                               "[^]*#framework-context-system-mismatch.*");
@@ -376,7 +376,7 @@ TEST_F(SystemTest, DiscreteUpdate) {
 
   std::unique_ptr<DiscreteValues<double>> update =
       system_.AllocateDiscreteVariables();
-  system_.CalcDiscreteVariableUpdates(
+  system_.CalcDiscreteVariableUpdate(
       *context_, event_info->get_discrete_update_events(), update.get());
   EXPECT_EQ(1, system_.get_update_count());
 }

--- a/systems/lcm/test/lcm_log_playback_test.cc
+++ b/systems/lcm/test/lcm_log_playback_test.cc
@@ -93,26 +93,26 @@ void GenerateLog() {
   auto context1 = pub1->CreateDefaultContext();
 
   SetInput(0.1, "Ch0", 1, pub0->get_input_port(), context0.get());
-  pub0->Publish(*context0);
+  pub0->ForcedPublish(*context0);
 
   SetInput(0.22, "Ch1", 2, pub1->get_input_port(), context1.get());
-  pub1->Publish(*context1);
+  pub1->ForcedPublish(*context1);
 
   // Testing multiple messages sent to the same channel at the same time.
   // Only the last one should be visible from the Subscriber's point of view.
   SetInput(0.3, "Ch0", 3, pub0->get_input_port(), context0.get());
-  pub0->Publish(*context0);
+  pub0->ForcedPublish(*context0);
   SetInput(0.3, "Ch0", 4, pub0->get_input_port(), context0.get());
-  pub0->Publish(*context0);
+  pub0->ForcedPublish(*context0);
   SetInput(0.3, "Ch0", 5, pub0->get_input_port(), context0.get());
-  pub0->Publish(*context0);
+  pub0->ForcedPublish(*context0);
 
   // Testing sending a message to a different channel at the same time.
   SetInput(0.3, "Ch1", 6, pub1->get_input_port(), context1.get());
-  pub1->Publish(*context1);
+  pub1->ForcedPublish(*context1);
 
   SetInput(0.4, "Ch1", 7, pub1->get_input_port(), context1.get());
-  pub1->Publish(*context1);
+  pub1->ForcedPublish(*context1);
 }
 
 void CheckLog(const std::vector<double>& expected_times,

--- a/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/systems/lcm/test/lcm_publisher_system_test.cc
@@ -101,7 +101,7 @@ GTEST_TEST(LcmPublisherSystemTest, SerializerTest) {
 
   // Verifies that a correct message is published.
   Subscriber sub(&interface, channel_name);
-  dut->Publish(*context.get());
+  dut->ForcedPublish(*context.get());
   interface.HandleSubscriptions(0);
   EXPECT_TRUE(CompareLcmtDrakeSignalMessages(sub.message(), sample_data));
 }
@@ -190,7 +190,7 @@ GTEST_TEST(LcmPublisherSystemTest, TestForcedPublishTrigger) {
   dut->get_input_port().FixValue(context.get(), lcmt_drake_signal{});
 
   for (int i = 0; i < force_publish_count; i++) {
-    dut->Publish(*context);
+    dut->ForcedPublish(*context);
     interface.HandleSubscriptions(0);
   }
 

--- a/systems/lcm/test/lcm_subscriber_system_test.cc
+++ b/systems/lcm/test/lcm_subscriber_system_test.cc
@@ -24,7 +24,7 @@ void EvalOutputHelper(const LcmSubscriberSystem& sub, Context<double>* context,
   if (event_info->HasEvents()) {
     std::unique_ptr<State<double>> tmp_state = context->CloneState();
     if (event_info->HasDiscreteUpdateEvents()) {
-      sub.CalcDiscreteVariableUpdates(
+      sub.CalcDiscreteVariableUpdate(
           *context, event_info->get_discrete_update_events(),
           &tmp_state->get_mutable_discrete_state());
     } else if (event_info->HasUnrestrictedUpdateEvents()) {
@@ -67,7 +67,7 @@ GTEST_TEST(LcmSubscriberSystemTest, ForcedEventTest) {
 
   // Call the forced update handler to update the abstract states.
   std::unique_ptr<State<double>> tmp_state = context->CloneState();
-  dut->CalcUnrestrictedUpdate(*context, tmp_state.get());
+  dut->CalcForcedUnrestrictedUpdate(*context, tmp_state.get());
   context->get_mutable_state().SetFrom(*tmp_state);
   dut->CalcOutput(*context, output.get());
 

--- a/systems/primitives/affine_system.cc
+++ b/systems/primitives/affine_system.cc
@@ -41,7 +41,12 @@ TimeVaryingAffineSystem<T>::TimeVaryingAffineSystem(
       this->DeclareContinuousState(num_states_);
     } else {
       this->DeclareDiscreteState(num_states_);
-      this->DeclarePeriodicDiscreteUpdateNoHandler(time_period_, 0.0);
+      this->DeclarePeriodicDiscreteUpdateEvent(
+          time_period_, 0.0, &TimeVaryingAffineSystem<T>::CalcDiscreteUpdate);
+
+      // Allow a forced update to trigger the same handler.
+      this->DeclareForcedDiscreteUpdateEvent(
+          &TimeVaryingAffineSystem<T>::CalcDiscreteUpdate);
     }
   }
 
@@ -159,12 +164,12 @@ void TimeVaryingAffineSystem<T>::DoCalcTimeDerivatives(
   derivatives->SetFromVector(xdot);
 }
 
+// This is the default implementation; may be overridden in derived classes.
 template <typename T>
-void TimeVaryingAffineSystem<T>::DoCalcDiscreteVariableUpdates(
-    const drake::systems::Context<T>& context,
-    const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>&,
-    drake::systems::DiscreteValues<T>* updates) const {
-  if (num_states_ == 0 || time_period_ == 0.0) return;
+EventStatus TimeVaryingAffineSystem<T>::CalcDiscreteUpdate(
+    const Context<T>& context, DiscreteValues<T>* updates) const {
+  if (num_states_ == 0 || time_period_ == 0.0)
+    return EventStatus::DidNothing();
 
   const T t = context.get_time();
 
@@ -188,6 +193,7 @@ void TimeVaryingAffineSystem<T>::DoCalcDiscreteVariableUpdates(
     xn += Bt * u;
   }
   updates->set_value(xn);
+  return EventStatus::Succeeded();
 }
 
 template <typename T>
@@ -379,12 +385,12 @@ void AffineSystem<T>::DoCalcTimeDerivatives(
   derivatives->SetFromVector(xdot);
 }
 
+// Overrides the base class default event handler with a simpler one.
 template <typename T>
-void AffineSystem<T>::DoCalcDiscreteVariableUpdates(
-    const drake::systems::Context<T>& context,
-    const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>&,
-    drake::systems::DiscreteValues<T>* updates) const {
-  if (this->num_states() == 0 || this->time_period() == 0.0) return;
+EventStatus AffineSystem<T>::CalcDiscreteUpdate(
+    const Context<T>& context, DiscreteValues<T>* updates) const {
+  if (this->num_states() == 0 || this->time_period() == 0.0)
+    return EventStatus::DidNothing();
 
   const auto& x = context.get_discrete_state(0).get_value();
 
@@ -396,6 +402,7 @@ void AffineSystem<T>::DoCalcDiscreteVariableUpdates(
     xnext += B_ * u;
   }
   updates->set_value(xnext);
+  return EventStatus::Succeeded();
 }
 
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((

--- a/systems/primitives/affine_system.cc
+++ b/systems/primitives/affine_system.cc
@@ -41,7 +41,7 @@ TimeVaryingAffineSystem<T>::TimeVaryingAffineSystem(
       this->DeclareContinuousState(num_states_);
     } else {
       this->DeclareDiscreteState(num_states_);
-      this->DeclarePeriodicDiscreteUpdate(time_period_, 0.0);
+      this->DeclarePeriodicDiscreteUpdateNoHandler(time_period_, 0.0);
     }
   }
 

--- a/systems/primitives/affine_system.h
+++ b/systems/primitives/affine_system.h
@@ -34,6 +34,9 @@ namespace systems {
  *   @f[ y(t) = C(t) x(t) + D(t) u(t) + y_0(t), @f]
  * where `y` denotes the output vector.
  *
+ * When configured as a discrete system, the discrete update can be triggered
+ * either by the defined periodic trigger or via a manual forced update.
+ *
  * @tparam_default_scalar
  * @ingroup primitive_systems
  * *
@@ -123,12 +126,11 @@ class TimeVaryingAffineSystem : public LeafSystem<T> {
                              ContinuousState<T>* derivatives) const override;
 
   /// Computes @f[ x(t+h) = A(t) x(t) + B(t) u(t) + f_0(t), @f] with by calling
-  /// `A(t)`, `B(t)`, and `f0(t)` with runtime size checks.  Derived classes
-  /// may override this for performance reasons.
-  void DoCalcDiscreteVariableUpdates(
-      const drake::systems::Context<T>& context,
-      const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>& events,
-      drake::systems::DiscreteValues<T>* updates) const override;
+  /// `A(t)`, `B(t)`, and `f0(t)` with runtime size checks. This is the event
+  /// handler for the periodic and forced discrete update events. Derived
+  /// classes may override this for performance reasons.
+  virtual EventStatus CalcDiscreteUpdate(
+      const Context<T>& context, DiscreteValues<T>* updates) const;
 
   /// Sets the initial conditions.
   void SetDefaultState(const Context<T>& context,
@@ -270,10 +272,9 @@ class AffineSystem : public TimeVaryingAffineSystem<T> {
   void DoCalcTimeDerivatives(const Context<T>& context,
                              ContinuousState<T>* derivatives) const final;
 
-  void DoCalcDiscreteVariableUpdates(
-      const drake::systems::Context<T>& context,
-      const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>& events,
-      drake::systems::DiscreteValues<T>* updates) const final;
+  // We can simplify the discrete update event handler here.
+  EventStatus CalcDiscreteUpdate(
+      const Context<T>& context, DiscreteValues<T>* updates) const final;
 
   const Eigen::MatrixXd A_;
   const Eigen::MatrixXd B_;

--- a/systems/primitives/discrete_derivative.cc
+++ b/systems/primitives/discrete_derivative.cc
@@ -32,7 +32,7 @@ DiscreteDerivative<T>::DiscreteDerivative(int num_inputs, double time_step,
     // at time == 0.0.
     this->DeclareDiscreteState(1);
   }
-  this->DeclarePeriodicDiscreteUpdate(time_step_);
+  this->DeclarePeriodicDiscreteUpdateNoHandler(time_step_);
 }
 
 template <typename T>

--- a/systems/primitives/linear_system.cc
+++ b/systems/primitives/linear_system.cc
@@ -178,8 +178,8 @@ std::unique_ptr<AffineSystem<double>> DoFirstOrderTaylorApproximation(
       autodiff_x0.SetFromVector(std::get<0>(autodiff_args));
       std::unique_ptr<DiscreteValues<AutoDiffXd>> autodiff_x1 =
           autodiff_system->AllocateDiscreteVariables();
-      autodiff_system->CalcForcedDiscreteVariableUpdate(*autodiff_context,
-                                                        autodiff_x1.get());
+      autodiff_x1->SetFrom(
+          autodiff_system->EvalUniquePeriodicDiscreteUpdate(*autodiff_context));
       auto autodiff_x1_vec = autodiff_x1->get_value();
 
       const Eigen::MatrixXd AB = math::ExtractGradient(autodiff_x1_vec);

--- a/systems/primitives/linear_system.cc
+++ b/systems/primitives/linear_system.cc
@@ -178,8 +178,8 @@ std::unique_ptr<AffineSystem<double>> DoFirstOrderTaylorApproximation(
       autodiff_x0.SetFromVector(std::get<0>(autodiff_args));
       std::unique_ptr<DiscreteValues<AutoDiffXd>> autodiff_x1 =
           autodiff_system->AllocateDiscreteVariables();
-      autodiff_system->CalcDiscreteVariableUpdates(*autodiff_context,
-                                                   autodiff_x1.get());
+      autodiff_system->CalcForcedDiscreteVariableUpdate(*autodiff_context,
+                                                        autodiff_x1.get());
       auto autodiff_x1_vec = autodiff_x1->get_value();
 
       const Eigen::MatrixXd AB = math::ExtractGradient(autodiff_x1_vec);

--- a/systems/primitives/symbolic_vector_system.cc
+++ b/systems/primitives/symbolic_vector_system.cc
@@ -130,7 +130,7 @@ SymbolicVectorSystem<T>::SymbolicVectorSystem(
       this->DeclareContinuousState(state_vars_.size());
     } else {
       this->DeclareDiscreteState(state_vars_.size());
-      this->DeclarePeriodicDiscreteUpdate(time_period_, 0.0);
+      this->DeclarePeriodicDiscreteUpdateNoHandler(time_period_, 0.0);
     }
   }
   if (parameter_vars_.size() > 0) {

--- a/systems/primitives/test/affine_system_test.cc
+++ b/systems/primitives/test/affine_system_test.cc
@@ -234,7 +234,7 @@ GTEST_TEST(DiscreteAffineSystemTest, DiscreteTime) {
   system.get_input_port().FixValue(context.get(), u0);
 
   auto update = system.AllocateDiscreteVariables();
-  system.CalcDiscreteVariableUpdates(*context, update.get());
+  system.CalcForcedDiscreteVariableUpdate(*context, update.get());
 
   EXPECT_TRUE(CompareMatrices(update->get_vector(0).CopyToVector(),
                               A * x0 + B * u0 + f0));
@@ -370,7 +370,8 @@ GTEST_TEST(SimpleTimeVaryingAffineSystemTest,
   sys.get_input_port().FixValue(context.get(), 42.0);
 
   auto updates = sys.AllocateDiscreteVariables();
-  EXPECT_NO_THROW(sys.CalcDiscreteVariableUpdates(*context, updates.get()));
+  EXPECT_NO_THROW(sys.CalcForcedDiscreteVariableUpdate(*context,
+                                                       updates.get()));
 }
 
 GTEST_TEST(SimpleTimeVaryingAffineSystemTest, DiscreteEvalTest) {
@@ -384,7 +385,7 @@ GTEST_TEST(SimpleTimeVaryingAffineSystemTest, DiscreteEvalTest) {
   sys.get_input_port().FixValue(context.get(), 42.0);
 
   auto updates = sys.AllocateDiscreteVariables();
-  sys.CalcDiscreteVariableUpdates(*context, updates.get());
+  sys.CalcForcedDiscreteVariableUpdate(*context, updates.get());
   EXPECT_TRUE(CompareMatrices(sys.A(t) * x + 42.0 * sys.B(t),
                               updates->get_vector().CopyToVector()));
 

--- a/systems/primitives/test/affine_system_test.cc
+++ b/systems/primitives/test/affine_system_test.cc
@@ -233,10 +233,9 @@ GTEST_TEST(DiscreteAffineSystemTest, DiscreteTime) {
   double u0 = 29;
   system.get_input_port().FixValue(context.get(), u0);
 
-  auto update = system.AllocateDiscreteVariables();
-  system.CalcForcedDiscreteVariableUpdate(*context, update.get());
+  auto& update = system.EvalUniquePeriodicDiscreteUpdate(*context);
 
-  EXPECT_TRUE(CompareMatrices(update->get_vector(0).CopyToVector(),
+  EXPECT_TRUE(CompareMatrices(update.get_vector(0).CopyToVector(),
                               A * x0 + B * u0 + f0));
 
   // Test TimeVaryingAffineSystem accessor methods.
@@ -370,8 +369,8 @@ GTEST_TEST(SimpleTimeVaryingAffineSystemTest,
   sys.get_input_port().FixValue(context.get(), 42.0);
 
   auto updates = sys.AllocateDiscreteVariables();
-  EXPECT_NO_THROW(sys.CalcForcedDiscreteVariableUpdate(*context,
-                                                       updates.get()));
+  EXPECT_NO_THROW(
+      sys.CalcForcedDiscreteVariableUpdate(*context, updates.get()));
 }
 
 GTEST_TEST(SimpleTimeVaryingAffineSystemTest, DiscreteEvalTest) {
@@ -384,10 +383,9 @@ GTEST_TEST(SimpleTimeVaryingAffineSystemTest, DiscreteEvalTest) {
   context->get_mutable_discrete_state().get_mutable_vector().SetFromVector(x);
   sys.get_input_port().FixValue(context.get(), 42.0);
 
-  auto updates = sys.AllocateDiscreteVariables();
-  sys.CalcForcedDiscreteVariableUpdate(*context, updates.get());
+  auto& updates = sys.EvalUniquePeriodicDiscreteUpdate(*context);
   EXPECT_TRUE(CompareMatrices(sys.A(t) * x + 42.0 * sys.B(t),
-                              updates->get_vector().CopyToVector()));
+                              updates.get_vector().CopyToVector()));
 
   EXPECT_TRUE(CompareMatrices(x + sys.y0(t) + 42.0 * sys.D(t),
                               sys.get_output_port().Eval(*context)));

--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -742,7 +742,7 @@ class MimoSystem final : public LeafSystem<T> {
 
     if (is_discrete) {
       this->DeclareDiscreteState(2);
-      this->DeclarePeriodicDiscreteUpdate(0.1, 0.0);
+      this->DeclarePeriodicDiscreteUpdateNoHandler(0.1, 0.0);
     } else {
       this->DeclareContinuousState(2);
     }

--- a/systems/primitives/test/symbolic_vector_system_test.cc
+++ b/systems/primitives/test/symbolic_vector_system_test.cc
@@ -399,7 +399,7 @@ TEST_F(SymbolicVectorSystemTest, DiscreteStateOnly) {
   const double xval = 0.45;
   context->get_mutable_discrete_state_vector()[0] = xval;
   auto discrete_variables = system.AllocateDiscreteVariables();
-  system.CalcDiscreteVariableUpdates(*context, discrete_variables.get());
+  system.CalcForcedDiscreteVariableUpdate(*context, discrete_variables.get());
   EXPECT_TRUE(CompareMatrices(discrete_variables->get_vector().get_value(),
                               Vector1d{-xval + xval * xval * xval}));
 }
@@ -600,7 +600,7 @@ TEST_F(SymbolicVectorSystemTest, DiscreteTimeSymbolic) {
   context->get_mutable_numeric_parameter(0).SetFromVector(pc_);
 
   auto discrete_variables = system->AllocateDiscreteVariables();
-  system->CalcDiscreteVariableUpdates(*context, discrete_variables.get());
+  system->CalcForcedDiscreteVariableUpdate(*context, discrete_variables.get());
   const auto& xnext = discrete_variables->get_vector().get_value();
   EXPECT_TRUE(xnext[0].EqualTo(tc_));
   EXPECT_TRUE(xnext[1].EqualTo(xc_[1] + uc_[1] + pc_[1]));

--- a/systems/primitives/test/trajectory_affine_system_test.cc
+++ b/systems/primitives/test/trajectory_affine_system_test.cc
@@ -109,7 +109,7 @@ TEST_P(TrajectoryAffineSystemTest, DiscreteUpdates) {
       EXPECT_TRUE(CompareMatrices(
           A * x + B * u + f0, derivatives_->get_vector().CopyToVector(), tol));
     } else {
-      dut_->CalcDiscreteVariableUpdates(*context_, updates_.get());
+      dut_->CalcForcedDiscreteVariableUpdate(*context_, updates_.get());
       EXPECT_TRUE(CompareMatrices(
           A * x + B * u + f0, updates_->get_vector(0).CopyToVector(), tol));
     }

--- a/systems/primitives/test/trajectory_affine_system_test.cc
+++ b/systems/primitives/test/trajectory_affine_system_test.cc
@@ -109,7 +109,7 @@ TEST_P(TrajectoryAffineSystemTest, DiscreteUpdates) {
       EXPECT_TRUE(CompareMatrices(
           A * x + B * u + f0, derivatives_->get_vector().CopyToVector(), tol));
     } else {
-      dut_->CalcForcedDiscreteVariableUpdate(*context_, updates_.get());
+      updates_->SetFrom(dut_->EvalUniquePeriodicDiscreteUpdate(*context_));
       EXPECT_TRUE(CompareMatrices(
           A * x + B * u + f0, updates_->get_vector(0).CopyToVector(), tol));
     }

--- a/systems/primitives/test/trajectory_linear_system_test.cc
+++ b/systems/primitives/test/trajectory_linear_system_test.cc
@@ -101,7 +101,7 @@ TEST_P(TrajectoryLinearSystemTest, Derivatives) {
       EXPECT_TRUE(CompareMatrices(
           A * x + B * u, derivatives_->get_vector().CopyToVector(), tol));
     } else {
-      dut_->CalcDiscreteVariableUpdates(*context_, updates_.get());
+      dut_->CalcForcedDiscreteVariableUpdate(*context_, updates_.get());
       EXPECT_TRUE(CompareMatrices(A * x + B * u,
                                   updates_->get_vector(0).CopyToVector(), tol));
     }

--- a/systems/primitives/test/trajectory_linear_system_test.cc
+++ b/systems/primitives/test/trajectory_linear_system_test.cc
@@ -101,7 +101,7 @@ TEST_P(TrajectoryLinearSystemTest, Derivatives) {
       EXPECT_TRUE(CompareMatrices(
           A * x + B * u, derivatives_->get_vector().CopyToVector(), tol));
     } else {
-      dut_->CalcForcedDiscreteVariableUpdate(*context_, updates_.get());
+      updates_->SetFrom(dut_->EvalUniquePeriodicDiscreteUpdate(*context_));
       EXPECT_TRUE(CompareMatrices(A * x + B * u,
                                   updates_->get_vector(0).CopyToVector(), tol));
     }

--- a/systems/primitives/test/vector_log_sink_test.cc
+++ b/systems/primitives/test/vector_log_sink_test.cc
@@ -165,7 +165,7 @@ GTEST_TEST(TestVectorLogSink, ForcedPublishOnly) {
 
   EXPECT_EQ(log.num_samples(), 0);
 
-  diagram->Publish(*context);
+  diagram->ForcedPublish(*context);
   EXPECT_EQ(log.num_samples(), 1);
 }
 
@@ -183,7 +183,7 @@ GTEST_TEST(TestVectorLogSink, NoForcedPublish) {
 
   EXPECT_EQ(log.num_samples(), 0);
 
-  diagram->Publish(*context);
+  diagram->ForcedPublish(*context);
   EXPECT_EQ(log.num_samples(), 0);
 }
 

--- a/systems/sensors/test/optitrack_sender_test.cc
+++ b/systems/sensors/test/optitrack_sender_test.cc
@@ -47,7 +47,7 @@ GTEST_TEST(OptitrackSenderTest, OptitrackLcmSenderTest) {
   auto output = dut.AllocateOutput();
   dut.get_input_port(0).FixValue(context.get(), pose_vector);
 
-  dut.CalcUnrestrictedUpdate(*context, &context->get_mutable_state());
+  dut.CalcForcedUnrestrictedUpdate(*context, &context->get_mutable_state());
   dut.CalcOutput(*context, output.get());
   auto output_value = output->get_data(0);
 

--- a/systems/trajectory_optimization/direct_transcription.cc
+++ b/systems/trajectory_optimization/direct_transcription.cc
@@ -113,7 +113,7 @@ class DirectTranscriptionConstraint : public solvers::Constraint {
       *y = next_state - context->get_continuous_state_vector().CopyToVector();
     } else {
       context->SetDiscreteState(0, state);
-      integrator_->get_system().CalcDiscreteVariableUpdates(
+      integrator_->get_system().CalcForcedDiscreteVariableUpdate(
           *context, discrete_state_.get());
       *y = next_state - discrete_state_->get_vector(0).get_value();
     }
@@ -292,8 +292,8 @@ bool DirectTranscription::AddSymbolicDynamicConstraints(
 
     if (discrete_time_system_) {
       symbolic_context->SetDiscreteState(state(i).cast<Expression>());
-      symbolic_system->CalcDiscreteVariableUpdates(*symbolic_context,
-                                                   discrete_state.get());
+      symbolic_system->CalcForcedDiscreteVariableUpdate(*symbolic_context,
+                                                        discrete_state.get());
       next_state = discrete_state->get_vector(0).get_value();
     } else {
       symbolic_context->SetContinuousState(state(i).cast<Expression>());

--- a/systems/trajectory_optimization/direct_transcription.cc
+++ b/systems/trajectory_optimization/direct_transcription.cc
@@ -113,8 +113,8 @@ class DirectTranscriptionConstraint : public solvers::Constraint {
       *y = next_state - context->get_continuous_state_vector().CopyToVector();
     } else {
       context->SetDiscreteState(0, state);
-      integrator_->get_system().CalcForcedDiscreteVariableUpdate(
-          *context, discrete_state_.get());
+      discrete_state_->SetFrom(
+          integrator_->get_system().EvalUniquePeriodicDiscreteUpdate(*context));
       *y = next_state - discrete_state_->get_vector(0).get_value();
     }
   }
@@ -275,9 +275,6 @@ bool DirectTranscription::AddSymbolicDynamicConstraints(
   const InputPort<Expression>* input_port =
       symbolic_system->get_input_port_selection(input_port_index);
 
-  std::unique_ptr<DiscreteValues<Expression>> discrete_state =
-      discrete_time_system_ ? symbolic_system->AllocateDiscreteVariables() :
-      nullptr;
   ExplicitEulerIntegrator<Expression> integrator(
       *symbolic_system, fixed_timestep(), symbolic_context.get());
   integrator.Initialize();
@@ -292,9 +289,9 @@ bool DirectTranscription::AddSymbolicDynamicConstraints(
 
     if (discrete_time_system_) {
       symbolic_context->SetDiscreteState(state(i).cast<Expression>());
-      symbolic_system->CalcForcedDiscreteVariableUpdate(*symbolic_context,
-                                                        discrete_state.get());
-      next_state = discrete_state->get_vector(0).get_value();
+      const DiscreteValues<Expression>& discrete_state =
+          symbolic_system->EvalUniquePeriodicDiscreteUpdate(*symbolic_context);
+      next_state = discrete_state.get_vector(0).get_value();
     } else {
       symbolic_context->SetContinuousState(state(i).cast<Expression>());
       DRAKE_THROW_UNLESS(integrator.IntegrateWithSingleFixedStepToTime(

--- a/systems/trajectory_optimization/test/direct_transcription_test.cc
+++ b/systems/trajectory_optimization/test/direct_transcription_test.cc
@@ -41,7 +41,7 @@ class CubicPolynomialSystem final : public systems::LeafSystem<T> {
         timestep_(timestep) {
     // Zero inputs, zero outputs.
     this->DeclareDiscreteState(1);  // One state variable.
-    this->DeclarePeriodicDiscreteUpdate(timestep);
+    this->DeclarePeriodicDiscreteUpdateNoHandler(timestep);
   }
 
   // Scalar-converting copy constructor.
@@ -75,7 +75,7 @@ class LinearSystemWParams final : public systems::LeafSystem<T> {
     // Zero inputs, zero outputs.
     this->DeclareDiscreteState(1);                     // One state variable.
     this->DeclareNumericParameter(BasicVector<T>(1));  // One parameter.
-    this->DeclarePeriodicDiscreteUpdate(1.0);
+    this->DeclarePeriodicDiscreteUpdateNoHandler(1.0);
   }
 
   // Scalar-converting copy constructor.


### PR DESCRIPTION
Deprecates problematic Event API names, replace with better ones, modify call sites, improve documentation. Modernizes some examples and tests to use event+handler rather than dispatcher override.

Resolves #10915 

### Background
The Drake Event system and API are an endless source of confusion. In particular, the anachronistic "forced events with no handlers" cause much trouble. Part of the confusion is that methods which trigger only forced events have the same names as general methods that handle modern events (with handlers). Here we rename them for a modest improvement in clarity.

In addition there are three periodic event sugar methods that declare events with no handlers, requiring overloading of the event dispatchers to make anything happen. Unfortunately despite their obscure behavior they have friendly names encouraging their use. Here we give them uglier names that accurately reflect what they do, and change the documentation to say "(Advanced)" and direct users to the better functions.

In case it's not clear how these are related (and I bet it isn't!), this has been a common practice:
- Use the declaration sugar methods to declare periodic events with no handlers
- Override the matching dispatcher (DoPublish(), DoCalcDiscreteUpdates(), DoCalcUnrestrictedUpdate()) to act as a handler
- Use the "Forced Event" methods to trigger the overloaded dispatcher and thus invoke the periodic events "handler". (Most commonly done in test code to see if the periodic events work properly.)

We already have better APIs that allow:
- Declaring periodic events with supplied handlers
- Manually triggering the events and executing the handlers for testing or other purposes
- Leaving the default dispatchers untouched

Some of the old-style code is modernized here along with necessary changes to all call sites.

### Details
Renamings:

Old name | New name
-----------|--------------
Publish(context)                                                       | ForcedPublish
CalcDiscreteVariableUpdates(context, &variables)  | CalcForcedDiscreteVariableUpdate
CalcUnrestrictedUpdate(context, &state)                | CalcForcedUnrestrictedUpdate
.                                                                                | .
DeclarePeriodicPublish(period, offset)                     | DeclarePeriodicPublishNoHandler
DeclarePeriodicDiscreteUpdate(period, offset)        | DeclarePeriodicDiscreteUpdateNoHandler
DeclarePeriodicUnrestrictedUpdate(period, offset) | DeclarePeriodicUnrestrictedUpdateNoHandler

This also has the advantage of making it easier to find the places where we are still using the dispreferred "forced event/dispatcher override" pattern rather than the "event/handler" pattern.  I was surprised at how many call sites there were!

In addition I am correcting the inconsistent use of plural "Updates" for consistency with everything else that uses singular "Update":

Old name | New name
-----------|--------------
CalcDiscreteVariableUpdates(context, collection, &variables) | CalcDiscreteVariableUpdate

Call sites and bindings are fixed here. I did not change names of protected virtuals for the dispatchers; that would cause a lot of trouble for diminishing gains as the overrides are unnecessary and will ultimately disappear.
I will check Anzu and provide a PR to fix its call sites also.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18106)
<!-- Reviewable:end -->
