### PR TITLE
Partially revert "... march=broadwell on Ubuntu arm64 machines"

### DIFF
--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -286,10 +286,9 @@ drake_cc_library(
     hdrs = ["fast_pose_composition_functions_avx2_fma.h"],
     copts = select({
         "//tools/cc_toolchain:apple": [],
-        "@platforms//cpu:x86_64": [
+        "//conditions:default": [
             "-march=broadwell",
         ],
-        "//conditions:default": [],
     }),
     deps = [],
 )


### PR DESCRIPTION
Hotfix for #18221.

Keep the missing unit test and comment fixes intact, but revert the arm64 change to the BUILD file to unbreak CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18230)
<!-- Reviewable:end -->
