### PR TITLE
[pydrake] Bind dataclass-like schemas for serializable structs

### DIFF
--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -287,7 +287,54 @@ drake_cc_library(
     hdrs = ["serialize_pybind.h"],
     declare_installed_headers = 0,
     visibility = ["//visibility:public"],
-    deps = ["//:drake_shared_library"],
+    deps = [
+        "//:drake_shared_library",
+        "//bindings/pydrake:pydrake_pybind",
+    ],
+)
+
+drake_pybind_library(
+    name = "serialize_test_foo_py",
+    testonly = 1,
+    add_install = False,
+    cc_deps = [":serialize_pybind"],
+    cc_so_name = "test/serialize_test_foo",
+    cc_srcs = [
+        "test/serialize_test_foo_py.cc",
+        "test/serialize_test_foo_py.h",
+    ],
+    package_info = PACKAGE_INFO,
+    py_deps = [
+        ":cpp_param_py",
+        ":module_py",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+drake_pybind_library(
+    name = "serialize_test_bar_py",
+    testonly = 1,
+    add_install = False,
+    cc_deps = [":serialize_pybind"],
+    cc_so_name = "test/serialize_test_bar",
+    cc_srcs = [
+        "test/serialize_test_bar_py.cc",
+        "test/serialize_test_foo_py.h",
+    ],
+    package_info = PACKAGE_INFO,
+    py_deps = [
+        ":cpp_param_py",
+        ":module_py",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+drake_py_unittest(
+    name = "serialize_import_failure_test",
+    deps = [
+        ":serialize_test_bar_py",
+        ":serialize_test_foo_py",
+    ],
 )
 
 drake_pybind_library(
@@ -299,6 +346,7 @@ drake_pybind_library(
     cc_srcs = ["test/serialize_test_util_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
+        ":cpp_param_py",
         ":module_py",
     ],
     visibility = ["//visibility:private"],

--- a/bindings/pydrake/common/serialize_pybind.h
+++ b/bindings/pydrake/common/serialize_pybind.h
@@ -1,17 +1,24 @@
 #pragma once
 
 #include <climits>
+#include <map>
+#include <optional>
 #include <sstream>
 #include <string>
+#include <type_traits>
 #include <utility>
+#include <variant>
 #include <vector>
 
+#include "bindings/pydrake/pydrake_pybind.h"
+#include "pybind11/eigen.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 #include <fmt/format.h>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
+#include "drake/common/eigen_types.h"
 
 namespace drake {
 namespace pydrake {
@@ -51,20 +58,20 @@ class DefAttributesArchive {
     const int offset = CalcClassOffset(prototype_value);
 
     // Define property functions to get and set this particular field.
-    pybind11::cpp_function getter(
+    py::cpp_function getter(
         [offset](const CxxClass& self) -> const T& {
           const T* const field_in_self = reinterpret_cast<const T*>(
               reinterpret_cast<const char*>(&self) + offset);
           return *field_in_self;
         },
-        pybind11::is_method(*ppy_class_));
-    pybind11::cpp_function setter(
+        py::is_method(*ppy_class_));
+    py::cpp_function setter(
         [offset](CxxClass& self, const T& value) {
           T* const field_in_self =
               reinterpret_cast<T*>(reinterpret_cast<char*>(&self) + offset);
           *field_in_self = value;
         },
-        pybind11::is_method(*ppy_class_));
+        py::is_method(*ppy_class_));
 
     // Fetch the docstring (or the empty string, if we aren't using docstrings).
     const char* doc = "";
@@ -83,11 +90,27 @@ class DefAttributesArchive {
     }
 
     // Add the binding.
-    ppy_class_->def_property(name, getter, setter, doc,
-        pybind11::return_value_policy::reference_internal);
+    ppy_class_->def_property(
+        name, getter, setter, doc, py::return_value_policy::reference_internal);
+
+    // Remember the field's name and type for later use by Finished().
+    auto field = py::module::import("types").attr("SimpleNamespace")();
+    py::setattr(field, "name", py::str(name));
+    py::setattr(field, "type", CalcSchemaType(prototype_value));
+    fields_.append(field);
   }
 
-  // Return the offset (in bytes) of `address` within our `prototype_` object.
+  // To be called after Serialize() is complete; binds any members that are
+  // scoped to the entire struct (rather than one field at a time).
+  void Finished() {
+    ppy_class_->def_property_readonly_static("__fields__",
+        [fields_tuple = py::tuple(fields_)](py::object /* self */) {  // BR
+          return fields_tuple;
+        });
+  }
+
+ private:
+  // Returns the offset (in bytes) of `address` within our `prototype_` object.
   // Fails if the address does not fall within the `prototype_` object.
   int CalcClassOffset(const void* address) {
     static_assert(sizeof(CxxClass) < INT_MAX);
@@ -98,10 +121,108 @@ class DefAttributesArchive {
     return reinterpret_cast<const char*>(address) - begin;
   }
 
- private:
+  // Returns the python type annotation corresponding to the given T.
+  //
+  // Our goal here is to align with what pybind11::type_caster produces when we
+  // bind this struct's C++ member fields as Python attributes, e.g., for a C++
+  // type `int16_t` we'll return the Python type `int` not `np.int16`. For any
+  // compound types (list, dict, Union, etc.) we'll use Python's conventional
+  // generic types (either the builtins or via `typing`) but via the cpp_param
+  // logic to ensure that alias types are always canonicalized.
+  //
+  // This logic is similar to GetPyParam<T> (in cpp_param_pybind.h) but with
+  // the important difference that in our case the primitive types follow the
+  // type_caster<> rules (C++ int16_t => Python int) whereas GetPyParam uses
+  // the numpy sizes (C++ int16_t => Python np.int16). For the purposes of
+  // DefAttributesUsingSerialize we want the return type of property getters
+  // (which use the type_caster<>) to match the schema type.
+  //
+  // Note that the argument pointer is ignored (can be nullptr).
+  // Note that this template function is specialized below for container types.
+  //
+  // @tparam T the C++ type for which we'll return the Python type.
+  template <typename T>
+  static py::object CalcSchemaType(const T*) {
+    // Pybind11 doesn't support type::of<> for primitive types, so we must
+    // match them manually. See https://github.com/pybind/pybind11/issues/2486.
+    if constexpr (std::is_same_v<T, bool>) {
+      return py::type::of(py::bool_());
+    } else if constexpr (std::is_integral_v<T>) {
+      return py::type::of(py::int_());
+    } else if constexpr (std::is_floating_point_v<T>) {
+      return py::type::of(py::float_());
+    } else if constexpr (std::is_same_v<T, std::string>) {
+      return py::type::of(py::str());
+    } else if constexpr (is_eigen_type<T>::value) {
+      // TODO(jwnimmer-tri) Perhaps we can use numpy.typing here some day?
+      return py::module::import("numpy").attr("ndarray");
+    } else {
+      // Anything that remains should be a registered C++ type.
+      constexpr bool is_registered_type =
+          std::is_base_of_v<py::detail::type_caster_generic,
+              py::detail::make_caster<T>>;
+      if constexpr (is_registered_type) {
+        return py::type::of<T>();
+      } else {
+        return CannotIdentifySchemaType<T>();
+      }
+    }
+  }
+
+  // Partial specialization for List.
+  template <typename U>
+  static py::object CalcSchemaType(const std::vector<U>*) {
+    auto u_type = CalcSchemaType(static_cast<U*>(nullptr));
+    return GetTemplateClass("List")[u_type];
+  }
+
+  // Partial specialization for Dict.
+  template <typename U, typename V>
+  static py::object CalcSchemaType(const std::map<U, V>*) {
+    auto u_type = CalcSchemaType(static_cast<U*>(nullptr));
+    auto v_type = CalcSchemaType(static_cast<V*>(nullptr));
+    auto inner_types = py::make_tuple(u_type, v_type);
+    return GetTemplateClass("Dict")[inner_types];
+  }
+
+  // Partial specialization for Optional.
+  template <typename U>
+  static py::object CalcSchemaType(const std::optional<U>*) {
+    auto u_type = CalcSchemaType(static_cast<U*>(nullptr));
+    return GetTemplateClass("Optional")[u_type];
+  }
+
+  // Partial specialization for Union.
+  template <typename... Types>
+  static py::object CalcSchemaType(const std::variant<Types...>*) {
+    auto inner_types = py::make_tuple(  // BR
+        CalcSchemaType(static_cast<Types*>(nullptr))...);
+    return GetTemplateClass("Union")[inner_types];
+  }
+
+  // Returns the cpp_param template class for the given name (e.g., "List",
+  // "Dict", etc.).
+  static py::object GetTemplateClass(const char* name) {
+    return py::module::import("pydrake.common.cpp_param").attr(name);
+  }
+
+  // When there is no match found for the schema type, this function will
+  // produce a compile-time error that's at least somewhat readable.
+  template <typename T>
+  static py::object CannotIdentifySchemaType(T*) {
+    // N.B. This static_assert will always fail, but with a nice message.
+    static_assert(std::is_same_v<T, void>,
+        "DefAttributesUsingSerialize() could not understand a field type");
+    return py::none();
+  }
+
   PyClass* const ppy_class_;
   CxxClass* const prototype_;
   const Docs* const cls_docs_;
+
+  // As we visit each field, we'll accumulate a list of [{name=, type=}, ...]
+  // to bind later as the `__fields__` static propery.
+  py::list fields_;
 };
 
 }  // namespace internal
@@ -120,6 +241,7 @@ void DefAttributesUsingSerialize(PyClass* ppy_class, const Docs& cls_docs) {
   CxxClass prototype{};
   internal::DefAttributesArchive archive(ppy_class, &prototype, &cls_docs);
   prototype.Serialize(&archive);
+  archive.Finished();
 }
 
 /// (Advanced) An overload that doesn't bind docstrings. We expect that pydrake
@@ -166,16 +288,16 @@ void DefReprUsingSerialize(PyClass* ppy_class) {
   CxxClass prototype{};
   prototype.Serialize(&archive);
   ppy_class->def("__repr__",
-      [names = std::move(archive.property_names())](pybind11::object self) {
+      [names = std::move(archive.property_names())](py::object self) {
         std::ostringstream result;
-        result << pybind11::str(self.attr("__class__").attr("__name__"));
+        result << py::str(self.attr("__class__").attr("__name__"));
         result << "(";
         bool first = true;
         for (const std::string& name : names) {
           if (!first) {
             result << ", ";
           }
-          result << name << "=" << pybind11::repr(self.attr(name.c_str()));
+          result << name << "=" << py::repr(self.attr(name.c_str()));
           first = false;
         }
         result << ")";

--- a/bindings/pydrake/common/test/serialize_import_failure_test.py
+++ b/bindings/pydrake/common/test/serialize_import_failure_test.py
@@ -1,0 +1,16 @@
+import unittest
+
+
+class TestSerializeImportFailure(unittest.TestCase):
+
+    def test_import_exception(self):
+        """Confirms that serialized types will fail-fast when they are missing
+        a py::module::import() statement for a member field's type.
+        """
+        # Bar has a field of type Foo, but forgot to py::import it.
+        # This is an error.
+        with self.assertRaises(ImportError) as cm:
+            from pydrake.common.test.serialize_test_bar import Bar
+        message = str(cm.exception)
+        self.assertIn("unable to find type info", message)
+        self.assertIn("drake::pydrake::test::Foo", message)

--- a/bindings/pydrake/common/test/serialize_pybind_test.py
+++ b/bindings/pydrake/common/test/serialize_pybind_test.py
@@ -1,49 +1,140 @@
 import inspect
+import typing
 import unittest
 
+import numpy as np
+
 from pydrake.common.test.serialize_test_util import (
-    MyData,
+    MyData1,
     MyData2
 )
 
 
 class TestSerializePybind(unittest.TestCase):
 
-    def test_attributes_using_serialize_structure(self):
-        """Tests that DefAttributesUsingSerialize binds the class properties
-        for read and write.
+    @staticmethod
+    def _make_data1():
+        return MyData1(quux=22.0)
+
+    @staticmethod
+    def _make_data2():
+        return MyData2(
+            some_bool=False,
+            some_int=1,
+            some_uint64=1 << 48,
+            some_float=0.5,
+            some_double=2.0,
+            some_string="3",
+            some_eigen=[4.4],
+            some_optional=None,
+            some_vector=[5.0, 6.0],
+            some_map={'key': 7},
+            some_variant=8.0)
+
+    def test_attributes_using_serialize_no_docs(self):
+        """Tests the DefAttributesUsingSerialize overload WITHOUT docstrings.
         """
-        dut = MyData(foo=1.0, bar=[2.0, 3.0])
-
-        self.assertEqual(dut.foo, 1.0)
-        dut.foo = -1.0
-        self.assertEqual(dut.foo, -1.0)
-
-        self.assertListEqual(dut.bar, [2.0, 3.0])
-        dut.bar = [-2.0, -3.0]
-        self.assertListEqual(dut.bar, [-2.0, -3.0])
-
-    def test_attributes_using_serialize_docs(self):
-        """Tests that DefAttributesUsingSerialize adds docstrings to the bound
-        fields.
-        """
-        self.assertEqual(inspect.getdoc(MyData.foo),
-                         "This is the field docstring for foo.")
-        self.assertEqual(inspect.getdoc(MyData.bar),
-                         "This is the field docstring for bar.")
-
-    def test_attributes_using_serialize_no_docstrings(self):
-        """Sanity checks the DefAttributesUsingSerialize overload that does not
-        use docstrings.
-        """
-        dut = MyData2(quux=1.0)
+        # Basic read / write.
+        dut = MyData1(quux=1.0)
         self.assertEqual(dut.quux, 1.0)
         dut.quux = -1.0
-        self.assertEqual(dut.quux, -1.0)
-        self.assertEqual(inspect.getdoc(MyData2.quux), "")
 
-    def test_repr_using_serialize(self):
-        self.assertEqual(repr(MyData(foo=1.0, bar=[2.0, 3.0])),
-                         "MyData(foo=1.0, bar=[2.0, 3.0])")
-        self.assertEqual(repr(MyData2(quux=1.0)),
-                         "MyData2(quux=1.0)")
+        # No docs.
+        self.assertEqual(dut.quux, -1.0)
+        self.assertEqual(inspect.getdoc(MyData1.quux), "")
+
+    def test_attributes_using_serialize_with_docs(self):
+        """Tests the DefAttributesUsingSerialize overload WITH docstrings.
+        """
+        # Basic read / write.
+        dut = MyData2(some_double=1.0)
+        self.assertEqual(dut.some_double, 1.0)
+        dut.some_double = -1.0
+        self.assertEqual(dut.some_double, -1.0)
+
+        # We'll just spot-check a few of the docs; that should be enough.
+        self.assertEqual(inspect.getdoc(MyData2.some_double),
+                         "Field docstring for a double.")
+        self.assertEqual(inspect.getdoc(MyData2.some_vector),
+                         "Field docstring for a vector.")
+
+    def test_attributes_using_serialize_types(self):
+        """Probes the details of DefAttributesUsingSerialize all of the
+        possible types of fields.
+        """
+        dut = self._make_data2()
+
+        # Reset all fields.
+        dut.some_bool = True
+        dut.some_int = 10
+        dut.some_uint64 = 1 << 52
+        dut.some_float = 5.0
+        dut.some_double = 20.0
+        dut.some_string = "30"
+        dut.some_eigen = [44.4]
+        dut.some_optional = -1.0
+        dut.some_vector = [50.0, 60.0]
+        dut.some_map = {'new_key': 70}
+        dut.some_variant = 80.0
+
+        # Read back all fields.
+        self.assertEqual(dut.some_bool, True)
+        self.assertEqual(dut.some_int, 10)
+        self.assertEqual(dut.some_uint64, 1 << 52)
+        self.assertEqual(dut.some_float, 5.0)
+        self.assertEqual(dut.some_double, 20.0)
+        self.assertEqual(dut.some_string, "30")
+        self.assertEqual(dut.some_eigen, [44.4])
+        self.assertEqual(dut.some_optional, -1.0)
+        self.assertEqual(dut.some_vector, [50.0, 60.0])
+        self.assertEqual(dut.some_map, {'new_key': 70})
+        self.assertEqual(dut.some_variant, 80.0)
+
+        try:
+            # Use the PEP-585 types if supported (Python >= 3.9).
+            expected_vector_type = list[float]
+            expected_dict_type = dict[str, float]
+        except TypeError:
+            # Otherwise, use the Python 3.8 types.
+            expected_vector_type = typing.List[float]
+            expected_dict_type = typing.Dict[str, float]
+
+        # Check all field types.
+        fields = getattr(MyData2, "__fields__")
+        self.assertSequenceEqual([(x.name, x.type) for x in fields], (
+            ("some_bool", bool),
+            ("some_int", int),
+            ("some_uint64", int),
+            ("some_float", float),
+            ("some_double", float),
+            ("some_string", str),
+            ("some_eigen", np.ndarray),
+            ("some_optional", typing.Optional[float]),
+            ("some_vector", expected_vector_type),
+            ("some_map", expected_dict_type),
+            ("some_variant", typing.Union[float, MyData1])))
+
+    def test_repr_using_serialize_no_docs(self):
+        """Tests the repr() for a class bound WITHOUT docstrings.
+        (The docstrings shouldn't make any difference one way or another.)
+        """
+        self.assertEqual(repr(self._make_data1()),
+                         "MyData1(quux=22.0)")
+
+    def test_repr_using_serialize_with_docs(self):
+        """Tests the repr() for a class bound WITH docstrings.
+        (The docstrings shouldn't make any difference one way or another.)
+        """
+        self.assertEqual(repr(self._make_data2()),
+                         "MyData2("
+                         "some_bool=False, "
+                         "some_int=1, "
+                         "some_uint64=281474976710656, "
+                         "some_float=0.5, "
+                         "some_double=2.0, "
+                         "some_string='3', "
+                         "some_eigen=array([[4.4]]), "
+                         "some_optional=None, "
+                         "some_vector=[5.0, 6.0], "
+                         "some_map={'key': 7.0}, "
+                         "some_variant=8.0)")

--- a/bindings/pydrake/common/test/serialize_test_bar_py.cc
+++ b/bindings/pydrake/common/test/serialize_test_bar_py.cc
@@ -1,0 +1,33 @@
+#include "pybind11/pybind11.h"
+
+#include "drake/bindings/pydrake/common/serialize_pybind.h"
+#include "drake/bindings/pydrake/common/test/serialize_test_foo_py.h"
+#include "drake/common/name_value.h"
+
+namespace drake {
+namespace pydrake {
+namespace test {
+
+// A compound serializable struct for unit testing.
+// Bar has a member field of type Foo.
+struct Bar {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(bar_value));
+  }
+  Foo bar_value{};
+};
+
+PYBIND11_MODULE(serialize_test_bar, m) {
+  // N.B. We're _supposed_ to do `py::module::import("foo")` here because we
+  // have a serialized member field of type Foo, but instead we've injected a
+  // bug into this binding by omitting it. The regression test will confirm
+  // that `import bar` raises an exception.
+
+  py::class_<Bar> cls(m, "Bar");
+  DefAttributesUsingSerialize(&cls);
+}
+
+}  // namespace test
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/common/test/serialize_test_foo_py.cc
+++ b/bindings/pydrake/common/test/serialize_test_foo_py.cc
@@ -1,0 +1,18 @@
+#include "drake/bindings/pydrake/common/test/serialize_test_foo_py.h"
+
+#include "pybind11/pybind11.h"
+
+#include "drake/bindings/pydrake/common/serialize_pybind.h"
+
+namespace drake {
+namespace pydrake {
+namespace test {
+
+PYBIND11_MODULE(serialize_test_foo, m) {
+  py::class_<Foo> cls(m, "Foo");
+  DefAttributesUsingSerialize(&cls);
+}
+
+}  // namespace test
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/common/test/serialize_test_foo_py.h
+++ b/bindings/pydrake/common/test/serialize_test_foo_py.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "drake/common/name_value.h"
+
+namespace drake {
+namespace pydrake {
+namespace test {
+
+// A simple serializable struct for unit testing.
+struct Foo {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(foo_value));
+  }
+  int foo_value{};
+};
+
+}  // namespace test
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/common/test/serialize_test_util_py.cc
+++ b/bindings/pydrake/common/test/serialize_test_util_py.cc
@@ -12,30 +12,7 @@ namespace drake {
 namespace pydrake {
 namespace {
 
-struct MyData {
-  template <typename Archive>
-  void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(foo));
-    a->Visit(DRAKE_NVP(bar));
-  }
-  double foo{0.0};
-  std::vector<double> bar;
-};
-
-// This is a manually-created mock up of part of what mkdoc would produce for
-// the MyData struct. TODO(jwnimmer-tri) If maintaining this struct by hand
-// becomes too brittle, we could instead add BUILD rules to generate it from
-// an actual header file.
-struct MyDataDocs {
-  const char* doc = "MyDataDocs class overview.";
-  auto Serialize__fields() const {
-    return std::array{
-        std::make_pair("foo", "This is the field docstring for foo."),
-        std::make_pair("bar", "This is the field docstring for bar.")};
-  }
-};
-
-struct MyData2 {
+struct MyData1 {
   template <typename Archive>
   void Serialize(Archive* a) {
     a->Visit(DRAKE_NVP(quux));
@@ -43,24 +20,74 @@ struct MyData2 {
   double quux{0.0};
 };
 
+struct MyData2 {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(some_bool));
+    a->Visit(DRAKE_NVP(some_int));
+    a->Visit(DRAKE_NVP(some_uint64));
+    a->Visit(DRAKE_NVP(some_float));
+    a->Visit(DRAKE_NVP(some_double));
+    a->Visit(DRAKE_NVP(some_string));
+    a->Visit(DRAKE_NVP(some_eigen));
+    a->Visit(DRAKE_NVP(some_optional));
+    a->Visit(DRAKE_NVP(some_vector));
+    a->Visit(DRAKE_NVP(some_map));
+    a->Visit(DRAKE_NVP(some_variant));
+  }
+  bool some_bool{};
+  int some_int{};
+  std::uint64_t some_uint64{};
+  float some_float{};
+  double some_double{};
+  std::string some_string;
+  Eigen::MatrixXd some_eigen;
+  std::optional<double> some_optional;
+  std::vector<double> some_vector;
+  std::map<std::string, double> some_map;
+  std::variant<double, MyData1> some_variant;
+};
+
+// This is a manually-created mock up of part of what mkdoc would produce for
+// the MyData2 struct. TODO(jwnimmer-tri) If maintaining this struct by hand
+// becomes too brittle, we could instead add BUILD rules to generate it from
+// an actual header file.
+struct MyData2Docs {
+  const char* doc = "MyData2 class overview.";
+  auto Serialize__fields() const {
+    return std::array{
+        std::make_pair("some_bool", "Field docstring for a bool."),
+        std::make_pair("some_int", "Field docstring for a int."),
+        std::make_pair("some_uint64", "Field docstring for a uint64."),
+        std::make_pair("some_float", "Field docstring for a float."),
+        std::make_pair("some_double", "Field docstring for a double."),
+        std::make_pair("some_string", "Field docstring for a string."),
+        std::make_pair("some_eigen", "Field docstring for a eigen."),
+        std::make_pair("some_optional", "Field docstring for a optional."),
+        std::make_pair("some_vector", "Field docstring for a vector."),
+        std::make_pair("some_map", "Field docstring for a map."),
+        std::make_pair("some_variant", "Field docstring for a variant.")};
+  }
+};
+
 }  // namespace
 
 PYBIND11_MODULE(serialize_test_util, m) {
-  // Bind MyData along with its documentation.
-  constexpr MyDataDocs cls_doc;
-  py::class_<MyData> cls(m, "MyData", cls_doc.doc);
-  cls  // BR
+  // Bind MyData1 with no documentation.
+  py::class_<MyData1> cls1(m, "MyData1");
+  cls1  // BR
       .def(py::init())
-      .def(ParamInit<MyData>());
-  DefAttributesUsingSerialize(&cls, cls_doc);
-  DefReprUsingSerialize(&cls);
+      .def(ParamInit<MyData1>());
+  DefAttributesUsingSerialize(&cls1);
+  DefReprUsingSerialize(&cls1);
 
-  // Bind MyData2 with no documentation.
-  py::class_<MyData2> cls2(m, "MyData2");
+  // Bind MyData2 along with its documentation.
+  constexpr MyData2Docs cls2_doc;
+  py::class_<MyData2> cls2(m, "MyData2", cls2_doc.doc);
   cls2  // BR
       .def(py::init())
       .def(ParamInit<MyData2>());
-  DefAttributesUsingSerialize(&cls2);
+  DefAttributesUsingSerialize(&cls2, cls2_doc);
   DefReprUsingSerialize(&cls2);
 }
 

--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -237,18 +237,12 @@ PYBIND11_MODULE(sensors, m) {
       double{RgbdSensorDiscrete::kDefaultPeriod};
 
   {
+    // To bind nested serializable structs without errors, we declare the outer
+    // struct first, then bind its inner structs, then bind the outer struct.
     constexpr auto& config_cls_doc = doc.CameraConfig;
     py::class_<CameraConfig> config_cls(m, "CameraConfig", config_cls_doc.doc);
-    config_cls  // BR
-        .def(ParamInit<CameraConfig>())
-        .def("focal_x", &CameraConfig::focal_x, config_cls_doc.focal_x.doc)
-        .def("focal_y", &CameraConfig::focal_y, config_cls_doc.focal_y.doc)
-        .def("principal_point", &CameraConfig::principal_point,
-            config_cls_doc.principal_point.doc);
-    DefAttributesUsingSerialize(&config_cls, config_cls_doc);
-    DefReprUsingSerialize(&config_cls);
-    DefCopyAndDeepCopy(&config_cls);
 
+    // Inner struct.
     constexpr auto& fov_degrees_doc = doc.CameraConfig.FovDegrees;
     py::class_<CameraConfig::FovDegrees> fov_class(
         config_cls, "FovDegrees", fov_degrees_doc.doc);
@@ -258,6 +252,7 @@ PYBIND11_MODULE(sensors, m) {
     DefReprUsingSerialize(&fov_class);
     DefCopyAndDeepCopy(&fov_class);
 
+    // Inner struct.
     constexpr auto& focal_doc = doc.CameraConfig.FocalLength;
     py::class_<CameraConfig::FocalLength> focal_class(
         config_cls, "FocalLength", focal_doc.doc);
@@ -266,6 +261,17 @@ PYBIND11_MODULE(sensors, m) {
     DefAttributesUsingSerialize(&focal_class, focal_doc);
     DefReprUsingSerialize(&focal_class);
     DefCopyAndDeepCopy(&focal_class);
+
+    // Now we can bind the outer struct (see above).
+    config_cls  // BR
+        .def(ParamInit<CameraConfig>())
+        .def("focal_x", &CameraConfig::focal_x, config_cls_doc.focal_x.doc)
+        .def("focal_y", &CameraConfig::focal_y, config_cls_doc.focal_y.doc)
+        .def("principal_point", &CameraConfig::principal_point,
+            config_cls_doc.principal_point.doc);
+    DefAttributesUsingSerialize(&config_cls, config_cls_doc);
+    DefReprUsingSerialize(&config_cls);
+    DefCopyAndDeepCopy(&config_cls);
 
     m.def("ApplyCameraConfig",
         py::overload_cast<const CameraConfig&, DiagramBuilder<double>*,


### PR DESCRIPTION
C++ structs whose Python attributes are bound using Serialize now offer a `__fields__` static property, enabling downstream code to interrogate the static schema of the type (akin to Python's dataclasses).

One consequence of this change is that the C++ classes used as struct fields must be bound prior to binding the struct that uses them. The `CameraConfig` structs need an adjustment to accommodate this.

Towards #17112.

Requires:
- [x] #18108
- [x] #18115
- [x] #18117

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18109)
<!-- Reviewable:end -->
