### PR TITLE
Touchup Diagram tutorial formatting for Deepnote

### DIFF
--- a/tutorials/working_with_diagrams.ipynb
+++ b/tutorials/working_with_diagrams.ipynb
@@ -212,16 +212,12 @@
     "More interesting is the subsystem `Context`s. You should understand that a diagram's `Context` is just an organized collection of the subsystem's `Context`s. You can access those subsystem `Context`s directly, most often using [`GetMyContextFromRoot()`](https://drake.mit.edu/doxygen_cxx/classdrake_1_1systems_1_1_system.html#ae7fa91d2b2102457ced3361207724e52). Note that since diagrams can be subsystems in other diagrams, this method will recurse through the potentially nested diagram to recover the correct sub-`Context`.\n",
     "\n",
     "In this example, the `Context`s are nested just like the diagram:\n",
-    "<ul style=\"list-style:none\">\n",
-    "<li>PID-controlled Pendulum (with θ shifted by π) Context (of a Diagram)</li>\n",
-    "  <ul style=\"list-style:none\">\n",
-    "    <li>↳ PID-controlled Pendulum Context (of a Diagram)</li>\n",
-    "    <ul style=\"list-style:none\">\n",
-    "      <li>↳ pendulum Context</li>\n",
-    "      <li>↳ controller Context</li>\n",
-    "    </ul>\n",
-    "  </ul>\n",
-    "</ul>"
+    "```\n",
+    "  PID-controlled Pendulum (with θ shifted by π) Context (of a Diagram)\n",
+    "    ↳ PID-controlled Pendulum Context (of a Diagram)\n",
+    "        ↳ pendulum Context\n",
+    "        ↳ controller Context\n",
+    "```"
    ]
   },
   {


### PR DESCRIPTION
The original <ul> approach to documenting the nested context led to comical amounts of whitespace. This one looks better.

I touched this up while uploading the new tutorial to our Deeepnote: https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/notebook/working_with_diagrams-294befd7b7fe44e496e2522d0706eaba already has this change.

+@jwnimmer-tri for both reviews, please.
