### PR TITLE
Revert "[py systems] Allow scalar conversion for subclassed diagrams …

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -192,18 +192,7 @@ struct Impl {
    public:
     using Base = Diagram<T>;
 
-    // Explicitly forward constructors as opposed to `using Base::Base`, as we
-    // want the protected scalar-converting constructors exposed publicly so
-    // that implementing Python classes can use them.
-
     DiagramPublic() = default;
-    explicit DiagramPublic(SystemScalarConverter converter)
-        : Base(std::move(converter)) {}
-
-    template <typename U>
-    explicit DiagramPublic(
-        SystemScalarConverter converter, const Diagram<U>& other)
-        : Base(std::move(converter), other) {}
   };
 
   // Provide flexible inheritance to leverage prior binding information, per
@@ -1010,26 +999,9 @@ Note: The above is for the C++ documentation. For Python, use
             doc.LeafSystem.DeclarePeriodicDiscreteUpdate.doc_deprecated);
 #pragma GCC diagnostic pop
 
-    auto diagram_cls =
-        DefineTemplateClassWithDefault<Diagram<T>, PyDiagram, System<T>>(
-            m, "Diagram", GetPyParam<T>(), doc.Diagram.doc);
-    diagram_cls  // BR
+    DefineTemplateClassWithDefault<Diagram<T>, PyDiagram, System<T>>(
+        m, "Diagram", GetPyParam<T>(), doc.Diagram.doc)
         .def(py::init<>(), doc.Diagram.ctor.doc_0args)
-        // See comment above for LeafSystem's converter-based constructor.
-        .def(py::init<SystemScalarConverter>(), py::arg("converter"),
-            doc.Diagram.ctor.doc_1args_converter);
-    auto def_diagram_init_U = [&diagram_cls](auto dummy) {
-      using U = decltype(dummy);
-      if constexpr (!std::is_same_v<T, U>) {
-        diagram_cls  // BR
-            .def(py::init<SystemScalarConverter, const Diagram<U>&>(),
-                py::arg("converter"), py::arg("other"),
-                doc.Diagram.ctor
-                    .doc_2args_drakesystemsSystemScalarConverter_constDiagram);
-      }
-    };
-    type_visit(def_diagram_init_U, CommonScalarPack{});
-    diagram_cls  // BR
         .def(
             "connection_map",
             [](Diagram<T>* self) {

--- a/bindings/pydrake/systems/scalar_conversion.py
+++ b/bindings/pydrake/systems/scalar_conversion.py
@@ -5,7 +5,7 @@ from functools import partial
 
 from pydrake.common import pretty_class_name
 from pydrake.systems.framework import (
-    System_,
+    LeafSystem_,
     SystemScalarConverter,
 )
 from pydrake.common.cpp_template import (
@@ -151,10 +151,10 @@ class TemplateSystem(TemplateClass):
 
         # Check that the user has not defined `__init__`, and has defined
         # `_construct` and `_construct_copy`.
-        if not issubclass(cls, System_[T]):
+        if not issubclass(cls, LeafSystem_[T]):
             raise RuntimeError(
                 "{} must inherit from {}".format(
-                    pretty_class_name(cls), System_[T]))
+                    pretty_class_name(cls), LeafSystem_[T]))
 
         # Use the immediate `__dict__`, rather than querying the attributes, so
         # that we don't get spillover from inheritance.

--- a/bindings/pydrake/systems/test/scalar_conversion_test.py
+++ b/bindings/pydrake/systems/test/scalar_conversion_test.py
@@ -6,9 +6,7 @@ import unittest
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.symbolic import Expression
 from pydrake.systems.framework import (
-    Diagram_,
     DiagramBuilder,
-    DiagramBuilder_,
     LeafSystem_,
     SystemScalarConverter,
 )
@@ -255,7 +253,7 @@ class TestScalarConversion(unittest.TestCase):
         with self.assertRaises(RuntimeError) as cm:
             BadParenting_[float]
         self.assertIn("BadParenting_[float]", str(cm.exception))
-        self.assertIn("System", str(cm.exception))
+        self.assertIn("LeafSystem", str(cm.exception))
 
     def test_clone(self):
         """Tests the System.Clone bindings. This is most convenient to do in
@@ -267,34 +265,3 @@ class TestScalarConversion(unittest.TestCase):
             dut.Clone()
             copy.copy(dut)
             copy.deepcopy(dut)
-
-    def test_diagram_sublcass(self):
-        @mut.TemplateSystem.define("MyDiagram_")
-        def MyDiagram_(T):
-
-            class Impl(Diagram_[T]):
-                def _construct(self, value, *, converter=None):
-                    Diagram_[T].__init__(self, converter=converter)
-                    builder = DiagramBuilder_[T]()
-                    self.example = builder.AddSystem(Example_[T](value=value))
-                    builder.BuildInto(self)
-
-                def _construct_copy(self, other, *, converter=None):
-                    Diagram_[T].__init__(
-                        self, converter=converter, other=other
-                    )
-                    self.example, = self.GetSystems()
-
-            return Impl
-
-        for T, U in SystemScalarConverter.SupportedConversionPairs:
-            diagram_U = MyDiagram_[U](value=10)
-            self.assertEqual(diagram_U.example.value, 10)
-            self.assertIsNone(diagram_U.example.copied_from)
-            diagram_T = diagram_U.ToScalarType[T]()
-            self.assertIsInstance(diagram_T, MyDiagram_[T])
-            self.assertEqual(diagram_T.example.value, 10)
-            self.assertIs(diagram_T.example.copied_from, diagram_U.example)
-            # Ensure both diagrams can create a context.
-            diagram_U.CreateDefaultContext()
-            diagram_T.CreateDefaultContext()


### PR DESCRIPTION
…(#18813)"

This reverts commit 917dcfa98af3306729ae8f7e49d04953be23d1ed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18832)
<!-- Reviewable:end -->
