### PR TITLE
defer import of matplotlib.animation in pyplot_visualizer

### DIFF
--- a/bindings/pydrake/systems/pyplot_visualizer.py
+++ b/bindings/pydrake/systems/pyplot_visualizer.py
@@ -1,5 +1,4 @@
 import matplotlib
-import matplotlib.animation as animation
 import numpy as np
 from warnings import warn
 
@@ -129,6 +128,9 @@ class PyPlotVisualizer(LeafSystem):
         return self.draw(self._recorded_contexts[i])
 
     def get_recording_as_animation(self, **kwargs):
+        # We defer this import to this call site to prevent the import
+        # from hanging. See #18323.
+        import matplotlib.animation as animation
         ani = animation.FuncAnimation(fig=self.fig,
                                       func=self._draw_recorded_frame,
                                       frames=len(self._recorded_contexts),
@@ -161,6 +163,9 @@ class PyPlotVisualizer(LeafSystem):
         def animate_update(i):
             self.draw(x[:, i])
 
+        # We defer this import to this call site to prevent the import
+        # from hanging. See #18323.
+        import matplotlib.animation as animation
         ani = animation.FuncAnimation(fig=self.fig,
                                       func=animate_update,
                                       frames=t.shape[0],


### PR DESCRIPTION
In some deeply nested import situations, importing matplotlib.animation will hang a backgrounded Python program because it's reading from stderr. Deferring the import solves the issue. Resolves #18323.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18324)
<!-- Reviewable:end -->
