### PR TITLE
[pydrake] Hotfix for moving geometry files into subdir

### DIFF
--- a/tools/wheel/image/setup.py
+++ b/tools/wheel/image/setup.py
@@ -29,6 +29,7 @@ def _actually_find_packages():
     result = find_packages()
     result.extend([
         "pydrake.examples",
+        "pydrake.geometry",
         "pydrake.solvers",
         "pydrake.visualization",
     ])


### PR DESCRIPTION
We need to teach `setuptools` to install the `_geometry_extra.py`.

Hotfix for #18684.

Closes #18702.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18706)
<!-- Reviewable:end -->
