### PR TITLE
[meshcat] JointSliders::Run() returns the final positions

### DIFF
--- a/bindings/pydrake/multibody/test/meshcat_test.py
+++ b/bindings/pydrake/multibody/test/meshcat_test.py
@@ -7,8 +7,9 @@ from pydrake.multibody.meshcat import (
 )
 
 import copy
-import os
 import unittest
+
+import numpy as np
 
 from pydrake.common import (
     FindResourceOrThrow,
@@ -25,7 +26,6 @@ from pydrake.multibody.parsing import (
 )
 from pydrake.multibody.plant import (
     AddMultibodyPlantSceneGraph,
-    MultibodyPlant,
 )
 from pydrake.systems.framework import (
     DiagramBuilder,
@@ -128,7 +128,10 @@ class TestMeshcat(unittest.TestCase):
         # The Run function doesn't crash.
         builder.AddSystem(dut)
         diagram = builder.Build()
-        dut.Run(diagram=diagram, timeout=1.0, stop_button_keycode="ArrowLeft")
+        q = dut.Run(diagram=diagram,
+                    timeout=1.0,
+                    stop_button_keycode="ArrowLeft")
+        np.testing.assert_equal(q, [0, 0])
 
         # The SetPositions function doesn't crash (Acrobot has two positions).
         dut.SetPositions(q=[1, 2])

--- a/multibody/meshcat/joint_sliders.h
+++ b/multibody/meshcat/joint_sliders.h
@@ -117,14 +117,17 @@ class JointSliders final : public systems::LeafSystem<T> {
   the empty string means no keycode. See Meshcat::AddButton for details.
   @default "Escape".
 
+  @returns the output of plant.GetPositions() given the most recently published
+  value of the plant Context.
+
   @pre `diagram` must be a top-level (i.e., "root") diagram.
   @pre `diagram` must contain this JointSliders system.
   @pre `diagram` must contain the `plant` that was passed into this
   JointSliders system's constructor.
   */
-  void Run(const systems::Diagram<T>& diagram,
-           std::optional<double> timeout = std::nullopt,
-           std::string stop_button_keycode = "Escape") const;
+  Eigen::VectorXd Run(const systems::Diagram<T>& diagram,
+                      std::optional<double> timeout = std::nullopt,
+                      std::string stop_button_keycode = "Escape") const;
 
   /** Sets all robot positions (corresponding to joint positions and potentially
   positions not associated with any joint) to the values in `q`.  The meshcat

--- a/multibody/meshcat/test/joint_sliders_test.cc
+++ b/multibody/meshcat/test/joint_sliders_test.cc
@@ -275,13 +275,17 @@ TEST_F(JointSlidersTest, Destructor) {
 TEST_F(JointSlidersTest, Run) {
   // Add the acrobot visualizer and sliders.
   AddAcrobot();
+
+  Vector2d initial_value{0.12, 0.34};
   MeshcatVisualizer<double>::AddToBuilder(&builder_, scene_graph_, meshcat_);
-  auto* dut = builder_.AddSystem<JointSliders<double>>(meshcat_, &plant_);
+  auto* dut = builder_.AddSystem<JointSliders<double>>(meshcat_, &plant_,
+                                                       initial_value);
   auto diagram = builder_.Build();
 
   // Run for a while.
   const double timeout = 1.0;
-  dut->Run(*diagram, timeout);
+  Eigen::VectorXd q = dut->Run(*diagram, timeout);
+  EXPECT_TRUE(CompareMatrices(q, initial_value));
 
   // Note: the stop button is deleted on timeout, so we cannot easily check
   // that it was created correctly here.
@@ -295,7 +299,8 @@ TEST_F(JointSlidersTest, Run) {
   meshcat_->SetSliderValue(kAcrobotJoint1, 0.25);
 
   // Run for a while (with a non-default stop_button_keycode).
-  dut->Run(*diagram, timeout, "KeyP");
+  q = dut->Run(*diagram, timeout, "KeyP");
+  EXPECT_TRUE(CompareMatrices(q, Vector2d{0.25, initial_value[1]}));
 
   // Check that the slider's transform had any effect, i.e., that the
   // MeshcatVisualizer::Publish was called.


### PR DESCRIPTION
As requested in https://stackoverflow.com/questions/74251312/pydrake-how-to-return-joint-positions-in-forward-kinematics-example/74254419

+@jwnimmer-tri for both reviews, please?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18215)
<!-- Reviewable:end -->
