### PR TITLE
added optional rounding solver options

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -393,10 +393,12 @@ void DefineGeometryOptimization(py::module m) {
                   return &(self.rounding_solver_options);
                 },
                 py_rvp::reference_internal),
-            py::cpp_function([](GraphOfConvexSetsOptions& self,
-                                 solvers::SolverOptions rounding_solver_options) {
-              self.rounding_solver_options = std::move(rounding_solver_options);
-            }),
+            py::cpp_function(
+                [](GraphOfConvexSetsOptions& self,
+                    solvers::SolverOptions rounding_solver_options) {
+                  self.rounding_solver_options =
+                      std::move(rounding_solver_options);
+                }),
             cls_doc.rounding_solver_options.doc)
         .def("__repr__", [](const GraphOfConvexSetsOptions& self) {
           return py::str(

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -387,6 +387,17 @@ void DefineGeometryOptimization(py::module m) {
               self.solver_options = std::move(solver_options);
             }),
             cls_doc.solver_options.doc)
+        .def_property("rounding_solver_options",
+            py::cpp_function(
+                [](GraphOfConvexSetsOptions& self) {
+                  return &(self.rounding_solver_options);
+                },
+                py_rvp::reference_internal),
+            py::cpp_function([](GraphOfConvexSetsOptions& self,
+                                 solvers::SolverOptions rounding_solver_options) {
+              self.rounding_solver_options = std::move(rounding_solver_options);
+            }),
+            cls_doc.rounding_solver_options.doc)
         .def("__repr__", [](const GraphOfConvexSetsOptions& self) {
           return py::str(
               "GraphOfConvexSetsOptions("
@@ -398,11 +409,12 @@ void DefineGeometryOptimization(py::module m) {
               "rounding_seed={}, "
               "solver={}, "
               "solver_options={}, "
+              "rounding_solver_options={}, "
               ")")
               .format(self.convex_relaxation, self.preprocessing,
                   self.max_rounded_paths, self.max_rounding_trials,
                   self.flow_tolerance, self.rounding_seed, self.solver,
-                  self.solver_options);
+                  self.solver_options, self.rounding_solver_options);
         });
 
     DefReadWriteKeepAlive(&gcs_options, "solver",

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -446,8 +446,12 @@ class TestGeometryOptimization(unittest.TestCase):
         options.solver = ClpSolver()
         options.solver_options = SolverOptions()
         options.solver_options.SetOption(ClpSolver.id(), "scaling", 2)
+        options.rounding_solver_options = SolverOptions()
+        options.rounding_solver_options.SetOption(ClpSolver.id(), "dual", 0)
         self.assertIn("scaling",
                       options.solver_options.GetOptions(ClpSolver.id()))
+        self.assertIn(
+            "dual", options.rounding_solver_options.GetOptions(ClpSolver.id()))
         self.assertIn("convex_relaxation", repr(options))
 
         spp = mut.GraphOfConvexSets()

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -625,19 +625,13 @@ MathematicalProgramResult Solve(const MathematicalProgram& prog,
                                 const GraphOfConvexSetsOptions& options,
                                 bool rounding) {
   MathematicalProgramResult result;
+  auto solver_options = (rounding && options.rounding_solver_options)
+                            ? options.rounding_solver_options
+                            : options.solver_options;
   if (options.solver) {
-    options.solver->Solve(
-        prog, {},
-        (rounding && options.rounding_solver_options != std::nullopt)
-            ? options.rounding_solver_options
-            : options.solver_options,
-        &result);
+    options.solver->Solve(prog, {}, solver_options, &result);
   } else {
-    result = solvers::Solve(
-        prog, {},
-        (rounding && options.rounding_solver_options != std::nullopt)
-            ? options.rounding_solver_options
-            : options.solver_options);
+    result = solvers::Solve(prog, {}, solver_options);
   }
   return result;
 }
@@ -1069,7 +1063,7 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
     // prevent the projection back into the Xᵤ, then we prefer to return NaN.
     if (sum_phi < 100.0 * std::numeric_limits<double>::epsilon()) {
       x_v = VectorXd::Constant(v->ambient_dimension(),
-                                std::numeric_limits<double>::quiet_NaN());
+                               std::numeric_limits<double>::quiet_NaN());
     } else if (options.convex_relaxation) {
       x_v /= sum_phi;
     }

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -68,8 +68,9 @@ struct GraphOfConvexSetsOptions {
 
   /** Optional solver options for the rounded problems.
   If not set, solver_options is used.
-  For instance, one might want to set lower tolerances for running
-  the relaxed problem and higher tolerances for final solves during rounding. */
+  For instance, one might want to set tighter (i.e., lower) tolerances for
+  running the relaxed problem and looser (i.e., higher) tolerances for final
+  solves during rounding. */
   std::optional<solvers::SolverOptions> rounding_solver_options{std::nullopt};
 };
 

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -65,6 +65,12 @@ struct GraphOfConvexSetsOptions {
 
   /** Options passed to the solver when solving the generated problem.*/
   solvers::SolverOptions solver_options;
+
+  /** Optional solver options for the rounded problems.
+  If not set, solver_options is used.
+  For instance, one might want to set lower tolerances for running
+  the relaxed problem and higher tolerances for final solves during rounding. */
+  std::optional<solvers::SolverOptions> rounding_solver_options{std::nullopt};
 };
 
 /**

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -1320,6 +1320,7 @@ GTEST_TEST(ShortestPathTest, RoundedSolution) {
 
   options.preprocessing = true;
   options.max_rounded_paths = 10;
+  options.rounding_solver_options = SolverOptions();
   auto rounded_result =
       spp.SolveShortestPath(source->id(), target->id(), options);
   ASSERT_TRUE(rounded_result.is_success());

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -1320,7 +1320,6 @@ GTEST_TEST(ShortestPathTest, RoundedSolution) {
 
   options.preprocessing = true;
   options.max_rounded_paths = 10;
-  options.rounding_solver_options = SolverOptions();
   auto rounded_result =
       spp.SolveShortestPath(source->id(), target->id(), options);
   ASSERT_TRUE(rounded_result.is_success());
@@ -1335,9 +1334,9 @@ GTEST_TEST(ShortestPathTest, RoundedSolution) {
       const double tol =
           (relaxed_result.get_solver_id() == solvers::GurobiSolver::id())
               ? 1e-1
-              : (relaxed_result.get_solver_id() == solvers::CsdpSolver::id())
-                    ? 1e-2
-                    : 1e-5;
+          : (relaxed_result.get_solver_id() == solvers::CsdpSolver::id())
+              ? 1e-2
+              : 1e-5;
       EXPECT_NEAR(relaxed_result.GetSolution(edges[ii]->phi()), 0.5, tol);
     } else if (ii < 10) {
       EXPECT_LT(relaxed_result.GetSolution(edges[ii]->phi()), 0.5);
@@ -1359,6 +1358,33 @@ GTEST_TEST(ShortestPathTest, RoundedSolution) {
   auto mip_result = spp.SolveShortestPath(source->id(), target->id(), options);
   EXPECT_NEAR(rounded_result.get_optimal_cost(), mip_result.get_optimal_cost(),
               2e-6);
+
+  if (solvers::MosekSolver::is_available() &&
+      solvers::MosekSolver::is_enabled()) {
+    // Test rounding_solver_options by setting the maximum iterations to 0,
+    // which is equivalent to not solving the rounding problem. Thus it should
+    // fail.
+    solvers::MosekSolver mosek_solver;
+    options.solver = &mosek_solver;
+    options.convex_relaxation = true;
+    options.preprocessing = false;
+    options.max_rounded_paths = 10;
+
+    options.rounding_solver_options = SolverOptions();
+    options.rounding_solver_options->SetOption(
+        solvers::MosekSolver::id(), "MSK_IPAR_INTPNT_MAX_ITERATIONS", 0);
+
+    auto failed_result =
+        spp.SolveShortestPath(source->id(), target->id(), options);
+    EXPECT_FALSE(failed_result.is_success());
+
+    // Without the convex relaxation, the solver should ignore the
+    // rounding_solver_options and succeed.
+    options.convex_relaxation = false;
+    auto successful_result =
+        spp.SolveShortestPath(source->id(), target->id(), options);
+    EXPECT_TRUE(successful_result.is_success());
+  }
 }
 
 // In some cases, the depth first search performed in rounding will lead to a


### PR DESCRIPTION
In practice, it is sufficient to solve the relaxed `GraphOfConvexSets` problem with lower tolerances and with higher tolerances for the simpler rounded problems where the flows are set. This dramatically reduces the overall solve time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18875)
<!-- Reviewable:end -->
