### PR TITLE
[workspace] Deprecate the stduuid external

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -471,7 +471,7 @@ drake_cc_library(
         "//common:unused",
         "@common_robotics_utilities",
         "@msgpack_internal//:msgpack",
-        "@stduuid",
+        "@stduuid_internal//:stduuid",
         "@uwebsockets",
     ],
 )

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -21,8 +21,8 @@
 #include <App.h>
 #include <common_robotics_utilities/base64_helpers.hpp>
 #include <drake_vendor/msgpack.hpp>
+#include <drake_vendor/uuid.h>
 #include <fmt/format.h>
-#include <uuid.h>
 
 #include "drake/common/drake_throw.h"
 #include "drake/common/find_resource.h"

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -99,6 +99,7 @@ _DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "sdformat_internal",
     "spdlog",
     "statsjs",
+    "stduuid_internal",
     "tinyobjloader",
     "tinyxml2_internal",
     "usockets",

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -87,6 +87,7 @@ load("@drake//tools/workspace/spdlog:repository.bzl", "spdlog_repository")
 load("@drake//tools/workspace/stable_baselines3_internal:repository.bzl", "stable_baselines3_internal_repository")  # noqa
 load("@drake//tools/workspace/statsjs:repository.bzl", "statsjs_repository")
 load("@drake//tools/workspace/stduuid:repository.bzl", "stduuid_repository")
+load("@drake//tools/workspace/stduuid_internal:repository.bzl", "stduuid_internal_repository")  # noqa
 load("@drake//tools/workspace/styleguide:repository.bzl", "styleguide_repository")  # noqa
 load("@drake//tools/workspace/suitesparse:repository.bzl", "suitesparse_repository")  # noqa
 load("@drake//tools/workspace/tinyobjloader:repository.bzl", "tinyobjloader_repository")  # noqa
@@ -297,6 +298,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         statsjs_repository(name = "statsjs", mirrors = mirrors)
     if "stduuid" not in excludes:
         stduuid_repository(name = "stduuid", mirrors = mirrors)
+    if "stduuid_internal" not in excludes:
+        stduuid_internal_repository(name = "stduuid_internal", mirrors = mirrors)  # noqa
     if "styleguide" not in excludes:
         styleguide_repository(name = "styleguide", mirrors = mirrors)
     if "suitesparse" not in excludes:

--- a/tools/workspace/stduuid/package.BUILD.bazel
+++ b/tools/workspace/stduuid/package.BUILD.bazel
@@ -1,10 +1,5 @@
 # -*- python -*-
 
-load(
-    "@drake//tools/install:install.bzl",
-    "install",
-)
-
 licenses(["notice"])  # MIT
 
 package(default_visibility = ["//visibility:public"])
@@ -14,10 +9,5 @@ cc_library(
     hdrs = glob(["include/uuid.h", "gsl/*"]),
     includes = ["include", "."],
     linkstatic = 1,
-)
-
-# Install the license file.
-install(
-    name = "install",
-    docs = ["LICENSE"],
+    deprecation = "DRAKE DEPRECATED: The @stduuid external is deprecated. The deprecated code will be removed from Drake on or after 2023-05-01.",  # noqa,
 )

--- a/tools/workspace/stduuid_internal/BUILD.bazel
+++ b/tools/workspace/stduuid_internal/BUILD.bazel
@@ -1,0 +1,8 @@
+# -*- python -*-
+
+# This file exists to make our directory into a Bazel package, so that our
+# neighboring *.bzl file can be loaded elsewhere.
+
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/workspace/stduuid_internal/package.BUILD.bazel
+++ b/tools/workspace/stduuid_internal/package.BUILD.bazel
@@ -1,0 +1,34 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/install:install.bzl",
+    "install",
+)
+
+licenses(["notice"])  # MIT
+
+package(default_visibility = ["//visibility:public"])
+
+# TODO(jwnimmer-tri) Once we require >= C++20, i.e., once we drop support for
+# Ubuntu 20.04 Focal, then we should remove the thus-unused gsl cc_library.
+cc_library(
+    name = "gsl",
+    hdrs = glob(["gsl/*"], allow_empty = False),
+    includes = ["."],
+    linkstatic = 1,
+)
+
+cc_library(
+    name = "stduuid",
+    hdrs = ["include/uuid.h"],
+    strip_include_prefix = "include",
+    include_prefix = "drake_vendor",
+    linkstatic = 1,
+    deps = [":gsl"],
+)
+
+# Install the license file.
+install(
+    name = "install",
+    docs = ["LICENSE"],
+)

--- a/tools/workspace/stduuid_internal/patches/vendor.patch
+++ b/tools/workspace/stduuid_internal/patches/vendor.patch
@@ -1,0 +1,31 @@
+Add vendoring namespace and disable std::hash
+
+This prevents ODR violations in case downstream code also links to stduuid.
+
+--- include/uuid.h
++++ include/uuid.h
+@@ -49,6 +49,7 @@
+ 
+ #endif
+ 
++inline namespace drake_vendor __attribute__ ((visibility ("hidden"))) {
+ namespace uuids
+ {
+ #ifdef __cpp_lib_span
+@@ -900,7 +901,9 @@
+    };
+ #endif
+ }
++}  // namespace drake_vendor
+ 
++#if 0  // Disable std::hash<> specialization.
+ namespace std
+ {
+    template <>
+@@ -947,5 +950,6 @@
+       }
+    };
+ }
++#endif
+ 
+ #endif /* STDUUID_H */

--- a/tools/workspace/stduuid_internal/repository.bzl
+++ b/tools/workspace/stduuid_internal/repository.bzl
@@ -1,0 +1,19 @@
+# -*- mode: python -*-
+# vi: set ft=python :
+
+load("@drake//tools/workspace:github.bzl", "github_archive")
+
+def stduuid_internal_repository(
+        name,
+        mirrors = None):
+    github_archive(
+        name = name,
+        repository = "mariusbancila/stduuid",
+        commit = "3afe7193facd5d674de709fccc44d5055e144d7a",
+        sha256 = "e11f9bf30c7f9c03d8e9a3a3fd7fe016eb5d8d9b89a2fe2c11b5f049e1d97916",  # noqa
+        build_file = ":package.BUILD.bazel",
+        patches = [
+            ":patches/vendor.patch",
+        ],
+        mirrors = mirrors,
+    )


### PR DESCRIPTION
Fork it to `@stduuid_internal` instead.
Fix the new copy to actually install its license file.
Adjust the new copy to use a numbered version now that upstream uses tags.
Adjust the new copy to be vendored and linker-hidden.
Rework `gsl` build rule and note that `gsl` is soon-to-be unused.

Towards #17231.

Note that Focal users will still be at ODR-risk for `gsl::span`, since we don't vendor that here.  It doesn't seem worth the effort since Focal support will eventually evaporate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18610)
<!-- Reviewable:end -->
