### PR TITLE
[workspace] Fix conex build with modern compilers

### DIFF
--- a/tools/workspace/conex/patches/debug_macros.patch
+++ b/tools/workspace/conex/patches/debug_macros.patch
@@ -1,0 +1,12 @@
+Add a missing #include statement
+
+See https://github.com/ToyotaResearchInstitute/conex/pull/3
+
+--- conex/debug_macros.h
++++ conex/debug_macros.h
+@@ -1,4 +1,5 @@
+ #pragma once
++#include <array>
+ #include <chrono>
+ #include <iomanip>
+ #include <iostream>

--- a/tools/workspace/conex/repository.bzl
+++ b/tools/workspace/conex/repository.bzl
@@ -10,5 +10,8 @@ def conex_repository(
         commit = "164a33df764d1f458756643e010f1bb62d0e1479",
         sha256 = "3f88f45276a1b474946b67e7c650fefd6d7c9dcb48f0c0a11393be3e6adc5ba7",  # noqa
         build_file = ":package.BUILD.bazel",
+        patches = [
+            ":patches/debug_macros.patch",
+        ],
         mirrors = mirrors,
     )


### PR DESCRIPTION
At the bottom of [conex/debug_macros.h](https://github.com/ToyotaResearchInstitute/conex/blob/main/conex/debug_macros.h), we see a use of `std::array` without a matching `#include` atop the file.

See also https://github.com/ToyotaResearchInstitute/conex/pull/3.

My repro on Jammy was `bazel test --config=clang --compilation_mode=dbg --config=tsan //geometry/optimization:iris_test` but I think most Jammy Clang Debug builds will hit this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18537)
<!-- Reviewable:end -->
