### PR TITLE
[parsing] Implements basic material and mesh support in MuJoCo parser

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -481,7 +481,11 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "detail_mujoco_parser_test",
-    data = _DM_CONTROL_MUJOCO_FILES,
+    data = [
+        ":test_models",
+        "//geometry:test_obj_files",
+        "//geometry:test_stl_files",
+    ] + _DM_CONTROL_MUJOCO_FILES,
     deps = [
         ":detail_mujoco_parser",
         "//common:find_resource",

--- a/multibody/parsing/test/box_package/mjcfs/box.xml
+++ b/multibody/parsing/test/box_package/mjcfs/box.xml
@@ -1,0 +1,9 @@
+<mujoco model="test">
+  <compiler meshdir="../meshes"/>
+  <asset>
+    <mesh name="box" file="box.obj"/>
+  </asset>
+  <worldbody>
+    <geom name="box_geom" type="mesh" mesh="box"/>
+  </worldbody>
+</mujoco>


### PR DESCRIPTION
This contains #18312 as its first commit.
- All files under `drake/geometry` belong to #18312 
- All files under `drake/multibody` belong solely to this PR and need review.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18317)
<!-- Reviewable:end -->
