### PR TITLE
Allow Gurobi tests to run in parallel in CI

### DIFF
--- a/tools/skylark/test_tags.bzl
+++ b/tools/skylark/test_tags.bzl
@@ -6,6 +6,8 @@
 # for any license-related needs and provide a marker so that //tools/bazel.rc
 # can selectively enable tests based on the developer's chosen configuration.
 
+load("@gurobi//:defs.bzl", "DRAKE_GUROBI_LICENSE_UNLIMITED")
+
 def gurobi_test_tags(gurobi_required = True):
     """Returns the test tags necessary for properly running Gurobi tests.
 
@@ -13,19 +15,24 @@ def gurobi_test_tags(gurobi_required = True):
     tag filters include "gurobi".
 
     Gurobi checks a license file outside the workspace so tests that use Gurobi
-    must have the tag "no-sandbox". For the moment, we also require the tag
-    "exclusive" to rate-limit license servers with a small number of licenses.
-    """
+    must have the tag "no-sandbox".
 
-    # TODO(david-german-tri): Find a better fix for the license server problem.
-    nominal_tags = [
-        "exclusive",  # implies "local"
+    Unless DRAKE_GUROBI_LICENSE_UNLIMITED=1 is set in the shell environment
+    (e.g., in CI), we also require the tag "exclusive" to rate-limit
+    license servers with a small number of licenses.
+    """
+    result = [
+        # TODO(david-german-tri): Find a better fix for the license file.
         "no-sandbox",
     ]
+
+    if not DRAKE_GUROBI_LICENSE_UNLIMITED:
+        result.append("exclusive")
+
     if gurobi_required:
-        return nominal_tags + ["gurobi"]
-    else:
-        return nominal_tags
+        result.append("gurobi")
+
+    return result
 
 def mosek_test_tags(mosek_required = True):
     """Returns the test tags necessary for properly running MOSEK™ tests.

--- a/tools/workspace/gurobi/repository.bzl
+++ b/tools/workspace/gurobi/repository.bzl
@@ -67,8 +67,18 @@ def _gurobi_impl(repo_ctx):
         executable = False,
     )
 
+    # Capture whether or not Gurobi tests can run in parallel.
+    license_unlimited_int = repo_ctx.os.environ.get("DRAKE_GUROBI_LICENSE_UNLIMITED", "0")  # noqa: E501
+    license_unlimited = bool(int(license_unlimited_int) == 1)
+    repo_ctx.file(
+        "defs.bzl",
+        content = "DRAKE_GUROBI_LICENSE_UNLIMITED = {}"
+            .format(license_unlimited),
+        executable = False,
+    )
+
 gurobi_repository = repository_rule(
-    environ = ["GUROBI_HOME"],
+    environ = ["GUROBI_HOME", "DRAKE_GUROBI_LICENSE_UNLIMITED"],
     local = True,
     implementation = _gurobi_impl,
 )


### PR DESCRIPTION
Half of changes for https://github.com/RobotLocomotion/drake/issues/8610.

Closes https://github.com/RobotLocomotion/drake/issues/8610 in combination with https://github.com/RobotLocomotion/drake-ci/pull/194.

I have kicked off a [CI job](https://drake-jenkins.csail.mit.edu/view/Gurobi/job/linux-focal-clang-bazel-experimental-gurobi-release/13/console) to test these changes.  I also tested this locally and verified that with `DRAKE_GUROBI_LICENSE_UNLIMITED=1`, more than one Gurobi test runs at one time, while `DRAKE_GUROBI_LICENSE_UNLIMITED=0` runs tests synchronously.  

Thanks to @jwnimmer-tri for providing starter code for this patch!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18663)
<!-- Reviewable:end -->
