### PR TITLE
Include hydroelastic in the computation of reaction forces (discrete models)

### DIFF
--- a/multibody/plant/compliant_contact_manager.h
+++ b/multibody/plant/compliant_contact_manager.h
@@ -179,6 +179,9 @@ class CompliantContactManager final
   void DoCalcContactResults(
       const systems::Context<T>&,
       ContactResults<T>* contact_results) const final;
+  void DoCalcDiscreteUpdateMultibodyForces(
+      const systems::Context<T>& context,
+      MultibodyForces<T>* forces) const final;
 
   // This method computes sparse kinematics information for each contact pair at
   // the given configuration stored in `context`.
@@ -259,6 +262,13 @@ class CompliantContactManager final
   void AppendContactResultsForHydroelasticContact(
       const systems::Context<T>& context,
       ContactResults<T>* contact_results) const;
+
+  // This method aggregates the total force on each body for a given
+  // `contact_results`.
+  void CalcAndAddSpatialContactForcesFromContactResults(
+      const systems::Context<T>& context,
+      const ContactResults<T>& contact_results,
+      std::vector<SpatialForce<T>>* F_Bo_W) const;
 
   CacheIndexes cache_indexes_;
   // Vector of joint damping coefficients, of size plant().num_velocities().

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -41,6 +41,26 @@ void DiscreteUpdateManager<T>::DeclareCacheEntries() {
   cache_indexes_.contact_solver_results =
       contact_solver_results_cache_entry.cache_index();
 
+  MultibodyForces<T> model_forces(plant());
+  const auto& multibody_forces_cache_entry = DeclareCacheEntry(
+      "Discrete update multibody forces.",
+      systems::ValueProducer(
+          this, model_forces,
+          &DiscreteUpdateManager<T>::CalcDiscreteUpdateMultibodyForces),
+      {systems::System<T>::xd_ticket(),
+       systems::System<T>::all_parameters_ticket()});
+  cache_indexes_.discrete_update_multibody_forces =
+      multibody_forces_cache_entry.cache_index();
+
+  const auto& contact_results_cache_entry = DeclareCacheEntry(
+      "Contact results.",
+      systems::ValueProducer(
+          this,
+          &DiscreteUpdateManager<T>::CalcContactResults),
+      {systems::System<T>::xd_ticket(),
+       systems::System<T>::all_parameters_ticket()});
+  cache_indexes_.contact_results = contact_results_cache_entry.cache_index();
+
   // Allow derived classes to declare their own cache entries.
   DoDeclareCacheEntries();
 }
@@ -208,6 +228,41 @@ BodyIndex DiscreteUpdateManager<T>::FindBodyByGeometryId(
     geometry::GeometryId geometry_id) const {
   return MultibodyPlantDiscreteUpdateManagerAttorney<T>::FindBodyByGeometryId(
       plant(), geometry_id);
+}
+
+template <typename T>
+void DiscreteUpdateManager<T>::CalcContactResults(
+    const systems::Context<T>& context,
+    ContactResults<T>* contact_results) const {
+  DRAKE_DEMAND(contact_results != nullptr);
+  plant().ValidateContext(context);
+  DoCalcContactResults(context, contact_results);
+}
+
+template <typename T>
+void DiscreteUpdateManager<T>::CalcDiscreteUpdateMultibodyForces(
+    const systems::Context<T>& context, MultibodyForces<T>* forces) const {
+  plant().ValidateContext(context);
+  DRAKE_DEMAND(forces != nullptr);
+  DRAKE_DEMAND(forces->CheckHasRightSizeForModel(plant()));
+  DoCalcDiscreteUpdateMultibodyForces(context, forces);
+}
+
+template <typename T>
+const MultibodyForces<T>&
+DiscreteUpdateManager<T>::EvalDiscreteUpdateMultibodyForces(
+    const systems::Context<T>& context) const {
+  return plant()
+      .get_cache_entry(cache_indexes_.discrete_update_multibody_forces)
+      .template Eval<MultibodyForces<T>>(context);
+}
+
+template <typename T>
+const ContactResults<T>& DiscreteUpdateManager<T>::EvalContactResults(
+    const systems::Context<T>& context) const {
+  return plant()
+      .get_cache_entry(cache_indexes_.contact_results)
+      .template Eval<ContactResults<T>>(context);
 }
 
 }  // namespace internal

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1638,14 +1638,6 @@ void MultibodyPlant<T>::AppendContactResultsContinuousPointPair(
 }
 
 template <typename T>
-void MultibodyPlant<T>::CalcContactResultsDiscrete(
-    const systems::Context<T>& context,
-    ContactResults<T>* contact_results) const {
-  DRAKE_DEMAND(contact_results != nullptr);
-  discrete_update_manager_->CalcContactResults(context, contact_results);
-}
-
-template <typename T>
 void MultibodyPlant<T>::CalcAndAddContactForcesByPenaltyMethod(
     const systems::Context<T>& context,
     std::vector<SpatialForce<T>>* F_BBo_W_array) const {
@@ -2575,13 +2567,15 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
           .get_index();
 
   // Contact results output port.
-  const auto& contact_results_cache_entry =
-      this->get_cache_entry(cache_indexes_.contact_results);
-  contact_results_port_ = this->DeclareAbstractOutputPort(
-                                  "contact_results", ContactResults<T>(),
-                                  &MultibodyPlant<T>::CopyContactResultsOutput,
-                                  {contact_results_cache_entry.ticket()})
-                              .get_index();
+  const systems::DependencyTicket state_ticket =
+      is_discrete() ? systems::System<T>::xd_ticket()
+                    : this->kinematics_ticket();
+  contact_results_port_ =
+      this->DeclareAbstractOutputPort(
+              "contact_results", ContactResults<T>(),
+              &MultibodyPlant<T>::CopyContactResultsOutput,
+              {state_ticket, systems::System<T>::all_parameters_ticket()})
+          .get_index();
 
   // See ThrowIfNonContactForceInProgress().
   const auto& non_contact_forces_evaluation_in_progress =
@@ -2651,33 +2645,22 @@ void MultibodyPlant<T>::DeclareCacheEntries() {
         contact_info_and_body_spatial_forces_cache_entry.cache_index();
   }
 
-  // Cache contact results.
-  // In discrete mode contact forces computation requires to advance the system
-  // from step n to n+1. Therefore they are a function of state and input.
+  // Cache contact results, for continuous plant models.
   // In continuous mode contact forces are simply a function of state.
   std::set<systems::DependencyTicket> dependency_ticket = [this,
                                                            use_hydroelastic]() {
     std::set<systems::DependencyTicket> tickets;
-    if (is_discrete()) {
-      tickets.insert(systems::System<T>::xd_ticket());
-      tickets.insert(systems::System<T>::all_parameters_ticket());
-    } else {
-      tickets.insert(this->kinematics_ticket());
-      if (use_hydroelastic) {
-        tickets.insert(this->cache_entry_ticket(
-            cache_indexes_.contact_info_and_body_spatial_forces));
-      }
+    tickets.insert(this->kinematics_ticket());
+    if (use_hydroelastic) {
+      tickets.insert(this->cache_entry_ticket(
+          cache_indexes_.contact_info_and_body_spatial_forces));
     }
     tickets.insert(this->all_parameters_ticket());
-
     return tickets;
   }();
   auto& contact_results_cache_entry = this->DeclareCacheEntry(
-      std::string("Contact results."),
-      is_discrete() ?
-          &MultibodyPlant<T>::CalcContactResultsDiscrete :
-          &MultibodyPlant<T>::CalcContactResultsContinuous,
-      {dependency_ticket});
+      std::string("Contact results (continuous)"),
+      &MultibodyPlant<T>::CalcContactResultsContinuous, {dependency_ticket});
   cache_indexes_.contact_results = contact_results_cache_entry.cache_index();
 
   // Cache spatial continuous contact forces.
@@ -2937,33 +2920,35 @@ void MultibodyPlant<T>::CalcReactionForces(
   // Guard against failure to acquire the geometry input deep in the call graph.
   ValidateGeometryInput(context, get_reaction_forces_output_port());
 
-  const VectorX<T>& vdot = this->EvalForwardDynamics(context).get_vdot();
-
-  // TODO(sherm1) EvalForwardDynamics() should record the forces it used
-  //              so that we don't have to attempt to reconstruct them
-  //              here (and this is broken, see #13888).
+  // Compute the multibody forces applied during the computation of forward
+  // dynamics, consistent with the value of vdot obtained below.
   MultibodyForces<T> applied_forces(*this);
-  CalcNonContactForces(context, is_discrete(), &applied_forces);
   auto& Fapplied_Bo_W_array = applied_forces.mutable_body_forces();
   auto& tau_applied = applied_forces.mutable_generalized_forces();
-
-  // Add in forces due to contact.
-  // Only add in hydroelastic contact forces for continuous mode for now as
-  // the forces computed by CalcHydroelasticContactForces() are wrong in
-  // discrete mode. See (#13888).
-  if (!is_discrete()) {
-    CalcAndAddSpatialContactForcesContinuous(context, &Fapplied_Bo_W_array);
+  if (is_discrete()) {
+    applied_forces =
+        discrete_update_manager_->EvalDiscreteUpdateMultibodyForces(context);
   } else {
-    CalcAndAddContactForcesByPenaltyMethod(context, &Fapplied_Bo_W_array);
+    CalcNonContactForces(context, is_discrete(), &applied_forces);
+    CalcAndAddSpatialContactForcesContinuous(context, &Fapplied_Bo_W_array);
   }
 
   // Compute reaction forces at each mobilizer.
+  // N.B. For discrete systems, this approach right now evaluates Coriolis terms
+  // at the state stored in the context (previous time step). This is correct
+  // for the discrete solver we have today, though it might change for future
+  // solvers that prefer an implicit evaluation of these terms.
+  // TODO(amcastro-tri): Consider having a
+  // DiscreteUpdateManager::EvalReactionForces() to ensure the manager performs
+  // this computation consistently with its discrete update.
+  const VectorX<T>& vdot = this->EvalForwardDynamics(context).get_vdot();
   std::vector<SpatialAcceleration<T>> A_WB_vector(num_bodies());
   std::vector<SpatialForce<T>> F_BMo_W_vector(num_bodies());
   VectorX<T> tau_id(num_velocities());
   internal_tree().CalcInverseDynamics(context, vdot, Fapplied_Bo_W_array,
                                       tau_applied, &A_WB_vector,
                                       &F_BMo_W_vector, &tau_id);
+
   // Since vdot is the result of Fapplied and tau_applied we expect the result
   // from inverse dynamics to be zero.
   // TODO(amcastro-tri): find a better estimation for this bound. For instance,

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -4746,17 +4746,15 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const systems::Context<T>& context,
       ContactResults<T>* contact_results) const;
 
-  // This method accumulates both point and hydroelastic contact results into
-  // contact_results when the model is discrete.
-  // @param[out] contact_results is fully overwritten
-  void CalcContactResultsDiscrete(const systems::Context<T>& context,
-                                  ContactResults<T>* contact_results) const;
-
   // Evaluate contact results.
   const ContactResults<T>& EvalContactResults(
       const systems::Context<T>& context) const {
-    return this->get_cache_entry(cache_indexes_.contact_results)
-        .template Eval<ContactResults<T>>(context);
+    if (this->is_discrete()) {
+      return discrete_update_manager_->EvalContactResults(context);
+    } else {
+      return this->get_cache_entry(cache_indexes_.contact_results)
+          .template Eval<ContactResults<T>>(context);
+    }
   }
 
   // Calc method for the reaction forces output port.

--- a/multibody/plant/test/discrete_update_manager_test.cc
+++ b/multibody/plant/test/discrete_update_manager_test.cc
@@ -157,6 +157,12 @@ class DummyDiscreteUpdateManager final : public DiscreteUpdateManager<T> {
   void DoCalcContactResults(const systems::Context<T>& context,
                             ContactResults<T>* contact_results) const final {}
 
+  // Not used in these tests.
+  void DoCalcDiscreteUpdateMultibodyForces(const systems::Context<T>&,
+                                           MultibodyForces<T>*) const final {
+    throw std::logic_error("Must implement if needed for these tests.");
+  }
+
  private:
   systems::DiscreteStateIndex additional_state_index_;
   systems::CacheIndex cache_index_;

--- a/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
+++ b/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
@@ -189,6 +189,10 @@ class DoubleOnlyDiscreteUpdateManager final
 
   void DoCalcContactResults(const systems::Context<T>&,
                             ContactResults<T>*) const final {}
+
+  void DoCalcDiscreteUpdateMultibodyForces(
+      const systems::Context<T>& context,
+      MultibodyForces<T>* forces) const final {}
 };
 
 // This test verifies that adding external components that do not support some


### PR DESCRIPTION
Per [Slack discussion](https://drakedevelopers.slack.com/archives/C2WBPQDB7/p1671712492417959) in Drake devs.
Towards resolving #13888. 

This PR includes hydroelastic contact forces in the computation of reaction forces.
Other constraints (as supported by SAP) are not considered yet. For those cases we throw an exception to alert users that evaluate reaction forces on a model with additional constraints.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18748)
<!-- Reviewable:end -->
