### PR TITLE
py plant: Bind MakeActuatorSelectorMatrix overloads

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -627,6 +627,25 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("MakeActuationMatrix", &Class::MakeActuationMatrix,
             cls_doc.MakeActuationMatrix.doc)
         .def(
+            "MakeActuatorSelectorMatrix",
+            [](const Class* self, const std::vector<JointActuatorIndex>&
+                                      user_to_actuator_index_map) {
+              return self->MakeActuatorSelectorMatrix(
+                  user_to_actuator_index_map);
+            },
+            py::arg("user_to_actuator_index_map"),
+            cls_doc.MakeActuatorSelectorMatrix
+                .doc_1args_user_to_actuator_index_map)
+        .def(
+            "MakeActuatorSelectorMatrix",
+            [](const Class* self,
+                const std::vector<JointIndex>& user_to_joint_index_map) {
+              return self->MakeActuatorSelectorMatrix(user_to_joint_index_map);
+            },
+            py::arg("user_to_joint_index_map"),
+            cls_doc.MakeActuatorSelectorMatrix
+                .doc_1args_user_to_joint_index_map)
+        .def(
             "MapVelocityToQDot",
             [](const Class* self, const Context<T>& context,
                 const Eigen::Ref<const VectorX<T>>& v) {

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2111,6 +2111,16 @@ class TestPlant(unittest.TestCase):
         B = plant.MakeActuationMatrix()
         numpy_compare.assert_float_equal(B, np.array([[0.], [1.]]))
 
+        sample_actuator = plant.GetJointActuatorByName("ElbowJoint")
+        Ba = plant.MakeActuatorSelectorMatrix(
+            user_to_actuator_index_map=[sample_actuator.index()])
+        numpy_compare.assert_float_equal(Ba, np.array([[1.]]))
+
+        sample_joint = plant.GetJointByName("ElbowJoint")
+        Bj = plant.MakeActuatorSelectorMatrix(
+            user_to_joint_index_map=[sample_joint.index()])
+        numpy_compare.assert_float_equal(Bj, np.array([[1.]]))
+
         forces = MultibodyForces(plant=plant)
         plant.CalcForceElementsContribution(context=context, forces=forces)
         copy.copy(forces)


### PR DESCRIPTION
Writing some simple torque controllers in a plant with some floating bodies and other robots. Found this was missing.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18209)
<!-- Reviewable:end -->
