### PR TITLE
[trajectories] BSplineTrajectory::EvalDerivative now clamps time.

### DIFF
--- a/common/trajectories/test/bspline_trajectory_test.cc
+++ b/common/trajectories/test/bspline_trajectory_test.cc
@@ -191,6 +191,16 @@ TYPED_TEST(BsplineTrajectoryTests, EvalDerivativeTest) {
       EXPECT_TRUE(CompareMatrices(derivative, expected_derivative, tolerance));
     }
   }
+
+  // Verify that evaluating outside the time interval gets clamped.
+  for (int o = 0; o < trajectory.basis().order(); ++o) {
+    EXPECT_TRUE(CompareMatrices(
+        trajectory.EvalDerivative(trajectory.start_time() - 1, o),
+        trajectory.EvalDerivative(trajectory.start_time(), o)));
+    EXPECT_TRUE(
+        CompareMatrices(trajectory.EvalDerivative(trajectory.end_time() + 1, o),
+                        trajectory.EvalDerivative(trajectory.end_time(), o)));
+  }
 }
 
 // Verifies that CopyBlock() works as expected.


### PR DESCRIPTION
The BSplineTrajectory::value() method clamps the time to the trajectory time interval, but the EvalDerivative implementation did not. Instead it threw an error.  This PR makes the behavior consistent.

+@mpetersen94 for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18383)
<!-- Reviewable:end -->
