### PR TITLE
[multibody] Warn when unsupported geometries are parsed from SDFormat

### DIFF
--- a/multibody/parsing/detail_sdf_diagnostic.cc
+++ b/multibody/parsing/detail_sdf_diagnostic.cc
@@ -32,13 +32,16 @@ void CheckSupportedElements(
         detail.filename = element->FilePath();
       }
       detail.line = element->LineNumber();
-      detail.message =
-          std::string("Unsupported SDFormat element in ") +
-          root_element->GetName() + std::string(": ") + element_name;
       // Unsupported elements in the drake namespace are errors.
       if (element_name.find("drake:") == 0) {
+        detail.message =
+            std::string("Unsupported SDFormat element in ") +
+            root_element->GetName() + std::string(": ") + element_name;
         diagnostic.Error(detail);
       } else {
+        detail.message =
+            std::string("Ignoring unsupported SDFormat element in ") +
+            root_element->GetName() + std::string(": ") + element_name;
         diagnostic.Warning(detail);
       }
     }

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -938,6 +938,18 @@ std::vector<LinkInfo> AddLinksFromSpecification(
     // floating).
     plant->SetDefaultFreeBodyPose(body, X_WL);
 
+    const std::set<std::string> supported_geometry_elements{
+      "box",
+      "capsule",
+      "cylinder",
+      "drake:capsule",
+      "drake:ellipsoid",
+      "ellipsoid",
+      "empty",
+      "mesh",
+      "plane",
+      "sphere"};
+
     if (plant->geometry_source_is_registered()) {
       ResolveFilename resolve_filename = [&package_map, &root_dir](
           const DiagnosticPolicy& inner_diagnostic, std::string uri) {
@@ -947,6 +959,12 @@ std::vector<LinkInfo> AddLinksFromSpecification(
       for (uint64_t visual_index = 0; visual_index < link.VisualCount();
            ++visual_index) {
         const sdf::Visual& sdf_visual = *link.VisualByIndex(visual_index);
+        const sdf::Geometry& sdf_geometry = *sdf_visual.Geom();
+
+        sdf::ElementPtr geometry_element = sdf_geometry.Element();
+        CheckSupportedElements(
+            diagnostic, geometry_element, supported_geometry_elements);
+
         const RigidTransformd X_LG = ResolveRigidTransform(
             diagnostic, sdf_visual.SemanticPose());
         unique_ptr<GeometryInstance> geometry_instance =
@@ -972,6 +990,10 @@ std::vector<LinkInfo> AddLinksFromSpecification(
         const sdf::Collision& sdf_collision =
             *link.CollisionByIndex(collision_index);
         const sdf::Geometry& sdf_geometry = *sdf_collision.Geom();
+
+        sdf::ElementPtr geometry_element = sdf_geometry.Element();
+        CheckSupportedElements(
+            diagnostic, geometry_element, supported_geometry_elements);
 
         std::unique_ptr<geometry::Shape> shape =
             MakeShapeFromSdfGeometry(

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -2742,6 +2742,70 @@ TEST_F(SdfParserTest, WorldJoint) {
                               X_CJc.GetAsMatrix4(), kEps));
 }
 
+// Tests the error handling for an unsupported visual geometry.
+TEST_F(SdfParserTest, TestUnsupportedVisualGeometry) {
+  AddSceneGraph();
+  ParseTestString(R"""(
+  <model name="heightmap_model">
+    <link name="a">
+      <visual name="b">
+        <geometry>
+          <heightmap/>
+        </geometry>
+      </visual>
+    </link>
+  </model>)""");
+  EXPECT_THAT(FormatFirstWarning(), ::testing::MatchesRegex(
+      ".*Ignoring unsupported SDFormat element in geometry: heightmap.*"));
+  ClearDiagnostics();
+
+  ParseTestString(R"""(
+  <model name="polyline_model">
+    <link name="a">
+      <visual name="b">
+        <geometry>
+          <polyline/>
+        </geometry>
+      </visual>
+    </link>
+  </model>)""");
+  EXPECT_THAT(FormatFirstWarning(), ::testing::MatchesRegex(
+      ".*Ignoring unsupported SDFormat element in geometry: polyline.*"));
+  ClearDiagnostics();
+}
+
+// Tests the error handling for an unsupported collision geometry.
+TEST_F(SdfParserTest, TestUnsupportedCollisionGeometry) {
+  AddSceneGraph();
+  ParseTestString(R"""(
+  <model name="heightmap_model">
+    <link name="a">
+      <collision name="b">
+        <geometry>
+          <heightmap/>
+        </geometry>
+      </collision>
+    </link>
+  </model>)""");
+  EXPECT_THAT(FormatFirstWarning(), ::testing::MatchesRegex(
+      ".*Ignoring unsupported SDFormat element in geometry: heightmap.*"));
+  ClearDiagnostics();
+
+  ParseTestString(R"""(
+  <model name="polyline_model">
+    <link name="a">
+      <collision name="b">
+        <geometry>
+          <polyline/>
+        </geometry>
+      </collision>
+    </link>
+  </model>)""");
+  EXPECT_THAT(FormatFirstWarning(), ::testing::MatchesRegex(
+      ".*Ignoring unsupported SDFormat element in geometry: polyline.*"));
+  ClearDiagnostics();
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace multibody


### PR DESCRIPTION
List of supported geometries were referenced from https://github.com/RobotLocomotion/drake/blob/master/multibody/parsing/detail_sdf_geometry.cc#L114-L219.

Resolves: https://github.com/RobotLocomotion/drake/issues/17257

Signed-off-by: Aaron Chong <aaronchongth@gmail.com>