### PR TITLE
[multibody] const InverseKinematics no longer gives mutable access to members

### DIFF
--- a/multibody/inverse_kinematics/inverse_kinematics.h
+++ b/multibody/inverse_kinematics/inverse_kinematics.h
@@ -358,7 +358,7 @@ class InverseKinematics {
   const solvers::MathematicalProgram& prog() const { return *prog_; }
 
   /** Getter for the optimization program constructed by InverseKinematics. */
-  solvers::MathematicalProgram* get_mutable_prog() const { return prog_.get(); }
+  solvers::MathematicalProgram* get_mutable_prog() { return prog_.get(); }
 
   /** Getter for the plant context. */
   const systems::Context<double>& context() const { return *context_; }


### PR DESCRIPTION
The `get_mutable_prog()` was mistakenly tagged as const.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18793)
<!-- Reviewable:end -->
