### PR TITLE
[setup] prevent Homebrew file ownership damage

### DIFF
--- a/setup/mac/binary_distribution/install_prereqs.sh
+++ b/setup/mac/binary_distribution/install_prereqs.sh
@@ -34,6 +34,20 @@ if ! command -v brew &>/dev/null; then
     "$(/usr/bin/curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
 
+eval "$(brew shellenv)"
+HOMEBREW_ADMIN=$(stat -f '%Su' ${HOMEBREW_PREFIX}/Cellar)
+if [[ "$HOMEBREW_ADMIN" != "$USER" ]]; then
+    cat <<EOF
+WARNING: You, $USER, are not the Homebrew administrator on this machine.
+Please ask $HOMEBREW_ADMIN to update Drake Homebrew dependencies if necessary.
+
+Skipping binary distribution dependency updates; try building Drake
+anyway. The currently installed dependencies may be adequate.
+
+EOF
+    exit 0
+fi
+
 # Pass --retry 2 when invoking the curl command line tool during execution of
 # this script to retry twice the download of a bottle.
 [[ -z "${HOMEBREW_CURL_RETRIES:-}" ]] || export HOMEBREW_CURL_RETRIES=2

--- a/setup/mac/install_prereqs.sh
+++ b/setup/mac/install_prereqs.sh
@@ -33,21 +33,39 @@ while [ "${1:-}" != "" ]; do
   shift
 done
 
-# Dependencies that are installed by the following sourced script that are
-# needed when developing with binary distributions are also needed when
-# developing with source distributions.
 
-# N.B. We need `${var:-}` here because mac's older version of bash does
-# not seem to be able to cope with an empty array.
+HOMEBREW_ADMIN=$USER
+if command -v brew &>/dev/null; then
+    eval "$(brew shellenv)"
+    HOMEBREW_ADMIN=$(stat -f '%Su' ${HOMEBREW_PREFIX}/Cellar)
+fi
 
-source "${BASH_SOURCE%/*}/binary_distribution/install_prereqs.sh" \
-  "${binary_distribution_args[@]:-}"
+if [[ "$HOMEBREW_ADMIN" != "$USER" ]]; then
+    cat <<EOF
+WARNING: You, $USER, are not the Homebrew administrator on this machine.
+Please ask $HOMEBREW_ADMIN to update Drake Homebrew dependencies if necessary.
 
-# The following additional dependencies are only needed when developing with
-# source distributions.
+Skipping dependency updates; try building Drake anyway. The currently
+installed dependencies may be adequate.
 
-source "${BASH_SOURCE%/*}/source_distribution/install_prereqs.sh" \
-  "${source_distribution_args[@]:-}"
+EOF
+else
+    # Dependencies that are installed by the following sourced script that are
+    # needed when developing with binary distributions are also needed when
+    # developing with source distributions.
+
+    # N.B. We need `${var:-}` here because mac's older version of bash does
+    # not seem to be able to cope with an empty array.
+
+    source "${BASH_SOURCE%/*}/binary_distribution/install_prereqs.sh" \
+	   "${binary_distribution_args[@]:-}"
+
+    # The following additional dependencies are only needed when developing with
+    # source distributions.
+
+    source "${BASH_SOURCE%/*}/source_distribution/install_prereqs.sh" \
+	   "${source_distribution_args[@]:-}"
+fi
 
 # The preceding only needs to be run once per machine. The following sourced
 # script should be run once per user who develops with source distributions.

--- a/setup/mac/source_distribution/install_prereqs.sh
+++ b/setup/mac/source_distribution/install_prereqs.sh
@@ -45,6 +45,20 @@ if ! command -v brew &>/dev/null; then
   exit 4
 fi
 
+eval "$(brew shellenv)"
+HOMEBREW_ADMIN=$(stat -f '%Su' ${HOMEBREW_PREFIX}/Cellar)
+if [[ "$HOMEBREW_ADMIN" != "$USER" ]]; then
+    cat <<EOF
+WARNING: You, $USER, are not the Homebrew administrator on this machine.
+Please ask $HOMEBREW_ADMIN to update Drake Homebrew dependencies if necessary.
+
+Skipping source distribution dependency updates; try building Drake
+anyway. The currently installed dependencies may be adequate.
+
+EOF
+    exit 0
+fi
+
 if [[ "${with_update}" -eq 1 && "${binary_distribution_called_update:-0}" -ne 1 ]]; then
   brew update || (sleep 30; brew update)
 fi


### PR DESCRIPTION
Homebrew prefers to have a single user account own system-wide files. This opens the way for naive users to mess up file ownership on shared machines. Guard against this hazard by checking the file ownership and issuing warnings when Homebrew is already installed on a machine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18328)
<!-- Reviewable:end -->
