### PR TITLE
[multibody] Add joint for each free body

### DIFF
--- a/manipulation/models/allegro_hand_description/test/parse_test.cc
+++ b/manipulation/models/allegro_hand_description/test/parse_test.cc
@@ -40,10 +40,10 @@ TEST_P(ParseTest, Quantities) {
 
   EXPECT_EQ(plant.num_actuators(), 2 * 16);
   if (file_extension == "sdf") {
-    EXPECT_EQ(plant.num_joints(), 2 * 16);
+    EXPECT_EQ(plant.num_joints(), 2 * 16 + 2);  // + 2 for floating body joints
     EXPECT_EQ(plant.num_bodies(), 2 * 17 + 1);  // + 1 for world
   } else {
-    EXPECT_EQ(plant.num_joints(), 2 * 21);
+    EXPECT_EQ(plant.num_joints(), 2 * 21 + 2);  // + 2 for floating body joints
     EXPECT_EQ(plant.num_bodies(), 2 * 22 + 1);  // + 1 for world
   }
   // 16 for finger joints, 7 for the free moving hand in the space

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -731,8 +731,8 @@ TEST_F(SdfParserTest, IncludeTags) {
   EXPECT_EQ(plant_.num_model_instances(), 7);
   // The models should have added 8 more bodies.
   EXPECT_EQ(plant_.num_bodies(), 9);
-  // The models should have added 5 more joints.
-  EXPECT_EQ(plant_.num_joints(), 5);
+  // The models should have added 8 more joints.
+  EXPECT_EQ(plant_.num_joints(), 8);
 
   // There should be a model instance with the name "robot1".
   ASSERT_TRUE(plant_.HasModelInstanceNamed("robot1"));
@@ -1765,8 +1765,8 @@ TEST_F(SdfParserTest, LoadDirectlyNestedModelsInWorld) {
   EXPECT_EQ(plant_.num_model_instances(), 5);
   // The models should have added 4 more bodies.
   EXPECT_EQ(plant_.num_bodies(), 5);
-  // The models should have added 3 more joints.
-  EXPECT_EQ(plant_.num_joints(), 3);
+  // The models should have added 4 more joints.
+  EXPECT_EQ(plant_.num_joints(), 4);
 
   // There should be a model instance with the name "parent_model".
   ASSERT_TRUE(plant_.HasModelInstanceNamed("parent_model"));
@@ -1821,8 +1821,8 @@ TEST_F(SdfParserTest, LoadDirectlyNestedModelsInModel) {
   EXPECT_EQ(plant_.num_model_instances(), 6);
   // The models should have added 4 more bodies.
   EXPECT_EQ(plant_.num_bodies(), 5);
-  // The models should have added 3 more joints.
-  EXPECT_EQ(plant_.num_joints(), 3);
+  // The models should have added 4 more joints.
+  EXPECT_EQ(plant_.num_joints(), 4);
 
   // There should be a model instance with the name "grand_parent_model" (top
   // level model).
@@ -2548,7 +2548,7 @@ TEST_F(SdfParserTest, MergeInclude) {
   // We should have loaded *only* 1 more model.
   EXPECT_EQ(plant_.num_model_instances(), 3);
   EXPECT_EQ(plant_.num_bodies(), 4);
-  EXPECT_EQ(plant_.num_joints(), 2);
+  EXPECT_EQ(plant_.num_joints(), 3);
 
   ASSERT_TRUE(plant_.HasModelInstanceNamed("robot1_with_tool"));
   ModelInstanceIndex robot1_model =

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -28,6 +28,7 @@
 #include "drake/multibody/plant/make_discrete_update_manager.h"
 #include "drake/multibody/plant/slicing_and_indexing.h"
 #include "drake/multibody/tree/prismatic_joint.h"
+#include "drake/multibody/tree/quaternion_floating_joint.h"
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/multibody/triangle_quadrature/gaussian_triangle_quadrature_rule.h"
 
@@ -840,6 +841,17 @@ template<typename T>
 void MultibodyPlant<T>::Finalize() {
   // After finalizing the base class, tree is read-only.
   internal::MultibodyTreeSystem<T>::Finalize();
+
+  // Add free joints created by tree's finalize to the multibody graph.
+  // Until the call to Finalize(), all joints are added through calls to
+  // MultibodyPlant APIs and therefore registered in the graph. This accounts
+  // for the QuaternionFloatingJoint added for each free body that was not
+  // explicitly given a parent joint. It is important that this loop happens
+  // AFTER finalizing the internal tree.
+  for (JointIndex i{multibody_graph_.num_joints()}; i < num_joints(); ++i) {
+    RegisterJointInGraph(get_joint(i));
+  }
+
   if (geometry_source_is_registered()) {
     ApplyDefaultCollisionFilters();
     ExcludeCollisionsWithVisualGeometry();
@@ -1059,6 +1071,7 @@ void MultibodyPlant<T>::ApplyDefaultCollisionFilters() {
     const Body<T>& child = joint.child_body();
     const Body<T>& parent = joint.parent_body();
     if (parent.index() == world_index()) continue;
+    if (joint.type_name() == QuaternionFloatingJoint<T>::kTypeName) continue;
     std::optional<FrameId> child_id = GetBodyFrameIdIfExists(child.index());
     std::optional<FrameId> parent_id = GetBodyFrameIdIfExists(parent.index());
 
@@ -2231,15 +2244,6 @@ void MultibodyPlant<T>::CalcJointLockingIndices(
     }
   }
 
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const Body<T>& body = get_body(body_index);
-    if (body.is_floating() && !body.is_locked(context)) {
-      for (int k = 0; k < 6; ++k) {
-        indices[unlocked_cursor++] =
-            body.floating_velocities_start() - num_positions() + k;
-      }
-    }
-  }
   DRAKE_ASSERT(unlocked_cursor <= num_velocities());
 
   // Use size to indicate exactly how many velocities are unlocked.

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1065,7 +1065,8 @@ template <typename T>
 void MultibodyPlant<T>::ApplyDefaultCollisionFilters() {
   DRAKE_DEMAND(geometry_source_is_registered());
   // Disallow collisions between adjacent bodies. Adjacency is implied by the
-  // existence of a joint between bodies.
+  // existence of a joint between bodies, except in the case of 6-dof joints or
+  // joints in which the parent body is `world`.
   for (JointIndex j{0}; j < num_joints(); ++j) {
     const Joint<T>& joint = get_joint(j);
     const Body<T>& child = joint.child_body();

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2390,6 +2390,15 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// multibody state vector. For such applications,
   /// Body::floating_positions_start() and Body::floating_velocities_start()
   /// offer the additional level of introspection needed.
+  ///
+  /// It is sometimes convenient for users to perform operations on Bodies
+  /// ubiquitously through the APIs of the Joint class. For that reason we
+  /// implicitly construct a 6-dof joint, QuaternionFloatingJoint, for all free
+  /// bodies at the time of Finalize(). Using Joint APIs to affect a free body
+  /// (setting  state, changing parameters, etc.) has the same effect as using
+  /// the free body APIs below. Each implicitly created joint is named
+  /// "$world_<bodyname>" where "<bodyname>" is the name of the free body, given
+  /// by `Body::name()`.
   /// @{
 
   /// Returns the set of body indexes corresponding to the free (floating)

--- a/multibody/plant/test/kuka_iiwa_model_tests.h
+++ b/multibody/plant/test/kuka_iiwa_model_tests.h
@@ -86,14 +86,16 @@ class KukaIiwaModelTests : public ::testing::Test {
   // velocity of the base is set arbitrarily to a non-identity pose and non-zero
   // spatial velocity.
   void SetState(const VectorX<double>& x_joints) {
-    EXPECT_EQ(plant_->num_joints(), kNumJoints + 1);  // + 1 for floating joint
-    for (JointIndex joint_index(0); joint_index < kNumJoints; ++joint_index) {
+    EXPECT_EQ(plant_->num_joints(), kNumJoints);
+    // The last joint is the free body's joint so we skip it.
+    for (JointIndex joint_index(0); joint_index < kNumJoints - 1;
+         ++joint_index) {
       const RevoluteJoint<double>& joint =
           dynamic_cast<const RevoluteJoint<double>&>(
               plant_->get_joint(joint_index));
       joint.set_angle(context_.get(), x_joints[joint_index]);
       joint.set_angular_rate(context_.get(),
-                             x_joints[kNumJoints + joint_index]);
+                             x_joints[kNumJoints + joint_index - 1]);
     }
 
     // Set an arbitrary (though non-identity) pose of the floating base link.
@@ -112,7 +114,7 @@ class KukaIiwaModelTests : public ::testing::Test {
   // Get an arm state associated with an arbitrary configuration that avoids
   // in-plane motion and in which joint angles and rates are non-zero.
   VectorX<double> GetArbitraryJointAnglesAndRates() {
-    VectorX<double> x(2 * kNumJoints);
+    VectorX<double> x(2 * (kNumJoints - 1));
 
     // These joint angles avoid in-plane motion, but are otherwise arbitrary.
     const double q30 = M_PI / 6, q60 = M_PI / 3;
@@ -138,7 +140,7 @@ class KukaIiwaModelTests : public ::testing::Test {
 
  protected:
   // Problem sizes.
-  const int kNumJoints = 7;
+  const int kNumJoints = 8;
   const int kNumPositions = 14;
   const int kNumVelocities = 13;
 

--- a/multibody/plant/test/kuka_iiwa_model_tests.h
+++ b/multibody/plant/test/kuka_iiwa_model_tests.h
@@ -86,9 +86,8 @@ class KukaIiwaModelTests : public ::testing::Test {
   // velocity of the base is set arbitrarily to a non-identity pose and non-zero
   // spatial velocity.
   void SetState(const VectorX<double>& x_joints) {
-    EXPECT_EQ(plant_->num_joints(), 7);
-    for (JointIndex joint_index(0); joint_index < plant_->num_joints();
-         ++joint_index) {
+    EXPECT_EQ(plant_->num_joints(), kNumJoints + 1);  // + 1 for floating joint
+    for (JointIndex joint_index(0); joint_index < kNumJoints; ++joint_index) {
       const RevoluteJoint<double>& joint =
           dynamic_cast<const RevoluteJoint<double>&>(
               plant_->get_joint(joint_index));

--- a/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
+++ b/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
@@ -175,7 +175,7 @@ GTEST_TEST(MultibodyPlantForwardDynamics, AtlasRobot) {
     const Joint<double>& joint = plant.get_joint(joint_index);
     // This model only has weld, revolute, and floating joints. Set the revolute
     // joints to an arbitrary angle.
-    if (joint.num_velocities() == 1) {
+    if (joint.type_name() == RevoluteJoint<double>::kTypeName) {
       const RevoluteJoint<double>& revolute_joint =
           dynamic_cast<const RevoluteJoint<double>&>(joint);
       // Arbitrary non-zero angle.

--- a/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
+++ b/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
@@ -127,7 +127,7 @@ class KukaIiwaModelForwardDynamicsTests : public test::KukaIiwaModelTests {
 // the computation for an arbitrary set of robot states.
 TEST_F(KukaIiwaModelForwardDynamicsTests, ForwardDynamicsTest) {
   // Joint angles and velocities.
-  VectorX<double> q(kNumJoints), qdot(kNumJoints);
+  VectorX<double> q(kNumJoints - 1), qdot(kNumJoints - 1);
   double q30 = M_PI / 6, q45 = M_PI / 4, q60 = M_PI / 3;
 
   // Test 1: Static configuration.

--- a/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
+++ b/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
@@ -173,8 +173,9 @@ GTEST_TEST(MultibodyPlantForwardDynamics, AtlasRobot) {
   for (JointIndex joint_index(0); joint_index < plant.num_joints();
        ++joint_index) {
     const Joint<double>& joint = plant.get_joint(joint_index);
-    // This model only has weld and revolute joints. Weld joints have zero DOFs.
-    if (joint.num_velocities() != 0) {
+    // This model only has weld, revolute, and floating joints. Set the revolute
+    // joints to an arbitrary angle.
+    if (joint.num_velocities() == 1) {
       const RevoluteJoint<double>& revolute_joint =
           dynamic_cast<const RevoluteJoint<double>&>(joint);
       // Arbitrary non-zero angle.

--- a/multibody/plant/test/multibody_plant_jacobians_test.cc
+++ b/multibody/plant/test/multibody_plant_jacobians_test.cc
@@ -77,7 +77,7 @@ void CalcJacobianViaPartialDerivativesOfPositionWithRespectToQ(
 TEST_F(KukaIiwaModelTests, FixtureInvariants) {
   // Sanity check basic invariants.
   // Seven dofs for the arm plus floating base.
-  EXPECT_EQ(plant_->num_joints(), kNumJoints + 1);  // + 1 for floating joint.
+  EXPECT_EQ(plant_->num_joints(), kNumJoints);
   EXPECT_EQ(plant_->num_positions(), kNumPositions);
   EXPECT_EQ(plant_->num_velocities(), kNumVelocities);
 }

--- a/multibody/plant/test/multibody_plant_jacobians_test.cc
+++ b/multibody/plant/test/multibody_plant_jacobians_test.cc
@@ -77,7 +77,7 @@ void CalcJacobianViaPartialDerivativesOfPositionWithRespectToQ(
 TEST_F(KukaIiwaModelTests, FixtureInvariants) {
   // Sanity check basic invariants.
   // Seven dofs for the arm plus floating base.
-  EXPECT_EQ(plant_->num_joints(), kNumJoints);
+  EXPECT_EQ(plant_->num_joints(), kNumJoints + 1);  // + 1 for floating joint.
   EXPECT_EQ(plant_->num_positions(), kNumPositions);
   EXPECT_EQ(plant_->num_velocities(), kNumVelocities);
 }

--- a/multibody/plant/test/multibody_plant_mass_matrix_test.cc
+++ b/multibody/plant/test/multibody_plant_mass_matrix_test.cc
@@ -115,8 +115,9 @@ TEST_F(MultibodyPlantMassMatrixTests, AtlasRobot) {
   for (JointIndex joint_index(0); joint_index < plant_.num_joints();
        ++joint_index) {
     const Joint<double>& joint = plant_.get_joint(joint_index);
-    // This model only has weld and revolute joints. Weld joints have zero DOFs.
-    if (joint.num_velocities() != 0) {
+    // This model has weld, revolute, and floating joints. Set the revolute
+    // joints to an arbitrary angle.
+    if (joint.type_name() == "revolute") {
       const RevoluteJoint<double>& revolute_joint =
           dynamic_cast<const RevoluteJoint<double>&>(joint);
       // Arbitrary non-zero angle.
@@ -140,8 +141,9 @@ TEST_F(MultibodyPlantMassMatrixTests, AtlasRobotWithFixedJoints) {
   for (JointIndex joint_index(0); joint_index < plant_.num_joints();
        ++joint_index) {
     const Joint<double>& joint = plant_.get_joint(joint_index);
-    // This model only has weld and revolute joints. Weld joints have zero DOFs.
-    if (joint.num_velocities() != 0) {
+    // This model has weld, revolute, and floating joints. Set the revolute
+    // joints to an arbitrary angle.
+    if (joint.type_name() == "revolute") {
       const RevoluteJoint<double>& revolute_joint =
           dynamic_cast<const RevoluteJoint<double>&>(joint);
       // Arbitrary non-zero angle.

--- a/multibody/plant/test/multibody_plant_mass_matrix_test.cc
+++ b/multibody/plant/test/multibody_plant_mass_matrix_test.cc
@@ -117,7 +117,7 @@ TEST_F(MultibodyPlantMassMatrixTests, AtlasRobot) {
     const Joint<double>& joint = plant_.get_joint(joint_index);
     // This model has weld, revolute, and floating joints. Set the revolute
     // joints to an arbitrary angle.
-    if (joint.type_name() == "revolute") {
+    if (joint.type_name() == RevoluteJoint<double>::kTypeName) {
       const RevoluteJoint<double>& revolute_joint =
           dynamic_cast<const RevoluteJoint<double>&>(joint);
       // Arbitrary non-zero angle.
@@ -143,7 +143,7 @@ TEST_F(MultibodyPlantMassMatrixTests, AtlasRobotWithFixedJoints) {
     const Joint<double>& joint = plant_.get_joint(joint_index);
     // This model has weld, revolute, and floating joints. Set the revolute
     // joints to an arbitrary angle.
-    if (joint.type_name() == "revolute") {
+    if (joint.type_name() == RevoluteJoint<double>::kTypeName) {
       const RevoluteJoint<double>& revolute_joint =
           dynamic_cast<const RevoluteJoint<double>&>(joint);
       // Arbitrary non-zero angle.
@@ -164,12 +164,12 @@ TEST_F(MultibodyPlantMassMatrixTests, IiwaWithWeldedGripper) {
        ++joint_index) {
     const Joint<double>& joint = plant_.get_joint(joint_index);
     // This model only has weld, prismatic, and revolute joints.
-    if (joint.type_name() == "revolute") {
+    if (joint.type_name() == RevoluteJoint<double>::kTypeName) {
       const RevoluteJoint<double>& revolute_joint =
           dynamic_cast<const RevoluteJoint<double>&>(joint);
       // Arbitrary non-zero angle.
       revolute_joint.set_angle(context.get(), 0.5 * joint_index);
-    } else if (joint.type_name() == "prismatic") {
+    } else if (joint.type_name() == PrismaticJoint<double>::kTypeName) {
        const PrismaticJoint<double>& prismatic_joint =
           dynamic_cast<const PrismaticJoint<double>&>(joint);
       // Arbitrary non-zero joint translation.

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -3,6 +3,7 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <regex>
 #include <set>
 #include <tuple>
 #include <utility>
@@ -1134,7 +1135,8 @@ GTEST_TEST(MultibodyPlantTest, Graphviz) {
   Parser(&plant).AddModelFromFile(cylinder_path, "cylinder2");
 
   plant.set_name("MyTestMBP");
-  const std::string dot = plant.GetTopologyGraphvizString();
+  const std::string dot = std::regex_replace(plant.GetTopologyGraphvizString(),
+                                             std::regex("\\n"), "");
 
   // Check that the diagram is labeled with the system name.
   EXPECT_NE(std::string::npos, dot.find("MyTestMBP")) << dot;
@@ -1154,9 +1156,24 @@ GTEST_TEST(MultibodyPlantTest, Graphviz) {
   // Check for the Acrobot elbow joint.
   EXPECT_NE(std::string::npos, dot.find("ElbowJoint [revolute]")) << dot;
 
-  // Check that the same string appears before and after calling Finalize().
+  // Finalize() will add floating joints for the free bodies.
   plant.Finalize();
-  EXPECT_STREQ(dot.c_str(), plant.GetTopologyGraphvizString().c_str());
+  const std::string dot_finalized = std::regex_replace(
+      plant.GetTopologyGraphvizString(), std::regex("\\n"), "");
+
+  // Check that the pre-finalize string is a substring of the post-finalize
+  // string (ignoring newlines and the ending '}' as the last character)
+  EXPECT_THAT(dot_finalized.c_str(),
+              testing::HasSubstr(dot.substr(0, dot.size() - 1).c_str()));
+
+  // Check that the two floating joints created at Finalize() exist.
+  const size_t pos_finalized =
+      dot_finalized.find("world_uniformSolidCylinder [quaternion_floating]");
+  EXPECT_NE(std::string::npos, pos_finalized) << dot_finalized;
+  EXPECT_NE(
+      std::string::npos,
+      dot_finalized.find("world_uniformSolidCylinder [quaternion_floating]",
+                         pos_finalized + 1));
 }
 
 // Verifies that the right errors get invoked upon finalization.

--- a/multibody/tree/multibody_tree-inl.h
+++ b/multibody/tree/multibody_tree-inl.h
@@ -208,8 +208,12 @@ const MobilizerType<T>& MultibodyTree<T>::AddMobilizer(
 
   // Mark free bodies as needed.
   const BodyIndex outboard_body_index = mobilizer->outboard_body().index();
+  bool is_body_floating =
+      mobilizer->is_floating() &&
+      mobilizer->inboard_frame().body().index() == world_body().index();
+
   topology_.get_mutable_body(outboard_body_index).is_floating =
-      mobilizer->is_floating();
+      is_body_floating;
   topology_.get_mutable_body(outboard_body_index).has_quaternion_dofs =
       mobilizer->has_quaternion_dofs();
 

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -17,6 +17,7 @@
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/tree/body_node_welded.h"
 #include "drake/multibody/tree/multibody_tree-inl.h"
+#include "drake/multibody/tree/quaternion_floating_joint.h"
 #include "drake/multibody/tree/quaternion_floating_mobilizer.h"
 #include "drake/multibody/tree/rigid_body.h"
 #include "drake/multibody/tree/spatial_inertia.h"
@@ -614,19 +615,64 @@ void MultibodyTree<T>::SetVelocitiesInArray(
 }
 
 template <typename T>
-void MultibodyTree<T>::AddQuaternionFreeMobilizerToAllBodiesWithNoMobilizer() {
+void MultibodyTree<T>::CreateJointImplementations() {
   DRAKE_DEMAND(!topology_is_valid());
+  // Create Joint objects's implementation. Joints are implemented using a
+  // combination of MultibodyTree's building blocks such as Body, Mobilizer,
+  // ForceElement and Constraint. For a same physical Joint, several
+  // implementations could be created (for instance, a Constraint instead of a
+  // Mobilizer). The decision on what implementation to create is performed by
+  // MultibodyTree at Finalize() time. Then, JointImplementationBuilder below
+  // can request MultibodyTree for these choices when building the Joint
+  // implementation. Since a Joint's implementation is built upon
+  // MultibodyTree's building blocks, notice that creating a Joint's
+  // implementation will therefore change the tree topology. Since topology
+  // changes are NOT allowed after Finalize(), joint implementations MUST be
+  // assembled BEFORE the tree's topology is finalized.
+  int num_joints_pre_floating_joints = num_joints();
+  joint_to_mobilizer_.resize(num_joints_pre_floating_joints);
+  for (int i = 0; i < num_joints_pre_floating_joints; ++i) {
+    auto& joint = owned_joints_[i];
+    std::vector<Mobilizer<T>*> mobilizers =
+        internal::JointImplementationBuilder<T>::Build(joint.get(), this);
+    // Below we assume a single mobilizer per joint, the sane thing to do.
+    // TODO(amcastro-tri): clean up the JointImplementationBuilder so that this
+    // assumption (one mobilizer per joint) is set in stone once and for all.
+    DRAKE_DEMAND(mobilizers.size() == 1);
+    for (Mobilizer<T>* mobilizer : mobilizers) {
+      mobilizer->set_model_instance(joint->model_instance());
+      // Record the joint to mobilizer map.
+      joint_to_mobilizer_[joint->index()] = mobilizer->index();
+    }
+  }
+  // It is VERY important to add quaternions if needed only AFTER joints had a
+  // chance to get implemented with mobilizers. This is because joints's
+  // implementations change the topology of the tree. Therefore, do not change
+  // this order!
+
   // Skip the world.
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
     const Body<T>& body = get_body(body_index);
-    const BodyTopology& body_topology =
-        get_topology().get_body(body.index());
+    const BodyTopology& body_topology = get_topology().get_body(body.index());
     if (!body_topology.inboard_mobilizer.is_valid()) {
-      std::unique_ptr<QuaternionFloatingMobilizer<T>> mobilizer =
-          std::make_unique<QuaternionFloatingMobilizer<T>>(
-              world_body().body_frame(), body.body_frame());
-      mobilizer->set_model_instance(body.model_instance());
-      this->AddMobilizer(std::move(mobilizer));
+      this->AddJoint<QuaternionFloatingJoint>("world_" + body.name(),
+                                              world_body(), {}, body, {});
+    }
+  }
+
+  joint_to_mobilizer_.resize(num_joints());
+  for (int i = num_joints_pre_floating_joints; i < num_joints(); ++i) {
+    auto& joint = owned_joints_[i];
+    std::vector<Mobilizer<T>*> mobilizers =
+        internal::JointImplementationBuilder<T>::Build(joint.get(), this);
+    // Below we assume a single mobilizer per joint, the sane thing to do.
+    // TODO(amcastro-tri): clean up the JointImplementationBuilder so that this
+    // assumption (one mobilizer per joint) is set in stone once and for all.
+    DRAKE_DEMAND(mobilizers.size() == 1);
+    for (Mobilizer<T>* mobilizer : mobilizers) {
+      mobilizer->set_model_instance(joint->model_instance());
+      // Record the joint to mobilizer map.
+      joint_to_mobilizer_[joint->index()] = mobilizer->index();
     }
   }
 }
@@ -711,37 +757,7 @@ void MultibodyTree<T>::FinalizeInternals() {
 template <typename T>
 void MultibodyTree<T>::Finalize() {
   DRAKE_MBT_THROW_IF_FINALIZED();
-  // Create Joint objects's implementation. Joints are implemented using a
-  // combination of MultibodyTree's building blocks such as Body, Mobilizer,
-  // ForceElement and Constraint. For a same physical Joint, several
-  // implementations could be created (for instance, a Constraint instead of a
-  // Mobilizer). The decision on what implementation to create is performed by
-  // MultibodyTree at Finalize() time. Then, JointImplementationBuilder below
-  // can request MultibodyTree for these choices when building the Joint
-  // implementation. Since a Joint's implementation is built upon
-  // MultibodyTree's building blocks, notice that creating a Joint's
-  // implementation will therefore change the tree topology. Since topology
-  // changes are NOT allowed after Finalize(), joint implementations MUST be
-  // assembled BEFORE the tree's topology is finalized.
-  joint_to_mobilizer_.resize(num_joints());
-  for (auto& joint : owned_joints_) {
-    std::vector<Mobilizer<T>*> mobilizers =
-        internal::JointImplementationBuilder<T>::Build(joint.get(), this);
-    // Below we assume a single mobilizer per joint, the sane thing to do.
-    // TODO(amcastro-tri): clean up the JointImplementationBuilder so that this
-    // assumption (one mobilizer per joint) is set in stone once and for all.
-    DRAKE_DEMAND(mobilizers.size() == 1);
-    for (Mobilizer<T>* mobilizer : mobilizers) {
-      mobilizer->set_model_instance(joint->model_instance());
-      // Record the joint to mobilizer map.
-      joint_to_mobilizer_[joint->index()] = mobilizer->index();
-    }
-  }
-  // It is VERY important to add quaternions if needed only AFTER joints had a
-  // chance to get implemented with mobilizers. This is because joints's
-  // implementations change the topology of the tree. Therefore, do not change
-  // this order!
-  AddQuaternionFreeMobilizerToAllBodiesWithNoMobilizer();
+  CreateJointImplementations();
   FinalizeTopology();
   FinalizeInternals();
 }

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -617,7 +617,7 @@ void MultibodyTree<T>::SetVelocitiesInArray(
 template <typename T>
 void MultibodyTree<T>::CreateJointImplementations() {
   DRAKE_DEMAND(!topology_is_valid());
-  // Create Joint objects's implementation. Joints are implemented using a
+  // Create Joint objects' implementation. Joints are implemented using a
   // combination of MultibodyTree's building blocks such as Body, Mobilizer,
   // ForceElement and Constraint. For a same physical Joint, several
   // implementations could be created (for instance, a Constraint instead of a
@@ -629,15 +629,15 @@ void MultibodyTree<T>::CreateJointImplementations() {
   // implementation will therefore change the tree topology. Since topology
   // changes are NOT allowed after Finalize(), joint implementations MUST be
   // assembled BEFORE the tree's topology is finalized.
-  int num_joints_pre_floating_joints = num_joints();
+  const int num_joints_pre_floating_joints = num_joints();
   joint_to_mobilizer_.resize(num_joints_pre_floating_joints);
   for (int i = 0; i < num_joints_pre_floating_joints; ++i) {
     auto& joint = owned_joints_[i];
     std::vector<Mobilizer<T>*> mobilizers =
         internal::JointImplementationBuilder<T>::Build(joint.get(), this);
-    // Below we assume a single mobilizer per joint, the sane thing to do.
-    // TODO(amcastro-tri): clean up the JointImplementationBuilder so that this
-    // assumption (one mobilizer per joint) is set in stone once and for all.
+    // Below we assume a single mobilizer per joint, which is  true
+    // for all joint types currently implemented. This may change in the future
+    // when closed topologies are supported.
     DRAKE_DEMAND(mobilizers.size() == 1);
     for (Mobilizer<T>* mobilizer : mobilizers) {
       mobilizer->set_model_instance(joint->model_instance());
@@ -645,9 +645,11 @@ void MultibodyTree<T>::CreateJointImplementations() {
       joint_to_mobilizer_[joint->index()] = mobilizer->index();
     }
   }
-  // It is VERY important to add quaternions if needed only AFTER joints had a
-  // chance to get implemented with mobilizers. This is because joints's
-  // implementations change the topology of the tree. Therefore, do not change
+  // It is VERY important to add joints to free bodies only AFTER joints had a
+  // chance to get implemented with mobilizers. This is because above added
+  // joints' implementations change the topology of the tree. After all joints
+  // above are implemented, any body remaining with no valid inboard mobilizer
+  // will get a 6-dof joint with world as its parent. Therefore, do not change
   // this order!
 
   // Skip the world.
@@ -665,9 +667,9 @@ void MultibodyTree<T>::CreateJointImplementations() {
     auto& joint = owned_joints_[i];
     std::vector<Mobilizer<T>*> mobilizers =
         internal::JointImplementationBuilder<T>::Build(joint.get(), this);
-    // Below we assume a single mobilizer per joint, the sane thing to do.
-    // TODO(amcastro-tri): clean up the JointImplementationBuilder so that this
-    // assumption (one mobilizer per joint) is set in stone once and for all.
+    // Below we assume a single mobilizer per joint, which is  true
+    // for all joint types currently implemented. This may change in the future
+    // when closed topologies are supported.
     DRAKE_DEMAND(mobilizers.size() == 1);
     for (Mobilizer<T>* mobilizer : mobilizers) {
       mobilizer->set_model_instance(joint->model_instance());

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -657,7 +657,7 @@ void MultibodyTree<T>::CreateJointImplementations() {
     const Body<T>& body = get_body(body_index);
     const BodyTopology& body_topology = get_topology().get_body(body.index());
     if (!body_topology.inboard_mobilizer.is_valid()) {
-      this->AddJoint<QuaternionFloatingJoint>("world_" + body.name(),
+      this->AddJoint<QuaternionFloatingJoint>("$world_" + body.name(),
                                               world_body(), {}, body, {});
     }
   }

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -2606,7 +2606,7 @@ class MultibodyTree {
   // called at Finalize().
   // The world body is special in that it is the only body in the model with no
   // mobilizer, even after Finalize().
-  void AddQuaternionFreeMobilizerToAllBodiesWithNoMobilizer();
+  void CreateJointImplementations();
 
   // For a frame Fp that is fixed/welded to a frame_F, this method computes
   // A_AFp_E, Fp's spatial acceleration in a body_A, expressed in a frame_E.


### PR DESCRIPTION
Towards #14949 and part of #18258.

- Creates a `QuaternionFloatingJoint` at finalize time for every free body in the tree.
    This creates a small breaking change: MbP::num_joints() will change in all existing
    plants that had previously declared at least one free body. 
- Explicitly declares `is_floating` to mean: is mobilized by a 6-dof mobilzer AND parent body of the mobilizer is world
  (this was only implicitly true before)
- Fixes all of the tests to deal with the breaking change.

This PR depends on the small behavior change from #18389 and will be rebased off of that branch. The changes to `body.h`, `joint.h` and `mobilizer.h` (all in the first commit) can be ignored. All of the relevant changes are in the second commit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18390)
<!-- Reviewable:end -->
