### PR TITLE
[geometry_spatial_inertia] Increase tolerance for mass check

### DIFF
--- a/multibody/tree/test/geometry_spatial_inertia_test.cc
+++ b/multibody/tree/test/geometry_spatial_inertia_test.cc
@@ -260,7 +260,7 @@ GTEST_TEST(TriangleSurfaceMassPropertiesTest, ExactPolyhedron) {
     // tolerance.
     EXPECT_TRUE(SpatialInertiasEqual(CalcSpatialInertia(mesh, kDensity),
                                      volume * kDensity, p_BcmMcm, G_MMo_M,
-                                     2 * kTol));
+                                     8 * kTol));
   }
 }
 


### PR DESCRIPTION
Prior tolerance was 4.4408920985006262e-16
Testing failed on mac-arm with diff of 4x prior tolerance (1.7763568394002505e-15)

Follow-up to #18345
Per @svenevs's Drake Slack post:
https://drakedevelopers.slack.com/archives/C270MN28G/p1670023472277669

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18395)
<!-- Reviewable:end -->
