### PR TITLE
[tools] Improve new_release script

### DIFF
--- a/tools/workspace/README.md
+++ b/tools/workspace/README.md
@@ -51,8 +51,7 @@ Run the "upgrades needed" report.  Copy its output into a temporary text file
 so that you can easily refer back to it as you proceed.
 
 ```
-  bazel build //tools/workspace:new_release
-  bazel-bin/tools/workspace/new_release
+  bazel run //tools/workspace:new_release
 ```
 
 For each external in the report, add a commit that upgrades it, as follows:
@@ -60,16 +59,15 @@ For each external in the report, add a commit that upgrades it, as follows:
 Run the script to perform one upgrade (for some external "foo"):
 
 ```
-  bazel-bin/tools/workspace/new_release --lint --commit foo
+  bazel run //tools/workspace:new_release -- --lint --commit foo
 ```
 
 If the automated update doesn't succeed, then you'll need to make the edits
 manually.  Ask for help in drake developers slack channel for ``#build``.
 
-If the automated update succeeded, then inspect the modified ``repository.bzl``
-in your editor.  Some diffs will have an instructive comment nearby, e.g.,
-"If you change this commit, then you need to do X, Y, Z afterward."
-Follow any advice that you find.
+If the automated update succeeded, check the output of ``new_release`` for any
+additional steps that need to be manually performed to complete the upgrade.
+Follow any advice that is given.
 
 If you didn't use ``--lint`` earlier, or need to re-test, run
 ``bazel test --config lint //...`` as a sanity check of the changes.
@@ -83,11 +81,12 @@ list several externals to try to update at once, although this will complicate
 making changes to those commits if needed.
 
 Each external being upgraded should have exactly one commit that does the
-upgrade, and each commit should only impact exactly one external.  If we
+upgrade, and each commit should either a) only impact exactly one external, or
+b) impact exactly those externals of a cohort which need to be upgraded.  If we
 find any problem with an upgrade, we need to be able to revert the commit
 for just that one external upgrade, leaving the other upgrades intact.
-(However, if multiple externals need to be upgraded together due to
-interdependency, a single commit should be used in such cases.)
+The ``new_release`` will automatically upgrade all externals of a cohort in a
+single operation.
 
 Once all upgrades are ready, open a Drake pull request and label it
 ``status: commits are properly curated``.  Open the Reviewable page and

--- a/tools/workspace/common_robotics_utilities/repository.bzl
+++ b/tools/workspace/common_robotics_utilities/repository.bzl
@@ -12,10 +12,12 @@ def common_robotics_utilities_repository(
     github_archive(
         name = name,
         repository = "ToyotaResearchInstitute/common_robotics_utilities",
-        # When updating, ensure that any new unit tests are reflected in
-        # package.BUILD.bazel and BUILD.bazel in drake. Tests may have been
-        # updated in ToyotaResearchInstitute/common_robotics_utilities/test/ or
-        # ToyotaResearchInstitute/common_robotics_utilities/CMakeLists.txt.ros2
+        upgrade_advice = """
+        When updating, ensure that any new unit tests are reflected in
+        package.BUILD.bazel and BUILD.bazel in drake. Tests may have been
+        updated in ToyotaResearchInstitute/common_robotics_utilities/test/ or
+        ToyotaResearchInstitute/common_robotics_utilities/CMakeLists.txt.ros2
+        """,
         commit = "d8b1a861d07e7c526e2a7dd3123d351498b53636",
         sha256 = "8d3357221aeacabc538391b1ab53bd848a8f29ddae75896912c23b7bb9c3d8d8",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/curl_internal/repository.bzl
+++ b/tools/workspace/curl_internal/repository.bzl
@@ -8,8 +8,10 @@ def curl_internal_repository(
     github_archive(
         name = name,
         repository = "curl/curl",
-        # In case of a cmake_configure_file build error when upgrading curl,
-        # update cmakedefines.bzl to match the new upstream definitions.
+        upgrade_advice = """
+        In case of a cmake_configure_file build error when upgrading curl,
+        update cmakedefines.bzl to match the new upstream definitions.
+        """,
         commit = "curl-7_88_1",
         sha256 = "eb9f2ca79e2c39b89827cf2cf21f39181f6a537f50dc1df9c33d705913009ac4",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/lcm/repository.bzl
+++ b/tools/workspace/lcm/repository.bzl
@@ -8,9 +8,11 @@ def lcm_repository(
     github_archive(
         name = name,
         repository = "lcm-proj/lcm",
-        # When upgrading this commit, check if the LCM maintainers have tagged
-        # a new version number; if so, then update the version numbers within
-        # the two lcm-*.cmake files in this directory to match.
+        upgrade_advice = """
+        When upgrading this commit, check if the LCM maintainers have tagged
+        a new version number; if so, then update the version numbers within
+        the two lcm-*.cmake files in this directory to match.
+        """,
         commit = "1aecca45e6a05d719da8e566533e45740d1fd88c",
         sha256 = "78ef84ccabf78ebb33a182393bb539f38fedb576e2c1cb244bf134470bd702e3",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/libcmaes/repository.bzl
+++ b/tools/workspace/libcmaes/repository.bzl
@@ -8,10 +8,12 @@ def libcmaes_repository(
     github_archive(
         name = name,
         repository = "CMA-ES/libcmaes",
-        # TODO(jwnimmer-tri) We use an untagged commit, in order to use the
-        # Apache-2.0 license. Any time we upgrade this to a newer commit, we
-        # should check if there is an official version number yet that we
-        # could use (i.e., newer than v0.10).
+        upgrade_advice = """
+        TODO(jwnimmer-tri) We use an untagged commit, in order to use the
+        Apache-2.0 license. Any time we upgrade this to a newer commit, we
+        should check if there is an official version number yet that we
+        could use (i.e., newer than v0.10).
+        """,
         commit = "17cbf58aec13c1d494fa0fed826f78560b817de1",
         sha256 = "759ab2d70d6d86d7d8fce6d80863a6368d7d245c96116c0f70cbc7c144873d51",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/meshcat/repository.bzl
+++ b/tools/workspace/meshcat/repository.bzl
@@ -9,8 +9,10 @@ def meshcat_repository(
     github_archive(
         name = name,
         repository = "rdeits/meshcat",
-        # Updating this commit requires local testing; see
-        # drake/tools/workspace/meshcat/README.md for details.
+        upgrade_advice = """
+        Updating this commit requires local testing; see
+        drake/tools/workspace/meshcat/README.md for details.
+        """,
         commit = "ea474eb1e7b595b45145c8104fc9684d49f15231",
         sha256 = "609988dcb6ca3090121ae0b0a149e0c1fab9656a8f2e867786e666264a1d42ca",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/osqp_internal/repository.bzl
+++ b/tools/workspace/osqp_internal/repository.bzl
@@ -8,7 +8,9 @@ def osqp_internal_repository(
     github_archive(
         name = name,
         repository = "osqp/osqp",
-        # When updating this commit, see drake/tools/workspace/qdldl/README.md.
+        upgrade_advice = """
+        When updating this commit, see drake/tools/workspace/qdldl/README.md.
+        """,
         commit = "v0.6.2",
         sha256 = "d973c33c3164caa381ed7387375347a46f7522523350a4e51989479b9d3b59c7",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/qdldl_internal/repository.bzl
+++ b/tools/workspace/qdldl_internal/repository.bzl
@@ -8,7 +8,9 @@ def qdldl_internal_repository(
     github_archive(
         name = name,
         repository = "osqp/qdldl",
-        # When updating this commit, see drake/tools/workspace/qdldl/README.md.
+        upgrade_advice = """
+        When updating this commit, see drake/tools/workspace/qdldl/README.md.
+        """,
         commit = "v0.1.6",
         sha256 = "aeb1b2d76849c13e9803760a4c2e26194bf80dcc9614ae25ca6bcc404dc70d65",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/rules_python/repository.bzl
+++ b/tools/workspace/rules_python/repository.bzl
@@ -11,10 +11,12 @@ def rules_python_repository(
         mirrors = None):
     github_archive(
         name = name,
-        repository = "bazelbuild/rules_python",  # License: Apache-2.0
-        # The commit (version) and sha256 here should be identical to the
-        # commit listed in
-        # drake/tools/install/bazel/test/drake_bazel_installed_test.py.
+        repository = "bazelbuild/rules_python",  # License: Apache-2.0,
+        upgrade_advice = """
+        The commit (version) and sha256 here should be identical to the
+        commit listed in
+        drake/tools/install/bazel/test/drake_bazel_installed_test.py.
+        """,
         commit = "0.19.0",
         sha256 = "ffc7b877c95413c82bfd5482c017edcf759a6250d8b24e82f41f3c8b8d9e287e",  # noqa
         mirrors = mirrors,

--- a/tools/workspace/scs_internal/repository.bzl
+++ b/tools/workspace/scs_internal/repository.bzl
@@ -8,7 +8,9 @@ def scs_internal_repository(
     github_archive(
         name = name,
         repository = "cvxgrp/scs",
-        # When updating this commit, see drake/tools/workspace/qdldl/README.md.
+        upgrade_advice = """
+        When updating this commit, see drake/tools/workspace/qdldl/README.md.
+        """,
         commit = "3.2.0",
         sha256 = "df546b8b8764cacaa0e72bfeb9183586e1c64bc815174cbbecd4c9c1ef18e122",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/usockets/repository.bzl
+++ b/tools/workspace/usockets/repository.bzl
@@ -11,8 +11,10 @@ def usockets_repository(
         # drake/tools/workspace/new_release.py.  When practical, all members
         # of this cohort should be updated at the same time.
         repository = "uNetworking/uSockets",
-        # NOTE: Do not upgrade without testing the tutorials on Deepnote.  See
-        # Drake #18289.  v0.8.5 was tested and showed the same symptoms.
+        upgrade_advice = """
+        NOTE: Do not upgrade without testing the tutorials on Deepnote.  See
+        Drake #18289.  v0.8.5 was tested and showed the same symptoms.
+        """,
         commit = "v0.8.1",
         sha256 = "3b33b5924a92577854e2326b3e2d393849ec00beb865a1271bf24c0f210cc1d6",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/uwebsockets/repository.bzl
+++ b/tools/workspace/uwebsockets/repository.bzl
@@ -11,8 +11,10 @@ def uwebsockets_repository(
         # drake/tools/workspace/new_release.py.  When practical, all members
         # of this cohort should be updated at the same time.
         repository = "uNetworking/uWebSockets",
-        # NOTE: Do not upgrade without testing the tutorials on Deepnote.  See
-        # Drake #18289.  v20.35.0 was tested and showed the same symptoms.
+        upgrade_advice = """
+        NOTE: Do not upgrade without testing the tutorials on Deepnote.  See
+        Drake #18289.  v20.35.0 was tested and showed the same symptoms.
+        """,
         commit = "v20.14.0",
         sha256 = "15cf995844a930c9a36747e8d714b94ff886b6814b5d4e3b3ee176f05681cccc",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/voxelized_geometry_tools/repository.bzl
+++ b/tools/workspace/voxelized_geometry_tools/repository.bzl
@@ -12,8 +12,10 @@ def voxelized_geometry_tools_repository(
     github_archive(
         name = name,
         repository = "ToyotaResearchInstitute/voxelized_geometry_tools",
-        # When updating, ensure that any new unit tests are reflected in
-        # package.BUILD.bazel and BUILD.bazel in drake.
+        upgrade_advice = """
+        When updating, ensure that any new unit tests are reflected in
+        package.BUILD.bazel and BUILD.bazel in drake.
+        """,
         commit = "83f9d52218fcd31a91b3cb493bedbad53fdf2bb3",
         sha256 = "2a04e90bb6ffcf34b502422b808a90c729ae495c525594957c3cdc9db4dce04c",  # noqa
         build_file = ":package.BUILD.bazel",


### PR DESCRIPTION
Fix new_release so it can be run via `bazel run`. Teach it to recognize notices that should be displayed during an upgrade. Add markers to externals that have such information. Update documentation.

This should avoid the need for the user running the script to manually inspect each `repository.bzl` to determine if additional actions need to be performed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18928)
<!-- Reviewable:end -->
