### PR TITLE
[planning] Update algorithms/planning module documentation

### DIFF
--- a/doc/doxygen_cxx/doxygen.h
+++ b/doc/doxygen_cxx/doxygen.h
@@ -186,17 +186,6 @@ namespace solvers {
  @}
  */
 
-/** @addtogroup planning
- @{
-   A collection of algorithms for finding configurations and/or trajectories of
-   dynamical systems.
-
-   Many planning algorithms make heavy use of solvers::MathematicalProgram and
-   the numerous @ref solver_evaluators.  There are also some useful classes in
-   @ref manipulation_systems.
- @}
-*/
-
 /** @addtogroup control
  @{
    A collection of algorithms for synthesizing feedback control.

--- a/multibody/inverse_kinematics/constraint_relaxing_ik.h
+++ b/multibody/inverse_kinematics/constraint_relaxing_ik.h
@@ -16,7 +16,7 @@ namespace multibody {
  * A wrapper class around the IK planner. This class improves IK's usability by
  * handling constraint relaxing and multiple initial guesses internally.
  *
- * @ingroup planning
+ * @ingroup planning_configuration
  */
 class ConstraintRelaxingIk {
  public:

--- a/multibody/inverse_kinematics/differential_inverse_kinematics.h
+++ b/multibody/inverse_kinematics/differential_inverse_kinematics.h
@@ -337,7 +337,7 @@ class DifferentialInverseKinematicsParameters {
  * @return If the solver successfully finds a solution, joint_velocities will
  * be set to v, otherwise it will be nullopt.
  *
- * @ingroup planning
+ * @ingroup planning_configuration
  */
 DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     const Eigen::Ref<const VectorX<double>>& q_current,
@@ -363,7 +363,7 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
  * @return If the solver successfully finds a solution, joint_velocities will
  * be set to v, otherwise it will be nullopt.
  *
- * @ingroup planning
+ * @ingroup planning_configuration
  */
 DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     const MultibodyPlant<double>& robot,
@@ -388,7 +388,7 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
  * @return If the solver successfully finds a solution, joint_velocities will
  * be set to v, otherwise it will be nullopt.
  *
- * @ingroup planning
+ * @ingroup planning_configuration
  */
 DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     const MultibodyPlant<double>& robot,

--- a/multibody/inverse_kinematics/global_inverse_kinematics.h
+++ b/multibody/inverse_kinematics/global_inverse_kinematics.h
@@ -23,7 +23,7 @@ namespace multibody {
  * Convex Optimization by Hongkai Dai, Gregory Izatt and Russ Tedrake,
  * International Journal of Robotics Research, 2019.
  *
- * @ingroup planning
+ * @ingroup planning_configuration
  */
 class GlobalInverseKinematics {
  public:

--- a/multibody/inverse_kinematics/inverse_kinematics.h
+++ b/multibody/inverse_kinematics/inverse_kinematics.h
@@ -15,7 +15,7 @@ namespace multibody {
  * postures of the robot satisfying certain constraints.
  * The decision variables include the generalized position of the robot.
  *
- * @ingroup planning
+ * @ingroup planning_configuration
  */
 class InverseKinematics {
  public:

--- a/multibody/optimization/static_equilibrium_problem.h
+++ b/multibody/optimization/static_equilibrium_problem.h
@@ -28,7 +28,7 @@ namespace multibody {
  *    distance.
  * 5. q within the joint limit.
  *
- * @ingroup planning
+ * @ingroup planning_configuration
  */
 class StaticEquilibriumProblem {
  public:

--- a/multibody/optimization/toppra.h
+++ b/multibody/optimization/toppra.h
@@ -59,7 +59,7 @@ struct CalcGridPointsOptions {
  * Parameterization based on Reachability Analysis" by Hung Pham and Quang Cuong
  * Pham, IEEE Transactions on Robotics, 2018.
  *
- * @ingroup planning
+ * @ingroup planning_trajectory
  */
 class Toppra {
  public:

--- a/planning/body_shape_description.h
+++ b/planning/body_shape_description.h
@@ -20,7 +20,9 @@ construct a valid %BodyShapeDescription; it will extract and verify the correct
 information from a multibody plant and its context.
 
 When moved-from, this object models a "null" description and all of the getter
-functions will throw. */
+functions will throw.
+
+@ingroup planning_collision_checker */
 class BodyShapeDescription final {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(BodyShapeDescription)

--- a/planning/collision_avoidance.h
+++ b/planning/collision_avoidance.h
@@ -41,7 +41,9 @@ namespace internal {
  @pre max_penetration <= 0.
  @pre max_clearance >= 0.
  @pre max_clearance > max_penetration.
- @pre if context != nullptr, it is a context managed by checker. */
+ @pre if context != nullptr, it is a context managed by checker.
+
+ @ingroup planning_collision_checker */
 Eigen::VectorXd ComputeCollisionAvoidanceDisplacement(
     const CollisionChecker& checker, const Eigen::VectorXd& q,
     double max_penetration, double max_clearance,

--- a/planning/collision_checker.h
+++ b/planning/collision_checker.h
@@ -148,7 +148,8 @@ namespace planning {
  CheckEdgesCollisionFree(), etc); a derived implementation should return `false`
  from SupportsParallelChecking() if there is no meaningful benefit to attempting
  to do work in parallel (e.g., they must fully serialize on shared state).
- */
+
+ @ingroup planning_collision_checker */
 class CollisionChecker {
  public:
   // N.B. The copy constructor is protected for use in implementing Clone().

--- a/planning/collision_checker_context.h
+++ b/planning/collision_checker_context.h
@@ -19,7 +19,9 @@ namespace planning {
 
  In all cases, modifying context should happen through
  CollisionChecker::PerformOperationAgainstAllModelContexts(). Modifying the
- contained Drake Contexts directly is generally erroneous. */
+ contained Drake Contexts directly is generally erroneous.
+
+ @ingroup planning_collision_checker */
 class CollisionCheckerContext {
  public:
   /** \name Does not allow copy, move, or assignment generally.

--- a/planning/collision_checker_params.h
+++ b/planning/collision_checker_params.h
@@ -40,7 +40,9 @@ using ConfigurationInterpolationFunction = std::function<Eigen::VectorXd(
 
 /** A set of common constructor parameters for a CollisionChecker.
 Not all subclasses of CollisionChecker will necessarily support this
-configuration struct, but many do so. */
+configuration struct, but many do so.
+
+@ingroup planning_collision_checker */
 struct CollisionCheckerParams {
   /** A RobotDiagram model of the robot and environment. Must not be
   nullptr. */

--- a/planning/edge_measure.h
+++ b/planning/edge_measure.h
@@ -34,7 +34,9 @@ namespace planning {
  @note For α to be meaningful, the caller is obliged to make sure that they
  use the same interpolating function as the CollisionChecker did when generating
  the measure. Calling CollisionChecker::InterpolateBetweenConfigurations() on
- the same checker instance would satisfy that requirement. */
+ the same checker instance would satisfy that requirement.
+
+ @ingroup planning_collision_checker */
 class EdgeMeasure {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(EdgeMeasure)

--- a/planning/planning_doxygen.h
+++ b/planning/planning_doxygen.h
@@ -1,0 +1,45 @@
+/** @addtogroup planning
+ @{
+   A collection of algorithms for finding configurations and/or trajectories of
+   dynamical systems.
+
+   Many planning algorithms make heavy use of @ref solvers::MathematicalProgram
+   "MathematicalProgram" and the numerous @ref solver_evaluators.  There are
+   also some useful classes in @ref manipulation_systems.
+
+   @defgroup planning_configuration
+   @defgroup planning_trajectory
+   @defgroup planning_collision_checker
+   @defgroup planning_infrastructure
+ @}
+*/
+
+/** @addtogroup planning_configuration Configurations
+ @{
+   These algorithms help define configurations of dynamical systems. While it
+   includes inverse kinematics (IK) algorithms, it also includes algorithms for
+   computing dynamically stable configurations.
+ @}
+*/
+
+/** @addtogroup planning_trajectory Trajectories
+ @{
+   These algorithms compute trajectories based on various criteria.
+ @}
+*/
+
+/** @addtogroup planning_collision_checker Collision checking
+ @{
+  The CollisionChecker interface provides a basis for performing distance
+  queries on robots in environments for various planning problems (e.g.,
+  sampling planning).
+ @}
+*/
+
+/** @addtogroup planning_infrastructure Convenience classes
+ @{
+   Simplifications for managing @ref drake::systems::Diagram "Diagrams"
+   containing @ref drake::multibody::MultibodyPlant "MultibodyPlant" and
+   @ref drake::geometry::SceneGraph "SceneGraph" systems in planning tasks.
+ @}
+*/

--- a/planning/robot_clearance.h
+++ b/planning/robot_clearance.h
@@ -59,7 +59,9 @@ namespace planning {
       filtering collisions will cull most of these Jacobians. But depending on
       the structure of the robot and its representative collision geometry, it
       is still possible to evaluate the Jacobian at a configuration that
-      represents a local optimum (zero-valued Jacobian). */
+      represents a local optimum (zero-valued Jacobian).
+
+ @ingroup planning_collision_checker */
 class RobotClearance {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RobotClearance)

--- a/planning/robot_collision_type.h
+++ b/planning/robot_collision_type.h
@@ -7,7 +7,9 @@ namespace planning {
 
 /** Enumerates these predicates (and their combinations):
  - is the robot in collision with itself?
- - is the robot in collision with something in the environment? */
+ - is the robot in collision with something in the environment?
+
+ @ingroup planning_collision_checker */
 enum class RobotCollisionType : uint8_t {
   kNoCollision = 0x00,
   kEnvironmentCollision = 0x01,

--- a/planning/robot_diagram.h
+++ b/planning/robot_diagram.h
@@ -19,7 +19,9 @@ references. It's purpose is to serve as planner-specific syntactic sugar for
 operating on a MultibodyPlant. For other purposes (e.g., simulation), users
 should generally prefer to just use a Diagram, instead.
 
-@tparam_default_scalar */
+@tparam_default_scalar
+
+@ingroup planning_infrastructure */
 template <typename T>
 class RobotDiagram final : public systems::Diagram<T> {
  public:

--- a/planning/robot_diagram_builder.h
+++ b/planning/robot_diagram_builder.h
@@ -22,7 +22,9 @@ This class is a convenient syntactic sugar to help build a robot diagram,
 especially in C++ code where it simplifies object lifetime tracking and
 downcasting of the plant and scene graph references.
 
-@tparam_default_scalar */
+@tparam_default_scalar
+
+@ingroup planning_infrastructure */
 template <typename T>
 class RobotDiagramBuilder {
  public:

--- a/planning/scene_graph_collision_checker.h
+++ b/planning/scene_graph_collision_checker.h
@@ -14,6 +14,8 @@ namespace planning {
 /** An implementation of CollisionChecker that uses SceneGraph to provide
 collision checks. Its behavior and limitations are exactly those of SceneGraph,
 e.g., in terms of what kinds of geometries can be collided.
+
+@ingroup planning_collision_checker
 */
 class SceneGraphCollisionChecker final : public CollisionChecker {
  public:

--- a/planning/trajectory_optimization/direct_collocation.h
+++ b/planning/trajectory_optimization/direct_collocation.h
@@ -24,7 +24,7 @@ namespace trajectory_optimization {
 /// achieve a 3rd order integration accuracy.
 ///
 /// Note: This algorithm only works with the continuous states of a system.
-/// @ingroup planning
+/// @ingroup planning_trajectory
 class DirectCollocation : public MultipleShooting {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DirectCollocation)

--- a/planning/trajectory_optimization/direct_transcription.h
+++ b/planning/trajectory_optimization/direct_transcription.h
@@ -27,7 +27,7 @@ struct TimeStep {
 /// control and input at every sample time in the trajectory, and one-step
 /// of numerical integration provides the dynamic constraints between those
 /// decision variables.
-/// @ingroup planning
+/// @ingroup planning_trajectory
 class DirectTranscription : public MultipleShooting {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DirectTranscription)

--- a/planning/trajectory_optimization/integration_constraint.h
+++ b/planning/trajectory_optimization/integration_constraint.h
@@ -10,6 +10,8 @@ namespace trajectory_optimization {
  *
  *     (ẋₗ + ẋᵣ)/2  * dt = xᵣ - xₗ
  * where the bounded variables are (xᵣ, xₗ, ẋᵣ, ẋₗ, dt)
+ *
+ * @ingroup solver_evaluators
  */
 class MidPointIntegrationConstraint : public solvers::Constraint {
  public:

--- a/planning/trajectory_optimization/kinematic_trajectory_optimization.h
+++ b/planning/trajectory_optimization/kinematic_trajectory_optimization.h
@@ -38,6 +38,8 @@ Use solvers::Solve to solve the problem. A typical use case could look like:
 
 When possible this class attempts to formulate convex forms of the costs and
 constraints.
+
+@ingroup planning_trajectory
 */
 class KinematicTrajectoryOptimization {
  public:

--- a/planning/trajectory_optimization/multiple_shooting.h
+++ b/planning/trajectory_optimization/multiple_shooting.h
@@ -40,7 +40,7 @@ namespace trajectory_optimization {
 /// and that the trajectory is discretized into timesteps h (N-1 of these),
 /// state x (N of these), and control input u (N of these).
 ///
-/// @ingroup planning
+/// @ingroup planning_trajectory
 class MultipleShooting {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MultipleShooting)

--- a/systems/controllers/zmp_planner.h
+++ b/systems/controllers/zmp_planner.h
@@ -68,7 +68,7 @@ namespace controllers {
  2015 IEEE-RAS 15th International Conference on Humanoid Robots (Humanoids),
  Seoul, 2015, pp. 936-940.
 
- @ingroup planning
+ @ingroup planning_trajectory
  */
 class ZmpPlanner {
  public:


### PR DESCRIPTION
1. Adds the new classes in drake/planning to the module.
2. Adds subgroups to the module to provide broad guidance on the classes.
3. Moves the planning module documentation into its own header.

resolves #18640

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18854)
<!-- Reviewable:end -->
