### PR TITLE
Look for Gurobi 9.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,7 +483,7 @@ set(BAZEL_CONFIGS)
 option(WITH_GUROBI "Build with support for Gurobi" OFF)
 
 if(WITH_GUROBI)
-  find_package(Gurobi 9.5.1 EXACT MODULE REQUIRED)
+  find_package(Gurobi 9.5 EXACT MODULE REQUIRED)
 
   list(APPEND BAZEL_CONFIGS --config=gurobi)
 


### PR DESCRIPTION
CMake's `find_package_handle_standard_args()` supports searching for an "exact" version containing only a major and minor version, allowing any patch version to suffice.

Issue: #14157

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18456)
<!-- Reviewable:end -->
