### PR TITLE
[solvers] retrieve Mosek IPM solution if basis selection is disabled for LP

### DIFF
--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -207,7 +207,19 @@ void MosekSolver::DoSolve(const MathematicalProgram& prog,
              prog.positive_semidefinite_constraints().empty() &&
              prog.linear_matrix_inequality_constraints().empty() &&
              prog.exponential_cone_constraints().empty()) {
-    solution_type = MSK_SOL_BAS;
+    // The program is LP.
+    int ipm_basis{};
+    if (rescode == MSK_RES_OK) {
+      rescode = MSK_getintparam(impl.task(), MSK_IPAR_INTPNT_BASIS, &ipm_basis);
+    }
+    // By default ipm_basis > 0 and Mosek will do a basis identification to
+    // clean up the solution after the interior point method (IPM), then we can
+    // query the basis solution. Otherwise we will only query the IPM solution.
+    if (ipm_basis > 0) {
+      solution_type = MSK_SOL_BAS;
+    } else {
+      solution_type = MSK_SOL_ITR;
+    }
   } else {
     solution_type = MSK_SOL_ITR;
   }


### PR DESCRIPTION
Previously MosekSolver will still query the basis solution, which is not available from Mosek, causing errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18895)
<!-- Reviewable:end -->
