### PR TITLE
[py plant] Deprecate CalcJacobianSpatialVelocity(*, p_BP)

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -494,22 +494,35 @@ void DoScalarDependentDefinitions(py::module m, T) {
               return self->EvalBodySpatialVelocityInWorld(context, body_B);
             },
             py::arg("context"), py::arg("body"),
-            cls_doc.EvalBodySpatialVelocityInWorld.doc)
-        .def(
-            "CalcJacobianSpatialVelocity",
-            [](const Class* self, const systems::Context<T>& context,
-                JacobianWrtVariable with_respect_to, const Frame<T>& frame_B,
-                const Eigen::Ref<const Vector3<T>>& p_BP,
-                const Frame<T>& frame_A, const Frame<T>& frame_E) {
-              MatrixX<T> Js_V_ABp_E(
-                  6, GetVariableSize<T>(*self, with_respect_to));
-              self->CalcJacobianSpatialVelocity(context, with_respect_to,
-                  frame_B, p_BP, frame_A, frame_E, &Js_V_ABp_E);
-              return Js_V_ABp_E;
-            },
+            cls_doc.EvalBodySpatialVelocityInWorld.doc);
+
+    auto CalcJacobianSpatialVelocity =
+        [](const Class* self, const systems::Context<T>& context,
+            JacobianWrtVariable with_respect_to, const Frame<T>& frame_B,
+            const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
+            const Frame<T>& frame_A, const Frame<T>& frame_E) {
+          MatrixX<T> Js_V_ABp_E(6, GetVariableSize<T>(*self, with_respect_to));
+          self->CalcJacobianSpatialVelocity(context, with_respect_to, frame_B,
+              p_BoBp_B, frame_A, frame_E, &Js_V_ABp_E);
+          return Js_V_ABp_E;
+        };
+    cls  // BR
+        .def("CalcJacobianSpatialVelocity", CalcJacobianSpatialVelocity,
+            py::arg("context"), py::arg("with_respect_to"), py::arg("frame_B"),
+            py::arg("p_BoBp_B"), py::arg("frame_A"), py::arg("frame_E"),
+            cls_doc.CalcJacobianSpatialVelocity.doc);
+    constexpr char doc_CalcJacobianSpatialVelocity_deprecated[] =
+        "CalcJacobianSpatialVelocity(*, p_BP) is deprecated, and will "
+        "be removed on or around 2023-06-01. Please use the variant with "
+        "the argument named `p_BoBp_B` instead.";
+    cls  // BR
+        .def("CalcJacobianSpatialVelocity",
+            WrapDeprecated(doc_CalcJacobianSpatialVelocity_deprecated,
+                CalcJacobianSpatialVelocity),
             py::arg("context"), py::arg("with_respect_to"), py::arg("frame_B"),
             py::arg("p_BP"), py::arg("frame_A"), py::arg("frame_E"),
-            cls_doc.CalcJacobianSpatialVelocity.doc)
+            doc_CalcJacobianSpatialVelocity_deprecated);
+    cls  // BR
         .def(
             "CalcJacobianAngularVelocity",
             [](const Class* self, const Context<T>& context,

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -983,9 +983,17 @@ class TestPlant(unittest.TestCase):
 
             Js_V_ABp_E = plant.CalcJacobianSpatialVelocity(
                 context=context, with_respect_to=wrt, frame_B=base_frame,
-                p_BP=np.zeros(3), frame_A=world_frame,
+                p_BoBp_B=np.zeros(3), frame_A=world_frame,
                 frame_E=world_frame)
             self.assert_sane(Js_V_ABp_E)
+
+            with catch_drake_warnings(expected_count=1) as w:
+                Js_V_ABp_E = plant.CalcJacobianSpatialVelocity(
+                    context=context, with_respect_to=wrt, frame_B=base_frame,
+                    p_BP=np.zeros(3), frame_A=world_frame,
+                    frame_E=world_frame)
+                self.assert_sane(Js_V_ABp_E)
+
             self.assertEqual(Js_V_ABp_E.shape, (6, nw))
             Js_w_AB_E = plant.CalcJacobianAngularVelocity(
                 context=context, with_respect_to=wrt, frame_B=base_frame,


### PR DESCRIPTION
See C++ code:
https://github.com/RobotLocomotion/drake/blob/520e11aef6fb102eb2752192b4bc76d287db23fe/multibody/plant/multibody_plant.h#L3494-L3500

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18876)
<!-- Reviewable:end -->
