### PR TITLE
[render_gltf] Compare glTF dictionaries directly

### DIFF
--- a/geometry/render_gltf_client/test/integration_test.py
+++ b/geometry/render_gltf_client/test/integration_test.py
@@ -218,7 +218,6 @@ class TestIntegration(unittest.TestCase):
             # handled above, anything hitting this should be exactly equal.
             self.assertEqual(expected, actual)
 
-    @unittest.skipIf("darwin" in sys.platform, "Broken on macOS")
     def test_integration(self):
         """Quantitatively compares the images rendered by RenderEngineVtk and
         RenderEngineGltfClient via a fully exercised RPC pipeline.


### PR DESCRIPTION
Perform nested dictionary comparisons with floating point tolerances rather than `self.assertDictEqual`.

The current tests do not survive the VTK upgrade taking place in #17962.  Upon inspection it appeared that `self.assertDictEqual` is sensitive to dictionary key ordering (which this test should not be), after fixing that the numerical tolerance comparisons became an issue.

The first and second commit here could be enough since the tests are already getting skipped on mac.  However, see the third commit, I'm not sure exactly what these tests are trying to achieve so passing off to @zachfang CC @jwnimmer-tri.

NOTE: there is still quite a bit of work for me to do on my end with VTK upgrade so currently this is "non-blocking" in the sense that I've fixed linux, and have some brief headwork on macOS for people here if they are interested.  But eventually these tests need to get fixed before the VTK upgrade can land (ETA January is the plan).