### PR TITLE
Parse screw joints from SDFormat

### DIFF
--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -32,6 +32,7 @@
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/multibody/tree/revolute_spring.h"
 #include "drake/multibody/tree/rigid_body.h"
+#include "drake/multibody/tree/screw_joint.h"
 #include "drake/multibody/tree/universal_joint.h"
 #include "drake/systems/framework/context.h"
 
@@ -986,6 +987,28 @@ TEST_F(SdfParserTest, JointParsingTest) {
       CompareMatrices(continuous_joint.acceleration_lower_limits(), neg_inf));
   EXPECT_TRUE(
       CompareMatrices(continuous_joint.acceleration_upper_limits(), inf));
+
+  // Screw joint
+  DRAKE_EXPECT_NO_THROW(
+      plant_.GetJointByName<ScrewJoint>("screw_joint", instance1));
+  const ScrewJoint<double>& screw_joint =
+      plant_.GetJointByName<ScrewJoint>("screw_joint", instance1);
+  EXPECT_EQ(screw_joint.name(), "screw_joint");
+  EXPECT_EQ(screw_joint.parent_body().name(), "link8");
+  EXPECT_EQ(screw_joint.child_body().name(), "link9");
+  EXPECT_EQ(screw_joint.screw_axis(), Vector3d::UnitX());
+  EXPECT_EQ(screw_joint.screw_pitch(), 0.04);
+  EXPECT_EQ(screw_joint.damping(), 0.1);
+  EXPECT_TRUE(
+      CompareMatrices(screw_joint.position_lower_limits(), neg_inf));
+  EXPECT_TRUE(CompareMatrices(screw_joint.position_upper_limits(), inf));
+  EXPECT_TRUE(
+      CompareMatrices(screw_joint.velocity_lower_limits(), neg_inf));
+  EXPECT_TRUE(CompareMatrices(screw_joint.velocity_upper_limits(), inf));
+  EXPECT_TRUE(
+      CompareMatrices(screw_joint.acceleration_lower_limits(), neg_inf));
+  EXPECT_TRUE(
+      CompareMatrices(screw_joint.acceleration_upper_limits(), inf));
 }
 
 // Tests the error handling for an unsupported joint type (when actuated).
@@ -1113,21 +1136,6 @@ TEST_F(SdfParserTest, ActuatedBallJointParsingTest) {
 </model>)""");
   EXPECT_THAT(FormatFirstWarning(), ::testing::MatchesRegex(
       ".*effort limits.*ball joint.*not implemented.*"));
-  ClearDiagnostics();
-}
-
-// Tests the error handling for an unsupported joint type.
-TEST_F(SdfParserTest, ScrewJointParsingTest) {
-  ParseTestString(R"""(
-<model name="molly">
-  <link name="larry" />
-  <joint name="jerry" type="screw">
-    <parent>world</parent>
-    <child>larry</child>
-  </joint>
-</model>)""");
-  EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
-      ".*screw.*not supported.*jerry.*"));
   ClearDiagnostics();
 }
 

--- a/multibody/parsing/test/sdf_parser_test/joint_parsing_test.sdf
+++ b/multibody/parsing/test/sdf_parser_test/joint_parsing_test.sdf
@@ -2,7 +2,7 @@
 <!--
 Defines an SDF model with various types of joints used for testing the parser.
 -->
-<sdf xmlns:drake="http://drake.mit.edu" version="1.7">
+<sdf xmlns:drake="http://drake.mit.edu" version="1.10">
   <world name="joint_parsing_test_world">
     <model name="joint_parsing_test">
       <link name="link1">
@@ -214,6 +214,30 @@ Defines an SDF model with various types of joints used for testing the parser.
           <dynamics>
             <spring_reference>0</spring_reference>
             <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name="link9">
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+        </inertial>
+      </link>
+      <joint name="screw_joint" type="screw">
+        <child>link9</child>
+        <parent>link8</parent>
+        <screw_thread_pitch>0.04</screw_thread_pitch>
+        <axis>
+          <xyz expressed_in="__model__">1 0 0</xyz>
+          <dynamics>
+            <damping>0.1</damping>
           </dynamics>
         </axis>
       </joint>

--- a/tools/workspace/sdformat_internal/repository.bzl
+++ b/tools/workspace/sdformat_internal/repository.bzl
@@ -8,9 +8,9 @@ def sdformat_internal_repository(
     github_archive(
         name = name,
         repository = "gazebosim/sdformat",
-        commit = "sdformat13_13.1.0",
+        commit = "sdformat13_13.2.0",
         build_file = ":package.BUILD.bazel",
-        sha256 = "4b40bf64bc7d3f22c89a2395c2802d5315a3fd5e5dbaf29b087c5c806180a9db",  # noqa
+        sha256 = "e1084091f65caf8aabd4cfca6df3a7bf3a9563de1715829810813840598d5de3",  # noqa
         patches = [
             ":patches/console.patch",
             ":patches/deprecation_unit_testing.patch",


### PR DESCRIPTION
Part of #17765.

Depends on https://github.com/gazebosim/sdformat/pull/1168 to provide the `//joint/screw_thread_pitch` parameter in SDFormat 1.10 and corresponding `Joint::ScrewThreadPitch()` that uses the same units as drake: meters / revolution. The existing `thread_pitch` parameter (exposed via `Joint::ThreadPitch()`) has been used in gazebo classic with inverse units and the opposite sign convention.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18127)
<!-- Reviewable:end -->
