### PR TITLE
[planning] Fix CollisionChecker test vs memcheck

### DIFF
--- a/planning/test_utilities/collision_checker_abstract_test_suite.cc
+++ b/planning/test_utilities/collision_checker_abstract_test_suite.cc
@@ -39,6 +39,15 @@ multibody::parsing::ModelDirectives MakeCollisionCheckerTestScene() {
   return directives;
 }
 
+std::ostream& operator<<(std::ostream& out,
+                         const CollisionCheckerTestParams& p) {
+  out << "checker = " << p.checker;
+  out << ", supports_added_world_obstacles = "
+      << p.supports_added_world_obstacles;
+  out << ", thread_stress_iterations = " << p.thread_stress_iterations;
+  return out;
+}
+
 TEST_P(CollisionCheckerAbstractTestSuite, Clone) {
   auto params = GetParam();
   auto& checker = *params.checker;

--- a/planning/test_utilities/collision_checker_abstract_test_suite.h
+++ b/planning/test_utilities/collision_checker_abstract_test_suite.h
@@ -6,6 +6,7 @@ implementation. Developers can parameterize it to run against a specific
 concrete checker implementation, e.g., scene_graph_collision_checker_test.
 */
 
+#include <ostream>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -59,6 +60,9 @@ struct CollisionCheckerTestParams {
   // others; the default here provides relatively light stress.
   int thread_stress_iterations{10};
 };
+
+std::ostream& operator<<(std::ostream& out,
+                         const CollisionCheckerTestParams& p);
 
 class CollisionCheckerAbstractTestSuite
     : public testing::TestWithParam<CollisionCheckerTestParams> {

--- a/planning/test_utilities/collision_checker_abstract_test_suite.h
+++ b/planning/test_utilities/collision_checker_abstract_test_suite.h
@@ -6,8 +6,8 @@ implementation. Developers can parameterize it to run against a specific
 concrete checker implementation, e.g., scene_graph_collision_checker_test.
 */
 
-#include <ostream>
 #include <memory>
+#include <ostream>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
Gtest's default efforts to print CollisionCheckerTestParams was apparently choking our sanitiziers on focal. Providing our own "to string" functionality circumvents the problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18658)
<!-- Reviewable:end -->
