### PR TITLE
[geometry] Define alphabetical order to Shapes by convention

### DIFF
--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -383,10 +383,37 @@ class ShapeToLcm : public ShapeReifier {
 
   using ShapeReifier::ImplementGeometry;
 
-  void ImplementGeometry(const Sphere& sphere, void*) override {
-    geometry_data_.type = geometry_data_.SPHERE;
-    geometry_data_.num_float_data = 1;
-    geometry_data_.float_data.push_back(static_cast<float>(sphere.radius()));
+  void ImplementGeometry(const Box& box, void*) override {
+    geometry_data_.type = geometry_data_.BOX;
+    geometry_data_.num_float_data = 3;
+    // Box width, depth, and height.
+    geometry_data_.float_data.push_back(static_cast<float>(box.width()));
+    geometry_data_.float_data.push_back(static_cast<float>(box.depth()));
+    geometry_data_.float_data.push_back(static_cast<float>(box.height()));
+  }
+
+  void ImplementGeometry(const Capsule& capsule, void*) override {
+    geometry_data_.type = geometry_data_.CAPSULE;
+    geometry_data_.num_float_data = 2;
+    geometry_data_.float_data.push_back(static_cast<float>(capsule.radius()));
+    geometry_data_.float_data.push_back(static_cast<float>(capsule.length()));
+  }
+
+  // For visualization, Convex is the same as Mesh.
+  void ImplementGeometry(const Convex& mesh, void*) override {
+    geometry_data_.type = geometry_data_.MESH;
+    geometry_data_.num_float_data = 3;
+    geometry_data_.float_data.push_back(static_cast<float>(mesh.scale()));
+    geometry_data_.float_data.push_back(static_cast<float>(mesh.scale()));
+    geometry_data_.float_data.push_back(static_cast<float>(mesh.scale()));
+    geometry_data_.string_data = mesh.filename();
+  }
+
+  void ImplementGeometry(const Cylinder& cylinder, void*) override {
+    geometry_data_.type = geometry_data_.CYLINDER;
+    geometry_data_.num_float_data = 2;
+    geometry_data_.float_data.push_back(static_cast<float>(cylinder.radius()));
+    geometry_data_.float_data.push_back(static_cast<float>(cylinder.length()));
   }
 
   void ImplementGeometry(const Ellipsoid& ellipsoid, void*) override {
@@ -395,13 +422,6 @@ class ShapeToLcm : public ShapeReifier {
     geometry_data_.float_data.push_back(static_cast<float>(ellipsoid.a()));
     geometry_data_.float_data.push_back(static_cast<float>(ellipsoid.b()));
     geometry_data_.float_data.push_back(static_cast<float>(ellipsoid.c()));
-  }
-
-  void ImplementGeometry(const Cylinder& cylinder, void*) override {
-    geometry_data_.type = geometry_data_.CYLINDER;
-    geometry_data_.num_float_data = 2;
-    geometry_data_.float_data.push_back(static_cast<float>(cylinder.radius()));
-    geometry_data_.float_data.push_back(static_cast<float>(cylinder.length()));
   }
 
   void ImplementGeometry(const HalfSpace&, void*) override {
@@ -423,22 +443,6 @@ class ShapeToLcm : public ShapeReifier {
     X_PG_ = X_PG_ * box_xform;
   }
 
-  void ImplementGeometry(const Box& box, void*) override {
-    geometry_data_.type = geometry_data_.BOX;
-    geometry_data_.num_float_data = 3;
-    // Box width, depth, and height.
-    geometry_data_.float_data.push_back(static_cast<float>(box.width()));
-    geometry_data_.float_data.push_back(static_cast<float>(box.depth()));
-    geometry_data_.float_data.push_back(static_cast<float>(box.height()));
-  }
-
-  void ImplementGeometry(const Capsule& capsule, void*) override {
-    geometry_data_.type = geometry_data_.CAPSULE;
-    geometry_data_.num_float_data = 2;
-    geometry_data_.float_data.push_back(static_cast<float>(capsule.radius()));
-    geometry_data_.float_data.push_back(static_cast<float>(capsule.length()));
-  }
-
   void ImplementGeometry(const Mesh& mesh, void*) override {
     geometry_data_.type = geometry_data_.MESH;
     geometry_data_.num_float_data = 3;
@@ -448,14 +452,10 @@ class ShapeToLcm : public ShapeReifier {
     geometry_data_.string_data = mesh.filename();
   }
 
-  // For visualization, Convex is the same as Mesh.
-  void ImplementGeometry(const Convex& mesh, void*) override {
-    geometry_data_.type = geometry_data_.MESH;
-    geometry_data_.num_float_data = 3;
-    geometry_data_.float_data.push_back(static_cast<float>(mesh.scale()));
-    geometry_data_.float_data.push_back(static_cast<float>(mesh.scale()));
-    geometry_data_.float_data.push_back(static_cast<float>(mesh.scale()));
-    geometry_data_.string_data = mesh.filename();
+  void ImplementGeometry(const Sphere& sphere, void*) override {
+    geometry_data_.type = geometry_data_.SPHERE;
+    geometry_data_.num_float_data = 1;
+    geometry_data_.float_data.push_back(static_cast<float>(sphere.radius()));
   }
 
  private:

--- a/geometry/make_mesh_for_deformable.cc
+++ b/geometry/make_mesh_for_deformable.cc
@@ -18,6 +18,14 @@ std::unique_ptr<VolumeMesh<double>> MeshBuilderForDeformable::Build(
   return std::move(data.mesh);
 }
 
+void MeshBuilderForDeformable::ImplementGeometry(const Mesh& mesh_spec,
+                                                 void* user_data) {
+  DRAKE_DEMAND(user_data != nullptr);
+  ReifyData& data = *static_cast<ReifyData*>(user_data);
+  data.mesh = std::make_unique<VolumeMesh<double>>(
+      MakeVolumeMeshFromVtk<double>(mesh_spec));
+}
+
 void MeshBuilderForDeformable::ImplementGeometry(const Sphere& sphere,
                                                  void* user_data) {
   DRAKE_DEMAND(user_data != nullptr);
@@ -27,14 +35,6 @@ void MeshBuilderForDeformable::ImplementGeometry(const Sphere& sphere,
   data.mesh = std::make_unique<VolumeMesh<double>>(MakeSphereVolumeMesh<double>(
       sphere, data.resolution_hint,
       TessellationStrategy::kDenseInteriorVertices));
-}
-
-void MeshBuilderForDeformable::ImplementGeometry(const Mesh& mesh_spec,
-                                                 void* user_data) {
-  DRAKE_DEMAND(user_data != nullptr);
-  ReifyData& data = *static_cast<ReifyData*>(user_data);
-  data.mesh = std::make_unique<VolumeMesh<double>>(
-      MakeVolumeMeshFromVtk<double>(mesh_spec));
 }
 
 void MeshBuilderForDeformable::ThrowUnsupportedGeometry(

--- a/geometry/make_mesh_for_deformable.h
+++ b/geometry/make_mesh_for_deformable.h
@@ -31,8 +31,8 @@ class MeshBuilderForDeformable : public ShapeReifier {
   };
 
   using ShapeReifier::ImplementGeometry;
-  void ImplementGeometry(const Sphere& sphere, void* user_data) override;
   void ImplementGeometry(const Mesh& mesh_spec, void* user_data) override;
+  void ImplementGeometry(const Sphere& sphere, void* user_data) override;
   // TODO(xuchenhan-tri): As other shapes get supported, include their specific
   //  overrides here.
 

--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -528,13 +528,6 @@ HPolyhedron::DoToShapeWithPose() const {
       "class (to support in-memory mesh data, or file I/O).");
 }
 
-void HPolyhedron::ImplementGeometry(const HalfSpace&, void* data) {
-  auto* Ab = static_cast<std::pair<MatrixXd, VectorXd>*>(data);
-  // z <= 0.0.
-  Ab->first = Eigen::RowVector3d{0.0, 0.0, 1.0};
-  Ab->second = Vector1d{0.0};
-}
-
 void HPolyhedron::ImplementGeometry(const Box& box, void* data) {
   Eigen::Matrix<double, 6, 3> A;
   A << Eigen::Matrix3d::Identity(), -Eigen::Matrix3d::Identity();
@@ -546,6 +539,13 @@ void HPolyhedron::ImplementGeometry(const Box& box, void* data) {
   auto* Ab = static_cast<std::pair<MatrixXd, VectorXd>*>(data);
   Ab->first = A;
   Ab->second = b;
+}
+
+void HPolyhedron::ImplementGeometry(const HalfSpace&, void* data) {
+  auto* Ab = static_cast<std::pair<MatrixXd, VectorXd>*>(data);
+  // z <= 0.0.
+  Ab->first = Eigen::RowVector3d{0.0, 0.0, 1.0};
+  Ab->second = Vector1d{0.0};
 }
 
 HPolyhedron HPolyhedron::PontryaginDifference(const HPolyhedron& other) const {

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -233,8 +233,8 @@ class HPolyhedron final : public ConvexSet {
 
   // Implement support shapes for the ShapeReifier interface.
   using ShapeReifier::ImplementGeometry;
-  void ImplementGeometry(const HalfSpace&, void* data) final;
   void ImplementGeometry(const Box& box, void* data) final;
+  void ImplementGeometry(const HalfSpace&, void* data) final;
   // TODO(russt): Support ImplementGeometry(const Convex& convex, ...), but
   // currently it would require e.g. digging ReadObjForConvex out of
   // proximity_engine.cc.

--- a/geometry/optimization/hyperellipsoid.cc
+++ b/geometry/optimization/hyperellipsoid.cc
@@ -267,17 +267,17 @@ Hyperellipsoid::DoToShapeWithPose() const {
   return std::make_pair(std::move(shape), X_WG);
 }
 
-void Hyperellipsoid::ImplementGeometry(const Sphere& sphere, void* data) {
-  auto* A = static_cast<Eigen::Matrix3d*>(data);
-  *A = Eigen::Matrix3d::Identity() / sphere.radius();
-}
-
 void Hyperellipsoid::ImplementGeometry(const Ellipsoid& ellipsoid, void* data) {
   // x²/a² + y²/b² + z²/c² = 1 in quadratic form is
   // xᵀ * diag(1/a^2, 1/b^2, 1/c^2) * x = 1 and A is the square root.
   auto* A = static_cast<Eigen::Matrix3d*>(data);
   *A = Eigen::DiagonalMatrix<double, 3>(
       1.0 / ellipsoid.a(), 1.0 / ellipsoid.b(), 1.0 / ellipsoid.c());
+}
+
+void Hyperellipsoid::ImplementGeometry(const Sphere& sphere, void* data) {
+  auto* A = static_cast<Eigen::Matrix3d*>(data);
+  *A = Eigen::Matrix3d::Identity() / sphere.radius();
 }
 
 }  // namespace optimization

--- a/geometry/optimization/hyperellipsoid.h
+++ b/geometry/optimization/hyperellipsoid.h
@@ -126,8 +126,8 @@ class Hyperellipsoid final : public ConvexSet {
 
   // Implement support shapes for the ShapeReifier interface.
   using ShapeReifier::ImplementGeometry;
-  void ImplementGeometry(const Sphere& sphere, void* data) final;
   void ImplementGeometry(const Ellipsoid& ellipsoid, void* data) final;
+  void ImplementGeometry(const Sphere& sphere, void* data) final;
 
   Eigen::MatrixXd A_{};
   Eigen::VectorXd center_{};

--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -141,25 +141,6 @@ class IrisConvexSetMaker final : public ShapeReifier {
 
   using ShapeReifier::ImplementGeometry;
 
-  void ImplementGeometry(const Sphere&, void* data) {
-    DRAKE_DEMAND(geom_id_.is_valid());
-    auto& set = *static_cast<copyable_unique_ptr<ConvexSet>*>(data);
-    set = std::make_unique<Hyperellipsoid>(query_, geom_id_, reference_frame_);
-  }
-
-  void ImplementGeometry(const Cylinder&, void* data) {
-    DRAKE_DEMAND(geom_id_.is_valid());
-    auto& set = *static_cast<copyable_unique_ptr<ConvexSet>*>(data);
-    set =
-        std::make_unique<CartesianProduct>(query_, geom_id_, reference_frame_);
-  }
-
-  void ImplementGeometry(const HalfSpace&, void* data) {
-    DRAKE_DEMAND(geom_id_.is_valid());
-    auto& set = *static_cast<copyable_unique_ptr<ConvexSet>*>(data);
-    set = std::make_unique<HPolyhedron>(query_, geom_id_, reference_frame_);
-  }
-
   void ImplementGeometry(const Box&, void* data) {
     DRAKE_DEMAND(geom_id_.is_valid());
     auto& set = *static_cast<copyable_unique_ptr<ConvexSet>*>(data);
@@ -176,7 +157,26 @@ class IrisConvexSetMaker final : public ShapeReifier {
     set = std::make_unique<MinkowskiSum>(query_, geom_id_, reference_frame_);
   }
 
+  void ImplementGeometry(const Cylinder&, void* data) {
+    DRAKE_DEMAND(geom_id_.is_valid());
+    auto& set = *static_cast<copyable_unique_ptr<ConvexSet>*>(data);
+    set =
+        std::make_unique<CartesianProduct>(query_, geom_id_, reference_frame_);
+  }
+
   void ImplementGeometry(const Ellipsoid&, void* data) {
+    DRAKE_DEMAND(geom_id_.is_valid());
+    auto& set = *static_cast<copyable_unique_ptr<ConvexSet>*>(data);
+    set = std::make_unique<Hyperellipsoid>(query_, geom_id_, reference_frame_);
+  }
+
+  void ImplementGeometry(const HalfSpace&, void* data) {
+    DRAKE_DEMAND(geom_id_.is_valid());
+    auto& set = *static_cast<copyable_unique_ptr<ConvexSet>*>(data);
+    set = std::make_unique<HPolyhedron>(query_, geom_id_, reference_frame_);
+  }
+
+  void ImplementGeometry(const Sphere&, void* data) {
     DRAKE_DEMAND(geom_id_.is_valid());
     auto& set = *static_cast<copyable_unique_ptr<ConvexSet>*>(data);
     set = std::make_unique<Hyperellipsoid>(query_, geom_id_, reference_frame_);

--- a/geometry/proximity/deformable_contact_internal.cc
+++ b/geometry/proximity/deformable_contact_internal.cc
@@ -73,14 +73,6 @@ DeformableContact<double> Geometries::ComputeDeformableContact() const {
   return result;
 }
 
-void Geometries::ImplementGeometry(const Sphere& sphere, void* user_data) {
-  AddRigidGeometry(sphere, *static_cast<ReifyData*>(user_data));
-}
-
-void Geometries::ImplementGeometry(const Cylinder& cylinder, void* user_data) {
-  AddRigidGeometry(cylinder, *static_cast<ReifyData*>(user_data));
-}
-
 void Geometries::ImplementGeometry(const Box& box, void* user_data) {
   AddRigidGeometry(box, *static_cast<ReifyData*>(user_data));
 }
@@ -89,17 +81,17 @@ void Geometries::ImplementGeometry(const Capsule& capsule, void* user_data) {
   AddRigidGeometry(capsule, *static_cast<ReifyData*>(user_data));
 }
 
+void Geometries::ImplementGeometry(const Convex& convex, void* user_data) {
+  AddRigidGeometry(convex, *static_cast<ReifyData*>(user_data));
+}
+
+void Geometries::ImplementGeometry(const Cylinder& cylinder, void* user_data) {
+  AddRigidGeometry(cylinder, *static_cast<ReifyData*>(user_data));
+}
+
 void Geometries::ImplementGeometry(const Ellipsoid& ellipsoid,
                                    void* user_data) {
   AddRigidGeometry(ellipsoid, *static_cast<ReifyData*>(user_data));
-}
-
-void Geometries::ImplementGeometry(const Mesh& mesh, void* user_data) {
-  AddRigidGeometry(mesh, *static_cast<ReifyData*>(user_data));
-}
-
-void Geometries::ImplementGeometry(const Convex& convex, void* user_data) {
-  AddRigidGeometry(convex, *static_cast<ReifyData*>(user_data));
 }
 
 void Geometries::ImplementGeometry(const HalfSpace&, void*) {
@@ -109,11 +101,19 @@ void Geometries::ImplementGeometry(const HalfSpace&, void*) {
       "be reported.");
 }
 
+void Geometries::ImplementGeometry(const Mesh& mesh, void* user_data) {
+  AddRigidGeometry(mesh, *static_cast<ReifyData*>(user_data));
+}
+
 void Geometries::ImplementGeometry(const MeshcatCone&, void*) {
   static const logging::Warn log_once(
       "Rigid (non-deformable) Meshcat cones are not currently supported for "
       "deformable contact; registration is allowed, but no contact data will "
       "be reported.");
+}
+
+void Geometries::ImplementGeometry(const Sphere& sphere, void* user_data) {
+  AddRigidGeometry(sphere, *static_cast<ReifyData*>(user_data));
 }
 
 template <typename ShapeType>

--- a/geometry/proximity/deformable_contact_internal.h
+++ b/geometry/proximity/deformable_contact_internal.h
@@ -115,15 +115,15 @@ class Geometries final : public ShapeReifier {
     const ProximityProperties& properties;
   };
 
-  void ImplementGeometry(const Sphere& sphere, void* user_data) override;
-  void ImplementGeometry(const Cylinder& cylinder, void* user_data) override;
   void ImplementGeometry(const Box& box, void* user_data) override;
   void ImplementGeometry(const Capsule& capsule, void* user_data) override;
-  void ImplementGeometry(const Ellipsoid& ellipsoid, void* user_data) override;
-  void ImplementGeometry(const Mesh& mesh, void* user_data) override;
   void ImplementGeometry(const Convex& convex, void* user_data) override;
+  void ImplementGeometry(const Cylinder& cylinder, void* user_data) override;
+  void ImplementGeometry(const Ellipsoid& ellipsoid, void* user_data) override;
   void ImplementGeometry(const HalfSpace& half_space, void* user_data) override;
+  void ImplementGeometry(const Mesh& mesh, void* user_data) override;
   void ImplementGeometry(const MeshcatCone& cone, void* user_data) override;
+  void ImplementGeometry(const Sphere& sphere, void* user_data) override;
 
   /* Makes a rigid (non-deformable) geometry from a supported shape type using
    the given `data`. */

--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -66,19 +66,6 @@ void Geometries::MaybeAddGeometry(const Shape& shape, GeometryId id,
   }
 }
 
-void Geometries::ImplementGeometry(const Sphere& sphere, void* user_data) {
-  MakeShape(sphere, *static_cast<ReifyData*>(user_data));
-}
-
-void Geometries::ImplementGeometry(const Cylinder& cylinder, void* user_data) {
-  MakeShape(cylinder, *static_cast<ReifyData*>(user_data));
-}
-
-void Geometries::ImplementGeometry(const HalfSpace& half_space,
-                                   void* user_data) {
-  MakeShape(half_space, *static_cast<ReifyData*>(user_data));
-}
-
 void Geometries::ImplementGeometry(const Box& box, void* user_data) {
   MakeShape(box, *static_cast<ReifyData*>(user_data));
 }
@@ -87,17 +74,30 @@ void Geometries::ImplementGeometry(const Capsule& capsule, void* user_data) {
   MakeShape(capsule, *static_cast<ReifyData*>(user_data));
 }
 
+void Geometries::ImplementGeometry(const Convex& convex, void* user_data) {
+  MakeShape(convex, *static_cast<ReifyData*>(user_data));
+}
+
+void Geometries::ImplementGeometry(const Cylinder& cylinder, void* user_data) {
+  MakeShape(cylinder, *static_cast<ReifyData*>(user_data));
+}
+
 void Geometries::ImplementGeometry(const Ellipsoid& ellipsoid,
                                    void* user_data) {
   MakeShape(ellipsoid, *static_cast<ReifyData*>(user_data));
+}
+
+void Geometries::ImplementGeometry(const HalfSpace& half_space,
+                                   void* user_data) {
+  MakeShape(half_space, *static_cast<ReifyData*>(user_data));
 }
 
 void Geometries::ImplementGeometry(const Mesh& mesh, void* user_data) {
   MakeShape(mesh, *static_cast<ReifyData*>(user_data));
 }
 
-void Geometries::ImplementGeometry(const Convex& convex, void* user_data) {
-  MakeShape(convex, *static_cast<ReifyData*>(user_data));
+void Geometries::ImplementGeometry(const Sphere& sphere, void* user_data) {
+  MakeShape(sphere, *static_cast<ReifyData*>(user_data));
 }
 
 template <typename ShapeType>

--- a/geometry/proximity/hydroelastic_internal.h
+++ b/geometry/proximity/hydroelastic_internal.h
@@ -335,14 +335,14 @@ class Geometries final : public ShapeReifier {
 
   using ShapeReifier::ImplementGeometry;
 
-  void ImplementGeometry(const Sphere& sphere, void* user_data) override;
-  void ImplementGeometry(const Cylinder& cylinder, void* user_data) override;
-  void ImplementGeometry(const HalfSpace&, void* user_data) override;
   void ImplementGeometry(const Box& box, void* user_data) override;
   void ImplementGeometry(const Capsule& capsule, void* user_data) override;
-  void ImplementGeometry(const Ellipsoid& ellipsoid, void* user_data) override;
-  void ImplementGeometry(const Mesh&, void*) override;
   void ImplementGeometry(const Convex& convex, void* user_data) override;
+  void ImplementGeometry(const Cylinder& cylinder, void* user_data) override;
+  void ImplementGeometry(const Ellipsoid& ellipsoid, void* user_data) override;
+  void ImplementGeometry(const HalfSpace&, void* user_data) override;
+  void ImplementGeometry(const Mesh&, void*) override;
+  void ImplementGeometry(const Sphere& sphere, void* user_data) override;
 
   template <typename ShapeType>
   void MakeShape(const ShapeType& shape, const ReifyData& data);

--- a/geometry/render_gl/internal_render_engine_gl.cc
+++ b/geometry/render_gl/internal_render_engine_gl.cc
@@ -501,25 +501,6 @@ void RenderEngineGl::UpdateViewpoint(const RigidTransformd& X_WR) {
   X_CW_ = X_WR.inverse();
 }
 
-void RenderEngineGl::ImplementGeometry(const Sphere& sphere, void* user_data) {
-  OpenGlGeometry geometry = GetSphere();
-  const double r = sphere.radius();
-  ImplementGeometry(geometry, user_data, Vector3d(r, r, r));
-}
-
-void RenderEngineGl::ImplementGeometry(const Cylinder& cylinder,
-                                       void* user_data) {
-  OpenGlGeometry geometry = GetCylinder();
-  const double r = cylinder.radius();
-  const double l = cylinder.length();
-  ImplementGeometry(geometry, user_data, Vector3d(r, r, l));
-}
-
-void RenderEngineGl::ImplementGeometry(const HalfSpace&, void* user_data) {
-  OpenGlGeometry geometry = GetHalfSpace();
-  ImplementGeometry(geometry, user_data, Vector3d(1, 1, 1));
-}
-
 void RenderEngineGl::ImplementGeometry(const Box& box, void* user_data) {
   OpenGlGeometry geometry = GetBox();
   ImplementGeometry(geometry, user_data,
@@ -538,11 +519,30 @@ void RenderEngineGl::ImplementGeometry(const Capsule& capsule,
   ImplementGeometry(geometry, user_data, Vector3d::Ones());
 }
 
+void RenderEngineGl::ImplementGeometry(const Convex& convex, void* user_data) {
+  OpenGlGeometry geometry = GetMesh(convex.filename());
+  ImplementMesh(geometry, user_data, Vector3d(1, 1, 1) * convex.scale(),
+                convex.filename());
+}
+
+void RenderEngineGl::ImplementGeometry(const Cylinder& cylinder,
+                                       void* user_data) {
+  OpenGlGeometry geometry = GetCylinder();
+  const double r = cylinder.radius();
+  const double l = cylinder.length();
+  ImplementGeometry(geometry, user_data, Vector3d(r, r, l));
+}
+
 void RenderEngineGl::ImplementGeometry(const Ellipsoid& ellipsoid,
                                        void* user_data) {
   OpenGlGeometry geometry = GetSphere();
   ImplementGeometry(geometry, user_data,
                     Vector3d(ellipsoid.a(), ellipsoid.b(), ellipsoid.c()));
+}
+
+void RenderEngineGl::ImplementGeometry(const HalfSpace&, void* user_data) {
+  OpenGlGeometry geometry = GetHalfSpace();
+  ImplementGeometry(geometry, user_data, Vector3d(1, 1, 1));
 }
 
 void RenderEngineGl::ImplementGeometry(const Mesh& mesh, void* user_data) {
@@ -551,10 +551,10 @@ void RenderEngineGl::ImplementGeometry(const Mesh& mesh, void* user_data) {
                 mesh.filename());
 }
 
-void RenderEngineGl::ImplementGeometry(const Convex& convex, void* user_data) {
-  OpenGlGeometry geometry = GetMesh(convex.filename());
-  ImplementMesh(geometry, user_data, Vector3d(1, 1, 1) * convex.scale(),
-                convex.filename());
+void RenderEngineGl::ImplementGeometry(const Sphere& sphere, void* user_data) {
+  OpenGlGeometry geometry = GetSphere();
+  const double r = sphere.radius();
+  ImplementGeometry(geometry, user_data, Vector3d(r, r, r));
 }
 
 void RenderEngineGl::ImplementMesh(const OpenGlGeometry& geometry,

--- a/geometry/render_gl/internal_render_engine_gl.h
+++ b/geometry/render_gl/internal_render_engine_gl.h
@@ -54,14 +54,14 @@ class RenderEngineGl final : public RenderEngine {
   /** @name    Shape reification  */
   //@{
   using RenderEngine::ImplementGeometry;
-  void ImplementGeometry(const Sphere& sphere, void* user_data) final;
-  void ImplementGeometry(const Cylinder& cylinder, void* user_data) final;
-  void ImplementGeometry(const HalfSpace& half_space, void* user_data) final;
   void ImplementGeometry(const Box& box, void* user_data) final;
   void ImplementGeometry(const Capsule& capsule, void* user_data) final;
-  void ImplementGeometry(const Ellipsoid& ellipsoid, void* user_data) final;
-  void ImplementGeometry(const Mesh& mesh, void* user_data) final;
   void ImplementGeometry(const Convex& convex, void* user_data) final;
+  void ImplementGeometry(const Cylinder& cylinder, void* user_data) final;
+  void ImplementGeometry(const Ellipsoid& ellipsoid, void* user_data) final;
+  void ImplementGeometry(const HalfSpace& half_space, void* user_data) final;
+  void ImplementGeometry(const Mesh& mesh, void* user_data) final;
+  void ImplementGeometry(const Sphere& sphere, void* user_data) final;
   //@}
 
  private:

--- a/geometry/render_vtk/internal_render_engine_vtk.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk.cc
@@ -132,10 +132,19 @@ void RenderEngineVtk::UpdateViewpoint(const RigidTransformd& X_WC) {
   }
 }
 
-void RenderEngineVtk::ImplementGeometry(const Sphere& sphere, void* user_data) {
-  vtkNew<vtkTexturedSphereSource> vtk_sphere;
-  SetSphereOptions(vtk_sphere.GetPointer(), sphere.radius());
-  ImplementGeometry(vtk_sphere.GetPointer(), user_data);
+void RenderEngineVtk::ImplementGeometry(const Box& box, void* user_data) {
+  const RegistrationData* data = static_cast<RegistrationData*>(user_data);
+  ImplementGeometry(CreateVtkBox(box, data->properties).GetPointer(),
+                    user_data);
+}
+
+void RenderEngineVtk::ImplementGeometry(const Capsule& capsule,
+                                        void* user_data) {
+  ImplementGeometry(CreateVtkCapsule(capsule).GetPointer(), user_data);
+}
+
+void RenderEngineVtk::ImplementGeometry(const Convex& convex, void* user_data) {
+  ImplementObj(convex.filename(), convex.scale(), user_data);
 }
 
 void RenderEngineVtk::ImplementGeometry(const Cylinder& cylinder,
@@ -152,6 +161,11 @@ void RenderEngineVtk::ImplementGeometry(const Cylinder& cylinder,
   ImplementGeometry(transform_filter.GetPointer(), user_data);
 }
 
+void RenderEngineVtk::ImplementGeometry(const Ellipsoid& ellipsoid,
+                                        void* user_data) {
+  ImplementGeometry(CreateVtkEllipsoid(ellipsoid).GetPointer(), user_data);
+}
+
 void RenderEngineVtk::ImplementGeometry(const HalfSpace&,
                                         void* user_data) {
   vtkSmartPointer<vtkPlaneSource> vtk_plane = CreateSquarePlane(kTerrainSize);
@@ -159,28 +173,14 @@ void RenderEngineVtk::ImplementGeometry(const HalfSpace&,
   ImplementGeometry(vtk_plane.GetPointer(), user_data);
 }
 
-void RenderEngineVtk::ImplementGeometry(const Box& box, void* user_data) {
-  const RegistrationData* data = static_cast<RegistrationData*>(user_data);
-  ImplementGeometry(CreateVtkBox(box, data->properties).GetPointer(),
-                    user_data);
-}
-
-void RenderEngineVtk::ImplementGeometry(const Capsule& capsule,
-                                        void* user_data) {
-  ImplementGeometry(CreateVtkCapsule(capsule).GetPointer(), user_data);
-}
-
-void RenderEngineVtk::ImplementGeometry(const Ellipsoid& ellipsoid,
-                                        void* user_data) {
-  ImplementGeometry(CreateVtkEllipsoid(ellipsoid).GetPointer(), user_data);
-}
-
 void RenderEngineVtk::ImplementGeometry(const Mesh& mesh, void* user_data) {
   ImplementObj(mesh.filename(), mesh.scale(), user_data);
 }
 
-void RenderEngineVtk::ImplementGeometry(const Convex& convex, void* user_data) {
-  ImplementObj(convex.filename(), convex.scale(), user_data);
+void RenderEngineVtk::ImplementGeometry(const Sphere& sphere, void* user_data) {
+  vtkNew<vtkTexturedSphereSource> vtk_sphere;
+  SetSphereOptions(vtk_sphere.GetPointer(), sphere.radius());
+  ImplementGeometry(vtk_sphere.GetPointer(), user_data);
 }
 
 bool RenderEngineVtk::DoRegisterVisual(

--- a/geometry/render_vtk/internal_render_engine_vtk.h
+++ b/geometry/render_vtk/internal_render_engine_vtk.h
@@ -118,14 +118,14 @@ class RenderEngineVtk : public RenderEngine,
   /** @name    Shape reification  */
   //@{
   using RenderEngine::ImplementGeometry;
-  void ImplementGeometry(const Sphere& sphere, void* user_data) override;
-  void ImplementGeometry(const Cylinder& cylinder, void* user_data) override;
-  void ImplementGeometry(const HalfSpace& half_space, void* user_data) override;
   void ImplementGeometry(const Box& box, void* user_data) override;
   void ImplementGeometry(const Capsule& capsule, void* user_data) override;
-  void ImplementGeometry(const Ellipsoid& ellipsoid, void* user_data) override;
-  void ImplementGeometry(const Mesh& mesh, void* user_data) override;
   void ImplementGeometry(const Convex& convex, void* user_data) override;
+  void ImplementGeometry(const Cylinder& cylinder, void* user_data) override;
+  void ImplementGeometry(const Ellipsoid& ellipsoid, void* user_data) override;
+  void ImplementGeometry(const HalfSpace& half_space, void* user_data) override;
+  void ImplementGeometry(const Mesh& mesh, void* user_data) override;
+  void ImplementGeometry(const Sphere& sphere, void* user_data) override;
   //@}
 
   /** @name    Access the default properties

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -36,11 +36,41 @@ Shape::Shape(ShapeTag<S>) {
   };
 }
 
-Sphere::Sphere(double radius)
-    : Shape(ShapeTag<Sphere>()), radius_(radius) {
-  if (radius < 0) {
+Box::Box(double width, double depth, double height)
+    : Shape(ShapeTag<Box>()),
+      size_(width, depth, height) {
+  if (width <= 0 || depth <= 0 || height <= 0) {
     throw std::logic_error(
-        fmt::format("Sphere radius should be >= 0 (was {}).", radius));
+        fmt::format("Box width, depth, and height should all be > 0 (were {}, "
+                    "{}, and {}, respectively).",
+                    width, depth, height));
+  }
+}
+
+Box::Box(const Vector3<double>& measures)
+    : Box(measures(0), measures(1), measures(2)) {}
+
+Box Box::MakeCube(double edge_size) {
+  return Box(edge_size, edge_size, edge_size);
+}
+
+Capsule::Capsule(double radius, double length)
+    : Shape(ShapeTag<Capsule>()), radius_(radius), length_(length) {
+  if (radius <= 0 || length <= 0) {
+    throw std::logic_error(
+        fmt::format("Capsule radius and length should both be > 0 (were {} "
+                    "and {}, respectively).",
+                    radius, length));
+  }
+}
+
+Capsule::Capsule(const Vector2<double>& measures)
+    : Capsule(measures(0), measures(1)) {}
+
+Convex::Convex(const std::string& absolute_filename, double scale)
+    : Shape(ShapeTag<Convex>()), filename_(absolute_filename), scale_(scale) {
+  if (std::abs(scale) < 1e-8) {
+    throw std::logic_error("Convex |scale| cannot be < 1e-8.");
   }
 }
 
@@ -58,6 +88,19 @@ Cylinder::Cylinder(double radius, double length)
 
 Cylinder::Cylinder(const Vector2<double>& measures)
     : Cylinder(measures(0), measures(1)) {}
+
+Ellipsoid::Ellipsoid(double a, double b, double c)
+    : Shape(ShapeTag<Ellipsoid>()), radii_(a, b, c) {
+  if (a <= 0 || b <= 0 || c <= 0) {
+    throw std::logic_error(
+        fmt::format("Ellipsoid lengths of principal semi-axes a, b, and c "
+                    "should all be > 0 (were {}, {}, and {}, respectively).",
+                    a, b, c));
+  }
+}
+
+Ellipsoid::Ellipsoid(const Vector3<double>& measures)
+    : Ellipsoid(measures(0), measures(1), measures(2)) {}
 
 HalfSpace::HalfSpace() : Shape(ShapeTag<HalfSpace>()) {}
 
@@ -92,61 +135,10 @@ RigidTransform<double> HalfSpace::MakePose(const Vector3<double>& Hz_dir_F,
   return RigidTransform<double>(R_FH, p_FH);
 }
 
-Box::Box(double width, double depth, double height)
-    : Shape(ShapeTag<Box>()),
-      size_(width, depth, height) {
-  if (width <= 0 || depth <= 0 || height <= 0) {
-    throw std::logic_error(
-        fmt::format("Box width, depth, and height should all be > 0 (were {}, "
-                    "{}, and {}, respectively).",
-                    width, depth, height));
-  }
-}
-
-Box::Box(const Vector3<double>& measures)
-    : Box(measures(0), measures(1), measures(2)) {}
-
-Box Box::MakeCube(double edge_size) {
-  return Box(edge_size, edge_size, edge_size);
-}
-
-Capsule::Capsule(double radius, double length)
-    : Shape(ShapeTag<Capsule>()), radius_(radius), length_(length) {
-  if (radius <= 0 || length <= 0) {
-    throw std::logic_error(
-        fmt::format("Capsule radius and length should both be > 0 (were {} "
-                    "and {}, respectively).",
-                    radius, length));
-  }
-}
-
-Capsule::Capsule(const Vector2<double>& measures)
-    : Capsule(measures(0), measures(1)) {}
-
-Ellipsoid::Ellipsoid(double a, double b, double c)
-    : Shape(ShapeTag<Ellipsoid>()), radii_(a, b, c) {
-  if (a <= 0 || b <= 0 || c <= 0) {
-    throw std::logic_error(
-        fmt::format("Ellipsoid lengths of principal semi-axes a, b, and c "
-                    "should all be > 0 (were {}, {}, and {}, respectively).",
-                    a, b, c));
-  }
-}
-
-Ellipsoid::Ellipsoid(const Vector3<double>& measures)
-    : Ellipsoid(measures(0), measures(1), measures(2)) {}
-
 Mesh::Mesh(const std::string& absolute_filename, double scale)
     : Shape(ShapeTag<Mesh>()), filename_(absolute_filename), scale_(scale) {
   if (std::abs(scale) < 1e-8) {
     throw std::logic_error("Mesh |scale| cannot be < 1e-8.");
-  }
-}
-
-Convex::Convex(const std::string& absolute_filename, double scale)
-    : Shape(ShapeTag<Convex>()), filename_(absolute_filename), scale_(scale) {
-  if (std::abs(scale) < 1e-8) {
-    throw std::logic_error("Convex |scale| cannot be < 1e-8.");
   }
 }
 
@@ -163,19 +155,15 @@ MeshcatCone::MeshcatCone(double height, double a, double b)
 MeshcatCone::MeshcatCone(const Vector3<double>& measures)
     : MeshcatCone(measures(0), measures(1), measures(2)) {}
 
+Sphere::Sphere(double radius)
+    : Shape(ShapeTag<Sphere>()), radius_(radius) {
+  if (radius < 0) {
+    throw std::logic_error(
+        fmt::format("Sphere radius should be >= 0 (was {}).", radius));
+  }
+}
+
 ShapeReifier::~ShapeReifier() = default;
-
-void ShapeReifier::ImplementGeometry(const Sphere&, void*) {
-  ThrowUnsupportedGeometry("Sphere");
-}
-
-void ShapeReifier::ImplementGeometry(const Cylinder&, void*) {
-  ThrowUnsupportedGeometry("Cylinder");
-}
-
-void ShapeReifier::ImplementGeometry(const HalfSpace&, void*) {
-  ThrowUnsupportedGeometry("HalfSpace");
-}
 
 void ShapeReifier::ImplementGeometry(const Box&, void*) {
   ThrowUnsupportedGeometry("Box");
@@ -185,19 +173,32 @@ void ShapeReifier::ImplementGeometry(const Capsule&, void*) {
   ThrowUnsupportedGeometry("Capsule");
 }
 
-void ShapeReifier::ImplementGeometry(const Ellipsoid&, void*) {
-  ThrowUnsupportedGeometry("Ellipsoid");
-}
-void ShapeReifier::ImplementGeometry(const Mesh&, void*) {
-  ThrowUnsupportedGeometry("Mesh");
-}
-
 void ShapeReifier::ImplementGeometry(const Convex&, void*) {
   ThrowUnsupportedGeometry("Convex");
 }
 
+void ShapeReifier::ImplementGeometry(const Cylinder&, void*) {
+  ThrowUnsupportedGeometry("Cylinder");
+}
+
+void ShapeReifier::ImplementGeometry(const Ellipsoid&, void*) {
+  ThrowUnsupportedGeometry("Ellipsoid");
+}
+
+void ShapeReifier::ImplementGeometry(const HalfSpace&, void*) {
+  ThrowUnsupportedGeometry("HalfSpace");
+}
+
+void ShapeReifier::ImplementGeometry(const Mesh&, void*) {
+  ThrowUnsupportedGeometry("Mesh");
+}
+
 void ShapeReifier::ImplementGeometry(const MeshcatCone&, void*) {
   ThrowUnsupportedGeometry("MeshcatCone");
+}
+
+void ShapeReifier::ImplementGeometry(const Sphere&, void*) {
+  ThrowUnsupportedGeometry("Sphere");
 }
 
 void ShapeReifier::ThrowUnsupportedGeometry(const std::string& shape_name) {
@@ -211,18 +212,6 @@ ShapeName::ShapeName(const Shape& shape) {
 
 ShapeName::~ShapeName() = default;
 
-void ShapeName::ImplementGeometry(const Sphere&, void*) {
-  string_ = "Sphere";
-}
-
-void ShapeName::ImplementGeometry(const Cylinder&, void*) {
-  string_ = "Cylinder";
-}
-
-void ShapeName::ImplementGeometry(const HalfSpace&, void*) {
-  string_ = "HalfSpace";
-}
-
 void ShapeName::ImplementGeometry(const Box&, void*) {
   string_ = "Box";
 }
@@ -231,20 +220,32 @@ void ShapeName::ImplementGeometry(const Capsule&, void*) {
   string_ = "Capsule";
 }
 
+void ShapeName::ImplementGeometry(const Convex&, void*) {
+  string_ = "Convex";
+}
+
+void ShapeName::ImplementGeometry(const Cylinder&, void*) {
+  string_ = "Cylinder";
+}
+
 void ShapeName::ImplementGeometry(const Ellipsoid&, void*) {
   string_ = "Ellipsoid";
+}
+
+void ShapeName::ImplementGeometry(const HalfSpace&, void*) {
+  string_ = "HalfSpace";
 }
 
 void ShapeName::ImplementGeometry(const Mesh&, void*) {
   string_ = "Mesh";
 }
 
-void ShapeName::ImplementGeometry(const Convex&, void*) {
-  string_ = "Convex";
-}
-
 void ShapeName::ImplementGeometry(const MeshcatCone&, void*) {
   string_ = "MeshcatCone";
+}
+
+void ShapeName::ImplementGeometry(const Sphere&, void*) {
+  string_ = "Sphere";
 }
 
 std::ostream& operator<<(std::ostream& out, const ShapeName& name) {
@@ -259,15 +260,6 @@ class CalcVolumeReifier final : public ShapeReifier {
 
   using ShapeReifier::ImplementGeometry;
 
-  void ImplementGeometry(const Sphere& sphere, void*) final {
-    volume_ = 4.0 / 3.0 * M_PI * std::pow(sphere.radius(), 3);
-  }
-  void ImplementGeometry(const Cylinder& cylinder, void*) final {
-    volume_ = M_PI * std::pow(cylinder.radius(), 2) * cylinder.length();
-  }
-  void ImplementGeometry(const HalfSpace&, void*) final {
-    volume_ = std::numeric_limits<double>::infinity();
-  }
   void ImplementGeometry(const Box& box, void*) final {
     volume_ = box.width() * box.depth() * box.height();
   }
@@ -275,11 +267,20 @@ class CalcVolumeReifier final : public ShapeReifier {
     volume_ = M_PI * std::pow(capsule.radius(), 2) * capsule.length() +
          4.0 / 3.0 * M_PI * std::pow(capsule.radius(), 3);
   }
+  void ImplementGeometry(const Cylinder& cylinder, void*) final {
+    volume_ = M_PI * std::pow(cylinder.radius(), 2) * cylinder.length();
+  }
   void ImplementGeometry(const Ellipsoid& ellipsoid, void*) final {
     volume_ = 4.0 / 3.0 * M_PI * ellipsoid.a() * ellipsoid.b() * ellipsoid.c();
   }
+  void ImplementGeometry(const HalfSpace&, void*) final {
+    volume_ = std::numeric_limits<double>::infinity();
+  }
   void ImplementGeometry(const MeshcatCone& cone, void*) final {
     volume_ = 1.0 / 3.0 * M_PI * cone.a() * cone.b() * cone.height();
+  }
+  void ImplementGeometry(const Sphere& sphere, void*) final {
+    volume_ = 4.0 / 3.0 * M_PI * std::pow(sphere.radius(), 3);
   }
 
   double volume() const { return volume_; }

--- a/geometry/shape_to_string.cc
+++ b/geometry/shape_to_string.cc
@@ -5,19 +5,6 @@
 namespace drake {
 namespace geometry {
 
-void ShapeToString::ImplementGeometry(const Sphere& sphere, void*) {
-  string_ = fmt::format("Sphere(r: {})", sphere.radius());
-}
-
-void ShapeToString::ImplementGeometry(const Cylinder& cylinder, void*) {
-  string_ = fmt::format("Cylinder(r: {}, l: {})", cylinder.radius(),
-                        cylinder.length());
-}
-
-void ShapeToString::ImplementGeometry(const HalfSpace&, void*) {
-  string_ = "Halfspace";
-}
-
 void ShapeToString::ImplementGeometry(const Box& box, void*) {
   string_ = fmt::format("Box(w: {}, d: {}, h: {})", box.width(), box.depth(),
                         box.height());
@@ -28,18 +15,31 @@ void ShapeToString::ImplementGeometry(const Capsule& capsule, void*) {
                         capsule.length());
 }
 
+void ShapeToString::ImplementGeometry(const Convex& convex, void*) {
+  string_ =
+      fmt::format("Convex(s: {}, path: {})", convex.scale(), convex.filename());
+}
+
+void ShapeToString::ImplementGeometry(const Cylinder& cylinder, void*) {
+  string_ = fmt::format("Cylinder(r: {}, l: {})", cylinder.radius(),
+                        cylinder.length());
+}
+
 void ShapeToString::ImplementGeometry(const Ellipsoid& ellipsoid, void*) {
   string_ = fmt::format("Ellipsoid(a: {}, b: {}, c: {})", ellipsoid.a(),
                         ellipsoid.b(), ellipsoid.c());
+}
+
+void ShapeToString::ImplementGeometry(const HalfSpace&, void*) {
+  string_ = "Halfspace";
 }
 
 void ShapeToString::ImplementGeometry(const Mesh& mesh, void*) {
   string_ = fmt::format("Mesh(s: {}, path: {})", mesh.scale(), mesh.filename());
 }
 
-void ShapeToString::ImplementGeometry(const Convex& convex, void*) {
-  string_ =
-      fmt::format("Convex(s: {}, path: {})", convex.scale(), convex.filename());
+void ShapeToString::ImplementGeometry(const Sphere& sphere, void*) {
+  string_ = fmt::format("Sphere(r: {})", sphere.radius());
 }
 
 }  // namespace geometry

--- a/geometry/shape_to_string.cc
+++ b/geometry/shape_to_string.cc
@@ -38,6 +38,11 @@ void ShapeToString::ImplementGeometry(const Mesh& mesh, void*) {
   string_ = fmt::format("Mesh(s: {}, path: {})", mesh.scale(), mesh.filename());
 }
 
+void ShapeToString::ImplementGeometry(const MeshcatCone& cone, void*) {
+  string_ = fmt::format("MeshcatCone(height: {}, a: {}, b: {})", cone.height(),
+                        cone.a(), cone.b());
+}
+
 void ShapeToString::ImplementGeometry(const Sphere& sphere, void*) {
   string_ = fmt::format("Sphere(r: {})", sphere.radius());
 }

--- a/geometry/shape_to_string.h
+++ b/geometry/shape_to_string.h
@@ -34,6 +34,7 @@ class ShapeToString final : public ShapeReifier {
   void ImplementGeometry(const Ellipsoid& ellipsoid, void* user_data) final;
   void ImplementGeometry(const HalfSpace& half_space, void* user_data) final;
   void ImplementGeometry(const Mesh& mesh, void* user_data) final;
+  void ImplementGeometry(const MeshcatCone& cone, void* user_data) final;
   void ImplementGeometry(const Sphere& sphere, void* user_data) final;
 
   //@}

--- a/geometry/shape_to_string.h
+++ b/geometry/shape_to_string.h
@@ -27,14 +27,14 @@ class ShapeToString final : public ShapeReifier {
   /** @name  Implementation of ShapeReifier interface  */
   //@{
   using ShapeReifier::ImplementGeometry;
-  void ImplementGeometry(const Sphere& sphere, void* user_data) final;
-  void ImplementGeometry(const Cylinder& cylinder, void* user_data) final;
-  void ImplementGeometry(const HalfSpace& half_space, void* user_data) final;
   void ImplementGeometry(const Box& box, void* user_data) final;
   void ImplementGeometry(const Capsule& capsule, void* user_data) final;
-  void ImplementGeometry(const Ellipsoid& ellipsoid, void* user_data) final;
-  void ImplementGeometry(const Mesh& mesh, void* user_data) final;
   void ImplementGeometry(const Convex& convex, void* user_data) final;
+  void ImplementGeometry(const Cylinder& cylinder, void* user_data) final;
+  void ImplementGeometry(const Ellipsoid& ellipsoid, void* user_data) final;
+  void ImplementGeometry(const HalfSpace& half_space, void* user_data) final;
+  void ImplementGeometry(const Mesh& mesh, void* user_data) final;
+  void ImplementGeometry(const Sphere& sphere, void* user_data) final;
 
   //@}
   const std::string& string() const { return string_; }

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -220,9 +220,21 @@ class ShapeMatcher final : public ShapeReifier {
   // Shape reifier implementations.
   using ShapeReifier::ImplementGeometry;
 
-  void ImplementGeometry(const Sphere& sphere, void*) final {
-    if (IsExpectedType(sphere)) {
-      TestShapeParameters(sphere);
+  void ImplementGeometry(const Box& box, void*) final {
+    if (IsExpectedType(box)) {
+      TestShapeParameters(box);
+    }
+  }
+
+  void ImplementGeometry(const Capsule& capsule, void*) final {
+    if (IsExpectedType(capsule)) {
+      TestShapeParameters(capsule);
+    }
+  }
+
+  void ImplementGeometry(const Convex& convex, void*) final {
+    if (IsExpectedType(convex)) {
+      TestShapeParameters(convex);
     }
   }
 
@@ -237,27 +249,15 @@ class ShapeMatcher final : public ShapeReifier {
     IsExpectedType(half_space);
   }
 
-  void ImplementGeometry(const Box& box, void*) final {
-    if (IsExpectedType(box)) {
-      TestShapeParameters(box);
-    }
-  }
-
-  void ImplementGeometry(const Capsule& capsule, void*) final {
-    if (IsExpectedType(capsule)) {
-      TestShapeParameters(capsule);
-    }
-  }
-
   void ImplementGeometry(const Mesh& mesh, void*) final {
     if (IsExpectedType(mesh)) {
       TestShapeParameters(mesh);
     }
   }
 
-  void ImplementGeometry(const Convex& convex, void*) final {
-    if (IsExpectedType(convex)) {
-      TestShapeParameters(convex);
+  void ImplementGeometry(const Sphere& sphere, void*) final {
+    if (IsExpectedType(sphere)) {
+      TestShapeParameters(sphere);
     }
   }
 

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -244,6 +244,8 @@ class ShapeMatcher final : public ShapeReifier {
     }
   }
 
+  // TODO(SeanCurtis-TRI): Why are we missing ellipsoid and meshcat cone?
+
   void ImplementGeometry(const HalfSpace& half_space, void*) final {
     // Halfspace has no parameters; so no further testing is necessary.
     IsExpectedType(half_space);

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -21,18 +21,6 @@ using std::unique_ptr;
 
 class ReifierTest : public ShapeReifier, public ::testing::Test {
  public:
-  void ImplementGeometry(const Sphere&, void* data) override {
-    received_user_data_ = data;
-    sphere_made_ = true;
-  }
-  void ImplementGeometry(const Cylinder&, void* data) override {
-    received_user_data_ = data;
-    cylinder_made_ = true;
-  }
-  void ImplementGeometry(const HalfSpace&, void* data) override {
-    received_user_data_ = data;
-    half_space_made_ = true;
-  }
   void ImplementGeometry(const Box&, void* data) override {
     received_user_data_ = data;
     box_made_ = true;
@@ -41,45 +29,57 @@ class ReifierTest : public ShapeReifier, public ::testing::Test {
     received_user_data_ = data;
     capsule_made_ = true;
   }
+  void ImplementGeometry(const Convex&, void* data) override {
+    received_user_data_ = data;
+    convex_made_ = true;
+  }
+  void ImplementGeometry(const Cylinder&, void* data) override {
+    received_user_data_ = data;
+    cylinder_made_ = true;
+  }
   void ImplementGeometry(const Ellipsoid&, void* data) override {
     received_user_data_ = data;
     ellipsoid_made_ = true;
+  }
+  void ImplementGeometry(const HalfSpace&, void* data) override {
+    received_user_data_ = data;
+    half_space_made_ = true;
   }
   void ImplementGeometry(const Mesh&, void* data) override {
     received_user_data_ = data;
     mesh_made_ = true;
   }
-  void ImplementGeometry(const Convex&, void* data) override {
-    received_user_data_ = data;
-    convex_made_ = true;
-  }
   void ImplementGeometry(const MeshcatCone&, void* data) override {
     received_user_data_ = data;
     meshcat_cone_made_ = true;
   }
+  void ImplementGeometry(const Sphere&, void* data) override {
+    received_user_data_ = data;
+    sphere_made_ = true;
+  }
   void Reset() {
     box_made_ = false;
     capsule_made_ = false;
-    ellipsoid_made_ = false;
-    sphere_made_ = false;
-    half_space_made_ = false;
-    cylinder_made_ = false;
     convex_made_ = false;
+    cylinder_made_ = false;
+    ellipsoid_made_ = false;
+    half_space_made_ = false;
     mesh_made_ = false;
     meshcat_cone_made_ = false;
+    sphere_made_ = false;
     received_user_data_ = nullptr;
   }
 
  protected:
   bool box_made_{false};
   bool capsule_made_{false};
-  bool ellipsoid_made_{false};
-  bool sphere_made_{false};
-  bool cylinder_made_{false};
-  bool half_space_made_{false};
   bool convex_made_{false};
+  bool cylinder_made_{false};
+  bool ellipsoid_made_{false};
+  bool half_space_made_{false};
   bool mesh_made_{false};
   bool meshcat_cone_made_{false};
+  bool sphere_made_{false};
   void* received_user_data_{nullptr};
 };
 
@@ -94,48 +94,6 @@ TEST_F(ReifierTest, UserData) {
 
 // This confirms that the shapes invoke the correct Reify method.
 TEST_F(ReifierTest, ReificationDifferentiation) {
-  const Sphere s(1.0);
-  s.Reify(this);
-  EXPECT_TRUE(sphere_made_);
-  EXPECT_FALSE(half_space_made_);
-  EXPECT_FALSE(cylinder_made_);
-  EXPECT_FALSE(box_made_);
-  EXPECT_FALSE(capsule_made_);
-  EXPECT_FALSE(convex_made_);
-  EXPECT_FALSE(ellipsoid_made_);
-  EXPECT_FALSE(mesh_made_);
-  EXPECT_FALSE(meshcat_cone_made_);
-
-  Reset();
-
-  const HalfSpace hs{};
-  hs.Reify(this);
-  EXPECT_FALSE(sphere_made_);
-  EXPECT_TRUE(half_space_made_);
-  EXPECT_FALSE(cylinder_made_);
-  EXPECT_FALSE(box_made_);
-  EXPECT_FALSE(capsule_made_);
-  EXPECT_FALSE(convex_made_);
-  EXPECT_FALSE(ellipsoid_made_);
-  EXPECT_FALSE(mesh_made_);
-  EXPECT_FALSE(meshcat_cone_made_);
-
-  Reset();
-
-  const Cylinder cylinder{1, 2};
-  cylinder.Reify(this);
-  EXPECT_FALSE(sphere_made_);
-  EXPECT_FALSE(half_space_made_);
-  EXPECT_TRUE(cylinder_made_);
-  EXPECT_FALSE(box_made_);
-  EXPECT_FALSE(capsule_made_);
-  EXPECT_FALSE(convex_made_);
-  EXPECT_FALSE(ellipsoid_made_);
-  EXPECT_FALSE(mesh_made_);
-  EXPECT_FALSE(meshcat_cone_made_);
-
-  Reset();
-
   const Box box{1, 2, 3};
   box.Reify(this);
   EXPECT_FALSE(sphere_made_);
@@ -178,6 +136,20 @@ TEST_F(ReifierTest, ReificationDifferentiation) {
 
   Reset();
 
+  const Cylinder cylinder{1, 2};
+  cylinder.Reify(this);
+  EXPECT_FALSE(sphere_made_);
+  EXPECT_FALSE(half_space_made_);
+  EXPECT_TRUE(cylinder_made_);
+  EXPECT_FALSE(box_made_);
+  EXPECT_FALSE(capsule_made_);
+  EXPECT_FALSE(convex_made_);
+  EXPECT_FALSE(ellipsoid_made_);
+  EXPECT_FALSE(mesh_made_);
+  EXPECT_FALSE(meshcat_cone_made_);
+
+  Reset();
+
   const Ellipsoid ellipsoid{1, 2, 3};
   ellipsoid.Reify(this);
   EXPECT_FALSE(sphere_made_);
@@ -187,6 +159,20 @@ TEST_F(ReifierTest, ReificationDifferentiation) {
   EXPECT_FALSE(capsule_made_);
   EXPECT_FALSE(convex_made_);
   EXPECT_TRUE(ellipsoid_made_);
+  EXPECT_FALSE(mesh_made_);
+  EXPECT_FALSE(meshcat_cone_made_);
+
+  Reset();
+
+  const HalfSpace hs{};
+  hs.Reify(this);
+  EXPECT_FALSE(sphere_made_);
+  EXPECT_TRUE(half_space_made_);
+  EXPECT_FALSE(cylinder_made_);
+  EXPECT_FALSE(box_made_);
+  EXPECT_FALSE(capsule_made_);
+  EXPECT_FALSE(convex_made_);
+  EXPECT_FALSE(ellipsoid_made_);
   EXPECT_FALSE(mesh_made_);
   EXPECT_FALSE(meshcat_cone_made_);
 
@@ -217,6 +203,20 @@ TEST_F(ReifierTest, ReificationDifferentiation) {
   EXPECT_FALSE(ellipsoid_made_);
   EXPECT_FALSE(mesh_made_);
   EXPECT_TRUE(meshcat_cone_made_);
+
+  Reset();
+
+  const Sphere s(1.0);
+  s.Reify(this);
+  EXPECT_TRUE(sphere_made_);
+  EXPECT_FALSE(half_space_made_);
+  EXPECT_FALSE(cylinder_made_);
+  EXPECT_FALSE(box_made_);
+  EXPECT_FALSE(capsule_made_);
+  EXPECT_FALSE(convex_made_);
+  EXPECT_FALSE(ellipsoid_made_);
+  EXPECT_FALSE(mesh_made_);
+  EXPECT_FALSE(meshcat_cone_made_);
 }
 
 // Confirms that the ReifiableShape properly clones the right types.
@@ -240,14 +240,14 @@ TEST_F(ReifierTest, CloningShapes) {
   }
   // Now confirm it's still alive. I should be able to reify it into a sphere.
   cloned_shape->Reify(this);
-  ASSERT_TRUE(sphere_made_);
-  ASSERT_FALSE(half_space_made_);
-  ASSERT_FALSE(cylinder_made_);
   ASSERT_FALSE(box_made_);
   ASSERT_FALSE(capsule_made_);
   EXPECT_FALSE(convex_made_);
+  ASSERT_FALSE(cylinder_made_);
+  ASSERT_FALSE(half_space_made_);
   ASSERT_FALSE(ellipsoid_made_);
   EXPECT_FALSE(mesh_made_);
+  ASSERT_TRUE(sphere_made_);
 }
 
 // Given the pose of a plane and its expected translation and z-axis, confirms
@@ -470,18 +470,6 @@ GTEST_TEST(ShapeTest, Constructors) {
 // it forwards construction to the validating constructor with individual
 // parameters.
 GTEST_TEST(ShapeTest, NumericalValidation) {
-  DRAKE_EXPECT_THROWS_MESSAGE(Sphere(-0.5),
-                              "Sphere radius should be >= 0.+");
-  DRAKE_EXPECT_NO_THROW(Sphere(0));  // Special case for 0 radius.
-
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      Cylinder(0, 1), "Cylinder radius and length should both be > 0.+");
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      Cylinder(0.5, -1), "Cylinder radius and length should both be > 0.+");
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      Cylinder(Vector2<double>{0.5, -1}),
-      "Cylinder radius and length should both be > 0.+");
-
   DRAKE_EXPECT_THROWS_MESSAGE(
       Box(2, 0, 2), "Box width, depth, and height should all be > 0.+");
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -500,6 +488,18 @@ GTEST_TEST(ShapeTest, NumericalValidation) {
   DRAKE_EXPECT_THROWS_MESSAGE(Capsule(Vector2<double>{0.5, -1}),
                               "Capsule radius and length should both be > 0.+");
 
+  DRAKE_EXPECT_THROWS_MESSAGE(Convex("bar", 0),
+                              "Convex .scale. cannot be < 1e-8.");
+  DRAKE_EXPECT_NO_THROW(Convex("foo", -1));  // Special case for negative scale.
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      Cylinder(0, 1), "Cylinder radius and length should both be > 0.+");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      Cylinder(0.5, -1), "Cylinder radius and length should both be > 0.+");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      Cylinder(Vector2<double>{0.5, -1}),
+      "Cylinder radius and length should both be > 0.+");
+
   DRAKE_EXPECT_THROWS_MESSAGE(Ellipsoid(0, 1, 1),
                               "Ellipsoid lengths of principal semi-axes a, b, "
                               "and c should all be > 0.+");
@@ -517,10 +517,6 @@ GTEST_TEST(ShapeTest, NumericalValidation) {
                               "Mesh .scale. cannot be < 1e-8.");
   DRAKE_EXPECT_NO_THROW(Mesh("foo", -1));  // Special case for negative scale.
 
-  DRAKE_EXPECT_THROWS_MESSAGE(Convex("bar", 0),
-                              "Convex .scale. cannot be < 1e-8.");
-  DRAKE_EXPECT_NO_THROW(Convex("foo", -1));  // Special case for negative scale.
-
   DRAKE_EXPECT_THROWS_MESSAGE(MeshcatCone(0, 1, 1),
                               "MeshcatCone parameters .+ should all be > 0.*");
   DRAKE_EXPECT_THROWS_MESSAGE(MeshcatCone(1, 0, 1),
@@ -529,29 +525,33 @@ GTEST_TEST(ShapeTest, NumericalValidation) {
                               "MeshcatCone parameters .+ should all be > 0.*");
   DRAKE_EXPECT_THROWS_MESSAGE(MeshcatCone(Vector3<double>{1, 1, 0}),
                               "MeshcatCone parameters .+ should all be > 0.*");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(Sphere(-0.5),
+                              "Sphere radius should be >= 0.+");
+  DRAKE_EXPECT_NO_THROW(Sphere(0));  // Special case for 0 radius.
 }
 
 class DefaultReifierTest : public ShapeReifier, public ::testing::Test {};
 
 // Tests default implementation of virtual functions for each shape.
 TEST_F(DefaultReifierTest, UnsupportedGeometry) {
-  DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(Sphere(0.5), nullptr),
-                              "This class (.+) does not support Sphere.");
-  DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(Cylinder(1, 2), nullptr),
-                              "This class (.+) does not support Cylinder.");
-  DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(HalfSpace(), nullptr),
-                              "This class (.+) does not support HalfSpace.");
   DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(Box(1, 1, 1), nullptr),
                               "This class (.+) does not support Box.");
   DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(Capsule(1, 2), nullptr),
                               "This class (.+) does not support Capsule.");
+  DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(Convex("a", 1), nullptr),
+                              "This class (.+) does not support Convex.");
+  DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(Cylinder(1, 2), nullptr),
+                              "This class (.+) does not support Cylinder.");
   DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(Ellipsoid(1, 1, 1),
                               nullptr),
                               "This class (.+) does not support Ellipsoid.");
+  DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(HalfSpace(), nullptr),
+                              "This class (.+) does not support HalfSpace.");
   DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(Mesh("foo", 1), nullptr),
                               "This class (.+) does not support Mesh.");
-  DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(Convex("a", 1), nullptr),
-                              "This class (.+) does not support Convex.");
+  DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(Sphere(0.5), nullptr),
+                              "This class (.+) does not support Sphere.");
 }
 
 GTEST_TEST(ShapeName, SimpleReification) {
@@ -559,17 +559,17 @@ GTEST_TEST(ShapeName, SimpleReification) {
 
   EXPECT_EQ(name.name(), "");
 
-  Sphere(0.5).Reify(&name);
-  EXPECT_EQ(name.name(), "Sphere");
-
-  Cylinder(1, 2).Reify(&name);
-  EXPECT_EQ(name.name(), "Cylinder");
-
   Box(1, 2, 3).Reify(&name);
   EXPECT_EQ(name.name(), "Box");
 
   Capsule(1, 2).Reify(&name);
   EXPECT_EQ(name.name(), "Capsule");
+
+  Convex("filepath", 1.0).Reify(&name);
+  EXPECT_EQ(name.name(), "Convex");
+
+  Cylinder(1, 2).Reify(&name);
+  EXPECT_EQ(name.name(), "Cylinder");
 
   Ellipsoid(1, 2, 3).Reify(&name);
   EXPECT_EQ(name.name(), "Ellipsoid");
@@ -580,19 +580,22 @@ GTEST_TEST(ShapeName, SimpleReification) {
   Mesh("filepath", 1.0).Reify(&name);
   EXPECT_EQ(name.name(), "Mesh");
 
-  Convex("filepath", 1.0).Reify(&name);
-  EXPECT_EQ(name.name(), "Convex");
+  MeshcatCone(1.0, 0.25, 0.5).Reify(&name);
+  EXPECT_EQ(name.name(), "MeshcatCone");
+
+  Sphere(0.5).Reify(&name);
+  EXPECT_EQ(name.name(), "Sphere");
 }
 
 GTEST_TEST(ShapeName, ReifyOnConstruction) {
-  EXPECT_EQ(ShapeName(Sphere(0.5)).name(), "Sphere");
-  EXPECT_EQ(ShapeName(Cylinder(1, 2)).name(), "Cylinder");
-  EXPECT_EQ(ShapeName(Capsule(1, 2)).name(), "Capsule");
-  EXPECT_EQ(ShapeName(Ellipsoid(1, 2, 3)).name(), "Ellipsoid");
   EXPECT_EQ(ShapeName(Box(1, 2, 3)).name(), "Box");
+  EXPECT_EQ(ShapeName(Capsule(1, 2)).name(), "Capsule");
+  EXPECT_EQ(ShapeName(Convex("filepath", 1.0)).name(), "Convex");
+  EXPECT_EQ(ShapeName(Cylinder(1, 2)).name(), "Cylinder");
+  EXPECT_EQ(ShapeName(Ellipsoid(1, 2, 3)).name(), "Ellipsoid");
   EXPECT_EQ(ShapeName(HalfSpace()).name(), "HalfSpace");
   EXPECT_EQ(ShapeName(Mesh("filepath", 1.0)).name(), "Mesh");
-  EXPECT_EQ(ShapeName(Convex("filepath", 1.0)).name(), "Convex");
+  EXPECT_EQ(ShapeName(Sphere(0.5)).name(), "Sphere");
 }
 
 GTEST_TEST(ShapeName, Streaming) {
@@ -604,21 +607,19 @@ GTEST_TEST(ShapeName, Streaming) {
 }
 
 GTEST_TEST(ShapeTest, Volume) {
-  EXPECT_NEAR(CalcVolume(Sphere(3)), 36.0 * M_PI, 1e-13);
-  EXPECT_NEAR(CalcVolume(Cylinder(1.3, 2.1)), M_PI * 1.3 * 1.3 * 2.1, 1e-14);
   EXPECT_NEAR(CalcVolume(Box(1, 2, 3)), 6.0, 1e-14);
   EXPECT_NEAR(CalcVolume(Capsule(1.23, 2.4)),
               CalcVolume(Cylinder(1.23, 2.4)) + CalcVolume(Sphere(1.23)),
               1e-14);
-  EXPECT_NEAR(CalcVolume(Ellipsoid(1, 2, 3)), 8.0 * M_PI, 1e-14);
-  EXPECT_EQ(CalcVolume(HalfSpace()), std::numeric_limits<double>::infinity());
-
-  DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Mesh("filepath", 1.0)),
-                              ".*does not support.*");
   DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Convex("filepath", 1.0)),
                               ".*does not support.*");
-
+  EXPECT_NEAR(CalcVolume(Cylinder(1.3, 2.1)), M_PI * 1.3 * 1.3 * 2.1, 1e-14);
+  EXPECT_NEAR(CalcVolume(Ellipsoid(1, 2, 3)), 8.0 * M_PI, 1e-14);
+  EXPECT_EQ(CalcVolume(HalfSpace()), std::numeric_limits<double>::infinity());
+  DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Mesh("filepath", 1.0)),
+                              ".*does not support.*");
   EXPECT_NEAR(CalcVolume(MeshcatCone(4, 2, 3)), 8.0 * M_PI, 1e-14);
+  EXPECT_NEAR(CalcVolume(Sphere(3)), 36.0 * M_PI, 1e-13);
 }
 
 }  // namespace

--- a/geometry/test/shape_to_string_test.cc
+++ b/geometry/test/shape_to_string_test.cc
@@ -6,26 +6,6 @@ namespace drake {
 namespace geometry {
 namespace {
 
-GTEST_TEST(ShapeToStringTest, Sphere) {
-  ShapeToString reifier;
-  Sphere s(1.25);
-  s.Reify(&reifier);
-  EXPECT_EQ(reifier.string(), "Sphere(r: 1.25)");
-}
-
-GTEST_TEST(ShapeToStringTest, Cylinder) {
-  ShapeToString reifier;
-  Cylinder c(1.25, 2.5);
-  c.Reify(&reifier);
-  EXPECT_EQ(reifier.string(), "Cylinder(r: 1.25, l: 2.5)");}
-
-GTEST_TEST(ShapeToStringTest, Halfspace) {
-  ShapeToString reifier;
-  HalfSpace h;
-  h.Reify(&reifier);
-  EXPECT_EQ(reifier.string(), "Halfspace");
-}
-
 GTEST_TEST(ShapeToStringTest, Box) {
   ShapeToString reifier;
   Box b(1.5, 2.5, 3.5);
@@ -40,6 +20,34 @@ GTEST_TEST(ShapeToStringTest, Capsule) {
   EXPECT_EQ(reifier.string(), "Capsule(r: 1.25, l: 2.5)");
 }
 
+GTEST_TEST(ShapeToStringTest, Convex) {
+  ShapeToString reifier;
+  Convex m("path/to/file", 1.5);
+  m.Reify(&reifier);
+  EXPECT_EQ(reifier.string(), "Convex(s: 1.5, path: path/to/file)");
+}
+
+GTEST_TEST(ShapeToStringTest, Cylinder) {
+  ShapeToString reifier;
+  Cylinder c(1.25, 2.5);
+  c.Reify(&reifier);
+  EXPECT_EQ(reifier.string(), "Cylinder(r: 1.25, l: 2.5)");
+}
+
+GTEST_TEST(ShapeToStringTest, Ellipsoid) {
+  ShapeToString reifier;
+  Ellipsoid e(1.25, 2.5, 0.5);
+  e.Reify(&reifier);
+  EXPECT_EQ(reifier.string(), "Ellipsoid(a: 1.25, b: 2.5, c: 0.5)");
+}
+
+GTEST_TEST(ShapeToStringTest, Halfspace) {
+  ShapeToString reifier;
+  HalfSpace h;
+  h.Reify(&reifier);
+  EXPECT_EQ(reifier.string(), "Halfspace");
+}
+
 GTEST_TEST(ShapeToStringTest, Mesh) {
   ShapeToString reifier;
   Mesh m("path/to/file", 1.5);
@@ -47,11 +55,11 @@ GTEST_TEST(ShapeToStringTest, Mesh) {
   EXPECT_EQ(reifier.string(), "Mesh(s: 1.5, path: path/to/file)");
 }
 
-GTEST_TEST(ShapeToStringTest, Convex) {
+GTEST_TEST(ShapeToStringTest, Sphere) {
   ShapeToString reifier;
-  Convex m("path/to/file", 1.5);
-  m.Reify(&reifier);
-  EXPECT_EQ(reifier.string(), "Convex(s: 1.5, path: path/to/file)");
+  Sphere s(1.25);
+  s.Reify(&reifier);
+  EXPECT_EQ(reifier.string(), "Sphere(r: 1.25)");
 }
 
 }  // namespace

--- a/geometry/test/shape_to_string_test.cc
+++ b/geometry/test/shape_to_string_test.cc
@@ -55,6 +55,13 @@ GTEST_TEST(ShapeToStringTest, Mesh) {
   EXPECT_EQ(reifier.string(), "Mesh(s: 1.5, path: path/to/file)");
 }
 
+GTEST_TEST(ShapeToStringTest, MeshcatCone) {
+  ShapeToString reifier;
+  MeshcatCone c(1.5, 0.25, 0.5);
+  c.Reify(&reifier);
+  EXPECT_EQ(reifier.string(), "MeshcatCone(height: 1.5, a: 0.25, b: 0.5)");
+}
+
 GTEST_TEST(ShapeToStringTest, Sphere) {
   ShapeToString reifier;
   Sphere s(1.25);

--- a/geometry/test_utilities/dummy_render_engine.h
+++ b/geometry/test_utilities/dummy_render_engine.h
@@ -55,14 +55,14 @@ class DummyRenderEngine : public render::RenderEngine {
   using render::RenderEngine::RenderLabelImage;
 
   using RenderEngine::ImplementGeometry;
-  void ImplementGeometry(const Sphere& sphere, void* user_data) override {}
+  void ImplementGeometry(const Box& box, void* user_data) override {}
+  void ImplementGeometry(const Capsule& capsule, void* user_data) override {}
+  void ImplementGeometry(const Convex& convex, void* user_data) override {}
   void ImplementGeometry(const Cylinder& cylinder, void* user_data) override {}
   void ImplementGeometry(const HalfSpace& half_space,
                          void* user_data) override {}
-  void ImplementGeometry(const Box& box, void* user_data) override {}
-  void ImplementGeometry(const Capsule& capsule, void* user_data) override {}
   void ImplementGeometry(const Mesh& mesh, void* user_data) override {}
-  void ImplementGeometry(const Convex& convex, void* user_data) override {}
+  void ImplementGeometry(const Sphere& sphere, void* user_data) override {}
   //@}
 
   /* @name  Functions for supporting tests.  */

--- a/geometry/test_utilities/dummy_render_engine.h
+++ b/geometry/test_utilities/dummy_render_engine.h
@@ -55,14 +55,14 @@ class DummyRenderEngine : public render::RenderEngine {
   using render::RenderEngine::RenderLabelImage;
 
   using RenderEngine::ImplementGeometry;
-  void ImplementGeometry(const Box& box, void* user_data) override {}
-  void ImplementGeometry(const Capsule& capsule, void* user_data) override {}
-  void ImplementGeometry(const Convex& convex, void* user_data) override {}
-  void ImplementGeometry(const Cylinder& cylinder, void* user_data) override {}
-  void ImplementGeometry(const HalfSpace& half_space,
-                         void* user_data) override {}
-  void ImplementGeometry(const Mesh& mesh, void* user_data) override {}
-  void ImplementGeometry(const Sphere& sphere, void* user_data) override {}
+  void ImplementGeometry(const Box&, void*) override {}
+  void ImplementGeometry(const Capsule&, void*) override {}
+  void ImplementGeometry(const Convex&, void*) override {}
+  void ImplementGeometry(const Cylinder&, void*) override {}
+  void ImplementGeometry(const HalfSpace&, void*) override {}
+  void ImplementGeometry(const Mesh&, void*) override {}
+  void ImplementGeometry(const MeshcatCone&, void*) override {}
+  void ImplementGeometry(const Sphere&, void*) override {}
   //@}
 
   /* @name  Functions for supporting tests.  */


### PR DESCRIPTION
The ordering of the shapes has historically been chaotic (they were ordered according to introduction order). This makes it hard to find the desired shape and interferes with assessing if a shape implementation is missing in a reifier.
    
The declarations of shapes are now alphabetized as well as the in the `ShapeReifier` implementation. Tests and implementations have been updated to reflect the same order.

This incidentally cleans up a couple of outliers discovered during the process.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18202)
<!-- Reviewable:end -->
