### PR TITLE
[parsing] Fix URDF planar joint support

### DIFF
--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -571,7 +571,10 @@ void UrdfParser::ParseJoint(
     plant->AddJoint<BallRpyJoint>(name, *parent_body, X_PJ,
                                   *child_body, std::nullopt, damping);
   } else if (type.compare("planar") == 0) {
-    throw_on_custom_joint(true);
+    // Permit both the standard 'joint' and custom 'drake:joint' spellings
+    // here. The standard spelling was actually always correct, but Drake only
+    // supported the custom spelling for quite some time, and some model files
+    // are likely spelled that way. See #18730.
     Vector3d damping_vec(0, 0, 0);
     XMLElement* dynamics_node = node->FirstChildElement("dynamics");
     if (dynamics_node) {

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -768,6 +768,20 @@ TEST_F(UrdfParserTest, JointParsingTest) {
       CompareMatrices(screw_joint.acceleration_upper_limits(), inf));
 }
 
+// Custom planar joints were not necessary, but long supported. See #18730.
+TEST_F(UrdfParserTest, LegacyPlanarJointAsCustomTest) {
+  constexpr const char* model = R"""(
+    <robot name='a'>
+      <link name="link1"/>
+      <link name="link2"/>
+      <drake:joint name="planar_joint" type="planar">
+        <parent link="link1"/>
+        <child link="link2"/>
+      </drake:joint>
+    </robot>)""";
+  EXPECT_NE(AddModelFromUrdfString(model, ""), std::nullopt);
+}
+
 TEST_F(UrdfParserTest, JointParsingTagMismatchTest) {
   // Improperly declared joints.
   const std::string full_name_mismatch_1 = FindResourceOrThrow(

--- a/multibody/parsing/test/urdf_parser_test/joint_parsing_test.urdf
+++ b/multibody/parsing/test/urdf_parser_test/joint_parsing_test.urdf
@@ -95,12 +95,12 @@ Defines a URDF model with various types of joints.
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <dynamics damping="0.1"/>
   </drake:joint>
-  <drake:joint name="planar_joint" type="planar">
+  <joint name="planar_joint" type="planar">
     <parent link="link6"/>
     <child link="link7"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <dynamics damping="0.1 0.1 0.1"/>
-  </drake:joint>
+  </joint>
   <joint name="continuous_joint" type="continuous">
     <axis xyz="0 0 1"/>
     <parent link="link7"/>


### PR DESCRIPTION
Support the correct, standard 'joint' spelling of planar joints. Since Drake only supported the incorrect 'drake:joint' spelling for several years, continue to accept that as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18735)
<!-- Reviewable:end -->
