### PR TITLE
Use const for quaternion used to build math::RigidTransform

### DIFF
--- a/multibody/tree/quaternion_floating_mobilizer.cc
+++ b/multibody/tree/quaternion_floating_mobilizer.cc
@@ -232,7 +232,7 @@ QuaternionFloatingMobilizer<T>::CalcAcrossMobilizerTransform(
   // The last 3 elements in q contain position from Fo to Mo.
   const Vector4<T> wxyz(q.template head<4>());
   const Vector3<T> p_FM = q.template tail<3>();  // position from Fo to Mo.
-  Eigen::Quaternion<T> quaternion_FM(wxyz(0), wxyz(1), wxyz(2), wxyz(3));
+  const Eigen::Quaternion<T> quaternion_FM(wxyz(0), wxyz(1), wxyz(2), wxyz(3));
   const math::RigidTransform<T> X_FM(quaternion_FM, p_FM);
   return X_FM;
 }


### PR DESCRIPTION
This is a tiny merge request proposed while discovering `QuaternionFloatingMobilizer ` class

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18270)
<!-- Reviewable:end -->
