### PR TITLE
Allow pressing Escape to stop ModelVisualizer

### DIFF
--- a/bindings/pydrake/visualization/_model_visualizer.py
+++ b/bindings/pydrake/visualization/_model_visualizer.py
@@ -286,10 +286,10 @@ class ModelVisualizer:
         # Wait for the user to cancel us.
         button_name = "Stop Running"
         if not loop_once:
-            print(f"Use Ctrl-C or click '{button_name}' to quit")
+            print(f"Click '{button_name}' or press Esc to quit")
 
         try:
-            self._meshcat.AddButton(button_name)
+            self._meshcat.AddButton(button_name, "Escape")
 
             sliders_context = self._sliders.GetMyContextFromRoot(self._context)
             while True:


### PR DESCRIPTION
Also change the message that ModelVisualizer prints so that it is accurate when running in a notebook, under the theory that someone running the script from the command line will understand that they can also press Ctrl-C to quit. This brings this script more into line with JointSliders::Run.

Fixes #18348

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18411)
<!-- Reviewable:end -->
