### PR TITLE
[multibody] Require finalize before state counts are available

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -4267,10 +4267,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   std::string GetTopologyGraphvizString() const;
 
   /// Returns the size of the generalized position vector q for this model.
-  /// @warning The intent of this function is only to be used after Finalize().
-  /// Calling it prior to Finalize() will return inaccurate results. On or after
-  /// 2023-01-01, calling this function before Finalize() will result in an
-  /// exception.
+  /// @throws std::exception if called pre-finalize.
   int num_positions() const { return internal_tree().num_positions(); }
 
   /// Returns the size of the generalized position vector qᵢ for model
@@ -4281,10 +4278,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   }
 
   /// Returns the size of the generalized velocity vector v for this model.
-  /// @warning The intent of this function is only to be used after Finalize().
-  /// Calling it prior to Finalize() will return inaccurate results. On or after
-  /// 2023-01-01, calling this function before Finalize() will result in an
-  /// exception.
+  /// @throws std::exception if called pre-finalize.
   int num_velocities() const { return internal_tree().num_velocities(); }
 
   /// Returns the size of the generalized velocity vector vᵢ for model
@@ -4298,10 +4292,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // integrated power and other discrete states, hence the specific name.
   /// Returns the size of the multibody system state vector x = [q v]. This
   /// will be `num_positions()` plus `num_velocities()`.
-  /// @warning The intent of this function is only to be used after Finalize().
-  /// Calling it prior to Finalize() will return inaccurate results. On or after
-  /// 2023-01-01, calling this function before Finalize() will result in an
-  /// exception.
+  /// @throws std::exception if called pre-finalize.
   int num_multibody_states() const { return internal_tree().num_states(); }
 
   /// Returns the size of the multibody system state vector xᵢ = [qᵢ vᵢ] for

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -569,6 +569,7 @@ class MultibodyTree {
 
   // Returns the number of generalized positions of the model.
   int num_positions() const {
+    DRAKE_MBT_THROW_IF_NOT_FINALIZED();
     return topology_.num_positions();
   }
 
@@ -580,6 +581,7 @@ class MultibodyTree {
 
   // Returns the number of generalized velocities of the model.
   int num_velocities() const {
+    DRAKE_MBT_THROW_IF_NOT_FINALIZED();
     return topology_.num_velocities();
   }
 
@@ -591,6 +593,7 @@ class MultibodyTree {
 
   // Returns the total size of the state vector in the model.
   int num_states() const {
+    DRAKE_MBT_THROW_IF_NOT_FINALIZED();
     return topology_.num_states();
   }
 


### PR DESCRIPTION
Removes deprecation documentation and implements the promised behavior of throwing pre-Finalize() for MultibodyPlant::
- num_positions()
- num_velocities()
- num_multibody_states()

Resolves #18511

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18515)
<!-- Reviewable:end -->
