### PR TITLE
[py planning] Remove RobotBuilder const vs non-const distinction

### DIFF
--- a/bindings/pydrake/planning/planning_py_robot_diagram.cc
+++ b/bindings/pydrake/planning/planning_py_robot_diagram.cc
@@ -54,33 +54,33 @@ void DefinePlanningRobotDiagram(py::module m) {
     {
       using Class = RobotDiagramBuilder<T>;
       constexpr auto& cls_doc = doc.RobotDiagramBuilder;
-      auto cls = DefineTemplateClassWithDefault<Class>(
-          m, "RobotDiagramBuilder", GetPyParam<T>(), cls_doc.doc);
+      auto cls = DefineTemplateClassWithDefault<Class>(m, "RobotDiagramBuilder",
+          GetPyParam<T>(),
+          (std::string(cls_doc.doc) +
+              "\n\n"
+              "Note:\n"
+              "    The C++ class defines pairs of sibling methods, e.g.,\n"
+              "    parser() vs mutable_parser(). Since Python does not use\n"
+              "    const-ness, we only provide one of the two siblings here,\n"
+              "    using the shorter method name but still allowing mutation,\n"
+              "    e.g., parser() returns a Parser that *does* allow loading\n"
+              "    models and changing package paths.\n")
+              .c_str());
       cls  // BR
           .def(py::init<double>(), py::arg("time_step") = 0.0, cls_doc.ctor.doc)
-          .def("mutable_builder", &Class::mutable_builder,
-              py_rvp::reference_internal, cls_doc.mutable_builder.doc)
-          .def("builder", &Class::builder, py_rvp::reference_internal,
-              cls_doc.builder.doc);
+          .def("builder", &Class::mutable_builder, py_rvp::reference_internal,
+              cls_doc.mutable_builder.doc);
       if constexpr (std::is_same_v<T, double>) {
         cls  // BR
             .def(
-                "mutable_parser",
-                [](Class& self) { return &self.mutable_parser(); },
-                py_rvp::reference_internal, cls_doc.mutable_parser.doc)
-            .def(
-                "parser", [](const Class& self) { return &self.parser(); },
-                py_rvp::reference_internal, cls_doc.parser.doc);
+                "parser", [](Class& self) { return &self.mutable_parser(); },
+                py_rvp::reference_internal, cls_doc.mutable_parser.doc);
       }
       cls  // BR
-          .def("mutable_plant", &Class::mutable_plant,
-              py_rvp::reference_internal, cls_doc.mutable_plant.doc)
-          .def("plant", &Class::plant, py_rvp::reference_internal,
-              cls_doc.plant.doc)
-          .def("mutable_scene_graph", &Class::mutable_scene_graph,
+          .def("plant", &Class::mutable_plant, py_rvp::reference_internal,
+              cls_doc.mutable_plant.doc)
+          .def("scene_graph", &Class::mutable_scene_graph,
               py_rvp::reference_internal, cls_doc.mutable_scene_graph.doc)
-          .def("scene_graph", &Class::scene_graph, py_rvp::reference_internal,
-              cls_doc.scene_graph.doc)
           .def("IsPlantFinalized", &Class::IsPlantFinalized,
               cls_doc.IsPlantFinalized.doc)
           .def(

--- a/bindings/pydrake/planning/test/collision_checker_test.py
+++ b/bindings/pydrake/planning/test/collision_checker_test.py
@@ -36,7 +36,7 @@ class TestCollisionChecker(unittest.TestCase):
             parent: world
             child: ground::ground_plane_box
         """)
-        builder.mutable_parser().AddModelsFromString(scene_yaml, "dmd.yaml")
+        builder.parser().AddModelsFromString(scene_yaml, "dmd.yaml")
         model_instance_index = builder.plant().GetModelInstanceByName("box")
         robot_diagram = builder.BuildDiagram()
         return (robot_diagram, model_instance_index)

--- a/bindings/pydrake/planning/test/robot_diagram_test.py
+++ b/bindings/pydrake/planning/test/robot_diagram_test.py
@@ -18,24 +18,17 @@ class TestRobotDiagram(unittest.TestCase):
         Class = mut.RobotDiagramBuilder_[T]
         dut = Class(time_step=0.0)
         if T == float:
-            # Most users would use the mutable_parser function.
-            dut.mutable_parser().AddModels(FindResourceOrThrow(
+            dut.parser().AddModels(FindResourceOrThrow(
                 "drake/manipulation/models/iiwa_description/urdf/"
                 "iiwa14_spheres_dense_collision.urdf"))
-            # Sanity check that this is bound. There are currently no const
-            # functions defined by Parser, so it's somewehat useless.
-            self.assertIsInstance(dut.parser(), Parser)
         else:
-            # TODO(jwnimmer-tri) Use dut.mutable_plant() to manually add some
+            # TODO(jwnimmer-tri) Use dut.plant() to manually add some
             # models, bodies, and geometries here.
             pass
 
         # Sanity check all of the accessors.
-        self.assertIsInstance(dut.mutable_builder(), DiagramBuilder_[T])
         self.assertIsInstance(dut.builder(), DiagramBuilder_[T])
-        self.assertIsInstance(dut.mutable_plant(), MultibodyPlant_[T])
         self.assertIsInstance(dut.plant(), MultibodyPlant_[T])
-        self.assertIsInstance(dut.mutable_scene_graph(), SceneGraph_[T])
         self.assertIsInstance(dut.scene_graph(), SceneGraph_[T])
 
         # Finalize.


### PR DESCRIPTION
In Python, only the mutable getters make any sense when using the builder pattern.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18714)
<!-- Reviewable:end -->
