### PR TITLE
[workspace] Upgrade gtest to latest release v1.13.0

### DIFF
--- a/tools/workspace/gtest/repository.bzl
+++ b/tools/workspace/gtest/repository.bzl
@@ -8,8 +8,8 @@ def gtest_repository(
     github_archive(
         name = name,
         repository = "google/googletest",
-        commit = "release-1.12.1",
-        sha256 = "81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2",  # noqa
+        commit = "v1.13.0",
+        sha256 = "ad7fdba11ea011c1d925b3289cf4af2c66a352e18d4c7264392fead75e919363",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )

--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -1,7 +1,7 @@
 """Reports on which of Drake's external dependencies can be updated to a more
 recent version.  This is intended for use by Drake maintainers (only).
 
-This program is only supported on Ubuntu Focal 20.04.
+This program is only supported on Ubuntu Jammy 22.04.
 
 To query GitHub APIs, you'll need to authenticate yourself first.  There are
 two ways to do this:


### PR DESCRIPTION
See https://github.com/google/googletest/releases/tag/v1.13.0.

Switch `new_release` tooling to claim support for Jammy. (I used it on Jammy to perform this update.)  Closes #18507.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18633)
<!-- Reviewable:end -->
