### PR TITLE
[tools] Fully evict pydrake from drake_visualizer

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -38,7 +38,6 @@ py_binary(
     deps = [
         "//lcmtypes:lcmtypes_drake_py",
         "//tools/workspace/drake_visualizer:builtin_scripts_py",
-        "//tools/workspace/drake_visualizer:stub_pydrake",
         "@drake_visualizer//:drake_visualizer_python_deps",
         "@optitrack_driver//lcmtypes:py_optitrack_lcmtypes",
     ] if _DRAKE_VISUALIZER_ENABLED else [],

--- a/tools/workspace/drake_visualizer/BUILD.bazel
+++ b/tools/workspace/drake_visualizer/BUILD.bazel
@@ -34,19 +34,6 @@ py_library(
     ],
 )
 
-# When developing within Drake, we don't want //tools:drake_visualizer to
-# depend on the entire pydrake library, because that adds a dependency on a
-# whole bunch of C++ code that is irrelevant for the visualizer.  So, here we
-# provide a small stub version of pydrake with only getDrakePath implemented
-# (the only piece drake_visualizer needs).  Note that the installed version of
-# drake-visualizer *does* use the installed (full) version of pydrake -- this
-# is development-sandbox-only stub.
-py_library(
-    name = "stub_pydrake",
-    srcs = ["stub/pydrake/__init__.py"],
-    visibility = ["//tools:__pkg__"],
-)
-
 # TODO(eric.cousineau): Use something simpler than cmake_configure_file to do
 # basic subsitutions as a genrule.
 cmake_configure_file(

--- a/tools/workspace/drake_visualizer/drake_visualizer_bazel.py
+++ b/tools/workspace/drake_visualizer/drake_visualizer_bazel.py
@@ -47,25 +47,8 @@ def main():
         "This must be called by a script generated using the "
         "`drake_runfiles_binary` macro.")
 
-    # Stub out pydrake (refer to our ./BUILD.bazel comments for rationale).
-    # If pydrake is already on the path, for instance because intentionally
-    # included as a dependency, then the stub will not be added to avoid
-    # conflicting.
-    #
-    # We add it to PYTHONPATH within the script, rather than
-    # `imports = ["stub"]` on the stub py_library, to avoid any other target
-    # accidentally pulling in the stubbed pydrake onto its PYTHONPATH.  Only
-    # the visualizer, when launched via this wrapper script, should employ the
-    # stub.
-    try:
-        import pydrake
-    except ImportError:
-        prepend_path("PYTHONPATH", "tools/workspace/drake_visualizer/stub")
-
-    # Don't use DRAKE_RESOURCE_ROOT; the stub getDrakePath should always win.
-    # This also placates the drake-visualizer logic that puts it into Director
-    # mode when DRAKE_RESOURCE_ROOT is set (thus requiring more than just
-    # getDrakePath).
+    # Placate the drake-visualizer logic that puts it into Director mode when
+    # DRAKE_RESOURCE_ROOT is set.
     try:
         del os.environ["DRAKE_RESOURCE_ROOT"]
     except KeyError:

--- a/tools/workspace/drake_visualizer/stub/pydrake/__init__.py
+++ b/tools/workspace/drake_visualizer/stub/pydrake/__init__.py
@@ -1,9 +1,0 @@
-# Refer to ../../BUILD.bazel comments for rationale.
-
-import os
-
-
-def getDrakePath():
-    # Because //tools:drake_visualizer is a drake_runfiles_binary, the correct
-    # answer to getDrakePath is always the runfiles root.  Nice!
-    return os.environ["DRAKE_BAZEL_RUNFILES"]

--- a/tools/workspace/drake_visualizer/use_drake_lcmtypes.patch
+++ b/tools/workspace/drake_visualizer/use_drake_lcmtypes.patch
@@ -2,7 +2,7 @@ Respell the imported lcmtypes to match Drake's build system.
 
 --- drakevisualizer.py	2020-07-15 08:51:01.000000000 -0700
 +++ drakevisualizer.py	2021-06-30 21:52:04.169503858 -0700
-@@ -15,22 +15,8 @@
+@@ -15,22 +15,7 @@
  from director import packagepath
  from director.fieldcontainer import FieldContainer
  
@@ -23,7 +23,6 @@ Respell the imported lcmtypes to match Drake's build system.
 -except ImportError:
 -    HAVE_PYDRAKE = False
 +import drake
-+import pydrake
  
  from PythonQt import QtGui
  
@@ -63,13 +62,12 @@ Respell the imported lcmtypes to match Drake's build system.
              d = DebugData()
              radii = geom.float_data[0:3]
              d.addEllipsoid(center=(0,0,0), radii=radii)
-@@ -191,8 +177,7 @@
+@@ -191,8 +177,6 @@
  
          if Geometry.PackageMap is None:
              m = packagepath.PackageMap()
 -            if HAVE_PYDRAKE:
 -                m.populateFromSearchPaths([pydrake.getDrakePath()])
-+            m.populateFromSearchPaths([pydrake.getDrakePath()])
              m.populateFromEnvironment(['DRAKE_PACKAGE_PATH', 'ROS_PACKAGE_PATH'])
              Geometry.PackageMap = m
  
@@ -107,4 +105,21 @@ Respell the imported lcmtypes to match Drake's build system.
 +        msg.command_type = drake.lcmt_viewer_command.STATUS
          msg.command_data = message
          lcmUtils.publish('DRAKE_VIEWER_STATUS', msg)
+ 
+--- drcargs.py	2022-05-05 14:25:21.000000000 -0700
++++ drcargs.py	2022-10-19 11:05:04.797458629 -0700
+@@ -80,13 +80,7 @@
+ 
+ 
+     def _isPyDrakeAvailable(self):
+-        try:
+-            import pydrake
+-        except ImportError:
+-            return False
+-        if 'DRAKE_RESOURCE_ROOT' not in os.environ:
+-            return False
+-        return True
++        return False
+ 
+     def addDrakeConfigShortcuts(self, directorConfig):
  


### PR DESCRIPTION
The `pydrake.getDrakePath()` path is no longer used to populate Director's package map.

This removes the ability to send `package://drake/models/...` URIs in `lcmt_viewer_load_robot`, but no code within Drake does that anyway.  Drake only ever sends absolute filename paths to Director for our meshes.

Users who need to load Drake package URIs via that message can set either of two environment variables to enable package map searching:

```
  export ROS_PACKAGE_PATH=/path/to/drake
```

or

```
  export DRAKE_PACKAGE_PATH=/path/to/drake
```

Towards #18141.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18144)
<!-- Reviewable:end -->
