### PR TITLE
[pydrake] Add missing bindings to UnitInertia

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -593,7 +593,7 @@ class TestPlant(unittest.TestCase):
         """Tests unit inertia construction and API."""
         UnitInertia = UnitInertia_[T]
         self._test_rotational_inertia_or_unit_inertia_api(T, UnitInertia)
-        # Test methods present only on UnitInertia, not RotationalInernia.
+        # Test methods present only on UnitInertia, not RotationalInertia.
         p = [0.1, 0.2, 0.3]
         dut = UnitInertia(I=RotationalInertia_[T](mass=1.0, p_PQ_E=p))
         self.assertIsInstance(
@@ -603,6 +603,30 @@ class TestPlant(unittest.TestCase):
         assert_pickle(self, dut, UnitInertia.CopyToFullMatrix3, T=T)
         # N.B. There are NO valid operators on UnitInertia.  They are inherited
         # through implementation reuse, but they are broken (#6109).
+
+        # The static constructors from "geometry".
+        self.assertIsInstance(UnitInertia.PointMass(p_FQ=[1, 2, 3]),
+                              UnitInertia)
+        self.assertIsInstance(UnitInertia.SolidEllipsoid(a=1, b=2, c=3),
+                              UnitInertia)
+        self.assertIsInstance(UnitInertia.SolidSphere(r=1.5), UnitInertia)
+        self.assertIsInstance(UnitInertia.HollowSphere(r=1.5), UnitInertia)
+        self.assertIsInstance(UnitInertia.SolidBox(Lx=1, Ly=2, Lz=3),
+                              UnitInertia)
+        self.assertIsInstance(UnitInertia.SolidCube(L=2), UnitInertia)
+        self.assertIsInstance(UnitInertia.SolidCylinder(r=1.5, L=2),
+                              UnitInertia)
+        self.assertIsInstance(
+            UnitInertia.SolidCylinder(r=1.5, L=2, b_E=[1, 2, 3]), UnitInertia)
+        self.assertIsInstance(UnitInertia.SolidCapsule(r=1, L=2), UnitInertia)
+        self.assertIsInstance(UnitInertia.SolidCylinderAboutEnd(r=1, L=2),
+                              UnitInertia)
+        self.assertIsInstance(
+            UnitInertia.AxiallySymmetric(J=1, K=2, b_E=[1, 2, 3]), UnitInertia)
+        self.assertIsInstance(UnitInertia.StraightLine(K=1.5, b_E=[1, 2, 3]),
+                              UnitInertia)
+        self.assertIsInstance(UnitInertia.ThinRod(L=1.5, b_E=[1, 2, 3]),
+                              UnitInertia)
 
     @numpy_compare.check_all_types
     def test_spatial_inertia_api(self, T):

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -1042,6 +1042,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("p_QBcm_E"), cls_doc.ShiftToCenterOfMass.doc)
         .def_static("PointMass", &Class::PointMass, py::arg("p_FQ"),
             cls_doc.PointMass.doc)
+        .def_static("SolidEllipsoid", &Class::SolidEllipsoid, py::arg("a"),
+            py::arg("b"), py::arg("c"), cls_doc.SolidEllipsoid.doc)
         .def_static("SolidSphere", &Class::SolidSphere, py::arg("r"),
             cls_doc.SolidSphere.doc)
         .def_static("HollowSphere", &Class::HollowSphere, py::arg("r"),
@@ -1053,6 +1055,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def_static("SolidCylinder", &Class::SolidCylinder, py::arg("r"),
             py::arg("L"), py::arg("b_E") = Vector3<T>::UnitZ().eval(),
             cls_doc.SolidCylinder.doc)
+        .def_static("SolidCapsule", &Class::SolidCapsule, py::arg("r"),
+            py::arg("L"), cls_doc.SolidCapsule.doc)
         .def_static("SolidCylinderAboutEnd", &Class::SolidCylinderAboutEnd,
             py::arg("r"), py::arg("L"), cls_doc.SolidCylinderAboutEnd.doc)
         .def_static("AxiallySymmetric", &Class::AxiallySymmetric, py::arg("J"),


### PR DESCRIPTION
This also adds previously missing tests on those bindings.

Adds the following bindings:

drake.multibody.tree.UnitInertia.SolidEllipsoid
drake.multibody.tree.UnitInertia.SolidCapsule

resolves #18337

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18341)
<!-- Reviewable:end -->
