### PR TITLE
[parsing] Support auto-renaming of models

### DIFF
--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -109,7 +109,11 @@ PYBIND11_MODULE(parsing, m) {
         .def("AddModelFromFile", &Class::AddModelFromFile, py::arg("file_name"),
             py::arg("model_name") = "", cls_doc.AddModelFromFile.doc)
         .def("SetStrictParsing", &Class::SetStrictParsing,
-            cls_doc.SetStrictParsing.doc);
+            cls_doc.SetStrictParsing.doc)
+        .def("SetAutoRenaming", &Class::SetAutoRenaming, py::arg("value"),
+            cls_doc.SetAutoRenaming.doc)
+        .def("GetAutoRenaming", &Class::GetAutoRenaming,
+            cls_doc.GetAutoRenaming.doc);
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"

--- a/bindings/pydrake/multibody/test/parsing_test.py
+++ b/bindings/pydrake/multibody/test/parsing_test.py
@@ -177,6 +177,24 @@ class TestParsing(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, r'.*version.*ignored.*'):
             parser.AddModelsFromString(file_contents=model, file_type='urdf')
 
+    def test_auto_renaming(self):
+        model = """<robot name='robot' version='0.99'>
+            <link name='a'/>
+            </robot>"""
+        plant = MultibodyPlant(time_step=0.01)
+        parser = Parser(plant=plant)
+        self.assertFalse(parser.GetAutoRenaming())
+        results = parser.AddModelsFromString(
+            file_contents=model, file_type='urdf')
+        self.assertIsInstance(results[0], ModelInstanceIndex)
+        # Reload without auto-renaming; fail.
+        with self.assertRaisesRegex(RuntimeError, r''):
+            parser.AddModelsFromString(model, 'urdf')
+        # Enable renaming and subsequently succeed with reload.
+        parser.SetAutoRenaming(value=True)
+        results = parser.AddModelsFromString(model, 'urdf')
+        self.assertTrue(plant.HasModelInstanceNamed('robot_1'))
+
     def test_model_instance_info(self):
         """Checks that ModelInstanceInfo bindings exist."""
         ModelInstanceInfo.model_name

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -108,6 +108,7 @@ drake_cc_library(
     internal = True,
     visibility = ["//visibility:private"],
     deps = [
+        ":detail_make_model_name",
         ":detail_parsing_workspace",
         "//geometry/proximity:obj_to_surface_mesh",
         "//multibody/plant",
@@ -178,6 +179,7 @@ drake_cc_library(
     internal = True,
     visibility = ["//visibility:private"],
     deps = [
+        ":detail_make_model_name",
         ":detail_misc",
         ":detail_parsing_workspace",
         ":scoped_names",
@@ -193,6 +195,7 @@ drake_cc_library(
     internal = True,
     visibility = ["//visibility:private"],
     deps = [
+        ":detail_make_model_name",
         ":detail_misc",
         ":detail_parsing_workspace",
         "//multibody/plant",
@@ -208,6 +211,7 @@ drake_cc_library(
     internal = True,
     visibility = ["//visibility:private"],
     deps = [
+        ":detail_make_model_name",
         ":detail_misc",
         ":detail_parsing_workspace",
         ":model_directives",
@@ -216,6 +220,17 @@ drake_cc_library(
         "//common/yaml",
         "//multibody/plant",
         "@fmt",
+    ],
+)
+
+drake_cc_library(
+    name = "detail_make_model_name",
+    srcs = ["detail_make_model_name.cc"],
+    hdrs = ["detail_make_model_name.h"],
+    internal = True,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":detail_parsing_workspace",
     ],
 )
 
@@ -472,6 +487,13 @@ drake_cc_googletest(
     deps = [
         ":detail_select_parser",
         ":diagnostic_policy_test_base",
+    ],
+)
+
+drake_cc_googletest(
+    name = "detail_make_model_name_test",
+    deps = [
+        ":detail_make_model_name",
     ],
 )
 

--- a/multibody/parsing/detail_composite_parse.cc
+++ b/multibody/parsing/detail_composite_parse.cc
@@ -15,7 +15,8 @@ std::unique_ptr<CompositeParse> CompositeParse::MakeCompositeParse(
 
 CompositeParse::CompositeParse(Parser* parser)
     : resolver_(&parser->plant()),
-      workspace_(parser->package_map(), parser->diagnostic_policy_,
+      options_({parser->GetAutoRenaming()}),
+      workspace_(options_, parser->package_map(), parser->diagnostic_policy_,
                  &parser->plant(), &resolver_, SelectParser) {}
 
 CompositeParse::~CompositeParse() {

--- a/multibody/parsing/detail_composite_parse.h
+++ b/multibody/parsing/detail_composite_parse.h
@@ -33,6 +33,7 @@ class CompositeParse {
   explicit CompositeParse(Parser* parser);
 
   CollisionFilterGroupResolver resolver_;
+  const ParsingOptions options_;
   const ParsingWorkspace workspace_;
 };
 

--- a/multibody/parsing/detail_dmd_parser.cc
+++ b/multibody/parsing/detail_dmd_parser.cc
@@ -5,6 +5,7 @@
 #include <set>
 
 #include "drake/common/yaml/yaml_io.h"
+#include "drake/multibody/parsing/detail_make_model_name.h"
 #include "drake/multibody/parsing/detail_path_utils.h"
 #include "drake/multibody/parsing/scoped_names.h"
 #include "drake/multibody/tree/scoped_name.h"
@@ -51,7 +52,7 @@ void ParseModelDirectivesImpl(
     std::vector<ModelInstanceInfo>* added_models) {
   drake::log()->debug("ParseModelDirectivesImpl(MultibodyPlant)");
   DRAKE_DEMAND(added_models != nullptr);
-  auto& [package_map, diagnostic, plant,
+  auto& [options, package_map, diagnostic, plant,
          collision_resolver, parser_selector] = workspace;
   DRAKE_DEMAND(plant != nullptr);
   auto get_scoped_frame = [plant = plant, &model_namespace](
@@ -100,7 +101,7 @@ void ParseModelDirectivesImpl(
     } else if (directive.add_model_instance) {
       auto& instance = *directive.add_model_instance;
       const std::string name =
-          ScopedName::Join(model_namespace, instance.name).to_string();
+          MakeModelName(instance.name, model_namespace, workspace);
       drake::log()->debug("  add_model_instance: {}", name);
       plant->AddModelInstance(name);
 

--- a/multibody/parsing/detail_make_model_name.cc
+++ b/multibody/parsing/detail_make_model_name.cc
@@ -1,0 +1,40 @@
+#include "drake/multibody/parsing/detail_make_model_name.h"
+
+#include "drake/multibody/tree/scoped_name.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+std::string MakeModelName(std::string_view candidate_name,
+                          const std::optional<std::string>& parent_model_name,
+                          const ParsingWorkspace& workspace) {
+  std::string model_name = ScopedName::Join(
+      parent_model_name.value_or(""), candidate_name).to_string();
+
+  if (workspace.options.enable_auto_renaming &&
+      workspace.plant->HasModelInstanceNamed(model_name)) {
+    std::string subscripted;
+    // A note on the loop upper bound: searches don't expect to hit it. There
+    // just needs to be some bound to make the loop guaranteed to terminate,
+    // but large enough to allow finding an unused subscript. In the simplest
+    // case {world_model_instance, default_model_instance, "candidate"}
+    // num_model_instances will already be 3, and the search will find an
+    // answer at 1. Any other models that happen to be around will only
+    // increase the bound. If future model instance features interfere with
+    // these assumptions, the algorithm here will need revisiting.
+    for (int k = 1; k < workspace.plant->num_model_instances(); ++k) {
+      subscripted = fmt::format("{}_{}", model_name, k);
+      if (!workspace.plant->HasModelInstanceNamed(subscripted)) {
+        break;
+      }
+    }
+    model_name = subscripted;
+  }
+  return model_name;
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+

--- a/multibody/parsing/detail_make_model_name.h
+++ b/multibody/parsing/detail_make_model_name.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "drake/multibody/parsing/detail_parsing_workspace.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Calculates the model name of a new model instance, enforcing consistent
+// naming across all parsers that use it.
+//
+// Rules:
+// * Use parent_model_name as a scoped name prefix, if present.
+// * Use auto renaming to avoid conflicts, if enabled.
+//   * Subscripts start at 1 ("thing_1"), and are compact.
+//   * Subscripts of different base names are independent.
+std::string MakeModelName(std::string_view candidate_name,
+                          const std::optional<std::string>& parent_model_name,
+                          const ParsingWorkspace& workspace);
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/detail_mesh_parser.cc
+++ b/multibody/parsing/detail_mesh_parser.cc
@@ -14,6 +14,7 @@
 #include "drake/common/diagnostic_policy.h"
 #include "drake/geometry/proximity/obj_to_surface_mesh.h"
 #include "drake/geometry/proximity/triangle_surface_mesh.h"
+#include "drake/multibody/parsing/detail_make_model_name.h"
 #include "drake/multibody/tree/geometry_spatial_inertia.h"
 
 namespace drake {
@@ -122,10 +123,8 @@ std::optional<ModelInstanceIndex> AddModelFromMesh(
 
   // Register model instance, body, and collision and visual geometries.
   MultibodyPlant<double>& plant = *workspace.plant;
-  const std::string model_instance_name =
-      parent_model_name.has_value()
-          ? fmt::format("{}::{}", *parent_model_name, candidate_name)
-          : candidate_name;
+  std::string model_instance_name =
+      MakeModelName(candidate_name, parent_model_name, workspace);
   const ModelInstanceIndex model_instance =
       plant.AddModelInstance(model_instance_name);
 

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -19,6 +19,7 @@
 #include "drake/geometry/shape_specification.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
+#include "drake/multibody/parsing/detail_make_model_name.h"
 #include "drake/multibody/parsing/detail_tinyxml.h"
 #include "drake/multibody/tree/ball_rpy_joint.h"
 #include "drake/multibody/tree/prismatic_joint.h"
@@ -1247,9 +1248,7 @@ class MujocoParser {
           "ERROR: Your robot must have a name attribute or a model name "
           "must be specified.");
     }
-    model_name =
-        ScopedName::Join(parent_model_name.value_or(""), model_name).get_full();
-
+    model_name = MakeModelName(model_name, parent_model_name, workspace_);
     model_instance_ = plant_->AddModelInstance(model_name);
 
     // Parse the compiler parameters.

--- a/multibody/parsing/detail_parsing_workspace.h
+++ b/multibody/parsing/detail_parsing_workspace.h
@@ -92,6 +92,9 @@ using ParserSelector = std::function<ParserInterface&(
     const drake::internal::DiagnosticPolicy& policy,
     const std::string& filename)>;
 
+struct ParsingOptions {
+  bool enable_auto_renaming{false};
+};
 
 // ParsingWorkspace bundles the commonly-needed elements for parsing routines.
 // It owns nothing; all members are references or pointers to objects owned
@@ -106,12 +109,14 @@ struct ParsingWorkspace {
   // All parameters are aliased; they must have a lifetime greater than that of
   // this struct.
   ParsingWorkspace(
+      const ParsingOptions& options_in,
       const PackageMap& package_map_in,
       const drake::internal::DiagnosticPolicy& diagnostic_in,
       MultibodyPlant<double>* plant_in,
       internal::CollisionFilterGroupResolver* collision_resolver_in,
       ParserSelector parser_selector_in)
-      : package_map(package_map_in),
+      : options(options_in),
+        package_map(package_map_in),
         diagnostic(diagnostic_in),
         plant(plant_in),
         collision_resolver(collision_resolver_in),
@@ -121,6 +126,7 @@ struct ParsingWorkspace {
     DRAKE_DEMAND(parser_selector != nullptr);
   }
 
+  const ParsingOptions& options;
   const PackageMap& package_map;
   const drake::internal::DiagnosticPolicy& diagnostic;
   MultibodyPlant<double>* const plant;

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -18,6 +18,7 @@
 
 #include "drake/common/sorted_pair.h"
 #include "drake/math/rotation_matrix.h"
+#include "drake/multibody/parsing/detail_make_model_name.h"
 #include "drake/multibody/parsing/detail_path_utils.h"
 #include "drake/multibody/parsing/detail_tinyxml.h"
 #include "drake/multibody/parsing/detail_tinyxml2_diagnostic.h"
@@ -914,9 +915,7 @@ std::optional<ModelInstanceIndex> UrdfParser::Parse() {
     return {};
   }
 
-  model_name = ScopedName::Join(
-      parent_model_name_.value_or(""), model_name).to_string();
-
+  model_name = MakeModelName(model_name, parent_model_name_, w_);
   model_instance_ = w_.plant->AddModelInstance(model_name);
 
   // Parses the model's material elements. Throws an exception if there's a

--- a/multibody/parsing/test/detail_make_model_name_test.cc
+++ b/multibody/parsing/test/detail_make_model_name_test.cc
@@ -1,0 +1,62 @@
+#include "drake/multibody/parsing/detail_make_model_name.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace {
+
+using drake::internal::DiagnosticPolicy;
+
+class MakeModelNameTest : public testing::Test {
+ public:
+  // Making model names does not involve parser delegation.
+  static ParserInterface& NoSelect(
+      const drake::internal::DiagnosticPolicy&, const std::string&) {
+    DRAKE_UNREACHABLE();
+  }
+ protected:
+  ParsingOptions options_;
+  PackageMap package_map_;
+  DiagnosticPolicy policy_;
+  MultibodyPlant<double> plant_{0.0};
+  CollisionFilterGroupResolver resolver_{&plant_};
+  ParsingWorkspace workspace_{options_, package_map_, policy_,
+    &plant_, &resolver_, NoSelect};
+};
+
+TEST_F(MakeModelNameTest, Identity) {
+  EXPECT_EQ("robot", MakeModelName("robot", {}, workspace_));
+}
+
+TEST_F(MakeModelNameTest, Prefix) {
+  EXPECT_EQ("prefix::robot", MakeModelName("robot", "prefix", workspace_));
+}
+
+TEST_F(MakeModelNameTest, AutoRename) {
+  options_.enable_auto_renaming = true;
+
+  // Subscripts are compact and start at 1.
+  plant_.AddModelInstance("robot");
+  EXPECT_EQ("robot_1", MakeModelName("robot", {}, workspace_));
+  plant_.AddModelInstance("robot_1");
+  EXPECT_EQ("robot_2", MakeModelName("robot", {}, workspace_));
+
+  // Subscripts of different base names are independent.
+  plant_.AddModelInstance("thing");
+  EXPECT_EQ("thing_1", MakeModelName("thing", {}, workspace_));
+  plant_.AddModelInstance("thing_1");
+  EXPECT_EQ("thing_2", MakeModelName("thing", {}, workspace_));
+}
+
+TEST_F(MakeModelNameTest, PrefixAndAutoRename) {
+  options_.enable_auto_renaming = true;
+  plant_.AddModelInstance("prefix::robot");
+  EXPECT_EQ("prefix::robot_1", MakeModelName("robot", "prefix", workspace_));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/test/detail_mesh_parser_test.cc
+++ b/multibody/parsing/test/detail_mesh_parser_test.cc
@@ -34,8 +34,8 @@ class MeshParserTest : public test::DiagnosticPolicyTestBase {
       const std::optional<std::string>& parent_model_name = {}) {
     const DataSource data_source{DataSource::kFilename, &file_name};
     internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{package_map_, diagnostic_policy_, &plant_, &resolver,
-                       TestingSelect};
+    ParsingWorkspace w{options_, package_map_, diagnostic_policy_, &plant_,
+                       &resolver, TestingSelect};
     // The wrapper simply delegates to AddModelFromMesh(), so we're testing
     // the underlying implementation *and* confirming that the wrapper delegates
     // appropriately.
@@ -50,8 +50,8 @@ class MeshParserTest : public test::DiagnosticPolicyTestBase {
       const std::optional<std::string>& parent_model_name = {}) {
     const DataSource data_source{DataSource::kFilename, &file_name};
     internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{package_map_, diagnostic_policy_, &plant_, &resolver,
-                       TestingSelect};
+    ParsingWorkspace w{options_, package_map_, diagnostic_policy_, &plant_,
+                       &resolver, TestingSelect};
     // The wrapper is responsible for building the vector from whatever a call
     // to AddModelFromMesh() does; this confirms invocation and successful
     // transformation of return type.
@@ -64,6 +64,7 @@ class MeshParserTest : public test::DiagnosticPolicyTestBase {
   }
 
  protected:
+  ParsingOptions options_;
   PackageMap package_map_;
   MultibodyPlant<double> plant_{0.0};
   SceneGraph<double> scene_graph_;
@@ -197,8 +198,8 @@ TEST_F(MeshParserTest, ErrorModes) {
     const std::string data("Just some text");
     const DataSource data_source{DataSource::kContents, &data};
     internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{package_map_, diagnostic_policy_, &plant_, &resolver,
-                       TestingSelect};
+    ParsingWorkspace w{options_, package_map_, diagnostic_policy_, &plant_,
+                       &resolver, TestingSelect};
     DRAKE_EXPECT_THROWS_MESSAGE(
         AddModelFromMesh(data_source, "", std::nullopt, w),
         ".*must be .+ file.*");

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -44,7 +44,7 @@ class MujocoParserTest : public testing::Test {
       const std::string& file_name,
       const std::string& model_name) {
     internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{package_map_, diagnostic_policy_,
+    ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
                        &plant_, &resolver, NoSelect};
     auto result = AddModelFromMujocoXml(
         {DataSource::kFilename, &file_name}, model_name, {}, w);
@@ -56,7 +56,7 @@ class MujocoParserTest : public testing::Test {
       const std::string& file_contents,
       const std::string& model_name) {
     internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{package_map_, diagnostic_policy_,
+    ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
                        &plant_, &resolver, NoSelect};
     auto result = AddModelFromMujocoXml(
         {DataSource::kContents, &file_contents}, model_name, {}, w);
@@ -71,6 +71,7 @@ class MujocoParserTest : public testing::Test {
   }
 
  protected:
+  ParsingOptions options_;
   PackageMap package_map_;
   DiagnosticPolicy diagnostic_policy_;
   MultibodyPlant<double> plant_{0.1};

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -83,7 +83,7 @@ class SdfParserTest : public test::DiagnosticPolicyTestBase{
       const std::optional<std::string>& parent_model_name = {}) {
     const DataSource data_source{DataSource::kFilename, &file_name};
     internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{package_map_, diagnostic_policy_,
+    ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
                        &plant_, &resolver, TestingSelect};
     std::optional<ModelInstanceIndex> result =
         AddModelFromSdf(data_source, model_name, parent_model_name, w);
@@ -97,7 +97,7 @@ class SdfParserTest : public test::DiagnosticPolicyTestBase{
       const std::optional<std::string>& parent_model_name = {}) {
     const DataSource data_source{DataSource::kFilename, &file_name};
     internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{package_map_, diagnostic_policy_,
+    ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
                        &plant_, &resolver, TestingSelect};
     auto result = AddModelsFromSdf(data_source, parent_model_name, w);
     resolver.Resolve(diagnostic_policy_);
@@ -109,8 +109,8 @@ class SdfParserTest : public test::DiagnosticPolicyTestBase{
       const std::optional<std::string>& parent_model_name = {}) {
     const DataSource data_source{DataSource::kContents, &file_contents};
     internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{package_map_, diagnostic_policy_, &plant_,
-                       &resolver, TestingSelect};
+    ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
+                       &plant_, &resolver, TestingSelect};
     auto result = AddModelsFromSdf(data_source, parent_model_name, w);
     resolver.Resolve(diagnostic_policy_);
     return result;
@@ -179,6 +179,7 @@ class SdfParserTest : public test::DiagnosticPolicyTestBase{
   }
 
  protected:
+  ParsingOptions options_;
   PackageMap package_map_;
   DiagnosticPolicy diagnostic_;
   MultibodyPlant<double> plant_{0.0};
@@ -2831,7 +2832,7 @@ TEST_F(SdfParserTest, TestSingleModelEnforcement) {
 
   const DataSource data_source{DataSource::kContents, &multi_models};
   internal::CollisionFilterGroupResolver resolver{&plant_};
-  ParsingWorkspace w{package_map_, diagnostic_policy_,
+  ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
     &plant_, &resolver, TestingSelect};
   std::optional<ModelInstanceIndex> result =
       AddModelFromSdf(data_source, "", {}, w);

--- a/multibody/parsing/test/detail_select_parser_test.cc
+++ b/multibody/parsing/test/detail_select_parser_test.cc
@@ -16,7 +16,8 @@ class SelectParserTest : public test::DiagnosticPolicyTestBase {
  protected:
   MultibodyPlant<double> plant_{0.0};
   CollisionFilterGroupResolver resolver_{&plant_};
-  ParsingWorkspace w_{{}, diagnostic_policy_, &plant_,
+  ParsingOptions options_;
+  ParsingWorkspace w_{options_, {}, diagnostic_policy_, &plant_,
                       &resolver_, SelectParser};
 };
 

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -51,7 +51,7 @@ class UrdfParserTest : public test::DiagnosticPolicyTestBase {
       const std::string& file_name,
       const std::string& model_name) {
     internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{package_map_, diagnostic_policy_,
+    ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
                        &plant_, &resolver, NoSelect};
     auto result = AddModelFromUrdf(
         {DataSource::kFilename, &file_name}, model_name, {}, w);
@@ -63,7 +63,7 @@ class UrdfParserTest : public test::DiagnosticPolicyTestBase {
       const std::string& file_contents,
       const std::string& model_name) {
     internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{package_map_, diagnostic_policy_,
+    ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
                        &plant_, &resolver, NoSelect};
     auto result = AddModelFromUrdf(
         {DataSource::kContents, &file_contents}, model_name, {}, w);
@@ -78,6 +78,7 @@ class UrdfParserTest : public test::DiagnosticPolicyTestBase {
   }
 
  protected:
+  ParsingOptions options_;
   PackageMap package_map_;
   // Note: We currently use a discrete plant here to be able to test
   // Sap-specific features like the joint 'mimic' element.

--- a/multibody/parsing/test/parser_test.cc
+++ b/multibody/parsing/test/parser_test.cc
@@ -452,6 +452,35 @@ GTEST_TEST(FileParserTest, StrictParsing) {
   }
 }
 
+GTEST_TEST(FileParserTest, AutoRenaming) {
+  std::string model = "<robot name='robot'><link name='a'/></robot>";
+  MultibodyPlant<double> plant(0.0);
+
+  Parser parser(&plant);
+  EXPECT_FALSE(parser.GetAutoRenaming());
+
+  // Load a model.
+  parser.AddModelsFromString(model, "urdf");
+  EXPECT_TRUE(plant.HasModelInstanceNamed("robot"));
+  // Auto renaming is off; fail to load it again.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      parser.AddModelsFromString(model, "urdf"),
+      ".*names must be unique.*");
+
+  // Load it again with auto renaming.
+  parser.SetAutoRenaming(true);
+  EXPECT_TRUE(parser.GetAutoRenaming());
+  parser.AddModelsFromString(model, "urdf");
+  EXPECT_TRUE(plant.HasModelInstanceNamed("robot_1"));
+
+  // Disable auto renaming and show repeat loading subsequently fails.
+  parser.SetAutoRenaming(false);
+  EXPECT_FALSE(parser.GetAutoRenaming());
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      parser.AddModelsFromString(model, "urdf"),
+      ".*names must be unique.*");
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake


### PR DESCRIPTION
Add a parser option {Set,Get}AutoRenaming(bool). When enabled, the parser will resolve model naming conflicts by adding a numeric subscript to names.

This is another step in the long march toward retiring Parser APIs that assume and/or enforce single-model-per-input-text conditions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18921)
<!-- Reviewable:end -->
