### PR TITLE
[common] Add FindOrCreateCache

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -277,6 +277,18 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "find_cache",
+    srcs = ["find_cache.cc"],
+    hdrs = ["find_cache.h"],
+    internal = True,
+    visibility = ["//:__subpackages__"],
+    interface_deps = [],
+    deps = [
+        ":essential",
+    ],
+)
+
+drake_cc_library(
     name = "find_runfiles",
     srcs = ["find_runfiles.cc"],
     hdrs = ["find_runfiles.h"],
@@ -832,6 +844,14 @@ drake_cc_googletest(
         ":essential",
         ":extract_double",
         "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "find_cache_test",
+    deps = [
+        ":find_cache",
+        ":temp_directory",
     ],
 )
 

--- a/common/find_cache.cc
+++ b/common/find_cache.cc
@@ -1,0 +1,100 @@
+#include "drake/common/find_cache.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <optional>
+#include <utility>
+
+#include <fmt/format.h>
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace internal {
+namespace {
+
+namespace fs = std::filesystem;
+
+#if defined(__APPLE__)
+constexpr bool kApple = true;
+#else
+constexpr bool kApple = false;
+#endif
+
+/* If var_name is set, returns its value. Otherwise, returns nullopt. */
+std::optional<std::string> GetStringEnv(const char* var_name) {
+  const char* const var_value = std::getenv(var_name);
+  if (var_value != nullptr) {
+    return var_value;
+  }
+  return std::nullopt;
+}
+
+/* If var_name is set to a directory that exists, returns that path.
+Otherwise, returns nullopt. */
+std::optional<fs::path> GetPathEnv(const char* var_name) {
+  const char* const var_value = std::getenv(var_name);
+  if (var_value != nullptr) {
+    auto path = fs::path{var_value};
+    std::error_code ec;
+    if (fs::is_directory(path, ec)) {
+      return path;
+    }
+  }
+  return std::nullopt;
+}
+
+/* If path exists, returns it. Otherwise, creates it and returns it. */
+PathOrError CreateDirectory(fs::path path) {
+  std::error_code ec;
+  fs::create_directory(path, ec);
+  if (ec) {
+    return {.error = fmt::format("Could not create {}: {}", path.string(),
+                                 ec.message())};
+  }
+  return {.abspath = fs::canonical(path)};
+}
+
+}  // namespace
+
+PathOrError FindOrCreateCache(std::string_view subdir) {
+  // We'll try the following options to find the ~/.cache, in order:
+  // - ${TEST_TMPDIR}/.cache
+  // - ${XDG_CACHE_HOME}
+  // - /private/var/tmp/.cache_${USER}  (on Apple only)
+  // - ${HOME}/.cache
+  const std::optional<fs::path> test_tmpdir = GetPathEnv("TEST_TMPDIR");
+  const std::optional<fs::path> xdg_cache_home = GetPathEnv("XDG_CACHE_HOME");
+  const std::optional<std::string> user = GetStringEnv("USER");
+  const std::optional<fs::path> home = GetPathEnv("HOME");
+  PathOrError cache_dir;
+  if (test_tmpdir.has_value()) {
+    cache_dir = CreateDirectory(*test_tmpdir / ".cache");
+  } else if (xdg_cache_home.has_value()) {
+    cache_dir.abspath = *xdg_cache_home;
+  } else if (kApple && user.has_value()) {
+    cache_dir = CreateDirectory(fs::path("/private/var/tmp") /
+                                fmt::format(".cache_{}", *user));
+  } else if (home.has_value()) {
+    cache_dir = CreateDirectory(*home / ".cache");
+  } else {
+    return {.error =
+                "Could not determine an appropriate cache_dir to use. "
+                "Set $XDG_CACHE_HOME to a valid scratch directory."};
+  }
+  if (!cache_dir.error.empty()) {
+    return cache_dir;
+  }
+
+  // Create the Drake-specific subdirectory.
+  auto cache_dir_drake = CreateDirectory(cache_dir.abspath / "drake");
+  if (!cache_dir_drake.error.empty()) {
+    return cache_dir_drake;
+  }
+
+  // Create the requested subdirectory.
+  return CreateDirectory(cache_dir_drake.abspath / subdir);
+}
+
+}  // namespace internal
+}  // namespace drake

--- a/common/find_cache.h
+++ b/common/find_cache.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <string_view>
+
+namespace drake {
+namespace internal {
+
+/* The return type of FindOrCreateDrakeCache(). Exactly one of the two strings
+is non-empty. */
+struct PathOrError {
+  /** The absolute path to a writeable, Drake-specific cache directory. */
+  std::filesystem::path abspath;
+  /** The error message. */
+  std::string error;
+};
+
+/* Returns the platform-appropriate location for ~/.cache/drake/{subdir},
+creating it if necessary. */
+PathOrError FindOrCreateCache(std::string_view subdir);
+
+}  // namespace internal
+}  // namespace drake

--- a/common/test/find_cache_test.cc
+++ b/common/test/find_cache_test.cc
@@ -1,0 +1,110 @@
+#include "drake/common/find_cache.h"
+
+#include <cstdlib>
+#include <filesystem>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/temp_directory.h"
+
+namespace drake {
+namespace internal {
+namespace {
+
+namespace fs = std::filesystem;
+
+/* RAII to temporarily change an environment variable. */
+class SetEnv {
+ public:
+  SetEnv(const std::string& var_name, std::optional<std::string> var_value)
+      : var_name_(var_name) {
+    const char* orig = std::getenv(var_name.c_str());
+    if (orig != nullptr) {
+      orig_value_ = orig;
+    }
+    if (var_value.has_value()) {
+      ::setenv(var_name.c_str(), var_value->c_str(), 1);
+    } else {
+      ::unsetenv(var_name.c_str());
+    }
+  }
+
+  ~SetEnv() {
+    if (orig_value_.has_value()) {
+      ::setenv(var_name_.c_str(), orig_value_->c_str(), 1);
+    } else {
+      ::unsetenv(var_name_.c_str());
+    }
+  }
+
+ private:
+  std::string var_name_;
+  std::optional<std::string> orig_value_;
+};
+
+// Check the TEST_TMPDIR case.
+GTEST_TEST(FindCacheTest, TestTmpdir) {
+  // Deny attempts to run this as `bazel-bin/...`; always use `bazel test`.
+  DRAKE_DEMAND(std::getenv("TEST_TMPDIR") != nullptr);
+
+  // Check the DUT.
+  const PathOrError result = FindOrCreateCache("foo");
+  ASSERT_EQ(result.error, "");
+  EXPECT_TRUE(fs::exists(result.abspath));
+  const fs::path expected =
+      fs::path(std::getenv("TEST_TMPDIR")) / ".cache" / "drake" / "foo";
+  EXPECT_EQ(result.abspath, expected);
+}
+
+// Check the XDG_CACHE_HOME case.
+GTEST_TEST(FindCacheTest, XdgCacheHome) {
+  // Prepare the environment.
+  const std::string xdg = temp_directory();
+  const SetEnv env1("TEST_TMPDIR", std::nullopt);
+  const SetEnv env2("XDG_CACHE_HOME", xdg);
+
+  // Check the DUT.
+  const PathOrError result = FindOrCreateCache("bar");
+  ASSERT_EQ(result.error, "");
+  EXPECT_TRUE(fs::exists(result.abspath));
+  const fs::path expected = fs::path(xdg) / "drake" / "bar";
+  EXPECT_EQ(result.abspath, expected);
+}
+
+// Check the HOME case.
+GTEST_TEST(FindCacheTest, Home) {
+  // Prepare the environment.
+  const std::string home = temp_directory();
+  const SetEnv env1("TEST_TMPDIR", std::nullopt);
+  const SetEnv env2("USER", std::nullopt);
+  const SetEnv env3("HOME", home);
+
+  // Check the DUT.
+  const PathOrError result = FindOrCreateCache("baz");
+  ASSERT_EQ(result.error, "");
+  EXPECT_TRUE(fs::exists(result.abspath));
+  const fs::path expected = fs::path(home) / ".cache" / "drake" / "baz";
+  EXPECT_EQ(result.abspath, expected);
+}
+
+// When the cache directory is read-only, we get a reasonable error.
+GTEST_TEST(FindCacheTest, ReadOnlyCache) {
+  // Prepare the environment.
+  const std::string xdg = temp_directory();
+  const SetEnv env1("TEST_TMPDIR", std::nullopt);
+  const SetEnv env2("XDG_CACHE_HOME", xdg);
+
+  // Remove all permissions.
+  fs::permissions(xdg, fs::perms{});
+
+  // Expect a failure.
+  const PathOrError result = FindOrCreateCache("bar");
+  EXPECT_EQ(result.abspath.string(), "");
+  EXPECT_THAT(result.error, testing::MatchesRegex(".*not create.*drake.*"));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace drake


### PR DESCRIPTION
Towards #15774 and #9498.

When we download models from the internet, we need a place to put them.  We could put them in `/tmp`, but that would be a lot of extra downloading.  Instead, we should endeavor to put them into a semi-permanent cache.

For an example use in-situ, see the WIP parser branch [here](https://github.com/jwnimmer-tri/drake/blob/package-map-uberweltenfresser/multibody/parsing/package_map.cc).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18939)
<!-- Reviewable:end -->
