### PR TITLE
[doc] Jenkins Mac jobs have been renamed

### DIFF
--- a/doc/_pages/code_review_checklist.md
+++ b/doc/_pages/code_review_checklist.md
@@ -125,7 +125,7 @@ changes, be sure to opt-in to a pre-merge macOS build.
 [Schedule an on-demand build](/jenkins.html#scheduling-an-on-demand-build) using an "everything"
 flavor, for example:
 
-* ``@drake-jenkins-bot mac-big-sur-clang-bazel-experimental-everything-release please``
+* ``@drake-jenkins-bot mac-x86-big-sur-clang-bazel-experimental-everything-release please``
 
 # Have you run linting tools?
 

--- a/doc/_pages/jenkins.md
+++ b/doc/_pages/jenkins.md
@@ -53,7 +53,7 @@ where ``<job-name>`` is the name of an
 
 For example:
 
-* ``@drake-jenkins-bot mac-big-sur-clang-bazel-experimental-release please``
+* ``@drake-jenkins-bot mac-x86-big-sur-clang-bazel-experimental-release please``
 * ``@drake-jenkins-bot linux-focal-clang-bazel-experimental-valgrind-memcheck please``
 
 ## Scheduling Builds via the Jenkins User Interface
@@ -105,7 +105,7 @@ most likely fail. To test new prerequisites, you should first request
 unprovisioned experimental builds, e.g.:
 
 * ``@drake-jenkins-bot linux-focal-unprovisioned-gcc-bazel-experimental-release please``
-* ``@drake-jenkins-bot mac-big-sur-unprovisioned-clang-bazel-experimental-release please``
+* ``@drake-jenkins-bot mac-x86-big-sur-unprovisioned-clang-bazel-experimental-release please``
 
 After this has passed, go through normal review. Once normal review is done,
 add `@BetsyMcPhail` for review and request that the provisioned instances be
@@ -117,14 +117,14 @@ To schedule an "experimental" build of the [binary packages](/from_binary.html),
 comment on an open pull request as follows:
 
 * ``@drake-jenkins-bot linux-focal-unprovisioned-gcc-bazel-experimental-snopt-packaging please``
-* ``@drake-jenkins-bot mac-big-sur-unprovisioned-clang-bazel-experimental-snopt-packaging please``
+* ``@drake-jenkins-bot mac-x86-big-sur-unprovisioned-clang-bazel-experimental-snopt-packaging please``
 
 or follow the [instructions above](#scheduling-builds-via-the-jenkins-user-interface)
 to schedule a build of one of the following jobs from the Jenkins user
 interface:
 
 * linux-focal-unprovisioned-gcc-bazel-experimental-snopt-packaging
-* mac-big-sur-unprovisioned-clang-bazel-experimental-snopt-packaging
+* mac-x86-big-sur-unprovisioned-clang-bazel-experimental-snopt-packaging
 
 The URL from which to download the built package will be indicated in the
 Jenkins console log for the completed build, for example:

--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -111,7 +111,7 @@ the main body of the document:
    3. Open the latest builds from the following builds:
       1. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-focal-unprovisioned-gcc-bazel-nightly-snopt-mosek-packaging/>
       2. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-jammy-unprovisioned-gcc-bazel-nightly-snopt-mosek-packaging/>
-      3. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/mac-big-sur-unprovisioned-clang-bazel-nightly-snopt-mosek-packaging/>
+      3. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/mac-x86-big-sur-unprovisioned-clang-bazel-nightly-snopt-mosek-packaging/>
       4. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/mac-m1-monterey-unprovisioned-clang-bazel-nightly-snopt-mosek-packaging/>
    4. Check the logs for those packaging builds and find the URLs they posted
       to (open the latest build, go to "View as plain text", and search for
@@ -127,7 +127,7 @@ the main body of the document:
 2. Launch the wheel staging builds for that git commit sha:
    1. For both macOS and linux, open the jenkins build page from
       this list:
-      - [macOS Jenkins Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Wheel/job/mac-big-sur-unprovisioned-clang-wheel-staging-snopt-mosek-release/)
+      - [macOS Jenkins Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Wheel/job/mac-x86-big-sur-unprovisioned-clang-wheel-staging-snopt-mosek-release/)
       - [linux Jenkins Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-focal-unprovisioned-gcc-wheel-staging-snopt-mosek-release/)
    2. In the upper right, click "log in" (unless you're already logged in). This
       will use your GitHub credentials.


### PR DESCRIPTION
Update the documentation to use the new names.

Towards #17869

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18143)
<!-- Reviewable:end -->
