### PR TITLE
Fix docker naming issues with the wheel builder

### DIFF
--- a/tools/wheel/wheel_builder/linux.py
+++ b/tools/wheel/wheel_builder/linux.py
@@ -259,7 +259,7 @@ def _test_wheel(target, identifier, options):
     if options.tag_stages:
         base_image = _tagname(target, TEST, 'test')
     else:
-        base_image = test_container
+        base_image = test_image
     test_dir = os.path.join(resource_root, 'test')
 
     # Build the test base image.
@@ -309,13 +309,10 @@ def build(options):
         die('Nothing to do! (Platform and/or Python version selection '
             'resulted in an empty set of wheels)')
 
-    # Generate a unique identifier for this build, if needed.
-    if options.tag_stages:
-        identifier = None
-    else:
-        salt = os.urandom(8).hex()
-        time = datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')
-        identifier = f'{time}-{salt}'
+    # Generate a unique identifier for this build.
+    salt = os.urandom(8).hex()
+    time = datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')
+    identifier = f'{time}-{salt}'
 
     # Generate the repository source archive.
     source_tar = os.path.join(resource_root, 'image', 'drake-src.tar.xz')


### PR DESCRIPTION
Fix naming of container image used to test wheels when not tagging stages to use a properly scoped name rather than a name with no scope. Always generate a unique identifier, so that when tagging stages, the temporary image name uses the unique identifier rather than `None`.

+@svenevs for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18426)
<!-- Reviewable:end -->
