### PR TITLE
Relocate helper methods for slicing and indexing 

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -35,6 +35,7 @@ drake_cc_package_library(
         ":multibody_plant_core",
         ":point_pair_contact_info",
         ":propeller",
+        ":slicing_and_indexing",
         ":tamsi_solver",
         ":wing",
     ],
@@ -123,6 +124,7 @@ drake_cc_library(
         ":externally_applied_spatial_force",
         ":hydroelastic_traction",
         ":multibody_plant_config",
+        ":slicing_and_indexing",
         ":tamsi_solver",
         "//common:default_scalars",
         "//common:essential",
@@ -378,6 +380,16 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "slicing_and_indexing",
+    srcs = ["slicing_and_indexing.cc"],
+    hdrs = ["slicing_and_indexing.h"],
+    deps = [
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "spheres_stack",
     testonly = 1,
     srcs = [],
@@ -485,6 +497,14 @@ drake_cc_googletest(
         ":tamsi_solver_test_util",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_no_throw",
+    ],
+)
+
+drake_cc_googletest(
+    name = "slicing_and_indexing_test",
+    deps = [
+        ":slicing_and_indexing",
+        "//common:essential",
     ],
 )
 

--- a/multibody/plant/slicing_and_indexing.cc
+++ b/multibody/plant/slicing_and_indexing.cc
@@ -1,0 +1,107 @@
+#include "drake/multibody/plant/slicing_and_indexing.h"
+
+#include <set>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/eigen_types.h"
+
+// TODO(rpoyner-tri): the Select*() and Expand*() functions below can be
+// removed and replaced with arbitrary indexing once Eigen 3.4 is our minimum
+// required version.
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+void DemandIndicesValid(const std::vector<int>& indices, int max_size) {
+  DRAKE_DEMAND(static_cast<int>(indices.size()) <= max_size);
+  if (indices.empty()) {
+    return;
+  }
+
+  // Only do the expensive check in debug builds.
+  DRAKE_ASSERT(std::is_sorted(indices.begin(), indices.end()));
+  DRAKE_ASSERT(std::set<int>(indices.begin(), indices.end()).size() ==
+               indices.size());  // Checks there are no duplicates.
+  DRAKE_DEMAND(indices[0] >= 0);
+  DRAKE_DEMAND(indices[indices.size() - 1] < max_size);
+}
+
+template <typename T>
+MatrixX<T> SelectRowsCols(const MatrixX<T>& M,
+                          const std::vector<int>& indices) {
+  DRAKE_DEMAND(M.rows() == M.cols());
+  DRAKE_ASSERT_VOID(DemandIndicesValid(indices, M.rows()));
+  const int selected_count = indices.size();
+  if (selected_count == M.rows()) {
+    return M;
+  }
+  MatrixX<T> result(selected_count, selected_count);
+
+  for (int i = 0; i < result.rows(); ++i) {
+    for (int j = 0; j < result.cols(); ++j) {
+      result(i, j) = M(indices[i], indices[j]);
+    }
+  }
+  return result;
+}
+
+template <typename T>
+MatrixX<T> SelectCols(const MatrixX<T>& M, const std::vector<int>& indices) {
+  DRAKE_ASSERT_VOID(DemandIndicesValid(indices, M.cols()));
+  const int selected_count = indices.size();
+  if (selected_count == M.cols()) {
+    return M;
+  }
+  MatrixX<T> result(M.rows(), selected_count);
+
+  for (int i = 0; i < result.cols(); ++i) {
+    result.col(i) = M.col(indices[i]);
+  }
+  return result;
+}
+
+template <typename T>
+VectorX<T> SelectRows(const VectorX<T>& v, const std::vector<int>& indices) {
+  DRAKE_ASSERT_VOID(DemandIndicesValid(indices, v.size()));
+  const int selected_count = indices.size();
+  if (selected_count == v.rows()) {
+    return v;
+  }
+  VectorX<T> result(selected_count);
+
+  for (int i = 0; i < result.rows(); ++i) {
+    result(i) = v(indices[i]);
+  }
+  return result;
+}
+
+template <typename T>
+VectorX<T> ExpandRows(const VectorX<T>& v, int rows_out,
+                      const std::vector<int>& indices) {
+  DRAKE_ASSERT(static_cast<int>(indices.size()) == v.rows());
+  DRAKE_ASSERT(rows_out >= v.rows());
+  DRAKE_ASSERT_VOID(DemandIndicesValid(indices, rows_out));
+  if (rows_out == v.rows()) {
+    return v;
+  }
+  VectorX<T> result(rows_out);
+
+  int index_cursor = 0;
+  for (int i = 0; i < result.rows(); ++i) {
+    if (index_cursor >= v.rows() || i < indices[index_cursor]) {
+      result(i) = 0.;
+    } else {
+      result(indices[index_cursor]) = v(index_cursor);
+      ++index_cursor;
+    }
+  }
+  return result;
+}
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    (&SelectRowsCols<T>, &SelectRows<T>, &SelectCols<T>, &ExpandRows<T>))
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/slicing_and_indexing.h
+++ b/multibody/plant/slicing_and_indexing.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+
+// TODO(rpoyner-tri): the Select*() and Expand*() functions below can be
+// removed and replaced with arbitrary indexing once Eigen 3.4 is our minimum
+// required version.
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Valid index arrays are no larger than max_size, are sorted, and contain
+// entries in the range [0, max_size).
+void DemandIndicesValid(const std::vector<int>& indices, int max_size);
+
+// Make a new, possibly smaller square matrix from square matrix @p M, by
+// selecting the rows and columns indexed by @p indices.
+// @pre indices.size() <= M.rows() (or M.cols() since M is a square matrix).
+// @pre indices argument is valid according to DemandIndicesValid().
+template <typename T>
+MatrixX<T> SelectRowsCols(const MatrixX<T>& M, const std::vector<int>& indices);
+
+// Make a new, possibly smaller matrix from matrix M, by selecting the columns
+// indexed by @p indices.
+// @pre indices.size() <= M.cols().
+// @pre indices argument is valid according to DemandIndicesValid().
+template <typename T>
+MatrixX<T> SelectCols(const MatrixX<T>& M, const std::vector<int>& indices);
+
+// Make a new, possibly smaller vector from vector @p v, by selecting the rows
+// indexed by @p indices.
+// @pre indices.size() <= v.size().
+// @pre indices argument is valid according to DemandIndicesValid().
+template <typename T>
+VectorX<T> SelectRows(const VectorX<T>& v, const std::vector<int>& indices);
+
+// Make a new, possibly larger vector of size @p rows_out, by copying rows
+// of @p v to rows indexed by @p indices. New rows are filled with zeros.
+// That is, v_expanded(indices(i)) = v(i), for i=0, v.size().
+// @pre indices.size() <= rows_out.
+// @pre indices must have the same size as v.
+// @pre indices argument is valid according to DemandIndicesValid().
+template <typename T>
+VectorX<T> ExpandRows(const VectorX<T>& v, int rows_out,
+                      const std::vector<int>& indices);
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/slicing_and_indexing_test.cc
+++ b/multibody/plant/test/slicing_and_indexing_test.cc
@@ -1,0 +1,69 @@
+#include "drake/multibody/plant/slicing_and_indexing.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace {
+
+const std::vector<int> indices = {1, 3, 4};
+
+MatrixXd MakeMatrixWithLinSpacedValues(int rows, int cols) {
+  const int size = rows * cols;
+  const VectorXd values = VectorXd::LinSpaced(size, 1, size);
+  return Eigen::Map<const MatrixXd>(values.data(), rows, cols);
+}
+
+GTEST_TEST(SlicingAndIndexing, SelectRows) {
+  const VectorXd M = MakeMatrixWithLinSpacedValues(6, 1);
+  const MatrixXd S = SelectRows(M, indices);
+  const VectorXd S_expected = (VectorXd(3, 1) << 2, 4, 5).finished();
+  EXPECT_EQ(S, S_expected);
+}
+
+GTEST_TEST(SlicingAndIndexing, SelectCols) {
+  const MatrixXd M = MakeMatrixWithLinSpacedValues(6, 5);
+  const MatrixXd S = SelectCols(M, indices);
+  // clang-format off
+  const MatrixXd S_expected = (MatrixXd(6, 3) <<
+     7, 19, 25,
+     8, 20, 26,
+     9, 21, 27,
+    10, 22, 28,
+    11, 23, 29,
+    12, 24, 30).finished();
+  // clang-format on
+  EXPECT_EQ(S, S_expected);
+}
+
+GTEST_TEST(SlicingAndIndexing, SelectRowsCols) {
+  const MatrixXd M = MakeMatrixWithLinSpacedValues(6, 6);
+  const MatrixXd S = SelectRowsCols(M, indices);
+  // clang-format off
+  const MatrixXd S_expected = (MatrixXd(3, 3) <<
+     8, 20, 26,
+    10, 22, 28,
+    11, 23, 29).finished();
+  // clang-format on
+  EXPECT_EQ(S, S_expected);
+}
+
+GTEST_TEST(SlicingAndIndexing, ExpandRows) {
+  const VectorXd M = MakeMatrixWithLinSpacedValues(3, 1);
+  const int expanded_size = 8;
+  const VectorXd S = ExpandRows(M, expanded_size, indices);
+  const VectorXd S_expected =
+      (VectorXd(expanded_size) << 0, 1, 0, 2, 3, 0, 0, 0).finished();
+  EXPECT_EQ(S, S_expected);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Per request in #18170, helper methods used in the joint locking code is move outside `MultibodyPlant` into their own files.
Towards #16955 and #13888.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18186)
<!-- Reviewable:end -->
