### PR TITLE
Fix installation of symlinks

### DIFF
--- a/tools/install/BUILD.bazel
+++ b/tools/install/BUILD.bazel
@@ -44,6 +44,11 @@ drake_py_binary(
     deps = [":otool"],
 )
 
+drake_py_unittest(
+    name = "installer_test",
+    data = [":installer"],
+)
+
 # Runs `install_test_helper` unit tests.
 drake_py_unittest(
     name = "install_test_helper_test",

--- a/tools/install/installer.py
+++ b/tools/install/installer.py
@@ -142,6 +142,8 @@ class Installer:
         """
         relative_link = _is_relative_link(src)
         if relative_link:
+            if os.path.exists(dst) or os.path.islink(dst):
+                os.unlink(dst)
             os.symlink(relative_link, dst)
         else:
             shutil.copy2(src, dst)

--- a/tools/install/test/installer_test.py
+++ b/tools/install/test/installer_test.py
@@ -1,0 +1,42 @@
+"""Tests the behavior of targets that use `installer.py`."""
+
+import os
+from os.path import isdir, join
+import unittest
+
+from drake.tools.install.installer import Installer
+
+
+class TestInstall(unittest.TestCase):
+    def get_tmpdir(self):
+        assert "TEST_TMPDIR" in os.environ, (
+            "Must only be run within `bazel test`.")
+        return os.environ["TEST_TMPDIR"]
+
+    def get_install_dir(self, case):
+        install_dir = join(self.get_tmpdir(), "installation", case)
+        # Ensure this is only called once per case.
+        os.makedirs(install_dir, exist_ok=False)
+        return install_dir
+
+    def test_install_symlink(self):
+        installer = Installer()
+
+        # Create a relative symlink to be installed (which happens to be a
+        # broken link, but that doesn't matter for the test). Note that 'src'
+        # here refers to the location of the artifact to be installed.
+        src = join(self.get_tmpdir(), 'link')
+        os.symlink(src="missing", dst=src)
+
+        # Get the install location.
+        install_dir = self.get_install_dir("install_symlink")
+        dst = join(install_dir, 'link')
+
+        # Install the link and verify that it was installed.
+        installer.copy_or_link(src, dst)
+        assert os.path.islink(dst), "Link was not created."
+
+        # Repeat, to verify that we can overwrite an existing symlink.
+        # (See issue #18007.)
+        installer.copy_or_link(src, dst)
+        assert os.path.islink(dst), "Link was not created."


### PR DESCRIPTION
Tweak logic to install symlinks to forcibly replace existing entities. This behavior is more consistent with installing files, which already replaces existing entities.

Also, add the start of a unit test suite for the installer, testing this function specifically.

Fixes #18007.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18107)
<!-- Reviewable:end -->
