### PR TITLE
[multibody] Add joint locking feature to SAP

### DIFF
--- a/multibody/contact_solvers/sap/sap_constraint.h
+++ b/multibody/contact_solvers/sap/sap_constraint.h
@@ -271,7 +271,11 @@ class SapConstraint {
     |     TRUE        |     TRUE        |   permuted(i)   |    permuted(j)   |
     |------------------------------------------------------------------------|
     Note: if both cliques do not participate, this function returns `nullptr`.
-    @pre clique_permutation.domain_size() == per_clique_known_dofs.size().
+    Note: per_clique_known_dofs.size() can be smaller than
+    clique_permutation.domain_size() (i.e. the number of cliques in the problem)
+    for cases in which the last set of cliques have zero known DoFs and it is
+    therefore unnecessary to pad per_clique_known_dofs with empty vectors.
+    @pre per_clique_known_dofs.size() <= clique_permutation.domain_size() .
     @pre first_clique() < clique_permutation.domain_size().
     @pre if num_cliques() > 1,
       second_clique() < clique_permutation.domain_size().

--- a/multibody/contact_solvers/sap/sap_contact_problem.h
+++ b/multibody/contact_solvers/sap/sap_contact_problem.h
@@ -102,7 +102,10 @@ class SapContactProblem {
     then its local velocity indices are {0, 1, 2}. If `known_free_motion_dofs` =
     {6}, i.e. we know v₆ = v₆*, then `per_clique_known_free_motion_dofs[0] =
     {1}` containing the known clique local index 1, corresponding to the known
-    global velocity index 6.
+    global velocity index 6. `per_clique_known_free_motion_dofs` need not
+    specify indices for every clique in the problem, it may only specify known
+    DoFs for the first n cliques where n < num_cliques(). All other cliques are
+    assumed to not have any known DoFs.
 
     @param[in] known_free_motion_dofs Specifies known DOFs to be eliminated.
     i ∈ known_free_motion_dofs specifies the i-th DOF.
@@ -117,7 +120,7 @@ class SapContactProblem {
 
     @pre known_free_motion_dofs is a strict ordered subset of
          [0, ..., num_velocities()-1].
-    @pre per_clique_known_free_motion_dofs.size() == num_cliques().
+    @pre per_clique_known_free_motion_dofs.size() <= num_cliques().
     @pre per_clique_known_free_motion_dofs[c] is a strict ordered subset of
          [0, ..., num_velocities(c)-1].
     @pre mapping != nullptr.

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -540,7 +540,6 @@ drake_cc_googletest(
     deps = [
         ":slicing_and_indexing",
         "//common:essential",
-        "//common/test_utilities:expect_throws_message",
     ],
 )
 
@@ -995,6 +994,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "joint_locking_test",
     deps = [
+        ":multibody_plant_config_functions",
         ":plant",
         "//systems/analysis:simulator",
     ],

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -366,7 +366,8 @@ void CompliantContactManager<T>::AppendDiscreteContactPairsForPointContact(
   const geometry::SceneGraphInspector<T>& inspector = query_object.inspector();
 
   const std::vector<std::vector<int>>& per_tree_unlocked_indices =
-      this->EvalUnlockedVelocityIndicesPerTree(context);
+      this->EvalJointLockingCache(context)
+          .unlocked_velocity_indices_per_tree;
   const MultibodyTreeTopology& topology = this->internal_tree().get_topology();
 
   // Fill in the point contact pairs.
@@ -460,7 +461,8 @@ void CompliantContactManager<T>::
       this->EvalContactSurfaces(context);
 
   const std::vector<std::vector<int>>& per_tree_unlocked_indices =
-      this->EvalUnlockedVelocityIndicesPerTree(context);
+      this->EvalJointLockingCache(context)
+          .unlocked_velocity_indices_per_tree;
   const MultibodyTreeTopology& topology = this->internal_tree().get_topology();
 
   const int num_surfaces = surfaces.size();
@@ -919,7 +921,8 @@ void CompliantContactManager<T>::CalcHydroelasticContactInfo(
 
   const MultibodyTreeTopology& topology = this->internal_tree().get_topology();
   const std::vector<std::vector<int>>& per_tree_unlocked_indices =
-      this->EvalUnlockedVelocityIndicesPerTree(context);
+      this->EvalJointLockingCache(context)
+          .unlocked_velocity_indices_per_tree;
 
   // Update contact info to include the correct contact forces.
   for (int surface_index = 0; surface_index < num_surfaces; ++surface_index) {

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -202,18 +202,11 @@ DiscreteUpdateManager<T>::coupler_constraints_specs() const {
 }
 
 template <typename T>
-const std::vector<int>& DiscreteUpdateManager<T>::EvalUnlockedVelocityIndices(
+const internal::JointLockingCacheData<T>&
+DiscreteUpdateManager<T>::EvalJointLockingCache(
     const systems::Context<T>& context) const {
   return MultibodyPlantDiscreteUpdateManagerAttorney<
-      T>::EvalUnlockedVelocityIndices(plant(), context);
-}
-
-template <typename T>
-const std::vector<std::vector<int>>&
-DiscreteUpdateManager<T>::EvalUnlockedVelocityIndicesPerTree(
-    const systems::Context<T>& context) const {
-  return MultibodyPlantDiscreteUpdateManagerAttorney<
-      T>::EvalUnlockedVelocityIndicesPerTree(plant(), context);
+      T>::EvalJointLockingCache(plant(), context);
 }
 
 template <typename T>

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -31,6 +31,9 @@ namespace internal {
 template <typename T>
 class AccelerationKinematicsCache;
 
+template <typename T>
+struct JointLockingCacheData;
+
 /* This class is used to perform all calculations needed to advance state for a
  MultibodyPlant with discrete state.
 
@@ -245,10 +248,8 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   const std::vector<internal::CouplerConstraintSpecs>&
   coupler_constraints_specs() const;
 
-  const std::vector<int>& EvalUnlockedVelocityIndices(
-      const systems::Context<T>& context) const;
-
-  const std::vector<std::vector<int>>& EvalUnlockedVelocityIndicesPerTree(
+  const internal::JointLockingCacheData<T>&
+  EvalJointLockingCache(
       const systems::Context<T>& context) const;
 
   const std::vector<internal::DistanceConstraintSpecs>&

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -64,6 +64,34 @@ struct HydroelasticContactInfoAndBodySpatialForces {
   std::vector<HydroelasticContactInfo<T>> contact_info;
 };
 
+// Data stored in the cache entry for joint locking.
+template <typename T>
+struct JointLockingCacheData {
+  // @name Dense joint locking indices.
+  // Values of each will be a sorted subset of [0, num_velocities()].
+  // `unlocked_velocity_indices` and `locked_velocity_indices` are disjoint and
+  // their union is [0, num_velocities()].
+  // @{
+  // Stores indices of unlocked DoFs in the context.
+  std::vector<int> unlocked_velocity_indices;
+  // Stores indices of locked DoFs in the context.
+  std::vector<int> locked_velocity_indices;
+  // @}
+
+  // @name Per-tree joint locking indices.
+  // Each has the same size as the number of trees in the plant's topology and
+  // is resized accordingly on output. For both unlocked and locked, element i
+  // is a sorted subset of [0, tree_i.num_velocities()] where tree_i is the i-th
+  // tree in this plant's topology. They are likewise disjoint and their union
+  // is [0, tree_i.num_velocities()].
+  // @{
+  // Stores indices of unlocked DoFs per tree in the plant's topology.
+  std::vector<std::vector<int>> unlocked_velocity_indices_per_tree;
+  // Stores indices of locked DoFs per tree in the plant's topology.
+  std::vector<std::vector<int>> locked_velocity_indices_per_tree;
+  // @}
+};
+
 // This struct contains the parameters to compute forces to enforce
 // no-interpenetration between bodies by a penalty method.
 struct ContactByPenaltyMethodParameters {
@@ -4655,7 +4683,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     systems::CacheIndex spatial_contact_forces_continuous;
     systems::CacheIndex discrete_contact_pairs;
     systems::CacheIndex joint_locking_data;
-    systems::CacheIndex joint_locking_data_per_tree;
   };
 
   // Constructor to bridge testing from MultibodyTree to MultibodyPlant.
@@ -4826,37 +4853,16 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const systems::Context<T>& context0,
       systems::DiscreteValues<T>* updates) const;
 
-  // Computes the array of indices of velocities that are not locked in the
-  // current configuration. The resulting index values in @p
-  // unlocked_velocity_indices will be in ascending order, in the range [0,
-  // num_velocities()), with the indices of the locked velocities removed.
-  void CalcUnlockedVelocityIndices(
-      const systems::Context<T>& context,
-      std::vector<int>* unlocked_velocity_indices) const;
+  // Data will be resized on output according to the documentation for
+  // JointLockingCacheData.
+  void CalcJointLockingCache(const systems::Context<T>& context,
+                             internal::JointLockingCacheData<T>* data) const;
 
-  // Eval version of the method CalcUnlockedVelocityIndices().
-  const std::vector<int>& EvalUnlockedVelocityIndices(
+  // Eval version of the method CalcJointLockingCache().
+  const internal::JointLockingCacheData<T>& EvalJointLockingCache(
       const systems::Context<T>& context) const {
     return this->get_cache_entry(cache_indexes_.joint_locking_data)
-        .template Eval<std::vector<int>>(context);
-  }
-
-  // Computes the array of indices of velocities that are not locked in the
-  // current configuration for each tree in the plant's topology. The resulting
-  // index values in each element of @p unlocked_velocity_indices will be in
-  // ascending order, in the range [0, tree_M.num_velocities()), with the
-  // indices of the locked velocities removed. `unlocked_velocity_indices` has
-  // the same size as the number of trees in the plant's topology and is resized
-  // accordingly on output.
-  void CalcUnlockedVelocityIndicesPerTree(
-      const systems::Context<T>& context,
-      std::vector<std::vector<int>>* unlocked_velocity_indices) const;
-
-  // Eval version of the method CalcUnlockedVelocityIndices().
-  const std::vector<std::vector<int>>& EvalUnlockedVelocityIndicesPerTree(
-      const systems::Context<T>& context) const {
-    return this->get_cache_entry(cache_indexes_.joint_locking_data_per_tree)
-        .template Eval<std::vector<std::vector<int>>>(context);
+        .template Eval<internal::JointLockingCacheData<T>>(context);
   }
 
   // Computes the vector of ContactSurfaces for hydroelastic contact.

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -92,15 +92,10 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
     return plant.coupler_constraints_specs_;
   }
 
-  static const std::vector<int>& EvalUnlockedVelocityIndices(
-      const MultibodyPlant<T>& plant, const systems::Context<T>& context) {
-    return plant.EvalUnlockedVelocityIndices(context);
-  }
-
-  static const std::vector<std::vector<int>>&
-  EvalUnlockedVelocityIndicesPerTree(const MultibodyPlant<T>& plant,
-                                     const systems::Context<T>& context) {
-    return plant.EvalUnlockedVelocityIndicesPerTree(context);
+  static const internal::JointLockingCacheData<T>&
+  EvalJointLockingCache(const MultibodyPlant<T>& plant,
+                                       const systems::Context<T>& context) {
+    return plant.EvalJointLockingCache(context);
   }
 
   static const std::vector<internal::DistanceConstraintSpecs>&

--- a/multibody/plant/sap_driver.h
+++ b/multibody/plant/sap_driver.h
@@ -37,13 +37,25 @@ struct ContactProblemCache {
     sap_problem =
         std::make_unique<contact_solvers::internal::SapContactProblem<T>>(
             time_step, std::vector<MatrixX<T>>(), VectorX<T>());
+    // `sap_problem_locked` is a transformation of the problem stored in
+    // `sap_problem` that eliminates DoFs and constraints given by joint locking
+    // data from the plant. When joint locking is preset, the locked problem
+    // is solved and its results expanded into results for the original.
+    sap_problem_locked =
+        std::make_unique<contact_solvers::internal::SapContactProblem<T>>(
+            time_step, std::vector<MatrixX<T>>(), VectorX<T>());
   }
   copyable_unique_ptr<contact_solvers::internal::SapContactProblem<T>>
       sap_problem;
 
+  copyable_unique_ptr<contact_solvers::internal::SapContactProblem<T>>
+      sap_problem_locked;
+
   // TODO(amcastro-tri): consider removing R_WC from the contact problem cache
   // and instead cache ContactPairKinematics separately.
   std::vector<math::RotationMatrix<T>> R_WC;
+
+  contact_solvers::internal::ReducedMapping mapping;
 };
 
 // Performs the computations needed by CompliantContactManager for discrete
@@ -170,7 +182,7 @@ class SapDriver {
       const systems::Context<T>& context,
       const contact_solvers::internal::SapContactProblem<T>& problem,
       int num_contacts,
-      const contact_solvers::internal::SapSolverResults<T>& sap_results,
+      const contact_solvers::internal::SapSolverResults<T>& sap_results_locked,
       contact_solvers::internal::ContactSolverResults<T>* contact_results)
       const;
 

--- a/multibody/plant/slicing_and_indexing.h
+++ b/multibody/plant/slicing_and_indexing.h
@@ -46,10 +46,11 @@ MatrixX<T> SelectCols(const MatrixX<T>& M, const std::vector<int>& indices);
 template <typename T>
 MatrixX<T> ExcludeCols(const MatrixX<T>& M, const std::vector<int>& indices);
 
-// If M.is_dense() == true, returns a new possibly smaller matrix from M, by
-// excluding the columns indexed by @p indices. Does not handle non-dense
-// MatrixBlock.
-// @throws std::exception if !M.is_dense()
+// If indices.size() > 0 &&  M.is_dense() == true, returns a new possibly
+// smaller matrix from M, by excluding the columns indexed by @p indices.
+// Returns a copy of M if indices.size() == 0. Only supports non-dense
+// MatrixBlock arguments with indices.size() == 0.
+// @throws std::exception if indices.size() > 0 && !M.is_dense()
 // @pre indices.size() <= M.cols().
 // @pre indices argument is valid according to DemandIndicesValid().
 template <typename T>
@@ -80,11 +81,6 @@ VectorX<T> ExcludeRows(const VectorX<T>& v, const std::vector<int>& indices);
 template <typename T>
 VectorX<T> ExpandRows(const VectorX<T>& v, int rows_out,
                       const std::vector<int>& indices);
-
-template <typename T>
-VectorX<T> ExpandRows(const Eigen::VectorBlock<const VectorX<T>>& v,
-                      int rows_out, const std::vector<int>& indices);
-
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/tamsi_driver.cc
+++ b/multibody/plant/tamsi_driver.cc
@@ -133,7 +133,9 @@ void TamsiDriver<T>::CalcContactSolverResults(
   }
 
   // Joint locking: quick exit if everything is locked.
-  const auto& indices = manager().EvalUnlockedVelocityIndices(context);
+  const auto& indices = manager()
+                            .EvalJointLockingCache(context)
+                            .unlocked_velocity_indices;
   if (indices.empty()) {
     // Everything is locked! Return a result that indicates no velocity, but
     // reports normal forces.

--- a/multibody/plant/test/deformable_driver_test.cc
+++ b/multibody/plant/test/deformable_driver_test.cc
@@ -36,6 +36,8 @@ class DeformableDriverTest : public ::testing::Test {
     body_id_ = RegisterSphere(deformable_model.get(), kRezHint);
     model_ = deformable_model.get();
     plant_->AddPhysicalModel(std::move(deformable_model));
+    const RigidBody<double>& body = plant_->AddRigidBody(
+        "rigid_body", SpatialInertia<double>::SolidSphereWithMass(1.0, 1.0));
     // N.B. Currently the manager only supports SAP.
     plant_->set_discrete_contact_solver(DiscreteContactSolver::kSap);
     plant_->Finalize();
@@ -51,6 +53,9 @@ class DeformableDriverTest : public ::testing::Test {
     diagram_context_ = diagram_->CreateDefaultContext();
     plant_context_ =
         &plant_->GetMyMutableContextFromRoot(diagram_context_.get());
+    // Lock the rigid body to test locking support in the presence of deformable
+    // DoFs.
+    body.Lock(plant_context_);
   }
 
   /* Forwarding calls to private member functions in DeformableDriver with the

--- a/multibody/plant/test/slicing_and_indexing_test.cc
+++ b/multibody/plant/test/slicing_and_indexing_test.cc
@@ -3,10 +3,10 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
-#include "drake/common/test_utilities/expect_throws_message.h"
 
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
+using Eigen::Vector3d;
 
 namespace drake {
 namespace multibody {
@@ -24,14 +24,14 @@ MatrixXd MakeMatrixWithLinSpacedValues(int rows, int cols) {
 GTEST_TEST(SlicingAndIndexing, SelectRows) {
   const VectorXd M = MakeMatrixWithLinSpacedValues(6, 1);
   const MatrixXd S = SelectRows(M, indices);
-  const VectorXd S_expected = (VectorXd(3, 1) << 2, 4, 5).finished();
+  const VectorXd S_expected = Vector3d(2, 4, 5);
   EXPECT_EQ(S, S_expected);
 }
 
 GTEST_TEST(SlicingAndIndexing, ExcludeRows) {
   const VectorXd M = MakeMatrixWithLinSpacedValues(6, 1);
   const MatrixXd S = ExcludeRows(M, indices);
-  const VectorXd S_expected = (VectorXd(3, 1) << 1, 3, 6).finished();
+  const VectorXd S_expected = Vector3d(1, 3, 6);
   EXPECT_EQ(S, S_expected);
 }
 
@@ -88,9 +88,7 @@ GTEST_TEST(SlicingAndIndexing, ExcludeCols) {
   {
     const contact_solvers::internal::MatrixBlock<double> M_block(
         contact_solvers::internal::Block3x3SparseMatrix<double>(0, 0));
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        ExcludeCols(M_block, indices),
-        ".*ExcludeCols only supports dense MatrixBlock arguments.*");
+    EXPECT_THROW(ExcludeCols(M_block, indices), std::runtime_error);
   }
 }
 
@@ -121,22 +119,10 @@ GTEST_TEST(SlicingAndIndexing, ExcludeRowsCols) {
 GTEST_TEST(SlicingAndIndexing, ExpandRows) {
   const VectorXd M = MakeMatrixWithLinSpacedValues(3, 1);
   const int expanded_size = 8;
-  // Test VectorX variant.
-  {
-    const VectorXd S = ExpandRows(M, expanded_size, indices);
-    const VectorXd S_expected =
-        (VectorXd(expanded_size) << 0, 1, 0, 2, 3, 0, 0, 0).finished();
-    EXPECT_EQ(S, S_expected);
-  }
-
-  // Test VectorBlock variant.
-  {
-    const Eigen::VectorBlock<const VectorXd>& M_block = M.head(3);
-    const VectorXd S = ExpandRows(M_block, expanded_size, indices);
-    const VectorXd S_expected =
-        (VectorXd(expanded_size) << 0, 1, 0, 2, 3, 0, 0, 0).finished();
-    EXPECT_EQ(S, S_expected);
-  }
+  const VectorXd S = ExpandRows(M, expanded_size, indices);
+  const VectorXd S_expected =
+      (VectorXd(expanded_size) << 0, 1, 0, 2, 3, 0, 0, 0).finished();
+  EXPECT_EQ(S, S_expected);
 }
 
 }  // namespace


### PR DESCRIPTION
Implements functionality for joint locking when SAP is the underlying discrete solver. Prior to this PR, the locked/unlocked status of a joint was ignored when using SAP.

Now joint locking with function as intended: whatever configuration the joint was in when `joint.Lock(&context)` is called will remain constant in every subsequent timestep until `joint.Unlock(&context)` is called. Further, joint velocities for the locked joint will remain exactly 0 for every timestep while the joint is locked.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18983)
<!-- Reviewable:end -->
