### PR TITLE
[common] Deprecate SortedPair::operator<<

### DIFF
--- a/common/sorted_pair.h
+++ b/common/sorted_pair.h
@@ -6,6 +6,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/hash.h"
 #include "drake/common/is_less_than_comparable.h"
 
@@ -26,6 +27,9 @@ namespace drake {
 /// constructor, copy constructor, copy assignment, move constructor, move
 /// assignment) is the same as whatever T provides .  All comparison operations
 /// (including equality, etc.) are always available.
+///
+/// To format this class for logging, include `<fmt/ranges.h>` (exactly the same
+/// as for `std::pair`).
 ///
 /// @tparam T A template type that provides `operator<`.
 template <class T>
@@ -118,9 +122,12 @@ struct SortedPair {
   T second_{};         // The second of the two objects, according to operator<.
 };
 
-/// Support writing a SortedPair to a stream (conditional on the support of
-/// writing the underlying type T to a stream).
 template <typename T>
+DRAKE_DEPRECATED("2023-06-01",
+    "Use fmt or spdlog for logging, not operator<<. "
+    "Add an #include <fmt/ranges.h> to format SortedPair as a range."
+    "See https://github.com/RobotLocomotion/drake/issues/17742 for background.")
+// TODO(jwnimmer-tri) On 2023-06-01 also remove the <ostream> include.
 inline std::ostream& operator<<(std::ostream& out, const SortedPair<T>& pair) {
   out << "(" << pair.first() << ", " << pair.second() << ")";
   return out;

--- a/common/test/sorted_pair_test.cc
+++ b/common/test/sorted_pair_test.cc
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <fmt/ranges.h>
 #include <gtest/gtest.h>
 
 namespace drake {
@@ -139,13 +140,24 @@ GTEST_TEST(SortedPair, MakeSortedPair) {
   EXPECT_EQ(SortedPair<int>(1, 2), MakeSortedPair(1, 2));
 }
 
+// Tests that formatting support is reasonable.
+GTEST_TEST(SortedPair, Format) {
+  SortedPair<int> pair{8, 7};
+  // We don't care exactly what fmt does here, just that it looks sensible.
+  // It's OK to to update this goal string in case fmt changes a bit over time.
+  EXPECT_EQ(fmt::to_string(pair), "(7, 8)");
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // Tests the streaming support.
-GTEST_TEST(SortedPair, WriteToStream) {
+GTEST_TEST(SortedPair, DeprecatedWriteToStream) {
   SortedPair<int> pair{8, 7};
   std::stringstream ss;
   ss << pair;
   EXPECT_EQ(ss.str(), "(7, 8)");
 }
+#pragma GCC diagnostic pop
 
 GTEST_TEST(SortedPair, StructuredBinding) {
   SortedPair<int> pair{8, 7};


### PR DESCRIPTION
Towards #17742.

FYI https://fmt.dev/latest/api.html#ranges-api

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18892)
<!-- Reviewable:end -->
