### PR TITLE
Add multibody::world_frame_index() getter

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -45,6 +45,7 @@ from pydrake.multibody.tree import (
     UnitInertia_,
     UniversalJoint_,
     WeldJoint_,
+    world_frame_index,
     world_index,
     world_model_instance,
     default_model_instance
@@ -152,6 +153,8 @@ class TestPlant(unittest.TestCase):
     def test_type_safe_indices(self):
         self.assertEqual(world_index(), BodyIndex(0))
         self.assertEqual(repr(world_index()), "BodyIndex(0)")
+        self.assertEqual(world_frame_index(), FrameIndex(0))
+        self.assertEqual(repr(world_frame_index()), "FrameIndex(0)")
         self.assertEqual(world_model_instance(), ModelInstanceIndex(0))
         self.assertEqual(repr(world_model_instance()), "ModelInstanceIndex(0)")
         self.assertEqual(default_model_instance(), ModelInstanceIndex(1))
@@ -363,7 +366,7 @@ class TestPlant(unittest.TestCase):
         self.assertIsInstance(
             plant.get_contact_results_output_port(), OutputPort)
         self.assertIsInstance(plant.num_frames(), int)
-        self.assertIsInstance(plant.get_body(body_index=BodyIndex(0)), Body)
+        self.assertIsInstance(plant.get_body(body_index=world_index()), Body)
         self.assertIs(shoulder, plant.get_joint(joint_index=JointIndex(0)))
         self.assertIs(shoulder, plant.get_mutable_joint(
             joint_index=JointIndex(0)))
@@ -377,7 +380,7 @@ class TestPlant(unittest.TestCase):
             "<JointActuator_[float] name='ElbowJoint' index=0 "
             "model_instance=2>")
         self.assertIsInstance(
-            plant.get_frame(frame_index=FrameIndex(0)), Frame)
+            plant.get_frame(frame_index=world_frame_index()), Frame)
         self.assertEqual("acrobot", plant.GetModelInstanceName(
             model_instance=model_instance))
         self.assertIn("acrobot", plant.GetTopologyGraphvizString())

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -107,6 +107,7 @@ void DoScalarIndependentDefinitions(py::module m) {
   BindTypeSafeIndex<ConstraintIndex>(
       m, "ConstraintIndex", doc.ConstraintIndex.doc);
   m.def("world_index", &world_index, doc.world_index.doc);
+  m.def("world_frame_index", &world_frame_index, doc.world_frame_index.doc);
   m.def("world_model_instance", &world_model_instance,
       doc.world_model_instance.doc);
   m.def("default_model_instance", &default_model_instance,

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -452,12 +452,40 @@ GTEST_TEST(MultibodyPlantTest, NoHeapAllocOnStringQueries) {
   plant->GetJointActuatorByName(kJointName, iiwa_instance);
 }
 
+// This test creates an empty model and checks simple invariants on model
+// elements. We test the contracts here, not in MultibodyTree, to test
+// behavior from public API perspective.
+GTEST_TEST(MultibodyPlant, EmptyWorldElements) {
+  const double time_step = 0.0;
+  MultibodyPlant<double> plant(time_step);
+  // Model instances.
+  EXPECT_EQ(plant.num_model_instances(), 2);
+  // Bodies.
+  EXPECT_EQ(plant.num_bodies(), 1);
+  const Body<double>& world_body = plant.world_body();
+  EXPECT_EQ(world_body.index(), world_index());
+  EXPECT_EQ(world_body.model_instance(), world_model_instance());
+  // Frames.
+  EXPECT_EQ(plant.num_frames(), 1);
+  const Frame<double>& world_frame = plant.world_frame();
+  EXPECT_EQ(world_frame.index(), world_frame_index());
+  EXPECT_EQ(world_frame.model_instance(), world_model_instance());
+  EXPECT_EQ(&world_body.body_frame(), &world_frame);
+  // Remaining elements.
+  EXPECT_EQ(plant.num_joints(), 0);
+  EXPECT_EQ(plant.num_actuators(), 0);
+  EXPECT_EQ(plant.num_constraints(), 0);
+  EXPECT_EQ(plant.num_force_elements(), 1);
+}
+
 GTEST_TEST(MultibodyPlantTest, EmptyWorldDiscrete) {
   const double discrete_update_period = 1.0e-3;
   MultibodyPlant<double> plant(discrete_update_period);
   plant.Finalize();
   EXPECT_EQ(plant.num_velocities(), 0);
   EXPECT_EQ(plant.num_positions(), 0);
+  EXPECT_EQ(plant.num_multibody_states(), 0);
+  EXPECT_EQ(plant.num_actuated_dofs(), 0);
   // Compute discrete update.
   auto context = plant.CreateDefaultContext();
   auto& discrete_state_vector = context->get_discrete_state_vector();
@@ -475,6 +503,8 @@ GTEST_TEST(MultibodyPlantTest, EmptyWorldContinuous) {
   plant.Finalize();
   EXPECT_EQ(plant.num_velocities(), 0);
   EXPECT_EQ(plant.num_positions(), 0);
+  EXPECT_EQ(plant.num_multibody_states(), 0);
+  EXPECT_EQ(plant.num_actuated_dofs(), 0);
   // Compute continuous derivatives.
   auto context = plant.CreateDefaultContext();
   auto& continuous_state_vector = context->get_continuous_state_vector();

--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -61,7 +61,7 @@ class Frame : public FrameBase<T> {
 
   /// Returns true if `this` is the world frame.
   bool is_world_frame() const {
-    return this->index() == FrameIndex(0);
+    return this->index() == world_frame_index();
   }
 
   /// Returns true if `this` is the body frame.

--- a/multibody/tree/multibody_tree_indexes.h
+++ b/multibody/tree/multibody_tree_indexes.h
@@ -51,12 +51,16 @@ using ModelInstanceIndex = TypeSafeIndex<class ModelInstanceTag>;
 // For this reason, we create and return an instance of pre-defined indices
 // instead of using a static variable.
 
-/// For every MultibodyTree the **world** body _always_ has this unique index
+/// For every MultibodyPlant the **world** body _always_ has this unique index
 /// and it is always zero.
 inline BodyIndex world_index() { return BodyIndex(0); }
 
+/// For every MultibodyPlant the **world** frame _always_ has this unique index
+/// and it is always zero.
+inline FrameIndex world_frame_index() { return FrameIndex(0); }
+
 /// Returns the model instance containing the *world* body.  For
-/// every MultibodyTree the **world** body _always_ has this unique
+/// every MultibodyPlant the **world** body _always_ has this unique
 /// model instance and it is always zero (as described in #3088).
 inline ModelInstanceIndex world_model_instance() {
   return ModelInstanceIndex(0);

--- a/multibody/tree/test/multibody_tree_indexes_test.cc
+++ b/multibody/tree/test/multibody_tree_indexes_test.cc
@@ -6,10 +6,12 @@ namespace drake {
 namespace multibody {
 namespace {
 
-// Verifies the correct behavior of BodyIndex.
-GTEST_TEST(MultibodyTreeIndexes, BodyIndex) {
-  // Verify the we can retrieve the "world" id.
+// Verifies the correct behavior of provided functions.
+GTEST_TEST(MultibodyTreeIndexes, ConstantFunctions) {
   EXPECT_EQ(world_index(), BodyIndex(0));
+  EXPECT_EQ(world_frame_index(), FrameIndex(0));
+  EXPECT_EQ(world_model_instance(), ModelInstanceIndex(0));
+  EXPECT_EQ(default_model_instance(), ModelInstanceIndex(1));
 }
 
 // Verifies that it is not possible to convert between two different

--- a/multibody/tree/test/tree_from_mobilizers_test.cc
+++ b/multibody/tree/test/tree_from_mobilizers_test.cc
@@ -408,7 +408,7 @@ TEST_F(PendulumTests, CreateModelBasics) {
 // assign these indexes.
 TEST_F(PendulumTests, Indexes) {
   CreatePendulumModel();
-  EXPECT_EQ(shoulder_inboard_frame_->index(), FrameIndex(0));
+  EXPECT_EQ(shoulder_inboard_frame_->index(), world_frame_index());
   EXPECT_EQ(upper_link_->body_frame().index(), FrameIndex(1));
   EXPECT_EQ(lower_link_->body_frame().index(), FrameIndex(2));
   EXPECT_EQ(shoulder_outboard_frame_->index(), FrameIndex(3));


### PR DESCRIPTION
Motivated by https://github.com/RobotLocomotion/drake/pull/17223#pullrequestreview-1149980403

Also adds simple checks on `num_multibody_states` and `num_actuated_dofs` for other empty world tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18149)
<!-- Reviewable:end -->
