### PR TITLE
[geometry/optimization] Remove requirement that CartesianProduct sets must be bounded

### DIFF
--- a/geometry/optimization/cartesian_product.cc
+++ b/geometry/optimization/cartesian_product.cc
@@ -39,18 +39,12 @@ int sum_ambient_dimensions(const ConvexSets& sets) {
 
 CartesianProduct::CartesianProduct(const ConvexSets& sets)
     : ConvexSet(&ConvexSetCloner<CartesianProduct>,
-                       sum_ambient_dimensions(sets)),
-      sets_{sets} {
-  for (const auto& s : sets_) {
-    DRAKE_DEMAND(s->IsBounded());
-  }
-}
+                sum_ambient_dimensions(sets)),
+      sets_{sets} {}
 
 CartesianProduct::CartesianProduct(const ConvexSet& setA, const ConvexSet& setB)
     : ConvexSet(&ConvexSetCloner<CartesianProduct>,
                 setA.ambient_dimension() + setB.ambient_dimension()) {
-  DRAKE_DEMAND(setA.IsBounded());
-  DRAKE_DEMAND(setB.IsBounded());
   sets_.emplace_back(setA.Clone());
   sets_.emplace_back(setB.Clone());
 }
@@ -64,9 +58,6 @@ CartesianProduct::CartesianProduct(const ConvexSets& sets,
   DRAKE_DEMAND(A_->rows() == b_->rows());
   DRAKE_DEMAND(A_->rows() == sum_ambient_dimensions(sets));
   DRAKE_DEMAND(A_->colPivHouseholderQr().rank() == A_->cols());
-  for (const auto& s : sets_) {
-    DRAKE_DEMAND(s->IsBounded());
-  }
 }
 
 CartesianProduct::CartesianProduct(const QueryObject<double>& query_object,
@@ -105,8 +96,12 @@ const ConvexSet& CartesianProduct::factor(int index) const {
 }
 
 bool CartesianProduct::DoIsBounded() const {
-  // Note: The constructor enforces that A_ is full column rank, and that all
-  // sets are bounded.
+  // Note: The constructor enforces that A_ is full column rank.
+  for (const auto& s : sets_) {
+    if (!s->IsBounded()) {
+      return false;
+    }
+  }
   return true;
 }
 

--- a/geometry/optimization/cartesian_product.h
+++ b/geometry/optimization/cartesian_product.h
@@ -13,8 +13,7 @@ namespace optimization {
 
 /** The Cartesian product of convex sets is a convex set:
 S = X₁ × X₂ × ⋯ × Xₙ =
-    {(x₁, x₂, ..., xₙ) | x₁ ∈ X₁, x₂ ∈ X₂, ..., xₙ ∈ Xₙ}
-We currently require the sets X to be bounded.
+    {(x₁, x₂, ..., xₙ) | x₁ ∈ X₁, x₂ ∈ X₂, ..., xₙ ∈ Xₙ}.
 
 This class also supports a generalization of this concept in which the
 coordinates are transformed by the linear map,
@@ -29,17 +28,14 @@ class CartesianProduct final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CartesianProduct)
 
-  /** Constructs the product from a vector of convex sets. All of the sets must
-  be bounded. */
+  /** Constructs the product from a vector of convex sets. */
   explicit CartesianProduct(const ConvexSets& sets);
 
-  /** Constructs the product from a pair of convex sets. `setA` and `setB` must
-  be bounded. */
+  /** Constructs the product from a pair of convex sets. */
   CartesianProduct(const ConvexSet& setA, const ConvexSet& setB);
 
   /** Constructs the product of convex sets in the transformed coordinates:
-  {x | y = Ax + b, y ∈ Y₁ × Y₂ × ⋯ × Yₙ}. `A` must be full column rank, and all
-  of the sets must be bounded. */
+  {x | y = Ax + b, y ∈ Y₁ × Y₂ × ⋯ × Yₙ}. `A` must be full column rank. */
   CartesianProduct(const ConvexSets& sets,
                    const Eigen::Ref<const Eigen::MatrixXd>& A,
                    const Eigen::Ref<const Eigen::VectorXd>& b);

--- a/geometry/optimization/test/cartesian_product_test.cc
+++ b/geometry/optimization/test/cartesian_product_test.cc
@@ -116,9 +116,36 @@ GTEST_TEST(CartesianProductTest, TwoBoxes) {
   HPolyhedron H1 = HPolyhedron::MakeBox(Vector2d{1, 1}, Vector2d{2, 2});
   HPolyhedron H2 = HPolyhedron::MakeBox(Vector2d{-2, 2}, Vector2d{0, 4});
   CartesianProduct S(H1, H2);
+  EXPECT_TRUE(S.IsBounded());
   EXPECT_TRUE(S.PointInSet(Vector4d{1.9, 1.9, -.1, 3.9}));
   EXPECT_FALSE(S.PointInSet(Vector4d{1.9, 1.9, -.1, 4.1}));
   EXPECT_FALSE(S.PointInSet(Vector4d{2.1, 1.9, -.1, 3.9}));
+}
+
+GTEST_TEST(CartesianProductTest, UnboundedSets) {
+  const Point P(Vector2d{1.2, 3.4});
+  Eigen::Matrix2d A;
+  A << -1, 0, 0, 1;
+  const HPolyhedron H(A, Vector2d(0, 2));
+
+  // Bounded x Unbounded -> Unbounded
+  const CartesianProduct S(P, H);
+  EXPECT_FALSE(S.IsBounded());
+
+  // Unbounded x Bounded -> Unbounded
+  const CartesianProduct S2(H, P);
+  EXPECT_FALSE(S2.IsBounded());
+
+  // Unbounded x Unbounded -> Unbounded
+  const CartesianProduct S3(H, H);
+  EXPECT_FALSE(S3.IsBounded());
+
+  // Bounded x Unbounded -> Unbounded
+  ConvexSets sets;
+  sets.emplace_back(P);
+  sets.emplace_back(H);
+  const CartesianProduct S4(sets);
+  EXPECT_FALSE(S4.IsBounded());
 }
 
 GTEST_TEST(CartesianProductTest, CloneTest) {
@@ -243,6 +270,7 @@ GTEST_TEST(CartesianProductTest, Rotated) {
 
   EXPECT_EQ(S.ambient_dimension(), 2);
   EXPECT_EQ(S.num_factors(), 2);
+  EXPECT_TRUE(S.IsBounded());
 
   // The set S is equivalent to Point(in_S).
   const double kTol = 1e-14;


### PR DESCRIPTION
@AlexandreAmice for feature review (namely to confirm `DoIsBounded` is correct)

cc @RussTedrake @TobiaMarcucci

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18140)
<!-- Reviewable:end -->
