### PR TITLE
[common] Add infrastructure for fmt without ostreams

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -76,6 +76,7 @@ drake_cc_library(
         "drake_deprecated.h",
         "drake_throw.h",
         "eigen_types.h",
+        "fmt.h",
         "never_destroyed.h",
         "text_logging.h",
     ],
@@ -885,6 +886,13 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "fmt_test",
+    deps = [
+        ":essential",
+    ],
+)
+
+drake_cc_googletest(
     name = "is_approx_equal_abstol_test",
     deps = [
         ":essential",
@@ -964,6 +972,7 @@ drake_cc_googletest(
     name = "text_logging_no_spdlog_test",
     srcs = [
         "drake_copyable.h",
+        "fmt.h",
         "never_destroyed.h",
         "test/text_logging_test.cc",
         "text_logging.cc",

--- a/common/copyable_unique_ptr.h
+++ b/common/copyable_unique_ptr.h
@@ -16,6 +16,8 @@ copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
 #include <utility>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/fmt.h"
 
 namespace drake {
 
@@ -421,10 +423,11 @@ class copyable_unique_ptr : public std::unique_ptr<T> {
   }
 };
 
-/** Output the system-dependent representation of the pointer contained
- in a copyable_unique_ptr object. This is equivalent to `os << p.get();`.
- @relates copyable_unique_ptr */
+// TODO(jwnimmer-tri) On 2023-06-01 also remove the <ostream> include above.
 template <class charT, class traits, class T>
+DRAKE_DEPRECATED("2023-06-01",
+    "Use fmt or spdlog for logging, not operator<<. "
+    "See https://github.com/RobotLocomotion/drake/issues/17742 for details.")
 std::basic_ostream<charT, traits>& operator<<(
     std::basic_ostream<charT, traits>& os,
     const copyable_unique_ptr<T>& cu_ptr) {
@@ -433,3 +436,6 @@ std::basic_ostream<charT, traits>& operator<<(
 }
 
 }  // namespace drake
+
+DRAKE_FORMATTER_AS(typename T, drake, copyable_unique_ptr<T>, x,
+                   static_cast<const void*>(x.get()))

--- a/common/fmt.h
+++ b/common/fmt.h
@@ -1,0 +1,163 @@
+#pragma once
+
+#include <string_view>
+
+#include <fmt/format.h>
+
+// This file contains the essentials of fmt support in Drake, mainly
+// compatibility code to inter-operate with different versions of fmt.
+
+namespace drake {
+
+#if FMT_VERSION >= 80000 || defined(DRAKE_DOXYGEN_CXX)
+/** When using fmt >= 8, this is an alias for fmt::runtime.
+When using fmt < 8, this is a no-op. */
+inline auto fmt_runtime(std::string_view s) {
+  return fmt::runtime(s);
+}
+/** When using fmt >= 8, this is defined to be `const` to indicate that the
+fmt::formatter<T>::format(...) function should be object-const.
+When using fmt < 8, the function signature was incorrect (lacking the const),
+so this macro will be empty. */
+#define DRAKE_FMT8_CONST const
+#else  // FMT_VERSION
+inline auto fmt_runtime(std::string_view s) {
+  return s;
+}
+#define DRAKE_FMT8_CONST
+#endif  // FMT_VERSION
+
+namespace internal::formatter_as {
+
+/* The DRAKE_FORMATTER_AS macro specializes this for it's format_as types.
+This struct is a functor that performs a conversion. See below for details.
+@tparam T is the TYPE to be formatted. */
+template <typename T>
+struct Converter;
+
+/* Provides convenient type shortcuts for the TYPE in DRAKE_FORMATTER_AS. */
+template <typename T>
+struct Traits {
+  /* The type being formatted. */
+  using InputType = T;
+  /* The format_as functor that provides the alternative object to format. */
+  using Functor = Converter<T>;
+  /* The type of the alternative object. */
+  using OutputType = decltype(Functor::call(std::declval<InputType>()));
+  /* The fmt::formatter<> for the alternative object. */
+  using OutputTypeFormatter = fmt::formatter<OutputType>;
+};
+
+/* Implements fmt::formatter<TYPE> for DRAKE_FORMATER_AS types. The macro
+specializes this for it's format_as types.  See below for details.
+@tparam T is the TYPE to be formatted. */
+template <typename T>
+struct Formatter;
+
+}  // namespace internal::formatter_as
+
+}  // namespace drake
+
+/** Adds a `fmt::formatter<NAMESPACE::TYPE>` template specialization that
+formats the `TYPE` by delegating the formatting using a transformed expression,
+as if a conversion function like this were interposed during formatting:
+
+@code{cpp}
+template <TEMPLATE_ARGS>
+auto format_as(const NAMESPACE::TYPE& ARG) {
+  return EXPR;
+}
+@endcode
+
+For example, this declaration ...
+
+@code{cpp}
+DRAKE_FORMATTER_AS(, my_namespace, MyType, x, x.to_string())
+@endcode
+
+... changes this code ...
+
+@code{cpp}
+MyType foo;
+fmt::print(foo);
+@endcode
+
+... to be equivalent to ...
+
+@code{cpp}
+MyType foo;
+fmt::print(foo.to_string());
+@endcode
+
+... allowing user to format `my_namespace::MyType` objects without manually
+adding the `to_string` call every time.
+
+This provides a convenient mechanism to add formatters for classes that already
+have a `to_string` function, or classes that are just thin wrappers over simple
+types (ints, enums, etc.).
+
+Always use this macro in the global namespace, and do not use a semicolon (`;`)
+afterward.
+
+@param TEMPLATE_ARGS The optional first argument `TEMPLATE_ARGS` can be used in
+case the `TYPE` is templated, e.g., it might commonly be set to `typename T`. It
+should be left empty when the TYPE is not templated. In case `TYPE` has multiple
+template arguments, note that macros will fight with commas so you should use
+`typename... Ts` instead of writing them all out.
+
+@param NAMESPACE The namespace that encloses the `TYPE` being formatted. Cannot
+be empty. For nested namespaces, use intemediate colons, e.g., `%drake::common`.
+Do not place _leading_ colons on the `NAMESPACE`.
+
+@param TYPE The class name (or struct name, or enum name, etc.) being formatted.
+Do not place _leading_ double-colons on the `TYPE`. If the type is templated,
+use the template arguments here, e.g., `MyOptional<T>` if `TEMPLATE_ARGS` was
+chosen as `typename T`.
+
+@param ARG A placeholder variable name to use for the value (i.e., object)
+being formatted within the `EXPR` expression.
+
+@param EXPR An expression to `return` from the format_as function; it can
+refer to the given `ARG` name which will be of type `const TYPE& ARG`.
+
+@note In future versions of fmt (perhaps fmt >= 10) there might be an ADL
+`format_as` customization point with this feature built-in. If so, then we can
+update this macro to use that spelling, and eventually deprecate the macro once
+Drake drops support for earlier version of fmt. */
+#define DRAKE_FORMATTER_AS(TEMPLATE_ARGS, NAMESPACE, TYPE, ARG, EXPR)         \
+  /* Specializes the Converter<> class template for our TYPE. */              \
+  namespace drake::internal::formatter_as {                                   \
+  template <TEMPLATE_ARGS>                                                    \
+  struct Converter<NAMESPACE::TYPE> {                                         \
+    using InputType = NAMESPACE::TYPE;                                        \
+    static auto call(const InputType& ARG) { return EXPR; }                   \
+  };                                                                          \
+                                                                              \
+  /* Provides the fmt::formatter<TYPE> implementation. */                     \
+  template <TEMPLATE_ARGS>                                                    \
+  struct Formatter<NAMESPACE::TYPE>                                           \
+      : fmt::formatter<typename Traits<NAMESPACE::TYPE>::OutputType> {        \
+    using MyTraits = Traits<NAMESPACE::TYPE>;                                 \
+    /* Shadow our base class member function template of the same name. */    \
+    template <typename FormatContext>                                         \
+    auto format(const typename MyTraits::InputType& x,                        \
+                FormatContext& ctx) DRAKE_FMT8_CONST {                        \
+      /* Call the base class member function after laundering the object   */ \
+      /* through the user's provided format_as function. Older versions of */ \
+      /* fmt have const-correctness bugs, which we can fix with some good  */ \
+      /* old fashioned const_cast-ing here.                                */ \
+      using Base = typename MyTraits::OutputTypeFormatter;                    \
+      const Base* const self = this;                                          \
+      return const_cast<Base*>(self)->format(                                 \
+          MyTraits::Functor::call(x),                                         \
+          ctx);                                                               \
+    }                                                                         \
+  };                                                                          \
+  } /* namespace drake::internal::formatter_as */                             \
+                                                                              \
+  /* Specializes the fmt::formatter<> class template for TYPE. */             \
+  namespace fmt {                                                             \
+  template <TEMPLATE_ARGS>                                                    \
+  struct formatter<NAMESPACE::TYPE>                                           \
+      : drake::internal::formatter_as::Formatter<NAMESPACE::TYPE> {};         \
+  } /* namespace fmt */

--- a/common/test/copyable_unique_ptr_test.cc
+++ b/common/test/copyable_unique_ptr_test.cc
@@ -1055,7 +1055,22 @@ GTEST_TEST(CopyableUniquePtrTest, ReleaseTest) {
 }
 
 // Tests the stream value.
-GTEST_TEST(CopyableUniquePtrTest, StreamTest) {
+GTEST_TEST(CopyableUniquePtrTest, FormatterTest) {
+  // Try a null pointer value.
+  cup<CloneOnly> ptr;
+  const void* raw = ptr.get();
+  EXPECT_EQ(fmt::to_string(ptr), fmt::to_string(raw));
+
+  // Try a non-null value.
+  ptr.reset(new CloneOnly(1));
+  raw = ptr.get();
+  EXPECT_EQ(fmt::to_string(ptr), fmt::to_string(raw));
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+// Tests the stream value.
+GTEST_TEST(CopyableUniquePtrTest, DeprecatedStreamTest) {
   stringstream ss;
   CloneOnly* raw = nullptr;
   ss << raw;
@@ -1076,6 +1091,7 @@ GTEST_TEST(CopyableUniquePtrTest, StreamTest) {
   ss << ptr;
   EXPECT_EQ(ss.str(), raw_str);
 }
+#pragma GCC diagnostic pop
 
 // Tests the == tests between copyable_unique_ptr and other entities.
 GTEST_TEST(CopyableUniquePtrTest, EqualityTest) {

--- a/common/test/fmt_test.cc
+++ b/common/test/fmt_test.cc
@@ -1,0 +1,71 @@
+#include "drake/common/fmt.h"
+
+#include <ostream>
+
+#include <fmt/ranges.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_assert.h"
+
+// This namespace contains example code (i.e., what a user would write) for
+// formatting a class (or struct) using the "format as" helper.
+namespace sample {
+
+// A simple, non-templated struct.
+struct Int {
+  int i{};
+};
+
+// A template with 1 type argument.
+template <typename T>
+struct Wrap {
+  T t{};
+};
+
+// A template with 2 type arguments.
+template <typename T, typename U>
+struct Pair {
+  T t{};
+  U u{};
+};
+
+}  // namespace sample
+
+// Tell fmt how to format the sample types.
+DRAKE_FORMATTER_AS(, sample, Int, x, x.i)
+DRAKE_FORMATTER_AS(typename T, sample, Wrap<T>, x, x.t)
+DRAKE_FORMATTER_AS(typename... Ts, sample, Pair<Ts...>, x, std::pair(x.t, x.u))
+
+namespace drake {
+namespace {
+
+// Spot check the for "format as" formatter.
+GTEST_TEST(FmtTest, FormatAsFormatter) {
+  const sample::Int plain{1};
+  EXPECT_EQ(fmt::format("{}", plain), "1");
+  EXPECT_EQ(fmt::format("{:3}", plain), "  1");
+  EXPECT_EQ(fmt::format("{:<3}", plain), "1  ");
+
+  const sample::Wrap<double> real{1.1234567e6};
+  EXPECT_EQ(fmt::format("{}", real), "1123456.7");
+  EXPECT_EQ(fmt::format("{:.3G}", real), "1.12E+06");
+
+  // N.B. The fmt:formatter for std::pair comes from <fmt/ranges.h>.
+  const sample::Pair<int, int> pear{1, 2};
+  EXPECT_EQ(fmt::format("{}", pear), "(1, 2)");
+}
+
+// The googletest infrastructure uses fmt's formatters.
+GTEST_TEST(FmtTest, TestPrinter) {
+  const sample::Int plain{1};
+  EXPECT_EQ(testing::PrintToString(plain), "1");
+
+  const sample::Wrap<double> real{1.1};
+  EXPECT_EQ(testing::PrintToString(real), "1.1");
+
+  const sample::Pair<int, int> pear{1, 2};
+  EXPECT_EQ(testing::PrintToString(pear), "(1, 2)");
+}
+
+}  // namespace
+}  // namespace drake

--- a/common/test_utilities/BUILD.bazel
+++ b/common/test_utilities/BUILD.bazel
@@ -64,6 +64,15 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "fmt_format_printer",
+    testonly = 1,
+    hdrs = ["fmt_format_printer.h"],
+    tags = ["exclude_from_package"],
+    visibility = ["@gtest//:__pkg__"],
+    deps = ["@fmt"],
+)
+
+drake_cc_library(
     name = "is_dynamic_castable",
     testonly = 1,
     hdrs = ["is_dynamic_castable.h"],

--- a/common/test_utilities/fmt_format_printer.h
+++ b/common/test_utilities/fmt_format_printer.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <type_traits>
+
+#include <fmt/format.h>
+
+namespace drake {
+namespace internal {
+
+/* Defines a googletest printer for values that provide fmt::format.
+We hack this option into our tools/workspace/gtest/package.BUILD.bazel file. */
+struct FmtFormatPrinter {
+  // This is true iff the type provides fmt::formatter<T> directly, without
+  // any conversions or fallback to operator<< streaming.
+  template <typename T>
+  static constexpr bool is_directly_formattable =
+      std::is_constructible_v<fmt::formatter<T, char>>;
+
+  // SFINAE on whether the type directly supports formatting.
+  // If not, gtest has a suite of other kinds of printers is will fall back on.
+  template <typename T, typename = std::enable_if_t<is_directly_formattable<T>>>
+  static void PrintValue(const T& value, std::ostream* os) {
+    *os << fmt::to_string(value);
+  }
+};
+
+}  // namespace internal
+}  // namespace drake

--- a/common/text_logging.h
+++ b/common/text_logging.h
@@ -32,6 +32,10 @@ used by Drake might be older.)
 
 #include <string>
 
+#include <fmt/ostream.h>
+
+#include "drake/common/fmt.h"
+
 #ifndef DRAKE_DOXYGEN_CXX
 #ifdef HAVE_SPDLOG
 #ifndef NDEBUG
@@ -70,20 +74,7 @@ used by Drake might be older.)
 
 #endif
 
-/* clang-format off */
 #include <spdlog/spdlog.h>
-#include <spdlog/fmt/ostr.h>
-/* clang-format on */
-
-#else  // HAVE_SPDLOG
-
-// We always want text_logging.h to provide fmt support to those who include
-// it, even if spdlog is disabled.
-
-/* clang-format off */
-#include <fmt/format.h>
-#include <fmt/ostream.h>
-/* clang-format on */
 
 #endif  // HAVE_SPDLOG
 #endif  // DRAKE_DOXYGEN_CXX
@@ -91,14 +82,6 @@ used by Drake might be older.)
 #include "drake/common/drake_copyable.h"
 
 namespace drake {
-
-#if FMT_VERSION >= 80000 || defined(DRAKE_DOXYGEN_CXX)
-/// When using fmt >= 8, this is an alias for fmt::runtime.
-/// When using fmt < 8, this is a no-op.
-inline auto fmt_runtime(std::string_view s) { return fmt::runtime(s); }
-#else
-inline auto fmt_runtime(std::string_view s) { return s; }
-#endif
 
 #ifdef HAVE_SPDLOG
 namespace logging {

--- a/tools/workspace/gtest/package.BUILD.bazel
+++ b/tools/workspace/gtest/package.BUILD.bazel
@@ -45,6 +45,9 @@ cc_library(
         "@//conditions:default": [],
     }),
     linkstatic = 1,
+    deps = [
+        "@drake//common/test_utilities:fmt_format_printer",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/tools/workspace/gtest/patches/add_printers.patch
+++ b/tools/workspace/gtest/patches/add_printers.patch
@@ -1,0 +1,23 @@
+Adds more printer options for displaying values under test
+
+The FmtFormatPrinter knows how to ask fmt::to_string to print values.
+
+--- googletest/include/gtest/gtest-printers.h
++++ googletest/include/gtest/gtest-printers.h
+@@ -115,6 +115,8 @@
+ #include "gtest/internal/gtest-internal.h"
+ #include "gtest/internal/gtest-port.h"
+ 
++#include "drake/common/test_utilities/fmt_format_printer.h"
++
+ namespace testing {
+ 
+ // Definitions in the internal* namespaces are subject to change without notice.
+@@ -306,6 +308,7 @@
+ void PrintWithFallback(const T& value, ::std::ostream* os) {
+   using Printer = typename FindFirstPrinter<
+       T, void, ContainerPrinter, FunctionPointerPrinter, PointerPrinter,
++      drake::internal::FmtFormatPrinter,
+       internal_stream_operator_without_lexical_name_lookup::StreamPrinter,
+       ProtobufPrinter, ConvertibleToIntegerPrinter,
+       ConvertibleToStringViewPrinter, RawBytesPrinter, FallbackPrinter>::type;

--- a/tools/workspace/gtest/repository.bzl
+++ b/tools/workspace/gtest/repository.bzl
@@ -11,5 +11,8 @@ def gtest_repository(
         commit = "v1.13.0",
         sha256 = "ad7fdba11ea011c1d925b3289cf4af2c66a352e18d4c7264392fead75e919363",  # noqa
         build_file = ":package.BUILD.bazel",
+        patches = [
+            ":patches/add_printers.patch",
+        ],
         mirrors = mirrors,
     )


### PR DESCRIPTION
Move `drake::fmt_runtime` shim from `common/text_logging.h` to new file `common/fmt.h`.

Add `DRAKE_FORMATTER_AS` macro to trampoline formatter to another related object. This is useful for formatting wrapper types (copyable_unique_ptr, identifier, sorted_pair, type_safe_index, etc).

Patch googletest to use fmt for formatting, when available.

Port `copyable_unique_ptr` to the new code and deprecate its `operator<<`.

---

Towards #17742.  See also the WIP branch: https://github.com/jwnimmer-tri/drake/commits/fmt-v9.

The goal of this first step is to land the googletest integration, so that as we continue to deprecate the `operator<<` overloads, we won't run into unit testing headaches.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18771)
<!-- Reviewable:end -->
