### PR TITLE
[C-IRIS] Consolidate to the formulation using Chebyshev center for polytope

### DIFF
--- a/geometry/optimization/dev/collision_geometry.h
+++ b/geometry/optimization/dev/collision_geometry.h
@@ -51,6 +51,18 @@ class CollisionGeometry {
   const math::RigidTransformd& X_BG() const { return X_BG_; }
 
   /**
+   When we constrain a polytope to be on one side of the plane (for example the
+   positive side), we impose the constraint
+   aᵀ*p_AVᵢ + b ≥ δ
+   aᵀ*p_AC  + b ≥ k * r
+   where Vᵢ being the i'th vertex of the polytope. C is the Chebyshev center of
+   the polytope, r is the radius (namely the distance from the Chebyshev center
+   to the boundary of the polytope), and k is a positive scalar. This function
+   returns the value of k.
+   */
+  static double PolytopeChebyshevRadiusMultiplier() { return 0.5; }
+
+  /**
    To impose the geometric constraint that this collision geometry is on one
    side of a plane {x|aᵀx+b=0} with a certain margin, we can equivalently write
    this constraint with the following conditions
@@ -104,8 +116,7 @@ class CollisionGeometry {
           X_AB_multilinear,
       const multibody::RationalForwardKinematics& rational_forward_kin,
       const std::optional<symbolic::Variable>& separating_margin,
-      PlaneSide plane_side, GeometryType other_side_geometry_type,
-      std::vector<symbolic::RationalFunction>* rationals,
+      PlaneSide plane_side, std::vector<symbolic::RationalFunction>* rationals,
       std::optional<VectorX<symbolic::Polynomial>>* unit_length_vector) const;
 
   [[nodiscard]] GeometryType type() const;
@@ -114,8 +125,7 @@ class CollisionGeometry {
    Returns the number of rationals in the condition "this geometry is on one
    side of the plane."
    */
-  [[nodiscard]] int num_rationals_per_side(
-      bool search_margin, GeometryType other_side_geometry_type) const;
+  [[nodiscard]] int num_rationals_per_side() const;
 
  private:
   const Shape* geometry_;

--- a/geometry/optimization/dev/cspace_free_polytope.cc
+++ b/geometry/optimization/dev/cspace_free_polytope.cc
@@ -382,8 +382,6 @@ std::vector<PlaneSeparatesGeometries> CspaceFreePolytope::GenerateRationals(
          {PlaneSide::kPositive, PlaneSide::kNegative}) {
       const CollisionGeometry* link_geometry =
           separating_plane.geometry(plane_side);
-      const CollisionGeometry* other_side_geometry =
-          separating_plane.geometry(OtherSide(plane_side));
 
       const BodyPair expressed_to_link(separating_plane.expressed_body,
                                        link_geometry->body_index());
@@ -401,10 +399,10 @@ std::vector<PlaneSeparatesGeometries> CspaceFreePolytope::GenerateRationals(
       auto& rationals = plane_side == PlaneSide::kPositive
                             ? positive_side_rationals
                             : negative_side_rationals;
-      link_geometry->OnPlaneSide(
-          separating_plane.a, separating_plane.b, X_AB_multilinear,
-          rational_forward_kin_, separating_margin, plane_side,
-          other_side_geometry->type(), &rationals, &unit_length_vec);
+      link_geometry->OnPlaneSide(separating_plane.a, separating_plane.b,
+                                 X_AB_multilinear, rational_forward_kin_,
+                                 separating_margin, plane_side, &rationals,
+                                 &unit_length_vec);
 
       if (unit_length_vec.has_value()) {
         if (unit_length_vectors.empty()) {

--- a/geometry/optimization/dev/test/cspace_free_polytope_test.cc
+++ b/geometry/optimization/dev/test/cspace_free_polytope_test.cc
@@ -304,11 +304,9 @@ TEST_F(CIrisToyRobotTest, CspaceFreePolytopeGenerateRationals) {
       EXPECT_TRUE(plane_geometries.unit_length_vectors.empty());
     }
     EXPECT_EQ(plane_geometries.positive_side_rationals.size(),
-              plane.positive_side_geometry->num_rationals_per_side(
-                  false, plane.negative_side_geometry->type()));
+              plane.positive_side_geometry->num_rationals_per_side());
     EXPECT_EQ(plane_geometries.negative_side_rationals.size(),
-              plane.negative_side_geometry->num_rationals_per_side(
-                  false, plane.positive_side_geometry->type()));
+              plane.negative_side_geometry->num_rationals_per_side());
     EXPECT_FALSE(plane_geometries.separating_margin.has_value());
   }
 


### PR DESCRIPTION
If I were to use the formulation that doesn't introduce Chebyshev, namely a'*x + b >= 1, then this causes problem in the bilinear iteration. Since when we search for the separating margin, we use the formulation a'*x + b - margin - lambda(s) * (d - C*s) is sos. Then in the next iteration when we search for C and d, we don't need the margin and use the formulation a'*x + b - 1 - lambda(s) * (d-C*s) is sos. This causes the problem that the solution a, b, lambda in the first iteration with margin is NOT a feasible solution for the next iteration when we search for C and d but fix lambda(s) (as very likely the margin is < 1).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18496)
<!-- Reviewable:end -->
