### PR TITLE
[trajectories] Deprecate PiecewisePolynomial::Cubic

### DIFF
--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -8,6 +8,7 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/polynomial.h"
 #include "drake/common/trajectories/piecewise_trajectory.h"
@@ -425,6 +426,8 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
       const Eigen::Ref<const MatrixX<T>>& samples,
       bool periodic_end_condition = false);
 
+  DRAKE_DEPRECATED("2023-03-01",
+                   "Please use CubicWithContinuousSecondDerivatives instead.")
   static PiecewisePolynomial<T> Cubic(
       const Eigen::Ref<const VectorX<T>>& breaks,
       const Eigen::Ref<const MatrixX<T>>& samples,


### PR DESCRIPTION
I think this method was meant to be deprecated before; the name was changed way back in #12939. There are no tests, no uses, and no python bindings. Here we're simply marking it for removal.

+@SeanCurtis-TRI for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18319)
<!-- Reviewable:end -->
