### PR TITLE
Canonicalize fmt include spellings

### DIFF
--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -1,12 +1,12 @@
 #include <map>
 #include <string>
 
-#include "fmt/format.h"
-#include "fmt/ostream.h"
 #include "pybind11/eigen.h"
 #include "pybind11/operators.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_pybind.h"

--- a/bindings/pydrake/symbolic_py_unapply.cc
+++ b/bindings/pydrake/symbolic_py_unapply.cc
@@ -1,8 +1,8 @@
 #include "drake/bindings/pydrake/symbolic_py_unapply.h"
 
-#include "fmt/format.h"
-#include "fmt/ostream.h"
 #include "pybind11/stl.h"
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 
 namespace drake {
 namespace pydrake {

--- a/common/find_runfiles.cc
+++ b/common/find_runfiles.cc
@@ -10,8 +10,8 @@
 
 #include <filesystem>
 
-#include "fmt/format.h"
 #include "tools/cpp/runfiles/runfiles.h"
+#include <fmt/format.h>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/never_destroyed.h"

--- a/examples/pendulum/pendulum_parameters_derivatives.cc
+++ b/examples/pendulum/pendulum_parameters_derivatives.cc
@@ -1,4 +1,4 @@
-#include "fmt/ostream.h"
+#include <fmt/ostream.h>
 
 #include "drake/common/eigen_types.h"
 #include "drake/examples/pendulum/gen/pendulum_input.h"

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -1,7 +1,7 @@
 #include <memory>
 #include <string>
 
-#include "fmt/ostream.h"
+#include <fmt/ostream.h>
 #include <gflags/gflags.h>
 
 #include "drake/common/drake_assert.h"

--- a/geometry/benchmarking/mesh_intersection_benchmark.cc
+++ b/geometry/benchmarking/mesh_intersection_benchmark.cc
@@ -1,7 +1,7 @@
 #include <iostream>
 
-#include "fmt/format.h"
 #include <benchmark/benchmark.h>
+#include <fmt/format.h>
 
 #include "drake/geometry/proximity/make_ellipsoid_field.h"
 #include "drake/geometry/proximity/make_ellipsoid_mesh.h"

--- a/geometry/benchmarking/render_benchmark.cc
+++ b/geometry/benchmarking/render_benchmark.cc
@@ -2,8 +2,8 @@
 
 #include <filesystem>
 
-#include "fmt/format.h"
 #include <benchmark/benchmark.h>
+#include <fmt/format.h>
 #include <gflags/gflags.h>
 
 #include "drake/geometry/render_gl/factory.h"

--- a/geometry/geometry_properties.h
+++ b/geometry/geometry_properties.h
@@ -7,8 +7,8 @@
 #include <typeinfo>
 #include <unordered_map>
 
-#include "fmt/ostream.h"
 #include <Eigen/Dense>
+#include <fmt/ostream.h>
 
 #include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/never_destroyed.h"

--- a/multibody/contact_solvers/sap/partial_permutation.cc
+++ b/multibody/contact_solvers/sap/partial_permutation.cc
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <utility>
 
-#include "fmt/format.h"
+#include <fmt/format.h>
 
 #include "drake/common/drake_throw.h"
 

--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -7,9 +7,9 @@
 #include <sstream>
 #include <vector>
 
-#include "fmt/ostream.h"
 #include <drake_vendor/sdf/Root.hh>
 #include <drake_vendor/sdf/parser.hh>
+#include <fmt/ostream.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/solvers/solver_options.cc
+++ b/solvers/solver_options.cc
@@ -4,8 +4,8 @@
 #include <sstream>
 #include <utility>
 
-#include "fmt/format.h"
-#include "fmt/ostream.h"
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 
 #include "drake/common/never_destroyed.h"
 

--- a/systems/lcm/lcm_interface_system.cc
+++ b/systems/lcm/lcm_interface_system.cc
@@ -3,7 +3,7 @@
 #include <limits>
 #include <utility>
 
-#include "fmt/format.h"
+#include <fmt/format.h>
 
 #include "drake/lcm/drake_lcm.h"
 

--- a/systems/sensors/image_writer.cc
+++ b/systems/sensors/image_writer.cc
@@ -8,7 +8,7 @@
 #include <utility>
 #include <vector>
 
-#include "fmt/ostream.h"
+#include <fmt/ostream.h>
 #include <vtkImageData.h>
 #include <vtkNew.h>
 #include <vtkPNGWriter.h>


### PR DESCRIPTION
Towards #17742.  Having everything use `<>` makes it a lot easier to grep for places that need adjustments.

+@SeanCurtis-TRI for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18805)
<!-- Reviewable:end -->
