### PR TITLE
ensure sdf diagnostic includes filename/lineno

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -128,8 +128,17 @@ drake_cc_library(
     internal = True,
     visibility = ["//visibility:private"],
     deps = [
+        ":detail_misc",
         "//common:diagnostic_policy",
         "@sdformat_internal//:sdformat",
+    ],
+)
+
+drake_cc_googletest(
+    name = "detail_sdf_diagnostic_test",
+    deps = [
+        ":detail_sdf_diagnostic",
+        ":diagnostic_policy_test_base",
     ],
 )
 
@@ -555,6 +564,7 @@ drake_cc_googletest(
     ],
     deps = [
         ":detail_sdf_geometry",
+        ":diagnostic_policy_test_base",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//math:geometric_transform",

--- a/multibody/parsing/detail_sdf_diagnostic.cc
+++ b/multibody/parsing/detail_sdf_diagnostic.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/parsing/detail_sdf_diagnostic.h"
 
+#include <utility>
+
 #include "drake/common/drake_assert.h"
 
 namespace drake {
@@ -9,40 +11,135 @@ namespace internal {
 using drake::internal::DiagnosticDetail;
 using drake::internal::DiagnosticPolicy;
 
+SDFormatDiagnostic::SDFormatDiagnostic(
+    const drake::internal::DiagnosticPolicy* diagnostic,
+    const drake::multibody::internal::DataSource* data_source,
+    const std::string& file_extension)
+    : diagnostic_(diagnostic), data_source_(data_source),
+      file_extension_(file_extension) {
+  DRAKE_DEMAND(diagnostic != nullptr);
+  DRAKE_DEMAND(data_source != nullptr);
+}
+
+DiagnosticDetail SDFormatDiagnostic::MakeDetail(
+    const sdf::Element& element, const std::string& message) const {
+  DiagnosticDetail detail;
+  if (!element.FilePath().empty()) {
+        detail.filename = element.FilePath();
+  } else {
+    if (data_source_->IsFilename()) {
+      detail.filename = data_source_->GetAbsolutePath();
+    } else {
+      detail.filename = data_source_->GetStem() + "." + file_extension_;
+    }
+  }
+  detail.line = element.LineNumber();
+  detail.message = message;
+  return detail;
+}
+
+void SDFormatDiagnostic::Warning(
+    sdf::ElementConstPtr element, const std::string& message) const {
+  diagnostic_->Warning(MakeDetail(*element, message));
+}
+
+void SDFormatDiagnostic::Error(
+    sdf::ElementConstPtr element, const std::string& message) const {
+  diagnostic_->Error(MakeDetail(*element, message));
+}
+
+DiagnosticPolicy SDFormatDiagnostic::MakePolicyForNode(
+    const sdf::Element& element) const {
+  DiagnosticPolicy result;
+  result.SetActionForWarnings(
+      [this, &element](const DiagnosticDetail& detail) {
+        diagnostic_->Warning(MakeDetail(element, detail.message));
+      });
+  result.SetActionForErrors(
+      [this, &element](const DiagnosticDetail& detail) {
+        diagnostic_->Error(MakeDetail(element, detail.message));
+      });
+  return result;
+}
+
+bool SDFormatDiagnostic::PropagateErrors(
+    const sdf::Errors& errors) const {
+  bool result = false;
+  for (const auto& e : errors) {
+    DiagnosticDetail detail;
+    detail.filename = e.FilePath();
+    detail.line = e.LineNumber();
+    if (e.XmlPath().has_value()) {
+      detail.message = fmt::format(
+          "At XML path {}: {}", e.XmlPath().value(), e.Message());
+    } else {
+      detail.message = e.Message();
+    }
+    if (IsError(e)) {
+      diagnostic_->Error(detail);
+      result = true;
+    } else {
+      diagnostic_->Warning(detail);
+    }
+  }
+  return result;
+}
+
+bool IsError(const sdf::Error& report) {
+  switch (report.Code()) {
+    case sdf::ErrorCode::ELEMENT_DEPRECATED:
+    case sdf::ErrorCode::VERSION_DEPRECATED:
+    case sdf::ErrorCode::NONE: {
+      return false;
+    }
+    default: {
+      return true;
+    }
+  }
+}
+
+bool PropagateErrors(
+    sdf::Errors&& input_errors,
+    sdf::Errors* output_errors) {
+  bool result = false;
+  for (auto& e : input_errors) {
+    if (IsError(e)) {
+      result = true;
+    }
+    output_errors->push_back(std::move(e));
+  }
+  return result;
+}
+
 void CheckSupportedElements(
-    const DiagnosticPolicy& diagnostic,
-    sdf::ElementPtr root_element,
+    const SDFormatDiagnostic& diagnostic,
+    sdf::ElementConstPtr root_element,
     const std::set<std::string>& supported_elements) {
   CheckSupportedElements(diagnostic, root_element.get(), supported_elements);
 }
 
 void CheckSupportedElements(
-    const DiagnosticPolicy& diagnostic,
+    const SDFormatDiagnostic& diagnostic,
     const sdf::Element* root_element,
     const std::set<std::string>& supported_elements) {
   DRAKE_DEMAND(root_element != nullptr);
 
-  sdf::ElementPtr element = root_element->GetFirstElement();
+  sdf::ElementConstPtr element = root_element->GetFirstElement();
   while (element) {
     const std::string& element_name = element->GetName();
     if ((supported_elements.find(element_name) == supported_elements.end()) &&
         element->GetExplicitlySetInFile()) {
-      internal::DiagnosticDetail detail;
-      if (!element->FilePath().empty()) {
-        detail.filename = element->FilePath();
-      }
-      detail.line = element->LineNumber();
       // Unsupported elements in the drake namespace are errors.
       if (element_name.find("drake:") == 0) {
-        detail.message =
+        std::string message =
             std::string("Unsupported SDFormat element in ") +
             root_element->GetName() + std::string(": ") + element_name;
-        diagnostic.Error(detail);
+        diagnostic.Error(element, std::move(message));
       } else {
-        detail.message =
+        std::string message =
             std::string("Ignoring unsupported SDFormat element in ") +
             root_element->GetName() + std::string(": ") + element_name;
-        diagnostic.Warning(detail);
+        diagnostic.Warning(element, std::move(message));
       }
     }
     element = element->GetNextElement();
@@ -50,8 +147,8 @@ void CheckSupportedElements(
 }
 
 void CheckSupportedElementValue(
-    const drake::internal::DiagnosticPolicy& diagnostic,
-    sdf::ElementPtr root_element,
+    const SDFormatDiagnostic& diagnostic,
+    sdf::ElementConstPtr root_element,
     const std::string& element_name,
     const std::string& expected) {
   DRAKE_DEMAND(root_element != nullptr);
@@ -60,22 +157,17 @@ void CheckSupportedElementValue(
     return;
   }
 
-  sdf::ElementPtr element = root_element->GetElement(element_name);
+  sdf::ElementConstPtr element = root_element->FindElement(element_name);
   if (!element->GetExplicitlySetInFile()) {
     return;
   }
 
   sdf::ParamPtr value = element->GetValue();
   if (value->GetAsString() != expected) {
-    internal::DiagnosticDetail detail;
-    if (!element->FilePath().empty()) {
-      detail.filename = element->FilePath();
-    }
-    detail.line = element->LineNumber();
-    detail.message =
-        std::string("Unsupported value for SDFormat element ") +
+    std::string message =
+      std::string("Unsupported value for SDFormat element ") +
         element->GetName() + std::string(": ") + value->GetAsString();
-    diagnostic.Warning(detail);
+    diagnostic.Warning(element, message);
   }
 }
 

--- a/multibody/parsing/detail_sdf_diagnostic.h
+++ b/multibody/parsing/detail_sdf_diagnostic.h
@@ -6,33 +6,96 @@
 #include <drake_vendor/sdf/Element.hh>
 
 #include "drake/common/diagnostic_policy.h"
+#include "drake/multibody/parsing/detail_common.h"
 
 namespace drake {
 namespace multibody {
 namespace internal {
 
-/// Checks that all child elements of @p root_element are in the set of @p
-/// supported_elements, and logs warnings/errors using @p diagnostic.
-/// Unsupported elements in the `drake:` namespace are errors, all others are
-/// warnings.  (see https://github.com/RobotLocomotion/drake/issues/16785 for
-/// some discussion of this rationale)
+// Helper class to format diagnostic messages for a SDFormat data source.
+class SDFormatDiagnostic {
+ public:
+  // Both @p diagnostic and @p data_source are aliased; their lifetime must
+  // exceed that of this object.  @p file_extension is only used to indicate
+  // the type of source when @p data_source is a literal string. It is copied
+  // internally, so places no restrictions on the lifetime of the passed
+  // parameter.
+  // @pre diagnostic cannot be nullptr.
+  // @pre data_source cannot be nullptr.
+  SDFormatDiagnostic(
+      const drake::internal::DiagnosticPolicy* diagnostic,
+      const DataSource* data_source,
+      const std::string& file_extension = "sdf");
+
+  // Issues a warning for an ElementConstPtr.
+  void Warning(const sdf::ElementConstPtr element,
+               const std::string& message) const;
+
+  // Issues an error for an ElementConstPtr.
+  void Error(const sdf::ElementConstPtr element,
+             const std::string& message) const;
+
+  // Make a temporary policy that can be passed to a node-unaware parsing
+  // function. The lifetime of this object, and the @p element should be
+  // greater than the lifetime of the returned policy.
+  drake::internal::DiagnosticPolicy MakePolicyForNode(
+      const sdf::Element& element) const;
+
+  // Warn about spec-documented elements ignored by Drake.
+  void WarnUnsupportedElement(const sdf::ElementConstPtr element,
+                              const std::string& tag) const;
+
+  // Warn about spec-documented attributes ignored by Drake.
+  void WarnUnsupportedAttribute(const sdf::ElementConstPtr element,
+                                const std::string& attribute) const;
+
+  // Copies all `errors` into this Diagnostic object.
+  // Returns true if there were any errors.
+  bool PropagateErrors(const sdf::Errors& errors) const;
+
+ private:
+  // Makes a diagnostic detail record based on an Element.
+  drake::internal::DiagnosticDetail MakeDetail(
+      const sdf::Element& element,
+      const std::string& message) const;
+
+  const drake::internal::DiagnosticPolicy* diagnostic_{};
+  const DataSource* data_source_{};
+  const std::string file_extension_;
+};
+
+// Checks that all child elements of @p root_element are in the set of @p
+// supported_elements, and logs warnings/errors using @p diagnostic.
+// Unsupported elements in the `drake:` namespace are errors, all others are
+// warnings.  (see https://github.com/RobotLocomotion/drake/issues/16785 for
+// some discussion of this rationale)
 void CheckSupportedElements(
-    const drake::internal::DiagnosticPolicy& diagnostic,
-    sdf::ElementPtr root_element,
+    const SDFormatDiagnostic& diagnostic,
+    sdf::ElementConstPtr root_element,
     const std::set<std::string>& supported_elements);
 
 void CheckSupportedElements(
-    const drake::internal::DiagnosticPolicy& diagnostic,
+    const SDFormatDiagnostic& diagnostic,
     const sdf::Element* root_element,
     const std::set<std::string>& supported_elements);
 
-/// Checks, for elements where there is only one supported value, that
-/// the element matches that value if it's present.
+// Checks, for elements where there is only one supported value, that
+// the element matches that value if it's present.
 void CheckSupportedElementValue(
-    const drake::internal::DiagnosticPolicy& diagnostic,
-    sdf::ElementPtr root_element,
+    const SDFormatDiagnostic& diagnostic,
+    sdf::ElementConstPtr root_element,
     const std::string& element_name,
     const std::string& expected);
+
+// Move-appends all `input_errors` onto `output_errors`.
+// Returns true if `input_errors` contains any error.
+bool PropagateErrors(
+    sdf::Errors&& input_errors,
+    sdf::Errors* output_errors);
+
+// Returns true iff the given report indicates an error, or false
+// for warnings.
+bool IsError(const sdf::Error& report);
 
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/parsing/test/detail_sdf_diagnostic_test.cc
+++ b/multibody/parsing/test/detail_sdf_diagnostic_test.cc
@@ -1,0 +1,112 @@
+#include "drake/multibody/parsing/detail_sdf_diagnostic.h"
+
+#include <drake_vendor/sdf/Root.hh>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/temp_directory.h"
+#include "drake/multibody/parsing/test/diagnostic_policy_test_base.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace {
+
+using drake::internal::DiagnosticDetail;
+using drake::internal::DiagnosticPolicy;
+
+class SDFormatDiagnosticTest : public test::DiagnosticPolicyTestBase {
+ public:
+  SDFormatDiagnosticTest() {
+    data_ = R"""(<sdf version='1.6'>
+<model name='mixed_emotions'>
+  <link name='a'/>
+</model>
+</sdf>)""";
+  }
+
+ protected:
+  std::string data_;
+  sdf::ParserConfig parser_config_;
+  sdf::Root root_;
+};
+
+class SDFormatDiagnosticContentsTest : public SDFormatDiagnosticTest {
+ public:
+  SDFormatDiagnosticContentsTest() {
+    sdf::Errors errors =
+        root_.LoadSdfString(data_source_.contents(), parser_config_);
+    EXPECT_FALSE(sdf_diagnostic_.PropagateErrors(errors));
+  }
+
+ protected:
+  DataSource data_source_{DataSource::kContents, &data_};
+  SDFormatDiagnostic sdf_diagnostic_{&diagnostic_policy_, &data_source_,
+                                     "stuff"};
+};
+
+class SDFormatDiagnosticFilenameTest : public SDFormatDiagnosticTest {
+ public:
+  SDFormatDiagnosticFilenameTest() {
+    filename_ = temp_directory() + "/test_data.stuff";
+    std::ofstream file(filename_);
+    file << data_;
+    file.close();
+    sdf::Errors errors = root_.Load(filename_, parser_config_);
+    sdf_diagnostic_.PropagateErrors(errors);
+  }
+
+ protected:
+  std::string filename_;
+  DataSource source_{DataSource::kFilename, &filename_};
+  SDFormatDiagnostic sdf_diagnostic_{&diagnostic_policy_, &source_, "stuff"};
+};
+
+TEST_F(SDFormatDiagnosticContentsTest, Error) {
+  sdf_diagnostic_.Error(root_.Element()->FindElement("model"),
+                        std::move("badness"));
+  EXPECT_EQ(TakeError(), "<literal-string>.stuff:2: error: badness");
+}
+
+TEST_F(SDFormatDiagnosticContentsTest, Warning) {
+  sdf_diagnostic_.Warning(root_.Element()->FindElement("model"), "regret");
+  EXPECT_EQ(TakeWarning(), "<literal-string>.stuff:2: warning: regret");
+}
+
+TEST_F(SDFormatDiagnosticFilenameTest, Error) {
+  sdf_diagnostic_.Error(root_.Element()->FindElement("model"), "badness");
+  EXPECT_THAT(TakeError(),
+              testing::MatchesRegex("/.*/test_data.stuff:2: error: badness"));
+}
+
+TEST_F(SDFormatDiagnosticFilenameTest, Warning) {
+  sdf_diagnostic_.Warning(root_.Element()->FindElement("model"), "regret");
+  EXPECT_THAT(TakeWarning(),
+              testing::MatchesRegex("/.*/test_data.stuff:2: warning: regret"));
+}
+
+TEST_F(SDFormatDiagnosticContentsTest, PolicyForNode) {
+  // Policies for different nodes pass messages through to the
+  // SDFormatDiagnostic that made them, with location information for their
+  // respective nodes.
+  auto root_policy = sdf_diagnostic_.MakePolicyForNode(*(root_.Element()));
+  root_policy.Warning("root rot");
+  EXPECT_EQ(TakeWarning(), "<literal-string>.stuff:1: warning: root rot");
+  root_policy.Error("root gone");
+  EXPECT_EQ(TakeError(), "<literal-string>.stuff:1: error: root gone");
+
+  auto error_policy = sdf_diagnostic_.MakePolicyForNode(
+      *(root_.Element()->FindElement("model")));
+  error_policy.Error("bad");
+  EXPECT_EQ(TakeError(), "<literal-string>.stuff:2: error: bad");
+
+  auto warning_policy = sdf_diagnostic_.MakePolicyForNode(
+      *(root_.Element()->FindElement("model")));
+  warning_policy.Warning("meh");
+  EXPECT_EQ(TakeWarning(), "<literal-string>.stuff:2: warning: meh");
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -23,6 +23,8 @@
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/parsing/detail_common.h"
 #include "drake/multibody/parsing/detail_ignition.h"
+#include "drake/multibody/parsing/detail_sdf_diagnostic.h"
+#include "drake/multibody/parsing/test/diagnostic_policy_test_base.h"
 
 namespace drake {
 namespace multibody {
@@ -186,36 +188,42 @@ unique_ptr<sdf::Collision> MakeSdfCollisionFromString(
 }
 
 // Define a pass-through functor for testing.
-std::string NoopResolveFilename(const DiagnosticPolicy&, std::string filename) {
+std::string NoopResolveFilename(const SDFormatDiagnostic&,
+                                std::string filename) {
   return filename;
 }
 
-class SceneGraphParserDetail : public ::testing::Test {
+class SceneGraphParserDetail : public test::DiagnosticPolicyTestBase {
  public:
   SceneGraphParserDetail() {
     // Don't let warnings leak into spdlog; tests should always specifically
     // handle any warnings that appear.
-    diagnostic_.SetActionForWarnings(&DiagnosticPolicy::ErrorDefaultAction);
+    diagnostic_policy_.SetActionForWarnings(
+        &DiagnosticPolicy::ErrorDefaultAction);
+    RecordErrors();
   }
 
   // Wraps a function under test with helpful defaults.
-  std::unique_ptr<geometry::Shape> MakeShapeFromSdfGeometry(
+  std::optional<std::unique_ptr<geometry::Shape>> MakeShapeFromSdfGeometry(
       const sdf::Geometry& sdf_geometry,
       const ResolveFilename& resolve_filename = &NoopResolveFilename) {
     return internal::MakeShapeFromSdfGeometry(
-        diagnostic_, sdf_geometry, resolve_filename);
+        sdf_diagnostic_, sdf_geometry, resolve_filename);
   }
 
   // Wraps a function under test with helpful defaults.
-  geometry::IllustrationProperties MakeVisualPropertiesFromSdfVisual(
-      const sdf::Visual& sdf_visual,
-      const ResolveFilename& resolve_filename = &NoopResolveFilename) {
+  std::optional<geometry::IllustrationProperties>
+      MakeVisualPropertiesFromSdfVisual(
+          const sdf::Visual& sdf_visual,
+          const ResolveFilename& resolve_filename = &NoopResolveFilename) {
     return internal::MakeVisualPropertiesFromSdfVisual(
-        diagnostic_, sdf_visual, resolve_filename);
+        sdf_diagnostic_, sdf_visual, resolve_filename);
   }
 
  protected:
-  DiagnosticPolicy diagnostic_;
+  const std::string dummy_file_path_{"dummy_test_file.sdf"};
+  DataSource data_source_{DataSource::kFilename, &dummy_file_path_};
+  SDFormatDiagnostic sdf_diagnostic_{&diagnostic_policy_, &data_source_};
 };
 
 // Verify MakeShapeFromSdfGeometry returns nullptr when we specify an <empty>
@@ -223,8 +231,10 @@ class SceneGraphParserDetail : public ::testing::Test {
 TEST_F(SceneGraphParserDetail, MakeEmptyFromSdfGeometry) {
   unique_ptr<sdf::Geometry> sdf_geometry =
       MakeSdfGeometryFromString("<empty/>");
-  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
-  EXPECT_EQ(shape, nullptr);
+  std::optional<unique_ptr<Shape>> shape =
+      MakeShapeFromSdfGeometry(*sdf_geometry);
+  EXPECT_TRUE(shape.has_value());
+  EXPECT_EQ(*shape, nullptr);
 }
 
 // Verify MakeShapeFromSdfGeometry can make a box from an sdf::Geometry.
@@ -233,8 +243,10 @@ TEST_F(SceneGraphParserDetail, MakeBoxFromSdfGeometry) {
       "<box>"
       "  <size>1.0 2.0 3.0</size>"
       "</box>");
-  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
-  const Box* box = dynamic_cast<const Box*>(shape.get());
+  std::optional<unique_ptr<Shape>> shape =
+      MakeShapeFromSdfGeometry(*sdf_geometry);
+  EXPECT_TRUE(shape.has_value());
+  const Box* box = dynamic_cast<const Box*>(shape->get());
   ASSERT_NE(box, nullptr);
   EXPECT_EQ(box->size(), Vector3d(1.0, 2.0, 3.0));
 }
@@ -249,8 +261,10 @@ TEST_F(SceneGraphParserDetail, MakeDrakeCapsuleFromSdfGeometry) {
       "  <radius>0.5</radius>"
       "  <length>1.2</length>"
       "</drake:capsule>");
-  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
-  const Capsule* capsule = dynamic_cast<const Capsule*>(shape.get());
+  std::optional<unique_ptr<Shape>> shape =
+      MakeShapeFromSdfGeometry(*sdf_geometry);
+  EXPECT_TRUE(shape.has_value());
+  const Capsule* capsule = dynamic_cast<const Capsule*>(shape->get());
   ASSERT_NE(capsule, nullptr);
   EXPECT_EQ(capsule->radius(), 0.5);
   EXPECT_EQ(capsule->length(), 1.2);
@@ -264,16 +278,23 @@ TEST_F(SceneGraphParserDetail, CheckInvalidDrakeCapsules) {
       "<drake:capsule>"
       "  <length>1.2</length>"
       "</drake:capsule>");
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      MakeShapeFromSdfGeometry(*no_radius_geometry),
-      "Element <radius> is required within element <drake:capsule>.");
+  std::optional<unique_ptr<Shape>> shape_no_radius =
+      MakeShapeFromSdfGeometry(*no_radius_geometry);
+  EXPECT_FALSE(shape_no_radius.has_value());
+  EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
+      ".*Element <radius> is required within element <drake:capsule>."));
+  ClearDiagnostics();
+
   unique_ptr<sdf::Geometry> no_length_geometry = MakeSdfGeometryFromString(
       "<drake:capsule>"
       "  <radius>0.5</radius>"
       "</drake:capsule>");
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      MakeShapeFromSdfGeometry(*no_length_geometry),
-      "Element <length> is required within element <drake:capsule>.");
+  std::optional<unique_ptr<Shape>> shape_no_length =
+      MakeShapeFromSdfGeometry(*no_length_geometry);
+  EXPECT_FALSE(shape_no_length.has_value());
+  EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
+      ".*Element <length> is required within element <drake:capsule>."));
+  ClearDiagnostics();
 }
 
 // Verify MakeShapeFromSdfGeometry can make a capsule from an sdf::Geometry.
@@ -283,8 +304,10 @@ TEST_F(SceneGraphParserDetail, MakeCapsuleFromSdfGeometry) {
       "  <radius>0.5</radius>"
       "  <length>1.2</length>"
       "</capsule>");
-  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
-  const Capsule* capsule = dynamic_cast<const Capsule*>(shape.get());
+  std::optional<unique_ptr<Shape>> shape =
+      MakeShapeFromSdfGeometry(*sdf_geometry);
+  EXPECT_TRUE(shape.has_value());
+  const Capsule* capsule = dynamic_cast<const Capsule*>(shape->get());
   ASSERT_NE(capsule, nullptr);
   EXPECT_EQ(capsule->radius(), 0.5);
   EXPECT_EQ(capsule->length(), 1.2);
@@ -297,8 +320,10 @@ TEST_F(SceneGraphParserDetail, MakeCylinderFromSdfGeometry) {
       "  <radius>0.5</radius>"
       "  <length>1.2</length>"
       "</cylinder>");
-  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
-  const Cylinder* cylinder = dynamic_cast<const Cylinder*>(shape.get());
+  std::optional<unique_ptr<Shape>> shape =
+      MakeShapeFromSdfGeometry(*sdf_geometry);
+  EXPECT_TRUE(shape.has_value());
+  const Cylinder* cylinder = dynamic_cast<const Cylinder*>(shape->get());
   ASSERT_NE(cylinder, nullptr);
   EXPECT_EQ(cylinder->radius(), 0.5);
   EXPECT_EQ(cylinder->length(), 1.2);
@@ -315,8 +340,10 @@ TEST_F(SceneGraphParserDetail, MakeDrakeEllipsoidFromSdfGeometry) {
       "  <b>1.2</b>"
       "  <c>0.9</c>"
       "</drake:ellipsoid>");
-  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
-  const Ellipsoid* ellipsoid = dynamic_cast<const Ellipsoid*>(shape.get());
+  std::optional<unique_ptr<Shape>> shape =
+      MakeShapeFromSdfGeometry(*sdf_geometry);
+  EXPECT_TRUE(shape.has_value());
+  const Ellipsoid* ellipsoid = dynamic_cast<const Ellipsoid*>(shape->get());
   ASSERT_NE(ellipsoid, nullptr);
   EXPECT_EQ(ellipsoid->a(), 0.5);
   EXPECT_EQ(ellipsoid->b(), 1.2);
@@ -332,25 +359,30 @@ TEST_F(SceneGraphParserDetail, CheckInvalidEllipsoids) {
       "  <b>1.2</b>"
       "  <c>0.9</c>"
       "</drake:ellipsoid>");
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      MakeShapeFromSdfGeometry(*no_a_geometry),
-      "Element <a> is required within element <drake:ellipsoid>.");
+  MakeShapeFromSdfGeometry(*no_a_geometry);
+  EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
+      ".*Element <a> is required within element <drake:ellipsoid>."));
+  ClearDiagnostics();
+
   unique_ptr<sdf::Geometry> no_b_geometry = MakeSdfGeometryFromString(
       "<drake:ellipsoid>"
       "  <a>0.5</a>"
       "  <c>0.9</c>"
       "</drake:ellipsoid>");
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      MakeShapeFromSdfGeometry(*no_b_geometry),
-      "Element <b> is required within element <drake:ellipsoid>.");
+  MakeShapeFromSdfGeometry(*no_b_geometry);
+  EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
+      ".*Element <b> is required within element <drake:ellipsoid>."));
+  ClearDiagnostics();
+
   unique_ptr<sdf::Geometry> no_c_geometry = MakeSdfGeometryFromString(
       "<drake:ellipsoid>"
       "  <a>0.5</a>"
       "  <b>1.2</b>"
       "</drake:ellipsoid>");
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      MakeShapeFromSdfGeometry(*no_c_geometry),
-      "Element <c> is required within element <drake:ellipsoid>.");
+  MakeShapeFromSdfGeometry(*no_c_geometry);
+  EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
+      ".*Element <c> is required within element <drake:ellipsoid>."));
+  ClearDiagnostics();
 }
 
 
@@ -360,8 +392,9 @@ TEST_F(SceneGraphParserDetail, MakeEllipsoidFromSdfGeometry) {
       "<ellipsoid>"
       "  <radii>0.5 1.2 0.9</radii>"
       "</ellipsoid>");
-  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
-  const Ellipsoid* ellipsoid = dynamic_cast<const Ellipsoid*>(shape.get());
+  std::optional<unique_ptr<Shape>> shape =
+      MakeShapeFromSdfGeometry(*sdf_geometry);
+  const Ellipsoid* ellipsoid = dynamic_cast<const Ellipsoid*>(shape->get());
   ASSERT_NE(ellipsoid, nullptr);
   EXPECT_EQ(ellipsoid->a(), 0.5);
   EXPECT_EQ(ellipsoid->b(), 1.2);
@@ -374,8 +407,9 @@ TEST_F(SceneGraphParserDetail, MakeSphereFromSdfGeometry) {
       "<sphere>"
       "  <radius>0.5</radius>"
       "</sphere>");
-  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
-  const Sphere* sphere = dynamic_cast<const Sphere*>(shape.get());
+  std::optional<unique_ptr<Shape>> shape =
+      MakeShapeFromSdfGeometry(*sdf_geometry);
+  const Sphere* sphere = dynamic_cast<const Sphere*>(shape->get());
   ASSERT_NE(sphere, nullptr);
   EXPECT_EQ(sphere->radius(), 0.5);
 }
@@ -389,8 +423,9 @@ TEST_F(SceneGraphParserDetail, MakeHalfSpaceFromSdfGeometry) {
       "</plane>");
   // MakeShapeFromSdfGeometry() ignores <normal> and <size> to create the
   // HalfSpace. Therefore we only verify it created the right object.
-  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
-  EXPECT_TRUE(dynamic_cast<const HalfSpace*>(shape.get()) != nullptr);
+  std::optional<unique_ptr<Shape>> shape =
+      MakeShapeFromSdfGeometry(*sdf_geometry);
+  EXPECT_TRUE(dynamic_cast<const HalfSpace*>(shape->get()) != nullptr);
 }
 
 // Verify MakeShapeFromSdfGeometry can make a mesh from an sdf::Geometry.
@@ -404,11 +439,30 @@ TEST_F(SceneGraphParserDetail, MakeMeshFromSdfGeometry) {
       "  <uri>" + absolute_file_path + "</uri>"
       "  <scale> 3 3 3 </scale>"
       "</mesh>");
-  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
-  const Mesh* mesh = dynamic_cast<const Mesh*>(shape.get());
+  std::optional<unique_ptr<Shape>> shape =
+      MakeShapeFromSdfGeometry(*sdf_geometry);
+  const Mesh* mesh = dynamic_cast<const Mesh*>(shape->get());
   ASSERT_NE(mesh, nullptr);
   EXPECT_EQ(mesh->filename(), absolute_file_path);
   EXPECT_EQ(mesh->scale(), 3);
+}
+
+// Verify error when mesh scale is not isotropic.
+TEST_F(SceneGraphParserDetail, MakeMeshFromSdfGeometryIsotropicError) {
+  // TODO(amcastro-tri): Be warned, the result of this test might (should)
+  // change as we add support allowing to specify paths relative to the SDF file
+  // location.
+  const std::string absolute_file_path = "/path/to/some/mesh.obj";
+  unique_ptr<sdf::Geometry> sdf_geometry = MakeSdfGeometryFromString(
+      "<mesh>"
+      "  <uri>" + absolute_file_path + "</uri>"
+      "  <scale> 3 1 2 </scale>"
+      "</mesh>");
+  MakeShapeFromSdfGeometry(*sdf_geometry);
+  EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
+      ".*Drake meshes only support isotropic scaling. Therefore"
+      " all three scaling factors must be exactly equal."));
+  ClearDiagnostics();
 }
 
 // Verify MakeShapeFromSdfGeometry can make a convex mesh from an sdf::Geometry.
@@ -420,8 +474,9 @@ TEST_F(SceneGraphParserDetail, MakeConvexFromSdfGeometry) {
       "  <uri>" + absolute_file_path + "</uri>"
       "  <scale> 3 3 3 </scale>"
       "</mesh>");
-  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
-  const Convex* convex = dynamic_cast<const Convex*>(shape.get());
+  std::optional<unique_ptr<Shape>> shape =
+      MakeShapeFromSdfGeometry(*sdf_geometry);
+  const Convex* convex = dynamic_cast<const Convex*>(shape->get());
   ASSERT_NE(convex, nullptr);
   EXPECT_EQ(convex->filename(), absolute_file_path);
   EXPECT_EQ(convex->scale(), 3);
@@ -433,8 +488,9 @@ TEST_F(SceneGraphParserDetail, MakeHeightmapFromSdfGeometry) {
       "<heightmap>"
       "  <uri>/path/to/some/heightmap.png</uri>"
       "</heightmap>");
-  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
-  EXPECT_EQ(shape, nullptr);
+  std::optional<unique_ptr<Shape>> shape =
+      MakeShapeFromSdfGeometry(*sdf_geometry);
+  EXPECT_EQ(*shape, nullptr);
 }
 
 // Verify that MakeShapeFromSdfGeometry does nothing with a polyline.
@@ -449,8 +505,10 @@ TEST_F(SceneGraphParserDetail, MakePolylineFromSdfGeometry) {
       "    <height>1</height>"
       "  </polyline>"
       "</polyline>");
-  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
-  EXPECT_EQ(shape, nullptr);
+  std::optional<unique_ptr<Shape>> shape =
+      MakeShapeFromSdfGeometry(*sdf_geometry);
+  EXPECT_TRUE(shape.has_value());
+  EXPECT_EQ(*shape, nullptr);
 }
 
 // Verify MakeGeometryInstanceFromSdfVisual can make a GeometryInstance from an
@@ -469,12 +527,12 @@ TEST_F(SceneGraphParserDetail, MakeGeometryInstanceFromSdfVisual) {
       "  </geometry>"
       "</visual>");
 
-  unique_ptr<GeometryInstance> geometry_instance =
+  std::optional<unique_ptr<GeometryInstance>> geometry_instance =
       MakeGeometryInstanceFromSdfVisual(
-          diagnostic_, *sdf_visual, NoopResolveFilename,
+          sdf_diagnostic_, *sdf_visual, NoopResolveFilename,
           ToRigidTransform(sdf_visual->RawPose()));
 
-  const RigidTransformd X_LC(geometry_instance->pose());
+  const RigidTransformd X_LC((*geometry_instance)->pose());
 
   // These are the expected values as specified by the string above.
   const RollPitchYaw<double> expected_rpy(3.14, 6.28, 1.57);
@@ -613,14 +671,14 @@ TEST_F(SceneGraphParserDetail, MakeHalfSpaceGeometryInstanceFromSdfVisual) {
       "  </geometry>"
       "</visual>");
 
-  unique_ptr<GeometryInstance> geometry_instance =
+  std::optional<unique_ptr<GeometryInstance>> geometry_instance =
       MakeGeometryInstanceFromSdfVisual(
-          diagnostic_, *sdf_visual, NoopResolveFilename,
+          sdf_diagnostic_, *sdf_visual, NoopResolveFilename,
           ToRigidTransform(sdf_visual->RawPose()));
 
   // Verify we do have a plane geometry.
   const HalfSpace* shape =
-      dynamic_cast<const HalfSpace*>(&geometry_instance->shape());
+      dynamic_cast<const HalfSpace*>(&(*geometry_instance)->shape());
   ASSERT_TRUE(shape != nullptr);
 
   // The expected coordinates of the normal vector in the link frame L.
@@ -632,7 +690,7 @@ TEST_F(SceneGraphParserDetail, MakeHalfSpaceGeometryInstanceFromSdfVisual) {
       HalfSpace::MakePose(normal_L_expected, Vector3d::Zero()).rotation();
 
   // Retrieve the GeometryInstance pose as parsed from the sdf::Visual.
-  const RotationMatrix<double> R_LC = geometry_instance->pose().rotation();
+  const RotationMatrix<double> R_LC = (*geometry_instance)->pose().rotation();
   const Vector3d normal_L = R_LC.col(2);
 
   // Verify results to precision given by kTolerance.
@@ -653,11 +711,11 @@ TEST_F(SceneGraphParserDetail, MakeEmptyGeometryInstanceFromSdfVisual) {
       "  </geometry>"
       "</visual>");
 
-  unique_ptr<GeometryInstance> geometry_instance =
+  std::optional<unique_ptr<GeometryInstance>> geometry_instance =
       MakeGeometryInstanceFromSdfVisual(
-          diagnostic_, *sdf_visual, NoopResolveFilename,
+          sdf_diagnostic_, *sdf_visual, NoopResolveFilename,
           ToRigidTransform(sdf_visual->RawPose()));
-  EXPECT_EQ(geometry_instance, nullptr);
+  EXPECT_EQ(*geometry_instance, nullptr);
 }
 
 
@@ -672,11 +730,11 @@ TEST_F(SceneGraphParserDetail, MakeHeightmapGeometryInstanceFromSdfVisual) {
     "    </heightmap>"
     "  </geometry>"
     "</visual>");
-  unique_ptr<GeometryInstance> geometry_instance =
+  std::optional<unique_ptr<GeometryInstance>> geometry_instance =
       MakeGeometryInstanceFromSdfVisual(
-          diagnostic_, *sdf_visual, NoopResolveFilename,
+          sdf_diagnostic_, *sdf_visual, NoopResolveFilename,
           ToRigidTransform(sdf_visual->RawPose()));
-  EXPECT_EQ(geometry_instance, nullptr);
+  EXPECT_EQ(*geometry_instance, nullptr);
 }
 
 // Reports if the indicated typed geometry property matches expectations.
@@ -833,9 +891,9 @@ TEST_F(SceneGraphParserDetail, ParseVisualMaterial) {
   {
     unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
         make_xml(false, nullptr, nullptr, nullptr, nullptr, ""));
-    IllustrationProperties material =
+    std::optional<IllustrationProperties> material =
         MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(expect_phong(material, false, {}, {}, {}, {}, {}));
+    EXPECT_TRUE(expect_phong(*material, false, {}, {}, {}, {}, {}));
   }
 
   // Case: Material tag defined, but no material properties -- empty
@@ -843,9 +901,9 @@ TEST_F(SceneGraphParserDetail, ParseVisualMaterial) {
   {
     unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
         make_xml(true, nullptr, nullptr, nullptr, nullptr, ""));
-    IllustrationProperties material =
+    std::optional<IllustrationProperties> material =
         MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(expect_phong(material, false, {}, {}, {}, {}, {}));
+    EXPECT_TRUE(expect_phong(*material, false, {}, {}, {}, {}, {}));
   }
 
   Vector4<double> diffuse{0.25, 0.5, 0.75, 1.0};
@@ -857,46 +915,46 @@ TEST_F(SceneGraphParserDetail, ParseVisualMaterial) {
   {
     unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
         make_xml(true, &diffuse, nullptr, nullptr, nullptr, ""));
-    IllustrationProperties material =
+    std::optional<IllustrationProperties> material =
         MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(expect_phong(material, true, diffuse, {}, {}, {}, {}));
+    EXPECT_TRUE(expect_phong(*material, true, diffuse, {}, {}, {}, {}));
   }
 
   // Case: Only valid specular defined.
   {
     unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
         make_xml(true, nullptr, &specular, nullptr, nullptr, ""));
-    IllustrationProperties material =
+    std::optional<IllustrationProperties> material =
         MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(expect_phong(material, true, {}, specular, {}, {}, {}));
+    EXPECT_TRUE(expect_phong(*material, true, {}, specular, {}, {}, {}));
   }
 
   // Case: Only valid ambient defined.
   {
     unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
         make_xml(true, nullptr, nullptr, &ambient, nullptr, ""));
-    IllustrationProperties material =
+    std::optional<IllustrationProperties> material =
         MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(expect_phong(material, true, {}, {}, ambient, {}, {}));
+    EXPECT_TRUE(expect_phong(*material, true, {}, {}, ambient, {}, {}));
   }
 
   // Case: Only valid emissive defined.
   {
     unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
         make_xml(true, nullptr, nullptr, nullptr, &emissive, ""));
-    IllustrationProperties material =
+    std::optional<IllustrationProperties> material =
         MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(expect_phong(material, true, {}, {}, {}, emissive, {}));
+    EXPECT_TRUE(expect_phong(*material, true, {}, {}, {}, emissive, {}));
   }
 
   // Case: All four.
   {
     unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
         make_xml(true, &diffuse, &specular, &ambient, &emissive, ""));
-    IllustrationProperties material =
+    std::optional<IllustrationProperties> material =
         MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(
-        expect_phong(material, true, diffuse, specular, ambient, emissive, {}));
+    EXPECT_TRUE(expect_phong(*material, true, diffuse,
+                specular, ambient, emissive, {}));
   }
 
   // Case: With diffuse map.
@@ -908,12 +966,27 @@ TEST_F(SceneGraphParserDetail, ParseVisualMaterial) {
         make_xml(true, &diffuse, &specular, &ambient, &emissive, kLocalMap);
     unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
         make_xml(true, &diffuse, &specular, &ambient, &emissive, kLocalMap));
-    IllustrationProperties material =
+    std::optional<IllustrationProperties> material =
         MakeVisualPropertiesFromSdfVisual(*sdf_visual);
     // Note: The "no-op" filename resolver will just return kLocalMap as the
     // property name.
-    EXPECT_TRUE(expect_phong(material, true, diffuse, specular, ambient,
-                             emissive, kLocalMap));
+    EXPECT_TRUE(expect_phong(*material, true, diffuse, specular,
+                             ambient, emissive, kLocalMap));
+  }
+
+  // Case: Diffuse map file not found.
+  {
+    const std::string kLocalMap = "empty.png";
+    const std::string xml =
+        make_xml(true, &diffuse, &specular, &ambient, &emissive, kLocalMap);
+    unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
+        make_xml(true, &diffuse, &specular, &ambient, &emissive, kLocalMap));
+    internal::MakeVisualPropertiesFromSdfVisual(sdf_diagnostic_,
+        *sdf_visual, [](const SDFormatDiagnostic&, std::string filename)
+            -> std::string {return {};});
+    EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
+        ".*Unable to locate the texture file: empty.png"));
+    ClearDiagnostics();
   }
 
   // Note: As of https://github.com/osrf/sdformat/pull/519, sdformat is doing
@@ -936,9 +1009,9 @@ TEST_F(SceneGraphParserDetail, ParseVisualMaterial) {
         "  <material>" + bad_diffuse +
         "  </material>"
         "</visual>");
-    IllustrationProperties material =
+    std::optional<IllustrationProperties> material =
         MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(expect_phong(material, false, {}, {}, {}, {}, {}));
+    EXPECT_TRUE(expect_phong(*material, false, {}, {}, {}, {}, {}));
   }
 }
 
@@ -961,9 +1034,9 @@ TEST_F(SceneGraphParserDetail, AcceptingRenderers) {
         "    <diffuse>0.25 1 0.5 0.25</diffuse>"
         "  </material>"
         "</visual>");
-    IllustrationProperties material =
+    std::optional<IllustrationProperties> material =
         MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_FALSE(material.HasProperty(group, property));
+    EXPECT_FALSE(material->HasProperty(group, property));
   }
 
   // Case: single <drake:accepting_renderer> tag.
@@ -981,11 +1054,11 @@ TEST_F(SceneGraphParserDetail, AcceptingRenderers) {
         "  </material>"
         "  <drake:accepting_renderer>renderer1</drake:accepting_renderer>"
         "</visual>");
-    IllustrationProperties material =
+    std::optional<IllustrationProperties> material =
         MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(material.HasProperty(group, property));
+    EXPECT_TRUE(material->HasProperty(group, property));
     const auto& names =
-        material.GetProperty<std::set<std::string>>(group, property);
+        material->GetProperty<std::set<std::string>>(group, property);
     EXPECT_EQ(names.size(), 1);
     EXPECT_EQ(names.count("renderer1"), 1);
   }
@@ -1006,11 +1079,11 @@ TEST_F(SceneGraphParserDetail, AcceptingRenderers) {
         "  <drake:accepting_renderer>renderer1</drake:accepting_renderer>"
         "  <drake:accepting_renderer>renderer2</drake:accepting_renderer>"
         "</visual>");
-    IllustrationProperties material =
+    std::optional<IllustrationProperties> material =
         MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(material.HasProperty(group, property));
+    EXPECT_TRUE(material->HasProperty(group, property));
     const auto& names =
-        material.GetProperty<std::set<std::string>>(group, property);
+        material->GetProperty<std::set<std::string>>(group, property);
     EXPECT_EQ(names.size(), 2);
     EXPECT_EQ(names.count("renderer1"), 1);
     EXPECT_EQ(names.count("renderer2"), 1);
@@ -1030,9 +1103,10 @@ TEST_F(SceneGraphParserDetail, AcceptingRenderers) {
         "  </material>"
         "  <drake:accepting_renderer> </drake:accepting_renderer>"
         "</visual>");
-    DRAKE_EXPECT_THROWS_MESSAGE(
-      MakeVisualPropertiesFromSdfVisual(*sdf_visual),
-      "<drake:accepting_renderer> tag given without any name");
+  MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+  EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
+      ".*<drake:accepting_renderer> tag given without any name"));
+  ClearDiagnostics();
 }
 
 // Verify MakeGeometryPoseFromSdfCollision() makes the pose X_LG of geometry
@@ -1153,17 +1227,18 @@ TEST_F(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
     <drake:mu_dynamic>4.5</drake:mu_dynamic>
     <drake:mu_static>4.75</drake:mu_static>
   </drake:proximity_properties>)""");
-    ProximityProperties properties = MakeProximityPropertiesForCollision(
-        diagnostic_, *sdf_collision);
-    assert_single_property(properties, geometry::internal::kHydroGroup,
+    std::optional<ProximityProperties> properties =
+        MakeProximityPropertiesForCollision(sdf_diagnostic_, *sdf_collision);
+    ASSERT_TRUE(properties.has_value());
+    assert_single_property(*properties, geometry::internal::kHydroGroup,
                            geometry::internal::kRezHint, 2.5);
-    assert_single_property(properties, geometry::internal::kHydroGroup,
+    assert_single_property(*properties, geometry::internal::kHydroGroup,
                            geometry::internal::kElastic, 3.5);
-    assert_single_property(properties, geometry::internal::kMaterialGroup,
+    assert_single_property(*properties, geometry::internal::kMaterialGroup,
                            geometry::internal::kHcDissipation, 4.5);
-    assert_single_property(properties, geometry::internal::kMaterialGroup,
+    assert_single_property(*properties, geometry::internal::kMaterialGroup,
                            geometry::internal::kRelaxationTime, 3.1);
-    assert_friction(properties, {4.75, 4.5});
+    assert_friction(*properties, {4.75, 4.5});
   }
 
   // Case: specifies rigid hydroelastic.
@@ -1172,11 +1247,12 @@ TEST_F(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
   <drake:proximity_properties>
     <drake:rigid_hydroelastic/>
   </drake:proximity_properties>)""");
-    ProximityProperties properties = MakeProximityPropertiesForCollision(
-        diagnostic_, *sdf_collision);
-    ASSERT_TRUE(properties.HasProperty(geometry::internal::kHydroGroup,
+    std::optional<ProximityProperties> properties =
+        MakeProximityPropertiesForCollision(sdf_diagnostic_, *sdf_collision);
+    ASSERT_TRUE(properties.has_value());
+    ASSERT_TRUE(properties->HasProperty(geometry::internal::kHydroGroup,
                                        geometry::internal::kComplianceType));
-    EXPECT_EQ(properties.GetProperty<geometry::internal::HydroelasticType>(
+    EXPECT_EQ(properties->GetProperty<geometry::internal::HydroelasticType>(
         geometry::internal::kHydroGroup, geometry::internal::kComplianceType),
               geometry::internal::HydroelasticType::kRigid);
   }
@@ -1187,11 +1263,12 @@ TEST_F(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
   <drake:proximity_properties>
     <drake:compliant_hydroelastic/>
   </drake:proximity_properties>)""");
-    ProximityProperties properties = MakeProximityPropertiesForCollision(
-        diagnostic_, *sdf_collision);
-    ASSERT_TRUE(properties.HasProperty(geometry::internal::kHydroGroup,
+    std::optional<ProximityProperties> properties =
+        MakeProximityPropertiesForCollision(sdf_diagnostic_, *sdf_collision);
+    ASSERT_TRUE(properties.has_value());
+    ASSERT_TRUE(properties->HasProperty(geometry::internal::kHydroGroup,
                                        geometry::internal::kComplianceType));
-    EXPECT_EQ(properties.GetProperty<geometry::internal::HydroelasticType>(
+    EXPECT_EQ(properties->GetProperty<geometry::internal::HydroelasticType>(
         geometry::internal::kHydroGroup, geometry::internal::kComplianceType),
               geometry::internal::HydroelasticType::kSoft);
   }
@@ -1204,11 +1281,14 @@ TEST_F(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
   <drake:proximity_properties>
     <drake:soft_hydroelastic/>
   </drake:proximity_properties>)""");
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        MakeProximityPropertiesForCollision(diagnostic_, *sdf_collision),
-        "A <collision> geometry has defined the unsupported tag "
+    std::optional<ProximityProperties> properties =
+        MakeProximityPropertiesForCollision(sdf_diagnostic_, *sdf_collision);
+    EXPECT_FALSE(properties.has_value());
+    EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
+        ".*A <collision> geometry has defined the unsupported tag "
         "<drake:soft_hydroelastic>. Please change it to "
-        "<drake:compliant_hydroelastic>.");
+        "<drake:compliant_hydroelastic>."));
+    ClearDiagnostics();
   }
 
   // Case: specifies both -- should be an error.
@@ -1218,10 +1298,13 @@ TEST_F(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
     <drake:rigid_hydroelastic/>
     <drake:compliant_hydroelastic/>
   </drake:proximity_properties>)""");
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        MakeProximityPropertiesForCollision(diagnostic_, *sdf_collision),
-        "A <collision> geometry has defined mutually-exclusive tags .*rigid.* "
-        "and .*compliant.*");
+    std::optional<ProximityProperties> properties =
+        MakeProximityPropertiesForCollision(sdf_diagnostic_, *sdf_collision);
+    EXPECT_FALSE(properties.has_value());
+    EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
+        ".*A <collision> geometry has defined mutually-exclusive tags "
+        ".*rigid.* and .*compliant.*"));
+    ClearDiagnostics();
   }
 
   // Case: has no drake coefficients, only mu & m2 in ode: contains mu, mu2
@@ -1236,9 +1319,10 @@ TEST_F(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
       </ode>
     </friction>
   </surface>)""");
-    ProximityProperties properties = MakeProximityPropertiesForCollision(
-        diagnostic_, *sdf_collision);
-    assert_friction(properties, {0.8, 0.3});
+    std::optional<ProximityProperties> properties =
+        MakeProximityPropertiesForCollision(sdf_diagnostic_, *sdf_collision);
+    ASSERT_TRUE(properties.has_value());
+    assert_friction(*properties, {0.8, 0.3});
   }
 
   // Case: has both ode (mu, mu2) and drake (dynamic): contains
@@ -1261,13 +1345,16 @@ TEST_F(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
     diagnostic.SetActionForWarnings([&](const DiagnosticDetail& detail) {
       warning = detail;
     });
-    ProximityProperties properties =
-        MakeProximityPropertiesForCollision(diagnostic, *sdf_collision);
+    const std::string file_path("file.txt");
+    DataSource data_source(DataSource::kFilename, &file_path);
+    SDFormatDiagnostic sdf_diagnostic(&diagnostic, &data_source);
+    std::optional<ProximityProperties> properties =
+        MakeProximityPropertiesForCollision(sdf_diagnostic, *sdf_collision);
+    ASSERT_TRUE(properties.has_value());
     EXPECT_THAT(warning.message, ::testing::MatchesRegex(
         ".*collision.*some_geo.*ode.*ignored.*"));
-    assert_friction(properties, {0.3, 0.3});
+    assert_friction(*properties, {0.3, 0.3});
   }
-
   // Note: we're not explicitly testing negative friction coefficients or
   // dynamic > static because we rely on the CoulombFriction constructor to
   // handle that.
@@ -1294,10 +1381,11 @@ TEST_F(SceneGraphParserDetail, MakeCoulombFrictionFromSdfCollisionOde) {
       "    </friction>"
       "  </surface>"
       "</collision>");
-  const CoulombFriction<double> friction =
-      MakeCoulombFrictionFromSdfCollisionOde(*sdf_collision);
-  EXPECT_EQ(friction.static_friction(), 0.8);
-  EXPECT_EQ(friction.dynamic_friction(), 0.3);
+  std::optional<CoulombFriction<double>> friction =
+      MakeCoulombFrictionFromSdfCollisionOde(sdf_diagnostic_, *sdf_collision);
+  ASSERT_TRUE(friction.has_value());
+  EXPECT_EQ(friction->static_friction(), 0.8);
+  EXPECT_EQ(friction->dynamic_friction(), 0.3);
 }
 
 // Verify that if no <surface> tag is present, we return default friction
@@ -1313,11 +1401,16 @@ TEST_F(SceneGraphParserDetail,
       "    </plane>"
       "  </geometry>"
       "</collision>");
-  const CoulombFriction<double> friction =
-      MakeCoulombFrictionFromSdfCollisionOde(*sdf_collision);
-  const CoulombFriction<double> expected_friction = default_friction();
-  EXPECT_EQ(friction.static_friction(), expected_friction.static_friction());
-  EXPECT_EQ(friction.dynamic_friction(), expected_friction.dynamic_friction());
+  std::optional<CoulombFriction<double>> friction =
+      MakeCoulombFrictionFromSdfCollisionOde(sdf_diagnostic_, *sdf_collision);
+  ASSERT_TRUE(friction.has_value());
+  std::optional<CoulombFriction<double>> expected_friction =
+      default_friction();
+  ASSERT_TRUE(expected_friction.has_value());
+  EXPECT_EQ(friction->static_friction(),
+            expected_friction->static_friction());
+  EXPECT_EQ(friction->dynamic_friction(),
+            expected_friction->dynamic_friction());
 }
 
 // Verify MakeCoulombFrictionFromSdfCollisionOde() throws an exception if
@@ -1352,7 +1445,7 @@ TEST_F(SceneGraphParserDetail,
       "  </surface>"
       "</collision>");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      MakeCoulombFrictionFromSdfCollisionOde(*sdf_collision),
+      MakeCoulombFrictionFromSdfCollisionOde(sdf_diagnostic_, *sdf_collision),
       "The given dynamic friction \\(.*\\) is greater than the given static "
       "friction \\(.*\\); dynamic friction must be less than or equal to "
       "static friction.");
@@ -1377,7 +1470,7 @@ TEST_F(SceneGraphParserDetail,
       "  </surface>"
       "</collision>");
   EXPECT_EQ(
-      MakeCoulombFrictionFromSdfCollisionOde(*sdf_collision),
+      MakeCoulombFrictionFromSdfCollisionOde(sdf_diagnostic_, *sdf_collision),
       CoulombFriction<double>(default_friction().static_friction(), 0.8));
 }
 
@@ -1400,7 +1493,7 @@ TEST_F(SceneGraphParserDetail,
       "  </surface>"
       "</collision>");
   EXPECT_EQ(
-      MakeCoulombFrictionFromSdfCollisionOde(*sdf_collision),
+      MakeCoulombFrictionFromSdfCollisionOde(sdf_diagnostic_, *sdf_collision),
       CoulombFriction<double>(1.1, default_friction().dynamic_friction()));
 }
 
@@ -1425,7 +1518,7 @@ TEST_F(SceneGraphParserDetail,
   // report a parsing error and/or raise an exception.  For now though, we
   // ignore it and use the defaults.
   EXPECT_EQ(
-      MakeCoulombFrictionFromSdfCollisionOde(*sdf_collision),
+      MakeCoulombFrictionFromSdfCollisionOde(sdf_diagnostic_, *sdf_collision),
       default_friction());
 }
 
@@ -1450,7 +1543,7 @@ TEST_F(SceneGraphParserDetail,
   // report a parsing error and/or raise an exception.  For now though, we
   // ignore it and use the defaults.
   EXPECT_EQ(
-      MakeCoulombFrictionFromSdfCollisionOde(*sdf_collision),
+      MakeCoulombFrictionFromSdfCollisionOde(sdf_diagnostic_, *sdf_collision),
       default_friction());
 }
 

--- a/multibody/parsing/test/diagnostic_policy_test_base.h
+++ b/multibody/parsing/test/diagnostic_policy_test_base.h
@@ -83,6 +83,47 @@ class DiagnosticPolicyTestBase : public ::testing::Test {
     return stream.str();
   }
 
+  void ThrowErrors() {
+    diagnostic_policy_.SetActionForErrors(
+        &DiagnosticPolicy::ErrorDefaultAction);
+  }
+
+  void RecordErrors() {
+    diagnostic_policy_.SetActionForErrors(
+    [this](const DiagnosticDetail& detail) {
+      error_records_.push_back(detail);
+    });
+  }
+
+  // Returns the first error as a string (or else fails the test case,
+  // if there were no errors).
+  std::string FormatFirstError() {
+    if (error_records_.empty()) {
+      for (const auto& warning : warning_records_) {
+        drake::log()->warn(warning.FormatWarning());
+      }
+      EXPECT_GT(error_records_.size(), 0)
+          << "FormatFirstError did not get any errors";
+      return {};
+    }
+    return error_records_[0].FormatError();
+  }
+
+  // Returns the first warning as a string (or else fails the test case,
+  // if there were no warnings). Also fails if there were any errors.
+  std::string FormatFirstWarning() {
+    for (const auto& error : error_records_) {
+      drake::log()->error(error.FormatError());
+    }
+    EXPECT_TRUE(error_records_.empty());
+    if (warning_records_.empty()) {
+      EXPECT_TRUE(warning_records_.size() > 0)
+          << "FormatFirstWarning did not get any warnings";
+      return {};
+    }
+    return warning_records_[0].FormatWarning();
+  }
+
   template <typename T>
   T Take(std::deque<T>* c) {
     T result = c->at(0);

--- a/multibody/parsing/test/parser_test.cc
+++ b/multibody/parsing/test/parser_test.cc
@@ -414,7 +414,7 @@ GTEST_TEST(FileParserTest, PackageMapTest) {
   // Attempt to read in the SDF file without setting the package map first.
   const std::string new_sdf_filename = sdf_path + "/box.sdf";
   DRAKE_EXPECT_THROWS_MESSAGE(parser.AddModelFromFile(new_sdf_filename),
-      "error.*unknown package.*box_model.*");
+      ".*error.*unknown package.*box_model.*");
 
   // Try again.
   parser.package_map().PopulateFromFolder(temp_dir);


### PR DESCRIPTION
Work towards https://github.com/RobotLocomotion/drake/issues/17053.

This PR adds filename/lineno to errors and warnings thrown from `detail_sdf_parser.cc`.

Some questions about it:

- Do we see value in creating a similar structure as [detail_tinixml2_diagnostic](https://github.com/RobotLocomotion/drake/blob/master/multibody/parsing/detail_tinyxml2_diagnostic.cc) for sdf? if so, should we add it in a following PR?
- Anything we should do about the exceptions being thrown?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18462)
<!-- Reviewable:end -->
