### PR TITLE
[C-IRIS] Speed up binary search.

### DIFF
--- a/geometry/optimization/dev/cspace_free_polytope.h
+++ b/geometry/optimization/dev/cspace_free_polytope.h
@@ -336,9 +336,15 @@ class CspaceFreePolytope {
     // The number of iterations at termination.
     int num_iter;
 
+    // Clear this->a and this->b and reset their values.
     void SetSeparatingPlanes(
-        std::vector<std::optional<SeparationCertificateResult>>
+        const std::vector<std::optional<SeparationCertificateResult>>&
             certificates_result);
+
+    // Update this->a and this->b with the values in certificates_result.
+    void UpdateSeparatingPlanes(
+        const std::vector<std::optional<SeparationCertificateResult>>&
+            certificates_results);
   };
 
   struct BilinearAlternationOptions {


### PR DESCRIPTION
If a pair of geometry is certified to be separated for a larger C-space region in the previous iteration of binary search, we can skip it in the current iteration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18623)
<!-- Reviewable:end -->
