### PR TITLE
[pydrake] Fix docstring formatting for IiwaDriver.control_mode

### DIFF
--- a/manipulation/kuka_iiwa/iiwa_driver.h
+++ b/manipulation/kuka_iiwa/iiwa_driver.h
@@ -24,10 +24,10 @@ struct IiwaDriver {
   /** Per BuildIiwaControl. */
   double ext_joint_filter_tau{0.01};
 
-  /// Per ParseIiwaControlMode. Valid options are:
-  /// - "position_only"
-  /// - "position_and_torque" (default)
-  /// - "torque_only"
+  /** The driver's control mode. Valid options (per ParseIiwaControlMode) are:
+  - "position_only"
+  - "position_and_torque" (default)
+  - "torque_only" */
   std::string control_mode{"position_and_torque"};
 
   std::string lcm_bus{"default"};


### PR DESCRIPTION
The prior docstring leads to a malformed property, which shows up wrong on the website and breaks Mypy.

Towards https://github.com/RobotLocomotion/drake/issues/18580.
Required for the Mypy regression test in #18587 to pass.

---

Current website:

![image](https://user-images.githubusercontent.com/17596505/212579092-ce78b87a-a8e0-4ae0-a62a-1a9799782296.png)

Updated website:

![image](https://user-images.githubusercontent.com/17596505/212579120-137d8468-0c58-42f8-bed4-f23bb203bbaa.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18592)
<!-- Reviewable:end -->
