### PR TITLE
[pydrake] Remove deprecated MeshcatVisualizerCpp 2022-11

### DIFF
--- a/bindings/pydrake/_geometry_extra.py
+++ b/bindings/pydrake/_geometry_extra.py
@@ -7,7 +7,6 @@ import subprocess
 import sys
 
 from pydrake.common import FindResourceOrThrow
-from pydrake.common.deprecation import deprecated_callable as _deprecated
 
 
 def _is_listening(port):
@@ -72,35 +71,3 @@ def StartMeshcat():
     if "DEEPNOTE_PROJECT_ID" in os.environ:
         return _start_meshcat_deepnote()
     return Meshcat()
-
-
-@_deprecated(
-    "MeshcatVisualizerCpp has been renamed to MeshcatVisualizer.",
-    date="2022-11-01")
-def MeshcatVisualizerCpp(*args, **kwargs):
-    return MeshcatVisualizer(*args, **kwargs)
-
-
-@_deprecated(
-    "MeshcatVisualizerCpp has been renamed to MeshcatVisualizer.",
-    date="2022-11-01")
-def _AddToBuilder(*args, **kwargs):
-    return MeshcatVisualizer.AddToBuilder(*args, **kwargs)
-
-
-MeshcatVisualizerCpp.AddToBuilder = _AddToBuilder
-
-
-@_deprecated(
-    "MeshcatPointCloudVisualizerCpp has been renamed to "
-    "MeshcatPointCloudVisualizer.",
-    date="2022-11-01")
-def MeshcatPointCloudVisualizerCpp(*args, **kwargs):
-    return MeshcatPointCloudVisualizer(*args, **kwargs)
-
-
-# For the template classes, it's not easy to add a deprecation message.
-# We'll rely on the default names above (no underscore) to provide one,
-# along with the release notes.
-MeshcatVisualizerCpp_ = MeshcatVisualizer_
-MeshcatPointCloudVisualizerCpp_ = MeshcatPointCloudVisualizer_

--- a/bindings/pydrake/test/geometry_visualizers_test.py
+++ b/bindings/pydrake/test/geometry_visualizers_test.py
@@ -9,7 +9,6 @@ from drake import lcmt_viewer_load_robot, lcmt_viewer_draw
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common.value import AbstractValue
 from pydrake.common.test_utilities import numpy_compare
-from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.lcm import DrakeLcm, Subscriber
 from pydrake.math import RigidTransform
 from pydrake.perception import PointCloud
@@ -268,26 +267,6 @@ class TestGeometryVisualizers(unittest.TestCase):
         self.assertIsInstance(vis_autodiff,
                               mut.MeshcatVisualizer_[AutoDiffXd])
 
-    def test_deprecated_meshcat_visualizer_cpp_add(self):
-        """This checks a deprecated API spelling; remove this on 2022-11-01."""
-        T = float
-        builder = DiagramBuilder_[T]()
-        scene_graph = builder.AddSystem(mut.SceneGraph_[T]())
-        meshcat = mut.Meshcat()
-        with catch_drake_warnings(expected_count=1):
-            added = mut.MeshcatVisualizerCpp.AddToBuilder(
-                builder=builder, scene_graph=scene_graph, meshcat=meshcat)
-        self.assertIsInstance(added, mut.MeshcatVisualizer)
-
-    def test_deprecated_meshcat_visualizer_cpp_scalar_conversion(self):
-        """This checks a deprecated API spelling; remove this on 2022-11-01."""
-        meshcat = mut.Meshcat()
-        with catch_drake_warnings(expected_count=1):
-            vis = mut.MeshcatVisualizerCpp(meshcat)
-        vis_autodiff = vis.ToAutoDiffXd()
-        self.assertIsInstance(vis_autodiff,
-                              mut.MeshcatVisualizerCpp_[AutoDiffXd])
-
     @numpy_compare.check_nonsymbolic_types
     def test_meshcat_point_cloud_visualizer(self, T):
         meshcat = mut.Meshcat()
@@ -307,17 +286,6 @@ class TestGeometryVisualizers(unittest.TestCase):
             ad_visualizer = visualizer.ToAutoDiffXd()
             self.assertIsInstance(
                 ad_visualizer, mut.MeshcatPointCloudVisualizer_[AutoDiffXd])
-
-    def test_deprecated_meshcat_point_cloud_visualizer_cpp(self):
-        """This checks a deprecated API spelling; remove this on 2022-11-01."""
-        meshcat = mut.Meshcat()
-        with catch_drake_warnings(expected_count=1):
-            visualizer = mut.MeshcatPointCloudVisualizerCpp(
-                meshcat=meshcat, path="cloud", publish_period=1/12.0)
-        visualizer.set_point_size(0.1)
-        ad_visualizer = visualizer.ToAutoDiffXd()
-        self.assertIsInstance(
-            ad_visualizer, mut.MeshcatPointCloudVisualizerCpp_[AutoDiffXd])
 
     def test_start_meshcat(self):
         # StartMeshcat only performs interesting work on cloud notebook hosts.

--- a/examples/manipulation_station/end_effector_teleop_dualshock4.py
+++ b/examples/manipulation_station/end_effector_teleop_dualshock4.py
@@ -17,7 +17,7 @@ from pydrake.common.value import AbstractValue
 from pydrake.examples import (
     ManipulationStation, ManipulationStationHardwareInterface,
     CreateClutterClearingYcbObjectList, SchunkCollisionModel)
-from pydrake.geometry import DrakeVisualizer, Meshcat, MeshcatVisualizerCpp
+from pydrake.geometry import DrakeVisualizer, Meshcat, MeshcatVisualizer
 from pydrake.multibody.plant import MultibodyPlant
 from pydrake.manipulation.planner import (
     DifferentialInverseKinematicsIntegrator,
@@ -372,7 +372,7 @@ def main():
         DrakeVisualizer.AddToBuilder(builder, query_port)
         if args.meshcat:
             meshcat = Meshcat()
-            MeshcatVisualizerCpp.AddToBuilder(
+            MeshcatVisualizer.AddToBuilder(
                 builder=builder,
                 query_object_port=query_port,
                 meshcat=meshcat)


### PR DESCRIPTION
Likewise remove MeshcatPointCloudVisualizerCpp.

Follow-up from #17462.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18225)
<!-- Reviewable:end -->
