### PR TITLE
Provide Python module information in drake-config.cmake

### DIFF
--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -3,6 +3,11 @@
 package(default_visibility = ["//visibility:private"])
 
 load(
+    "@python//:version.bzl",
+    "PYTHON_SITE_PACKAGES_RELPATH",
+    "PYTHON_VERSION",
+)
+load(
     "@drake//tools/install:install.bzl",
     "install",
     "install_cmake_config",
@@ -24,6 +29,17 @@ load(":build_components.bzl", "LIBDRAKE_COMPONENTS")
 load(
     "//third_party:com_github_bazelbuild_rules_cc/whole_archive.bzl",
     "cc_whole_archive_library",
+)
+
+genrule(
+    name = "drake_config_cmake_expand",
+    srcs = ["drake-config.cmake.in"],
+    outs = ["drake-config.cmake"],
+    cmd = "sed '" +
+          "s!@PYTHON_SITE_PACKAGES_RELPATH@!" +
+          PYTHON_SITE_PACKAGES_RELPATH + "!g;" +
+          "s!@PYTHON_VERSION@!" + PYTHON_VERSION + "!g;" +
+          "' $< > $@",
 )
 
 install_cmake_config(
@@ -97,6 +113,7 @@ cc_library(
 install(
     name = "install",
     install_tests = [
+        "test/drake_python_dir_install_test.py",
         "test/find_package_drake_install_test.py",
         "test/snopt_visibility_install_test.py",
         "test/rpath_install_test.py",
@@ -281,5 +298,8 @@ drake_py_unittest(
 )
 
 add_lint_tests(
-    python_lint_extra_srcs = ["build_components_refresh.py"],
+    python_lint_extra_srcs = [
+        "build_components_refresh.py",
+        "test/drake_python_dir_install_test.py",
+    ],
 )

--- a/tools/install/libdrake/drake-config.cmake.in
+++ b/tools/install/libdrake/drake-config.cmake.in
@@ -91,6 +91,9 @@ unset(_apple_soname_prologue)
 set(drake_LIBRARIES "drake::drake")
 set(drake_INCLUDE_DIRS "")
 
+set(drake_PYTHON_DIR "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/@PYTHON_SITE_PACKAGES_RELPATH@")
+# Allow users to easily check Drake's expected CPython version.
+set(drake_PYTHON_VERSION "@PYTHON_VERSION@")
 
 unset(${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX)
 unset(CMAKE_IMPORT_FILE_VERSION)

--- a/tools/install/libdrake/test/drake_python_dir_install_test.py
+++ b/tools/install/libdrake/test/drake_python_dir_install_test.py
@@ -1,0 +1,70 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+
+import install_test_helper
+
+
+class DrakePythonDirInstallTest(unittest.TestCase):
+    def test_drake_python_dir(self):
+        cmake_source_dir = install_test_helper.create_temporary_dir(
+            "pydir_src")
+
+        cmake_prefix_path = install_test_helper.get_install_dir()
+
+        cmake_content = """
+            cmake_minimum_required(VERSION 3.10)
+            project(drake_python_dir_install_test)
+            set(CMAKE_PREFIX_PATH {cmake_prefix_path})
+            find_package(drake CONFIG REQUIRED)
+
+            # PYTHON_VERSION check
+            if(NOT "{py_major}.{py_minor}" EQUAL ${{drake_PYTHON_VERSION}})
+              message(FATAL_ERROR "Python version does not match")
+            else()
+              message(
+                STATUS "Found expected Drake Python "
+                "version: ${{drake_PYTHON_VERSION}}")
+            endif()
+
+            # PYTHON_DIR Sanity check
+            execute_process(
+              COMMAND ${{CMAKE_COMMAND}} -E env PYTHONPATH=""
+                {python_exe} -c "import pydrake.all"
+              ERROR_QUIET
+              RESULT_VARIABLE _IMPORT_RESULT)
+            if(0 EQUAL _IMPORT_RESULT)
+              message(FATAL_ERROR "Import of pydrake should have failed")
+            endif()
+
+            # PYTHON_DIR Actual test
+            execute_process(
+              COMMAND ${{CMAKE_COMMAND}} -E env
+                PYTHONPATH=${{drake_PYTHON_DIR}}
+                {python_exe} -c "import pydrake.all"
+              RESULT_VARIABLE _IMPORT_RESULT)
+            if(NOT 0 EQUAL _IMPORT_RESULT)
+              message(FATAL_ERROR "Import of pydrake failed")
+            else()
+              message(STATUS "Import of pydrake works as expected")
+            endif()
+        """.format(
+            cmake_prefix_path=cmake_prefix_path, python_exe=sys.executable,
+            py_major=sys.version_info.major, py_minor=sys.version_info.minor)
+
+        cmake_filename = os.path.join(cmake_source_dir, "CMakeLists.txt")
+
+        with open(cmake_filename, "w") as f:
+            f.write(textwrap.dedent(cmake_content))
+
+        cmake_binary_dir = install_test_helper.create_temporary_dir(
+            "pydir_build")
+
+        subprocess.check_call(["cmake", cmake_source_dir],
+                              cwd=cmake_binary_dir)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This will provide a reliable way for downstream CMake projects to get information about the Python modules installed as part of Drake.

Resolves #18150

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18201)
<!-- Reviewable:end -->
