### PR TITLE
[kcov] Support python coverage with Bazel 6

### DIFF
--- a/tools/dynamic_analysis/kcov.sh
+++ b/tools/dynamic_analysis/kcov.sh
@@ -48,10 +48,12 @@ eof
 # If we have a Python target...
 if [[ $(file -b --mime -L "$1") == *text/x-*python* ]]; then
     # Bazel's Python wrappers[1] require extra treatment. PYTHON_COVERAGE and
-    # COVERAGE_DIR are consumed by the wrapper.
-    # [1]: https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
+    # COVERAGE_DIR are consumed by the wrapper. The wrapper will try to write
+    # to COVERAGE_DIR, so it needs to be created here first.
+    # [1]: https://github.com/bazelbuild/bazel/blob/6.0.0/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
     export PYTHON_COVERAGE="${WORKSPACE}/tools/dynamic_analysis/kcoverage.py"
     export COVERAGE_DIR="${TEST_UNDECLARED_OUTPUTS_DIR}/kcov"
+    mkdir -p ${COVERAGE_DIR}
 
     # DRAKE_KCOV_COMMAND is consumed by drake's kcov/python integration.
     export DRAKE_KCOV_COMMAND

--- a/tools/dynamic_analysis/kcoverage.py
+++ b/tools/dynamic_analysis/kcoverage.py
@@ -18,11 +18,12 @@ def parse_command_line(argv):
     """
     parser = argparse.ArgumentParser()
     parser.add_argument('verb', type=str, help='coverage.py verb')
-    parser.add_argument('exe', type=str, help='target executable')
-    parser.add_argument('-a', action='store_true', default=False,
-                        help='coverage.py -a')
+    parser.add_argument('-a', '--append', action='store_true', default=False,
+                        help='coverage.py --append')
     parser.add_argument('--branch', action='store_true', default=False,
                         help='coverage.py --branch')
+    parser.add_argument('--rcfile', type=str, help='coverage.py rcfile')
+    parser.add_argument('-o', type=str, help='coverage.py outfile')
 
     return parser.parse_known_args(argv)
 
@@ -49,7 +50,9 @@ def exec_with_kcov(exe, exe_args):
 
 def main():
     args, extra = parse_command_line(sys.argv[1:])
-    exec_with_kcov(args.exe, extra)
+    if args.verb != 'run':
+        return
+    exec_with_kcov(extra[0], extra[1:])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
To work with the updated python stubs, pre-create our test output directory, and absorb/ignore more kinds of coverage-py command lines.