### PR TITLE
Remove fmt::formatter of internal types from Doxygen

### DIFF
--- a/common/fmt_eigen.h
+++ b/common/fmt_eigen.h
@@ -57,6 +57,7 @@ internal::fmt_eigen_ref<Derived> fmt_eigen(
 
 }  // namespace drake
 
+#ifndef DRAKE_DOXYGEN_CXX
 // Formatter specialization for drake::fmt_eigen.
 namespace fmt {
 template <typename Derived>
@@ -83,3 +84,4 @@ struct formatter<drake::internal::fmt_eigen_ref<Derived>>
   }
 };
 }  // namespace fmt
+#endif

--- a/common/fmt_ostream.h
+++ b/common/fmt_ostream.h
@@ -51,6 +51,7 @@ struct ostream_formatter : fmt::formatter<std::string_view> {
 }  // namespace drake
 
 // Formatter specialization for drake::fmt_streamed.
+#ifndef DRAKE_DOXYGEN_CXX
 #if FMT_VERSION < 90000
 namespace fmt {
 template <typename T>
@@ -64,3 +65,4 @@ struct formatter<drake::internal::streamed_ref<T>> : drake::ostream_formatter {
 };
 }  // namespace fmt
 #endif  // FMT_VERSION
+#endif  // DRAKE_DOXYGEN_CXX

--- a/common/yaml/yaml_node.h
+++ b/common/yaml/yaml_node.h
@@ -246,9 +246,11 @@ class Node final {
 }  // namespace yaml
 }  // namespace drake
 
+#ifndef DRAKE_DOXYGEN_CXX
 // TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
 namespace fmt {
 template <>
 struct formatter<drake::yaml::internal::Node>
     : drake::ostream_formatter {};
 }  // namespace fmt
+#endif

--- a/geometry/geometry_ids.h
+++ b/geometry/geometry_ids.h
@@ -64,5 +64,5 @@ struct hash<drake::geometry::GeometryId> {
 namespace fmt {
 template <>
 struct formatter<drake::geometry::GeometryId>
-    : public formatter<drake::Identifier<drake::geometry::GeometryTag>> {};
+    : public fmt::formatter<drake::Identifier<drake::geometry::GeometryTag>> {};
 }  // namespace fmt

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -179,9 +179,11 @@ void AddCompliantHydroelasticPropertiesForHalfSpace(
 }  // namespace geometry
 }  // namespace drake
 
+#ifndef DRAKE_DOXYGEN_CXX
 // TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
 namespace fmt {
 template <>
 struct formatter<drake::geometry::internal::HydroelasticType>
     : drake::ostream_formatter {};
 }  // namespace fmt
+#endif


### PR DESCRIPTION
Also work around a Doxygen bug parsing the GeometryId formatter.

---

Towards https://github.com/RobotLocomotion/drake/issues/17742.

Examples of what's fixed in this PR:
- https://drake.mit.edu/doxygen_cxx/classformatter.html
- https://drake.mit.edu/doxygen_cxx/namespacefmt.html

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18894)
<!-- Reviewable:end -->
