### PR TITLE
[setup] Remove macOS auto-cleanup for drake_visualizer's removal

### DIFF
--- a/setup/mac/binary_distribution/install_prereqs.sh
+++ b/setup/mac/binary_distribution/install_prereqs.sh
@@ -60,14 +60,6 @@ if [[ "${with_update}" -eq 1 ]]; then
   binary_distribution_called_update=1
 fi
 
-# TODO(jwnimmer-tri): Remove lines tapping robotlocomotion/director and
-# uninstalling vtk@8.2.0 on or after 2022-11-01.
-brew tap robotlocomotion/director
-brew uninstall --force $(cat <<EOF
-robotlocomotion/director/vtk@8.2.0
-EOF
-)
-
 brew bundle --file="${BASH_SOURCE%/*}/Brewfile" --no-lock
 
 if ! command -v pip3.10 &>/dev/null; then


### PR DESCRIPTION
As a courtesy, we were uninstalling software that's no longer needed by Drake (#16945). We assume that enough users will have run this by now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18229)
<!-- Reviewable:end -->
