### PR TITLE
Ignore collision filter groups from model directives if there's no scene graph

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -406,7 +406,7 @@ drake_cc_googletest(
     deps = [
         ":process_model_directives",
         ":scoped_names",
-        "//common/test_utilities:expect_throws_message",
+        "//common/test_utilities",
     ],
 )
 

--- a/multibody/parsing/detail_dmd_parser.cc
+++ b/multibody/parsing/detail_dmd_parser.cc
@@ -138,6 +138,13 @@ void ParseModelDirectivesImpl(
           X_PC, plant, added_models);
 
     } else if (directive.add_collision_filter_group) {
+      // If there's no geometry registered, there's nothing to be done with
+      // collision filtering.  Trying to proceed will just trigger an error
+      // eventually.
+      if (!plant->geometry_source_is_registered()) {
+        continue;
+      }
+
       // Find the model instance index that corresponds to model_namespace, if
       // the name is non-empty.
       std::optional<ModelInstanceIndex> model_instance;
@@ -260,4 +267,3 @@ std::vector<ModelInstanceIndex> DmdParserWrapper::AddAllModels(
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake
-

--- a/multibody/parsing/test/process_model_directives_test.cc
+++ b/multibody/parsing/test/process_model_directives_test.cc
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/parsing/scoped_names.h"
@@ -309,6 +310,20 @@ GTEST_TEST(ProcessModelDirectivesTest, CollisionFilterGroupSmokeTest) {
     {"nested::sub_model1::collision", "nested::sub_model2::collision"},
   };
   VerifyCollisionFilters(scene_graph, expected_filters);
+}
+
+// Test collision filter groups in ModelDirectives.
+GTEST_TEST(ProcessModelDirectivesTest, CollisionFilterGroupNoSceneGraph) {
+  ModelDirectives directives = LoadModelDirectives(
+      FindResourceOrThrow(std::string(kTestDir) +
+                          "/collision_filter_group.dmd.yaml"));
+
+
+  MultibodyPlant<double> plant(0.0);
+  ASSERT_FALSE(plant.geometry_source_is_registered());
+  DRAKE_EXPECT_NO_THROW(
+      ProcessModelDirectives(directives, &plant,
+                             nullptr, make_parser(&plant).get()));
 }
 
 // Test collision filter groups in ModelDirectives.


### PR DESCRIPTION
The SDF  and URDF parsers already do this, it  was missing from the model directives parser.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18798)
<!-- Reviewable:end -->
