### PR TITLE
[planning] BodyShapeDescription fails fast upon mis-use

### DIFF
--- a/planning/body_shape_description.h
+++ b/planning/body_shape_description.h
@@ -17,7 +17,10 @@ the rigid pose of the shape S relative to the body B, X_BS.
 
 Most clients should use the factory method MakeBodyShapeDescription() to
 construct a valid %BodyShapeDescription; it will extract and verify the correct
-information from a multibody plant and its context. */
+information from a multibody plant and its context.
+
+When moved-from, this object models a "null" description and all of the getter
+functions will throw. */
 class BodyShapeDescription final {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(BodyShapeDescription)
@@ -29,25 +32,33 @@ class BodyShapeDescription final {
                        const math::RigidTransformd& X_BS,
                        std::string model_instance_name, std::string body_name);
 
-  /** @returns the shape passed at construction.
-      @throws std::exception if this instance has been moved from. */
+  /** @returns the shape passed at construction. */
   const geometry::Shape& shape() const {
-    DRAKE_THROW_UNLESS(shape_ != nullptr);
+    DRAKE_THROW_UNLESS(!is_moved_from());
     return *shape_;
   }
 
   /** @retval X_BS The pose passed at construction. */
-  const math::RigidTransformd& pose_in_body() const { return X_BS_; }
+  const math::RigidTransformd& pose_in_body() const {
+    DRAKE_THROW_UNLESS(!is_moved_from());
+    return X_BS_;
+  }
 
   /** @returns the model instance name passed at construction. */
   const std::string& model_instance_name() const {
+    DRAKE_THROW_UNLESS(!is_moved_from());
     return model_instance_name_;
   }
 
   /** @returns the body name passed at construction. */
-  const std::string& body_name() const { return body_name_; }
+  const std::string& body_name() const {
+    DRAKE_THROW_UNLESS(!is_moved_from());
+    return body_name_;
+  }
 
  private:
+  bool is_moved_from() const { return shape_ == nullptr; }
+
   copyable_unique_ptr<geometry::Shape> shape_;
   math::RigidTransformd X_BS_;
   std::string model_instance_name_;

--- a/planning/test/body_shape_description_test.cc
+++ b/planning/test/body_shape_description_test.cc
@@ -28,6 +28,13 @@ GTEST_TEST(BodyShapeDescriptionTest, Arbitrary) {
   EXPECT_TRUE(dut.pose_in_body().IsExactlyEqualTo(pose));
   EXPECT_EQ(dut.model_instance_name(), model);
   EXPECT_EQ(dut.body_name(), body);
+
+  // A moved-from object should reject any attempt at using it.
+  BodyShapeDescription other(std::move(dut));
+  EXPECT_THROW(dut.shape(), std::exception);
+  EXPECT_THROW(dut.pose_in_body(), std::exception);
+  EXPECT_THROW(dut.model_instance_name(), std::exception);
+  EXPECT_THROW(dut.body_name(), std::exception);
 }
 
 GTEST_TEST(BodyShapeDescriptionTest, FromPlant) {


### PR DESCRIPTION
BodyShapeDescription is a serialization helper, not an inner-loop class. When the user attempts to fetch a name from a moved-from object, we should fail immediately rather than allow them to bash on with an empty string.

See `anzu/pull/9094#pullrequestreview-31230` for rationale.

Amends #18424 and #18472.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18521)
<!-- Reviewable:end -->
