### PR TITLE
Downgrade usockets/uwebsockets

### DIFF
--- a/tools/workspace/usockets/repository.bzl
+++ b/tools/workspace/usockets/repository.bzl
@@ -8,8 +8,10 @@ def usockets_repository(
     github_archive(
         name = name,
         repository = "uNetworking/uSockets",
-        commit = "v0.8.5",
-        sha256 = "c52c98b7ff2c24534c17ad97d5fea8ca0cb7ff38cc933b8d08bac6e498a2ea6b",  # noqa
+        # NOTE: Do not upgrade without testing the tutorials on Deepnote.  See
+        # Drake #18289.  v0.8.5 was tested and showed the same symptoms.
+        commit = "v0.8.1",
+        sha256 = "3b33b5924a92577854e2326b3e2d393849ec00beb865a1271bf24c0f210cc1d6",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )

--- a/tools/workspace/uwebsockets/repository.bzl
+++ b/tools/workspace/uwebsockets/repository.bzl
@@ -8,8 +8,10 @@ def uwebsockets_repository(
     github_archive(
         name = name,
         repository = "uNetworking/uWebSockets",
-        commit = "v20.36.0",
-        sha256 = "cda266f7ed6abe67ef3cae6e223a580fe5091db9156c1f4123ee328ae21511c9",  # noqa
+        # NOTE: Do not upgrade without testing the tutorials on Deepnote.  See
+        # Drake #18289.  v20.35.0 was tested and showed the same symptoms.
+        commit = "v20.14.0",
+        sha256 = "15cf995844a930c9a36747e8d714b94ff886b6814b5d4e3b3ee176f05681cccc",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
The upgrade in #18516 broke meshcat on Deepnote again.  See #18289.

+@jwnimmer-tri for both reviews, please.

Marking "emergency", because I'm trying to release pset 1 tonight, and it is MUCH more complicated if I can't use the recent Drake nightlies. (we've had a lot of deprecations / changes since the last functional nightly).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18755)
<!-- Reviewable:end -->
