### PR TITLE
CMake builds: Treat DrakeDeprecationWarning as a warning not an error

### DIFF
--- a/CTestCustom.cmake.in
+++ b/CTestCustom.cmake.in
@@ -18,6 +18,7 @@ string(ASCII 27 ESC)
 # be colored magenta (CSI 35m) and bolded (CSI 1m).
 list(APPEND CTEST_CUSTOM_ERROR_EXCEPTION
   "^DEBUG: "
+  ": DrakeDeprecationWarning: "
   "^WARNING: "
   ": warning: "
   ":[0-9]+: Failure$"
@@ -41,6 +42,7 @@ list(APPEND CTEST_CUSTOM_WARNING_EXCEPTION
 # "WARNING" emitted by Bazel may be colored magenta (CSI 35m) and "warning"
 # emitted by Clang may be colored magenta (CSI 35m) and bolded (CSI 1m).
 list(APPEND CTEST_CUSTOM_WARNING_MATCH
+  ": DrakeDeprecationWarning: "
   "^WARNING: "
   ": warning: "
   "(^${ESC}\\[35mWARNING|: ${ESC}\\[0m${ESC}\\[0\;1\;35mwarning): ${ESC}\\[0m"


### PR DESCRIPTION
Example of failing CI job:

https://drake-jenkins.csail.mit.edu/view/Production/job/mac-x86-monterey-clang-cmake-nightly-release/

CDash lists the deprecation warnings as errors: https://drake-cdash.csail.mit.edu/viewBuildError.php?buildid=1667379

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18707)
<!-- Reviewable:end -->
