### PR TITLE
[pydrake] Fix AddContactMaterial parameter ordering

### DIFF
--- a/bindings/pydrake/geometry_py_common.cc
+++ b/bindings/pydrake/geometry_py_common.cc
@@ -531,10 +531,22 @@ void DoScalarIndependentDefinitions(py::module m) {
           const std::optional<double>&,
           const std::optional<multibody::CoulombFriction<double>>&,
           ProximityProperties*>(&AddContactMaterial),
-      py::arg("dissipation") = std::nullopt,
+      py::arg("dissipation"), py::arg("point_stiffness"), py::arg("friction"),
+      py::arg("properties"), doc.AddContactMaterial.doc);
+  // The C++ function does not offer default arguments, but it's convenient to
+  // default the optional arguments to None in Python because a caller can use
+  // named arguments to disambiguate which arguments get which values.
+  m.def(
+      "AddContactMaterial",
+      [](ProximityProperties* properties,
+          const std::optional<double>& dissipation,
+          const std::optional<double>& point_stiffness,
+          const std::optional<multibody::CoulombFriction<double>>& friction) {
+        AddContactMaterial(dissipation, point_stiffness, friction, properties);
+      },
+      py::arg("properties"), py::arg("dissipation") = std::nullopt,
       py::arg("point_stiffness") = std::nullopt,
-      py::arg("friction") = std::nullopt, py::arg("properties"),
-      doc.AddContactMaterial.doc);
+      py::arg("friction") = std::nullopt, doc.AddContactMaterial.doc);
 }
 
 // Test-only code.

--- a/bindings/pydrake/test/geometry_common_test.py
+++ b/bindings/pydrake/test/geometry_common_test.py
@@ -231,6 +231,8 @@ class TestGeometryCore(unittest.TestCase):
         proximity_properties.h).
         """
         props = mut.ProximityProperties()
+        mut.AddContactMaterial(properties=props)
+        props = mut.ProximityProperties()
         reference_friction = CoulombFriction(0.25, 0.125)
         mut.AddContactMaterial(dissipation=2.7,
                                point_stiffness=3.9,


### PR DESCRIPTION
A non-default argument is not allowed after defaulted arguments.

Towards #18580.
Required for the Mypy regression test in #18587 to pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18591)
<!-- Reviewable:end -->
