### PR TITLE
NloptSolver supports setting algorithm

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_nlopt.cc
+++ b/bindings/pydrake/solvers/solvers_py_nlopt.cc
@@ -19,7 +19,20 @@ void DefineSolversNlopt(py::module m) {
   py::class_<NloptSolver, SolverInterface>(
       m, "NloptSolver", doc.NloptSolver.doc)
       .def(py::init<>(), doc.NloptSolver.ctor.doc)
-      .def_static("id", &NloptSolver::id, doc.NloptSolver.id.doc);
+      .def_static("id", &NloptSolver::id, doc.NloptSolver.id.doc)
+      .def_static("ConstraintToleranceName",
+          &NloptSolver::ConstraintToleranceName,
+          doc.NloptSolver.ConstraintToleranceName.doc)
+      .def_static("XRelativeToleranceName",
+          &NloptSolver::XRelativeToleranceName,
+          doc.NloptSolver.XRelativeToleranceName.doc)
+      .def_static("XAbsoluteToleranceName",
+          &NloptSolver::XAbsoluteToleranceName,
+          doc.NloptSolver.XAbsoluteToleranceName.doc)
+      .def_static("MaxEvalName", &NloptSolver::MaxEvalName,
+          doc.NloptSolver.MaxEvalName.doc)
+      .def_static("AlgorithmName", &NloptSolver::AlgorithmName,
+          doc.NloptSolver.AlgorithmName.doc);
 
   py::class_<NloptSolverDetails>(
       m, "NloptSolverDetails", doc.NloptSolverDetails.doc)

--- a/bindings/pydrake/solvers/test/nlopt_solver_test.py
+++ b/bindings/pydrake/solvers/test/nlopt_solver_test.py
@@ -29,6 +29,12 @@ class TestNloptSolver(unittest.TestCase):
             result.GetSolution(x), x_expected, atol=1E-7)
         self.assertEqual(result.get_solver_details().status, 4)
 
+        self.assertIsInstance(NloptSolver.ConstraintToleranceName(), str)
+        self.assertIsInstance(NloptSolver.XRelativeToleranceName(), str)
+        self.assertIsInstance(NloptSolver.XAbsoluteToleranceName(), str)
+        self.assertIsInstance(NloptSolver.MaxEvalName(), str)
+        self.assertIsInstance(NloptSolver.AlgorithmName(), str)
+
     def unavailable(self):
         """Per the BUILD file, this test is only run when NLopt is disabled."""
         solver = NloptSolver()

--- a/solvers/nlopt_solver.h
+++ b/solvers/nlopt_solver.h
@@ -40,6 +40,9 @@ class NloptSolver final : public SolverBase {
   /** The key name for int-valued maximum number of evaluations. */
   static std::string MaxEvalName();
 
+  /** The key name for the string-valued algorithm. */
+  static std::string AlgorithmName();
+
   /// @name Static versions of the instance methods with similar names.
   //@{
   static SolverId id();

--- a/solvers/nlopt_solver_common.cc
+++ b/solvers/nlopt_solver_common.cc
@@ -44,5 +44,7 @@ std::string NloptSolver::XAbsoluteToleranceName() { return "xtol_abs"; }
 
 std::string NloptSolver::MaxEvalName() { return "max_eval"; }
 
+std::string NloptSolver::AlgorithmName() { return "algorithm"; }
+
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/solver_options.h
+++ b/solvers/solver_options.h
@@ -32,6 +32,15 @@ namespace solvers {
  * guide section "Options Reference"
  * http://www.coin-or.org/Ipopt/documentation/node40.html
  *
+ * "NLOPT" -- Parameter names and values are specifed in
+ * https://nlopt.readthedocs.io/en/latest/NLopt_C-plus-plus_Reference/ (in the
+ * Stopping criteria section). Besides these parameters, the user can specify
+ * "algorithm" using a string of the algorithm name. The complete set of
+ * algorithms is listed in "nlopt_algorithm_to_string()" function in
+ * github.com/stevengj/nlopt/blob/master/src/api/general.c. If you would like to
+ * use certain algorithm, for example NLOPT_LD_SLSQP, call
+ * `SetOption(NloptSolver::id(), NloptSolver::AlgorithmName(), "LD_SLSQP");`
+ *
  * "GUROBI" -- Parameter name and values as specified in Gurobi Reference
  * Manual, section 10.2 "Parameter Descriptions"
  * https://www.gurobi.com/documentation/9.5/refman/parameters.html

--- a/solvers/test/nlopt_solver_test.cc
+++ b/solvers/test/nlopt_solver_test.cc
@@ -41,6 +41,21 @@ GTEST_TEST(NloptSolverTest, TestNonconvexQP) {
     TestNonconvexQP(solver, false);
   }
 }
+
+GTEST_TEST(NloptSolverTest, SetAlgorithm) {
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<2>();
+  prog.AddQuadraticCost(Eigen::Matrix2d::Identity(), Eigen::Vector2d::Ones(), x,
+                        true /*is_convex */);
+  prog.AddBoundingBoxConstraint(1, 2, x);
+  NloptSolver solver;
+  SolverOptions solver_options;
+  solver_options.SetOption(solver.id(), NloptSolver::AlgorithmName(),
+                           "LD_CCSAQ");
+  const auto result =
+      solver.Solve(prog, Eigen::VectorXd::Ones(2), solver_options);
+  ASSERT_TRUE(result.is_success());
+}
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
Call SolverOptions::SetOption(NloptSolver::id(), algorithm, ALGORITHM_NAME_STRING) to set the algorithm.

Requested by the stackoverflow question https://stackoverflow.com/questions/74972952/pydrake-nlopt-method-selection

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18535)
<!-- Reviewable:end -->
