### PR TITLE
Increase mypy timeout for glacial CI machines

### DIFF
--- a/tools/workspace/mypy_internal/patches/timeout.patch
+++ b/tools/workspace/mypy_internal/patches/timeout.patch
@@ -1,0 +1,22 @@
+Increase timeout from 30 seconds to 90 seconds
+
+--- mypy/moduleinspect.py
++++ mypy/moduleinspect.py
+@@ -157,13 +157,15 @@
+ 
+         Return the value read from the queue, or None if the process unexpectedly died.
+         """
+-        max_iter = 600
++        timeout_seconds = 90
++        timeout_increment = 0.05
++        max_iter = int(timeout_seconds / timeout_increment)
+         n = 0
+         while True:
+             if n == max_iter:
+                 raise RuntimeError("Timeout waiting for subprocess")
+             try:
+-                return self.results.get(timeout=0.05)
++                return self.results.get(timeout=timeout_increment)
+             except queue.Empty:
+                 if not self.proc.is_alive():
+                     return None

--- a/tools/workspace/mypy_internal/repository.bzl
+++ b/tools/workspace/mypy_internal/repository.bzl
@@ -11,5 +11,8 @@ def mypy_internal_repository(
         commit = "v0.991",
         sha256 = "a88d446622657e5ef455e9e3a1693c6732a5b8311a17bec90ba103c8e39db3d5",  # noqa
         build_file = ":package.BUILD.bazel",
+        patches = [
+            ":patches/timeout.patch",
+        ],
         mirrors = mirrors,
     )


### PR DESCRIPTION
For now, we'll just bump the timeout and see if that is enough for CI be happy.  If not, possibly the process is stuck forever instead of just slow.

See also https://github.com/RobotLocomotion/drake/pull/17552 and https://github.com/python/mypy/pull/13109 for prior failed attempt (increasing from 5s to 30s).

Closes #18119.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18527)
<!-- Reviewable:end -->
