### PR TITLE
[wheel] Set macOS deployment target explicitly

### DIFF
--- a/tools/wheel/macos/build-wheel.sh
+++ b/tools/wheel/macos/build-wheel.sh
@@ -97,6 +97,8 @@ declare -a bazel_args=(
     --define NO_DREAL=ON
     --define WITH_MOSEK=ON
     --define WITH_SNOPT=ON
+    # See tools/wheel/wheel_builder/macos.py for more on this env variable.
+    --macos_minimum_os="${MACOSX_DEPLOYMENT_TARGET}"
 )
 
 bazel build "${bazel_args[@]}" //tools/wheel:strip_rpath


### PR DESCRIPTION
Xcode may arbitrarily change the default MACOSX_DEPLOYMENT_TARGET meaning that the final artifact may be for a newer macOS than the one building the wheel.  To avoid this, set the relevant environment variables and command line flags for all tools involved.

This first surfaced during a [CI update that included bumping Xcode from 14.0.1 to 14.1](https://drakedevelopers.slack.com/archives/C270MN28G/p1669900240408939).  Current CI is using 14.0.1, this fix should pass the related wheel builds with the same results.  I am also doing a full wheel rebuild locally on a macmini with Xcode 14.1 to confirm (ETA 1hr).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18408)
<!-- Reviewable:end -->
