### PR TITLE
[yaml] Add json output

### DIFF
--- a/common/yaml/BUILD.bazel
+++ b/common/yaml/BUILD.bazel
@@ -166,4 +166,4 @@ drake_cc_googletest(
     ],
 )
 
-add_lint_tests()
+add_lint_tests(enable_clang_format_lint = True)

--- a/common/yaml/BUILD.bazel
+++ b/common/yaml/BUILD.bazel
@@ -94,6 +94,15 @@ drake_cc_library(
 )
 
 drake_cc_googletest(
+    name = "json_test",
+    deps = [
+        ":example_structs",
+        ":yaml_io",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
     name = "yaml_doxygen_test",
     deps = [
         ":yaml_io",

--- a/common/yaml/test/example_structs.h
+++ b/common/yaml/test/example_structs.h
@@ -87,9 +87,7 @@ struct ArrayStruct {
     a->Visit(DRAKE_NVP(value));
   }
 
-  ArrayStruct() {
-    value.fill(kNominalDouble);
-  }
+  ArrayStruct() { value.fill(kNominalDouble); }
 
   explicit ArrayStruct(const std::array<double, 3>& value_in)
       : value(value_in) {}
@@ -103,9 +101,7 @@ struct VectorStruct {
     a->Visit(DRAKE_NVP(value));
   }
 
-  VectorStruct() {
-    value.resize(1, kNominalDouble);
-  }
+  VectorStruct() { value.resize(1, kNominalDouble); }
 
   explicit VectorStruct(const std::vector<double>& value_in)
       : value(value_in) {}
@@ -119,9 +115,7 @@ struct NonPodVectorStruct {
     a->Visit(DRAKE_NVP(value));
   }
 
-  NonPodVectorStruct() {
-    value.resize(1, {"kNominalDouble"});
-  }
+  NonPodVectorStruct() { value.resize(1, {"kNominalDouble"}); }
 
   std::vector<StringStruct> value;
 };
@@ -132,9 +126,7 @@ struct MapStruct {
     a->Visit(DRAKE_NVP(value));
   }
 
-  MapStruct() {
-    value["kNominalDouble"] = kNominalDouble;
-  }
+  MapStruct() { value["kNominalDouble"] = kNominalDouble; }
 
   explicit MapStruct(const std::map<std::string, double>& value_in)
       : value(value_in) {}
@@ -148,9 +140,7 @@ struct UnorderedMapStruct {
     a->Visit(DRAKE_NVP(value));
   }
 
-  UnorderedMapStruct() {
-    value["kNominalDouble"] = kNominalDouble;
-  }
+  UnorderedMapStruct() { value["kNominalDouble"] = kNominalDouble; }
 
   explicit UnorderedMapStruct(
       const std::unordered_map<std::string, double>& value_in)
@@ -165,9 +155,7 @@ struct OptionalStruct {
     a->Visit(DRAKE_NVP(value));
   }
 
-  OptionalStruct() {
-    value = kNominalDouble;
-  }
+  OptionalStruct() { value = kNominalDouble; }
 
   explicit OptionalStruct(const double value_in)
       : OptionalStruct(std::optional<double>(value_in)) {}
@@ -184,8 +172,7 @@ struct OptionalStructNoDefault {
     a->Visit(DRAKE_NVP(value));
   }
 
-  OptionalStructNoDefault()
-      : value(std::nullopt) {}
+  OptionalStructNoDefault() : value(std::nullopt) {}
 
   explicit OptionalStructNoDefault(const double value_in)
       : OptionalStructNoDefault(std::optional<double>(value_in)) {}
@@ -239,8 +226,8 @@ using EigenMatrix00Struct = EigenStruct<0, 0>;
 using EigenMatrixUpTo6Struct =
     EigenStruct<Eigen::Dynamic, Eigen::Dynamic, 6, 6>;
 
-using Variant4 = std::variant<
-    std::string, double, DoubleStruct, EigenVecStruct>;
+using Variant4 =
+    std::variant<std::string, double, DoubleStruct, EigenVecStruct>;
 
 std::ostream& operator<<(std::ostream& os, const Variant4& value) {
   if (value.index() == 0) {
@@ -261,12 +248,9 @@ struct VariantStruct {
     a->Visit(DRAKE_NVP(value));
   }
 
-  VariantStruct() {
-    value = kNominalDouble;
-  }
+  VariantStruct() { value = kNominalDouble; }
 
-  explicit VariantStruct(const Variant4& value_in)
-      : value(value_in) {}
+  explicit VariantStruct(const Variant4& value_in) : value(value_in) {}
 
   Variant4 value;
 };

--- a/common/yaml/test/json_test.cc
+++ b/common/yaml/test/json_test.cc
@@ -1,0 +1,106 @@
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/yaml/test/example_structs.h"
+#include "drake/common/yaml/yaml_io.h"
+
+namespace drake {
+namespace yaml {
+namespace test {
+namespace {
+
+GTEST_TEST(YamlJsonTest, WriteScalars) {
+  AllScalarsStruct data;
+  constexpr char expected[] =
+      R"""({"some_bool":false,"some_double":1.2345,"some_float":1.2345,"some_int32":12,"some_int64":14,"some_string":"kNominalString","some_uint32":12,"some_uint64":15})""";
+  EXPECT_EQ(SaveJsonString(data), expected);
+}
+
+GTEST_TEST(YamlJsonTest, StringEscaping) {
+  StringStruct data;
+  data.value = "foo\n\"bar\"\t";
+  EXPECT_EQ(SaveJsonString(data),
+            R"""({"value":"foo\u000a\u0022bar\u0022\u0009"})""");
+}
+
+GTEST_TEST(YamlJsonTest, NonFinite) {
+  DoubleStruct data;
+
+  data.value = std::numeric_limits<double>::infinity();
+  EXPECT_EQ(SaveJsonString(data), R"""({"value":Infinity})""");
+
+  data.value = -data.value;
+  EXPECT_EQ(SaveJsonString(data), R"""({"value":-Infinity})""");
+
+  data.value = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_EQ(SaveJsonString(data), R"""({"value":NaN})""");
+}
+
+GTEST_TEST(YamlJsonTest, WriteSequence) {
+  VectorStruct data;
+  data.value = {1.0, 2.0};
+  EXPECT_EQ(SaveJsonString(data), R"""({"value":[1.0,2.0]})""");
+}
+
+GTEST_TEST(YamlJsonTest, WriteMapping) {
+  MapStruct data;
+  data.value.clear();
+  data.value["a"] = 1.0;
+  data.value["b"] = 2.0;
+  EXPECT_EQ(SaveJsonString(data), R"""({"value":{"a":1.0,"b":2.0}})""");
+}
+
+GTEST_TEST(YamlJsonTest, WriteNested) {
+  OuterStruct data;
+  EXPECT_EQ(
+      SaveJsonString(data),
+      R"""({"inner_struct":{"inner_value":1.2345},"outer_value":1.2345})""");
+}
+
+GTEST_TEST(YamlJsonTest, WriteOptional) {
+  OptionalStruct data;
+  EXPECT_EQ(SaveJsonString(data), R"""({"value":1.2345})""");
+
+  data.value.reset();
+  EXPECT_EQ(SaveJsonString(data), "{}");
+}
+
+GTEST_TEST(YamlJsonTest, WriteVariant) {
+  VariantStruct data;
+
+  data.value = std::string{"foo"};
+  EXPECT_EQ(SaveJsonString(data), R"""({"value":"foo"})""");
+
+  // It would be plausible here to use the `_tag` convention to annotate
+  // variant tags, matching what we do in our yaml.py conventions.
+  data.value = DoubleStruct{};
+  DRAKE_EXPECT_THROWS_MESSAGE(SaveJsonString(data),
+                              ".*SaveJsonString.*mapping.*tag.*");
+}
+
+struct IntVariant {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(value));
+  }
+
+  std::variant<int, uint64_t> value{0};
+};
+
+GTEST_TEST(YamlJsonTest, WriteVariantScalar) {
+  IntVariant data;
+
+  data.value.emplace<int>(1);
+  EXPECT_EQ(SaveJsonString(data), R"""({"value":1})""");
+
+  data.value.emplace<uint64_t>(22);
+  DRAKE_EXPECT_THROWS_MESSAGE(SaveJsonString(data),
+                              ".*SaveJsonString.*scalar.*22.*tag.*");
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace yaml
+}  // namespace drake

--- a/common/yaml/test/yaml_io_test.cc
+++ b/common/yaml/test/yaml_io_test.cc
@@ -75,13 +75,13 @@ extra_junk: will_be_ignored
   const std::optional<StringStruct> no_defaults;
   LoadYamlOptions options;
   options.allow_yaml_with_no_cpp = true;
-  const auto result = LoadYamlString<StringStruct>(
-      data, no_child_name, no_defaults, options);
+  const auto result =
+      LoadYamlString<StringStruct>(data, no_child_name, no_defaults, options);
   EXPECT_EQ(result.value, "some_value");
   // Cross-check that the options actually were important.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      LoadYamlString<StringStruct>(
-          data, no_child_name, no_defaults, { /* no options */ }),
+      LoadYamlString<StringStruct>(data, no_child_name, no_defaults,
+                                   {/* no options */}),
       ".*extra_junk.*");
 }
 
@@ -96,8 +96,8 @@ extra_junk:
   const MapStruct defaults;  // The defaults contains kNominalDouble already.
   LoadYamlOptions options;
   options.allow_yaml_with_no_cpp = true;
-  const auto result = LoadYamlString<MapStruct>(
-      data, no_child_name, defaults, options);
+  const auto result =
+      LoadYamlString<MapStruct>(data, no_child_name, defaults, options);
   // When user options are provided, the implicit options that would otherwise
   // be used for defaults parsing are not in effect; thus, retain_map_defaults
   // will be false and kNominalDouble is not present in the result.
@@ -106,23 +106,23 @@ extra_junk:
 }
 
 GTEST_TEST(YamlIoTest, LoadFile) {
-  const std::string filename = FindResourceOrThrow(
-      "drake/common/yaml/test/yaml_io_test_input_1.yaml");
+  const std::string filename =
+      FindResourceOrThrow("drake/common/yaml/test/yaml_io_test_input_1.yaml");
   const auto result = LoadYamlFile<StringStruct>(filename);
   EXPECT_EQ(result.value, "some_value_1");
 }
 
 GTEST_TEST(YamlIoTest, LoadFileChildName) {
-  const std::string filename = FindResourceOrThrow(
-      "drake/common/yaml/test/yaml_io_test_input_2.yaml");
+  const std::string filename =
+      FindResourceOrThrow("drake/common/yaml/test/yaml_io_test_input_2.yaml");
   const std::string child_name = "some_string_struct";
   const auto result = LoadYamlFile<StringStruct>(filename, child_name);
   EXPECT_EQ(result.value, "some_value_2");
 }
 
 GTEST_TEST(YamlIoTest, LoadFileChildNameBad) {
-  const std::string filename = FindResourceOrThrow(
-      "drake/common/yaml/test/yaml_io_test_input_2.yaml");
+  const std::string filename =
+      FindResourceOrThrow("drake/common/yaml/test/yaml_io_test_input_2.yaml");
   const std::string child_name = "wrong_child_name";
   DRAKE_EXPECT_THROWS_MESSAGE(
       LoadYamlFile<StringStruct>(filename, child_name),
@@ -189,9 +189,8 @@ GTEST_TEST(YamlIoTest, SaveFileAllArgs) {
 
 GTEST_TEST(YamlIoTest, SaveFileBad) {
   const std::string filename = temp_directory() + "/no_such_dir/file.yaml";
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      SaveYamlFile(filename, StringStruct{}),
-      ".* could not open .*/no_such_dir/.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(SaveYamlFile(filename, StringStruct{}),
+                              ".* could not open .*/no_such_dir/.*");
 }
 
 }  // namespace

--- a/common/yaml/test/yaml_node_test.cc
+++ b/common/yaml/test/yaml_node_test.cc
@@ -42,21 +42,20 @@ using Param = std::tuple<NodeType, std::string_view>;
 class YamlNodeParamaterizedTest : public testing::TestWithParam<Param> {
  protected:
   // Returns the test suite's desired type.
-  NodeType GetExpectedType() {
-    return std::get<0>(GetParam());
-  }
+  NodeType GetExpectedType() { return std::get<0>(GetParam()); }
 
   // Returns the test suite's desired type string.
-  std::string_view GetExpectedTypeString() {
-    return std::get<1>(GetParam());
-  }
+  std::string_view GetExpectedTypeString() { return std::get<1>(GetParam()); }
 
   // Returns a new, empty Node with using the test suite's desired type.
   Node MakeEmptyDut() {
     switch (GetExpectedType()) {
-      case NodeType::kScalar:   return Node::MakeScalar();
-      case NodeType::kSequence: return Node::MakeSequence();
-      case NodeType::kMapping:  return Node::MakeMapping();
+      case NodeType::kScalar:
+        return Node::MakeScalar();
+      case NodeType::kSequence:
+        return Node::MakeSequence();
+      case NodeType::kMapping:
+        return Node::MakeMapping();
     }
     DRAKE_UNREACHABLE();
   }
@@ -84,9 +83,8 @@ class YamlNodeParamaterizedTest : public testing::TestWithParam<Param> {
   // Given a function name, returns the expected exception message in case the
   // runtime type of the Node is incorrect.
   std::string GetExpectedCannot(std::string_view operation) {
-    return fmt::format(
-        ".*Cannot.*{}.*on a {}.*",
-        operation, GetExpectedTypeString());
+    return fmt::format(".*Cannot.*{}.*on a {}.*", operation,
+                       GetExpectedTypeString());
   }
 };
 
@@ -170,8 +168,8 @@ TEST_P(YamlNodeParamaterizedTest, ScalarOps) {
     EXPECT_FALSE(dut == dut2);
     EXPECT_EQ(dut2.GetScalar(), "foo");
   } else {
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        dut.GetScalar(), GetExpectedCannot("GetScalar"));
+    DRAKE_EXPECT_THROWS_MESSAGE(dut.GetScalar(),
+                                GetExpectedCannot("GetScalar"));
   }
 }
 
@@ -185,10 +183,10 @@ TEST_P(YamlNodeParamaterizedTest, SequenceOps) {
     ASSERT_EQ(dut2.GetSequence().size(), 1);
     EXPECT_EQ(dut2.GetSequence().front().GetScalar(), "item");
   } else {
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        dut.GetSequence(), GetExpectedCannot("GetSequence"));
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        dut.Add(Node::MakeNull()), GetExpectedCannot("Add"));
+    DRAKE_EXPECT_THROWS_MESSAGE(dut.GetSequence(),
+                                GetExpectedCannot("GetSequence"));
+    DRAKE_EXPECT_THROWS_MESSAGE(dut.Add(Node::MakeNull()),
+                                GetExpectedCannot("Add"));
   }
 }
 
@@ -197,42 +195,31 @@ TEST_P(YamlNodeParamaterizedTest, MappingOps) {
   Node dut = MakeEmptyDut();
   if (dut.IsMapping()) {
     EXPECT_TRUE(dut.GetMapping().empty());
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        dut.Remove("quux"),
-        ".*No such key.*'quux'.*");
+    DRAKE_EXPECT_THROWS_MESSAGE(dut.Remove("quux"), ".*No such key.*'quux'.*");
     Node dut2 = MakeNonEmptyDut();
     EXPECT_FALSE(dut == dut2);
     ASSERT_EQ(dut2.GetMapping().size(), 1);
     EXPECT_EQ(dut2.GetMapping().begin()->first, "key");
     EXPECT_EQ(dut2.At("key").GetScalar(), "value");
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        dut2.Add("key", Node::MakeScalar()),
-        "Cannot .*Add.* duplicate key 'key'");
+    DRAKE_EXPECT_THROWS_MESSAGE(dut2.Add("key", Node::MakeScalar()),
+                                "Cannot .*Add.* duplicate key 'key'");
     dut2.Remove("key");
     EXPECT_TRUE(dut.GetMapping().empty());
   } else {
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        dut.GetMapping(), GetExpectedCannot("GetMapping"));
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        dut.Add("key", Node::MakeNull()), GetExpectedCannot("Add"));
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        dut.At("key"), GetExpectedCannot("At"));
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        dut.Remove("key"), GetExpectedCannot("Remove"));
+    DRAKE_EXPECT_THROWS_MESSAGE(dut.GetMapping(),
+                                GetExpectedCannot("GetMapping"));
+    DRAKE_EXPECT_THROWS_MESSAGE(dut.Add("key", Node::MakeNull()),
+                                GetExpectedCannot("Add"));
+    DRAKE_EXPECT_THROWS_MESSAGE(dut.At("key"), GetExpectedCannot("At"));
+    DRAKE_EXPECT_THROWS_MESSAGE(dut.Remove("key"), GetExpectedCannot("Remove"));
   }
 }
 
 // Helper to check visiting.
 struct VisitorThatCopies {
-  void operator()(const Node::ScalarData& data) {
-    scalar = data.scalar;
-  }
-  void operator()(const Node::SequenceData& data) {
-    sequence = data.sequence;
-  }
-  void operator()(const Node::MappingData& data) {
-    mapping = data.mapping;
-  }
+  void operator()(const Node::ScalarData& data) { scalar = data.scalar; }
+  void operator()(const Node::SequenceData& data) { sequence = data.sequence; }
+  void operator()(const Node::MappingData& data) { mapping = data.mapping; }
 
   std::optional<std::string> scalar;
   std::optional<std::vector<Node>> sequence;
@@ -281,9 +268,18 @@ TEST_P(YamlNodeParamaterizedTest, ToString) {
   // substring within the printed result.
   std::string needle;
   switch (GetExpectedType()) {
-    case NodeType::kScalar:   { needle = "foo";  break; }
-    case NodeType::kSequence: { needle = "item"; break; }
-    case NodeType::kMapping:  { needle = "key";  break; }
+    case NodeType::kScalar: {
+      needle = "foo";
+      break;
+    }
+    case NodeType::kSequence: {
+      needle = "item";
+      break;
+    }
+    case NodeType::kMapping: {
+      needle = "key";
+      break;
+    }
   }
   EXPECT_THAT(fmt::format("{}", dut), testing::HasSubstr(needle));
 
@@ -292,10 +288,10 @@ TEST_P(YamlNodeParamaterizedTest, ToString) {
   EXPECT_THAT(fmt::format("{}", dut), testing::HasSubstr("MyTag"));
 }
 
-INSTANTIATE_TEST_SUITE_P(Suite, YamlNodeParamaterizedTest, testing::Values(
-    Param(NodeType::kScalar, "Scalar"),
-    Param(NodeType::kSequence, "Sequence"),
-    Param(NodeType::kMapping, "Mapping")));
+INSTANTIATE_TEST_SUITE_P(Suite, YamlNodeParamaterizedTest,
+                         testing::Values(Param(NodeType::kScalar, "Scalar"),
+                                         Param(NodeType::kSequence, "Sequence"),
+                                         Param(NodeType::kMapping, "Mapping")));
 
 }  // namespace
 }  // namespace internal

--- a/common/yaml/test/yaml_node_test.cc
+++ b/common/yaml/test/yaml_node_test.cc
@@ -21,9 +21,10 @@ namespace {
 
 // Check that the tag constants exist.
 GTEST_TEST(YamlNodeTest, TagConstants) {
-  EXPECT_GT(Node::kTagFloat.size(), 0);
-  EXPECT_GT(Node::kTagInt.size(), 0);
   EXPECT_GT(Node::kTagNull.size(), 0);
+  EXPECT_GT(Node::kTagBool.size(), 0);
+  EXPECT_GT(Node::kTagInt.size(), 0);
+  EXPECT_GT(Node::kTagFloat.size(), 0);
   EXPECT_GT(Node::kTagStr.size(), 0);
 }
 
@@ -103,12 +104,25 @@ TEST_P(YamlNodeParamaterizedTest, StaticTypeString) {
   EXPECT_EQ(Node::GetTypeString(GetExpectedType()), GetExpectedTypeString());
 }
 
-// Check tag getting and setting.
+// Check generic tag getting and setting.
 TEST_P(YamlNodeParamaterizedTest, GetSetTag) {
   Node dut = MakeEmptyDut();
   EXPECT_EQ(dut.GetTag(), "");
   dut.SetTag("tag");
   EXPECT_EQ(dut.GetTag(), "tag");
+}
+
+// Check JSON Schema tag getting and setting.
+TEST_P(YamlNodeParamaterizedTest, JsonSchemaTag) {
+  Node dut = MakeEmptyDut();
+  dut.SetTag(JsonSchemaTag::kNull);
+  EXPECT_EQ(dut.GetTag(), Node::kTagNull);
+  dut.SetTag(JsonSchemaTag::kBool);
+  EXPECT_EQ(dut.GetTag(), Node::kTagBool);
+  dut.SetTag(JsonSchemaTag::kInt);
+  EXPECT_EQ(dut.GetTag(), Node::kTagInt);
+  dut.SetTag(JsonSchemaTag::kFloat);
+  EXPECT_EQ(dut.GetTag(), Node::kTagFloat);
 }
 
 // It is important for our YAML subsystem performance that the Node's move
@@ -156,8 +170,15 @@ TEST_P(YamlNodeParamaterizedTest, EqualityPerTag) {
   Node dut = MakeEmptyDut();
   Node dut2 = MakeEmptyDut();
   EXPECT_TRUE(dut == dut2);
+
+  // Different tag; not equal.
   dut2.SetTag("tag");
   EXPECT_FALSE(dut == dut2);
+
+  // Same tag, set via two different overloads; still equal.
+  dut.SetTag(JsonSchemaTag::kInt);
+  dut2.SetTag(std::string{Node::kTagInt});
+  EXPECT_TRUE(dut == dut2);
 }
 
 // Check Scalar-specific operations.

--- a/common/yaml/test/yaml_read_archive_test.cc
+++ b/common/yaml/test/yaml_read_archive_test.cc
@@ -31,15 +31,14 @@ using internal::YamlReadArchive;
 // TODO(jwnimmer-tri) Add a test case for reading UnorderedMapStruct.
 
 // A test fixture with common helpers.
-class YamlReadArchiveTest
-    : public ::testing::TestWithParam<LoadYamlOptions> {
+class YamlReadArchiveTest : public ::testing::TestWithParam<LoadYamlOptions> {
  public:
   // Loads a single "doc: { ... }" map from `contents` and returns the nested
   // map (i.e., just the "{ ... }" part, not the "doc" part).  It is an error
   // for the "{ ... }" part not to be a map node.
   static internal::Node Load(const std::string& contents) {
-    const internal::Node loaded = YamlReadArchive::LoadStringAsNode(
-       contents, std::nullopt);
+    const internal::Node loaded =
+        YamlReadArchive::LoadStringAsNode(contents, std::nullopt);
     if (!loaded.IsMapping()) {
       throw std::logic_error("Bad contents parse " + contents);
     }
@@ -109,8 +108,8 @@ class YamlReadArchiveTest
       EXPECT_EQ(what, "");
     } else {
       EXPECT_TRUE(raised);
-      EXPECT_THAT(what, testing::MatchesRegex(
-          ".*missing entry for [^ ]* value.*"));
+      EXPECT_THAT(what,
+                  testing::MatchesRegex(".*missing entry for [^ ]* value.*"));
     }
     return result;
   }
@@ -336,7 +335,8 @@ doc:
   value:
     << : *template
     bar: 2.0
-)""", {{"foo", 1.0}, {"bar", 2.0}});
+)""",
+       {{"foo", 1.0}, {"bar", 2.0}});
 
   // A pre-existing value should win, though.
   test(R"""(
@@ -348,7 +348,8 @@ doc:
     << : *template
     foo: 1.0
     bar: 2.0
-)""", {{"foo", 1.0}, {"bar", 2.0}});
+)""",
+       {{"foo", 1.0}, {"bar", 2.0}});
 
   // A list of merges should also work.
   test(R"""(
@@ -360,7 +361,8 @@ doc:
   value:
     << : *template
     bar: 2.0
-)""", {{"foo", 1.0}, {"bar", 2.0}, {"baz", 3.0}});
+)""",
+       {{"foo", 1.0}, {"bar", 2.0}, {"baz", 3.0}});
 }
 
 TEST_P(YamlReadArchiveTest, StdMapWithBadMergeKey) {
@@ -515,8 +517,7 @@ TEST_P(YamlReadArchiveTest, Optional) {
 }
 
 TEST_P(YamlReadArchiveTest, Variant) {
-  const auto test = [](const std::string& doc,
-                       const Variant4& expected) {
+  const auto test = [](const std::string& doc, const Variant4& expected) {
     const auto& x = AcceptNoThrow<VariantStruct>(Load(doc));
     EXPECT_EQ(x.value, expected) << doc;
   };
@@ -561,12 +562,11 @@ TEST_P(YamlReadArchiveTest, EigenVectorX) {
 }
 
 TEST_P(YamlReadArchiveTest, EigenVectorOverflow) {
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      AcceptIntoDummy<EigenVecUpTo3Struct>(Load(R"""(
+  DRAKE_EXPECT_THROWS_MESSAGE(AcceptIntoDummy<EigenVecUpTo3Struct>(Load(R"""(
 doc:
   value: [0, 0, 0, 0]
 )""")),
-      ".*maximum size is 3.*");
+                              ".*maximum size is 3.*");
 }
 
 TEST_P(YamlReadArchiveTest, EigenMatrix) {
@@ -585,13 +585,13 @@ doc:
   - [0.0, 1.0, 2.0, 3.0]
   - [4.0, 5.0, 6.0, 7.0]
   - [8.0, 9.0, 10.0, 11.0]
-)""", (Matrix34d{} << 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).finished());
+)""",
+       (Matrix34d{} << 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).finished());
 }
 
 TEST_P(YamlReadArchiveTest, EigenMatrixUpTo6) {
   using Matrix34d = Eigen::Matrix<double, 3, 4>;
-  const auto test = [](const std::string& doc,
-                       const Matrix34d& expected) {
+  const auto test = [](const std::string& doc, const Matrix34d& expected) {
     const auto& mat = AcceptNoThrow<EigenMatrixUpTo6Struct>(Load(doc));
     EXPECT_TRUE(drake::CompareMatrices(mat.value, expected));
   };
@@ -602,7 +602,8 @@ doc:
   - [0.0, 1.0, 2.0, 3.0]
   - [4.0, 5.0, 6.0, 7.0]
   - [8.0, 9.0, 10.0, 11.0]
-)""", (Matrix34d{} << 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).finished());
+)""",
+       (Matrix34d{} << 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).finished());
 }
 
 TEST_P(YamlReadArchiveTest, EigenMatrix00) {
@@ -652,8 +653,8 @@ TEST_P(YamlReadArchiveTest, NestedWithMergeKeys) {
   const auto test = [](const std::string& orig_doc) {
     std::string doc = orig_doc;
     if (!GetParam().allow_yaml_with_no_cpp) {
-      doc = std::regex_replace(
-          orig_doc, std::regex(" *ignored_key: ignored_value"), "");
+      doc = std::regex_replace(orig_doc,
+                               std::regex(" *ignored_key: ignored_value"), "");
     }
     SCOPED_TRACE("With doc = " + doc);
     const auto& x = AcceptNoThrow<OuterStruct>(Load(doc));
@@ -765,8 +766,7 @@ doc:
   inner_struct:
     inner_value_TYPO: 2.0
 )""");
-  if (GetParam().allow_cpp_with_no_yaml &&
-      GetParam().allow_yaml_with_no_cpp) {
+  if (GetParam().allow_cpp_with_no_yaml && GetParam().allow_yaml_with_no_cpp) {
     const auto& x = AcceptNoThrow<OuterStruct>(node);
     EXPECT_EQ(x.outer_value, 1.0);
     EXPECT_EQ(x.inner_struct.inner_value, kNominalDouble);
@@ -1066,9 +1066,8 @@ std::vector<LoadYamlOptions> MakeAllPossibleOptions() {
   return all;
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    AllOptions, YamlReadArchiveTest,
-    ::testing::ValuesIn(MakeAllPossibleOptions()));
+INSTANTIATE_TEST_SUITE_P(AllOptions, YamlReadArchiveTest,
+                         ::testing::ValuesIn(MakeAllPossibleOptions()));
 
 }  // namespace
 }  // namespace test

--- a/common/yaml/test/yaml_write_archive_defaults_test.cc
+++ b/common/yaml/test/yaml_write_archive_defaults_test.cc
@@ -135,10 +135,10 @@ TEST_F(YamlWriteArchiveDefaultsTest, Nulls) {
 // Arrays differing in their values are not erased.
 TEST_F(YamlWriteArchiveDefaultsTest, DifferentArrays) {
   ArrayStruct data;
-  data.value = { 1.0, 2.0, 3.0 };
+  data.value = {1.0, 2.0, 3.0};
 
   ArrayStruct defaults;
-  defaults.value = { 0.0, 0.0, 0.0 };
+  defaults.value = {0.0, 0.0, 0.0};
 
   EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"""(doc:
   value: [1.0, 2.0, 3.0]
@@ -148,10 +148,10 @@ TEST_F(YamlWriteArchiveDefaultsTest, DifferentArrays) {
 // Vectors differing in size (but sharing a prefix) are not erased.
 TEST_F(YamlWriteArchiveDefaultsTest, DifferentSizeVectors) {
   VectorStruct data;
-  data.value = { 1.0, 2.0, 3.0 };
+  data.value = {1.0, 2.0, 3.0};
 
   VectorStruct defaults;
-  defaults.value = { 1.0, 2.0 };
+  defaults.value = {1.0, 2.0};
 
   EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"""(doc:
   value: [1.0, 2.0, 3.0]

--- a/common/yaml/test/yaml_write_archive_test.cc
+++ b/common/yaml/test/yaml_write_archive_test.cc
@@ -106,8 +106,8 @@ TEST_F(YamlWriteArchiveTest, StdVector) {
   // "block" style, where each gets its own line(s).
   NonPodVectorStruct x;
   x.value = {
-    {.value = "foo"},
-    {.value = "bar"},
+      {.value = "foo"},
+      {.value = "bar"},
   };
   EXPECT_EQ(Save(x), R"""(doc:
   value:
@@ -139,7 +139,6 @@ TEST_F(YamlWriteArchiveTest, StdMap) {
 )""");
 }
 
-
 TEST_F(YamlWriteArchiveTest, StdUnorderedMap) {
   const auto test = [](const std::unordered_map<std::string, double>& value,
                        const std::string& expected) {
@@ -150,17 +149,14 @@ TEST_F(YamlWriteArchiveTest, StdUnorderedMap) {
   // The YamlWriteArchive API promises that the output must be deterministic.
   // Here, we test a stronger condition that it's always sorted.  (If in the
   // future we decide to use a different order, we can update here to match.)
-  test({
-    // Use many values to increase the chance that we'll detect implementations
-    // that fail to sort.
-    {"gulf", 6.0},
-    {"fox", 5.0},
-    {"echo", 4.0},
-    {"delta", 3.0},
-    {"charlie", 2.0},
-    {"bravo", 1.0},
-    {"alpha", 0.0},
-  }, R"""(doc:
+  const std::unordered_map<std::string, double> value{
+      // Use many values to increase the chance that we'll detect
+      // implementations that fail to sort.
+      {"gulf", 6.0},    {"fox", 5.0},   {"echo", 4.0},  {"delta", 3.0},
+      {"charlie", 2.0}, {"bravo", 1.0}, {"alpha", 0.0},
+  };
+  test(value,
+       R"""(doc:
   value:
     alpha: 0.0
     bravo: 1.0

--- a/common/yaml/yaml_io.cc
+++ b/common/yaml/yaml_io.cc
@@ -6,19 +6,16 @@ namespace drake {
 namespace yaml {
 namespace internal {
 
-void WriteFile(
-    const std::string& filename, const std::string& data) {
+void WriteFile(const std::string& filename, const std::string& data) {
   std::ofstream out(filename, std::ios::binary);
   if (out.fail()) {
     throw std::runtime_error(fmt::format(
-        "SaveYamlFile() could not open '{}' for writing",
-        filename));
+        "SaveYamlFile() could not open '{}' for writing", filename));
   }
   out << data;
   if (out.fail()) {
-    throw std::runtime_error(fmt::format(
-        "SaveYamlFile() could not write to '{}'",
-        filename));
+    throw std::runtime_error(
+        fmt::format("SaveYamlFile() could not write to '{}'", filename));
   }
 }
 

--- a/common/yaml/yaml_io.h
+++ b/common/yaml/yaml_io.h
@@ -115,6 +115,21 @@ std::string SaveYamlString(
     const std::optional<std::string>& child_name = std::nullopt,
     const std::optional<Serializable>& defaults = std::nullopt);
 
+/** Saves data as a JSON-formatted string.
+
+Refer to @ref yaml_serialization "YAML Serialization" for background.
+
+Note that there is no LoadJsonString() function, because LoadYamlString() can
+already load JSON data.
+
+@param data User data to be serialized.
+@returns the JSON data as a string.
+
+@tparam Serializable must implement a @ref implementing_serialize "Serialize"
+  function. */
+template <typename Serializable>
+std::string SaveJsonString(const Serializable& data);
+
 namespace internal {
 
 void WriteFile(const std::string& filename, const std::string& data);
@@ -185,6 +200,15 @@ std::string SaveYamlString(const Serializable& data,
     archive.EraseMatchingMaps(defaults_archive);
   }
   return archive.EmitString(child_name.value_or(std::string()));
+}
+
+// (Implementation of a function declared above.  This could be defined
+// inline, but we keep it with the others for consistency.)
+template <typename Serializable>
+std::string SaveJsonString(const Serializable& data) {
+  internal::YamlWriteArchive archive;
+  archive.Accept(data);
+  return archive.ToJson();
 }
 
 }  // namespace yaml

--- a/common/yaml/yaml_io.h
+++ b/common/yaml/yaml_io.h
@@ -85,11 +85,9 @@ only one entry, whose key is `child_name` and value is the serialized `data`.
 @tparam Serializable must implement a @ref implementing_serialize "Serialize"
   function. */
 template <typename Serializable>
-void SaveYamlFile(
-    const std::string& filename,
-    const Serializable& data,
-    const std::optional<std::string>& child_name = std::nullopt,
-    const std::optional<Serializable>& defaults = std::nullopt);
+void SaveYamlFile(const std::string& filename, const Serializable& data,
+                  const std::optional<std::string>& child_name = std::nullopt,
+                  const std::optional<Serializable>& defaults = std::nullopt);
 
 /** Saves data as a YAML-formatted string.
 
@@ -122,10 +120,9 @@ namespace internal {
 void WriteFile(const std::string& filename, const std::string& data);
 
 template <typename Serializable>
-static Serializable LoadNode(
-    internal::Node node,
-    const std::optional<Serializable>& defaults,
-    const std::optional<LoadYamlOptions>& options) {
+static Serializable LoadNode(internal::Node node,
+                             const std::optional<Serializable>& defaults,
+                             const std::optional<LoadYamlOptions>& options) {
   // Reify our optional arguments.
   Serializable result = defaults.value_or(Serializable{});
   LoadYamlOptions new_options = options.value_or(LoadYamlOptions{});
@@ -145,12 +142,11 @@ static Serializable LoadNode(
 // inline because we need internal::LoadNode to be declared.)
 template <typename Serializable>
 static Serializable LoadYamlFile(
-    const std::string& filename,
-    const std::optional<std::string>& child_name,
+    const std::string& filename, const std::optional<std::string>& child_name,
     const std::optional<Serializable>& defaults,
     const std::optional<LoadYamlOptions>& options) {
-  internal::Node node = internal::YamlReadArchive::LoadFileAsNode(
-      filename, child_name);
+  internal::Node node =
+      internal::YamlReadArchive::LoadFileAsNode(filename, child_name);
   return internal::LoadNode(std::move(node), defaults, options);
 }
 
@@ -158,34 +154,29 @@ static Serializable LoadYamlFile(
 // inline because we need internal::LoadNode to be declared.)
 template <typename Serializable>
 static Serializable LoadYamlString(
-    const std::string& data,
-    const std::optional<std::string>& child_name,
+    const std::string& data, const std::optional<std::string>& child_name,
     const std::optional<Serializable>& defaults,
     const std::optional<LoadYamlOptions>& options) {
-  internal::Node node = internal::YamlReadArchive::LoadStringAsNode(
-      data, child_name);
+  internal::Node node =
+      internal::YamlReadArchive::LoadStringAsNode(data, child_name);
   return internal::LoadNode(std::move(node), defaults, options);
 }
 
 // (Implementation of a function declared above.  This cannot be defined
 // inline because we need SaveYamlString to be declared.)
 template <typename Serializable>
-void SaveYamlFile(
-    const std::string& filename,
-    const Serializable& data,
-    const std::optional<std::string>& child_name,
-    const std::optional<Serializable>& defaults) {
-  internal::WriteFile(filename,
-      SaveYamlString(data, child_name, defaults));
+void SaveYamlFile(const std::string& filename, const Serializable& data,
+                  const std::optional<std::string>& child_name,
+                  const std::optional<Serializable>& defaults) {
+  internal::WriteFile(filename, SaveYamlString(data, child_name, defaults));
 }
 
 // (Implementation of a function declared above.  This could be defined
 // inline, but we keep it with the others for consistency.)
 template <typename Serializable>
-std::string SaveYamlString(
-    const Serializable& data,
-    const std::optional<std::string>& child_name,
-    const std::optional<Serializable>& defaults) {
+std::string SaveYamlString(const Serializable& data,
+                           const std::optional<std::string>& child_name,
+                           const std::optional<Serializable>& defaults) {
   internal::YamlWriteArchive archive;
   archive.Accept(data);
   if (defaults.has_value()) {

--- a/common/yaml/yaml_io_options.cc
+++ b/common/yaml/yaml_io_options.cc
@@ -4,12 +4,9 @@ namespace drake {
 namespace yaml {
 
 std::ostream& operator<<(std::ostream& os, const LoadYamlOptions& x) {
-  return os << "{.allow_yaml_with_no_cpp = "
-            << x.allow_yaml_with_no_cpp
-            << ", .allow_cpp_with_no_yaml = "
-            << x.allow_cpp_with_no_yaml
-            << ", .retain_map_defaults = "
-            << x.retain_map_defaults << "}";
+  return os << "{.allow_yaml_with_no_cpp = " << x.allow_yaml_with_no_cpp
+            << ", .allow_cpp_with_no_yaml = " << x.allow_cpp_with_no_yaml
+            << ", .retain_map_defaults = " << x.retain_map_defaults << "}";
 }
 
 }  // namespace yaml

--- a/common/yaml/yaml_io_options.h
+++ b/common/yaml/yaml_io_options.h
@@ -33,10 +33,8 @@ struct LoadYamlOptions {
 }  // namespace yaml
 }  // namespace drake
 
-
 // TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
 namespace fmt {
 template <>
-struct formatter<drake::yaml::LoadYamlOptions>
-    : drake::ostream_formatter {};
+struct formatter<drake::yaml::LoadYamlOptions> : drake::ostream_formatter {};
 }  // namespace fmt

--- a/common/yaml/yaml_node.cc
+++ b/common/yaml/yaml_node.cc
@@ -13,11 +13,16 @@ namespace internal {
 namespace {
 
 // Boilerplate for std::visit.
-template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
-template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+template <class... Ts>
+struct overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
 
 // Converts a type T from our variant<> into a string name for errors.
-template <typename T> std::string_view GetNiceVariantName(const T&) {
+template <typename T>
+std::string_view GetNiceVariantName(const T&) {
   if constexpr (std::is_same_v<T, Node::ScalarData>) {
     return "Scalar";
   } else if constexpr (std::is_same_v<T, Node::SequenceData>) {
@@ -57,17 +62,27 @@ Node Node::MakeNull() {
 }
 
 NodeType Node::GetType() const {
-  return std::visit(overloaded{
-    [](const ScalarData&) { return NodeType::kScalar; },
-    [](const SequenceData&) { return NodeType::kSequence; },
-    [](const MappingData&) { return NodeType::kMapping; },
-  }, data_);
+  return std::visit(  // BR
+      overloaded{
+          [](const ScalarData&) {
+            return NodeType::kScalar;
+          },
+          [](const SequenceData&) {
+            return NodeType::kSequence;
+          },
+          [](const MappingData&) {
+            return NodeType::kMapping;
+          },
+      },
+      data_);
 }
 
 std::string_view Node::GetTypeString() const {
-  return std::visit([](auto&& data) {
-    return GetNiceVariantName(data);
-  }, data_);
+  return std::visit(
+      [](auto&& data) {
+        return GetNiceVariantName(data);
+      },
+      data_);
 }
 
 std::string_view Node::GetTypeString(NodeType type) {
@@ -122,100 +137,117 @@ void Node::SetTag(std::string tag) {
 }
 
 const std::string& Node::GetScalar() const {
-  return std::visit(overloaded{
-    [](const ScalarData& data) -> const std::string& {
-      return data.scalar;
-    },
-    [](auto&& data) -> const std::string& {
-      throw std::logic_error(fmt::format(
-          "Cannot Node::GetScalar on a {}", GetNiceVariantName(data)));
-    },
-  }, data_);
+  return std::visit(
+      overloaded{
+          [](const ScalarData& data) -> const std::string& {
+            return data.scalar;
+          },
+          [](auto&& data) -> const std::string& {
+            throw std::logic_error(fmt::format("Cannot Node::GetScalar on a {}",
+                                               GetNiceVariantName(data)));
+          },
+      },
+      data_);
 }
 
 const std::vector<Node>& Node::GetSequence() const {
-  return std::visit(overloaded{
-    [](const SequenceData& data) -> const std::vector<Node>& {
-      return data.sequence;
-    },
-    [](auto&& data) -> const std::vector<Node>& {
-      throw std::logic_error(fmt::format(
-          "Cannot Node::GetSequence on a {}", GetNiceVariantName(data)));
-    },
-  }, data_);
+  return std::visit(
+      overloaded{
+          [](const SequenceData& data) -> const std::vector<Node>& {
+            return data.sequence;
+          },
+          [](auto&& data) -> const std::vector<Node>& {
+            throw std::logic_error(fmt::format(
+                "Cannot Node::GetSequence on a {}", GetNiceVariantName(data)));
+          },
+      },
+      data_);
 }
 
 void Node::Add(Node value) {
-  return std::visit(overloaded{
-    [&value](SequenceData& data) -> void {
-      data.sequence.push_back(std::move(value));
-    },
-    [](auto&& data) -> void {
-      throw std::logic_error(fmt::format(
-          "Cannot Node::Add(value) on a {}", GetNiceVariantName(data)));
-    },
-  }, data_);
+  return std::visit(
+      overloaded{
+          [&value](SequenceData& data) -> void {
+            data.sequence.push_back(std::move(value));
+          },
+          [](auto&& data) -> void {
+            throw std::logic_error(fmt::format(
+                "Cannot Node::Add(value) on a {}", GetNiceVariantName(data)));
+          },
+      },
+      data_);
 }
 
 const std::map<std::string, Node>& Node::GetMapping() const {
-  return std::visit(overloaded{
-    [](const MappingData& data) -> const std::map<std::string, Node>& {
-      return data.mapping;
-    },
-    [](auto&& data) -> const std::map<std::string, Node>& {
-      throw std::logic_error(fmt::format(
-          "Cannot Node::GetMapping on a {}", GetNiceVariantName(data)));
-    },
-  }, data_);
+  return std::visit(
+      overloaded{
+          [](const MappingData& data) -> const std::map<std::string, Node>& {
+            return data.mapping;
+          },
+          [](auto&& data) -> const std::map<std::string, Node>& {
+            throw std::logic_error(fmt::format(
+                "Cannot Node::GetMapping on a {}", GetNiceVariantName(data)));
+          },
+      },
+      data_);
 }
 
 void Node::Add(std::string key, Node value) {
-  return std::visit(overloaded{
-      [&key, &value](MappingData& data) -> void {
-      const auto result = data.mapping.insert({
-          std::move(key), std::move(value)});
-      const bool inserted = result.second;
-      if (!inserted) {
-        // Our 'key' argument is now empty (because it has been moved-from), so
-        // for the error message we need to dig the existing key out of the map.
-        const std::string& old_key = result.first->first;
-        throw std::logic_error(fmt::format(
-            "Cannot Node::Add(key, value) using duplicate key '{}'", old_key));
-      }
-    },
-    [](auto&& data) -> void {
-      throw std::logic_error(fmt::format(
-          "Cannot Node::Add(key, value) on a {}", GetNiceVariantName(data)));
-    },
-  }, data_);
+  return std::visit(
+      overloaded{
+          [&key, &value](MappingData& data) -> void {
+            const auto result =
+                data.mapping.insert({std::move(key), std::move(value)});
+            const bool inserted = result.second;
+            if (!inserted) {
+              // Our 'key' argument is now empty (because it has been
+              // moved-from), so for the error message we need to dig the
+              // existing key out of the map.
+              const std::string& old_key = result.first->first;
+              throw std::logic_error(fmt::format(
+                  "Cannot Node::Add(key, value) using duplicate key '{}'",
+                  old_key));
+            }
+          },
+          [](auto&& data) -> void {
+            throw std::logic_error(
+                fmt::format("Cannot Node::Add(key, value) on a {}",
+                            GetNiceVariantName(data)));
+          },
+      },
+      data_);
 }
 
 Node& Node::At(std::string_view key) {
-  return std::visit(overloaded{
-    [key](MappingData& data) -> Node& {
-      return data.mapping.at(std::string{key});
-    },
-    [](auto&& data) -> Node& {
-      throw std::logic_error(fmt::format(
-          "Cannot Node::At(key) on a {}", GetNiceVariantName(data)));
-    },
-  }, data_);
+  return std::visit(
+      overloaded{
+          [key](MappingData& data) -> Node& {
+            return data.mapping.at(std::string{key});
+          },
+          [](auto&& data) -> Node& {
+            throw std::logic_error(fmt::format("Cannot Node::At(key) on a {}",
+                                               GetNiceVariantName(data)));
+          },
+      },
+      data_);
 }
 
 void Node::Remove(std::string_view key) {
-  return std::visit(overloaded{
-    [key](MappingData& data) -> void {
-      auto erased = data.mapping.erase(std::string{key});
-      if (!erased) {
-        throw std::logic_error(fmt::format(
-            "No such key '{}' during Node::Remove(key)", key));
-      }
-    },
-    [](auto&& data) -> void {
-      throw std::logic_error(fmt::format(
-          "Cannot Node::Remove(key) on a {}", GetNiceVariantName(data)));
-    },
-  }, data_);
+  return std::visit(
+      overloaded{
+          [key](MappingData& data) -> void {
+            auto erased = data.mapping.erase(std::string{key});
+            if (!erased) {
+              throw std::logic_error(fmt::format(
+                  "No such key '{}' during Node::Remove(key)", key));
+            }
+          },
+          [](auto&& data) -> void {
+            throw std::logic_error(fmt::format(
+                "Cannot Node::Remove(key) on a {}", GetNiceVariantName(data)));
+          },
+      },
+      data_);
 }
 
 std::ostream& operator<<(std::ostream& os, const Node& node) {
@@ -223,33 +255,33 @@ std::ostream& operator<<(std::ostream& os, const Node& node) {
     os << "!<" << node.GetTag() << "> ";
   }
   node.Visit(overloaded{
-    [&](const Node::ScalarData& data) {
-      os << '"' << data.scalar << '"';
-    },
-    [&](const Node::SequenceData& data) {
-      os << "[";
-      bool first = true;
-      for (const auto& child : data.sequence) {
-        if (!first) {
-          os << ", ";
+      [&](const Node::ScalarData& data) {
+        os << '"' << data.scalar << '"';
+      },
+      [&](const Node::SequenceData& data) {
+        os << "[";
+        bool first = true;
+        for (const auto& child : data.sequence) {
+          if (!first) {
+            os << ", ";
+          }
+          first = false;
+          os << child;
         }
-        first = false;
-        os << child;
-      }
-      os << "]";
-    },
-    [&](const Node::MappingData& data) {
-      os << "{";
-      bool first = true;
-      for (const auto& [key, child] : data.mapping) {
-        if (!first) {
-          os << ", ";
+        os << "]";
+      },
+      [&](const Node::MappingData& data) {
+        os << "{";
+        bool first = true;
+        for (const auto& [key, child] : data.mapping) {
+          if (!first) {
+            os << ", ";
+          }
+          first = false;
+          os << '"' << key << '"' << ": " << child;
         }
-        first = false;
-        os << '"' << key << '"' << ": " << child;
-      }
-      os << "}";
-    },
+        os << "}";
+      },
   });
   return os;
 }

--- a/common/yaml/yaml_node.cc
+++ b/common/yaml/yaml_node.cc
@@ -57,7 +57,7 @@ Node Node::MakeMapping() {
 Node Node::MakeNull() {
   Node result;
   result.data_ = ScalarData{"null"};
-  result.tag_ = kTagNull;
+  result.tag_ = JsonSchemaTag::kNull;
   return result;
 }
 
@@ -113,7 +113,10 @@ bool Node::IsMapping() const {
 }
 
 bool operator==(const Node& a, const Node& b) {
-  return std::tie(a.tag_, a.data_) == std::tie(b.tag_, b.data_);
+  // We need to compare the canonical form of a tag (i.e., its string).
+  auto a_tag = a.GetTag();
+  auto b_tag = b.GetTag();
+  return std::tie(a_tag, a.data_) == std::tie(b_tag, b.data_);
 }
 
 bool operator==(const Node::ScalarData& a, const Node::ScalarData& b) {
@@ -128,12 +131,42 @@ bool operator==(const Node::MappingData& a, const Node::MappingData& b) {
   return a.mapping == b.mapping;
 }
 
-const std::string& Node::GetTag() const {
-  return tag_;
+std::string_view Node::GetTag() const {
+  return std::visit(  // BR
+      overloaded{
+          [](std::monostate) -> std::string_view {
+            return {};
+          },
+          [](JsonSchemaTag tag) -> std::string_view {
+            switch (tag) {
+              case JsonSchemaTag::kNull:
+                return kTagNull;
+              case JsonSchemaTag::kBool:
+                return kTagBool;
+              case JsonSchemaTag::kInt:
+                return kTagInt;
+              case JsonSchemaTag::kFloat:
+                return kTagFloat;
+            }
+            DRAKE_UNREACHABLE();
+          },
+          [](const std::string& tag) -> std::string_view {
+            return tag;
+          },
+      },
+      tag_);
+}
+
+void Node::SetTag(JsonSchemaTag tag) {
+  tag_ = tag;
 }
 
 void Node::SetTag(std::string tag) {
-  tag_ = std::move(tag);
+  if (tag.empty()) {
+    tag_ = {};
+  } else {
+    tag_ = std::move(tag);
+  }
 }
 
 const std::string& Node::GetScalar() const {

--- a/common/yaml/yaml_node.h
+++ b/common/yaml/yaml_node.h
@@ -55,6 +55,19 @@ enum class NodeType {
   kMapping,
 };
 
+/* Denotes one of the "JSON Schema" tags.
+See https://yaml.org/spec/1.2.2/#json-schema. */
+enum class JsonSchemaTag {
+  // https://yaml.org/spec/1.2.2/#null
+  kNull,
+  // https://yaml.org/spec/1.2.2/#boolean
+  kBool,
+  // https://yaml.org/spec/1.2.2/#integer
+  kInt,
+  // https://yaml.org/spec/1.2.2/#floating-point
+  kFloat,
+};
+
 /* Data type that represents a YAML node.  A Node can hold one of three
 possible kinds of value at runtime:
 - Scalar
@@ -120,7 +133,11 @@ class Node final {
   /* Gets this node's YAML tag.
   See https://yaml.org/spec/1.2.2/#tags.
   By default (i.e., at construction time), the tag will be empty. */
-  const std::string& GetTag() const;
+  std::string_view GetTag() const;
+
+  /* Sets this node's YAML tag to one of the "JSON Schema" tags.
+  See https://yaml.org/spec/1.2.2/#json-schema. */
+  void SetTag(JsonSchemaTag);
 
   /* Sets this node's YAML tag.
   See https://yaml.org/spec/1.2.2/#tags.
@@ -128,14 +145,17 @@ class Node final {
   type nor value.  The caller is responsible for providing a valid tag. */
   void SetTag(std::string);
 
-  // https://yaml.org/spec/1.2.2/#floating-point
-  static constexpr std::string_view kTagFloat{"tag:yaml.org,2002:float"};
+  // https://yaml.org/spec/1.2.2/#null
+  static constexpr std::string_view kTagNull{"tag:yaml.org,2002:null"};
+
+  // https://yaml.org/spec/1.2.2/#boolean
+  static constexpr std::string_view kTagBool{"tag:yaml.org,2002:bool"};
 
   // https://yaml.org/spec/1.2.2/#integer
   static constexpr std::string_view kTagInt{"tag:yaml.org,2002:int"};
 
-  // https://yaml.org/spec/1.2.2/#null
-  static constexpr std::string_view kTagNull{"tag:yaml.org,2002:null"};
+  // https://yaml.org/spec/1.2.2/#floating-point
+  static constexpr std::string_view kTagFloat{"tag:yaml.org,2002:float"};
 
   // https://yaml.org/spec/1.2.2/#generic-string
   static constexpr std::string_view kTagStr{"tag:yaml.org,2002:str"};
@@ -237,9 +257,12 @@ class Node final {
   Node();
 
   using Variant = std::variant<ScalarData, SequenceData, MappingData>;
-
-  std::string tag_;
   Variant data_;
+
+  // The YAML tag is not required, but can be set to either a well-known enum or
+  // a bespoke string. The representation here is not canonical -- it's possible
+  // to set a string value that is equivalent to an enum's implied string.
+  std::variant<std::monostate, JsonSchemaTag, std::string> tag_;
 };
 
 }  // namespace internal

--- a/common/yaml/yaml_node.h
+++ b/common/yaml/yaml_node.h
@@ -250,7 +250,6 @@ class Node final {
 // TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
 namespace fmt {
 template <>
-struct formatter<drake::yaml::internal::Node>
-    : drake::ostream_formatter {};
+struct formatter<drake::yaml::internal::Node> : drake::ostream_formatter {};
 }  // namespace fmt
 #endif

--- a/common/yaml/yaml_read_archive.cc
+++ b/common/yaml/yaml_read_archive.cc
@@ -16,8 +16,8 @@ namespace {
 
 // The source and destination are both of type Map.  Copy the key-value pairs
 // from source into destination, but don't overwrite any existing keys.
-void CopyWithMergeKeySemantics(
-    const YAML::Node& source, YAML::Node* destination) {
+void CopyWithMergeKeySemantics(const YAML::Node& source,
+                               YAML::Node* destination) {
   for (const auto& key_value : source) {
     const YAML::Node& key = key_value.first;
     const YAML::Node& value = key_value.second;
@@ -99,16 +99,16 @@ void RewriteMergeKeys(const YAML::Node& parent, YAML::Node* node) {
     keys.push_back(map_pair.first.as<std::string>());
   }
   std::sort(keys.begin(), keys.end());
-  throw std::runtime_error(fmt::format(
-      "YAML node of type Mapping (with size {} and keys {{{}}}) {}",
-      keys.size(), fmt::join(keys, ", "), error_message));
+  throw std::runtime_error(
+      fmt::format("YAML node of type Mapping (with size {} and keys {{{}}}) {}",
+                  keys.size(), fmt::join(keys, ", "), error_message));
 }
 
 // Convert a jbeder/yaml-cpp YAML::Node `node` to a Drake yaml::internal::Node.
 // See https://github.com/jbeder/yaml-cpp/wiki/Tutorial for a jbeder reference.
 // The `parent` is only used to provide context during error reporting.
-internal::Node ConvertJbederYamlNodeToDrakeYamlNode(
-    const YAML::Node& parent, const YAML::Node& node) {
+internal::Node ConvertJbederYamlNodeToDrakeYamlNode(const YAML::Node& parent,
+                                                    const YAML::Node& node) {
   switch (node.Type()) {
     case YAML::NodeType::Undefined: {
       throw std::runtime_error("A yaml-cpp node was unexpectedly Undefined");
@@ -137,8 +137,8 @@ internal::Node ConvertJbederYamlNodeToDrakeYamlNode(
       for (const auto& key_value : merged_node) {
         const YAML::Node& key = key_value.first;
         const YAML::Node& value = key_value.second;
-        result.Add(key.Scalar(), ConvertJbederYamlNodeToDrakeYamlNode(
-            node, value));
+        result.Add(key.Scalar(),
+                   ConvertJbederYamlNodeToDrakeYamlNode(node, value));
       }
       return result;
     }
@@ -148,9 +148,8 @@ internal::Node ConvertJbederYamlNodeToDrakeYamlNode(
 
 }  // namespace
 
-YamlReadArchive::YamlReadArchive(
-    internal::Node root,
-    const LoadYamlOptions& options)
+YamlReadArchive::YamlReadArchive(internal::Node root,
+                                 const LoadYamlOptions& options)
     : owned_root_(std::move(root)),
       root_(&owned_root_.value()),
       mapish_item_key_(nullptr),
@@ -164,8 +163,7 @@ YamlReadArchive::YamlReadArchive(
 // a separate file with more specific testing, but for the moment our use of
 // yaml-cpp in our public API makes that difficult.
 internal::Node YamlReadArchive::LoadFileAsNode(
-    const std::string& filename,
-    const std::optional<std::string>& child_name) {
+    const std::string& filename, const std::optional<std::string>& child_name) {
   YAML::Node root = YAML::LoadFile(filename);
   if (child_name.has_value()) {
     YAML::Node child_node = root[*child_name];
@@ -186,8 +184,7 @@ internal::Node YamlReadArchive::LoadFileAsNode(
 // a separate file with more specific testing, but for the moment our use of
 // yaml-cpp in our public API makes that difficult.
 internal::Node YamlReadArchive::LoadStringAsNode(
-    const std::string& data,
-    const std::optional<std::string>& child_name) {
+    const std::string& data, const std::optional<std::string>& child_name) {
   YAML::Node root = YAML::Load(data);
   if (child_name.has_value()) {
     YAML::Node child_node = root[*child_name];
@@ -209,8 +206,8 @@ void YamlReadArchive::ParseScalarImpl(const std::string& value, T* result) {
   // Generally, all of the POD types are supported.
   bool success = YAML::convert<T>::decode(YAML::Node(value), *result);
   if (!success) {
-    ReportError(fmt::format(
-        "could not parse {} value", drake::NiceTypeName::Get<T>()));
+    ReportError(
+        fmt::format("could not parse {} value", drake::NiceTypeName::Get<T>()));
   }
 }
 
@@ -242,8 +239,8 @@ void YamlReadArchive::ParseScalar(const std::string& value, uint64_t* result) {
   ParseScalarImpl<uint64_t>(value, result);
 }
 
-void YamlReadArchive::ParseScalar(
-    const std::string& value, std::string* result) {
+void YamlReadArchive::ParseScalar(const std::string& value,
+                                  std::string* result) {
   DRAKE_DEMAND(result != nullptr);
   *result = value;
 }
@@ -269,8 +266,8 @@ const internal::Node* YamlReadArchive::MaybeGetSubNode(const char* name) const {
 
 const internal::Node* YamlReadArchive::GetSubNodeScalar(
     const char* name) const {
-  const internal::Node* result = GetSubNodeAny(
-      name, internal::NodeType::kScalar);
+  const internal::Node* result =
+      GetSubNodeAny(name, internal::NodeType::kScalar);
   if ((result != nullptr) && (result->GetTag() == internal::Node::kTagNull)) {
     ReportError("has non-Scalar (Null)");
     result = nullptr;
@@ -305,8 +302,8 @@ const internal::Node* YamlReadArchive::GetSubNodeAny(
     if (result->GetTag() == internal::Node::kTagNull) {
       actual_type_string = "Null";
     }
-    ReportError(fmt::format(
-        "has non-{} ({})", expected_type_string, actual_type_string));
+    ReportError(fmt::format("has non-{} ({})", expected_type_string,
+                            actual_type_string));
     result = nullptr;
   }
   return result;
@@ -324,8 +321,7 @@ void YamlReadArchive::CheckAllAccepted() const {
   for (const auto& [key, value] : root_->GetMapping()) {
     unused(value);
     if (visited_names_.count(key) == 0) {
-      ReportError(fmt::format(
-          "key '{}' did not match any visited value", key));
+      ReportError(fmt::format("key '{}' did not match any visited value", key));
     }
   }
 }
@@ -369,8 +365,8 @@ void YamlReadArchive::PrintNodeSummary(std::ostream& s) const {
   }
 
   // Output the details of the keys.
-  fmt::print(s, " (with size {} and keys {{{}}})",
-             keys.size(), fmt::join(keys, ", "));
+  fmt::print(s, " (with size {} and keys {{{}}})", keys.size(),
+             fmt::join(keys, ", "));
 }
 
 void YamlReadArchive::PrintVisitNameType(std::ostream& s) const {
@@ -380,8 +376,7 @@ void YamlReadArchive::PrintVisitNameType(std::ostream& s) const {
   }
   DRAKE_DEMAND(debug_visit_name_ != nullptr);
   DRAKE_DEMAND(debug_visit_type_ != nullptr);
-  fmt::print(s, "{} {}",
-             drake::NiceTypeName::Get(*debug_visit_type_),
+  fmt::print(s, "{} {}", drake::NiceTypeName::Get(*debug_visit_type_),
              debug_visit_name_);
 }
 

--- a/common/yaml/yaml_read_archive.h
+++ b/common/yaml/yaml_read_archive.h
@@ -41,8 +41,7 @@ class YamlReadArchive final {
       const std::optional<std::string>& child_name);
 
   static internal::Node LoadStringAsNode(
-      const std::string& data,
-      const std::optional<std::string>& child_name);
+      const std::string& data, const std::optional<std::string>& child_name);
 
   // Sets the contents `serializable` based on the YAML file associated this
   // archive.
@@ -118,8 +117,8 @@ class YamlReadArchive final {
 
   // This version applies when Serialize is member method.
   template <typename Serializable>
-  auto DoAccept(Serializable* serializable, int32_t) ->
-      decltype(serializable->Serialize(this)) {
+  auto DoAccept(Serializable* serializable, int32_t)
+      -> decltype(serializable->Serialize(this)) {
     serializable->Serialize(this);
   }
 
@@ -148,16 +147,17 @@ class YamlReadArchive final {
 
   // This version applies when the type has a Serialize member function.
   template <typename NVP, typename T>
-  auto DoVisit(const NVP& nvp, const T&, int32_t) ->
-      decltype(nvp.value()->Serialize(
+  auto DoVisit(const NVP& nvp, const T&, int32_t)
+      -> decltype(nvp.value()->Serialize(
           static_cast<YamlReadArchive*>(nullptr))) {
     this->VisitSerializable(nvp);
   }
 
   // This version applies when the type has an ADL Serialize function.
   template <typename NVP, typename T>
-  auto DoVisit(const NVP& nvp, const T&, int32_t) ->
-      decltype(Serialize(static_cast<YamlReadArchive*>(nullptr), nvp.value())) {
+  auto DoVisit(const NVP& nvp, const T&, int32_t)
+      -> decltype(Serialize(static_cast<YamlReadArchive*>(nullptr),
+                            nvp.value())) {
     this->VisitSerializable(nvp);
   }
 
@@ -198,8 +198,8 @@ class YamlReadArchive final {
   }
 
   // For Eigen::Matrix or Eigen::Vector.
-  template <typename NVP, typename T, int Rows, int Cols,
-      int Options = 0, int MaxRows = Rows, int MaxCols = Cols>
+  template <typename NVP, typename T, int Rows, int Cols, int Options = 0,
+            int MaxRows = Rows, int MaxCols = Cols>
   void DoVisit(const NVP& nvp,
                const Eigen::Matrix<T, Rows, Cols, Options, MaxRows, MaxCols>&,
                int32_t) {
@@ -228,7 +228,9 @@ class YamlReadArchive final {
   template <typename NVP>
   void VisitSerializable(const NVP& nvp) {
     const internal::Node* sub_node = GetSubNodeMapping(nvp.name());
-    if (sub_node == nullptr) { return; }
+    if (sub_node == nullptr) {
+      return;
+    }
     YamlReadArchive sub_archive(sub_node, this);
     auto&& value = *nvp.value();
     sub_archive.Accept(&value);
@@ -237,7 +239,9 @@ class YamlReadArchive final {
   template <typename NVP>
   void VisitScalar(const NVP& nvp) {
     const internal::Node* sub_node = GetSubNodeScalar(nvp.name());
-    if (sub_node == nullptr) { return; }
+    if (sub_node == nullptr) {
+      return;
+    }
     ParseScalar(sub_node->GetScalar(), nvp.value());
   }
 
@@ -261,7 +265,9 @@ class YamlReadArchive final {
     // Visit the unpacked optional as if it weren't wrapped in optional<>.
     using T = typename NVP::value_type::value_type;
     std::optional<T>& storage = *nvp.value();
-    if (!storage) { storage = T{}; }
+    if (!storage) {
+      storage = T{};
+    }
     this->Visit(drake::MakeNameValue(nvp.name(), &storage.value()),
                 VisitShouldMemorizeType::kNo);
   }
@@ -282,8 +288,8 @@ class YamlReadArchive final {
 
   // Steps through Types to extract 'size_t I' and 'typename T' for the Impl.
   template <template <typename...> class Variant, typename... Types>
-  void VariantHelper(
-      const std::string& tag, const char* name, Variant<Types...>* storage) {
+  void VariantHelper(const std::string& tag, const char* name,
+                     Variant<Types...>* storage) {
     if (tag == internal::Node::kTagNull) {
       // Our variant parsing does not yet support nulls.  When the tag indicates
       // null, don't try to match it to a variant type; instead, just parse into
@@ -291,7 +297,7 @@ class YamlReadArchive final {
       // TODO(jwnimmer-tri) Allow for std::monostate as one of the Types...,
       // in case the user wants to permit nullable variants.
       using T = std::variant_alternative_t<0, Variant<Types...>>;
-      T& typed_storage =  storage->template emplace<0>();
+      T& typed_storage = storage->template emplace<0>();
       this->Visit(drake::MakeNameValue(name, &typed_storage));
       return;
     }
@@ -301,8 +307,8 @@ class YamlReadArchive final {
   // Recursive case -- checks if `tag` matches `T` (which was the I'th type in
   // the template parameter pack), or else keeps looking.
   template <size_t I, typename Variant, typename T, typename... Remaining>
-  void VariantHelperImpl(
-      const std::string& tag, const char* name, Variant* storage) {
+  void VariantHelperImpl(const std::string& tag, const char* name,
+                         Variant* storage) {
     // For the first type declared in the variant<> (I == 0), the tag can be
     // absent; otherwise, the tag must match one of the variant's types.
     if (((I == 0) && (tag.empty() || (tag == "?"))) ||
@@ -318,8 +324,7 @@ class YamlReadArchive final {
   template <size_t, typename Variant>
   void VariantHelperImpl(const std::string& tag, const char*, Variant*) {
     ReportError(fmt::format(
-        "has unsupported type tag {} while selecting a variant<>",
-        tag));
+        "has unsupported type tag {} while selecting a variant<>", tag));
   }
 
   // Checks if a NiceTypeName matches the yaml type tag.
@@ -339,25 +344,28 @@ class YamlReadArchive final {
     // will match to our variant item's name such as "my_namespace::MyClass"
     // ignoring the namespace and any template parameters.
     const auto start_offset = name.rfind(':');
-    const auto start = name.begin() + (start_offset == std::string::npos ? 0 :
-                                       start_offset + 1);
+    const auto start =
+        name.begin() +
+        (start_offset == std::string::npos ? 0 : start_offset + 1);
     const auto end = std::find(start, name.end(), '<');
-    return (tag[0] == '!') && std::equal(
-        // The `tag` without the leading '!'.
-        tag.begin() + 1, tag.end(),
-        // The `name` without any namespaces or templates.
-        start, end);
+    return (tag[0] == '!') &&
+           std::equal(
+               // The `tag` without the leading '!'.
+               tag.begin() + 1, tag.end(),
+               // The `name` without any namespaces or templates.
+               start, end);
   }
 
   template <typename T>
   void VisitArray(const char* name, size_t size, T* data) {
     const internal::Node* sub_node = GetSubNodeSequence(name);
-    if (sub_node == nullptr) { return; }
+    if (sub_node == nullptr) {
+      return;
+    }
     const std::vector<internal::Node>& elements = sub_node->GetSequence();
     if (elements.size() != size) {
-      ReportError(fmt::format(
-          "has {}-size entry (wanted {}-size)",
-          elements.size(), size));
+      ReportError(fmt::format("has {}-size entry (wanted {}-size)",
+                              elements.size(), size));
     }
     for (size_t i = 0; i < size; ++i) {
       const std::string key = fmt::format("{}[{}]", name, i);
@@ -371,7 +379,9 @@ class YamlReadArchive final {
   template <typename NVP>
   void VisitVector(const NVP& nvp, std::optional<size_t> max_size = {}) {
     const internal::Node* sub_node = GetSubNodeSequence(nvp.name());
-    if (sub_node == nullptr) { return; }
+    if (sub_node == nullptr) {
+      return;
+    }
     const std::vector<internal::Node>& elements = sub_node->GetSequence();
     const size_t size = elements.size();
     if (max_size.has_value() && size > *max_size) {
@@ -389,12 +399,15 @@ class YamlReadArchive final {
     }
   }
 
-  template <typename T, int Rows, int Cols,
-      int Options = 0, int MaxRows = Rows, int MaxCols = Cols>
-  void VisitMatrix(const char* name,
+  template <typename T, int Rows, int Cols, int Options = 0, int MaxRows = Rows,
+            int MaxCols = Cols>
+  void VisitMatrix(
+      const char* name,
       Eigen::Matrix<T, Rows, Cols, Options, MaxRows, MaxCols>* matrix) {
     const internal::Node* sub_node = GetSubNodeSequence(name);
-    if (sub_node == nullptr) { return; }
+    if (sub_node == nullptr) {
+      return;
+    }
     const std::vector<internal::Node>& elements = sub_node->GetSequence();
 
     // Measure the YAML Sequence-of-Sequence dimensions.
@@ -404,9 +417,8 @@ class YamlReadArchive final {
     for (size_t i = 0; i < pending_rows; ++i) {
       const internal::Node& one_row = elements[i];
       if (!one_row.IsSequence()) {
-        ReportError(fmt::format(
-            "is Sequence-of-{} (not Sequence-of-Sequence)",
-            one_row.GetTypeString()));
+        ReportError(fmt::format("is Sequence-of-{} (not Sequence-of-Sequence)",
+                                one_row.GetTypeString()));
         return;
       }
       const size_t one_row_size = one_row.GetSequence().size();
@@ -427,8 +439,8 @@ class YamlReadArchive final {
     // Check the YAML dimensions vs Eigen dimensions, then resize (if dynamic).
     if (((Rows != Eigen::Dynamic) && (static_cast<int>(rows) != Rows)) ||
         ((Cols != Eigen::Dynamic) && (static_cast<int>(cols) != Cols))) {
-      ReportError(fmt::format(
-          "has dimension {}x{} (wanted {}x{})", rows, cols, Rows, Cols));
+      ReportError(fmt::format("has dimension {}x{} (wanted {}x{})", rows, cols,
+                              Rows, Cols));
       return;
     }
     auto&& storage = *matrix;
@@ -455,7 +467,9 @@ class YamlReadArchive final {
     static_assert(std::is_same_v<Key, std::string>,
                   "std::map keys must be strings");
     const internal::Node* sub_node = GetSubNodeMapping(nvp.name());
-    if (sub_node == nullptr) { return; }
+    if (sub_node == nullptr) {
+      return;
+    }
     auto& result = *nvp.value();
     this->VisitMapDirectly<Value>(*sub_node, &result);
   }

--- a/common/yaml/yaml_read_archive.h
+++ b/common/yaml/yaml_read_archive.h
@@ -282,13 +282,13 @@ class YamlReadArchive final {
       return;
     }
     // Figure out which variant<...> type we have based on the node's tag.
-    const std::string& tag = sub_node->GetTag();
+    const std::string_view tag = sub_node->GetTag();
     VariantHelper(tag, nvp.name(), nvp.value());
   }
 
   // Steps through Types to extract 'size_t I' and 'typename T' for the Impl.
   template <template <typename...> class Variant, typename... Types>
-  void VariantHelper(const std::string& tag, const char* name,
+  void VariantHelper(std::string_view tag, const char* name,
                      Variant<Types...>* storage) {
     if (tag == internal::Node::kTagNull) {
       // Our variant parsing does not yet support nulls.  When the tag indicates
@@ -307,7 +307,7 @@ class YamlReadArchive final {
   // Recursive case -- checks if `tag` matches `T` (which was the I'th type in
   // the template parameter pack), or else keeps looking.
   template <size_t I, typename Variant, typename T, typename... Remaining>
-  void VariantHelperImpl(const std::string& tag, const char* name,
+  void VariantHelperImpl(std::string_view tag, const char* name,
                          Variant* storage) {
     // For the first type declared in the variant<> (I == 0), the tag can be
     // absent; otherwise, the tag must match one of the variant's types.
@@ -322,13 +322,13 @@ class YamlReadArchive final {
 
   // Base case -- no match.
   template <size_t, typename Variant>
-  void VariantHelperImpl(const std::string& tag, const char*, Variant*) {
+  void VariantHelperImpl(std::string_view tag, const char*, Variant*) {
     ReportError(fmt::format(
         "has unsupported type tag {} while selecting a variant<>", tag));
   }
 
   // Checks if a NiceTypeName matches the yaml type tag.
-  bool IsTagMatch(const std::string& name, const std::string& tag) const {
+  bool IsTagMatch(std::string_view name, std::string_view tag) const {
     // Check for the "fail safe schema" YAML types and similar.
     if (name == "std::string") {
       return tag == internal::Node::kTagStr;

--- a/common/yaml/yaml_write_archive.h
+++ b/common/yaml/yaml_write_archive.h
@@ -97,8 +97,8 @@ class YamlWriteArchive final {
 
   // This version applies when Serialize is member function.
   template <typename Serializable>
-  auto DoAccept(Serializable* serializable, int32_t) ->
-      decltype(serializable->Serialize(this)) {
+  auto DoAccept(Serializable* serializable, int32_t)
+      -> decltype(serializable->Serialize(this)) {
     return serializable->Serialize(this);
   }
 
@@ -121,18 +121,17 @@ class YamlWriteArchive final {
 
   // This version applies when the type has a Serialize member function.
   template <typename NVP, typename T>
-  auto DoVisit(const NVP& nvp, const T&, int32_t) ->
-      decltype(nvp.value()->Serialize(
+  auto DoVisit(const NVP& nvp, const T&, int32_t)
+      -> decltype(nvp.value()->Serialize(
           static_cast<YamlWriteArchive*>(nullptr))) {
     return this->VisitSerializable(nvp);
   }
 
   // This version applies when the type has an ADL Serialize function.
   template <typename NVP, typename T>
-  auto DoVisit(const NVP& nvp, const T&, int32_t) ->
-      decltype(Serialize(
-          static_cast<YamlWriteArchive*>(nullptr),
-          nvp.value())) {
+  auto DoVisit(const NVP& nvp, const T&, int32_t)
+      -> decltype(Serialize(static_cast<YamlWriteArchive*>(nullptr),
+                            nvp.value())) {
     return this->VisitSerializable(nvp);
   }
 
@@ -175,8 +174,8 @@ class YamlWriteArchive final {
   }
 
   // For Eigen::Matrix or Eigen::Vector.
-  template <typename NVP, typename T, int Rows, int Cols,
-      int Options = 0, int MaxRows = Rows, int MaxCols = Cols>
+  template <typename NVP, typename T, int Rows, int Cols, int Options = 0,
+            int MaxRows = Rows, int MaxCols = Cols>
   void DoVisit(const NVP& nvp,
                const Eigen::Matrix<T, Rows, Cols, Options, MaxRows, MaxCols>&,
                int32_t) {
@@ -219,12 +218,12 @@ class YamlWriteArchive final {
       // ".0" when formatting integer-valued floating-point numbers.  Force
       // the ".0" in all cases by using the "#" option for floats.  Also be
       // sure to add the required leading period for special values.
-      root_.Add(nvp.name(), internal::Node::MakeScalar(
-          fmt::format("{}{:#}", std::isfinite(value) ? "" : ".", value)));
+      root_.Add(nvp.name(),
+                internal::Node::MakeScalar(fmt::format(
+                    "{}{:#}", std::isfinite(value) ? "" : ".", value)));
       return;
     }
-    root_.Add(nvp.name(), internal::Node::MakeScalar(
-        fmt::format("{}", value)));
+    root_.Add(nvp.name(), internal::Node::MakeScalar(fmt::format("{}", value)));
   }
 
   // This is used for std::optional or similar.
@@ -258,13 +257,15 @@ class YamlWriteArchive final {
     const char* const name = nvp.name();
     auto& variant = *nvp.value();
     const size_t index = variant.index();
-    std::visit([this, name, index](auto&& unwrapped) {
-      this->Visit(drake::MakeNameValue(name, &unwrapped));
-      if (index != 0) {
-        using T = decltype(unwrapped);
-        root_.At(name).SetTag(YamlWriteArchive::GetVariantTag<T>());
-      }
-    }, variant);
+    std::visit(
+        [this, name, index](auto&& unwrapped) {
+          this->Visit(drake::MakeNameValue(name, &unwrapped));
+          if (index != 0) {
+            using T = decltype(unwrapped);
+            root_.At(name).SetTag(YamlWriteArchive::GetVariantTag<T>());
+          }
+        },
+        variant);
 
     // The above call to this->Visit() for the *unwrapped* value pushed our
     // name onto the visit_order a second time, duplicating work performed by
@@ -275,9 +276,8 @@ class YamlWriteArchive final {
   template <typename T>
   static std::string GetVariantTag() {
     const std::string full_name = NiceTypeName::GetFromStorage<T>();
-    if ((full_name == "std::string")
-        || (full_name == "double")
-        || (full_name == "int")) {
+    if ((full_name == "std::string") || (full_name == "double") ||
+        (full_name == "int")) {
       // TODO(jwnimmer-tri) Add support for well-known YAML primitive types
       // within variants (when placed other than at the 0'th index).  To do
       // that, we need to emit the tag as "!!str" instead of "!string" or
@@ -312,9 +312,10 @@ class YamlWriteArchive final {
     root_.Add(name, std::move(sub_node));
   }
 
-  template <typename T, int Rows, int Cols,
-      int Options = 0, int MaxRows = Rows, int MaxCols = Cols>
-  void VisitMatrix(const char* name,
+  template <typename T, int Rows, int Cols, int Options = 0, int MaxRows = Rows,
+            int MaxCols = Cols>
+  void VisitMatrix(
+      const char* name,
       const Eigen::Matrix<T, Rows, Cols, Options, MaxRows, MaxCols>* matrix) {
     auto sub_node = internal::Node::MakeSequence();
     for (int i = 0; i < matrix->rows(); ++i) {
@@ -326,7 +327,6 @@ class YamlWriteArchive final {
     root_.Add(name, std::move(sub_node));
   }
 
-
   // This is used for std::map, std::unordered_map, or similar.
   // The map key must be a string; the value can be anything that serializes.
   template <typename Key, typename Value, typename NVP>
@@ -336,8 +336,7 @@ class YamlWriteArchive final {
     // that was convertible to a string (int, double, string_view, etc.) if we
     // found that useful.  However, to remain compatible with JSON semantics,
     // we should never allow a YAML Sequence or Mapping to be a used as a key.
-    static_assert(std::is_same_v<Key, std::string>,
-                  "Map keys must be strings");
+    static_assert(std::is_same_v<Key, std::string>, "Map keys must be strings");
     auto sub_node = this->VisitMapDirectly(nvp.value());
     root_.Add(nvp.name(), std::move(sub_node));
   }


### PR DESCRIPTION
Requires #18941.

Towards #15774.  When shelling out to the python downloader, it will be run using the system Python which might not have any libraries, so to pass data back and forth we need to use JSON, not YAML.