### PR TITLE
Add fmt_eigen and use throughout for logging and errors

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -77,6 +77,7 @@ drake_cc_library(
         "drake_throw.h",
         "eigen_types.h",
         "fmt.h",
+        "fmt_eigen.h",
         "fmt_ostream.h",
         "never_destroyed.h",
         "text_logging.h",
@@ -888,6 +889,13 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "fmt_test",
+    deps = [
+        ":essential",
+    ],
+)
+
+drake_cc_googletest(
+    name = "fmt_eigen_test",
     deps = [
         ":essential",
     ],

--- a/common/ad/auto_diff.h
+++ b/common/ad/auto_diff.h
@@ -111,5 +111,6 @@ class AutoDiff {
 // These further refine our AutoDiff type and must appear in exactly this order.
 #include "drake/common/ad/internal/standard_operations.h"
 
-/* Formats the `value()` part of x to the stream. */
+/* Formats the `value()` part of x to the stream.
+To format the derivatives use `drake::fmt_eigen(x.derivatives())`. */
 DRAKE_FORMATTER_AS(, drake::ad, AutoDiff, x, x.value())

--- a/common/fmt_eigen.h
+++ b/common/fmt_eigen.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <limits>
+#include <sstream>
+#include <string_view>
+
+#include <Eigen/Core>
+
+#include "drake/common/fmt.h"
+
+namespace drake {
+namespace internal {
+
+/* A tag type to be used in fmt::format("{}", fmt_eigen(...)) calls.
+Below we'll add a fmt::formatter<> specialization for this tag. */
+template <typename Derived>
+struct fmt_eigen_ref {
+  const Eigen::MatrixBase<Derived>& matrix;
+};
+
+}  // namespace internal
+
+/** When passing an Eigen::Matrix to fmt, use this wrapper function to instruct
+fmt to use Drake's custom formatter for Eigen types.
+
+@warning The return value of this function should only ever be used as a
+temporary object, i.e., in a fmt argument list or a logging statement argument
+list. Never store it as a local variable, member field, etc. */
+template <typename Derived>
+internal::fmt_eigen_ref<Derived> fmt_eigen(
+    const Eigen::MatrixBase<Derived>& matrix) {
+  return {matrix};
+}
+
+}  // namespace drake
+
+// Formatter specialization for drake::fmt_eigen.
+// TODO(jwnimmer-tri) Write our own formatting logic instead of using Eigen IO,
+// and add customization flags for how to display the matrix data.
+namespace fmt {
+template <typename Derived>
+struct formatter<drake::internal::fmt_eigen_ref<Derived>>
+    : formatter<std::string_view> {
+  template <typename FormatContext>
+  auto format(const drake::internal::fmt_eigen_ref<Derived>& ref,
+              // NOLINTNEXTLINE(runtime/references) To match fmt API.
+              FormatContext& ctx) DRAKE_FMT8_CONST -> decltype(ctx.out()) {
+    const auto& matrix = ref.matrix;
+    std::stringstream stream;
+    // We'll print our matrix data using as much precision as we can, so that
+    // console log output and/or error messages paint the full picture. Sadly,
+    // the ostream family of floating-point formatters doesn't know how to do
+    // "shortest round-trip precision". If we set the precision to max_digits,
+    // then simple numbers like "1.1" print as "1.1000000000000001"; instead,
+    // well use max_digits - 1 to avoid that problem, with the risk of losing
+    // the last ulps in the printout it case it does matter. This will all be
+    // fixed once we stop using Eigen IO.
+    stream.precision(std::numeric_limits<double>::max_digits10 - 1);
+    stream << matrix;
+    return formatter<std::string_view>{}.format(stream.str(), ctx);
+  }
+};
+}  // namespace fmt

--- a/common/symbolic/expression/formula_cell.cc
+++ b/common/symbolic/expression/formula_cell.cc
@@ -10,7 +10,10 @@
 #include <stdexcept>
 #include <utility>
 
+#include <fmt/ostream.h>
+
 #include "drake/common/drake_assert.h"
+#include "drake/common/fmt_eigen.h"
 
 namespace drake {
 namespace symbolic {
@@ -553,11 +556,10 @@ FormulaPositiveSemidefinite::FormulaPositiveSemidefinite(
     const Eigen::Ref<const MatrixX<Expression>>& m)
     : FormulaCell{FormulaKind::PositiveSemidefinite}, m_{m} {
   if (!IsSymmetric(m)) {
-    ostringstream oss;
-    oss << "The following matrix is not symmetric and cannot be used to "
-           "construct drake::symbolic::FormulaPositiveSemidefinite:\n"
-        << m;
-    throw std::runtime_error(oss.str());
+    throw std::runtime_error(fmt::format(
+        "The following matrix is not symmetric and cannot be used to "
+        "construct drake::symbolic::FormulaPositiveSemidefinite:\n{}",
+        fmt_eigen(m)));
   }
 }
 
@@ -649,7 +651,8 @@ Formula FormulaPositiveSemidefinite::Substitute(const Substitution& s) const {
 }
 
 ostream& FormulaPositiveSemidefinite::Display(ostream& os) const {
-  return os << "positive_semidefinite(" << m_ << ")";
+  fmt::print(os, "positive_semidefinite({})", fmt_eigen(m_));
+  return os;
 }
 
 bool is_false(const FormulaCell& f) {

--- a/common/symbolic/expression/test/variable_overloading_test.cc
+++ b/common/symbolic/expression/test/variable_overloading_test.cc
@@ -6,6 +6,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/symbolic_test_util.h"
 
 namespace drake {
@@ -313,7 +314,7 @@ TEST_F(VariableOverloadingTest, OperatorOverloadingEigenDivideVariable) {
   EXPECT_PRED2(ExprEqual, m2(1, 1), w_ / (x_ + y_));
 }
 
-TEST_F(VariableOverloadingTest, EigenExpressionMatrixOutput) {
+TEST_F(VariableOverloadingTest, EigenExpressionMatrixOutputStream) {
   ostringstream oss1;
   oss1 << expr_mat_;
 
@@ -322,6 +323,12 @@ TEST_F(VariableOverloadingTest, EigenExpressionMatrixOutput) {
        << "      (y + z)       (y + w)";
 
   EXPECT_EQ(oss1.str(), oss2.str());
+}
+
+TEST_F(VariableOverloadingTest, EigenExpressionMatrixOutputFmt) {
+  EXPECT_EQ(fmt::to_string(fmt_eigen(expr_mat_)),
+            "      (x + z)       (x + w)\n"
+            "      (y + z)       (y + w)");
 }
 }  // namespace
 }  // namespace symbolic

--- a/common/symbolic/test/polynomial_matrix_test.cc
+++ b/common/symbolic/test/polynomial_matrix_test.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/symbolic/expression.h"
 #include "drake/common/test_utilities/symbolic_test_util.h"
 
@@ -82,19 +83,18 @@ class SymbolicPolynomialMatrixTest : public ::testing::Test {
   const MatrixX<Expression> m2_expanded{
       m2.unaryExpr([](const Expression& e) { return e.Expand(); })};
   if (m1_expanded == m2_expanded) {
-    return ::testing::AssertionSuccess()
-           << "m1 and m2 are equal after expansion where m1 = \n"
-           << m1 << "\n"
-           << "and m2 = " << m2;
+    return ::testing::AssertionSuccess() << fmt::format(
+               "m1 and m2 are equal after expansion where m1 = \n{}\n"
+               "and m2 = {}",
+               fmt_eigen(m1), fmt_eigen(m2));
   } else {
-    return ::testing::AssertionFailure()
-           << "m1 and m2 are not equal after expansion where m1 = \n"
-           << m1 << "\n"
-           << "m2 = " << m2 << "\n"
-           << "m1_expanded = \n"
-           << m1_expanded << "\n"
-           << "m2_expanded = \n"
-           << m2_expanded;
+    return ::testing::AssertionFailure() << fmt::format(
+               "m1 and m2 are not equal after expansion where m1 = \n{}\n"
+               "m2 = \n{}\n"
+               "m1_expanded = \n{}\n"
+               "m2_expanded = \n{}\n",
+               fmt_eigen(m1), fmt_eigen(m2), fmt_eigen(m1_expanded),
+               fmt_eigen(m2_expanded));
   }
 }
 

--- a/common/test/fmt_eigen_test.cc
+++ b/common/test/fmt_eigen_test.cc
@@ -1,0 +1,63 @@
+#include "drake/common/fmt_eigen.h"
+
+#include <Eigen/Core>
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace {
+
+// TODO(jwnimer-tri) The expected values below are what Eigen prints for us by
+// default. In the future, we might decide to use some different formatting.
+// In that case, it's fine to update the test goals here to reflect those
+// updated defaults.
+
+GTEST_TEST(FmtEigenTest, RowVector3d) {
+  const Eigen::RowVector3d value{1.1, 2.2, 3.3};
+  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), "1.1 2.2 3.3");
+}
+
+GTEST_TEST(FmtEigenTest, Vector3d) {
+  const Eigen::Vector3d value{1.1, 2.2, 3.3};
+  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), "1.1\n2.2\n3.3");
+}
+
+GTEST_TEST(FmtEigenTest, EmptyMatrix) {
+  const Eigen::MatrixXd value;
+  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), "");
+}
+
+GTEST_TEST(FmtEigenTest, Matrix3d) {
+  Eigen::Matrix3d value;
+  value << 1.1, 1.2, 1.3,
+           2.1, 2.2, 2.3,
+           3.1, 3.2, 3.3;
+  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)),
+            "1.1 1.2 1.3\n"
+            "2.1 2.2 2.3\n"
+            "3.1 3.2 3.3");
+}
+
+GTEST_TEST(FmtEigenTest, Matrix3dNeedsPadding) {
+  Eigen::Matrix3d value;
+  value << 10.1, 1.2, 1.3,
+           2.1, 2.2, 2.3,
+           3.1, 3.2, 3.3;
+  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)),
+            "10.1  1.2  1.3\n"
+            " 2.1  2.2  2.3\n"
+            " 3.1  3.2  3.3");
+}
+
+GTEST_TEST(FmtEigenTest, Matrix3i) {
+  Eigen::Matrix3i value;
+  value << 11, 12, 13,
+           21, 22, 23,
+           31, 32, 33;
+  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)),
+            "11 12 13\n"
+            "21 22 23\n"
+            "31 32 33");
+}
+
+}  // namespace
+}  // namespace drake

--- a/common/yaml/test/example_structs.h
+++ b/common/yaml/test/example_structs.h
@@ -10,7 +10,9 @@
 #include <vector>
 
 #include <Eigen/Core>
+#include <fmt/ostream.h>
 
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/name_value.h"
 
 namespace drake {
@@ -242,13 +244,13 @@ using Variant4 = std::variant<
 
 std::ostream& operator<<(std::ostream& os, const Variant4& value) {
   if (value.index() == 0) {
-    os << "std::string{" << std::get<0>(value) << "}";
+    fmt::print(os,  "std::string{{{}}}", std::get<0>(value));
   } else if (value.index() == 1) {
-    os << "double{" << std::get<1>(value) << "}";
+    fmt::print(os, "double{{{}}}", std::get<1>(value));
   } else if (value.index() == 2) {
-    os << "DoubleStruct{" << std::get<2>(value).value << "}";
+    fmt::print(os, "DoubleStruct{{{}}}", std::get<2>(value).value);
   } else {
-    os << "EigenVecStruct{" << std::get<3>(value).value << "}";
+    fmt::print(os, "EigenVecStruct{{{}}}", fmt_eigen(std::get<3>(value).value));
   }
   return os;
 }

--- a/examples/acrobot/run_lqr_w_estimator.cc
+++ b/examples/acrobot/run_lqr_w_estimator.cc
@@ -4,6 +4,7 @@
 
 #include <gflags/gflags.h>
 
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/proto/call_python.h"
 #include "drake/examples/acrobot/acrobot_geometry.h"
 #include "drake/examples/acrobot/acrobot_plant.h"
@@ -82,9 +83,9 @@ int do_main() {
 
     Eigen::Matrix4d error_sys =
         linearized_acrobot->A() - observer->L() * linearized_acrobot->C();
-    std::cout << "L = " << observer->L() << std::endl;
-    std::cout << "A - LC = " << std::endl << error_sys << std::endl;
-    std::cout << "eig(A-LC) = " << error_sys.eigenvalues() << std::endl;
+    fmt::print("L = {}\n", fmt_eigen(observer->L()));
+    fmt::print("A - LC =\n{}\n", fmt_eigen(error_sys));
+    fmt::print("eig(A-LC) = {}\n", fmt_eigen(error_sys.eigenvalues().real()));
   }
 
   // Make the LQR Controller.

--- a/examples/kuka_iiwa_arm/kuka_plan_runner.cc
+++ b/examples/kuka_iiwa_arm/kuka_plan_runner.cc
@@ -17,6 +17,7 @@
 #include "lcm/lcm-cpp.hpp"
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/lcmt_iiwa_command.hpp"
 #include "drake/lcmt_iiwa_status.hpp"
@@ -150,7 +151,7 @@ class RobotPlanRunner {
     }
 
     for (int i = 0; i < plan->num_states; ++i) {
-      std::cout << knots[i] << std::endl;
+      fmt::print("{}\n", fmt_eigen(knots[i]));
     }
 
     std::vector<double> input_time;

--- a/examples/manipulation_station/proof_of_life.cc
+++ b/examples/manipulation_station/proof_of_life.cc
@@ -1,9 +1,8 @@
-#include <iostream>
-
 #include <gflags/gflags.h>
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/find_resource.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/is_approx_equal_abstol.h"
 #include "drake/examples/manipulation_station/manipulation_station.h"
 #include "drake/geometry/drake_visualizer.h"
@@ -124,8 +123,8 @@ int do_main(int argc, char* argv[]) {
   // Check that the arm is (very roughly) in the commanded position.
   VectorXd q = station->GetIiwaPosition(station_context);
   if (!is_approx_equal_abstol(q, q0, 1.e-3)) {
-    std::cout << "q is not sufficiently close to q0.\n";
-    std::cout << "q - q0  = " << (q - q0).transpose() << "\n";
+    fmt::print("q is not sufficiently close to q0.\n");
+    fmt::print("q - q0  = {}\n", fmt_eigen((q - q0).transpose()));
     return EXIT_FAILURE;
   }
 

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/yaml/yaml_io.h"
 #include "drake/geometry/geometry_frame.h"
@@ -257,7 +258,8 @@ GTEST_TEST(HPolyhedronTest, InscribedEllipsoidTest) {
   RandomGenerator generator;
   for (int i = 0; i < 10; ++i) {
     const RotationMatrixd R = math::UniformlyRandomRotationMatrix(&generator);
-    SCOPED_TRACE(fmt::format("With random rotation matrix\n{}", R.matrix()));
+    SCOPED_TRACE(fmt::format("With random rotation matrix\n{}",
+                             fmt_eigen(R.matrix())));
     Vector3d x = C * R.matrix() * Vector3d(0.99, 0.0, 0.0) + E2.center();
     EXPECT_TRUE(E2.PointInSet(x));
     EXPECT_TRUE(H2.PointInSet(x));

--- a/geometry/proximity/plane.h
+++ b/geometry/proximity/plane.h
@@ -2,12 +2,10 @@
 
 #include <limits>
 
-#include <fmt/format.h>
-#include <fmt/ostream.h>
-
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/geometry/proximity/mesh_traits.h"
 
 namespace drake {
@@ -62,10 +60,10 @@ class Plane {
       // passes in an incredibly small normal (picometers), it is probably an
       // error.
       if (magnitude < 1e-10) {
-        throw std::runtime_error(
-            fmt::format("Cannot instantiate plane from normal n_F = [{}]; its "
-                        "magnitude is too small: {}",
-                        n_F.transpose(), magnitude));
+        throw std::runtime_error(fmt::format(
+            "Cannot instantiate plane from normal n_F = [{}]; its magnitude is "
+            "too small: {}",
+            fmt_eigen(n_F.transpose()), magnitude));
       }
       nhat_F_ = n_F / magnitude;
     } else {
@@ -101,10 +99,10 @@ class Plane {
     // in the columns/rows of a rotation matrix -- a likely source for plane
     // normals.
     if (delta > 1e-13) {
-      throw std::runtime_error(
-          fmt::format("Plane constructed with a normal vector that was "
-                      "declared normalized; the vector is not unit length. "
-                      "Vector [{}] with length {}", n.transpose(), n.norm()));
+      throw std::runtime_error(fmt::format(
+          "Plane constructed with a normal vector that was declared normalized;"
+          " the vector is not unit length. Vector [{}] with length {}",
+          fmt_eigen(n.transpose()), T{n.norm()}));
     }
   }
 

--- a/geometry/proximity/test/characterization_utilities.cc
+++ b/geometry/proximity/test/characterization_utilities.cc
@@ -4,8 +4,7 @@
 #include <fstream>
 #include <limits>
 
-#include <fmt/format.h>
-
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/temp_directory.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
@@ -108,7 +107,7 @@ void ShapeConfigurations<T>::ImplementGeometry(const Box& box, void*) {
       throw std::runtime_error(
           fmt::format("The box (with dimensions {}) isn't large enough for "
                       "penetration depth of {}",
-                      box.size(), -distance_));
+                      fmt_eigen(box.size()), -distance_));
     }
     // If we actually need penetration, we need to make sure that the distance
     // to the edges is *larger* than the requested depth (plus small padding).
@@ -552,7 +551,7 @@ void CharacterizeResultTest<T>::RunCharacterization(
             "\n{}\n",
             GetGeometryName(*obj_A), GetGeometryName(*obj_B), first, second,
             test_config.description, test_config.signed_distance,
-            test_config.X_AB.GetAsMatrix34()));
+            fmt_eigen(test_config.X_AB.GetAsMatrix34())));
         RunCallback(query, obj_A, obj_B, &collision_filter_, &world_poses);
         const std::optional<double> error =
             ComputeErrorMaybe(test_config.signed_distance);

--- a/geometry/proximity/test/distance_sphere_to_shape_test.cc
+++ b/geometry/proximity/test/distance_sphere_to_shape_test.cc
@@ -8,6 +8,7 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
@@ -215,10 +216,10 @@ class DistancePairGeometryTest : public ::testing::Test {
     const Vector3d dd_dAo_point = point_result.distance.derivatives();
     result = CompareMatrices(dd_dAo_shape, dd_dAo_point);
     if (!result) {
-      return ::testing::AssertionFailure()
-             << "Distance derivatives don't match; "
-             << "expected: <" << dd_dAo_point << ">, got: <" << dd_dAo_shape
-             << ">";
+      const std::string message = fmt::format(
+          "Distance derivatives don't match; expected: <{}>, got: <{}>",
+          fmt_eigen(dd_dAo_point), fmt_eigen(dd_dAo_shape));
+      return ::testing::AssertionFailure() << message;
     }
 
     // Derivatives of nhat_BA_W; point distance grad_W member is the same
@@ -227,10 +228,10 @@ class DistancePairGeometryTest : public ::testing::Test {
     const auto dgrad_dAo_point = math::ExtractGradient(point_result.grad_W);
     result = CompareMatrices(dgrad_dAo_shape, dgrad_dAo_point);
     if (!result) {
-      return ::testing::AssertionFailure() << "Normal derivatives don't match; "
-                                           << "expected:\n"
-                                           << dgrad_dAo_point << "\ngot:\n"
-                                           << dgrad_dAo_shape;
+      const std::string message =
+          fmt::format("Normal derivatives don't match; expected:\n{}\ngot:\n{}",
+                      fmt_eigen(dgrad_dAo_point), fmt_eigen(dgrad_dAo_shape));
+      return ::testing::AssertionFailure() << message;
     }
 
     // Derivatives of p_BCb.
@@ -238,10 +239,10 @@ class DistancePairGeometryTest : public ::testing::Test {
     const auto dN_dAo = math::ExtractGradient(point_result.p_GN);
     result = CompareMatrices(dCb_dAo, dN_dAo);
     if (!result) {
-      return ::testing::AssertionFailure() << "p_BCb derivatives don't match; "
-                                           << "expected:\n"
-                                           << dN_dAo << "\ngot:\n"
-                                           << dCb_dAo;
+      const std::string message =
+          fmt::format("p_BCb derivatives don't match; expected:\n{}\ngot:\n{}",
+                      fmt_eigen(dN_dAo), fmt_eigen(dCb_dAo));
+      return ::testing::AssertionFailure() << message;
     }
 
     // Derivatives of p_ACa.
@@ -294,10 +295,10 @@ class DistancePairGeometryTest : public ::testing::Test {
     const auto dCa_dAo = math::ExtractGradient(shape_result.p_ACa);
     result = CompareMatrices(dCa_dAo, dCa_dAo_expected, 4 * kEps);
     if (!result) {
-      return ::testing::AssertionFailure() << "p_ACa derivatives don't match; "
-                                           << "expected:\n"
-                                           << dCa_dAo_expected << "\ngot:\n"
-                                           << dCa_dAo;
+      const std::string message =
+          fmt::format("p_ACa derivatives don't match; expected:\n{}\ngot:\n{}",
+                      fmt_eigen(dCa_dAo_expected), fmt_eigen(dCa_dAo));
+      return ::testing::AssertionFailure() << message;
     }
 
     return result;

--- a/geometry/proximity/test/distance_to_point_callback_test.cc
+++ b/geometry/proximity/test/distance_to_point_callback_test.cc
@@ -3,6 +3,7 @@
 #include <drake_vendor/fcl/fcl.h>
 #include <gtest/gtest.h>
 
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/proximity/proximity_utilities.h"
@@ -103,7 +104,8 @@ class PointShapeAutoDiffSignedDistanceTester {
     if (grad_W_val.array().isNaN().any()) {
       if (error) failure << "\n";
       error = true;
-      failure << "Analytical gradient contains NaN: " << grad_W_val.transpose();
+      failure << fmt::format("Analytical gradient contains NaN: {}",
+                             fmt_eigen(grad_W_val.transpose()));
     }
     auto gradient_compare =
         CompareMatrices(ddistance_dp_WQ, grad_W_val, tolerance_);

--- a/geometry/proximity/test/mesh_half_space_intersection_test.cc
+++ b/geometry/proximity/test/mesh_half_space_intersection_test.cc
@@ -10,6 +10,7 @@
 
 #include "drake/common/autodiff.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/proximity/contact_surface_utility.h"
@@ -338,14 +339,16 @@ class MeshHalfSpaceValueTest : public ::testing::Test {
       const Scalar p_X_test = test_field_W.EvaluateCartesian(f, p_WX);
       const Scalar error = (p_X_test - p_X_expected);
       if (error > kPressureEps) {
-        return ::testing::AssertionFailure()
-               << "\nMesh face " << f
-               << " failed to provide the correct pressure for a point on the "
-                  "inside of the face: " << p_WX.transpose() << ".\n"
-               << "  Expected: " << p_X_expected << "\n"
-               << "  Found: " << p_X_test << "\n"
-               << "  tolerance: " << kPressureEps << "\n"
-               << "  error: " << error;
+        const std::string message = fmt::format(
+            "\nMesh face {} failed to provide the correct pressure for a "
+            "point on the inside of the face: {}.\n"
+            "  Expected: {}\n"
+            "  Found: {}\n"
+            "  tolerance: {}\n"
+            "  error: {}",
+            f, fmt_eigen(p_WX.transpose()), p_X_expected, p_X_test,
+            kPressureEps, error);
+        return ::testing::AssertionFailure() << message;
       }
     }
 

--- a/geometry/render_gl/test/internal_render_engine_gl_test.cc
+++ b/geometry/render_gl/test/internal_render_engine_gl_test.cc
@@ -10,6 +10,7 @@
 #include <vtkPNGReader.h>
 
 #include "drake/common/find_resource.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/geometry_ids.h"
@@ -1698,7 +1699,8 @@ TEST_F(RenderEngineGlTest, IntrinsicsAndRenderProperties) {
   // Confirm all edges were found, the box is square and centered in the
   // image.
   const Vector4<int> ref_box_edges = FindBoxEdges(ref_depth);
-  ASSERT_TRUE((ref_box_edges.array() > -1).all()) << ref_box_edges.transpose();
+  ASSERT_TRUE((ref_box_edges.array() > -1).all())
+      << fmt::to_string(fmt_eigen(ref_box_edges.transpose()));
   const int ref_box_width = ref_box_edges(2) - ref_box_edges(0);
   const int ref_box_height = ref_box_edges(1) - ref_box_edges(3);
   ASSERT_EQ(ref_box_width, ref_box_height);
@@ -1708,9 +1710,11 @@ TEST_F(RenderEngineGlTest, IntrinsicsAndRenderProperties) {
   {
     // Also confirm the box is positioned the same in color and label images.
     const Vector4<int> color_edges = FindBoxEdges(ref_color);
-    ASSERT_EQ(color_edges, ref_box_edges) << color_edges;
+    ASSERT_EQ(color_edges, ref_box_edges)
+        << fmt::to_string(fmt_eigen(color_edges));
     const Vector4<int> label_edges = FindBoxEdges(ref_label);
-    ASSERT_EQ(label_edges, ref_box_edges) << label_edges;
+    ASSERT_EQ(label_edges, ref_box_edges)
+        << fmt::to_string(fmt_eigen(label_edges));
   }
 
   {
@@ -1755,7 +1759,8 @@ TEST_F(RenderEngineGlTest, IntrinsicsAndRenderProperties) {
     //    increase or decrease the amount of image around the box.
 
     const Vector4<int> test_edges = FindBoxEdges(depth);
-    ASSERT_TRUE((test_edges.array() > -1).all()) << test_edges.transpose();
+    ASSERT_TRUE((test_edges.array() > -1).all())
+        << fmt::to_string(fmt_eigen(test_edges.transpose()));
     const int test_box_width = test_edges(2) - test_edges(0);
     const int test_box_height = test_edges(1) - test_edges(3);
 
@@ -1767,16 +1772,18 @@ TEST_F(RenderEngineGlTest, IntrinsicsAndRenderProperties) {
 
     // Confirm that its center is translated.
     EXPECT_NEAR((test_edges(0) + test_edges(2)) / 2.0, w2 / 2.0 + offset_x, 1.0)
-        << test_edges.transpose();
+        << fmt::to_string(fmt_eigen(test_edges.transpose()));
     EXPECT_NEAR((test_edges(1) + test_edges(3)) / 2.0, h2 / 2.0 + offset_y, 1.0)
-        << test_edges.transpose();
+        << fmt::to_string(fmt_eigen(test_edges.transpose()));
 
     {
       // Also confirm it matches for color and label.
       const Vector4<int> color_edges = FindBoxEdges(color);
-      ASSERT_EQ(color_edges, test_edges) << color_edges.transpose();
+      ASSERT_EQ(color_edges, test_edges)
+          << fmt::to_string(fmt_eigen(color_edges.transpose()));
       const Vector4<int> label_edges = FindBoxEdges(label);
-      ASSERT_EQ(label_edges, test_edges) << label_edges.transpose();
+      ASSERT_EQ(label_edges, test_edges)
+          << fmt::to_string(fmt_eigen(label_edges.transpose()));
     }
   }
 

--- a/geometry/render_gl/test/internal_shape_meshes_test.cc
+++ b/geometry/render_gl/test/internal_shape_meshes_test.cc
@@ -8,6 +8,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/find_resource.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/math/rigid_transform.h"
@@ -579,8 +580,8 @@ void TestGenericPrimitiveTraits(const MeshData& mesh,
       ASSERT_GT(n_face.dot(c), 0) << "for triangle " << t;
     }
     const NormalCone cone(mesh, t);
-    ASSERT_TRUE(cone.Contains(n_face))
-        << "for triangle " << t << "\n  face normal: " << n_face.transpose();
+    ASSERT_TRUE(cone.Contains(n_face)) << fmt::format(
+        "for triangle {}\n  face normal: {}", t, fmt_eigen(n_face.transpose()));
   }
 
   // UVs lie in the expected range.

--- a/geometry/render_gltf_client/test/internal_render_client_test.cc
+++ b/geometry/render_gltf_client/test/internal_render_client_test.cc
@@ -11,9 +11,11 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/ostream.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/temp_directory.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
@@ -37,8 +39,8 @@ void PrintTo(const Image<kPixelType>& image, std::ostream* os) {
     using Stride = Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>;
     Eigen::Map<const MatrixX<T>, 0, Stride> eigen(
         base, height, width, Stride(num_channels, width * num_channels));
-    *os << "Channel " << z << ":\n";
-    *os << eigen.template cast<Promoted>() << "\n";
+    fmt::print(*os, "Channel {}:\n", z);
+    fmt::print(*os, "{}\n", fmt_eigen(eigen.template cast<Promoted>()));
   }
 }
 }  // namespace sensors

--- a/geometry/render_gltf_client/test/internal_render_engine_gltf_client_test.cc
+++ b/geometry/render_gltf_client/test/internal_render_engine_gltf_client_test.cc
@@ -10,6 +10,7 @@
 #include <vtkMatrix4x4.h>
 
 #include "drake/common/find_resource.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/temp_directory.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/geometry/render_gltf_client/internal_http_service.h"
@@ -156,18 +157,18 @@ TEST_F(RenderEngineGltfClientTest, UpdateViewpoint) {
     const Matrix4d vtk_inv = transform_inverse(vtk);
     const Matrix3d R_vtk_inv = vtk_inv.topLeftCorner<3, 3>();
     const Matrix3d R_gltf = gltf.topLeftCorner<3, 3>();
-    EXPECT_TRUE(R_vtk_inv.isApprox(R_gltf, tolerance))
-        << "Rotation matrices not similar enough:\nR_vtk_inv:\n"
-        << R_vtk_inv << "\nR_gltf:\n"
-        << R_gltf << '\n';
+    EXPECT_TRUE(R_vtk_inv.isApprox(R_gltf, tolerance)) << fmt::format(
+        "Rotation matrices not similar enough:\n"
+        "R_vtk_inv:\n{}\nR_gltf:\n{}\n",
+        fmt_eigen(R_vtk_inv), fmt_eigen(R_gltf));
 
     // Compare the translations.
     const Vector3d t_vtk_inv = vtk_inv.topRightCorner<3, 1>();
     const Vector3d t_gltf = gltf.topRightCorner<3, 1>();
-    EXPECT_TRUE(t_vtk_inv.isApprox(t_gltf, tolerance))
-        << "Translation vectors not similar enough:\nt_vtk_inv:\n"
-        << t_vtk_inv << "\nt_gltf:\n"
-        << t_gltf << '\n';
+    EXPECT_TRUE(t_vtk_inv.isApprox(t_gltf, tolerance)) << fmt::format(
+        "Translation vectors not similar enough:\n"
+        "t_vtk_inv:\n{}\nt_gltf:\n{}\n",
+        fmt_eigen(t_vtk_inv), fmt_eigen(t_gltf));
 
     // For posterity, compare the homogeneous row.
     const Vector4d gltf_homogeneous = gltf.bottomRightCorner<1, 4>();

--- a/geometry/render_vtk/internal_render_engine_vtk_base.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk_base.cc
@@ -16,6 +16,7 @@
 #include <vtkPolyDataAlgorithm.h>
 #include <vtkStreamingDemandDrivenPipeline.h>
 
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/scope_exit.h"
 
 namespace drake {
@@ -69,8 +70,9 @@ class DrakeCubeSource : public vtkPolyDataAlgorithm {
   /* VTK boilerplate to support printing the source.  */
   void PrintSelf(std::ostream& os, vtkIndent indent) override {
     this->Superclass::PrintSelf(os, indent);
-    os << indent << "Size: " << size_.transpose() << "\n";
-    os << indent << "UV Scale: " << uv_scale_.transpose() << "\n";
+    os << indent << fmt::format("Size: {}\n", fmt_eigen(size_.transpose()));
+    os << indent
+       << fmt::format("UV Scale: {}\n", fmt_eigen(uv_scale_.transpose()));
   }
 
   /* Set the size of the box along each of its principal axes.

--- a/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
@@ -17,6 +17,7 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/find_resource.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
@@ -1506,7 +1507,8 @@ TEST_F(RenderEngineVtkTest, IntrinsicsAndRenderProperties) {
   // Confirm all edges were found, the box is square and centered in the
   // image.
   const Vector4<int> ref_box_edges = FindBoxEdges(ref_depth);
-  ASSERT_TRUE((ref_box_edges.array() > -1).all()) << ref_box_edges.transpose();
+  ASSERT_TRUE((ref_box_edges.array() > -1).all())
+      << fmt::to_string(fmt_eigen(ref_box_edges.transpose()));
   const int ref_box_width = ref_box_edges(2) - ref_box_edges(0);
   const int ref_box_height = ref_box_edges(1) - ref_box_edges(3);
   ASSERT_EQ(ref_box_width, ref_box_height);
@@ -1516,9 +1518,11 @@ TEST_F(RenderEngineVtkTest, IntrinsicsAndRenderProperties) {
   {
     // Also confirm the box is positioned the same in color and label images.
     const Vector4<int> color_edges = FindBoxEdges(ref_color);
-    ASSERT_EQ(color_edges, ref_box_edges) << color_edges;
+    ASSERT_EQ(color_edges, ref_box_edges)
+        << fmt::to_string(fmt_eigen(color_edges));
     const Vector4<int> label_edges = FindBoxEdges(ref_label);
-    ASSERT_EQ(label_edges, ref_box_edges) << label_edges;
+    ASSERT_EQ(label_edges, ref_box_edges)
+        << fmt::to_string(fmt_eigen(label_edges));
   }
 
   {
@@ -1563,7 +1567,8 @@ TEST_F(RenderEngineVtkTest, IntrinsicsAndRenderProperties) {
     //    increase or decrease the amount of image around the box.
 
     const Vector4<int> test_edges = FindBoxEdges(depth);
-    ASSERT_TRUE((test_edges.array() > -1).all()) << test_edges.transpose();
+    ASSERT_TRUE((test_edges.array() > -1).all())
+        << fmt::to_string(fmt_eigen(test_edges.transpose()));
     const int test_box_width = test_edges(2) - test_edges(0);
     const int test_box_height = test_edges(1) - test_edges(3);
 
@@ -1575,16 +1580,18 @@ TEST_F(RenderEngineVtkTest, IntrinsicsAndRenderProperties) {
 
     // Confirm that its center is translated.
     EXPECT_NEAR((test_edges(0) + test_edges(2)) / 2.0, w2 / 2.0 + offset_x, 1.0)
-        << test_edges.transpose();
+        << fmt::to_string(fmt_eigen(test_edges.transpose()));
     EXPECT_NEAR((test_edges(1) + test_edges(3)) / 2.0, h2 / 2.0 + offset_y, 1.0)
-        << test_edges.transpose();
+        << fmt::to_string(fmt_eigen(test_edges.transpose()));
 
     {
       // Also confirm it matches for color and label.
       const Vector4<int> color_edges = FindBoxEdges(color);
-      ASSERT_EQ(color_edges, test_edges) << color_edges.transpose();
+      ASSERT_EQ(color_edges, test_edges)
+          << fmt::to_string(fmt_eigen(color_edges.transpose()));
       const Vector4<int> label_edges = FindBoxEdges(label);
-      ASSERT_EQ(label_edges, test_edges) << label_edges.transpose();
+      ASSERT_EQ(label_edges, test_edges)
+          << fmt::to_string(fmt_eigen(label_edges.transpose()));
     }
   }
 

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -1071,17 +1071,20 @@ struct SignedDistanceToPointTestData {
   // when a test fails.
   friend std::ostream& operator<<(std::ostream& os,
                                   const SignedDistanceToPointTestData& obj) {
-    return os << "{\n"
-              << "  geometry: (not printed)\n"
-              << "  X_WG: (not printed)\n"
-              << "  p_WQ: " << obj.p_WQ.transpose() << "\n"
-              << "  expected_result.p_GN: "
-              << obj.expected_result.p_GN.transpose() << "\n"
-              << "  expected_result.distance: " << obj.expected_result.distance
-              << "\n"
-              << "  expected_result.grad_W: "
-              << obj.expected_result.grad_W.transpose() << "\n"
-              << "}" << std::flush;
+    fmt::print(os,
+               "{{\n"
+               "  geometry: (not printed)\n"
+               "  X_WG: (not printed)\n"
+               "  p_WQ: {}\n"
+               "  expected_result.p_GN: {}\n"
+               "  expected_result.distance: {}\n"
+               "  expected_result.grad_W: {}\n"
+               "}}",
+               fmt_eigen(obj.p_WQ.transpose()),
+               fmt_eigen(obj.expected_result.p_GN.transpose()),
+               obj.expected_result.distance,
+               fmt_eigen(obj.expected_result.grad_W.transpose()));
+    return os;
   }
 
   shared_ptr<Shape> geometry;
@@ -2601,22 +2604,23 @@ class SignedDistancePairTestData {
   // when a test fails.
   friend std::ostream& operator<<(std::ostream& os,
                                   const SignedDistancePairTestData& obj) {
-    return os << "{\n"
-              << " geometry A: (not printed)\n"
-              << " geometry B: (not printed)\n"
-              << " X_WA: (not printed)\n"
-              << " X_WB: (not printed)\n"
-              << " expected_result.id_A: "
-              << obj.expected_result_.id_A << "\n"
-              << " expected_result.id_B: "
-              << obj.expected_result_.id_B << "\n"
-              << " expected_result.distance: "
-              << obj.expected_result_.distance << "\n"
-              << " expected_result.p_ACa: "
-              << obj.expected_result_.p_ACa.transpose() << "\n"
-              << " expected_result.p_BCb: "
-              << obj.expected_result_.p_BCb.transpose() << "\n"
-              << "}" << std::flush;
+    fmt::print(os,
+               "{{\n"
+               " geometry A: (not printed)\n"
+               " geometry B: (not printed)\n"
+               " X_WA: (not printed)\n"
+               " X_WB: (not printed)\n"
+               " expected_result.id_A: {}\n"
+               " expected_result.id_B: {}\n"
+               " expected_result.distance: {}\n"
+               " expected_result.p_ACa: {}\n"
+               " expected_result.p_BCb: {}\n"
+               "}}",
+               obj.expected_result_.id_A, obj.expected_result_.id_B,
+               obj.expected_result_.distance,
+               fmt_eigen(obj.expected_result_.p_ACa.transpose()),
+               fmt_eigen(obj.expected_result_.p_BCb.transpose()));
+    return os;
   }
 
   shared_ptr<const Shape> a_;

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
@@ -264,33 +265,34 @@ TEST_F(ReifierTest, CloningShapes) {
   const Vector3<double>& z_axis = pose.rotation().col(2);
   if (!CompareMatrices(z_axis, expected_z, tolerance,
                        MatrixCompareType::absolute)) {
-    return ::testing::AssertionFailure()
-           << "pose =\n"
-           << pose.GetAsMatrix34() << "\nExpected z-axis "
-           << expected_z.transpose() << " does not match pose's z-axis "
-           << z_axis.transpose();
+    const std::string message = fmt::format(
+        "pose =\n{}\nExpected z-axis {} does not match pose's z-axis {}",
+        fmt_eigen(pose.GetAsMatrix34()), fmt_eigen(expected_z.transpose()),
+        fmt_eigen(z_axis.transpose()));
+    return ::testing::AssertionFailure() << message;
   }
 
   // Test expected translation.
   if (!CompareMatrices(pose.translation(), expected_translation, tolerance,
                        MatrixCompareType::absolute)) {
-    return ::testing::AssertionFailure()
-           << "pose =\n"
-           << pose.GetAsMatrix34() << "\nExpected translation "
-           << expected_translation.transpose()
-           << " does not match pose's translation "
-           << pose.translation().transpose();
+    const std::string message = fmt::format(
+        "pose =\n{}\nExpected translation {} does not match pose's "
+        "translation {}",
+        fmt_eigen(pose.GetAsMatrix34()),
+        fmt_eigen(expected_translation.transpose()),
+        fmt_eigen(pose.translation().transpose()));
+    return ::testing::AssertionFailure() << message;
   }
 
   // Test unit-length rotation.
   char axis_labels[] = {'x', 'y', 'z'};
   for (int i = 0; i < 3; ++i) {
     if (abs(pose.rotation().col(i).norm() - 1) > tolerance) {
-      return ::testing::AssertionFailure()
-             << "pose =\n"
-             << pose.GetAsMatrix34() << "\ndoes not have unit length "
-             << axis_labels[i] << "-axis "
-             << pose.rotation().col(i).transpose();
+      const std::string message =
+          fmt::format("pose =\n{}\ndoes not have unit length {}-axis {}",
+                      fmt_eigen(pose.GetAsMatrix34()), axis_labels[i],
+                      fmt_eigen(pose.rotation().col(i).transpose()));
+      return ::testing::AssertionFailure() << message;
     }
   }
 
@@ -299,18 +301,18 @@ TEST_F(ReifierTest, CloningShapes) {
     for (int j = i + 1; j < 3; ++j) {
       double dot_product = pose.rotation().col(i).dot(pose.rotation().col(j));
       if (abs(dot_product) > tolerance) {
-        return ::testing::AssertionFailure()
-               << "For pose =\n"
-               << pose.GetAsMatrix34() << "\nThe " << axis_labels[i]
-               << "-axis and " << axis_labels[j] << "-axis are not orthogonal";
+        const std::string message = fmt::format(
+            "For pose =\n{}\nThe {}-axis and {}-axis are not orthogonal",
+            fmt_eigen(pose.GetAsMatrix34()), axis_labels[i], axis_labels[j]);
+        return ::testing::AssertionFailure() << message;
       }
     }
   }
-  return ::testing::AssertionSuccess()
-         << "pose =\n"
-         << pose.GetAsMatrix34()
-         << "\nhas expected z-axis = " << expected_z.transpose()
-         << "\nand expected translation = " << expected_translation.transpose();
+  const std::string message = fmt::format(
+      "pose =\n{}\nhas expected z-axis = {}\nand expected translation = {}",
+      fmt_eigen(pose.GetAsMatrix34()), fmt_eigen(expected_z.transpose()),
+      fmt_eigen(expected_translation.transpose()));
+  return ::testing::AssertionSuccess() << message;
 }
 
 // Confirms that the pose computed by HalfSpace::X_FC() is consistent with

--- a/manipulation/util/move_ik_demo_base.cc
+++ b/manipulation/util/move_ik_demo_base.cc
@@ -3,6 +3,7 @@
 #include <utility>
 
 #include "drake/common/drake_throw.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/manipulation/util/robot_plan_utils.h"
 #include "drake/multibody/parsing/parser.h"
 
@@ -49,10 +50,9 @@ void MoveIkDemoBase::HandleStatus(
         plant_.EvalBodyPoseInWorld(
             *context_, plant_.GetBodyByName(ik_link_));
     const math::RollPitchYaw<double> rpy(current_link_pose.rotation());
-    drake::log()->info("{} at: {} {}",
-                       ik_link_,
-                       current_link_pose.translation().transpose(),
-                       rpy.vector().transpose());
+    drake::log()->info("{} at: {} {}", ik_link_,
+                       fmt_eigen(current_link_pose.translation().transpose()),
+                       fmt_eigen(rpy.vector().transpose()));
   }
 }
 

--- a/manipulation/util/robot_plan_interpolator.cc
+++ b/manipulation/util/robot_plan_interpolator.cc
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/text_logging.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/lcmt_robot_plan.hpp"
@@ -148,7 +149,7 @@ void RobotPlanInterpolator::MakeFixedPlan(
   plan.pp = PiecewisePolynomial<double>::ZeroOrderHold(times, knots);
   plan.pp_deriv = plan.pp.derivative();
   plan.pp_double_deriv = plan.pp_deriv.derivative();
-  drake::log()->info("Generated fixed plan at {}", q0.transpose());
+  drake::log()->info("Generated fixed plan at {}", fmt_eigen(q0.transpose()));
 }
 
 void RobotPlanInterpolator::Initialize(double plan_start_time,

--- a/math/test/autodiff_test.cc
+++ b/math/test/autodiff_test.cc
@@ -82,8 +82,7 @@ TEST_F(AutodiffTest, ExtractValue) {
   expected[1] = sin(v0_) + v1_;
   expected[2] = v0_ * v0_ + v1_ * v1_ * v1_;
   EXPECT_TRUE(
-      CompareMatrices(expected, values, 1e-10, MatrixCompareType::absolute))
-      << values;
+      CompareMatrices(expected, values, 1e-10, MatrixCompareType::absolute));
 }
 
 TEST_F(AutodiffTest, ExtractGradient) {
@@ -110,8 +109,7 @@ TEST_F(AutodiffTest, ExtractGradient) {
   expected(2, 1) = 3 * v1_ * v1_;
 
   EXPECT_TRUE(
-      CompareMatrices(expected, gradients, 1e-10, MatrixCompareType::absolute))
-      << gradients;
+      CompareMatrices(expected, gradients, 1e-10, MatrixCompareType::absolute));
 
   // Given an AutoDiff matrix with no derivatives, ExtractGradient() should
   // return a matrix with zero-length rows, or return with specified-length

--- a/multibody/constraint/constraint_solver.h
+++ b/multibody/constraint/constraint_solver.h
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/text_logging.h"
 #include "drake/multibody/constraint/constraint_problem_data.h"
 #include "drake/solvers/moby_lcp_solver.h"
@@ -2443,11 +2444,11 @@ void ConstraintSolver<T>::CalcContactForcesInContactFrames(
 
     // Verify that the two directions are orthogonal.
     if (abs(contact_normal.dot(contact_tangent)) > loose_eps) {
-      std::ostringstream oss;
-      oss << "Contact normal (" << contact_normal.transpose() << ") and ";
-      oss << "contact tangent (" << contact_tangent.transpose() << ") ";
-      oss << "insufficiently orthogonal.";
-      throw std::logic_error(oss.str());
+      throw std::logic_error(fmt::format(
+          "Contact normal ({}) and contact tangent ({}) insufficiently "
+          "orthogonal.",
+          fmt_eigen(contact_normal.transpose()),
+          fmt_eigen(contact_tangent.transpose())));
     }
 
     // Initialize the contact force expressed in the global frame.
@@ -2535,11 +2536,11 @@ void ConstraintSolver<T>::CalcContactForcesInContactFrames(
 
     // Verify that the two directions are orthogonal.
     if (abs(contact_normal.dot(contact_tangent)) > loose_eps) {
-      std::ostringstream oss;
-      oss << "Contact normal (" << contact_normal.transpose() << ") and ";
-      oss << "contact tangent (" << contact_tangent.transpose() << ") ";
-      oss << "insufficiently orthogonal.";
-      throw std::logic_error(oss.str());
+      throw std::logic_error(fmt::format(
+          "Contact normal ({}) and contact tangent ({}) insufficiently "
+          "orthogonal.",
+          fmt_eigen(contact_normal.transpose()),
+          fmt_eigen(contact_tangent.transpose())));
     }
 
     // Compute the contact force expressed in the global frame.

--- a/multibody/inverse_kinematics/test/differential_inverse_kinematics_test.cc
+++ b/multibody/inverse_kinematics/test/differential_inverse_kinematics_test.cc
@@ -9,6 +9,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/find_resource.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/manipulation/kuka_iiwa/iiwa_constants.h"
 #include "drake/math/rigid_transform.h"
@@ -96,7 +97,7 @@ class DifferentialInverseKinematicsTest : public ::testing::Test {
                            const DifferentialInverseKinematicsResult& result) {
     ASSERT_TRUE(result.joint_velocities != std::nullopt);
     drake::log()->info("result.joint_velocities = {}",
-                       result.joint_velocities->transpose());
+                       fmt_eigen(result.joint_velocities->transpose()));
 
     const VectorXd q = plant_->GetPositions(*context_);
     auto temp_context = plant_->CreateDefaultContext();
@@ -105,9 +106,9 @@ class DifferentialInverseKinematicsTest : public ::testing::Test {
 
     const multibody::SpatialVelocity<double> V_WE_actual =
         frame_E_->CalcSpatialVelocityInWorld(*temp_context);
-    drake::log()->info(
-        "V_WE_actual = {}", V_WE_actual.get_coeffs().transpose());
-    drake::log()->info("V_WE = {}", V_WE.get_coeffs().transpose());
+    drake::log()->info("V_WE_actual = {}",
+                       fmt_eigen(V_WE_actual.get_coeffs().transpose()));
+    drake::log()->info("V_WE = {}", fmt_eigen(V_WE.get_coeffs().transpose()));
     EXPECT_TRUE(CompareMatrices(V_WE_actual.get_coeffs().normalized(),
                                 V_WE.get_coeffs().normalized(), 1e-6));
 

--- a/multibody/inverse_kinematics/test/global_inverse_kinematics_test_util.cc
+++ b/multibody/inverse_kinematics/test/global_inverse_kinematics_test_util.cc
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "drake/common/find_resource.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/multibody/inverse_kinematics/inverse_kinematics.h"
@@ -74,8 +75,8 @@ void KukaTest::CheckGlobalIKSolution(
     // Tolerance from Gurobi is about 1E-6. I increase it to 3e-6 to pass on Mac
     // CI.
     const double tol = 3e-6;
-    EXPECT_TRUE((body_Ri.array().abs() <= 1 + tol).all()) << "body_Ri:\n"
-                                                          << body_Ri << "\n";
+    EXPECT_TRUE((body_Ri.array().abs() <= 1 + tol).all())
+        << fmt::format("body_Ri:\n{}\n", fmt_eigen(body_Ri));
     EXPECT_LE(body_Ri.trace(), 3 + tol);
     EXPECT_GE(body_Ri.trace(), -1 - tol);
     Vector3d body_pos_global_ik =

--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -3,15 +3,13 @@
 #include <filesystem>
 #include <iomanip>
 #include <memory>
-#include <ostream>
 #include <set>
 #include <sstream>
 #include <stdexcept>
 
-#include <fmt/format.h>
-
 #include "drake/common/diagnostic_policy.h"
 #include "drake/common/drake_assert.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/text_logging.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/proximity_properties.h"
@@ -89,7 +87,7 @@ UrdfMaterial AddMaterialToMaterialMap(
       auto mat_descrip = [](const UrdfMaterial& mat) {
         std::string rgb_string =
             mat.rgba.has_value()
-                ? fmt::format("RGBA: {}", mat.rgba->transpose())
+                ? fmt::format("RGBA: {}", fmt_eigen(mat.rgba->transpose()))
                 : "RGBA: None";
         std::string map_string =
             mat.diffuse_map.has_value()

--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -9,12 +9,11 @@
 
 #include <drake_vendor/sdf/Root.hh>
 #include <drake_vendor/sdf/parser.hh>
-#include <fmt/ostream.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/geometry_instance.h"
@@ -697,9 +696,19 @@ template <typename T, typename Compare>
       if (matches(value, *expected_value)) {
         return ::testing::AssertionSuccess();
       } else {
-        failure << "\nIncorrect values for ('" << group << "', " << property
-                << "'):" << "\n  expected: " << (*expected_value)
-                << "\n  found:    " << value;
+        std::string value_str;
+        std::string expected_str;
+        if constexpr (is_eigen_type<T>::value) {
+          value_str = fmt::to_string(fmt_eigen(value));
+          expected_str = fmt::to_string(fmt_eigen(*expected_value));
+        } else {
+          value_str = fmt::to_string(value);
+          expected_str = fmt::to_string(*expected_value);
+        }
+        failure << "\nIncorrect values for "
+                << "('" << group << "', " << property << "'):"
+                << "\n  expected: " << expected_str
+                << "\n  found:    " << value_str;
       }
     } else {
       failure << "\n  missing expected property ('" << group << "', '"

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -3,10 +3,12 @@
 #include <memory>
 #include <vector>
 
+#include <fmt/ostream.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
@@ -24,13 +26,13 @@ namespace internal {
 
 std::ostream& operator<<(std::ostream& out, const UrdfMaterial& m) {
   if (m.rgba.has_value()) {
-    out << "RGBA: " << m.rgba->transpose();
+    fmt::print(out, "RGBA: {}", fmt_eigen(m.rgba->transpose()));
   } else {
     out << "RGBA: None";
   }
   out << ", ";
   if (m.diffuse_map.has_value()) {
-    out << "Diffuse map: " << *m.diffuse_map;
+    fmt::print(out, "Diffuse map: {}", *m.diffuse_map);
   } else {
     out << "Diffuse map: None";
   }

--- a/multibody/tree/spatial_inertia.cc
+++ b/multibody/tree/spatial_inertia.cc
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include <fmt/format.h>
+#include "drake/common/fmt_eigen.h"
 
 namespace drake {
 namespace multibody {
@@ -68,9 +68,9 @@ SpatialInertia<T> SpatialInertia<T>::SolidCylinderWithDensity(
   using std::abs;
   constexpr double kTolerance = 1E-14;
   if (abs(unit_vector.norm() - 1) > kTolerance) {
-    std::string error_message = fmt::format("{}(): The unit_vector argument "
-      "{} is not a unit vector.", __func__, unit_vector.transpose());
-    throw std::logic_error(error_message);
+    throw std::logic_error(
+        fmt::format("{}(): The unit_vector argument {} is not a unit vector.",
+                    __func__, fmt_eigen(unit_vector.transpose())));
   }
 
   const T volume = M_PI * r * r * l;  // π r² l
@@ -216,6 +216,7 @@ std::ostream& operator<<(std::ostream& out, const SpatialInertia<T>& M) {
   const T& y = p_PBcm.y();
   const T& z = p_PBcm.z();
 
+  // TODO(jwnimmer-tri) Rewrite this to use fmt to our advantage.
   if constexpr (scalar_predicate<T>::is_bool) {
     out << "\n"
         << fmt::format(" mass = {}\n", mass)
@@ -223,7 +224,7 @@ std::ostream& operator<<(std::ostream& out, const SpatialInertia<T>& M) {
   } else {
     // Print symbolic results.
     out << " mass = " << mass << "\n"
-        << " Center of mass = [" << p_PBcm.transpose() << "]\n";
+        << fmt::format(" Center of mass = {}\n", fmt_eigen(p_PBcm.transpose()));
   }
 
   // Get G_BP (unit inertia about point P) and use it to calculate I_BP

--- a/multibody/tree/test/body_node_test.cc
+++ b/multibody/tree/test/body_node_test.cc
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/multibody/tree/body.h"
 #include "drake/multibody/tree/planar_mobilizer.h"
@@ -240,7 +241,8 @@ GTEST_TEST(BodyNodeTest, FactorHingeMatrixThrows) {
         Vector3d{Vector3d{1.1, 2e12, 3e17}}}) {
     six_by_six.block<3, 3>(0, 0) = make_K(K_eigen_values);
     EXPECT_NO_THROW(Tester::CallLltFactorization(body_node, six_by_six))
-        << "For expected bad eigenvalues: " << K_eigen_values.transpose();
+        << fmt::format("For expected bad eigenvalues: {}",
+                       fmt_eigen(K_eigen_values.transpose()));
   }
 
   // N.B. There are more ways the matrix could cause a throw. This approach
@@ -263,7 +265,8 @@ GTEST_TEST(BodyNodeTest, FactorHingeMatrixThrows) {
     six_by_six.block<3, 3>(0, 0) = make_K(K_eigen_values);
     EXPECT_THROW(Tester::CallLltFactorization(body_node, six_by_six),
                  std::exception)
-        << "For expected bad eigenvalues: " << K_eigen_values.transpose();
+        << fmt::format("For expected bad eigenvalues: {}",
+                       fmt_eigen(K_eigen_values.transpose()));
   }
 }
 

--- a/multibody/tree/test/geometry_spatial_inertia_test.cc
+++ b/multibody/tree/test/geometry_spatial_inertia_test.cc
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/proximity/make_box_mesh.h"
@@ -57,7 +58,8 @@ constexpr double kTol = std::numeric_limits<double>::epsilon();
            << dut.get_unit_inertia() << "\n"
            << "  with tolerance: " << tolerance << "\n"
            << "(with mass: " << dut.get_mass() << "\n"
-           << " and com: " << dut.get_com().transpose() << "\n";
+           << " and com: "
+           << fmt::to_string(fmt_eigen(dut.get_com().transpose())) << "\n";
   }
   return ::testing::AssertionSuccess();
 }

--- a/multibody/tree/unit_inertia.cc
+++ b/multibody/tree/unit_inertia.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/tree/unit_inertia.h"
 
+#include "drake/common/fmt_eigen.h"
+
 namespace drake {
 namespace multibody {
 
@@ -28,8 +30,9 @@ UnitInertia<T> UnitInertia<T>::SolidCapsule(const T& r, const T& L,
   using std::abs;
   constexpr double kTolerance = 1E-14;
   if (abs(unit_vector.norm() - 1) > kTolerance) {
-    std::string error_message = fmt::format("{}(): The unit_vector argument "
-      "{} is not a unit vector.", __func__, unit_vector.transpose());
+    std::string error_message =
+        fmt::format("{}(): The unit_vector argument {} is not a unit vector.",
+                    __func__, fmt_eigen(unit_vector.transpose()));
     throw std::logic_error(error_message);
   }
 

--- a/perception/test/point_cloud_test.cc
+++ b/perception/test/point_cloud_test.cc
@@ -5,6 +5,7 @@
 #include <common_robotics_utilities/openmp_helpers.hpp>
 #include <gtest/gtest.h>
 
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/random.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
@@ -546,7 +547,7 @@ void CheckNormal(const Eigen::Ref<const Eigen::Vector3f>& normal,
                  const Eigen::Ref<const Eigen::Vector3f>& expected,
                  double tolerance) {
   EXPECT_NEAR(normal.norm(), 1.0, tolerance)
-      << "Normal " << normal << " does not have unit length.";
+      << fmt::format("Normal {} does not have unit length.", fmt_eigen(normal));
   EXPECT_NEAR(std::abs(normal.dot(expected)), 1.0, tolerance)
       << "normal.dot(expected) = " << normal.dot(expected);
 }

--- a/planning/collision_checker.cc
+++ b/planning/collision_checker.cc
@@ -20,6 +20,7 @@
 #endif
 
 #include "drake/common/drake_throw.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/multibody/parsing/scoped_names.h"
 
 namespace drake {
@@ -429,7 +430,8 @@ void CollisionChecker::SetCollisionFilterMatrix(
   // Now test for consistency.
   ValidateFilteredCollisionMatrix(filter_matrix, __func__);
   filtered_collisions_ = filter_matrix;
-  log()->debug("Set collision filter matrix to:\n{}", filtered_collisions_);
+  log()->debug("Set collision filter matrix to:\n{}",
+               fmt_eigen(filtered_collisions_));
   UpdateMaxCollisionPadding();
 }
 
@@ -809,7 +811,7 @@ CollisionChecker::CollisionChecker(CollisionCheckerParams params,
   // Generate the filtered collision matrix.
   nominal_filtered_collisions_ = GenerateFilteredCollisionMatrix();
   filtered_collisions_ = nominal_filtered_collisions_;
-  log()->debug("Collision filter matrix:\n{}", filtered_collisions_);
+  log()->debug("Collision filter matrix:\n{}", fmt_eigen(filtered_collisions_));
 }
 
 CollisionChecker::CollisionChecker(const CollisionChecker&) = default;

--- a/planning/scene_graph_collision_checker.cc
+++ b/planning/scene_graph_collision_checker.cc
@@ -5,6 +5,7 @@
 #include <set>
 #include <utility>
 
+#include "drake/common/fmt_eigen.h"
 #include "drake/geometry/collision_filter_manager.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/scene_graph.h"
@@ -63,7 +64,7 @@ std::optional<GeometryId> SceneGraphCollisionChecker::DoAddCollisionShapeToBody(
       plant().CollectRegisteredGeometries(plant().GetBodiesWeldedTo(bodyA));
   log()->debug("Adding shape (group: [{}]) to {} (FrameID {}) at X_AG =\n{}",
                group_name, GetScopedName(bodyA), body_frame_id,
-               X_AG.GetAsMatrix4());
+               fmt_eigen(X_AG.GetAsMatrix4()));
 
   // The geometry instance template which will be copied into each per-thread
   // SceneGraph Context; the GeometryId will match across each thread this way.

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -18,6 +18,7 @@
 #include <fmt/ostream.h>
 
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/symbolic/decompose.h"
 #include "drake/common/symbolic/monomial_util.h"
 #include "drake/math/matrix_util.h"
@@ -744,9 +745,8 @@ Binding<LinearConstraint> MathematicalProgram::AddLinearConstraint(
     return AddConstraint(
         internal::BindingDynamicCast<LinearConstraint>(binding));
   } else {
-    std::stringstream oss;
-    oss << "Expression " << v << " is non-linear.";
-    throw std::runtime_error(oss.str());
+    throw std::runtime_error(
+        fmt::format("Expression {} is non-linear.", fmt_eigen(v)));
   }
 }
 
@@ -1786,14 +1786,15 @@ bool MathematicalProgram::CheckBinding(const Binding<C>& binding) const {
 
 std::ostream& operator<<(std::ostream& os, const MathematicalProgram& prog) {
   if (prog.num_vars() > 0) {
-    os << "Decision variables:" << prog.decision_variables().transpose()
-       << "\n\n";
+    os << fmt::format("Decision variables: {}\n\n",
+                      fmt_eigen(prog.decision_variables().transpose()));
   } else {
     os << "No decision variables.\n";
   }
 
   if (prog.num_indeterminates() > 0) {
-    os << "Indeterminates:" << prog.indeterminates().transpose() << "\n\n";
+    os << fmt::format("Indeterminates: {}\n\n",
+                      fmt_eigen(prog.indeterminates().transpose()));
   }
 
   for (const auto& b : prog.GetAllCosts()) {

--- a/solvers/test/equality_constrained_qp_solver_test.cc
+++ b/solvers/test/equality_constrained_qp_solver_test.cc
@@ -59,9 +59,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testUnconstrainedQPDispatch) {
   const auto& y_value = result.GetSolution(y);
   actual_answer << x_value, y_value;
   EXPECT_TRUE(CompareMatrices(expected_answer, actual_answer, 1e-10,
-                              MatrixCompareType::absolute))
-      << "\tExpected: " << expected_answer.transpose()
-      << "\tActual: " << actual_answer.transpose();
+                              MatrixCompareType::absolute));
   EXPECT_NEAR(2.0, result.get_optimal_cost(), 1e-10);
 
   // Problem still has only quadratic costs, so solver should be the same.
@@ -115,9 +113,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testLinearlyConstrainedQPDispatch) {
   auto y_value = result.GetSolution(y);
   actual_answer << x_value, y_value;
   EXPECT_TRUE(CompareMatrices(expected_answer, actual_answer, 1e-10,
-                              MatrixCompareType::absolute))
-      << "\tExpected: " << expected_answer.transpose()
-      << "\tActual: " << actual_answer.transpose();
+                              MatrixCompareType::absolute));
   EXPECT_NEAR(0.5, result.get_optimal_cost(), 1e-10);
   EXPECT_TRUE(CompareMatrices(result.GetDualSolution(constraint1), Vector1d(-1),
                               1e-14));

--- a/solvers/test/moby_lcp_solver_test.cc
+++ b/solvers/test/moby_lcp_solver_test.cc
@@ -72,8 +72,7 @@ void RunRegularizedLcp(const Eigen::MatrixBase<Derived>& M,
     if (expect_fast_pass) {
       ASSERT_TRUE(result);
       EXPECT_TRUE(CompareMatrices(fast_z, expected_z, epsilon,
-                                  MatrixCompareType::absolute))
-          << "expected: " << expected_z << " actual " << fast_z << std::endl;
+                                  MatrixCompareType::absolute));
     } else {
       EXPECT_FALSE(CompareMatrices(fast_z, expected_z, epsilon,
                                    MatrixCompareType::absolute));

--- a/systems/analysis/test/initial_value_problem_test.cc
+++ b/systems/analysis/test/initial_value_problem_test.cc
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/systems/analysis/integrator_base.h"
@@ -131,17 +132,18 @@ TEST_P(InitialValueProblemAccuracyTest, ParticleInAGasMomentum) {
 
         EXPECT_TRUE(CompareMatrices(particle_momentum_ivp.Solve(t0, t),
                                     solution, integration_accuracy_))
-            << "Failure solving d𝐩/dt = -μ * 𝐩/m"
-            << " using 𝐩(" << t0 << "; [μ, m]) = " << p0 << " for t = " << t
-            << ", μ = " << mu << " and m = " << m << " to an accuracy of "
-            << integration_accuracy_;
+            << fmt::format(
+                   "Failure solving d𝐩/dt = -μ * 𝐩/m using 𝐩({}; [μ, m]) = {}"
+                   " for t = {}, μ = {} and m = {} to an accuracy of {}",
+                   t0, fmt_eigen(p0), t, mu, m, integration_accuracy_);
 
         EXPECT_TRUE(CompareMatrices(particle_momentum_approx->Evaluate(t),
                                     solution, integration_accuracy_))
-            << "Failure approximating the solution for d𝐩/dt = -μ * 𝐩/m"
-            << " using 𝐩(" << t0 << "; [μ, m]) = " << p0 << " for t = " << t
-            << ", μ = " << mu << " and m = " << m << " to an accuracy of "
-            << integration_accuracy_ << " with solver's continuous extension.";
+            << fmt::format(
+                   "Failure approximating the solution for d𝐩/dt = -μ * 𝐩/m"
+                   " using 𝐩({}; [μ, m]) = {} for t = {}, μ = {} and m = {}"
+                   " to an accuracy of {} with solver's continuous extension.",
+                   t0, fmt_eigen(p0), t, mu, m, integration_accuracy_);
       }
     }
   }
@@ -212,18 +214,23 @@ TEST_P(InitialValueProblemAccuracyTest, ParticleInAGasForcedVelocity) {
             F / mu * (1. - std::exp(-mu * (t - t0) / m));
         EXPECT_TRUE(CompareMatrices(particle_velocity_ivp.Solve(t0, t),
                                     solution, integration_accuracy_))
-            << "Failure solving d𝐯/dt = (-μ * 𝐯 + 𝐅) / m"
-            << " using 𝐯(" << t0 << "; [μ, m]) = " << v0 << " for t = " << t
-            << ", μ = " << mu << ", m = " << m << "and 𝐅 = " << F
-            << " to an accuracy of " << integration_accuracy_;
+            << fmt::format(
+                   "Failure solving"
+                   " d𝐯/dt = (-μ * 𝐯 + 𝐅) / m using 𝐯({}; [μ, m]) = {}"
+                   " for t = {}, μ = {}, m = {} and 𝐅 = {}"
+                   " to an accuracy of {}",
+                   t0, fmt_eigen(v0), t, mu, m, fmt_eigen(F),
+                   integration_accuracy_);
 
         EXPECT_TRUE(CompareMatrices(particle_velocity_approx->Evaluate(t),
                                     solution, integration_accuracy_))
-            << "Failure approximating the solution for "
-            << "d𝐯/dt = (-μ * 𝐯 + 𝐅) / m using 𝐯(" << t0 << "; [μ, m]) = " << v0
-            << " for t = " << t << ", μ = " << mu << ", m = " << m
-            << "and 𝐅 = " << F << " to an accuracy of " << integration_accuracy_
-            << " with solver's continuous extension.";
+            << fmt::format(
+                   "Failure approximating the solution for"
+                   " d𝐯/dt = (-μ * 𝐯 + 𝐅) / m using 𝐯({}; [μ, m]) = {}"
+                   " for t = {}, μ = {}, m = {} and 𝐅 = {}"
+                   " to an accuracy of {} with solver's continuous extension.",
+                   t0, fmt_eigen(v0), t, mu, m, fmt_eigen(F),
+                   integration_accuracy_);
       }
     }
   }

--- a/systems/framework/vector_base.h
+++ b/systems/framework/vector_base.h
@@ -12,6 +12,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/fmt_ostream.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/unused.h"
@@ -260,7 +261,7 @@ class VectorBase {
 /// RowVectorX<T>. This is useful for debugging purposes.
 template <typename T>
 std::ostream& operator<<(std::ostream& os, const VectorBase<T>& vec) {
-  os << vec.CopyToVector().transpose();
+  os << fmt::to_string(fmt_eigen(vec.CopyToVector().transpose()));
   return os;
 }
 

--- a/systems/primitives/first_order_low_pass_filter.cc
+++ b/systems/primitives/first_order_low_pass_filter.cc
@@ -1,10 +1,10 @@
 #include "drake/systems/primitives/first_order_low_pass_filter.h"
 
-#include <sstream>
 #include <stdexcept>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/unused.h"
 
 namespace drake {
@@ -36,11 +36,11 @@ FirstOrderLowPassFilter<T>::FirstOrderLowPassFilter(
 template <typename T>
 double FirstOrderLowPassFilter<T>::get_time_constant() const {
   if (!time_constants_.isConstant(time_constants_[0])) {
-    std::stringstream s;
-    s << "The time constants vector, [" << time_constants_ << "], cannot be "
-         "represented as a scalar value. Please use "
-         "FirstOrderLowPassFilter::get_time_constants_vector() instead.";
-    throw std::domain_error(s.str());
+    throw std::domain_error(fmt::format(
+        "The time constants vector, [{}], cannot be represented as a scalar "
+        "value. Please use FirstOrderLowPassFilter::get_time_constants_vector()"
+        " instead.",
+        fmt_eigen(time_constants_)));
   }
   return time_constants_[0];
 }

--- a/systems/primitives/gain.cc
+++ b/systems/primitives/gain.cc
@@ -1,7 +1,6 @@
 #include "drake/systems/primitives/gain.h"
 
-#include <fmt/format.h>
-
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/unused.h"
 
 namespace drake {
@@ -28,7 +27,7 @@ double Gain<T>::get_gain() const {
     throw std::runtime_error(fmt::format(
         "The gain vector [{}] cannot be represented as a scalar value. "
         "Please use drake::systems::Gain::get_gain_vector() instead.",
-        k_.transpose()));
+        fmt_eigen(k_.transpose())));
   }
   return k_[0];
 }

--- a/systems/primitives/sine.cc
+++ b/systems/primitives/sine.cc
@@ -1,8 +1,7 @@
 #include "drake/systems/primitives/sine.h"
 
-#include <sstream>
-
 #include "drake/common/drake_throw.h"
+#include "drake/common/fmt_eigen.h"
 
 namespace drake {
 namespace systems {
@@ -62,11 +61,10 @@ Sine<T>::Sine(const Sine<U>& other)
 template <typename T>
 double Sine<T>::amplitude() const {
   if (!is_const_amplitude_) {
-    std::stringstream s;
-    s << "The amplitude vector, [" << amplitude_ << "], cannot be represented "
-      << "as a scalar value. Please use "
-      << "drake::systems::Sine::amplitude_vector() instead.";
-    throw std::logic_error(s.str());
+    throw std::logic_error(fmt::format(
+        "The amplitude vector, [{}], cannot be represented as a scalar value. "
+        "Please use drake::systems::Sine::amplitude_vector() instead.",
+        fmt_eigen(amplitude_)));
   }
   return amplitude_[0];
 }
@@ -74,11 +72,10 @@ double Sine<T>::amplitude() const {
 template <typename T>
 double Sine<T>::frequency() const {
   if (!is_const_frequency_) {
-    std::stringstream s;
-    s << "The frequency vector, [" << frequency_ << "], cannot be represented "
-      << "as a scalar value. Please use "
-      << "drake::systems::Sine::frequency_vector() instead.";
-    throw std::logic_error(s.str());
+    throw std::logic_error(fmt::format(
+        "The frequency vector, [{}], cannot be represented as a scalar value. "
+        "Please use drake::systems::Sine::frequency_vector() instead.",
+        fmt_eigen(frequency_)));
   }
   return frequency_[0];
 }
@@ -86,11 +83,10 @@ double Sine<T>::frequency() const {
 template <typename T>
 double Sine<T>::phase() const {
   if (!is_const_phase_) {
-    std::stringstream s;
-    s << "The phase vector, [" << phase_ << "], cannot be represented as a "
-      << "scalar value. Please use "
-      << "drake::systems::Sine::phase_vector() instead.";
-    throw std::logic_error(s.str().c_str());
+    throw std::logic_error(fmt::format(
+        "The phase vector, [{}], cannot be represented as a scalar value. "
+        "Please use drake::systems::Sine::phase_vector() instead.",
+        fmt_eigen(phase_)));
   }
   return phase_[0];
 }

--- a/systems/sensors/camera_info.cc
+++ b/systems/sensors/camera_info.cc
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/fmt_eigen.h"
 
 namespace drake {
 namespace systems {
@@ -68,7 +69,8 @@ CameraInfo::CameraInfo(
   // TODO(eric.cousineau): Relax this with a tolerance?
   if (K(0, 1) != 0 || K(1, 0) != 0 || K(2, 0) != 0 || K(2, 1) != 0 ||
       K(2, 2) != 1) {
-    errors << kPrefix << "The camera's intrinsic matrix is malformed:\n" << K;
+    errors << kPrefix << "The camera's intrinsic matrix is malformed:\n"
+           << fmt::to_string(fmt_eigen(K));
   }
 
   const std::string error_message = errors.str();


### PR DESCRIPTION
Towards #17742.  That issue provides a long explanation of the whole situation; please have a look.

The goal of this PR is to get most of our uses of `Eigen::operator<<` centralized to go through `fmt_eigen`.  This provides for a single point of control to change how we format them (e.g., to ensure that we always print using round-trip precision), eventually allowing us to build using `-DEIGEN_NO_IO` to ensure that we're ready for fmt versions > 9, as well as using format mini-language to customize the output.

(Note that we _cannot_ specialize `fmt::formatter` for Eigen ourselves.  Specializing the formatting for third-party types easily leads to ODR violations.  Only first-party code should ever specialize formatters for its types.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18811)
<!-- Reviewable:end -->
