### PR TITLE
[py systems] Allow simulator monitor to return None

### DIFF
--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -195,6 +195,10 @@ PYBIND11_MODULE(analysis, m) {
             // Keep alive, reference: `self` keeps `context` alive.
             py::keep_alive<1, 3>(), doc.RungeKutta3Integrator.ctor.doc);
 
+    // See equivalent note about EventCallback in `framework_py_systems.cc`.
+    using MonitorCallback =
+        std::function<std::optional<EventStatus>(const Context<T>&)>;
+
     auto cls = DefineTemplateClassWithDefault<Simulator<T>>(
         m, "Simulator", GetPyParam<T>(), doc.Simulator.doc);
     cls  // BR
@@ -211,7 +215,12 @@ PYBIND11_MODULE(analysis, m) {
             doc.Simulator.AdvanceTo.doc)
         .def("AdvancePendingEvents", &Simulator<T>::AdvancePendingEvents,
             doc.Simulator.AdvancePendingEvents.doc)
-        .def("set_monitor", WrapCallbacks(&Simulator<T>::set_monitor),
+        .def("set_monitor",
+            WrapCallbacks([](Simulator<T>* self, MonitorCallback monitor) {
+              self->set_monitor([monitor](const Context<T>& context) {
+                return monitor(context).value_or(EventStatus::DidNothing());
+              });
+            }),
             py::arg("monitor"), doc.Simulator.set_monitor.doc)
         .def("clear_monitor", &Simulator<T>::clear_monitor,
             doc.Simulator.clear_monitor.doc)

--- a/bindings/pydrake/systems/test/analysis_test.py
+++ b/bindings/pydrake/systems/test/analysis_test.py
@@ -170,12 +170,25 @@ class TestAnalysis(unittest.TestCase):
 
         simulator.set_monitor(monitor=monitor)
         # N.B. This will be round-trip wrapped via pybind11, but should be the
-        # same function underneath.w
+        # same function underneath.
         monitor_from_pybind = simulator.get_monitor()
         self.assertIsNot(monitor_from_pybind, monitor)
         self.assertEqual(monitor_called_count, 0)
         monitor_from_pybind(simulator.get_context())
         self.assertEqual(monitor_called_count, 1)
+        simulator.clear_monitor()
+
+        monitor_no_return_called_count = 0
+
+        def monitor_no_return(root_context):
+            nonlocal monitor_no_return_called_count
+            monitor_no_return_called_count += 1
+
+        simulator.set_monitor(monitor_no_return)
+        monitor_from_pybind = simulator.get_monitor()
+        status = monitor_from_pybind(simulator.get_context())
+        self.assertEqual(status.severity(), EventStatus.Severity.kDidNothing)
+        self.assertEqual(monitor_no_return_called_count, 1)
         simulator.clear_monitor()
 
         self.assertIsInstance(simulator.get_context(), Context_[T])
@@ -258,8 +271,8 @@ class TestAnalysis(unittest.TestCase):
             context = sys.GetMyContextFromRoot(root_context)
             if context.get_time() >= 1.:
                 return EventStatus.ReachedTermination(sys, "Time reached")
-            else:
-                return EventStatus.DidNothing()
+            # N.B. We suppress returning anything to test the binding's ability
+            # to handle `None` return type.
 
         self.assertIsNone(simulator.get_monitor())
         simulator.set_monitor(monitor)


### PR DESCRIPTION
Similar to / derived from #17859

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18696)
<!-- Reviewable:end -->
