### PR TITLE
cpp_template: Add get_module_name()

### DIFF
--- a/bindings/pydrake/common/cpp_template.py
+++ b/bindings/pydrake/common/cpp_template.py
@@ -116,6 +116,23 @@ class TemplateBase:
             ("{}: incompatible function arguments for template: No "
              "compatible instantiations").format(self.name))
 
+    def get_module_name(self):
+        """
+        Returns module name for this object's parent scope.
+
+        Example::
+
+            >>> pydrake.common.value.Value.get_module_name()
+            pydrake.common.value
+        """
+        if isinstance(self._scope, types.ModuleType):
+            return self._scope.__name__
+        else:
+            raise RuntimeError(
+                f"Unable to resolve `get_module_name` for a scope that is not "
+                f"a module: {self._scope}"
+            )
+
     # Unique token to signify that this instantiation is deferred when using
     # `add_instantiations` or `define`. The instantiation function will not be
     # called until the specific instantiation is requested. To illustrate, the

--- a/bindings/pydrake/common/test/cpp_template_test.py
+++ b/bindings/pydrake/common/test/cpp_template_test.py
@@ -43,6 +43,8 @@ class TestCppTemplate(unittest.TestCase):
         self.assertEqual(str(template), "<TemplateBase {}.BaseTpl>".format(
             _TEST_MODULE))
 
+        self.assertEqual(template.get_module_name(), _TEST_MODULE)
+
         # Single arguments.
         template.add_instantiation(int, 1)
         self.assertEqual(template[int], 1)
@@ -95,6 +97,19 @@ class TestCppTemplate(unittest.TestCase):
         else:
             pickle_error = "can't pickle module objects"
         self.assertIn(pickle_error, str(cm.exception))
+
+    def test_base_negative(self):
+
+        class ParentScope:
+            pass
+
+        template = m.TemplateBase("NestedTemplate", scope=ParentScope)
+        with self.assertRaises(RuntimeError) as cm:
+            template.get_module_name()
+        self.assertIn(
+            "Unable to resolve `get_module_name` for a scope that is not a "
+            "module",
+            str(cm.exception))
 
     def test_deprecation(self):
         template = m.TemplateBase("BaseTpl")

--- a/bindings/pydrake/common/test/value_test.py
+++ b/bindings/pydrake/common/test/value_test.py
@@ -12,6 +12,13 @@ from pydrake.common.test.value_test_util import (
 
 
 class TestValue(unittest.TestCase):
+    def test_module(self):
+        # Note that __module__ is not what you expect.
+        self.assertEqual(Value.__module__, "pydrake.common.cpp_template")
+        # Instead, `get_module_name()` is what you want for instances of type
+        # TemplateBase.
+        self.assertEqual(Value.get_module_name(), "pydrake.common.value")
+
     def test_abstract_value_type_conversion(self):
         """Tests type-conversion types (passed by value, not reference)."""
         expected = "Hello world"


### PR DESCRIPTION
Useful when trying to get the equivalent of `type.__module__`
py value: Add equivalent test

Resolves #18168

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18169)
<!-- Reviewable:end -->
