### PR TITLE
Setting optimization/dev test manual

### DIFF
--- a/geometry/optimization/dev/BUILD.bazel
+++ b/geometry/optimization/dev/BUILD.bazel
@@ -100,9 +100,12 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "cspace_free_polytope_with_mosek_test",
     timeout = "long",
+    # Set to manual because it is failing on mac-x86-monterey-clang tests.
+    #  https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-x86-monterey-clang-bazel-nightly-everything-address-sanitizer/79/
+    #  https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-x86-monterey-clang-bazel-nightly-everything-release/76/
     # This test launches 2 threads to test both serial and parallel code paths
     # in CspaceFreePolytope.
-    tags = mosek_test_tags() + ["cpu:2"] + ["no_memcheck"],
+    tags = mosek_test_tags() + ["cpu:2"] + ["no_memcheck"] + ["manual"],
     use_default_main = False,
     deps = [
         ":c_iris_test_utilities",


### PR DESCRIPTION
The test IrisToyRobotTest.FindPolytopeGivenLagrangian failed in a couple of mac tests. Simply marking the dev test as being manual for later resolution.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18657)
<!-- Reviewable:end -->
