### PR TITLE
[doc] Fix missing date substitution for release v1.10.0

### DIFF
--- a/doc/_release-notes/v1.10.0.md
+++ b/doc/_release-notes/v1.10.0.md
@@ -282,7 +282,7 @@ Fixes
 # Notes
 
 This release provides [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v1.10.0) named
-``drake-YYYYMMDD-{focal|jammy|mac|mac-arm64}.tar.gz``. See [Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
+``drake-20221116-{focal|jammy|mac|mac-arm64}.tar.gz``. See [Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the
 [Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html). Thanks to


### PR DESCRIPTION
Per https://github.com/RobotLocomotion/drake/pull/18263#issuecomment-1329143513

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18369)
<!-- Reviewable:end -->
