### PR TITLE
[workspace] Remove opt-in to FMT_DEPRECATED_OSTREAM

### DIFF
--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -16,6 +16,7 @@
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
 #include "drake/common/drake_deprecated.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/math/barycentric.h"
 #include "drake/math/bspline_basis.h"
 #include "drake/math/compute_numerical_gradient.h"
@@ -581,8 +582,8 @@ void DoScalarIndependentDefinitions(py::module m) {
               // displaying memory addresses in pydrake docs and help strings.
               // In the future, we should enhance this to display all of the
               // information.
-              return fmt::format(
-                  "<NumericalGradientOption({})>", py::repr(method));
+              return fmt::format("<NumericalGradientOption({})>",
+                  fmt_streamed(py::repr(method)));
             });
   }
 

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -6,7 +6,6 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_pybind.h"
@@ -75,7 +74,7 @@ PYBIND11_MODULE(symbolic, m) {
       .def("__repr__",
           [](const Variable& self) {
             return fmt::format(
-                "Variable('{}', {})", self.to_string(), self.get_type());
+                "Variable('{}', {})", self.get_name(), self.get_type());
           })
       .def("__hash__",
           [](const Variable& self) { return std::hash<Variable>{}(self); })

--- a/bindings/pydrake/symbolic_py_unapply.cc
+++ b/bindings/pydrake/symbolic_py_unapply.cc
@@ -2,7 +2,6 @@
 
 #include "pybind11/stl.h"
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 
 namespace drake {
 namespace pydrake {

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -999,6 +999,18 @@ drake_cc_googletest(
     ],
 )
 
+# Likewise (to the above test) for the ostream variation.
+drake_cc_googletest(
+    name = "text_logging_ostream_test",
+    defines = [
+        "TEXT_LOGGING_TEST_SPDLOG=1",
+    ],
+    use_default_main = False,
+    deps = [
+        ":essential",
+    ],
+)
+
 # This version of text_logging_test re-compiles all source files without
 # defining HAVE_SPDLOG, to ensure that the no-op stubs behave as desired.
 drake_cc_googletest(
@@ -1008,6 +1020,26 @@ drake_cc_googletest(
         "fmt.h",
         "never_destroyed.h",
         "test/text_logging_test.cc",
+        "text_logging.cc",
+        "text_logging.h",
+    ],
+    defines = [
+        "TEXT_LOGGING_TEST_SPDLOG=0",
+    ],
+    use_default_main = False,
+    deps = [
+        "@fmt",
+    ],
+)
+
+# Likewise (to the above test) for the ostream variation.
+drake_cc_googletest(
+    name = "text_logging_ostream_no_spdlog_test",
+    srcs = [
+        "drake_copyable.h",
+        "fmt.h",
+        "never_destroyed.h",
+        "test/text_logging_ostream_test.cc",
         "text_logging.cc",
         "text_logging.h",
     ],

--- a/common/ad/internal/partials.cc
+++ b/common/ad/internal/partials.cc
@@ -3,7 +3,6 @@
 #include <stdexcept>
 
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 
 namespace drake {
 namespace ad {

--- a/common/autodiffxd.h
+++ b/common/autodiffxd.h
@@ -23,6 +23,8 @@
 
 #include <Eigen/Dense>
 
+#include "drake/common/fmt_ostream.h"
+
 namespace Eigen {
 
 #if !defined(DRAKE_DOXYGEN_CXX)
@@ -550,3 +552,8 @@ inline const AutoDiffScalar<VectorXd> max(const AutoDiffScalar<VectorXd>& a,
 #endif
 
 }  // namespace Eigen
+
+namespace fmt {
+template <>
+struct formatter<drake::AutoDiffXd> : drake::ostream_formatter {};
+}  // namespace fmt

--- a/common/find_runfiles.cc
+++ b/common/find_runfiles.cc
@@ -74,7 +74,7 @@ RunfilesSingleton Create() {
     result.runfiles.reset(Runfiles::Create(argv0, &bazel_error));
   }
   drake::log()->debug("FindRunfile mechanism = {}", mechanism);
-  drake::log()->debug("cwd = {}", fs::current_path());
+  drake::log()->debug("cwd = \"{}\"", fs::current_path().string());
 
   // If there were runfiles, identify the RUNFILES_DIR.
   if (result.runfiles) {

--- a/common/fmt_ostream.h
+++ b/common/fmt_ostream.h
@@ -31,10 +31,10 @@ internal::streamed_ref<T> fmt_streamed(const T& ref) { return {ref}; }
 
 // Compatibility shim for fmt::ostream_formatter.
 #if FMT_VERSION >= 90000
-/** When using fmt >= 9, this is an alias for fmt::ostream_formatter.
-When using fmt < 9, this uses a polyfill instead. */
 using fmt::ostream_formatter;
 #else  // FMT_VERSION
+/** When using fmt >= 9, this is an alias for fmt::ostream_formatter.
+When using fmt < 9, this uses a polyfill instead. */
 struct ostream_formatter : fmt::formatter<std::string_view> {
   template <typename T, typename FormatContext>
   auto format(const T& value,

--- a/common/symbolic/decompose.cc
+++ b/common/symbolic/decompose.cc
@@ -6,7 +6,7 @@
 #include <tuple>
 #include <vector>
 
-#include <fmt/ostream.h>
+#include <fmt/format.h>
 
 namespace drake {
 namespace symbolic {

--- a/common/symbolic/expression/expression.cc
+++ b/common/symbolic/expression/expression.cc
@@ -8,7 +8,6 @@
 #include <stdexcept>
 
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/never_destroyed.h"

--- a/common/symbolic/expression/formula_cell.cc
+++ b/common/symbolic/expression/formula_cell.cc
@@ -10,6 +10,7 @@
 #include <stdexcept>
 #include <utility>
 
+#include <fmt/format.h>
 #include <fmt/ostream.h>
 
 #include "drake/common/drake_assert.h"

--- a/common/symbolic/expression/variable.h
+++ b/common/symbolic/expression/variable.h
@@ -373,4 +373,7 @@ namespace fmt {
 template <>
 struct formatter<drake::symbolic::Variable>
     : drake::ostream_formatter {};
+template <>
+struct formatter<drake::symbolic::Variable::Type>
+    : drake::ostream_formatter {};
 }  // namespace fmt

--- a/common/test/text_logging_ostream_test.cc
+++ b/common/test/text_logging_ostream_test.cc
@@ -1,0 +1,96 @@
+/* clang-format off to disable clang-format-includes */
+#include "drake/common/text_logging.h"
+/* clang-format on */
+
+#include <ostream>
+#include <sstream>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+// The BUILD.bazel rules must supply this flag.  This test code is compiled and
+// run twice -- once with spdlog, and once without.
+#ifndef TEXT_LOGGING_TEST_SPDLOG
+#error Missing a required definition to compile this test case.
+#endif
+
+// Check for the expected HAVE_SPDLOG value.
+#if TEXT_LOGGING_TEST_SPDLOG
+  #ifndef HAVE_SPDLOG
+    #error Missing HAVE_SPDLOG.
+  #endif
+#else
+  #ifdef HAVE_SPDLOG
+    #error Unwanted HAVE_SPDLOG.
+  #endif
+#endif
+
+#ifdef HAVE_SPDLOG
+#include <spdlog/sinks/dist_sink.h>
+#include <spdlog/sinks/ostream_sink.h>
+#endif  // HAVE_SPDLOG
+
+#include "drake/common/fmt_ostream.h"
+
+namespace {
+
+class Streamable {
+  [[maybe_unused]]  // If we don't have spdlog, this function is dead code.
+  friend std::ostream& operator<<(std::ostream& os, const Streamable& c) {
+    return os << "OK";
+  }
+};
+
+using drake::fmt_streamed;
+
+// Call each API function and macro to ensure that all of them compile.
+// These should all compile and run both with and without spdlog.
+GTEST_TEST(TextLoggingTest, SmokeTestStreamable) {
+  Streamable obj;
+  drake::log()->trace("drake::log()->trace test: {} {}", "OK",
+                      fmt_streamed(obj));
+  drake::log()->debug("drake::log()->debug test: {} {}", "OK",
+                      fmt_streamed(obj));
+  drake::log()->info("drake::log()->info test: {} {}", "OK", fmt_streamed(obj));
+  drake::log()->warn("drake::log()->warn test: {} {}", "OK", fmt_streamed(obj));
+  drake::log()->error("drake::log()->error test: {} {}", "OK",
+                      fmt_streamed(obj));
+  drake::log()->critical("drake::log()->critical test: {} {}", "OK",
+                         fmt_streamed(obj));
+  DRAKE_LOGGER_TRACE("DRAKE_LOGGER_TRACE macro test: {}, {}", "OK",
+                     fmt_streamed(obj));
+  DRAKE_LOGGER_DEBUG("DRAKE_LOGGER_DEBUG macro test: {}, {}", "OK",
+                     fmt_streamed(obj));
+}
+
+// We must run this test last because it changes the default configuration.
+GTEST_TEST(TextLoggingTest, ZZZ_ChangeDefaultSink) {
+  // The getter should never return nullptr, even with spdlog disabled.
+  drake::logging::sink* const sink_base = drake::logging::get_dist_sink();
+  ASSERT_NE(sink_base, nullptr);
+
+  // The remainder of the test case only makes sense when spdlog is enabled.
+  #if TEXT_LOGGING_TEST_SPDLOG
+    // Our API promises that the result always has this subtype.
+    auto* const sink = dynamic_cast<spdlog::sinks::dist_sink_mt*>(sink_base);
+    ASSERT_NE(sink, nullptr);
+
+    // Redirect all logs to a memory stream.
+    std::ostringstream messages;
+    auto custom_sink = std::make_shared<spdlog::sinks::ostream_sink_st>(
+        messages, true /* flush */);
+    sink->set_sinks({custom_sink});
+    drake::log()->info("This is some good info!");
+    EXPECT_THAT(messages.str(), testing::EndsWith(
+        "[console] [info] This is some good info!\n"));
+  #endif
+}
+
+}  // anon namespace
+
+// To enable compiling without depending on @spdlog, we need to provide our own
+// main routine.  The default drake_cc_googletest_main depends on @spdlog.
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/common/text_logging.h
+++ b/common/text_logging.h
@@ -24,15 +24,23 @@ not be compiled if debugging is turned off (-DNDEBUG is set):
 </pre>
 
 The format string syntax is fmtlib; see https://fmt.dev/latest/syntax.html.
-In particular, any class that overloads `operator<<` for `ostream` can be
-printed without any special handling.  (Note that the documentation link
-provides syntax for the latest version of fmtlib; the version of fmtlib
-used by Drake might be older.)
-*/
+(Note that the documentation link provides syntax for the latest version of
+fmtlib; the version of fmtlib used by Drake might be older.)
+
+When formatting an Eigen matrix into a string you must wrap the Eigen object
+with fmt_eigen(); see its documentation for details. This holds true whether it
+be for logging, error messages, etc.
+
+When logging a third-party type whose only affordance for string output is
+`operator<<`, use fmt_streamed(); see its documentation for details. This is
+very rare (only a couple uses in Drake so far).
+
+When implementing a string output for a Drake type, eventually this page will
+demonstrate how to use fmt::formatter<T>. In the meantime, you can implement
+`operator<<` and use drake::ostream_formatter, or else use the macro helper
+DRAKE_FORMATTER_AS(). Grep around in Drake's existing code to find examples. */
 
 #include <string>
-
-#include <fmt/ostream.h>
 
 #include "drake/common/fmt.h"
 

--- a/common/trajectories/path_parameterized_trajectory.cc
+++ b/common/trajectories/path_parameterized_trajectory.cc
@@ -2,7 +2,7 @@
 
 #include <algorithm>
 
-#include <fmt/ostream.h>
+#include <fmt/format.h>
 
 #include "drake/common/drake_assert.h"
 

--- a/common/yaml/test/example_structs.h
+++ b/common/yaml/test/example_structs.h
@@ -244,7 +244,7 @@ using Variant4 = std::variant<
 
 std::ostream& operator<<(std::ostream& os, const Variant4& value) {
   if (value.index() == 0) {
-    fmt::print(os,  "std::string{{{}}}", std::get<0>(value));
+    fmt::print(os, "std::string{{{}}}", std::get<0>(value));
   } else if (value.index() == 1) {
     fmt::print(os, "double{{{}}}", std::get<1>(value));
   } else if (value.index() == 2) {

--- a/common/yaml/test/yaml_node_test.cc
+++ b/common/yaml/test/yaml_node_test.cc
@@ -1,7 +1,6 @@
 #include "drake/common/yaml/yaml_node.h"
 
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/common/yaml/yaml_read_archive.cc
+++ b/common/yaml/yaml_read_archive.cc
@@ -4,6 +4,7 @@
 #include <cstring>
 
 #include <drake_vendor/yaml-cpp/yaml.h>
+#include <fmt/format.h>
 #include <fmt/ostream.h>
 
 #include "drake/common/nice_type_name.h"

--- a/examples/pendulum/pendulum_parameters_derivatives.cc
+++ b/examples/pendulum/pendulum_parameters_derivatives.cc
@@ -1,4 +1,4 @@
-#include <fmt/ostream.h>
+#include <fmt/format.h>
 
 #include "drake/common/eigen_types.h"
 #include "drake/examples/pendulum/gen/pendulum_input.h"

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -1,7 +1,7 @@
 #include <memory>
 #include <string>
 
-#include <fmt/ostream.h>
+#include <fmt/format.h>
 #include <gflags/gflags.h>
 
 #include "drake/common/drake_assert.h"

--- a/geometry/geometry_properties.h
+++ b/geometry/geometry_properties.h
@@ -8,7 +8,6 @@
 #include <unordered_map>
 
 #include <Eigen/Dense>
-#include <fmt/ostream.h>
 
 #include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/fmt_ostream.h"

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -362,16 +362,16 @@ class MeshcatShapeReifier : public ShapeReifier {
                               map_data));
           } else {
             drake::log()->warn(
-                "Meshcat: Failed to load texture. {} references {}, but "
-                "Meshcat could not open filename {}",
-                basedir / mtllib, map, basedir / map);
+                "Meshcat: Failed to load texture. \"{}\" references {}, but "
+                "Meshcat could not open filename \"{}\"",
+                (basedir / mtllib).string(), map, (basedir / map).string());
           }
         }
       } else {
         drake::log()->warn(
             "Meshcat: Failed to load texture. {} references {}, but Meshcat "
-            "could not open filename {}",
-            mesh.filename(), mtllib, basedir / mtllib);
+            "could not open filename \"{}\"",
+            mesh.filename(), mtllib, (basedir / mtllib).string());
       }
       Eigen::Map<Eigen::Matrix4d> matrix(meshfile_object.matrix);
       matrix(0, 0) = mesh.scale();

--- a/geometry/proximity/contact_surface_utility.cc
+++ b/geometry/proximity/contact_surface_utility.cc
@@ -3,7 +3,6 @@
 #include <algorithm>
 
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/fmt_eigen.h"

--- a/geometry/render_gl/internal_opengl_context.cc
+++ b/geometry/render_gl/internal_opengl_context.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -49,6 +50,15 @@ GLXContext glXCreateContextAttribsARB(
       GLXContext(Display*, GLXFBConfig, GLXContext, Bool, const int*)>(
       "glXCreateContextAttribsARB")(
           dpy, config, share_context, direct, attrib_list);
+}
+
+// Returns the GL_VENDOR bytes as a std::string.
+std::string GetGlVendor() {
+  std::stringstream result;
+  for (const GLubyte* iter = glGetString(GL_VENDOR); *iter != 0; ++iter) {
+    result << static_cast<char>(*iter);
+  }
+  return result.str();
 }
 
 void GlDebugCallback(GLenum, GLenum type, GLuint, GLenum severity, GLsizei,
@@ -166,7 +176,7 @@ class OpenGlContext::Impl {
 
     // Enable debug.
     if (debug) {
-      drake::log()->info("Vendor: {}", glGetString(GL_VENDOR));
+      drake::log()->info("Vendor: {}", GetGlVendor());
       glEnable(GL_DEBUG_OUTPUT);
       glDebugMessageCallback(GlDebugCallback, 0);
     }

--- a/geometry/render_gltf_client/test/internal_render_client_test.cc
+++ b/geometry/render_gltf_client/test/internal_render_client_test.cc
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <gtest/gtest.h>
 

--- a/geometry/rgba.cc
+++ b/geometry/rgba.cc
@@ -3,7 +3,6 @@
 #include <stdexcept>
 
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 
 namespace drake {
 namespace geometry {

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include <drake_vendor/fcl/fcl.h>
+#include <fmt/ostream.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"

--- a/math/roll_pitch_yaw.cc
+++ b/math/roll_pitch_yaw.cc
@@ -3,7 +3,6 @@
 #include <string>
 
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 
 #include "drake/common/cond.h"
 #include "drake/math/rotation_matrix.h"

--- a/math/roll_pitch_yaw.h
+++ b/math/roll_pitch_yaw.h
@@ -4,7 +4,6 @@
 #include <limits>
 
 #include <Eigen/Dense>
-#include <fmt/ostream.h>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -971,9 +971,9 @@ class MujocoParser {
         } else if (std::filesystem::exists(original_filename)) {
           log()->warn(
               "Drake's MuJoCo parser currently only supports mesh files in "
-              ".obj format. The meshfile {} was requested; Drake attempted to "
-              "load {}, but that file does not exist.",
-              original_filename, filename);
+              ".obj format. The meshfile \"{}\" was requested; Drake attempted "
+              "to load \"{}\", but that file does not exist.",
+              original_filename.string(), filename.string());
           std::string original_extension = original_filename.extension();
           std::transform(original_extension.begin(), original_extension.end(),
                          original_extension.begin(),
@@ -981,15 +981,15 @@ class MujocoParser {
           if (original_extension == ".stl") {
             log()->warn(
                 "If you have built Drake from source, running\n\n bazel run "
-                "//manipulation/utils/stl2obj -- {} {}\n\nonce will "
+                "//manipulation/utils/stl2obj -- \"{}\" \"{}\"\n\nonce will "
                 "resolve this.",
-                original_filename, filename);
+                original_filename.string(), filename.string());
           }
         } else {
           log()->warn(
-              "The mesh asset {} could not be found, nor could its .obj "
-              "replacement {}.",
-              original_filename, filename);
+              "The mesh asset \"{}\" could not be found, nor could its .obj "
+              "replacement \"{}\".",
+              original_filename.string(), filename.string());
         }
       } else {
         std::string name{};

--- a/multibody/parsing/detail_path_utils.cc
+++ b/multibody/parsing/detail_path_utils.cc
@@ -7,7 +7,6 @@
 #include <vector>
 
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/never_destroyed.h"
@@ -32,11 +31,11 @@ string ResolveUri(const DiagnosticPolicy& diagnostic, const string& uri,
   if (std::regex_match(uri, match, uri_matcher.access())) {
     // The `uri` was actually a URI (not a bare filename).
     DRAKE_DEMAND(match.size() == 4);
-    const auto& uri_scheme = match[1];
-    const auto& uri_package = match[2];
-    const auto& uri_path = match[3];
+    const std::string& uri_scheme = match[1];
+    const std::string& uri_package = match[2];
+    const std::string& uri_path = match[3];
     if (uri_scheme == "file") {
-      result = "/" + uri_path.str();
+      result = "/" + uri_path;
     } else if ((uri_scheme == "model") || (uri_scheme == "package")) {
       if (!package_map.Contains(uri_package)) {
         diagnostic.Error(fmt::format(
@@ -50,7 +49,7 @@ string ResolveUri(const DiagnosticPolicy& diagnostic, const string& uri,
         diagnostic.Warning(fmt::format(
             "In URI '{}': {}", uri, *deprecation));
       }
-      result = fs::path(package_path) / std::string(uri_path);
+      result = fs::path(package_path) / uri_path;
     } else {
       diagnostic.Error(fmt::format(
           "URI '{}' specifies an unsupported scheme; supported schemes are "

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -437,8 +437,8 @@ TEST_F(BoxMeshTest, MeshFileAbsolutePathCompiler) {
   std::string mesh_asset =
       R"""(<mesh name="box" file="box.obj"/>)""";
   std::string compiler =
-      fmt::format(R"""(<compiler meshdir={}/>)""",
-                  std::filesystem::path(box_obj_).parent_path());
+      fmt::format(R"""(<compiler meshdir="{}"/>)""",
+                  std::filesystem::path(box_obj_).parent_path().string());
   TestBoxMesh(box_obj_, mesh_asset, compiler);
 }
 

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 
+#include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/multibody/plant/coulomb_friction.cc
+++ b/multibody/plant/coulomb_friction.cc
@@ -1,7 +1,6 @@
 #include "drake/multibody/plant/coulomb_friction.h"
 
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 
 namespace drake {
 namespace multibody {

--- a/perception/point_cloud.cc
+++ b/perception/point_cloud.cc
@@ -12,7 +12,6 @@
 #include <common_robotics_utilities/voxel_grid.hpp>
 #include <drake_vendor/nanoflann.hpp>
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_throw.h"

--- a/solvers/branch_and_bound.cc
+++ b/solvers/branch_and_bound.cc
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 
 #include "drake/common/unused.h"
 #include "drake/solvers/choose_best_solver.h"

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -15,7 +15,6 @@
 #include <vector>
 
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/fmt_eigen.h"

--- a/solvers/solver_options.cc
+++ b/solvers/solver_options.cc
@@ -5,7 +5,6 @@
 #include <utility>
 
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 
 #include "drake/common/never_destroyed.h"
 

--- a/systems/analysis/dense_output.h
+++ b/systems/analysis/dense_output.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"

--- a/systems/sensors/image_writer.cc
+++ b/systems/sensors/image_writer.cc
@@ -8,7 +8,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/ostream.h>
+#include <fmt/format.h>
 #include <vtkImageData.h>
 #include <vtkNew.h>
 #include <vtkPNGWriter.h>

--- a/tools/install/libdrake/header_lint.bzl
+++ b/tools/install/libdrake/header_lint.bzl
@@ -23,7 +23,6 @@ _ALLOWED_EXTERNALS = [
 # permitted here are definitions required by the _ALLOWED_EXTERNALS, above.
 _ALLOWED_DEFINES = [
     "EIGEN_MPL2_ONLY",
-    "FMT_DEPRECATED_OSTREAM=1",
     "FMT_HEADER_ONLY=1",
     "FMT_NO_FMT_STRING_ALIAS=1",
     "HAVE_SPDLOG",

--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -413,9 +413,6 @@ def _generate_pybind_documentation_header_impl(ctx):
 
     # TODO(jamiesnape): Remove this line when #14034 is resolved.
     args.add("-DDRAKE_COMMON_SYMBOLIC_EXPRESSION_DETAIL_HEADER")
-
-    # TODO(svenevs): Remove when drake uses fmt 9+ ostream behavior.
-    args.add("-DFMT_DEPRECATED_OSTREAM=1")
     args.add_all(
         targets.compile_flags + target_deps.compile_flags,
         uniquify = True,

--- a/tools/workspace/fmt/repository.bzl
+++ b/tools/workspace/fmt/repository.bzl
@@ -52,9 +52,6 @@ load("@drake//tools/install:install.bzl", "install")
 install(name = "install")
             """,
         ),
-        "extra_defines": attr.string_list(
-            default = ["FMT_DEPRECATED_OSTREAM=1"],
-        ),
         # The remaining attributes are used only when we take the branch for
         # setup_github_repository in the above logic.
         "repository": attr.string(


### PR DESCRIPTION
Drake is natively compatible with fmt v9 now. This reverts commit 33a33485 and 7c44c7e2.

Remove all mentions of `#include <fmt/ostream.h>` except where it is actually used in earnest.

Add a few formatters missed in prior commits.

---

Towards #17742.

This retires the risk that a fmt 10 upgrade will break us on Homebrew.

Remaining work involves polishing up all of the loose ends to make the developer UX even better.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18850)
<!-- Reviewable:end -->
