### PR TITLE
[planning] Clean up of planning module documentation

### DIFF
--- a/multibody/inverse_kinematics/constraint_relaxing_ik.h
+++ b/multibody/inverse_kinematics/constraint_relaxing_ik.h
@@ -16,7 +16,7 @@ namespace multibody {
  * A wrapper class around the IK planner. This class improves IK's usability by
  * handling constraint relaxing and multiple initial guesses internally.
  *
- * @ingroup planning_configuration
+ * @ingroup planning_kinematics
  */
 class ConstraintRelaxingIk {
  public:

--- a/multibody/inverse_kinematics/differential_inverse_kinematics.h
+++ b/multibody/inverse_kinematics/differential_inverse_kinematics.h
@@ -337,7 +337,7 @@ class DifferentialInverseKinematicsParameters {
  * @return If the solver successfully finds a solution, joint_velocities will
  * be set to v, otherwise it will be nullopt.
  *
- * @ingroup planning_configuration
+ * @ingroup planning_kinematics
  */
 DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     const Eigen::Ref<const VectorX<double>>& q_current,
@@ -363,7 +363,7 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
  * @return If the solver successfully finds a solution, joint_velocities will
  * be set to v, otherwise it will be nullopt.
  *
- * @ingroup planning_configuration
+ * @ingroup planning_kinematics
  */
 DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     const MultibodyPlant<double>& robot,
@@ -388,7 +388,7 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
  * @return If the solver successfully finds a solution, joint_velocities will
  * be set to v, otherwise it will be nullopt.
  *
- * @ingroup planning_configuration
+ * @ingroup planning_kinematics
  */
 DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     const MultibodyPlant<double>& robot,

--- a/multibody/inverse_kinematics/global_inverse_kinematics.h
+++ b/multibody/inverse_kinematics/global_inverse_kinematics.h
@@ -23,7 +23,7 @@ namespace multibody {
  * Convex Optimization by Hongkai Dai, Gregory Izatt and Russ Tedrake,
  * International Journal of Robotics Research, 2019.
  *
- * @ingroup planning_configuration
+ * @ingroup planning_kinematics
  */
 class GlobalInverseKinematics {
  public:

--- a/multibody/inverse_kinematics/inverse_kinematics.h
+++ b/multibody/inverse_kinematics/inverse_kinematics.h
@@ -15,7 +15,7 @@ namespace multibody {
  * postures of the robot satisfying certain constraints.
  * The decision variables include the generalized position of the robot.
  *
- * @ingroup planning_configuration
+ * @ingroup planning_kinematics
  */
 class InverseKinematics {
  public:

--- a/multibody/optimization/static_equilibrium_problem.h
+++ b/multibody/optimization/static_equilibrium_problem.h
@@ -28,7 +28,7 @@ namespace multibody {
  *    distance.
  * 5. q within the joint limit.
  *
- * @ingroup planning_configuration
+ * @ingroup planning
  */
 class StaticEquilibriumProblem {
  public:

--- a/planning/planning_doxygen.h
+++ b/planning/planning_doxygen.h
@@ -7,18 +7,17 @@
    "MathematicalProgram" and the numerous @ref solver_evaluators.  There are
    also some useful classes in @ref manipulation_systems.
 
-   @defgroup planning_configuration
+   @defgroup planning_kinematics
    @defgroup planning_trajectory
    @defgroup planning_collision_checker
    @defgroup planning_infrastructure
  @}
 */
 
-/** @addtogroup planning_configuration Configurations
+/** @addtogroup planning_kinematics Inverse kinematics
  @{
-   These algorithms help define configurations of dynamical systems. While it
-   includes inverse kinematics (IK) algorithms, it also includes algorithms for
-   computing dynamically stable configurations.
+   These algorithms help define configurations of dynamical systems based on
+   inverse kinematics (IK).
  @}
 */
 


### PR DESCRIPTION
1. Rename configuration -> Inverse kinematics
2. Put the static equilibrium problem directly into planning (as it doesn't fit well with the other topics).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18883)
<!-- Reviewable:end -->
