### PR TITLE
[parsing] Initial collision filter support in mujoco parser

### DIFF
--- a/multibody/parsing/detail_tinyxml.cc
+++ b/multibody/parsing/detail_tinyxml.cc
@@ -12,7 +12,8 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-std::vector<double> ConvertToDoubles(const std::string& str) {
+template <typename T>
+std::vector<T> ConvertToVector(const std::string& str) {
   std::istringstream ss(str);
   // Every real number in a URDF file needs to be parsed assuming that the
   // decimal point separator is the period, as specified in XML Schema
@@ -21,8 +22,8 @@ std::vector<double> ConvertToDoubles(const std::string& str) {
   // Related PR: https://github.com/ros/urdfdom_headers/pull/42 .
   ss.imbue(std::locale::classic());
 
-  double val{};
-  std::vector<double> out;
+  T val{};
+  std::vector<T> out;
   while (ss >> val) {
     out.push_back(val);
   }
@@ -40,16 +41,16 @@ bool ParseStringAttribute(const tinyxml2::XMLElement* node,
   return false;
 }
 
+template <typename T>
 bool ParseScalarAttribute(
-    const tinyxml2::XMLElement* node,
-    const char* attribute_name, double* val,
+    const tinyxml2::XMLElement* node, const char* attribute_name, T* val,
     std::optional<const drake::internal::DiagnosticPolicy> policy) {
   if (!policy.has_value()) {
     policy.emplace();
   }
   const char* attr = node->Attribute(attribute_name);
   if (attr) {
-    std::vector<double> vals = ConvertToDoubles(attr);
+    std::vector<T> vals = ConvertToVector<T>(attr);
     if (vals.size() != 1) {
       policy->Error(
           fmt::format("Expected single value for attribute '{}' got '{}'",
@@ -99,6 +100,16 @@ bool ParseThreeVectorAttribute(const tinyxml2::XMLElement* node,
   }
   return true;
 }
+
+// Explicit instantiation
+template std::vector<double> ConvertToVector(const std::string& str);
+template std::vector<int> ConvertToVector(const std::string& str);
+template bool ParseScalarAttribute(
+    const tinyxml2::XMLElement* node, const char* attribute_name, double* val,
+    std::optional<const drake::internal::DiagnosticPolicy> policy);
+template bool ParseScalarAttribute(
+    const tinyxml2::XMLElement* node, const char* attribute_name, int* val,
+    std::optional<const drake::internal::DiagnosticPolicy> policy);
 
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/parsing/detail_tinyxml.h
+++ b/multibody/parsing/detail_tinyxml.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <optional>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -14,9 +15,10 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-// Parses a string containing double values in the XML attribute format into a
-// vector of doubles.
-std::vector<double> ConvertToDoubles(const std::string& str);
+// Parses a string containing values of type T in the XML attribute format into
+// a vector of T.  T must be double or int.
+template <typename T>
+std::vector<T> ConvertToVector(const std::string& str);
 
 // Parses a string attribute of @p node named @p attribute_name into @p val.
 // If the attribute is not present, @p val will be cleared.
@@ -35,11 +37,13 @@ bool ParseStringAttribute(const tinyxml2::XMLElement* node,
 //
 // If @p policy is empty, then the default policy will be used, which results
 // in a `throw` on error.
-bool ParseScalarAttribute(
-    const tinyxml2::XMLElement* node,
-    const char* attribute_name, double* val,
-    std::optional<const drake::internal::DiagnosticPolicy> policy =
-    std::nullopt);
+//
+// The template parameter T must be double or int.
+template <typename T>
+bool ParseScalarAttribute(const tinyxml2::XMLElement* node,
+                          const char* attribute_name, T* val,
+                          std::optional<const drake::internal::DiagnosticPolicy>
+                              policy = std::nullopt);
 
 // Parses an attribute of @p node named @p attribute_name consisting of scalar
 // values into @p val.
@@ -56,7 +60,7 @@ bool ParseVectorAttribute(const tinyxml2::XMLElement* node,
                           Eigen::Matrix<double, rows, 1>* val) {
   const char* attr = node->Attribute(attribute_name);
   if (attr) {
-    std::vector<double> vals = ConvertToDoubles(attr);
+    std::vector<double> vals = ConvertToVector<double>(attr);
     if (vals.size() != rows) {
       throw std::invalid_argument(
           fmt::format("Expected {} values for attribute {} got {}", rows,

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -679,7 +679,7 @@ void UrdfParser::ParseMechanicalReduction(const XMLElement& node) {
   if (!child) { return; }
   const char* text = child->GetText();
   if (!text) { return; }
-  std::vector<double> values = ConvertToDoubles(text);
+  std::vector<double> values = ConvertToVector<double>(text);
   if (values.size() == 1 && values[0] == 1) { return; }
   Warning(*child, fmt::format(
               "A '{}' element contains a mechanicalReduction element with a"

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -912,6 +912,83 @@ GTEST_TEST(MujocoParser, Motor) {
   EXPECT_EQ(motor3.effort_limit(), std::numeric_limits<double>::infinity());
 }
 
+GTEST_TEST(MujocoParser, Contact) {
+  // Run through once without the contact elements, then again with the contact
+  // elements.
+  for (bool include_contact : {false, true}) {
+    for (bool adjacent_bodies_collision_filters : {false, true}) {
+      MultibodyPlant<double> plant(0.0);
+      SceneGraph<double> scene_graph;
+      plant.RegisterAsSourceForSceneGraph(&scene_graph);
+
+      std::string xml = fmt::format(R"""(
+  <mujoco model="test">
+    <default>
+      <geom type="sphere" size="1"/>
+    </default>
+    <worldbody>
+      <body name="base">
+        <geom name="base_geom"/>
+        <body name="body1">
+          <geom name="body1_geom"/>
+          <joint type="hinge"/>
+        </body>
+        <body name="body2">
+          <geom name="body2_geom"/>
+          <joint type="hinge"/>
+        </body>
+      </body>
+    </worldbody>
+    {}
+  </mujoco>
+  )""",
+                                    include_contact ? R"""(
+    <contact>
+      <pair name="pair1" geom1="base_geom" geom2="body1_geom"/>
+      <exclude name="exclude1" body1="body1" body2="body2" />
+    </contact>
+  )"""
+                                                    : "");
+
+      plant.set_adjacent_bodies_collision_filters(
+          adjacent_bodies_collision_filters);
+      AddModelFromMujocoXml({DataSource::kContents, &xml}, "test", {}, &plant);
+      plant.Finalize();
+
+      const SceneGraphInspector<double>& inspector =
+          scene_graph.model_inspector();
+      GeometryId base_geom = inspector.GetGeometries(
+          plant.GetBodyFrameIdOrThrow(plant.GetBodyByName("base").index()),
+          geometry::Role::kProximity)[0];
+      GeometryId body1_geom = inspector.GetGeometries(
+          plant.GetBodyFrameIdOrThrow(plant.GetBodyByName("body1").index()),
+          geometry::Role::kProximity)[0];
+      GeometryId body2_geom = inspector.GetGeometries(
+          plant.GetBodyFrameIdOrThrow(plant.GetBodyByName("body2").index()),
+          geometry::Role::kProximity)[0];
+      if (include_contact) {
+        if (adjacent_bodies_collision_filters) {
+          // In this case, the parser will have emitted a warning, and the
+          // collision filter gets overwritten during Finalize().
+          EXPECT_TRUE(inspector.CollisionFiltered(base_geom, body1_geom));
+        } else {
+          // No warning is emitted; the parsed filter is consistent with the
+          // defaults.
+          EXPECT_FALSE(inspector.CollisionFiltered(base_geom, body1_geom));
+        }
+        EXPECT_TRUE(inspector.CollisionFiltered(body1_geom, body2_geom));
+      } else {
+        if (adjacent_bodies_collision_filters) {
+          EXPECT_TRUE(inspector.CollisionFiltered(base_geom, body1_geom));
+        } else {
+          EXPECT_FALSE(inspector.CollisionFiltered(base_geom, body1_geom));
+        }
+        EXPECT_FALSE(inspector.CollisionFiltered(body1_geom, body2_geom));
+      }
+    }
+  }
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -4445,6 +4445,21 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       return false;
     }
   }
+
+  // Note: As discussed in #18351, we've used CamelCase here in case we need to
+  // change its implementation down the road to a more expensive lookup.
+  /// (Internal use only) Returns a mutable pointer to the SceneGraph that this
+  /// plant is registered as a source for. This method can only be used
+  /// pre-Finalize.
+  ///
+  /// @throws std::exception if is_finalized() == true ||
+  ///           geometry_source_is_registered() == false
+  geometry::SceneGraph<T>* GetMutableSceneGraphPreFinalize() {
+    DRAKE_THROW_UNLESS(!is_finalized());
+    DRAKE_THROW_UNLESS(geometry_source_is_registered());
+    return scene_graph_;
+  }
+
   /// @} <!-- Introspection -->
 
   using internal::MultibodyTreeSystem<T>::is_discrete;

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -4086,6 +4086,20 @@ GTEST_TEST(MultibodyPlantTest, SetDefaultPositions) {
                               q.tail<14>(), kTol));
 }
 
+GTEST_TEST(MultibodyPlantTest, GetMutableSceneGraphPreFinalize) {
+  MultibodyPlant<double> plant(0.0);
+  DRAKE_EXPECT_THROWS_MESSAGE(plant.GetMutableSceneGraphPreFinalize(),
+                              ".*geometry_source_is_registered.*");
+
+  SceneGraph<double> scene_graph;
+  plant.RegisterAsSourceForSceneGraph(&scene_graph);
+  EXPECT_EQ(plant.GetMutableSceneGraphPreFinalize(), &scene_graph);
+
+  plant.Finalize();
+  DRAKE_EXPECT_THROWS_MESSAGE(plant.GetMutableSceneGraphPreFinalize(),
+                              ".*!is_finalized.*");
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake


### PR DESCRIPTION
Adds support for parsing the `<contact>` elements.

Adds an accessor method to MultibodyPlant to get the registered SceneGraph.  I don't know why we've never offered it before; I don't see a problem with it.  And I can't get access to the collision filter logic directly without it.  The CollisionFilterResolver hoopla from the other parsers isn't immediately suited to this MuJoCo case.

+@rpoyner-tri for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18351)
<!-- Reviewable:end -->
