### PR TITLE
Ensure that the N matrix is consistent with MapVelocityToQdot() and MapQdotToVelocity().

### DIFF
--- a/multibody/tree/test/planar_mobilizer_test.cc
+++ b/multibody/tree/test/planar_mobilizer_test.cc
@@ -196,9 +196,9 @@ TEST_F(PlanarMobilizerTest, CalcAcrossMobilizerTransform) {
 }
 
 TEST_F(PlanarMobilizerTest, CalcAcrossMobilizerSpatialVeloctiy) {
-  const Vector2d translations(1, 0.5);
-  const double angle = 1.5;
-  const Vector3d velocity(2.5, 2, 3);
+  const Vector2d translations(1.1, 0.6);
+  const double angle = 1.6;
+  const Vector3d velocity(2.5, 2.1, 3.1);
   mobilizer_->set_translations(context_.get(), translations);
   mobilizer_->set_angle(context_.get(), angle);
   const SpatialVelocity<double> V_FM =
@@ -285,11 +285,11 @@ TEST_F(PlanarMobilizerTest, KinematicMapping) {
 TEST_F(PlanarMobilizerTest, MapUsesN) {
   // Set an arbitrary "non-zero" state.
   const Vector2d some_values(1.5, 2.5);
-  mobilizer_->set_angle(context_.get(), 4.5);
+  mobilizer_->set_angle(context_.get(), 3.5);
   mobilizer_->set_translations(context_.get(), some_values);
 
   // Set arbitrary v and MapVelocityToQDot.
-  Vector3d v(1.5, 2.5, 3.5);
+  Vector3d v(4.5, 5.5, 6.5);
   Vector3d qdot;
   mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
 
@@ -304,11 +304,11 @@ TEST_F(PlanarMobilizerTest, MapUsesN) {
 TEST_F(PlanarMobilizerTest, MapUsesNplus) {
   // Set an arbitrary "non-zero" state.
   const Vector2d some_values(1.5, 2.5);
-  mobilizer_->set_angle(context_.get(), 4.5);
+  mobilizer_->set_angle(context_.get(), 3.5);
   mobilizer_->set_translations(context_.get(), some_values);
 
   // Set arbitrary qdot and MapQDotToVelocity.
-  Vector3d qdot(1.5, 2.5, 3.5);
+  Vector3d qdot(4.5, 5.5, 6.5);
   Vector3d v;
   mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
 

--- a/multibody/tree/test/planar_mobilizer_test.cc
+++ b/multibody/tree/test/planar_mobilizer_test.cc
@@ -282,7 +282,7 @@ TEST_F(PlanarMobilizerTest, KinematicMapping) {
   EXPECT_EQ(Nplus, Matrix3d::Identity());
 }
 
-TEST_F(PlanarMobilizerTest, MapUsesN){
+TEST_F(PlanarMobilizerTest, MapUsesN) {
   Vector3d v(1.5, 2.5, 3.5);
   Vector3d qdot;
   mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
@@ -295,7 +295,7 @@ TEST_F(PlanarMobilizerTest, MapUsesN){
   EXPECT_EQ(qdot, N * v);
 }
 
-TEST_F(PlanarMobilizerTest, MapUsesNplus){
+TEST_F(PlanarMobilizerTest, MapUsesNplus) {
   Vector3d v(1.5, 2.5, 3.5);
   Vector3d qdot;
   mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
@@ -304,7 +304,7 @@ TEST_F(PlanarMobilizerTest, MapUsesNplus){
   MatrixX<double> Nplus(3, 3);
   mobilizer_->CalcNplusMatrix(*context_, &Nplus);
 
-  //Ensure N⁺(q) is used in `v = N⁺(q)⋅q̇`
+  // Ensure N⁺(q) is used in `v = N⁺(q)⋅q̇`
   EXPECT_EQ(v, Nplus * qdot);
 }
 

--- a/multibody/tree/test/planar_mobilizer_test.cc
+++ b/multibody/tree/test/planar_mobilizer_test.cc
@@ -283,6 +283,12 @@ TEST_F(PlanarMobilizerTest, KinematicMapping) {
 }
 
 TEST_F(PlanarMobilizerTest, MapUsesN) {
+  // Set an arbitrary "non-zero" state.
+  const Vector2d some_values(1.5, 2.5);
+  mobilizer_->set_angle(context_.get(), 4.5);
+  mobilizer_->set_translations(context_.get(), some_values);
+
+  // Set arbitrary v and MapVelocityToQDot.
   Vector3d v(1.5, 2.5, 3.5);
   Vector3d qdot;
   mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
@@ -296,8 +302,14 @@ TEST_F(PlanarMobilizerTest, MapUsesN) {
 }
 
 TEST_F(PlanarMobilizerTest, MapUsesNplus) {
-  Vector3d v(1.5, 2.5, 3.5);
-  Vector3d qdot;
+  // Set an arbitrary "non-zero" state.
+  const Vector2d some_values(1.5, 2.5);
+  mobilizer_->set_angle(context_.get(), 4.5);
+  mobilizer_->set_translations(context_.get(), some_values);
+
+  // Set arbitrary qdot and MapQDotToVelocity.
+  Vector3d qdot(1.5, 2.5, 3.5);
+  Vector3d v;
   mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
 
   // Compute Nplus.

--- a/multibody/tree/test/planar_mobilizer_test.cc
+++ b/multibody/tree/test/planar_mobilizer_test.cc
@@ -282,6 +282,32 @@ TEST_F(PlanarMobilizerTest, KinematicMapping) {
   EXPECT_EQ(Nplus, Matrix3d::Identity());
 }
 
+TEST_F(PlanarMobilizerTest, MapUsesN){
+  Vector3d v(1.5, 2.5, 3.5);
+  Vector3d qdot;
+  mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
+
+  // Compute N.
+  MatrixX<double> N(3, 3);
+  mobilizer_->CalcNMatrix(*context_, &N);
+
+  // Ensure N(q) is used in `q̇ = N(q)⋅v`
+  EXPECT_EQ(qdot, N * v);
+}
+
+TEST_F(PlanarMobilizerTest, MapUsesNplus){
+  Vector3d v(1.5, 2.5, 3.5);
+  Vector3d qdot;
+  mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
+
+  // Compute Nplus.
+  MatrixX<double> Nplus(3, 3);
+  mobilizer_->CalcNplusMatrix(*context_, &Nplus);
+
+  //Ensure N⁺(q) is used in `v = N⁺(q)⋅q̇`
+  EXPECT_EQ(v, Nplus * qdot);
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/tree/test/prismatic_mobilizer_test.cc
+++ b/multibody/tree/test/prismatic_mobilizer_test.cc
@@ -173,6 +173,32 @@ TEST_F(PrismaticMobilizerTest, KinematicMapping) {
   EXPECT_EQ(Nplus(0, 0), 1.0);
 }
 
+TEST_F(PrismaticMobilizerTest, MapUsesN){
+  Vector1d v(1.5);
+  Vector1d qdot;
+  slider_->MapVelocityToQDot(*context_, v, &qdot);
+
+  // Compute N.
+  MatrixX<double> N(1, 1);
+  slider_->CalcNMatrix(*context_, &N);
+
+  // Ensure N(q) is used in `q̇ = N(q)⋅v`
+  EXPECT_EQ(qdot, N * v);
+}
+
+TEST_F(PrismaticMobilizerTest, MapUsesNplus) {
+  // Compute Map
+  Vector1d qdot(1.5);
+  Vector1d v;
+  slider_->MapQDotToVelocity(*context_, qdot, &v);
+
+  // Compute Nplus.
+  MatrixX<double> Nplus(1, 1);
+  slider_->CalcNplusMatrix(*context_, &Nplus);
+
+  // Ensure N⁺(q) is used in `v = N⁺(q)⋅q̇`
+  EXPECT_EQ(v, Nplus * qdot);
+}
 }  // namespace
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/tree/test/prismatic_mobilizer_test.cc
+++ b/multibody/tree/test/prismatic_mobilizer_test.cc
@@ -174,6 +174,10 @@ TEST_F(PrismaticMobilizerTest, KinematicMapping) {
 }
 
 TEST_F(PrismaticMobilizerTest, MapUsesN) {
+  // Set an arbitrary "non-zero" state.
+  slider_->set_translation(context_.get(), 1.5);
+
+  // Set arbitrary v and MapVelocityToQDot.
   Vector1d v(1.5);
   Vector1d qdot;
   slider_->MapVelocityToQDot(*context_, v, &qdot);
@@ -187,7 +191,10 @@ TEST_F(PrismaticMobilizerTest, MapUsesN) {
 }
 
 TEST_F(PrismaticMobilizerTest, MapUsesNplus) {
-  // Compute Map
+  // Set an arbitrary "non-zero" state.
+  slider_->set_translation(context_.get(), 1.5);
+
+  // Set arbitrary qdot and MapQDotToVelocity.
   Vector1d qdot(1.5);
   Vector1d v;
   slider_->MapQDotToVelocity(*context_, qdot, &v);

--- a/multibody/tree/test/prismatic_mobilizer_test.cc
+++ b/multibody/tree/test/prismatic_mobilizer_test.cc
@@ -173,7 +173,7 @@ TEST_F(PrismaticMobilizerTest, KinematicMapping) {
   EXPECT_EQ(Nplus(0, 0), 1.0);
 }
 
-TEST_F(PrismaticMobilizerTest, MapUsesN){
+TEST_F(PrismaticMobilizerTest, MapUsesN) {
   Vector1d v(1.5);
   Vector1d qdot;
   slider_->MapVelocityToQDot(*context_, v, &qdot);

--- a/multibody/tree/test/quaternion_floating_mobilizer_test.cc
+++ b/multibody/tree/test/quaternion_floating_mobilizer_test.cc
@@ -190,7 +190,7 @@ TEST_F(QuaternionFloatingMobilizerTest, MapUsesN) {
 
   // Set arbitrary v and MapVelocityToQDot
   const Vector6<double> v =
-      (Vector6<double>() << 1, 2, 3, 4, 5, 6).finished();
+      (Vector6<double>() << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0).finished();
   VectorX<double> qdot(7);
   mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
 

--- a/multibody/tree/test/quaternion_floating_mobilizer_test.cc
+++ b/multibody/tree/test/quaternion_floating_mobilizer_test.cc
@@ -180,6 +180,15 @@ TEST_F(QuaternionFloatingMobilizerTest, CheckExceptionMessage) {
 }
 
 TEST_F(QuaternionFloatingMobilizerTest, MapUsesN) {
+  // Set an arbitrary "non-zero" state.
+  const Quaterniond Q_WB(
+      RollPitchYawd(M_PI / 3, -M_PI / 3, M_PI / 5).ToQuaternion());
+  mobilizer_->set_quaternion(context_.get(), Q_WB);
+
+  const Vector3d p_WB(1.0, 2.0, 3.0);
+  mobilizer_->set_position(context_.get(), p_WB);
+
+  // Set arbitrary v and MapVelocityToQDot
   const Vector6<double> v =
       (Vector6<double>() << 1, 2, 3, 4, 5, 6).finished();
   VectorX<double> qdot(7);
@@ -195,6 +204,15 @@ TEST_F(QuaternionFloatingMobilizerTest, MapUsesN) {
 }
 
 TEST_F(QuaternionFloatingMobilizerTest, MapUsesNplus) {
+  // Set an arbitrary "non-zero" state.
+  const Quaterniond Q_WB(
+      RollPitchYawd(M_PI / 3, -M_PI / 3, M_PI / 5).ToQuaternion());
+  mobilizer_->set_quaternion(context_.get(), Q_WB);
+
+  const Vector3d p_WB(1.0, 2.0, 3.0);
+  mobilizer_->set_position(context_.get(), p_WB);
+
+  // Set arbitrary qdot and MapQDotToVelocity
   VectorX<double> qdot(7);
   qdot << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0;
 

--- a/multibody/tree/test/revolute_mobilizer_test.cc
+++ b/multibody/tree/test/revolute_mobilizer_test.cc
@@ -222,6 +222,31 @@ TEST_F(RevoluteMobilizerTest, KinematicMapping) {
   EXPECT_EQ(Nplus(0, 0), 1.0);
 }
 
+TEST_F(RevoluteMobilizerTest, MapUsesN){
+  Vector1d v(1.5);
+  Vector1d qdot;
+  mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
+
+  // Compute N.
+  MatrixX<double> N(1, 1);
+  mobilizer_->CalcNMatrix(*context_, &N);
+
+  // Ensure N(q) is used in `q̇ = N(q)⋅v`
+  EXPECT_EQ(qdot, N * v);
+}
+
+TEST_F(RevoluteMobilizerTest, MapUsesNplus){
+  Vector1d qdot(1.5);
+  Vector1d v;
+  mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
+
+  // Compute Nplus.
+  MatrixX<double> Nplus(1, 1);
+  mobilizer_->CalcNplusMatrix(*context_, &Nplus);
+
+  //Ensure N⁺(q) is used in `v = N⁺(q)⋅q̇`
+  EXPECT_EQ(v, Nplus * qdot);
+}
 }  // namespace
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/tree/test/revolute_mobilizer_test.cc
+++ b/multibody/tree/test/revolute_mobilizer_test.cc
@@ -227,7 +227,7 @@ TEST_F(RevoluteMobilizerTest, MapUsesN) {
   mobilizer_->set_angle(context_.get(), 1.5);
 
   // Set arbitrary v and MapVelocityToQDot
-  Vector1d v(1.5);
+  Vector1d v(2.5);
   Vector1d qdot;
   mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
 
@@ -244,7 +244,7 @@ TEST_F(RevoluteMobilizerTest, MapUsesNplus) {
   mobilizer_->set_angle(context_.get(), 1.5);
 
   // Set arbitrary qdot and MapQDotToVelocity
-  Vector1d qdot(1.5);
+  Vector1d qdot(2.5);
   Vector1d v;
   mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
 

--- a/multibody/tree/test/revolute_mobilizer_test.cc
+++ b/multibody/tree/test/revolute_mobilizer_test.cc
@@ -222,7 +222,7 @@ TEST_F(RevoluteMobilizerTest, KinematicMapping) {
   EXPECT_EQ(Nplus(0, 0), 1.0);
 }
 
-TEST_F(RevoluteMobilizerTest, MapUsesN){
+TEST_F(RevoluteMobilizerTest, MapUsesN) {
   Vector1d v(1.5);
   Vector1d qdot;
   mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
@@ -235,7 +235,7 @@ TEST_F(RevoluteMobilizerTest, MapUsesN){
   EXPECT_EQ(qdot, N * v);
 }
 
-TEST_F(RevoluteMobilizerTest, MapUsesNplus){
+TEST_F(RevoluteMobilizerTest, MapUsesNplus) {
   Vector1d qdot(1.5);
   Vector1d v;
   mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
@@ -244,7 +244,7 @@ TEST_F(RevoluteMobilizerTest, MapUsesNplus){
   MatrixX<double> Nplus(1, 1);
   mobilizer_->CalcNplusMatrix(*context_, &Nplus);
 
-  //Ensure N⁺(q) is used in `v = N⁺(q)⋅q̇`
+  // Ensure N⁺(q) is used in `v = N⁺(q)⋅q̇`
   EXPECT_EQ(v, Nplus * qdot);
 }
 }  // namespace

--- a/multibody/tree/test/revolute_mobilizer_test.cc
+++ b/multibody/tree/test/revolute_mobilizer_test.cc
@@ -223,6 +223,10 @@ TEST_F(RevoluteMobilizerTest, KinematicMapping) {
 }
 
 TEST_F(RevoluteMobilizerTest, MapUsesN) {
+  // Set an arbitrary "non-zero" state.
+  mobilizer_->set_angle(context_.get(), 1.5);
+
+  // Set arbitrary v and MapVelocityToQDot
   Vector1d v(1.5);
   Vector1d qdot;
   mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
@@ -236,6 +240,10 @@ TEST_F(RevoluteMobilizerTest, MapUsesN) {
 }
 
 TEST_F(RevoluteMobilizerTest, MapUsesNplus) {
+  // Set an arbitrary "non-zero" state.
+  mobilizer_->set_angle(context_.get(), 1.5);
+
+  // Set arbitrary qdot and MapQDotToVelocity
   Vector1d qdot(1.5);
   Vector1d v;
   mobilizer_->MapQDotToVelocity(*context_, qdot, &v);

--- a/multibody/tree/test/screw_mobilizer_test.cc
+++ b/multibody/tree/test/screw_mobilizer_test.cc
@@ -308,7 +308,7 @@ TEST_F(ScrewMobilizerTest, KinematicMapping) {
   EXPECT_EQ(Nplus, Matrix1d::Identity().eval());
 }
 
-TEST_F(ScrewMobilizerTest, MapUsesN){
+TEST_F(ScrewMobilizerTest, MapUsesN) {
   Vector1d v(1.5);
   Vector1d qdot;
   mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
@@ -321,7 +321,7 @@ TEST_F(ScrewMobilizerTest, MapUsesN){
   EXPECT_EQ(qdot, N * v);
 }
 
-TEST_F(ScrewMobilizerTest, MapUsesNplus){
+TEST_F(ScrewMobilizerTest, MapUsesNplus) {
   Vector1d qdot(1.5);
   Vector1d v;
   mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
@@ -330,7 +330,7 @@ TEST_F(ScrewMobilizerTest, MapUsesNplus){
   MatrixX<double> Nplus(1, 1);
   mobilizer_->CalcNplusMatrix(*context_, &Nplus);
 
-  //Ensure N⁺(q) is used in `v = N⁺(q)⋅q̇`
+  // Ensure N⁺(q) is used in `v = N⁺(q)⋅q̇`
   EXPECT_EQ(v, Nplus * qdot);
 }
 }  // namespace

--- a/multibody/tree/test/screw_mobilizer_test.cc
+++ b/multibody/tree/test/screw_mobilizer_test.cc
@@ -309,6 +309,13 @@ TEST_F(ScrewMobilizerTest, KinematicMapping) {
 }
 
 TEST_F(ScrewMobilizerTest, MapUsesN) {
+  // Set an arbitrary "non-zero" state.
+  const double angle_z{1. * 180. / M_PI};
+  const double translation_z{angle_z * kScrewPitch / (2. * M_PI)};
+  mobilizer_->set_angle(context_.get(), angle_z);
+  mobilizer_->set_translation(context_.get(), translation_z);
+
+  // Set arbitrary v and MapVelocityToQDot.
   Vector1d v(1.5);
   Vector1d qdot;
   mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
@@ -322,6 +329,13 @@ TEST_F(ScrewMobilizerTest, MapUsesN) {
 }
 
 TEST_F(ScrewMobilizerTest, MapUsesNplus) {
+  // Set an arbitrary "non-zero" state.
+  const double angle_z{1. * 180. / M_PI};
+  const double translation_z{angle_z * kScrewPitch / (2. * M_PI)};
+  mobilizer_->set_angle(context_.get(), angle_z);
+  mobilizer_->set_translation(context_.get(), translation_z);
+
+  // Set arbitrary qdot and MapQDotToVelocity.
   Vector1d qdot(1.5);
   Vector1d v;
   mobilizer_->MapQDotToVelocity(*context_, qdot, &v);

--- a/multibody/tree/test/screw_mobilizer_test.cc
+++ b/multibody/tree/test/screw_mobilizer_test.cc
@@ -308,6 +308,31 @@ TEST_F(ScrewMobilizerTest, KinematicMapping) {
   EXPECT_EQ(Nplus, Matrix1d::Identity().eval());
 }
 
+TEST_F(ScrewMobilizerTest, MapUsesN){
+  Vector1d v(1.5);
+  Vector1d qdot;
+  mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
+
+  // Compute N.
+  MatrixX<double> N(1, 1);
+  mobilizer_->CalcNMatrix(*context_, &N);
+
+  // Ensure N(q) is used in `q̇ = N(q)⋅v`
+  EXPECT_EQ(qdot, N * v);
+}
+
+TEST_F(ScrewMobilizerTest, MapUsesNplus){
+  Vector1d qdot(1.5);
+  Vector1d v;
+  mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
+
+  // Compute Nplus.
+  MatrixX<double> Nplus(1, 1);
+  mobilizer_->CalcNplusMatrix(*context_, &Nplus);
+
+  //Ensure N⁺(q) is used in `v = N⁺(q)⋅q̇`
+  EXPECT_EQ(v, Nplus * qdot);
+}
 }  // namespace
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/tree/test/screw_mobilizer_test.cc
+++ b/multibody/tree/test/screw_mobilizer_test.cc
@@ -58,8 +58,8 @@ TEST_F(ScrewMobilizerTest, ExceptionRaisingWhenZeroPitch) {
       tree().world_body().body_frame(), body_->body_frame(),
       Vector3<double>::UnitZ(), zero_screw_pitch);
 
-  const double translation_z{1.};
-  const double velocity_z{2.};
+  const double translation_z{1.0};
+  const double velocity_z{2.0};
   EXPECT_THROW(
       zero_pitch_screw_mobilizer.set_translation(context_.get(), translation_z),
       std::exception);
@@ -71,8 +71,8 @@ TEST_F(ScrewMobilizerTest, ExceptionRaisingWhenZeroPitch) {
 TEST_F(ScrewMobilizerTest, StateAccess) {
   // Verify we can set a screw mobilizer configuration given the model's
   // context.
-  const double translation_z_first{1.};
-  const double translation_z_second{2.};
+  const double translation_z_first{1.0};
+  const double translation_z_second{2.0};
   const double angle_z_second{translation_z_second  * 2 * M_PI / kScrewPitch};
 
   mobilizer_->set_translation(context_.get(), translation_z_first);
@@ -82,7 +82,7 @@ TEST_F(ScrewMobilizerTest, StateAccess) {
   EXPECT_EQ(mobilizer_->get_translation(*context_), translation_z_second);
   EXPECT_EQ(mobilizer_->get_angle(*context_), angle_z_second);
 
-  const double angle_z_first{1. * 180. / M_PI};
+  const double angle_z_first{1.0 * 180.0 / M_PI};
 
   mobilizer_->set_angle(context_.get(), angle_z_first);
   EXPECT_EQ(mobilizer_->get_angle(*context_), angle_z_first);
@@ -90,8 +90,8 @@ TEST_F(ScrewMobilizerTest, StateAccess) {
   mobilizer_->set_angle(context_.get(), angle_z_second);
   EXPECT_EQ(mobilizer_->get_angle(*context_), angle_z_second);
 
-  const double velocity_z_first{1.};
-  const double velocity_z_second{2.};
+  const double velocity_z_first{1.0};
+  const double velocity_z_second{2.0};
   const double angular_velocity_z_second{
     velocity_z_second * 2 * M_PI / kScrewPitch};
 
@@ -103,7 +103,7 @@ TEST_F(ScrewMobilizerTest, StateAccess) {
   EXPECT_EQ(mobilizer_->get_translation_rate(*context_), velocity_z_second);
   EXPECT_EQ(mobilizer_->get_angular_rate(*context_), angular_velocity_z_second);
 
-  const double angular_velocity_z_first{1. * 180. / M_PI};
+  const double angular_velocity_z_first{1.0 * 180.0 / M_PI};
 
   mobilizer_->set_angular_rate(context_.get(), angular_velocity_z_first);
   EXPECT_EQ(mobilizer_->get_angular_rate(*context_), angular_velocity_z_first);
@@ -113,11 +113,11 @@ TEST_F(ScrewMobilizerTest, StateAccess) {
 }
 
 TEST_F(ScrewMobilizerTest, ZeroState) {
-  const double angle_z{1. * 180. / M_PI};
-  const double angular_velocity_z{2. * 180. / M_PI};
+  const double angle_z{1.0 * 180.0 / M_PI};
+  const double angular_velocity_z{2.0 * 180.0 / M_PI};
 
-  const double translation_z{angle_z * kScrewPitch / (2. * M_PI)};
-  const double velocity_z{angular_velocity_z * kScrewPitch / (2. * M_PI)};
+  const double translation_z{angle_z * kScrewPitch / (2.0 * M_PI)};
+  const double velocity_z{angular_velocity_z * kScrewPitch / (2.0 * M_PI)};
 
   // Set the state to some arbitrary non-zero value.
   mobilizer_->set_angle(context_.get(), angle_z);
@@ -144,13 +144,13 @@ TEST_F(ScrewMobilizerTest, DefaultPosition) {
   EXPECT_EQ(mobilizer_->get_translation(*context_), 0.0);
   EXPECT_EQ(mobilizer_->get_angle(*context_), 0.0);
 
-  const Vector1d new_default(.4);
+  const Vector1d new_default(0.4);
   mutable_mobilizer->set_default_position(new_default);
   mobilizer_->set_default_state(*context_, &context_->get_mutable_state());
 
   EXPECT_EQ(mobilizer_->get_angle(*context_), new_default(0));
   EXPECT_EQ(mobilizer_->get_translation(*context_),
-            new_default(0) * kScrewPitch / (2. * M_PI));
+            new_default(0) * kScrewPitch / (2.0 * M_PI));
 }
 
 TEST_F(ScrewMobilizerTest, RandomState) {
@@ -310,10 +310,8 @@ TEST_F(ScrewMobilizerTest, KinematicMapping) {
 
 TEST_F(ScrewMobilizerTest, MapUsesN) {
   // Set an arbitrary "non-zero" state.
-  const double angle_z{1. * 180. / M_PI};
-  const double translation_z{angle_z * kScrewPitch / (2. * M_PI)};
+  const double angle_z{1.0 * 180.0 / M_PI};
   mobilizer_->set_angle(context_.get(), angle_z);
-  mobilizer_->set_translation(context_.get(), translation_z);
 
   // Set arbitrary v and MapVelocityToQDot.
   Vector1d v(1.5);
@@ -330,10 +328,8 @@ TEST_F(ScrewMobilizerTest, MapUsesN) {
 
 TEST_F(ScrewMobilizerTest, MapUsesNplus) {
   // Set an arbitrary "non-zero" state.
-  const double angle_z{1. * 180. / M_PI};
-  const double translation_z{angle_z * kScrewPitch / (2. * M_PI)};
+  const double angle_z{1.0 * 180.0 / M_PI};
   mobilizer_->set_angle(context_.get(), angle_z);
-  mobilizer_->set_translation(context_.get(), translation_z);
 
   // Set arbitrary qdot and MapQDotToVelocity.
   Vector1d qdot(1.5);

--- a/multibody/tree/test/space_xyz_floating_mobilizer_test.cc
+++ b/multibody/tree/test/space_xyz_floating_mobilizer_test.cc
@@ -183,7 +183,7 @@ TEST_F(SpaceXYZFloatingMobilizerTest, KinematicMapping) {
                               kTolerance, MatrixCompareType::relative));
 }
 
-TEST_F(SpaceXYZFloatingMobilizerTest, MapUsesN){
+TEST_F(SpaceXYZFloatingMobilizerTest, MapUsesN) {
   SetArbitraryNonZeroState();
   const Vector6<double> v = (Vector6<double>() << 1, 2, 3, 4, 5, 6).finished();
   Vector6<double> qdot;
@@ -194,12 +194,14 @@ TEST_F(SpaceXYZFloatingMobilizerTest, MapUsesN){
   mobilizer_->CalcNMatrix(*context_, &N);
 
   // Ensure N(q) is used in `q̇ = N(q)⋅v`
-  EXPECT_TRUE(CompareMatrices(qdot,N * v ,kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(
+      CompareMatrices(qdot, N * v, kTolerance, MatrixCompareType::relative));
 }
 
-TEST_F(SpaceXYZFloatingMobilizerTest, MapUsesNplus){
+TEST_F(SpaceXYZFloatingMobilizerTest, MapUsesNplus) {
   SetArbitraryNonZeroState();
-  const Vector6<double> qdot = (Vector6<double>() << 1, 2, 3, 4, 5, 6).finished();
+  const Vector6<double> qdot =
+      (Vector6<double>() << 1, 2, 3, 4, 5, 6).finished();
   Vector6<double> v;
   mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
 
@@ -207,8 +209,9 @@ TEST_F(SpaceXYZFloatingMobilizerTest, MapUsesNplus){
   Matrix6<double> Nplus;
   mobilizer_->CalcNplusMatrix(*context_, &Nplus);
 
-  //Ensure N⁺(q) is used in `v = N⁺(q)⋅q̇`
-  EXPECT_TRUE(CompareMatrices(v,Nplus * qdot ,kTolerance, MatrixCompareType::relative));
+  // Ensure N⁺(q) is used in `v = N⁺(q)⋅q̇`
+  EXPECT_TRUE(CompareMatrices(v, Nplus * qdot, kTolerance,
+                              MatrixCompareType::relative));
 }
 
 }  // namespace

--- a/multibody/tree/test/space_xyz_floating_mobilizer_test.cc
+++ b/multibody/tree/test/space_xyz_floating_mobilizer_test.cc
@@ -183,6 +183,34 @@ TEST_F(SpaceXYZFloatingMobilizerTest, KinematicMapping) {
                               kTolerance, MatrixCompareType::relative));
 }
 
+TEST_F(SpaceXYZFloatingMobilizerTest, MapUsesN){
+  SetArbitraryNonZeroState();
+  const Vector6<double> v = (Vector6<double>() << 1, 2, 3, 4, 5, 6).finished();
+  Vector6<double> qdot;
+  mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
+
+  // Compute N.
+  Matrix6<double> N;
+  mobilizer_->CalcNMatrix(*context_, &N);
+
+  // Ensure N(q) is used in `q̇ = N(q)⋅v`
+  EXPECT_TRUE(CompareMatrices(qdot,N * v ,kTolerance, MatrixCompareType::relative));
+}
+
+TEST_F(SpaceXYZFloatingMobilizerTest, MapUsesNplus){
+  SetArbitraryNonZeroState();
+  const Vector6<double> qdot = (Vector6<double>() << 1, 2, 3, 4, 5, 6).finished();
+  Vector6<double> v;
+  mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
+
+  // Compute Nplus.
+  Matrix6<double> Nplus;
+  mobilizer_->CalcNplusMatrix(*context_, &Nplus);
+
+  //Ensure N⁺(q) is used in `v = N⁺(q)⋅q̇`
+  EXPECT_TRUE(CompareMatrices(v,Nplus * qdot ,kTolerance, MatrixCompareType::relative));
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/tree/test/space_xyz_mobilizer_test.cc
+++ b/multibody/tree/test/space_xyz_mobilizer_test.cc
@@ -106,6 +106,11 @@ TEST_F(SpaceXYZMobilizerTest, KinematicMapping) {
 }
 
 TEST_F(SpaceXYZMobilizerTest, MapUsesN) {
+  // Set an arbitrary "non-zero" state.
+  const Vector3d rpy_value(M_PI / 3, -M_PI / 3, M_PI / 5);
+  mobilizer_->set_angles(context_.get(), rpy_value);
+
+  // Set arbitrary v and MapVelocityToQDot.
   const Vector3<double> v = (Vector3<double>() << 1, 2, 3).finished();
   Vector3<double> qdot;
   mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
@@ -120,6 +125,11 @@ TEST_F(SpaceXYZMobilizerTest, MapUsesN) {
 }
 
 TEST_F(SpaceXYZMobilizerTest, MapUsesNplus) {
+  // Set an arbitrary "non-zero" state.
+  const Vector3d rpy_value(M_PI / 3, -M_PI / 3, M_PI / 5);
+  mobilizer_->set_angles(context_.get(), rpy_value);
+
+  // Set arbitrary qdot and MapQDotToVelocity.
   const Vector3<double> qdot = (Vector3<double>() << 1, 2, 3).finished();
   Vector3<double> v;
   mobilizer_->MapQDotToVelocity(*context_, qdot, &v);

--- a/multibody/tree/test/space_xyz_mobilizer_test.cc
+++ b/multibody/tree/test/space_xyz_mobilizer_test.cc
@@ -105,6 +105,31 @@ TEST_F(SpaceXYZMobilizerTest, KinematicMapping) {
       kTolerance, MatrixCompareType::relative));
 }
 
+TEST_F(SpaceXYZMobilizerTest, MapUsesN){
+  const Vector3<double> v = (Vector3<double>() << 1, 2, 3).finished();
+  Vector3<double> qdot;
+  mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
+
+  // Compute N.
+  MatrixX<double> N(3, 3);
+  mobilizer_->CalcNMatrix(*context_, &N);
+
+  // Ensure N(q) is used in `q̇ = N(q)⋅v`
+  EXPECT_TRUE(CompareMatrices(qdot,N * v ,kTolerance, MatrixCompareType::relative));
+}
+
+TEST_F(SpaceXYZMobilizerTest, MapUsesNplus){
+  const Vector3<double> qdot = (Vector3<double>() << 1, 2, 3, 4, 5, 6).finished();
+  Vector3<double> v;
+  mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
+
+  // Compute Nplus.
+  MatrixX<double> Nplus(3,3);
+  mobilizer_->CalcNplusMatrix(*context_, &Nplus);
+
+  //Ensure N⁺(q) is used in `v = N⁺(q)⋅q̇`
+  EXPECT_TRUE(CompareMatrices(v,Nplus * qdot ,kTolerance, MatrixCompareType::relative));
+}
 }  // namespace
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/tree/test/space_xyz_mobilizer_test.cc
+++ b/multibody/tree/test/space_xyz_mobilizer_test.cc
@@ -105,7 +105,7 @@ TEST_F(SpaceXYZMobilizerTest, KinematicMapping) {
       kTolerance, MatrixCompareType::relative));
 }
 
-TEST_F(SpaceXYZMobilizerTest, MapUsesN){
+TEST_F(SpaceXYZMobilizerTest, MapUsesN) {
   const Vector3<double> v = (Vector3<double>() << 1, 2, 3).finished();
   Vector3<double> qdot;
   mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
@@ -115,20 +115,22 @@ TEST_F(SpaceXYZMobilizerTest, MapUsesN){
   mobilizer_->CalcNMatrix(*context_, &N);
 
   // Ensure N(q) is used in `q̇ = N(q)⋅v`
-  EXPECT_TRUE(CompareMatrices(qdot,N * v ,kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(
+      CompareMatrices(qdot, N * v, kTolerance, MatrixCompareType::relative));
 }
 
-TEST_F(SpaceXYZMobilizerTest, MapUsesNplus){
-  const Vector3<double> qdot = (Vector3<double>() << 1, 2, 3, 4, 5, 6).finished();
+TEST_F(SpaceXYZMobilizerTest, MapUsesNplus) {
+  const Vector3<double> qdot = (Vector3<double>() << 1, 2, 3).finished();
   Vector3<double> v;
   mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
 
   // Compute Nplus.
-  MatrixX<double> Nplus(3,3);
+  MatrixX<double> Nplus(3, 3);
   mobilizer_->CalcNplusMatrix(*context_, &Nplus);
 
-  //Ensure N⁺(q) is used in `v = N⁺(q)⋅q̇`
-  EXPECT_TRUE(CompareMatrices(v,Nplus * qdot ,kTolerance, MatrixCompareType::relative));
+  // Ensure N⁺(q) is used in `v = N⁺(q)⋅q̇`
+  EXPECT_TRUE(CompareMatrices(v, Nplus * qdot, kTolerance,
+                              MatrixCompareType::relative));
 }
 }  // namespace
 }  // namespace internal

--- a/multibody/tree/test/universal_mobilizer_test.cc
+++ b/multibody/tree/test/universal_mobilizer_test.cc
@@ -255,7 +255,7 @@ TEST_F(UniversalMobilizerTest, KinematicMapping) {
   EXPECT_EQ(Nplus, Matrix2d::Identity());
 }
 
-TEST_F(UniversalMobilizerTest, MapUsesN){
+TEST_F(UniversalMobilizerTest, MapUsesN) {
   Vector2d v(1.5, 2.5);
   Vector2d qdot;
   mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
@@ -265,10 +265,11 @@ TEST_F(UniversalMobilizerTest, MapUsesN){
   mobilizer_->CalcNMatrix(*context_, &N);
 
   // Ensure N(q) is used in `q̇ = N(q)⋅v`
-  EXPECT_TRUE(CompareMatrices(qdot, N * v, kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(
+      CompareMatrices(qdot, N * v, kTolerance, MatrixCompareType::relative));
 }
 
-TEST_F(UniversalMobilizerTest, MapUsesNplus){
+TEST_F(UniversalMobilizerTest, MapUsesNplus) {
   Vector2d qdot(1.5, 2.5);
   Vector2d v;
   mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
@@ -277,8 +278,9 @@ TEST_F(UniversalMobilizerTest, MapUsesNplus){
   MatrixX<double> Nplus(2, 2);
   mobilizer_->CalcNplusMatrix(*context_, &Nplus);
 
-  //Ensure N⁺(q) is used in `v = N⁺(q)⋅q̇`
-  EXPECT_TRUE(CompareMatrices(v, Nplus * qdot, kTolerance, MatrixCompareType::relative));
+  // Ensure N⁺(q) is used in `v = N⁺(q)⋅q̇`
+  EXPECT_TRUE(CompareMatrices(v, Nplus * qdot, kTolerance,
+                              MatrixCompareType::relative));
 }
 }  // namespace
 }  // namespace internal

--- a/multibody/tree/test/universal_mobilizer_test.cc
+++ b/multibody/tree/test/universal_mobilizer_test.cc
@@ -256,6 +256,11 @@ TEST_F(UniversalMobilizerTest, KinematicMapping) {
 }
 
 TEST_F(UniversalMobilizerTest, MapUsesN) {
+  // Set an arbitrary "non-zero" state.
+  const Vector2d some_values(1.5, 2.5);
+  mobilizer_->set_angles(context_.get(), some_values);
+
+  // Set arbitrary v and MapVelocityToQDot.
   Vector2d v(1.5, 2.5);
   Vector2d qdot;
   mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
@@ -270,6 +275,11 @@ TEST_F(UniversalMobilizerTest, MapUsesN) {
 }
 
 TEST_F(UniversalMobilizerTest, MapUsesNplus) {
+  // Set an arbitrary "non-zero" state.
+  const Vector2d some_values(1.5, 2.5);
+  mobilizer_->set_angles(context_.get(), some_values);
+
+  // Set arbitrary qdot and MapQDotToVelocity.
   Vector2d qdot(1.5, 2.5);
   Vector2d v;
   mobilizer_->MapQDotToVelocity(*context_, qdot, &v);

--- a/multibody/tree/test/universal_mobilizer_test.cc
+++ b/multibody/tree/test/universal_mobilizer_test.cc
@@ -255,6 +255,31 @@ TEST_F(UniversalMobilizerTest, KinematicMapping) {
   EXPECT_EQ(Nplus, Matrix2d::Identity());
 }
 
+TEST_F(UniversalMobilizerTest, MapUsesN){
+  Vector2d v(1.5, 2.5);
+  Vector2d qdot;
+  mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
+
+  // Compute N.
+  MatrixX<double> N(2, 2);
+  mobilizer_->CalcNMatrix(*context_, &N);
+
+  // Ensure N(q) is used in `q̇ = N(q)⋅v`
+  EXPECT_TRUE(CompareMatrices(qdot, N * v, kTolerance, MatrixCompareType::relative));
+}
+
+TEST_F(UniversalMobilizerTest, MapUsesNplus){
+  Vector2d qdot(1.5, 2.5);
+  Vector2d v;
+  mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
+
+  // Compute Nplus.
+  MatrixX<double> Nplus(2, 2);
+  mobilizer_->CalcNplusMatrix(*context_, &Nplus);
+
+  //Ensure N⁺(q) is used in `v = N⁺(q)⋅q̇`
+  EXPECT_TRUE(CompareMatrices(v, Nplus * qdot, kTolerance, MatrixCompareType::relative));
+}
 }  // namespace
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/tree/test/universal_mobilizer_test.cc
+++ b/multibody/tree/test/universal_mobilizer_test.cc
@@ -261,7 +261,7 @@ TEST_F(UniversalMobilizerTest, MapUsesN) {
   mobilizer_->set_angles(context_.get(), some_values);
 
   // Set arbitrary v and MapVelocityToQDot.
-  Vector2d v(1.5, 2.5);
+  Vector2d v(3.5, 4.5);
   Vector2d qdot;
   mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
 
@@ -280,7 +280,7 @@ TEST_F(UniversalMobilizerTest, MapUsesNplus) {
   mobilizer_->set_angles(context_.get(), some_values);
 
   // Set arbitrary qdot and MapQDotToVelocity.
-  Vector2d qdot(1.5, 2.5);
+  Vector2d qdot(3.5, 4.5);
   Vector2d v;
   mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
 

--- a/multibody/tree/test/weld_mobilizer_test.cc
+++ b/multibody/tree/test/weld_mobilizer_test.cc
@@ -100,6 +100,9 @@ TEST_F(WeldMobilizerTest, KinematicMapping) {
   weld_body_to_world_->CalcNplusMatrix(*context_, &N);
 }
 
+// Since the functions involved are no-ops, MapUsesN and MapUsesNPlus
+// tests are not included here.
+
 }  // namespace
 }  // namespace internal
 }  // namespace multibody


### PR DESCRIPTION
Pull request adding unit tests to ensure mobilizer implementations are consistent with the N matrix. 
https://stackoverflow.com/questions/75211342/why-isnt-the-use-of-the-kinematic-coupling-matrix-in-unit-tests-for-mobilizers

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18642)
<!-- Reviewable:end -->
