### PR TITLE
SpatialInertia tetrahedron calculations always returns a valid spatial inertia.

### DIFF
--- a/multibody/tree/spatial_inertia.cc
+++ b/multibody/tree/spatial_inertia.cc
@@ -145,21 +145,15 @@ SpatialInertia<T> SpatialInertia<T>::SolidTetrahedronAboutVertexWithDensity(
     const T& density, const Vector3<T>& p1, const Vector3<T>& p2,
     const Vector3<T>& p3) {
   DRAKE_THROW_UNLESS(density >= 0);
-  // The calculations of the volume and mass of a general shape sometimes rely
-  // on decomposing the general shape into many tetrahedrons.  Some of those
-  // tetrahedrons may have negative volume (and mass) due to intentional
-  // ordering p1, p2, p3 (i.e., negative mass is not necessarily a mistake).
-  const T volume = (1.0 / 6.0) * p1.cross(p2).dot(p3);
+  using std::abs;
+  const T volume = (1.0 / 6.0) * abs(p1.cross(p2).dot(p3));
   const T mass = density * volume;
 
-  // Form position vector from tetrahedron B's vertex at Bo to Bcm (B's center
-  // of mass).
+  // Get position from tetrahedron B's vertex at Bo to Bcm (B's center of mass).
   const Vector3<T> p_BoBcm = 0.25 * (p1 + p2 + p3);
   const UnitInertia<T> G_BBo =
       UnitInertia<T>::SolidTetrahedronAboutVertex(p1, p2, p3);
-  // Ensure negative mass, etc. can be a valid possibility for this function.
-  return SpatialInertia<T>(mass, p_BoBcm, G_BBo,
-      /* skip_validity_check = */ true);
+  return SpatialInertia<T>(mass, p_BoBcm, G_BBo);
 }
 
 template <typename T>

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -212,11 +212,6 @@ class SpatialInertia {
   ///     SpatialInertia<double>::SolidTetrahedronAboutPointWithDensity(
   ///         density, p_WoB0_W, p_WoB1_W, p_WoB2_W, p_WoB3_W);
   /// @endcode
-  /// @note A positive volume (and mass) occurs if vertices B0, B1, B2 define a
-  /// triangle with its right-handed normal pointing inward (toward vertex B3).
-  /// A zero volume means B is a triangle, line, or point (not a tetrahedron).
-  /// A negative volume occurs if the triangle defined by B0, B1, B2 has its
-  /// right-handed normal pointing outward (away from vertex B3).
   /// @see SolidTetrahedronAboutVertexWithDensity() to efficiently calculate a
   /// spatial inertia about a vertex of B.
   static SpatialInertia<T> SolidTetrahedronAboutPointWithDensity(
@@ -233,14 +228,6 @@ class SpatialInertia {
   /// @param[in] p3 position vector p_B0B3_E from B0 to B3, expressed in E.
   /// @retval M_BB0_E B's spatial inertia about its vertex B0, expressed in E.
   /// @pre density ≥ 0.
-  /// @note A positive volume (and mass) occurs if vertices B0, B1, B2 define a
-  /// triangle with its right-handed normal pointing inward (toward vertex B3).
-  /// In other words the volume is positive if  p1.cross(p2).dot(p3) > 0.
-  /// A zero volume means B is a triangle, line, or point (not a tetrahedron).
-  /// In other words the volume is zero if p1.cross(p2).dot(p3) = 0.
-  /// A negative volume occurs if the triangle defined by B0, B1, B2 has its
-  /// right-handed normal pointing outward (away from vertex B3).
-  /// In other words the volume is negative if p1.cross(p2).dot(p3) < 0.
   /// @see SolidTetrahedronAboutPointWithDensity() to calculate a spatial
   /// inertia about an arbitrary point.
   static SpatialInertia<T> SolidTetrahedronAboutVertexWithDensity(

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -259,8 +259,8 @@ GTEST_TEST(SpatialInertia, SolidTetrahedronAboutVertex) {
   const Vector3<double> p_B0Bcm = 0.25 * (p1 + p2 + p3);
   const UnitInertia<double> G_BB0 =
       UnitInertia<double>::SolidTetrahedronAboutVertex(p1, p2, p3);
-  SpatialInertia<double> M_BB0_expected(mass, p_B0Bcm, G_BB0);
-  SpatialInertia<double> M_BB0 =
+  const SpatialInertia<double> M_BB0_expected(mass, p_B0Bcm, G_BB0);
+  const SpatialInertia<double> M_BB0 =
       SpatialInertia<double>::SolidTetrahedronAboutVertexWithDensity(
           density, p1, p2, p3);
 

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -268,13 +268,6 @@ GTEST_TEST(SpatialInertia, SolidTetrahedronAboutVertex) {
   const double kTolerance = 4 * std::numeric_limits<double>::epsilon();
   EXPECT_TRUE(CompareMatrices(M_BB0_expected.CopyToFullMatrix6(),
                               M_BB0.CopyToFullMatrix6(), kTolerance));
-
-  // Ensure nothing changes if two arguments are switched (e.g., p1 and p2).
-  M_BB0_expected = SpatialInertia<double>(mass, p_B0Bcm, G_BB0);
-  M_BB0 = SpatialInertia<double>::SolidTetrahedronAboutVertexWithDensity(
-          density, p2, p1, p3);
-  EXPECT_TRUE(CompareMatrices(M_BB0_expected.CopyToFullMatrix6(),
-                              M_BB0.CopyToFullMatrix6(), kTolerance));
 }
 
 // Test spatial inertia of a solid tetrahedron about an arbitrary point A.
@@ -307,16 +300,6 @@ GTEST_TEST(SpatialInertia, SolidTetrahedronAboutPoint) {
   M_BA_expected.ShiftInPlace(-p_AB0);
   M_BA = SpatialInertia<double>::SolidTetrahedronAboutPointWithDensity(
           density, p_AB0, p_AB1, p_AB2, p_AB3);
-  EXPECT_TRUE(CompareMatrices(M_BA_expected.CopyToFullMatrix6(),
-                              M_BA.CopyToFullMatrix6(), kTolerance));
-
-  // Ensure nothing changes if two arguments are switched (e.g., p_AB2, p_AB3).
-  const double mass = M_BA_expected.get_mass();
-  const Vector3<double> p_ABcm = M_BA_expected.get_com();
-  const UnitInertia<double> G_BA = M_BA_expected.get_unit_inertia();
-  M_BA_expected = SpatialInertia<double>(mass, p_ABcm, G_BA);
-  M_BA = SpatialInertia<double>::SolidTetrahedronAboutPointWithDensity(density,
-      p_AB0, p_AB1, p_AB3, p_AB2);
   EXPECT_TRUE(CompareMatrices(M_BA_expected.CopyToFullMatrix6(),
                               M_BA.CopyToFullMatrix6(), kTolerance));
 }

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -260,12 +260,18 @@ GTEST_TEST(SpatialInertia, SolidTetrahedronAboutVertex) {
   const UnitInertia<double> G_BB0 =
       UnitInertia<double>::SolidTetrahedronAboutVertex(p1, p2, p3);
   const SpatialInertia<double> M_BB0_expected(mass, p_B0Bcm, G_BB0);
-  const SpatialInertia<double> M_BB0 =
+  SpatialInertia<double> M_BB0 =
       SpatialInertia<double>::SolidTetrahedronAboutVertexWithDensity(
           density, p1, p2, p3);
 
   // An empirical tolerance: two bits = 2^2 times machine epsilon.
   const double kTolerance = 4 * std::numeric_limits<double>::epsilon();
+  EXPECT_TRUE(CompareMatrices(M_BB0_expected.CopyToFullMatrix6(),
+                              M_BB0.CopyToFullMatrix6(), kTolerance));
+
+  // Ensure nothing changes if two arguments are switched (e.g., p1 and p2).
+  M_BB0 = SpatialInertia<double>::SolidTetrahedronAboutVertexWithDensity(
+          density, p2, p1, p3);
   EXPECT_TRUE(CompareMatrices(M_BB0_expected.CopyToFullMatrix6(),
                               M_BB0.CopyToFullMatrix6(), kTolerance));
 }
@@ -300,6 +306,12 @@ GTEST_TEST(SpatialInertia, SolidTetrahedronAboutPoint) {
   M_BA_expected.ShiftInPlace(-p_AB0);
   M_BA = SpatialInertia<double>::SolidTetrahedronAboutPointWithDensity(
           density, p_AB0, p_AB1, p_AB2, p_AB3);
+  EXPECT_TRUE(CompareMatrices(M_BA_expected.CopyToFullMatrix6(),
+                              M_BA.CopyToFullMatrix6(), kTolerance));
+
+  // Ensure nothing changes if two arguments are switched (e.g., p_AB2, p_AB3).
+  M_BA = SpatialInertia<double>::SolidTetrahedronAboutPointWithDensity(density,
+      p_AB0, p_AB1, p_AB3, p_AB2);
   EXPECT_TRUE(CompareMatrices(M_BA_expected.CopyToFullMatrix6(),
                               M_BA.CopyToFullMatrix6(), kTolerance));
 }

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -269,9 +269,8 @@ GTEST_TEST(SpatialInertia, SolidTetrahedronAboutVertex) {
   EXPECT_TRUE(CompareMatrices(M_BB0_expected.CopyToFullMatrix6(),
                               M_BB0.CopyToFullMatrix6(), kTolerance));
 
-  // Ensure mass becomes negative if the first two arguments are switched.
-  M_BB0_expected = SpatialInertia<double>(-mass, p_B0Bcm, G_BB0,
-      /* skip_validity_check = */ true);
+  // Ensure nothing changes if two arguments are switched (e.g., p1 and p2).
+  M_BB0_expected = SpatialInertia<double>(mass, p_B0Bcm, G_BB0);
   M_BB0 = SpatialInertia<double>::SolidTetrahedronAboutVertexWithDensity(
           density, p2, p1, p3);
   EXPECT_TRUE(CompareMatrices(M_BB0_expected.CopyToFullMatrix6(),
@@ -301,7 +300,7 @@ GTEST_TEST(SpatialInertia, SolidTetrahedronAboutPoint) {
                               M_BA.CopyToFullMatrix6(), kTolerance));
 
   // Check a more general case in which p_AB0 is a non-zero vector.
-  p_AB0 = Vector3<double>(0.1, 0.4, 0.5);
+  p_AB0 = Vector3<double>(1, 4, 5);
   p_AB1 += p_AB0;
   p_AB2 += p_AB0;
   p_AB3 += p_AB0;
@@ -311,12 +310,11 @@ GTEST_TEST(SpatialInertia, SolidTetrahedronAboutPoint) {
   EXPECT_TRUE(CompareMatrices(M_BA_expected.CopyToFullMatrix6(),
                               M_BA.CopyToFullMatrix6(), kTolerance));
 
-  // Ensure mass becomes negative if the two arguments are switched.
+  // Ensure nothing changes if two arguments are switched (e.g., p_AB2, p_AB3).
   const double mass = M_BA_expected.get_mass();
   const Vector3<double> p_ABcm = M_BA_expected.get_com();
   const UnitInertia<double> G_BA = M_BA_expected.get_unit_inertia();
-  M_BA_expected = SpatialInertia<double>(-mass, p_ABcm, G_BA,
-                                         /* skip_validity_check = */ true);
+  M_BA_expected = SpatialInertia<double>(mass, p_ABcm, G_BA);
   M_BA = SpatialInertia<double>::SolidTetrahedronAboutPointWithDensity(density,
       p_AB0, p_AB1, p_AB3, p_AB2);
   EXPECT_TRUE(CompareMatrices(M_BA_expected.CopyToFullMatrix6(),


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18725)
<!-- Reviewable:end -->
