### PR TITLE
[math] Remove stray "fast pose composition" Doxygen details

### DIFF
--- a/math/fast_pose_composition_functions.h
+++ b/math/fast_pose_composition_functions.h
@@ -1,8 +1,10 @@
 #pragma once
 
 /** @file
-Declarations for fast, low-level functions for handling objects stored in small
-matrices with known memory layouts. Ideally these are implemented using
+Internal use only. */
+
+/* Declarations for fast, low-level functions for handling objects stored in
+small matrices with known memory layouts. Ideally these are implemented using
 platform-specific SIMD instructions for speed; however, we always provide a
 straightforward portable fallback. */
 
@@ -23,10 +25,12 @@ the class declarations:
    twelve consecutive doubles. The first nine elements comprise a 3x3
    RotationMatrix and the last three are the translation vector. */
 
+#ifndef DRAKE_DOXYGEN_CXX
 template <typename>
 class RotationMatrix;
 template <typename>
 class RigidTransform;
+#endif
 
 namespace internal {
 

--- a/math/fast_pose_composition_functions_avx2_fma.h
+++ b/math/fast_pose_composition_functions_avx2_fma.h
@@ -1,9 +1,11 @@
 #pragma once
 
 /** @file
-Declarations for fast, low-level functions for handling objects stored in small
-matrices with known memory layouts, implemented using platform-specific SIMD
-instructions for speed. */
+Internal use only. */
+
+/* Declarations for fast, low-level functions for handling objects stored in
+small matrices with known memory layouts, implemented using platform-specific
+SIMD instructions for speed. */
 
 /* N.B. Do not include any other drake headers here because this file will be
 included by a compilation unit that may have a different opinion about whether
@@ -22,10 +24,12 @@ the class declarations:
    twelve consecutive doubles. The first nine elements comprise a 3x3
    RotationMatrix and the last three are the translation vector. */
 
+#ifndef DRAKE_DOXYGEN_CXX
 template <typename>
 class RotationMatrix;
 template <typename>
 class RigidTransform;
+#endif
 
 namespace internal {
 


### PR DESCRIPTION
The forward declarations of RotationMatrix etc. show up in the index in this header, but that's wrong.

For file with no public symbols, we don't need a user-facing overview.

Buggy version: https://drake.mit.edu/doxygen_cxx/fast__pose__composition__functions__avx2__fma_8h.html

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18239)
<!-- Reviewable:end -->
