### PR TITLE
[pydrake] Remove spurous keep-alive annotations

### DIFF
--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -196,12 +196,7 @@ struct Impl {
           m, "PathParameterizedTrajectory", param, cls_doc.doc);
       cls  // BR
           .def(py::init<const Trajectory<T>&, const Trajectory<T>&>(),
-              py::arg("path"), py::arg("time_scaling"),
-              // Keep alive, reference: `self` keeps `path` alive.
-              py::keep_alive<1, 2>(),  // BR
-              // Keep alive, reference: `self` keeps `time_scaling` alive.
-              py::keep_alive<1, 3>(),  // BR
-              cls_doc.ctor.doc)
+              py::arg("path"), py::arg("time_scaling"), cls_doc.ctor.doc)
           .def("Clone", &Class::Clone, cls_doc.Clone.doc)
           .def("path", &Class::path, py_rvp::reference_internal,
               cls_doc.path.doc)


### PR DESCRIPTION
The function takes its arguments by reference and internally copies them. There's no need to any keep_alive annotations.

Amends #17816.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18301)
<!-- Reviewable:end -->
