### PR TITLE
[workspace] Drop macOS Big Sur support

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -34,7 +34,6 @@ body:
         - Unknown / Other
         - Ubuntu 20.04
         - Ubuntu 22.04
-        - macOS 11 (Big Sur)
         - macOS 12 (Monterey)
         - Other
   - type: dropdown

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,10 +28,10 @@ set(UNIX_DISTRIBUTION_ID)
 set(UNIX_DISTRIBUTION_CODENAME)
 
 if(APPLE)
-  if(CMAKE_SYSTEM_VERSION VERSION_LESS 20)
-    message(FATAL_ERROR
+  if(CMAKE_SYSTEM_VERSION VERSION_LESS 21)
+    message(WARNING
       "Darwin ${CMAKE_SYSTEM_VERSION} is NOT supported. Please use "
-      "Darwin 20.x (macOS Big Sur) or 21.x (macOS Monterey)."
+      "Darwin 21.x (macOS Monterey) or newer."
     )
   endif()
 else()
@@ -102,7 +102,7 @@ endif()
 
 # The minimum compiler versions should match those listed in both
 # doc/_pages/from_source.md and tools/workspace/cc/repository.bzl.
-set(MINIMUM_APPLE_CLANG_VERSION 12)
+set(MINIMUM_APPLE_CLANG_VERSION 14)
 set(MINIMUM_CLANG_VERSION 12)
 set(MINIMUM_GNU_VERSION 9.3)
 

--- a/doc/_pages/code_review_checklist.md
+++ b/doc/_pages/code_review_checklist.md
@@ -125,7 +125,7 @@ changes, be sure to opt-in to a pre-merge macOS build.
 [Schedule an on-demand build](/jenkins.html#scheduling-an-on-demand-build) using an "everything"
 flavor, for example:
 
-* ``@drake-jenkins-bot mac-x86-big-sur-clang-bazel-experimental-everything-release please``
+* ``@drake-jenkins-bot mac-x86-monterey-clang-bazel-experimental-everything-release please``
 
 # Have you run linting tools?
 

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -17,7 +17,6 @@ integration. Any other configurations are provided on a best-effort basis.
 |------------------------------------|--------------|------------|-------|-------|------------------------------|-------------------------------|
 | Ubuntu 20.04 LTS (Focal Fossa)     | x86_64       | 3.8        | 5.3   | 3.16  | GCC 9 (default) or Clang 12  | OpenJDK 11                    |
 | Ubuntu 22.04 LTS (Jammy Jellyfish) | x86_64       | 3.10       | 5.3   | 3.22  | GCC 11 (default) or Clang 12 | OpenJDK 11                    |
-| macOS Big Sur (11)                 | x86_64       | 3.10       | 5.3   | 3.24  | Apple LLVM 12 (Xcode 12)     | AdoptOpenJDK 16 (HotSpot JVM) |
 | macOS Monterey (12)                | x86_64       | 3.10       | 5.3   | 3.24  | Apple LLVM 14 (Xcode 14)     | AdoptOpenJDK 16 (HotSpot JVM) |
 | macOS Monterey (12)                | arm64        | 3.10       | 5.3   | 3.24  | Apple LLVM 14 (Xcode 14)     | AdoptOpenJDK 16 (HotSpot JVM) |
 

--- a/doc/_pages/installation.md
+++ b/doc/_pages/installation.md
@@ -18,7 +18,6 @@ officially supports:
 |------------------------------------|------------------|------------|
 | Ubuntu 20.04 LTS (Focal Fossa)     | x86_64           | 3.8        |
 | Ubuntu 22.04 LTS (Jammy Jellyfish) | x86_64           | 3.10       |
-| macOS Big Sur (11)                 | x86_64           | 3.10       |
 | macOS Monterey (12)                | x86_64 or arm64  | 3.10       |
 
 ⁽¹⁾ CPython is the only Python implementation supported.
@@ -42,7 +41,6 @@ compiler as our releases:
 |------------------------------------|--------------------------|-------|
 | Ubuntu 20.04 LTS (Focal Fossa)     | GCC 9                    | C++17 |
 | Ubuntu 22.04 LTS (Jammy Jellyfish) | GCC 11                   | C++20 |
-| macOS Big Sur (11)                 | Apple LLVM 12 (Xcode 12) | C++20 |
 | macOS Monterey (12)                | Apple LLVM 14 (Xcode 14) | C++20 |
 
 ## Available Versions

--- a/doc/_pages/jenkins.md
+++ b/doc/_pages/jenkins.md
@@ -53,7 +53,7 @@ where ``<job-name>`` is the name of an
 
 For example:
 
-* ``@drake-jenkins-bot mac-x86-big-sur-clang-bazel-experimental-release please``
+* ``@drake-jenkins-bot mac-x86-monterey-clang-bazel-experimental-release please.``
 * ``@drake-jenkins-bot linux-focal-clang-bazel-experimental-valgrind-memcheck please``
 
 ## Scheduling Builds via the Jenkins User Interface
@@ -105,7 +105,7 @@ most likely fail. To test new prerequisites, you should first request
 unprovisioned experimental builds, e.g.:
 
 * ``@drake-jenkins-bot linux-focal-unprovisioned-gcc-bazel-experimental-release please``
-* ``@drake-jenkins-bot mac-x86-big-sur-unprovisioned-clang-bazel-experimental-release please``
+* ``@drake-jenkins-bot mac-x86-monterey-unprovisioned-clang-bazel-experimental-release please.``
 
 After this has passed, go through normal review. Once normal review is done,
 add `@BetsyMcPhail` for review and request that the provisioned instances be
@@ -117,14 +117,14 @@ To schedule an "experimental" build of the [binary packages](/from_binary.html),
 comment on an open pull request as follows:
 
 * ``@drake-jenkins-bot linux-focal-unprovisioned-gcc-bazel-experimental-snopt-packaging please``
-* ``@drake-jenkins-bot mac-x86-big-sur-unprovisioned-clang-bazel-experimental-snopt-packaging please``
+* ``@drake-jenkins-bot mac-x86-monterey-unprovisioned-clang-bazel-experimental-snopt-packaging please``
 
 or follow the [instructions above](#scheduling-builds-via-the-jenkins-user-interface)
 to schedule a build of one of the following jobs from the Jenkins user
 interface:
 
 * linux-focal-unprovisioned-gcc-bazel-experimental-snopt-packaging
-* mac-x86-big-sur-unprovisioned-clang-bazel-experimental-snopt-packaging
+* mac-x86-monterey-unprovisioned-clang-bazel-experimental-snopt-packaging
 
 The URL from which to download the built package will be indicated in the
 Jenkins console log for the completed build, for example:

--- a/doc/_pages/pip.md
+++ b/doc/_pages/pip.md
@@ -106,16 +106,18 @@ Mac x86_64 are generated nightly and are available to download at:
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp38-cp38-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp38-cp38-manylinux_2_31_x86_64.whl)
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp39-cp39-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp39-cp39-manylinux_2_31_x86_64.whl)
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp310-cp310-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp310-cp310-manylinux_2_31_x86_64.whl)
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp310-cp310-macosx_11_0_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp310-cp310-macosx_11_0_x86_64.whl)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp310-cp310-macosx_12_0_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp310-cp310-macosx_12_0_x86_64.whl)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp310-cp310-macosx_12_0_arm64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp310-cp310-macosx_12_0_arm64.whl)
 
 Older packages for specific dates are available by replacing ``latest`` with an
-8-digit date, e.g., ``20220914`` for September 14th, 2022.  The version number to
+8-digit date, e.g., ``20221110`` for November 10th, 2022.  The version number to
 replace ``latest`` with follows the pattern ``0.0.YYYYMMDD``.
 
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20220914-cp38-cp38-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20220914-cp38-cp38-manylinux_2_31_x86_64.whl)
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20220914-cp39-cp39-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20220914-cp39-cp39-manylinux_2_31_x86_64.whl)
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20220914-cp310-cp310-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20220914-cp310-cp310-manylinux_2_31_x86_64.whl)
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20220914-cp310-cp310-macosx_11_0_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20220914-cp310-cp310-macosx_11_0_x86_64.whl)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221110-cp38-cp38-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221110-cp38-cp38-manylinux_2_31_x86_64.whl)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221110-cp39-cp39-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221110-cp39-cp39-manylinux_2_31_x86_64.whl)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221110-cp310-cp310-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221110-cp310-cp310-manylinux_2_31_x86_64.whl)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221110-cp310-cp310-macosx_12_0_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221110-cp310-cp310-macosx_12_0_x86_64.whl)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221110-cp310-cp310-macosx_12_0_arm64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221110-cp310-cp310-macosx_12_0_arm64.whl)
 
 Nightly wheels are retained for 56 days from their date of creation.
 

--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -111,7 +111,7 @@ the main body of the document:
    3. Open the latest builds from the following builds:
       1. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-focal-unprovisioned-gcc-bazel-nightly-snopt-mosek-packaging/>
       2. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-jammy-unprovisioned-gcc-bazel-nightly-snopt-mosek-packaging/>
-      3. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/mac-x86-big-sur-unprovisioned-clang-bazel-nightly-snopt-mosek-packaging/>
+      3. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/mac-x86-monterey-unprovisioned-clang-bazel-nightly-snopt-mosek-packaging/>
       4. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/mac-arm-monterey-unprovisioned-clang-bazel-nightly-snopt-mosek-packaging/>
    4. Check the logs for those packaging builds and find the URLs they posted
       to (open the latest build, go to "View as plain text", and search for
@@ -128,7 +128,7 @@ the main body of the document:
    1. Open the following five Jenkins jobs (e.g., each in its own
       new browser tab):
       - [Linux Jenkins Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-focal-unprovisioned-gcc-wheel-staging-snopt-mosek-release/)
-      - [macOS x86 Jenkins Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Wheel/job/mac-x86-big-sur-unprovisioned-clang-wheel-staging-snopt-mosek-release/)
+      - [macOS x86 Jenkins Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-x86-monterey-unprovisioned-clang-wheel-staging-snopt-mosek-release/)
       - [macOS arm Jenkins Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-arm-monterey-unprovisioned-clang-wheel-staging-snopt-mosek-release/)
       - [Focal Packaging Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-focal-unprovisioned-gcc-bazel-staging-snopt-mosek-packaging/)
       - [Jammy Packaging Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-jammy-unprovisioned-gcc-bazel-staging-snopt-mosek-packaging/)

--- a/examples/manipulation_station/end_effector_teleop_sliders.py
+++ b/examples/manipulation_station/end_effector_teleop_sliders.py
@@ -3,15 +3,6 @@ from dataclasses import dataclass
 import sys
 import webbrowser
 
-if sys.platform == "darwin":
-    # TODO(jamiesnape): Fix this example on macOS Big Sur. Skipping on all
-    # macOS for simplicity and because of the tendency for macOS versioning
-    # schemes to unexpectedly change.
-    # ImportError: C++ type is not registered in pybind:
-    # NSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEE
-    print("ERROR: Skipping this example on macOS because it fails on Big Sur")
-    sys.exit(0)
-
 import numpy as np
 
 from pydrake.common.value import AbstractValue

--- a/tools/release_engineering/download_release_candidate.py
+++ b/tools/release_engineering/download_release_candidate.py
@@ -134,7 +134,7 @@ def _download_binaries(*, timestamp, staging, version):
             f"drake-{version[1:]}-cp38-cp38-manylinux_2_31_x86_64.whl",
             f"drake-{version[1:]}-cp39-cp39-manylinux_2_31_x86_64.whl",
             f"drake-{version[1:]}-cp310-cp310-manylinux_2_31_x86_64.whl",
-            f"drake-{version[1:]}-cp310-cp310-macosx_11_0_x86_64.whl",
+            f"drake-{version[1:]}-cp310-cp310-macosx_12_0_x86_64.whl",
             f"drake-{version[1:]}-cp310-cp310-macosx_12_0_arm64.whl",
             # Deb filenames.
             f"drake-dev_{version[1:]}-1_amd64-focal.deb",

--- a/tools/workspace/cc/repository.bzl
+++ b/tools/workspace/cc/repository.bzl
@@ -125,7 +125,7 @@ def _impl(repository_ctx):
     # CMakeLists.txt and doc/_pages/from_source.md.
 
     if repository_ctx.os.name == "mac os x":
-        supported_compilers = {"AppleClang": (12, 0)}
+        supported_compilers = {"AppleClang": (14, 0)}
     else:
         supported_compilers = {"Clang": (12, 0), "GNU": (9, 3)}
 

--- a/tools/workspace/os.bzl
+++ b/tools/workspace/os.bzl
@@ -165,7 +165,7 @@ def _determine_macos(repository_ctx):
 
     # Match supported macOS release(s).
     (macos_release,) = sw_vers.stdout.strip().split(".")[:1]
-    if macos_release not in ["11", "12"]:
+    if macos_release not in ["12"]:
         print("WARNING: unsupported macOS '%s'" % macos_release)
 
     # Check which arch we should be using.


### PR DESCRIPTION
Fixes #18294.

- Minimum supported macOS is now: Monterey.
- Minimum supported Xcode is now: 14.0.1.
- CMake will warn (rather than error) on unsupported macOS.
- Advertise existing macOS arm64 wheels (monterey and later).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18299)
<!-- Reviewable:end -->
