### PR TITLE
[pydrake] Add type canonicalization for all unsigned ints

### DIFF
--- a/bindings/pydrake/common/cpp_param.py
+++ b/bindings/pydrake/common/cpp_param.py
@@ -42,10 +42,12 @@ class _ParamAliases:
         self.register(float, [np.double, ctypes.c_double])
         self.register(np.float32, [ctypes.c_float])
         self.register(int, [np.int32, ctypes.c_int32])
-        self.register(np.uint8, [ctypes.c_uint8])
         self.register(np.int16, [ctypes.c_int16])
-        self.register(np.uint32, [ctypes.c_uint32])
         self.register(np.int64, [ctypes.c_int64])
+        self.register(np.uint8, [ctypes.c_uint8])
+        self.register(np.uint16, [ctypes.c_uint16])
+        self.register(np.uint32, [ctypes.c_uint32])
+        self.register(np.uint64, [ctypes.c_uint64])
 
     def register(self, canonical, aliases):
         # Registers a set of aliases to a canonical value.

--- a/bindings/pydrake/common/cpp_param_pybind.cc
+++ b/bindings/pydrake/common/cpp_param_pybind.cc
@@ -67,11 +67,12 @@ void RegisterCommon(py::module m, py::object param_aliases) {
   RegisterType<double>(m, param_aliases, "float");
   RegisterType<float>(m, param_aliases, "np.float32");
   RegisterType<int>(m, param_aliases, "int");
+  RegisterType<int16_t>(m, param_aliases, "np.int16");
+  RegisterType<int64_t>(m, param_aliases, "np.int64");
   RegisterType<uint8_t>(m, param_aliases, "np.uint8");
   RegisterType<uint16_t>(m, param_aliases, "np.uint16");
-  RegisterType<int16_t>(m, param_aliases, "np.int16");
   RegisterType<uint32_t>(m, param_aliases, "np.uint32");
-  RegisterType<int64_t>(m, param_aliases, "np.int64");
+  RegisterType<uint64_t>(m, param_aliases, "np.uint64");
   // For supporting generic Python types.
   RegisterType<Object>(m, param_aliases, "object");
 }

--- a/bindings/pydrake/common/test/cpp_param_pybind_test.cc
+++ b/bindings/pydrake/common/test/cpp_param_pybind_test.cc
@@ -44,8 +44,11 @@ GTEST_TEST(CppParamTest, PrimitiveTypes) {
   ASSERT_TRUE(CheckPyParam<double>("float,"));
   ASSERT_TRUE(CheckPyParam<float>("np.float32,"));
   ASSERT_TRUE(CheckPyParam<int>("int,"));
-  ASSERT_TRUE(CheckPyParam<uint32_t>("np.uint32,"));
+  ASSERT_TRUE(CheckPyParam<int16_t>("np.int16,"));
   ASSERT_TRUE(CheckPyParam<int64_t>("np.int64,"));
+  ASSERT_TRUE(CheckPyParam<uint16_t>("np.uint16,"));
+  ASSERT_TRUE(CheckPyParam<uint32_t>("np.uint32,"));
+  ASSERT_TRUE(CheckPyParam<uint64_t>("np.uint64,"));
   // N.B. CheckPyParam<py::object>(...) should cause a compile-time failure.
   ASSERT_TRUE(CheckPyParam<Object>("object,"));
 }

--- a/bindings/pydrake/common/test/cpp_param_test.py
+++ b/bindings/pydrake/common/test/cpp_param_test.py
@@ -45,8 +45,11 @@ class TestCppParam(unittest.TestCase):
         self._check_idempotent(float)
         self._check_idempotent(np.float32)
         self._check_idempotent(int)
-        self._check_idempotent(np.uint32)
+        self._check_idempotent(np.int16)
         self._check_idempotent(np.int64)
+        self._check_idempotent(np.uint16)
+        self._check_idempotent(np.uint32)
+        self._check_idempotent(np.uint64)
         self._check_idempotent(object)
         # - Custom Types.
         self._check_idempotent(CustomPyType)
@@ -60,8 +63,11 @@ class TestCppParam(unittest.TestCase):
         self._check_aliases(float, [np.double, ctypes.c_double])
         self._check_aliases(np.float32, [ctypes.c_float])
         self._check_aliases(int, [np.int32, ctypes.c_int32])
-        self._check_aliases(np.uint32, [ctypes.c_uint32])
+        self._check_aliases(np.int16, [ctypes.c_int16])
         self._check_aliases(np.int64, [ctypes.c_int64])
+        self._check_aliases(np.uint16, [ctypes.c_uint16])
+        self._check_aliases(np.uint32, [ctypes.c_uint32])
+        self._check_aliases(np.uint64, [ctypes.c_uint64])
 
     def test_names(self):
         self._check_names("int", [int, np.int32, ctypes.c_int32])


### PR DESCRIPTION
The rules for uint16 and uint64 were partially and/or fully missing.

Towards #18109.

+@EricCousineau-TRI for both reviews, please?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18115)
<!-- Reviewable:end -->
