### PR TITLE
Add PrismaticSpring and its SDF parsing

### DIFF
--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -29,6 +29,7 @@
 #include "drake/multibody/tree/multibody_tree_indexes.h"
 #include "drake/multibody/tree/planar_joint.h"
 #include "drake/multibody/tree/prismatic_joint.h"
+#include "drake/multibody/tree/prismatic_spring.h"
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/multibody/tree/revolute_spring.h"
 #include "drake/multibody/tree/rigid_body.h"
@@ -801,6 +802,22 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("free_length", &Class::free_length, cls_doc.free_length.doc)
         .def("stiffness", &Class::stiffness, cls_doc.stiffness.doc)
         .def("damping", &Class::damping, cls_doc.damping.doc);
+  }
+
+  {
+    using Class = PrismaticSpring<T>;
+    constexpr auto& cls_doc = doc.PrismaticSpring;
+    auto cls = DefineTemplateClassWithDefault<Class, ForceElement<T>>(
+        m, "PrismaticSpring", param, cls_doc.doc);
+    cls  // BR
+        .def(py::init<const PrismaticJoint<T>&, double, double>(),
+            py::arg("joint"), py::arg("nominal_position"), py::arg("stiffness"),
+            cls_doc.ctor.doc)
+        .def("joint", &Class::joint, py_rvp::reference_internal,
+            cls_doc.joint.doc)
+        .def("nominal_position", &Class::nominal_position,
+            cls_doc.nominal_position.doc)
+        .def("stiffness", &Class::stiffness, cls_doc.stiffness.doc);
   }
 
   {

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -120,6 +120,7 @@ drake_cc_library(
         "planar_mobilizer.cc",
         "prismatic_joint.cc",
         "prismatic_mobilizer.cc",
+        "prismatic_spring.cc",
         "quaternion_floating_joint.cc",
         "quaternion_floating_mobilizer.cc",
         "revolute_joint.cc",
@@ -163,6 +164,7 @@ drake_cc_library(
         "planar_mobilizer.h",
         "prismatic_joint.h",
         "prismatic_mobilizer.h",
+        "prismatic_spring.h",
         "quaternion_floating_joint.h",
         "quaternion_floating_mobilizer.h",
         "revolute_joint.h",
@@ -566,6 +568,15 @@ drake_cc_googletest(
         "//multibody/plant",
         "//systems/analysis:initial_value_problem",
         "//systems/analysis:simulator",
+    ],
+)
+
+drake_cc_googletest(
+    name = "prismatic_spring_test",
+    deps = [
+        ":tree",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//systems/framework:context",
     ],
 )
 

--- a/multibody/tree/prismatic_spring.cc
+++ b/multibody/tree/prismatic_spring.cc
@@ -1,0 +1,117 @@
+#include "drake/multibody/tree/prismatic_spring.h"
+
+#include <memory>
+
+#include "drake/multibody/tree/body.h"
+#include "drake/multibody/tree/multibody_tree.h"
+
+namespace drake {
+namespace multibody {
+
+template <typename T>
+PrismaticSpring<T>::PrismaticSpring(const PrismaticJoint<T>& joint,
+                                    double nominal_position, double stiffness)
+    : PrismaticSpring(joint.model_instance(), joint.index(), nominal_position,
+                      stiffness) {}
+
+template <typename T>
+PrismaticSpring<T>::PrismaticSpring(ModelInstanceIndex model_instance,
+                                    JointIndex joint_index,
+                                    double nominal_position, double stiffness)
+    : ForceElement<T>(model_instance),
+      joint_index_(joint_index),
+      nominal_position_(nominal_position),
+      stiffness_(stiffness) {
+  DRAKE_THROW_UNLESS(stiffness >= 0);
+}
+
+template <typename T>
+const PrismaticJoint<T>& PrismaticSpring<T>::joint() const {
+  const PrismaticJoint<T>* joint = dynamic_cast<const PrismaticJoint<T>*>(
+      &this->get_parent_tree().get_joint(joint_index_));
+  DRAKE_DEMAND(joint != nullptr);
+  return *joint;
+}
+
+template <typename T>
+void PrismaticSpring<T>::DoCalcAndAddForceContribution(
+    const systems::Context<T>& context,
+    const internal::PositionKinematicsCache<T>&,
+    const internal::VelocityKinematicsCache<T>&,
+    MultibodyForces<T>* forces) const {
+  const T delta = nominal_position_ - joint().get_translation(context);
+  const T force = stiffness_ * delta;
+  joint().AddInForce(context, force, forces);
+}
+
+template <typename T>
+T PrismaticSpring<T>::CalcPotentialEnergy(
+    const systems::Context<T>& context,
+    const internal::PositionKinematicsCache<T>&) const {
+  const T delta = nominal_position_ - joint().get_translation(context);
+
+  return 0.5 * stiffness_ * delta * delta;
+}
+
+template <typename T>
+T PrismaticSpring<T>::CalcConservativePower(
+    const systems::Context<T>& context,
+    const internal::PositionKinematicsCache<T>&,
+    const internal::VelocityKinematicsCache<T>&) const {
+  // Since the potential energy is:
+  //   V = 1/2⋅k⋅(x₀-x)²
+  // The conservative power is defined as:
+  //  Pc = -d(V)/dt = -[k⋅(x₀-x)⋅(-dx/dt)] = k⋅(x₀-x)⋅dx/dt
+  // being positive when the potential energy decreases.
+  const T delta = nominal_position_ - joint().get_translation(context);
+  const T x_dot = joint().get_translation_rate(context);
+  return stiffness_ * delta * x_dot;
+}
+
+template <typename T>
+T PrismaticSpring<T>::CalcNonConservativePower(
+    const systems::Context<T>&, const internal::PositionKinematicsCache<T>&,
+    const internal::VelocityKinematicsCache<T>&) const {
+  // Purely conservative spring
+  return 0;
+}
+
+template <typename T>
+template <typename ToScalar>
+std::unique_ptr<ForceElement<ToScalar>>
+PrismaticSpring<T>::TemplatedDoCloneToScalar(
+    const internal::MultibodyTree<ToScalar>&) const {
+  // N.B. We can't use std::make_unique here since this constructor is private
+  // to std::make_unique.
+  // N.B. We use the private constructor since it doesn't rely on a valid joint
+  // reference, which might not be available during cloning.
+  std::unique_ptr<PrismaticSpring<ToScalar>> spring_clone(
+      new PrismaticSpring<ToScalar>(this->model_instance(), joint_index_,
+                                   nominal_position(), stiffness()));
+  return spring_clone;
+}
+
+template <typename T>
+std::unique_ptr<ForceElement<double>> PrismaticSpring<T>::DoCloneToScalar(
+    const internal::MultibodyTree<double>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+template <typename T>
+std::unique_ptr<ForceElement<AutoDiffXd>> PrismaticSpring<T>::DoCloneToScalar(
+    const internal::MultibodyTree<AutoDiffXd>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+template <typename T>
+std::unique_ptr<ForceElement<symbolic::Expression>>
+PrismaticSpring<T>::DoCloneToScalar(
+    const internal::MultibodyTree<symbolic::Expression>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::PrismaticSpring)

--- a/multibody/tree/prismatic_spring.h
+++ b/multibody/tree/prismatic_spring.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/multibody/tree/force_element.h"
+#include "drake/multibody/tree/prismatic_joint.h"
+
+namespace drake {
+namespace multibody {
+
+template <typename T>
+class Body;
+
+/// This %ForceElement models a linear spring attached to a PrismaticJoint
+/// and applies a force to that joint according to
+/// <pre>
+///   f = -k⋅(x - x₀)
+/// </pre>
+/// where x₀ is the nominal (zero spring force) position in meters,
+/// x is the joint position in meters, f is the spring force in Newtons and
+/// k is the spring constant in N/m.
+/// Note that joint damping exists within the PrismaticJoint itself, and
+/// so is not included here.
+///
+/// @note This is different from the LinearSpringDamper: this
+/// %PrismaticSpring is associated with a joint, while the LinearSpringDamper
+/// connects two bodies.
+/// @tparam_default_scalar
+template <typename T>
+class PrismaticSpring final : public ForceElement<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PrismaticSpring)
+
+  /// Constructor for a linear spring attached to the given prismatic joint.
+  /// @param[in] nominal_position
+  /// The nominal position of the spring x₀, in meters, at which the spring
+  /// applies no force. This is measured the same way as the generalized
+  /// position of the prismatic joint.
+  /// @param[in] stiffness
+  /// The stiffness k of the spring in N/m.
+  /// @throws std::exception if `stiffness` is (strictly) negative.
+  PrismaticSpring(
+      const PrismaticJoint<T>& joint,
+      double nominal_position,
+      double stiffness);
+
+  const PrismaticJoint<T>& joint() const;
+
+  double nominal_position() const { return nominal_position_; }
+
+  double stiffness() const { return stiffness_; }
+
+  T CalcPotentialEnergy(
+      const systems::Context<T>& context,
+      const internal::PositionKinematicsCache<T>& pc) const override;
+
+  T CalcConservativePower(
+      const systems::Context<T>& context,
+      const internal::PositionKinematicsCache<T>& pc,
+      const internal::VelocityKinematicsCache<T>& vc) const override;
+
+  T CalcNonConservativePower(
+      const systems::Context<T>& context,
+      const internal::PositionKinematicsCache<T>& pc,
+      const internal::VelocityKinematicsCache<T>& vc) const override;
+
+ private:
+  void DoCalcAndAddForceContribution(
+      const systems::Context<T>& context,
+      const internal::PositionKinematicsCache<T>& pc,
+      const internal::VelocityKinematicsCache<T>& vc,
+      MultibodyForces<T>* forces) const override;
+
+  std::unique_ptr<ForceElement<double>> DoCloneToScalar(
+      const internal::MultibodyTree<double>& tree_clone) const override;
+
+  std::unique_ptr<ForceElement<AutoDiffXd>> DoCloneToScalar(
+      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
+
+  std::unique_ptr<ForceElement<symbolic::Expression>> DoCloneToScalar(
+      const internal::MultibodyTree<symbolic::Expression>&) const override;
+
+  // Allow different specializations to access each other's private data for
+  // scalar conversion.
+  template <typename U> friend class PrismaticSpring;
+
+  // Private constructor for internal use in TemplatedDoCloneToScalar()
+  PrismaticSpring(ModelInstanceIndex model_instance, JointIndex joint_index,
+                 double nominal_position, double stiffness);
+
+  // Helper method to make a clone templated on ToScalar().
+  template <typename ToScalar>
+  std::unique_ptr<ForceElement<ToScalar>> TemplatedDoCloneToScalar(
+      const internal::MultibodyTree<ToScalar>& tree_clone) const;
+
+  const JointIndex joint_index_;
+  double nominal_position_{0};
+  double stiffness_{0};
+};
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::PrismaticSpring)

--- a/multibody/tree/test/prismatic_spring_test.cc
+++ b/multibody/tree/test/prismatic_spring_test.cc
@@ -1,0 +1,189 @@
+#include "drake/multibody/tree/prismatic_spring.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/multibody/tree/multibody_tree-inl.h"
+#include "drake/multibody/tree/multibody_tree.h"
+#include "drake/multibody/tree/multibody_tree_system.h"
+#include "drake/multibody/tree/position_kinematics_cache.h"
+#include "drake/multibody/tree/prismatic_joint.h"
+#include "drake/multibody/tree/rigid_body.h"
+#include "drake/multibody/tree/spatial_inertia.h"
+#include "drake/multibody/tree/velocity_kinematics_cache.h"
+#include "drake/multibody/tree/weld_joint.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+
+using systems::Context;
+
+namespace multibody {
+namespace internal {
+namespace {
+
+constexpr double kTolerance = std::numeric_limits<double>::epsilon();
+
+class SpringTester : public ::testing::Test {
+ public:
+  void SetUp() override {
+    // Create an empty model.
+    auto model = std::make_unique<MultibodyTree<double>>();
+
+    bodyA_ = &model->AddRigidBody("BodyA", SpatialInertia<double>());
+    bodyB_ = &model->AddRigidBody("BodyB", SpatialInertia<double>());
+
+    model->AddJoint<WeldJoint>("WeldBodyAToWorld", model->world_body(), {},
+                               *bodyA_, {},
+                               math::RigidTransform<double>::Identity());
+
+    // Allow body B to translate along the z axis.
+    joint_ = &model->AddJoint<PrismaticJoint>("joint_AB", *bodyA_,
+                                              std::nullopt, *bodyB_,
+                                              std::nullopt,
+                                              Vector3<double>::UnitZ());
+
+    // Add spring
+    spring_ = &model->AddForceElement<PrismaticSpring>(*joint_,
+                                                      nominal_position_,
+                                                      stiffness_);
+
+    // We are done adding modeling elements. Transfer tree to system and get
+    // a Context.
+    system_ = std::make_unique<MultibodyTreeSystem<double>>(std::move(model));
+    context_ = system_->CreateDefaultContext();
+
+    forces_ = std::make_unique<MultibodyForces<double>>(tree());
+  }
+
+  void SetJointState(double position, double position_rate) {
+    joint_->set_translation(context_.get(), position);
+    joint_->set_translation_rate(context_.get(), position_rate);
+  }
+
+  void CalcSpringForces() const {
+    forces_->SetZero();
+    spring_->CalcAndAddForceContribution(
+        *context_, tree().EvalPositionKinematics(*context_),
+        tree().EvalVelocityKinematics(*context_), forces_.get());
+  }
+
+  const MultibodyTree<double>& tree() const {
+    return GetInternalTree(*system_);
+  }
+
+ protected:
+  std::unique_ptr<MultibodyTreeSystem<double>> system_;
+  std::unique_ptr<Context<double>> context_;
+
+  const RigidBody<double>* bodyA_{nullptr};
+  const RigidBody<double>* bodyB_{nullptr};
+  const RigidBody<double>* bodyC_{nullptr};
+  const PrismaticJoint<double>* joint_{nullptr};
+  const PrismaticSpring<double>* spring_{nullptr};
+  std::unique_ptr<MultibodyForces<double>> forces_;
+
+  // Parameters of the case.
+  const double nominal_position_ = 1.0;  // [m]
+  const double stiffness_ = 2.0;         // [N/m]
+};
+
+TEST_F(SpringTester, ConstructionAndAccessors) {
+  EXPECT_EQ(spring_->joint().index(), joint_->index());
+  EXPECT_EQ(spring_->stiffness(), stiffness_);
+  EXPECT_EQ(spring_->nominal_position(), nominal_position_);
+}
+
+// Verify the spring applies no forces when the separation equals the
+// nominal position.
+TEST_F(SpringTester, NominalPosition) {
+  SetJointState(1.0, 0.0);
+  CalcSpringForces();
+  const VectorX<double>& generalized_forces = forces_->generalized_forces();
+  EXPECT_TRUE(CompareMatrices(generalized_forces, VectorX<double>::Zero(1),
+      kTolerance, MatrixCompareType::relative));
+
+  // Verify the potential energy is zero.
+  const double potential_energy = spring_->CalcPotentialEnergy(
+      *context_, tree().EvalPositionKinematics(*context_));
+  EXPECT_NEAR(potential_energy, 0.0, kTolerance);
+}
+
+// Verify forces computation when the spring position differs from the nominal.
+TEST_F(SpringTester, DeltaPosition) {
+  const double position = 2.0;
+  SetJointState(position, 0.0);
+  CalcSpringForces();
+  const VectorX<double>& generalized_forces = forces_->generalized_forces();
+
+  const double expected_force_magnitude =
+      stiffness_ * (nominal_position_ - position);
+  VectorX<double> expected_generalized_forces(1);
+  expected_generalized_forces << expected_force_magnitude;
+  EXPECT_TRUE(CompareMatrices(generalized_forces, expected_generalized_forces,
+                              kTolerance, MatrixCompareType::relative));
+
+  // Verify the value of the potential energy.
+  const double potential_energy_expected =
+      0.5 * stiffness_ * (position - nominal_position_) *
+      (position - nominal_position_);
+  const double potential_energy = spring_->CalcPotentialEnergy(
+      *context_, tree().EvalPositionKinematics(*context_));
+  EXPECT_NEAR(potential_energy, potential_energy_expected, kTolerance);
+
+  // Since the spring configuration is static, that is velocities are zero, we
+  // expect zero conservative and non-conservative power.
+  const double conservative_power = spring_->CalcConservativePower(
+      *context_, tree().EvalPositionKinematics(*context_),
+      tree().EvalVelocityKinematics(*context_));
+  EXPECT_NEAR(conservative_power, 0.0, kTolerance);
+  const double non_conservative_power = spring_->CalcNonConservativePower(
+      *context_, tree().EvalPositionKinematics(*context_),
+      tree().EvalVelocityKinematics(*context_));
+  EXPECT_NEAR(non_conservative_power, 0.0, kTolerance);
+}
+
+// This test verifies the computation of both conservative and non-conservative
+// powers for a configuration when they are non-zero.
+TEST_F(SpringTester, Power) {
+  const double position = 2.0;
+  const double position_dot = 1.7;
+  SetJointState(position, position_dot);
+
+  const double conservative_power = spring_->CalcConservativePower(
+      *context_, tree().EvalPositionKinematics(*context_),
+      tree().EvalVelocityKinematics(*context_));
+  const double conservative_power_expected =
+      -stiffness_ * (position - nominal_position_) * position_dot;
+  EXPECT_NEAR(conservative_power, conservative_power_expected, kTolerance);
+
+  const double non_conservative_power = spring_->CalcNonConservativePower(
+      *context_, tree().EvalPositionKinematics(*context_),
+      tree().EvalVelocityKinematics(*context_));
+  const double non_conservative_power_expected = 0;
+  // It should always be zero.
+  EXPECT_EQ(non_conservative_power, non_conservative_power_expected);
+}
+
+TEST_F(SpringTester, Clone) {
+  /* Clone the entire model, which should also clone the prismatic spring in the
+   model. */
+  auto model_clone = tree().CloneToScalar<AutoDiffXd>();
+  /* ForceElementIndex 0 corresponds to gravity and 1 corresponds to the only
+   force element we have, which is the PrismaticSpring. */
+  const auto& force_element_clone =
+      model_clone->get_force_element(ForceElementIndex(1));
+  const PrismaticSpring<AutoDiffXd>* spring_clone =
+      dynamic_cast<const PrismaticSpring<AutoDiffXd>*>(&force_element_clone);
+  ASSERT_NE(spring_clone, nullptr);
+  /* Verify all quantities are truthfully copied. */
+  EXPECT_EQ(spring_->joint().index(), spring_clone->joint().index());
+  EXPECT_EQ(spring_->stiffness(), spring_clone->stiffness());
+  EXPECT_EQ(spring_->nominal_position(), spring_clone->nominal_position());
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Following up with the conversation in the developer slack channel: https://drakedevelopers.slack.com/archives/C2WBPQDB7/p1659970165050719

I am creating this draft PR to support springs on prismatic joints and the associated SDF parsing, for use cases such as _linear Series Elastic Actuators_, _spring-loaded foot for quadrupeds_, _spring-loaded air pistons_, etc.

With this effort, we can parse a joint in SDF similar to this:
```
    <joint name="prismatic_joint" type="prismatic">
      ...
      <axis>
        ...
        <dynamics>
          <spring_reference>0.1</spring_reference>
          <spring_stiffness>1000</spring_stiffness>
        </dynamics>
      </axis>
    </joint>
```

Here are some FAQs for this implementation:
* Q: Why bother creating a new `PrismaticSpring` class instead of using `LinearSpringDamper` and adding its SDF parsing functionality?
  - A: `LinearSpringDamper` does not have a sense of "joint", and it can connect any two points on different bodies. However, SDF associates a linear spring with a joint. We do not have full information from the parsing unit `<joint>` to infer all the connection points for the construction of `LinearSpringDamper`, however we do have the information of associated joint. So we created a `PrismaticSpring` that is associated with a joint.
* Q: Why making copies of code (changing "revolute" to "prismatic"), why not using polymorphism?
  - A: The prismatic vs. revolute divergence is pretty deep in Drake, and it is not easy (requiring a big amount of work) to change it to use polymorphism/virtual functions because a lot of APIs the joint springs depend on are already joint-type specific, e.g. `PrismaticMobilizer` vs `RevoluteMobilizer`, `get_translation()` vs `get_angle()`, etc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18240)
<!-- Reviewable:end -->
