### PR TITLE
ModelVisualizer: re-pose joints by name

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -291,6 +291,8 @@ void DoScalarIndependentDefinitions(py::module m) {
             py::arg("value"), cls_doc.SetSliderValue.doc)
         .def("GetSliderValue", &Class::GetSliderValue, py::arg("name"),
             cls_doc.GetSliderValue.doc)
+        .def("GetSliderNames", &Class::GetSliderNames,
+            cls_doc.GetSliderNames.doc)
         .def("DeleteSlider", &Class::DeleteSlider, py::arg("name"),
             cls_doc.DeleteSlider.doc)
         .def("DeleteAddedControls", &Class::DeleteAddedControls,

--- a/bindings/pydrake/geometry/test/visualizers_test.py
+++ b/bindings/pydrake/geometry/test/visualizers_test.py
@@ -156,6 +156,7 @@ class TestGeometryVisualizers(unittest.TestCase):
                           value=0.5,
                           decrement_keycode="ArrowLeft",
                           increment_keycode="ArrowRight")
+        self.assertEqual(meshcat.GetSliderNames(), ["slider"])
         meshcat.SetSliderValue(name="slider", value=0.7)
         self.assertAlmostEqual(meshcat.GetSliderValue(
             name="slider"), 0.7, delta=1e-14)

--- a/bindings/pydrake/visualization/_model_visualizer.py
+++ b/bindings/pydrake/visualization/_model_visualizer.py
@@ -45,10 +45,10 @@ class ModelVisualizer:
       visualizer.AddModels(filename)
       visualizer.Run()
 
-    The class also provides a `parser` property to allow more complex
+    The class also provides a `parser()` method to allow more complex
     Parser handling, e.g. adding a model from a string::
 
-      visualizer.parser.AddModelsFromString(buffer_containing_model, 'sdf')
+      visualizer.parser().AddModelsFromString(buffer_containing_model, 'sdf')
 
     This class may also be run as a standalone command-line tool using the
     ``pydrake.visualization.model_visualizer`` script, or via
@@ -254,10 +254,10 @@ class ModelVisualizer:
         self._meshcat.Delete()
         self._meshcat.DeleteAddedControls()
 
-        # We want to place this button far away from the Stop Running button,
-        # hence the work to do this here.
+        # We want to place the Reload Model Files button far away from the
+        # Stop Running button, hence the work to do this here.
         if self._model_filenames:
-            self._reload_button_name = "Reload model files"
+            self._reload_button_name = "Reload Model Files"
             self._meshcat.AddButton(self._reload_button_name)
 
         # Connect to drake_visualizer, meldis, and meshcat.
@@ -273,6 +273,16 @@ class ModelVisualizer:
             meshcat=self._meshcat)
 
         # Add joint sliders to meshcat.
+        # TODO(trowell-tri) Restoring slider values depends on the slider
+        # names remaining consistent across the reload; currently the
+        # JointSlider code names sliders by joint name and position suffix
+        # and adds a model name suffix when those names aren't unique, e.g.
+        # when the same model appears multiple times. Thus if the set of
+        # models changes to cause or eliminate such a name collision then
+        # slider values won't be fully restored. It would probably be better to
+        # be able to configure the JointSliders to always use fully-qualified
+        # names on demand, especially once the size of the control panel is
+        # adjustable so that the slider names are better visible.
         self._sliders = self._builder.builder().AddNamedSystem(
             "joint_sliders", JointSliders(meshcat=self._meshcat,
                                           plant=self._builder.plant()))
@@ -292,10 +302,10 @@ class ModelVisualizer:
         # the truth values of arrays.
         if position is not None and len(position) > 0:
             self._raise_if_invalid_positions(position)
-            self._sliders.SetPositions(position)
             self._diagram.plant().SetPositions(
                 self._diagram.plant().GetMyContextFromRoot(self._context),
                 position)
+            self._sliders.SetPositions(position)
 
         # Use Simulator to dispatch initialization events.
         # TODO(eric.cousineau): Simplify as part of #13776 (was #10015).
@@ -353,6 +363,7 @@ class ModelVisualizer:
         else:
             self._check_rep(finalized=True)
             if position is not None and len(position) > 0:
+                self._raise_if_invalid_positions(position)
                 self._diagram.plant().SetPositions(
                     self._diagram.plant().GetMyContextFromRoot(self._context),
                     position)
@@ -382,19 +393,19 @@ class ModelVisualizer:
 
             while True:
                 time.sleep(1 / 32.0)
-                if has_clicks(stop_button_name):
-                    break
+                if has_clicks(self._reload_button_name):
+                    self._meshcat.DeleteButton(stop_button_name)
+                    slider_values = self._get_slider_values()
+                    self._reload()
+                    self._set_slider_values(slider_values)
+                    self._meshcat.AddButton(stop_button_name, "Escape")
                 q = self._sliders.get_output_port().Eval(
                     self._sliders.GetMyContextFromRoot(self._context))
                 self._diagram.plant().SetPositions(
                     self._diagram.plant().GetMyContextFromRoot(self._context),
                     q)
                 self._diagram.ForcedPublish(self._context)
-                if has_clicks(self._reload_button_name):
-                    self._meshcat.DeleteButton(stop_button_name)
-                    self._reload()
-                    self._meshcat.AddButton(stop_button_name, "Escape")
-                if loop_once:
+                if loop_once or has_clicks(stop_button_name):
                     break
         except KeyboardInterrupt:
             pass
@@ -428,6 +439,23 @@ class ModelVisualizer:
             raise ValueError(
                 f"Number of passed positions ({actual}) does not match the "
                 f"number in the model ({expected}).")
+
+    def _get_slider_values(self):
+        """Returns a map of slider names to current values."""
+        return {name: self._meshcat.GetSliderValue(name)
+                for name in self._meshcat.GetSliderNames()}
+
+    def _set_slider_values(self, slider_values):
+        """
+        Sets current sliders to the values found in the slider_values dict.
+
+        Current sliders not in the passed map -- or values in the map but
+        which not longer exist in the GUI -- are ignored.
+        """
+        current_names = self._meshcat.GetSliderNames()
+        for old_name, old_value in slider_values.items():
+            if old_name in current_names:
+                self._meshcat.SetSliderValue(old_name, old_value)
 
     def _add_triad(
         self,

--- a/bindings/pydrake/visualization/model_visualizer.py
+++ b/bindings/pydrake/visualization/model_visualizer.py
@@ -3,6 +3,11 @@ Drake's built-in visualizers (MeshCat and/or Meldis). When viewing in MeshCat,
 joint sliders to posture the model are available by clicking on "Open Controls"
 in the top right corner.
 
+If the loaded model file is changed, it can be reloaded by pressing
+the "Reload Model Files" button, which will attempt to maintain slider values
+once reloading is finished. To exit, press the "Stop Running" button or press
+the Escape key.
+
 This command-line module is provided for convenience, but the feature is also
 available via the library class ``pydrake.visualization.ModelVisualizer``.
 

--- a/bindings/pydrake/visualization/test/model_visualizer_test.py
+++ b/bindings/pydrake/visualization/test/model_visualizer_test.py
@@ -212,8 +212,18 @@ class TestModelVisualizer(unittest.TestCase):
         self.assertEqual(meshcat.GetButtonClicks(button), 1)
 
         # Run once. If a reload() happened, the diagram will have changed out.
-        dut.Run(loop_once=True)
+        # Use a non-default position so we can check that it is maintained.
+        original_q = [1.0, 2.0]
+        dut.Run(position=original_q, loop_once=True)
         self.assertNotEqual(id(orig_diagram), id(dut._diagram))
+
+        # Ensure the reloaded slider and joint values are the same.
+        slider_q = dut._sliders.get_output_port().Eval(
+            dut._sliders.GetMyContextFromRoot(dut._context))
+        self.assertListEqual(list(original_q), list(slider_q))
+        joint_q = dut._diagram.plant().GetPositions(
+            dut._diagram.plant().GetMyContextFromRoot(dut._context))
+        self.assertListEqual(list(original_q), list(joint_q))
 
     def test_webbrowser(self):
         """

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -1395,6 +1395,18 @@ class Meshcat::Impl {
     return iter->second.value;
   }
 
+  std::vector<std::string> GetSliderNames() const {
+    DRAKE_DEMAND(IsThread(main_thread_id_));
+
+    std::lock_guard<std::mutex> lock(controls_mutex_);
+    std::vector<std::string> names;
+    names.reserve(sliders_.size());
+    for (const auto& [name, _] : sliders_) {
+      names.push_back(name);
+    }
+    return names;
+  }
+
   // This function is public via the PIMPL.
   void DeleteSlider(std::string name) {
     DRAKE_DEMAND(IsThread(main_thread_id_));
@@ -2187,6 +2199,10 @@ void Meshcat::SetSliderValue(std::string name, double value) {
 
 double Meshcat::GetSliderValue(std::string_view name) const {
   return impl().GetSliderValue(name);
+}
+
+std::vector<std::string> Meshcat::GetSliderNames() const {
+  return impl().GetSliderNames();
 }
 
 void Meshcat::DeleteSlider(std::string name) {

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -550,6 +550,9 @@ class Meshcat {
    @throws std::exception if `name` is not a registered slider. */
   double GetSliderValue(std::string_view name) const;
 
+  /** Returns the names of all sliders. */
+  std::vector<std::string> GetSliderNames() const;
+
   /** Removes the slider `name` from the GUI.
    @throws std::exception if `name` is not a registered slider. */
   void DeleteSlider(std::string name);

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -20,6 +20,7 @@ namespace {
 using Eigen::Vector3d;
 using math::RigidTransformd;
 using math::RotationMatrixd;
+using testing::ElementsAre;
 using ::testing::HasSubstr;
 
 // A small wrapper around std::system to ensure correct argument passing.
@@ -667,6 +668,10 @@ GTEST_TEST(MeshcatTest, Sliders) {
 
   meshcat.AddSlider("slider1", 2, 3, 0.01, 2.35);
   meshcat.AddSlider("slider2", 4, 5, 0.01, 4.56);
+
+  auto slider_names = meshcat.GetSliderNames();
+  EXPECT_THAT(slider_names, ElementsAre("slider1", "slider2"));
+
   meshcat.DeleteAddedControls();
   DRAKE_EXPECT_THROWS_MESSAGE(
       meshcat.GetSliderValue("slider1"),
@@ -674,6 +679,9 @@ GTEST_TEST(MeshcatTest, Sliders) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       meshcat.GetSliderValue("slider2"),
       "Meshcat does not have any slider named slider2.");
+
+  slider_names = meshcat.GetSliderNames();
+  EXPECT_EQ(slider_names.size(), 0);
 }
 
 GTEST_TEST(MeshcatTest, DuplicateMixedControls) {
@@ -712,7 +720,7 @@ GTEST_TEST(MeshcatTest, Gamepad) {
       "type": "gamepad",
       "name": "",
       "gamepad": {
-        "index": 1, 
+        "index": 1,
         "button_values": [0, 0.5],
         "axes": [0.1, 0.2, 0.3, 0.4]
       }


### PR DESCRIPTION
Makes the reload feature of ModelVisualizer more robust by setting joint positions in the reloaded model to the prior values of joints with the same names, rather than requiring an exact match of the number of joints before and after.

Also fixes docstrings relating to accessing the visualizer's parser.

Closes #18910.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18949)
<!-- Reviewable:end -->
