### PR TITLE
Revert "[visualization] Meldis displays point cloud data"

### DIFF
--- a/bindings/pydrake/visualization/_meldis.py
+++ b/bindings/pydrake/visualization/_meldis.py
@@ -5,8 +5,6 @@ import time
 
 from drake import (
     lcmt_contact_results_for_viz,
-    lcmt_point_cloud,
-    lcmt_point_cloud_field,
     lcmt_viewer_draw,
     lcmt_viewer_geometry_data,
     lcmt_viewer_link_data,
@@ -42,11 +40,6 @@ from pydrake.multibody.meshcat import (
     _PointContactVisualizer,
     _PointContactVisualizerItem,
     ContactVisualizerParams,
-)
-from pydrake.perception import (
-    BaseField,
-    Fields,
-    PointCloud,
 )
 
 _logger = logging.getLogger("drake")
@@ -369,107 +362,6 @@ class _ContactApplet:
         self._hydro_helper.Update(viz_items)
 
 
-class _PointCloudApplet:
-    """Displays lcmt_point_cloud into MeshCat."""
-
-    _POINT_CLOUD_FIELDS = (
-        # (name, byte_offset, datatype, count)
-        ("x", 0, lcmt_point_cloud_field.FLOAT32, 1),
-        ("y", 4, lcmt_point_cloud_field.FLOAT32, 1),
-        ("z", 8, lcmt_point_cloud_field.FLOAT32, 1),
-        ("rgb", 12, lcmt_point_cloud_field.UINT32, 1),
-        ("normal_x", 16, lcmt_point_cloud_field.FLOAT32, 1),
-        ("normal_y", 20, lcmt_point_cloud_field.FLOAT32, 1),
-        ("normal_z", 24, lcmt_point_cloud_field.FLOAT32, 1),
-    )
-    """The supported fields and their data types of a point cloud. An XYZ,
-    XYZRGB, and XYZRGBNormal cloud will have the first three, first four, and
-    all the fields in this particular order.
-    """
-
-    def __init__(self, *, meshcat):
-        self._meshcat = meshcat
-        self._already_warned_channel_names = set()
-
-    def _validate_and_get_fields(self, message):
-        """Checks the point cloud LCM message and returns the corresponding
-        `Fields` for the PointCloud object. Either XYZ, XYZRGB, or XYZRGBNormal
-        cloud with the exact data type is supported.
-        """
-        if message.flags != lcmt_point_cloud.IS_STRICTLY_FINITE:
-            return None
-
-        if message.num_fields not in (3, 4, 7):
-            return None
-
-        for i in range(message.num_fields):
-            (name, byte_offset, datatype, count) = self._POINT_CLOUD_FIELDS[i]
-            if (
-                message.fields[i].name != name
-                or message.fields[i].byte_offset != byte_offset
-                or message.fields[i].datatype != datatype
-                or message.fields[i].count != count
-            ):
-                return None
-
-        if message.num_fields == 3:
-            return Fields(BaseField.kXYZs)
-        elif message.num_fields == 4:
-            return Fields(BaseField.kXYZs | BaseField.kRGBs)
-        else:
-            return Fields(
-                BaseField.kXYZs | BaseField.kRGBs | BaseField.kNormals
-            )
-
-    def _channel_to_meshcat_path(self, channel):
-        assert channel.startswith("DRAKE_POINT_CLOUD")
-        if channel == "DRAKE_POINT_CLOUD":
-            return "/POINT_CLOUD/default"
-        else:
-            # E.g., `DRAKE_POINT_CLOUD_FOO` => `/POINT_CLOUD/FOO`.
-            suffix = channel[len("DRAKE_POINT_CLOUD_"):]
-            return f"/POINT_CLOUD/{suffix}"
-
-    def on_point_cloud(self, channel, message):
-        """Handler for lcmt_point_cloud.
-
-        Validates and converts the lcmt_point_cloud message to a PointCloud
-        object for display.
-        """
-        cloud_fields = self._validate_and_get_fields(message)
-        if cloud_fields is None:
-            # Throttle warning messages to one per channel.
-            if channel not in self._already_warned_channel_names:
-                self._already_warned_channel_names.add(channel)
-                _logger.warn(f"Unsupported point cloud data from {channel}.")
-            return
-
-        # Transform the raw data into an N x num_fields array.
-        raw_data = np.frombuffer(message.data, dtype=np.float32).reshape(
-            -1, message.num_fields
-        )
-        num_points = raw_data.shape[0]
-
-        cloud = PointCloud(num_points, cloud_fields)
-        xyzs = raw_data[:, 0:3]
-        cloud.mutable_xyzs()[:] = xyzs.transpose()
-        if message.num_fields > 3:
-            rgbs_with_padding = (
-                raw_data[:, 3].astype(np.float32).view(np.uint8).reshape(-1, 4)
-            )
-            rgbs = rgbs_with_padding[:, 0:3]
-            cloud.mutable_rgbs()[:] = rgbs.transpose()
-        if message.num_fields > 4:
-            normals = raw_data[:, 4:]
-            cloud.mutable_normals()[:] = normals.transpose()
-
-        self._meshcat.SetObject(
-            path=self._channel_to_meshcat_path(channel),
-            cloud=cloud,
-            point_size=0.01
-        )
-
-
 class Meldis:
     """
     MeshCat LCM Display Server (MeLDiS)
@@ -545,12 +437,6 @@ class Meldis:
                         message_type=lcmt_contact_results_for_viz,
                         handler=contact.on_contact_results)
 
-        # Subscribe to all the point-cloud-related channels.
-        point_cloud = _PointCloudApplet(meshcat=self.meshcat)
-        self._subscribe_multichannel(regex="DRAKE_POINT_CLOUD.*",
-                                     message_type=lcmt_point_cloud,
-                                     handler=point_cloud.on_point_cloud)
-
         # Bookkeeping for automatic shutdown.
         self._last_poll = None
         self._last_active = None
@@ -564,12 +450,7 @@ class Meldis:
         # Record this channel's type and handler.
         assert self._message_types.get(channel, message_type) == message_type
         self._message_types[channel] = message_type
-
-        # A wrapper to discard `channel` information as it's not used in the
-        # actual handler.
-        def _multi_handler(*, channel, message):
-            handler(message)
-        self._message_handlers.setdefault(channel, []).append(_multi_handler)
+        self._message_handlers.setdefault(channel, []).append(handler)
 
         # Subscribe using an internal function that implements "last one wins".
         # It's important to service the LCM queue as frequently as possible:
@@ -583,18 +464,6 @@ class Meldis:
         def _on_message(data):
             self._message_pending_data[channel] = data
         self._lcm.Subscribe(channel=channel, handler=_on_message)
-
-    def _subscribe_multichannel(self, regex, message_type, handler):
-        """Subscribes the handler to a group of channels filtered by regex. How
-        this function handles messages is the same as _subscribe() except that
-        the channel name is only known when invoking the callback.
-        """
-        def _on_message(channel, data):
-            if channel not in self._message_types:
-                self._message_types[channel] = message_type
-                self._message_handlers.setdefault(channel, []).append(handler)
-            self._message_pending_data[channel] = data
-        self._lcm.SubscribeMultichannel(regex=regex, handler=_on_message)
 
     def _poll(self, handler):
         self._poll_handlers.append(handler)
@@ -610,8 +479,7 @@ class Meldis:
         for channel, data in self._message_pending_data.items():
             message = self._message_types[channel].decode(data)
             for function in self._message_handlers[channel]:
-                function(channel=channel, message=message)
-
+                function(message=message)
         self._message_pending_data.clear()
 
     def serve_forever(self, *, idle_timeout=None):

--- a/bindings/pydrake/visualization/test/meldis_test.py
+++ b/bindings/pydrake/visualization/test/meldis_test.py
@@ -13,20 +13,15 @@ You can also visualize the LCM test data like so:
 import pydrake.visualization as mut
 
 import functools
-import numpy as np
 import unittest
 
 from drake import (
-    lcmt_point_cloud,
     lcmt_viewer_geometry_data,
     lcmt_viewer_link_data,
 )
 
 from pydrake.common import (
     FindResourceOrThrow,
-)
-from pydrake.common.value import (
-    Value,
 )
 from pydrake.geometry import (
     DrakeVisualizer,
@@ -46,17 +41,8 @@ from pydrake.multibody.plant import (
 from pydrake.multibody.tree import (
     PrismaticJoint,
 )
-from pydrake.perception import (
-    BaseField,
-    Fields,
-    PointCloud,
-    PointCloudToLcm,
-)
 from pydrake.systems.framework import (
     DiagramBuilder,
-)
-from pydrake.systems.lcm import (
-    LcmPublisherSystem,
 )
 
 
@@ -72,56 +58,6 @@ class TestMeldis(unittest.TestCase):
                                      params=visualizer_params, lcm=lcm)
         diagram = builder.Build()
         return diagram
-
-    def _create_point_cloud(self, num_fields):
-        if num_fields == 3:
-            cloud_fields = Fields(BaseField.kXYZs)
-        elif num_fields == 4:
-            cloud_fields = Fields(BaseField.kXYZs | BaseField.kRGBs)
-        else:
-            assert num_fields == 7
-            cloud_fields = Fields(
-                BaseField.kXYZs | BaseField.kRGBs | BaseField.kNormals
-            )
-
-        num_points = 10
-        cloud = PointCloud(num_points, cloud_fields)
-        xyzs = np.random.uniform(-0.1, 0.1, (3, num_points))
-        cloud.mutable_xyzs()[:] = xyzs
-        if num_fields > 3:
-            rgbs = np.random.randint(0, 255, (3, num_points), dtype=np.uint8)
-            cloud.mutable_rgbs()[:] = rgbs
-        if num_fields > 4:
-            normals = np.random.uniform(-0.1, 0.1, (3, num_points))
-            cloud.mutable_normals()[:] = normals
-        return cloud
-
-    def _publish_lcm_point_cloud(self, lcm, channel, cloud):
-        """Given the complexity of the lcmt_point_cloud message format, the
-        easiest way to feed the DUT with a sample point cloud is to use
-        PointCloudToLcmSystem for the point cloud conversion and
-        LcmPublisherSystem to publish the LCM message onto the DUT's LCM bus.
-        """
-        builder = DiagramBuilder()
-        cloud_to_lcm = builder.AddSystem(PointCloudToLcm(frame_name="world"))
-        cloud_lcm_publisher = builder.AddSystem(
-            LcmPublisherSystem.Make(
-                channel=channel,
-                lcm_type=lcmt_point_cloud,
-                lcm=lcm,
-                publish_period=1.0,
-                use_cpp_serializer=True))
-        builder.Connect(
-            cloud_to_lcm.get_output_port(),
-            cloud_lcm_publisher.get_input_port())
-        diagram = builder.Build()
-
-        # Set input and publish the point cloud.
-        context = diagram.CreateDefaultContext()
-        cloud_context = cloud_to_lcm.GetMyContextFromRoot(context)
-        cloud_to_lcm.get_input_port().FixValue(
-            cloud_context, Value[PointCloud](cloud))
-        diagram.ForcedPublish(context)
 
     def test_viewer_applet(self):
         """Checks that _ViewerApplet doesn't crash when receiving messages.
@@ -389,25 +325,3 @@ class TestMeldis(unittest.TestCase):
 
         # After the handlers are called, we have the expected meshcat path.
         self.assertEqual(dut.meshcat.HasPath(meshcat_path), True)
-
-    def test_point_cloud(self):
-        """Check that _PointCloudApplet doesn't crash when receiving point
-        cloud messages.
-        """
-        # Create the device under test.
-        dut = mut.Meldis()
-
-        test_tuples = (
-           (3, "DRAKE_POINT_CLOUD", "/POINT_CLOUD/default"),
-           (4, "DRAKE_POINT_CLOUD_XYZRGB", "/POINT_CLOUD/XYZRGB"),
-           (7, "DRAKE_POINT_CLOUD_12345", "/POINT_CLOUD/12345"),
-        )
-        for num_fields, channel, meshcat_path in test_tuples:
-            with self.subTest(num_fields=num_fields):
-                self.assertEqual(dut.meshcat.HasPath(meshcat_path), False)
-                cloud = self._create_point_cloud(num_fields=num_fields)
-                self._publish_lcm_point_cloud(dut._lcm, channel, cloud)
-
-                dut._lcm.HandleSubscriptions(timeout_millis=1)
-                dut._invoke_subscriptions()
-                self.assertEqual(dut.meshcat.HasPath(meshcat_path), True)


### PR DESCRIPTION
Reverts RobotLocomotion/drake#18774

Dear @zachfang ,

 The on-call build cop, @svenevs, believes that your PR #18774 may have
 broken one or more of Drake's continuous integration builds [1]. It is
 possible to break a build even if your PR passed continuous integration
 pre-merge because additional platforms are tested post-merge.

 The specific build failures under investigation are:

- https://drake-jenkins.csail.mit.edu/job/mac-arm-monterey-clang-bazel-continuous-release/363/

```
[1:36:50 PM]  FAIL: //bindings/pydrake/visualization:py/meldis_test (see /Users/admin/workspace/mac-arm-monterey-clang-bazel-continuous-release/_bazel_admin/d8209b58b645930155068a99d03380e4/execroot/drake/bazel-out/darwin_arm64-opt/testlogs/bindings/pydrake/visualization/py/meldis_test/test.log)
[1:36:50 PM]  ==================== Test output for //bindings/pydrake/visualization:py/meldis_test:
[1:36:50 PM]  Matplotlib created a temporary config/cache directory at /var/folders/5x/39krnxc16vqfb0kbhp44y08c0000gn/T/matplotlib-fewx3933 because the default path (/Users/admin/.matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.
[1:36:50 PM]  Unit tests for MeLDiS.
[1:36:50 PM]  
[1:36:50 PM]  You can also visualize the LCM test data like so:
[1:36:50 PM]  
[1:36:50 PM]  1. In a separate terminal,
[1:36:50 PM]      bazel run //tools:meldis -- -w
[1:36:50 PM]  
[1:36:50 PM]  2. In another terminal, pass the name of a specific test to bazel. For example,
[1:36:50 PM]      bazel run //bindings/pydrake/visualization:py/meldis_test \
[1:36:50 PM]          TestMeldis.test_contact_applet_hydroelastic
[1:36:50 PM]  
[1:36:50 PM]  
[1:36:50 PM]  
[1:36:50 PM]  Running tests...
[1:36:50 PM]  ----------------------------------------------------------------------
[1:36:50 PM]  INFO:drake:Meshcat listening for connections at http://localhost:7000/
[1:36:50 PM]  .INFO:drake:Meldis is listening for LCM messages atINFO: From Testing //bindings/pydrake/visualization:py/meldis_test:
[1:36:50 PM]   memq://
[1:36:50 PM]  INFO:drake:Meshcat listening for connections at http://localhost:7001/
[1:36:50 PM]  .INFO:drake:Meldis is listening for LCM messages at memq://
[1:36:50 PM]  INFO:drake:Meshcat listening for connections at http://localhost:7002/
[1:36:50 PM]  .INFO:drake:Meldis is listening for LCM messages at memq://
[1:36:50 PM]  INFO:drake:Meshcat listening for connections at http://localhost:7003/
[1:36:50 PM]  WARNING:drake:Meldis cannot yet display hydroelastic collision meshes; that geometry will be ignored.
[1:36:50 PM]  .INFO:drake:Meldis is listening for LCM messages at memq://
[1:36:50 PM]  INFO:drake:Meshcat listening for connections at http://localhost:7004/
[1:36:50 PM]  .INFO:drake:Meldis is listening for LCM messages at memq://
[1:36:50 PM]  INFO:drake:Meshcat listening for connections at http://localhost:7005/
[1:36:50 PM]  .INFO:drake:Meldis is listening for LCM messages at memq://
[1:36:50 PM]  INFO:drake:Meshcat listening for connections at http://localhost:7006/
[1:36:50 PM]  FINFO:drake:Meldis is listening for LCM messages at memq://
[1:36:50 PM]  INFO:drake:Meshcat listening for connections at http://localhost:7007/
[1:36:50 PM]  .
[1:36:50 PM]  ======================================================================
[1:36:50 PM]  FAIL [0.055s]: test_viewer_applet_reload_optimization (meldis_test.TestMeldis.test_viewer_applet_reload_optimization)
[1:36:50 PM]  Checks that loading the identical scene twice is efficient.
[1:36:50 PM]  ----------------------------------------------------------------------
[1:36:50 PM]  Traceback (most recent call last):
[1:36:50 PM]    File "/Users/admin/workspace/mac-arm-monterey-clang-bazel-continuous-release/_bazel_admin/d8209b58b645930155068a99d03380e4/sandbox/darwin-sandbox/11985/execroot/drake/bazel-out/darwin_arm64-opt/bin/bindings/pydrake/visualization/py/meldis_test.runfiles/drake/bindings/pydrake/visualization/test/meldis_test.py", line 221, in test_viewer_applet_reload_optimization
[1:36:50 PM]      self.assertTrue(meshcat.HasPath(link_path))
[1:36:50 PM]  AssertionError: False is not true
[1:36:50 PM]  
[1:36:50 PM]  ----------------------------------------------------------------------
[1:36:50 PM]  Ran 8 tests in 0.282s
[1:36:50 PM]  
[1:36:50 PM]  FAILED (failures=1)
[1:36:50 PM]  
[1:36:50 PM]  Generating XML reports...
[1:36:50 PM]  ================================================================================
```

- [slack discussion](https://drakedevelopers.slack.com/archives/C270MN28G/p1677523550314859)

 Therefore, the build cop has created this revert PR and started a complete
 post-merge build to determine whether your PR was in fact the cause of the
 problem. If that build passes, this revert PR will be merged 60 minutes from
 now. You can then fix the problem at your leisure, and send a new PR to
 reinstate your change.

 If you believe your original PR did not actually break the build, please
 explain on this thread.

 If you believe you can fix the break promptly in lieu of a revert, please
 explain on this thread, and send a PR to the build cop for review ASAP.

 If you believe your original PR definitely did break the build and should be
 reverted, please review and LGTM this PR. This allows the build cop to merge
 without waiting for CI results.

 For advice on how to handle a build cop revert, see [2].

 Thanks!
 Your Friendly On-call Build Cop

 [1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
 [2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18885)
<!-- Reviewable:end -->
