### PR TITLE
MosekSolver aggregates duplicated variables in constraints.

### DIFF
--- a/solvers/aggregate_costs_constraints.cc
+++ b/solvers/aggregate_costs_constraints.cc
@@ -201,6 +201,39 @@ void AggregateBoundingBoxConstraints(const MathematicalProgram& prog,
   }
 }
 
+void AggregateDuplicateVariables(const Eigen::SparseMatrix<double>& A,
+                                 const VectorX<symbolic::Variable>& vars,
+                                 Eigen::SparseMatrix<double>* A_new,
+                                 VectorX<symbolic::Variable>* vars_new) {
+  // First select the unique variables from decision_vars.
+  vars_new->resize(vars.rows());
+  // vars_to_vars_new records the mapping from vars to vars_new. Namely
+  // vars[i] = (*vars_new)[vars_to_vars_new[vars[i].get_id()]]
+  std::unordered_map<symbolic::Variable::Id, int> vars_to_vars_new;
+  int unique_var_count = 0;
+  for (int i = 0; i < vars.rows(); ++i) {
+    const bool seen_already = vars_to_vars_new.count(vars(i).get_id());
+    if (!seen_already) {
+      (*vars_new)(unique_var_count) = vars(i);
+      vars_to_vars_new.emplace(vars(i).get_id(), unique_var_count);
+      unique_var_count++;
+    }
+  }
+  // A * vars = A_new * vars_new.
+  // A_new_triplets are the non-zero triplets in A_new.
+  std::vector<Eigen::Triplet<double>> A_new_triplets;
+  A_new_triplets.reserve(A.nonZeros());
+  for (int i = 0; i < A.cols(); ++i) {
+    const int A_new_col = vars_to_vars_new.at(vars(i).get_id());
+    for (Eigen::SparseMatrix<double>::InnerIterator it(A, i); it; ++it) {
+      A_new_triplets.emplace_back(it.row(), A_new_col, it.value());
+    }
+  }
+  *A_new = Eigen::SparseMatrix<double>(A.rows(), unique_var_count);
+  A_new->setFromTriplets(A_new_triplets.begin(), A_new_triplets.end());
+  vars_new->conservativeResize(unique_var_count);
+}
+
 const Binding<QuadraticCost>* FindNonconvexQuadraticCost(
     const std::vector<Binding<QuadraticCost>>& quadratic_costs) {
   for (const auto& cost : quadratic_costs) {

--- a/solvers/aggregate_costs_constraints.h
+++ b/solvers/aggregate_costs_constraints.h
@@ -82,6 +82,17 @@ void AggregateBoundingBoxConstraints(const MathematicalProgram& prog,
                                      Eigen::VectorXd* lower,
                                      Eigen::VectorXd* upper);
 
+
+/**
+ For linear expression A * vars where `vars` might contain duplicated entries,
+ rewrite this linear expression as A_new * vars_new where vars_new doesn't
+ contain duplicated entries.
+ */
+void AggregateDuplicateVariables(const Eigen::SparseMatrix<double>& A,
+                                 const VectorX<symbolic::Variable>& vars,
+                                 Eigen::SparseMatrix<double>* A_new,
+                                 VectorX<symbolic::Variable>* vars_new);
+
 /**
  * Returns the first non-convex quadratic cost among @p quadratic_costs. If all
  * quadratic costs are convex, then return a nullptr.

--- a/solvers/mosek_solver_internal.h
+++ b/solvers/mosek_solver_internal.h
@@ -194,6 +194,20 @@ class MosekSolverProgram {
           MSKint64t, std::pair<std::vector<MSKint64t>, std::vector<MSKrealt>>>>*
           bar_F);
 
+  // Same as ParseLinearExpression, but assumes that each entry in
+  // `decision_vars` is unique.
+  MSKrescodee ParseLinearExpressionNoDuplication(
+      const solvers::MathematicalProgram& prog,
+      const Eigen::SparseMatrix<double>& A,
+      const Eigen::SparseMatrix<double>& B,
+      const VectorX<symbolic::Variable>& decision_vars,
+      const std::vector<MSKint32t>& slack_vars_mosek_indices,
+      std::vector<MSKint32t>* F_subi, std::vector<MSKint32t>* F_subj,
+      std::vector<MSKrealt>* F_valij,
+      std::vector<std::unordered_map<
+          MSKint64t, std::pair<std::vector<MSKint64t>, std::vector<MSKrealt>>>>*
+          bar_F);
+
   // Add LinearConstraints and LinearEqualityConstraints to the Mosek task.
   // @param[out] dual_indices maps each linear constraint to its dual variable
   // indices.

--- a/solvers/test/linear_program_examples.cc
+++ b/solvers/test/linear_program_examples.cc
@@ -7,6 +7,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/solvers/ipopt_solver.h"
+#include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/mosek_solver.h"
 #include "drake/solvers/test/mathematical_program_test_util.h"
 
@@ -22,6 +23,8 @@ using drake::symbolic::Expression;
 namespace drake {
 namespace solvers {
 namespace test {
+const double kInf = std::numeric_limits<double>::infinity();
+
 LinearFeasibilityProgram::LinearFeasibilityProgram(
     ConstraintForm constraint_form)
     : OptimizationProgram(CostForm::kSymbolic, constraint_form), x_() {
@@ -449,6 +452,50 @@ UnboundedLinearProgramTest1::UnboundedLinearProgramTest1()
   prog_->AddBoundingBoxConstraint(0, 1, VectorDecisionVariable<2>(x(0), x(2)));
 }
 
+DuplicatedVariableLinearProgramTest1::DuplicatedVariableLinearProgramTest1()
+    : prog_{std::make_unique<MathematicalProgram>()} {
+  x_ = prog_->NewContinuousVariables<3>();
+  // Intentionally add the cost with duplicated entries x_(1).
+  prog_->AddLinearCost(Eigen::Vector4d(1, 2, 1, 4),
+                       Vector4<symbolic::Variable>(x_(0), x_(1), x_(1), x_(2)));
+  prog_->AddLinearCost(Eigen::Vector2d(2, -2), 3,
+                       Vector2<symbolic::Variable>(x_(0), x_(0)));
+  prog_->AddLinearEqualityConstraint(
+      Eigen::RowVector3d(2, 2, -1), Vector1d(1),
+      Vector3<symbolic::Variable>(x_(0), x_(2), x_(0)));
+  Eigen::Matrix<double, 2, 5> A;
+  // A * vars = [x0 + 2*x1 + x2]
+  //            [2*x0 + x1     ]
+  // clang-format off
+  A << -1, 1, 3, 2, -1,
+       2, 2, -1, 1, -1;
+  // clang-format on
+  Eigen::Matrix<symbolic::Variable, 5, 1> vars;
+  vars << x_(2), x_(0), x_(2), x_(1), x_(2);
+  prog_->AddLinearConstraint(A, Eigen::Vector2d(-kInf, 1),
+                             Eigen::Vector2d(3, 3), vars);
+  prog_->AddLinearConstraint(
+      Eigen::RowVector4d(2, 3, 2, -1), Vector1d(0), Vector1d(kInf),
+      Vector4<symbolic::Variable>(x_(1), x_(2), x_(0), x_(0)));
+}
+
+void DuplicatedVariableLinearProgramTest1::CheckSolution(
+    const SolverInterface& solver, double tol) const {
+  if (solver.available()) {
+    MathematicalProgramResult result;
+    solver.Solve(*prog_, std::nullopt, std::nullopt, &result);
+    EXPECT_TRUE(result.is_success());
+    const Eigen::Vector3d x_sol = result.GetSolution(x_);
+    EXPECT_NEAR(result.get_optimal_cost(),
+                x_sol(0) + 3 * x_sol(1) + 4 * x_sol(2) + 3, tol);
+    EXPECT_LE(x_sol(0) + 2 * x_sol(1) + x_sol(2), 3 + tol);
+    EXPECT_NEAR(x_sol(0) + 2 * x_sol(2), 1, tol);
+    EXPECT_GE(2 * x_sol(0) + x_sol(1), 1 - tol);
+    EXPECT_LE(2 * x_sol(0) + x_sol(1), 3 + tol);
+    EXPECT_GE(x_sol(0) + 2 * x_sol(1) + 3 * x_sol(2), -tol);
+  }
+}
+
 void TestLPDualSolution1(const SolverInterface& solver, double tol) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>();
@@ -460,7 +507,6 @@ void TestLPDualSolution1(const SolverInterface& solver, double tol) {
        1, 5,
        3, 2;
   // clang-format on
-  const double kInf = std::numeric_limits<double>::infinity();
   Eigen::Matrix<double, 5, 1> lb, ub;
   lb << -kInf, -2, -3, -kInf, 4;
   ub << 3, kInf, 4, kInf, 5;
@@ -599,7 +645,6 @@ void TestLPPoorScaling2(const SolverInterface& solver, bool expect_success,
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<3>();
   auto r = prog.NewContinuousVariables<1>()(0);
-  const double kInf = std::numeric_limits<double>::infinity();
   for (int i = 0; i < A.rows(); ++i) {
     prog.AddLinearConstraint(A.row(i).dot(x) + A.row(i).norm() * r <= b(i));
   }

--- a/solvers/test/linear_program_examples.h
+++ b/solvers/test/linear_program_examples.h
@@ -6,6 +6,7 @@
 #include <tuple>
 #include <vector>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/solvers/test/optimization_examples.h"
 
 namespace drake {
@@ -209,6 +210,29 @@ class UnboundedLinearProgramTest1 : public ::testing::Test {
 
  protected:
   std::unique_ptr<MathematicalProgram> prog_;
+};
+
+/**
+ When adding constraints and costs, we intentionally put duplicated variables in
+ each constraint/cost binding, so as to test if Drake's solver wrapper can
+ handle duplicated variables correctly.
+ min x0 + 3 * x1 + 4 * x2 + 3
+ s.t x0 + 2 * x1 + x2 <= 3
+     x0 + 2 * x2 = 1
+     1 <= 2 * x0 + x1 <= 3
+     x0 + 2x1 + 3x2 >= 0
+ */
+class DuplicatedVariableLinearProgramTest1 : public ::testing::Test {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DuplicatedVariableLinearProgramTest1)
+
+  DuplicatedVariableLinearProgramTest1();
+
+  void CheckSolution(const SolverInterface& solver, double tol = 1E-7) const;
+
+ protected:
+  std::unique_ptr<MathematicalProgram> prog_;
+  Vector3<symbolic::Variable> x_;
 };
 
 /**

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -62,6 +62,13 @@ TEST_F(UnboundedLinearProgramTest1, Test) {
   }
 }
 
+TEST_F(DuplicatedVariableLinearProgramTest1, Test) {
+  MosekSolver solver;
+  if (solver.available()) {
+    CheckSolution(solver);
+  }
+}
+
 TEST_P(QuadraticProgramTest, TestQP) {
   MosekSolver solver;
   prob()->RunProblem(&solver);


### PR DESCRIPTION
This fixes duplicated variables in linear and conic constraints in Mosek.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18280)
<!-- Reviewable:end -->
