### PR TITLE
[tools] Removes pybind (libclang setup) errors on arm64

### DIFF
--- a/tools/workspace/pybind11/libclang_setup.py
+++ b/tools/workspace/pybind11/libclang_setup.py
@@ -37,7 +37,8 @@ def add_library_paths(parameters=None):
                 parameters.append('-isysroot')
                 parameters.append(sdkroot)
     elif platform.system() == 'Linux':
-        library_file = '/usr/lib/x86_64-linux-gnu/libclang-12.so'
+        arch = platform.machine()
+        library_file = f'/usr/lib/{arch}-linux-gnu/libclang-12.so'
     if not os.path.exists(library_file):
         raise RuntimeError(f'Library file {library_file} does NOT exist')
     cindex.Config.set_library_file(library_file)


### PR DESCRIPTION
Sets the arch-specific path for libclang instead of a blanket `x86_64` path. Relates to #13514

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18264)
<!-- Reviewable:end -->
