### PR TITLE
lcm_publisher_system: Add should_publish port

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,7 @@
 # -*- python -*-
 
+DISABLE CI
+
 # This file marks a workspace root for the Bazel build system. see
 # https://bazel.build/ .
 


### PR DESCRIPTION
Per proposal in Anzu issue 9276

This PR currently provides low-effort backwards compatibility when directly using `LcmPublisherSystem`. However, there are some edge cases:
(a) When using `LeafSystem::get_input_port()`, the case `num_ports() == 1` fails.
(b) When using sugar `DiagramBuilder::Connect(System, System)`, the above case fails.

I am a fan of sugar for (a), and this could be resolved with simple runtime flag (`allow_single_get_input_port`).

I am not a fan of sugar for (b), and do not desire to spend my time addressing its backwards compatibility. I am willing to, though, with guidance.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18227)
<!-- Reviewable:end -->
