### PR TITLE
CompareMatrices takes RigidTransform and RotationMatrix directly

### DIFF
--- a/common/test_utilities/BUILD.bazel
+++ b/common/test_utilities/BUILD.bazel
@@ -188,6 +188,7 @@ drake_cc_googletest(
     deps = [
         ":eigen_matrix_compare",
         "//common:essential",
+        "//math:geometric_transform",
     ],
 )
 

--- a/common/test_utilities/eigen_matrix_compare.h
+++ b/common/test_utilities/eigen_matrix_compare.h
@@ -113,4 +113,45 @@ template <typename DerivedA, typename DerivedB>
                                        << m2;
 }
 
+/** Specialization for comparing rotation matrices. The enabling criteria is
+ a shibboleth that should uniquely apply to rotation matrices. This allows us
+ to directly compare RotationMatrixes without explicitly pulling in drake::math
+ as a dependency. I.e.,
+
+ RotationMatrixd R_AB_dut = ...;
+ RotationMatrixd R_AB_expected = ...;
+ EXPECT_TRUE(CompareMatrices(R_AB_dut, R_AB_expected));
+ */
+template <template <typename> typename RotMatrixType, typename T>
+[[nodiscard]] std::enable_if_t<
+    std::is_same_v<decltype(RotMatrixType<T>::MakeXRotation(0)),
+                   RotMatrixType<T>>,
+    ::testing::AssertionResult>
+CompareMatrices(const RotMatrixType<T>& m1, const RotMatrixType<T>& m2,
+                double tolerance = 0.0,
+                MatrixCompareType compare_type = MatrixCompareType::absolute) {
+  return CompareMatrices(m1.matrix(), m2.matrix(), tolerance, compare_type);
+}
+
+/** Specialization for comparing rigid transforms. The enabling criteria is
+ a shibboleth that should uniquely apply to rigid transforms. This allows us
+ to directly compare RigidTransforms without explicitly pulling in drake::math
+ as a dependency. I.e.,
+
+ RigidTransformd X_AB_dut = ...;
+ RigidTransformd X_AB_expected = ...;
+ EXPECT_TRUE(CompareMatrices(X_AB_dut, X_AB_expected));
+ */
+template <template <typename> typename TransformType, typename T>
+[[nodiscard]] std::enable_if_t<
+    std::is_same_v<decltype(TransformType<T>().GetAsMatrix34()),
+                   Eigen::Matrix<T, 3, 4>>,
+    ::testing::AssertionResult>
+CompareMatrices(const TransformType<T>& m1, const TransformType<T>& m2,
+                double tolerance = 0.0,
+                MatrixCompareType compare_type = MatrixCompareType::absolute) {
+  return CompareMatrices(m1.GetAsMatrix34(), m2.GetAsMatrix34(), tolerance,
+                         compare_type);
+}
+
 }  // namespace drake


### PR DESCRIPTION
This changes calls like:

```c++
EXPECT_TRUE(CompareMatrices(X_AB.GetAsMatrix34(),
                            X_AB_expected.GetAsMatrix34()));
```

to

```c++
EXPECT_TRUE(CompareMatrices(X_AB, X_AB_expected));
```

And the same for rotations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18584)
<!-- Reviewable:end -->
