### PR TITLE
[meshcat] Implement Meshcat::PlotSurface()

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -185,6 +185,18 @@ void DoScalarIndependentDefinitions(py::module m) {
     constexpr auto& cls_doc = doc.Meshcat;
     py::class_<Class, std::shared_ptr<Class>> meshcat(
         m, "Meshcat", cls_doc.doc);
+
+    // Meshcat::SideOfFaceToRender enumeration
+    constexpr auto& side_doc = doc.Meshcat.SideOfFaceToRender;
+    py::enum_<Meshcat::SideOfFaceToRender>(
+        meshcat, "SideOfFaceToRender", side_doc.doc)
+        .value("kFrontSide", Meshcat::SideOfFaceToRender::kFrontSide,
+            side_doc.kFrontSide.doc)
+        .value("kBackSide", Meshcat::SideOfFaceToRender::kBackSide,
+            side_doc.kBackSide.doc)
+        .value("kDoubleSide", Meshcat::SideOfFaceToRender::kDoubleSide,
+            side_doc.kDoubleSide.doc);
+
     meshcat  // BR
         .def(py::init<std::optional<int>>(), py::arg("port") = std::nullopt,
             cls_doc.ctor.doc_1args_port)
@@ -208,11 +220,12 @@ void DoScalarIndependentDefinitions(py::module m) {
             py::arg("rgba") = Rgba(.9, .9, .9, 1.), cls_doc.SetObject.doc_cloud)
         .def("SetObject",
             py::overload_cast<std::string_view,
-                const TriangleSurfaceMesh<double>&, const Rgba&, bool, double>(
-                &Class::SetObject),
+                const TriangleSurfaceMesh<double>&, const Rgba&, bool, double,
+                Meshcat::SideOfFaceToRender>(&Class::SetObject),
             py::arg("path"), py::arg("mesh"),
             py::arg("rgba") = Rgba(0.1, 0.1, 0.1, 1.0),
             py::arg("wireframe") = false, py::arg("wireframe_line_width") = 1.0,
+            py::arg("side") = Meshcat::SideOfFaceToRender::kDoubleSide,
             cls_doc.SetObject.doc_triangle_surface_mesh)
         .def("SetLine", &Class::SetLine, py::arg("path"), py::arg("vertices"),
             py::arg("line_width") = 1.0,
@@ -225,12 +238,19 @@ void DoScalarIndependentDefinitions(py::module m) {
             py::arg("vertices"), py::arg("faces"),
             py::arg("rgba") = Rgba(0.1, 0.1, 0.1, 1.0),
             py::arg("wireframe") = false, py::arg("wireframe_line_width") = 1.0,
+            py::arg("side") = Meshcat::SideOfFaceToRender::kDoubleSide,
             cls_doc.SetTriangleMesh.doc)
         .def("SetTriangleColorMesh", &Class::SetTriangleColorMesh,
             py::arg("path"), py::arg("vertices"), py::arg("faces"),
             py::arg("colors"), py::arg("wireframe") = false,
             py::arg("wireframe_line_width") = 1.0,
+            py::arg("side") = Meshcat::SideOfFaceToRender::kDoubleSide,
             cls_doc.SetTriangleColorMesh.doc)
+        .def("PlotSurface", &Class::PlotSurface, py::arg("path"), py::arg("X"),
+            py::arg("Y"), py::arg("Z"),
+            py::arg("rgba") = Rgba(0.1, 0.1, 0.9, 1.0),
+            py::arg("wireframe") = false, py::arg("wireframe_line_width") = 1.0,
+            cls_doc.PlotSurface.doc)
         .def("SetCamera",
             py::overload_cast<Meshcat::PerspectiveCamera, std::string>(
                 &Class::SetCamera),

--- a/bindings/pydrake/geometry/test/visualizers_test.py
+++ b/bindings/pydrake/geometry/test/visualizers_test.py
@@ -114,9 +114,12 @@ class TestGeometryVisualizers(unittest.TestCase):
             triangles=[mut.SurfaceTriangle(
                 0, 1, 2), mut.SurfaceTriangle(3, 0, 2)],
             vertices=[[0, 0, 0], [1, 0, 0], [1, 0, 1], [0, 0, 1]])
-        meshcat.SetObject(path="/test/triangle_surface_mesh", mesh=mesh,
-                          rgba=mut.Rgba(0.3, 0.3, 0.3), wireframe=True,
-                          wireframe_line_width=2.0)
+        meshcat.SetObject(path="/test/triangle_surface_mesh",
+                          mesh=mesh,
+                          rgba=mut.Rgba(0.3, 0.3, 0.3),
+                          wireframe=True,
+                          wireframe_line_width=2.0,
+                          side=meshcat.SideOfFaceToRender.kFrontSide)
         meshcat.SetLine(path="/test/line", vertices=np.eye(3),
                         line_width=2.0, rgba=mut.Rgba(.3, .3, .3))
         meshcat.SetLineSegments(path="/test/line_segments", start=np.eye(3),
@@ -128,14 +131,28 @@ class TestGeometryVisualizers(unittest.TestCase):
             faces=np.array([[0, 1, 2], [3, 0, 2]]).T,
             rgba=mut.Rgba(0.3, 0.3, 0.3),
             wireframe=True,
-            wireframe_line_width=2.0)
+            wireframe_line_width=2.0,
+            side=meshcat.SideOfFaceToRender.kBackSide)
         meshcat.SetTriangleColorMesh(
             path="/test/triangle_mesh",
             vertices=np.array([[0, 0, 0], [1, 0, 0], [1, 0, 1], [0, 0, 1]]).T,
             faces=np.array([[0, 1, 2], [3, 0, 2]]).T,
             colors=np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1], [1, 1, 0]]).T,
             wireframe=False,
-            wireframe_line_width=2.0)
+            wireframe_line_width=2.0,
+            side=meshcat.SideOfFaceToRender.kDoubleSide)
+        # Plot the six-hump camel
+        xs = np.linspace(-2.2, 2.2, 51)
+        ys = np.linspace(-1.2, 1.2, 51)
+        [X, Y] = np.meshgrid(xs, ys)
+        P = 4 * X**2 + X * Y - 4 * Y**2 - 2.1 * X**4 + 4 * Y**4 + X**6 / 3
+        meshcat.PlotSurface(path="six_hump_camel",
+                            X=X,
+                            Y=Y,
+                            Z=P,
+                            rgba=mut.Rgba(0.3, 0.3, 0.3),
+                            wireframe=True,
+                            wireframe_line_width=2.0)
         meshcat.SetProperty(path="/Background",
                             property="visible",
                             value=True)

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -743,7 +743,7 @@ class Meshcat::Impl {
       material->color = ToMeshcatColor(rgba);
       // TODO(russt): Most values are taken verbatim from meshcat-python.
       material->reflectivity = 0.5;
-      material->side = internal::kDoubleSide;
+      material->side = SideOfFaceToRender::kDoubleSide;
       // From meshcat-python: Three.js allows a material to have an opacity
       // which is != 1, but to still be non - transparent, in which case the
       // opacity only serves to desaturate the material's color. That's a
@@ -823,7 +823,7 @@ class Meshcat::Impl {
   // This function is public via the PIMPL.
   void SetObject(std::string_view path, const TriangleSurfaceMesh<double>& mesh,
                  const Rgba& rgba, bool wireframe,
-                 double wireframe_line_width) {
+                 double wireframe_line_width, SideOfFaceToRender side) {
     DRAKE_DEMAND(IsThread(main_thread_id_));
     Eigen::Matrix3Xd vertices(3, mesh.num_vertices());
     for (int i = 0; i < mesh.num_vertices(); ++i) {
@@ -837,7 +837,7 @@ class Meshcat::Impl {
       }
     }
     SetTriangleMesh(path, vertices, faces, rgba, wireframe,
-                    wireframe_line_width);
+                    wireframe_line_width, side);
   }
 
   // This function is public via the PIMPL.
@@ -909,7 +909,7 @@ class Meshcat::Impl {
                        const Eigen::Ref<const Eigen::Matrix3Xd>& vertices,
                        const Eigen::Ref<const Eigen::Matrix3Xi>& faces,
                        const Rgba& rgba, bool wireframe,
-                       double wireframe_line_width) {
+                       double wireframe_line_width, SideOfFaceToRender side) {
     DRAKE_DEMAND(IsThread(main_thread_id_));
 
     uuids::uuid_random_generator uuid_generator{generator_};
@@ -931,6 +931,7 @@ class Meshcat::Impl {
     material->wireframe = wireframe;
     material->wireframeLineWidth = wireframe_line_width;
     material->vertexColors = false;
+    material->side = side;
     data.object.material = std::move(material);
 
     internal::MeshData mesh;
@@ -956,7 +957,7 @@ class Meshcat::Impl {
                        const Eigen::Ref<const Eigen::Matrix3Xi>& faces,
                        const Eigen::Ref<const Eigen::Matrix3Xd>& colors,
                        bool wireframe,
-                       double wireframe_line_width) {
+                       double wireframe_line_width, SideOfFaceToRender side) {
     DRAKE_DEMAND(IsThread(main_thread_id_));
 
     uuids::uuid_random_generator uuid_generator{generator_};
@@ -978,7 +979,7 @@ class Meshcat::Impl {
     material->wireframe = wireframe;
     material->wireframeLineWidth = wireframe_line_width;
     material->vertexColors = true;
-    material->side = internal::kDoubleSide;
+    material->side = side;
     data.object.material = std::move(material);
 
     internal::MeshData mesh;
@@ -2074,8 +2075,8 @@ void Meshcat::SetObject(std::string_view path,
 void Meshcat::SetObject(std::string_view path,
                         const TriangleSurfaceMesh<double>& mesh,
                         const Rgba& rgba, bool wireframe,
-                        double wireframe_line_width) {
-  impl().SetObject(path, mesh, rgba, wireframe, wireframe_line_width);
+                        double wireframe_line_width, SideOfFaceToRender side) {
+  impl().SetObject(path, mesh, rgba, wireframe, wireframe_line_width, side);
 }
 
 void Meshcat::SetLine(std::string_view path,
@@ -2094,18 +2095,82 @@ void Meshcat::SetLineSegments(std::string_view path,
 void Meshcat::SetTriangleMesh(
     std::string_view path, const Eigen::Ref<const Eigen::Matrix3Xd>& vertices,
     const Eigen::Ref<const Eigen::Matrix3Xi>& faces, const Rgba& rgba,
-    bool wireframe, double wireframe_line_width) {
+    bool wireframe, double wireframe_line_width, SideOfFaceToRender side) {
   impl().SetTriangleMesh(path, vertices, faces, rgba, wireframe,
-                              wireframe_line_width);
+                              wireframe_line_width, side);
 }
 
 void Meshcat::SetTriangleColorMesh(
     std::string_view path, const Eigen::Ref<const Eigen::Matrix3Xd>& vertices,
     const Eigen::Ref<const Eigen::Matrix3Xi>& faces,
     const Eigen::Ref<const Eigen::Matrix3Xd>& colors, bool wireframe,
-    double wireframe_line_width) {
+    double wireframe_line_width, SideOfFaceToRender side) {
   impl().SetTriangleColorMesh(path, vertices, faces, colors, wireframe,
-                         wireframe_line_width);
+                         wireframe_line_width, side);
+}
+
+void Meshcat::PlotSurface(std::string_view path,
+                          const Eigen::Ref<const Eigen::MatrixXd>& X,
+                          const Eigen::Ref<const Eigen::MatrixXd>& Y,
+                          const Eigen::Ref<const Eigen::MatrixXd>& Z,
+                          const Rgba& rgba, bool wireframe,
+                          double wireframe_line_width) {
+  DRAKE_DEMAND(Y.rows() == X.rows() && Y.cols() == X.cols());
+  DRAKE_DEMAND(Z.rows() == X.rows() && Z.cols() == X.cols());
+  const int rows = X.rows(), cols = X.cols();
+
+  if (wireframe) {
+    int count = -1;
+    Eigen::Matrix3Xd vertices(3, rows * cols * 2);
+    // Sweep back and forth along rows.
+    for (int r = 0; r < rows; ++r) {
+      const int c0 = (r & 0x1) ? cols - 1 : 0;
+      const int c_delta = (r & 0x1) ? -1 : 1;
+      for (int j = 0, c = c0; j < cols; ++j, c += c_delta) {
+        vertices.col(++count) << X(r, c), Y(r, c), Z(r, c);
+      }
+    }
+    // Sweep back and forth along columns.
+    const int c0 = (rows & 0x1) ? cols - 1 : 0;
+    const int c_delta = (rows & 0x1) ? -1 : 1;
+    for (int j = 0, c = c0; j < cols; ++j, c += c_delta) {
+      const int r0 = (j & 0x1) ? 0 : rows - 1;
+      const int r_delta = (j & 0x1) ? 1 : -1;
+      for (int i = 0, r = r0; i < rows; ++i, r += r_delta) {
+        vertices.col(++count) << X(r, c), Y(r, c), Z(r, c);
+      }
+    }
+
+    impl().SetLine(path, vertices, wireframe_line_width, rgba);
+  } else {
+    using MapRowVector = const Eigen::Map<const Eigen::RowVectorXd>;
+
+    Eigen::Matrix3Xd vertices(3, rows * cols);
+    vertices.row(0) = MapRowVector(X.data(), rows * cols);
+    vertices.row(1) = MapRowVector(Y.data(), rows * cols);
+    vertices.row(2) = MapRowVector(Z.data(), rows * cols);
+
+    // Make a regular grid as in https://stackoverflow.com/q/44934631.
+    const int num_boxes = (rows - 1) * (cols - 1);
+    Eigen::Matrix3Xi faces(3, 2 * num_boxes);
+    Eigen::MatrixXi ids(rows, cols);
+    // Populate ids with [0, 1, ..., num vertices-1]
+    std::iota(ids.data(), ids.data() + rows * cols, 0);
+
+    int count = 0;
+    for (int i = 0; i < rows - 1; ++i) {
+      for (int j = 0; j < cols - 1; ++j) {
+        // Upper left triangles.
+        faces.col(count++) << ids(i, j), ids(i + 1, j), ids(i, j + 1);
+        // Lower right triangles.
+        faces.col(count++) << ids(i + 1, j), ids(i + 1, j + 1), ids(i, j + 1);
+      }
+    }
+
+    impl().SetTriangleMesh(path, vertices, faces, rgba, wireframe,
+                           wireframe_line_width,
+                           SideOfFaceToRender::kDoubleSide);
+  }
 }
 
 void Meshcat::SetCamera(PerspectiveCamera camera, std::string path) {

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -131,6 +131,10 @@ class Meshcat {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Meshcat)
 
+  // Defines which side of faces will be rendered - front, back or both.
+  // From https://github.com/mrdoob/three.js/blob/dev/src/constants.js
+  enum SideOfFaceToRender { kFrontSide = 0, kBackSide = 1, kDoubleSide = 2 };
+
   /** Constructs the %Meshcat instance on `port`. If no port is specified,
   it will listen on the first available port starting at 7000 (up to 7099).
   @pre We require `port` >= 1024.
@@ -210,7 +214,8 @@ class Meshcat {
   */
   void SetObject(std::string_view path, const TriangleSurfaceMesh<double>& mesh,
                  const Rgba& rgba = Rgba(0.1, 0.1, 0.1, 1.0),
-                 bool wireframe = false, double wireframe_line_width = 1.0);
+                 bool wireframe = false, double wireframe_line_width = 1.0,
+                 SideOfFaceToRender side = kDoubleSide);
 
   /** Sets the "object" at `path` in the scene tree to a piecewise-linear
   interpolation between the `vertices`.
@@ -268,10 +273,11 @@ class Meshcat {
                        const Eigen::Ref<const Eigen::Matrix3Xi>& faces,
                        const Rgba& rgba = Rgba(0.1, 0.1, 0.1, 1.0),
                        bool wireframe = false,
-                       double wireframe_line_width = 1.0);
+                       double wireframe_line_width = 1.0,
+                       SideOfFaceToRender side = kDoubleSide);
 
   /** Sets the "object" at `path` in the scene tree to a triangular mesh with
-      per-vertex coloring.
+  per-vertex coloring.
 
   @param path a "/"-delimited string indicating the path in the scene tree. See
               @ref meshcat_path "Meshcat paths" for the semantics.
@@ -288,11 +294,49 @@ class Meshcat {
                               WebGL implementations, the line width may be 1
                               regardless of the set value. */
   void SetTriangleColorMesh(std::string_view path,
-                       const Eigen::Ref<const Eigen::Matrix3Xd>& vertices,
-                       const Eigen::Ref<const Eigen::Matrix3Xi>& faces,
-                       const Eigen::Ref<const Eigen::Matrix3Xd>& colors,
-                       bool wireframe = false,
-                       double wireframe_line_width = 1.0);
+                            const Eigen::Ref<const Eigen::Matrix3Xd>& vertices,
+                            const Eigen::Ref<const Eigen::Matrix3Xi>& faces,
+                            const Eigen::Ref<const Eigen::Matrix3Xd>& colors,
+                            bool wireframe = false,
+                            double wireframe_line_width = 1.0,
+                            SideOfFaceToRender side = kDoubleSide);
+
+  // TODO(russt): Add support for per vertex colors / colormaps.
+  /** Sets the "object" at `path` to be a triangle surface mesh representing a
+  3D surface, via an API that roughly follows matplotlib's plot_surface()
+  method.
+
+  @param X matrix of `x` coordinate values defining the vertices of the mesh.
+  @param Y matrix of `y` coordinate values.
+  @param Z matrix of `z` coordinate values.
+  @param rgba is the mesh face or wireframe color.
+  @param wireframe if "true", then only the triangle edges are visualized, not
+                   the faces.
+  @param wireframe_line_width is the width in pixels.  Due to limitations in
+                              WebGL implementations, the line width may be 1
+                              regardless of the set value.
+
+  Typically, X and Y are obtained via, e.g.
+  @code
+  constexpr int nx = 15, ny = 11;
+  X = RowVector<double, nx>::LinSpaced(0, 1).replicate<ny, 1>();
+  Y = Vector<double, ny>::LinSpaced(0, 1).replicate<1, nx>();
+  @code
+  in C++ or e.g.
+  @code
+  xs = np.linspace(0, 1, 15)
+  ys = np.linspace(0, 1, 11)
+  [X, Y] = np.meshgrid(xs, ys)
+  @code
+  in Python, and Z is the surface evaluated on each X, Y value.
+
+  @pre X, Y, and Z must be the same shape. */
+  void PlotSurface(std::string_view path,
+                   const Eigen::Ref<const Eigen::MatrixXd>& X,
+                   const Eigen::Ref<const Eigen::MatrixXd>& Y,
+                   const Eigen::Ref<const Eigen::MatrixXd>& Z,
+                   const Rgba& rgba = Rgba(0.1, 0.1, 0.9, 1.0),
+                   bool wireframe = false, double wireframe_line_width = 1.0);
 
   // TODO(russt): Provide a more general SetObject(std::string_view path,
   // msgpack::object object) that would allow users to pass through anything

--- a/geometry/meshcat_types.h
+++ b/geometry/meshcat_types.h
@@ -38,9 +38,6 @@ namespace internal {
 // compatible with msgpack, which wants to be able to unpack into the same
 // structure.
 
-// From https://github.com/mrdoob/three.js/blob/dev/src/constants.js
-enum ThreeSide { kFrontSide = 0, kBackSide = 1, kDoubleSide = 2 };
-
 // TODO(russt): We should expose these options to the user.
 // The documentation of the fields is adapted from
 // https://threejs.org/docs/#api/en/materials/Material and its derived classes.
@@ -74,7 +71,7 @@ struct MaterialData {
 
   // Defines which side of faces will be rendered - front, back or both. Default
   // is kFrontSide. Other options are kBackSide and kDoubleSide.
-  std::optional<ThreeSide> side;
+  std::optional<Meshcat::SideOfFaceToRender> side;
 
   // For PointsMaterial, sets the size of the points. The three.js default
   // is 1.0. Will be capped if it exceeds the hardware dependent parameter
@@ -487,7 +484,7 @@ struct UserInterfaceEvent {
 
 #ifndef DRAKE_DOXYGEN_CXX
 
-MSGPACK_ADD_ENUM(drake::geometry::internal::ThreeSide);
+MSGPACK_ADD_ENUM(drake::geometry::Meshcat::SideOfFaceToRender);
 MSGPACK_ADD_ENUM(drake::geometry::MeshcatAnimation::LoopMode);
 
 // We use the msgpack "non-intrusive" approach for packing types exposed in the

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -147,6 +147,20 @@ int do_main() {
                           RigidTransformd(Vector3d{8.75, -.25, 0}));
   }
 
+  // PlotSurface.
+  {
+    constexpr int nx = 15, ny = 11;
+    Eigen::MatrixXd X =
+        Eigen::RowVectorXd::LinSpaced(nx, 0, 1).replicate<ny, 1>();
+    Eigen::MatrixXd Y = Eigen::VectorXd::LinSpaced(ny, 0, 1).replicate<1, nx>();
+    // z = y*sin(5*x)
+    Eigen::MatrixXd Z = (Y.array() * (5 * X.array()).sin()).matrix();
+
+    meshcat->PlotSurface("plot_surface", X, Y, Z, Rgba(0, 0, .9, 1.0), true);
+    meshcat->SetTransform("plot_surface",
+                          RigidTransformd(Vector3d{9.75, -.25, 0}));
+  }
+
   std::cout << R"""(
 Open up your browser to the URL above.
 
@@ -166,6 +180,7 @@ Open up your browser to the URL above.
   - a purple triangle mesh with 2 faces.
   - the same purple triangle mesh drawn as a wireframe.
   - the same triangle mesh drawn in multicolor.
+  - a blue mesh plot of the function z = y*sin(5*x).
 )""";
   std::cout << "[Press RETURN to continue]." << std::endl;
   std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -356,6 +356,27 @@ GTEST_TEST(MeshcatTest, SetObjectWithTriangleSurfaceMesh) {
   EXPECT_FALSE(meshcat.GetPackedObject("triangle_mesh_wireframe").empty());
 }
 
+GTEST_TEST(MeshcatTest, PlotSurface) {
+  Meshcat meshcat;
+
+  constexpr int nx = 15, ny = 11;
+  Eigen::MatrixXd X =
+      RowVector<double, nx>::LinSpaced(0, 1).replicate<ny, 1>();
+  Eigen::MatrixXd Y =
+      Vector<double, ny>::LinSpaced(0, 1).replicate<1, nx>();
+  // z = y*sin(5*x)
+  Eigen::MatrixXd Z = (Y.array() * (5*X.array()).sin()).matrix();
+
+  // Wireframe = false.
+  meshcat.PlotSurface("plot_surface", X, Y, Z, Rgba(0, 0, .9, 1.0), false);
+  EXPECT_FALSE(meshcat.GetPackedObject("plot_surface").empty());
+
+  // Wireframe = true.
+  meshcat.PlotSurface("plot_surface_wireframe", X, Y, Z, Rgba(0, 0, .9, 1.0),
+                      true);
+  EXPECT_FALSE(meshcat.GetPackedObject("plot_surface_wireframe").empty());
+}
+
 GTEST_TEST(MeshcatTest, SetLine) {
   Meshcat meshcat;
 


### PR DESCRIPTION
This is a handy plotting helper, providing an interface like matplotlib's plot_surface. I've been using a python version of it for years in my course notes, but now I find myself wanting it in C++.

+@xuchenhan-tri for feature review, please?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18924)
<!-- Reviewable:end -->
