### PR TITLE
[lint] Tidy up genquery input

### DIFF
--- a/tools/lint/library_lint.bzl
+++ b/tools/lint/library_lint.bzl
@@ -96,7 +96,7 @@ def library_lint(
 
     # Find libraries that are deps of the package_library but shouldn't be.
     extra_deps_expression = "deps({}, 1) except ({}) except {}".format(
-        package_name,
+        package_name + ":" + short_package_name,
         correct_deps_expression,
         # This is fine (it's a dependency of our copt select() statement).
         "//tools:drake_werror",
@@ -107,7 +107,7 @@ def library_lint(
     # positives from this report.
     missing_deps_expression = "({}) except deps({}, 1) ".format(
         correct_deps_expression,
-        package_name,
+        package_name + ":" + short_package_name,
     )
 
     # If there was a package_library rule, ensure its deps are comprehensive.


### PR DESCRIPTION
Our genquery [scope](https://github.com/RobotLocomotion/drake/blob/b23faa4e542d8cf7ddd4c0abde29893ad1cf41f5/tools/lint/library_lint.bzl#L74-L79) opts-in to the `//foo/bar:bar` library spelling, not the `//foo/bar` abbreviation; this is flagged as an error in Bazel 6.0. Use the `//foo/bar:bar` spelling to avoid the error.

Example failure prior to this PR [here](https://drake-jenkins.csail.mit.edu/job/linux-focal-unprovisioned-gcc-bazel-experimental-release/190/).

Example success with this PR [here](https://drake-jenkins.csail.mit.edu/job/linux-focal-unprovisioned-gcc-bazel-experimental-release/191/).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18253)
<!-- Reviewable:end -->
