### PR TITLE
parsing_doxygen: Clarify that SDFormat uses screw_thread_pitch

### DIFF
--- a/multibody/parsing/parsing_doxygen.h
+++ b/multibody/parsing/parsing_doxygen.h
@@ -713,7 +713,8 @@ object. Units are kg⋅m² for revolute joints, and kg for prismatic joints.
 
 @subsection tag_drake_screw_thread_pitch drake:screw_thread_pitch
 
-- SDFormat path: `//model/joint/drake:screw_thread_pitch`
+- SDFormat path: `//model/joint/screw_thread_pitch` <br/>
+  Note this is **not** the custom attribute.
 - URDF path: `/robot/joint/actuator/drake:screw_thread_pitch@value`
 - Syntax: Non-zero floating point value.
 


### PR DESCRIPTION
It does not use the custom drake:screw_thread_pitch

Minor hotfix for #18191

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18255)
<!-- Reviewable:end -->
