### PR TITLE
[pydrake] Consolidate the C++ list of math operators

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -103,6 +103,7 @@ drake_pybind_library(
     cc_deps = [
         ":autodiff_types_pybind",
         "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake:math_operators_pybind",
     ],
     cc_srcs = ["autodiffutils_py.cc"],
     package_info = PACKAGE_INFO,
@@ -131,15 +132,22 @@ drake_pybind_library(
     py_srcs = ["_lcm_extra.py"],
 )
 
+drake_cc_library(
+    name = "math_operators_pybind",
+    hdrs = ["math_operators_pybind.h"],
+    declare_installed_headers = 0,
+    deps = ["//:drake_shared_library"],
+)
+
 drake_pybind_library(
     name = "math_py",
     cc_deps = [
         "//bindings/pydrake:autodiff_types_pybind",
         "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake:math_operators_pybind",
         "//bindings/pydrake:symbolic_types_pybind",
         "//bindings/pydrake/common:cpp_template_pybind",
         "//bindings/pydrake/common:default_scalars_pybind",
-        "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:eigen_pybind",
         "//bindings/pydrake/common:type_pack",
         "//bindings/pydrake/common:value_pybind",
@@ -212,7 +220,7 @@ drake_pybind_library(
     cc_deps = [
         ":symbolic_types_pybind",
         "//bindings/pydrake:documentation_pybind",
-        "//bindings/pydrake/common:deprecation_pybind",
+        "//bindings/pydrake:math_operators_pybind",
         "//bindings/pydrake/common:eigen_pybind",
     ],
     cc_srcs = [

--- a/bindings/pydrake/autodiff_types_pybind.h
+++ b/bindings/pydrake/autodiff_types_pybind.h
@@ -1,67 +1,11 @@
 #pragma once
 
-#include <algorithm>
-
 #include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-#include <Eigen/Core>
+#include "pybind11/numpy.h"
 
-#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/autodiff.h"
 
 // The macro `PYBIND11_NUMPY_OBJECT_DTYPE` place symbols into the namespace
 // `pybind11::detail`, so we should not place these in `drake::pydrake`.
 
 PYBIND11_NUMPY_OBJECT_DTYPE(drake::AutoDiffXd);
-
-namespace drake {
-namespace pydrake {
-namespace internal {
-
-// TODO(eric.cousineau): Deprecate these methods once we support proper NumPy
-// UFuncs.
-
-// Adds math function overloads for AutoDiffXd (ADL free functions from
-// `autodiff.h`) for both NumPy methods and `pydrake.math`.
-// @param obj
-//   If this is py::class_, this is intended to register class methods on
-//   `AutoDiffXd` to overload NumPy's math methods.
-//   If this is py::module, this is intended to register the overloads in
-//   `pydrake.math`.
-template <typename PyObject>
-void BindAutoDiffMathOverloads(PyObject* obj) {
-  // TODO(m-chaturvedi) Add Pybind11 documentation.
-  (*obj)  // BR
-      .def("log", [](const AutoDiffXd& x) { return log(x); })
-      .def("abs", [](const AutoDiffXd& x) { return abs(x); })
-      .def("exp", [](const AutoDiffXd& x) { return exp(x); })
-      .def("sqrt", [](const AutoDiffXd& x) { return sqrt(x); })
-      .def("pow", [](const AutoDiffXd& x, double y) { return pow(x, y); })
-      .def("sin", [](const AutoDiffXd& x) { return sin(x); })
-      .def("cos", [](const AutoDiffXd& x) { return cos(x); })
-      .def("tan", [](const AutoDiffXd& x) { return tan(x); })
-      .def("asin", [](const AutoDiffXd& x) { return asin(x); })
-      .def("acos", [](const AutoDiffXd& x) { return acos(x); })
-      .def("atan2",
-          [](const AutoDiffXd& y, const AutoDiffXd& x) { return atan2(y, x); })
-      .def("sinh", [](const AutoDiffXd& x) { return sinh(x); })
-      .def("cosh", [](const AutoDiffXd& x) { return cosh(x); })
-      .def("tanh", [](const AutoDiffXd& x) { return tanh(x); })
-      .def("min",
-          [](const AutoDiffXd& x, const AutoDiffXd& y) { return min(x, y); })
-      .def("max",
-          [](const AutoDiffXd& x, const AutoDiffXd& y) { return max(x, y); })
-      .def("ceil", [](const AutoDiffXd& x) { return ceil(x); })
-      .def("__ceil__", [](const AutoDiffXd& x) { return ceil(x); })
-      .def("floor", [](const AutoDiffXd& x) { return floor(x); })
-      .def("__floor__", [](const AutoDiffXd& x) { return floor(x); })
-      // TODO(eric.cousineau): This is not a NumPy-overridable method using
-      // dtype=object. Deprecate and move solely into `pydrake.math`.
-      .def("inv", [](const MatrixX<AutoDiffXd>& X) -> MatrixX<AutoDiffXd> {
-        return X.inverse();
-      });
-}
-
-}  // namespace internal
-}  // namespace pydrake
-}  // namespace drake

--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -6,6 +6,7 @@
 
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/math_operators_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/drake_throw.h"
 #include "drake/math/autodiff.h"
@@ -100,7 +101,7 @@ PYBIND11_MODULE(autodiffutils, m) {
   py::implicitly_convertible<double, AutoDiffXd>();
   py::implicitly_convertible<int, AutoDiffXd>();
 
-  pydrake::internal::BindAutoDiffMathOverloads(&autodiff);
+  pydrake::internal::BindMathOperators<AutoDiffXd>(&autodiff);
 
   // Mirror for numpy.
   autodiff.attr("arcsin") = autodiff.attr("asin");

--- a/bindings/pydrake/math_operators_pybind.h
+++ b/bindings/pydrake/math_operators_pybind.h
@@ -1,0 +1,147 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <type_traits>
+
+#include "pybind11/eigen.h"
+#include "pybind11/numpy.h"
+
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/common/drake_bool.h"
+
+namespace drake {
+namespace pydrake {
+namespace internal {
+
+/* Returns X.inverse() but with special casing for symbolic types. */
+template <typename T>
+MatrixX<T> CalcMatrixInverse(const MatrixX<T>& X) {
+  constexpr bool is_symbolic_algebra = !scalar_predicate<T>::is_bool;
+  if (is_symbolic_algebra) {
+    const int N = X.rows();
+    // Note that MatrixX<Expression>.inverse() will fail for symbolic matrices
+    // that contain variables. We'll special case the sizes shown to work in
+    // `expression_matrix_test.cc`.
+    if (N == X.cols()) {
+      switch (N) {
+        case 1:
+          return Eigen::Matrix<T, 1, 1>(X).inverse();
+        case 2:
+          return Eigen::Matrix<T, 2, 2>(X).inverse();
+        case 3:
+          return Eigen::Matrix<T, 3, 3>(X).inverse();
+        case 4:
+          return Eigen::Matrix<T, 4, 4>(X).inverse();
+      }
+    }
+  }
+  return X.inverse();
+}
+
+// TODO(eric.cousineau): Deprecate these methods once we support proper NumPy
+// UFuncs.
+
+/* Adds math function overloads (ADL free functions) for the given class `T`.
+This is used for both NumPy methods and `pydrake.math` module functions.
+@param obj If this is py::class_, this is intended to register class methods on
+to overload NumPy's math methods. If this is py::module_, this is intended to
+register the overloads in `pydrake.math`. */
+template <typename T, typename PyObject>
+void BindMathOperators(PyObject* obj) {
+  // Prepare for ADL in case T is `double`.
+  using std::abs;
+  using std::acos;
+  using std::asin;
+  using std::atan;
+  using std::atan2;
+  using std::ceil;
+  using std::cos;
+  using std::cosh;
+  using std::exp;
+  using std::floor;
+  using std::isnan;
+  using std::log;
+  using std::max;
+  using std::min;
+  using std::pow;
+  using std::sin;
+  using std::sinh;
+  using std::sqrt;
+  using std::tan;
+  using std::tanh;
+
+  // A few functions differ for module vs class bindings.
+  constexpr bool is_module = std::is_same_v<PyObject, py::module_>;
+
+  // When binding certain types (e.g., symbolic::Variable), operations return
+  // a type other than the argument type.
+  using Promoted = decltype(std::declval<T>() + std::declval<T>());
+
+  // Add functions that exist both on the class and in the module.
+  (*obj)  // BR
+      .def("abs", [](const T& x) { return abs(x); })
+      .def("acos", [](const T& x) { return acos(x); })
+      .def("arccos", [](const T& x) { return acos(x); })
+      .def("asin", [](const T& x) { return asin(x); })
+      .def("arcsin", [](const T& x) { return asin(x); })
+      .def("atan", [](const T& x) { return atan(x); })
+      .def("arctan", [](const T& x) { return atan(x); })
+      .def("ceil", [](const T& x) { return ceil(x); })
+      .def("cos", [](const T& x) { return cos(x); })
+      .def("cosh", [](const T& x) { return cosh(x); })
+      .def("exp", [](const T& x) { return exp(x); })
+      .def("floor", [](const T& x) { return floor(x); })
+      .def("log", [](const T& x) { return log(x); })
+      .def("max", [](const T& x, const T& y) { return max(x, y); })
+      .def("min", [](const T& x, const T& y) { return min(x, y); })
+      .def("pow", [](const T& x, double y) { return pow(x, y); })
+      .def("sin", [](const T& x) { return sin(x); })
+      .def("sinh", [](const T& x) { return sinh(x); })
+      .def("sqrt", [](const T& x) { return sqrt(x); })
+      .def("tan", [](const T& x) { return tan(x); })
+      .def("tanh", [](const T& x) { return tanh(x); });
+  // For symbolic types (only), the `pow` exponent can also be an Expression.
+  if constexpr (!scalar_predicate<T>::is_bool) {
+    obj->def("pow", [](const T& x, const Promoted& y) { return pow(x, y); });
+  }
+  // For atan2 the named arguments change for the module function vs the method.
+  {
+    auto func = [](const T& y, const T& x) { return atan2(y, x); };
+    if constexpr (is_module) {
+      obj->def("atan2", func, py::arg("y"), py::arg("x"));
+      obj->def("arctan2", func, py::arg("y"), py::arg("x"));
+    } else {
+      obj->def("atan2", func, py::arg("x"),
+          "Uses ``self`` for ``y`` in ``atan2(y, x)``.");
+      obj->def("arctan2", func, py::arg("x"),
+          "Uses ``self`` for ``y`` in ``arctan2(y, x)``.");
+    }
+  }
+
+  // Add functions specific to either the class or the module.
+  if constexpr (is_module) {
+    auto& m = *obj;
+    m  // BR
+        .def("inv",
+            [](const MatrixX<T>& X) {
+              if constexpr (std::is_same_v<T, Promoted>) {
+                return CalcMatrixInverse(X);
+              } else {
+                return CalcMatrixInverse(X.template cast<Promoted>().eval());
+              }
+            })
+        .def(
+            "isnan", [](const T& x) { return isnan(x); }, py::arg("x"));
+  } else {
+    auto& cls = *obj;
+    cls  // BR
+        .def("__abs__", [](const T& x) { return abs(x); })
+        .def("__ceil__", [](const T& x) { return ceil(x); })
+        .def("__floor__", [](const T& x) { return floor(x); });
+  }
+}
+
+}  // namespace internal
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -7,9 +7,9 @@
 #include "pybind11/stl.h"
 #include <fmt/format.h>
 
-#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/math_operators_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_py_unapply.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
@@ -145,7 +145,7 @@ PYBIND11_MODULE(symbolic, m) {
       .def(py::self != Expression())
       .def(py::self != py::self)
       .def(py::self != double());
-  internal::BindSymbolicMathOverloads<Variable>(&var_cls);
+  internal::BindMathOperators<Variable>(&var_cls);
   DefCopyAndDeepCopy(&var_cls);
 
   // Bind the free function TaylorExpand.
@@ -460,8 +460,8 @@ PYBIND11_MODULE(symbolic, m) {
       .def("Jacobian", &Expression::Jacobian, py::arg("vars"),
           doc.Expression.Jacobian.doc);
   // TODO(eric.cousineau): Clean this overload stuff up (#15041).
-  pydrake::internal::BindSymbolicMathOverloads<Expression>(&expr_cls);
-  pydrake::internal::BindSymbolicMathOverloads<Expression>(&m);
+  pydrake::internal::BindMathOperators<Expression>(&expr_cls);
+  pydrake::internal::BindMathOperators<Expression>(&m);
   DefCopyAndDeepCopy(&expr_cls);
 
   m.def("if_then_else", &symbolic::if_then_else, py::arg("f_cond"),

--- a/bindings/pydrake/symbolic_py_unapply.h
+++ b/bindings/pydrake/symbolic_py_unapply.h
@@ -2,6 +2,7 @@
 
 #include "pybind11/pybind11.h"
 
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
 
 namespace drake {

--- a/bindings/pydrake/symbolic_types_pybind.h
+++ b/bindings/pydrake/symbolic_types_pybind.h
@@ -1,10 +1,8 @@
 #pragma once
 
 #include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
+#include "pybind11/numpy.h"
 
-#include "drake/bindings/pydrake/documentation_pybind.h"
-#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/symbolic/expression.h"
 #include "drake/common/symbolic/polynomial.h"
 #include "drake/common/symbolic/rational_function.h"
@@ -21,79 +19,3 @@ PYBIND11_NUMPY_OBJECT_DTYPE(drake::symbolic::Monomial);
 PYBIND11_NUMPY_OBJECT_DTYPE(drake::symbolic::Polynomial);
 PYBIND11_NUMPY_OBJECT_DTYPE(drake::symbolic::RationalFunction);
 PYBIND11_NUMPY_OBJECT_DTYPE(drake::symbolic::Variable);
-
-namespace drake {
-namespace pydrake {
-namespace internal {
-
-// TODO(eric.cousineau): Deprecate these methods once we support proper NumPy
-// UFuncs.
-
-// Adds math function overloads for Expression (ADL free functions from
-// `expression.h`) for both NumPy methods and `pydrake.math`.
-// @param obj
-//   This is used to register functions or overloads in either
-//   `pydrake.symbolic` or `pydrake.math`.
-template <typename Class, typename PyObject>
-void BindSymbolicMathOverloads(PyObject* obj) {
-  using symbolic::Expression;
-  constexpr auto& doc = pydrake_doc.drake.symbolic;
-  (*obj)  // BR
-      .def("log", &symbolic::log, doc.log.doc)
-      .def("abs", &symbolic::abs, doc.abs.doc)
-      .def("__abs__", &symbolic::abs, doc.abs.doc)
-      .def("exp", &symbolic::exp, doc.exp.doc)
-      .def("sqrt", &symbolic::sqrt, doc.sqrt.doc)
-      .def("pow",
-          [](const Class& base, const Expression& exponent) {
-            return pow(base, exponent);
-          })
-      .def("sin", &symbolic::sin, doc.sin.doc)
-      .def("cos", &symbolic::cos, doc.cos.doc)
-      .def("tan", &symbolic::tan, doc.tan.doc)
-      .def("arcsin", &symbolic::asin, doc.asin.doc)
-      .def("asin", &symbolic::asin, doc.asin.doc)
-      .def("arccos", &symbolic::acos, doc.acos.doc)
-      .def("acos", &symbolic::acos, doc.acos.doc)
-      .def("arctan", &symbolic::atan, doc.atan.doc)
-      .def("atan", &symbolic::atan, doc.atan.doc)
-      .def("arctan2", &symbolic::atan2, doc.atan2.doc)
-      .def("atan2", &symbolic::atan2, doc.atan2.doc)
-      .def("sinh", &symbolic::sinh, doc.sinh.doc)
-      .def("cosh", &symbolic::cosh, doc.cosh.doc)
-      .def("tanh", &symbolic::tanh, doc.tanh.doc)
-      .def("min", &symbolic::min, doc.min.doc)
-      .def("max", &symbolic::max, doc.max.doc)
-      .def("ceil", &symbolic::ceil, doc.ceil.doc)
-      .def("__ceil__", &symbolic::ceil, doc.ceil.doc)
-      .def("floor", &symbolic::floor, doc.floor.doc)
-      .def("__floor__", &symbolic::floor, doc.floor.doc)
-      // TODO(eric.cousineau): This is not a NumPy-overridable method using
-      // dtype=object. Deprecate and move solely into `pydrake.math`.
-      .def(
-          "inv",
-          [](const MatrixX<Expression>& X) -> MatrixX<Expression> {
-            const int N = X.rows();
-            // Note that MatrixX<Expression>.inverse() will fail for
-            // non-float-convertible symbolic matrices. We special case the
-            // sizes shown to work in `expression_matrix_test.cc`.
-            if (N == X.cols()) {
-              switch (N) {
-                case 1:
-                  return Eigen::Matrix<Expression, 1, 1>(X).inverse();
-                case 2:
-                  return Eigen::Matrix<Expression, 2, 2>(X).inverse();
-                case 3:
-                  return Eigen::Matrix<Expression, 3, 3>(X).inverse();
-                case 4:
-                  return Eigen::Matrix<Expression, 4, 4>(X).inverse();
-              }
-            }
-            return X.inverse();
-          },
-          "Symbolic matrix inverse");
-}
-
-}  // namespace internal
-}  // namespace pydrake
-}  // namespace drake


### PR DESCRIPTION
Repeating the list of functions in three different places is too difficult to maintain; refactor into a single place.

Remove `inv` methods on symbolic types; the type of `self` would never be able to match so they would always throw (I think?).

Add proper `atan2` kwargs and documentation for all scalars.  Calling `y.atan2(x)` is ... a thing.

Towards https://github.com/RobotLocomotion/drake/issues/11802.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18979)
<!-- Reviewable:end -->
