### PR TITLE
[geometry/optimization] Add Iris support for Convex mesh geometries

### DIFF
--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -178,6 +178,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "iris_in_configuration_space_test",
     timeout = "moderate",
+    data = ["//multibody/parsing:test_models"],
     shard_count = 8,
     # Most of these tests take an exceptionally long time under
     # instrumentation, resulting in timeouts, and so are excluded.

--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -13,6 +13,7 @@
 #include "drake/geometry/optimization/cartesian_product.h"
 #include "drake/geometry/optimization/convex_set.h"
 #include "drake/geometry/optimization/minkowski_sum.h"
+#include "drake/geometry/optimization/vpolytope.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/solvers/choose_best_solver.h"
@@ -180,6 +181,12 @@ class IrisConvexSetMaker final : public ShapeReifier {
     DRAKE_DEMAND(geom_id_.is_valid());
     auto& set = *static_cast<copyable_unique_ptr<ConvexSet>*>(data);
     set = std::make_unique<Hyperellipsoid>(query_, geom_id_, reference_frame_);
+  }
+
+  void ImplementGeometry(const Convex&, void* data) {
+    DRAKE_DEMAND(geom_id_.is_valid());
+    auto& set = *static_cast<copyable_unique_ptr<ConvexSet>*>(data);
+    set = std::make_unique<VPolytope>(query_, geom_id_, reference_frame_);
   }
 
  private:


### PR DESCRIPTION
IrisInConfigurationSpace now supports convex meshes via VPolytope.

+@mpetersen94 for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18376)
<!-- Reviewable:end -->
