### PR TITLE
[workspace] Patch FCL for missing include statement

### DIFF
--- a/tools/workspace/fcl_internal/patches/cassert.patch
+++ b/tools/workspace/fcl_internal/patches/cassert.patch
@@ -1,0 +1,12 @@
+Add missing #include statement
+
+--- include/fcl/common/types.h
++++ include/fcl/common/types.h
+@@ -38,6 +38,7 @@
+ #ifndef FCL_DATA_TYPES_H
+ #define FCL_DATA_TYPES_H
+ 
++#include <cassert>
+ #include <cstddef>
+ #include <cstdint>
+ #include <vector>

--- a/tools/workspace/fcl_internal/repository.bzl
+++ b/tools/workspace/fcl_internal/repository.bzl
@@ -11,5 +11,8 @@ def fcl_internal_repository(
         commit = "df2702ca5e703dec98ebd725782ce13862e87fc8",
         sha256 = "3ebcf2470a3ee372440cdec4cb78d1723411c3cf84f419679c2c85317c4c2dae",  # noqa
         build_file = ":package.BUILD.bazel",
+        patches = [
+            ":patches/cassert.patch",
+        ],
         mirrors = mirrors,
     )


### PR DESCRIPTION
Pre-release versions of Eigen have stopped including `<cassert>`, which exposes some places in FCL where its now missing.

Towards #17850.

I'm not submitting this patch to FCL upstream, since it's dead.

Example:
```console
external/fcl_internal/include/fcl/geometry/shape/convex-inl.h:68:3: error: there are no arguments to 'assert' that depend on a template parameter, so a declaration of 'assert' must be available [-fpermissive]
   68 |   assert(faces != nullptr);
```

+@ggould-tri for both reviews per schedule, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18694)
<!-- Reviewable:end -->
