### PR TITLE
Add formatter specializations throughout the codebase

### DIFF
--- a/common/ad/auto_diff.h
+++ b/common/ad/auto_diff.h
@@ -3,6 +3,7 @@
 #include "drake/common/ad/internal/partials.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt.h"
 
 namespace drake {
 namespace ad {
@@ -109,3 +110,6 @@ class AutoDiff {
 /* clang-format off to disable clang-format-includes */
 // These further refine our AutoDiff type and must appear in exactly this order.
 #include "drake/common/ad/internal/standard_operations.h"
+
+/* Formats the `value()` part of x to the stream. */
+DRAKE_FORMATTER_AS(, drake::ad, AutoDiff, x, x.value())

--- a/common/ad/internal/standard_operations.h
+++ b/common/ad/internal/standard_operations.h
@@ -566,6 +566,7 @@ inline bool isnan(const AutoDiff& x) {
 /// @name Miscellaneous functions
 //@{
 
+// TODO(jwnimmer-tri) Deprecate me.
 /** Outputs the `value()` part of x to the stream.
 To output the derivatives use `<< x.derivatives().transpose()`. */
 std::ostream& operator<<(std::ostream& s, const AutoDiff& x);

--- a/common/identifier.h
+++ b/common/identifier.h
@@ -7,6 +7,7 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/hash.h"
 
 namespace drake {
@@ -255,3 +256,10 @@ template <typename Tag>
 struct hash<drake::Identifier<Tag>> : public drake::DefaultHash {};
 
 }  // namespace std
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <typename Tag>
+struct formatter<drake::Identifier<Tag>>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/common/polynomial.h
+++ b/common/polynomial.h
@@ -15,6 +15,7 @@
 #include "drake/common/autodiff.h"
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/symbolic/expression.h"
 
 namespace drake {
@@ -411,6 +412,7 @@ class Polynomial {
    */
   static Polynomial<T> FromExpression(const drake::symbolic::Expression& e);
 
+  // TODO(jwnimmer-tri) Rewrite this as a fmt::formatter specialization.
   friend std::ostream& operator<<(std::ostream& os, const Monomial& m) {
     //    if (m.coefficient == 0) return os;
 
@@ -436,6 +438,7 @@ class Polynomial {
     return os;
   }
 
+  // TODO(jwnimmer-tri) Rewrite this as a fmt::formatter specialization.
   friend std::ostream& operator<<(std::ostream& os, const Polynomial& poly) {
     if (poly.monomials_.empty()) {
       os << "0";
@@ -494,6 +497,8 @@ Polynomial<T> pow(
   }
 }
 
+// TODO(jwnimmer-tri) Rewrite this as a fmt::formatter specialization,
+// most likely just fmt_eigen without anything extra.
 template <typename T, int Rows, int Cols>
 std::ostream& operator<<(
     std::ostream& os,
@@ -514,6 +519,16 @@ typedef Polynomial<double> Polynomiald;
 /// A column vector of polynomials; used in several optimization classes.
 typedef Eigen::Matrix<Polynomiald, Eigen::Dynamic, 1> VectorXPoly;
 }  // namespace drake
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <typename T>
+struct formatter<drake::Polynomial<T>>
+    : drake::ostream_formatter {};
+template <>
+struct formatter<drake::Polynomial<double>::Monomial>
+    : drake::ostream_formatter {};
+}  // namespace fmt
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::Polynomial)

--- a/common/sorted_pair.h
+++ b/common/sorted_pair.h
@@ -107,6 +107,10 @@ struct SortedPair {
     if constexpr (Index == 0) return first_;
     if constexpr (Index == 1) return second_;
   }
+  template <std::size_t Index>
+  friend const T& get(const SortedPair<T>& self) {
+    return self.get<Index>();
+  }
   //@}
 
  private:

--- a/common/symbolic/chebyshev_basis_element.h
+++ b/common/symbolic/chebyshev_basis_element.h
@@ -4,6 +4,7 @@
 #include <utility>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/hash.h"
 #include "drake/common/symbolic/polynomial_basis_element.h"
 
@@ -150,3 +151,10 @@ struct NumTraits<drake::symbolic::ChebyshevBasisElement>
 };
 }  // namespace Eigen
 #endif  // !defined(DRAKE_DOXYGEN_CXX)
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<drake::symbolic::ChebyshevBasisElement>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/common/symbolic/chebyshev_polynomial.h
+++ b/common/symbolic/chebyshev_polynomial.h
@@ -7,6 +7,7 @@
 #include <Eigen/Core>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/hash.h"
 #include "drake/common/symbolic/expression.h"
 #include "drake/common/symbolic/polynomial.h"
@@ -130,3 +131,10 @@ template <>
 struct hash<drake::symbolic::ChebyshevPolynomial> : public drake::DefaultHash {
 };
 }  // namespace std
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<drake::symbolic::ChebyshevPolynomial>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/common/symbolic/expression/environment.h
+++ b/common/symbolic/expression/environment.h
@@ -11,6 +11,7 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt.h"
 #include "drake/common/random.h"
 
 namespace drake {
@@ -163,3 +164,5 @@ Environment PopulateRandomVariables(Environment env, const Variables& variables,
 
 }  // namespace symbolic
 }  // namespace drake
+
+DRAKE_FORMATTER_AS(, drake::symbolic, Environment, env, env.to_string())

--- a/common/symbolic/expression/expression.h
+++ b/common/symbolic/expression/expression.h
@@ -29,6 +29,7 @@
 #include "drake/common/dummy_value.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/extract_double.h"
+#include "drake/common/fmt.h"
 #include "drake/common/hash.h"
 #include "drake/common/random.h"
 
@@ -1028,6 +1029,7 @@ inline bool operator!=(
   return !(lhs == rhs);
 }
 
+// TODO(jwnimmer-tri) Rewrite this as a fmt::formatter specialization.
 inline std::ostream& operator<<(
     std::ostream& os,
     const uniform_real_distribution<drake::symbolic::Expression>& d) {
@@ -1169,6 +1171,7 @@ inline bool operator!=(
   return !(lhs == rhs);
 }
 
+// TODO(jwnimmer-tri) Rewrite this as a fmt::formatter specialization.
 inline std::ostream& operator<<(
     std::ostream& os,
     const normal_distribution<drake::symbolic::Expression>& d) {
@@ -1267,6 +1270,7 @@ inline bool operator!=(
   return !(lhs == rhs);
 }
 
+// TODO(jwnimmer-tri) Rewrite this as a fmt::formatter specialization.
 inline std::ostream& operator<<(
     std::ostream& os,
     const exponential_distribution<drake::symbolic::Expression>& d) {
@@ -1621,3 +1625,5 @@ struct is_eigen_vector_expression_double_pair
               is_eigen_vector_of<DerivedB, double>::value> {};
 
 }  // namespace drake
+
+DRAKE_FORMATTER_AS(, drake::symbolic, Expression, e, e.to_string())

--- a/common/symbolic/expression/formula.h
+++ b/common/symbolic/expression/formula.h
@@ -17,6 +17,7 @@
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt.h"
 #include "drake/common/hash.h"
 #include "drake/common/random.h"
 
@@ -1407,3 +1408,5 @@ EIGEN_STRONG_INLINE bool isnan(const drake::symbolic::Expression& e) {
 }  // namespace numext
 }  // namespace Eigen
 #endif  // !defined(DRAKE_DOXYGEN_CXX)
+
+DRAKE_FORMATTER_AS(, drake::symbolic, Formula, f, f.to_string())

--- a/common/symbolic/expression/variable.h
+++ b/common/symbolic/expression/variable.h
@@ -14,6 +14,7 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/hash.h"
 
 namespace drake {
@@ -366,3 +367,10 @@ CheckStructuralEquality(const DerivedA& m1, const DerivedB& m2) {
 }
 }  // namespace symbolic
 }  // namespace drake
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<drake::symbolic::Variable>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/common/symbolic/expression/variables.h
+++ b/common/symbolic/expression/variables.h
@@ -12,6 +12,7 @@
 #include <string>
 
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt.h"
 #include "drake/common/hash.h"
 
 namespace drake {
@@ -182,3 +183,5 @@ namespace std {
 template <>
 struct hash<drake::symbolic::Variables> : public drake::DefaultHash {};
 }  // namespace std
+
+DRAKE_FORMATTER_AS(, drake::symbolic, Variables, vs, vs.to_string())

--- a/common/symbolic/generic_polynomial.h
+++ b/common/symbolic/generic_polynomial.h
@@ -7,6 +7,7 @@
 #include <fmt/format.h>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/symbolic/chebyshev_basis_element.h"
 #include "drake/common/symbolic/expression.h"
 #include "drake/common/symbolic/monomial_basis_element.h"
@@ -558,3 +559,11 @@ struct NumTraits<
 };
 }  // namespace Eigen
 #endif  // !defined(DRAKE_DOXYGEN_CXX)
+
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <typename BasisElement>
+struct formatter<drake::symbolic::GenericPolynomial<BasisElement>>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/common/symbolic/monomial.h
+++ b/common/symbolic/monomial.h
@@ -8,6 +8,7 @@
 #include <Eigen/Core>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/hash.h"
 #include "drake/common/symbolic/expression.h"
 
@@ -193,4 +194,11 @@ EIGEN_DEVICE_FUNC inline drake::symbolic::Expression cast(
 }
 }  // namespace internal
 }  // namespace Eigen
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<drake::symbolic::Monomial> : drake::ostream_formatter {};
+}  // namespace fmt
+
 #endif  // !defined(DRAKE_DOXYGEN_CXX)

--- a/common/symbolic/monomial_basis_element.h
+++ b/common/symbolic/monomial_basis_element.h
@@ -6,6 +6,7 @@
 #include <Eigen/Core>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/hash.h"
 #include "drake/common/symbolic/chebyshev_basis_element.h"
 #include "drake/common/symbolic/polynomial_basis_element.h"
@@ -233,3 +234,11 @@ EIGEN_DEVICE_FUNC inline drake::symbolic::Expression cast(
 }  // namespace internal
 }  // namespace Eigen
 #endif  // !defined(DRAKE_DOXYGEN_CXX)
+
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<drake::symbolic::MonomialBasisElement>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/common/symbolic/polynomial.h
+++ b/common/symbolic/polynomial.h
@@ -11,6 +11,7 @@
 #include <Eigen/Core>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/symbolic/expression.h"
 #define DRAKE_COMMON_SYMBOLIC_POLYNOMIAL_H
 #include "drake/common/symbolic/monomial.h"
@@ -675,3 +676,11 @@ CalcPolynomialWLowerTriangularPart(
 }
 }  // namespace symbolic
 }  // namespace drake
+
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<drake::symbolic::Polynomial>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/common/symbolic/rational_function.h
+++ b/common/symbolic/rational_function.h
@@ -2,6 +2,7 @@
 
 #include <ostream>
 
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/symbolic/polynomial.h"
 
 namespace drake {
@@ -324,3 +325,11 @@ EIGEN_STRONG_INLINE bool not_equal_strict(
 }  // namespace numext
 }  // namespace Eigen
 #endif  // !defined(DRAKE_DOXYGEN_CXX)
+
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<drake::symbolic::RationalFunction>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/common/type_safe_index.h
+++ b/common/type_safe_index.h
@@ -7,6 +7,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_throw.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/hash.h"
 #include "drake/common/nice_type_name.h"
 
@@ -586,3 +587,10 @@ namespace std {
 template <typename Tag>
 struct hash<drake::TypeSafeIndex<Tag>> : public drake::DefaultHash {};
 }  // namespace std
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <typename Tag>
+struct formatter<drake::TypeSafeIndex<Tag>>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/common/yaml/BUILD.bazel
+++ b/common/yaml/BUILD.bazel
@@ -27,6 +27,9 @@ drake_cc_library(
     name = "yaml_io_options",
     srcs = ["yaml_io_options.cc"],
     hdrs = ["yaml_io_options.h"],
+    deps = [
+        "//common:essential",
+    ],
 )
 
 drake_cc_library(

--- a/common/yaml/yaml_io_options.h
+++ b/common/yaml/yaml_io_options.h
@@ -2,6 +2,8 @@
 
 #include <ostream>
 
+#include "drake/common/fmt_ostream.h"
+
 namespace drake {
 namespace yaml {
 
@@ -30,3 +32,11 @@ struct LoadYamlOptions {
 
 }  // namespace yaml
 }  // namespace drake
+
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<drake::yaml::LoadYamlOptions>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/common/yaml/yaml_node.h
+++ b/common/yaml/yaml_node.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/fmt_ostream.h"
 
 // Note that even though this file contains "class Node", the file is named
 // "yaml_node.h" not "node.h" to avoid conflict with "yaml-cpp/node/node.h".
@@ -244,3 +245,10 @@ class Node final {
 }  // namespace internal
 }  // namespace yaml
 }  // namespace drake
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<drake::yaml::internal::Node>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/geometry/geometry_ids.h
+++ b/geometry/geometry_ids.h
@@ -57,3 +57,12 @@ struct hash<drake::geometry::GeometryId> {
 };
 
 }  // namespace std
+
+// Tell fmt to use the Identifier formatter for GeometryId values. By default,
+// fmt wouldn't find the Identifier<GeometryTag> formatter because GeometryId
+// inherits from Identifier instead of using a typedef.
+namespace fmt {
+template <>
+struct formatter<drake::geometry::GeometryId>
+    : public formatter<drake::Identifier<drake::geometry::GeometryTag>> {};
+}  // namespace fmt

--- a/geometry/geometry_properties.h
+++ b/geometry/geometry_properties.h
@@ -11,6 +11,7 @@
 #include <fmt/ostream.h>
 
 #include "drake/common/copyable_unique_ptr.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/never_destroyed.h"
 #include "drake/common/value.h"
 #include "drake/geometry/rgba.h"
@@ -501,3 +502,11 @@ class GeometryProperties {
 
 }  // namespace geometry
 }  // namespace drake
+
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<drake::geometry::GeometryProperties>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/geometry/geometry_roles.h
+++ b/geometry/geometry_roles.h
@@ -5,6 +5,7 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/geometry/geometry_properties.h"
 
 namespace drake {
@@ -227,3 +228,9 @@ IllustrationProperties MakePhongIllustrationProperties(
 
 }  // namespace geometry
 }  // namespace drake
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<drake::geometry::Role> : drake::ostream_formatter {};
+}  // namespace fmt

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -10,6 +10,7 @@
 #include <optional>
 #include <ostream>
 
+#include "drake/common/fmt_ostream.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/multibody/plant/coulomb_friction.h"
 
@@ -177,3 +178,10 @@ void AddCompliantHydroelasticPropertiesForHalfSpace(
 
 }  // namespace geometry
 }  // namespace drake
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<drake::geometry::internal::HydroelasticType>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/geometry/render/render_label.h
+++ b/geometry/render/render_label.h
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/hash.h"
 #include "drake/systems/sensors/pixel_types.h"
 
@@ -182,3 +183,10 @@ struct hash<drake::geometry::render::RenderLabel>
   : public drake::DefaultHash {};
 
 }  // namespace std
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<drake::geometry::render::RenderLabel>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -7,6 +7,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/math/rigid_transform.h"
 
 /** @file
@@ -510,3 +511,10 @@ double CalcVolume(const Shape& shape);
 
 }  // namespace geometry
 }  // namespace drake
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<drake::geometry::ShapeName>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -9,6 +9,7 @@
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/never_destroyed.h"
 #include "drake/math/rotation_matrix.h"
 

--- a/multibody/inverse_kinematics/differential_inverse_kinematics.h
+++ b/multibody/inverse_kinematics/differential_inverse_kinematics.h
@@ -13,6 +13,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/math/spatial_algebra.h"
 #include "drake/multibody/plant/multibody_plant.h"
@@ -410,3 +411,9 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
 
 }  // namespace multibody
 }  // namespace drake
+
+namespace fmt {
+template <>
+struct formatter<drake::multibody::DifferentialInverseKinematicsStatus>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/multibody/math/spatial_vector.h
+++ b/multibody/math/spatial_vector.h
@@ -10,6 +10,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/math/rotation_matrix.h"
 
 namespace drake {
@@ -310,3 +311,10 @@ std::ostream& operator<<(std::ostream& o,
 
 }  // namespace multibody
 }  // namespace drake
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <template <typename> class SpatialQuantity, typename T>
+struct formatter<drake::multibody::SpatialVector<SpatialQuantity, T>>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/multibody/parsing/package_map.h
+++ b/multibody/parsing/package_map.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/fmt_ostream.h"
 
 namespace drake {
 namespace multibody {
@@ -159,3 +160,10 @@ class PackageMap final {
 
 }  // namespace multibody
 }  // namespace drake
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<drake::multibody::PackageMap>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -19,6 +19,7 @@
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/extract_double.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/math/rotation_matrix.h"
 
 namespace drake {
@@ -1180,6 +1181,13 @@ RotationalInertia<T>& RotationalInertia<T>::ReExpressInPlace(
 
 }  // namespace multibody
 }  // namespace drake
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <typename T>
+struct formatter<drake::multibody::RotationalInertia<T>>
+    : drake::ostream_formatter {};
+}  // namespace fmt
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::RotationalInertia)

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -11,6 +11,7 @@
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/text_logging.h"
 #include "drake/math/cross_product.h"
 #include "drake/math/rotation_matrix.h"
@@ -652,6 +653,13 @@ std::ostream& operator<<(std::ostream& out, const SpatialInertia<T>& M);
 
 }  // namespace multibody
 }  // namespace drake
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <typename T>
+struct formatter<drake::multibody::SpatialInertia<T>>
+    : drake::ostream_formatter {};
+}  // namespace fmt
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::SpatialInertia)

--- a/perception/point_cloud_flags.h
+++ b/perception/point_cloud_flags.h
@@ -6,6 +6,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/fmt_ostream.h"
 
 namespace drake {
 namespace perception {
@@ -199,3 +200,11 @@ inline Fields operator|(const DescriptorType& lhs, const Fields& rhs) {
 
 }  // namespace perception
 }  // namespace drake
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<drake::perception::pc_flags::Fields>
+    : drake::ostream_formatter {};
+}  // namespace fmt
+

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -669,6 +669,9 @@ drake_cc_library(
     name = "solution_result",
     srcs = ["solution_result.cc"],
     hdrs = ["solution_result.h"],
+    deps = [
+        "//common:essential",
+    ],
 )
 
 drake_cc_library(

--- a/solvers/binding.h
+++ b/solvers/binding.h
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/hash.h"
 #include "drake/solvers/decision_variable.h"
 #include "drake/solvers/evaluator_base.h"
@@ -168,3 +169,11 @@ namespace std {
 template <typename C>
 struct hash<drake::solvers::Binding<C>> : public drake::DefaultHash {};
 }  // namespace std
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <typename C>
+struct formatter<drake::solvers::Binding<C>>
+    : drake::ostream_formatter {};
+}  // namespace fmt
+

--- a/solvers/common_solver_option.h
+++ b/solvers/common_solver_option.h
@@ -2,6 +2,8 @@
 
 #include <ostream>
 
+#include "drake/common/fmt_ostream.h"
+
 namespace drake {
 namespace solvers {
 /**
@@ -31,3 +33,10 @@ std::ostream& operator<<(std::ostream& os,
                          CommonSolverOption common_solver_option);
 }  // namespace solvers
 }  // namespace drake
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<drake::solvers::CommonSolverOption>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/solvers/evaluator_base.h
+++ b/solvers/evaluator_base.h
@@ -12,6 +12,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/polynomial.h"
 #include "drake/common/symbolic/expression.h"
 #include "drake/math/autodiff.h"
@@ -385,3 +386,12 @@ class VisualizationCallback : public EvaluatorBase {
 
 }  // namespace solvers
 }  // namespace drake
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <typename T>
+struct formatter<
+    T,
+    std::enable_if_t<std::is_base_of_v<drake::solvers::EvaluatorBase, T>, char>>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -23,6 +23,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt.h"
 #include "drake/common/polynomial.h"
 #include "drake/common/symbolic/expression.h"
 #include "drake/common/symbolic/monomial_util.h"
@@ -3468,6 +3469,7 @@ class MathematicalProgram {
 
 std::ostream& operator<<(std::ostream& os, const MathematicalProgram& prog);
 
-
 }  // namespace solvers
 }  // namespace drake
+
+DRAKE_FORMATTER_AS(, drake::solvers, MathematicalProgram, x, x.to_string())

--- a/solvers/mixed_integer_optimization_util.h
+++ b/solvers/mixed_integer_optimization_util.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <utility>
 
+#include "drake/common/fmt.h"
 #include "drake/solvers/mathematical_program.h"
 
 namespace drake {
@@ -412,3 +413,6 @@ void AddBilinearProductMcCormickEnvelopeMultipleChoice(
 
 }  // namespace solvers
 }  // namespace drake
+
+DRAKE_FORMATTER_AS(, drake::solvers, IntervalBinning, x,
+                   drake::solvers::to_string(x))

--- a/solvers/mixed_integer_rotation_constraint.h
+++ b/solvers/mixed_integer_rotation_constraint.h
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/fmt_ostream.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/mixed_integer_optimization_util.h"
 
@@ -231,3 +232,11 @@ AddRotationMatrixBoxSphereIntersectionMilpConstraints(
 
 }  // namespace solvers
 }  // namespace drake
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<
+    drake::solvers::MixedIntegerRotationConstraintGenerator::Approach>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/solvers/program_attribute.h
+++ b/solvers/program_attribute.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <unordered_set>
 
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/hash.h"
 
 namespace drake {
@@ -97,3 +98,16 @@ std::string to_string(const ProgramType&);
 std::ostream& operator<<(std::ostream&, const ProgramType&);
 }  // namespace solvers
 }  // namespace drake
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<drake::solvers::ProgramAttribute>
+    : drake::ostream_formatter {};
+template <>
+struct formatter<drake::solvers::ProgramAttributes>
+    : drake::ostream_formatter {};
+template <>
+struct formatter<drake::solvers::ProgramType>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/solvers/solution_result.h
+++ b/solvers/solution_result.h
@@ -3,6 +3,8 @@
 #include <ostream>
 #include <string>
 
+#include "drake/common/fmt.h"
+
 namespace drake {
 namespace solvers {
 enum SolutionResult {
@@ -22,3 +24,6 @@ std::string to_string(SolutionResult solution_result);
 std::ostream& operator<<(std::ostream& os, SolutionResult solution_result);
 }  // namespace solvers
 }  // namespace drake
+
+DRAKE_FORMATTER_AS(, drake::solvers, SolutionResult, x,
+                   drake::solvers::to_string(x))

--- a/solvers/solver_id.h
+++ b/solvers/solver_id.h
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/hash.h"
 #include "drake/common/reset_after_move.h"
 
@@ -68,3 +69,10 @@ struct less<drake::solvers::SolverId> {
 template <>
 struct hash<drake::solvers::SolverId> : public drake::DefaultHash {};
 }  // namespace std
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<drake::solvers::SolverId>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/solvers/solver_options.h
+++ b/solvers/solver_options.h
@@ -8,6 +8,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/solvers/common_solver_option.h"
 #include "drake/solvers/solver_id.h"
 
@@ -185,3 +186,10 @@ std::ostream& operator<<(std::ostream&, const SolverOptions&);
 
 }  // namespace solvers
 }  // namespace drake
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <>
+struct formatter<drake::solvers::SolverOptions>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -7,6 +7,7 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_throw.h"
+#include "drake/common/fmt.h"
 #include "drake/common/value.h"
 #include "drake/systems/framework/context_base.h"
 #include "drake/systems/framework/parameters.h"
@@ -894,6 +895,8 @@ std::ostream& operator<<(std::ostream& os, const Context<T>& context) {
 
 }  // namespace systems
 }  // namespace drake
+
+DRAKE_FORMATTER_AS(typename T, drake::systems, Context<T>, x, x.to_string())
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::Context)

--- a/systems/framework/vector_base.h
+++ b/systems/framework/vector_base.h
@@ -12,6 +12,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/unused.h"
 
@@ -265,6 +266,13 @@ std::ostream& operator<<(std::ostream& os, const VectorBase<T>& vec) {
 
 }  // namespace systems
 }  // namespace drake
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <typename T>
+struct formatter<drake::systems::VectorBase<T>>
+    : drake::ostream_formatter {};
+}  // namespace fmt
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::VectorBase)

--- a/systems/sensors/color_palette.h
+++ b/systems/sensors/color_palette.h
@@ -7,6 +7,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/hash.h"
 
 namespace drake {
@@ -197,3 +198,10 @@ class ColorPalette {
 }  // namespace sensors
 }  // namespace systems
 }  // namespace drake
+
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <typename T>
+struct formatter<drake::systems::sensors::Color<T>>
+    : drake::ostream_formatter {};
+}  // namespace fmt

--- a/tools/workspace/pybind11/mkdoc.py
+++ b/tools/workspace/pybind11/mkdoc.py
@@ -535,6 +535,11 @@ def print_symbols(f, name, node, level=0, *, tree_parser_doc,
     """
     Prints C++ code for relevant documentation.
     """
+    if level == 1 and name == "fmt":
+        # We have trouble parsing fmt's nested inline namespaces, so just
+        # skip everything in the fmt namespace wholesale.
+        return
+
     indent = '  ' * level
 
     def iprint(s):


### PR DESCRIPTION
Most are legacy `fmt::ostream_formatter`s for now (with a TODO), though a few can use `DRAKE_FORMATTER_AS`.

---

Towards #17742.

I _think_ I found all of the `operator<<` declarations and added a formatter, but anything I missed here will show up as a compiler error once we opt-out of `-DFMT_DEPRECATED_OSTREAM` a few PRs from now, so we don't need to be 100% perfect yet.  I just want to get the vast majority of these out of the way now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18806)
<!-- Reviewable:end -->
