### PR TITLE
Remove a redundant check on the signed_distance < influence_distance in MinimumDistanceConstraint.

### DIFF
--- a/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.cc
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.cc
@@ -6,6 +6,7 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/find_resource.h"
 #include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/coulomb_friction.h"
 #include "drake/systems/framework/diagram_builder.h"
 
 using drake::geometry::SceneGraph;

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
@@ -3,6 +3,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
The original code is correct, but the check on `signed_distance_pair.distance < influence_distance` is redundant because `signed_distance_pairs` is computed with `max_distance = influence_distance`. https://github.com/RobotLocomotion/drake/blob/4443764321ac2dcad19fc796b5ce685916b045c1/multibody/inverse_kinematics/minimum_distance_constraint.cc#L33-L35

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18459)
<!-- Reviewable:end -->

This was motivated by the stack overflow question https://stackoverflow.com/questions/74793241/multiple-minimumdistanceconstraint-constraints
