### PR TITLE
Deprecate "register w.r.t. geometry" SceneGraph APIs

### DIFF
--- a/bindings/pydrake/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry_py_scene_graph.cc
@@ -132,10 +132,20 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py_rvp::reference_internal, py::arg("geometry_id"),
             cls_doc.GetName.doc_1args_geometry_id)
         .def("GetShape", &Class::GetShape, py_rvp::reference_internal,
-            py::arg("geometry_id"), cls_doc.GetShape.doc)
-        .def("GetPoseInParent", &Class::GetPoseInParent,
+            py::arg("geometry_id"), cls_doc.GetShape.doc);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    // 2023-04-01 Deprecation removal.
+    cls  // BR
+        .def("GetPoseInParent",
+            WrapDeprecated(cls_doc.GetPoseInParent.doc_deprecated,
+                &Class::GetPoseInParent),
             py_rvp::reference_internal, py::arg("geometry_id"),
-            cls_doc.GetPoseInParent.doc)
+            cls_doc.GetPoseInParent.doc_deprecated);
+#pragma GCC diagnostic pop
+
+    cls  // BR
         .def("GetPoseInFrame", &Class::GetPoseInFrame,
             py_rvp::reference_internal, py::arg("geometry_id"),
             cls_doc.GetPoseInFrame.doc)
@@ -199,20 +209,18 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::overload_cast<SourceId, FrameId,
                 std::unique_ptr<GeometryInstance>>(&Class::RegisterGeometry),
             py::arg("source_id"), py::arg("frame_id"), py::arg("geometry"),
-            cls_doc.RegisterGeometry.doc_3args_source_id_frame_id_geometry)
+            cls_doc.RegisterGeometry.doc_3args);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    // 2023-04-01 Deprecation removal.
+    cls  // BR
         .def("RegisterGeometry",
-            py::overload_cast<SourceId, GeometryId,
-                std::unique_ptr<GeometryInstance>>(&Class::RegisterGeometry),
+            WrapDeprecated(cls_doc.RegisterGeometry.doc_deprecated_3args,
+                py::overload_cast<SourceId, GeometryId,
+                    std::unique_ptr<GeometryInstance>>(
+                    &Class::RegisterGeometry)),
             py::arg("source_id"), py::arg("geometry_id"), py::arg("geometry"),
-            cls_doc.RegisterGeometry.doc_3args_source_id_geometry_id_geometry)
-        .def("RegisterGeometry",
-            overload_cast_explicit<GeometryId, systems::Context<T>*, SourceId,
-                FrameId, std::unique_ptr<GeometryInstance>>(
-                &Class::RegisterGeometry),
-            py::arg("context"), py::arg("source_id"), py::arg("frame_id"),
-            py::arg("geometry"),
-            cls_doc.RegisterGeometry
-                .doc_4args_context_source_id_frame_id_geometry)
+            cls_doc.RegisterGeometry.doc_deprecated_3args)
         .def("RegisterGeometry",
             overload_cast_explicit<GeometryId, systems::Context<T>*, SourceId,
                 GeometryId, std::unique_ptr<GeometryInstance>>(
@@ -220,7 +228,15 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("context"), py::arg("source_id"), py::arg("geometry_id"),
             py::arg("geometry"),
             cls_doc.RegisterGeometry
-                .doc_4args_context_source_id_geometry_id_geometry)
+                .doc_4args_context_source_id_geometry_id_geometry);
+#pragma GCC diagnostic pop
+    cls  // BR
+        .def("RegisterGeometry",
+            overload_cast_explicit<GeometryId, systems::Context<T>*, SourceId,
+                FrameId, std::unique_ptr<GeometryInstance>>(
+                &Class::RegisterGeometry),
+            py::arg("context"), py::arg("source_id"), py::arg("frame_id"),
+            py::arg("geometry"), cls_doc.RegisterGeometry.doc_4args)
         .def("RegisterAnchoredGeometry",
             py::overload_cast<SourceId, std::unique_ptr<GeometryInstance>>(
                 &Class::RegisterAnchoredGeometry),

--- a/bindings/pydrake/test/geometry_scene_graph_test.py
+++ b/bindings/pydrake/test/geometry_scene_graph_test.py
@@ -43,11 +43,15 @@ class TestGeometrySceneGraph(unittest.TestCase):
                                           shape=mut.Sphere(1.),
                                           name="sphere1"))
         # We'll explicitly give sphere_2 a rigid hydroelastic representation.
-        sphere_2 = scene_graph.RegisterGeometry(
-            source_id=global_source, geometry_id=global_geometry,
-            geometry=mut.GeometryInstance(X_PG=RigidTransform_[float](),
-                                          shape=mut.Sphere(1.),
-                                          name="sphere2"))
+        with catch_drake_warnings(expected_count=1):
+            # 2023-04-01 Deprecation removal. Upon removal, register sphere_2
+            # against global_frame and keep it around for the hydroelastic
+            # tests.
+            sphere_2 = scene_graph.RegisterGeometry(
+                source_id=global_source, geometry_id=global_geometry,
+                geometry=mut.GeometryInstance(X_PG=RigidTransform_[float](),
+                                              shape=mut.Sphere(1.),
+                                              name="sphere2"))
         props = mut.ProximityProperties()
         mut.AddRigidHydroelasticProperties(resolution_hint=1, properties=props)
         scene_graph.AssignRole(source_id=global_source, geometry_id=sphere_2,
@@ -227,9 +231,11 @@ class TestGeometrySceneGraph(unittest.TestCase):
             inspector.GetName(geometry_id=global_geometry), "sphere1")
         self.assertIsInstance(inspector.GetShape(geometry_id=global_geometry),
                               mut.Sphere)
-        self.assertIsInstance(
-            inspector.GetPoseInParent(geometry_id=global_geometry),
-            RigidTransform_[float])
+        with catch_drake_warnings(expected_count=1):
+            # 2023-04-01 Deprecation removal.
+            self.assertIsInstance(
+                inspector.GetPoseInParent(geometry_id=global_geometry),
+                RigidTransform_[float])
         self.assertIsInstance(
             inspector.GetPoseInFrame(geometry_id=global_geometry),
             RigidTransform_[float])

--- a/examples/scene_graph/solar_system.cc
+++ b/examples/scene_graph/solar_system.cc
@@ -273,7 +273,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   const double kMarsSize = 0.24;
   RigidTransformd X_OmM{
       Translation3d{kMarsOrbitRadius, 0, -orrery_bottom}};
-  GeometryId mars_geometry_id = scene_graph->RegisterGeometry(
+  scene_graph->RegisterGeometry(
       source_id_, planet_id,
       MakeShape<Sphere>(X_OmM, "Mars", Vector4d(0.9, 0.1, 0, 1), kMarsSize));
 
@@ -282,8 +282,8 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   Vector3d axis = Vector3d(1, 1, 1).normalized();
   RigidTransformd X_MR(AngleAxisd(M_PI / 3, axis), Vector3d{0, 0, 0});
   scene_graph->RegisterGeometry(
-      source_id_, mars_geometry_id,
-      MakeShape<Mesh>(X_MR, "MarsRings", Vector4d(0.45, 0.9, 0, 1),
+      source_id_, planet_id,
+      MakeShape<Mesh>(X_OmM * X_MR, "MarsRings", Vector4d(0.45, 0.9, 0, 1),
                       rings_absolute_path, kMarsSize));
 
   // Mars's orrery arm.

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -285,6 +285,9 @@ class GeometryState {
       GeometryId geometry_id) const;
 
   /** Implementation of SceneGraphInspector::X_PG().  */
+  DRAKE_DEPRECATED("2023-04-01",
+                   "Geometries are no longer posed with respect to other "
+                   "geometries -- only frames; use GetPoseInFrame().")
   const math::RigidTransform<double>& GetPoseInParent(
       GeometryId geometry_id) const;
 
@@ -369,6 +372,9 @@ class GeometryState {
    @ref SceneGraph::RegisterGeometry(SourceId,GeometryId,
    std::unique_ptr<GeometryInstance>) "SceneGraph::RegisterGeometry()" with
    parent GeometryId.  */
+  DRAKE_DEPRECATED("2023-04-01",
+                   "Geometries are no longer posed with respect to other "
+                   "geometries -- only frames.")
   GeometryId RegisterGeometryWithParent(
       SourceId source_id, GeometryId parent_id,
       std::unique_ptr<GeometryInstance> geometry);

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -159,6 +159,8 @@ class QueryObject {
   /** Reports the position of the frame indicated by `frame_id` relative to its
    parent frame. If the frame was registered with the world frame as its parent
    frame, this value will be identical to that returned by GetPoseInWorld().
+   <!-- 2023-04-01 Remove this note when we're done deprecating
+    SGI::GetPoseInParent(). -->
    @note This is analogous to but distinct from
    SceneGraphInspector::GetPoseInParent(). In this case, the pose will *always*
    be relative to another frame.

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -199,8 +199,12 @@ template <typename T>
 GeometryId SceneGraph<T>::RegisterGeometry(
     SourceId source_id, GeometryId geometry_id,
     std::unique_ptr<GeometryInstance> geometry) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  // 2023-04-01 Deprecation removal.
   return model_.RegisterGeometryWithParent(source_id, geometry_id,
                                            std::move(geometry));
+#pragma GCC diagnostic pop
 }
 
 template <typename T>
@@ -208,8 +212,12 @@ GeometryId SceneGraph<T>::RegisterGeometry(
     Context<T>* context, SourceId source_id, GeometryId geometry_id,
     std::unique_ptr<GeometryInstance> geometry) const {
   auto& g_state = mutable_geometry_state(context);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  // 2023-04-01 Deprecation removal.
   return g_state.RegisterGeometryWithParent(source_id, geometry_id,
                                             std::move(geometry));
+#pragma GCC diagnostic pop
 }
 
 template <typename T>

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -512,6 +512,9 @@ class SceneGraph final : public systems::LeafSystem<T> {
                           c) the `geometry` is equal to `nullptr`, or
                           d) the geometry's name doesn't satisfy the
                           requirements outlined in GeometryInstance.  */
+  DRAKE_DEPRECATED("2023-04-01",
+                   "Geometries are no longer posed with respect to other "
+                   "geometries; use RegisterGeometry(frame_id) instead.")
   GeometryId RegisterGeometry(SourceId source_id, GeometryId geometry_id,
                               std::unique_ptr<GeometryInstance> geometry);
 
@@ -520,6 +523,9 @@ class SceneGraph final : public systems::LeafSystem<T> {
    the provided context.
    @pydrake_mkdoc_identifier{4args_context_source_id_geometry_id_geometry}
      */
+  DRAKE_DEPRECATED("2023-04-01",
+                   "Geometries are no longer posed with respect to other "
+                   "geometries -- only frames.")
   GeometryId RegisterGeometry(systems::Context<T>* context, SourceId source_id,
                               GeometryId geometry_id,
                               std::unique_ptr<GeometryInstance> geometry) const;

--- a/geometry/scene_graph_inspector.cc
+++ b/geometry/scene_graph_inspector.cc
@@ -197,7 +197,10 @@ template <typename T>
 const math::RigidTransform<double>& SceneGraphInspector<T>::GetPoseInParent(
     GeometryId geometry_id) const {
   DRAKE_DEMAND(state_ != nullptr);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return state_->GetPoseInParent(geometry_id);
+#pragma GCC diagnostic pop
 }
 
 template <typename T>

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -302,6 +302,9 @@ class SceneGraphInspector {
    @note For deformable geometries, this returns the pose of the reference mesh.
    @throws std::exception if `geometry_id` does not map to a registered
    geometry. */
+  DRAKE_DEPRECATED("2023-04-01",
+                   "Geometries are no longer posed with respect to other "
+                   "geometries -- only frames; use GetPoseInFrame().")
   const math::RigidTransform<double>& GetPoseInParent(
       GeometryId geometry_id) const;
 
@@ -309,6 +312,8 @@ class SceneGraphInspector {
    registered frame F (regardless of whether its _topological parent_ is another
    geometry P or not). If the geometry was registered directly to the frame F,
    then `X_PG = X_FG`.
+   <!-- 2023-04-01 When deprecation is complete, remove references to other
+    geometries. -->
    @sa GetPoseInParent()
    @note For deformable geometries, this returns the pose of the reference mesh.
    @throws std::exception if `geometry_id` does not map to a registered

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -1109,15 +1109,21 @@ TEST_F(GeometryStateTest, ValidateSingleSourceTree) {
       EXPECT_EQ(geometry.name(), geometry_names_[i]);
       EXPECT_EQ(geometry.child_geometry_ids().size(), 0);
 
+      // 2023-04-01 Also modify this documentation with the removal of
+      // GetPoseInParent().
       // Note: There are no geometries parented to other geometries. The results
       // of GetPoseInFrame() and GetPoseInParent() must be the identical (as
       // the documentation for GeometryState::GetPoseInParent() indicates).
       EXPECT_TRUE(CompareMatrices(
           geometry_state_.GetPoseInFrame(geometry.id()).GetAsMatrix34(),
           X_FGs_[i].GetAsMatrix34()));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+      // 2023-04-01 Deprecation removal.
       EXPECT_TRUE(CompareMatrices(
           geometry_state_.GetPoseInParent(geometry.id()).GetAsMatrix34(),
           X_FGs_[i].GetAsMatrix34()));
+#pragma GCC diagnostic pop
     }
   }
   EXPECT_EQ(static_cast<int>(gs_tester_.get_geometry_world_poses().size()),
@@ -1507,6 +1513,9 @@ TEST_F(GeometryStateTest, RegisterNullGeometry) {
       "Registering null geometry to frame \\d+, on source \\d+.");
 }
 
+// 2023-04-01 Simply remove all of the RegisterGeometryOn*Geometry tests.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // Tests the logic for hanging a geometry on another geometry. This confirms
 // topology and pose values.
 TEST_F(GeometryStateTest, RegisterGeometryonValidGeometry) {
@@ -1577,6 +1586,7 @@ TEST_F(GeometryStateTest, RegisterNullGeometryonGeometry) {
                                                  move(instance)),
       "Registering null geometry to geometry \\d+, on source \\d+.");
 }
+#pragma GCC diagnostic pop
 
 // Tests the registration of anchored geometry.
 TEST_F(GeometryStateTest, RegisterAnchoredGeometry) {
@@ -1598,6 +1608,9 @@ TEST_F(GeometryStateTest, RegisterAnchoredGeometry) {
       CompareMatrices(g->X_FG().GetAsMatrix34(), g->X_PG().GetAsMatrix34()));
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+// 2023-04-01 Deprecation removal.
 // Tests the registration of a new geometry on another geometry.
 TEST_F(GeometryStateTest, RegisterAnchoredOnAnchoredGeometry) {
   // Add an anchored geometry.
@@ -1625,6 +1638,7 @@ TEST_F(GeometryStateTest, RegisterAnchoredOnAnchoredGeometry) {
                               child->X_FG().GetAsMatrix34()));
   EXPECT_EQ(InternalFrame::world_frame_id(), parent->frame_id());
 }
+#pragma GCC diagnostic pop
 
 // Confirms that registering two geometries with the same id causes failure.
 TEST_F(GeometryStateTest, RegisterDuplicateAnchoredGeometry) {
@@ -1702,7 +1716,11 @@ TEST_F(GeometryStateTest, RegisterDeformableGeometry) {
 
   // Querying the _reference_ pose is fine.
   EXPECT_TRUE(geometry_state_.GetPoseInFrame(g_id).IsExactlyEqualTo(X_WG));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  // 2023-04-01 Deprecation removal.
   EXPECT_TRUE(geometry_state_.GetPoseInParent(g_id).IsExactlyEqualTo(X_WG));
+#pragma GCC diagnostic pop
   // Querying _current_ pose on deformable geometry throws. (Deformable
   // geometries are characterized by vertex positions via
   // get_configurations_in_world.)
@@ -1853,6 +1871,9 @@ TEST_F(GeometryStateTest, RemoveGeometry) {
   DRAKE_EXPECT_NO_THROW(gs_tester_.FinalizePoseUpdate());
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  // 2023-04-01 Deprecation removal.
 // Tests the RemoveGeometry functionality in which the geometry removed has
 // geometry children.
 TEST_F(GeometryStateTest, RemoveGeometryTree) {
@@ -1928,6 +1949,7 @@ TEST_F(GeometryStateTest, RemoveChildLeaf) {
   EXPECT_TRUE(gs_tester_.get_frames().at(frame_id).has_child(parent_id));
   EXPECT_FALSE(gs_tester_.get_geometries().at(parent_id).has_child(g_id));
 }
+#pragma GCC diagnostic pop
 
 // Tests the response to invalid use of RemoveGeometry.
 TEST_F(GeometryStateTest, RemoveGeometryInvalid) {
@@ -2036,9 +2058,13 @@ TEST_F(GeometryStateTest, GetPoseForBadGeometryId) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.GetPoseInFrame(GeometryId::get_new_id()),
       "Referenced geometry \\d+ has not been registered.");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  // 2023-04-01 Deprecation removal.
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.GetPoseInParent(GeometryId::get_new_id()),
       "Referenced geometry \\d+ has not been registered.");
+#pragma GCC diagnostic pop
 }
 
 // This tests the source ownership functionality - a function which reports if
@@ -3752,11 +3778,15 @@ TEST_F(GeometryStateTest, GeometryVersionUpdate) {
       &GeometryState<double>::RegisterGeometry, new_source, new_frame_0,
       std::make_unique<GeometryInstance>(
           RigidTransformd(), make_unique<Sphere>(1), "new_geometry_0"));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  // 2023-04-01 Deprecation removal.
   VerifyVersionUnchanged(
       &GeometryState<double>::RegisterGeometryWithParent, new_source,
       new_geometry_0,
       std::make_unique<GeometryInstance>(
           RigidTransformd(), make_unique<Sphere>(1), "new_geometry_1"));
+#pragma GCC diagnostic pop
   VerifyVersionUnchanged(
       &GeometryState<double>::RegisterAnchoredGeometry, new_source,
       std::make_unique<GeometryInstance>(

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -89,7 +89,11 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   inspector.GetFrameId(geometry_id);
   inspector.GetName(geometry_id);
   inspector.GetShape(geometry_id);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  // 2023-04-01 Deprecation removal.
   inspector.GetPoseInParent(geometry_id);
+#pragma GCC diagnostic pop
   inspector.GetPoseInFrame(geometry_id);
   inspector.maybe_get_hydroelastic_mesh(geometry_id);
   inspector.GetProximityProperties(geometry_id);

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -236,8 +236,12 @@ TEST_F(SceneGraphTest, TopologyAfterAllocation) {
       scene_graph_.RegisterFrame(id, parent_frame_id, GeometryFrame("child"));
   GeometryId parent_geometry_id = scene_graph_.RegisterGeometry(
       id, parent_frame_id, make_sphere_instance());
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  // 2023-04-01 Deprecation removal; delete all references to child_geometry_id.
   GeometryId child_geometry_id = scene_graph_.RegisterGeometry(
       id, parent_geometry_id, make_sphere_instance());
+#pragma GCC diagnostic pop
   GeometryId anchored_id =
       scene_graph_.RegisterAnchoredGeometry(id, make_sphere_instance());
   scene_graph_.RemoveGeometry(id, old_geometry_id);
@@ -754,12 +758,17 @@ GTEST_TEST(SceneGraphContextModifier, RegisterGeometry) {
   EXPECT_EQ(1, inspector.NumGeometriesForFrame(frame_id));
   EXPECT_EQ(frame_id, inspector.GetFrameId(sphere_id_1));
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  // 2023-04-01 Deprecation removal.
   // Test registration of geometry onto _geometry_.
   GeometryId sphere_id_2 = scene_graph.RegisterGeometry(
       context.get(), source_id, sphere_id_1, make_sphere_instance());
   EXPECT_EQ(2, inspector.NumGeometriesForFrame(frame_id));
   EXPECT_EQ(frame_id, inspector.GetFrameId(sphere_id_2));
+#pragma GCC diagnostic pop
 
+  // 2023-04-01 Change from sphere_id_2 to sphere_id_1.
   // Remove the geometry.
   DRAKE_EXPECT_NO_THROW(
       scene_graph.RemoveGeometry(context.get(), source_id, sphere_id_2));

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -216,19 +216,16 @@ GTEST_TEST(MujocoParser, GeometryPose) {
   const SceneGraphInspector<double>& inspector = scene_graph.model_inspector();
 
   auto CheckPose = [&inspector](const std::string& geometry_name,
-                                const RigidTransformd& X_PG) {
+                                const RigidTransformd& X_FG) {
     GeometryId geom_id = inspector.GetGeometryIdByName(
         inspector.world_frame_id(), Role::kProximity, geometry_name);
-    EXPECT_TRUE(
-        inspector.GetPoseInParent(geom_id).IsNearlyEqualTo(X_PG, 1e-14));
+    EXPECT_TRUE(inspector.GetPoseInFrame(geom_id).IsNearlyEqualTo(X_FG, 1e-14));
     geom_id = inspector.GetGeometryIdByName(inspector.world_frame_id(),
                                             Role::kPerception, geometry_name);
-    EXPECT_TRUE(
-        inspector.GetPoseInParent(geom_id).IsNearlyEqualTo(X_PG, 1e-14));
+    EXPECT_TRUE(inspector.GetPoseInFrame(geom_id).IsNearlyEqualTo(X_FG, 1e-14));
     geom_id = inspector.GetGeometryIdByName(inspector.world_frame_id(),
                                             Role::kIllustration, geometry_name);
-    EXPECT_TRUE(
-        inspector.GetPoseInParent(geom_id).IsNearlyEqualTo(X_PG, 1e-14));
+    EXPECT_TRUE(inspector.GetPoseInFrame(geom_id).IsNearlyEqualTo(X_FG, 1e-14));
   };
 
   const Vector3d p{1, 2, 3};


### PR DESCRIPTION
Users have the ability to register a geometry in a fixed pose relative to another geometry. Ultimately, it has a fixed pose relative the common geometry::Frame. This extra layer has not proved to be useful and the concept of "parent vs frame" has only caused confusion.

This deprecates the limited public API in preparation for removing all of the supporting internal code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18448)
<!-- Reviewable:end -->
