### PR TITLE
[planning] Reorganize planning artifacts in planning (3 of 3)

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -596,7 +596,7 @@ PYI_FILES = [
     "pydrake/manipulation/__init__.pyi",
     "pydrake/manipulation/all.pyi",
     "pydrake/manipulation/kuka_iiwa.pyi",
-    "pydrake/manipulation/planner.pyi",
+    "pydrake/manipulation/planner.pyi",  # 2023-05-01 Delete this.
     "pydrake/manipulation/schunk_wsg.pyi",
     "pydrake/manipulation/util.pyi",
     "pydrake/math.pyi",

--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -596,7 +596,7 @@ PYI_FILES = [
     "pydrake/manipulation/__init__.pyi",
     "pydrake/manipulation/all.pyi",
     "pydrake/manipulation/kuka_iiwa.pyi",
-    "pydrake/manipulation/planner.pyi",  # 2023-05-01 Delete this.
+    "pydrake/manipulation/planner.pyi",  # 2023-06-01 Delete this.
     "pydrake/manipulation/schunk_wsg.pyi",
     "pydrake/manipulation/util.pyi",
     "pydrake/math.pyi",

--- a/bindings/pydrake/manipulation/BUILD.bazel
+++ b/bindings/pydrake/manipulation/BUILD.bazel
@@ -32,6 +32,14 @@ drake_py_library(
     ],
 )
 
+# 2023-06-01 Remove this target upon completion of deprecation.
+drake_py_library(
+    name = "planner_py",
+    srcs = ["planner.py"],
+    imports = PACKAGE_INFO.py_imports,
+    deps = ["//bindings/pydrake/multibody:inverse_kinematics_py"],
+)
+
 drake_pybind_library(
     name = "kuka_iiwa_py",
     cc_deps = [
@@ -82,6 +90,7 @@ PY_LIBRARIES_WITH_INSTALL = [
 
 PY_LIBRARIES = [
     ":module_py",
+    ":planner_py",
 ]
 
 drake_py_unittest(
@@ -94,6 +103,14 @@ drake_py_unittest(
         ":kuka_iiwa_py",
         "//bindings/pydrake/multibody",
         "//bindings/pydrake/systems",
+    ],
+)
+
+drake_py_unittest(
+    name = "planner_deprecated_test",
+    deps = [
+        ":planner_py",
+        "//bindings/pydrake/common/test_utilities:deprecation_py",
     ],
 )
 

--- a/bindings/pydrake/manipulation/BUILD.bazel
+++ b/bindings/pydrake/manipulation/BUILD.bazel
@@ -47,20 +47,6 @@ drake_pybind_library(
 )
 
 drake_pybind_library(
-    name = "planner_py",
-    cc_deps = [
-        "//bindings/pydrake:documentation_pybind",
-        "//bindings/pydrake/common:deprecation_pybind",
-        "//bindings/pydrake/common:eigen_pybind",
-    ],
-    cc_srcs = ["planner_py.cc"],
-    package_info = PACKAGE_INFO,
-    py_deps = [
-        ":module_py",
-    ],
-)
-
-drake_pybind_library(
     name = "schunk_wsg_py",
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
@@ -90,7 +76,6 @@ drake_pybind_library(
 
 PY_LIBRARIES_WITH_INSTALL = [
     ":kuka_iiwa_py",
-    ":planner_py",
     ":schunk_wsg_py",
     ":util_py",
 ]
@@ -109,18 +94,6 @@ drake_py_unittest(
         ":kuka_iiwa_py",
         "//bindings/pydrake/multibody",
         "//bindings/pydrake/systems",
-    ],
-)
-
-drake_py_unittest(
-    name = "planner_test",
-    data = [
-        "//multibody/benchmarks/acrobot:models",
-    ],
-    deps = [
-        ":planner_py",
-        "//bindings/pydrake/common/test_utilities",
-        "//bindings/pydrake/multibody",
     ],
 )
 

--- a/bindings/pydrake/manipulation/all.py
+++ b/bindings/pydrake/manipulation/all.py
@@ -1,4 +1,3 @@
 from .kuka_iiwa import *
-from .planner import *
 from .schunk_wsg import *
 from .util import *

--- a/bindings/pydrake/manipulation/planner.py
+++ b/bindings/pydrake/manipulation/planner.py
@@ -1,0 +1,17 @@
+"""Deprecated aliases to planning resources."""
+
+from pydrake.common.deprecation import _warn_deprecated
+
+from pydrake.multibody.inverse_kinematics import (
+    DifferentialInverseKinematicsIntegrator,
+    DifferentialInverseKinematicsStatus,
+    DifferentialInverseKinematicsParameters,
+    DifferentialInverseKinematicsResult,
+    DoDifferentialInverseKinematics,
+)
+
+_warn_deprecated(
+    "Please import the differential ik API from "
+    "pydrake.multibody.inverse_kinematics instead of the deprecated "
+    f"{__name__} submodule.",
+    date="2023-06-01", stacklevel=3)

--- a/bindings/pydrake/manipulation/test/planner_deprecated_test.py
+++ b/bindings/pydrake/manipulation/test/planner_deprecated_test.py
@@ -1,0 +1,24 @@
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
+
+import unittest
+
+
+# 2023-06-01 Delete this file with the rest of the deprecation.
+
+class TestDeprecation(unittest.TestCase):
+    def test_deprecated_symbols_exist(self):
+        # The whole point of this test is that we can access the same symbols
+        # tested in
+        # /bindings/pydrake/multibody/test/inverse_kinematics_differential_test.py  # noqa
+        # via the old, deprecated module path. We should get a single
+        # deprecation warning on the module. Otherwise, all of the given
+        # symbols should be successfully imported.
+        with catch_drake_warnings(expected_count=1) as w:
+            from pydrake.manipulation.planner import (
+                DifferentialInverseKinematicsIntegrator,
+                DifferentialInverseKinematicsStatus,
+                DifferentialInverseKinematicsParameters,
+                DifferentialInverseKinematicsResult,
+                DoDifferentialInverseKinematics,
+            )
+            self.assertIn("2023-06-01", str(w[0].message))

--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -189,7 +189,11 @@ drake_pybind_library(
         "//bindings/pydrake/common:default_scalars_pybind",
         "//bindings/pydrake/common:sorted_pair_pybind",
     ],
-    cc_srcs = ["inverse_kinematics_py.cc"],
+    cc_srcs = [
+        "inverse_kinematics_py.cc",
+        "inverse_kinematics_py.h",
+        "inverse_kinematics_py_differential.cc",
+    ],
     package_info = PACKAGE_INFO,
     py_deps = [
         ":module_py",
@@ -384,6 +388,18 @@ drake_py_unittest(
     ],
     deps = [
         ":benchmarks_py",
+        ":inverse_kinematics_py",
+        ":parsing_py",
+        "//bindings/pydrake/common/test_utilities",
+    ],
+)
+
+drake_py_unittest(
+    name = "inverse_kinematics_differential_test",
+    data = [
+        "//multibody/benchmarks/acrobot:models",
+    ],
+    deps = [
         ":inverse_kinematics_py",
         ":parsing_py",
         "//bindings/pydrake/common/test_utilities",

--- a/bindings/pydrake/multibody/inverse_kinematics_py.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py.cc
@@ -1,3 +1,5 @@
+#include "drake/bindings/pydrake/multibody/inverse_kinematics_py.h"
+
 #include "pybind11/eigen.h"
 #include "pybind11/pybind11.h"
 
@@ -817,6 +819,12 @@ PYBIND11_MODULE(inverse_kinematics, m) {
     // TODO(russt): Add bindings for Polytope3D struct and related methods
     // (or convert those methods to use ConvexSets).
   }
+
+  // TODO(SeanCurtis-TRI): Refactor this into its own stand-alone .cc file and
+  // re-introduce the inverse_kinematics_py.cc that just assembles the full
+  // module.
+  internal::DefineIkDifferential(m);
+
   // NOLINTNEXTLINE(readability/fn_size)
 }
 

--- a/bindings/pydrake/multibody/inverse_kinematics_py.h
+++ b/bindings/pydrake/multibody/inverse_kinematics_py.h
@@ -1,0 +1,25 @@
+#pragma once
+
+/* This file declares the functions that bind into the
+ drake.multibody.inverse_kinematics module. These functions form a complete
+ partition of the drake.multibody.inverse_kinematics bindings. Note: the
+ artifacts all belong in the drake::multibody namespace.
+
+ The implementations of these functions are parceled out into various *.cc
+ files as indicated in each function's documentation. */
+
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+
+namespace drake {
+namespace pydrake {
+namespace internal {
+
+/* Defines bindings per inverse_kinematics_py_differential.cc. */
+void DefineIkDifferential(py::module m);
+
+// TODO(SeanCurtis-TRI): Make the partition promise true by refactoring
+// inverse_kinematics_py.cc into its own function declared here.
+
+}  // namespace internal
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/multibody/inverse_kinematics_py_differential.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py_differential.cc
@@ -2,21 +2,22 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
-#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
-#include "drake/manipulation/planner/differential_inverse_kinematics.h"
-#include "drake/manipulation/planner/differential_inverse_kinematics_integrator.h"
+#include "drake/multibody/inverse_kinematics/differential_inverse_kinematics.h"
+#include "drake/multibody/inverse_kinematics/differential_inverse_kinematics_integrator.h"
 
 namespace drake {
 namespace pydrake {
+namespace internal {
 
-PYBIND11_MODULE(planner, m) {
-  using drake::manipulation::planner::DifferentialInverseKinematicsStatus;
+void DefineIkDifferential(py::module m) {
+  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+  using namespace drake::multibody;
+
   using drake::systems::LeafSystem;
 
-  m.doc() = "Tools for manipulation planning.";
-  constexpr auto& doc = pydrake_doc.drake.manipulation.planner;
+  constexpr auto& doc = pydrake_doc.drake.multibody;
 
   py::module::import("pydrake.systems.framework");
 
@@ -33,7 +34,7 @@ PYBIND11_MODULE(planner, m) {
           doc.DifferentialInverseKinematicsStatus.kStuck.doc);
 
   {
-    using Class = manipulation::planner::DifferentialInverseKinematicsResult;
+    using Class = DifferentialInverseKinematicsResult;
     constexpr auto& cls_doc = doc.DifferentialInverseKinematicsResult;
     py::class_<Class> cls(m, "DifferentialInverseKinematicsResult",
         doc.DifferentialInverseKinematicsResult.doc);
@@ -46,8 +47,7 @@ PYBIND11_MODULE(planner, m) {
         .def_readwrite("status", &Class::status, cls_doc.status.doc);
   }
   {
-    using Class =
-        manipulation::planner::DifferentialInverseKinematicsParameters;
+    using Class = DifferentialInverseKinematicsParameters;
     constexpr auto& cls_doc = doc.DifferentialInverseKinematicsParameters;
 
     py::class_<Class> cls(m, "DifferentialInverseKinematicsParameters",
@@ -118,9 +118,8 @@ PYBIND11_MODULE(planner, m) {
       "DoDifferentialInverseKinematics",
       [](const Eigen::VectorXd& q_current, const Eigen::VectorXd& v_current,
           const Eigen::VectorXd& V, const Eigen::MatrixXd& J,
-          const manipulation::planner::DifferentialInverseKinematicsParameters&
-              parameters) {
-        return manipulation::planner::DoDifferentialInverseKinematics(
+          const DifferentialInverseKinematicsParameters& parameters) {
+        return DoDifferentialInverseKinematics(
             q_current, v_current, V, J, parameters);
       },
       py::arg("q_current"), py::arg("v_current"), py::arg("V"), py::arg("J"),
@@ -134,9 +133,8 @@ PYBIND11_MODULE(planner, m) {
           const systems::Context<double>& context,
           const Vector6<double>& V_WE_desired,
           const multibody::Frame<double>& frame_E,
-          const manipulation::planner::DifferentialInverseKinematicsParameters&
-              parameters) {
-        return manipulation::planner::DoDifferentialInverseKinematics(
+          const DifferentialInverseKinematicsParameters& parameters) {
+        return DoDifferentialInverseKinematics(
             robot, context, V_WE_desired, frame_E, parameters);
       },
       py::arg("robot"), py::arg("context"), py::arg("V_WE_desired"),
@@ -150,9 +148,8 @@ PYBIND11_MODULE(planner, m) {
           const systems::Context<double>& context,
           const math::RigidTransform<double>& X_WE_desired,
           const multibody::Frame<double>& frame_E,
-          const manipulation::planner::DifferentialInverseKinematicsParameters&
-              parameters) {
-        return manipulation::planner::DoDifferentialInverseKinematics(
+          const DifferentialInverseKinematicsParameters& parameters) {
+        return DoDifferentialInverseKinematics(
             robot, context, X_WE_desired, frame_E, parameters);
       },
       py::arg("robot"), py::arg("context"), py::arg("X_WE_desired"),
@@ -161,15 +158,13 @@ PYBIND11_MODULE(planner, m) {
           .doc_5args_robot_context_X_WE_desired_frame_E_parameters);
 
   {
-    using Class =
-        manipulation::planner::DifferentialInverseKinematicsIntegrator;
+    using Class = DifferentialInverseKinematicsIntegrator;
     constexpr auto& cls_doc = doc.DifferentialInverseKinematicsIntegrator;
     py::class_<Class, LeafSystem<double>>(
         m, "DifferentialInverseKinematicsIntegrator", cls_doc.doc)
         .def(py::init<const multibody::MultibodyPlant<double>&,
                  const multibody::Frame<double>&, double,
-                 const manipulation::planner::
-                     DifferentialInverseKinematicsParameters&,
+                 const DifferentialInverseKinematicsParameters&,
                  const systems::Context<double>*, bool>(),
             // Keep alive, reference: `self` keeps `robot` alive.
             py::keep_alive<1, 2>(), py::arg("robot"), py::arg("frame_E"),
@@ -188,5 +183,6 @@ PYBIND11_MODULE(planner, m) {
   }
 }
 
+}  // namespace internal
 }  // namespace pydrake
 }  // namespace drake

--- a/bindings/pydrake/multibody/test/inverse_kinematics_differential_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_differential_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import pydrake.manipulation.planner as mut
+import pydrake.multibody.inverse_kinematics as mut
 
 import unittest
 import numpy as np

--- a/examples/manipulation_station/end_effector_teleop_dualshock4.py
+++ b/examples/manipulation_station/end_effector_teleop_dualshock4.py
@@ -18,11 +18,11 @@ from pydrake.examples import (
     ManipulationStation, ManipulationStationHardwareInterface,
     CreateClutterClearingYcbObjectList, SchunkCollisionModel)
 from pydrake.geometry import DrakeVisualizer, Meshcat, MeshcatVisualizer
-from pydrake.multibody.plant import MultibodyPlant
-from pydrake.manipulation.planner import (
+from pydrake.math import RigidTransform, RollPitchYaw, RotationMatrix
+from pydrake.multibody.inverse_kinematics import (
     DifferentialInverseKinematicsIntegrator,
     DifferentialInverseKinematicsParameters)
-from pydrake.math import RigidTransform, RollPitchYaw, RotationMatrix
+from pydrake.multibody.plant import MultibodyPlant
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import DiagramBuilder, LeafSystem
 from pydrake.systems.primitives import FirstOrderLowPassFilter

--- a/examples/manipulation_station/end_effector_teleop_mouse.py
+++ b/examples/manipulation_station/end_effector_teleop_mouse.py
@@ -10,11 +10,11 @@ from pydrake.examples import (
     ManipulationStation, ManipulationStationHardwareInterface,
     CreateClutterClearingYcbObjectList, SchunkCollisionModel)
 from pydrake.geometry import DrakeVisualizer, Meshcat, MeshcatVisualizer
-from pydrake.multibody.plant import MultibodyPlant
-from pydrake.manipulation.planner import (
+from pydrake.math import RigidTransform, RollPitchYaw, RotationMatrix
+from pydrake.multibody.inverse_kinematics import (
     DifferentialInverseKinematicsIntegrator,
     DifferentialInverseKinematicsParameters)
-from pydrake.math import RigidTransform, RollPitchYaw, RotationMatrix
+from pydrake.multibody.plant import MultibodyPlant
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import DiagramBuilder, LeafSystem
 from pydrake.systems.primitives import FirstOrderLowPassFilter

--- a/examples/manipulation_station/end_effector_teleop_sliders.py
+++ b/examples/manipulation_station/end_effector_teleop_sliders.py
@@ -10,10 +10,10 @@ from pydrake.examples import (
     ManipulationStation, ManipulationStationHardwareInterface,
     CreateClutterClearingYcbObjectList, SchunkCollisionModel)
 from pydrake.geometry import DrakeVisualizer, Meshcat, MeshcatVisualizer
-from pydrake.manipulation.planner import (
+from pydrake.math import RigidTransform, RollPitchYaw, RotationMatrix
+from pydrake.multibody.inverse_kinematics import (
     DifferentialInverseKinematicsIntegrator,
     DifferentialInverseKinematicsParameters)
-from pydrake.math import RigidTransform, RollPitchYaw, RotationMatrix
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import (DiagramBuilder, LeafSystem,
                                        PublishEvent)

--- a/manipulation/planner/BUILD.bazel
+++ b/manipulation/planner/BUILD.bazel
@@ -1,5 +1,7 @@
 # -*- python -*-
 
+# 2023-06-01 Remove this entire file upon deprecation completion.
+
 load(
     "@drake//tools/skylark:drake_cc.bzl",
     "drake_cc_googletest",
@@ -17,17 +19,19 @@ drake_cc_package_library(
     visibility = ["//visibility:public"],
     deps = [
         ":constraint_relaxing_ik",
+        ":differential_inverse_kinematics",
+        ":differential_inverse_kinematics_integrator",
         ":robot_plan_interpolator",
     ],
 )
 
-# TODO(SeanCurtis-TRI): 2023-05-01 remove along with deprecation.
 _STUB_HDRS = [
     "constraint_relaxing_ik.h",
+    "differential_inverse_kinematics.h",
+    "differential_inverse_kinematics_integrator.h",
     "robot_plan_interpolator.h",
 ]
 
-# TODO(SeanCurtis-TRI): 2023-05-01 remove along with deprecation.
 [
     genrule(
         name = "_cp_" + hdr,
@@ -40,37 +44,65 @@ _STUB_HDRS = [
     for hdr in _STUB_HDRS
 ]
 
-# TODO(SeanCurtis-TRI): 2023-05-01 remove along with deprecation.
 drake_cc_library(
     name = "constraint_relaxing_ik",
     hdrs = _STUB_HDRS,
-    deprecation = "This label is deprecated and will be removed from Drake on 2023-05-01; as a replacement, use //multibody/inverse_kinematics:constraint_relaxing_ik instead.",  # noqa
+    deprecation = "This label is deprecated and will be removed from Drake on 2023-06-01; as a replacement, use //multibody/inverse_kinematics:constraint_relaxing_ik instead.",  # noqa
     tags = [
         "manual",
         "nolint",
     ],
     deps = [
+        "//common:essential",
         "//multibody/inverse_kinematics:constraint_relaxing_ik",
     ],
 )
 
-# TODO(SeanCurtis-TRI): 2023-05-01 remove along with deprecation.
 drake_cc_library(
-    name = "robot_plan_interpolator",
+    name = "differential_inverse_kinematics",
     hdrs = _STUB_HDRS,
-    deprecation = "This label is deprecated and will be removed from Drake on 2023-05-01; as a replacement, use //manipulation/util:robot_plan_interpolator instead.",  # noqa
+    deprecation = "This label is deprecated and will be removed from Drake on 2023-06-01; as a replacement, use //multibody/inverse_kinematics:differential_inverse_kinematics instead.",  # noqa
     tags = [
         "manual",
         "nolint",
     ],
     deps = [
+        "//common:essential",
+        "//multibody/inverse_kinematics:differential_inverse_kinematics",
+    ],
+)
+
+drake_cc_library(
+    name = "differential_inverse_kinematics_integrator",
+    hdrs = _STUB_HDRS,
+    deprecation = "This label is deprecated and will be removed from Drake on 2023-06-01; as a replacement, use //multibody/inverse_kinematics:differential_inverse_kinematics_integrator instead.",  # noqa
+    tags = [
+        "manual",
+        "nolint",
+    ],
+    deps = [
+        ":differential_inverse_kinematics",
+        "//common:essential",
+        "//multibody/inverse_kinematics:differential_inverse_kinematics_integrator",  # noqa
+    ],
+)
+
+drake_cc_library(
+    name = "robot_plan_interpolator",
+    hdrs = _STUB_HDRS,
+    deprecation = "This label is deprecated and will be removed from Drake on 2023-06-01; as a replacement, use //manipulation/util:robot_plan_interpolator instead.",  # noqa
+    tags = [
+        "manual",
+        "nolint",
+    ],
+    deps = [
+        "//common:essential",
         "//manipulation/util:robot_plan_interpolator",
     ],
 )
 
 # === test/ ===
 
-# TODO(SeanCurtis-TRI): 2023-05-01 remove along with deprecation.
 drake_cc_googletest(
     name = "deprecation_test",
     copts = [
@@ -82,8 +114,13 @@ drake_cc_googletest(
     ],
     deps = [
         ":constraint_relaxing_ik",
+        ":differential_inverse_kinematics",
+        ":differential_inverse_kinematics_integrator",
         ":robot_plan_interpolator",
         "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//manipulation/kuka_iiwa:iiwa_constants",
+        "//multibody/parsing",
     ],
 )
 

--- a/manipulation/planner/BUILD.bazel
+++ b/manipulation/planner/BUILD.bazel
@@ -17,8 +17,6 @@ drake_cc_package_library(
     visibility = ["//visibility:public"],
     deps = [
         ":constraint_relaxing_ik",
-        ":differential_inverse_kinematics",
-        ":differential_inverse_kinematics_integrator",
         ":robot_plan_interpolator",
     ],
 )
@@ -70,28 +68,6 @@ drake_cc_library(
     ],
 )
 
-drake_cc_library(
-    name = "differential_inverse_kinematics",
-    srcs = ["differential_inverse_kinematics.cc"],
-    hdrs = ["differential_inverse_kinematics.h"],
-    deps = [
-        "//multibody/plant",
-        "//solvers:clp_solver",
-        "//solvers:mathematical_program",
-        "//solvers:osqp_solver",
-    ],
-)
-
-drake_cc_library(
-    name = "differential_inverse_kinematics_integrator",
-    srcs = ["differential_inverse_kinematics_integrator.cc"],
-    hdrs = ["differential_inverse_kinematics_integrator.h"],
-    deps = [
-        ":differential_inverse_kinematics",
-        "//systems/framework:leaf_system",
-    ],
-)
-
 # === test/ ===
 
 # TODO(SeanCurtis-TRI): 2023-05-01 remove along with deprecation.
@@ -108,33 +84,6 @@ drake_cc_googletest(
         ":constraint_relaxing_ik",
         ":robot_plan_interpolator",
         "//common:find_resource",
-    ],
-)
-
-drake_cc_googletest(
-    name = "differential_inverse_kinematics_test",
-    data = [
-        "//manipulation/models/iiwa_description:models",
-    ],
-    deps = [
-        ":differential_inverse_kinematics",
-        "//common/test_utilities:eigen_matrix_compare",
-        "//manipulation/kuka_iiwa:iiwa_constants",
-        "//multibody/parsing",
-    ],
-)
-
-drake_cc_googletest(
-    name = "differential_inverse_kinematics_integrator_test",
-    data = [
-        "//manipulation/models/iiwa_description:models",
-    ],
-    deps = [
-        ":differential_inverse_kinematics_integrator",
-        "//common/test_utilities:eigen_matrix_compare",
-        "//manipulation/kuka_iiwa:iiwa_constants",
-        "//multibody/parsing",
-        "//systems/analysis:simulator",
     ],
 )
 

--- a/manipulation/planner/stub/constraint_relaxing_ik.h
+++ b/manipulation/planner/stub/constraint_relaxing_ik.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#warning The include path drake/manipulation/planner/constraint_relaxing_ik.h is deprecated and will be removed on or after 2023-05-01; instead, use drake/multibody/inverse_kinematics/constraint_relaxing_ik.h.
+#warning The include path drake/manipulation/planner/constraint_relaxing_ik.h is deprecated and will be removed on or after 2023-06-01; instead, use drake/multibody/inverse_kinematics/constraint_relaxing_ik.h.
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/multibody/inverse_kinematics/constraint_relaxing_ik.h"
 
 namespace drake {
@@ -9,7 +10,7 @@ namespace manipulation {
 namespace planner {
 
 using ConstraintRelaxingIk DRAKE_DEPRECATED(
-    "2023-05-01",
+    "2023-06-01",
     "Please use drake::multibody::ConstraintRelaxingIk instead.") =
     drake::multibody::ConstraintRelaxingIk;
 

--- a/manipulation/planner/stub/differential_inverse_kinematics.h
+++ b/manipulation/planner/stub/differential_inverse_kinematics.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#warning The include path drake/manipulation/planner/differential_inverse_kinematics.h is deprecated and will be removed on or after 2023-06-01; instead, use drake/multibody/inverse_kinematics/differential_inverse_kinematics.h.
+
+#include "drake/common/drake_deprecated.h"
+#include "drake/multibody/inverse_kinematics/differential_inverse_kinematics.h"
+
+namespace drake {
+namespace manipulation {
+namespace planner {
+
+using DifferentialInverseKinematicsStatus DRAKE_DEPRECATED(
+    "2023-06-01",
+    "Please use drake::multibody::DifferentialInverseKinematicsStatus "
+    "instead.") = drake::multibody::DifferentialInverseKinematicsStatus;
+
+using DifferentialInverseKinematicsParameters DRAKE_DEPRECATED(
+    "2023-06-01",
+    "Please use drake::multibody::DifferentialInverseKinematicsParameters "
+    "instead.") = drake::multibody::DifferentialInverseKinematicsParameters;
+
+using DifferentialInverseKinematicsResult DRAKE_DEPRECATED(
+    "2023-06-01",
+    "Please use drake::multibody::DifferentialInverseKinematicsResult "
+    "instead.") = drake::multibody::DifferentialInverseKinematicsResult;
+
+// We can't deprecate this namespace hoisting; instead, we rely on the pragma
+// and assume that correcting the include file will be sufficient.
+using drake::multibody::ComputePoseDiffInCommonFrame;
+using drake::multibody::DoDifferentialInverseKinematics;
+
+}  // namespace planner
+}  // namespace manipulation
+}  // namespace drake

--- a/manipulation/planner/stub/differential_inverse_kinematics_integrator.h
+++ b/manipulation/planner/stub/differential_inverse_kinematics_integrator.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#warning The include path drake/manipulation/planner/differential_inverse_kinematics_integrator.h is deprecated and will be removed on or after 2023-06-01; instead, use drake/multibody/inverse_kinematics/differential_inverse_kinematics_integrator.h.
+
+#include "drake/common/drake_deprecated.h"
+#include "drake/manipulation/planner/differential_inverse_kinematics.h"
+#include "drake/multibody/inverse_kinematics/differential_inverse_kinematics_integrator.h"
+
+namespace drake {
+namespace manipulation {
+namespace planner {
+
+using DifferentialInverseKinematicsIntegrator DRAKE_DEPRECATED(
+    "2023-06-01",
+    "Please use drake::multibody::DifferentialInverseKinematicsIntegrator "
+    "instead.") = drake::multibody::DifferentialInverseKinematicsIntegrator;
+
+}
+}  // namespace manipulation
+}  // namespace drake

--- a/manipulation/planner/stub/robot_plan_interpolator.h
+++ b/manipulation/planner/stub/robot_plan_interpolator.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#warning The include path drake/manipulation/planner/robot_plan_interpolator.h is deprecated and will be removed on or after 2023-05-01; instead, use drake/manipulation/util/robot_plan_interpolator.h.
+#warning The include path drake/manipulation/planner/robot_plan_interpolator.h is deprecated and will be removed on or after 2023-06-01; instead, use drake/manipulation/util/robot_plan_interpolator.h.
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/manipulation/util/robot_plan_interpolator.h"
 
 namespace drake {
@@ -9,12 +10,12 @@ namespace manipulation {
 namespace planner {
 
 using RobotPlanInterpolator DRAKE_DEPRECATED(
-    "2023-05-01",
+    "2023-06-01",
     "Please use  drake::manipulation::util::RobotPlanInterpolator instead.") =
     drake::manipulation::util::RobotPlanInterpolator;
 
 using InterpolatorType DRAKE_DEPRECATED(
-    "2023-05-01",
+    "2023-06-01",
     "Please use  drake::manipulation::util::InterpolatorType instead.") =
     drake::manipulation::util::InterpolatorType;
 

--- a/manipulation/planner/test/deprecation_test.cc
+++ b/manipulation/planner/test/deprecation_test.cc
@@ -4,14 +4,22 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/eigen_types.h"
 #include "drake/common/find_resource.h"
 #include "drake/manipulation/planner/constraint_relaxing_ik.h"
+#include "drake/manipulation/planner/differential_inverse_kinematics.h"
+#include "drake/manipulation/planner/differential_inverse_kinematics_integrator.h"
 #include "drake/manipulation/planner/robot_plan_interpolator.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/parsing/parser.h"
 
 namespace drake {
 namespace manipulation {
 namespace planner {
 namespace {
+
+using Eigen::Vector3d;
+using Eigen::VectorXd;
 
 const char* const kIiwaUrdf =
     "drake/manipulation/models/iiwa_description/urdf/"
@@ -27,6 +35,87 @@ GTEST_TEST(ManipulationPlannerPathsDeprecation, RobotPlanInterpolator) {
   // Include *both* types declared in the header file.
   EXPECT_NO_THROW(RobotPlanInterpolator(FindResourceOrThrow(kIiwaUrdf),
                                         InterpolatorType::ZeroOrderHold));
+}
+
+GTEST_TEST(ManipulationPlannerPathsDeprecation, DifferentialIK) {
+  auto status = DifferentialInverseKinematicsStatus::kSolutionFound;
+  EXPECT_EQ(status, DifferentialInverseKinematicsStatus::kSolutionFound);
+
+  EXPECT_NO_THROW(DifferentialInverseKinematicsResult(
+      {.joint_velocities = std::nullopt, .status = status}));
+
+  EXPECT_NO_THROW(DifferentialInverseKinematicsParameters(1, 1));
+
+  // All three spellings of DoDifferentialInverseKinematics; we'll get them
+  // to throw.
+  multibody::MultibodyPlant<double> plant(0.0);
+  multibody::Parser parser(&plant);
+  const std::string filename = FindResourceOrThrow(
+      "drake/manipulation/models/iiwa_description/urdf/"
+      "planar_iiwa14_spheres_dense_elbow_collision.urdf");
+  parser.AddModels(filename);
+  plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("iiwa_link_0"));
+  plant.Finalize();
+  const multibody::Frame<double>& frame_7 = plant.GetFrameByName("iiwa_link_7");
+  auto context = plant.CreateDefaultContext();
+
+  // Configure the Diff IK.
+  DifferentialInverseKinematicsParameters params(plant.num_positions(),
+                                                 plant.num_velocities());
+  const int num_joints = plant.num_positions();
+  params.set_nominal_joint_position(VectorX<double>::Zero(num_joints));
+  params.set_time_step(1e-3);
+  // The planar model can only move in x, z, and rotations around the link 7
+  // y-axis.
+  params.set_end_effector_velocity_flag(
+      (Vector6<bool>() << false, true, false, true, false, true).finished());
+
+  // Set the initial plant state.  These values were randomly generated.
+  const Vector3d q{0.1, 1.2, 1.6};
+  const VectorXd v = VectorXd::Zero(plant.num_velocities());
+  plant.SetPositions(context.get(), q);
+  plant.SetVelocities(context.get(), v);
+
+  multibody::SpatialVelocity<double> V_WE_W_desired(Vector3d(0, 1, 0),
+                                                    Vector3d(0.1, 0, 0.3));
+  EXPECT_NO_THROW(DoDifferentialInverseKinematics(
+      plant, *context, V_WE_W_desired.get_coeffs(), frame_7, params));
+
+  math::RigidTransform<double> X_WE_desired =
+      math::RigidTransform<double>(Vector3d(-0.02, -0.01, -0.03));
+  EXPECT_NO_THROW(DoDifferentialInverseKinematics(plant, *context, X_WE_desired,
+                                                  frame_7, params));
+
+  const int size = plant.num_velocities();
+  EXPECT_NO_THROW(DoDifferentialInverseKinematics(
+      plant.GetPositions(*context), plant.GetVelocities(*context), v,
+      MatrixX<double>::Identity(size, size), params));
+
+  // Random free function.
+  EXPECT_NO_THROW(ComputePoseDiffInCommonFrame(X_WE_desired, X_WE_desired));
+}
+
+GTEST_TEST(ManipulationPlannerPathsDeprecation, DifferentialIKIntegrator) {
+  // Load the IIWA SDF, welding link_0 to the world.
+  auto robot = std::make_unique<multibody::MultibodyPlant<double>>(0.01);
+  multibody::Parser parser(robot.get());
+  const std::string filename = FindResourceOrThrow(
+      "drake/manipulation/models/"
+      "iiwa_description/sdf/iiwa14_no_collision.sdf");
+  parser.AddModels(filename);
+  robot->WeldFrames(robot->world_frame(), robot->GetFrameByName("iiwa_link_0"));
+  robot->Finalize();
+
+  auto robot_context = robot->CreateDefaultContext();
+  const multibody::Frame<double>& frame_E =
+      robot->GetFrameByName("iiwa_link_7");
+
+  DifferentialInverseKinematicsParameters params(robot->num_positions(),
+                                                 robot->num_velocities());
+
+  const double time_step = 0.1;
+  EXPECT_NO_THROW(DifferentialInverseKinematicsIntegrator diff_ik(
+      *robot, frame_E, time_step, params));
 }
 
 }  // namespace

--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -18,6 +18,8 @@ drake_cc_package_library(
     visibility = ["//visibility:public"],
     deps = [
         ":constraint_relaxing_ik",
+        ":differential_inverse_kinematics",
+        ":differential_inverse_kinematics_integrator",
         ":global_inverse_kinematics",
         ":inverse_kinematics_core",
         ":kinematic_evaluators",
@@ -34,6 +36,28 @@ drake_cc_library(
         "//multibody/parsing",
         "//multibody/plant",
         "//solvers:solve",
+    ],
+)
+
+drake_cc_library(
+    name = "differential_inverse_kinematics",
+    srcs = ["differential_inverse_kinematics.cc"],
+    hdrs = ["differential_inverse_kinematics.h"],
+    deps = [
+        "//multibody/plant",
+        "//solvers:clp_solver",
+        "//solvers:mathematical_program",
+        "//solvers:osqp_solver",
+    ],
+)
+
+drake_cc_library(
+    name = "differential_inverse_kinematics_integrator",
+    srcs = ["differential_inverse_kinematics_integrator.cc"],
+    hdrs = ["differential_inverse_kinematics_integrator.h"],
+    deps = [
+        ":differential_inverse_kinematics",
+        "//systems/framework:leaf_system",
     ],
 )
 
@@ -133,6 +157,33 @@ drake_cc_googletest(
     deps = [
         ":constraint_relaxing_ik",
         "//common:find_resource",
+    ],
+)
+
+drake_cc_googletest(
+    name = "differential_inverse_kinematics_test",
+    data = [
+        "//manipulation/models/iiwa_description:models",
+    ],
+    deps = [
+        ":differential_inverse_kinematics",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//manipulation/kuka_iiwa:iiwa_constants",
+        "//multibody/parsing",
+    ],
+)
+
+drake_cc_googletest(
+    name = "differential_inverse_kinematics_integrator_test",
+    data = [
+        "//manipulation/models/iiwa_description:models",
+    ],
+    deps = [
+        ":differential_inverse_kinematics_integrator",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//manipulation/kuka_iiwa:iiwa_constants",
+        "//multibody/parsing",
+        "//systems/analysis:simulator",
     ],
 )
 

--- a/multibody/inverse_kinematics/differential_inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/differential_inverse_kinematics.cc
@@ -1,4 +1,4 @@
-#include "drake/manipulation/planner/differential_inverse_kinematics.h"
+#include "drake/multibody/inverse_kinematics/differential_inverse_kinematics.h"
 
 #include <memory>
 #include <stdexcept>
@@ -10,8 +10,7 @@
 #include "drake/solvers/osqp_solver.h"
 
 namespace drake {
-namespace manipulation {
-namespace planner {
+namespace multibody {
 
 namespace internal {
 DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
@@ -19,10 +18,10 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     const Eigen::Ref<const VectorX<double>>& v_current,
     const math::RigidTransform<double>& X_WE,
     const Eigen::Ref<const Matrix6X<double>>& J_WE_W,
-    const multibody::SpatialVelocity<double>& V_WE_desired,
+    const SpatialVelocity<double>& V_WE_desired,
     const DifferentialInverseKinematicsParameters& parameters) {
   const math::RotationMatrix<double> R_EW = X_WE.rotation().transpose();
-  const multibody::SpatialVelocity<double> V_WE_E = R_EW * V_WE_desired;
+  const SpatialVelocity<double> V_WE_E = R_EW * V_WE_desired;
 
   // Rotate the 6 x n Jacobian from the world frame W to the E frame.
   // TODO(Mitiguy) Switch to direct application of RotationMatrix multiplied by
@@ -224,30 +223,30 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
 }
 
 DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
-    const multibody::MultibodyPlant<double>& plant,
+    const MultibodyPlant<double>& plant,
     const systems::Context<double>& context,
     const Vector6<double>& V_WE_desired,
-    const multibody::Frame<double>& frame_E,
+    const Frame<double>& frame_E,
     const DifferentialInverseKinematicsParameters& parameters) {
   const math::RigidTransform<double> X_WE =
       plant.CalcRelativeTransform(context, plant.world_frame(), frame_E);
   MatrixX<double> J_WE(6, plant.num_velocities());
-  const multibody::Frame<double>& frame_W = plant.world_frame();
+  const Frame<double>& frame_W = plant.world_frame();
   plant.CalcJacobianSpatialVelocity(context,
-                                    multibody::JacobianWrtVariable::kV,
+                                    JacobianWrtVariable::kV,
                                     frame_E, Vector3<double>::Zero(),
                                     frame_W, frame_W, &J_WE);
 
   return internal::DoDifferentialInverseKinematics(
       plant.GetPositions(context), plant.GetVelocities(context),
-      X_WE, J_WE, multibody::SpatialVelocity<double>(V_WE_desired), parameters);
+      X_WE, J_WE, SpatialVelocity<double>(V_WE_desired), parameters);
 }
 
 DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
-    const multibody::MultibodyPlant<double>& plant,
+    const MultibodyPlant<double>& plant,
     const systems::Context<double>& context,
     const math::RigidTransform<double>& X_WE_desired,
-    const multibody::Frame<double>& frame_E,
+    const Frame<double>& frame_E,
     const DifferentialInverseKinematicsParameters& parameters) {
   const math::RigidTransform<double> X_WE =
       plant.EvalBodyPoseInWorld(context, frame_E.body()) *
@@ -275,6 +274,5 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
                                          parameters);
 }
 
-}  // namespace planner
-}  // namespace manipulation
+}  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/differential_inverse_kinematics.h
+++ b/multibody/inverse_kinematics/differential_inverse_kinematics.h
@@ -19,8 +19,7 @@
 #include "drake/solvers/mathematical_program.h"
 
 namespace drake {
-namespace manipulation {
-namespace planner {
+namespace multibody {
 
 enum class DifferentialInverseKinematicsStatus {
   kSolutionFound,    ///< Found the optimal solution.
@@ -366,10 +365,10 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
  * @ingroup planning
  */
 DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
-    const multibody::MultibodyPlant<double>& robot,
+    const MultibodyPlant<double>& robot,
     const systems::Context<double>& context,
     const Vector6<double>& V_WE_desired,
-    const multibody::Frame<double>& frame_E,
+    const Frame<double>& frame_E,
     const DifferentialInverseKinematicsParameters& parameters);
 
 /**
@@ -391,10 +390,10 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
  * @ingroup planning
  */
 DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
-    const multibody::MultibodyPlant<double>& robot,
+    const MultibodyPlant<double>& robot,
     const systems::Context<double>& context,
     const math::RigidTransform<double>& X_WE_desired,
-    const multibody::Frame<double>& frame_E,
+    const Frame<double>& frame_E,
     const DifferentialInverseKinematicsParameters& parameters);
 
 #ifndef DRAKE_DOXYGEN_CXX
@@ -404,11 +403,10 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     const Eigen::Ref<const VectorX<double>>&,
     const math::RigidTransform<double>&,
     const Eigen::Ref<const Matrix6X<double>>&,
-    const multibody::SpatialVelocity<double>&,
+    const SpatialVelocity<double>&,
     const DifferentialInverseKinematicsParameters&);
 }  // namespace internal
 #endif
 
-}  // namespace planner
-}  // namespace manipulation
+}  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/differential_inverse_kinematics_integrator.cc
+++ b/multibody/inverse_kinematics/differential_inverse_kinematics_integrator.cc
@@ -1,19 +1,18 @@
-#include "drake/manipulation/planner/differential_inverse_kinematics_integrator.h"  // noqa
+#include "drake/multibody/inverse_kinematics/differential_inverse_kinematics_integrator.h"  // noqa
 
 #include "drake/common/text_logging.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
-namespace manipulation {
-namespace planner {
+namespace multibody {
 
 using systems::Context;
 
 DifferentialInverseKinematicsIntegrator::
     DifferentialInverseKinematicsIntegrator(
-        const multibody::MultibodyPlant<double>& robot,
-        const multibody::Frame<double>& frame_E, double time_step,
+        const MultibodyPlant<double>& robot,
+        const Frame<double>& frame_E, double time_step,
         const DifferentialInverseKinematicsParameters& parameters,
         const Context<double>* context, bool log_only_when_result_state_changes)
     : robot_(robot),
@@ -187,6 +186,5 @@ systems::EventStatus DifferentialInverseKinematicsIntegrator::Initialize(
   return systems::EventStatus::DidNothing();
 }
 
-}  // namespace planner
-}  // namespace manipulation
+}  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/differential_inverse_kinematics_integrator.h
+++ b/multibody/inverse_kinematics/differential_inverse_kinematics_integrator.h
@@ -2,14 +2,13 @@
 
 #include <vector>
 
-#include "drake/manipulation/planner/differential_inverse_kinematics.h"
 #include "drake/math/rigid_transform.h"
+#include "drake/multibody/inverse_kinematics/differential_inverse_kinematics.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
-namespace manipulation {
-namespace planner {
+namespace multibody {
 
 /** A LeafSystem which uses DoDifferentialInverseKinematics to produce joint
 position commands.
@@ -75,8 +74,8 @@ class DifferentialInverseKinematicsIntegrator
   Note: All references must remain valid for the lifetime of this system.
   */
   DifferentialInverseKinematicsIntegrator(
-      const multibody::MultibodyPlant<double>& robot,
-      const multibody::Frame<double>& frame_E, double time_step,
+      const MultibodyPlant<double>& robot,
+      const Frame<double>& frame_E, double time_step,
       // Note: parameters last so they could be optional in the future.
       const DifferentialInverseKinematicsParameters& parameters,
       const systems::Context<double>* robot_context = nullptr,
@@ -121,8 +120,8 @@ class DifferentialInverseKinematicsIntegrator
       const systems::Context<double>& context,
       systems::DiscreteValues<double>* values) const;
 
-  const multibody::MultibodyPlant<double>& robot_;
-  const multibody::Frame<double>& frame_E_;
+  const MultibodyPlant<double>& robot_;
+  const Frame<double>& frame_E_;
   DifferentialInverseKinematicsParameters parameters_;
   const double time_step_{0.0};
   const systems::CacheEntry* robot_context_cache_entry_{};
@@ -131,6 +130,5 @@ class DifferentialInverseKinematicsIntegrator
   systems::InputPortIndex use_robot_state_index_{};
 };
 
-}  // namespace planner
-}  // namespace manipulation
+}  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/test/differential_inverse_kinematics_integrator_test.cc
+++ b/multibody/inverse_kinematics/test/differential_inverse_kinematics_integrator_test.cc
@@ -1,4 +1,4 @@
-#include "drake/manipulation/planner/differential_inverse_kinematics_integrator.h"  // noqa
+#include "drake/multibody/inverse_kinematics/differential_inverse_kinematics_integrator.h"  // noqa
 
 #include <gtest/gtest.h>
 
@@ -10,8 +10,7 @@
 #include "drake/systems/analysis/simulator.h"
 
 namespace drake {
-namespace manipulation {
-namespace planner {
+namespace multibody {
 
 namespace {
 
@@ -244,6 +243,5 @@ GTEST_TEST(DifferentialInverseKinematicsIntegratorTest,
 }
 
 }  // namespace
-}  // namespace planner
-}  // namespace manipulation
+}  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/test/differential_inverse_kinematics_test.cc
+++ b/multibody/inverse_kinematics/test/differential_inverse_kinematics_test.cc
@@ -1,4 +1,4 @@
-#include "drake/manipulation/planner/differential_inverse_kinematics.h"
+#include "drake/multibody/inverse_kinematics/differential_inverse_kinematics.h"
 
 #include <memory>
 #include <optional>
@@ -16,8 +16,7 @@
 #include "drake/solvers/constraint.h"
 
 namespace drake {
-namespace manipulation {
-namespace planner {
+namespace multibody {
 
 namespace {
 
@@ -403,6 +402,5 @@ GTEST_TEST(AdditionalDifferentialInverseKinematicsTests, TestLinearObjective) {
 }
 
 }  // namespace
-}  // namespace planner
-}  // namespace manipulation
+}  // namespace multibody
 }  // namespace drake

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -49,7 +49,7 @@ LIBDRAKE_COMPONENTS = [
     "//lcm",
     "//manipulation/kinova_jaco",
     "//manipulation/kuka_iiwa",
-    "//manipulation/planner",  # 2023-05-01 Remove this with completed deprecation  # noqa
+    "//manipulation/planner",  # 2023-06-01 Remove this with completed deprecation  # noqa
     "//manipulation/schunk_wsg",
     "//manipulation/util",
     "//math",

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -49,7 +49,7 @@ LIBDRAKE_COMPONENTS = [
     "//lcm",
     "//manipulation/kinova_jaco",
     "//manipulation/kuka_iiwa",
-    "//manipulation/planner",
+    "//manipulation/planner",  # 2023-05-01 Remove this with completed deprecation  # noqa
     "//manipulation/schunk_wsg",
     "//manipulation/util",
     "//math",


### PR DESCRIPTION
 - manipulation/planner/differential_inverse_dynamics* goes to multibody/inverse_dynamics.

Moving includes updating all references, namespaces, and bindings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18715)
<!-- Reviewable:end -->
