### PR TITLE
[controllers] Deprecate `get_mutlibody_plant_for_control()` and `get_output_port_control()`

### DIFF
--- a/systems/controllers/inverse_dynamics_controller.cc
+++ b/systems/controllers/inverse_dynamics_controller.cc
@@ -94,8 +94,11 @@ void InverseDynamicsController<T>::SetUp(
   }
 
   // Exposes inverse dynamics' output force port.
-  output_port_index_control_ =
-      builder.ExportOutput(inverse_dynamics->get_output_port_force(), "force");
+  // TODO(eric.cousineau): Deprecate "force" in lieu of "generalized_force".
+  output_port_index_generalized_forces_ =
+      builder.ExportOutput(
+          inverse_dynamics->get_output_port_force(),
+          "force");
 
   builder.BuildInto(this);
 }

--- a/systems/controllers/inverse_dynamics_controller.h
+++ b/systems/controllers/inverse_dynamics_controller.h
@@ -143,17 +143,28 @@ class InverseDynamicsController final
   }
 
   /**
-   * Returns the output port for computed control.
+   * Returns the output port the desired generalized forces.
    */
-  const OutputPort<T>& get_output_port_control() const final {
-    return this->get_output_port(output_port_index_control_);
+  const OutputPort<T>& get_output_port_generalized_forces() const final {
+    return this->get_output_port(output_port_index_generalized_forces_);
   }
 
   /**
-   * Returns a constant pointer to the MultibodyPlant used for control.
+   *  Returns a constant pointer to the MultibodyPlant used for control.
    */
+  const multibody::MultibodyPlant<T>* get_multibody_plant() const {
+    return multibody_plant_;
+  }
+
+  DRAKE_DEPRECATED(
+      "2023-03-01", "Please use get_output_port_generalized_forces() instead.")
+  const OutputPort<T>& get_output_port_control() const final {
+    return get_output_port_generalized_forces();
+  }
+
+  DRAKE_DEPRECATED("2023-03-01", "Please use get_multibody_plant() instead.")
   const multibody::MultibodyPlant<T>* get_multibody_plant_for_control() const {
-    return multibody_plant_for_control_;
+    return get_multibody_plant();
   }
 
  private:
@@ -161,13 +172,13 @@ class InverseDynamicsController final
              const VectorX<double>& kp, const VectorX<double>& ki,
              const VectorX<double>& kd);
 
-  const multibody::MultibodyPlant<T>* multibody_plant_for_control_{nullptr};
+  const multibody::MultibodyPlant<T>* multibody_plant_{nullptr};
   PidController<T>* pid_{nullptr};
   const bool has_reference_acceleration_{false};
   InputPortIndex input_port_index_estimated_state_;
   InputPortIndex input_port_index_desired_state_;
   InputPortIndex input_port_index_desired_acceleration_;
-  OutputPortIndex output_port_index_control_;
+  OutputPortIndex output_port_index_generalized_forces_;
 };
 
 }  // namespace controllers

--- a/systems/controllers/test/inverse_dynamics_controller_test.cc
+++ b/systems/controllers/test/inverse_dynamics_controller_test.cc
@@ -31,7 +31,8 @@ class InverseDynamicsControllerTest : public ::testing::Test {
     auto inverse_dynamics_context = test_sys->CreateDefaultContext();
     auto output = test_sys->AllocateOutput();
     const MultibodyPlant<double>& robot_plant =
-        *test_sys->get_multibody_plant_for_control();
+        *test_sys->get_multibody_plant();
+
 
     // Sets current state and reference state and acceleration values.
     const int dim = robot_plant.num_positions();
@@ -83,6 +84,17 @@ class InverseDynamicsControllerTest : public ::testing::Test {
     const BasicVector<double>* output_vector = output->get_vector_data(0);
     EXPECT_TRUE(CompareMatrices(expected_torque, output_vector->get_value(),
                                 1e-10, MatrixCompareType::absolute));
+
+    // Test deprecated aliases.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    EXPECT_EQ(
+        test_sys->get_multibody_plant(),
+        test_sys->get_multibody_plant_for_control());
+    EXPECT_EQ(
+        &test_sys->get_output_port_generalized_force(),
+        &test_sys->get_output_port_control());
+#pragma GCC diagnostic pop
   }
 };
 


### PR DESCRIPTION
We should use more concise / less redundant names, per #18272 (for local improvement and consistency)

This is just for `InverseDynamicsController`; seems like we also have offenses in `PidController` and `InverseDynamics`.
This also doesn't fix port deprecation inside of diagrams. That seems solvable, though workflow isn't immediately clear (#12214).

I may need help in plumbing the rest of this through.
@rpoyner-tri @RussTedrake Any chance I could ask for y'all's help? I can file issue w/ checkboxes to divvy up the work; with work split up, I think we could fix this before December so the target deprecation of 2023-03-01 can remain in place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18315)
<!-- Reviewable:end -->
