### PR TITLE
[multibody] Repair some physical dependency defects in MbT

### DIFF
--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -18,7 +18,6 @@ drake_cc_package_library(
     deps = [
         ":articulated_body_inertia",
         ":geometry_spatial_inertia",
-        ":multibody_element",
         ":multibody_tree_caches",
         ":multibody_tree_core",
         ":multibody_tree_indexes",
@@ -79,12 +78,14 @@ drake_cc_library(
 
 drake_cc_library(
     name = "multibody_element",
-    srcs = [],
-    hdrs = [
-        "multibody_element.h",
+    deprecation = "This label is deprecated and will be removed from Drake on 2023-04-01; as a replacement, use //multibody/tree instead.",  # noqa
+    tags = [
+        "exclude_from_libdrake",
+        "exclude_from_package",
+        "manual",
     ],
     deps = [
-        ":multibody_tree_topology",
+        ":multibody_tree_core",
     ],
 )
 
@@ -113,6 +114,7 @@ drake_cc_library(
         "linear_spring_damper.cc",
         "mobilizer_impl.cc",
         "model_instance.cc",
+        "multibody_element.cc",
         "multibody_forces.cc",
         "multibody_tree.cc",
         "multibody_tree_system.cc",
@@ -155,6 +157,7 @@ drake_cc_library(
         "mobilizer.h",
         "mobilizer_impl.h",
         "model_instance.h",
+        "multibody_element.h",
         "multibody_forces.h",
         "multibody_tree.h",
         "multibody_tree-inl.h",
@@ -185,7 +188,6 @@ drake_cc_library(
     # "//multibody/tree" broadly, not just ":multibody_tree_core".
     visibility = ["//visibility:private"],
     deps = [
-        ":multibody_element",
         ":multibody_tree_caches",
         ":multibody_tree_indexes",
         ":spatial_inertia",

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -18,6 +18,13 @@
 namespace drake {
 namespace multibody {
 
+namespace internal {
+// This is a class used by MultibodyTree internals to create the implementation
+// for a particular joint object.
+template <typename T>
+class JointImplementationBuilder;
+}  // namespace internal
+
 /// A %Joint models the kinematical relationship which characterizes the
 /// possible relative motion between two bodies.
 /// The two bodies connected by this %Joint object are referred to as _parent_

--- a/multibody/tree/multibody_element.cc
+++ b/multibody/tree/multibody_element.cc
@@ -1,0 +1,4 @@
+#include "drake/multibody/tree/multibody_element.h"
+
+// This is an empty .cc file that only serves to confirm multibody_element.h is
+// a stand-alone header.

--- a/multibody/tree/multibody_element.h
+++ b/multibody/tree/multibody_element.h
@@ -13,13 +13,6 @@ namespace multibody {
 template <typename T>
 class MultibodyPlant;
 
-namespace internal {
-// This is a class used by MultibodyTree internals to create the implementation
-// for a particular joint object.
-template <typename T>
-class JointImplementationBuilder;
-}  // namespace internal
-
 /// A class representing an element (subcomponent) of a MultibodyPlant or
 /// (internally) a MultibodyTree. Examples of multibody elements are bodies,
 /// joints, force elements, and actuators. After a Finalize() call, multibody


### PR DESCRIPTION
The `MultibodyElement` header depends on `MultibodyTree`, so should be part of the main library, instead of pretending to be usable in isolation. This will allow for it to have a `*.cc` file down the road.

The `JointImplementBuilder` is a Tree--Joint interface so should not pollute `MultibodyElement`.

I noticed this while reading #18460.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18522)
<!-- Reviewable:end -->
