### PR TITLE
[parsing] Allow models to be parsed into plant from obj files

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -665,6 +665,7 @@ drake_cc_library(
     hdrs = ["obj_to_surface_mesh.h"],
     interface_deps = [
         ":triangle_surface_mesh",
+        "//common:diagnostic_policy",
     ],
     deps = [
         "//common:essential",

--- a/geometry/proximity/obj_to_surface_mesh.cc
+++ b/geometry/proximity/obj_to_surface_mesh.cc
@@ -22,6 +22,8 @@ namespace drake {
 namespace geometry {
 namespace {
 
+using drake::internal::DiagnosticDetail;
+using drake::internal::DiagnosticPolicy;
 using Eigen::Vector3d;
 
 // TODO(DamrongGuoy): Refactor the tinyobj usage between here and
@@ -109,11 +111,15 @@ void TinyObjToSurfaceFaces(const tinyobj::mesh_t& mesh,
   }
 }
 
-TriangleSurfaceMesh<double> DoReadObjToSurfaceMesh(
+}  // namespace
+
+namespace internal {
+std::optional<TriangleSurfaceMesh<double>> DoReadObjToSurfaceMesh(
     std::istream* input_stream,
     const double scale,
     const std::optional<std::string>& mtl_basedir,
-    const std::function<void(std::string_view)> on_warning) {
+    const ObjParseConfig& config) {
+
   tinyobj::attrib_t attrib;  // Used for vertices.
   std::vector<tinyobj::shape_t> shapes;  // Used for triangles.
   std::vector<tinyobj::material_t> materials;  // Not used.
@@ -130,22 +136,33 @@ TriangleSurfaceMesh<double> DoReadObjToSurfaceMesh(
       &attrib, &shapes, &materials, &warn, &err, input_stream, readMatFn.get(),
       triangulate);
   if (!ret || !err.empty()) {
-    throw std::runtime_error("Error parsing Wavefront obj file : " + err);
+    const std::string err_message =
+        fmt::format("Error parsing Wavefront obj data : {}", err);
+    config.diagnostic.Error(err_message);
+    return std::nullopt;
   }
   if (!warn.empty()) {
-    warn = "Warning parsing Wavefront obj file : " + warn;
+    warn = "Warning parsing Wavefront obj data : " + warn;
     if (warn.back() == '\n') {
       warn.pop_back();
     }
-    if (on_warning) {
-      on_warning(warn);
-    } else {
-      drake::log()->warn(warn);
-    }
+    config.diagnostic.Warning(warn);
   }
   if (shapes.size() == 0) {
-    throw std::runtime_error("The Wavefront obj file has no faces.");
+    const char* err_message = "The Wavefront obj data has no faces.";
+    config.diagnostic.Error(err_message);
+    return std::nullopt;
   }
+
+  if (config.allowed_shape_count > 0 &&
+      static_cast<int>(shapes.size()) > config.allowed_shape_count) {
+    const std::string err_message = fmt::format(
+        "The Wavefront obj data defines {} unique shapes; only {} allowed.",
+        shapes.size(), config.allowed_shape_count);
+    config.diagnostic.Error(err_message);
+    return std::nullopt;
+  }
+
   std::vector<Vector3d> vertices =
       TinyObjToSurfaceVertices(attrib.vertices, scale);
 
@@ -168,7 +185,7 @@ TriangleSurfaceMesh<double> DoReadObjToSurfaceMesh(
   return TriangleSurfaceMesh<double>(std::move(faces), std::move(vertices));
 }
 
-}  // namespace
+}  // namespace internal
 
 TriangleSurfaceMesh<double> ReadObjToTriangleSurfaceMesh(
     const std::string& filename,
@@ -180,17 +197,35 @@ TriangleSurfaceMesh<double> ReadObjToTriangleSurfaceMesh(
   }
   const std::string mtl_basedir =
       std::filesystem::path(filename).parent_path().string() + "/";
-  return DoReadObjToSurfaceMesh(&input_stream, scale, mtl_basedir,
-                                std::move(on_warning));
+
+  DiagnosticPolicy policy;
+  if (on_warning != nullptr) {
+    policy.SetActionForWarnings([&on_warning](const DiagnosticDetail& detail) {
+      on_warning(detail.FormatWarning());
+    });
+  }
+
+  // We will either throw or return a mesh here.
+  return *internal::DoReadObjToSurfaceMesh(&input_stream, scale, mtl_basedir,
+                                           {.diagnostic = policy});
 }
 
 TriangleSurfaceMesh<double> ReadObjToTriangleSurfaceMesh(
-    std::istream* input_stream,
-    const double scale,
+    std::istream* input_stream, const double scale,
     std::function<void(std::string_view)> on_warning) {
   DRAKE_THROW_UNLESS(input_stream != nullptr);
-  return DoReadObjToSurfaceMesh(input_stream, scale,
-      std::nullopt /* mtl_basedir */, std::move(on_warning));
+
+  DiagnosticPolicy policy;
+  if (on_warning != nullptr) {
+    policy.SetActionForWarnings([&on_warning](const DiagnosticDetail& detail) {
+      on_warning(detail.FormatWarning());
+    });
+  }
+
+  // We will either throw or return a mesh here.
+  return *internal::DoReadObjToSurfaceMesh(input_stream, scale,
+                                           std::nullopt /* mtl_basedir */,
+                                           {.diagnostic = policy});
 }
 
 }  // namespace geometry

--- a/geometry/proximity/obj_to_surface_mesh.h
+++ b/geometry/proximity/obj_to_surface_mesh.h
@@ -2,14 +2,38 @@
 
 #include <functional>
 #include <istream>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
 
+#include "drake/common/diagnostic_policy.h"
 #include "drake/geometry/proximity/triangle_surface_mesh.h"
 
 namespace drake {
 namespace geometry {
+namespace internal {
+
+/* Configures the obj->mesh parsing operation. */
+struct ObjParseConfig {
+    /* The policy for handling warnings and errors. */
+    drake::internal::DiagnosticPolicy diagnostic;
+    /* Defines the maximum number of unique shapes in the file for a strictly
+     positive value. For any non-positive value, there is no limit. */
+    int allowed_shape_count{-1};
+};
+
+/* Creates a triangle mesh from the obj data contained in the `input_stream`.
+ Parsing will continue through warnings, but stop for errors. If the given
+ diagnostic policy (as defined in `config`) doesn't throw for errors,
+ std::nullopt is returned.
+ @pre `config` has both warning and error handlers defined. */
+std::optional<TriangleSurfaceMesh<double>> DoReadObjToSurfaceMesh(
+    std::istream* input_stream, double scale,
+    const std::optional<std::string>& mtl_basedir,
+    const ObjParseConfig& config);
+
+}  // namespace internal
 
 /**
  Constructs a surface mesh from a Wavefront .obj file and optionally scales

--- a/geometry/proximity/test/obj_to_surface_mesh_test.cc
+++ b/geometry/proximity/test/obj_to_surface_mesh_test.cc
@@ -157,7 +157,7 @@ GTEST_TEST(ObjToSurfaceMeshTest, ThrowExceptionInvalidFilePath) {
 GTEST_TEST(ObjToSurfaceMeshTest, ThrowExceptionForEmptyFile) {
   std::istringstream empty("");
   DRAKE_EXPECT_THROWS_MESSAGE(ReadObjToTriangleSurfaceMesh(&empty),
-                              "The Wavefront obj file has no faces.");
+                              ".*The Wavefront obj data has no faces.");
 }
 
 void FailOnWarning(std::string_view message) {
@@ -183,7 +183,7 @@ GTEST_TEST(ObjToSurfaceMeshTest, WarningCallback) {
     std::ifstream input(filename);
     DRAKE_EXPECT_THROWS_MESSAGE(
         ReadObjToTriangleSurfaceMesh(&input, 1.0, &FailOnWarning),
-        "FailOnWarning: Warning parsing Wavefront obj file : "
+        "FailOnWarning: .*Warning parsing Wavefront obj data : "
         ".*CubeMaterial.*not found.*");
   }
 
@@ -199,7 +199,7 @@ v 0.0 1.0 0.0
 v 0.0 0.0 1.0
 )"};
   DRAKE_EXPECT_THROWS_MESSAGE(ReadObjToTriangleSurfaceMesh(&no_faces),
-                              "The Wavefront obj file has no faces.");
+                              ".*The Wavefront obj data has no faces.");
 }
 
 GTEST_TEST(ObjToSurfaceMeshTest, ThrowExceptionObjectHasNoFaces) {
@@ -210,7 +210,7 @@ v 0.0 1.0 0.0
 v 0.0 0.0 1.0
 )"};
   DRAKE_EXPECT_THROWS_MESSAGE(ReadObjToTriangleSurfaceMesh(&no_faces),
-                              "The Wavefront obj file has no faces.");
+                              ".*The Wavefront obj data has no faces.");
 }
 
 // Confirms that we can accept an obj file with faces (f lines) without

--- a/geometry/render/test/meshes/box.obj
+++ b/geometry/render/test/meshes/box.obj
@@ -1,5 +1,6 @@
 mtllib ./box.obj.mtl
 
+o test_box
 # Vertices
 v -1.0 -1.0 -1.0
 v -1.0 1.0 -1.0

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -102,6 +102,22 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "detail_mesh_parser",
+    srcs = ["detail_mesh_parser.cc"],
+    hdrs = ["detail_mesh_parser.h"],
+    internal = True,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":detail_parsing_workspace",
+        "//geometry/proximity:obj_to_surface_mesh",
+        "//multibody/plant",
+        "//multibody/tree:geometry_spatial_inertia",
+        "@fmt",
+        "@tinyobjloader",
+    ],
+)
+
+drake_cc_library(
     name = "detail_sdf_diagnostic",
     srcs = ["detail_sdf_diagnostic.cc"],
     hdrs = ["detail_sdf_diagnostic.h"],
@@ -211,6 +227,7 @@ drake_cc_library(
     internal = True,
     visibility = ["//visibility:private"],
     deps = [
+        ":detail_misc",
         ":package_map",
         "//common:diagnostic_policy",
         "//multibody/plant",
@@ -225,6 +242,7 @@ drake_cc_library(
     visibility = ["//visibility:private"],
     deps = [
         ":detail_dmd_parser",
+        ":detail_mesh_parser",
         ":detail_mujoco_parser",
         ":detail_parsing_workspace",
         ":detail_sdf_parser",
@@ -435,6 +453,20 @@ drake_cc_googletest(
     name = "detail_common_test",
     deps = [
         ":detail_misc",
+    ],
+)
+
+drake_cc_googletest(
+    name = "detail_mesh_parser_test",
+    data = [
+        ":test_models",
+        "//geometry/render:test_models",
+    ],
+    deps = [
+        ":detail_mesh_parser",
+        ":diagnostic_policy_test_base",
+        "//common:find_resource",
+        "//common/test_utilities",
     ],
 )
 

--- a/multibody/parsing/detail_mesh_parser.cc
+++ b/multibody/parsing/detail_mesh_parser.cc
@@ -1,0 +1,180 @@
+#include "drake/multibody/parsing/detail_mesh_parser.h"
+
+#include <filesystem>
+#include <fstream>
+#include <istream>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+#include <tiny_obj_loader.h>
+
+#include "drake/common/diagnostic_policy.h"
+#include "drake/geometry/proximity/obj_to_surface_mesh.h"
+#include "drake/geometry/proximity/triangle_surface_mesh.h"
+#include "drake/multibody/tree/geometry_spatial_inertia.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace {
+
+using drake::geometry::TriangleSurfaceMesh;
+using drake::internal::DiagnosticPolicy;
+
+// The parse result of attempting to read a single object from OBJ data.
+struct NamedMesh {
+  std::string name;
+  std::unique_ptr<TriangleSurfaceMesh<double>> mesh;
+};
+
+// Callback function for capturing the parsed object name; required by tinyobj's
+// API. `storage` is provided by the caller.
+void CaptureName(void* storage, const char* parsed_name) {
+  *static_cast<std::string*>(storage) = parsed_name;
+}
+
+// Attempts to parse a single mesh out of the input stream returning the
+// resulting triangle mesh and its name (if any is defined). If there is a
+// parsing failure, the return value contains a null mesh.
+NamedMesh DoGetObjMesh(const DiagnosticPolicy& diagnostic,
+                       std::istream* input_stream,
+                       const std::string& mtl_basedir) {
+  std::optional<TriangleSurfaceMesh<double>> mesh =
+      geometry::internal::DoReadObjToSurfaceMesh(input_stream, 1.0,
+                                                 mtl_basedir,
+                                                 {.diagnostic = diagnostic,
+                                                  .allowed_shape_count = 1});
+
+  if (!mesh.has_value()) {
+    return {};
+  }
+
+  // A mesh exists, let's see if it had a name. We'll rewind the input stream
+  // and parse explicitly listening for the "o some_name" data.
+  std::string object_name;
+  tinyobj::callback_t callback;
+  callback.object_cb = CaptureName;
+
+  input_stream->seekg(0);
+  const bool result =
+      tinyobj::LoadObjWithCallback(*input_stream, callback, &object_name);
+  // If we have a mesh, then no error should be encountered in attempting to
+  // find the name.
+  DRAKE_DEMAND(result);
+  // Note: the name may still be *empty*. This simply means the obj didn't
+  // define an object name.
+  return {object_name,
+          std::make_unique<TriangleSurfaceMesh<double>>(std::move(*mesh))};
+}
+
+// N.B. This layer of abstraction leaves the door open for implementing
+// GetMeshFromString() once we can support handling SceneGraph geometry from
+// an in-memory source.
+NamedMesh GetMeshFromFile(const DiagnosticPolicy& diagnostic,
+                          const std::string filename) {
+  std::ifstream input_stream(filename);
+  if (!input_stream.is_open()) {
+    diagnostic.Error(fmt::format("Cannot open file '{}'", filename));
+    return {};
+  }
+  // Failure to provide the directory of the obj file as the base material
+  // library directory will cause OBJs with MTL files referenced by relative
+  // paths to spew warnings.
+  const std::string mtl_basedir =
+      std::filesystem::path(filename).parent_path().string() + "/";
+  return DoGetObjMesh(diagnostic, &input_stream, mtl_basedir);
+}
+
+}  // namespace
+
+std::optional<ModelInstanceIndex> AddModelFromMesh(
+    const DataSource& data_source, const std::string& model_name,
+    const std::optional<std::string>& parent_model_name,
+    const ParsingWorkspace& workspace) {
+  if (!data_source.IsFilename()) {
+    throw std::runtime_error(
+        "Parser does not yet support adding models using in-memory OBJ data. "
+        "The OBJ data must be referenced as a file.");
+  }
+  DRAKE_THROW_UNLESS(!workspace.plant->is_finalized());
+
+  const std::string filename = data_source.GetAbsolutePath();
+
+  NamedMesh named_mesh = GetMeshFromFile(workspace.diagnostic, filename);
+
+  if (named_mesh.mesh == nullptr) {
+    // Reasons for there being no mesh should already have been dispatched to
+    // the diagnostic policy.
+    return std::nullopt;
+  }
+
+  // Resolve the naming protocol - see Parser documentation.
+  std::string candidate_name = model_name;
+  if (candidate_name.empty()) {
+    candidate_name = named_mesh.name;
+  }
+  if (candidate_name.empty()) {
+    candidate_name = std::filesystem::path(filename).stem();
+  }
+
+  // Register model instance, body, and collision and visual geometries.
+  MultibodyPlant<double>& plant = *workspace.plant;
+  const std::string model_instance_name =
+      parent_model_name.has_value()
+          ? fmt::format("{}::{}", *parent_model_name, candidate_name)
+          : candidate_name;
+  const ModelInstanceIndex model_instance =
+      plant.AddModelInstance(model_instance_name);
+
+  const SpatialInertia<double> M_BBo_B =
+      CalcSpatialInertia(*named_mesh.mesh, 1000.0 /* kg/m3 */);
+  const RigidBody<double>& body =
+      plant.AddRigidBody(candidate_name, model_instance, M_BBo_B);
+
+  if (plant.geometry_source_is_registered()) {
+    // TODO(SeanCurtis-TRI): Consider using named_mesh.name as part of the
+    // geometry names.
+    // TODO(SeanCurtis-TRI): It would be better to use a single geometry and
+    // assign all three roles to it. This would require access to the SceneGraph
+    // and some shenanigans to placate MbP.
+    const auto X_BG = math::RigidTransformd::Identity();
+    const geometry::Mesh mesh(filename);
+    plant.RegisterCollisionGeometry(body, X_BG, mesh, "collision",
+                                    CoulombFriction<double>());
+    // TODO(SeanCurtis-TRI): If there's a material applied to the object, use
+    // the specified color.
+    plant.RegisterVisualGeometry(body, X_BG, mesh, "visual");
+  }
+
+  return model_instance;
+}
+
+MeshParserWrapper::MeshParserWrapper() = default;
+MeshParserWrapper::~MeshParserWrapper() = default;
+
+std::optional<ModelInstanceIndex> MeshParserWrapper::AddModel(
+    const DataSource& data_source, const std::string& model_name,
+    const std::optional<std::string>& parent_model_name,
+    const ParsingWorkspace& workspace) {
+  return AddModelFromMesh(data_source, model_name, parent_model_name,
+                          workspace);
+}
+
+std::vector<ModelInstanceIndex> MeshParserWrapper::AddAllModels(
+    const DataSource& data_source,
+    const std::optional<std::string>& parent_model_name,
+    const ParsingWorkspace& workspace) {
+  std::optional<ModelInstanceIndex> maybe_index =
+      AddModelFromMesh(data_source, "", parent_model_name, workspace);
+  if (maybe_index.has_value()) {
+    return {*maybe_index};
+  }
+  return {};
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/detail_mesh_parser.h
+++ b/multibody/parsing/detail_mesh_parser.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "drake/multibody/parsing/detail_parsing_workspace.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Adds a single model instance with a single body to `plant` based on the mesh
+// data specified by `data_source`. The mesh data must be in the Wavefront OBJ
+// format and contain only a _single_ object specification.
+//
+// @throws std::exception if the file is not in accordance with the OBJ
+// specification containing a message with a list of errors encountered while
+// parsing the file.
+// @throws std::exception if there is not a single object in the mesh data.
+// @throws std::exception if plant is nullptr or if MultibodyPlant::Finalize()
+// was already called on `plant`.
+// @throws if `data_source` is not a filename.
+//
+// @param data_source
+//   The OBJ data to be parsed.
+// @param model_name
+//   The name given to the newly created instance of this model (if not empty).
+//   Otherwise, applies the protocol defined in the documentation for Parser.
+// @param parent_model_name
+//   Optional name of parent model. If set, the model name of the parsed model
+//   will be prefixed with the parent_model_name, using the scope delimiter
+//   "::". The body name does not get prefixed.
+// @param workspace
+//   The ParsingWorkspace.
+// @returns The model instance index for the newly added model; this might be
+//   null if there were parsing errors reported through the workspace.diagnostic
+//   policy.
+std::optional<ModelInstanceIndex> AddModelFromMesh(
+    const DataSource& data_source, const std::string& model_name,
+    const std::optional<std::string>& parent_model_name,
+    const ParsingWorkspace& workspace);
+
+class MeshParserWrapper final : public ParserInterface {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MeshParserWrapper)
+  MeshParserWrapper();
+  ~MeshParserWrapper() final;
+  std::optional<ModelInstanceIndex> AddModel(
+      const DataSource& data_source, const std::string& model_name,
+      const std::optional<std::string>& parent_model_name,
+      const ParsingWorkspace& workspace) final;
+
+  std::vector<ModelInstanceIndex> AddAllModels(
+      const DataSource& data_source,
+      const std::optional<std::string>& parent_model_name,
+      const ParsingWorkspace& workspace) final;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -28,6 +28,7 @@ class CompositeParse;
 /// SDFormat                 | ".sdf"
 /// MJCF (Mujoco XML)        | ".xml"
 /// Drake Model Directives   | ".dmd.yaml"
+/// Wavefront OBJ            | ".obj"
 ///
 /// The output of parsing is one or more model instances added to the
 /// MultibodyPlant provided to the parser at construction.
@@ -48,6 +49,30 @@ class CompositeParse;
 /// Drake Model Directives are only available via AddModels or
 /// AddModelsFromString. The single-model methods (AddModelFromFile,
 /// AddModelFromString) cannot load model directives.
+///
+/// OBJ files will infer a model with a single body from the geometry. The OBJ
+/// file must contain a _single_ object (in the OBJ-file sense). The body's mass
+/// properties are computed based on uniform distribution of material in the
+/// enclosed volume of the mesh (with the approximate density of water: 1000
+/// kg/m³). If the mesh is not a closed manifold, this can produce unexpected
+/// results. The spatial inertia of the body is measured at the body frame's
+/// origin. The body's frame is coincident and fixed with the frame the mesh's
+/// vertices are measured and expressed in. The mesh's vertices are assumed to
+/// be measured in units of _meters_.
+///
+/// The name of the model and body are determined according to the following
+/// prioritized protocol:
+///
+///   - The non-empty `model_name`, if given (e.g., in AddModelFromFile()).
+///   - If the object is named in the obj file, that object name is used.
+///   - Otherwise, the base name of the file name is used (i.e., the file name
+///     with the prefixed directory and extension removed).
+///
+/// If the underlying plant is registered with a SceneGraph instance, the mesh
+/// will also be used for all three roles: illustration, perception, and
+/// proximity.
+///
+/// @warning AddModelsFromString() cannot be passed OBJ file contents yet.
 ///
 /// For more documentation of Drake-specific treatment of these input formats,
 /// see @ref multibody_parsing.

--- a/multibody/parsing/test/detail_mesh_parser_test.cc
+++ b/multibody/parsing/test/detail_mesh_parser_test.cc
@@ -1,0 +1,284 @@
+#include "drake/multibody/parsing/detail_mesh_parser.h"
+
+#include <filesystem>
+#include <optional>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/temp_directory.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/parsing/test/diagnostic_policy_test_base.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace {
+
+using drake::internal::DiagnosticPolicy;
+using geometry::SceneGraph;
+
+class MeshParserTest : public test::DiagnosticPolicyTestBase {
+ public:
+  MeshParserTest() = default;
+
+  static ParserInterface& TestingSelect(const DiagnosticPolicy&,
+                                        const std::string&) {
+    static never_destroyed<MeshParserWrapper> mesh;
+    return mesh.access();
+  }
+
+  ModelInstanceIndex AddModelFromMeshFile(
+      const std::string& file_name, const std::string& model_name,
+      const std::optional<std::string>& parent_model_name = {}) {
+    const DataSource data_source{DataSource::kFilename, &file_name};
+    internal::CollisionFilterGroupResolver resolver{&plant_};
+    ParsingWorkspace w{package_map_, diagnostic_policy_, &plant_, &resolver,
+                       TestingSelect};
+    // The wrapper simply delegates to AddModelFromMesh(), so we're testing
+    // the underlying implementation *and* confirming that the wrapper delegates
+    // appropriately.
+    MeshParserWrapper wrapper;
+    std::optional<ModelInstanceIndex> result =
+        wrapper.AddModel(data_source, model_name, parent_model_name, w);
+    return result.value_or(ModelInstanceIndex{});
+  }
+
+  ModelInstanceIndex AddModelsFromMeshFile(
+      const std::string& file_name,
+      const std::optional<std::string>& parent_model_name = {}) {
+    const DataSource data_source{DataSource::kFilename, &file_name};
+    internal::CollisionFilterGroupResolver resolver{&plant_};
+    ParsingWorkspace w{package_map_, diagnostic_policy_, &plant_, &resolver,
+                       TestingSelect};
+    // The wrapper is responsible for building the vector from whatever a call
+    // to AddModelFromMesh() does; this confirms invocation and successful
+    // transformation of return type.
+    MeshParserWrapper wrapper;
+    std::vector<ModelInstanceIndex> results =
+        wrapper.AddAllModels(data_source, parent_model_name, w);
+    // We should either throw or return a model instance index.
+    DRAKE_DEMAND(results.size() == 1);
+    return results[0];
+  }
+
+ protected:
+  PackageMap package_map_;
+  MultibodyPlant<double> plant_{0.0};
+  SceneGraph<double> scene_graph_;
+};
+
+// Tests the name generation logic for model instances and bodies. This
+// includes:
+//
+//  - Naming protocol: 1) user given name, 2) OBJ data name, 3) file name.
+//  - Combination with "parent_model_name" prefix.
+//  - Prefix only applies to model name and not body name.
+//  - A token call to AddModelsFromMesh (plural); we know it simply delegates
+//    to AddModelFromMesh.
+TEST_F(MeshParserTest, ModelInstanceNameTest) {
+  // Initial plant has two model instances (model_instance.h explains why).
+  ASSERT_EQ(plant_.num_model_instances(), 2);
+
+  // These two files both define a 2x2x2 (meter) box. The former has only the
+  // geometry (no object name). The latter has object name *and* material
+  // library.
+  const std::string obj_path = FindResourceOrThrow(
+      "drake/multibody/parsing/test/box_package/meshes/box.obj");
+  const std::string obj_with_object_path =
+      FindResourceOrThrow("drake/geometry/render/test/meshes/box.obj");
+
+  // We'll add boxes with a various combination of permutations.
+  const ModelInstanceIndex filename_model_instance =
+      AddModelFromMeshFile(obj_path, "");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      AddModelFromMeshFile(obj_path, ""),
+      ".+already contains a model instance named 'box'.+");
+
+  const ModelInstanceIndex user_named_model_instance =
+      AddModelFromMeshFile(obj_path, "box1");
+
+  const ModelInstanceIndex prefix_user_model_instance =
+      AddModelFromMeshFile(obj_path, "box2", "prefix");
+
+  const ModelInstanceIndex prefix_file_model_instance =
+      AddModelFromMeshFile(obj_path, "", "prefix");
+
+  const ModelInstanceIndex geom_box_model_instance =
+      AddModelFromMeshFile(obj_with_object_path, "");
+
+  const ModelInstanceIndex user_geom_box_model_instance =
+      AddModelFromMeshFile(obj_with_object_path, "geom_box");
+
+  // This is the token call to the plural form: AddModelsFromMesh.
+  const ModelInstanceIndex prefix_geom_box_model_instance =
+      AddModelsFromMeshFile(obj_with_object_path, "prefix");
+
+  // Proof that we didn't need a SceneGraph to happily add bodies.
+  ASSERT_FALSE(plant_.geometry_source_is_registered());
+
+  // We are done adding models.
+  plant_.Finalize();
+
+  ASSERT_EQ(plant_.num_model_instances(), 9);
+
+  // All instances names are as expected.
+  EXPECT_EQ(plant_.GetModelInstanceByName("box"), filename_model_instance);
+  EXPECT_EQ(plant_.GetModelInstanceByName("box1"), user_named_model_instance);
+  EXPECT_EQ(plant_.GetModelInstanceByName("prefix::box2"),
+            prefix_user_model_instance);
+  EXPECT_EQ(plant_.GetModelInstanceByName("prefix::box"),
+            prefix_file_model_instance);
+  EXPECT_EQ(plant_.GetModelInstanceByName("test_box"), geom_box_model_instance);
+  EXPECT_EQ(plant_.GetModelInstanceByName("geom_box"),
+            user_geom_box_model_instance);
+  EXPECT_EQ(plant_.GetModelInstanceByName("prefix::test_box"),
+            prefix_geom_box_model_instance);
+
+  // All body names are as expected.
+  EXPECT_TRUE(plant_.HasBodyNamed("box", filename_model_instance));
+  EXPECT_TRUE(plant_.HasBodyNamed("box1", user_named_model_instance));
+  EXPECT_TRUE(plant_.HasBodyNamed("box2", prefix_user_model_instance));
+  EXPECT_TRUE(plant_.HasBodyNamed("box", prefix_file_model_instance));
+  EXPECT_TRUE(plant_.HasBodyNamed("test_box", geom_box_model_instance));
+  EXPECT_TRUE(plant_.HasBodyNamed("geom_box", user_geom_box_model_instance));
+  EXPECT_TRUE(plant_.HasBodyNamed("test_box", prefix_geom_box_model_instance));
+}
+
+// Various means by which we end up getting an exception.
+TEST_F(MeshParserTest, ErrorModes) {
+  // Reset the diagnostic policy to actually throw on errors.
+  diagnostic_policy_ = DiagnosticPolicy();
+
+  const std::filesystem::path temp_dir = temp_directory();
+
+  // 1. No geometry.
+  {
+    const std::filesystem::path file = temp_dir / "empty.obj";
+    {
+      std::ofstream f(file.string());
+      ASSERT_TRUE(f);
+      f << "v 0 0 0\n";  // A single vertex with no faces.
+    }
+
+    DRAKE_EXPECT_THROWS_MESSAGE(AddModelFromMeshFile(file.string(), ""),
+                                ".* has no faces.*");
+  }
+  // 2. Two objects.
+  {
+    const std::filesystem::path file = temp_dir / "two_objects.obj";
+    {
+      std::ofstream f(file.string());
+      ASSERT_TRUE(f);
+      f << "v 0 0 0\n"
+        << "o one\n"   // Create first object.
+        << "f 1 1 1\n"
+        << "o two\n"    // Create a second object.
+        << "f 1 1 1\n";
+    }
+    DRAKE_EXPECT_THROWS_MESSAGE(AddModelFromMeshFile(file.string(), ""),
+                                ".* 2 unique shapes; only 1 allowed.*");
+  }
+  // 3. Not an OBJ.
+  {
+    const std::filesystem::path file = temp_dir / "empty.obj";
+    {
+      std::ofstream f(file.string());
+      ASSERT_TRUE(f);
+      f << "Non-OBJ gibberish";
+    }
+    DRAKE_EXPECT_THROWS_MESSAGE(AddModelFromMeshFile(file.string(), ""),
+                                ".* has no faces.*");
+  }
+  // 4. Called with obj data in a string.
+  {
+    const std::string data("Just some text");
+    const DataSource data_source{DataSource::kContents, &data};
+    internal::CollisionFilterGroupResolver resolver{&plant_};
+    ParsingWorkspace w{package_map_, diagnostic_policy_, &plant_, &resolver,
+                       TestingSelect};
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        AddModelFromMesh(data_source, "", std::nullopt, w),
+        ".*must be .+ file.*");
+  }
+  // 5. Plant has been finalized.
+  {
+    plant_.Finalize();
+    const std::string obj_path = FindResourceOrThrow(
+        "drake/multibody/parsing/test/box_package/meshes/box.obj");
+    EXPECT_THROW(AddModelFromMeshFile(obj_path, ""), std::exception);
+  }
+}
+
+// Confirm that the obj added has computed the correct mass. As these
+// calculations delegate to other tested APIs, we'll simply look for evidence
+// that they were correctly invoked and the results registered properly.
+TEST_F(MeshParserTest, CorrectMass) {
+  // A 2x2x2 (meter) box centered on its canonical frame.
+  const std::string obj_path = FindResourceOrThrow(
+      "drake/multibody/parsing/test/box_package/meshes/box.obj");
+  const ModelInstanceIndex model_instance =
+      AddModelFromMeshFile(obj_path, "body");
+
+  // We are done adding models.
+  plant_.Finalize();
+  auto context = plant_.CreateDefaultContext();
+
+  const Body<double>& body = plant_.GetBodyByName("body", model_instance);
+  const double mass = body.get_mass(*context);
+  const double density = 1000;  // kg/m³
+  // 2x2x2 box with proscribed density.
+  EXPECT_DOUBLE_EQ(mass, 2 * 2 * 2 * density);
+
+  const auto I_BBo_B_expected =
+      SpatialInertia<double>::SolidBoxWithDensity(density, 2, 2, 2);
+  const SpatialInertia<double> I_BBo_B =
+      body.CalcSpatialInertiaInBodyFrame(*context);
+  // For unit scale, we'd expect tolerance to be satisifed around 1e-15; with
+  // a mass of 1e3 kg/m³, we have to scale the tolerance accordingly.
+  EXPECT_TRUE(CompareMatrices(I_BBo_B.CopyToFullMatrix6(),
+                              I_BBo_B_expected.CopyToFullMatrix6(), 1e-12));
+}
+
+// When the plant has been registered as a SceneGraph geometry source, we should
+// get illustration, perception, and proximity roles associated with the body.
+TEST_F(MeshParserTest, RegisteredGeometry) {
+  plant_.RegisterAsSourceForSceneGraph(&scene_graph_);
+
+  // A 2x2x2 (meter) box centered on its canonical frame.
+  const std::string obj_path = FindResourceOrThrow(
+      "drake/multibody/parsing/test/box_package/meshes/box.obj");
+
+  // We'll add boxes with a various combination of permutations.
+  const ModelInstanceIndex model_instance =
+      AddModelFromMeshFile(obj_path, "body");
+
+  // We are done adding models.
+  plant_.Finalize();
+  auto context = plant_.CreateDefaultContext();
+
+  const Body<double>& body = plant_.GetBodyByName("body", model_instance);
+  std::optional<geometry::FrameId> frame_id =
+      plant_.GetBodyFrameIdIfExists(body.index());
+  ASSERT_TRUE(frame_id.has_value());
+
+  const geometry::SceneGraphInspector<double>& inspector =
+      scene_graph_.model_inspector();
+
+  EXPECT_EQ(inspector.NumGeometriesForFrameWithRole(
+                *frame_id, geometry::Role::kIllustration),
+            1);
+  EXPECT_EQ(inspector.NumGeometriesForFrameWithRole(
+                *frame_id, geometry::Role::kPerception),
+            1);
+  EXPECT_EQ(inspector.NumGeometriesForFrameWithRole(*frame_id,
+                                                    geometry::Role::kProximity),
+            1);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/test/parser_test.cc
+++ b/multibody/parsing/test/parser_test.cc
@@ -33,6 +33,8 @@ GTEST_TEST(FileParserTest, BasicTest) {
   const std::string dmd_name = FindResourceOrThrow(
       "drake/multibody/parsing/test/process_model_directives_test/"
       "acrobot.dmd.yaml");
+  const std::string obj_name = FindResourceOrThrow(
+      "drake/multibody/parsing/test/box_package/meshes/box.obj");
 
   // Load from SDF using plural method.
   // Add a second one with an overridden model_name.
@@ -107,6 +109,26 @@ GTEST_TEST(FileParserTest, BasicTest) {
     const auto prefix_ids = Parser(&plant, "prefix").AddModels(dmd_name);
     EXPECT_EQ(prefix_ids.size(), 1);
     EXPECT_EQ(plant.GetModelInstanceName(prefix_ids[0]), "prefix::acrobot");
+  }
+
+  // Load from OBJ using plural method.
+  // Add a second one with an overridden model_name.
+  // Add one with a name prefix.
+  {
+    // TODO(SeanCurtis-TRI): Break this "basic test" up into each extension
+    // type. The shared infrastructure is negligible, but the cost of adding
+    // a new extension is reduced by having each extension isolated in its own
+    // test.
+    MultibodyPlant<double> plant(0.0);
+    Parser dut(&plant);
+    const std::vector<ModelInstanceIndex> ids = dut.AddModels(obj_name);
+    EXPECT_EQ(ids.size(), 1);
+    EXPECT_EQ(plant.GetModelInstanceName(ids[0]), "box");
+    const ModelInstanceIndex id = dut.AddModelFromFile(obj_name, "foo");
+    EXPECT_EQ(plant.GetModelInstanceName(id), "foo");
+    const auto prefix_ids = Parser(&plant, "prefix").AddModels(obj_name);
+    EXPECT_EQ(prefix_ids.size(), 1);
+    EXPECT_EQ(plant.GetModelInstanceName(prefix_ids[0]), "prefix::box");
   }
 }
 


### PR DESCRIPTION
The parser now accepts files with the .obj extension. The result of parsing is a new model instance with a single body whose mass properties are derived from the mesh.

To support this, it required some infrastructure support:

  - geometry parsing of OBJ --> `TriangleSurfaceMesh` exposed for the parser to use.
      - Tweak the error messages to allude to *data* instead of file as it allows for parsing from in-memory OBJ data.
  - Update box.obj to include an object name.
  - New patch to address defect in tiny obj loader.

Resolves #17267

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18776)
<!-- Reviewable:end -->
