### PR TITLE
Add a benchmark on trace(A*X) where X contains symbolic variables.

### DIFF
--- a/common/benchmarking/BUILD.bazel
+++ b/common/benchmarking/BUILD.bazel
@@ -13,6 +13,10 @@ drake_cc_googlebench_binary(
     name = "benchmark_polynomial",
     srcs = ["benchmark_polynomial.cc"],
     add_test_rule = True,
+    test_args = [
+        # When testing, skip over Args() that are >= 100.
+        "--benchmark_filter=-/.00+$$",
+    ],
     test_timeout = "moderate",
     deps = [
         "//common:add_text_logging_gflags",

--- a/common/benchmarking/benchmark_polynomial.cc
+++ b/common/benchmarking/benchmark_polynomial.cc
@@ -44,7 +44,37 @@ void BenchmarkPolynomialEvaluatePartial(benchmark::State& state) {  // NOLINT
   }
 }
 
+void BenchmarkMatrixInnerProduct(benchmark::State& state) {  // NOLINT
+  const int n = state.range(0);
+  Eigen::MatrixXd Q(n, n);
+  for (int i = 0; i < n; ++i) {
+    Q(i, i) = std::sin(i);
+    for (int j = i + 1; j < n; ++j) {
+      Q(i, j) = std::cos(i + 2 * j);
+      Q(j, i) = Q(i, j);
+    }
+  }
+  MatrixX<symbolic::Variable> X(n, n);
+  for (int i = 0; i < n; ++i) {
+    X(i, i) = symbolic::Variable(fmt::format("X({}, {})", i, i));
+    for (int j = i + 1; j < n; ++j) {
+      X(i, j) = symbolic::Variable(fmt::format("X({}, {})", i, j));
+      X(j, i) = X(i, j);
+    }
+  }
+
+  for (auto _ : state) {
+    symbolic::Polynomial((Q * X).trace());
+  }
+}
+
 BENCHMARK(BenchmarkPolynomialEvaluatePartial)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BenchmarkMatrixInnerProduct)
+    ->Arg(10)
+    ->Arg(50)
+    ->Arg(100)
+    ->Arg(200)
+    ->Unit(benchmark::kSecond);
 }  // namespace
 }  // namespace symbolic
 }  // namespace drake


### PR DESCRIPTION
This is extremely slow for A and X being of size 200 * 200, takes 77 seconds on my Puget.

As reported from the slack discussion https://drakedevelopers.slack.com/archives/C3L92BM2Q/p1677172164932209

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18861)
<!-- Reviewable:end -->
