### PR TITLE
Enforce external upgrades in "cohorts"

### DIFF
--- a/tools/workspace/gz_math_internal/repository.bzl
+++ b/tools/workspace/gz_math_internal/repository.bzl
@@ -7,6 +7,9 @@ def gz_math_internal_repository(
         mirrors = None):
     github_archive(
         name = name,
+        # This dependency is part of a "cohort" defined in
+        # drake/tools/workspace/new_release.py.  When practical, all members
+        # of this cohort should be updated at the same time.
         repository = "gazebosim/gz-math",
         commit = "gz-math7_7.1.0",
         sha256 = "3df09a16b84fa27fabf4955b5efb207f417ef9b0b5b801ae28cfda6d8e11765a",  # noqa

--- a/tools/workspace/gz_utils_internal/repository.bzl
+++ b/tools/workspace/gz_utils_internal/repository.bzl
@@ -7,6 +7,9 @@ def gz_utils_internal_repository(
         mirrors = None):
     github_archive(
         name = name,
+        # This dependency is part of a "cohort" defined in
+        # drake/tools/workspace/new_release.py.  When practical, all members
+        # of this cohort should be updated at the same time.
         repository = "gazebosim/gz-utils",
         commit = "gz-utils2_2.0.0",
         sha256 = "af9e5b862e10aa0cedd97d9c5ca3eb9a443b7c9e560a083e8f0399e93e1cfafa",  # noqa

--- a/tools/workspace/mypy_extensions_internal/repository.bzl
+++ b/tools/workspace/mypy_extensions_internal/repository.bzl
@@ -7,6 +7,9 @@ def mypy_extensions_internal_repository(
         mirrors = None):
     github_archive(
         name = name,
+        # This dependency is part of a "cohort" defined in
+        # drake/tools/workspace/new_release.py.  When practical, all members
+        # of this cohort should be updated at the same time.
         repository = "python/mypy_extensions",
         commit = "0.4.3",
         sha256 = "21e830f4baf996d0a9bd7048a5b23722dbd3b88354b8bf0e22376f9a8d508c16",  # noqa

--- a/tools/workspace/mypy_internal/repository.bzl
+++ b/tools/workspace/mypy_internal/repository.bzl
@@ -7,6 +7,9 @@ def mypy_internal_repository(
         mirrors = None):
     github_archive(
         name = name,
+        # This dependency is part of a "cohort" defined in
+        # drake/tools/workspace/new_release.py.  When practical, all members
+        # of this cohort should be updated at the same time.
         repository = "python/mypy",
         commit = "v0.991",
         sha256 = "a88d446622657e5ef455e9e3a1693c6732a5b8311a17bec90ba103c8e39db3d5",  # noqa

--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -36,19 +36,20 @@ command line.
 import argparse
 import getpass
 import git
-import glob
+import github3
 import hashlib
 import json
 import logging
 import os
 import re
+import shlex
 import subprocess
-import sys
-from tempfile import TemporaryDirectory
 import time
 import urllib
 
-import github3
+from dataclasses import dataclass
+from tempfile import TemporaryDirectory
+from typing import List, Optional
 
 from drake.tools.workspace.metadata import read_repository_metadata
 
@@ -76,6 +77,24 @@ _OVERLOOK_RELEASE_REPOSITORIES = {
     "ros_xacro_internal": r"^(\d+\.\d+\.)",
     "sdformat_internal": "",
 }
+
+# Packages in these cohorts should be upgraded together (in a single commit).
+_COHORTS = (
+    # mypy uses mypy_extensions; be sure to keep them aligned.
+    {"mypy_internal", "mypy_extensions_internal"},
+    # sdformat depends on both gz libraries; be sure to keep them aligned.
+    {"sdformat_internal", "gz_math_internal", "gz_utils_internal"},
+    # uwebsockets depends on usockets; be sure to keep them aligned.
+    {"uwebsockets", "usockets"},
+)
+
+
+@dataclass
+class UpgradeResult:
+    was_upgraded: bool
+    can_be_committed: bool = False
+    modified_paths: Optional[List[str]] = None
+    commit_message: Optional[str] = None
 
 
 def _check_output(args):
@@ -219,7 +238,27 @@ def _is_modified(repo, path):
     return False
 
 
+def _do_commit(local_drake_checkout, actually_commit,
+               workspace_names, paths, message):
+    if actually_commit:
+        names = ", ".join(workspace_names)
+        path_args = zip(['-o'] * len(paths), paths)
+        local_drake_checkout.git.commit(
+            *path_args, '-m', "[workspace] " + message)
+        print("\n" + ("*" * 72))
+        print(f"Done.  Changes for {names} were committed.")
+        print("Be sure to review the changes and amend the commit if needed.")
+        print(("*" * 72) + "\n")
+    else:
+        print("\n" + ("*" * 72))
+        print("Done.  Be sure to review and commit the changes:")
+        print(f"  git add {' '.join([shlex.quote(p) for p in paths])}")
+        print(f"  git commit -m{shlex.quote('[workspace] ' + message)}")
+        print(("*" * 72) + "\n")
+
+
 def _do_upgrade(temp_dir, gh, local_drake_checkout, workspace_name, metadata):
+    """Returns an `UpgradeResult` describing what (if anything) was done."""
     if workspace_name not in metadata:
         raise RuntimeError(f"Unknown repository {workspace_name}")
     data = metadata[workspace_name]
@@ -237,16 +276,16 @@ def _do_upgrade(temp_dir, gh, local_drake_checkout, workspace_name, metadata):
         if _is_modified(local_drake_checkout, bzl_filename):
             print(f"{bzl_filename} has local changes.")
             print(f"Changes made for {workspace_name} will NOT be committed.")
-            commit = False
+            can_commit = False
         else:
-            commit = True
+            can_commit = True
     else:
-        commit = False
+        can_commit = False
 
     # Figure out what to upgrade.
     old_commit, new_commit = _handle_github(workspace_name, gh, data)
     if old_commit == new_commit:
-        raise RuntimeError(f"No upgrade needed for {workspace_name}")
+        return UpgradeResult(False)
     elif new_commit is None:
         raise RuntimeError(f"Cannot auto-upgrade {workspace_name}")
     print("Upgrading {} from {} to {}".format(
@@ -264,12 +303,10 @@ def _do_upgrade(temp_dir, gh, local_drake_checkout, workspace_name, metadata):
         if match:
             assert commit_line_num is None
             commit_line_num = i
-            commit_line_match = match
         match = checksum_line_re.search(line)
         if match:
             assert checksum_line_num is None
             checksum_line_num = i
-            checksum_line_match = match
     assert commit_line_num is not None
     assert checksum_line_num is not None
 
@@ -301,24 +338,53 @@ def _do_upgrade(temp_dir, gh, local_drake_checkout, workspace_name, metadata):
     print("Populating repository cache ...")
     subprocess.check_call(["bazel", "fetch", "//...", f"--distdir={temp_dir}"])
 
-    message = f"[workspace] Upgrade {workspace_name}"
+    message = f"Upgrade {workspace_name} to latest"
     if _smells_like_a_git_commit(new_commit):
-        message += " to latest commit"
+        message += " commit"
     else:
-        message += f" to latest release {new_commit}"
+        message += f" release {new_commit}"
 
-    if commit:
-        local_drake_checkout.git.commit('-o', bzl_filename, '-m', message)
-        print("\n" + ("*" * 72))
-        print(f"Done.  Changes for {workspace_name} were committed.")
-        print("Be sure to review the changes and amend the commit if needed.")
-        print(("*" * 72) + "\n")
+    return UpgradeResult(True, can_commit, [bzl_filename], message)
+
+
+def _do_upgrades(temp_dir, gh, local_drake_checkout,
+                 workspace_names, metadata):
+
+    # Make sure there are workspaces to update.
+    if len(workspace_names) == 0:
+        return
+
+    can_commit = True
+    modified_paths = []
+    commit_messages = []
+    modified_workspace_names = []
+    for workspace_name in workspace_names:
+        result = _do_upgrade(temp_dir, gh, local_drake_checkout,
+                             workspace_name, metadata)
+        if result.was_upgraded:
+            can_commit = can_commit and result.can_be_committed
+            modified_paths += result.modified_paths
+            commit_messages.append(result.commit_message)
+            modified_workspace_names.append(workspace_name)
+        elif len(workspace_names) == 1:
+            raise RuntimeError(f"No upgrade needed for {workspace_name}")
+
+    # Determine if we should and can commit the changes made.
+    if len(modified_workspace_names) == 1:
+        _do_commit(local_drake_checkout, actually_commit=can_commit,
+                   workspace_names=modified_workspace_names,
+                   paths=modified_paths, message=commit_messages[0])
     else:
-        print("\n" + ("*" * 72))
-        print("Done.  Be sure to review and commit the changes:")
-        print(f"  git add {bzl_filename}")
-        print(f"  git commit -m'{message}'")
-        print(("*" * 72) + "\n")
+        cohort = ', '.join(modified_workspace_names)
+
+        if not can_commit:
+            print(f"Changes made for {cohort} will NOT be committed.")
+
+        message = f"Upgrade {cohort} to latest\n\n"
+        message += "- " + "\n- ".join(commit_messages)
+        _do_commit(local_drake_checkout, actually_commit=can_commit,
+                   workspace_names=modified_workspace_names,
+                   paths=modified_paths, message=message)
 
 
 def main():
@@ -373,7 +439,14 @@ def main():
 
     # Are we operating on all repositories, or just one?
     if len(args.workspace):
-        workspaces = args.workspace
+        workspaces = set(args.workspace)
+
+        # Grow the set of specified repositories to cover cohorts.
+        for workspace in args.workspace:
+            for cohort in _COHORTS:
+                if workspace in cohort:
+                    workspaces.update(cohort)
+
     else:
         if args.commit:
             parser.error("--commit requires one or more workspaces.")
@@ -392,10 +465,23 @@ def main():
         print(json.dumps(metadata, sort_keys=True, indent=2))
 
     if workspaces is not None:
+        visited_workspaces = set()
         for workspace in workspaces:
+            # If we already did this as part of a tandem upgrade, skip it.
+            if workspace in visited_workspaces:
+                continue
+
+            # Determine if this workspace is part of a cohort.
+            cohort_workspaces = {workspace}
+            for cohort in _COHORTS:
+                if workspace in cohort:
+                    cohort_workspaces = cohort
+
+            # Actually do the upgrade(s).
             with TemporaryDirectory(prefix='drake_new_release_') as temp_dir:
-                _do_upgrade(temp_dir, gh, local_drake_checkout,
-                            workspace, metadata)
+                _do_upgrades(temp_dir, gh, local_drake_checkout,
+                             cohort_workspaces, metadata)
+                visited_workspaces.update(cohort_workspaces)
     else:
         # Run our report of what's available.
         print("Checking for new releases...")

--- a/tools/workspace/sdformat_internal/repository.bzl
+++ b/tools/workspace/sdformat_internal/repository.bzl
@@ -7,6 +7,9 @@ def sdformat_internal_repository(
         mirrors = None):
     github_archive(
         name = name,
+        # This dependency is part of a "cohort" defined in
+        # drake/tools/workspace/new_release.py.  When practical, all members
+        # of this cohort should be updated at the same time.
         repository = "gazebosim/sdformat",
         commit = "sdformat13_13.2.0",
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/usockets/repository.bzl
+++ b/tools/workspace/usockets/repository.bzl
@@ -7,6 +7,9 @@ def usockets_repository(
         mirrors = None):
     github_archive(
         name = name,
+        # This dependency is part of a "cohort" defined in
+        # drake/tools/workspace/new_release.py.  When practical, all members
+        # of this cohort should be updated at the same time.
         repository = "uNetworking/uSockets",
         commit = "v0.8.5",
         sha256 = "c52c98b7ff2c24534c17ad97d5fea8ca0cb7ff38cc933b8d08bac6e498a2ea6b",  # noqa

--- a/tools/workspace/uwebsockets/repository.bzl
+++ b/tools/workspace/uwebsockets/repository.bzl
@@ -7,6 +7,9 @@ def uwebsockets_repository(
         mirrors = None):
     github_archive(
         name = name,
+        # This dependency is part of a "cohort" defined in
+        # drake/tools/workspace/new_release.py.  When practical, all members
+        # of this cohort should be updated at the same time.
         repository = "uNetworking/uWebSockets",
         commit = "v20.35.0",
         sha256 = "907431acec1d480f6e5d29d8c8cc7ace1c96b31e45aebaa18a7e9512fb2f17fc",  # noqa


### PR DESCRIPTION
A `_COHORTS` constant has been added to the top of the `new_release` script, and checks have been added to enforce upgrades as a "cohort" for the groups of dependencies listed.  Additionally, a message was added to the relevant `repository.bzl` scripts to point to the `new_release` script.

Closes https://github.com/RobotLocomotion/drake/issues/18638.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18673)
<!-- Reviewable:end -->
