### PR TITLE
[sensors] Fix typo in deprecation date

### DIFF
--- a/systems/sensors/camera_config_functions.h
+++ b/systems/sensors/camera_config_functions.h
@@ -67,7 +67,7 @@ void ApplyCameraConfig(const CameraConfig& config,
                        geometry::SceneGraph<double>* scene_graph = nullptr,
                        drake::lcm::DrakeLcmInterface* lcm = nullptr);
 
-DRAKE_DEPRECATED("2022-02-01", "Use the LcmBuses-related overload instead.")
+DRAKE_DEPRECATED("2023-02-01", "Use the LcmBuses-related overload instead.")
 void ApplyCameraConfig(const CameraConfig& config,
                        multibody::MultibodyPlant<double>* plant,
                        DiagramBuilder<double>* builder,


### PR DESCRIPTION
There was a typo in #18069.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18228)
<!-- Reviewable:end -->
