### PR TITLE
Add a benchmark on Q * X while Q is sparse.

### DIFF
--- a/common/benchmarking/BUILD.bazel
+++ b/common/benchmarking/BUILD.bazel
@@ -15,7 +15,7 @@ drake_cc_googlebench_binary(
     add_test_rule = True,
     test_args = [
         # When testing, skip over Args() that are >= 100.
-        "--benchmark_filter=-/.00+$$",
+        "--benchmark_filter=-/.00+/.$$",
     ],
     test_timeout = "moderate",
     deps = [

--- a/common/benchmarking/benchmark_polynomial.cc
+++ b/common/benchmarking/benchmark_polynomial.cc
@@ -46,12 +46,20 @@ void BenchmarkPolynomialEvaluatePartial(benchmark::State& state) {  // NOLINT
 
 void BenchmarkMatrixInnerProduct(benchmark::State& state) {  // NOLINT
   const int n = state.range(0);
+  const bool sparse_Q = state.range(1);
   Eigen::MatrixXd Q(n, n);
-  for (int i = 0; i < n; ++i) {
-    Q(i, i) = std::sin(i);
-    for (int j = i + 1; j < n; ++j) {
-      Q(i, j) = std::cos(i + 2 * j);
-      Q(j, i) = Q(i, j);
+  if (sparse_Q) {
+    Q.setZero();
+    for (int i = 0; i < n; ++i) {
+      Q(i, i) = std::sin(i);
+    }
+  } else {
+    for (int i = 0; i < n; ++i) {
+      Q(i, i) = std::sin(i);
+      for (int j = i + 1; j < n; ++j) {
+        Q(i, j) = std::cos(i + 2 * j);
+        Q(j, i) = Q(i, j);
+      }
     }
   }
   MatrixX<symbolic::Variable> X(n, n);
@@ -70,10 +78,7 @@ void BenchmarkMatrixInnerProduct(benchmark::State& state) {  // NOLINT
 
 BENCHMARK(BenchmarkPolynomialEvaluatePartial)->Unit(benchmark::kMicrosecond);
 BENCHMARK(BenchmarkMatrixInnerProduct)
-    ->Arg(10)
-    ->Arg(50)
-    ->Arg(100)
-    ->Arg(200)
+    ->ArgsProduct({{10, 50, 100, 200}, {false, true}})
     ->Unit(benchmark::kSecond);
 }  // namespace
 }  // namespace symbolic


### PR DESCRIPTION
Here is the result on my machine
```
Benchmark                                   Time             CPU   Iterations
-----------------------------------------------------------------------------
BenchmarkPolynomialEvaluatePartial       2394 us         2389 us          304
BenchmarkMatrixInnerProduct/10/0        0.001 s         0.001 s          1024
BenchmarkMatrixInnerProduct/50/0        0.239 s         0.238 s             3
BenchmarkMatrixInnerProduct/100/0        3.54 s          3.54 s             1
BenchmarkMatrixInnerProduct/200/0        55.7 s          55.6 s             1
BenchmarkMatrixInnerProduct/10/1        0.000 s         0.000 s          8238
BenchmarkMatrixInnerProduct/50/1        0.006 s         0.006 s           122
BenchmarkMatrixInnerProduct/100/1       0.041 s         0.041 s            17
BenchmarkMatrixInnerProduct/200/1       0.320 s         0.320 s             2
```
With the current code, the sparse version of Q runs much faster than the dense version of Q.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18870)
<!-- Reviewable:end -->
