### PR TITLE
Enable manual model reloading in ModelVisualizer

### DIFF
--- a/bindings/pydrake/visualization/model_visualizer.py
+++ b/bindings/pydrake/visualization/model_visualizer.py
@@ -54,8 +54,12 @@ def _main():
     assert defaults["pyplot"] is False
     args_parser.add_argument(
         "--pyplot", action="store_true",
-        help="Opens a pyplot figure for rendering using "
+        help="Open a pyplot figure for rendering using "
              "PlanarSceneGraphVisualizer.")
+    # N.B.: There's no default for enable_reload; it's not an init argument.
+    args_parser.add_argument(
+        "-r", "--enable_reload", action="store_true",
+        help="Enable reloading of the model.")
     # TODO(russt): Consider supporting the PlanarSceneGraphVisualizer
     #  options as additional arguments.
     assert defaults["visualize_frames"] is False
@@ -122,7 +126,11 @@ def _main():
         args_parser.error(f"File does not exist: {filename}")
 
     visualizer.AddModels(filename)
-    visualizer.Run(position=args.position, loop_once=args.loop_once)
+    if not args.loop_once and args.enable_reload:
+        # TODO(trowell-tri) Consider enabling reload by default in the future.
+        visualizer.RunWithReload(position=args.position)
+    else:
+        visualizer.Run(position=args.position, loop_once=args.loop_once)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds a Reload Model File button to the ModelVisualizer control panel to allow live model editing and re-visualization. Also improves error feedback when the number of position arguments does not match that in the model, and normalizes some docstring style.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18488)
<!-- Reviewable:end -->
