### PR TITLE
[workspace] Upgrade rules_python to latest release 0.16.1

### DIFF
--- a/tools/install/bazel/test/drake_bazel_installed_test.py
+++ b/tools/install/bazel/test/drake_bazel_installed_test.py
@@ -18,12 +18,12 @@ def main():
 
     # The commit (version) here should be identical to the commit listed in
     # drake/tools/workspace/rules_python/repository.bzl.
-    rules_python_commit = "0.13.0"
+    rules_python_commit = "0.16.0"
     rules_python_urls = [
         f"https://github.com/bazelbuild/rules_python/archive/{rules_python_commit}.tar.gz",  # noqa
         f"https://drake-mirror.csail.mit.edu/github/bazelbuild/rules_python/{rules_python_commit}.tar.gz",  # noqa
     ]
-    rules_python_sha256 = "8c8fe44ef0a9afc256d1e75ad5f448bb59b81aba149b8958f02f7b3a98f5d9b4"  # noqa
+    rules_python_sha256 = "497ca47374f48c8b067d786b512ac10a276211810f4a580178ee9b9ad139323a"  # noqa
 
     with open(join(scratch_dir, "WORKSPACE"), "w") as f:
         f.write(f"""

--- a/tools/install/bazel/test/drake_bazel_installed_test.py
+++ b/tools/install/bazel/test/drake_bazel_installed_test.py
@@ -18,7 +18,7 @@ def main():
 
     # The commit (version) here should be identical to the commit listed in
     # drake/tools/workspace/rules_python/repository.bzl.
-    rules_python_commit = "0.16.0"
+    rules_python_commit = "0.16.1"
     rules_python_urls = [
         f"https://github.com/bazelbuild/rules_python/archive/{rules_python_commit}.tar.gz",  # noqa
         f"https://drake-mirror.csail.mit.edu/github/bazelbuild/rules_python/{rules_python_commit}.tar.gz",  # noqa

--- a/tools/workspace/rules_python/repository.bzl
+++ b/tools/workspace/rules_python/repository.bzl
@@ -15,7 +15,7 @@ def rules_python_repository(
         # The commit (version) and sha256 here should be identical to the
         # commit listed in
         # drake/tools/install/bazel/test/drake_bazel_installed_test.py.
-        commit = "0.15.1",
-        sha256 = "bc4e59e17c7809a5b373ba359e2c974ed2386c58634819ac5a89c0813c15705c",  # noqa
+        commit = "0.16.1",
+        sha256 = "497ca47374f48c8b067d786b512ac10a276211810f4a580178ee9b9ad139323a",  # noqa
         mirrors = mirrors,
     )


### PR DESCRIPTION
Not expected to pass tests (causes `//:py/install_test` to fail). Needs investigation (@jwnimmer-tri ?). Should be locally reproducible; unfortunately, all CI reports for that test is to see a more detailed log.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18524)
<!-- Reviewable:end -->
