### PR TITLE
Enhance ApplyVisualizationConfig with meshcat support

### DIFF
--- a/bindings/pydrake/visualization/_model_visualizer.py
+++ b/bindings/pydrake/visualization/_model_visualizer.py
@@ -192,29 +192,23 @@ class ModelVisualizer:
 
         self._plant.Finalize()
 
-        # Connect to drake_visualizer or meldis. Meldis provides simultaneous
-        # visualization of illustration and proximity geometry.
-        ApplyVisualizationConfig(
-            config=VisualizationConfig(
-                publish_contacts=self._publish_contacts),
-            plant=self._plant,
-            scene_graph=self._scene_graph,
-            builder=self._builder)
-
         # (Re-)initialize the meshcat instance, creating one if needed.
         self.meshcat()
         self._meshcat.Delete()
         self._meshcat.DeleteAddedControls()
 
-        # Connect to MeshCat for visualizing and interfacing w/ widgets.
-        # Add two visualizers: one to publish the "illustration" geometry and
-        # another to publish the "collision" geometry.
-        MeshcatVisualizer.AddToBuilder(
-            self._builder, self._scene_graph, self._meshcat,
-            MeshcatVisualizerParams(role=Role.kIllustration, prefix="visual"))
-        MeshcatVisualizer.AddToBuilder(
-            self._builder, self._scene_graph, self._meshcat,
-            MeshcatVisualizerParams(role=Role.kProximity, prefix="collision"))
+        # Connect to drake_visualizer, meldis, and meshcat.
+        # Meldis and meshcat provide simultaneous visualization of
+        # illustration and proximity geometry.
+        ApplyVisualizationConfig(
+            config=VisualizationConfig(
+                publish_contacts=self._publish_contacts),
+            plant=self._plant,
+            scene_graph=self._scene_graph,
+            builder=self._builder,
+            meshcat=self._meshcat)
+
+        # Add joint sliders to meshcat.
         self._sliders = self._builder.AddNamedSystem(
             "joint_sliders", JointSliders(meshcat=self._meshcat,
                                           plant=self._plant))
@@ -241,9 +235,9 @@ class ModelVisualizer:
         # Publish draw messages with current state.
         self._diagram.ForcedPublish(self._context)
 
-        # Disable the collision geometry at the start; it can be enabled by
+        # Disable the proximity geometry at the start; it can be enabled by
         # the checkbox in the meshcat controls.
-        self._meshcat.SetProperty("collision", "visible", False)
+        self._meshcat.SetProperty("proximity", "visible", False)
 
         self._builder = None
         self._scene_graph = None

--- a/bindings/pydrake/visualization/visualization_py_config.cc
+++ b/bindings/pydrake/visualization/visualization_py_config.cc
@@ -31,7 +31,8 @@ void DefineVisualizationConfig(py::module m) {
       .def("ApplyVisualizationConfig", &ApplyVisualizationConfig,
           py::arg("config"), py::arg("builder"), py::arg("lcm_buses") = nullptr,
           py::arg("plant") = nullptr, py::arg("scene_graph") = nullptr,
-          py::arg("lcm") = nullptr, doc.ApplyVisualizationConfig.doc)
+          py::arg("meshcat") = nullptr, py::arg("lcm") = nullptr,
+          doc.ApplyVisualizationConfig.doc)
       .def("AddDefaultVisualization", &AddDefaultVisualization,
           py::arg("builder"), doc.AddDefaultVisualization.doc);
 }

--- a/tutorials/authoring_multibody_simulation.ipynb
+++ b/tutorials/authoring_multibody_simulation.ipynb
@@ -88,7 +88,7 @@
     "\n",
     "Drake provides a `ModelVisualizer` class to visualize models interactively. This class will help as we start to produce our own robot description files, or port description files over from another simulator. We'll show examples in the cells below, using a couple of pre-existing models provided by Drake.\n",
     "\n",
-    "After running each of the two example cells, switch to the MeshCat tab to see the robot. Be sure to check out both the visual and collision geometries using the MeshCat control panel. Click **Open Controls** to unfold the control panel.  The geometry checkboxes are under the **Scene / drake** menu. Try adjusting the sliding bars to observe the kinematics of the robot."
+    "After running each of the two example cells, switch to the MeshCat tab to see the robot. Be sure to check out both the \"illustration\" and \"proximity\" geometries (the Drake names for visual and collision) using the MeshCat control panel. Click **Open Controls** to unfold the control panel.  The geometry checkboxes are under the **Scene / drake** menu. Try adjusting the sliding bars to observe the kinematics of the robot."
    ]
   },
   {
@@ -227,7 +227,7 @@
    "source": [
     "### Visual and collision geometry\n",
     "\n",
-    "In the KUKA arm example, if you toggle the `drake/collision` checkbox in the MeshCat control panel a couple of times, you should see white boxes enveloping the KUKA arm appear and disappear. Those are the collision geometries defined in `iiwa7_with_box_collision.sdf` that are usually consumed by a motion planning or collision checking module when running the simulation.\n",
+    "In the KUKA arm example, if you toggle the `drake/proximity` checkbox in the MeshCat control panel a couple of times, you should see white boxes enveloping the KUKA arm appear and disappear. Those are the collision geometries defined in `iiwa7_with_box_collision.sdf` that are usually consumed by a motion planning or collision checking module when running the simulation.\n",
     "\n",
     "Even though we can use the same mesh to represent both the visual and collision geometry, approximating a complex mesh, like the KUKA arm, by primitive shapes can reduce the computation enormously. It's easier to check whether two cylinders collide than two irregular cylinder-like meshes. For that reason, we tend to load mesh files as the visual geometry but utilize various primitives as the collision geometry.\n",
     "\n",

--- a/visualization/BUILD.bazel
+++ b/visualization/BUILD.bazel
@@ -26,6 +26,9 @@ drake_cc_library(
     deps = [
         "//common:name_value",
         "//geometry:drake_visualizer_params",
+        "//geometry:meshcat",
+        "//geometry:meshcat_visualizer",
+        "//geometry:meshcat_visualizer_params",
         "//geometry:rgba",
         "@eigen",
     ],

--- a/visualization/test/visualization_config_functions_test.cc
+++ b/visualization/test/visualization_config_functions_test.cc
@@ -4,10 +4,13 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/meshcat.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/systems/analysis/simulator.h"
 
 using drake::geometry::DrakeVisualizerParams;
+using drake::geometry::Meshcat;
+using drake::geometry::MeshcatVisualizerParams;
 using drake::geometry::Rgba;
 using drake::geometry::Role;
 using drake::geometry::SceneGraph;
@@ -29,29 +32,52 @@ namespace {
 // the Params, or whether we agree they can differ (and remove the test).
 GTEST_TEST(VisualizationConfigTest, Defaults) {
   const VisualizationConfig config;
-  const DrakeVisualizerParams params;
-  EXPECT_EQ(config.publish_period, params.publish_period);
-  EXPECT_EQ(config.default_illustration_color, params.default_color);
+  const DrakeVisualizerParams drake_params;
+  const DrakeVisualizerParams meshcat_params;
+  EXPECT_EQ(config.publish_period, drake_params.publish_period);
+  EXPECT_EQ(config.default_illustration_color, drake_params.default_color);
+  EXPECT_EQ(config.publish_period, meshcat_params.publish_period);
+  EXPECT_EQ(config.default_illustration_color, meshcat_params.default_color);
 }
 
 // Tests the mapping from default schema data to geometry params.
 GTEST_TEST(VisualizationConfigFunctionsTest, ParamConversionDefault) {
   const VisualizationConfig config;
-  const std::vector<DrakeVisualizerParams> params =
-      ConvertVisualizationConfigToParams(config);
-  ASSERT_EQ(params.size(), 2);
 
-  EXPECT_EQ(params.at(0).role, Role::kIllustration);
-  EXPECT_EQ(params.at(0).default_color, config.default_illustration_color);
-  EXPECT_FALSE(params.at(0).show_hydroelastic);
-  EXPECT_FALSE(params.at(0).use_role_channel_suffix);
-  EXPECT_EQ(params.at(0).publish_period, config.publish_period);
+  const std::vector<DrakeVisualizerParams> drake_params =
+      ConvertVisualizationConfigToDrakeParams(config);
+  ASSERT_EQ(drake_params.size(), 2);
 
-  EXPECT_EQ(params.at(1).role, Role::kProximity);
-  EXPECT_EQ(params.at(1).default_color, config.default_proximity_color);
-  EXPECT_TRUE(params.at(1).show_hydroelastic);
-  EXPECT_TRUE(params.at(1).use_role_channel_suffix);
-  EXPECT_EQ(params.at(1).publish_period, config.publish_period);
+  EXPECT_EQ(drake_params.at(0).role, Role::kIllustration);
+  EXPECT_EQ(drake_params.at(0).default_color,
+            config.default_illustration_color);
+  EXPECT_FALSE(drake_params.at(0).show_hydroelastic);
+  EXPECT_FALSE(drake_params.at(0).use_role_channel_suffix);
+  EXPECT_EQ(drake_params.at(0).publish_period, config.publish_period);
+
+  EXPECT_EQ(drake_params.at(1).role, Role::kProximity);
+  EXPECT_EQ(drake_params.at(1).default_color, config.default_proximity_color);
+  EXPECT_TRUE(drake_params.at(1).show_hydroelastic);
+  EXPECT_TRUE(drake_params.at(1).use_role_channel_suffix);
+  EXPECT_EQ(drake_params.at(1).publish_period, config.publish_period);
+
+  const std::vector<MeshcatVisualizerParams> meshcat_params =
+      ConvertVisualizationConfigToMeshcatParams(config);
+  ASSERT_EQ(meshcat_params.size(), 2);
+
+  EXPECT_EQ(meshcat_params.at(0).role, Role::kIllustration);
+  EXPECT_EQ(meshcat_params.at(0).publish_period, config.publish_period);
+  EXPECT_EQ(meshcat_params.at(0).default_color,
+            config.default_illustration_color);
+  EXPECT_EQ(meshcat_params.at(0).delete_on_initialization_event,
+            config.delete_on_initialization_event);
+
+  EXPECT_EQ(meshcat_params.at(1).role, Role::kProximity);
+  EXPECT_EQ(meshcat_params.at(1).publish_period, config.publish_period);
+  EXPECT_EQ(meshcat_params.at(1).default_color,
+            config.default_proximity_color);
+  EXPECT_EQ(meshcat_params.at(1).delete_on_initialization_event,
+            config.delete_on_initialization_event);
 }
 
 // Tests the mapping from non-default schema data to geometry params.
@@ -60,13 +86,21 @@ GTEST_TEST(VisualizationConfigFunctionsTest, ParamConversionSpecial) {
   config.publish_period = 0.5;
   config.publish_proximity = false;
   config.default_illustration_color = Rgba(0.25, 0.25, 0.25, 0.25);
-  const std::vector<DrakeVisualizerParams> params =
-      ConvertVisualizationConfigToParams(config);
-  ASSERT_EQ(params.size(), 1);
-  EXPECT_EQ(params.at(0).role, Role::kIllustration);
-  EXPECT_FALSE(params.at(0).show_hydroelastic);
-  EXPECT_EQ(params.at(0).publish_period, 0.5);
-  EXPECT_EQ(params.at(0).default_color, Rgba(0.25, 0.25, 0.25, 0.25));
+
+  const std::vector<DrakeVisualizerParams> drake_params =
+      ConvertVisualizationConfigToDrakeParams(config);
+  ASSERT_EQ(drake_params.size(), 1);
+  EXPECT_EQ(drake_params.at(0).role, Role::kIllustration);
+  EXPECT_FALSE(drake_params.at(0).show_hydroelastic);
+  EXPECT_EQ(drake_params.at(0).publish_period, 0.5);
+  EXPECT_EQ(drake_params.at(0).default_color, Rgba(0.25, 0.25, 0.25, 0.25));
+
+  const std::vector<MeshcatVisualizerParams> meshcat_params =
+      ConvertVisualizationConfigToMeshcatParams(config);
+  ASSERT_EQ(meshcat_params.size(), 1);
+  EXPECT_EQ(meshcat_params.at(0).role, Role::kIllustration);
+  EXPECT_EQ(meshcat_params.at(0).publish_period, 0.5);
+  EXPECT_EQ(meshcat_params.at(0).default_color, Rgba(0.25, 0.25, 0.25, 0.25));
 }
 
 // Tests everything disabled.
@@ -74,9 +108,14 @@ GTEST_TEST(VisualizationConfigFunctionsTest, ParamConversionAllDisabled) {
   VisualizationConfig config;
   config.publish_illustration = false;
   config.publish_proximity = false;
-  const std::vector<DrakeVisualizerParams> params =
-      ConvertVisualizationConfigToParams(config);
-  EXPECT_EQ(params.size(), 0);
+
+  const std::vector<DrakeVisualizerParams> drake_params =
+      ConvertVisualizationConfigToDrakeParams(config);
+  EXPECT_EQ(drake_params.size(), 0);
+
+  const std::vector<MeshcatVisualizerParams> meshcat_params =
+      ConvertVisualizationConfigToMeshcatParams(config);
+  EXPECT_EQ(meshcat_params.size(), 0);
 }
 
 // Overall acceptance test with everything enabled.
@@ -96,8 +135,11 @@ GTEST_TEST(VisualizationConfigFunctionsTest, ApplyDefault) {
   DiagramBuilder<double> builder;
   auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.0);
   plant.Finalize();
+  // Check that we can pass an existing meshcat.
+  std::shared_ptr<Meshcat> meshcat = std::make_shared<Meshcat>();
   const VisualizationConfig config;
-  ApplyVisualizationConfig(config, &builder, &lcm_buses, &plant, &scene_graph);
+  ApplyVisualizationConfig(config, &builder, &lcm_buses, &plant, &scene_graph,
+                           meshcat);
   Simulator<double> simulator(builder.Build());
 
   // Simulate for a moment and make sure everything showed up.
@@ -129,7 +171,10 @@ GTEST_TEST(VisualizationConfigFunctionsTest, ApplyNothing) {
   DiagramBuilder<double> builder;
   auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.0);
   plant.Finalize();
-  ApplyVisualizationConfig(config, &builder, &lcm_buses, &plant, &scene_graph);
+  // Check that we can pass an existing meshcat.
+  std::shared_ptr<Meshcat> meshcat = std::make_shared<Meshcat>();
+  ApplyVisualizationConfig(config, &builder, &lcm_buses, &plant, &scene_graph,
+                           meshcat);
   Simulator<double> simulator(builder.Build());
 
   // Simulate for a moment and make sure nothing showed up.

--- a/visualization/visualization_config.h
+++ b/visualization/visualization_config.h
@@ -30,6 +30,8 @@ struct VisualizationConfig {
     a->Visit(DRAKE_NVP(publish_proximity));
     a->Visit(DRAKE_NVP(default_proximity_color));
     a->Visit(DRAKE_NVP(publish_contacts));
+    a->Visit(DRAKE_NVP(enable_meshcat_creation));
+    a->Visit(DRAKE_NVP(delete_on_initialization_event));
   }
 
   /** Which LCM URL to use.
@@ -58,6 +60,14 @@ struct VisualizationConfig {
 
   /** Whether to show contact forces. */
   bool publish_contacts{true};
+
+  /** Whether to create a Meshcat object if needed. */
+  bool enable_meshcat_creation{true};
+
+  /** Determines whether to send a Meshcat::Delete() messages to the Meshcat
+   object (if any) on an initialization event to remove any visualizations,
+   e.g., from a previous simulation, to . */
+  bool delete_on_initialization_event{true};
 };
 
 }  // namespace visualization

--- a/visualization/visualization_config_functions.cc
+++ b/visualization/visualization_config_functions.cc
@@ -1,10 +1,10 @@
 #include "drake/visualization/visualization_config_functions.h"
 
-#include <memory>
 #include <stdexcept>
 #include <string>
 
 #include "drake/geometry/drake_visualizer.h"
+#include "drake/geometry/meshcat_visualizer.h"
 #include "drake/multibody/plant/contact_results_to_lcm.h"
 #include "drake/systems/lcm/lcm_config_functions.h"
 
@@ -14,6 +14,8 @@ namespace {
 
 using geometry::DrakeVisualizer;
 using geometry::DrakeVisualizerParams;
+using geometry::MeshcatVisualizer;
+using geometry::MeshcatVisualizerParams;
 using geometry::Rgba;
 using geometry::Role;
 using geometry::SceneGraph;
@@ -27,14 +29,15 @@ using systems::lcm::LcmBuses;
 void ApplyVisualizationConfigImpl(
     const VisualizationConfig& config,
     DrakeLcmInterface* lcm,
+    std::shared_ptr<geometry::Meshcat> meshcat,
     const MultibodyPlant<double>& plant,
     const SceneGraph<double>& scene_graph,
     DiagramBuilder<double>* builder) {
   // This is required due to ConnectContactResultsToDrakeVisualizer().
   DRAKE_THROW_UNLESS(plant.is_finalized());
-  const std::vector<DrakeVisualizerParams> all_params =
-      internal::ConvertVisualizationConfigToParams(config);
-  for (const DrakeVisualizerParams& params : all_params) {
+  const std::vector<DrakeVisualizerParams> all_drake_params =
+      internal::ConvertVisualizationConfigToDrakeParams(config);
+  for (const DrakeVisualizerParams& params : all_drake_params) {
     // TODO(jwnimmer-tri) At the moment, meldis cannot yet display hydroelastic
     // geometry. So long as that's true, we should not enable it.
     DrakeVisualizerParams oopsie = params;
@@ -43,6 +46,19 @@ void ApplyVisualizationConfigImpl(
   }
   if (config.publish_contacts) {
     ConnectContactResultsToDrakeVisualizer(builder, plant, scene_graph, lcm);
+  }
+
+  if (meshcat == nullptr && config.enable_meshcat_creation) {
+    meshcat = std::make_shared<geometry::Meshcat>();
+  }
+
+  if (meshcat != nullptr) {
+    const std::vector<MeshcatVisualizerParams> all_meshcat_params =
+        internal::ConvertVisualizationConfigToMeshcatParams(config);
+    for (const MeshcatVisualizerParams& params : all_meshcat_params) {
+      MeshcatVisualizer<double>::AddToBuilder(
+        builder, scene_graph, meshcat, params);
+    }
   }
 }
 
@@ -54,6 +70,7 @@ void ApplyVisualizationConfig(
     const LcmBuses* lcm_buses,
     const MultibodyPlant<double>* plant,
     const SceneGraph<double>* scene_graph,
+    std::shared_ptr<geometry::Meshcat> meshcat,
     DrakeLcmInterface* lcm) {
   DRAKE_THROW_UNLESS(builder != nullptr);
   lcm = FindOrCreateLcmBus(
@@ -72,7 +89,8 @@ void ApplyVisualizationConfig(
     scene_graph = &builder->GetDowncastSubsystemByName<SceneGraph>(
         "scene_graph");
   }
-  ApplyVisualizationConfigImpl(config, lcm, *plant, *scene_graph, builder);
+  ApplyVisualizationConfigImpl(
+    config, lcm, meshcat, *plant, *scene_graph, builder);
 }
 
 void AddDefaultVisualization(DiagramBuilder<double>* builder) {
@@ -82,7 +100,7 @@ void AddDefaultVisualization(DiagramBuilder<double>* builder) {
 namespace internal {
 
 std::vector<DrakeVisualizerParams>
-ConvertVisualizationConfigToParams(
+ConvertVisualizationConfigToDrakeParams(
     const VisualizationConfig& config) {
   std::vector<DrakeVisualizerParams> result;
 
@@ -101,6 +119,36 @@ ConvertVisualizationConfigToParams(
     proximity.default_color = config.default_proximity_color;
     proximity.show_hydroelastic = true;
     proximity.use_role_channel_suffix = true;
+    result.push_back(proximity);
+  }
+
+  return result;
+}
+
+std::vector<MeshcatVisualizerParams>
+ConvertVisualizationConfigToMeshcatParams(
+    const VisualizationConfig& config) {
+  std::vector<MeshcatVisualizerParams> result;
+
+  if (config.publish_illustration) {
+    MeshcatVisualizerParams illustration;
+    illustration.role = Role::kIllustration;
+    illustration.publish_period = config.publish_period;
+    illustration.default_color = config.default_illustration_color;
+    illustration.prefix = std::string("illustration");
+    illustration.delete_on_initialization_event =
+        config.delete_on_initialization_event;
+    result.push_back(illustration);
+  }
+
+  if (config.publish_proximity) {
+    MeshcatVisualizerParams proximity;
+    proximity.role = Role::kProximity;
+    proximity.publish_period = config.publish_period;
+    proximity.default_color = config.default_proximity_color;
+    proximity.prefix = std::string("proximity");
+    proximity.delete_on_initialization_event =
+        config.delete_on_initialization_event;
     result.push_back(proximity);
   }
 

--- a/visualization/visualization_config_functions.h
+++ b/visualization/visualization_config_functions.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "drake/geometry/drake_visualizer_params.h"
+#include "drake/geometry/meshcat.h"
+#include "drake/geometry/meshcat_visualizer_params.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -63,6 +66,10 @@ When provided, it must be a System that's been added to the the given `builder`.
 When not provided, visualizes the system named "scene_graph" in the given
 `builder`.
 
+@param[in] meshcat (Optional) A Meshcat object for visualization message
+publication. When not provided, a Meshcat object will be created unless
+`config.enable_meshcat_creation` is set to false.
+
 @param[in] lcm (Optional) The LCM interface used for visualization message
 publication. When not provided, uses the `config.lcm_bus` value to look up
 the appropriate interface from `lcm_buses`.
@@ -89,6 +96,7 @@ void ApplyVisualizationConfig(
     const systems::lcm::LcmBuses* lcm_buses = nullptr,
     const multibody::MultibodyPlant<double>* plant = nullptr,
     const geometry::SceneGraph<double>* scene_graph = nullptr,
+    std::shared_ptr<geometry::Meshcat> meshcat = nullptr,
     lcm::DrakeLcmInterface* lcm = nullptr);
 
 /** Adds LCM visualization publishers to communicate to drake_visualizer
@@ -128,7 +136,11 @@ namespace internal {
 
 // (For unit testing only.)
 std::vector<geometry::DrakeVisualizerParams>
-ConvertVisualizationConfigToParams(const VisualizationConfig&);
+ConvertVisualizationConfigToDrakeParams(const VisualizationConfig&);
+
+// (For unit testing only.)
+std::vector<geometry::MeshcatVisualizerParams>
+ConvertVisualizationConfigToMeshcatParams(const VisualizationConfig&);
 
 }  // namespace internal
 }  // namespace visualization


### PR DESCRIPTION
Enhance ApplyVisualizationConfig to accept or create a meshcat instance, and imbue that meshcat instance with support for both illustration and proximity geometry.

Update ModelVisualizer to utilize this dual geometry support, and tweak a tutorial which referred to the old names (visual/collision).