### PR TITLE
Remove unneeded CRTP parameter from MultibodyElement

### DIFF
--- a/multibody/tree/body.h
+++ b/multibody/tree/body.h
@@ -181,7 +181,7 @@ class BodyAttorney {
 ///
 /// @tparam_default_scalar
 template <typename T>
-class Body : public MultibodyElement<Body, T, BodyIndex> {
+class Body : public MultibodyElement<T, BodyIndex> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Body)
 
@@ -469,7 +469,7 @@ class Body : public MultibodyElement<Body, T, BodyIndex> {
   /// Creates a %Body named `name` in model instance `model_instance`.
   /// The `name` must not be empty.
   Body(const std::string& name, ModelInstanceIndex model_instance)
-      : MultibodyElement<Body, T, BodyIndex>(model_instance),
+      : MultibodyElement<T, BodyIndex>(model_instance),
         name_(internal::DeprecateWhenEmptyName(name, "Body")),
         body_frame_(*this) {}
 

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -94,7 +94,7 @@ namespace internal {
 //
 // @tparam_default_scalar
 template <typename T>
-class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
+class BodyNode : public MultibodyElement<T, BodyNodeIndex> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BodyNode)
 
@@ -117,8 +117,7 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
   // for this node, which must outlive `this` BodyNode.
   BodyNode(const BodyNode<T>* parent_node,
            const Body<T>* body, const Mobilizer<T>* mobilizer)
-      : MultibodyElement<BodyNode, T, BodyNodeIndex>(
-            body->model_instance()),
+      : MultibodyElement<T, BodyNodeIndex>(body->model_instance()),
         parent_node_(parent_node),
         body_(body),
         mobilizer_(mobilizer) {

--- a/multibody/tree/force_element.h
+++ b/multibody/tree/force_element.h
@@ -35,15 +35,13 @@ namespace multibody {
 ///
 /// @tparam_default_scalar
 template <typename T>
-class ForceElement : public
-                     MultibodyElement<ForceElement, T, ForceElementIndex> {
+class ForceElement : public MultibodyElement<T, ForceElementIndex> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ForceElement)
 
   /// Default constructor for a generic force element.
   explicit ForceElement(ModelInstanceIndex model_instance)
-      : MultibodyElement<ForceElement, T, ForceElementIndex>(
-            model_instance) {}
+      : MultibodyElement<T, ForceElementIndex>(model_instance) {}
 
   /// (Advanced) Computes the force contribution for `this` force element and
   /// **adds** it to the output arrays of forces. Depending on their model,

--- a/multibody/tree/frame_base.h
+++ b/multibody/tree/frame_base.h
@@ -43,7 +43,7 @@ namespace multibody {
 ///
 /// @tparam_default_scalar
 template <typename T>
-class FrameBase : public MultibodyElement<FrameBase, T, FrameIndex> {
+class FrameBase : public MultibodyElement<T, FrameIndex> {
   // TODO(amcastro-tri): Provide a method with the signature:
   // const math::RigidTransform<T>& get_pose_in_world_frame(
   //     const Context<T>& context) const;
@@ -58,7 +58,7 @@ class FrameBase : public MultibodyElement<FrameBase, T, FrameIndex> {
   // `measured_in_frame` frame.
  protected:
   explicit FrameBase(ModelInstanceIndex model_instance)
-      : MultibodyElement<FrameBase, T, FrameIndex>(model_instance) {}
+      : MultibodyElement<T, FrameIndex>(model_instance) {}
 };
 
 }  // namespace multibody

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -67,7 +67,7 @@ namespace multibody {
 ///
 /// @tparam_default_scalar
 template <typename T>
-class Joint : public MultibodyElement<Joint, T, JointIndex> {
+class Joint : public MultibodyElement<T, JointIndex> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Joint)
 
@@ -119,7 +119,7 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
         const VectorX<double>& vel_upper_limits,
         const VectorX<double>& acc_lower_limits,
         const VectorX<double>& acc_upper_limits)
-      : MultibodyElement<Joint, T, JointIndex>(frame_on_child.model_instance()),
+      : MultibodyElement<T, JointIndex>(frame_on_child.model_instance()),
         name_(name),
         frame_on_parent_(frame_on_parent),
         frame_on_child_(frame_on_child),

--- a/multibody/tree/joint_actuator.cc
+++ b/multibody/tree/joint_actuator.cc
@@ -9,7 +9,7 @@ namespace multibody {
 template <typename T>
 JointActuator<T>::JointActuator(const std::string& name, const Joint<T>& joint,
                                 double effort_limit)
-    : MultibodyElement<JointActuator, T, JointActuatorIndex>(
+    : MultibodyElement<T, JointActuatorIndex>(
           joint.model_instance()),
       name_(name),
       joint_index_(joint.index()),

--- a/multibody/tree/joint_actuator.h
+++ b/multibody/tree/joint_actuator.h
@@ -27,8 +27,7 @@ template<typename T> class Joint;
 ///
 /// @tparam_default_scalar
 template <typename T>
-class JointActuator final
-    : public MultibodyElement<JointActuator, T, JointActuatorIndex> {
+class JointActuator final : public MultibodyElement<T, JointActuatorIndex> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(JointActuator)
 
@@ -295,8 +294,7 @@ class JointActuator final
   void DoDeclareParameters(
       internal::MultibodyTreeSystem<T>* tree_system) final {
     // Declare parent classes' parameters
-    MultibodyElement<JointActuator, T, JointActuatorIndex>::DoDeclareParameters(
-        tree_system);
+    MultibodyElement<T, JointActuatorIndex>::DoDeclareParameters(tree_system);
     rotor_inertia_parameter_index_ = this->DeclareNumericParameter(
         tree_system,
         systems::BasicVector<T>(Vector1<T>(default_rotor_inertia_)));

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -209,7 +209,7 @@ template<typename T> class BodyNode;
 //
 // @tparam_default_scalar
 template <typename T>
-class Mobilizer : public MultibodyElement<Mobilizer, T, MobilizerIndex> {
+class Mobilizer : public MultibodyElement<T, MobilizerIndex> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Mobilizer)
 
@@ -706,8 +706,7 @@ class Mobilizer : public MultibodyElement<Mobilizer, T, MobilizerIndex> {
   void DoDeclareParameters(
       internal::MultibodyTreeSystem<T>* tree_system) override {
     // Declare parent class's parameters
-    MultibodyElement<Mobilizer, T, MobilizerIndex>::DoDeclareParameters(
-        tree_system);
+    MultibodyElement<T, MobilizerIndex>::DoDeclareParameters(tree_system);
 
     is_locked_parameter_index_ =
         this->DeclareAbstractParameter(tree_system, Value<bool>(false));

--- a/multibody/tree/model_instance.h
+++ b/multibody/tree/model_instance.h
@@ -55,13 +55,12 @@ namespace internal {
 
 // @tparam_default_scalar
 template <typename T>
-class ModelInstance :
-      public MultibodyElement<ModelInstance, T, ModelInstanceIndex> {
+class ModelInstance : public MultibodyElement<T, ModelInstanceIndex> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ModelInstance)
 
   explicit ModelInstance(ModelInstanceIndex index)
-      : MultibodyElement<ModelInstance, T, ModelInstanceIndex>(index) {}
+      : MultibodyElement<T, ModelInstanceIndex>(index) {}
 
   int num_positions() const { return num_positions_; }
   int num_velocities() const { return num_velocities_; }

--- a/multibody/tree/multibody_element.h
+++ b/multibody/tree/multibody_element.h
@@ -28,15 +28,11 @@ class JointImplementationBuilder;
 /// this class as:
 /// @code{.cpp}
 /// template <typename T>
-/// class MultibodyThing :
-///     public MultibodyElement<MultibodyThing, T, MultibodyThingIndex> {
+/// class MultibodyThing : public MultibodyElement<T, MultibodyThingIndex> {
 ///  ...
 /// };
 /// @endcode
 ///
-/// @tparam ElementType The type of the specific multibody element, for
-///     instance, a body or a mobilizer. It must be a template class that can
-///     be templatized by scalar type T.
 /// @tparam_default_scalar
 /// @tparam ElementIndexType The type-safe index used for this element type.
 ///
@@ -44,11 +40,9 @@ class JointImplementationBuilder;
 /// as a multibody element. This is accomplished with:
 /// @code{.cpp}
 ///   template <typename T>
-///   class ForceElement :
-///       public MultibodyElement<ForceElement, T, ForceElementIndex>;
+///   class ForceElement : public MultibodyElement<T, ForceElementIndex>;
 /// @endcode
-template <template <typename> class ElementType,
-    typename T, typename ElementIndexType>
+template <typename T, typename ElementIndexType>
 class MultibodyElement {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MultibodyElement)

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -538,9 +538,8 @@ const MultibodyTree<T>& GetInternalTree(const MultibodyTreeSystem<T>& system) {
 
 namespace drake {
 namespace multibody {
-// Forward delcaration of MultibodyElement for attorney-client.
-template <template <typename> class ElementType, typename T,
-          typename ElementIndexType>
+// Forward declaration of MultibodyElement for attorney-client.
+template <typename T, typename ElementIndexType>
 class MultibodyElement;
 
 namespace internal {
@@ -554,8 +553,7 @@ class MultibodyTreeSystemElementAttorney {
   MultibodyTreeSystemElementAttorney() = delete;
 
  private:
-  template <template <typename> class ElementType, typename U,
-            typename ElementIndexType>
+  template <typename U, typename ElementIndexType>
   friend class drake::multibody::MultibodyElement;
 
   static systems::NumericParameterIndex DeclareNumericParameter(

--- a/multibody/tree/test/multibody_tree_creation_test.cc
+++ b/multibody/tree/test/multibody_tree_creation_test.cc
@@ -27,17 +27,15 @@ namespace multibody {
 class MultibodyElementTester {
  public:
   MultibodyElementTester() = delete;
-  template <template <typename> class ElementType, typename T,
-      typename ElementIndexType>
+  template <typename T, typename ElementIndexType>
   static bool has_parent_tree(
-      const MultibodyElement<ElementType, T, ElementIndexType>& element) {
+      const MultibodyElement<T, ElementIndexType>& element) {
     return element.has_parent_tree();
   }
 
-  template <template <typename> class ElementType, typename T,
-      typename ElementIndexType>
+  template <typename T, typename ElementIndexType>
   static const internal::MultibodyTree<T>& get_parent_tree(
-      const MultibodyElement<ElementType, T, ElementIndexType>& element) {
+      const MultibodyElement<T, ElementIndexType>& element) {
     return element.get_parent_tree();
   }
 };


### PR DESCRIPTION
For some reason lost to history the internal class MultibodyElement used a CRTP pattern yet never actually referenced the recursive template at all. This PR removes that parameter and hopefully some unnecessary confusion along with it.

**Release note**: this is technically a breaking change since MultibodyElement is the non-internal base class for all the elements, both internal and visible. However it is very unlikely that anyone is referencing the base class directly. If they are, they'll have to make the same (easy) change to their code also.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18460)
<!-- Reviewable:end -->
