### PR TITLE
[tutorials] Fix markup typo for link

### DIFF
--- a/tutorials/_developers.md
+++ b/tutorials/_developers.md
@@ -19,7 +19,7 @@ your fork and branch, e.g.,
 # Deploying changes
 
 The tutorials on the Drake website are refreshed to latest master as part of
-our [stable release process](/release_playbook.html]. In general we do not
+our [stable release process](/release_playbook.html). In general we do not
 upgrade them between those monthly releases, but in case of emergency feel
 free to manually edit them online at deepnote.com. Any manual changes will
 be overwritten during the next stable release, so be sure that the fixes


### PR DESCRIPTION
Encountered while wanting to look at tutorials
(I always get tripped on when to fork w/ DeepNote)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18708)
<!-- Reviewable:end -->
