### PR TITLE
Fix a bug in QuaternionToHopfCoordinate.

### DIFF
--- a/math/hopf_coordinate.h
+++ b/math/hopf_coordinate.h
@@ -46,25 +46,27 @@ const Eigen::Quaternion<T> HopfCoordinateToQuaternion(const T& theta,
 }
 
 /**
- * Convert a unit-length quaternion (w, x, y, z) to Hopf coordinate as
- * if w >= 0
- *   ψ = 2*atan2(x, w)
- * else
- *   ψ = 2*atan2(-x, -w)
+ * Convert a unit-length quaternion (w, x, y, z) (with the requirement w >= 0)
+ * to Hopf coordinate as
+ * ψ = 2*atan2(x, w)
  * φ = mod(atan2(z, y) - ψ/2, 2pi)
  * θ = 2*atan2(√(y²+z²), √(w²+x²))
  * ψ is in the range of [-pi, pi].
  * φ is in the range of [0, 2pi].
  * θ is in the range of [0, pi].
+ * If the given quaternion has w < 0, then we reverse the signs of (w, x, y, z),
+ * and compute the Hopf coordinate of (-w, -x, -y, -z).
  * @param quaternion A unit length quaternion.
  * @return hopf_coordinate (θ, φ, ψ) as an Eigen vector.
  */
 template <typename T>
 Vector3<T> QuaternionToHopfCoordinate(const Eigen::Quaternion<T>& quaternion) {
+  if (quaternion.w() < 0) {
+    return QuaternionToHopfCoordinate(Eigen::Quaternion<T>(
+        -quaternion.w(), -quaternion.x(), -quaternion.y(), -quaternion.z()));
+  }
   using std::atan2;
-  const T psi = quaternion.w() >= T(0)
-                    ? 2 * atan2(quaternion.x(), quaternion.w())
-                    : 2 * atan2(-quaternion.x(), -quaternion.w());
+  const T psi = 2 * atan2(quaternion.x(), quaternion.w());
   const T phi_unwrapped = atan2(quaternion.z(), quaternion.y()) - psi / 2;
   // The range of phi_unwrapped is [-1.5pi, 1.5pi]
   const T phi = phi_unwrapped >= 0 ? phi_unwrapped : phi_unwrapped + 2 * M_PI;

--- a/math/test/random_rotation_test.cc
+++ b/math/test/random_rotation_test.cc
@@ -132,7 +132,8 @@ GTEST_TEST(RandomRotationTest, UniformlyRandomRotation) {
   CheckUniformAngleAxes(quaternions, num_intervals, fudge_factor);
   CheckUniformAngleAxes(angle_axes, num_intervals, fudge_factor);
   CheckUniformAngleAxes(rotation_matrices, num_intervals, fudge_factor);
-  CheckUniformHopfCoordinate(hopf_coordinates, 10, fudge_factor);
+  const double hopf_fudge_factor = 3;
+  CheckUniformHopfCoordinate(hopf_coordinates, 10, hopf_fudge_factor);
 }
 
 GTEST_TEST(RandomRotationTest, Symbolic) {


### PR DESCRIPTION
The psi angle was computed incorrectly before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18747)
<!-- Reviewable:end -->
