### PR TITLE
ModelVisualizer: re-pose joints by name

### DIFF
--- a/bindings/pydrake/visualization/model_visualizer.py
+++ b/bindings/pydrake/visualization/model_visualizer.py
@@ -115,7 +115,7 @@ def _main():
                                   browser_new=args.browser_new,
                                   pyplot=args.pyplot)
 
-    package_map = visualizer.parser().package_map()
+    package_map = visualizer.package_map()
     package_map.PopulateFromRosPackagePath()
 
     # Resolve the filename if necessary.


### PR DESCRIPTION
Makes the reload feature of ModelVisualizer more robust by setting joint positions in the reloaded model to the values of joints with the same names, rather than requiring an exact match of the number of joints before and after.

Also fixes docstrings relating to accessing the visualizer's parser, and warns the user if the reload option is invoked when the parser was accessed directly. Also adds a package map accessor method so that the main script doesn't need to access the parser method in order to get to the package map.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18910)
<!-- Reviewable:end -->
