### PR TITLE
[tools] Add all models to model_visualizer's runfiles

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -35,6 +35,47 @@ alias(
     visibility = ["//visibility:public"],
 )
 
+# A manually-curated collection of most model files in Drake, so that we can
+# easily provide access to them for tools like //tools:model_visualizer.
+filegroup(
+    name = "all_models",
+    data = [
+        "//bindings/pydrake/multibody:models",
+        "//examples/acrobot:models",
+        "//examples/atlas:models",
+        "//examples/compass_gait:models",
+        "//examples/hardware_sim:demo_data",
+        "//examples/hydroelastic/ball_plate:floor_files",
+        "//examples/hydroelastic/ball_plate:plate_files",
+        "//examples/hydroelastic/python_ball_paddle:ball_paddle_files",
+        "//examples/hydroelastic/python_nonconvex_mesh:models",
+        "//examples/hydroelastic/spatula_slip_control:models",
+        "//examples/kuka_iiwa_arm/models",
+        "//examples/manipulation_station:models",
+        "//examples/multibody/cart_pole:models",
+        "//examples/multibody/four_bar:models",
+        "//examples/pendulum:models",
+        "//examples/planar_gripper:models",
+        "//examples/pr2:models",
+        "//examples/quadrotor:models",
+        "//examples/rimless_wheel:models",
+        "//examples/scene_graph:models",
+        "//examples/simple_gripper:simple_gripper_models",
+        "//examples/zmp:models",
+        "//manipulation/models/allegro_hand_description:models",
+        "//manipulation/models/franka_description:models",
+        "//manipulation/models/iiwa_description:models",
+        "//manipulation/models/jaco_description:models",
+        "//manipulation/models/realsense2_description:models",
+        "//manipulation/models/tri_homecart:models",
+        "//manipulation/models/ur3e:models",
+        "//manipulation/models/wsg_50_description:models",
+        "//manipulation/models/ycb:models",
+        "//multibody/benchmarks/acrobot:models",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
 # To create a manifest of all installed files for use by drake_bazel_installed,
 # we declare an install target that contains almost everything -- but it can't
 # contain the bazel logic that is generated based on the manifest, so we'll add

--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -288,6 +288,7 @@ filegroup(
     srcs = glob([
         "**/*.sdf",
     ]),
+    visibility = ["//:__pkg__"],
 )
 
 drake_jupyter_py_binary(

--- a/bindings/pydrake/visualization/BUILD.bazel
+++ b/bindings/pydrake/visualization/BUILD.bazel
@@ -72,6 +72,7 @@ drake_py_binary(
 drake_py_binary(
     name = "model_visualizer",
     srcs = ["model_visualizer.py"],
+    data = ["//:all_models"],
     visibility = ["//tools:__pkg__"],
     deps = [":visualization"],
 )

--- a/examples/hardware_sim/BUILD.bazel
+++ b/examples/hardware_sim/BUILD.bazel
@@ -29,6 +29,7 @@ filegroup(
         "//manipulation/models/iiwa_description:prod_models",
         "//manipulation/models/wsg_50_description:prod_models",
     ],
+    visibility = ["//:__pkg__"],
 )
 
 drake_cc_library(

--- a/examples/hydroelastic/ball_plate/BUILD.bazel
+++ b/examples/hydroelastic/ball_plate/BUILD.bazel
@@ -59,6 +59,7 @@ filegroup(
         "plate_8in_col.mtl",
         "plate_8in_col.obj",
     ],
+    visibility = ["//:__pkg__"],
 )
 
 filegroup(
@@ -66,6 +67,7 @@ filegroup(
     srcs = [
         "floor.sdf",
     ],
+    visibility = ["//:__pkg__"],
 )
 
 add_lint_tests()

--- a/examples/hydroelastic/python_ball_paddle/BUILD.bazel
+++ b/examples/hydroelastic/python_ball_paddle/BUILD.bazel
@@ -25,6 +25,7 @@ filegroup(
         "ball.sdf",
         "paddle.sdf",
     ],
+    visibility = ["//:__pkg__"],
 )
 
 add_lint_tests()

--- a/examples/hydroelastic/python_nonconvex_mesh/BUILD.bazel
+++ b/examples/hydroelastic/python_nonconvex_mesh/BUILD.bazel
@@ -50,6 +50,7 @@ filegroup(
         "pepper.sdf",
         "table.sdf",
     ] + _VEGGIES_MESHES + _DISHES_FILES,
+    visibility = ["//:__pkg__"],
 )
 
 add_lint_tests()

--- a/examples/multibody/four_bar/BUILD.bazel
+++ b/examples/multibody/four_bar/BUILD.bazel
@@ -12,6 +12,7 @@ filegroup(
     srcs = glob([
         "**/*.sdf",
     ]),
+    visibility = ["//:__pkg__"],
 )
 
 drake_cc_binary(


### PR DESCRIPTION
Closes #18827.

Note that this is only relevant for source builds.  Install users of model_visualizer still only have access to the same set of installed models as before.

+@SeanCurtis-TRI for both reviews, please.

\CC @trowell-tri FYI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18843)
<!-- Reviewable:end -->
