### PR TITLE
[pydrake] Finish bindings for schema.Rotation and schema.Transform

### DIFF
--- a/bindings/pydrake/common/schema_py.cc
+++ b/bindings/pydrake/common/schema_py.cc
@@ -117,12 +117,16 @@ PYBIND11_MODULE(schema, m) {
             py::arg("var"), doc.GetDeterministicValue.doc_1args_var);
   }
 
-  // TODO(jwnimmer-tri) In the below, we hard-code the template argument `int
-  // Size` to be `Eigen::Dynamic`, i.e., we only bind one of the allowed
-  // values.  In the future, we should also bind Size == 1 through Size == 6
-  // (to match the C++ code).  When we do that, we'll replace the suffix X with
-  // the template pattern `[Size]` or `_[Size]`, e.g., `DeterministicVector[3]`
-  // or `DeterministicVector_[3]`.
+  {
+    // We need to bind these to placate some runtime type checks, but we should
+    // not expose them to users.
+    py::class_<schema::internal::InvalidVariantSelection<Deterministic>>(
+        m, "_InvalidVariantSelectionDeterministic");
+    py::class_<schema::internal::InvalidVariantSelection<Gaussian>>(
+        m, "_InvalidVariantSelectionGaussian");
+    py::class_<schema::internal::InvalidVariantSelection<Uniform>>(
+        m, "_InvalidVariantSelectionUniform");
+  }
 
   {
     using Class = DistributionVector;
@@ -133,70 +137,88 @@ PYBIND11_MODULE(schema, m) {
         .def("ToSymbolic", &Class::ToSymbolic, cls_doc.ToSymbolic.doc);
   }
 
-  {
-    constexpr int size = Eigen::Dynamic;
-    using Class = DeterministicVector<size>;
-    constexpr auto& cls_doc = doc.DeterministicVector;
-    py::class_<Class, DistributionVector> cls(
-        m, "DeterministicVectorX", cls_doc.doc);
-    cls  // BR
-        .def(py::init<>(), cls_doc.ctor.doc)
-        .def(py::init<const Class&>(), py::arg("other"))
-        .def(py::init<const drake::Vector<double, size>&>(), py::arg("value"),
-            cls_doc.ctor.doc);
-    DefAttributesUsingSerialize(&cls, cls_doc);
-    DefCopyAndDeepCopy(&cls);
-  }
+  // Here, we bind all supported values of the 'Size' template argument.
+  //
+  // TODO(jwnimmer-tri) For convenience, it would be nice if we could also
+  // offer a type array, e.g., 'DeterministicVector[i]' to look up a fixed-size
+  // vector type.
+  auto bind_distribution_vectors = [&]<int Size>(
+                                       std::integral_constant<int, Size>) {
+    const std::string size_suffix =
+        (Size == Eigen::Dynamic) ? std::string("X") : std::to_string(Size);
 
-  {
-    constexpr int size = Eigen::Dynamic;
-    using Class = GaussianVector<size>;
-    constexpr auto& cls_doc = doc.GaussianVector;
-    py::class_<Class, DistributionVector> cls(
-        m, "GaussianVectorX", cls_doc.doc);
-    cls  // BR
-        .def(py::init<>(), cls_doc.ctor.doc)
-        .def(py::init<const Class&>(), py::arg("other"))
-        .def(py::init<const drake::Vector<double, size>&,
-                 const drake::VectorX<double>&>(),
-            py::arg("mean"), py::arg("stddev"), cls_doc.ctor.doc);
-    DefAttributesUsingSerialize(&cls, cls_doc);
-    DefCopyAndDeepCopy(&cls);
-  }
+    {
+      using Class = DeterministicVector<Size>;
+      constexpr auto& cls_doc = doc.DeterministicVector;
+      py::class_<Class, DistributionVector> cls(
+          m, ("DeterministicVector" + size_suffix).c_str(), cls_doc.doc);
+      cls  // BR
+          .def(py::init<>(), cls_doc.ctor.doc)
+          .def(py::init<const Class&>(), py::arg("other"))
+          .def(py::init<const drake::Vector<double, Size>&>(), py::arg("value"),
+              cls_doc.ctor.doc);
+      DefAttributesUsingSerialize(&cls, cls_doc);
+      DefCopyAndDeepCopy(&cls);
+    }
 
-  {
-    constexpr int size = Eigen::Dynamic;
-    using Class = UniformVector<size>;
-    constexpr auto& cls_doc = doc.UniformVector;
-    py::class_<Class, DistributionVector> cls(m, "UniformVectorX", cls_doc.doc);
-    cls  // BR
-        .def(py::init<>(), cls_doc.ctor.doc)
-        .def(py::init<const Class&>(), py::arg("other"))
-        .def(py::init<const drake::Vector<double, size>&,
-                 const drake::Vector<double, size>&>(),
-            py::arg("min"), py::arg("max"), cls_doc.ctor.doc);
-    DefAttributesUsingSerialize(&cls, cls_doc);
-    DefCopyAndDeepCopy(&cls);
-  }
+    {
+      using Class = GaussianVector<Size>;
+      constexpr auto& cls_doc = doc.GaussianVector;
+      py::class_<Class, DistributionVector> cls(
+          m, ("GaussianVector" + size_suffix).c_str(), cls_doc.doc);
+      cls  // BR
+          .def(py::init<>(), cls_doc.ctor.doc)
+          .def(py::init<const Class&>(), py::arg("other"))
+          .def(py::init<const drake::Vector<double, Size>&,
+                   const drake::VectorX<double>&>(),
+              py::arg("mean"), py::arg("stddev"), cls_doc.ctor.doc);
+      DefAttributesUsingSerialize(&cls, cls_doc);
+      DefCopyAndDeepCopy(&cls);
+    }
 
-  {
-    constexpr int size = Eigen::Dynamic;
-    m  // BR
-        .def("ToDistributionVector",
-            pydrake::overload_cast_explicit<std::unique_ptr<DistributionVector>,
-                const DistributionVectorVariant<size>&>(ToDistributionVector),
-            py::arg("vec"), doc.ToDistributionVector.doc)
-        .def("IsDeterministic",
-            pydrake::overload_cast_explicit<bool,
-                const DistributionVectorVariant<size>&>(IsDeterministic),
-            py::arg("vec"),
-            doc.IsDeterministic.doc_1args_constDistributionVectorVariant)
-        .def("GetDeterministicValue",
-            pydrake::overload_cast_explicit<Eigen::VectorXd,
-                const DistributionVectorVariant<size>&>(GetDeterministicValue),
-            py::arg("vec"),
-            doc.GetDeterministicValue.doc_1args_constDistributionVectorVariant);
-  }
+    {
+      using Class = UniformVector<Size>;
+      constexpr auto& cls_doc = doc.UniformVector;
+      py::class_<Class, DistributionVector> cls(
+          m, ("UniformVector" + size_suffix).c_str(), cls_doc.doc);
+      cls  // BR
+          .def(py::init<>(), cls_doc.ctor.doc)
+          .def(py::init<const Class&>(), py::arg("other"))
+          .def(py::init<const drake::Vector<double, Size>&,
+                   const drake::Vector<double, Size>&>(),
+              py::arg("min"), py::arg("max"), cls_doc.ctor.doc);
+      DefAttributesUsingSerialize(&cls, cls_doc);
+      DefCopyAndDeepCopy(&cls);
+    }
+
+    {
+      m  // BR
+          .def("ToDistributionVector",
+              pydrake::overload_cast_explicit<
+                  std::unique_ptr<DistributionVector>,
+                  const DistributionVectorVariant<Size>&>(ToDistributionVector),
+              py::arg("vec"), doc.ToDistributionVector.doc)
+          .def("IsDeterministic",
+              pydrake::overload_cast_explicit<bool,
+                  const DistributionVectorVariant<Size>&>(IsDeterministic),
+              py::arg("vec"),
+              doc.IsDeterministic.doc_1args_constDistributionVectorVariant)
+          .def("GetDeterministicValue",
+              pydrake::overload_cast_explicit<Eigen::VectorXd,
+                  const DistributionVectorVariant<Size>&>(
+                  GetDeterministicValue),
+              py::arg("vec"),
+              doc.GetDeterministicValue
+                  .doc_1args_constDistributionVectorVariant);
+    }
+  };  // NOLINT
+  bind_distribution_vectors(std::integral_constant<int, Eigen::Dynamic>{});
+  bind_distribution_vectors(std::integral_constant<int, 1>{});
+  bind_distribution_vectors(std::integral_constant<int, 2>{});
+  bind_distribution_vectors(std::integral_constant<int, 3>{});
+  bind_distribution_vectors(std::integral_constant<int, 4>{});
+  bind_distribution_vectors(std::integral_constant<int, 5>{});
+  bind_distribution_vectors(std::integral_constant<int, 6>{});
 
   // Bindings for rotation.h.
 

--- a/bindings/pydrake/common/test/schema_test.py
+++ b/bindings/pydrake/common/test/schema_test.py
@@ -1,6 +1,8 @@
 import copy
 import unittest
 
+import numpy as np
+
 from pydrake.common import RandomGenerator
 import pydrake.common.schema as mut
 import pydrake.math
@@ -136,24 +138,78 @@ class TestSchema(unittest.TestCase):
                 mut.GetDeterministicValue(vec=item)
 
     def test_rotation(self):
-        mut.Rotation()
-        mut.Rotation(pydrake.math.RotationMatrix())
-        dut = mut.Rotation(pydrake.math.RollPitchYaw([0.0, 0.0, 0.0]))
-        copy.copy(dut)
-        copy.deepcopy(dut)
-        dut.IsDeterministic()
-        dut.GetDeterministicValue()
-        dut.ToSymbolic()
+        for dut in [mut.Rotation(),
+                    mut.Rotation(pydrake.math.RotationMatrix()),
+                    mut.Rotation(pydrake.math.RollPitchYaw([0.0, 0.0, 0.0]))]:
+            # The dut should be the identity.
+            self.assertTrue(dut.IsDeterministic())
+            rotmat = dut.GetDeterministicValue()
+            self.assertTrue(rotmat.IsExactlyIdentity())
+
+            # All getter functions work without crashing.
+            dut.ToSymbolic()
+
+            # The class is copyable and has a real repr.
+            mut.Rotation(other=dut)
+            copy.copy(dut)
+            copy.deepcopy(dut)
+            self.assertIn("value", repr(dut))
+
+        # Setters.
         dut.set_rpy_deg([0.1, 0.2, 0.3])
+        np.testing.assert_equal(dut.value.deg, [0.1, 0.2, 0.3])
+
+        # Attributes.
+        self.assertIsInstance(
+            mut.Rotation(value=mut.Rotation.AngleAxis()).value,
+            mut.Rotation.AngleAxis)
+
+    def test_rotation_nested_clases(self):
+        # The class is copyable and has a real repr.
+        for dut_cls in [mut.Rotation.Identity,
+                        mut.Rotation.Uniform,
+                        mut.Rotation.Rpy,
+                        mut.Rotation.AngleAxis]:
+            dut = dut_cls()
+            dut_cls(other=dut)
+            copy.copy(dut)
+            copy.deepcopy(dut)
+            self.assertNotIn("0x", repr(dut))
+
+        # Properties are bound.
+        np.testing.assert_equal(mut.Rotation.Rpy(deg=[1, 2, 3]).deg, [1, 2, 3])
+        self.assertEqual(mut.Rotation.AngleAxis(angle_deg=5).angle_deg, 5)
 
     def test_transform(self):
-        mut.Transform()
-        dut = mut.Transform(pydrake.math.RigidTransform())
-        copy.copy(dut)
-        copy.deepcopy(dut)
-        dut.set_rotation_rpy_deg([0.1, 0.2, 0.3])
-        dut.IsDeterministic()
-        dut.GetDeterministicValue()
-        dut.ToSymbolic()
-        dut.Sample(generator=RandomGenerator())
+        for dut in [mut.Transform(),
+                    mut.Transform(pydrake.math.RigidTransform())]:
+            # The dut should be the identity.
+            self.assertIsNone(dut.base_frame)
+            self.assertTrue(dut.IsDeterministic())
+            np.testing.assert_equal(dut.translation, [0, 0, 0])
+            rotmat = dut.rotation.GetDeterministicValue()
+            self.assertTrue(rotmat.IsExactlyIdentity())
+
+            # All getter functions work without crashing.
+            dut.ToSymbolic()
+            dut.Mean()
+            dut.Sample(generator=RandomGenerator())
+
+            # The class is copyable and has a real repr.
+            mut.Transform(other=dut)
+            copy.copy(dut)
+            copy.deepcopy(dut)
+            self.assertIn("base_frame", repr(dut))
+
+        # Setters.
         dut.base_frame = "name"
+        self.assertEqual(dut.base_frame, "name")
+
+        dut.translation = [1.0, 2.0, 3.0]
+        np.testing.assert_equal(dut.translation, [1.0, 2.0, 3.0])
+
+        dut.set_rotation_rpy_deg([0.1, 0.2, 0.3])
+        np.testing.assert_equal(dut.rotation.value.deg, [0.1, 0.2, 0.3])
+
+        # Attributes.
+        self.assertEqual(mut.Transform(base_frame="base").base_frame, "base")

--- a/bindings/pydrake/common/test/schema_test.py
+++ b/bindings/pydrake/common/test/schema_test.py
@@ -103,6 +103,21 @@ class TestSchema(unittest.TestCase):
         dut.max = [2.0, 20.0]
         self._check_distribution_vector(dut)
 
+    def test_sized_vectors(self):
+        """Spot check the fixed-size stochastic vectors."""
+        for size in range(1, 7):
+            vec = [1.0] * size
+            for key in ["Deterministic", "Gaussian", "Uniform"]:
+                name = f"{key}Vector{size}"
+                with self.subTest(name=name):
+                    dut_cls = getattr(mut, name)
+                    if key == "Deterministic":
+                        init_args = [vec]
+                    else:
+                        init_args = [vec, vec]
+                    dut = dut_cls(*init_args)
+                    self._check_distribution_vector(dut)
+
     def test_distribution_vector_variant(self):
         """Confirms that the free functions that operate on a vector variant
         are bound."""
@@ -110,6 +125,9 @@ class TestSchema(unittest.TestCase):
             mut.DeterministicVectorX(value=[1.0]),
             mut.GaussianVectorX(mean=[1.0], stddev=[0.1]),
             mut.UniformVectorX(min=[-1.0], max=[1.0]),
+            mut.DeterministicVector3(value=[1.0]*3),
+            mut.GaussianVector3(mean=[1.0]*3, stddev=[0.1]*3),
+            mut.UniformVector3(min=[-1.0]*3, max=[1.0]*3),
         ]
         for item in items:
             copied = mut.ToDistributionVector(item)

--- a/common/schema/stochastic.cc
+++ b/common/schema/stochastic.cc
@@ -383,7 +383,15 @@ unique_ptr<DistributionVector> ToDistributionVector(
           Eigen::VectorXd::Constant(1, arg.min),
           Eigen::VectorXd::Constant(1, arg.max));
     },
-    [](const internal::InvalidVariantSelection&)
+    [](const internal::InvalidVariantSelection<Deterministic>&)
+        -> unique_ptr<DistributionVector> {
+      DRAKE_UNREACHABLE();
+    },
+    [](const internal::InvalidVariantSelection<Gaussian>&)
+        -> unique_ptr<DistributionVector> {
+      DRAKE_UNREACHABLE();
+    },
+    [](const internal::InvalidVariantSelection<Uniform>&)
         -> unique_ptr<DistributionVector> {
       DRAKE_UNREACHABLE();
     },
@@ -414,7 +422,13 @@ bool IsDeterministic(const DistributionVectorVariant<Size>& vec) {
     [](const Uniform& arg) -> bool {
       return arg.min == arg.max;
     },
-    [](const internal::InvalidVariantSelection&) -> bool {
+    [](const internal::InvalidVariantSelection<Deterministic>&) -> bool {
+      DRAKE_UNREACHABLE();
+    },
+    [](const internal::InvalidVariantSelection<Gaussian>&) -> bool {
+      DRAKE_UNREACHABLE();
+    },
+    [](const internal::InvalidVariantSelection<Uniform>&) -> bool {
       DRAKE_UNREACHABLE();
     },
   }, vec);

--- a/common/schema/stochastic.h
+++ b/common/schema/stochastic.h
@@ -447,6 +447,7 @@ class UniformVector final : public DistributionVector {
 };
 
 namespace internal {
+template <typename Singular>
 struct InvalidVariantSelection {
   template <typename Archive>
   void Serialize(Archive*) {
@@ -471,13 +472,13 @@ using DistributionVectorVariant = std::variant<
   UniformVector<Size>,
   std::conditional_t<(Size == Eigen::Dynamic || Size == 1),
     Deterministic,
-    internal::InvalidVariantSelection>,
+    internal::InvalidVariantSelection<Deterministic>>,
   std::conditional_t<(Size == Eigen::Dynamic || Size == 1),
     Gaussian,
-    internal::InvalidVariantSelection>,
+    internal::InvalidVariantSelection<Gaussian>>,
   std::conditional_t<(Size == Eigen::Dynamic || Size == 1),
     Uniform,
-    internal::InvalidVariantSelection>>;
+    internal::InvalidVariantSelection<Uniform>>>;
 
 /// DistributionVectorVariant that permits any vector size dynamically.
 using DistributionVectorVariantX = DistributionVectorVariant<Eigen::Dynamic>;


### PR DESCRIPTION
Towards https://github.com/RobotLocomotion/drake/pull/18566 (and therefore https://github.com/RobotLocomotion/drake/issues/17112).

Requires #18567 first.