### PR TITLE
[pydrake] Fix RollPitchYaw repr for missing template annotation

### DIFF
--- a/bindings/pydrake/_math_extra.py
+++ b/bindings/pydrake/_math_extra.py
@@ -117,7 +117,8 @@ def _remove_float_suffix(typename):
 
 def _roll_pitch_yaw_repr(rpy):
     return (
-        f"RollPitchYaw(roll={repr(rpy.roll_angle())}, "
+        f"{_remove_float_suffix(type(rpy).__name__)}("
+        f"roll={repr(rpy.roll_angle())}, "
         f"pitch={repr(rpy.pitch_angle())}, "
         f"yaw={repr(rpy.yaw_angle())})")
 

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -333,7 +333,8 @@ class TestMath(unittest.TestCase):
           [{z}, {z}, {i}],
         ])"""))
         self.assertEqual(repr(RollPitchYaw(rpy=[2, 1, 0])),
-                         f"RollPitchYaw(roll={t}, pitch={i}, yaw={z})")
+                         f"RollPitchYaw{type_suffix}("
+                         f"roll={t}, pitch={i}, yaw={z})")
         if T == float:
             # TODO(jwnimmer-tri) Once AutoDiffXd and Expression implement an
             # eval-able repr, then we can test more than just T=float here.


### PR DESCRIPTION
(Noticed during #18587.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18588)
<!-- Reviewable:end -->
