### PR TITLE
[doc] Enable Doxygen builds on Ubuntu 22.04

### DIFF
--- a/tools/workspace/doxygen/repository.bzl
+++ b/tools/workspace/doxygen/repository.bzl
@@ -17,7 +17,7 @@ def _impl(repo_ctx):
         "BUILD.bazel",
     )
 
-    if os_result.ubuntu_release == "20.04":
+    if os_result.is_ubuntu:
         # Download and extract Drake's pre-compiled Doxygen binary.
         archive = "doxygen-1.8.15-focal-x86_64.tar.gz"
         url = [


### PR DESCRIPTION
The Doxygen binary runs on Ubuntu 22 without errors.

Towards #18507.

(Prior to switching CI to use Ubuntu 22, we still need to check that it's output has no regressions on the new platform.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18528)
<!-- Reviewable:end -->
