### PR TITLE
[wheel] Use the correct python version in macOS wheel build

### DIFF
--- a/tools/wheel/macos/build-wheel.sh
+++ b/tools/wheel/macos/build-wheel.sh
@@ -110,7 +110,9 @@ bazel run "${bazel_args[@]}" //:install -- /opt/drake
 
 rm -rf  "/opt/drake-wheel-build/python"
 
-python3 -m venv "/opt/drake-wheel-build/python"
+# NOTE: Xcode ships python3, make sure to use the one from brew.
+$(brew --prefix python@3.10)/bin/python3.10 \
+    -m venv "/opt/drake-wheel-build/python"
 
 . "/opt/drake-wheel-build/python/bin/activate"
 

--- a/tools/wheel/macos/provision-test-python.sh
+++ b/tools/wheel/macos/provision-test-python.sh
@@ -10,4 +10,6 @@ set -eu -o pipefail
 rm -rf /opt/drake-wheel-test
 
 # Prepare test environment.
-python3 -m venv /opt/drake-wheel-test/python
+# NOTE: Xcode ships python3, make sure to use the one from brew.
+$(brew --prefix python@3.10)/bin/python3.10 \
+    -m venv /opt/drake-wheel-test/python


### PR DESCRIPTION
The `python3` executable may come from a different `brew` python or from Xcode, make sure to use the drake-supported python version by hard-coding paths to `brew --prefix python@3.10`.

Extracted from #18262, active image updates on the macOS CI front need this change escalated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18381)
<!-- Reviewable:end -->
