### PR TITLE
Fix a missing paramname

### DIFF
--- a/multibody/meshcat/joint_sliders.h
+++ b/multibody/meshcat/joint_sliders.h
@@ -113,9 +113,9 @@ class JointSliders final : public systems::LeafSystem<T> {
   will return promptly, without waiting for the timeout. When no timeout is
   given, this function will block indefinitely.
 
-  @param a keycode that will be assigned to the "Stop" button.  Setting this to
-  the empty string means no keycode. See Meshcat::AddButton for details.
-  @default "Escape".
+  @param stop_button_keycode a keycode that will be assigned to the "Stop"
+  button.  Setting this to the empty string means no keycode. See
+  Meshcat::AddButton for details. @default "Escape".
 
   @returns the output of plant.GetPositions() given the most recently published
   value of the plant Context.


### PR DESCRIPTION
This also moves the default annotation for this argument to allow the subsequent return annotation to create proper output, at the cost of mangling the pydoc output of this default directive. But at least this is semi-readable and this exact problem exists with default annotations elsewhere in our pydocs and I'm looking into it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18248)
<!-- Reviewable:end -->
