### PR TITLE
[solvers] Fix a bug in GurobiSolver with duplicated variables in second-order cone constraints.

### DIFF
--- a/solvers/gurobi_solver.cc
+++ b/solvers/gurobi_solver.cc
@@ -490,6 +490,9 @@ int AddSecondOrderConeConstraints(
   DRAKE_ASSERT(second_order_cone_constraints.size() ==
                second_order_cone_new_variable_indices.size());
   int second_order_cone_count = 0;
+  int num_gurobi_vars;
+  int error = GRBgetintattr(model, "NumVars", &num_gurobi_vars);
+  DRAKE_ASSERT(!error);
   for (const auto& binding : second_order_cone_constraints) {
     const auto& A = binding.evaluator()->A();
     const auto& b = binding.evaluator()->b();
@@ -511,46 +514,28 @@ int AddSecondOrderConeConstraints(
     // z - A*x will be written as M * [x; z], where M = [-A I].
     // Gurobi expects M in compressed sparse row format, so we will first find
     // out the non-zero entries in each row of M.
-    // M_rows_col[i] stores the column index of non-zero entries in M.row(i)
-    std::vector<std::vector<int>> M_rows_col(num_z);
-    // M_rows_val[i] stores the value of non-zero entries in M.row(i).
-    std::vector<std::vector<double>> M_rows_val(num_z);
-    for (int i = 0; i < num_z; ++i) {
-      M_rows_val[i].reserve(num_x + 1);
-      M_rows_col[i].reserve(num_x + 1);
-    }
-    for (int i = 0; i < num_x; ++i) {
-      // The entries are from -A.
+    std::vector<Eigen::Triplet<double>> M_triplets;
+    M_triplets.reserve(A.nonZeros() + num_z);
+    for (int i = 0; i < A.outerSize(); ++i) {
       for (Eigen::SparseMatrix<double>::InnerIterator it(A, i); it; ++it) {
-        M_rows_col[it.row()].push_back(xz_indices[it.col()]);
-        M_rows_val[it.row()].push_back(-it.value());
+        M_triplets.emplace_back(it.row(), xz_indices[it.col()], -it.value());
       }
     }
     for (int i = 0; i < num_z; ++i) {
-      // The entries of identity matrix.
-      M_rows_col[i].push_back(xz_indices[num_x + i]);
-      M_rows_val[i].push_back(1.0);
+      M_triplets.emplace_back(i, xz_indices[num_x + i], 1);
     }
-    // M_val, M_beg, M_ind stores M in compressed sparse row format.
-    std::vector<double> M_val;
-    M_val.reserve(A.nonZeros() + num_z);
-    std::vector<int> M_beg(num_z + 1);
-    std::vector<int> M_ind;
-    M_ind.reserve(A.nonZeros() + num_z);
-    int M_nonzero_count = 0;
-    for (int i = 0; i < num_z; ++i) {
-      M_beg[i] = M_nonzero_count;
-      M_val.insert(M_val.end(), M_rows_val[i].begin(), M_rows_val[i].end());
-      M_ind.insert(M_ind.end(), M_rows_col[i].begin(), M_rows_col[i].end());
-      M_nonzero_count += static_cast<int>(M_rows_val[i].size());
-    }
-    M_beg[num_z] = M_nonzero_count;
+
+    Eigen::SparseMatrix<double, Eigen::RowMajor> M(num_z, num_gurobi_vars);
+    // Eigen::SparseMatrix::setFromTriplets will automatically group the sum of
+    // the values in M_triplets that correspond to the same entry in the sparse
+    // matrix.
+    M.setFromTriplets(M_triplets.begin(), M_triplets.end());
 
     std::vector<char> sense(num_z, GRB_EQUAL);
 
-    int error = GRBaddconstrs(model, num_z, M_nonzero_count, M_beg.data(),
-                              M_ind.data(), M_val.data(), sense.data(),
-                              const_cast<double*>(b.data()), nullptr);
+    error = GRBaddconstrs(model, num_z, M.nonZeros(), M.outerIndexPtr(),
+                          M.innerIndexPtr(), M.valuePtr(), sense.data(),
+                          const_cast<double*>(b.data()), nullptr);
     DRAKE_ASSERT(!error);
     *num_gurobi_linear_constraints += num_z;
 

--- a/solvers/test/csdp_solver_test.cc
+++ b/solvers/test/csdp_solver_test.cc
@@ -240,6 +240,18 @@ GTEST_TEST(TestSOCP, TestSocpDuplicatedVariable1) {
     }
   }
 }
+
+GTEST_TEST(TestSOCP, TestSocpDuplicatedVariable2) {
+  for (auto method : GetRemoveFreeVariableMethods()) {
+    CsdpSolver solver;
+    if (solver.available()) {
+      SolverOptions solver_options;
+      solver_options.SetOption(solver.id(), "drake::RemoveFreeVariableMethod",
+                               static_cast<int>(method));
+      TestSocpDuplicatedVariable2(solver, solver_options, 1E-6);
+    }
+  }
+}
 }  // namespace test
 
 namespace test {

--- a/solvers/test/gurobi_solver_test.cc
+++ b/solvers/test/gurobi_solver_test.cc
@@ -304,6 +304,11 @@ GTEST_TEST(TestSOCP, TestSocpDuplicatedVariable1) {
   TestSocpDuplicatedVariable1(solver, std::nullopt, 1E-6);
 }
 
+GTEST_TEST(TestSOCP, TestSocpDuplicatedVariable2) {
+  GurobiSolver solver;
+  TestSocpDuplicatedVariable2(solver, std::nullopt, 1E-6);
+}
+
 GTEST_TEST(GurobiTest, MultipleThreadsSharingEnvironment) {
   // Running multiple threads of GurobiSolver, they share the same GRBenv
   // which is created when acquiring the Gurobi license in the main function.
@@ -662,6 +667,13 @@ GTEST_TEST(GurobiTest, SOCPDualSolution2) {
     // price is 0.
     EXPECT_TRUE(CompareMatrices(result.GetDualSolution(constraint2),
                                 Vector1d(0), 1e-8));
+  }
+}
+
+GTEST_TEST(GurobiTest, TestDegenerateSOCP) {
+  GurobiSolver solver;
+  if (solver.is_available()) {
+    TestDegenerateSOCP(solver);
   }
 }
 

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -156,6 +156,11 @@ GTEST_TEST(TestSOCP, TestSocpDuplicatedVariable1) {
   TestSocpDuplicatedVariable1(solver, std::nullopt, 1E-6);
 }
 
+GTEST_TEST(TestSOCP, TestSocpDuplicatedVariable2) {
+  MosekSolver solver;
+  TestSocpDuplicatedVariable2(solver, std::nullopt, 1E-6);
+}
+
 GTEST_TEST(TestSemidefiniteProgram, TrivialSDP) {
   MosekSolver mosek_solver;
   if (mosek_solver.available()) {

--- a/solvers/test/scs_solver_test.cc
+++ b/solvers/test/scs_solver_test.cc
@@ -292,6 +292,11 @@ GTEST_TEST(TestSOCP, TestSocpDuplicatedVariable1) {
   TestSocpDuplicatedVariable1(solver, std::nullopt, 1E-6);
 }
 
+GTEST_TEST(TestSOCP, TestSocpDuplicatedVariable2) {
+  ScsSolver solver;
+  TestSocpDuplicatedVariable2(solver, std::nullopt, 1E-6);
+}
+
 TEST_P(QuadraticProgramTest, TestQP) {
   ScsSolver solver;
   if (solver.available()) {

--- a/solvers/test/second_order_cone_program_examples.cc
+++ b/solvers/test/second_order_cone_program_examples.cc
@@ -616,6 +616,62 @@ void TestSocpDuplicatedVariable1(
     EXPECT_NEAR(4 * x_sol(0) * x_sol(0) + 3 * x_sol(1) * x_sol(1), 1, tol);
   }
 }
+
+void TestSocpDuplicatedVariable2(
+    const SolverInterface& solver,
+    const std::optional<SolverOptions>& solver_options, double tol) {
+  MathematicalProgram prog;
+  // Intentionally create dummy variable to test that the constraint doesn't
+  // take all variables in `prog`.
+  auto dummy = prog.NewContinuousVariables<2>();
+  auto x = prog.NewContinuousVariables<2>();
+  // A * [x(0), x(1), x(0), x(1)] + b = [1; 2x(0); 3x(1)]
+  Eigen::Matrix<double, 3, 4> A;
+  // clang-format off
+  A << 1, 0, -1, 0,
+       3, 0, -1, 0,
+       2, 2, -2, 1;
+  // clang-format on
+  Eigen::Vector3d b(1, 0, 0);
+  prog.AddLorentzConeConstraint(A, b, {x, x});
+  prog.AddLinearCost(-x(0) - x(1));
+  if (solver.available()) {
+    MathematicalProgramResult result;
+    solver.Solve(prog, std::nullopt, solver_options, &result);
+    EXPECT_TRUE(result.is_success());
+    const auto x_sol = result.GetSolution(x);
+    // This expected solution is obtained by solving the equation
+    // 4x0²+9x1² = 1
+    // x0+x1= sqrt(13)/6
+    // where x0+x1=sqrt(13)/6 is obtained from the Jensen's inequality
+    // (4x0²+9x1²) * (1/4 + 1/9) >= (x0+x1)²
+    // Also by the fact
+    // (4x0²+9x1²) * (1/4 + 1/9) <= (1/4 + 1/9) = 13 / 36 = (sqrt(13)/6)²
+    // We obtain x + y <= sqrt(13)/6 and the bound is tight.
+    Eigen::Vector2d x_expected(3 * std::sqrt(13) / 26, 4 * std::sqrt(13) / 78);
+    EXPECT_TRUE(CompareMatrices(x_sol, x_expected, tol));
+  }
+}
+
+void TestDegenerateSOCP(const SolverInterface& solver) {
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<3>();
+
+  // A * [x(0), x(1), x(2), x(1), x(2)] = [x(0); x(1)-x(1); x(2)-x(2)]
+  Eigen::Matrix<double, 3, 5> A;
+  A.setZero();
+  A(0, 0) = 1;
+  A.block<2, 2>(1, 1) = Eigen::Matrix2d::Identity();
+  A.block<2, 2>(1, 3) = -Eigen::Matrix2d::Identity();
+  prog.AddLorentzConeConstraint(A, Eigen::Vector3d::Zero(), {x, x.tail<2>()});
+  if (solver.available()) {
+    MathematicalProgramResult result;
+    solver.Solve(prog, std::nullopt, std::nullopt, &result);
+    EXPECT_TRUE(result.is_success());
+    const auto x_sol = result.GetSolution(x);
+    EXPECT_GE(x_sol(0), 0);
+  }
+}
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/second_order_cone_program_examples.h
+++ b/solvers/test/second_order_cone_program_examples.h
@@ -348,6 +348,21 @@ void TestSocpDualSolution2(const SolverInterface& solver,
 void TestSocpDuplicatedVariable1(
     const SolverInterface& solver,
     const std::optional<SolverOptions>& solver_options, double tol);
+
+// We intentionally use duplicated variables in the second order cone constraint
+// to test if Drake's solver wrappers can handle duplicated variables.
+// min x0 + x1
+// s.t 4x0²+9x1² ≤ 1
+void TestSocpDuplicatedVariable2(
+    const SolverInterface& solver,
+    const std::optional<SolverOptions>& solver_options, double tol);
+
+// This SOCP is degenerate, in the sense it can be formulated as an LP.
+// find x
+// s.t x(0) >= sqrt( (x(1)-x(1))² + (x(2)-x(2))² )
+// We also intentionally impose it in a way to contain duplicated variables in
+// the LorentzConeConstraint.
+void TestDegenerateSOCP(const SolverInterface& solver);
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
Resolves #18882

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18890)
<!-- Reviewable:end -->
