### PR TITLE
Remove Jammy APT packages warning from documentation

### DIFF
--- a/doc/_pages/apt.md
+++ b/doc/_pages/apt.md
@@ -29,12 +29,6 @@ in [Source Installation](/from_source.html).
 
 ## Stable Releases
 
-<div class="warning" markdown="1">
-Drake does not yet publish stable APT packages for Ubuntu 22.04. See
-[#17736](https://github.com/RobotLocomotion/drake/issues/17736) for updates.
-In the meantime, you could manually install the Nightly Releases (see below).
-</div>
-
 To add the Drake APT repository to your machine and install the `drake-dev` package,
 please do the following in order:
 

--- a/doc/_pages/apt.md
+++ b/doc/_pages/apt.md
@@ -6,8 +6,6 @@ title: Installation via APT (Ubuntu)
 
 Drake publishes pre-compiled binaries as APT packages (``*.deb``) for the
 Ubuntu 20.04 (Focal) and Ubuntu 22.04 (Jammy) operating systems.
-(At the moment, the Ubuntu 22.04 packages are only provided for nightly builds,
-not stable releases.)
 Refer to
 [Supported Configurations](/installation.html#supported-configurations)
 for additional compatibility details.


### PR DESCRIPTION
The [documentation](https://drake.mit.edu/apt.html) currently indicates that no stable APT packages are published for Ubuntu 22.04 Jammy.

The warning has been removed since stable packages are now published.

Closes https://github.com/RobotLocomotion/drake/issues/18649.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18654)
<!-- Reviewable:end -->
