### PR TITLE
[common] Adjust Expression for Eigen pre-3.5 compatibility

### DIFF
--- a/common/symbolic/expression/formula.h
+++ b/common/symbolic/expression/formula.h
@@ -1252,6 +1252,28 @@ struct scalar_cmp_op<drake::symbolic::Expression, drake::symbolic::Expression,
   }
 };
 
+#if EIGEN_VERSION_AT_LEAST(3, 4, 90)
+// Provides specialization for minmax_compare to handle the case "Expr < Expr".
+// This is needed for the trunk versions of Eigen (i.e., anticipating 3.5.x).
+template <int NaNPropagation>
+struct minmax_compare<drake::symbolic::Expression, NaNPropagation, true> {
+  using Scalar = drake::symbolic::Expression;
+  static EIGEN_DEVICE_FUNC inline bool compare(Scalar a, Scalar b) {
+    return static_cast<bool>(a < b);
+  }
+};
+
+// Provides specialization for minmax_compare to handle the case "Expr > Expr".
+// This is needed for the trunk versions of Eigen (i.e., anticipating 3.5.x).
+template <int NaNPropagation>
+struct minmax_compare<drake::symbolic::Expression, NaNPropagation, false> {
+  using Scalar = drake::symbolic::Expression;
+  static EIGEN_DEVICE_FUNC inline bool compare(Scalar a, Scalar b) {
+    return static_cast<bool>(a > b);
+  }
+};
+#endif  // EIGEN_VERSION_AT_LEAST
+
 /// Provides specialization for scalar_cmp_op to handle the case "Var == Var".
 template <>
 struct scalar_cmp_op<drake::symbolic::Variable, drake::symbolic::Variable,

--- a/common/symbolic/polynomial.cc
+++ b/common/symbolic/polynomial.cc
@@ -991,3 +991,16 @@ ostream& operator<<(ostream& os, const Polynomial& p) {
 }
 }  // namespace symbolic
 }  // namespace drake
+
+// We must define this in the cc file so that symbolic_formula.h is fully
+// defined (not just forward declared) when comparing.
+namespace Eigen {
+namespace numext {
+template <>
+bool equal_strict(
+    const drake::symbolic::Polynomial& x,
+    const drake::symbolic::Polynomial& y) {
+  return static_cast<bool>(x == y);
+}
+}  // namespace numext
+}  // namespace Eigen

--- a/common/symbolic/polynomial.h
+++ b/common/symbolic/polynomial.h
@@ -555,6 +555,18 @@ EIGEN_DEVICE_FUNC inline drake::symbolic::Expression cast(
   return p.ToExpression();
 }
 }  // namespace internal
+namespace numext {
+template <>
+bool equal_strict(
+    const drake::symbolic::Polynomial& x,
+    const drake::symbolic::Polynomial& y);
+template <>
+EIGEN_STRONG_INLINE bool not_equal_strict(
+    const drake::symbolic::Polynomial& x,
+    const drake::symbolic::Polynomial& y) {
+  return !Eigen::numext::equal_strict(x, y);
+}
+}  // namespace numext
 }  // namespace Eigen
 #endif  // !defined(DRAKE_DOXYGEN_CXX)
 

--- a/common/symbolic/rational_function.cc
+++ b/common/symbolic/rational_function.cc
@@ -305,3 +305,16 @@ void RationalFunction::SetIndeterminates(const Variables& new_indeterminates) {
 }
 }  // namespace symbolic
 }  // namespace drake
+
+// We must define this in the cc file so that symbolic_formula.h is fully
+// defined (not just forward declared) when comparing.
+namespace Eigen {
+namespace numext {
+template <>
+bool equal_strict(
+    const drake::symbolic::RationalFunction& x,
+    const drake::symbolic::RationalFunction& y) {
+  return static_cast<bool>(x == y);
+}
+}  // namespace numext
+}  // namespace Eigen

--- a/common/symbolic/rational_function.h
+++ b/common/symbolic/rational_function.h
@@ -309,5 +309,18 @@ DRAKE_SYMBOLIC_SCALAR_SUM_DIFF_PRODUCT_CONJ_PRODUCT_TRAITS(
     drake::symbolic::RationalFunction)
 #undef DRAKE_SYMBOLIC_SCALAR_BINARY_OP_TRAITS
 #undef DRAKE_SYMBOLIC_SCALAR_SUM_DIFF_PRODUCT_CONJ_PRODUCT_TRAITS
+
+namespace numext {
+template <>
+bool equal_strict(
+    const drake::symbolic::RationalFunction& x,
+    const drake::symbolic::RationalFunction& y);
+template <>
+EIGEN_STRONG_INLINE bool not_equal_strict(
+    const drake::symbolic::RationalFunction& x,
+    const drake::symbolic::RationalFunction& y) {
+  return !Eigen::numext::equal_strict(x, y);
+}
+}  // namespace numext
 }  // namespace Eigen
 #endif  // !defined(DRAKE_DOXYGEN_CXX)


### PR DESCRIPTION
Our existing `equal_strict` specializations must be extended to cover even more symbolic types, and a new operator struct `minmax_compare` must also be specialized now.

Closes #17850.

In #18700, I ran a bunch of CI testing to prove that this passes when mixed with a recent version of Eigen `master`, modulo two exceptions:

(1) `@libcmaes` does not build with the latest Eigen, so I disabled it.  It's `dev`-only code.

(2) `drake/math/test/linear_solve_test.cc` doesn't build, due to some template changes in upstream Eigen solvers.  That problem will still remain even after this PR lands, but it's a much more isolated piece of code, so will have less impact on users.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18710)
<!-- Reviewable:end -->
