### PR TITLE
[framework] Add the ability to deprecate input and output ports

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -587,6 +587,19 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "multibody_plant_deprecated_test",
+    data = [
+        "test/split_pendulum.sdf",
+    ],
+    deps = [
+        ":plant",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//multibody/benchmarks/acrobot",
+        "//multibody/parsing",
+    ],
+)
+
+drake_cc_googletest(
     name = "multibody_plant_introspection_test",
     data = [
         "//examples/atlas:models",

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -155,8 +155,6 @@ enum class DiscreteContactSolver {
 #define DRAKE_MBP_THROW_IF_NOT_FINALIZED() ThrowIfNotFinalized(__func__)
 /// @endcond
 
-// TODO(sherm1) Rename "continuous_state" output ports to just "state" since
-//              they can be discrete. However see issue #12214.
 /**
 %MultibodyPlant is a Drake system framework representation (see
 systems::System) for the model of a physical system consisting of a
@@ -172,14 +170,14 @@ input_ports:
 - <em style="color:gray">model_instance_name[i]</em>_actuation
 - <span style="color:green">geometry_query</span>
 output_ports:
-- continuous_state
+- state
 - body_poses
 - body_spatial_velocities
 - body_spatial_accelerations
 - generalized_acceleration
 - reaction_forces
 - contact_results
-- <em style="color:gray">model_instance_name[i]</em>_continuous_state
+- <em style="color:gray">model_instance_name[i]</em>_state
 - '<em style="color:gray">
   model_instance_name[i]</em>_generalized_acceleration'
 - '<em style="color:gray">

--- a/multibody/plant/test/multibody_plant_deprecated_test.cc
+++ b/multibody/plant/test/multibody_plant_deprecated_test.cc
@@ -1,0 +1,57 @@
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/multibody/benchmarks/acrobot/make_acrobot_plant.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+using benchmarks::acrobot::AcrobotParameters;
+using benchmarks::acrobot::MakeAcrobotPlant;
+
+// Checks the deprecated output port behavior.
+GTEST_TEST(MultibodyPlant, DeprecatedOutputNames) {
+  const AcrobotParameters parameters;
+  std::unique_ptr<MultibodyPlant<double>> plant =
+      MakeAcrobotPlant(parameters, /* finalize = */ false);
+  Parser(plant.get()).AddModelFromFile(FindResourceOrThrow(
+      "drake/multibody/plant/test/split_pendulum.sdf"));
+  plant->Finalize();
+  EXPECT_EQ(plant->num_model_instances(), 3);
+
+  // Check that deprecated output ports have the appropriate sizes.
+  const auto& all_state_port_old =
+      plant->GetOutputPort("continuous_state");
+  const auto& default_state_port_old =
+      plant->GetOutputPort("DefaultModelInstance_continuous_state");
+  const auto& pendulum_state_port_old =
+      plant->GetOutputPort("SplitPendulum_continuous_state");
+  EXPECT_EQ(all_state_port_old.size(), 6);
+  EXPECT_EQ(default_state_port_old.size(), 4);
+  EXPECT_EQ(pendulum_state_port_old.size(), 2);
+
+  // Check that the deprecated output ports match the non-deprecated ones.
+  auto context = plant->CreateDefaultContext();
+  plant->SetPositions(context.get(), Eigen::Vector3d{0.1, 0.2, 0.3});
+  plant->SetVelocities(context.get(), Eigen::Vector3d{0.01, 0.02, 0.03});
+  const auto& all_state_port_new =
+      plant->GetOutputPort("state");
+  const auto& default_state_port_new =
+      plant->GetOutputPort("DefaultModelInstance_state");
+  const auto& pendulum_state_port_new =
+      plant->GetOutputPort("SplitPendulum_state");
+  EXPECT_TRUE(CompareMatrices(all_state_port_old.Eval(*context),
+                              all_state_port_new.Eval(*context)));
+  EXPECT_TRUE(CompareMatrices(default_state_port_old.Eval(*context),
+                              default_state_port_new.Eval(*context)));
+  EXPECT_TRUE(CompareMatrices(pendulum_state_port_old.Eval(*context),
+                              pendulum_state_port_new.Eval(*context)));
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -219,10 +219,10 @@ GTEST_TEST(MultibodyPlant, SimpleModelCreation) {
       "DefaultModelInstance_actuation");
   EXPECT_EQ(plant->get_state_output_port(default_model_instance())
                 .get_name(),
-            "DefaultModelInstance_continuous_state");
+            "DefaultModelInstance_state");
   EXPECT_EQ(plant->get_state_output_port(pendulum_model_instance)
                 .get_name(),
-            "SplitPendulum_continuous_state");
+            "SplitPendulum_state");
 
   // Query if elements exist in the model.
   EXPECT_TRUE(plant->HasBodyNamed(parameters.link1_name()));

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -880,6 +880,13 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "leaf_system_deprecation_test",
+    deps = [
+        ":leaf_system",
+    ],
+)
+
+drake_cc_googletest(
     name = "model_values_test",
     deps = [
         ":model_values",

--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -1034,8 +1034,8 @@ const AbstractValue* Diagram<T>::EvalConnectedSubsystemInputPort(
   // A static_cast is safe as long as the given input_port_base was actually
   // an InputPort<T>, and since our sole caller is SystemBase which always
   // retrieves the input_port_base from `this`, the <T> must be correct.
-  auto& system =
-      static_cast<const System<T>&>(input_port_base.get_system_interface());
+  auto& system = static_cast<const System<T>&>(
+      internal::PortBaseAttorney::get_system_interface(input_port_base));
   const InputPortLocator id{&system, input_port_base.get_index()};
 
   // Find if this input port is exported (connected to an input port of this

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -1205,6 +1205,11 @@ class LeafSystem : public System<T> {
   InputPort<T>& DeclareAbstractInputPort(
       std::variant<std::string, UseDefaultName> name,
       const AbstractValue& model_value);
+
+  /** Flags an already-declared input port as deprecated. The first attempt to
+  use the port in a program will log a warning message. This function may be
+  called at most once for any given port. */
+  void DeprecateInputPort(const InputPort<T>& port, std::string message);
   //@}
 
   // =========================================================================
@@ -1539,6 +1544,11 @@ class LeafSystem : public System<T> {
   LeafOutputPort<T>& DeclareStateOutputPort(
       std::variant<std::string, UseDefaultName> name,
       AbstractStateIndex state_index);
+
+  /** Flags an already-declared output port as deprecated. The first attempt to
+  use the port in a program will log a warning message. This function may be
+  called at most once for any given port. */
+  void DeprecateOutputPort(const OutputPort<T>& port, std::string message);
   //@}
 
   // =========================================================================

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -1016,7 +1016,8 @@ class System : public SystemBase {
     // has a check that port.get_system_interface() matches `this` which is a
     // System<T>, so we are safe.
     return static_cast<const InputPort<T>&>(
-        this->GetInputPortBaseOrThrow(__func__, port_index));
+        this->GetInputPortBaseOrThrow(__func__, port_index,
+                                      /* warn_deprecated = */ true));
   }
 
   /** Convenience method for the case of exactly one input port. */
@@ -1057,7 +1058,8 @@ class System : public SystemBase {
     // has a check that port.get_system_interface() matches `this` which is a
     // System<T>, so we are safe.
     return static_cast<const OutputPort<T>&>(
-        this->GetOutputPortBaseOrThrow(__func__, port_index));
+        this->GetOutputPortBaseOrThrow(__func__, port_index,
+                                       /* warn_deprecated = */ true));
   }
 
   /** Convenience method for the case of exactly one output port. */

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -195,13 +195,15 @@ class SystemBase : public internal::SystemMessageInterface {
   /** Returns a reference to an InputPort given its `port_index`.
   @pre `port_index` selects an existing input port of this System. */
   const InputPortBase& get_input_port_base(InputPortIndex port_index) const {
-    return GetInputPortBaseOrThrow(__func__, port_index);
+    return GetInputPortBaseOrThrow(__func__, port_index,
+                                   /* warn_deprecated = */ true);
   }
 
   /** Returns a reference to an OutputPort given its `port_index`.
   @pre `port_index` selects an existing output port of this System. */
   const OutputPortBase& get_output_port_base(OutputPortIndex port_index) const {
-    return GetOutputPortBaseOrThrow(__func__, port_index);
+    return GetOutputPortBaseOrThrow(__func__, port_index,
+                                    /* warn_deprecated = */ true);
   }
 
   /** Returns the total dimension of all of the vector-valued input ports (as if
@@ -414,6 +416,8 @@ class SystemBase : public internal::SystemMessageInterface {
   @pre `index` selects an existing input port of this System. */
   DependencyTicket input_port_ticket(InputPortIndex index) const {
     DRAKE_DEMAND(0 <= index && index < num_input_ports());
+    if (input_ports_[index]->get_deprecation().has_value())
+      WarnPortDeprecation(/* is_input = */ true, index);
     return input_ports_[index]->ticket();
   }
 
@@ -811,6 +815,7 @@ class SystemBase : public internal::SystemMessageInterface {
           all_sources_ticket()});
   //@}
 
+  // TODO(jwnimmer-tri) This function does not meet the criteria for inline.
   /** (Internal use only) Adds an already-constructed input port to this System.
   Insists that the port already contains a reference to this System, and that
   the port's index is already set to the next available input port index for
@@ -819,14 +824,15 @@ class SystemBase : public internal::SystemMessageInterface {
   // TODO(sherm1) Add check on suitability of `size` parameter for the port's
   // data type.
   void AddInputPort(std::unique_ptr<InputPortBase> port) {
+    using internal::PortBaseAttorney;
     DRAKE_DEMAND(port != nullptr);
-    DRAKE_DEMAND(&port->get_system_interface() == this);
+    DRAKE_DEMAND(&PortBaseAttorney::get_system_interface(*port) == this);
     DRAKE_DEMAND(port->get_index() == num_input_ports());
     DRAKE_DEMAND(!port->get_name().empty());
 
     // Check that name is unique.
     for (InputPortIndex i{0}; i < num_input_ports(); i++) {
-      if (port->get_name() == get_input_port_base(i).get_name()) {
+      if (port->get_name() == input_ports_[i]->get_name()) {
         throw std::logic_error("System " + GetSystemName() +
             " already has an input port named " +
             port->get_name());
@@ -836,6 +842,7 @@ class SystemBase : public internal::SystemMessageInterface {
     input_ports_.push_back(std::move(port));
   }
 
+  // TODO(jwnimmer-tri) This function does not meet the criteria for inline.
   /** (Internal use only) Adds an already-constructed output port to this
   System. Insists that the port already contains a reference to this System, and
   that the port's index is already set to the next available output port index
@@ -844,14 +851,15 @@ class SystemBase : public internal::SystemMessageInterface {
   // TODO(sherm1) Add check on suitability of `size` parameter for the port's
   // data type.
   void AddOutputPort(std::unique_ptr<OutputPortBase> port) {
+    using internal::PortBaseAttorney;
     DRAKE_DEMAND(port != nullptr);
-    DRAKE_DEMAND(&port->get_system_interface() == this);
+    DRAKE_DEMAND(&PortBaseAttorney::get_system_interface(*port) == this);
     DRAKE_DEMAND(port->get_index() == num_output_ports());
     DRAKE_DEMAND(!port->get_name().empty());
 
     // Check that name is unique.
     for (OutputPortIndex i{0}; i < num_output_ports(); i++) {
-      if (port->get_name() == get_output_port_base(i).get_name()) {
+      if (port->get_name() == output_ports_[i]->get_name()) {
         throw std::logic_error("System " + GetSystemName() +
                                " already has an output port named " +
                                port->get_name());
@@ -1041,28 +1049,40 @@ class SystemBase : public internal::SystemMessageInterface {
   /** (Internal use only) Returns the InputPortBase at index `port_index`,
   throwing std::exception we don't like the port index. The name of the
   public API method that received the bad index is provided in `func` and is
-  included in the error message. */
+  included in the error message. The `warn_deprecated` governs whether or not
+  a deprecation warning should occur when the `port_index` is deprecated; calls
+  made on behalf of the user should pass `true`; calls made on behalf or the
+  framework internals should pass `false`. */
   const InputPortBase& GetInputPortBaseOrThrow(const char* func,
-                                               int port_index) const {
+                                               int port_index,
+                                               bool warn_deprecated) const {
     if (port_index < 0)
       ThrowNegativePortIndex(func, port_index);
     const InputPortIndex port(port_index);
     if (port_index >= num_input_ports())
       ThrowInputPortIndexOutOfRange(func, port);
+    if (warn_deprecated && input_ports_[port]->get_deprecation().has_value())
+      WarnPortDeprecation(/* is_input = */ true, port_index);
     return *input_ports_[port];
   }
 
   /** (Internal use only) Returns the OutputPortBase at index `port_index`,
   throwing std::exception if we don't like the port index. The name of the
   public API method that received the bad index is provided in `func` and is
-  included in the error message. */
+  included in the error message. The `warn_deprecated` governs whether or not
+  a deprecation warning should occur when the `port_index` is deprecated; calls
+  made on behalf of the user should pass `true`; calls made on behalf or the
+  framework internals should pass `false`. */
   const OutputPortBase& GetOutputPortBaseOrThrow(const char* func,
-                                                 int port_index) const {
+                                                 int port_index,
+                                                 bool warn_deprecated) const {
     if (port_index < 0)
       ThrowNegativePortIndex(func, port_index);
     const OutputPortIndex port(port_index);
     if (port_index >= num_output_ports())
       ThrowOutputPortIndexOutOfRange(func, port);
+    if (warn_deprecated && output_ports_[port]->get_deprecation().has_value())
+      WarnPortDeprecation(/* is_input = */ false, port_index);
     return *output_ports_[port_index];
   }
 
@@ -1196,6 +1216,10 @@ class SystemBase : public internal::SystemMessageInterface {
 
   [[noreturn]] void ThrowNotCreatedForThisSystemImpl(
       const std::string& nice_type_name, internal::SystemId id) const;
+
+  // Given a deprecated input or output port (as determined by `input`), logs
+  // a warning (just once per process) about the deprecation.
+  void WarnPortDeprecation(bool is_input, int port_index) const;
 
   // Ports and cache entries hold their own DependencyTickets. Note that the
   // addresses of the elements are stable even if the std::vectors are resized.

--- a/systems/framework/test/input_port_test.cc
+++ b/systems/framework/test/input_port_test.cc
@@ -51,7 +51,6 @@ GTEST_TEST(InputPortTest, VectorTest) {
   EXPECT_EQ(dut->size(), size);
   EXPECT_EQ(dut->GetFullDescription(),
             "InputPort[2] (port_name) of System ::dummy (DummySystem)");
-  EXPECT_EQ(&dut->get_system_interface(), system_interface);
   EXPECT_EQ(&dut->get_system(), system);
 
   // Check HasValue.
@@ -111,7 +110,6 @@ GTEST_TEST(InputPortTest, AbstractTest) {
   EXPECT_EQ(dut->size(), size);
   EXPECT_EQ(dut->GetFullDescription(),
             "InputPort[2] (port_name) of System ::dummy (DummySystem)");
-  EXPECT_EQ(&dut->get_system_interface(), system_interface);
   EXPECT_EQ(&dut->get_system(), system);
 
   // Check HasValue.

--- a/systems/framework/test/leaf_system_deprecation_test.cc
+++ b/systems/framework/test/leaf_system_deprecation_test.cc
@@ -1,0 +1,290 @@
+#include <gtest/gtest.h>
+
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+
+// This is used for friendship, so can't be anonymous.
+class LeafSystemDeprecationTest : public ::testing::Test {
+ protected:
+  class PortDeprecationSystem : public LeafSystem<double> {
+   public:
+    using LeafSystem::DeclareVectorInputPort;
+    using LeafSystem::DeclareVectorOutputPort;
+    using LeafSystem::DeprecateInputPort;
+    using LeafSystem::DeprecateOutputPort;
+  };
+
+  InputPort<double>& DeclareDeprecatedInput(const std::string& message = "") {
+    auto& result = dut_.DeclareVectorInputPort(kUseDefaultName, 1);
+    dut_.DeprecateInputPort(result, message);
+    return result;
+  }
+
+  OutputPort<double>& DeclareDeprecatedOutput(const std::string& message = "") {
+    auto& result = dut_.DeclareVectorOutputPort(
+        kUseDefaultName, 1, noop_calc_, {SystemBase::all_input_ports_ticket()});
+    dut_.DeprecateOutputPort(result, message);
+    return result;
+  }
+
+  bool has_warned(const PortBase& port) const {
+    using internal::PortBaseAttorney;
+    PortBase& mutable_port = const_cast<PortBase&>(port);
+    return PortBaseAttorney::deprecation_already_warned(&mutable_port)->load();
+  }
+
+  PortDeprecationSystem dut_;
+
+  const LeafOutputPort<double>::CalcVectorCallback noop_calc_ =
+      [](const Context<double>&, BasicVector<double>*) {};
+};
+
+namespace {
+
+// ======== Positive test cases: we want these to generate warnings ========
+
+// Give a deprecation message (or not) and make sure nothing crashes.
+// You can manually look at the test's output to see what it looks like.
+TEST_F(LeafSystemDeprecationTest, Messages) {
+  // Use default messages.
+  EXPECT_NO_THROW(DeclareDeprecatedInput());
+  EXPECT_NO_THROW(DeclareDeprecatedOutput());
+
+  // Use custom messages.
+  EXPECT_NO_THROW(DeclareDeprecatedInput("this string gets logged"));
+  EXPECT_NO_THROW(DeclareDeprecatedOutput("this string gets logged, too"));
+
+  // Log the warnings.
+  EXPECT_NO_THROW(dut_.get_input_port(0));
+  EXPECT_NO_THROW(dut_.get_input_port(1));
+  EXPECT_NO_THROW(dut_.get_output_port(0));
+  EXPECT_NO_THROW(dut_.get_output_port(1));
+}
+
+// Accessing input by index triggers the message.
+TEST_F(LeafSystemDeprecationTest, InputByIndex) {
+  auto& port = DeclareDeprecatedInput();
+  EXPECT_EQ(has_warned(port), false);
+  dut_.get_input_port(0);
+  EXPECT_EQ(has_warned(port), true);
+}
+
+// Accessing base input by index triggers the message.
+TEST_F(LeafSystemDeprecationTest, BaseInputByIndex) {
+  auto& port = DeclareDeprecatedInput();
+  EXPECT_EQ(has_warned(port), false);
+  dut_.get_input_port_base(InputPortIndex{0});
+  EXPECT_EQ(has_warned(port), true);
+}
+
+// Accessing input ticket by index triggers the message.
+TEST_F(LeafSystemDeprecationTest, TicketInputByIndex) {
+  auto& port = DeclareDeprecatedInput();
+  EXPECT_EQ(has_warned(port), false);
+  dut_.input_port_ticket(InputPortIndex{0});
+  EXPECT_EQ(has_warned(port), true);
+}
+
+// Accessing output by index triggers the message.
+TEST_F(LeafSystemDeprecationTest, OutputByIndex) {
+  auto& port = DeclareDeprecatedOutput();
+  EXPECT_EQ(has_warned(port), false);
+  dut_.get_output_port(0);
+  EXPECT_EQ(has_warned(port), true);
+}
+
+// Accessing base output by index triggers the message.
+TEST_F(LeafSystemDeprecationTest, BaseOutputByIndex) {
+  auto& port = DeclareDeprecatedOutput();
+  EXPECT_EQ(has_warned(port), false);
+  dut_.get_output_port_base(OutputPortIndex{0});
+  EXPECT_EQ(has_warned(port), true);
+}
+
+// Accessing input by name triggers the message.
+TEST_F(LeafSystemDeprecationTest, InputByName) {
+  auto& port = DeclareDeprecatedInput();
+  EXPECT_EQ(has_warned(port), false);
+  dut_.GetInputPort("u0");
+  EXPECT_EQ(has_warned(port), true);
+}
+
+// Checking for input by name triggers the message.
+TEST_F(LeafSystemDeprecationTest, HasInputByName) {
+  auto& port = DeclareDeprecatedInput();
+  EXPECT_EQ(has_warned(port), false);
+  dut_.HasInputPort("u0");
+  EXPECT_EQ(has_warned(port), true);
+}
+
+// Accessing output by name triggers the message.
+TEST_F(LeafSystemDeprecationTest, OutputByName) {
+  auto& port = DeclareDeprecatedOutput();
+  EXPECT_EQ(has_warned(port), false);
+  dut_.GetOutputPort("y0");
+  EXPECT_EQ(has_warned(port), true);
+}
+
+// Checking for output by name triggers the message.
+TEST_F(LeafSystemDeprecationTest, HasOutputByName) {
+  auto& port = DeclareDeprecatedOutput();
+  EXPECT_EQ(has_warned(port), false);
+  dut_.HasOutputPort("y0");
+  EXPECT_EQ(has_warned(port), true);
+}
+
+// Evaluating the input (using the dispreferred SystemBase function) triggers
+// the message.
+TEST_F(LeafSystemDeprecationTest, InputEval) {
+  auto& port = DeclareDeprecatedInput();
+  auto context = dut_.CreateDefaultContext();
+  EXPECT_EQ(has_warned(port), false);
+  dut_.EvalAbstractInput(*context, 0);
+  EXPECT_EQ(has_warned(port), true);
+}
+
+// ======== Negative test cases: we want these to NOT generate warnings ========
+
+// Non-deprecated input ports don't trigger the message.
+TEST_F(LeafSystemDeprecationTest, OtherInputNoSpurious) {
+  auto& in0 = DeclareDeprecatedInput();
+  auto& in1 = dut_.DeclareVectorInputPort("ok", 1);
+  EXPECT_EQ(has_warned(in0), false);
+  EXPECT_EQ(has_warned(in1), false);
+  dut_.HasInputPort("ok");
+  dut_.GetInputPort("ok");
+  EXPECT_EQ(has_warned(in0), false);
+  EXPECT_EQ(has_warned(in1), false);
+}
+
+// Non-deprecated output ports don't trigger the message.
+TEST_F(LeafSystemDeprecationTest, OtherOutputNoSpurious) {
+  auto& out0 = DeclareDeprecatedOutput();
+  auto& out1 = dut_.DeclareVectorOutputPort("ok", 1, noop_calc_);
+  EXPECT_EQ(has_warned(out0), false);
+  EXPECT_EQ(has_warned(out1), false);
+  dut_.HasOutputPort("ok");
+  dut_.GetOutputPort("ok");
+  EXPECT_EQ(has_warned(out0), false);
+  EXPECT_EQ(has_warned(out1), false);
+}
+
+// Multiple inputs don't trigger the message when checking for duplicate names.
+TEST_F(LeafSystemDeprecationTest, HeterogeneousInputNoSpurious) {
+  auto& port0 = DeclareDeprecatedInput();
+  auto& port1 = DeclareDeprecatedInput();
+  EXPECT_EQ(has_warned(port0), false);
+  EXPECT_EQ(has_warned(port1), false);
+}
+
+// Multiple outputs don't trigger the message when checking for duplicate names.
+TEST_F(LeafSystemDeprecationTest, HeterogeneousOutputNoSpurious) {
+  auto& port0 = DeclareDeprecatedOutput();
+  auto& port1 = DeclareDeprecatedOutput();
+  EXPECT_EQ(has_warned(port0), false);
+  EXPECT_EQ(has_warned(port1), false);
+}
+
+// Feedthrough calculations don't trigger the message.
+TEST_F(LeafSystemDeprecationTest, FeedthroughNoSpurious) {
+  auto& in0 = DeclareDeprecatedInput();
+  auto& out0 = DeclareDeprecatedOutput();
+  dut_.GetDirectFeedthroughs();
+  EXPECT_EQ(has_warned(in0), false);
+  EXPECT_EQ(has_warned(out0), false);
+}
+
+// Fixed input port allocation doesn't trigger the message.
+TEST_F(LeafSystemDeprecationTest, FixedAllocateNoSpurious) {
+  auto& in0 = DeclareDeprecatedInput();
+  auto context = dut_.CreateDefaultContext();
+  dut_.AllocateFixedInputs(context.get());
+  EXPECT_EQ(has_warned(in0), false);
+}
+
+// Fixed input port bulk setting doesn't trigger the message.
+TEST_F(LeafSystemDeprecationTest, FixedFromNoSpurious) {
+  PortDeprecationSystem other;
+  auto& other_in = other.DeclareVectorInputPort("ok", 1);
+  auto other_context = other.CreateDefaultContext();
+  other.get_input_port().FixValue(
+      other_context.get(), Eigen::VectorXd::Constant(1, 22.0));
+
+  auto& dut_in = DeclareDeprecatedInput();
+  auto dut_context = dut_.CreateDefaultContext();
+  dut_.FixInputPortsFrom(other, *other_context, dut_context.get());
+  EXPECT_EQ(has_warned(other_in), false);
+  EXPECT_EQ(has_warned(dut_in), false);
+}
+
+// Bulk output calculation doesn't trigger the message.
+TEST_F(LeafSystemDeprecationTest, CalcOutputNoSpurious) {
+  auto& port = DeclareDeprecatedOutput();
+  auto context = dut_.CreateDefaultContext();
+  auto output = dut_.AllocateOutput();
+  dut_.CalcOutput(*context, output.get());
+  EXPECT_EQ(has_warned(port), false);
+}
+
+// ======== Acceptance test ========
+
+// Illustrates how to use the deprecation mechanism in practice. We have a
+// PassThrough system where we've decided to add a "_new" suffix to port names.
+class SillyPassThrough : public LeafSystem<double> {
+ public:
+  SillyPassThrough() {
+    // These are the non-deprecated ports.
+    input_new_ = &this->DeclareVectorInputPort("input_new", 1);
+    output_new_ = &this->DeclareVectorOutputPort(
+        "output_new", 1, &SillyPassThrough::CalcOutput);
+
+    // These are the deprecated ports. For the output port, we'll use the same
+    // CalcOutput function as the non-deprecated port. (Another option would be
+    // to have the deprecated port calculation function call Eval on the non-
+    // deprecated port and copy the result; that might be more appropriate in
+    // case the computation was too expensive to risk doing twice.)
+    const std::string message = "use the ports with suffix '_new'";
+    input_old_ = &this->DeclareVectorInputPort("input", 1);
+    output_old_ = &this->DeclareVectorOutputPort(
+        "output", 1, &SillyPassThrough::CalcOutput);
+    this->DeprecateInputPort(*input_old_, message);
+    this->DeprecateOutputPort(*output_old_, message);
+  }
+
+  void CalcOutput(const Context<double>& context,
+                  BasicVector<double>* output) const {
+    const bool has_old = input_old_->HasValue(context);
+    const bool has_new = input_new_->HasValue(context);
+    if (has_old && has_new) {
+      throw std::runtime_error("Don't connect both input ports!");
+    }
+    const Eigen::VectorXd& input =
+        (has_old ? *input_old_ : *input_new_).Eval(context);
+    output->SetFromVector(input);
+  }
+
+ private:
+  const InputPort<double>* input_new_{};
+  const InputPort<double>* input_old_{};
+  const OutputPort<double>* output_new_{};
+  const OutputPort<double>* output_old_{};
+};
+
+GTEST_TEST(LeafSystemDeprecationAcceptanceTest, Demo) {
+  SillyPassThrough dut;
+  auto context = dut.CreateDefaultContext();
+
+  // The call to GetInputPort will log a warning.
+  const Eigen::VectorXd u = Eigen::VectorXd::Constant(1, 22.0);
+  dut.GetInputPort("input").FixValue(context.get(), u);
+
+  // The call to GetOutputPort will log a warning.
+  EXPECT_EQ(dut.GetOutputPort("output").Eval(*context), u);
+}
+
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
Towards #12214.  This adds the _ability_ to deprecate ports in the first place.

No sugar for renaming input ports is implemented here, so I'll leave the issue open for now.

As a showcase of the feature, this deprecates MultibodyPlant's `continuous_state` port names, in lieu of just `state`.

This PR also adds an attorney for PortBase to de-clutter the public API.

---

When a port is marked as deprecated, the first user-induced attempt to use it within a process will result in a warning printed to the log.

Uses are detected as:

- Obtaining a reference to the InputPort or OutputPort handle (other than at declaration-time), with lookup either by name or index.

  Using the handle after lookup does not generate additional warnings.

  Note that connecting or exporting subsystem ports during Diagram construction counts as a detected use.

- Checking whether a port name exists.

- Obtaining the input port's cache ticket via the SystemBase.

- Evaluating an input port via the (dispreferred) direct System functions EvalAbstractInput or EvalInputValue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18274)
<!-- Reviewable:end -->
