### PR TITLE
[parsing] Deprecate PopulateFromEnvironment("ROS_PACKAGE_PATH")

### DIFF
--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -130,7 +130,7 @@ void PackageMap::PopulateFromEnvironment(const string& environment_variable) {
   if (environment_variable == "ROS_PACKAGE_PATH") {
     drake::log()->warn(
       "PackageMap: PopulateFromEnvironment(\"ROS_PACKAGE_PATH\") is "
-      "deprecated, and will be disabled on or around 2022-11-01. To populate "
+      "deprecated, and will be disabled on or around 2023-02-01. To populate "
       "manifests from ROS_PACKAGE_PATH, use PopulateFromRosPackagePath() "
       "instead.");
   }


### PR DESCRIPTION
We'd intended to deprecate this previously (#17251), but apparently I can't read and I mistakenly removed the release notes label.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18226)
<!-- Reviewable:end -->
