### PR TITLE
py serialize: Add example of binding pointer field

### DIFF
--- a/bindings/pydrake/common/serialize_pybind.h
+++ b/bindings/pydrake/common/serialize_pybind.h
@@ -162,7 +162,7 @@ class DefAttributesArchive {
           std::is_base_of_v<py::detail::type_caster_generic,
               py::detail::make_caster<T>>;
       if constexpr (is_registered_type) {
-        return py::type::of<T>();
+        return py::type::of<py::detail::intrinsic_t<T>>();
       } else {
         return CannotIdentifySchemaType<T>();
       }

--- a/bindings/pydrake/common/test/serialize_pybind_test.py
+++ b/bindings/pydrake/common/test/serialize_pybind_test.py
@@ -29,7 +29,8 @@ class TestSerializePybind(unittest.TestCase):
             some_optional=None,
             some_vector=[5.0, 6.0],
             some_map={'key': 7},
-            some_variant=8.0)
+            some_variant=8.0,
+            some_pointer=None)
 
     def test_attributes_using_serialize_no_docs(self):
         """Tests the DefAttributesUsingSerialize overload WITHOUT docstrings.
@@ -64,6 +65,10 @@ class TestSerializePybind(unittest.TestCase):
         """
         dut = self._make_data2()
 
+        # Check default.
+        self.assertIs(dut.some_pointer, None)
+        data1 = self._make_data1()
+
         # Reset all fields.
         dut.some_bool = True
         dut.some_int = 10
@@ -76,6 +81,7 @@ class TestSerializePybind(unittest.TestCase):
         dut.some_vector = [50.0, 60.0]
         dut.some_map = {'new_key': 70}
         dut.some_variant = 80.0
+        dut.some_pointer = data1
 
         # Read back all fields.
         self.assertEqual(dut.some_bool, True)
@@ -89,6 +95,7 @@ class TestSerializePybind(unittest.TestCase):
         self.assertEqual(dut.some_vector, [50.0, 60.0])
         self.assertEqual(dut.some_map, {'new_key': 70})
         self.assertEqual(dut.some_variant, 80.0)
+        self.assertIs(dut.some_pointer, data1)
 
         try:
             # Use the PEP-585 types if supported (Python >= 3.9).
@@ -112,7 +119,8 @@ class TestSerializePybind(unittest.TestCase):
             ("some_optional", typing.Optional[float]),
             ("some_vector", expected_vector_type),
             ("some_map", expected_dict_type),
-            ("some_variant", typing.Union[float, MyData1])))
+            ("some_variant", typing.Union[float, MyData1]),
+            ("some_pointer", MyData1)))
 
     def test_repr_using_serialize_no_docs(self):
         """Tests the repr() for a class bound WITHOUT docstrings.
@@ -137,4 +145,5 @@ class TestSerializePybind(unittest.TestCase):
                          "some_optional=None, "
                          "some_vector=[5.0, 6.0], "
                          "some_map={'key': 7.0}, "
-                         "some_variant=8.0)")
+                         "some_variant=8.0, "
+                         "some_pointer=None)")

--- a/bindings/pydrake/common/test/serialize_test_util_py.cc
+++ b/bindings/pydrake/common/test/serialize_test_util_py.cc
@@ -34,6 +34,7 @@ struct MyData2 {
     a->Visit(DRAKE_NVP(some_vector));
     a->Visit(DRAKE_NVP(some_map));
     a->Visit(DRAKE_NVP(some_variant));
+    a->Visit(DRAKE_NVP(some_pointer));
   }
   bool some_bool{};
   int some_int{};
@@ -46,6 +47,7 @@ struct MyData2 {
   std::vector<double> some_vector;
   std::map<std::string, double> some_map;
   std::variant<double, MyData1> some_variant;
+  const MyData1* some_pointer{};
 };
 
 // This is a manually-created mock up of part of what mkdoc would produce for
@@ -66,7 +68,8 @@ struct MyData2Docs {
         std::make_pair("some_optional", "Field docstring for a optional."),
         std::make_pair("some_vector", "Field docstring for a vector."),
         std::make_pair("some_map", "Field docstring for a map."),
-        std::make_pair("some_variant", "Field docstring for a variant.")};
+        std::make_pair("some_variant", "Field docstring for a variant."),
+        std::make_pair("some_pointer", "Field docstring for a pointer.")};
   }
 };
 


### PR DESCRIPTION
Fix bug when using pybind's RTTI lookup by using py::detail::intrinsic_t

Using this as I'm prototyping controllers in Python, then doing very low effort ports to C++ for speed, w/ simple workflow shown in  basic C++ controllers as a means to just accelerate
https://stackoverflow.com/a/74215122/7829525

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18204)
<!-- Reviewable:end -->
