### PR TITLE
Upgrade tinyobjloader to the latest commit and fix tests

### DIFF
--- a/geometry/render_gl/internal_shape_meshes.cc
+++ b/geometry/render_gl/internal_shape_meshes.cc
@@ -135,11 +135,6 @@ MeshData LoadMeshFromObj(std::istream* input_stream,
         const int position_index = shape_mesh.indices[v_index].vertex_index;
         const int norm_index = shape_mesh.indices[v_index].normal_index;
         const int uv_index = shape_mesh.indices[v_index].texcoord_index;
-        // TODO(SeanCurtis-TRI) PR 14656 changed parse semantics. This error
-        // condition appears to no longer be reachable (it no longer appears
-        // in the unit tests) and the condition that this detects won't trigger
-        // this helpful message. Either clean up this case or find a way to give
-        // this feedback under the new tinyobj.
         if (norm_index < 0) {
           throw std::runtime_error(
               fmt::format("Not all faces reference normals: {}", filename));

--- a/geometry/render_gl/internal_shape_meshes.h
+++ b/geometry/render_gl/internal_shape_meshes.h
@@ -49,9 +49,10 @@ struct MeshData {
  If no texture coordinates are specified by the file, it will be indicated in
  the returned MeshData. See MeshData::has_tex_coord for more detail.
 
- @throws std::exception if a) there are no normals, b) faces fail to
-                           reference normals, or c) faces fail to reference
-                           the texture coordinates if they are present.  */
+ @throws std::exception if a) tinyobj::LoadObj() fails, (b) there are no faces
+                           or normals, c) faces fail to reference normals, or d)
+                           faces fail to reference the texture coordinates if
+                           they are present.  */
 MeshData LoadMeshFromObj(std::istream* input_stream,
                          const std::string& filename = "from_string");
 

--- a/geometry/render_gl/test/internal_shape_meshes_test.cc
+++ b/geometry/render_gl/test/internal_shape_meshes_test.cc
@@ -46,7 +46,7 @@ GTEST_TEST(LoadMeshFromObjTest, ErrorModes) {
         "OBJ has no normals; RenderEngineGl requires OBJs with normals.+");
   }
   {
-    // Case: not all faces reference normals. Note: the face specification is
+    // Case: Not all faces reference normals. Note: the face specification is
     // otherwise invalid in that it references vertex positions that don't
     // exist.
     std::stringstream in_stream(R"""(
@@ -59,18 +59,17 @@ f 1 2 3
                                 "Not all faces reference normals.+");
   }
   {
-    // Case: not all faces reference uvs. Note: the face specification is
+    // Case: Not all faces reference uvs. Note: the face specification is
     // otherwise invalid in that it references vertex positions that don't
     // exist.
-    std::stringstream in_stream(R"""()
+    std::stringstream in_stream(R"""(
 v 1 2 3
 vn 0 0 1
 vt 0 0
-f 1//0 2//0 3//0
+f 1//1 2//1 3//1
 )""");
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        LoadMeshFromObj(&in_stream),
-        "tinyobj::LoadObj failed to load file.+");
+    DRAKE_EXPECT_THROWS_MESSAGE(LoadMeshFromObj(&in_stream),
+                                "Not all faces reference texture.+");
   }
 }
 

--- a/tools/workspace/tinyobjloader/repository.bzl
+++ b/tools/workspace/tinyobjloader/repository.bzl
@@ -8,8 +8,8 @@ def tinyobjloader_repository(
     github_archive(
         name = name,
         repository = "tinyobjloader/tinyobjloader",
-        commit = "5790ebd9eb466bc1ebe8ed5c5a55ee642b6f24bc",
-        sha256 = "aa8b4f53bf400b025499bf48296233e2614ff8f5ce2d36fdc3902168cee4a04f",  # noqa
+        commit = "2f947710aeedea2089ade2b62ef669521d90f2ef",
+        sha256 = "cbd289eddb9702df52b79980fb9994ad6ccf976618c6da1c79817b5134064a85",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
         patches = [


### PR DESCRIPTION
From investigating, [this commit](https://github.com/tinyobjloader/tinyobjloader/commit/f026a1e0b86979cb5a7d7f6f2432d02590e61dc9) from `tinyobjloader` allowed normal and texture indices to be zero, and that caused the original test to fail.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18479)
<!-- Reviewable:end -->
