### PR TITLE
Example sim contact and control instabilities for floating / articulated

### DIFF
--- a/examples/instability/BUILD.bazel
+++ b/examples/instability/BUILD.bazel
@@ -4,6 +4,7 @@
 load(
     "@drake//tools/skylark:drake_py.bzl",
     "drake_py_library",
+    "drake_py_test",
     "drake_py_unittest",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
@@ -38,6 +39,11 @@ drake_py_unittest(
         ":instability_common_py",
         "//bindings/pydrake",
     ],
+)
+
+drake_py_test(
+    name = "plant_hidden_state_test",
+    deps = ["//bindings/pydrake"],
 )
 
 add_lint_tests()

--- a/examples/instability/BUILD.bazel
+++ b/examples/instability/BUILD.bazel
@@ -1,0 +1,34 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+load(
+    "@drake//tools/skylark:drake_py.bzl",
+    "drake_py_unittest",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+drake_py_unittest(
+    name = "control_instability_test",
+    timeout = "moderate",
+    data = [
+        "test/floating_body.sdf",
+        "//manipulation/models/franka_description:models",
+    ],
+    deps = [
+        "//bindings/pydrake",
+    ],
+)
+
+drake_py_unittest(
+    name = "contact_instability_test",
+    timeout = "moderate",
+    data = [
+        "test/contact_object_a.sdf",
+        "test/contact_object_b.sdf",
+    ],
+    deps = [
+        "//bindings/pydrake",
+    ],
+)
+
+add_lint_tests()

--- a/examples/instability/BUILD.bazel
+++ b/examples/instability/BUILD.bazel
@@ -3,30 +3,39 @@
 
 load(
     "@drake//tools/skylark:drake_py.bzl",
+    "drake_py_library",
     "drake_py_unittest",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
+drake_py_library(
+    name = "instability_common_py",
+    srcs = ["test/instability_common.py"],
+    deps = ["//bindings/pydrake"],
+)
+
 drake_py_unittest(
     name = "control_instability_test",
-    timeout = "moderate",
+    timeout = "long",
     data = [
         "test/floating_body.sdf",
         "//manipulation/models/franka_description:models",
     ],
     deps = [
+        ":instability_common_py",
         "//bindings/pydrake",
     ],
 )
 
 drake_py_unittest(
     name = "contact_instability_test",
-    timeout = "moderate",
+    timeout = "long",
     data = [
         "test/contact_object_a.sdf",
         "test/contact_object_b.sdf",
     ],
     deps = [
+        ":instability_common_py",
         "//bindings/pydrake",
     ],
 )

--- a/examples/instability/README.md
+++ b/examples/instability/README.md
@@ -1,0 +1,3 @@
+# Expected (or not?) Simulation Instabilities
+
+Hoisting content from Anzu PR 9768

--- a/examples/instability/test/contact_instability_test.py
+++ b/examples/instability/test/contact_instability_test.py
@@ -11,6 +11,7 @@ from pydrake.common import FindResourceOrThrow
 from pydrake.math import RigidTransform, RollPitchYaw
 from pydrake.multibody.math import SpatialVelocity
 from pydrake.systems.analysis import Simulator
+from pydrake.visualization import AddDefaultVisualization
 
 from drake.examples.instability.test.instability_common import (
     TestBase,
@@ -18,7 +19,7 @@ from drake.examples.instability.test.instability_common import (
     monitor_large_energy_delta,
 )
 
-VISUALIZE = False
+VISUALIZE = True
 
 
 def add_floating_contact_sim(ns):
@@ -33,6 +34,7 @@ def add_floating_contact_sim(ns):
     ns.model_a = ns.parser.AddModelFromFile(a_file, "a")
     ns.model_b = ns.parser.AddModelFromFile(b_file, "b")
     ns.plant.Finalize()
+    AddDefaultVisualization(builder=ns.builder)
     ns.frame_W = ns.plant.world_frame()
     ns.frame_A = ns.plant.GetFrameByName("__model__", ns.model_a)
     ns.frame_B = ns.plant.GetFrameByName("__model__", ns.model_b)

--- a/examples/instability/test/contact_instability_test.py
+++ b/examples/instability/test/contact_instability_test.py
@@ -1,0 +1,137 @@
+"""
+Shows simple box collision going unstable based on time step.
+"""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+import unittest
+
+import numpy as np
+
+from pydrake.common import FindResourceOrThrow
+from pydrake.geometry import DrakeVisualizer, DrakeVisualizerParams, Role
+from pydrake.math import RigidTransform, RollPitchYaw
+from pydrake.multibody.math import SpatialVelocity
+from pydrake.multibody.parsing import Parser
+from pydrake.multibody.plant import AddMultibodyPlant, MultibodyPlantConfig
+from pydrake.systems.analysis import Simulator
+from pydrake.systems.framework import DiagramBuilder, EventStatus
+
+VISUALIZE = True
+
+
+def add_basic_simulation_components(ns, time_step, solver=None):
+    ns.builder = DiagramBuilder()
+    config = MultibodyPlantConfig(time_step=time_step)
+    if solver is not None:
+        config.discrete_contact_solver = solver
+    else:
+        assert time_step == 0.0
+    ns.plant, ns.scene_graph = AddMultibodyPlant(config, ns.builder)
+    ns.parser = Parser(ns.plant)
+    DrakeVisualizer.AddToBuilder(
+        ns.builder,
+        ns.scene_graph,
+        params=DrakeVisualizerParams(role=Role.kIllustration),
+    )
+    ns.plant.mutable_gravity_field().set_gravity_vector([0.0, 0.0, 0.0])
+
+
+def add_floating_contact_sim(ns):
+    a_file = FindResourceOrThrow(
+        "drake/examples/instability/test/contact_object_a.sdf"
+    )
+    b_file = FindResourceOrThrow(
+        "drake/examples/instability/test/contact_object_b.sdf"
+    )
+    ns.model_a = ns.parser.AddModelFromFile(a_file, "a")
+    ns.model_b = ns.parser.AddModelFromFile(b_file, "b")
+    ns.plant.Finalize()
+    ns.frame_W = ns.plant.world_frame()
+    ns.frame_A = ns.plant.GetFrameByName("__model__", ns.model_a)
+    ns.frame_B = ns.plant.GetFrameByName("__model__", ns.model_b)
+    return ns
+
+
+def total_energy(plant, context):
+    return plant.EvalKineticEnergy(context) + plant.EvalPotentialEnergy(
+        context
+    )
+
+
+def monitor_large_energy_delta(simulator, t, plant, max_energy_gain):
+    diagram_context = simulator.get_context()
+    context = plant.GetMyContextFromRoot(diagram_context)
+    energy_init = total_energy(plant, context)
+    max_bad_energy_delta = None
+
+    def monitor(diagram_context):
+        nonlocal max_bad_energy_delta
+        context = plant.GetMyContextFromRoot(diagram_context)
+        energy_now = total_energy(plant, context)
+        energy_delta = energy_now - energy_init
+        if energy_delta > max_energy_gain:
+            if (
+                max_bad_energy_delta is None
+                or energy_delta > max_bad_energy_delta
+            ):
+                max_bad_energy_delta = energy_delta
+        return EventStatus.DidNothing()
+
+    simulator.set_monitor(monitor)
+    simulator.AdvanceTo(t)
+    if max_bad_energy_delta is not None:
+        raise RuntimeError(f"Too much energy gained: {max_bad_energy_delta} J")
+
+
+class Test(unittest.TestCase):
+    @contextmanager
+    def assert_raises_message(self, pieces, cls=RuntimeError):
+        with self.assertRaises(cls) as cm:
+            yield
+        for piece in pieces:
+            self.assertIn(piece, str(cm.exception))
+
+    def run_floating_contact(
+        self, time_step, *, solver=None, max_energy_gain,
+    ):
+        print((time_step, solver))
+        ns = SimpleNamespace()
+        add_basic_simulation_components(ns, time_step, solver)
+        add_floating_contact_sim(ns)
+
+        diagram = ns.builder.Build()
+        diagram_context = diagram.CreateDefaultContext()
+        context = ns.plant.GetMyContextFromRoot(diagram_context)
+
+        X_WA0 = RigidTransform([0, -0.18, 0])
+        X_WB0 = RigidTransform(
+            rpy=RollPitchYaw(np.deg2rad([0, 0, -90.0])), p=[0, 0.0, 0],
+        )
+        ns.plant.SetFreeBodyPose(context, ns.frame_A.body(), X_WA0)
+        ns.plant.SetFreeBodyPose(context, ns.frame_B.body(), X_WB0)
+
+        V_WA0 = SpatialVelocity(w=[0, 0, 0], v=[0, 0.1, 0.0])
+        ns.plant.SetFreeBodySpatialVelocity(ns.frame_A.body(), V_WA0, context)
+
+        simulator = Simulator(diagram, diagram_context)
+        if VISUALIZE:
+            simulator.set_target_realtime_rate(1.0)
+        t_max = 1.0
+        monitor_large_energy_delta(simulator, t_max, ns.plant, max_energy_gain)
+
+    def test_floating_contact(self):
+        time_step_continuous = 0.0
+        time_step_unstable = 0.0005
+        time_step_stable = 0.0004
+
+        self.run_floating_contact(
+            time_step_continuous, max_energy_gain=0.0,
+        )
+        with self.assert_raises_message(["Too much energy gained"]):
+            self.run_floating_contact(
+                time_step_unstable, solver="sap", max_energy_gain=0.15,
+            )
+        self.run_floating_contact(
+            time_step_stable, solver="sap", max_energy_gain=0.0,
+        )

--- a/examples/instability/test/contact_object_a.sdf
+++ b/examples/instability/test/contact_object_a.sdf
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<sdf version="1.7">
+  <model name="user_cursor">
+    <link name="user_cursor">
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>1</mass>
+        <inertia>
+          <ixx>0.1</ixx>
+          <ixy> 0 </ixy>
+          <ixz> 0 </ixz>
+          <iyy>0.1</iyy>
+          <iyz> 0 </iyz>
+          <izz>0.1</izz>
+        </inertia>
+      </inertial>
+      <visual name="visual">
+        <geometry>
+          <box>
+            <size>0.075 0.075 0.05</size>
+          </box>
+        </geometry>
+      </visual>
+      <collision name="collision">
+        <geometry>
+          <box>
+            <size>0.075 0.075 0.05</size>
+          </box>
+        </geometry>
+        <!-- N.B. Naively estimated properties. -->
+        <drake:proximity_properties>
+          <drake:rigid_hydroelastic/>
+          <drake:mu_dynamic>0.5</drake:mu_dynamic>
+          <drake:mu_static>0.5</drake:mu_static>
+          <drake:hunt_crossley_dissipation>1.25</drake:hunt_crossley_dissipation>
+          <drake:mesh_resolution_hint>0.005</drake:mesh_resolution_hint>
+        </drake:proximity_properties>
+      </collision>
+    </link>
+  </model>
+</sdf>

--- a/examples/instability/test/contact_object_a.sdf
+++ b/examples/instability/test/contact_object_a.sdf
@@ -5,6 +5,7 @@
       <inertial>
         <pose>0 0 0 0 0 0</pose>
         <mass>1</mass>
+        <!-- TODO(eric.cousineau): Use better inertia. -->
         <inertia>
           <ixx>0.1</ixx>
           <ixy> 0 </ixy>

--- a/examples/instability/test/contact_object_b.sdf
+++ b/examples/instability/test/contact_object_b.sdf
@@ -1,0 +1,48 @@
+<?xml version="1.0" ?>
+<sdf version="1.7" xmlns:drake="https://drake.mit.edu">
+  <model name="peeler">
+    <link name="peeler">
+      <visual name="blade_visual">
+        <pose>0.08 0 0  0 0 0</pose>
+        <geometry>
+          <box>
+            <size> 0.05 0.02 0.01 </size>
+          </box>
+        </geometry>
+      </visual>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>1</mass>
+        <inertia>
+          <ixx> 0.1 </ixx>
+          <ixy> 0 </ixy>
+          <ixz> 0 </ixz>
+          <iyy> 0.1 </iyy>
+          <iyz> 0 </iyz>
+          <izz> 0.1 </izz>
+        </inertia>
+      </inertial>
+      <collision name="blade_collision">
+        <pose>0.08 0 0  0 0 0</pose>
+        <geometry>
+          <box>
+            <size> 0.05 0.02 0.01 </size>
+          </box>
+        </geometry>
+        <!-- N.B. Naively estimated properties. -->
+        <drake:proximity_properties>
+          <drake:compliant_hydroelastic/>
+          <drake:mu_dynamic>0.5</drake:mu_dynamic>
+          <drake:mu_static>0.5</drake:mu_static>
+          <drake:mesh_resolution_hint>0.005</drake:mesh_resolution_hint>
+          <!--
+          Using value for AISI 302 Steel
+          (https://www.engineeringtoolbox.com/)
+          -->
+          <drake:hydroelastic_modulus>180.0e9</drake:hydroelastic_modulus>
+          <drake:hunt_crossley_dissipation>1.25</drake:hunt_crossley_dissipation>
+        </drake:proximity_properties>
+      </collision>
+    </link>
+  </model>
+</sdf>

--- a/examples/instability/test/contact_object_b.sdf
+++ b/examples/instability/test/contact_object_b.sdf
@@ -13,6 +13,7 @@
       <inertial>
         <pose>0 0 0 0 0 0</pose>
         <mass>1</mass>
+        <!-- TODO(eric.cousineau): Use better inertia. -->
         <inertia>
           <ixx> 0.1 </ixx>
           <ixy> 0 </ixy>

--- a/examples/instability/test/control_instability_test.py
+++ b/examples/instability/test/control_instability_test.py
@@ -1,0 +1,427 @@
+"""
+Shows simulated controllers going unstable.
+"""
+
+from contextlib import contextmanager
+import dataclasses as dc
+from types import SimpleNamespace
+import unittest
+
+import numpy as np
+
+from pydrake.common import FindResourceOrThrow
+from pydrake.common.cpp_param import List
+from pydrake.common.value import Value
+from pydrake.geometry import DrakeVisualizer, DrakeVisualizerParams, Role
+from pydrake.multibody.math import SpatialForce, SpatialVelocity
+from pydrake.multibody.parsing import Parser
+from pydrake.multibody.plant import (
+    AddMultibodyPlant,
+    ExternallyAppliedSpatialForce,
+    MultibodyPlantConfig,
+)
+from pydrake.multibody.tree import JacobianWrtVariable
+from pydrake.systems.analysis import Simulator
+from pydrake.systems.framework import DiagramBuilder, EventStatus, LeafSystem
+
+VISUALIZE = False
+
+
+def simple_jacobian(plant, context, frame_W, frame_F):
+    Jv_WF = plant.CalcJacobianSpatialVelocity(
+        context,
+        with_respect_to=JacobianWrtVariable.kV,
+        frame_B=frame_F,
+        p_BP=[0, 0, 0],
+        frame_A=frame_W,
+        frame_E=frame_W,
+    )
+    return Jv_WF
+
+
+def get_frame_spatial_velocity(plant, context, frame_W, frame_F):
+    Jv_WF = simple_jacobian(plant, context, frame_W, frame_F)
+    v = plant.GetVelocities(context)
+    V_WF = SpatialVelocity(Jv_WF @ v)
+    return V_WF
+
+
+def make_force_for_frame(frame_F, F_F_W):
+    external_force = ExternallyAppliedSpatialForce()
+    external_force.body_index = frame_F.body().index()
+    external_force.F_Bq_W = F_F_W
+    external_force.p_BoBq_B = frame_F.GetFixedPoseInBodyFrame().translation()
+    return external_force
+
+
+def add_basic_simulation_components(ns, time_step, solver=None):
+    ns.builder = DiagramBuilder()
+    config = MultibodyPlantConfig(time_step=time_step)
+    if solver is not None:
+        config.discrete_contact_solver = solver
+    else:
+        assert time_step == 0.0
+    ns.plant, ns.scene_graph = AddMultibodyPlant(config, ns.builder)
+    ns.parser = Parser(ns.plant)
+    DrakeVisualizer.AddToBuilder(
+        ns.builder,
+        ns.scene_graph,
+        params=DrakeVisualizerParams(role=Role.kIllustration),
+    )
+    ns.plant.mutable_gravity_field().set_gravity_vector([0.0, 0.0, 0.0])
+
+
+def add_floating_sim(ns):
+    model_file = FindResourceOrThrow(
+        "drake/examples/instability/test/floating_body.sdf"
+    )
+    ns.model = ns.parser.AddModelFromFile(model_file, "model")
+    ns.plant.Finalize()
+    ns.frame_W = ns.plant.world_frame()
+    ns.frame_F = ns.plant.GetFrameByName("__model__", ns.model)
+
+
+def add_articulated_sim(ns):
+    model_file = FindResourceOrThrow(
+        "drake/manipulation/models/franka_description/urdf/panda_arm.urdf"
+    )
+    ns.model = ns.parser.AddModelFromFile(model_file, "model")
+    ns.plant.WeldFrames(
+        ns.plant.world_frame(),
+        ns.plant.GetFrameByName("panda_link0", ns.model),
+    )
+    ns.plant.Finalize()
+    ns.frame_W = ns.plant.world_frame()
+    ns.frame_F = ns.plant.GetFrameByName("panda_link8", ns.model)
+    # Bent elbow.
+    q0 = np.deg2rad([0.0, 45.0, 0.0, -45.0, 0.0, 90.0, 0.0])
+    ns.plant.SetDefaultPositions(ns.model, q0)
+    return ns
+
+
+@dc.dataclass
+class RotationalVelocityDamper:
+    """Should generally remove energy from the system."""
+
+    kd: float
+
+    def __call__(self, V_WF):
+        V_WFdes = SpatialVelocity.Zero()
+        V_FFdes_W = V_WFdes - V_WF
+        tau = self.kd * V_FFdes_W.rotational()
+        F_F_W = SpatialForce(tau=tau, f=np.zeros(3))
+        return F_F_W
+
+
+class FloatingController(LeafSystem):
+    def __init__(self, plant, frame_F, damper):
+        super().__init__()
+        frame_W = plant.world_frame()
+
+        nx = plant.num_positions() + plant.num_velocities()
+        context = plant.CreateDefaultContext()
+
+        def control_math():
+            V_WF = get_frame_spatial_velocity(plant, context, frame_W, frame_F)
+            F_F_W = damper(V_WF)
+            external_force = make_force_for_frame(frame_F, F_F_W)
+            return external_force
+
+        self.plant_state_input = self.DeclareVectorInputPort("plant_state", nx)
+
+        def control_calc(sys_context, output):
+            x = self.plant_state_input.Eval(sys_context)
+            plant.SetPositionsAndVelocities(context, x)
+            external_force = control_math()
+            output.set_value([external_force])
+
+        forces_cls = Value[List[ExternallyAppliedSpatialForce]]
+        self.forces_output = self.DeclareAbstractOutputPort(
+            "forces_output", alloc=forces_cls, calc=control_calc,
+        )
+        self._plant = plant
+
+    def AddToBuilder(self, builder):
+        plant = self._plant
+        builder.AddSystem(self)
+        builder.Connect(
+            plant.get_state_output_port(), self.plant_state_input,
+        )
+        builder.Connect(
+            self.forces_output, plant.get_applied_spatial_force_input_port(),
+        )
+
+
+class ArticulatedController(LeafSystem):
+    def __init__(self, plant, frame_F, damper):
+        super().__init__()
+        frame_W = plant.world_frame()
+        nx = plant.num_positions() + plant.num_velocities()
+        nu = plant.num_actuated_dofs()
+        context = plant.CreateDefaultContext()
+
+        def control_math():
+            v = plant.GetVelocities(context)
+            Jv_WF = simple_jacobian(plant, context, frame_W, frame_F)
+            V_WF = SpatialVelocity(Jv_WF @ v)
+            F_F_W = damper(V_WF)
+            u = Jv_WF.T @ F_F_W.get_coeffs()
+            return u
+
+        self.plant_state_input = self.DeclareVectorInputPort("plant_state", nx)
+
+        def control_calc(sys_context, output):
+            x = self.plant_state_input.Eval(sys_context)
+            plant.SetPositionsAndVelocities(context, x)
+            u = control_math()
+            output.set_value(u)
+
+        self.torques_output = self.DeclareVectorOutputPort(
+            "torques_output", size=nu, calc=control_calc,
+        )
+        self._plant = plant
+
+    def AddToBuilder(self, builder):
+        plant = self._plant
+        builder.AddSystem(self)
+        builder.Connect(
+            plant.get_state_output_port(), self.plant_state_input,
+        )
+        builder.Connect(
+            self.torques_output, plant.get_actuation_input_port(),
+        )
+
+
+def lstsq(A, b):
+    return np.linalg.lstsq(A, b, rcond=None)[0]
+
+
+def norm(x):
+    return np.linalg.norm(x)
+
+
+def total_energy(plant, context):
+    return plant.EvalKineticEnergy(context) + plant.EvalPotentialEnergy(
+        context
+    )
+
+
+def monitor_large_energy_delta(simulator, t, plant, max_energy_gain):
+    diagram_context = simulator.get_context()
+    context = plant.GetMyContextFromRoot(diagram_context)
+    energy_init = total_energy(plant, context)
+    max_bad_energy_delta = None
+
+    def monitor(diagram_context):
+        nonlocal max_bad_energy_delta
+        context = plant.GetMyContextFromRoot(diagram_context)
+        energy_now = total_energy(plant, context)
+        energy_delta = energy_now - energy_init
+        if energy_delta > max_energy_gain:
+            if (
+                max_bad_energy_delta is None
+                or energy_delta > max_bad_energy_delta
+            ):
+                max_bad_energy_delta = energy_delta
+        return EventStatus.DidNothing()
+
+    simulator.set_monitor(monitor)
+    simulator.AdvanceTo(t)
+    if max_bad_energy_delta is not None:
+        raise RuntimeError(f"Too much energy gained: {max_bad_energy_delta} J")
+
+
+class Test(unittest.TestCase):
+    @contextmanager
+    def assert_raises_message(self, pieces, cls=RuntimeError):
+        with self.assertRaises(cls) as cm:
+            yield
+        for piece in pieces:
+            self.assertIn(piece, str(cm.exception))
+
+    def run_floating(
+        self, time_step, *, kd, solver=None, max_energy_gain,
+    ):
+        print((time_step, kd, solver))
+        ns = SimpleNamespace()
+        add_basic_simulation_components(ns, time_step, solver)
+        add_floating_sim(ns)
+        controller = FloatingController(
+            ns.plant, ns.frame_F, RotationalVelocityDamper(kd),
+        )
+        controller.AddToBuilder(ns.builder)
+        diagram = ns.builder.Build()
+        diagram_context = diagram.CreateDefaultContext()
+        context = ns.plant.GetMyContextFromRoot(diagram_context)
+        V0 = SpatialVelocity(w=[0.5, -0.3, 0.2], v=np.zeros(3))
+        ns.plant.SetFreeBodySpatialVelocity(ns.frame_F.body(), V0, context)
+
+        simulator = Simulator(diagram, diagram_context)
+        if VISUALIZE:
+            simulator.set_target_realtime_rate(1.0)
+        t_max = 1.0
+        if max_energy_gain is not None:
+            monitor_large_energy_delta(
+                simulator, t_max, ns.plant, max_energy_gain
+            )
+        else:
+            simulator.AdvanceTo(t_max)
+
+    def run_articulated(
+        self, time_step, *, kd, solver=None, max_energy_gain,
+    ):
+        print((time_step, kd, solver))
+        ns = SimpleNamespace()
+        add_basic_simulation_components(ns, time_step, solver)
+        add_articulated_sim(ns)
+
+        controller = ArticulatedController(
+            ns.plant, ns.frame_F, RotationalVelocityDamper(kd),
+        )
+        controller.AddToBuilder(ns.builder)
+        diagram = ns.builder.Build()
+        diagram_context = diagram.CreateDefaultContext()
+        context = ns.plant.GetMyContextFromRoot(diagram_context)
+
+        V0 = SpatialVelocity(w=[0.5, -0.3, 0.2], v=np.zeros(3))
+        Jv_WF = simple_jacobian(ns.plant, context, ns.frame_W, ns.frame_F)
+        v0 = lstsq(Jv_WF, V0.get_coeffs())
+        ns.plant.SetVelocities(context, ns.model, v0)
+
+        simulator = Simulator(diagram, diagram_context)
+        if VISUALIZE:
+            simulator.set_target_realtime_rate(1.0)
+        t_max = 1.0
+        if max_energy_gain is not None:
+            monitor_large_energy_delta(
+                simulator, t_max, ns.plant, max_energy_gain
+            )
+        else:
+            simulator.AdvanceTo(t_max)
+
+    def test_floating(self):
+        print("[ Floating ]")
+        kd_stable = 0.3
+        # kd_stable = 0.0001  # Can see visible evolution.
+        kd_unstable = 0.35
+
+        time_step_continuous = 0.0
+        time_step_unstable = 0.001
+        time_step_stable = 0.0008
+
+        # (kd_stable, time_step_unstable): Things are happy.
+        self.run_floating(
+            time_step_unstable,
+            kd=kd_stable,
+            solver="sap",
+            max_energy_gain=0.0,
+        )
+        self.run_floating(
+            time_step_unstable,
+            kd=kd_stable,
+            solver="tamsi",
+            max_energy_gain=0.0,
+        )
+        self.run_floating(
+            time_step_continuous, kd=kd_stable, max_energy_gain=0.0,
+        )
+
+        # (kd_unstable, time_step_unstable): Makes SAP and TAMSI go unstable.
+        with self.assert_raises_message(
+            ["Encountered singular articulated body hinge inertia"]
+        ):
+            self.run_floating(
+                time_step_unstable,
+                kd=kd_unstable,
+                solver="sap",
+                # Let error message come through.
+                max_energy_gain=None,
+            )
+        with self.assert_raises_message(["Spatial force", "contains NaN"]):
+            self.run_floating(
+                time_step_unstable,
+                kd=kd_unstable,
+                solver="tamsi",
+                # Let error message come through.
+                max_energy_gain=None,
+            )
+        # (kd_unstable, time_step_stable): Good.
+        self.run_floating(
+            time_step_stable,
+            kd=kd_unstable,
+            solver="sap",
+            max_energy_gain=0.0,
+        )
+        self.run_floating(
+            time_step_stable,
+            kd=kd_unstable,
+            solver="tamsi",
+            max_energy_gain=0.0,
+        )
+        # - Continuous is good (but "stiff").
+        self.run_floating(
+            time_step_continuous, kd=kd_unstable, max_energy_gain=0.0,
+        )
+
+    def test_articulated(self):
+        print("[ Articulated ]")
+        kd_stable = 1.6
+        kd_unstable = 1.7
+
+        time_step_continuous = 0.0
+        time_step_unstable = 0.001
+        time_step_stable = 0.0008
+
+        # (kd_stable, time_step_unstable): Things are happy.
+        self.run_articulated(
+            time_step_unstable,
+            kd=kd_stable,
+            solver="sap",
+            max_energy_gain=0.001,
+        )
+        self.run_articulated(
+            time_step_unstable,
+            kd=kd_stable,
+            solver="tamsi",
+            max_energy_gain=0.001,
+        )
+        self.run_articulated(
+            time_step_continuous, kd=kd_stable, max_energy_gain=0.0,
+        )
+
+        # kd_unstable: Makes SAP and TAMSI go unstable.
+        with self.assert_raises_message(["Too much energy gained"]):
+            # N.B. No solver error by default, but goes unstable.
+            self.run_articulated(
+                time_step_unstable,
+                kd=kd_unstable,
+                solver="sap",
+                max_energy_gain=15059.0,
+            )
+        with self.assert_raises_message(
+            ["MultibodyPlant's discrete update solver failed to converge"]
+        ):
+            self.run_articulated(
+                time_step_unstable,
+                kd=kd_unstable,
+                solver="tamsi",
+                # Let error message come through.
+                max_energy_gain=None,
+            )
+        self.run_articulated(
+            time_step_continuous, kd=kd_unstable, max_energy_gain=0.0,
+        )
+
+        # Using same gain but decreasing time step makes it stable.
+        self.run_articulated(
+            time_step_stable,
+            kd=kd_unstable,
+            solver="sap",
+            max_energy_gain=0.0,
+        )
+        self.run_articulated(
+            time_step_stable,
+            kd=kd_unstable,
+            solver="tamsi",
+            max_energy_gain=0.0,
+        )

--- a/examples/instability/test/floating_body.sdf
+++ b/examples/instability/test/floating_body.sdf
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<sdf version="1.7">
+  <model name="floating_body">
+    <link name="body">
+      <visual name="visual">
+        <geometry>
+          <box>
+            <size>0.05 0.05 0.05</size>
+          </box>
+        </geometry>
+      </visual>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>0.1</mass>
+        <inertia>
+          <ixx>0.000156</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.000156</iyy>
+          <iyz>0</iyz>
+          <izz>0.000156</izz>
+        </inertia>
+      </inertial>
+    </link>
+  </model>
+</sdf>

--- a/examples/instability/test/floating_body.sdf
+++ b/examples/instability/test/floating_body.sdf
@@ -11,6 +11,10 @@
       </visual>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
+        <!--
+        Represents inertial terms in Anzu's yukon_gold_potato.sdf on
+        2022-11-02.
+        -->
         <mass>0.1</mass>
         <inertia>
           <ixx>0.000156</ixx>

--- a/examples/instability/test/instability_common.py
+++ b/examples/instability/test/instability_common.py
@@ -1,0 +1,116 @@
+from contextlib import contextmanager
+import unittest
+
+import numpy as np
+
+from pydrake.geometry import DrakeVisualizer, DrakeVisualizerParams, Role
+from pydrake.multibody.math import SpatialVelocity
+from pydrake.multibody.parsing import Parser
+from pydrake.multibody.plant import (
+    AddMultibodyPlant,
+    ExternallyAppliedSpatialForce,
+    MultibodyPlantConfig,
+)
+from pydrake.multibody.tree import JacobianWrtVariable
+from pydrake.systems.framework import DiagramBuilder, EventStatus
+
+
+class TestBase(unittest.TestCase):
+    @contextmanager
+    def assert_raises_message(self, pieces, cls=RuntimeError):
+        with self.assertRaises(cls) as cm:
+            yield
+        for piece in pieces:
+            self.assertIn(piece, str(cm.exception))
+
+
+def add_basic_simulation_components(ns, time_step, solver=None):
+    ns.builder = DiagramBuilder()
+    config = MultibodyPlantConfig(time_step=time_step)
+    if solver is not None:
+        config.discrete_contact_solver = solver
+    else:
+        assert time_step == 0.0
+    ns.plant, ns.scene_graph = AddMultibodyPlant(config, ns.builder)
+    ns.parser = Parser(ns.plant)
+    DrakeVisualizer.AddToBuilder(
+        ns.builder,
+        ns.scene_graph,
+        params=DrakeVisualizerParams(role=Role.kIllustration),
+    )
+    # Disable gravity so that we do not need to worry about gravity feedforward
+    # control terms.
+    ns.plant.mutable_gravity_field().set_gravity_vector([0.0, 0.0, 0.0])
+
+
+def total_energy(plant, context):
+    return plant.EvalKineticEnergy(context) + plant.EvalPotentialEnergy(
+        context
+    )
+
+
+def monitor_large_energy_delta(simulator, t, plant, max_energy_gain):
+    """
+    Assumes simulator currently has desired intial state.
+
+    This will simulate the system forward to time t, and check if the
+    max_energy_gain (change from initial energy) is ever exceeded. If so, the
+    maximum violation is recorded and an exception is thrown.
+    """
+    diagram_context = simulator.get_context()
+    context = plant.GetMyContextFromRoot(diagram_context)
+    energy_init = total_energy(plant, context)
+    max_bad_energy_delta = None
+
+    def monitor(diagram_context):
+        nonlocal max_bad_energy_delta
+        context = plant.GetMyContextFromRoot(diagram_context)
+        energy_now = total_energy(plant, context)
+        energy_delta = energy_now - energy_init
+        if energy_delta > max_energy_gain:
+            if (
+                max_bad_energy_delta is None
+                or energy_delta > max_bad_energy_delta
+            ):
+                max_bad_energy_delta = energy_delta
+        return EventStatus.DidNothing()
+
+    simulator.set_monitor(monitor)
+    simulator.AdvanceTo(t)
+    if max_bad_energy_delta is not None:
+        raise RuntimeError(f"Too much energy gained: {max_bad_energy_delta} J")
+
+
+def simple_jacobian(plant, context, frame_W, frame_F):
+    Jv_WF = plant.CalcJacobianSpatialVelocity(
+        context,
+        with_respect_to=JacobianWrtVariable.kV,
+        frame_B=frame_F,
+        p_BP=[0, 0, 0],
+        frame_A=frame_W,
+        frame_E=frame_W,
+    )
+    return Jv_WF
+
+
+def get_frame_spatial_velocity(plant, context, frame_W, frame_F):
+    Jv_WF = simple_jacobian(plant, context, frame_W, frame_F)
+    v = plant.GetVelocities(context)
+    V_WF = SpatialVelocity(Jv_WF @ v)
+    return V_WF
+
+
+def make_force_for_frame(frame_F, F_F_W):
+    external_force = ExternallyAppliedSpatialForce()
+    external_force.body_index = frame_F.body().index()
+    external_force.F_Bq_W = F_F_W
+    external_force.p_BoBq_B = frame_F.GetFixedPoseInBodyFrame().translation()
+    return external_force
+
+
+def lstsq(A, b):
+    return np.linalg.lstsq(A, b, rcond=None)[0]
+
+
+def norm(x):
+    return np.linalg.norm(x)

--- a/examples/instability/test/instability_common.py
+++ b/examples/instability/test/instability_common.py
@@ -33,11 +33,6 @@ def add_basic_simulation_components(ns, time_step, solver=None):
         assert time_step == 0.0
     ns.plant, ns.scene_graph = AddMultibodyPlant(config, ns.builder)
     ns.parser = Parser(ns.plant)
-    DrakeVisualizer.AddToBuilder(
-        ns.builder,
-        ns.scene_graph,
-        params=DrakeVisualizerParams(role=Role.kIllustration),
-    )
     # Disable gravity so that we do not need to worry about gravity feedforward
     # control terms.
     ns.plant.mutable_gravity_field().set_gravity_vector([0.0, 0.0, 0.0])

--- a/examples/instability/test/plant_hidden_state_test.py
+++ b/examples/instability/test/plant_hidden_state_test.py
@@ -1,0 +1,283 @@
+import copy
+import dataclasses as dc
+
+import numpy as np
+
+from pydrake.all import (
+    AddMultibodyPlant,
+    BasicVector,
+    ConnectContactResultsToDrakeVisualizer,
+    DiagramBuilder,
+    EventStatus,
+    LeafSystem,
+    MultibodyPlantConfig,
+    Parser,
+    PortDataType,
+    Simulator,
+    Value,
+)
+
+
+class ModifiedZoh(LeafSystem):
+    """
+    Modified zero-order hold that adds an initialization event.
+    e.g. https://github.com/RobotLocomotion/drake/pull/18356
+    """
+    def __init__(self, period_sec, vector_size):
+        super().__init__()
+        self.DeclareVectorInputPort("u", BasicVector(vector_size))
+        state_index = self.DeclareDiscreteState(vector_size)
+
+        def update(context, discrete_state):
+            input = self.get_input_port().Eval(context)
+            discrete_state.set_value(0, input)
+
+        self.DeclareInitializationDiscreteUpdateEvent(update)
+        self.DeclarePeriodicDiscreteUpdateEvent(
+            period_sec,
+            0.0,
+            update,
+        )
+        self.DeclareStateOutputPort("y", state_index)
+
+
+def attach_zoh(builder, output_port, dt):
+    assert dt > 0
+    assert output_port.get_data_type() != PortDataType.kAbstractValued
+    zoh = ModifiedZoh(dt, output_port.size())
+    builder.AddSystem(zoh)
+    builder.Connect(output_port, zoh.get_input_port())
+    return zoh.get_output_port()
+
+
+class LatchInitial(LeafSystem):
+    def __init__(self, vector_size):
+        super().__init__()
+        self.DeclareVectorInputPort("u", BasicVector(vector_size))
+        state_index = self.DeclareDiscreteState(vector_size)
+
+        def init(context, discrete_state):
+            input = self.get_input_port().Eval(context)
+            discrete_state.set_value(0, input)
+
+        self.DeclareInitializationDiscreteUpdateEvent(init)
+        self.DeclareStateOutputPort("y", state_index)
+
+    @staticmethod
+    def AddToBuilder(builder, output_port, input_port):
+        model_value = output_port.Allocate()
+        assert isinstance(model_value, Value[BasicVector])
+        latch = LatchInitial(model_value.get_value().size())
+        builder.AddSystem(latch)
+        builder.Connect(output_port, latch.get_input_port())
+        builder.Connect(latch.get_output_port(), input_port)
+        return latch
+
+
+def eval_port(port, parent_context):
+    context = port.get_system().GetMyContextFromRoot(parent_context)
+    return port.Eval(context)
+
+
+class SimpleController(LeafSystem):
+    def __init__(self):
+        super().__init__()
+        K = 1.0
+
+        self.x_actual = self.DeclareVectorInputPort("x_actual", size=2)
+        self.x_desired = self.DeclareVectorInputPort("x_desired", size=2)
+
+        def calc_force(context, output):
+            q_a, _ = self.x_actual.Eval(context)
+            q_d, _ = self.x_desired.Eval(context)
+            u = -K * (q_a - q_d)
+            output.set_value([u])
+
+        self.u_desired = self.DeclareVectorOutputPort(
+            "forces_output", 1, calc=calc_force,
+        )
+
+
+# Needs collision.
+MODEL_TEXT = """\
+<?xml version="1.0"?>
+<sdf version="1.7">
+  <model name="object">
+    <joint name="z_axis" type="prismatic">
+      <parent>world</parent>
+      <child>object</child>
+      <axis>0 0 1</axis>
+    </joint>
+    <link name="object">
+      <collision name="collision">
+        <geometry>
+          <box>
+            <size>1 1 1</size>
+          </box>
+        </geometry>
+      </collision>
+    </link>
+  </model>
+</sdf>
+"""
+
+
+class BadVelocity(Exception):
+    pass
+
+
+@dc.dataclass
+class Setup:
+    discrete_plant: bool
+    add_contact_viz: bool
+    add_zoh: bool
+    add_latch: bool
+    clean_plant_state: bool
+
+
+def change_one_field_at_time(base, other):
+    out = []
+    for field in dc.fields(base):
+        new = copy.deepcopy(base)
+        other_value = getattr(other, field.name)
+        setattr(new, field.name, other_value)
+        out.append(new)
+    return out
+
+
+def run(name, setup, should_fail=False):
+    print(f"[ {name} ]")
+    print(setup)
+    print()
+
+    try:
+        run_inner(setup)
+        if should_fail:
+            raise RuntimeError("Did not fail as expected!")
+        else:
+            print("Good!")
+    except BadVelocity as e:
+        if should_fail:
+            print(f"Failed as expected: {repr(e)}")
+        else:
+            raise
+    print()
+
+
+def clean_plant_state(plant, context):
+    x = plant.GetPositionsAndVelocities(context)
+    context.SetStateAndParametersFrom(plant.CreateDefaultContext())
+    plant.SetPositionsAndVelocities(context, x)
+
+
+def run_inner(setup):
+    time_step = 0.25
+    if setup.discrete_plant:
+        plant_time_step = time_step  # any non-zero time step
+    else:
+        plant_time_step = 0.0
+    builder = DiagramBuilder()
+    config = MultibodyPlantConfig(
+        time_step=plant_time_step,
+        discrete_contact_solver="sap",  # or "tamsi",
+        contact_model="hydroelastic",  # any contact model with drake#18647
+    )
+    plant, scene_graph = AddMultibodyPlant(config, builder)
+    # Disable gravity.
+    plant.mutable_gravity_field().set_gravity_vector(np.zeros(3))
+    # Add model.
+    model, = Parser(plant).AddModelsFromString(MODEL_TEXT, "sdf")
+    plant.Finalize()
+    if setup.add_contact_viz:
+        ConnectContactResultsToDrakeVisualizer(
+            builder,
+            plant,
+            scene_graph,
+            publish_period=time_step,
+        )
+
+    # Add controller.
+    controller = builder.AddSystem(SimpleController())
+    u_desired_input = plant.get_actuation_input_port(model)
+    x_actual_output = plant.get_state_output_port()
+    if setup.add_zoh:
+        u_desired_output = attach_zoh(
+            builder, controller.u_desired, time_step
+        )
+    else:
+        u_desired_output = controller.u_desired
+    builder.Connect(u_desired_output, u_desired_input)
+    builder.Connect(x_actual_output, controller.x_actual)
+    if setup.add_latch:
+        LatchInitial.AddToBuilder(
+            builder, x_actual_output, controller.x_desired
+        )
+    else:
+        builder.Connect(x_actual_output, controller.x_desired)
+
+    diagram = builder.Build()
+    diagram_context = diagram.CreateDefaultContext()
+
+    context = plant.GetMyMutableContextFromRoot(diagram_context)
+    # This must be non-default (zero) value.
+    z0 = 0.125
+    plant.SetPositions(context, [z0])
+
+    def monitor(diagram_context):
+        t = diagram_context.get_time()
+        u = eval_port(u_desired_input, diagram_context)
+        x_a = eval_port(controller.x_actual, diagram_context)
+        print(f"  t: {t}")
+        print(f"  x_a: {x_a}")
+        print(f"  u: {u}")
+        q_a, v_a = x_a
+        if v_a != 0.0:
+            raise BadVelocity()
+        return EventStatus.DidNothing()
+
+    simulator = Simulator(diagram, diagram_context)
+    simulator.set_monitor(monitor)
+
+    # Initialize twice per
+    # https://github.com/RobotLocomotion/drake/pull/18551#issuecomment-1384319905
+    for i in range(2):
+        print(f"Initialize: {i}")
+        simulator.Initialize()
+
+    print("Post-Init")
+    monitor(simulator.get_context())
+
+    if setup.clean_plant_state:
+        clean_plant_state(plant, context)
+
+    print("Run")
+    simulator.AdvanceTo(time_step)
+
+
+def main():
+    all_good = Setup(
+        discrete_plant=False,
+        add_contact_viz=False,
+        add_zoh=False,
+        add_latch=False,
+        clean_plant_state=True,
+    )
+
+    bad = Setup(
+        discrete_plant=True,
+        add_contact_viz=True,
+        add_zoh=True,
+        add_latch=True,
+        clean_plant_state=False,
+    )
+
+    # Changing any of the bad flags makes it work.
+    goods = change_one_field_at_time(bad, all_good)
+    for i, good in enumerate(goods):
+        run(f"good {i}", good)
+
+    run("bad", bad, should_fail=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Part of Anzu PR 9768 and its upstream issue
Tracked via #18236 and  #18241

Provides concrete reproduction cases as unittests:
```
bazel run //examples/instability:py/contact_instability_test
bazel run //examples/instability:py/control_instability_test
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18235)
<!-- Reviewable:end -->
