### PR TITLE
[parsing] Port to parser.AddModels, part 2

### DIFF
--- a/bindings/pydrake/examples/test/manipulation_station_test.py
+++ b/bindings/pydrake/examples/test/manipulation_station_test.py
@@ -69,7 +69,7 @@ class TestManipulationStation(unittest.TestCase):
         iiwa_model_file = FindResourceOrThrow(
             "drake/manipulation/models/iiwa_description/iiwa7/"
             "iiwa7_no_collision.sdf")
-        iiwa = parser.AddModelFromFile(iiwa_model_file, "iiwa")
+        (iiwa,) = parser.AddModels(iiwa_model_file)
         X_WI = RigidTransform.Identity()
         plant.WeldFrames(plant.world_frame(),
                          plant.GetFrameByName("iiwa_link_0", iiwa),
@@ -78,7 +78,7 @@ class TestManipulationStation(unittest.TestCase):
         wsg_model_file = FindResourceOrThrow(
             "drake/manipulation/models/wsg_50_description/sdf/"
             "schunk_wsg_50.sdf")
-        wsg = parser.AddModelFromFile(wsg_model_file, "gripper")
+        (wsg,) = parser.AddModels(wsg_model_file)
         X_7G = RigidTransform.Identity()
         plant.WeldFrames(
             plant.GetFrameByName("iiwa_link_7", iiwa),

--- a/bindings/pydrake/multibody/test/inverse_kinematics_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_test.py
@@ -682,8 +682,8 @@ class TestGlobalInverseKinematics(unittest.TestCase):
 
     def test_api(self):
         plant = MultibodyPlant(time_step=0.01)
-        model_instance = Parser(plant).AddModelFromFile(FindResourceOrThrow(
-                "drake/bindings/pydrake/multibody/test/two_bodies.sdf"))
+        model_instance, = Parser(plant).AddModels(FindResourceOrThrow(
+            "drake/bindings/pydrake/multibody/test/two_bodies.sdf"))
         plant.Finalize()
         context = plant.CreateDefaultContext()
         options = ik.GlobalInverseKinematics.Options()

--- a/bindings/pydrake/multibody/test/optimization_test.py
+++ b/bindings/pydrake/multibody/test/optimization_test.py
@@ -236,7 +236,7 @@ class TestToppra(unittest.TestCase):
         file_path = FindResourceOrThrow(
             "drake/manipulation/models/iiwa_description/iiwa7/"
             "iiwa7_no_collision.sdf")
-        iiwa_id = Parser(plant).AddModelFromFile(file_path, "iiwa")
+        iiwa_id, = Parser(plant).AddModels(file_path)
         plant.WeldFrames(plant.world_frame(),
                          plant.GetFrameByName("iiwa_link_0", iiwa_id))
         plant.Finalize()

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -272,7 +272,7 @@ class TestPlant(unittest.TestCase):
             "drake/multibody/benchmarks/acrobot/acrobot.sdf")
         # N.B. `Parser` only supports `MultibodyPlant_[float]`.
         plant_f = MultibodyPlant_[float](time_step=0.01)
-        model_instance = Parser(plant_f).AddModelFromFile(file_name)
+        model_instance, = Parser(plant_f).AddModels(file_name)
         self.assertIsInstance(model_instance, ModelInstanceIndex)
         check_repr(model_instance, "ModelInstanceIndex(2)")
         plant_f.Finalize()
@@ -828,7 +828,7 @@ class TestPlant(unittest.TestCase):
         file_name = FindResourceOrThrow(
             "drake/bindings/pydrake/multibody/test/double_pendulum.sdf")
         # N.B. `Parser` only supports `MultibodyPlant_[float]`.
-        instance = Parser(plant_f).AddModelFromFile(file_name)
+        instance, = Parser(plant_f).AddModels(file_name)
         plant_f.Finalize()
         plant = to_type(plant_f, T)
         context = plant.CreateDefaultContext()
@@ -1002,7 +1002,7 @@ class TestPlant(unittest.TestCase):
         file_name = FindResourceOrThrow(
             "drake/multibody/benchmarks/acrobot/acrobot.sdf")
         # N.B. `Parser` only supports `MultibodyPlant_[float]`.
-        instance = Parser(plant_f).AddModelFromFile(file_name)
+        instance, = Parser(plant_f).AddModels(file_name)
         plant_f.Finalize()
         plant = to_type(plant_f, T)
         context = plant.CreateDefaultContext()
@@ -1114,10 +1114,8 @@ class TestPlant(unittest.TestCase):
         # N.B. `Parser` only supports `MultibodyPlant_[float]`.
         plant_f = MultibodyPlant_[float](time_step=2e-3)
         parser = Parser(plant_f)
-        iiwa_model = parser.AddModelFromFile(
-            file_name=iiwa_sdf_path, model_name='robot')
-        gripper_model = parser.AddModelFromFile(
-            file_name=wsg50_sdf_path, model_name='gripper')
+        iiwa_model, = parser.AddModels(file_name=iiwa_sdf_path)
+        gripper_model, = parser.AddModels(file_name=wsg50_sdf_path)
         plant_f.Finalize()
         plant = to_type(plant_f, T)
         models = [iiwa_model, gripper_model]
@@ -1277,10 +1275,8 @@ class TestPlant(unittest.TestCase):
         plant_f = MultibodyPlant_[float](0.0)
         parser = Parser(plant_f)
 
-        iiwa_model = parser.AddModelFromFile(
-            file_name=iiwa_sdf_path, model_name='robot')
-        gripper_model = parser.AddModelFromFile(
-            file_name=wsg50_sdf_path, model_name='gripper')
+        iiwa_model, = parser.AddModels(file_name=iiwa_sdf_path)
+        gripper_model, = parser.AddModels(file_name=wsg50_sdf_path)
 
         # Weld the base of arm and gripper to reduce the number of states.
         X_EeGripper = RigidTransform_[float](
@@ -1426,10 +1422,8 @@ class TestPlant(unittest.TestCase):
         plant_f = MultibodyPlant_[float](timestep)
         parser = Parser(plant_f)
 
-        iiwa_model = parser.AddModelFromFile(
-            file_name=iiwa_sdf_path, model_name='robot')
-        gripper_model = parser.AddModelFromFile(
-            file_name=wsg50_sdf_path, model_name='gripper')
+        iiwa_model, = parser.AddModels(file_name=iiwa_sdf_path)
+        gripper_model, = parser.AddModels(file_name=wsg50_sdf_path)
 
         # Weld the base of arm and gripper to reduce the number of states.
         X_EeGripper = RigidTransform_[float](
@@ -1537,8 +1531,7 @@ class TestPlant(unittest.TestCase):
             "iiwa_description/sdf/iiwa14_no_collision.sdf")
         # Use floating base to effectively add a quaternion in the generalized
         # quaternion.
-        iiwa_model = Parser(plant=plant_f).AddModelFromFile(
-            file_name=iiwa_sdf_path, model_name='robot')
+        iiwa_model, = Parser(plant_f).AddModels(iiwa_sdf_path)
         plant_f.Finalize()
         plant = to_type(plant_f, T)
         context = plant.CreateDefaultContext()
@@ -2043,8 +2036,7 @@ class TestPlant(unittest.TestCase):
             "wsg_50_description/sdf/schunk_wsg_50.sdf")
 
         parser = Parser(plant)
-        gripper_model = parser.AddModelFromFile(
-            file_name=wsg50_sdf_path, model_name='gripper')
+        gripper_model, = parser.AddModels(file_name=wsg50_sdf_path)
 
         # Add coupler constraint.
         left_slider = plant.GetJointByName("left_finger_sliding_joint")
@@ -2293,9 +2285,8 @@ class TestPlant(unittest.TestCase):
         plant_f, scene_graph_f = AddMultibodyPlantSceneGraph(builder_f, 0.0)
         parser = Parser(plant=plant_f, scene_graph=scene_graph_f)
 
-        parser.AddModels(
-            FindResourceOrThrow(
-                "drake/bindings/pydrake/multibody/test/two_bodies.sdf"))
+        parser.AddModels(FindResourceOrThrow(
+            "drake/bindings/pydrake/multibody/test/two_bodies.sdf"))
         plant_f.Finalize()
 
         # Build a set with geometries from bodies 1 and 2.
@@ -2320,9 +2311,8 @@ class TestPlant(unittest.TestCase):
         # supported across all nonsymbolic scalar types (double, autodiffxd).
         # If two_bodies.sdf were to change to unsupported geometries, this
         # test would break.
-        parser.AddModels(
-            FindResourceOrThrow(
-                "drake/bindings/pydrake/multibody/test/two_bodies.sdf"))
+        parser.AddModels(FindResourceOrThrow(
+            "drake/bindings/pydrake/multibody/test/two_bodies.sdf"))
         plant_f.Finalize()
         diagram_f = builder_f.Build()
 
@@ -2423,8 +2413,8 @@ class TestPlant(unittest.TestCase):
     def test_wing(self):
         builder = DiagramBuilder()
         plant = builder.AddSystem(MultibodyPlant(0.0))
-        Parser(plant).AddModels(
-            FindResourceOrThrow("drake/multibody/models/box.urdf"))
+        Parser(plant).AddModels(FindResourceOrThrow(
+            "drake/multibody/models/box.urdf"))
         plant.Finalize()
 
         body = plant.GetBodyByName("box")
@@ -2470,9 +2460,8 @@ class TestPlant(unittest.TestCase):
     def _check_hydroelastic_contact_results(self, time_step):
         builder = DiagramBuilder_[float]()
         plant, scene_graph = AddMultibodyPlantSceneGraph(builder, time_step)
-        Parser(plant).AddModels(
-            FindResourceOrThrow(
-                "drake/bindings/pydrake/multibody/test/hydroelastic.sdf"))
+        Parser(plant).AddModels(FindResourceOrThrow(
+            "drake/bindings/pydrake/multibody/test/hydroelastic.sdf"))
         plant.set_contact_model(ContactModel.kHydroelastic)
         plant.Finalize()
 

--- a/bindings/pydrake/systems/test/rendering_test.py
+++ b/bindings/pydrake/systems/test/rendering_test.py
@@ -34,7 +34,7 @@ class TestRendering(unittest.TestCase):
         file_name = FindResourceOrThrow(
             "drake/multibody/benchmarks/acrobot/acrobot.sdf")
         plant = MultibodyPlant(time_step=0.01)
-        model_instance = Parser(plant).AddModelFromFile(file_name)
+        Parser(plant).AddModels(file_name)
         scene_graph = SceneGraph()
         plant.RegisterAsSourceForSceneGraph(scene_graph)
         plant.Finalize()

--- a/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
+++ b/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
@@ -102,8 +102,8 @@ void DoMain() {
   const std::string object_model_path = FindResourceOrThrow(
       "drake/examples/allegro_hand/joint_control/simple_mug.sdf");
   multibody::Parser parser(&plant);
-  parser.AddModelFromFile(hand_model_path);
-  ModelInstanceIndex mug_model = parser.AddModelFromFile(object_model_path);
+  parser.AddModels(hand_model_path);
+  parser.AddModels(object_model_path);
 
   // Weld the hand to the world frame
   const auto& joint_hand_root = plant.GetBodyByName("hand_root");
@@ -265,13 +265,13 @@ void DoMain() {
       diagram->GetMutableSubsystemContext(plant, diagram_context.get());
 
   // Initialize the mug pose to be right in the middle between the fingers.
+  const multibody::Body<double>& mug = plant.GetBodyByName("simple_mug");
   const Eigen::Vector3d& p_WHand =
       plant.EvalBodyPoseInWorld(plant_context, hand).translation();
   RigidTransformd X_WM(
       RollPitchYawd(M_PI / 2, 0, 0),
       p_WHand + Eigen::Vector3d(0.095, 0.062, 0.095));
-  plant.SetFreeBodyPose(&plant_context,
-                        plant.GetUniqueFreeBaseBodyOrThrow(mug_model), X_WM);
+  plant.SetFreeBodyPose(&plant_context, mug, X_WM);
 
   // set the initial command for the hand
   hand_command_receiver.set_initial_position(

--- a/examples/allegro_hand/joint_control/simple_mug.sdf
+++ b/examples/allegro_hand/joint_control/simple_mug.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <sdf version="1.7">
   <model name="simple_mug">
-    <link name="main_body">
+    <link name="simple_mug">
       <inertial>
         <pose>0.01 0 0.05 0 0 0</pose>
         <mass>0.094</mass>

--- a/examples/hydroelastic/python_ball_paddle/BUILD.bazel
+++ b/examples/hydroelastic/python_ball_paddle/BUILD.bazel
@@ -8,7 +8,12 @@ package(default_visibility = ["//visibility:private"])
 drake_py_binary(
     name = "contact_sim_demo_py",
     srcs = ["contact_sim_demo.py"],
+    add_test_rule = 1,
     data = [":ball_paddle_files"],
+    test_rule_args = [
+        "--target_realtime_rate=0",
+        "--simulation_time=0.1",
+    ],
     deps = [
         "//bindings/pydrake",
     ],

--- a/examples/hydroelastic/python_ball_paddle/contact_sim_demo.py
+++ b/examples/hydroelastic/python_ball_paddle/contact_sim_demo.py
@@ -40,7 +40,7 @@ def make_ball_paddle(contact_model, contact_surface_representation,
     paddle_sdf_file_name = \
         FindResourceOrThrow("drake/examples/hydroelastic/python_ball_paddle"
                             "/paddle.sdf")
-    paddle = parser.AddModelFromFile(paddle_sdf_file_name, model_name="paddle")
+    (paddle,) = parser.AddModels(paddle_sdf_file_name)
     plant.WeldFrames(
         frame_on_parent_F=plant.world_frame(),
         frame_on_child_M=plant.GetFrameByName("paddle", paddle),

--- a/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
+++ b/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
@@ -154,9 +154,8 @@ int DoMain() {
       "schunk_wsg_50_hydro_bubble.sdf");
   const std::string spatula_file = FindResourceOrThrow(
       "drake/examples/hydroelastic/spatula_slip_control/models/spatula.sdf");
-  parser.AddModelFromFile(gripper_file);
-  multibody::ModelInstanceIndex spatula_instance =
-      parser.AddModelFromFile(spatula_file);
+  parser.AddModels(gripper_file);
+  parser.AddModels(spatula_file);
   // Pose the gripper and weld it to the world.
   const math::RigidTransform<double> X_WF0 = math::RigidTransform<double>(
       math::RollPitchYaw(0.0, -1.57, 0.0), Eigen::Vector3d(0, 0, 0.25));
@@ -217,7 +216,7 @@ int DoMain() {
   // Set spatula's free body pose.
   const math::RigidTransform<double> X_WF1 = math::RigidTransform<double>(
       math::RollPitchYaw(-0.4, 0.0, 1.57), Eigen::Vector3d(0.35, 0, 0.25));
-  const auto& base_link = plant.GetBodyByName("spatula", spatula_instance);
+  const auto& base_link = plant.GetBodyByName("spatula");
   plant.SetFreeBodyPose(&plant_context, base_link, X_WF1);
 
   // Set finger joint positions.

--- a/examples/kinova_jaco_arm/jaco_simulation.cc
+++ b/examples/kinova_jaco_arm/jaco_simulation.cc
@@ -65,7 +65,7 @@ int DoMain() {
       multibody::AddMultibodyPlantSceneGraph(&builder, FLAGS_time_step);
 
   const multibody::ModelInstanceIndex jaco_id =
-      Parser(&jaco_plant).AddModelFromFile(FindResourceOrThrow(kUrdfPath));
+      Parser(&jaco_plant).AddModels(FindResourceOrThrow(kUrdfPath)).at(0);
   jaco_plant.WeldFrames(jaco_plant.world_frame(),
                         jaco_plant.GetFrameByName("base"));
   jaco_plant.Finalize();

--- a/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -65,8 +65,8 @@ int DoMain() {
       "urdf/iiwa14_polytope_collision.urdf";
   const std::string urdf =
       (!FLAGS_urdf.empty() ? FLAGS_urdf : FindResourceOrThrow(kModelPath));
-  auto iiwa_instance = multibody::Parser(
-      &plant, &scene_graph).AddModelFromFile(urdf);
+  auto iiwa_instance =
+      multibody::Parser(&plant, &scene_graph).AddModels(urdf).at(0);
   plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("base"));
   plant.Finalize();
 

--- a/examples/manipulation_station/manipulation_station_hardware_interface.cc
+++ b/examples/manipulation_station/manipulation_station_hardware_interface.cc
@@ -132,7 +132,7 @@ ManipulationStationHardwareInterface::ManipulationStationHardwareInterface(
   const std::string iiwa_sdf_path = FindResourceOrThrow(
       "drake/manipulation/models/iiwa_description/sdf/iiwa14_no_collision.sdf");
   Parser parser(owned_controller_plant_.get());
-  iiwa_model_instance_ = parser.AddModelFromFile(iiwa_sdf_path, "iiwa");
+  iiwa_model_instance_ = parser.AddModels(iiwa_sdf_path).at(0);
 
   // TODO(russt): Provide API for changing the base coordinates of the plant.
   owned_controller_plant_->WeldFrames(owned_controller_plant_->world_frame(),

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -108,10 +108,8 @@ GTEST_TEST(ManipulationStationTest, CheckPlantBasics) {
   station.SetupManipulationClassStation();
   multibody::Parser parser(&station.get_mutable_multibody_plant(),
                            &station.get_mutable_scene_graph());
-  parser.AddModelFromFile(
-      FindResourceOrThrow("drake/examples/manipulation_station/models"
-                          "/061_foam_brick.sdf"),
-      "object");
+  parser.AddModels(FindResourceOrThrow(
+      "drake/examples/manipulation_station/models/061_foam_brick.sdf"));
   station.Finalize();
 
   auto& plant = station.get_multibody_plant();

--- a/examples/planar_gripper/gripper_brick.cc
+++ b/examples/planar_gripper/gripper_brick.cc
@@ -59,11 +59,11 @@ std::unique_ptr<systems::Diagram<T>> ConstructDiagram(
   const std::string gripper_path =
       FindResourceOrThrow("drake/examples/planar_gripper/planar_gripper.sdf");
   multibody::Parser parser(*plant, *scene_graph);
-  parser.AddModelFromFile(gripper_path, "gripper");
+  parser.AddModels(gripper_path);
   examples::planar_gripper::WeldGripperFrames(*plant);
   const std::string brick_path =
       FindResourceOrThrow("drake/examples/planar_gripper/planar_brick.sdf");
-  parser.AddModelFromFile(brick_path, "brick");
+  parser.AddModels(brick_path);
   (*plant)->WeldFrames((*plant)->world_frame(),
                        (*plant)->GetFrameByName("brick_base"),
                        math::RigidTransformd());
@@ -87,7 +87,7 @@ GripperBrickHelper<T>::GripperBrickHelper() {
             plant_
                 ->GetBodyByName("finger" + std::to_string(i + 1) + "_tip_link")
                 .index()),
-        geometry::Role::kProximity, "gripper::tip_sphere_collision");
+        geometry::Role::kProximity, "planar_gripper::tip_sphere_collision");
   }
   const geometry::Shape& fingertip_shape =
       inspector.GetShape(finger_tip_sphere_geometry_ids_[0]);

--- a/examples/planar_gripper/planar_gripper_simulation.cc
+++ b/examples/planar_gripper/planar_gripper_simulation.cc
@@ -243,14 +243,13 @@ int DoMain() {
   const std::string full_name =
       FindResourceOrThrow("drake/examples/planar_gripper/planar_gripper.sdf");
   const ModelInstanceIndex gripper_index =
-      Parser(&plant).AddModelFromFile(full_name);
+      Parser(&plant).AddModels(full_name).at(0);
   WeldGripperFrames<double>(&plant);
 
   // Adds the brick to be manipulated.
   const std::string brick_file_name =
       FindResourceOrThrow("drake/examples/planar_gripper/planar_brick.sdf");
-  const ModelInstanceIndex brick_index =
-      Parser(&plant).AddModelFromFile(brick_file_name, "brick");
+  Parser(&plant).AddModels(brick_file_name);
 
   // When the planar-gripper is welded via WeldGripperFrames(), motion always
   // lies in the world Y-Z plane (because the planar-gripper frame is aligned
@@ -259,7 +258,7 @@ int DoMain() {
   Vector3d gravity;
   if (FLAGS_orientation == "vertical") {
     const multibody::Frame<double>& brick_base_frame =
-        plant.GetFrameByName("brick_base", brick_index);
+        plant.GetFrameByName("brick_base");
     plant.WeldFrames(plant.world_frame(), brick_base_frame);
     gravity = Vector3d(
         0, 0, -multibody::UniformGravityFieldElement<double>::kDefaultStrength);

--- a/examples/planar_gripper/test/planar_gripper_common_test.cc
+++ b/examples/planar_gripper/test/planar_gripper_common_test.cc
@@ -34,7 +34,7 @@ GTEST_TEST(ReorderKeyframesTest, Test) {
   const std::string full_name =
       FindResourceOrThrow("drake/examples/planar_gripper/planar_gripper.sdf");
   MultibodyPlant<double> plant(0.0);
-  multibody::Parser(&plant).AddModelFromFile(full_name, "gripper");
+  multibody::Parser(&plant).AddModels(full_name);
   WeldGripperFrames(&plant);
   plant.Finalize();
 
@@ -85,11 +85,11 @@ GTEST_TEST(ReorderKeyframesTest, Test) {
   // Test throw when plant positions don't match number of expected planar
   // gripper joints.
   MultibodyPlant<double> bad_plant(0.0);
-  multibody::Parser(&bad_plant).AddModelFromFile(full_name, "gripper");
+  multibody::Parser(&bad_plant).AddModels(full_name);
   WeldGripperFrames(&bad_plant);
   const std::string extra_model_name =
       FindResourceOrThrow("drake/examples/planar_gripper/planar_brick.sdf");
-  multibody::Parser(&bad_plant).AddModelFromFile(extra_model_name, "brick");
+  multibody::Parser(&bad_plant).AddModels(extra_model_name);
   bad_plant.Finalize();
   EXPECT_THROW(
       ReorderKeyframesForPlant(bad_plant, keyframes,

--- a/examples/quadrotor/quadrotor_geometry.cc
+++ b/examples/quadrotor/quadrotor_geometry.cc
@@ -44,13 +44,17 @@ QuadrotorGeometry::QuadrotorGeometry(
   multibody::MultibodyPlant<double> mbp(0.0);
   multibody::Parser parser(&mbp, scene_graph);
 
-  auto model_id = parser.AddModelFromFile(
-      FindResourceOrThrow("drake/examples/quadrotor/quadrotor.urdf"),
-      "quadrotor");
+  const auto model_instance_indices = parser.AddModels(
+      FindResourceOrThrow("drake/examples/quadrotor/quadrotor.urdf"));
   mbp.Finalize();
 
+  // Identify the single quadrotor body and its frame.
+  DRAKE_THROW_UNLESS(model_instance_indices.size() == 1);
+  const auto body_indices = mbp.GetBodyIndices(model_instance_indices[0]);
+  DRAKE_THROW_UNLESS(body_indices.size() == 1);
+  const multibody::BodyIndex body_index = body_indices[0];
   source_id_ = *mbp.get_source_id();
-  frame_id_ = mbp.GetBodyFrameIdOrThrow(mbp.GetBodyIndices(model_id)[0]);
+  frame_id_ = mbp.GetBodyFrameIdOrThrow(body_index);
 
   this->DeclareVectorInputPort("state", 12);
   this->DeclareAbstractOutputPort(

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -169,13 +169,10 @@ int do_main() {
       multibody::AddMultibodyPlant(plant_config, &builder);
 
   Parser parser(&plant);
-  std::string full_name =
-      FindResourceOrThrow("drake/examples/simple_gripper/simple_gripper.sdf");
-  parser.AddModelFromFile(full_name);
-
-  full_name =
-      FindResourceOrThrow("drake/examples/simple_gripper/simple_mug.sdf");
-  ModelInstanceIndex mug_model = parser.AddModelFromFile(full_name);
+  parser.AddModels(FindResourceOrThrow(
+      "drake/examples/simple_gripper/simple_gripper.sdf"));
+  parser.AddModels(FindResourceOrThrow(
+      "drake/examples/simple_gripper/simple_mug.sdf"));
 
   // Obtain the "translate_joint" axis so that we know the direction of the
   // forced motions. We do not apply gravity if motions are forced in the
@@ -335,6 +332,7 @@ int do_main() {
   right_slider.set_translation(&plant_context, finger_offset);
 
   // Initialize the mug pose to be right in the middle between the fingers.
+  const multibody::Body<double>& mug = plant.GetBodyByName("simple_mug");
   const Vector3d& p_WBr =
       plant.EvalBodyPoseInWorld(plant_context, right_finger).translation();
   const Vector3d& p_WBl =
@@ -345,8 +343,7 @@ int do_main() {
       RollPitchYawd(FLAGS_rx * M_PI / 180, FLAGS_ry * M_PI / 180,
                     (FLAGS_rz * M_PI / 180) + M_PI),
       Vector3d(0.0, mug_y_W, 0.0));
-  plant.SetFreeBodyPose(&plant_context,
-                        plant.GetUniqueFreeBaseBodyOrThrow(mug_model), X_WM);
+  plant.SetFreeBodyPose(&plant_context, mug, X_WM);
 
   // Set the initial height of the gripper and its initial velocity so that with
   // the applied harmonic forces it continues to move in a harmonic oscillation

--- a/examples/simple_gripper/simple_mug.sdf
+++ b/examples/simple_gripper/simple_mug.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <sdf version="1.7">
   <model name="simple_mug">
-    <link name="main_body">
+    <link name="simple_mug">
       <inertial>
         <pose>0.01 0 0.05 0 0 0</pose>
         <mass>0.094</mass>

--- a/geometry/render_gltf_client/test/client_demo.cc
+++ b/geometry/render_gltf_client/test/client_demo.cc
@@ -196,10 +196,8 @@ int DoMain() {
   // we don't want to have to wait for gravity to take effect to observe a
   // difference in position.
   Parser parser{&plant};
-  parser.AddModelFromFile(
-      FindResourceOrThrow(
-          "drake/geometry/render_gltf_client/test/example_scene.sdf"),
-      "example_scene");
+  parser.AddModels(FindResourceOrThrow(
+      "drake/geometry/render_gltf_client/test/example_scene.sdf"));
 
   DrakeLcm lcm;
   DrakeVisualizerd::AddToBuilder(&builder, scene_graph, &lcm);

--- a/manipulation/kuka_iiwa/test/build_iiwa_control_test.cc
+++ b/manipulation/kuka_iiwa/test/build_iiwa_control_test.cc
@@ -46,12 +46,13 @@ class BuildIiwaControlTest : public ::testing::Test {
   void SetUp() {
     sim_plant_ = builder_.AddSystem<MultibodyPlant<double>>(0.001);
     Parser parser{sim_plant_};
-    const std::string iiwa7_model_name = "iiwa7_model";
     const std::string iiwa7_model_path = FindResourceOrThrow(
         "drake/manipulation/models/iiwa_description/iiwa7"
         "/iiwa7_no_collision.sdf");
     const ModelInstanceIndex iiwa7_instance =
-        parser.AddModelFromFile(iiwa7_model_path, iiwa7_model_name);
+        parser.AddModels(iiwa7_model_path).at(0);
+    const std::string iiwa7_model_name =
+        sim_plant_->GetModelInstanceName(iiwa7_instance);
 
     iiwa7_info_.model_name = iiwa7_model_name;
     iiwa7_info_.model_path = iiwa7_model_path;

--- a/manipulation/models/allegro_hand_description/test/parse_test.cc
+++ b/manipulation/models/allegro_hand_description/test/parse_test.cc
@@ -29,9 +29,8 @@ TEST_P(ParseTest, Quantities) {
   MultibodyPlant<double> plant(0.0);
   Parser parser(&plant);
   const ModelInstanceIndex right_hand_index =
-      parser.AddModelFromFile(path_right);
-  const ModelInstanceIndex left_hand_index =
-      parser.AddModelFromFile(path_left);
+      parser.AddModels(path_right).at(0);
+  const ModelInstanceIndex left_hand_index = parser.AddModels(path_left).at(0);
   plant.Finalize();
 
   // MultibodyPlant always creates at least two model instances, one for the

--- a/manipulation/models/iiwa_description/test/iiwa14_variants_parsing_test.cc
+++ b/manipulation/models/iiwa_description/test/iiwa14_variants_parsing_test.cc
@@ -18,7 +18,7 @@ multibody::ModelInstanceIndex LoadIiwa14CanonicalModel(
       FindResourceOrThrow("drake/manipulation/models/iiwa_description/sdf/"
                           "iiwa14_no_collision.sdf"));
   multibody::Parser parser(plant);
-  return parser.AddModelFromFile(canonical_model_file);
+  return parser.AddModels(canonical_model_file).at(0);
 }
 
 // Compares velocity, acceleration, effort and position limits of two given

--- a/manipulation/planner/constraint_relaxing_ik.cc
+++ b/manipulation/planner/constraint_relaxing_ik.cc
@@ -20,8 +20,10 @@ ConstraintRelaxingIk::ConstraintRelaxingIk(
     const std::string& end_effector_link_name)
     : rand_generator_(kDefaultRandomSeed),
       plant_(0) {
-  const auto model_instance =
-      multibody::Parser(&plant_).AddModelFromFile(model_path);
+  const auto models = multibody::Parser(&plant_).AddModels(model_path);
+  DRAKE_THROW_UNLESS(models.size() == 1);
+  const auto model_instance = models[0];
+
 
   // Check if our robot is welded to the world.  If not, try welding the first
   // link.

--- a/manipulation/planner/test/differential_inverse_kinematics_integrator_test.cc
+++ b/manipulation/planner/test/differential_inverse_kinematics_integrator_test.cc
@@ -22,7 +22,7 @@ std::unique_ptr<multibody::MultibodyPlant<double>> MakeIiwa(void) {
   const std::string filename = FindResourceOrThrow(
       "drake/manipulation/models/"
       "iiwa_description/sdf/iiwa14_no_collision.sdf");
-  parser.AddModelFromFile(filename, "iiwa");
+  parser.AddModels(filename);
   robot->WeldFrames(robot->world_frame(), robot->GetFrameByName("iiwa_link_0"));
   robot->Finalize();
   return robot;

--- a/manipulation/planner/test/differential_inverse_kinematics_test.cc
+++ b/manipulation/planner/test/differential_inverse_kinematics_test.cc
@@ -45,7 +45,7 @@ class DifferentialInverseKinematicsTest : public ::testing::Test {
     const std::string filename = FindResourceOrThrow(
         "drake/manipulation/models/"
         "iiwa_description/sdf/iiwa14_no_collision.sdf");
-    parser.AddModelFromFile(filename, "iiwa");
+    parser.AddModels(filename);
     plant_->WeldFrames(
         plant_->world_frame(),
         plant_->GetFrameByName("iiwa_link_0"));
@@ -366,7 +366,7 @@ GTEST_TEST(AdditionalDifferentialInverseKinematicsTests, TestLinearObjective) {
   const std::string filename = FindResourceOrThrow(
       "drake/manipulation/models/iiwa_description/urdf/"
       "planar_iiwa14_spheres_dense_elbow_collision.urdf");
-  parser.AddModelFromFile(filename, "iiwa");
+  parser.AddModels(filename);
   plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("iiwa_link_0"));
   plant.Finalize();
   const multibody::Frame<double>& frame_7 = plant.GetFrameByName("iiwa_link_7");

--- a/manipulation/schunk_wsg/test/build_schunk_wsg_control_test.cc
+++ b/manipulation/schunk_wsg/test/build_schunk_wsg_control_test.cc
@@ -35,7 +35,7 @@ class BuildSchunkWsgControlTest : public ::testing::Test {
     Parser parser{sim_plant_};
     const std::string wsg_file = FindResourceOrThrow(
         "drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50.sdf");
-    wsg_instance_ = parser.AddModelFromFile(wsg_file, "wsg_instance");
+    wsg_instance_ = parser.AddModels(wsg_file).at(0);
 
     // Weld the gripper to the world frame.
     sim_plant_->WeldFrames(sim_plant_->world_frame(),

--- a/manipulation/schunk_wsg/test/schunk_wsg_driver_functions_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_driver_functions_test.cc
@@ -34,7 +34,7 @@ GTEST_TEST(SchunkWsgDriverFunctionsTest, ApplyDriverConfig) {
   const std::string filename = FindResourceOrThrow(
       "drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50.sdf");
   const ModelInstanceIndex schunk_wsg =
-      Parser(&plant).AddModelFromFile(filename, "schunk_wsg");
+      Parser(&plant).AddModels(filename).at(0);
   plant.WeldFrames(plant.world_frame(),
                    plant.GetFrameByName("body", schunk_wsg));
   plant.Finalize();
@@ -45,7 +45,8 @@ GTEST_TEST(SchunkWsgDriverFunctionsTest, ApplyDriverConfig) {
       systems::lcm::ApplyLcmBusConfig(lcm_bus_config, &builder);
 
   const SchunkWsgDriver schunk_wsg_driver;
-  ApplyDriverConfig(schunk_wsg_driver, "schunk_wsg", plant, {}, lcm_buses,
+  const std::string schunk_wsg_name = plant.GetModelInstanceName(schunk_wsg);
+  ApplyDriverConfig(schunk_wsg_driver, schunk_wsg_name, plant, {}, lcm_buses,
                     &builder);
 
   // Prove that simulation does not crash.

--- a/manipulation/schunk_wsg/test/schunk_wsg_position_controller_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_position_controller_test.cc
@@ -77,7 +77,7 @@ GTEST_TEST(SchunkWsgPositionControllerTest, SimTest) {
   const std::string wsg_sdf_path = FindResourceOrThrow(
       "drake/manipulation/models/"
       "wsg_50_description/sdf/schunk_wsg_50.sdf");
-  const auto wsg_model = Parser(wsg).AddModelFromFile(wsg_sdf_path, "gripper");
+  const auto wsg_model = Parser(wsg).AddModels(wsg_sdf_path).at(0);
   wsg->WeldFrames(wsg->world_frame(), wsg->GetFrameByName("body", wsg_model),
                   math::RigidTransformd::Identity());
   wsg->Finalize();

--- a/manipulation/util/test/zero_force_driver_functions_test.cc
+++ b/manipulation/util/test/zero_force_driver_functions_test.cc
@@ -24,12 +24,12 @@ GTEST_TEST(ZeroForceDriverFunctionsTest, SmokeTest) {
       AddMultibodyPlant(MultibodyPlantConfig{}, &builder);
   const std::string filename = FindResourceOrThrow(
       "drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50.sdf");
-  Parser(&plant).AddModelFromFile(filename, "gripper");
+  Parser(&plant).AddModels(filename);
   plant.Finalize();
 
   // Apply zero actuation input.
   const ZeroForceDriver config;
-  ApplyDriverConfig(config, "gripper", plant, {}, {}, &builder);
+  ApplyDriverConfig(config, "Schunk_Gripper", plant, {}, {}, &builder);
 
   // Prove that simulation does not crash.
   Simulator<double> simulator(builder.Build());

--- a/multibody/benchmarking/iiwa_relaxed_pos_ik.cc
+++ b/multibody/benchmarking/iiwa_relaxed_pos_ik.cc
@@ -49,11 +49,9 @@ BENCHMARK_F(RelaxedPosIkBenchmark, Iiwa)(benchmark::State& state) {  // NOLINT
   // Create a parser for the plant.
   multibody::Parser parser{&plant};
   // Load the model into the parser.
-  const multibody::ModelInstanceIndex model_instance =
-      parser.AddModelFromFile(iiwa_path);
+  parser.AddModels(iiwa_path);
   // Attach the base of the robot into the world frame.
-  plant.WeldFrames(plant.world_frame(),
-                   plant.GetFrameByName("iiwa_link_0", model_instance));
+  plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("iiwa_link_0"));
   // Finalize the plant.
   plant.Finalize();
   // Create a context.

--- a/multibody/inverse_kinematics/test/global_inverse_kinematics_test_util.cc
+++ b/multibody/inverse_kinematics/test/global_inverse_kinematics_test_util.cc
@@ -26,7 +26,7 @@ std::unique_ptr<multibody::MultibodyPlant<double>> ConstructKuka() {
       "iiwa14_no_collision.sdf");
   auto plant = std::make_unique<MultibodyPlant<double>>(0.1);
   multibody::Parser parser{plant.get()};
-  parser.AddModelFromFile(iiwa_path, "iiwa");
+  parser.AddModels(iiwa_path);
   plant->WeldFrames(plant->world_frame(), plant->GetFrameByName("iiwa_link_0"));
   plant->Finalize();
 

--- a/multibody/optimization/test/toppra_test.cc
+++ b/multibody/optimization/test/toppra_test.cc
@@ -21,11 +21,9 @@ class IiwaToppraTest : public ::testing::Test {
     std::string file_path = FindResourceOrThrow(
         "drake/manipulation/models/iiwa_description/iiwa7/"
         "iiwa7_no_collision.sdf");
-    const auto iiwa_instance = multibody::Parser(iiwa_plant_.get())
-                                   .AddModelFromFile(file_path, "iiwa");
+    multibody::Parser(iiwa_plant_.get()).AddModels(file_path);
     iiwa_plant_->WeldFrames(
-        iiwa_plant_->world_frame(),
-        iiwa_plant_->GetFrameByName("iiwa_link_0", iiwa_instance));
+        iiwa_plant_->world_frame(), iiwa_plant_->GetFrameByName("iiwa_link_0"));
     iiwa_plant_->Finalize();
     plant_context_ = iiwa_plant_->CreateDefaultContext();
 

--- a/multibody/plant/test/frame_kinematics_test.cc
+++ b/multibody/plant/test/frame_kinematics_test.cc
@@ -670,7 +670,7 @@ GTEST_TEST(MultibodyPlantTest, FixedWorldKinematics) {
   // However the world is non-empty.
   ASSERT_NE(plant.num_bodies(), 0);
 
-  const Body<double>& mug = plant.GetBodyByName("main_body");
+  const Body<double>& mug = plant.GetBodyByName("simple_mug");
 
   // The objects frame O is affixed to a robot table defined by
   // test::AddFixedObjectsToPlant().

--- a/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
+++ b/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
@@ -165,7 +165,7 @@ GTEST_TEST(MultibodyPlantForwardDynamics, AtlasRobot) {
   const std::string model_path =
       FindResourceOrThrow("drake/examples/atlas/urdf/atlas_convex_hull.urdf");
   Parser parser(&plant);
-  auto atlas_instance = parser.AddModelFromFile(model_path);
+  auto atlas_instance = parser.AddModels(model_path).at(0);
   plant.Finalize();
 
   // Create a context and store an arbitrary configuration.

--- a/multibody/plant/test/multibody_plant_introspection_test.cc
+++ b/multibody/plant/test/multibody_plant_introspection_test.cc
@@ -58,7 +58,7 @@ GTEST_TEST(MultibodyPlantIntrospection, FloatingBodies) {
 
   // Add a floating mug.
   const ModelInstanceIndex mug_model = parser.AddModelFromFile(mug_sdf_path);
-  const Body<double>& mug = plant.GetBodyByName("main_body", mug_model);
+  const Body<double>& mug = plant.GetBodyByName("simple_mug", mug_model);
 
   // Introspection of the underlying mathematical model is not available until
   // we call Finalize().

--- a/multibody/plant/test/multibody_plant_mass_matrix_test.cc
+++ b/multibody/plant/test/multibody_plant_mass_matrix_test.cc
@@ -46,11 +46,11 @@ class MultibodyPlantMassMatrixTests : public ::testing::Test {
 
     Parser parser(&plant_);
     const ModelInstanceIndex arm_model =
-        parser.AddModelFromFile(FindResourceOrThrow(kArmSdfPath));
+        parser.AddModels(FindResourceOrThrow(kArmSdfPath)).at(0);
 
     // Add the gripper.
     const ModelInstanceIndex gripper_model =
-        parser.AddModelFromFile(FindResourceOrThrow(kWsg50SdfPath));
+        parser.AddModels(FindResourceOrThrow(kWsg50SdfPath)).at(0);
 
     const auto& base_body = plant_.GetBodyByName("iiwa_link_0", arm_model);
     const auto& end_effector = plant_.GetBodyByName("iiwa_link_7", arm_model);

--- a/multibody/plant/test/multibody_plant_reflected_inertia_test.cc
+++ b/multibody/plant/test/multibody_plant_reflected_inertia_test.cc
@@ -119,10 +119,10 @@ class MultibodyPlantReflectedInertiaTests : public ::testing::Test {
         "drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50.sdf";
 
     Parser parser(plant);
-    arm_model = parser.AddModelFromFile(FindResourceOrThrow(kArmSdfPath));
+    arm_model = parser.AddModels(FindResourceOrThrow(kArmSdfPath)).at(0);
 
     // Add the gripper.
-    gripper_model = parser.AddModelFromFile(FindResourceOrThrow(kWsg50SdfPath));
+    gripper_model = parser.AddModels(FindResourceOrThrow(kWsg50SdfPath)).at(0);
 
     const auto& base_body = plant->GetBodyByName("iiwa_link_0", arm_model);
     const auto& end_effector = plant->GetBodyByName("iiwa_link_7", arm_model);

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -3308,9 +3308,8 @@ GTEST_TEST(StateSelection, FloatingBodies) {
           X_TO));
 
   // Add a floating mug.
-  const ModelInstanceIndex mug_model =
-      parser.AddModelFromFile(mug_sdf_path);
-  const Body<double>& mug = plant.GetBodyByName("main_body", mug_model);
+  parser.AddModels(mug_sdf_path);
+  const Body<double>& mug = plant.GetBodyByName("simple_mug");
 
   plant.Finalize();
 

--- a/multibody/test_utilities/add_fixed_objects_to_plant.h
+++ b/multibody/test_utilities/add_fixed_objects_to_plant.h
@@ -59,8 +59,8 @@ void AddFixedObjectsToPlant(MultibodyPlant<T>* plant) {
           X_TO));
 
   // Add a mug and weld it to the table.
-  const ModelInstanceIndex mug_model = parser.AddModelFromFile(mug_sdf_path);
-  const Body<double>& mug = plant->GetBodyByName("main_body", mug_model);
+  parser.AddModels(mug_sdf_path);
+  const Body<double>& mug = plant->GetBodyByName("simple_mug");
 
   // Weld the mug to the table with its center 5 cm above the table, i.e. with
   // its base on the table.

--- a/tutorials/mathematical_program_multibody_plant.ipynb
+++ b/tutorials/mathematical_program_multibody_plant.ipynb
@@ -86,7 +86,7 @@
     "iiwa_file = FindResourceOrThrow(\n",
     "   \"drake/manipulation/models/iiwa_description/sdf/\"\n",
     "   \"iiwa14_no_collision.sdf\")\n",
-    "iiwa = Parser(plant_f).AddModelFromFile(iiwa_file)\n",
+    "(iiwa,) = Parser(plant_f).AddModels(iiwa_file)\n",
     "\n",
     "# Define some short aliases for frames.\n",
     "W = plant_f.world_frame()\n",


### PR DESCRIPTION
Port some more parser call sites to AddModels. These examples are a bit more involved than those in part 1.

- Some select a single model index from the return vector
  - using bounds-checked access:
    - Python: AddModels("blah")[0]
    - C++: AddModels("blah").at(0)
- Some abandon unnecessary model renaming
- Some are ported to use model names from the file in nearby code

In addition, some Python call sites from the prior patch get formatting cleanups.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18277)
<!-- Reviewable:end -->
