### PR TITLE
[systems/framework] More verbose error message in DiagramBuilder

### DIFF
--- a/systems/framework/diagram_builder.cc
+++ b/systems/framework/diagram_builder.cc
@@ -343,10 +343,25 @@ void DiagramBuilder<T>::ThrowIfSystemNotRegistered(
     const System<T>* system) const {
   DRAKE_DEMAND(system != nullptr);
   if (systems_.count(system) == 0) {
+    std::string registered_system_names{};
+    for (const auto& sys : registered_systems_) {
+      if (!registered_system_names.empty()) {
+        registered_system_names += ", ";
+      }
+      registered_system_names += '\'' + sys->get_name() + '\'';
+    }
+    if (registered_system_names.empty()) {
+      registered_system_names = "NONE";
+    }
+
     throw std::logic_error(fmt::format(
-        "DiagramBuilder: Cannot operate on ports of System {} "
-        "until it has been registered using AddSystem",
-        system->get_name()));
+        "DiagramBuilder: System '{}' has not been registered to this "
+        "DiagramBuilder using AddSystem nor AddNamedSystem.\n\nThe systems "
+        "currently registered to this builder are: {}.\n\nIf '{}' was "
+        "registered as a subsystem to one of these, you must export the input "
+        "or output port using ExportInput/ExportOutput and then connect to the "
+        "exported port.",
+        system->get_name(), registered_system_names, system->get_name()));
   }
 }
 

--- a/systems/framework/test/diagram_builder_test.cc
+++ b/systems/framework/test/diagram_builder_test.cc
@@ -227,20 +227,27 @@ GTEST_TEST(DiagramBuilderTest, FinalizeWhenEmpty) {
 
 GTEST_TEST(DiagramBuilderTest, SystemsThatAreNotAddedThrow) {
   DiagramBuilder<double> builder;
+  // These integrators should be listed in the error messages when it prints the
+  // lists of registered systems.
+  builder.AddNamedSystem<Integrator>("integrator1", 1 /* size */);
+  builder.AddNamedSystem<Integrator>("integrator2", 1 /* size */);
   Adder<double> adder(1 /* inputs */, 1 /* size */);
   adder.set_name("adder");
   DRAKE_EXPECT_THROWS_MESSAGE(
       builder.Connect(adder, adder),
-      "DiagramBuilder: Cannot operate on ports of System adder "
-      "until it has been registered using AddSystem");
+      "DiagramBuilder: System 'adder' has not been registered to this "
+      "DiagramBuilder using AddSystem nor AddNamedSystem.\n\n.*'integrator1', "
+      "'integrator2'.*\n\n.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       builder.ExportInput(adder.get_input_port(0)),
-      "DiagramBuilder: Cannot operate on ports of System adder "
-      "until it has been registered using AddSystem");
+      "DiagramBuilder: System 'adder' has not been registered to this "
+      "DiagramBuilder using AddSystem nor AddNamedSystem.\n\n.*'integrator1', "
+      "'integrator2'.*\n\n.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       builder.ExportOutput(adder.get_output_port()),
-      "DiagramBuilder: Cannot operate on ports of System adder "
-      "until it has been registered using AddSystem");
+      "DiagramBuilder: System 'adder' has not been registered to this "
+      "DiagramBuilder using AddSystem nor AddNamedSystem.\n\n.*'integrator1', "
+      "'integrator2'.*\n\n.*");
 }
 
 GTEST_TEST(DiagramBuilderTest, ConnectVectorToAbstractThrow) {


### PR DESCRIPTION
When a system is not registered, it will now list the registered system, and offer the export input/output option that people often are missing.

+@sherm1 for both reviews, please.

I saw countless student notebooks that were trying to connect to a subsystem port directly, etc.  I think this will help a lot!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18446)
<!-- Reviewable:end -->
