### PR TITLE
[math] Don't use march=broadwell on Ubuntu arm64 machines

### DIFF
--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -25,7 +25,6 @@ drake_cc_package_library(
         ":eigen_sparse_triplet",
         ":evenly_distributed_pts_on_sphere",
         ":fast_pose_composition_functions",
-        ":fast_pose_composition_functions_avx2_fma",
         ":geometric_transform",
         ":gradient",
         ":gray_code",
@@ -276,20 +275,32 @@ drake_cc_library(
     ],
 )
 
-# This should be compiled with Intel AVX2 and FMA enabled if possible.
-# Compiling for Broadwell (or later) gets those instructions. On macOS,
-# we opt-out of this feature (even for Apple hardware that supports it)
-# to reduce our test matrix burden for the deprecated architecture.
+# This setting governs when we'll compile with Intel AVX2 and FMA enabled.
+# Compiling for Broadwell (or later) gets those instructions.
+#
+# Note that we have runtime detection of CPU support; this flag only affects
+# what happens at build time, i.e., will the compiler support it.
+config_setting(
+    name = "build_avx2_fma",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        # On macOS, we opt-out of this feature (even for Apple hardware that
+        # supports it) to reduce our test matrix burden for the deprecated
+        # architecture.
+        "@bazel_tools//platforms:linux",
+    ],
+)
+
 drake_cc_library(
     name = "fast_pose_composition_functions_avx2_fma",
     srcs = ["fast_pose_composition_functions_avx2_fma.cc"],
     hdrs = ["fast_pose_composition_functions_avx2_fma.h"],
     copts = select({
-        "//tools/cc_toolchain:apple": [],
-        "//conditions:default": [
-            "-march=broadwell",
-        ],
+        ":build_avx2_fma": ["-march=broadwell"],
+        "//conditions:default": [],
     }),
+    internal = True,
+    visibility = ["//visibility:private"],
     deps = [],
 )
 
@@ -297,6 +308,7 @@ drake_cc_library(
     name = "fast_pose_composition_functions",
     srcs = ["fast_pose_composition_functions.cc"],
     hdrs = ["fast_pose_composition_functions.h"],
+    interface_deps = [],
     deps = [":fast_pose_composition_functions_avx2_fma"],
 )
 
@@ -555,6 +567,7 @@ drake_cc_googletest(
     name = "fast_pose_composition_functions_test",
     deps = [
         ":fast_pose_composition_functions",
+        ":fast_pose_composition_functions_avx2_fma",
         "//common:essential",
         "//common/test_utilities:eigen_matrix_compare",
     ],


### PR DESCRIPTION
This reverts commit 4a18155 (#18230) effectively re-applying 1b2f517 (#18221) but with BUILD fixes.

Marking `internal = True` is not strictly required, but seemed like a nice adjacent improvement.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18238)
<!-- Reviewable:end -->
