### PR TITLE
Calculate SpatialInertia from Shape and TriangleMesh

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -18,6 +18,7 @@ from pydrake.multibody.tree import (
     BallRpyJoint_,
     Body_,
     BodyIndex,
+    CalcSpatialInertia,
     ConstraintIndex,
     DoorHinge_,
     DoorHingeConfig,
@@ -105,6 +106,8 @@ from pydrake.geometry import (
     SignedDistancePair_,
     SignedDistanceToPoint_,
     Sphere,
+    SurfaceTriangle,
+    TriangleSurfaceMesh,
 )
 from pydrake.math import (
     RigidTransform_,
@@ -677,6 +680,19 @@ class TestPlant(unittest.TestCase):
         # N.B. `numpy_compare.assert_equal(IsNaN(), True)` does not work.
         if T != Expression:
             self.assertTrue(spatial_inertia.IsNaN())
+
+    def test_geometry_spatial_inertia_apis(self):
+        box = Box(1, 2, 3)
+        M_BBo_B = CalcSpatialInertia(shape=box, density=2.5)
+        self.assertIsInstance(M_BBo_B, SpatialInertia_[float])
+
+        t_a = SurfaceTriangle(v0=0, v1=1, v2=2)
+        v0 = (0, 0, 1)
+        v1 = (1, 0, 0)
+        v2 = (0, 1, 0)
+        mesh = TriangleSurfaceMesh(triangles=(t_a,), vertices=(v0, v1, v2))
+        M_MMo_M = CalcSpatialInertia(mesh=mesh, density=2.5)
+        self.assertIsInstance(M_MMo_M, SpatialInertia_[float])
 
     @numpy_compare.check_all_types
     def test_friction_api(self, T):

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -19,6 +19,7 @@
 #include "drake/multibody/tree/door_hinge.h"
 #include "drake/multibody/tree/force_element.h"
 #include "drake/multibody/tree/frame.h"
+#include "drake/multibody/tree/geometry_spatial_inertia.h"
 #include "drake/multibody/tree/joint.h"
 #include "drake/multibody/tree/joint_actuator.h"
 #include "drake/multibody/tree/linear_bushing_roll_pitch_yaw.h"
@@ -112,6 +113,18 @@ void DoScalarIndependentDefinitions(py::module m) {
       doc.world_model_instance.doc);
   m.def("default_model_instance", &default_model_instance,
       doc.default_model_instance.doc);
+
+  // CalcSpatialInertia.
+  {
+    m.def("CalcSpatialInertia",
+        py::overload_cast<const geometry::Shape&, double>(&CalcSpatialInertia),
+        py::arg("shape"), py::arg("density"), doc.CalcSpatialInertia.doc_shape);
+
+    m.def("CalcSpatialInertia",
+        py::overload_cast<const geometry::TriangleSurfaceMesh<double>&, double>(
+            &CalcSpatialInertia),
+        py::arg("mesh"), py::arg("density"), doc.CalcSpatialInertia.doc_mesh);
+  }
 
   {
     using Class = DoorHingeConfig;

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -17,6 +17,7 @@ drake_cc_package_library(
     visibility = ["//visibility:public"],
     deps = [
         ":articulated_body_inertia",
+        ":geometry_spatial_inertia",
         ":multibody_element",
         ":multibody_tree_caches",
         ":multibody_tree_core",
@@ -247,6 +248,18 @@ drake_cc_library(
         "//math:linear_solve",
         "//math:vector3_util",
         "//multibody/math:spatial_algebra",
+    ],
+)
+
+drake_cc_library(
+    name = "geometry_spatial_inertia",
+    srcs = ["geometry_spatial_inertia.cc"],
+    hdrs = ["geometry_spatial_inertia.h"],
+    deps = [
+        ":spatial_inertia",
+        "//geometry:shape_specification",
+        "//geometry/proximity:obj_to_surface_mesh",
+        "//geometry/proximity:triangle_surface_mesh",
     ],
 )
 
@@ -620,6 +633,20 @@ drake_cc_googletest(
     deps = [
         ":tree",
         "//common/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "geometry_spatial_inertia_test",
+    data = ["//multibody/parsing:test_models"],
+    deps = [
+        ":geometry_spatial_inertia",
+        "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+        "//geometry:shape_specification",
+        "//geometry/proximity:make_box_mesh",
+        "//geometry/proximity:triangle_surface_mesh",
     ],
 )
 

--- a/multibody/tree/geometry_spatial_inertia.cc
+++ b/multibody/tree/geometry_spatial_inertia.cc
@@ -1,0 +1,185 @@
+#include "drake/multibody/tree/geometry_spatial_inertia.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <string>
+
+#include "drake/geometry/proximity/obj_to_surface_mesh.h"
+#include "drake/multibody/tree/spatial_inertia.h"
+#include "drake/multibody/tree/unit_inertia.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+using Eigen::Vector3d;
+using geometry::Shape;
+using geometry::ShapeReifier;
+using std::pow;
+
+/* The spatial inertia documented in the header file. See documentation there
+ for semantics and notation. */
+class SpatialInertiaCalculator final : public ShapeReifier {
+ public:
+  SpatialInertia<double> Calculate(const Shape& shape, double density) {
+    density_ = density;
+    shape.Reify(this);
+    return spatial_inertia_;
+  }
+
+  SpatialInertia<double> spatial_inertia() const { return spatial_inertia_; }
+
+ private:
+  void ImplementGeometry(const geometry::Box& box, void*) final {
+    const double volume = box.width() * box.depth() * box.height();
+    const double mass = volume * density_;
+    const Vector3d p_SoScm_S = Vector3d::Zero();
+    const UnitInertia<double> G_SSo_S =
+        UnitInertia<double>::SolidBox(box.width(), box.depth(), box.height());
+    spatial_inertia_ = SpatialInertia<double>{mass, p_SoScm_S, G_SSo_S};
+  }
+
+  void ImplementGeometry(const geometry::Capsule& capsule, void*) final {
+    const double volume = (M_PI * 4.0 / 3.0 * pow(capsule.radius(), 3) +
+                           M_PI * pow(capsule.radius(), 2) * capsule.length());
+    const double mass = volume * density_;
+    const Vector3d p_SoScm_S = Vector3d::Zero();
+    const UnitInertia<double> G_SSo_S =
+        UnitInertia<double>::SolidCapsule(capsule.radius(), capsule.length());
+    spatial_inertia_ = SpatialInertia<double>{mass, p_SoScm_S, G_SSo_S};
+  }
+
+  void ImplementGeometry(const geometry::Convex& convex, void*) final {
+    ImplementMesh(convex);
+  }
+
+  void ImplementGeometry(const geometry::Cylinder& cylinder, void*) final {
+    const double volume = M_PI * pow(cylinder.radius(), 2) * cylinder.length();
+    const double mass = volume * density_;
+    const Vector3d p_SoScm_S = Vector3d::Zero();
+    const UnitInertia<double> G_SSo_S = UnitInertia<double>::SolidCylinder(
+        cylinder.radius(), cylinder.length());
+    spatial_inertia_ = SpatialInertia<double>{mass, p_SoScm_S, G_SSo_S};
+  }
+
+  void ImplementGeometry(const geometry::Ellipsoid& ellipsoid, void*) final {
+    const double volume =
+        4.0 * M_PI / 3.0 * ellipsoid.a() * ellipsoid.b() * ellipsoid.c();
+    const double mass = volume * density_;
+    const Vector3d p_SoScm_S = Vector3d::Zero();
+    const UnitInertia<double> G_SSo_S = UnitInertia<double>::SolidEllipsoid(
+        ellipsoid.a(), ellipsoid.b(), ellipsoid.c());
+    spatial_inertia_ = SpatialInertia<double>{mass, p_SoScm_S, G_SSo_S};
+  }
+
+  void ImplementGeometry(const geometry::HalfSpace&, void*) final {
+    throw std::logic_error(
+        "Cannot compute mass properties for an infinite volume: HalfSpace");
+  }
+
+  void ImplementGeometry(const geometry::Mesh& mesh, void*) final {
+    ImplementMesh(mesh);
+  }
+
+  void ImplementGeometry(const geometry::MeshcatCone&, void*) final {
+    throw std::logic_error(
+        "Cannot compute mass properties for the visualization-only "
+        "MeshcatCone");
+  }
+
+  void ImplementGeometry(const geometry::Sphere& sphere, void*) final {
+    const double volume = 4.0 * M_PI / 3.0 * pow(sphere.radius(), 3);
+    const double mass = volume * density_;
+    const Vector3d p_SoScm_S = Vector3d::Zero();
+    const UnitInertia<double> G_SSo_S =
+        UnitInertia<double>::SolidSphere(sphere.radius());
+    spatial_inertia_ = SpatialInertia<double>{mass, p_SoScm_S, G_SSo_S};
+  }
+
+  template <typename MeshType>
+  void ImplementMesh(const MeshType& mesh) {
+    std::string extension = std::filesystem::path(mesh.filename()).extension();
+    std::transform(extension.begin(), extension.end(), extension.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    // TODO(russt): Support .vtk files.
+    if (extension != ".obj") {
+      throw std::runtime_error(fmt::format(
+          "CalcMassProperties currently only supports .obj files for mesh "
+          "geometries but was given '{}'.",
+          mesh.filename()));
+    }
+    const geometry::TriangleSurfaceMesh<double> surface_mesh =
+        geometry::ReadObjToTriangleSurfaceMesh(mesh.filename(), mesh.scale());
+
+    spatial_inertia_ = CalcSpatialInertia(surface_mesh, density_);
+  }
+
+  double density_{};
+  SpatialInertia<double> spatial_inertia_;
+};
+
+}  // namespace
+
+SpatialInertia<double> CalcSpatialInertia(const geometry::Shape& shape,
+                                          double density) {
+  SpatialInertiaCalculator calculator;
+  calculator.Calculate(shape, density);
+  return calculator.spatial_inertia();
+}
+
+SpatialInertia<double> CalcSpatialInertia(
+    const geometry::TriangleSurfaceMesh<double>& mesh, double density) {
+  /* This algorithm is based on:
+   - https://www.geometrictools.com/Documentation/PolyhedralMassProperties.pdf
+   - http://number-none.com/blow/inertia/bb_inertia.doc
+  */
+  // The co-variance matrix of a canonical tetrahedron with vertices at
+  // (0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1) with an assumption of *unit*
+  // density.
+  Matrix3<double> C_canonical;
+  // clang-format off
+  C_canonical << 1 / 60.0,  1 / 120.0, 1 / 120.0,
+                 1 / 120.0, 1 / 60.0,  1 / 120.0,
+                 1 / 120.0, 1 / 120.0, 1 / 60.0;
+  // clang-format on
+
+  // We'll accumulate volume, center of mass, and inertia. The quantities
+  // we accumulate will be off by a factor of six to reduce operations.
+  double vol_times_six = 0.0;
+  Vector3d accum_com = Vector3d::Zero();
+  Matrix3<double> C = Matrix3<double>::Zero();
+  // The *transpose* of the affine transformation that takes us from the
+  // canonical co-variance matrix to the matrix for the particular tet.
+  Matrix3<double> A_T = Matrix3<double>::Zero();
+  for (const auto& tri : mesh.triangles()) {
+    const Vector3d& p = mesh.vertex(tri.vertex(0));
+    const Vector3d& q = mesh.vertex(tri.vertex(1));
+    const Vector3d& r = mesh.vertex(tri.vertex(2));
+    double tet_vol_times_six = p.cross(q).dot(r);
+    A_T.row(0) = p;
+    A_T.row(1) = q;
+    A_T.row(2) = r;
+    // We're computing C += det(A)⋅ACAᵀ. Fortunately, det(A) is equal to 6V.
+    C += A_T.transpose() * C_canonical * A_T * tet_vol_times_six;
+    vol_times_six += tet_vol_times_six;
+    accum_com += (p + q + r) * tet_vol_times_six;
+  }
+
+  const double volume = vol_times_six / 6.0;
+  const double mass = density * volume;
+  const Vector3d p_GoGcm = accum_com / (vol_times_six * 4);
+  // We can compute I = C.trace * 1₃ - C. Two key points:
+  //  1. We don't want I, we want G, the unit inertia. Our computation of C is
+  //     *mass* weighted with an implicit assumption of unit density. So, to
+  //     make it a *unit* inertia, we must divide by mass = ρV = 1 * V = V.
+  //  2. G is symmetric, so we'll forego doing the full matrix multiplication
+  //     and go get the six terms we actually care about.
+  C /= volume;
+  const double trace_C = C.trace();
+  const UnitInertia G_GGo_G(trace_C - C(0, 0), trace_C - C(1, 1),
+                            trace_C - C(2, 2), -C(1, 0), -C(2, 0), -C(2, 1));
+  return SpatialInertia<double>{mass, p_GoGcm, G_GGo_G};
+}
+
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/tree/geometry_spatial_inertia.h
+++ b/multibody/tree/geometry_spatial_inertia.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "drake/geometry/proximity/triangle_surface_mesh.h"
+#include "drake/geometry/shape_specification.h"
+#include "drake/multibody/tree/spatial_inertia.h"
+
+namespace drake {
+namespace multibody {
+
+/** Computes the SpatialInertia of a body made up of a homogeneous material
+ (of given `density` in kg/m³) uniformly distributed in the volume of the given
+ `shape`.
+ 
+ The `shape` is defined in its canonical frame S and the body in frame B. The
+ two frames are coincident and aligned (i.e., X_SB = I).
+
+ Most shapes are defined such that their center of mass is coincident with So
+ (and, therefore, Bo). These are the shapes that have symmetry across So along
+ each of the axes Sx, Sy, Sz (e.g., geometry::Box, geometry::Sphere, etc.) For
+ meshes, it depends on how the mesh is defined. For more discussion on the
+ nuances of geometry::Mesh and geometry::Convex calculations
+ @ref CalcSpatialInertia(const geometry::TriangleSurfaceMesh<double>&,double)
+ "see below".
+
+ Note: Spatial inertia calculations for the geometry::Convex type do not
+ currently require that the underlying mesh actually be convex. Although certain
+ collision calculations involving geometry::Convex may use the mesh's convex
+ hull, this function uses the *actual* mesh.
+
+ @retval M_BBo_B The spatial inertia of the hypothetical body implied by the
+                 given `shape`.
+ @throws std::exception if `shape` is an instance of geometry::HalfSpace or
+                        geometry::MeshcatCone.
+ @pydrake_mkdoc_identifier{shape} */
+SpatialInertia<double> CalcSpatialInertia(const geometry::Shape& shape,
+                                          double density);
+
+/** Computes the SpatialInertia of a body made up of a homogeneous material
+ (of given `density` in kg/m³) uniformly distributed in the volume of the given
+ `mesh`.
+ 
+ The `mesh` is defined in its canonical frame M and the body in frame B. The two
+ frames are coincident and aligned (i.e., X_MB = I).
+
+ For the resultant spatial inertia to be meaningful, the `mesh` must satisfy
+ certain requirements:
+
+   - The mesh must *fully* enclose a volume (no cracks, no open manifolds,
+     etc.)
+   - All triangles must be "wound" such that their normals point outward
+     (according to the right-hand rule based on vertex winding).
+
+ If these requirements are not met, a value *will* be returned, but its value
+ is meaningless.
+ @pydrake_mkdoc_identifier{mesh} */
+SpatialInertia<double> CalcSpatialInertia(
+    const geometry::TriangleSurfaceMesh<double>& mesh, double density = 1.0);
+
+// TODO(SeanCurtis-TRI): Add CalcSpatialinertia(VolumeMesh).
+
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -279,8 +279,8 @@ class RotationalInertia {
   /// is symmetric and includes both lower and upper parts of the matrix.
   Matrix3<T> CopyToFullMatrix3() const { return get_symmetric_matrix_view(); }
 
-  /// Compares `this` rotational inertia to `other` rotional inertia within the
-  /// specified `precision` (which is a dimensionless number specifying
+  /// Compares `this` rotational inertia to `other` rotational inertia within
+  /// the specified `precision` (which is a dimensionless number specifying
   /// the relative precision to which the comparison is performed).
   /// Denoting `I_maxA` as the largest element value that can appear in a valid
   /// `this` rotational inertia (independent of the expressed-in frame E) and

--- a/multibody/tree/test/geometry_spatial_inertia_test.cc
+++ b/multibody/tree/test/geometry_spatial_inertia_test.cc
@@ -1,0 +1,269 @@
+#include "drake/multibody/tree/geometry_spatial_inertia.h"
+
+#include <algorithm>
+#include <limits>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/proximity/make_box_mesh.h"
+#include "drake/geometry/proximity/triangle_surface_mesh.h"
+#include "drake/geometry/shape_specification.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/rotation_matrix.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+using Eigen::AngleAxisd;
+using Eigen::Vector3d;
+using math::RigidTransformd;
+using math::RotationMatrixd;
+
+// Arbitrary, non-unit density.
+constexpr double kDensity = 1.5;
+constexpr double kTol = std::numeric_limits<double>::epsilon();
+
+// Asserts that the given spatial inertia is equivalent to the given mass
+// properties.
+::testing::AssertionResult SpatialInertiasEqual(
+    const SpatialInertia<double>& dut, const double mass,
+    const Vector3d& p_SScm, const UnitInertia<double>& G_SScm_S,
+    double tolerance = 0.0) {
+  if (std::abs(mass - dut.get_mass()) > tolerance) {
+    return ::testing::AssertionFailure()
+           << "Expected equal masses\n"
+           << "  expected:   " << mass << "\n"
+           << "  tested:     " << dut.get_mass() << "\n"
+           << "  difference: " << std::abs(mass - dut.get_mass()) << "\n"
+           << "  is greater than tolerance: " << tolerance << "\n";
+  }
+  ::testing::AssertionResult result =
+      CompareMatrices(dut.get_com(), p_SScm, tolerance);
+  if (!result) return result;
+  if (!dut.get_unit_inertia().IsNearlyEqualTo(G_SScm_S, tolerance)) {
+    return ::testing::AssertionFailure()
+           << "Expected equal unit inertias\n"
+           << "  expected\n"
+           << G_SScm_S << "\n"
+           << "  tested\n"
+           << dut.get_unit_inertia() << "\n"
+           << "  with tolerance: " << tolerance << "\n"
+           << "(with mass: " << dut.get_mass() << "\n"
+           << " and com: " << dut.get_com().transpose() << "\n";
+  }
+  return ::testing::AssertionSuccess();
+}
+
+// Note: These tests mostly rely on UnitInertia::SolidFoo() methods to validate.
+// The *implementations* use the same logic. So, these tests would seem to be
+// a tautology. This is intentional. The goal is that the unit inertia generated
+// via this API should provide *exactly* the same value as passing through the
+// UnitInertia APIs. This supports that goal as a regression test.
+
+GTEST_TEST(GeometrySpatialInertaTest, Box) {
+  const double Lx = 1;
+  const double Ly = 2;
+  const double Lz = 3;
+  const double volume = 6;  // Lx * Ly * Lz
+  const Vector3d p_SScm = Vector3d::Zero();
+  const auto G_SScm_S = UnitInertia<double>::SolidBox(Lx, Ly, Lz);
+
+  const geometry::Box box(Lx, Ly, Lz);
+  EXPECT_TRUE(SpatialInertiasEqual(CalcSpatialInertia(box, kDensity),
+                                   volume * kDensity, p_SScm, G_SScm_S, kTol));
+}
+
+GTEST_TEST(GeometrySpatialInertaTest, Capsule) {
+  const double r = 1.5;
+  const double L = 2;
+  const double volume = 28.274333882308138;  // πr²L + 4/3πr³
+  const Vector3d p_SScm = Vector3d::Zero();
+  const auto G_SScm_S = UnitInertia<double>::SolidCapsule(r, L);
+
+  const geometry::Capsule capsule(r, L);
+  EXPECT_TRUE(SpatialInertiasEqual(CalcSpatialInertia(capsule, kDensity),
+                                   volume * kDensity, p_SScm, G_SScm_S, kTol));
+}
+
+// Note: Convex can be found below in the MeshTypes test.
+
+GTEST_TEST(GeometrySpatialInertaTest, Cylinder) {
+  const double r = 1.5;
+  const double L = 2;
+  const double volume = 14.137166941154069;  // πr²L
+  const Vector3d p_SScm = Vector3d::Zero();
+  const auto G_SScm_S = UnitInertia<double>::SolidCylinder(r, L);
+
+  const geometry::Cylinder cylinder(r, L);
+  EXPECT_TRUE(SpatialInertiasEqual(CalcSpatialInertia(cylinder, kDensity),
+                                   volume * kDensity, p_SScm, G_SScm_S, kTol));
+}
+
+GTEST_TEST(GeometrySpatialInertaTest, Ellipsoid) {
+  const double a = 1.5;
+  const double b = 2.5;
+  const double c = 3.5;
+  const double volume = 54.97787143782138;  // 4/3πabc
+  const Vector3d p_SScm = Vector3d::Zero();
+  const auto G_SScm_S = UnitInertia<double>::SolidEllipsoid(a, b, c);
+
+  const geometry::Ellipsoid ellipsoid(a, b, c);
+  EXPECT_TRUE(SpatialInertiasEqual(CalcSpatialInertia(ellipsoid, kDensity),
+                                   volume * kDensity, p_SScm, G_SScm_S, kTol));
+}
+
+GTEST_TEST(GeometrySpatialInertaTest, HalfSpace) {
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      CalcSpatialInertia(geometry::HalfSpace(), kDensity), ".*HalfSpace.*");
+}
+
+// Note: Mesh can be found below in the MeshTypes test.
+
+GTEST_TEST(GeometrySpatialInertaTest, MeshcatCone) {
+  const geometry::MeshcatCone cone(1, 2, 3);
+  DRAKE_EXPECT_THROWS_MESSAGE(CalcSpatialInertia(cone, kDensity),
+                              ".*MeshcatCone.*");
+}
+
+GTEST_TEST(GeometrySpatialInertaTest, Sphere) {
+  const double r = 1.5;
+  const double volume = 14.137166941154067;  // 4/3πr³
+  const Vector3d p_SScm = Vector3d::Zero();
+  const auto G_SScm_S = UnitInertia<double>::SolidSphere(r);
+
+  const geometry::Sphere sphere(r);
+  EXPECT_TRUE(SpatialInertiasEqual(CalcSpatialInertia(sphere, kDensity),
+                                   volume * kDensity, p_SScm, G_SScm_S, kTol));
+}
+
+// Exercises the common code paths for Mesh and Convex (i.e., "MeshTypes").
+template <typename MeshType>
+class MeshTypeSpatialInertaTest : public testing::Test {};
+
+TYPED_TEST_SUITE_P(MeshTypeSpatialInertaTest);
+
+/* Calling CalcSpatialInertia(Shape) on a MeshType delegates the math to
+ CalcSpatialInertia(TriangleSurfaceMesh). However, this function *does* have the
+ following administrative responsibilities:
+
+   1. Vet the extension and throw for non-obj files.
+   2. Make sure the mesh type's `scale` property is used.
+   3. Make sure the given density value is used.
+
+ Those responsibilities are tested here. The math is tested below. */
+TYPED_TEST_P(MeshTypeSpatialInertaTest, Administrivia) {
+  using MeshType = TypeParam;
+
+  const std::string valid_path = FindResourceOrThrow(
+      "drake/multibody/parsing/test/box_package/meshes/box.obj");
+  const MeshType unit_scale(valid_path, 1.0);
+  const MeshType double_scale(valid_path, 2.0);
+  const MeshType nonexistant("nonexistant.stl", 1.0);
+
+  {
+    // Extension test; .obj doesn't throw, everything else does.
+    // Note: this should be case-insensitve; .OBJ should also work. However,
+    // we need *another* valid OBJ with the different capitalization of the
+    // extension to test this. Rather than creating/copying such a file, we're
+    // foregoing the test. The case insensitivity is *not* documented.
+
+    EXPECT_NO_THROW(CalcSpatialInertia(unit_scale, kDensity));
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        CalcSpatialInertia(nonexistant, kDensity),
+        ".*only supports .obj .* given 'nonexistant.stl'.*");
+  }
+
+  {
+    // Confirm that the scale is used.
+    const SpatialInertia<double> M_SScm_S_small =
+        CalcSpatialInertia(unit_scale, kDensity);
+    const SpatialInertia<double> M_SScm_S_large =
+        CalcSpatialInertia(double_scale, kDensity);
+    EXPECT_DOUBLE_EQ(M_SScm_S_large.get_mass(), M_SScm_S_small.get_mass() * 8);
+  }
+
+  {
+    // Confirm that the density is used.
+    const SpatialInertia<double> M_SScm_S_small =
+        CalcSpatialInertia(unit_scale, kDensity);
+    const SpatialInertia<double> M_SScm_S_large =
+        CalcSpatialInertia(unit_scale, kDensity * 2);
+    EXPECT_DOUBLE_EQ(M_SScm_S_large.get_mass(), M_SScm_S_small.get_mass() * 2);
+  }
+}
+
+REGISTER_TYPED_TEST_SUITE_P(MeshTypeSpatialInertaTest, Administrivia);
+using MeshTypes = ::testing::Types<geometry::Convex, geometry::Mesh>;
+INSTANTIATE_TYPED_TEST_SUITE_P(All, MeshTypeSpatialInertaTest, MeshTypes);
+
+/* Tests the math for a triangle surface mesh by using a mesh that perfectly
+ reproduces a primitive: a Box.
+
+   - When the mesh is posed in its frame like the corresponding primitive is,
+     we should get identical SpatialInertia values.
+   - We can transform the mesh and observe predictable changes to the
+     resulting spatial inertia.  */
+GTEST_TEST(TriangleSurfaceMassPropertiesTest, ExactPolyhedron) {
+  // Note: this is the same box B used in the Box test above.
+  const double Lx = 2;
+  const double Ly = 1;
+  const double Lz = 3;
+  const double volume = 6;  // Lx * Ly * Lz
+  // Note: p_BoBcm = [0, 0, 0]. The box is defined such that its center of mass
+  // is coincident with the box frame's origin.
+  const Vector3d p_BBcm = Vector3d::Zero();
+  const auto G_BBo_B = UnitInertia<double>::SolidBox(Lx, Ly, Lz);
+  const geometry::Box box(Lx, Ly, Lz);
+
+  {
+    // Mesh posed in its frame the same as the solid box is in its own frame.
+    // We use a coarse resolution hint simply to reduce the cost of the test.
+    const double resolution_hint = std::max({Lx, Ly, Lz});
+    const geometry::TriangleSurfaceMesh<double> mesh =
+        geometry::internal::MakeBoxSurfaceMesh<double>(box, resolution_hint);
+
+    EXPECT_TRUE(SpatialInertiasEqual(CalcSpatialInertia(mesh, kDensity),
+                                     volume * kDensity, p_BBcm, G_BBo_B, kTol));
+  }
+
+  {
+    // We'll reposition the mesh's vertices so that the "bulk" of the geometry
+    // is posed differently from the solid box (in each geometry's frame). By
+    // transforming the set of vertices rigidly, we preserve the total volume
+    // (and, therefore, mass) but its center of mass and unit inertia, in its
+    // frame M, will be different from the box's in its own frame B. With
+    // X_BM = I, the two bodies' quantities are related as follows:
+    //
+    //     p_MMcm = p_BBo + p_BcmMcm  // R_BM = I and Bo = Bcm.
+    //            = p_BcmMcm          // Bo = Bcm --> p_BBo = [0, 0, 0].
+    //     G_MMo_M = G_BBo_B re-expressed in M and then shifted to Mcm.
+
+    const Vector3d p_BcmMcm(0.25, 2.3, -5.4);
+    const RotationMatrixd R_MB(
+        AngleAxisd(M_PI / 3, Vector3d(1, 2, 3).normalized()));
+    const RigidTransformd X_MB(R_MB, p_BcmMcm);
+
+    geometry::TriangleSurfaceMesh<double> mesh =
+        geometry::internal::MakeBoxSurfaceMesh<double>(box, 5);
+    mesh.TransformVertices(X_MB);
+
+    const UnitInertia<double> G_BBo_M = G_BBo_B.ReExpress(R_MB);
+    const UnitInertia<double> G_MMo_M =
+        G_BBo_M.ShiftFromCenterOfMass(p_BcmMcm);
+
+    // The vertex transformation introduces precision loss, requiring a larger
+    // tolerance.
+    EXPECT_TRUE(SpatialInertiasEqual(CalcSpatialInertia(mesh, kDensity),
+                                     volume * kDensity, p_BcmMcm, G_MMo_M,
+                                     2 * kTol));
+  }
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Provides a utility in `drake::multibody` to compute `SpatialInertia` from `geometry::Shape` and `geometry::TriangleSurfaceMesh`.

Incidental opportunistic clean up of typos encountered along the way.

Relates #18314.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18345)
<!-- Reviewable:end -->
