### PR TITLE
[meshcat] Fix Meshcat::StaticHtml()

### DIFF
--- a/geometry/meshcat.html
+++ b/geometry/meshcat.html
@@ -62,7 +62,7 @@
         };
         break;  // Just take the first connected gamepad.
       }
-      if (this.connection.readyState == WebSocket.OPEN && 
+      if (this.connection && this.connection.readyState == WebSocket.OPEN && 
         JSON.stringify(gamepad) !== JSON.stringify(last_gamepad)) {
         this.connection.send(MeshCat.msgpack.encode(
           { 'type': 'gamepad', 'name': '', 'gamepad': gamepad }));

--- a/tools/workspace/meshcat/repository.bzl
+++ b/tools/workspace/meshcat/repository.bzl
@@ -11,8 +11,8 @@ def meshcat_repository(
         repository = "rdeits/meshcat",
         # Updating this commit requires local testing; see
         # drake/tools/workspace/meshcat/README.md for details.
-        commit = "946026bf4b146a3448d976ee855ec5c5fd8f7e9b",
-        sha256 = "69b6ac6d3de27cf3ba1f52dd717a7171374a4b3d5b27a4d3816c7b4dc7af45dc",  # noqa
+        commit = "ea474eb1e7b595b45145c8104fc9684d49f15231",
+        sha256 = "609988dcb6ca3090121ae0b0a149e0c1fab9656a8f2e867786e666264a1d42ca",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
My recent meshcat changes broke the StaticHtml()
method. meshcat_manual_test revealed the problem but I failed to notice during my offending PR! I've fixed it upstream and this PR updates the meshcat SHA.

Also updates the gamepad logic to not throw an error due to not having a connection.

Resolves #18342.

+@mpetersen94 for feature review, please.