### PR TITLE
[solvers] Add test with ipopt for problem costs/constraints containing duplicated variables.

### DIFF
--- a/solvers/test/ipopt_solver_test.cc
+++ b/solvers/test/ipopt_solver_test.cc
@@ -75,6 +75,13 @@ TEST_F(UnboundedLinearProgramTest0, TestIpopt) {
   }
 }
 
+TEST_F(DuplicatedVariableLinearProgramTest1, Test) {
+  IpoptSolver solver;
+  if (solver.available()) {
+    CheckSolution(solver);
+  }
+}
+
 TEST_P(QuadraticProgramTest, TestQP) {
   IpoptSolver solver;
   prob()->RunProblem(&solver);

--- a/solvers/test/nonlinear_program_test.cc
+++ b/solvers/test/nonlinear_program_test.cc
@@ -542,6 +542,8 @@ GTEST_TEST(testNonlinearProgram, CallbackTest) {
 TEST_F(DuplicatedVariableNonlinearProgram1, Test) {
   SnoptSolver snopt_solver;
   CheckSolution(snopt_solver, Eigen::Vector2d(0.5, 0.5), std::nullopt, 1E-6);
+  IpoptSolver ipopt_solver;
+  CheckSolution(ipopt_solver, Eigen::Vector2d(0.5, 0.5), std::nullopt, 1E-6);
 }
 
 }  // namespace test


### PR DESCRIPTION
IPOPT already handles variable duplication through its sparse matrix format. So I only need to add test to confirm it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18503)
<!-- Reviewable:end -->
