### PR TITLE
[planning] Reorganize planning artifacts in planning (1 of 3)

### DIFF
--- a/examples/kinova_jaco_arm/BUILD.bazel
+++ b/examples/kinova_jaco_arm/BUILD.bazel
@@ -25,7 +25,7 @@ drake_cc_binary(
         "//common:find_resource",
         "//lcm",
         "//manipulation/kinova_jaco",
-        "//manipulation/planner:robot_plan_interpolator",
+        "//manipulation/util:robot_plan_interpolator",
         "//systems/analysis:simulator",
         "//systems/controllers:pid_controller",
         "//systems/lcm:lcm_pubsub_system",

--- a/examples/kinova_jaco_arm/jaco_controller.cc
+++ b/examples/kinova_jaco_arm/jaco_controller.cc
@@ -16,7 +16,7 @@
 #include "drake/manipulation/kinova_jaco/jaco_command_sender.h"
 #include "drake/manipulation/kinova_jaco/jaco_constants.h"
 #include "drake/manipulation/kinova_jaco/jaco_status_receiver.h"
-#include "drake/manipulation/planner/robot_plan_interpolator.h"
+#include "drake/manipulation/util/robot_plan_interpolator.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/controllers/pid_controller.h"
 #include "drake/systems/framework/context.h"
@@ -46,7 +46,7 @@ using manipulation::kinova_jaco::JacoCommandSender;
 using manipulation::kinova_jaco::kJacoDefaultArmNumJoints;
 using manipulation::kinova_jaco::kJacoDefaultArmNumFingers;
 using manipulation::kinova_jaco::JacoStatusReceiver;
-using manipulation::planner::RobotPlanInterpolator;
+using manipulation::util::RobotPlanInterpolator;
 
 const char* const kJacoUrdf =
     "drake/manipulation/models/jaco_description/urdf/"

--- a/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/BUILD.bazel
@@ -51,7 +51,7 @@ drake_cc_library(
     deps = [
         ":iiwa_common",
         ":iiwa_lcm",
-        "//manipulation/planner:robot_plan_interpolator",
+        "//manipulation/util:robot_plan_interpolator",
         "//systems/framework:diagram_builder",
         "//systems/primitives:demultiplexer",
     ],

--- a/examples/kuka_iiwa_arm/iiwa_controller.cc
+++ b/examples/kuka_iiwa_arm/iiwa_controller.cc
@@ -36,8 +36,8 @@ namespace drake {
 namespace examples {
 namespace kuka_iiwa_arm {
 namespace {
-using manipulation::planner::RobotPlanInterpolator;
-using manipulation::planner::InterpolatorType;
+using manipulation::util::InterpolatorType;
+using manipulation::util::RobotPlanInterpolator;
 
 const char kIiwaUrdf[] =
     "drake/manipulation/models/iiwa_description/urdf/"

--- a/examples/kuka_iiwa_arm/lcm_plan_interpolator.cc
+++ b/examples/kuka_iiwa_arm/lcm_plan_interpolator.cc
@@ -8,8 +8,8 @@ namespace drake {
 namespace examples {
 namespace kuka_iiwa_arm {
 
-using manipulation::planner::InterpolatorType;
-using manipulation::planner::RobotPlanInterpolator;
+using manipulation::util::InterpolatorType;
+using manipulation::util::RobotPlanInterpolator;
 using systems::DiagramBuilder;
 
 LcmPlanInterpolator::LcmPlanInterpolator(const std::string& model_path,

--- a/examples/kuka_iiwa_arm/lcm_plan_interpolator.h
+++ b/examples/kuka_iiwa_arm/lcm_plan_interpolator.h
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include "drake/manipulation/planner/robot_plan_interpolator.h"
+#include "drake/manipulation/util/robot_plan_interpolator.h"
 #include "drake/systems/framework/diagram.h"
 
 namespace drake {
@@ -27,7 +27,7 @@ class LcmPlanInterpolator : public systems::Diagram<double> {
  public:
   LcmPlanInterpolator(
       const std::string& model_path,
-      manipulation::planner::InterpolatorType interpolator_type);
+      manipulation::util::InterpolatorType interpolator_type);
 
   const systems::InputPort<double>& get_input_port_iiwa_status()
       const {
@@ -60,7 +60,7 @@ class LcmPlanInterpolator : public systems::Diagram<double> {
   // Output ports.
   int output_port_iiwa_command_{-1};
 
-  manipulation::planner::RobotPlanInterpolator* robot_plan_interpolator_{};
+  manipulation::util::RobotPlanInterpolator* robot_plan_interpolator_{};
   int num_joints_{};
 };
 }  // namespace kuka_iiwa_arm

--- a/manipulation/planner/BUILD.bazel
+++ b/manipulation/planner/BUILD.bazel
@@ -16,23 +16,8 @@ drake_cc_package_library(
     name = "planner",
     visibility = ["//visibility:public"],
     deps = [
-        ":constraint_relaxing_ik",
         ":differential_inverse_kinematics",
         ":differential_inverse_kinematics_integrator",
-        ":robot_plan_interpolator",
-    ],
-)
-
-drake_cc_library(
-    name = "constraint_relaxing_ik",
-    srcs = ["constraint_relaxing_ik.cc"],
-    hdrs = ["constraint_relaxing_ik.h"],
-    deps = [
-        "//common/trajectories:piecewise_polynomial",
-        "//multibody/inverse_kinematics",
-        "//multibody/parsing",
-        "//multibody/plant",
-        "//solvers:solve",
     ],
 )
 
@@ -58,32 +43,7 @@ drake_cc_library(
     ],
 )
 
-drake_cc_library(
-    name = "robot_plan_interpolator",
-    srcs = ["robot_plan_interpolator.cc"],
-    hdrs = ["robot_plan_interpolator.h"],
-    deps = [
-        "//common/trajectories:piecewise_polynomial",
-        "//lcmtypes:robot_plan",
-        "//multibody/parsing",
-        "//systems/framework:leaf_system",
-    ],
-)
-
 # === test/ ===
-
-drake_cc_googletest(
-    name = "constraint_relaxing_ik_test",
-    srcs = ["test/constraint_relaxing_ik_test.cc"],
-    data = [
-        "//manipulation/models/iiwa_description:models",
-    ],
-    tags = ["snopt"],
-    deps = [
-        ":constraint_relaxing_ik",
-        "//common:find_resource",
-    ],
-)
 
 drake_cc_googletest(
     name = "differential_inverse_kinematics_test",
@@ -109,19 +69,6 @@ drake_cc_googletest(
         "//manipulation/kuka_iiwa:iiwa_constants",
         "//multibody/parsing",
         "//systems/analysis:simulator",
-    ],
-)
-
-drake_cc_googletest(
-    name = "robot_plan_interpolator_test",
-    data = [
-        "//examples/kuka_iiwa_arm:models",
-        "//manipulation/models/iiwa_description:models",
-    ],
-    deps = [
-        ":robot_plan_interpolator",
-        "//common:find_resource",
-        "//systems/framework",
     ],
 )
 

--- a/manipulation/planner/BUILD.bazel
+++ b/manipulation/planner/BUILD.bazel
@@ -16,8 +16,51 @@ drake_cc_package_library(
     name = "planner",
     visibility = ["//visibility:public"],
     deps = [
+        ":constraint_relaxing_ik",
         ":differential_inverse_kinematics",
         ":differential_inverse_kinematics_integrator",
+        ":robot_plan_interpolator",
+    ],
+)
+
+# TODO(SeanCurtis-TRI): 2023-05-01 remove along with deprecation.
+_STUB_HDRS = [
+    "constraint_relaxing_ik.h",
+    "robot_plan_interpolator.h",
+]
+
+# TODO(SeanCurtis-TRI): 2023-05-01 remove along with deprecation.
+[
+    genrule(
+        name = "_cp_" + hdr,
+        srcs = ["stub/" + hdr],
+        outs = [hdr],
+        cmd = "cp $< $@",
+        tags = ["nolint"],
+        visibility = ["//visibility:private"],
+    )
+    for hdr in _STUB_HDRS
+]
+
+# TODO(SeanCurtis-TRI): 2023-05-01 remove along with deprecation.
+drake_cc_library(
+    name = "constraint_relaxing_ik",
+    hdrs = _STUB_HDRS,
+    deprecation = "This label is deprecated and will be removed from Drake on 2023-05-01; as a replacement, use //multibody/inverse_kinematics:constraint_relaxing_ik instead.",  # noqa
+    tags = ["nolint"],
+    deps = [
+        "//multibody/inverse_kinematics:constraint_relaxing_ik",
+    ],
+)
+
+# TODO(SeanCurtis-TRI): 2023-05-01 remove along with deprecation.
+drake_cc_library(
+    name = "robot_plan_interpolator",
+    hdrs = _STUB_HDRS,
+    deprecation = "This label is deprecated and will be removed from Drake on 2023-05-01; as a replacement, use //manipulation/util:robot_plan_interpolator instead.",  # noqa
+    tags = ["nolint"],
+    deps = [
+        "//manipulation/util:robot_plan_interpolator",
     ],
 )
 
@@ -44,6 +87,23 @@ drake_cc_library(
 )
 
 # === test/ ===
+
+# TODO(SeanCurtis-TRI): 2023-05-01 remove along with deprecation.
+drake_cc_googletest(
+    name = "deprecation_test",
+    copts = [
+        "-Wno-cpp",
+        "-Wno-deprecated-declarations",
+    ],
+    data = [
+        "//manipulation/models/iiwa_description:models",
+    ],
+    deps = [
+        ":constraint_relaxing_ik",
+        ":robot_plan_interpolator",
+        "//common:find_resource",
+    ],
+)
 
 drake_cc_googletest(
     name = "differential_inverse_kinematics_test",

--- a/manipulation/planner/stub/constraint_relaxing_ik.h
+++ b/manipulation/planner/stub/constraint_relaxing_ik.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#warning The include path drake/manipulation/planner/constraint_relaxing_ik.h is deprecated and will be removed on or after 2023-05-01; instead, use drake/multibody/inverse_kinematics/constraint_relaxing_ik.h.
+
+#include "drake/multibody/inverse_kinematics/constraint_relaxing_ik.h"
+
+namespace drake {
+namespace manipulation {
+namespace planner {
+
+using ConstraintRelaxingIk DRAKE_DEPRECATED(
+    "2023-05-01",
+    "Please use drake::multibody::ConstraintRelaxingIk instead.") =
+    drake::multibody::ConstraintRelaxingIk;
+
+}
+}  // namespace manipulation
+}  // namespace drake

--- a/manipulation/planner/stub/robot_plan_interpolator.h
+++ b/manipulation/planner/stub/robot_plan_interpolator.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#warning The include path drake/manipulation/planner/robot_plan_interpolator.h is deprecated and will be removed on or after 2023-05-01; instead, use drake/manipulation/util/robot_plan_interpolator.h.
+
+#include "drake/manipulation/util/robot_plan_interpolator.h"
+
+namespace drake {
+namespace manipulation {
+namespace planner {
+
+using RobotPlanInterpolator DRAKE_DEPRECATED(
+    "2023-05-01",
+    "Please use  drake::manipulation::util::RobotPlanInterpolator instead.") =
+    drake::manipulation::util::RobotPlanInterpolator;
+
+using InterpolatorType DRAKE_DEPRECATED(
+    "2023-05-01",
+    "Please use  drake::manipulation::util::InterpolatorType instead.") =
+    drake::manipulation::util::InterpolatorType;
+
+}  // namespace planner
+}  // namespace manipulation
+}  // namespace drake

--- a/manipulation/planner/test/deprecation_test.cc
+++ b/manipulation/planner/test/deprecation_test.cc
@@ -1,0 +1,35 @@
+// This file serves to check that our deprecation shims compile successfully,
+// aside from warning messages.  We can remove this file entirely once the
+// deprecation period ends.
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/manipulation/planner/constraint_relaxing_ik.h"
+#include "drake/manipulation/planner/robot_plan_interpolator.h"
+
+namespace drake {
+namespace manipulation {
+namespace planner {
+namespace {
+
+const char* const kIiwaUrdf =
+    "drake/manipulation/models/iiwa_description/urdf/"
+    "iiwa14_polytope_collision.urdf";
+
+GTEST_TEST(ManipulationPlannerPathsDeprecation, ConstraintRelaxingIk) {
+  // Exercise the *single* type declared in the header.
+  EXPECT_NO_THROW(
+      ConstraintRelaxingIk(FindResourceOrThrow(kIiwaUrdf), "iiwa_link_7"));
+}
+
+GTEST_TEST(ManipulationPlannerPathsDeprecation, RobotPlanInterpolator) {
+  // Include *both* types declared in the header file.
+  EXPECT_NO_THROW(RobotPlanInterpolator(FindResourceOrThrow(kIiwaUrdf),
+                                        InterpolatorType::ZeroOrderHold));
+}
+
+}  // namespace
+}  // namespace planner
+}  // namespace manipulation
+}  // namespace drake

--- a/manipulation/util/BUILD.bazel
+++ b/manipulation/util/BUILD.bazel
@@ -34,6 +34,7 @@ drake_cc_package_library(
         ":make_arm_controller_model",
         ":move_ik_demo_base",
         ":moving_average_filter",
+        ":robot_plan_interpolator",
         ":robot_plan_utils",
         ":zero_force_driver",
         ":zero_force_driver_functions",
@@ -51,7 +52,7 @@ drake_cc_library(
     deps = [
         ":robot_plan_utils",
         "//lcmtypes:robot_plan",
-        "//manipulation/planner:constraint_relaxing_ik",
+        "//multibody/inverse_kinematics:constraint_relaxing_ik",
         "//multibody/parsing",
         "//multibody/plant",
     ],
@@ -117,6 +118,18 @@ drake_cc_library(
         "//math:geometric_transform",
         "//multibody/parsing",
         "//multibody/plant",
+    ],
+)
+
+drake_cc_library(
+    name = "robot_plan_interpolator",
+    srcs = ["robot_plan_interpolator.cc"],
+    hdrs = ["robot_plan_interpolator.h"],
+    deps = [
+        "//common/trajectories:piecewise_polynomial",
+        "//lcmtypes:robot_plan",
+        "//multibody/parsing",
+        "//systems/framework:leaf_system",
     ],
 )
 
@@ -208,6 +221,19 @@ drake_cc_googletest(
         "//multibody/plant",
         "//systems/framework:diagram_builder",
         "//systems/primitives:shared_pointer_system",
+    ],
+)
+
+drake_cc_googletest(
+    name = "robot_plan_interpolator_test",
+    data = [
+        "//examples/kuka_iiwa_arm:models",
+        "//manipulation/models/iiwa_description:models",
+    ],
+    deps = [
+        ":robot_plan_interpolator",
+        "//common:find_resource",
+        "//systems/framework",
     ],
 )
 

--- a/manipulation/util/move_ik_demo_base.cc
+++ b/manipulation/util/move_ik_demo_base.cc
@@ -10,7 +10,7 @@ namespace drake {
 namespace manipulation {
 namespace util {
 
-using planner::ConstraintRelaxingIk;
+using multibody::ConstraintRelaxingIk;
 
 MoveIkDemoBase::MoveIkDemoBase(std::string robot_description,
                                std::string base_link,

--- a/manipulation/util/move_ik_demo_base.h
+++ b/manipulation/util/move_ik_demo_base.h
@@ -8,8 +8,8 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/lcmt_robot_plan.hpp"
-#include "drake/manipulation/planner/constraint_relaxing_ik.h"
 #include "drake/math/rigid_transform.h"
+#include "drake/multibody/inverse_kinematics/constraint_relaxing_ik.h"
 #include "drake/multibody/plant/multibody_plant.h"
 
 namespace drake {
@@ -86,7 +86,7 @@ class MoveIkDemoBase {
   std::vector<std::string> joint_names_;
   Eigen::VectorXd joint_velocity_limits_;
   int status_count_{0};
-  planner::ConstraintRelaxingIk constraint_relaxing_ik_;
+  multibody::ConstraintRelaxingIk constraint_relaxing_ik_;
 };
 
 }  // namespace util

--- a/manipulation/util/robot_plan_interpolator.cc
+++ b/manipulation/util/robot_plan_interpolator.cc
@@ -1,4 +1,4 @@
-#include "drake/manipulation/planner/robot_plan_interpolator.h"
+#include "drake/manipulation/util/robot_plan_interpolator.h"
 
 #include <map>
 #include <memory>
@@ -15,7 +15,7 @@
 
 namespace drake {
 namespace manipulation {
-namespace planner {
+namespace util {
 
 using multibody::BodyIndex;
 using multibody::JointIndex;
@@ -235,6 +235,6 @@ systems::EventStatus RobotPlanInterpolator::UpdatePlanOnNewMessage(
   return systems::EventStatus::Succeeded();
 }
 
-}  // namespace planner
+}  // namespace util
 }  // namespace manipulation
 }  // namespace drake

--- a/manipulation/util/robot_plan_interpolator.h
+++ b/manipulation/util/robot_plan_interpolator.h
@@ -10,7 +10,7 @@
 
 namespace drake {
 namespace manipulation {
-namespace planner {
+namespace util {
 
 /// This enum specifies the type of interpolator to use in constructing
 /// the piece-wise polynomial.
@@ -113,6 +113,6 @@ class RobotPlanInterpolator : public systems::LeafSystem<double> {
   const InterpolatorType interp_type_;
 };
 
-}  // namespace planner
+}  // namespace util
 }  // namespace manipulation
 }  // namespace drake

--- a/manipulation/util/test/robot_plan_interpolator_test.cc
+++ b/manipulation/util/test/robot_plan_interpolator_test.cc
@@ -1,4 +1,4 @@
-#include "drake/manipulation/planner/robot_plan_interpolator.h"
+#include "drake/manipulation/util/robot_plan_interpolator.h"
 
 #include <gtest/gtest.h>
 
@@ -7,7 +7,7 @@
 
 namespace drake {
 namespace manipulation {
-namespace planner {
+namespace util {
 namespace {
 
 static const int kNumJoints = 7;
@@ -232,6 +232,6 @@ TEST_P(TrajectoryTestClass, TrajectoryTest) {
 }
 
 }  // namespace
-}  // namespace planner
+}  // namespace util
 }  // namespace manipulation
 }  // namespace drake

--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -17,9 +17,23 @@ drake_cc_package_library(
     name = "inverse_kinematics",
     visibility = ["//visibility:public"],
     deps = [
+        ":constraint_relaxing_ik",
         ":global_inverse_kinematics",
         ":inverse_kinematics_core",
         ":kinematic_evaluators",
+    ],
+)
+
+drake_cc_library(
+    name = "constraint_relaxing_ik",
+    srcs = ["constraint_relaxing_ik.cc"],
+    hdrs = ["constraint_relaxing_ik.h"],
+    deps = [
+        ":inverse_kinematics_core",
+        "//common/trajectories:piecewise_polynomial",
+        "//multibody/parsing",
+        "//multibody/plant",
+        "//solvers:solve",
     ],
 )
 
@@ -108,6 +122,19 @@ drake_cc_library(
 )
 
 #============ Test ============================
+
+drake_cc_googletest(
+    name = "constraint_relaxing_ik_test",
+    srcs = ["test/constraint_relaxing_ik_test.cc"],
+    data = [
+        "//manipulation/models/iiwa_description:models",
+    ],
+    tags = ["snopt"],
+    deps = [
+        ":constraint_relaxing_ik",
+        "//common:find_resource",
+    ],
+)
 
 drake_cc_library(
     name = "inverse_kinematics_test_utilities",

--- a/multibody/inverse_kinematics/constraint_relaxing_ik.cc
+++ b/multibody/inverse_kinematics/constraint_relaxing_ik.cc
@@ -1,4 +1,4 @@
-#include "drake/manipulation/planner/constraint_relaxing_ik.h"
+#include "drake/multibody/inverse_kinematics/constraint_relaxing_ik.h"
 
 #include <memory>
 #include <stdexcept>
@@ -9,9 +9,9 @@
 #include "drake/solvers/solve.h"
 
 namespace drake {
-namespace manipulation {
-namespace planner {
+namespace multibody {
 namespace {
+
 constexpr int kDefaultRandomSeed = 1234;
 }  // namespace
 
@@ -20,7 +20,7 @@ ConstraintRelaxingIk::ConstraintRelaxingIk(
     const std::string& end_effector_link_name)
     : rand_generator_(kDefaultRandomSeed),
       plant_(0) {
-  const auto models = multibody::Parser(&plant_).AddModels(model_path);
+  const auto models = Parser(&plant_).AddModels(model_path);
   DRAKE_THROW_UNLESS(models.size() == 1);
   const auto model_instance = models[0];
 
@@ -28,7 +28,7 @@ ConstraintRelaxingIk::ConstraintRelaxingIk(
   // Check if our robot is welded to the world.  If not, try welding the first
   // link.
   if (plant_.GetBodiesWeldedTo(plant_.world_body()).size() <= 1) {
-    const std::vector<multibody::BodyIndex> bodies =
+    const std::vector<BodyIndex> bodies =
         plant_.GetBodyIndices(model_instance);
     plant_.WeldFrames(plant_.world_frame(),
                       plant_.get_body(bodies[0]).body_frame());
@@ -167,7 +167,7 @@ bool ConstraintRelaxingIk::SolveIk(
     VectorX<double>* q_res) {
   DRAKE_DEMAND(q_res != nullptr);
 
-  multibody::InverseKinematics ik(plant_);
+  InverseKinematics ik(plant_);
 
   // Adds a position constraint.
   Vector3<double> pos_lb = waypoint.pose.translation() - pos_tol;
@@ -194,6 +194,5 @@ bool ConstraintRelaxingIk::SolveIk(
   return true;
 }
 
-}  // namespace planner
-}  // namespace manipulation
+}  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/constraint_relaxing_ik.h
+++ b/multibody/inverse_kinematics/constraint_relaxing_ik.h
@@ -10,8 +10,7 @@
 #include "drake/multibody/plant/multibody_plant.h"
 
 namespace drake {
-namespace manipulation {
-namespace planner {
+namespace multibody {
 
 /**
  * A wrapper class around the IK planner. This class improves IK's usability by
@@ -85,10 +84,9 @@ class ConstraintRelaxingIk {
                VectorX<double>* q_res);
 
   RandomGenerator rand_generator_;
-  multibody::MultibodyPlant<double> plant_;
-  multibody::BodyIndex end_effector_body_idx_{};
+  MultibodyPlant<double> plant_;
+  BodyIndex end_effector_body_idx_{};
 };
 
-}  // namespace planner
-}  // namespace manipulation
+}  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/test/constraint_relaxing_ik_test.cc
+++ b/multibody/inverse_kinematics/test/constraint_relaxing_ik_test.cc
@@ -1,4 +1,4 @@
-#include "drake/manipulation/planner/constraint_relaxing_ik.h"
+#include "drake/multibody/inverse_kinematics/constraint_relaxing_ik.h"
 
 #include <gtest/gtest.h>
 
@@ -7,8 +7,7 @@
 #include "drake/multibody/parsing/parser.h"
 
 namespace drake {
-namespace manipulation {
-namespace planner {
+namespace multibody {
 
 // N random samples are taken from the configuration space (q), and
 // the corresponding end effector poses are computed with forward
@@ -20,14 +19,14 @@ GTEST_TEST(ConstraintRelaxingIkTest, SolveIkFromFk) {
   const std::string kModelPath = FindResourceOrThrow(
       "drake/manipulation/models/iiwa_description/urdf/"
       "iiwa14_polytope_collision.urdf");
-  multibody::MultibodyPlant<double> iiwa(0);
-  multibody::Parser(&iiwa).AddModels(kModelPath);
+  MultibodyPlant<double> iiwa(0);
+  Parser(&iiwa).AddModels(kModelPath);
   iiwa.WeldFrames(iiwa.world_frame(),
                   iiwa.GetBodyByName("base").body_frame());
   iiwa.Finalize();
 
   const std::string kEndEffectorLinkName = "iiwa_link_ee";
-  const multibody::Body<double>& end_effector =
+  const Body<double>& end_effector =
       iiwa.GetBodyByName(kEndEffectorLinkName);
 
   ConstraintRelaxingIk ik_planner(kModelPath, kEndEffectorLinkName);
@@ -108,6 +107,5 @@ GTEST_TEST(ConstraintRelaxingIkTest, SolveIkFromFk) {
       waypoints, kQcurrent, &q_sol, never_stop));
 }
 
-}  // namespace planner
-}  // namespace manipulation
+}  // namespace multibody
 }  // namespace drake


### PR DESCRIPTION
Moves the *unbound* artifacts into `planning` with deprecated breadcrumbs.

 - manipulation/planner to multibody/inverse_kinematics
   - constraint_relaxing_ik
 - manipulation/planner to manipulation/util
    - robot_plan_interpolator

Moving includes updating all references and namespaces.

relates #18640

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18664)
<!-- Reviewable:end -->
