### PR TITLE
Move joint locking parameter to mobilizer

### DIFF
--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -335,11 +335,9 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
     // Joint locking is only supported for discrete mode.
     // TODO(sherm1): extend the design to support continuous-mode systems.
     DRAKE_THROW_UNLESS(this->get_parent_tree().is_state_discrete());
-    context->get_mutable_abstract_parameter(is_locked_parameter_index_)
-        .set_value(true);
-    this->get_parent_tree().GetMutableVelocities(context).segment(
-        this->velocity_start(),
-        this->num_velocities()).setZero();
+    for (internal::Mobilizer<T>* mobilizer : implementation_->mobilizers_) {
+      mobilizer->Lock(context);
+    }
   }
 
   /// Unlock the joint. Unlocking is not yet supported for continuous-mode
@@ -349,14 +347,18 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
     // Joint locking is only supported for discrete mode.
     // TODO(sherm1): extend the design to support continuous-mode systems.
     DRAKE_THROW_UNLESS(this->get_parent_tree().is_state_discrete());
-    context->get_mutable_abstract_parameter(is_locked_parameter_index_)
-        .set_value(false);
+    for (internal::Mobilizer<T>* mobilizer : implementation_->mobilizers_) {
+      mobilizer->Unlock(context);
+    }
   }
 
   /// @return true if the joint is locked, false otherwise.
   bool is_locked(const systems::Context<T>& context) const {
-    return context.get_parameters().template get_abstract_parameter<bool>(
-        is_locked_parameter_index_);
+    bool locked = false;
+    for (internal::Mobilizer<T>* mobilizer : implementation_->mobilizers_) {
+      locked |= mobilizer->is_locked(context);
+    }
+    return locked;
   }
 
   /// @name Methods to get and set the limits of `this` joint. For position
@@ -694,16 +696,6 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
   /// If the MultibodyTree has been finalized, this will return true.
   bool has_implementation() const { return implementation_ != nullptr; }
 
-  // Implementation for MultibodyElement::DoDeclareParameters().
-  void DoDeclareParameters(
-      internal::MultibodyTreeSystem<T>* tree_system) override {
-    // Declare parent class's parameters
-    MultibodyElement<Joint, T, JointIndex>::DoDeclareParameters(tree_system);
-
-    is_locked_parameter_index_ =
-        this->DeclareAbstractParameter(tree_system, Value<bool>(false));
-  }
-
  private:
   // Make all other Joint<U> objects a friend of Joint<T> so they can make
   // Joint<ToScalar>::JointImplementation from CloneToScalar<ToScalar>().
@@ -744,9 +736,6 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
 
   // Joint default position. This vector has zero size for joints with no state.
   VectorX<double> default_positions_;
-
-  // System parameter index for `this` joint's lock state stored in a context.
-  systems::AbstractParameterIndex is_locked_parameter_index_;
 
   // The Joint<T> implementation:
   std::unique_ptr<JointImplementation> implementation_;

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -633,6 +633,38 @@ class Mobilizer : public MultibodyElement<Mobilizer, T, MobilizerIndex> {
       const internal::BodyNode<T>* parent_node,
       const Body<T>* body, const Mobilizer<T>* mobilizer) const = 0;
 
+  /// Lock the mobilizer. Its generalized velocities will be 0 until it is
+  /// unlocked. Locking is not yet supported for continuous-mode systems.
+  /// @throws std::exception if the parent model uses continuous state.
+  void Lock(systems::Context<T>* context) const {
+    // Joint locking is only supported for discrete mode.
+    // TODO(sherm1): extend the design to support continuous-mode systems.
+    DRAKE_THROW_UNLESS(this->get_parent_tree().is_state_discrete());
+    context->get_mutable_abstract_parameter(is_locked_parameter_index_)
+        .set_value(true);
+    this->get_parent_tree()
+        .GetMutableVelocities(context)
+        .segment(this->velocity_start_in_v(), this->num_velocities())
+        .setZero();
+  }
+
+  /// Unlock the mobilizer. Unlocking is not yet supported for continuous-mode
+  /// systems.
+  /// @throws std::exception if the parent model uses continuous state.
+  void Unlock(systems::Context<T>* context) const {
+    // Joint locking is only supported for discrete mode.
+    // TODO(sherm1): extend the design to support continuous-mode systems.
+    DRAKE_THROW_UNLESS(this->get_parent_tree().is_state_discrete());
+    context->get_mutable_abstract_parameter(is_locked_parameter_index_)
+        .set_value(false);
+  }
+
+  /// @return true if the mobilizer is locked, false otherwise.
+  bool is_locked(const systems::Context<T>& context) const {
+    return context.get_parameters().template get_abstract_parameter<bool>(
+        is_locked_parameter_index_);
+  }
+
  protected:
   // NVI to CalcNMatrix(). Implementations can safely assume that N is not the
   // nullptr and that N has the proper size.
@@ -670,6 +702,17 @@ class Mobilizer : public MultibodyElement<Mobilizer, T, MobilizerIndex> {
       const MultibodyTree<symbolic::Expression>& tree_clone) const = 0;
   // @}
 
+  // Implementation for MultibodyElement::DoDeclareParameters().
+  void DoDeclareParameters(
+      internal::MultibodyTreeSystem<T>* tree_system) override {
+    // Declare parent class's parameters
+    MultibodyElement<Mobilizer, T, MobilizerIndex>::DoDeclareParameters(
+        tree_system);
+
+    is_locked_parameter_index_ =
+        this->DeclareAbstractParameter(tree_system, Value<bool>(false));
+  }
+
  private:
   // Implementation for MultibodyElement::DoSetTopology().
   // At MultibodyTree::Finalize() time, each mobilizer retrieves its topology
@@ -681,6 +724,10 @@ class Mobilizer : public MultibodyElement<Mobilizer, T, MobilizerIndex> {
   const Frame<T>& inboard_frame_;
   const Frame<T>& outboard_frame_;
   MobilizerTopology topology_;
+
+  // System parameter index for `this` mobilizer's lock state stored in a
+  // context.
+  systems::AbstractParameterIndex is_locked_parameter_index_;
 };
 
 }  // namespace internal

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -690,6 +690,11 @@ class MultibodyTree {
     return *owned_mobilizers_[mobilizer_index];
   }
 
+  Mobilizer<T>& get_mutable_mobilizer(MobilizerIndex mobilizer_index) {
+    DRAKE_THROW_UNLESS(mobilizer_index < num_mobilizers());
+    return *owned_mobilizers_[mobilizer_index];
+  }
+
   // See MultibodyPlant method.
   template <template <typename> class ForceElementType = ForceElement>
   const ForceElementType<T>& GetForceElement(

--- a/multibody/tree/multibody_tree_system.cc
+++ b/multibody/tree/multibody_tree_system.cc
@@ -92,6 +92,13 @@ MultibodyTree<T>& MultibodyTreeSystem<T>::mutable_tree() const {
 
 template <typename T>
 void MultibodyTreeSystem<T>::DeclareMultibodyElementParameters() {
+  // Mobilizers.
+  for (MobilizerIndex mobilizer_index(0);
+       mobilizer_index < tree_->num_mobilizers(); ++mobilizer_index) {
+    mutable_tree()
+        .get_mutable_mobilizer(mobilizer_index)
+        .DeclareParameters(this);
+  }
   // Joints.
   for (JointIndex joint_index(0); joint_index < tree_->num_joints();
        ++joint_index) {


### PR DESCRIPTION
Towards #14949 and part of #18258.

This is an intermediate PR that consolidates the context parameter that handles joint/body locking in the underlying mobilizer. Once all of #18258 lands, free body APIs and `QuaternionFloatingJoint` APIs for all free bodies will affect the same underlying body. In order for joint/body locking to work correctly and communicate lock/unlock status between these redundant APIs, we move the lock parameter to the underlying mobilizer. Therefore if a user was to lock a body with `Body::Lock()` and then query the parent joint of that body with `Joint::is_locked()` it would return `true` and vice versa with `Joint::Lock()` and `Body::is_locked()` for the child body of the joint.

Since this is just changing an underlying implementation no additional tests are added. The tests already covering joint/body locking live in `joint_locking_test` and `floating_body_test` respectively.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18389)
<!-- Reviewable:end -->
