### PR TITLE
[workspace] Upgrade sdformat_internal to 13.1.0

### DIFF
--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -112,7 +112,8 @@ unique_ptr<sdf::Geometry> MakeSdfGeometryFromString(
       sdf_parsed->Root()->GetElement("model")->
           GetElement("link")->GetElement("visual")->GetElement("geometry");
   auto sdf_geometry = make_unique<sdf::Geometry>();
-  sdf_geometry->Load(geometry_element);
+  sdf::ParserConfig config = MakeStrictConfig();
+  sdf_geometry->Load(geometry_element, config);
   return sdf_geometry;
 }
 
@@ -143,7 +144,8 @@ unique_ptr<sdf::Visual> MakeSdfVisualFromString(
       sdf_parsed->Root()->GetElement("model")->
           GetElement("link")->GetElement("visual");
   auto sdf_visual = make_unique<sdf::Visual>();
-  sdf_visual->Load(visual_element);
+  sdf::ParserConfig config = MakeStrictConfig();
+  sdf_visual->Load(visual_element, config);
   return sdf_visual;
 }
 
@@ -178,7 +180,8 @@ unique_ptr<sdf::Collision> MakeSdfCollisionFromString(
       sdf_parsed->Root()->GetElement("model")->
           GetElement("link")->GetElement("collision");
   auto sdf_collision = make_unique<sdf::Collision>();
-  sdf_collision->Load(collision_element);
+  sdf::ParserConfig config = MakeStrictConfig();
+  sdf_collision->Load(collision_element, config);
   return sdf_collision;
 }
 

--- a/tools/workspace/sdformat_internal/repository.bzl
+++ b/tools/workspace/sdformat_internal/repository.bzl
@@ -8,9 +8,9 @@ def sdformat_internal_repository(
     github_archive(
         name = name,
         repository = "gazebosim/sdformat",
-        commit = "sdformat13_13.0.1",
+        commit = "sdformat13_13.1.0",
         build_file = ":package.BUILD.bazel",
-        sha256 = "4dfb9d938f77d590c4465c9ad5769777e5b0f40dd21c288fe2cc1987d5a0b036",  # noqa
+        sha256 = "4b40bf64bc7d3f22c89a2395c2802d5315a3fd5e5dbaf29b087c5c806180a9db",  # noqa
         patches = [
             ":patches/console.patch",
             ":patches/deprecation_unit_testing.patch",


### PR DESCRIPTION
Closes #18129.

There are some new overloads of the `Load()` methods that take a ParserConfig object (from https://github.com/gazebosim/sdformat/pull/1147) so that the old APIs use GlobalConfig, so pass the `StrictConfig` to those APIs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18130)
<!-- Reviewable:end -->
