### PR TITLE
[graph of convex sets] adjust test tolerance on rounding test

### DIFF
--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -1336,7 +1336,7 @@ GTEST_TEST(ShortestPathTest, RoundedSolution) {
       const double tol =
           (relaxed_result.get_solver_id() == solvers::GurobiSolver::id()) ? 1e-1
           : (relaxed_result.get_solver_id() == solvers::CsdpSolver::id()) ? 1e-2
-          : 1e-6;
+          : 1e-5;
       EXPECT_NEAR(relaxed_result.GetSolution(edges[ii]->phi()), 0.5, tol);
     } else if (ii < 10) {
       EXPECT_LT(relaxed_result.GetSolution(edges[ii]->phi()), 0.5);


### PR DESCRIPTION
Mosek has been failing on this test for me for weeks on my standard focal install, with mosek installed via bazel.

The big mystery for me has been "why is my setup any different?"  I still don't have a good answer. But there is certainly no great loss in adjusting this tolerance.
+@mpetersen94 for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18313)
<!-- Reviewable:end -->
