### PR TITLE
[symbolic] Speed up Add and Mul cell ctors

### DIFF
--- a/common/symbolic/expression/expression.cc
+++ b/common/symbolic/expression/expression.cc
@@ -276,7 +276,7 @@ void Expression::AddImpl(const Expression& rhs) {
     }
   }
   // Extract an expression from factory
-  lhs = add_factory.GetExpression();
+  lhs = std::move(add_factory).GetExpression();
 }
 
 Expression& Expression::operator++() {
@@ -484,7 +484,7 @@ void Expression::MulImpl(const Expression& rhs) {
       mul_factory.AddExpression(rhs);
     }
   }
-  lhs = mul_factory.GetExpression();
+  lhs = std::move(mul_factory).GetExpression();
 }
 
 void Expression::DivImpl(const Expression& rhs) {
@@ -941,7 +941,7 @@ Expression Exp(const vector<Expression>& terms, const MultiIndex& alpha) {
   for (size_t i = 0; i < terms.size(); ++i) {
     factory.AddExpression(pow(terms[i], alpha[i]));
   }
-  return factory.GetExpression();
+  return std::move(factory).GetExpression();
 }
 
 // Computes ∑_{|α| = order} ∂fᵅ(a) / α! * (x - a)ᵅ.
@@ -978,7 +978,7 @@ Expression TaylorExpand(const Expression& f, const Environment& a,
   for (int i = 1; i <= order; ++i) {
     DoTaylorExpand(f, a, terms, i, num_vars, &factory);
   }
-  return factory.GetExpression();
+  return std::move(factory).GetExpression();
 }
 
 namespace {

--- a/common/symbolic/expression/expression_cell.h
+++ b/common/symbolic/expression/expression_cell.h
@@ -232,7 +232,7 @@ class ExpressionAdd : public ExpressionCell {
   /** Constructs ExpressionAdd from @p constant_term and @p term_to_coeff_map.
    */
   ExpressionAdd(double constant,
-                const std::map<Expression, double>& expr_to_coeff_map);
+                std::map<Expression, double> expr_to_coeff_map);
   void HashAppendDetail(DelegatingHasher*) const override;
   [[nodiscard]] Variables GetVariables() const override;
   [[nodiscard]] bool EqualTo(const ExpressionCell& e) const override;
@@ -288,9 +288,10 @@ class ExpressionAddFactory {
    * this method flips it into -c0 - c1 * t1 - ... - cn * tn.
    * @returns *this.
    */
-  ExpressionAddFactory& Negate();
+  ExpressionAddFactory&& Negate() &&;
+
   /** Returns a symbolic expression. */
-  [[nodiscard]] Expression GetExpression() const;
+  [[nodiscard]] Expression GetExpression() &&;
 
  private:
   /* Adds a constant @p constant to this factory.
@@ -336,7 +337,7 @@ class ExpressionMul : public ExpressionCell {
  public:
   /** Constructs ExpressionMul from @p constant and @p base_to_exponent_map. */
   ExpressionMul(double constant,
-                const std::map<Expression, Expression>& base_to_exponent_map);
+                std::map<Expression, Expression> base_to_exponent_map);
   void HashAppendDetail(DelegatingHasher*) const override;
   [[nodiscard]] Variables GetVariables() const override;
   [[nodiscard]] bool EqualTo(const ExpressionCell& e) const override;
@@ -393,14 +394,16 @@ class ExpressionMulFactory {
   void Add(const ExpressionMul& ptr);
   /** Assigns a factory from an ExpressionMul.  */
   ExpressionMulFactory& operator=(const ExpressionMul& ptr);
+
   /** Negates the expressions in factory.
    * If it represents c0 * p1 * ... * pn,
    * this method flips it into -c0 * p1 * ... * pn.
    * @returns *this.
    */
-  ExpressionMulFactory& Negate();
+  ExpressionMulFactory&& Negate() &&;
+
   /** Returns a symbolic expression. */
-  [[nodiscard]] Expression GetExpression() const;
+  [[nodiscard]] Expression GetExpression() &&;
 
  private:
   /* Adds constant to this factory.

--- a/common/symbolic/expression/variable.cc
+++ b/common/symbolic/expression/variable.cc
@@ -38,8 +38,6 @@ Variable::Variable(string name, const Type type)
       name_{make_shared<const string>(move(name))} {
   DRAKE_ASSERT(id_ > 0);
 }
-Variable::Id Variable::get_id() const { return id_; }
-Variable::Type Variable::get_type() const { return type_; }
 string Variable::get_name() const { return *name_; }
 string Variable::to_string() const {
   ostringstream oss;

--- a/common/symbolic/expression/variable.h
+++ b/common/symbolic/expression/variable.h
@@ -74,8 +74,8 @@ class Variable {
   /** Checks if this is a dummy variable (ID = 0) which is created by
    *  the default constructor. */
   [[nodiscard]] bool is_dummy() const { return get_id() == 0; }
-  [[nodiscard]] Id get_id() const;
-  [[nodiscard]] Type get_type() const;
+  [[nodiscard]] Id get_id() const { return id_; }
+  [[nodiscard]] Type get_type() const { return type_; }
   [[nodiscard]] std::string get_name() const;
   [[nodiscard]] std::string to_string() const;
 


### PR DESCRIPTION
Note that `expression_cell.h` is internal use only, so this API change will not disturb any users.

This is roughly a 50% reduction in BenchmarkMatrixInnerProduct/200, and a 10% reduction in all three BenchmarkSosProgram.

Also move two tiny Variable getters to the header file. It's a little difficult to show this in a profile, but I think we'd all agree that this change is blindingly obvious and should have been like this from the beginning.

+@hongkai-dai for feature review, please.

Relates to #18861.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18869)
<!-- Reviewable:end -->
