### PR TITLE
[pydrake] Switch the clang-format directives order

### DIFF
--- a/bindings/pydrake/.clang-format
+++ b/bindings/pydrake/.clang-format
@@ -1,24 +1,5 @@
 # -*- yaml -*-
 
-# This portion of the file contains settings that are local to the
-# //bindings/... code, rather than all of Drake.
-
-# When a function signature's parameters or a function call's arguments need to
-# wrap onto another line, indent by four spaces -- do not whitespace castle all
-# the way over to the open-paren.
-AlignAfterOpenBracket: DontAlign
-
-# Try to fit onto a single line:
-# - functions with an empty body, or
-# - member functions defined inside a class;
-# everything else (e.g., free functions) are forced onto multiple lines.
-AllowShortFunctionsOnASingleLine: Inline
-
-# -----------------------------------------------------------------------------
-# The contents of the root dotfile should be exactly copied below this point.
-# -----------------------------------------------------------------------------
-# -*- yaml -*-
-
 # This file determines clang-format's style settings; for details, refer to
 # http://clang.llvm.org/docs/ClangFormatStyleOptions.html
 
@@ -63,3 +44,18 @@ IncludeCategories:
   # Other libraries' h files (with quotes).
   - Regex:    '^"'
     Priority: 40
+
+# -----------------------------------------------------------------------------
+# Hereafter are the pydrake-specific override settings.
+# -----------------------------------------------------------------------------
+
+# When a function signature's parameters or a function call's arguments need to
+# wrap onto another line, indent by four spaces -- do not whitespace castle all
+# the way over to the open-paren.
+AlignAfterOpenBracket: DontAlign
+
+# Try to fit onto a single line:
+# - functions with an empty body, or
+# - member functions defined inside a class;
+# everything else (e.g., free functions) are forced onto multiple lines.
+AllowShortFunctionsOnASingleLine: Inline

--- a/bindings/pydrake/test/dot_clang_format_test.py
+++ b/bindings/pydrake/test/dot_clang_format_test.py
@@ -15,10 +15,8 @@ class TestDotfile(unittest.TestCase):
 
         # The bindings file should be longer.
         self.assertGreater(len(bindings_contents), len(root_contents))
-        offset = len(bindings_contents) - len(root_contents)
-        assert offset > 0
 
-        # Every line in root should appear in bindings.
+        # The bindings config only ever appends to the root settings.
         self.assertMultiLineEqual(
             "".join(root_contents),
-            "".join(bindings_contents[offset:]))
+            "".join(bindings_contents[:len(root_contents)]))


### PR DESCRIPTION
The config file is "last one wins" so pydrake's dotfile should be appending to the root settings, not prepending.

This hasn't mattered in the past because we had not yet overridden any settings in pydrake that were also set in the root; that might be changing soon, so we'll preemptively correct the order here now.

Towards #18175.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18281)
<!-- Reviewable:end -->
