### PR TITLE
[math] Don't use march=broadwell on Ubuntu arm64 machines

### DIFF
--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -277,18 +277,19 @@ drake_cc_library(
 )
 
 # This should be compiled with Intel AVX2 and FMA enabled if possible.
-# Currently (March 2021) we can't do that on Apple even if it is Intel-based
-# due to our old Mac CI machines. Compiling for Broadwell (or later) gets
-# those instructions.
+# Compiling for Broadwell (or later) gets those instructions. On macOS,
+# we opt-out of this feature (even for Apple hardware that supports it)
+# to reduce our test matrix burden for the deprecated architecture.
 drake_cc_library(
     name = "fast_pose_composition_functions_avx2_fma",
     srcs = ["fast_pose_composition_functions_avx2_fma.cc"],
     hdrs = ["fast_pose_composition_functions_avx2_fma.h"],
     copts = select({
         "//tools/cc_toolchain:apple": [],
-        "//conditions:default": [
+        "@platforms//cpu:x86_64": [
             "-march=broadwell",
         ],
+        "//conditions:default": [],
     }),
     deps = [],
 )

--- a/math/test/fast_pose_composition_functions_test.cc
+++ b/math/test/fast_pose_composition_functions_test.cc
@@ -10,13 +10,30 @@
 
 namespace drake {
 namespace math {
-
-namespace  {
+namespace {
 using Eigen::Matrix3d;
 using Eigen::Matrix4d;
 using Matrix34d = Eigen::Matrix<double, 3, 4>;
 
-GTEST_TEST(TestFastPoseCompositionFunctions, UsingAVX) {
+#if defined(__APPLE__)
+constexpr bool kApple = true;
+#else
+constexpr bool kApple = false;
+#endif
+
+// Checks that our logic for detecting AVX at runtime works as expected.
+GTEST_TEST(TestFastPoseCompositionFunctions, AvxDetection) {
+  if (!kApple) {
+    // On Drake's Ubuntu CI we should always have AVX available (Drake CI only
+    // covers x64_64 builds, no arm64 yet). If we ever do add arm64 in CI, then
+    // we'll need to amend this condition.
+    EXPECT_EQ(internal::AvxSupported(), true);
+  }
+}
+
+// The "using portable" and "has avx" should be opposites so long as AVX is the
+// only accelerated option.
+GTEST_TEST(TestFastPoseCompositionFunctions, UsingPortable) {
   EXPECT_NE(
       internal::IsUsingPortableCompositionFunctions(),
       internal::AvxSupported());


### PR DESCRIPTION
Relates to #13514.

See [slack thread](https://app.slack.com/client/T0JNB2DS4/C0KDGF4V9/thread/C0KDGF4V9-1667265291.809839) for a user testimonial that this resolves a problem with their attempt to build on arm64.

We don't have Ubuntu arm64 in CI (yet?), so the updated `BUILD` logic is only covered by testimonial, not by CI.  Therefore it might regress without us noticing, but that's fine because it's not a supported build flavor. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18221)
<!-- Reviewable:end -->
