### PR TITLE
[wheel] Hotfix broken auditwheel and import error test case

### DIFF
--- a/tools/wheel/image/build-wheel.sh
+++ b/tools/wheel/image/build-wheel.sh
@@ -58,8 +58,10 @@ cp -r -t ${WHEEL_DIR}/pydrake \
 cp -r -t ${WHEEL_DIR}/pydrake/lib \
     /opt/drake/lib/libdrake*.so
 
-cp -r -t ${WHEEL_DIR}/pydrake \
-    /opt/drake-wheel-content/*
+if [[ "$(uname)" == "Linux" ]]; then
+  cp -r -t ${WHEEL_DIR}/pydrake \
+      /opt/drake-wheel-content/*
+fi
 
 # NOTE: build-vtk.sh also puts licenses in /opt/drake-dependencies/licenses.
 cp -r -t ${WHEEL_DIR}/pydrake/doc \

--- a/tools/wheel/image/provision-python.sh
+++ b/tools/wheel/image/provision-python.sh
@@ -35,7 +35,8 @@ ln -s ${PREFIX}/include/${PYTHON}m /usr/local/include/
 ln -s /usr/local/bin/python /usr/bin/python
 
 # TODO(jwnimmer-tri): Should these be version-pinned? What's the process for
-# keeping them up to date if they are?
+# keeping them up to date if they are? For now we pin auditwheel because the
+# most recent 5.2.0 is not compatible with our current patchelf.
 pip install \
     lxml \
     matplotlib \
@@ -44,4 +45,4 @@ pip install \
     semantic-version \
     setuptools \
     wheel \
-    auditwheel
+    auditwheel==5.1.2

--- a/tools/wheel/test/tests/hermetic/import-error-test.sh
+++ b/tools/wheel/test/tests/hermetic/import-error-test.sh
@@ -19,4 +19,4 @@ EOF
 trap 'cat out' ERR
 
 grep -q 'Drake failed to load a required library' out
-grep -q '/pydrake/INSTALLATION' out
+grep -q 'apt.*install' out


### PR DESCRIPTION
The latest `auditwheel==5.2.0` is not compatible with our environment. We'll pin the prior version for now.

The recent commit (#18015) adding an import-error test case had a mismatch in the actual error message vs expected error message; fix that here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18165)
<!-- Reviewable:end -->
