### PR TITLE
Improve defaults for AffineSystem and LinearSystem

### DIFF
--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -82,9 +82,10 @@ PYBIND11_MODULE(primitives, m) {
                  const Eigen::Ref<const MatrixXd>&,
                  const Eigen::Ref<const MatrixXd>&,
                  const Eigen::Ref<const VectorXd>&, double>(),
-            py::arg("A"), py::arg("B"), py::arg("f0"), py::arg("C"),
-            py::arg("D"), py::arg("y0"), py::arg("time_period") = 0.0,
-            doc.AffineSystem.ctor.doc_7args)
+            py::arg("A") = Eigen::MatrixXd(), py::arg("B") = Eigen::MatrixXd(),
+            py::arg("f0") = Eigen::VectorXd(), py::arg("C") = Eigen::MatrixXd(),
+            py::arg("D") = Eigen::MatrixXd(), py::arg("y0") = Eigen::VectorXd(),
+            py::arg("time_period") = 0.0, doc.AffineSystem.ctor.doc_7args)
         // TODO(eric.cousineau): Fix these to return references instead of
         // copies.
         .def("A", overload_cast_explicit<const MatrixXd&>(&AffineSystem<T>::A),
@@ -106,6 +107,12 @@ PYBIND11_MODULE(primitives, m) {
         // wrapped.
         .def("time_period", &AffineSystem<T>::time_period,
             doc.TimeVaryingAffineSystem.time_period.doc)
+        .def("num_states", &TrajectoryAffineSystem<T>::num_states,
+            doc.TimeVaryingAffineSystem.num_states.doc)
+        .def("num_inputs", &TrajectoryAffineSystem<T>::num_inputs,
+            doc.TimeVaryingAffineSystem.num_inputs.doc)
+        .def("num_outputs", &TrajectoryAffineSystem<T>::num_outputs,
+            doc.TimeVaryingAffineSystem.num_outputs.doc)
         .def("configure_default_state",
             &TimeVaryingAffineSystem<T>::configure_default_state, py::arg("x0"),
             doc.TimeVaryingAffineSystem.configure_default_state.doc)
@@ -214,7 +221,8 @@ PYBIND11_MODULE(primitives, m) {
                  const Eigen::Ref<const MatrixXd>&,
                  const Eigen::Ref<const MatrixXd>&,
                  const Eigen::Ref<const MatrixXd>&, double>(),
-            py::arg("A"), py::arg("B"), py::arg("C"), py::arg("D"),
+            py::arg("A") = Eigen::MatrixXd(), py::arg("B") = Eigen::MatrixXd(),
+            py::arg("C") = Eigen::MatrixXd(), py::arg("D") = Eigen::MatrixXd(),
             py::arg("time_period") = 0.0, doc.LinearSystem.ctor.doc_5args);
 
     DefineTemplateClassWithDefault<MatrixGain<T>, LinearSystem<T>>(

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -225,6 +225,32 @@ class TestGeneral(unittest.TestCase):
         system.configure_default_state(x0=np.array([1, 2]))
         system.configure_random_state(covariance=np.eye(2))
 
+    def test_linear_affine_system_empty_matrices(self):
+        # Confirm the default values for the system matrices in the
+        # constructor.
+        def CheckSizes(system, num_states, num_inputs, num_outputs):
+            self.assertEqual(system.num_continuous_states(), num_states)
+            self.assertEqual(system.num_inputs(), num_inputs)
+            self.assertEqual(system.num_outputs(), num_outputs)
+
+        # A constant vector system.
+        system = AffineSystem(y0=[2, 1])
+        CheckSizes(system, num_states=0, num_inputs=0, num_outputs=2)
+
+        # A matrix gain.
+        system = AffineSystem(D=np.eye(2))
+        CheckSizes(system, num_states=0, num_inputs=2, num_outputs=2)
+        system = LinearSystem(D=np.eye(2))
+        CheckSizes(system, num_states=0, num_inputs=2, num_outputs=2)
+
+        # Add an offset.
+        system = AffineSystem(D=np.eye(2), y0=[1, 2])
+        CheckSizes(system, num_states=0, num_inputs=2, num_outputs=2)
+
+        # An integrator.
+        system = LinearSystem(B=np.eye(2))
+        CheckSizes(system, num_states=2, num_inputs=2, num_outputs=0)
+
     def test_linear_system_zero_size(self):
         # Explicitly test #12633.
         num_x = 0

--- a/systems/primitives/affine_system.cc
+++ b/systems/primitives/affine_system.cc
@@ -232,25 +232,106 @@ void TimeVaryingAffineSystem<T>::SetRandomState(
 // Our public constructor declares that our most specific subclass is
 // AffineSystem, and then delegates to our protected constructor.
 template <typename T>
-AffineSystem<T>::AffineSystem(const Eigen::Ref<const Eigen::MatrixXd>& A,
-                              const Eigen::Ref<const Eigen::MatrixXd>& B,
-                              const Eigen::Ref<const Eigen::VectorXd>& f0,
-                              const Eigen::Ref<const Eigen::MatrixXd>& C,
-                              const Eigen::Ref<const Eigen::MatrixXd>& D,
-                              const Eigen::Ref<const Eigen::VectorXd>& y0,
-                              double time_period)
-    : AffineSystem<T>(
-          SystemTypeTag<AffineSystem>{},
-          A, B, f0, C, D, y0, time_period) {}
+AffineSystem<T>::AffineSystem(
+    const Eigen::Ref<const Eigen::MatrixXd>& A,
+    const Eigen::Ref<const Eigen::MatrixXd>& B,
+    const Eigen::Ref<const Eigen::VectorXd>& f0,
+    const Eigen::Ref<const Eigen::MatrixXd>& C,
+    const Eigen::Ref<const Eigen::MatrixXd>& D,
+    const Eigen::Ref<const Eigen::VectorXd>& y0,
+
+    double time_period)
+    : AffineSystem<T>(SystemTypeTag<AffineSystem>{}, A, B, f0, C, D, y0,
+                      time_period) {}
 
 namespace {
 
+// Returns the number of states, where any empty matrix is assumed to have the
+// correct size.
+int CalcNumStates(const Eigen::Ref<const Eigen::MatrixXd>& A,
+                  const Eigen::Ref<const Eigen::MatrixXd>& B,
+                  const Eigen::Ref<const Eigen::VectorXd>& f0,
+                  const Eigen::Ref<const Eigen::MatrixXd>& C) {
+  int num_states = 0;
+  if (A.size() > 0) {
+    num_states = A.rows();
+    DRAKE_DEMAND(A.rows() == A.cols());
+  }
+  if (B.size() > 0) {
+    if (num_states) {
+      // This error message is more informative than comparing with num_states.
+      DRAKE_DEMAND(B.rows() == A.rows());
+    } else {
+      num_states = B.rows();
+    }
+  }
+  if (f0.size() > 0) {
+    if (num_states) {
+      DRAKE_DEMAND(f0.size() == num_states);
+    } else {
+      num_states = f0.size();
+    }
+  }
+  if (C.size() > 0) {
+    if (num_states) {
+      DRAKE_DEMAND(C.cols() == num_states);
+    } else {
+      num_states = C.cols();
+    }
+  }
+  return num_states;
+}
+
+// Returns the number of inputs, where any empty matrix is assumed to have the
+// correct size.
+int CalcNumInputs(const Eigen::Ref<const Eigen::MatrixXd>& B,
+                  const Eigen::Ref<const Eigen::MatrixXd>& D) {
+  int num_inputs = 0;
+  if (B.size() > 0) {
+    num_inputs = B.cols();
+  }
+  if (D.size() > 0) {
+    if (num_inputs) {
+      DRAKE_DEMAND(D.cols() == B.cols());
+    } else {
+      num_inputs = D.cols();
+    }
+  }
+  return num_inputs;
+}
+
+// Returns the number of outputs, where any empty matrix is assumed to have the
+// correct size.
+int CalcNumOutputs(const Eigen::Ref<const Eigen::MatrixXd>& C,
+                   const Eigen::Ref<const Eigen::MatrixXd>& D,
+                   const Eigen::Ref<const Eigen::VectorXd>& y0) {
+  int num_outputs = 0;
+  if (C.size() > 0) {
+    num_outputs = C.rows();
+  }
+  if (D.size() > 0) {
+    if (num_outputs) {
+      DRAKE_DEMAND(D.rows() == C.rows());
+    } else {
+      num_outputs = D.rows();
+    }
+  }
+  if (y0.size() > 0) {
+    if (num_outputs) {
+      DRAKE_DEMAND(y0.size() == num_outputs);
+    } else {
+      num_outputs = y0.size();
+    }
+  }
+  return num_outputs;
+}
+
 // Returns whether a matrix is "meaningful" when pre-multiplying a vector.
-bool IsMeaningful(const Eigen::MatrixXd& m) {
+bool IsMeaningful(const Eigen::Ref<const Eigen::MatrixXd>& m) {
   return m.size() > 0 && (m.array() != 0).any();
 }
 
-}  // namespace
+}   // namespace
 
 // Our protected constructor does all of the real work -- everything else
 // delegates to here.
@@ -264,24 +345,24 @@ AffineSystem<T>::AffineSystem(SystemScalarConverter converter,
                               const Eigen::Ref<const Eigen::VectorXd>& y0,
                               double time_period)
     : TimeVaryingAffineSystem<T>(
-          std::move(converter), f0.size(), D.cols(), D.rows(), time_period),
-      A_(A),
-      B_(B),
-      f0_(f0),
-      C_(C),
-      D_(D),
-      y0_(y0),
+          std::move(converter), CalcNumStates(A, B, f0, C), CalcNumInputs(B, D),
+          CalcNumOutputs(C, D, y0), time_period),
+      A_(A.size()
+             ? A
+             : Eigen::MatrixXd::Zero(this->num_states(), this->num_states())),
+      B_(B.size()
+             ? B
+             : Eigen::MatrixXd::Zero(this->num_states(), this->num_inputs())),
+      f0_(f0.size() ? f0 : Eigen::VectorXd::Zero(this->num_states())),
+      C_(C.size()
+             ? C
+             : Eigen::MatrixXd::Zero(this->num_outputs(), this->num_states())),
+      D_(D.size()
+             ? D
+             : Eigen::MatrixXd::Zero(this->num_outputs(), this->num_inputs())),
+      y0_(y0.size() ? y0 : Eigen::VectorXd::Zero(this->num_outputs())),
       has_meaningful_C_(IsMeaningful(C)),
       has_meaningful_D_(IsMeaningful(D)) {
-  DRAKE_DEMAND(this->num_states() == A.rows());
-  DRAKE_DEMAND(this->num_states() == A.cols());
-  DRAKE_DEMAND(this->num_states() == B.rows());
-  DRAKE_DEMAND(this->num_states() == C.cols());
-  DRAKE_DEMAND(this->num_inputs() == B.cols());
-  DRAKE_DEMAND(this->num_inputs() == D.cols());
-  DRAKE_DEMAND(this->num_outputs() == C.rows());
-  DRAKE_DEMAND(this->num_outputs() == D.rows());
-
   // Specify our output port's dependencies more precisely than our base class
   // is able to.  We know that output never depends on time nor parameters,
   // only on state (iff C if non-zero) and input (iff D is non-zero).

--- a/systems/primitives/affine_system.h
+++ b/systems/primitives/affine_system.h
@@ -198,20 +198,26 @@ class AffineSystem : public TimeVaryingAffineSystem<T> {
   /// |:-------:|:-----------:|:-----------:|
   /// | A       | num states  | num states  |
   /// | B       | num states  | num inputs  |
+  /// | f0      | num_states  | 1           |
   /// | C       | num outputs | num states  |
   /// | D       | num outputs | num inputs  |
+  /// | y0      | num_outputs | 1           |
+  ///
+  /// Empty matrices are treated as zero matrices with the appropriate number
+  /// of rows and columns.
   ///
   /// @param time_period Defines the period of the discrete time system; use
-  ///  time_period=0.0 to denote a continuous time system.  @default 0.0
+  /// time_period=0.0 to denote a continuous time system.  @default 0.0
   ///
   /// Subclasses must use the protected constructor, not this one.
-  AffineSystem(const Eigen::Ref<const Eigen::MatrixXd>& A,
-               const Eigen::Ref<const Eigen::MatrixXd>& B,
-               const Eigen::Ref<const Eigen::VectorXd>& f0,
-               const Eigen::Ref<const Eigen::MatrixXd>& C,
-               const Eigen::Ref<const Eigen::MatrixXd>& D,
-               const Eigen::Ref<const Eigen::VectorXd>& y0,
-               double time_period = 0.0);
+  explicit AffineSystem(
+      const Eigen::Ref<const Eigen::MatrixXd>& A = Eigen::MatrixXd(),
+      const Eigen::Ref<const Eigen::MatrixXd>& B = Eigen::MatrixXd(),
+      const Eigen::Ref<const Eigen::VectorXd>& f0 = Eigen::VectorXd(),
+      const Eigen::Ref<const Eigen::MatrixXd>& C = Eigen::MatrixXd(),
+      const Eigen::Ref<const Eigen::MatrixXd>& D = Eigen::MatrixXd(),
+      const Eigen::Ref<const Eigen::VectorXd>& y0 = Eigen::VectorXd(),
+      double time_period = 0.0);
 
   /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
   template <typename U>

--- a/systems/primitives/linear_system.cc
+++ b/systems/primitives/linear_system.cc
@@ -22,13 +22,13 @@ using std::make_unique;
 using std::unique_ptr;
 
 template <typename T>
-LinearSystem<T>::LinearSystem(const Eigen::Ref<const Eigen::MatrixXd>& A,
-                              const Eigen::Ref<const Eigen::MatrixXd>& B,
-                              const Eigen::Ref<const Eigen::MatrixXd>& C,
-                              const Eigen::Ref<const Eigen::MatrixXd>& D,
-                              double time_period)
-    : LinearSystem<T>(SystemTypeTag<LinearSystem>{}, A, B, C, D,
-                      time_period) {}
+LinearSystem<T>::LinearSystem(
+    const Eigen::Ref<const Eigen::MatrixXd>& A,
+    const Eigen::Ref<const Eigen::MatrixXd>& B,
+    const Eigen::Ref<const Eigen::MatrixXd>& C,
+    const Eigen::Ref<const Eigen::MatrixXd>& D,
+    double time_period)
+    : LinearSystem<T>(SystemTypeTag<LinearSystem>{}, A, B, C, D, time_period) {}
 
 template <typename T>
 template <typename U>
@@ -37,15 +37,15 @@ LinearSystem<T>::LinearSystem(const LinearSystem<U>& other)
                       other.time_period()) {}
 
 template <typename T>
-LinearSystem<T>::LinearSystem(SystemScalarConverter converter,
-                              const Eigen::Ref<const Eigen::MatrixXd>& A,
-                              const Eigen::Ref<const Eigen::MatrixXd>& B,
-                              const Eigen::Ref<const Eigen::MatrixXd>& C,
-                              const Eigen::Ref<const Eigen::MatrixXd>& D,
-                              double time_period)
-    : AffineSystem<T>(std::move(converter), A, B,
-                      Eigen::VectorXd::Zero(A.rows()), C, D,
-                      Eigen::VectorXd::Zero(C.rows()), time_period) {}
+LinearSystem<T>::LinearSystem(
+    SystemScalarConverter converter,
+    const Eigen::Ref<const Eigen::MatrixXd>& A,
+    const Eigen::Ref<const Eigen::MatrixXd>& B,
+    const Eigen::Ref<const Eigen::MatrixXd>& C,
+    const Eigen::Ref<const Eigen::MatrixXd>& D,
+    double time_period)
+    : AffineSystem<T>(std::move(converter), A, B, Eigen::VectorXd(), C, D,
+                      Eigen::VectorXd(), time_period) {}
 
 template <typename T>
 unique_ptr<LinearSystem<T>> LinearSystem<T>::MakeLinearSystem(

--- a/systems/primitives/linear_system.h
+++ b/systems/primitives/linear_system.h
@@ -55,12 +55,16 @@ class LinearSystem : public AffineSystem<T> {
   /// | C       | num outputs | num states  |
   /// | D       | num outputs | num inputs  |
   ///
+  /// Empty matrices are treated as zero matrices with the appropriate number
+  /// of rows and columns.
+  ///
   /// Subclasses must use the protected constructor, not this one.
-  LinearSystem(const Eigen::Ref<const Eigen::MatrixXd>& A,
-               const Eigen::Ref<const Eigen::MatrixXd>& B,
-               const Eigen::Ref<const Eigen::MatrixXd>& C,
-               const Eigen::Ref<const Eigen::MatrixXd>& D,
-               double time_period = 0.0);
+  explicit LinearSystem(
+      const Eigen::Ref<const Eigen::MatrixXd>& A = Eigen::MatrixXd(),
+      const Eigen::Ref<const Eigen::MatrixXd>& B = Eigen::MatrixXd(),
+      const Eigen::Ref<const Eigen::MatrixXd>& C = Eigen::MatrixXd(),
+      const Eigen::Ref<const Eigen::MatrixXd>& D = Eigen::MatrixXd(),
+      double time_period = 0.0);
 
   /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
   template <typename U>
@@ -84,11 +88,13 @@ class LinearSystem : public AffineSystem<T> {
   /// etc.); pass a default-constructed object if such support is not desired.
   /// See @ref system_scalar_conversion for detailed background and examples
   /// related to scalar-type conversion support.
-  LinearSystem(SystemScalarConverter converter,
-               const Eigen::Ref<const Eigen::MatrixXd>& A,
-               const Eigen::Ref<const Eigen::MatrixXd>& B,
-               const Eigen::Ref<const Eigen::MatrixXd>& C,
-               const Eigen::Ref<const Eigen::MatrixXd>& D, double time_period);
+  LinearSystem(
+      SystemScalarConverter converter,
+      const Eigen::Ref<const Eigen::MatrixXd>& A,
+      const Eigen::Ref<const Eigen::MatrixXd>& B,
+      const Eigen::Ref<const Eigen::MatrixXd>& C,
+      const Eigen::Ref<const Eigen::MatrixXd>& D,
+      double time_period);
 };
 
 /// Base class for a discrete or continuous linear time-varying (LTV) system.

--- a/systems/primitives/test/affine_system_test.cc
+++ b/systems/primitives/test/affine_system_test.cc
@@ -530,6 +530,75 @@ TEST_F(AffineSystemSymbolicTest, MakeAffineSystemException3) {
                    C_ * x_ + D_ * u_ + y0_, x_, u_, 10.0),
                std::runtime_error);
 }
+
+void CheckSizes(const AffineSystem<double>& sys, int num_states, int num_inputs,
+                int num_outputs) {
+  EXPECT_EQ(sys.A().rows(), num_states);
+  EXPECT_EQ(sys.A().cols(), num_states);
+  EXPECT_EQ(sys.B().rows(), num_states);
+  EXPECT_EQ(sys.B().cols(), num_inputs);
+  EXPECT_EQ(sys.C().rows(), num_outputs);
+  EXPECT_EQ(sys.C().cols(), num_states);
+  EXPECT_EQ(sys.D().rows(), num_outputs);
+  EXPECT_EQ(sys.D().cols(), num_inputs);
+  EXPECT_EQ(sys.f0().size(), num_states);
+  EXPECT_EQ(sys.y0().size(), num_outputs);
+}
+
+// Confirm that empty matrices passed to the constructor are treated as zeros
+// of the correct size.
+GTEST_TEST(AffineSystemExtraTest, EmptyMatrices) {
+  const int kNumStates = 3;
+  const int kNumInputs = 2;
+  const int kNumOutputs = 1;
+  // Default matrices (uninitialized; only their size matters).
+  Eigen::Matrix<double, kNumStates, kNumStates> A;
+  A.setConstant(1);
+  Eigen::Matrix<double, kNumStates, kNumInputs> B;
+  B.setConstant(2);
+  Vector<double, kNumStates> f0;
+  f0.setConstant(3);
+  Eigen::Matrix<double, kNumOutputs, kNumStates> C;
+  C.setConstant(4);
+  Eigen::Matrix<double, kNumOutputs, kNumInputs> D;
+  D.setConstant(5);
+  Vector<double, kNumOutputs> y0;
+  y0.setConstant(6);
+  Eigen::MatrixXd empty{};
+  Eigen::VectorXd empty_vec{};
+
+  auto sys = std::make_unique<AffineSystem<double>>(A, B, f0, C, D, y0);
+  CheckSizes(*sys, kNumStates, kNumInputs, kNumOutputs);
+  // Default A.
+  sys = std::make_unique<AffineSystem<double>>(empty, B, f0, C, D, y0);
+  CheckSizes(*sys, kNumStates, kNumInputs, kNumOutputs);
+  EXPECT_TRUE(sys->A().isZero());
+  // Default B.
+  sys = std::make_unique<AffineSystem<double>>(A, empty, f0, C, D, y0);
+  CheckSizes(*sys, kNumStates, kNumInputs, kNumOutputs);
+  EXPECT_TRUE(sys->B().isZero());
+  // Default f0.
+  sys = std::make_unique<AffineSystem<double>>(A, B, empty_vec, C, D, y0);
+  CheckSizes(*sys, kNumStates, kNumInputs, kNumOutputs);
+  EXPECT_TRUE(sys->f0().isZero());
+  // Default C.
+  sys = std::make_unique<AffineSystem<double>>(A, B, f0, empty, D, y0);
+  CheckSizes(*sys, kNumStates, kNumInputs, kNumOutputs);
+  EXPECT_TRUE(sys->C().isZero());
+  // Default D.
+  sys = std::make_unique<AffineSystem<double>>(A, B, f0, C, empty, y0);
+  CheckSizes(*sys, kNumStates, kNumInputs, kNumOutputs);
+  EXPECT_TRUE(sys->D().isZero());
+  // Default y0.
+  sys = std::make_unique<AffineSystem<double>>(A, B, f0, C, D, empty_vec);
+  CheckSizes(*sys, kNumStates, kNumInputs, kNumOutputs);
+  EXPECT_TRUE(sys->y0().isZero());
+
+  // All default.
+  sys = std::make_unique<AffineSystem<double>>();
+  CheckSizes(*sys, 0, 0, 0);
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
It's always been a pain to produce simple linear/affine systems, because we needed to pass in empty matrices of the correct size (e.g. even if we have no states, the B matrix must have zero rows and number of input columns).  This PR makes the constructor for AffineSystem more robust, setting any empty matrix to an appropriate size. This makes it reasonable to have default values.

This motivation for this was that I was writing a tutorial where the simplest way to produce a system that simple adds an offset to a signal (e.g. to change coordinates), took many lines and lots of explaining. Now we can just have e.g.

```
system = AffineSystem(D=np.eye(2), y0=[1, 2])
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18822)
<!-- Reviewable:end -->
