### PR TITLE
Improve error message for MbP::GetModelInstanceByName()

### DIFF
--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -531,9 +531,21 @@ ModelInstanceIndex MultibodyTree<T>::GetModelInstanceByName(
     std::string_view name) const {
   const auto it = instance_name_to_index_.find(name);
   if (it == instance_name_to_index_.end()) {
+    std::string instance_names{};
+    for (const auto& kv : instance_name_to_index_) {
+      if (!instance_names.empty()) {
+        instance_names += ", ";
+      }
+      instance_names += '\'' + std::string(kv.first.view()) + '\'';
+    }
+    if (instance_names.empty()) {
+      instance_names = "NONE";
+    }
+
     throw std::logic_error(fmt::format(
-        "GetModelInstanceByName(): There is no model instance named '{}'.",
-        name));
+        "GetModelInstanceByName(): There is no model instance named '{}'. The "
+        "current model instances are {}.",
+        name, instance_names));
   }
   return it->second;
 }

--- a/multibody/tree/test/multibody_tree_test.cc
+++ b/multibody/tree/test/multibody_tree_test.cc
@@ -121,6 +121,11 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
   }
   EXPECT_FALSE(model.HasJointActuatorNamed(kInvalidName));
 
+  // Get model instance by name.
+  DRAKE_EXPECT_THROWS_MESSAGE(model.GetModelInstanceByName(kInvalidName),
+                              ".*There is no model instance named.*The current "
+                              "model instances are.*DefaultModelInstance.*");
+
   // Get links by name.
   for (const std::string& link_name : kLinkNames) {
     drake::test::LimitMalloc guard;
@@ -216,7 +221,7 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
   }
 }
 
-// This test creates a model for a KUKA Iiiwa arm and verifies we can retrieve
+// This test creates a model for a KUKA Iiwa arm and verifies we can retrieve
 // multibody elements by name or get exceptions accordingly.
 GTEST_TEST(MultibodyTree, VerifyModelBasics) {
   // Create a non-finalized model of the arm so that we can test adding more


### PR DESCRIPTION
Now when the model instance is not found, it helpfully reports the model instances that could have been found.

+@ggould-tri for both reviews, please.  (I think you'll approve of the change!)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18879)
<!-- Reviewable:end -->
