### PR TITLE
Consolidate out-of-support documentation

### DIFF
--- a/doc/_release-notes/2015.md
+++ b/doc/_release-notes/2015.md
@@ -1,55 +1,7 @@
 ---
 title: Using older (MATLAB 2015) releases
-date: 2015-01-01
-released: in 2015 or earlier
+supplemental: true
+hidden: true
 ---
 
-We cannot offer support for older releases, but we still host the binaries for
-reference.
-
-Download the appropriate binary release (v0.9.x) for your platform
-[https://github.com/RobotLocomotion/drake/releases](https://github.com/RobotLocomotion/drake/releases).
-Simply extract the archive file into a folder of your choice (mine is called ``drake-distro``).
-
-To view the original MATLAB implementation, you may use the tag
-[last_sha_with_original_matlab ](https://github.com/RobotLocomotion/drake/tree/last_sha_with_original_matlab).
-Note, however, that the dependencies on this branch are out of date and we do
-not expect that you will be able to easily compile/run the code, and do not
-provide support for this.
-
-# Running MATLAB examples
-
-To run the MATLAB examples, change directories (in MATLAB) into the ``drake-distro/drake`` folder and at the MATLAB prompt do:
-
-```
-addpath_drake
-```
-
-Then ``cd`` into the examples directories and try some things out.  Here are a few fun ones to get you started:
-
-* ``runLQR`` in the ``examples/CartPole`` directory
-* ``runLQR`` in the ``examples/Quadrotor2D`` directory
-* ``RimlessWheelPlant.run()`` in the ``examples/RimlessWheel`` directory
-* ``StateMachineControl.run()`` in the ``examples/PlanarMonopodHopper`` directory
-
-Please note that you will have to run `addpath_drake` each time you start MATLAB, or [add it to your startup.m](http://www.mathworks.com/help/matlab/ref/startup.html).
-
-# Linux Specific
-
-The version of the standard C++ libraries that are shipped with the Linux distribution of MATLAB is severely outdated and can cause problems when running mex files that are built against a newer version of the standard.  The typical error message in this case reports `Invalid MEX-Files`.
-
-To work around this issue, the symbolic link for the standard C++ library provided by MATLAB must be redirected to point to a more up-to-date version.
-
-First, make sure that a suitable version of the standard library is installed:
-
-```
-sudo apt install g++-4.4
-```
-
-Now, the symbolic link in MATLAB must be updated to point to the version that was just installed in `/usr/lib`.  An example for MATLAB R2014a is shown below:
-
-```
-cd /usr/local/MATLAB/R2014a/sys/os/glnxa64
-sudo rm libstdc++.so.6
-sudo ln -s /usr/lib/gcc/x86_64-linux-gnu/4.4/libstdc++.so libstdc++.so.6
-```
+This content has <a href="end_of_support.html">moved</a>.

--- a/doc/_release-notes/2016.md
+++ b/doc/_release-notes/2016.md
@@ -1,12 +1,7 @@
 ---
 title: Using older (Ubuntu 16.04) releases
-date: 2016-01-01
-released: for Ubuntu 16.04
+supplemental: true
+hidden: true
 ---
 
-We cannot offer support for older releases, but we still host the binaries
-for reference.
-
-The last published package for Ubuntu 16.04 (Xenial) is available here:
-
-* [https://github.com/RobotLocomotion/drake/releases/tag/v0.11.0](https://github.com/RobotLocomotion/drake/releases/tag/v0.11.0)
+This content has <a href="end_of_support.html">moved</a>.

--- a/doc/_release-notes/end_of_support.md
+++ b/doc/_release-notes/end_of_support.md
@@ -1,0 +1,69 @@
+---
+title: End of support releases
+supplemental: true
+---
+
+Due to limited resources, we cannot offer indefinite support
+for older operating systems or third-party libraries.
+If you need to use these, you can use an old release of Drake.
+
+## Ubuntu 18.04 (Bionic)
+
+The last version with support for Ubuntu 18.04 is v1.1.0:
+
+* <https://github.com/RobotLocomotion/drake/releases/tag/v1.1.0>
+
+## Ubuntu 16.04 (Xenial)
+
+The last version with support for Ubuntu 16.04 is v0.11.0:
+
+* <https://github.com/RobotLocomotion/drake/releases/tag/v0.11.0>
+
+## MATLAB 2015
+
+Download the appropriate binary release (v0.9.x) for your platform from
+<https://github.com/RobotLocomotion/drake/releases>.
+Simply extract the archive file into a folder of your choice (mine is called ``drake-distro``).
+
+To view the original MATLAB implementation, you may use the tag
+[last_sha_with_original_matlab ](https://github.com/RobotLocomotion/drake/tree/last_sha_with_original_matlab).
+Note, however, that the dependencies on this branch are out of date and we do
+not expect that you will be able to easily compile/run the code, and do not
+provide support for this.
+
+### Running MATLAB examples
+
+To run the MATLAB examples, change directories (in MATLAB) into the ``drake-distro/drake`` folder and at the MATLAB prompt do:
+
+```
+addpath_drake
+```
+
+Then ``cd`` into the examples directories and try some things out.  Here are a few fun ones to get you started:
+
+* ``runLQR`` in the ``examples/CartPole`` directory
+* ``runLQR`` in the ``examples/Quadrotor2D`` directory
+* ``RimlessWheelPlant.run()`` in the ``examples/RimlessWheel`` directory
+* ``StateMachineControl.run()`` in the ``examples/PlanarMonopodHopper`` directory
+
+Please note that you will have to run `addpath_drake` each time you start MATLAB, or [add it to your startup.m](http://www.mathworks.com/help/matlab/ref/startup.html).
+
+### Linux Specific
+
+The version of the standard C++ libraries that are shipped with the Linux distribution of MATLAB is severely outdated and can cause problems when running mex files that are built against a newer version of the standard.  The typical error message in this case reports `Invalid MEX-Files`.
+
+To work around this issue, the symbolic link for the standard C++ library provided by MATLAB must be redirected to point to a more up-to-date version.
+
+First, make sure that a suitable version of the standard library is installed:
+
+```
+sudo apt install g++-4.4
+```
+
+Now, the symbolic link in MATLAB must be updated to point to the version that was just installed in `/usr/lib`.  An example for MATLAB R2014a is shown below:
+
+```
+cd /usr/local/MATLAB/R2014a/sys/os/glnxa64
+sudo rm libstdc++.so.6
+sudo ln -s /usr/lib/gcc/x86_64-linux-gnu/4.4/libstdc++.so libstdc++.so.6
+```

--- a/doc/_release-notes/release_notes.md
+++ b/doc/_release-notes/release_notes.md
@@ -1,6 +1,8 @@
 ---
 layout: default
 title: Release Notes
+supplemental: true
+hidden: true
 ---
 
 <div class="drake-page">
@@ -20,8 +22,18 @@ title: Release Notes
 Latest releases are first:
 
 {% for note in site.release-notes reversed %}
-{% if note.title != "Release Notes" %}
+{% if note.supplemental %}
+{% else %}
 * <a href="{{ note.url }}.html">{{ note.title }}</a> (released {{ note.released }})
+{% endif %}
+{% endfor %}
+
+{% for page in site.release-notes %}
+{% if page.supplemental %}
+{% if page.hidden %}
+{% else %}
+<h3><a href="{{ page.url }}.html">{{ page.title }}</a></h3>
+{% endif %}
 {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
Move end-of-support information to a new, consolidated document. Add a separate section to the release notes content page for "supplemental" pages (i.e. things that make sense here but aren't releases, such as the aforementioned end-of-support information). Replace old documents with a redirect and hide from the contents.

Fixes #18303. ~I'm guessing we will still need to add the EOS information for Bionic.~ Right, information for Bionic *is* added here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18713)
<!-- Reviewable:end -->
