### PR TITLE
Add bounding box or rotated lorentz cone constraint for small psd matrices

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -730,33 +730,36 @@ void BindMathematicalProgram(py::module m) {
               MathematicalProgram::*)(
               const Eigen::Ref<const VectorX<Monomial>>&,
               MathematicalProgram::NonnegativePolynomial,
-              const std::string& gram_name)>(
+              const std::string& gram_name, bool small_gram_as_lorentz_cone)>(
               &MathematicalProgram::NewSosPolynomial),
           py::arg("monomial_basis"),
           py::arg("type") = MathematicalProgram::NonnegativePolynomial::kSos,
           py::arg("gram_name") = "S",
+          py::arg("small_gram_as_lorentz_cone") = true,
           doc.MathematicalProgram.NewSosPolynomial
-              .doc_3args_monomial_basis_type_gram_name)
+              .doc_4args_monomial_basis_type_gram_name_small_gram_as_lorentz_cone)
       .def("NewSosPolynomial",
           static_cast<Polynomial (MathematicalProgram::*)(
               const Eigen::Ref<const MatrixX<symbolic::Variable>>&,
               const Eigen::Ref<const VectorX<Monomial>>&,
-              MathematicalProgram::NonnegativePolynomial)>(
+              MathematicalProgram::NonnegativePolynomial, bool)>(
               &MathematicalProgram::NewSosPolynomial),
           py::arg("gramian"), py::arg("monomial_basis"),
           py::arg("type") = MathematicalProgram::NonnegativePolynomial::kSos,
+          py::arg("small_gram_as_lorentz_cone") = true,
           doc.MathematicalProgram.NewSosPolynomial
-              .doc_3args_gramian_monomial_basis_type)
+              .doc_4args_gramian_monomial_basis_type_small_gram_as_lorentz_cone)
       .def("NewSosPolynomial",
           static_cast<std::pair<Polynomial, MatrixXDecisionVariable> (
               MathematicalProgram::*)(const Variables&, int,
-              MathematicalProgram::NonnegativePolynomial, const std::string&)>(
-              &MathematicalProgram::NewSosPolynomial),
+              MathematicalProgram::NonnegativePolynomial, const std::string&,
+              bool)>(&MathematicalProgram::NewSosPolynomial),
           py::arg("indeterminates"), py::arg("degree"),
           py::arg("type") = MathematicalProgram::NonnegativePolynomial::kSos,
           py::arg("gram_name") = "S",
+          py::arg("small_gram_as_lorentz_cone") = true,
           doc.MathematicalProgram.NewSosPolynomial
-              .doc_4args_indeterminates_degree_type_gram_name)
+              .doc_5args_indeterminates_degree_type_gram_name_small_gram_as_lorentz_cone)
       .def("NewEvenDegreeNonnegativePolynomial",
           &MathematicalProgram::NewEvenDegreeNonnegativePolynomial,
           py::arg("indeterminates"), py::arg("degree"), py::arg("type"),

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -642,7 +642,7 @@ class TestMathematicalProgram(unittest.TestCase):
         (poly1, gramian1) = prog.NewSosPolynomial(
             indeterminates=sym.Variables(x), degree=4,
             type=mp.MathematicalProgram.NonnegativePolynomial.kSdsos,
-            gram_name="M0")
+            gram_name="M0", small_gram_as_lorentz_cone=True)
         self.assertIsInstance(poly1, sym.Polynomial)
         self.assertIsInstance(gramian1, np.ndarray)
 
@@ -650,13 +650,14 @@ class TestMathematicalProgram(unittest.TestCase):
         poly2 = prog.NewSosPolynomial(
             gramian=gramian2,
             monomial_basis=(sym.Monomial(x[0]), sym.Monomial(x[1])),
-            type=mp.MathematicalProgram.NonnegativePolynomial.kDsos)
+            type=mp.MathematicalProgram.NonnegativePolynomial.kDsos,
+            small_gram_as_lorentz_cone=True)
         self.assertIsInstance(gramian2, np.ndarray)
 
         poly3, gramian3 = prog.NewSosPolynomial(
             monomial_basis=(sym.Monomial(x[0]), sym.Monomial(x[1])),
             type=mp.MathematicalProgram.NonnegativePolynomial.kSos,
-            gram_name="M2")
+            gram_name="M2", small_gram_as_lorentz_cone=True)
         self.assertIsInstance(poly3, sym.Polynomial)
         self.assertIsInstance(gramian3, np.ndarray)
 

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -215,17 +215,36 @@ symbolic::Polynomial MathematicalProgram::NewSosPolynomial(
     const Eigen::Ref<const MatrixX<symbolic::Variable>>& gramian,
     const Eigen::Ref<const VectorX<symbolic::Monomial>>& monomial_basis,
     NonnegativePolynomial type) {
-  DRAKE_ASSERT(gramian.rows() == gramian.cols());
+  DRAKE_ASSERT(math::IsSymmetric(gramian));
   DRAKE_ASSERT(gramian.rows() == monomial_basis.rows());
   const symbolic::Polynomial p =
       ComputePolynomialFromMonomialBasisAndGramMatrix(monomial_basis, gramian);
   switch (type) {
     case MathematicalProgram::NonnegativePolynomial::kSos: {
-      AddPositiveSemidefiniteConstraint(gramian);
+      if (gramian.rows() == 1) {
+        // A 1x1 matrix being PSD is equivalent to its entry being non-negative.
+        AddBoundingBoxConstraint(0, kInf, gramian(0, 0));
+      } else if (gramian.rows() == 2) {
+        // A 2x2 matrix
+        // ⌈X(0, 0) X(0, 1)⌉
+        // ⌊X(0, 1) X(1, 1)⌋
+        // being psd is equivalent to [X(0, 0), X(1, 1), X(0, 1)] in the rotated
+        // lorentz cone.
+        AddRotatedLorentzConeConstraint(Vector3<symbolic::Variable>(
+            gramian(0, 0), gramian(1, 1), gramian(0, 1)));
+      } else {
+        AddPositiveSemidefiniteConstraint(gramian);
+      }
       return p;
     }
     case MathematicalProgram::NonnegativePolynomial::kSdsos: {
-      AddScaledDiagonallyDominantMatrixConstraint(gramian);
+      if (gramian.rows() == 1) {
+        // A 1x1 matrix being scaled diagonally dominant is equivalent to its
+        // entry being non-negative.
+        AddBoundingBoxConstraint(0, kInf, gramian(0, 0));
+      } else {
+        AddScaledDiagonallyDominantMatrixConstraint(gramian);
+      }
       return p;
     }
     case MathematicalProgram::NonnegativePolynomial::kDsos: {

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -482,7 +482,7 @@ class MathematicalProgram {
     kDsos,       ///< A diagonally dominant sum-of-squares polynomial.
   };
 
-  /** Returns a pair of a SOS polynomial p = mᵀQm and the Gramian matrix Q,
+  /** Returns a pair of a SOS polynomial p = mᵀQm and the Gram matrix Q,
    * where m is the @p monomial basis.
    * For example, `NewSosPolynomial(Vector2<Monomial>{x,y})` returns a
    * polynomial
@@ -496,11 +496,27 @@ class MathematicalProgram {
    * @param gram_name The name of the gram matrix for print out.
    * @note Q is a symmetric monomial_basis.rows() x monomial_basis.rows()
    * matrix.
+   * @param small_gram_as_lorentz_cone If set to true, then for
+   * small-sized Gram matrix Q (with size 2 x 2), we impose a rotated Lorentz
+   * cone constraint Q(0, 0) * Q(1, 1) >= Q(0, 1)², Q(0, 0) >= 0, Q(1, 1) >= 0.
+   * If set to false, then we always impose the positive semidefinite constraint
+   * "Q is psd", whatever the size of Q is. @default is true. Note that for most
+   * optimization solvers (Mosek, SCS, etc) that support positive semidefinite
+   * matrix constraint, it is advantageous to use rotated Lorentz cone
+   * constraint for small-size 2x2 Gram matrices, because these solvers have
+   * special routines for (rotated) Lorentz cone constraint. On the other hand
+   * for some optimization solvers (like CSDP) which doesn't have special
+   * routines for (rotated) Lorentz cone constraint, it is disadvantage to set
+   * this flag to true, since the solver actually need to impose the (rotated)
+   * Lorentz cone constraint as matrix positive semidefinite constraint, and
+   * introduce larger size psd matrix (this rotated Lorentz cone constraint will
+   * be imposed as a 3 x 3 matrix being psd).
    */
   std::pair<symbolic::Polynomial, MatrixXDecisionVariable> NewSosPolynomial(
       const Eigen::Ref<const VectorX<symbolic::Monomial>>& monomial_basis,
       NonnegativePolynomial type = NonnegativePolynomial::kSos,
-      const std::string& gram_name = "S");
+      const std::string& gram_name = "S",
+      bool small_gram_as_lorentz_cone = true);
 
   /**
    * Overloads NewSosPolynomial, except the Gramian matrix Q is an
@@ -510,7 +526,8 @@ class MathematicalProgram {
   symbolic::Polynomial NewSosPolynomial(
       const Eigen::Ref<const MatrixX<symbolic::Variable>>& gramian,
       const Eigen::Ref<const VectorX<symbolic::Monomial>>& monomial_basis,
-      NonnegativePolynomial type = NonnegativePolynomial::kSos);
+      NonnegativePolynomial type = NonnegativePolynomial::kSos,
+      bool small_gram_as_lorentz_cone = true);
 
   /**
    * Overloads NewSosPolynomial.
@@ -533,7 +550,8 @@ class MathematicalProgram {
   std::pair<symbolic::Polynomial, MatrixXDecisionVariable> NewSosPolynomial(
       const symbolic::Variables& indeterminates, int degree,
       NonnegativePolynomial type = NonnegativePolynomial::kSos,
-      const std::string& gram_name = "S");
+      const std::string& gram_name = "S",
+      bool small_gram_as_lorentz_cone = true);
 
   /**
    * @anchor even_degree_nonnegative_polynomial

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -505,6 +505,7 @@ class MathematicalProgram {
   /**
    * Overloads NewSosPolynomial, except the Gramian matrix Q is an
    * input instead of an output.
+   * @pre `gramian` is a symmetric matrix.
    */
   symbolic::Polynomial NewSosPolynomial(
       const Eigen::Ref<const MatrixX<symbolic::Variable>>& gramian,

--- a/solvers/test/csdp_solver_test.cc
+++ b/solvers/test/csdp_solver_test.cc
@@ -435,7 +435,7 @@ GTEST_TEST(TestSOS, MotzkinPolynomial) {
 }
 
 GTEST_TEST(TestSOS, UnivariateNonnegative1) {
-  UnivariateNonnegative1 dut;
+  UnivariateNonnegative1 dut{false /*small_gram_as_lorentz_cone*/};
   for (auto method : GetRemoveFreeVariableMethods()) {
     CsdpSolver solver;
     if (solver.available()) {

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -3328,6 +3328,43 @@ void CheckNewSosPolynomial(MathematicalProgram::NonnegativePolynomial type) {
   EXPECT_TRUE(p2.EqualTo(p_expected));
 }
 
+// Test NewSosPolynomial whose gram matrix has size 1x1 or 2x2.
+GTEST_TEST(TestMathematicalProgram, NewSosPolynomialSmallGram) {
+  MathematicalProgram prog;
+  // Check 1 x 1 matrix.
+  auto gramian1 = prog.NewSymmetricContinuousVariables<1>();
+  auto x = prog.NewIndeterminates<1>();
+  const auto p1 = prog.NewSosPolynomial(
+      gramian1, Vector1<symbolic::Monomial>(symbolic::Monomial(x(0))));
+  EXPECT_EQ(prog.bounding_box_constraints().size(), 1);
+  EXPECT_EQ(prog.bounding_box_constraints().front().variables().rows(), 1);
+  EXPECT_EQ(prog.bounding_box_constraints().front().variables()(0),
+            gramian1(0));
+  EXPECT_EQ(prog.bounding_box_constraints().front().evaluator()->lower_bound(),
+            Vector1d(0));
+  EXPECT_TRUE(std::isinf(
+      prog.bounding_box_constraints().front().evaluator()->upper_bound()(0)));
+
+  // Now check 2 x 2 matrix.
+  const auto gramian2 = prog.NewSymmetricContinuousVariables<2>();
+  const auto p2 = prog.NewSosPolynomial(
+      gramian2, Vector2<symbolic::Monomial>(symbolic::Monomial(),
+                                            symbolic::Monomial(x(0))));
+  EXPECT_EQ(prog.rotated_lorentz_cone_constraints().size(), 1);
+  EXPECT_TRUE(CompareMatrices(
+      prog.rotated_lorentz_cone_constraints().front().evaluator()->A_dense(),
+      Eigen::Matrix3d::Identity()));
+  EXPECT_TRUE(CompareMatrices(
+      prog.rotated_lorentz_cone_constraints().front().evaluator()->b(),
+      Eigen::Vector3d::Zero()));
+  EXPECT_EQ(prog.rotated_lorentz_cone_constraints().front().variables()(0),
+            gramian2(0, 0));
+  EXPECT_EQ(prog.rotated_lorentz_cone_constraints().front().variables()(1),
+            gramian2(1, 1));
+  EXPECT_EQ(prog.rotated_lorentz_cone_constraints().front().variables()(2),
+            gramian2(0, 1));
+}
+
 GTEST_TEST(TestMathematicalProgram, NewSosPolynomial) {
   CheckNewSosPolynomial(MathematicalProgram::NonnegativePolynomial::kSos);
   CheckNewSosPolynomial(MathematicalProgram::NonnegativePolynomial::kSdsos);
@@ -3371,7 +3408,7 @@ void CheckNewEvenDegreeNonnegativePolynomial(
   MathematicalProgram prog;
   auto t = prog.NewIndeterminates<2>();
   const symbolic::Variables t_vars(t);
-  const int degree{4};
+  const int degree{6};
   const auto m_e = symbolic::EvenDegreeMonomialBasis(t_vars, degree / 2);
   const auto m_o = symbolic::OddDegreeMonomialBasis(t_vars, degree / 2);
   symbolic::Polynomial p;
@@ -3645,11 +3682,11 @@ GTEST_TEST(TestMathematicalProgram, AddSosConstraint) {
 
   // p1 has both a and x as indeterminates. So we need to reparse the polynomial
   // to have only x as the indeterminates.
-  const symbolic::Polynomial p1(a + x * x);
-  const Vector2<symbolic::Monomial> monomial_basis(symbolic::Monomial{},
-                                                   symbolic::Monomial(x, 1));
+  const symbolic::Polynomial p1(a + x * x + pow(x, 4));
+  const Vector3<symbolic::Monomial> monomial_basis(
+      symbolic::Monomial{}, symbolic::Monomial(x, 1), symbolic::Monomial(x, 2));
 
-  const Matrix2<symbolic::Variable> Q_psd = prog.AddSosConstraint(
+  const Matrix3<symbolic::Variable> Q_psd = prog.AddSosConstraint(
       p1, monomial_basis, MathematicalProgram::NonnegativePolynomial::kSos,
       "Q");
   EXPECT_NE(Q_psd(0, 0).get_name().find("Q"), std::string::npos);

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -396,7 +396,7 @@ GTEST_TEST(MosekTest, SimpleSos1) {
   MosekSolver solver;
   if (solver.available()) {
     const auto result = solver.Solve(dut.prog());
-    dut.CheckResult(result, 2E-9);
+    dut.CheckResult(result, 1E-8);
   }
 }
 

--- a/solvers/test/sos_examples.cc
+++ b/solvers/test/sos_examples.cc
@@ -113,7 +113,8 @@ void MotzkinPolynomial::CheckResult(const MathematicalProgramResult& result,
   CheckSymmetricMatrixPSD(gram2_val, tol);
 }
 
-UnivariateNonnegative1::UnivariateNonnegative1() : prog_{} {
+UnivariateNonnegative1::UnivariateNonnegative1(bool small_gram_as_lorentz_cone)
+    : prog_{} {
   a_ = prog_.NewContinuousVariables<1>()(0);
   b_ = prog_.NewContinuousVariables<1>()(0);
   c_ = prog_.NewContinuousVariables<1>()(0);
@@ -126,7 +127,9 @@ UnivariateNonnegative1::UnivariateNonnegative1() : prog_{} {
   prog_.AddLinearEqualityConstraint(2 + a_ + b_ + c_ == 1);
   prog_.AddLinearCost(-a_ - b_ - c_);
   std::tie(s_, gram_s_) = prog_.NewSosPolynomial({x_}, 4);
-  std::tie(t_, gram_t_) = prog_.NewSosPolynomial({x_}, 2);
+  std::tie(t_, gram_t_) = prog_.NewSosPolynomial(
+      {x_}, 2, MathematicalProgram::NonnegativePolynomial::kSos,
+      "T" /* gram_name */, small_gram_as_lorentz_cone);
   prog_.AddEqualityConstraintBetweenPolynomials(p_, s_ + x_ * t_);
 }
 

--- a/solvers/test/sos_examples.h
+++ b/solvers/test/sos_examples.h
@@ -132,7 +132,9 @@ class UnivariateNonnegative1 {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(UnivariateNonnegative1)
 
-  UnivariateNonnegative1();
+  // @param small_gram_as_lorentz_cone Refer to
+  // MathematicalProgram::NewSosPolynomial for more details.
+  explicit UnivariateNonnegative1(bool small_gram_as_lorentz_cone = true);
 
   const MathematicalProgram& prog() const { return prog_; }
 


### PR DESCRIPTION
When calling NewSosPolynomial, if the gram matrix has size 1x1, add a bounding box constraint. if the gram matrix has size 2x2, add a rotated lorentz cone constraint.

This PR was submitted in #18562, but was reverted later due to failure on mac. Now I fixed the Mac failure and submit it again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18789)
<!-- Reviewable:end -->
