### PR TITLE
[py framework] Bind CacheEntry.Eval for better workflow

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -220,6 +220,14 @@ void DoScalarIndependentDefinitions(py::module m) {
     constexpr auto& cls_doc = doc.CacheEntryValue;
     py::class_<Class>(m, "CacheEntryValue", cls_doc.doc)
         .def(
+            "GetValueOrThrow",
+            [](const Class& self) {
+              py::object value = py::cast<const AbstractValue*>(
+                  &self.GetAbstractValueOrThrow());
+              return value.attr("get_value")();
+            },
+            py_rvp::reference_internal, cls_doc.GetValueOrThrow.doc)
+        .def(
             "GetMutableValueOrThrow",
             [](Class* self) {
               py::object value = py::cast<AbstractValue*>(
@@ -234,6 +242,24 @@ void DoScalarIndependentDefinitions(py::module m) {
     constexpr auto& cls_doc = doc.CacheEntry;
     py::class_<Class>(m, "CacheEntry", cls_doc.doc)
         .def("prerequisites", &Class::prerequisites, cls_doc.prerequisites.doc)
+        .def("EvalAbstract", &Class::EvalAbstract, py::arg("context"),
+            py_rvp::reference_internal, cls_doc.EvalAbstract.doc)
+        .def(
+            "Eval",
+            [](const Class& self, const ContextBase& context) {
+              const auto& abstract = self.EvalAbstract(context);
+              // See above comments in `DoEval`.
+              py::object context_ref = py::cast(&context);
+              py::object abstract_value_ref =
+                  py::cast(&abstract, py_rvp::reference_internal, context_ref);
+              return abstract_value_ref.attr("get_value")();
+            },
+            py::arg("context"), cls_doc.Eval.doc)
+        .def("get_cache_entry_value", &Class::get_cache_entry_value,
+            py::arg("context"),
+            // Keep alive, ownership: `return` keeps `context` alive.
+            py::keep_alive<0, 2>(), py_rvp::reference,
+            cls_doc.get_cache_entry_value.doc)
         .def("get_mutable_cache_entry_value",
             &Class::get_mutable_cache_entry_value, py::arg("context"),
             // Keep alive, ownership: `return` keeps `context` alive.


### PR DESCRIPTION
Using proper workflow allows users to avoid spurious cache invalidation by exposing the proper way to get immutable access with proper updates

- Switch test to use `SimpleNamespace` to make it easier to check aliasing and mutation (int is an immutable type)
- Change style to use `allocate=model_value.Clone`
- Add test for const access. Not the best workflow, but establishes symmetry

Follow-up expanding on #15983

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18354)
<!-- Reviewable:end -->
