### PR TITLE
[pydrake] Correct and unify examples in pydrake docstrings

### DIFF
--- a/bindings/pydrake/common/containers.py
+++ b/bindings/pydrake/common/containers.py
@@ -150,14 +150,16 @@ def namedview(name, fields):
     is instantiated, it must be given the object that it will be a proxy for.
     Similar to ``namedtuple``.
 
-    Example::
-        MyView = namedview("MyView", ('a', 'b'))
+    Example:
+        ::
 
-        value = np.array([1, 2])
-        view = MyView(value)
-        view.a = 10  # `value` is now [10, 2]
-        value[1] = 100  # `view` is now [10, 100]
-        view[:] = 3  # `value` is now [3, 3]
+            MyView = namedview("MyView", ('a', 'b'))
+
+            value = np.array([1, 2])
+            view = MyView(value)
+            view.a = 10  # `value` is now [10, 2]
+            value[1] = 100  # `view` is now [10, 100]
+            view[:] = 3  # `value` is now [3, 3]
 
     For more details, see ``NamedViewBase``.
     """

--- a/bindings/pydrake/common/cpp_template.py
+++ b/bindings/pydrake/common/cpp_template.py
@@ -122,10 +122,11 @@ class TemplateBase:
         """
         Returns module name for this object's parent scope.
 
-        Example::
+        Example:
+            ::
 
-            >>> pydrake.common.value.Value.get_module_name()
-            pydrake.common.value
+                >>> pydrake.common.value.Value.get_module_name()
+                pydrake.common.value
         """
         if isinstance(self._scope, types.ModuleType):
             return self._scope.__name__

--- a/bindings/pydrake/common/deprecation.py
+++ b/bindings/pydrake/common/deprecation.py
@@ -257,17 +257,18 @@ def deprecated_callable(message, *, date=None):
     However, if you are dealing with a C++ module (and are writing code inside
     of `_{module}_extra.py`), you should use this approach.
 
-    Example as decorator:
+    Example:
+        ::
 
-        @deprecated_callable("Please use `func_y` instead", date="2038-01-19")
-        def func_x():
-            ...
+            # As decorator
+            @deprecated_callable("Please use `func_y` instead", date="2038-01-19")  # noqa
+            def func_x():
+                ...
 
-    Example for alias:
-
-        my_alias = deprecated_callable(
-            "Please use `my_original` instead", date="2038-01-19"
-        )(my_original)
+            # As alias
+            deprecated_alias = deprecated_callable(
+                "Please use `real_callable` instead", date="2038-01-19"
+            )(real_callable)
     """
 
     def decorator(original):

--- a/bindings/pydrake/systems/scalar_conversion.py
+++ b/bindings/pydrake/systems/scalar_conversion.py
@@ -40,22 +40,23 @@ class TemplateSystem(TemplateClass):
     If any of these constraints are violated, then an error will be thrown
     at the time of the first class instantiation.
 
-    Example::
+    Example:
+        ::
 
-        @TemplateSystem.define("MySystem_")
-        def MySystem_(T):
+            @TemplateSystem.define("MySystem_")
+            def MySystem_(T):
 
-            class Impl(LeafSystem_[T]):
-                def _construct(self, value, converter=None):
-                    LeafSystem_[T].__init__(self, converter=converter)
-                    self.value = value
+                class Impl(LeafSystem_[T]):
+                    def _construct(self, value, converter=None):
+                        LeafSystem_[T].__init__(self, converter=converter)
+                        self.value = value
 
-                def _construct_copy(self, other, converter=None):
-                    Impl._construct(self, other.value, converter=converter)
+                    def _construct_copy(self, other, converter=None):
+                        Impl._construct(self, other.value, converter=converter)
 
-            return Impl
+                return Impl
 
-        MySystem = MySystem_[None]  # Default instantiation.
+            MySystem = MySystem_[None]  # Default instantiation.
 
     Things to note:
 


### PR DESCRIPTION
We have several pure python methods with example code in their doc strings. In some cases, they don't render as doc strings at all. In other cases, they render inconsistently (i.e., as a list).

This picks an arbitrary style for the examples and confirms that the instances all render the same.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18825)
<!-- Reviewable:end -->
