### PR TITLE
[solvers] Change SolverBase constructor to prefer SolverId directly

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1613,6 +1613,7 @@ drake_cc_googletest(
     name = "solver_id_test",
     deps = [
         ":solver_id",
+        "//common/test_utilities:limit_malloc",
     ],
 )
 

--- a/solvers/clp_solver_common.cc
+++ b/solvers/clp_solver_common.cc
@@ -9,7 +9,7 @@
 namespace drake {
 namespace solvers {
 ClpSolver::ClpSolver()
-    : SolverBase(&id, &is_available, &is_enabled, &ProgramAttributesSatisfied,
+    : SolverBase(id(), &is_available, &is_enabled, &ProgramAttributesSatisfied,
                  &UnsatisfiedProgramAttributes) {}
 
 ClpSolver::~ClpSolver() = default;

--- a/solvers/csdp_solver_common.cc
+++ b/solvers/csdp_solver_common.cc
@@ -12,7 +12,7 @@ namespace drake {
 namespace solvers {
 
 CsdpSolver::CsdpSolver()
-    : SolverBase(&id, &is_available, &is_enabled,
+    : SolverBase(id(), &is_available, &is_enabled,
                  &ProgramAttributesSatisfied) {}
 
 CsdpSolver::~CsdpSolver() = default;

--- a/solvers/equality_constrained_qp_solver.cc
+++ b/solvers/equality_constrained_qp_solver.cc
@@ -103,7 +103,7 @@ void SetDualSolutions(const MathematicalProgram& prog,
 }  // namespace
 
 EqualityConstrainedQPSolver::EqualityConstrainedQPSolver()
-    : SolverBase(&id, &is_available, &is_enabled,
+    : SolverBase(id(), &is_available, &is_enabled,
                  &ProgramAttributesSatisfied) {}
 
 EqualityConstrainedQPSolver::~EqualityConstrainedQPSolver() = default;
@@ -323,7 +323,7 @@ std::string EqualityConstrainedQPSolver::FeasibilityTolOptionName() {
 }
 
 SolverId EqualityConstrainedQPSolver::id() {
-  static const never_destroyed<SolverId> singleton{"Equality constrained QP"};
+  static const never_destroyed<SolverId> singleton{"EqConstrainedQP"};
   return singleton.access();
 }
 

--- a/solvers/gurobi_solver_common.cc
+++ b/solvers/gurobi_solver_common.cc
@@ -16,7 +16,7 @@ namespace drake {
 namespace solvers {
 
 GurobiSolver::GurobiSolver()
-    : SolverBase(&id, &is_available, &is_enabled, &ProgramAttributesSatisfied,
+    : SolverBase(id(), &is_available, &is_enabled, &ProgramAttributesSatisfied,
                  &UnsatisfiedProgramAttributes) {}
 
 GurobiSolver::~GurobiSolver() = default;

--- a/solvers/ipopt_solver_common.cc
+++ b/solvers/ipopt_solver_common.cc
@@ -9,7 +9,7 @@ namespace drake {
 namespace solvers {
 
 IpoptSolver::IpoptSolver()
-    : SolverBase(&id, &is_available, &is_enabled,
+    : SolverBase(id(), &is_available, &is_enabled,
                  &ProgramAttributesSatisfied) {}
 
 IpoptSolver::~IpoptSolver() = default;

--- a/solvers/linear_system_solver.cc
+++ b/solvers/linear_system_solver.cc
@@ -15,7 +15,7 @@ namespace drake {
 namespace solvers {
 
 LinearSystemSolver::LinearSystemSolver()
-    : SolverBase(&id, &is_available, &is_enabled, &ProgramAttributesSatisfied,
+    : SolverBase(id(), &is_available, &is_enabled, &ProgramAttributesSatisfied,
                  &UnsatisfiedProgramAttributes) {}
 
 LinearSystemSolver::~LinearSystemSolver() = default;

--- a/solvers/moby_lcp_solver.cc
+++ b/solvers/moby_lcp_solver.cc
@@ -1038,7 +1038,7 @@ bool MobyLCPSolver<T>::SolveLcpLemkeRegularized(const MatrixX<T>& M,
 
 template <typename T>
 MobyLCPSolver<T>::MobyLCPSolver()
-    : SolverBase(&id, &is_available, &is_enabled,
+    : SolverBase(id(), &is_available, &is_enabled,
                  &ProgramAttributesSatisfied) {}
 
 template <typename T>

--- a/solvers/mosek_solver_common.cc
+++ b/solvers/mosek_solver_common.cc
@@ -13,7 +13,7 @@ namespace drake {
 namespace solvers {
 
 MosekSolver::MosekSolver()
-    : SolverBase(&id, &is_available, &is_enabled, &ProgramAttributesSatisfied,
+    : SolverBase(id(), &is_available, &is_enabled, &ProgramAttributesSatisfied,
                  &UnsatisfiedProgramAttributes) {}
 
 MosekSolver::~MosekSolver() = default;

--- a/solvers/nlopt_solver_common.cc
+++ b/solvers/nlopt_solver_common.cc
@@ -9,7 +9,7 @@ namespace drake {
 namespace solvers {
 
 NloptSolver::NloptSolver()
-    : SolverBase(&id, &is_available, &is_enabled,
+    : SolverBase(id(), &is_available, &is_enabled,
                  &ProgramAttributesSatisfied) {}
 
 NloptSolver::~NloptSolver() = default;

--- a/solvers/osqp_solver_common.cc
+++ b/solvers/osqp_solver_common.cc
@@ -13,7 +13,7 @@ namespace drake {
 namespace solvers {
 
 OsqpSolver::OsqpSolver()
-    : SolverBase(&id, &is_available, &is_enabled, &ProgramAttributesSatisfied,
+    : SolverBase(id(), &is_available, &is_enabled, &ProgramAttributesSatisfied,
                  &UnsatisfiedProgramAttributes) {}
 
 OsqpSolver::~OsqpSolver() = default;

--- a/solvers/scs_solver_common.cc
+++ b/solvers/scs_solver_common.cc
@@ -10,7 +10,7 @@ namespace drake {
 namespace solvers {
 
 ScsSolver::ScsSolver()
-    : SolverBase(&id, &is_available, &is_enabled, &ProgramAttributesSatisfied,
+    : SolverBase(id(), &is_available, &is_enabled, &ProgramAttributesSatisfied,
                  &UnsatisfiedProgramAttributes) {}
 
 ScsSolver::~ScsSolver() = default;

--- a/solvers/snopt_solver_common.cc
+++ b/solvers/snopt_solver_common.cc
@@ -9,14 +9,13 @@ namespace drake {
 namespace solvers {
 
 SnoptSolver::SnoptSolver()
-    : SolverBase(&id, &is_available, &is_enabled,
+    : SolverBase(id(), &is_available, &is_enabled,
                  &ProgramAttributesSatisfied) {}
 
 SnoptSolver::~SnoptSolver() = default;
 
 SolverId SnoptSolver::id() {
-  static const never_destroyed<SolverId> singleton{
-      SnoptSolver::is_available() ? "SNOPT/fortran" : "SNOPT/unavailable"};
+  static const never_destroyed<SolverId> singleton{"SNOPT"};
   return singleton.access();
 }
 

--- a/solvers/solver_base.cc
+++ b/solvers/solver_base.cc
@@ -12,16 +12,25 @@ namespace drake {
 namespace solvers {
 
 SolverBase::SolverBase(
-    std::function<SolverId()> id,
-    std::function<bool()> available,
+    const SolverId& id, std::function<bool()> available,
     std::function<bool()> enabled,
     std::function<bool(const MathematicalProgram&)> are_satisfied,
     std::function<std::string(const MathematicalProgram&)> explain_unsatisfied)
-    : default_id_(std::move(id)),
+    : solver_id_(id),
       default_available_(std::move(available)),
       default_enabled_(std::move(enabled)),
       default_are_satisfied_(std::move(are_satisfied)),
       default_explain_unsatisfied_(std::move(explain_unsatisfied)) {}
+
+// Remove 2023-06-01 upon completion of deprecation.
+SolverBase::SolverBase(
+    std::function<SolverId()> id, std::function<bool()> available,
+    std::function<bool()> enabled,
+    std::function<bool(const MathematicalProgram&)> are_satisfied,
+    std::function<std::string(const MathematicalProgram&)> explain_unsatisfied)
+    : SolverBase((id != nullptr) ? id() : SolverId{"MISSING"},
+                 std::move(available), std::move(enabled),
+                 std::move(are_satisfied), std::move(explain_unsatisfied)) {}
 
 SolverBase::~SolverBase() = default;
 
@@ -93,9 +102,10 @@ bool SolverBase::enabled() const {
   return default_enabled_();
 }
 
+// On 2023-06-01 upon completion of deprecation, move this function definition
+// to the header file and change it from `override` to `final`.
 SolverId SolverBase::solver_id() const {
-  DRAKE_DEMAND(default_id_ != nullptr);
-  return default_id_();
+  return solver_id_;
 }
 
 bool SolverBase::AreProgramAttributesSatisfied(

--- a/solvers/solver_base.h
+++ b/solvers/solver_base.h
@@ -7,6 +7,7 @@
 #include <Eigen/Core>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/solution_result.h"
 #include "drake/solvers/solver_id.h"
@@ -16,15 +17,15 @@
 namespace drake {
 namespace solvers {
 
-/// Abstract base class used by implementations of individual solvers.
+/** Abstract base class used by implementations of individual solvers. */
 class SolverBase : public SolverInterface {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SolverBase)
 
   ~SolverBase() override;
 
-  /// Like SolverInterface::Solve(), but the result is a
-  /// return value instead of an output argument.
+  /** Like SolverInterface::Solve(), but the result is a return value instead of
+  an output argument. */
   MathematicalProgramResult Solve(
       const MathematicalProgram& prog,
       const std::optional<Eigen::VectorXd>& initial_guess = std::nullopt,
@@ -42,13 +43,22 @@ class SolverBase : public SolverInterface {
       const MathematicalProgram&) const override;
 
  protected:
-  /// Constructs a SolverBase with the given default implementations of the
-  /// solver_id(), available(), enabled(), AreProgramAttributesSatisfied(),
-  /// and ExplainUnsatisfiedProgramAttributes() methods.  Typically, the
-  /// subclass will simply pass the address of its static method, e.g. `&id`,
-  /// for these functors.)  Any of the functors can be nullptr, in which case
-  /// the subclass must override the matching virtual method instead, except
-  /// for `explain_unsatisfied` which already has a default implementation.
+  /** Constructs a SolverBase with the given default implementations of the
+  solver_id(), available(), enabled(), AreProgramAttributesSatisfied(), and
+  ExplainUnsatisfiedProgramAttributes() methods. Typically, the subclass will
+  simply pass the address of its static method, e.g., `&available`, for these
+  functors. Any of the functors can be nullptr, in which case the subclass must
+  override the matching virtual method instead, except for `explain_unsatisfied`
+  which already has a default implementation. */
+  SolverBase(
+      const SolverId& id,
+      std::function<bool()> available,
+      std::function<bool()> enabled,
+      std::function<bool(const MathematicalProgram&)> are_satisfied,
+      std::function<std::string(const MathematicalProgram&)>
+          explain_unsatisfied = nullptr);
+
+  DRAKE_DEPRECATED("2023-06-01", "Pass SolverId directly as the first argument")
   SolverBase(
       std::function<SolverId()> id,
       std::function<bool()> available,
@@ -57,12 +67,12 @@ class SolverBase : public SolverInterface {
       std::function<std::string(const MathematicalProgram&)>
           explain_unsatisfied = nullptr);
 
-  /// Hook for subclasses to implement Solve.  Prior to the SolverBase's call
-  /// to this method, the solver's availability and capabilities vs the program
-  /// attributes have already been checked, and the result's set_solver_id()
-  /// and set_decision_variable_index() have already been set. The options and
-  /// initial guess are already merged, i.e., the DoSolve implementation should
-  /// ignore prog's solver options and prog's initial guess.
+  /** Hook for subclasses to implement Solve. Prior to the SolverBase's call to
+  this method, the solver's availability and capabilities vs the program
+  attributes have already been checked, and the result's set_solver_id() and
+  set_decision_variable_index() have already been set. The options and initial
+  guess are already merged, i.e., the DoSolve implementation should ignore
+  prog's solver options and prog's initial guess. */
   virtual void DoSolve(
       const MathematicalProgram& prog,
       const Eigen::VectorXd& initial_guess,
@@ -70,7 +80,7 @@ class SolverBase : public SolverInterface {
       MathematicalProgramResult* result) const = 0;
 
  private:
-  std::function<SolverId()> default_id_;
+  SolverId solver_id_;
   std::function<bool()> default_available_;
   std::function<bool()> default_enabled_;
   std::function<bool(const MathematicalProgram&)> default_are_satisfied_;

--- a/solvers/solver_id.cc
+++ b/solvers/solver_id.cc
@@ -4,6 +4,7 @@
 #include <utility>
 
 #include "drake/common/never_destroyed.h"
+#include "drake/common/text_logging.h"
 
 namespace drake {
 namespace solvers {
@@ -19,7 +20,13 @@ int get_next_id() {
 }  // namespace
 
 SolverId::SolverId(std::string name)
-    : id_{get_next_id()}, name_{std::move(name)} {}
+    : id_{get_next_id()}, name_{std::move(name)} {
+  if (name_.length() > 15) {
+    static const logging::Warn log_once(
+        "The SolverId(name='{}') exceeds the recommended name length of 15.",
+        name_);
+  }
+}
 
 bool operator==(const SolverId& a, const SolverId& b) {
   return a.id_ == b.id_;

--- a/solvers/solver_id.h
+++ b/solvers/solver_id.h
@@ -12,25 +12,28 @@
 namespace drake {
 namespace solvers {
 
-/// Identifies a SolverInterface implementation.
-///
-/// A moved-from instance is guaranteed to be empty and will not compare equal
-/// to any non-empty ID.
+/** Identifies a SolverInterface implementation.
+
+A moved-from instance is guaranteed to be empty and will not compare equal to
+any non-empty ID. */
 class SolverId {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SolverId)
   ~SolverId() = default;
 
-  /// Constructs a specific, known solver type.  Internally, a hidden
-  /// identifier is allocated and assigned to this instance; all instances that
-  /// share an identifier (including copies of this instance) are considered
-  /// equal.  The solver names are not enforced to be unique, though we
-  /// recommend that they remain so in practice.
+  /** Constructs a specific, known solver type. Internally, a hidden integer is
+  allocated and assigned to this instance; all instances that share an integer
+  (including copies of this instance) are considered equal. The solver names are
+  not enforced to be unique, though we recommend that they remain so in
+  practice.
+
+  For best performance, choose a name that is 15 characters or less, so that it
+  fits within the libstdc++ "small string" optimization ("SSO"). */
   explicit SolverId(std::string name);
 
   const std::string& name() const { return name_; }
 
-  /// Implements the @ref hash_append concept.
+  /** Implements the @ref hash_append concept. */
   template <class HashAlgorithm>
   friend void hash_append(HashAlgorithm& hasher,
                           const SolverId& item) noexcept {

--- a/solvers/test/equality_constrained_qp_solver_test.cc
+++ b/solvers/test/equality_constrained_qp_solver_test.cc
@@ -394,7 +394,7 @@ TEST_F(EqualityConstrainedQPSolverTest, WrongSolverOptions1) {
   solver_options_.SetOption(solver_.solver_id(), "Foo", 0.1);
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
       solver_.Solve(prog_, {}, solver_options_, &result_),
-      "Foo is not allowed in the SolverOptions for Equality constrained QP.");
+      "Foo is not allowed in the SolverOptions for EqConstrainedQP.");
 }
 
 TEST_F(EqualityConstrainedQPSolverTest, WrongSolverOptions2) {

--- a/solvers/test/snopt_solver_test.cc
+++ b/solvers/test/snopt_solver_test.cc
@@ -92,9 +92,7 @@ GTEST_TEST(QPtest, TestUnitBallExample) {
 }
 
 GTEST_TEST(SnoptTest, NameTest) {
-  EXPECT_THAT(
-      SnoptSolver::id().name(),
-      testing::StartsWith("SNOPT/"));
+  EXPECT_EQ(SnoptSolver::id().name(), "SNOPT");
 }
 
 GTEST_TEST(SnoptTest, TestSetOption) {

--- a/solvers/test/solver_base_test.cc
+++ b/solvers/test/solver_base_test.cc
@@ -15,18 +15,23 @@ using ::testing::HasSubstr;
 // A stub subclass of SolverBase, so that we can instantiate and test it.
 class StubSolverBase final : public SolverBase {
  public:
+  // On 2023-06-01 upon completion of deprecation, remove this pragma and
+  // switch from &id to id() below.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(StubSolverBase)
   StubSolverBase() : SolverBase(
       &id,
       [this](){ return available_; },
       [this](){ return enabled_; },
       [this](const auto& prog){ return satisfied_; }) {}
+#pragma GCC diagnostic pop
 
   // This overload passes the explain_unsatisfied functor to the base class,
   // in contrast to the above constructor which leaves it defaulted.
   explicit StubSolverBase(std::string explanation)
     : SolverBase(
-        &id,
+        id(),
         [this](){ return available_; },
         [this](){ return enabled_; },
         [this](const auto& prog){ return satisfied_; },

--- a/solvers/test/solver_id_test.cc
+++ b/solvers/test/solver_id_test.cc
@@ -2,9 +2,13 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/limit_malloc.h"
+
 namespace drake {
 namespace solvers {
 namespace {
+
+using test::LimitMalloc;
 
 GTEST_TEST(SolverId, Equality) {
   // An ID is equal to itself.
@@ -38,6 +42,19 @@ GTEST_TEST(SolverId, Move) {
   EXPECT_EQ(old_bar.name(), "");
   EXPECT_EQ(new_bar.name(), "bar");
   EXPECT_NE(new_bar, old_bar);
+}
+
+GTEST_TEST(SolverId, NoHeap) {
+  // Solver names that are <= 15 characters do not allocate.
+  LimitMalloc guard;
+  SolverId foo{"123456789012345"};
+  SolverId bar(foo);
+}
+
+GTEST_TEST(SolverId, WarningForVeryLongName) {
+  // Solver names that are > 15 characters will warn.
+  // We'll just make sure nothing crashes.
+  SolverId foo{"this_solver_name_is_way_too_long"};
 }
 
 }  // namespace

--- a/solvers/unrevised_lemke_solver.cc
+++ b/solvers/unrevised_lemke_solver.cc
@@ -872,7 +872,7 @@ bool UnrevisedLemkeSolver<T>::SolveLcpLemke(const MatrixX<T>& M,
 
 template <typename T>
 UnrevisedLemkeSolver<T>::UnrevisedLemkeSolver()
-    : SolverBase(&id, &is_available, &is_enabled,
+    : SolverBase(id(), &is_available, &is_enabled,
                  &ProgramAttributesSatisfied) {}
 
 template <typename T>


### PR DESCRIPTION
The constructor with a `SolverId`-returning functor is now deprecated.

Fetching the `solver_id()` should be a zero-cost abstraction, which means the function must be final and inline, rather than a virtual function that makes another indirect call.

Add an API comment and runtime warning about `SolverId` pessimizations. The `SolverId` is supposed to be a integer-like flyweight that's cheap to pass by value, but when its name exceeds 15 characters (i.e., more than SSO can handle) then we were using heap when copying it (e.g., into the `SolverOptions` maps).

While we're updating comments anyway, upgrade them all to the preferred lightweight Doxygen style.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18880)
<!-- Reviewable:end -->
