### PR TITLE
[parsing] Implement parent model name for Sdformat

### DIFF
--- a/multibody/parsing/detail_mujoco_parser.h
+++ b/multibody/parsing/detail_mujoco_parser.h
@@ -31,10 +31,11 @@ namespace internal {
 // @param data_source The XML data to be parsed.
 // @param model_name The name given to the newly created instance of this
 //   model.  If empty, the "name" attribute from the model tag will be used.
-// @param parent_model_name Optional name of parent model. If set, this will be
-//   prefixed with the model name (either `model_name` or from the "name"
-//   attribute) using the SDFormat scope delimiter "::". The prefixed name will
-//   used as the name given to the newly created instance of this model.
+// @param parent_model_name Optional name of parent model. If set, the model
+//   name of the parsed model (either `model_name` or from the "name"
+//   attribute) will be prefixed with the parent_model_name, using the SDFormat
+//   scope delimiter "::". The prefixed name will used as the name given to the
+//   newly created instance of this model.
 // @param plant A pointer to a mutable MultibodyPlant object to which the model
 //   will be added.
 // @returns The model instance index for the newly added model.

--- a/multibody/parsing/detail_parsing_workspace.h
+++ b/multibody/parsing/detail_parsing_workspace.h
@@ -34,9 +34,9 @@ class ParserInterface {
   // @param model_name
   //   The name given to the newly created instance of this model.  If
   //   empty, the model name found within the model data will be used.
-  // @param parent_model_name
-  //   Optional name of parent model. If set, this will be prefixed onto the
-  //   model name (either `model_name` or from the "name" attribute) using the
+  // @param parent_model_name Optional name of parent model. If set, the model
+  //   name of the parsed model (either `model_name` or from the "name"
+  //   attribute) will be prefixed with the parent_model_name, using the
   //   SDFormat scope delimiter "::". The prefixed name will used as the name
   //   given to the newly created instance of this model.
   // @param workspace
@@ -56,11 +56,10 @@ class ParserInterface {
   //
   // @param data_source
   //   The model data to be parsed.
-  // @param parent_model_name
-  //   Optional name of parent model. If set, this will be prefixed onto the
-  //   model name (either `model_name` or from the "name" attribute) using the
-  //   SDFormat scope delimiter "::". The prefixed name will used as the name
-  //   given to the newly created instance of this model.
+  // @param parent_model_name Optional name of parent model. If set, the model
+  //   names of all parsed models will be prefixed with the parent_model_name,
+  //   using the SDFormat scope delimiter "::". The prefixed name will used as
+  //   the name given to the newly created instances of these models.
   // @param workspace
   //   The ParsingWorkspace.
   // @returns The model instance indices for the newly added models, or an

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -1684,8 +1684,8 @@ sdf::ParserConfig MakeSdfParserConfig(const ParsingWorkspace& workspace) {
 }  // namespace
 
 std::optional<ModelInstanceIndex> AddModelFromSdf(
-    const DataSource& data_source,
-    const std::string& model_name_in,
+    const DataSource& data_source, const std::string& model_name_in,
+    const std::optional<std::string>& parent_model_name,
     const ParsingWorkspace& workspace) {
   DRAKE_THROW_UNLESS(!workspace.plant->is_finalized());
 
@@ -1705,8 +1705,13 @@ std::optional<ModelInstanceIndex> AddModelFromSdf(
   // Get the only model in the file.
   const sdf::Model& model = *root.Model();
 
-  const std::string model_name =
+  const std::string local_model_name =
       model_name_in.empty() ? model.Name() : model_name_in;
+
+  const std::string model_name =
+      parent_model_name.has_value()
+          ? sdf::JoinName(*parent_model_name, local_model_name)
+          : local_model_name;
 
   std::vector<ModelInstanceIndex> added_model_instances =
       AddModelsFromSpecification(
@@ -1720,6 +1725,7 @@ std::optional<ModelInstanceIndex> AddModelFromSdf(
 
 std::vector<ModelInstanceIndex> AddModelsFromSdf(
     const DataSource& data_source,
+    const std::optional<std::string>& parent_model_name,
     const ParsingWorkspace& workspace) {
   DRAKE_THROW_UNLESS(!workspace.plant->is_finalized());
 
@@ -1755,11 +1761,16 @@ std::vector<ModelInstanceIndex> AddModelsFromSdf(
     DRAKE_DEMAND(root.Model() != nullptr);
     const sdf::Model& model = *root.Model();
 
+    const std::string model_name =
+        parent_model_name.has_value()
+            ? sdf::JoinName(*parent_model_name, model.Name())
+            : model.Name();
+
     std::vector<ModelInstanceIndex> added_model_instances =
         AddModelsFromSpecification(
-            workspace.diagnostic, model, model.Name(), {}, workspace.plant,
-            workspace.collision_resolver,
-            workspace.package_map, data_source.GetRootDir());
+            workspace.diagnostic, model, model_name, {}, workspace.plant,
+            workspace.collision_resolver, workspace.package_map,
+            data_source.GetRootDir());
     model_instances.insert(model_instances.end(),
                            added_model_instances.begin(),
                            added_model_instances.end());
@@ -1784,11 +1795,16 @@ std::vector<ModelInstanceIndex> AddModelsFromSdf(
         ++model_index) {
       // Get the model.
       const sdf::Model& model = *world.ModelByIndex(model_index);
+      const std::string model_name =
+          parent_model_name.has_value()
+              ? sdf::JoinName(*parent_model_name, model.Name())
+              : model.Name();
+
       std::vector<ModelInstanceIndex> added_model_instances =
           AddModelsFromSpecification(
-              workspace.diagnostic, model, model.Name(), {}, workspace.plant,
-              workspace.collision_resolver,
-              workspace.package_map, data_source.GetRootDir());
+              workspace.diagnostic, model, model_name, {}, workspace.plant,
+              workspace.collision_resolver, workspace.package_map,
+              data_source.GetRootDir());
       model_instances.insert(model_instances.end(),
                              added_model_instances.begin(),
                              added_model_instances.end());
@@ -1831,17 +1847,14 @@ std::optional<ModelInstanceIndex> SdfParserWrapper::AddModel(
     const DataSource& data_source, const std::string& model_name,
     const std::optional<std::string>& parent_model_name,
     const ParsingWorkspace& workspace) {
-  std::string full_name =
-      parsing::PrefixName(parent_model_name.value_or(""), model_name);
-  return AddModelFromSdf(data_source, full_name, workspace);
+  return AddModelFromSdf(data_source, model_name, parent_model_name, workspace);
 }
 
 std::vector<ModelInstanceIndex> SdfParserWrapper::AddAllModels(
     const DataSource& data_source,
-    const std::optional<std::string>&,
+    const std::optional<std::string>& parent_model_name,
     const ParsingWorkspace& workspace) {
-  // TODO(rpoyner-tri): parent_model_name dropped?
-  return AddModelsFromSdf(data_source, workspace);
+  return AddModelsFromSdf(data_source, parent_model_name, workspace);
 }
 
 }  // namespace internal

--- a/multibody/parsing/detail_sdf_parser.h
+++ b/multibody/parsing/detail_sdf_parser.h
@@ -30,14 +30,19 @@ namespace internal {
 // @param model_name
 //   The name given to the newly created instance of this model.  If
 //   empty, the "name" attribute from the model tag will be used.
+// @param parent_model_name Optional name of parent model. If set, the model
+//   name of the parsed model (either `model_name` or from the "name"
+//   attribute) will be prefixed with the parent_model_name, using the SDFormat
+//   scope delimiter "::". The prefixed name will used as the name given to the
+//   newly created instance of this model.
 // @param workspace
 //   The ParsingWorkspace.
 // @returns The model instance index for the newly added model; this might be
 //   null if there were parsing errors reported through the workspace.diagnostic
 //   policy.
 std::optional<ModelInstanceIndex> AddModelFromSdf(
-    const DataSource& data_source,
-    const std::string& model_name,
+    const DataSource& data_source, const std::string& model_name,
+    const std::optional<std::string>& parent_model_name,
     const ParsingWorkspace& workspace);
 
 // Parses all `<model>` elements from the SDF file specified by `data_source`
@@ -54,6 +59,10 @@ std::optional<ModelInstanceIndex> AddModelFromSdf(
 //
 // @param data_source
 //   The SDF data to be parsed.
+// @param parent_model_name Optional name of parent model. If set, the model
+//   names of all parsed models will be prefixed with the parent_model_name,
+//   using the SDFormat scope delimiter "::". The prefixed name will used as
+//   the name given to the newly created instances of these models.
 // @param workspace
 //   The ParsingWorkspace.
 // @returns The set of model instance indices for the newly added models. This
@@ -61,6 +70,7 @@ std::optional<ModelInstanceIndex> AddModelFromSdf(
 //   errors reported through the workspace.diagnostic policy.
 std::vector<ModelInstanceIndex> AddModelsFromSdf(
     const DataSource& data_source,
+    const std::optional<std::string>& parent_model_name,
     const ParsingWorkspace& workspace);
 
 class SdfParserWrapper final : public ParserInterface {

--- a/multibody/parsing/detail_urdf_parser.h
+++ b/multibody/parsing/detail_urdf_parser.h
@@ -24,9 +24,9 @@ namespace internal {
 // @param model_name
 //   The name given to the newly created instance of this model.  If
 //   empty, the "name" attribute from the model tag will be used.
-// @param parent_model_name
-//   Optional name of parent model. If set, this will be prefixed with the model
-//   name (either `model_name` or from the "name" attribute) using the SDFormat
+// @param parent_model_name Optional name of parent model. If set, the model
+//   name of the parsed model (either `model_name` or from the "name"
+//   attribute) will be prefixed with the parent_model_name, using the SDFormat
 //   scope delimiter "::". The prefixed name will used as the name given to the
 //   newly created instance of this model.
 // @param workspace

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -79,47 +79,53 @@ class SdfParserTest : public test::DiagnosticPolicyTestBase{
 
   ModelInstanceIndex AddModelFromSdfFile(
       const std::string& file_name,
-      const std::string& model_name) {
+      const std::string& model_name,
+      const std::optional<std::string>& parent_model_name = {}) {
     const DataSource data_source{DataSource::kFilename, &file_name};
     internal::CollisionFilterGroupResolver resolver{&plant_};
     ParsingWorkspace w{package_map_, diagnostic_policy_,
                        &plant_, &resolver, TestingSelect};
-    std::optional<ModelInstanceIndex> result = AddModelFromSdf(
-        data_source, model_name, w);
+    std::optional<ModelInstanceIndex> result =
+        AddModelFromSdf(data_source, model_name, parent_model_name, w);
     EXPECT_TRUE(result.has_value());
     resolver.Resolve(diagnostic_policy_);
     return result.value_or(ModelInstanceIndex{});
   }
 
   std::vector<ModelInstanceIndex> AddModelsFromSdfFile(
-      const std::string& file_name) {
+      const std::string& file_name,
+      const std::optional<std::string>& parent_model_name = {}) {
     const DataSource data_source{DataSource::kFilename, &file_name};
     internal::CollisionFilterGroupResolver resolver{&plant_};
     ParsingWorkspace w{package_map_, diagnostic_policy_,
                        &plant_, &resolver, TestingSelect};
-    auto result = AddModelsFromSdf(data_source, w);
+    auto result = AddModelsFromSdf(data_source, parent_model_name, w);
     resolver.Resolve(diagnostic_policy_);
     return result;
   }
 
   std::vector<ModelInstanceIndex> AddModelsFromSdfString(
-      const std::string& file_contents) {
+      const std::string& file_contents,
+      const std::optional<std::string>& parent_model_name = {}) {
     const DataSource data_source{DataSource::kContents, &file_contents};
     internal::CollisionFilterGroupResolver resolver{&plant_};
     ParsingWorkspace w{package_map_, diagnostic_policy_, &plant_,
                        &resolver, TestingSelect};
-    auto result = AddModelsFromSdf(data_source, w);
+    auto result = AddModelsFromSdf(data_source, parent_model_name, w);
     resolver.Resolve(diagnostic_policy_);
     return result;
   }
 
-  void ParseTestString(const std::string& inner,
-                       const std::string& sdf_version = "1.6") {
+  void ParseTestString(
+      const std::string& inner,
+      const std::optional<std::string>& sdf_version = {},
+      const std::optional<std::string>& parent_model_name = {}) {
     SCOPED_TRACE(inner);
     FlushDiagnostics();
     const std::string file_contents =
-        "<sdf version='" + sdf_version + "'>" + inner + "\n</sdf>\n";
-    AddModelsFromSdfString(file_contents);
+        "<sdf version='" + sdf_version.value_or("1.6") + "'>"
+        + inner + "\n</sdf>\n";
+    AddModelsFromSdfString(file_contents, parent_model_name);
   }
 
   // Returns the first error as a string (or else fails the test case,
@@ -251,16 +257,28 @@ TEST_F(SdfParserTest, ModelInstanceTest) {
   EXPECT_THROW(AddModelFromSdfFile(acrobot_sdf_name, ""),
                std::logic_error);
 
+  // Avoid name collisions with model renaming.
   ModelInstanceIndex acrobot2 =
       AddModelFromSdfFile(acrobot_sdf_name, "acrobot2");
+
+  // Avoid name collisions with parent model names; both entry points.
+  ModelInstanceIndex acrobot3 =
+      AddModelFromSdfFile(acrobot_sdf_name, "", "3");
+  ModelInstanceIndex acrobot3rename =
+      AddModelFromSdfFile(acrobot_sdf_name, "new_model_name", "3");
+  ModelInstanceIndex acrobot4 =
+      AddModelsFromSdfFile(acrobot_sdf_name, "4").at(0);
 
   // We are done adding models.
   plant_.Finalize();
 
-  ASSERT_EQ(plant_.num_model_instances(), 5);
+  ASSERT_EQ(plant_.num_model_instances(), 8);
   EXPECT_EQ(plant_.GetModelInstanceByName("instance1"), instance1);
   EXPECT_EQ(plant_.GetModelInstanceByName("acrobot"), acrobot1);
   EXPECT_EQ(plant_.GetModelInstanceByName("acrobot2"), acrobot2);
+  EXPECT_EQ(plant_.GetModelInstanceByName("3::acrobot"), acrobot3);
+  EXPECT_EQ(plant_.GetModelInstanceByName("3::new_model_name"), acrobot3rename);
+  EXPECT_EQ(plant_.GetModelInstanceByName("4::acrobot"), acrobot4);
 
   // Check a couple links from the first model without specifying the model
   // instance.
@@ -357,6 +375,35 @@ TEST_F(SdfParserTest, ModelInstanceTest) {
   const RigidTransformd X_MF3(Vector3d(0.7, 0.8, 0.9));
   check_frame(
       "__model__", "model_scope_model_frame_implicit", X_MF3);
+}
+
+TEST_F(SdfParserTest, ParentModelNameWithString) {
+  std::string model = "<model name='something'><link name='link'/></model>";
+  ParseTestString(model);
+  // Add a parent model name to avoid name collisions.
+  ParseTestString(model, {}, "2");
+  plant_.Finalize();
+  ASSERT_EQ(plant_.num_model_instances(), 4);
+  EXPECT_NO_THROW(plant_.GetModelInstanceByName("something"));
+  EXPECT_NO_THROW(plant_.GetModelInstanceByName("2::something"));
+}
+
+TEST_F(SdfParserTest, ParentModelNameWithStringWorld) {
+  std::string model = R"""(
+<world name='here'>
+  <model name='a'><link name='link'/></model>
+  <model name='b'><link name='link'/></model>
+</world>
+)""";
+  ParseTestString(model);
+  // Add a parent model name to avoid name collisions.
+  ParseTestString(model, {}, "2");
+  plant_.Finalize();
+  ASSERT_EQ(plant_.num_model_instances(), 6);
+  EXPECT_NO_THROW(plant_.GetModelInstanceByName("a"));
+  EXPECT_NO_THROW(plant_.GetModelInstanceByName("b"));
+  EXPECT_NO_THROW(plant_.GetModelInstanceByName("2::a"));
+  EXPECT_NO_THROW(plant_.GetModelInstanceByName("2::b"));
 }
 
 TEST_F(SdfParserTest, EntireInertialTagOmitted) {


### PR DESCRIPTION
This is part of a long campaign to modernize Parser APIs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18550)
<!-- Reviewable:end -->
