### PR TITLE
[planning] Add CollisionChecker

### DIFF
--- a/planning/BUILD.bazel
+++ b/planning/BUILD.bazel
@@ -15,12 +15,14 @@ drake_cc_package_library(
     visibility = ["//visibility:public"],
     deps = [
         ":body_shape_description",
+        ":collision_checker",
         ":collision_checker_context",
         ":collision_checker_params",
         ":robot_clearance",
         ":robot_collision_type",
         ":robot_diagram",
         ":robot_diagram_builder",
+        ":unimplemented_collision_checker",
     ],
 )
 
@@ -32,6 +34,29 @@ drake_cc_library(
         "//common:essential",
         "//geometry",
         "//multibody/plant",
+    ],
+)
+
+drake_cc_library(
+    name = "collision_checker",
+    srcs = ["collision_checker.cc"],
+    hdrs = [
+        "collision_checker.h",
+        "edge_measure.h",
+    ],
+    interface_deps = [
+        ":body_shape_description",
+        ":collision_checker_context",
+        ":collision_checker_params",
+        ":robot_clearance",
+        ":robot_collision_type",
+        ":robot_diagram_builder",
+        "//common:essential",
+        "//geometry",
+        "//multibody/plant",
+    ],
+    deps = [
+        "@common_robotics_utilities",
     ],
 )
 
@@ -97,6 +122,16 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "unimplemented_collision_checker",
+    srcs = ["unimplemented_collision_checker.cc"],
+    hdrs = ["unimplemented_collision_checker.h"],
+    deps = [
+        ":collision_checker",
+        ":collision_checker_params",
+    ],
+)
+
 drake_cc_googletest(
     name = "body_shape_description_test",
     deps = [
@@ -104,6 +139,18 @@ drake_cc_googletest(
         ":robot_diagram_builder",
         "//multibody/parsing",
         "//multibody/plant",
+    ],
+)
+
+drake_cc_googletest(
+    name = "collision_checker_test",
+    num_threads = 2,
+    deps = [
+        ":collision_checker",
+        ":unimplemented_collision_checker",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+        "@common_robotics_utilities",
     ],
 )
 
@@ -139,6 +186,14 @@ drake_cc_googletest(
     deps = [
         ":robot_diagram",
         ":robot_diagram_builder",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "unimplemented_collision_checker_test",
+    deps = [
+        ":unimplemented_collision_checker",
         "//common/test_utilities:expect_throws_message",
     ],
 )

--- a/planning/collision_checker.cc
+++ b/planning/collision_checker.cc
@@ -1,0 +1,1119 @@
+#include "planning/collision_checker.h"
+
+#include <algorithm>
+#include <atomic>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <common_robotics_utilities/math.hpp>
+#include <common_robotics_utilities/openmp_helpers.hpp>
+#include <common_robotics_utilities/print.hpp>
+#include <common_robotics_utilities/utility.hpp>
+#if defined(_OPENMP)
+#include <omp.h>
+#endif
+
+#include "drake/common/drake_throw.h"
+#include "drake/multibody/parsing/scoped_names.h"
+
+namespace anzu {
+namespace planning {
+
+using drake::log;
+using drake::geometry::GeometryId;
+using drake::geometry::QueryObject;
+using drake::geometry::Shape;
+using drake::math::RigidTransform;
+using drake::multibody::Body;
+using drake::multibody::BodyIndex;
+using drake::multibody::Frame;
+using drake::multibody::Joint;
+using drake::multibody::JointIndex;
+using drake::multibody::ModelInstanceIndex;
+using drake::multibody::MultibodyPlant;
+using drake::multibody::world_model_instance;
+using drake::planning::BodyShapeDescription;
+using drake::planning::CollisionCheckerContext;
+using drake::planning::CollisionCheckerParams;
+using drake::planning::ConfigurationDistanceFunction;
+using drake::planning::ConfigurationInterpolationFunction;
+using drake::planning::RobotClearance;
+using drake::planning::RobotCollisionType;
+using drake::systems::Context;
+using std::move;
+
+ConfigurationInterpolationFunction
+MakeDefaultConfigurationInterpolationFunction(
+    const std::vector<int>& quaternion_dof_start_indices) {
+  return [quaternion_dof_start_indices](
+      const Eigen::VectorXd& q_1, const Eigen::VectorXd& q_2, double ratio) {
+    // Start with linear interpolation between q_1 and q_2.
+    Eigen::VectorXd interpolated_q =
+        common_robotics_utilities::math::InterpolateXd(q_1, q_2, ratio);
+    // Handle quaternion dof properly.
+    for (const int quat_dof_start_index : quaternion_dof_start_indices) {
+      const Eigen::Quaterniond quat_1(q_1.segment<4>(quat_dof_start_index));
+      const Eigen::Quaterniond quat_2(q_2.segment<4>(quat_dof_start_index));
+      const Eigen::Quaterniond interpolated_quat =
+          common_robotics_utilities::math::Interpolate(quat_1, quat_2, ratio);
+      interpolated_q.segment<4>(quat_dof_start_index) =
+          interpolated_quat.coeffs();
+    }
+    return interpolated_q;
+  };
+}
+
+std::vector<int> GetQuaternionDofStartIndices(
+    const MultibodyPlant<double>& plant) {
+  std::vector<int> quaternion_dof_start_indices;
+  for (BodyIndex body_index(0); body_index < plant.num_bodies(); ++body_index) {
+    const auto& body = plant.get_body(body_index);
+    if (body.has_quaternion_dofs()) {
+      quaternion_dof_start_indices.push_back(
+          body.floating_positions_start());
+    }
+  }
+  return quaternion_dof_start_indices;
+}
+
+namespace {
+
+// Returns the set of indices in `q` that kinematically affect the robot model
+// but that are not a part of the robot dofs (e.g., a floating or mobile base).
+// This pre-computed analysis will be used for RobotClearance calculations.
+std::vector<int> CalcUncontrolledDofsThatKinematicallyAffectTheRobot(
+    const MultibodyPlant<double>& plant,
+    const std::vector<ModelInstanceIndex>& robot) {
+  // Our tactic in the loop below is to identify dofs that are either controlled
+  // by one of our robot joints, or controlled by a non-robot joint but anyway
+  // don't kinematically affect our robot. Then at the end, we'll return the
+  // complement of this set. This is important to cover the case where there
+  // are dofs without any associated joints.
+  std::vector<const Joint<double>*> controlled_or_unaffecting;
+  for (JointIndex joint_i{0}; joint_i < plant.num_joints(); ++joint_i) {
+    const Joint<double>& joint = plant.get_joint(joint_i);
+    // Skip these (or else GetBodiesKinematicallyAffectedBy will throw).
+    if (joint.num_positions() == 0) {
+      continue;
+    }
+    // Identify joints that are part of the robot.
+    auto iter = std::find(robot.begin(), robot.end(), joint.model_instance());
+    if (iter != robot.end()) {
+      controlled_or_unaffecting.push_back(&joint);
+      continue;
+    }
+    // Identify whether the joint affects any robot bodies.
+    std::vector<BodyIndex> outboard_bodies =
+        plant.GetBodiesKinematicallyAffectedBy({joint_i});
+    bool affects_robot = false;
+    for (const BodyIndex& body_i : outboard_bodies) {
+      const Body<double>& body = plant.get_body(body_i);
+      iter = std::find(robot.begin(), robot.end(), body.model_instance());
+      if (iter != robot.end()) {
+        affects_robot = true;
+        break;
+      }
+    }
+    if (!affects_robot) {
+      controlled_or_unaffecting.push_back(&joint);
+    }
+  }
+  // Compute the list of controlled or unaffected indices in a position vector.
+  using boolish = uint8_t;
+  std::vector<boolish> controlled_or_unaffecting_array;
+  controlled_or_unaffecting_array.resize(plant.num_positions(), false);
+  for (const auto* joint : controlled_or_unaffecting) {
+    const int start = joint->position_start();
+    const int nq = joint->num_positions();
+    for (int i = 0; i < nq; ++i) {
+      controlled_or_unaffecting_array[start + i] = true;
+    }
+  }
+  // Floating robot bodies are "controlled" even with no joints.
+  for (const BodyIndex& body_i : plant.GetFloatingBaseBodies()) {
+    const Body<double>& body = plant.get_body(body_i);
+    DRAKE_DEMAND(body.is_floating());
+    auto iter = std::find(robot.begin(), robot.end(), body.model_instance());
+    if (iter != robot.end()) {
+      const int start = body.floating_positions_start();
+      const int nq = body.has_quaternion_dofs() ? 7 : 6;
+      for (int i = 0; i < nq; ++i) {
+        controlled_or_unaffecting_array[start + i] = true;
+      }
+      continue;
+    }
+  }
+  // Now return the complement: the uncontrolled & affecting indices.
+  std::vector<int> result;
+  for (int i = 0; i < plant.num_positions(); ++i) {
+    if (!controlled_or_unaffecting_array[i]) {
+      result.push_back(i);
+    }
+  }
+  return result;
+}
+
+}  // namespace
+
+CollisionChecker::~CollisionChecker() = default;
+
+std::string CollisionChecker::GetScopedName(const Frame<double>& frame) const {
+  return drake::multibody::parsing::PrefixName(
+      plant().GetModelInstanceName(frame.model_instance()), frame.name());
+}
+
+std::string CollisionChecker::GetScopedName(const Body<double>& body) const {
+  return drake::multibody::parsing::PrefixName(
+      plant().GetModelInstanceName(body.model_instance()), body.name());
+}
+
+bool CollisionChecker::IsPartOfRobot(const Body<double>& body) const {
+  const ModelInstanceIndex needle = body.model_instance();
+  const auto& haystack = robot_model_instances_;
+  return std::binary_search(haystack.begin(), haystack.end(), needle);
+}
+
+bool CollisionChecker::IsPartOfRobot(BodyIndex body_index) const {
+  return IsPartOfRobot(get_body(body_index));
+}
+
+const CollisionCheckerContext& CollisionChecker::model_context() const {
+  return model_context_by_index(
+      common_robotics_utilities::openmp_helpers::GetContextOmpThreadNum());
+}
+
+std::shared_ptr<CollisionCheckerContext>
+CollisionChecker::MakeStandaloneModelContext() const {
+  // Make a shared clone of the special last "prototype" context.
+  std::shared_ptr<CollisionCheckerContext> standalone_context(
+      owned_contexts_.prototype_context().Clone());
+  // Save a weak reference to the shared standalone context.
+  standalone_contexts_.AddStandaloneContext(standalone_context);
+  return standalone_context;
+}
+
+void CollisionChecker::PerformOperationAgainstAllModelContexts(
+    const std::function<void(
+        const RobotDiagram<double>&,
+        CollisionCheckerContext*)>& operation) {
+  owned_contexts_.PerformOperationAgainstAllOwnedContexts(
+      model(), operation);
+  standalone_contexts_.PerformOperationAgainstAllStandaloneContexts(
+      model(), operation);
+}
+
+bool CollisionChecker::AddCollisionShape(
+    const std::string& group_name, const BodyShapeDescription& description) {
+  const Body<double>& body = plant().GetBodyByName(
+      description.body_name(),
+      plant().GetModelInstanceByName(description.model_instance_name()));
+  return AddCollisionShapeToBody(group_name, body, description.shape(),
+                                 description.pose_in_body());
+}
+
+int CollisionChecker::AddCollisionShapes(
+    const std::string& group_name,
+    const std::vector<BodyShapeDescription>& descriptions) {
+  int added = 0;
+  for (const auto& body_shape : descriptions) {
+    if (AddCollisionShape(group_name, body_shape)) {
+      ++added;
+    }
+  }
+  return added;
+}
+
+std::map<std::string, int> CollisionChecker::AddCollisionShapes(
+    const std::map<std::string, std::vector<BodyShapeDescription>>&
+        geometry_groups) {
+  std::map<std::string, int> group_added_shapes;
+  for (const auto& [group_name, group_shapes] : geometry_groups) {
+    const int num_added_shapes = AddCollisionShapes(group_name, group_shapes);
+    group_added_shapes.emplace(group_name, num_added_shapes);
+  }
+  return group_added_shapes;
+}
+
+bool CollisionChecker::AddCollisionShapeToFrame(
+    const std::string& group_name,
+    const Frame<double>& frameA,
+    const Shape& shape,
+    const RigidTransform<double>& X_AG) {
+  const Body<double>& bodyA = frameA.body();
+  const RigidTransform<double>& X_BA =
+      frameA.GetFixedPoseInBodyFrame();
+  const RigidTransform<double> X_BG = X_BA * X_AG;
+  return AddCollisionShapeToBody(group_name, bodyA, shape, X_BG);
+}
+
+bool CollisionChecker::AddCollisionShapeToBody(
+    const std::string& group_name, const Body<double>& bodyA,
+    const Shape& shape, const RigidTransform<double>& X_AG) {
+  const std::optional<GeometryId> maybe_geometry =
+      DoAddCollisionShapeToBody(group_name, bodyA, shape, X_AG);
+  if (maybe_geometry.has_value()) {
+    const std::string& model_instance_name =
+        plant().GetModelInstanceName(bodyA.model_instance());
+    geometry_groups_[group_name].push_back(AddedShape{
+        *maybe_geometry, bodyA.index(),
+        BodyShapeDescription(shape, X_AG, model_instance_name, bodyA.name())});
+  }
+  return maybe_geometry.has_value();
+}
+
+std::map<std::string, std::vector<BodyShapeDescription>>
+CollisionChecker::GetAllAddedCollisionShapes() const {
+  std::map<std::string, std::vector<BodyShapeDescription>> result;
+  for (const auto& [group_name, group_shapes] : geometry_groups_) {
+    result[group_name].reserve(group_shapes.size());
+    for (const auto& shape : group_shapes) {
+      result[group_name].push_back(shape.description);
+    }
+  }
+  return result;
+}
+
+void CollisionChecker::RemoveAllAddedCollisions(
+    const std::string& group_name) {
+  auto iter = geometry_groups_.find(group_name);
+  if (iter != geometry_groups_.end()) {
+    drake::log()->debug("Removing geometries from group [{}].", group_name);
+    DoRemoveAddedGeometries(iter->second);
+    geometry_groups_.erase(iter);
+  }
+}
+
+void CollisionChecker::RemoveAllAddedCollisions() {
+  drake::log()->debug("Removing all added geometries");
+  for (const auto& [group_name, group_ids] : geometry_groups_) {
+    DoRemoveAddedGeometries(group_ids);
+  }
+  geometry_groups_.clear();
+}
+
+std::optional<double>
+CollisionChecker::MaybeGetUniformRobotEnvironmentPadding() const {
+  std::optional<double> check_padding;
+  for (BodyIndex body_index(0); body_index < plant().num_bodies();
+       body_index++) {
+    for (BodyIndex other_body_index(body_index + 1);
+         other_body_index < plant().num_bodies(); other_body_index++) {
+      if (IsPartOfRobot(get_body(body_index)) !=
+          IsPartOfRobot(get_body(other_body_index))) {
+        const double this_padding =
+            GetPaddingBetween(body_index, other_body_index);
+        if (!check_padding) {
+          check_padding = this_padding;
+        }
+        if (check_padding.value() != this_padding) {
+          return std::nullopt;
+        }
+      }
+    }
+  }
+  return check_padding;
+}
+
+std::optional<double>
+CollisionChecker::MaybeGetUniformRobotRobotPadding() const {
+  std::optional<double> check_padding;
+  for (BodyIndex body_index(0); body_index < plant().num_bodies();
+       body_index++) {
+    for (BodyIndex other_body_index(body_index + 1);
+         other_body_index < plant().num_bodies(); other_body_index++) {
+      if (IsPartOfRobot(get_body(body_index)) &&
+          IsPartOfRobot(get_body(other_body_index))) {
+        const double this_padding =
+            GetPaddingBetween(body_index, other_body_index);
+        if (!check_padding) {
+          check_padding = this_padding;
+        }
+        if (check_padding.value() != this_padding) {
+          return std::nullopt;
+        }
+      }
+    }
+  }
+  return check_padding;
+}
+
+void CollisionChecker::SetPaddingBetween(BodyIndex bodyA_index,
+                                         BodyIndex bodyB_index,
+                                         double padding) {
+  DRAKE_THROW_UNLESS(
+      bodyA_index >= 0 && bodyA_index < collision_padding_.rows());
+  DRAKE_THROW_UNLESS(
+      bodyB_index >= 0 && bodyB_index < collision_padding_.rows());
+  DRAKE_THROW_UNLESS(bodyA_index != bodyB_index);
+  DRAKE_THROW_UNLESS(std::isfinite(padding));
+  DRAKE_THROW_UNLESS(IsPartOfRobot(get_body(bodyA_index)) ||
+                     IsPartOfRobot(get_body(bodyB_index)));
+  collision_padding_(int{bodyA_index}, int{bodyB_index}) = padding;
+  collision_padding_(int{bodyB_index}, int{bodyA_index}) = padding;
+  UpdateMaxCollisionPadding();
+}
+
+void CollisionChecker::SetPaddingMatrix(
+    const Eigen::MatrixXd& collision_padding) {
+  // First confirm it is of appropriate *size*.
+  if (collision_padding.rows() != collision_padding_.rows() ||
+      collision_padding.cols() != collision_padding_.cols()) {
+    throw std::logic_error(
+        fmt::format("CollisionChecker::SetPaddingMatrix(): The padding"
+                    " matrix must be {}x{}. The given padding matrix is the"
+                    " wrong size: {}x{}.",
+                    collision_padding_.rows(), collision_padding_.cols(),
+                    collision_padding.rows(), collision_padding.cols()));
+  }
+  ValidatePaddingMatrix(collision_padding, __func__);
+  collision_padding_ = collision_padding;
+  UpdateMaxCollisionPadding();
+}
+
+void CollisionChecker::SetPaddingOneRobotBodyAllEnvironmentPairs(
+    const BodyIndex body_index, const double padding) {
+  DRAKE_THROW_UNLESS(std::isfinite(padding));
+  DRAKE_THROW_UNLESS(IsPartOfRobot(get_body(body_index)));
+  for (BodyIndex other_body_index(0); other_body_index < plant().num_bodies();
+       other_body_index++) {
+    if (!IsPartOfRobot(get_body(other_body_index))) {
+      collision_padding_(int{body_index}, int{other_body_index}) = padding;
+      collision_padding_(int{other_body_index}, int{body_index}) = padding;
+    }
+  }
+  UpdateMaxCollisionPadding();
+}
+
+void CollisionChecker::SetPaddingAllRobotEnvironmentPairs(
+    const double padding) {
+  DRAKE_THROW_UNLESS(std::isfinite(padding));
+  for (BodyIndex body_index(0); body_index < plant().num_bodies();
+       body_index++) {
+    for (BodyIndex other_body_index(body_index + 1);
+         other_body_index < plant().num_bodies(); other_body_index++) {
+      if (IsPartOfRobot(get_body(body_index)) !=
+          IsPartOfRobot(get_body(other_body_index))) {
+        collision_padding_(int{body_index}, int{other_body_index}) = padding;
+        collision_padding_(int{other_body_index}, int{body_index}) = padding;
+      }
+    }
+  }
+  UpdateMaxCollisionPadding();
+}
+
+void CollisionChecker::SetPaddingAllRobotRobotPairs(const double padding) {
+  DRAKE_THROW_UNLESS(std::isfinite(padding));
+  for (BodyIndex body_index(0); body_index < plant().num_bodies();
+       body_index++) {
+    for (BodyIndex other_body_index(body_index + 1);
+         other_body_index < plant().num_bodies(); other_body_index++) {
+      if (IsPartOfRobot(get_body(body_index)) &&
+          IsPartOfRobot(get_body(other_body_index))) {
+        collision_padding_(int{body_index}, int{other_body_index}) = padding;
+        collision_padding_(int{other_body_index}, int{body_index}) = padding;
+      }
+    }
+  }
+  UpdateMaxCollisionPadding();
+}
+
+
+void CollisionChecker::SetCollisionFilterMatrix(
+    const Eigen::MatrixXi& filter_matrix) {
+  // First confirm it is of appropriate *size*.
+  if (filter_matrix.rows() != filtered_collisions_.rows() ||
+      filter_matrix.cols() != filtered_collisions_.cols()) {
+    throw std::logic_error(
+        fmt::format("CollisionChecker::SetCollisionFilterMatrix(): The filter "
+                    "matrix must be {}X{};. The given matrix is the wrong "
+                    "size: {}X{}.",
+                    filtered_collisions_.rows(), filtered_collisions_.cols(),
+                    filter_matrix.rows(), filter_matrix.cols()));
+  }
+  // Now test for consistency.
+  ValidateFilteredCollisionMatrix(filter_matrix, __func__);
+  filtered_collisions_ = filter_matrix;
+  log()->debug(
+      "Set collision filter matrix to:\n{}", filtered_collisions_);
+}
+
+bool CollisionChecker::IsCollisionFilteredBetween(
+    BodyIndex bodyA_index, BodyIndex bodyB_index) const {
+  DRAKE_THROW_UNLESS(bodyA_index >= 0 &&
+                     bodyA_index < filtered_collisions_.rows());
+  DRAKE_THROW_UNLESS(bodyB_index >= 0 &&
+                     bodyB_index < filtered_collisions_.rows());
+  return (filtered_collisions_(int{bodyA_index}, int{bodyB_index}) != 0);
+}
+
+void CollisionChecker::SetCollisionFilteredBetween(BodyIndex bodyA_index,
+                                                   BodyIndex bodyB_index,
+                                                   bool filter_collision) {
+  const int N = filtered_collisions_.rows();
+  DRAKE_THROW_UNLESS(bodyA_index >= 0 && bodyA_index < N);
+  DRAKE_THROW_UNLESS(bodyB_index >= 0 && bodyB_index < N);
+  if (!(IsPartOfRobot(bodyA_index) || IsPartOfRobot(bodyB_index))) {
+    throw std::logic_error(
+        fmt::format("CollisionChecker::SetCollisionFilteredBetween(): cannot "
+                    "be used on pairs of environment bodies: ({}, {})",
+                    bodyA_index, bodyB_index));
+  }
+  const int encoded = filter_collision ? 1 : 0;
+  filtered_collisions_(int{bodyA_index}, int{bodyB_index}) = encoded;
+  filtered_collisions_(int{bodyB_index}, int{bodyA_index}) = encoded;
+}
+
+void CollisionChecker::SetCollisionFilteredWithAllBodies(BodyIndex body_index) {
+  DRAKE_THROW_UNLESS(
+      body_index >= 0 && body_index < filtered_collisions_.rows());
+  DRAKE_THROW_UNLESS(IsPartOfRobot(body_index));
+  filtered_collisions_.row(body_index).setConstant(1);
+  filtered_collisions_.col(body_index).setConstant(1);
+  // Maintain the invariant that the diagonal is always -1.
+  filtered_collisions_(int{body_index}, int{body_index}) = -1;
+}
+
+bool CollisionChecker::CheckConfigCollisionFree(
+    const Eigen::VectorXd& q) const {
+  return CheckContextConfigCollisionFree(&mutable_model_context(), q);
+}
+
+bool CollisionChecker::CheckContextConfigCollisionFree(
+    CollisionCheckerContext* model_context, const Eigen::VectorXd& q) const {
+  DRAKE_THROW_UNLESS(model_context != nullptr);
+  UpdateContextPositions(model_context, q);
+  return DoCheckContextConfigCollisionFree(*model_context);
+}
+
+std::vector<int8_t> CollisionChecker::CheckConfigsCollisionFree(
+    const std::vector<Eigen::VectorXd>& configs, const bool parallelize) const {
+  // Note: vector<int8_t> is used since vector<bool> is not thread safe.
+  std::vector<int8_t> collision_checks(configs.size(), 0);
+
+  const bool check_in_parallel = CanEvaluateInParallel() && parallelize;
+  CRU_OMP_PARALLEL_FOR_IF(check_in_parallel)
+  for (size_t idx = 0; idx < configs.size(); idx++) {
+    if (CheckConfigCollisionFree(configs.at(idx))) {
+      collision_checks.at(idx) = 1;
+    } else {
+      collision_checks.at(idx) = 0;
+    }
+  }
+
+  return collision_checks;
+}
+
+void CollisionChecker::SetConfigurationDistanceFunction(
+    const ConfigurationDistanceFunction& distance_function) {
+  const double test_distance =
+      distance_function(GetZeroConfiguration(), GetZeroConfiguration());
+  DRAKE_THROW_UNLESS(test_distance == 0.0);
+  configuration_distance_function_ = distance_function;
+}
+
+ConfigurationDistanceFunction
+CollisionChecker::MakeStandaloneConfigurationDistanceFunction() const {
+  return [&] (const Eigen::VectorXd& q_1, const Eigen::VectorXd& q_2) {
+    return ComputeConfigurationDistance(q_1, q_2);
+  };
+}
+
+void CollisionChecker::SetConfigurationInterpolationFunction(
+    const ConfigurationInterpolationFunction& interpolation_function) {
+  if (interpolation_function == nullptr) {
+    SetConfigurationInterpolationFunction(
+        MakeDefaultConfigurationInterpolationFunction(
+            GetQuaternionDofStartIndices(plant())));
+    return;
+  }
+  const Eigen::VectorXd test_interpolated_q = interpolation_function(
+      GetZeroConfiguration(), GetZeroConfiguration(), 0.0);
+  DRAKE_THROW_UNLESS(
+      test_interpolated_q.size() == GetZeroConfiguration().size());
+  for (int index = 0; index < test_interpolated_q.size(); ++index) {
+    DRAKE_THROW_UNLESS(
+        test_interpolated_q(index) == GetZeroConfiguration()(index));
+  }
+  configuration_interpolation_function_ = interpolation_function;
+}
+
+ConfigurationInterpolationFunction
+CollisionChecker::MakeStandaloneConfigurationInterpolationFunction() const {
+  return [&] (
+      const Eigen::VectorXd& q_1, const Eigen::VectorXd& q_2, double ratio) {
+    return InterpolateBetweenConfigurations(q_1, q_2, ratio);
+  };
+}
+
+bool CollisionChecker::CheckEdgeCollisionFree(
+    const Eigen::VectorXd& q1, const Eigen::VectorXd& q2) const {
+  return CheckContextEdgeCollisionFree(&mutable_model_context(), q1, q2);
+}
+
+bool CollisionChecker::CheckContextEdgeCollisionFree(
+    CollisionCheckerContext* model_context, const Eigen::VectorXd& q1,
+    const Eigen::VectorXd& q2) const {
+  DRAKE_THROW_UNLESS(model_context != nullptr);
+
+  // Fail fast if q2 is in collision. This method is used by motion planners
+  // that extend/connect towards some target configuration, and thus require a
+  // number of edge collision checks in which q1 is often known to be
+  // collision-free while q2 is unknown. Many of these potential
+  // extensions/connections will result in a colliding configuration, so failing
+  // fast on a colliding q2 helps reduce the work of checking colliding edges.
+  // There is also no need to special case checking q1, since it will be the
+  // first configuration checked in the loop.
+  if (!CheckContextConfigCollisionFree(model_context, q2)) {
+    return false;
+  }
+
+  const double distance = ComputeConfigurationDistance(q1, q2);
+  const int num_steps = static_cast<int>(
+      std::max(1.0, std::ceil(distance / edge_step_size())));
+  for (int step = 0; step < num_steps; step++) {
+    const double ratio =
+        static_cast<double>(step) / static_cast<double>(num_steps);
+    const Eigen::VectorXd qinterp =
+        InterpolateBetweenConfigurations(q1, q2, ratio);
+    if (!CheckContextConfigCollisionFree(model_context, qinterp)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool CollisionChecker::CheckEdgeCollisionFreeParallel(
+    const Eigen::VectorXd& q1, const Eigen::VectorXd& q2) const {
+  // Only perform parallel operations if `omp parallel for` will use >1 thread.
+  if (CanEvaluateInParallel()) {
+    // Fail fast if q2 is in collision. This method is used by motion planners
+    // that extend/connect towards some target configuration, and thus require a
+    // number of edge collision checks in which q1 is often known to be
+    // collision-free while q2 is unknown. Many of these potential
+    // extensions/connections will result in a colliding configuration, so
+    // failing fast on a colliding q2 helps reduce the work of checking
+    // colliding edges.
+    // There is also no need to special case checking q1, since it will be the
+    // first configuration checked in the loop.
+    if (!CheckConfigCollisionFree(q2)) {
+      return false;
+    }
+
+    const double distance = ComputeConfigurationDistance(q1, q2);
+    const int num_steps = static_cast<int>(
+        std::max(1.0, std::ceil(distance / edge_step_size())));
+    std::atomic<bool> edge_valid(true);
+#if defined(_OPENMP)
+#pragma omp parallel for
+#endif
+    for (int step = 0; step < num_steps; step++) {
+      const double ratio =
+          static_cast<double>(step) / static_cast<double>(num_steps);
+      if (edge_valid.load()) {
+        const Eigen::VectorXd qinterp =
+            InterpolateBetweenConfigurations(q1, q2, ratio);
+        if (!CheckConfigCollisionFree(qinterp)) {
+          edge_valid.store(false);
+        }
+      }
+    }
+    return edge_valid.load();
+  } else {
+    // If OpenMP cannot parallelize, fall back to the serial version.
+    return CheckEdgeCollisionFree(q1, q2);
+  }
+}
+
+std::vector<int8_t> CollisionChecker::CheckEdgesCollisionFree(
+    const std::vector<std::pair<Eigen::VectorXd, Eigen::VectorXd>>& edges,
+    const bool parallelize) const {
+  // Note: vector<int8_t> is used since vector<bool> is not thread safe.
+  std::vector<int8_t> collision_checks(edges.size(), 0);
+
+  const bool check_in_parallel = CanEvaluateInParallel() && parallelize;
+  CRU_OMP_PARALLEL_FOR_IF(check_in_parallel)
+  for (size_t idx = 0; idx < edges.size(); idx++) {
+    const std::pair<Eigen::VectorXd, Eigen::VectorXd>& edge = edges.at(idx);
+    if (CheckEdgeCollisionFree(edge.first, edge.second)) {
+      collision_checks.at(idx) = 1;
+    } else {
+      collision_checks.at(idx) = 0;
+    }
+  }
+
+  return collision_checks;
+}
+
+EdgeMeasure CollisionChecker::MeasureEdgeCollisionFree(
+    const Eigen::VectorXd& q1, const Eigen::VectorXd& q2) const {
+  return MeasureContextEdgeCollisionFree(
+      &mutable_model_context(), q1, q2);
+}
+
+EdgeMeasure CollisionChecker::MeasureContextEdgeCollisionFree(
+    CollisionCheckerContext* model_context, const Eigen::VectorXd& q1,
+    const Eigen::VectorXd& q2) const {
+  DRAKE_THROW_UNLESS(model_context != nullptr);
+  const double distance = ComputeConfigurationDistance(q1, q2);
+  const int num_steps = static_cast<int>(
+      std::max(1.0, std::ceil(distance / edge_step_size())));
+  double last_valid_ratio = -1.0;
+  for (int step = 0; step <= num_steps; ++step) {
+    const double ratio =
+        static_cast<double>(step) / static_cast<double>(num_steps);
+    const Eigen::VectorXd qinterp =
+        InterpolateBetweenConfigurations(q1, q2, ratio);
+    if (!CheckContextConfigCollisionFree(model_context, qinterp)) {
+      return EdgeMeasure(distance, last_valid_ratio);
+    }
+    last_valid_ratio = ratio;
+  }
+  return EdgeMeasure(distance, 1.0);
+}
+
+EdgeMeasure CollisionChecker::MeasureEdgeCollisionFreeParallel(
+    const Eigen::VectorXd& q1, const Eigen::VectorXd& q2) const {
+  // Only perform parallel operations if omp parallel for will use >1 thread.
+  if (CanEvaluateInParallel()) {
+    const double distance = ComputeConfigurationDistance(q1, q2);
+    const int num_steps = static_cast<int>(
+        std::max(1.0, std::ceil(distance / edge_step_size())));
+    // The "highest" interpolant value, alpha, (uninterrupted from q1) for
+    // which there is no collision.
+    std::atomic<double> alpha;
+    // Start by assuming the whole edge is fine; we'll whittle away at it.
+    alpha.store(1.0);
+    std::mutex alpha_mutex;
+#if defined(_OPENMP)
+#pragma omp parallel for
+#endif
+    for (int step = 0; step <= num_steps; ++step) {
+      const double ratio = step / static_cast<double>(num_steps);
+      // If this step fails, this is the alpha which we would report.
+      const double possible_alpha = (step - 1) / static_cast<double>(num_steps);
+      if (possible_alpha <= alpha.load()) {
+        const Eigen::VectorXd qinterp =
+            InterpolateBetweenConfigurations(q1, q2, ratio);
+        if (!CheckConfigCollisionFree(qinterp)) {
+          std::lock_guard<std::mutex> update_lock(alpha_mutex);
+          // Between the initial decision to interpolate and check collisions
+          // and now, another thread may have proven a *lower* alpha is invalid;
+          // check again before setting *this* as the lowest known invalid step.
+          if (possible_alpha < alpha.load()) {
+            alpha.store(possible_alpha);
+          }
+        }
+      }
+    }
+    return EdgeMeasure(distance, alpha.load());
+  } else {
+    // If OpenMP cannot parallelize, fall back to the serial version.
+    return MeasureEdgeCollisionFree(q1, q2);
+  }
+}
+
+std::vector<EdgeMeasure> CollisionChecker::MeasureEdgesCollisionFree(
+    const std::vector<std::pair<Eigen::VectorXd, Eigen::VectorXd>>& edges,
+    const bool parallelize) const {
+  std::vector<EdgeMeasure> collision_checks(
+      edges.size(), EdgeMeasure(0.0, -1.0));
+
+  const bool check_in_parallel = CanEvaluateInParallel() && parallelize;
+  CRU_OMP_PARALLEL_FOR_IF(check_in_parallel)
+  for (size_t idx = 0; idx < edges.size(); idx++) {
+    const std::pair<Eigen::VectorXd, Eigen::VectorXd>& edge = edges.at(idx);
+    collision_checks.at(idx) =
+        MeasureEdgeCollisionFree(edge.first, edge.second);
+  }
+
+  return collision_checks;
+}
+
+RobotClearance CollisionChecker::CalcRobotClearance(
+    const Eigen::VectorXd& q, const double influence_distance) const {
+  return CalcContextRobotClearance(&mutable_model_context(), q,
+                                      influence_distance);
+}
+
+RobotClearance CollisionChecker::CalcContextRobotClearance(
+    CollisionCheckerContext* model_context, const Eigen::VectorXd& q,
+    const double influence_distance) const {
+  DRAKE_THROW_UNLESS(model_context != nullptr);
+  DRAKE_THROW_UNLESS(influence_distance >= 0.0);
+  DRAKE_THROW_UNLESS(std::isfinite(influence_distance));
+  UpdateContextPositions(model_context, q);
+  auto result = DoCalcContextRobotClearance(*model_context, influence_distance);
+  for (int j : uncontrolled_dofs_that_kinematically_affect_the_robot_) {
+    result.mutable_jacobians().col(j).setZero();
+  }
+  return result;
+}
+
+int CollisionChecker::MaxNumDistances() const {
+  return MaxContextNumDistances(model_context());
+}
+
+int CollisionChecker::MaxContextNumDistances(
+    const CollisionCheckerContext& model_context) const {
+  return DoMaxContextNumDistances(model_context);
+}
+
+std::vector<RobotCollisionType> CollisionChecker::ClassifyBodyCollisions(
+    const Eigen::VectorXd& q) const {
+  return ClassifyContextBodyCollisions(&mutable_model_context(), q);
+}
+
+std::vector<RobotCollisionType> CollisionChecker::ClassifyContextBodyCollisions(
+    CollisionCheckerContext* model_context, const Eigen::VectorXd& q) const {
+  DRAKE_THROW_UNLESS(model_context != nullptr);
+  UpdateContextPositions(model_context, q);
+  return DoClassifyContextBodyCollisions(*model_context);
+}
+
+CollisionChecker::CollisionChecker(CollisionCheckerParams params,
+                                   bool supports_parallel_checking)
+    : setup_model_(move(params.model)),
+      robot_model_instances_([&params]() {
+        // Sort (and de-duplicate) the robot model instances for faster lookups.
+        DRAKE_THROW_UNLESS(params.robot_model_instances.size() > 0);
+        const std::set<ModelInstanceIndex> sorted_set(
+            params.robot_model_instances.begin(),
+            params.robot_model_instances.end());
+        const std::vector<ModelInstanceIndex> sorted_vec(
+            sorted_set.begin(), sorted_set.end());
+        const ModelInstanceIndex world = world_model_instance();
+        for (const auto& robot_model_instance : sorted_vec) {
+          DRAKE_THROW_UNLESS(robot_model_instance != world);
+        }
+        return sorted_vec;
+      }()),
+      uncontrolled_dofs_that_kinematically_affect_the_robot_(
+          CalcUncontrolledDofsThatKinematicallyAffectTheRobot(
+              setup_model_->plant(), robot_model_instances_)),
+      supports_parallel_checking_(supports_parallel_checking) {
+  // Initialize the zero configuration.
+  zero_configuration_ = Eigen::VectorXd::Zero(plant().num_positions());
+  // Initialize the collision padding matrix.
+  collision_padding_ =
+      Eigen::MatrixXd::Zero(plant().num_bodies(), plant().num_bodies());
+  // Set parameters with safety checks.
+  SetConfigurationDistanceFunction(
+      move(params.configuration_distance_function));
+  set_edge_step_size(params.edge_step_size);
+  SetPaddingAllRobotEnvironmentPairs(params.env_collision_padding);
+  SetPaddingAllRobotRobotPairs(params.self_collision_padding);
+  // Generate the default interpolation function.
+  SetConfigurationInterpolationFunction(
+      MakeDefaultConfigurationInterpolationFunction(
+          GetQuaternionDofStartIndices(plant())));
+  // Generate the filtered collision matrix.
+  nominal_filtered_collisions_ = GenerateFilteredCollisionMatrix();
+  filtered_collisions_ = nominal_filtered_collisions_;
+  log()->debug(
+      "Collision filter matrix:\n{}", filtered_collisions_);
+}
+
+CollisionChecker::CollisionChecker(const CollisionChecker&) = default;
+
+void CollisionChecker::AllocateContexts() {
+  DRAKE_THROW_UNLESS(IsInitialSetup());
+  // Move to a const model
+  model_ = move(setup_model_);
+  // Make a diagram & plant context for each thread
+  const int num_omp_threads =
+      common_robotics_utilities::openmp_helpers::GetNumOmpThreads();
+  const int max_num_omp_threads =
+      common_robotics_utilities::openmp_helpers::GetMaxNumOmpThreads();
+  const int omp_thread_limit =
+      common_robotics_utilities::openmp_helpers::GetOmpThreadLimit();
+  const int num_threads = std::max(num_omp_threads, max_num_omp_threads);
+  log()->info(
+      "Allocating contexts to support {} parallel queries given "
+      "omp_num_threads {} omp_max_threads {} and omp_thread_limit {}",
+      num_threads, num_omp_threads, max_num_omp_threads, omp_thread_limit);
+  // Make the prototype context.
+  const std::unique_ptr<CollisionCheckerContext> prototype_context =
+      CreatePrototypeContext();
+  // TODO(rpoyner): DRAKE_DEMAND() instead?
+  DRAKE_THROW_UNLESS(prototype_context != nullptr);
+  owned_contexts_.AllocateOwnedContexts(*prototype_context, num_threads);
+}
+
+void CollisionChecker::OwnedContextKeeper::AllocateOwnedContexts(
+    const CollisionCheckerContext& prototype_context,
+    const int num_contexts) {
+  DRAKE_THROW_UNLESS(num_contexts >= 1);
+  DRAKE_THROW_UNLESS(empty());
+  for (int index = 0; index < num_contexts; ++index) {
+    model_contexts_.emplace_back(prototype_context.Clone());
+  }
+  prototype_context_ = prototype_context.Clone();
+}
+
+bool CollisionChecker::CanEvaluateInParallel() const {
+  return SupportsParallelChecking() &&
+      common_robotics_utilities::openmp_helpers::GetNumOmpThreads() > 1;
+}
+
+std::string CollisionChecker::CriticizePaddingMatrix() const {
+  return CriticizePaddingMatrix(collision_padding_, __func__);
+}
+
+CollisionCheckerContext& CollisionChecker::mutable_model_context() const {
+  return mutable_model_context_by_index(
+      common_robotics_utilities::openmp_helpers::GetContextOmpThreadNum());
+}
+
+void CollisionChecker::ValidateFilteredCollisionMatrix(
+    const Eigen::MatrixXi& filtered, const char* func) const {
+  DRAKE_THROW_UNLESS(filtered.rows() == filtered.cols());
+  const int count = filtered.rows();
+  // TODO(sean.curtis): These messages have the prefix CollisionChecker.
+  // Consider whether that should be replaced with NiceTypeName::Get(*this).
+  // Loop counters below use `int` for Eigen indexing compatibility.
+  for (int i = 0; i < count; ++i) {
+    if (filtered(i, i) != -1) {
+      throw std::logic_error(fmt::format(
+          "CollisionChecker::{}(): The filtered collision matrix has invalid "
+          "values on the diagonal ({}, {}) = {}; the values on the diagonal "
+          "must always be -1.",
+          func, i, i, filtered(i, i)));
+    }
+
+    const bool i_is_robot = IsPartOfRobot(BodyIndex(i));
+    for (int j = i + 1; j < count; ++j) {
+      const bool pair_has_robot = i_is_robot || IsPartOfRobot(BodyIndex(j));
+      // Both are environment bodies.
+      if (!pair_has_robot && filtered(i, j) != -1) {
+        throw std::logic_error(fmt::format(
+            "CollisionChecker::{}(): The filtered collision matrix must "
+            "contain -1 for pairs of environment bodies. Found {} at ({}, {}).",
+            func, filtered(i, j), i, j));
+      }
+      // Values must lie in the range [-1, 1].
+      if (filtered(i, j) > 1 || filtered(i, j) < -1) {
+        throw std::logic_error(fmt::format(
+            "CollisionChecker::{}(): The filtered collision matrix must "
+            "contain values that are 0, 1, or -1. Found {} at ({}, {}).",
+            func, filtered(i, j), i, j));
+      }
+      // Matrix must be symmetric.
+      if (filtered(i, j) != filtered(j, i)) {
+        throw std::logic_error(fmt::format(
+            "CollisionChecker::{}(): The filtered collision matrix must be "
+            "symmetric. Values at ({}, {}) and ({}, {}) are not equal; "
+            "{} != {}.",
+            func, i, j, j, i, filtered(i, j), filtered(j, i)));
+      }
+      // (Body, *) pairs cannot have -1.
+      if (filtered(i, j) < 0 && pair_has_robot) {
+        throw std::logic_error(fmt::format(
+            "CollisionChecker::{}(): The filtered collision matrix can only be "
+            "1 or 0 for a pair with a robot body ({}, {}), found {}.",
+            func, i, j, filtered(i, j)));
+      }
+    }
+  }
+}
+
+Eigen::MatrixXi CollisionChecker::GenerateFilteredCollisionMatrix() const {
+  const int num_bodies = plant().num_bodies();
+  // Initialize matrix to zero (no filtered collisions).
+  Eigen::MatrixXi filtered_collisions =
+      Eigen::MatrixXi::Zero(num_bodies, num_bodies);
+
+  const auto& inspector = model().scene_graph().model_inspector();
+
+  // For consistency, (B, B) is always filtered.
+  // Loop variables below use `int` for Eigen indexing compatibility.
+  for (int i = 0; i < num_bodies; ++i) {
+    filtered_collisions(i, i) = -1;
+    const bool i_is_robot = IsPartOfRobot(BodyIndex(i));
+
+    const Body<double>& body_i = get_body(BodyIndex(i));
+    const std::vector<GeometryId>& geometries_i =
+        plant().GetCollisionGeometriesForBody(body_i);
+
+    for (int j = i + 1; j < num_bodies; ++j) {
+      const bool j_is_robot = IsPartOfRobot(BodyIndex(j));
+      // (Env, env) pairs are immutably filtered (marked -1).
+      if (!(i_is_robot || j_is_robot)) {
+        filtered_collisions(i, j) = -1;
+        filtered_collisions(j, i) = -1;
+        continue;
+      }
+
+      const Body<double>& body_j = get_body(BodyIndex(j));
+      log()->debug(
+          "Checking if collision is filtered between {} [{}] and {} [{}]",
+          GetScopedName(body_i), i, GetScopedName(body_j), j);
+
+      // Check if collisions between the geometries_i are already filtered.
+      bool collisions_filtered = false;
+      const std::vector<GeometryId>& geometries_j =
+          plant().GetCollisionGeometriesForBody(body_j);
+      if (geometries_i.size() > 0 && geometries_j.size() > 0) {
+        collisions_filtered =
+            inspector.CollisionFiltered(geometries_i.at(0), geometries_j.at(0));
+        // Ensure that the collision filtering is consistent
+        for (const auto& id_i : geometries_i) {
+          for (const auto& id_j : geometries_j) {
+            const bool current_filtered =
+                inspector.CollisionFiltered(id_i, id_j);
+            if (current_filtered != collisions_filtered) {
+              throw std::runtime_error(fmt::format(
+                  "Collision filtering between body {} [{}] and body {} "
+                  "[{}] is inconsistent",
+                  GetScopedName(body_i), i, GetScopedName(body_j), j));
+            }
+          }
+        }
+      }
+
+      // TODO(sean.curtis) Since #16920 MbP has introduced collision filters
+      //  for welded sub-graphs. This is possibly redundant. Currently, this
+      //  will *replace* collision filters even if SceneGraph erases them
+      //  post finalize. Presumably, that's not the *intent*. This probably
+      //  exists because these welded subgraphs weren't previously handled.
+      //  We can probably remove this logic and simply say, "the nominal
+      //  filters" merely reflect the state of SceneGraph's collision filters
+      //  and be done.
+
+      // If the body pair has a welded path between them, it should be filtered.
+      bool bodies_welded_together = false;
+      for (const auto* welded_body : plant().GetBodiesWeldedTo(body_j)) {
+        if (welded_body->index() == i) {
+          bodies_welded_together = true;
+          break;
+        }
+      }
+
+      // Add the filter accordingly.
+      if (collisions_filtered) {
+        // Filter the collision
+        log()->debug(
+            "Collision between body {} [{}] and body {} [{}] filtered "
+            "(filtered in SceneGraph)",
+            GetScopedName(body_i), i, GetScopedName(body_j), j);
+        filtered_collisions(i, j) = 1;
+        filtered_collisions(j, i) = 1;
+      } else if (bodies_welded_together) {
+        // Filter the collision
+        log()->debug(
+            "Collision between body {} [{}] and body {} [{}] filtered "
+            "(bodies are welded together)",
+            GetScopedName(body_i), i, GetScopedName(body_j), j);
+        filtered_collisions(i, j) = 1;
+        filtered_collisions(j, i) = 1;
+      } else {
+        log()->debug(
+            "Collision between body {} [{}] and body {} [{}] not filtered",
+            GetScopedName(body_i), i, GetScopedName(body_j), j);
+      }
+    }
+  }
+  return filtered_collisions;
+}
+
+void CollisionChecker::ValidatePaddingMatrix(
+    const Eigen::MatrixXd& padding, const char* func) const {
+  const std::string criticism = CriticizePaddingMatrix(padding, func);
+  if (!criticism.empty()) {
+    throw std::logic_error(criticism);
+  }
+}
+
+std::string CollisionChecker::CriticizePaddingMatrix(
+    const Eigen::MatrixXd& padding, const char* func) const {
+  if (padding.rows() != padding.cols()) {
+    return fmt::format(
+        "CollisionChecker::{}(): The padding"
+        " matrix must be square. The given padding matrix is the"
+        " wrong shape: {}x{}.",
+        func, padding.rows(), padding.cols());
+  }
+  const int count = padding.rows();
+  // TODO(sean.curtis): These messages have the prefix CollisionChecker.
+  // Consider whether that should be replaced with NiceTypeName::Get(*this).
+  // Loop variables below use `int` for Eigen indexing compatibility.
+  for (int i = 0; i < count; ++i) {
+    if (padding(i, i) != 0.0) {
+      return fmt::format(
+          "CollisionChecker::{}(): The collision padding matrix has invalid "
+          "values on the diagonal ({}, {}) = {}; the values on the diagonal "
+          "must always be 0.",
+          func, i, i, padding(i, i));
+    }
+
+    const bool i_is_robot = IsPartOfRobot(BodyIndex(i));
+    for (int j = i + 1; j < count; ++j) {
+      const bool pair_has_robot = i_is_robot || IsPartOfRobot(BodyIndex(j));
+      // Both are environment bodies.
+      if (!pair_has_robot && padding(i, j) != 0.0) {
+        return fmt::format(
+            "CollisionChecker::{}(): The collision padding matrix must contain "
+            "0 for pairs of environment bodies. Found {} at ({}, {}).",
+            func, padding(i, j), i, j);
+      }
+      // Values must be finite.
+      if (!std::isfinite(padding(i, j))) {
+        return fmt::format(
+            "CollisionChecker::{}(): The collision padding matrix must contain "
+            "finite values. Found {} at ({}, {}).",
+            func, padding(i, j), i, j);
+      }
+      // Matrix must be symmetric.
+      if (padding(i, j) != padding(j, i)) {
+        return fmt::format(
+            "CollisionChecker::{}(): The collision padding matrix must be "
+            "symmetric. Values at ({}, {}) and ({}, {}) are not equal; "
+            "{} != {}.",
+            func, i, j, j, i, padding(i, j), padding(j, i));
+      }
+    }
+  }
+  return {};
+}
+
+void
+CollisionChecker::OwnedContextKeeper::PerformOperationAgainstAllOwnedContexts(
+    const RobotDiagram<double>& model,
+    const std::function<void(
+        const RobotDiagram<double>&,
+        CollisionCheckerContext*)>& operation) {
+  DRAKE_THROW_UNLESS(allocated());
+  for (auto& model_context : model_contexts_) {
+    operation(model, model_context.get());
+  }
+  operation(model, prototype_context_.get());
+}
+
+void CollisionChecker::StandaloneContextReferenceKeeper
+        ::PerformOperationAgainstAllStandaloneContexts(
+    const RobotDiagram<double>& model,
+    const std::function<void(
+        const RobotDiagram<double>&,
+        CollisionCheckerContext*)>& operation) {
+  std::lock_guard<std::mutex> lock(standalone_contexts_mutex_);
+  for (auto standalone_context = standalone_contexts_.begin();
+        standalone_context != standalone_contexts_.end();) {
+    auto maybe_context = standalone_context->lock();
+    if (maybe_context != nullptr) {
+      operation(model, maybe_context.get());
+      // Advance to next item.
+      ++standalone_context;
+    } else {
+      // If the pointed-to context is no longer alive, remove it.
+      // Note that erase() returns the iterator to the next item.
+      standalone_context = standalone_contexts_.erase(standalone_context);
+    }
+  }
+}
+
+}  // namespace planning
+}  // namespace anzu

--- a/planning/collision_checker.h
+++ b/planning/collision_checker.h
@@ -1,0 +1,1409 @@
+#pragma once
+
+#include <list>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_throw.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/planning/body_shape_description.h"
+#include "drake/planning/collision_checker_context.h"
+#include "drake/planning/collision_checker_params.h"
+#include "drake/planning/robot_clearance.h"
+#include "planning/edge_measure.h"
+#include "planning/robot_collision_type.h"
+#include "planning/robot_diagram.h"
+
+namespace anzu {
+namespace planning {
+
+/** Interface for collision checkers to use.
+
+ <!-- TODO(SeanCurtis-TRI): This documentation focuses on the context management
+  aspect of this class. We need to extend the documentation to give a broader
+  overview of the class. The goal is to give sufficient context that they'd know
+  what kind of nail this is a hammer for and how to swing it. Topics include,
+  but are not limited to:
+
+    - Emphasis that everything is characterized w.r.t. *robot* bodies.
+      Distinguish the terms "full model" (robot and environment), "robot" or
+      "robot model", and "environment bodies".
+    - Performing collision queries
+      - individual configurations
+      - "edges"
+      - Clearance
+    - Padding
+    - Collision filtering
+    - Adding additional collision geometries.
+    - Clear guidance on the minimal acts that constitute correct usage. E.g.,
+      do I have to call `AllocateContexts()`? When should I not? etc.
+    - Clear delineation of serial queries that can be performed in parallel and
+      queries that themselves parallelize and guidance on not mixing them.
+  -->
+
+ This interface builds on the basic multi-threading idiom of Drake: one context
+ per thread. It offers two models to achieve multi-threaded parallel collision
+ checking:
+
+ - using OpenMP thread pools and "implicit contexts" managed by this object
+ - using arbitrary threads and "explicit contexts" created by this object
+
+ @anchor ccb_implicit_contexts
+ <h4>Implicit Context Parallelism</h4>
+
+ Many methods of this class aren't designed for entry from arbitrary threads
+ (e.g. from std::async threads), but rather are designed for use with a main
+ thread and various thread-pool-parallel operations achieved by using
+ directives like `omp parallel`. To support this usage, the base class
+ `AllocateContexts()` protected method establishes a pool of contexts, one per
+ OMP thread. `AllocateContexts()` must be called and only be called as part of
+ the constructor of a derived class defined as final.
+
+ Once the context pool is created, clients can access a thread-associated
+ context by using `model_context()` and related methods. The association
+ between thread and context uses the OpenMP notion of thread number. As a
+ result, these context access methods are only safe under the following
+ conditions:
+
+ - the caller is the "main thread"
+ - the caller is an OMP team thread *during execution of a parallel region*
+
+ Methods supporting implicit context parallelism are noted below by having a
+ reference to this section.
+
+ Users of this class (derived classes and others) can write their own parallel
+ operations using implicit contexts, provided they use OpenMP directives and
+ limit parallel blocks to only use `const` methods or methods marked to support
+ implicit contexts parallelism.
+
+ <!-- TODO(calderpg, rick-poyner) Add OpenMP for-loop example once drakelint
+      supports OpenMP pragmas in docs.  -->
+
+ @anchor ccb_explicit_contexts
+ <h4>Explicit Context Parallelism</h4>
+
+ It is also possible to use arbitrary thread models to perform collision
+ checking in parallel using explicitly-created contexts from this class.
+ Contexts returned from MakeStandaloneModelContext() may be used in any thread,
+ using only `const` methods of this class, or "explicit context" methods.
+
+ Explicit contexts are tracked by this class using `std::weak_ptr` to track
+ their lifetimes. This mechanism is used by
+ PerformOperationAgainstAllModelContexts to map an operation over all collision
+ contexts, whether explicit or implicit.
+
+ Methods supporting explicit context parallelism are noted below by having a
+ reference to this section.
+
+ In practice, multi-threaded collision checking with explicit contexts may look
+ something like the example below.
+
+ @code
+ const Eigen::VectorXd start_q ...
+ const Eigen::VectorXd sample_q1 ...
+ const Eigen::VectorXd sample_q2 ...
+
+ const auto check_edge_to = [&collision_checker, &start_q] (
+     const Eigen::VectorXd& sample_q,
+     CollisionCheckerContext* explicit_context) {
+   return collision_checker.CheckContextEdgeCollisionFree(
+       explicit_context, start_q, sample_q);
+ };
+
+ const auto context_1 = collision_checker.MakeStandaloneModelContext();
+ const auto context_2 = collision_checker.MakeStandaloneModelContext();
+
+ auto future_q1 = std::async(std::launch::async, check_edge_to, sample_q1,
+                             context_1.get());
+ auto future_q2 = std::async(std::launch::async, check_edge_to, sample_q2,
+                             context_2.get());
+
+ const double edge_1_valid = future_q1.get();
+ const double edge_2_valid = future_q2.get();
+ @endcode
+
+ <h4>>Mixing Threading Models</h4>
+
+ It is possible to support mixed threading models, i.e. using both OpenOMP
+ thread pools and arbitrary threads. In this case, each arbitrary thread (say,
+ from std::async) should have its own instance of a collision checker made using
+ Clone(). Then each arbitrary thread will have its own implicit context pool.
+
+ <h4>Implementing Derived Classes</h4>
+
+ Collision checkers deriving from CollisionChecker *must* support parallel
+ operations from both of the above parallelism models. This is generally
+ accomplished by placing all mutable state within the per-thread context. If
+ this cannot be accomplished, the shared mutable state must be accessed in a
+ thread-safe manner. There are APIs that depend on SupportsParallelChecking()
+ (e.g., CheckConfigsCollisionFree(), CheckEdgeCollisionFreeParallel(),
+ CheckEdgesCollisionFree(), etc); a derived implementation should return `false`
+ from SupportsParallelChecking() if there is no meaningful benefit to attempting
+ to do work in parallel (e.g., they must fully serialize on shared state).
+ */
+class CollisionChecker {
+ public:
+  // N.B. The copy constructor is protected for use in implementing Clone().
+  /** @name     Does not allow copy, move, or assignment. */
+  //@{
+
+  CollisionChecker(CollisionChecker&&) = delete;
+  CollisionChecker& operator=(const CollisionChecker&) = delete;
+  CollisionChecker& operator=(CollisionChecker&&) = delete;
+  //@}
+
+  virtual ~CollisionChecker();
+
+  std::unique_ptr<CollisionChecker> Clone() const { return DoClone(); }
+
+  /** @name Robot Model
+
+   These methods all provide access to the underlying robot model's contents. */
+  //@{
+
+  /** @returns a `const` reference to the full model. */
+  const RobotDiagram<double>& model() const {
+    if (IsInitialSetup()) {
+      return *setup_model_;
+    } else {
+      DRAKE_DEMAND(model_ != nullptr);
+      return *model_;
+    }
+  }
+
+  /** @returns a `const reference to the full model's plant. */
+  const drake::multibody::MultibodyPlant<double>& plant() const {
+    return model().plant();
+  }
+
+  /** @returns a `const` body reference to a body in the full model's plant for
+   the given `body_index`. */
+  const drake::multibody::Body<double>& get_body(
+      drake::multibody::BodyIndex body_index) const {
+    return plant().get_body(body_index);
+  }
+
+  // TODO(SeanCurtis-TRI): Ideally, these utilities do not belong to the
+  // checker. They don't use the collision checker's API or data. It's MbP sugar
+  // that belongs with MbP sugar.
+  // TODO(rpoyner-tri): reference to discussion of scoped names?
+  /** Gets the scoped name for a frame within the full model. */
+  std::string GetScopedName(const drake::multibody::Frame<double>& frame) const;
+
+  /** Gets the scoped name for a body within the full model. */
+  std::string GetScopedName(const drake::multibody::Body<double>& body) const;
+
+  /** Gets the set of model instances belonging to the robot. The returned
+   vector has no duplicates and is in sorted order. */
+  const std::vector<drake::multibody::ModelInstanceIndex>&
+  robot_model_instances() const { return robot_model_instances_; }
+
+  /** @returns true if the indicated body is part of the robot. */
+  bool IsPartOfRobot(const drake::multibody::Body<double>& body) const;
+
+  /** @returns true if the indicated body is part of the robot. */
+  bool IsPartOfRobot(drake::multibody::BodyIndex body_index) const;
+
+  /** @returns a generalized position vector, sized according to the full model,
+   whose values are all zero.
+   @warning A zero vector is not necessarily a valid configuration, e.g., in
+   case the configuration has quaternions, or position constraints, or etc. */
+  const Eigen::VectorXd& GetZeroConfiguration() const {
+    return zero_configuration_;
+  }
+
+  //@}
+
+  /** @name Context management */
+  //@{
+
+  /** @returns the number of internal (not standalone) per-thread contexts. */
+  int num_allocated_contexts() const {
+    return owned_contexts_.num_contexts();
+  }
+
+  /** @returns a `const` reference to the collision checking context to be used
+   with the current thread.
+   @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
+  const drake::planning::CollisionCheckerContext& model_context() const;
+
+  // TODO(jeremy.nimmer) This is only lightly used, maybe we should toss it?
+  /** @returns a `const` reference to the multibody plant sub-context within
+   the context for the current thread.
+   @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
+  const drake::systems::Context<double>& plant_context() const {
+    return model_context().plant_context();
+  }
+
+  /** Updates the generalized positions `q` in the current thread's associated
+   context, and returns a reference to the MultibodyPlant's now-updated context.
+   @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
+  const drake::systems::Context<double>&
+  UpdatePositions(const Eigen::VectorXd& q) const {
+    return UpdateContextPositions(&mutable_model_context(), q);
+  }
+
+  /** Explicit Context-based version of UpdatePositions().
+   @throws std::exception if `model_context` is `nullptr`.
+   @see @ref ccb_explicit_contexts "Explicit Context Parallelism". */
+  const drake::systems::Context<double>& UpdateContextPositions(
+      drake::planning::CollisionCheckerContext* model_context,
+      const Eigen::VectorXd& q) const {
+    DRAKE_THROW_UNLESS(model_context != nullptr);
+    plant().SetPositions(&model_context->mutable_plant_context(), q);
+    DoUpdateContextPositions(model_context);
+    return model_context->plant_context();
+  }
+
+  /** Make and track a CollisionCheckerContext. The returned context will
+   participate in PerformOperationAgainstAllModelContexts() until it is
+   destroyed. */
+  std::shared_ptr<drake::planning::CollisionCheckerContext>
+  MakeStandaloneModelContext() const;
+
+  /** Allows externally-provided operations that must be performed against all
+   contexts in the per-thread context pool, and any standalone contexts made
+   with MakeStandaloneModelContext(). */
+  void PerformOperationAgainstAllModelContexts(
+      const std::function<void(const RobotDiagram<double>&,
+                               drake::planning::CollisionCheckerContext*)>&
+          operation);
+
+  //@}
+
+  /** @name Adding geometries to a body
+
+   While the underlying model will have some set of geometries to represent
+   each body, it can be useful to extend the representative set of geometries.
+   These APIs admit adding and removing such geometries to the underlying model.
+   We'll distinguish the geometries added by the checker from those in the
+   underlying model by referring to them as "checker" geometries and "model"
+   geometries, respectively.
+
+   For example, when an end effector has successfully grasped a manipuland,
+   we can add additional geometry to the end effector body, representing the
+   extent of the manipuland, causing the motion planning to likewise consider
+   collisions with the manipuland. Note, this implicitly treats the manipuland
+   as being rigidly affixed to the end effector.
+
+   Checker geometries are managed in groups, identified by "group names". Each
+   group can contain one or more checker geometries. This is particularly useful
+   when multiple geometries should be added and removed as a whole. Simply by
+   storing the shared group name, all checker geometries in the group can be
+   removed with a single invocation, relying on the collision checker to do
+   the book keeping for you.
+
+   Note that different collision checker implementations may limit the set of
+   supported Shape types; e.g. sphere-robot-model collision checkers only add
+   sphere shapes to robot bodies, and voxel-based collision checkers cannot add
+   individual collision geometries to the environment at all. Therefore, all
+   methods for adding collision geometries report if the geometries were added.
+   The derived classes should clearly document which shapes they support. */
+  //@{
+
+  // TODO(sean.curtis): These BodyShapeDescription APIs are not used. Just cut
+  //  them?
+
+  // TODO(sean.curtis): Make these functions [[nodiscard]].
+
+  /** Requests the addition of a shape to a body, both given in `description`.
+   If added, the shape will belong to the named geometry group.
+
+   @param group_name    The name of the group to add the geometry to.
+   @param description   The data describing the shape and target body.
+   @returns `true` if the shape was added. */
+  bool AddCollisionShape(
+      const std::string& group_name,
+      const drake::planning::BodyShapeDescription& description);
+
+  // TODO(sean.curtis): Convert this to a simple `bool` return; either all of
+  //  the shapes were accepted or none were.
+  /** Requests the addition of N shapes to N bodies, each given in the set of
+   `descriptions`. Each added shape will belong to the named geometry group.
+
+   @param group_name    The name of the group to add the geometry to.
+   @param descriptions  The descriptions of N (shape, body) pairs.
+   @returns The total number of shapes in `descriptions` that got added. */
+  int AddCollisionShapes(
+      const std::string& group_name,
+      const std::vector<drake::planning::BodyShapeDescription>& descriptions);
+
+  /** Requests the addition of a collection of shapes to bodies across multiple
+   geometry groups. `geometry_groups` specifies a collection of (shape, body)
+   descriptors across multiple geometry groups.
+
+   @param geometry_groups   A map from a named geometry group to the
+                            (shape, body) pairs to add to that group.
+   @returns A map from input named geometry group to the *number* of geometries
+            added to that group. */
+  std::map<std::string, int> AddCollisionShapes(
+      const std::map<std::string,
+                     std::vector<drake::planning::BodyShapeDescription>>&
+          geometry_groups);
+
+  /** Requests the addition of `shape` to the frame A in the checker's model.
+   The added `shape` will belong to the named geometry group.
+
+   @param group_name    The name of the group to add the geometry to.
+   @param frameA        The frame the shape should be rigidly affixed to.
+   @param shape         The requested shape, defined in its canonical frame G.
+   @param X_AG          The pose of the shape in the frame A.
+   @returns `true` if the shape was added. */
+  bool AddCollisionShapeToFrame(
+      const std::string& group_name,
+      const drake::multibody::Frame<double>& frameA,
+      const drake::geometry::Shape& shape,
+      const drake::math::RigidTransform<double>& X_AG);
+
+  /** Requests the addition of `shape` to the body A in the checker's model
+   The added `shape` will belong to the named geometry group.
+
+   @param group_name    The name of the group to add the geometry to.
+   @param bodyA         The body the shape should be rigidly affixed to.
+   @param shape         The requested shape, defined in its canonical frame G.
+   @param X_AG          The pose of the shape in body A's frame.
+   @returns `true` if the shape was added. */
+  bool AddCollisionShapeToBody(const std::string& group_name,
+                               const drake::multibody::Body<double>& bodyA,
+                               const drake::geometry::Shape& shape,
+                               const drake::math::RigidTransform<double>& X_AG);
+
+  /** Gets all checker geometries currently added across the whole checker.
+   @returns A mapping from each geometry group name to the collection of
+            (shape, body) descriptions in that group. */
+  std::map<std::string, std::vector<drake::planning::BodyShapeDescription>>
+  GetAllAddedCollisionShapes() const;
+
+  // TODO(sean.curtis): Consider returning the total number of geometries
+  //  deleted; here and for "remove all".
+
+  /** Removes all added checker geometries which belong to the named group. */
+  void RemoveAllAddedCollisions(const std::string& group_name);
+
+  /** Removes all added checker geometries from all geometry groups. */
+  void RemoveAllAddedCollisions();
+
+  //@}
+
+  /** @name Padding the distance between bodies
+
+   Ultimately, the model's bodies are represented with geometries. The distance
+   between bodies is the distance between their representative geometries.
+   However, the exact distance between those geometries is not necessarily
+   helpful in planning. For example,
+
+     - The disparity between simulation geometry and real world objects
+       may be such that the distance isn't sufficiently conservative.
+     - In some cases, limited penetration is expected, and possibly desirable,
+       such as when grasping in clutter.
+
+   Padding is a mechanism where these distances can be "fudged" without
+   modifying the underlying model. The *reported* distance between two bodies
+   can be decreased by adding *positive* padding or increased by adding
+   *negative* padding. One could think of it as padding the geometries -- making
+   the objects larger (positive) or smaller (negative). This isn't quite true.
+   Padding is defined for *pairs* of geometries.
+
+   Ultimately, the padding data is stored in an NxN matrix (where the underlying
+   model has N total bodies). The matrix is symmetric and the entry at (i, j) --
+   and (j, i) -- is the padding value to be applied to distance measurements
+   between bodies i and j.
+
+   <h3>Configuring padding</h3>
+
+   <!-- TODO(sean.curtis): We have a function for setting the padding between
+    one robot body and *all* environment bodies, but not between a robot body
+    and all *other* robot bodies. This apparent hole is only due to the
+    judgement that it wouldn't be helpful. If we have a use case that would
+    benefit, we can add it. -->
+
+   Padding can be applied at different levels of scope:
+
+     - For all pairs, via SetPaddingMatrix().
+     - For all (robot, environment) or (robot, robot) pairs via
+       SetPaddingAllRobotEnvironmentPairs() and SetPaddingAllRobotRobotPairs().
+     - For all (robot i, environment) pairs via
+       SetPaddingOneRobotBodyAllEnvironmentPairs().
+     - For pair (body i, body j) via SetPaddingBetween().
+
+   Invocations of these methods make immediate changes to the underlying padding
+   data. Changing the order of invocations will change the final padding state.
+   In other words, setting padding for a particular pair (A, B) followed by
+   calling, for example, SetPaddingOneRobotBodyAllEnvironmentPairs(A) could
+   erase the effect of the first invocation.
+
+   @anchor collision_checker_padding_prereqs
+   <h4>Configuration prerequisites</h4>
+   In all these configuration methods, there are some specific requirements:
+
+     - The padding value must always be finite.
+     - Body indices must be in range (i.e., in [0, N) for a model with N
+       total bodies).
+     - If the parameters include one or more more body indices, at least one of
+       them must reference a robot body.
+     - Padding values must be *finite* values.
+
+   <h3>Introspection</h3>
+
+   The current state of collision padding can be introspected via a number of
+   methods:
+
+     - View the underlying NxN padding matrix via GetPaddingMatrix().
+     - Find out if padding values are heterogeneous via
+       MaybeGetUniformRobotEnvironmentPadding() and
+       MaybeGetUniformRobotRobotPadding().
+     - Query the specific padding value between a pair of bodies via
+       GetPaddingBetween().
+     - Find out the maximum defined padding value via GetLargestPadding().
+  */
+  //@{
+
+  /** If the padding between all robot bodies and environment bodies is the
+   same, return the common padding value. Returns nullopt otherwise. */
+  std::optional<double> MaybeGetUniformRobotEnvironmentPadding() const;
+
+  /** If the padding between all pairs of robot bodies is the same, returns
+   the common padding value. Returns nullopt otherwise. */
+  std::optional<double> MaybeGetUniformRobotRobotPadding() const;
+
+  /** Gets the padding value for the pair of bodies specified.
+   @throws std::exception if either body index is out of range. */
+  double GetPaddingBetween(drake::multibody::BodyIndex bodyA_index,
+                           drake::multibody::BodyIndex bodyB_index) const {
+    DRAKE_THROW_UNLESS(
+        bodyA_index >= 0 && bodyA_index < collision_padding_.rows());
+    DRAKE_THROW_UNLESS(
+        bodyB_index >= 0 && bodyB_index < collision_padding_.rows());
+    return collision_padding_(int{bodyA_index}, int{bodyB_index});
+  }
+
+  /** Overload that uses body references. */
+  double GetPaddingBetween(const drake::multibody::Body<double>& bodyA,
+                           const drake::multibody::Body<double>& bodyB) const {
+    return GetPaddingBetween(bodyA.index(), bodyB.index());
+  }
+
+  /** Sets the padding value for the pair of bodies specified.
+   @throws std::exception if the @ref collision_checker_padding_prereqs
+           "configuration prerequisites" are not met or `bodyA_index ==
+           bodyB_index`. */
+  void SetPaddingBetween(drake::multibody::BodyIndex bodyA_index,
+                         drake::multibody::BodyIndex bodyB_index,
+                         double padding);
+
+  /** Overload that uses body references. */
+  void SetPaddingBetween(const drake::multibody::Body<double>& bodyA,
+                         const drake::multibody::Body<double>& bodyB,
+                         double padding) {
+    SetPaddingBetween(bodyA.index(), bodyB.index(), padding);
+  }
+
+  /** Gets the collision padding matrix. */
+  const Eigen::MatrixXd& GetPaddingMatrix() const {
+    return collision_padding_;
+  }
+
+  /** Sets the collision padding matrix. Note that this matrix contains all
+   padding data, both robot-robot "self" padding, and robot-environment padding.
+   `collision_padding` must have the following properties to be considered
+   valid.
+
+     - It is a square NxN matrix (where N is the total number of bodies).
+     - Diagonal values are all zero.
+     - Entries involving only environment bodies are all zero.
+     - It is symmetric.
+     - All values are finite.
+
+   @throws std::exception if `collision_padding` doesn't have the enumerated
+           properties. */
+  void SetPaddingMatrix(const Eigen::MatrixXd& collision_padding);
+
+  /** Gets the current largest collision padding across all body pairs. */
+  double GetLargestPadding() const {
+    return max_collision_padding_;
+  }
+
+  /** Sets the environment collision padding for the provided robot body with
+   respect to all environment bodies.
+   @throws std::exception if the @ref collision_checker_padding_prereqs
+           "configuration prerequisites" are not met. */
+  void SetPaddingOneRobotBodyAllEnvironmentPairs(
+      drake::multibody::BodyIndex body_index, double padding);
+
+  /** Sets the padding for all (robot, environement) pairs.
+   @throws std::exception if the @ref collision_checker_padding_prereqs
+           "configuration prerequisites" are not met. */
+  void SetPaddingAllRobotEnvironmentPairs(double padding);
+
+  /** Sets the padding for all (robot, robot) pairs.
+   @throws std::exception if the @ref collision_checker_padding_prereqs
+           "configuration prerequisites" are not met. */
+  void SetPaddingAllRobotRobotPairs(double padding);
+
+  //@}
+
+  /** @name Collision filtering
+
+   The %CollisionChecker adapts the idea of "collision filtering" to *bodies*
+   (see drake::geometry::CollisionFilterManager). In addition to whatever
+   collision filters have been declared within the underlying model,
+   %CollisionChecker provides mechanisms to layer *additional* filters by
+   specifying a pair of bodies as being "filtered". No collisions or
+   distance measurements are reported on filtered body pairs.
+
+   The "filter" state of all possible body pairs are stored in an NxN
+   integer-valued matrix, where N is the number of bodies reported by the
+   plant owned by this collision checker.
+
+   The matrix can only contain one of three values: 0, 1, and -1. For the
+   (i, j) entry in the matrix, each value would be interpreted as follows:
+
+     0: The collision is *not* filtered. Collision checker will report
+        collisions and clearance between bodies I and J.
+     1: The collision *is* filtered. Collision checker will *not* report
+        collisions and clearance between bodies I and J.
+    -1: The collision *is* filtered *by definition*. Collision checker will
+        *not* report collisions and clearance between bodies I and J and
+        the user cannot change this state.
+
+   CollisionChecker limits itself to characterizing the state of the *robot*.
+   As such, it *always* filters collisions between pairs of environment
+   bodies. It also filters collisions between a body and itself as nonsensical.
+   Therefore, the matrix will always have immutable -1s along the diagonal and
+   for every cell representing an environment-environment pair.
+
+   The collision filter matrix must remain *consistent*. Only valid values
+   for body pairs are accepted. I.e., assigning an (environment, environment)
+   pair a value of 0 or 1 is "inconsistent". Likewise doing the same on the
+   diagonal. Alternatively, assigning a -1 to any pair with a robot body
+   would be inconsistent. The functions for configuring collision filters
+   will throw if explicitly asked to make an inconsistent change.
+
+   The %CollisionChecker's definition of filtered body pairs is initially
+   drawn from the underlying model's configuration (see
+   GetNominalFilteredCollisionMatrix()). However, the CollisionChecker's
+   definition of the set of collision filters is independent of the model after
+   construction and can be freely modified to allow for greater freedom
+   in determining which bodies can affect each other. */
+  //@{
+
+  /** Returns the "nominal" collision filter matrix. The nominal matrix is
+   initialized at construction time and represents the configuration of the
+   model's plant and scene graph. It serves as a reference point to assess
+   any changes to collision filters beyond this checker's intrinsic model.
+
+   Collisions between bodies A and B are filtered in the following cases:
+
+     - There exists a welded path between A and B.
+     - SceneGraph has filtered the collisions between *all* pairs of geometries
+       of A and B.
+
+   Note: SceneGraph allows arbitrary collision filter configuration at the
+   *geometry* level. The filters on one geometry of body need not be the same
+   as another geometry on the same body. %CollisionChecker is body centric.
+   It requires all geometries on a body to be filtered homogeneously. A
+   SceneGraph that violates this stricter requirement cannot be used in
+   a %CollisionChecker. It is highly unlikely that a SceneGraph instance
+   will ever be in this configuration by accident. */
+  const Eigen::MatrixXi& GetNominalFilteredCollisionMatrix() const {
+    return nominal_filtered_collisions_;
+  }
+
+  /** Gets the "active" collision filter matrix. */
+  const Eigen::MatrixXi& GetFilteredCollisionMatrix() const {
+    return filtered_collisions_;
+  }
+
+  /** Sets the "active" collision filter matrix
+   @param filter_matrix must meet the above conditions to be a "consistent"
+                        collision filter matrix.
+   @throws std::exception if the given matrix is incompatible with this
+                          collision checker, or if it is inconsistent. */
+  void SetCollisionFilterMatrix(const Eigen::MatrixXi& filter_matrix);
+
+  /** Checks if collision is filtered between the two bodies specified.
+   Note: collision between two environment bodies is *always* filtered.
+   @throws std::exception if either body index is out of range. */
+  bool IsCollisionFilteredBetween(
+      drake::multibody::BodyIndex bodyA_index,
+      drake::multibody::BodyIndex bodyB_index) const;
+
+  /** Overload that uses body references. */
+  bool IsCollisionFilteredBetween(
+      const drake::multibody::Body<double>& bodyA,
+      const drake::multibody::Body<double>& bodyB) const {
+    return IsCollisionFilteredBetween(bodyA.index(), bodyB.index());
+  }
+
+  /** Declares the body pair (bodyA, bodyB) to be filtered (nor not) based on
+   `filter_collision`.
+   @param filter_collision Sets the to body pair to be filtered if `true`.
+   @throws std::exception if either body index is out of range.
+   @throws std::exception if both indices refer to environment bodies. */
+  void SetCollisionFilteredBetween(drake::multibody::BodyIndex bodyA_index,
+                                   drake::multibody::BodyIndex bodyB_index,
+                                   bool filter_collision);
+
+  /** Overload that uses body references. */
+  void SetCollisionFilteredBetween(
+      const drake::multibody::Body<double>& bodyA,
+      const drake::multibody::Body<double>& bodyB, bool filter_collision) {
+    SetCollisionFilteredBetween(bodyA.index(), bodyB.index(), filter_collision);
+  }
+
+  /** Declares that body pair (B, O) is filtered (for all bodies O in this
+   checker's plant).
+   @throws std::exception if `body_index` is out of range.
+   @throws std::exception if `body_index` refers to an environment body. */
+  void SetCollisionFilteredWithAllBodies(
+      drake::multibody::BodyIndex body_index);
+
+  //@}
+
+  /** @name Configuration collision checking */
+  //@{
+
+  /** Checks a single configuration for collision using the current thread's
+   associated context.
+   @param q Configuration to check
+   @returns true if collision free, false if in collision.
+   @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
+  bool CheckConfigCollisionFree(const Eigen::VectorXd& q) const;
+
+  /** Explicit Context-based version of CheckConfigCollisionFree().
+   @throws std::exception if model_context is nullptr.
+   @see @ref ccb_explicit_contexts "Explicit Context Parallelism". */
+  bool CheckContextConfigCollisionFree(
+      drake::planning::CollisionCheckerContext* model_context,
+      const Eigen::VectorXd& q) const;
+
+  /** Checks a vector of configurations for collision, evaluating in parallel
+   when supported and enabled by `parallelize`. Parallelization in configuration
+   collision checks is provided using OpenMP and is supported when both: (1) the
+   collision checker declares that parallelization is supported (i.e. when
+   SupportsParallelChecking() is true) and (2) when multiple OpenMP threads are
+   available for execution.
+   Due to the internal parallelism, special care must be paid when calling this
+   method with `parallelize=true` from any thread that is not the main thread.
+   @param configs       Configurations to check
+   @param parallelize   Should configuration collision checks be parallelized?
+   @returns std::vector<int8_t>, one for each configuration in configs. For each
+   configuration, 1 if collision free, 0 if in collision. */
+  std::vector<int8_t> CheckConfigsCollisionFree(
+      const std::vector<Eigen::VectorXd>& configs,
+      bool parallelize = true) const;
+
+  /** @name Edge collision checking
+
+   These functions serve motion planning methods, such as sampling-based
+   planners and shortcut smoothers, which are concerned about checking that an
+   "edge" between two configurations, q1 and q2, is free of collision.
+
+   These functions *approximately* answer the question: is the edge collision
+   free. The answer is determined by sampling configurations along the edge
+   and reporting the edge to be collision free if all samples are collision
+   free. Otherwise, we report the fraction of samples (starting with the start
+   configuration) that reported to be collision free. The tested samples include
+   the start and end configurations, q1 and q2, respecitvely.
+
+   %CollisionChecker doesn't know how an edge is defined. An edge can be
+   anything from a simple line (e.g. a linear path in C-space) to an arbitrarily
+   complex path (e.g. a Reeds-Shepp path). The shape of the edge is defined
+   implicitly by the ConfigurationInterpolationFunction as an interpolation
+   between two configurations `q1` and `q2` (see
+   SetConfigurationDistanceFunction() and
+   SetConfigurationInterpolationFunction()).
+
+   %CollisionChecker picks configuration samples along an edge by uniformly
+   sampling the interpolation *parameter* from zero to one. (By definition, the
+   interpolation at zero is equal to `q1` and at one is equal to `q2`.) The
+   number of samples is determined by the distance between `q1` and `q2`, as
+   provided by a ConfigurationDistanceFunction, divided by "edge step size"
+   (see set_edge_step_size()).
+
+   As a result, the selection of interpolation function, distance function, and
+   edge step size must be coordinated to ensure that edge collision checking is
+   sufficiently accurate for your application.
+
+   <h4>Default functions</h4>
+
+   The configuration distance function is defined at construction (from
+   CollisionCheckerParams). It can be as simple as `|q1 - q2|` or could be
+   a weighted norm `|wᵀ⋅(q1 − q2)|` based on joint importance or unit
+   reconciliation (e.g., some qs are translational and some are rotational).
+   Because of this, the "distance" reported may have arbitrary units.
+
+   Whatever the units are, the edge step size must match. The step size value
+   and distance function will determine the number of samples on the edge. The
+   smaller the step size, the more samples (and the more expensive the collision
+   check becomes).
+
+   If all joints are revolute joints, one reasonable distance function is the
+   weighted function `|wᵀ⋅(q1 − q2)|` where the weights are based on joint
+   speed. For joint dofs `J = [J₀, J₁, ...]` with corresponding maximum speeds
+   `[q̇⁰ₘ, q̇¹ₘ, ...]`, we identify the speed of the fastest joint
+   `q̇ₘₐₓ = maxᵢ(q̇ⁱₘ)` and define the per-dof weights as `wᵢ = q̇ₘₐₓ / q̇ⁱₘ`.
+   Intuitively, the more time a particular joint requires to cover an angular
+   distance, the more significance we attribute to that distance -- it's a
+   *time*-biased weighting function. The weights are unitless so the reported
+   distance is in radians. For some common arms (IIWA, Panda, UR, Jaco, etc.),
+   we have found that an edge step size of 0.05 radians to produce reasonable
+   results.
+
+   %CollisionChecker has a default interpolation function, as defined by
+   MakeDefaultConfigurationInterpolationFunction(). It performs Slerp for
+   quaternion-valued dofs and linear interpolation for all other dofs. Note that
+   this is not appropriate for all robots, (e.g. those using a BallRpyJoint, or
+   any non-holonomic robot). You will need to provide your own interpolation
+   function in such cases.
+
+   <h4>Function-level parallelism</h4>
+
+   Parallelization in some edge collision checks is provided using OpenMP and is
+   enabled when both: (1) the collision checker declares that parallelization is
+   supported (i.e. when SupportsParallelChecking() is true) and (2) when
+   multiple OpenMP threads are available for execution.
+
+   Due to this internal parallelism, special care must be paid when calling
+   these methods from any thread that is not the main thread.
+
+   <h4>Thoughts on configuring %CollisionChecker for edge collision
+       detection</h4>
+
+   Because the edge collision check samples the edge, there is a perpetual
+   trade off between the cost of evaluating the edge and the likelihood that
+   a real collision is missed. In practice, the %CollisionChecker should be
+   configured to maximize performance for a reasonable level of collision
+   detection reliability. There is no definitive method for tuning the
+   parameters. Rather than advocating a tuning strategy, we'll simply elaborate
+   on the available parameters and leave the actual tuning as an exercise for
+   the reader.
+
+   There are two properties that will most directly contribute to the accuracy
+   of the edge tests: edge step size and padding. Ultimately, any obstacle in
+   *C-space* whose measure is smaller than the edge step size is likely to be
+   missed. The goal is to tune the parameters such that such features -- located
+   in an area of interest (i.e., where you want your robot to operate) -- will
+   have a low probability of being missed.
+
+   Edge step size is very much a global parameter. It will increase the cost of
+   *every* collision check. If you are unable to anticipate where the small
+   features are, a small edge step size will be robust to that uncertainty. As
+   such, it serves as a good backstop. It comes at a cost of increasing the cost
+   of *every* test, even for large geometries with nothing but coarse features.
+
+   Increasing the padding can likewise reduce the likelihood of missing
+   features. Adding padding has the effect of increasing the size of the
+   workspace obstacles in C-space. The primary benefit is that it can be applied
+   locally. If there is a particular obstacle with fine features that your robot
+   will be near, padding between robot and that obstacle can be added so that
+   interactions between robot and obstacle are more likely to be caught. Doing
+   so leaves the global cost low for coarse features. However, padding comes at
+   the cost that physically free edges may no longer be considered free.
+
+   The best tuning will likely include configuring both edge step size and
+   applying appropriate padding. */
+  //@{
+
+  /** Sets the configuration distance function to `distance_function`.
+   @pre distance_function satisfies the requirements documented on
+   ConfigurationDistanceFunction.
+   @note the `distance_function` object will be copied and retained by this
+   collision checker, so if the function has any lambda-captured data then
+   that data must outlive this collision checker. */
+  void SetConfigurationDistanceFunction(
+      const drake::planning::ConfigurationDistanceFunction& distance_function);
+
+  /** Computes configuration-space distance between the provided configurations
+   `q_1` and `q_2`, using the distance function configured at construction-
+   time or via SetConfigurationDistanceFunction(). */
+  double ComputeConfigurationDistance(const Eigen::VectorXd& q_1,
+                                      const Eigen::VectorXd& q_2) const {
+    return configuration_distance_function_(q_1, q_2);
+  }
+
+  /** @returns a functor that captures this object, so it can be used like a
+   free function. The returned functor is only valid during the lifetime of
+   this object. The math of the function is equivalent to
+   ComputeConfigurationDistance().
+   @warning do not pass this standalone function back into
+   SetConfigurationDistanceFunction() function; doing so would create an
+   infinite loop. */
+  drake::planning::ConfigurationDistanceFunction
+  MakeStandaloneConfigurationDistanceFunction() const;
+
+  /** Sets the configuration interpolation function to `interpolation_function`.
+
+   @param interpolation_function a functor, or nullptr. If nullptr, the default
+   function will be configured and used.
+   @pre interpolation_function satisfies the requirements documented on
+   ConfigurationInterpolationFunction, or is nullptr.
+   @note the `interpolation_function` object will be copied and retained by
+   this collision checker, so if the function has any lambda-captured data
+   then that data must outlive this collision checker.
+   @note the default function uses linear interpolation for most variables,
+   and uses slerp for quaternion valued variables.*/
+  void SetConfigurationInterpolationFunction(
+      const drake::planning::ConfigurationInterpolationFunction&
+          interpolation_function);
+
+  /** Interpolates between provided configurations `q_1` and `q_2`.
+   @param ratio Interpolation ratio.
+   @returns Interpolated configuration.
+   @throws std::exception if ratio is not in range [0, 1]. */
+  Eigen::VectorXd InterpolateBetweenConfigurations(
+      const Eigen::VectorXd& q_1, const Eigen::VectorXd& q_2,
+      double ratio) const {
+    DRAKE_THROW_UNLESS(ratio >= 0.0 && ratio <= 1.0);
+    return configuration_interpolation_function_(q_1, q_2, ratio);
+  }
+
+  /** @returns a functor that captures this object, so it can be used like a
+   free function. The returned functor is only valid during the lifetime of
+   this object. The math of the function is equivalent to
+   InterpolateBetweenConfigurations().
+   @warning do not pass this standalone function back into our
+   SetConfigurationInterpolationFunction() function; doing so would create
+   an infinite loop. */
+  drake::planning::ConfigurationInterpolationFunction
+  MakeStandaloneConfigurationInterpolationFunction() const;
+
+  /** Gets the current edge step size. */
+  double edge_step_size() const { return edge_step_size_; }
+
+  /** Sets the edge step size to `edge_step_size`.
+   @throws std::exception if `edge_step_size` is not positive. */
+  void set_edge_step_size(double edge_step_size) {
+    DRAKE_THROW_UNLESS(edge_step_size > 0.0);
+    edge_step_size_ = edge_step_size;
+  }
+
+  /** Checks a single configuration-to-configuration edge for collision, using
+   the current thread's associated context.
+   @param q1 Start configuration for edge.
+   @param q2 End configuration for edge.
+   @returns true if collision free, false if in collision.
+   @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
+  bool CheckEdgeCollisionFree(const Eigen::VectorXd& q1,
+                              const Eigen::VectorXd& q2) const;
+
+  /** Explicit Context-based version of CheckEdgeCollisionFree().
+   @throws std::exception if `model_context` is nullptr.
+   @see @ref ccb_explicit_contexts "Explicit Context Parallelism". */
+  bool CheckContextEdgeCollisionFree(
+      drake::planning::CollisionCheckerContext* model_context,
+      const Eigen::VectorXd& q1, const Eigen::VectorXd& q2) const;
+
+  /** Checks a single configuration-to-configuration edge for collision.
+   Collision check is parallelized via OpenMP when supported.
+   Due to the internal parallelism, special care must be paid when calling this
+   method from any thread that is not the main thread.
+   @param q1 Start configuration for edge.
+   @param q2 End configuration for edge.
+   @returns true if collision free, false if in collision. */
+  bool CheckEdgeCollisionFreeParallel(const Eigen::VectorXd& q1,
+                                   const Eigen::VectorXd& q2) const;
+
+  /** Checks multiple configuration-to-configuration edges for collision.
+   Collision checks are parallelized via OpenMP when supported and enabled by
+   `parallelize`.
+   Due to the internal parallelism, special care must be paid when calling this
+   method with `parallelize=true` from any thread that is not the main thread.
+   @param edges        Edges to check, each in the form of pair<q1, q2>.
+   @param parallelize  Should edge collision checks be parallelized?
+   @returns std::vector<int8_t>, one for each edge in edges. For each edge, 1 if
+   collision free, 0 if in collision. */
+  std::vector<int8_t> CheckEdgesCollisionFree(
+      const std::vector<std::pair<Eigen::VectorXd, Eigen::VectorXd>>& edges,
+      bool parallelize = true) const;
+
+  /** Checks a single configuration-to-configuration edge for collision, using
+   the current thread's associated context.
+   @param q1 Start configuration for edge.
+   @param q2 End configuration for edge.
+   @returns A measure of how much of the edge is collision free.
+   @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
+  EdgeMeasure MeasureEdgeCollisionFree(const Eigen::VectorXd& q1,
+                                       const Eigen::VectorXd& q2) const;
+
+  /** Explicit Context-based version of MeasureEdgeCollisionFree().
+   @throws std::exception if `model_context` is nullptr.
+   @see @ref ccb_explicit_contexts "Explicit Context Parallelism". */
+  EdgeMeasure MeasureContextEdgeCollisionFree(
+      drake::planning::CollisionCheckerContext* model_context,
+      const Eigen::VectorXd& q1, const Eigen::VectorXd& q2) const;
+
+  /** Checks a single configuration-to-configuration edge for collision.
+   Collision check is parallelized via OpenMP when supported.
+   Due to the internal parallelism, special care must be paid when calling this
+   method from any thread that is not the main thread.
+   @param q1 Start configuration for edge.
+   @param q2 End configuration for edge.
+   @returns A measure of how much of the edge is collision free. */
+  EdgeMeasure MeasureEdgeCollisionFreeParallel(
+      const Eigen::VectorXd& q1, const Eigen::VectorXd& q2) const;
+
+  /** Checks multiple configuration-to-configuration edge for collision.
+   Collision checks are parallelized via OpenMP when supported and enabled by
+   `parallelize`.
+   Due to the internal parallelism, special care must be paid when calling this
+   method with `parallelize=true` from any thread that is not the main thread.
+   @param edges        Edges to check, each in the form of pair<q1, q2>.
+   @param parallelize  Should edge collision checks be parallelized?
+   @returns A measure of how much of each edge is collision free. The iᵗʰ entry
+            is the result for the iᵗʰ edge. */
+  std::vector<EdgeMeasure> MeasureEdgesCollisionFree(
+      const std::vector<std::pair<Eigen::VectorXd, Eigen::VectorXd>>& edges,
+      bool parallelize = true) const;
+
+  //@}
+
+  /** @name Robot collision state
+
+   These methods help characterize the robot's collision state with respect to
+   a particular robot configuration.
+
+   The collision state includes its *clearance* -- a measure of how near to
+   collision the robot is -- as computed by CalcRobotClearance() and report
+   the boolean state of collision for each robot body as computed by
+   ClassifyBodyCollisions(). */
+  //@{
+
+  /** Calculates the distance, ϕ, and distance Jacobian, Jqᵣ_ϕ, for each
+   potential collision whose distance is less than `influence_distance`,
+   using the current thread's associated context.
+
+   Distances for filtered collisions will not be returned.
+
+   Distances between a pair of robot bodies (i.e., where `collision_types()`
+   reports `SelfCollision`) report one body's index in `robot_indices()` and the
+   the other body's in `other_indices()`; which body appears in which column is
+   arbitrary.
+
+   The total number of rows can depend on how the model is defined and how a
+   particular CollisionChecker instance is implemented (see MaxNumDistances()).
+   @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
+  drake::planning::RobotClearance CalcRobotClearance(
+      const Eigen::VectorXd& q, double influence_distance) const;
+
+  /** Explicit Context-based version of CalcRobotClearance().
+   @throws std::exception if `model_context` is nullptr.
+   @see @ref ccb_explicit_contexts "Explicit Context Parallelism". */
+  drake::planning::RobotClearance CalcContextRobotClearance(
+      drake::planning::CollisionCheckerContext* model_context,
+      const Eigen::VectorXd& q, double influence_distance) const;
+
+  /** Returns an upper bound on the number of distances returned by
+   CalcRobotClearance(), using the current thread's associated context.
+   @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
+  int MaxNumDistances() const;
+
+  /** Explicit Context-based version of MaxNumDistances().
+   @see @ref ccb_explicit_contexts "Explicit Context Parallelism". */
+  int MaxContextNumDistances(
+      const drake::planning::CollisionCheckerContext& model_context) const;
+
+  /** Classifies which robot bodies are in collision (and which type of
+   collision) for the provided configuration `q`, using the current thread's
+   associated context.
+   @returns a vector of collision types arranged in body index order. Only
+   entries for robot bodies are guaranteed to be valid; entries for
+   environment bodies are populated with kNoCollision, regardless of their
+   actual status.
+   @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
+  std::vector<drake::planning::RobotCollisionType> ClassifyBodyCollisions(
+      const Eigen::VectorXd& q) const;
+
+  /** Explicit Context-based version of ClassifyBodyCollisions().
+   @throws std::exception if `model_context` is nullptr.
+   @see @ref ccb_explicit_contexts "Explicit Context Parallelism". */
+  std::vector<drake::planning::RobotCollisionType>
+  ClassifyContextBodyCollisions(
+      drake::planning::CollisionCheckerContext* model_context,
+      const Eigen::VectorXd& q) const;
+
+  //@}
+
+  /** Does the collision checker support true parallel collision checks?
+   @returns true if parallel checking is supported. */
+  bool SupportsParallelChecking() const { return supports_parallel_checking_; }
+
+ protected:
+  /** Derived classes declare upon construction whether they support parallel
+   checking (see SupportsParallelChecking()).
+   @throws std::exception if params is invalid. @see CollisionCheckerParams.
+   */
+  CollisionChecker(drake::planning::CollisionCheckerParams params,
+                   bool supports_parallel_checking);
+
+  /** To support Clone(), allow copying (but not move nor assign). */
+  CollisionChecker(const CollisionChecker&);
+
+  /** Allocate the per-thread context pool, and discontinue mutable access to
+   the robot model. This must be called and only be called as part of the
+   constructor in a derived class defined as final.
+
+   @pre This cannot have already been called for this instance. */
+  void AllocateContexts();
+
+  /** Collision checkers that use derived context types can override this
+   implementation to allocate their context type instead. */
+  virtual std::unique_ptr<drake::planning::CollisionCheckerContext>
+  CreatePrototypeContext() const {
+    return std::make_unique<drake::planning::CollisionCheckerContext>(&model());
+  }
+
+  /** @returns true if called during initial setup (before AllocateContexts()
+   is called). */
+  bool IsInitialSetup() const { return setup_model_ != nullptr; }
+
+  /** @returns a mutable reference to the robot model.
+      @throws std::exception if IsInitialSetup() == false. */
+  RobotDiagram<double>& GetMutableSetupModel() {
+    DRAKE_THROW_UNLESS(IsInitialSetup());
+    return *setup_model_;
+  }
+
+  /** @name Internal overridable implementations of public methods. */
+  //@{
+
+  /** Derived collision checkers implement can make use of the protected copy
+   constructor to implement DoClone(). */
+  virtual std::unique_ptr<CollisionChecker> DoClone() const = 0;
+
+  /** Derived collision checkers can do further work in this function in
+   response to updates to the MultibodyPlant positions. CollisionChecker
+   guarantees that `model_context` will not be nullptr and that the new
+   positions are present in model_context->plant_context(). */
+  virtual void DoUpdateContextPositions(
+      drake::planning::CollisionCheckerContext* model_context) const = 0;
+
+  /** Derived collision checkers are responsible for reporting the collision
+   status of the configuration. CollisionChecker guarantees that the passed
+   `model_context` has been updated with the configuration `q` supplied to the
+   public method. */
+  virtual bool DoCheckContextConfigCollisionFree(
+      const drake::planning::CollisionCheckerContext& model_context) const = 0;
+
+  /** Does the work of adding a shape to be rigidly affixed to the body. Derived
+   checkers can choose to ignore the request, but must return `nullopt` if they
+   do so. */
+  virtual std::optional<drake::geometry::GeometryId> DoAddCollisionShapeToBody(
+      const std::string& group_name,
+      const drake::multibody::Body<double>& bodyA,
+      const drake::geometry::Shape& shape,
+      const drake::math::RigidTransform<double>& X_AG) = 0;
+
+  /** Representation of an "added" shape. These are shapes that get added to
+   the model via the CollisionChecker's Shape API. They encode the id for the
+   added geometry and the index of the body (robot or environment) to which the
+   geometry is affixed. */
+  struct AddedShape {
+    /** The id of the geometry. */
+    drake::geometry::GeometryId geometry_id;
+
+    /** The index of the body the shape was added; could be robot or
+     environment. */
+    drake::multibody::BodyIndex body_index;
+
+    /** The full body description.
+     We have the invariant that `body_index` has the body and model instance
+     names recorded in the description. */
+    drake::planning::BodyShapeDescription description;
+  };
+
+  /** Removes all of the given added shapes (if they exist) from the checker. */
+  virtual void DoRemoveAddedGeometries(
+      const std::vector<AddedShape>& shapes) = 0;
+
+  /** Derived collision checkers are responsible for defining the reported
+   measurements. But they must adhere to the characteristics documented on
+   RobotClearance, e.g., one measurement per row. CollisionChecker guarantees
+   that `influence_distance` is finite and non-negative. */
+  virtual drake::planning::RobotClearance DoCalcContextRobotClearance(
+      const drake::planning::CollisionCheckerContext& model_context,
+      double influence_distance) const = 0;
+
+  /** Derived collision checkers are responsible for choosing a collision type
+   for each of the robot bodies. They should adhere to the semantics documented
+   for ClassifyBodyCollisions. CollisionChecker guarantees that the passed
+   `model_context` has been updated with the configuration `q` supplied to the
+   public method. */
+  virtual std::vector<drake::planning::RobotCollisionType>
+  DoClassifyContextBodyCollisions(
+      const drake::planning::CollisionCheckerContext& model_context) const = 0;
+
+  /** Derived collision checkers must implement the semantics documented for
+   MaxNumDistances. CollisionChecker does nothing; it just calls this method. */
+  virtual int DoMaxContextNumDistances(
+      const drake::planning::CollisionCheckerContext& model_context) const = 0;
+
+  //@}
+
+  /** @returns true if this object SupportsParallelChecking() and more than one
+   thread is available. */
+  bool CanEvaluateInParallel() const;
+
+  /* (Testing only.) Checks that the padding matrix in this instance is valid,
+   returning an error message if problems are found, or an empty string if not.
+   */
+  std::string CriticizePaddingMatrix() const;
+
+ private:
+  /* @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
+  drake::planning::CollisionCheckerContext& mutable_model_context() const;
+
+  drake::planning::CollisionCheckerContext& mutable_model_context_by_index(
+      int index) const {
+    return owned_contexts_.get_mutable_model_context(index);
+  }
+
+  const drake::planning::CollisionCheckerContext& model_context_by_index(
+      int index) const {
+    return owned_contexts_.get_model_context(index);
+  }
+
+  /* Tests the given filtered collision matrix for several invariants, throwing
+   if they are not satisfied:
+
+      - The matrix is square.
+      - The diagonal is all -1.
+      - The matrix is symmetric.
+      - For off-diagonal, non-zero values:
+          - 1: at least one of the bodies in the pair is a robot body
+          - -1: both bodies in the pair are environment bodies.
+      - All entries are either 0, 1, or -1. */
+  void ValidateFilteredCollisionMatrix(const Eigen::MatrixXi& filtered,
+                                       const char* func) const;
+
+  /* The "nominal" collision matrix. This is intended to be called only upon
+   construction.
+
+   The nominal filtered collision matrix has the following properties:
+
+      - All diagonal entries are set to -1 (a body colliding with itself
+        is meaningless).
+      - All environment-environment pairs are set to -1. CollisionChecker
+        ignores them; so it might as well be explicit about it in the matrix.
+      - For bodies I and J,
+        - if all geometries of I have "filtered collisions" (in the SceneGraph
+          sense), with all the geometries of J, the matrix is set to 1.
+        - If *no* geometries of I and J are filtered, the matrix is set to 0.
+        - If some geometry pairs are filtered, and some are not, an error is
+          thrown.
+      - If a welded path exists between two bodies (in the MultibodyPlant),
+        the matrix is set to 1. */
+  Eigen::MatrixXi GenerateFilteredCollisionMatrix() const;
+
+  void UpdateMaxCollisionPadding() {
+    max_collision_padding_ = collision_padding_.maxCoeff();
+  }
+
+  /* Tests the given collision padding matrix for several invariants, throwing
+   if they are not satisfied:
+
+      - It is a square NxN matrix (where N is the total number of bodies).
+      - Diagonal values are all zero.
+      - Entries involving only environment bodies are all zero.
+      - It is symmetric.
+      - All values are finite. */
+  void ValidatePaddingMatrix(const Eigen::MatrixXd& padding,
+                             const char* func) const;
+
+  /* Checks the same conditions as ValidatePaddingMatrix, but instead of
+   throwing, returns the error message, or an empty string if no errors were
+   found. */
+  std::string CriticizePaddingMatrix(
+      const Eigen::MatrixXd& padding, const char* func) const;
+
+  /* @note this class has two phases: `empty()` (before calling
+   AllocateOwnedContexts()), and `allocated()`. In the `empty()` phase,
+   `num_contexts()` returns 0, and all methods that access a context will
+   throw. */
+  class OwnedContextKeeper {
+   public:
+    OwnedContextKeeper() {}
+
+    /* The copy constructor is used to implement our outer class's Clone(). */
+    explicit OwnedContextKeeper(const OwnedContextKeeper& other) {
+      AllocateOwnedContexts(other.prototype_context(), other.num_contexts());
+    }
+
+    /* Does not allow assignment. */
+    void operator=(const OwnedContextKeeper&) = delete;
+
+    /* Allocates the requested number of contexts, for later access by index,
+     and clones the passed prototype context.
+     @note This method is exposed since
+     CollisionChecker::AllocateContexts can't be called in the
+     CollisionChecker constructor.
+     @throws std::exception if called more than once. */
+    void AllocateOwnedContexts(
+        const drake::planning::CollisionCheckerContext& prototype_context,
+        int num_contexts);
+
+    /* @returns true if the keeper is empty. In the empty state, there are no
+     contexts allocated and no prototype context is available. */
+    bool empty() const {
+      DRAKE_DEMAND((prototype_context_ == nullptr) == model_contexts_.empty());
+      return model_contexts_.empty();
+    }
+
+    /* @returns true if the keeper has allocated contexts. In the allocated
+     state, there are contexts available for access by index, and the prototype
+     context is available. */
+    bool allocated() const { return !empty(); }
+
+    int num_contexts() const { return model_contexts_.size(); }
+
+    /* Gets the special "prototype" context used for copy & clone operations. */
+    const drake::planning::CollisionCheckerContext& prototype_context() const {
+      // The prototype context is only available in the allocated phase.
+      DRAKE_THROW_UNLESS(allocated());
+      return *prototype_context_;
+    }
+
+    drake::planning::CollisionCheckerContext& get_mutable_model_context(
+        int index) const {
+      return *model_contexts_.at(index);
+    }
+
+    const drake::planning::CollisionCheckerContext& get_model_context(
+        int index) const {
+      return *model_contexts_.at(index);
+    }
+
+    /* Performs the provided `operation` on all owned contexts. */
+    void PerformOperationAgainstAllOwnedContexts(
+        const RobotDiagram<double>& model,
+        const std::function<void(const RobotDiagram<double>&,
+                                 drake::planning::CollisionCheckerContext*)>&
+            operation);
+
+   private:
+    std::vector<std::unique_ptr<drake::planning::CollisionCheckerContext>>
+        model_contexts_;
+
+    /* This prototype context plays an important role. The CollisionChecker is
+     supposed to allow the execution of *any* const methods in parallel without
+     incident. This prototype is vital to include Clone() in that set.
+
+     The various const query methods (e.g., CheckConfigCollisionFree()) treat
+     the underlying per-thread context as being functionally mutable. To
+     evaluate the query, the positions in the MbP's context must be updated to
+     the given configuration values. Therefore, if we were to attempt to clone
+     this checker while such a query is being evaluated, we *must* not read from
+     that thread's Context so we don't catch it in an intermediate state.
+
+     Instead, we clone the collision checker's contexts by cloning this
+     prototype context (which is not accessed by any other const method)
+     repeatedly. For this approach to be valid, we maintain the invariant that
+     this prototype context is bit-identical with all of the owned and
+     standalone contexts for this CollisionChecker (except for those differences
+     directly attributable to setting the qs in MbP). */
+    std::unique_ptr<drake::planning::CollisionCheckerContext>
+        prototype_context_;
+  };
+
+  class StandaloneContextReferenceKeeper {
+   public:
+    StandaloneContextReferenceKeeper() {}
+
+    /* The copy constructor is used to implement our outer class's Clone(). */
+    explicit StandaloneContextReferenceKeeper(
+        const StandaloneContextReferenceKeeper&) {
+      // Nothing to do here; contexts should NOT be copied during Clone().
+    }
+
+    /* Does not allow assignment. */
+    void operator=(const StandaloneContextReferenceKeeper&) = delete;
+
+    void AddStandaloneContext(
+        const std::shared_ptr<drake::planning::CollisionCheckerContext>&
+            standalone_context) const {
+      std::lock_guard<std::mutex> lock(standalone_contexts_mutex_);
+      standalone_contexts_.push_back(
+          std::weak_ptr<drake::planning::CollisionCheckerContext>(
+              standalone_context));
+    }
+
+    /* Performs the provided `operation` on all live referenced contexts, and
+     removes any references to dead contexts. */
+    void PerformOperationAgainstAllStandaloneContexts(
+        const RobotDiagram<double>& model,
+        const std::function<void(const RobotDiagram<double>&,
+                                 drake::planning::CollisionCheckerContext*)>&
+            operation);
+
+   private:
+    mutable std::list<std::weak_ptr<drake::planning::CollisionCheckerContext>>
+        standalone_contexts_;
+    mutable std::mutex standalone_contexts_mutex_;
+  };
+
+  /* Model of the robot used during initial setup only. */
+  std::shared_ptr<RobotDiagram<double>> setup_model_;
+
+  /* Model of the robot to perform collision checks with. */
+  std::shared_ptr<const RobotDiagram<double>> model_;
+
+  /* We maintain per-thread contexts to allow multiple simultaneous queries. */
+  OwnedContextKeeper owned_contexts_;
+
+  /* We maintain weak references to standalone contexts to allow updates to
+   standalone contexts. These must be weak refs to avoid keeping standalone
+   contexts alive indefinitely. */
+  StandaloneContextReferenceKeeper standalone_contexts_;
+
+  /* We maintain a set of all robot model instances for lookups. This vector is
+   already de-duplicated and sorted. */
+  const std::vector<drake::multibody::ModelInstanceIndex>
+      robot_model_instances_;
+
+  /* The set of indices in q that kinematically affect the robot_model_instances
+   but which are not themselves part of robot_model_instances (e.g., a mobile
+   base). In many cases this vector will be empty. */
+  const std::vector<int> uncontrolled_dofs_that_kinematically_affect_the_robot_;
+
+  /* Function to compute distance between two configurations. */
+  drake::planning::ConfigurationDistanceFunction
+      configuration_distance_function_;
+
+  /* Function to interpolate between two configurations. */
+  drake::planning::ConfigurationInterpolationFunction
+      configuration_interpolation_function_;
+
+  /* Step size for edge collision checking. */
+  double edge_step_size_ = 0.0;
+
+  /* Storage for body-body collision padding. */
+  Eigen::MatrixXd collision_padding_;
+
+  /* The current maximum collision padding. */
+  double max_collision_padding_ = 0.0;
+
+  /* Internal storage of the filtered collision matrix. */
+  Eigen::MatrixXi filtered_collisions_;
+
+  /* Internal storage of the nominal filtered collision matrix generated at
+   setup time. */
+  Eigen::MatrixXi nominal_filtered_collisions_;
+
+  /* We maintain a "zero configuration" of the model. */
+  Eigen::VectorXd zero_configuration_;
+
+  /* Determines whether the checker reports support for parallel evaluation.
+   This is defined upon construction by implementations. */
+  bool supports_parallel_checking_{};
+
+  /* The names of all groups with added geometries. */
+  std::map<std::string, std::vector<AddedShape>> geometry_groups_;
+};
+
+}  // namespace planning
+}  // namespace anzu

--- a/planning/collision_checker.h
+++ b/planning/collision_checker.h
@@ -14,12 +14,12 @@
 #include "drake/planning/body_shape_description.h"
 #include "drake/planning/collision_checker_context.h"
 #include "drake/planning/collision_checker_params.h"
+#include "drake/planning/edge_measure.h"
 #include "drake/planning/robot_clearance.h"
-#include "planning/edge_measure.h"
-#include "planning/robot_collision_type.h"
-#include "planning/robot_diagram.h"
+#include "drake/planning/robot_collision_type.h"
+#include "drake/planning/robot_diagram.h"
 
-namespace anzu {
+namespace drake {
 namespace planning {
 
 /** Interface for collision checkers to use.
@@ -44,6 +44,9 @@ namespace planning {
       do I have to call `AllocateContexts()`? When should I not? etc.
     - Clear delineation of serial queries that can be performed in parallel and
       queries that themselves parallelize and guidance on not mixing them.
+
+  It's also important to partition the guidance between "user" documentation and
+  "implementer" documentation.
   -->
 
  This interface builds on the basic multi-threading idiom of Drake: one context
@@ -54,7 +57,7 @@ namespace planning {
  - using arbitrary threads and "explicit contexts" created by this object
 
  @anchor ccb_implicit_contexts
- <h4>Implicit Context Parallelism</h4>
+ <h5>Implicit Context Parallelism</h5>
 
  Many methods of this class aren't designed for entry from arbitrary threads
  (e.g. from std::async threads), but rather are designed for use with a main
@@ -85,10 +88,10 @@ namespace planning {
       supports OpenMP pragmas in docs.  -->
 
  @anchor ccb_explicit_contexts
- <h4>Explicit Context Parallelism</h4>
+ <h5>Explicit Context Parallelism</h5>
 
  It is also possible to use arbitrary thread models to perform collision
- checking in parallel using explicitly-created contexts from this class.
+ checking in parallel using explicitly created contexts from this class.
  Contexts returned from MakeStandaloneModelContext() may be used in any thread,
  using only `const` methods of this class, or "explicit context" methods.
 
@@ -127,14 +130,14 @@ namespace planning {
  const double edge_2_valid = future_q2.get();
  @endcode
 
- <h4>>Mixing Threading Models</h4>
+ <h5>Mixing Threading Models</h5>
 
- It is possible to support mixed threading models, i.e. using both OpenOMP
+ It is possible to support mixed threading models, i.e., using both OpenMP
  thread pools and arbitrary threads. In this case, each arbitrary thread (say,
  from std::async) should have its own instance of a collision checker made using
  Clone(). Then each arbitrary thread will have its own implicit context pool.
 
- <h4>Implementing Derived Classes</h4>
+ <h5>Implementing Derived Classes</h5>
 
  Collision checkers deriving from CollisionChecker *must* support parallel
  operations from both of the above parallelism models. This is generally
@@ -177,14 +180,14 @@ class CollisionChecker {
   }
 
   /** @returns a `const reference to the full model's plant. */
-  const drake::multibody::MultibodyPlant<double>& plant() const {
+  const multibody::MultibodyPlant<double>& plant() const {
     return model().plant();
   }
 
   /** @returns a `const` body reference to a body in the full model's plant for
    the given `body_index`. */
-  const drake::multibody::Body<double>& get_body(
-      drake::multibody::BodyIndex body_index) const {
+  const multibody::Body<double>& get_body(
+      multibody::BodyIndex body_index) const {
     return plant().get_body(body_index);
   }
 
@@ -193,21 +196,23 @@ class CollisionChecker {
   // that belongs with MbP sugar.
   // TODO(rpoyner-tri): reference to discussion of scoped names?
   /** Gets the scoped name for a frame within the full model. */
-  std::string GetScopedName(const drake::multibody::Frame<double>& frame) const;
+  std::string GetScopedName(const multibody::Frame<double>& frame) const;
 
   /** Gets the scoped name for a body within the full model. */
-  std::string GetScopedName(const drake::multibody::Body<double>& body) const;
+  std::string GetScopedName(const multibody::Body<double>& body) const;
 
   /** Gets the set of model instances belonging to the robot. The returned
    vector has no duplicates and is in sorted order. */
-  const std::vector<drake::multibody::ModelInstanceIndex>&
-  robot_model_instances() const { return robot_model_instances_; }
+  const std::vector<multibody::ModelInstanceIndex>& robot_model_instances()
+      const {
+    return robot_model_instances_;
+  }
 
   /** @returns true if the indicated body is part of the robot. */
-  bool IsPartOfRobot(const drake::multibody::Body<double>& body) const;
+  bool IsPartOfRobot(const multibody::Body<double>& body) const;
 
   /** @returns true if the indicated body is part of the robot. */
-  bool IsPartOfRobot(drake::multibody::BodyIndex body_index) const;
+  bool IsPartOfRobot(multibody::BodyIndex body_index) const;
 
   /** @returns a generalized position vector, sized according to the full model,
    whose values are all zero.
@@ -223,37 +228,34 @@ class CollisionChecker {
   //@{
 
   /** @returns the number of internal (not standalone) per-thread contexts. */
-  int num_allocated_contexts() const {
-    return owned_contexts_.num_contexts();
-  }
+  int num_allocated_contexts() const { return owned_contexts_.num_contexts(); }
 
   /** @returns a `const` reference to the collision checking context to be used
    with the current thread.
    @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
-  const drake::planning::CollisionCheckerContext& model_context() const;
+  const CollisionCheckerContext& model_context() const;
 
   // TODO(jeremy.nimmer) This is only lightly used, maybe we should toss it?
   /** @returns a `const` reference to the multibody plant sub-context within
    the context for the current thread.
    @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
-  const drake::systems::Context<double>& plant_context() const {
+  const systems::Context<double>& plant_context() const {
     return model_context().plant_context();
   }
 
   /** Updates the generalized positions `q` in the current thread's associated
    context, and returns a reference to the MultibodyPlant's now-updated context.
    @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
-  const drake::systems::Context<double>&
-  UpdatePositions(const Eigen::VectorXd& q) const {
+  const systems::Context<double>& UpdatePositions(
+      const Eigen::VectorXd& q) const {
     return UpdateContextPositions(&mutable_model_context(), q);
   }
 
   /** Explicit Context-based version of UpdatePositions().
    @throws std::exception if `model_context` is `nullptr`.
    @see @ref ccb_explicit_contexts "Explicit Context Parallelism". */
-  const drake::systems::Context<double>& UpdateContextPositions(
-      drake::planning::CollisionCheckerContext* model_context,
-      const Eigen::VectorXd& q) const {
+  const systems::Context<double>& UpdateContextPositions(
+      CollisionCheckerContext* model_context, const Eigen::VectorXd& q) const {
     DRAKE_THROW_UNLESS(model_context != nullptr);
     plant().SetPositions(&model_context->mutable_plant_context(), q);
     DoUpdateContextPositions(model_context);
@@ -263,16 +265,18 @@ class CollisionChecker {
   /** Make and track a CollisionCheckerContext. The returned context will
    participate in PerformOperationAgainstAllModelContexts() until it is
    destroyed. */
-  std::shared_ptr<drake::planning::CollisionCheckerContext>
-  MakeStandaloneModelContext() const;
+  std::shared_ptr<CollisionCheckerContext> MakeStandaloneModelContext() const;
 
   /** Allows externally-provided operations that must be performed against all
    contexts in the per-thread context pool, and any standalone contexts made
-   with MakeStandaloneModelContext(). */
+   with MakeStandaloneModelContext().
+
+   For any standalone contexts, note that it is illegal to mutate a context from
+   two different threads. No other threads should be mutating any of our
+   standalone contexts when this function is called. */
   void PerformOperationAgainstAllModelContexts(
       const std::function<void(const RobotDiagram<double>&,
-                               drake::planning::CollisionCheckerContext*)>&
-          operation);
+                               CollisionCheckerContext*)>& operation);
 
   //@}
 
@@ -317,9 +321,8 @@ class CollisionChecker {
    @param group_name    The name of the group to add the geometry to.
    @param description   The data describing the shape and target body.
    @returns `true` if the shape was added. */
-  bool AddCollisionShape(
-      const std::string& group_name,
-      const drake::planning::BodyShapeDescription& description);
+  bool AddCollisionShape(const std::string& group_name,
+                         const BodyShapeDescription& description);
 
   // TODO(sean.curtis): Convert this to a simple `bool` return; either all of
   //  the shapes were accepted or none were.
@@ -329,9 +332,8 @@ class CollisionChecker {
    @param group_name    The name of the group to add the geometry to.
    @param descriptions  The descriptions of N (shape, body) pairs.
    @returns The total number of shapes in `descriptions` that got added. */
-  int AddCollisionShapes(
-      const std::string& group_name,
-      const std::vector<drake::planning::BodyShapeDescription>& descriptions);
+  int AddCollisionShapes(const std::string& group_name,
+                         const std::vector<BodyShapeDescription>& descriptions);
 
   /** Requests the addition of a collection of shapes to bodies across multiple
    geometry groups. `geometry_groups` specifies a collection of (shape, body)
@@ -342,8 +344,7 @@ class CollisionChecker {
    @returns A map from input named geometry group to the *number* of geometries
             added to that group. */
   std::map<std::string, int> AddCollisionShapes(
-      const std::map<std::string,
-                     std::vector<drake::planning::BodyShapeDescription>>&
+      const std::map<std::string, std::vector<BodyShapeDescription>>&
           geometry_groups);
 
   /** Requests the addition of `shape` to the frame A in the checker's model.
@@ -354,11 +355,10 @@ class CollisionChecker {
    @param shape         The requested shape, defined in its canonical frame G.
    @param X_AG          The pose of the shape in the frame A.
    @returns `true` if the shape was added. */
-  bool AddCollisionShapeToFrame(
-      const std::string& group_name,
-      const drake::multibody::Frame<double>& frameA,
-      const drake::geometry::Shape& shape,
-      const drake::math::RigidTransform<double>& X_AG);
+  bool AddCollisionShapeToFrame(const std::string& group_name,
+                                const multibody::Frame<double>& frameA,
+                                const geometry::Shape& shape,
+                                const math::RigidTransform<double>& X_AG);
 
   /** Requests the addition of `shape` to the body A in the checker's model
    The added `shape` will belong to the named geometry group.
@@ -369,24 +369,24 @@ class CollisionChecker {
    @param X_AG          The pose of the shape in body A's frame.
    @returns `true` if the shape was added. */
   bool AddCollisionShapeToBody(const std::string& group_name,
-                               const drake::multibody::Body<double>& bodyA,
-                               const drake::geometry::Shape& shape,
-                               const drake::math::RigidTransform<double>& X_AG);
+                               const multibody::Body<double>& bodyA,
+                               const geometry::Shape& shape,
+                               const math::RigidTransform<double>& X_AG);
 
   /** Gets all checker geometries currently added across the whole checker.
    @returns A mapping from each geometry group name to the collection of
             (shape, body) descriptions in that group. */
-  std::map<std::string, std::vector<drake::planning::BodyShapeDescription>>
+  std::map<std::string, std::vector<BodyShapeDescription>>
   GetAllAddedCollisionShapes() const;
 
   // TODO(sean.curtis): Consider returning the total number of geometries
   //  deleted; here and for "remove all".
 
   /** Removes all added checker geometries which belong to the named group. */
-  void RemoveAllAddedCollisions(const std::string& group_name);
+  void RemoveAllAddedCollisionShapes(const std::string& group_name);
 
   /** Removes all added checker geometries from all geometry groups. */
-  void RemoveAllAddedCollisions();
+  void RemoveAllAddedCollisionShapes();
 
   //@}
 
@@ -397,8 +397,8 @@ class CollisionChecker {
    However, the exact distance between those geometries is not necessarily
    helpful in planning. For example,
 
-     - The disparity between simulation geometry and real world objects
-       may be such that the distance isn't sufficiently conservative.
+     - You may want to add padding when real-world objects differ from the
+       planning geometry.
      - In some cases, limited penetration is expected, and possibly desirable,
        such as when grasping in clutter.
 
@@ -412,9 +412,13 @@ class CollisionChecker {
    Ultimately, the padding data is stored in an NxN matrix (where the underlying
    model has N total bodies). The matrix is symmetric and the entry at (i, j) --
    and (j, i) -- is the padding value to be applied to distance measurements
-   between bodies i and j.
+   between bodies i and j. It is meaningless to apply padding between a
+   body and itself. Furthermore, as %CollisionChecker is concerned with the
+   state of the *robot*, it is equally meaningless to apply padding between
+   *environment* bodies. To avoid the illusion of padding, those entries on
+   the diagonal and corresponding to environment body pairs are kept at zero.
 
-   <h3>Configuring padding</h3>
+   <u>Configuring padding</u>
 
    <!-- TODO(sean.curtis): We have a function for setting the padding between
     one robot body and *all* environment bodies, but not between a robot body
@@ -438,7 +442,8 @@ class CollisionChecker {
    erase the effect of the first invocation.
 
    @anchor collision_checker_padding_prereqs
-   <h4>Configuration prerequisites</h4>
+   <u>Configuration prerequisites</u>
+
    In all these configuration methods, there are some specific requirements:
 
      - The padding value must always be finite.
@@ -446,9 +451,8 @@ class CollisionChecker {
        total bodies).
      - If the parameters include one or more more body indices, at least one of
        them must reference a robot body.
-     - Padding values must be *finite* values.
 
-   <h3>Introspection</h3>
+   <u>Introspection</u>
 
    The current state of collision padding can be introspected via a number of
    methods:
@@ -459,12 +463,12 @@ class CollisionChecker {
        MaybeGetUniformRobotRobotPadding().
      - Query the specific padding value between a pair of bodies via
        GetPaddingBetween().
-     - Find out the maximum defined padding value via GetLargestPadding().
+     - Find out the maximum padding value via GetLargestPadding().
   */
   //@{
 
   /** If the padding between all robot bodies and environment bodies is the
-   same, return the common padding value. Returns nullopt otherwise. */
+   same, returns the common padding value. Returns nullopt otherwise. */
   std::optional<double> MaybeGetUniformRobotEnvironmentPadding() const;
 
   /** If the padding between all pairs of robot bodies is the same, returns
@@ -472,19 +476,20 @@ class CollisionChecker {
   std::optional<double> MaybeGetUniformRobotRobotPadding() const;
 
   /** Gets the padding value for the pair of bodies specified.
+   If the body indices are the same, zero will always be returned.
    @throws std::exception if either body index is out of range. */
-  double GetPaddingBetween(drake::multibody::BodyIndex bodyA_index,
-                           drake::multibody::BodyIndex bodyB_index) const {
-    DRAKE_THROW_UNLESS(
-        bodyA_index >= 0 && bodyA_index < collision_padding_.rows());
-    DRAKE_THROW_UNLESS(
-        bodyB_index >= 0 && bodyB_index < collision_padding_.rows());
+  double GetPaddingBetween(multibody::BodyIndex bodyA_index,
+                           multibody::BodyIndex bodyB_index) const {
+    DRAKE_THROW_UNLESS(bodyA_index >= 0 &&
+                       bodyA_index < collision_padding_.rows());
+    DRAKE_THROW_UNLESS(bodyB_index >= 0 &&
+                       bodyB_index < collision_padding_.rows());
     return collision_padding_(int{bodyA_index}, int{bodyB_index});
   }
 
   /** Overload that uses body references. */
-  double GetPaddingBetween(const drake::multibody::Body<double>& bodyA,
-                           const drake::multibody::Body<double>& bodyB) const {
+  double GetPaddingBetween(const multibody::Body<double>& bodyA,
+                           const multibody::Body<double>& bodyB) const {
     return GetPaddingBetween(bodyA.index(), bodyB.index());
   }
 
@@ -492,21 +497,17 @@ class CollisionChecker {
    @throws std::exception if the @ref collision_checker_padding_prereqs
            "configuration prerequisites" are not met or `bodyA_index ==
            bodyB_index`. */
-  void SetPaddingBetween(drake::multibody::BodyIndex bodyA_index,
-                         drake::multibody::BodyIndex bodyB_index,
-                         double padding);
+  void SetPaddingBetween(multibody::BodyIndex bodyA_index,
+                         multibody::BodyIndex bodyB_index, double padding);
 
   /** Overload that uses body references. */
-  void SetPaddingBetween(const drake::multibody::Body<double>& bodyA,
-                         const drake::multibody::Body<double>& bodyB,
-                         double padding) {
+  void SetPaddingBetween(const multibody::Body<double>& bodyA,
+                         const multibody::Body<double>& bodyB, double padding) {
     SetPaddingBetween(bodyA.index(), bodyB.index(), padding);
   }
 
   /** Gets the collision padding matrix. */
-  const Eigen::MatrixXd& GetPaddingMatrix() const {
-    return collision_padding_;
-  }
+  const Eigen::MatrixXd& GetPaddingMatrix() const { return collision_padding_; }
 
   /** Sets the collision padding matrix. Note that this matrix contains all
    padding data, both robot-robot "self" padding, and robot-environment padding.
@@ -523,17 +524,17 @@ class CollisionChecker {
            properties. */
   void SetPaddingMatrix(const Eigen::MatrixXd& collision_padding);
 
-  /** Gets the current largest collision padding across all body pairs. */
-  double GetLargestPadding() const {
-    return max_collision_padding_;
-  }
+  /** Gets the current largest collision padding across all (robot, *) body
+   pairs. This excludes the meaningless zeros on the diagonal and
+   environment-environment pairs; the return value *can* be negative. */
+  double GetLargestPadding() const { return max_collision_padding_; }
 
   /** Sets the environment collision padding for the provided robot body with
    respect to all environment bodies.
    @throws std::exception if the @ref collision_checker_padding_prereqs
            "configuration prerequisites" are not met. */
   void SetPaddingOneRobotBodyAllEnvironmentPairs(
-      drake::multibody::BodyIndex body_index, double padding);
+      multibody::BodyIndex body_index, double padding);
 
   /** Sets the padding for all (robot, environement) pairs.
    @throws std::exception if the @ref collision_checker_padding_prereqs
@@ -550,13 +551,13 @@ class CollisionChecker {
   /** @name Collision filtering
 
    The %CollisionChecker adapts the idea of "collision filtering" to *bodies*
-   (see drake::geometry::CollisionFilterManager). In addition to whatever
+   (see geometry::CollisionFilterManager). In addition to whatever
    collision filters have been declared within the underlying model,
    %CollisionChecker provides mechanisms to layer *additional* filters by
    specifying a pair of bodies as being "filtered". No collisions or
    distance measurements are reported on filtered body pairs.
 
-   The "filter" state of all possible body pairs are stored in an NxN
+   The "filter" state of all possible body pairs are stored in a symmetric NxN
    integer-valued matrix, where N is the number of bodies reported by the
    plant owned by this collision checker.
 
@@ -629,30 +630,29 @@ class CollisionChecker {
   /** Checks if collision is filtered between the two bodies specified.
    Note: collision between two environment bodies is *always* filtered.
    @throws std::exception if either body index is out of range. */
-  bool IsCollisionFilteredBetween(
-      drake::multibody::BodyIndex bodyA_index,
-      drake::multibody::BodyIndex bodyB_index) const;
+  bool IsCollisionFilteredBetween(multibody::BodyIndex bodyA_index,
+                                  multibody::BodyIndex bodyB_index) const;
 
   /** Overload that uses body references. */
-  bool IsCollisionFilteredBetween(
-      const drake::multibody::Body<double>& bodyA,
-      const drake::multibody::Body<double>& bodyB) const {
+  bool IsCollisionFilteredBetween(const multibody::Body<double>& bodyA,
+                                  const multibody::Body<double>& bodyB) const {
     return IsCollisionFilteredBetween(bodyA.index(), bodyB.index());
   }
 
-  /** Declares the body pair (bodyA, bodyB) to be filtered (nor not) based on
+  /** Declares the body pair (bodyA, bodyB) to be filtered (or not) based on
    `filter_collision`.
    @param filter_collision Sets the to body pair to be filtered if `true`.
    @throws std::exception if either body index is out of range.
+   @throws std::exception if both indices refer to the same body.
    @throws std::exception if both indices refer to environment bodies. */
-  void SetCollisionFilteredBetween(drake::multibody::BodyIndex bodyA_index,
-                                   drake::multibody::BodyIndex bodyB_index,
+  void SetCollisionFilteredBetween(multibody::BodyIndex bodyA_index,
+                                   multibody::BodyIndex bodyB_index,
                                    bool filter_collision);
 
   /** Overload that uses body references. */
-  void SetCollisionFilteredBetween(
-      const drake::multibody::Body<double>& bodyA,
-      const drake::multibody::Body<double>& bodyB, bool filter_collision) {
+  void SetCollisionFilteredBetween(const multibody::Body<double>& bodyA,
+                                   const multibody::Body<double>& bodyB,
+                                   bool filter_collision) {
     SetCollisionFilteredBetween(bodyA.index(), bodyB.index(), filter_collision);
   }
 
@@ -660,8 +660,7 @@ class CollisionChecker {
    checker's plant).
    @throws std::exception if `body_index` is out of range.
    @throws std::exception if `body_index` refers to an environment body. */
-  void SetCollisionFilteredWithAllBodies(
-      drake::multibody::BodyIndex body_index);
+  void SetCollisionFilteredWithAllBodies(multibody::BodyIndex body_index);
 
   //@}
 
@@ -678,25 +677,27 @@ class CollisionChecker {
   /** Explicit Context-based version of CheckConfigCollisionFree().
    @throws std::exception if model_context is nullptr.
    @see @ref ccb_explicit_contexts "Explicit Context Parallelism". */
-  bool CheckContextConfigCollisionFree(
-      drake::planning::CollisionCheckerContext* model_context,
-      const Eigen::VectorXd& q) const;
+  bool CheckContextConfigCollisionFree(CollisionCheckerContext* model_context,
+                                       const Eigen::VectorXd& q) const;
 
+  // TODO(SeanCurtis-TRI): This isn't tested.
   /** Checks a vector of configurations for collision, evaluating in parallel
    when supported and enabled by `parallelize`. Parallelization in configuration
    collision checks is provided using OpenMP and is supported when both: (1) the
    collision checker declares that parallelization is supported (i.e. when
    SupportsParallelChecking() is true) and (2) when multiple OpenMP threads are
    available for execution.
-   Due to the internal parallelism, special care must be paid when calling this
-   method with `parallelize=true` from any thread that is not the main thread.
+   See @ref collision_checker_parallel_edge "function-level parallelism" for
+   guidance on proper usage.
    @param configs       Configurations to check
    @param parallelize   Should configuration collision checks be parallelized?
-   @returns std::vector<int8_t>, one for each configuration in configs. For each
-   configuration, 1 if collision free, 0 if in collision. */
-  std::vector<int8_t> CheckConfigsCollisionFree(
+   @returns std::vector<uint8_t>, one for each configuration in configs. For
+   each configuration, 1 if collision free, 0 if in collision. */
+  std::vector<uint8_t> CheckConfigsCollisionFree(
       const std::vector<Eigen::VectorXd>& configs,
       bool parallelize = true) const;
+
+  //@}
 
   /** @name Edge collision checking
 
@@ -709,13 +710,13 @@ class CollisionChecker {
    and reporting the edge to be collision free if all samples are collision
    free. Otherwise, we report the fraction of samples (starting with the start
    configuration) that reported to be collision free. The tested samples include
-   the start and end configurations, q1 and q2, respecitvely.
+   the start and end configurations, q1 and q2, respectively.
 
    %CollisionChecker doesn't know how an edge is defined. An edge can be
-   anything from a simple line (e.g. a linear path in C-space) to an arbitrarily
-   complex path (e.g. a Reeds-Shepp path). The shape of the edge is defined
-   implicitly by the ConfigurationInterpolationFunction as an interpolation
-   between two configurations `q1` and `q2` (see
+   anything from a simple line segment (e.g. a linear path in C-space) to an
+   arbitrarily complex path (e.g. a Reeds-Shepp path). The shape of the edge is
+   defined implicitly by the ConfigurationInterpolationFunction as an
+   interpolation between two configurations `q1` and `q2` (see
    SetConfigurationDistanceFunction() and
    SetConfigurationInterpolationFunction()).
 
@@ -730,7 +731,7 @@ class CollisionChecker {
    edge step size must be coordinated to ensure that edge collision checking is
    sufficiently accurate for your application.
 
-   <h4>Default functions</h4>
+   <u>Default functions</u>
 
    The configuration distance function is defined at construction (from
    CollisionCheckerParams). It can be as simple as `|q1 - q2|` or could be
@@ -745,14 +746,14 @@ class CollisionChecker {
 
    If all joints are revolute joints, one reasonable distance function is the
    weighted function `|wᵀ⋅(q1 − q2)|` where the weights are based on joint
-   speed. For joint dofs `J = [J₀, J₁, ...]` with corresponding maximum speeds
-   `[q̇⁰ₘ, q̇¹ₘ, ...]`, we identify the speed of the fastest joint
-   `q̇ₘₐₓ = maxᵢ(q̇ⁱₘ)` and define the per-dof weights as `wᵢ = q̇ₘₐₓ / q̇ⁱₘ`.
+   speed. For joint dofs `J = [J₀, J₁, ...]` with corresponding positive maximum
+   speeds `[s₀, s₁, ...]`, we identify the speed of the fastest joint
+   `sₘₐₓ = maxᵢ(sᵢ)` and define the per-dof weights as `wᵢ = sₘₐₓ / sᵢ`.
    Intuitively, the more time a particular joint requires to cover an angular
    distance, the more significance we attribute to that distance -- it's a
-   *time*-biased weighting function. The weights are unitless so the reported
+   _time_-biased weighting function. The weights are unitless so the reported
    distance is in radians. For some common arms (IIWA, Panda, UR, Jaco, etc.),
-   we have found that an edge step size of 0.05 radians to produce reasonable
+   we have found that an edge step size of 0.05 radians produces reasonable
    results.
 
    %CollisionChecker has a default interpolation function, as defined by
@@ -762,7 +763,8 @@ class CollisionChecker {
    any non-holonomic robot). You will need to provide your own interpolation
    function in such cases.
 
-   <h4>Function-level parallelism</h4>
+   @anchor collision_checker_parallel_edge
+   <u>Function-level parallelism</u>
 
    Parallelization in some edge collision checks is provided using OpenMP and is
    enabled when both: (1) the collision checker declares that parallelization is
@@ -770,10 +772,12 @@ class CollisionChecker {
    multiple OpenMP threads are available for execution.
 
    Due to this internal parallelism, special care must be paid when calling
-   these methods from any thread that is not the main thread.
+   these methods from any thread that is not the main thread; ensure that, for a
+   given collision checker instance, implicit context methods are only called
+   from one non-OpenMP thread at a given time.
 
-   <h4>Thoughts on configuring %CollisionChecker for edge collision
-       detection</h4>
+   <u>Thoughts on configuring %CollisionChecker for edge collision
+       detection</u>
 
    Because the edge collision check samples the edge, there is a perpetual
    trade off between the cost of evaluating the edge and the likelihood that
@@ -786,13 +790,13 @@ class CollisionChecker {
 
    There are two properties that will most directly contribute to the accuracy
    of the edge tests: edge step size and padding. Ultimately, any obstacle in
-   *C-space* whose measure is smaller than the edge step size is likely to be
+   _C-space_ whose measure is smaller than the edge step size is likely to be
    missed. The goal is to tune the parameters such that such features -- located
    in an area of interest (i.e., where you want your robot to operate) -- will
    have a low probability of being missed.
 
    Edge step size is very much a global parameter. It will increase the cost of
-   *every* collision check. If you are unable to anticipate where the small
+   _every_ collision check. If you are unable to anticipate where the small
    features are, a small edge step size will be robust to that uncertainty. As
    such, it serves as a good backstop. It comes at a cost of increasing the cost
    of *every* test, even for large geometries with nothing but coarse features.
@@ -817,7 +821,7 @@ class CollisionChecker {
    collision checker, so if the function has any lambda-captured data then
    that data must outlive this collision checker. */
   void SetConfigurationDistanceFunction(
-      const drake::planning::ConfigurationDistanceFunction& distance_function);
+      const ConfigurationDistanceFunction& distance_function);
 
   /** Computes configuration-space distance between the provided configurations
    `q_1` and `q_2`, using the distance function configured at construction-
@@ -834,8 +838,8 @@ class CollisionChecker {
    @warning do not pass this standalone function back into
    SetConfigurationDistanceFunction() function; doing so would create an
    infinite loop. */
-  drake::planning::ConfigurationDistanceFunction
-  MakeStandaloneConfigurationDistanceFunction() const;
+  ConfigurationDistanceFunction MakeStandaloneConfigurationDistanceFunction()
+      const;
 
   /** Sets the configuration interpolation function to `interpolation_function`.
 
@@ -849,16 +853,16 @@ class CollisionChecker {
    @note the default function uses linear interpolation for most variables,
    and uses slerp for quaternion valued variables.*/
   void SetConfigurationInterpolationFunction(
-      const drake::planning::ConfigurationInterpolationFunction&
-          interpolation_function);
+      const ConfigurationInterpolationFunction& interpolation_function);
 
   /** Interpolates between provided configurations `q_1` and `q_2`.
    @param ratio Interpolation ratio.
    @returns Interpolated configuration.
-   @throws std::exception if ratio is not in range [0, 1]. */
-  Eigen::VectorXd InterpolateBetweenConfigurations(
-      const Eigen::VectorXd& q_1, const Eigen::VectorXd& q_2,
-      double ratio) const {
+   @throws std::exception if ratio is not in range [0, 1].
+   @see ConfigurationInterpolationFunction for more. */
+  Eigen::VectorXd InterpolateBetweenConfigurations(const Eigen::VectorXd& q_1,
+                                                   const Eigen::VectorXd& q_2,
+                                                   double ratio) const {
     DRAKE_THROW_UNLESS(ratio >= 0.0 && ratio <= 1.0);
     return configuration_interpolation_function_(q_1, q_2, ratio);
   }
@@ -870,7 +874,7 @@ class CollisionChecker {
    @warning do not pass this standalone function back into our
    SetConfigurationInterpolationFunction() function; doing so would create
    an infinite loop. */
-  drake::planning::ConfigurationInterpolationFunction
+  ConfigurationInterpolationFunction
   MakeStandaloneConfigurationInterpolationFunction() const;
 
   /** Gets the current edge step size. */
@@ -895,30 +899,30 @@ class CollisionChecker {
   /** Explicit Context-based version of CheckEdgeCollisionFree().
    @throws std::exception if `model_context` is nullptr.
    @see @ref ccb_explicit_contexts "Explicit Context Parallelism". */
-  bool CheckContextEdgeCollisionFree(
-      drake::planning::CollisionCheckerContext* model_context,
-      const Eigen::VectorXd& q1, const Eigen::VectorXd& q2) const;
+  bool CheckContextEdgeCollisionFree(CollisionCheckerContext* model_context,
+                                     const Eigen::VectorXd& q1,
+                                     const Eigen::VectorXd& q2) const;
 
   /** Checks a single configuration-to-configuration edge for collision.
    Collision check is parallelized via OpenMP when supported.
-   Due to the internal parallelism, special care must be paid when calling this
-   method from any thread that is not the main thread.
+   See @ref collision_checker_parallel_edge "function-level parallelism" for
+   guidance on proper usage.
    @param q1 Start configuration for edge.
    @param q2 End configuration for edge.
    @returns true if collision free, false if in collision. */
   bool CheckEdgeCollisionFreeParallel(const Eigen::VectorXd& q1,
-                                   const Eigen::VectorXd& q2) const;
+                                      const Eigen::VectorXd& q2) const;
 
   /** Checks multiple configuration-to-configuration edges for collision.
    Collision checks are parallelized via OpenMP when supported and enabled by
    `parallelize`.
-   Due to the internal parallelism, special care must be paid when calling this
-   method with `parallelize=true` from any thread that is not the main thread.
+   See @ref collision_checker_parallel_edge "function-level parallelism" for
+   guidance on proper usage.
    @param edges        Edges to check, each in the form of pair<q1, q2>.
    @param parallelize  Should edge collision checks be parallelized?
-   @returns std::vector<int8_t>, one for each edge in edges. For each edge, 1 if
-   collision free, 0 if in collision. */
-  std::vector<int8_t> CheckEdgesCollisionFree(
+   @returns std::vector<uint8_t>, one for each edge in edges. For each edge, 1
+   if collision free, 0 if in collision. */
+  std::vector<uint8_t> CheckEdgesCollisionFree(
       const std::vector<std::pair<Eigen::VectorXd, Eigen::VectorXd>>& edges,
       bool parallelize = true) const;
 
@@ -935,24 +939,24 @@ class CollisionChecker {
    @throws std::exception if `model_context` is nullptr.
    @see @ref ccb_explicit_contexts "Explicit Context Parallelism". */
   EdgeMeasure MeasureContextEdgeCollisionFree(
-      drake::planning::CollisionCheckerContext* model_context,
-      const Eigen::VectorXd& q1, const Eigen::VectorXd& q2) const;
+      CollisionCheckerContext* model_context, const Eigen::VectorXd& q1,
+      const Eigen::VectorXd& q2) const;
 
   /** Checks a single configuration-to-configuration edge for collision.
    Collision check is parallelized via OpenMP when supported.
-   Due to the internal parallelism, special care must be paid when calling this
-   method from any thread that is not the main thread.
+   See @ref collision_checker_parallel_edge "function-level parallelism" for
+   guidance on proper usage.
    @param q1 Start configuration for edge.
    @param q2 End configuration for edge.
    @returns A measure of how much of the edge is collision free. */
-  EdgeMeasure MeasureEdgeCollisionFreeParallel(
-      const Eigen::VectorXd& q1, const Eigen::VectorXd& q2) const;
+  EdgeMeasure MeasureEdgeCollisionFreeParallel(const Eigen::VectorXd& q1,
+                                               const Eigen::VectorXd& q2) const;
 
   /** Checks multiple configuration-to-configuration edge for collision.
    Collision checks are parallelized via OpenMP when supported and enabled by
    `parallelize`.
-   Due to the internal parallelism, special care must be paid when calling this
-   method with `parallelize=true` from any thread that is not the main thread.
+   See @ref collision_checker_parallel_edge "function-level parallelism" for
+   guidance on proper usage.
    @param edges        Edges to check, each in the form of pair<q1, q2>.
    @param parallelize  Should edge collision checks be parallelized?
    @returns A measure of how much of each edge is collision free. The iᵗʰ entry
@@ -968,10 +972,13 @@ class CollisionChecker {
    These methods help characterize the robot's collision state with respect to
    a particular robot configuration.
 
-   The collision state includes its *clearance* -- a measure of how near to
-   collision the robot is -- as computed by CalcRobotClearance() and report
-   the boolean state of collision for each robot body as computed by
-   ClassifyBodyCollisions(). */
+   In this section, the "collision state" is characterized with two different
+   APIs:
+
+      - "clearance", a measure of how near to collision the robot as computed by
+         CalcRobotClearance(), and
+      - a boolean colliding state for each robot body as computed by
+        ClassifyBodyCollisions(). */
   //@{
 
   /** Calculates the distance, ϕ, and distance Jacobian, Jqᵣ_ϕ, for each
@@ -987,16 +994,18 @@ class CollisionChecker {
 
    The total number of rows can depend on how the model is defined and how a
    particular CollisionChecker instance is implemented (see MaxNumDistances()).
+   @see RobotClearance for details on the quantities ϕ and Jqᵣ_ϕ (and other
+   details).
    @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
-  drake::planning::RobotClearance CalcRobotClearance(
-      const Eigen::VectorXd& q, double influence_distance) const;
+  RobotClearance CalcRobotClearance(const Eigen::VectorXd& q,
+                                    double influence_distance) const;
 
   /** Explicit Context-based version of CalcRobotClearance().
    @throws std::exception if `model_context` is nullptr.
    @see @ref ccb_explicit_contexts "Explicit Context Parallelism". */
-  drake::planning::RobotClearance CalcContextRobotClearance(
-      drake::planning::CollisionCheckerContext* model_context,
-      const Eigen::VectorXd& q, double influence_distance) const;
+  RobotClearance CalcContextRobotClearance(
+      CollisionCheckerContext* model_context, const Eigen::VectorXd& q,
+      double influence_distance) const;
 
   /** Returns an upper bound on the number of distances returned by
    CalcRobotClearance(), using the current thread's associated context.
@@ -1006,7 +1015,7 @@ class CollisionChecker {
   /** Explicit Context-based version of MaxNumDistances().
    @see @ref ccb_explicit_contexts "Explicit Context Parallelism". */
   int MaxContextNumDistances(
-      const drake::planning::CollisionCheckerContext& model_context) const;
+      const CollisionCheckerContext& model_context) const;
 
   /** Classifies which robot bodies are in collision (and which type of
    collision) for the provided configuration `q`, using the current thread's
@@ -1016,16 +1025,14 @@ class CollisionChecker {
    environment bodies are populated with kNoCollision, regardless of their
    actual status.
    @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
-  std::vector<drake::planning::RobotCollisionType> ClassifyBodyCollisions(
+  std::vector<RobotCollisionType> ClassifyBodyCollisions(
       const Eigen::VectorXd& q) const;
 
   /** Explicit Context-based version of ClassifyBodyCollisions().
    @throws std::exception if `model_context` is nullptr.
    @see @ref ccb_explicit_contexts "Explicit Context Parallelism". */
-  std::vector<drake::planning::RobotCollisionType>
-  ClassifyContextBodyCollisions(
-      drake::planning::CollisionCheckerContext* model_context,
-      const Eigen::VectorXd& q) const;
+  std::vector<RobotCollisionType> ClassifyContextBodyCollisions(
+      CollisionCheckerContext* model_context, const Eigen::VectorXd& q) const;
 
   //@}
 
@@ -1038,7 +1045,7 @@ class CollisionChecker {
    checking (see SupportsParallelChecking()).
    @throws std::exception if params is invalid. @see CollisionCheckerParams.
    */
-  CollisionChecker(drake::planning::CollisionCheckerParams params,
+  CollisionChecker(CollisionCheckerParams params,
                    bool supports_parallel_checking);
 
   /** To support Clone(), allow copying (but not move nor assign). */
@@ -1053,9 +1060,9 @@ class CollisionChecker {
 
   /** Collision checkers that use derived context types can override this
    implementation to allocate their context type instead. */
-  virtual std::unique_ptr<drake::planning::CollisionCheckerContext>
-  CreatePrototypeContext() const {
-    return std::make_unique<drake::planning::CollisionCheckerContext>(&model());
+  virtual std::unique_ptr<CollisionCheckerContext> CreatePrototypeContext()
+      const {
+    return std::make_unique<CollisionCheckerContext>(&model());
   }
 
   /** @returns true if called during initial setup (before AllocateContexts()
@@ -1081,23 +1088,22 @@ class CollisionChecker {
    guarantees that `model_context` will not be nullptr and that the new
    positions are present in model_context->plant_context(). */
   virtual void DoUpdateContextPositions(
-      drake::planning::CollisionCheckerContext* model_context) const = 0;
+      CollisionCheckerContext* model_context) const = 0;
 
   /** Derived collision checkers are responsible for reporting the collision
    status of the configuration. CollisionChecker guarantees that the passed
    `model_context` has been updated with the configuration `q` supplied to the
    public method. */
   virtual bool DoCheckContextConfigCollisionFree(
-      const drake::planning::CollisionCheckerContext& model_context) const = 0;
+      const CollisionCheckerContext& model_context) const = 0;
 
   /** Does the work of adding a shape to be rigidly affixed to the body. Derived
    checkers can choose to ignore the request, but must return `nullopt` if they
    do so. */
-  virtual std::optional<drake::geometry::GeometryId> DoAddCollisionShapeToBody(
-      const std::string& group_name,
-      const drake::multibody::Body<double>& bodyA,
-      const drake::geometry::Shape& shape,
-      const drake::math::RigidTransform<double>& X_AG) = 0;
+  virtual std::optional<geometry::GeometryId> DoAddCollisionShapeToBody(
+      const std::string& group_name, const multibody::Body<double>& bodyA,
+      const geometry::Shape& shape,
+      const math::RigidTransform<double>& X_AG) = 0;
 
   /** Representation of an "added" shape. These are shapes that get added to
    the model via the CollisionChecker's Shape API. They encode the id for the
@@ -1105,16 +1111,16 @@ class CollisionChecker {
    geometry is affixed. */
   struct AddedShape {
     /** The id of the geometry. */
-    drake::geometry::GeometryId geometry_id;
+    geometry::GeometryId geometry_id;
 
     /** The index of the body the shape was added; could be robot or
      environment. */
-    drake::multibody::BodyIndex body_index;
+    multibody::BodyIndex body_index;
 
     /** The full body description.
      We have the invariant that `body_index` has the body and model instance
      names recorded in the description. */
-    drake::planning::BodyShapeDescription description;
+    BodyShapeDescription description;
   };
 
   /** Removes all of the given added shapes (if they exist) from the checker. */
@@ -1125,8 +1131,8 @@ class CollisionChecker {
    measurements. But they must adhere to the characteristics documented on
    RobotClearance, e.g., one measurement per row. CollisionChecker guarantees
    that `influence_distance` is finite and non-negative. */
-  virtual drake::planning::RobotClearance DoCalcContextRobotClearance(
-      const drake::planning::CollisionCheckerContext& model_context,
+  virtual RobotClearance DoCalcContextRobotClearance(
+      const CollisionCheckerContext& model_context,
       double influence_distance) const = 0;
 
   /** Derived collision checkers are responsible for choosing a collision type
@@ -1134,14 +1140,13 @@ class CollisionChecker {
    for ClassifyBodyCollisions. CollisionChecker guarantees that the passed
    `model_context` has been updated with the configuration `q` supplied to the
    public method. */
-  virtual std::vector<drake::planning::RobotCollisionType>
-  DoClassifyContextBodyCollisions(
-      const drake::planning::CollisionCheckerContext& model_context) const = 0;
+  virtual std::vector<RobotCollisionType> DoClassifyContextBodyCollisions(
+      const CollisionCheckerContext& model_context) const = 0;
 
   /** Derived collision checkers must implement the semantics documented for
    MaxNumDistances. CollisionChecker does nothing; it just calls this method. */
   virtual int DoMaxContextNumDistances(
-      const drake::planning::CollisionCheckerContext& model_context) const = 0;
+      const CollisionCheckerContext& model_context) const = 0;
 
   //@}
 
@@ -1156,17 +1161,7 @@ class CollisionChecker {
 
  private:
   /* @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
-  drake::planning::CollisionCheckerContext& mutable_model_context() const;
-
-  drake::planning::CollisionCheckerContext& mutable_model_context_by_index(
-      int index) const {
-    return owned_contexts_.get_mutable_model_context(index);
-  }
-
-  const drake::planning::CollisionCheckerContext& model_context_by_index(
-      int index) const {
-    return owned_contexts_.get_model_context(index);
-  }
+  CollisionCheckerContext& mutable_model_context() const;
 
   /* Tests the given filtered collision matrix for several invariants, throwing
    if they are not satisfied:
@@ -1200,9 +1195,9 @@ class CollisionChecker {
         the matrix is set to 1. */
   Eigen::MatrixXi GenerateFilteredCollisionMatrix() const;
 
-  void UpdateMaxCollisionPadding() {
-    max_collision_padding_ = collision_padding_.maxCoeff();
-  }
+  /* Updates the stored value representing the largest value found in the
+   padding matrix -- this excludes the meaningless zeros on the diagonal. */
+  void UpdateMaxCollisionPadding();
 
   /* Tests the given collision padding matrix for several invariants, throwing
    if they are not satisfied:
@@ -1218,10 +1213,18 @@ class CollisionChecker {
   /* Checks the same conditions as ValidatePaddingMatrix, but instead of
    throwing, returns the error message, or an empty string if no errors were
    found. */
-  std::string CriticizePaddingMatrix(
-      const Eigen::MatrixXd& padding, const char* func) const;
+  std::string CriticizePaddingMatrix(const Eigen::MatrixXd& padding,
+                                     const char* func) const;
 
-  /* @note this class has two phases: `empty()` (before calling
+  /* This class allocates and maintains the contexts associated with OpenMP
+   threads. When the CollisionChecker is evaluated in its implicit mode, the
+   contexts used are drawn from this collection and each context is associated
+   explicitly with one available OpenMP thread.
+
+   In addition, this container takes ownership of a reference "prototype"
+   context (see below for details about the prototype context).
+
+   @note this class has two phases: `empty()` (before calling
    AllocateOwnedContexts()), and `allocated()`. In the `empty()` phase,
    `num_contexts()` returns 0, and all methods that access a context will
    throw. */
@@ -1229,10 +1232,10 @@ class CollisionChecker {
    public:
     OwnedContextKeeper() {}
 
+    ~OwnedContextKeeper();
+
     /* The copy constructor is used to implement our outer class's Clone(). */
-    explicit OwnedContextKeeper(const OwnedContextKeeper& other) {
-      AllocateOwnedContexts(other.prototype_context(), other.num_contexts());
-    }
+    explicit OwnedContextKeeper(const OwnedContextKeeper& other);
 
     /* Does not allow assignment. */
     void operator=(const OwnedContextKeeper&) = delete;
@@ -1243,9 +1246,8 @@ class CollisionChecker {
      CollisionChecker::AllocateContexts can't be called in the
      CollisionChecker constructor.
      @throws std::exception if called more than once. */
-    void AllocateOwnedContexts(
-        const drake::planning::CollisionCheckerContext& prototype_context,
-        int num_contexts);
+    void AllocateOwnedContexts(const CollisionCheckerContext& prototype_context,
+                               int num_contexts);
 
     /* @returns true if the keeper is empty. In the empty state, there are no
      contexts allocated and no prototype context is available. */
@@ -1262,32 +1264,29 @@ class CollisionChecker {
     int num_contexts() const { return model_contexts_.size(); }
 
     /* Gets the special "prototype" context used for copy & clone operations. */
-    const drake::planning::CollisionCheckerContext& prototype_context() const {
+    const CollisionCheckerContext& prototype_context() const {
       // The prototype context is only available in the allocated phase.
       DRAKE_THROW_UNLESS(allocated());
       return *prototype_context_;
     }
 
-    drake::planning::CollisionCheckerContext& get_mutable_model_context(
-        int index) const {
+    CollisionCheckerContext& get_mutable_model_context(int index) const {
       return *model_contexts_.at(index);
     }
 
-    const drake::planning::CollisionCheckerContext& get_model_context(
-        int index) const {
+    const CollisionCheckerContext& get_model_context(int index) const {
       return *model_contexts_.at(index);
     }
 
-    /* Performs the provided `operation` on all owned contexts. */
+    /* Performs the provided `operation` on all owned contexts.
+     @pre operation != nullptr; */
     void PerformOperationAgainstAllOwnedContexts(
         const RobotDiagram<double>& model,
         const std::function<void(const RobotDiagram<double>&,
-                                 drake::planning::CollisionCheckerContext*)>&
-            operation);
+                                 CollisionCheckerContext*)>& operation);
 
    private:
-    std::vector<std::unique_ptr<drake::planning::CollisionCheckerContext>>
-        model_contexts_;
+    std::vector<std::unique_ptr<CollisionCheckerContext>> model_contexts_;
 
     /* This prototype context plays an important role. The CollisionChecker is
      supposed to allow the execution of *any* const methods in parallel without
@@ -1306,13 +1305,21 @@ class CollisionChecker {
      this prototype context is bit-identical with all of the owned and
      standalone contexts for this CollisionChecker (except for those differences
      directly attributable to setting the qs in MbP). */
-    std::unique_ptr<drake::planning::CollisionCheckerContext>
-        prototype_context_;
+    std::unique_ptr<CollisionCheckerContext> prototype_context_;
   };
 
+  /* When a non-OpenMP threading system is used, users of CollisionChecker must
+   request "standalone" contexts. This keeps a *weak* reference to each of the
+   allocated standalone contexts so that they can be updated in lock step with
+   all other contexts in response to PerformOperationAgainstAllModelContexts().
+
+   The references are weak references so that the user has full control over
+   the lifespan of the standalone contexts. */
   class StandaloneContextReferenceKeeper {
    public:
     StandaloneContextReferenceKeeper() {}
+
+    ~StandaloneContextReferenceKeeper();
 
     /* The copy constructor is used to implement our outer class's Clone(). */
     explicit StandaloneContextReferenceKeeper(
@@ -1323,25 +1330,19 @@ class CollisionChecker {
     /* Does not allow assignment. */
     void operator=(const StandaloneContextReferenceKeeper&) = delete;
 
-    void AddStandaloneContext(
-        const std::shared_ptr<drake::planning::CollisionCheckerContext>&
-            standalone_context) const {
-      std::lock_guard<std::mutex> lock(standalone_contexts_mutex_);
-      standalone_contexts_.push_back(
-          std::weak_ptr<drake::planning::CollisionCheckerContext>(
-              standalone_context));
-    }
+    void AddStandaloneContext(const std::shared_ptr<CollisionCheckerContext>&
+                                  standalone_context) const;
 
     /* Performs the provided `operation` on all live referenced contexts, and
-     removes any references to dead contexts. */
+     removes any references to dead contexts.
+     @pre operation != nullptr; */
     void PerformOperationAgainstAllStandaloneContexts(
         const RobotDiagram<double>& model,
         const std::function<void(const RobotDiagram<double>&,
-                                 drake::planning::CollisionCheckerContext*)>&
-            operation);
+                                 CollisionCheckerContext*)>& operation);
 
    private:
-    mutable std::list<std::weak_ptr<drake::planning::CollisionCheckerContext>>
+    mutable std::list<std::weak_ptr<CollisionCheckerContext>>
         standalone_contexts_;
     mutable std::mutex standalone_contexts_mutex_;
   };
@@ -1362,8 +1363,7 @@ class CollisionChecker {
 
   /* We maintain a set of all robot model instances for lookups. This vector is
    already de-duplicated and sorted. */
-  const std::vector<drake::multibody::ModelInstanceIndex>
-      robot_model_instances_;
+  const std::vector<multibody::ModelInstanceIndex> robot_model_instances_;
 
   /* The set of indices in q that kinematically affect the robot_model_instances
    but which are not themselves part of robot_model_instances (e.g., a mobile
@@ -1371,12 +1371,10 @@ class CollisionChecker {
   const std::vector<int> uncontrolled_dofs_that_kinematically_affect_the_robot_;
 
   /* Function to compute distance between two configurations. */
-  drake::planning::ConfigurationDistanceFunction
-      configuration_distance_function_;
+  ConfigurationDistanceFunction configuration_distance_function_;
 
   /* Function to interpolate between two configurations. */
-  drake::planning::ConfigurationInterpolationFunction
-      configuration_interpolation_function_;
+  ConfigurationInterpolationFunction configuration_interpolation_function_;
 
   /* Step size for edge collision checking. */
   double edge_step_size_ = 0.0;
@@ -1406,4 +1404,4 @@ class CollisionChecker {
 };
 
 }  // namespace planning
-}  // namespace anzu
+}  // namespace drake

--- a/planning/edge_measure.h
+++ b/planning/edge_measure.h
@@ -1,0 +1,88 @@
+#pragma once
+
+namespace anzu {
+namespace planning {
+
+/** The measure of the distance of the edge from q1 to q2 and the portion of
+ that is collision free.
+
+ Distance is that produced by CollisionChecker::ComputeConfigurationDistance()
+ for the entire edge between q1 and q2.
+
+ The portion of the edge between q1 and q2 that is collision free is encoded as
+ the value α with the following semantics:
+
+ - α = 1:
+     No collisions were detected. The full edge can be considered collision
+     free. This is the *only* time completely_free() reports `true`.
+ - 0 ≤ α < 1:
+     A collision was detected between q1 and q2. α is the *largest*
+     interpolation value such that (q, qα) can be considered collision free
+     (where qα = interpolate(q1, q2, α)). partially_free() reports `true`.
+ - α is undefined:
+     q1 was found to be in collision. That means there exists no α for which the
+     edge (q1, qα) can be collision free.
+
+ @note The length of the collision-free edge can be computed via distance * α.
+ To simplify comparisons between a number of edges, some of which may not have a
+ defined α, the function alpha_or(default_value) is provided. This is equivalent
+ to `edge.partially_free() ? edge.alpha() : default_value`.
+
+ @note For α to be meaningful, the caller is obliged to make sure that they
+ use the same interpolating function as the CollisionChecker did when generating
+ the measure. Calling CollisionChecker::InterpolateBetweenConfigurations() on
+ the same checker instance would satisfy that requirement. */
+class EdgeMeasure {
+ public:
+  /** @pre `0 ≤ distance`
+   @pre `0 ≤ alpha ≤ 1` to indicate defined `alpha`, negative otherwise. */
+  EdgeMeasure(double distance, double alpha)
+      : distance_(distance), alpha_(alpha < 0 ? -1 : alpha) {
+    DRAKE_THROW_UNLESS(distance >= 0.0);
+    DRAKE_THROW_UNLESS(alpha <= 1.0);
+  }
+
+  /** Reports `true` if all samples were collision free. */
+  bool completely_free() const { return alpha_ == 1.0; }
+
+  /** Reports `true` if there's *any* portion of the edge (starting from q1)
+   that is collision free. By implication, if completely_free() reports
+   `true`, so will this. */
+  bool partially_free() const { return alpha_ >= 0.0; }
+
+  /* Returns the edge distance. */
+  double distance() const { return distance_; }
+
+  /* Returns the value of alpha, if defined.
+
+   Note: Due to the sampling nature of the edge check, the edge (q1, qα) may not
+   actually be collision free (due to a missed collision). There's a further
+   subtlety. Subsequently calling CheckEdgeCollisionFree(q1, qα) may return
+   `false`. This apparent contradiction is due to the fact that the samples
+   on the edge (q1, qα) will not necessarily be the same as the samples
+   originally tested on the edge (q1, q2). It is possible for those new samples
+   to detect a previously missed collision. This is not a bug, merely a property
+   of sampling-based testing.
+
+   @pre partially_free() returns `true`. */
+  double alpha() const {
+    DRAKE_THROW_UNLESS(partially_free());
+    return alpha_;
+  }
+
+  /* Returns the value of alpha, if defined, or the provided default value. */
+  double alpha_or(double default_value) const {
+    if (partially_free()) {
+      return alpha_;
+    } else {
+      return default_value;
+    }
+  }
+
+ private:
+  double distance_{};
+  double alpha_{};  // -1 implies invalid; caller is not obliged to know this.
+};
+
+}  // namespace planning
+}  // namespace anzu

--- a/planning/edge_measure.h
+++ b/planning/edge_measure.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace anzu {
+namespace drake {
 namespace planning {
 
 /** The measure of the distance of the edge from q1 to q2 and the portion of
@@ -17,8 +17,9 @@ namespace planning {
      free. This is the *only* time completely_free() reports `true`.
  - 0 ≤ α < 1:
      A collision was detected between q1 and q2. α is the *largest*
-     interpolation value such that (q, qα) can be considered collision free
-     (where qα = interpolate(q1, q2, α)). partially_free() reports `true`.
+     interpolation value such that an edge from q to qα can be considered
+     collision free (where qα = interpolate(q1, q2, α)). partially_free()
+     reports `true`.
  - α is undefined:
      q1 was found to be in collision. That means there exists no α for which the
      edge (q1, qα) can be collision free.
@@ -50,10 +51,10 @@ class EdgeMeasure {
    `true`, so will this. */
   bool partially_free() const { return alpha_ >= 0.0; }
 
-  /* Returns the edge distance. */
+  /** Returns the edge distance. */
   double distance() const { return distance_; }
 
-  /* Returns the value of alpha, if defined.
+  /** Returns the value of alpha, if defined.
 
    Note: Due to the sampling nature of the edge check, the edge (q1, qα) may not
    actually be collision free (due to a missed collision). There's a further
@@ -70,7 +71,7 @@ class EdgeMeasure {
     return alpha_;
   }
 
-  /* Returns the value of alpha, if defined, or the provided default value. */
+  /** Returns the value of alpha, if defined, or the provided default value. */
   double alpha_or(double default_value) const {
     if (partially_free()) {
       return alpha_;
@@ -85,4 +86,4 @@ class EdgeMeasure {
 };
 
 }  // namespace planning
-}  // namespace anzu
+}  // namespace drake

--- a/planning/test/collision_checker_test.cc
+++ b/planning/test/collision_checker_test.cc
@@ -1,6 +1,7 @@
 #include "planning/collision_checker.h"
 
 #include <chrono>
+#include <map>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -14,10 +15,9 @@
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/planning/robot_diagram_builder.h"
-#include "planning/test/planning_test_helpers.h"
-#include "planning/unimplemented_collision_checker.h"
+#include "drake/planning/unimplemented_collision_checker.h"
 
-namespace anzu {
+namespace drake {
 namespace planning {
 
 // Support for easily comparing EdgeMeasurements.
@@ -39,37 +39,33 @@ std::ostream& operator<<(std::ostream& out, const EdgeMeasure& r) {
 
 namespace {
 
-using drake::CompareMatrices;
-using drake::geometry::CollisionFilterDeclaration;
-using drake::geometry::FrameId;
-using drake::geometry::GeometryId;
-using drake::geometry::GeometrySet;
-using drake::geometry::Role;
-using drake::geometry::Shape;
-using drake::geometry::Sphere;
-using drake::math::RigidTransform;
-using drake::math::RigidTransformd;
-using drake::math::RotationMatrixd;
-using drake::multibody::Body;
-using drake::multibody::BodyIndex;
-using drake::multibody::CoulombFriction;
-using drake::multibody::default_model_instance;
-using drake::multibody::ModelInstanceIndex;
-using drake::multibody::MultibodyPlant;
-using drake::multibody::RevoluteJoint;
-using drake::multibody::RigidBody;
-using drake::multibody::SpatialInertia;
-using drake::multibody::world_model_instance;
-using drake::planning::BodyShapeDescription;
-using drake::planning::CollisionCheckerContext;
-using drake::planning::CollisionCheckerParams;
-using drake::planning::ConfigurationDistanceFunction;
-using drake::planning::ConfigurationInterpolationFunction;
-using drake::planning::RobotClearance;
-using drake::planning::RobotCollisionType;
-using drake::planning::RobotDiagram;
-using drake::planning::RobotDiagramBuilder;
-using drake::systems::Context;
+#if defined(_OPENMP)
+constexpr bool kHasOpenmp = true;
+#else
+constexpr bool kHasOpenmp = false;
+#endif
+
+using geometry::CollisionFilterDeclaration;
+using geometry::FrameId;
+using geometry::GeometryId;
+using geometry::GeometrySet;
+using geometry::Role;
+using geometry::Shape;
+using geometry::Sphere;
+using math::RigidTransform;
+using math::RigidTransformd;
+using math::RotationMatrixd;
+using multibody::Body;
+using multibody::BodyIndex;
+using multibody::CoulombFriction;
+using multibody::default_model_instance;
+using multibody::ModelInstanceIndex;
+using multibody::MultibodyPlant;
+using multibody::RevoluteJoint;
+using multibody::RigidBody;
+using multibody::SpatialInertia;
+using multibody::world_model_instance;
+using systems::Context;
 using Eigen::AngleAxisd;
 using Eigen::Vector3d;
 using Eigen::VectorXd;
@@ -78,6 +74,32 @@ using std::optional;
 using std::pair;
 using std::vector;
 using testing::ElementsAre;
+
+// TODO(SeanCurtis-TRI): This was pulled out of
+// anzu/planning/planning_test_helpers. As more of planning gets pulled into
+// drake, rehome this in the drake equivalent file.
+ModelInstanceIndex AddChain(MultibodyPlant<double>* plant, int n,
+                            int num_geo = 1) {
+  ModelInstanceIndex instance = plant->AddModelInstance(fmt::format("m{}", n));
+  std::vector<const RigidBody<double>*> bodies;
+  for (int k = 0; k < n; ++k) {
+    bodies.push_back(
+        &plant->AddRigidBody(fmt::format("b{}", k), instance,
+                             SpatialInertia<double>::MakeUnitary()));
+    if (plant->geometry_source_is_registered()) {
+      for (int i = 0; i < num_geo; ++i) {
+        plant->RegisterCollisionGeometry(
+            *bodies.back(), RigidTransformd::Identity(), Sphere(0.01),
+            fmt::format("g{}", i), CoulombFriction<double>());
+      }
+    }
+  }
+  for (int k = 1; k < n; ++k) {
+    plant->AddJoint<RevoluteJoint>(fmt::format("j{}", k), *bodies[k - 1], {},
+                                   *bodies[k], {}, Eigen::Vector3d::UnitY());
+  }
+  return instance;
+}
 
 // Adds a new model instance consisting of a non-zero number of floating bodies.
 ModelInstanceIndex AddEnvironmentModelInstance(MultibodyPlant<double>* plant,
@@ -138,6 +160,11 @@ class CollisionCheckerTester : public UnimplementedCollisionChecker {
       const std::string&, const Body<double>&, const Shape&,
       const RigidTransform<double>&) override {
     return added_shape_id_;
+  }
+
+  void DoRemoveAddedGeometries(
+      const std::vector<CollisionChecker::AddedShape>& shapes) override {
+    // Don't need to do work; just don't throw.
   }
 
   RobotClearance DoCalcContextRobotClearance(
@@ -330,7 +357,7 @@ class CollisionCheckerThrowTest : public testing::Test {
 
 TEST_F(CollisionCheckerThrowTest, BadFn) {
   distance_fn_ = {};
-  ExpectConstructorThrow(".*bad.*function.*");
+  ExpectConstructorThrow(".*distance_function != nullptr.*");
 }
 
 TEST_F(CollisionCheckerThrowTest, BadStepSize) {
@@ -404,14 +431,14 @@ GTEST_TEST(CollisionCheckerTest, CollisionCheckerEmpty) {
             };
 
   // Examples of methods that throw with no contexts allocated. Derived classes
-  // will typically allocate contexts during construction.
-  DRAKE_EXPECT_THROWS_MESSAGE(dut.plant_context(), ".*range_check.*");
-  DRAKE_EXPECT_THROWS_MESSAGE(dut.model_context(), ".*range_check.*");
-  DRAKE_EXPECT_THROWS_MESSAGE(dut.Clone(), ".*allocated().*failed.*");
-  DRAKE_EXPECT_THROWS_MESSAGE(dut.MakeStandaloneModelContext(),
-                              ".*allocated().*failed.*");
-  DRAKE_EXPECT_THROWS_MESSAGE(dut.PerformOperationAgainstAllModelContexts(op),
-                              ".*allocated().*failed.*");
+  // are required to allocate contexts during construction. This is proof that
+  // such an erroneous implementation can't appear functional.
+  EXPECT_THROW(dut.plant_context(), std::exception);
+  EXPECT_THROW(dut.model_context(), std::exception);
+  EXPECT_THROW(dut.Clone(), std::exception);
+  EXPECT_THROW(dut.MakeStandaloneModelContext(), std::exception);
+  EXPECT_THROW(dut.PerformOperationAgainstAllModelContexts(op), std::exception);
+
   dut.AllocateContexts();
   EXPECT_NO_THROW(dut.plant_context());
   EXPECT_NO_THROW(dut.model_context());
@@ -466,6 +493,9 @@ GTEST_TEST(CollisionCheckerTest, MutableSetupModel) {
 // Calling MaxNumDistance() simply defaults to the NVI implementation; we'll
 // confirm we get back the magic number: 13.
 GTEST_TEST(CollisionCheckerTest, RobotClearance) {
+  // These tests only call the *implicit* method; they assume that the implicit
+  // method always simply calls the explicit method, so that we're testing
+  // both in one fell swoop.
   auto [robot, robot_index] =
       MakeModel({.weld_robot = false, .on_env_base = true});
   std::unique_ptr<CollisionCheckerTester> checker =
@@ -544,29 +574,35 @@ class TrivialCollisionCheckerTest : public testing::Test {
 };
 
 TEST_F(TrivialCollisionCheckerTest, ClonesAndContexts) {
-  EXPECT_NE(dut_->Clone(), nullptr);
-
   const auto count_contexts =
-      [&]() {
+      [](CollisionChecker* checker) {
         int count{0};
         auto op = [&count](const RobotDiagram<double>&,
                            CollisionCheckerContext*) { ++count; };
-        dut_->PerformOperationAgainstAllModelContexts(op);
+        checker->PerformOperationAgainstAllModelContexts(op);
         return count;
       };
-  EXPECT_EQ(count_contexts(),
+
+  EXPECT_EQ(count_contexts(dut_.get()),
             dut_->num_allocated_contexts()
             + 1);  // prototype context
 
   // Add one standalone context.
   auto context = dut_->MakeStandaloneModelContext();
-  EXPECT_EQ(count_contexts(),
+  EXPECT_EQ(count_contexts(dut_.get()),
             dut_->num_allocated_contexts()
             + 1  // prototype context
             + 1);  // our standalone context
 
+  auto cloned = dut_->Clone();
+  EXPECT_NE(cloned, nullptr);
+  EXPECT_EQ(count_contexts(cloned.get()),
+            dut_->num_allocated_contexts()  // Allocated context count matches.
+            + 1  // prototype context
+            + 0);  // standalone context has not been carried over.
+
   context.reset();  // Give up our standalone context.
-  EXPECT_EQ(count_contexts(),
+  EXPECT_EQ(count_contexts(dut_.get()),
             dut_->num_allocated_contexts()
             + 1);  // prototype context
 }
@@ -579,14 +615,21 @@ TEST_F(TrivialCollisionCheckerTest, Padding) {
 
   EXPECT_EQ(dut_->MaybeGetUniformRobotEnvironmentPadding(), 0);
   EXPECT_EQ(dut_->MaybeGetUniformRobotRobotPadding(), 0);
+  EXPECT_EQ(dut_->GetLargestPadding(), 0);
 
-  EXPECT_NO_THROW(dut_->SetPaddingBetween(BodyIndex(2), BodyIndex(3), 0.1));
+  EXPECT_NO_THROW(dut_->SetPaddingBetween(BodyIndex(2), BodyIndex(3), -0.1));
+  EXPECT_EQ(dut_->GetLargestPadding(), 0);
   EXPECT_EQ(dut_->CriticizePaddingMatrix(), "");
-  EXPECT_EQ(dut_->GetPaddingBetween(BodyIndex(2), BodyIndex(3)), 0.1);
+  EXPECT_EQ(dut_->GetPaddingBetween(BodyIndex(2), BodyIndex(3)), -0.1);
   EXPECT_NO_THROW(dut_->SetPaddingBetween(b2, b3, 0.01));
+  EXPECT_EQ(dut_->GetLargestPadding(), 0.01);
   EXPECT_EQ(dut_->CriticizePaddingMatrix(), "");
   EXPECT_EQ(dut_->GetPaddingBetween(b2, b3), 0.01);
   EXPECT_EQ(dut_->MaybeGetUniformRobotRobotPadding(), std::nullopt);
+
+  // Padding between an object and itself is always zero.
+  EXPECT_EQ(dut_->GetPaddingBetween(b2, b2), 0);
+  EXPECT_EQ(dut_->GetPaddingBetween(b3, b3), 0);
 
   EXPECT_NO_THROW(dut_->SetPaddingBetween(BodyIndex(0), BodyIndex(3), 0.1));
   EXPECT_EQ(dut_->CriticizePaddingMatrix(), "");
@@ -594,25 +637,41 @@ TEST_F(TrivialCollisionCheckerTest, Padding) {
 
   EXPECT_NO_THROW(
       dut_->SetPaddingMatrix(Eigen::MatrixXd::Zero(nbodies, nbodies)));
+  EXPECT_EQ(dut_->GetLargestPadding(), 0);
   EXPECT_EQ(dut_->CriticizePaddingMatrix(), "");
   EXPECT_EQ(dut_->MaybeGetUniformRobotEnvironmentPadding(), 0);
   EXPECT_EQ(dut_->MaybeGetUniformRobotRobotPadding(), 0);
 
+  // Confirm negative values come through.
+  EXPECT_NO_THROW(dut_->SetPaddingAllRobotEnvironmentPairs(-1));
+  EXPECT_NO_THROW(dut_->SetPaddingAllRobotRobotPairs(-2));
+  EXPECT_EQ(dut_->GetLargestPadding(), -1);
+  EXPECT_EQ(dut_->CriticizePaddingMatrix(), "");
+  EXPECT_EQ(dut_->MaybeGetUniformRobotEnvironmentPadding(), -1);
+  EXPECT_EQ(dut_->MaybeGetUniformRobotRobotPadding(), -2);
+
+  // Reset.
+  EXPECT_NO_THROW(
+      dut_->SetPaddingMatrix(Eigen::MatrixXd::Zero(nbodies, nbodies)));
+
   EXPECT_NO_THROW(
       dut_->SetPaddingOneRobotBodyAllEnvironmentPairs(BodyIndex(3), 0.01));
+  EXPECT_EQ(dut_->GetLargestPadding(), 0.01);
   EXPECT_EQ(dut_->CriticizePaddingMatrix(), "");
   EXPECT_EQ(dut_->MaybeGetUniformRobotEnvironmentPadding(), std::nullopt);
   EXPECT_EQ(dut_->MaybeGetUniformRobotRobotPadding(), 0);
 
-  EXPECT_NO_THROW(dut_->SetPaddingAllRobotEnvironmentPairs(0.01));
+  EXPECT_NO_THROW(dut_->SetPaddingAllRobotEnvironmentPairs(0.02));
+  EXPECT_EQ(dut_->GetLargestPadding(), 0.02);
   EXPECT_EQ(dut_->CriticizePaddingMatrix(), "");
-  EXPECT_EQ(dut_->MaybeGetUniformRobotEnvironmentPadding(), 0.01);
+  EXPECT_EQ(dut_->MaybeGetUniformRobotEnvironmentPadding(), 0.02);
   EXPECT_EQ(dut_->MaybeGetUniformRobotRobotPadding(), 0);
 
-  EXPECT_NO_THROW(dut_->SetPaddingAllRobotRobotPairs(0.02));
+  EXPECT_NO_THROW(dut_->SetPaddingAllRobotRobotPairs(0.03));
+  EXPECT_EQ(dut_->GetLargestPadding(), 0.03);
   EXPECT_EQ(dut_->CriticizePaddingMatrix(), "");
-  EXPECT_EQ(dut_->MaybeGetUniformRobotEnvironmentPadding(), 0.01);
-  EXPECT_EQ(dut_->MaybeGetUniformRobotRobotPadding(), 0.02);
+  EXPECT_EQ(dut_->MaybeGetUniformRobotEnvironmentPadding(), 0.02);
+  EXPECT_EQ(dut_->MaybeGetUniformRobotRobotPadding(), 0.03);
 }
 
 // Tests the ValidatePaddingMatrix() method by exercising SetPaddingMatrix() and
@@ -629,8 +688,8 @@ TEST_F(TrivialCollisionCheckerTest, SetPaddingMatrix) {
   EXPECT_EQ(dut_->MaybeGetUniformRobotEnvironmentPadding(), 0.0);
   EXPECT_EQ(dut_->MaybeGetUniformRobotRobotPadding(), 0.0);
   Eigen::MatrixXd padding = Eigen::MatrixXd::Zero(num_bodies, num_bodies);
-  padding(1, 2) = 1;
-  padding(2, 1) = 1;
+  padding(1, 2) = -1;
+  padding(2, 1) = -1;
   padding(1, 4) = 2;
   padding(4, 1) = 2;
   ASSERT_NO_THROW(dut_->SetPaddingMatrix(padding));
@@ -735,6 +794,7 @@ TEST_F(TrivialCollisionCheckerTest, Shapes) {
   const BodyShapeDescription body_shape{sphere, {}, "m3", "b0"};
   const auto& b1 = dut_->get_body(BodyIndex(1));
   for (bool can_add : {false, true}) {
+    SCOPED_TRACE(fmt::format("Can add shapes: {}", can_add));
     dut_->SetCanAddCollisionShapes(can_add);
 
     EXPECT_EQ(dut_->AddCollisionShape("test", body_shape), can_add);
@@ -748,9 +808,31 @@ TEST_F(TrivialCollisionCheckerTest, Shapes) {
                   {{"test", expected_count}, {"test2", expected_count}})));
 
     EXPECT_EQ(
-        dut_->AddCollisionShapeToFrame("test", b1.body_frame(), sphere, {}),
+        dut_->AddCollisionShapeToFrame("test3", b1.body_frame(), sphere, {}),
         can_add);
-    EXPECT_EQ(dut_->AddCollisionShapeToBody("test", b1, sphere, {}), can_add);
+    EXPECT_EQ(dut_->AddCollisionShapeToBody("test3", b1, sphere, {}), can_add);
+
+    const std::map<std::string, std::vector<BodyShapeDescription>> all_shapes =
+        dut_->GetAllAddedCollisionShapes();
+    if (can_add) {
+      // Three groups with a number of shapes added to each group.
+      EXPECT_EQ(all_shapes.size(), 3);
+      EXPECT_EQ(all_shapes.at("test").size(), 3);
+      EXPECT_EQ(all_shapes.at("test2").size(), 1);
+      EXPECT_EQ(all_shapes.at("test3").size(), 2);
+
+      // Remove a single group by name (with multiple shapes).
+      EXPECT_NO_THROW(dut_->RemoveAllAddedCollisionShapes("test"));
+      EXPECT_EQ(dut_->GetAllAddedCollisionShapes().size(), 2);
+      EXPECT_EQ(all_shapes.at("test2").size(), 1);
+      EXPECT_EQ(all_shapes.at("test3").size(), 2);
+
+      // Remove remaining groups entirely.
+      EXPECT_NO_THROW(dut_->RemoveAllAddedCollisionShapes());
+      EXPECT_EQ(dut_->GetAllAddedCollisionShapes().size(), 0);
+    } else {
+      EXPECT_EQ(all_shapes.size(), 0);
+    }
   }
 }
 
@@ -835,7 +917,8 @@ TEST_F(TrivialCollisionCheckerTest, CheckConfigCollisionFree) {
 
 // Tests the ValidateFilteredCollisionMatrix() method by exercising
 // SetCollisionFilterMatrix() and passing otherwise invalid filtered
-// specifications.
+// specifications. Other APIs that attempt to manipulate the matrix are covered
+// in their own tests (including their failure conditions).
 TEST_F(TrivialCollisionCheckerTest, SetCollisionFilterMatrix) {
   const int num_bodies = dut_->plant().num_bodies();
   // Bodies 1, 2, 3 are robot bodies and bodies 4 and 5 are environment (and
@@ -1007,7 +1090,7 @@ TEST_F(TrivialCollisionCheckerTest, CollisionFiltersNominal) {
 
   {
     // Underlying model has collision filters added, but nothing welded;
-    // should be -1s and 0, except for where the collision filter has been
+    // should be -1s and 0s, except for where the collision filter has been
     // specified.
     auto [robot, robot_index] = MakeModel({.weld_robot = false});
     auto& scene_graph = robot->mutable_scene_graph();
@@ -1052,7 +1135,7 @@ TEST_F(TrivialCollisionCheckerTest, CollisionFiltersNominal) {
 
     DRAKE_EXPECT_THROWS_MESSAGE(
         MakeUnallocatedChecker(move(robot), {robot_index}),
-        ".*filtering between body .+ is inconsistent");
+        ".*SceneGraph's collision filters .+ are not homogeneous.*");
   }
 }
 
@@ -1074,14 +1157,24 @@ TEST_F(TrivialCollisionCheckerTest, SetCollisionFilteredBetween) {
   // override delegates to it.
 
   {
-    // Trying to set collision filters between environment bodies. It always
-    // throws.
+    // Error conditions.
+    // Both bodies are environment bodies.
     DRAKE_EXPECT_THROWS_MESSAGE(
         dut_->SetCollisionFilteredBetween(b[0], b[4], true),
         ".* cannot be used on pairs of environment bodies.*");
     DRAKE_EXPECT_THROWS_MESSAGE(
         dut_->SetCollisionFilteredBetween(b[0], b[4], false),
         ".* cannot be used on pairs of environment bodies.*");
+
+    // Out of range indices.
+    EXPECT_THROW(dut_->SetCollisionFilteredBetween(b[0], BodyIndex(10), true),
+                 std::exception);
+    EXPECT_THROW(dut_->SetCollisionFilteredBetween(BodyIndex(10), b[0], true),
+                 std::exception);
+
+    // Trying to set filter on a robot body with itself.
+    EXPECT_THROW(dut_->SetCollisionFilteredBetween(b[1], b[1], true),
+                 std::exception);
   }
 
   {
@@ -1156,7 +1249,7 @@ TEST_F(TrivialCollisionCheckerTest, SetCollisionFilteredWithAllBodies) {
 // Simple tests against the IsCollisionFilteredBetween() API. It assumes the
 // collision filter matrix is consistent and known and simply confirms that
 // it is interpreted correctly and doesn't depend on the ordering of the
-// parameter values.
+// parameter values (matrix is symmetric).
 TEST_F(TrivialCollisionCheckerTest, IsCollisionFilteredBetween) {
   const int num_bodies = dut_->plant().num_bodies();
   // Bodies 1, 2, 3 are robot bodies and bodies 4 and 5 are environment (and
@@ -1197,7 +1290,7 @@ TEST_F(TrivialCollisionCheckerTest, IsCollisionFilteredBetween) {
   // exploit the fact that the overload that takes bodies delegates to the
   // body index overload tested above.
   EXPECT_TRUE(dut_->IsCollisionFilteredBetween(dut_->get_body(BodyIndex(1)),
-                                              dut_->get_body(BodyIndex(3))));
+                                               dut_->get_body(BodyIndex(3))));
 }
 
 // Creates a checker on a plant with an N-link chain (optionally) welded to the
@@ -1374,8 +1467,7 @@ GTEST_TEST(EdgeCheckTest, DefaultInterpolation) {
   auto get_interpolated = [&](double s) {
     const Vector3d p_InitS = p_InitFinal * s;
     const RigidTransformd X_InitS(
-        RotationMatrixd(AngleAxisd(init_final_theta * s, rot_axis_W)),
-        p_InitFinal * s);
+        RotationMatrixd(AngleAxisd(init_final_theta * s, rot_axis_W)), p_InitS);
     const RigidTransformd X_WS = X_WB0_init * X_InitS;
     const double j12_s = j12_init + s * (j12_final - j12_init);
     return get_q(X_WS, j12_s);
@@ -1395,7 +1487,7 @@ GTEST_TEST(EdgeCheckTest, DefaultInterpolation) {
   }
 }
 
-// The configuration of a test case for the MeasureEdgeCollisionFree* APIS.
+// The configuration of a test case for the MeasureEdgeCollisionFree* APIs.
 struct EdgeTestConfig {
   // The expected interpolant value (in the range [0, 1]) returned by
   // MeasureEdgeCollisionFree(). If this is negative, we'll simply test for an
@@ -1411,6 +1503,8 @@ struct EdgeTestConfig {
 };
 
 std::ostream& operator<<(std::ostream& out, const EdgeTestConfig& c) {
+  // Note: no spaces because we are using this as a gtest parameterized test
+  // name.
   out << "EdgeTestWith" << c.alpha << "AlphaIn"
       << (c.parallel ? "Parallel" : "Serial");
   return out;
@@ -1424,42 +1518,42 @@ class ParameterizedEdgeCheckTest
 // on the user-defined distance and interpolation functions, as well as the
 // derived CollisionChecker's DoCheckContextConfigCollisionFree()
 // implementation.
-//
+
 // To cater to both the Measure* and Check* variants, we can't just define an
 // edge as being in collision for every sample *beyond* a certain interpolant
 // value. If we were to do so, we couldn't test an edge that only has
-// collisions on the *interior*. So, the test creates *ranges* of collision.
+// collisions on the *interior*.So, the test creates ranges of collision.
 // Ranges with more than a single colliding sample allows us to confirm that
 // algorithms always return the last valid interpolant value closest to the
-// *minimum* colliding sample.
+// minimum colliding sample.
 //
-// This class exploits this by providing *very* custom distance, interpolation,
-// and collision checks. It does so by encoding test parameters *inside* the
-// end configuration. No geometry is required and we only need enough bodies in
-// the plant to provide sufficient robot dofs to hold the encoding.
+// To that end, each test characterizes the colliding interval with two test
+// parameters: αᶠ (the "last" free value) and αᶜ (the last collision value)
+// defined such that:
 //
-// The collision check is based on the current plant configuration.
-//   q[0]: The largest interpolant value that is still "collision
-//         free". This is the expected return value. It is designed to be
-//         exactly equal to the value of alpha that would be computed by
-//         CheckEdgeCollisionFree() as an interpolant value.
-//   q[1]: The largest interpolant value that is in collision. It should be the
-//         case that q[1] > q[0]. For interpolation(q1, q2, s), that
-//         configuration is in collision if q[0] < s <= q[1].
-//   q[2]: The interpolant value at which this configuration was generated. This
-//         is defined by the interpolating function.
+//   - αᶠ < αᶜ
+//   - ∀ α ∈ [0, 1], and the interpolation qα = interpolation(q1, q2, α)
+//     - α ∈ [0, αᶠ]  → qα is collision free;
+//     - α ∈ (αᶠ, αᶜ] → qα is in collision;
+//     - α ∈ (αᶜ, 1]  → qα is collision free.
+//
+// This class encodes values for α, αᶠ, and αᶜ inside the end configuration, q2.
+// In particular, we set q2[0] = αᶠ, q2[1] = αᶜ, and q2[2] = α. No geometry is
+// required and we only need enough bodies in the plant to provide sufficient
+// robot dofs to hold the encoding.
 //
 // The configuration interpolator is responsible for providing the encoding to
-// the collision check. The "interpolation" simply copies q[0] and q[1] into the
-// interpolated result and then sets the interpolant into q[2]. CollisionChecker
-// updates the plant's positions with these values so that the collision check
-// can read them. In all cases, the values of q1 are completely ignored.
+// the collision check. The "interpolation" simply copies q2[0] and q2[1] into
+// the first two entries of the interpolated result (q[0] and q[1]) and then
+// sets the interpolant into q[2]. CollisionChecker updates the plant's
+// positions with these values so that the collision test can read them. The
+// interpolator always ignores the values of q1.
 //
-// The collision checker uses the "colliding range" (q[0], q[1]] to determine if
+// The collision checker uses the "colliding range" (αᶠ, αᶜ] to determine if
 // the current configuration is in collision. The test configurations will be
 // set up so that multiple configurations will be colliding. When this range
-// includes s = 1, special care must be taken for CheckEdgeCollisionFree() (see
-// below for details).
+// includes interpolant s = 1, special care must be taken for
+// CheckEdgeCollisionFree() (see below for details).
 //
 // Finally, the distance function is responsible for guaranteeing we have a
 // small, fixed number of steps on each edge. This serves two purposes: keeps
@@ -1492,7 +1586,10 @@ class MockEdgeChecker : public UnimplementedCollisionChecker {
   // Force five samples based on the given `step_size`.
   static ConfigurationDistanceFunction MakeEdgeDistance(double step_size) {
     return [step_size](const VectorXd& q1, const VectorXd& q2) {
-      // f(q, q) = 0 is a requirement of CollisionChecker.
+      // f(q, q) = 0 is a requirement of CollisionChecker and gets validated
+      // when the function is set in the checker. That is the only time this
+      // function will be evaluated with |q1| = 0, so we'll game the system to
+      // convince the checker this is a valid distance function.
       if (q1.norm() == 0.0) return 0.0;
       // This *guarantees* four steps without recourse to numerical errors. Four
       // steps --> five samples.
@@ -1564,6 +1661,11 @@ std::vector<EdgeTestConfig> MakeEdgeTestCases() {
   const double divisor = static_cast<double>(MockEdgeChecker::kNumSamples - 1);
 
   for (const bool in_parallel : {true, false}) {
+    if (in_parallel & !kHasOpenmp) {
+      // We don't have OpenMP in all test configurations.
+      continue;
+    }
+
     // Edges are 100% valid.
     configs.push_back({.alpha = 1.0,
                        .last_colliding_alpha = 2.0,
@@ -1706,9 +1808,12 @@ TEST_P(ParameterizedEdgeCheckTest, CheckEdgeCollisionFree) {
   EXPECT_EQ(result, expected_result);
   if (config.parallel) {
     if (config.alpha >= 0.5 && config.alpha < 1.0) {
-      // If 0.5 <= expected_result < 1.0, then the colliding range includes q2.
-      // For the parallel implementation, we should fail fast and never enter
-      // the parallel regime.
+      // If 0.5 <= expected_result < 1.0, then the colliding range includes q2
+      // (due to the fact that there are five samples, each 0.25 away from
+      // each other and that q[0] and q[1] are two samples away from each
+      // other).
+      // For the parallel implementation, we should fail fast on q2 and never
+      // enter the parallel regime.
       EXPECT_EQ(dut.thread_count(), 1);
     } else {
       EXPECT_GT(dut.thread_count(), 1);
@@ -1716,7 +1821,7 @@ TEST_P(ParameterizedEdgeCheckTest, CheckEdgeCollisionFree) {
   }
 }
 
-// The test for CheckEdgesCollisionFree() (plural) uses
+// The test for MeasureEdgesCollisionFree() (plural) uses
 // MeasureEdgeCollisionFree() (singular) to test individual edges. For this
 // function, we only need to test:
 //
@@ -1734,9 +1839,13 @@ GTEST_TEST(EdgeCheckTest, MeasureMultipleEdges) {
   // Garbage start configuration; the values are ignored.
   const VectorXd q_start = VectorXd::Constant(q_size, 0.75);
   // All edges start from the same configuration, q_start. The end configuration
-  // gets encoded by MockEdgeChecker. Note: we know that we're getting five
-  // samples so the distance between values of alpha is 0.25. So, to make sure
-  // *two* samples are in collision, the last colliding alpha should be the
+  // gets encoded by MockEdgeChecker.
+  // Note: we want to make sure that the parallel collision checker properly
+  // reconciles multiple internal colliding configurations, reporting the
+  // earliest. To test that, we need two colliding internal samples. We know
+  // that we're getting five samples (by design) so the distance between values
+  // of alpha is 0.25. So, to make sure *two* samples are in collision, the last
+  // *colliding* alpha should be *two* samples values beyond the last free, or
   // last free + 0.5.
   vector<std::pair<VectorXd, VectorXd>> edges;
   // 100% clear.
@@ -1756,6 +1865,10 @@ GTEST_TEST(EdgeCheckTest, MeasureMultipleEdges) {
       EdgeMeasure(edge_dist, edges[2].second(0))};
 
   for (const bool parallel : {false, true}) {
+    if (parallel & !kHasOpenmp) {
+      // We don't have OpenMP in all test configurations.
+      continue;
+    }
     auto dut = MakeEdgeChecker<MockEdgeChecker>(calc_dist, step_size, interp,
                                                 true /* welded */, q_size + 1);
     ASSERT_EQ(dut.plant().num_positions(), q_size);
@@ -1807,11 +1920,15 @@ GTEST_TEST(EdgeCheckTest, CheckMultipleEdgesFree) {
   // Later collision.
   edges.emplace_back(q_start,
                      MockEdgeChecker::EncodeConfiguration(q_size, 0.75, 1.25));
-  const vector<int8_t> expected_results{edges[0].second(0) == 1.0,
-                                        edges[1].second(0) == 1.0,
-                                        edges[2].second(0) == 1.0};
+  const vector<uint8_t> expected_results{edges[0].second(0) == 1.0,
+                                         edges[1].second(0) == 1.0,
+                                         edges[2].second(0) == 1.0};
 
   for (const bool parallel : {false, true}) {
+    if (parallel & !kHasOpenmp) {
+      // We don't have OpenMP in all test configurations.
+      continue;
+    }
     auto dut = MakeEdgeChecker<MockEdgeChecker>(calc_dist, step_size, interp,
                                                 true /* welded */, q_size + 1);
     ASSERT_EQ(dut.plant().num_positions(), q_size);
@@ -1823,8 +1940,7 @@ GTEST_TEST(EdgeCheckTest, CheckMultipleEdgesFree) {
       ASSERT_TRUE(dut.CanEvaluateInParallel());
     }
 
-    vector<int8_t> results =
-        dut.CheckEdgesCollisionFree(edges, parallel);
+    vector<uint8_t> results = dut.CheckEdgesCollisionFree(edges, parallel);
 
     // Confirm behavior (1). Results for every edge.
     EXPECT_EQ(results, expected_results);
@@ -1869,4 +1985,4 @@ GTEST_TEST(EdgeMeasureTest, Test) {
 
 }  // namespace
 }  // namespace planning
-}  // namespace anzu
+}  // namespace drake

--- a/planning/test/collision_checker_test.cc
+++ b/planning/test/collision_checker_test.cc
@@ -1,0 +1,1872 @@
+#include "planning/collision_checker.h"
+
+#include <chrono>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <common_robotics_utilities/openmp_helpers.hpp>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/tree/revolute_joint.h"
+#include "drake/planning/robot_diagram_builder.h"
+#include "planning/test/planning_test_helpers.h"
+#include "planning/unimplemented_collision_checker.h"
+
+namespace anzu {
+namespace planning {
+
+// Support for easily comparing EdgeMeasurements.
+bool operator==(const EdgeMeasure& r1, const EdgeMeasure& r2) {
+  bool equal = true;
+  equal &= r1.distance() == r2.distance();
+  equal &= r1.completely_free() == r2.completely_free();
+  equal &= r1.partially_free() == r2.partially_free();
+  if (r1.partially_free()) {
+    equal &= r1.alpha() == r2.alpha();
+  }
+  return equal;
+}
+
+std::ostream& operator<<(std::ostream& out, const EdgeMeasure& r) {
+  out << "EdgeMeasure(" << r.distance() << ", " << r.alpha_or(-1.0) << ")";
+  return out;
+}
+
+namespace {
+
+using drake::CompareMatrices;
+using drake::geometry::CollisionFilterDeclaration;
+using drake::geometry::FrameId;
+using drake::geometry::GeometryId;
+using drake::geometry::GeometrySet;
+using drake::geometry::Role;
+using drake::geometry::Shape;
+using drake::geometry::Sphere;
+using drake::math::RigidTransform;
+using drake::math::RigidTransformd;
+using drake::math::RotationMatrixd;
+using drake::multibody::Body;
+using drake::multibody::BodyIndex;
+using drake::multibody::CoulombFriction;
+using drake::multibody::default_model_instance;
+using drake::multibody::ModelInstanceIndex;
+using drake::multibody::MultibodyPlant;
+using drake::multibody::RevoluteJoint;
+using drake::multibody::RigidBody;
+using drake::multibody::SpatialInertia;
+using drake::multibody::world_model_instance;
+using drake::planning::BodyShapeDescription;
+using drake::planning::CollisionCheckerContext;
+using drake::planning::CollisionCheckerParams;
+using drake::planning::ConfigurationDistanceFunction;
+using drake::planning::ConfigurationInterpolationFunction;
+using drake::planning::RobotClearance;
+using drake::planning::RobotCollisionType;
+using drake::planning::RobotDiagram;
+using drake::planning::RobotDiagramBuilder;
+using drake::systems::Context;
+using Eigen::AngleAxisd;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+using std::move;
+using std::optional;
+using std::pair;
+using std::vector;
+using testing::ElementsAre;
+
+// Adds a new model instance consisting of a non-zero number of floating bodies.
+ModelInstanceIndex AddEnvironmentModelInstance(MultibodyPlant<double>* plant,
+                                               int num_geo = 1) {
+  // We want to be able to call this without model instances to conflict, so
+  // we'll simply track how many times we call it.
+  static int count = 0;
+  const ModelInstanceIndex instance =
+      plant->AddModelInstance(fmt::format("env{}", ++count));
+
+  DRAKE_DEMAND(plant->geometry_source_is_registered());
+
+  std::vector<const RigidBody<double>*> bodies;
+  const RigidBody<double>& body = plant->AddRigidBody(
+      "env_body", instance, SpatialInertia<double>::MakeUnitary());
+  for (int i = 0; i < num_geo; ++i) {
+    plant->RegisterCollisionGeometry(body, RigidTransformd::Identity(),
+                                     Sphere(0.01), fmt::format("g{}", i),
+                                     CoulombFriction<double>());
+  }
+  return instance;
+}
+
+// This is a minimal derived collision checker for unit testing. By default,
+// this checker does *not* allocate contexts. However, it makes the allocation
+// functionality public for testing.
+class CollisionCheckerTester : public UnimplementedCollisionChecker {
+ public:
+  explicit CollisionCheckerTester(CollisionCheckerParams params,
+                                  bool supports_parallel_checking = false)
+      : UnimplementedCollisionChecker(move(params),
+                                      supports_parallel_checking) {}
+
+  //@{
+  // Interesting virtual overrides.
+  std::unique_ptr<CollisionChecker> DoClone() const override {
+    return std::make_unique<CollisionCheckerTester>(*this);
+  }
+
+  void DoUpdateContextPositions(
+      CollisionCheckerContext* model_context) const override {
+    // We need to confirm two things promised by CollisionChecker:
+    //   - model_context != nullptr
+    //   - The plant's positions have been updated.
+    ASSERT_TRUE(model_context != nullptr);
+    latest_positions_ = plant().GetPositions(model_context->plant_context());
+  }
+
+  bool DoCheckContextConfigCollisionFree(
+      const CollisionCheckerContext& model_context) const override {
+    // CollisionChecker promises that positions have been updated from public
+    // method arguments.
+    positions_for_check_ = plant().GetPositions(model_context.plant_context());
+    return collision_free_;
+  }
+
+  optional<GeometryId> DoAddCollisionShapeToBody(
+      const std::string&, const Body<double>&, const Shape&,
+      const RigidTransform<double>&) override {
+    return added_shape_id_;
+  }
+
+  RobotClearance DoCalcContextRobotClearance(
+      const CollisionCheckerContext&, double influence_dist) const override {
+    // CollisionChecker promises that influence_dist is finite and non-negative.
+    EXPECT_GE(influence_dist, 0.0);
+    EXPECT_TRUE(std::isfinite(influence_dist));
+
+    // To confirm CollisionChecker takes responsibility for zeroing out non
+    // robot columns, we'll populate non-zero values in *every* column.
+    const int q_size = plant().num_positions();
+    RobotClearance clearance{plant().num_positions()};
+    VectorXd Jq_dist(q_size);
+    for (int i = 0; i < q_size; ++i) {
+      Jq_dist(i) = i + 1;
+    }
+    clearance.Append(BodyIndex(1), BodyIndex(0),
+                     RobotCollisionType::kEnvironmentCollision, 1.5, Jq_dist);
+    return clearance;
+  }
+
+  std::vector<RobotCollisionType> DoClassifyContextBodyCollisions(
+      const CollisionCheckerContext& model_context) const override {
+    // CollisionChecker promises that positions have been updated from public
+    // method arguments.
+    positions_for_classify_ =
+        plant().GetPositions(model_context.plant_context());
+    return {};
+  }
+
+  int32_t DoMaxContextNumDistances(
+      const CollisionCheckerContext&) const override {
+    return 13;
+  }
+  //@}
+
+  //@{
+  // Protected methods required in testing.
+  using CollisionChecker::AllocateContexts;
+  using CollisionChecker::GetMutableSetupModel;
+
+  // Note: private overload foils a plain "using" statement.
+  std::string CriticizePaddingMatrix() const {
+    return CollisionChecker::CriticizePaddingMatrix();
+  }
+  //@}
+
+  //@{
+  // Testing knobs.
+  void SetCollisionFree(bool value) {
+    collision_free_ = value;
+  }
+
+  // This ultimately controls whether *any* of the AddCollisionShape APIs will
+  // report "shape added". All of the APIs ultimately delegate to
+  // AddCollisionShapeToBody which returns this value.
+  void SetCanAddCollisionShapes(bool value) {
+    if (value) {
+      added_shape_id_ = GeometryId::get_new_id();
+    } else {
+      added_shape_id_ = std::nullopt;
+    }
+  }
+
+  // Returns the latest positions set in this checker via Update*Positions().
+  const VectorXd& latest_positions() const { return latest_positions_; }
+
+  // Returns the positions available in this checker from the most recent
+  // Classify*BodyCollisions() call.
+  const VectorXd& positions_for_classify() const {
+    return positions_for_classify_;
+  }
+
+  // Returns the positions available in this checker from the most recent
+  // Check*ConfigCollisionFree() call.
+  const VectorXd& positions_for_check() const {
+    return positions_for_check_;
+  }
+  //@}
+
+ private:
+  bool collision_free_{false};
+  optional<GeometryId> added_shape_id_;
+  // Updated with every call to DoUpdateContextPositions().
+  mutable VectorXd latest_positions_;
+  // Updated with every call to DoClassifyContextBodyCollisions().
+  mutable VectorXd positions_for_classify_;
+  // Updated with every call to DoCheckContextConfigCollisionFree().
+  mutable VectorXd positions_for_check_;
+};
+
+// Makes a test checker for the given model and enumerated set of robot
+// model instances - the contexts are *not* allocated.
+std::unique_ptr<CollisionCheckerTester> MakeUnallocatedChecker(
+    std::unique_ptr<RobotDiagram<double>> robot,
+    const vector<ModelInstanceIndex>& robot_indices,
+    bool supports_parallel = true) {
+  const ConfigurationDistanceFunction dist{
+      [](const VectorXd& a, const VectorXd& b) { return (b - a).norm(); }};
+  return std::make_unique<CollisionCheckerTester>(
+      CollisionCheckerParams{move(robot), robot_indices, dist, 0.1, 0, 0},
+      supports_parallel);
+}
+
+struct ModelConfig {
+  bool weld_robot{true};
+  int per_body_geometries{1};
+  bool on_env_base{false};  // Ignored if weld_robot is true.
+};
+
+// Creates a model with robot and environment bodies, returning the model and
+// the model's robot's model instance index.
+pair<std::unique_ptr<RobotDiagram<double>>, ModelInstanceIndex> MakeModel(
+    const ModelConfig& config = {}) {
+  RobotDiagramBuilder<double> builder;
+  auto& builder_plant = builder.mutable_plant();
+  // Add the robot -- a chain of three links -- and weld it to the world.
+  // Don't change the ordering or the length of the chain; the tests for this
+  // fixture rely on knowing body indices.
+  auto robot_index = AddChain(&builder_plant, 3, config.per_body_geometries);
+  if (config.weld_robot) {
+    builder.mutable_plant().WeldFrames(
+        builder_plant.get_body(BodyIndex(0)).body_frame(),
+        builder_plant.get_body(BodyIndex(1)).body_frame());
+  } else if (config.on_env_base) {
+    const ModelInstanceIndex instance =
+        builder_plant.AddModelInstance("floating");
+    const RigidBody<double>& floater = builder_plant.AddRigidBody(
+        "floater", instance, SpatialInertia<double>::MakeUnitary());
+    // Connect the first chain body (1) to this floating base.
+    builder_plant.AddJoint<RevoluteJoint>("floating", floater, {},
+                                          builder_plant.get_body(BodyIndex(1)),
+                                          {}, Eigen::Vector3d::UnitY());
+  }
+
+  // Add environment model instances; don't track the model instance indices,
+  // because we don't care.
+  AddEnvironmentModelInstance(&builder_plant, config.per_body_geometries);
+  AddEnvironmentModelInstance(&builder_plant, config.per_body_geometries);
+  return {builder.BuildDiagram(), robot_index};
+}
+
+// Reports the indices of the dofs of the robot's environmental floating base.
+// These indices only apply if MakeModel was called with weld_robot = false and
+// on_env_base = true.
+std::set<int> GetFloatingBaseDofs() {
+  return {0, 1, 2, 3, 4, 5, 6};
+}
+
+// In the case where we mount the robot on an environment floating base, we
+// want to make sure that GetFloatingBaseDofs() returns the right values. This
+// confirms them -- it is used to test RobotClearance.
+GTEST_TEST(MakeModel, EnvironmentalFloatingBase) {
+  auto [robot, robot_index] =
+      MakeModel({.weld_robot = false, .on_env_base = true});
+  const auto& floater = robot->plant().GetBodyByName("floater");
+  ASSERT_TRUE(floater.is_floating());
+  ASSERT_TRUE(floater.has_quaternion_dofs());
+
+  const std::set<int> base_dofs = GetFloatingBaseDofs();
+  const int start = floater.floating_positions_start();
+  for (int i = start; i < start + 7; ++i) {
+    EXPECT_EQ(base_dofs.count(i), 1);
+  }
+}
+
+class CollisionCheckerThrowTest : public testing::Test {
+ public:
+  void ExpectConstructorThrow(const std::string& throw_message_pattern) {
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        CollisionCheckerTester(
+            {move(diagram_), robot_model_instances_, distance_fn_,
+             edge_step_size_, env_collision_padding_,
+             self_collision_padding_}),
+        throw_message_pattern);
+  }
+
+ protected:
+  // The default values are all legal. Tests will invalidate specific values.
+  RobotDiagramBuilder<double> builder_;
+  std::unique_ptr<RobotDiagram<double>> diagram_{builder_.BuildDiagram()};
+  std::vector<ModelInstanceIndex> robot_model_instances_{
+    default_model_instance()};
+  ConfigurationDistanceFunction distance_fn_{
+      [](const VectorXd&, const VectorXd&) { return 0.0; }};
+  double edge_step_size_{0.1};
+  double env_collision_padding_{0.0};
+  double self_collision_padding_{0.0};
+};
+
+TEST_F(CollisionCheckerThrowTest, BadFn) {
+  distance_fn_ = {};
+  ExpectConstructorThrow(".*bad.*function.*");
+}
+
+TEST_F(CollisionCheckerThrowTest, BadStepSize) {
+  edge_step_size_ = 0.0;
+  ExpectConstructorThrow(".*edge_step_size.*");
+}
+
+TEST_F(CollisionCheckerThrowTest, NoRobots) {
+  robot_model_instances_ = {};
+  ExpectConstructorThrow(".*robot.* > 0.*");
+}
+
+TEST_F(CollisionCheckerThrowTest, WorldRobot) {
+  robot_model_instances_ = {world_model_instance()};
+  ExpectConstructorThrow(".*robot.* != *.world.*");
+}
+
+// When the user passes duplicate and/or out-of-order robots, the constructor
+// sorts them.
+GTEST_TEST(CollisionCheckerTest, SortedRobots) {
+  RobotDiagramBuilder<double> builder;
+  auto& plant = builder.mutable_plant();
+  const ModelInstanceIndex robot1 = AddChain(&plant, 1);
+  const ModelInstanceIndex robot2 = AddChain(&plant, 2);
+  auto distance_function = [](auto...) { return 0; };
+  auto dut =
+      std::make_unique<CollisionCheckerTester>(CollisionCheckerParams{
+          builder.BuildDiagram(),
+          std::vector<ModelInstanceIndex>{robot2, robot2, robot1},
+          distance_function, 0.1, 0, 0});
+  EXPECT_THAT(dut->robot_model_instances(), ElementsAre(robot1, robot2));
+}
+
+TEST_F(CollisionCheckerThrowTest, InfEnvPad) {
+  env_collision_padding_ = std::numeric_limits<double>::infinity();
+  ExpectConstructorThrow(".*Env.*isfinite.*");
+}
+
+TEST_F(CollisionCheckerThrowTest, InfSelfPad) {
+  self_collision_padding_ = std::numeric_limits<double>::infinity();
+  ExpectConstructorThrow(".*AllRobotRobot.*isfinite.*");
+}
+
+// This tests the APIs that depend on the RobotDiagram in the case where the
+// diagram is empty; the only body is the world body. It confirms that the
+// exercised APIs return meaningful values without throwing.
+//
+// This does not exercise the *full* set of APIs; only those that depend on the
+// diagram. (See e.g. the EdgeCheckConfiguration test).
+GTEST_TEST(CollisionCheckerTest, CollisionCheckerEmpty) {
+  RobotDiagramBuilder<double> builder;
+  auto diagram = builder.BuildDiagram();
+  const ConfigurationDistanceFunction fn0 = [](const VectorXd&,
+                                               const VectorXd&) { return 0.0; };
+  const ModelInstanceIndex robot = default_model_instance();
+  const ModelInstanceIndex world = world_model_instance();
+  CollisionCheckerTester dut({move(diagram), {robot}, fn0, 0.1, 0, 0});
+
+  EXPECT_THAT(dut.robot_model_instances(), testing::ElementsAre(robot));
+  RigidBody<double> free_body("free", world, {});
+  EXPECT_FALSE(dut.IsPartOfRobot(free_body));
+  EXPECT_FALSE(dut.IsPartOfRobot(BodyIndex(0)));
+
+  EXPECT_EQ(dut.GetLargestPadding(), 0.0);
+  EXPECT_EQ(dut.GetFilteredCollisionMatrix().size(), 1);
+  EXPECT_EQ(dut.GetNominalFilteredCollisionMatrix().size(), 1);
+
+  // Here is an operation that will help check memory safety of callbacks.
+  auto op = [](const RobotDiagram<double>&, CollisionCheckerContext* context) {
+              ASSERT_NE(context, nullptr);
+            };
+
+  // Examples of methods that throw with no contexts allocated. Derived classes
+  // will typically allocate contexts during construction.
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.plant_context(), ".*range_check.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.model_context(), ".*range_check.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.Clone(), ".*allocated().*failed.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.MakeStandaloneModelContext(),
+                              ".*allocated().*failed.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.PerformOperationAgainstAllModelContexts(op),
+                              ".*allocated().*failed.*");
+  dut.AllocateContexts();
+  EXPECT_NO_THROW(dut.plant_context());
+  EXPECT_NO_THROW(dut.model_context());
+  EXPECT_NO_THROW(dut.Clone());
+  EXPECT_NO_THROW(dut.MakeStandaloneModelContext());
+  EXPECT_NO_THROW(dut.PerformOperationAgainstAllModelContexts(op));
+}
+
+// Test the robot model introspection APIs.
+GTEST_TEST(CollisionCheckerTest, ModelIntrospection) {
+  auto [robot, robot_index] = MakeModel();
+  RobotDiagram<double>* robot_raw = robot.get();
+  std::unique_ptr<CollisionCheckerTester> checker =
+      MakeUnallocatedChecker(move(robot), {robot_index});
+
+  EXPECT_EQ(&checker->model(), robot_raw);
+  EXPECT_EQ(&checker->plant(), &robot_raw->plant());
+
+  const auto& b1 = checker->get_body(BodyIndex(1));
+  EXPECT_TRUE(checker->IsPartOfRobot(BodyIndex(1)));
+  EXPECT_TRUE(checker->IsPartOfRobot(b1));
+
+  EXPECT_THAT(checker->robot_model_instances(),
+              testing::ElementsAre(robot_index));
+
+  EXPECT_EQ(checker->GetScopedName(b1), "m3::b0");
+  EXPECT_EQ(checker->GetScopedName(b1.body_frame()), "m3::b0");
+
+  const auto q = checker->GetZeroConfiguration();
+  EXPECT_EQ(q.size(), checker->plant().num_positions());
+  EXPECT_EQ(q.norm(), 0.0);
+}
+
+// The "setup" model only exists before allocation and goes away after
+// allocation.
+GTEST_TEST(CollisionCheckerTest, MutableSetupModel) {
+  auto [robot, robot_index] = MakeModel();
+  std::unique_ptr<CollisionCheckerTester> checker =
+      MakeUnallocatedChecker(move(robot), {robot_index});
+
+  EXPECT_NO_THROW(checker->GetMutableSetupModel());
+  checker->AllocateContexts();  // Required explicit allocation step.
+  EXPECT_THROW(checker->GetMutableSetupModel(), std::exception);
+}
+
+// CollisionChecker has several responsibilities when calling
+// CalcRobotClearance():
+//
+//  - influence distance must be finite and positive
+//  - non-robot dofs must be zeroed out in the Jacobian.
+//
+// Calling MaxNumDistance() simply defaults to the NVI implementation; we'll
+// confirm we get back the magic number: 13.
+GTEST_TEST(CollisionCheckerTest, RobotClearance) {
+  auto [robot, robot_index] =
+      MakeModel({.weld_robot = false, .on_env_base = true});
+  std::unique_ptr<CollisionCheckerTester> checker =
+      MakeUnallocatedChecker(move(robot), {robot_index});
+  checker->AllocateContexts();
+
+  // MaxNumDistances called the implemented NVI.
+  EXPECT_EQ(checker->MaxNumDistances(), 13);
+
+  // The actual values in the configuration are ignored.
+  const auto q = checker->GetZeroConfiguration();
+
+  const std::set<int> non_robot_dofs = GetFloatingBaseDofs();
+  // We have a non-empty set of dof indices that all index into q.
+  ASSERT_GT(non_robot_dofs.size(), 0);
+  const int q_size = q.size();
+  for (int qi : non_robot_dofs) {
+    ASSERT_LT(qi, q_size);
+  }
+
+  // Confirm zero-ing out non-robot dofs.
+  const RobotClearance clearance = checker->CalcRobotClearance(q, 0);
+  ASSERT_EQ(clearance.size(), 1);
+  for (int i = 0; i < clearance.num_positions(); ++i) {
+    if (non_robot_dofs.count(i) > 0) {
+      EXPECT_EQ(clearance.jacobians()(i), 0);
+    } else {
+      EXPECT_EQ(clearance.jacobians()(i), i + 1);
+    }
+  }
+
+  // Error conditions.
+  EXPECT_THROW(checker->CalcRobotClearance(q, -1), std::exception);
+  constexpr double kInf = std::numeric_limits<double>::infinity();
+  EXPECT_THROW(checker->CalcRobotClearance(q, kInf), std::exception);
+}
+
+// Testing framework for the collision checker such that the model contains
+// both robot and environment bodies.
+class TrivialCollisionCheckerTest : public testing::Test {
+ public:
+  TrivialCollisionCheckerTest() {
+    auto [robot, robot_index] = MakeModel();
+    dut_ = MakeUnallocatedChecker(move(robot), {robot_index});
+    dut_->AllocateContexts();
+  }
+
+  // Returns the indices of environment bodies in the model.
+  vector<BodyIndex> environment_indices() const {
+    return {BodyIndex(0), BodyIndex(4), BodyIndex(5)};
+  }
+
+  // Creates an filter matrix with *no* filtered collisions for the bodies
+  // in the model of the given checker. If checker is null, then the fixture's
+  // dut will be used.
+  Eigen::MatrixXi MakeNothingFiltered(
+      CollisionCheckerTester* checker = nullptr) {
+    if (checker == nullptr) {
+      checker = dut_.get();
+    }
+    const int n = checker->plant().num_bodies();
+    Eigen::MatrixXi filtered = Eigen::MatrixXi::Zero(n, n);
+    for (int i = 0; i < n; ++i) filtered(i, i) = -1;
+    const vector<BodyIndex>& environment_bodies = environment_indices();
+    // Loop variables below use `int` for Eigen indexing compatibility.
+    for (const int i : environment_bodies) {
+      for (const int j : environment_bodies) {
+        filtered(i, j) = -1;
+      }
+    }
+    return filtered;
+  }
+
+ protected:
+  std::unique_ptr<CollisionCheckerTester> dut_;
+};
+
+TEST_F(TrivialCollisionCheckerTest, ClonesAndContexts) {
+  EXPECT_NE(dut_->Clone(), nullptr);
+
+  const auto count_contexts =
+      [&]() {
+        int count{0};
+        auto op = [&count](const RobotDiagram<double>&,
+                           CollisionCheckerContext*) { ++count; };
+        dut_->PerformOperationAgainstAllModelContexts(op);
+        return count;
+      };
+  EXPECT_EQ(count_contexts(),
+            dut_->num_allocated_contexts()
+            + 1);  // prototype context
+
+  // Add one standalone context.
+  auto context = dut_->MakeStandaloneModelContext();
+  EXPECT_EQ(count_contexts(),
+            dut_->num_allocated_contexts()
+            + 1  // prototype context
+            + 1);  // our standalone context
+
+  context.reset();  // Give up our standalone context.
+  EXPECT_EQ(count_contexts(),
+            dut_->num_allocated_contexts()
+            + 1);  // prototype context
+}
+
+TEST_F(TrivialCollisionCheckerTest, Padding) {
+  const int nbodies = dut_->plant().num_bodies();
+  ASSERT_EQ(nbodies, 6);
+  const auto& b2 = dut_->get_body(BodyIndex(2));
+  const auto& b3 = dut_->get_body(BodyIndex(3));
+
+  EXPECT_EQ(dut_->MaybeGetUniformRobotEnvironmentPadding(), 0);
+  EXPECT_EQ(dut_->MaybeGetUniformRobotRobotPadding(), 0);
+
+  EXPECT_NO_THROW(dut_->SetPaddingBetween(BodyIndex(2), BodyIndex(3), 0.1));
+  EXPECT_EQ(dut_->CriticizePaddingMatrix(), "");
+  EXPECT_EQ(dut_->GetPaddingBetween(BodyIndex(2), BodyIndex(3)), 0.1);
+  EXPECT_NO_THROW(dut_->SetPaddingBetween(b2, b3, 0.01));
+  EXPECT_EQ(dut_->CriticizePaddingMatrix(), "");
+  EXPECT_EQ(dut_->GetPaddingBetween(b2, b3), 0.01);
+  EXPECT_EQ(dut_->MaybeGetUniformRobotRobotPadding(), std::nullopt);
+
+  EXPECT_NO_THROW(dut_->SetPaddingBetween(BodyIndex(0), BodyIndex(3), 0.1));
+  EXPECT_EQ(dut_->CriticizePaddingMatrix(), "");
+  EXPECT_EQ(dut_->MaybeGetUniformRobotEnvironmentPadding(), std::nullopt);
+
+  EXPECT_NO_THROW(
+      dut_->SetPaddingMatrix(Eigen::MatrixXd::Zero(nbodies, nbodies)));
+  EXPECT_EQ(dut_->CriticizePaddingMatrix(), "");
+  EXPECT_EQ(dut_->MaybeGetUniformRobotEnvironmentPadding(), 0);
+  EXPECT_EQ(dut_->MaybeGetUniformRobotRobotPadding(), 0);
+
+  EXPECT_NO_THROW(
+      dut_->SetPaddingOneRobotBodyAllEnvironmentPairs(BodyIndex(3), 0.01));
+  EXPECT_EQ(dut_->CriticizePaddingMatrix(), "");
+  EXPECT_EQ(dut_->MaybeGetUniformRobotEnvironmentPadding(), std::nullopt);
+  EXPECT_EQ(dut_->MaybeGetUniformRobotRobotPadding(), 0);
+
+  EXPECT_NO_THROW(dut_->SetPaddingAllRobotEnvironmentPairs(0.01));
+  EXPECT_EQ(dut_->CriticizePaddingMatrix(), "");
+  EXPECT_EQ(dut_->MaybeGetUniformRobotEnvironmentPadding(), 0.01);
+  EXPECT_EQ(dut_->MaybeGetUniformRobotRobotPadding(), 0);
+
+  EXPECT_NO_THROW(dut_->SetPaddingAllRobotRobotPairs(0.02));
+  EXPECT_EQ(dut_->CriticizePaddingMatrix(), "");
+  EXPECT_EQ(dut_->MaybeGetUniformRobotEnvironmentPadding(), 0.01);
+  EXPECT_EQ(dut_->MaybeGetUniformRobotRobotPadding(), 0.02);
+}
+
+// Tests the ValidatePaddingMatrix() method by exercising SetPaddingMatrix() and
+// passing otherwise invalid padding specifications.
+TEST_F(TrivialCollisionCheckerTest, SetPaddingMatrix) {
+  const int num_bodies = dut_->plant().num_bodies();
+  // Bodies 1, 2, 3 are robot bodies and bodies 4 and 5 are environment (and
+  // body zero is the world).
+  ASSERT_EQ(num_bodies, 6);
+
+  // Make a padding matrix with some non-zero padding. Confirm it constitutes a
+  // change from the original state -- i.e., we can set the matrix with a valid
+  // matrix.
+  EXPECT_EQ(dut_->MaybeGetUniformRobotEnvironmentPadding(), 0.0);
+  EXPECT_EQ(dut_->MaybeGetUniformRobotRobotPadding(), 0.0);
+  Eigen::MatrixXd padding = Eigen::MatrixXd::Zero(num_bodies, num_bodies);
+  padding(1, 2) = 1;
+  padding(2, 1) = 1;
+  padding(1, 4) = 2;
+  padding(4, 1) = 2;
+  ASSERT_NO_THROW(dut_->SetPaddingMatrix(padding));
+  // Padding values are no longer uniform.
+  EXPECT_FALSE(dut_->MaybeGetUniformRobotEnvironmentPadding().has_value());
+  EXPECT_FALSE(dut_->MaybeGetUniformRobotRobotPadding().has_value());
+
+  // Now test the various ways we can throw.
+
+  {
+    // The padding matrix is the wrong size.
+    Eigen::MatrixXd wrong_size =
+        Eigen::MatrixXd::Zero(num_bodies + 1, num_bodies + 1);
+
+    DRAKE_EXPECT_THROWS_MESSAGE(dut_->SetPaddingMatrix(wrong_size),
+                                ".*6x6.*wrong size: 7x7.*");
+    Eigen::MatrixXd too_tall =
+        Eigen::MatrixXd::Zero(num_bodies + 1, num_bodies);
+
+    DRAKE_EXPECT_THROWS_MESSAGE(dut_->SetPaddingMatrix(too_tall),
+                                ".*6x6.*wrong size: 7x6.*");
+    Eigen::MatrixXd too_wide =
+        Eigen::MatrixXd::Zero(num_bodies, num_bodies + 1);
+
+    DRAKE_EXPECT_THROWS_MESSAGE(dut_->SetPaddingMatrix(too_wide),
+                                ".*6x6.*wrong size: 6x7.*");
+  }
+
+  {
+    // Diagonal is not 0.
+    for (int i = 0; i < num_bodies; ++i) {
+      Eigen::MatrixXd bad_padding(padding);
+      bad_padding(i, i) = 10.0;
+      DRAKE_EXPECT_THROWS_MESSAGE(
+          dut_->SetPaddingMatrix(bad_padding),
+          ".*invalid values on the diagonal.+ must always be 0.*");
+    }
+  }
+
+  {
+    // Environment-environment pairs aren't 0.
+    const vector<pair<int, int>> environment_body_pairs{{0, 4}, {0, 5}, {4, 5}};
+    for (const auto& [i, j] : environment_body_pairs) {
+      Eigen::MatrixXd bad_padding(padding);
+      bad_padding(i, j) = 22.0;
+      bad_padding(j, i) = 22.0;
+      DRAKE_EXPECT_THROWS_MESSAGE(
+          dut_->SetPaddingMatrix(bad_padding),
+          ".* must contain 0 for pairs of environment bodies.*");
+    }
+  }
+
+  {
+    // Matrix is not symmetric, tested for an arbitrary pair.
+    Eigen::MatrixXd bad_padding(padding);
+    bad_padding(0, 3) = 77.0;
+    DRAKE_EXPECT_THROWS_MESSAGE(dut_->SetPaddingMatrix(bad_padding),
+                                ".* must be symmetric.*");
+  }
+
+  {
+    // Matrix is not symmetric, tested for an arbitrary pair, with sneaky NaNs.
+    // Try NaN in both upper and lower triangles.
+    Eigen::MatrixXd bad_padding(padding);
+    // NaN is in the upper triangle. The implementation catches the non-finite
+    // value.
+    bad_padding(0, 3) = std::numeric_limits<double>::quiet_NaN();
+    DRAKE_EXPECT_THROWS_MESSAGE(dut_->SetPaddingMatrix(bad_padding),
+                                ".* must contain finite values.*");
+
+    // NaN is in the lower triangle. The implementation catches the
+    // asymmetry.
+    bad_padding(0, 3) = 0.0;
+    bad_padding(3, 0) = std::numeric_limits<double>::quiet_NaN();
+    DRAKE_EXPECT_THROWS_MESSAGE(dut_->SetPaddingMatrix(bad_padding),
+                                ".* must be symmetric.*");
+  }
+
+  {
+    // Matrix is not finite, tested for an arbitrary pair.
+    Eigen::MatrixXd bad_padding(padding);
+    bad_padding(0, 3) = std::numeric_limits<double>::infinity();
+    bad_padding(3, 0) = std::numeric_limits<double>::infinity();
+    DRAKE_EXPECT_THROWS_MESSAGE(dut_->SetPaddingMatrix(bad_padding),
+                                ".* must contain finite values.*");
+
+    bad_padding(0, 3) = std::numeric_limits<double>::quiet_NaN();
+    bad_padding(3, 0) = std::numeric_limits<double>::quiet_NaN();
+    DRAKE_EXPECT_THROWS_MESSAGE(dut_->SetPaddingMatrix(bad_padding),
+                                ".* must contain finite values.*");
+  }
+}
+
+// The AddCollisionShape APIs ultimately depend on the virtual
+// AddCollisionShapeToBody() method. For the CollisionChecker base class test,
+// we are simply confirming that the return value defined by the implementation
+// is properly propagated all the way up.
+TEST_F(TrivialCollisionCheckerTest, Shapes) {
+  // We use a sphere as being representative of Shape. Nothing here depends on
+  // it being a sphere.
+  const Sphere sphere(0.1);
+  const BodyShapeDescription body_shape{sphere, {}, "m3", "b0"};
+  const auto& b1 = dut_->get_body(BodyIndex(1));
+  for (bool can_add : {false, true}) {
+    dut_->SetCanAddCollisionShapes(can_add);
+
+    EXPECT_EQ(dut_->AddCollisionShape("test", body_shape), can_add);
+    EXPECT_EQ(dut_->AddCollisionShapes("test", {body_shape}), can_add);
+
+    auto added_shapes = dut_->AddCollisionShapes(
+        {{"test", {body_shape}}, {"test2", {body_shape}}});
+    const int expected_count = can_add ? 1 : 0;
+    EXPECT_EQ(added_shapes,
+              (std::map<std::string, int>(
+                  {{"test", expected_count}, {"test2", expected_count}})));
+
+    EXPECT_EQ(
+        dut_->AddCollisionShapeToFrame("test", b1.body_frame(), sphere, {}),
+        can_add);
+    EXPECT_EQ(dut_->AddCollisionShapeToBody("test", b1, sphere, {}), can_add);
+  }
+}
+
+TEST_F(TrivialCollisionCheckerTest, ReportParallelChecking) {
+  for (bool parallel_supported : {true, false}) {
+    auto [robot, robot_index] = MakeModel();
+    auto checker =
+        MakeUnallocatedChecker(move(robot), {robot_index}, parallel_supported);
+    EXPECT_EQ(checker->SupportsParallelChecking(), parallel_supported);
+  }
+}
+
+// For Update*Positions, we need to test the following:
+//   1 Do we operate on the right context?
+//   2 Does the context get updated?
+//   3 Does the context get updated before DoUpdateContextPositions gets called?
+//   4 Does DoUpdateContextPositions get called with a non-null context?
+TEST_F(TrivialCollisionCheckerTest, UpdatePositions) {
+  VectorXd q = dut_->GetZeroConfiguration();
+
+  q[0] = 0.1;
+  const Context<double>& model_plant_context = dut_->UpdatePositions(q);
+  // Test for #3 and #4; it doesn't throw and the right positions were recorded.
+  EXPECT_EQ(dut_->latest_positions()[0], 0.1);
+
+  q[0] = 0.2;
+  std::shared_ptr<CollisionCheckerContext> collision_context =
+      dut_->MakeStandaloneModelContext();
+  const Context<double>& standalone_plant_context =
+      dut_->UpdateContextPositions(collision_context.get(), q);
+  // Test for #3 and #4; it doesn't throw and the right positions were recorded.
+  EXPECT_EQ(dut_->latest_positions()[0], 0.2);
+
+  // Test for #1 and #2; each context is observably updated as expected.
+  EXPECT_EQ(dut_->plant().GetPositions(model_plant_context)[0], 0.1);
+  EXPECT_EQ(dut_->plant().GetPositions(standalone_plant_context)[0], 0.2);
+}
+
+// Verify that positions get updated before the NVI method
+// DoClassifyContextBodyCollisions gets called.
+TEST_F(TrivialCollisionCheckerTest, ClassifyBodyCollisions) {
+  VectorXd q = dut_->GetZeroConfiguration();
+
+  q[0] = 0.1;
+  dut_->ClassifyBodyCollisions(q);
+  // Update got called.
+  EXPECT_EQ(dut_->latest_positions()[0], 0.1);
+  // Update got called before forwarding to a derived class.
+  EXPECT_EQ(dut_->positions_for_classify()[0], 0.1);
+
+  q[0] = 0.2;
+  std::shared_ptr<CollisionCheckerContext> collision_context =
+      dut_->MakeStandaloneModelContext();
+  dut_->ClassifyContextBodyCollisions(collision_context.get(), q);
+  // Update got called.
+  EXPECT_EQ(dut_->latest_positions()[0], 0.2);
+  // Update got called before forwarding to a derived class.
+  EXPECT_EQ(dut_->positions_for_classify()[0], 0.2);
+}
+
+// Verify that positions get updated before the NVI method
+// DoCheckContextConfigCollisionFree gets called.
+TEST_F(TrivialCollisionCheckerTest, CheckConfigCollisionFree) {
+  VectorXd q = dut_->GetZeroConfiguration();
+
+  q[0] = 0.1;
+  dut_->CheckConfigCollisionFree(q);
+  // Update got called.
+  EXPECT_EQ(dut_->latest_positions()[0], 0.1);
+  // Update got called before forwarding to a derived class.
+  EXPECT_EQ(dut_->positions_for_check()[0], 0.1);
+
+  q[0] = 0.2;
+  std::shared_ptr<CollisionCheckerContext> collision_context =
+      dut_->MakeStandaloneModelContext();
+  dut_->CheckContextConfigCollisionFree(collision_context.get(), q);
+  // Update got called.
+  EXPECT_EQ(dut_->latest_positions()[0], 0.2);
+  // Update got called before forwarding to a derived class.
+  EXPECT_EQ(dut_->positions_for_check()[0], 0.2);
+}
+
+// Tests the ValidateFilteredCollisionMatrix() method by exercising
+// SetCollisionFilterMatrix() and passing otherwise invalid filtered
+// specifications.
+TEST_F(TrivialCollisionCheckerTest, SetCollisionFilterMatrix) {
+  const int num_bodies = dut_->plant().num_bodies();
+  // Bodies 1, 2, 3 are robot bodies and bodies 4 and 5 are environment (and
+  // body zero is the world).
+  ASSERT_EQ(num_bodies, 6);
+
+  // Make a baseline filter matrix with no filtered collisions for the model.
+  // Confirm it constitutes a change from the original state -- i.e., we can
+  // set the matrix with a valid matrix.
+  const Eigen::MatrixXi no_filters = MakeNothingFiltered();
+  EXPECT_FALSE(CompareMatrices(dut_->GetFilteredCollisionMatrix(), no_filters));
+  ASSERT_NO_THROW(dut_->SetCollisionFilterMatrix(no_filters));
+  EXPECT_TRUE(CompareMatrices(dut_->GetFilteredCollisionMatrix(), no_filters));
+
+  // Now test the various ways we can throw.
+
+  {
+    // The filter matrix is the wrong size.
+    Eigen::MatrixXi wrong_size =
+        Eigen::MatrixXi::Zero(num_bodies + 1, num_bodies + 1);
+
+    DRAKE_EXPECT_THROWS_MESSAGE(dut_->SetCollisionFilterMatrix(wrong_size),
+                                ".*wrong size.*");
+    Eigen::MatrixXi not_square =
+        Eigen::MatrixXi::Zero(num_bodies + 1, num_bodies);
+
+    DRAKE_EXPECT_THROWS_MESSAGE(dut_->SetCollisionFilterMatrix(not_square),
+                                ".*wrong size.*");
+  }
+
+  {
+    // Diagonal is not -1.
+    for (int i = 0; i < num_bodies; ++i) {
+      Eigen::MatrixXi bad_filters(no_filters);
+      bad_filters(i, i) = 0;
+      DRAKE_EXPECT_THROWS_MESSAGE(
+          dut_->SetCollisionFilterMatrix(bad_filters),
+          ".*invalid values on the diagonal.+ must always be -1.*");
+      bad_filters(i, i) = 1;
+      DRAKE_EXPECT_THROWS_MESSAGE(
+          dut_->SetCollisionFilterMatrix(bad_filters),
+          ".*invalid values on the diagonal.+ must always be -1.*");
+    }
+  }
+
+  {
+    // Environment-environment pairs aren't -1.
+    const vector<pair<int, int>> environment_body_pairs{{0, 4}, {0, 5}, {4, 5}};
+    for (const auto& [i, j] : environment_body_pairs) {
+      Eigen::MatrixXi bad_filters(no_filters);
+      bad_filters(i, j) = 0;
+      bad_filters(j, i) = 0;
+      DRAKE_EXPECT_THROWS_MESSAGE(
+          dut_->SetCollisionFilterMatrix(bad_filters),
+          ".* must contain -1 for pairs of environment bodies.*");
+      bad_filters(i, j) = 1;
+      bad_filters(j, i) = 1;
+      DRAKE_EXPECT_THROWS_MESSAGE(
+          dut_->SetCollisionFilterMatrix(bad_filters),
+          ".* must contain -1 for pairs of environment bodies.*");
+    }
+  }
+
+  {
+    // Values not included in {-1, 0, 1}, tested for an arbitrary
+    // robot-environment pair.
+    Eigen::MatrixXi bad_filters(no_filters);
+    bad_filters(0, 3) = 2;
+    bad_filters(3, 0) = 2;
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        dut_->SetCollisionFilterMatrix(bad_filters),
+        ".* must contain values that are 0, 1, or -1.*");
+    bad_filters(0, 3) = -2;
+    bad_filters(3, 0) = -2;
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        dut_->SetCollisionFilterMatrix(bad_filters),
+        ".* must contain values that are 0, 1, or -1.*");
+  }
+
+  {
+    // Matrix is not symmetric, tested for an arbitrary pair.
+    Eigen::MatrixXi bad_filters(no_filters);
+    bad_filters(0, 3) = 1;
+    DRAKE_EXPECT_THROWS_MESSAGE(dut_->SetCollisionFilterMatrix(bad_filters),
+                                ".* must be symmetric.*");
+  }
+
+  {
+    // Pairs with bodies marked as -1.
+    Eigen::MatrixXi bad_filters(no_filters);
+    bad_filters(0, 3) = -1;
+    bad_filters(3, 0) = -1;
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        dut_->SetCollisionFilterMatrix(bad_filters),
+        ".* can only be 1 or 0 for a pair with a robot body.*");
+  }
+}
+
+// Confirms construction of the nominal collision filter matrix. Explores the
+// various properties based on the initial configuration of the underlying
+// model. Finally, uses SetCollisionFilterMatrix() on the resulting filter
+// matrix to assert its validity.
+//
+// We'll be creating a RobotDiagram over and over to control its underlying
+// properties to achieve specific preconditions when creating the checker.
+TEST_F(TrivialCollisionCheckerTest, CollisionFiltersNominal) {
+  {
+    // Initial collision filters are equal to nominal.
+    EXPECT_TRUE(CompareMatrices(dut_->GetNominalFilteredCollisionMatrix(),
+                                dut_->GetFilteredCollisionMatrix()));
+  }
+
+  {
+    // A change to the checker's filter configuration doesn't change the
+    // nominal matrix.
+    auto [robot, robot_index] = MakeModel();
+    auto checker = MakeUnallocatedChecker(move(robot), {robot_index});
+    const Eigen::MatrixXi first_nominal =
+        checker->GetNominalFilteredCollisionMatrix();
+    const Eigen::MatrixXi no_filters = MakeNothingFiltered(checker.get());
+    // The nominal filters don't match what we're going to set.
+    EXPECT_FALSE(CompareMatrices(first_nominal, no_filters));
+
+    EXPECT_NO_THROW(checker->SetCollisionFilterMatrix(no_filters));
+
+    // Filter matrix has updated, but the reported nominal matrix hasn't
+    // changed.
+    EXPECT_TRUE(
+        CompareMatrices(checker->GetFilteredCollisionMatrix(), no_filters));
+    EXPECT_TRUE(CompareMatrices(first_nominal,
+                                checker->GetNominalFilteredCollisionMatrix()));
+  }
+
+  {
+    // Underlying model has *zero* collision filters and nothing welded; should
+    // be all -1s and 0s.
+    auto [robot, robot_index] = MakeModel({.weld_robot = false});
+    auto& scene_graph = robot->mutable_scene_graph();
+    auto collision_filters = scene_graph.collision_filter_manager();
+    collision_filters.Apply(CollisionFilterDeclaration().AllowWithin(
+        GeometrySet(scene_graph.model_inspector().GetAllFrameIds())));
+    auto checker = MakeUnallocatedChecker(move(robot), {robot_index});
+    const Eigen::MatrixXi filters = checker->GetFilteredCollisionMatrix();
+    // Confirm it is valid.
+    EXPECT_NO_THROW(checker->SetCollisionFilterMatrix(filters));
+    // Confirm there are no `1` values.
+    const Eigen::MatrixXi filters_expected = MakeNothingFiltered(checker.get());
+    EXPECT_TRUE(CompareMatrices(filters, filters_expected));
+  }
+
+  {
+    // Underlying model has *zero* collision filters but robot body (1) is
+    // welded to the world (0); should be all -1s and 0s, except at (0,1) and
+    // (1, 0).
+    auto [robot, robot_index] = MakeModel();
+    auto& scene_graph = robot->mutable_scene_graph();
+    auto collision_filters = scene_graph.collision_filter_manager();
+    collision_filters.Apply(CollisionFilterDeclaration().AllowWithin(
+        GeometrySet(scene_graph.model_inspector().GetAllFrameIds())));
+    auto checker = MakeUnallocatedChecker(move(robot), {robot_index});
+    const Eigen::MatrixXi filters = checker->GetFilteredCollisionMatrix();
+    // Confirm it is valid.
+    EXPECT_NO_THROW(checker->SetCollisionFilterMatrix(filters));
+    // The only 1s are between the world and the welded robot root.
+    Eigen::MatrixXi filters_expected = MakeNothingFiltered(checker.get());
+    filters_expected(0, 1) = filters_expected(1, 0) = 1;
+    EXPECT_TRUE(CompareMatrices(filters, filters_expected));
+  }
+
+  {
+    // Underlying model has collision filters added, but nothing welded;
+    // should be -1s and 0, except for where the collision filter has been
+    // specified.
+    auto [robot, robot_index] = MakeModel({.weld_robot = false});
+    auto& scene_graph = robot->mutable_scene_graph();
+    auto collision_filters = scene_graph.collision_filter_manager();
+    // Clear all collision filters and then add one back between robot bodies
+    // 1 & 3.
+    collision_filters.Apply(CollisionFilterDeclaration().AllowWithin(
+        GeometrySet(scene_graph.model_inspector().GetAllFrameIds())));
+    const FrameId id1 = robot->plant().GetBodyFrameIdOrThrow(BodyIndex(1));
+    const FrameId id3 = robot->plant().GetBodyFrameIdOrThrow(BodyIndex(3));
+    collision_filters.Apply(
+        CollisionFilterDeclaration().ExcludeWithin(GeometrySet({id1, id3})));
+    auto checker = MakeUnallocatedChecker(move(robot), {robot_index});
+    const Eigen::MatrixXi filters = checker->GetFilteredCollisionMatrix();
+    // Confirm it is valid.
+    EXPECT_NO_THROW(checker->SetCollisionFilterMatrix(filters));
+    // The only 1s are between bodies 1 and 3.
+    Eigen::MatrixXi filters_expected = MakeNothingFiltered(checker.get());
+    filters_expected(3, 1) = filters_expected(1, 3) = 1;
+    EXPECT_TRUE(CompareMatrices(filters, filters_expected));
+  }
+
+  {
+    // SceneGraph can have multiple geometries on a single body that have
+    // different filter status w.r.t. geometries on another body.
+    // CollisionChecker will get angry about that.
+    auto [robot, robot_index] = MakeModel({.per_body_geometries = 2});
+    auto& scene_graph = robot->mutable_scene_graph();
+    auto collision_filters = scene_graph.collision_filter_manager();
+    // Clear all collision filters and then add one back between two
+    // geometries belonging to robot bodies 1 & 3.
+    collision_filters.Apply(CollisionFilterDeclaration().AllowWithin(
+        GeometrySet(scene_graph.model_inspector().GetAllFrameIds())));
+    const FrameId f_id1 = robot->plant().GetBodyFrameIdOrThrow(BodyIndex(1));
+    const GeometryId g_id1 =
+        scene_graph.model_inspector().GetGeometries(f_id1, Role::kProximity)[0];
+    const FrameId f_id3 = robot->plant().GetBodyFrameIdOrThrow(BodyIndex(3));
+    const GeometryId g_id3 =
+        scene_graph.model_inspector().GetGeometries(f_id3, Role::kProximity)[0];
+    collision_filters.Apply(CollisionFilterDeclaration().ExcludeWithin(
+        GeometrySet({g_id1, g_id3})));
+
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        MakeUnallocatedChecker(move(robot), {robot_index}),
+        ".*filtering between body .+ is inconsistent");
+  }
+}
+
+// Tests SetCollisionFilteredBetween(). This function doesn't call validate
+// because its correctness doesn't depend on input parameters. Instead,
+// we test its validity here by confirming the filter matrix produced
+// passes the validity test exercised by SetCollisionFilterMatrix().
+TEST_F(TrivialCollisionCheckerTest, SetCollisionFilteredBetween) {
+  const int num_bodies = dut_->plant().num_bodies();
+  // Bodies 1, 2, 3 are robot bodies and bodies 4 and 5 are environment (and
+  // body zero is the world).
+  ASSERT_EQ(num_bodies, 6);
+
+  const vector<BodyIndex> b{BodyIndex(0), BodyIndex(1), BodyIndex(2),
+                            BodyIndex(3), BodyIndex(4), BodyIndex(5)};
+
+  // There are two overrides: one takes bodies, one takes body indices. We'll
+  // test the body-index-based override, relying on the fact that the body-based
+  // override delegates to it.
+
+  {
+    // Trying to set collision filters between environment bodies. It always
+    // throws.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        dut_->SetCollisionFilteredBetween(b[0], b[4], true),
+        ".* cannot be used on pairs of environment bodies.*");
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        dut_->SetCollisionFilteredBetween(b[0], b[4], false),
+        ".* cannot be used on pairs of environment bodies.*");
+  }
+
+  {
+    // Setting filters between robot-environment, in either order is valid.
+    EXPECT_NO_THROW(dut_->SetCollisionFilteredBetween(b[1], b[4], true));
+    EXPECT_TRUE(dut_->IsCollisionFilteredBetween(b[1], b[4]));
+    EXPECT_NO_THROW(
+        dut_->SetCollisionFilterMatrix(dut_->GetFilteredCollisionMatrix()));
+
+    // Clearing filters is likewise valid - we'll reverse the order of indices
+    // to show it doesn't matter.
+    EXPECT_NO_THROW(dut_->SetCollisionFilteredBetween(b[4], b[1], false));
+    EXPECT_FALSE(dut_->IsCollisionFilteredBetween(b[1], b[4]));
+    EXPECT_NO_THROW(
+        dut_->SetCollisionFilterMatrix(dut_->GetFilteredCollisionMatrix()));
+  }
+
+  {
+    // Setting filters between robot-robot, in either order, is valid.
+    EXPECT_NO_THROW(dut_->SetCollisionFilteredBetween(b[1], b[2], true));
+    EXPECT_TRUE(dut_->IsCollisionFilteredBetween(b[1], b[2]));
+    EXPECT_NO_THROW(
+        dut_->SetCollisionFilterMatrix(dut_->GetFilteredCollisionMatrix()));
+
+    // Clearing filters is likewise valid - we'll reverse the order of indices
+    // to show it doesn't matter.
+    EXPECT_NO_THROW(dut_->SetCollisionFilteredBetween(b[2], b[1], false));
+    EXPECT_FALSE(dut_->IsCollisionFilteredBetween(b[1], b[2]));
+    EXPECT_NO_THROW(
+        dut_->SetCollisionFilterMatrix(dut_->GetFilteredCollisionMatrix()));
+  }
+
+  // Token test against bodies, instead of indices.
+  EXPECT_NO_THROW(dut_->SetCollisionFilteredBetween(dut_->get_body(b[2]),
+                                                   dut_->get_body(b[3]), true));
+  EXPECT_TRUE(dut_->IsCollisionFilteredBetween(b[2], b[3]));
+  EXPECT_NO_THROW(
+      dut_->SetCollisionFilterMatrix(dut_->GetFilteredCollisionMatrix()));
+}
+
+// Tests SetCollisionFilteredWithAllBodies(). This function doesn't call
+// validate because its correctness doesn't depend on input parameters. Instead,
+// we test its validity here by confirming the filter matrix produced
+// passes the validity test exercised by SetCollisionFilterMatrix().
+TEST_F(TrivialCollisionCheckerTest, SetCollisionFilteredWithAllBodies) {
+  const int num_bodies = dut_->plant().num_bodies();
+  // Bodies 1, 2, 3 are robot bodies and bodies 4 and 5 are environment (and
+  // body zero is the world).
+  ASSERT_EQ(num_bodies, 6);
+
+  const vector<BodyIndex> b{BodyIndex(0), BodyIndex(1), BodyIndex(2),
+                            BodyIndex(3), BodyIndex(4), BodyIndex(5)};
+
+  {
+    // Setting an environment body is simply bad.
+    EXPECT_THROW(dut_->SetCollisionFilteredWithAllBodies(b[4]),
+                 std::exception);
+  }
+
+  {
+    // Setting a robot body doesn't throw, produces a consistent matrix and
+    // reports filters as expected.
+    EXPECT_NO_THROW(dut_->SetCollisionFilteredWithAllBodies(b[3]));
+    EXPECT_NO_THROW(
+      dut_->SetCollisionFilterMatrix(dut_->GetFilteredCollisionMatrix()));
+    for (BodyIndex i(0); i < num_bodies; ++i) {
+      EXPECT_TRUE(dut_->IsCollisionFilteredBetween(i, b[3]));
+    }
+  }
+}
+
+// Simple tests against the IsCollisionFilteredBetween() API. It assumes the
+// collision filter matrix is consistent and known and simply confirms that
+// it is interpreted correctly and doesn't depend on the ordering of the
+// parameter values.
+TEST_F(TrivialCollisionCheckerTest, IsCollisionFilteredBetween) {
+  const int num_bodies = dut_->plant().num_bodies();
+  // Bodies 1, 2, 3 are robot bodies and bodies 4 and 5 are environment (and
+  // body zero is the world).
+  ASSERT_EQ(num_bodies, 6);
+
+  // Make a baseline filter matrix with no filtered collisions for the model.
+  Eigen::MatrixXi filters = MakeNothingFiltered();
+
+  // Now filter collisions between one robot-robot pair and one
+  // robot-environment pair.
+  filters(1, 3) = filters(3, 1) = 1;
+  filters(2, 4) = filters(4, 2) = 1;
+
+  EXPECT_NO_THROW(dut_->SetCollisionFilterMatrix(filters));
+
+  // Sample *unfiltered* robot-robot pair.
+  EXPECT_FALSE(dut_->IsCollisionFilteredBetween(BodyIndex(1), BodyIndex(2)));
+  EXPECT_FALSE(dut_->IsCollisionFilteredBetween(BodyIndex(2), BodyIndex(1)));
+
+  // Sample *filtered* robot-robot pair.
+  EXPECT_TRUE(dut_->IsCollisionFilteredBetween(BodyIndex(1), BodyIndex(3)));
+  EXPECT_TRUE(dut_->IsCollisionFilteredBetween(BodyIndex(3), BodyIndex(1)));
+
+  // Sample *unfiltered* robot-environment pair.
+  EXPECT_FALSE(dut_->IsCollisionFilteredBetween(BodyIndex(0), BodyIndex(1)));
+  EXPECT_FALSE(dut_->IsCollisionFilteredBetween(BodyIndex(1), BodyIndex(0)));
+
+  // Sample *filtered* robot-environment pair.
+  EXPECT_TRUE(dut_->IsCollisionFilteredBetween(BodyIndex(2), BodyIndex(4)));
+  EXPECT_TRUE(dut_->IsCollisionFilteredBetween(BodyIndex(4), BodyIndex(2)));
+
+  // Sample *filtered* environment-environment pair.
+  EXPECT_TRUE(dut_->IsCollisionFilteredBetween(BodyIndex(0), BodyIndex(4)));
+  EXPECT_TRUE(dut_->IsCollisionFilteredBetween(BodyIndex(4), BodyIndex(0)));
+
+  // Token invocation of the same API using bodies instead of body indices. We
+  // exploit the fact that the overload that takes bodies delegates to the
+  // body index overload tested above.
+  EXPECT_TRUE(dut_->IsCollisionFilteredBetween(dut_->get_body(BodyIndex(1)),
+                                              dut_->get_body(BodyIndex(3))));
+}
+
+// Creates a checker on a plant with an N-link chain (optionally) welded to the
+// world. Part of the edge-checking API test infrastructure (see below).
+template <typename CheckerType>
+CheckerType MakeEdgeChecker(ConfigurationDistanceFunction calc_dist,
+                            double step_size = 0.25,
+                            ConfigurationInterpolationFunction interp = nullptr,
+                            bool welded = true, int N = 2) {
+  RobotDiagramBuilder<double> builder;
+  // We need just enough state so we can save values in q.
+  auto& plant = builder.mutable_plant();
+  const ModelInstanceIndex robot = AddChain(&plant, N);
+  // Weld the chain to the world so we don't have to worry about quaternions.
+  const auto& body = plant.GetBodyByName("b0");
+  if (welded) {
+    plant.WeldFrames(plant.world_frame(), body.body_frame(), {});
+  }
+  auto diagram = builder.BuildDiagram();
+
+  CheckerType checker({move(diagram), {robot}, calc_dist, step_size, 0, 0});
+  checker.SetConfigurationInterpolationFunction(interp);
+  return checker;
+}
+
+// The edge-checking API is configured with a distance function, interpolation
+// function, and edge step size. This test simply confirms that those quantities
+// get configured as expected upon construction and can be modified after
+// construction via their setters.
+//
+// These configuration values do *not* depend on the underlying robot model or
+// checker's contexts; so, we'll use the most bare bones instance possible.
+GTEST_TEST(EdgeCheckTest, Configuration) {
+  // This distance function is designed to return an arbitrary, recognizable
+  // value that clearly signals its invocation: -1.5. However, to be accepted
+  // by CollisionChecker dist(q, q) *must* return 0.
+  const ConfigurationDistanceFunction dist0 = [](const VectorXd& q1,
+                                                 const VectorXd& q2) {
+    const double dist = (q1 - q2).norm();
+    if (dist == 0) return 0.0;
+    return -1.5;
+  };
+  CollisionCheckerTester dut = MakeEdgeChecker<CollisionCheckerTester>(dist0);
+  const int q_size = dut.plant().num_positions();
+
+  // Edge step size: set by constructor, is retrievable and settable.
+  // Constructor value came through.
+  EXPECT_EQ(dut.edge_step_size(), 0.25);
+  // Explicitly setting post-construction likewise works.
+  dut.set_edge_step_size(0.1);
+  EXPECT_EQ(dut.edge_step_size(), 0.1);
+
+  // Both distance and interpolation functionality provide parallel APIs:
+  //   (1) Function to evaluate the function directly.
+  //   (2) Function to create a functor that wraps the checker.
+  //   (3) Ability to set the functor.
+  // We'll use the same pattern for both distance and interpolation functions:
+  //   - Confirm post-construction behavior
+  //     - Evaluate (1) and (2) above.
+  //   - Set the function to something else (3):
+  //     - Evaluate (1) and (2) again.
+  // We're not testing the underlying distance and interpolation functions; just
+  // looking for evidence that they're being called.
+
+  const Eigen::VectorXd q1 = Eigen::VectorXd::Constant(q_size, 1);
+  const Eigen::VectorXd q2 = Eigen::VectorXd::Zero(q_size);
+
+  {
+    // Distance function.
+
+    // Evaluate (1) and (2) as constructed. dist0 should always return -1.5.
+    EXPECT_EQ(dut.ComputeConfigurationDistance(q1, q2), -1.5);
+    ASSERT_NE(dut.MakeStandaloneConfigurationDistanceFunction(), nullptr);
+    EXPECT_EQ(dut.MakeStandaloneConfigurationDistanceFunction()(q1, q2), -1.5);
+
+    // Change the function via (3).
+    const ConfigurationDistanceFunction dist1 =
+        [](const VectorXd& a, const VectorXd& b) { return (b - a).norm(); };
+    dut.SetConfigurationDistanceFunction(dist1);
+
+    // Evaluate (1) and (2) again.
+    EXPECT_EQ(dut.ComputeConfigurationDistance(q1, q2), q1.norm());
+    ASSERT_NE(dut.MakeStandaloneConfigurationDistanceFunction(), nullptr);
+    EXPECT_EQ(dut.MakeStandaloneConfigurationDistanceFunction()(q1, q2),
+              q1.norm());
+  }
+
+  {
+    // Interpolation function.
+
+    // Evaluate (1) and (2) as constructed; default interpolation is linear
+    // interpolation.
+    EXPECT_EQ(dut.InterpolateBetweenConfigurations(q1, q2, 0.5),
+              0.5 * (q1 + q2));
+    ASSERT_NE(dut.MakeStandaloneConfigurationInterpolationFunction(), nullptr);
+    EXPECT_EQ(
+        dut.MakeStandaloneConfigurationInterpolationFunction()(q1, q2, 0.5),
+        0.5 * (q1 + q2));
+
+    // Change the function via (3).
+    const ConfigurationInterpolationFunction interpolation_fn =
+        [](const VectorXd& q, const VectorXd&, double alpha) {
+          return VectorXd::Constant(q.size(), alpha);
+        };
+    dut.SetConfigurationInterpolationFunction(interpolation_fn);
+
+    // Evaluate (1) and (2) again.
+    EXPECT_EQ(dut.InterpolateBetweenConfigurations(q1, q2, 0.5),
+              Eigen::VectorXd::Constant(q_size, 0.5));
+    ASSERT_NE(dut.MakeStandaloneConfigurationInterpolationFunction(), nullptr);
+    EXPECT_EQ(
+        dut.MakeStandaloneConfigurationInterpolationFunction()(q1, q2, 0.5),
+        Eigen::VectorXd::Constant(q_size, 0.5));
+
+    // The interpolation function has a "reset" function that restores the
+    // default interpolation function. Evaluate (1) and (2) again.
+    dut.SetConfigurationInterpolationFunction(nullptr);
+    EXPECT_EQ(dut.InterpolateBetweenConfigurations(q1, q2, 0.5),
+              0.5 * (q1 + q2));
+    ASSERT_NE(dut.MakeStandaloneConfigurationInterpolationFunction(), nullptr);
+    EXPECT_EQ(
+        dut.MakeStandaloneConfigurationInterpolationFunction()(q1, q2, 0.5),
+        0.5 * (q1 + q2));
+  }
+}
+
+// The default interpolation should handle quaternion and other joints in an
+// expected way (SLERP for the former, LERP for the latter).
+GTEST_TEST(EdgeCheckTest, DefaultInterpolation) {
+  const ConfigurationDistanceFunction dist =
+      [](const VectorXd& a, const VectorXd& b) { return (b - a).norm(); };
+  // We want a floating body to guarantee we have quaternions.
+  auto dut = MakeEdgeChecker<CollisionCheckerTester>(
+      dist, 0.1, nullptr /* default interpolator */, false /* welded */);
+
+  const auto& plant = dut.plant();
+  auto context = plant.CreateDefaultContext();
+
+  // Body "b0" should be floating (7 dof) and "b1" should be linked to "b0" by
+  // a single revolute joint.
+  ASSERT_EQ(dut.plant().num_positions(), 8);
+
+  // Arbitrary initial pose for free body.
+  const RigidTransform X_WB0_init(
+      RotationMatrixd(AngleAxisd(M_PI / 7, Vector3d{1, 2, 3}.normalized())),
+      Vector3d{0.5, -0.3, 1.2});
+  const double j12_init = -M_PI + 0.1;
+
+  // Final pose is defined as offset from initial pose. Define the offset.
+  const Vector3d rot_axis_W = Vector3d{-3, 1, 2}.normalized();
+  const double init_final_theta = 5 * M_PI / 7;
+  const Vector3d p_InitFinal{-0.25, 0.75, 0.8};
+  const RigidTransformd X_InitFinal(AngleAxisd(init_final_theta, rot_axis_W),
+                                    p_InitFinal);
+
+  // Now define the final.
+  const RigidTransformd X_WB0_final = X_WB0_init * X_InitFinal;
+  const double j12_final = M_PI - 0.1;
+
+  // Given a pose of the free body and the angle theta between bodies b0 and b1,
+  // returns the plant's q.
+  auto get_q = [&plant, &context](const RigidTransformd& X_B0, double theta) {
+    const Body<double>& body0 = plant.GetBodyByName("b0");
+    plant.SetFreeBodyPose(context.get(), body0, X_B0);
+    plant.GetMutablePositions(context.get())[7] = theta;
+    return plant.GetPositions(*context);
+  };
+
+  const VectorXd q_init = get_q(X_WB0_init, j12_init);
+  const VectorXd q_final = get_q(X_WB0_final, j12_final);
+
+  // Compute the interpolation based on the known relationship between init and
+  // final.
+  auto get_interpolated = [&](double s) {
+    const Vector3d p_InitS = p_InitFinal * s;
+    const RigidTransformd X_InitS(
+        RotationMatrixd(AngleAxisd(init_final_theta * s, rot_axis_W)),
+        p_InitFinal * s);
+    const RigidTransformd X_WS = X_WB0_init * X_InitS;
+    const double j12_s = j12_init + s * (j12_final - j12_init);
+    return get_q(X_WS, j12_s);
+  };
+
+  for (const double s : {0.0, 0.25, 0.6, 1.0}) {
+    EXPECT_TRUE(CompareMatrices(
+        dut.InterpolateBetweenConfigurations(q_init, q_final, s),
+        get_interpolated(s), 1e-15));
+  }
+
+  // Definitely not simply LERP.
+  for (const double s : {0.25, 0.6}) {
+    EXPECT_FALSE(CompareMatrices(
+        dut.InterpolateBetweenConfigurations(q_init, q_final, s),
+        q_init + s * (q_final - q_init), 1e-7));
+  }
+}
+
+// The configuration of a test case for the MeasureEdgeCollisionFree* APIS.
+struct EdgeTestConfig {
+  // The expected interpolant value (in the range [0, 1]) returned by
+  // MeasureEdgeCollisionFree(). If this is negative, we'll simply test for an
+  // edge that is *not* partially free.
+  double alpha;
+
+  // The expected interpolant value (greater than alpha) that represents the
+  // last colliding configuration.
+  double last_colliding_alpha;
+
+  // Request the calculation to be done in parallel.
+  bool parallel;
+};
+
+std::ostream& operator<<(std::ostream& out, const EdgeTestConfig& c) {
+  out << "EdgeTestWith" << c.alpha << "AlphaIn"
+      << (c.parallel ? "Parallel" : "Serial");
+  return out;
+}
+
+class ParameterizedEdgeCheckTest
+    : public testing::TestWithParam<EdgeTestConfig> {};
+
+// To evaluate the edge-checking APIs, we need direct control over when an edge
+// is collision free and when it is not. The edge-checking APIs completely rely
+// on the user-defined distance and interpolation functions, as well as the
+// derived CollisionChecker's DoCheckContextConfigCollisionFree()
+// implementation.
+//
+// To cater to both the Measure* and Check* variants, we can't just define an
+// edge as being in collision for every sample *beyond* a certain interpolant
+// value. If we were to do so, we couldn't test an edge that only has
+// collisions on the *interior*. So, the test creates *ranges* of collision.
+// Ranges with more than a single colliding sample allows us to confirm that
+// algorithms always return the last valid interpolant value closest to the
+// *minimum* colliding sample.
+//
+// This class exploits this by providing *very* custom distance, interpolation,
+// and collision checks. It does so by encoding test parameters *inside* the
+// end configuration. No geometry is required and we only need enough bodies in
+// the plant to provide sufficient robot dofs to hold the encoding.
+//
+// The collision check is based on the current plant configuration.
+//   q[0]: The largest interpolant value that is still "collision
+//         free". This is the expected return value. It is designed to be
+//         exactly equal to the value of alpha that would be computed by
+//         CheckEdgeCollisionFree() as an interpolant value.
+//   q[1]: The largest interpolant value that is in collision. It should be the
+//         case that q[1] > q[0]. For interpolation(q1, q2, s), that
+//         configuration is in collision if q[0] < s <= q[1].
+//   q[2]: The interpolant value at which this configuration was generated. This
+//         is defined by the interpolating function.
+//
+// The configuration interpolator is responsible for providing the encoding to
+// the collision check. The "interpolation" simply copies q[0] and q[1] into the
+// interpolated result and then sets the interpolant into q[2]. CollisionChecker
+// updates the plant's positions with these values so that the collision check
+// can read them. In all cases, the values of q1 are completely ignored.
+//
+// The collision checker uses the "colliding range" (q[0], q[1]] to determine if
+// the current configuration is in collision. The test configurations will be
+// set up so that multiple configurations will be colliding. When this range
+// includes s = 1, special care must be taken for CheckEdgeCollisionFree() (see
+// below for details).
+//
+// Finally, the distance function is responsible for guaranteeing we have a
+// small, fixed number of steps on each edge. This serves two purposes: keeps
+// the test runtime short and makes the values of the alpha value easier to
+// reason about.
+//
+// Also, the checker tracks work done across threads and can report if work has
+// been done in more than one thread.
+class MockEdgeChecker : public UnimplementedCollisionChecker {
+ public:
+  explicit MockEdgeChecker(CollisionCheckerParams params)
+      : UnimplementedCollisionChecker(move(params), true) {
+    DRAKE_DEMAND(plant().num_positions() >= kQSize);
+    AllocateContexts();
+    const int num_omp_threads =
+        common_robotics_utilities::openmp_helpers::GetNumOmpThreads();
+    const int max_num_omp_threads =
+        common_robotics_utilities::openmp_helpers::GetMaxNumOmpThreads();
+    const int num_threads = std::max(num_omp_threads, max_num_omp_threads);
+    thread_signals_ = vector<int>(num_threads, 0);
+  }
+
+  using CollisionChecker::CanEvaluateInParallel;
+
+  // Returns the number of threads this was evaluated on.
+  int thread_count() const {
+    return std::accumulate(thread_signals_.begin(), thread_signals_.end(), 0);
+  }
+
+  // Force five samples based on the given `step_size`.
+  static ConfigurationDistanceFunction MakeEdgeDistance(double step_size) {
+    return [step_size](const VectorXd& q1, const VectorXd& q2) {
+      // f(q, q) = 0 is a requirement of CollisionChecker.
+      if (q1.norm() == 0.0) return 0.0;
+      // This *guarantees* four steps without recourse to numerical errors. Four
+      // steps --> five samples.
+      return step_size * 3.5;
+    };
+  }
+
+  // Interpolation function responsible for propagating encoded parameters into
+  // a new position vector.
+  static ConfigurationInterpolationFunction MakeEdgeInterpolation() {
+    return [](const VectorXd&, const VectorXd& q2, double s) {
+      VectorXd result(q2);
+      result(2) = s;
+      return result;
+    };
+  }
+
+  // Encodes a configuration vector q* with the information about whether the
+  // edge (q, q*) is in collision, and, if so, where. The result has the
+  // values:
+  //  q(0): The highest value of alpha that is collision free.
+  //  q(1): The highest value of alpha that is colliding; q(1) > q(0).
+  //  q(2): We set it to 1.0 so that when we encode the end point configuration,
+  //        the value for interpolant is consistent with that interpretation.
+  //        Necessary for CheckEdgeCollisionFree() as it doesn't interpolate
+  //        prior to testing the end point.
+  static VectorXd EncodeConfiguration(int size, double last_free,
+                                      double last_colliding) {
+    DRAKE_DEMAND(size >= kQSize);
+    DRAKE_DEMAND(last_free <= 1.0);
+    DRAKE_DEMAND(last_colliding > last_free);
+
+    VectorXd q = VectorXd::Zero(size);
+    q(0) = last_free;
+    q(1) = last_colliding;
+    q(2) = 1.0;
+    return q;
+  }
+
+  static constexpr int kQSize = 3;
+  static constexpr int kNumSamples = 5;
+
+ protected:
+  bool DoCheckContextConfigCollisionFree(
+      const CollisionCheckerContext& model_context) const override {
+    // Make this call artificially more expensive so that parallel edge checks
+    // will actually perform work in multiple OpenMP threads.
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    const int thread_index =
+        common_robotics_utilities::openmp_helpers::GetContextOmpThreadNum();
+    thread_signals_[thread_index] = 1;
+    const auto q = plant().GetPositions(model_context.plant_context());
+    const double s = q(2);
+    const bool free = s <= q(0) || q(1) < s;
+    return free;
+  }
+
+  // We just want this to *not* throw.
+  void DoUpdateContextPositions(CollisionCheckerContext*) const override {}
+
+  // A per-thread signal; if the code was exercised in thread i, the value
+  // at the ith index is one, otherwise zero.
+  mutable vector<int> thread_signals_;
+};
+
+std::vector<EdgeTestConfig> MakeEdgeTestCases() {
+  std::vector<EdgeTestConfig> configs;
+
+  const double divisor = static_cast<double>(MockEdgeChecker::kNumSamples - 1);
+
+  for (const bool in_parallel : {true, false}) {
+    // Edges are 100% valid.
+    configs.push_back({.alpha = 1.0,
+                       .last_colliding_alpha = 2.0,
+                       .parallel = in_parallel});
+
+    // Edges are invalid to varying degrees (this includes edges where q1 is not
+    // valid -- alpha < 0).
+    for (int step = 0; step < MockEdgeChecker::kNumSamples; ++step) {
+      const double free = (step - 1) / divisor;
+      // We want *two* samples to be in collision.
+      const double colliding = (step + 1) / divisor;
+      configs.push_back({.alpha = free,
+                         .last_colliding_alpha = colliding,
+                         .parallel = in_parallel});
+    }
+  }
+
+  return configs;
+}
+
+INSTANTIATE_TEST_SUITE_P(EdgeCheckTest, ParameterizedEdgeCheckTest,
+                         testing::ValuesIn(MakeEdgeTestCases()));
+
+// CollisionChecker logic for checking a single edge in serial includes the
+// following unique responsibilities:
+//
+//   1. Makes use of edge_step_size and distance function to compute the
+//      expected number of samples.
+//   2. It uses the registered interpolation function to create sample
+//      configurations.
+//   3. All edge samples are evaluated to report the edge free of collision.
+//   4. Failure on any given sample returns the right alpha value.
+//
+// (1) and (2) will be validated by the test producing the result that we
+// expect, when we expect. The configurations provided are nonsensical. The
+// only way for them to make sense, is to use our provided functions and
+// edge step size.
+//
+// (3) We'll provide test cases such that collisions at all possible locations
+// are covered. This provides evidence that every sample is tested.
+//
+// (4) Finally, we confirm the reported alpha with the expected alpha.
+//
+// We hit both MeasureEdgeCollisionFree() and MeasureEdgeCollisionFreeParallel()
+// in this test. For a given configuration, we set up a scenario which should
+// produce a requested number of samples (with some portion of them being
+// collision free). We explicitly exercise MeasureEdgeCollisionFree knowing it
+// delegates to MeasureContextEdgeCollisionFree, getting two tests for one.
+//
+// This test depends *heavily* on MockEdgeChecker to map test configuration to
+// the expected outcome. Understanding that mechanism is a prerequisite to
+// understanding this test.
+TEST_P(ParameterizedEdgeCheckTest, MeasureEdgeCollisionFree) {
+  const EdgeTestConfig& config = GetParam();
+  ASSERT_LE(config.alpha, 1.0);
+
+  // Set up the mock checker with our mock functions.
+
+  // Arbitrary value; friendly to base 2.
+  const double step_size = 0.25;
+  const int q_size = MockEdgeChecker::kQSize;
+  auto dut = MakeEdgeChecker<MockEdgeChecker>(
+      MockEdgeChecker::MakeEdgeDistance(step_size), step_size,
+      MockEdgeChecker::MakeEdgeInterpolation(), true /* welded */,
+      q_size + 1 /* num_bodies */);
+
+  // Reality check. If we've requested parallel evaluation we need to confirm
+  // it'll happen; otherwise we're simply testing the serial implementation
+  // again.
+  if (config.parallel) {
+    ASSERT_TRUE(dut.CanEvaluateInParallel());
+  }
+
+  // Start configuration values are simply ignored.
+  const VectorXd q1 = VectorXd::Constant(q_size, 0.75);
+  // End configuration encodes failure based on the expected colliding range.
+  const VectorXd q2 = dut.EncodeConfiguration(q_size, config.alpha,
+                                              config.last_colliding_alpha);
+
+  const EdgeMeasure result =
+      config.parallel ? dut.MeasureEdgeCollisionFreeParallel(q1, q2)
+                      : dut.MeasureEdgeCollisionFree(q1, q2);
+
+  const double expected_alpha = config.alpha;
+  if (expected_alpha == 1.0) {
+    EXPECT_TRUE(result.completely_free());
+  }
+  if (expected_alpha >= 0) {
+    ASSERT_TRUE(result.partially_free());
+    EXPECT_EQ(result.alpha(), expected_alpha);
+  } else {
+    EXPECT_FALSE(result.completely_free());
+    EXPECT_FALSE(result.partially_free());
+    EXPECT_THROW(result.alpha(), std::exception);
+  }
+  // Are things parallel as we expect?
+  if (config.parallel) {
+    EXPECT_GT(dut.thread_count(), 1);
+  }
+}
+
+// Same test as for MeasureEdgeCollisionFree, but uses the boolean variant.
+// There is one *further* change due to the differences between Check* and Is*.
+// The Is* variant does an early check on q2. If q2 isn't free, it never tests
+// anything else. This means that in the parallel mode, we never enter parallel
+// evaluation.
+TEST_P(ParameterizedEdgeCheckTest, CheckEdgeCollisionFree) {
+  const EdgeTestConfig& config = GetParam();
+  ASSERT_LE(config.alpha, 1.0);
+
+  // Set up the mock checker with our mock functions.
+
+  // Arbitrary value; friendly to base 2.
+  const double step_size = 0.25;
+  const int q_size = MockEdgeChecker::kQSize;
+  auto dut = MakeEdgeChecker<MockEdgeChecker>(
+      MockEdgeChecker::MakeEdgeDistance(step_size), step_size,
+      MockEdgeChecker::MakeEdgeInterpolation(), true /* welded */,
+      q_size + 1 /* num_bodies */);
+
+  // Reality check. If we've requested parallel evaluation we need to confirm
+  // it'll happen; otherwise we're simply testing the serial implementation
+  // again.
+  if (config.parallel) {
+    ASSERT_TRUE(dut.CanEvaluateInParallel());
+  }
+
+  // Start configuration values are simply ignored.
+  const VectorXd q1 = VectorXd::Constant(q_size, 0.75);
+  // End configuration encodes failure based on the expected colliding range.
+  const VectorXd q2 = dut.EncodeConfiguration(q_size, config.alpha,
+                                              config.last_colliding_alpha);
+
+  const bool result =
+      config.parallel ? dut.CheckEdgeCollisionFreeParallel(q1, q2)
+                      : dut.CheckEdgeCollisionFree(q1, q2);
+
+  // The encoded alpha (as documented above on EncodeConfiguration()).
+  const bool expected_result = config.alpha == 1.0;
+  EXPECT_EQ(result, expected_result);
+  if (config.parallel) {
+    if (config.alpha >= 0.5 && config.alpha < 1.0) {
+      // If 0.5 <= expected_result < 1.0, then the colliding range includes q2.
+      // For the parallel implementation, we should fail fast and never enter
+      // the parallel regime.
+      EXPECT_EQ(dut.thread_count(), 1);
+    } else {
+      EXPECT_GT(dut.thread_count(), 1);
+    }
+  }
+}
+
+// The test for CheckEdgesCollisionFree() (plural) uses
+// MeasureEdgeCollisionFree() (singular) to test individual edges. For this
+// function, we only need to test:
+//
+//   1. Do *all* the edges get evaluated with the expected result?
+//   2. Does the `parallelize` parameter have the documented effect?
+//
+GTEST_TEST(EdgeCheckTest, MeasureMultipleEdges) {
+  // Use the MockEdgeChecker to control edge failures.
+  const double step_size = 0.05;
+  auto calc_dist = MockEdgeChecker::MakeEdgeDistance(step_size);
+  auto interp = MockEdgeChecker::MakeEdgeInterpolation();
+
+  const int q_size = MockEdgeChecker::kQSize;
+
+  // Garbage start configuration; the values are ignored.
+  const VectorXd q_start = VectorXd::Constant(q_size, 0.75);
+  // All edges start from the same configuration, q_start. The end configuration
+  // gets encoded by MockEdgeChecker. Note: we know that we're getting five
+  // samples so the distance between values of alpha is 0.25. So, to make sure
+  // *two* samples are in collision, the last colliding alpha should be the
+  // last free + 0.5.
+  vector<std::pair<VectorXd, VectorXd>> edges;
+  // 100% clear.
+  edges.emplace_back(q_start,
+                     MockEdgeChecker::EncodeConfiguration(q_size, 1.0, 1.5));
+  // Quarter free (collision at 0.5 and 0.75).
+  edges.emplace_back(q_start,
+                     MockEdgeChecker::EncodeConfiguration(q_size, 0.25, 0.75));
+  // Three quarters free (collision at 1.0).
+  edges.emplace_back(q_start,
+                     MockEdgeChecker::EncodeConfiguration(q_size, 0.75, 1.25));
+  // The distance for all of the edges is the same.
+  const double edge_dist = calc_dist(edges[0].first, edges[0].second);
+  const vector<EdgeMeasure> expected_results{
+      EdgeMeasure(edge_dist, edges[0].second(0)),
+      EdgeMeasure(edge_dist, edges[1].second(0)),
+      EdgeMeasure(edge_dist, edges[2].second(0))};
+
+  for (const bool parallel : {false, true}) {
+    auto dut = MakeEdgeChecker<MockEdgeChecker>(calc_dist, step_size, interp,
+                                                true /* welded */, q_size + 1);
+    ASSERT_EQ(dut.plant().num_positions(), q_size);
+
+    // Reality check; if we've requested parallel evaluation we need to confirm
+    // it'll happen; otherwise we're simply testing the serial implementation
+    // again.
+    if (parallel) {
+      ASSERT_TRUE(dut.CanEvaluateInParallel());
+    }
+
+    vector<EdgeMeasure> results =
+        dut.MeasureEdgesCollisionFree(edges, parallel);
+
+    // Confirm behavior (1). Results for every edge.
+    EXPECT_EQ(results, expected_results);
+    // Confirm behavior (2). Parallel when asked, serial when not.
+    if (parallel) {
+      EXPECT_GT(dut.thread_count(), 1);
+    } else {
+      EXPECT_EQ(dut.thread_count(), 1);
+    }
+  }
+}
+
+// Same test as for MeasureEdgeCollisionFree, but uses the boolean variant.
+GTEST_TEST(EdgeCheckTest, CheckMultipleEdgesFree) {
+  // Use the MockEdgeChecker to control edge failures.
+  const double step_size = 0.05;
+  auto calc_dist = MockEdgeChecker::MakeEdgeDistance(step_size);
+  auto interp = MockEdgeChecker::MakeEdgeInterpolation();
+
+  const int q_size = MockEdgeChecker::kQSize;
+
+  // Garbage start configuration; the values are ignored.
+  const VectorXd q_start = VectorXd::Constant(q_size, 0.75);
+  // All edges start from the same configuration, q_start. The end configuration
+  // gets encoded by MockEdgeChecker. Note: we know that we're getting five
+  // samples so the distance between values of alpha is 0.25. So, to make sure
+  // *two* samples are in collision, the last colliding alpha should be the
+  // last free + 0.5.
+  vector<std::pair<VectorXd, VectorXd>> edges;
+  // 100% clear.
+  edges.emplace_back(q_start,
+                     MockEdgeChecker::EncodeConfiguration(q_size, 1.0, 1.5));
+  // Early collision.
+  edges.emplace_back(q_start,
+                     MockEdgeChecker::EncodeConfiguration(q_size, 0.25, 0.75));
+  // Later collision.
+  edges.emplace_back(q_start,
+                     MockEdgeChecker::EncodeConfiguration(q_size, 0.75, 1.25));
+  const vector<int8_t> expected_results{edges[0].second(0) == 1.0,
+                                        edges[1].second(0) == 1.0,
+                                        edges[2].second(0) == 1.0};
+
+  for (const bool parallel : {false, true}) {
+    auto dut = MakeEdgeChecker<MockEdgeChecker>(calc_dist, step_size, interp,
+                                                true /* welded */, q_size + 1);
+    ASSERT_EQ(dut.plant().num_positions(), q_size);
+
+    // Reality check; if we've requested parallel evaluation we need to confirm
+    // it'll happen; otherwise we're simply testing the serial implementation
+    // again.
+    if (parallel) {
+      ASSERT_TRUE(dut.CanEvaluateInParallel());
+    }
+
+    vector<int8_t> results =
+        dut.CheckEdgesCollisionFree(edges, parallel);
+
+    // Confirm behavior (1). Results for every edge.
+    EXPECT_EQ(results, expected_results);
+    // Confirm behavior (2). Parallel when asked, serial when not.
+    if (parallel) {
+      EXPECT_GT(dut.thread_count(), 1);
+    } else {
+      EXPECT_EQ(dut.thread_count(), 1);
+    }
+  }
+}
+
+// Additional test cases for basic EdgeMeasure functionality not covered already
+// in the above cases.
+GTEST_TEST(EdgeMeasureTest, Test) {
+  const EdgeMeasure completely_free(10.0, 1.0);
+  EXPECT_EQ(completely_free.distance(), 10.0);
+  EXPECT_EQ(completely_free.alpha(), 1.0);
+  EXPECT_TRUE(completely_free.completely_free());
+  EXPECT_TRUE(completely_free.partially_free());
+  EXPECT_EQ(completely_free.alpha_or(-1.0), 1.0);
+
+  const EdgeMeasure partially_free(10.0, 0.5);
+  EXPECT_EQ(partially_free.distance(), 10.0);
+  EXPECT_EQ(partially_free.alpha(), 0.5);
+  EXPECT_FALSE(partially_free.completely_free());
+  EXPECT_TRUE(partially_free.partially_free());
+  EXPECT_EQ(partially_free.alpha_or(-1.0), 0.5);
+
+  const EdgeMeasure invalid(10.0, -5.0);
+  EXPECT_EQ(invalid.distance(), 10.0);
+  EXPECT_THROW(invalid.alpha(), std::exception);
+  EXPECT_FALSE(invalid.completely_free());
+  EXPECT_FALSE(invalid.partially_free());
+  EXPECT_EQ(invalid.alpha_or(-10.0), -10.0);
+
+  // Invalid distance throws.
+  EXPECT_THROW(EdgeMeasure(-1.0, 0.0), std::exception);
+  // Invalid alpha throws.
+  EXPECT_THROW(EdgeMeasure(1.0, 10.0), std::exception);
+}
+
+}  // namespace
+}  // namespace planning
+}  // namespace anzu

--- a/planning/test/unimplemented_collision_checker_test.cc
+++ b/planning/test/unimplemented_collision_checker_test.cc
@@ -1,20 +1,26 @@
-#include "planning/unimplemented_collision_checker.h"
+#include "drake/planning/unimplemented_collision_checker.h"
 
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"
-#include "planning/robot_diagram_builder.h"
+#include "drake/planning/robot_diagram_builder.h"
 
-namespace anzu {
+namespace drake {
 namespace planning {
 namespace {
 
 using drake::multibody::default_model_instance;
-using drake::planning::CollisionCheckerParams;
 
 class MyUnimplementedCollisionChecker : public UnimplementedCollisionChecker {
  public:
-  using UnimplementedCollisionChecker::UnimplementedCollisionChecker;
+  MyUnimplementedCollisionChecker(CollisionCheckerParams params,
+                                  bool supports_parallel_checking)
+      : UnimplementedCollisionChecker(std::move(params),
+                                      supports_parallel_checking) {
+    // We need to allocate contexts so that the DoClone() test below fails
+    // on UnimplementedCollisionChecker's DoClone() and not Clone().
+    AllocateContexts();
+  }
 };
 
 GTEST_TEST(UnimplementedCollisionCheckerTest, SmokeTest) {
@@ -34,4 +40,4 @@ GTEST_TEST(UnimplementedCollisionCheckerTest, SmokeTest) {
 
 }  // namespace
 }  // namespace planning
-}  // namespace anzu
+}  // namespace drake

--- a/planning/test/unimplemented_collision_checker_test.cc
+++ b/planning/test/unimplemented_collision_checker_test.cc
@@ -1,0 +1,37 @@
+#include "planning/unimplemented_collision_checker.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "planning/robot_diagram_builder.h"
+
+namespace anzu {
+namespace planning {
+namespace {
+
+using drake::multibody::default_model_instance;
+using drake::planning::CollisionCheckerParams;
+
+class MyUnimplementedCollisionChecker : public UnimplementedCollisionChecker {
+ public:
+  using UnimplementedCollisionChecker::UnimplementedCollisionChecker;
+};
+
+GTEST_TEST(UnimplementedCollisionCheckerTest, SmokeTest) {
+  CollisionCheckerParams params{
+    .model = RobotDiagramBuilder<double>{}.BuildDiagram(),
+    .robot_model_instances = {default_model_instance()},
+    .configuration_distance_function = [](auto...) { return 0; },
+    .edge_step_size = 0.1,
+  };
+
+  // Prove that the class is concrete (no missing overrides).
+  const MyUnimplementedCollisionChecker dut(std::move(params), false);
+
+  // Sanity check one error message string.
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.Clone(), "DoClone is not implemented");
+}
+
+}  // namespace
+}  // namespace planning
+}  // namespace anzu

--- a/planning/unimplemented_collision_checker.cc
+++ b/planning/unimplemented_collision_checker.cc
@@ -1,0 +1,78 @@
+#include "planning/unimplemented_collision_checker.h"
+
+#include <stdexcept>
+#include <utility>
+
+#include <fmt/format.h>
+
+namespace anzu {
+namespace planning {
+
+using drake::planning::CollisionCheckerContext;
+using drake::planning::CollisionCheckerParams;
+using drake::planning::RobotCollisionType;
+
+namespace {
+
+[[noreturn]] void ThrowNotImplemented(const char* func) {
+  throw std::runtime_error(fmt::format("{} is not implemented", func));
+}
+
+}  // namespace
+
+using drake::planning::RobotClearance;
+
+UnimplementedCollisionChecker::UnimplementedCollisionChecker(
+    CollisionCheckerParams params, bool supports_parallel_checking)
+    : CollisionChecker(std::move(params), supports_parallel_checking) {}
+
+UnimplementedCollisionChecker::UnimplementedCollisionChecker(
+    const UnimplementedCollisionChecker&) = default;
+
+UnimplementedCollisionChecker::~UnimplementedCollisionChecker() {}
+
+std::unique_ptr<CollisionChecker> UnimplementedCollisionChecker::DoClone()
+    const {
+  ThrowNotImplemented(__func__);
+}
+
+void UnimplementedCollisionChecker::DoUpdateContextPositions(
+    CollisionCheckerContext*) const {
+  ThrowNotImplemented(__func__);
+}
+
+bool UnimplementedCollisionChecker::DoCheckContextConfigCollisionFree(
+    const CollisionCheckerContext&) const {
+  ThrowNotImplemented(__func__);
+}
+
+std::optional<drake::geometry::GeometryId>
+UnimplementedCollisionChecker::DoAddCollisionShapeToBody(
+    const std::string&, const drake::multibody::Body<double>&,
+    const drake::geometry::Shape&, const drake::math::RigidTransform<double>&) {
+  ThrowNotImplemented(__func__);
+}
+
+void UnimplementedCollisionChecker::DoRemoveAddedGeometries(
+    const std::vector<CollisionChecker::AddedShape>&) {
+  ThrowNotImplemented(__func__);
+}
+
+RobotClearance UnimplementedCollisionChecker::DoCalcContextRobotClearance(
+    const CollisionCheckerContext&, double) const {
+  ThrowNotImplemented(__func__);
+}
+
+std::vector<RobotCollisionType>
+UnimplementedCollisionChecker::DoClassifyContextBodyCollisions(
+    const CollisionCheckerContext&) const {
+  ThrowNotImplemented(__func__);
+}
+
+int UnimplementedCollisionChecker::DoMaxContextNumDistances(
+    const CollisionCheckerContext&) const {
+  ThrowNotImplemented(__func__);
+}
+
+}  // namespace planning
+}  // namespace anzu

--- a/planning/unimplemented_collision_checker.cc
+++ b/planning/unimplemented_collision_checker.cc
@@ -1,17 +1,12 @@
-#include "planning/unimplemented_collision_checker.h"
+#include "drake/planning/unimplemented_collision_checker.h"
 
 #include <stdexcept>
 #include <utility>
 
 #include <fmt/format.h>
 
-namespace anzu {
+namespace drake {
 namespace planning {
-
-using drake::planning::CollisionCheckerContext;
-using drake::planning::CollisionCheckerParams;
-using drake::planning::RobotCollisionType;
-
 namespace {
 
 [[noreturn]] void ThrowNotImplemented(const char* func) {
@@ -19,8 +14,6 @@ namespace {
 }
 
 }  // namespace
-
-using drake::planning::RobotClearance;
 
 UnimplementedCollisionChecker::UnimplementedCollisionChecker(
     CollisionCheckerParams params, bool supports_parallel_checking)
@@ -46,10 +39,10 @@ bool UnimplementedCollisionChecker::DoCheckContextConfigCollisionFree(
   ThrowNotImplemented(__func__);
 }
 
-std::optional<drake::geometry::GeometryId>
+std::optional<geometry::GeometryId>
 UnimplementedCollisionChecker::DoAddCollisionShapeToBody(
-    const std::string&, const drake::multibody::Body<double>&,
-    const drake::geometry::Shape&, const drake::math::RigidTransform<double>&) {
+    const std::string&, const multibody::Body<double>&,
+    const geometry::Shape&, const math::RigidTransform<double>&) {
   ThrowNotImplemented(__func__);
 }
 
@@ -75,4 +68,4 @@ int UnimplementedCollisionChecker::DoMaxContextNumDistances(
 }
 
 }  // namespace planning
-}  // namespace anzu
+}  // namespace drake

--- a/planning/unimplemented_collision_checker.h
+++ b/planning/unimplemented_collision_checker.h
@@ -1,15 +1,14 @@
 #pragma once
 
-#include <map>
 #include <memory>
 #include <optional>
 #include <string>
 #include <vector>
 
+#include "drake/planning/collision_checker.h"
 #include "drake/planning/collision_checker_params.h"
-#include "planning/collision_checker.h"
 
-namespace anzu {
+namespace drake {
 namespace planning {
 
 /** A concrete collision checker implementation that throws an exception for
@@ -18,7 +17,7 @@ deriving your own collision checker without providing for the full suite of
 operations. */
 class UnimplementedCollisionChecker : public CollisionChecker {
  public:
-  UnimplementedCollisionChecker(drake::planning::CollisionCheckerParams params,
+  UnimplementedCollisionChecker(CollisionCheckerParams params,
                                 bool supports_parallel_checking);
 
   /** @name Does not allow copy, move, or assignment. */
@@ -40,30 +39,27 @@ class UnimplementedCollisionChecker : public CollisionChecker {
   std::unique_ptr<CollisionChecker> DoClone() const override;
 
   void DoUpdateContextPositions(
-      drake::planning::CollisionCheckerContext* model_context) const override;
+      CollisionCheckerContext* model_context) const override;
 
   bool DoCheckContextConfigCollisionFree(
-      const drake::planning::CollisionCheckerContext&) const override;
+      const CollisionCheckerContext&) const override;
 
-  std::optional<drake::geometry::GeometryId> DoAddCollisionShapeToBody(
-      const std::string& group_name,
-      const drake::multibody::Body<double>& bodyA,
-      const drake::geometry::Shape& shape,
-      const drake::math::RigidTransform<double>& X_AG) override;
+  std::optional<geometry::GeometryId> DoAddCollisionShapeToBody(
+      const std::string& group_name, const multibody::Body<double>& bodyA,
+      const geometry::Shape& shape,
+      const math::RigidTransform<double>& X_AG) override;
 
   void DoRemoveAddedGeometries(
       const std::vector<CollisionChecker::AddedShape>& shapes) override;
 
-  drake::planning::RobotClearance DoCalcContextRobotClearance(
-      const drake::planning::CollisionCheckerContext&, double) const override;
+  RobotClearance DoCalcContextRobotClearance(const CollisionCheckerContext&,
+                                             double) const override;
 
-  std::vector<drake::planning::RobotCollisionType>
-  DoClassifyContextBodyCollisions(
-      const drake::planning::CollisionCheckerContext&) const override;
+  std::vector<RobotCollisionType> DoClassifyContextBodyCollisions(
+      const CollisionCheckerContext&) const override;
 
-  int DoMaxContextNumDistances(
-      const drake::planning::CollisionCheckerContext&) const override;
+  int DoMaxContextNumDistances(const CollisionCheckerContext&) const override;
 };
 
 }  // namespace planning
-}  // namespace anzu
+}  // namespace drake

--- a/planning/unimplemented_collision_checker.h
+++ b/planning/unimplemented_collision_checker.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "drake/planning/collision_checker_params.h"
+#include "planning/collision_checker.h"
+
+namespace anzu {
+namespace planning {
+
+/** A concrete collision checker implementation that throws an exception for
+every virtual function hook. This might be useful for unit testing or for
+deriving your own collision checker without providing for the full suite of
+operations. */
+class UnimplementedCollisionChecker : public CollisionChecker {
+ public:
+  UnimplementedCollisionChecker(drake::planning::CollisionCheckerParams params,
+                                bool supports_parallel_checking);
+
+  /** @name Does not allow copy, move, or assignment. */
+  /** @{ */
+  // N.B. The copy constructor is protected for use in implementing Clone().
+  UnimplementedCollisionChecker(UnimplementedCollisionChecker&&) = delete;
+  UnimplementedCollisionChecker& operator=(
+      const UnimplementedCollisionChecker&) = delete;
+  UnimplementedCollisionChecker& operator=(UnimplementedCollisionChecker&&) =
+      delete;
+  /** @} */
+
+  ~UnimplementedCollisionChecker();
+
+ protected:
+  // To support Clone(), allow copying (but not move nor assign).
+  UnimplementedCollisionChecker(const UnimplementedCollisionChecker&);
+
+  std::unique_ptr<CollisionChecker> DoClone() const override;
+
+  void DoUpdateContextPositions(
+      drake::planning::CollisionCheckerContext* model_context) const override;
+
+  bool DoCheckContextConfigCollisionFree(
+      const drake::planning::CollisionCheckerContext&) const override;
+
+  std::optional<drake::geometry::GeometryId> DoAddCollisionShapeToBody(
+      const std::string& group_name,
+      const drake::multibody::Body<double>& bodyA,
+      const drake::geometry::Shape& shape,
+      const drake::math::RigidTransform<double>& X_AG) override;
+
+  void DoRemoveAddedGeometries(
+      const std::vector<CollisionChecker::AddedShape>& shapes) override;
+
+  drake::planning::RobotClearance DoCalcContextRobotClearance(
+      const drake::planning::CollisionCheckerContext&, double) const override;
+
+  std::vector<drake::planning::RobotCollisionType>
+  DoClassifyContextBodyCollisions(
+      const drake::planning::CollisionCheckerContext&) const override;
+
+  int DoMaxContextNumDistances(
+      const drake::planning::CollisionCheckerContext&) const override;
+};
+
+}  // namespace planning
+}  // namespace anzu


### PR DESCRIPTION
Towards #14431.


|  Topic  | Total lines | Reviewer | Code sections |
| -------| -----------| ------------| ------------- |
| Contexts | 498 | @jwnimmer-tri | `collision_checker.h`:25-148, 1029-1053, 1137-1148, 1202-1317 <br> `collision_checker.cc`: 177-201, 814-848, 858-862, 1074-1111 <br> `collision_checker_test.cc`: 469-480, 567-594, 787-812 |
| Base Class | 395 | @sammy-tri | `collision_checker.h`: 149-223, 1014-1028, 1128-1131 <br> `collision_checker.cc`: 155-176, 769-813, 849-853 <br> `collision_checker_test.cc`: 77-124, 352-468, 778-786 <br> `BUILD.bazel`: all lines |
| Shapes | 229 | @sherm1 | `collision_checker.h`: 276-385 <br> `collision_checker.cc`: 202-290 <br> `collision_checker_test.cc`: 748-777 |
| Collision filters | 720 | @EricCousineau-TRI  | `collision_checker.h`: 537-651, 1149-1180 <br> `collision_checker.cc`: 417-471, 863-1013 <br> `collision_checker_test.cc`: 835-856 |
| Collision state | 336 | @sherm1 | `collision_checker.h`: 652-685, 950-1013 <br> `collision_checker.cc`: 472-501, 78-154, 728-768 <br> `collision_checker_test.cc`: 481-526, 813-834, 835-856 |
| Edge checks | 1317 | @xuchenhan-tri | `collision_checker.h`: 686-949 <br> `collision_checker.cc`: 42-77, 502-727 <br> `collision_checker_test.cc`: 22-40, 1224-1906 <br> `edge_measure.h`: all lines |
|Padding | 520 | @ggould-tri  | `collision_checker.h`: 386-536, 1132-1136, 1181-1201 <br> `collision_checker.cc`: 291-416, 854-857, 1014-1073 <br> `collision_checker_test.cc`: 696-747 |
|Unimplemented | 178 | @sammy-tri | `unimplemented*`: all |


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18558)
<!-- Reviewable:end -->
