### PR TITLE
[workspace] Patch Conex for missing include statement

### DIFF
--- a/tools/workspace/conex/patches/debug_macros.patch
+++ b/tools/workspace/conex/patches/debug_macros.patch
@@ -1,12 +1,13 @@
-Add a missing #include statement
+Add a missing #include statements
 
-See https://github.com/ToyotaResearchInstitute/conex/pull/3
+See https://github.com/ToyotaResearchInstitute/conex/pull/4
 
 --- conex/debug_macros.h
 +++ conex/debug_macros.h
-@@ -1,4 +1,5 @@
+@@ -1,4 +1,6 @@
  #pragma once
 +#include <array>
++#include <cassert>
  #include <chrono>
  #include <iomanip>
  #include <iostream>


### PR DESCRIPTION
Pre-release versions of Eigen have stopped including `<cassert>`, which exposes some places in Conex where its now missing.

See https://github.com/ToyotaResearchInstitute/conex/pull/4.

Towards https://github.com/RobotLocomotion/drake/pull/17850.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18695)
<!-- Reviewable:end -->
