### PR TITLE
[common] Deprecate unused constants and typedefs in :essential

### DIFF
--- a/bindings/pydrake/common/test/eigen_geometry_test_util_py.cc
+++ b/bindings/pydrake/common/test/eigen_geometry_test_util_py.cc
@@ -33,8 +33,8 @@ PYBIND11_MODULE(eigen_geometry_test_util, m) {
   });
 
   m.def("create_translation",
-      []() { return Translation3<T>(Vector3<T>::Zero()); });
-  m.def("check_translation", [max_abs](const Translation3<T>& p) {
+      []() { return Eigen::Translation<T, 3>(Vector3<T>::Zero()); });
+  m.def("check_translation", [max_abs](const Eigen::Translation<T, 3>& p) {
     const T error = max_abs(p.vector());
     DRAKE_THROW_UNLESS(error < kTolerance);
   });

--- a/common/constants.h
+++ b/common/constants.h
@@ -1,20 +1,26 @@
 #pragma once
 
+#include "drake/common/drake_deprecated.h"
+
 namespace drake {
 
+DRAKE_DEPRECATED("2023-06-01", "This constant is no longer used in Drake.")
 constexpr int kQuaternionSize = 4;
 
+DRAKE_DEPRECATED("2023-06-01", "This constant is no longer used in Drake.")
 constexpr int kSpaceDimension = 3;
 
+DRAKE_DEPRECATED("2023-06-01", "This constant is no longer used in Drake.")
 constexpr int kRpySize = 3;
 
-/// https://en.wikipedia.org/wiki/Screw_theory#Twist
+DRAKE_DEPRECATED("2023-06-01", "This constant is no longer used in Drake.")
 constexpr int kTwistSize = 6;
 
-/// http://www.euclideanspace.com/maths/geometry/affine/matrix4x4/
+DRAKE_DEPRECATED("2023-06-01", "This constant is no longer used in Drake.")
 constexpr int kHomogeneousTransformSize = 16;
 
-const int kRotmatSize = kSpaceDimension * kSpaceDimension;
+DRAKE_DEPRECATED("2023-06-01", "This constant is no longer used in Drake.")
+constexpr int kRotmatSize = 9;
 
 enum class ToleranceType { kAbsolute, kRelative };
 

--- a/common/eigen_types.h
+++ b/common/eigen_types.h
@@ -19,6 +19,7 @@ static_assert(EIGEN_VERSION_AT_LEAST(3, 3, 5),
 #include "drake/common/constants.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 
 namespace drake {
 
@@ -158,37 +159,40 @@ using AngleAxis = Eigen::AngleAxis<Scalar>;
 template <typename Scalar>
 using Isometry3 = Eigen::Transform<Scalar, 3, Eigen::Isometry>;
 
-/// A translation in 3D templated on scalar type.
+/// (Deprecated.)
 template <typename Scalar>
-using Translation3 = Eigen::Translation<Scalar, 3>;
+using Translation3
+    DRAKE_DEPRECATED("2023-06-01", "This typedef is no longer used in Drake.")
+    = Eigen::Translation<Scalar, 3>;
 
-/// A column vector consisting of one twist.
+/// (Deprecated.)
 template <typename Scalar>
-using TwistVector = Eigen::Matrix<Scalar, kTwistSize, 1>;
+using TwistVector
+    DRAKE_DEPRECATED("2023-06-01", "This typedef is no longer used in Drake.")
+    = Eigen::Matrix<Scalar, 6, 1>;
 
-/// A matrix with one twist per column, and dynamically many columns.
+/// (Deprecated.)
 template <typename Scalar>
-using TwistMatrix = Eigen::Matrix<Scalar, kTwistSize, Eigen::Dynamic>;
+using TwistMatrix
+    DRAKE_DEPRECATED("2023-06-01", "This typedef is no longer used in Drake.")
+    = Eigen::Matrix<Scalar, 6, Eigen::Dynamic>;
 
-/// A six-by-six matrix.
+/// (Deprecated.)
 template <typename Scalar>
-using SquareTwistMatrix = Eigen::Matrix<Scalar, kTwistSize, kTwistSize>;
+using SquareTwistMatrix
+    DRAKE_DEPRECATED("2023-06-01", "This typedef is no longer used in Drake.")
+    = Eigen::Matrix<Scalar, 6, 6>;
 
-/// A column vector consisting of one wrench (spatial force) = `[r X f; f]`,
-/// where f is a force (translational force) applied at a point `P` and `r` is
-/// the position vector from a point `O` (called the "moment center") to point
-/// `P`.
+/// (Deprecated.)
 template <typename Scalar>
-using WrenchVector = Eigen::Matrix<Scalar, 6, 1>;
+using WrenchVector
+    DRAKE_DEPRECATED("2023-06-01", "This typedef is no longer used in Drake.")
+    = Eigen::Matrix<Scalar, 6, 1>;
 
-/// EigenSizeMinPreferDynamic<a, b>::value gives the min between compile-time
-/// sizes @p a and @p b. 0 has absolute priority, followed by 1, followed by
-/// Dynamic, followed by other finite values.
-///
-/// Note that this is a type-trait version of EIGEN_SIZE_MIN_PREFER_DYNAMIC
-/// macro in "Eigen/Core/util/Macros.h".
 template <int a, int b>
-struct EigenSizeMinPreferDynamic {
+struct DRAKE_DEPRECATED("2023-06-01",
+    "This metaprogramming struct is no longer used in Drake.")
+EigenSizeMinPreferDynamic {
   // clang-format off
   static constexpr int value = (a == 0 || b == 0) ? 0 :
                                (a == 1 || b == 1) ? 1 :
@@ -197,14 +201,10 @@ struct EigenSizeMinPreferDynamic {
   // clang-format on
 };
 
-/// EigenSizeMinPreferFixed is a variant of EigenSizeMinPreferDynamic. The
-/// difference is that finite values now have priority over Dynamic, so that
-/// EigenSizeMinPreferFixed<3, Dynamic>::value gives 3.
-///
-/// Note that this is a type-trait version of EIGEN_SIZE_MIN_PREFER_FIXED macro
-/// in "Eigen/Core/util/Macros.h".
 template <int a, int b>
-struct EigenSizeMinPreferFixed {
+struct DRAKE_DEPRECATED("2023-06-01",
+    "This metaprogramming struct is no longer used in Drake.")
+EigenSizeMinPreferFixed {
   // clang-format off
   static constexpr int value = (a == 0 || b == 0) ? 0 :
                                (a == 1 || b == 1) ? 1 :
@@ -215,10 +215,10 @@ struct EigenSizeMinPreferFixed {
   // clang-format on
 };
 
-/// MultiplyEigenSizes<a, b> gives a * b if both of a and b are fixed
-/// sizes. Otherwise it gives Eigen::Dynamic.
 template <int a, int b>
-struct MultiplyEigenSizes {
+struct DRAKE_DEPRECATED("2023-06-01",
+    "This metaprogramming struct is no longer used in Drake.")
+MultiplyEigenSizes {
   static constexpr int value =
       (a == Eigen::Dynamic || b == Eigen::Dynamic) ? Eigen::Dynamic : a * b;
 };

--- a/common/symbolic/expression/formula.h
+++ b/common/symbolic/expression/formula.h
@@ -518,23 +518,25 @@ namespace internal {
 /// @pre The type of (DerivedA::Scalar() == DerivedB::Scalar()) is symbolic
 /// formula.
 template <
-  typename DerivedA,
-  typename DerivedB,
-  typename = std::enable_if_t<
-    std::is_same_v<typename Eigen::internal::traits<DerivedA>::XprKind,
-                   Eigen::ArrayXpr> &&
-    std::is_same_v<typename Eigen::internal::traits<DerivedB>::XprKind,
-                   Eigen::ArrayXpr> &&
-    std::is_same_v<decltype(typename DerivedA::Scalar() ==
-                            typename DerivedB::Scalar()),
-                   Formula>>>
+    typename DerivedA, typename DerivedB,
+    typename = std::enable_if_t<
+        std::is_same_v<typename Eigen::internal::traits<DerivedA>::XprKind,
+                       Eigen::ArrayXpr> &&
+        std::is_same_v<typename Eigen::internal::traits<DerivedB>::XprKind,
+                       Eigen::ArrayXpr> &&
+        std::is_same_v<decltype(typename DerivedA::Scalar() ==
+                                typename DerivedB::Scalar()),
+                       Formula>>>
 struct RelationalOpTraits {
-  using ReturnType =
-      Eigen::Array<Formula,
-                   EigenSizeMinPreferFixed<DerivedA::RowsAtCompileTime,
-                                           DerivedB::RowsAtCompileTime>::value,
-                   EigenSizeMinPreferFixed<DerivedA::ColsAtCompileTime,
-                                           DerivedB::ColsAtCompileTime>::value>;
+  static constexpr auto Dynamic = Eigen::Dynamic;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+  static constexpr int Rows = EIGEN_SIZE_MIN_PREFER_FIXED(
+      (DerivedA::RowsAtCompileTime), (DerivedB::RowsAtCompileTime));
+  static constexpr int Cols = EIGEN_SIZE_MIN_PREFER_FIXED(
+      (DerivedA::ColsAtCompileTime), (DerivedB::ColsAtCompileTime));
+#pragma GCC diagnostic pop
+  using ReturnType = Eigen::Array<Formula, Rows, Cols>;
 };
 /// Returns @p f1 ∧ @p f2.
 /// Note that this function returns a `Formula` while

--- a/math/cross_product.h
+++ b/math/cross_product.h
@@ -10,8 +10,8 @@ namespace math {
 template <typename Derived>
 drake::Matrix3<typename Derived::Scalar> VectorToSkewSymmetric(
     const Eigen::MatrixBase<Derived>& p) {
-  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<Derived>,
-                                           drake::kSpaceDimension);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<Derived>, 3);
+
   drake::Matrix3<typename Derived::Scalar> ret;
   ret << 0.0, -p(2), p(1), p(2), 0.0, -p(0), -p(1), p(0), 0.0;
   return ret;

--- a/math/rotation_conversion_gradient.h
+++ b/math/rotation_conversion_gradient.h
@@ -17,15 +17,14 @@ namespace math {
  */
 template <typename Derived>
 typename drake::math::Gradient<Eigen::Matrix<typename Derived::Scalar, 3, 3>,
-                               drake::kQuaternionSize>::type
+                               4>::type
 dquat2rotmat(const Eigen::MatrixBase<Derived>& quaternion) {
-  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<Derived>,
-                                           drake::kQuaternionSize);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<Derived>, 4);
 
   typename drake::math::Gradient<Eigen::Matrix<typename Derived::Scalar, 3, 3>,
-                                 drake::kQuaternionSize>::type ret;
+                                 4>::type ret;
   typename Eigen::MatrixBase<Derived>::PlainObject qtilde;
-  typename drake::math::Gradient<Derived, drake::kQuaternionSize>::type dqtilde;
+  typename drake::math::Gradient<Derived, 4>::type dqtilde;
   drake::math::NormalizeVector(quaternion, qtilde, &dqtilde);
 
   typedef typename Derived::Scalar Scalar;
@@ -53,24 +52,23 @@ dquat2rotmat(const Eigen::MatrixBase<Derived>& quaternion) {
  */
 template <typename DerivedR, typename DerivedDR>
 typename drake::math::Gradient<
-    Eigen::Matrix<typename DerivedR::Scalar, drake::kRpySize, 1>,
+    Eigen::Matrix<typename DerivedR::Scalar, 3, 1>,
     DerivedDR::ColsAtCompileTime>::type
 drotmat2rpy(const Eigen::MatrixBase<DerivedR>& R,
             const Eigen::MatrixBase<DerivedDR>& dR) {
-  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Eigen::MatrixBase<DerivedR>,
-                                           drake::kSpaceDimension,
-                                           drake::kSpaceDimension);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Eigen::MatrixBase<DerivedR>, 3, 3);
+
   EIGEN_STATIC_ASSERT(
-      Eigen::MatrixBase<DerivedDR>::RowsAtCompileTime == drake::kRotmatSize,
+      Eigen::MatrixBase<DerivedDR>::RowsAtCompileTime == 9,
       THIS_METHOD_IS_ONLY_FOR_MATRICES_OF_A_SPECIFIC_SIZE);
 
   typename DerivedDR::Index nq = dR.cols();
   typedef typename DerivedR::Scalar Scalar;
   typedef
-      typename drake::math::Gradient<Eigen::Matrix<Scalar, drake::kRpySize, 1>,
+      typename drake::math::Gradient<Eigen::Matrix<Scalar, 3, 1>,
                                      DerivedDR::ColsAtCompileTime>::type
           ReturnType;
-  ReturnType drpy(drake::kRpySize, nq);
+  ReturnType drpy(3, nq);
 
   auto dR11_dq =
       getSubMatrixGradient<DerivedDR::ColsAtCompileTime>(dR, 0, 0, R.rows());
@@ -115,20 +113,19 @@ drotmat2rpy(const Eigen::MatrixBase<DerivedR>& R,
  */
 template <typename DerivedR, typename DerivedDR>
 typename drake::math::Gradient<
-    Eigen::Matrix<typename DerivedR::Scalar, drake::kQuaternionSize, 1>,
+    Eigen::Matrix<typename DerivedR::Scalar, 4, 1>,
     DerivedDR::ColsAtCompileTime>::type
 drotmat2quat(const Eigen::MatrixBase<DerivedR>& R,
              const Eigen::MatrixBase<DerivedDR>& dR) {
-  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Eigen::MatrixBase<DerivedR>,
-                                           drake::kSpaceDimension,
-                                           drake::kSpaceDimension);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Eigen::MatrixBase<DerivedR>, 3, 3);
+
   EIGEN_STATIC_ASSERT(
-      Eigen::MatrixBase<DerivedDR>::RowsAtCompileTime == drake::kRotmatSize,
+      Eigen::MatrixBase<DerivedDR>::RowsAtCompileTime == 9,
       THIS_METHOD_IS_ONLY_FOR_MATRICES_OF_A_SPECIFIC_SIZE);
 
   typedef typename DerivedR::Scalar Scalar;
   typedef typename drake::math::Gradient<
-      Eigen::Matrix<Scalar, drake::kQuaternionSize, 1>,
+      Eigen::Matrix<Scalar, 4, 1>,
       DerivedDR::ColsAtCompileTime>::type ReturnType;
   typename DerivedDR::Index nq = dR.cols();
 
@@ -160,7 +157,7 @@ drotmat2quat(const Eigen::MatrixBase<DerivedR>& R,
   typename Eigen::Matrix<Scalar, 4, 1>::Index ind, max_col;
   Scalar val = B.maxCoeff(&ind, &max_col);
 
-  ReturnType dq(drake::kQuaternionSize, nq);
+  ReturnType dq(4, nq);
   using namespace std;  // NOLINT(build/namespaces)
   switch (ind) {
     case 0: {

--- a/multibody/fem/test/constitutive_model_test_utilities.cc
+++ b/multibody/fem/test/constitutive_model_test_utilities.cc
@@ -135,6 +135,7 @@ the handcrafted derivative matches that produced by automatic differentiation.
 CorotatedModel. */
 template <class Model>
 void TestdPdFIsDerivativeOfP() {
+  constexpr int kSpaceDimension = 3;
   const double kTolerance = 1e-12;
   constexpr int num_locations = Model::Data::num_locations;
   constexpr double kYoungsModulus = 100.0;

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -62,7 +62,8 @@ struct NewVariableNames<Eigen::Dynamic> {
 
 template <int Rows, int Cols>
 struct NewVariableNames<Rows, Cols>
-    : public NewVariableNames<MultiplyEigenSizes<Rows, Cols>::value> {};
+    : public NewVariableNames<
+          Eigen::Matrix<double, Rows, Cols>::SizeAtCompileTime> {};
 
 template <int Rows>
 struct NewSymmetricVariableNames
@@ -261,9 +262,8 @@ class MathematicalProgram {
       int rows, int cols, const std::string& name = "X") {
     rows = Rows == Eigen::Dynamic ? rows : Rows;
     cols = Cols == Eigen::Dynamic ? cols : Cols;
-    auto names =
-        internal::CreateNewVariableNames<MultiplyEigenSizes<Rows, Cols>::value>(
-            rows * cols);
+    auto names = internal::CreateNewVariableNames<
+        Eigen::Matrix<double, Rows, Cols>::SizeAtCompileTime>(rows * cols);
     internal::SetVariableNames(name, rows, cols, &names);
     return NewVariables<Rows, Cols>(VarType::CONTINUOUS, names, rows, cols);
   }
@@ -331,9 +331,8 @@ class MathematicalProgram {
       int rows, int cols, const std::string& name) {
     rows = Rows == Eigen::Dynamic ? rows : Rows;
     cols = Cols == Eigen::Dynamic ? cols : Cols;
-    auto names =
-        internal::CreateNewVariableNames<MultiplyEigenSizes<Rows, Cols>::value>(
-            rows * cols);
+    auto names = internal::CreateNewVariableNames<
+        Eigen::Matrix<double, Rows, Cols>::SizeAtCompileTime>(rows * cols);
     internal::SetVariableNames(name, rows, cols, &names);
     return NewVariables<Rows, Cols>(VarType::BINARY, names, rows, cols);
   }


### PR DESCRIPTION
Many of the deprecations are just for dead constants. 

The more interesting ones are using-statements for some Eigen types ...

In cases like `Eigen::Matrix...`, it's sensible to alias them as `drake::Matrix...` because (1) they are extremely heavily used, and (2) we are effectively _adopting_ them as our own type, with a promise to keep the type intact and inter-operable forevermore.

In contrast, for `std::vector` we have not aliased nor adoped it.  In headers we say `std::` and in some cc files we choose `using std::vector`.

My thesis here is that things like `Eigen::AngleAxis` are more like `std::vector` than `Eigen::Matrix` -- we should not adopt them, but rather treat them as third-party library types, with a fully-qualified (and therefore much more clear) typename in headers, and (if desired) to add `using` in some cc files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18857)
<!-- Reviewable:end -->
