### PR TITLE
[planning] Clean up ZMPPlanner

### DIFF
--- a/examples/zmp/zmp_example.cc
+++ b/examples/zmp/zmp_example.cc
@@ -9,7 +9,7 @@ namespace examples {
 namespace zmp {
 namespace {
 
-void PlotResults(const systems::controllers::ZMPTestTraj& traj) {
+void PlotResults(const systems::controllers::ZmpTestTraj& traj) {
   using common::CallPython;
   using common::ToPythonTuple;
 
@@ -88,20 +88,20 @@ void do_main() {
       Eigen::Vector2d(2, -0.1), Eigen::Vector2d(2.5, 0)};
 
   std::vector<trajectories::PiecewisePolynomial<double>> zmp_trajs =
-      systems::controllers::GenerateDesiredZMPTrajs(footsteps, 0.5, 1);
+      systems::controllers::GenerateDesiredZmpTrajs(footsteps, 0.5, 1);
 
   Eigen::Vector4d x0(0, 0, 0, 0);
   double z = 1;
 
-  systems::controllers::ZMPPlanner zmp_planner;
+  systems::controllers::ZmpPlanner zmp_planner;
   zmp_planner.Plan(zmp_trajs[0], x0, z);
 
   double sample_dt = 0.01;
 
   // Perturb the initial state a bit.
   x0 << 0, 0, 0.2, -0.1;
-  systems::controllers::ZMPTestTraj result =
-      systems::controllers::SimulateZMPPolicy(zmp_planner, x0, sample_dt, 2);
+  systems::controllers::ZmpTestTraj result =
+      systems::controllers::SimulateZmpPolicy(zmp_planner, x0, sample_dt, 2);
 
   PlotResults(result);
 }

--- a/systems/controllers/test/zmp_test_util.cc
+++ b/systems/controllers/test/zmp_test_util.cc
@@ -8,7 +8,7 @@ namespace controllers {
 
 using trajectories::PiecewisePolynomial;
 
-ZMPTestTraj SimulateZMPPolicy(const ZMPPlanner& zmp_planner,
+ZmpTestTraj SimulateZmpPolicy(const ZmpPlanner& zmp_planner,
                               const Eigen::Vector4d& x0, double dt,
                               double extra_time_at_the_end) {
   const PiecewisePolynomial<double>& zmp_d = zmp_planner.get_desired_zmp();
@@ -16,7 +16,7 @@ ZMPTestTraj SimulateZMPPolicy(const ZMPPlanner& zmp_planner,
       (zmp_d.end_time() + extra_time_at_the_end - zmp_d.start_time())
       / dt);
 
-  ZMPTestTraj traj(N);
+  ZmpTestTraj traj(N);
 
   for (int i = 0; i < N; i++) {
     traj.time[i] = zmp_d.start_time() + i * dt;
@@ -44,7 +44,7 @@ ZMPTestTraj SimulateZMPPolicy(const ZMPPlanner& zmp_planner,
   return traj;
 }
 
-std::vector<PiecewisePolynomial<double>> GenerateDesiredZMPTrajs(
+std::vector<PiecewisePolynomial<double>> GenerateDesiredZmpTrajs(
     const std::vector<Eigen::Vector2d>& footsteps,
     double double_support_duration, double single_support_duration) {
   DRAKE_DEMAND(!footsteps.empty());
@@ -82,6 +82,18 @@ std::vector<PiecewisePolynomial<double>> GenerateDesiredZMPTrajs(
 
   return zmp_trajs;
 }
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+const std::function<ZmpTestTraj(const ZmpPlanner&, const Eigen::Vector4d&,
+                                double, double)>
+    SimulateZMPPolicy = SimulateZmpPolicy;
+
+const std::function<
+    std::vector<trajectories::PiecewisePolynomial<double>>(
+        const std::vector<Eigen::Vector2d>&, double, double)>
+    GenerateDesiredZMPTrajs = GenerateDesiredZmpTrajs;
+#pragma GCC diagnostic pop
 
 }  // namespace controllers
 }  // namespace systems

--- a/systems/controllers/test/zmp_test_util.h
+++ b/systems/controllers/test/zmp_test_util.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <functional>
 #include <vector>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/systems/controllers/zmp_planner.h"
 
 namespace drake {
@@ -9,10 +11,10 @@ namespace systems {
 namespace controllers {
 
 /** A structure for storing trajectories from simulating a linear inverted
- * pendulum model (LIPM) using the policy from a ZMPPlanner.
+ * pendulum model (LIPM) using the policy from a ZmpPlanner.
  */
-struct ZMPTestTraj {
-  explicit ZMPTestTraj(int N) {
+struct ZmpTestTraj {
+  explicit ZmpTestTraj(int N) {
     time.resize(N);
     nominal_com.resize(6, N);
     desired_zmp.resize(2, N);
@@ -29,6 +31,9 @@ struct ZMPTestTraj {
   Eigen::Matrix<double, 2, Eigen::Dynamic> cop;
 };
 
+using ZMPTestTraj DRAKE_DEPRECATED("2023-06-01",
+                                   "Use ZmpTestTraj instead") = ZmpTestTraj;
+
 /**
  * Forward simulation using the linear policy from `zmp_planner` starting from
  * the initial condition `x0` using explicit Euler integration.
@@ -38,11 +43,16 @@ struct ZMPTestTraj {
  * @param dt, Time step.
  * @param extra_time_at_the_end, Simulate `extra_time_at_the_end` seconds past
  * the end of the trajectories for convergence.
- * @return ZMPTestTraj that contains all the information.
+ * @return ZmpTestTraj that contains all the information.
  */
-ZMPTestTraj SimulateZMPPolicy(const ZMPPlanner& zmp_planner,
+ZmpTestTraj SimulateZmpPolicy(const ZmpPlanner& zmp_planner,
                               const Eigen::Vector4d& x0, double dt,
                               double extra_time_at_the_end);
+
+DRAKE_DEPRECATED("2023-06-01", "Use SimulateZmpPolicy instead")
+extern const std::function<ZmpTestTraj(const ZmpPlanner&,
+                                       const Eigen::Vector4d&, double, double)>
+    SimulateZMPPolicy;
 
 /**
  * Generates desired ZMP trajectories as piecewise polynomials given the
@@ -63,9 +73,15 @@ ZMPTestTraj SimulateZMPPolicy(const ZMPPlanner& zmp_planner,
  * @param single_support_duration, Duration for single support.
  * @return Three trajectories: 0 is zero-order-hold, 1 is linear, 2 is cubic.
  */
-std::vector<trajectories::PiecewisePolynomial<double>> GenerateDesiredZMPTrajs(
+std::vector<trajectories::PiecewisePolynomial<double>> GenerateDesiredZmpTrajs(
     const std::vector<Eigen::Vector2d>& footsteps,
     double double_support_duration, double single_support_duration);
+
+DRAKE_DEPRECATED("2023-06-01", "Use GenerateDesiredZmpTrajs instead")
+extern const std::function<
+    std::vector<trajectories::PiecewisePolynomial<double>>(
+        const std::vector<Eigen::Vector2d>&, double, double)>
+    GenerateDesiredZMPTrajs;
 
 }  // namespace controllers
 }  // namespace systems

--- a/systems/controllers/zmp_planner.cc
+++ b/systems/controllers/zmp_planner.cc
@@ -14,7 +14,7 @@ namespace controllers {
 using trajectories::ExponentialPlusPiecewisePolynomial;
 using trajectories::PiecewisePolynomial;
 
-Eigen::Vector2d ZMPPlanner::ComputeOptimalCoMdd(
+Eigen::Vector2d ZmpPlanner::ComputeOptimalCoMdd(
     double time, const Eigen::Vector4d& x) const {
   DRAKE_DEMAND(planned_);
   // Eq. 20 in [1].
@@ -24,7 +24,7 @@ Eigen::Vector2d ZMPPlanner::ComputeOptimalCoMdd(
   return K_ * x_bar + k2_.value(time);
 }
 
-bool ZMPPlanner::CheckStationaryEndPoint(
+bool ZmpPlanner::CheckStationaryEndPoint(
     const PiecewisePolynomial<double>& zmp_d) const {
   PiecewisePolynomial<double> last_segment =
       zmp_d.slice(zmp_d.get_number_of_segments() - 1, 1);
@@ -40,7 +40,7 @@ bool ZMPPlanner::CheckStationaryEndPoint(
   return true;
 }
 
-void ZMPPlanner::Plan(const PiecewisePolynomial<double>& zmp_d,
+void ZmpPlanner::Plan(const PiecewisePolynomial<double>& zmp_d,
                       const Eigen::Vector4d& x0, double height, double gravity,
                       const Eigen::Matrix2d& Qy, const Eigen::Matrix2d& R) {
   // Warn the caller if the last point is not stationary. The math is still
@@ -48,7 +48,7 @@ void ZMPPlanner::Plan(const PiecewisePolynomial<double>& zmp_d,
   // If the user use the policy / nominal trajectory past the end point, the
   // system diverges exponentially fast.
   if (!CheckStationaryEndPoint(zmp_d)) {
-    drake::log()->warn("ZMPPlanner: The desired zmp trajectory does not end "
+    drake::log()->warn("ZmpPlanner: The desired zmp trajectory does not end "
         "in a stationary condition.");
   }
 

--- a/systems/controllers/zmp_planner.h
+++ b/systems/controllers/zmp_planner.h
@@ -2,6 +2,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/trajectories/exponential_plus_piecewise_polynomial.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
 
@@ -10,87 +11,86 @@ namespace systems {
 namespace controllers {
 
 /**
- * Given a desired two dimensional (X and Y) zero-moment point (ZMP) trajectory
- * parameterized as a piecewise polynomial, an optimal center of mass (CoM)
- * trajectory is planned using a linear inverted pendulum model (LIPM).
- * A second order value function (optimal cost-to-go) and a linear policy are
- * also computed along the optimal trajectory.
- * The system dynamics for the X and Y directions are decoupled, however, we
- * plan the XY motion together for convenience.
- *
- * Let \f$ c \f$ be the CoM position, the The state of the system, \f$ x \f$,
- * is \f$ [c; \dot{c}] \f$, the control, \f$ u = \ddot{c} \f$,
- * and \f$ y \f$ represents the center of pressure (CoP).
- * For the X direction, the LIPM dynamics is:
- * \f[
- *   y = c - \frac{z}{g} * u,
- * \f]
- * where \f$ g \f$ is the gravity constant and \f$ z \f$ is the CoM height.
- * \f$ z \f$ is assumed to be constant in LIPM.
- * The full dynamics can also be written in the matrix form as:
- * \f[
- *   \dot{x} = A x + B u \\
- *         y = C x + D u
- * \f]
- *
- * The one step cost function \f$ L \f$ is defined as:
- * \f[
- *   L(y, u, t) = (y - y_d(t))^T Q_y (y - y_d(t)) + u^T R u,
- * \f]
- * where \f$ Q_y \f$ and \f$ R \f$ are weighting matrices, and \f$ y_d(t) \f$
- * is the desired ZMP trajectory at time \f$ t \f$.
- *
- * The value function is defined as
- * \f[
- *   V(x, t) = \min_{u[t:t_f]} \bar{x}(t_f)^T S \bar{x}(t_f)
- *           + \int_{t}^{t_f} L(y, u, \tau) d\tau,
- * \f]
- * subject to the dynamics, and \f$ t_f \f$ is the last time in the desired
- * ZMP trajectory, \f$ \bar{x} = [c - y_d(t_f); \dot{c}] \f$,
- * \f$ S \f$ is the quadratic term from the infinite horizon continuous time
- * LQR solution solved with the same dynamics and one step cost function.
- *
- * For this problem, \f$ V \f$ is known to have a quadratic form of:
- * \f[
- *   V(x, t) = \bar{x}^T V_{xx} \bar{x} + \bar{x}^T V_x(t) + V_0(t),
- * \f]
- * and the corresponding optimal control policy, \f$ u^* \f$, is linear
- * w.r.t. to \f$ x \f$:
- * \f[
- *   u^*(x, t) = K \bar{x} + u_0(t).
- * \f]
- *
- * See the following reference for more details about the algorithm:
- *
- * [1] R. Tedrake, S. Kuindersma, R. Deits and K. Miura, "A closed-form solution
- * for real-time ZMP gait generation and feedback stabilization,"
- * 2015 IEEE-RAS 15th International Conference on Humanoid Robots (Humanoids),
- * Seoul, 2015, pp. 936-940.
- *
- * @ingroup planning
- */
-class ZMPPlanner {
- public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ZMPPlanner)
+ Given a desired two dimensional (X and Y) zero-moment point (ZMP) trajectory
+ parameterized as a piecewise polynomial, an optimal center of mass (CoM)
+ trajectory is planned using a linear inverted pendulum model (LIPM).
+ A second order value function (optimal cost-to-go) and a linear policy are
+ also computed alongside the optimal trajectory.
+ The system dynamics for the X and Y directions are decoupled, however, we
+ plan the XY motion together for convenience.
 
-  ZMPPlanner() {}
+ Let \f$ c \f$ be the CoM position, the state of the system, \f$ x \f$,
+ is \f$ [c; \dot{c}] \f$, the control, \f$ u = \ddot{c} \f$,
+ and \f$ y \f$ represents the center of pressure (CoP).
+ For the X direction, the LIPM dynamics is:
+ \f[
+   y = c - \frac{z}{g} * u,
+ \f]
+ where \f$ g \f$ is the gravity constant and \f$ z \f$ is the CoM height.
+ \f$ z \f$ is assumed to be constant in LIPM.
+ The full dynamics can also be written in the matrix form as:
+ \f[
+   \dot{x} = A x + B u \\
+         y = C x + D u
+ \f]
+
+ The one step cost function \f$ L \f$ is defined as:
+ \f[
+   L(y, u, t) = (y - y_d(t))^T Q_y (y - y_d(t)) + u^T R u,
+ \f]
+ where \f$ Q_y \f$ and \f$ R \f$ are weighting matrices, and \f$ y_d(t) \f$
+ is the desired ZMP trajectory at time \f$ t \f$.
+
+ The value function is defined as
+ \f[
+   V(x, t) = \min_{u[t:t_f]} \bar{x}(t_f)^T S \bar{x}(t_f)
+           + \int_{t}^{t_f} L(y, u, \tau) d\tau,
+ \f]
+ subject to the dynamics, and \f$ t_f \f$ is the last time in the desired
+ ZMP trajectory, \f$ \bar{x} = [c - y_d(t_f); \dot{c}] \f$,
+ \f$ S \f$ is the quadratic term from the infinite horizon continuous time
+ LQR solution solved with the same dynamics and one step cost function.
+
+ For this problem, \f$ V \f$ is known to have a quadratic form of:
+ \f[
+   V(x, t) = \bar{x}^T V_{xx} \bar{x} + \bar{x}^T V_x(t) + V_0(t),
+ \f]
+ and the corresponding optimal control policy, \f$ u^* \f$, is linear
+ w.r.t. to \f$ x \f$:
+ \f[
+   u^*(x, t) = K \bar{x} + u_0(t).
+ \f]
+
+ See the following reference for more details about the algorithm:
+
+ [1] R. Tedrake, S. Kuindersma, R. Deits and K. Miura, "A closed-form solution
+ for real-time ZMP gait generation and feedback stabilization,"
+ 2015 IEEE-RAS 15th International Conference on Humanoid Robots (Humanoids),
+ Seoul, 2015, pp. 936-940.
+
+ @ingroup planning
+ */
+class ZmpPlanner {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ZmpPlanner)
+
+  ZmpPlanner() = default;
 
   /**
-   * Implements the algorithm in [1] that computes a nominal CoM trajectory,
-   * and the corresponding second order value function and linear policy.
-   *
-   * None of the other public methods should be called until Plan is called.
-   *
-   * It is allowed to pass in a `zmp_d` with a non-stationary end point, but
-   * the user should treat the result with caution, since the resulting nominal
-   * CoM trajectory diverges exponentially fast past the end point.
-   * @param zmp_d, Desired two dimensional ZMP trajectory.
-   * @param x0, Initial CoM state.
-   * @param height, CoM height from the ground.
-   * @param gravity, Gravity constant, defaults to 9.81
-   * @param Qy, Quadratic cost term on ZMP deviation from the desired, defaults
-   * to identity.
-   * @param R, Quadratic cost term on CoM acceleration, defaults to zero.
+   Implements the algorithm in [1] that computes a nominal CoM trajectory,
+   and the corresponding second order value function and linear policy.
+
+   No other public method should be called until Plan() has been called.
+
+   The velocity of the ZMP at the end of `zmp_d` does not need to be zero, but
+   the user should treat the result with caution, since the resulting nominal
+   CoM trajectory diverges exponentially quickly beyond the end of `zmp_d`.
+   @param zmp_d    Desired two dimensional ZMP trajectory.
+   @param x0       Initial CoM state.
+   @param height   CoM height from the ground.
+   @param gravity  Gravity constant, defaults to 9.81
+   @param Qy       Quadratic cost term on ZMP deviation from the desired.
+   @param R        Quadratic cost term on CoM acceleration.
    */
   void Plan(const trajectories::PiecewisePolynomial<double>& zmp_d,
             const Eigen::Vector4d& x0, double height, double gravity = 9.81,
@@ -98,29 +98,30 @@ class ZMPPlanner {
             const Eigen::Matrix2d& R = Eigen::Matrix2d::Zero());
 
   /**
-   * Returns true if Plan has been called.
+   Returns true if Plan() has been called.
    */
   bool has_planned() const { return planned_; }
 
   /**
-   * Computes the optimal control (CoM acceleration) at `time` given CoM state
-   * `x` using the linear policy.
-   * Should only be called after Plan is called.
-   * @param time, Current time.
-   * @param x, Current state.
-   * @return Optimal CoMdd.
+   Computes the optimal control (CoM acceleration) at `time` given CoM state
+   `x` using the linear policy.
+   @param time  Current time.
+   @param x     Current state.
+   @return Optimal CoMdd.
+   @pre Plan() has already been called.
    */
   Eigen::Vector2d ComputeOptimalCoMdd(double time,
                                       const Eigen::Vector4d& x) const;
 
   /**
-   * Converts CoM acceleration to center of pressure (CoP) using
-   *    cop = C * x + D * u, which is equivalent to
-   *    cop = com - z / g * comdd
-   * Should only be called after Plan is called.
-   * @param x, CoM position and velocity
-   * @param u, CoM acceleration
-   * @return center of pressure (CoP)
+   Converts CoM acceleration to center of pressure (CoP) using
+       cop = C * x + D * u, which is equivalent to
+       cop = com - z / g * comdd
+   Should only be called after Plan is called.
+   @param x  CoM position and velocity
+   @param u  CoM acceleration
+   @return center of pressure (CoP)
+   @pre Plan() has already been called.
    */
   Eigen::Vector2d comdd_to_cop(const Eigen::Vector4d& x,
                                const Eigen::Vector2d& u) const {
@@ -129,7 +130,8 @@ class ZMPPlanner {
   }
 
   /**
-   * Getter for A matrix.
+   Getter for A matrix.
+   @pre Plan() has already been called.
    */
   const Eigen::Matrix<double, 4, 4>& get_A() const {
     DRAKE_DEMAND(planned_);
@@ -137,7 +139,8 @@ class ZMPPlanner {
   }
 
   /**
-   * Getter for B matrix.
+   Getter for B matrix.
+   @pre Plan() has already been called.
    */
   const Eigen::Matrix<double, 4, 2>& get_B() const {
     DRAKE_DEMAND(planned_);
@@ -145,7 +148,8 @@ class ZMPPlanner {
   }
 
   /**
-   * Getter for C matrix.
+   Getter for C matrix.
+   @pre Plan() has already been called.
    */
   const Eigen::Matrix<double, 2, 4>& get_C() const {
     DRAKE_DEMAND(planned_);
@@ -153,7 +157,8 @@ class ZMPPlanner {
   }
 
   /**
-   * Getter for D matrix.
+   Getter for D matrix.
+   @pre Plan() has already been called.
    */
   const Eigen::Matrix<double, 2, 2>& get_D() const {
     DRAKE_DEMAND(planned_);
@@ -161,7 +166,8 @@ class ZMPPlanner {
   }
 
   /**
-   * Getter for Qy matrix.
+   Getter for Qy matrix.
+   @pre Plan() has already been called.
    */
   const Eigen::Matrix<double, 2, 2>& get_Qy() const {
     DRAKE_DEMAND(planned_);
@@ -169,7 +175,8 @@ class ZMPPlanner {
   }
 
   /**
-   * Getter for R matrix.
+   Getter for R matrix.
+   @pre Plan() has already been called.
    */
   const Eigen::Matrix<double, 2, 2>& get_R() const {
     DRAKE_DEMAND(planned_);
@@ -177,7 +184,8 @@ class ZMPPlanner {
   }
 
   /**
-   * Returns the desired ZMP evaluated at `time`.
+   Returns the desired ZMP evaluated at `time`.
+   @pre Plan() has already been called.
    */
   Eigen::Vector2d get_desired_zmp(double time) const {
     DRAKE_DEMAND(planned_);
@@ -185,7 +193,8 @@ class ZMPPlanner {
   }
 
   /**
-   * Returns the nominal CoM evaluated at `time`.
+   Returns the nominal CoM position evaluated at `time`.
+   @pre Plan() has already been called.
    */
   Eigen::Vector2d get_nominal_com(double time) const {
     DRAKE_DEMAND(planned_);
@@ -193,7 +202,8 @@ class ZMPPlanner {
   }
 
   /**
-   * Returns the nominal CoM velocity evaluated at `time`.
+   Returns the nominal CoM velocity evaluated at `time`.
+   @pre Plan() has already been called.
    */
   Eigen::Vector2d get_nominal_comd(double time) const {
     DRAKE_DEMAND(planned_);
@@ -201,20 +211,26 @@ class ZMPPlanner {
   }
 
   /**
-   * Returns the nominal CoM acceleration evaluated at `time`.
+   Returns the nominal CoM acceleration evaluated at `time`.
+   @pre Plan() has already been called.
    */
   Eigen::Vector2d get_nominal_comdd(double time) const {
     DRAKE_DEMAND(planned_);
     return comdd_.value(time);
   }
 
+  /**
+   Returns the position of the ZMP at the end of the desired trajectory.
+   @pre Plan() has already been called.
+   */
   Eigen::Vector2d get_final_desired_zmp() const {
     DRAKE_DEMAND(planned_);
     return zmp_d_.value(zmp_d_.end_time());
   }
 
   /**
-   * Returns the desired ZMP trajectory.
+   Returns the desired ZMP trajectory.
+   @pre Plan() has already been called.
    */
   const trajectories::PiecewisePolynomial<double>& get_desired_zmp() const {
     DRAKE_DEMAND(planned_);
@@ -222,7 +238,8 @@ class ZMPPlanner {
   }
 
   /**
-   * Returns the nominal CoM trajectory.
+   Returns the nominal CoM trajectory.
+   @pre Plan() has already been called.
    */
   const trajectories::ExponentialPlusPiecewisePolynomial<double>&
   get_nominal_com() const {
@@ -231,7 +248,8 @@ class ZMPPlanner {
   }
 
   /**
-   * Returns the nominal CoM velocity trajectory.
+   Returns the nominal CoM velocity trajectory.
+   @pre Plan() has already been called.
    */
   const trajectories::ExponentialPlusPiecewisePolynomial<double>&
   get_nominal_comd() const {
@@ -240,7 +258,8 @@ class ZMPPlanner {
   }
 
   /**
-   * Returns the nominal CoM acceleration trajectory.
+   Returns the nominal CoM acceleration trajectory.
+   @pre Plan() has already been called.
    */
   const trajectories::ExponentialPlusPiecewisePolynomial<double>&
   get_nominal_comdd() const {
@@ -249,8 +268,9 @@ class ZMPPlanner {
   }
 
   /**
-   * Returns the time invariant second order term (S1 in [1]) of the value
-   * function.
+   Returns the time invariant second order term (S1 in [1]) of the value
+   function.
+   @pre Plan() has already been called.
    */
   const Eigen::Matrix<double, 4, 4>& get_Vxx() const {
     DRAKE_DEMAND(planned_);
@@ -258,8 +278,8 @@ class ZMPPlanner {
   }
 
   /**
-   * Returns the time varying first order term (s2 in [1]) of the value
-   * function.
+   Returns the time varying first order term (s2 in [1]) of the value function.
+   @pre Plan() has already been called.
    */
   const trajectories::ExponentialPlusPiecewisePolynomial<double>& get_Vx()
       const {
@@ -268,8 +288,9 @@ class ZMPPlanner {
   }
 
   /**
-   * Returns the time varying first order term (s2 in [1]) of the value
-   * function.
+   Returns the time varying first order term (s2 in [1]) of the value function,
+   evaluated at the given `time`.
+   @pre Plan() has already been called.
    */
   const Eigen::Vector4d get_Vx(double time) const {
     DRAKE_DEMAND(planned_);
@@ -330,6 +351,9 @@ class ZMPPlanner {
 
   bool planned_{false};
 };
+
+using ZMPPlanner DRAKE_DEPRECATED("2023-06-01",
+                                  "Use ZmpPlanner instead") = ZmpPlanner;
 
 }  // namespace controllers
 }  // namespace systems


### PR DESCRIPTION
Originally inspired by observed errors in doxygen formatting (erroneous comments in `@param foo, bar` led to incorrect documentation). However, the clean up expanded to the following:

1. Correct the doxygen formatting error.
2. Update doxygen to use the current practice of /** */ comments without leading * on each line.
3. References to other methods include terminal ().
4. Add `@pre` to functions that require `Plan()` to have been called.
5. Rename the class to conform with current standards.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18845)
<!-- Reviewable:end -->
