### PR TITLE
[visualization] Add InertiaVisualizer

### DIFF
--- a/bindings/pydrake/visualization/visualization_py_config.cc
+++ b/bindings/pydrake/visualization/visualization_py_config.cc
@@ -28,7 +28,12 @@ void DefineVisualizationConfig(py::module m) {
   }
 
   m  // BR
-      .def("ApplyVisualizationConfig", &ApplyVisualizationConfig,
+      .def("ApplyVisualizationConfig",
+          py::overload_cast<const VisualizationConfig&,
+              systems::DiagramBuilder<double>*, const systems::lcm::LcmBuses*,
+              const multibody::MultibodyPlant<double>*,
+              geometry::SceneGraph<double>*, std::shared_ptr<geometry::Meshcat>,
+              lcm::DrakeLcmInterface*>(&ApplyVisualizationConfig),
           py::arg("config"), py::arg("builder"), py::arg("lcm_buses") = nullptr,
           py::arg("plant") = nullptr, py::arg("scene_graph") = nullptr,
           py::arg("meshcat") = nullptr, py::arg("lcm") = nullptr,

--- a/visualization/BUILD.bazel
+++ b/visualization/BUILD.bazel
@@ -14,8 +14,30 @@ drake_cc_package_library(
     name = "visualization",
     visibility = ["//visibility:public"],
     deps = [
+        ":inertia_visualizer",
+        ":inertia_visualizer_params",
         ":visualization_config",
         ":visualization_config_functions",
+    ],
+)
+
+drake_cc_library(
+    name = "inertia_visualizer",
+    srcs = ["inertia_visualizer.cc"],
+    hdrs = ["inertia_visualizer.h"],
+    deps = [
+        ":inertia_visualizer_params",
+        "//multibody/plant",
+        "//systems/framework:diagram_builder",
+        "//systems/framework:leaf_system",
+    ],
+)
+
+drake_cc_library(
+    name = "inertia_visualizer_params",
+    hdrs = ["inertia_visualizer_params.h"],
+    deps = [
+        "//common:name_value",
     ],
 )
 
@@ -47,6 +69,7 @@ drake_cc_library(
         "//systems/lcm:lcm_buses",
     ],
     deps = [
+        ":inertia_visualizer",
         "//geometry:drake_visualizer",
         "//multibody/plant:contact_results_to_lcm",
         "//systems/lcm:lcm_config_functions",

--- a/visualization/inertia_visualizer.cc
+++ b/visualization/inertia_visualizer.cc
@@ -1,0 +1,138 @@
+#include "drake/visualization/inertia_visualizer.h"
+
+#include <memory>
+#include <utility>
+
+namespace drake {
+namespace visualization {
+
+using geometry::Box;
+using geometry::FramePoseVector;
+using geometry::GeometryFrame;
+using geometry::GeometryInstance;
+using geometry::IllustrationProperties;
+using geometry::Rgba;
+using geometry::SceneGraph;
+using math::RigidTransform;
+using systems::Context;
+using systems::DiagramBuilder;
+
+template <typename T>
+InertiaVisualizer<T>::InertiaVisualizer(
+    const multibody::MultibodyPlant<T>& plant, SceneGraph<T>* scene_graph,
+    InertiaVisualizerParams params)
+    : params_{std::move(params)} {
+  DRAKE_THROW_UNLESS(scene_graph != nullptr);
+  source_id_ = scene_graph->RegisterSource("inertia_visualizer");
+
+  // For all MbP bodies, except for those welded to the world ...
+  const std::vector<const multibody::Body<T>*> world_bodies =
+      plant.GetBodiesWeldedTo(plant.world_body());
+  const int num_bodies = plant.num_bodies();
+  for (multibody::BodyIndex i{0}; i < num_bodies; ++i) {
+    bool welded = false;
+    for (const auto* world_body : world_bodies) {
+      if (world_body->index() == i) {
+        welded = true;
+        break;
+      }
+    }
+    if (welded) {
+      continue;
+    }
+    const multibody::Body<T>& body = plant.get_body(i);
+
+    // Add a Bcm geometry frame.
+    Item item;
+    item.body = i;
+    item.Bo_frame = plant.GetBodyFrameIdIfExists(i).value();
+    item.Bcm_frame = scene_graph->RegisterFrame(
+        source_id_, SceneGraph<T>::world_frame_id(),
+        GeometryFrame{fmt::format(
+            "InertiaVisualizer::{}::{}",
+            plant.GetModelInstanceName(body.model_instance()), body.name())});
+
+    // Add an illustration shape on Bcm.
+    auto shape = std::make_unique<Box>(0.001, 0.001, 0.001);
+    auto geom = std::make_unique<GeometryInstance>(
+        RigidTransform<double>(), std::move(shape),
+        fmt::format("$inertia({})", i));
+    IllustrationProperties props;
+    // FIXME Make this invisible by default.
+    props.AddProperty("phong", "diffuse", Rgba{0.0, 0.0, 1.0, 0.2});
+    geom->set_illustration_properties(std::move(props));
+    item.geometry = scene_graph->RegisterGeometry(source_id_, item.Bcm_frame,
+                                                  std::move(geom));
+    items_.push_back(std::move(item));
+  }
+
+  // Update the geometry information to reflect the default inertia values
+  // from the plant.
+  UpdateItems(plant, *plant.CreateDefaultContext(), scene_graph);
+
+  this->DeclareAbstractInputPort("plant_geometry_pose",
+                                 Value<FramePoseVector<T>>());
+  this->DeclareAbstractOutputPort("geometry_pose",
+                                  &InertiaVisualizer<T>::CalcFramePoseOutput);
+}
+
+template <typename T>
+const InertiaVisualizer<T>& InertiaVisualizer<T>::AddToBuilder(
+    DiagramBuilder<T>* builder, const multibody::MultibodyPlant<T>& plant,
+    SceneGraph<T>* scene_graph, InertiaVisualizerParams params) {
+  DRAKE_THROW_UNLESS(builder != nullptr);
+  DRAKE_THROW_UNLESS(scene_graph != nullptr);
+  auto result = builder->template AddSystem<InertiaVisualizer<T>>(
+      plant, scene_graph, std::move(params));
+  builder->Connect(plant.get_geometry_poses_output_port(),
+                   result->get_input_port());
+  builder->Connect(result->get_output_port(),
+                   scene_graph->get_source_pose_port(result->source_id_));
+  return *result;
+}
+
+template <typename T>
+InertiaVisualizer<T>::~InertiaVisualizer() = default;
+
+template <typename T>
+void InertiaVisualizer<T>::UpdateItems(
+    const multibody::MultibodyPlant<T>& plant, const Context<T>& plant_context,
+    SceneGraph<T>* scene_graph) {
+  for (auto& item : items_) {
+    // Interrogate the plant context for the inertia information.
+    const multibody::Body<T>& body = plant.get_body(item.body);
+    const double mass = ExtractDoubleOrThrow(body.get_mass(plant_context));
+    // FIXME
+    // const Vector3<T> com = body.CalcCenterOfMassInBodyFrame(plant_context);
+
+    // Compute the equivalent illustration box.
+    (void)(mass);                                  // FIXME
+    const Eigen::Vector3d box_dim{0.1, 0.1, 0.1};  // FIXME
+    const RigidTransform<double> X_BBcm;           // FIXME
+
+    // Update the visualization.
+    const Box box(box_dim);
+    scene_graph->ChangeShape(source_id_, item.geometry, box);
+    item.X_BBcm = X_BBcm;
+  }
+}
+
+template <typename T>
+void InertiaVisualizer<T>::CalcFramePoseOutput(
+    const Context<T>& context, FramePoseVector<T>* poses) const {
+  const auto& plant_poses =
+      this->get_input_port().template Eval<FramePoseVector<T>>(context);
+
+  poses->clear();
+  for (const auto& item : items_) {
+    const RigidTransform<T>& X_WBo = plant_poses.value(item.Bo_frame);
+    const RigidTransform<T> X_WBcm = X_WBo * item.X_BBcm.template cast<T>();
+    poses->set_value(item.Bcm_frame, X_WBcm);
+  }
+}
+
+}  // namespace visualization
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::visualization::InertiaVisualizer)

--- a/visualization/inertia_visualizer.h
+++ b/visualization/inertia_visualizer.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/geometry/scene_graph.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/visualization/inertia_visualizer_params.h"
+
+namespace drake {
+namespace visualization {
+
+/** InertiaVisualizer provides illustration geometry to reflect equivalent
+inertia of all bodies in a MultibodyPlant that are not welded to the world.
+
+Instead of constructing this system directly, most users should use
+AddDefaultVisualization() which automatically uses this system.
+
+ @system
+ name: InertiaVisualizer
+ input_ports:
+ - plant_geometry_pose
+ output_ports:
+ - geometry_pose
+ @endsystem
+
+@tparam_default_scalar
+@ingroup visualization */
+template <typename T>
+class InertiaVisualizer final : public systems::LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(InertiaVisualizer)
+
+  /** Creates an instance of %InertiaVisualizer.
+  The plant must be finalized. */
+  InertiaVisualizer(const multibody::MultibodyPlant<T>& plant,
+                    geometry::SceneGraph<T>* scene_graph,
+                    InertiaVisualizerParams params = {});
+
+  /** Scalar-converting copy constructor. See @ref system_scalar_conversion. */
+  template <typename U>
+  explicit InertiaVisualizer(const InertiaVisualizer<U>& other)
+      : params_{other.params_},
+        source_id_{other.source_id_},
+        items_{other.items_} {}
+
+  ~InertiaVisualizer() final;
+
+  /** Adds a new InertiaVisualizer to the given `builder` and connects it to the
+  given `plant` and `scene_graph`. */
+  static const InertiaVisualizer<T>& AddToBuilder(
+      systems::DiagramBuilder<T>* builder,
+      const multibody::MultibodyPlant<T>& plant,
+      geometry::SceneGraph<T>* scene_graph,
+      InertiaVisualizerParams params = {});
+
+  /** (Advanced) Returns the source_id for our visualization geometries.
+  Most users will not need to use this. */
+  geometry::SourceId source_id() const { return source_id_; }
+
+ private:
+  template <typename>
+  friend class InertiaVisualizer;
+
+  /* Each visualization box has an Item to track its associated indices. */
+  struct Item {
+    multibody::BodyIndex body;
+    geometry::FrameId Bo_frame;
+    geometry::FrameId Bcm_frame;
+    geometry::GeometryId geometry;
+    math::RigidTransform<double> X_BBcm;
+  };
+
+  /* Updates `this->items_` to match the inertia values in the given context. */
+  void UpdateItems(const multibody::MultibodyPlant<T>& plant,
+                   const systems::Context<T>& plant_context,
+                   geometry::SceneGraph<T>* scene_graph);
+
+  /* Calculates the "geometry_pose" output port. */
+  void CalcFramePoseOutput(const systems::Context<T>& context,
+                           geometry::FramePoseVector<T>* poses) const;
+
+  const InertiaVisualizerParams params_;
+  geometry::SourceId source_id_;
+  std::vector<Item> items_;
+};
+
+}  // namespace visualization
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::visualization::InertiaVisualizer)

--- a/visualization/inertia_visualizer_params.h
+++ b/visualization/inertia_visualizer_params.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "drake/common/name_value.h"
+
+namespace drake {
+namespace visualization {
+
+/** The set of parameters for configuring InertiaVisualizer. */
+struct InertiaVisualizerParams {
+  /** Passes this object to an Archive.
+   Refer to @ref yaml_serialization "YAML Serialization" for background. */
+  template <typename Archive>
+  void Serialize(Archive* a) {}
+
+  // XXX
+};
+
+}  // namespace visualization
+}  // namespace drake

--- a/visualization/visualization_config.h
+++ b/visualization/visualization_config.h
@@ -29,6 +29,7 @@ struct VisualizationConfig {
     a->Visit(DRAKE_NVP(publish_proximity));
     a->Visit(DRAKE_NVP(default_proximity_color));
     a->Visit(DRAKE_NVP(publish_contacts));
+    a->Visit(DRAKE_NVP(publish_inertia));
     a->Visit(DRAKE_NVP(enable_meshcat_creation));
     a->Visit(DRAKE_NVP(delete_on_initialization_event));
     a->Visit(DRAKE_NVP(enable_alpha_sliders));
@@ -60,6 +61,9 @@ struct VisualizationConfig {
 
   /** Whether to show contact forces. */
   bool publish_contacts{true};
+
+  /** Whether to show body inertia. */
+  bool publish_inertia{true};
 
   /** Whether to create a Meshcat object if needed. */
   bool enable_meshcat_creation{true};

--- a/visualization/visualization_config_functions.cc
+++ b/visualization/visualization_config_functions.cc
@@ -2,11 +2,13 @@
 
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 #include "drake/geometry/drake_visualizer.h"
 #include "drake/geometry/meshcat_visualizer.h"
 #include "drake/multibody/plant/contact_results_to_lcm.h"
 #include "drake/systems/lcm/lcm_config_functions.h"
+#include "drake/visualization/inertia_visualizer.h"
 
 namespace drake {
 namespace visualization {
@@ -30,8 +32,12 @@ void ApplyVisualizationConfigImpl(const VisualizationConfig& config,
                                   DrakeLcmInterface* lcm,
                                   std::shared_ptr<geometry::Meshcat> meshcat,
                                   const MultibodyPlant<double>& plant,
-                                  const SceneGraph<double>& scene_graph,
+                                  SceneGraph<double>* scene_graph,
                                   DiagramBuilder<double>* builder) {
+  DRAKE_DEMAND(lcm != nullptr);
+  DRAKE_DEMAND(scene_graph != nullptr);
+  DRAKE_DEMAND(builder != nullptr);
+
   // This is required due to ConnectContactResultsToDrakeVisualizer().
   DRAKE_THROW_UNLESS(plant.is_finalized());
 
@@ -43,10 +49,13 @@ void ApplyVisualizationConfigImpl(const VisualizationConfig& config,
     // geometry. So long as that's true, we should not enable it.
     DrakeVisualizerParams oopsie = params;
     oopsie.show_hydroelastic = false;
-    DrakeVisualizer<double>::AddToBuilder(builder, scene_graph, lcm, oopsie);
+    DrakeVisualizer<double>::AddToBuilder(builder, *scene_graph, lcm, oopsie);
   }
   if (config.publish_contacts) {
-    ConnectContactResultsToDrakeVisualizer(builder, plant, scene_graph, lcm);
+    ConnectContactResultsToDrakeVisualizer(builder, plant, *scene_graph, lcm);
+  }
+  if (config.publish_inertia) {
+    InertiaVisualizer<double>::AddToBuilder(builder, plant, scene_graph);
   }
 
   if (meshcat == nullptr && config.enable_meshcat_creation) {
@@ -58,7 +67,7 @@ void ApplyVisualizationConfigImpl(const VisualizationConfig& config,
     const std::vector<MeshcatVisualizerParams> all_meshcat_params =
         internal::ConvertVisualizationConfigToMeshcatParams(config);
     for (const MeshcatVisualizerParams& params : all_meshcat_params) {
-      MeshcatVisualizer<double>::AddToBuilder(builder, scene_graph, meshcat,
+      MeshcatVisualizer<double>::AddToBuilder(builder, *scene_graph, meshcat,
                                               params);
     }
   }
@@ -66,11 +75,24 @@ void ApplyVisualizationConfigImpl(const VisualizationConfig& config,
 
 }  // namespace
 
+// This is the deprecated overload.
 void ApplyVisualizationConfig(const VisualizationConfig& config,
                               DiagramBuilder<double>* builder,
                               const LcmBuses* lcm_buses,
                               const MultibodyPlant<double>* plant,
                               const SceneGraph<double>* scene_graph,
+                              std::shared_ptr<geometry::Meshcat> meshcat,
+                              DrakeLcmInterface* lcm) {
+  ApplyVisualizationConfig(config, builder, lcm_buses, plant,
+                           const_cast<SceneGraph<double>*>(scene_graph),
+                           std::move(meshcat), lcm);
+}
+
+void ApplyVisualizationConfig(const VisualizationConfig& config,
+                              DiagramBuilder<double>* builder,
+                              const LcmBuses* lcm_buses,
+                              const MultibodyPlant<double>* plant,
+                              SceneGraph<double>* scene_graph,
                               std::shared_ptr<geometry::Meshcat> meshcat,
                               DrakeLcmInterface* lcm) {
   DRAKE_THROW_UNLESS(builder != nullptr);
@@ -88,9 +110,9 @@ void ApplyVisualizationConfig(const VisualizationConfig& config,
   }
   if (scene_graph == nullptr) {
     scene_graph =
-        &builder->GetDowncastSubsystemByName<SceneGraph>("scene_graph");
+        &builder->GetMutableDowncastSubsystemByName<SceneGraph>("scene_graph");
   }
-  ApplyVisualizationConfigImpl(config, lcm, meshcat, *plant, *scene_graph,
+  ApplyVisualizationConfigImpl(config, lcm, meshcat, *plant, scene_graph,
                                builder);
 }
 

--- a/visualization/visualization_config_functions.h
+++ b/visualization/visualization_config_functions.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/geometry/drake_visualizer_params.h"
 #include "drake/geometry/meshcat.h"
 #include "drake/geometry/meshcat_visualizer_params.h"
@@ -94,7 +95,16 @@ void ApplyVisualizationConfig(
     const VisualizationConfig& config, systems::DiagramBuilder<double>* builder,
     const systems::lcm::LcmBuses* lcm_buses = nullptr,
     const multibody::MultibodyPlant<double>* plant = nullptr,
-    const geometry::SceneGraph<double>* scene_graph = nullptr,
+    geometry::SceneGraph<double>* scene_graph = nullptr,
+    std::shared_ptr<geometry::Meshcat> meshcat = nullptr,
+    lcm::DrakeLcmInterface* lcm = nullptr);
+
+DRAKE_DEPRECATED("2023-06-01", "Pass a non-const SceneGraph pointer")
+void ApplyVisualizationConfig(
+    const VisualizationConfig& config, systems::DiagramBuilder<double>* builder,
+    const systems::lcm::LcmBuses* lcm_buses,
+    const multibody::MultibodyPlant<double>* plant,
+    const geometry::SceneGraph<double>* scene_graph,
     std::shared_ptr<geometry::Meshcat> meshcat = nullptr,
     lcm::DrakeLcmInterface* lcm = nullptr);
 


### PR DESCRIPTION
A prototype for #17662.

The thesis goes like this:

(1) Use illustration geometry, so that any illustration back-end will have these shapes available and correct (meshcat, meldis, rviz, etc).

(2) Set alpha=0% by default, so that it doesn't get in the way normally.  Back-ends (like model_visualizer) can offer a knob to unblur it easily.  Probably also the config file could offer an option to use non-zero alpha at the start.

(3) Phrase it as a System so that there is future hope for initializing using context-specific inertia, though defer that feature for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18846)
<!-- Reviewable:end -->
