### PR TITLE
[geometry] SceneGraphInspector provides ordering guarantees on reported ids

### DIFF
--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -229,6 +229,16 @@ GeometryState<T>::GeometryState(const GeometryState<U>& source)
     }
   }
 }
+template <typename T>
+std::vector<GeometryId> GeometryState<T>::GetAllGeometryIds() const {
+  std::vector<GeometryId> ids;
+  ids.reserve(geometries_.size());
+  for (const auto& id_geometry_pair : geometries_) {
+    ids.push_back(id_geometry_pair.first);
+  }
+  std::sort(ids.begin(), ids.end());
+  return ids;
+}
 
 template <typename T>
 unordered_set<GeometryId> GeometryState<T>::GetGeometryIds(
@@ -598,12 +608,12 @@ bool GeometryState<T>::IsDeformableGeometry(GeometryId id) const {
 
 template <typename T>
 std::vector<GeometryId> GeometryState<T>::GetAllDeformableGeometryIds() const {
-  std::vector<GeometryId> deformable_geometries;
+  std::vector<GeometryId> ids;
   for (const auto& it : source_deformable_geometry_id_map_) {
-    deformable_geometries.insert(
-        deformable_geometries.end(), it.second.begin(), it.second.end());
+    ids.insert(ids.end(), it.second.begin(), it.second.end());
   }
-  return deformable_geometries;
+  std::sort(ids.begin(), ids.end());
+  return ids;
 }
 
 template <typename T>

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -161,14 +161,7 @@ class GeometryState {
   }
 
   /** Implementation of SceneGraphInspector::GetAllGeometryIds().  */
-  std::vector<GeometryId> GetAllGeometryIds() const {
-    std::vector<GeometryId> ids;
-    ids.reserve(geometries_.size());
-    for (const auto& id_geometry_pair : geometries_) {
-      ids.push_back(id_geometry_pair.first);
-    }
-    return ids;
-  }
+  std::vector<GeometryId> GetAllGeometryIds() const;
 
   /** Implementation of SceneGraphInspector::GetGeometryIds().  */
   std::unordered_set<GeometryId> GetGeometryIds(

--- a/geometry/scene_graph_inspector.cc
+++ b/geometry/scene_graph_inspector.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/scene_graph_inspector.h"
 
+#include <algorithm>
 #include <memory>
 
 #include "drake/geometry/geometry_state.h"
@@ -23,7 +24,9 @@ template <typename T>
 std::vector<FrameId> SceneGraphInspector<T>::GetAllFrameIds() const {
   DRAKE_DEMAND(state_ != nullptr);
   typename GeometryState<T>::FrameIdRange range = state_->get_frame_ids();
-  return std::vector<FrameId>(range.begin(), range.end());
+  std::vector<FrameId> frame_ids(range.begin(), range.end());
+  std::sort(frame_ids.begin(), frame_ids.end());
+  return frame_ids;
 }
 
 template <typename T>
@@ -33,8 +36,7 @@ int SceneGraphInspector<T>::num_geometries() const {
 }
 
 template <typename T>
-const std::vector<GeometryId> SceneGraphInspector<T>::GetAllGeometryIds()
-    const {
+std::vector<GeometryId> SceneGraphInspector<T>::GetAllGeometryIds() const {
   DRAKE_DEMAND(state_ != nullptr);
   return state_->GetAllGeometryIds();
 }

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -87,10 +87,9 @@ class SceneGraphInspector {
    (including the world frame).  */
   int num_frames() const;
 
-  /** Returns all of the frame ids in the scene graph. The order is not
-   guaranteed; but it will be consistent across invocations as long as there are
-   no changes to the topology. The ids includes the world frame's id.  */
-  typename std::vector<FrameId> GetAllFrameIds() const;
+  /** Returns all of the frame ids in the scene graph. The order is guaranteed
+   to be stable and consistent. The ids include the world frame's id.  */
+  std::vector<FrameId> GetAllFrameIds() const;
 
   /** Reports the id for the world frame.  */
   FrameId world_frame_id() const {
@@ -101,11 +100,9 @@ class SceneGraphInspector {
   /** Reports the _total_ number of geometries in the scene graph.  */
   int num_geometries() const;
 
-  /** Returns the set of all ids for registered geometries. The order is _not_
-   guaranteed to have any particular meaning. But the order is
-   guaranteed to remain fixed until a topological change is made (e.g., removal
-   or addition of geometry/frames).  */
-  const std::vector<GeometryId> GetAllGeometryIds() const;
+  /** Returns the set of all ids for registered geometries. The order is
+   guaranteed to be stable and consistent.  */
+  std::vector<GeometryId> GetAllGeometryIds() const;
 
   /** Returns the geometry ids that are *implied* by the given GeometrySet and
    `role`. Remember that a GeometrySet can reference a FrameId in place of the
@@ -231,6 +228,7 @@ class SceneGraphInspector {
   /** Returns geometry ids that have been registered directly to the frame
    indicated by `frame_id`. If a `role` is provided, only geometries with that
    role assigned will be returned, otherwise all geometries will be returned.
+   The order of the ids is guaranteed to be stable and consistent.
    @param frame_id    The id of the frame in question.
    @param role  The requested role; if omitted, all geometries registered to the
                 frame are returned.
@@ -408,7 +406,8 @@ class SceneGraphInspector {
            geometry.  */
   bool IsDeformableGeometry(GeometryId geometry_id) const;
 
-  /** Returns all geometry ids that correspond to deformable geometries. */
+  /** Returns all geometry ids that correspond to deformable geometries. The
+   order is guaranteed to be stable and consistent.  */
   std::vector<GeometryId> GetAllDeformableGeometryIds() const;
 
   /** Reports true if the two geometries with given ids `geometry_id1` and

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -132,7 +132,7 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
 }
 
 // Generally, SceneGraphInspector is a thin wrapper for invoking methods on
-// GeometryState. SceneGraphInspector::GetAllFrameIds() is an exception, it does
+// GeometryState. SceneGraphInspector::GetAllFrameIds() is an exception; it does
 // transformation work and, as such, needs to be functionally tested.
 GTEST_TEST(SceneGraphInspector, AllFrameIds) {
   SceneGraphInspectorTester tester;
@@ -142,7 +142,9 @@ GTEST_TEST(SceneGraphInspector, AllFrameIds) {
   // Always includes the world frame.
   ASSERT_EQ(tester.inspector().GetAllFrameIds().size(), 1);
 
-  // Add a number of frames.
+  // Add a number of frames (in addition to the world frame which is always
+  // included).
+  const FrameId world_id = internal::InternalFrame::world_frame_id();
   const FrameId frame_id_1 =
       tester.mutable_state().RegisterFrame(source_id, GeometryFrame("frame1"));
   const FrameId frame_id_2 =
@@ -150,12 +152,15 @@ GTEST_TEST(SceneGraphInspector, AllFrameIds) {
   const FrameId frame_id_3 =
       tester.mutable_state().RegisterFrame(source_id, GeometryFrame("frame3"));
 
-  const std::vector<FrameId> all_frames = tester.inspector().GetAllFrameIds();
-  EXPECT_EQ(std::count(all_frames.begin(), all_frames.end(), frame_id_1), 1);
-  EXPECT_EQ(std::count(all_frames.begin(), all_frames.end(), frame_id_2), 1);
-  EXPECT_EQ(std::count(all_frames.begin(), all_frames.end(), frame_id_3), 1);
-}
+  // We expect the results to be nicely, consistently ordered.
+  std::vector<FrameId> expected_ids{frame_id_1, frame_id_2, frame_id_3,
+                                    world_id};
+  std::sort(expected_ids.begin(), expected_ids.end());
 
+  const std::vector<FrameId> all_frames = tester.inspector().GetAllFrameIds();
+  // Same contents and same order.
+  EXPECT_EQ(all_frames, expected_ids);
+}
 
 }  // namespace
 }  // namespace geometry


### PR DESCRIPTION
SceneGraphInspector has four methods that return collections of ids (frame and geometry). Previously, only one of those guaranteed ordering on the ids. This brings the other three in line.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18903)
<!-- Reviewable:end -->
