### PR TITLE
[pydrake] Bind all model directives

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -136,6 +136,7 @@ drake_pybind_library(
     package_info = PACKAGE_INFO,
     py_deps = [
         ":module_py",
+        "//bindings/pydrake/common:schema_py",
     ],
 )
 

--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -24,6 +24,8 @@ PYBIND11_MODULE(parsing, m) {
   using namespace drake::multibody;
   constexpr auto& doc = pydrake_doc.drake.multibody;
 
+  py::module::import("pydrake.common.schema");
+
   // PackageMap
   {
     using Class = PackageMap;
@@ -85,9 +87,59 @@ PYBIND11_MODULE(parsing, m) {
 
   // Model Directives
   {
-    using Class = parsing::ModelDirectives;
-    constexpr auto& cls_doc = doc.parsing.ModelDirectives;
-    py::class_<Class> cls(m, "ModelDirectives", cls_doc.doc);
+    using Class = parsing::AddWeld;
+    constexpr auto& cls_doc = doc.parsing.AddWeld;
+    py::class_<Class> cls(m, "AddWeld", cls_doc.doc);
+    cls.def(ParamInit<Class>());
+    DefAttributesUsingSerialize(&cls, cls_doc);
+    DefReprUsingSerialize(&cls);
+    DefCopyAndDeepCopy(&cls);
+  }
+
+  {
+    using Class = parsing::AddModel;
+    constexpr auto& cls_doc = doc.parsing.AddModel;
+    py::class_<Class> cls(m, "AddModel", cls_doc.doc);
+    cls.def(ParamInit<Class>());
+    DefAttributesUsingSerialize(&cls, cls_doc);
+    DefReprUsingSerialize(&cls);
+    DefCopyAndDeepCopy(&cls);
+  }
+
+  {
+    using Class = parsing::AddModelInstance;
+    constexpr auto& cls_doc = doc.parsing.AddModelInstance;
+    py::class_<Class> cls(m, "AddModelInstance", cls_doc.doc);
+    cls.def(ParamInit<Class>());
+    DefAttributesUsingSerialize(&cls, cls_doc);
+    DefReprUsingSerialize(&cls);
+    DefCopyAndDeepCopy(&cls);
+  }
+
+  {
+    using Class = parsing::AddFrame;
+    constexpr auto& cls_doc = doc.parsing.AddFrame;
+    py::class_<Class> cls(m, "AddFrame", cls_doc.doc);
+    cls.def(ParamInit<Class>());
+    DefAttributesUsingSerialize(&cls, cls_doc);
+    DefReprUsingSerialize(&cls);
+    DefCopyAndDeepCopy(&cls);
+  }
+
+  {
+    using Class = parsing::AddCollisionFilterGroup;
+    constexpr auto& cls_doc = doc.parsing.AddCollisionFilterGroup;
+    py::class_<Class> cls(m, "AddCollisionFilterGroup", cls_doc.doc);
+    cls.def(ParamInit<Class>());
+    DefAttributesUsingSerialize(&cls, cls_doc);
+    DefReprUsingSerialize(&cls);
+    DefCopyAndDeepCopy(&cls);
+  }
+
+  {
+    using Class = parsing::AddDirectives;
+    constexpr auto& cls_doc = doc.parsing.AddDirectives;
+    py::class_<Class> cls(m, "AddDirectives", cls_doc.doc);
     cls.def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
     DefReprUsingSerialize(&cls);
@@ -98,6 +150,16 @@ PYBIND11_MODULE(parsing, m) {
     using Class = parsing::ModelDirective;
     constexpr auto& cls_doc = doc.parsing.ModelDirective;
     py::class_<Class> cls(m, "ModelDirective", cls_doc.doc);
+    cls.def(ParamInit<Class>());
+    DefAttributesUsingSerialize(&cls, cls_doc);
+    DefReprUsingSerialize(&cls);
+    DefCopyAndDeepCopy(&cls);
+  }
+
+  {
+    using Class = parsing::ModelDirectives;
+    constexpr auto& cls_doc = doc.parsing.ModelDirectives;
+    py::class_<Class> cls(m, "ModelDirectives", cls_doc.doc);
     cls.def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
     DefReprUsingSerialize(&cls);
@@ -125,17 +187,6 @@ PYBIND11_MODULE(parsing, m) {
         .def_readonly("X_PC", &Class::X_PC, cls_doc.X_PC.doc)
         .def_readonly("model_instance", &Class::model_instance,
             cls_doc.model_instance.doc);
-  }
-
-  // Individual directives are not bound here (they are generally loaded from
-  // yaml rather than constructed explicitly), but some downstream users use
-  // this type as a return value which requires an explicit binding.
-  {
-    using Class = drake::multibody::parsing::AddFrame;
-    constexpr auto& cls_doc = doc.parsing.AddFrame;
-    py::class_<Class>(m, "AddFrame")
-        .def_readonly("name", &Class::name, cls_doc.name.doc)
-        .def_readonly("X_PF", &Class::X_PF, cls_doc.X_PF.doc);
   }
 
   m.def("ProcessModelDirectives",

--- a/bindings/pydrake/multibody/test/parsing_test.py
+++ b/bindings/pydrake/multibody/test/parsing_test.py
@@ -1,17 +1,22 @@
 # -*- coding: utf-8 -*-
 
 from pydrake.multibody.parsing import (
-    Parser,
-    PackageMap,
+    AddCollisionFilterGroup,
+    AddDirectives,
+    AddFrame,
+    AddModel,
+    AddModelInstance,
+    AddWeld,
+    GetScopedFrameByName,
+    GetScopedFrameName,
     LoadModelDirectives,
     LoadModelDirectivesFromString,
     ModelDirective,
     ModelDirectives,
-    ProcessModelDirectives,
     ModelInstanceInfo,
-    AddFrame,
-    GetScopedFrameByName,
-    GetScopedFrameName,
+    PackageMap,
+    Parser,
+    ProcessModelDirectives,
 )
 
 import copy
@@ -130,11 +135,6 @@ class TestParsing(unittest.TestCase):
         ModelInstanceInfo.X_PC
         ModelInstanceInfo.model_instance
 
-    def test_add_frame(self):
-        """Checks that AddFrame bindings exist."""
-        AddFrame.name
-        AddFrame.X_PF
-
     def test_scoped_frame_names(self):
         plant = MultibodyPlant(time_step=0.01)
         frame = GetScopedFrameByName(plant, "world")
@@ -179,23 +179,58 @@ directives:
         self.assertIn("extra_model", model_names)
         plant.GetModelInstanceByName("extra_model")
 
+    def test_add_collision_filter_group_struct(self):
+        """Checks the bindings of the AddCollisionFilterGroup helper struct."""
+        dut = AddCollisionFilterGroup(name="foo")
+        self.assertIn("foo", repr(dut))
+        copy.copy(dut)
+        copy.deepcopy(dut)
+
+    def test_add_directives_struct(self):
+        """Checks the bindings of the AddDirectives helper struct."""
+        dut = AddDirectives(file="package://foo/bar.dmd.yaml")
+        self.assertIn("bar.dmd.yaml", repr(dut))
+        copy.copy(dut)
+        copy.deepcopy(dut)
+
+    def test_add_frame_struct(self):
+        """Checks the bindings of the AddFrame helper struct."""
+        dut = AddFrame(name="foo")
+        self.assertIn("foo", repr(dut))
+        copy.copy(dut)
+        copy.deepcopy(dut)
+
+    def test_add_model_struct(self):
+        """Checks the bindings of the AddModel helper struct."""
+        dut = AddModel(file="package://foo/bar.sdf")
+        self.assertIn("bar.sdf", repr(dut))
+        copy.copy(dut)
+        copy.deepcopy(dut)
+
+    def test_add_model_instance_struct(self):
+        """Checks the bindings of the AddModelInstance helper struct."""
+        dut = AddModelInstance(name="foo")
+        self.assertIn("foo", repr(dut))
+        copy.copy(dut)
+        copy.deepcopy(dut)
+
+    def test_add_weld_struct(self):
+        """Checks the bindings of the AddWeld helper struct."""
+        dut = AddWeld(parent="foo")
+        self.assertIn("foo", repr(dut))
+        copy.copy(dut)
+        copy.deepcopy(dut)
+
     def test_model_directive_struct(self):
         """Checks the bindings of the ModelDirective helper struct."""
         dut = ModelDirective(add_model=None)
-        dut.add_model = None
-        dut.add_model_instance = None
-        dut.add_frame = None
-        dut.add_weld = None
-        dut.add_collision_filter_group = None
-        dut.add_directives = None
-        self.assertIn("add_collision_filter_group", repr(dut))
+        self.assertIn("add_model", repr(dut))
         copy.copy(dut)
         copy.deepcopy(dut)
 
     def test_model_directives_struct(self):
         """Checks the bindings of the ModelDirectives helper struct."""
-        directive = ModelDirective()
-        dut = ModelDirectives(directives=[directive])
-        self.assertIn("add_collision_filter_group", repr(dut))
+        dut = ModelDirectives(directives=[ModelDirective()])
+        self.assertIn("add_model", repr(dut))
         copy.copy(dut)
         copy.deepcopy(dut)


### PR DESCRIPTION
Sometimes it's convenient to be able to parse and inspect the directives from Python.

Relatedly, fix bindings order to match physical dependency order (i.e., always bind child structs prior to binding their enclosing structs) for both `ModelDirectives` and `CameraConfig`.

Towards #18109 in service of #17112.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18108)
<!-- Reviewable:end -->
