### PR TITLE
[geometry/optimization] Fix Iris Hit and Run failure bug

### DIFF
--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -586,7 +586,7 @@ void MakeGuessFeasible(const HPolyhedron& P, const IrisOptions& options,
                            A.row(N - 1).normalized().transpose();
     // If this causes a different constraint to be violated, then just
     // go back to the "center" of the set.
-    if (!P.PointInSet(*guess, 1e-12)) {
+    if (!P.PointInSet(*guess)) {
       *guess = P.ChebyshevCenter();
     }
   }


### PR DESCRIPTION
Fixes a bug where `MakeGuessFeasible` returns a point outside the region causing the Hit and Run sampling algorithm to fail during IRIS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18439)
<!-- Reviewable:end -->
