### PR TITLE
[common] Move non-inlined TypeSafeIndex functions to the cc file

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -448,6 +448,7 @@ drake_cc_library(
 
 drake_cc_library(
     name = "type_safe_index",
+    srcs = ["type_safe_index.cc"],
     hdrs = ["type_safe_index.h"],
     deps = [
         ":essential",

--- a/common/type_safe_index.cc
+++ b/common/type_safe_index.cc
@@ -1,0 +1,25 @@
+#include "drake/common/type_safe_index.h"
+
+#include <stdexcept>
+
+#include "drake/common/nice_type_name.h"
+
+namespace drake {
+namespace internal {
+
+void ThrowTypeSafeIndexAssertValidFailed(const std::type_info& type,
+                                         const char* source) {
+  throw std::logic_error(fmt::format(
+      "{} Type \"{}\", has an invalid value; it must lie in the range "
+      "[0, 2³¹ - 1].",
+      source, NiceTypeName::Get(type)));
+}
+
+void ThrowTypeSafeIndexAssertNoOverflowFailed(const std::type_info& type,
+                                              const char* source) {
+  throw std::logic_error(fmt::format("{} Type \"{}\", has overflowed.", source,
+                                     NiceTypeName::Get(type)));
+}
+
+}  // namespace internal
+}  // namespace drake

--- a/common/type_safe_index.h
+++ b/common/type_safe_index.h
@@ -1,17 +1,21 @@
 #pragma once
 
-#include <functional>
 #include <limits>
-#include <stdexcept>
 #include <string>
+#include <typeinfo>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/fmt_ostream.h"
 #include "drake/common/hash.h"
-#include "drake/common/nice_type_name.h"
 
 namespace drake {
+
+namespace internal {
+[[noreturn]] void ThrowTypeSafeIndexAssertValidFailed(
+    const std::type_info& type, const char* source);
+[[noreturn]] void ThrowTypeSafeIndexAssertNoOverflowFailed(
+    const std::type_info& type, const char* source);
+}  // namespace internal
 
 /// A type-safe non-negative index class.
 ///
@@ -499,10 +503,8 @@ class TypeSafeIndex {
   // Invocations provide a string explaining the origin of the bad value.
   static void AssertValid(int64_t index, const char* source) {
     if (index < 0 || index > kMaxIndex) {
-      throw std::runtime_error(
-          std::string(source) + " Type \"" +
-          drake::NiceTypeName::Get<TypeSafeIndex<Tag>>() +
-          "\", has an invalid value; it must lie in the range [0, 2³¹ - 1].");
+      internal::ThrowTypeSafeIndexAssertValidFailed(typeid(TypeSafeIndex),
+                                                    source);
     }
   }
 
@@ -510,10 +512,8 @@ class TypeSafeIndex {
   // the current index value.
   void AssertNoOverflow(int delta, const char* source) const {
     if (delta > 0 && index_ > kMaxIndex - delta) {
-      throw std::runtime_error(
-          std::string(source) + " Type \"" +
-          drake::NiceTypeName::Get<TypeSafeIndex<Tag>>() +
-          "\", has overflowed.");
+      internal::ThrowTypeSafeIndexAssertNoOverflowFailed(typeid(TypeSafeIndex),
+                                                         source);
     }
   }
 
@@ -581,7 +581,6 @@ operator>=(const U& value, const TypeSafeIndex<Tag>& tag) {
 }  // namespace drake
 
 namespace std {
-
 /// Enables use of the type-safe index to serve as a key in STL containers.
 /// @relates TypeSafeIndex
 template <typename Tag>


### PR DESCRIPTION
Noticed during #17742.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18856)
<!-- Reviewable:end -->
