### PR TITLE
[solvers] Add GUROBI_NUM_THREADS environment variable

### DIFF
--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -366,6 +366,7 @@ drake_cc_library(
 drake_cc_googletest(
     name = "global_inverse_kinematics_test",
     timeout = "moderate",
+    num_threads = 4,
     tags = gurobi_test_tags() + [
         # Takes too long to run with Valgrind.
         "no_memcheck",
@@ -382,6 +383,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "global_inverse_kinematics_reachable_test",
     timeout = "moderate",
+    num_threads = 4,
     tags = gurobi_test_tags() + [
         # Takes too long to run with Valgrind.
         "no_memcheck",
@@ -400,6 +402,7 @@ drake_cc_googletest(
     timeout = "long",
     # This test is prohibitively slow with --compilation_mode=dbg.
     disable_in_compilation_mode_dbg = True,
+    num_threads = 4,
     tags = gurobi_test_tags() + [
         "no_asan",
         # Takes too long to run with Valgrind.
@@ -416,6 +419,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "global_inverse_kinematics_collision_avoidance_test",
     timeout = "moderate",
+    num_threads = 4,
     tags = gurobi_test_tags() + [
         # Takes too long to run with Valgrind.
         "no_memcheck",

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1546,6 +1546,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "mixed_integer_rotation_constraint_limit_test",
     timeout = "long",
+    num_threads = 4,
     tags = gurobi_test_tags() + [
         # Times out with Valgrind
         "no_memcheck",

--- a/tools/skylark/kwargs.bzl
+++ b/tools/skylark/kwargs.bzl
@@ -78,5 +78,6 @@ def incorporate_num_threads(kwargs, *, num_threads):
         "OPENBLAS_NUM_THREADS": str(num_threads),
         "NUMEXPR_NUM_THREADS": str(num_threads),
         "MKL_NUM_THREADS": str(num_threads),
+        "GUROBI_NUM_THREADS": str(num_threads),
     })
     return kwargs


### PR DESCRIPTION
Towards #18775.

When `GUROBI_NUM_THREADS` is set to an integer, it provides a default for the `"Threads"` solver-specific solver option.

Wire this up into the Bazel test runner so that the BUILD rule `num_threads = ...` specification covers this new variable as well.

This should allow us to run Gurobi tests in parallel in CI again with caching, by reverting https://github.com/RobotLocomotion/drake-ci/pull/199.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18819)
<!-- Reviewable:end -->
