### PR TITLE
Revert "[multibody] Adding time-varying constraints to two Toppra APIs"

### DIFF
--- a/bindings/pydrake/multibody/optimization_py.cc
+++ b/bindings/pydrake/multibody/optimization_py.cc
@@ -200,32 +200,14 @@ PYBIND11_MODULE(optimization, m) {
             py::arg("constraint_frame"), py::arg("lower_limit"),
             py::arg("upper_limit"), cls_doc.AddFrameVelocityLimit.doc)
         .def("AddFrameTranslationalSpeedLimit",
-            py::overload_cast<const Frame<double>&, const double&>(
-                &Class::AddFrameTranslationalSpeedLimit),
+            &Class::AddFrameTranslationalSpeedLimit,
             py::arg("constraint_frame"), py::arg("upper_limit"),
-            cls_doc.AddFrameTranslationalSpeedLimit.doc_const)
-        .def("AddFrameTranslationalSpeedLimit",
-            py::overload_cast<const Frame<double>&, const Trajectory<double>&>(
-                &Class::AddFrameTranslationalSpeedLimit),
-            py::arg("constraint_frame"), py::arg("upper_limit"),
-            cls_doc.AddFrameTranslationalSpeedLimit.doc_trajectory)
-        .def("AddFrameAccelerationLimit",
-            py::overload_cast<const Frame<double>&,
-                const Eigen::Ref<const Vector6d>&,
-                const Eigen::Ref<const Vector6d>&, ToppraDiscretization>(
-                &Class::AddFrameAccelerationLimit),
+            cls_doc.AddFrameTranslationalSpeedLimit.doc)
+        .def("AddFrameAccelerationLimit", &Class::AddFrameAccelerationLimit,
             py::arg("constraint_frame"), py::arg("lower_limit"),
             py::arg("upper_limit"),
             py::arg("discretization") = ToppraDiscretization::kInterpolation,
-            cls_doc.AddFrameAccelerationLimit.doc_const)
-        .def("AddFrameAccelerationLimit",
-            py::overload_cast<const Frame<double>&, const Trajectory<double>&,
-                const Trajectory<double>&, ToppraDiscretization>(
-                &Class::AddFrameAccelerationLimit),
-            py::arg("constraint_frame"), py::arg("lower_limit"),
-            py::arg("upper_limit"),
-            py::arg("discretization") = ToppraDiscretization::kInterpolation,
-            cls_doc.AddFrameAccelerationLimit.doc_trajectory);
+            cls_doc.AddFrameAccelerationLimit.doc);
   }
 }
 }  // namespace

--- a/bindings/pydrake/multibody/test/optimization_test.py
+++ b/bindings/pydrake/multibody/test/optimization_test.py
@@ -329,35 +329,15 @@ class TestToppra(unittest.TestCase):
         constraint = toppra.AddFrameTranslationalSpeedLimit(
             constraint_frame=frame, upper_limit=1.)
         self.assertIsInstance(constraint, mp.Binding[mp.BoundingBoxConstraint])
-
-        breaks = [path.start_time(), path.end_time()]
-
-        speed_limit_traj = PiecewisePolynomial.FirstOrderHold(
-            breaks, np.array(([[1, 1]])))
-        constraint = toppra.AddFrameTranslationalSpeedLimit(
-            constraint_frame=frame, upper_limit=speed_limit_traj)
-        self.assertIsInstance(constraint, mp.Binding[mp.BoundingBoxConstraint])
-
-        backward_con, forward_con = toppra.AddFrameAccelerationLimit(
+        constraint = toppra.AddFrameAccelerationLimit(
             constraint_frame=frame, lower_limit=lower_limit,
             upper_limit=upper_limit,
             discretization=ToppraDiscretization.kCollocation)
         self.assertIsInstance(backward_con, mp.Binding[mp.LinearConstraint])
         self.assertIsInstance(forward_con, mp.Binding[mp.LinearConstraint])
-        backward_con, forward_con = toppra.AddFrameAccelerationLimit(
+        constraint = toppra.AddFrameAccelerationLimit(
             constraint_frame=frame, lower_limit=lower_limit,
             upper_limit=upper_limit,
-            discretization=ToppraDiscretization.kInterpolation)
-        self.assertIsInstance(backward_con, mp.Binding[mp.LinearConstraint])
-        self.assertIsInstance(forward_con, mp.Binding[mp.LinearConstraint])
-
-        upper_traj = PiecewisePolynomial.FirstOrderHold(breaks,
-                                                        np.ones((6, 2)))
-        lower_traj = PiecewisePolynomial.FirstOrderHold(breaks,
-                                                        -np.ones((6, 2)))
-        backward_con, forward_con = toppra.AddFrameAccelerationLimit(
-            constraint_frame=frame, lower_limit=lower_traj,
-            upper_limit=upper_traj,
             discretization=ToppraDiscretization.kInterpolation)
         self.assertIsInstance(backward_con, mp.Binding[mp.LinearConstraint])
         self.assertIsInstance(forward_con, mp.Binding[mp.LinearConstraint])

--- a/multibody/optimization/BUILD.bazel
+++ b/multibody/optimization/BUILD.bazel
@@ -308,7 +308,6 @@ drake_cc_googletest(
     deps = [
         ":toppra",
         "//common/test_utilities:eigen_matrix_compare",
-        "//common/test_utilities:expect_throws_message",
         "//multibody/parsing",
         "//multibody/tree",
         "//solvers:gurobi_solver",

--- a/multibody/optimization/test/toppra_test.cc
+++ b/multibody/optimization/test/toppra_test.cc
@@ -1,11 +1,9 @@
 #include "drake/multibody/optimization/toppra.h"
 
-#include <utility>
-
 #include <gtest/gtest.h>
 
+#include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
-#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/solvers/gurobi_solver.h"
@@ -20,10 +18,10 @@ class IiwaToppraTest : public ::testing::Test {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(IiwaToppraTest)
 
   IiwaToppraTest() : iiwa_plant_(std::make_unique<MultibodyPlant<double>>(0)) {
-    multibody::Parser(iiwa_plant_.get())
-        .AddModelsFromUrl(
-            "package://drake/manipulation/models/iiwa_description/iiwa7/"
-            "iiwa7_no_collision.sdf");
+    std::string file_path = FindResourceOrThrow(
+        "drake/manipulation/models/iiwa_description/iiwa7/"
+        "iiwa7_no_collision.sdf");
+    multibody::Parser(iiwa_plant_.get()).AddModels(file_path);
     iiwa_plant_->WeldFrames(
         iiwa_plant_->world_frame(), iiwa_plant_->GetFrameByName("iiwa_link_0"));
     iiwa_plant_->Finalize();
@@ -43,61 +41,6 @@ class IiwaToppraTest : public ::testing::Test {
   }
 
   ~IiwaToppraTest() override {}
-
-  // TODO(hongkai-dai): Consider hoisting this function into the toppra API.
-  // Perhaps with the sugar where s_path has the default implementation of being
-  // s_path(t) = s.
-
-  // Computes the spatial velocity of a given `frame`. The state of the iiwa
-  // plant is defined by the underlying geometric path_ and the re-parameterized
-  // trajectory as defined by s_path (mapping time t to path parameter s). This
-  // writes to the test's allocated MbP Context.
-  SpatialVelocity<double> CalcSpatialVelocity(
-      double t, const PiecewisePolynomial<double>& s_path,
-      const Frame<double>& frame) {
-    const double s = s_path.scalarValue(t);
-    const auto s_dot = s_path.EvalDerivative(t, 1);
-    const auto dq_ds = path_.EvalDerivative(s, 1);
-    const auto position = path_.value(s);
-    const auto velocity = dq_ds * s_dot;
-
-    iiwa_plant_->SetPositions(plant_context_.get(), position);
-    iiwa_plant_->SetVelocities(plant_context_.get(), velocity);
-    return frame.CalcSpatialVelocityInWorld(*plant_context_);
-  }
-
-  // Computes the spatial acceleration of a given `frame`.  The state of the
-  // iiwa plant is defined by the underlying geometric path_ and the
-  // re-parameterized trajectory as defined by s_path (mapping time t to path
-  // parameter s). This writes to the test's allocated MbP Context.
-  Vector6d CalcSpatialAcceleration(double t,
-                                   const PiecewisePolynomial<double>& s_path,
-                                   const Frame<double>& frame) {
-    const auto s_dot = s_path.EvalDerivative(t, 1);
-    const auto s_ddot = s_path.EvalDerivative(t, 2);
-    const double s = s_path.scalarValue(t);
-    const auto dq_ds = path_.EvalDerivative(s, 1);
-    const auto ddq_dds = path_.EvalDerivative(s, 2);
-    const auto position = path_.value(s);
-    const auto velocity = dq_ds * s_dot;
-    const auto acceleration = dq_ds * s_ddot + ddq_dds * s_dot * s_dot;
-
-    iiwa_plant_->SetPositions(plant_context_.get(), position);
-    iiwa_plant_->SetVelocities(plant_context_.get(), velocity);
-    Eigen::MatrixXd J(6, 7);
-    iiwa_plant_->CalcJacobianSpatialVelocity(
-        *plant_context_, JacobianWrtVariable::kQDot, frame,
-        Eigen::Vector3d::Zero(), iiwa_plant_->world_frame(),
-        iiwa_plant_->world_frame(), &J);
-    Eigen::VectorXd J_dot_v(6);
-    J_dot_v = iiwa_plant_
-                  ->CalcBiasSpatialAcceleration(
-                      *plant_context_, JacobianWrtVariable::kV, frame,
-                      Eigen::Vector3d::Zero(), iiwa_plant_->world_frame(),
-                      iiwa_plant_->world_frame())
-                  .get_coeffs();
-    return J * acceleration + J_dot_v;
-  }
 
  protected:
   std::unique_ptr<MultibodyPlant<double>> iiwa_plant_;
@@ -291,121 +234,7 @@ TEST_F(IiwaToppraTest, FrameTranslationalSpeedLimit) {
   const double upper_bound = 1.1;
   const auto& frame = iiwa_plant_->GetFrameByName("iiwa_link_7");
 
-  for (bool use_trajectory : {true, false}) {
-    SCOPED_TRACE(
-        fmt::format("Speed limit with trajectory: {}", use_trajectory));
-    if (use_trajectory) {
-      // A trajectory limit with a const image (defined over the domain of the
-      // path) should be identical to the single, constant limit.
-      const std::vector<double> breaks{path_.start_time(), path_.end_time()};
-      const Eigen::MatrixXd upper_bound_mat =
-          Vector1<double>::Constant(upper_bound);
-      const std::vector samples{upper_bound_mat, upper_bound_mat};
-      const auto upper_bound_traj =
-          PiecewisePolynomial<double>::ZeroOrderHold(breaks, samples);
-
-      toppra_->AddFrameTranslationalSpeedLimit(frame, upper_bound_traj);
-    } else {
-      toppra_->AddFrameTranslationalSpeedLimit(frame, upper_bound);
-    }
-    toppra_->AddJointAccelerationLimit(Eigen::VectorXd::Constant(7, -10),
-                                       Eigen::VectorXd::Constant(7, 10));
-
-    auto result = toppra_->SolvePathParameterization();
-    ASSERT_TRUE(result);
-    auto s_path = result.value();
-
-    // This tolerance was tuned to work with the given gridpoints.
-    const double tol = 1e-14;
-    for (int ii = 0; ii < s_path.get_number_of_segments(); ii++) {
-      const auto frame_velocity =
-          CalcSpatialVelocity(s_path.start_time(ii), s_path, frame);
-      const double speed = frame_velocity.translational().norm();
-
-      EXPECT_LT(speed, upper_bound + tol);
-    }
-
-    const auto frame_velocity =
-        CalcSpatialVelocity(s_path.end_time(), s_path, frame);
-    const double speed = frame_velocity.translational().norm();
-
-    EXPECT_LT(speed, upper_bound + tol);
-  }
-}
-
-// Tests (non-)error responses based on the (non-)overlapping of limit and
-// path domains.
-TEST_F(IiwaToppraTest, FrameTranslationalSpeedLimitTrajectoryOverlap) {
-  const double upper_bound = 1.1;
-  const Eigen::MatrixXd upper_bound_mat =
-      Vector1<double>::Constant(upper_bound);
-  const std::vector samples{upper_bound_mat, upper_bound_mat};
-  const auto& frame = iiwa_plant_->GetFrameByName("iiwa_link_7");
-
-  const double path_start = path_.start_time();
-  const double path_end = path_.end_time();
-
-  // Limit domain lies "above" path domain.
-  {
-    const std::vector<double> breaks{path_end + 0.1, path_end + 1.1};
-    const auto upper_bound_traj =
-        PiecewisePolynomial<double>::ZeroOrderHold(breaks, samples);
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        toppra_->AddFrameTranslationalSpeedLimit(frame, upper_bound_traj),
-        fmt::format(".* can't add a trajectory translational speed .* limit "
-                    "domain \\[{}, {}\\].* path domain \\[{}, {}\\].",
-                    breaks[0], breaks[1], path_start, path_end));
-  }
-
-  // Limit domain lies "below" path domain.
-  {
-    const std::vector<double> breaks{path_start - 1.1, path_start - 0.1};
-    const auto upper_bound_traj =
-        PiecewisePolynomial<double>::ZeroOrderHold(breaks, samples);
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        toppra_->AddFrameTranslationalSpeedLimit(frame, upper_bound_traj),
-        ".* can't add a trajectory translational speed .* limit .*");
-  }
-
-  // Overlap at the lower range of the path domain is valid.
-  {
-    const std::vector<double> breaks{path_start - 1.1,
-                                     (path_start + path_end) / 2};
-    const auto upper_bound_traj =
-        PiecewisePolynomial<double>::ZeroOrderHold(breaks, samples);
-    EXPECT_NO_THROW(
-        toppra_->AddFrameTranslationalSpeedLimit(frame, upper_bound_traj));
-  }
-
-  // Overlap at the upper range of the path domain is valid.
-  {
-    const std::vector<double> breaks{(path_start + path_end) / 2,
-                                     path_end + 1.1};
-    const auto upper_bound_traj =
-        PiecewisePolynomial<double>::ZeroOrderHold(breaks, samples);
-    EXPECT_NO_THROW(
-        toppra_->AddFrameTranslationalSpeedLimit(frame, upper_bound_traj));
-  }
-}
-
-// Confirms that if the limit varies over the path, the observed speed respects
-// it.
-TEST_F(IiwaToppraTest, FrameTranslationalSpeedLimitVarying) {
-  const auto& frame = iiwa_plant_->GetFrameByName("iiwa_link_7");
-
-  // Create a trajectory with a lower speed for the first half and a higher
-  // speed for the second half.
-  const double s0 = path_.start_time();
-  const double s2 = path_.end_time();
-  const double s1 = (s0 + s2) / 2;
-  const double limit0 = 1.1;  // bound for the interval [s0, s1).
-  const double limit1 = 2.2;  // bound for the interval [s1, s2).
-  Eigen::MatrixXd samples(1, 3);
-  samples.row(0) << limit0, limit1, limit1;
-  const auto bound_traj = PiecewisePolynomial<double>::ZeroOrderHold(
-      Eigen::VectorXd::LinSpaced(3, s0, s2), samples);
-
-  toppra_->AddFrameTranslationalSpeedLimit(frame, bound_traj);
+  toppra_->AddFrameTranslationalSpeedLimit(frame, upper_bound);
   toppra_->AddJointAccelerationLimit(Eigen::VectorXd::Constant(7, -10),
                                      Eigen::VectorXd::Constant(7, 10));
 
@@ -413,40 +242,36 @@ TEST_F(IiwaToppraTest, FrameTranslationalSpeedLimitVarying) {
   ASSERT_TRUE(result);
   auto s_path = result.value();
 
-  auto calc_speed_and_limit = [&s_path, &frame, &bound_traj,
-                               this](double t) -> std::pair<double, double> {
-    const double s = s_path.scalarValue(t);
-    const SpatialVelocity<double> frame_velocity =
-        CalcSpatialVelocity(t, s_path, frame);
-    const double speed = frame_velocity.translational().norm();
-    const double speed_limit = bound_traj.scalarValue(s);
-    return {speed, speed_limit};
-  };
-
   // This tolerance was tuned to work with the given gridpoints.
-  bool second_half_sped_up = false;
   const double tol = 1e-14;
   for (int ii = 0; ii < s_path.get_number_of_segments(); ii++) {
-    const double t = s_path.start_time(ii);
-    const auto [speed, speed_limit] = calc_speed_and_limit(t);
+    const auto s = s_path.scalarValue(s_path.start_time(ii));
+    const auto s_dot = s_path.EvalDerivative(s_path.start_time(ii), 1);
+    const auto dq_ds = path_.EvalDerivative(s, 1);
+    const auto position = path_.value(s);
+    const auto velocity = dq_ds * s_dot;
 
-    // We should always respect the instantaneous speed limit.
-    EXPECT_LT(speed, speed_limit + tol);
+    iiwa_plant_->SetPositions(plant_context_.get(), position);
+    iiwa_plant_->SetVelocities(plant_context_.get(), velocity);
+    const auto frame_velocity =
+        frame.CalcSpatialVelocityInWorld(*plant_context_);
+    const double speed = frame_velocity.translational().norm();
 
-    // In the first half, we should remain below limit0. In the second half we
-    // should rise above limit0. Because the trajectory is hard-coded to
-    // terminate with zero velocity, we will simply detect that the speed
-    // rises above the lower limit *after* the change and before the end.
-    if (s_path.scalarValue(t) >= s1) {
-      second_half_sped_up = second_half_sped_up || speed > limit0;
-    }
+    EXPECT_LT(speed, upper_bound + tol);
   }
 
-  const double t = s_path.end_time();
-  const auto [speed, speed_limit] = calc_speed_and_limit(t);
+  const auto s = s_path.scalarValue(s_path.end_time());
+  const auto s_dot = s_path.EvalDerivative(s_path.end_time(), 1);
+  const auto dq_ds = path_.EvalDerivative(s, 1);
+  const auto position = path_.value(s);
+  const auto velocity = dq_ds * s_dot;
 
-  EXPECT_LT(speed, speed_limit + tol);
-  EXPECT_TRUE(second_half_sped_up);
+  iiwa_plant_->SetPositions(plant_context_.get(), position);
+  iiwa_plant_->SetVelocities(plant_context_.get(), velocity);
+  const auto frame_velocity = frame.CalcSpatialVelocityInWorld(*plant_context_);
+  const double speed = frame_velocity.translational().norm();
+
+  EXPECT_LT(speed, upper_bound + tol);
 }
 
 TEST_F(IiwaToppraTest, FrameAccelerationLimit) {
@@ -456,213 +281,72 @@ TEST_F(IiwaToppraTest, FrameAccelerationLimit) {
   upper_bound << 2.1, 2.2, 2.3, 2.4, 2.5, 2.6;
   const auto& frame = iiwa_plant_->GetFrameByName("iiwa_link_7");
 
-  for (bool use_trajectory : {true, false}) {
-    SCOPED_TRACE(fmt::format("Frame acceleration limit with trajectory: {}",
-                             use_trajectory));
-    if (use_trajectory) {
-      const std::vector<double> breaks{path_.start_time(), path_.end_time()};
-      const std::vector<MatrixX<double>> lower_samples{lower_bound,
-                                                       lower_bound};
-      const auto lower_bound_traj =
-          PiecewisePolynomial<double>::ZeroOrderHold(breaks, lower_samples);
+  toppra_->AddFrameAccelerationLimit(frame, lower_bound, upper_bound);
 
-      const std::vector<MatrixX<double>> upper_samples{upper_bound,
-                                                       upper_bound};
-      const auto upper_bound_traj =
-          PiecewisePolynomial<double>::ZeroOrderHold(breaks, upper_samples);
+  auto result = toppra_->SolvePathParameterization();
+  ASSERT_TRUE(result);
+  auto s_path = result.value();
 
-      toppra_->AddFrameAccelerationLimit(frame, lower_bound_traj,
-                                         upper_bound_traj);
-    } else {
-      toppra_->AddFrameAccelerationLimit(frame, lower_bound, upper_bound);
-    }
+  // This tolerance was tuned to work with the given gridpoints.
+  const double tol = 1e-14;
+  Eigen::MatrixXd J(6, 7);
+  Eigen::VectorXd J_dot_v(6);
+  Eigen::VectorXd frame_acceleration(6);
+  for (int ii = 0; ii < s_path.get_number_of_segments(); ii++) {
+    const auto s = s_path.scalarValue(s_path.start_time(ii));
+    const auto s_dot = s_path.EvalDerivative(s_path.start_time(ii), 1);
+    const auto s_ddot = s_path.EvalDerivative(s_path.start_time(ii), 2);
+    const auto dq_ds = path_.EvalDerivative(s, 1);
+    const auto ddq_dds = path_.EvalDerivative(s, 2);
+    const auto position = path_.value(s);
+    const auto velocity = dq_ds * s_dot;
+    const auto acceleration = dq_ds * s_ddot + ddq_dds * s_dot * s_dot;
 
-    auto result = toppra_->SolvePathParameterization();
-    ASSERT_TRUE(result);
-    auto s_path = result.value();
-
-    // This tolerance was tuned to work with the given gridpoints.
-    const double tol = 1e-14;
-    for (int ii = 0; ii < s_path.get_number_of_segments(); ii++) {
-      Vector6d frame_acceleration =
-          CalcSpatialAcceleration(s_path.start_time(ii), s_path, frame);
-
-      EXPECT_TRUE(
-          (frame_acceleration.array() >= lower_bound.array() - tol).all());
-      EXPECT_TRUE(
-          (frame_acceleration.array() <= upper_bound.array() + tol).all());
-    }
-
-    Vector6d frame_acceleration =
-        CalcSpatialAcceleration(s_path.end_time(), s_path, frame);
+    iiwa_plant_->SetPositions(plant_context_.get(), position);
+    iiwa_plant_->SetVelocities(plant_context_.get(), velocity);
+    iiwa_plant_->CalcJacobianSpatialVelocity(
+        *plant_context_, JacobianWrtVariable::kQDot, frame,
+        Eigen::Vector3d::Zero(), iiwa_plant_->world_frame(),
+        iiwa_plant_->world_frame(), &J);
+    J_dot_v = iiwa_plant_
+                  ->CalcBiasSpatialAcceleration(
+                      *plant_context_, JacobianWrtVariable::kV, frame,
+                      Eigen::Vector3d::Zero(), iiwa_plant_->world_frame(),
+                      iiwa_plant_->world_frame())
+                  .get_coeffs();
+    frame_acceleration = J * acceleration + J_dot_v;
 
     EXPECT_TRUE(
         (frame_acceleration.array() >= lower_bound.array() - tol).all());
     EXPECT_TRUE(
         (frame_acceleration.array() <= upper_bound.array() + tol).all());
   }
-}
 
-// Tests (non-)error responses based on the (non-)overlapping of limit and
-// path domains.
-TEST_F(IiwaToppraTest, FrameAccelerationLimitTrajectoryOverlap) {
-  Eigen::VectorXd lower_bound(6);
-  lower_bound << -1.1, -1.2, -1.3, -1.4, -1.5, -1.6;
-  const std::vector<MatrixX<double>> lower_samples{lower_bound, lower_bound};
+  const auto s = s_path.scalarValue(s_path.end_time());
+  const auto s_dot = s_path.EvalDerivative(s_path.end_time(), 1);
+  const auto s_ddot = s_path.EvalDerivative(s_path.end_time(), 2);
+  const auto dq_ds = path_.EvalDerivative(s, 1);
+  const auto ddq_dds = path_.EvalDerivative(s, 2);
+  const auto position = path_.value(s);
+  const auto velocity = dq_ds * s_dot;
+  const auto acceleration = dq_ds * s_ddot + ddq_dds * s_dot * s_dot;
 
-  Eigen::VectorXd upper_bound(6);
-  upper_bound << 2.1, 2.2, 2.3, 2.4, 2.5, 2.6;
-  const std::vector<MatrixX<double>> upper_samples{upper_bound, upper_bound};
+  iiwa_plant_->SetPositions(plant_context_.get(), position);
+  iiwa_plant_->SetVelocities(plant_context_.get(), velocity);
+  iiwa_plant_->CalcJacobianSpatialVelocity(
+      *plant_context_, JacobianWrtVariable::kQDot, frame,
+      Eigen::Vector3d::Zero(), iiwa_plant_->world_frame(),
+      iiwa_plant_->world_frame(), &J);
+  J_dot_v = iiwa_plant_
+                ->CalcBiasSpatialAcceleration(
+                    *plant_context_, JacobianWrtVariable::kV, frame,
+                    Eigen::Vector3d::Zero(), iiwa_plant_->world_frame(),
+                    iiwa_plant_->world_frame())
+                .get_coeffs();
+  frame_acceleration = J * acceleration + J_dot_v;
 
-  const auto& frame = iiwa_plant_->GetFrameByName("iiwa_link_7");
-
-  const double path_start = path_.start_time();
-  const double path_end = path_.end_time();
-  const std::vector<double> big_breaks{path_start - 0.1, path_end +  0.1};
-
-  const auto lower_bigger =
-      PiecewisePolynomial<double>::ZeroOrderHold(big_breaks, lower_samples);
-  const auto upper_bigger =
-      PiecewisePolynomial<double>::ZeroOrderHold(big_breaks, upper_samples);
-
-  {
-    // Limit domain lies "above" path domain.
-    const std::vector<double> bad_breaks{path_end + 0.1, path_end + 1.1};
-    const auto lower_bad =
-        PiecewisePolynomial<double>::ZeroOrderHold(bad_breaks, lower_samples);
-    const auto upper_bad =
-        PiecewisePolynomial<double>::ZeroOrderHold(bad_breaks, upper_samples);
-
-    // Just for lower.
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        toppra_->AddFrameAccelerationLimit(frame, lower_bad, upper_bigger),
-        fmt::format(".* can't add a trajectory frame acceleration .* lower "
-                    "limit domain \\[{}, {}\\].* upper limit domain "
-                    "\\[{}, {}\\] .* path domain \\[{}, {}\\].",
-                    bad_breaks[0], bad_breaks[1], big_breaks[0],
-                    big_breaks[1], path_start, path_end));
-
-    // Just for upper.
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        toppra_->AddFrameAccelerationLimit(frame, lower_bigger, upper_bad),
-        ".* can't add a trajectory frame acceleration .*");
-
-    // Both.
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        toppra_->AddFrameAccelerationLimit(frame, lower_bad, upper_bad),
-        ".* can't add a trajectory frame acceleration .*");
-  }
-
-  {
-    // Limit domain lies "below" path domain.
-    const std::vector<double> bad_breaks{path_start - 1, path_start - 0.1};
-    const auto lower_bad =
-        PiecewisePolynomial<double>::ZeroOrderHold(bad_breaks, lower_samples);
-    const auto upper_bad =
-        PiecewisePolynomial<double>::ZeroOrderHold(bad_breaks, upper_samples);
-
-    // Just for lower.
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        toppra_->AddFrameAccelerationLimit(frame, lower_bad, upper_bigger),
-        ".* can't add a trajectory frame acceleration .*");
-
-    // Just for upper.
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        toppra_->AddFrameAccelerationLimit(frame, lower_bigger, upper_bad),
-        ".* can't add a trajectory frame acceleration .*");
-
-    // Both.
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        toppra_->AddFrameAccelerationLimit(frame, lower_bad, upper_bad),
-        ".* can't add a trajectory frame acceleration .*");
-  }
-
-  {
-    // We'll use a single test to infer that the limit domains can partially
-    // overlap. We'll send each limit in different directions.
-    const std::vector<double> low_breaks{path_start - 1,
-                                         (path_start + path_end) / 2};
-    const std::vector<double> high_breaks{(path_start + path_end) / 2,
-                                          path_end + 1};
-    const auto lower_traj =
-        PiecewisePolynomial<double>::ZeroOrderHold(high_breaks, lower_samples);
-    const auto upper_traj =
-        PiecewisePolynomial<double>::ZeroOrderHold(low_breaks, upper_samples);
-    EXPECT_NO_THROW(
-        toppra_->AddFrameAccelerationLimit(frame, lower_traj, upper_traj));
-  }
-}
-
-// Confirms that if the limit varies over the path, the observed acceleration
-// respects it.
-TEST_F(IiwaToppraTest, FrameAccelerationLimitVarying) {
-  const auto& frame = iiwa_plant_->GetFrameByName("iiwa_link_7");
-
-  // Create a trajectory with a lower speed for the first half and a higher
-  // speed for the second half.
-  const double s0 = path_.start_time();
-  const double s2 = path_.end_time();
-  const double s1 = (s0 + s2) / 2;
-
-  // Lower limit for the interval [s0, s1).
-  const Vector6d lower0 = Vector6d::Constant(-0.5);
-  const Vector6d upper0 = -lower0;
-    // Lower limit for the interval [s1, s2).
-  const Vector6d lower1 = Vector6d::Constant(-7);
-  const Vector6d upper1 = -lower1;
-
-  Eigen::MatrixXd lower_samples(6, 3);
-  lower_samples << lower0, lower1, lower1;
-  const auto lower_traj = PiecewisePolynomial<double>::ZeroOrderHold(
-      Eigen::VectorXd::LinSpaced(3, s0, s2), lower_samples);
-  Eigen::MatrixXd upper_samples(6, 3);
-  upper_samples << upper0, upper1, upper1;
-  const auto upper_traj = PiecewisePolynomial<double>::ZeroOrderHold(
-      Eigen::VectorXd::LinSpaced(3, s0, s2), upper_samples);
-
-  toppra_->AddFrameAccelerationLimit(frame, lower_traj, upper_traj);
-
-  auto result = toppra_->SolvePathParameterization();
-  ASSERT_TRUE(result);
-  auto s_path = result.value();
-
-  auto calc_accel_lower_and_upper_limit =
-      [&s_path, &frame, &lower_traj, &upper_traj,
-       this](double t) -> std::tuple<Vector6d, Vector6d, Vector6d> {
-    const double s = s_path.scalarValue(t);
-    const Vector6d acceleration = CalcSpatialAcceleration(t, s_path, frame);
-    return {acceleration, lower_traj.value(s), upper_traj.value(s)};
-  };
-
-  // This tolerance was tuned to work with the given gridpoints.
-  bool second_half_increased_accleration = false;
-  const double tol = 1e-14;
-  for (int ii = 0; ii < s_path.get_number_of_segments(); ii++) {
-    const double t = s_path.start_time(ii);
-    auto [accel, lower, upper] = calc_accel_lower_and_upper_limit(t);
-
-    // We should always respect the instantaneous acceleration limit.
-    EXPECT_TRUE((accel.array() >= lower.array() - tol).all());
-    EXPECT_TRUE((accel.array() <= upper.array() + tol).all());
-
-    // In the first half, we should remain within the smaller [lower0, upper0]
-    // constraint box. In the second half we should fill the larger box. We
-    // can't assert the acceleration at each gridpoint; instead, we'll simply
-    // assert that we *observed* a change in accleration magnitude in the
-    // second half that is larger than the first half's small box.
-    if (s_path.scalarValue(t) >= s1) {
-      second_half_increased_accleration =
-          second_half_increased_accleration ||
-          (accel.array().abs() > upper1.array()).any();
-    }
-  }
-  const double t = s_path.end_time();
-  auto [accel, lower, upper] = calc_accel_lower_and_upper_limit(t);
-
-  EXPECT_TRUE((accel.array() >= lower.array() - tol).all());
-  EXPECT_TRUE((accel.array() <= upper.array() + tol).all());
-
-  EXPECT_TRUE(second_half_increased_accleration);
+  EXPECT_TRUE((frame_acceleration.array() >= lower_bound.array() - tol).all());
+  EXPECT_TRUE((frame_acceleration.array() <= upper_bound.array() + tol).all());
 }
 
 GTEST_TEST(ToppraTest, GridpointsTest) {

--- a/multibody/optimization/toppra.cc
+++ b/multibody/optimization/toppra.cc
@@ -273,62 +273,15 @@ Binding<BoundingBoxConstraint> Toppra::AddFrameVelocityLimit(
   return x_bbox;
 }
 
-namespace {
-
-// Creates a trajectory consisting of a constant `value` over the same domain
-// as path.
-PiecewisePolynomial<double> MakeLimitTrajectory(const Trajectory<double>& path,
-                                                const Eigen::MatrixXd& value) {
-  const std::vector<double> breaks{path.start_time(), path.end_time()};
-  const std::vector<Eigen::MatrixXd> samples{value, value};
-  return PiecewisePolynomial<double>::ZeroOrderHold(breaks, samples);
-}
-
-// Samples the given `path` at the value `t`. If `t` lies outside the domain
-// of `path`, the given default value is returned.
-Eigen::MatrixXd SampleOrDefault(double t, const Trajectory<double>& path,
-                                const Eigen::MatrixXd& or_default) {
-  if (path.start_time() <= t && t <= path.end_time()) {
-    return path.value(t);
-  }
-  return or_default;
-}
-
-}  // namespace
-
 Binding<BoundingBoxConstraint> Toppra::AddFrameTranslationalSpeedLimit(
     const Frame<double>& constraint_frame, const double& upper_limit) {
-  const auto upper_bound_traj =
-      MakeLimitTrajectory(path_, Vector1<double>::Constant(upper_limit));
-  return AddFrameTranslationalSpeedLimit(constraint_frame, upper_bound_traj);
-}
-
-Binding<BoundingBoxConstraint> Toppra::AddFrameTranslationalSpeedLimit(
-    const Frame<double>& constraint_frame,
-    const Trajectory<double>& upper_limit) {
-  DRAKE_DEMAND(upper_limit.rows() == 1);
-  DRAKE_DEMAND(upper_limit.cols() == 1);
-  if (upper_limit.start_time() > path_.end_time() ||
-      upper_limit.end_time() < path_.start_time()) {
-    throw std::runtime_error(
-        fmt::format("Toppra can't add a trajectory translational speed "
-                    "limit. The upper limit domain [{}, {}] must overlap the "
-                    "path domain [{}, {}].",
-                    upper_limit.start_time(), upper_limit.end_time(),
-                    path_.start_time(), path_.end_time()));
-  }
-
-  const MatrixX<double> kInf_mat =
-      Vector1<double>::Constant(std::numeric_limits<double>::infinity());
-
   const int N = gridpoints_.size() - 1;
   Eigen::VectorXd x_lower_bound = Eigen::VectorXd::Zero(N);
   Eigen::VectorXd x_upper_bound(N);
 
   for (int knot = 0; knot < N; knot++) {
-    const double t = gridpoints_(knot);
-    const Eigen::VectorXd qs = path_.value(t);
-    const Eigen::VectorXd qs_dot = path_.EvalDerivative(t, 1);
+    const Eigen::VectorXd qs = path_.value(gridpoints_(knot));
+    const Eigen::VectorXd qs_dot = path_.EvalDerivative(gridpoints_(knot), 1);
 
     plant_.SetPositions(plant_context_.get(), qs);
     plant_.SetVelocities(plant_context_.get(), qs_dot);
@@ -336,11 +289,9 @@ Binding<BoundingBoxConstraint> Toppra::AddFrameTranslationalSpeedLimit(
         constraint_frame.CalcSpatialVelocityInWorld(*plant_context_);
     const double speed_squared = velocity.translational().squaredNorm();
 
-    const double sampled_limit =
-        SampleOrDefault(t, upper_limit, kInf_mat)(0, 0);
     // Check to avoid performing division by zero.
     if (speed_squared > 0) {
-      x_upper_bound(knot) = std::pow(sampled_limit, 2) / speed_squared;
+      x_upper_bound(knot) = std::pow(upper_limit, 2) / speed_squared;
     } else {
       x_upper_bound(knot) = std::numeric_limits<double>::infinity();
     }
@@ -352,42 +303,11 @@ Binding<BoundingBoxConstraint> Toppra::AddFrameTranslationalSpeedLimit(
 }
 
 std::pair<Binding<LinearConstraint>, Binding<LinearConstraint>>
-Toppra::AddFrameAccelerationLimit(const Frame<double>& constraint_frame,
-                                  const Eigen::Ref<const Vector6d>& lower_limit,
-                                  const Eigen::Ref<const Vector6d>& upper_limit,
-                                  ToppraDiscretization discretization) {
-  const auto lower_traj = MakeLimitTrajectory(path_, lower_limit);
-  const auto upper_traj = MakeLimitTrajectory(path_, upper_limit);
-  return AddFrameAccelerationLimit(constraint_frame, lower_traj, upper_traj,
-                                   discretization);
-}
-
-std::pair<Binding<LinearConstraint>, Binding<LinearConstraint>>
-Toppra::AddFrameAccelerationLimit(const Frame<double>& constraint_frame,
-                                  const Trajectory<double>& lower_limit,
-                                  const Trajectory<double>& upper_limit,
-                                  ToppraDiscretization discretization) {
-  DRAKE_DEMAND(lower_limit.rows() == 6);
-  DRAKE_DEMAND(lower_limit.cols() == 1);
-  DRAKE_DEMAND(upper_limit.rows() == 6);
-  DRAKE_DEMAND(upper_limit.cols() == 1);
-
-  if (upper_limit.start_time() > path_.end_time() ||
-      upper_limit.end_time() < path_.start_time() ||
-      lower_limit.start_time() > path_.end_time() ||
-      lower_limit.end_time() < path_.start_time()) {
-    throw std::runtime_error(
-        fmt::format("Toppra can't add a trajectory frame acceleration "
-                    "limit. The lower limit domain [{}, {}] and upper limit "
-                    "domain [{}, {}] must both overlap the path domain "
-                    "[{}, {}].",
-                    lower_limit.start_time(), lower_limit.end_time(),
-                    upper_limit.start_time(), upper_limit.end_time(),
-                    path_.start_time(), path_.end_time()));
-  }
-  const Vector6d kInf_mat =
-      Vector6d::Constant(std::numeric_limits<double>::infinity());
-
+Toppra::AddFrameAccelerationLimit(
+    const Frame<double>& constraint_frame,
+    const Eigen::Ref<const Vector6d>& lower_limit,
+    const Eigen::Ref<const Vector6d>& upper_limit,
+    ToppraDiscretization discretization) {
   const int N = gridpoints_.size() - 1;
   const int n_dof = path_.rows();
   const int n_con =
@@ -404,10 +324,9 @@ Toppra::AddFrameAccelerationLimit(const Frame<double>& constraint_frame,
     // the constraint becomes
     // Jv_WF * dq/ds * s̈ + (Jv_WF * d²q/ds² + J̇v_WF) * ṡ² = a_WF
     // Toppra assumes q̇ = v and will have undefined behavior if it does not.
-    const double t = gridpoints_(knot);
-    const Eigen::VectorXd qs = path_.value(t);
-    const Eigen::VectorXd qs_dot = path_.EvalDerivative(t, 1);
-    const Eigen::VectorXd qs_ddot = path_.EvalDerivative(t, 2);
+    const Eigen::VectorXd qs = path_.value(gridpoints_(knot));
+    const Eigen::VectorXd qs_dot = path_.EvalDerivative(gridpoints_(knot), 1);
+    const Eigen::VectorXd qs_ddot = path_.EvalDerivative(gridpoints_(knot), 2);
 
     plant_.SetPositions(plant_context_.get(), qs);
     plant_.SetVelocities(plant_context_.get(), qs_dot);
@@ -424,8 +343,8 @@ Toppra::AddFrameAccelerationLimit(const Frame<double>& constraint_frame,
 
     con_A.block(0, 2 * knot, 6, 1) << J * qs_ddot + dJds_times_v;
     con_A.block(0, 2 * knot + 1, 6, 1) << J * qs_dot;
-    con_lb.block(0, knot, 6, 1) << SampleOrDefault(t, lower_limit, -kInf_mat);
-    con_ub.block(0, knot, 6, 1) << SampleOrDefault(t, upper_limit, kInf_mat);
+    con_lb.block(0, knot, 6, 1) << lower_limit;
+    con_ub.block(0, knot, 6, 1) << upper_limit;
   }
   if (discretization == ToppraDiscretization::kInterpolation) {
     CalcInterpolationConstraint(&con_A, &con_lb, &con_ub);

--- a/multibody/optimization/toppra.h
+++ b/multibody/optimization/toppra.h
@@ -185,44 +185,23 @@ class Toppra {
    *                    constraint_frame.
    * @return The bounding box constraint that will enforce the frame
    *         translational speed limit during the backward pass.
-   * @pydrake_mkdoc_identifier{const}
    */
   Binding<BoundingBoxConstraint> AddFrameTranslationalSpeedLimit(
       const Frame<double>& constraint_frame, const double& upper_limit);
 
   /**
-   * A version of the frame translational speed limit that uses a trajectory for
-   * the limit.
-   * @param constraint_frame The frame to limit the translational speed of.
-   * @param upper_limit The upper translational speed limit trajectory for
-   *                    constraint_frame.
-   * @pre upper_limit must have scalar values (a 1x1 matrix).
-   * @return The bounding box constraint that will enforce the frame
-   *         translational speed limit during the backward pass.
-   * @throws If the interval [upper_limit.start_time(), upper_limit.end_time()]
-   *         doesn't overlap with [path.start_time(), path.end_time()].
-   * @note The constraints are only added between upper_limit.start_time() and
-   *       upper_limit.end_time(). The rest of the path is _not_ constrained.
-   * @pydrake_mkdoc_identifier{trajectory}
-   */
-  Binding<BoundingBoxConstraint> AddFrameTranslationalSpeedLimit(
-      const Frame<double>& constraint_frame,
-      const Trajectory<double>& upper_limit);
-
-  /**
    * Adds a limit on the elements of the spatial acceleration of the given
-   * frame, measured and expressed in the world frame.  The limits should be
+   * frame, measured and and expressed in the world frame.  The limits should be
    * given as [α_WF, a_WF], where α_WF is the frame's angular acceleration and
-   * a_WF is the frame's translational acceleration.
+   * v_WF is the frame's translational acceleration.
    * @param constraint_frame The frame to limit the acceleration of.
    * @param lower_limit The lower acceleration limit for constraint_frame.
    * @param upper_limit The upper acceleration limit for constraint_frame.
    * @param discretization The discretization scheme to use for this linear
    *                       constraint. See ToppraDiscretization for details.
    * @return A pair containing the linear constraints that will enforce the
-   *         frame acceleration limit on the backward pass and forward pass
-   *         respectively.
-   * @pydrake_mkdoc_identifier{const}
+   * frame acceleration limit on the backward pass and forward pass
+   * respectively.
    */
   std::pair<Binding<LinearConstraint>, Binding<LinearConstraint>>
   AddFrameAccelerationLimit(
@@ -231,37 +210,6 @@ class Toppra {
       const Eigen::Ref<const Vector6d>& upper_limit,
       ToppraDiscretization discretization =
           ToppraDiscretization::kInterpolation);
-  /**
-   * A version of acceleration limit that uses a trajectory for the upper and
-   * lower limits.
-   * @param constraint_frame The frame to limit the acceleration of.
-   * @param lower_limit The lower acceleration limit trajectory for
-   *                    constraint_frame.
-   * @param upper_limit The upper acceleration limit trajectory for
-   *                    constraint_frame.
-   * @param discretization The discretization scheme to use for this linear
-   *                       constraint. See ToppraDiscretization for details.
-   * @return A pair containing the linear constraints that will enforce the
-   * frame acceleration limit on the backward pass and forward pass
-   * respectively.
-   * @pre Both lower_limit and upper_limit trajectories must have values in ℜ⁶.
-   *      The six-dimensional column vector is interpreted as [α_WF, a_WF],
-   *      where α_WF is the frame's angular acceleration and a_WF is the frame's
-   *      translational acceleration.
-   * @throws If the intervals [upper_limit.start_time(), upper_limit.end_time()]
-   *         and [lower_limit.start_time(), lower_limit.end_time()] don't
-   *         overlap with [path.start_time(), path.end_time()].
-   * @note The constraints are only added in the constraint trajectories
-   *       domains (where they overlap the path). The rest of the path is _not_
-   *       constrained.
-   * @pydrake_mkdoc_identifier{trajectory}
-   */
-  std::pair<Binding<LinearConstraint>, Binding<LinearConstraint>>
-  AddFrameAccelerationLimit(const Frame<double>& constraint_frame,
-                            const Trajectory<double>& lower_limit,
-                            const Trajectory<double>& upper_limit,
-                            ToppraDiscretization discretization =
-                                ToppraDiscretization::kInterpolation);
 
  private:
   /*


### PR DESCRIPTION
Dear @SeanCurtis-TRI ,

 The on-call build cop, @BetsyMcPhail, believes that your PR #18738 may have
 broken one or more of Drake's continuous integration builds [1]. It is
 possible to break a build even if your PR passed continuous integration
 pre-merge because additional platforms are tested post-merge.

 The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/mac-arm-monterey-clang-bazel-continuous-release/293/

 Therefore, the build cop has created this revert PR and started a complete
 post-merge build to determine whether your PR was in fact the cause of the
 problem. If that build passes, this revert PR will be merged 60 minutes from
 now. You can then fix the problem at your leisure, and send a new PR to
 reinstate your change.

 If you believe your original PR did not actually break the build, please
 explain on this thread.

 If you believe you can fix the break promptly in lieu of a revert, please
 explain on this thread, and send a PR to the build cop for review ASAP.

 If you believe your original PR definitely did break the build and should be
 reverted, please review and LGTM this PR. This allows the build cop to merge
 without waiting for CI results.

 For advice on how to handle a build cop revert, see [2].

 Thanks!
 Your Friendly On-call Build Cop

 [1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
 [2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18778)
<!-- Reviewable:end -->
