### PR TITLE
[manipulation] Remove spurious deprecation warning output

### DIFF
--- a/manipulation/planner/BUILD.bazel
+++ b/manipulation/planner/BUILD.bazel
@@ -47,7 +47,10 @@ drake_cc_library(
     name = "constraint_relaxing_ik",
     hdrs = _STUB_HDRS,
     deprecation = "This label is deprecated and will be removed from Drake on 2023-05-01; as a replacement, use //multibody/inverse_kinematics:constraint_relaxing_ik instead.",  # noqa
-    tags = ["nolint"],
+    tags = [
+        "manual",
+        "nolint",
+    ],
     deps = [
         "//multibody/inverse_kinematics:constraint_relaxing_ik",
     ],
@@ -58,7 +61,10 @@ drake_cc_library(
     name = "robot_plan_interpolator",
     hdrs = _STUB_HDRS,
     deprecation = "This label is deprecated and will be removed from Drake on 2023-05-01; as a replacement, use //manipulation/util:robot_plan_interpolator instead.",  # noqa
-    tags = ["nolint"],
+    tags = [
+        "manual",
+        "nolint",
+    ],
     deps = [
         "//manipulation/util:robot_plan_interpolator",
     ],


### PR DESCRIPTION
During `bazel build //...`, the deprecated targets were being globbed and therefore creating warnings.

Hotfix for #18664.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18698)
<!-- Reviewable:end -->
