### PR TITLE
py multibody math: Add repr() for spatial vectors

### DIFF
--- a/bindings/pydrake/_math_extra.py
+++ b/bindings/pydrake/_math_extra.py
@@ -140,12 +140,11 @@ def _rigid_transform_repr(X):
         f")")
 
 
-RollPitchYaw_[float].__repr__ = _roll_pitch_yaw_repr
-RollPitchYaw_[_AutoDiffXd].__repr__ = _roll_pitch_yaw_repr
-RollPitchYaw_[_sym.Expression].__repr__ = _roll_pitch_yaw_repr
-RotationMatrix_[float].__repr__ = _rotation_matrix_repr
-RotationMatrix_[_AutoDiffXd].__repr__ = _rotation_matrix_repr
-RotationMatrix_[_sym.Expression].__repr__ = _rotation_matrix_repr
-RigidTransform_[float].__repr__ = _rigid_transform_repr
-RigidTransform_[_AutoDiffXd].__repr__ = _rigid_transform_repr
-RigidTransform_[_sym.Expression].__repr__ = _rigid_transform_repr
+def _add_repr_functions():
+    for T in [float, _AutoDiffXd, _sym.Expression]:
+        RollPitchYaw_[T].__repr__ = _roll_pitch_yaw_repr
+        RotationMatrix_[T].__repr__ = _rotation_matrix_repr
+        RigidTransform_[T].__repr__ = _rigid_transform_repr
+
+
+_add_repr_functions()

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -48,6 +48,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
   using namespace drake::math;
   constexpr auto& doc = pydrake_doc.drake.math;
 
+  // N.B. Some classes define `__repr__` in `_math_extra.py`.
+
   {
     using Class = RigidTransform<T>;
     constexpr auto& cls_doc = doc.RigidTransform;

--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -76,6 +76,7 @@ drake_pybind_library(
         "//bindings/pydrake/common:value_py",
         "//bindings/pydrake:math_py",
     ],
+    py_srcs = ["_math_extra.py"],
 )
 
 drake_pybind_library(

--- a/bindings/pydrake/multibody/_math_extra.py
+++ b/bindings/pydrake/multibody/_math_extra.py
@@ -1,0 +1,41 @@
+import pydrake.autodiffutils as _ad
+import pydrake.symbolic as _sym
+
+
+def _indented_repr(o):
+    """Returns repr(o), with any lines beyond the first one indented +2."""
+    return repr(o).replace("\n", "\n  ")
+
+
+def _remove_float_suffix(typename):
+    suffix = "_[float]"
+    if typename.endswith(suffix):
+        return typename[:-len(suffix)]
+    return typename
+
+
+def _spatial_vector_repr(rotation_name, translation_name):
+
+    def repr_with_closure(self):
+        cls = type(self)
+        cls_name = _remove_float_suffix(cls.__name__)
+        rotation = self.rotational().tolist()
+        translation = self.translational().tolist()
+        return (
+            f"{cls_name}(\n"
+            f"  {rotation_name}={_indented_repr(rotation)},\n"
+            f"  {translation_name}={_indented_repr(translation)},\n"
+            f")")
+
+    return repr_with_closure
+
+
+def _add_repr_functions():
+    for T in [float, _ad.AutoDiffXd, _sym.Expression]:
+        SpatialVelocity_[T].__repr__ = _spatial_vector_repr("w", "v")
+        SpatialMomentum_[T].__repr__ = _spatial_vector_repr("h", "l")
+        SpatialAcceleration_[T].__repr__ = _spatial_vector_repr("alpha", "a")
+        SpatialForce_[T].__repr__ = _spatial_vector_repr("tau", "f")
+
+
+_add_repr_functions()

--- a/bindings/pydrake/multibody/math_py.cc
+++ b/bindings/pydrake/multibody/math_py.cc
@@ -92,6 +92,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
 
   m.doc() = "Bindings for multibody math.";
 
+  // N.B. Some classes define `__repr__` in `_math_extra.py`.
+
   {
     using Class = SpatialVelocity<T>;
     constexpr auto& cls_doc = doc.SpatialVelocity;
@@ -208,6 +210,8 @@ PYBIND11_MODULE(math, m) {
   m.doc() = "Bindings for multibody math.";
   type_visit([m](auto dummy) { DoScalarDependentDefinitions(m, dummy); },
       CommonScalarPack{});
+
+  ExecuteExtraPythonCode(m);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/multibody/test/math_test.py
+++ b/bindings/pydrake/multibody/test/math_test.py
@@ -1,4 +1,5 @@
 import copy
+import textwrap
 import unittest
 
 import numpy as np
@@ -10,16 +11,29 @@ from pydrake.common.test_utilities.pickle_compare import assert_pickle
 from pydrake.symbolic import Expression
 from pydrake.math import RotationMatrix_
 from pydrake.multibody.math import (
+    SpatialAcceleration,
     SpatialAcceleration_,
+    SpatialForce,
     SpatialForce_,
+    SpatialMomentum,
     SpatialMomentum_,
+    SpatialVelocity,
     SpatialVelocity_,
 )
 
 
 class TestMultibodyTreeMath(unittest.TestCase):
+    def test_default_aliases(self):
+        # N.B. This is tested in general via `cpp_template`, but we add this to
+        # test to also appease flake8.
+        self.assertIs(SpatialAcceleration, SpatialAcceleration_[float])
+        self.assertIs(SpatialForce, SpatialForce_[float])
+        self.assertIs(SpatialMomentum, SpatialMomentum_[float])
+        self.assertIs(SpatialVelocity, SpatialVelocity_[float])
+
     def check_spatial_vector(
-            self, T, cls, coeffs_name, rotation_name, translation_name):
+            self, *, T, cls, base_name,
+            coeffs_name, rotation_name, translation_name):
         vec = cls()
         # - Accessors.
         if T == Expression:
@@ -84,14 +98,44 @@ class TestMultibodyTreeMath(unittest.TestCase):
             vec1.Rotate(R_FE=R)).get_coeffs(), coeffs_expected)
         # Test pickling.
         assert_pickle(self, vec1, cls.get_coeffs, T=T)
+        # Repr.
+        z = repr(T(0.0))
+        type_suffix = {
+            float: "",
+            AutoDiffXd: "_[AutoDiffXd]",
+            Expression: "_[Expression]",
+        }[T]
+        repr_cls_name = f"{base_name}{type_suffix}"
+        self.assertEqual(
+            repr(cls.Zero()),
+            textwrap.dedent(f"""\
+                {repr_cls_name}(
+                  {rotation_name}=[{z}, {z}, {z}],
+                  {translation_name}=[{z}, {z}, {z}],
+                )"""))
+        if T == float:
+            # TODO(jwnimmer-tri) Once AutoDiffXd and Expression implement an
+            # eval-able repr, then we can test more than just T=float here.
+            original = cls.Zero()
+            roundtrip = eval(repr(original))
+            self.assertIsInstance(roundtrip, cls)
+            numpy_compare.assert_float_equal(
+                original.get_coeffs(), roundtrip.get_coeffs())
 
     @numpy_compare.check_all_types
     def test_spatial_vector_types(self, T):
-        self.check_spatial_vector(T, SpatialVelocity_[T], "V", "w", "v")
-        self.check_spatial_vector(T, SpatialMomentum_[T], "L", "h", "l")
         self.check_spatial_vector(
-            T, SpatialAcceleration_[T], "A", "alpha", "a")
-        self.check_spatial_vector(T, SpatialForce_[T], "F", "tau", "f")
+            T=T, cls=SpatialVelocity_[T], base_name="SpatialVelocity",
+            coeffs_name="V", rotation_name="w", translation_name="v")
+        self.check_spatial_vector(
+            T=T, cls=SpatialMomentum_[T], base_name="SpatialMomentum",
+            coeffs_name="L", rotation_name="h", translation_name="l")
+        self.check_spatial_vector(
+            T=T, cls=SpatialAcceleration_[T], base_name="SpatialAcceleration",
+            coeffs_name="A", rotation_name="alpha", translation_name="a")
+        self.check_spatial_vector(
+            T=T, cls=SpatialForce_[T], base_name="SpatialForce",
+            coeffs_name="F", rotation_name="tau", translation_name="f")
 
     @numpy_compare.check_all_types
     def test_value_instantiations(self, T):


### PR DESCRIPTION
py math:
- Add slight adjustment to logic / imports
- Add note about where `__repr__` is defined

Motivated by doing some math for haptic stuff
Following / adapting pattern from #14993

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18112)
<!-- Reviewable:end -->
