### PR TITLE
[multibody] Allow opt out of adjacent body collision filters

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -972,6 +972,12 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("get_contact_surface_representation",
             &Class::get_contact_surface_representation,
             cls_doc.get_contact_surface_representation.doc)
+        .def("set_adjacent_bodies_collision_filters",
+            &Class::set_adjacent_bodies_collision_filters, py::arg("value"),
+            cls_doc.set_adjacent_bodies_collision_filters.doc)
+        .def("get_adjacent_bodies_collision_filters",
+            &Class::get_adjacent_bodies_collision_filters,
+            cls_doc.get_adjacent_bodies_collision_filters.doc)
         .def("AddPhysicalModel", &Class::AddPhysicalModel, py::arg("model"),
             cls_doc.AddPhysicalModel.doc)
         .def("physical_models", &Class::physical_models,

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2331,6 +2331,14 @@ class TestPlant(unittest.TestCase):
                 self.assertEqual(
                     plant.get_contact_surface_representation(), rep)
 
+    def test_adjacent_bodies_collision_filters(self):
+        plant = MultibodyPlant_[float](0.1)
+        values = [False, True]
+        for value in values:
+            plant.set_adjacent_bodies_collision_filters(value=value)
+            self.assertEqual(plant.get_adjacent_bodies_collision_filters(),
+                             value)
+
     def test_contact_results_to_lcm(self):
         # ContactResultsToLcmSystem
         file_name = FindResourceOrThrow(

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1809,6 +1809,22 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     return contact_surface_representation_;
   }
 
+  /// Sets whether to apply collision filters to topologically adjacent bodies
+  /// at Finalize() time.  Filters are applied when there exists a joint
+  /// between bodies, except in the case of 6-dof joints or joints in which the
+  /// parent body is `world`.
+  /// @throws std::exception iff called post-finalize.
+  void set_adjacent_bodies_collision_filters(bool value) {
+    DRAKE_MBP_THROW_IF_FINALIZED();
+    adjacent_bodies_collision_filters_ = value;
+  }
+
+  /// Returns whether to apply collision filters to topologically adjacent
+  /// bodies at Finalize() time.
+  bool get_adjacent_bodies_collision_filters() const {
+    return adjacent_bodies_collision_filters_;
+  }
+
   /// For use only by advanced developers wanting to try out their custom time
   /// stepping strategies, including contact resolution.
   ///
@@ -5177,6 +5193,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // Vector (with size num_bodies()) of default poses for each body. This is
   // only used if Body::is_floating() is true.
   std::vector<math::RigidTransform<double>> X_WB_default_list_;
+
+  // Whether to apply collsion filters to adjacent bodies at Finalize().
+  bool adjacent_bodies_collision_filters_{
+    MultibodyPlantConfig{}.adjacent_bodies_collision_filters};
 };
 
 /// @cond

--- a/multibody/plant/multibody_plant_config.h
+++ b/multibody/plant/multibody_plant_config.h
@@ -22,6 +22,7 @@ struct MultibodyPlantConfig {
     a->Visit(DRAKE_NVP(contact_model));
     a->Visit(DRAKE_NVP(discrete_contact_solver));
     a->Visit(DRAKE_NVP(contact_surface_representation));
+    a->Visit(DRAKE_NVP(adjacent_bodies_collision_filters));
   }
 
   /// Configures the MultibodyPlant::MultibodyPlant() constructor time_step.
@@ -62,6 +63,9 @@ struct MultibodyPlantConfig {
   /// chosen above; keep this consistent with
   /// MultibodyPlant::GetDefaultContactSurfaceRepresentation().
   std::string contact_surface_representation{"polygon"};
+
+  /// Configures the MultibodyPlant::set_adjacent_bodies_collision_filters().
+  bool adjacent_bodies_collision_filters{true};
 };
 
 }  // namespace multibody

--- a/multibody/plant/multibody_plant_config_functions.cc
+++ b/multibody/plant/multibody_plant_config_functions.cc
@@ -25,6 +25,8 @@ AddResult AddMultibodyPlant(
   result.plant.set_contact_surface_representation(
       internal::GetContactSurfaceRepresentationFromString(
           config.contact_surface_representation));
+  result.plant.set_adjacent_bodies_collision_filters(
+      config.adjacent_bodies_collision_filters);
   return result;
 }
 

--- a/multibody/plant/test/multibody_plant_config_functions_test.cc
+++ b/multibody/plant/test/multibody_plant_config_functions_test.cc
@@ -19,6 +19,7 @@ GTEST_TEST(MultibodyPlantConfigFunctionsTest, BasicTest) {
   config.stiction_tolerance = 0.004;
   config.contact_model = "hydroelastic";
   config.contact_surface_representation = "polygon";
+  config.adjacent_bodies_collision_filters = false;
 
   drake::systems::DiagramBuilder<double> builder;
   auto result = AddMultibodyPlant(config, &builder);
@@ -27,6 +28,7 @@ GTEST_TEST(MultibodyPlantConfigFunctionsTest, BasicTest) {
             ContactModel::kHydroelasticsOnly);
   EXPECT_EQ(result.plant.get_contact_surface_representation(),
             geometry::HydroelasticContactRepresentation::kPolygon);
+  EXPECT_EQ(result.plant.get_adjacent_bodies_collision_filters(), false);
   // There is no getter for penetration_allowance nor stiction_tolerance, so we
   // can't test them.
 }
@@ -38,6 +40,7 @@ stiction_tolerance: 0.004
 contact_model: hydroelastic
 discrete_contact_solver: sap
 contact_surface_representation: triangle
+adjacent_bodies_collision_filters: false
 )""";
 
 GTEST_TEST(MultibodyPlantConfigFunctionsTest, YamlTest) {
@@ -51,6 +54,7 @@ GTEST_TEST(MultibodyPlantConfigFunctionsTest, YamlTest) {
             geometry::HydroelasticContactRepresentation::kTriangle);
   EXPECT_EQ(result.plant.get_discrete_contact_solver(),
             DiscreteContactSolver::kSap);
+  EXPECT_EQ(result.plant.get_adjacent_bodies_collision_filters(), false);
   // There is no getter for penetration_allowance nor stiction_tolerance, so we
   // can't test them.
 }


### PR DESCRIPTION
This long-standing automatic filtering was correct and convenient in many cases, but is not always correct or desirable. This patch gives a config entry and APIs to turn them off when needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18736)
<!-- Reviewable:end -->
