### PR TITLE
[parsing] Add Parser::AddModelsFromString

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -131,6 +131,7 @@ drake_pybind_library(
     name = "parsing_py",
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:serialize_pybind",
     ],
     cc_srcs = ["parsing_py.cc"],
@@ -273,6 +274,7 @@ drake_py_unittest(
     deps = [
         ":parsing_py",
         ":plant_py",
+        "//bindings/pydrake/common/test_utilities",
     ],
 )
 

--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -1,6 +1,7 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
@@ -66,7 +67,8 @@ PYBIND11_MODULE(parsing, m) {
   {
     using Class = Parser;
     constexpr auto& cls_doc = doc.Parser;
-    py::class_<Class>(m, "Parser", cls_doc.doc)
+    auto cls = py::class_<Class>(m, "Parser", cls_doc.doc);
+    cls  // BR
         .def(py::init<MultibodyPlant<double>*, SceneGraph<double>*>(),
             py::arg("plant"), py::arg("scene_graph") = nullptr,
             cls_doc.ctor.doc)
@@ -76,13 +78,24 @@ PYBIND11_MODULE(parsing, m) {
             cls_doc.package_map.doc)
         .def("AddAllModelsFromFile", &Class::AddAllModelsFromFile,
             py::arg("file_name"), cls_doc.AddAllModelsFromFile.doc)
+        .def("AddModelsFromString", &Class::AddModelsFromString,
+            py::arg("file_contents"), py::arg("file_type"),
+            cls_doc.AddModelsFromString.doc)
         .def("AddModelFromFile", &Class::AddModelFromFile, py::arg("file_name"),
             py::arg("model_name") = "", cls_doc.AddModelFromFile.doc)
-        .def("AddModelFromString", &Class::AddModelFromString,
-            py::arg("file_contents"), py::arg("file_type"),
-            py::arg("model_name") = "", cls_doc.AddModelFromString.doc)
         .def("SetStrictParsing", &Class::SetStrictParsing,
             cls_doc.SetStrictParsing.doc);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("AddModelFromString",
+            WrapDeprecated(cls_doc.AddModelFromString.doc_deprecated,
+                &Class::AddModelFromString),
+            py::arg("file_contents"), py::arg("file_type"),
+            py::arg("model_name") = "",
+            cls_doc.AddModelFromString.doc_deprecated);
+#pragma GCC diagnostic pop
   }
 
   // Model Directives

--- a/bindings/pydrake/test/geometry_optimization_test.py
+++ b/bindings/pydrake/test/geometry_optimization_test.py
@@ -393,7 +393,7 @@ class TestGeometryOptimization(unittest.TestCase):
 </robot>"""
         builder = DiagramBuilder()
         plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
-        Parser(plant).AddModelFromString(limits_urdf, "urdf")
+        Parser(plant).AddModelsFromString(limits_urdf, "urdf")
         plant.Finalize()
         diagram = builder.Build()
         context = diagram.CreateDefaultContext()

--- a/geometry/optimization/test/iris_in_configuration_space_test.cc
+++ b/geometry/optimization/test/iris_in_configuration_space_test.cc
@@ -27,7 +27,7 @@ HPolyhedron IrisFromUrdf(const std::string urdf,
   systems::DiagramBuilder<double> builder;
   multibody::MultibodyPlant<double>& plant =
       multibody::AddMultibodyPlantSceneGraph(&builder, 0.0);
-  multibody::Parser(&plant).AddModelFromString(urdf, "urdf");
+  multibody::Parser(&plant).AddModelsFromString(urdf, "urdf");
   plant.Finalize();
   auto diagram = builder.Build();
 
@@ -509,7 +509,7 @@ GTEST_TEST(IrisInConfigurationSpaceTest, DoublePendulumEndEffectorConstraints) {
   systems::DiagramBuilder<double> builder;
   multibody::MultibodyPlant<double>& plant =
       multibody::AddMultibodyPlantSceneGraph(&builder, 0.0);
-  multibody::Parser(&plant).AddModelFromString(double_pendulum_urdf, "urdf");
+  multibody::Parser(&plant).AddModelsFromString(double_pendulum_urdf, "urdf");
   plant.Finalize();
   auto diagram = builder.Build();
 

--- a/multibody/parsing/detail_dmd_parser.cc
+++ b/multibody/parsing/detail_dmd_parser.cc
@@ -239,8 +239,6 @@ std::optional<ModelInstanceIndex> DmdParserWrapper::AddModel(
       "'{}' is a model directives data source; it is always an error to pass"
       " a model directives source to a single-model parser method. Use"
       " AddAllModelsFromFile() instead.", display_source));
-  // TODO(rpoyner-tri): Does this imply we should have
-  // AddAllModelsFromString() as well?
   return {};
 }
 

--- a/multibody/parsing/parser.cc
+++ b/multibody/parsing/parser.cc
@@ -50,6 +50,15 @@ std::vector<ModelInstanceIndex> Parser::AddAllModelsFromFile(
   return parser.AddAllModels(data_source, {}, composite->workspace());
 }
 
+std::vector<ModelInstanceIndex> Parser::AddModelsFromString(
+    const std::string& file_contents, const std::string& file_type) {
+  DataSource data_source(DataSource::kContents, &file_contents);
+  const std::string pseudo_name(data_source.GetStem() + "." + file_type);
+  ParserInterface& parser = SelectParser(diagnostic_policy_, pseudo_name);
+  auto composite = internal::CompositeParse::MakeCompositeParse(this);
+  return parser.AddAllModels(data_source, {}, composite->workspace());
+}
+
 ModelInstanceIndex Parser::AddModelFromFile(
     const std::string& file_name,
     const std::string& model_name) {

--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "drake/common/diagnostic_policy.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/multibody/parsing/package_map.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/multibody_tree_indexes.h"
@@ -92,6 +93,19 @@ class Parser final {
   std::vector<ModelInstanceIndex> AddAllModelsFromFile(
       const std::string& file_name);
 
+  /// Provides same functionality as AddAllModelsFromFile, but instead parses
+  /// the model description text data via @p file_contents with format dictated
+  /// by @p file_type.
+  ///
+  /// @param file_contents The model data to be parsed.
+  /// @param file_type The data format; must be one of the filename suffixes
+  /// listed above, *without* the leading dot (.).
+  /// @returns The set of model instance indices for the newly added models,
+  /// including nested models.
+  /// @throws std::exception in case of errors.
+  std::vector<ModelInstanceIndex> AddModelsFromString(
+      const std::string& file_contents, const std::string& file_type);
+
   /// Parses the input file named in @p file_name and adds one top-level model
   /// to @p plant. It is an error to call this using any file that adds more
   /// than one model instance.
@@ -119,6 +133,7 @@ class Parser final {
   /// model. If empty, the model name provided by the input text will be used.
   /// @returns The instance index for the newly added model.
   /// @throws std::exception in case of errors.
+  DRAKE_DEPRECATED("2023-04-01", "Use AddModelsFromString() instead.")
   ModelInstanceIndex AddModelFromString(
       const std::string& file_contents,
       const std::string& file_type,

--- a/multibody/plant/test/multibody_plant_query_object_connect_test.cc
+++ b/multibody/plant/test/multibody_plant_query_object_connect_test.cc
@@ -82,9 +82,9 @@ MultibodyPlant<double>& PopulateTestDiagram(DiagramBuilder<double>* builder,
 
   Parser parser(plant);
   if (has_collision_geometry) {
-    parser.AddModelFromString(kModelWithCollisions, "urdf");
+    parser.AddModelsFromString(kModelWithCollisions, "urdf");
   } else {
-    parser.AddModelFromString(kModelWithoutCollisions, "urdf");
+    parser.AddModelsFromString(kModelWithoutCollisions, "urdf");
   }
 
   plant->Finalize();


### PR DESCRIPTION
This new method allows DMD format data to be read from a string, and paves the way for eventual deprecation and removal of the obsolete "singular" methods.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18110)
<!-- Reviewable:end -->
