### PR TITLE
[py controllers] Use `using Class` conventions

### DIFF
--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -36,204 +36,201 @@ PYBIND11_MODULE(controllers, m) {
   py::module::import("pydrake.systems.primitives");
   py::module::import("pydrake.trajectories");
 
-  py::class_<DynamicProgrammingOptions::PeriodicBoundaryCondition>(m,
-      "PeriodicBoundaryCondition",
-      doc.DynamicProgrammingOptions.PeriodicBoundaryCondition.doc)
-      .def(py::init<int, double, double>(),
-          doc.DynamicProgrammingOptions.PeriodicBoundaryCondition.ctor.doc);
-
-  py::class_<DynamicProgrammingOptions>(
-      m, "DynamicProgrammingOptions", doc.DynamicProgrammingOptions.doc)
-      .def(py::init<>(), doc.DynamicProgrammingOptions.ctor.doc)
-      .def_readwrite("discount_factor",
-          &DynamicProgrammingOptions::discount_factor,
-          doc.DynamicProgrammingOptions.discount_factor.doc)
-      .def_readwrite("periodic_boundary_conditions",
-          &DynamicProgrammingOptions::periodic_boundary_conditions,
-          doc.DynamicProgrammingOptions.periodic_boundary_conditions.doc)
-      .def_readwrite("convergence_tol",
-          &DynamicProgrammingOptions::convergence_tol,
-          doc.DynamicProgrammingOptions.convergence_tol.doc)
-      .def_readwrite("visualization_callback",
-          &DynamicProgrammingOptions::visualization_callback,
-          doc.DynamicProgrammingOptions.visualization_callback.doc)
-      .def_readwrite("input_port_index",
-          &DynamicProgrammingOptions::input_port_index,
-          doc.DynamicProgrammingOptions.input_port_index.doc)
-      .def_readwrite("assume_non_continuous_states_are_fixed",
-          &DynamicProgrammingOptions::assume_non_continuous_states_are_fixed,
-          doc.DynamicProgrammingOptions.assume_non_continuous_states_are_fixed
-              .doc);
-
-  // TODO(russt): Bind all default scalars.
-  py::class_<InverseDynamics<double>, LeafSystem<double>> idyn(
-      m, "InverseDynamics", doc.InverseDynamics.doc);
-
-  py::enum_<InverseDynamics<double>::InverseDynamicsMode>(  // BR
-      idyn, "InverseDynamicsMode")
-      .value("kInverseDynamics", InverseDynamics<double>::kInverseDynamics,
-          doc.InverseDynamics.InverseDynamicsMode.doc)
-      .value("kGravityCompensation",
-          InverseDynamics<double>::kGravityCompensation,
-          doc.InverseDynamics.InverseDynamicsMode.kGravityCompensation.doc)
-      .export_values();
-
-  idyn  // BR
-      .def(py::init<const multibody::MultibodyPlant<double>*,
-               InverseDynamics<double>::InverseDynamicsMode>(),
-          py::arg("plant"),
-          py::arg("mode") = InverseDynamics<double>::kInverseDynamics,
-          doc.InverseDynamics.ctor.doc)
-      .def("is_pure_gravity_compensation",
-          &InverseDynamics<double>::is_pure_gravity_compensation,
-          doc.InverseDynamics.is_pure_gravity_compensation.doc);
+  {
+    using Class = DynamicProgrammingOptions;
+    constexpr auto& cls_doc = doc.DynamicProgrammingOptions;
+    py::class_<DynamicProgrammingOptions> cls(
+        m, "DynamicProgrammingOptions", cls_doc.doc);
+    {
+      using Nested = Class::PeriodicBoundaryCondition;
+      constexpr auto& nested_doc = cls_doc.PeriodicBoundaryCondition;
+      py::class_<Nested> nested(
+          cls, "PeriodicBoundaryCondition", nested_doc.doc);
+      nested  // BR
+          .def(py::init<int, double, double>(), py::arg("state_index"),
+              py::arg("low"), py::arg("high"), nested_doc.ctor.doc)
+          .def_readwrite(
+              "state_index", &Nested::state_index, nested_doc.state_index.doc)
+          .def_readwrite("low", &Nested::low, nested_doc.low.doc)
+          .def_readwrite("high", &Nested::high, nested_doc.high.doc);
+      // TODO(eric.cousineau): Deprecate module-scope alias.
+      m.attr("PeriodicBoundaryCondition") = nested;
+    }
+    cls  // BR
+        .def(py::init<>(), cls_doc.ctor.doc)
+        .def_readwrite("discount_factor", &Class::discount_factor,
+            cls_doc.discount_factor.doc)
+        .def_readwrite("periodic_boundary_conditions",
+            &Class::periodic_boundary_conditions,
+            cls_doc.periodic_boundary_conditions.doc)
+        .def_readwrite("convergence_tol", &Class::convergence_tol,
+            cls_doc.convergence_tol.doc)
+        .def_readwrite("visualization_callback", &Class::visualization_callback,
+            cls_doc.visualization_callback.doc)
+        .def_readwrite("input_port_index", &Class::input_port_index,
+            cls_doc.input_port_index.doc)
+        .def_readwrite("assume_non_continuous_states_are_fixed",
+            &Class::assume_non_continuous_states_are_fixed,
+            cls_doc.assume_non_continuous_states_are_fixed.doc);
+  }
 
   // TODO(russt): Bind all default scalars.
-  // TODO(eric.cousineau): Expose multiple inheritance from
-  // StateFeedbackControllerInterface once #9243 is resolved.
-  py::class_<InverseDynamicsController<double>, Diagram<double>>(
-      m, "InverseDynamicsController", doc.InverseDynamicsController.doc)
-      .def(py::init<const MultibodyPlant<double>&, const VectorX<double>&,
-               const VectorX<double>&, const VectorX<double>&, bool>(),
-          py::arg("robot"), py::arg("kp"), py::arg("ki"), py::arg("kd"),
-          py::arg("has_reference_acceleration"),
-          // Keep alive, reference: `self` keeps `robot` alive.
-          py::keep_alive<1, 2>(), doc.InverseDynamicsController.ctor.doc)
-      .def("set_integral_value",
-          &InverseDynamicsController<double>::set_integral_value,
-          doc.InverseDynamicsController.set_integral_value.doc)
-      .def("get_input_port_desired_acceleration",
-          &InverseDynamicsController<
-              double>::get_input_port_desired_acceleration,
-          py_rvp::reference_internal,
-          doc.InverseDynamicsController.get_input_port_desired_acceleration.doc)
-      .def("get_input_port_estimated_state",
-          &InverseDynamicsController<double>::get_input_port_estimated_state,
-          py_rvp::reference_internal,
-          doc.InverseDynamicsController.get_input_port_estimated_state.doc)
-      .def("get_input_port_desired_state",
-          &InverseDynamicsController<double>::get_input_port_desired_state,
-          py_rvp::reference_internal,
-          doc.InverseDynamicsController.get_input_port_desired_state.doc)
-      .def("get_output_port_control",
-          &InverseDynamicsController<double>::get_output_port_control,
-          py_rvp::reference_internal,
-          doc.InverseDynamicsController.get_output_port_control.doc)
-      .def("get_multibody_plant_for_control",
-          &InverseDynamicsController<double>::get_multibody_plant_for_control,
-          py_rvp::reference_internal,
-          doc.InverseDynamicsController.get_multibody_plant_for_control.doc);
 
-  // TODO(russt): Bind all scalar types.
-  py::class_<JointStiffnessController<double>, LeafSystem<double>>(
-      m, "JointStiffnessController", doc.JointStiffnessController.doc)
-      .def(py::init<const multibody::MultibodyPlant<double>&,
-               const Eigen::Ref<const Eigen::VectorXd>&,
-               const Eigen::Ref<const Eigen::VectorXd>&>(),
-          py::arg("plant"), py::arg("kp"), py::arg("kd"),
-          // Keep alive, reference: `self` keeps `robot` alive.
-          py::keep_alive<1, 2>(), doc.JointStiffnessController.ctor.doc)
-      .def("get_input_port_estimated_state",
-          &JointStiffnessController<double>::get_input_port_estimated_state,
-          py_rvp::reference_internal,
-          doc.JointStiffnessController.get_input_port_estimated_state.doc)
-      .def("get_input_port_desired_state",
-          &JointStiffnessController<double>::get_input_port_desired_state,
-          py_rvp::reference_internal,
-          doc.JointStiffnessController.get_input_port_desired_state.doc)
-      .def("get_output_port_generalized_force",
-          &JointStiffnessController<double>::get_output_port_generalized_force,
-          py_rvp::reference_internal,
-          doc.JointStiffnessController.get_output_port_generalized_force.doc)
-      .def("get_multibody_plant",
-          &JointStiffnessController<double>::get_multibody_plant,
-          py_rvp::reference_internal,
-          doc.JointStiffnessController.get_multibody_plant.doc);
-
-  py::class_<PidControlledSystem<double>, Diagram<double>>(
-      m, "PidControlledSystem", doc.PidControlledSystem.doc)
-      .def(py::init<std::unique_ptr<System<double>>, double, double, double,
-               int, int>(),
-          py::arg("plant"), py::arg("kp"), py::arg("ki"), py::arg("kd"),
-          py::arg("state_output_port_index") = 0,
-          py::arg("plant_input_port_index") = 0,
-          // Keep alive, ownership: `plant` keeps `self` alive.
-          py::keep_alive<2, 1>(),
-          doc.PidControlledSystem.ctor.doc_6args_double_gains)
-      .def(py::init<std::unique_ptr<System<double>>, const VectorX<double>&,
-               const VectorX<double>&, const VectorX<double>&, int, int>(),
-          py::arg("plant"), py::arg("kp"), py::arg("ki"), py::arg("kd"),
-          py::arg("state_output_port_index") = 0,
-          py::arg("plant_input_port_index") = 0,
-          // Keep alive, ownership: `plant` keeps `self` alive.
-          py::keep_alive<2, 1>(),
-          doc.PidControlledSystem.ctor.doc_6args_vector_gains)
-      .def(py::init<std::unique_ptr<System<double>>, const MatrixX<double>&,
-               double, double, double, int, int>(),
-          py::arg("plant"), py::arg("feedback_selector"), py::arg("kp"),
-          py::arg("ki"), py::arg("kd"), py::arg("state_output_port_index") = 0,
-          py::arg("plant_input_port_index") = 0,
-          // Keep alive, ownership: `plant` keeps `self` alive.
-          py::keep_alive<2, 1>(),
-          doc.PidControlledSystem.ctor.doc_7args_double_gains)
-      .def(py::init<std::unique_ptr<System<double>>, const MatrixX<double>&,
-               const VectorX<double>&, const VectorX<double>&,
-               const VectorX<double>&, int, int>(),
-          py::arg("plant"), py::arg("feedback_selector"), py::arg("kp"),
-          py::arg("ki"), py::arg("kd"), py::arg("state_output_port_index") = 0,
-          py::arg("plant_input_port_index") = 0,
-          // Keep alive, ownership: `plant` keeps `self` alive.
-          py::keep_alive<2, 1>(),
-          doc.PidControlledSystem.ctor.doc_7args_vector_gains)
-      .def("get_control_input_port",
-          &PidControlledSystem<double>::get_control_input_port,
-          py_rvp::reference_internal,
-          doc.PidControlledSystem.get_control_input_port.doc)
-      .def("get_state_input_port",
-          &PidControlledSystem<double>::get_state_input_port,
-          py_rvp::reference_internal,
-          doc.PidControlledSystem.get_state_input_port.doc)
-      .def("get_state_output_port",
-          &PidControlledSystem<double>::get_state_output_port,
-          py_rvp::reference_internal,
-          doc.PidControlledSystem.get_state_output_port.doc);
+  {
+    using Class = InverseDynamics<double>;
+    constexpr auto& cls_doc = doc.InverseDynamics;
+    py::class_<Class, LeafSystem<double>> cls(
+        m, "InverseDynamics", cls_doc.doc);
+    {
+      using Nested = Class::InverseDynamicsMode;
+      constexpr auto& nested_doc = cls_doc.InverseDynamicsMode;
+      py::enum_<Nested>(cls, "InverseDynamicsMode")
+          .value("kInverseDynamics", Nested::kInverseDynamics, nested_doc.doc)
+          .value("kGravityCompensation", Nested::kGravityCompensation,
+              nested_doc.kGravityCompensation.doc)
+          .export_values();
+    }
+    cls  // BR
+        .def(py::init<const MultibodyPlant<double>*,
+                 Class::InverseDynamicsMode>(),
+            py::arg("plant"), py::arg("mode") = Class::kInverseDynamics,
+            cls_doc.ctor.doc)
+        .def("is_pure_gravity_compensation",
+            &Class::is_pure_gravity_compensation,
+            cls_doc.is_pure_gravity_compensation.doc);
+  }
 
   // TODO(eric.cousineau): Expose multiple inheritance from
   // StateFeedbackControllerInterface once #9243 is resolved.
-  py::class_<PidController<double>, LeafSystem<double>>(
-      m, "PidController", doc.PidController.doc)
-      .def(py::init<const VectorX<double>&, const VectorX<double>&,
-               const VectorX<double>&>(),
-          py::arg("kp"), py::arg("ki"), py::arg("kd"),
-          doc.PidController.ctor.doc_3args)
-      .def(py::init<const MatrixX<double>&, const VectorX<double>&,
-               const VectorX<double>&, const VectorX<double>&>(),
-          py::arg("state_projection"), py::arg("kp"), py::arg("ki"),
-          py::arg("kd"), doc.PidController.ctor.doc_4args)
-      .def(py::init<const MatrixX<double>&, const MatrixX<double>&,
-               const VectorX<double>&, const VectorX<double>&,
-               const VectorX<double>&>(),
-          py::arg("state_projection"), py::arg("output_projection"),
-          py::arg("kp"), py::arg("ki"), py::arg("kd"),
-          doc.PidController.ctor.doc_5args)
-      .def("get_Kp_vector", &PidController<double>::get_Kp_vector,
-          doc.PidController.get_Kp_vector.doc)
-      .def("get_Ki_vector", &PidController<double>::get_Ki_vector,
-          doc.PidController.get_Ki_vector.doc)
-      .def("get_Kd_vector", &PidController<double>::get_Kd_vector,
-          doc.PidController.get_Kd_vector.doc)
-      .def("get_input_port_estimated_state",
-          &PidController<double>::get_input_port_estimated_state,
-          py_rvp::reference_internal,
-          doc.PidController.get_input_port_estimated_state.doc)
-      .def("get_input_port_desired_state",
-          &PidController<double>::get_input_port_desired_state,
-          py_rvp::reference_internal,
-          doc.PidController.get_input_port_desired_state.doc)
-      .def("get_output_port_control",
-          &PidController<double>::get_output_port_control,
-          py_rvp::reference_internal,
-          doc.PidController.get_output_port_control.doc);
+  {
+    using Class = InverseDynamicsController<double>;
+    constexpr auto& cls_doc = doc.InverseDynamicsController;
+    py::class_<Class, Diagram<double>>(
+        m, "InverseDynamicsController", cls_doc.doc)
+        .def(py::init<const MultibodyPlant<double>&, const VectorX<double>&,
+                 const VectorX<double>&, const VectorX<double>&, bool>(),
+            py::arg("robot"), py::arg("kp"), py::arg("ki"), py::arg("kd"),
+            py::arg("has_reference_acceleration"),
+            // Keep alive, reference: `self` keeps `robot` alive.
+            py::keep_alive<1, 2>(), cls_doc.ctor.doc)
+        .def("set_integral_value", &Class::set_integral_value,
+            cls_doc.set_integral_value.doc)
+        .def("get_input_port_desired_acceleration",
+            &InverseDynamicsController<
+                double>::get_input_port_desired_acceleration,
+            py_rvp::reference_internal,
+            cls_doc.get_input_port_desired_acceleration.doc)
+        .def("get_input_port_estimated_state",
+            &Class::get_input_port_estimated_state, py_rvp::reference_internal,
+            cls_doc.get_input_port_estimated_state.doc)
+        .def("get_input_port_desired_state",
+            &Class::get_input_port_desired_state, py_rvp::reference_internal,
+            cls_doc.get_input_port_desired_state.doc)
+        .def("get_output_port_control", &Class::get_output_port_control,
+            py_rvp::reference_internal, cls_doc.get_output_port_control.doc)
+        .def("get_multibody_plant_for_control",
+            &Class::get_multibody_plant_for_control, py_rvp::reference_internal,
+            cls_doc.get_multibody_plant_for_control.doc);
+  }
+
+  {
+    using Class = JointStiffnessController<double>;
+    constexpr auto& cls_doc = doc.JointStiffnessController;
+    py::class_<Class, LeafSystem<double>>(
+        m, "JointStiffnessController", cls_doc.doc)
+        .def(py::init<const MultibodyPlant<double>&,
+                 const Eigen::Ref<const Eigen::VectorXd>&,
+                 const Eigen::Ref<const Eigen::VectorXd>&>(),
+            py::arg("plant"), py::arg("kp"), py::arg("kd"),
+            // Keep alive, reference: `self` keeps `robot` alive.
+            py::keep_alive<1, 2>(), cls_doc.ctor.doc)
+        .def("get_input_port_estimated_state",
+            &Class::get_input_port_estimated_state, py_rvp::reference_internal,
+            cls_doc.get_input_port_estimated_state.doc)
+        .def("get_input_port_desired_state",
+            &Class::get_input_port_desired_state, py_rvp::reference_internal,
+            cls_doc.get_input_port_desired_state.doc)
+        .def("get_output_port_generalized_force",
+            &Class::get_output_port_generalized_force,
+            py_rvp::reference_internal,
+            cls_doc.get_output_port_generalized_force.doc)
+        .def("get_multibody_plant", &Class::get_multibody_plant,
+            py_rvp::reference_internal, cls_doc.get_multibody_plant.doc);
+  }
+
+  {
+    using Class = PidControlledSystem<double>;
+    constexpr auto& cls_doc = doc.PidControlledSystem;
+    py::class_<Class, Diagram<double>>(m, "PidControlledSystem", cls_doc.doc)
+        .def(py::init<std::unique_ptr<System<double>>, double, double, double,
+                 int, int>(),
+            py::arg("plant"), py::arg("kp"), py::arg("ki"), py::arg("kd"),
+            py::arg("state_output_port_index") = 0,
+            py::arg("plant_input_port_index") = 0,
+            // Keep alive, ownership: `plant` keeps `self` alive.
+            py::keep_alive<2, 1>(), cls_doc.ctor.doc_6args_double_gains)
+        .def(py::init<std::unique_ptr<System<double>>, const VectorX<double>&,
+                 const VectorX<double>&, const VectorX<double>&, int, int>(),
+            py::arg("plant"), py::arg("kp"), py::arg("ki"), py::arg("kd"),
+            py::arg("state_output_port_index") = 0,
+            py::arg("plant_input_port_index") = 0,
+            // Keep alive, ownership: `plant` keeps `self` alive.
+            py::keep_alive<2, 1>(), cls_doc.ctor.doc_6args_vector_gains)
+        .def(py::init<std::unique_ptr<System<double>>, const MatrixX<double>&,
+                 double, double, double, int, int>(),
+            py::arg("plant"), py::arg("feedback_selector"), py::arg("kp"),
+            py::arg("ki"), py::arg("kd"),
+            py::arg("state_output_port_index") = 0,
+            py::arg("plant_input_port_index") = 0,
+            // Keep alive, ownership: `plant` keeps `self` alive.
+            py::keep_alive<2, 1>(), cls_doc.ctor.doc_7args_double_gains)
+        .def(py::init<std::unique_ptr<System<double>>, const MatrixX<double>&,
+                 const VectorX<double>&, const VectorX<double>&,
+                 const VectorX<double>&, int, int>(),
+            py::arg("plant"), py::arg("feedback_selector"), py::arg("kp"),
+            py::arg("ki"), py::arg("kd"),
+            py::arg("state_output_port_index") = 0,
+            py::arg("plant_input_port_index") = 0,
+            // Keep alive, ownership: `plant` keeps `self` alive.
+            py::keep_alive<2, 1>(), cls_doc.ctor.doc_7args_vector_gains)
+        .def("get_control_input_port", &Class::get_control_input_port,
+            py_rvp::reference_internal, cls_doc.get_control_input_port.doc)
+        .def("get_state_input_port", &Class::get_state_input_port,
+            py_rvp::reference_internal, cls_doc.get_state_input_port.doc)
+        .def("get_state_output_port", &Class::get_state_output_port,
+            py_rvp::reference_internal, cls_doc.get_state_output_port.doc);
+  }
+
+  // TODO(eric.cousineau): Expose multiple inheritance from
+  // StateFeedbackControllerInterface once #9243 is resolved.
+  {
+    using Class = PidController<double>;
+    constexpr auto& cls_doc = doc.PidController;
+    py::class_<Class, LeafSystem<double>>(m, "PidController", cls_doc.doc)
+        .def(py::init<const VectorX<double>&, const VectorX<double>&,
+                 const VectorX<double>&>(),
+            py::arg("kp"), py::arg("ki"), py::arg("kd"), cls_doc.ctor.doc_3args)
+        .def(py::init<const MatrixX<double>&, const VectorX<double>&,
+                 const VectorX<double>&, const VectorX<double>&>(),
+            py::arg("state_projection"), py::arg("kp"), py::arg("ki"),
+            py::arg("kd"), cls_doc.ctor.doc_4args)
+        .def(py::init<const MatrixX<double>&, const MatrixX<double>&,
+                 const VectorX<double>&, const VectorX<double>&,
+                 const VectorX<double>&>(),
+            py::arg("state_projection"), py::arg("output_projection"),
+            py::arg("kp"), py::arg("ki"), py::arg("kd"), cls_doc.ctor.doc_5args)
+        .def("get_Kp_vector", &Class::get_Kp_vector, cls_doc.get_Kp_vector.doc)
+        .def("get_Ki_vector", &Class::get_Ki_vector, cls_doc.get_Ki_vector.doc)
+        .def("get_Kd_vector", &Class::get_Kd_vector, cls_doc.get_Kd_vector.doc)
+        .def("get_input_port_estimated_state",
+            &Class::get_input_port_estimated_state, py_rvp::reference_internal,
+            cls_doc.get_input_port_estimated_state.doc)
+        .def("get_input_port_desired_state",
+            &Class::get_input_port_desired_state, py_rvp::reference_internal,
+            cls_doc.get_input_port_desired_state.doc)
+        .def("get_output_port_control", &Class::get_output_port_control,
+            py_rvp::reference_internal, cls_doc.get_output_port_control.doc);
+  }
 
   m.def("FittedValueIteration", WrapCallbacks(&FittedValueIteration),
       doc.FittedValueIteration.doc);
@@ -291,72 +288,48 @@ PYBIND11_MODULE(controllers, m) {
       py::arg("input_port_index") = 0,
       doc.LinearQuadraticRegulator.doc_linearize_at_context);
 
-  py::class_<FiniteHorizonLinearQuadraticRegulatorOptions> fhlqr_options(m,
-      "FiniteHorizonLinearQuadraticRegulatorOptions",
-      doc.FiniteHorizonLinearQuadraticRegulatorOptions.doc);
-  fhlqr_options
-      .def(py::init<>(),
-          doc.FiniteHorizonLinearQuadraticRegulatorOptions.ctor.doc)
-      .def_readwrite("Qf", &FiniteHorizonLinearQuadraticRegulatorOptions::Qf,
-          doc.FiniteHorizonLinearQuadraticRegulatorOptions.Qf.doc)
-      .def_readwrite("N", &FiniteHorizonLinearQuadraticRegulatorOptions::N,
-          doc.FiniteHorizonLinearQuadraticRegulatorOptions.N.doc)
-      .def_readwrite("input_port_index",
-          &FiniteHorizonLinearQuadraticRegulatorOptions::input_port_index,
-          doc.FiniteHorizonLinearQuadraticRegulatorOptions.input_port_index.doc)
-      .def_readwrite("use_square_root_method",
-          &FiniteHorizonLinearQuadraticRegulatorOptions::use_square_root_method,
-          doc.FiniteHorizonLinearQuadraticRegulatorOptions
-              .use_square_root_method.doc)
-      .def("__repr__",
-          [](const FiniteHorizonLinearQuadraticRegulatorOptions& self) {
-            return py::str(
-                "FiniteHorizonLinearQuadraticRegulatorOptions("
-                "Qf={}, "
-                "N={}, "
-                "input_port_index={}, "
-                "use_square_root_method={})")
-                .format(self.Qf, self.N, self.input_port_index,
-                    self.use_square_root_method);
-          });
+  {
+    using Class = FiniteHorizonLinearQuadraticRegulatorOptions;
+    constexpr auto& cls_doc = doc.FiniteHorizonLinearQuadraticRegulatorOptions;
+    py::class_<Class> cls(
+        m, "FiniteHorizonLinearQuadraticRegulatorOptions", cls_doc.doc);
+    cls  // BR
+        .def(py::init<>(), cls_doc.ctor.doc)
+        .def_readwrite("Qf", &Class::Qf, cls_doc.Qf.doc)
+        .def_readwrite("N", &Class::N, cls_doc.N.doc)
+        .def_readwrite("input_port_index", &Class::input_port_index,
+            cls_doc.input_port_index.doc)
+        .def_readwrite("use_square_root_method", &Class::use_square_root_method,
+            cls_doc.use_square_root_method.doc)
+        .def("__repr__", [](const Class& self) {
+          return py::str(
+              "FiniteHorizonLinearQuadraticRegulatorOptions("
+              "Qf={}, "
+              "N={}, "
+              "input_port_index={}, "
+              "use_square_root_method={})")
+              .format(self.Qf, self.N, self.input_port_index,
+                  self.use_square_root_method);
+        });
+    DefReadWriteKeepAlive(&cls, "x0", &Class::x0, cls_doc.x0.doc);
+    DefReadWriteKeepAlive(&cls, "u0", &Class::u0, cls_doc.u0.doc);
+    DefReadWriteKeepAlive(&cls, "xd", &Class::xd, cls_doc.xd.doc);
+    DefReadWriteKeepAlive(&cls, "ud", &Class::ud, cls_doc.ud.doc);
+  }
 
-  DefReadWriteKeepAlive(&fhlqr_options, "x0",
-      &FiniteHorizonLinearQuadraticRegulatorOptions::x0,
-      doc.FiniteHorizonLinearQuadraticRegulatorOptions.x0.doc);
-  DefReadWriteKeepAlive(&fhlqr_options, "u0",
-      &FiniteHorizonLinearQuadraticRegulatorOptions::u0,
-      doc.FiniteHorizonLinearQuadraticRegulatorOptions.u0.doc);
-  DefReadWriteKeepAlive(&fhlqr_options, "xd",
-      &FiniteHorizonLinearQuadraticRegulatorOptions::xd,
-      doc.FiniteHorizonLinearQuadraticRegulatorOptions.xd.doc);
-  DefReadWriteKeepAlive(&fhlqr_options, "ud",
-      &FiniteHorizonLinearQuadraticRegulatorOptions::ud,
-      doc.FiniteHorizonLinearQuadraticRegulatorOptions.ud.doc);
-
-  py::class_<FiniteHorizonLinearQuadraticRegulatorResult> fhlqr_result(m,
-      "FiniteHorizonLinearQuadraticRegulatorResult",
-      doc.FiniteHorizonLinearQuadraticRegulatorResult.doc);
-  DefReadUniquePtr(&fhlqr_result, "x0",
-      &FiniteHorizonLinearQuadraticRegulatorResult::x0,
-      doc.FiniteHorizonLinearQuadraticRegulatorResult.x0.doc);
-  DefReadUniquePtr(&fhlqr_result, "u0",
-      &FiniteHorizonLinearQuadraticRegulatorResult::u0,
-      doc.FiniteHorizonLinearQuadraticRegulatorResult.u0.doc);
-  DefReadUniquePtr(&fhlqr_result, "K",
-      &FiniteHorizonLinearQuadraticRegulatorResult::K,
-      doc.FiniteHorizonLinearQuadraticRegulatorResult.K.doc);
-  DefReadUniquePtr(&fhlqr_result, "S",
-      &FiniteHorizonLinearQuadraticRegulatorResult::S,
-      doc.FiniteHorizonLinearQuadraticRegulatorResult.S.doc);
-  DefReadUniquePtr(&fhlqr_result, "k0",
-      &FiniteHorizonLinearQuadraticRegulatorResult::k0,
-      doc.FiniteHorizonLinearQuadraticRegulatorResult.k0.doc);
-  DefReadUniquePtr(&fhlqr_result, "sx",
-      &FiniteHorizonLinearQuadraticRegulatorResult::sx,
-      doc.FiniteHorizonLinearQuadraticRegulatorResult.sx.doc);
-  DefReadUniquePtr(&fhlqr_result, "s0",
-      &FiniteHorizonLinearQuadraticRegulatorResult::s0,
-      doc.FiniteHorizonLinearQuadraticRegulatorResult.s0.doc);
+  {
+    using Class = FiniteHorizonLinearQuadraticRegulatorResult;
+    constexpr auto& cls_doc = doc.FiniteHorizonLinearQuadraticRegulatorResult;
+    py::class_<Class> cls(
+        m, "FiniteHorizonLinearQuadraticRegulatorResult", cls_doc.doc);
+    DefReadUniquePtr(&cls, "x0", &Class::x0, cls_doc.x0.doc);
+    DefReadUniquePtr(&cls, "u0", &Class::u0, cls_doc.u0.doc);
+    DefReadUniquePtr(&cls, "K", &Class::K, cls_doc.K.doc);
+    DefReadUniquePtr(&cls, "S", &Class::S, cls_doc.S.doc);
+    DefReadUniquePtr(&cls, "k0", &Class::k0, cls_doc.k0.doc);
+    DefReadUniquePtr(&cls, "sx", &Class::sx, cls_doc.sx.doc);
+    DefReadUniquePtr(&cls, "s0", &Class::s0, cls_doc.s0.doc);
+  }
 
   m.def("FiniteHorizonLinearQuadraticRegulator",
       &FiniteHorizonLinearQuadraticRegulator, py::arg("system"),

--- a/bindings/pydrake/systems/test/controllers_test.py
+++ b/bindings/pydrake/systems/test/controllers_test.py
@@ -60,8 +60,12 @@ class TestControllers(unittest.TestCase):
         options = DynamicProgrammingOptions()
         options.convergence_tol = 1.
         options.periodic_boundary_conditions = [
-            PeriodicBoundaryCondition(0, 0., 2.*math.pi)
+            DynamicProgrammingOptions.PeriodicBoundaryCondition(
+                state_index=0, low=0., high=2.*math.pi),
         ]
+        self.assertIs(
+            PeriodicBoundaryCondition,
+            DynamicProgrammingOptions.PeriodicBoundaryCondition)
         options.visualization_callback = callback
         options.input_port_index = InputPortSelection.kUseFirstInputIfItExists
         options.assume_non_continuous_states_are_fixed = False


### PR DESCRIPTION
Doing this in service of making #18315 a bit easier to wrangle for Python bindings
This does not change functionality aside from ensuring scopes, attributes, and kwargs are reflected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18316)
<!-- Reviewable:end -->
