### PR TITLE
[visualization] Enable alpha sliders in ModelVisualizer

### DIFF
--- a/bindings/pydrake/visualization/_model_visualizer.py
+++ b/bindings/pydrake/visualization/_model_visualizer.py
@@ -202,7 +202,8 @@ class ModelVisualizer:
         # illustration and proximity geometry.
         ApplyVisualizationConfig(
             config=VisualizationConfig(
-                publish_contacts=self._publish_contacts),
+                publish_contacts=self._publish_contacts,
+                enable_alpha_sliders=True),
             plant=self._plant,
             scene_graph=self._scene_graph,
             builder=self._builder,


### PR DESCRIPTION
Since the alpha sliders introduced by #18469 are optional, opt the ModelVisualizer class into showing them, in the spirit of the original request in #17688.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18481)
<!-- Reviewable:end -->
