### PR TITLE
Add bounding box or rotated lorentz cone constraint for small psd matrices

### DIFF
--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -215,17 +215,36 @@ symbolic::Polynomial MathematicalProgram::NewSosPolynomial(
     const Eigen::Ref<const MatrixX<symbolic::Variable>>& gramian,
     const Eigen::Ref<const VectorX<symbolic::Monomial>>& monomial_basis,
     NonnegativePolynomial type) {
-  DRAKE_ASSERT(gramian.rows() == gramian.cols());
+  DRAKE_ASSERT(math::IsSymmetric(gramian));
   DRAKE_ASSERT(gramian.rows() == monomial_basis.rows());
   const symbolic::Polynomial p =
       ComputePolynomialFromMonomialBasisAndGramMatrix(monomial_basis, gramian);
   switch (type) {
     case MathematicalProgram::NonnegativePolynomial::kSos: {
-      AddPositiveSemidefiniteConstraint(gramian);
+      if (gramian.rows() == 1) {
+        // A 1x1 matrix being PSD is equivalent to its entry being non-negative.
+        AddBoundingBoxConstraint(0, kInf, gramian(0, 0));
+      } else if (gramian.rows() == 2) {
+        // A 2x2 matrix
+        // ⌈X(0, 0) X(0, 1)⌉
+        // ⌊X(0, 1) X(1, 1)⌋
+        // being psd is equivalent to [X(0, 0), X(1, 1), X(0, 1)] in the rotated
+        // lorentz cone.
+        AddRotatedLorentzConeConstraint(Vector3<symbolic::Variable>(
+            gramian(0, 0), gramian(1, 1), gramian(0, 1)));
+      } else {
+        AddPositiveSemidefiniteConstraint(gramian);
+      }
       return p;
     }
     case MathematicalProgram::NonnegativePolynomial::kSdsos: {
-      AddScaledDiagonallyDominantMatrixConstraint(gramian);
+      if (gramian.rows() == 1) {
+        // A 1x1 matrix being scaled diagonally dominant is equivalent to its
+        // entry being non-negative.
+        AddBoundingBoxConstraint(0, kInf, gramian(0, 0));
+      } else {
+        AddScaledDiagonallyDominantMatrixConstraint(gramian);
+      }
       return p;
     }
     case MathematicalProgram::NonnegativePolynomial::kDsos: {

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -505,6 +505,7 @@ class MathematicalProgram {
   /**
    * Overloads NewSosPolynomial, except the Gramian matrix Q is an
    * input instead of an output.
+   * @pre `gramian` is a symmetric matrix.
    */
   symbolic::Polynomial NewSosPolynomial(
       const Eigen::Ref<const MatrixX<symbolic::Variable>>& gramian,

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -3328,6 +3328,43 @@ void CheckNewSosPolynomial(MathematicalProgram::NonnegativePolynomial type) {
   EXPECT_TRUE(p2.EqualTo(p_expected));
 }
 
+// Test NewSosPolynomial whose gram matrix has size 1x1 or 2x2.
+GTEST_TEST(TestMathematicalProgram, NewSosPolynomialSmallGram) {
+  MathematicalProgram prog;
+  // Check 1 x 1 matrix.
+  auto gramian1 = prog.NewSymmetricContinuousVariables<1>();
+  auto x = prog.NewIndeterminates<1>();
+  const auto p1 = prog.NewSosPolynomial(
+      gramian1, Vector1<symbolic::Monomial>(symbolic::Monomial(x(0))));
+  EXPECT_EQ(prog.bounding_box_constraints().size(), 1);
+  EXPECT_EQ(prog.bounding_box_constraints().front().variables().rows(), 1);
+  EXPECT_EQ(prog.bounding_box_constraints().front().variables()(0),
+            gramian1(0));
+  EXPECT_EQ(prog.bounding_box_constraints().front().evaluator()->lower_bound(),
+            Vector1d(0));
+  EXPECT_TRUE(std::isinf(
+      prog.bounding_box_constraints().front().evaluator()->upper_bound()(0)));
+
+  // Now check 2 x 2 matrix.
+  const auto gramian2 = prog.NewSymmetricContinuousVariables<2>();
+  const auto p2 = prog.NewSosPolynomial(
+      gramian2, Vector2<symbolic::Monomial>(symbolic::Monomial(),
+                                            symbolic::Monomial(x(0))));
+  EXPECT_EQ(prog.rotated_lorentz_cone_constraints().size(), 1);
+  EXPECT_TRUE(CompareMatrices(
+      prog.rotated_lorentz_cone_constraints().front().evaluator()->A_dense(),
+      Eigen::Matrix3d::Identity()));
+  EXPECT_TRUE(CompareMatrices(
+      prog.rotated_lorentz_cone_constraints().front().evaluator()->b(),
+      Eigen::Vector3d::Zero()));
+  EXPECT_EQ(prog.rotated_lorentz_cone_constraints().front().variables()(0),
+            gramian2(0, 0));
+  EXPECT_EQ(prog.rotated_lorentz_cone_constraints().front().variables()(1),
+            gramian2(1, 1));
+  EXPECT_EQ(prog.rotated_lorentz_cone_constraints().front().variables()(2),
+            gramian2(0, 1));
+}
+
 GTEST_TEST(TestMathematicalProgram, NewSosPolynomial) {
   CheckNewSosPolynomial(MathematicalProgram::NonnegativePolynomial::kSos);
   CheckNewSosPolynomial(MathematicalProgram::NonnegativePolynomial::kSdsos);
@@ -3371,7 +3408,7 @@ void CheckNewEvenDegreeNonnegativePolynomial(
   MathematicalProgram prog;
   auto t = prog.NewIndeterminates<2>();
   const symbolic::Variables t_vars(t);
-  const int degree{4};
+  const int degree{6};
   const auto m_e = symbolic::EvenDegreeMonomialBasis(t_vars, degree / 2);
   const auto m_o = symbolic::OddDegreeMonomialBasis(t_vars, degree / 2);
   symbolic::Polynomial p;
@@ -3645,11 +3682,11 @@ GTEST_TEST(TestMathematicalProgram, AddSosConstraint) {
 
   // p1 has both a and x as indeterminates. So we need to reparse the polynomial
   // to have only x as the indeterminates.
-  const symbolic::Polynomial p1(a + x * x);
-  const Vector2<symbolic::Monomial> monomial_basis(symbolic::Monomial{},
-                                                   symbolic::Monomial(x, 1));
+  const symbolic::Polynomial p1(a + x * x + pow(x, 4));
+  const Vector3<symbolic::Monomial> monomial_basis(
+      symbolic::Monomial{}, symbolic::Monomial(x, 1), symbolic::Monomial(x, 2));
 
-  const Matrix2<symbolic::Variable> Q_psd = prog.AddSosConstraint(
+  const Matrix3<symbolic::Variable> Q_psd = prog.AddSosConstraint(
       p1, monomial_basis, MathematicalProgram::NonnegativePolynomial::kSos,
       "Q");
   EXPECT_NE(Q_psd(0, 0).get_name().find("Q"), std::string::npos);

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -396,7 +396,7 @@ GTEST_TEST(MosekTest, SimpleSos1) {
   MosekSolver solver;
   if (solver.available()) {
     const auto result = solver.Solve(dut.prog());
-    dut.CheckResult(result, 2E-9);
+    dut.CheckResult(result, 1E-8);
   }
 }
 


### PR DESCRIPTION
When calling NewSosPolynomial, if the gram matrix has size 1x1, add a bounding box constraint. if the gram matrix has size 2x2, add a rotated lorentz cone constraint.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/18562)
<!-- Reviewable:end -->
