### PR TITLE
[parsing] Integrate ParsingWorkspace into Mujoco parser

### DIFF
--- a/multibody/parsing/detail_mujoco_parser.h
+++ b/multibody/parsing/detail_mujoco_parser.h
@@ -42,7 +42,7 @@ namespace internal {
 ModelInstanceIndex AddModelFromMujocoXml(
     const DataSource& data_source, const std::string& model_name,
     const std::optional<std::string>& parent_model_name,
-    MultibodyPlant<double>* plant);
+    const ParsingWorkspace& workspace);
 
 class MujocoParserWrapper final : public ParserInterface {
  public:


### PR DESCRIPTION
This patch clears the way for making the Mujoco parser work more like the other parsers in the suite. It will be necessary for integrating control of diagnostic output, and for other forthcoming changes that affect all parsers.

The bulk of the changes are in the unit test, but that should all be functionality-neutral.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18812)
<!-- Reviewable:end -->
