### PR TITLE
Add memory leak exception to valgrind.supp to mute mosek memory leak error

### DIFF
--- a/tools/dynamic_analysis/valgrind.supp
+++ b/tools/dynamic_analysis/valgrind.supp
@@ -45,6 +45,16 @@
    obj:*/libmosek64.so.*
 }
 
+{
+   MOSEK memory leak #2 
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   fun:allocate_dtv
+   ...
+   obj:*/libmosek64.so.10.0
+}
+
 # Started happening when Gurobi got updated to 7.0.2. PR 6332.
 {
     <gurobi-1>


### PR DESCRIPTION
Address #18223

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18231)
<!-- Reviewable:end -->
