### PR TITLE
Implements TamsiDriver

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -99,6 +99,7 @@ drake_cc_library(
         "multibody_plant.cc",
         "physical_model.cc",
         "sap_driver.cc",
+        "tamsi_driver.cc",
     ],
     hdrs = [
         "compliant_contact_manager.h",
@@ -112,6 +113,7 @@ drake_cc_library(
         "physical_model.h",
         "sap_driver.h",
         "scalar_convertible_component.h",
+        "tamsi_driver.h",
     ],
     visibility = ["//visibility:private"],
     deps = [
@@ -484,6 +486,16 @@ drake_cc_googletest(
         ":compliant_contact_manager_tester",
         ":plant",
         "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "tamsi_driver_test",
+    data = ["test/square_surface.obj"],
+    deps = [
+        ":compliant_contact_manager_tester",
+        ":plant",
+        "//common:find_resource",
     ],
 )
 

--- a/multibody/plant/compliant_contact_manager.h
+++ b/multibody/plant/compliant_contact_manager.h
@@ -26,6 +26,8 @@ namespace internal {
 // Forward declaration.
 template <typename>
 class SapDriver;
+template <typename>
+class TamsiDriver;
 
 // To compute accelerations due to external forces (in particular non-contact
 // forces), we pack forces, ABA cache and accelerations into a single struct
@@ -94,6 +96,7 @@ class CompliantContactManager final
   // with tighter functionality. For instance, a class that takes care of
   // getting proximity properties and creating DiscreteContactPairs.
   friend class SapDriver<T>;
+  friend class TamsiDriver<T>;
 
   // Struct used to conglomerate the indexes of cache entries declared by the
   // manager.

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -151,6 +151,13 @@ DiscreteUpdateManager<T>::coupler_constraints_specs() const {
       T>::coupler_constraints_specs(*plant_);
 }
 
+template <typename T>
+const std::vector<int>& DiscreteUpdateManager<T>::EvalJointLockingIndices(
+    const systems::Context<T>& context) const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<
+      T>::EvalJointLockingIndices(plant(), context);
+}
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -224,6 +224,9 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
 
   const std::vector<internal::CouplerConstraintSpecs<T>>&
   coupler_constraints_specs() const;
+
+  const std::vector<int>& EvalJointLockingIndices(
+      const systems::Context<T>& context) const;
   /* @} */
 
   /* Concrete DiscreteUpdateManagers must override these NVI Calc methods to

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1862,6 +1862,13 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       double v_stiction = MultibodyPlantConfig{}.stiction_tolerance) {
     friction_model_.set_stiction_tolerance(v_stiction);
   }
+
+  /// @returns the stiction tolerance parameter, in m/s.
+  /// @see set_stiction_tolerance.
+  double stiction_tolerance() const {
+    return friction_model_.stiction_tolerance();
+  }
+
   /// @} <!-- Contact modeling -->
 
   /// @anchor mbp_state_accessors_and_mutators

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -108,6 +108,11 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
   coupler_constraints_specs(const MultibodyPlant<T>& plant) {
     return plant.coupler_constraints_specs_;
   }
+
+  static const std::vector<int>& EvalJointLockingIndices(
+      const MultibodyPlant<T>& plant, const systems::Context<T>& context) {
+    return plant.EvalJointLockingIndices(context);
+  }
 };
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/plant/tamsi_driver.cc
+++ b/multibody/plant/tamsi_driver.cc
@@ -1,0 +1,273 @@
+#include "drake/multibody/plant/tamsi_driver.h"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/plant/compliant_contact_manager.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/slicing_and_indexing.h"
+#include "drake/multibody/plant/tamsi_solver.h"
+
+using drake::multibody::contact_solvers::internal::ContactSolverResults;
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+template <typename T>
+TamsiDriver<T>::TamsiDriver(const CompliantContactManager<T>* manager)
+    : manager_(manager) {
+  DRAKE_DEMAND(manager != nullptr);
+}
+
+template <typename T>
+void TamsiDriver<T>::CalcContactSolverResults(
+    const systems::Context<T>& context,
+    contact_solvers::internal::ContactSolverResults<T>* results) const {
+  // Assert this method was called on a context storing discrete state.
+  plant().ValidateContext(context);
+  DRAKE_ASSERT(context.num_continuous_states() == 0);
+  // Only discrete state updates for rigid bodies is supported.
+  DRAKE_ASSERT(context.num_discrete_state_groups() == 1);
+
+  const int nq = plant().num_positions();
+  const int nv = plant().num_velocities();
+
+  // Quick exit if there are no moving objects.
+  if (nv == 0) return;
+
+  // Get the system state as raw Eigen vectors
+  // (solution at the previous time step).
+  auto x0 = context.get_discrete_state(0).get_value();
+  VectorX<T> q0 = x0.topRows(nq);
+  VectorX<T> v0 = x0.bottomRows(nv);
+
+  // Mass matrix.
+  MatrixX<T> M0(nv, nv);
+  plant().CalcMassMatrix(context, &M0);
+
+  // Forces at the previous time step.
+  MultibodyForces<T> forces0(plant());
+
+  manager().CalcNonContactForces(context, &forces0);
+
+  // Workspace for inverse dynamics:
+  // Bodies' accelerations, ordered by BodyNodeIndex.
+  std::vector<SpatialAcceleration<T>> A_WB_array(plant().num_bodies());
+  // Generalized accelerations.
+  VectorX<T> vdot = VectorX<T>::Zero(nv);
+  // Body forces (alias to forces0).
+  std::vector<SpatialForce<T>>& F_BBo_W_array = forces0.mutable_body_forces();
+
+  // With vdot = 0, this computes:
+  //   -tau = C(q, v)v - tau_app - ∑ J_WBᵀ(q) Fapp_Bo_W.
+  VectorX<T>& minus_tau = forces0.mutable_generalized_forces();
+  manager().internal_tree().CalcInverseDynamics(
+      context, vdot, F_BBo_W_array, minus_tau, &A_WB_array,
+      &F_BBo_W_array, /* Note: these arrays get overwritten on output. */
+      &minus_tau);
+
+  // Compute all contact pairs, including both penetration pairs and quadrature
+  // pairs for discrete hydroelastic.
+  const std::vector<internal::DiscreteContactPair<T>>& contact_pairs =
+      manager().EvalDiscreteContactPairs(context);
+  const int num_contacts = contact_pairs.size();
+
+  // Compute normal and tangential velocity Jacobians at t0.
+  const internal::ContactJacobians<T>& contact_jacobians =
+      manager().EvalContactJacobians(context);
+
+  // Get friction coefficient into a single vector.
+  VectorX<T> mu(num_contacts);
+  std::transform(contact_pairs.begin(), contact_pairs.end(), mu.data(),
+                 [](const internal::DiscreteContactPair<T>& pair) {
+                   return pair.friction_coefficient;
+                 });
+
+  // Fill in data as required by our discrete solver.
+  VectorX<T> fn0(num_contacts);
+  VectorX<T> stiffness(num_contacts);
+  VectorX<T> damping(num_contacts);
+  VectorX<T> phi0(num_contacts);
+  for (int i = 0; i < num_contacts; ++i) {
+    fn0[i] = contact_pairs[i].fn0;
+    stiffness[i] = contact_pairs[i].stiffness;
+    damping[i] = contact_pairs[i].damping;
+    phi0[i] = contact_pairs[i].phi0;
+  }
+
+  // Joint locking: quick exit if everything is locked.
+  const auto& indices = manager().EvalJointLockingIndices(context);
+  if (indices.empty()) {
+    // Everything is locked! Return a result that indicates no velocity, but
+    // reports normal forces.
+    results->Resize(nv, num_contacts);
+    results->v_next.setZero();
+    results->fn = fn0;
+    results->ft.setZero();
+    results->vn.setZero();
+    results->vt.setZero();
+    results->tau_contact = contact_jacobians.Jn.transpose() * results->fn;
+    return;
+  }
+
+  // Joint locking: reduce solver inputs.
+  MatrixX<T> M0_unlocked = SelectRowsCols(M0, indices);
+  VectorX<T> minus_tau_unlocked = SelectRows(minus_tau, indices);
+  MatrixX<T> Jn_unlocked = SelectCols(contact_jacobians.Jn, indices);
+  MatrixX<T> Jt_unlocked = SelectCols(contact_jacobians.Jt, indices);
+  MatrixX<T> Jc_unlocked = SelectCols(contact_jacobians.Jc, indices);
+
+  VectorX<T> v0_unlocked = SelectRows(v0, indices);
+
+  contact_solvers::internal::ContactSolverResults<T> results_unlocked;
+  results_unlocked.Resize(indices.size(), num_contacts);
+
+  TamsiSolver<T> tamsi_solver(indices.size());
+  if (tamsi_solver.get_solver_parameters().stiction_tolerance !=
+      plant().stiction_tolerance()) {
+    // Set the stiction tolerance according to the values set by users with
+    // set_stiction_tolerance().
+    TamsiSolverParameters solver_parameters;
+    solver_parameters.stiction_tolerance = plant().stiction_tolerance();
+    tamsi_solver.set_solver_parameters(solver_parameters);
+  }
+
+  CallTamsiSolver(&tamsi_solver, context.get_time(), v0_unlocked, M0_unlocked,
+                  minus_tau_unlocked, fn0, Jn_unlocked, Jt_unlocked, stiffness,
+                  damping, mu, &results_unlocked);
+
+  // Joint locking: expand reduced outputs.
+  results->v_next =
+      ExpandRows(results_unlocked.v_next, plant().num_velocities(), indices);
+  results->tau_contact =
+      contact_jacobians.Jn.transpose() * results_unlocked.fn +
+      contact_jacobians.Jt.transpose() * results_unlocked.ft;
+
+  results->fn = results_unlocked.fn;
+  results->ft = results_unlocked.ft;
+  results->vn = results_unlocked.vn;
+  results->vt = results_unlocked.vt;
+}
+
+template <typename T>
+TamsiSolverResult TamsiDriver<T>::SolveUsingSubStepping(
+    TamsiSolver<T>* tamsi_solver, int num_substeps, const MatrixX<T>& M0,
+    const MatrixX<T>& Jn, const MatrixX<T>& Jt, const VectorX<T>& minus_tau,
+    const VectorX<T>& stiffness, const VectorX<T>& damping,
+    const VectorX<T>& mu, const VectorX<T>& v0, const VectorX<T>& fn0) const {
+  const double dt = plant().time_step();  // just a shorter alias.
+  const double dt_substep = dt / num_substeps;
+  VectorX<T> v0_substep = v0;
+  VectorX<T> fn0_substep = fn0;
+
+  // Initialize info to an unsuccessful result.
+  TamsiSolverResult info{TamsiSolverResult::kMaxIterationsReached};
+
+  for (int substep = 0; substep < num_substeps; ++substep) {
+    // Discrete update before applying friction forces.
+    // We denote this state x* = [q*, v*], the "star" state.
+    // Generalized momentum "star", before contact forces are applied.
+    VectorX<T> p_star_substep = M0 * v0_substep - dt_substep * minus_tau;
+
+    // Update the data.
+    tamsi_solver->SetTwoWayCoupledProblemData(&M0, &Jn, &Jt, &p_star_substep,
+                                              &fn0_substep, &stiffness,
+                                              &damping, &mu);
+
+    info = tamsi_solver->SolveWithGuess(dt_substep, v0_substep);
+
+    // Break the sub-stepping loop on failure and return the info result.
+    if (info != TamsiSolverResult::kSuccess) break;
+
+    // Update previous time step to new solution.
+    v0_substep = tamsi_solver->get_generalized_velocities();
+
+    // TAMSI updates each normal force according to:
+    //   fₙ = (1 − d vₙ)₊ (fₙ₀ − h k vₙ)₊
+    // using the last computed normal velocity vₙ and we use the shorthand
+    // notation  h = dt_substep in this scope.
+    // The input fₙ₀ to the solver is the undamped (no dissipation) term only.
+    // We must update fₙ₀ for each substep accordingly, i.e:
+    //   fₙ₀(next) = (fₙ₀(previous) − h k vₙ(next))₊
+    const auto vn_substep = tamsi_solver->get_normal_velocities();
+    fn0_substep = fn0_substep.array() -
+                  dt_substep * stiffness.array() * vn_substep.array();
+    fn0_substep = fn0_substep.cwiseMax(T(0.0));
+  }
+
+  return info;
+}
+
+template <typename T>
+void TamsiDriver<T>::CallTamsiSolver(
+    TamsiSolver<T>* tamsi_solver, const T& time0, const VectorX<T>& v0,
+    const MatrixX<T>& M0, const VectorX<T>& minus_tau, const VectorX<T>& fn0,
+    const MatrixX<T>& Jn, const MatrixX<T>& Jt, const VectorX<T>& stiffness,
+    const VectorX<T>& damping, const VectorX<T>& mu,
+    contact_solvers::internal::ContactSolverResults<T>* results) const {
+  // Solve for v and the contact forces.
+  TamsiSolverResult info{TamsiSolverResult::kMaxIterationsReached};
+
+  TamsiSolverParameters params = tamsi_solver->get_solver_parameters();
+  // A nicely converged NR iteration should not take more than 20 iterations.
+  // Otherwise we attempt a smaller time step.
+  params.max_iterations = 20;
+  tamsi_solver->set_solver_parameters(params);
+
+  // We attempt to compute the update during the time interval dt using a
+  // progressively larger number of sub-steps (i.e each using a smaller time
+  // step than in the previous attempt). This loop breaks on the first
+  // successful attempt.
+  // We only allow a maximum number of trials. If the solver is unsuccessful
+  // in this number of trials, the user should probably decrease the discrete
+  // update time step dt or evaluate the validity of the model.
+  const int kNumMaxSubTimeSteps = 20;
+  int num_substeps = 0;
+  do {
+    ++num_substeps;
+    info = SolveUsingSubStepping(tamsi_solver, num_substeps, M0, Jn, Jt,
+                                 minus_tau, stiffness, damping, mu, v0, fn0);
+  } while (info != TamsiSolverResult::kSuccess &&
+           num_substeps < kNumMaxSubTimeSteps);
+
+  if (info != TamsiSolverResult::kSuccess) {
+    const std::string msg = fmt::format(
+        "MultibodyPlant's discrete update solver failed to converge at "
+        "simulation time = {} with discrete update period = {}. "
+        "This usually means that the plant's discrete update period is too "
+        "large to resolve the system's dynamics for the given simulation "
+        "conditions. This is often the case during abrupt collisions or during "
+        "complex and fast changing contact configurations. Another common "
+        "cause is the use of high gains in the simulation of closed loop "
+        "systems. These might cause numerical instabilities given our discrete "
+        "solver uses an explicit treatment of actuation inputs. Possible "
+        "solutions include:\n"
+        "  1. reduce the discrete update period set at construction,\n"
+        "  2. decrease the high gains in your controller whenever possible,\n"
+        "  3. switch to a continuous model (discrete update period is zero), "
+        "     though this might affect the simulation run time.",
+        time0, plant().time_step());
+    throw std::runtime_error(msg);
+  }
+
+  // TODO(amcastro-tri): implement capability to dump solver statistics to a
+  // file for analysis.
+
+  // Update the results.
+  results->v_next = tamsi_solver->get_generalized_velocities();
+  results->fn = tamsi_solver->get_normal_forces();
+  results->ft = tamsi_solver->get_friction_forces();
+  results->vn = tamsi_solver->get_normal_velocities();
+  results->vt = tamsi_solver->get_tangential_velocities();
+  results->tau_contact = tamsi_solver->get_generalized_contact_forces();
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::TamsiDriver);

--- a/multibody/plant/tamsi_driver.h
+++ b/multibody/plant/tamsi_driver.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/contact_solver_results.h"
+#include "drake/multibody/plant/tamsi_solver.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+namespace multibody {
+
+// Forward declaration.
+template <typename>
+class MultibodyPlant;
+
+namespace internal {
+
+// Forward declaration.
+template <typename>
+class CompliantContactManager;
+
+// Performs the computations needed by CompliantContactManager for discrete
+// updates using the TAMSI solver. A const manager is provided at construction
+// so that the driver has access to the const model and computation services
+// agnostic to the solver type, such as geometry queries and/or kinematics.
+// @tparam_default_scalar
+template <typename T>
+class TamsiDriver {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TamsiDriver);
+
+  // The newly constructed driver is used in the given `manager` to perform
+  // discrete updates using the TAMSI solver. This driver will user manager
+  // services to perform solver-agnostic multibody computations, e.g. contact
+  // kinematics. The given `manager` must outlive this driver.
+  // @pre manager != nullptr.
+  explicit TamsiDriver(const CompliantContactManager<T>* manager);
+
+  // Solves for the next time step velocities and contact forces given the
+  // current state stored in `context`.
+  void CalcContactSolverResults(
+      const systems::Context<T>& context,
+      contact_solvers::internal::ContactSolverResults<T>* results) const;
+
+ private:
+  // Returns a reference to the manager provided at construction.
+  const CompliantContactManager<T>& manager() const { return *manager_; }
+
+  // Returns a reference to the MultibodyPlant model held by the manager
+  // provided at construction.
+  const MultibodyPlant<T>& plant() const { return manager().plant(); }
+
+  // Helper method used within CallTamsiSolver() to update generalized
+  // velocities from previous step value v0 to next step value v. This helper
+  // uses num_substeps within a time interval of duration dt to perform the
+  // update using a step size dt_substep = dt/num_substeps. During the time span
+  // dt the problem data M, Jn, Jt and minus_tau, are approximated to be
+  // constant, a first order approximation.
+  TamsiSolverResult SolveUsingSubStepping(
+      TamsiSolver<T>* tamsi_solver, int num_substeps, const MatrixX<T>& M0,
+      const MatrixX<T>& Jn, const MatrixX<T>& Jt, const VectorX<T>& minus_tau,
+      const VectorX<T>& stiffness, const VectorX<T>& damping,
+      const VectorX<T>& mu, const VectorX<T>& v0, const VectorX<T>& fn0) const;
+
+  // Helper to invoke TAMSI during the call to CalcContactSolverResults().
+  void CallTamsiSolver(
+      TamsiSolver<T>* tamsi_solver, const T& time0, const VectorX<T>& v0,
+      const MatrixX<T>& M0, const VectorX<T>& minus_tau, const VectorX<T>& fn0,
+      const MatrixX<T>& Jn, const MatrixX<T>& Jt, const VectorX<T>& stiffness,
+      const VectorX<T>& damping, const VectorX<T>& mu,
+      contact_solvers::internal::ContactSolverResults<T>* results) const;
+
+  // Const access to the manager.
+  const CompliantContactManager<T>* const manager_{nullptr};
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::TamsiDriver);

--- a/multibody/plant/test/square_surface.obj
+++ b/multibody/plant/test/square_surface.obj
@@ -1,0 +1,23 @@
+# Vertices
+v -1.0 -1.0 0.0
+v -1.0 1.0 0.0
+v 1.0 -1.0 0.0
+v 1.0 1.0 0.0
+
+# Normals
+vn 0 0 -1
+
+# Polygonal faces
+# Each number corresponds to the vertices' definition order.
+#
+#      2---------4
+#     /         /
+#    /         /
+#   1---------3
+#
+#   z  y
+#   | /
+#   |/
+#   +----x
+#
+f 1//1 2//1 4//1 3//1

--- a/multibody/plant/test/tamsi_driver_test.cc
+++ b/multibody/plant/test/tamsi_driver_test.cc
@@ -1,0 +1,205 @@
+#include "drake/multibody/plant/tamsi_driver.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/geometry/proximity_properties.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/plant/compliant_contact_manager.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/test/compliant_contact_manager_tester.h"
+#include "drake/systems/framework/diagram.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+using drake::math::RigidTransformd;
+using drake::systems::Context;
+using drake::systems::Diagram;
+using drake::systems::DiagramBuilder;
+using Eigen::MatrixXd;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+
+constexpr double kEps = std::numeric_limits<double>::epsilon();
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+struct TestConfig {
+  // This is a gtest test suffix; no underscores or spaces.
+  std::string description;
+  // Model with point contact if `true` or with hydroelastic contact if `false`.
+  bool point_contact{};
+};
+
+// This provides the suffix for each test parameter: the test config
+// description.
+std::ostream& operator<<(std::ostream& out, const TestConfig& c) {
+  out << c.description;
+  return out;
+}
+
+// The purpose of this fixture is to verify the implementation of TamsiDriver's
+// CalcContactSolverResults(). In this regard this is more of an integration
+// test where the correctness of the results rely on the ability of the driver
+// to properly setup a contact problem for TAMSI using MultibodyPlant (for
+// kinematics and dynamics) and CompliantContactManager's services (for
+// contact), and solve it with TAMSI. MultibodyPlant, CompliantContactManager
+// and TamsiSolver are tested elsewhere.
+class RigidBodyOnCompliantGround : public ::testing::TestWithParam<TestConfig> {
+ public:
+  // This fixture sets up a problem where a rigid body is set on top of a
+  // compliant ground. The position of the body is set so that the compliant
+  // contact force with the ground balances that of gravity.
+  //
+  // Depending on the TestConfig parameter of this fixture, the geometry model
+  // of the rigid body will consist of either a point contact sphere or a rigid
+  // hydroelastic mesh of a square plate.
+  void SetUp() override {
+    DiagramBuilder<double> builder;
+    auto items = AddMultibodyPlantSceneGraph(&builder, 0.001 /* time_step */);
+    plant_ = &items.plant;
+    plant_->set_discrete_contact_solver(DiscreteContactSolver::kTamsi);
+
+    // We change the default gravity magnitude so that numbers are simpler to
+    // work with.
+    plant_->mutable_gravity_field().set_gravity_vector(
+        Vector3d(0.0, 0.0, -kGravity_));
+
+    // Arbitrary inertia values.
+    const double radius = 0.1;
+    const SpatialInertia<double> M_Bo =
+        SpatialInertia<double>::MakeFromCentralInertia(
+            kMass_, Vector3d::Zero(),
+            UnitInertia<double>::SolidSphere(radius) * kMass_);
+
+    body_ = &plant_->AddRigidBody("body", M_Bo);
+
+    geometry::ProximityProperties body_props;
+    geometry::AddContactMaterial(0.0, 1.0e40, CoulombFriction<double>(),
+                                 &body_props);
+
+    const TestConfig& config = GetParam();
+    if (config.point_contact) {
+      plant_->RegisterCollisionGeometry(
+          *body_, RigidTransformd::Identity(),
+          geometry::Sphere(kPointContactSphereRadius_),
+          "point_contact_geometry", body_props);
+    } else {
+      const std::string mesh_file =
+          FindResourceOrThrow("drake/multibody/plant/test/square_surface.obj");
+      geometry::AddRigidHydroelasticProperties(&body_props);
+      plant_->RegisterCollisionGeometry(
+          *body_, RigidTransformd::Identity(), geometry::Mesh(mesh_file),
+          "hydroelastic_contact_geometry", body_props);
+    }
+
+    // Ground geometry.
+    geometry::ProximityProperties ground_props;
+    geometry::AddContactMaterial(kHcDissipation_, kStiffness_,
+                                 CoulombFriction<double>(), &ground_props);
+    geometry::AddCompliantHydroelasticPropertiesForHalfSpace(
+        kGroundThickness_, kHydroelasticModulus_, &ground_props);
+    plant_->RegisterCollisionGeometry(
+        plant_->world_body(),
+        geometry::HalfSpace::MakePose(Vector3d::UnitZ(), Vector3d::Zero()),
+        geometry::HalfSpace(), "ground_collision", ground_props);
+
+    plant_->Finalize();
+
+    diagram_ = builder.Build();
+
+    // Make and add a manager so that we have access to it.
+    auto owned_contact_manager =
+        std::make_unique<CompliantContactManager<double>>();
+    manager_ = owned_contact_manager.get();
+    plant_->SetDiscreteUpdateManager(std::move(owned_contact_manager));
+    tamsi_driver_ = std::make_unique<TamsiDriver<double>>(manager_);
+
+    // Create context.
+    context_ = diagram_->CreateDefaultContext();
+    plant_context_ =
+        &diagram_->GetMutableSubsystemContext(*plant_, context_.get());
+
+    // Set a known configuration.
+    const Vector3d p_WB(0.0, 0.0, CalcEquilibriumZPosition());
+    const RigidTransformd X_WB(p_WB);
+    plant_->SetFreeBodyPose(plant_context_, *body_, X_WB);
+  }
+
+ protected:
+  // Weight in Newtons of the rigid body.
+  double CalcBodyWeight() const {
+    return kMass_ * plant_->gravity_field().gravity_vector().norm();
+  }
+
+  // Computes the z position of the body in this test at which the compliant
+  // contact force balances its weight.
+  double CalcEquilibriumZPosition() const {
+    const TestConfig& config = GetParam();
+    const double weight = CalcBodyWeight();
+    // Either point contact stiffness or the effective hydroelastic stiffness.
+    if (config.point_contact) {
+      return kPointContactSphereRadius_ - weight / kStiffness_;
+    } else {
+      const double stiffness =
+          kArea_ * kHydroelasticModulus_ / kGroundThickness_;
+      return -weight / stiffness;
+    }
+  }
+
+  std::unique_ptr<Diagram<double>> diagram_;
+  MultibodyPlant<double>* plant_{nullptr};
+  const RigidBody<double>* body_{nullptr};
+  CompliantContactManager<double>* manager_{nullptr};
+  std::unique_ptr<Context<double>> context_;
+  Context<double>* plant_context_{nullptr};
+  std::unique_ptr<TamsiDriver<double>> tamsi_driver_;
+
+  // Parameters of the problem.
+  const double kGravity_{10.0};  // Acceleration of gravity, in m/s².
+  const double kMass_{10.0};     // Mass of the rigid body, in kg.
+  const double kPointContactSphereRadius_{0.02};  // In m.
+  const double kStiffness_{1.0e4};                // In N/m.
+  const double kHydroelasticModulus_{250.0};      // In Pa.
+  const double kHcDissipation_{0.2};              // In s/m.
+  const double kGroundThickness_{0.1};            // In m.
+  // Number of triangles and area of the plate must be kept in sync with the
+  // mesh file square_surface.obj.
+  const int kNumberOfTriangles_{2};  // Number of triangles in the hydro mesh.
+  const double kArea_{4.0};          // Area of the rigid hydroelastic mesh.
+};
+
+// This test verifies contact results in the equilibrium configuration.
+TEST_P(RigidBodyOnCompliantGround, VerifyEquilibriumConfiguration) {
+  const TestConfig& config = GetParam();
+  EXPECT_EQ(plant_->num_velocities(), 6);
+  contact_solvers::internal::ContactSolverResults<double> results;
+  tamsi_driver_->CalcContactSolverResults(*plant_context_, &results);
+
+  EXPECT_EQ(results.v_next.size(), plant_->num_velocities());
+  const int num_contacts = config.point_contact ? 1 : kNumberOfTriangles_;
+  EXPECT_EQ(results.fn.size(), num_contacts);
+
+  const double normal_force_expected = CalcBodyWeight();
+  const double normal_force = results.fn.sum();
+  EXPECT_NEAR(normal_force, normal_force_expected, kEps);
+}
+
+// Setup test cases using point and hydroelastic contact.
+std::vector<TestConfig> MakeTestCases() {
+  return std::vector<TestConfig>{
+      {.description = "HydroelasticContact", .point_contact = false},
+      {.description = "PointContact", .point_contact = true},
+  };
+}
+
+INSTANTIATE_TEST_SUITE_P(TamsiDriverTests, RigidBodyOnCompliantGround,
+                         testing::ValuesIn(MakeTestCases()),
+                         testing::PrintToStringParamName());
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Towards https://github.com/RobotLocomotion/drake/issues/16955 and https://github.com/RobotLocomotion/drake/issues/13888.

`TamsiDriver` split from the bigger PR #18170 where all of the TAMSI code in `MultibodyPlant` is moved into the `TamsiDriver`. 
Most of the code in `TamsiDriver` introduced in this PR is simply a copy from already tested `MultibodyPlant` code.
A simple unit test verifies we can properly use the `TamsiDriver`, though as soon as #18170, all of the MultibodyPlant unit tests using TAMSI will go through `TamsiDriver`, effectively adding more coverage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18265)
<!-- Reviewable:end -->
