### PR TITLE
[pydrake] Fix incompatibility with Mypy

### DIFF
--- a/bindings/pydrake/test/stubgen_test.py
+++ b/bindings/pydrake/test/stubgen_test.py
@@ -32,10 +32,6 @@ class TestStubgen(unittest.TestCase):
         stubs_dir, paths = self._expected_pyi_files()
         self.assertGreater(len(paths), 0)
         for path in paths:
-            # TODO(jwnimmer-tri) This file still has several syntax errors.
-            # We should work to fix those, but for now we'll skip over it.
-            if path == "pydrake/solvers/__init__.pyi":
-                continue
             with self.subTest(pyi=path):
                 self._check_one_valid_syntax(stubs_dir, path)
 

--- a/common/symbolic/expression/formula.h
+++ b/common/symbolic/expression/formula.h
@@ -341,9 +341,9 @@ Formula isfinite(const Expression& e);
  *
  * @note This method checks if @p m is symmetric, which can be costly. If you
  * want to avoid it, please consider using
- * `positive_semidefinite(m.triangularView<...>())` instead of
- * `positive_semidefinite(m)`, where `...` is either `Eigen::Lower` or
- * `Eigen::Upper`.
+ * `positive_semidefinite(m.triangularView<Eigen::Lower>())` or
+ * `positive_semidefinite(m.triangularView<Eigen::Upper>())` instead of
+ * `positive_semidefinite(m)`.
  *
  * @pydrake_mkdoc_identifier{1args_m}
  */

--- a/multibody/tree/geometry_spatial_inertia.h
+++ b/multibody/tree/geometry_spatial_inertia.h
@@ -18,8 +18,9 @@ namespace multibody {
  (and, therefore, Bo). These are the shapes that have symmetry across So along
  each of the axes Sx, Sy, Sz (e.g., geometry::Box, geometry::Sphere, etc.) For
  meshes, it depends on how the mesh is defined. For more discussion on the
- nuances of geometry::Mesh and geometry::Convex calculations refer to the
- `mesh` overload, below.
+ nuances of geometry::Mesh and geometry::Convex calculations
+ @ref CalcSpatialInertia(const geometry::TriangleSurfaceMesh<double>&,double)
+ "see below".
 
  Note: Spatial inertia calculations for the geometry::Convex type do not
  currently require that the underlying mesh actually be convex. Although certain
@@ -28,7 +29,8 @@ namespace multibody {
 
  @retval M_BBo_B The spatial inertia of the hypothetical body implied by the
                  given `shape`.
- @throws std::exception if `shape` is not supported (e.g., a half space)
+ @throws std::exception if `shape` is an instance of geometry::HalfSpace or
+                        geometry::MeshcatCone.
  @pydrake_mkdoc_identifier{shape} */
 SpatialInertia<double> CalcSpatialInertia(const geometry::Shape& shape,
                                           double density);

--- a/tools/workspace/mypy_internal/patches/reject_double_colon.patch
+++ b/tools/workspace/mypy_internal/patches/reject_double_colon.patch
@@ -1,0 +1,26 @@
+Fix mis-parsing of double colon ("::")
+
+When parsing the docstrings of a function to find its set of overloads,
+C++ code samples that mention the function name were at risk of matching
+the C++ scoping operator "::" as a type annotation, leading to malformed
+output. For example "MyFunc(foo: int) -> bool" is a valid signature, but
+the sample code "MyFunc(Eigen::Lower)" was being mis-parsed. Fix this by
+patching stubgen to reset in case it sees a double colon.
+
+--- mypy/stubdoc.py
++++ mypy/stubdoc.py
+@@ -139,6 +139,14 @@
+ 
+         elif (
+             token.type == tokenize.OP
++            and token.string == ":"
++            and self.state[-1] == STATE_ARGUMENT_TYPE
++        ):
++            self.reset()
++            return
++
++        elif (
++            token.type == tokenize.OP
+             and token.string == "="
+             and self.state[-1] in (STATE_ARGUMENT_LIST, STATE_ARGUMENT_TYPE)
+         ):

--- a/tools/workspace/mypy_internal/repository.bzl
+++ b/tools/workspace/mypy_internal/repository.bzl
@@ -12,6 +12,7 @@ def mypy_internal_repository(
         sha256 = "a88d446622657e5ef455e9e3a1693c6732a5b8311a17bec90ba103c8e39db3d5",  # noqa
         build_file = ":package.BUILD.bazel",
         patches = [
+            ":patches/reject_double_colon.patch",
             ":patches/timeout.patch",
         ],
         mirrors = mirrors,


### PR DESCRIPTION
When parsing the docstrings of a function to find its set of overloads, C++ code samples that mention the function name were at risk of matching the C++ scoping operator `::` as a type annotation, leading to malformed output. For example `MyFunc(foo : int) -> bool` is a valid signature, but the sample code `MyFunc(Eigen::Lower)` was being mis-parsed. Fix this by patching stubgen to reset in case it sees a double colon.

Enable the stubgen regression for all of pydrake; no more caveats.

Revert da58ae08 and 2cf04fdc header file changes, which were work-arounds for this parsing bug and are no longer needed.

Closes #18580.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18674)
<!-- Reviewable:end -->
