### PR TITLE
[doc] Fix pydrake custom stylesheet for Sphinx on Jammy

### DIFF
--- a/doc/pydrake/_static/css/custom.css
+++ b/doc/pydrake/_static/css/custom.css
@@ -764,7 +764,7 @@ pre code {
   margin-bottom: 10px;
 }
 
-.rst-content dl:not(.docutils) dt {
+.rst-content dl:not(.docutils) dt, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) > dt {
   display: inline-block;
   margin: 6px 0;
   font-size: 90%;


### PR DESCRIPTION
We need to override more of the main style sheet to keep things red.

Towards #18552.

+@SeanCurtis-TRI for both reviews per schedule, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18557)
<!-- Reviewable:end -->
