### PR TITLE
Fix a bug in GlobalInverseKinematics

### DIFF
--- a/multibody/inverse_kinematics/global_inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/global_inverse_kinematics.cc
@@ -78,16 +78,28 @@ GlobalInverseKinematics::GlobalInverseKinematics(
   // This dummy_plant_context is used to compute the pose of a body welded to
   // the world.
   auto dummy_plant_context = plant_.CreateDefaultContext();
+  // First go through each body to assign the pose variables.
   for (BodyIndex body_idx{1}; body_idx < num_bodies; ++body_idx) {
     const Body<double>& body = plant_.get_body(body_idx);
     const string body_R_name = body.name() + "_R";
     const string body_pos_name = body.name() + "_pos";
     p_WBo_[body_idx] = prog_.NewContinuousVariables<3>(body_pos_name);
+    if (weld_to_world_body_index_set.count(body_idx) > 0) {
+      // This body is welded to the world.
+      R_WB_[body_idx] = prog_.NewContinuousVariables<3, 3>(body_R_name);
+    } else {
+      // This body is not rigidly fixed to the world.
+      R_WB_[body_idx] = solvers::NewRotationMatrixVars(&prog_, body_R_name);
+    }
+  }
+  // Now go through each body to add the kinematic constraint between each body
+  // and its parent.
+  for (BodyIndex body_idx{1}; body_idx < num_bodies; ++body_idx) {
+    const Body<double>& body = plant_.get_body(body_idx);
     // If the body is fixed to the world, then fix the decision variables on
     // the body position and orientation.
     if (weld_to_world_body_index_set.count(body_idx) > 0) {
       // This body is welded to the world.
-      R_WB_[body_idx] = prog_.NewContinuousVariables<3, 3>(body_R_name);
       const math::RigidTransformd X_WB = plant_.CalcRelativeTransform(
           *dummy_plant_context, plant_.world_frame(), body.body_frame());
       // TODO(hongkai.dai): clean up this for loop using
@@ -101,8 +113,6 @@ GlobalInverseKinematics::GlobalInverseKinematics(
                                      p_WBo_[body_idx]);
     } else {
       // This body is not rigidly fixed to the world.
-      R_WB_[body_idx] = solvers::NewRotationMatrixVars(&prog_, body_R_name);
-
       if (!options.linear_constraint_only) {
         solvers::AddRotationMatrixOrthonormalSocpConstraint(&prog_,
                                                             R_WB_[body_idx]);
@@ -171,7 +181,7 @@ GlobalInverseKinematics::GlobalInverseKinematics(
           // where axis_Jc = axis_Jp since the rotation axis is invaraiant in
           // the inboard frame Jp and the outboard frame Jc.
           prog_.AddLinearEqualityConstraint(
-              R_WB_[body_idx] * X_CJc.rotation().matrix().transpose() * axis -
+              R_WB_[body_idx] * X_CJc.rotation().matrix() * axis -
                   R_WB_[parent_idx] * X_PJp.rotation().matrix() * axis,
               Vector3d::Zero());
 
@@ -179,7 +189,7 @@ GlobalInverseKinematics::GlobalInverseKinematics(
           // parent bodies.
           prog_.AddLinearEqualityConstraint(
               p_WBo_[parent_idx] + R_WB_[parent_idx] * X_PJp.translation() -
-                  p_WBo_[body_idx] + R_WB_[body_idx] * X_CJc.translation(),
+                  p_WBo_[body_idx] - R_WB_[body_idx] * X_CJc.translation(),
               Vector3d::Zero());
 
           // Now we process the joint limits constraint.

--- a/multibody/inverse_kinematics/test/global_inverse_kinematics_reachable_test.cc
+++ b/multibody/inverse_kinematics/test/global_inverse_kinematics_reachable_test.cc
@@ -31,7 +31,7 @@ TEST_F(KukaTest, ReachableTest) {
     EXPECT_TRUE(result.is_success());
 
     double pos_tol = 0.061;
-    double orient_tol = 0.24;
+    double orient_tol = 0.25;
     CheckGlobalIKSolution(result, pos_tol, orient_tol);
     // Now call nonlinear IK with the solution from global IK as the initial
     // seed. If the global IK provides a good initial seed, then the nonlinear

--- a/multibody/inverse_kinematics/test/global_inverse_kinematics_test.cc
+++ b/multibody/inverse_kinematics/test/global_inverse_kinematics_test.cc
@@ -194,6 +194,34 @@ TEST_F(KukaTest, ReachableWithCost) {
   }
 }
 
+TEST_F(ToyTest, Test) {
+  GlobalInverseKinematics::Options global_ik_options;
+  GlobalInverseKinematics global_ik(*plant_, global_ik_options);
+
+  // Test an arbitrary configuration. Set the body position and orientation to
+  // the pose at this configuration, and make sure that global IK is feasible.
+  auto context = plant_->CreateDefaultContext();
+  const Eigen::Vector2d q(0.5, 1);
+  plant_->SetPositions(context.get(), q);
+  for (BodyIndex body_index{1}; body_index < plant_->num_bodies();
+       ++body_index) {
+    const auto X_WB = plant_->CalcRelativeTransform(
+        *context, plant_->world_frame(),
+        plant_->get_body(body_index).body_frame());
+    global_ik.get_mutable_prog()->AddBoundingBoxConstraint(
+        X_WB.rotation().matrix(), X_WB.rotation().matrix(),
+        global_ik.body_rotation_matrix(body_index));
+    global_ik.get_mutable_prog()->AddBoundingBoxConstraint(
+        X_WB.translation(), X_WB.translation(),
+        global_ik.body_position(body_index));
+  }
+  solvers::GurobiSolver gurobi_solver;
+  if (gurobi_solver.available()) {
+    const auto result = gurobi_solver.Solve(global_ik.prog());
+    EXPECT_TRUE(result.is_success());
+  }
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/test/global_inverse_kinematics_test_util.cc
+++ b/multibody/inverse_kinematics/test/global_inverse_kinematics_test_util.cc
@@ -5,8 +5,11 @@
 
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/roll_pitch_yaw.h"
 #include "drake/multibody/inverse_kinematics/inverse_kinematics.h"
 #include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/tree/revolute_joint.h"
+#include "drake/multibody/tree/weld_joint.h"
 #include "drake/solvers/solve.h"
 #include "drake/systems/framework/diagram_builder.h"
 
@@ -107,6 +110,44 @@ Eigen::VectorXd KukaTest::CheckNonlinearIK(
   const auto result = solvers::Solve(ik.prog(), q_guess_ik);
   EXPECT_EQ(result.is_success(), ik_success_expected);
   return q_sol;
+}
+
+ToyTest::ToyTest() : plant_{std::make_unique<MultibodyPlant<double>>(0.0)} {
+  const SpatialInertia<double> spatial_inertia(
+      1, Eigen::Vector3d::Zero(), UnitInertia<double>(0.01, 0.01, 0.01));
+  body_indices_.push_back(
+      plant_->AddRigidBody("body0", spatial_inertia).index());
+  // weld body0.
+  plant_->AddJoint<WeldJoint>(
+      "joint0", plant_->get_body(world_index()),
+      math::RigidTransform<double>(math::RollPitchYaw<double>(0.2, 0.1, 0.3),
+                                   Eigen::Vector3d(0.2, -0.1, 0.1)),
+      plant_->get_body(body_indices_[0]),
+      math::RigidTransform<double>(math::RollPitchYaw<double>(0.3, 0.1, -0.5),
+                                   Eigen::Vector3d(0.3, 0.2, 0.5)),
+      math::RigidTransform<double>(math::RollPitchYaw(0.4, -0.3, 0.2),
+                                   Eigen::Vector3d(0.5, 0.3, -0.2)));
+  const auto& body2 = plant_->AddRigidBody("body2", spatial_inertia);
+  const auto& body1 = plant_->AddRigidBody("body1", spatial_inertia);
+  body_indices_.push_back(body1.index());
+  body_indices_.push_back(body2.index());
+  plant_->AddJoint<RevoluteJoint>(
+      "joint1", plant_->get_body(body_indices_[0]),
+      math::RigidTransform<double>(math::RollPitchYawd(0.1, 0.5, 0.3),
+                                   Eigen::Vector3d(0.2, 0.1, 0.4)),
+      body1,
+      math::RigidTransformd(math::RollPitchYawd(0.5, -0.2, 0.1),
+                            Eigen::Vector3d(0.1, 0.2, 0.3)),
+      Eigen::Vector3d::UnitX());
+  plant_->AddJoint<RevoluteJoint>(
+      "joint2", body1,
+      math::RigidTransform<double>(math::RollPitchYawd(0.3, -0.5, 0.3),
+                                   Eigen::Vector3d(-0.2, 0.2, 0.4)),
+      body2,
+      math::RigidTransformd(math::RollPitchYawd(0.2, -0.5, 0.1),
+                            Eigen::Vector3d(0.1, 0.2, 0.1)),
+      Eigen::Vector3d::UnitY());
+  plant_->Finalize();
 }
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/test/global_inverse_kinematics_test_util.h
+++ b/multibody/inverse_kinematics/test/global_inverse_kinematics_test_util.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <memory>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -49,6 +50,19 @@ class KukaTest : public ::testing::Test {
   std::unique_ptr<MultibodyPlant<double>> plant_;
   GlobalInverseKinematics global_ik_;
   BodyIndex ee_idx_;  // end effector's body index.
+};
+
+// Construct a toy robot. This robot uses non-identity transform between the
+// mobilizer and the parent/child joints. It also intentionally flips the order
+// of constructing the parent/child links, such that the child link has smaller
+// body index than the parent link.
+class ToyTest : public testing::Test {
+ public:
+  ToyTest();
+
+ protected:
+  std::unique_ptr<MultibodyPlant<double>> plant_;
+  std::vector<BodyIndex> body_indices_;
 };
 }  // namespace multibody
 }  // namespace drake


### PR DESCRIPTION
Assign the pose variables forefront for all bodies, before imposing the kinematic constraint that connect the parent and the child bodies.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18206)
<!-- Reviewable:end -->
