### PR TITLE
[common] Remove SortedPair mutable structured bindings

### DIFF
--- a/common/sorted_pair.h
+++ b/common/sorted_pair.h
@@ -102,14 +102,8 @@ struct SortedPair {
 
   /// @name Support for using SortedPair in structured bindings.
   //@{
-  template<std::size_t Index>
-  std::tuple_element_t<Index, SortedPair<T>>& get() {
-    if constexpr (Index == 0) return first_;
-    if constexpr (Index == 1) return second_;
-  }
-
-  template<std::size_t Index>
-  const std::tuple_element_t<Index, SortedPair<T>>& get() const {
+  template <size_t Index>
+  const T& get() const {
     if constexpr (Index == 0) return first_;
     if constexpr (Index == 1) return second_;
   }
@@ -207,7 +201,7 @@ struct tuple_size<drake::SortedPair<T>> : std::integral_constant<size_t, 2> {};
 
 template <size_t Index, typename T>
 struct tuple_element<Index, drake::SortedPair<T>> {
-  using type = T;
+  using type = const T;
 };
 
 }  // namespace std

--- a/common/test/sorted_pair_test.cc
+++ b/common/test/sorted_pair_test.cc
@@ -157,15 +157,6 @@ GTEST_TEST(SortedPair, StructuredBinding) {
     EXPECT_EQ(b, pair.second());
   }
 
-  // Mutable reference access.
-  {
-    auto& [a, b] = pair;
-    a = 13;
-    b = 14;
-    EXPECT_EQ(a, pair.first());
-    EXPECT_EQ(b, pair.second());
-  }
-
   // Const reference access.
   {
     auto& [a, b] = pair;


### PR DESCRIPTION
Mutation allows the user to violate the sorting invariant.

See https://github.com/RobotLocomotion/drake/pull/15551#issuecomment-1426961027.

---

I noticed this while deprecating `operator<<` functions. With a `#include <fmt/ranges.h>`, there is no need for any `operator<<` customization; formatting works exactly the same, right out of the box, because SortedPair presents the tuple concept.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18767)
<!-- Reviewable:end -->
