### PR TITLE
Update DeclareAbstractState() doc and py kwarg names

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -942,7 +942,7 @@ Note: The above is for the C++ documentation. For Python, use
         .def("DeclareAbstractState",
             py::overload_cast<const AbstractValue&>(
                 &LeafSystemPublic::DeclareAbstractState),
-            doc.LeafSystem.DeclareAbstractState.doc);
+            py::arg("model_value"), doc.LeafSystem.DeclareAbstractState.doc);
 
     DefineTemplateClassWithDefault<Diagram<T>, PyDiagram, System<T>>(
         m, "Diagram", GetPyParam<T>(), doc.Diagram.doc)

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -211,12 +211,12 @@ class TestCustom(unittest.TestCase):
 
     def test_leaf_system_per_item_tickets(self):
         dut = LeafSystem()
-        dut.DeclareAbstractParameter(AbstractValue.Make(1))
-        dut.DeclareAbstractState(AbstractValue.Make(1))
+        dut.DeclareAbstractParameter(model_value=AbstractValue.Make(1))
+        dut.DeclareAbstractState(model_value=AbstractValue.Make(1))
         dut.DeclareDiscreteState(1)
         dut.DeclareVectorInputPort("u0", BasicVector(1))
         self.assertEqual(dut.DeclareVectorInputPort("u1", 2).size(), 2)
-        dut.DeclareNumericParameter(BasicVector(1))
+        dut.DeclareNumericParameter(model_vector=BasicVector(1))
         for func, arg in [
                 (dut.abstract_parameter_ticket, AbstractParameterIndex(0)),
                 (dut.abstract_state_ticket, AbstractStateIndex(0)),
@@ -695,9 +695,9 @@ class TestCustom(unittest.TestCase):
                 LeafSystem.__init__(self)
                 self.DeclareContinuousState(1)
                 self.DeclareDiscreteState(2)
-                self.DeclareAbstractState(model_value.Clone())
-                self.DeclareAbstractParameter(model_value.Clone())
-                self.DeclareNumericParameter(model_vector.Clone())
+                self.DeclareAbstractState(model_value=model_value.Clone())
+                self.DeclareAbstractParameter(model_value=model_value.Clone())
+                self.DeclareNumericParameter(model_vector=model_vector.Clone())
 
         system = TrivialSystem()
         context = system.CreateDefaultContext()

--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -611,9 +611,9 @@ DiscreteStateIndex LeafSystem<T>::DeclareDiscreteState(
 
 template <typename T>
 AbstractStateIndex LeafSystem<T>::DeclareAbstractState(
-    const AbstractValue& abstract_state) {
+    const AbstractValue& model_value) {
   const AbstractStateIndex index(model_abstract_states_.size());
-  model_abstract_states_.AddModel(index, abstract_state.Clone());
+  model_abstract_states_.AddModel(index, model_value.Clone());
   this->AddAbstractState(index);
   return index;
 }

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -68,8 +68,6 @@ class LeafSystem : public System<T> {
 
   std::unique_ptr<ContextBase> DoAllocateContext() const final;
 
-  // TODO(sherm/russt): Initialize the discrete state from the model vector
-  // pending resolution of #7058.
   /** Default implementation: sets all continuous state to the model vector
   given in DeclareContinuousState (or zero if no model vector was given) and
   discrete states to zero. Overrides must not change the number of state
@@ -1123,11 +1121,15 @@ class LeafSystem : public System<T> {
   variable index is returned. */
   //@{
 
-  /** Declares an abstract state.
-  @param abstract_state The abstract state model value.
-  @return index of the declared abstract state. */
+  /** Declares an abstract state variable and provides a model value
+  for it. A Context obtained with CreateDefaultContext() will contain this
+  abstract state variable initially set to a clone of the `model_value`
+  given here. The actual concrete type is always preserved.
+
+  @param model_value The abstract state model value to be cloned as needed.
+  @returns index of the declared abstract state variable. */
   AbstractStateIndex DeclareAbstractState(
-      const AbstractValue& abstract_state);
+      const AbstractValue& model_value);
   //@}
 
 


### PR DESCRIPTION
Clarifies documentation for DeclareAbstractState(), including argument name (and matching Pydrake kwarg). Improves consistency somewhat among DeclareAbstract{State,Parameter}() and DeclareNumericParameter().

Deprecation conveniently not required because the previous python binding didn't specify a kwarg at all.

Also removes a stale TODO.

Resolves #18065

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18254)
<!-- Reviewable:end -->
