### PR TITLE
[visualization] Meldis displays point cloud data

### DIFF
--- a/bindings/pydrake/visualization/test/meldis_test.py
+++ b/bindings/pydrake/visualization/test/meldis_test.py
@@ -13,15 +13,20 @@ You can also visualize the LCM test data like so:
 import pydrake.visualization as mut
 
 import functools
+import numpy as np
 import unittest
 
 from drake import (
+    lcmt_point_cloud,
     lcmt_viewer_geometry_data,
     lcmt_viewer_link_data,
 )
 
 from pydrake.common import (
     FindResourceOrThrow,
+)
+from pydrake.common.value import (
+    Value,
 )
 from pydrake.geometry import (
     DrakeVisualizer,
@@ -41,8 +46,17 @@ from pydrake.multibody.plant import (
 from pydrake.multibody.tree import (
     PrismaticJoint,
 )
+from pydrake.perception import (
+    BaseField,
+    Fields,
+    PointCloud,
+    PointCloudToLcm,
+)
 from pydrake.systems.framework import (
     DiagramBuilder,
+)
+from pydrake.systems.lcm import (
+    LcmPublisherSystem,
 )
 
 
@@ -58,6 +72,56 @@ class TestMeldis(unittest.TestCase):
                                      params=visualizer_params, lcm=lcm)
         diagram = builder.Build()
         return diagram
+
+    def _create_point_cloud(self, num_fields):
+        if num_fields == 3:
+            cloud_fields = Fields(BaseField.kXYZs)
+        elif num_fields == 4:
+            cloud_fields = Fields(BaseField.kXYZs | BaseField.kRGBs)
+        else:
+            assert num_fields == 7
+            cloud_fields = Fields(
+                BaseField.kXYZs | BaseField.kRGBs | BaseField.kNormals
+            )
+
+        num_points = 10
+        cloud = PointCloud(num_points, cloud_fields)
+        xyzs = np.random.uniform(-0.1, 0.1, (3, num_points))
+        cloud.mutable_xyzs()[:] = xyzs
+        if num_fields > 3:
+            rgbs = np.random.randint(0, 255, (3, num_points), dtype=np.uint8)
+            cloud.mutable_rgbs()[:] = rgbs
+        if num_fields > 4:
+            normals = np.random.uniform(-0.1, 0.1, (3, num_points))
+            cloud.mutable_normals()[:] = normals
+        return cloud
+
+    def _publish_lcm_point_cloud(self, lcm, channel, cloud):
+        """Given the complexity of the lcmt_point_cloud message format, the
+        easiest way to feed the DUT with a sample point cloud is to use
+        PointCloudToLcmSystem for the point cloud conversion and
+        LcmPublisherSystem to publish the LCM message onto the DUT's LCM bus.
+        """
+        builder = DiagramBuilder()
+        cloud_to_lcm = builder.AddSystem(PointCloudToLcm(frame_name="world"))
+        cloud_lcm_publisher = builder.AddSystem(
+            LcmPublisherSystem.Make(
+                channel=channel,
+                lcm_type=lcmt_point_cloud,
+                lcm=lcm,
+                publish_period=1.0,
+                use_cpp_serializer=True))
+        builder.Connect(
+            cloud_to_lcm.get_output_port(),
+            cloud_lcm_publisher.get_input_port())
+        diagram = builder.Build()
+
+        # Set input and publish the point cloud.
+        context = diagram.CreateDefaultContext()
+        cloud_context = cloud_to_lcm.GetMyContextFromRoot(context)
+        cloud_to_lcm.get_input_port().FixValue(
+            cloud_context, Value[PointCloud](cloud))
+        diagram.ForcedPublish(context)
 
     def test_viewer_applet(self):
         """Checks that _ViewerApplet doesn't crash when receiving messages.
@@ -165,7 +229,7 @@ class TestMeldis(unittest.TestCase):
             self.assertTrue(meshcat.HasPath(link_path))
 
     def test_hydroelastic_geometry(self):
-        """Check that _ViewerApplet doesn't crash when receiving
+        """Checks that _ViewerApplet doesn't crash when receiving
         hydroelastic geometry.
         """
         dut = mut.Meldis()
@@ -183,7 +247,7 @@ class TestMeldis(unittest.TestCase):
         dut._invoke_subscriptions()
 
     def test_contact_applet_point_pair(self):
-        """Check that _ContactApplet doesn't crash when receiving point
+        """Checks that _ContactApplet doesn't crash when receiving point
            contact messages.
         """
         # Create the device under test.
@@ -226,7 +290,7 @@ class TestMeldis(unittest.TestCase):
         self.assertEqual(meshcat.HasPath(pair_path), True)
 
     def test_contact_applet_hydroelastic(self):
-        """Check that _ContactApplet doesn't crash when receiving hydroelastic
+        """Checks that _ContactApplet doesn't crash when receiving hydroelastic
            messages.
         """
         # Create the device under test.
@@ -276,7 +340,7 @@ class TestMeldis(unittest.TestCase):
         self.assertEqual(meshcat.HasPath(hydro_path2), True)
 
     def test_deformable(self):
-        """Check that _ViewerApplet doesn't crash for deformable geometries
+        """Checks that _ViewerApplet doesn't crash for deformable geometries
         in DRAKE_VIEWER_DEFORMABLE channel.
         """
 
@@ -325,3 +389,25 @@ class TestMeldis(unittest.TestCase):
 
         # After the handlers are called, we have the expected meshcat path.
         self.assertEqual(dut.meshcat.HasPath(meshcat_path), True)
+
+    def test_point_cloud(self):
+        """Checks that _PointCloudApplet doesn't crash when receiving point
+        cloud messages.
+        """
+        # Create the device under test.
+        dut = mut.Meldis()
+
+        test_tuples = (
+           (3, "DRAKE_POINT_CLOUD", "/POINT_CLOUD/default"),
+           (4, "DRAKE_POINT_CLOUD_XYZRGB", "/POINT_CLOUD/XYZRGB"),
+           (7, "DRAKE_POINT_CLOUD_12345", "/POINT_CLOUD/12345"),
+        )
+        for num_fields, channel, meshcat_path in test_tuples:
+            with self.subTest(num_fields=num_fields):
+                self.assertEqual(dut.meshcat.HasPath(meshcat_path), False)
+                cloud = self._create_point_cloud(num_fields=num_fields)
+                self._publish_lcm_point_cloud(dut._lcm, channel, cloud)
+
+                dut._lcm.HandleSubscriptions(timeout_millis=1)
+                dut._invoke_subscriptions()
+                self.assertEqual(dut.meshcat.HasPath(meshcat_path), True)


### PR DESCRIPTION
This PR is a re-apply of a previous commit, #18774, with a fix for a unit test.

Investigation:
EDIT: The root cause is the indeterministic order of `FrameId` when constructing `lcmt_viewer_load_robot` messages. The test depends on two LCM messages to be encoded exactly the same to pass its test objectives.

~~I haven't fully grasped what the root cause is, but one of the LCM message comparisons behaves differently due to the order of a field, i.e., `lcmt_viewer_load_robot.link`.~~ This is an example from: https://github.com/RobotLocomotion/drake/blob/master/bindings/pydrake/visualization/_meldis.py#L102
```
(message.encode() == self._load_message.encode()) yields `false` when it should be `true`.

b'\x89\x87 \x9b\x10\xaa-9\x00\x00\x00\x02\x00\x00\x00\x16plant::acrobot::Link1\x00\x00\x00\x00\x02\x00\x00\x00\x02\x03\x00\x00\x00\x00\x00\x00\x00\x00\xbf\x00\x00\x00?\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00?\x80\x00\x00\x00\x00\x00\x00?\x80\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x02=L\xcc\xcd?\x8c\xcc\xcd\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00?\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00?\x80\x00\x00?\x80\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x01>\x00\x00\x00\x00\x00\x00\x16plant::acrobot::Link2\x00\x00\x00\x00\x02\x00\x00\x00\x01\x03\x00\x00\x00\x00\x00\x00\x00\x00\xbf\x80\x00\x00?\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00?\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00?\x80\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x02=L\xcc\xcd@\x06ff'
vs.
b'\x89\x87 \x9b\x10\xaa-9\x00\x00\x00\x02\x00\x00\x00\x16plant::acrobot::Link2\x00\x00\x00\x00\x02\x00\x00\x00\x01\x03\x00\x00\x00\x00\x00\x00\x00\x00\xbf\x80\x00\x00?\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00?\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00?\x80\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x02=L\xcc\xcd@\x06ff\x00\x00\x00\x16plant::acrobot::Link1\x00\x00\x00\x00\x02\x00\x00\x00\x02\x03\x00\x00\x00\x00\x00\x00\x00\x00\xbf\x00\x00\x00?\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00?\x80\x00\x00\x00\x00\x00\x00?\x80\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x02=L\xcc\xcd?\x8c\xcc\xcd\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00?\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00?\x80\x00\x00?\x80\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x01>\x00\x00\x00'
```

Oddly, if I comment out some of the point cloud tests, the order will then be the same, and it seems persistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18896)
<!-- Reviewable:end -->
