### PR TITLE
[contact_properties] Use GetProperty<double>, not GetProperty<T>

### DIFF
--- a/multibody/plant/contact_properties.cc
+++ b/multibody/plant/contact_properties.cc
@@ -24,7 +24,7 @@ T GetPointContactStiffness(geometry::GeometryId id, double default_value,
   const geometry::ProximityProperties* prop =
       inspector.GetProximityProperties(id);
   DRAKE_DEMAND(prop != nullptr);
-  return prop->template GetPropertyOrDefault<T>(
+  return prop->template GetPropertyOrDefault<double>(
       geometry::internal::kMaterialGroup, geometry::internal::kPointStiffness,
       default_value);
 }
@@ -43,9 +43,9 @@ T GetHydroelasticModulus(geometry::GeometryId id, double default_value,
       geometry::internal::HydroelasticType::kRigid) {
     return std::numeric_limits<double>::infinity();
   }
-  return prop->GetPropertyOrDefault(geometry::internal::kHydroGroup,
-                                    geometry::internal::kElastic,
-                                    default_value);
+  return prop->template GetPropertyOrDefault<double>(
+      geometry::internal::kHydroGroup, geometry::internal::kElastic,
+      default_value);
 }
 
 template <typename T>
@@ -56,7 +56,7 @@ T GetHuntCrossleyDissipation(
   const geometry::ProximityProperties* prop =
       inspector.GetProximityProperties(id);
   DRAKE_DEMAND(prop != nullptr);
-  return prop->template GetPropertyOrDefault<T>(
+  return prop->template GetPropertyOrDefault<double>(
       geometry::internal::kMaterialGroup, geometry::internal::kHcDissipation,
       default_value);
 }


### PR DESCRIPTION
Using "use `GetProperty<double>`" per #18396, as the contract seemed insufficiently tested

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18397)
<!-- Reviewable:end -->
