### PR TITLE
[multibody] Remove MultibodyElement's second template argument

### DIFF
--- a/multibody/tree/body.h
+++ b/multibody/tree/body.h
@@ -181,9 +181,12 @@ class BodyAttorney {
 ///
 /// @tparam_default_scalar
 template <typename T>
-class Body : public MultibodyElement<T, BodyIndex> {
+class Body : public MultibodyElement<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Body)
+
+  /// Returns this element's unique index.
+  BodyIndex index() const { return this->template index_impl<BodyIndex>(); }
 
   /// Gets the `name` associated with `this` body. The name will never be empty.
   const std::string& name() const { return name_; }
@@ -469,7 +472,7 @@ class Body : public MultibodyElement<T, BodyIndex> {
   /// Creates a %Body named `name` in model instance `model_instance`.
   /// The `name` must not be empty.
   Body(const std::string& name, ModelInstanceIndex model_instance)
-      : MultibodyElement<T, BodyIndex>(model_instance),
+      : MultibodyElement<T>(model_instance),
         name_(internal::DeprecateWhenEmptyName(name, "Body")),
         body_frame_(*this) {}
 

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -94,7 +94,7 @@ namespace internal {
 //
 // @tparam_default_scalar
 template <typename T>
-class BodyNode : public MultibodyElement<T, BodyNodeIndex> {
+class BodyNode : public MultibodyElement<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BodyNode)
 
@@ -117,7 +117,7 @@ class BodyNode : public MultibodyElement<T, BodyNodeIndex> {
   // for this node, which must outlive `this` BodyNode.
   BodyNode(const BodyNode<T>* parent_node,
            const Body<T>* body, const Mobilizer<T>* mobilizer)
-      : MultibodyElement<T, BodyNodeIndex>(body->model_instance()),
+      : MultibodyElement<T>(body->model_instance()),
         parent_node_(parent_node),
         body_(body),
         mobilizer_(mobilizer) {
@@ -135,6 +135,11 @@ class BodyNode : public MultibodyElement<T, BodyNodeIndex> {
   // MultibodyTree::Finalize() method call.
   void add_child_node(const BodyNode<T>* child) {
     children_.push_back(child);
+  }
+
+  // Returns this element's unique index.
+  BodyNodeIndex index() const {
+    return this->template index_impl<BodyNodeIndex>();
   }
 
   // Returns a constant reference to the body B associated with this node.

--- a/multibody/tree/force_element.h
+++ b/multibody/tree/force_element.h
@@ -35,13 +35,18 @@ namespace multibody {
 ///
 /// @tparam_default_scalar
 template <typename T>
-class ForceElement : public MultibodyElement<T, ForceElementIndex> {
+class ForceElement : public MultibodyElement<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ForceElement)
 
   /// Default constructor for a generic force element.
   explicit ForceElement(ModelInstanceIndex model_instance)
-      : MultibodyElement<T, ForceElementIndex>(model_instance) {}
+      : MultibodyElement<T>(model_instance) {}
+
+  /// Returns this element's unique index.
+  ForceElementIndex index() const {
+    return this->template index_impl<ForceElementIndex>();
+  }
 
   /// (Advanced) Computes the force contribution for `this` force element and
   /// **adds** it to the output arrays of forces. Depending on their model,

--- a/multibody/tree/frame_base.h
+++ b/multibody/tree/frame_base.h
@@ -43,7 +43,11 @@ namespace multibody {
 ///
 /// @tparam_default_scalar
 template <typename T>
-class FrameBase : public MultibodyElement<T, FrameIndex> {
+class FrameBase : public MultibodyElement<T> {
+ public:
+  /// Returns this element's unique index.
+  FrameIndex index() const { return this->template index_impl<FrameIndex>(); }
+
   // TODO(amcastro-tri): Provide a method with the signature:
   // const math::RigidTransform<T>& get_pose_in_world_frame(
   //     const Context<T>& context) const;
@@ -58,7 +62,7 @@ class FrameBase : public MultibodyElement<T, FrameIndex> {
   // `measured_in_frame` frame.
  protected:
   explicit FrameBase(ModelInstanceIndex model_instance)
-      : MultibodyElement<T, FrameIndex>(model_instance) {}
+      : MultibodyElement<T>(model_instance) {}
 };
 
 }  // namespace multibody

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -74,7 +74,7 @@ class JointImplementationBuilder;
 ///
 /// @tparam_default_scalar
 template <typename T>
-class Joint : public MultibodyElement<T, JointIndex> {
+class Joint : public MultibodyElement<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Joint)
 
@@ -126,7 +126,7 @@ class Joint : public MultibodyElement<T, JointIndex> {
         const VectorX<double>& vel_upper_limits,
         const VectorX<double>& acc_lower_limits,
         const VectorX<double>& acc_upper_limits)
-      : MultibodyElement<T, JointIndex>(frame_on_child.model_instance()),
+      : MultibodyElement<T>(frame_on_child.model_instance()),
         name_(name),
         frame_on_parent_(frame_on_parent),
         frame_on_child_(frame_on_child),
@@ -174,6 +174,9 @@ class Joint : public MultibodyElement<T, JointIndex> {
               acc_lower_limits, acc_upper_limits) {}
 
   virtual ~Joint() {}
+
+  /// Returns this element's unique index.
+  JointIndex index() const { return this->template index_impl<JointIndex>(); }
 
   /// Returns the name of this joint.
   const std::string& name() const { return name_; }

--- a/multibody/tree/joint_actuator.cc
+++ b/multibody/tree/joint_actuator.cc
@@ -9,8 +9,7 @@ namespace multibody {
 template <typename T>
 JointActuator<T>::JointActuator(const std::string& name, const Joint<T>& joint,
                                 double effort_limit)
-    : MultibodyElement<T, JointActuatorIndex>(
-          joint.model_instance()),
+    : MultibodyElement<T>(joint.model_instance()),
       name_(name),
       joint_index_(joint.index()),
       effort_limit_(effort_limit) {

--- a/multibody/tree/joint_actuator.h
+++ b/multibody/tree/joint_actuator.h
@@ -27,7 +27,7 @@ template<typename T> class Joint;
 ///
 /// @tparam_default_scalar
 template <typename T>
-class JointActuator final : public MultibodyElement<T, JointActuatorIndex> {
+class JointActuator final : public MultibodyElement<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(JointActuator)
 
@@ -47,6 +47,11 @@ class JointActuator final : public MultibodyElement<T, JointActuatorIndex> {
   ///   for prismatic joints.
   JointActuator(const std::string& name, const Joint<T>& joint,
                 double effort_limit = std::numeric_limits<double>::infinity());
+
+  /// Returns this element's unique index.
+  JointActuatorIndex index() const {
+    return this->template index_impl<JointActuatorIndex>();
+  }
 
   /// Returns the name of the actuator.
   const std::string& name() const { return name_; }
@@ -294,7 +299,7 @@ class JointActuator final : public MultibodyElement<T, JointActuatorIndex> {
   void DoDeclareParameters(
       internal::MultibodyTreeSystem<T>* tree_system) final {
     // Declare parent classes' parameters
-    MultibodyElement<T, JointActuatorIndex>::DoDeclareParameters(tree_system);
+    MultibodyElement<T>::DoDeclareParameters(tree_system);
     rotor_inertia_parameter_index_ = this->DeclareNumericParameter(
         tree_system,
         systems::BasicVector<T>(Vector1<T>(default_rotor_inertia_)));

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -209,7 +209,7 @@ template<typename T> class BodyNode;
 //
 // @tparam_default_scalar
 template <typename T>
-class Mobilizer : public MultibodyElement<T, MobilizerIndex> {
+class Mobilizer : public MultibodyElement<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Mobilizer)
 
@@ -227,6 +227,11 @@ class Mobilizer : public MultibodyElement<T, MobilizerIndex> {
       throw std::runtime_error(
           "The provided inboard and outboard frames reference the same object");
     }
+  }
+
+  /// Returns this element's unique index.
+  MobilizerIndex index() const {
+    return this->template index_impl<MobilizerIndex>();
   }
 
   // Returns the number of generalized coordinates granted by this mobilizer.
@@ -706,7 +711,7 @@ class Mobilizer : public MultibodyElement<T, MobilizerIndex> {
   void DoDeclareParameters(
       internal::MultibodyTreeSystem<T>* tree_system) override {
     // Declare parent class's parameters
-    MultibodyElement<T, MobilizerIndex>::DoDeclareParameters(tree_system);
+    MultibodyElement<T>::DoDeclareParameters(tree_system);
 
     is_locked_parameter_index_ =
         this->DeclareAbstractParameter(tree_system, Value<bool>(false));

--- a/multibody/tree/model_instance.h
+++ b/multibody/tree/model_instance.h
@@ -55,12 +55,17 @@ namespace internal {
 
 // @tparam_default_scalar
 template <typename T>
-class ModelInstance : public MultibodyElement<T, ModelInstanceIndex> {
+class ModelInstance : public MultibodyElement<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ModelInstance)
 
   explicit ModelInstance(ModelInstanceIndex index)
-      : MultibodyElement<T, ModelInstanceIndex>(index) {}
+      : MultibodyElement<T>(index) {}
+
+  /// Returns this element's unique index.
+  ModelInstanceIndex index() const {
+    return this->template index_impl<ModelInstanceIndex>();
+  }
 
   int num_positions() const { return num_positions_; }
   int num_velocities() const { return num_velocities_; }

--- a/multibody/tree/multibody_element.cc
+++ b/multibody/tree/multibody_element.cc
@@ -1,4 +1,66 @@
 #include "drake/multibody/tree/multibody_element.h"
 
-// This is an empty .cc file that only serves to confirm multibody_element.h is
-// a stand-alone header.
+namespace drake {
+namespace multibody {
+
+using internal::MultibodyTreeSystem;
+
+template <typename T>
+MultibodyElement<T>::~MultibodyElement() {}
+
+template <typename T>
+void MultibodyElement<T>::DeclareParameters(
+    MultibodyTreeSystem<T>* tree_system) {
+  DRAKE_DEMAND(tree_system == &GetParentTreeSystem());
+  DoDeclareParameters(tree_system);
+}
+
+template <typename T>
+MultibodyElement<T>::MultibodyElement() {}
+
+template <typename T>
+MultibodyElement<T>::MultibodyElement(ModelInstanceIndex model_instance)
+    : model_instance_(model_instance) {}
+
+template <typename T>
+void MultibodyElement<T>::DoDeclareParameters(MultibodyTreeSystem<T>*) {}
+
+template <typename T>
+systems::NumericParameterIndex MultibodyElement<T>::DeclareNumericParameter(
+    MultibodyTreeSystem<T>* tree_system,
+    const systems::BasicVector<T>& model_vector) {
+  return internal::MultibodyTreeSystemElementAttorney<T>
+      ::DeclareNumericParameter(tree_system, model_vector);
+}
+
+template <typename T>
+systems::AbstractParameterIndex MultibodyElement<T>::DeclareAbstractParameter(
+    MultibodyTreeSystem<T>* tree_system,
+    const AbstractValue& model_value) {
+  return internal::MultibodyTreeSystemElementAttorney<T>
+      ::DeclareAbstractParameter(tree_system, model_value);
+}
+
+template <typename T>
+void MultibodyElement<T>::HasParentTreeOrThrow() const {
+  if (!has_parent_tree()) {
+    throw std::logic_error(
+        "This multibody element was not added to a MultibodyTree.");
+  }
+}
+
+template <typename T>
+void MultibodyElement<T>::HasThisParentTreeOrThrow(
+    const internal::MultibodyTree<T>* tree) const {
+  DRAKE_ASSERT(tree != nullptr);
+  if (parent_tree_ != tree) {
+    throw std::logic_error("This multibody element does not belong to the "
+                           "supplied MultibodyTree.");
+  }
+}
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::MultibodyElement)

--- a/multibody/tree/multibody_element.h
+++ b/multibody/tree/multibody_element.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/multibody/tree/multibody_tree.h"
@@ -16,38 +17,26 @@ class MultibodyPlant;
 /// A class representing an element (subcomponent) of a MultibodyPlant or
 /// (internally) a MultibodyTree. Examples of multibody elements are bodies,
 /// joints, force elements, and actuators. After a Finalize() call, multibody
-/// elements get assigned an type-specific index that uniquely identifies them.
-/// A generic multibody tree element `MultibodyThing` is derived from
-/// this class as:
-/// @code{.cpp}
-/// template <typename T>
-/// class MultibodyThing : public MultibodyElement<T, MultibodyThingIndex> {
-///  ...
-/// };
+/// elements get assigned a type-specific index that uniquely identifies them.
+/// By convention, every subclass of MultibodyElement provides an `index()`
+/// member function that returns the assigned index, e.g.,
+///
+/// @code
+/// /** Returns this element's unique index. */
+/// BodyIndex index() const { return this->template index_impl<BodyIndex>(); }
 /// @endcode
 ///
 /// @tparam_default_scalar
-/// @tparam ElementIndexType The type-safe index used for this element type.
-///
-/// As an example of usage, consider the definition of a `ForceElement` class
-/// as a multibody element. This is accomplished with:
-/// @code{.cpp}
-///   template <typename T>
-///   class ForceElement : public MultibodyElement<T, ForceElementIndex>;
-/// @endcode
-template <typename T, typename ElementIndexType>
+template <typename T>
 class MultibodyElement {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MultibodyElement)
 
-  virtual ~MultibodyElement() {}
-
-  /// Returns this element's unique index.
-  ElementIndexType index() const { return index_;}
+  virtual ~MultibodyElement();
 
   /// Returns the ModelInstanceIndex of the model instance to which this
   /// element belongs.
-  ModelInstanceIndex model_instance() const { return model_instance_;}
+  ModelInstanceIndex model_instance() const { return model_instance_; }
 
   /// Returns the MultibodyPlant that owns this %MultibodyElement.
   ///
@@ -77,19 +66,22 @@ class MultibodyElement {
   /// @param[in] tree_system A mutable copy of the parent MultibodyTreeSystem.
   /// @pre 'tree_system' must be the same as the parent tree system (what's
   /// returned from GetParentTreeSystem()).
-  void DeclareParameters(internal::MultibodyTreeSystem<T>* tree_system) {
-    DRAKE_DEMAND(tree_system == &GetParentTreeSystem());
-    DoDeclareParameters(tree_system);
-  }
+  void DeclareParameters(internal::MultibodyTreeSystem<T>* tree_system);
 
  protected:
   /// Default constructor made protected so that sub-classes can still declare
   /// their default constructors if they need to.
-  MultibodyElement() {}
+  MultibodyElement();
 
   /// Constructor which allows specifying a model instance.
-  explicit MultibodyElement(ModelInstanceIndex model_instance)
-      : model_instance_(model_instance) {}
+  explicit MultibodyElement(ModelInstanceIndex model_instance);
+
+  /// Returns this element's unique index.
+  template <typename ElementIndexType>
+  ElementIndexType index_impl() const {
+    DRAKE_ASSERT(index_ >= 0);
+    return ElementIndexType{index_};
+  }
 
   /// Returns a constant reference to the parent MultibodyTree that
   /// owns this element.
@@ -120,27 +112,21 @@ class MultibodyElement {
   /// objects must override to declare their specific parameters. If an object
   /// is not a direct descendent of MultibodyElement, it must invoke its parent
   /// classes' DoDeclareParameters() before declaring its own parameters.
-  virtual void DoDeclareParameters(internal::MultibodyTreeSystem<T>*) {}
+  virtual void DoDeclareParameters(internal::MultibodyTreeSystem<T>*);
 
   /// To be used by MultibodyElement-derived objects when declaring parameters
   /// in their implementation of DoDeclareParameters(). For an example, see
   /// RigidBody::DoDeclareParameters().
   systems::NumericParameterIndex DeclareNumericParameter(
       internal::MultibodyTreeSystem<T>* tree_system,
-      const systems::BasicVector<T>& model_vector) {
-    return internal::MultibodyTreeSystemElementAttorney<T>
-        ::DeclareNumericParameter(tree_system, model_vector);
-  }
+      const systems::BasicVector<T>& model_vector);
 
   /// To be used by MultibodyElement-derived objects when declaring parameters
   /// in their implementation of DoDeclareParameters(). For an example, see
   /// Joint::DoDeclareParameters().
   systems::AbstractParameterIndex DeclareAbstractParameter(
       internal::MultibodyTreeSystem<T>* tree_system,
-      const AbstractValue& model_value) {
-    return internal::MultibodyTreeSystemElementAttorney<T>
-        ::DeclareAbstractParameter(tree_system, model_value);
-  }
+      const AbstractValue& model_value);
 
  private:
   // MultibodyTree<T> is a natural friend of MultibodyElement objects and
@@ -151,7 +137,7 @@ class MultibodyElement {
   friend class MultibodyElementTester;
 
   void set_parent_tree(
-      const internal::MultibodyTree<T>* tree, ElementIndexType index) {
+      const internal::MultibodyTree<T>* tree, int64_t index) {
     index_ = index;
     parent_tree_ = tree;
   }
@@ -165,29 +151,18 @@ class MultibodyElement {
   // Checks whether this MultibodyElement has been registered into
   // a MultibodyTree and throws an exception if not.
   // @throws std::exception if the element is not in a MultibodyTree.
-  void HasParentTreeOrThrow() const {
-    if (!has_parent_tree()) {
-      throw std::logic_error(
-          "This multibody element was not added to a MultibodyTree.");
-    }
-  }
+  void HasParentTreeOrThrow() const;
 
   // Checks whether this MultibodyElement belongs to the provided
   // MultibodyTree `tree` and throws an exception if not.
   // @throws std::exception if `this` element is not in the given `tree`.
-  void HasThisParentTreeOrThrow(const internal::MultibodyTree<T>* tree) const {
-    DRAKE_ASSERT(tree != nullptr);
-    if (parent_tree_ != tree) {
-      throw std::logic_error("This multibody element does not belong to the "
-                             "supplied MultibodyTree.");
-    }
-  }
+  void HasThisParentTreeOrThrow(const internal::MultibodyTree<T>* tree) const;
 
   const internal::MultibodyTree<T>* parent_tree_{nullptr};
 
   // The default index value is *invalid*. This must be set to a valid index
   // value before the element is released to the wild.
-  ElementIndexType index_;
+  int64_t index_{-1};
 
   // The default model instance id is *invalid*. This must be set to a
   // valid index value before the element is released to the wild.
@@ -196,3 +171,6 @@ class MultibodyElement {
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::MultibodyElement)

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -539,7 +539,7 @@ const MultibodyTree<T>& GetInternalTree(const MultibodyTreeSystem<T>& system) {
 namespace drake {
 namespace multibody {
 // Forward declaration of MultibodyElement for attorney-client.
-template <typename T, typename ElementIndexType>
+template <typename T>
 class MultibodyElement;
 
 namespace internal {
@@ -553,7 +553,7 @@ class MultibodyTreeSystemElementAttorney {
   MultibodyTreeSystemElementAttorney() = delete;
 
  private:
-  template <typename U, typename ElementIndexType>
+  template <typename U>
   friend class drake::multibody::MultibodyElement;
 
   static systems::NumericParameterIndex DeclareNumericParameter(

--- a/multibody/tree/test/multibody_tree_creation_test.cc
+++ b/multibody/tree/test/multibody_tree_creation_test.cc
@@ -27,15 +27,14 @@ namespace multibody {
 class MultibodyElementTester {
  public:
   MultibodyElementTester() = delete;
-  template <typename T, typename ElementIndexType>
-  static bool has_parent_tree(
-      const MultibodyElement<T, ElementIndexType>& element) {
+  template <typename T>
+  static bool has_parent_tree(const MultibodyElement<T>& element) {
     return element.has_parent_tree();
   }
 
-  template <typename T, typename ElementIndexType>
+  template <typename T>
   static const internal::MultibodyTree<T>& get_parent_tree(
-      const MultibodyElement<T, ElementIndexType>& element) {
+      const MultibodyElement<T>& element) {
     return element.get_parent_tree();
   }
 };


### PR DESCRIPTION
This allows us to to move a bunch of function definitions into the cc file, which is Drake style.

I noticed this while reading #18460. (Since we already did one breaking change to the template list in that PR, I think it makes sense to try to get this change into the next release as well, so there's effectively only one break.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18526)
<!-- Reviewable:end -->
