### PR TITLE
When we document "_absolute_ file path", enforce it

### DIFF
--- a/bindings/pydrake/systems/test/planar_scenegraph_visualizer_test.py
+++ b/bindings/pydrake/systems/test/planar_scenegraph_visualizer_test.py
@@ -176,13 +176,13 @@ class TestPlanarSceneGraphVisualizer(unittest.TestCase):
                 scene_graph, substitute_collocated_mesh_files=False)
 
         # This should report that the file does not exist.
-        scene_graph = scene_graph_with_mesh("garbage.obj")
+        scene_graph = scene_graph_with_mesh("/garbage.obj")
         with self.assertRaises(FileNotFoundError):
             PlanarSceneGraphVisualizer(scene_graph)
 
         # This should report that the extension was wrong and no .obj was
         # found.
-        scene_graph = scene_graph_with_mesh("garbage.STL")
+        scene_graph = scene_graph_with_mesh("/garbage.STL")
         with self.assertRaises(RuntimeError):
             PlanarSceneGraphVisualizer(scene_graph)
 

--- a/bindings/pydrake/test/geometry_common_test.py
+++ b/bindings/pydrake/test/geometry_common_test.py
@@ -323,8 +323,8 @@ class TestGeometryCore(unittest.TestCase):
             mut.Capsule(radius=1.0, length=2.0),
             mut.Ellipsoid(a=1.0, b=2.0, c=3.0),
             mut.HalfSpace(),
-            mut.Mesh(absolute_filename="arbitrary/path", scale=1.0),
-            mut.Convex(absolute_filename="arbitrary/path", scale=1.0),
+            mut.Mesh(absolute_filename="/arbitrary/path", scale=1.0),
+            mut.Convex(absolute_filename="/arbitrary/path", scale=1.0),
             mut.MeshcatCone(height=1.23, a=3.45, b=6.78)
         ]
         for shape in shapes:
@@ -366,7 +366,7 @@ class TestGeometryCore(unittest.TestCase):
         assert_pickle(
             self, capsule, lambda shape: [shape.radius(), shape.length()])
 
-        junk_path = "arbitrary/path"
+        junk_path = "/arbitrary/path"
         convex = mut.Convex(absolute_filename=junk_path, scale=1.0)
         assert_shape_api(convex)
         self.assertEqual(convex.filename(), junk_path)

--- a/geometry/proximity/test/characterization_utilities.cc
+++ b/geometry/proximity/test/characterization_utilities.cc
@@ -679,7 +679,7 @@ Capsule CharacterizeResultTest<T>::capsule(bool alt) {
 
 template <typename T>
 Convex CharacterizeResultTest<T>::convex(bool) {
-  return Convex("ignored for this test", 1.0);
+  return Convex("/ignored/for/this/test", 1.0);
 }
 
 template <typename T>

--- a/geometry/proximity/test/characterization_utilities_test.cc
+++ b/geometry/proximity/test/characterization_utilities_test.cc
@@ -48,7 +48,7 @@ GTEST_TEST(MakeFclShapeTest, Capsule) {
 }
 
 GTEST_TEST(MakeFclShapeTest, Convex) {
-  auto fcl_geometry = MakeFclShape(Convex("ignored", 1.0)).object();
+  auto fcl_geometry = MakeFclShape(Convex("/ignored", 1.0)).object();
   const auto& fcl_convex = dynamic_cast<fcl::Convexd&>(*fcl_geometry);
   /* The convex shape is actually a box with fixed dimensions. We won't *prove*
    it's the expected box. But we'll confirm:
@@ -216,7 +216,7 @@ GTEST_TEST(SampleShapeSurfaceTest, Convex) {
   /* The convex is actually a box with edge half lengths defined by
    convex_half_size(). We'll generate the samples based on a convex declaration,
    but test against a box.  */
-  const Convex convex("ignored", 1.0);
+  const Convex convex("/ignored", 1.0);
   const Box box = CharacterizeResultTest<double>::box();
   const Vector3d half_size = box.size() / 2;
   /* We validate for a requested penetration that is too deep.  */

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -74,6 +74,17 @@ Capsule::Capsule(const Vector2<double>& measures)
 
 Convex::Convex(const std::string& absolute_filename, double scale)
     : Shape(ShapeTag<Convex>()), filename_(absolute_filename), scale_(scale) {
+  auto path = std::filesystem::path(absolute_filename);
+  if (path.is_relative()) {
+    throw std::logic_error(fmt::format(
+      "Mesh filename `{}` is a relative path; it must be absolute.",
+      absolute_filename));
+  }
+  if (!path.has_filename()) {
+    throw std::logic_error(fmt::format(
+      "Mesh filename `{}` is a directory; it must be a file.",
+      absolute_filename));
+  }
   if (std::abs(scale) < 1e-8) {
     throw std::logic_error("Convex |scale| cannot be < 1e-8.");
   }
@@ -142,6 +153,17 @@ RigidTransform<double> HalfSpace::MakePose(const Vector3<double>& Hz_dir_F,
 
 Mesh::Mesh(const std::string& absolute_filename, double scale)
     : Shape(ShapeTag<Mesh>()), filename_(absolute_filename), scale_(scale) {
+  auto path = std::filesystem::path(absolute_filename);
+  if (path.is_relative()) {
+    throw std::logic_error(fmt::format(
+      "Mesh filename `{}` is a relative path; it must be absolute.",
+      absolute_filename));
+  }
+  if (!path.has_filename()) {
+    throw std::logic_error(fmt::format(
+      "Mesh filename `{}` is a directory; it must be a file.",
+      absolute_filename));
+  }
   if (std::abs(scale) < 1e-8) {
     throw std::logic_error("Mesh |scale| cannot be < 1e-8.");
   }

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -185,6 +185,8 @@ class Convex final : public Shape {
                                 We assume that the polyhedron is convex.
    @param scale                 An optional scale to coordinates.
 
+   @throws std::exception       if `absolute_filename` is not absolute or a
+                                filename.
    @throws std::exception       if the .obj file doesn't define a single object.
                                 This can happen if it is empty, if there are
                                 multiple object-name statements (e.g.,
@@ -312,7 +314,9 @@ class Mesh final : public Shape {
    @throws std::exception if |scale| < 1e-8. Note that a negative scale is
    considered valid. We want to preclude scales near zero but recognise that
    scale is a convenience tool for "tweaking" models. 8 orders of magnitude
-   should be plenty without considering revisiting the model itself. */
+   should be plenty without considering revisiting the model itself.
+   @throws std::exception if `absolute_filename` is not absolute or a filename.
+  */
   explicit Mesh(const std::string& absolute_filename, double scale = 1.0);
 
   const std::string& filename() const { return filename_; }

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -808,12 +808,12 @@ TEST_F(GeometryStateTest, IntrospectShapes) {
         matcher.ShapeIntrospects(&geometry_state_, source_id, frame_id));
   }
   {
-    ShapeMatcher<Mesh> matcher(Mesh{"Path/to/mesh", 0.25});
+    ShapeMatcher<Mesh> matcher(Mesh{"/Path/to/mesh", 0.25});
     EXPECT_TRUE(
         matcher.ShapeIntrospects(&geometry_state_, source_id, frame_id));
   }
   {
-    ShapeMatcher<Convex> matcher(Convex{"Path/to/convex", 0.25});
+    ShapeMatcher<Convex> matcher(Convex{"/Path/to/convex", 0.25});
     EXPECT_TRUE(
         matcher.ShapeIntrospects(&geometry_state_, source_id, frame_id));
   }

--- a/geometry/test/make_mesh_for_deformable_test.cc
+++ b/geometry/test/make_mesh_for_deformable_test.cc
@@ -63,7 +63,7 @@ TEST_F(MeshBuilderForDeformableTest, Mesh) {
 }
 
 TEST_F(MeshBuilderForDeformableTest, Convex) {
-  const Convex m("path/to/file", 1.5);
+  const Convex m("/path/to/file", 1.5);
   DRAKE_EXPECT_THROWS_MESSAGE(
       builder_.Build(m, kRezHint),
       ".*don't yet generate deformable meshes.+ Convex.");

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -299,10 +299,10 @@ GTEST_TEST(MeshcatTest, SetObjectWithShape) {
                        .25));
   EXPECT_FALSE(meshcat.GetPackedObject("convex").empty());
   // Bad filename (no extension).  Should only log a warning.
-  meshcat.SetObject("bad", Mesh("test"));
+  meshcat.SetObject("bad", Mesh("/test"));
   EXPECT_TRUE(meshcat.GetPackedObject("bad").empty());
   // Bad filename (file doesn't exist).  Should only log a warning.
-  meshcat.SetObject("bad", Mesh("test.obj"));
+  meshcat.SetObject("bad", Mesh("/test.obj"));
   EXPECT_TRUE(meshcat.GetPackedObject("bad").empty());
 }
 

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -123,7 +123,7 @@ TEST_F(ReifierTest, ReificationDifferentiation) {
 
   Reset();
 
-  const Convex convex{"fictitious_name.obj", 1.0};
+  const Convex convex{"/fictitious_name.obj", 1.0};
   convex.Reify(this);
   EXPECT_FALSE(sphere_made_);
   EXPECT_FALSE(half_space_made_);
@@ -179,7 +179,7 @@ TEST_F(ReifierTest, ReificationDifferentiation) {
 
   Reset();
 
-  const Mesh mesh{"fictitious_mesh_name.obj", 1.4};
+  const Mesh mesh{"/fictitious_mesh_name.obj", 1.4};
   mesh.Reify(this);
   EXPECT_FALSE(sphere_made_);
   EXPECT_FALSE(half_space_made_);
@@ -406,7 +406,7 @@ GTEST_TEST(BoxTest, Cube) {
 // Simple test that exercises all constructors and confirms the construction
 // parameters are reflected in the getters.
 GTEST_TEST(ShapeTest, Constructors) {
-  const std::string kFilename = "fictitious_name.obj";
+  const std::string kFilename = "/fictitious_name.obj";
 
   const Box box{1, 2, 3};
   EXPECT_EQ(box.width(), 1);
@@ -489,9 +489,9 @@ GTEST_TEST(ShapeTest, NumericalValidation) {
   DRAKE_EXPECT_THROWS_MESSAGE(Capsule(Vector2<double>{0.5, -1}),
                               "Capsule radius and length should both be > 0.+");
 
-  DRAKE_EXPECT_THROWS_MESSAGE(Convex("bar", 0),
+  DRAKE_EXPECT_THROWS_MESSAGE(Convex("/bar", 0),
                               "Convex .scale. cannot be < 1e-8.");
-  DRAKE_EXPECT_NO_THROW(Convex("foo", -1));  // Special case for negative scale.
+  DRAKE_EXPECT_NO_THROW(Convex("/foo", -1));  // Special case: negative scale.
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       Cylinder(0, 1), "Cylinder radius and length should both be > 0.+");
@@ -514,9 +514,9 @@ GTEST_TEST(ShapeTest, NumericalValidation) {
                               "Ellipsoid lengths of principal semi-axes a, b, "
                               "and c should all be > 0.+");
 
-  DRAKE_EXPECT_THROWS_MESSAGE(Mesh("foo", 1e-9),
+  DRAKE_EXPECT_THROWS_MESSAGE(Mesh("/foo", 1e-9),
                               "Mesh .scale. cannot be < 1e-8.");
-  DRAKE_EXPECT_NO_THROW(Mesh("foo", -1));  // Special case for negative scale.
+  DRAKE_EXPECT_NO_THROW(Mesh("/foo", -1));  // Special case for negative scale.
 
   DRAKE_EXPECT_THROWS_MESSAGE(MeshcatCone(0, 1, 1),
                               "MeshcatCone parameters .+ should all be > 0.*");
@@ -540,7 +540,7 @@ TEST_F(DefaultReifierTest, UnsupportedGeometry) {
                               "This class (.+) does not support Box.");
   DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(Capsule(1, 2), nullptr),
                               "This class (.+) does not support Capsule.");
-  DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(Convex("a", 1), nullptr),
+  DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(Convex("/a", 1), nullptr),
                               "This class (.+) does not support Convex.");
   DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(Cylinder(1, 2), nullptr),
                               "This class (.+) does not support Cylinder.");
@@ -549,7 +549,7 @@ TEST_F(DefaultReifierTest, UnsupportedGeometry) {
                               "This class (.+) does not support Ellipsoid.");
   DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(HalfSpace(), nullptr),
                               "This class (.+) does not support HalfSpace.");
-  DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(Mesh("foo", 1), nullptr),
+  DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(Mesh("/foo", 1), nullptr),
                               "This class (.+) does not support Mesh.");
   DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(Sphere(0.5), nullptr),
                               "This class (.+) does not support Sphere.");
@@ -566,7 +566,7 @@ GTEST_TEST(ShapeName, SimpleReification) {
   Capsule(1, 2).Reify(&name);
   EXPECT_EQ(name.name(), "Capsule");
 
-  Convex("filepath", 1.0).Reify(&name);
+  Convex("/filepath", 1.0).Reify(&name);
   EXPECT_EQ(name.name(), "Convex");
 
   Cylinder(1, 2).Reify(&name);
@@ -578,7 +578,7 @@ GTEST_TEST(ShapeName, SimpleReification) {
   HalfSpace().Reify(&name);
   EXPECT_EQ(name.name(), "HalfSpace");
 
-  Mesh("filepath", 1.0).Reify(&name);
+  Mesh("/filepath", 1.0).Reify(&name);
   EXPECT_EQ(name.name(), "Mesh");
 
   MeshcatCone(1.0, 0.25, 0.5).Reify(&name);
@@ -591,11 +591,11 @@ GTEST_TEST(ShapeName, SimpleReification) {
 GTEST_TEST(ShapeName, ReifyOnConstruction) {
   EXPECT_EQ(ShapeName(Box(1, 2, 3)).name(), "Box");
   EXPECT_EQ(ShapeName(Capsule(1, 2)).name(), "Capsule");
-  EXPECT_EQ(ShapeName(Convex("filepath", 1.0)).name(), "Convex");
+  EXPECT_EQ(ShapeName(Convex("/filepath", 1.0)).name(), "Convex");
   EXPECT_EQ(ShapeName(Cylinder(1, 2)).name(), "Cylinder");
   EXPECT_EQ(ShapeName(Ellipsoid(1, 2, 3)).name(), "Ellipsoid");
   EXPECT_EQ(ShapeName(HalfSpace()).name(), "HalfSpace");
-  EXPECT_EQ(ShapeName(Mesh("filepath", 1.0)).name(), "Mesh");
+  EXPECT_EQ(ShapeName(Mesh("/filepath", 1.0)).name(), "Mesh");
   EXPECT_EQ(ShapeName(Sphere(0.5)).name(), "Sphere");
 }
 
@@ -623,13 +623,13 @@ GTEST_TEST(ShapeTest, Volume) {
   EXPECT_NEAR(CalcVolume(Convex(cube_obj, 1.0)), 8.0, 1e-14);
   EXPECT_NEAR(CalcVolume(Mesh(cube_obj, 1.0)), 8.0, 1e-14);
 
-  DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Convex("fakename.obj", 1.0)),
+  DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Convex("/fakename.obj", 1.0)),
                               "Cannot open file.*");
-  DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Mesh("fakename.obj", 1.0)),
+  DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Mesh("/fakename.obj", 1.0)),
                               "Cannot open file.*");
 
   // We only support obj but should eventually support vtk.
-  const std::string non_obj = "only_extension_matters.not_obj";
+  const std::string non_obj = "/only_extension_matters.not_obj";
   DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Convex(non_obj, 1.0)),
                               ".*only supports .obj files.*");
   DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Mesh(non_obj, 1.0)),

--- a/geometry/test/shape_to_string_test.cc
+++ b/geometry/test/shape_to_string_test.cc
@@ -22,9 +22,9 @@ GTEST_TEST(ShapeToStringTest, Capsule) {
 
 GTEST_TEST(ShapeToStringTest, Convex) {
   ShapeToString reifier;
-  Convex m("path/to/file", 1.5);
+  Convex m("/path/to/file", 1.5);
   m.Reify(&reifier);
-  EXPECT_EQ(reifier.string(), "Convex(s: 1.5, path: path/to/file)");
+  EXPECT_EQ(reifier.string(), "Convex(s: 1.5, path: /path/to/file)");
 }
 
 GTEST_TEST(ShapeToStringTest, Cylinder) {
@@ -50,9 +50,9 @@ GTEST_TEST(ShapeToStringTest, Halfspace) {
 
 GTEST_TEST(ShapeToStringTest, Mesh) {
   ShapeToString reifier;
-  Mesh m("path/to/file", 1.5);
+  Mesh m("/path/to/file", 1.5);
   m.Reify(&reifier);
-  EXPECT_EQ(reifier.string(), "Mesh(s: 1.5, path: path/to/file)");
+  EXPECT_EQ(reifier.string(), "Mesh(s: 1.5, path: /path/to/file)");
 }
 
 GTEST_TEST(ShapeToStringTest, MeshcatCone) {

--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -398,7 +398,7 @@ TEST_F(SceneGraphParserDetail, MakeMeshFromSdfGeometry) {
   // TODO(amcastro-tri): Be warned, the result of this test might (should)
   // change as we add support allowing to specify paths relative to the SDF file
   // location.
-  const std::string absolute_file_path = "path/to/some/mesh.obj";
+  const std::string absolute_file_path = "/path/to/some/mesh.obj";
   unique_ptr<sdf::Geometry> sdf_geometry = MakeSdfGeometryFromString(
       "<mesh>"
       "  <uri>" + absolute_file_path + "</uri>"
@@ -413,7 +413,7 @@ TEST_F(SceneGraphParserDetail, MakeMeshFromSdfGeometry) {
 
 // Verify MakeShapeFromSdfGeometry can make a convex mesh from an sdf::Geometry.
 TEST_F(SceneGraphParserDetail, MakeConvexFromSdfGeometry) {
-  const std::string absolute_file_path = "path/to/some/mesh.obj";
+  const std::string absolute_file_path = "/path/to/some/mesh.obj";
   unique_ptr<sdf::Geometry> sdf_geometry = MakeSdfGeometryFromString(
       "<mesh xmlns:drake='http://drake.mit.edu'>"
       "  <drake:declare_convex/>"

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -1553,7 +1553,7 @@ class GeometrySdfParserTest : public SdfParserTest {
     const auto frame_id =
         plant_.GetBodyFrameIdOrThrow(plant_.GetBodyByName("link1").index());
 
-    const std::string mesh_uri = "drake/multibody/parsing/test/tri_cube.obj";
+    const std::string mesh_uri = "/drake/multibody/parsing/test/tri_cube.obj";
 
     // Note: the parameters for the various example shapes do not matter to this
     // test.

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -520,7 +520,7 @@ TEST_F(UrdfGeometryTest, TestParseMaterial2) {
   ASSERT_TRUE(mesh);
 
   const std::string& mesh_filename = mesh->filename();
-  std::string obj_name = "tri_cube.obj";
+  std::string obj_name = "/tri_cube.obj";
   EXPECT_EQ(mesh_filename.rfind(obj_name),
             mesh_filename.size() - obj_name.size());
 

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -907,7 +907,7 @@ class UrdfParsedGeometryTest : public UrdfParserTest {
     const auto frame_id =
         plant_.GetBodyFrameIdOrThrow(plant_.GetBodyByName("link1").index());
 
-    const std::string mesh_uri = "drake/multibody/parsing/test/tri_cube.obj";
+    const std::string mesh_uri = "/drake/multibody/parsing/test/tri_cube.obj";
 
     // Note: the parameters for the various example shapes do not matter to this
     // test.

--- a/multibody/tree/test/geometry_spatial_inertia_test.cc
+++ b/multibody/tree/test/geometry_spatial_inertia_test.cc
@@ -163,7 +163,7 @@ TYPED_TEST_P(MeshTypeSpatialInertaTest, Administrivia) {
       "drake/multibody/parsing/test/box_package/meshes/box.obj");
   const MeshType unit_scale(valid_path, 1.0);
   const MeshType double_scale(valid_path, 2.0);
-  const MeshType nonexistant("nonexistant.stl", 1.0);
+  const MeshType nonexistant("/nonexistant.stl", 1.0);
 
   {
     // Extension test; .obj doesn't throw, everything else does.
@@ -175,7 +175,7 @@ TYPED_TEST_P(MeshTypeSpatialInertaTest, Administrivia) {
     EXPECT_NO_THROW(CalcSpatialInertia(unit_scale, kDensity));
     DRAKE_EXPECT_THROWS_MESSAGE(
         CalcSpatialInertia(nonexistant, kDensity),
-        ".*only supports .obj .* given 'nonexistant.stl'.*");
+        ".*only supports .obj .* given '/nonexistant.stl'.*");
   }
 
   {


### PR DESCRIPTION
Glory in the number of these diff lines where the word "absolute" appears within a hundred characters of a relative path.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18471)
<!-- Reviewable:end -->
