### PR TITLE
[common] Add infrastructure to opt-in to fmt via ostream

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -77,6 +77,7 @@ drake_cc_library(
         "drake_throw.h",
         "eigen_types.h",
         "fmt.h",
+        "fmt_ostream.h",
         "never_destroyed.h",
         "text_logging.h",
     ],
@@ -887,6 +888,13 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "fmt_test",
+    deps = [
+        ":essential",
+    ],
+)
+
+drake_cc_googletest(
+    name = "fmt_ostream_test",
     deps = [
         ":essential",
     ],

--- a/common/fmt.h
+++ b/common/fmt.h
@@ -10,13 +10,14 @@
 namespace drake {
 
 #if FMT_VERSION >= 80000 || defined(DRAKE_DOXYGEN_CXX)
-/** When using fmt >= 8, this is an alias for fmt::runtime.
+/** When using fmt >= 8, this is an alias for
+<a href="https://fmt.dev/latest/api.html#compile-time-format-string-checks">fmt::runtime</a>.
 When using fmt < 8, this is a no-op. */
 inline auto fmt_runtime(std::string_view s) {
   return fmt::runtime(s);
 }
 /** When using fmt >= 8, this is defined to be `const` to indicate that the
-fmt::formatter<T>::format(...) function should be object-const.
+`fmt::formatter<T>::format(...)` function should be object-const.
 When using fmt < 8, the function signature was incorrect (lacking the const),
 so this macro will be empty. */
 #define DRAKE_FMT8_CONST const

--- a/common/fmt_ostream.h
+++ b/common/fmt_ostream.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <sstream>
+#include <string_view>
+
+#include <fmt/ostream.h>
+
+#include "drake/common/fmt.h"
+
+namespace drake {
+
+// Compatibility shim for fmt::streamed.
+#if FMT_VERSION >= 90000 || defined(DRAKE_DOXYGEN_CXX)
+/** When using fmt >= 9, this is an alias for
+<a href="https://fmt.dev/latest/api.html#ostream-api">fmt::streamed</a>.
+When using fmt < 9, this uses a polyfill instead.
+
+Within Drake, the nominal use for `fmt::streamed` is when formatting third-party
+types that provide `operator<<` support but not `fmt::formatter<T>` support.
+Once we stop using `FMT_DEPRECATED_OSTREAM=1`, compilation errors will help you
+understand where you are required to use this wrapper. */
+template <typename T>
+auto fmt_streamed(const T& ref) { return fmt::streamed(ref); }
+#else  // FMT_VERSION
+namespace internal {
+template <typename T> struct streamed_ref { const T& ref; };
+}  // namespace internal
+template <typename T>
+internal::streamed_ref<T> fmt_streamed(const T& ref) { return {ref}; }
+#endif  // FMT_VERSION
+
+// Compatibility shim for fmt::ostream_formatter.
+#if FMT_VERSION >= 90000
+/** When using fmt >= 9, this is an alias for fmt::ostream_formatter.
+When using fmt < 9, this uses a polyfill instead. */
+using fmt::ostream_formatter;
+#else  // FMT_VERSION
+struct ostream_formatter : fmt::formatter<std::string_view> {
+  template <typename T, typename FormatContext>
+  auto format(const T& value,
+              // NOLINTNEXTLINE(runtime/references) To match fmt API.
+              FormatContext& ctx) DRAKE_FMT8_CONST {
+    std::ostringstream output;
+    output << value;
+    output.exceptions(std::ios_base::failbit | std::ios_base::badbit);
+    return fmt::formatter<std::string_view>::format(output.str(), ctx);
+  }
+};
+#endif  // FMT_VERSION
+
+}  // namespace drake
+
+// Formatter specialization for drake::fmt_streamed.
+#if FMT_VERSION < 90000
+namespace fmt {
+template <typename T>
+struct formatter<drake::internal::streamed_ref<T>> : drake::ostream_formatter {
+  template <typename FormatContext>
+  auto format(drake::internal::streamed_ref<T> tag,
+              // NOLINTNEXTLINE(runtime/references) To match fmt API.
+              FormatContext& ctx) DRAKE_FMT8_CONST {
+    return ostream_formatter::format(tag.ref, ctx);
+  }
+};
+}  // namespace fmt
+#endif  // FMT_VERSION

--- a/common/test/fmt_ostream_test.cc
+++ b/common/test/fmt_ostream_test.cc
@@ -1,0 +1,58 @@
+#include "drake/common/fmt_ostream.h"
+
+#include <gtest/gtest.h>
+
+// Sample code that shows how to shim Drake code that defines an operator<< to
+// interface with fmt >= 9 semantics. The ostream_formatter is intended to be a
+// porting shim for #17742 and will probably be deleted eventually, once all
+// of Drake is using fmt pervasively.
+namespace sample {
+class UnportedStreamable {
+ public:
+  friend std::ostream& operator<<(std::ostream& os, const UnportedStreamable&) {
+    return os << "US";
+  }
+};
+}  // namespace sample
+namespace fmt {
+template <>
+struct formatter<sample::UnportedStreamable> : drake::ostream_formatter {};
+}  // namespace fmt
+
+// Sample code that shows how to print a third-party type that only supports
+// operator<< and not fmt::formatter. We plan to keep this sugar indefinitely,
+// since many third-party types will never know about fmt::formatter.
+namespace sample {
+class ThirdPartyStreamable {
+ public:
+  ThirdPartyStreamable() = default;
+
+  // Non-copyable.
+  ThirdPartyStreamable(const ThirdPartyStreamable&) = delete;
+
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const ThirdPartyStreamable&) {
+    return os << "TPS";
+  }
+};
+}  // namespace sample
+
+namespace drake {
+namespace {
+
+GTEST_TEST(FmtOstreamTest, UnportedOstreamShim) {
+  const sample::UnportedStreamable value;
+  EXPECT_EQ(fmt::format("{}", value), "US");
+  EXPECT_EQ(fmt::format("{:4}", value), "US  ");
+  EXPECT_EQ(fmt::format("{:>4}", value), "  US");
+}
+
+GTEST_TEST(FmtOstreamTest, ThirdPartyOstreamShim) {
+  const sample::ThirdPartyStreamable value;
+  EXPECT_EQ(fmt::format("{}", fmt_streamed(value)), "TPS");
+  EXPECT_EQ(fmt::format("{:4}", fmt_streamed(value)), "TPS ");
+  EXPECT_EQ(fmt::format("{:>4}", fmt_streamed(value)), " TPS");
+}
+
+}  // namespace
+}  // namespace drake

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -692,5 +692,13 @@ using RigidTransformd = RigidTransform<double>;
 }  // namespace math
 }  // namespace drake
 
+// Format RigidTransform using its operator<<.
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <typename T>
+struct formatter<drake::math::RigidTransform<T>>
+    : drake::ostream_formatter {};
+}  // namespace fmt
+
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::math::RigidTransform)

--- a/math/roll_pitch_yaw.cc
+++ b/math/roll_pitch_yaw.cc
@@ -238,7 +238,7 @@ std::ostream& operator<<(std::ostream& out, const RollPitchYaw<T>& rpy) {
   // Helper to represent an angle as a terse string.  If the angle is symbolic
   // and ends up a string that's too long, return a placeholder instead.
   auto repr = [](const T& angle) {
-    std::string result = fmt::format("{}", angle);
+    std::string result = fmt::to_string(angle);
     if (std::is_same_v<T, symbolic::Expression> && (result.size() >= 30)) {
       result = "<symbolic>";
     }

--- a/math/roll_pitch_yaw.h
+++ b/math/roll_pitch_yaw.h
@@ -10,6 +10,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt_ostream.h"
 
 namespace drake {
 namespace math {
@@ -663,6 +664,14 @@ using RollPitchYawd = RollPitchYaw<double>;
 
 }  // namespace math
 }  // namespace drake
+
+// Format RollPitchYaw using its operator<<.
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <typename T>
+struct formatter<drake::math::RollPitchYaw<T>>
+    : drake::ostream_formatter {};
+}  // namespace fmt
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::math::RollPitchYaw)

--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -7,13 +7,13 @@
 #include <sstream>
 #include <vector>
 
-#include "fmt/ostream.h"
 #include <drake_vendor/sdf/Root.hh>
 #include <drake_vendor/sdf/parser.hh>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/geometry_instance.h"
@@ -75,7 +75,7 @@ sdf::SDFPtr ReadString(const std::string& input) {
   const bool success = sdf::readString(input, config, result, errors);
   if (!success) {
     for (const auto& error : errors) {
-      drake::log()->error("Parse error: {}", error);
+      drake::log()->error("Parse error: {}", fmt_streamed(error));
     }
     // Note that we don't throw here, we just spam the console.  This is not
     // great, but it matches the pre-existing behavior which wants this helper


### PR DESCRIPTION
Towards #17742.

The "feature" here is the `fmt::streamed` and `fmt::ostream_formatter` polyfills.

---

This is a microcosm of the coming porting.  As one of the next steps in porting, we'll add snippets like this ...

```c++
// Format RollPitchYaw using its operator<<.
// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
namespace fmt {
template <typename T>
struct formatter<drake::math::RollPitchYaw<T>>
    : drake::ostream_formatter {};
}  // namespace fmt
```

... to any Drake class that provides an `operator<<`.  I've decided not to sugar that up with a macro, because they will all soon thereafter be replaced with proper formatters, and the sugar isn't a huge win anyway.

+@SeanCurtis-TRI for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18801)
<!-- Reviewable:end -->
