### PR TITLE
Fix macOS CI and re-enalbe tests

### DIFF
--- a/geometry/render_gltf_client/BUILD.bazel
+++ b/geometry/render_gltf_client/BUILD.bazel
@@ -285,7 +285,9 @@ drake_py_unittest(
     data = [
         ":client_demo",
         ":server_demo",
-        ":test/ground_truth.gltf",
+        ":test/test_color_scene.gltf",
+        ":test/test_depth_scene.gltf",
+        ":test/test_label_scene.gltf",
     ],
     tags = [
         "cpu:2",

--- a/geometry/render_gltf_client/test/example_scene.sdf
+++ b/geometry/render_gltf_client/test/example_scene.sdf
@@ -60,8 +60,10 @@
             <length>0.1</length>
           </capsule>
         </geometry>
+        <!-- TODO(zachfang): capsules don't have the texture coordinate defined.
+             Revert back to a texture map once Drake 18296 is resolved. -->
         <material>
-          <drake:diffuse_map>4_color_texture.png</drake:diffuse_map>
+          <diffuse>1.0 1.0 0.25 1.0</diffuse>
         </material>
       </visual>
     </link>

--- a/geometry/render_gltf_client/test/integration_test.py
+++ b/geometry/render_gltf_client/test/integration_test.py
@@ -33,7 +33,7 @@ from PIL import Image
 COLOR_PIXEL_THRESHOLD = 20  # RGB pixel value tolerance.
 DEPTH_PIXEL_THRESHOLD = 0.001  # Depth measurement tolerance in meters.
 LABEL_PIXEL_THRESHOLD = 0
-INVALID_PIXEL_FRACTION = 0.5
+INVALID_PIXEL_FRACTION = 0.2
 
 
 class TestIntegration(unittest.TestCase):
@@ -53,7 +53,9 @@ class TestIntegration(unittest.TestCase):
             "--port=0",
         ]
         self.server_proc = subprocess.Popen(
-            server_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            server_args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
         )
 
         # Wait to hear which port it's using.
@@ -116,52 +118,105 @@ class TestIntegration(unittest.TestCase):
             image_sets.append(image_set)
         return image_sets
 
-    def get_gltf_paths(self, gltf_file_dir):
-        """Returns one glTF file for each image type for inspection."""
-        return [
-            f"{gltf_file_dir}/{1:019d}-color.gltf",
-            f"{gltf_file_dir}/{2:019d}-depth.gltf",
-            f"{gltf_file_dir}/{3:019d}-label.gltf",
-        ]
+    def get_gltf_path_pairs(self, gltf_file_dir):
+        """Returns pairs of generated and ground truth glTF files for each
+        image type for inspection.
+        """
+        gltf_path_pairs = []
+        for index, image_type in enumerate(["color", "depth", "label"]):
+            gltf_path = f"{gltf_file_dir}/{index+1:019d}-{image_type}.gltf"
+            ground_truth_gltf = self.runfiles.Rlocation(
+                "drake/geometry/render_gltf_client/test/"
+                f"test_{image_type}_scene.gltf"
+            )
+            gltf_path_pairs.append((gltf_path, ground_truth_gltf))
+        return gltf_path_pairs
 
     def assert_error_fraction_less(self, image_diff, fraction):
         image_diff_fraction = np.count_nonzero(image_diff) / image_diff.size
         self.assertLess(image_diff_fraction, fraction)
 
-    def _fuzz_irrelevant_data(self, gltf, is_color_image):
-        """Replaces irrelevant entries and returns the processed glTF dict for
+    _REPLACED = {
+        "bufferView": "bufferViews",
+        "camera": "cameras",
+        "index": "textures",
+        "indices": "accessors",
+        "material": "materials",
+        "mesh": "meshes",
+        "sampler": "samplers",
+        "source": "images",
+        "POSITION": "accessors",
+        "TEXCOORD_0": "accessors",
+    }
+    """The dict keys that their values should be replaced with actual data. """
+
+    _IGNORED = ["buffer", "name"]
+    """The dict keys that are order-dependent and should be ignored. """
+
+    def _get_or_replace_value(self, gltf, keys, value=None):
+        """Retrieves the data through a list of keys in a nested dict. If
+        `value` is not provided, the function will iterate to the leaf node and
+        return. Otherwise, the leaf node will be updated but return at the
+        second-to-last layer.
+        """
+        entry = gltf
+        for key in keys[:-1]:
+            entry = entry[key]
+
+        if value:
+            entry[keys[-1]] = value
+        else:
+            entry = entry[keys[-1]]
+        return entry
+
+    def _traverse_and_mutate_recursively(self, gltf, keys):
+        """The glTF entries usually contain indices that point to another
+        entry. This function traverses through the dictionary recursively and
+        replaces the indices with the actual data.
+        """
+        entry = self._get_or_replace_value(gltf, keys)
+        entry_type = type(entry)
+        if entry_type == dict:
+            for k, v in entry.items():
+                # Replace the index with the actual pointed data structure.
+                if k in self._REPLACED.keys():
+                    self._get_or_replace_value(
+                        gltf, keys + [k], gltf[self._REPLACED[k]][v]
+                    )
+                elif k in self._IGNORED:
+                    self._get_or_replace_value(gltf, keys + [k], "IGNORED")
+                self._traverse_and_mutate_recursively(gltf, keys + [k])
+        elif entry_type == list:
+            if not all(isinstance(x, (int, float, str)) for x in entry):
+                for index, _ in enumerate(entry):
+                    self._traverse_and_mutate_recursively(gltf, keys + [index])
+
+    def _fuzz_data_and_restructure(self, gltf):
+        """Restructures the glTF by fuzzing irrelevant entries and unlinking
+        the internal references to produce an order-agnostic dict for
         comparison.
         """
         result = copy.deepcopy(gltf)
 
-        # These two entries encode the exact texture information and are
-        # ignored for all image types.
-        for entry in ["buffers", "bufferViews"]:
-            result[entry] = "IGNORED"
+        # The `buffers` entry encodes all the raw data, e.g., textures and
+        # UV-coordinates, and is fuzzed out for comparison.
+        result["buffers"] = "IGNORED"
 
-        # These entries contain basic material properties, e.g., RGBA, and are
-        # only relevant for color image comparison.
-        if not is_color_image:
-            for entry in [
-                "accessors",
-                "images",
-                "materials",
-                "samplers",
-                "textures",
-            ]:
-                result[entry] = "IGNORED"
+        self._traverse_and_mutate_recursively(result, ["nodes"])
         return result
 
-    def _check_one_gltf(self, gltf, ground_truth_gltf, is_color_image):
-        actual = self._fuzz_irrelevant_data(gltf, is_color_image)
-        expected = self._fuzz_irrelevant_data(
-            ground_truth_gltf, is_color_image
-        )
-        # Check the glTF-related section in README for some troubleshooting
-        # tips if this test failed.
-        self.assertDictEqual(expected, actual)
+    def _check_one_gltf(self, gltf, ground_truth_gltf):
+        actual = self._fuzz_data_and_restructure(gltf)
+        expected = self._fuzz_data_and_restructure(ground_truth_gltf)
 
-    @unittest.skipIf("darwin" in sys.platform, "Broken on macOS")
+        # Compare each entry by their types. Note that `nodes` entry has
+        # combined information for the rest of the entries, e.g., meshes,
+        # cameras, materials, textures, accessors, etc.
+        self.assertEqual(actual["scene"], expected["scene"])
+        self.assertDictEqual(actual["asset"], expected["asset"])
+        for entry in ["scenes", "nodes"]:
+            self.assertCountEqual(actual[entry], expected[entry])
+
     def test_integration(self):
         """Quantitatively compares the images rendered by RenderEngineVtk and
         RenderEngineGltfClient via a fully exercised RPC pipeline.
@@ -207,17 +262,12 @@ class TestIntegration(unittest.TestCase):
             )
             self.assert_error_fraction_less(label_diff, INVALID_PIXEL_FRACTION)
 
-    @unittest.skipIf("darwin" in sys.platform, "Broken on macOS")
     def test_gltf_conversion(self):
         """Checks that the fundamental structure of the generated glTF files is
         preserved.  The comparison of the exact texture information is not in
         the test's scope and is covered in the integration test above.
         """
         result = self.run_render_client("client", cleanup=False)
-
-        ground_truth_gltf_path = self.runfiles.Rlocation(
-            "drake/geometry/render_gltf_client/test/ground_truth.gltf"
-        )
 
         # Scrape the directory for the glTF files.
         gltf_file_dir = None
@@ -231,13 +281,13 @@ class TestIntegration(unittest.TestCase):
                 break
         self.assertIsNotNone(gltf_file_dir)
 
-        with open(ground_truth_gltf_path, "r") as gt:
-            ground_truth_gltf = json.load(gt)
-
         # Iterate through each gltf file to compare against the ground truth.
-        for gltf_path in self.get_gltf_paths(gltf_file_dir):
-            is_color_image = "color.gltf" in gltf_path
+        for gltf_path, ground_truth_gltf_path in self.get_gltf_path_pairs(
+            gltf_file_dir
+        ):
             with open(gltf_path, "r") as f:
                 gltf = json.load(f)
+            with open(ground_truth_gltf_path, "r") as g:
+                ground_truth_gltf = json.load(g)
             with self.subTest(gltf_path=os.path.basename(gltf_path)):
-                self._check_one_gltf(gltf, ground_truth_gltf, is_color_image)
+                self._check_one_gltf(gltf, ground_truth_gltf)

--- a/geometry/render_gltf_client/test/test_color_scene.gltf
+++ b/geometry/render_gltf_client/test/test_color_scene.gltf
@@ -1,0 +1,955 @@
+{
+   "accessors" : 
+   [
+      {
+         "bufferView" : 0,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 2601,
+         "max" : [ 0.05000000074505806, 0.049901336431503296, 0.05000000074505806 ],
+         "min" : [ -0.05000000074505806, -0.049901336431503296, -0.05000000074505806 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 1,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 2601,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 2,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 15000,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 4,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 2601,
+         "max" : [ 0.05000000074505806, 0.049901336431503296, 0.05000000074505806 ],
+         "min" : [ -0.05000000074505806, -0.049901336431503296, -0.05000000074505806 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 5,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 2601,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 6,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 15000,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 7,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 2601,
+         "max" : [ 0.05000000074505806, 0.024950668215751648, 0.037500001490116119 ],
+         "min" : [ -0.05000000074505806, -0.024950668215751648, -0.037500001490116119 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 8,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 2601,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 9,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 15000,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 11,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 2601,
+         "max" : [ 0.05000000074505806, 0.024950668215751648, 0.037500001490116119 ],
+         "min" : [ -0.05000000074505806, -0.024950668215751648, -0.037500001490116119 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 12,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 2601,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 13,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 15000,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 14,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 200,
+         "max" : [ 0.05000000074505806, 0.049901336431503296, 0.05000000074505806 ],
+         "min" : [ -0.05000000074505806, -0.049901336431503296, -0.05000000074505806 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 15,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 200,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 16,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 588,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 18,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 200,
+         "max" : [ 0.05000000074505806, 0.049901336431503296, 0.05000000074505806 ],
+         "min" : [ -0.05000000074505806, -0.049901336431503296, -0.05000000074505806 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 19,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 200,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 20,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 588,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 21,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 4804,
+         "max" : [ 0.049974311143159866, 0.05000000074505806, 0.099948637187480927 ],
+         "min" : [ -0.049974311143159866, -0.05000000074505806, -0.099948637187480927 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 22,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 28812,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 23,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 4804,
+         "max" : [ 0.049974311143159866, 0.05000000074505806, 0.099948637187480927 ],
+         "min" : [ -0.049974311143159866, -0.05000000074505806, -0.099948637187480927 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 24,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 28812,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 25,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 24,
+         "max" : [ 0.050000000000000003, 0.037499999999999999, 0.025000000000000001 ],
+         "min" : [ -0.050000000000000003, -0.037499999999999999, -0.025000000000000001 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 26,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 24,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 27,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 36,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 29,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 24,
+         "max" : [ 0.050000000000000003, 0.037499999999999999, 0.025000000000000001 ],
+         "min" : [ -0.050000000000000003, -0.037499999999999999, -0.025000000000000001 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 30,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 24,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 31,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 36,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 32,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 49152,
+         "max" : [ 0.033259999006986618, 0.0098120002076029778, 0.18814800679683685 ],
+         "min" : [ -0.063937999308109283, -0.056809000670909882, -0.0031530000269412994 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 33,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 49152,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 34,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 49152,
+         "type" : "SCALAR"
+      }
+   ],
+   "asset" : 
+   {
+      "generator" : "VTK",
+      "version" : "2.0"
+   },
+   "bufferViews" : 
+   [
+      {
+         "buffer" : 0,
+         "byteLength" : 31212,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 1,
+         "byteLength" : 20808,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 2,
+         "byteLength" : 60000,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 3,
+         "byteLength" : 1123,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 4,
+         "byteLength" : 31212,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 5,
+         "byteLength" : 20808,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 6,
+         "byteLength" : 60000,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 7,
+         "byteLength" : 31212,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 8,
+         "byteLength" : 20808,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 9,
+         "byteLength" : 60000,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 10,
+         "byteLength" : 1123,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 11,
+         "byteLength" : 31212,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 12,
+         "byteLength" : 20808,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 13,
+         "byteLength" : 60000,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 14,
+         "byteLength" : 2400,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 15,
+         "byteLength" : 1600,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 16,
+         "byteLength" : 2352,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 17,
+         "byteLength" : 1123,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 18,
+         "byteLength" : 2400,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 19,
+         "byteLength" : 1600,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 20,
+         "byteLength" : 2352,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 21,
+         "byteLength" : 57648,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 22,
+         "byteLength" : 115248,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 23,
+         "byteLength" : 57648,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 24,
+         "byteLength" : 115248,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 25,
+         "byteLength" : 288,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 26,
+         "byteLength" : 192,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 27,
+         "byteLength" : 144,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 28,
+         "byteLength" : 1123,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 29,
+         "byteLength" : 288,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 30,
+         "byteLength" : 192,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 31,
+         "byteLength" : 144,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 32,
+         "byteLength" : 589824,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 33,
+         "byteLength" : 393216,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 34,
+         "byteLength" : 196608,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 35,
+         "byteLength" : 9081569,
+         "byteOffset" : 0
+      }
+   ],
+   "cameras" : 
+   [
+      {
+         "perspective" : 
+         {
+            "aspectRatio" : 1.3333333333333333,
+            "yfov" : 0.78539816339744828,
+            "zfar" : 10,
+            "znear" : 0.01
+         },
+         "type" : "perspective"
+      }
+   ],
+   "images" : 
+   [
+      {
+         "bufferView" : 3,
+         "mimeType" : "image/png"
+      },
+      {
+         "bufferView" : 10,
+         "mimeType" : "image/png"
+      },
+      {
+         "bufferView" : 17,
+         "mimeType" : "image/png"
+      },
+      {
+         "bufferView" : 28,
+         "mimeType" : "image/png"
+      },
+      {
+         "bufferView" : 35,
+         "mimeType" : "image/png"
+      }
+   ],
+   "materials" : 
+   [
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 1, 1, 1, 1 ],
+            "baseColorTexture" : 
+            {
+               "index" : 0,
+               "texCoord" : 0
+            },
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 0.25, 0.25, 1, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 1, 1, 1, 1 ],
+            "baseColorTexture" : 
+            {
+               "index" : 1,
+               "texCoord" : 0
+            },
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 0.25, 1, 1, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 1, 1, 1, 1 ],
+            "baseColorTexture" : 
+            {
+               "index" : 2,
+               "texCoord" : 0
+            },
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 0.25, 1, 0.25, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 1, 1, 0.25, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 1, 1, 0.25, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 1, 1, 1, 1 ],
+            "baseColorTexture" : 
+            {
+               "index" : 3,
+               "texCoord" : 0
+            },
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 1, 0.25, 0.25, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 1, 1, 1, 1 ],
+            "baseColorTexture" : 
+            {
+               "index" : 4,
+               "texCoord" : 0
+            },
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      }
+   ],
+   "meshes" : 
+   [
+      {
+         "name" : "mesh0",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 0,
+                  "TEXCOORD_0" : 1
+               },
+               "indices" : 2,
+               "material" : 0,
+               "mode" : 4
+            }
+         ]
+      },
+      {
+         "name" : "mesh1",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 3,
+                  "TEXCOORD_0" : 4
+               },
+               "indices" : 5,
+               "material" : 1,
+               "mode" : 4
+            }
+         ]
+      },
+      {
+         "name" : "mesh2",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 6,
+                  "TEXCOORD_0" : 7
+               },
+               "indices" : 8,
+               "material" : 2,
+               "mode" : 4
+            }
+         ]
+      },
+      {
+         "name" : "mesh3",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 9,
+                  "TEXCOORD_0" : 10
+               },
+               "indices" : 11,
+               "material" : 3,
+               "mode" : 4
+            }
+         ]
+      },
+      {
+         "name" : "mesh4",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 12,
+                  "TEXCOORD_0" : 13
+               },
+               "indices" : 14,
+               "material" : 4,
+               "mode" : 4
+            }
+         ]
+      },
+      {
+         "name" : "mesh5",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 15,
+                  "TEXCOORD_0" : 16
+               },
+               "indices" : 17,
+               "material" : 5,
+               "mode" : 4
+            }
+         ]
+      },
+      {
+         "name" : "mesh6",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 18
+               },
+               "indices" : 19,
+               "material" : 6,
+               "mode" : 4
+            }
+         ]
+      },
+      {
+         "name" : "mesh7",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 20
+               },
+               "indices" : 21,
+               "material" : 7,
+               "mode" : 4
+            }
+         ]
+      },
+      {
+         "name" : "mesh8",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 22,
+                  "TEXCOORD_0" : 23
+               },
+               "indices" : 24,
+               "material" : 8,
+               "mode" : 4
+            }
+         ]
+      },
+      {
+         "name" : "mesh9",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 25,
+                  "TEXCOORD_0" : 26
+               },
+               "indices" : 27,
+               "material" : 9,
+               "mode" : 4
+            }
+         ]
+      },
+      {
+         "name" : "mesh10",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 28,
+                  "TEXCOORD_0" : 29
+               },
+               "indices" : 30,
+               "material" : 10,
+               "mode" : 4
+            }
+         ]
+      }
+   ],
+   "nodes" : 
+   [
+      {
+         "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -0.20000000000000001, 0.25, 0, 1 ],
+         "mesh" : 0,
+         "name" : "mesh0"
+      },
+      {
+         "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -0.20000000000000001, -0.25, 0, 1 ],
+         "mesh" : 1,
+         "name" : "mesh1"
+      },
+      {
+         "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -0.050000000000000003, 0.25, 0, 1 ],
+         "mesh" : 2,
+         "name" : "mesh2"
+      },
+      {
+         "matrix" : 
+         [
+            1,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            -0.050000000000000003,
+            -0.25,
+            0,
+            1
+         ],
+         "mesh" : 3,
+         "name" : "mesh3"
+      },
+      {
+         "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0.10000000000000001, 0.25, 0, 1 ],
+         "mesh" : 4,
+         "name" : "mesh4"
+      },
+      {
+         "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0.10000000000000001, -0.25, 0, 1 ],
+         "mesh" : 5,
+         "name" : "mesh5"
+      },
+      {
+         "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0.25, 0.25, 0, 1 ],
+         "mesh" : 6,
+         "name" : "mesh6"
+      },
+      {
+         "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0.25, -0.25, 0, 1 ],
+         "mesh" : 7,
+         "name" : "mesh7"
+      },
+      {
+         "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0.40000000000000002, 0.25, 0, 1 ],
+         "mesh" : 8,
+         "name" : "mesh8"
+      },
+      {
+         "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0.40000000000000002, -0.25, 0, 1 ],
+         "mesh" : 9,
+         "name" : "mesh9"
+      },
+      {
+         "matrix" : 
+         [
+            0.38941834230865052,
+            -0.92106099400288499,
+            -1.0225831226261361e-16,
+            0,
+            0.92106070196376555,
+            0.38941821883649125,
+            -0.0007963267107332692,
+            0,
+            0.00073346547173895604,
+            0.00031010422762989276,
+            0.99999968293183472,
+            0,
+            0.02700000000000001,
+            -0.0048999999999999972,
+            -0.091999999999999998,
+            1
+         ],
+         "mesh" : 10,
+         "name" : "mesh10"
+      },
+      {
+         "camera" : 0,
+         "matrix" : 
+         [
+            0.00079632671073322247,
+            0.99999968293183472,
+            0,
+            0,
+            -0.58850093066037634,
+            0.00046863915896677607,
+            0.80849640381959009,
+            0,
+            0.80849614747111864,
+            -0.00064382728189329335,
+            0.58850111725534593,
+            0,
+            0.80000000000000016,
+            3.2742905609062234e-17,
+            0.50000000000000011,
+            1
+         ],
+         "name" : "Camera Node"
+      },
+      {
+         "children" : [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ],
+         "name" : "Renderer Node"
+      }
+   ],
+   "samplers" : 
+   [
+      {
+         "magFilter" : 9729,
+         "minFilter" : 9729,
+         "wrapS" : 33071,
+         "wrapT" : 33071
+      },
+      {
+         "magFilter" : 9729,
+         "minFilter" : 9729,
+         "wrapS" : 33071,
+         "wrapT" : 33071
+      },
+      {
+         "magFilter" : 9729,
+         "minFilter" : 9729,
+         "wrapS" : 33071,
+         "wrapT" : 33071
+      },
+      {
+         "magFilter" : 9729,
+         "minFilter" : 9729,
+         "wrapS" : 33071,
+         "wrapT" : 33071
+      },
+      {
+         "magFilter" : 9729,
+         "minFilter" : 9729,
+         "wrapS" : 33071,
+         "wrapT" : 33071
+      }
+   ],
+   "scene" : 0,
+   "scenes" : 
+   [
+      {
+         "name" : "Layer 0",
+         "nodes" : [ 12 ]
+      }
+   ],
+   "textures" : 
+   [
+      {
+         "sampler" : 0,
+         "source" : 0
+      },
+      {
+         "sampler" : 1,
+         "source" : 1
+      },
+      {
+         "sampler" : 2,
+         "source" : 2
+      },
+      {
+         "sampler" : 3,
+         "source" : 3
+      },
+      {
+         "sampler" : 4,
+         "source" : 4
+      }
+   ]
+}

--- a/geometry/render_gltf_client/test/test_depth_scene.gltf
+++ b/geometry/render_gltf_client/test/test_depth_scene.gltf
@@ -26,7 +26,7 @@
          "type" : "SCALAR"
       },
       {
-         "bufferView" : 4,
+         "bufferView" : 3,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 2601,
@@ -35,7 +35,7 @@
          "type" : "VEC3"
       },
       {
-         "bufferView" : 5,
+         "bufferView" : 4,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 2601,
@@ -43,38 +43,38 @@
          "type" : "VEC2"
       },
       {
-         "bufferView" : 6,
+         "bufferView" : 5,
          "byteOffset" : 0,
          "componentType" : 5125,
          "count" : 15000,
          "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 6,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 2601,
+         "max" : [ 0.05000000074505806, 0.024950668215751648, 0.037500001490116119 ],
+         "min" : [ -0.05000000074505806, -0.024950668215751648, -0.037500001490116119 ],
+         "type" : "VEC3"
       },
       {
          "bufferView" : 7,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 2601,
-         "max" : [ 0.05000000074505806, 0.024950668215751648, 0.037500001490116119 ],
-         "min" : [ -0.05000000074505806, -0.024950668215751648, -0.037500001490116119 ],
-         "type" : "VEC3"
+         "normalized" : false,
+         "type" : "VEC2"
       },
       {
          "bufferView" : 8,
          "byteOffset" : 0,
-         "componentType" : 5126,
-         "count" : 2601,
-         "normalized" : false,
-         "type" : "VEC2"
-      },
-      {
-         "bufferView" : 9,
-         "byteOffset" : 0,
          "componentType" : 5125,
          "count" : 15000,
          "type" : "SCALAR"
       },
       {
-         "bufferView" : 11,
+         "bufferView" : 9,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 2601,
@@ -83,7 +83,7 @@
          "type" : "VEC3"
       },
       {
-         "bufferView" : 12,
+         "bufferView" : 10,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 2601,
@@ -91,14 +91,14 @@
          "type" : "VEC2"
       },
       {
-         "bufferView" : 13,
+         "bufferView" : 11,
          "byteOffset" : 0,
          "componentType" : 5125,
          "count" : 15000,
          "type" : "SCALAR"
       },
       {
-         "bufferView" : 14,
+         "bufferView" : 12,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 200,
@@ -107,7 +107,7 @@
          "type" : "VEC3"
       },
       {
-         "bufferView" : 15,
+         "bufferView" : 13,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 200,
@@ -115,7 +115,31 @@
          "type" : "VEC2"
       },
       {
+         "bufferView" : 14,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 588,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 15,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 200,
+         "max" : [ 0.05000000074505806, 0.049901336431503296, 0.05000000074505806 ],
+         "min" : [ -0.05000000074505806, -0.049901336431503296, -0.05000000074505806 ],
+         "type" : "VEC3"
+      },
+      {
          "bufferView" : 16,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 200,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 17,
          "byteOffset" : 0,
          "componentType" : 5125,
          "count" : 588,
@@ -125,108 +149,84 @@
          "bufferView" : 18,
          "byteOffset" : 0,
          "componentType" : 5126,
-         "count" : 200,
-         "max" : [ 0.05000000074505806, 0.049901336431503296, 0.05000000074505806 ],
-         "min" : [ -0.05000000074505806, -0.049901336431503296, -0.05000000074505806 ],
+         "count" : 4804,
+         "max" : [ 0.049974311143159866, 0.05000000074505806, 0.099948637187480927 ],
+         "min" : [ -0.049974311143159866, -0.05000000074505806, -0.099948637187480927 ],
          "type" : "VEC3"
       },
       {
          "bufferView" : 19,
          "byteOffset" : 0,
-         "componentType" : 5126,
-         "count" : 200,
-         "normalized" : false,
-         "type" : "VEC2"
+         "componentType" : 5125,
+         "count" : 28812,
+         "type" : "SCALAR"
       },
       {
          "bufferView" : 20,
          "byteOffset" : 0,
-         "componentType" : 5125,
-         "count" : 588,
-         "type" : "SCALAR"
+         "componentType" : 5126,
+         "count" : 4804,
+         "max" : [ 0.049974311143159866, 0.05000000074505806, 0.099948637187480927 ],
+         "min" : [ -0.049974311143159866, -0.05000000074505806, -0.099948637187480927 ],
+         "type" : "VEC3"
       },
       {
          "bufferView" : 21,
          "byteOffset" : 0,
-         "componentType" : 5126,
-         "count" : 4804,
-         "max" : [ 0.049974311143159866, 0.05000000074505806, 0.099948637187480927 ],
-         "min" : [ -0.049974311143159866, -0.05000000074505806, -0.099948637187480927 ],
-         "type" : "VEC3"
+         "componentType" : 5125,
+         "count" : 28812,
+         "type" : "SCALAR"
       },
       {
          "bufferView" : 22,
          "byteOffset" : 0,
-         "componentType" : 5125,
-         "count" : 28812,
-         "type" : "SCALAR"
+         "componentType" : 5126,
+         "count" : 24,
+         "max" : [ 0.050000000000000003, 0.037499999999999999, 0.025000000000000001 ],
+         "min" : [ -0.050000000000000003, -0.037499999999999999, -0.025000000000000001 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 23,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 24,
+         "normalized" : false,
+         "type" : "VEC2"
       },
       {
          "bufferView" : 24,
          "byteOffset" : 0,
-         "componentType" : 5126,
-         "count" : 4804,
-         "max" : [ 0.049974311143159866, 0.05000000074505806, 0.099948637187480927 ],
-         "min" : [ -0.049974311143159866, -0.05000000074505806, -0.099948637187480927 ],
-         "type" : "VEC3"
+         "componentType" : 5125,
+         "count" : 36,
+         "type" : "SCALAR"
       },
       {
          "bufferView" : 25,
          "byteOffset" : 0,
-         "componentType" : 5125,
-         "count" : 28812,
-         "type" : "SCALAR"
+         "componentType" : 5126,
+         "count" : 24,
+         "max" : [ 0.050000000000000003, 0.037499999999999999, 0.025000000000000001 ],
+         "min" : [ -0.050000000000000003, -0.037499999999999999, -0.025000000000000001 ],
+         "type" : "VEC3"
       },
       {
          "bufferView" : 26,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 24,
-         "max" : [ 0.050000000000000003, 0.037499999999999999, 0.025000000000000001 ],
-         "min" : [ -0.050000000000000003, -0.037499999999999999, -0.025000000000000001 ],
-         "type" : "VEC3"
+         "normalized" : false,
+         "type" : "VEC2"
       },
       {
          "bufferView" : 27,
          "byteOffset" : 0,
-         "componentType" : 5126,
-         "count" : 24,
-         "normalized" : false,
-         "type" : "VEC2"
+         "componentType" : 5125,
+         "count" : 36,
+         "type" : "SCALAR"
       },
       {
          "bufferView" : 28,
-         "byteOffset" : 0,
-         "componentType" : 5125,
-         "count" : 36,
-         "type" : "SCALAR"
-      },
-      {
-         "bufferView" : 30,
-         "byteOffset" : 0,
-         "componentType" : 5126,
-         "count" : 24,
-         "max" : [ 0.050000000000000003, 0.037499999999999999, 0.025000000000000001 ],
-         "min" : [ -0.050000000000000003, -0.037499999999999999, -0.025000000000000001 ],
-         "type" : "VEC3"
-      },
-      {
-         "bufferView" : 31,
-         "byteOffset" : 0,
-         "componentType" : 5126,
-         "count" : 24,
-         "normalized" : false,
-         "type" : "VEC2"
-      },
-      {
-         "bufferView" : 32,
-         "byteOffset" : 0,
-         "componentType" : 5125,
-         "count" : 36,
-         "type" : "SCALAR"
-      },
-      {
-         "bufferView" : 33,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 49152,
@@ -235,7 +235,7 @@
          "type" : "VEC3"
       },
       {
-         "bufferView" : 34,
+         "bufferView" : 29,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 49152,
@@ -243,7 +243,7 @@
          "type" : "VEC2"
       },
       {
-         "bufferView" : 35,
+         "bufferView" : 30,
          "byteOffset" : 0,
          "componentType" : 5125,
          "count" : 49152,
@@ -255,8 +255,164 @@
       "generator" : "VTK",
       "version" : "2.0"
    },
-   "buffers" : "Placeholder",
-   "bufferViews" : "Placeholder",
+   "bufferViews" : 
+   [
+      {
+         "buffer" : 0,
+         "byteLength" : 31212,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 1,
+         "byteLength" : 20808,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 2,
+         "byteLength" : 60000,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 3,
+         "byteLength" : 31212,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 4,
+         "byteLength" : 20808,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 5,
+         "byteLength" : 60000,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 6,
+         "byteLength" : 31212,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 7,
+         "byteLength" : 20808,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 8,
+         "byteLength" : 60000,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 9,
+         "byteLength" : 31212,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 10,
+         "byteLength" : 20808,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 11,
+         "byteLength" : 60000,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 12,
+         "byteLength" : 2400,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 13,
+         "byteLength" : 1600,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 14,
+         "byteLength" : 2352,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 15,
+         "byteLength" : 2400,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 16,
+         "byteLength" : 1600,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 17,
+         "byteLength" : 2352,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 18,
+         "byteLength" : 57648,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 19,
+         "byteLength" : 115248,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 20,
+         "byteLength" : 57648,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 21,
+         "byteLength" : 115248,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 22,
+         "byteLength" : 288,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 23,
+         "byteLength" : 192,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 24,
+         "byteLength" : 144,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 25,
+         "byteLength" : 288,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 26,
+         "byteLength" : 192,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 27,
+         "byteLength" : 144,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 28,
+         "byteLength" : 589824,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 29,
+         "byteLength" : 393216,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 30,
+         "byteLength" : 196608,
+         "byteOffset" : 0
+      }
+   ],
    "cameras" : 
    [
       {
@@ -270,52 +426,12 @@
          "type" : "perspective"
       }
    ],
-   "images" : 
-   [
-      {
-         "bufferView" : 3,
-         "mimeType" : "image/png"
-      },
-      {
-         "bufferView" : 10,
-         "mimeType" : "image/png"
-      },
-      {
-         "bufferView" : 17,
-         "mimeType" : "image/png"
-      },
-      {
-         "bufferView" : 23,
-         "mimeType" : "image/png"
-      },
-      {
-         "bufferView" : 29,
-         "mimeType" : "image/png"
-      },
-      {
-         "bufferView" : 36,
-         "mimeType" : "image/png"
-      }
-   ],
    "materials" : 
    [
       {
          "pbrMetallicRoughness" : 
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
-            "baseColorTexture" : 
-            {
-               "index" : 0,
-               "texCoord" : 0
-            },
-            "metallicFactor" : 0,
-            "roughnessFactor" : 1
-         }
-      },
-      {
-         "pbrMetallicRoughness" : 
-         {
-            "baseColorFactor" : [ 0.25, 0.25, 1, 1 ],
             "metallicFactor" : 0,
             "roughnessFactor" : 1
          }
@@ -324,19 +440,6 @@
          "pbrMetallicRoughness" : 
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
-            "baseColorTexture" : 
-            {
-               "index" : 1,
-               "texCoord" : 0
-            },
-            "metallicFactor" : 0,
-            "roughnessFactor" : 1
-         }
-      },
-      {
-         "pbrMetallicRoughness" : 
-         {
-            "baseColorFactor" : [ 0.25, 1, 1, 1 ],
             "metallicFactor" : 0,
             "roughnessFactor" : 1
          }
@@ -345,19 +448,6 @@
          "pbrMetallicRoughness" : 
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
-            "baseColorTexture" : 
-            {
-               "index" : 2,
-               "texCoord" : 0
-            },
-            "metallicFactor" : 0,
-            "roughnessFactor" : 1
-         }
-      },
-      {
-         "pbrMetallicRoughness" : 
-         {
-            "baseColorFactor" : [ 0.25, 1, 0.25, 1 ],
             "metallicFactor" : 0,
             "roughnessFactor" : 1
          }
@@ -366,19 +456,6 @@
          "pbrMetallicRoughness" : 
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
-            "baseColorTexture" : 
-            {
-               "index" : 3,
-               "texCoord" : 0
-            },
-            "metallicFactor" : 0,
-            "roughnessFactor" : 1
-         }
-      },
-      {
-         "pbrMetallicRoughness" : 
-         {
-            "baseColorFactor" : [ 1, 1, 0.25, 1 ],
             "metallicFactor" : 0,
             "roughnessFactor" : 1
          }
@@ -387,19 +464,6 @@
          "pbrMetallicRoughness" : 
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
-            "baseColorTexture" : 
-            {
-               "index" : 4,
-               "texCoord" : 0
-            },
-            "metallicFactor" : 0,
-            "roughnessFactor" : 1
-         }
-      },
-      {
-         "pbrMetallicRoughness" : 
-         {
-            "baseColorFactor" : [ 1, 0.25, 0.25, 1 ],
             "metallicFactor" : 0,
             "roughnessFactor" : 1
          }
@@ -408,11 +472,46 @@
          "pbrMetallicRoughness" : 
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
-            "baseColorTexture" : 
-            {
-               "index" : 5,
-               "texCoord" : 0
-            },
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 1, 1, 1, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 1, 1, 1, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 1, 1, 1, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 1, 1, 1, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 1, 1, 1, 1 ],
             "metallicFactor" : 0,
             "roughnessFactor" : 1
          }
@@ -716,78 +815,12 @@
          "name" : "Renderer Node"
       }
    ],
-   "samplers" : 
-   [
-      {
-         "magFilter" : 9729,
-         "minFilter" : 9729,
-         "wrapS" : 33071,
-         "wrapT" : 33071
-      },
-      {
-         "magFilter" : 9729,
-         "minFilter" : 9729,
-         "wrapS" : 33071,
-         "wrapT" : 33071
-      },
-      {
-         "magFilter" : 9729,
-         "minFilter" : 9729,
-         "wrapS" : 33071,
-         "wrapT" : 33071
-      },
-      {
-         "magFilter" : 9729,
-         "minFilter" : 9729,
-         "wrapS" : 33071,
-         "wrapT" : 33071
-      },
-      {
-         "magFilter" : 9729,
-         "minFilter" : 9729,
-         "wrapS" : 33071,
-         "wrapT" : 33071
-      },
-      {
-         "magFilter" : 9729,
-         "minFilter" : 9729,
-         "wrapS" : 33071,
-         "wrapT" : 33071
-      }
-   ],
    "scene" : 0,
    "scenes" : 
    [
       {
          "name" : "Layer 0",
          "nodes" : [ 12 ]
-      }
-   ],
-   "textures" : 
-   [
-      {
-         "sampler" : 0,
-         "source" : 0
-      },
-      {
-         "sampler" : 1,
-         "source" : 1
-      },
-      {
-         "sampler" : 2,
-         "source" : 2
-      },
-      {
-         "sampler" : 3,
-         "source" : 3
-      },
-      {
-         "sampler" : 4,
-         "source" : 4
-      },
-      {
-         "sampler" : 5,
-         "source" : 5
       }
    ]
 }

--- a/geometry/render_gltf_client/test/test_label_scene.gltf
+++ b/geometry/render_gltf_client/test/test_label_scene.gltf
@@ -1,0 +1,826 @@
+{
+   "accessors" : 
+   [
+      {
+         "bufferView" : 0,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 2601,
+         "max" : [ 0.05000000074505806, 0.049901336431503296, 0.05000000074505806 ],
+         "min" : [ -0.05000000074505806, -0.049901336431503296, -0.05000000074505806 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 1,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 2601,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 2,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 15000,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 3,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 2601,
+         "max" : [ 0.05000000074505806, 0.049901336431503296, 0.05000000074505806 ],
+         "min" : [ -0.05000000074505806, -0.049901336431503296, -0.05000000074505806 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 4,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 2601,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 5,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 15000,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 6,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 2601,
+         "max" : [ 0.05000000074505806, 0.024950668215751648, 0.037500001490116119 ],
+         "min" : [ -0.05000000074505806, -0.024950668215751648, -0.037500001490116119 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 7,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 2601,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 8,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 15000,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 9,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 2601,
+         "max" : [ 0.05000000074505806, 0.024950668215751648, 0.037500001490116119 ],
+         "min" : [ -0.05000000074505806, -0.024950668215751648, -0.037500001490116119 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 10,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 2601,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 11,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 15000,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 12,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 200,
+         "max" : [ 0.05000000074505806, 0.049901336431503296, 0.05000000074505806 ],
+         "min" : [ -0.05000000074505806, -0.049901336431503296, -0.05000000074505806 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 13,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 200,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 14,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 588,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 15,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 200,
+         "max" : [ 0.05000000074505806, 0.049901336431503296, 0.05000000074505806 ],
+         "min" : [ -0.05000000074505806, -0.049901336431503296, -0.05000000074505806 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 16,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 200,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 17,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 588,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 18,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 4804,
+         "max" : [ 0.049974311143159866, 0.05000000074505806, 0.099948637187480927 ],
+         "min" : [ -0.049974311143159866, -0.05000000074505806, -0.099948637187480927 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 19,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 28812,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 20,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 4804,
+         "max" : [ 0.049974311143159866, 0.05000000074505806, 0.099948637187480927 ],
+         "min" : [ -0.049974311143159866, -0.05000000074505806, -0.099948637187480927 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 21,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 28812,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 22,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 24,
+         "max" : [ 0.050000000000000003, 0.037499999999999999, 0.025000000000000001 ],
+         "min" : [ -0.050000000000000003, -0.037499999999999999, -0.025000000000000001 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 23,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 24,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 24,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 36,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 25,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 24,
+         "max" : [ 0.050000000000000003, 0.037499999999999999, 0.025000000000000001 ],
+         "min" : [ -0.050000000000000003, -0.037499999999999999, -0.025000000000000001 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 26,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 24,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 27,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 36,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 28,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 49152,
+         "max" : [ 0.033259999006986618, 0.0098120002076029778, 0.18814800679683685 ],
+         "min" : [ -0.063937999308109283, -0.056809000670909882, -0.0031530000269412994 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 29,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 49152,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 30,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 49152,
+         "type" : "SCALAR"
+      }
+   ],
+   "asset" : 
+   {
+      "generator" : "VTK",
+      "version" : "2.0"
+   },
+   "bufferViews" : 
+   [
+      {
+         "buffer" : 0,
+         "byteLength" : 31212,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 1,
+         "byteLength" : 20808,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 2,
+         "byteLength" : 60000,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 3,
+         "byteLength" : 31212,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 4,
+         "byteLength" : 20808,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 5,
+         "byteLength" : 60000,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 6,
+         "byteLength" : 31212,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 7,
+         "byteLength" : 20808,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 8,
+         "byteLength" : 60000,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 9,
+         "byteLength" : 31212,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 10,
+         "byteLength" : 20808,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 11,
+         "byteLength" : 60000,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 12,
+         "byteLength" : 2400,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 13,
+         "byteLength" : 1600,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 14,
+         "byteLength" : 2352,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 15,
+         "byteLength" : 2400,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 16,
+         "byteLength" : 1600,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 17,
+         "byteLength" : 2352,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 18,
+         "byteLength" : 57648,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 19,
+         "byteLength" : 115248,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 20,
+         "byteLength" : 57648,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 21,
+         "byteLength" : 115248,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 22,
+         "byteLength" : 288,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 23,
+         "byteLength" : 192,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 24,
+         "byteLength" : 144,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 25,
+         "byteLength" : 288,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 26,
+         "byteLength" : 192,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 27,
+         "byteLength" : 144,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 28,
+         "byteLength" : 589824,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 29,
+         "byteLength" : 393216,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 30,
+         "byteLength" : 196608,
+         "byteOffset" : 0
+      }
+   ],
+   "cameras" : 
+   [
+      {
+         "perspective" : 
+         {
+            "aspectRatio" : 1.3333333333333333,
+            "yfov" : 0.78539816339744828,
+            "zfar" : 10,
+            "znear" : 0.01
+         },
+         "type" : "perspective"
+      }
+   ],
+   "materials" : 
+   [
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 0.043137254901960784, 0, 0, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 0.039215686274509803, 0, 0, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 0.035294117647058823, 0, 0, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 0.031372549019607843, 0, 0, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 0.027450980392156862, 0, 0, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 0.023529411764705882, 0, 0, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 0.019607843137254902, 0, 0, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 0.015686274509803921, 0, 0, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 0.011764705882352941, 0, 0, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 0.0078431372549019607, 0, 0, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" : 
+         {
+            "baseColorFactor" : [ 0.0039215686274509803, 0, 0, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      }
+   ],
+   "meshes" : 
+   [
+      {
+         "name" : "mesh0",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 0,
+                  "TEXCOORD_0" : 1
+               },
+               "indices" : 2,
+               "material" : 0,
+               "mode" : 4
+            }
+         ]
+      },
+      {
+         "name" : "mesh1",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 3,
+                  "TEXCOORD_0" : 4
+               },
+               "indices" : 5,
+               "material" : 1,
+               "mode" : 4
+            }
+         ]
+      },
+      {
+         "name" : "mesh2",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 6,
+                  "TEXCOORD_0" : 7
+               },
+               "indices" : 8,
+               "material" : 2,
+               "mode" : 4
+            }
+         ]
+      },
+      {
+         "name" : "mesh3",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 9,
+                  "TEXCOORD_0" : 10
+               },
+               "indices" : 11,
+               "material" : 3,
+               "mode" : 4
+            }
+         ]
+      },
+      {
+         "name" : "mesh4",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 12,
+                  "TEXCOORD_0" : 13
+               },
+               "indices" : 14,
+               "material" : 4,
+               "mode" : 4
+            }
+         ]
+      },
+      {
+         "name" : "mesh5",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 15,
+                  "TEXCOORD_0" : 16
+               },
+               "indices" : 17,
+               "material" : 5,
+               "mode" : 4
+            }
+         ]
+      },
+      {
+         "name" : "mesh6",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 18
+               },
+               "indices" : 19,
+               "material" : 6,
+               "mode" : 4
+            }
+         ]
+      },
+      {
+         "name" : "mesh7",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 20
+               },
+               "indices" : 21,
+               "material" : 7,
+               "mode" : 4
+            }
+         ]
+      },
+      {
+         "name" : "mesh8",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 22,
+                  "TEXCOORD_0" : 23
+               },
+               "indices" : 24,
+               "material" : 8,
+               "mode" : 4
+            }
+         ]
+      },
+      {
+         "name" : "mesh9",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 25,
+                  "TEXCOORD_0" : 26
+               },
+               "indices" : 27,
+               "material" : 9,
+               "mode" : 4
+            }
+         ]
+      },
+      {
+         "name" : "mesh10",
+         "primitives" : 
+         [
+            {
+               "attributes" : 
+               {
+                  "POSITION" : 28,
+                  "TEXCOORD_0" : 29
+               },
+               "indices" : 30,
+               "material" : 10,
+               "mode" : 4
+            }
+         ]
+      }
+   ],
+   "nodes" : 
+   [
+      {
+         "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -0.20000000000000001, 0.25, 0, 1 ],
+         "mesh" : 0,
+         "name" : "mesh0"
+      },
+      {
+         "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -0.20000000000000001, -0.25, 0, 1 ],
+         "mesh" : 1,
+         "name" : "mesh1"
+      },
+      {
+         "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -0.050000000000000003, 0.25, 0, 1 ],
+         "mesh" : 2,
+         "name" : "mesh2"
+      },
+      {
+         "matrix" : 
+         [
+            1,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            -0.050000000000000003,
+            -0.25,
+            0,
+            1
+         ],
+         "mesh" : 3,
+         "name" : "mesh3"
+      },
+      {
+         "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0.10000000000000001, 0.25, 0, 1 ],
+         "mesh" : 4,
+         "name" : "mesh4"
+      },
+      {
+         "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0.10000000000000001, -0.25, 0, 1 ],
+         "mesh" : 5,
+         "name" : "mesh5"
+      },
+      {
+         "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0.25, 0.25, 0, 1 ],
+         "mesh" : 6,
+         "name" : "mesh6"
+      },
+      {
+         "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0.25, -0.25, 0, 1 ],
+         "mesh" : 7,
+         "name" : "mesh7"
+      },
+      {
+         "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0.40000000000000002, 0.25, 0, 1 ],
+         "mesh" : 8,
+         "name" : "mesh8"
+      },
+      {
+         "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0.40000000000000002, -0.25, 0, 1 ],
+         "mesh" : 9,
+         "name" : "mesh9"
+      },
+      {
+         "matrix" : 
+         [
+            0.38941834230865052,
+            -0.92106099400288499,
+            -1.0225831226261361e-16,
+            0,
+            0.92106070196376555,
+            0.38941821883649125,
+            -0.0007963267107332692,
+            0,
+            0.00073346547173895604,
+            0.00031010422762989276,
+            0.99999968293183472,
+            0,
+            0.02700000000000001,
+            -0.0048999999999999972,
+            -0.091999999999999998,
+            1
+         ],
+         "mesh" : 10,
+         "name" : "mesh10"
+      },
+      {
+         "camera" : 0,
+         "matrix" : 
+         [
+            0.00079632671073322247,
+            0.99999968293183472,
+            0,
+            0,
+            -0.58850093066037634,
+            0.00046863915896677607,
+            0.80849640381959009,
+            0,
+            0.80849614747111864,
+            -0.00064382728189329335,
+            0.58850111725534593,
+            0,
+            0.80000000000000016,
+            3.2742905609062234e-17,
+            0.50000000000000011,
+            1
+         ],
+         "name" : "Camera Node"
+      },
+      {
+         "children" : [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ],
+         "name" : "Renderer Node"
+      }
+   ],
+   "scene" : 0,
+   "scenes" : 
+   [
+      {
+         "name" : "Layer 0",
+         "nodes" : [ 12 ]
+      }
+   ]
+}


### PR DESCRIPTION
The core reason for the macOS CI failure is the nodes, e.g., meshes and materials, are ordered differently across platforms (Ubuntu and macOS). This PR adds functions to traverse and restructure the dictionary so that all the information is aggregated to the "nodes" entry. All the order-dependent field names or indices are thus removed.

It is tested locally on an Ubuntu 20.04 and a mac M1 machine.
 
Close #18134 