### PR TITLE
Notes on the formulation of ball constraints

### DIFF
--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -512,6 +512,13 @@ void SapDriver<T>::AddBallConstraints(
     manager().internal_tree().CalcJacobianTranslationalVelocity(
         context, JacobianWrtVariable::kV, body_B.body_frame(), frame_W, p_WQ,
         frame_W, frame_W, &Jv_WBq_W);
+
+    // TODO(amcastro-tri): Per conversation with Sherm. Consider using the same
+    // point here, affixed to each corresponding body. That is, we could for
+    // instance use the middle point M and write:
+    //   p_WM = 0.5 * (p_WP + p_WQ)
+    //   Compute Jacobian Jv_AmBm_W instead.
+    // Consider conservation of energy and momentum.
     Jv_ApBq_W = (Jv_WBq_W - Jv_WAp_W);
 
     // TODO(amcastro-tri): consider exposing this parameter.


### PR DESCRIPTION
A few thoughts on the formulation of ball constraints, per conversation with @sherm1.
We should investigate if using the same position (say the point midway of P and Q) leads to better physics (validity of Newton's 3rd law), energy conservation and/or momentum conservation.

@sherm1, you mentioned to me you know of a reference on this?

cc'ing @joemasterjohn

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18660)
<!-- Reviewable:end -->
