### PR TITLE
Move the distal geometry for the Jaco arm to link 7

### DIFF
--- a/manipulation/models/jaco_description/urdf/j2s7s300_arm_sphere_collision.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300_arm_sphere_collision.urdf
@@ -566,12 +566,6 @@
         <sphere radius="0.035"/>
       </geometry>
     </collision>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0.1 -0.0"/>
-      <geometry>
-        <sphere radius="0.035"/>
-      </geometry>
-    </collision>
     <inertial>
       <mass value="0.463"/>
       <origin xyz="0 0.0497208855 -0.0028562765"/>
@@ -596,6 +590,12 @@
     </actuator>
   </transmission>
   <link name="j2s7s300_link_7">
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0.00375"/>
+      <geometry>
+        <sphere radius="0.035"/>
+      </geometry>
+    </collision>
     <inertial>
       <!-- TODO(sammy-tri) This inertial is bogus with the hand removed. -->
       <mass value="0.001"/>


### PR DESCRIPTION
This doesn't actually affect the collision geometry of the arm -- moving a sphere across a revolute joint has no effect.  What it does do is make the adjacent link collision filtering work more effectively so that attaching a gripper to this model doesn't create a self collision.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18799)
<!-- Reviewable:end -->
