### PR TITLE
[visualization] Add sliders for geometry alpha in MeshcatVisualizer

### DIFF
--- a/geometry/meshcat_visualizer_params.h
+++ b/geometry/meshcat_visualizer_params.h
@@ -20,6 +20,7 @@ struct MeshcatVisualizerParams {
     a->Visit(DRAKE_NVP(default_color));
     a->Visit(DRAKE_NVP(prefix));
     a->Visit(DRAKE_NVP(delete_on_initialization_event));
+    a->Visit(DRAKE_NVP(enable_alpha_slider));
   }
 
   /** The duration (in simulation seconds) between attempts to update poses in
@@ -46,6 +47,9 @@ struct MeshcatVisualizerParams {
    simulation. See @ref declare_initialization_events "Declare initialization
    events" for more information. */
   bool delete_on_initialization_event{true};
+
+  /** Determines whether to enable the alpha slider for geometry display. */
+  bool enable_alpha_slider{false};
 };
 
 }  // namespace geometry

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -103,6 +103,8 @@ TEST_F(MeshcatVisualizerWithIiwaTest, PublishPeriod) {
 // Confirms that all geometry registered to iiwa_link_7 in the urdf (in all
 // three allowed roles) gets properly added.
 TEST_F(MeshcatVisualizerWithIiwaTest, Roles) {
+  // This also tests adding multiple MeshcatVisualizers to a single meshcat,
+  // which is a common workflow in Python notebooks.
   MeshcatVisualizerParams params;
   for (Role role : {Role::kProximity, Role::kIllustration, Role::kPerception}) {
     params.role = role;
@@ -123,6 +125,15 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Roles) {
   params.role = Role::kUnassigned;
   DRAKE_EXPECT_THROWS_MESSAGE(SetUpDiagram(params),
                               ".*Role::kUnassigned.*");
+}
+
+// Tests that adding multiple MeshcatVisualizers using the same role to a
+// single meshcat works, as this is a common workflow in Python notebooks.
+TEST_F(MeshcatVisualizerWithIiwaTest, DuplicateRole) {
+  MeshcatVisualizerParams params;
+  params.role = Role::kIllustration;
+  SetUpDiagram(params);
+  SetUpDiagram(params);
 }
 
 TEST_F(MeshcatVisualizerWithIiwaTest, Prefix) {
@@ -277,6 +288,23 @@ TEST_F(MeshcatVisualizerWithIiwaTest, ScalarConversion) {
   // UpdateMeshcat / SetObjects SetTransforms.  We simply confirm that the code
   // doesn't blow up.
   ad_diagram->ForcedPublish(*ad_context);
+}
+
+TEST_F(MeshcatVisualizerWithIiwaTest, UpdateAlphaSliders) {
+  MeshcatVisualizerParams params;
+  params.enable_alpha_slider = true;
+  SetUpDiagram(params);
+  systems::Simulator<double> simulator(*diagram_);
+
+  // Simulate for a moment and publish to populate the visualizer.
+  simulator.AdvanceTo(0.1);
+  diagram_->ForcedPublish(*context_);
+
+  meshcat_->SetSliderValue("visualizer α", 0.5);
+
+  // Simulate and publish again to cause an update.
+  simulator.AdvanceTo(0.1);
+  diagram_->ForcedPublish(*context_);
 }
 
 GTEST_TEST(MeshcatVisualizerTest, MultipleModels) {

--- a/visualization/test/visualization_config_functions_test.cc
+++ b/visualization/test/visualization_config_functions_test.cc
@@ -71,6 +71,8 @@ GTEST_TEST(VisualizationConfigFunctionsTest, ParamConversionDefault) {
             config.default_illustration_color);
   EXPECT_EQ(meshcat_params.at(0).delete_on_initialization_event,
             config.delete_on_initialization_event);
+  EXPECT_EQ(meshcat_params.at(0).enable_alpha_slider,
+            config.enable_alpha_sliders);
 
   EXPECT_EQ(meshcat_params.at(1).role, Role::kProximity);
   EXPECT_EQ(meshcat_params.at(1).publish_period, config.publish_period);
@@ -78,6 +80,8 @@ GTEST_TEST(VisualizationConfigFunctionsTest, ParamConversionDefault) {
             config.default_proximity_color);
   EXPECT_EQ(meshcat_params.at(1).delete_on_initialization_event,
             config.delete_on_initialization_event);
+  EXPECT_EQ(meshcat_params.at(1).enable_alpha_slider,
+            config.enable_alpha_sliders);
 }
 
 // Tests the mapping from non-default schema data to geometry params.
@@ -86,6 +90,7 @@ GTEST_TEST(VisualizationConfigFunctionsTest, ParamConversionSpecial) {
   config.publish_period = 0.5;
   config.publish_proximity = false;
   config.default_illustration_color = Rgba(0.25, 0.25, 0.25, 0.25);
+  config.enable_alpha_sliders = true;
 
   const std::vector<DrakeVisualizerParams> drake_params =
       ConvertVisualizationConfigToDrakeParams(config);
@@ -101,6 +106,7 @@ GTEST_TEST(VisualizationConfigFunctionsTest, ParamConversionSpecial) {
   EXPECT_EQ(meshcat_params.at(0).role, Role::kIllustration);
   EXPECT_EQ(meshcat_params.at(0).publish_period, 0.5);
   EXPECT_EQ(meshcat_params.at(0).default_color, Rgba(0.25, 0.25, 0.25, 0.25));
+  EXPECT_EQ(meshcat_params.at(0).enable_alpha_slider, true);
 }
 
 // Tests everything disabled.
@@ -138,8 +144,8 @@ GTEST_TEST(VisualizationConfigFunctionsTest, ApplyDefault) {
   // Check that we can pass an existing meshcat.
   std::shared_ptr<Meshcat> meshcat = std::make_shared<Meshcat>();
   const VisualizationConfig config;
-  ApplyVisualizationConfig(config, &builder, &lcm_buses, &plant, &scene_graph,
-                           meshcat);
+  ApplyVisualizationConfig(
+    config, &builder, &lcm_buses, &plant, &scene_graph, meshcat);
   Simulator<double> simulator(builder.Build());
 
   // Simulate for a moment and make sure everything showed up.
@@ -151,6 +157,14 @@ GTEST_TEST(VisualizationConfigFunctionsTest, ApplyDefault) {
       "DRAKE_VIEWER_DRAW",
       "DRAKE_VIEWER_DRAW_PROXIMITY",
       "CONTACT_RESULTS"}));
+
+  // Check that alpha sliders don't exist by default.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+    meshcat->GetSliderValue("illustration α"),
+    ".*does not have any slider named illustration.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+    meshcat->GetSliderValue("proximity α"),
+    ".*does not have any slider named proximity.*");
 }
 
 // Overall acceptance test with nothing enabled.
@@ -211,6 +225,27 @@ GTEST_TEST(VisualizationConfigFunctionsTest, NoMeshcat) {
     }
   }
   EXPECT_EQ(meshcat_count, 2);
+}
+
+// Check that turning on the alpha sliders functions as expected.
+GTEST_TEST(VisualizationConfigFunctionsTest, AlphaSliders) {
+  DrakeLcm drake_lcm;
+  LcmBuses lcm_buses;
+  lcm_buses.Add("default", &drake_lcm);
+
+  // Add MbP and SG, then the default visualization.
+  DiagramBuilder<double> builder;
+  auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.0);
+  plant.Finalize();
+  std::shared_ptr<Meshcat> meshcat = std::make_shared<Meshcat>();
+  VisualizationConfig config;
+  config.enable_alpha_sliders = true;
+  ApplyVisualizationConfig(
+    config, &builder, &lcm_buses, &plant, &scene_graph, meshcat);
+
+  // Check that alpha sliders exist.
+  meshcat->GetSliderValue("illustration α");
+  meshcat->GetSliderValue("proximity α");
 }
 
 // The AddDefault... sugar shouldn't crash.

--- a/visualization/visualization_config.h
+++ b/visualization/visualization_config.h
@@ -31,6 +31,7 @@ struct VisualizationConfig {
     a->Visit(DRAKE_NVP(publish_contacts));
     a->Visit(DRAKE_NVP(enable_meshcat_creation));
     a->Visit(DRAKE_NVP(delete_on_initialization_event));
+    a->Visit(DRAKE_NVP(enable_alpha_sliders));
   }
 
   /** Which LCM URL to use.
@@ -67,6 +68,9 @@ struct VisualizationConfig {
    object (if any) on an initialization event to remove any visualizations,
    e.g., from a previous simulation, to . */
   bool delete_on_initialization_event{true};
+
+  /** Determines whether to enable alpha sliders for geometry display. */
+  bool enable_alpha_sliders{false};
 };
 
 }  // namespace visualization

--- a/visualization/visualization_config_functions.cc
+++ b/visualization/visualization_config_functions.cc
@@ -141,6 +141,7 @@ ConvertVisualizationConfigToMeshcatParams(
     illustration.prefix = std::string("illustration");
     illustration.delete_on_initialization_event =
         config.delete_on_initialization_event;
+    illustration.enable_alpha_slider = config.enable_alpha_sliders;
     result.push_back(illustration);
   }
 
@@ -152,6 +153,7 @@ ConvertVisualizationConfigToMeshcatParams(
     proximity.prefix = std::string("proximity");
     proximity.delete_on_initialization_event =
         config.delete_on_initialization_event;
+    proximity.enable_alpha_slider = config.enable_alpha_sliders;
     result.push_back(proximity);
   }
 


### PR DESCRIPTION
Adds optional sliders to adjust the visual alpha of geometry added by MeshcatVisualizer. These sliders default to being disabled for now while we discuss the preferred method for handling these without breaking other code.

This reworks #18454, which was reverted by #18463; the main difference is that the sliders are disabled by default, and so the dubious test deltas aren't necessary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18469)
<!-- Reviewable:end -->
