### PR TITLE
[multibody] Remove markup that destroys Python

### DIFF
--- a/multibody/tree/geometry_spatial_inertia.h
+++ b/multibody/tree/geometry_spatial_inertia.h
@@ -18,9 +18,8 @@ namespace multibody {
  (and, therefore, Bo). These are the shapes that have symmetry across So along
  each of the axes Sx, Sy, Sz (e.g., geometry::Box, geometry::Sphere, etc.) For
  meshes, it depends on how the mesh is defined. For more discussion on the
- nuances of geometry::Mesh and geometry::Convex calculations
- @ref CalcSpatialInertia(const geometry::TriangleSurfaceMesh<double>&,double)
- "see below".
+ nuances of geometry::Mesh and geometry::Convex calculations refer to the
+ `mesh` overload, below.
 
  Note: Spatial inertia calculations for the geometry::Convex type do not
  currently require that the underlying mesh actually be convex. Although certain
@@ -29,8 +28,7 @@ namespace multibody {
 
  @retval M_BBo_B The spatial inertia of the hypothetical body implied by the
                  given `shape`.
- @throws std::exception if `shape` is an instance of geometry::HalfSpace or
-                        geometry::MeshcatCone.
+ @throws std::exception if `shape` is not supported (e.g., a half space)
  @pydrake_mkdoc_identifier{shape} */
 SpatialInertia<double> CalcSpatialInertia(const geometry::Shape& shape,
                                           double density);


### PR DESCRIPTION
In the `shape` overload of `CalcSpatialInertia`, the hyperlink to the other overload just below on the page ends up unparseable in Python. Reword to use slightly less precise (but simpler) phrasing.

(Ideally, our API documentation parsing tools would be able to handle cross-references like this, but there are so many layers of parsing, transformation, reparsing, retransformation, etc. that sometimes discretion is the better part of valor.)

Towards https://github.com/RobotLocomotion/drake/issues/18580.
Required for the Mypy regression test in #18587 to pass.

---

FYI here are the current Python docs on master, showing the unparsed cross-reference:
![image](https://user-images.githubusercontent.com/17596505/212607154-cd15a9be-cd95-44bb-8d16-627647bea82d.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18593)
<!-- Reviewable:end -->
