### PR TITLE
[pydrake] Bind all SceneGraph.RemoveRole overloads

### DIFF
--- a/bindings/pydrake/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry_py_scene_graph.cc
@@ -330,6 +330,23 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.AssignRole.doc_illustration_context)
         // - End: AssignRole Overloads.
         // - Begin: RemoveRole Overloads
+        // - - FrameId.
+        .def(
+            "RemoveRole",
+            [](Class& self, SourceId source_id, FrameId frame_id, Role role) {
+              return self.RemoveRole(source_id, frame_id, role);
+            },
+            py::arg("source_id"), py::arg("frame_id"), py::arg("role"),
+            cls_doc.RemoveRole.doc_frame_direct)
+        .def(
+            "RemoveRole",
+            [](Class& self, Context<T>* context, SourceId source_id,
+                FrameId frame_id, Role role) {
+              return self.RemoveRole(context, source_id, frame_id, role);
+            },
+            py::arg("context"), py::arg("source_id"), py::arg("frame_id"),
+            py::arg("role"), cls_doc.RemoveRole.doc_frame_context)
+        // - - GeometryId.
         .def(
             "RemoveRole",
             [](Class& self, SourceId source_id, GeometryId geometry_id,
@@ -338,6 +355,14 @@ void DoScalarDependentDefinitions(py::module m, T) {
             },
             py::arg("source_id"), py::arg("geometry_id"), py::arg("role"),
             cls_doc.RemoveRole.doc_geometry_direct)
+        .def(
+            "RemoveRole",
+            [](Class& self, Context<T>* context, SourceId source_id,
+                GeometryId geometry_id, Role role) {
+              return self.RemoveRole(context, source_id, geometry_id, role);
+            },
+            py::arg("context"), py::arg("source_id"), py::arg("geometry_id"),
+            py::arg("role"), cls_doc.RemoveRole.doc_geometry_context)
         // - End: RemoveRole Overloads.
         .def_static("world_frame_id", &Class::world_frame_id,
             cls_doc.world_frame_id.doc);
@@ -581,7 +606,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("Equal", &Class::Equal, py::arg("surface"), cls_doc.Equal.doc);
     DefCopyAndDeepCopy(&cls);
   }
-}
+}  // NOLINT(readability/fn_size)
 }  // namespace
 
 void DefineGeometrySceneGraph(py::module m) {

--- a/bindings/pydrake/test/geometry_scene_graph_test.py
+++ b/bindings/pydrake/test/geometry_scene_graph_test.py
@@ -297,12 +297,31 @@ class TestGeometrySceneGraph(unittest.TestCase):
             mut.Role.kPerception,
             mut.Role.kIllustration,
         ]
-        for role in roles:
+        for i, role in enumerate(roles):
+            # Check GeometryId SceneGraph mutating variant.
             self.assertEqual(
                 scene_graph.RemoveRole(
                     source_id=global_source, geometry_id=global_geometry,
                     role=role),
                 1)
+            # Check GeometryId Context mutating variant.
+            self.assertEqual(
+                scene_graph.RemoveRole(
+                    context=context, source_id=global_source,
+                    geometry_id=global_geometry, role=role),
+                1)
+            # Check FrameId SceneGraph mutating variant.
+            self.assertEqual(
+                scene_graph.RemoveRole(
+                    source_id=global_source, frame_id=global_frame,
+                    role=role),
+                1 if i == 0 else 0)
+            # Check FrameId Context mutating variant.
+            self.assertEqual(
+                scene_graph.RemoveRole(
+                    context=context, source_id=global_source,
+                    frame_id=global_frame, role=role),
+                1 if i == 0 else 0)
 
     @numpy_compare.check_all_types
     def test_scene_graph_register_geometry(self, T):

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -891,13 +891,15 @@ class SceneGraph final : public systems::LeafSystem<T> {
                           b) `frame_id` does not map to a registered frame,
                           c) `frame_id` does not belong to `source_id`
                           (unless `frame_id` is the world frame id), or
-                          d) the context has already been allocated.  */
+                          d) the context has already been allocated.
+   @pydrake_mkdoc_identifier{frame_direct}  */
   int RemoveRole(SourceId source_id, FrameId frame_id, Role role);
 
   /** systems::Context-modifying variant of
    @ref RemoveRole(SourceId,FrameId,Role) "RemoveRole()" for frames.
    Rather than modifying %SceneGraph's model, it modifies the copy of the model
-   stored in the provided context.  */
+   stored in the provided context.
+   @pydrake_mkdoc_identifier{frame_context}  */
   int RemoveRole(systems::Context<T>* context, SourceId source_id,
                  FrameId frame_id, Role role) const;
 
@@ -919,7 +921,8 @@ class SceneGraph final : public systems::LeafSystem<T> {
   /** systems::Context-modifying variant of
    @ref RemoveRole(SourceId,GeometryId,Role) "RemoveRole()" for individual
    geometries. Rather than modifying %SceneGraph's model, it modifies the copy
-   of the model stored in the provided context.  */
+   of the model stored in the provided context.
+   @pydrake_mkdoc_identifier{geometry_context}  */
   int RemoveRole(systems::Context<T>* context, SourceId source_id,
                  GeometryId geometry_id, Role role) const;
 


### PR DESCRIPTION
In particular, it's important for users to be able to modify roles in a `Context`, not just the model.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18645)
<!-- Reviewable:end -->
