### PR TITLE
Include underactuated and manipulation in "Search all of Drake"

### DIFF
--- a/doc/_includes/header.html
+++ b/doc/_includes/header.html
@@ -30,10 +30,14 @@
             </svg>
           </div>
           <div class="search-bar">
-            <form id="ddg-search-form" action="https://duckduckgo.com/" method="get">
-              <input type="text" id="search-input" name="q" placeholder="Search all of Drake…" />
-              <input type="hidden" name="sites" value="drake.mit.edu OR site:underactuated.csail.mit.edu OR site:manipulation.csail.mit.edu" />
+            <form id="search_form" action="https://google.com/search" method="get">
+              <input type="text" id="box" name="q" placeholder="Search all of Drake…" />
             </form>
+            <script>
+              search_form.addEventListener('submit', function() {
+                box.value = box.value + ' site:drake.mit.edu OR site:underactuated.csail.mit.edu OR site:manipulation.csail.mit.edu';
+              })
+            </script>
             <div class="search-close">
               <!-- This is an inline SVG image of an "X". -->
               <svg height="20" width="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 373.61 373.57">

--- a/doc/_includes/header.html
+++ b/doc/_includes/header.html
@@ -32,7 +32,7 @@
           <div class="search-bar">
             <form id="ddg-search-form" action="https://duckduckgo.com/" method="get">
               <input type="text" id="search-input" name="q" placeholder="Search all of Drake…" />
-              <input type="hidden" name="sites" value="drake.mit.edu" />
+              <input type="hidden" name="sites" value="drake.mit.edu OR site:underactuated.csail.mit.edu OR site:manipulation.csail.mit.edu" />
             </form>
             <div class="search-close">
               <!-- This is an inline SVG image of an "X". -->

--- a/doc/_includes/header.html
+++ b/doc/_includes/header.html
@@ -31,13 +31,9 @@
           </div>
           <div class="search-bar">
             <form id="search_form" action="https://google.com/search" method="get">
-              <input type="text" id="box" name="q" placeholder="Search all of Drake…" />
+              <input type="text" name="q" placeholder="Search all of Drake…" />
+              <input type="hidden" name="q" value="site:drake.mit.edu OR site:underactuated.csail.mit.edu OR site:manipulation.csail.mit.edu" />
             </form>
-            <script>
-              search_form.addEventListener('submit', function() {
-                box.value = box.value + ' site:drake.mit.edu OR site:underactuated.csail.mit.edu OR site:manipulation.csail.mit.edu';
-              })
-            </script>
             <div class="search-close">
               <!-- This is an inline SVG image of an "X". -->
               <svg height="20" width="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 373.61 373.57">

--- a/doc/doxygen_cxx/doxygen_extra.css
+++ b/doc/doxygen_cxx/doxygen_extra.css
@@ -1132,7 +1132,7 @@ footer.site-footer>div.contain {
   display: none;
 }
 
-/* Place the duckduckgo.com search box in the upper right. */
+/* Place the google.com search box in the upper right. */
 
 #titlearea {
   border-bottom: 0;

--- a/doc/doxygen_cxx/header.html.patch
+++ b/doc/doxygen_cxx/header.html.patch
@@ -69,7 +69,7 @@
 +  </form>
 +  <form id="ddg-search-form" class="wy_form" action="https://duckduckgo.com/" method="get">
 +   <input type="text" name="q" placeholder="Search all of Drake…">
-+   <input type="hidden" name="sites" value="drake.mit.edu">
++   <input type="hidden" name="sites" value="drake.mit.edu OR site:underactuated.csail.mit.edu OR site:manipulation.csail.mit.edu" />
 +  </form>
 + </div>
 + <!--BEGIN SEARCHENGINE-->

--- a/doc/doxygen_cxx/header.html.patch
+++ b/doc/doxygen_cxx/header.html.patch
@@ -47,7 +47,7 @@
  <!--BEGIN TITLEAREA-->
  <div id="titlearea">
  <table cellspacing="0" cellpadding="0">
-@@ -44,13 +84,38 @@
+@@ -44,13 +84,30 @@
     <!--END PROJECT_BRIEF-->
    <!--END !PROJECT_NAME-->
    <!--BEGIN DISABLE_INDEX-->
@@ -64,21 +64,13 @@
 + </div>
 + <div id="DDGSearch">
 +  <form id="search_form_cpp" class="wy_form" action="https://google.com/search" method="get">
-+   <input type="text" name="q" id="box_cpp" placeholder="Search C++ API only…">
++   <input type="text" name="q" placeholder="Search C++ API only…">
++   <input type="hidden" name="q" value="site:drake.mit.edu/doxygen_cxx">
 +  </form>
-+  <script>
-+    search_form_cpp.addEventListener('submit', function() {
-+      box_cpp.value = box_cpp.value + ' site:drake.mit.edu/doxygen_cxx';
-+    })
-+  </script>
 +  <form id="search_form" class="wy_form" action="https://google.com/search" method="get">
-+   <input type="text" name="q" id="box" placeholder="Search all of Drake…">
++   <input type="text" name="q" placeholder="Search all of Drake…">
++   <input type="hidden" name="q" value="site:drake.mit.edu OR site:underactuated.csail.mit.edu OR site:manipulation.csail.mit.edu">
 +  </form>
-+  <script>
-+    search_form.addEventListener('submit', function() {
-+      box.value = box.value + ' site:drake.mit.edu OR site:underactuated.csail.mit.edu OR site:manipulation.csail.mit.edu';
-+    })
-+  </script>
 + </div>
 + <!--BEGIN SEARCHENGINE-->
 + <div id="MSearchBoxContainer">

--- a/doc/doxygen_cxx/header.html.patch
+++ b/doc/doxygen_cxx/header.html.patch
@@ -47,7 +47,7 @@
  <!--BEGIN TITLEAREA-->
  <div id="titlearea">
  <table cellspacing="0" cellpadding="0">
-@@ -44,13 +84,30 @@
+@@ -44,13 +84,38 @@
     <!--END PROJECT_BRIEF-->
    <!--END !PROJECT_NAME-->
    <!--BEGIN DISABLE_INDEX-->
@@ -63,14 +63,22 @@
 +  Drake C++ Documentation
 + </div>
 + <div id="DDGSearch">
-+  <form id="ddg-search-form" class="wy_form" action="https://duckduckgo.com/" method="get">
-+   <input type="text" name="q" placeholder="Search C++ API only…">
-+   <input type="hidden" name="sites" value="drake.mit.edu/doxygen_cxx">
++  <form id="search_form_cpp" class="wy_form" action="https://google.com/search" method="get">
++   <input type="text" name="q" id="box_cpp" placeholder="Search C++ API only…">
 +  </form>
-+  <form id="ddg-search-form" class="wy_form" action="https://duckduckgo.com/" method="get">
-+   <input type="text" name="q" placeholder="Search all of Drake…">
-+   <input type="hidden" name="sites" value="drake.mit.edu OR site:underactuated.csail.mit.edu OR site:manipulation.csail.mit.edu" />
++  <script>
++    search_form_cpp.addEventListener('submit', function() {
++      box_cpp.value = box_cpp.value + ' site:drake.mit.edu/doxygen_cxx';
++    })
++  </script>
++  <form id="search_form" class="wy_form" action="https://google.com/search" method="get">
++   <input type="text" name="q" id="box" placeholder="Search all of Drake…">
 +  </form>
++  <script>
++    search_form.addEventListener('submit', function() {
++      box.value = box.value + ' site:drake.mit.edu OR site:underactuated.csail.mit.edu OR site:manipulation.csail.mit.edu';
++    })
++  </script>
 + </div>
 + <!--BEGIN SEARCHENGINE-->
 + <div id="MSearchBoxContainer">

--- a/doc/pydrake/searchbox.html
+++ b/doc/pydrake/searchbox.html
@@ -5,9 +5,13 @@
     <input type="hidden" name="check_keywords" value="yes" />
     <input type="hidden" name="area" value="default" />
   </form>
-  <form id="ddg-search-form" class="wy_form" action="https://duckduckgo.com/" method="get">
-    <input type="text" name="q" placeholder="Search all of Drake…" />
-    <input type="hidden" name="sites" value="drake.mit.edu OR site:underactuated.csail.mit.edu OR site:manipulation.csail.mit.edu" />
+  <form id="search_form" class="wy_form" action="https://google.com/search" method="get">
+    <input type="text" name="q" id="box" placeholder="Search all of Drake…" />
   </form>
+  <script>
+    search_form.addEventListener('submit', function() {
+      box.value = box.value + ' site:drake.mit.edu OR site:underactuated.csail.mit.edu OR site:manipulation.csail.mit.edu';
+    })
+  </script>
 </div>
 {% endblock %}

--- a/doc/pydrake/searchbox.html
+++ b/doc/pydrake/searchbox.html
@@ -7,7 +7,7 @@
   </form>
   <form id="ddg-search-form" class="wy_form" action="https://duckduckgo.com/" method="get">
     <input type="text" name="q" placeholder="Search all of Drake…" />
-    <input type="hidden" name="sites" value="drake.mit.edu" />
+    <input type="hidden" name="sites" value="drake.mit.edu OR site:underactuated.csail.mit.edu OR site:manipulation.csail.mit.edu" />
   </form>
 </div>
 {% endblock %}

--- a/doc/pydrake/searchbox.html
+++ b/doc/pydrake/searchbox.html
@@ -6,12 +6,8 @@
     <input type="hidden" name="area" value="default" />
   </form>
   <form id="search_form" class="wy_form" action="https://google.com/search" method="get">
-    <input type="text" name="q" id="box" placeholder="Search all of Drake…" />
+    <input type="text" name="q" placeholder="Search all of Drake…" />
+    <input type="hidden" name="q" value="site:drake.mit.edu OR site:underactuated.csail.mit.edu OR site:manipulation.csail.mit.edu" />
   </form>
-  <script>
-    search_form.addEventListener('submit', function() {
-      box.value = box.value + ' site:drake.mit.edu OR site:underactuated.csail.mit.edu OR site:manipulation.csail.mit.edu';
-    })
-  </script>
 </div>
 {% endblock %}


### PR DESCRIPTION
Adds underactuated.csail.mit.edu and manipulation.csail.mit.edu to the search provided by duckduckgo. According to online discussions (like https://www.reddit.com/r/duckduckgo/comments/gcabk5/multiple_site_search_not_working/) and my testing, I believe using the OR is the recommended syntax.

+@jwnimmer-tri for feature review, please?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18737)
<!-- Reviewable:end -->
