### PR TITLE
[setup] Avoid accidentally installing OpenBLAS

### DIFF
--- a/setup/ubuntu/binary_distribution/packages-jammy.txt
+++ b/setup/ubuntu/binary_distribution/packages-jammy.txt
@@ -4,7 +4,7 @@ coinor-libipopt1v5
 default-jre
 jupyter-notebook
 libamd2
-libblas3
+libblas-dev
 libbz2-1.0
 libdouble-conversion3
 libeigen3-dev
@@ -50,6 +50,7 @@ python3
 python3-ipywidgets
 python3-lxml
 python3-matplotlib
+python3-munkres
 python3-numpy
 python3-pil
 python3-pydot

--- a/setup/ubuntu/source_distribution/packages-jammy.txt
+++ b/setup/ubuntu/source_distribution/packages-jammy.txt
@@ -6,7 +6,6 @@ default-jdk
 file
 gfortran
 git
-libblas-dev
 libbz2-dev
 libclang-12-dev
 libdouble-conversion-dev


### PR DESCRIPTION
Drake by default should stick with the Ubuntu default BLAS (Netlib). Users are invited to install a custom BLAS, but we shouldn't force it.

Through a chain of calamities in upstream Ubuntu 22.04 packaging, Drake's `binary_distribution` dependency on `python3-matplotlib` leads to the dependency chain of:
```
  python3-matplotlib =>
  python3-fonttools =>
  python3-scipy | python3-munkres
```
with
```
  python3-scipy =>
  python3-pythran =>
  libopenblas-dev | ... | libblas.so
```

This ends up installing the OpenBLAS dev package, trumping our `source_distribution` dependency preference for `libblas-dev` that comes along in the second install command.

Work around this problem by elevating Drake's BLAS dev package dependency from a source dep to a binary dep, which is able to guide `python3-pythran`'s disjunction to use Netlib.

Furthermore, now that we see SciPy in the chain (and knowing that Drake goes to great lengths not to require SciPy (see #14691)), add a binary dependency on `python3-munkres` to short-circuit that disjunction in order to reduce our footprint.

Technically munkres on its own (without the `libblas-dev` change) would be sufficient to get us to Netlib BLAS, but we'll keep the dev package in binary deps to preempt similar potholes in the future.

---

You can observe the OpenBLAS creeping in the console log of any recent Jammy Unprovisioned nightly, e.g., https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-jammy-unprovisioned-gcc-bazel-nightly-release/175/.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18540)
<!-- Reviewable:end -->
