### PR TITLE
Add Clone support to SceneGraph and RobotDiagram

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -248,6 +248,7 @@ drake_cc_library(
         ":proximity_engine",
         ":utilities",
         "//geometry/render:render_engine",
+        "//math:gradient",
     ],
 )
 

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -561,13 +561,6 @@ const GeometryState<T>& SceneGraph<T>::geometry_state(
 }
 
 }  // namespace geometry
-
-namespace systems {
-namespace scalar_conversion {
-template <> struct Traits<geometry::SceneGraph> : public FromDoubleTraits {};
-}  // namespace scalar_conversion
-}  // namespace systems
-
 }  // namespace drake
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -304,8 +304,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
   /** Constructs a default (empty) scene graph. */
   SceneGraph();
 
-  /** Constructor used for scalar conversions. It should only be used to convert
-   _from_ double _to_ other scalar types.  */
+  /** Constructor used for scalar conversions. */
   template <typename U>
   explicit SceneGraph(const SceneGraph<U>& other);
 

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -429,13 +429,35 @@ TYPED_TEST_P(TypedSceneGraphTest, TransmogrifyContext) {
   DRAKE_EXPECT_NO_THROW(context_U->SetTimeStateAndParametersFrom(context_T));
 }
 
+// Tests Clone for a non-double SceneGraph.
+// We'll rely on the lack of any exceptions as the success criterion;
+// the cloning and conversion code has enough fail-fast checks built in.
+TYPED_TEST_P(TypedSceneGraphTest, NonDoubleClone) {
+  using U = TypeParam;
+  std::unique_ptr<SceneGraph<U>> scene_graph_U =
+      System<double>::ToScalarType<U>(this->scene_graph_);
+  std::unique_ptr<SceneGraph<U>> copy;
+  EXPECT_NO_THROW(copy = System<U>::Clone(*scene_graph_U));
+  ASSERT_NE(copy, nullptr);
+}
+
 REGISTER_TYPED_TEST_SUITE_P(TypedSceneGraphTest,
     TransmogrifyWithoutAllocation,
     TransmogrifyPorts,
-    TransmogrifyContext);
+    TransmogrifyContext,
+    NonDoubleClone);
 
 using NonDoubleScalarTypes = ::testing::Types<AutoDiffXd, Expression>;
 INSTANTIATE_TYPED_TEST_SUITE_P(My, TypedSceneGraphTest, NonDoubleScalarTypes);
+
+// Tests Clone for a non-double SceneGraph.
+// We'll rely on the lack of any exceptions as the success criterion;
+// the cloning and conversion code has enough fail-fast checks built in.
+TEST_F(SceneGraphTest, DoubleClone) {
+  std::unique_ptr<SceneGraph<double>> copy;
+  EXPECT_NO_THROW(copy = System<double>::Clone(scene_graph_));
+  ASSERT_NE(copy, nullptr);
+}
 
 // Tests the model inspector. Exercises a token piece of functionality. The
 // inspector is a wrapper on the GeometryState. It is assumed that GeometryState

--- a/planning/robot_diagram.cc
+++ b/planning/robot_diagram.cc
@@ -58,7 +58,7 @@ RobotDiagram<T>::~RobotDiagram() = default;
 template <typename T>
 template <typename U>
 RobotDiagram<T>::RobotDiagram(const RobotDiagram<U>& other)
-    : Diagram<T>(other),
+    : Diagram<T>(SystemTypeTag<RobotDiagram>{}, other),
       plant_(DowncastSubsystem<T, MultibodyPlant>(this, kPlantIndex)),
       scene_graph_(DowncastSubsystem<T, SceneGraph>(this, kSceneGraphIndex)) {}
 

--- a/planning/test/robot_diagram_test.cc
+++ b/planning/test/robot_diagram_test.cc
@@ -167,6 +167,17 @@ GTEST_TEST(RobotDiagramTest, ContextGetters) {
   EXPECT_NO_THROW(dut->scene_graph().ValidateContext(scene_graph_context));
 }
 
+GTEST_TEST(RobotDiagramTest, Clone) {
+  std::unique_ptr<RobotDiagram<double>> dut = MakeSampleDut()->BuildDiagram();
+  std::unique_ptr<RobotDiagram<double>> copy = System<double>::Clone(*dut);
+
+  // Sanity check: the new plant is part of the new diagram.
+  EXPECT_THAT(copy->GetSystems(), ::testing::Contains(&copy->plant()));
+
+  // The new plant is distinct from the old plant.
+  EXPECT_NE(&copy->plant(), &dut->plant());
+}
+
 }  // namespace
 }  // namespace planning
 }  // namespace drake

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -257,6 +257,18 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   /// related to scalar-type conversion support.
   explicit Diagram(SystemScalarConverter converter);
 
+  /// (Advanced) Scalar-converting constructor, for used by derived classes
+  /// that are performing a conversion and also need to supply a `converter`
+  /// that preserves subtypes for additional conversions.
+  ///
+  /// See @ref system_scalar_conversion for detailed background and examples
+  /// related to scalar-type conversion support.
+  template <typename U>
+  Diagram(SystemScalarConverter converter, const Diagram<U>& other)
+      : Diagram(std::move(converter)) {
+    Initialize(other.template ConvertScalarType<T>());
+  }
+
   /// For the subsystem associated with @p witness_func, gets its subcontext
   /// from @p context, passes the subcontext to @p witness_func' Evaluate
   /// method and returns the result. Aborts if the subsystem is not part of

--- a/systems/framework/system_scalar_conversion_doxygen.h
+++ b/systems/framework/system_scalar_conversion_doxygen.h
@@ -327,6 +327,10 @@ class SpecialDiagram<T> final : public Diagram<T> {
     builder.ExportOutput(integrator->get_output_port());
     builder.BuildInto(this);
   }
+  // Scalar-converting copy constructor.  See @ref system_scalar_conversion.
+  template <typename U>
+  explicit SpecialDiagram(const SpecialDiagram<U>& other)
+      : SpecialDiagram<T>(SystemTypeTag<SpecialDiagram>{}, other) {}
 };
 @endcode
 

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -1565,7 +1565,7 @@ class FeedbackDiagram : public Diagram<T> {
   // Scalar-converting copy constructor.
   template <typename U>
   explicit FeedbackDiagram(const FeedbackDiagram<U>& other)
-      : Diagram<T>(other) {}
+      : Diagram<T>(SystemTypeTag<FeedbackDiagram>{}, other) {}
 };
 
 // Tests that since there are no outputs, there is no direct feedthrough.
@@ -1592,6 +1592,11 @@ TEST_F(DiagramTest, SubclassTransmogrificationTest) {
   EXPECT_TRUE(is_symbolic_convertible(dut, [](const auto& converted) {
     EXPECT_FALSE(converted.HasAnyDirectFeedthrough());
   }));
+
+  // Check that the subtype makes it all the way through cloning.
+  // Any mismatched subtype will fail-fast within the Clone implementation.
+  std::unique_ptr<FeedbackDiagram<double>> copy = System<double>::Clone(dut);
+  EXPECT_NE(copy, nullptr);
 
   // Diagram subclasses that declare a specific SystemTypeTag but then use a
   // subclass at runtime will fail-fast.


### PR DESCRIPTION
In support, amend `SceneGraph` to support `AutoDiff`-to-`double` and `Expression`-to-`double` scalar conversions.

In support, enhance `Diagram` scalar conversion to allow preserving subtypes even across multiple chained conversions (which is how we implement cloning for systems).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18717)
<!-- Reviewable:end -->
