### PR TITLE
[skylark] Set num_threads for test concurrency control

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -913,14 +913,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "openmp_test",
-    # TODO(jwnimmer-tri) Encapsulate unit test concurrency configuration into
-    # Drake's starlark macros, so that we don't have to repeat ourselves here.
-    env = {
-        "OMP_NUM_THREADS": "2",
-    },
-    tags = [
-        "cpu:2",
-    ],
+    num_threads = 2,
     deps = [
         "//common:essential",
     ],

--- a/perception/BUILD.bazel
+++ b/perception/BUILD.bazel
@@ -92,7 +92,7 @@ drake_cc_googletest(
     name = "point_cloud_test_serial",
     srcs = ["test/point_cloud_test.cc"],
     defines = ["ENABLE_PARALLEL_OPS=false"],
-    env = {"OMP_NUM_THREADS": "1"},
+    num_threads = 1,
     deps = [
         ":point_cloud",
         "//common:random",
@@ -106,8 +106,7 @@ drake_cc_googletest(
     name = "point_cloud_test_parallel",
     srcs = ["test/point_cloud_test.cc"],
     defines = ["ENABLE_PARALLEL_OPS=true"],
-    env = {"OMP_NUM_THREADS": "2"},
-    tags = ["cpu:2"],
+    num_threads = 2,
     deps = [
         ":point_cloud",
         "//common:random",

--- a/tools/skylark/README.md
+++ b/tools/skylark/README.md
@@ -8,3 +8,29 @@ Specifically, files named `*.bzl` are Skylark extensions.
 This folder is intended to house skylark code used by Drake.  It contains both
 generic functions such as `pathutils.bzl`, and widely-used but drake-specific
 functions such as the `drake_{cc,java,py,...}.bzl` language-specific helpers.
+
+
+# Common options
+
+Several of the macros in Drake (e.g., drake_cc_googletest, drake_py_unittest,
+etc.) provide for additional options beyond what is built-in to Bazel.  In
+cases where those options are shared across several different rules, we
+document the option here to avoid repetition.
+
+**num_threads**
+
+Can either be None, or else an integer.
+
+When None or 1, adds `OMP_NUM_THREADS="1"` to `env` to disable OpenMP.
+
+When N>1, adds `OMP_NUM_THREADS="N"` to `env` to establish OpenMP's
+desired level of parallelism, and also adds "cpu:N" to `tags` to reserve
+sufficient CPUs for the test.
+
+Note that setting N>1 will also be applied to any sub-processes that
+are launched by your test program.  Ask for help on Slack if you need
+this flag to work correctly in the presence of sub-processes.
+
+(Aside: Besides OMP_NUM_THREADS, the function also sets several other
+environment variables using alternative spellings of the same concept;
+the overall effect should be the same.)

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -1,6 +1,7 @@
 # -*- python -*-
 
 load("@cc//:compiler.bzl", "COMPILER_ID", "COMPILER_VERSION_MAJOR")
+load("//tools/skylark:kwargs.bzl", "incorporate_num_threads")
 
 # The CXX_FLAGS will be enabled for all C++ rules in the project
 # building with any compiler.
@@ -490,6 +491,7 @@ def _maybe_add_pruned_private_hdrs_dep(
     new_srcs, private_hdrs = _prune_private_hdrs(srcs)
     if private_hdrs:
         name = "_" + base_name + "_private_headers_cc_impl"
+        kwargs.pop("env", "")
         kwargs.pop("linkshared", "")
         kwargs.pop("linkstatic", "")
         kwargs.pop("visibility", "")
@@ -765,11 +767,11 @@ def drake_cc_test(
         size = None,
         srcs = [],
         args = [],
-        tags = [],
         deps = [],
         copts = [],
         gcc_copts = [],
         clang_copts = [],
+        num_threads = None,
         **kwargs):
     """Creates a rule to declare a C++ unit test.  Note that for almost all
     cases, drake_cc_googletest should be used, instead of this rule.
@@ -777,12 +779,16 @@ def drake_cc_test(
     By default, sets size="small" because that indicates a unit test.
     By default, sets name="test/${name}.cc" per Drake's filename convention.
     Unconditionally forces testonly=1.
+
+    @param num_threads (optional, default is 1)
+        See drake/tools/skylark/README.md for details.
     """
     if size == None:
         size = "small"
     if not srcs:
         srcs = ["test/%s.cc" % name]
     kwargs["testonly"] = 1
+    kwargs = incorporate_num_threads(kwargs, num_threads = num_threads)
     new_copts = _platform_copts(copts, gcc_copts, clang_copts, cc_test = 1)
     new_srcs, add_deps = _maybe_add_pruned_private_hdrs_dep(
         base_name = name,
@@ -796,7 +802,6 @@ def drake_cc_test(
         size = size,
         srcs = new_srcs,
         args = args,
-        tags = tags,
         deps = deps + add_deps,
         copts = new_copts,
         **kwargs

--- a/tools/skylark/kwargs.bzl
+++ b/tools/skylark/kwargs.bzl
@@ -1,0 +1,82 @@
+# -*- python -*-
+# vi: set ft=python :
+
+def amend(
+        kwargs,
+        option_name,
+        *,
+        default = None,
+        prepend = None,
+        append = None,
+        update = None):
+    """Changes one specific option_name in kwargs, using the mnemonically-named
+    mutation operation(s) given by our optional arguments as follows:
+    - `default` sets the option iff it is currently missing or set to None.
+      It's an error is the option is already set to this exact value.
+    - `prepend` adds a list to the front of a list-valued option.
+    - `append` adds a list to the back of a list-valued option.
+    - `update` updates a dict-valued option.
+    If no optional arguments are provided, then kwargs is returned unchanged.
+
+    As with most functions in the file, this takes a kwargs dict as the first
+    argument and returns a modified copy of it.
+    """
+    if default != None:
+        if kwargs.get(option_name) == default:
+            fail(("Remove the {} argument; it is already the default").format(
+                option_name,
+            ))
+        if kwargs.get(option_name) == None:
+            kwargs[option_name] = default
+    if prepend != None:
+        kwargs[option_name] = prepend + kwargs.get(option_name, [])
+    if append != None:
+        kwargs[option_name] = kwargs.get(option_name, []) + append
+    if update != None:
+        item = kwargs.get(option_name, {})
+        item.update(update)
+        kwargs[option_name] = item
+    return kwargs
+
+def _bump_cpu_tag(kwargs, *, new_size):
+    """Adds "cpu:{new_size}" tag if there are no other "cpu:*" tags specified,
+    or if the existing "cpu:*" tag has a smaller size.
+
+    As with most functions in the file, this takes a kwargs dict as the first
+    argument and returns a modified copy of it.
+    """
+    add_new_tag = True
+    tags = list(kwargs.get("tags", []))
+    for tag in tags:
+        if tag.startswith("cpu:"):
+            existing_size = int(tag[4:])
+            if existing_size < new_size:
+                tags.remove(tag)
+            else:
+                add_new_tag = False
+            break
+    if add_new_tag:
+        tags += ["cpu:{}".format(new_size)]
+    kwargs["tags"] = tags
+    return kwargs
+
+def incorporate_num_threads(kwargs, *, num_threads):
+    """Incorporates multi-threading directives (e.g., for OpenMP) into
+    well-known Bazel args (i.e., tags=, env=).
+
+    As with most functions in the file, this takes a kwargs dict as the first
+    argument and returns a modified copy of it.
+    """
+    num_threads = num_threads or 1
+    if num_threads < 1:
+        fail("The num_threads must be strictly positive")
+    if num_threads > 1:
+        kwargs = _bump_cpu_tag(kwargs, new_size = num_threads)
+        kwargs = amend(kwargs, "tags", append = ["omp"])
+    kwargs = amend(kwargs, "env", update = {
+        "OMP_NUM_THREADS": str(num_threads),
+        "OPENBLAS_NUM_THREADS": str(num_threads),
+        "NUMEXPR_NUM_THREADS": str(num_threads),
+        "MKL_NUM_THREADS": str(num_threads),
+    })
+    return kwargs


### PR DESCRIPTION
Tests that do not opt-in to concurrency will be limited to 1 thread.

---

Reviewable r1 contains code copied from Anzu; r2 and onward contain Drake's integration changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18546)
<!-- Reviewable:end -->
