### PR TITLE
Fix wheel installation documentation on macOS

### DIFF
--- a/tools/wheel/image/build-wheel.sh
+++ b/tools/wheel/image/build-wheel.sh
@@ -58,10 +58,8 @@ cp -r -t ${WHEEL_DIR}/pydrake \
 cp -r -t ${WHEEL_DIR}/pydrake/lib \
     /opt/drake/lib/libdrake*.so
 
-if [[ "$(uname)" == "Linux" ]]; then
-  cp -r -t ${WHEEL_DIR}/pydrake \
-      /opt/drake-wheel-content/*
-fi
+cp -r -t ${WHEEL_DIR}/pydrake \
+    /opt/drake-wheel-content/*
 
 # NOTE: build-vtk.sh also puts licenses in /opt/drake-dependencies/licenses.
 cp -r -t ${WHEEL_DIR}/pydrake/doc \

--- a/tools/wheel/macos/build-wheel.sh
+++ b/tools/wheel/macos/build-wheel.sh
@@ -137,6 +137,10 @@ cp \
     "$resource_root/image/setup.py" \
     "/opt/drake-wheel-build/wheel/setup.py"
 
+cp -R \
+    "$resource_root/content" \
+    "/opt/drake-wheel-content"
+
 export DRAKE_VERSION="$1"
 
 "$resource_root/image/build-wheel.sh"


### PR DESCRIPTION
Add missing logic to copy additional wheel content when building wheels on macOS. Revert recent change to only copy this into the wheel build on Linux.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18176)
<!-- Reviewable:end -->
