### PR TITLE
[tools] Offer --config=packaging option to build a nightly release

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -47,6 +47,9 @@ build --test_env=LCM_DEFAULT_URL=memq://
 # Prevent matplotlib from showing windows (#11029).
 build --test_env=MPLBACKEND=Template
 
+### A configuration that enables all optional dependencies. ###
+build:everything --test_tag_filters=-no_everything
+
 ### A configuration that enables Gurobi. ###
 # -- To use this config, the GRB_LICENSE_FILE environment variable must be set
 # -- to the location of the Gurobi license key file. On Ubuntu, the GUROBI_HOME
@@ -58,6 +61,10 @@ build --test_env=MPLBACKEND=Template
 # -- "gurobi_test_tags()" from //tools/skylark:test_tags.bzl.
 # -- If Gurobi is optional, set gurobi_required=False.
 build:gurobi --define=WITH_GUROBI=ON
+build:everything --define=WITH_GUROBI=ON
+# N.B. The build:packaging configuration does NOT use Gurobi (yet).
+# See https://github.com/RobotLocomotion/drake/issues/10804.
+build:packaging --test_tag_filters=-gurobi
 
 ### A configuration that enables MOSEK™. ###
 # -- To use this config, the MOSEKLM_LICENSE_FILE environment variable must be
@@ -67,6 +74,8 @@ build:gurobi --define=WITH_GUROBI=ON
 # -- "mosek_test_tags()" from //tools/skylark:test_tags.bzl.
 # -- If MOSEK™ is optional, set mosek_required=False.
 build:mosek --define=WITH_MOSEK=ON
+build:packaging --define=WITH_MOSEK=ON
+build:everything --define=WITH_MOSEK=ON
 
 ### A configuration that enables SNOPT. ###
 # -- To use this config, you must have access to the private repository
@@ -76,15 +85,7 @@ build:mosek --define=WITH_MOSEK=ON
 # -- To run tests that require SNOPT, also specify a set of test_tag_filters
 # -- that does not exclude the "snopt" tag.
 build:snopt --define=WITH_SNOPT=ON
-
-### A configuration that enables all optional dependencies. ###
-build:everything --test_tag_filters=-no_everything
-
-# -- Options for Gurobi.
-build:everything --define=WITH_GUROBI=ON
-# -- Options for MOSEK.
-build:everything --define=WITH_MOSEK=ON
-# -- Options for SNOPT.
+build:packaging --define=WITH_SNOPT=ON
 build:everything --define=WITH_SNOPT=ON
 
 # -- Options for explicitly using GCC.


### PR DESCRIPTION
Towards #18828.

My intention here is that we switch the CI job definition for packaging builds to **not** specify mosek and/or snopt specifically, but rather to just say `--config=packaging`, so that `drake.git` owns its configuration entropy.

I think it's harmless to add this option here first, and then later refactor the Drake CI job names.  I don't think we need tandem.

@svenevs or @BetsyMcPhail whoever is around, please grab a feature-review here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18840)
<!-- Reviewable:end -->
