### PR TITLE
Reduce macOS console spam

### DIFF
--- a/tools/workspace/pybind11/pybind_coverage_xml_parser.py
+++ b/tools/workspace/pybind11/pybind_coverage_xml_parser.py
@@ -186,7 +186,8 @@ class ClassCoverage:
                     doc_var_nodes, self.pybind_strings)
 
             row["ClassName"] = c.attrib["full_name"]
-            self.df = self.df.append(row, ignore_index=True)
+            self.df = pandas.concat([self.df, pandas.DataFrame([row])],
+                                    ignore_index=True, sort=False)
 
         self.df_pruned = CommonUtils.prune_dataframe(
                 self.df, ["ClassName", "Coverage"])
@@ -254,7 +255,8 @@ class FileCoverage:
             row = CommonUtils.get_node_coverage(doc_nodes, self.pybind_strings)
 
             row["FileName"] = FileName(fn)
-            self.df = self.df.append(row, ignore_index=True)
+            self.df = pandas.concat([self.df, pandas.DataFrame([row])],
+                                    ignore_index=True, sort=False)
 
     def make_tree(self, file_coverage, sep="/"):
         """Makes an XML tree from list of paths.


### PR DESCRIPTION
~Partially resolves~ Towards https://github.com/RobotLocomotion/drake/issues/17933.

This PR fixes the Pandas-related console spam which is currently appearing on macOS.  This PR only fixes the source of the existing spam and makes no attempt to suppress similar spam.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18573)
<!-- Reviewable:end -->
