### PR TITLE
Remove unenforced "absolute path" requirement; resolve relpaths

### DIFF
--- a/bindings/pydrake/geometry_py_common.cc
+++ b/bindings/pydrake/geometry_py_common.cc
@@ -7,9 +7,11 @@
 #include "pybind11/operators.h"
 
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/identifier_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/geometry/collision_filter_declaration.h"
 #include "drake/geometry/collision_filter_manager.h"
 #include "drake/geometry/geometry_frame.h"
@@ -395,8 +397,9 @@ void DoScalarIndependentDefinitions(py::module m) {
               return Capsule(dims.first, dims.second);
             }));
 
-    py::class_<Convex, Shape>(m, "Convex", doc.Convex.doc)
-        .def(py::init<std::string, double>(), py::arg("absolute_filename"),
+    py::class_<Convex, Shape> convex_cls(m, "Convex", doc.Convex.doc);
+    convex_cls
+        .def(py::init<std::string, double>(), py::arg("filename"),
             py::arg("scale") = 1.0, doc.Convex.ctor.doc)
         .def("filename", &Convex::filename, doc.Convex.filename.doc)
         .def("scale", &Convex::scale, doc.Convex.scale.doc)
@@ -407,6 +410,15 @@ void DoScalarIndependentDefinitions(py::module m) {
             [](std::pair<std::string, double> info) {
               return Convex(info.first, info.second);
             }));
+
+    constexpr char doc_ConvexInitWithArgumentNameAbsoluteFilename[] =
+        "Convex(absolute_filename=...) is deprecated, and will be removed on "
+        "or around 2023-05-01.  Please use Convex(filename=...) instead.";
+
+    convex_cls.def(py_init_deprecated<Convex, std::string, double>(
+                       doc_ConvexInitWithArgumentNameAbsoluteFilename),
+        py::arg("absolute_filename"), py::arg("scale") = 1.0,
+        doc_ConvexInitWithArgumentNameAbsoluteFilename);
 
     py::class_<Cylinder, Shape>(m, "Cylinder", doc.Cylinder.doc)
         .def(py::init<double, double>(), py::arg("radius"), py::arg("length"),
@@ -445,8 +457,9 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def_static("MakePose", &HalfSpace::MakePose, py::arg("Hz_dir_F"),
             py::arg("p_FB"), doc.HalfSpace.MakePose.doc);
 
-    py::class_<Mesh, Shape>(m, "Mesh", doc.Mesh.doc)
-        .def(py::init<std::string, double>(), py::arg("absolute_filename"),
+    py::class_<Mesh, Shape> mesh_cls(m, "Mesh", doc.Mesh.doc);
+    mesh_cls
+        .def(py::init<std::string, double>(), py::arg("filename"),
             py::arg("scale") = 1.0, doc.Mesh.ctor.doc)
         .def("filename", &Mesh::filename, doc.Mesh.filename.doc)
         .def("scale", &Mesh::scale, doc.Mesh.scale.doc)
@@ -457,6 +470,15 @@ void DoScalarIndependentDefinitions(py::module m) {
             [](std::pair<std::string, double> info) {
               return Mesh(info.first, info.second);
             }));
+
+    constexpr char doc_MeshInitWithArgumentNameAbsoluteFilename[] =
+        "Mesh(absolute_filename=...) is deprecated, and will be removed on "
+        "or around 2023-05-01.  Please use Mesh(filename=...) instead.";
+
+    mesh_cls.def(py_init_deprecated<Mesh, std::string, double>(
+                     doc_MeshInitWithArgumentNameAbsoluteFilename),
+        py::arg("absolute_filename"), py::arg("scale") = 1.0,
+        doc_MeshInitWithArgumentNameAbsoluteFilename);
 
     py::class_<Sphere, Shape>(m, "Sphere", doc.Sphere.doc)
         .def(py::init<double>(), py::arg("radius"), doc.Sphere.ctor.doc)

--- a/bindings/pydrake/test/geometry_common_test.py
+++ b/bindings/pydrake/test/geometry_common_test.py
@@ -323,8 +323,8 @@ class TestGeometryCore(unittest.TestCase):
             mut.Capsule(radius=1.0, length=2.0),
             mut.Ellipsoid(a=1.0, b=2.0, c=3.0),
             mut.HalfSpace(),
-            mut.Mesh(absolute_filename="arbitrary/path", scale=1.0),
-            mut.Convex(absolute_filename="arbitrary/path", scale=1.0),
+            mut.Mesh(filename="arbitrary/path", scale=1.0),
+            mut.Convex(filename="arbitrary/path", scale=1.0),
             mut.MeshcatCone(height=1.23, a=3.45, b=6.78)
         ]
         for shape in shapes:
@@ -333,6 +333,9 @@ class TestGeometryCore(unittest.TestCase):
             shape_copy = shape.Clone()
             self.assertIsInstance(shape_copy, shape_cls)
             self.assertIsNot(shape, shape_copy)
+        with catch_drake_warnings(expected_count=2):
+            mut.Mesh(absolute_filename="arbitrary/path", scale=1.0),
+            mut.Convex(absolute_filename="arbitrary/path", scale=1.0),
 
     def test_shapes(self):
         # We'll test some invariants on all shapes as inherited from the Shape
@@ -367,9 +370,9 @@ class TestGeometryCore(unittest.TestCase):
             self, capsule, lambda shape: [shape.radius(), shape.length()])
 
         junk_path = "arbitrary/path"
-        convex = mut.Convex(absolute_filename=junk_path, scale=1.0)
+        convex = mut.Convex(filename=junk_path, scale=1.0)
         assert_shape_api(convex)
-        self.assertEqual(convex.filename(), junk_path)
+        self.assertIn(junk_path, convex.filename())
         self.assertEqual(convex.scale(), 1.0)
         assert_pickle(
             self, convex, lambda shape: [shape.filename(), shape.scale()])
@@ -394,9 +397,9 @@ class TestGeometryCore(unittest.TestCase):
         X_FH = mut.HalfSpace.MakePose(Hz_dir_F=[0, 1, 0], p_FB=[1, 1, 1])
         self.assertIsInstance(X_FH, RigidTransform)
 
-        mesh = mut.Mesh(absolute_filename=junk_path, scale=1.0)
+        mesh = mut.Mesh(filename=junk_path, scale=1.0)
         assert_shape_api(mesh)
-        self.assertEqual(mesh.filename(), junk_path)
+        self.assertIn(junk_path, mesh.filename())
         self.assertEqual(mesh.scale(), 1.0)
         assert_pickle(
             self, mesh, lambda shape: [shape.filename(), shape.scale()])

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -72,8 +72,10 @@ Capsule::Capsule(double radius, double length)
 Capsule::Capsule(const Vector2<double>& measures)
     : Capsule(measures(0), measures(1)) {}
 
-Convex::Convex(const std::string& absolute_filename, double scale)
-    : Shape(ShapeTag<Convex>()), filename_(absolute_filename), scale_(scale) {
+Convex::Convex(const std::string& filename, double scale)
+    : Shape(ShapeTag<Convex>()),
+      filename_(std::filesystem::absolute(filename)),
+      scale_(scale) {
   if (std::abs(scale) < 1e-8) {
     throw std::logic_error("Convex |scale| cannot be < 1e-8.");
   }
@@ -140,8 +142,10 @@ RigidTransform<double> HalfSpace::MakePose(const Vector3<double>& Hz_dir_F,
   return RigidTransform<double>(R_FH, p_FH);
 }
 
-Mesh::Mesh(const std::string& absolute_filename, double scale)
-    : Shape(ShapeTag<Mesh>()), filename_(absolute_filename), scale_(scale) {
+Mesh::Mesh(const std::string& filename, double scale)
+    : Shape(ShapeTag<Mesh>()),
+      filename_(std::filesystem::absolute(filename)),
+      scale_(scale) {
   if (std::abs(scale) < 1e-8) {
     throw std::logic_error("Mesh |scale| cannot be < 1e-8.");
   }

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -178,12 +178,14 @@ class Convex final : public Shape {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Convex)
 
   /** Constructs a convex shape specification from the file located at the
-   given _absolute_ file path. Optionally uniformly scaled by the given scale
-   factor.
-   @param absolute_filename     The file name with absolute path. We only
-                                support an .obj file with only one polyhedron.
-                                We assume that the polyhedron is convex.
-   @param scale                 An optional scale to coordinates.
+   given file path. Optionally uniformly scaled by the given scale factor.
+
+   * We only support an .obj file with only one polyhedron.
+   * We assume that the polyhedron is convex.
+
+   @param filename     The file name; if it is not absolute, it will be
+                       interpreted relative to the current working directory.
+   @param scale        An optional scale to coordinates.
 
    @throws std::exception       if the .obj file doesn't define a single object.
                                 This can happen if it is empty, if there are
@@ -196,7 +198,7 @@ class Convex final : public Shape {
                                 convenience tool for "tweaking" models. 8 orders
                                 of magnitude should be plenty without
                                 considering revisiting the model itself. */
-  explicit Convex(const std::string& absolute_filename, double scale = 1.0);
+  explicit Convex(const std::string& filename, double scale = 1.0);
 
   const std::string& filename() const { return filename_; }
   double scale() const { return scale_; }
@@ -308,12 +310,14 @@ class Mesh final : public Shape {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Mesh)
 
   /** Constructs a mesh specification from the mesh file located at the given
-   _absolute_ file path. Optionally uniformly scaled by the given scale factor.
+   file path; if the path is not absolute, it will be interpreted relative to
+   the current working directory.
+   Optionally uniformly scaled by the given scale factor.
    @throws std::exception if |scale| < 1e-8. Note that a negative scale is
    considered valid. We want to preclude scales near zero but recognise that
    scale is a convenience tool for "tweaking" models. 8 orders of magnitude
    should be plenty without considering revisiting the model itself. */
-  explicit Mesh(const std::string& absolute_filename, double scale = 1.0);
+  explicit Mesh(const std::string& filename, double scale = 1.0);
 
   const std::string& filename() const { return filename_; }
   double scale() const { return scale_; }

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/shape_specification.h"
 
+#include <filesystem>
 #include <memory>
 
 #include <gtest/gtest.h>
@@ -406,7 +407,7 @@ GTEST_TEST(BoxTest, Cube) {
 // Simple test that exercises all constructors and confirms the construction
 // parameters are reflected in the getters.
 GTEST_TEST(ShapeTest, Constructors) {
-  const std::string kFilename = "fictitious_name.obj";
+  const std::string kFilename = "/fictitious_name.obj";
 
   const Box box{1, 2, 3};
   EXPECT_EQ(box.width(), 1);
@@ -634,6 +635,26 @@ GTEST_TEST(ShapeTest, Volume) {
                               ".*only supports .obj files.*");
   DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Mesh(non_obj, 1.0)),
                               ".*only supports .obj files.*");
+}
+
+GTEST_TEST(ShapeTest, Pathname) {
+  const Mesh abspath_mesh("/absolute_path.obj");
+  EXPECT_TRUE(std::filesystem::path(abspath_mesh.filename()).is_absolute());
+  EXPECT_EQ(abspath_mesh.filename(), "/absolute_path.obj");
+
+  const Convex abspath_convex("/absolute_path.obj");
+  EXPECT_TRUE(std::filesystem::path(abspath_convex.filename()).is_absolute());
+  EXPECT_EQ(abspath_convex.filename(), "/absolute_path.obj");
+
+  const Mesh relpath_mesh("relative_path.obj");
+  EXPECT_TRUE(std::filesystem::path(relpath_mesh.filename()).is_absolute());
+  EXPECT_EQ(relpath_mesh.filename(),
+            std::filesystem::current_path() / "relative_path.obj");
+
+  const Convex relpath_convex("relative_path.obj");
+  EXPECT_TRUE(std::filesystem::path(relpath_convex.filename()).is_absolute());
+  EXPECT_EQ(relpath_convex.filename(),
+            std::filesystem::current_path() / "relative_path.obj");
 }
 
 }  // namespace

--- a/geometry/test/shape_to_string_test.cc
+++ b/geometry/test/shape_to_string_test.cc
@@ -22,9 +22,9 @@ GTEST_TEST(ShapeToStringTest, Capsule) {
 
 GTEST_TEST(ShapeToStringTest, Convex) {
   ShapeToString reifier;
-  Convex m("path/to/file", 1.5);
+  Convex m("/path/to/file", 1.5);
   m.Reify(&reifier);
-  EXPECT_EQ(reifier.string(), "Convex(s: 1.5, path: path/to/file)");
+  EXPECT_EQ(reifier.string(), "Convex(s: 1.5, path: /path/to/file)");
 }
 
 GTEST_TEST(ShapeToStringTest, Cylinder) {
@@ -50,9 +50,9 @@ GTEST_TEST(ShapeToStringTest, Halfspace) {
 
 GTEST_TEST(ShapeToStringTest, Mesh) {
   ShapeToString reifier;
-  Mesh m("path/to/file", 1.5);
+  Mesh m("/path/to/file", 1.5);
   m.Reify(&reifier);
-  EXPECT_EQ(reifier.string(), "Mesh(s: 1.5, path: path/to/file)");
+  EXPECT_EQ(reifier.string(), "Mesh(s: 1.5, path: /path/to/file)");
 }
 
 GTEST_TEST(ShapeToStringTest, MeshcatCone) {

--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -398,7 +398,7 @@ TEST_F(SceneGraphParserDetail, MakeMeshFromSdfGeometry) {
   // TODO(amcastro-tri): Be warned, the result of this test might (should)
   // change as we add support allowing to specify paths relative to the SDF file
   // location.
-  const std::string absolute_file_path = "path/to/some/mesh.obj";
+  const std::string absolute_file_path = "/path/to/some/mesh.obj";
   unique_ptr<sdf::Geometry> sdf_geometry = MakeSdfGeometryFromString(
       "<mesh>"
       "  <uri>" + absolute_file_path + "</uri>"
@@ -413,7 +413,7 @@ TEST_F(SceneGraphParserDetail, MakeMeshFromSdfGeometry) {
 
 // Verify MakeShapeFromSdfGeometry can make a convex mesh from an sdf::Geometry.
 TEST_F(SceneGraphParserDetail, MakeConvexFromSdfGeometry) {
-  const std::string absolute_file_path = "path/to/some/mesh.obj";
+  const std::string absolute_file_path = "/path/to/some/mesh.obj";
   unique_ptr<sdf::Geometry> sdf_geometry = MakeSdfGeometryFromString(
       "<mesh xmlns:drake='http://drake.mit.edu'>"
       "  <drake:declare_convex/>"

--- a/multibody/tree/test/geometry_spatial_inertia_test.cc
+++ b/multibody/tree/test/geometry_spatial_inertia_test.cc
@@ -175,7 +175,7 @@ TYPED_TEST_P(MeshTypeSpatialInertaTest, Administrivia) {
     EXPECT_NO_THROW(CalcSpatialInertia(unit_scale, kDensity));
     DRAKE_EXPECT_THROWS_MESSAGE(
         CalcSpatialInertia(nonexistant, kDensity),
-        ".*only supports .obj .* given 'nonexistant.stl'.*");
+        ".*only supports .obj .* given '.*nonexistant.stl'.*");
   }
 
   {


### PR DESCRIPTION
 * Release engineer:  This changes an incorrect parameter name, deprecating the old kwarg in pydrake.
 * The absolute path requirement was documented but never checked.
 * Much code used relative paths, to unspecified effect.
 * Remove the absolute path requirement; if path is relative, resolve it immediately wrt the cwd.
 * Deprecate the old parameter name in the bindings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18536)
<!-- Reviewable:end -->
