### PR TITLE
Fixes skydio model prop colors and normals

### DIFF
--- a/examples/quadrotor/README.md
+++ b/examples/quadrotor/README.md
@@ -8,18 +8,3 @@ You can try out sample programs; each has its own overview atop the file:
 
  - `run_quadrotor_dynamics`
  - `run_quadrotor_lqr`
-
-Historical note: IRIS mixed-integer convex planning
----------------------------------------------------
-
-Prior to 2016, Drake was built around a substantial base of MATLAB software.
-Most of that was removed from the head of git master during 2017.
-
-To view or use the original MATLAB implementation of the Quadrotor you may use
-this tag:
-
-https://github.com/RobotLocomotion/drake/tree/last_sha_with_original_matlab/drake/examples/Quadrotor
-
-In particular, the IRIS mixed-integer convex planning examples have not yet
-been re-implemented in the new framework (Drake issue #6243).  To view that
-algorithm and example, you'll need to consult the above link.

--- a/examples/quadrotor/run_quadrotor_lqr.cc
+++ b/examples/quadrotor/run_quadrotor_lqr.cc
@@ -2,6 +2,9 @@
 ///
 /// This demo sets up a controlled Quadrotor that uses a Linear Quadratic
 /// Regulator to (locally) stabilize a nominal hover.
+///
+/// Use meldis to view the visualization:
+///   bazel run //tools:meldis -- -w
 
 #include <memory>
 

--- a/tools/workspace/models_internal/files.bzl
+++ b/tools/workspace/models_internal/files.bzl
@@ -59,7 +59,6 @@ def skydio_2_mesh_files():
     return [
         "skydio_2/skydio_2_1000_poly.mtl",
         "skydio_2/skydio_2_1000_poly.obj",
-        "skydio_2/skydio_2.png",
         "skydio_2/LICENSE",
     ]
 

--- a/tools/workspace/models_internal/repository.bzl
+++ b/tools/workspace/models_internal/repository.bzl
@@ -8,8 +8,8 @@ def models_internal_repository(
     github_archive(
         name = name,
         repository = "RobotLocomotion/models",
-        commit = "bcd2cf1b27979bc725608d133ddbf3adfd497365",
-        sha256 = "df55e5bd99d3e8e46fe169efe18872b66d2611ac9815c4e33039ffb1ece202b3",  # noqa
+        commit = "6751ba850fd46fee789a095edba7ad9fc99cd188",
+        sha256 = "dc38658f7acb4d07442e6dae4d18818d31ac6cc6d66bf16913ef1b208692627c",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
Pull in the fixes from
https://github.com/RobotLocomotion/models/pull/21

To test, run `meldis` and `//examples/quadrotor/run_quadrotor_lqr`.  Before this change, you will see that the propellers are black from above and invisible from below.  Now they should be grey from both sides.

Also removes stale comment in quadrotor/README.md.  Issue #6243 is closed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18867)
<!-- Reviewable:end -->
