### PR TITLE
Consolidate contact results

### DIFF
--- a/examples/multibody/inclined_plane_with_body/inclined_plane_with_body.cc
+++ b/examples/multibody/inclined_plane_with_body/inclined_plane_with_body.cc
@@ -8,6 +8,7 @@
 #include "drake/lcm/drake_lcm.h"
 #include "drake/multibody/benchmarks/inclined_plane/inclined_plane_plant.h"
 #include "drake/multibody/plant/contact_results_to_lcm.h"
+#include "drake/multibody/plant/multibody_plant_config_functions.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
 
@@ -58,14 +59,21 @@ DEFINE_bool(is_inclined_plane_half_space, true,
             "Is inclined plane a half-space (true) or box (false).");
 DEFINE_string(bodyB_type, "sphere", "Valid body types are "
               "'sphere', 'block', or 'block_with_4Spheres'");
+DEFINE_string(contact_solver, "tamsi", "Options are: "
+              "'tamsi', 'sap'");
 
 using drake::multibody::MultibodyPlant;
 
 int do_main() {
   // Build a generic multibody plant.
   systems::DiagramBuilder<double> builder;
-  auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(
-      &builder, std::make_unique<MultibodyPlant<double>>(FLAGS_time_step));
+
+  MultibodyPlantConfig plant_config;
+  plant_config.time_step = FLAGS_time_step;
+  plant_config.stiction_tolerance = FLAGS_stiction_tolerance;
+  plant_config.discrete_contact_solver = FLAGS_contact_solver;
+  auto [plant, scene_graph] =
+      multibody::AddMultibodyPlant(plant_config, &builder);
 
   // Set constants that are relevant whether body B is a sphere or block.
   const double massB = 0.1;       // Body B's mass (kg).

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -798,7 +798,17 @@ void CompliantContactManager<T>::CalcHydroelasticContactInfo(
   DRAKE_DEMAND(vn.size() == num_contacts);
   DRAKE_DEMAND(vt.size() == 2 * num_contacts);
 
-  int num_point_contacts = plant().EvalPointPairPenetrations(context).size();
+  // If the point contact model is used, hydroelastic contact pairs are appended
+  // after point contact pairs.
+  // TODO(amcastro-tri): right now EvalPointPairPenetrations() throws an
+  // exception if only hydroelastic is used. Consider a solution in which this
+  // method always returns a valid result, possibly empty.
+  // A possible solution could be moving this method into DiscreteUpdateManager
+  // if the plant no longer uses it.
+  const int num_point_contacts =
+      plant().get_contact_model() == ContactModel::kHydroelastic
+          ? 0
+          : plant().EvalPointPairPenetrations(context).size();
   const int num_surfaces = all_surfaces.size();
 
   std::vector<SpatialForce<T>> F_Ao_W_per_surface(num_surfaces,

--- a/multibody/plant/contact_jacobians.h
+++ b/multibody/plant/contact_jacobians.h
@@ -10,16 +10,15 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-// Stores the computed contact Jacobians when a point contact model is used.
+// Stores the computed contact Jacobians when a discrete contact model is used.
 // At a given state of the multibody system, there will be `nc` contact pairs.
 // For each penetration pair involving bodies A and B a contact frame C is
 // defined by the rotation matrix `R_WC = [Cx_W, Cy_W, Cz_W]` where
 // `Cz_W = nhat_BA_W` equals the normal vector pointing from body B into body
-// A, expressed in the world frame W. See PenetrationAsPointPair for further
+// A, expressed in the world frame W. See DiscreteContactPair for further
 // details on the definition of each contact pair. Versors `Cx_W` and `Cy_W`
 // constitute a basis of the plane normal to `Cz_W` and are arbitrarily chosen.
 // Below, v denotes the vector of generalized velocities, of size `nv`.
-// @see MultibodyPlant::EvalContactJacobians().
 template <class T>
 struct ContactJacobians {
   // Normal contact Jacobian.

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -91,14 +91,6 @@ DiscreteUpdateManager<T>::EvalContactSolverResults(
 }
 
 template <typename T>
-const internal::ContactJacobians<T>&
-DiscreteUpdateManager<T>::EvalContactJacobians(
-    const systems::Context<T>& context) const {
-  return MultibodyPlantDiscreteUpdateManagerAttorney<T>::EvalContactJacobians(
-      plant(), context);
-}
-
-template <typename T>
 const std::vector<geometry::ContactSurface<T>>&
 DiscreteUpdateManager<T>::EvalContactSurfaces(
     const systems::Context<T>& context) const {

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -216,9 +216,6 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   // N.B. Keep the spelling and order of declarations here identical to the
   // MultibodyPlantDiscreteUpdateManagerAttorney spelling and order of same.
 
-  const internal::ContactJacobians<T>& EvalContactJacobians(
-      const systems::Context<T>& context) const;
-
   const std::vector<geometry::ContactSurface<T>>& EvalContactSurfaces(
       const systems::Context<T>& context) const;
 

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -48,11 +48,6 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
     return plant.EvalContactSolverResults(context);
   }
 
-  static const internal::ContactJacobians<T>& EvalContactJacobians(
-      const MultibodyPlant<T>& plant, const systems::Context<T>& context) {
-    return plant.EvalContactJacobians(context);
-  }
-
   static const std::vector<geometry::ContactSurface<T>>& EvalContactSurfaces(
       const MultibodyPlant<T>& plant, const systems::Context<T>& context) {
     return plant.EvalContactSurfaces(context);

--- a/multibody/plant/tamsi_driver.h
+++ b/multibody/plant/tamsi_driver.h
@@ -4,7 +4,9 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/contact_solvers/contact_solver_results.h"
+#include "drake/multibody/plant/contact_jacobians.h"
 #include "drake/multibody/plant/tamsi_solver.h"
+#include "drake/multibody/tree/multibody_tree_topology.h"
 #include "drake/systems/framework/context.h"
 
 namespace drake {
@@ -47,9 +49,20 @@ class TamsiDriver {
   // Returns a reference to the manager provided at construction.
   const CompliantContactManager<T>& manager() const { return *manager_; }
 
+  // Returns a reference to the underlying tree topology of the multibody
+  // system.
+  const MultibodyTreeTopology& tree_topology() const {
+    return manager().tree_topology();
+  }
+
   // Returns a reference to the MultibodyPlant model held by the manager
   // provided at construction.
   const MultibodyPlant<T>& plant() const { return manager().plant(); }
+
+  // Computes a dense contact Jacobian matrix for the configuration currently
+  // stored in `context`.
+  internal::ContactJacobians<T> CalcContactJacobians(
+      const systems::Context<T>& context) const;
 
   // Helper method used within CallTamsiSolver() to update generalized
   // velocities from previous step value v0 to next step value v. This helper

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -100,27 +100,6 @@ class MultibodyPlantTester {
       const MultibodyPlant<T>& plant, GeometryId id) {
     return plant.FindBodyByGeometryId(id);
   }
-
-  static void CalcNormalAndTangentContactJacobians(
-      const MultibodyPlant<double>& plant, const Context<double>& context,
-      const std::vector<PenetrationAsPointPair<double>>& point_pairs,
-      MatrixX<double>* Jn, MatrixX<double>* Jt,
-      std::vector<RotationMatrix<double>>* R_WC_set) {
-    // We first convert point contact pairs to discrete contact pairs.
-    std::vector<internal::DiscreteContactPair<double>> discrete_pairs;
-    for (const PenetrationAsPointPair<double>& pair : point_pairs) {
-      const Vector3d p_WC = 0.5 * (pair.p_WCa + pair.p_WCb);
-      // fn0, k and d are irrelevant values for Jacobian computation. Thus we
-      // arbitrarily set them to zero.
-      const double fn0 = 0.0;
-      const double k = 0.0;
-      const double d = 0.0;
-      discrete_pairs.push_back(
-          {pair.id_A, pair.id_B, p_WC, pair.nhat_BA_W, fn0, k, d});
-    }
-    plant.CalcNormalAndTangentContactJacobians(
-        context, discrete_pairs, Jn, Jt, R_WC_set);
-  }
 };
 
 namespace {
@@ -2596,54 +2575,6 @@ class MultibodyPlantContactJacobianTests : public ::testing::Test {
   const double large_box_size_{5.0};
   const double penetration_{0.01};
 };
-
-TEST_F(MultibodyPlantContactJacobianTests, NormalAndTangentJacobian) {
-  const double kTolerance = 5 * std::numeric_limits<double>::epsilon();
-
-  // Store the orientation of the contact frames so that we can use them later
-  // to compute the same Jacobian using autodifferentiation.
-  std::vector<RotationMatrix<double>> R_WC_set;
-
-  // Compute separation velocities Jacobian.
-  MatrixX<double> N, D;
-  MultibodyPlantTester::CalcNormalAndTangentContactJacobians(
-          plant_, *context_, penetrations_, &N, &D, &R_WC_set);
-
-  // Assert Jt has the right sizes.
-  const int nv = plant_.num_velocities();
-  const int nc = penetrations_.size();
-
-  ASSERT_EQ(N.rows(), nc);
-  ASSERT_EQ(N.cols(), nv);
-
-  ASSERT_EQ(D.rows(), 2 * nc);
-  ASSERT_EQ(D.cols(), nv);
-
-  // Scalar convert the plant and its context_.
-  unique_ptr<MultibodyPlant<AutoDiffXd>> plant_autodiff;
-  unique_ptr<Context<AutoDiffXd>> context_autodiff;
-  tie(plant_autodiff, context_autodiff) = ConvertPlantAndContextToAutoDiffXd();
-
-  // Automatically differentiate vn (with respect to v) to get the normal
-  // separation velocities Jacobian N.
-  VectorX<AutoDiffXd> vn_autodiff = CalcNormalVelocities(
-      *plant_autodiff, *context_autodiff, penetrations_);
-  const MatrixX<double> vn_derivs = math::ExtractGradient(vn_autodiff);
-
-  // Verify the result.
-  EXPECT_TRUE(CompareMatrices(
-      N, vn_derivs, kTolerance, MatrixCompareType::relative));
-
-  // Automatically differentiate vt (with respect to v) to get the tangent
-  // velocities Jacobian Jt.
-  VectorX<AutoDiffXd> vt_autodiff = CalcTangentVelocities(
-      *plant_autodiff, *context_autodiff, penetrations_, R_WC_set);
-  const MatrixX<double> vt_derivs = math::ExtractGradient(vt_autodiff);
-
-  // Verify the result.
-  EXPECT_TRUE(CompareMatrices(
-      D, vt_derivs, kTolerance, MatrixCompareType::relative));
-}
 
 // Verifies that we can obtain the indexes into the state vector for each joint
 // in the model of a Kuka arm.

--- a/multibody/plant/test_utilities/rigid_body_on_compliant_ground.h
+++ b/multibody/plant/test_utilities/rigid_body_on_compliant_ground.h
@@ -37,8 +37,13 @@ using systems::Simulator;
 struct ContactTestConfig {
   // This is a gtest test suffix; no underscores or spaces.
   std::string description;
-  // Model with point contact if `true` or with hydroelastic contact if `false`.
+  // Contact is modeled with point contact if `true` or with hydroelastic
+  // contact if `false`.
   bool point_contact{};
+  // Option to allow changing the default contact model. This allows unit
+  // testing of cases using the hydroelastic contact model, whether point
+  // contact is used or not.
+  ContactModel contact_model{ContactModel::kHydroelasticWithFallback};
   DiscreteContactSolver contact_solver{DiscreteContactSolver::kTamsi};
 };
 
@@ -135,6 +140,8 @@ class RigidBodyOnCompliantGround
         plant_->world_body(),
         geometry::HalfSpace::MakePose(Vector3d::UnitZ(), Vector3d::Zero()),
         geometry::HalfSpace(), "ground_collision", ground_props);
+
+    plant_->set_contact_model(config.contact_model);
 
     plant_->Finalize();
 


### PR DESCRIPTION
Towards #16955. The result of work that started long ago, #17741, #18121, #18170, #18265, #18402.

This PR moves the responsibility of computing contact results from MultibodyPlant into the DiscreteUpdateManager. This allows for the consistent computation of contact results according to the underlying contact model (regularization with TAMSI, convex relaxation with SAP).

This is done in two parts (two commits):
  1. TamsiDriver computes a consistent contact Jacobian from the pair kinematics computed by the manager. Therefore now both SAP and TAMSI always use consistent sign conventions hardwired in the Jacobian.
  2. Removal of unused Jacobian computation code in the MultibodyPlant.
  
Unit tests already in master verify that this refactoring of the code does not break existing functionality. 

## Note
Thus far the reporting of contact results in discrete mode has been an approximation. We've approximated contact results using the same state dependent computation we use in continuous mode, for both point and hydro models. This approximation has proven useful for most quasi-satic sims we run in the past, but it can lead to observable inconsistencies specially during transients.
This PR fixes that (therefore the release notes label). Now contact results are consistent for either choice of the contact solver. cc'ing @edrumwri here since I believe this was the problem you recently reported.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18647)
<!-- Reviewable:end -->
