### PR TITLE
[manipulation] Expose utime input port for IiwaCommandSender and IiwaStatusSender

### DIFF
--- a/bindings/pydrake/manipulation/kuka_iiwa_py.cc
+++ b/bindings/pydrake/manipulation/kuka_iiwa_py.cc
@@ -56,6 +56,9 @@ PYBIND11_MODULE(kuka_iiwa, m) {
     py::class_<Class, LeafSystem<double>>(m, "IiwaCommandSender", cls_doc.doc)
         .def(py::init<int>(), py::arg("num_joints") = kIiwaArmNumJoints,
             cls_doc.ctor.doc)
+        .def("get_time_measured_input_port",
+            &Class::get_time_measured_input_port, py_rvp::reference_internal,
+            cls_doc.get_time_measured_input_port.doc)
         .def("get_position_input_port", &Class::get_position_input_port,
             py_rvp::reference_internal, cls_doc.get_position_input_port.doc)
         .def("get_torque_input_port", &Class::get_torque_input_port,
@@ -101,6 +104,9 @@ PYBIND11_MODULE(kuka_iiwa, m) {
     py::class_<Class, LeafSystem<double>>(m, "IiwaStatusSender", cls_doc.doc)
         .def(py::init<int>(), py::arg("num_joints") = kIiwaArmNumJoints,
             cls_doc.ctor.doc)
+        .def("get_time_measured_input_port",
+            &Class::get_time_measured_input_port, py_rvp::reference_internal,
+            cls_doc.get_time_measured_input_port.doc)
         .def("get_position_commanded_input_port",
             &Class::get_position_commanded_input_port,
             py_rvp::reference_internal,

--- a/bindings/pydrake/manipulation/test/kuka_iiwa_test.py
+++ b/bindings/pydrake/manipulation/test/kuka_iiwa_test.py
@@ -36,6 +36,8 @@ class TestKukaIiwa(unittest.TestCase):
 
         command_send = mut.IiwaCommandSender()
         self.assertIsInstance(
+            command_send.get_time_measured_input_port(), InputPort)
+        self.assertIsInstance(
             command_send.get_position_input_port(), InputPort)
         self.assertIsInstance(
             command_send.get_torque_input_port(), InputPort)
@@ -57,6 +59,8 @@ class TestKukaIiwa(unittest.TestCase):
             status_rec.get_torque_external_output_port(), OutputPort)
 
         status_send = mut.IiwaStatusSender()
+        self.assertIsInstance(
+            status_send.get_time_measured_input_port(), InputPort)
         self.assertIsInstance(
             status_send.get_position_commanded_input_port(), InputPort)
         self.assertIsInstance(

--- a/manipulation/kuka_iiwa/iiwa_command_sender.cc
+++ b/manipulation/kuka_iiwa/iiwa_command_sender.cc
@@ -10,6 +10,7 @@ IiwaCommandSender::IiwaCommandSender(int num_joints)
       "position", systems::kVectorValued, num_joints_);
   this->DeclareInputPort(
       "torque", systems::kVectorValued, num_joints_);
+  this->DeclareInputPort("time_measured", systems::kVectorValued, 1);
   this->DeclareAbstractOutputPort(
       "lcmt_iiwa_command", &IiwaCommandSender::CalcOutput);
 }
@@ -23,15 +24,22 @@ const InPort& IiwaCommandSender::get_position_input_port() const {
 const InPort& IiwaCommandSender::get_torque_input_port() const {
   return LeafSystem<double>::get_input_port(1);
 }
+const InPort& IiwaCommandSender::get_time_measured_input_port() const {
+  return LeafSystem<double>::get_input_port(2);
+}
 
 void IiwaCommandSender::CalcOutput(
     const systems::Context<double>& context, lcmt_iiwa_command* output) const {
+  const double time_measured =
+      get_time_measured_input_port().HasValue(context)
+          ? get_time_measured_input_port().Eval(context)[0]
+          : context.get_time();
   const auto& position = get_position_input_port().Eval(context);
   const bool has_torque = get_torque_input_port().HasValue(context);
   const int num_torques = has_torque ? num_joints_ : 0;
 
   lcmt_iiwa_command& command = *output;
-  command.utime = context.get_time() * 1e6;
+  command.utime = time_measured * 1e6;
   command.num_joints = num_joints_;
   command.joint_position.resize(num_joints_);
   for (int i = 0; i < num_joints_; ++i) {

--- a/manipulation/kuka_iiwa/iiwa_command_sender.h
+++ b/manipulation/kuka_iiwa/iiwa_command_sender.h
@@ -15,10 +15,13 @@ namespace kuka_iiwa {
 /// send the message, the output of this system should be connected to a
 /// systems::lcm::LcmPublisherSystem::Make<lcmt_iiwa_command>().
 ///
-/// This system has two vector-valued input ports, one for the commanded
-/// position (which must be connected) and one for commanded torque (which is
-/// optional).  If the torque input port is not connected, then no torque
-/// values will be emitted in the resulting message.
+/// This system has three vector-valued input ports, one for the commanded
+/// position (which must be connected), one for commanded torque (which is
+/// optional), and one for the time to use, in seconds, for the message
+/// timestamp (which is optional). If the torque input port is not connected,
+/// then no torque values will be emitted in the resulting message. If the
+/// time_measured input port is not connected, the context time will be used for
+/// message timestamp.
 ///
 /// This system has one abstract-valued output port of type lcmt_iiwa_command.
 ///
@@ -27,6 +30,7 @@ namespace kuka_iiwa {
 /// input_ports:
 /// - position
 /// - torque (optional)
+/// - time_measured (optional)
 /// output_ports:
 /// - lcmt_iiwa_command
 /// @endsystem
@@ -41,6 +45,7 @@ class IiwaCommandSender final : public systems::LeafSystem<double> {
 
   /// @name Named accessors for this System's input and output ports.
   //@{
+  const systems::InputPort<double>& get_time_measured_input_port() const;
   const systems::InputPort<double>& get_position_input_port() const;
   const systems::InputPort<double>& get_torque_input_port() const;
   //@}

--- a/manipulation/kuka_iiwa/iiwa_status_sender.h
+++ b/manipulation/kuka_iiwa/iiwa_status_sender.h
@@ -15,8 +15,11 @@ namespace kuka_iiwa {
 /// send the message, the output of this system should be connected to a
 /// systems::lcm::LcmPublisherSystem::Make<lcmt_iiwa_status>().
 ///
-/// This system has many vector-valued input ports, each of which has exactly
-/// num_joints elements.
+/// This system has many vector-valued input ports, most of which have exactly
+/// num_joints elements. The exception is `time_measured` which is the
+/// one-dimensional time in seconds to set as the message timestamp (i.e. the
+/// time inputed will be converted to microseconds and sent to the hardware). It
+/// is optional and if unset, the context time is used.
 ///
 /// - `position_commanded`: the most recently received position command.
 /// - `position_measured`: the plant's current position.
@@ -44,12 +47,13 @@ namespace kuka_iiwa {
 /// - torque_commanded
 /// - torque_measured
 /// - torque_external
+/// - time_measured
 /// output_ports:
 /// - lcmt_iiwa_status
 /// @endsystem
 ///
-/// The ports `velocity_estimated`, `torque_measured`, and `torque_external`
-/// may be left unconnected, as detailed above.
+/// The ports `velocity_estimated`, `torque_measured`, `torque_external`, and
+/// `time_measured` may be left unconnected, as detailed above.
 ///
 /// @see `lcmt_iiwa_status.lcm` for additional documentation.
 class IiwaStatusSender final : public systems::LeafSystem<double> {
@@ -61,6 +65,7 @@ class IiwaStatusSender final : public systems::LeafSystem<double> {
 
   /// @name Named accessors for this System's input and output ports.
   //@{
+  const systems::InputPort<double>& get_time_measured_input_port() const;
   const systems::InputPort<double>& get_position_commanded_input_port() const;
   const systems::InputPort<double>& get_position_measured_input_port() const;
   const systems::InputPort<double>& get_velocity_estimated_input_port() const;

--- a/manipulation/kuka_iiwa/test/iiwa_status_sender_test.cc
+++ b/manipulation/kuka_iiwa/test/iiwa_status_sender_test.cc
@@ -48,6 +48,7 @@ class IiwaStatusSenderTest : public testing::Test {
 };
 
 TEST_F(IiwaStatusSenderTest, AcceptanceTest) {
+  const VectorXd time_measured = Vector1d(1.2);
   const VectorXd q0_commanded = VectorXd::LinSpaced(N, 0.1, 0.2);
   const VectorXd q0_measured = VectorXd::LinSpaced(N, 0.11, 0.22);
   const VectorXd v0_estimated = VectorXd::LinSpaced(N, 0.2, 0.3);
@@ -64,15 +65,18 @@ TEST_F(IiwaStatusSenderTest, AcceptanceTest) {
   EXPECT_EQ(output().joint_position_measured, as_vector(q0_measured));
   EXPECT_EQ(output().joint_torque_commanded, as_vector(t0_commanded));
   // ... and some outputs have default values.
+  EXPECT_EQ(output().utime, 0);
   EXPECT_EQ(output().joint_velocity_estimated, std::vector<double>(N, 0.0));
   EXPECT_EQ(output().joint_torque_measured, as_vector(t0_commanded));
   EXPECT_EQ(output().joint_torque_external, std::vector<double>(N, 0.0));
 
   // Fix all of the inputs ...
+  Fix(dut_.get_time_measured_input_port(), time_measured);
   Fix(dut_.get_velocity_estimated_input_port(), v0_estimated);
   Fix(dut_.get_torque_measured_input_port(), t0_measured);
   Fix(dut_.get_torque_external_input_port(), t0_external);
   // ... so all outputs have values.
+  EXPECT_EQ(output().utime, time_measured[0] * 1e6);
   EXPECT_EQ(output().joint_position_commanded, as_vector(q0_commanded));
   EXPECT_EQ(output().joint_position_measured, as_vector(q0_measured));
   EXPECT_EQ(output().joint_torque_commanded, as_vector(t0_commanded));


### PR DESCRIPTION
Continues work done in #17761 to allow command publisher to use utime from received status message.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18167)
<!-- Reviewable:end -->
