### PR TITLE
ScsSolver adds quadratic cost directly.

### DIFF
--- a/bindings/pydrake/solvers/test/scs_solver_test.py
+++ b/bindings/pydrake/solvers/test/scs_solver_test.py
@@ -36,8 +36,7 @@ class TestScsSolver(unittest.TestCase):
             result.get_solver_details().primal_residue, np.array([0.]),
             atol=atol)
         numpy_compare.assert_float_allclose(
-            result.get_solver_details().y,
-            np.array([1., 1., 1.5, 0.5, -1., -1]), atol=atol)
+            result.get_solver_details().y, np.array([1., 1.]), atol=atol)
 
     def unavailable(self):
         """Per the BUILD file, this test is only run when SCS is disabled."""

--- a/multibody/contact_solvers/sap/test/sap_friction_cone_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_friction_cone_constraint_test.cc
@@ -230,7 +230,7 @@ void ValidateProjection(double mu, const Vector3d& R, const Vector3d& y) {
 
   // We first validate the result of the projection γ = P(y).
   const Vector3d gamma_numerical = SolveProjectionWithScs(mu, R, y);
-  EXPECT_TRUE(CompareMatrices(gamma, gamma_numerical, 5.0 * kTolerance,
+  EXPECT_TRUE(CompareMatrices(gamma, gamma_numerical, 10.0 * kTolerance,
                               MatrixCompareType::relative));
 
   // We now verify gradients using automatic differentiation.


### PR DESCRIPTION
Instead of converting it to rotated Lorentz cone constraints with linear costs.

resolves #18365

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18605)
<!-- Reviewable:end -->
