### PR TITLE
[py systems] Bind `DiagramBuilder.{already_built,IsConnectedOrExported}`

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -549,6 +549,8 @@ void DoScalarDependentDefinitions(py::module m) {
           // Keep alive, ownership: `system` keeps `self` alive.
           py::keep_alive<3, 1>(), doc.DiagramBuilder.AddNamedSystem.doc)
       .def("empty", &DiagramBuilder<T>::empty, doc.DiagramBuilder.empty.doc)
+      .def("already_built", &DiagramBuilder<T>::already_built,
+          doc.DiagramBuilder.already_built.doc)
       .def(
           "GetSystems",
           [](DiagramBuilder<T>* self) {
@@ -645,7 +647,9 @@ void DoScalarDependentDefinitions(py::module m) {
           py::keep_alive<1, 0>(), doc.DiagramBuilder.Build.doc)
       .def("BuildInto", &DiagramBuilder<T>::BuildInto, py::arg("target"),
           // Keep alive, ownership (tr.): `target` keeps `self` alive.
-          py::keep_alive<2, 1>(), doc.DiagramBuilder.BuildInto.doc);
+          py::keep_alive<2, 1>(), doc.DiagramBuilder.BuildInto.doc)
+      .def("IsConnectedOrExported", &DiagramBuilder<T>::IsConnectedOrExported,
+          py::arg("port"), doc.DiagramBuilder.IsConnectedOrExported.doc);
 
   DefineTemplateClassWithDefault<OutputPort<T>>(
       m, "OutputPort", GetPyParam<T>(), doc.OutputPort.doc)

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -873,9 +873,13 @@ class TestGeneral(unittest.TestCase):
     def test_diagram_api(self):
         def make_diagram():
             builder = DiagramBuilder()
+            self.assertTrue(builder.empty())
+            self.assertFalse(builder.already_built())
             adder1 = builder.AddNamedSystem("adder1", Adder(2, 2))
             adder2 = builder.AddNamedSystem("adder2", Adder(1, 2))
             builder.Connect(adder1.get_output_port(), adder2.get_input_port())
+            self.assertTrue(
+                builder.IsConnectedOrExported(port=adder2.get_input_port()))
             builder.ExportInput(adder1.get_input_port(0), "in0")
             builder.ExportInput(adder1.get_input_port(1), "in1")
             builder.ExportOutput(adder2.get_output_port(), "out")


### PR DESCRIPTION
Wanted `.already_built()` for debugging Anzu work, but saw it wasn't bound.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18636)
<!-- Reviewable:end -->
