### PR TITLE
[bindings] Bind DeformableModel and related functions

### DIFF
--- a/bindings/pydrake/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry_py_scene_graph.cc
@@ -171,7 +171,10 @@ void DoScalarDependentDefinitions(py::module m, T) {
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc)
         .def("get_source_pose_port", &Class::get_source_pose_port,
-            py_rvp::reference_internal, cls_doc.get_source_pose_port.doc);
+            py_rvp::reference_internal, cls_doc.get_source_pose_port.doc)
+        .def("get_source_configuration_port",
+            &Class::get_source_configuration_port, py_rvp::reference_internal,
+            cls_doc.get_source_configuration_port.doc);
 
     cls  // BR
         .def("get_query_output_port", &Class::get_query_output_port,

--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -126,6 +126,7 @@ drake_pybind_library(
         "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:eigen_geometry_pybind",
         "//bindings/pydrake/common:eigen_pybind",
+        "//bindings/pydrake/common:identifier_pybind",
         "//bindings/pydrake/common:serialize_pybind",
         "//bindings/pydrake/common:type_pack",
         "//bindings/pydrake/common:type_safe_index_pybind",
@@ -321,6 +322,7 @@ drake_py_unittest(
     ],
     deps = [
         ":benchmarks_py",
+        ":fem_py",
         ":parsing_py",
         ":plant_py",
         ":tree_py",

--- a/bindings/pydrake/multibody/all.py
+++ b/bindings/pydrake/multibody/all.py
@@ -1,8 +1,8 @@
 import warnings
 
 # Normal symbols.
-from .fem import *  # noqa
 from .inverse_kinematics import *  # noqa
+from .fem import *  # noqa
 from .math import *  # noqa
 from .meshcat import *  # noqa
 from .optimization import *  # noqa

--- a/bindings/pydrake/multibody/fem_py.cc
+++ b/bindings/pydrake/multibody/fem_py.cc
@@ -6,6 +6,7 @@
 #include "drake/bindings/pydrake/common/type_pack.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/common/default_scalars.h"
 #include "drake/multibody/fem/deformable_body_config.h"
 
 namespace drake {

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -11,6 +11,9 @@ from pydrake.autodiffutils import AutoDiffXd
 from pydrake.symbolic import Expression, Variable
 from pydrake.lcm import DrakeLcm
 from pydrake.math import RigidTransform
+from pydrake.multibody.fem import (
+    DeformableBodyConfig_
+)
 from pydrake.multibody.tree import (
     BallRpyJoint_,
     Body_,
@@ -65,6 +68,7 @@ from pydrake.multibody.plant import (
     ContactResults_,
     ContactResultsToLcmSystem,
     CoulombFriction_,
+    DeformableModel,
     DiscreteContactSolver,
     ExternallyAppliedSpatialForce_,
     ExternallyAppliedSpatialForceMultiplexer_,
@@ -91,6 +95,7 @@ from pydrake.common.value import AbstractValue, Value
 from pydrake.geometry import (
     Box,
     GeometryId,
+    GeometryInstance,
     GeometrySet,
     HydroelasticContactRepresentation,
     Meshcat,
@@ -2539,3 +2544,49 @@ class TestPlant(unittest.TestCase):
         self.assertTrue(plant.HasUniqueFreeBaseBody(model_instance))
         body = plant.GetUniqueFreeBaseBodyOrThrow(model_instance)
         self.assertEqual(body.index(), added_body.index())
+
+    def test_deformable_model(self):
+        builder = DiagramBuilder_[float]()
+        plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 1.0e-3)
+        dut = DeformableModel(plant)
+        self.assertEqual(dut.num_bodies(), 0)
+        # Add a deformable body to the model.
+        deformable_body_config = DeformableBodyConfig_[float]()
+        geometry = GeometryInstance(X_PG=RigidTransform(),
+                                    shape=Sphere(1.), name="sphere")
+        props = ProximityProperties()
+        props.AddProperty("material", "coulomb_friction",
+                          CoulombFriction_[float](1.0, 1.0))
+        geometry.set_proximity_properties(props)
+        body_id = dut.RegisterDeformableBody(
+            geometry_instance=geometry,
+            config=deformable_body_config,
+            resolution_hint=1.0)
+
+        geometry_id = dut.GetGeometryId(body_id)
+        self.assertEqual(dut.GetBodyId(geometry_id), body_id)
+
+        # Verify that a body has been added to the model.
+        self.assertEqual(dut.num_bodies(), 1)
+        self.assertIsInstance(dut.GetReferencePositions(body_id), np.ndarray)
+        # Add the model to the plant.
+        plant.AddPhysicalModel(dut)
+        registered_models = plant.physical_models()
+        self.assertEqual(len(registered_models), 1)
+        self.assertEqual(registered_models[0].num_bodies(), 1)
+        # Turn on SAP and finalize.
+        plant.set_discrete_contact_solver(DiscreteContactSolver.kSap)
+        plant.Finalize()
+
+        # Post-finalize operations.
+        self.assertIsInstance(
+            dut.vertex_positions_port(), OutputPort_[float])
+        builder.Connect(dut.vertex_positions_port(),
+                        scene_graph.get_source_configuration_port(
+                            plant.get_source_id()))
+        self.assertEqual(dut.GetDiscreteStateIndex(body_id), 1)
+
+        diagram = builder.Build()
+        # Ensure we can simulate this system.
+        simulator = Simulator_[float](diagram)
+        simulator.AdvanceTo(0.01)

--- a/bindings/pydrake/test/geometry_scene_graph_test.py
+++ b/bindings/pydrake/test/geometry_scene_graph_test.py
@@ -67,6 +67,9 @@ class TestGeometrySceneGraph(unittest.TestCase):
 
         self.assertIsInstance(
             scene_graph.get_source_pose_port(global_source), InputPort)
+        self.assertIsInstance(
+            scene_graph.get_source_configuration_port(global_source),
+            InputPort)
 
         self.assertIsInstance(
             scene_graph.get_query_output_port(), OutputPort)

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -721,9 +721,9 @@ void CompliantContactManager<T>::ExtractModelInfo() {
   }
 
   // Collect information from each PhysicalModel owned by the plant.
-  const std::vector<std::unique_ptr<multibody::internal::PhysicalModel<T>>>&
-      physical_models = this->plant().physical_models();
-  for (const auto& model : physical_models) {
+  const std::vector<const multibody::PhysicalModel<T>*> physical_models =
+      this->plant().physical_models();
+  for (const auto* model : physical_models) {
     std::visit(
         [this](auto&& concrete_model) {
           this->ExtractConcreteModel(concrete_model);

--- a/multibody/plant/deformable_model.h
+++ b/multibody/plant/deformable_model.h
@@ -30,7 +30,7 @@ using DeformableBodyIndex = TypeSafeIndex<class DeformableBodyTag>;
  @experimental
  @tparam_double_only */
 template <typename T>
-class DeformableModel final : public multibody::internal::PhysicalModel<T> {
+class DeformableModel final : public multibody::PhysicalModel<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DeformableModel)
 
@@ -149,9 +149,9 @@ class DeformableModel final : public multibody::internal::PhysicalModel<T> {
   }
 
  private:
-  internal::PhysicalModelPointerVariant<T> DoToPhysicalModelPointerVariant()
+  PhysicalModelPointerVariant<T> DoToPhysicalModelPointerVariant()
       const final {
-    return internal::PhysicalModelPointerVariant<T>(this);
+    return PhysicalModelPointerVariant<T>(this);
   }
 
   // TODO(xuchenhan-tri): Implement CloneToDouble() and CloneToAutoDiffXd()

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1285,13 +1285,23 @@ void MultibodyPlant<T>::SetDiscreteUpdateManager(
 
 template <typename T>
 void MultibodyPlant<T>::AddPhysicalModel(
-    std::unique_ptr<internal::PhysicalModel<T>> model) {
+    std::unique_ptr<PhysicalModel<T>> model) {
   // TODO(xuchenhan-tri): Guard against the same type of model being registered
   //  more than once.
   DRAKE_MBP_THROW_IF_FINALIZED();
   DRAKE_DEMAND(model != nullptr);
   auto& added_model = physical_models_.emplace_back(std::move(model));
   RemoveUnsupportedScalars(*added_model);
+}
+
+template <typename T>
+std::vector<const PhysicalModel<T>*> MultibodyPlant<T>::physical_models()
+    const {
+  std::vector<const PhysicalModel<T>*> result;
+  for (const std::unique_ptr<PhysicalModel<T>>& model : physical_models_) {
+    result.emplace_back(model.get());
+  }
+  return result;
 }
 
 template <typename T>

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1782,15 +1782,13 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if called post-finalize. See Finalize().
   /// @note `this` MultibodyPlant will no longer support scalar conversion to or
   /// from symbolic::Expression after a call to this method.
-  void AddPhysicalModel(std::unique_ptr<internal::PhysicalModel<T>> model);
+  void AddPhysicalModel(std::unique_ptr<PhysicalModel<T>> model);
 
-  /// For use only by advanced developers.
+  /// Returns a vector of pointers to all physical models registered with this
+  /// %MultibodyPlant. For use only by advanced developers.
   ///
   /// @experimental
-  const std::vector<std::unique_ptr<internal::PhysicalModel<T>>>&
-  physical_models() const {
-    return physical_models_;
-  }
+  std::vector<const PhysicalModel<T>*> physical_models() const;
 
   // TODO(amcastro-tri): per work in #13064, we should reconsider whether to
   // deprecate/remove this method altogether or at least promote to proper
@@ -5144,7 +5142,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       discrete_update_manager_;
 
   // (Experimental) The vector of physical models owned by MultibodyPlant.
-  std::vector<std::unique_ptr<internal::PhysicalModel<T>>> physical_models_;
+  std::vector<std::unique_ptr<PhysicalModel<T>>> physical_models_;
 
   // Vector of coupler constraints specifications.
   std::vector<internal::CouplerConstraintSpecs> coupler_constraints_specs_;

--- a/multibody/plant/multibody_plant_model_attorney.h
+++ b/multibody/plant/multibody_plant_model_attorney.h
@@ -9,9 +9,11 @@
 
 namespace drake {
 namespace multibody {
-namespace internal {
+
 template <typename T>
 class PhysicalModel;
+
+namespace internal {
 
 /* This class is used to grant access to a selected collection of
  MultibodyPlant's private methods to PhysicalModel.

--- a/multibody/plant/physical_model.cc
+++ b/multibody/plant/physical_model.cc
@@ -6,7 +6,6 @@
 
 namespace drake {
 namespace multibody {
-namespace internal {
 
 template <typename T>
 std::unique_ptr<PhysicalModel<double>> PhysicalModel<T>::CloneToDouble() const {
@@ -48,14 +47,14 @@ bool PhysicalModel<T>::is_cloneable_to_symbolic() const {
 template <typename T>
 geometry::SceneGraph<T>& PhysicalModel<T>::mutable_scene_graph(
     MultibodyPlant<T>* plant) {
-  return MultibodyPlantModelAttorney<T>::mutable_scene_graph(plant);
+  return internal::MultibodyPlantModelAttorney<T>::mutable_scene_graph(plant);
 }
 
 template <typename T>
 systems::DiscreteStateIndex PhysicalModel<T>::DeclareDiscreteState(
     MultibodyPlant<T>* plant, const VectorX<T>& model_value) {
-  return MultibodyPlantModelAttorney<T>::DeclareDiscreteState(plant,
-                                                              model_value);
+  return internal::MultibodyPlantModelAttorney<T>::DeclareDiscreteState(
+      plant, model_value);
 }
 
 template <typename T>
@@ -64,7 +63,7 @@ systems::LeafOutputPort<T>& PhysicalModel<T>::DeclareAbstractOutputPort(
     typename systems::LeafOutputPort<T>::AllocCallback alloc_function,
     typename systems::LeafOutputPort<T>::CalcCallback calc_function,
     std::set<systems::DependencyTicket> prerequisites_of_calc) {
-  return MultibodyPlantModelAttorney<T>::DeclareAbstractOutputPort(
+  return internal::MultibodyPlantModelAttorney<T>::DeclareAbstractOutputPort(
       plant, std::move(name), std::move(alloc_function),
       std::move(calc_function), std::move(prerequisites_of_calc));
 }
@@ -76,12 +75,12 @@ systems::LeafOutputPort<T>& PhysicalModel<T>::DeclareVectorOutputPort(
     typename systems::LeafOutputPort<T>::CalcVectorCallback
         vector_calc_function,
     std::set<systems::DependencyTicket> prerequisites_of_calc) {
-  return MultibodyPlantModelAttorney<T>::DeclareVectorOutputPort(
+  return internal::MultibodyPlantModelAttorney<T>::DeclareVectorOutputPort(
       plant, std::move(name), model_vector, std::move(vector_calc_function),
       std::move(prerequisites_of_calc));
 }
-}  // namespace internal
+
 }  // namespace multibody
 }  // namespace drake
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
-    class ::drake::multibody::internal::PhysicalModel);
+    class ::drake::multibody::PhysicalModel);

--- a/multibody/plant/physical_model.h
+++ b/multibody/plant/physical_model.h
@@ -20,8 +20,6 @@ class MultibodyPlant;
 template <typename T>
 class DeformableModel;
 
-namespace internal {
-
 /* Variant over const pointers to all PhysicalModel.
  MultibodyPlant owns all the physical models, as PhysicalModel pointers. Now,
  discrete update manager must create concrete instances for each physical model.
@@ -35,7 +33,7 @@ template <typename T>
 using PhysicalModelPointerVariant =
     std::variant<const DeformableModel<T>*, std::monostate>;
 
-/* PhysicalModel provides the functionalities to extend the type of
+/** (Internal) PhysicalModel provides the functionalities to extend the type of
  physical model of MultibodyPlant. Developers can derive from this
  PhysicalModel to incorporate additional model elements coupled with the
  rigid body dynamics. For instance, simulation of deformable objects requires
@@ -49,9 +47,12 @@ using PhysicalModelPointerVariant =
  each PhysicalModel it owns. After the system resources are allocated, model
  mutation in the PhysicalModels owned by MultibodyPlant is not allowed.
 
+ This class is for internal use only. Use derived concrete models (e.g.
+ DeformableModel) instead.
+
  @tparam_default_scalar */
 template <typename T>
-class PhysicalModel : public ScalarConvertibleComponent<T> {
+class PhysicalModel : public internal::ScalarConvertibleComponent<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PhysicalModel);
 
@@ -59,11 +60,11 @@ class PhysicalModel : public ScalarConvertibleComponent<T> {
 
   ~PhysicalModel() override = default;
 
-  /* (Internal) Creates a clone of the concrete PhysicalModel object
-   with the scalar type `ScalarType`. The clone should be a deep copy of the
-   original PhysicalModel with the exception of members overwritten in
-   `DeclareSystemResources()`. This method is meant to be called by the
-   scalar-converting copy constructor of MultibodyPlant only.
+  /** Creates a clone of the concrete PhysicalModel object with the scalar type
+   `ScalarType`. The clone should be a deep copy of the original PhysicalModel
+   with the exception of members overwritten in `DeclareSystemResources()`. This
+   method is meant to be called by the scalar-converting copy constructor of
+   MultibodyPlant only.
    @tparam_default_scalar */
   template <typename ScalarType>
   std::unique_ptr<PhysicalModel<ScalarType>> CloneToScalar() const {
@@ -77,22 +78,22 @@ class PhysicalModel : public ScalarConvertibleComponent<T> {
     DRAKE_UNREACHABLE();
   }
 
-  /* Defaults to false. Derived classes that support making a clone that uses
+  /** Defaults to false. Derived classes that support making a clone that uses
    double as a scalar type must override this to return true. */
   bool is_cloneable_to_double() const override;
 
-  /* Defaults to false. Derived classes that support making a clone that uses
+  /** Defaults to false. Derived classes that support making a clone that uses
    AutoDiffXd as a scalar type must override this to return true. */
   bool is_cloneable_to_autodiff() const override;
 
-  /* Defaults to false. Derived classes that support making a clone that uses
+  /** Defaults to false. Derived classes that support making a clone that uses
    symbolic::Expression as a scalar type must override this to return true. */
   bool is_cloneable_to_symbolic() const override;
 
-  /* (Internal) MultibodyPlant calls this from within Finalize() to declare
-   additional system resources. This method is only meant to be called by
-   MultibodyPlant. We pass in a MultibodyPlant pointer so that derived
-   PhysicalModels can use specific MultibodyPlant cache tickets.
+  /** MultibodyPlant calls this from within Finalize() to declare additional
+   system resources. This method is only meant to be called by MultibodyPlant.
+   We pass in a MultibodyPlant pointer so that derived PhysicalModels can use
+   specific MultibodyPlant cache tickets.
    @pre plant != nullptr. */
   void DeclareSystemResources(MultibodyPlant<T>* plant) {
     DRAKE_DEMAND(plant != nullptr);
@@ -100,7 +101,7 @@ class PhysicalModel : public ScalarConvertibleComponent<T> {
     system_resources_declared_ = true;
   }
 
-  /* Returns (a const pointer to) the specific model variant of `this`
+  /** Returns (a const pointer to) the specific model variant of `this`
    PhysicalModel. Note that the variant contains a pointer to the concrete model
    and therefore should not persist longer than the lifespan of this model.  */
   PhysicalModelPointerVariant<T> ToPhysicalModelPointerVariant() const {
@@ -188,8 +189,9 @@ class PhysicalModel : public ScalarConvertibleComponent<T> {
    PhysicalModel have been declared. */
   bool system_resources_declared_{false};
 };
-}  // namespace internal
+
 }  // namespace multibody
 }  // namespace drake
+
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
-    class ::drake::multibody::internal::PhysicalModel);
+    class ::drake::multibody::PhysicalModel);

--- a/multibody/plant/test/discrete_update_manager_test.cc
+++ b/multibody/plant/test/discrete_update_manager_test.cc
@@ -98,8 +98,8 @@ class DummyDiscreteUpdateManager final : public DiscreteUpdateManager<T> {
     /* For unit testing we verify there is a single physical model of type
      DummyModel. */
     DRAKE_DEMAND(this->plant().physical_models().size() == 1);
-    const auto* dummy_model = dynamic_cast<const DummyModel<T>*>(
-        this->plant().physical_models()[0].get());
+    const auto* dummy_model =
+        dynamic_cast<const DummyModel<T>*>(this->plant().physical_models()[0]);
     DRAKE_DEMAND(dummy_model != nullptr);
     additional_state_index_ = dummy_model->discrete_state_index();
   }
@@ -253,7 +253,7 @@ TEST_F(DiscreteUpdateManagerTest, ScalarConversion) {
   ASSERT_EQ(autodiff_plant->physical_models().size(), 1);
   const DummyModel<AutoDiffXd>* model =
       dynamic_cast<const DummyModel<AutoDiffXd>*>(
-          autodiff_plant->physical_models()[0].get());
+          autodiff_plant->physical_models()[0]);
   ASSERT_NE(model, nullptr);
 
   const int time_steps = 2;

--- a/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
+++ b/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
@@ -200,7 +200,7 @@ class DoubleOnlyDiscreteUpdateManager final
 // scalar types.
 GTEST_TEST(ScalarConversionTest, ExternalComponent) {
   MultibodyPlant<double> plant(0.1);
-  std::unique_ptr<internal::PhysicalModel<double>> dummy_physical_model =
+  std::unique_ptr<PhysicalModel<double>> dummy_physical_model =
       std::make_unique<internal::test::DummyModel<double>>();
   EXPECT_TRUE(dummy_physical_model->is_cloneable_to_double());
   EXPECT_TRUE(dummy_physical_model->is_cloneable_to_autodiff());


### PR DESCRIPTION
This includes:
1. binding DeformableModel itself with a selection of functions;
2. binding SceneGraph::get_source_configuration_port()
3. binding MultibodyPlant::AddPhysicalModel which takes PhysicalModel as a parameter. As a result, PhysicalModel is moved out of internal namespace and bindings are provided.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18310)
<!-- Reviewable:end -->
