### PR TITLE
Added System::Clone() functionality

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -1004,6 +1004,7 @@ drake_cc_googletest(
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
         "//systems/framework/test_utilities",
+        "//systems/primitives:adder",
     ],
 )
 

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -261,6 +261,22 @@ class System : public SystemBase {
     return this->get_cache_entry(time_derivatives_cache_index_);
   }
 
+//----------------------------------------------------------------------------
+/** @name                     CloneSystem
+ * This method clones the system and returns a unique pointer to the
+ * clone. The clone is a deep copy of the original system, including
+ * all of its state, parameters, and input ports. The clone is not
+ * connected to the original system in any way. The clone is done using
+ * hacky workaround - converts to AutoDiff and then back to double.
+ * This is not a good solution, but it works for now. */
+template <typename SystemType>
+std::unique_ptr<SystemType> CloneSystem(const SystemType& system) {
+  // Cast here because SFINAE is ugly and not strictly necessary.
+  const drake::systems::System<double>& base = system;
+  return dynamic_pointer_cast<SystemType>(
+        base.ToAutoDiffXd()->ToScalarType<double>());
+}
+
   /** Returns a reference to the cached value of the potential energy (PE),
   evaluating first if necessary using CalcPotentialEnergy().
 

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -18,6 +18,7 @@
 #include "drake/systems/framework/leaf_output_port.h"
 #include "drake/systems/framework/system_output.h"
 #include "drake/systems/framework/test_utilities/my_vector.h"
+#include "drake/systems/primitives/adder.h"
 
 namespace drake {
 namespace systems {
@@ -274,6 +275,16 @@ class TestSystem : public TestSystemBase<double> {
   mutable std::vector<int> published_numbers_;
   mutable std::vector<int> updated_numbers_;
 };
+
+// Tests that CloneSystem() works for a System with no inputs or outputs.
+GTEST_TEST(SystemExtrasTest, CloneSystem) {
+  Adder<double> adder(1, 1);
+  adder.set_name("my_adder");
+
+  std::unique_ptr<Adder<double>> adder_clone =
+    adder.CloneSystem(adder);
+  EXPECT_EQ(adder_clone->get_name(), "my_adder");
+}
 
 class SystemTest : public ::testing::Test {
  protected:


### PR DESCRIPTION
Adds the ability to clone a `System` and returns a unique pointer to that clone. Goes via AutoDiff back to double. More in the comments

Resolves #17860

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18212)
<!-- Reviewable:end -->
