### PR TITLE
[workspace] Better hide ccd and fcl externals

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -145,6 +145,7 @@ drake_cc_library(
     deps = [
         ":collision_filter",
         ":proximity_utilities",
+        "//common:drake_export",
         "//geometry:geometry_ids",
         "@fcl_internal//:fcl",
     ],
@@ -230,6 +231,7 @@ drake_cc_library(
     deps = [
         ":proximity_utilities",
         "//common:default_scalars",
+        "//common:drake_export",
         "//common:essential",
         "//geometry:geometry_ids",
         "//geometry/query_results:signed_distance_to_point",
@@ -251,6 +253,7 @@ drake_cc_library(
         ":distance_to_point_callback",
         ":proximity_utilities",
         "//common:default_scalars",
+        "//common:drake_export",
         "//common:nice_type_name",
         "//geometry/query_results:signed_distance_pair",
     ],
@@ -284,6 +287,7 @@ drake_cc_library(
     deps = [
         ":collision_filter",
         ":proximity_utilities",
+        "//common:drake_export",
         "//common:sorted_pair",
         "@fcl_internal//:fcl",
         "@fmt",
@@ -308,6 +312,7 @@ drake_cc_library(
         ":proximity_utilities",
         ":triangle_surface_mesh",
         ":volume_mesh",
+        "//common:drake_export",
         "//common:hash",
         "//geometry:proximity_properties",
         "//geometry/query_results:contact_surface",
@@ -680,6 +685,7 @@ drake_cc_library(
         ":collision_filter",
         ":distance_to_point_callback",
         "//common:default_scalars",
+        "//common:drake_export",
         "//common:nice_type_name",
         "//geometry/query_results:penetration_as_point_pair",
         "//geometry/query_results:signed_distance_to_point",
@@ -731,6 +737,7 @@ drake_cc_library(
     deps = [
         ":sorted_triplet",
         ":volume_mesh",
+        "//common:drake_export",
         "//common:sorted_pair",
         "//geometry:geometry_ids",
         "//geometry:shape_specification",
@@ -863,6 +870,7 @@ drake_cc_library(
     visibility = ["//visibility:private"],
     deps = [
         ":collision_filter",
+        "//common:drake_export",
         "//common:temp_directory",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",

--- a/geometry/proximity/collisions_exist_callback.h
+++ b/geometry/proximity/collisions_exist_callback.h
@@ -1,15 +1,16 @@
 #pragma once
 
-#include <fcl/fcl.h>
+#include <drake_vendor/fcl/fcl.h>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_export.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/proximity/collision_filter.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
-namespace has_collisions {
+namespace has_collisions DRAKE_NO_EXPORT {
 
 /* Supporting data for the collisions exist callback (see Callback below).
    It includes:

--- a/geometry/proximity/distance_to_point_callback.h
+++ b/geometry/proximity/distance_to_point_callback.h
@@ -6,9 +6,10 @@
 #include <unordered_map>
 #include <vector>
 
-#include <fcl/fcl.h>
+#include <drake_vendor/fcl/fcl.h>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_export.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/proximity/proximity_utilities.h"
@@ -18,7 +19,7 @@
 namespace drake {
 namespace geometry {
 namespace internal {
-namespace point_distance {
+namespace point_distance DRAKE_NO_EXPORT {
 
 /* Supporting data for the distance-to-point callback (see Callback below).
  It includes:

--- a/geometry/proximity/distance_to_shape_callback.h
+++ b/geometry/proximity/distance_to_shape_callback.h
@@ -3,8 +3,9 @@
 #include <unordered_map>
 #include <vector>
 
-#include <fcl/fcl.h>
+#include <drake_vendor/fcl/fcl.h>
 
+#include "drake/common/drake_export.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/geometry/geometry_ids.h"
@@ -19,7 +20,7 @@
 namespace drake {
 namespace geometry {
 namespace internal {
-namespace shape_distance {
+namespace shape_distance DRAKE_NO_EXPORT {
 
 /* Supporting data for the shape-to-shape signed distance callback (see
  Callback below). It includes:

--- a/geometry/proximity/find_collision_candidates_callback.h
+++ b/geometry/proximity/find_collision_candidates_callback.h
@@ -4,9 +4,10 @@
 #include <utility>
 #include <vector>
 
-#include <fcl/fcl.h>
+#include <drake_vendor/fcl/fcl.h>
 #include <fmt/format.h>
 
+#include "drake/common/drake_export.h"
 #include "drake/common/sorted_pair.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/proximity/collision_filter.h"
@@ -14,7 +15,7 @@
 namespace drake {
 namespace geometry {
 namespace internal {
-namespace find_collision_candidates {
+namespace find_collision_candidates DRAKE_NO_EXPORT {
 
 /* Supporting data for the collision candidates callback (see Callback below).
    It includes:

--- a/geometry/proximity/hydroelastic_callback.h
+++ b/geometry/proximity/hydroelastic_callback.h
@@ -5,9 +5,10 @@
 #include <utility>
 #include <vector>
 
-#include <fcl/fcl.h>
+#include <drake_vendor/fcl/fcl.h>
 #include <fmt/format.h>
 
+#include "drake/common/drake_export.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/proximity/collision_filter.h"
@@ -26,7 +27,7 @@
 namespace drake {
 namespace geometry {
 namespace internal {
-namespace hydroelastic {
+namespace hydroelastic DRAKE_NO_EXPORT {
 
 /* Supporting data for the shape-to-shape hydroelastic contact callback (see
  Callback below). It includes:

--- a/geometry/proximity/penetration_as_point_pair_callback.h
+++ b/geometry/proximity/penetration_as_point_pair_callback.h
@@ -3,8 +3,9 @@
 #include <unordered_map>
 #include <vector>
 
-#include <fcl/fcl.h>
+#include <drake_vendor/fcl/fcl.h>
 
+#include "drake/common/drake_export.h"
 #include "drake/geometry/proximity/collision_filter.h"
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
 #include "drake/math/rigid_transform.h"
@@ -12,7 +13,7 @@
 namespace drake {
 namespace geometry {
 namespace internal {
-namespace penetration_as_point_pair {
+namespace penetration_as_point_pair DRAKE_NO_EXPORT {
 
 /* Supporting data for the detecting collision between geometries and reporting
  them as a pair of points (see PenetrationAsPointPair). It includes:

--- a/geometry/proximity/proximity_utilities.h
+++ b/geometry/proximity/proximity_utilities.h
@@ -5,16 +5,17 @@
 #include <string>
 #include <vector>
 
-#include <fcl/fcl.h>
+#include <drake_vendor/fcl/fcl.h>
 #include <fmt/format.h>
 
+#include "drake/common/drake_export.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/proximity/volume_mesh.h"
 #include "drake/geometry/shape_specification.h"
 
 namespace drake {
 namespace geometry {
-namespace internal {
+namespace internal DRAKE_NO_EXPORT {
 
 // TODO(SeanCurtis-TRI): Given the dependencies on fcl for this file, the name
 //  should reflect it so that it doesn't get included in files that will

--- a/geometry/proximity/test/characterization_utilities.h
+++ b/geometry/proximity/test/characterization_utilities.h
@@ -15,10 +15,11 @@
 #include <utility>
 #include <vector>
 
-#include <fcl/fcl.h>
+#include <drake_vendor/fcl/fcl.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/default_scalars.h"
+#include "drake/common/drake_export.h"
 #include "drake/common/unused.h"
 #include "drake/geometry/proximity/collision_filter.h"
 #include "drake/geometry/shape_specification.h"
@@ -217,7 +218,7 @@ class ShapeConfigurations : public ShapeReifier {
 };
 
 /* @name Fcl geometry from drake shape specifications. */
-class MakeFclShape : public ShapeReifier {
+class DRAKE_NO_EXPORT MakeFclShape : public ShapeReifier {
  public:
   explicit MakeFclShape(const Shape& shape);
 

--- a/geometry/proximity/test/collisions_exist_callback_test.cc
+++ b/geometry/proximity/test/collisions_exist_callback_test.cc
@@ -2,7 +2,7 @@
 
 #include <utility>
 
-#include <fcl/fcl.h>
+#include <drake_vendor/fcl/fcl.h>
 #include <gtest/gtest.h>
 
 #include "drake/geometry/proximity/proximity_utilities.h"

--- a/geometry/proximity/test/distance_sphere_to_shape_test.cc
+++ b/geometry/proximity/test/distance_sphere_to_shape_test.cc
@@ -4,7 +4,7 @@
 #include <utility>
 #include <vector>
 
-#include <fcl/fcl.h>
+#include <drake_vendor/fcl/fcl.h>
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/distance_to_point_callback_test.cc
+++ b/geometry/proximity/test/distance_to_point_callback_test.cc
@@ -1,6 +1,6 @@
 #include "drake/geometry/proximity/distance_to_point_callback.h"
 
-#include <fcl/fcl.h>
+#include <drake_vendor/fcl/fcl.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/geometry/proximity/test/find_collision_candidates_callback_test.cc
+++ b/geometry/proximity/test/find_collision_candidates_callback_test.cc
@@ -3,7 +3,7 @@
 #include <utility>
 #include <vector>
 
-#include <fcl/fcl.h>
+#include <drake_vendor/fcl/fcl.h>
 #include <gtest/gtest.h>
 
 #include "drake/geometry/proximity/proximity_utilities.h"

--- a/geometry/proximity/test/hydroelastic_callback_test.cc
+++ b/geometry/proximity/test/hydroelastic_callback_test.cc
@@ -5,7 +5,7 @@
 #include <utility>
 #include <vector>
 
-#include <fcl/fcl.h>
+#include <drake_vendor/fcl/fcl.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_no_throw.h"

--- a/geometry/proximity/test/proximity_utilities_test.cc
+++ b/geometry/proximity/test/proximity_utilities_test.cc
@@ -3,7 +3,7 @@
 #include <memory>
 #include <sstream>
 
-#include <fcl/fcl.h>
+#include <drake_vendor/fcl/fcl.h>
 #include <gtest/gtest.h>
 
 namespace drake {

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -7,7 +7,7 @@
 #include <utility>
 #include <vector>
 
-#include <fcl/fcl.h>
+#include <drake_vendor/fcl/fcl.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -49,6 +49,7 @@ drake_py_binary(
     srcs = ["vendor_cxx.py"],
     visibility = [
         # These should all be of the form "@foo_internal//:__pkg__".
+        "@fcl_internal//:__pkg__",
         "@gz_math_internal//:__pkg__",
         "@gz_utils_internal//:__pkg__",
         "@msgpack_internal//:__pkg__",

--- a/tools/workspace/ccd/package.BUILD.bazel
+++ b/tools/workspace/ccd/package.BUILD.bazel
@@ -37,6 +37,8 @@ CCD_PUBLIC_HEADERS = [
 # Options used when building the ccd code. Handled by cmake in upstream code
 CCD_COPTS = [
     "-Wno-all",
+    # N.B. Because ccd is C code (not C++ code), we can set hidden visibility
+    # globally, rather than laundering it though our vendor_cxx tool.
     "-fvisibility=hidden",
 ]
 

--- a/tools/workspace/ccd_internal/package.BUILD.bazel
+++ b/tools/workspace/ccd_internal/package.BUILD.bazel
@@ -8,59 +8,66 @@ load(
     "@drake//tools/install:install.bzl",
     "install",
 )
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "cc_linkonly_library",
+)
 
 licenses(["notice"])  # BSD-3-Clause
 
-package(
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:private"])
 
-# Generates config.h based on the defines= we want in Drake.
+# Generate config.h based on the defines= we want in Drake.
 cmake_configure_file(
     name = "config",
     src = "src/ccd/config.h.cmake.in",
     out = "src/ccd/config.h",
+    strict = True,
     defines = ["CCD_DOUBLE"],
-    visibility = ["//visibility:private"],
+    undefines = ["CCD_SINGLE"],
 )
 
-# Guessing headers with
-#       install(...
-#          guess_hdrs = "PACKAGE",
-#         )
-# fails and lists internal headers in addition to the public headers.
-CCD_PUBLIC_HEADERS = [
-    "src/ccd/ccd.h",
-    "src/ccd/config.h",
-    "src/ccd/compiler.h",
-    "src/ccd/quat.h",
-    "src/ccd/vec3.h",
-    "src/ccd/ccd_export.h",
-]
-
-# Options used when building the ccd code. Handled by cmake in upstream code
-CCD_COPTS = [
-    "-Wno-all",
-    "-fvisibility=hidden",
-]
-
-# Generates the library exported to users.  Upstream's CMake code lists out all
-# sources instead of globbing, but conveniently puts the public headers in one
-# place and private sources and headers in another; we'll use globbing here.
+# Group the headers exported by this library.
 cc_library(
-    name = "ccd",
-    srcs = glob([
-        "src/*.c",
-        "src/*.h",
-    ]),
-    hdrs = CCD_PUBLIC_HEADERS,
-    copts = CCD_COPTS,
+    name = "hdrs",
+    hdrs = [":config"] + glob(["src/ccd/*.h"], allow_empty = False),
     defines = ["CCD_STATIC_DEFINE"],
     includes = ["src"],
-    linkstatic = 1,
+)
+
+# Compile the code (using both its exported headers and its private headers).
+cc_library(
+    name = "compiled",
+    srcs = glob(["src/*.c", "src/*.h"], allow_empty = False),
+    copts = [
+        "-Wno-all",
+        "-fvisibility=hidden",
+    ],
+    includes = ["src"],
+    linkstatic = True,
+    deps = [":hdrs"],
+)
+
+# Strip the private headers out; we just want the object code.
+cc_linkonly_library(
+    name = "archive",
+    deps = [":compiled"],
+)
+
+# Combine the public headers with the object code.
+# This does not provide the private headers.
+cc_library(
+    name = "ccd",
+    linkstatic = True,
+    deps = [
+        ":archive",
+        ":hdrs",
+    ],
+    visibility = ["//visibility:public"],
 )
 
 install(
     name = "install",
     docs = ["BSD-LICENSE"],
+    visibility = ["//visibility:public"],
 )

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -125,6 +125,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
     if "cc" not in excludes:
         cc_repository(name = "cc")
     if "ccd" not in excludes:
+        # N.B. This repository is deprecated for removal on 2023-05-01.
+        # For details see https://github.com/RobotLocomotion/drake/pull/18611.
         ccd_repository(name = "ccd", mirrors = mirrors)
     if "ccd_internal" not in excludes:
         ccd_internal_repository(name = "ccd_internal", mirrors = mirrors)
@@ -159,6 +161,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
     if "expat" not in excludes:
         expat_repository(name = "expat")
     if "fcl" not in excludes:
+        # N.B. This repository is deprecated for removal on 2023-05-01.
+        # For details see https://github.com/RobotLocomotion/drake/pull/18611.
         fcl_repository(name = "fcl", mirrors = mirrors)
     if "fcl_internal" not in excludes:
         fcl_internal_repository(name = "fcl_internal", mirrors = mirrors)

--- a/tools/workspace/fcl_internal/package.BUILD.bazel
+++ b/tools/workspace/fcl_internal/package.BUILD.bazel
@@ -16,6 +16,10 @@ load(
     "@drake//tools/workspace:generate_include_header.bzl",
     "drake_generate_include_header",
 )
+load(
+    "@drake//tools/workspace:vendor_cxx.bzl",
+    "cc_library_vendored",
+)
 
 licenses(["notice"])  # BSD-3-Clause
 
@@ -30,45 +34,33 @@ generate_export_header(
     static_define = "FCL_STATIC_DEFINE",
 )
 
-# Generates a version.cmake stub based on package.xml contents.
-genrule(
-    name = "version-from-xml.cmake_genrule",
-    srcs = [
-        "package.xml",
-        "@drake//tools/workspace/fcl_internal:version-from-xml.sed",
-    ],
-    outs = [
-        "version-from-xml.cmake",
-    ],
-    cmd = " ".join([
-        "sed",
-        "-f $(execpath @drake//tools/workspace/fcl_internal:version-from-xml.sed)",  # noqa
-        "-n $(execpath package.xml) > $@",
-        "&&",
-        "test -s $@",
-    ]),
-)
-
-# Generates config.h based on the version numbers in CMake code.
+# Generate config.h.
 cmake_configure_file(
     name = "config",
     src = "include/fcl/config.h.in",
     out = "include/fcl/config.h",
-    cmakelists = [
-        ":version-from-xml.cmake",
-    ],
+    strict = True,
     defines = [
+        "FCL_VERSION=\"0.0.0\"",
+        "FCL_MAJOR_VERSION=0",
+        "FCL_MINOR_VERSION=0",
+        "FCL_PATCH_VERSION=0",
         "OCTOMAP_MAJOR_VERSION=0",
         "OCTOMAP_MINOR_VERSION=0",
         "OCTOMAP_PATCH_VERSION=0",
         "GENERATED_FILE_MARKER=GENERATED FILE DO NOT EDIT",
+    ],
+    undefines = [
+        "FCL_ENABLE_PROFILING",
+        "FCL_HAVE_OCTOMAP",
+        "FCL_HAVE_SSE",
     ],
     visibility = ["//visibility:private"],
 )
 
 # Provide all headers (except octomap-related ones) for simplicitly, even
 # though many of these will not have their '*.cpp' mate compiled.
-_HDRS = glob(
+_HDRS_GLOB = glob(
     include = [
         "include/**/*.h",
     ],
@@ -80,7 +72,7 @@ _HDRS = glob(
 
 # To minimize the build footprint, only build the fraction of FCL that is
 # needed by Drake.
-_DRAKE_RELEVANT_SRCS = glob(
+_SRCS = glob(
     include = [
         "src/**/*.cpp",
     ],
@@ -115,23 +107,37 @@ _DRAKE_RELEVANT_SRCS = glob(
 drake_generate_include_header(
     name = "fcl_h_genrule",
     out = "include/fcl/fcl.h",
-    hdrs = _HDRS,
+    hdrs = _HDRS_GLOB,
 )
 
-cc_library(
+# All headers -- those from upstream directly, plus our generated headers.
+_HDRS = _HDRS_GLOB + [
+    "include/fcl/config.h",
+    "include/fcl/fcl.h",
+    "include/fcl/export.h",
+]
+
+cc_library_vendored(
     name = "fcl",
-    srcs = _DRAKE_RELEVANT_SRCS,
-    hdrs = _HDRS + [
-        ":config",
-        ":fcl_h_genrule",
-        ":include/fcl/export.h",
+    srcs = _SRCS,
+    srcs_vendored = [
+        x.replace("src/", "drake_src/src/")
+        for x in _SRCS
     ],
+    hdrs = _HDRS,
+    hdrs_vendored = [
+        x.replace("include/fcl/", "drake_src/drake_vendor/fcl/")
+        for x in _HDRS
+    ],
+    edit_include = {
+        "fcl/": "drake_vendor/fcl/",
+    },
     copts = ["-fvisibility=hidden"],
     defines = [
         "FCL_STATIC_DEFINE",
     ],
-    includes = ["include"],
-    linkstatic = 1,
+    includes = ["drake_src"],
+    linkstatic = True,
     deps = [
         "@ccd_internal//:ccd",
         "@eigen",

--- a/tools/workspace/fcl_internal/version-from-xml.sed
+++ b/tools/workspace/fcl_internal/version-from-xml.sed
@@ -1,4 +1,0 @@
-s|.*<version>\(\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)\)</version>.*|set(FCL_VERSION \1)\
-set(FCL_MAJOR_VERSION \2)\
-set(FCL_MINOR_VERSION \3)\
-set(FCL_PATCH_VERSION \4)|p


### PR DESCRIPTION
Fix `ccd` BUILD file to disallow things like `#include "polytope.h"` which previously resolved to its `src` directory.

Remove unnecessary fcl version rules; use strict genrule checking.

Towards #17231.

- [x] Requires #18677 first.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18678)
<!-- Reviewable:end -->
