### PR TITLE
[planning] Simplify RobotDiagramBuilder function names

### DIFF
--- a/bindings/pydrake/planning/planning_py_robot_diagram.cc
+++ b/bindings/pydrake/planning/planning_py_robot_diagram.cc
@@ -55,37 +55,30 @@ void DefinePlanningRobotDiagram(py::module m) {
     {
       using Class = RobotDiagramBuilder<T>;
       constexpr auto& cls_doc = doc.RobotDiagramBuilder;
-      auto cls = DefineTemplateClassWithDefault<Class>(m, "RobotDiagramBuilder",
-          GetPyParam<T>(),
-          (std::string(cls_doc.doc) +
-              "\n\n"
-              "Note:\n"
-              "    The C++ class defines pairs of sibling methods, e.g.,\n"
-              "    parser() vs mutable_parser(). Since Python does not use\n"
-              "    const-ness, we only provide one of the two siblings here,\n"
-              "    using the shorter method name but still allowing mutation,\n"
-              "    e.g., parser() returns a Parser that *does* allow loading\n"
-              "    models and changing package paths.\n")
-              .c_str());
+      auto cls = DefineTemplateClassWithDefault<Class>(
+          m, "RobotDiagramBuilder", GetPyParam<T>(), cls_doc.doc);
       cls  // BR
           .def(py::init<double>(), py::arg("time_step") = 0.0, cls_doc.ctor.doc)
-          .def("builder", &Class::mutable_builder, py_rvp::reference_internal,
-              cls_doc.mutable_builder.doc);
+          .def("builder",
+              overload_cast_explicit<systems::DiagramBuilder<T>&>(
+                  &Class::builder),
+              py_rvp::reference_internal, cls_doc.builder.doc_0args_nonconst);
       if constexpr (std::is_same_v<T, double>) {
         cls  // BR
             .def(
-                "parser", [](Class& self) { return &self.mutable_parser(); },
-                py_rvp::reference_internal, cls_doc.mutable_parser.doc);
+                "parser", [](Class& self) { return &self.parser(); },
+                py_rvp::reference_internal, cls_doc.parser.doc_0args_nonconst);
       }
       cls  // BR
-          .def("plant", &Class::mutable_plant, py_rvp::reference_internal,
-              cls_doc.mutable_plant.doc)
-          .def("scene_graph", &Class::mutable_scene_graph,
-              py_rvp::reference_internal, cls_doc.mutable_scene_graph.doc)
-          .def("IsPlantFinalized", &Class::IsPlantFinalized,
-              cls_doc.IsPlantFinalized.doc)
-          .def(
-              "FinalizePlant", &Class::FinalizePlant, cls_doc.FinalizePlant.doc)
+          .def("plant",
+              overload_cast_explicit<multibody::MultibodyPlant<T>&>(
+                  &Class::plant),
+              py_rvp::reference_internal, cls_doc.plant.doc_0args_nonconst)
+          .def("scene_graph",
+              overload_cast_explicit<geometry::SceneGraph<T>&>(
+                  &Class::scene_graph),
+              py_rvp::reference_internal,
+              cls_doc.scene_graph.doc_0args_nonconst)
           .def("IsDiagramBuilt", &Class::IsDiagramBuilt,
               cls_doc.IsDiagramBuilt.doc)
           .def("Build", &Class::Build,
@@ -95,13 +88,23 @@ void DefinePlanningRobotDiagram(py::module m) {
               // until the builder (and all of its internal references) are
               // finished.
               py::keep_alive<1, 0>(), cls_doc.Build.doc);
-      cls.def(  // Deprecation for BuildDiagram.
-          "BuildDiagram",
-          [](Class* self) {
-            WarnDeprecated(cls_doc.BuildDiagram.doc_deprecated);
-            return self->Build();
-          },
-          py::keep_alive<1, 0>(), cls_doc.BuildDiagram.doc_deprecated);
+      // Remove these deprecations on 2023-06-01.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+      cls  // BR
+          .def("BuildDiagram",
+              WrapDeprecated(
+                  cls_doc.BuildDiagram.doc_deprecated, &Class::BuildDiagram),
+              py::keep_alive<1, 0>(), cls_doc.BuildDiagram.doc_deprecated)
+          .def("IsPlantFinalized",
+              WrapDeprecated(cls_doc.IsPlantFinalized.doc_deprecated,
+                  &Class::IsPlantFinalized),
+              cls_doc.IsPlantFinalized.doc_deprecated)
+          .def("FinalizePlant",
+              WrapDeprecated(
+                  cls_doc.FinalizePlant.doc_deprecated, &Class::FinalizePlant),
+              cls_doc.FinalizePlant.doc_deprecated);
+#pragma GCC diagnostic pop
     }
   };
   type_visit(bind_common_scalar_types, CommonScalarPack{});

--- a/bindings/pydrake/planning/test/robot_diagram_test.py
+++ b/bindings/pydrake/planning/test/robot_diagram_test.py
@@ -32,11 +32,6 @@ class TestRobotDiagram(unittest.TestCase):
         self.assertIsInstance(dut.plant(), MultibodyPlant_[T])
         self.assertIsInstance(dut.scene_graph(), SceneGraph_[T])
 
-        # Finalize.
-        self.assertFalse(dut.IsPlantFinalized())
-        dut.FinalizePlant()
-        self.assertTrue(dut.IsPlantFinalized())
-
         # Build.
         self.assertFalse(dut.IsDiagramBuilt())
         diagram = dut.Build()
@@ -46,6 +41,10 @@ class TestRobotDiagram(unittest.TestCase):
     def test_robot_diagram_builder_deprecation(self):
         builder = mut.RobotDiagramBuilder()
         self.assertFalse(builder.IsDiagramBuilt())
+        with catch_drake_warnings(expected_count=1) as w:
+            self.assertFalse(builder.IsPlantFinalized())
+        with catch_drake_warnings(expected_count=1) as w:
+            builder.FinalizePlant()
         with catch_drake_warnings(expected_count=1) as w:
             diagram = builder.BuildDiagram()
         self.assertTrue(builder.IsDiagramBuilt())

--- a/planning/robot_diagram_builder.cc
+++ b/planning/robot_diagram_builder.cc
@@ -26,8 +26,8 @@ RobotDiagramBuilder<T>::~RobotDiagramBuilder() = default;
 template <typename T>
 std::unique_ptr<RobotDiagram<T>> RobotDiagramBuilder<T>::Build() {
   ThrowIfAlreadyBuilt();
-  if (!IsPlantFinalized()) {
-    FinalizePlant();
+  if (!plant().is_finalized()) {
+    plant().Finalize();
   }
   return std::unique_ptr<RobotDiagram<T>>(
       new RobotDiagram<T>(std::move(builder_)));

--- a/planning/robot_diagram_builder.h
+++ b/planning/robot_diagram_builder.h
@@ -36,7 +36,7 @@ class RobotDiagramBuilder {
   /** Gets the contained DiagramBuilder (mutable).
   Do not call Build() on the return value; instead, call Build() on this.
   @throws exception when IsDiagramBuilt() already. */
-  systems::DiagramBuilder<T>& mutable_builder() {
+  systems::DiagramBuilder<T>& builder() {
     ThrowIfAlreadyBuilt();
     return *builder_;
   }
@@ -52,7 +52,7 @@ class RobotDiagramBuilder {
   @throws exception when IsDiagramBuilt() already. */
   template <typename T1 = T, typename std::enable_if_t<
     std::is_same_v<T1, double>>* = nullptr>
-  multibody::Parser& mutable_parser() {
+  multibody::Parser& parser() {
     ThrowIfAlreadyBuilt();
     return parser_;
   }
@@ -68,7 +68,7 @@ class RobotDiagramBuilder {
 
   /** Gets the contained plant (mutable).
   @throws exception when IsDiagramBuilt() already. */
-  multibody::MultibodyPlant<T>& mutable_plant() {
+  multibody::MultibodyPlant<T>& plant() {
     ThrowIfAlreadyBuilt();
     return plant_;
   }
@@ -82,7 +82,7 @@ class RobotDiagramBuilder {
 
   /** Gets the contained scene graph (mutable).
   @throws exception when IsDiagramBuilt() already. */
-  geometry::SceneGraph<T>& mutable_scene_graph() {
+  geometry::SceneGraph<T>& scene_graph() {
     ThrowIfAlreadyBuilt();
     return scene_graph_;
   }
@@ -92,20 +92,6 @@ class RobotDiagramBuilder {
   const geometry::SceneGraph<T>& scene_graph() const {
     ThrowIfAlreadyBuilt();
     return scene_graph_;
-  }
-
-  /** Checks if the contained plant is finalized.
-  @throws exception when IsDiagramBuilt() already. */
-  bool IsPlantFinalized() const {
-    ThrowIfAlreadyBuilt();
-    return plant_.is_finalized();
-  }
-
-  /** Finalizes the contained plant.
-  @throws exception when IsDiagramBuilt() already. */
-  void FinalizePlant() {
-    ThrowIfAlreadyBuilt();
-    plant_.Finalize();
   }
 
   /** Checks if the diagram has already been built. */
@@ -120,6 +106,43 @@ class RobotDiagramBuilder {
   DRAKE_DEPRECATED("2023-06-01", "Use Build() instead of BuildDiagram().")
   std::unique_ptr<RobotDiagram<T>> BuildDiagram() {
     return Build();
+  }
+
+  DRAKE_DEPRECATED("2023-06-01", "Use builder() instead of mutable_builder().")
+  systems::DiagramBuilder<T>& mutable_builder() {
+    return builder();
+  }
+
+  template <typename T1 = T, typename std::enable_if_t<
+    std::is_same_v<T1, double>>* = nullptr>
+  DRAKE_DEPRECATED("2023-06-01", "Use parser() instead of mutable_parser().")
+  multibody::Parser& mutable_parser() {
+    return parser();
+  }
+
+  DRAKE_DEPRECATED("2023-06-01", "Use plant() instead of mutable_plant().")
+  multibody::MultibodyPlant<T>& mutable_plant() {
+    return plant();
+  }
+
+  DRAKE_DEPRECATED("2023-06-01",
+      "Use scene_graph() instead of mutable_scene_graph().")
+  geometry::SceneGraph<T>& mutable_scene_graph() {
+    return scene_graph();
+  }
+
+  DRAKE_DEPRECATED("2023-06-01",
+      "Use plant().is_finalized() instead of IsPlantFinalized().")
+  bool IsPlantFinalized() const {
+    ThrowIfAlreadyBuilt();
+    return plant_.is_finalized();
+  }
+
+  DRAKE_DEPRECATED("2023-06-01",
+      "Use plant().Finalize() instead of FinalizePlant().")
+  void FinalizePlant() {
+    ThrowIfAlreadyBuilt();
+    plant_.Finalize();
   }
 
  private:

--- a/planning/test/body_shape_description_test.cc
+++ b/planning/test/body_shape_description_test.cc
@@ -53,7 +53,7 @@ GTEST_TEST(BodyShapeDescriptionTest, FromPlant) {
   </model>
 </sdf>
 )""";
-  builder.mutable_parser().AddModelsFromString(model, "sdf");
+  builder.parser().AddModelsFromString(model, "sdf");
   auto diagram = builder.Build();
   auto diagram_context = diagram->CreateDefaultContext();
   auto& plant = diagram->plant();

--- a/planning/test/collision_avoidance_test.cc
+++ b/planning/test/collision_avoidance_test.cc
@@ -28,8 +28,8 @@ double ZeroDistanceFunc(const VectorXd&, const VectorXd&) { return 0.0; }
 unique_ptr<RobotDiagram<double>> MakeRobot() {
   RobotDiagramBuilder<double> builder;
   const auto model_instance = drake::multibody::default_model_instance();
-  builder.mutable_plant().AddRigidBody("floater", model_instance,
-                                       SpatialInertia<double>::MakeUnitary());
+  builder.plant().AddRigidBody("floater", model_instance,
+                               SpatialInertia<double>::MakeUnitary());
   return builder.Build();
 }
 

--- a/planning/test/collision_checker_test.cc
+++ b/planning/test/collision_checker_test.cc
@@ -257,13 +257,13 @@ struct ModelConfig {
 pair<std::unique_ptr<RobotDiagram<double>>, ModelInstanceIndex> MakeModel(
     const ModelConfig& config = {}) {
   RobotDiagramBuilder<double> builder;
-  auto& builder_plant = builder.mutable_plant();
+  auto& builder_plant = builder.plant();
   // Add the robot -- a chain of three links -- and weld it to the world.
   // Don't change the ordering or the length of the chain; the tests for this
   // fixture rely on knowing body indices.
   auto robot_index = AddChain(&builder_plant, 3, config.per_body_geometries);
   if (config.weld_robot) {
-    builder.mutable_plant().WeldFrames(
+    builder_plant.WeldFrames(
         builder_plant.get_body(BodyIndex(0)).body_frame(),
         builder_plant.get_body(BodyIndex(1)).body_frame());
   } else if (config.on_env_base) {
@@ -356,7 +356,7 @@ TEST_F(CollisionCheckerThrowTest, WorldRobot) {
 // sorts them.
 GTEST_TEST(CollisionCheckerTest, SortedRobots) {
   RobotDiagramBuilder<double> builder;
-  auto& plant = builder.mutable_plant();
+  auto& plant = builder.plant();
   const ModelInstanceIndex robot1 = AddChain(&plant, 1);
   const ModelInstanceIndex robot2 = AddChain(&plant, 2);
   auto distance_function = [](auto...) { return 0; };
@@ -1279,7 +1279,7 @@ CheckerType MakeEdgeChecker(ConfigurationDistanceFunction calc_dist,
                             bool welded = true, int N = 2) {
   RobotDiagramBuilder<double> builder;
   // We need just enough state so we can save values in q.
-  auto& plant = builder.mutable_plant();
+  auto& plant = builder.plant();
   const ModelInstanceIndex robot = AddChain(&plant, N);
   // Weld the chain to the world so we don't have to worry about quaternions.
   const auto& body = plant.GetBodyByName("b0");

--- a/planning/test/planning_test_helpers.cc
+++ b/planning/test/planning_test_helpers.cc
@@ -25,7 +25,7 @@ using multibody::parsing::ProcessModelDirectives;
 std::unique_ptr<RobotDiagram<double>> MakePlanningTestModel(
     const ModelDirectives& directives) {
   auto builder = std::make_unique<RobotDiagramBuilder<double>>();
-  auto& parser = builder->mutable_parser();
+  auto& parser = builder->parser();
   ProcessModelDirectives(directives, &parser);
   return builder->Build();
 }

--- a/planning/test/scene_graph_collision_checker_test.cc
+++ b/planning/test/scene_graph_collision_checker_test.cc
@@ -62,7 +62,7 @@ INSTANTIATE_TEST_SUITE_P(
 // Dallas's sphere has a radius of 1.0.
 GTEST_TEST(SceneGraphCollisionCheckerTest, ClearanceThreeSpheres) {
   RobotDiagramBuilder<double> builder;
-  builder.mutable_parser().AddModelsFromString(R"""(
+  builder.parser().AddModelsFromString(R"""(
 <?xml version='1.0'?>
 <sdf xmlns:drake='http://drake.mit.edu' version='1.9'>
 <world name='default'>
@@ -216,7 +216,7 @@ GTEST_TEST(SceneGraphCollisionCheckerTest, ClearanceThreeSpheres) {
 GTEST_TEST(SceneGraphCollisionCheckerTest, ClearanceFloatingBase) {
   // Build a dut with a ground plane + floating chassis with welded arm.
   RobotDiagramBuilder<double> builder;
-  builder.mutable_parser().AddModelsFromString(R"""(
+  builder.parser().AddModelsFromString(R"""(
 directives:
 - add_model:
     name: ground


### PR DESCRIPTION
The typical use case of a builder is that the object is mutable and users are mutating it. In that case, the clarity benefit of using "mutable_" prefix on is small compared to the cost. (In contrast with, e.g., a Context where mutation access causes cache entry invalidation so using special names make sense.)  This brings C++ up to par with what we did in Python.

Also deprecate the IsPlantFinalized and FinalizePlant sugar. The sugar isn't encapsulating or abbreviating anything versus calling the MbP functions directly on the plant() accessor, where the MbP functions have full documentation directly under your auto-complete IDE fingertips.

---

Follow-up from #18770.

\CC @RussTedrake @calderpg-tri FYI

Confirmed `Anzu-master-Drake-PR/181` passes vs these deprecations.

Confirmed `anzu/pull/10107` passes with this PR + Anzu fixes for the new spellings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18772)
<!-- Reviewable:end -->
