### PR TITLE
Cleanup of the EvalContactResults() workflow

### DIFF
--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -78,7 +78,7 @@ void CompliantContactManager<T>::set_sap_solver_parameters(
 }
 
 template <typename T>
-void CompliantContactManager<T>::DeclareCacheEntries() {
+void CompliantContactManager<T>::DoDeclareCacheEntries() {
   // N.B. We use xd_ticket() instead of q_ticket() since discrete
   // multibody plant does not have q's, but rather discrete state.
   // Therefore if we make it dependent on q_ticket() the Jacobian only

--- a/multibody/plant/compliant_contact_manager.h
+++ b/multibody/plant/compliant_contact_manager.h
@@ -162,7 +162,7 @@ class CompliantContactManager final
   // function that extracts the particular variant of the physical model.
   void ExtractConcreteModel(std::monostate) {}
 
-  void DeclareCacheEntries() final;
+  void DoDeclareCacheEntries() final;
 
   // TODO(amcastro-tri): implement these APIs according to #16955.
   // @throws For SAP if T = symbolic::Expression.
@@ -214,7 +214,7 @@ class CompliantContactManager final
 
   // Eval version of CalcDiscreteContactPairs().
   const std::vector<internal::DiscreteContactPair<T>>& EvalDiscreteContactPairs(
-      const systems::Context<T>& context) const final;
+      const systems::Context<T>& context) const;
 
   // Computes per-face contact information for the hydroelastic model (slip
   // velocity, traction, etc). On return contact_info->size() will equal the

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -9,6 +9,43 @@ namespace multibody {
 namespace internal {
 
 template <typename T>
+void DiscreteUpdateManager<T>::DeclareCacheEntries() {
+  // The Correct Solution:
+  // The Implicit Stribeck solver solution S is a function of state x,
+  // actuation input u (and externally applied forces) and even time if
+  // any of the force elements in the model is time dependent. We can
+  // write this as S = S(t, x, u).
+  // Even though this variables can change continuously with time, we
+  // want the solver solution to be updated periodically (with period
+  // time_step()) only. That is, ContactSolverResults should be handled
+  // as an abstract state with periodic updates. In the systems::
+  // framework terminology, we'd like to have an "unrestricted update"
+  // with a periodic event trigger.
+  // The Problem (#10149):
+  // From issue #10149 we know unrestricted updates incur a very
+  // noticeably performance hit that at this stage we are not willing to
+  // pay.
+  // The Work Around (#10888):
+  // To emulate the correct behavior until #10149 is addressed we declare
+  // the Implicit Stribeck solver solution dependent only on the discrete
+  // state. This is not the correct solution given these results do
+  // depend on time and (even continuous) inputs. However it does emulate
+  // the discrete update of these values as if zero-order held, which is
+  // what we want.
+  const auto& contact_solver_results_cache_entry = this->DeclareCacheEntry(
+      "Contact solver results",
+      systems::ValueProducer(
+          this, &DiscreteUpdateManager<T>::CalcContactSolverResults),
+      {systems::System<T>::xd_ticket(),
+       systems::System<T>::all_parameters_ticket()});
+  cache_indexes_.contact_solver_results =
+      contact_solver_results_cache_entry.cache_index();
+
+  // Allow derived classes to declare their own cache entries.
+  DoDeclareCacheEntries();
+}
+
+template <typename T>
 systems::CacheEntry& DiscreteUpdateManager<T>::DeclareCacheEntry(
     std::string description, systems::ValueProducer value_producer,
     std::set<systems::DependencyTicket> prerequisites_of_calc) {
@@ -86,8 +123,10 @@ template <typename T>
 const contact_solvers::internal::ContactSolverResults<T>&
 DiscreteUpdateManager<T>::EvalContactSolverResults(
     const systems::Context<T>& context) const {
-  return MultibodyPlantDiscreteUpdateManagerAttorney<
-      T>::EvalContactSolverResults(plant(), context);
+  return plant()
+      .get_cache_entry(cache_indexes_.contact_solver_results)
+      .template Eval<contact_solvers::internal::ContactSolverResults<T>>(
+          context);
 }
 
 template <typename T>

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -2092,20 +2092,6 @@ void MultibodyPlant<symbolic::Expression>::CalcHydroelasticWithFallback(
 }
 
 template <typename T>
-void MultibodyPlant<T>::CalcContactSolverResults(
-    const drake::systems::Context<T>& context,
-    contact_solvers::internal::ContactSolverResults<T>* results) const {
-  this->ValidateContext(context);
-  // Assert this method was called on a context storing discrete state.
-  DRAKE_ASSERT(context.num_continuous_states() == 0);
-
-  // By default MultibodyPlant uses a DiscreteUpdateManger to advance the
-  // discrete dynamics.
-  DRAKE_DEMAND(discrete_update_manager_ != nullptr);
-  discrete_update_manager_->CalcContactSolverResults(context, results);
-}
-
-template <typename T>
 void MultibodyPlant<T>::CalcJointLockingIndices(
     const systems::Context<T>& context,
     std::vector<int>* unlocked_velocity_indices) const {
@@ -2532,8 +2518,6 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
     const int instance_num_velocities = num_velocities(model_instance_index);
 
     if (is_discrete()) {
-      const auto& contact_solver_results_cache_entry =
-          this->get_cache_entry(cache_indexes_.contact_solver_results);
       auto calc = [this, model_instance_index](
                       const systems::Context<T>& context,
                       systems::BasicVector<T>* result) {
@@ -2543,8 +2527,10 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
             context,
             get_generalized_contact_forces_output_port(model_instance_index));
 
+        DRAKE_DEMAND(discrete_update_manager_ != nullptr);
         const contact_solvers::internal::ContactSolverResults<T>&
-            solver_results = EvalContactSolverResults(context);
+            solver_results =
+                discrete_update_manager_->EvalContactSolverResults(context);
         this->CopyGeneralizedContactForcesOut(solver_results,
                                               model_instance_index, result);
       };
@@ -2553,7 +2539,8 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
                   GetModelInstanceName(model_instance_index) +
                       "_generalized_contact_forces",
                   instance_num_velocities, calc,
-                  {contact_solver_results_cache_entry.ticket()})
+                  {systems::System<T>::xd_ticket(),
+                   systems::System<T>::all_parameters_ticket()})
               .get_index();
     } else {
       const auto& generalized_contact_forces_continuous_cache_entry =
@@ -2649,39 +2636,6 @@ void MultibodyPlant<T>::DeclareCacheEntries() {
       {this->configuration_ticket()});
   cache_indexes_.contact_surfaces = contact_surfaces_cache_entry.cache_index();
 
-  if (is_discrete()) {
-    // Cache discrete solver computations.
-    auto& contact_solver_results_cache_entry = this->DeclareCacheEntry(
-        std::string("discrete contact solver computations."),
-        &MultibodyPlant<T>::CalcContactSolverResults,
-        // The Correct Solution:
-        // The Implicit Stribeck solver solution S is a function of state x,
-        // actuation input u (and externally applied forces) and even time if
-        // any of the force elements in the model is time dependent. We can
-        // write this as S = S(t, x, u).
-        // Even though this variables can change continuously with time, we
-        // want the solver solution to be updated periodically (with period
-        // time_step()) only. That is, ContactSolverResults should be handled
-        // as an abstract state with periodic updates. In the systems::
-        // framework terminology, we'd like to have an "unrestricted update"
-        // with a periodic event trigger.
-        // The Problem (#10149):
-        // From issue #10149 we know unrestricted updates incur a very
-        // noticeably performance hit that at this stage we are not willing to
-        // pay.
-        // The Work Around (#10888):
-        // To emulate the correct behavior until #10149 is addressed we declare
-        // the Implicit Stribeck solver solution dependent only on the discrete
-        // state. This is not the correct solution given these results do
-        // depend on time and (even continuous) inputs. However it does emulate
-        // the discrete update of these values as if zero-order held, which is
-        // what we want.
-        {this->xd_ticket(), this->all_parameters_ticket()});
-    cache_indexes_.contact_solver_results =
-        contact_solver_results_cache_entry.cache_index();
-  }
-
-
   // Cache entry for spatial forces and contact info due to hydroelastic
   // contact.
   const bool use_hydroelastic =
@@ -2709,8 +2663,8 @@ void MultibodyPlant<T>::DeclareCacheEntries() {
                                                            use_hydroelastic]() {
     std::set<systems::DependencyTicket> tickets;
     if (is_discrete()) {
-      tickets.insert(
-          this->cache_entry_ticket(cache_indexes_.contact_solver_results));
+      tickets.insert(systems::System<T>::xd_ticket());
+      tickets.insert(systems::System<T>::all_parameters_ticket());
     } else {
       tickets.insert(this->kinematics_ticket());
       if (use_hydroelastic) {

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -4461,7 +4461,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     systems::CacheIndex hydro_fallback;
     systems::CacheIndex point_pairs;
     systems::CacheIndex spatial_contact_forces_continuous;
-    systems::CacheIndex contact_solver_results;
     systems::CacheIndex discrete_contact_pairs;
     systems::CacheIndex joint_locking_data;
     systems::CacheIndex non_contact_forces_evaluation_in_progress;
@@ -4648,23 +4647,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   systems::EventStatus CalcDiscreteStep(
       const systems::Context<T>& context0,
       systems::DiscreteValues<T>* updates) const;
-
-  // This method performs the computation of the impulses to advance the state
-  // stored in `context0` in time.
-  // Contact forces and velocities are computed and stored in `results`. See
-  // ContactSolverResults for further details on the returned data.
-  void CalcContactSolverResults(
-      const drake::systems::Context<T>& context0,
-      contact_solvers::internal::ContactSolverResults<T>* results) const;
-
-
-  // Eval version of the method CalcContactSolverResults().
-  const contact_solvers::internal::ContactSolverResults<T>&
-  EvalContactSolverResults(const systems::Context<T>& context) const {
-    return this->get_cache_entry(cache_indexes_.contact_solver_results)
-        .template Eval<contact_solvers::internal::ContactSolverResults<T>>(
-            context);
-  }
 
   // Computes the array of indices of velocities that are not locked in the
   // current configuration. The resulting index values in @p

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -42,12 +42,6 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
                                     std::move(prerequisites_of_calc));
   }
 
-  static const contact_solvers::internal::ContactSolverResults<T>&
-  EvalContactSolverResults(const MultibodyPlant<T>& plant,
-                           const systems::Context<T>& context) {
-    return plant.EvalContactSolverResults(context);
-  }
-
   static const std::vector<geometry::ContactSurface<T>>& EvalContactSurfaces(
       const MultibodyPlant<T>& plant, const systems::Context<T>& context) {
     return plant.EvalContactSurfaces(context);

--- a/multibody/plant/test/discrete_update_manager_test.cc
+++ b/multibody/plant/test/discrete_update_manager_test.cc
@@ -60,13 +60,6 @@ class DummyDiscreteUpdateManager final : public DiscreteUpdateManager<T> {
     return data;
   }
 
-  // This method will be removed with the resolution of #16955 and therefore a
-  // no-op is implemented simply to be able to instantiate this class.
-  const std::vector<internal::DiscreteContactPair<T>>& EvalDiscreteContactPairs(
-      const systems::Context<T>&) const final {
-    DRAKE_UNREACHABLE();
-  }
-
  private:
   /* Allow different specializations to access each other's private data for
    cloning to a different scalar type. */
@@ -105,7 +98,7 @@ class DummyDiscreteUpdateManager final : public DiscreteUpdateManager<T> {
   }
 
   /* Declares a cache entry that stores twice the additional state value. */
-  void DeclareCacheEntries() final {
+  void DoDeclareCacheEntries() final {
     cache_index_ = this->DeclareCacheEntry(
                            "Twice the additional_state value",
                            systems::ValueProducer(

--- a/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
+++ b/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
@@ -189,13 +189,6 @@ class DoubleOnlyDiscreteUpdateManager final
 
   void DoCalcContactResults(const systems::Context<T>&,
                             ContactResults<T>*) const final {}
-
-  // This method will be removed with the resolution of #16955 and therefore a
-  // no-op is implemented simply to be able to instantiate this class.
-  const std::vector<internal::DiscreteContactPair<T>>& EvalDiscreteContactPairs(
-      const systems::Context<T>&) const final {
-    DRAKE_UNREACHABLE();
-  }
 };
 
 // This test verifies that adding external components that do not support some


### PR DESCRIPTION
Towards #16955.
A follow up cleanup to #18647 (consolidate contact results).

This PR moves EvalContactSolverResults() into DiscreteUpdateManager().
Before this PR this methods was implemented in the plant, but with a forwarding in the manager to pretend it was its job. Now it is.

Simply a cleanup, no new functionality, no new unit tests needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18746)
<!-- Reviewable:end -->
