### PR TITLE
[install] Add and use drake_models/package.xml

### DIFF
--- a/bindings/pydrake/multibody/test/parsing_test.py
+++ b/bindings/pydrake/multibody/test/parsing_test.py
@@ -40,7 +40,7 @@ class TestParsing(unittest.TestCase):
     def test_package_map(self):
         # Simple coverage test for constructors.
         dut = PackageMap()
-        self.assertEqual(dut.size(), 1)
+        self.assertEqual(dut.size(), 2)
         PackageMap(other=dut)
         copy.copy(dut)
 

--- a/bindings/pydrake/visualization/test/visualization_install_tests.py
+++ b/bindings/pydrake/visualization/test/visualization_install_tests.py
@@ -7,7 +7,7 @@ import install_test_helper
 
 class TestVisualizationInstalled(unittest.TestCase):
 
-    def test_meldis(self):
+    def test_meldis_help(self):
         """Ensures we can call `./bin/meldis --help` from install."""
         # Get install directory.
         install_dir = install_test_helper.get_install_dir()
@@ -17,7 +17,7 @@ class TestVisualizationInstalled(unittest.TestCase):
         text = install_test_helper.check_output([bin_path, "--help"])
         self.assertIn("usage: meldis ", text)
 
-    def test_model_visualizer(self):
+    def test_model_visualizer_help(self):
         """Ensures we can call `./bin/model_visualizer --help` from install."""
         # Get install directory.
         install_dir = install_test_helper.get_install_dir()
@@ -26,6 +26,18 @@ class TestVisualizationInstalled(unittest.TestCase):
         bin_path = join(install_dir, "bin", "model_visualizer")
         text = install_test_helper.check_output([bin_path, "--help"])
         self.assertIn("usage: model_visualizer ", text)
+
+    def test_drake_models_meshes(self):
+        """Ensures that the package://drake_models/... can be found by testing
+        a model that uses a meshfile from that location.
+        """
+        install_dir = install_test_helper.get_install_dir()
+        install_test_helper.check_call([
+            join(install_dir, "bin", "model_visualizer"),
+            "--loop_once",
+            "package://drake_models/"
+            "wsg_50_description/meshes/finger_without_tip.obj"
+        ])
 
 
 if __name__ == '__main__':

--- a/examples/hydroelastic/spatula_slip_control/BUILD.bazel
+++ b/examples/hydroelastic/spatula_slip_control/BUILD.bazel
@@ -11,24 +11,26 @@ load(
     "wsg_50_hydro_bubble_mesh_files",
 )
 
-_WSG_50_HYDRO_BUBBLE_MESHES = forward_files(
-    srcs = ["@models_internal//:" +
-            x for x in wsg_50_hydro_bubble_mesh_files()],
-    dest_prefix = "",
-    strip_prefix = "@models_internal//:wsg_50_hydro_bubble/",
-    visibility = ["//visibility:private"],
-)
-
 models_filegroup(
-    name = "models",
-    extra_srcs = _WSG_50_HYDRO_BUBBLE_MESHES,
+    name = "glob_models",
     glob_exclude = ["images/**/*"],
-    visibility = ["//visibility:public"],
+    visibility = ["//visibility:private"],
 )
 
 install_data(
     name = "install_data",
-    data = [":models"],
+    data = [":glob_models"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "models",
+    srcs = [
+        ":glob_models",
+    ] + [
+        "@models_internal//:" + x
+        for x in wsg_50_hydro_bubble_mesh_files()
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/examples/hydroelastic/spatula_slip_control/models/schunk_wsg_50_hydro_bubble.sdf
+++ b/examples/hydroelastic/spatula_slip_control/models/schunk_wsg_50_hydro_bubble.sdf
@@ -33,7 +33,7 @@
         <pose>0 0 -0.036 -1.5708 0 -1.5708</pose>
         <geometry>
           <mesh>
-            <uri>package://drake/manipulation/models/wsg_50_description/meshes/wsg_body.obj</uri>
+            <uri>package://drake_models/wsg_50_description/meshes/wsg_body.obj</uri>
             <scale>1 1 1</scale>
           </mesh>
         </geometry>
@@ -70,7 +70,7 @@
         <pose>0 0.0 0 1.5708 0 3.14159</pose>
         <geometry>
           <mesh>
-            <uri>package://drake/examples/hydroelastic/spatula_slip_control/meshes/bubble_finger.obj</uri>
+            <uri>package://drake_models/wsg_50_hydro_bubble/meshes/bubble_finger.obj</uri>
             <scale>.001 .001 .001</scale>
           </mesh>
         </geometry>
@@ -80,7 +80,7 @@
         <pose>0 -0.03 -0.1095 0 1.5708 -1.5708</pose>
         <geometry>
           <mesh>
-            <uri>package://drake/examples/hydroelastic/spatula_slip_control/meshes/ellipsoid_bubble_geometry.obj</uri>
+            <uri>package://drake_models/wsg_50_hydro_bubble/meshes/ellipsoid_bubble_geometry.obj</uri>
             <scale>.001 .001 .001</scale>
           </mesh>
         </geometry>
@@ -144,7 +144,7 @@
         <pose>0 0 0 1.5708 0 0</pose>
         <geometry>
           <mesh>
-            <uri>package://drake/examples/hydroelastic/spatula_slip_control/meshes/bubble_finger.obj</uri>
+            <uri>package://drake_models/wsg_50_hydro_bubble/meshes/bubble_finger.obj</uri>
             <scale>.001 .001 .001</scale>
           </mesh>
         </geometry>
@@ -154,7 +154,7 @@
         <pose>0 0.03 -0.1095 0 1.5708 1.5708</pose>
         <geometry>
           <mesh>
-            <uri>package://drake/examples/hydroelastic/spatula_slip_control/meshes/ellipsoid_bubble_geometry.obj</uri>
+            <uri>package://drake_models/wsg_50_hydro_bubble/meshes/ellipsoid_bubble_geometry.obj</uri>
             <scale>.001 .001 .001</scale>
           </mesh>
         </geometry>

--- a/examples/quadrotor/BUILD.bazel
+++ b/examples/quadrotor/BUILD.bazel
@@ -9,26 +9,28 @@ load(
 load("//tools/skylark:drake_data.bzl", "models_filegroup")
 load("//tools/install:install_data.bzl", "install_data")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/workspace:forward_files.bzl", "forward_files")
 load("//tools/workspace/models_internal:files.bzl", "skydio_2_mesh_files")
 
 package(default_visibility = ["//visibility:public"])
 
-_SKYDIO_2_MESHES = forward_files(
-    srcs = ["@models_internal//:" + x for x in skydio_2_mesh_files()],
-    dest_prefix = "",
-    strip_prefix = "@models_internal//:skydio_2/",
-    visibility = ["//visibility:private"],
-)
-
 models_filegroup(
-    name = "models",
-    extra_srcs = _SKYDIO_2_MESHES,
+    name = "glob_models",
+    visibility = ["//visibility:private"],
 )
 
 install_data(
     name = "install_data",
-    data = [":models"],
+    data = [":glob_models"],
+)
+
+filegroup(
+    name = "models",
+    srcs = [
+        ":glob_models",
+    ] + [
+        "@models_internal//:" + x
+        for x in skydio_2_mesh_files()
+    ],
 )
 
 drake_cc_library(

--- a/examples/quadrotor/quadrotor.urdf
+++ b/examples/quadrotor/quadrotor.urdf
@@ -18,7 +18,7 @@
     <visual>
       <origin rpy="1.570796 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://drake/examples/quadrotor/skydio_2_1000_poly.obj" scale=".00254"/>
+        <mesh filename="package://drake_models/skydio_2/skydio_2_1000_poly.obj" scale=".00254"/>
       </geometry>
     </visual>
     <collision>

--- a/manipulation/models/franka_description/BUILD.bazel
+++ b/manipulation/models/franka_description/BUILD.bazel
@@ -7,7 +7,6 @@ load(
 load("//tools/skylark:drake_data.bzl", "models_filegroup")
 load("//tools/install:install_data.bzl", "install_data")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("@drake//tools/workspace:forward_files.bzl", "forward_files")
 load(
     "//tools/workspace/models_internal:files.bzl",
     "franka_description_mesh_files",
@@ -15,27 +14,28 @@ load(
 
 package(default_visibility = ["//visibility:public"])
 
-_FRANKA_DESCRIPTION_MESHES = forward_files(
-    srcs = [
-        "@models_internal//:" + x
-        for x in franka_description_mesh_files()
-    ],
-    dest_prefix = "",
-    strip_prefix = "@models_internal//:franka_description/",
-    visibility = ["//visibility:private"],
-)
-
 models_filegroup(
-    name = "models",
-    extra_srcs = _FRANKA_DESCRIPTION_MESHES + [
+    name = "glob_models",
+    extra_srcs = [
         "LICENSE.TXT",
         "README.md",
     ],
+    visibility = ["//visibility:private"],
 )
 
 install_data(
     name = "install_data",
-    data = [":models"],
+    data = [":glob_models"],
+)
+
+filegroup(
+    name = "models",
+    srcs = [
+        ":glob_models",
+    ] + [
+        "@models_internal//:" + x
+        for x in franka_description_mesh_files()
+    ],
 )
 
 # === test/ ===

--- a/manipulation/models/franka_description/urdf/hand.urdf
+++ b/manipulation/models/franka_description/urdf/hand.urdf
@@ -13,7 +13,7 @@
     <visual>
       <origin rpy="1.57079632679 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/hand.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/hand.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -50,7 +50,7 @@
     <visual>
       <origin rpy="1.57079632679 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/finger.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/finger.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -75,7 +75,7 @@
     <visual>
       <origin rpy="1.57079632679 0 3.14159265359" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/finger.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/finger.obj"/>
       </geometry>
     </visual>
     <collision>

--- a/manipulation/models/franka_description/urdf/panda_arm.urdf
+++ b/manipulation/models/franka_description/urdf/panda_arm.urdf
@@ -13,7 +13,7 @@
     <visual>
       <origin rpy="1.57079632679 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/link0.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/link0.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -110,7 +110,7 @@
     <visual>
       <origin rpy="1.57079632679 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/link1.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/link1.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -166,7 +166,7 @@
     <visual>
       <origin rpy="1.57079632679 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/link2.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/link2.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -222,7 +222,7 @@
     <visual>
       <origin rpy="1.57079632679 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/link3.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/link3.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -272,7 +272,7 @@
     <visual>
       <origin rpy="1.57079632679 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/link4.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/link4.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -334,7 +334,7 @@
     <visual>
       <origin rpy="1.57079632679 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/link5.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/link5.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -426,7 +426,7 @@
     <visual>
       <origin rpy="1.57079632679 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/link6.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/link6.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -476,7 +476,7 @@
     <visual>
       <origin rpy="1.57079632679 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/link7.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/link7.obj"/>
       </geometry>
     </visual>
     <collision>

--- a/manipulation/models/franka_description/urdf/panda_arm_hand.urdf
+++ b/manipulation/models/franka_description/urdf/panda_arm_hand.urdf
@@ -13,7 +13,7 @@
     <visual>
       <origin rpy="1.57079632679 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/link0.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/link0.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -110,7 +110,7 @@
     <visual>
       <origin rpy="1.57079632679 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/link1.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/link1.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -166,7 +166,7 @@
     <visual>
       <origin rpy="1.57079632679 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/link2.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/link2.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -222,7 +222,7 @@
     <visual>
       <origin rpy="1.57079632679 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/link3.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/link3.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -272,7 +272,7 @@
     <visual>
       <origin rpy="1.57079632679 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/link4.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/link4.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -334,7 +334,7 @@
     <visual>
       <origin rpy="1.57079632679 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/link5.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/link5.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -426,7 +426,7 @@
     <visual>
       <origin rpy="1.57079632679 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/link6.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/link6.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -476,7 +476,7 @@
     <visual>
       <origin rpy="1.57079632679 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/link7.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/link7.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -596,7 +596,7 @@
     <visual>
       <origin rpy="1.57079632679 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/hand.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/hand.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -633,7 +633,7 @@
     <visual>
       <origin rpy="1.57079632679 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/finger.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/finger.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -658,7 +658,7 @@
     <visual>
       <origin rpy="1.57079632679 0 3.14159265359" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/franka_description/meshes/visual/finger.obj"/>
+        <mesh filename="package://drake_models/franka_description/meshes/visual/finger.obj"/>
       </geometry>
     </visual>
     <collision>

--- a/manipulation/models/jaco_description/BUILD.bazel
+++ b/manipulation/models/jaco_description/BUILD.bazel
@@ -7,7 +7,6 @@ load(
 load("//tools/skylark:drake_data.bzl", "models_filegroup")
 load("//tools/install:install_data.bzl", "install_data")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("@drake//tools/workspace:forward_files.bzl", "forward_files")
 load(
     "//tools/workspace/models_internal:files.bzl",
     "jaco_description_mesh_files",
@@ -15,25 +14,29 @@ load(
 
 package(default_visibility = [":__subpackages__"])
 
-_JACO_DESCRIPTION_MESHES = forward_files(
-    srcs = ["@models_internal//:" + x for x in jaco_description_mesh_files()],
-    dest_prefix = "",
-    strip_prefix = "@models_internal//:jaco_description/",
-    visibility = ["//visibility:private"],
-)
-
 models_filegroup(
-    name = "models",
-    extra_srcs = _JACO_DESCRIPTION_MESHES + [
+    name = "glob_models",
+    extra_srcs = [
         "LICENSE.TXT",
         "README.md",
     ],
-    visibility = ["//visibility:public"],
+    visibility = ["//visibility:private"],
 )
 
 install_data(
     name = "install_data",
-    data = [":models"],
+    data = [":glob_models"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "models",
+    srcs = [
+        ":glob_models",
+    ] + [
+        "@models_internal//:" + x
+        for x in jaco_description_mesh_files()
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/manipulation/models/jaco_description/urdf/j2n6s300.urdf
+++ b/manipulation/models/jaco_description/urdf/j2n6s300.urdf
@@ -51,7 +51,7 @@
   <link name="j2n6s300_link_base">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/base.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/base.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -80,7 +80,7 @@
   <link name="j2n6s300_link_1">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/shoulder.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/shoulder.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -88,7 +88,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -126,7 +126,7 @@
   <link name="j2n6s300_link_2">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/arm.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -134,7 +134,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -172,7 +172,7 @@
   <link name="j2n6s300_link_3">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/forearm.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/forearm.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -180,7 +180,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -218,7 +218,7 @@
   <link name="j2n6s300_link_4">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/wrist.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -226,7 +226,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -264,7 +264,7 @@
   <link name="j2n6s300_link_5">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/wrist.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -272,7 +272,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -309,7 +309,7 @@
   <link name="j2n6s300_link_6">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/hand_3finger.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/hand_3finger.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -317,7 +317,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -363,7 +363,7 @@
   <link name="j2n6s300_link_finger_1">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -400,7 +400,7 @@
   <link name="j2n6s300_link_finger_tip_1">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -427,7 +427,7 @@
   <link name="j2n6s300_link_finger_2">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -464,7 +464,7 @@
   <link name="j2n6s300_link_finger_tip_2">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -491,7 +491,7 @@
   <link name="j2n6s300_link_finger_3">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -528,7 +528,7 @@
   <link name="j2n6s300_link_finger_tip_3">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>

--- a/manipulation/models/jaco_description/urdf/j2s7s300.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300.urdf
@@ -25,7 +25,7 @@
   <link name="j2s7s300_link_base">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/base.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/base.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -33,7 +33,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/base.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/base.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -53,7 +53,7 @@
   <link name="j2s7s300_link_1">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/shoulder.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/shoulder.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -61,7 +61,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -69,7 +69,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/shoulder.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/shoulder.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -102,7 +102,7 @@
   <link name="j2s7s300_link_2">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm_half_1.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/arm_half_1.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -110,7 +110,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -118,7 +118,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm_half_1.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/arm_half_1.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -147,7 +147,7 @@
   <link name="j2s7s300_link_3">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm_half_2.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/arm_half_2.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -155,7 +155,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -163,7 +163,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm_half_2.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/arm_half_2.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -192,7 +192,7 @@
   <link name="j2s7s300_link_4">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/forearm.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/forearm.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -200,7 +200,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -208,7 +208,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/forearm.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/forearm.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -237,7 +237,7 @@
   <link name="j2s7s300_link_5">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist_spherical_1.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/wrist_spherical_1.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -245,7 +245,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -253,7 +253,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist_spherical_1.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/wrist_spherical_1.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -282,7 +282,7 @@
   <link name="j2s7s300_link_6">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist_spherical_2.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/wrist_spherical_2.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -290,7 +290,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -298,7 +298,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist_spherical_2.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/wrist_spherical_2.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -327,7 +327,7 @@
   <link name="j2s7s300_link_7">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/hand_3finger.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/hand_3finger.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -335,7 +335,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -343,7 +343,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/hand_3finger.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/hand_3finger.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -391,7 +391,7 @@
   <link name="j2s7s300_link_finger_1">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -399,7 +399,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -428,7 +428,7 @@
   <link name="j2s7s300_link_finger_tip_1">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -436,7 +436,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -455,7 +455,7 @@
   <link name="j2s7s300_link_finger_2">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -463,7 +463,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -492,7 +492,7 @@
   <link name="j2s7s300_link_finger_tip_2">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -500,7 +500,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -519,7 +519,7 @@
   <link name="j2s7s300_link_finger_3">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -527,7 +527,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -556,7 +556,7 @@
   <link name="j2s7s300_link_finger_tip_3">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -564,7 +564,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
     </collision>
     <inertial>

--- a/manipulation/models/jaco_description/urdf/j2s7s300_arm.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300_arm.urdf
@@ -25,7 +25,7 @@
   <link name="j2s7s300_link_base">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/base.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/base.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -33,7 +33,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/base.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/base.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -53,7 +53,7 @@
   <link name="j2s7s300_link_1">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/shoulder.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/shoulder.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -61,7 +61,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -69,7 +69,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/shoulder.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/shoulder.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -102,7 +102,7 @@
   <link name="j2s7s300_link_2">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm_half_1.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/arm_half_1.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -110,7 +110,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -118,7 +118,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm_half_1.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/arm_half_1.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -147,7 +147,7 @@
   <link name="j2s7s300_link_3">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm_half_2.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/arm_half_2.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -155,7 +155,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -163,7 +163,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm_half_2.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/arm_half_2.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -192,7 +192,7 @@
   <link name="j2s7s300_link_4">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/forearm.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/forearm.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -200,7 +200,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -208,7 +208,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/forearm.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/forearm.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -237,7 +237,7 @@
   <link name="j2s7s300_link_5">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist_spherical_1.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/wrist_spherical_1.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -245,7 +245,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -253,7 +253,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist_spherical_1.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/wrist_spherical_1.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -282,7 +282,7 @@
   <link name="j2s7s300_link_6">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist_spherical_2.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/wrist_spherical_2.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -290,7 +290,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -298,7 +298,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist_spherical_2.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/wrist_spherical_2.obj"/>
       </geometry>
     </collision>
     <inertial>

--- a/manipulation/models/jaco_description/urdf/j2s7s300_arm_sphere_collision.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300_arm_sphere_collision.urdf
@@ -25,7 +25,7 @@
   <link name="j2s7s300_link_base">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/base.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/base.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -78,7 +78,7 @@
   <link name="j2s7s300_link_1">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/shoulder.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/shoulder.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -86,7 +86,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -164,7 +164,7 @@
   <link name="j2s7s300_link_2">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm_half_1.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/arm_half_1.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -172,7 +172,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -264,7 +264,7 @@
   <link name="j2s7s300_link_3">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm_half_2.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/arm_half_2.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -272,7 +272,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -370,7 +370,7 @@
   <link name="j2s7s300_link_4">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/forearm.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/forearm.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -378,7 +378,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -482,7 +482,7 @@
   <link name="j2s7s300_link_5">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist_spherical_1.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/wrist_spherical_1.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -490,7 +490,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -540,7 +540,7 @@
   <link name="j2s7s300_link_6">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist_spherical_2.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/wrist_spherical_2.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -548,7 +548,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>

--- a/manipulation/models/jaco_description/urdf/j2s7s300_hand.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300_hand.urdf
@@ -8,7 +8,7 @@
   <link name="hand_base">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/hand_3finger.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/hand_3finger.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -16,7 +16,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -24,7 +24,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/hand_3finger.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/hand_3finger.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -55,7 +55,7 @@
   <link name="j2s7s300_link_finger_1">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -63,7 +63,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -92,7 +92,7 @@
   <link name="j2s7s300_link_finger_tip_1">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -100,7 +100,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -119,7 +119,7 @@
   <link name="j2s7s300_link_finger_2">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -127,7 +127,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -156,7 +156,7 @@
   <link name="j2s7s300_link_finger_tip_2">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -164,7 +164,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -183,7 +183,7 @@
   <link name="j2s7s300_link_finger_3">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -191,7 +191,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
     </collision>
     <inertial>
@@ -220,7 +220,7 @@
   <link name="j2s7s300_link_finger_tip_3">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -228,7 +228,7 @@
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
     </collision>
     <inertial>

--- a/manipulation/models/jaco_description/urdf/j2s7s300_hand_sphere_collision.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300_hand_sphere_collision.urdf
@@ -8,7 +8,7 @@
   <link name="hand_base">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/hand_3finger.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/hand_3finger.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -16,7 +16,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -98,7 +98,7 @@
   <link name="j2s7s300_link_finger_1">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -154,7 +154,7 @@
   <link name="j2s7s300_link_finger_tip_1">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -206,7 +206,7 @@
   <link name="j2s7s300_link_finger_2">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -262,7 +262,7 @@
   <link name="j2s7s300_link_finger_tip_2">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -314,7 +314,7 @@
   <link name="j2s7s300_link_finger_3">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -370,7 +370,7 @@
   <link name="j2s7s300_link_finger_tip_3">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>

--- a/manipulation/models/jaco_description/urdf/j2s7s300_sphere_collision.urdf
+++ b/manipulation/models/jaco_description/urdf/j2s7s300_sphere_collision.urdf
@@ -25,7 +25,7 @@
   <link name="j2s7s300_link_base">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/base.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/base.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -78,7 +78,7 @@
   <link name="j2s7s300_link_1">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/shoulder.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/shoulder.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -86,7 +86,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -164,7 +164,7 @@
   <link name="j2s7s300_link_2">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm_half_1.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/arm_half_1.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -172,7 +172,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -264,7 +264,7 @@
   <link name="j2s7s300_link_3">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/arm_half_2.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/arm_half_2.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -272,7 +272,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_big.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_big.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -370,7 +370,7 @@
   <link name="j2s7s300_link_4">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/forearm.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/forearm.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -378,7 +378,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -482,7 +482,7 @@
   <link name="j2s7s300_link_5">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist_spherical_1.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/wrist_spherical_1.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -490,7 +490,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -540,7 +540,7 @@
   <link name="j2s7s300_link_6">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/wrist_spherical_2.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/wrist_spherical_2.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -548,7 +548,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -598,7 +598,7 @@
   <link name="j2s7s300_link_7">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/hand_3finger.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/hand_3finger.obj"/>
       </geometry>
       <material>
         <color rgba="0.1788232 0.1788232 0.1788232 1"/>
@@ -606,7 +606,7 @@
     </visual>
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/ring_small.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/ring_small.obj"/>
       </geometry>
       <material>
         <color rgba="0.627451 0.627451 0.627451 1"/>
@@ -705,7 +705,7 @@
   <link name="j2s7s300_link_finger_1">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -761,7 +761,7 @@
   <link name="j2s7s300_link_finger_tip_1">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -813,7 +813,7 @@
   <link name="j2s7s300_link_finger_2">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -869,7 +869,7 @@
   <link name="j2s7s300_link_finger_tip_2">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -921,7 +921,7 @@
   <link name="j2s7s300_link_finger_3">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_proximal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_proximal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>
@@ -977,7 +977,7 @@
   <link name="j2s7s300_link_finger_tip_3">
     <visual>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/jaco_description/meshes/finger_distal.obj"/>
+        <mesh filename="package://drake_models/jaco_description/meshes/finger_distal.obj"/>
       </geometry>
       <material>
         <color rgba="0.5960783 0.5960783 0.5960783 1"/>

--- a/manipulation/models/realsense2_description/BUILD.bazel
+++ b/manipulation/models/realsense2_description/BUILD.bazel
@@ -14,6 +14,7 @@ load(
 
 package(default_visibility = ["//visibility:public"])
 
+# TODO(jwnimmer-tri) Convert this into drake_models somehow or another.
 _REALSENSE2_DESCRIPTION_FILES = forward_files(
     srcs = ["@intel_realsense_ros_internal//:" +
             x for x in realsense2_description_files()],

--- a/manipulation/models/tri_homecart/BUILD.bazel
+++ b/manipulation/models/tri_homecart/BUILD.bazel
@@ -8,7 +8,6 @@ load("//tools/skylark:drake_data.bzl", "models_filegroup")
 load("//tools/install:install_data.bzl", "install_data")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load("@drake//tools/workspace/ros_xacro_internal:defs.bzl", "xacro_file")
-load("@drake//tools/workspace:forward_files.bzl", "forward_files")
 load("//tools/workspace/models_internal:files.bzl", "tri_homecart_mesh_files")
 
 package(default_visibility = ["//visibility:public"])
@@ -23,27 +22,31 @@ xacro_file(
     src = "homecart_cutting_board.sdf.xacro",
 )
 
-_TRI_HOMECART_MESHES = forward_files(
-    srcs = ["@models_internal//:" + x for x in tri_homecart_mesh_files()],
-    dest_prefix = "",
-    strip_prefix = "@models_internal//:tri_homecart/",
-    visibility = ["//visibility:private"],
-)
-
 models_filegroup(
-    name = "models",
+    name = "glob_models",
     extra_srcs = [
         "homecart_bimanual.urdf",
         "homecart_cutting_board.sdf",
         "homecart_grippers.dmd.yaml",
         "homecart_no_grippers.dmd.yaml",
         "homecart.dmd.yaml",
-    ] + _TRI_HOMECART_MESHES,
+    ],
+    visibility = ["//visibility:private"],
 )
 
 install_data(
     name = "install_data",
-    data = [":models"],
+    data = [":glob_models"],
+)
+
+filegroup(
+    name = "models",
+    srcs = [
+        ":glob_models",
+    ] + [
+        "@models_internal//:" + x
+        for x in tri_homecart_mesh_files()
+    ],
 )
 
 # === test/ ===

--- a/manipulation/models/tri_homecart/homecart_bimanual.urdf.xacro
+++ b/manipulation/models/tri_homecart/homecart_bimanual.urdf.xacro
@@ -46,7 +46,7 @@
         <origin xyz="0 0 ${(num_plates-1)*arm_mount_stack_plate_height}"
                 rpy="0 0 0"/>
         <geometry>
-          <mesh filename="package://drake/manipulation/models/tri_homecart/homecart_arm_mount_stack.obj"/>
+          <mesh filename="package://drake_models/tri_homecart/homecart_arm_mount_stack.obj"/>
         </geometry>
       </visual>
       <xacro:if value="${num_plates>1}">
@@ -57,7 +57,7 @@
       <visual>
         <origin xyz="0 0 0.0" rpy="0 0 0"/>
         <geometry>
-          <mesh filename="package://drake/manipulation/models/tri_homecart/homecart_arm_mount_cantilever.obj"/>
+          <mesh filename="package://drake_models/tri_homecart/homecart_arm_mount_cantilever.obj"/>
         </geometry>
       </visual>
       <collision>
@@ -147,7 +147,7 @@
     <visual>
       <origin xyz="0 0 0.0" rpy="0 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/tri_homecart/homecart_baseplate.obj"/>
+        <mesh filename="package://drake_models/tri_homecart/homecart_baseplate.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -172,7 +172,7 @@
     <visual>
       <origin xyz="0 0 0.0" rpy="0 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/tri_homecart/homecart_basecart.obj"/>
+        <mesh filename="package://drake_models/tri_homecart/homecart_basecart.obj"/>
       </geometry>
     </visual>
     <collision>
@@ -224,7 +224,7 @@
     <visual>
     <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
-        <mesh filename="package://drake/manipulation/models/tri_homecart/homecart_bimanual_upper_structure.obj"/>
+        <mesh filename="package://drake_models/tri_homecart/homecart_bimanual_upper_structure.obj"/>
       </geometry>
     </visual>
 

--- a/manipulation/models/tri_homecart/homecart_cutting_board.sdf.xacro
+++ b/manipulation/models/tri_homecart/homecart_cutting_board.sdf.xacro
@@ -37,7 +37,7 @@
         <pose>0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
-            <uri>homecart_cutting_board.obj</uri>
+            <uri>package://drake_models/tri_homecart/homecart_cutting_board.obj</uri>
             <scale>1.0 1.0 1.0</scale>
           </mesh>
         </geometry>

--- a/manipulation/models/ur3e/BUILD.bazel
+++ b/manipulation/models/ur3e/BUILD.bazel
@@ -7,7 +7,6 @@ load(
 load("//tools/install:install_data.bzl", "install_data")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load("@drake//tools/workspace/ros_xacro_internal:defs.bzl", "xacro_file")
-load("@drake//tools/workspace:forward_files.bzl", "forward_files")
 load("//tools/workspace/models_internal:files.bzl", "ur3e_mesh_files")
 
 package(default_visibility = ["//visibility:public"])
@@ -30,24 +29,28 @@ xacro_file(
     ],
 )
 
-_UR3E_MESHES = forward_files(
-    srcs = ["@models_internal//:" + x for x in ur3e_mesh_files()],
-    dest_prefix = "",
-    strip_prefix = "@models_internal//:ur3e/",
-    visibility = ["//visibility:private"],
-)
-
 filegroup(
-    name = "models",
-    srcs = _UR3E_MESHES + [
-        "ur3e_spheres_collision.urdf",
+    name = "glob_models",
+    srcs = [
         "ur3e_cylinders_collision.urdf",
+        "ur3e_spheres_collision.urdf",
     ],
+    visibility = ["//visibility:private"],
 )
 
 install_data(
     name = "install_data",
-    data = [":models"],
+    data = [":glob_models"],
+)
+
+filegroup(
+    name = "models",
+    srcs = [
+        ":glob_models",
+    ] + [
+        "@models_internal//:" + x
+        for x in ur3e_mesh_files()
+    ],
 )
 
 # === test/ ===

--- a/manipulation/models/ur3e/ur3e.urdf.xacro
+++ b/manipulation/models/ur3e/ur3e.urdf.xacro
@@ -82,7 +82,7 @@
       <visual>
         <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
         <geometry>
-          <mesh filename="base.obj"/>
+          <mesh filename="package://drake_models/ur3e/base.obj"/>
         </geometry>
         <material name="LightGrey">
           <color rgba="0.7 0.7 0.7 1.0"/>
@@ -161,7 +161,7 @@
       <visual>
         <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
         <geometry>
-          <mesh filename="shoulder.obj"/>
+          <mesh filename="package://drake_models/ur3e/shoulder.obj"/>
         </geometry>
         <material name="LightGrey">
           <color rgba="0.7 0.7 0.7 1.0"/>
@@ -224,7 +224,7 @@
       <visual>
         <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
         <geometry>
-          <mesh filename="upperarm.obj"/>
+          <mesh filename="package://drake_models/ur3e/upperarm.obj"/>
         </geometry>
         <material name="LightGrey">
           <color rgba="0.7 0.7 0.7 1.0"/>
@@ -341,7 +341,7 @@
       <visual>
         <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
         <geometry>
-          <mesh filename="forearm.obj"/>
+          <mesh filename="package://drake_models/ur3e/forearm.obj"/>
         </geometry>
         <material name="LightGrey">
           <color rgba="0.7 0.7 0.7 1.0"/>
@@ -476,7 +476,7 @@
       <visual>
         <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
         <geometry>
-          <mesh filename="wrist1.obj"/>
+          <mesh filename="package://drake_models/ur3e/wrist1.obj"/>
         </geometry>
         <material name="LightGrey">
           <color rgba="0.7 0.7 0.7 1.0"/>
@@ -552,7 +552,7 @@
       <visual>
         <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
         <geometry>
-          <mesh filename="wrist2.obj"/>
+          <mesh filename="package://drake_models/ur3e/wrist2.obj"/>
         </geometry>
         <material name="LightGrey">
           <color rgba="0.7 0.7 0.7 1.0"/>
@@ -627,7 +627,7 @@
       <visual>
         <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
         <geometry>
-          <mesh filename="wrist3.obj"/>
+          <mesh filename="package://drake_models/ur3e/wrist3.obj"/>
         </geometry>
         <material name="LightGrey">
           <color rgba="0.7 0.7 0.7 1.0"/>

--- a/manipulation/models/wsg_50_description/BUILD.bazel
+++ b/manipulation/models/wsg_50_description/BUILD.bazel
@@ -6,7 +6,6 @@ load(
 load("//tools/skylark:drake_data.bzl", "models_filegroup")
 load("//tools/install:install_data.bzl", "install_data")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("@drake//tools/workspace:forward_files.bzl", "forward_files")
 load(
     "//tools/workspace/models_internal:files.bzl",
     "wsg_50_description_mesh_files",
@@ -14,25 +13,25 @@ load(
 
 package(default_visibility = [":__subpackages__"])
 
-_WSG_50_DESCRIPTION_MESHES = forward_files(
-    srcs = [
-        "@models_internal//:" + x
-        for x in wsg_50_description_mesh_files()
-    ],
-    dest_prefix = "",
-    strip_prefix = "@models_internal//:wsg_50_description/",
-    visibility = ["//visibility:private"],
-)
-
 models_filegroup(
-    name = "models",
-    extra_srcs = _WSG_50_DESCRIPTION_MESHES,
-    visibility = ["//visibility:public"],
+    name = "glob_models",
+    visibility = ["//visibility:private"],
 )
 
 install_data(
     name = "install_data",
-    data = [":models"],
+    data = [":glob_models"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "models",
+    srcs = [
+        ":glob_models",
+    ] + [
+        "@models_internal//:" + x
+        for x in wsg_50_description_mesh_files()
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_no_tip.sdf
+++ b/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_no_tip.sdf
@@ -19,7 +19,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>package://drake/manipulation/models/wsg_50_description/meshes/wsg_body.obj</uri>
+            <uri>package://drake_models/wsg_50_description/meshes/wsg_body.obj</uri>
           </mesh>
         </geometry>
         <material>
@@ -99,7 +99,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>package://drake/manipulation/models/wsg_50_description/meshes/finger_without_tip.obj</uri>
+            <uri>package://drake_models/wsg_50_description/meshes/finger_without_tip.obj</uri>
           </mesh>
         </geometry>
         <material>
@@ -176,7 +176,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>package://drake/manipulation/models/wsg_50_description/meshes/finger_without_tip.obj</uri>
+            <uri>package://drake_models/wsg_50_description/meshes/finger_without_tip.obj</uri>
           </mesh>
         </geometry>
         <material>

--- a/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_welded_fingers.sdf
+++ b/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_welded_fingers.sdf
@@ -19,7 +19,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>package://drake/manipulation/models/wsg_50_description/meshes/wsg_body.obj</uri>
+            <uri>package://drake_models/wsg_50_description/meshes/wsg_body.obj</uri>
           </mesh>
         </geometry>
         <material>
@@ -54,7 +54,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>package://drake/manipulation/models/wsg_50_description/meshes/finger_without_tip.obj</uri>
+            <uri>package://drake_models/wsg_50_description/meshes/finger_without_tip.obj</uri>
           </mesh>
         </geometry>
         <material>
@@ -86,7 +86,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>package://drake/manipulation/models/wsg_50_description/meshes/finger_without_tip.obj</uri>
+            <uri>package://drake_models/wsg_50_description/meshes/finger_without_tip.obj</uri>
           </mesh>
         </geometry>
         <material>

--- a/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_with_tip.sdf
+++ b/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_with_tip.sdf
@@ -20,7 +20,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>package://drake/manipulation/models/wsg_50_description/meshes/wsg_body.obj</uri>
+            <uri>package://drake_models/wsg_50_description/meshes/wsg_body.obj</uri>
           </mesh>
         </geometry>
         <material>
@@ -102,7 +102,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>package://drake/manipulation/models/wsg_50_description/meshes/finger_with_tip.obj</uri>
+            <uri>package://drake_models/wsg_50_description/meshes/finger_with_tip.obj</uri>
           </mesh>
         </geometry>
         <material>
@@ -213,7 +213,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>package://drake/manipulation/models/wsg_50_description/meshes/finger_with_tip.obj</uri>
+            <uri>package://drake_models/wsg_50_description/meshes/finger_with_tip.obj</uri>
           </mesh>
         </geometry>
         <material>

--- a/manipulation/models/ycb/BUILD.bazel
+++ b/manipulation/models/ycb/BUILD.bazel
@@ -7,26 +7,28 @@ load(
 load("//tools/skylark:drake_data.bzl", "models_filegroup")
 load("@drake//tools/install:install_data.bzl", "install_data")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("@drake//tools/workspace:forward_files.bzl", "forward_files")
 load("//tools/workspace/models_internal:files.bzl", "ycb_mesh_files")
 
 package(default_visibility = ["//visibility:public"])
 
-_YCB_MESHES = forward_files(
-    srcs = ["@models_internal//:" + x for x in ycb_mesh_files()],
-    dest_prefix = "",
-    strip_prefix = "@models_internal//:ycb/",
-    visibility = ["//visibility:private"],
-)
-
 models_filegroup(
-    name = "models",
-    extra_srcs = _YCB_MESHES,
+    name = "glob_models",
+    visibility = ["//visibility:private"],
 )
 
 install_data(
     name = "install_data",
-    data = [":models"],
+    data = [":glob_models"],
+)
+
+filegroup(
+    name = "models",
+    srcs = [
+        ":glob_models",
+    ] + [
+        "@models_internal//:" + x
+        for x in ycb_mesh_files()
+    ],
 )
 
 # === test/ ===

--- a/manipulation/models/ycb/sdf/003_cracker_box.sdf
+++ b/manipulation/models/ycb/sdf/003_cracker_box.sdf
@@ -30,7 +30,7 @@
         <pose>-0.014 0.103 0.013 1.57 -1.57 0</pose>
         <geometry>
           <mesh>
-            <uri>package://drake/manipulation/models/ycb/meshes/003_cracker_box_textured.obj</uri>
+            <uri>package://drake_models/ycb/meshes/003_cracker_box_textured.obj</uri>
           </mesh>
         </geometry>
       </visual>

--- a/manipulation/models/ycb/sdf/004_sugar_box.sdf
+++ b/manipulation/models/ycb/sdf/004_sugar_box.sdf
@@ -30,7 +30,7 @@
         <pose>-0.018  0.088  0.0039 -0.77 -1.52 2.36</pose>
         <geometry>
           <mesh>
-            <uri>package://drake/manipulation/models/ycb/meshes/004_sugar_box_textured.obj</uri>
+            <uri>package://drake_models/ycb/meshes/004_sugar_box_textured.obj</uri>
           </mesh>
         </geometry>
       </visual>

--- a/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf
+++ b/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf
@@ -30,7 +30,7 @@
         <pose>-0.0018  0.051 -0.084 1.57 0.13 0.0</pose>
         <geometry>
           <mesh>
-            <uri>package://drake/manipulation/models/ycb/meshes/005_tomato_soup_can_textured.obj</uri>
+            <uri>package://drake_models/ycb/meshes/005_tomato_soup_can_textured.obj</uri>
           </mesh>
         </geometry>
       </visual>

--- a/manipulation/models/ycb/sdf/006_mustard_bottle.sdf
+++ b/manipulation/models/ycb/sdf/006_mustard_bottle.sdf
@@ -31,7 +31,7 @@
         <pose>0.0049 0.092 0.027 1.57 -0.40 0.0</pose>
         <geometry>
           <mesh>
-            <uri>package://drake/manipulation/models/ycb/meshes/006_mustard_bottle_textured.obj</uri>
+            <uri>package://drake_models/ycb/meshes/006_mustard_bottle_textured.obj</uri>
           </mesh>
         </geometry>
       </visual>

--- a/manipulation/models/ycb/sdf/009_gelatin_box.sdf
+++ b/manipulation/models/ycb/sdf/009_gelatin_box.sdf
@@ -30,7 +30,7 @@
         <pose>-0.0029 0.024 -0.015 -0.0085 -0.002 1.34</pose>
         <geometry>
           <mesh>
-            <uri>package://drake/manipulation/models/ycb/meshes/009_gelatin_box_textured.obj</uri>
+            <uri>package://drake_models/ycb/meshes/009_gelatin_box_textured.obj</uri>
           </mesh>
         </geometry>
       </visual>

--- a/manipulation/models/ycb/sdf/010_potted_meat_can.sdf
+++ b/manipulation/models/ycb/sdf/010_potted_meat_can.sdf
@@ -30,7 +30,7 @@
         <pose>0.034 0.039 0.025 1.57 0.052 0.0</pose>
         <geometry>
           <mesh>
-            <uri>package://drake/manipulation/models/ycb/meshes/010_potted_meat_can_textured.obj</uri>
+            <uri>package://drake_models/ycb/meshes/010_potted_meat_can_textured.obj</uri>
           </mesh>
         </geometry>
       </visual>

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -54,7 +54,10 @@ drake_cc_library(
     name = "package_map",
     srcs = ["package_map.cc"],
     hdrs = ["package_map.h"],
-    data = ["//:package.xml"],
+    data = [
+        "//:package.xml",
+        "@models_internal//:package.xml",
+    ],
     visibility = ["//visibility:public"],
     interface_deps = [
         "//common:essential",

--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -16,6 +16,7 @@
 #include "drake/common/drake_path.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/find_resource.h"
+#include "drake/common/find_runfiles.h"
 #include "drake/common/text_logging.h"
 #include "drake/common/unused.h"
 
@@ -29,11 +30,42 @@ using std::string;
 using tinyxml2::XMLDocument;
 using tinyxml2::XMLElement;
 
-PackageMap::PackageMap()
-    : PackageMap{FindResourceOrThrow("drake/package.xml")} {}
+PackageMap::PackageMap(std::nullopt_t) {
+  // Any common initialization code for all constructors could go here.
+}
+
+PackageMap::PackageMap() : PackageMap{std::nullopt} {
+  // FindResource is the source of truth for where Drake's first-party files
+  // live, no matter whether we're building from source or using a installed
+  // version of Drake.
+  const std::string drake_package = FindResourceOrThrow("drake/package.xml");
+  AddPackageXml(drake_package);
+
+  // For drake_models (i.e., https://github.com/RobotLocomotion/models), we need
+  // to do something different for source vs installed, hinging on whether or
+  // not we have runfiles. When running from source, we have bazel runfiles and
+  // will find our drake_models there. Otherwise, we're using installed Drake,
+  // in which case the drake_models package is a sibling to the drake package.
+  if (HasRunfiles()) {
+    // This is the case for Bazel-aware programs or tests, either first-party
+    // use of Bazel in Drake, or also for downstream Bazel projects that are
+    // using Drake as a dependency.
+    const RlocationOrError find = FindRunfile("models_internal/package.xml");
+    DRAKE_DEMAND(find.error.empty());
+    AddPackageXml(find.abspath);
+  } else {
+    // This is the case for installed Drake. The models are installed under
+    //  $prefix/share/drake_models/package.xml
+    // which is a sibling to
+    //  $prefix/share/drake/package.xml
+    auto share_drake = std::filesystem::path(drake_package).parent_path();
+    auto share = share_drake.parent_path().lexically_normal();
+    AddPackageXml((share / "drake_models/package.xml").string());
+  }
+}
 
 PackageMap PackageMap::MakeEmpty() {
-  return PackageMap(std::initializer_list<std::string>());
+  return PackageMap(std::nullopt);
 }
 
 void PackageMap::Add(const string& package_name, const string& package_path) {
@@ -260,12 +292,6 @@ bool PackageMap::AddPackageIfNew(const string& package_name,
     }
   }
   return true;
-}
-
-PackageMap::PackageMap(std::initializer_list<std::string> manifest_paths) {
-  for (const auto& manifest_path : manifest_paths) {
-    AddPackageXml(manifest_path);
-  }
 }
 
 void PackageMap::CrawlForPackages(

--- a/multibody/parsing/package_map.h
+++ b/multibody/parsing/package_map.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <initializer_list>
 #include <map>
 #include <optional>
 #include <string>
@@ -141,9 +140,8 @@ class PackageMap final {
     std::optional<std::string> deprecated_message;
   };
 
-  /* A constructor that initializes a map by parsing a list of package.xml file
-  paths. */
-  explicit PackageMap(std::initializer_list<std::string> manifest_paths);
+  /* A constructor that creates an empty map . */
+  explicit PackageMap(std::nullopt_t);
 
   /* Recursively crawls through `path` looking for package.xml files. Adds the
   packages defined by these package.xml files to this PackageMap.
@@ -163,7 +161,7 @@ class PackageMap final {
 
   /* The key is the name of a ROS package and the value is a struct containing
   information about that package. */
-  std::map<std::string, struct PackageData> map_;
+  std::map<std::string, PackageData> map_;
 };
 
 }  // namespace multibody

--- a/tools/wheel/image/build-wheel.sh
+++ b/tools/wheel/image/build-wheel.sh
@@ -40,7 +40,7 @@ chrpath()
 ###############################################################################
 
 readonly WHEEL_DIR=/opt/drake-wheel-build/wheel
-readonly WHEEL_DATA_DIR=${WHEEL_DIR}/pydrake/share/drake
+readonly WHEEL_SHARE_DIR=${WHEEL_DIR}/pydrake/share
 
 # TODO(mwoehlke-kitware) Most of this should move to Bazel.
 mkdir -p ${WHEEL_DIR}/drake
@@ -82,34 +82,33 @@ else
         /opt/drake/lib/libtbb*.so*
 fi
 
-# TODO(mwoehlke-kitware) We need a different way of shipping non-arch files
-# (examples, models).
-cp -r -t ${WHEEL_DATA_DIR} \
+cp -r -t ${WHEEL_SHARE_DIR}/drake \
     /opt/drake/share/drake/.drake-find_resource-sentinel \
     /opt/drake/share/drake/package.xml \
     /opt/drake/share/drake/examples \
     /opt/drake/share/drake/geometry \
     /opt/drake/share/drake/manipulation \
     /opt/drake/share/drake/tutorials
+# TODO(#15774) Eventually we will download these at runtime, instead of shipping
+# them in the wheel.
+cp -r -t ${WHEEL_SHARE_DIR} \
+    /opt/drake/share/drake_models
 
 if [[ "$(uname)" == "Linux" ]]; then
-    mkdir -p ${WHEEL_DATA_DIR}/setup
-    cp -r -t ${WHEEL_DATA_DIR}/setup \
+    mkdir -p ${WHEEL_SHARE_DIR}/drake/setup
+    cp -r -t ${WHEEL_SHARE_DIR}/drake/setup \
         /opt/drake/share/drake/setup/deepnote
 fi
 
 # TODO(mwoehlke-kitware) We need to remove these to keep the wheel from being
-# too large, but (per above), the whole of share/drake shouldn't be in the
-# wheel.
+# too large, but (per above), the whole of share/drake_models shouldn't be in
+# the wheel (and atlas's meshes should move into drake_models).
 rm -rf \
-    ${WHEEL_DATA_DIR}/manipulation/models/franka_description/meshes \
-    ${WHEEL_DATA_DIR}/manipulation/models/tri-homecart/*.obj \
-    ${WHEEL_DATA_DIR}/manipulation/models/tri-homecart/*.png \
-    ${WHEEL_DATA_DIR}/manipulation/models/ur3e/*.obj \
-    ${WHEEL_DATA_DIR}/manipulation/models/ur3e/*.png \
-    ${WHEEL_DATA_DIR}/manipulation/models/ycb/meshes \
-    ${WHEEL_DATA_DIR}/examples/atlas \
-    ${WHEEL_DATA_DIR}/examples/hydroelastic/spatula_slip_control
+    ${WHEEL_SHARE_DIR}/drake_models/franka_description \
+    ${WHEEL_SHARE_DIR}/drake_models/ur3e \
+    ${WHEEL_SHARE_DIR}/drake_models/ycb \
+    ${WHEEL_SHARE_DIR}/drake/examples/atlas \
+    ${WHEEL_SHARE_DIR}/drake_models/wsg_50_hydro_bubble
 
 if [[ "$(uname)" == "Linux" ]]; then
     export LD_LIBRARY_PATH=${WHEEL_DIR}/pydrake/lib:/opt/drake-dependencies/lib

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -89,6 +89,7 @@ _DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "gz_utils_internal",
     "lcm",
     "meshcat",
+    "models_internal",
     "msgpack_internal",
     "net_sf_jchart2d",
     "nanoflann_internal",

--- a/tools/workspace/models_internal/package.BUILD.bazel
+++ b/tools/workspace/models_internal/package.BUILD.bazel
@@ -1,6 +1,17 @@
 # -*- python -*-
 
+load("@drake//tools/install:install.bzl", "install")
+
 package(default_visibility = ["//visibility:private"])
+
+# TODO(jwnimmer-tri) Add a real package.xml upstream.
+genrule(
+    name = "package.xml_genrule",
+    srcs = ["@drake//:package.xml"],
+    outs = ["package.xml"],
+    cmd = "sed -e 's#drake#drake_models#' $< > $@",
+    visibility = ["//visibility:public"],
+)
 
 exports_files(
     # Keep this list alpha-sorted.
@@ -16,5 +27,25 @@ exports_files(
         "wsg_50_hydro_bubble/**",
         "ycb/meshes/**",
     ], allow_empty = False),
+    visibility = ["//visibility:public"],
+)
+
+# Install a subset of the models.
+install(
+    name = "install",
+    data = [
+        ":package.xml",
+    ] + glob([
+        # Keep this list alpha-sorted.
+        "franka_description/**",
+        "jaco_description/**",
+        "skydio_2/**",
+        "tri_homecart/**",
+        "ur3e/**",
+        "wsg_50_description/**",
+        "wsg_50_hydro_bubble/**",
+        "ycb/meshes/**",
+    ], allow_empty = False),
+    data_dest = "share/drake_models",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Instead of installing `RobotLocomotion/models` meshes as-if there were copied into the Drake source tree, rather install them as a separate ROS package `drake_models/package.xml`. This is precursor work to fetching them at runtime instead of installing them at all.

---

Towards #15774.

By using a different package name for large data files, it opens the door in future commits to fetch the models on-demand, instead of distributing them in our releases.

I'm using "fix" for release notes so that we can mention it.  This _shouldn't_ change anything for users, but on the chance it does I'd like to have it mentioned.

---

Manual testing:

(1)

```console
$ git checkout master
$ bazel run //:install -- /home/jwnimmer/tmp/master
$ git checkout package-map-models
$ bazel run //:install -- /home/jwnimmer/tmp/pr18919
$ (cd ~/tmp/master && find . -type f | sort) > master.txt
$ (cd ~/tmp/pr18919 && find . -type f | sort) > pr18919.txt
$ diff master.txt pr18919.txt 
```

The diffs are the renamed installation paths, plus a few newly-added files like READMEs that explain the origin myths for some of the data.

(2) Wheel testing

```
$ bazel run //tools/wheel:builder -- --python=310 0.0.0
$ cd ~/tmp
$ python3 -m venv env
$ env/bin/pip install /path/to/drake-0.0.0-cp310-cp310-manylinux_2_31_x86_64.whl 
$ env/bin/python3 -m pydrake.visualization.model_visualizer package://drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_with_tip.sdf
```

The meshes show up fine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18919)
<!-- Reviewable:end -->
