### PR TITLE
[pydrake] Add __repr__ to several classes

### DIFF
--- a/bindings/pydrake/geometry_py_render.cc
+++ b/bindings/pydrake/geometry_py_render.cc
@@ -300,6 +300,25 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def(py::init<int>(), py::arg("value"), doc.RenderLabel.ctor.doc_1args)
         .def("is_reserved", &RenderLabel::is_reserved)
         .def("__int__", [](const RenderLabel& self) -> int { return self; })
+        .def("__repr__",
+            [](const RenderLabel& self) -> std::string {
+              if (self == RenderLabel::kEmpty) {
+                return "RenderLabel.kEmpty";
+              }
+              if (self == RenderLabel::kDoNotRender) {
+                return "RenderLabel.kDoNotRender";
+              }
+              if (self == RenderLabel::kDontCare) {
+                return "RenderLabel.kDontCare";
+              }
+              if (self == RenderLabel::kUnspecified) {
+                return "RenderLabel.kUnspecified";
+              }
+              if (self == RenderLabel::kMaxUnreserved) {
+                return "RenderLabel.kMaxUnreserved";
+              }
+              return fmt::format("RenderLabel({})", int{self});
+            })
         // EQ(==).
         .def(py::self == py::self)
         .def(py::self == int{})

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -565,6 +565,10 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def(
             "__repr__", [](const NumericalGradientOption& self) -> std::string {
               py::object method = py::cast(self.method());
+              // This is a minimal implementation that serves to avoid
+              // displaying memory addresses in pydrake docs and help strings.
+              // In the future, we should enhance this to display all of the
+              // information.
               return fmt::format(
                   "<NumericalGradientOption({})>", py::repr(method));
             });

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -561,7 +561,13 @@ void DoScalarIndependentDefinitions(py::module m) {
             py::arg("function_accuracy") = 1E-15, cls_doc.ctor.doc)
         .def("NumericalGradientMethod", &Class::method, cls_doc.method.doc)
         .def("perturbation_size", &Class::perturbation_size,
-            cls_doc.perturbation_size.doc);
+            cls_doc.perturbation_size.doc)
+        .def(
+            "__repr__", [](const NumericalGradientOption& self) -> std::string {
+              py::object method = py::cast(self.method());
+              return fmt::format(
+                  "<NumericalGradientOption({})>", py::repr(method));
+            });
   }
 
   m.def(

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -524,6 +524,9 @@ void BindSolverInterfaceAndFlags(py::module m) {
       .def("get_print_to_console", &SolverOptions::get_print_to_console,
           doc.SolverOptions.get_print_to_console.doc)
       .def("__repr__", [](const SolverOptions&) -> std::string {
+        // This is a minimal implementation that serves to avoid displaying
+        // memory addresses in pydrake docs and help strings. In the future,
+        // we should enhance this to provide more details.
         return "<SolverOptions>";
       });
 

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -522,7 +522,10 @@ void BindSolverInterfaceAndFlags(py::module m) {
       .def("get_print_file_name", &SolverOptions::get_print_file_name,
           doc.SolverOptions.get_print_file_name.doc)
       .def("get_print_to_console", &SolverOptions::get_print_to_console,
-          doc.SolverOptions.get_print_to_console.doc);
+          doc.SolverOptions.get_print_to_console.doc)
+      .def("__repr__", [](const SolverOptions&) -> std::string {
+        return "<SolverOptions>";
+      });
 
   py::enum_<CommonSolverOption>(
       m, "CommonSolverOption", doc.CommonSolverOption.doc)

--- a/bindings/pydrake/test/geometry_render_test.py
+++ b/bindings/pydrake/test/geometry_render_test.py
@@ -78,6 +78,25 @@ class TestGeometryRender(unittest.TestCase):
         # Confirm value instantiation.
         Value[mut.render.RenderLabel]
 
+    def test_render_label_repr(self):
+        RenderLabel = mut.render.RenderLabel
+
+        # Special labels should use a non-numeric spelling.
+        special_labels = [
+            RenderLabel.kEmpty,
+            RenderLabel.kDoNotRender,
+            RenderLabel.kDontCare,
+            RenderLabel.kUnspecified,
+        ]
+        for label in special_labels:
+            self.assertIn("RenderLabel.k", repr(label))
+
+        # Any label should round-trip via 'eval'.
+        all_labels = special_labels + [RenderLabel(10)]
+        for label in all_labels:
+            roundtrip = eval(repr(label), dict(RenderLabel=RenderLabel))
+            self.assertEqual(label, roundtrip)
+
     def test_render_engine_api(self):
         class DummyRenderEngine(mut.render.RenderEngine):
             """Mirror of C++ DummyRenderEngine."""

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -504,6 +504,8 @@ class TestMath(unittest.TestCase):
             method=mut.NumericalGradientMethod.kCentral,
             function_accuracy=1E-15)
 
+        self.assertIn("kCentral", repr(option))
+
         def foo(x):
             return np.array([x[0] ** 2, x[0] * x[1]])
 


### PR DESCRIPTION
Closes #13987.

`RenderLabel` gets a round-trip `repr()`.

`NumericalGradientOption` lacks a getter function for one of its constructor arguments, so can only provide an incomplete `repr()`.

`SolverOptions` only provides a no-argument constructor, so cannot offer round-trip.  For the purpose of cleaning up our generated documentation, it's sufficient to just hard-code a return value in order to omit the hex address that would otherwise show up in our docs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18529)
<!-- Reviewable:end -->
