### PR TITLE
Avoid auto-diff for linear IPOPT constraints

### DIFF
--- a/solvers/benchmarking/BUILD.bazel
+++ b/solvers/benchmarking/BUILD.bazel
@@ -7,6 +7,8 @@ load(
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
+package(default_visibility = ["//visibility:public"])
+
 drake_cc_googlebench_binary(
     name = "benchmark_mathematical_program",
     srcs = ["benchmark_mathematical_program.cc"],
@@ -20,11 +22,28 @@ drake_cc_googlebench_binary(
     ],
 )
 
-package(default_visibility = ["//visibility:public"])
-
 drake_py_experiment_binary(
     name = "mathematical_program_experiment",
     googlebench_binary = ":benchmark_mathematical_program",
+)
+
+drake_cc_googlebench_binary(
+    name = "benchmark_ipopt_solver",
+    srcs = ["benchmark_ipopt_solver.cc"],
+    add_test_rule = True,
+    test_timeout = "moderate",
+    deps = [
+        "//common:add_text_logging_gflags",
+        "//solvers:ipopt_solver",
+        "//solvers:mathematical_program",
+        "//tools/performance:fixture_common",
+        "//tools/performance:gflags_main",
+    ],
+)
+
+drake_py_experiment_binary(
+    name = "ipopt_solver_experiment",
+    googlebench_binary = ":benchmark_ipopt_solver",
 )
 
 add_lint_tests()

--- a/solvers/benchmarking/benchmark_ipopt_solver.cc
+++ b/solvers/benchmarking/benchmark_ipopt_solver.cc
@@ -1,0 +1,48 @@
+#include "drake/solvers/ipopt_solver.h"
+#include "drake/solvers/mathematical_program.h"
+#include "drake/tools/performance/fixture_common.h"
+
+namespace drake {
+namespace solvers {
+namespace {
+
+static void BenchmarkIpoptSolver(benchmark::State& state) {  // NOLINT
+  // Number of decision variables.
+  const int nx = 1000;
+  // Create the mathematical program and the solver.
+  MathematicalProgram prog;
+  IpoptSolver solver;
+  // Create decision variables.
+  auto x = prog.NewContinuousVariables<nx>();
+  // Add bounding box constraints.
+  auto lbx = -1e0 * Eigen::VectorXd::Ones(nx);
+  auto ubx = +1e0 * Eigen::VectorXd::Ones(nx);
+  prog.AddBoundingBoxConstraint(lbx, ubx, x);
+  // Add random linear constraints.
+  auto A = Eigen::MatrixXd::Random(nx, nx);
+  auto lb = Eigen::VectorXd::Zero(nx);
+  auto ub = 1e20 * Eigen::VectorXd::Ones(nx);
+  prog.AddLinearConstraint(A, lb, ub, x);
+  // Add linear equality constraints.
+  auto Aeq = Eigen::MatrixXd::Identity(nx, nx);
+  auto beq = Eigen::VectorXd::Zero(nx);
+  prog.AddLinearEqualityConstraint(Aeq, beq, x);
+  // Add a nonlinear constraint: closed unit disk.
+  prog.AddConstraint(x.transpose() * x <= 1e0);
+  // Add a quadratic cost.
+  prog.AddQuadraticCost(Eigen::MatrixXd::Identity(nx, nx),
+                        Eigen::VectorXd::Zero(nx), x);
+
+  // Run the solver and measure the performance.
+  MathematicalProgramResult result;
+  for (auto _ : state) {
+    result = solver.Solve(prog);
+  }
+  // Verify the success of the solver.
+  DRAKE_DEMAND(result.is_success());
+}
+
+BENCHMARK(BenchmarkIpoptSolver);
+}  // namespace
+}  // namespace solvers
+}  // namespace drake


### PR DESCRIPTION
* Addresses the following IPOPT issue mentioned in [#18292](https://github.com/RobotLocomotion/drake/issues/18292#issuecomment-1314121771) by avoiding auto-diff for linear constraints:
> We treat the linear constraints as if they are nonlinear. When we compute the gradient of the linear constraints lb <= A * x <= ub, instead of fetching the A matrix directly, we form an AutoDiffVecXd, evaluate this constraint with AutoDiffVecXd, and then take the gradient. This is very inefficient. We should directly fetch A matrix as the gradient without evaluating AutoDiff. This is a problem specific in IpoptSolver, but not in SnoptSolver.

* Adds a benchmark to evaluate the IPOPT performance for a nonlinear program in the following form:
`min x^T*x s.t. x^T*x <= 1, Identity*x  = 0, 0 <= A*x <= 1e20, -1 <= x <= 1`
where A is a random matrix.

The benchmark results show that the solver speed is improved significantly, especially for large-enough problems, by the proposed change.

| Version | Size | Time [ns] | CPU [ns] | Iters |
| ----------- | ----------- | ----------- | ----------- | ----------- |
| Baseline    | 10 |  1226912 | 1226656   | 555 |
| Proposed  | 10 |  1200639 |  1200614  | 581 |
| Baseline    | 100 |  15413920 |  15413016  | 45 |
| Proposed  | 100 |  13354838 |  13353761  | 52 |
| Baseline    | 1000 | 9818495035  |  9817708665  | 1 |
| Proposed  | 1000 | 7225218296  |  7224712225  | 1 |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18603)
<!-- Reviewable:end -->
