### PR TITLE
[C-IRIS] fix add IsGeometrySeparable function test

### DIFF
--- a/geometry/optimization/dev/test/cspace_free_polytope_with_mosek_test.cc
+++ b/geometry/optimization/dev/test/cspace_free_polytope_with_mosek_test.cc
@@ -414,7 +414,7 @@ TEST_F(CIrisToyRobotTest, MakeAndSolveIsGeometrySeparableProgram) {
       tester.cspace_free_polytope().MakeIsGeometrySeparableProgram(
           geometry_pair, C_good, d_good);
   auto separation_certificate_result =
-      test.cspace_free_polytope().SolveSeparationCertificateProgram(
+      tester.cspace_free_polytope().SolveSeparationCertificateProgram(
           separation_certificate_program, options);
   EXPECT_TRUE(separation_certificate_result.has_value());
   Eigen::Matrix<double, 10, 3> s_samples;


### PR DESCRIPTION
Followup to build failures in #18742.

Closes #18759.

CC @hongkai-dai @AlexandreAmice there were three build failures:

- [mac-arm-monterey-clang-bazel-nightly-debug](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-arm-monterey-clang-bazel-nightly-debug/94/)
- [mac-x86-monterey-clang-bazel-nightly-debug](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-x86-monterey-clang-bazel-nightly-debug/90/)
- [mac-x86-monterey-clang-bazel-nightly-everything-debug](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-x86-monterey-clang-bazel-nightly-everything-debug/94/)

What we do not have an answer to: why is it only in mac?  Should this code be getting excluded from tests altogether instead?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18758)
<!-- Reviewable:end -->
