### PR TITLE
[pydrake] Use Python's typing for generic types

### DIFF
--- a/bindings/pydrake/common/cpp_param.py
+++ b/bindings/pydrake/common/cpp_param.py
@@ -4,17 +4,10 @@ Python types as they relate to C++.
 """
 
 import ctypes
+import sys
+import typing
 
 import numpy as np
-
-
-def _get_type_name(t, verbose):
-    # Gets type name as a string.
-    # Defaults to just returning the name to shorten template names.
-    if verbose and t.__module__ != "__builtin__":
-        return t.__module__ + "." + t.__name__
-    else:
-        return t.__name__
 
 
 class _StrictMap:
@@ -63,11 +56,31 @@ class _ParamAliases:
         # return the same parameter.
         return self._to_canonical.get(alias, alias)
 
+    @staticmethod
+    def _resugar_typing_shortcuts(origin_name, arg_names):
+        # Re-sugars typing.Union[T, NoneType] into typing.Optional[T] in case
+        # that's what the origin and arg names refer to. Otherwise, returns the
+        # data unchanged.
+        if (origin_name == "typing.Union"
+                and len(arg_names) == 2
+                and arg_names[-1] == "NoneType"):
+            origin_name = "typing.Optional"
+            arg_names = arg_names[:1]
+        return origin_name, arg_names
+
     def get_name(self, alias):
         # Gets string for an alias.
         canonical = self.get_canonical(alias)
-        if isinstance(canonical, type):
-            return _get_type_name(canonical, False)
+        if typing.get_origin(alias) is not None:
+            origin = typing.get_origin(alias)
+            args = typing.get_args(alias)
+            origin_name = self.get_name(origin)
+            arg_names = [self.get_name(x) for x in args]
+            origin_name, arg_names = self._resugar_typing_shortcuts(
+                origin_name, arg_names)
+            return f"{origin_name}[{', '.join(arg_names)}]"
+        elif isinstance(canonical, type):
+            return canonical.__name__
         else:
             # For literals.
             return str(canonical)
@@ -79,72 +92,85 @@ _param_aliases = _ParamAliases()
 
 def get_param_canonical(param):
     """Gets the canonical types for a set of Python types (canonical as in
-    how they relate to C++ types.
+    how they relate to C++ types).
     """
     return tuple(map(_param_aliases.get_canonical, param))
 
 
 def get_param_names(param):
     """Gets the canonical type names for a set of Python types (canonical as
-    in how they relate to C++ types.
+    in how they relate to C++ types).
     """
     return tuple(map(_param_aliases.get_name, param))
 
 
 class _Generic:
+    """Provides a C++-compatible way to denote generic types. This uses the
+    same type classes as Python's built-in generics (e.g., `typing.Union`) but
+    is careful to canonicalize any type aliases in params during instantiation.
     """
-    Provides a way to denote unique "classes" for C++ generics that do not
-    normally convert to unique types in Python (via pybind11).
-
-    As an example, pybind11 casts ``std::vector<T>`` to ``list()``, but we may
-    still want to associate a unique type with it for registration in
-    templates. We can do this by creating a unique class (or object),
-    ``List[T]``.
-
-    The ``typing`` module in Python provides generics like this; however, the
-    API does not admit easy inspection, at least in Python 3.8, thus we
-    reinvent a smaller wheel.
-    """
-    def __init__(self, name, factory, num_param):
+    def __init__(self, name, instantiator, num_params):
         self._name = name
-        self._factory = factory
-        self._num_param = num_param
-        # TODO(eric.cousineau): Rather than caching, consider allowing this to
-        # `hash` the same as `typing`. As an example, both `typing.List` and
-        # this `List` implementation could be used to retrieve an
-        # implementation. However, that would also may need to be handled in
-        # `get_canonical`.
-        self._instantiations = {}
+        self._instantiator = instantiator
+        self._num_params = num_params
 
-    class _Instantiation:
-        # TODO(eric.cousineau): Return a class if it messes up downstream APIs.
-        def __init__(self, generic, param):
-            param_str = ', '.join(get_param_names(param))
-            self._full_name = f"{generic._name}[{param_str}]"
-            self._factory = generic._factory
-
-        def __call__(self, *args, **kwargs):
-            return self._factory(*args, **kwargs)
-
-        def __repr__(self):
-            return self._full_name
-
-    def __getitem__(self, param):
-        if not isinstance(param, tuple):
-            param = (param,)
-        if len(param) != self._num_param:
+    def __getitem__(self, params):
+        if not isinstance(params, tuple):
+            params = (params,)
+        if self._num_params is not None and len(params) != self._num_params:
             raise RuntimeError(
-                f"{self} can only accept {self._num_param} parameter(s)")
-        param = get_param_canonical(param)
-        # Rather than implement hashing, simply cache instantiations.
-        instantiation = self._instantiations.get(param)
-        if instantiation is None:
-            instantiation = self._Instantiation(self, param)
-            self._instantiations[param] = instantiation
-        return instantiation
+                f"{self._name}[] requires exactly "
+                f"{self._num_params} type parameter(s)")
+        params_canonical = get_param_canonical(params)
+        return self._instantiator(params_canonical)
 
     def __repr__(self):
         return f"<Generic {self._name}>"
 
 
-List = _Generic("List", factory=list, num_param=1)
+def _has_pep585():
+    return sys.version_info[:2] >= (3, 9)
+
+
+def _dict_instantiator(params):
+    # Backport PEP-585 support into Python 3.8 and earlier.
+    if _has_pep585():
+        result = dict[params]
+    else:
+        result = typing.Dict[params]
+        # We need the result to be a callable type to match PEP-585 (i.e.,
+        # calling it must return a fresh `dict` object.)
+        result._inst = True
+    return result
+
+
+def _list_instantiator(params):
+    # Backport PEP-585 support into Python 3.8 and earlier.
+    if _has_pep585():
+        result = list[params]
+    else:
+        result = typing.List[params]
+        # We need the result to be a callable type to match PEP-585 (i.e.,
+        # calling it must return a fresh `list` object.)
+        result._inst = True
+    return result
+
+
+def _optional_instantiator(params):
+    # Unpack the tuple into the (single) argument required by typing.Optional.
+    (param,) = params
+    return typing.Optional[param]
+
+
+# A generic type `dict[KT, VT]` for the C++ class std::map<KT, VT>.
+Dict = _Generic("Dict", _dict_instantiator, 2)
+
+# A generic type `list[T]` for the C++ class std::vector<T>.
+List = _Generic("List", _list_instantiator, 1)
+
+# A generic type `typing.Optional[T]` for the C++ class std::optional<T>.
+# Note that `typing` de-sugars this to be `typing.Union[T, NoneType]`.
+Optional = _Generic("Optional", _optional_instantiator, 1)
+
+# A generic type `typing.Union[X, ...]` for the C++ class std::variant<X, ...>.
+Union = _Generic("Union", typing.Union.__getitem__, None)


### PR DESCRIPTION
We still need to carefully canonicalize the parameters used for instantiation, but we don't need to re-implement the typeclasses themselves.

Add generics for Optional and Union, to be used down the road.

Towards https://github.com/RobotLocomotion/drake/pull/18109.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18117)
<!-- Reviewable:end -->
