### PR TITLE
[pydrake] Add YAML parsing for schema.Transform

### DIFF
--- a/bindings/pydrake/common/test/schema_test.py
+++ b/bindings/pydrake/common/test/schema_test.py
@@ -211,6 +211,8 @@ class TestSchema(unittest.TestCase):
 
         dut.set_rotation_rpy_deg([0.1, 0.2, 0.3])
         np.testing.assert_equal(dut.rotation.value.deg, [0.1, 0.2, 0.3])
+        dut.rotation.value.deg = [0.4, 0.5, 0.6]
+        np.testing.assert_equal(dut.rotation.value.deg, [0.4, 0.5, 0.6])
 
         # Attributes.
         self.assertEqual(mut.Transform(base_frame="base").base_frame, "base")

--- a/bindings/pydrake/common/yaml.py
+++ b/bindings/pydrake/common/yaml.py
@@ -211,6 +211,7 @@ def _merge_yaml_dict_item_into_target(*, options, name, yaml_value,
     writing the result to the field named `name` of the given `target` object.
     """
     # The target can be either a dictionary or a dataclass.
+    assert target is not None
     if isinstance(target, collections.abc.Mapping):
         old_value = target[name]
         setter = functools.partial(target.__setitem__, name)
@@ -372,6 +373,7 @@ def _merge_yaml_dict_into_target(*, options, yaml_dict,
     raw strings, dictionaries, lists, etc.).
     """
     assert isinstance(yaml_dict, collections.abc.Mapping), yaml_dict
+    assert target is not None
     static_field_map = _enumerate_field_types(target_schema)
     schema_names = list(static_field_map.keys())
     schema_optionals = set([


### PR DESCRIPTION
Add some asserts that trip when getattr/setattr are broken.

---

We need to special-case Transform and Rotation due to this oddball line:
https://github.com/RobotLocomotion/drake/blob/8b40ab2fa2fc59ad59e506842211f60eeae4e36a/common/schema/transform.h#L195

Towards https://github.com/RobotLocomotion/drake/pull/18566 and thus https://github.com/RobotLocomotion/drake/issues/17112.  This is the final preparatory commit before the end-user feature can actually land!

Fixes #13494.

+@rpoyner-tri for feature review, please.

+@sammy-tri for platform review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18606)
<!-- Reviewable:end -->
