### PR TITLE
[macOS] Fix python 3.11 testing issues

### DIFF
--- a/bindings/pydrake/common/test/deprecation_autocomplete_test.py
+++ b/bindings/pydrake/common/test/deprecation_autocomplete_test.py
@@ -9,6 +9,7 @@ to fail if this test is part of that suite.
 """
 
 import rlcompleter
+import sys
 import unittest
 
 
@@ -69,6 +70,11 @@ class TestDeprecation(unittest.TestCase):
             "sub_module",
             "value",
         ]
+        # Python 3.11 adds a default implementation of __getstate__(), see:
+        # https://docs.python.org/3/library/pickle.html#object.__getstate__
+        # It does not exist in python <=3.10.
+        if sys.version_info[0:2] >= (3, 11):
+            suffixes_expected.append("__getstate__(")
         suffixes_expected += [
             "__ge__(",
             "__eq__(",

--- a/tools/workspace/styleguide/BUILD.bazel
+++ b/tools/workspace/styleguide/BUILD.bazel
@@ -7,7 +7,14 @@ py_test(
     name = "cpplint_unittest",
     size = "small",
     srcs = ["@styleguide//:cpplint_unittest"],
-    tags = ["no_kcov"],
+    # TODO(jwnimmer-tri): macOS python 3.11 began having import issues because
+    # the directory cpplint has an __init__.py, so `import cpplint` ends up
+    # finding __init__.py rather than cpplint/cpplint.py.  When fixed, remove
+    # the manual tag.
+    tags = [
+        "manual",
+        "no_kcov",
+    ],
 )
 
 add_lint_tests()


### PR DESCRIPTION
Follow-up to #18262.

- deprecation_autocomplete_test: add __getstate__(, refs: https://docs.python.org/3/library/pickle.html#object.__getstate__

  Changed in version 3.11: Added the default implementation of the __getstate__() method in the object class.
- styleguide: temporarily mark the failing test as manual to unblock CI, proper fix to adjust import paths TBD.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18786)
<!-- Reviewable:end -->
