### PR TITLE
[common] Remove vestigial Eigen version guards

### DIFF
--- a/common/eigen_types.h
+++ b/common/eigen_types.h
@@ -13,9 +13,8 @@
 
 #include <Eigen/Dense>
 
-// Keep this version in sync with drake/tools/workspace/repository.bzl.
-static_assert(EIGEN_VERSION_AT_LEAST(3, 3, 4),
-              "Drake requires Eigen >= v3.3.4.");
+static_assert(EIGEN_VERSION_AT_LEAST(3, 3, 5),
+              "Drake requires Eigen >= v3.3.5.");
 
 #include "drake/common/constants.h"
 #include "drake/common/drake_assert.h"

--- a/common/symbolic/expression/formula.h
+++ b/common/symbolic/expression/formula.h
@@ -1347,10 +1347,6 @@ namespace numext {
 // the optimization. Therefore, we tweak these guards to special-case the
 // result when either of the operands is a literal zero, with no throwing
 // even if the other operand has unbound variables.
-//
-// These functions were only added in Eigen 3.3.5, but the minimum
-// Eigen version used by drake is 3.3.4, so a version check is needed.
-#if EIGEN_VERSION_AT_LEAST(3, 3, 5)
 template <>
 EIGEN_STRONG_INLINE bool equal_strict(
     const drake::symbolic::Expression& x,
@@ -1365,7 +1361,6 @@ EIGEN_STRONG_INLINE bool not_equal_strict(
     const drake::symbolic::Expression& y) {
   return !Eigen::numext::equal_strict(x, y);
 }
-#endif
 
 // Provides specialization of Eigen::numext::isfinite, numext::isnan, and
 // numext::isinf for Expression. The default template relies on an implicit

--- a/common/symbolic/expression/test/expression_test.cc
+++ b/common/symbolic/expression/test/expression_test.cc
@@ -897,9 +897,6 @@ TEST_F(SymbolicExpressionTest, UnaryPlus) {
 // specialized for Expression.
 // We only need a limited set of cases because if the specialization doesn't
 // exist, this would result in a compile error.
-// This function was only introduced in eigen 3.3.5. Therefore, we only want to
-// test if the eigen version is at least that.
-#if EIGEN_VERSION_AT_LEAST(3, 3, 5)
 TEST_F(SymbolicExpressionTest, EigenEqualStrict) {
   EXPECT_TRUE(Eigen::numext::equal_strict(c3_, c3_));
   EXPECT_FALSE(Eigen::numext::equal_strict(c3_, c4_));
@@ -925,7 +922,6 @@ TEST_F(SymbolicExpressionTest, EigenNotEqualStrict) {
   EXPECT_TRUE(Eigen::numext::not_equal_strict(x_, zero_));
   EXPECT_THROW(Eigen::numext::not_equal_strict(x_, y_), std::exception);
 }
-#endif
 
 // Confirm the other Eigen::numext specializations:
 //  - isfinite


### PR DESCRIPTION
We no longer support Bionic.

FYI
- https://packages.ubuntu.com/bionic/libeigen3-dev is 3.3.4
- https://packages.ubuntu.com/focal/libeigen3-dev is 3.3.7
- https://packages.ubuntu.com/jammy/libeigen3-dev is 3.4.0
- 
+@rpoyner-tri for both reviews per schedule, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18699)
<!-- Reviewable:end -->
