### PR TITLE
[geometry] Eliminate unnecessary heap allocation in Geometry_properties

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -706,6 +706,7 @@ drake_cc_googletest(
     deps = [
         ":geometry_properties",
         "//common/test_utilities",
+        "//common/test_utilities:limit_malloc",
     ],
 )
 

--- a/geometry/geometry_properties.h
+++ b/geometry/geometry_properties.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <string_view>
 #include <typeinfo>
 #include <unordered_map>
 
@@ -469,7 +470,7 @@ class GeometryProperties {
   // that is easily traceable to this class.
   template <typename ValueType>
   static const ValueType& GetValueOrThrow(
-      const std::string& method, const std::string& group_name,
+      std::string_view method, const std::string& group_name,
       const std::string& name, const AbstractValue& abstract,
       const std::type_info& requested_type = typeid(ValueType)) {
     const ValueType* value = abstract.maybe_get_value<ValueType>();


### PR DESCRIPTION
The private method GetValueOrThrow would take the name of the calling function in the event of failure so it could be included in the error message. However, that method name was being captured as a const std::string&. Going from string literal to string requires a copy of the string (and a concomitant heap allocation).

By replacing string with string_view, we eliminate the copy.

Closes #18897

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18899)
<!-- Reviewable:end -->
