### PR TITLE
[meshcat] Add support for gamepads in Meshcat

### DIFF
--- a/bindings/pydrake/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry_py_visualizers.cc
@@ -295,6 +295,7 @@ void DoScalarIndependentDefinitions(py::module m) {
             cls_doc.DeleteSlider.doc)
         .def("DeleteAddedControls", &Class::DeleteAddedControls,
             cls_doc.DeleteAddedControls.doc)
+        .def("GetGamepad", &Class::GetGamepad, cls_doc.GetGamepad.doc)
         .def("StaticHtml", &Class::StaticHtml, cls_doc.StaticHtml.doc)
         .def("HasPath", &Class::HasPath, py::arg("path"), cls_doc.HasPath.doc);
     // Note: we intentionally do not bind the advanced methods (GetPacked...)
@@ -319,6 +320,15 @@ void DoScalarIndependentDefinitions(py::module m) {
         &orthographic_camera_cls, orthographic_camera_doc);
     DefReprUsingSerialize(&orthographic_camera_cls);
     DefCopyAndDeepCopy(&orthographic_camera_cls);
+
+    const auto& gamepad_doc = doc.Meshcat.Gamepad;
+    py::class_<Meshcat::Gamepad> gamepad_cls(
+        meshcat, "Gamepad", gamepad_doc.doc);
+    gamepad_cls  // BR
+        .def(ParamInit<Meshcat::Gamepad>());
+    DefAttributesUsingSerialize(&gamepad_cls, gamepad_doc);
+    DefReprUsingSerialize(&gamepad_cls);
+    DefCopyAndDeepCopy(&gamepad_cls);
   }
 
   // MeshcatAnimation

--- a/bindings/pydrake/test/geometry_visualizers_test.py
+++ b/bindings/pydrake/test/geometry_visualizers_test.py
@@ -163,6 +163,11 @@ class TestGeometryVisualizers(unittest.TestCase):
         meshcat.DeleteAddedControls()
         self.assertIn("data:application/octet-binary;base64",
                       meshcat.StaticHtml())
+        gamepad = meshcat.GetGamepad()
+        # Check default values (assuming no gamepad messages have arrived):
+        self.assertIsNone(gamepad.index)
+        self.assertEqual(len(gamepad.button_values), 0)
+        self.assertEqual(len(gamepad.axes), 0)
         meshcat.SetRealtimeRate(1.0)
         meshcat.Flush()
 

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -570,7 +570,7 @@ class Meshcat {
       a->Visit(DRAKE_NVP(axes));
     }
 
-    // Descriptions of these properties were adopted from
+    // Descriptions of these properties were adapted from
     // https://developer.mozilla.org/en-US/docs/Web/API/Gamepad.
 
     /** An an integer that is auto-incremented to be unique for each device

--- a/geometry/meshcat.html
+++ b/geometry/meshcat.html
@@ -36,12 +36,47 @@
       }
     }
 
+    const clamp = (num, min, max) => Math.min(Math.max(num, min), max);
+
+    // See https://beej.us/blog/data/javascript-gamepad/ for a tutorial.
+    var last_gamepad = {};
+    function handle_gamepads() {
+      let gamepads = navigator.getGamepads();
+      let gamepad = {};
+      for (let i = 0; i < gamepads.length; i++) {
+        if (gamepads[i] === null || !gamepads[i].connected) {
+          continue;
+        }
+
+        // Only send a subset of the available information. Also, the floating
+        // point values are not constant; they are constantly changing in the
+        // least significant digits even when the gamepad is untouched by the
+        // user. We truncate the floating point values to two significant
+        // digits to reject this noise.
+        gamepad = {
+          'index': gamepads[i].index, 
+          'button_values': gamepads[i].buttons.map(
+            a => clamp(Math.round(a.value * 100) / 100, 0, 1)), 
+          'axes': gamepads[i].axes.map(
+            a => clamp(Math.round(a * 100) / 100, -1, 1)),
+        };
+        break;  // Just take the first connected gamepad.
+      }
+      if (this.connection.readyState == WebSocket.OPEN && 
+        JSON.stringify(gamepad) !== JSON.stringify(last_gamepad)) {
+        this.connection.send(MeshCat.msgpack.encode(
+          { 'type': 'gamepad', 'name': '', 'gamepad': gamepad }));
+        last_gamepad = gamepad;
+      }
+    }
+
     function animate() {
       stats.begin();
       // convert realtime rate to percentage so it is easier to read
       realtimeRatePanel.update(latestRealtimeRate*100, 100);
       viewer.animate()
       stats.end();
+      handle_gamepads();
       requestAnimationFrame(animate);
     }
 

--- a/geometry/meshcat_types.h
+++ b/geometry/meshcat_types.h
@@ -464,11 +464,21 @@ struct DeleteControl {
   MSGPACK_DEFINE_MAP(type, name);
 };
 
+// This message schema is defined by gamepad dictionary populated in
+// /drake/geometry/meshcat.html::handle_gamepads().
+struct Gamepad {
+  int index{};
+  std::vector<double> button_values;
+  std::vector<double> axes;
+  MSGPACK_DEFINE_MAP(index, button_values, axes);
+};
+
 struct UserInterfaceEvent {
   std::string type;
   std::string name;
   std::optional<double> value;
-  MSGPACK_DEFINE_MAP(type, name, value);
+  std::optional<internal::Gamepad> gamepad;
+  MSGPACK_DEFINE_MAP(type, name, value, gamepad);
 };
 
 }  // namespace internal
@@ -485,7 +495,6 @@ MSGPACK_ADD_ENUM(drake::geometry::MeshcatAnimation::LoopMode);
 namespace msgpack {
 MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS) {
 namespace adaptor {
-
 
 template <typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime,
           int Options, int MaxRowsAtCompileTime, int MaxColsAtCompileTime>

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -1,6 +1,8 @@
+#include <chrono>
 #include <cstdio>
 #include <fstream>
 #include <iostream>
+#include <thread>
 
 #include "drake/common/find_resource.h"
 #include "drake/common/temp_directory.h"
@@ -403,7 +405,44 @@ Open up your browser to the URL above.
             << "Got " << meshcat->GetButtonClicks("Press t Key")
             << " clicks on \"Press t Key\".\n"
             << "Got " << meshcat->GetSliderValue("SliderTest")
-            << " value for SliderTest." << std::endl;
+            << " value for SliderTest.\n\n" << std::endl;
+
+  std::cout << "Next, we'll test gamepad (i.e., joystick) features.\n\n";
+  std::cout
+      << "While the Meshcat browser window has focus, click any button on "
+      << "your gamepad to activate gamepad support in the browser.\n\n";
+  std::cout
+      << "Then(after you press RETURN), we'll print the gamepad stats for 5 "
+      << "seconds. During that time, move the control sticks and hold some "
+      << "buttons and you should see those values reflected in the printouts. "
+      << "As long as you see varying values as you move the controls, that's "
+      << "sufficient to consider the test passing; the exact values do not "
+      << "matter.\n";
+
+  std::cout << "[Press RETURN to continue]." << std::endl;
+  std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+
+  Meshcat::Gamepad gamepad = meshcat->GetGamepad();
+  if (!gamepad.index) {
+    std::cout << "No gamepad activity detected.\n";
+  } else {
+    for (int i = 0; i < 5; ++i) {
+      gamepad = meshcat->GetGamepad();
+      std::cout << "Gamepad status:\n";
+      std::cout << "  gamepad index: " << *gamepad.index << "\n";
+      std::cout << "  buttons: ";
+      for (auto const& value : gamepad.button_values) {
+        std::cout << value << ", ";
+      }
+      std::cout << "\n";
+      std::cout << "  axes: ";
+      for (auto const& value : gamepad.axes) {
+        std::cout << value << ", ";
+      }
+      std::cout << "\n";
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+  }
 
   std::cout << "Exiting..." << std::endl;
   return 0;

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -695,6 +695,38 @@ GTEST_TEST(MeshcatTest, DuplicateMixedControls) {
       "Meshcat already has a button named button.");
 }
 
+// Properly testing Meshcat's limited support for gamepads requires human
+// input, and is done in meshcat_manual_test. This test simply ensures the
+// entry point forwards along the Javascript messages.
+GTEST_TEST(MeshcatTest, Gamepad) {
+  Meshcat meshcat;
+
+  Meshcat::Gamepad gamepad = meshcat.GetGamepad();
+  // Check the default status assuming no messages have been received:
+  EXPECT_FALSE(gamepad.index);
+  EXPECT_TRUE(gamepad.button_values.empty());
+  EXPECT_TRUE(gamepad.axes.empty());
+
+  // Clicking the button increases the count.
+  CheckWebsocketCommand(meshcat, R"""({
+      "type": "gamepad",
+      "name": "",
+      "gamepad": {
+        "index": 1, 
+        "button_values": [0, 0.5],
+        "axes": [0.1, 0.2, 0.3, 0.4]
+      }
+    })""", {}, {});
+
+  gamepad = meshcat.GetGamepad();
+  EXPECT_TRUE(gamepad.index);
+  EXPECT_EQ(gamepad.index, 1);
+  std::vector<double> expected_button_values{0, 0.5};
+  std::vector<double> expected_axes{0.1, 0.2, 0.3, 0.4};
+  EXPECT_EQ(gamepad.button_values, expected_button_values);
+  EXPECT_EQ(gamepad.axes, expected_axes);
+}
+
 GTEST_TEST(MeshcatTest, SetPropertyWebSocket) {
   Meshcat meshcat;
   meshcat.SetProperty("/Background", "visible", false);


### PR DESCRIPTION
The meshcat javascript reads the gamepad info and sends it to the meshcat server whenever a change is detected.  The c++ meshcat interface provides access to the most recent gamepad status.

This feature is provided primarily to support applications where Drake is running on a remote machine (e.g. in the cloud), and the Meshcat javascript in the browser is the only code running on the local machine which has access to the gamepad.

+@jwnimmer-tri for feature review, please.
cc @pathammer .  Would love your opinion, too, if you have time.

For background: this feature will support a richer teleop interface for students running on Deepnote.  I have a version that drives around a mobile base with mecanum wheels (from @calderpg-tri) which is incredibly compelling... at least to me!  It's a simple racing game running in Drake on deepnote.  My daughter is using that for her FIRST robotics team.  I plan to send a follow-up PR adding a version of that as a Drake tutorial on Meshcat teleop.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18243)
<!-- Reviewable:end -->
