### PR TITLE
[parsing] Relax single model test in SDFormat singular API

### DIFF
--- a/multibody/parsing/test/sdf_parser_test/table_in_world.sdf
+++ b/multibody/parsing/test/sdf_parser_test/table_in_world.sdf
@@ -1,0 +1,24 @@
+?xml version="1.0" ?>
+<sdf version="1.9">
+  <world name="table_world">
+    <model name="table">
+      <static>true</static>
+      <pose>0.0 0.0 -0.005 0 0 0</pose>
+      <link name="table_link">
+        <collision name="table_collision">
+          <geometry>
+            <box><size>1. 1. 0.001</size></box>
+          </geometry>
+        </collision>
+        <visual name="table_visual">
+          <geometry>
+            <box> <size>2. 2. 0.001</size> </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+          </material>
+        </visual>
+      </link>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
The SDFormat API has evolved since the original check was written. Work harder to tolerate single-model loading within the richer API.

Long term, we aim to drop single-model enforcing APIs altogether.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18888)
<!-- Reviewable:end -->
