### PR TITLE
[multibody] Add 3-dof ball constraints to SAP

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -473,6 +473,16 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "sap_driver_ball_constraints_test",
+    deps = [
+        ":compliant_contact_manager_tester",
+        ":plant",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
     name = "sap_driver_joint_limits_test",
     data = [
         "//manipulation/models/iiwa_description:models",

--- a/multibody/plant/constraint_specs.h
+++ b/multibody/plant/constraint_specs.h
@@ -66,6 +66,28 @@ struct DistanceConstraintSpecs {
   double damping{0.0};  // Constraint damping c in N⋅s/m.
 };
 
+// Struct to store the specification for a ball constraint. A ball
+// constraint is modeled as a holonomic constraint:
+//   p_PQ_W(q) = 0
+// P is a point rigidly affixed to body A and Q is a point rigidly affixed to
+// body B. p_PQ_W(q) denotes the relative position of point Q with respect to
+// point P, expressed in the world frame, as a function of the configuration of
+// the model q. Imposing this constraint forces P and Q to be coincident, but
+// does not restrict the rotational degrees of freedom.
+//
+// @pre body_A != body_B. @see IsValid().
+struct BallConstraintSpecs {
+  // Returns `true` iff `this` specification is valid to define a ball
+  // constraint. A ball constraint specification is considered to be valid iff:
+  //   body_A != body_B.
+  bool IsValid() { return body_A != body_B; }
+
+  BodyIndex body_A;      // Index of body A.
+  Vector3<double> p_AP;  // Position of point P in body frame A.
+  BodyIndex body_B;      // Index of body B.
+  Vector3<double> p_BQ;  // Position of point Q in body frame B.
+};
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -166,6 +166,13 @@ DiscreteUpdateManager<T>::distance_constraints_specs() const {
 }
 
 template <typename T>
+const std::vector<internal::BallConstraintSpecs>&
+DiscreteUpdateManager<T>::ball_constraints_specs() const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<T>::ball_constraints_specs(
+      *plant_);
+}
+
+template <typename T>
 BodyIndex DiscreteUpdateManager<T>::FindBodyByGeometryId(
     geometry::GeometryId geometry_id) const {
   return MultibodyPlantDiscreteUpdateManagerAttorney<T>::FindBodyByGeometryId(

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -248,6 +248,9 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   const std::vector<internal::DistanceConstraintSpecs>&
   distance_constraints_specs() const;
 
+  const std::vector<internal::BallConstraintSpecs>& ball_constraints_specs()
+      const;
+
   BodyIndex FindBodyByGeometryId(geometry::GeometryId geometry_id) const;
   /* @} */
 

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -392,6 +392,7 @@ MultibodyPlant<T>::MultibodyPlant(const MultibodyPlant<U>& other)
 
     coupler_constraints_specs_ = other.coupler_constraints_specs_;
     distance_constraints_specs_ = other.distance_constraints_specs_;
+    ball_constraints_specs_ = other.ball_constraints_specs_;
 
     // cache_indexes_ is set in DeclareCacheEntries() in
     // DeclareStateCacheAndPorts() in FinalizePlantOnly().
@@ -500,6 +501,49 @@ ConstraintIndex MultibodyPlant<T>::AddDistanceConstraint(
   const ConstraintIndex constraint_index(num_constraints());
 
   distance_constraints_specs_.push_back(spec);
+
+  return constraint_index;
+}
+
+template <typename T>
+ConstraintIndex MultibodyPlant<T>::AddBallConstraint(
+    const Body<T>& body_A, const Vector3<double>& p_AP, const Body<T>& body_B,
+    const Vector3<double>& p_BQ) {
+  // N.B. The manager is set up at Finalize() and therefore we must require
+  // constraints to be added pre-finalize.
+  DRAKE_MBP_THROW_IF_FINALIZED();
+
+  if (!is_discrete()) {
+    throw std::runtime_error(
+        "Currently ball constraints are only supported for discrete "
+        "MultibodyPlant models.");
+  }
+
+  // TAMSI does not support ball constraints. For all other solvers, we let
+  // the discrete update manager throw an exception at finalize time.
+  if (contact_solver_enum_ == DiscreteContactSolver::kTamsi) {
+    throw std::runtime_error(
+        "Currently this MultibodyPlant is set to use the TAMSI solver. TAMSI "
+        "does not support ball constraints. Use "
+        "set_discrete_contact_solver(DiscreteContactSolver::kSap) to use the "
+        "SAP solver instead. For other solvers, refer to "
+        "DiscreteContactSolver.");
+  }
+
+  internal::BallConstraintSpecs spec{body_A.index(), p_AP, body_B.index(),
+                                     p_BQ};
+  if (!spec.IsValid()) {
+    const std::string msg = fmt::format(
+        "Invalid set of parameters for constraint between bodies '{}' and "
+        "'{}'. For a ball constraint, points P and Q must be on two distinct "
+        "bodies, i.e. body_A != body_B must be satisfied.",
+        body_A.name(), body_B.name());
+    throw std::logic_error(msg);
+  }
+
+  const ConstraintIndex constraint_index(num_constraints());
+
+  ball_constraints_specs_.push_back(spec);
 
   return constraint_index;
 }

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1195,7 +1195,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// Returns the total number of constraints specified by the user.
   int num_constraints() const {
     return static_cast<int>(coupler_constraints_specs_.size() +
-           distance_constraints_specs_.size());
+                            distance_constraints_specs_.size() +
+                            ball_constraints_specs_.size());
   }
 
   /// Defines a holonomic constraint between two single-dof joints `joint0`
@@ -1276,6 +1277,23 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const Vector3<double>& p_BQ, double distance,
       double stiffness = std::numeric_limits<double>::infinity(),
       double damping = 0.0);
+
+  /// Defines a constraint such that point P affixed to body A is coincident at
+  /// all times with point Q affixed to body B, effectively modeling a
+  /// ball-and-socket joint.
+  ///
+  /// @param[in] body_A Body to which point P is rigidly attached.
+  /// @param[in] p_AP Position of point P in body A's frame.
+  /// @param[in] body_B Body to which point Q is rigidly attached.
+  /// @param[in] p_BQ Position of point Q in body B's frame.
+  /// @returns the index to the newly added constraint.
+  ///
+  /// @throws std::exception if bodies A and B are the same body.
+  /// @throws std::exception if the %MultibodyPlant has already been finalized.
+  ConstraintIndex AddBallConstraint(const Body<T>& body_A,
+                                    const Vector3<double>& p_AP,
+                                    const Body<T>& body_B,
+                                    const Vector3<double>& p_BQ);
 
   /// <!-- TODO(xuchenhan-tri): Add getters to interrogate existing constraints.
   /// -->
@@ -5246,6 +5264,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   // Vector of distance constraints specifications.
   std::vector<internal::DistanceConstraintSpecs> distance_constraints_specs_;
+
+  // Vector of ball constraint specifications.
+  std::vector<internal::BallConstraintSpecs> ball_constraints_specs_;
 
   // All MultibodyPlant cache indexes are stored in cache_indexes_.
   CacheIndexes cache_indexes_;

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -119,6 +119,11 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
     return plant.distance_constraints_specs_;
   }
 
+  static const std::vector<internal::BallConstraintSpecs>&
+  ball_constraints_specs(const MultibodyPlant<T>& plant) {
+    return plant.ball_constraints_specs_;
+  }
+
   static BodyIndex FindBodyByGeometryId(const MultibodyPlant<T>& plant,
                                         geometry::GeometryId geometry_id) {
     return plant.FindBodyByGeometryId(geometry_id);

--- a/multibody/plant/sap_driver.h
+++ b/multibody/plant/sap_driver.h
@@ -144,6 +144,14 @@ class SapDriver {
       const systems::Context<T>& context,
       contact_solvers::internal::SapContactProblem<T>* problem) const;
 
+  // Adds holonomic constraint equations to model ball constraints specified in
+  // the MultibodyPlant.
+  // @throws std::exception if both bodies have invalid tree indices from the
+  // tree topology (i.e. both bodies are welded to `world`).
+  void AddBallConstraints(
+      const systems::Context<T>& context,
+      contact_solvers::internal::SapContactProblem<T>* problem) const;
+
   // This method takes SAP results for a given `problem` and loads forces due to
   // contact only into `contact_results`. `contact_results` is properly resized
   // on output.

--- a/multibody/plant/test/sap_driver_ball_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_ball_constraints_test.cc
@@ -1,0 +1,286 @@
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
+#include "drake/multibody/contact_solvers/sap/sap_holonomic_constraint.h"
+#include "drake/multibody/plant/compliant_contact_manager.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/sap_driver.h"
+#include "drake/multibody/plant/test/compliant_contact_manager_tester.h"
+
+/* @file This file tests SapDriver's support for ball constraints. */
+
+using drake::math::RigidTransformd;
+using drake::multibody::contact_solvers::internal::SapContactProblem;
+using drake::multibody::contact_solvers::internal::SapHolonomicConstraint;
+using drake::systems::Context;
+using Eigen::MatrixXd;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+
+constexpr double kInfinity = std::numeric_limits<double>::infinity();
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Friend class used to provide access to a selection of private functions in
+// SapDriver for testing purposes.
+class SapDriverTest {
+ public:
+  static const ContactProblemCache<double>& EvalContactProblemCache(
+      const SapDriver<double>& driver, const Context<double>& context) {
+    return driver.EvalContactProblemCache(context);
+  }
+};
+
+struct TestConfig {
+  // This is a gtest test suffix; no underscores or spaces.
+  std::string description;
+  bool bodyA_anchored{};
+};
+
+// This provides the suffix for each test parameter: the test config
+// description.
+std::ostream& operator<<(std::ostream& out, const TestConfig& c) {
+  out << c.description;
+  return out;
+}
+
+// Fixture that sets a MultibodyPlant model of two bodies A and B with a
+// ball constraint connecting point P on body A and point Q on body B.
+class TwoBodiesTest : public ::testing::TestWithParam<TestConfig> {
+ public:
+  // Makes the model described in the fixture's documentation.
+  // @param[in] anchor_bodyA If true, body A will be anchored to the world.
+  // Otherwise body A has 6 DOFs as body B does.
+  void MakeModel(bool anchor_bodyA) {
+    plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+
+    // Arbitrary inertia values only used by the driver to build a valid contact
+    // problem.
+    const double mass = 1.5;
+    const double radius = 0.1;
+    const SpatialInertia<double> M_Bo =
+        SpatialInertia<double>::MakeFromCentralInertia(
+            mass, Vector3d::Zero(),
+            UnitInertia<double>::SolidSphere(radius) * mass);
+
+    bodyA_ = &plant_.AddRigidBody("A", M_Bo);
+    bodyB_ = &plant_.AddRigidBody("B", M_Bo);
+    if (anchor_bodyA) {
+      plant_.WeldFrames(plant_.world_frame(), bodyA_->body_frame());
+    }
+
+    plant_.AddBallConstraint(*bodyA_, p_AP_, *bodyB_, p_BQ_);
+
+    plant_.Finalize();
+
+    auto owned_contact_manager =
+        std::make_unique<CompliantContactManager<double>>();
+    manager_ = owned_contact_manager.get();
+    plant_.SetDiscreteUpdateManager(std::move(owned_contact_manager));
+    // Model with a single ball constraint.
+    EXPECT_EQ(plant_.num_constraints(), 1);
+
+    context_ = plant_.CreateDefaultContext();
+  }
+
+  const SapDriver<double>& sap_driver() const {
+    return CompliantContactManagerTester::sap_driver(*manager_);
+  }
+
+ protected:
+  MultibodyPlant<double> plant_{0.01};  // Discrete model.
+  const RigidBody<double>* bodyA_{nullptr};
+  const RigidBody<double>* bodyB_{nullptr};
+  CompliantContactManager<double>* manager_{nullptr};
+  std::unique_ptr<Context<double>> context_;
+
+  // Parameters of the problem. Arbitrary and non-zero.
+  Vector3d p_AP_{1.0, -2.0, 3.0};
+  Vector3d p_BQ_{-5.0, 4.0, -6.0};
+  const Vector3d kOffset_{0.1, 0.2, 0.3};
+};
+
+// This test configures a single ball constraint in variety of ways (causing
+// differing numbers of cliques and varying constraint properties). It then
+// examines the newly added constraint to confirm that its instantiation
+// reflects the specification.
+TEST_P(TwoBodiesTest, ConfirmConstraintProperties) {
+  const TestConfig& config = GetParam();
+
+  MakeModel(config.bodyA_anchored);
+
+  const int expected_num_velocities = config.bodyA_anchored ? 6 : 12;
+  EXPECT_EQ(plant_.num_velocities(), expected_num_velocities);
+
+  // Place Bo at known offset from Ao; this does *not* satisfy the
+  // constraint. We'll observe a non-zero value when evaluating the constraint
+  // function.
+  plant_.SetFreeBodyPoseInWorldFrame(context_.get(), *bodyB_,
+                                     RigidTransformd(kOffset_));
+
+  const ContactProblemCache<double>& problem_cache =
+      SapDriverTest::EvalContactProblemCache(sap_driver(), *context_);
+  const SapContactProblem<double>& problem = *problem_cache.sap_problem;
+
+  // Verify the expected number of constraints and equations for a single
+  // ball constraint.
+  EXPECT_EQ(problem.num_constraints(), 1);
+  EXPECT_EQ(problem.num_constraint_equations(), 3);
+
+  const auto* constraint = dynamic_cast<const SapHolonomicConstraint<double>*>(
+      &problem.get_constraint(0));
+  // Verify it is a SapHolonomicConstraint as expected.
+  ASSERT_NE(constraint, nullptr);
+
+  // One clique if body A is anchored, two if not.
+  const int expected_num_cliques = config.bodyA_anchored ? 1 : 2;
+  EXPECT_EQ(constraint->num_cliques(), expected_num_cliques);
+  EXPECT_EQ(constraint->first_clique(), 0);
+  if (expected_num_cliques == 1) {
+    EXPECT_THROW(constraint->second_clique(), std::exception);
+  } else {
+    EXPECT_EQ(constraint->second_clique(), 1);
+  }
+
+  // Verify parameters.
+  const SapHolonomicConstraint<double>::Parameters p = constraint->parameters();
+  EXPECT_EQ(p.num_constraint_equations(), 3);
+  // bi-lateral constraint with no impulse bounds.
+  EXPECT_EQ(p.impulse_lower_limits(),
+            Vector3d(-kInfinity, -kInfinity, -kInfinity));
+  EXPECT_EQ(p.impulse_upper_limits(),
+            Vector3d(kInfinity, kInfinity, kInfinity));
+
+  EXPECT_EQ(p.stiffnesses(), Vector3d(kInfinity, kInfinity, kInfinity));
+  EXPECT_EQ(p.relaxation_times(), plant_.time_step() * Vector3d::Ones());
+
+  // This value is hard-coded in the source. This test serves as a brake to
+  // prevent the value changing without notification. Changing this value
+  // would lead to a behavior change and shouldn't happen silently.
+  EXPECT_EQ(p.beta(), 0.1);
+
+  // The constraint function for a ball constraint is defined as:
+  //   g = p_WQ - p_WP
+  // We verify its value.
+  const VectorXd& g = constraint->constraint_function();
+  const RigidTransformd& X_WA = plant_.EvalBodyPoseInWorld(*context_, *bodyA_);
+  const RigidTransformd& X_WB = plant_.EvalBodyPoseInWorld(*context_, *bodyB_);
+  const Vector3d g_expected = X_WB * p_BQ_ - X_WA * p_AP_;
+  EXPECT_TRUE(CompareMatrices(g, g_expected));
+
+  // Verify the constraint Jacobians (based on number of cliques).
+  // We know by construction that the 6 generalized velocities for a floating
+  // body, A, are laid out in the same order as V_WA. We can express the
+  // Jacobian of the constraint with respect to each body's spatial velocity:
+  //
+  // g = p_PQ_W
+  //
+  // d(g)/dt = v_PQ_W
+  //
+  // v_PQ_W = v_WQ - v_WP
+  //        = (v_WB + w_WB x p_BQ) - (v_WA + w_WA x p_AP)
+  //        = (v_WB - p_BQ x w_WB) - (v_WA - p_AP x w_WA)
+  //        = [-[p_BQ]ₓ [I]] ⋅ V_WB - [-[p_AP]ₓ [I]] ⋅ V_WA
+  //        = J_B ⋅ V_WB - J_A ⋅ V_WA
+  if (expected_num_cliques == 1) {
+    const MatrixXd& J = constraint->first_clique_jacobian();
+    // clang-format off
+      const MatrixXd J_expected =
+        (MatrixXd(3, 6) <<         0,  p_BQ_(2), -p_BQ_(1), 1, 0, 0,
+                           -p_BQ_(2),         0,  p_BQ_(0), 0, 1, 0,
+                            p_BQ_(1), -p_BQ_(0),         0, 0, 0, 1).finished();
+    // clang-format on
+    EXPECT_TRUE(CompareMatrices(J, J_expected));
+  } else {
+    const MatrixXd& Ja = constraint->first_clique_jacobian();
+    // clang-format off
+    const MatrixXd Ja_expected =
+      -(MatrixXd(3, 6) <<         0,  p_AP_(2), -p_AP_(1), 1, 0, 0,
+                          -p_AP_(2),         0,  p_AP_(0), 0, 1, 0,
+                           p_AP_(1), -p_AP_(0),         0, 0, 0, 1).finished();
+    // clang-format on
+    EXPECT_TRUE(CompareMatrices(Ja, Ja_expected));
+
+    const MatrixXd& Jb = constraint->second_clique_jacobian();
+    // clang-format off
+      const MatrixXd Jb_expected =
+        (MatrixXd(3, 6) <<         0,  p_BQ_(2), -p_BQ_(1), 1, 0, 0,
+                           -p_BQ_(2),         0,  p_BQ_(0), 0, 1, 0,
+                            p_BQ_(1), -p_BQ_(0),         0, 0, 0, 1).finished();
+    // clang-format on
+    EXPECT_TRUE(CompareMatrices(Jb, Jb_expected));
+  }
+}
+
+std::vector<TestConfig> MakeTestCases() {
+  return std::vector<TestConfig>{
+      {.description = "SingleClique", .bodyA_anchored = true},
+      {.description = "TwoCliques", .bodyA_anchored = false},
+  };
+}
+
+INSTANTIATE_TEST_SUITE_P(SapBallConstraintTests, TwoBodiesTest,
+                         testing::ValuesIn(MakeTestCases()),
+                         testing::PrintToStringParamName());
+
+GTEST_TEST(BallConstraintTests, FailOnTAMSI) {
+  MultibodyPlant<double> plant{0.1};
+  plant.set_discrete_contact_solver(DiscreteContactSolver::kTamsi);
+  const RigidBody<double>& bodyA =
+      plant.AddRigidBody("A", SpatialInertia<double>{});
+  const RigidBody<double>& bodyB =
+      plant.AddRigidBody("B", SpatialInertia<double>{});
+  DRAKE_EXPECT_THROWS_MESSAGE(plant.AddBallConstraint(bodyA, Vector3d{0, 0, 0},
+                                                      bodyB, Vector3d{0, 0, 0}),
+                              ".*TAMSI does not support ball constraints.*");
+}
+
+GTEST_TEST(BallConstraintTests, FailOnContinuous) {
+  MultibodyPlant<double> plant{0.0};
+  const RigidBody<double>& bodyA =
+      plant.AddRigidBody("A", SpatialInertia<double>{});
+  const RigidBody<double>& bodyB =
+      plant.AddRigidBody("B", SpatialInertia<double>{});
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant.AddBallConstraint(bodyA, Vector3d{0, 0, 0}, bodyB,
+                              Vector3d{0, 0, 0}),
+      ".*Currently ball constraints are only supported for discrete "
+      "MultibodyPlant models.*");
+}
+
+GTEST_TEST(BallConstraintTests, FailOnFinalized) {
+  MultibodyPlant<double> plant{0.1};
+  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  const RigidBody<double>& bodyA =
+      plant.AddRigidBody("A", SpatialInertia<double>{});
+  const RigidBody<double>& bodyB =
+      plant.AddRigidBody("B", SpatialInertia<double>{});
+  plant.Finalize();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant.AddBallConstraint(bodyA, Vector3d{0, 0, 0}, bodyB,
+                              Vector3d{0, 0, 0}),
+      ".*Post-finalize calls to 'AddBallConstraint\\(\\)' are not allowed.*");
+}
+
+GTEST_TEST(BallConstraintTests, FailOnSameBody) {
+  MultibodyPlant<double> plant{0.1};
+  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  const RigidBody<double>& bodyA =
+      plant.AddRigidBody("A", SpatialInertia<double>{});
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant.AddBallConstraint(bodyA, Vector3d{0, 0, 0}, bodyA,
+                              Vector3d{0, 0, 0}),
+      ".*Invalid set of parameters for constraint between bodies 'A' and "
+      "'A'.*");
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Implements support for ball constraints when using the SAP solver.
With this PR the user can set a ball constraint with the call to `MultibodyPlant::AddBallConstraint()`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18470)
<!-- Reviewable:end -->
