### PR TITLE
multibody: Change world body name from "WorldBody" to "world"

### DIFF
--- a/multibody/parsing/test/detail_collision_filter_group_resolver_test.cc
+++ b/multibody/parsing/test/detail_collision_filter_group_resolver_test.cc
@@ -116,13 +116,13 @@ TEST_F(CollisionFilterGroupResolverTest, OutOfParseBodyGlobal) {
   AddBody("stuff", {});
   resolver_.AddGroup(diagnostic_policy_, "a", {
       "DefaultModelInstance::stuff",
-      "WorldModelInstance::WorldBody",
+      "WorldModelInstance::world",
       "stuff",
     },
     {});
   EXPECT_THAT(TakeError(), MatchesRegex(".*'DefaultModelInstance::stuff'"
                                         ".*outside the current parse"));
-  EXPECT_THAT(TakeError(), MatchesRegex(".*'WorldModelInstance::WorldBody'"
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'WorldModelInstance::world'"
                                         ".*outside the current parse"));
   // Ensure that unqualified bodies names at global scope aren't looked up in
   // the default model inadvertently.

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -685,7 +685,7 @@ GTEST_TEST(MujocoParser, Joint) {
       plant.GetBodyByName("weld").EvalPoseInWorld(*context).IsNearlyEqualTo(
           X_WB, 1e-14));
   const WeldJoint<double>& weld_joint =
-      plant.GetJointByName<WeldJoint>("WorldBody_welds_to_weld");
+      plant.GetJointByName<WeldJoint>("world_welds_to_weld");
   EXPECT_TRUE(weld_joint.X_FM().IsNearlyEqualTo(X_WB, 1e-14));
 }
 

--- a/multibody/plant/test/contact_results_to_lcm_test.cc
+++ b/multibody/plant/test/contact_results_to_lcm_test.cc
@@ -407,7 +407,7 @@ TYPED_TEST(ContactResultsToLcmTest, Constructor) {
      match the tables we build by hand. */
     unordered_map<GeometryId, FullBodyName> expected_geo_body_map;
     /* The world body will always be the first listed. */
-    vector<string> expected_body_names{{"WorldBody(0)"}};
+    vector<string> expected_body_names{{"world(0)"}};
 
     auto namer = [use_custom_names](GeometryId id) {
       if (use_custom_names) {

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1027,7 +1027,7 @@ TEST_F(AcrobotPlantTests, VisualGeometryRegistration) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant_->GetBodyFrameIdOrThrow(world_index()),
       /* Verify this method is throwing for the right reasons. */
-      "Body 'WorldBody' does not have geometry registered with it.");
+      "Body 'world' does not have geometry registered with it.");
 
   // Similarly, the "optional" variant should return a null opt.
   std::optional<FrameId> undefined_id =

--- a/multibody/topology/multibody_graph.h
+++ b/multibody/topology/multibody_graph.h
@@ -82,7 +82,7 @@ class MultibodyGraph {
 
   /* Returns the name we recognize as the World (or Ground) body. This is
   the name that was provided in the first AddBody() call.
-  In Drake, MultibodyPlant names it the "WorldBody".
+  In Drake, MultibodyPlant names it the "world".
   @throws std::exception iff AddBody() was not called even once yet. */
   const std::string& world_body_name() const;
 

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -11,6 +11,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/text_logging.h"
 #include "drake/common/unused.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
@@ -318,26 +319,55 @@ int MultibodyTree<T>::NumBodiesWithName(std::string_view name) const {
   return static_cast<int>(body_name_to_index_.count(name));
 }
 
+namespace {
+// In case the given (name, model_instance) uses the the deprecated name for
+// the world body, logs a warning and returns the non-deprecated name. Remove
+// this deprecation shim on or after 2023-06-01.
+std::string_view MaybeRewriteWorldBodyName(
+    std::string_view name, ModelInstanceIndex model_instance) {
+  if (model_instance == world_model_instance() && name == "WorldBody") {
+    static const logging::Warn log_once(
+        "MultibodyPlant's world body is named 'world' now, not 'WorldBody'. "
+        "Please update your hard-coded string literals to match. "
+        "The old name will no longer work on or after 2023-06-01.");
+    return "world";
+  }
+  return name;
+}
+}  // namespace
+
 template <typename T>
 bool MultibodyTree<T>::HasBodyNamed(std::string_view name) const {
-  return HasElementNamed(*this, name, std::nullopt, body_name_to_index_);
+  const std::string_view rewritten_name = MaybeRewriteWorldBodyName(
+      name, world_model_instance());
+  return HasElementNamed(*this, rewritten_name, std::nullopt,
+    body_name_to_index_);
 }
 
 template <typename T>
 bool MultibodyTree<T>::HasBodyNamed(
     std::string_view name, ModelInstanceIndex model_instance) const {
-  return HasElementNamed(*this, name, model_instance, body_name_to_index_);
+  const std::string_view rewritten_name = MaybeRewriteWorldBodyName(
+      name, model_instance);
+  return HasElementNamed(*this, rewritten_name, model_instance,
+    body_name_to_index_);
 }
 
 template <typename T>
 bool MultibodyTree<T>::HasFrameNamed(std::string_view name) const {
-  return HasElementNamed(*this, name, std::nullopt, frame_name_to_index_);
+  const std::string_view rewritten_name = MaybeRewriteWorldBodyName(
+      name, world_model_instance());
+  return HasElementNamed(*this, rewritten_name, std::nullopt,
+     frame_name_to_index_);
 }
 
 template <typename T>
 bool MultibodyTree<T>::HasFrameNamed(
     std::string_view name, ModelInstanceIndex model_instance) const {
-  return HasElementNamed(*this, name, model_instance, frame_name_to_index_);
+  const std::string_view rewritten_name = MaybeRewriteWorldBodyName(
+      name, model_instance);
+  return HasElementNamed(*this, rewritten_name, model_instance,
+      frame_name_to_index_);
 }
 
 template <typename T>
@@ -369,13 +399,19 @@ bool MultibodyTree<T>::HasModelInstanceNamed(std::string_view name) const {
 
 template <typename T>
 const Body<T>& MultibodyTree<T>::GetBodyByName(std::string_view name) const {
-  return GetElementByName(*this, name, std::nullopt, body_name_to_index_);
+  const std::string_view rewritten_name = MaybeRewriteWorldBodyName(
+      name, world_model_instance());
+  return GetElementByName(*this, rewritten_name, std::nullopt,
+      body_name_to_index_);
 }
 
 template <typename T>
 const Body<T>& MultibodyTree<T>::GetBodyByName(
     std::string_view name, ModelInstanceIndex model_instance) const {
-  return GetElementByName(*this, name, model_instance, body_name_to_index_);
+  const std::string_view rewritten_name =
+      MaybeRewriteWorldBodyName(name, model_instance);
+  return GetElementByName(*this, rewritten_name, model_instance,
+      body_name_to_index_);
 }
 
 template <typename T>
@@ -419,13 +455,19 @@ std::vector<FrameIndex> MultibodyTree<T>::GetFrameIndices(
 
 template <typename T>
 const Frame<T>& MultibodyTree<T>::GetFrameByName(std::string_view name) const {
-  return GetElementByName(*this, name, std::nullopt, frame_name_to_index_);
+  const std::string_view rewritten_name = MaybeRewriteWorldBodyName(
+      name, world_model_instance());
+  return GetElementByName(*this, rewritten_name, std::nullopt,
+      frame_name_to_index_);
 }
 
 template <typename T>
 const Frame<T>& MultibodyTree<T>::GetFrameByName(
     std::string_view name, ModelInstanceIndex model_instance) const {
-  return GetElementByName(*this, name, model_instance, frame_name_to_index_);
+  const std::string_view rewritten_name = MaybeRewriteWorldBodyName(
+      name, model_instance);
+  return GetElementByName(*this, rewritten_name, model_instance,
+      frame_name_to_index_);
 }
 
 template <typename T>

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -71,7 +71,7 @@ MultibodyTree<T>::MultibodyTree() {
   // `world_model_instance()` hardcodes the returned index.  Make sure it's
   // correct.
   DRAKE_DEMAND(world_instance == world_model_instance());
-  world_body_ = &AddRigidBody("WorldBody", world_model_instance(),
+  world_body_ = &AddRigidBody("world", world_model_instance(),
                               SpatialInertia<double>());
 
   // `default_model_instance()` hardcodes the returned index.  Make sure it's


### PR DESCRIPTION
More in line with conventions in URDF and SDFormat

Resolves #14638

Per #18149 and stability guidelines, shouldn't need deprecation?
(Though Anzu code, and probably other's, will need to change)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18158)
<!-- Reviewable:end -->
