### PR TITLE
Suppress Valgrind false positive in mosek_solver_internal_test

### DIFF
--- a/tools/dynamic_analysis/valgrind.supp
+++ b/tools/dynamic_analysis/valgrind.supp
@@ -19,7 +19,6 @@
     MOSEK invalid memory access #3
     Memcheck:Leak
     match-leak-kinds: possible
-    match-leak-kinds: possible
     ...
     fun:moseklicense_checkout
 }

--- a/tools/dynamic_analysis/valgrind.supp
+++ b/tools/dynamic_analysis/valgrind.supp
@@ -14,6 +14,15 @@
     fun:checkout_from_flexlm
 }
 
+
+{
+    MOSEK invalid memory access #3
+    Memcheck:Leak
+    match-leak-kinds: possible
+    ...
+    fun:_ZN7testing4Test3RunEv
+}
+
 {
    MOSEK use of uninitialized CPU condition code #1
    Memcheck:Cond

--- a/tools/dynamic_analysis/valgrind.supp
+++ b/tools/dynamic_analysis/valgrind.supp
@@ -19,7 +19,20 @@
     MOSEK invalid memory access #3
     Memcheck:Leak
     match-leak-kinds: possible
-    ...
+    match-leak-kinds: possible
+    fun:calloc
+    fun:calloc
+    fun:allocate_dtv
+    fun:_dl_allocate_tls
+    fun:allocate_stack
+    fun:lc_checkout
+    fun:moseklicense_flexlmcheckout
+    fun:moseklicense_checkout
+    fun:MSKP_islicensed
+    fun:MSK_optimize
+    fun:MSK_optimizetrm
+    fun:_ZN5drake7solvers8internal38AddQuadraticCostAsLinearCost_Test_Test8TestBodyEv
+    fun:_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
     fun:_ZN7testing4Test3RunEv
 }
 

--- a/tools/dynamic_analysis/valgrind.supp
+++ b/tools/dynamic_analysis/valgrind.supp
@@ -20,20 +20,8 @@
     Memcheck:Leak
     match-leak-kinds: possible
     match-leak-kinds: possible
-    fun:calloc
-    fun:calloc
-    fun:allocate_dtv
-    fun:_dl_allocate_tls
-    fun:allocate_stack
-    fun:lc_checkout
-    fun:moseklicense_flexlmcheckout
+    ...
     fun:moseklicense_checkout
-    fun:MSKP_islicensed
-    fun:MSK_optimize
-    fun:MSK_optimizetrm
-    fun:_ZN5drake7solvers8internal38AddQuadraticCostAsLinearCost_Test_Test8TestBodyEv
-    fun:_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
-    fun:_ZN7testing4Test3RunEv
 }
 
 {


### PR DESCRIPTION
The test `solvers/mosek_solver_internal_test` is currently failing under Valgrind on Jammy.  To speed our migration to Jammy, Valgrind has been disabled for this test.

This change fixes one of the issues listed in https://github.com/RobotLocomotion/drake/issues/18091.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18539)
<!-- Reviewable:end -->
