### PR TITLE
Update documentation to reflect switch to Jammy for documentation site

### DIFF
--- a/doc/_pages/documentation_instructions.md
+++ b/doc/_pages/documentation_instructions.md
@@ -16,7 +16,7 @@ The website infrastructure uses a combination of
 # Prerequisites
 
 Documentation generation and preview as described in this document are
-supported on Ubuntu **20.04** only.
+supported on Ubuntu **22.04** only.
 
 Before getting started, install Drake's prerequisites with the additional
 ``--with-doc-only`` command line option, i.e.:

--- a/doc/_pages/documentation_instructions.md
+++ b/doc/_pages/documentation_instructions.md
@@ -81,7 +81,7 @@ If you would like to check Jenkins results on a pull request, you need to
 by posting a comment
 
 ```
-@drake-jenkins-bot linux-focal-unprovisioned-gcc-bazel-experimental-documentation please
+@drake-jenkins-bot linux-jammy-unprovisioned-gcc-bazel-experimental-documentation please
 ```
 
 # Advanced Building

--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -158,7 +158,7 @@ the main body of the document:
       [download_release_candidate.py](https://github.com/RobotLocomotion/drake/blob/master/tools/release_engineering/download_release_candidate.py).)
 6. Merge the release notes PR
    1. Take care when squashing not to accept github's auto-generated commit message if it is not appropriate.
-   2. After merge, go to <https://drake-jenkins.csail.mit.edu/view/Documentation/job/linux-focal-unprovisioned-gcc-bazel-nightly-documentation/> and push "Build now".
+   2. After merge, go to <https://drake-jenkins.csail.mit.edu/view/Documentation/job/linux-jammy-unprovisioned-gcc-bazel-nightly-documentation/> and push "Build now".
       * If you don't have "Build now" click "Log in" first in upper right.
 7. Open <https://github.com/RobotLocomotion/drake/releases> and choose "Draft
    a new release".  Note that this page does has neither history nor undo.  Be


### PR DESCRIPTION
This PR updates the relevant pages in the documentation to properly indicate that only Ubuntu 22.04 Jammy is officially supported when generating the documentation site.

Partially resolves https://github.com/RobotLocomotion/drake/issues/18552.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18574)
<!-- Reviewable:end -->
