### PR TITLE
[meshcat] Fix issue setting realtime rate display

### DIFF
--- a/geometry/meshcat.html
+++ b/geometry/meshcat.html
@@ -85,7 +85,7 @@
     function handle_message(ws_message) {
       let decoded = viewer.decode(ws_message);
       if (decoded.type == "realtime_rate") {
-        rtr = decoded.rate;
+        latestRealtimeRate = decoded.rate;
       } else if (decoded.type == "show_realtime_rate") {
         stats.dom.style.display = decoded.show ? "block" : "none";
       } else {


### PR DESCRIPTION
There is a typo in `meshcat.html` where incoming realtime rate measurements are assigned to the wrong variable. Correct variable is `latestRealtimeRate`