### PR TITLE
[setup] Remove errors on Ubuntu arm64

### DIFF
--- a/setup/ubuntu/binary_distribution/packages-focal.txt
+++ b/setup/ubuntu/binary_distribution/packages-focal.txt
@@ -36,7 +36,6 @@ libqt5core5a
 libqt5gui5
 libqt5printsupport5
 libqt5widgets5
-libquadmath0
 libspdlog-dev
 libsqlite3-0
 libtheora0

--- a/setup/ubuntu/binary_distribution/packages-jammy.txt
+++ b/setup/ubuntu/binary_distribution/packages-jammy.txt
@@ -36,7 +36,6 @@ libqt5core5a
 libqt5gui5
 libqt5printsupport5
 libqt5widgets5
-libquadmath0
 libspdlog-dev
 libsqlite3-0
 libtheora0

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -175,7 +175,10 @@ if [[ $(arch) = "aarch64" ]]; then
   if [[ "$(which bazel)" ]]; then
     echo "Bazel is already installed." >&2
   else
-    echo "You need to manually install Bazel somehow; see https://bazel.build/ for details." >&2
+    echo
+    "WARNING: On Ubuntu arm64 systems, Drake's install_prereqs does not
+    automatically install Bazel on your behalf. You will need to install
+    Bazel yourself. See https://bazel.build for instructions." >&2
   fi
 else
   dpkg_install_from_wget \

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -175,10 +175,9 @@ if [[ $(arch) = "aarch64" ]]; then
   if [[ "$(which bazel)" ]]; then
     echo "Bazel is already installed." >&2
   else
-    echo
-    "WARNING: On Ubuntu arm64 systems, Drake's install_prereqs does not
-    automatically install Bazel on your behalf. You will need to install
-    Bazel yourself. See https://bazel.build for instructions." >&2
+    echo "WARNING: On Ubuntu arm64 systems, Drake's install_prereqs does not" \
+    "automatically install Bazel on your behalf. You will need to install" \
+    "Bazel yourself. See https://bazel.build for instructions." >&2
   fi
 else
   dpkg_install_from_wget \

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -170,18 +170,17 @@ EOF
 
 # Install bazel.
 # Keep this version number in sync with the drake/.bazeliskrc version number.
-
 if [[ $(arch) = "aarch64" ]]; then
-  # Check if bazel is already installed
+  # Check if bazel is already installed.
   if [[ "$(which bazel)" ]]; then
     echo "Bazel is already installed"
   else
     echo "You need to manually install Bazel somehow; \
     see https://bazel.build/ for details."
   fi
-else 
-dpkg_install_from_wget \
-  bazel 5.3.1 \
-  https://releases.bazel.build/5.3.1/release/bazel_5.3.1-linux-x86_64.deb \
-  1e939b50d90f68d30fa4f3c12dfdf31429b83ddd8076c622429854f64253c23d
+else
+  dpkg_install_from_wget \
+    bazel 5.3.1 \
+    https://releases.bazel.build/5.3.1/release/bazel_5.3.1-linux-x86_64.deb \
+    1e939b50d90f68d30fa4f3c12dfdf31429b83ddd8076c622429854f64253c23d
 fi

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -173,10 +173,9 @@ EOF
 if [[ $(arch) = "aarch64" ]]; then
   # Check if bazel is already installed.
   if [[ "$(which bazel)" ]]; then
-    echo "Bazel is already installed"
+    echo "Bazel is already installed." >&2
   else
-    echo "You need to manually install Bazel somehow; \
-    see https://bazel.build/ for details."
+    echo "You need to manually install Bazel somehow; see https://bazel.build/ for details." >&2
   fi
 else
   dpkg_install_from_wget \

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -172,10 +172,13 @@ EOF
 # Keep this version number in sync with the drake/.bazeliskrc version number.
 
 if [[ $(arch) = "aarch64" ]]; then
-  dpkg_install_from_wget \
-  bazel 5.3.1 \
-  https://releases.bazel.build/5.3.1/release/bazel_5.3.1-linux-arm64.deb \
-  1e939b50d90f68d30fa4f3c12dfdf31429b83ddd8076c622429854f64253c23d
+  # Check if bazel is already installed
+  if [[ "$(which bazel)" ]]; then
+    echo "Bazel is already installed"
+  else
+    echo "You need to manually install Bazel somehow; \
+    see https://bazel.build/ for details."
+  fi
 else 
 dpkg_install_from_wget \
   bazel 5.3.1 \

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -168,8 +168,17 @@ zlib1g-dev
 EOF
 )
 
+# Install bazel.
 # Keep this version number in sync with the drake/.bazeliskrc version number.
+
+if [[ $(arch) = "aarch64" ]]; then
+  dpkg_install_from_wget \
+  bazel 5.3.1 \
+  https://releases.bazel.build/5.3.1/release/bazel_5.3.1-linux-arm64.deb \
+  1e939b50d90f68d30fa4f3c12dfdf31429b83ddd8076c622429854f64253c23d
+else 
 dpkg_install_from_wget \
   bazel 5.3.1 \
   https://releases.bazel.build/5.3.1/release/bazel_5.3.1-linux-x86_64.deb \
   1e939b50d90f68d30fa4f3c12dfdf31429b83ddd8076c622429854f64253c23d
+fi


### PR DESCRIPTION
Relates to #13514. Removes `libquadmath0` as a package since it gets pulled in via `libgfortran5` anyway and is redundant. 
 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18261)
<!-- Reviewable:end -->
