### PR TITLE
[meshcat] Hoist recording logic from MeshcatVisualizer to Meshcat

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -269,9 +269,10 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def("ResetRenderMode", &Class::ResetRenderMode,
             cls_doc.ResetRenderMode.doc)
         .def("SetTransform",
-            py::overload_cast<std::string_view, const math::RigidTransformd&>(
-                &Class::SetTransform),
+            py::overload_cast<std::string_view, const math::RigidTransformd&,
+                const std::optional<double>&>(&Class::SetTransform),
             py::arg("path"), py::arg("X_ParentPath"),
+            py::arg("time_in_recording") = std::nullopt,
             cls_doc.SetTransform.doc_RigidTransform)
         .def("SetTransform",
             py::overload_cast<std::string_view,
@@ -281,19 +282,23 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def("SetRealtimeRate", &Class::SetRealtimeRate, py::arg("rate"),
             cls_doc.SetRealtimeRate.doc)
         .def("SetProperty",
-            py::overload_cast<std::string_view, std::string, bool>(
-                &Class::SetProperty),
+            py::overload_cast<std::string_view, std::string, bool,
+                const std::optional<double>&>(&Class::SetProperty),
             py::arg("path"), py::arg("property"), py::arg("value"),
+            py::arg("time_in_recording") = std::nullopt,
             cls_doc.SetProperty.doc_bool)
         .def("SetProperty",
-            py::overload_cast<std::string_view, std::string, double>(
-                &Class::SetProperty),
+            py::overload_cast<std::string_view, std::string, double,
+                const std::optional<double>&>(&Class::SetProperty),
             py::arg("path"), py::arg("property"), py::arg("value"),
+            py::arg("time_in_recording") = std::nullopt,
             cls_doc.SetProperty.doc_double)
         .def("SetProperty",
             py::overload_cast<std::string_view, std::string,
-                const std::vector<double>&>(&Class::SetProperty),
+                const std::vector<double>&, const std::optional<double>&>(
+                &Class::SetProperty),
             py::arg("path"), py::arg("property"), py::arg("value"),
+            py::arg("time_in_recording") = std::nullopt,
             cls_doc.SetProperty.doc_vector_double)
         .def("SetAnimation", &Class::SetAnimation, py::arg("animation"),
             +cls_doc.SetAnimation.doc)
@@ -319,6 +324,17 @@ void DoScalarIndependentDefinitions(py::module m) {
             cls_doc.DeleteAddedControls.doc)
         .def("GetGamepad", &Class::GetGamepad, cls_doc.GetGamepad.doc)
         .def("StaticHtml", &Class::StaticHtml, cls_doc.StaticHtml.doc)
+        .def("StartRecording", &Class::StartRecording,
+            py::arg("frames_per_second") = 32.0,
+            py::arg("set_visualizations_while_recording") = true,
+            cls_doc.StartRecording.doc)
+        .def("StopRecording", &Class::StopRecording, cls_doc.StopRecording.doc)
+        .def("PublishRecording", &Class::PublishRecording,
+            cls_doc.PublishRecording.doc)
+        .def("DeleteRecording", &Class::DeleteRecording,
+            cls_doc.DeleteRecording.doc)
+        .def("get_mutable_recording", &Class::get_mutable_recording,
+            py_rvp::reference_internal, cls_doc.get_mutable_recording.doc)
         .def("HasPath", &Class::HasPath, py::arg("path"), cls_doc.HasPath.doc);
     // Note: we intentionally do not bind the advanced methods (GetPacked...)
     // which were intended primarily for testing in C++.

--- a/bindings/pydrake/geometry/test/visualizers_test.py
+++ b/bindings/pydrake/geometry/test/visualizers_test.py
@@ -103,7 +103,9 @@ class TestGeometryVisualizers(unittest.TestCase):
         meshcat.SetObject(path="/test/box",
                           shape=mut.Box(1, 1, 1),
                           rgba=mut.Rgba(.5, .5, .5))
-        meshcat.SetTransform(path="/test/box", X_ParentPath=RigidTransform())
+        meshcat.SetTransform(path="/test/box",
+                             X_ParentPath=RigidTransform(),
+                             time_in_recording=0.2)
         meshcat.SetTransform(path="/test/box", matrix=np.eye(4))
         self.assertTrue(meshcat.HasPath("/test/box"))
         cloud = PointCloud(4)
@@ -155,11 +157,16 @@ class TestGeometryVisualizers(unittest.TestCase):
                             wireframe_line_width=2.0)
         meshcat.SetProperty(path="/Background",
                             property="visible",
-                            value=True)
+                            value=True,
+                            time_in_recording=0.2)
         meshcat.SetProperty(path="/Lights/DirectionalLight/<object>",
-                            property="intensity", value=1.0)
-        meshcat.SetProperty(path="/Background", property="top_color",
-                            value=[0, 0, 0])
+                            property="intensity",
+                            value=1.0,
+                            time_in_recording=0.2)
+        meshcat.SetProperty(path="/Background",
+                            property="top_color",
+                            value=[0, 0, 0],
+                            time_in_recording=0.2)
         meshcat.Set2dRenderMode(
             X_WC=RigidTransform(), xmin=-1, xmax=1, ymin=-1, ymax=1)
         meshcat.ResetRenderMode()
@@ -188,6 +195,14 @@ class TestGeometryVisualizers(unittest.TestCase):
         self.assertEqual(len(gamepad.axes), 0)
         meshcat.SetRealtimeRate(1.0)
         meshcat.Flush()
+
+        meshcat.StartRecording(frames_per_second=64.0,
+                               set_visualizations_while_recording=False)
+        ani = meshcat.get_mutable_recording()
+        self.assertEqual(ani.frames_per_second(), 64.0)
+        meshcat.StopRecording()
+        meshcat.PublishRecording()
+        meshcat.DeleteRecording()
 
         # PerspectiveCamera
         camera = mut.Meshcat.PerspectiveCamera(fov=80,

--- a/bindings/pydrake/multibody/meshcat_py.cc
+++ b/bindings/pydrake/multibody/meshcat_py.cc
@@ -63,7 +63,7 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def(py::init<std::shared_ptr<geometry::Meshcat>,
                  ContactVisualizerParams>(),
             py::arg("meshcat"), py::arg("params"), doc_internal)
-        .def("Update", &Class::Update, py::arg("items"));
+        .def("Update", &Class::Update, py::arg("time"), py::arg("items"));
   }
 
   // HydroelasticContactVisualizerItem (internal)
@@ -97,7 +97,7 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def(py::init<std::shared_ptr<geometry::Meshcat>,
                  ContactVisualizerParams>(),
             py::arg("meshcat"), py::arg("params"), doc_internal)
-        .def("Update", &Class::Update, py::arg("items"))
+        .def("Update", &Class::Update, py::arg("time"), py::arg("items"))
         .def("Delete", &Class::Delete);
   }
 }

--- a/bindings/pydrake/visualization/_meldis.py
+++ b/bindings/pydrake/visualization/_meldis.py
@@ -351,7 +351,7 @@ class _ContactApplet:
                 body_B=lcm_item.body2_name,
                 contact_force=lcm_item.contact_force,
                 contact_point=lcm_item.contact_point))
-        self._point_helper.Update(viz_items)
+        self._point_helper.Update(0, viz_items)
 
         # Handle hydroelastic contact pairs
         viz_items = []
@@ -366,7 +366,7 @@ class _ContactApplet:
                 p_WV=self.convert_verts(lcm_item.p_WV),
                 faces=self.convert_faces(lcm_item.poly_data),
                 pressure=lcm_item.pressure))
-        self._hydro_helper.Update(viz_items)
+        self._hydro_helper.Update(0, viz_items)
 
 
 class _PointCloudApplet:

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -2194,8 +2194,15 @@ void Meshcat::SetCamera(OrthographicCamera camera, std::string path) {
 }
 
 void Meshcat::SetTransform(std::string_view path,
-                           const RigidTransformd& X_ParentPath) {
-  impl().SetTransform(path, X_ParentPath);
+                           const RigidTransformd& X_ParentPath,
+                           const std::optional<double>& time) {
+  if (recording_ && time) {
+    animation_->SetTransform(animation_->frame(*time), std::string(path),
+                             X_ParentPath);
+  }
+  if (!recording_ || !time || set_visualizations_while_recording_) {
+    impl().SetTransform(path, X_ParentPath);
+  }
 }
 
 void Meshcat::SetTransform(std::string_view path,
@@ -2212,18 +2219,37 @@ void Meshcat::SetRealtimeRate(double rate) {
 }
 
 void Meshcat::SetProperty(std::string_view path, std::string property,
-                          bool value) {
-  impl().SetProperty(path, std::move(property), value);
+                          bool value, const std::optional<double>& time) {
+  if (recording_ && time) {
+    animation_->SetProperty(animation_->frame(*time), std::string(path),
+                            property, value);
+  }
+  if (!recording_ || !time || set_visualizations_while_recording_) {
+    impl().SetProperty(path, std::move(property), value);
+  }
 }
 
 void Meshcat::SetProperty(std::string_view path, std::string property,
-                          double value) {
-  impl().SetProperty(path, std::move(property), value);
+                          double value, const std::optional<double>& time) {
+  if (recording_ && time) {
+    animation_->SetProperty(animation_->frame(*time), std::string(path),
+                            property, value);
+  }
+  if (!recording_ || set_visualizations_while_recording_) {
+    impl().SetProperty(path, std::move(property), value);
+  }
 }
 
 void Meshcat::SetProperty(std::string_view path, std::string property,
-                          const std::vector<double>& value) {
-  impl().SetProperty(path, std::move(property), value);
+                          const std::vector<double>& value,
+                          const std::optional<double>& time) {
+  if (recording_ && time) {
+    animation_->SetProperty(animation_->frame(*time), std::string(path),
+                            property, value);
+  }
+  if (!recording_ || set_visualizations_while_recording_) {
+    impl().SetProperty(path, std::move(property), value);
+  }
 }
 
 void Meshcat::SetAnimation(const MeshcatAnimation& animation) {
@@ -2284,6 +2310,34 @@ Meshcat::Gamepad Meshcat::GetGamepad() const {
 
 std::string Meshcat::StaticHtml() {
   return impl().StaticHtml();
+}
+
+void Meshcat::StartRecording(double frames_per_second,
+                             bool set_visualizations_while_recording) {
+  animation_ = std::make_unique<MeshcatAnimation>(frames_per_second);
+  recording_ = true;
+  set_visualizations_while_recording_ = set_visualizations_while_recording;
+}
+
+void Meshcat::PublishRecording() {
+  impl().SetAnimation(*animation_);
+}
+
+void Meshcat::DeleteRecording() {
+  if (animation_) {
+    // Reset the recording.
+    double frames_per_second = animation_->frames_per_second();
+    animation_ = std::make_unique<MeshcatAnimation>(frames_per_second);
+  }
+}
+
+MeshcatAnimation& Meshcat::get_mutable_recording() {
+  if (!animation_) {
+    throw std::runtime_error(
+        "You must create a recording (via StartRecording) before calling "
+        "get_mutable_recording");
+  }
+  return *animation_;
 }
 
 bool Meshcat::HasPath(std::string_view path) const {

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -428,15 +428,20 @@ class Meshcat {
   parent path. An object's pose is the concatenation of all of the transforms
   along its path, so setting the transform of "/foo" will move the objects at
   "/foo/box1" and "/foo/robots/HAL9000".
-  @param path a "/"-delimited string indicating the path in the scene tree.
-              See @ref meshcat_path "Meshcat paths" for the semantics.
+  @param path a "/"-delimited string indicating the path in the scene tree. See
+              @ref meshcat_path "Meshcat paths" for the semantics.
   @param X_ParentPath the relative transform from the path to its immediate
-  parent.
+              parent.
+  @param time_in_recording (optional). If recording (see StartRecording()), then
+              in addition to publishing the transform to any meshcat browsers
+              immediately, this transform is saved to the current animation at
+              `time_in_recording`.
 
   @pydrake_mkdoc_identifier{RigidTransform}
   */
-  void SetTransform(std::string_view path,
-                    const math::RigidTransformd& X_ParentPath);
+  void SetTransform(
+      std::string_view path, const math::RigidTransformd& X_ParentPath,
+      const std::optional<double>& time_in_recording = std::nullopt);
 
   /** Set the homogeneous transform for a given path in the scene tree relative
   to its parent path. An object's pose is the concatenation of all of the
@@ -450,6 +455,9 @@ class Meshcat {
   Note: Prefer to use the overload which takes a RigidTransformd unless you need
   the fully parameterized homogeneous transform (which additionally allows
   scale and sheer).
+
+  Note: Meshcat does not properly support non-uniform scaling. See Drake issue
+  #18095.
 
   @pydrake_mkdoc_identifier{matrix}
   */
@@ -481,10 +489,16 @@ class Meshcat {
               See @ref meshcat_path for the semantics.
   @param property the string name of the property to set
   @param value the new value.
+  @param time_in_recording (optional). If recording (see StartRecording()), then
+              in addition to publishing the property to any meshcat browsers
+              immediately, this transform is saved to the current animation at
+              `time_in_recording`.
 
   @pydrake_mkdoc_identifier{bool}
   */
-  void SetProperty(std::string_view path, std::string property, bool value);
+  void SetProperty(
+      std::string_view path, std::string property, bool value,
+      const std::optional<double>& time_in_recording = std::nullopt);
 
   /** Sets a single named property of the object at the given path. For example,
   @verbatim
@@ -497,10 +511,16 @@ class Meshcat {
               See @ref meshcat_path for the semantics.
   @param property the string name of the property to set
   @param value the new value.
+  @param time_in_recording (optional) the time at which this property should
+              be applied, if Meshcat is current recording (see
+              StartRecording()). If Meshcat is not currently recording, then
+              this value is simply ignored.
 
   @pydrake_mkdoc_identifier{double}
   */
-  void SetProperty(std::string_view path, std::string property, double value);
+  void SetProperty(
+      std::string_view path, std::string property, double value,
+      const std::optional<double>& time_in_recording = std::nullopt);
 
   /** Sets a single named property of the object at the given path. For example,
   @verbatim
@@ -513,16 +533,26 @@ class Meshcat {
               See @ref meshcat_path for the semantics.
   @param property the string name of the property to set
   @param value the new value.
+  @param time_in_recording (optional) the time at which this property should
+              be applied, if Meshcat is current recording (see
+              StartRecording()). If Meshcat is not currently recording, then
+              this value is simply ignored.
 
   @pydrake_mkdoc_identifier{vector_double}
   */
-  void SetProperty(std::string_view path, std::string property,
-                   const std::vector<double>& value);
+  void SetProperty(
+      std::string_view path, std::string property,
+      const std::vector<double>& value,
+      const std::optional<double>& time_in_recording = std::nullopt);
 
   // TODO(russt): Support multiple animations, by name.  Currently "default" is
   // hard-coded in the meshcat javascript.
   /** Sets the MeshcatAnimation, which creates a slider interface element to
-  play/pause/rewind through a series of animation frames in the visualizer. */
+  play/pause/rewind through a series of animation frames in the visualizer.
+
+  See also StartRecording(), which records supported calls to `this` into a
+  MeshcatAnimation, and PublishRecording(), which calls SetAnimation() with the
+  recording. */
   void SetAnimation(const MeshcatAnimation& animation);
 
   /** @name Meshcat Controls
@@ -689,6 +719,50 @@ class Meshcat {
   output, because their usefulness relies on a connection to the server. */
   std::string StaticHtml();
 
+  /** Sets a flag indicating that subsequent calls to SetTransform and
+  SetProperty should also be "recorded" into a MeshcatAnimation when their
+  optional time_in_recording argument is supplied.  The data in these events
+  will be combined with any frames previously added to the animation; if the
+  same transform/property is set at the same time, then it will overwrite the
+  existing frame in the animation.
+
+  @param set_visualizations_while_recording if true, then each method will send
+  the visualization immediately to Meshcat *and* record the visualization in
+  the animation. Set to false to avoid updating the visualization during
+  recording. One exception is calls to SetObject, which will always be sent to
+  the visualizer immediately (because meshcat animations do not support
+  SetObject).
+  */
+  void StartRecording(double frames_per_second = 32.0,
+                      bool set_visualizations_while_recording = true);
+
+  /** Sets a flag to pause/stop recording.  When stopped, publish events will
+  not add frames to the animation. */
+  void StopRecording() { recording_ = false; }
+
+  /** Sends the recording to Meshcat as an animation. The published animation
+  only includes transforms and properties; the objects that they modify must be
+  sent to the visualizer separately (e.g. by calling Publish()). */
+  void PublishRecording();
+
+  /** Deletes the current animation holding the recorded frames.  Animation
+  options (autoplay, repetitions, etc) will also be reset, and any pointers
+  obtained from get_mutable_recording() will be rendered invalid. This does
+  *not* currently remove the animation from Meshcat. */
+  void DeleteRecording();
+
+  /** Returns a mutable pointer to this Meshcat's unique MeshcatAnimation
+  object, if it exists, in which the frames will be recorded. This pointer can
+  be used to set animation properties (like autoplay, the loop mode, number of
+  repetitions, etc).
+
+  The MeshcatAnimation object will only remain valid for the lifetime of `this`
+  or until DeleteRecording() is called.
+
+  @throws std::exception if meshcat does not have a recording.
+  */
+  MeshcatAnimation& get_mutable_recording();
+
   /* These remaining public methods are intended to primarily for testing. These
   calls must safely acquire the data from the websocket thread and will block
   execution waiting for that data to be acquired. They are intentionally
@@ -743,6 +817,15 @@ class Meshcat {
   // Always a non-nullptr Impl, but stored as void* to enforce that the
   // impl() accessors are always used.
   void* const impl_{};
+
+  /* MeshcatAnimation object for recording. It must be mutable to allow the set
+  methods to be otherwise const. */
+  std::unique_ptr<MeshcatAnimation> animation_;
+
+  /* Recording status.  True means that each new Publish event will record a
+  frame in the animation. */
+  bool recording_{false};
+  bool set_visualizations_while_recording_{true};
 };
 
 }  // namespace geometry

--- a/geometry/meshcat_visualizer.cc
+++ b/geometry/meshcat_visualizer.cc
@@ -19,8 +19,6 @@ MeshcatVisualizer<T>::MeshcatVisualizer(std::shared_ptr<Meshcat> meshcat,
     : systems::LeafSystem<T>(systems::SystemTypeTag<MeshcatVisualizer>{}),
       meshcat_(std::move(meshcat)),
       params_(std::move(params)),
-      animation_(
-          std::make_unique<MeshcatAnimation>(1.0 / params_.publish_period)),
       alpha_slider_name_(std::string(params_.prefix + " α")) {
   DRAKE_DEMAND(meshcat_ != nullptr);
   DRAKE_DEMAND(params_.publish_period >= 0.0);
@@ -62,13 +60,31 @@ void MeshcatVisualizer<T>::Delete() const {
 }
 
 template <typename T>
+MeshcatAnimation* MeshcatVisualizer<T>::StartRecording(
+    bool set_transforms_while_recording) {
+  meshcat_->StartRecording(1.0 / params_.publish_period,
+                            set_transforms_while_recording);
+  return &meshcat_->get_mutable_recording();
+}
+
+template <typename T>
+void MeshcatVisualizer<T>::StopRecording() {
+  meshcat_->StopRecording();
+}
+
+template <typename T>
 void MeshcatVisualizer<T>::PublishRecording() const {
-  meshcat_->SetAnimation(*animation_);
+    meshcat_->PublishRecording();
 }
 
 template <typename T>
 void MeshcatVisualizer<T>::DeleteRecording() {
-  animation_ = std::make_unique<MeshcatAnimation>(1.0 / params_.publish_period);
+  meshcat_->DeleteRecording();
+}
+
+template <typename T>
+MeshcatAnimation* MeshcatVisualizer<T>::get_mutable_recording() {
+  return &meshcat_->get_mutable_recording();
 }
 
 template <typename T>
@@ -189,14 +205,8 @@ void MeshcatVisualizer<T>::SetTransforms(
   for (const auto& [frame_id, path] : dynamic_frames_) {
     const math::RigidTransformd X_WF =
         internal::convert_to_double(query_object.GetPoseInWorld(frame_id));
-    if (!recording_ || set_transforms_while_recording_) {
-      meshcat_->SetTransform(path, X_WF);
-    }
-    if (recording_) {
-      animation_->SetTransform(
-          animation_->frame(ExtractDoubleOrThrow(context.get_time())), path,
-          X_WF);
-    }
+    meshcat_->SetTransform(path, X_WF,
+                           ExtractDoubleOrThrow(context.get_time()));
   }
 }
 

--- a/geometry/meshcat_visualizer.h
+++ b/geometry/meshcat_visualizer.h
@@ -92,15 +92,11 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
   @returns a mutable pointer to the current recording.  See
   get_mutable_recording().
   */
-  MeshcatAnimation* StartRecording(bool set_transforms_while_recording = true) {
-    recording_ = true;
-    set_transforms_while_recording_ = set_transforms_while_recording;
-    return get_mutable_recording();
-  }
+  MeshcatAnimation* StartRecording(bool set_transforms_while_recording = true);
 
   /** Sets a flag to pause/stop recording.  When stopped, publish events will
   not add frames to the animation. */
-  void StopRecording() { recording_ = false; }
+  void StopRecording();
 
   /** Sends the recording to Meshcat as an animation. The published animation
   only includes transforms and properties; the objects that they modify must be
@@ -121,8 +117,11 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
   into the same animation.
 
   The MeshcatAnimation object will only remain valid for the lifetime of `this`
-  or until DeleteRecording() is called. */
-  MeshcatAnimation* get_mutable_recording() { return animation_.get(); }
+  or until DeleteRecording() is called.
+
+  @throws std::exception if meshcat does not have a recording.
+  */
+  MeshcatAnimation* get_mutable_recording();
 
   /** Returns the QueryObject-valued input port. It should be connected to
    SceneGraph's QueryObject-valued output port. Failure to do so will cause a
@@ -218,15 +217,6 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
   shared Meshcat instance keeping track).  We may also want to allow users to
   disable the default publishing behavior (to record without visualizing
   immediately). */
-
-  /* MeshcatAnimation object for recording. It must be mutable so that frames
-   * can be added to it during Publish events. */
-  mutable std::unique_ptr<MeshcatAnimation> animation_;
-
-  /* Recording status.  True means that each new Publish event will record a
-  frame in the animation. */
-  bool recording_{false};
-  bool set_transforms_while_recording_{true};
 
   /* TODO(#16486): ideally this mutable state will go away once it is safe to
   run Meshcat multithreaded */

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -345,7 +345,7 @@ Open up your browser to the URL above.
 
     multibody::meshcat::ContactVisualizerParams cparams;
     cparams.newtons_per_meter = 60.0;
-    auto& contact = multibody::meshcat::ContactVisualizerd::AddToBuilder(
+    multibody::meshcat::ContactVisualizerd::AddToBuilder(
         &builder, plant, meshcat, std::move(cparams));
 
     auto diagram = builder.Build();
@@ -370,12 +370,10 @@ Open up your browser to the URL above.
     visualizer.StartRecording();
     simulator.AdvanceTo(4.0);
     visualizer.PublishRecording();
-    contact.Delete();
 
     std::cout
         << "The recorded simulation results should now be available as an "
-           "animation.  Use the animation GUI to confirm.  The contact "
-           "forces are not recorded (yet)."
+           "animation.  Use the animation GUI to confirm."
         << std::endl;
 
     std::cout << "[Press RETURN to continue]." << std::endl;

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -942,6 +942,123 @@ GTEST_TEST(MeshcatTest, SetAnimation) {
   })""");
 }
 
+bool has_frame(const MeshcatAnimation& animation, int frame) {
+  return animation.get_key_frame<std::vector<double>>(0, "frame", "position")
+      .has_value();
+}
+
+GTEST_TEST(MeshcatTest, Recording) {
+  Meshcat meshcat;
+  DRAKE_EXPECT_THROWS_MESSAGE(meshcat.get_mutable_recording(),
+                              ".*You must create a recording.*");
+
+  const RigidTransformd X_ParentPath{math::RollPitchYawd(.5, .26, -3),
+                                     Vector3d{.9, -2., .12}};
+  meshcat.SetTransform("frame", X_ParentPath, 0);
+  meshcat.StartRecording();
+  MeshcatAnimation* animation = &meshcat.get_mutable_recording();
+  // No transforms have been published since recording started.
+  EXPECT_FALSE(has_frame(*animation, 0));
+
+  meshcat.SetTransform("frame", X_ParentPath, 0);
+  EXPECT_TRUE(has_frame(*animation, 0));
+
+  // Deleting the recording removes that frame.
+  meshcat.DeleteRecording();
+  animation = &meshcat.get_mutable_recording();
+  EXPECT_FALSE(has_frame(*animation, 0));
+
+  // We are still recording, so SetTransform *will* add it.
+  meshcat.SetTransform("frame", X_ParentPath, 0);
+  EXPECT_TRUE(has_frame(*animation, 0));
+
+  // But if we stop recording, then it's not added.
+  meshcat.StopRecording();
+  meshcat.DeleteRecording();
+  animation = &meshcat.get_mutable_recording();
+  EXPECT_FALSE(has_frame(*animation, 0));
+  meshcat.SetTransform("frame", X_ParentPath, 0);
+  EXPECT_FALSE(has_frame(*animation, 0));
+
+  // Now publish a time 0.0 and time = 1.0 and confirm we have the frames.
+  const double kFrameRate = 64.0;
+  meshcat.StartRecording(kFrameRate);
+  animation = &meshcat.get_mutable_recording();
+  meshcat.SetTransform("frame", X_ParentPath, 0);
+  meshcat.SetTransform("frame", X_ParentPath, 1);
+  EXPECT_TRUE(has_frame(*animation, 0));
+  EXPECT_TRUE(has_frame(*animation, std::floor(kFrameRate)));
+
+  const double kTime = 0.5;
+  const int kFrame = std::floor(kFrameRate * kTime);
+  EXPECT_FALSE(
+      animation->get_key_frame<bool>(kFrame, "bool_property", "visible")
+          .has_value());
+  meshcat.SetProperty("bool_property", "visible", false, kTime);
+  EXPECT_TRUE(
+      animation->get_key_frame<bool>(kFrame, "bool_property", "visible")
+          .has_value());
+
+  EXPECT_FALSE(
+      animation
+          ->get_key_frame<double>(kFrame, "double_property", "material.opacity")
+          .has_value());
+  meshcat.SetProperty("double_property", "material.opacity", 0.5, kTime);
+  EXPECT_TRUE(
+      animation
+          ->get_key_frame<double>(kFrame, "double_property", "material.opacity")
+          .has_value());
+
+  EXPECT_FALSE(animation
+                   ->get_key_frame<std::vector<double>>(
+                       kFrame, "vector_double_property", "position")
+                   .has_value());
+  meshcat.SetProperty("vector_double_property", "position", {0.1, 0.2, 0.3},
+                      kTime);
+  EXPECT_TRUE(animation
+                  ->get_key_frame<std::vector<double>>(
+                      kFrame, "vector_double_property", "position")
+                  .has_value());
+
+  // Confirm that PublishRecording runs.  Its correctness is established by
+  // meshcat_manual_test.
+  meshcat.PublishRecording();
+}
+
+GTEST_TEST(MeshcatTest, RecordingWithoutSetTransform) {
+  Meshcat meshcat;
+
+  const RigidTransformd X_0{math::RollPitchYawd(.5, .26, -3),
+                            Vector3d{.9, -2., .12}};
+  const RigidTransformd X_1{math::RollPitchYawd(.75, .21, 2.4),
+                            Vector3d{6.9, -2.2, 1.12}};
+
+  const double kFrameRate = 64.0;
+  bool set_visualizations_while_recording = false;
+  meshcat.SetTransform("frame", X_0);
+  std::string X_0_message = meshcat.GetPackedTransform("frame");
+
+  meshcat.StartRecording(kFrameRate, set_visualizations_while_recording);
+  // This SetTransform should *not* change the transform in the Meshcat scene
+  // tree.
+  meshcat.SetTransform("frame", X_1, 0);
+  EXPECT_EQ(meshcat.GetPackedTransform("frame"), X_0_message);
+
+  // This SetTransform *should* change the transform in the Meshcat scene tree,
+  // because it doesn't pass the time_in_recording argument.
+  meshcat.SetTransform("frame", X_1);
+  EXPECT_NE(meshcat.GetPackedTransform("frame"), X_0_message);
+
+  set_visualizations_while_recording = true;
+  // This publish *should* change the transform in the Meshcat scene tree.
+  meshcat.SetTransform("frame", X_0);
+  EXPECT_EQ(meshcat.GetPackedTransform("frame"), X_0_message);
+  meshcat.StartRecording(kFrameRate, set_visualizations_while_recording);
+  // This publish *should* change the transform in the Meshcat scene tree.
+  meshcat.SetTransform("frame", X_1, 0);
+  EXPECT_NE(meshcat.GetPackedTransform("frame"), X_0_message);
+}
+
 GTEST_TEST(MeshcatTest, Set2dRenderMode) {
   Meshcat meshcat;
   meshcat.Set2dRenderMode();

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -208,15 +208,17 @@ bool has_iiwa_frame(const MeshcatAnimation& animation, int frame) {
 TEST_F(MeshcatVisualizerWithIiwaTest, Recording) {
   MeshcatVisualizerParams params;
   SetUpDiagram(params);
-  auto animation = visualizer_->get_mutable_recording();
+  DRAKE_EXPECT_THROWS_MESSAGE(visualizer_->get_mutable_recording(),
+                              ".*You must create a recording.*");
 
   // Publish once without recording and confirm that we don't have the iiwa
   // frame.
   diagram_->ForcedPublish(*context_);
+  visualizer_->StartRecording();
+  auto animation = visualizer_->get_mutable_recording();
   EXPECT_FALSE(has_iiwa_frame(*animation, 0));
 
   // Publish again *with* recording and confirm that we do now have the frame.
-  visualizer_->StartRecording();
   diagram_->ForcedPublish(*context_);
   EXPECT_TRUE(has_iiwa_frame(*animation, 0));
 

--- a/multibody/meshcat/contact_visualizer.cc
+++ b/multibody/meshcat/contact_visualizer.cc
@@ -148,16 +148,17 @@ const ContactVisualizer<T>& ContactVisualizer<T>::AddToBuilder(
 template <typename T>
 EventStatus ContactVisualizer<T>::UpdateMeshcat(
     const Context<T>& context) const {
+  double time = ExtractDoubleOrThrow(context.get_time());
   const auto& point_contacts =
       this->get_cache_entry(point_contacts_cache_)
           .template Eval<std::vector<PointContactVisualizerItem>>(context);
-  point_visualizer_->Update(point_contacts);
+  point_visualizer_->Update(time, point_contacts);
 
   const auto& hydroelastic_contacts =
       this->get_cache_entry(hydroelastic_contacts_cache_)
           .template Eval<std::vector<HydroelasticContactVisualizerItem>>(
               context);
-  hydroelastic_visualizer_->Update(hydroelastic_contacts);
+  hydroelastic_visualizer_->Update(time, hydroelastic_contacts);
   return EventStatus::Succeeded();
 }
 

--- a/multibody/meshcat/hydroelastic_contact_visualizer.h
+++ b/multibody/meshcat/hydroelastic_contact_visualizer.h
@@ -67,7 +67,8 @@ class HydroelasticContactVisualizer {
 
   /* Update meshcat to show _only_ the given contacts.
   Any previously-visualized contacts will no longer be visible. */
-  void Update(const std::vector<HydroelasticContactVisualizerItem>& items);
+  void Update(double time,
+              const std::vector<HydroelasticContactVisualizerItem>& items);
 
   /* Calls geometry::Meshcat::Delete(path), with the path set to params.prefix.
   Since this visualizer will only ever add geometry under this prefix, this will

--- a/multibody/meshcat/point_contact_visualizer.h
+++ b/multibody/meshcat/point_contact_visualizer.h
@@ -50,7 +50,8 @@ class PointContactVisualizer {
 
   /* Update meshcat to show _only_ the given contact pairs.
   Any previously-visualized contact points will no longer be visible. */
-  void Update(const std::vector<PointContactVisualizerItem>& items);
+  void Update(double time,
+              const std::vector<PointContactVisualizerItem>& items);
 
   /* Calls geometry::Meshcat::Delete(path), with the path set to params.prefix.
   Since this visualizer will only ever add geometry under this prefix, this will

--- a/multibody/meshcat/test/hydroelastic_contact_visualizer_test.cc
+++ b/multibody/meshcat/test/hydroelastic_contact_visualizer_test.cc
@@ -50,7 +50,7 @@ GTEST_TEST(HydroelasticContactVisualizer, TestZeroForceOrMoment) {
     items.push_back({"body_A", "body_B", centroid_W,
                      non_zero_force_C_W, zero_moment_C_W,
                      p_WV, faces, pressure});
-    DRAKE_EXPECT_NO_THROW(visualizer.Update(items));
+    DRAKE_EXPECT_NO_THROW(visualizer.Update(0, items));
   }
   // Zero force / non-zero moment
   {
@@ -58,7 +58,7 @@ GTEST_TEST(HydroelasticContactVisualizer, TestZeroForceOrMoment) {
     items.push_back({"body_A", "body_B", centroid_W,
                      zero_force_C_W, non_zero_moment_C_W,
                      p_WV, faces, pressure});
-    DRAKE_EXPECT_NO_THROW(visualizer.Update(items));
+    DRAKE_EXPECT_NO_THROW(visualizer.Update(0, items));
   }
 }
 


### PR DESCRIPTION
Towards #17832 -- with this PR we now support recording contact
visualization in meshcat animations (only not the hydroelastic
surface visualization yet).

Previously the recording logic lived in the System
(MeshcatVisualizer), because it was the system that knows about
time. But this became unwieldy... as more systems wanted to contribute
to the animation (for instance the contact visualizer, the point cloud
visualizer, my manipulation class meshcat writer, ...), I had to start
writing a significant amount of custom recording-specific logic in
each subsystem. (I do have a working experimental branch in which I
made this possible through a recording output port on the
MeshcatVisualizer... but the burden on every downstream visualizer was
too great).

In this PR I've hoisted the recording logic from MeshcatVisualizer
into the main Meshcat class.  SetTransform and SetProperty can take an
additional optional input for time_in_recording. If a user has called
StartRecording, then any future calls to SetTransform/SetProperty with
the time included will be recorded.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18433)
<!-- Reviewable:end -->
