### PR TITLE
Add VTK textured capsule source

### DIFF
--- a/geometry/render_gltf_client/test/example_scene.sdf
+++ b/geometry/render_gltf_client/test/example_scene.sdf
@@ -60,10 +60,8 @@
             <length>0.1</length>
           </capsule>
         </geometry>
-        <!-- TODO(zachfang): capsules don't have the texture coordinate defined.
-             Revert back to a texture map once Drake 18296 is resolved. -->
         <material>
-          <diffuse>1.0 1.0 0.25 1.0</diffuse>
+          <drake:diffuse_map>4_color_texture.png</drake:diffuse_map>
         </material>
       </visual>
     </link>

--- a/geometry/render_gltf_client/test/test_color_scene.gltf
+++ b/geometry/render_gltf_client/test/test_color_scene.gltf
@@ -1,5 +1,5 @@
 {
-   "accessors" : 
+   "accessors" :
    [
       {
          "bufferView" : 0,
@@ -149,48 +149,40 @@
          "bufferView" : 21,
          "byteOffset" : 0,
          "componentType" : 5126,
-         "count" : 4804,
-         "max" : [ 0.049974311143159866, 0.05000000074505806, 0.099948637187480927 ],
-         "min" : [ -0.049974311143159866, -0.05000000074505806, -0.099948637187480927 ],
+         "count" : 2652,
+         "max" : [ 0.05000000074505806, 0.049901336431503296, 0.10000000149011612 ],
+         "min" : [ -0.05000000074505806, -0.049901336431503296, -0.10000000149011612 ],
          "type" : "VEC3"
       },
       {
          "bufferView" : 22,
          "byteOffset" : 0,
-         "componentType" : 5125,
-         "count" : 28812,
-         "type" : "SCALAR"
+         "componentType" : 5126,
+         "count" : 2652,
+         "normalized" : false,
+         "type" : "VEC2"
       },
       {
          "bufferView" : 23,
          "byteOffset" : 0,
-         "componentType" : 5126,
-         "count" : 4804,
-         "max" : [ 0.049974311143159866, 0.05000000074505806, 0.099948637187480927 ],
-         "min" : [ -0.049974311143159866, -0.05000000074505806, -0.099948637187480927 ],
-         "type" : "VEC3"
-      },
-      {
-         "bufferView" : 24,
-         "byteOffset" : 0,
          "componentType" : 5125,
-         "count" : 28812,
+         "count" : 15300,
          "type" : "SCALAR"
       },
       {
          "bufferView" : 25,
          "byteOffset" : 0,
          "componentType" : 5126,
-         "count" : 24,
-         "max" : [ 0.050000000000000003, 0.037499999999999999, 0.025000000000000001 ],
-         "min" : [ -0.050000000000000003, -0.037499999999999999, -0.025000000000000001 ],
+         "count" : 2652,
+         "max" : [ 0.05000000074505806, 0.049901336431503296, 0.10000000149011612 ],
+         "min" : [ -0.05000000074505806, -0.049901336431503296, -0.10000000149011612 ],
          "type" : "VEC3"
       },
       {
          "bufferView" : 26,
          "byteOffset" : 0,
          "componentType" : 5126,
-         "count" : 24,
+         "count" : 2652,
          "normalized" : false,
          "type" : "VEC2"
       },
@@ -198,11 +190,11 @@
          "bufferView" : 27,
          "byteOffset" : 0,
          "componentType" : 5125,
-         "count" : 36,
+         "count" : 15300,
          "type" : "SCALAR"
       },
       {
-         "bufferView" : 29,
+         "bufferView" : 28,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 24,
@@ -211,7 +203,7 @@
          "type" : "VEC3"
       },
       {
-         "bufferView" : 30,
+         "bufferView" : 29,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 24,
@@ -219,7 +211,7 @@
          "type" : "VEC2"
       },
       {
-         "bufferView" : 31,
+         "bufferView" : 30,
          "byteOffset" : 0,
          "componentType" : 5125,
          "count" : 36,
@@ -229,16 +221,16 @@
          "bufferView" : 32,
          "byteOffset" : 0,
          "componentType" : 5126,
-         "count" : 49152,
-         "max" : [ 0.033259999006986618, 0.0098120002076029778, 0.18814800679683685 ],
-         "min" : [ -0.063937999308109283, -0.056809000670909882, -0.0031530000269412994 ],
+         "count" : 24,
+         "max" : [ 0.050000000000000003, 0.037499999999999999, 0.025000000000000001 ],
+         "min" : [ -0.050000000000000003, -0.037499999999999999, -0.025000000000000001 ],
          "type" : "VEC3"
       },
       {
          "bufferView" : 33,
          "byteOffset" : 0,
          "componentType" : 5126,
-         "count" : 49152,
+         "count" : 24,
          "normalized" : false,
          "type" : "VEC2"
       },
@@ -246,16 +238,40 @@
          "bufferView" : 34,
          "byteOffset" : 0,
          "componentType" : 5125,
+         "count" : 36,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 35,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 49152,
+         "max" : [ 0.033259999006986618, 0.0098120002076029778, 0.18814800679683685 ],
+         "min" : [ -0.063937999308109283, -0.056809000670909882, -0.0031530000269412994 ],
+         "type" : "VEC3"
+      },
+      {
+         "bufferView" : 36,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 49152,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 37,
+         "byteOffset" : 0,
+         "componentType" : 5125,
          "count" : 49152,
          "type" : "SCALAR"
       }
    ],
-   "asset" : 
+   "asset" :
    {
       "generator" : "VTK",
       "version" : "2.0"
    },
-   "bufferViews" : 
+   "bufferViews" :
    [
       {
          "buffer" : 0,
@@ -364,84 +380,99 @@
       },
       {
          "buffer" : 21,
-         "byteLength" : 57648,
+         "byteLength" : 31824,
          "byteOffset" : 0
       },
       {
          "buffer" : 22,
-         "byteLength" : 115248,
+         "byteLength" : 21216,
          "byteOffset" : 0
       },
       {
          "buffer" : 23,
-         "byteLength" : 57648,
+         "byteLength" : 61200,
          "byteOffset" : 0
       },
       {
          "buffer" : 24,
-         "byteLength" : 115248,
-         "byteOffset" : 0
-      },
-      {
-         "buffer" : 25,
-         "byteLength" : 288,
-         "byteOffset" : 0
-      },
-      {
-         "buffer" : 26,
-         "byteLength" : 192,
-         "byteOffset" : 0
-      },
-      {
-         "buffer" : 27,
-         "byteLength" : 144,
-         "byteOffset" : 0
-      },
-      {
-         "buffer" : 28,
          "byteLength" : 1123,
          "byteOffset" : 0
       },
       {
-         "buffer" : 29,
+         "buffer" : 25,
+         "byteLength" : 31824,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 26,
+         "byteLength" : 21216,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 27,
+         "byteLength" : 61200,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 28,
          "byteLength" : 288,
          "byteOffset" : 0
       },
       {
-         "buffer" : 30,
+         "buffer" : 29,
          "byteLength" : 192,
          "byteOffset" : 0
       },
       {
-         "buffer" : 31,
+         "buffer" : 30,
          "byteLength" : 144,
          "byteOffset" : 0
       },
       {
+         "buffer" : 31,
+         "byteLength" : 1123,
+         "byteOffset" : 0
+      },
+      {
          "buffer" : 32,
-         "byteLength" : 589824,
+         "byteLength" : 288,
          "byteOffset" : 0
       },
       {
          "buffer" : 33,
-         "byteLength" : 393216,
+         "byteLength" : 192,
          "byteOffset" : 0
       },
       {
          "buffer" : 34,
-         "byteLength" : 196608,
+         "byteLength" : 144,
          "byteOffset" : 0
       },
       {
          "buffer" : 35,
+         "byteLength" : 589824,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 36,
+         "byteLength" : 393216,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 37,
+         "byteLength" : 196608,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 38,
          "byteLength" : 9081569,
          "byteOffset" : 0
       }
    ],
-   "cameras" : 
+   "cameras" :
    [
       {
-         "perspective" : 
+         "perspective" :
          {
             "aspectRatio" : 1.3333333333333333,
             "yfov" : 0.78539816339744828,
@@ -451,7 +482,7 @@
          "type" : "perspective"
       }
    ],
-   "images" : 
+   "images" :
    [
       {
          "bufferView" : 3,
@@ -466,21 +497,25 @@
          "mimeType" : "image/png"
       },
       {
-         "bufferView" : 28,
+         "bufferView" : 24,
          "mimeType" : "image/png"
       },
       {
-         "bufferView" : 35,
+         "bufferView" : 31,
+         "mimeType" : "image/png"
+      },
+      {
+         "bufferView" : 38,
          "mimeType" : "image/png"
       }
    ],
-   "materials" : 
+   "materials" :
    [
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
-            "baseColorTexture" : 
+            "baseColorTexture" :
             {
                "index" : 0,
                "texCoord" : 0
@@ -490,7 +525,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 0.25, 0.25, 1, 1 ],
             "metallicFactor" : 0,
@@ -498,10 +533,10 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
-            "baseColorTexture" : 
+            "baseColorTexture" :
             {
                "index" : 1,
                "texCoord" : 0
@@ -511,7 +546,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 0.25, 1, 1, 1 ],
             "metallicFactor" : 0,
@@ -519,10 +554,10 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
-            "baseColorTexture" : 
+            "baseColorTexture" :
             {
                "index" : 2,
                "texCoord" : 0
@@ -532,7 +567,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 0.25, 1, 0.25, 1 ],
             "metallicFactor" : 0,
@@ -540,26 +575,10 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
-         {
-            "baseColorFactor" : [ 1, 1, 0.25, 1 ],
-            "metallicFactor" : 0,
-            "roughnessFactor" : 1
-         }
-      },
-      {
-         "pbrMetallicRoughness" : 
-         {
-            "baseColorFactor" : [ 1, 1, 0.25, 1 ],
-            "metallicFactor" : 0,
-            "roughnessFactor" : 1
-         }
-      },
-      {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
-            "baseColorTexture" : 
+            "baseColorTexture" :
             {
                "index" : 3,
                "texCoord" : 0
@@ -569,18 +588,18 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
-            "baseColorFactor" : [ 1, 0.25, 0.25, 1 ],
+            "baseColorFactor" : [ 1, 1, 0.25, 1 ],
             "metallicFactor" : 0,
             "roughnessFactor" : 1
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
-            "baseColorTexture" : 
+            "baseColorTexture" :
             {
                "index" : 4,
                "texCoord" : 0
@@ -588,16 +607,37 @@
             "metallicFactor" : 0,
             "roughnessFactor" : 1
          }
+      },
+      {
+         "pbrMetallicRoughness" :
+         {
+            "baseColorFactor" : [ 1, 0.25, 0.25, 1 ],
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
+      },
+      {
+         "pbrMetallicRoughness" :
+         {
+            "baseColorFactor" : [ 1, 1, 1, 1 ],
+            "baseColorTexture" :
+            {
+               "index" : 5,
+               "texCoord" : 0
+            },
+            "metallicFactor" : 0,
+            "roughnessFactor" : 1
+         }
       }
    ],
-   "meshes" : 
+   "meshes" :
    [
       {
          "name" : "mesh0",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
                   "POSITION" : 0,
                   "TEXCOORD_0" : 1
@@ -610,10 +650,10 @@
       },
       {
          "name" : "mesh1",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
                   "POSITION" : 3,
                   "TEXCOORD_0" : 4
@@ -626,10 +666,10 @@
       },
       {
          "name" : "mesh2",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
                   "POSITION" : 6,
                   "TEXCOORD_0" : 7
@@ -642,10 +682,10 @@
       },
       {
          "name" : "mesh3",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
                   "POSITION" : 9,
                   "TEXCOORD_0" : 10
@@ -658,10 +698,10 @@
       },
       {
          "name" : "mesh4",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
                   "POSITION" : 12,
                   "TEXCOORD_0" : 13
@@ -674,10 +714,10 @@
       },
       {
          "name" : "mesh5",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
                   "POSITION" : 15,
                   "TEXCOORD_0" : 16
@@ -690,14 +730,15 @@
       },
       {
          "name" : "mesh6",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
-                  "POSITION" : 18
+                  "POSITION" : 18,
+                  "TEXCOORD_0" : 19
                },
-               "indices" : 19,
+               "indices" : 20,
                "material" : 6,
                "mode" : 4
             }
@@ -705,14 +746,15 @@
       },
       {
          "name" : "mesh7",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
-                  "POSITION" : 20
+                  "POSITION" : 21,
+                  "TEXCOORD_0" : 22
                },
-               "indices" : 21,
+               "indices" : 23,
                "material" : 7,
                "mode" : 4
             }
@@ -720,15 +762,15 @@
       },
       {
          "name" : "mesh8",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
-                  "POSITION" : 22,
-                  "TEXCOORD_0" : 23
+                  "POSITION" : 24,
+                  "TEXCOORD_0" : 25
                },
-               "indices" : 24,
+               "indices" : 26,
                "material" : 8,
                "mode" : 4
             }
@@ -736,15 +778,15 @@
       },
       {
          "name" : "mesh9",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
-                  "POSITION" : 25,
-                  "TEXCOORD_0" : 26
+                  "POSITION" : 27,
+                  "TEXCOORD_0" : 28
                },
-               "indices" : 27,
+               "indices" : 29,
                "material" : 9,
                "mode" : 4
             }
@@ -752,22 +794,22 @@
       },
       {
          "name" : "mesh10",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
-                  "POSITION" : 28,
-                  "TEXCOORD_0" : 29
+                  "POSITION" : 30,
+                  "TEXCOORD_0" : 31
                },
-               "indices" : 30,
+               "indices" : 32,
                "material" : 10,
                "mode" : 4
             }
          ]
       }
    ],
-   "nodes" : 
+   "nodes" :
    [
       {
          "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -0.20000000000000001, 0.25, 0, 1 ],
@@ -785,7 +827,7 @@
          "name" : "mesh2"
       },
       {
-         "matrix" : 
+         "matrix" :
          [
             1,
             0,
@@ -838,7 +880,7 @@
          "name" : "mesh9"
       },
       {
-         "matrix" : 
+         "matrix" :
          [
             0.38941834230865052,
             -0.92106099400288499,
@@ -862,7 +904,7 @@
       },
       {
          "camera" : 0,
-         "matrix" : 
+         "matrix" :
          [
             0.00079632671073322247,
             0.99999968293183472,
@@ -888,8 +930,14 @@
          "name" : "Renderer Node"
       }
    ],
-   "samplers" : 
+   "samplers" :
    [
+      {
+         "magFilter" : 9729,
+         "minFilter" : 9729,
+         "wrapS" : 33071,
+         "wrapT" : 33071
+      },
       {
          "magFilter" : 9729,
          "minFilter" : 9729,
@@ -922,14 +970,14 @@
       }
    ],
    "scene" : 0,
-   "scenes" : 
+   "scenes" :
    [
       {
          "name" : "Layer 0",
          "nodes" : [ 12 ]
       }
    ],
-   "textures" : 
+   "textures" :
    [
       {
          "sampler" : 0,
@@ -950,6 +998,10 @@
       {
          "sampler" : 4,
          "source" : 4
+      },
+      {
+         "sampler" : 5,
+         "source" : 5
       }
    ]
 }

--- a/geometry/render_gltf_client/test/test_depth_scene.gltf
+++ b/geometry/render_gltf_client/test/test_depth_scene.gltf
@@ -1,5 +1,5 @@
 {
-   "accessors" : 
+   "accessors" :
    [
       {
          "bufferView" : 0,
@@ -149,69 +149,85 @@
          "bufferView" : 18,
          "byteOffset" : 0,
          "componentType" : 5126,
-         "count" : 4804,
-         "max" : [ 0.049974311143159866, 0.05000000074505806, 0.099948637187480927 ],
-         "min" : [ -0.049974311143159866, -0.05000000074505806, -0.099948637187480927 ],
+         "count" : 2652,
+         "max" : [ 0.05000000074505806, 0.049901336431503296, 0.10000000149011612 ],
+         "min" : [ -0.05000000074505806, -0.049901336431503296, -0.10000000149011612 ],
          "type" : "VEC3"
       },
       {
          "bufferView" : 19,
          "byteOffset" : 0,
-         "componentType" : 5125,
-         "count" : 28812,
-         "type" : "SCALAR"
+         "componentType" : 5126,
+         "count" : 2652,
+         "normalized" : false,
+         "type" : "VEC2"
       },
       {
          "bufferView" : 20,
          "byteOffset" : 0,
-         "componentType" : 5126,
-         "count" : 4804,
-         "max" : [ 0.049974311143159866, 0.05000000074505806, 0.099948637187480927 ],
-         "min" : [ -0.049974311143159866, -0.05000000074505806, -0.099948637187480927 ],
-         "type" : "VEC3"
+         "componentType" : 5125,
+         "count" : 15300,
+         "type" : "SCALAR"
       },
       {
          "bufferView" : 21,
          "byteOffset" : 0,
-         "componentType" : 5125,
-         "count" : 28812,
-         "type" : "SCALAR"
+         "componentType" : 5126,
+         "count" : 2652,
+         "max" : [ 0.05000000074505806, 0.049901336431503296, 0.10000000149011612 ],
+         "min" : [ -0.05000000074505806, -0.049901336431503296, -0.10000000149011612 ],
+         "type" : "VEC3"
       },
       {
          "bufferView" : 22,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 2652,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 23,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 15300,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 24,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 24,
          "max" : [ 0.050000000000000003, 0.037499999999999999, 0.025000000000000001 ],
          "min" : [ -0.050000000000000003, -0.037499999999999999, -0.025000000000000001 ],
          "type" : "VEC3"
-      },
-      {
-         "bufferView" : 23,
-         "byteOffset" : 0,
-         "componentType" : 5126,
-         "count" : 24,
-         "normalized" : false,
-         "type" : "VEC2"
-      },
-      {
-         "bufferView" : 24,
-         "byteOffset" : 0,
-         "componentType" : 5125,
-         "count" : 36,
-         "type" : "SCALAR"
       },
       {
          "bufferView" : 25,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 24,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 26,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 36,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 27,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 24,
          "max" : [ 0.050000000000000003, 0.037499999999999999, 0.025000000000000001 ],
          "min" : [ -0.050000000000000003, -0.037499999999999999, -0.025000000000000001 ],
          "type" : "VEC3"
       },
       {
-         "bufferView" : 26,
+         "bufferView" : 28,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 24,
@@ -219,14 +235,14 @@
          "type" : "VEC2"
       },
       {
-         "bufferView" : 27,
+         "bufferView" : 29,
          "byteOffset" : 0,
          "componentType" : 5125,
          "count" : 36,
          "type" : "SCALAR"
       },
       {
-         "bufferView" : 28,
+         "bufferView" : 30,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 49152,
@@ -235,7 +251,7 @@
          "type" : "VEC3"
       },
       {
-         "bufferView" : 29,
+         "bufferView" : 31,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 49152,
@@ -243,19 +259,19 @@
          "type" : "VEC2"
       },
       {
-         "bufferView" : 30,
+         "bufferView" : 32,
          "byteOffset" : 0,
          "componentType" : 5125,
          "count" : 49152,
          "type" : "SCALAR"
       }
    ],
-   "asset" : 
+   "asset" :
    {
       "generator" : "VTK",
       "version" : "2.0"
    },
-   "bufferViews" : 
+   "bufferViews" :
    [
       {
          "buffer" : 0,
@@ -349,74 +365,84 @@
       },
       {
          "buffer" : 18,
-         "byteLength" : 57648,
+         "byteLength" : 31824,
          "byteOffset" : 0
       },
       {
          "buffer" : 19,
-         "byteLength" : 115248,
+         "byteLength" : 21216,
          "byteOffset" : 0
       },
       {
          "buffer" : 20,
-         "byteLength" : 57648,
+         "byteLength" : 61200,
          "byteOffset" : 0
       },
       {
          "buffer" : 21,
-         "byteLength" : 115248,
+         "byteLength" : 31824,
          "byteOffset" : 0
       },
       {
          "buffer" : 22,
-         "byteLength" : 288,
+         "byteLength" : 21216,
          "byteOffset" : 0
       },
       {
          "buffer" : 23,
-         "byteLength" : 192,
+         "byteLength" : 61200,
          "byteOffset" : 0
       },
       {
          "buffer" : 24,
-         "byteLength" : 144,
-         "byteOffset" : 0
-      },
-      {
-         "buffer" : 25,
          "byteLength" : 288,
          "byteOffset" : 0
       },
       {
-         "buffer" : 26,
+         "buffer" : 25,
          "byteLength" : 192,
          "byteOffset" : 0
       },
       {
-         "buffer" : 27,
+         "buffer" : 26,
          "byteLength" : 144,
          "byteOffset" : 0
       },
       {
+         "buffer" : 27,
+         "byteLength" : 288,
+         "byteOffset" : 0
+      },
+      {
          "buffer" : 28,
-         "byteLength" : 589824,
+         "byteLength" : 192,
          "byteOffset" : 0
       },
       {
          "buffer" : 29,
-         "byteLength" : 393216,
+         "byteLength" : 144,
          "byteOffset" : 0
       },
       {
          "buffer" : 30,
+         "byteLength" : 589824,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 31,
+         "byteLength" : 393216,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 32,
          "byteLength" : 196608,
          "byteOffset" : 0
       }
    ],
-   "cameras" : 
+   "cameras" :
    [
       {
-         "perspective" : 
+         "perspective" :
          {
             "aspectRatio" : 1.3333333333333333,
             "yfov" : 0.78539816339744828,
@@ -426,10 +452,10 @@
          "type" : "perspective"
       }
    ],
-   "materials" : 
+   "materials" :
    [
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
             "metallicFactor" : 0,
@@ -437,7 +463,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
             "metallicFactor" : 0,
@@ -445,7 +471,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
             "metallicFactor" : 0,
@@ -453,7 +479,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
             "metallicFactor" : 0,
@@ -461,7 +487,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
             "metallicFactor" : 0,
@@ -469,7 +495,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
             "metallicFactor" : 0,
@@ -477,7 +503,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
             "metallicFactor" : 0,
@@ -485,7 +511,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
             "metallicFactor" : 0,
@@ -493,7 +519,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
             "metallicFactor" : 0,
@@ -501,7 +527,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
             "metallicFactor" : 0,
@@ -509,7 +535,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 1, 1, 1, 1 ],
             "metallicFactor" : 0,
@@ -517,14 +543,14 @@
          }
       }
    ],
-   "meshes" : 
+   "meshes" :
    [
       {
          "name" : "mesh0",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
                   "POSITION" : 0,
                   "TEXCOORD_0" : 1
@@ -537,10 +563,10 @@
       },
       {
          "name" : "mesh1",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
                   "POSITION" : 3,
                   "TEXCOORD_0" : 4
@@ -553,10 +579,10 @@
       },
       {
          "name" : "mesh2",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
                   "POSITION" : 6,
                   "TEXCOORD_0" : 7
@@ -569,10 +595,10 @@
       },
       {
          "name" : "mesh3",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
                   "POSITION" : 9,
                   "TEXCOORD_0" : 10
@@ -585,10 +611,10 @@
       },
       {
          "name" : "mesh4",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
                   "POSITION" : 12,
                   "TEXCOORD_0" : 13
@@ -601,10 +627,10 @@
       },
       {
          "name" : "mesh5",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
                   "POSITION" : 15,
                   "TEXCOORD_0" : 16
@@ -617,14 +643,15 @@
       },
       {
          "name" : "mesh6",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
-                  "POSITION" : 18
+                  "POSITION" : 18,
+                  "TEXCOORD_0" : 19
                },
-               "indices" : 19,
+               "indices" : 20,
                "material" : 6,
                "mode" : 4
             }
@@ -632,14 +659,15 @@
       },
       {
          "name" : "mesh7",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
-                  "POSITION" : 20
+                  "POSITION" : 21,
+                  "TEXCOORD_0" : 22
                },
-               "indices" : 21,
+               "indices" : 23,
                "material" : 7,
                "mode" : 4
             }
@@ -647,15 +675,15 @@
       },
       {
          "name" : "mesh8",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
-                  "POSITION" : 22,
-                  "TEXCOORD_0" : 23
+                  "POSITION" : 24,
+                  "TEXCOORD_0" : 25
                },
-               "indices" : 24,
+               "indices" : 26,
                "material" : 8,
                "mode" : 4
             }
@@ -663,15 +691,15 @@
       },
       {
          "name" : "mesh9",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
-                  "POSITION" : 25,
-                  "TEXCOORD_0" : 26
+                  "POSITION" : 27,
+                  "TEXCOORD_0" : 28
                },
-               "indices" : 27,
+               "indices" : 29,
                "material" : 9,
                "mode" : 4
             }
@@ -679,22 +707,22 @@
       },
       {
          "name" : "mesh10",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
-                  "POSITION" : 28,
-                  "TEXCOORD_0" : 29
+                  "POSITION" : 30,
+                  "TEXCOORD_0" : 31
                },
-               "indices" : 30,
+               "indices" : 32,
                "material" : 10,
                "mode" : 4
             }
          ]
       }
    ],
-   "nodes" : 
+   "nodes" :
    [
       {
          "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -0.20000000000000001, 0.25, 0, 1 ],
@@ -712,7 +740,7 @@
          "name" : "mesh2"
       },
       {
-         "matrix" : 
+         "matrix" :
          [
             1,
             0,
@@ -765,7 +793,7 @@
          "name" : "mesh9"
       },
       {
-         "matrix" : 
+         "matrix" :
          [
             0.38941834230865052,
             -0.92106099400288499,
@@ -789,7 +817,7 @@
       },
       {
          "camera" : 0,
-         "matrix" : 
+         "matrix" :
          [
             0.00079632671073322247,
             0.99999968293183472,
@@ -816,7 +844,7 @@
       }
    ],
    "scene" : 0,
-   "scenes" : 
+   "scenes" :
    [
       {
          "name" : "Layer 0",

--- a/geometry/render_gltf_client/test/test_label_scene.gltf
+++ b/geometry/render_gltf_client/test/test_label_scene.gltf
@@ -1,5 +1,5 @@
 {
-   "accessors" : 
+   "accessors" :
    [
       {
          "bufferView" : 0,
@@ -149,69 +149,85 @@
          "bufferView" : 18,
          "byteOffset" : 0,
          "componentType" : 5126,
-         "count" : 4804,
-         "max" : [ 0.049974311143159866, 0.05000000074505806, 0.099948637187480927 ],
-         "min" : [ -0.049974311143159866, -0.05000000074505806, -0.099948637187480927 ],
+         "count" : 2652,
+         "max" : [ 0.05000000074505806, 0.049901336431503296, 0.10000000149011612 ],
+         "min" : [ -0.05000000074505806, -0.049901336431503296, -0.10000000149011612 ],
          "type" : "VEC3"
       },
       {
          "bufferView" : 19,
          "byteOffset" : 0,
-         "componentType" : 5125,
-         "count" : 28812,
-         "type" : "SCALAR"
+         "componentType" : 5126,
+         "count" : 2652,
+         "normalized" : false,
+         "type" : "VEC2"
       },
       {
          "bufferView" : 20,
          "byteOffset" : 0,
-         "componentType" : 5126,
-         "count" : 4804,
-         "max" : [ 0.049974311143159866, 0.05000000074505806, 0.099948637187480927 ],
-         "min" : [ -0.049974311143159866, -0.05000000074505806, -0.099948637187480927 ],
-         "type" : "VEC3"
+         "componentType" : 5125,
+         "count" : 15300,
+         "type" : "SCALAR"
       },
       {
          "bufferView" : 21,
          "byteOffset" : 0,
-         "componentType" : 5125,
-         "count" : 28812,
-         "type" : "SCALAR"
+         "componentType" : 5126,
+         "count" : 2652,
+         "max" : [ 0.05000000074505806, 0.049901336431503296, 0.10000000149011612 ],
+         "min" : [ -0.05000000074505806, -0.049901336431503296, -0.10000000149011612 ],
+         "type" : "VEC3"
       },
       {
          "bufferView" : 22,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 2652,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 23,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 15300,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 24,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 24,
          "max" : [ 0.050000000000000003, 0.037499999999999999, 0.025000000000000001 ],
          "min" : [ -0.050000000000000003, -0.037499999999999999, -0.025000000000000001 ],
          "type" : "VEC3"
-      },
-      {
-         "bufferView" : 23,
-         "byteOffset" : 0,
-         "componentType" : 5126,
-         "count" : 24,
-         "normalized" : false,
-         "type" : "VEC2"
-      },
-      {
-         "bufferView" : 24,
-         "byteOffset" : 0,
-         "componentType" : 5125,
-         "count" : 36,
-         "type" : "SCALAR"
       },
       {
          "bufferView" : 25,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 24,
+         "normalized" : false,
+         "type" : "VEC2"
+      },
+      {
+         "bufferView" : 26,
+         "byteOffset" : 0,
+         "componentType" : 5125,
+         "count" : 36,
+         "type" : "SCALAR"
+      },
+      {
+         "bufferView" : 27,
+         "byteOffset" : 0,
+         "componentType" : 5126,
+         "count" : 24,
          "max" : [ 0.050000000000000003, 0.037499999999999999, 0.025000000000000001 ],
          "min" : [ -0.050000000000000003, -0.037499999999999999, -0.025000000000000001 ],
          "type" : "VEC3"
       },
       {
-         "bufferView" : 26,
+         "bufferView" : 28,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 24,
@@ -219,14 +235,14 @@
          "type" : "VEC2"
       },
       {
-         "bufferView" : 27,
+         "bufferView" : 29,
          "byteOffset" : 0,
          "componentType" : 5125,
          "count" : 36,
          "type" : "SCALAR"
       },
       {
-         "bufferView" : 28,
+         "bufferView" : 30,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 49152,
@@ -235,7 +251,7 @@
          "type" : "VEC3"
       },
       {
-         "bufferView" : 29,
+         "bufferView" : 31,
          "byteOffset" : 0,
          "componentType" : 5126,
          "count" : 49152,
@@ -243,19 +259,19 @@
          "type" : "VEC2"
       },
       {
-         "bufferView" : 30,
+         "bufferView" : 32,
          "byteOffset" : 0,
          "componentType" : 5125,
          "count" : 49152,
          "type" : "SCALAR"
       }
    ],
-   "asset" : 
+   "asset" :
    {
       "generator" : "VTK",
       "version" : "2.0"
    },
-   "bufferViews" : 
+   "bufferViews" :
    [
       {
          "buffer" : 0,
@@ -349,74 +365,84 @@
       },
       {
          "buffer" : 18,
-         "byteLength" : 57648,
+         "byteLength" : 31824,
          "byteOffset" : 0
       },
       {
          "buffer" : 19,
-         "byteLength" : 115248,
+         "byteLength" : 21216,
          "byteOffset" : 0
       },
       {
          "buffer" : 20,
-         "byteLength" : 57648,
+         "byteLength" : 61200,
          "byteOffset" : 0
       },
       {
          "buffer" : 21,
-         "byteLength" : 115248,
+         "byteLength" : 31824,
          "byteOffset" : 0
       },
       {
          "buffer" : 22,
-         "byteLength" : 288,
+         "byteLength" : 21216,
          "byteOffset" : 0
       },
       {
          "buffer" : 23,
-         "byteLength" : 192,
+         "byteLength" : 61200,
          "byteOffset" : 0
       },
       {
          "buffer" : 24,
-         "byteLength" : 144,
-         "byteOffset" : 0
-      },
-      {
-         "buffer" : 25,
          "byteLength" : 288,
          "byteOffset" : 0
       },
       {
-         "buffer" : 26,
+         "buffer" : 25,
          "byteLength" : 192,
          "byteOffset" : 0
       },
       {
-         "buffer" : 27,
+         "buffer" : 26,
          "byteLength" : 144,
          "byteOffset" : 0
       },
       {
+         "buffer" : 27,
+         "byteLength" : 288,
+         "byteOffset" : 0
+      },
+      {
          "buffer" : 28,
-         "byteLength" : 589824,
+         "byteLength" : 192,
          "byteOffset" : 0
       },
       {
          "buffer" : 29,
-         "byteLength" : 393216,
+         "byteLength" : 144,
          "byteOffset" : 0
       },
       {
          "buffer" : 30,
+         "byteLength" : 589824,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 31,
+         "byteLength" : 393216,
+         "byteOffset" : 0
+      },
+      {
+         "buffer" : 32,
          "byteLength" : 196608,
          "byteOffset" : 0
       }
    ],
-   "cameras" : 
+   "cameras" :
    [
       {
-         "perspective" : 
+         "perspective" :
          {
             "aspectRatio" : 1.3333333333333333,
             "yfov" : 0.78539816339744828,
@@ -426,10 +452,10 @@
          "type" : "perspective"
       }
    ],
-   "materials" : 
+   "materials" :
    [
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 0.043137254901960784, 0, 0, 1 ],
             "metallicFactor" : 0,
@@ -437,7 +463,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 0.039215686274509803, 0, 0, 1 ],
             "metallicFactor" : 0,
@@ -445,7 +471,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 0.035294117647058823, 0, 0, 1 ],
             "metallicFactor" : 0,
@@ -453,7 +479,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 0.031372549019607843, 0, 0, 1 ],
             "metallicFactor" : 0,
@@ -461,7 +487,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 0.027450980392156862, 0, 0, 1 ],
             "metallicFactor" : 0,
@@ -469,7 +495,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 0.023529411764705882, 0, 0, 1 ],
             "metallicFactor" : 0,
@@ -477,7 +503,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 0.019607843137254902, 0, 0, 1 ],
             "metallicFactor" : 0,
@@ -485,7 +511,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 0.015686274509803921, 0, 0, 1 ],
             "metallicFactor" : 0,
@@ -493,7 +519,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 0.011764705882352941, 0, 0, 1 ],
             "metallicFactor" : 0,
@@ -501,7 +527,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 0.0078431372549019607, 0, 0, 1 ],
             "metallicFactor" : 0,
@@ -509,7 +535,7 @@
          }
       },
       {
-         "pbrMetallicRoughness" : 
+         "pbrMetallicRoughness" :
          {
             "baseColorFactor" : [ 0.0039215686274509803, 0, 0, 1 ],
             "metallicFactor" : 0,
@@ -517,14 +543,14 @@
          }
       }
    ],
-   "meshes" : 
+   "meshes" :
    [
       {
          "name" : "mesh0",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
                   "POSITION" : 0,
                   "TEXCOORD_0" : 1
@@ -537,10 +563,10 @@
       },
       {
          "name" : "mesh1",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
                   "POSITION" : 3,
                   "TEXCOORD_0" : 4
@@ -553,10 +579,10 @@
       },
       {
          "name" : "mesh2",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
                   "POSITION" : 6,
                   "TEXCOORD_0" : 7
@@ -569,10 +595,10 @@
       },
       {
          "name" : "mesh3",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
                   "POSITION" : 9,
                   "TEXCOORD_0" : 10
@@ -585,10 +611,10 @@
       },
       {
          "name" : "mesh4",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
                   "POSITION" : 12,
                   "TEXCOORD_0" : 13
@@ -601,10 +627,10 @@
       },
       {
          "name" : "mesh5",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
                   "POSITION" : 15,
                   "TEXCOORD_0" : 16
@@ -617,14 +643,15 @@
       },
       {
          "name" : "mesh6",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
-                  "POSITION" : 18
+                  "POSITION" : 18,
+                  "TEXCOORD_0" : 19
                },
-               "indices" : 19,
+               "indices" : 20,
                "material" : 6,
                "mode" : 4
             }
@@ -632,14 +659,15 @@
       },
       {
          "name" : "mesh7",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
-                  "POSITION" : 20
+                  "POSITION" : 21,
+                  "TEXCOORD_0" : 22
                },
-               "indices" : 21,
+               "indices" : 23,
                "material" : 7,
                "mode" : 4
             }
@@ -647,15 +675,15 @@
       },
       {
          "name" : "mesh8",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
-                  "POSITION" : 22,
-                  "TEXCOORD_0" : 23
+                  "POSITION" : 24,
+                  "TEXCOORD_0" : 25
                },
-               "indices" : 24,
+               "indices" : 26,
                "material" : 8,
                "mode" : 4
             }
@@ -663,15 +691,15 @@
       },
       {
          "name" : "mesh9",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
-                  "POSITION" : 25,
-                  "TEXCOORD_0" : 26
+                  "POSITION" : 27,
+                  "TEXCOORD_0" : 28
                },
-               "indices" : 27,
+               "indices" : 29,
                "material" : 9,
                "mode" : 4
             }
@@ -679,22 +707,22 @@
       },
       {
          "name" : "mesh10",
-         "primitives" : 
+         "primitives" :
          [
             {
-               "attributes" : 
+               "attributes" :
                {
-                  "POSITION" : 28,
-                  "TEXCOORD_0" : 29
+                  "POSITION" : 30,
+                  "TEXCOORD_0" : 31
                },
-               "indices" : 30,
+               "indices" : 32,
                "material" : 10,
                "mode" : 4
             }
          ]
       }
    ],
-   "nodes" : 
+   "nodes" :
    [
       {
          "matrix" : [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -0.20000000000000001, 0.25, 0, 1 ],
@@ -712,7 +740,7 @@
          "name" : "mesh2"
       },
       {
-         "matrix" : 
+         "matrix" :
          [
             1,
             0,
@@ -765,7 +793,7 @@
          "name" : "mesh9"
       },
       {
-         "matrix" : 
+         "matrix" :
          [
             0.38941834230865052,
             -0.92106099400288499,
@@ -789,7 +817,7 @@
       },
       {
          "camera" : 0,
-         "matrix" : 
+         "matrix" :
          [
             0.00079632671073322247,
             0.99999968293183472,
@@ -816,7 +844,7 @@
       }
    ],
    "scene" : 0,
-   "scenes" : 
+   "scenes" :
    [
       {
          "name" : "Layer 0",

--- a/geometry/render_vtk/BUILD.bazel
+++ b/geometry/render_vtk/BUILD.bazel
@@ -80,6 +80,7 @@ drake_cc_library(
         "//common:scope_exit",
         "//geometry:geometry_roles",
         "//geometry:shape_specification",
+        "//third_party/com_gitlab_vtk:vtk_textured_capsule_source",
         "@vtk//:vtkCommonCore",
         "@vtk//:vtkFiltersSources",
     ],

--- a/geometry/render_vtk/internal_render_engine_vtk_base.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk_base.cc
@@ -4,7 +4,6 @@
 #include <utility>
 #include <vector>
 
-#include <vtkCapsuleSource.h>
 #include <vtkCellArray.h>
 #include <vtkFloatArray.h>
 #include <vtkInformation.h>
@@ -17,6 +16,7 @@
 #include <vtkStreamingDemandDrivenPipeline.h>
 
 #include "drake/common/scope_exit.h"
+#include "drake/third_party/com_gitlab_vtk/vtk_textured_capsule_source.h"
 
 namespace drake {
 namespace geometry {
@@ -236,7 +236,9 @@ class DrakeCubeSource : public vtkPolyDataAlgorithm {
 }  // namespace
 
 vtkSmartPointer<vtkPolyDataAlgorithm> CreateVtkCapsule(const Capsule& capsule) {
-  vtkNew<vtkCapsuleSource> vtk_capsule;
+  using com_gitlab_vtk::vtkTexturedCapsuleSource;
+
+  vtkNew<vtkTexturedCapsuleSource> vtk_capsule;
   vtk_capsule->SetCylinderLength(capsule.length());
   vtk_capsule->SetRadius(capsule.radius());
   // TODO(SeanCurtis-TRI): Provide control for smoothness/tessellation.

--- a/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
@@ -744,26 +744,31 @@ TEST_F(RenderEngineVtkTest, TransparentSphereTest) {
 
 // Performs the shape-centered-in-the-image test with a capsule.
 TEST_F(RenderEngineVtkTest, CapsuleTest) {
-  Init(X_WC_, true);
+  for (const bool use_texture : {false, true}) {
+    Init(X_WC_, true);
 
-  // Sets up a capsule.
-  const double radius = 0.15;
-  const double length = 1.2;
-  Capsule capsule(radius, length);
-  expected_label_ = RenderLabel(2);
-  const GeometryId id = GeometryId::get_new_id();
-  renderer_->RegisterVisual(id, capsule, simple_material(),
-                            RigidTransformd::Identity(),
-                            true /* needs update */);
-  // Position the top of the capsule to be 1 m above the terrain. Since the
-  // middle of the capsule is positioned at the origin 0, the top of the
-  // capsule is placed at half the length plus the radius, i.e. 1.2/2 + 0.15 =
-  // 0.75. To reach a total of 1, we need to offset it by an additional 0.25.
-  RigidTransformd X_WV{Vector3d{0, 0, 0.25}};
-  renderer_->UpdatePoses(
-      unordered_map<GeometryId, RigidTransformd>{{id, X_WV}});
+    // Sets up a capsule.
+    const double radius = 0.15;
+    const double length = 1.2;
+    Capsule capsule(radius, length);
+    expected_label_ = RenderLabel(2);
+    const GeometryId id = GeometryId::get_new_id();
+    renderer_->RegisterVisual(id, capsule, simple_material(use_texture),
+                              RigidTransformd::Identity(),
+                              true /* needs update */);
+    // Position the top of the capsule to be 1 m above the terrain. Since the
+    // middle of the capsule is positioned at the origin 0, the top of the
+    // capsule is placed at half the length plus the radius, i.e.
+    // 1.2/2 + 0.15 = 0.75. To reach a total of 1, we need to offset it by an
+    // additional 0.25.
+    RigidTransformd X_WV{Vector3d{0, 0, 0.25}};
+    renderer_->UpdatePoses(
+        unordered_map<GeometryId, RigidTransformd>{{id, X_WV}});
 
-  PerformCenterShapeTest(renderer_.get(), "Capsule test");
+    expected_color_ =
+        use_texture ? RgbaColor(kTextureColor, 255) : default_color_;
+    PerformCenterShapeTest(renderer_.get(), "Capsule test");
+  }
 }
 
 // Performs a test with a capsule centered in the image but rotated

--- a/third_party/com_gitlab_vtk/BUILD.bazel
+++ b/third_party/com_gitlab_vtk/BUILD.bazel
@@ -1,0 +1,20 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_library",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+drake_cc_library(
+    name = "vtk_textured_capsule_source",
+    srcs = ["vtk_textured_capsule_source.cc"],
+    hdrs = ["vtk_textured_capsule_source.h"],
+    visibility = ["//geometry:__subpackages__"],
+    deps = [
+        "@vtk//:vtkCommonCore",
+        "@vtk//:vtkFiltersSources",
+    ],
+)
+
+add_lint_tests()

--- a/third_party/com_gitlab_vtk/Copyright.txt
+++ b/third_party/com_gitlab_vtk/Copyright.txt
@@ -1,0 +1,34 @@
+/*=========================================================================
+
+  Program:   Visualization Toolkit
+  Module:    Copyright.txt
+
+Copyright (c) 1993-2015 Ken Martin, Will Schroeder, Bill Lorensen
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither name of Ken Martin, Will Schroeder, or Bill Lorensen nor the names
+   of any contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=========================================================================*/

--- a/third_party/com_gitlab_vtk/README.md
+++ b/third_party/com_gitlab_vtk/README.md
@@ -1,0 +1,13 @@
+# Description
+
+This uses the VTK implementation of `vtkTexturedSphereSource` as a base to
+create a `vtkTexturedCapsuleSource`.
+
+Replaces the `vtkCapsuleSource` with `vtkTexturedCapsuleSource`. This
+implementation contains texture coordinates for the capsule. It also changes
+the wireframe construction of the capsule. Now a single sphere is used where
+the poles are parallel to the cylinder body. The `vtkCapsuleSource` has two
+spheres with their poles parallel to the normal of the cylinder body. This
+change enables adding texture to the capsule body.
+
+Please refer to [VTK MR #9828](https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9828) for additional details.

--- a/third_party/com_gitlab_vtk/vtk_textured_capsule_source.cc
+++ b/third_party/com_gitlab_vtk/vtk_textured_capsule_source.cc
@@ -1,0 +1,248 @@
+/*=========================================================================
+
+  Program:   Visualization Toolkit
+  Module:    vtkTexturedCapsuleSource.cxx
+
+  Copyright (c) Ken Martin, Will Schroeder, Bill Lorensen
+  All rights reserved.
+
+  See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+
+=========================================================================*/
+#include "drake/third_party/com_gitlab_vtk/vtk_textured_capsule_source.h"
+
+#include <cmath>
+
+#include <vtkCellArray.h>
+#include <vtkFloatArray.h>
+#include <vtkInformation.h>
+#include <vtkInformationVector.h>
+#include <vtkMath.h>
+#include <vtkObjectFactory.h>
+#include <vtkPointData.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+#include <vtkStreamingDemandDrivenPipeline.h>
+
+namespace com_gitlab_vtk {
+
+vtkStandardNewMacro(vtkTexturedCapsuleSource);
+
+//------------------------------------------------------------------------------
+vtkTexturedCapsuleSource::vtkTexturedCapsuleSource(int res) {
+  res = res < 8 ? 8 : res;
+  this->Radius = 0.5;
+  this->Center[0] = 0.0;
+  this->Center[1] = 0.0;
+  this->Center[2] = 0.0;
+  this->ThetaResolution = res;
+  this->PhiResolution = res;
+  this->CylinderLength = 1.0;
+  this->OutputPointsPrecision = vtkAlgorithm::DEFAULT_PRECISION;
+  this->SetNumberOfInputPorts(0);
+}
+
+int vtkTexturedCapsuleSource::RequestData(
+    vtkInformation* vtkNotUsed(request),
+    vtkInformationVector** vtkNotUsed(inputVector),
+    vtkInformationVector* outputVector) {
+  // get the info object
+  vtkInformation* outInfo = outputVector->GetInformationObject(0);
+
+  // get the output
+  vtkPolyData* output = vtkPolyData::SafeDownCast(
+      outInfo->Get(vtkDataObject::DATA_OBJECT()));
+
+  int i, j;
+  int numPts;
+  int numPolys;
+  int phiResolutionHalf;
+  vtkPoints* newPoints;
+  vtkFloatArray* newNormals;
+  vtkFloatArray* newTCoords;
+  vtkCellArray* newPolys;
+  double x[3], n[3], deltaPhi, deltaTheta, phi, theta, radius, norm;
+  vtkIdType pts[3];
+  double tc[2], tcNorm;
+
+  // NOTE: To simplify the math for the TCoords and ensure that there are
+  // bands generated at the equator for both hemispheres, it is absolutely
+  // necessary to ensure PhiResolution is an even number.
+  if (this->PhiResolution % 2 != 0) {
+    static bool logged = false;
+    if (!logged) {
+      drake::log()->warn(
+          "Capsule PhiResolution must be even, changing from {} to {}!",
+          this->PhiResolution, this->PhiResolution + 1);
+      logged = true;
+    }
+    this->PhiResolution += 1;
+  }
+
+  //
+  // Set things up; allocate memory
+  //
+  // NOTE: Instead of (phi_R + 1) it should be (phi_R + 2) (two equators).
+  numPts = (this->PhiResolution + 2) * (this->ThetaResolution + 1);
+  // NOTE: Num of polys increase by theta_R * 2 (i.e., one more band of
+  // triangles around the barrel of the cylinder).
+  numPolys = (this->PhiResolution + 1) * 2 * this->ThetaResolution;
+
+  newPoints = vtkPoints::New();
+
+  // Set the desired precision for the points in the output.
+  if (this->OutputPointsPrecision == vtkAlgorithm::DOUBLE_PRECISION) {
+    newPoints->SetDataType(VTK_DOUBLE);
+  } else {
+    newPoints->SetDataType(VTK_FLOAT);
+  }
+
+  newPoints->Allocate(numPts);
+  newNormals = vtkFloatArray::New();
+  newNormals->SetNumberOfComponents(3);
+  newNormals->Allocate(3 * numPts);
+  newTCoords = vtkFloatArray::New();
+  newTCoords->SetNumberOfComponents(2);
+  newTCoords->Allocate(2 * numPts);
+  newPolys = vtkCellArray::New();
+  newPolys->AllocateEstimate(numPolys, 3);
+  //
+  // Create capsule
+  //
+  // Create intermediate points
+  // NOTE: We need to make sure that j * deltaPhi (for some integer j) is equal
+  // to pi/2. Hard requirement. Generally, not true for arbitrary PhiResolution.
+  // This is to ensure we always have a band at the equator for both
+  // hemispheres.
+  phiResolutionHalf = this->PhiResolution / 2;
+  deltaPhi = vtkMath::Pi() / this->PhiResolution;
+  deltaTheta = 2.0 * vtkMath::Pi() / this->ThetaResolution;
+  tcNorm = (vtkMath::Pi() * this->Radius + this->CylinderLength);
+  for (i = 0; i <= this->ThetaResolution; i++) {
+    theta = i * deltaTheta;
+    tc[0] = theta / (2.0 * vtkMath::Pi());
+    for (j = 0; j <= phiResolutionHalf; j++) {
+      phi = j * deltaPhi;
+      radius = this->Radius * sin(static_cast<double>(phi));
+      // The capsule is oriented along the y-axis.
+      x[0] = this->Center[0] + radius * cos(static_cast<double>(theta));
+      x[1] = this->Center[1] + this->Radius * cos(static_cast<double>(phi))
+          + this->CylinderLength / 2;
+      x[2] = this->Center[2] + -1 * radius * sin(static_cast<double>(theta));
+      newPoints->InsertNextPoint(x);
+
+      // CylinderLength is not needed for the normal computation.
+      n[0] = radius * cos(static_cast<double>(theta));
+      n[1] = this->Radius * cos(static_cast<double>(phi));
+      n[2] = -1 * radius * sin(static_cast<double>(theta));
+      if ((norm = vtkMath::Norm(n)) == 0.0) {
+        norm = 1.0;
+      }
+      n[0] /= norm;
+      n[1] /= norm;
+      n[2] /= norm;
+      newNormals->InsertNextTuple(n);
+
+      // 1 - x means flipped image.
+      tc[1] = 1.0 - (phi * this->Radius) / tcNorm;
+      newTCoords->InsertNextTuple(tc);
+    }
+
+    // The 'phiResolutionHalf' is set twice for both the two equators.
+    for (j = phiResolutionHalf; j <= 2 * phiResolutionHalf; j++) {
+      phi = j * deltaPhi;
+      radius = this->Radius * sin(static_cast<double>(phi));
+      // The capsule is oriented along the y-axis.
+      x[0] = this->Center[0] + radius * cos(static_cast<double>(theta));
+      x[1] = this->Center[1] + this->Radius * cos(static_cast<double>(phi))
+          - this->CylinderLength / 2;
+      x[2] = this->Center[2] + -1 * radius * sin(static_cast<double>(theta));
+      newPoints->InsertNextPoint(x);
+
+      n[0] = radius * cos(static_cast<double>(theta));
+      n[1] = this->Radius * cos(static_cast<double>(phi));
+      n[2] = -1 * radius * sin(static_cast<double>(theta));
+      if ((norm = vtkMath::Norm(n)) == 0.0) {
+        norm = 1.0;
+      }
+      n[0] /= norm;
+      n[1] /= norm;
+      n[2] /= norm;
+      newNormals->InsertNextTuple(n);
+
+      // 1 - x means flipped image.
+      tc[1] = 1.0 - (phi * this->Radius + this->CylinderLength) / tcNorm;
+      newTCoords->InsertNextTuple(tc);
+    }
+  }
+
+  //
+  // Generate mesh connectivity
+  //
+  for (i = 0; i < this->ThetaResolution; i++) {
+    for (j = 0; j <= 2 * phiResolutionHalf; j++) {
+      // +2 is required to properly connect the points.
+      pts[0] = (2 * phiResolutionHalf + 2) * i + j;
+      pts[1] = pts[0] + 1;
+      pts[2] = (2 * phiResolutionHalf + 2) * (i + 1) + (j + 1);
+      newPolys->InsertNextCell(3, pts);
+
+      pts[1] = pts[2];
+      pts[2] = pts[1] - 1;
+      newPolys->InsertNextCell(3, pts);
+    }
+  }
+
+  //
+  // Update ourselves and release memory
+  //
+  output->SetPoints(newPoints);
+  newPoints->Delete();
+
+  output->GetPointData()->SetNormals(newNormals);
+  newNormals->Delete();
+
+  output->GetPointData()->SetTCoords(newTCoords);
+  newTCoords->Delete();
+
+  output->SetPolys(newPolys);
+  newPolys->Delete();
+
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+void vtkTexturedCapsuleSource::PrintSelf(ostream& os, vtkIndent indent) {
+  this->Superclass::PrintSelf(os, indent);
+  os << indent << "Center: (" << this->Center[0] << ", " << this->Center[1]
+      << ", " << this->Center[2] << ")" << std::endl;
+  os << indent << "CylinderLength: " << this->CylinderLength << std::endl;
+  os << indent << "PhiResolution: " << this->PhiResolution << std::endl;
+  os << indent << "ThetaResolution: " << this->ThetaResolution << std::endl;
+  os << indent << "Radius: " << this->Radius << std::endl;
+  os << indent << "Output Points Precision: " << this->OutputPointsPrecision
+      << std::endl;
+}
+
+//------------------------------------------------------------------------------
+int vtkTexturedCapsuleSource::RequestInformation(
+    vtkInformation* vtkNotUsed(request),
+    vtkInformationVector** vtkNotUsed(inputVector),
+    vtkInformationVector* outputVector) {
+  vtkInformation* outInfo = outputVector->GetInformationObject(0);
+  outInfo->Set(vtkStreamingDemandDrivenPipeline::UPDATE_NUMBER_OF_PIECES(), -1);
+  const double halfLength = this->CylinderLength * 0.5;
+  outInfo->Set(vtkStreamingDemandDrivenPipeline::BOUNDS(),
+      this->Center[0] - this->Radius - halfLength,
+      this->Center[0] + this->Radius + halfLength,
+      this->Center[1] - this->Radius,
+      this->Center[1] + this->Radius, this->Center[2] - this->Radius,
+      this->Center[2] + this->Radius);
+  return 1;
+}
+
+}  // namespace com_gitlab_vtk

--- a/third_party/com_gitlab_vtk/vtk_textured_capsule_source.h
+++ b/third_party/com_gitlab_vtk/vtk_textured_capsule_source.h
@@ -1,0 +1,116 @@
+/*=========================================================================
+
+  Program:   Visualization Toolkit
+  Module:    vtkTexturedCapsuleSource.h
+
+  Copyright (c) Ken Martin, Will Schroeder, Bill Lorensen
+  All rights reserved.
+  See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+
+=========================================================================*/
+/**
+ * @class   vtkTexturedCapsuleSource
+ * @brief   Generate a capsule centered at the origin
+ *
+ * vtkTexturedCapsuleSource creates a capsule (represented by polygons) of
+ * specified radius centered at the origin.  The resolution (polygonal
+ * discretization) in both the latitude (phi) and longitude (theta) directions
+ * can be specified as well as the length of the capsule cylinder
+ * (CylinderLength).
+ */
+
+#pragma once
+
+#include "vtkPolyDataAlgorithm.h"
+
+namespace com_gitlab_vtk {
+
+class vtkTexturedCapsuleSource : public vtkPolyDataAlgorithm  {
+ public:
+  vtkTypeMacro(vtkTexturedCapsuleSource, vtkPolyDataAlgorithm);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /**
+   * Construct a capsule with radius 0.5 and resolution 8 in both the Phi and
+   * Theta directions and a cylinder of length 1.0.
+   */
+  static vtkTexturedCapsuleSource* New();
+
+  ///@{
+  /**
+   * Set/get the radius of the capsule.  The initial value is 0.5.
+   */
+  vtkSetClampMacro(Radius, double, 0.0, VTK_DOUBLE_MAX);
+  vtkGetMacro(Radius, double);
+  ///@}
+
+  ///@{
+  /**
+   * Set/get the center of the capsule.  The initial value is (0.0, 0.0, 0.0).
+   */
+  vtkSetVector3Macro(Center, double);
+  vtkGetVectorMacro(Center, double, 3);
+  ///@}
+
+  ///@{
+  /**
+   * Set/get the length of the cylinder.  The initial value is 1.0.
+   */
+  vtkSetClampMacro(CylinderLength, double, 0.0, VTK_DOUBLE_MAX);
+  vtkGetMacro(CylinderLength, double);
+  ///@}
+
+  ///@{
+  /**
+   * Set/get the number of points in the longitude direction for the spheres.
+   * The initial value is 8.
+   */
+  vtkSetClampMacro(ThetaResolution, int, 8, VTK_INT_MAX);
+  vtkGetMacro(ThetaResolution, int);
+  ///@}
+
+  ///@{
+  /**
+   * Set/get the number of points in the latitude direction for the spheres.
+   * The initial value is 8.
+   */
+  vtkSetClampMacro(PhiResolution, int, 8, VTK_INT_MAX);
+  vtkGetMacro(PhiResolution, int);
+  ///@}
+
+  ///@{
+  /**
+   * Set/get the desired precision for the output points.
+   * vtkAlgorithm::SINGLE_PRECISION - Output single-precision floating point.
+   * vtkAlgorithm::DOUBLE_PRECISION - Output double-precision floating point.
+   */
+  vtkSetMacro(OutputPointsPrecision, int);
+  vtkGetMacro(OutputPointsPrecision, int);
+  ///@}
+
+ protected:
+  explicit vtkTexturedCapsuleSource(int res = 8);
+  ~vtkTexturedCapsuleSource() override = default;
+
+  int RequestData(vtkInformation*, vtkInformationVector**,
+                  vtkInformationVector*) override;
+  int RequestInformation(vtkInformation*, vtkInformationVector**,
+                         vtkInformationVector*) override;
+
+  double Radius;
+  double Center[3];
+  int ThetaResolution;
+  int PhiResolution;
+  double CylinderLength;
+  int OutputPointsPrecision;
+
+ private:
+  vtkTexturedCapsuleSource(const vtkTexturedCapsuleSource&) = delete;
+  void operator=(const vtkTexturedCapsuleSource&) = delete;
+};
+
+}  // namespace com_gitlab_vtk


### PR DESCRIPTION
Replace the vtkCapsuleSource with vtkTexturedCapsuleSource. This implementation contains the texture coordinates. It also changes the wireframe construction of the capsule. Now a single sphere is used where the poles are parallel to the cylinder body. The vtkCapsuleSource has two spheres with their poles parallel to the normal of the cylinder body. This change enables adding texture to the capsule body.

close #18296

**+CC** @svenevs, @zachfang, @SeanCurtis-TRI 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18547)
<!-- Reviewable:end -->
