### PR TITLE
[geometry] Clean up AssignAllRoles for registering geometry

### DIFF
--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -693,7 +693,7 @@ GeometryId GeometryState<T>::RegisterGeometry(
       InternalGeometry(source_id, geometry->release_shape(), frame_id,
                        geometry_id, geometry->name(), geometry->pose()));
 
-  AssignAllRoles(source_id, geometry_id, std::move(geometry));
+  AssignAllDefinedRoles(source_id, std::move(geometry));
 
   return geometry_id;
 }
@@ -734,7 +734,7 @@ GeometryId GeometryState<T>::RegisterDeformableGeometry(
   kinematics_data_.q_WGs[geometry_id] = std::move(q_WG);
   geometries_.emplace(geometry_id, std::move(internal_geometry));
 
-  AssignAllRoles(source_id, geometry_id, std::move(geometry));
+  AssignAllDefinedRoles(source_id, std::move(geometry));
 
   return geometry_id;
 }
@@ -1409,9 +1409,11 @@ void GeometryState<T>::ThrowIfNameExistsInRole(FrameId id, Role role,
 }
 
 template <typename T>
-void GeometryState<T>::AssignAllRoles(
-    SourceId source_id, GeometryId geometry_id,
-    std::unique_ptr<GeometryInstance> geometry) {
+void GeometryState<T>::AssignAllDefinedRoles(
+    SourceId source_id, std::unique_ptr<GeometryInstance> geometry) {
+  DRAKE_DEMAND(geometry != nullptr);
+
+  const GeometryId geometry_id = geometry->id();
   // Any roles defined on the geometry instance propagate through
   // automatically.
   if (geometry->illustration_properties()) {

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -819,9 +819,9 @@ class GeometryState {
   void ThrowIfNameExistsInRole(FrameId id, Role role,
                                const std::string& name) const;
 
-  // Propagate all roles defined in geometry instance to `this` geometry state.
-  void AssignAllRoles(SourceId source_id, GeometryId geometry_id,
-                      std::unique_ptr<GeometryInstance> geometry);
+  // Propagates all roles defined in geometry instance to `this` geometry state.
+  void AssignAllDefinedRoles(SourceId source_id,
+                             std::unique_ptr<GeometryInstance> geometry);
 
   // Confirms that the given role assignment is valid and return the geometry
   // if valid. Throws if not.


### PR DESCRIPTION
 - Remove the redundant parameter (geometry_id).
   - The geometry passed already has the id.
   - Passing the id explicitly opens for an error in which the geometry is associated with the *wrong* geometry id.
 - Change the name so it doesn't imply roles are *arbitrarily* assigned.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18120)
<!-- Reviewable:end -->
