### PR TITLE
Simplify the authoring_multibody_simulation tutorial

### DIFF
--- a/tutorials/authoring_multibody_simulation.ipynb
+++ b/tutorials/authoring_multibody_simulation.ipynb
@@ -19,13 +19,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Creating (or porting) a new robot/object in URDF or SDFormat\n",
+    "## Scene file formats: URDF and SDFormat\n",
     "\n",
     "The most important formats for creating multibody scenarios in Drake are the [Unified Robot Description Format (URDF)](http://wiki.ros.org/urdf) and the [Simulation Description Format (SDFormat)](http://sdformat.org/).\n",
     "\n",
     "They are both XML formats to describe robots or objects for robot simulators or visualization, and are fairly similar in syntax.\n",
     "\n",
-    "In a high-level sense, you express different components of your robot using `<link>` tags and connect them via `<joint>` tags. Each `<link>` has three major subtags, `<visual>`, `<collision>`, and `<inertial>`, for its visualization, planning/collision checking, and dynamics aspects. For `<visual>` and `<collision>`, you can either use primitives (box, sphere, cylinder, etc.) or meshes (.obj, .stl, and .dae) to represent the underlying geometry.   \n",
+    "In a high-level sense, you express different components of your robot using `<link>` tags and connect them via `<joint>` tags. Each `<link>` has three major subtags, `<visual>`, `<collision>`, and `<inertial>`, for its visualization, planning/collision checking, and dynamics aspects. For `<visual>` and `<collision>`, you can either use primitives (box, sphere, cylinder, etc.) or meshes (.obj, .stl, and .dae) to represent the underlying geometry.\n",
     "\n",
     "Here are some useful resources specifically for [URDF](http://wiki.ros.org/urdf/Tutorials/Building%20a%20Visual%20Robot%20Model%20with%20URDF%20from%20Scratch) and [SDFormat](https://classic.gazebosim.org/tutorials?tut=build_model) creation.\n",
     "\n",
@@ -33,7 +33,7 @@
     "\n",
     "While URDF is the standardized format in ROS, it's lacking many features to describe a more complex scene. For example, URDF can only specify the kinematic and dynamic properties of a single robot in isolation. It can't specify joint loops and friction properties. Additionally, it can't specify things that are not robots, such as lights, heightmaps, etc.\n",
     "\n",
-    "SDFormat was created to solve the shortcomings of URDF. SDFormat is a complete description for everything from the world level down to the robot level. The scalability makes it more suitable for sophisticated simulations.\n",
+    "SDFormat was created to solve the shortcomings of URDF. SDFormat is a complete description for everything from the world level down to the robot level. This scalability makes it more suitable for sophisticated simulations.\n",
     "\n",
     "This tutorial will primarily focus on leveraging SDFormat, but the differences in using URDF should be minimal with some syntax changes.\n",
     "\n",
@@ -60,11 +60,11 @@
     "    StartMeshcat,\n",
     ")\n",
     "from pydrake.math import RigidTransform, RollPitchYaw\n",
-    "from pydrake.multibody.meshcat import JointSliders\n",
     "from pydrake.multibody.parsing import Parser\n",
     "from pydrake.multibody.plant import AddMultibodyPlantSceneGraph\n",
     "from pydrake.systems.analysis import Simulator\n",
-    "from pydrake.systems.framework import DiagramBuilder"
+    "from pydrake.systems.framework import DiagramBuilder\n",
+    "from pydrake.visualization import ModelVisualizer"
    ]
   },
   {
@@ -73,11 +73,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create a Drake temporary directory to store files.\n",
-    "# Note: this tutorial will create two temporary files (cylinder.sdf and\n",
-    "# table_top.sdf) under `/tmp/robotlocomotion_drake_xxxxxx` directory.\n",
-    "temp_dir = temp_directory()\n",
-    "\n",
     "# Start the visualizer. The cell will output an HTTP link after the execution.\n",
     "# Click the link and a MeshCat tab should appear in your browser.\n",
     "meshcat = StartMeshcat()"
@@ -87,13 +82,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Inspecting an URDF/SDFormat model in Drake with joint sliders\n",
+    "## Viewing models\n",
     "\n",
-    "*Note: do make sure you have the MeshCat tab opened in your browser at this point since the following steps rely on that for visualization.*\n",
+    "*Make sure you have the MeshCat tab opened in your browser; the link is shown immediately above.*\n",
     "\n",
-    "To visualize the models, we provide a `model_inspector()` function. This helper function will be very useful as we start to produce our own robot description files, or port description files over from another simulator.\n",
+    "Drake provides a `ModelVisualizer` class to visualize models interactively. This class will help as we start to produce our own robot description files, or port description files over from another simulator. We'll show examples in the cells below, using a couple of pre-existing models provided by Drake.\n",
     "\n",
-    "Simply supply the model file as an argument to the `model_inspector()` function. You should be able to visualize each model in MeshCat when you click through the following code blocks."
+    "After running each of the two example cells, switch to the MeshCat tab to see the robot. Be sure to check out both the visual and collision geometries using the MeshCat control panel. Click **Open Controls** to unfold the control panel.  The geometry checkboxes are under the **Scene / drake** menu. Try adjusting the sliding bars to observe the kinematics of the robot."
    ]
   },
   {
@@ -102,68 +97,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def model_inspector(filename):\n",
-    "    meshcat.Delete()\n",
-    "    meshcat.DeleteAddedControls()\n",
-    "    builder = DiagramBuilder()\n",
-    "\n",
-    "    # Note: the time_step here is chosen arbitrarily.\n",
-    "    plant, scene_graph = AddMultibodyPlantSceneGraph(builder, time_step=0.001)\n",
-    "\n",
-    "    # Load the file into the plant/scene_graph.\n",
-    "    parser = Parser(plant)\n",
-    "    parser.AddModels(filename)\n",
-    "    plant.Finalize()\n",
-    "\n",
-    "    # Add two visualizers, one to publish the \"visual\" geometry, and one to\n",
-    "    # publish the \"collision\" geometry.\n",
-    "    visual = MeshcatVisualizer.AddToBuilder(builder, scene_graph, meshcat,\n",
-    "        MeshcatVisualizerParams(role=Role.kPerception, prefix=\"visual\"))\n",
-    "    collision = MeshcatVisualizer.AddToBuilder(\n",
-    "        builder, scene_graph, meshcat,\n",
-    "        MeshcatVisualizerParams(role=Role.kProximity, prefix=\"collision\"))\n",
-    "    # Disable the collision geometry at the start; it can be enabled by the\n",
-    "    # checkbox in the meshcat controls.\n",
-    "    meshcat.SetProperty(\"collision\", \"visible\", False)\n",
-    "\n",
-    "    # Set the timeout to a small number in test mode. Otherwise, JointSliders\n",
-    "    # will run until \"Stop JointSliders\" button is clicked.\n",
-    "    default_interactive_timeout = 1.0 if \"TEST_SRCDIR\" in os.environ else None\n",
-    "    sliders = builder.AddSystem(JointSliders(meshcat, plant))\n",
-    "    diagram = builder.Build()\n",
-    "    sliders.Run(diagram, default_interactive_timeout)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Loading an existing SDFormat in Drake\n",
-    "\n",
-    "Drake's `drake::multibody::Parser` can take SDFormat or URDF model files and instantiate the corresponding `drake::multibody::MultibodyPlant` and `drake::geometry::SceneGraph` (optionally) objects that a Drake simulation can interact with.\n",
-    "\n",
-    "To do that, we can use a Drake helper function, `FindResourceOrThrow()`, with an SDFormat file path to locate models inside Drake's repository, and use `model_inspector()` to visualize them.\n",
-    "\n",
-    "Now here are a few examples. Be sure to check out both the visual and collision geometries using the MeshCat control panel! The checkboxes are under the `Scene/drake` menu.\n",
-    "\n",
-    "### Interacting with JointSliders\n",
-    "\n",
-    "When running `model_inspector()` function, we can interactively control the joints through `JointSliders`. If any joint is specified in your robot/object, you should see various sliding bars in the control panel. Try adjusting the sliding bars and observing the motion of your robot/object.\n",
-    "\n",
-    "When you finish visualizing a model, you *NEED* to click the 'Stop JointSliders' button in the control panel to proceed to the next step. Once the button is clicked, it will disappear from the panel to indicate that the function execution ends. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Press the 'Stop JointSliders' button in MeshCat to continue.\n",
+    "# First we'll locate one of Drake's example model files, a KUKA iiwa arm.\n",
+    "# Note that FindResourceOrThrow() is only used for models included with Drake.\n",
+    "# Don't use FindResourceOrThrow for your own models.\n",
     "iiwa7_model_file = FindResourceOrThrow(\n",
     "    \"drake/manipulation/models/\"\n",
     "    \"iiwa_description/iiwa7/iiwa7_with_box_collision.sdf\")\n",
-    "model_inspector(iiwa7_model_file)"
+    "\n",
+    "# Create a model visualizer and add the robot arm.\n",
+    "visualizer = ModelVisualizer(meshcat=meshcat)\n",
+    "visualizer.AddModels(iiwa7_model_file)\n",
+    "\n",
+    "# When this notebook is run in test mode it needs to stop execution without\n",
+    "# user interaction. For interactive model visualization you won't normally\n",
+    "# need the 'loop_once' flag.\n",
+    "test_mode = True if \"TEST_SRCDIR\" in os.environ else False\n",
+    "\n",
+    "# Start the interactive visualizer.\n",
+    "# Click the \"Stop Running\" button in MeshCat when you're finished.\n",
+    "visualizer.Run(loop_once=test_mode)"
    ]
   },
   {
@@ -172,20 +124,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Press the 'Stop JointSliders' button in MeshCat to continue.\n",
+    "# Locate another one of Drake's example model files, a Schunk WSG gripper.\n",
+    "# Note that FindResourceOrThrow() is only used for models included with Drake.\n",
+    "# Don't use FindResourceOrThrow for your own models.\n",
     "schunk_wsg50_model_file = FindResourceOrThrow(\n",
     "    \"drake/manipulation/models/\"\n",
     "    \"wsg_50_description/sdf/schunk_wsg_50_with_tip.sdf\")\n",
-    "model_inspector(schunk_wsg50_model_file)"
+    "\n",
+    "# Create a NEW model visualizer and add the robot gripper.\n",
+    "visualizer = ModelVisualizer(meshcat=meshcat)\n",
+    "visualizer.AddModels(schunk_wsg50_model_file)\n",
+    "\n",
+    "# Start the interactive visualizer.\n",
+    "# Click the \"Stop Running\" button in MeshCat when you're finished.\n",
+    "visualizer.Run(loop_once=test_mode)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Creating your own simple SDFormat file\n",
-    "\n",
-    "Besides loading the existing SDFormat files in Drake, you can also create your own SDFormat file and visualize it in this tutorial.\n",
+    "## Creating custom models\n",
+    "Besides loading the existing SDFormat files in Drake, you can also create your own SDFormat model and visualize it in this tutorial. The data can be in a file or in a string.\n",
     "\n",
     "We can create a very simple SDFormat that contains one model with a single link. Inside the link, we declare the mass and inertia properties, along with a primitive cylinder for the visual and collision geometries.\n",
     "\n",
@@ -198,8 +158,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create a simple cylinder model.\n",
-    "cylinder_sdf_file = os.path.join(temp_dir, \"cylinder.sdf\")\n",
+    "# Define a simple cylinder model.\n",
     "cylinder_sdf = \"\"\"<?xml version=\"1.0\"?>\n",
     "<sdf version=\"1.7\">\n",
     "  <model name=\"cylinder\">\n",
@@ -238,11 +197,14 @@
     "    </link>\n",
     "  </model>\n",
     "</sdf>\n",
-    "\n",
-    "\"\"\"\n",
-    "\n",
-    "with open(cylinder_sdf_file, \"w\") as f:\n",
-    "    f.write(cylinder_sdf)"
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition to the `AddModels` method, the `ModelVisualizer` class provides access to its `Parser` object; you can access the full parser API to add models, e.g., from the string buffer we just created."
    ]
   },
   {
@@ -251,9 +213,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Press the 'Stop JointSliders' button in Meshcat to continue.\n",
-    "# Visualize the cylinder from a SDFormat file you just created.\n",
-    "model_inspector(cylinder_sdf_file)"
+    "# Visualize the cylinder from the SDFormat string you just defined.\n",
+    "visualizer = ModelVisualizer(meshcat=meshcat)\n",
+    "visualizer.parser().AddModelsFromString(cylinder_sdf, \"sdf\")\n",
+    "\n",
+    "# Click the \"Stop Running\" button in MeshCat when you're finished.\n",
+    "visualizer.Run(loop_once=test_mode)"
    ]
   },
   {
@@ -270,7 +235,7 @@
     "\n",
     "As collision geometry is merely an approximation for the actual shape of your model, we want the approximation to be reasonably close to reality. A rule of thumb is to completely envelop the actual shape but not inflate it too much. For example, rather than trying to cover an L-shape model with one giant box, using two boxes or cylinders can actually better represent the shape.\n",
     "\n",
-    "It's a balancing act between the fidelity of the approximation and the computation cycles saved. When in doubt, start with a rough approximation around the actual shape, and see if any undesired behavior is introduced. E.g., the robot thinks it's in a collision when it's apparently not. Identify the questionable part of the collision geometry and replace it with a more accurate approximation, and then iterate.\n",
+    "It's a balancing act between the fidelity of the approximation and the computation cycles saved. When in doubt, start with a rough approximation around the actual shape and see if any undesired behavior is introduced, e.g., the robot thinks it's in a collision when it's apparently not. Identify the questionable part of the collision geometry and replace it with a more accurate approximation, and then iterate.\n",
     "\n",
     "### Use a mesh as collision geometry\n",
     "\n",
@@ -327,7 +292,7 @@
     "\n",
     "### Create a simplified table\n",
     "\n",
-    "Similar to the cylinder example above, we create and save the XML content to an SDFormat file to use in our simulation."
+    "This is similar to the cylinder example above but here we create and save the XML content to an SDFormat file to use in our simulation."
    ]
   },
   {
@@ -336,6 +301,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Create a Drake temporary directory to store files.\n",
+    "# Note: this tutorial will create a temporary file (table_top.sdf)\n",
+    "# in the `/tmp/robotlocomotion_drake_xxxxxx` directory.\n",
+    "temp_dir = temp_directory()\n",
+    "\n",
     "# Create a table top SDFormat model.\n",
     "table_top_sdf_file = os.path.join(temp_dir, \"table_top.sdf\")\n",
     "table_top_sdf = \"\"\"<?xml version=\"1.0\"?>\n",
@@ -392,7 +362,7 @@
     "\n",
     "### Load different objects into a \"scene\"\n",
     "\n",
-    "In the `create_scene()` function, we first create a `drake::multibody::MultibodyPlant`, a `drake::multibody::SceneGraph`, and a parser.\n",
+    "In the `create_scene()` function, we first create a `pydrake.multibody.MultibodyPlant`, a `pydrake.multibody.SceneGraph`, and a `pydrake.multibody.parsing.Parser`.\n",
     "\n",
     "The parser is used to load the models into a MultibodyPlant. One thing to note in this example is we fix (or \"weld\") the table with respect to the world while treating the cracker box and the cylinder as free bodies. Once the MultibodyPlant is all set up properly, the function returns a diagram that a Drake Simulator consumes (a default context is used in this case)."
    ]
@@ -404,7 +374,7 @@
    "outputs": [],
    "source": [
     "def create_scene(sim_time_step=0.0001):\n",
-    "    # Clean up MeshCat.\n",
+    "    # Clean up the Meshcat instance.\n",
     "    meshcat.Delete()\n",
     "    meshcat.DeleteAddedControls()\n",
     "\n",
@@ -419,7 +389,7 @@
     "        \"drake/manipulation/models/ycb/sdf/003_cracker_box.sdf\")\n",
     "    parser.AddModels(cracker_box)\n",
     "    # Load the table top and the cylinder we created.\n",
-    "    parser.AddModels(cylinder_sdf_file)\n",
+    "    parser.AddModelsFromString(cylinder_sdf, \"sdf\")\n",
     "    parser.AddModels(table_top_sdf_file)\n",
     "\n",
     "    # Weld the table to the world so that it's fixed during the simulation.\n",
@@ -463,7 +433,9 @@
     "\n",
     "We have everything we need to launch the simulator! Run the following code block to start the simulation and visualize it in your MeshCat tab.\n",
     "\n",
-    "This simple simulation represents a passive system in that the objects fall purely due to gravity without other power sources. Did they do what you expect? Try adjusting the `sim_time_step` and rerun the simulation. Start with a small value and increase it gradually to see if that changes the behavior."
+    "This simple simulation represents a passive system in that the objects fall purely due to gravity without other power sources. Did they do what you expect? You can also use the **reset** and **play** buttons in the MeshCat tab to re-run the simulation.\n",
+    "\n",
+    "Try adjusting the `sim_time_step` and re-run the simulation. Start with a small value and increase it gradually to see if that changes the behavior."
    ]
   },
   {


### PR DESCRIPTION
Remove the old model_inspector function and replace with ModelVisualizer. Switch one example to use a model in a string buffer to demonstrate using parser methods. Rewrite surrouding prose to support the new usage and also for clarity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18249)
<!-- Reviewable:end -->
