### PR TITLE
[pydrake] Rename symbolic.FormulaKind.True and False

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -159,8 +159,6 @@ class TestPlant(unittest.TestCase):
         unittest.TestCase.setUp(self)
         # For some reason, something in how `unittest` tries to scope warnings
         # causes the previous filters to be lost. Re-install here.
-        # TODO(eric.cousineau): This used to be necessary for PY3-only, but
-        # with NumPy 1.16, it became PY2 too. Figure out why.
         install_numpy_warning_filters(force=True)
 
     def test_type_safe_indices(self):

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -577,8 +577,9 @@ PYBIND11_MODULE(symbolic, m) {
   {
     constexpr auto& cls_doc = doc.FormulaKind;
     py::enum_<FormulaKind>(m, "FormulaKind", doc.FormulaKind.doc)
-        .value("False", FormulaKind::False, cls_doc.False.doc)
-        .value("True", FormulaKind::True, cls_doc.True.doc)
+        // `True` and `False` are reserved keywords as of Python3.
+        .value("False_", FormulaKind::False, cls_doc.False.doc)
+        .value("True_", FormulaKind::True, cls_doc.True.doc)
         .value("Var", FormulaKind::Var, cls_doc.Var.doc)
         .value("Eq", FormulaKind::Eq, cls_doc.Eq.doc)
         .value("Neq", FormulaKind::Neq, cls_doc.Neq.doc)
@@ -649,9 +650,7 @@ PYBIND11_MODULE(symbolic, m) {
                          const Formula& other) { return !self.EqualTo(other); })
       .def("__hash__",
           [](const Formula& self) { return std::hash<Formula>{}(self); })
-      .def_static("True", &Formula::True, doc.FormulaTrue.doc)
-      .def_static("False", &Formula::False, doc.FormulaFalse.doc)
-      // `True` and `False` are reserved as of Python3
+      // `True` and `False` are reserved keywords as of Python3.
       .def_static("True_", &Formula::True, doc.FormulaTrue.doc)
       .def_static("False_", &Formula::False, doc.FormulaFalse.doc)
       .def("__nonzero__", [](const Formula&) {

--- a/bindings/pydrake/test/symbolic_test.py
+++ b/bindings/pydrake/test/symbolic_test.py
@@ -422,8 +422,6 @@ class TestSymbolicExpression(unittest.TestCase):
         unittest.TestCase.setUp(self)
         # For some reason, something in how `unittest` tries to scope warnings
         # causes the previous filters to be lost. Re-install here.
-        # TODO(eric.cousineau): This used to be necessary for PY3-only, but
-        # with NumPy 1.16, it became PY2 too. Figure out why.
         install_numpy_warning_filters(force=True)
 
     def test_constructor(self):


### PR DESCRIPTION
Add an underscore to `FormulaKind.True_` and `FormulaKind.False_`. The plain `True` and `False` (without the underscore) are reserved words; for users to be able to use these constants, they must have valid names.

Remove Python 2 bindings of `symbolic.Formula.True()` and `symbolic.Formula.False()`. The corresponding test code was already removed in 040b2b0f, and the `True_()` and `False_()` functions already exist.

Also purge some straggler six.PY2 TODOs.

---

Towards #18580:  Mypy chokes on our code when we use reserved keywords as names.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18589)
<!-- Reviewable:end -->
