### PR TITLE
[workspace] Add dependency on bazelbuild/platforms

### DIFF
--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -287,7 +287,7 @@ config_setting(
         # On macOS, we opt-out of this feature (even for Apple hardware that
         # supports it) to reduce our test matrix burden for the deprecated
         # architecture.
-        "@bazel_tools//platforms:linux",
+        "@platforms//os:linux",
     ],
 )
 

--- a/tools/cc_toolchain/BUILD.bazel
+++ b/tools/cc_toolchain/BUILD.bazel
@@ -6,12 +6,12 @@ package(default_visibility = ["//visibility:public"])
 
 config_setting(
     name = "apple",
-    constraint_values = ["@bazel_tools//platforms:osx"],
+    constraint_values = ["@platforms//os:osx"],
 )
 
 config_setting(
     name = "apple_debug",
-    constraint_values = ["@bazel_tools//platforms:osx"],
+    constraint_values = ["@platforms//os:osx"],
     values = {"compilation_mode": "dbg"},
 )
 
@@ -22,7 +22,7 @@ config_setting(
 
 config_setting(
     name = "linux",
-    constraint_values = ["@bazel_tools//platforms:linux"],
+    constraint_values = ["@platforms//os:linux"],
 )
 
 filegroup(

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -73,6 +73,7 @@ load("@drake//tools/workspace/osqp:repository.bzl", "osqp_repository")
 load("@drake//tools/workspace/petsc:repository.bzl", "petsc_repository")
 load("@drake//tools/workspace/picosat:repository.bzl", "picosat_repository")
 load("@drake//tools/workspace/picosha2:repository.bzl", "picosha2_repository")
+load("@drake//tools/workspace/platforms:repository.bzl", "platforms_repository")  # noqa
 load("@drake//tools/workspace/pybind11:repository.bzl", "pybind11_repository")
 load("@drake//tools/workspace/pycodestyle:repository.bzl", "pycodestyle_repository")  # noqa
 load("@drake//tools/workspace/python:repository.bzl", "python_repository")
@@ -268,6 +269,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         picosat_repository(name = "picosat", mirrors = mirrors)
     if "picosha2" not in excludes:
         picosha2_repository(name = "picosha2", mirrors = mirrors)
+    if "platforms" not in excludes:
+        platforms_repository(name = "platforms", mirrors = mirrors)
     if "pybind11" not in excludes:
         pybind11_repository(name = "pybind11", mirrors = mirrors)
     if "pycodestyle" not in excludes:

--- a/tools/workspace/dreal/patches/platforms.patch
+++ b/tools/workspace/dreal/patches/platforms.patch
@@ -1,0 +1,22 @@
+Use the Drake-compatible spelling of platforms (for Bazel 6.0)
+
+--- tools/BUILD
++++ tools/BUILD
+@@ -31,7 +31,7 @@
+ 
+ config_setting(
+     name = "apple",
+-    constraint_values = ["@bazel_tools//platforms:osx"],
++    constraint_values = ["@platforms//os:osx"],
+     visibility = ["//visibility:public"],
+ )
+ 
+@@ -58,7 +58,7 @@
+ 
+ config_setting(
+     name = "linux",
+-    constraint_values = ["@bazel_tools//platforms:linux"],
++    constraint_values = ["@platforms//os:linux"],
+     visibility = ["//visibility:public"],
+ )
+ 

--- a/tools/workspace/dreal/repository.bzl
+++ b/tools/workspace/dreal/repository.bzl
@@ -16,6 +16,7 @@ def dreal_repository(
         mirrors = mirrors,
         patches = [
             ":patches/ibex_2.8.6.patch",
+            ":patches/platforms.patch",
             ":patches/pull283.patch",
             ":patches/warnings.patch",
         ],

--- a/tools/workspace/platforms/BUILD.bazel
+++ b/tools/workspace/platforms/BUILD.bazel
@@ -1,0 +1,5 @@
+# -*- python -*-
+
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/workspace/platforms/repository.bzl
+++ b/tools/workspace/platforms/repository.bzl
@@ -1,0 +1,18 @@
+# -*- python -*-
+
+load("@drake//tools/workspace:github.bzl", "github_archive")
+
+# Note that we do NOT install a LICENSE file as part of the Drake install
+# because this repository is required only when building and testing with
+# Bazel.
+
+def platforms_repository(
+        name,
+        mirrors = None):
+    github_archive(
+        name = name,
+        repository = "bazelbuild/platforms",  # License: Apache-2.0
+        commit = "0.0.6",
+        sha256 = "1626b708a06989c2365f3101c9c937153e03ee39faaaeab98a2c204e9d015a0d",  # noqa
+        mirrors = mirrors,
+    )


### PR DESCRIPTION
Bazel 6.0 will remove the built-in copy, requiring users to BYO.

See https://github.com/bazelbuild/bazel/issues/8622 for details and current https://github.com/RobotLocomotion/drake/pull/18246 CI for sample failure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18250)
<!-- Reviewable:end -->
