### PR TITLE
Support Gurobi 9.5.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,7 +483,7 @@ set(BAZEL_CONFIGS)
 option(WITH_GUROBI "Build with support for Gurobi" OFF)
 
 if(WITH_GUROBI)
-  find_package(Gurobi 9.5.1 EXACT MODULE REQUIRED)
+  find_package(Gurobi 9.5 EXACT MODULE REQUIRED)
 
   list(APPEND BAZEL_CONFIGS --config=gurobi)
 

--- a/cmake/modules/FindGurobi.cmake
+++ b/cmake/modules/FindGurobi.cmake
@@ -1,11 +1,15 @@
 # -*- mode: cmake -*-
 # vi: set ft=cmake :
 
+file(GLOB _GUROBI_SEARCH_PATHS
+    /Library/gurobi95*/macos_universal2
+    /opt/gurobi95*/linux64
+    /opt/gurobi95*/power64
+)
+
 find_path(Gurobi_INCLUDE_DIR NAMES gurobi_c.h
   PATHS
-    /Library/gurobi951/macos_universal2
-    /opt/gurobi951/linux64
-    /opt/gurobi951/power64
+    ${_GUROBI_SEARCH_PATHS}
     ENV GUROBI_HOME
   PATH_SUFFIXES include
 )
@@ -38,14 +42,13 @@ find_library(Gurobi_LIBRARY
   NAMES "gurobi${Gurobi_VERSION_MAJOR}${Gurobi_VERSION_MINOR}"
   HINTS "${_GUROBI_ROOT}"
   PATHS
-    /Library/gurobi951/macos_universal2
-    /opt/gurobi951/linux64
-    /opt/gurobi951/power64
+    ${_GUROBI_SEARCH_PATHS}
     ENV GUROBI_HOME
   PATH_SUFFIXES lib
 )
 
 unset(_GUROBI_ROOT)
+unset(_GUROBI_SEARCH_PATHS)
 
 include(FindPackageHandleStandardArgs)
 

--- a/doc/_pages/bazel.md
+++ b/doc/_pages/bazel.md
@@ -169,27 +169,31 @@ bazel build //tools/lint:buildifier
 
 The Drake Bazel build currently supports the following proprietary solvers:
 
-* Gurobi 9.5.1
+* Gurobi 9.5
 * MOSEK™ 10.0
 * SNOPT 7.4
 
-## Gurobi 9.5.1
+## Gurobi 9.5
 
 ### Install on Ubuntu
 
 1. Register for an account on [https://www.gurobi.com](https://www.gurobi.com).
 2. Set up your Gurobi license file in accordance with Gurobi documentation.
 3. ``export GRB_LICENSE_FILE=/path/to/gurobi.lic``.
-4. Download ``gurobi9.5.1_linux64.tar.gz``. You may need to manually edit the URL to get the correct minor version.
-5. Unzip it.  We suggest that you use ``/opt/gurobi951`` to simplify working with Drake installations.
-6. If you unzipped into a location other than ``/opt/gurobi951``, then call ``export GUROBI_HOME=GUROBI_UNZIP_PATH/linux64`` to set the path you used, where in ``GUROBI_HOME`` folder you can find ``bin`` folder.
+4. Download ``gurobi9.5.2_linux64.tar.gz``. You may need to manually edit the URL to get the correct version.
+5. Unzip it.  We suggest that you use ``/opt/gurobi952`` to simplify working with Drake installations.
+6. If you unzipped into a location other than ``/opt/gurobi952``, then call ``export GUROBI_HOME=GUROBI_UNZIP_PATH/linux64`` to set the path you used, where in ``GUROBI_HOME`` folder you can find ``bin`` folder.
+
+Drake supports any patch version of Gurobi 9.5. At time of writing, the most
+recent available version was 9.5.2; if using a newer patch version, the paths
+and file names above should be adjusted accordingly.
 
 ### Install on macOS
 
 1. Register for an account on [http://www.gurobi.com](http://www.gurobi.com).
 2. Set up your Gurobi license file in accordance with Gurobi documentation.
 3. ``export GRB_LICENSE_FILE=/path/to/gurobi.lic``
-4. Download and install ``gurobi9.5.1_mac64.pkg``.
+4. Download and install ``gurobi9.5.2_mac64.pkg``.
 
 To confirm that your setup was successful, run the tests that require Gurobi:
 

--- a/doc/_pages/python_bindings.md
+++ b/doc/_pages/python_bindings.md
@@ -42,7 +42,7 @@ python3 -c 'import pydrake.all; print(pydrake.__file__)'
 ```
 
 <div class="note" markdown="1">
-If you are using Gurobi, you must either have it installed in the suggested location under `/opt/...` mentioned in Gurobi 9.5.1, or you must ensure that you define the `${GUROBI_HOME}` environment variable, or specify `${GUROBI_INCLUDE_DIR}` via CMake.
+If you are using Gurobi, you must either have it installed in the suggested location under `/opt/...` mentioned in Gurobi 9.5, or you must ensure that you define the `${GUROBI_HOME}` environment variable, or specify `${GUROBI_INCLUDE_DIR}` via CMake.
 </div>
 
 

--- a/tools/workspace/gurobi/package-macos.BUILD.bazel.in
+++ b/tools/workspace/gurobi/package-macos.BUILD.bazel.in
@@ -11,7 +11,7 @@ licenses(["by_exception_only"])  # Gurobi
 genrule(
     name = "error-message",
     outs = ["error-message.h"],
-    cmd = "echo 'error: Gurobi 9.5.1 is not installed at {gurobi_home}' && false",  # noqa
+    cmd = "echo 'error: Gurobi 9.5 is not installed at {gurobi_home}' && false",  # noqa
     visibility = ["//visibility:private"],
 )
 

--- a/tools/workspace/gurobi/package-ubuntu.BUILD.bazel.in
+++ b/tools/workspace/gurobi/package-ubuntu.BUILD.bazel.in
@@ -12,7 +12,7 @@ licenses(["by_exception_only"])  # Gurobi
 genrule(
     name = "error-message",
     outs = ["error-message.h"],
-    cmd = "echo 'error: Gurobi 9.5.1 is not installed at {gurobi_home}, export GUROBI_HOME to the correct value' && false",  # noqa
+    cmd = "echo 'error: Gurobi 9.5 is not installed at {gurobi_home}, export GUROBI_HOME to the correct value' && false",  # noqa
     visibility = ["//visibility:private"],
 )
 
@@ -25,8 +25,8 @@ GUROBI_CXX_HDRS = glob([
     "gurobi-distro/include/gurobi_c++.h",
 ]) or [":error-message.h"]
 
-# In the Gurobi package, libgurobi95.so is a symlink to libgurobi.so.9.0.0.
-# However, if we use libgurobi.so.9.0.0 in srcs, executables that link this
+# In the Gurobi package, libgurobi95.so is a symlink to libgurobi.so.9.5.*.
+# However, if we use libgurobi.so.9.5.* in srcs, executables that link this
 # library will be unable to find it at runtime in the Bazel sandbox,
 # because the NEEDED statements in the executable will not square with the
 # RPATH statements.  I don't really know why this happens, but I suspect it
@@ -42,7 +42,7 @@ GUROBI_CXX_SRCS = glob([
 ]) or [":error-message.h"]
 
 GUROBI_INSTALL_LIBRARIES = glob([
-    "gurobi-distro/lib/libgurobi.so.9.5.1",
+    "gurobi-distro/lib/libgurobi.so.9.5.*",
     "gurobi-distro/lib/libgurobi95.so",
 ]) or [":error-message.h"]
 


### PR DESCRIPTION
Remove logic that limits Gurobi to 9.5.1, in order to support 9.5.x at any patch version. Update documentation accordingly.

Towards #14157.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18464)
<!-- Reviewable:end -->
