### PR TITLE
[C-IRIS] add CIris to CollisionGeometry and SeparatingPlane.

### DIFF
--- a/geometry/optimization/dev/BUILD.bazel
+++ b/geometry/optimization/dev/BUILD.bazel
@@ -13,9 +13,9 @@ load(
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 drake_cc_library(
-    name = "collision_geometry",
-    srcs = ["collision_geometry.cc"],
-    hdrs = ["collision_geometry.h"],
+    name = "c_iris_collision_geometry",
+    srcs = ["c_iris_collision_geometry.cc"],
+    hdrs = ["c_iris_collision_geometry.h"],
     deps = [
         "//geometry:geometry_ids",
         "//geometry:shape_specification",
@@ -26,11 +26,11 @@ drake_cc_library(
 )
 
 drake_cc_library(
-    name = "separating_plane",
-    srcs = ["separating_plane.cc"],
-    hdrs = ["separating_plane.h"],
+    name = "c_iris_separating_plane",
+    srcs = ["c_iris_separating_plane.cc"],
+    hdrs = ["c_iris_separating_plane.h"],
     deps = [
-        ":collision_geometry",
+        ":c_iris_collision_geometry",
         "//common/symbolic:polynomial",
     ],
 )
@@ -40,8 +40,8 @@ drake_cc_library(
     srcs = ["cspace_free_polytope.cc"],
     hdrs = ["cspace_free_polytope.h"],
     deps = [
-        ":collision_geometry",
-        ":separating_plane",
+        ":c_iris_collision_geometry",
+        ":c_iris_separating_plane",
         "//common/symbolic:monomial_util",
         "//solvers:choose_best_solver",
         "//solvers:mathematical_program",
@@ -71,18 +71,18 @@ drake_cc_library(
 )
 
 drake_cc_googletest(
-    name = "collision_geometry_test",
+    name = "c_iris_collision_geometry_test",
     deps = [
+        ":c_iris_collision_geometry",
         ":c_iris_test_utilities",
-        ":collision_geometry",
         "//common/test_utilities:symbolic_test_util",
     ],
 )
 
 drake_cc_googletest(
-    name = "separating_plane_test",
+    name = "c_iris_separating_plane_test",
     deps = [
-        ":separating_plane",
+        ":c_iris_separating_plane",
         "//common/test_utilities:symbolic_test_util",
     ],
 )

--- a/geometry/optimization/dev/c_iris_collision_geometry.cc
+++ b/geometry/optimization/dev/c_iris_collision_geometry.cc
@@ -1,4 +1,4 @@
-#include "drake/geometry/optimization/dev/collision_geometry.h"
+#include "drake/geometry/optimization/dev/c_iris_collision_geometry.h"
 
 #include <utility>
 
@@ -16,11 +16,12 @@ PlaneSide OtherSide(PlaneSide plane_side) {
                                             : PlaneSide::kPositive;
 }
 
-CollisionGeometry::CollisionGeometry(const geometry::Shape* geometry,
-                                     multibody::BodyIndex body_index,
-                                     geometry::GeometryId id,
-                                     math::RigidTransformd X_BG)
-    : geometry_{geometry}, body_index_{body_index}, id_{id}, X_BG_{X_BG} {}
+CIrisCollisionGeometry::CIrisCollisionGeometry(const geometry::Shape* geometry,
+                                               multibody::BodyIndex body_index,
+                                               geometry::GeometryId id,
+                                               math::RigidTransformd X_BG)
+    : geometry_{geometry}, body_index_{body_index}, id_{id}, X_BG_{X_BG} {
+}
 
 namespace {
 struct ReifyData {
@@ -371,12 +372,13 @@ class OnPlaneSideReifier : public ShapeReifier {
   GeometryId geometry_id_;
 };
 
-class GeometryTypeReifier : public ShapeReifier {
+class CIrisGeometryTypeReifier : public ShapeReifier {
  public:
-  explicit GeometryTypeReifier(const geometry::Shape* shape) : shape_{shape} {}
+  explicit CIrisGeometryTypeReifier(const geometry::Shape* shape)
+      : shape_{shape} {}
 
-  GeometryType ProcessData() {
-    GeometryType type;
+  CIrisGeometryType ProcessData() {
+    CIrisGeometryType type;
     shape_->Reify(this, &type);
     return type;
   }
@@ -384,28 +386,28 @@ class GeometryTypeReifier : public ShapeReifier {
  private:
   using ShapeReifier::ImplementGeometry;
   void ImplementGeometry(const Box&, void* data) {
-    auto* type = static_cast<GeometryType*>(data);
-    *type = GeometryType::kPolytope;
+    auto* type = static_cast<CIrisGeometryType*>(data);
+    *type = CIrisGeometryType::kPolytope;
   }
 
   void ImplementGeometry(const Convex&, void* data) {
-    auto* type = static_cast<GeometryType*>(data);
-    *type = GeometryType::kPolytope;
+    auto* type = static_cast<CIrisGeometryType*>(data);
+    *type = CIrisGeometryType::kPolytope;
   }
 
   void ImplementGeometry(const Sphere&, void* data) {
-    auto* type = static_cast<GeometryType*>(data);
-    *type = GeometryType::kSphere;
+    auto* type = static_cast<CIrisGeometryType*>(data);
+    *type = CIrisGeometryType::kSphere;
   }
 
   void ImplementGeometry(const Capsule&, void* data) {
-    auto* type = static_cast<GeometryType*>(data);
-    *type = GeometryType::kCapsule;
+    auto* type = static_cast<CIrisGeometryType*>(data);
+    *type = CIrisGeometryType::kCapsule;
   }
 
   void ImplementGeometry(const Cylinder&, void* data) {
-    auto* type = static_cast<GeometryType*>(data);
-    *type = GeometryType::kCylinder;
+    auto* type = static_cast<CIrisGeometryType*>(data);
+    *type = CIrisGeometryType::kCylinder;
   }
 
   const Shape* shape_;
@@ -542,7 +544,7 @@ class DistanceToHalfspaceReifier : public ShapeReifier {
 };
 }  // namespace
 
-void CollisionGeometry::OnPlaneSide(
+void CIrisCollisionGeometry::OnPlaneSide(
     const Vector3<symbolic::Polynomial>& a, const symbolic::Polynomial& b,
     const multibody::RationalForwardKinematics::Pose<symbolic::Polynomial>&
         X_AB_multilinear,
@@ -554,17 +556,17 @@ void CollisionGeometry::OnPlaneSide(
                       y_slack, rationals);
 }
 
-GeometryType CollisionGeometry::type() const {
-  GeometryTypeReifier reifier(geometry_);
+CIrisGeometryType CIrisCollisionGeometry::type() const {
+  CIrisGeometryTypeReifier reifier(geometry_);
   return reifier.ProcessData();
 }
 
-int CollisionGeometry::num_rationals() const {
+int CIrisCollisionGeometry::num_rationals() const {
   NumRationalsReifier reifier(geometry_);
   return reifier.ProcessData();
 }
 
-double DistanceToHalfspace(const CollisionGeometry& collision_geometry,
+double DistanceToHalfspace(const CIrisCollisionGeometry& collision_geometry,
                            const Eigen::Vector3d& a, double b,
                            multibody::BodyIndex expressed_body,
                            PlaneSide plane_side,

--- a/geometry/optimization/dev/c_iris_collision_geometry.h
+++ b/geometry/optimization/dev/c_iris_collision_geometry.h
@@ -13,7 +13,7 @@ namespace drake {
 namespace geometry {
 namespace optimization {
 
-enum class GeometryType {
+enum class CIrisGeometryType {
   kSphere,
   kPolytope,
   kCylinder,
@@ -28,9 +28,9 @@ enum class PlaneSide {
 /** Returns the other side */
 [[nodiscard]] PlaneSide OtherSide(PlaneSide plane_side);
 
-class CollisionGeometry {
+class CIrisCollisionGeometry {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CollisionGeometry)
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CIrisCollisionGeometry)
 
   /**
    @param geometry The actual geometry object.
@@ -38,9 +38,9 @@ class CollisionGeometry {
    @param id The ID of this geometry.
    @param X_BG The pose of the geometry (G) in the attached body frame (B).
    */
-  CollisionGeometry(const geometry::Shape* geometry,
-                    multibody::BodyIndex body_index, geometry::GeometryId id,
-                    math::RigidTransformd X_BG);
+  CIrisCollisionGeometry(const geometry::Shape* geometry,
+                         multibody::BodyIndex body_index,
+                         geometry::GeometryId id, math::RigidTransformd X_BG);
 
   const Shape& geometry() const { return *geometry_; }
 
@@ -97,7 +97,7 @@ class CollisionGeometry {
       PlaneSide plane_side, const VectorX<symbolic::Variable>& y_slack,
       std::vector<symbolic::RationalFunction>* rationals) const;
 
-  [[nodiscard]] GeometryType type() const;
+  [[nodiscard]] CIrisGeometryType type() const;
 
   /**
    Returns the number of rationals in the condition "this geometry is
@@ -118,7 +118,7 @@ class CollisionGeometry {
  The halfspace is expressed in the expressed_body's body frame.
  */
 [[nodiscard]] double DistanceToHalfspace(
-    const CollisionGeometry& collision_geometry, const Eigen::Vector3d& a,
+    const CIrisCollisionGeometry& collision_geometry, const Eigen::Vector3d& a,
     double b, multibody::BodyIndex expressed_body, PlaneSide plane_side,
     const multibody::MultibodyPlant<double>& plant,
     const systems::Context<double>& plant_context);

--- a/geometry/optimization/dev/c_iris_separating_plane.cc
+++ b/geometry/optimization/dev/c_iris_separating_plane.cc
@@ -1,0 +1,1 @@
+#include "drake/geometry/optimization/dev/c_iris_separating_plane.h"

--- a/geometry/optimization/dev/c_iris_separating_plane.h
+++ b/geometry/optimization/dev/c_iris_separating_plane.h
@@ -3,7 +3,7 @@
 #include <utility>
 
 #include "drake/common/symbolic/polynomial.h"
-#include "drake/geometry/optimization/dev/collision_geometry.h"
+#include "drake/geometry/optimization/dev/c_iris_collision_geometry.h"
 
 namespace drake {
 namespace geometry {
@@ -22,18 +22,19 @@ enum class SeparatingPlaneOrder {
  @tparam T The type of decision_variables. T= symbolic::Variable or double.
  */
 template <typename T>
-struct SeparatingPlane {
+struct CIrisSeparatingPlane {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SeparatingPlane)
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CIrisSeparatingPlane)
 
-  SeparatingPlane() = default;
+  CIrisSeparatingPlane() = default;
 
-  SeparatingPlane(Vector3<symbolic::Polynomial> m_a, symbolic::Polynomial m_b,
-                  const CollisionGeometry* m_positive_side_geometry,
-                  const CollisionGeometry* m_negative_side_geometry,
-                  multibody::BodyIndex m_expressed_body,
-                  SeparatingPlaneOrder m_plane_order,
-                  const Eigen::Ref<const VectorX<T>>& m_decision_variables)
+  CIrisSeparatingPlane(Vector3<symbolic::Polynomial> m_a,
+                       symbolic::Polynomial m_b,
+                       const CIrisCollisionGeometry* m_positive_side_geometry,
+                       const CIrisCollisionGeometry* m_negative_side_geometry,
+                       multibody::BodyIndex m_expressed_body,
+                       SeparatingPlaneOrder m_plane_order,
+                       const Eigen::Ref<const VectorX<T>>& m_decision_variables)
       : a{std::move(m_a)},
         b{std::move(m_b)},
         positive_side_geometry{m_positive_side_geometry},
@@ -43,15 +44,16 @@ struct SeparatingPlane {
         decision_variables{m_decision_variables} {}
 
   /// Return the geometry on the specified side.
-  [[nodiscard]] const CollisionGeometry* geometry(PlaneSide plane_side) const {
+  [[nodiscard]] const CIrisCollisionGeometry* geometry(
+      PlaneSide plane_side) const {
     return plane_side == PlaneSide::kPositive ? positive_side_geometry
                                               : negative_side_geometry;
   }
 
   Vector3<symbolic::Polynomial> a;
   symbolic::Polynomial b;
-  const CollisionGeometry* positive_side_geometry;
-  const CollisionGeometry* negative_side_geometry;
+  const CIrisCollisionGeometry* positive_side_geometry;
+  const CIrisCollisionGeometry* negative_side_geometry;
   multibody::BodyIndex expressed_body;
   SeparatingPlaneOrder plane_order;
   VectorX<T> decision_variables;

--- a/geometry/optimization/dev/cspace_free_polytope.h
+++ b/geometry/optimization/dev/cspace_free_polytope.h
@@ -11,8 +11,8 @@
 
 #include <fmt/format.h>
 
-#include "drake/geometry/optimization/dev/collision_geometry.h"
-#include "drake/geometry/optimization/dev/separating_plane.h"
+#include "drake/geometry/optimization/dev/c_iris_collision_geometry.h"
+#include "drake/geometry/optimization/dev/c_iris_separating_plane.h"
 #include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/multibody/rational/rational_forward_kinematics.h"
 #include "drake/solvers/mathematical_program.h"
@@ -125,7 +125,7 @@ class CspaceFreePolytope {
     return map_geometries_to_separating_planes_;
   }
 
-  [[nodiscard]] const std::vector<SeparatingPlane<symbolic::Variable>>&
+  [[nodiscard]] const std::vector<CIrisSeparatingPlane<symbolic::Variable>>&
   separating_planes() const {
     return separating_planes_;
   }
@@ -616,11 +616,11 @@ class CspaceFreePolytope {
   multibody::RationalForwardKinematics rational_forward_kin_;
   const geometry::SceneGraph<double>& scene_graph_;
   std::map<multibody::BodyIndex,
-           std::vector<std::unique_ptr<CollisionGeometry>>>
+           std::vector<std::unique_ptr<CIrisCollisionGeometry>>>
       link_geometries_;
 
   SeparatingPlaneOrder plane_order_;
-  std::vector<SeparatingPlane<symbolic::Variable>> separating_planes_;
+  std::vector<CIrisSeparatingPlane<symbolic::Variable>> separating_planes_;
   std::unordered_map<SortedPair<geometry::GeometryId>, int>
       map_geometries_to_separating_planes_;
 
@@ -657,7 +657,7 @@ class CspaceFreePolytope {
  * the collision geometries.
  */
 [[nodiscard]] std::map<multibody::BodyIndex,
-                       std::vector<std::unique_ptr<CollisionGeometry>>>
+                       std::vector<std::unique_ptr<CIrisCollisionGeometry>>>
 GetCollisionGeometries(const multibody::MultibodyPlant<double>& plant,
                        const geometry::SceneGraph<double>& scene_graph);
 }  // namespace optimization

--- a/geometry/optimization/dev/separating_plane.cc
+++ b/geometry/optimization/dev/separating_plane.cc
@@ -1,1 +1,0 @@
-#include "drake/geometry/optimization/dev/separating_plane.h"

--- a/geometry/optimization/dev/test/c_iris_collision_geometry_test.cc
+++ b/geometry/optimization/dev/test/c_iris_collision_geometry_test.cc
@@ -1,4 +1,4 @@
-#include "drake/geometry/optimization/dev/collision_geometry.h"
+#include "drake/geometry/optimization/dev/c_iris_collision_geometry.h"
 
 #include <memory>
 
@@ -44,9 +44,9 @@ void SetupPlane(const Eigen::Ref<const VectorX<symbolic::Variable>>& s,
       b_coeff.dot(s.cast<symbolic::Expression>()) + b_constant, s_set);
 }
 
-class CollisionGeometryTest : public CIrisToyRobotTest {
+class CIrisCollisionGeometryTest : public CIrisToyRobotTest {
  public:
-  CollisionGeometryTest()
+  CIrisCollisionGeometryTest()
       : rational_forward_kin_{plant_},
         diagram_context_{diagram_->CreateDefaultContext()} {
     SetupPlane(rational_forward_kin_.s(), &a_, &b_);
@@ -147,13 +147,14 @@ void CheckRationalWSlack(const symbolic::RationalFunction& rational,
                symbolic::Polynomial(expr_expected), 1E-10);
 }
 
-TEST_F(CollisionGeometryTest, Box) {
-  // Test CollisionGeometry constructed from a box.
+TEST_F(CIrisCollisionGeometryTest, Box) {
+  // Test CIrisCollisionGeometry constructed from a box.
   const auto& model_inspector = scene_graph_->model_inspector();
   const multibody::BodyIndex geometry_body = body_indices_[0];
-  CollisionGeometry box(&model_inspector.GetShape(body0_box_), geometry_body,
-                        body0_box_, model_inspector.GetPoseInFrame(body0_box_));
-  EXPECT_EQ(box.type(), GeometryType::kPolytope);
+  CIrisCollisionGeometry box(&model_inspector.GetShape(body0_box_),
+                             geometry_body, body0_box_,
+                             model_inspector.GetPoseInFrame(body0_box_));
+  EXPECT_EQ(box.type(), CIrisGeometryType::kPolytope);
 
   Eigen::Vector3d q_star(0., 0., 0.);
   const multibody::BodyIndex expressed_body = body_indices_[1];
@@ -217,14 +218,14 @@ TEST_F(CollisionGeometryTest, Box) {
   }
 }
 
-TEST_F(CollisionGeometryTest, Convex) {
-  // Test CollisionGeometry constructed from a convex object.
+TEST_F(CIrisCollisionGeometryTest, Convex) {
+  // Test CIrisCollisionGeometry constructed from a convex object.
   const auto& model_inspector = scene_graph_->model_inspector();
   const multibody::BodyIndex geometry_body = body_indices_[1];
-  CollisionGeometry convex(&model_inspector.GetShape(body1_convex_),
-                           geometry_body, body1_convex_,
-                           model_inspector.GetPoseInFrame(body1_convex_));
-  EXPECT_EQ(convex.type(), GeometryType::kPolytope);
+  CIrisCollisionGeometry convex(&model_inspector.GetShape(body1_convex_),
+                                geometry_body, body1_convex_,
+                                model_inspector.GetPoseInFrame(body1_convex_));
+  EXPECT_EQ(convex.type(), CIrisGeometryType::kPolytope);
 
   const multibody::BodyIndex expressed_body = body_indices_[3];
   const Eigen::Vector3d q_star(0, 0, 0);
@@ -289,13 +290,13 @@ TEST_F(CollisionGeometryTest, Convex) {
   }
 }
 
-TEST_F(CollisionGeometryTest, Sphere) {
-  // Test CollisionGeometry constructed from a sphere object.
+TEST_F(CIrisCollisionGeometryTest, Sphere) {
+  // Test CIrisCollisionGeometry constructed from a sphere object.
   const auto& model_inspector = scene_graph_->model_inspector();
-  CollisionGeometry sphere(&model_inspector.GetShape(body2_sphere_),
-                           body_indices_[2], body2_sphere_,
-                           model_inspector.GetPoseInFrame(body2_sphere_));
-  EXPECT_EQ(sphere.type(), GeometryType::kSphere);
+  CIrisCollisionGeometry sphere(&model_inspector.GetShape(body2_sphere_),
+                                body_indices_[2], body2_sphere_,
+                                model_inspector.GetPoseInFrame(body2_sphere_));
+  EXPECT_EQ(sphere.type(), CIrisGeometryType::kSphere);
   EXPECT_EQ(sphere.num_rationals(), 2);
 
   const Eigen::Vector3d q_star(0., 0., 0.);
@@ -347,14 +348,14 @@ TEST_F(CollisionGeometryTest, Sphere) {
   CheckRationalNoSlack(rationals_no_y[0], env, a_expr.dot(p_AS) + b_expr - 1);
 }
 
-TEST_F(CollisionGeometryTest, Capsule) {
-  // Test CollisionGeometry constructed from a capsule object.
+TEST_F(CIrisCollisionGeometryTest, Capsule) {
+  // Test CIrisCollisionGeometry constructed from a capsule object.
   const auto& model_inspector = scene_graph_->model_inspector();
   const multibody::BodyIndex geometry_body = body_indices_[2];
-  CollisionGeometry capsule(&model_inspector.GetShape(body2_capsule_),
-                            geometry_body, body2_capsule_,
-                            model_inspector.GetPoseInFrame(body2_capsule_));
-  EXPECT_EQ(capsule.type(), GeometryType::kCapsule);
+  CIrisCollisionGeometry capsule(
+      &model_inspector.GetShape(body2_capsule_), geometry_body, body2_capsule_,
+      model_inspector.GetPoseInFrame(body2_capsule_));
+  EXPECT_EQ(capsule.type(), CIrisGeometryType::kCapsule);
   EXPECT_EQ(capsule.num_rationals(), 3);
 
   const Eigen::Vector3d q_star(0., 0., 0.);
@@ -419,14 +420,14 @@ TEST_F(CollisionGeometryTest, Capsule) {
   CheckRationalNoSlack(rationals_no_y[0], env, a_expr.dot(p_AO) + b_expr - 1);
 }
 
-TEST_F(CollisionGeometryTest, Cylinder) {
-  // Test CollisionGeometry constructed from a cylinder object.
+TEST_F(CIrisCollisionGeometryTest, Cylinder) {
+  // Test CIrisCollisionGeometry constructed from a cylinder object.
   const auto& model_inspector = scene_graph_->model_inspector();
   const multibody::BodyIndex geometry_body = body_indices_[3];
-  CollisionGeometry cylinder(&model_inspector.GetShape(body3_cylinder_),
-                             geometry_body, body3_cylinder_,
-                             model_inspector.GetPoseInFrame(body3_cylinder_));
-  EXPECT_EQ(cylinder.type(), GeometryType::kCylinder);
+  CIrisCollisionGeometry cylinder(
+      &model_inspector.GetShape(body3_cylinder_), geometry_body,
+      body3_cylinder_, model_inspector.GetPoseInFrame(body3_cylinder_));
+  EXPECT_EQ(cylinder.type(), CIrisGeometryType::kCylinder);
   EXPECT_EQ(cylinder.num_rationals(), 3);
 
   const Eigen::Vector3d q_star(0., 0., 0.);
@@ -573,9 +574,9 @@ GTEST_TEST(DistanceToHalfspace, Test) {
   plant->SetPositions(&plant_context, q);
 
   // Test the distance for each geometry.
-  const CollisionGeometry sphere(&(model_inspector.GetShape(body1_sphere)),
-                                 body_indices[1], body1_sphere,
-                                 model_inspector.GetPoseInFrame(body1_sphere));
+  const CIrisCollisionGeometry sphere(
+      &(model_inspector.GetShape(body1_sphere)), body_indices[1], body1_sphere,
+      model_inspector.GetPoseInFrame(body1_sphere));
 
   // Expressed body is where the halfspace is welded to.
   const multibody::BodyIndex expressed_body = body_indices[3];
@@ -608,9 +609,9 @@ GTEST_TEST(DistanceToHalfspace, Test) {
 
   {
     // Distance to box
-    const CollisionGeometry box(&(model_inspector.GetShape(body0_box)),
-                                body_indices[0], body0_box,
-                                model_inspector.GetPoseInFrame(body0_box));
+    const CIrisCollisionGeometry box(&(model_inspector.GetShape(body0_box)),
+                                     body_indices[0], body0_box,
+                                     model_inspector.GetPoseInFrame(body0_box));
     const double distance = DistanceToHalfspace(
         box, a, b, expressed_body, PlaneSide::kNegative, *plant, plant_context);
     // SceneGraph doesn't support distance between box and halfspace yet.
@@ -636,7 +637,7 @@ GTEST_TEST(DistanceToHalfspace, Test) {
 
   {
     // Distance to capsule
-    const CollisionGeometry capsule(
+    const CIrisCollisionGeometry capsule(
         &(model_inspector.GetShape(body2_capsule)), body_indices[2],
         body2_capsule, model_inspector.GetPoseInFrame(body2_capsule));
     const double distance =
@@ -660,7 +661,7 @@ GTEST_TEST(DistanceToHalfspace, Test) {
 
   {
     // Distance to cylinder
-    const CollisionGeometry cylinder(
+    const CIrisCollisionGeometry cylinder(
         &(model_inspector.GetShape(body4_cylinder)), body_indices[4],
         body4_cylinder, model_inspector.GetPoseInFrame(body4_cylinder));
     const double distance =

--- a/geometry/optimization/dev/test/c_iris_separating_plane_test.cc
+++ b/geometry/optimization/dev/test/c_iris_separating_plane_test.cc
@@ -1,4 +1,4 @@
-#include "drake/geometry/optimization/dev/separating_plane.h"
+#include "drake/geometry/optimization/dev/c_iris_separating_plane.h"
 
 #include <gtest/gtest.h>
 

--- a/geometry/optimization/dev/test/cspace_free_polytope_test.cc
+++ b/geometry/optimization/dev/test/cspace_free_polytope_test.cc
@@ -8,7 +8,6 @@
 #include "drake/common/test_utilities/symbolic_test_util.h"
 #include "drake/geometry/collision_filter_declaration.h"
 #include "drake/geometry/geometry_ids.h"
-#include "drake/geometry/optimization/dev/collision_geometry.h"
 #include "drake/geometry/optimization/dev/test/c_iris_test_utilities.h"
 #include "drake/multibody/rational/rational_forward_kinematics.h"
 #include "drake/multibody/rational/rational_forward_kinematics_internal.h"
@@ -110,24 +109,24 @@ TEST_F(CIrisToyRobotTest, CspaceFreePolytopeGenerateRationals) {
   for (const auto& plane_geometries : tester.plane_geometries()) {
     const auto& plane = tester.cspace_free_polytope()
                             .separating_planes()[plane_geometries.plane_index];
-    if (plane.positive_side_geometry->type() == GeometryType::kPolytope &&
-        plane.negative_side_geometry->type() == GeometryType::kPolytope) {
+    if (plane.positive_side_geometry->type() == CIrisGeometryType::kPolytope &&
+        plane.negative_side_geometry->type() == CIrisGeometryType::kPolytope) {
       EXPECT_EQ(plane_geometries.positive_side_rationals.size(),
                 plane.positive_side_geometry->num_rationals());
       EXPECT_EQ(plane_geometries.negative_side_rationals.size(),
                 plane.negative_side_geometry->num_rationals());
     } else if (plane.positive_side_geometry->type() ==
-                   GeometryType::kPolytope &&
+                   CIrisGeometryType::kPolytope &&
                plane.negative_side_geometry->type() !=
-                   GeometryType::kPolytope) {
+                   CIrisGeometryType::kPolytope) {
       EXPECT_EQ(plane_geometries.positive_side_rationals.size(),
                 plane.positive_side_geometry->num_rationals());
       EXPECT_EQ(plane_geometries.negative_side_rationals.size(),
                 plane.negative_side_geometry->num_rationals() - 1);
     } else if (plane.positive_side_geometry->type() !=
-                   GeometryType::kPolytope &&
+                   CIrisGeometryType::kPolytope &&
                plane.negative_side_geometry->type() ==
-                   GeometryType::kPolytope) {
+                   CIrisGeometryType::kPolytope) {
       EXPECT_EQ(plane_geometries.positive_side_rationals.size(),
                 plane.positive_side_geometry->num_rationals() - 1);
       EXPECT_EQ(plane_geometries.negative_side_rationals.size(),

--- a/geometry/optimization/dev/test/cspace_free_polytope_with_mosek_test.cc
+++ b/geometry/optimization/dev/test/cspace_free_polytope_with_mosek_test.cc
@@ -6,7 +6,6 @@
 #include "drake/common/test_utilities/symbolic_test_util.h"
 #include "drake/geometry/collision_filter_declaration.h"
 #include "drake/geometry/geometry_ids.h"
-#include "drake/geometry/optimization/dev/collision_geometry.h"
 #include "drake/geometry/optimization/dev/cspace_free_polytope.h"  // NOLINT
 #include "drake/geometry/optimization/dev/test/c_iris_test_utilities.h"
 #include "drake/multibody/rational/rational_forward_kinematics.h"


### PR DESCRIPTION
CollisionGeometry and SeparatingPlane are too general names, these names can be used in many other applications. To avoid name collision, I rename them as CIrisCollisionGeometry and CIrisSeparatingPlane.
Also rename the file to add c_iris.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18781)
<!-- Reviewable:end -->
