### PR TITLE
Fix warning when ball joint has an axis

### DIFF
--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -406,15 +406,22 @@ void AddJointActuatorFromSpecification(
                joint_spec.Type() == sdf::JointType::REVOLUTE ||
                joint_spec.Type() == sdf::JointType::CONTINUOUS);
 
-  // Ball joints cannot specify an axis (nor actuation) per SDFormat. However,
-  // Drake still permits the first axis in order to specify damping, but it
-  // should not have actuation, nor should there be a second axis.
+  // Ball joints do not have an axis (nor actuation). However, Drake still
+  // permits the declaration of a first axis in order to specify damping, but
+  // it should not have actuation, nor should there be a second axis.
   if (joint_spec.Type() == sdf::JointType::BALL) {
     if (joint_spec.Axis(0) != nullptr) {
       std::string message = fmt::format(
-          "An axis may not be specified for ball joint '{}' and will be "
-          "ignored", joint_spec.Name());
+          "A ball joint axis will be ignored. Only the dynamic parameters"
+          " and limits will be considered.", joint_spec.Name());
       diagnostic.Warning(joint_spec.Element(), std::move(message));
+      if (GetEffortLimit(diagnostic, joint_spec, 0) != 0) {
+        std::string effort_message = fmt::format(
+            "Actuation (via non-zero effort limits) for ball joint '{}' is"
+            " not implemented yet and will be ignored.",
+            joint_spec.Name());
+        diagnostic.Warning(joint_spec.Element(), std::move(effort_message));
+      }
     }
     if (joint_spec.Axis(1) != nullptr) {
       std::string message = fmt::format(

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -411,13 +411,10 @@ void AddJointActuatorFromSpecification(
   // should not have actuation, nor should there be a second axis.
   if (joint_spec.Type() == sdf::JointType::BALL) {
     if (joint_spec.Axis(0) != nullptr) {
-      if (GetEffortLimit(diagnostic, joint_spec, 0) != 0) {
-        std::string message = fmt::format(
-            "Actuation (via non-zero effort limits) for ball joint '{}' is"
-            " not implemented yet and will be ignored.",
-            joint_spec.Name());
-        diagnostic.Warning(joint_spec.Element(), std::move(message));
-      }
+      std::string message = fmt::format(
+          "An axis may not be specified for ball joint '{}' and will be "
+          "ignored", joint_spec.Name());
+      diagnostic.Warning(joint_spec.Element(), std::move(message));
     }
     if (joint_spec.Axis(1) != nullptr) {
       std::string message = fmt::format(

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -754,18 +754,11 @@ TEST_F(SdfParserTest, BallJointWithAxis2Error) {
   <joint name='should_not_have_axis' type='ball'>
     <parent>a</parent>
     <child>b</child>
-    <axis>
-      <xyz>0 0 1</xyz>
-    </axis>
     <axis2>
       <xyz>0 0 1</xyz>
     </axis2>
   </joint>
 </model>)""");
-  EXPECT_THAT(TakeWarning(), ::testing::MatchesRegex(
-      R"(.*Actuation \(via non-zero effort limits\) for ball joint )"
-      R"('should_not_have_axis' is not implemented yet and will be )"
-      R"(ignored.*)"));
   EXPECT_THAT(TakeWarning(), ::testing::MatchesRegex(
       ".*An axis2 may not be specified for ball joint 'should_not_have_axis' "
       "and will be ignored.*"));
@@ -1130,7 +1123,6 @@ TEST_F(SdfParserTest, JointParsingTest) {
   EXPECT_EQ(ball_joint.name(), "ball_joint");
   EXPECT_EQ(ball_joint.parent_body().name(), "link4");
   EXPECT_EQ(ball_joint.child_body().name(), "link5");
-  EXPECT_EQ(ball_joint.damping(), 0.1);
   const Vector3d inf3(std::numeric_limits<double>::infinity(),
                       std::numeric_limits<double>::infinity(),
                       std::numeric_limits<double>::infinity());
@@ -1366,8 +1358,8 @@ TEST_F(SdfParserTest, UniversalJointDampingCoeffParsingTest) {
           "match.*"));
 }
 
-// Tests the error handling for an unsupported joint type (when actuated).
-TEST_F(SdfParserTest, ActuatedBallJointParsingTest) {
+// Tests the error handling for a ball joint with an axis.
+TEST_F(SdfParserTest, BallJointParsingTest) {
   ParseTestString(R"""(
 <model name="molly">
   <link name="larry" />
@@ -1383,7 +1375,8 @@ TEST_F(SdfParserTest, ActuatedBallJointParsingTest) {
   </joint>
 </model>)""");
   EXPECT_THAT(TakeWarning(), ::testing::MatchesRegex(
-      ".*effort limits.*ball joint.*not implemented.*"));
+      ".*An axis may not be specified for ball joint 'jerry' "
+      "and will be ignored.*"));
 }
 
 // Tests the error handling for an unsupported joint type.

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -754,11 +754,21 @@ TEST_F(SdfParserTest, BallJointWithAxis2Error) {
   <joint name='should_not_have_axis' type='ball'>
     <parent>a</parent>
     <child>b</child>
+    <axis>
+      <xyz>0 0 1</xyz>
+    </axis>
     <axis2>
       <xyz>0 0 1</xyz>
     </axis2>
   </joint>
 </model>)""");
+  EXPECT_THAT(TakeWarning(), ::testing::MatchesRegex(
+      ".*A ball joint axis will be ignored. Only the dynamic"
+      " parameters and limits will be considered.*"));
+  EXPECT_THAT(TakeWarning(), ::testing::MatchesRegex(
+      R"(.*Actuation \(via non-zero effort limits\) for ball joint )"
+      R"('should_not_have_axis' is not implemented yet and will be )"
+      R"(ignored.*)"));
   EXPECT_THAT(TakeWarning(), ::testing::MatchesRegex(
       ".*An axis2 may not be specified for ball joint 'should_not_have_axis' "
       "and will be ignored.*"));
@@ -1123,6 +1133,7 @@ TEST_F(SdfParserTest, JointParsingTest) {
   EXPECT_EQ(ball_joint.name(), "ball_joint");
   EXPECT_EQ(ball_joint.parent_body().name(), "link4");
   EXPECT_EQ(ball_joint.child_body().name(), "link5");
+  EXPECT_EQ(ball_joint.damping(), 0.1);
   const Vector3d inf3(std::numeric_limits<double>::infinity(),
                       std::numeric_limits<double>::infinity(),
                       std::numeric_limits<double>::infinity());
@@ -1133,6 +1144,13 @@ TEST_F(SdfParserTest, JointParsingTest) {
   EXPECT_TRUE(CompareMatrices(ball_joint.position_upper_limits(), inf3));
   EXPECT_TRUE(CompareMatrices(ball_joint.velocity_lower_limits(), neg_inf3));
   EXPECT_TRUE(CompareMatrices(ball_joint.velocity_upper_limits(), inf3));
+  // Ball joints with axis produce a waring indicating it only some params
+  // of it are used.
+  EXPECT_THAT(TakeWarning(), ::testing::MatchesRegex(
+      ".*A ball joint axis will be ignored. Only the dynamic"
+      " parameters and limits will be considered.*"));
+  FlushDiagnostics();
+
 
   // Universal joint
   DRAKE_EXPECT_NO_THROW(
@@ -1358,8 +1376,8 @@ TEST_F(SdfParserTest, UniversalJointDampingCoeffParsingTest) {
           "match.*"));
 }
 
-// Tests the error handling for a ball joint with an axis.
-TEST_F(SdfParserTest, BallJointParsingTest) {
+// Tests the error handling for an unsupported joint type (when actuated).
+TEST_F(SdfParserTest, ActuatedBallJointParsingTest) {
   ParseTestString(R"""(
 <model name="molly">
   <link name="larry" />
@@ -1375,8 +1393,10 @@ TEST_F(SdfParserTest, BallJointParsingTest) {
   </joint>
 </model>)""");
   EXPECT_THAT(TakeWarning(), ::testing::MatchesRegex(
-      ".*An axis may not be specified for ball joint 'jerry' "
-      "and will be ignored.*"));
+      ".*A ball joint axis will be ignored. Only the dynamic"
+      " parameters and limits will be considered.*"));
+  EXPECT_THAT(TakeWarning(), ::testing::MatchesRegex(
+      ".*effort limits.*ball joint.*not implemented.*"));
 }
 
 // Tests the error handling for an unsupported joint type.

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -1151,7 +1151,6 @@ TEST_F(SdfParserTest, JointParsingTest) {
       " parameters and limits will be considered.*"));
   FlushDiagnostics();
 
-
   // Universal joint
   DRAKE_EXPECT_NO_THROW(
       plant_.GetJointByName<UniversalJoint>("universal_joint", instance1));

--- a/multibody/parsing/test/sdf_parser_test/joint_parsing_test.sdf
+++ b/multibody/parsing/test/sdf_parser_test/joint_parsing_test.sdf
@@ -122,6 +122,16 @@ Defines an SDF model with various types of joints used for testing the parser.
       <joint name="ball_joint" type="ball">
         <child>link5</child>
         <parent>link4</parent>
+        <axis>
+          <dynamics>
+            <damping>0.1</damping>
+          </dynamics>
+          <xyz expressed_in="__model__">0 0 1</xyz>
+          <limit>
+            <!-- not actuated -->
+            <effort>0</effort>
+          </limit>
+        </axis>
       </joint>
       <link name="link6">
         <inertial>

--- a/multibody/parsing/test/sdf_parser_test/joint_parsing_test.sdf
+++ b/multibody/parsing/test/sdf_parser_test/joint_parsing_test.sdf
@@ -122,16 +122,6 @@ Defines an SDF model with various types of joints used for testing the parser.
       <joint name="ball_joint" type="ball">
         <child>link5</child>
         <parent>link4</parent>
-        <axis>
-          <dynamics>
-            <damping>0.1</damping>
-          </dynamics>
-          <xyz expressed_in="__model__">0 0 1</xyz>
-          <limit>
-            <!-- not actuated -->
-            <effort>0</effort>
-          </limit>
-        </axis>
       </joint>
       <link name="link6">
         <inertial>


### PR DESCRIPTION
Closes https://github.com/RobotLocomotion/drake/issues/18951.

Ball joints should have no axis and if there is one the sdf parser will ignore it.

This PR corrects the warning the user gets when the sdf parser finds an axis in a ball joint. It also adds fixes to the relevant tests and removes irrelevant code related to parameters of a ball joint axis.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18966)
<!-- Reviewable:end -->
