### PR TITLE
Simplify Gurobi _find_latest

### DIFF
--- a/tools/workspace/gurobi/repository.bzl
+++ b/tools/workspace/gurobi/repository.bzl
@@ -17,7 +17,7 @@ def _find_latest(repo_ctx, path, prefix, subdir):
                 version = int(d.basename[len(prefix):])
                 if best_version == None or version > best_version:
                     best_version = version
-                    best_dir = str(full_dir.realpath)
+                    best_dir = str(full_dir)
 
     return best_dir or (path + "/" + prefix + "-notfound/" + subdir)
 


### PR DESCRIPTION
Remove unnecessary `realpath` in Gurobi's _find_latest helper. Apparently, the only way to get a string from a Bazel `path` object is... to use `str()` on it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18576)
<!-- Reviewable:end -->
