### PR TITLE
[planning] Add logging of OpenMP enablement in CollisionChecker

### DIFF
--- a/planning/collision_checker.cc
+++ b/planning/collision_checker.cc
@@ -833,11 +833,15 @@ void CollisionChecker::AllocateContexts() {
       common_robotics_utilities::openmp_helpers::GetMaxNumOmpThreads();
   const int omp_thread_limit =
       common_robotics_utilities::openmp_helpers::GetOmpThreadLimit();
+  const bool omp_enabled_in_build =
+      common_robotics_utilities::openmp_helpers::IsOmpEnabledInBuild();
   const int num_threads = std::max(num_omp_threads, max_num_omp_threads);
   log()->info(
       "Allocating contexts to support {} parallel queries given "
-      "omp_num_threads {} omp_max_threads {} and omp_thread_limit {}",
-      num_threads, num_omp_threads, max_num_omp_threads, omp_thread_limit);
+      "omp_num_threads {} omp_max_threads {} and omp_thread_limit {} "
+      "OpenMP enabled in build? {}",
+      num_threads, num_omp_threads, max_num_omp_threads, omp_thread_limit,
+      omp_enabled_in_build);
   // Make the prototype context.
   const std::unique_ptr<CollisionCheckerContext> prototype_context =
       CreatePrototypeContext();

--- a/tools/workspace/common_robotics_utilities/repository.bzl
+++ b/tools/workspace/common_robotics_utilities/repository.bzl
@@ -16,8 +16,8 @@ def common_robotics_utilities_repository(
         # package.BUILD.bazel and BUILD.bazel in drake. Tests may have been
         # updated in ToyotaResearchInstitute/common_robotics_utilities/test/ or
         # ToyotaResearchInstitute/common_robotics_utilities/CMakeLists.txt.ros2
-        commit = "73a4d936fcf72a7319d15f46f3ea493625f29a26",
-        sha256 = "4a3cdd7b3d21c0d40477ca87166e6c7e2750118566d4bd83c400f0f1f8d10db1",  # noqa
+        commit = "d8b1a861d07e7c526e2a7dd3123d351498b53636",
+        sha256 = "8d3357221aeacabc538391b1ab53bd848a8f29ddae75896912c23b7bb9c3d8d8",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )

--- a/tools/workspace/voxelized_geometry_tools/repository.bzl
+++ b/tools/workspace/voxelized_geometry_tools/repository.bzl
@@ -14,8 +14,8 @@ def voxelized_geometry_tools_repository(
         repository = "ToyotaResearchInstitute/voxelized_geometry_tools",
         # When updating, ensure that any new unit tests are reflected in
         # package.BUILD.bazel and BUILD.bazel in drake.
-        commit = "8b1008197f6a77811a572db8de45b125da216df1",
-        sha256 = "034322a87723536ceb79b9239e942a8993defbfd22be89940bb2f69da5361e11",  # noqa
+        commit = "83f9d52218fcd31a91b3cb493bedbad53fdf2bb3",
+        sha256 = "2a04e90bb6ffcf34b502422b808a90c729ae495c525594957c3cdc9db4dce04c",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
Adds logging to `CollisionChecker::AllocateContexts` of whether or not OpenMP is enabled in the build.

Bumps CRU and VGT externals to add the necessary `IsOmpEnabledInBuild` function from CRU.

+@jwnimmer-tri for review, thanks!

cc @sadraddini

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18709)
<!-- Reviewable:end -->
