### PR TITLE
[wheel] Enable mac arm64 wheel builds

### DIFF
--- a/tools/wheel/image/dependencies/CMakeLists.txt
+++ b/tools/wheel/image/dependencies/CMakeLists.txt
@@ -1,8 +1,31 @@
 cmake_minimum_required(VERSION 3.10.0)
 project(pip-drake-dependencies)
 
-include(ExternalProject)
+# See: https://cmake.org/cmake/help/latest/policy/CMP0135.html
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
 
+# Enable checking for `if(APPLE_ARM64)`, needed by some projects.
+if(APPLE)
+  execute_process(
+      COMMAND "/usr/bin/arch"
+      RESULT_VARIABLE APPLE_ARCHITECTURE_RESULT_VARIABLE
+      OUTPUT_VARIABLE APPLE_ARCHITECTURE
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(NOT APPLE_ARCHITECTURE_RESULT_VARIABLE EQUAL 0)
+    message(FATAL_ERROR "Unable to detect Apple architecture via /usr/bin/arch")
+  endif()
+  if(APPLE_ARCHITECTURE STREQUAL "arm64")
+    set(APPLE_ARM64 ON)
+  else()
+    set(APPLE_ARM64 OFF)
+  endif()
+else()
+  set(APPLE_ARM64 OFF)
+endif()
+
+include(ExternalProject)
 include(projects.cmake)
 message(STATUS "zlib: ${zlib_url}")
 
@@ -30,6 +53,13 @@ set (COMMON_CMAKE_ARGS
     -DCMAKE_PREFIX_PATH:PATH=${CMAKE_INSTALL_PREFIX}
     -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
     )
+if(APPLE)
+  if(APPLE_ARM64)
+    list(APPEND COMMON_CMAKE_ARGS "-DCMAKE_OSX_ARCHITECTURES=arm64")
+  else()
+    list(APPEND COMMON_CMAKE_ARGS "-DCMAKE_OSX_ARCHITECTURES=x86_64")
+  endif()
+endif()
 
 function(extract_license PROJECT)
     set(command "")

--- a/tools/wheel/image/dependencies/projects.cmake
+++ b/tools/wheel/image/dependencies/projects.cmake
@@ -32,16 +32,15 @@ set(xz_md5 "0d270c997aff29708c74d53f599ef717")
 list(APPEND ALL_PROJECTS xz)
 
 # libjpeg-turbo
-set(libjpeg-turbo_version 1.4.0)
-set(libjpeg-turbo_url "http://sourceforge.net/projects/libjpeg-turbo/files/libjpeg-turbo-${libjpeg-turbo_version}.tar.gz")
-set(libjpeg-turbo_md5 "039153dabe61e1ac8d9323b5522b56b0")
+set(libjpeg-turbo_version 2.1.4)
+set(libjpeg-turbo_url "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/${libjpeg-turbo_version}.tar.gz")
+set(libjpeg-turbo_md5 "357dc26a802c34387512a42697846d16")
 list(APPEND ALL_PROJECTS libjpeg-turbo)
 
 # png
-set(png_version 1.6.19)
-set(png_archive_version 16)
-set(png_url "http://sourceforge.net/projects/libpng/files/libpng${png_archive_version}/older-releases/${png_version}/libpng-${png_version}.tar.gz")
-set(png_md5 "3121bdc77c365a87e054b9f859f421fe")
+set(png_version 1.6.38)
+set(png_url "https://downloads.sourceforge.net/project/libpng/libpng16/${png_version}/libpng-${png_version}.tar.xz")
+set(png_md5 "122e6b7837811698563083b352bc8ca2")
 list(APPEND ALL_PROJECTS png)
 
 # libtiff

--- a/tools/wheel/image/dependencies/projects/libjpeg-turbo.cmake
+++ b/tools/wheel/image/dependencies/projects/libjpeg-turbo.cmake
@@ -1,23 +1,13 @@
-if(APPLE)
-    set(_libjpeg-turbo_ARGS_APPLE --host x86_64-apple-darwin )
-endif()
-
 ExternalProject_Add(libjpeg-turbo
     URL ${libjpeg-turbo_url}
     URL_MD5 ${libjpeg-turbo_md5}
     ${COMMON_EP_ARGS}
-    BUILD_IN_SOURCE 1
-    CONFIGURE_COMMAND ./configure
-        --prefix=${CMAKE_INSTALL_PREFIX}
-        --disable-shared
-        ${_libjpeg-turbo_ARGS_APPLE}
-        NASM=yasm
-        CFLAGS=-fPIC
-        CXXFLAGS=-fPIC
-    BUILD_COMMAND make
-    INSTALL_COMMAND make install
-    )
+    ${COMMON_CMAKE_EP_ARGS}
+    CMAKE_ARGS
+        ${COMMON_CMAKE_ARGS}
+        -DCMAKE_ASM_NASM_COMPILER=yasm
+)
 
 extract_license(libjpeg-turbo
-    README
+    LICENSE.md
 )


### PR DESCRIPTION
Fixes #17906.

- [X] Confirm the wheel builds:
    - [X] [mac x86_64](https://drake-jenkins.csail.mit.edu/job/mac-x86-big-sur-unprovisioned-clang-wheel-experimental-snopt-mosek-release/6/)
    - [X] [linux focal](https://drake-jenkins.csail.mit.edu/job/linux-focal-unprovisioned-gcc-wheel-experimental-snopt-mosek-release/89/)
    - [X] [mac arm64](https://drake-jenkins.csail.mit.edu/job/mac-arm-monterey-unprovisioned-clang-wheel-experimental-snopt-mosek-release/2/)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18189)
<!-- Reviewable:end -->
