### PR TITLE
[symbolic] Tweak API comment to satisfy stubgen

### DIFF
--- a/common/symbolic/expression/formula.h
+++ b/common/symbolic/expression/formula.h
@@ -341,9 +341,9 @@ Formula isfinite(const Expression& e);
  *
  * @note This method checks if @p m is symmetric, which can be costly. If you
  * want to avoid it, please consider using
- * `positive_semidefinite(m.triangularView<Eigen::Lower>())` or
- * `positive_semidefinite(m.triangularView<Eigen::Upper>())` instead of
- * `positive_semidefinite(m)`.
+ * `positive_semidefinite(m.triangularView<...>())` instead of
+ * `positive_semidefinite(m)`, where `...` is either `Eigen::Lower` or
+ * `Eigen::Upper`.
  *
  * @pydrake_mkdoc_identifier{1args_m}
  */


### PR DESCRIPTION
For some reason, stubgen takes the `::` in `<Eigen::Lower>` as the end of a function signature, leading to broken `*.pyi` stubs. Reword the comment slightly to avoid this hazard.

Towards https://github.com/RobotLocomotion/drake/issues/18580.
Required for the Mypy regression test in https://github.com/RobotLocomotion/drake/pull/18587 to pass.