### PR TITLE
[lcm] Add DrakeLcmBase

### DIFF
--- a/lcm/BUILD.bazel
+++ b/lcm/BUILD.bazel
@@ -21,6 +21,7 @@ drake_cc_package_library(
     visibility = ["//visibility:public"],
     deps = [
         ":drake_lcm",
+        ":drake_lcm_base",
         ":drake_lcm_params",
         ":interface",
         ":lcm_log",
@@ -45,6 +46,16 @@ drake_cc_library(
     deps = [
         ":lcm_messages",
         "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "drake_lcm_base",
+    srcs = ["drake_lcm_base.cc"],
+    hdrs = ["drake_lcm_base.h"],
+    deps = [
+        ":interface",
+        "//common:nice_type_name",
     ],
 )
 
@@ -114,6 +125,14 @@ drake_cc_googletest(
         ":drake_lcm",
         ":lcmt_drake_signal_utils",
         "//common/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "drake_lcm_base_test",
+    deps = [
+        ":drake_lcm_base",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/lcm/drake_lcm_base.cc
+++ b/lcm/drake_lcm_base.cc
@@ -1,0 +1,56 @@
+#include "drake/lcm/drake_lcm_base.h"
+
+#include <stdexcept>
+
+#include "drake/common/nice_type_name.h"
+
+namespace drake {
+namespace lcm {
+namespace {
+
+[[noreturn]] void ThrowNotImplemented(const DrakeLcmBase& self,
+                                      const char* func) {
+  throw std::runtime_error(
+      fmt::format("{}::{} is not implemented", NiceTypeName::Get(self), func));
+}
+
+}  // namespace
+
+DrakeLcmBase::DrakeLcmBase() = default;
+
+DrakeLcmBase::~DrakeLcmBase() = default;
+
+std::string DrakeLcmBase::get_lcm_url() const {
+  ThrowNotImplemented(*this, __func__);
+}
+
+void DrakeLcmBase::Publish(const std::string&, const void*, int,
+                           std::optional<double>) {
+  ThrowNotImplemented(*this, __func__);
+}
+
+std::shared_ptr<DrakeSubscriptionInterface> DrakeLcmBase::Subscribe(
+    const std::string&, HandlerFunction) {
+  ThrowNotImplemented(*this, __func__);
+}
+
+std::shared_ptr<DrakeSubscriptionInterface> DrakeLcmBase::SubscribeMultichannel(
+    std::string_view, MultichannelHandlerFunction) {
+  ThrowNotImplemented(*this, __func__);
+}
+
+std::shared_ptr<DrakeSubscriptionInterface> DrakeLcmBase::SubscribeAllChannels(
+    MultichannelHandlerFunction) {
+  ThrowNotImplemented(*this, __func__);
+}
+
+int DrakeLcmBase::HandleSubscriptions(int) {
+  ThrowNotImplemented(*this, __func__);
+}
+
+void DrakeLcmBase::OnHandleSubscriptionsError(const std::string&) {
+  ThrowNotImplemented(*this, __func__);
+}
+
+}  // namespace lcm
+}  // namespace drake

--- a/lcm/drake_lcm_base.h
+++ b/lcm/drake_lcm_base.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/lcm/drake_lcm_interface.h"
+
+namespace drake {
+namespace lcm {
+
+/** A concrete subclass of DrakeInterface that throws for all functions except
+the constructor and destructor. This is useful for subclasses that only wish to
+implement a subset of the %DrakeLcmInterface features. */
+class DrakeLcmBase : public DrakeLcmInterface {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DrakeLcmBase)
+  ~DrakeLcmBase() override;
+  std::string get_lcm_url() const override;
+  void Publish(const std::string& channel, const void* data, int data_size,
+               std::optional<double> time_sec) override;
+  std::shared_ptr<DrakeSubscriptionInterface> Subscribe(
+      const std::string& channel, HandlerFunction) override;
+  std::shared_ptr<DrakeSubscriptionInterface> SubscribeMultichannel(
+      std::string_view regex, MultichannelHandlerFunction) override;
+  std::shared_ptr<DrakeSubscriptionInterface> SubscribeAllChannels(
+      MultichannelHandlerFunction) override;
+  int HandleSubscriptions(int timeout_millis) override;
+
+ protected:
+  DrakeLcmBase();
+
+ private:
+  void OnHandleSubscriptionsError(const std::string& error_message) override;
+};
+
+}  // namespace lcm
+}  // namespace drake

--- a/lcm/drake_lcm_interface.h
+++ b/lcm/drake_lcm_interface.h
@@ -34,7 +34,7 @@ void OnHandleSubscriptionsError(DrakeLcmInterface* lcm,
  *
  * Because it must be pure, in general it will receive breaking API changes
  * without notice.  Users should not subclass this interface directly, but
- * rather use one of the existing subclasses instead.
+ * rather use one of the existing subclasses such as DrakeLcmBase instead.
  *
  * Similarly, method arguments will receive breaking API changes without
  * notice.  Users should not call this interface directly, but rather use

--- a/lcm/test/drake_lcm_base_test.cc
+++ b/lcm/test/drake_lcm_base_test.cc
@@ -1,0 +1,40 @@
+#include "drake/lcm/drake_lcm_base.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace lcm {
+namespace {
+
+class SampleLcm : public DrakeLcmBase {};
+
+GTEST_TEST(LcmBaseTest, All) {
+  SampleLcm dut;
+  std::array<char, 1> data;
+  DrakeLcmInterface::HandlerFunction handler;
+  DrakeLcmInterface::MultichannelHandlerFunction multi_handler;
+
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.get_lcm_url(),
+                              ".*SampleLcm.*get_lcm_url.*not implemented.*");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.Publish("channel", data.data(), 1, {}),
+                              ".*SampleLcm.*Publish.*not.*");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.Subscribe("channel", handler),
+                              ".*SampleLcm.*Subscribe.*not.*");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.SubscribeMultichannel(".*", multi_handler),
+                              ".*SampleLcm.*Multichannel.*not.*");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.SubscribeAllChannels(multi_handler),
+                              ".*SampleLcm.*AllChannels.*not.*");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.HandleSubscriptions(0),
+                              ".*SampleLcm.*HandleSubscriptions.*not.*");
+}
+
+}  // namespace
+}  // namespace lcm
+}  // namespace drake


### PR DESCRIPTION
This might smooth out downstream transitions for subclasses of `DrakeLcmInterface` for changes such as #18826.

+@EricCousineau-TRI for both reviews per schedule, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18847)
<!-- Reviewable:end -->
