### PR TITLE
SceneGraph allows changing geometry shape

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -759,6 +759,7 @@ drake_cc_googletest(
     name = "internal_geometry_test",
     deps = [
         ":internal_geometry",
+        "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
         "//geometry/proximity:make_sphere_mesh",
@@ -769,6 +770,7 @@ drake_cc_googletest(
     name = "scene_graph_test",
     deps = [
         ":scene_graph",
+        "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
         "//geometry/test_utilities:dummy_render_engine",

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -390,6 +390,11 @@ class GeometryState {
       SourceId source_id, FrameId frame_id,
       std::unique_ptr<GeometryInstance> geometry, double resolution_hint);
 
+  /** Implementation of SceneGraph::ChangeShape().  */
+  void ChangeShape(
+      SourceId source_id, GeometryId geometry_id, const Shape& shape,
+      std::optional<math::RigidTransform<double>> X_FG);
+
   /** Implementation of SceneGraph::RemoveGeometry().  */
   void RemoveGeometry(SourceId source_id, GeometryId geometry_id);
 
@@ -841,12 +846,37 @@ class GeometryState {
   // @pre geometry_id maps to a registered geometry.
   bool RemoveRoleUnchecked(GeometryId geometry_id, Role role);
 
+  // Handles adding the given geometry to the proximity engine. The only
+  // GeometryState-level data structure modified is the proximity version. All
+  // other changes to GeometryState data must happen elsewhere.
+  void AddToProximityEngineUnchecked(
+      const internal::InternalGeometry& geometry);
+
+  // Handles removing the given geometry from the proximity engine. The only
+  // GeometryState-level data structure modified is the proximity version. All
+  // other changes to GeometryState data must happen elsewhere.
+  void RemoveFromProximityEngineUnchecked(
+      const internal::InternalGeometry& geometry);
+
   // Attempts to remove the geometry with the given `id` from the named
   // renderer. Returns true if removed (false doesn't imply "failure", just
   // nothing to remove). This does no checking on ownership.
   // @pre geometry_id maps to a registered geometry.
   bool RemoveFromRendererUnchecked(const std::string& renderer_name,
                                    GeometryId id);
+
+  // Attempts to add the given `geometry` to all compatible render engines. The
+  // only GeometryState-level data structure modified is the perception version.
+  // All other changes to GeometryState data must happen elsewhere.
+  // @returns `true` if the geometry was added to *any* renderer.
+  bool AddToCompatibleRenderersUnchecked(
+      const internal::InternalGeometry& geometry);
+
+  // Attempts to remove the geometry with the given id from *all* render
+  // engines. The only GeometryState-level data structure modified is the
+  // perception version. All other changes to GeometryState data must happen
+  // elsewhere.
+  void RemoveFromAllRenderersUnchecked(GeometryId id);
 
   bool RemoveProximityRole(GeometryId geometry_id);
   bool RemoveIllustrationRole(GeometryId geometry_id);

--- a/geometry/internal_geometry.h
+++ b/geometry/internal_geometry.h
@@ -89,6 +89,9 @@ class InternalGeometry {
   /* Returns the shape specification for this geometry.  */
   const Shape& shape() const { return *shape_spec_; }
 
+  /* Updates the shape associated with this geometry. */
+  void SetShape(const Shape& shape) { shape_spec_ = shape.Clone(); }
+
   /* Returns the globally unique identifier for this geometry.  */
   GeometryId id() const { return id_; }
 
@@ -115,6 +118,8 @@ class InternalGeometry {
     return frame_id == frame_id_;
   }
 
+  // 2023-04-01 X_PG() and related functionality should be removed with the
+  // completed deprecation of the public aspects of this API.
   /* Returns the pose of this geometry in the declared *parent* frame -- note
    if this geometry was registered as a child of another geometry it will *not*
    be the same as X_FG().  */
@@ -123,6 +128,17 @@ class InternalGeometry {
   /* Returns the pose of this geometry in the frame to which it is ultimately
    rigidly attached. This is in contrast to X_PG().  */
   const math::RigidTransform<double>& X_FG() const { return X_FG_; }
+
+  // 2023-04-01 Simply set X_FG when the deprecation of X_PG is complete.
+  /* Changes the geometry's pose with respect to its frame from the old pose to
+   `X_FG`. However that pose changes, the same change is applied to X_PG. */
+  void set_pose(const math::RigidTransform<double>& X_FG) {
+    const math::RigidTransform<double> X_GoldF = X_FG_.inverse();
+    const math::RigidTransform<double> X_GoldG = X_GoldF * X_FG;
+    X_FG_ = X_FG;
+    const math::RigidTransform<double>& x_PGold = X_PG_;
+    X_PG_ = x_PGold * X_GoldG;
+  }
 
   // TODO(SeanCurtis-TRI): Determine if tracking this parent geometry is
   // necessary for now or if that only exists to facilitate removal later on.

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -244,6 +244,21 @@ GeometryId SceneGraph<T>::RegisterDeformableGeometry(
 }
 
 template <typename T>
+void SceneGraph<T>::ChangeShape(
+    SourceId source_id, GeometryId geometry_id, const Shape& shape,
+    std::optional<math::RigidTransform<double>> X_FG) {
+  return model_.ChangeShape(source_id, geometry_id, shape, X_FG);
+}
+
+template <typename T>
+void SceneGraph<T>::ChangeShape(
+    Context<T>* context, SourceId source_id, GeometryId geometry_id,
+    const Shape& shape, std::optional<math::RigidTransform<double>> X_FG) {
+  auto& g_state = mutable_geometry_state(context);
+  return g_state.ChangeShape(source_id, geometry_id, shape, X_FG);
+}
+
+template <typename T>
 void SceneGraph<T>::RemoveGeometry(SourceId source_id, GeometryId geometry_id) {
   model_.RemoveGeometry(source_id, geometry_id);
 }

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -596,6 +597,44 @@ class SceneGraph final : public systems::LeafSystem<T> {
   GeometryId RegisterDeformableGeometry(
       systems::Context<T>* context, SourceId source_id, FrameId frame_id,
       std::unique_ptr<GeometryInstance> geometry, double resolution_hint) const;
+
+  /** Changes the `shape` of the geometry indicated by the given `geometry_id`.
+
+   The geometry is otherwise unchanged -- same geometry_id, same assigned roles,
+   same pose with respect to the parent (unless a new value for `X_FG` is
+   given).
+
+   This method modifies the underlying model and requires a new Context to be
+   allocated. Potentially modifies proximity, perception, and illustration
+   versions based on the roles assigned to the geometry (see @ref
+   scene_graph_versioning).
+
+   @param source_id    The id for the source modifying the geometry.
+   @param geometry_id  The id for the geometry whose shape is being modified.
+   @param shape        The new shape to use.
+   @param X_FG         The (optional) new pose of the geometry in its frame. If
+                       omitted, the old pose is used.
+
+   @throws std::exception if a) the `source_id` does _not_ map to a
+                           registered source,
+                           b) the `geometry_id` does not map to a valid
+                           geometry,
+                           c) the `geometry_id` maps to a geometry that does
+                           not belong to the indicated source, or
+                           d) the geometry is deformable.
+   @pydrake_mkdoc_identifier{model} */
+  void ChangeShape(
+      SourceId source_id, GeometryId geometry_id, const Shape& shape,
+      std::optional<math::RigidTransform<double>> X_FG = std::nullopt);
+
+  /** systems::Context-modifying variant of ChangeShape(). Rather than modifying
+   %SceneGraph's model, it modifies the copy of the model stored in the provided
+   context.
+   @pydrake_mkdoc_identifier{context} */
+  void ChangeShape(
+      systems::Context<T>* context, SourceId source_id, GeometryId geometry_id,
+      const Shape& shape,
+      std::optional<math::RigidTransform<double>> X_FG = std::nullopt);
 
   /** Removes the given geometry G (indicated by `geometry_id`) from the given
    source's registered geometries. All registered geometries hanging from

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <unordered_set>
 #include <utility>
@@ -43,6 +44,7 @@ using render::RenderLabel;
 using std::make_unique;
 using std::map;
 using std::move;
+using std::optional;
 using std::pair;
 using std::set;
 using std::string;
@@ -634,6 +636,9 @@ class GeometryStateTestBase {
   void AssignProximityToSingleSourceTree() {
     ASSERT_TRUE(source_id_.is_valid());
     ProximityProperties properties;
+    // Add an arbitrary, meaningless property so we can detect if the properties
+    // get thrown out.
+    properties.AddProperty("test", "value", 17);
     AssignRoleToSingleSourceTree(properties);
   }
 
@@ -644,6 +649,9 @@ class GeometryStateTestBase {
     IllustrationProperties properties;
     properties.AddProperty("phong", "diffuse",
                            Vector4<double>{0.8, 0.8, 0.8, 1.0});
+    // Add an arbitrary, meaningless property so we can detect if the properties
+    // get thrown out.
+    properties.AddProperty("test", "value", 17);
     AssignRoleToSingleSourceTree(properties);
   }
 
@@ -659,6 +667,9 @@ class GeometryStateTestBase {
     properties.AddProperty("phong", "diffuse",
                            Vector4<double>{0.8, 0.8, 0.8, 1.0});
     properties.AddProperty("label", "id", RenderLabel::kDontCare);
+    // Add an arbitrary, meaningless property so we can detect if the properties
+    // get thrown out.
+    properties.AddProperty("test", "value", 17);
     AssignRoleToSingleSourceTree(properties);
   }
 
@@ -1743,6 +1754,223 @@ TEST_F(GeometryStateTest, RegisterDeformableGeometry) {
       geometry_state_.GetAllDeformableGeometryIds();
   ASSERT_EQ(deformable_ids.size(), 1);
   EXPECT_EQ(deformable_ids[0], g_id);
+}
+
+/* This test covers the data maintenance *within* GeometryState. It confirms
+ that shape and pose change, but all other InternalGeometry fields remain the
+ same.
+
+ There are per-role tests below that provide coverage for the unchanged
+ role properties and confirm that the shape has changed in the various engines.
+
+ This test makes a simplifying assumption: multiple roles don't interfere in
+ the process. So, we can test a single geometry with all three roles and don't
+ have to test geometries with all possible role configurations. */
+TEST_F(GeometryStateTest, ChangeShapeInternals) {
+  const SourceId s_id = SetUpSingleSourceTree(
+      Assign::kProximity | Assign::kPerception | Assign::kIllustration);
+
+  const GeometryId g_id = geometries_[0];
+  const InternalGeometry* geometry = gs_tester_.GetGeometry(g_id);
+  const InternalGeometry original_geo(*geometry);
+  const RigidTransformd X_GG2(Vector3d(1, 2, 3));
+  const RigidTransformd X_FG2 = X_GG2 * geometry->X_FG();
+
+  // Changing from sphere to box.
+  ASSERT_EQ(ShapeName(geometry->shape()).name(), ShapeName(Sphere(1.0)).name());
+  const Box new_shape(1.0, 2.0, 3.0);
+
+  geometry_state_.ChangeShape(s_id, g_id, new_shape, X_FG2);
+
+  // We've modified it in place; the address hasn't changed.
+  ASSERT_EQ(geometry, gs_tester_.GetGeometry(g_id));
+
+  // Shape and pose have changed.
+  EXPECT_EQ(ShapeName(geometry->shape()).name(),
+            ShapeName(Box(1, 1, 1)).name());
+  EXPECT_TRUE(
+      CompareMatrices(X_FG2.GetAsMatrix34(), geometry->X_FG().GetAsMatrix34()));
+
+  // Nothing else has.
+  EXPECT_EQ(original_geo.id(), geometry->id());
+  EXPECT_EQ(original_geo.name(), geometry->name());
+  EXPECT_EQ(original_geo.source_id(), geometry->source_id());
+  EXPECT_EQ(original_geo.frame_id(), geometry->frame_id());
+  EXPECT_EQ(original_geo.is_deformable(), geometry->is_deformable());
+  EXPECT_EQ(original_geo.is_dynamic(), geometry->is_dynamic());
+}
+
+/* Changes a shape with the illustration role. The only observable indications
+ of a successful change is that the shape and pose have changed *and* that the
+ illustration version has changed. */
+TEST_F(GeometryStateTest, ChangeShapeIllustration) {
+  const SourceId s_id = SetUpSingleSourceTree(Assign::kIllustration);
+
+  const GeometryId g_id = geometries_[0];
+  const InternalGeometry* geometry = gs_tester_.GetGeometry(g_id);
+  const InternalGeometry original_geo(*geometry);
+
+  // Changing from sphere to box.
+  ASSERT_EQ(ShapeName(geometry->shape()).name(), ShapeName(Sphere(1.0)).name());
+  const Box new_shape(1.0, 2.0, 3.0);
+
+  const GeometryVersion pre_version = geometry_state_.geometry_version();
+  geometry_state_.ChangeShape(s_id, g_id, new_shape, geometry->X_FG());
+  const GeometryVersion post_version = geometry_state_.geometry_version();
+
+  // Only illustration version has changed.
+  EXPECT_FALSE(post_version.IsSameAs(pre_version, Role::kIllustration));
+  EXPECT_TRUE(post_version.IsSameAs(pre_version, Role::kPerception));
+  EXPECT_TRUE(post_version.IsSameAs(pre_version, Role::kProximity));
+
+  // IllustrationProperties haven't changed. In this test, every property gets
+  // this arbitrary (test, value) property; we'll confirm that it's still there
+  // as *evidence* that the properties haven't changed.
+  EXPECT_EQ(
+      original_geo.illustration_properties()->GetProperty<int>("test", "value"),
+      geometry->illustration_properties()->GetProperty<int>("test", "value"));
+}
+
+// Engine to test the ChangeShape() API. Change shape registers a new shape,
+// and passes a new pose. This render engine records the last geometry id
+// registered and removed. We'll confirm that both happen in response to a call
+// to ChangeShape().
+class ChangeShapeRenderEngine : public DummyRenderEngine {
+ public:
+  ChangeShapeRenderEngine() : DummyRenderEngine() {}
+
+  optional<GeometryId> get_and_clear_last_registered_id() {
+    optional<GeometryId> last_value = registered_id_;
+    registered_id_ = std::nullopt;
+    return last_value;
+  }
+
+  optional<GeometryId> get_and_clear_last_removed_id() {
+    optional<GeometryId> last_value = removed_id_;
+    removed_id_ = std::nullopt;
+    return last_value;
+  }
+
+ protected:
+  bool DoRegisterVisual(GeometryId id, const Shape&,
+                        const PerceptionProperties&,
+                        const math::RigidTransformd&) override {
+    registered_id_ = id;
+    return true;
+  }
+
+  bool DoRemoveGeometry(GeometryId id) override {
+    removed_id_ = id;
+    return true;
+  }
+
+ private:
+  optional<GeometryId> registered_id_{};
+  optional<GeometryId> removed_id_{};
+};
+
+ChangeShapeRenderEngine* AddRenderer(const char* name,
+                                     GeometryState<double>* state) {
+  state->AddRenderer(name, make_unique<ChangeShapeRenderEngine>());
+  auto* engine =
+      const_cast<render::RenderEngine*>(state->GetRenderEngineByName(name));
+  auto* test_engine = dynamic_cast<ChangeShapeRenderEngine*>(engine);
+  DRAKE_DEMAND(test_engine != nullptr);
+  return test_engine;
+}
+
+/* Changes a shape with the perception role. In this case, we'll confirm that
+ the shape in the render engine has changed by using a custom render engine
+ implementation that will report that its APIs have been called. */
+TEST_F(GeometryStateTest, ChangeShapePerception) {
+  // We'll add to render engines to make sure that all render engines get
+  // processed.
+  ChangeShapeRenderEngine* renderer1 =
+      AddRenderer("renderer1", &geometry_state_);
+  ChangeShapeRenderEngine* renderer2 =
+      AddRenderer("renderer2", &geometry_state_);
+
+  const SourceId s_id = SetUpSingleSourceTree(Assign::kPerception);
+
+  const GeometryId g_id = geometries_[0];
+  const InternalGeometry* geometry = gs_tester_.GetGeometry(g_id);
+  const InternalGeometry original_geo(*geometry);
+
+  // Confirm pre-test conditions; neither reports g_id as last registered or
+  // removed.
+  ASSERT_NE(renderer1->get_and_clear_last_registered_id(), g_id);
+  ASSERT_NE(renderer2->get_and_clear_last_registered_id(), g_id);
+  ASSERT_NE(renderer1->get_and_clear_last_removed_id(), g_id);
+  ASSERT_NE(renderer2->get_and_clear_last_removed_id(), g_id);
+
+  ASSERT_EQ(ShapeName(geometry->shape()).name(), ShapeName(Sphere(1.0)).name());
+  const Box new_shape(0.1, 0.2, 0.3);
+
+  const GeometryVersion pre_version = geometry_state_.geometry_version();
+  geometry_state_.ChangeShape(s_id, g_id, new_shape, geometry->X_FG());
+  const GeometryVersion post_version = geometry_state_.geometry_version();
+
+  // Only illustration version has changed.
+  EXPECT_TRUE(post_version.IsSameAs(pre_version, Role::kIllustration));
+  EXPECT_FALSE(post_version.IsSameAs(pre_version, Role::kPerception));
+  EXPECT_TRUE(post_version.IsSameAs(pre_version, Role::kProximity));
+
+  // PerceptionProperties haven't changed. In this test, every property gets
+  // this arbitrary (test, value) property; we'll confirm that it's still
+  // there as *evidence* that the properties haven't changed.
+  EXPECT_EQ(
+      original_geo.perception_properties()->GetProperty<int>("test", "value"),
+      geometry->perception_properties()->GetProperty<int>("test", "value"));
+
+  // Each render engine now reports that the changed geometry id was both
+  // removed and registered (presumably in the correct order).
+  ASSERT_EQ(renderer1->get_and_clear_last_registered_id(), g_id);
+  ASSERT_EQ(renderer2->get_and_clear_last_registered_id(), g_id);
+  ASSERT_EQ(renderer1->get_and_clear_last_removed_id(), g_id);
+  ASSERT_EQ(renderer2->get_and_clear_last_removed_id(), g_id);
+}
+
+/* Changes a shape with the proximity role. In this case, we'll confirm that the
+ shape in the proximity engine has changed by performing a query before and
+ after, showing that the query result changes as expected. */
+TEST_F(GeometryStateTest, ChangeShapeProximity) {
+  const SourceId s_id = SetUpSingleSourceTree(Assign::kProximity);
+
+  const GeometryId g_id = geometries_[0];
+  const InternalGeometry* geometry = gs_tester_.GetGeometry(g_id);
+  const InternalGeometry original_geo(*geometry);
+
+  // Record the old distance.
+  const SignedDistancePair<double> old_distance =
+      geometry_state_.ComputeSignedDistancePairClosestPoints(g_id,
+                                                             geometries_[2]);
+
+  // Changing from sphere to a *small* box (should be smaller than the sphere).
+  // The distance between the two shapes should get *larger*.
+  ASSERT_EQ(ShapeName(geometry->shape()).name(), ShapeName(Sphere(1.0)).name());
+  const Box new_shape(0.1, 0.2, 0.3);
+
+  const GeometryVersion pre_version = geometry_state_.geometry_version();
+  geometry_state_.ChangeShape(s_id, g_id, new_shape, geometry->X_FG());
+  const GeometryVersion post_version = geometry_state_.geometry_version();
+
+  // Only proximity version has changed.
+  EXPECT_TRUE(post_version.IsSameAs(pre_version, Role::kIllustration));
+  EXPECT_TRUE(post_version.IsSameAs(pre_version, Role::kPerception));
+  EXPECT_FALSE(post_version.IsSameAs(pre_version, Role::kProximity));
+
+  // ProximityProperties haven't changed. In this test, every property gets
+  // this arbitrary (test, value) property; we'll confirm that it's still there
+  // as *evidence* that the properties haven't changed.
+  EXPECT_EQ(
+      original_geo.proximity_properties()->GetProperty<int>("test", "value"),
+      geometry->proximity_properties()->GetProperty<int>("test", "value"));
+
+  // Now confirm an increase in distance.
+  const SignedDistancePair<double> new_distance =
+      geometry_state_.ComputeSignedDistancePairClosestPoints(g_id,
+                                                             geometries_[2]);
+  EXPECT_GT(new_distance.distance, old_distance.distance);
 }
 
 /* This tests for two things:

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/nice_type_name.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/geometry_frame.h"
@@ -542,6 +543,70 @@ TEST_F(SceneGraphTest, RoleManagementSmokeTest) {
   EXPECT_EQ(scene_graph_.RemoveRole(s_id, g_id, Role::kPerception), 1);
   EXPECT_EQ(scene_graph_.RemoveRole(s_id, g_id, Role::kProximity), 1);
   EXPECT_EQ(scene_graph_.RemoveRole(s_id, g_id, Role::kIllustration), 1);
+}
+
+// For SceneGraph::ChangeShape to be correct, we need to make sure it invokes
+// GeometryState correctly. So, we'll invoke it and look for minimum evidence
+// that the change has happened (i.e., we report a different shape) and rely
+// on GeometryState tests to confirm that all other ancillary details are also
+// taken care of.
+TEST_F(SceneGraphTest, ChangeShape) {
+  const SourceId source_id = scene_graph_.RegisterSource();
+  const Sphere sphere(1.0);
+  const RigidTransformd X_WG_original(Eigen::Vector3d(1, 2, 3));
+  GeometryId g_id = scene_graph_.RegisterAnchoredGeometry(
+      source_id, make_unique<GeometryInstance>(
+                     X_WG_original, make_unique<Sphere>(sphere), "sphere"));
+  CreateDefaultContext();
+
+  const SceneGraphInspector<double>& model_inspector =
+      scene_graph_.model_inspector();
+  const SceneGraphInspector<double>& context_inspector =
+      query_object().inspector();
+
+  // Confirm the shape in the model and context is of the expected type.
+  ASSERT_EQ(ShapeName(sphere).name(),
+            ShapeName(model_inspector.GetShape(g_id)).name());
+  ASSERT_EQ(ShapeName(sphere).name(),
+            ShapeName(context_inspector.GetShape(g_id)).name());
+
+  // Change shape without changing pose.
+  const Box box(1.5, 2.5, 3.5);
+
+  scene_graph_.ChangeShape(source_id, g_id, box);
+  EXPECT_EQ(ShapeName(box).name(),
+            ShapeName(model_inspector.GetShape(g_id)).name());
+  EXPECT_TRUE(
+      CompareMatrices(X_WG_original.GetAsMatrix34(),
+                      model_inspector.GetPoseInFrame(g_id).GetAsMatrix34()));
+
+  scene_graph_.ChangeShape(context_.get(), source_id, g_id, box);
+  EXPECT_EQ(ShapeName(box).name(),
+            ShapeName(context_inspector.GetShape(g_id)).name());
+  EXPECT_TRUE(
+      CompareMatrices(X_WG_original.GetAsMatrix34(),
+                      context_inspector.GetPoseInFrame(g_id).GetAsMatrix34()));
+
+  // Change shape and pose.
+  const Cylinder cylinder(1.5, 2.5);
+  // We just need *some* different transformation that isn't the identity. So,
+  // we'll transform the original non-identity pose by itself to get something
+  // unique. The apparent frame anarchy is unimportant.
+  const RigidTransformd X_WG_new = X_WG_original * X_WG_original;
+
+  scene_graph_.ChangeShape(source_id, g_id, cylinder, X_WG_new);
+  EXPECT_EQ(ShapeName(cylinder).name(),
+            ShapeName(model_inspector.GetShape(g_id)).name());
+  EXPECT_TRUE(
+      CompareMatrices(X_WG_new.GetAsMatrix34(),
+                      model_inspector.GetPoseInFrame(g_id).GetAsMatrix34()));
+
+  scene_graph_.ChangeShape(context_.get(), source_id, g_id, cylinder, X_WG_new);
+  EXPECT_EQ(ShapeName(cylinder).name(),
+            ShapeName(context_inspector.GetShape(g_id)).name());
+  EXPECT_TRUE(
+      CompareMatrices(X_WG_new.GetAsMatrix34(),
+                      context_inspector.GetPoseInFrame(g_id).GetAsMatrix34()));
 }
 
 // Dummy system to serve as geometry source.


### PR DESCRIPTION
In addition to changing things like collision filters or geometry properties after registration, now the `Shape` associated with a geometry instance can also be changed.

This is *especially* useful if a user wants to change a body in an existing plant. They can change the mass properties via MbP's mass "parameters" and change the geometric representation in `SceneGraph` to match.

The new shape is associated with the original `GeometryId`, making it friendly to MbP's internals.

This required some refactoring of the `GeometryState` code that controls the registration/removal of geometry with respect to the proximity and render engines.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18513)
<!-- Reviewable:end -->
