### PR TITLE
Implements support for distance constraints with SAP

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -462,6 +462,15 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "sap_driver_distance_constraints_test",
+    deps = [
+        ":compliant_contact_manager_tester",
+        ":plant",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
     name = "sap_driver_joint_limits_test",
     data = [
         "//manipulation/models/iiwa_description:models",

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -158,6 +158,13 @@ const std::vector<int>& DiscreteUpdateManager<T>::EvalJointLockingIndices(
       T>::EvalJointLockingIndices(plant(), context);
 }
 
+template <typename T>
+const std::vector<internal::DistanceConstraintSpecs>&
+DiscreteUpdateManager<T>::distance_constraints_specs() const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<
+      T>::distance_constraints_specs(*plant_);
+}
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -235,6 +235,9 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
 
   const std::vector<int>& EvalJointLockingIndices(
       const systems::Context<T>& context) const;
+
+  const std::vector<internal::DistanceConstraintSpecs>&
+  distance_constraints_specs() const;
   /* @} */
 
   /* Concrete DiscreteUpdateManagers must override these NVI Calc methods to

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -390,6 +390,7 @@ MultibodyPlant<T>::MultibodyPlant(const MultibodyPlant<U>& other)
     }
 
     coupler_constraints_specs_ = other.coupler_constraints_specs_;
+    distance_constraints_specs_ = other.distance_constraints_specs_;
 
     // cache_indexes_ is set in DeclareCacheEntries() in
     // DeclareStateCacheAndPorts() in FinalizePlantOnly().
@@ -453,6 +454,51 @@ ConstraintIndex MultibodyPlant<T>::AddCouplerConstraint(const Joint<T>& joint0,
 
   coupler_constraints_specs_.push_back(internal::CouplerConstraintSpecs{
       joint0.index(), joint1.index(), gear_ratio, offset});
+
+  return constraint_index;
+}
+
+template <typename T>
+ConstraintIndex MultibodyPlant<T>::AddDistanceConstraint(
+    const Body<T>& body_A, const Vector3<double>& p_AP, const Body<T>& body_B,
+    const Vector3<double>& p_BQ, double distance, double stiffness,
+    double damping) {
+  // N.B. The manager is setup at Finalize() and therefore we must require
+  // constraints to be added pre-finalize.
+  DRAKE_MBP_THROW_IF_FINALIZED();
+
+  if (!is_discrete()) {
+    throw std::runtime_error(
+        "Currently distance constraints are only supported for discrete "
+        "MultibodyPlant models.");
+  }
+
+  // TAMSI does not support distance constraints. For all other solvers, we let
+  // the discrete update manger throw an exception at finalize time.
+  if (contact_solver_enum_ == DiscreteContactSolver::kTamsi) {
+    throw std::runtime_error(
+        "Currently this MultibodyPlant is set to use the TAMSI solver. TAMSI "
+        "does not support distance constraints. Use "
+        "set_discrete_contact_solver(DiscreteContactSolver::kSap) to use the "
+        "SAP solver instead. For other solvers, refer to "
+        "DiscreteContactSolver.");
+  }
+
+  DRAKE_THROW_UNLESS(body_A.index() != body_B.index());
+
+  internal::DistanceConstraintSpecs spec{body_A.index(), p_AP, body_B.index(),
+                                         p_BQ, distance, stiffness, damping};
+  if (!spec.IsValid()) {
+    const std::string msg = fmt::format(
+        "Invalid set of parameters for constraint between bodies '{}' and "
+        "'{}'. distance = {}, stiffness = {}, damping = {}.",
+        body_A.name(), body_B.name(), distance, stiffness, damping);
+    throw std::runtime_error(msg);
+  }
+
+  const ConstraintIndex constraint_index(num_constraints());
+
+  distance_constraints_specs_.push_back(spec);
 
   return constraint_index;
 }

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1192,7 +1192,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @{
 
   /// Returns the total number of constraints specified by the user.
-  int num_constraints() const { return coupler_constraints_specs_.size(); }
+  int num_constraints() const {
+    return static_cast<int>(coupler_constraints_specs_.size() +
+           distance_constraints_specs_.size());
+  }
 
   /// Defines a holonomic constraint between two single-dof joints `joint0`
   /// and `joint1` with positions q₀ and q₁, respectively, such that q₀ = ρ⋅q₁ +
@@ -1226,6 +1229,52 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
                                       ExtractDoubleOrThrow(gear_ratio),
                                       ExtractDoubleOrThrow(offset));
   }
+
+  /// Defines a distance constraint between a point P on a body A and a point Q
+  /// on a body B.
+  ///
+  /// This constraint can be compliant, modeling a spring with free length
+  /// `distance` and given `stiffness` and `damping` parameters between points P
+  /// and Q. For d = ‖p_PQ‖, then a compliant distance constraint models a
+  /// spring with force along p_PQ given by:
+  ///
+  ///    f = −stiffness ⋅ d − damping ⋅ ḋ
+  ///
+  /// @param[in] body_A Body to which point P is rigidly attached.
+  /// @param[in] p_AP Position of point P in body A's frame.
+  /// @param[in] body_B Body to which point Q is rigidly attached.
+  /// @param[in] p_BQ Position of point Q in body B's frame.
+  /// @param[in] distance Fixed length of the distance constraint, in meters. It
+  /// must be strictly positive.
+  /// @param[in] stiffness For modeling a spring with free length equal to
+  /// `distance`, the stiffness parameter in N/m. Optional, with its default
+  /// value being infinite to model a rigid massless rod of length `distance`
+  /// connecting points A and B.
+  /// @param[in] damping For modeling a spring with free length equal to
+  /// `distance`, damping parameter in N⋅s/m. Optional, with its default value
+  /// being zero for a non-dissipative constraint.
+  /// @returns the index to the newly added constraint.
+  ///
+  /// @warning Currently, it is the user's responsibility to initialize the
+  /// model's context in a configuration compatible with the newly added
+  /// constraint.
+  ///
+  /// @warning A distance constraint is the wrong modeling choice if the
+  /// distance needs to go through zero. To constrain two points to be
+  /// coincident we need a 3-dof ball constraint, the 1-dof distance constraint
+  /// is singular in this case. Therefore we require the distance parameter to
+  /// be strictly positive.
+  ///
+  /// @throws std::exception if bodies A and B are the same body.
+  /// @throws std::exception if `distance` is not strictly positive.
+  /// @throws std::exception if `stiffness` is not positive or zero.
+  /// @throws std::exception if `damping` is not positive or zero.
+  /// @throws std::exception if the %MultibodyPlant has already been finalized.
+  ConstraintIndex AddDistanceConstraint(
+      const Body<T>& body_A, const Vector3<double>& p_AP, const Body<T>& body_B,
+      const Vector3<double>& p_BQ, double distance,
+      double stiffness = std::numeric_limits<double>::infinity(),
+      double damping = 0.0);
 
   /// <!-- TODO(xuchenhan-tri): Add getters to interrogate existing constraints.
   /// -->
@@ -5146,6 +5195,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   // Vector of coupler constraints specifications.
   std::vector<internal::CouplerConstraintSpecs> coupler_constraints_specs_;
+
+  // Vector of distance constraints specifications.
+  std::vector<internal::DistanceConstraintSpecs> distance_constraints_specs_;
 
   // All MultibodyPlant cache indexes are stored in cache_indexes_.
   CacheIndexes cache_indexes_;

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -113,6 +113,11 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
       const MultibodyPlant<T>& plant, const systems::Context<T>& context) {
     return plant.EvalJointLockingIndices(context);
   }
+
+  static const std::vector<internal::DistanceConstraintSpecs>&
+  distance_constraints_specs(const MultibodyPlant<T>& plant) {
+    return plant.distance_constraints_specs_;
+  }
 };
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -363,6 +363,110 @@ void SapDriver<T>::AddCouplerConstraints(const systems::Context<T>& context,
 }
 
 template <typename T>
+void SapDriver<T>::AddDistanceConstraints(const systems::Context<T>& context,
+                                          SapContactProblem<T>* problem) const {
+  DRAKE_DEMAND(problem != nullptr);
+
+  // Distance constraints do not have impulse limits, they are bi-lateral
+  // constraints. Each distance constraint introduces a single constraint
+  // equation.
+  constexpr double kInfinity = std::numeric_limits<double>::infinity();
+  const Vector1<T> gamma_lower(-kInfinity);
+  const Vector1<T> gamma_upper(kInfinity);
+
+  const int nv = plant().num_velocities();
+  Matrix3X<T> Jv_WAp_W(3, nv);
+  Matrix3X<T> Jv_WBq_W(3, nv);
+  MatrixX<T> Jdistance = MatrixX<T>::Zero(1, nv);
+
+  const Frame<T>& frame_W = plant().world_frame();
+  for (const DistanceConstraintSpecs& specs :
+       manager().distance_constraints_specs()) {
+    const Body<T>& body_A = plant().get_body(specs.body_A);
+    const Body<T>& body_B = plant().get_body(specs.body_B);
+
+    const math::RigidTransform<T>& X_WA =
+        plant().EvalBodyPoseInWorld(context, body_A);
+    const math::RigidTransform<T>& X_WB =
+        plant().EvalBodyPoseInWorld(context, body_B);
+    const Vector3<T>& p_WP = X_WA * specs.p_AP.cast<T>();
+    const Vector3<T>& p_WQ = X_WB * specs.p_BQ.cast<T>();
+
+    // Distance as the norm of p_PQ_W = p_WQ - p_WP
+    const Vector3<T> p_PQ_W = p_WQ - p_WP;
+    const T d0 = p_PQ_W.norm();
+    // Verify the distance did not become ridiculously small. We use the
+    // user-specified distance as a reference.
+    constexpr double kMinimumDistance = 1.0e-7;
+    constexpr double kRelativeDistance = 1.0e-2;
+    if (d0 < kMinimumDistance + kRelativeDistance * specs.distance) {
+      const std::string msg = fmt::format(
+          "The distance between bodies '{}' and '{}' is: {}. This is "
+          "nonphysically small when compared to the free length of the "
+          "constraint, {}. ",
+          body_A.name(), body_B.name(), d0, specs.distance);
+      throw std::logic_error(msg);
+    }
+    const Vector3<T> p_hat_W = p_PQ_W / d0;
+
+    DRAKE_DEMAND(body_A.index() != body_B.index());
+
+    // Dense Jacobian.
+    // d(distance)/dt = Jdistance * v.
+    manager().internal_tree().CalcJacobianTranslationalVelocity(
+        context, JacobianWrtVariable::kV, body_A.body_frame(), frame_W, p_WP,
+        frame_W, frame_W, &Jv_WAp_W);
+    manager().internal_tree().CalcJacobianTranslationalVelocity(
+        context, JacobianWrtVariable::kV, body_B.body_frame(), frame_W, p_WQ,
+        frame_W, frame_W, &Jv_WBq_W);
+    Jdistance = p_hat_W.transpose() * (Jv_WBq_W - Jv_WAp_W);
+
+    const T dissipation_time_scale = specs.damping / specs.stiffness;
+
+    // TODO(amcastro-tri): consider exposing this parameter.
+    const double beta = 0.1;
+    const typename SapHolonomicConstraint<T>::Parameters parameters{
+        gamma_lower, gamma_upper, Vector1<T>(specs.stiffness),
+        Vector1<T>(dissipation_time_scale), beta};
+
+    const TreeIndex treeA_index =
+        tree_topology().body_to_tree_index(specs.body_A);
+    const TreeIndex treeB_index =
+        tree_topology().body_to_tree_index(specs.body_B);
+
+    // Sanity check at least one body is not the world.
+    DRAKE_DEMAND(treeA_index.is_valid() || treeB_index.is_valid());
+
+    // Both bodies A and B belong to the same tree or one of them is the world.
+    const bool single_tree = !treeA_index.is_valid() ||
+                             !treeB_index.is_valid() ||
+                             treeA_index == treeB_index;
+
+    // Constraint function at current time step.
+    const Vector1<T> g0(d0 - specs.distance);
+    if (single_tree) {
+      const TreeIndex tree_index =
+          treeA_index.is_valid() ? treeA_index : treeB_index;
+      const MatrixX<T> J = Jdistance.middleCols(
+          tree_topology().tree_velocities_start(tree_index),
+          tree_topology().num_tree_velocities(tree_index));
+
+      problem->AddConstraint(std::make_unique<SapHolonomicConstraint<T>>(
+          tree_index, g0, J, parameters));
+    } else {
+      const MatrixX<T> JA = Jdistance.middleCols(
+          tree_topology().tree_velocities_start(treeA_index),
+          tree_topology().num_tree_velocities(treeA_index));
+      const MatrixX<T> JB = Jdistance.middleCols(
+          tree_topology().tree_velocities_start(treeB_index),
+          tree_topology().num_tree_velocities(treeB_index));
+      problem->AddConstraint(std::make_unique<SapHolonomicConstraint<T>>(
+          treeA_index, treeB_index, g0, JA, JB, parameters));
+    }
+  }
+}
+
+template <typename T>
 void SapDriver<T>::CalcContactProblemCache(
     const systems::Context<T>& context, ContactProblemCache<T>* cache) const {
   SapContactProblem<T>& problem = *cache->sap_problem;
@@ -378,6 +482,7 @@ void SapDriver<T>::CalcContactProblemCache(
   cache->R_WC = AddContactConstraints(context, &problem);
   AddLimitConstraints(context, problem.v_star(), &problem);
   AddCouplerConstraints(context, &problem);
+  AddDistanceConstraints(context, &problem);
 }
 
 template <typename T>

--- a/multibody/plant/sap_driver.h
+++ b/multibody/plant/sap_driver.h
@@ -138,6 +138,12 @@ class SapDriver {
       const systems::Context<T>& context,
       contact_solvers::internal::SapContactProblem<T>* problem) const;
 
+  // Adds holonomic constraints to model distance constraints specified in the
+  // MultibodyPlant.
+  void AddDistanceConstraints(
+      const systems::Context<T>& context,
+      contact_solvers::internal::SapContactProblem<T>* problem) const;
+
   // This method takes SAP results for a given `problem` and loads forces due to
   // contact only into `contact_results`. `contact_results` is properly resized
   // on output.

--- a/multibody/plant/test/sap_driver_distance_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_distance_constraints_test.cc
@@ -1,0 +1,246 @@
+#include <algorithm>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
+#include "drake/multibody/contact_solvers/sap/sap_holonomic_constraint.h"
+#include "drake/multibody/plant/compliant_contact_manager.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/sap_driver.h"
+#include "drake/multibody/plant/test/compliant_contact_manager_tester.h"
+
+/* @file This file tests SapDriver's support for distance constraints. */
+
+using drake::math::RigidTransformd;
+using drake::multibody::contact_solvers::internal::SapContactProblem;
+using drake::multibody::contact_solvers::internal::SapHolonomicConstraint;
+using drake::systems::Context;
+using Eigen::MatrixXd;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+
+constexpr double kInfinity = std::numeric_limits<double>::infinity();
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Friend class used to provide access to a selection of private functions in
+// SapDriver for testing purposes.
+class SapDriverTest {
+ public:
+  static const ContactProblemCache<double>& EvalContactProblemCache(
+      const SapDriver<double>& driver, const Context<double>& context) {
+    return driver.EvalContactProblemCache(context);
+  }
+};
+
+struct TestConfig {
+  // This is a gtest test suffix; no underscores or spaces.
+  std::string description;
+  bool bodyA_anchored{};
+  bool hard_constraint{};
+};
+
+// This provides the suffix for each test parameter: the test config
+// description.
+std::ostream& operator<<(std::ostream& out, const TestConfig& c) {
+  out << c.description;
+  return out;
+}
+
+// Fixture that sets a MultibodyPlant model of two bodies A and B with a
+// distance constraint connecting point P on body A and point Q on body B.
+class TwoBodiesTest : public ::testing::TestWithParam<TestConfig> {
+ public:
+  // Makes the model described in the fixture's documentation.
+  // @param[in] anchor_bodyA If true, body A will be anchored to the world.
+  // Otherwise body A has 6 DOFs as body B does.
+  // @param[in] use_hard_constraint_defaults If true, it uses the
+  // MultibodyPlant::AddDistanceConstraint() defaults for a hard constraint with
+  // no dissipation.
+  void MakeModel(bool anchor_bodyA, bool use_hard_constraint_defaults) {
+    plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+
+    // Arbitrary inertia values only used by the driver to build a valid contact
+    // problem.
+    const double mass = 1.5;
+    const double radius = 0.1;
+    const SpatialInertia<double> M_Bo =
+        SpatialInertia<double>::MakeFromCentralInertia(
+            mass, Vector3d::Zero(),
+            UnitInertia<double>::SolidSphere(radius) * mass);
+
+    bodyA_ = &plant_.AddRigidBody("A", M_Bo);
+    bodyB_ = &plant_.AddRigidBody("B", M_Bo);
+    if (anchor_bodyA) {
+      plant_.WeldFrames(plant_.world_frame(), bodyA_->body_frame());
+    }
+
+    if (use_hard_constraint_defaults) {
+      plant_.AddDistanceConstraint(*bodyA_, p_AP_, *bodyB_, p_BQ_, kDistance_);
+    } else {
+      plant_.AddDistanceConstraint(*bodyA_, p_AP_, *bodyB_, p_BQ_, kDistance_,
+                                   kStiffness_, kDissipation_);
+    }
+
+    plant_.Finalize();
+
+    auto owned_contact_manager =
+        std::make_unique<CompliantContactManager<double>>();
+    manager_ = owned_contact_manager.get();
+    plant_.SetDiscreteUpdateManager(std::move(owned_contact_manager));
+    // Model with a single distance constraint.
+    EXPECT_EQ(plant_.num_constraints(), 1);
+
+    context_ = plant_.CreateDefaultContext();
+  }
+
+  const SapDriver<double>& sap_driver() const {
+    return CompliantContactManagerTester::sap_driver(*manager_);
+  }
+
+ protected:
+  MultibodyPlant<double> plant_{0.01};  // Discrete model.
+  const RigidBody<double>* bodyA_{nullptr};
+  const RigidBody<double>* bodyB_{nullptr};
+  CompliantContactManager<double>* manager_{nullptr};
+  std::unique_ptr<Context<double>> context_;
+
+  // Parameters of the problem.
+  Vector3d p_AP_{0.1, 0.0, 0.0};
+  Vector3d p_BQ_{-0.05, 0.0, 0.0};
+  const double kStiffness_{3.0e4};
+  const double kDissipation_{1.5};
+  const double kDistance_{1.2};
+};
+
+// This test configures a single distance constraint in variety of ways (causing
+// differing numbers of cliques and varying constraint properties). It then
+// examines the newly added constraint to confirm that its instantiation
+// reflects the specification.
+TEST_P(TwoBodiesTest, ConfirmConstraintProperties) {
+    const TestConfig& config = GetParam();
+
+    MakeModel(config.bodyA_anchored, config.hard_constraint);
+
+    const int expected_num_velocities = config.bodyA_anchored ? 6 : 12;
+    EXPECT_EQ(plant_.num_velocities(), expected_num_velocities);
+
+    // Place Bo at known distance from Ao; this does *not* satisfy the
+    // constraint. We'll observe a non-zero value when evaluating the constraint
+    // function.
+    const double kDistanceAoBo = 2.0;
+    plant_.SetFreeBodyPoseInWorldFrame(
+        context_.get(), *bodyB_,
+        RigidTransformd(Vector3d(kDistanceAoBo, 0.0, 0.0)));
+
+    const ContactProblemCache<double>& problem_cache =
+        SapDriverTest::EvalContactProblemCache(sap_driver(), *context_);
+    const SapContactProblem<double>& problem = *problem_cache.sap_problem;
+
+    // Verify the expected number of constraints and equations for a single
+    // distance constraint.
+    EXPECT_EQ(problem.num_constraints(), 1);
+    EXPECT_EQ(problem.num_constraint_equations(), 1);
+
+    const auto* constraint =
+        dynamic_cast<const SapHolonomicConstraint<double>*>(
+            &problem.get_constraint(0));
+    // Verify it is a SapHolonomicConstraint as expected.
+    ASSERT_NE(constraint, nullptr);
+
+    // One clique if body A is anchored, two if not.
+    const int expected_num_cliques = config.bodyA_anchored ? 1 : 2;
+    EXPECT_EQ(constraint->num_cliques(), expected_num_cliques);
+    EXPECT_EQ(constraint->first_clique(), 0);
+    if (expected_num_cliques == 1) {
+      EXPECT_THROW(constraint->second_clique(), std::exception);
+    } else {
+      EXPECT_EQ(constraint->second_clique(), 1);
+    }
+
+    // Verify parameters.
+    const SapHolonomicConstraint<double>::Parameters p =
+        constraint->parameters();
+    EXPECT_EQ(p.num_constraint_equations(), 1);
+    // bi-lateral constraint with no impulse bounds.
+    EXPECT_EQ(p.impulse_lower_limits(), Vector1d(-kInfinity));
+    EXPECT_EQ(p.impulse_upper_limits(), Vector1d(kInfinity));
+    if (config.hard_constraint) {
+      EXPECT_EQ(p.stiffnesses(), Vector1d(kInfinity));
+      // For a finite dissipation, the dissipation time scale will be zero.
+      EXPECT_EQ(p.relaxation_times(), Vector1d(0.0));
+    } else {
+      EXPECT_EQ(p.stiffnesses(), Vector1d(kStiffness_));
+      EXPECT_EQ(p.relaxation_times(), Vector1d(kDissipation_ / kStiffness_));
+    }
+
+    // This value is hard-coded in the source. This test serves as a brake to
+    // prevent the value changing without notification. Changing this value
+    // would lead to a behavior change and shouldn't happen silently.
+    EXPECT_EQ(p.beta(), 0.1);
+
+    // The constraint function for a distance constraint is defined as:
+    //   g = |p_PQ| - kDistance.
+    // We verify its value.
+    const VectorXd& g = constraint->constraint_function();
+    const Vector1d g_expected(kDistanceAoBo - p_AP_.x() + p_BQ_.x() -
+                              kDistance_);
+    EXPECT_TRUE(CompareMatrices(g, g_expected));
+
+    // Verify the constraint Jacobians (based on number of cliques).
+    // We exploit internal knowledge of the fact that the state stores angular
+    // velocities first, followed by translational velocities (and the
+    // relative positions of the bodies).
+    if (expected_num_cliques == 1) {
+      const MatrixXd& J = constraint->first_clique_jacobian();
+      const MatrixXd J_expected =
+          (MatrixXd(1, 6) << 0, 0, 0, 1, 0, 0).finished();
+      EXPECT_TRUE(CompareMatrices(J, J_expected));
+    } else {
+      const MatrixXd& Ja = constraint->first_clique_jacobian();
+      const MatrixXd Ja_expected =
+          (MatrixXd(1, 6) << 0, 0, 0, -1, 0, 0).finished();
+      EXPECT_TRUE(CompareMatrices(Ja, Ja_expected));
+
+      const MatrixXd& Jb = constraint->second_clique_jacobian();
+      const MatrixXd Jb_expected =
+          (MatrixXd(1, 6) << 0, 0, 0, 1, 0, 0).finished();
+      EXPECT_TRUE(CompareMatrices(Jb, Jb_expected));
+    }
+  }
+
+std::vector<TestConfig> MakeTestCases() {
+  return std::vector<TestConfig>{
+      {.description = "SingleClique",
+       .bodyA_anchored = true,
+       .hard_constraint = false},
+      {.description = "TwoCliques",
+       .bodyA_anchored = false,
+       .hard_constraint = false},
+      {.description = "SingleCliqueWithDefaultValues",
+       .bodyA_anchored = true,
+       .hard_constraint = true},
+      {.description = "TwoCliquesWithDefaultValues",
+       .bodyA_anchored = false,
+       .hard_constraint = true},
+  };
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SapDistanceConstraintTests, TwoBodiesTest,
+    testing::ValuesIn(MakeTestCases()),
+    testing::PrintToStringParamName());
+
+// TODO(amcastro-tri): implement unit tests verifying:
+//  - unreasonably small distance between the points
+//  - attempt to use distance constraint with continuous system or TAMSI
+//  - illegal values for distance, stiffness, or damping
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Implements support for distance constraints when using the SAP solver.
With this PR the user can set a distance constraint with the call to `MultibodyPlant::AddDistanceConstraint()`.

cc'ing @mposa 


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18196)
<!-- Reviewable:end -->
