### PR TITLE
[primitives] Add TrajectorySource::UpdateTrajectory

### DIFF
--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -717,7 +717,9 @@ PYBIND11_MODULE(primitives, m) {
       .def(py::init<const trajectories::Trajectory<double>&, int, bool>(),
           py::arg("trajectory"), py::arg("output_derivative_order") = 0,
           py::arg("zero_derivatives_beyond_limits") = true,
-          doc.TrajectorySource.ctor.doc);
+          doc.TrajectorySource.ctor.doc)
+      .def("UpdateTrajectory", &TrajectorySource<double>::UpdateTrajectory,
+          py::arg("trajectory"), doc.TrajectorySource.UpdateTrajectory.doc);
 
   m.def("AddRandomInputs", &AddRandomInputs<double>,
        py::arg("sampling_interval_sec"), py::arg("builder"),

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -362,6 +362,13 @@ class TestGeneral(unittest.TestCase):
         mytest(0.5, (2.5, 1.5))
         mytest(1.0, (3.0, 1.0))
 
+        ppt2 = PiecewisePolynomial.FirstOrderHold(
+            [0., 1.], [[4., 6.], [4., 2.]])
+        system.UpdateTrajectory(trajectory=ppt2)
+        mytest(0.0, (4.0, 4.0))
+        mytest(0.5, (5.0, 3.0))
+        mytest(1.0, (6.0, 2.0))
+
     def test_symbolic_vector_system(self):
         t = Variable("t")
         x = [Variable("x0"), Variable("x1")]

--- a/systems/primitives/test/trajectory_source_test.cc
+++ b/systems/primitives/test/trajectory_source_test.cc
@@ -25,7 +25,7 @@ class TrajectorySourceTest : public ::testing::Test {
  protected:
   const size_t kDerivativeOrder = 5;
 
-  void Reset(PiecewisePolynomial<double> pp) {
+  void BuildSource(PiecewisePolynomial<double> pp) {
     kppTraj_ = make_unique<PiecewisePolynomial<double>>(pp);
     source_ = make_unique<TrajectorySource<double>>(*kppTraj_, kDerivativeOrder,
                                                     true);
@@ -34,7 +34,7 @@ class TrajectorySourceTest : public ::testing::Test {
   }
 
   std::unique_ptr<PiecewisePolynomial<double>> kppTraj_;
-  std::unique_ptr<System<double>> source_;
+  std::unique_ptr<TrajectorySource<double>> source_;
   std::unique_ptr<Context<double>> context_;
   std::unique_ptr<BasicVector<double>> input_;
 };
@@ -43,14 +43,14 @@ TEST_F(TrajectorySourceTest, OutputTest) {
   const Polynomiald y = Polynomiald("y");
   const Polynomiald yyyy = (y * y * y * y);
   const std::vector<Polynomiald> p_vec {yyyy};
-  Reset(PiecewisePolynomial<double>(p_vec, {0.0, 3}));
+  BuildSource(PiecewisePolynomial<double>(p_vec, {0.0, 3}));
 
   ASSERT_EQ(0, context_->num_input_ports());
 
   const double kTestTime = 1.75;
   context_->SetTime(kTestTime);
 
-  const auto& output = source_->get_output_port(0).Eval(*context_);
+  const auto& output = source_->get_output_port().Eval(*context_);
 
   int len = kppTraj_->rows();
   EXPECT_EQ(kppTraj_->value(kTestTime), output.segment(0, len));
@@ -65,11 +65,27 @@ TEST_F(TrajectorySourceTest, OutputTest) {
   // Test first derivative (which is in second segment):
   // f`(yyyy) = f`(y^4) = 4 * y^3.  y = kTestTime.
   EXPECT_NEAR(output.segment(len, len)(0), 21.4375, 1e-6);
+
+  Eigen::MatrixXd samples(1, 2);
+  samples << 0, 1;
+  PiecewisePolynomial<double> pp = PiecewisePolynomial<double>::FirstOrderHold(
+      Eigen::Vector2d(0, 2), samples);
+  source_->UpdateTrajectory(pp);
+  context_->SetTime(kTestTime);  // Set the time again to invalidate the cache.
+
+  const auto& output2 = source_->get_output_port().Eval(*context_);
+  EXPECT_EQ(pp.value(kTestTime), output2.segment(0, len));
+  for (size_t i = 1; i <= kDerivativeOrder; ++i) {
+    EXPECT_TRUE(
+        CompareMatrices(pp.derivative(i).value(kTestTime),
+                        output2.segment(len * i, len), 1e-10,
+                        MatrixCompareType::absolute));
+  }
 }
 
 // Tests that ConstantVectorSource allocates no state variables in the context_.
 TEST_F(TrajectorySourceTest, ConstantVectorSourceIsStateless) {
-  Reset(PiecewisePolynomial<double>(MatrixXd::Constant(2, 1, 1.5)));
+  BuildSource(PiecewisePolynomial<double>(MatrixXd::Constant(2, 1, 1.5)));
   EXPECT_EQ(0, context_->num_continuous_states());
 }
 

--- a/systems/primitives/trajectory_source.cc
+++ b/systems/primitives/trajectory_source.cc
@@ -21,11 +21,26 @@ TrajectorySource<T>::TrajectorySource(const Trajectory<T>& trajectory,
   DRAKE_DEMAND(trajectory.cols() == 1);
   DRAKE_DEMAND(output_derivative_order >= 0);
 
-  for (int i = 0; i < output_derivative_order; i++) {
+  for (int i = 0; i < output_derivative_order; ++i) {
     if (i == 0)
       derivatives_.push_back(trajectory_->MakeDerivative());
     else
       derivatives_.push_back(derivatives_[i - 1]->MakeDerivative());
+  }
+}
+
+template <typename T>
+void TrajectorySource<T>::UpdateTrajectory(
+    const trajectories::Trajectory<T>& trajectory) {
+  DRAKE_DEMAND(trajectory.rows() == trajectory_->rows());
+  DRAKE_DEMAND(trajectory.cols() == 1);
+
+  trajectory_ = trajectory.Clone();
+  for (int i = 0; i < static_cast<int>(derivatives_.size()); ++i) {
+    if (i == 0)
+      derivatives_[i] = trajectory_->MakeDerivative();
+    else
+      derivatives_[i] = derivatives_[i - 1]->MakeDerivative();
   }
 }
 

--- a/systems/primitives/trajectory_source.h
+++ b/systems/primitives/trajectory_source.h
@@ -12,9 +12,13 @@
 namespace drake {
 namespace systems {
 
-/// A source block that generates the value of a Trajectory for a given time.
-/// The output is vector values, and may vary with the time (as reflected in
-/// the context) at which the output is evaluated.
+/// Given a Trajectory, this System provides an output port with the value of
+/// the trajectory evaluated at the current time.
+///
+/// If the particular Trajectory is not available at the time the System /
+/// Diagram is being constructed, one can create a TrajectorySource with a
+/// placeholder trajectory (e.g. PiecewisePolynomimal(Eigen::VectorXd)) with the
+/// correct number of rows, and then use UpdateTrajectory().
 ///
 /// @system
 /// name: TrajectorySource
@@ -42,17 +46,21 @@ class TrajectorySource final : public SingleOutputVectorSource<T> {
 
   ~TrajectorySource() final = default;
 
+  /// Updates the stored trajectory. @p trajectory must have the same number of
+  /// rows as the trajectory passed to the constructor.
+  void UpdateTrajectory(const trajectories::Trajectory<T>& trajectory);
+
  private:
-  /// Outputs a vector of values evaluated at the context time of the trajectory
-  /// and up to its Nth derivatives, where the trajectory and N are passed to
-  /// the constructor. The size of the vector is:
-  /// (1 + output_derivative_order) * rows of the trajectory passed to the
-  /// constructor.
+  // Outputs a vector of values evaluated at the context time of the trajectory
+  // and up to its Nth derivatives, where the trajectory and N are passed to
+  // the constructor. The size of the vector is:
+  // (1 + output_derivative_order) * rows of the trajectory passed to the
+  // constructor.
   void DoCalcVectorOutput(
       const Context<T>& context,
       Eigen::VectorBlock<VectorX<T>>* output) const final;
 
-  const std::unique_ptr<trajectories::Trajectory<T>> trajectory_;
+  std::unique_ptr<trajectories::Trajectory<T>> trajectory_;
   const bool clamp_derivatives_;
   std::vector<std::unique_ptr<trajectories::Trajectory<T>>> derivatives_;
 };


### PR DESCRIPTION
I've seen a number of examples where a user wants to construct a Diagram in order to compute quantities for planning, then execute the planned trajectory using a TrajectorySource. This caused a chicken-and-the-egg problem -- they couldn't produce the final diagram until they had the trajectory but couldn't produce the trajectory until they had the Diagram. Constructing a completely different Diagram for the planning felt too cumbersome.

With the addition in this PR, a user can set up the Diagram with a placeholder trajectory that only needs to be the right size, then set the trajectory after the Diagram is built.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18434)
<!-- Reviewable:end -->
