### PR TITLE
Add Linux Python 3.11 wheel

### DIFF
--- a/doc/_pages/pip.md
+++ b/doc/_pages/pip.md
@@ -106,18 +106,20 @@ Mac x86_64 are generated nightly and are available to download at:
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp38-cp38-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp38-cp38-manylinux_2_31_x86_64.whl)
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp39-cp39-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp39-cp39-manylinux_2_31_x86_64.whl)
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp310-cp310-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp310-cp310-manylinux_2_31_x86_64.whl)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp311-cp311-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp311-cp311-manylinux_2_31_x86_64.whl)
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp310-cp310-macosx_12_0_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp310-cp310-macosx_12_0_x86_64.whl)
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp310-cp310-macosx_12_0_arm64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp310-cp310-macosx_12_0_arm64.whl)
 
 Older packages for specific dates are available by replacing ``latest`` with an
-8-digit date, e.g., ``20221110`` for November 10th, 2022.  The version number to
+8-digit date, e.g., ``20221217`` for December 17th, 2022.  The version number to
 replace ``latest`` with follows the pattern ``0.0.YYYYMMDD``.
 
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221110-cp38-cp38-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221110-cp38-cp38-manylinux_2_31_x86_64.whl)
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221110-cp39-cp39-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221110-cp39-cp39-manylinux_2_31_x86_64.whl)
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221110-cp310-cp310-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221110-cp310-cp310-manylinux_2_31_x86_64.whl)
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221110-cp310-cp310-macosx_12_0_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221110-cp310-cp310-macosx_12_0_x86_64.whl)
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221110-cp310-cp310-macosx_12_0_arm64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221110-cp310-cp310-macosx_12_0_arm64.whl)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221217-cp38-cp38-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221217-cp38-cp38-manylinux_2_31_x86_64.whl)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221217-cp39-cp39-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221217-cp39-cp39-manylinux_2_31_x86_64.whl)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221217-cp310-cp310-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221217-cp310-cp310-manylinux_2_31_x86_64.whl)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221217-cp311-cp311-manylinux_2_31_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221217-cp311-cp311-manylinux_2_31_x86_64.whl)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221217-cp310-cp310-macosx_12_0_x86_64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221217-cp310-cp310-macosx_12_0_x86_64.whl)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221217-cp310-cp310-macosx_12_0_arm64.whl](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20221217-cp310-cp310-macosx_12_0_arm64.whl)
 
 Nightly wheels are retained for 56 days from their date of creation.
 

--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -174,11 +174,11 @@ the main body of the document:
       appropriate edits as follows:
       * The version number
    5. Into the box labeled "Attach binaries by dropping them here or selecting
-      them.", drag and drop the 33 release files from
+      them.", drag and drop the 36 release files from
       ``/tmp/drake-release/v1.N.0``:
       - 12: 4 `.tar.gz` + 8 checksums
       - 6: 2 `.deb` + 4 checksums
-      - 9: 3 linux `.whl` + 6 checksums
+      - 9: 4 linux `.whl` + 8 checksums
       - 3: 1 macOS x86 `.whl` + 2 checksums
       - 3: 1 macOS arm `.whl` + 2 checksums
    6. Choose "Save draft" and take a deep breath.

--- a/tools/release_engineering/download_release_candidate.py
+++ b/tools/release_engineering/download_release_candidate.py
@@ -134,6 +134,7 @@ def _download_binaries(*, timestamp, staging, version):
             f"drake-{version[1:]}-cp38-cp38-manylinux_2_31_x86_64.whl",
             f"drake-{version[1:]}-cp39-cp39-manylinux_2_31_x86_64.whl",
             f"drake-{version[1:]}-cp310-cp310-manylinux_2_31_x86_64.whl",
+            f"drake-{version[1:]}-cp311-cp311-manylinux_2_31_x86_64.whl",
             f"drake-{version[1:]}-cp310-cp310-macosx_12_0_x86_64.whl",
             f"drake-{version[1:]}-cp310-cp310-macosx_12_0_arm64.whl",
             # Deb filenames.

--- a/tools/wheel/image/provision-python.sh
+++ b/tools/wheel/image/provision-python.sh
@@ -28,6 +28,10 @@ fi
 
 ${PREFIX}/bin/${PYTHON} -m venv /usr/local
 
+# Python 3.11 venv creates an empty directory here, which prevents us creating
+# a symlink to the real directory, so remove it if present.
+rmdir /usr/local/include/${PYTHON} || true
+
 ln -s ${PREFIX}/bin/${PYTHON}-config /usr/bin/python3-config
 ln -s ${PREFIX}/bin/${PYTHON}-config /usr/local/bin/python-config
 ln -s ${PREFIX}/include/${PYTHON} /usr/local/include/

--- a/tools/wheel/wheel_builder/linux.py
+++ b/tools/wheel/wheel_builder/linux.py
@@ -42,6 +42,11 @@ targets = (
         test_platform=Platform('ubuntu', '22.04', 'jammy'),
         python_version_tuple=(3, 10, 6),
         python_sha='f795ff87d11d4b0c7c33bc8851b0c28648d8a4583aa2100a98c22b4326b6d3f3'),  # noqa
+    Target(
+        build_platform=Platform('ubuntu', '20.04', 'focal'),
+        test_platform=Platform('ubuntu', '22.04', 'jammy'),
+        python_version_tuple=(3, 11, 1),
+        python_sha='85879192f2cffd56cb16c092905949ebf3e5e394b7f764723529637901dfb58f'),  # noqa
 )
 glibc_versions = {
     'focal': '2_31',

--- a/tools/workspace/python/repository.bzl
+++ b/tools/workspace/python/repository.bzl
@@ -55,7 +55,7 @@ _VERSION_SUPPORT_MATRIX = {
     # - Update URLs on doc/_pages/pip.md (`cpXY-cpXY` components), and
     # - Tables on from_source.md and installation.md (python version number).
     "macos_wheel": ["3.10"],
-    "manylinux": ["3.8", "3.9", "3.10"],
+    "manylinux": ["3.8", "3.9", "3.10", "3.11"],
 }
 
 def repository_python_info(repository_ctx):


### PR DESCRIPTION
Also build a Linux wheel against Python 3.11. Like 3.10, this uses Python built from source. Update relevant release-playbook documentation and script.

Fixes #18417.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18468)
<!-- Reviewable:end -->
