### PR TITLE
[parsing] Port to parser.AddModels, part 3

### DIFF
--- a/bindings/pydrake/systems/test/controllers_test.py
+++ b/bindings/pydrake/systems/test/controllers_test.py
@@ -111,7 +111,7 @@ class TestControllers(unittest.TestCase):
             "iiwa_description/sdf/iiwa14_no_collision.sdf")
 
         plant = MultibodyPlant(time_step=0.01)
-        Parser(plant).AddModelFromFile(sdf_path)
+        Parser(plant).AddModels(sdf_path)
         plant.WeldFrames(plant.world_frame(),
                          plant.GetFrameByName("iiwa_link_0"))
         plant.Finalize()

--- a/multibody/plant/test/multibody_plant_deprecated_test.cc
+++ b/multibody/plant/test/multibody_plant_deprecated_test.cc
@@ -18,7 +18,7 @@ GTEST_TEST(MultibodyPlant, DeprecatedOutputNames) {
   const AcrobotParameters parameters;
   std::unique_ptr<MultibodyPlant<double>> plant =
       MakeAcrobotPlant(parameters, /* finalize = */ false);
-  Parser(plant.get()).AddModelFromFile(FindResourceOrThrow(
+  Parser(plant.get()).AddModels(FindResourceOrThrow(
       "drake/multibody/plant/test/split_pendulum.sdf"));
   plant->Finalize();
   EXPECT_EQ(plant->num_model_instances(), 3);

--- a/systems/controllers/test/inverse_dynamics_controller_test.cc
+++ b/systems/controllers/test/inverse_dynamics_controller_test.cc
@@ -137,7 +137,7 @@ GTEST_TEST(AdditionalInverseDynamicsTest, ScalarConversion) {
   auto mbp = std::make_unique<MultibodyPlant<double>>(0.0);
   const std::string full_name = drake::FindResourceOrThrow(
       "drake/manipulation/models/iiwa_description/sdf/iiwa14_no_collision.sdf");
-  multibody::Parser(mbp.get()).AddModelFromFile(full_name);
+  multibody::Parser(mbp.get()).AddModels(full_name);
   mbp->WeldFrames(mbp->world_frame(),
                   mbp->GetFrameByName("iiwa_link_0"));
   mbp->Finalize();

--- a/systems/controllers/test/inverse_dynamics_test.cc
+++ b/systems/controllers/test/inverse_dynamics_test.cc
@@ -211,7 +211,7 @@ GTEST_TEST(AdditionalInverseDynamicsTest, ScalarConversion) {
   auto mbp = std::make_unique<MultibodyPlant<double>>(0.0);
   const std::string full_name = drake::FindResourceOrThrow(
       "drake/manipulation/models/iiwa_description/sdf/iiwa14_no_collision.sdf");
-  multibody::Parser(mbp.get()).AddModelFromFile(full_name);
+  multibody::Parser(mbp.get()).AddModels(full_name);
   mbp->WeldFrames(mbp->world_frame(),
                   mbp->GetFrameByName("iiwa_link_0"));
   mbp->Finalize();

--- a/systems/controllers/test/joint_stiffness_controller_test.cc
+++ b/systems/controllers/test/joint_stiffness_controller_test.cc
@@ -22,7 +22,7 @@ GTEST_TEST(JointStiffnessControllerTest, SimpleDoublePendulum) {
   auto plant = builder.AddSystem<MultibodyPlant>(0.0);
   std::string full_name = FindResourceOrThrow(
       "drake/multibody/benchmarks/acrobot/double_pendulum.urdf");
-  multibody::Parser(plant).AddModelFromFile(full_name);
+  multibody::Parser(plant).AddModels(full_name);
   plant->WeldFrames(plant->world_frame(), plant->GetFrameByName("base"));
   plant->Finalize();
 
@@ -64,7 +64,7 @@ GTEST_TEST(JointStiffnessControllerTest, ScalarConversion) {
   auto mbp = std::make_unique<MultibodyPlant<double>>(0.0);
   const std::string full_name = FindResourceOrThrow(
       "drake/manipulation/models/iiwa_description/sdf/iiwa14_no_collision.sdf");
-  multibody::Parser(mbp.get()).AddModelFromFile(full_name);
+  multibody::Parser(mbp.get()).AddModels(full_name);
   mbp->WeldFrames(mbp->world_frame(), mbp->GetFrameByName("iiwa_link_0"));
   mbp->Finalize();
   const int num_states = mbp->num_multibody_states();


### PR DESCRIPTION
Port some more parser call sites to AddModels. These just escaped detection in prior passes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18343)
<!-- Reviewable:end -->
