### PR TITLE
Change the returned dual solution for rotated Lorentz cone constraint in MosekSolver

### DIFF
--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -531,7 +531,7 @@ GTEST_TEST(MosekSolver, SocpDualSolution2) {
   MosekSolver solver;
   if (solver.available()) {
     SolverOptions solver_options{};
-    TestSocpDualSolution2(solver, solver_options, 1E-6, true);
+    TestSocpDualSolution2(solver, solver_options, 1E-6);
   }
 }
 

--- a/solvers/test/second_order_cone_program_examples.cc
+++ b/solvers/test/second_order_cone_program_examples.cc
@@ -572,8 +572,7 @@ void TestSocpDualSolution1(const SolverInterface& solver,
 }
 
 void TestSocpDualSolution2(const SolverInterface& solver,
-                           const SolverOptions& solver_options, double tol,
-                           bool rotated_lorentz_cone_with_coefficient_two) {
+                           const SolverOptions& solver_options, double tol) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<1>()(0);
   auto constraint1 = prog.AddRotatedLorentzConeConstraint(
@@ -585,10 +584,7 @@ void TestSocpDualSolution2(const SolverInterface& solver,
     MathematicalProgramResult result;
     solver.Solve(prog, {}, solver_options, &result);
     ASSERT_TRUE(result.is_success());
-    const Eigen::Vector3d constraint1_dual =
-        rotated_lorentz_cone_with_coefficient_two
-            ? Eigen::Vector3d(0.25, 0.5, 0.5)
-            : Eigen::Vector3d(0.5, 0.5, 0.5);
+    const Eigen::Vector3d constraint1_dual = Eigen::Vector3d(0.125, 0.5, 0.5);
     EXPECT_TRUE(CompareMatrices(result.GetDualSolution(constraint1),
                                 constraint1_dual, tol));
     // This Lorentz cone is not activated, hence its dual should be zero.

--- a/solvers/test/second_order_cone_program_examples.h
+++ b/solvers/test/second_order_cone_program_examples.h
@@ -338,14 +338,8 @@ class MinimalDistanceFromSphereProblem {
 void TestSocpDualSolution1(const SolverInterface& solver,
                            const SolverOptions& solver_options, double tol);
 
-// @param rotated_lorentz_cone_with_coefficient_two. Set this to true if this
-// solver has a coefficient 2 on the rotated Lorentz cone constraint as 2*x₁x₂
-// >= x₃² + ... + xₙ² (like in Mosek). Set this to false if this solver doesn't
-// have a coefficient 2 on the rotated Lorentz cone constraint, as x₁x₂
-// >= x₃² + ... + xₙ²
 void TestSocpDualSolution2(const SolverInterface& solver,
-                           const SolverOptions& solver_options, double tol,
-                           bool rotated_lorentz_cone_with_coefficient_two);
+                           const SolverOptions& solver_options, double tol);
 
 // We intentionally use duplicated variables in the second order cone constraint
 // to test if Drake's solver wrappers can handle duplicated variables.


### PR DESCRIPTION
The Mosek definition of rotated Lorentz cone is different from Drake's definition by a factor of two. Hence we also need to scale the first entry of the dual solution by a factor of 1/2.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18361)
<!-- Reviewable:end -->
