### PR TITLE
[geometry] Make namespace of all three RenderEngine consistent

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_render.cc
+++ b/bindings/pydrake/geometry/geometry_py_render.cc
@@ -336,7 +336,7 @@ void DoScalarIndependentDefinitions(py::module m) {
   }
 
   {
-    using Class = geometry::RenderEngineVtkParams;
+    using Class = RenderEngineVtkParams;
     constexpr auto& cls_doc = doc_geometry.RenderEngineVtkParams;
     py::class_<Class> cls(m, "RenderEngineVtkParams", cls_doc.doc);
     cls  // BR
@@ -346,12 +346,14 @@ void DoScalarIndependentDefinitions(py::module m) {
     DefCopyAndDeepCopy(&cls);
   }
 
-  m.def("MakeRenderEngineVtk", &geometry::MakeRenderEngineVtk,
-      py::arg("params"), doc_geometry.MakeRenderEngineVtk.doc);
+  m.def("MakeRenderEngineVtk", &MakeRenderEngineVtk, py::arg("params"),
+      doc_geometry.MakeRenderEngineVtk.doc);
 
   {
-    using Class = RenderEngineGlParams;
-    constexpr auto& cls_doc = doc.RenderEngineGlParams;
+    // TODO(zachfang): During the 2023-07-01 deprecation removals also
+    // remove the spurious `geometry::` qualifier on this typename.
+    using Class = geometry::RenderEngineGlParams;
+    constexpr auto& cls_doc = doc_geometry.RenderEngineGlParams;
     py::class_<Class> cls(m, "RenderEngineGlParams", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
@@ -360,11 +362,14 @@ void DoScalarIndependentDefinitions(py::module m) {
     DefCopyAndDeepCopy(&cls);
   }
 
-  m.def("MakeRenderEngineGl", &MakeRenderEngineGl,
-      py::arg("params") = RenderEngineGlParams(), doc.MakeRenderEngineGl.doc);
+  // TODO(zachfang): During the 2023-07-01 deprecation removals also
+  // remove the spurious `geometry::` qualifier on this typename.
+  m.def("MakeRenderEngineGl", &geometry::MakeRenderEngineGl,
+      py::arg("params") = geometry::RenderEngineGlParams(),
+      doc_geometry.MakeRenderEngineGl.doc);
 
   {
-    using Class = geometry::RenderEngineGltfClientParams;
+    using Class = RenderEngineGltfClientParams;
     constexpr auto& cls_doc = doc_geometry.RenderEngineGltfClientParams;
     py::class_<Class> cls(m, "RenderEngineGltfClientParams", cls_doc.doc);
     cls  // BR
@@ -374,7 +379,7 @@ void DoScalarIndependentDefinitions(py::module m) {
     DefCopyAndDeepCopy(&cls);
   }
 
-  m.def("MakeRenderEngineGltfClient", &geometry::MakeRenderEngineGltfClient,
+  m.def("MakeRenderEngineGltfClient", &MakeRenderEngineGltfClient,
       py::arg("params") = RenderEngineGltfClientParams(),
       doc_geometry.MakeRenderEngineGltfClient.doc);
 
@@ -383,7 +388,9 @@ void DoScalarIndependentDefinitions(py::module m) {
 }  // namespace
 
 void DefineGeometryRender(py::module m) {
-  m.doc() = "Local bindings for `drake::geometry::render`";
+  m.doc() =
+      "Local bindings for render artifacts found in `drake::geometry` and "
+      "`drake::geometry::render`";
   DoScalarIndependentDefinitions(m);
 }
 

--- a/geometry/benchmarking/render_benchmark.cc
+++ b/geometry/benchmarking/render_benchmark.cc
@@ -39,7 +39,6 @@ using render::DepthRange;
 using render::DepthRenderCamera;
 using render::RenderCameraCore;
 using render::RenderEngine;
-using render::RenderEngineGlParams;
 using render::RenderEngineTester;
 using render::RenderLabel;
 using systems::sensors::ImageDepth32F;

--- a/geometry/render_gl/BUILD.bazel
+++ b/geometry/render_gl/BUILD.bazel
@@ -243,6 +243,20 @@ drake_cc_googletest(
     ],
 )
 
+# TODO(zachfang): Remove this along with deprecation on 2023-07-01.
+drake_cc_googletest(
+    name = "deprecation_test",
+    copts = [
+        "-Wno-cpp",
+        "-Wno-deprecated-declarations",
+    ],
+    deps = [
+        ":factory",
+        ":render_engine_gl_params",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
 drake_cc_googletest_ubuntu_only(
     name = "internal_shape_meshes_test",
     data = [

--- a/geometry/render_gl/factory.cc
+++ b/geometry/render_gl/factory.cc
@@ -6,16 +6,21 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
 
 // Definition of extern bool in factory.h. When we build against *this* .cc file
 // RenderEngineGl is always available.
 const bool kHasRenderEngineGl = true;
 
-std::unique_ptr<RenderEngine> MakeRenderEngineGl(RenderEngineGlParams params) {
-  return std::make_unique<internal::RenderEngineGl>(std::move(params));
+std::unique_ptr<render::RenderEngine> MakeRenderEngineGl(
+    RenderEngineGlParams params) {
+  return std::make_unique<render_gl::internal::RenderEngineGl>(
+      std::move(params));
 }
 
+namespace render {
+  DRAKE_DEPRECATED("2023-07-01", "Use the geometry namespace instead.")
+  const bool kHasRenderEngineGl = true;
 }  // namespace render
+
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/factory.h
+++ b/geometry/render_gl/factory.h
@@ -2,12 +2,12 @@
 
 #include <memory>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/geometry/render/render_engine.h"
 #include "drake/geometry/render_gl/render_engine_gl_params.h"
 
 namespace drake {
 namespace geometry {
-namespace render {
 
 /** Reports the availability of the RenderEngineGl implementation. */
 extern const bool kHasRenderEngineGl;
@@ -30,9 +30,18 @@ extern const bool kHasRenderEngineGl;
  SceneGraph, rendering in multiple threads may exhibit issues.
 
  @throws std::exception if kHasRenderEngineGl is false. */
-std::unique_ptr<RenderEngine> MakeRenderEngineGl(
+std::unique_ptr<render::RenderEngine> MakeRenderEngineGl(
     RenderEngineGlParams params = {});
 
+namespace render {
+
+DRAKE_DEPRECATED("2023-07-01", "Use the geometry namespace instead.")
+extern const bool kHasRenderEngineGl;
+
+DRAKE_DEPRECATED("2023-07-01", "Use the geometry namespace instead.")
+constexpr auto MakeRenderEngineGl = &geometry::MakeRenderEngineGl;
+
 }  // namespace render
+
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/internal_buffer_dim.h
+++ b/geometry/render_gl/internal_buffer_dim.h
@@ -6,7 +6,7 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_gl {
 namespace internal {
 
 /* Simple class for recording the dimensions of a render target. Serves as a
@@ -57,7 +57,7 @@ struct RenderTarget {
 };
 
 }  // namespace internal
-}  // namespace render
+}  // namespace render_gl
 }  // namespace geometry
 }  // namespace drake
 
@@ -65,6 +65,6 @@ namespace std {
 
 /* Provides std::hash<BufferDim>.  */
 template <>
-struct hash<drake::geometry::render::internal::BufferDim>
+struct hash<drake::geometry::render_gl::internal::BufferDim>
     : public drake::DefaultHash {};
 }  // namespace std

--- a/geometry/render_gl/internal_opengl_context.cc
+++ b/geometry/render_gl/internal_opengl_context.cc
@@ -19,7 +19,7 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_gl {
 namespace internal {
 
 namespace {
@@ -326,6 +326,6 @@ GLint OpenGlContext::max_allowable_texture_size() {
 }
 
 }  // namespace internal
-}  // namespace render
+}  // namespace render_gl
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/internal_opengl_context.h
+++ b/geometry/render_gl/internal_opengl_context.h
@@ -6,7 +6,7 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_gl {
 namespace internal {
 
 /* Handle OpenGL context initialization, clean-up, and generic OpenGL queries.
@@ -66,6 +66,6 @@ class OpenGlContext {
 };
 
 }  // namespace internal
-}  // namespace render
+}  // namespace render_gl
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/internal_opengl_geometry.h
+++ b/geometry/render_gl/internal_opengl_geometry.h
@@ -11,7 +11,7 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_gl {
 namespace internal {
 
 // TODO(SeanCurtis-TRI): Consider moving this up to RenderEngine; it's useful
@@ -126,6 +126,6 @@ struct OpenGlInstance {
 };
 
 }  // namespace internal
-}  // namespace render
+}  // namespace render_gl
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/internal_render_engine_gl.cc
+++ b/geometry/render_gl/internal_render_engine_gl.cc
@@ -12,7 +12,7 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_gl {
 namespace internal {
 
 using Eigen::Vector2d;
@@ -25,6 +25,11 @@ using std::string;
 using std::unique_ptr;
 using std::unordered_map;
 using std::vector;
+using render::ColorRenderCamera;
+using render::DepthRenderCamera;
+using render::RenderCameraCore;
+using render::RenderEngine;
+using render::RenderLabel;
 using systems::sensors::ColorD;
 using systems::sensors::ColorI;
 using systems::sensors::ImageDepth32F;
@@ -1132,6 +1137,6 @@ ShaderProgramData RenderEngineGl::GetShaderProgram(
 }
 
 }  // namespace internal
-}  // namespace render
+}  // namespace render_gl
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/internal_render_engine_gl.h
+++ b/geometry/render_gl/internal_render_engine_gl.h
@@ -23,11 +23,11 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_gl {
 namespace internal {
 
 /** See documentation of MakeRenderEngineGl().  */
-class RenderEngineGl final : public RenderEngine {
+class RenderEngineGl final : public render::RenderEngine {
  public:
   /** @name Does not allow public copy, move, or assignment  */
   //@{
@@ -53,7 +53,7 @@ class RenderEngineGl final : public RenderEngine {
 
   /** @name    Shape reification  */
   //@{
-  using RenderEngine::ImplementGeometry;
+  using render::RenderEngine::ImplementGeometry;
   void ImplementGeometry(const Box& box, void* user_data) final;
   void ImplementGeometry(const Capsule& capsule, void* user_data) final;
   void ImplementGeometry(const Convex& convex, void* user_data) final;
@@ -92,17 +92,17 @@ class RenderEngineGl final : public RenderEngine {
 
   // @see RenderEngine::DoRenderColorImage().
   void DoRenderColorImage(
-      const ColorRenderCamera& camera,
+      const render::ColorRenderCamera& camera,
       systems::sensors::ImageRgba8U* color_image_out) const final;
 
   // @see RenderEngine::DoRenderDepthImage().
   void DoRenderDepthImage(
-      const DepthRenderCamera& render_camera,
+      const render::DepthRenderCamera& render_camera,
       systems::sensors::ImageDepth32F* depth_image_out) const final;
 
   // @see RenderEngine::DoRenderLabelImage().
   void DoRenderLabelImage(
-      const ColorRenderCamera& camera,
+      const render::ColorRenderCamera& camera,
       systems::sensors::ImageLabel16I* label_image_out) const final;
 
   // Copy constructor used for cloning.
@@ -143,7 +143,7 @@ class RenderEngineGl final : public RenderEngine {
   // called if there is not already a cached render target for the camera's
   // reported image size (w, h) in render_targets_.
   static RenderTarget CreateRenderTarget(
-      const RenderCameraCore& camera, RenderType render_type);
+      const render::RenderCameraCore& camera, RenderType render_type);
 
   // Obtains the label image rendered from a specific object pose. This is
   // slower than it has to be because it does per-pixel processing on the CPU.
@@ -154,8 +154,8 @@ class RenderEngineGl final : public RenderEngine {
   // Acquires the render target for the given camera. "Acquiring" the render
   // target guarantees that the target will be ready for receiving OpenGL
   // draw commands.
-  RenderTarget GetRenderTarget(
-      const RenderCameraCore& camera, RenderType render_type) const;
+  RenderTarget GetRenderTarget(const render::RenderCameraCore& camera,
+                               RenderType render_type) const;
 
   // Creates an OpenGlGeometry from the mesh defined by the given `mesh_data`.
   static OpenGlGeometry CreateGlGeometry(
@@ -170,8 +170,8 @@ class RenderEngineGl final : public RenderEngine {
   //  - the window is made hidden (or remains hidden).
   // @pre RenderTarget's frame buffer has the same dimensions as reported by the
   // camera.
-  void SetWindowVisibility(const RenderCameraCore& camera, bool show_window,
-                           const RenderTarget& target) const;
+  void SetWindowVisibility(const render::RenderCameraCore& camera,
+                           bool show_window, const RenderTarget& target) const;
 
   // Adds a shader program to the set of candidate shaders for the given render
   // type.
@@ -271,6 +271,6 @@ class RenderEngineGl final : public RenderEngine {
 };
 
 }  // namespace internal
-}  // namespace render
+}  // namespace render_gl
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/internal_shader_program.cc
+++ b/geometry/render_gl/internal_shader_program.cc
@@ -10,7 +10,7 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_gl {
 namespace internal {
 
 using Eigen::Vector3d;
@@ -148,6 +148,6 @@ void ShaderProgram::Unuse() const {
 }
 
 }  // namespace internal
-}  // namespace render
+}  // namespace render_gl
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/internal_shader_program.h
+++ b/geometry/render_gl/internal_shader_program.h
@@ -14,7 +14,7 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_gl {
 namespace internal {
 
 /* TODO(SeanCurtis-TRI) This implies a compile-time shader definition. It may
@@ -117,7 +117,7 @@ class ShaderProgram {
    properties. This should *not* include model -> camera -> device transforms.
    they are handled elsewhere.  */
   virtual void SetDepthCameraParameters(
-      const DepthRenderCamera& /* camera */) const {}
+      const render::DepthRenderCamera& /* camera */) const {}
 
   /* Sets the direction of the directional light (if supported).
    @pre light_dir_C.norm() == 1.0.  */
@@ -205,6 +205,6 @@ class ShaderProgram {
 };
 
 }  // namespace internal
-}  // namespace render
+}  // namespace render_gl
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/internal_shader_program_data.h
+++ b/geometry/render_gl/internal_shader_program_data.h
@@ -9,7 +9,7 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_gl {
 namespace internal {
 
 /* Type used to identify unique shader programs in RenderEngineGl. */
@@ -42,6 +42,6 @@ class ShaderProgramData {
 };
 }  // namespace internal
 
-}  // namespace render
+}  // namespace render_gl
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/internal_shape_meshes.cc
+++ b/geometry/render_gl/internal_shape_meshes.cc
@@ -19,7 +19,7 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_gl {
 namespace internal {
 
 using Eigen::Vector2d;
@@ -1077,6 +1077,6 @@ MeshData MakeCapsule(int samples, double radius, double length) {
 }
 
 }  // namespace internal
-}  // namespace render
+}  // namespace render_gl
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/internal_shape_meshes.h
+++ b/geometry/render_gl/internal_shape_meshes.h
@@ -9,7 +9,7 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_gl {
 namespace internal {
 
 /* The data representing a mesh. The triangle mesh is defined by `indices`. Row
@@ -170,6 +170,6 @@ MeshData MakeUnitBox();
 MeshData MakeCapsule(int samples, double radius, double length);
 
 }  // namespace internal
-}  // namespace render
+}  // namespace render_gl
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/internal_texture_library.cc
+++ b/geometry/render_gl/internal_texture_library.cc
@@ -16,7 +16,7 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_gl {
 namespace internal {
 
 TextureLibrary::TextureLibrary(const OpenGlContext* context)
@@ -101,6 +101,6 @@ std::optional<GLuint> TextureLibrary::GetTextureId(
 }
 
 }  // namespace internal
-}  // namespace render
+}  // namespace render_gl
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/internal_texture_library.h
+++ b/geometry/render_gl/internal_texture_library.h
@@ -9,7 +9,7 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_gl {
 namespace internal {
 
 /* Stores a set of OpenGl textures objects, keyed by their in-filesystem name.
@@ -41,6 +41,6 @@ class TextureLibrary {
 };
 
 }  // namespace internal
-}  // namespace render
+}  // namespace render_gl
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/no_factory.cc
+++ b/geometry/render_gl/no_factory.cc
@@ -3,18 +3,21 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
 
 // Definition of extern bool in factory.h. When we build against *this* .cc file
 // RenderEngineGl is not available.
 const bool kHasRenderEngineGl = false;
 
-std::unique_ptr<RenderEngine> MakeRenderEngineGl(RenderEngineGlParams) {
+std::unique_ptr<render::RenderEngine> MakeRenderEngineGl(RenderEngineGlParams) {
   throw std::runtime_error(
       "RenderEngineGl was not compiled. You'll need to use a different render "
       "engine.");
 }
 
+namespace render {
+  DRAKE_DEPRECATED("2023-07-01", "Use the geometry namespace instead.")
+  const bool kHasRenderEngineGl = false;
 }  // namespace render
+
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/render_engine_gl_params.h
+++ b/geometry/render_gl/render_engine_gl_params.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/name_value.h"
 #include "drake/geometry/render/render_label.h"
 #include "drake/geometry/rgba.h"
 
 namespace drake {
 namespace geometry {
-namespace render {
 
 /** Construction parameters for RenderEngineGl.  */
 struct RenderEngineGlParams {
@@ -21,7 +21,7 @@ struct RenderEngineGlParams {
 
   /** Default render label to apply to a geometry when none is otherwise
    specified.  */
-  RenderLabel default_label{RenderLabel::kUnspecified};
+  render::RenderLabel default_label{render::RenderLabel::kUnspecified};
 
   /** Default diffuse color to apply to a geometry when none is otherwise
    specified in the (phong, diffuse) property.  */
@@ -31,6 +31,13 @@ struct RenderEngineGlParams {
   Rgba default_clear_color{204 / 255., 229 / 255., 255 / 255., 1.0};
 };
 
+namespace render {
+
+using RenderEngineGlParams
+    DRAKE_DEPRECATED("2023-07-01", "Use the geometry namespace instead.")
+    = geometry::RenderEngineGlParams;
+
 }  // namespace render
+
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/test/deprecation_test.cc
+++ b/geometry/render_gl/test/deprecation_test.cc
@@ -1,0 +1,28 @@
+// This file serves to check that our deprecation shims compile successfully,
+// aside from warning messages.  We can remove this file entirely once the
+// deprecation period ends.
+// TODO(zachfang): Remove this along with deprecation on 2023-07-01.
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/render_gl/factory.h"
+#include "drake/geometry/render_gl/render_engine_gl_params.h"
+
+namespace {
+
+GTEST_TEST(RenderGlNamespaceDeprecation, SanityCheck) {
+  const auto has_gl_engine = drake::geometry::render::kHasRenderEngineGl;
+  const drake::geometry::render::RenderEngineGlParams params;
+
+  if (has_gl_engine) {
+    const auto engine = drake::geometry::render::MakeRenderEngineGl(params);
+  } else {
+    // We should be able to call the function but expect an exception.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        drake::geometry::render::MakeRenderEngineGl(params),
+        ".*RenderEngineGl was not compiled.*");
+  }
+}
+
+}  // namespace

--- a/geometry/render_gl/test/internal_buffer_dim_test.cc
+++ b/geometry/render_gl/test/internal_buffer_dim_test.cc
@@ -6,7 +6,7 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_gl {
 namespace internal {
 namespace {
 
@@ -60,6 +60,6 @@ GTEST_TEST(BufferDimTest, HashableKey) {
 
 }  // namespace
 }  // namespace internal
-}  // namespace render
+}  // namespace render_gl
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/test/internal_no_render_engine_gl_test.cc
+++ b/geometry/render_gl/test/internal_no_render_engine_gl_test.cc
@@ -5,7 +5,6 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
 namespace {
 
 // Tests that attempting to use the unsupported RenderEngineGl throws.
@@ -16,6 +15,5 @@ GTEST_TEST(RenderEngineGl, NoRenderEngineGlSupport) {
 }
 
 }  // namespace
-}  // namespace render
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/test/internal_opengl_context_test.cc
+++ b/geometry/render_gl/test/internal_opengl_context_test.cc
@@ -4,7 +4,7 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_gl {
 namespace internal {
 namespace {
 
@@ -52,6 +52,6 @@ GTEST_TEST(OpenGlContext, WindowVisibility) {
 
 }  // namespace
 }  // namespace internal
-}  // namespace render
+}  // namespace render_gl
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/test/internal_opengl_geometry_test.cc
+++ b/geometry/render_gl/test/internal_opengl_geometry_test.cc
@@ -8,12 +8,13 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_gl {
 namespace internal {
 namespace {
 
 using Eigen::Vector3d;
 using math::RigidTransformd;
+using render::RenderLabel;
 
 // Note: All values in these tests are effectively garbage. They are not really
 // names of OpenGL objects. These tests merely exercise the functionality of the
@@ -105,6 +106,6 @@ GTEST_TEST(OpenGlInstanceTest, Construction) {
 
 }  // namespace
 }  // namespace internal
-}  // namespace render
+}  // namespace render_gl
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/test/internal_render_engine_gl_test.cc
+++ b/geometry/render_gl/test/internal_render_engine_gl_test.cc
@@ -23,8 +23,14 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_gl {
 namespace internal {
+
+using render::ColorRenderCamera;
+using render::DepthRenderCamera;
+using render::RenderCameraCore;
+using render::RenderEngine;
+using render::RenderLabel;
 
 // Friend class that gives the tests access to a RenderEngineGl's OpenGlContext.
 class RenderEngineGlTester {
@@ -1260,7 +1266,7 @@ TEST_F(RenderEngineGlTest, DifferentCameras) {
   const auto& ref_core = depth_camera_.core();
   const std::string& ref_name = ref_core.renderer_name();
   const RigidTransformd ref_X_BS = ref_core.sensor_pose_in_camera_body();
-  const ClippingRange& ref_clipping = ref_core.clipping();
+  const render::ClippingRange& ref_clipping = ref_core.clipping();
   const auto& ref_intrinsics = ref_core.intrinsics();
   const int ref_w = ref_intrinsics.width();
   const int ref_h = ref_intrinsics.height();
@@ -1898,6 +1904,6 @@ TEST_F(RenderEngineGlTest, IntrinsicsAndRenderProperties) {
 
 }  // namespace
 }  // namespace internal
-}  // namespace render
+}  // namespace render_gl
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/test/internal_shader_program_test.cc
+++ b/geometry/render_gl/test/internal_shader_program_test.cc
@@ -15,10 +15,14 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_gl {
 namespace internal {
 class ShaderProgramTest;
 namespace {
+
+using render::DepthRange;
+using render::DepthRenderCamera;
+using render::RenderCameraCore;
 
 /* A simple shader implementation that exercises all of the virtual API and
  reports if it has been called.  */
@@ -57,7 +61,7 @@ class TestShader final : public ShaderProgram {
   }
 
  private:
-  friend class drake::geometry::render::internal::ShaderProgramTest;
+  friend class drake::geometry::render_gl::internal::ShaderProgramTest;
 
   std::unique_ptr<ShaderProgram> DoClone() const final {
     return std::make_unique<TestShader>(*this);
@@ -429,6 +433,6 @@ TEST_F(ShaderProgramTest, Cloning) {
 }
 
 }  // namespace internal
-}  // namespace render
+}  // namespace render_gl
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gl/test/internal_shape_meshes_test.cc
+++ b/geometry/render_gl/test/internal_shape_meshes_test.cc
@@ -15,7 +15,7 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_gl {
 namespace internal {
 namespace {
 
@@ -848,6 +848,6 @@ GTEST_TEST(PrimitiveMeshTests, MakeCapsule) {
 
 }  // namespace
 }  // namespace internal
-}  // namespace render
+}  // namespace render_gl
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_gltf_client/internal_render_client.cc
+++ b/geometry/render_gltf_client/internal_render_client.cc
@@ -29,14 +29,14 @@ namespace {
 
 namespace fs = std::filesystem;
 
-using drake::geometry::render::ClippingRange;
-using drake::geometry::render::DepthRange;
-using drake::geometry::render::RenderCameraCore;
-using drake::systems::sensors::CameraInfo;
-using drake::systems::sensors::ImageDepth16U;
-using drake::systems::sensors::ImageDepth32F;
-using drake::systems::sensors::ImageLabel16I;
-using drake::systems::sensors::ImageRgba8U;
+using render::ClippingRange;
+using render::DepthRange;
+using render::RenderCameraCore;
+using systems::sensors::CameraInfo;
+using systems::sensors::ImageDepth16U;
+using systems::sensors::ImageDepth32F;
+using systems::sensors::ImageLabel16I;
+using systems::sensors::ImageRgba8U;
 
 /* Adds field_name = field_data to the map, assumes data_map does **not**
  already have the key `field_name`. */
@@ -167,14 +167,13 @@ RenderClient::~RenderClient() {
     } catch (const std::exception& e) {
       // Note: Catching an exception is generally verboten.  However, since
       // exceptions can't be thrown in a destructor, doing so is allowed here.
-      drake::log()->debug("RenderClient: could not delete '{}'. {}",
-                          temp_directory_, e.what());
+      log()->debug("RenderClient: could not delete '{}'. {}", temp_directory_,
+                   e.what());
     }
   } else if (params_.verbose) {
     // NOTE: This gets printed twice because of cloning, cannot be avoided.
-    drake::log()->debug(
-        "RenderClient: temporary directory '{}' was *NOT* deleted.",
-        temp_directory_);
+    log()->debug("RenderClient: temporary directory '{}' was *NOT* deleted.",
+                 temp_directory_);
   }
 }
 

--- a/geometry/render_gltf_client/internal_render_client.h
+++ b/geometry/render_gltf_client/internal_render_client.h
@@ -78,10 +78,10 @@ class RenderClient {
      `depth_range` was not provided for a depth render, or `depth_range` was
      provided but `image_type` is color or label. */
   std::string RenderOnServer(
-      const drake::geometry::render::RenderCameraCore& camera_core,
-      RenderImageType image_type, const std::string& scene_path,
+      const render::RenderCameraCore& camera_core, RenderImageType image_type,
+      const std::string& scene_path,
       const std::optional<std::string>& mime_type = std::nullopt,
-      const std::optional<drake::geometry::render::DepthRange>& depth_range =
+      const std::optional<render::DepthRange>& depth_range =
           std::nullopt) const;
 
   //@}
@@ -152,9 +152,8 @@ class RenderClient {
      If the specified `path` cannot be loaded as an unsigned char RGB or RGBA
      PNG file, or the image denoted by `path` does not have the same width and
      height as the specified `color_image_out`. */
-  static void LoadColorImage(
-      const std::string& path,
-      drake::systems::sensors::ImageRgba8U* color_image_out);
+  static void LoadColorImage(const std::string& path,
+                             systems::sensors::ImageRgba8U* color_image_out);
 
   /* Loads the specified image file to a drake output buffer.
 
@@ -174,9 +173,8 @@ class RenderClient {
      If the specified `path` has an unsupported extension or channel type, or
      the image denoted by `path` does not have the same width and height as the
      specified `depth_image_out`. */
-  static void LoadDepthImage(
-      const std::string& path,
-      drake::systems::sensors::ImageDepth32F* depth_image_out);
+  static void LoadDepthImage(const std::string& path,
+                             systems::sensors::ImageDepth32F* depth_image_out);
 
   //@}
 

--- a/geometry/render_gltf_client/internal_render_engine_gltf_client.cc
+++ b/geometry/render_gltf_client/internal_render_engine_gltf_client.cc
@@ -21,12 +21,12 @@ namespace internal {
 
 namespace fs = std::filesystem;
 
-using geometry::render::ColorRenderCamera;
-using geometry::render::DepthRenderCamera;
-using geometry::render::RenderCameraCore;
-using geometry::render::RenderEngine;
-using geometry::render::RenderEngineVtk;
-using geometry::render::internal::ImageType;
+using render::ColorRenderCamera;
+using render::DepthRenderCamera;
+using render::RenderCameraCore;
+using render::RenderEngine;
+using render_vtk::internal::ImageType;
+using render_vtk::internal::RenderEngineVtk;
 using systems::sensors::ColorI;
 using systems::sensors::ImageDepth32F;
 using systems::sensors::ImageLabel16I;
@@ -41,7 +41,7 @@ namespace {
  https://github.com/RobotLocomotion/drake/blob/master/common/identifier.h
  */
 int64_t GetNextSceneId() {
-  static drake::never_destroyed<std::atomic<int64_t>> global_scene_id;
+  static never_destroyed<std::atomic<int64_t>> global_scene_id;
   return ++(global_scene_id.access());
 }
 
@@ -118,17 +118,17 @@ std::string_view ImageTypeToString(ImageType image_type) {
 }
 
 void LogFrameStart(ImageType image_type, int64_t scene_id) {
-  drake::log()->debug("RenderEngineGltfClient: rendering {} scene id {}.",
-                      ImageTypeToString(image_type), scene_id);
+  log()->debug("RenderEngineGltfClient: rendering {} scene id {}.",
+               ImageTypeToString(image_type), scene_id);
 }
 
 void LogFrameGltfExportPath(ImageType image_type, const std::string& path) {
-  drake::log()->debug("RenderEngineGltfClient: {} scene exported to '{}'.",
-                      ImageTypeToString(image_type), path);
+  log()->debug("RenderEngineGltfClient: {} scene exported to '{}'.",
+               ImageTypeToString(image_type), path);
 }
 
 void LogFrameServerResponsePath(ImageType image_type, const std::string& path) {
-  drake::log()->debug(
+  log()->debug(
       "RenderEngineGltfClient: {} server response image saved to '{}'.",
       ImageTypeToString(image_type), path);
 }
@@ -140,9 +140,8 @@ void CleanupFrame(const std::string& scene_path, const std::string& image_path,
   fs::remove(scene_path);
   fs::remove(image_path);
   if (verbose) {
-    drake::log()->debug(
-        "RenderEngineGltfClient: deleted unused files {} and {}.", scene_path,
-        image_path);
+    log()->debug("RenderEngineGltfClient: deleted unused files {} and {}.",
+                 scene_path, image_path);
   }
 }
 

--- a/geometry/render_gltf_client/internal_render_engine_gltf_client.h
+++ b/geometry/render_gltf_client/internal_render_engine_gltf_client.h
@@ -16,7 +16,7 @@ namespace internal {
 /* A RenderEngine that exports
  <a href="https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html">glTF
  </a> scenes, uploads to a render server, and retrieves the renderings back. */
-class RenderEngineGltfClient : public geometry::render::RenderEngineVtk {
+class RenderEngineGltfClient : public render_vtk::internal::RenderEngineVtk {
  public:
   /* @name Does not allow copy, move, or assignment  */
   //@{
@@ -52,7 +52,7 @@ class RenderEngineGltfClient : public geometry::render::RenderEngineVtk {
    inversion for the specified image_type.
    TODO(zachfang): Remove this after VTK is updated. */
   Eigen::Matrix4d CameraModelViewTransformMatrix(
-      geometry::render::internal::ImageType image_type) const;
+      render_vtk::internal::ImageType image_type) const;
 
  protected:
   /* Copy constructor for the purpose of cloning. */
@@ -60,27 +60,27 @@ class RenderEngineGltfClient : public geometry::render::RenderEngineVtk {
 
  private:
   // @see RenderEngine::DoClone().
-  std::unique_ptr<geometry::render::RenderEngine> DoClone() const override;
+  std::unique_ptr<render::RenderEngine> DoClone() const override;
 
   // @see RenderEngine::DoRenderColorImage().
   void DoRenderColorImage(
-      const geometry::render::ColorRenderCamera& camera,
+      const render::ColorRenderCamera& camera,
       systems::sensors::ImageRgba8U* color_image_out) const override;
 
   // @see RenderEngine::DoRenderDepthImage().
   void DoRenderDepthImage(
-      const geometry::render::DepthRenderCamera& render_camera,
+      const render::DepthRenderCamera& render_camera,
       systems::sensors::ImageDepth32F* depth_image_out) const override;
 
   // @see RenderEngine::DoRenderLabelImage().
   void DoRenderLabelImage(
-      const geometry::render::ColorRenderCamera& camera,
+      const render::ColorRenderCamera& camera,
       systems::sensors::ImageLabel16I* label_image_out) const override;
 
   /* Exports the `RenderEngineVtk::pipelines_[image_type]` VTK scene to a
    glTF file given `export_path`. */
   void ExportScene(const std::string& export_path,
-                   geometry::render::internal::ImageType image_type) const;
+                   render_vtk::internal::ImageType image_type) const;
 
   std::unique_ptr<RenderClient> render_client_;
 };

--- a/geometry/render_gltf_client/test/client_demo.cc
+++ b/geometry/render_gltf_client/test/client_demo.cc
@@ -189,15 +189,14 @@ int DoMain() {
 
   const std::string renderer_name("renderer");
   if (FLAGS_render_engine == "vtk") {
-    scene_graph.AddRenderer(renderer_name, geometry::MakeRenderEngineVtk({}));
+    scene_graph.AddRenderer(renderer_name, MakeRenderEngineVtk({}));
   } else {  // FLAGS_render_engine == "client"
     RenderEngineGltfClientParams params;
     params.base_url = FLAGS_server_base_url;
     params.render_endpoint = FLAGS_server_render_endpoint;
     params.cleanup = FLAGS_cleanup;
     params.verbose = !FLAGS_cleanup;
-    scene_graph.AddRenderer(renderer_name,
-                            geometry::MakeRenderEngineGltfClient(params));
+    scene_graph.AddRenderer(renderer_name, MakeRenderEngineGltfClient(params));
   }
 
   // We assume the example sdf contains a body called "base_link_mustard".  We

--- a/geometry/render_gltf_client/test/internal_render_client_test.cc
+++ b/geometry/render_gltf_client/test/internal_render_client_test.cc
@@ -53,11 +53,11 @@ namespace internal {
 namespace fs = std::filesystem;
 
 using Params = RenderEngineGltfClientParams;
-using geometry::render::ClippingRange;
-using geometry::render::ColorRenderCamera;
-using geometry::render::DepthRange;
-using geometry::render::DepthRenderCamera;
-using geometry::render::RenderCameraCore;
+using render::ClippingRange;
+using render::ColorRenderCamera;
+using render::DepthRange;
+using render::DepthRenderCamera;
+using render::RenderCameraCore;
 using systems::sensors::CameraInfo;
 using systems::sensors::ImageDepth32F;
 using systems::sensors::ImageLabel16I;
@@ -107,7 +107,7 @@ class RenderClientTest : public ::testing::Test {
 
  protected:
   // A per-test-case temporary directory.
-  const fs::path scratch_{drake::temp_directory()};
+  const fs::path scratch_{temp_directory()};
   const std::string fake_scene_path_{scratch_ / "fake_scene.gltf"};
 
   /* The params to create the test RenderClient are to help ensure nothing

--- a/geometry/render_gltf_client/test/internal_render_engine_gltf_client_test.cc
+++ b/geometry/render_gltf_client/test/internal_render_engine_gltf_client_test.cc
@@ -29,12 +29,12 @@ using Eigen::Matrix4d;
 using Eigen::Vector3d;
 using Eigen::Vector4d;
 
-using geometry::render::ColorRenderCamera;
-using geometry::render::DepthRenderCamera;
-using geometry::render::RenderEngine;
-using geometry::render::internal::ImageType;
 using math::RigidTransformd;
 using math::RollPitchYawd;
+using render::ColorRenderCamera;
+using render::DepthRenderCamera;
+using render::RenderEngine;
+using render_vtk::internal::ImageType;
 using systems::sensors::ImageDepth32F;
 using systems::sensors::ImageLabel16I;
 using systems::sensors::ImageRgba8U;

--- a/geometry/render_gltf_client/test/server_vtk_backend.cc
+++ b/geometry/render_gltf_client/test/server_vtk_backend.cc
@@ -108,11 +108,11 @@ namespace render_gltf_client {
 namespace internal {
 namespace {
 
-using drake::geometry::render::internal::ShaderCallback;
-using drake::systems::sensors::ImageDepth32F;
-using drake::systems::sensors::ImageRgba8U;
-using drake::systems::sensors::ImageTraits;
-using drake::systems::sensors::PixelType;
+using render_vtk::internal::ShaderCallback;
+using systems::sensors::ImageDepth32F;
+using systems::sensors::ImageRgba8U;
+using systems::sensors::ImageTraits;
+using systems::sensors::PixelType;
 
 // Imported from internal_render_engine_vtk.cc, for converting the depth image.
 float CheckRangeAndConvertToMeters(float z_buffer_value, double z_near,
@@ -130,13 +130,13 @@ float CheckRangeAndConvertToMeters(float z_buffer_value, double z_near,
 bool ValidateOutputExtension() {
   if (FLAGS_image_type == "depth") {
     if (std::filesystem::path(FLAGS_output_path).extension() == ".png") {
-      drake::log()->debug("Depth images must have a .tiff extension.");
+      log()->debug("Depth images must have a .tiff extension.");
       return false;
     }
   } else {
     const std::filesystem::path output_path{FLAGS_output_path};
     if (output_path.extension() != ".png") {
-      drake::log()->debug("Color and label images must have a .png extension.");
+      log()->debug("Color and label images must have a .png extension.");
       return false;
     }
   }

--- a/geometry/render_vtk/factory.cc
+++ b/geometry/render_vtk/factory.cc
@@ -7,7 +7,7 @@ namespace geometry {
 
 std::unique_ptr<render::RenderEngine> MakeRenderEngineVtk(
     const RenderEngineVtkParams& params) {
-  return std::make_unique<render::RenderEngineVtk>(params);
+  return std::make_unique<render_vtk::internal::RenderEngineVtk>(params);
 }
 
 }  // namespace geometry

--- a/geometry/render_vtk/internal_render_engine_vtk.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk.cc
@@ -28,13 +28,18 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_vtk {
+namespace internal {
 
 using Eigen::Vector2d;
 using Eigen::Vector4d;
 using math::RigidTransformd;
+using render::ColorRenderCamera;
+using render::DepthRenderCamera;
+using render::RenderCameraCore;
+using render::RenderEngine;
+using render::RenderLabel;
 using std::make_unique;
-using internal::ImageType;
 using systems::sensors::CameraInfo;
 using systems::sensors::ColorD;
 using systems::sensors::ColorI;
@@ -43,9 +48,6 @@ using systems::sensors::ImageLabel16I;
 using systems::sensors::ImageRgba8U;
 using systems::sensors::ImageTraits;
 using systems::sensors::PixelType;
-using vtk_util::ConvertToVtkTransform;
-using vtk_util::CreateSquarePlane;
-using vtk_util::MakeVtkPointerArray;
 
 namespace {
 
@@ -95,20 +97,15 @@ std::string RemoveFileExtension(const std::string& filepath) {
 
 }  // namespace
 
-namespace internal {
-
 ShaderCallback::ShaderCallback() :
     // These values are arbitrary "reasonable" values, but we expect them to
     // *both* be overwritten upon every usage.
     z_near_(0.01),
     z_far_(100.0) {}
 
-}  // namespace internal
+vtkNew<ShaderCallback> RenderEngineVtk::uniform_setting_callback_;
 
-vtkNew<internal::ShaderCallback> RenderEngineVtk::uniform_setting_callback_;
-
-RenderEngineVtk::RenderEngineVtk(
-    const geometry::RenderEngineVtkParams& parameters)
+RenderEngineVtk::RenderEngineVtk(const RenderEngineVtkParams& parameters)
     : RenderEngine(parameters.default_label ? *parameters.default_label
                                             : RenderLabel::kUnspecified),
       pipelines_{{make_unique<RenderingPipeline>(),
@@ -478,8 +475,8 @@ void RenderEngineVtk::ImplementGeometry(vtkPolyDataAlgorithm* source,
   vtkOpenGLShaderProperty* shader_prop = vtkOpenGLShaderProperty::SafeDownCast(
       actors[ImageType::kDepth]->GetShaderProperty());
   DRAKE_DEMAND(shader_prop != nullptr);
-  shader_prop->SetVertexShaderCode(shaders::kDepthVS);
-  shader_prop->SetFragmentShaderCode(shaders::kDepthFS);
+  shader_prop->SetVertexShaderCode(render::shaders::kDepthVS);
+  shader_prop->SetFragmentShaderCode(render::shaders::kDepthFS);
   mappers[ImageType::kDepth]->AddObserver(
       vtkCommand::UpdateShaderEvent, uniform_setting_callback_.Get());
 
@@ -640,6 +637,7 @@ void RenderEngineVtk::UpdateWindow(const DepthRenderCamera& camera,
   UpdateWindow(camera.core(), false, p, "");
 }
 
-}  // namespace render
+}  // namespace internal
+}  // namespace render_vtk
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_vtk/internal_render_engine_vtk.h
+++ b/geometry/render_vtk/internal_render_engine_vtk.h
@@ -32,10 +32,10 @@ VTK_AUTOINIT_DECLARE(vtkRenderingOpenGL2)
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_vtk {
+namespace internal {
 
 #ifndef DRAKE_DOXYGEN_CXX
-namespace internal {
 struct ModuleInitVtkRenderingOpenGL2 {
   ModuleInitVtkRenderingOpenGL2(){
     VTK_AUTOINIT_CONSTRUCT(vtkRenderingOpenGL2)
@@ -84,13 +84,11 @@ enum ImageType {
   kDepth = 2,
 };
 
-}  // namespace internal
-
 #endif  // !DRAKE_DOXYGEN_CXX
 
 /** See documentation of MakeRenderEngineVtk().  */
-class RenderEngineVtk : public RenderEngine,
-                        private internal::ModuleInitVtkRenderingOpenGL2 {
+class RenderEngineVtk : public render::RenderEngine,
+                        private ModuleInitVtkRenderingOpenGL2 {
  public:
   /** @name Does not allow copy, move, or assignment  */
   //@{
@@ -109,8 +107,8 @@ class RenderEngineVtk : public RenderEngine,
    When one of the optional parameters is omitted, the constructed value will be
    as documented elsewhere in @ref render_engine_vtk_properties "this class".
   */
-  explicit RenderEngineVtk(const geometry::RenderEngineVtkParams& parameters =
-      geometry::RenderEngineVtkParams());
+  explicit RenderEngineVtk(
+      const RenderEngineVtkParams& parameters = RenderEngineVtkParams());
 
   /** @see RenderEngine::UpdateViewpoint().  */
   void UpdateViewpoint(const math::RigidTransformd& X_WR) override;
@@ -136,7 +134,7 @@ class RenderEngineVtk : public RenderEngine,
 
   const Eigen::Vector4d& default_diffuse() const { return default_diffuse_; }
 
-  using RenderEngine::default_render_label;
+  using render::RenderEngine::default_render_label;
   //@}
 
  protected:
@@ -164,13 +162,12 @@ class RenderEngineVtk : public RenderEngine,
   /** Configures the VTK model to reflect the given `camera`, this includes
    render size camera intrinsics, visible windows, etc. If `show_window` is set
    to true, a named VTK window will be displayed. */
-  void UpdateWindow(const RenderCameraCore& camera,
-                    bool show_window, const RenderingPipeline& p,
-                    const char* name) const;
+  void UpdateWindow(const render::RenderCameraCore& camera, bool show_window,
+                    const RenderingPipeline& p, const char* name) const;
 
   /** Variant of configuring the VTK model (see previous function) that *also*
    configures the depth range. */
-  void UpdateWindow(const DepthRenderCamera& camera,
+  void UpdateWindow(const render::DepthRenderCamera& camera,
                     const RenderingPipeline& p) const;
 
   /** Updates VTK rendering related objects including vtkRenderWindow,
@@ -179,9 +176,9 @@ class RenderEngineVtk : public RenderEngine,
   static void PerformVtkUpdate(const RenderingPipeline& p);
 
   /** Provides access to the private data member pipelines_ by returning a
-   mutable RenderingPipeline reference. Only image types in internal::ImageType
-   enum are valid. */
-  RenderingPipeline& get_mutable_pipeline(internal::ImageType image_type) const;
+   mutable RenderingPipeline reference. Only image types in ImageType enum are
+   valid. */
+  RenderingPipeline& get_mutable_pipeline(ImageType image_type) const;
 
  private:
   // @see RenderEngine::DoRegisterVisual().
@@ -201,17 +198,17 @@ class RenderEngineVtk : public RenderEngine,
 
   // @see RenderEngine::DoRenderColorImage().
   void DoRenderColorImage(
-      const ColorRenderCamera& camera,
+      const render::ColorRenderCamera& camera,
       systems::sensors::ImageRgba8U* color_image_out) const override;
 
   // @see RenderEngine::DoRenderDepthImage().
   void DoRenderDepthImage(
-      const DepthRenderCamera& render_camera,
+      const render::DepthRenderCamera& render_camera,
       systems::sensors::ImageDepth32F* depth_image_out) const override;
 
   // @see RenderEngine::DoRenderLabelImage().
   void DoRenderLabelImage(
-      const ColorRenderCamera& camera,
+      const render::ColorRenderCamera& camera,
       systems::sensors::ImageLabel16I* label_image_out) const override;
 
   // Initializes the VTK pipelines.
@@ -248,7 +245,7 @@ class RenderEngineVtk : public RenderEngine,
   // formal thread safe mechanism so that it doesn't rely on that in the future.
   // TODO(SeanCurtis-TRI): This is not threadsafe; investigate mechanisms to
   // prevent undesirable behaviors if used in multi-threaded application.
-  static vtkNew<internal::ShaderCallback> uniform_setting_callback_;
+  static vtkNew<ShaderCallback> uniform_setting_callback_;
 
   // Obnoxious bright orange.
   Eigen::Vector4d default_diffuse_{0.9, 0.45, 0.1, 1.0};
@@ -262,6 +259,7 @@ class RenderEngineVtk : public RenderEngine,
       actors_;
 };
 
-}  // namespace render
+}  // namespace internal
+}  // namespace render_vtk
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_vtk/internal_render_engine_vtk_base.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk_base.cc
@@ -21,12 +21,11 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
-
-using Eigen::Vector2d;
-
+namespace render_vtk {
+namespace internal {
 namespace {
 
+using Eigen::Vector2d;
 using Eigen::Vector3d;
 
 // TODO(SeanCurtis-TRI): The semantics of this textured box needs to be
@@ -310,6 +309,7 @@ void TransformToDrakeCylinder(vtkTransform* transform,
   transform_filter->Update();
 }
 
-}  // namespace render
+}  // namespace internal
+}  // namespace render_vtk
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_vtk/internal_render_engine_vtk_base.h
+++ b/geometry/render_vtk/internal_render_engine_vtk_base.h
@@ -11,7 +11,8 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_vtk {
+namespace internal {
 
 // Creates a z-axis aligned VTK capsule.
 vtkSmartPointer<vtkPolyDataAlgorithm> CreateVtkCapsule(const Capsule& capsule);
@@ -39,6 +40,7 @@ void TransformToDrakeCylinder(vtkTransform* transform,
                               vtkTransformPolyDataFilter* transform_filter,
                               vtkCylinderSource* vtk_cylinder);
 
-}  // namespace render
+}  // namespace internal
+}  // namespace render_vtk
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_vtk/internal_vtk_util.cc
+++ b/geometry/render_vtk/internal_vtk_util.cc
@@ -10,8 +10,8 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
-namespace vtk_util {
+namespace render_vtk {
+namespace internal {
 
 vtkSmartPointer<vtkPlaneSource> CreateSquarePlane(double size) {
   vtkSmartPointer<vtkPlaneSource> plane =
@@ -48,7 +48,7 @@ vtkSmartPointer<vtkTransform> ConvertToVtkTransform(
   return vtk_transform;
 }
 
-}  // namespace vtk_util
-}  // namespace render
+}  // namespace internal
+}  // namespace render_vtk
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_vtk/internal_vtk_util.h
+++ b/geometry/render_vtk/internal_vtk_util.h
@@ -13,8 +13,8 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
-namespace vtk_util {
+namespace render_vtk {
+namespace internal {
 /// An array type for vtkSmartPointer.
 ///
 /// @tparam T The VTK class type stored in vtkSmartPointer.
@@ -47,7 +47,7 @@ const vtkPointerArray<T, N> MakeVtkPointerArray(
       vtkSmartPointer<Ts>(elements.GetPointer())...}};
 }
 
-}  // namespace vtk_util
-}  // namespace render
+}  // namespace internal
+}  // namespace render_vtk
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
@@ -22,24 +22,27 @@
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/shape_specification.h"
-#include "drake/geometry/test_utilities/dummy_render_engine.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/systems/sensors/image.h"
 
 namespace drake {
 namespace geometry {
-namespace render {
+namespace render_vtk {
+namespace internal {
 namespace {
 
 using Eigen::AngleAxisd;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
 using Eigen::Vector4d;
-using geometry::RenderEngineVtkParams;
-using geometry::internal::DummyRenderEngine;
 using math::RigidTransformd;
 using math::RotationMatrixd;
+using render::ColorRenderCamera;
+using render::DepthRenderCamera;
+using render::RenderCameraCore;
+using render::RenderEngine;
+using render::RenderLabel;
 using std::make_unique;
 using std::unique_ptr;
 using std::unordered_map;
@@ -1184,7 +1187,7 @@ TEST_F(RenderEngineVtkTest, DifferentCameras) {
   const auto& ref_core = depth_camera_.core();
   const std::string& ref_name = ref_core.renderer_name();
   const RigidTransformd ref_X_BS = ref_core.sensor_pose_in_camera_body();
-  const ClippingRange& ref_clipping = ref_core.clipping();
+  const render::ClippingRange& ref_clipping = ref_core.clipping();
   const auto& ref_intrinsics = ref_core.intrinsics();
   const int ref_w = ref_intrinsics.width();
   const int ref_h = ref_intrinsics.height();
@@ -1705,6 +1708,7 @@ TEST_F(RenderEngineVtkTest, IntrinsicsAndRenderProperties) {
 }
 
 }  // namespace
-}  // namespace render
+}  // namespace internal
+}  // namespace render_vtk
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_vtk/test/internal_vtk_util_test.cc
+++ b/geometry/render_vtk/test/internal_vtk_util_test.cc
@@ -12,8 +12,8 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
-namespace vtk_util {
+namespace render_vtk {
+namespace internal {
 namespace {
 
 const double kTolerance = 1e-15;
@@ -90,7 +90,7 @@ GTEST_TEST(MakeVtkPointerArrayTest, ValidTest) {
 }
 
 }  // namespace
-}  // namespace vtk_util
-}  // namespace render
+}  // namespace internal
+}  // namespace render_vtk
 }  // namespace geometry
 }  // namespace drake

--- a/systems/sensors/camera_config_functions.cc
+++ b/systems/sensors/camera_config_functions.cc
@@ -26,9 +26,9 @@ namespace sensors {
 using drake::lcm::DrakeLcmInterface;
 using drake::systems::lcm::LcmBuses;
 using Eigen::Vector3d;
-using geometry::render::MakeRenderEngineGl;
-using geometry::render::RenderEngineGlParams;
+using geometry::MakeRenderEngineGl;
 using geometry::MakeRenderEngineVtk;
+using geometry::RenderEngineGlParams;
 using geometry::RenderEngineVtkParams;
 using geometry::SceneGraph;
 using geometry::render::ColorRenderCamera;
@@ -53,9 +53,10 @@ void ValidateEngineAndMaybeAdd(const CameraConfig& config,
   using Dict = std::map<std::string, std::string>;
   static const never_destroyed<Dict> type_lookup(
       std::initializer_list<Dict::value_type>{
-          {"RenderEngineVtk", "drake::geometry::render::RenderEngineVtk"},
+          {"RenderEngineVtk",
+           "drake::geometry::render_vtk::internal::RenderEngineVtk"},
           {"RenderEngineGl",
-           "drake::geometry::render::internal::RenderEngineGl"}});
+           "drake::geometry::render_gl::internal::RenderEngineGl"}});
 
   DRAKE_DEMAND(scene_graph != nullptr);
 
@@ -81,7 +82,7 @@ void ValidateEngineAndMaybeAdd(const CameraConfig& config,
 
   // Now we know we need to add one. Confirm we can add the specified class.
   if (config.renderer_class == "RenderEngineGl") {
-    if (!geometry::render::kHasRenderEngineGl) {
+    if (!geometry::kHasRenderEngineGl) {
       throw std::logic_error(
           "Invalid camera configuration; renderer_class = 'RenderEngineGl' "
           "is not supported in current build.");

--- a/systems/sensors/test/camera_config_functions_test.cc
+++ b/systems/sensors/test/camera_config_functions_test.cc
@@ -413,6 +413,11 @@ TEST_F(CameraConfigFunctionsTest, RenderEngineRequest) {
                 vtk_config.renderer_name)),
             "RenderEngineVtk");
 
+  // Specifying the same config again should not produce a new render engine.
+  int current_renderer_count = scene_graph_->RendererCount();
+  ApplyCameraConfig(vtk_config, &builder_);
+  EXPECT_EQ(current_renderer_count, scene_graph_->RendererCount());
+
   // Using an existing name but the wrong render engine type throws.
   DRAKE_EXPECT_THROWS_MESSAGE(
       ApplyCameraConfig(
@@ -425,15 +430,15 @@ TEST_F(CameraConfigFunctionsTest, RenderEngineRequest) {
   // ApplyCameraConfig doesn't throw, and the renderer count doesn't change.
   // This test assumes that this behavior doesn't depend on the type of the
   // RenderEngine.
-  const int renderer_count = scene_graph_->RendererCount();
+  current_renderer_count = scene_graph_->RendererCount();
   ApplyCameraConfig(CameraConfig{.renderer_name = "vtk_renderer"}, &builder_);
-  EXPECT_EQ(renderer_count, scene_graph_->RendererCount());
+  EXPECT_EQ(current_renderer_count, scene_graph_->RendererCount());
 
   // Now explicitly request a new RenderEngineGl -- whether it throws depends
   // on whether GL is available.
   const CameraConfig gl_config{.renderer_name = "gl_renderer",
                                .renderer_class = "RenderEngineGl"};
-  if (geometry::render::kHasRenderEngineGl) {
+  if (geometry::kHasRenderEngineGl) {
     ASSERT_FALSE(scene_graph_->HasRenderer(gl_config.renderer_name));
     ApplyCameraConfig(gl_config, &builder_);
     ASSERT_EQ(NiceTypeName::RemoveNamespaces(

--- a/systems/sensors/test/camera_config_test.cc
+++ b/systems/sensors/test/camera_config_test.cc
@@ -22,7 +22,7 @@ namespace {
 using geometry::render::ColorRenderCamera;
 using geometry::render::DepthRenderCamera;
 using geometry::render::RenderCameraCore;
-using geometry::render::RenderEngineGlParams;
+using geometry::RenderEngineGlParams;
 using geometry::Rgba;
 using math::RigidTransformd;
 using schema::Transform;


### PR DESCRIPTION
According to [a Slack discussion](https://drakedevelopers.slack.com/archives/C2WBPQDB7/p1646937427862689) for the RenderEngine folder structure and their namespaces, this PR attempts to address the loose ends that do not currently obey the policy.

For all three RenderEngine implementations, change the namespace of the public interfaces to `geometry` and all the internal classes to `geometry/render_*/internal`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18877)
<!-- Reviewable:end -->
