### PR TITLE
Increase mypy timeout for glacial CI machines again

### DIFF
--- a/tools/workspace/mypy_internal/patches/timeout.patch
+++ b/tools/workspace/mypy_internal/patches/timeout.patch
@@ -1,4 +1,4 @@
-Increase timeout from 30 seconds to 90 seconds
+Increase timeout from 30 seconds to 180 seconds
 
 --- mypy/moduleinspect.py
 +++ mypy/moduleinspect.py
@@ -7,7 +7,7 @@ Increase timeout from 30 seconds to 90 seconds
          Return the value read from the queue, or None if the process unexpectedly died.
          """
 -        max_iter = 600
-+        timeout_seconds = 90
++        timeout_seconds = 180
 +        timeout_increment = 0.05
 +        max_iter = int(timeout_seconds / timeout_increment)
          n = 0


### PR DESCRIPTION
Followup to #18527.  Closes #18119.  Linux debug jobs have been timing out again, increasing from "90 seconds" to "180 seconds" to try and give it enough time to poll the results.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18644)
<!-- Reviewable:end -->
