### PR TITLE
[parsing] Add model name prefix constructors to Parser

### DIFF
--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -70,9 +70,14 @@ PYBIND11_MODULE(parsing, m) {
     constexpr auto& cls_doc = doc.Parser;
     auto cls = py::class_<Class>(m, "Parser", cls_doc.doc);
     cls  // BR
-        .def(py::init<MultibodyPlant<double>*, SceneGraph<double>*>(),
+        .def(py::init<MultibodyPlant<double>*, SceneGraph<double>*,
+                 std::string_view>(),
             py::arg("plant"), py::arg("scene_graph") = nullptr,
-            cls_doc.ctor.doc)
+            py::arg("model_name_prefix") = "",
+            cls_doc.ctor.doc_3args_plant_scene_graph_model_name_prefix)
+        .def(py::init<MultibodyPlant<double>*, std::string_view>(),
+            py::arg("plant"), py::arg("model_name_prefix"),
+            cls_doc.ctor.doc_2args_plant_model_name_prefix)
         .def("plant", &Class::plant, py_rvp::reference_internal,
             cls_doc.plant.doc)
         .def("package_map", &Class::package_map, py_rvp::reference_internal,

--- a/multibody/parsing/parser.cc
+++ b/multibody/parsing/parser.cc
@@ -20,11 +20,23 @@ using internal::ParserInterface;
 using internal::ParsingWorkspace;
 using internal::SelectParser;
 
-Parser::Parser(
-    MultibodyPlant<double>* plant,
-    geometry::SceneGraph<double>* scene_graph)
+Parser::Parser(MultibodyPlant<double>* plant,
+               geometry::SceneGraph<double>* scene_graph)
+    : Parser(plant, scene_graph, {}) {}
+
+Parser::Parser(MultibodyPlant<double>* plant,
+               std::string_view model_name_prefix)
+    : Parser(plant, nullptr, model_name_prefix) {}
+
+Parser::Parser(MultibodyPlant<double>* plant,
+               geometry::SceneGraph<double>* scene_graph,
+               std::string_view model_name_prefix)
     : plant_(plant) {
   DRAKE_THROW_UNLESS(plant != nullptr);
+
+  if (!model_name_prefix.empty()) {
+    model_name_prefix_ = std::string(model_name_prefix);
+  }
 
   if (scene_graph != nullptr && !plant->geometry_source_is_registered()) {
     plant->RegisterAsSourceForSceneGraph(scene_graph);
@@ -47,7 +59,8 @@ std::vector<ModelInstanceIndex> Parser::AddModels(
   DataSource data_source(DataSource::kFilename, &filename_string);
   ParserInterface& parser = SelectParser(diagnostic_policy_, file_name);
   auto composite = internal::CompositeParse::MakeCompositeParse(this);
-  return parser.AddAllModels(data_source, {}, composite->workspace());
+  return parser.AddAllModels(data_source, model_name_prefix_,
+                             composite->workspace());
 }
 
 std::vector<ModelInstanceIndex> Parser::AddAllModelsFromFile(
@@ -61,7 +74,8 @@ std::vector<ModelInstanceIndex> Parser::AddModelsFromString(
   const std::string pseudo_name(data_source.GetStem() + "." + file_type);
   ParserInterface& parser = SelectParser(diagnostic_policy_, pseudo_name);
   auto composite = internal::CompositeParse::MakeCompositeParse(this);
-  return parser.AddAllModels(data_source, {}, composite->workspace());
+  return parser.AddAllModels(data_source, model_name_prefix_,
+                             composite->workspace());
 }
 
 ModelInstanceIndex Parser::AddModelFromFile(
@@ -71,8 +85,8 @@ ModelInstanceIndex Parser::AddModelFromFile(
   ParserInterface& parser = SelectParser(diagnostic_policy_, file_name);
   auto composite = internal::CompositeParse::MakeCompositeParse(this);
   std::optional<ModelInstanceIndex> maybe_model;
-  maybe_model = parser.AddModel(data_source, model_name, {},
-                                 composite->workspace());
+  maybe_model = parser.AddModel(data_source, model_name, model_name_prefix_,
+                                composite->workspace());
   if (!maybe_model.has_value()) {
     throw std::runtime_error(
         fmt::format("{}: parsing failed", file_name));
@@ -89,8 +103,8 @@ ModelInstanceIndex Parser::AddModelFromString(
   ParserInterface& parser = SelectParser(diagnostic_policy_, pseudo_name);
   auto composite = internal::CompositeParse::MakeCompositeParse(this);
   std::optional<ModelInstanceIndex> maybe_model;
-  maybe_model = parser.AddModel(data_source, model_name, {},
-                                 composite->workspace());
+  maybe_model = parser.AddModel(data_source, model_name, model_name_prefix_,
+                                composite->workspace());
   if (!maybe_model.has_value()) {
     throw std::runtime_error(
         fmt::format("{}: parsing failed", pseudo_name));

--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -55,6 +56,30 @@ class CompositeParse;
 /// absence of units specified by the format itself. This includes the literals
 /// in the explicitly specified files as well as referenced files such as OBJ
 /// or other data file formats.
+///
+/// MultibodyPlant requires that model instances have unique names. To support
+/// loading multiple instances of the same model file(s) into a plant, Parser
+/// offers constructors that take a model name prefix, which gets applied to
+/// all models loaded with that Parser instance. The resulting workflow makes
+/// multiple parsers to build models for a single plant:
+/// @code
+///  Parser left_parser(plant, "left");
+///  Parser right_parser(plant, "right");
+///  left_parser.AddModels(arm_model);  // "left::arm"
+///  right_parser.AddModels(arm_model);  // "right::arm"
+///  left_parser.AddModels(gripper_model);  // "left::gripper"
+///  right_parser.AddModels(gripper_model);  // "right::gripper"
+/// @endcode
+///
+/// (Advanced) In the rare case where the user is parsing into a MultibodyPlant
+/// and SceneGraph but has created them one at a time instead of using the more
+/// convenient AddMultibodyPlant() or AddMultibodyPlantSceneGraph() functions,
+/// the Parser constructors accept an optional SceneGraph pointer to specify
+/// which SceneGraph to parse into. If it is provided and non-null and the
+/// MultibodyPlant is not registered as a source, the Parser will perform the
+/// SceneGraph registration into the given plant. We describe this option only
+/// for completeness; we strongly discourage anyone from taking advantage of
+/// this feature.
 class Parser final {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Parser)
@@ -64,13 +89,41 @@ class Parser final {
   ///
   /// @param plant A pointer to a mutable MultibodyPlant object to which parsed
   ///   model(s) will be added; `plant->is_finalized()` must remain `false` for
-  ///   as long as the @p plant is in used by `this`.
+  ///   as long as the @p plant is in use by `this`.
   /// @param scene_graph A pointer to a mutable SceneGraph object used for
   ///   geometry registration (either to model visual or contact geometry).
   ///   May be nullptr.
-  explicit Parser(
-    MultibodyPlant<double>* plant,
-    geometry::SceneGraph<double>* scene_graph = nullptr);
+  explicit Parser(MultibodyPlant<double>* plant,
+                  geometry::SceneGraph<double>* scene_graph = nullptr);
+
+  /// Creates a Parser that adds models to the given plant and scene_graph. The
+  /// resulting parser will apply `model_name_prefix` to the names of any
+  /// models parsed.
+  ///
+  /// @param plant A pointer to a mutable MultibodyPlant object to which parsed
+  ///   model(s) will be added; `plant->is_finalized()` must remain `false` for
+  ///   as long as the @p plant is in use by `this`.
+  /// @param scene_graph A pointer to a mutable SceneGraph object used for
+  ///   geometry registration (either to model visual or contact geometry).
+  ///   May be nullptr.
+  /// @param model_name_prefix A string that will be added as a scoped name
+  ///   prefix to the names of any models loaded by this parser;
+  ///   when empty, no scoping will be added.
+  Parser(MultibodyPlant<double>* plant,
+         geometry::SceneGraph<double>* scene_graph,
+         std::string_view model_name_prefix);
+
+  /// Creates a Parser that adds models to the given plant and scene_graph. The
+  /// resulting parser will apply `model_name_prefix` to the names of any
+  /// models parsed.
+  ///
+  /// @param plant A pointer to a mutable MultibodyPlant object to which parsed
+  ///   model(s) will be added; `plant->is_finalized()` must remain `false` for
+  ///   as long as the @p plant is in use by `this`.
+  /// @param model_name_prefix A string that will be added as a scoped name
+  ///   prefix to the names of any models loaded by this parser;
+  ///   when empty, no scoping will be added.
+  Parser(MultibodyPlant<double>* plant, std::string_view model_name_prefix);
 
   /// Gets a mutable reference to the plant that will be modified by this
   /// parser.
@@ -152,6 +205,7 @@ class Parser final {
   PackageMap package_map_;
   drake::internal::DiagnosticPolicy diagnostic_policy_;
   MultibodyPlant<double>* const plant_;
+  std::optional<std::string> model_name_prefix_;
 };
 
 }  // namespace multibody

--- a/multibody/test_utilities/add_fixed_objects_to_plant.h
+++ b/multibody/test_utilities/add_fixed_objects_to_plant.h
@@ -32,15 +32,15 @@ void AddFixedObjectsToPlant(MultibodyPlant<T>* plant) {
       FindResourceOrThrow("drake/examples/simple_gripper/simple_mug.sdf");
 
   // Load a model of a table for a robot.
-  Parser parser(plant);
   const ModelInstanceIndex robot_table_model =
-      parser.AddModelFromFile(table_sdf_path, "robot_table");
+      Parser(plant, "robot").AddModels(table_sdf_path).at(0);
   plant->WeldFrames(plant->world_frame(),
                    plant->GetFrameByName("link", robot_table_model));
 
   // Load a second table for objects.
+  Parser objects_parser(plant, "objects");
   const ModelInstanceIndex objects_table_model =
-      parser.AddModelFromFile(table_sdf_path, "objects_table");
+      objects_parser.AddModels(table_sdf_path).at(0);
   const RigidTransformd X_WT(Vector3d(0.8, 0.0, 0.0));
   plant->WeldFrames(plant->world_frame(),
                    plant->GetFrameByName("link", objects_table_model), X_WT);
@@ -59,7 +59,7 @@ void AddFixedObjectsToPlant(MultibodyPlant<T>* plant) {
           X_TO));
 
   // Add a mug and weld it to the table.
-  parser.AddModels(mug_sdf_path);
+  objects_parser.AddModels(mug_sdf_path);
   const Body<double>& mug = plant->GetBodyByName("simple_mug");
 
   // Weld the mug to the table with its center 5 cm above the table, i.e. with

--- a/tutorials/rendering_multibody_plant.ipynb
+++ b/tutorials/rendering_multibody_plant.ipynb
@@ -191,7 +191,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "parser = Parser(plant)\n",
     "iiwa_file = FindResourceOrThrow(\n",
     "   \"drake/manipulation/models/iiwa_description/sdf/\"\n",
     "   \"iiwa14_no_collision.sdf\"\n",
@@ -211,10 +210,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "iiwa_1 = parser.AddModelFromFile(iiwa_file, model_name=\"iiwa_1\")\n",
+    "(left_iiwa,) = Parser(plant, \"left\").AddModels(iiwa_file)\n",
     "plant.WeldFrames(\n",
     "    frame_on_parent_F=plant.world_frame(),\n",
-    "    frame_on_child_M=plant.GetFrameByName(\"iiwa_link_0\", iiwa_1),\n",
+    "    frame_on_child_M=plant.GetFrameByName(\"iiwa_link_0\", left_iiwa),\n",
     "    X_FM=xyz_rpy_deg([0, -0.5, 0], [0, 0, 0]),\n",
     ")"
    ]
@@ -232,10 +231,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "iiwa_2 = parser.AddModelFromFile(iiwa_file, model_name=\"iiwa_2\")\n",
+    "(right_iiwa,) = Parser(plant, \"right\").AddModels(iiwa_file)\n",
     "plant.WeldFrames(\n",
     "    frame_on_parent_F=plant.world_frame(),\n",
-    "    frame_on_child_M=plant.GetFrameByName(\"iiwa_link_0\", iiwa_2),\n",
+    "    frame_on_child_M=plant.GetFrameByName(\"iiwa_link_0\", right_iiwa),\n",
     "    X_FM=xyz_rpy_deg([0, 0.5, 0], [0, 0, 0]),\n",
     ")"
    ]


### PR DESCRIPTION
This patch introduces a new means to disambiguate parsed copies of the same model: Parser constructors that take model_name_prefix. The new mechanism will supplant the old scheme of renaming a single model during parsing.

This patch only introduces the new API elements; later patches will port call sites and deprecate the APIs that implemented parse-time renaming.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18625)
<!-- Reviewable:end -->
