### PR TITLE
[pydrake] Add pydrake.planning to pydrake.all

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -741,7 +741,7 @@ PYI_FILES = [
     "pydrake/multibody/plant.pyi",
     "pydrake/multibody/tree.pyi",
     "pydrake/perception.pyi",
-    "pydrake/planning/__init__.pyi",
+    "pydrake/planning.pyi",
     "pydrake/polynomial.pyi",
     "pydrake/solvers/__init__.pyi",
     "pydrake/solvers/_extra.pyi",

--- a/bindings/pydrake/all.py
+++ b/bindings/pydrake/all.py
@@ -41,6 +41,7 @@ from .forwarddiff import *
 from .lcm import *
 from .math import *
 from .perception import *
+from .planning import *
 from .polynomial import *
 from .symbolic import *
 from .trajectories import *

--- a/bindings/pydrake/planning/BUILD.bazel
+++ b/bindings/pydrake/planning/BUILD.bazel
@@ -44,9 +44,6 @@ drake_pybind_library(
         "//bindings/pydrake/multibody:parsing_py",
         "//bindings/pydrake/multibody:plant_py",
     ],
-    py_srcs = [
-        "all.py",
-    ],
 )
 
 install(

--- a/bindings/pydrake/planning/all.py
+++ b/bindings/pydrake/planning/all.py
@@ -1,1 +1,0 @@
-from pydrake.planning import *

--- a/bindings/pydrake/test/all_test.py
+++ b/bindings/pydrake/test/all_test.py
@@ -142,6 +142,8 @@ class TestAll(unittest.TestCase):
             "MultibodyForces",
             # perception
             "PointCloud",
+            # planning
+            "RobotDiagram",
             # solvers
             # - agumented_lagrangian
             "AugmentedLagrangianSmooth",


### PR DESCRIPTION
Missed in #18650.  (New modules always need to be specifically added to our lists.)

Since we don't intend to have sub-modules under `pydrake.planning`, we don't need the ` pydrake.planning.all` sugar either.

+@SeanCurtis-TRI for both reviews, please.

\CC @xuchenhan-tri FYI