### PR TITLE
Replace unsupported NumPy aliases

### DIFF
--- a/bindings/pydrake/common/test/numpy_compare_test.py
+++ b/bindings/pydrake/common/test/numpy_compare_test.py
@@ -40,7 +40,7 @@ class TestNumpyCompareSimple(unittest.TestCase):
         self.assertEqual(xf.dtype, float)
         self.assertEqual(xi, xf)
         # Array.
-        Xi = np.array([1, 2, 3], np.int)
+        Xi = np.array([1, 2, 3], int)
         Xf = numpy_compare.to_float(Xi)
         self.assertEqual(Xf.dtype, float)
         np.testing.assert_equal(Xi, Xf)

--- a/bindings/pydrake/forwarddiff.py
+++ b/bindings/pydrake/forwarddiff.py
@@ -47,7 +47,7 @@ def jacobian(function, x):
     """
     x = np.asarray(x)
     assert x.ndim == 1, "x must be a vector"
-    x_ad = np.empty(x.shape, dtype=np.object)
+    x_ad = np.empty(x.shape, dtype=object)
     for i in range(x.size):
         der = np.zeros(x.size)
         der[i] = 1

--- a/bindings/pydrake/test/autodiffutils_test.py
+++ b/bindings/pydrake/test/autodiffutils_test.py
@@ -98,12 +98,12 @@ class TestAutoDiffXd(unittest.TestCase):
         # Conversion.
         with self.assertRaises(TypeError):
             # Avoid implicit coercion, as this will imply information loss.
-            xf = np.zeros(2, dtype=np.float)
+            xf = np.zeros(2, dtype=float)
             xf[:] = x
         with self.assertRaises(TypeError):
             # We could define `__float__` to allow this, but then that will
             # enable implicit coercion, which we should avoid.
-            xf = x.astype(dtype=np.float)
+            xf = x.astype(dtype=float)
         # Presently, does not convert.
         x = np.zeros((3, 3), dtype=AD)
         self.assertFalse(isinstance(x[0, 0], AD))

--- a/common/proto/call_python_client.py
+++ b/common/proto/call_python_client.py
@@ -390,7 +390,7 @@ class CallPythonClient:
                 assert arg.rows == 1
                 value = arg.data.decode('utf8')
             elif arg.data_type == lcmt_call_python_data.LOGICAL:
-                value = self._to_array(arg, np.bool)
+                value = self._to_array(arg, bool)
             elif arg.data_type == lcmt_call_python_data.INT:
                 value = self._to_array(arg, np.int32)
             else:

--- a/tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts/show_hydroelastic_contact.py
+++ b/tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts/show_hydroelastic_contact.py
@@ -399,7 +399,7 @@ class IntensityMap(ColorMap):
         """Returns the color for highest intensity."""
         # For the auto contrasting color, make sure this color is always full
         # contrast (e.g., one channel must be zero).
-        return np.array((1.0, 0.6, 0.0), dtype=np.float)
+        return np.array((1.0, 0.6, 0.0), dtype=float)
 
     def _do_get_color(self, norm_data):
         # TODO(drum) Make the color configurable.


### PR DESCRIPTION
In NumPy 1.24.0, deprecated aliases `np.object`, `np.bool`, `np.float` and `np.int` are no longer supported. Replace aliases with the equivalent builtin types.

When Homebrew updated to NumPy 1.24.0, Mac unprovisioned jobs to failed due to this change, e.g.
- [mac-x86-monterey-unprovisioned-clang-bazel-nightly-release](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-x86-monterey-unprovisioned-clang-bazel-nightly-release/39/) 
- [mac-arm-monterey-unprovisioned-clang-bazel-nightly-release](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-arm-monterey-unprovisioned-clang-bazel-nightly-release/)

NumPy 1.24.0 release notes: https://numpy.org/devdocs/release/1.24.0-notes.html
Deprecation: https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18486)
<!-- Reviewable:end -->
