### PR TITLE
[visualization] Add sliders for geometry alpha in MeshcatVisualizer

### DIFF
--- a/bindings/pydrake/test/geometry_visualizers_test.py
+++ b/bindings/pydrake/test/geometry_visualizers_test.py
@@ -241,6 +241,7 @@ class TestGeometryVisualizers(unittest.TestCase):
         params.default_color = mut.Rgba(0.5, 0.5, 0.5)
         params.prefix = "py_visualizer"
         params.delete_on_initialization_event = False
+        params.enable_alpha_sliders = False
         self.assertIn("publish_period", repr(params))
         copy.copy(params)
         vis = mut.MeshcatVisualizer_[T](meshcat=meshcat, params=params)
@@ -267,7 +268,9 @@ class TestGeometryVisualizers(unittest.TestCase):
 
     def test_meshcat_visualizer_scalar_conversion(self):
         meshcat = mut.Meshcat()
-        vis = mut.MeshcatVisualizer(meshcat)
+        params = mut.MeshcatVisualizerParams()
+        params.enable_alpha_sliders = False
+        vis = mut.MeshcatVisualizer(meshcat, params)
         vis_autodiff = vis.ToAutoDiffXd()
         self.assertIsInstance(vis_autodiff,
                               mut.MeshcatVisualizer_[AutoDiffXd])

--- a/geometry/meshcat_visualizer.cc
+++ b/geometry/meshcat_visualizer.cc
@@ -20,7 +20,8 @@ MeshcatVisualizer<T>::MeshcatVisualizer(std::shared_ptr<Meshcat> meshcat,
       meshcat_(std::move(meshcat)),
       params_(std::move(params)),
       animation_(
-          std::make_unique<MeshcatAnimation>(1.0 / params_.publish_period)) {
+          std::make_unique<MeshcatAnimation>(1.0 / params_.publish_period)),
+      alpha_slider_name_(std::string(params_.prefix + " α")) {
   DRAKE_DEMAND(meshcat_ != nullptr);
   DRAKE_DEMAND(params_.publish_period >= 0.0);
   if (params_.role == Role::kUnassigned) {
@@ -42,6 +43,11 @@ MeshcatVisualizer<T>::MeshcatVisualizer(std::shared_ptr<Meshcat> meshcat,
   query_object_input_port_ =
       this->DeclareAbstractInputPort("query_object", Value<QueryObject<T>>())
           .get_index();
+
+  if (params_.enable_alpha_sliders) {
+    meshcat_->AddSlider(
+      alpha_slider_name_, 0.02, 1.0, 0.02, alpha_value_);
+  }
 }
 
 template <typename T>
@@ -97,6 +103,13 @@ systems::EventStatus MeshcatVisualizer<T>::UpdateMeshcat(
     version_ = current_version;
   }
   SetTransforms(context, query_object);
+  if (params_.enable_alpha_sliders) {
+    double new_alpha_value = meshcat_->GetSliderValue(alpha_slider_name_);
+    if (new_alpha_value != alpha_value_) {
+      alpha_value_ = new_alpha_value;
+      SetColorAlphas();
+    }
+  }
   std::optional<double> rate = realtime_rate_calculator_.UpdateAndRecalculate(
       ExtractDoubleOrThrow(context.get_time()));
   if (rate) {
@@ -109,6 +122,8 @@ systems::EventStatus MeshcatVisualizer<T>::UpdateMeshcat(
 template <typename T>
 void MeshcatVisualizer<T>::SetObjects(
     const SceneGraphInspector<T>& inspector) const {
+  colors_.clear();
+
   // Frames registered previously that are not set again here should be deleted.
   std::map <FrameId, std::string> frames_to_delete{};
   dynamic_frames_.swap(frames_to_delete);
@@ -152,6 +167,7 @@ void MeshcatVisualizer<T>::SetObjects(
       meshcat_->SetObject(path, inspector.GetShape(geom_id), rgba);
       meshcat_->SetTransform(path, inspector.GetPoseInFrame(geom_id));
       geometries_[geom_id] = path;
+      colors_[geom_id] = rgba;
       geometries_to_delete.erase(geom_id);  // Don't delete this one.
     }
   }
@@ -181,6 +197,16 @@ void MeshcatVisualizer<T>::SetTransforms(
           animation_->frame(ExtractDoubleOrThrow(context.get_time())), path,
           X_WF);
     }
+  }
+}
+
+template <typename T>
+void MeshcatVisualizer<T>::SetColorAlphas() const {
+  for (const auto& [geom_id, path] : geometries_) {
+    Rgba color = colors_[geom_id];
+    color.set(color.r(), color.g(), color.b(), alpha_value_ * color.a());
+    meshcat_->SetProperty(path, "color",
+      {color.r(), color.g(), color.b(), alpha_value_ * color.a()});
   }
 }
 

--- a/geometry/meshcat_visualizer.h
+++ b/geometry/meshcat_visualizer.h
@@ -135,7 +135,7 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
       systems::DiagramBuilder<T>* builder, const SceneGraph<T>& scene_graph,
       std::shared_ptr<Meshcat> meshcat, MeshcatVisualizerParams params = {});
 
-  /** Adds a MescatVisualizer and connects it to the given QueryObject-valued
+  /** Adds a MeshcatVisualizer and connects it to the given QueryObject-valued
    output port. See MeshcatVisualizer::MeshcatVisualizer(MeshcatVisualizer*,
    MeshcatVisualizerParams) for details. */
   static MeshcatVisualizer<T>& AddToBuilder(
@@ -160,6 +160,9 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
    */
   void SetTransforms(const systems::Context<T>& context,
                      const QueryObject<T>& query_object) const;
+
+  /* Makes calls to Meshcat::SetProperty to update color alphas. */
+  void SetColorAlphas() const;
 
   /* Handles the initialization event. */
   systems::EventStatus OnInitialization(const systems::Context<T>&) const;
@@ -192,6 +195,9 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
    new geometry version appears that does not contain them. */
   mutable std::map<GeometryId, std::string> geometries_{};
 
+  /* A store of the original colors for the objects in geometries_. */
+  mutable std::map<GeometryId, Rgba> colors_{};
+
   /* The parameters for the visualizer.  */
   MeshcatVisualizerParams params_;
 
@@ -218,6 +224,12 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
   run Meshcat multithreaded */
   mutable systems::internal::InstantaneousRealtimeRateCalculator
       realtime_rate_calculator_{};
+
+  /* The name of the alpha slider, if any. */
+  std::string alpha_slider_name_;
+
+  /* The last alpha value applied to geometry. */
+  mutable double alpha_value_{1.0};
 };
 
 /** A convenient alias for the MeshcatVisualizer class when using the `double`

--- a/geometry/meshcat_visualizer_params.h
+++ b/geometry/meshcat_visualizer_params.h
@@ -20,6 +20,7 @@ struct MeshcatVisualizerParams {
     a->Visit(DRAKE_NVP(default_color));
     a->Visit(DRAKE_NVP(prefix));
     a->Visit(DRAKE_NVP(delete_on_initialization_event));
+    a->Visit(DRAKE_NVP(enable_alpha_sliders));
   }
 
   /** The duration (in simulation seconds) between attempts to update poses in
@@ -46,6 +47,9 @@ struct MeshcatVisualizerParams {
    simulation. See @ref declare_initialization_events "Declare initialization
    events" for more information. */
   bool delete_on_initialization_event{true};
+
+  /** Determines whether to enable alpha sliders for geometry display. */
+  bool enable_alpha_sliders{true};
 };
 
 }  // namespace geometry

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -118,6 +118,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Roles) {
           fmt::format("visualizer/iiwa14/iiwa_link_7/{}", geom_id)));
     }
     meshcat_->Delete();
+    meshcat_->DeleteAddedControls();
   }
 
   params.role = Role::kUnassigned;
@@ -148,6 +149,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Prefix) {
 TEST_F(MeshcatVisualizerWithIiwaTest, DeletePrefixOnInitialization) {
   MeshcatVisualizerParams params;
   params.delete_on_initialization_event = true;
+  params.enable_alpha_sliders = false;
   SetUpDiagram(params);
   // Scribble a transform onto the scene tree beneath the visualizer prefix.
   meshcat_->SetTransform("/drake/visualizer/my_random_path",
@@ -268,7 +270,9 @@ TEST_F(MeshcatVisualizerWithIiwaTest, RecordingWithoutSetTransform) {
 }
 
 TEST_F(MeshcatVisualizerWithIiwaTest, ScalarConversion) {
-  SetUpDiagram();
+  MeshcatVisualizerParams params;
+  params.enable_alpha_sliders = false;
+  SetUpDiagram(params);
 
   auto ad_diagram = diagram_->ToAutoDiffXd();
   auto ad_context = ad_diagram->CreateDefaultContext();
@@ -277,6 +281,21 @@ TEST_F(MeshcatVisualizerWithIiwaTest, ScalarConversion) {
   // UpdateMeshcat / SetObjects SetTransforms.  We simply confirm that the code
   // doesn't blow up.
   ad_diagram->ForcedPublish(*ad_context);
+}
+
+TEST_F(MeshcatVisualizerWithIiwaTest, UpdateAlphaSliders) {
+  SetUpDiagram();
+  systems::Simulator<double> simulator(*diagram_);
+
+  // Simulate for a moment and publish to populate the visualizer.
+  simulator.AdvanceTo(0.1);
+  diagram_->ForcedPublish(*context_);
+
+  meshcat_->SetSliderValue("visualizer α", 0.5);
+
+  // Simulate and publish again to cause an update.
+  simulator.AdvanceTo(0.1);
+  diagram_->ForcedPublish(*context_);
 }
 
 GTEST_TEST(MeshcatVisualizerTest, MultipleModels) {

--- a/manipulation/models/ycb/test/parse_test.cc
+++ b/manipulation/models/ycb/test/parse_test.cc
@@ -78,6 +78,8 @@ TEST_P(ParseTest, Quantities) {
   auto diagram = builder.Build();
   ScopeExit guard([&visualizer]() {
     visualizer.Delete();
+    std::shared_ptr<Meshcat> meshcat = GetTestEnvironmentMeshcat();
+    meshcat->DeleteAddedControls();
   });
 
   // MultibodyPlant always creates at least two model instances, one for the

--- a/visualization/visualization_config.h
+++ b/visualization/visualization_config.h
@@ -31,6 +31,7 @@ struct VisualizationConfig {
     a->Visit(DRAKE_NVP(publish_contacts));
     a->Visit(DRAKE_NVP(enable_meshcat_creation));
     a->Visit(DRAKE_NVP(delete_on_initialization_event));
+    a->Visit(DRAKE_NVP(enable_alpha_sliders));
   }
 
   /** Which LCM URL to use.
@@ -67,6 +68,9 @@ struct VisualizationConfig {
    object (if any) on an initialization event to remove any visualizations,
    e.g., from a previous simulation, to . */
   bool delete_on_initialization_event{true};
+
+  /** Determines whether to enable alpha sliders for geometry display. */
+  bool enable_alpha_sliders{true};
 };
 
 }  // namespace visualization

--- a/visualization/visualization_config_functions.cc
+++ b/visualization/visualization_config_functions.cc
@@ -141,6 +141,7 @@ ConvertVisualizationConfigToMeshcatParams(
     illustration.prefix = std::string("illustration");
     illustration.delete_on_initialization_event =
         config.delete_on_initialization_event;
+    illustration.enable_alpha_sliders = config.enable_alpha_sliders;
     result.push_back(illustration);
   }
 
@@ -152,6 +153,7 @@ ConvertVisualizationConfigToMeshcatParams(
     proximity.prefix = std::string("proximity");
     proximity.delete_on_initialization_event =
         config.delete_on_initialization_event;
+    proximity.enable_alpha_sliders = config.enable_alpha_sliders;
     result.push_back(proximity);
   }
 


### PR DESCRIPTION
Adds sliders to control geometry alpha to MeshcatVisualizer, as well as a config option to disable them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18454)
<!-- Reviewable:end -->
