### PR TITLE
[tools] Keep bazel analysis phase intact

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -15,37 +15,37 @@ build --strip=never
 build --strict_system_includes
 
 # Default test options.
-test --test_output=errors
-test --test_summary=terse
+build --test_output=errors
+build --test_summary=terse
 
 # By default, disable execution of tests that require proprietary software.
 # Individual targets that use proprietary software are responsible for ensuring
 # they can also build without it, typically by using a select statement.
 # config_setting rules for proprietary software are provided in //tools.
-test --test_tag_filters=-gurobi,-mosek,-snopt
+build --test_tag_filters=-gurobi,-mosek,-snopt
 
 # Inject DISPLAY into test runner environment for tests that use X.
-test --test_env=DISPLAY
+build --test_env=DISPLAY
 
 # Location of the Gurobi license key file, typically named "gurobi.lic".
 # Setting this --test_env for all configurations is deliberate to improve
 # remote caching performance.
-test --test_env=GRB_LICENSE_FILE
+build --test_env=GRB_LICENSE_FILE
 
 # Location of the MOSEK license file, typically named "mosek.lic". Setting
 # this --test_env for all configurations is deliberate to improve remote
 # caching performance.
-test --test_env=MOSEKLM_LICENSE_FILE
+build --test_env=MOSEKLM_LICENSE_FILE
 
 # Prevent LCM messages from leaking outside of tests.
 # See documentation: https://lcm-proj.github.io/group__LcmC__lcm__t.html#gaf29963ef43edadf45296d5ad82c18d4b  # noqa
 # WARNING: If your LCM test depends on communication between separate LCM
 # instances (and you cannot easily mock the LCM instances), make sure that each
 # instance has a consistent, but non-default, LCM URL.
-test --test_env=LCM_DEFAULT_URL=memq://
+build --test_env=LCM_DEFAULT_URL=memq://
 
 # Prevent matplotlib from showing windows (#11029).
-test --test_env=MPLBACKEND=Template
+build --test_env=MPLBACKEND=Template
 
 ### A configuration that enables Gurobi. ###
 # -- To use this config, the GRB_LICENSE_FILE environment variable must be set
@@ -78,7 +78,7 @@ build:mosek --define=WITH_MOSEK=ON
 build:snopt --define=WITH_SNOPT=ON
 
 ### A configuration that enables all optional dependencies. ###
-test:everything --test_tag_filters=-no_everything
+build:everything --test_tag_filters=-no_everything
 
 # -- Options for Gurobi.
 build:everything --define=WITH_GUROBI=ON

--- a/tools/dynamic_analysis/bazel.rc
+++ b/tools/dynamic_analysis/bazel.rc
@@ -231,7 +231,7 @@ build:memcheck --test_tag_filters=-gurobi,-mosek,-snopt,-lint,-no_memcheck,-no_v
 # Slowdown factor can range from 5-100.
 # See http://valgrind.org/info/about.html
 build:memcheck --test_timeout=1500,7500,22500,90000  # 25x
-test:memcheck --test_env=VALGRIND_OPTS
+build:memcheck --test_env=VALGRIND_OPTS
 
 ### Memcheck everything build. ###
 build:memcheck_everything --build_tests_only

--- a/tools/lint/bazel.rc
+++ b/tools/lint/bazel.rc
@@ -1,4 +1,4 @@
 ### Lint. ###
 # Run the tests for code style compliance, but not any functional (unit) tests.
-test:lint --build_tests_only
-test:lint --test_tag_filters=lint
+build:lint --build_tests_only
+build:lint --test_tag_filters=lint


### PR DESCRIPTION
As it turns out, varying 'test' vs 'build' for options in a bazelrc causes the analysis phase to be re-run as the user alternates between 'bazel build' and 'bazel test'.  Since all test options are valid for build as well, we should just list everything in build.

This removes "Options have changed, discarding analysis cache" output from bazel in the typical case.

(See also `anzu#4460` for the ditto change.)

Towards #18828.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18838)
<!-- Reviewable:end -->
