### PR TITLE
[math] Convert between std::vector<VectorX<T>> and MatrixX<T>

### DIFF
--- a/common/trajectories/BUILD.bazel
+++ b/common/trajectories/BUILD.bazel
@@ -45,6 +45,7 @@ drake_cc_library(
         ":trajectory",
         "//common:default_scalars",
         "//common:essential",
+        "//math:matrix_util",
     ],
 )
 
@@ -85,6 +86,7 @@ drake_cc_library(
         "//common:default_scalars",
         "//common:essential",
         "//common:polynomial",
+        "//math:matrix_util",
         "@fmt",
     ],
 )

--- a/common/trajectories/discrete_time_trajectory.cc
+++ b/common/trajectories/discrete_time_trajectory.cc
@@ -7,25 +7,12 @@
 #include <fmt/format.h>
 
 #include "drake/common/drake_assert.h"
+#include "drake/math/matrix_util.h"
 
 namespace drake {
 namespace trajectories {
 
-namespace {
-
-// Helper method to go from the Eigen entry points to the std::vector versions.
-// Copies each column of mat to an element of the returned std::vector.
-template <typename T>
-std::vector<MatrixX<T>> ColsToStdVector(
-    const Eigen::Ref<const MatrixX<T>>& mat) {
-  std::vector<MatrixX<T>> vec(mat.cols());
-  for (int i = 0; i < mat.cols(); i++) {
-    vec[i] = mat.col(i);
-  }
-  return vec;
-}
-
-}  // end namespace
+using math::EigenToStdVector;
 
 template <typename T>
 DiscreteTimeTrajectory<T>::DiscreteTimeTrajectory(
@@ -34,7 +21,7 @@ DiscreteTimeTrajectory<T>::DiscreteTimeTrajectory(
     const double time_comparison_tolerance)
     : DiscreteTimeTrajectory(
           std::vector<T>(times.data(), times.data() + times.size()),
-          ColsToStdVector(values), time_comparison_tolerance) {}
+          EigenToStdVector(values), time_comparison_tolerance) {}
 
 template <typename T>
 DiscreteTimeTrajectory<T>::DiscreteTimeTrajectory(

--- a/common/trajectories/piecewise_polynomial.cc
+++ b/common/trajectories/piecewise_polynomial.cc
@@ -10,6 +10,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_throw.h"
+#include "drake/math/matrix_util.h"
 
 using std::runtime_error;
 using std::vector;
@@ -19,6 +20,8 @@ using std::max;
 
 namespace drake {
 namespace trajectories {
+
+using math::EigenToStdVector;
 
 template <typename T>
 PiecewisePolynomial<T>::PiecewisePolynomial(
@@ -1128,22 +1131,6 @@ PiecewisePolynomial<T> PiecewisePolynomial<T>::LagrangeInterpolatingPolynomial(
                                 {times[0], times[times.size() - 1]});
 }
 
-namespace {
-
-// Helper method to go from the Eigen entry points to the std::vector versions.
-// Copies each column of mat to an element of the returned std::vector.
-template <typename T>
-std::vector<MatrixX<T>> ColsToStdVector(
-    const Eigen::Ref<const MatrixX<T>>& mat) {
-  std::vector<MatrixX<T>> vec(mat.cols());
-  for (int i=0; i < mat.cols(); i++) {
-    vec[i] = mat.col(i);
-  }
-  return vec;
-}
-
-}  // end namespace
-
 template <typename T>
 PiecewisePolynomial<T> PiecewisePolynomial<T>::ZeroOrderHold(
     const Eigen::Ref<const VectorX<T>>& breaks,
@@ -1151,7 +1138,7 @@ PiecewisePolynomial<T> PiecewisePolynomial<T>::ZeroOrderHold(
   DRAKE_DEMAND(samples.cols() == breaks.size());
   std::vector<T> my_breaks(breaks.data(), breaks.data() + breaks.size());
   return PiecewisePolynomial<T>::ZeroOrderHold(my_breaks,
-                                               ColsToStdVector(samples));
+                                               EigenToStdVector(samples));
 }
 
 template <typename T>
@@ -1161,7 +1148,7 @@ PiecewisePolynomial<T> PiecewisePolynomial<T>::FirstOrderHold(
   DRAKE_DEMAND(samples.cols() == breaks.size());
   std::vector<T> my_breaks(breaks.data(), breaks.data() + breaks.size());
   return PiecewisePolynomial<T>::FirstOrderHold(my_breaks,
-                                                ColsToStdVector(samples));
+                                                EigenToStdVector(samples));
 }
 
 template <typename T>
@@ -1172,7 +1159,7 @@ PiecewisePolynomial<T> PiecewisePolynomial<T>::CubicShapePreserving(
   DRAKE_DEMAND(samples.cols() == breaks.size());
   std::vector<T> my_breaks(breaks.data(), breaks.data() + breaks.size());
   return PiecewisePolynomial<T>::CubicShapePreserving(
-      my_breaks, ColsToStdVector(samples), zero_end_point_derivatives);
+      my_breaks, EigenToStdVector(samples), zero_end_point_derivatives);
 }
 
 template <typename T>
@@ -1185,7 +1172,7 @@ PiecewisePolynomial<T>::CubicWithContinuousSecondDerivatives(
   DRAKE_DEMAND(samples.cols() == breaks.size());
   std::vector<T> my_breaks(breaks.data(), breaks.data() + breaks.size());
   return PiecewisePolynomial<T>::CubicWithContinuousSecondDerivatives(
-      my_breaks, ColsToStdVector(samples), samples_dot_start.eval(),
+      my_breaks, EigenToStdVector(samples), samples_dot_start.eval(),
       samples_dot_end.eval());
 }
 
@@ -1197,7 +1184,7 @@ PiecewisePolynomial<T> PiecewisePolynomial<T>::CubicHermite(
   DRAKE_DEMAND(samples.cols() == breaks.size());
   std::vector<T> my_breaks(breaks.data(), breaks.data() + breaks.size());
   return PiecewisePolynomial<T>::CubicHermite(
-      my_breaks, ColsToStdVector(samples), ColsToStdVector(samples_dot));
+      my_breaks, EigenToStdVector(samples), EigenToStdVector(samples_dot));
 }
 
 template <typename T>
@@ -1208,7 +1195,7 @@ PiecewisePolynomial<T>::CubicWithContinuousSecondDerivatives(
   DRAKE_DEMAND(samples.cols() == breaks.size());
   std::vector<T> my_breaks(breaks.data(), breaks.data() + breaks.size());
   return PiecewisePolynomial<T>::CubicWithContinuousSecondDerivatives(
-      my_breaks, ColsToStdVector(samples), periodic_end_condition);
+      my_breaks, EigenToStdVector(samples), periodic_end_condition);
 }
 
 template <typename T>
@@ -1218,7 +1205,7 @@ PiecewisePolynomial<T> PiecewisePolynomial<T>::LagrangeInterpolatingPolynomial(
   DRAKE_DEMAND(samples.cols() == times.size());
   std::vector<T> my_times(times.data(), times.data() + times.size());
   return PiecewisePolynomial<T>::LagrangeInterpolatingPolynomial(
-      my_times, ColsToStdVector(samples));
+      my_times, EigenToStdVector(samples));
 }
 
 // Computes the cubic spline coefficients based on the given values and first

--- a/math/matrix_util.h
+++ b/math/matrix_util.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <functional>
+#include <vector>
 
 #include <Eigen/Dense>
 
@@ -151,6 +152,36 @@ bool IsPositiveDefinite(const Eigen::MatrixBase<Derived>& matrix,
   return eigensolver.eigenvalues().minCoeff() >=
          eigenvalue_tolerance * std::max(1., max_abs_eigenvalue);
 }
+
+/// Converts a MatrixX<T> into a std::vector<MatrixX<T>>, taking each column of
+/// the m-by-n matrix `mat` into an m-by-1 element of the returned std::vector.
+template <typename T>
+std::vector<MatrixX<T>> EigenToStdVector(
+    const Eigen::Ref<const MatrixX<T>>& mat) {
+  std::vector<MatrixX<T>> vec(mat.cols());
+  for (int i = 0; i < mat.cols(); ++i) {
+    vec[i] = mat.col(i);
+  }
+  return vec;
+}
+
+/// Converts a std::vector<MatrixX<T>> into a MatrixX<T>, composing each
+/// element of `vec` into a column of the returned matrix.
+///
+/// @pre all elements of `vec` must have one column and the same number of
+/// rows.
+template <typename T>
+MatrixX<T> StdVectorToEigen(const std::vector<MatrixX<T>>& vec) {
+  DRAKE_DEMAND(vec.size() > 0);
+  MatrixX<T> mat(vec[0].rows(), vec.size());
+  for (int i = 0; i < static_cast<int>(vec.size()); ++i) {
+    DRAKE_DEMAND(vec[i].rows() == mat.rows());
+    DRAKE_DEMAND(vec[i].cols() == 1);
+    mat.col(i) = vec[i];
+  }
+  return mat;
+}
+
 
 }  // namespace math
 }  // namespace drake

--- a/math/test/matrix_util_test.cc
+++ b/math/test/matrix_util_test.cc
@@ -8,6 +8,9 @@
 namespace drake {
 namespace math {
 namespace test {
+
+using Eigen::MatrixXd;
+
 GTEST_TEST(TestMatrixUtil, TestIsSymmetric) {
   auto A = Eigen::Matrix3d::Zero();
   EXPECT_TRUE(IsSymmetric(A, 0.0));
@@ -82,6 +85,23 @@ GTEST_TEST(TestMatrixUtil, IsPositiveDefiniteTest) {
   // Generate a PSD matrix.
   EXPECT_FALSE(IsPositiveDefinite(
       A * Eigen::Vector3d(1., 0., 1.).asDiagonal() * A.transpose(), 1e-8));
+}
+
+GTEST_TEST(TestMatrixUtil, StdVector) {
+  MatrixXd A(3, 4);
+  A << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12;
+  std::vector<MatrixXd> vec = EigenToStdVector<double>(A);
+  EXPECT_EQ(vec.size(), 4);
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_EQ(vec[i].size(), 3);
+    EXPECT_TRUE(CompareMatrices(vec[i], A.col(i)));
+  }
+  MatrixXd mat = StdVectorToEigen(vec);
+  EXPECT_TRUE(CompareMatrices(mat, A));
+
+  EXPECT_EQ(
+      EigenToStdVector<double>(Eigen::RowVector3d::LinSpaced(0.0, 1.0)).size(),
+      3);
 }
 
 }  // namespace test


### PR DESCRIPTION
This was a utility used in a few trajectory classes.  I'm using it in my upcoming KinematicTrajectoryOptimization PR; by the rule of 3 I'm extracting it to a common location rather than making another copy.

+@sherm1 for both reviews(?), please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18183)
<!-- Reviewable:end -->
