### PR TITLE
[perception] PointCloud can morph its fields after construction

### DIFF
--- a/bindings/pydrake/perception_py.cc
+++ b/bindings/pydrake/perception_py.cc
@@ -119,6 +119,8 @@ void init_perception(py::module m) {
               self->SetFrom(other);
             },
             py::arg("other"), cls_doc.SetFrom.doc)
+        .def("SetFields", &Class::SetFields, py::arg("new_fields"),
+            py::arg("skip_initialize") = false, cls_doc.SetFields.doc)
         .def("Crop", &Class::Crop, py::arg("lower_xyz"), py::arg("upper_xyz"),
             cls_doc.Crop.doc)
         .def("FlipNormalsTowardPoint", &Class::FlipNormalsTowardPoint,

--- a/bindings/pydrake/test/perception_test.py
+++ b/bindings/pydrake/test/perception_test.py
@@ -77,6 +77,22 @@ class TestPerception(unittest.TestCase):
         pc.rgbs()
         pc.mutable_rgb(i=0)
         pc.rgb(i=0)
+        # Test morphing fields after PointCloud creation.
+        rgb_pc = mut.PointCloud(new_size=count,
+                                fields=mut.Fields(mut.BaseField.kRGBs))
+        all_fields_pc = mut.PointCloud(new_size=count, fields=all_fields)
+        test_rgbs = [[1, 2, 3]]
+        all_fields_pc.mutable_rgbs().T[:] = test_rgbs
+        self.assertFalse((rgb_pc.rgbs().T == test_rgbs).all())
+        self.assertFalse(rgb_pc.has_xyzs())
+        rgb_pc = all_fields_pc
+        self.assertTrue((rgb_pc.rgbs().T == test_rgbs).all())
+        self.assertTrue(rgb_pc.has_xyzs())
+        self.assertTrue(rgb_pc.has_normals())
+        rgb_pc.SetFields(new_fields=mut.Fields(mut.BaseField.kNormals),
+                         skip_initialize=False)
+        self.assertFalse(rgb_pc.has_rgbs())
+        self.assertTrue(rgb_pc.has_normals())
         # - Check for none.
         with self.assertRaises(RuntimeError) as ex:
             mut.PointCloud(new_size=0, fields=mut.Fields(mut.BaseField.kNone))

--- a/bindings/pydrake/visualization/test/meldis_test.py
+++ b/bindings/pydrake/visualization/test/meldis_test.py
@@ -25,9 +25,6 @@ from drake import (
 from pydrake.common import (
     FindResourceOrThrow,
 )
-from pydrake.common.value import (
-    Value,
-)
 from pydrake.geometry import (
     DrakeVisualizer,
     DrakeVisualizerParams,
@@ -119,8 +116,7 @@ class TestMeldis(unittest.TestCase):
         # Set input and publish the point cloud.
         context = diagram.CreateDefaultContext()
         cloud_context = cloud_to_lcm.GetMyContextFromRoot(context)
-        cloud_to_lcm.get_input_port().FixValue(
-            cloud_context, Value[PointCloud](cloud))
+        cloud_to_lcm.get_input_port().FixValue(cloud_context, cloud)
         diagram.ForcedPublish(context)
 
     def test_viewer_applet(self):

--- a/perception/point_cloud.cc
+++ b/perception/point_cloud.cc
@@ -83,7 +83,10 @@ class PointCloud::Storage {
     normals_.conservativeResize(NoChange,
                                 f.contains(pc_flags::kNormals) ? size_ : 0);
     rgbs_.conservativeResize(NoChange, f.contains(pc_flags::kRGBs) ? size_ : 0);
-    descriptors_.conservativeResize(NoChange, f.has_descriptor() ? size_ : 0);
+    // Note: The row size can change depends on whether 'f' contains a
+    // descriptor field and the type of the descriptor.
+    descriptors_.conservativeResize(f.descriptor_type().size(),
+                                    f.has_descriptor() ? size_ : 0);
     fields_ = f;
     CheckInvariants();
   }
@@ -95,21 +98,32 @@ class PointCloud::Storage {
 
  private:
   void CheckInvariants() const {
+    const int xyz_size = xyzs_.cols();
     if (fields_.contains(pc_flags::kXYZs)) {
-      const int xyz_size = xyzs_.cols();
       DRAKE_DEMAND(xyz_size == size());
+    } else {
+      DRAKE_DEMAND(xyz_size == 0);
     }
+    const int normals_size = normals_.cols();
     if (fields_.contains(pc_flags::kNormals)) {
-      const int normals_size = normals_.cols();
       DRAKE_DEMAND(normals_size == size());
+    } else {
+      DRAKE_DEMAND(normals_size == 0);
     }
+    const int rgbs_size = rgbs_.cols();
     if (fields_.contains(pc_flags::kRGBs)) {
-      const int rgbs_size = rgbs_.cols();
       DRAKE_DEMAND(rgbs_size == size());
+    } else {
+      DRAKE_DEMAND(rgbs_size == 0);
     }
+    const int descriptor_cols = descriptors_.cols();
+    const int descriptor_rows = descriptors_.rows();
     if (fields_.has_descriptor()) {
-      const int descriptor_size = descriptors_.cols();
-      DRAKE_DEMAND(descriptor_size == size());
+      DRAKE_DEMAND(descriptor_cols == size());
+      DRAKE_DEMAND(descriptor_rows == fields_.descriptor_type().size());
+    } else {
+      DRAKE_DEMAND(descriptor_cols == 0);
+      DRAKE_DEMAND(descriptor_rows == 0);
     }
   }
 
@@ -132,23 +146,21 @@ pc_flags::Fields ResolveFields(
   }
 }
 
-// Resolves the fields from a pair of point clouds and desired fields.
-// Implements the resolution rules in `SetFrom`.
-// @pre Valid point clouds `a` and `b`.
-// @returns Fields that both point clouds have.
-pc_flags::Fields ResolvePairFields(
-    const PointCloud& a,
-    const PointCloud& b,
-    pc_flags::Fields fields) {
-  if (fields == pc_flags::kInherit) {
-    // If we do not permit a subset, expect the exact same fields.
-    a.RequireExactFields(b.fields());
-    return a.fields();
-  } else {
-    a.RequireFields(fields);
-    b.RequireFields(fields);
-    return fields;
+// Finds the added fields from `new_fields` w.r.t. `old_fields`.
+pc_flags::Fields FindAddedFields(pc_flags::Fields old_fields,
+                                 pc_flags::Fields new_fields) {
+  pc_flags::Fields added_fields(pc_flags::kNone);
+  for (const auto field :
+       {pc_flags::kXYZs, pc_flags::kNormals, pc_flags::kRGBs}) {
+    if (!old_fields.contains(field) && new_fields.contains(field))
+      added_fields |= field;
   }
+
+  if (new_fields.has_descriptor() &&
+      old_fields.descriptor_type() != new_fields.descriptor_type()) {
+    added_fields |= new_fields.descriptor_type();
+  }
+  return added_fields;
 }
 
 }  // namespace
@@ -172,7 +184,7 @@ PointCloud::PointCloud(const PointCloud& other,
 }
 
 PointCloud::PointCloud(PointCloud&& other)
-    : PointCloud(0, other.fields(), true) {
+    : PointCloud(0, other.storage_->fields(), true) {
   // This has zero size. Directly swap storages.
   storage_.swap(other.storage_);
 }
@@ -183,8 +195,6 @@ PointCloud& PointCloud::operator=(const PointCloud& other) {
 }
 
 PointCloud& PointCloud::operator=(PointCloud&& other) {
-  // We may only take rvalue references if the fields match exactly.
-  RequireExactFields(other.fields());
   // Swap storages.
   storage_.swap(other.storage_);
   // Empty out the other cloud, but let it remain being a valid point cloud
@@ -207,11 +217,34 @@ int PointCloud::size() const {
 void PointCloud::resize(int new_size, bool skip_initialization) {
   DRAKE_DEMAND(new_size >= 0);
   const int old_size = size();
+  if (old_size == new_size)
+    return;
   storage_->resize(new_size);
   DRAKE_DEMAND(storage_->size() == new_size);
   if (new_size > old_size && !skip_initialization) {
     const int size_diff = new_size - old_size;
     SetDefault(old_size, size_diff);
+  }
+}
+
+void PointCloud::SetFields(pc_flags::Fields new_fields, bool skip_initialize) {
+  const pc_flags::Fields old_fields = storage_->fields();
+  if (old_fields == new_fields)
+    return;
+  storage_->UpdateFields(new_fields);
+
+  if (!skip_initialize) {
+    // Default-initialize containers for newly added fields.
+    const pc_flags::Fields added_fields =
+        FindAddedFields(old_fields, new_fields);
+    if (added_fields.contains(pc_flags::kXYZs))
+      mutable_xyzs().setConstant(kDefaultValue);
+    if (added_fields.contains(pc_flags::kNormals))
+      mutable_normals().setConstant(kDefaultValue);
+    if (added_fields.contains(pc_flags::kRGBs))
+      mutable_rgbs().setConstant(kDefaultColor);
+    if (added_fields.has_descriptor())
+      mutable_descriptors().setConstant(kDefaultValue);
   }
 }
 
@@ -236,6 +269,7 @@ void PointCloud::SetDefault(int start, int num) {
 void PointCloud::SetFrom(const PointCloud& other,
                          pc_flags::Fields fields_in,
                          bool allow_resize) {
+  // Update the size of this point cloud if necessary.
   int old_size = size();
   int new_size = other.size();
   if (allow_resize) {
@@ -244,18 +278,28 @@ void PointCloud::SetFrom(const PointCloud& other,
     throw std::runtime_error(
         fmt::format("SetFrom: {} != {}", new_size, old_size));
   }
-  pc_flags::Fields fields_resolved =
-      ResolvePairFields(*this, other, fields_in);
-  if (fields_resolved.contains(pc_flags::kXYZs)) {
+
+  // Update or check the fields of the point cloud(s) if necessary.
+  pc_flags::Fields fields_to_copy = fields_in;
+  if (fields_in == pc_flags::kInherit) {
+    fields_to_copy = other.storage_->fields();
+    SetFields(other.storage_->fields(), true);
+  } else {
+    this->RequireFields(fields_to_copy);
+    other.RequireFields(fields_to_copy);
+  }
+
+  // Populate data from `other` to this point cloud.
+  if (fields_to_copy.contains(pc_flags::kXYZs)) {
     mutable_xyzs() = other.xyzs();
   }
-  if (fields_resolved.contains(pc_flags::kNormals)) {
+  if (fields_to_copy.contains(pc_flags::kNormals)) {
     mutable_normals() = other.normals();
   }
-  if (fields_resolved.contains(pc_flags::kRGBs)) {
+  if (fields_to_copy.contains(pc_flags::kRGBs)) {
     mutable_rgbs() = other.rgbs();
   }
-  if (fields_resolved.has_descriptor()) {
+  if (fields_to_copy.has_descriptor()) {
     mutable_descriptors() = other.descriptors();
   }
 }

--- a/perception/point_cloud.h
+++ b/perception/point_cloud.h
@@ -22,10 +22,6 @@ namespace perception {
 /// This is a mix between the philosophy of PCL (templated interface to
 /// provide a compile-time open set, run-time closed set) and VTK (non-templated
 /// interface to provide a very free form run-time open set).
-/// You may construct one PointCloud which will contain different sets of
-/// data, but you cannot change the contained data types after construction.
-/// However, you can mutate the data contained within the structure and resize
-/// the cloud.
 ///
 /// Definitions:
 ///
@@ -42,7 +38,7 @@ namespace perception {
 ///
 /// @note "contiguous" here means contiguous in memory. This was chosen to
 /// avoid ambiguity between PCL and Eigen, where in PCL "dense" implies that
-/// the point cloud corresponds to a cloud with invalid values, and in Eigen
+/// the point cloud corresponds to a cloud with only valid values, and in Eigen
 /// "dense" implies contiguous storage.
 ///
 /// @note The accessors / mutators for the point fields of this class returns
@@ -90,7 +86,7 @@ class PointCloud final {
   /// @param fields
   ///   Fields that the point cloud contains.
   /// @param skip_initialize
-  ///    Do not default-initialize new values.
+  ///   Do not default-initialize new values.
   explicit PointCloud(int new_size = 0,
                       pc_flags::Fields fields = pc_flags::kXYZs,
                       bool skip_initialize = false);
@@ -253,9 +249,9 @@ class PointCloud final {
   /// @param other
   ///    Other point cloud.
   /// @param fields_in
-  ///    Fields to copy. If this is `kInherit`, then both clouds must have the
-  ///    exact same fields. Otherwise, both clouds must support the fields
-  ///    indicated this parameter.
+  ///    Fields to copy. If this is `kInherit`, then `other`s fields will be
+  ///    copied. Otherwise, both clouds must support the fields indicated this
+  ///    parameter.
   /// @param allow_resize
   ///    Permit resizing to the other cloud's size.
   void SetFrom(
@@ -276,6 +272,16 @@ class PointCloud final {
 
   /// @name Fields
   /// @{
+
+  /// Updates the point cloud to a given set of fields. In the case of
+  /// introducing a new field, its container will be allocated with the current
+  /// size and default initialized. The data for all retained fields will remain
+  /// unchanged.
+  /// @param new_fields
+  ///    New fields to set to.
+  /// @param skip_initialize
+  ///    Do not default-initialize new values.
+  void SetFields(pc_flags::Fields new_fields, bool skip_initialize = false);
 
   /// Returns if a point cloud has a given set of fields.
   bool HasFields(pc_flags::Fields fields_in) const;

--- a/perception/test/point_cloud_test.cc
+++ b/perception/test/point_cloud_test.cc
@@ -11,7 +11,7 @@
 #include "drake/common/test_utilities/expect_no_throw.h"
 
 using Eigen::Matrix3Xf;
-using Eigen::Matrix4Xf;
+using Eigen::RowVectorXf;
 using Eigen::Vector3f;
 
 using ::testing::AssertionResult;
@@ -55,6 +55,24 @@ struct check_helper<uint8_t> {
   }
 };
 
+void CompareClouds(const PointCloud& cloud_1, const PointCloud& cloud_2) {
+  EXPECT_TRUE(cloud_1.fields() == cloud_2.fields());
+
+  pc_flags::Fields fields_to_compare = cloud_1.fields();
+  if (fields_to_compare.contains(pc_flags::kXYZs)) {
+    EXPECT_TRUE(CompareMatrices(cloud_1.xyzs(), cloud_2.xyzs()));
+  }
+  if (fields_to_compare.contains(pc_flags::kRGBs)) {
+    EXPECT_TRUE((cloud_1.rgbs().array() == cloud_2.rgbs().array()).all());
+  }
+  if (fields_to_compare.contains(pc_flags::kNormals)) {
+    EXPECT_TRUE(CompareMatrices(cloud_1.normals(), cloud_2.normals()));
+  }
+  if (fields_to_compare.has_descriptor()) {
+    EXPECT_TRUE(CompareMatrices(cloud_1.descriptors(), cloud_2.descriptors()));
+  }
+}
+
 GTEST_TEST(PointCloudTest, TestExpectedNumThreads) {
 #if defined(_OPENMP)
   constexpr bool has_openmp = true;
@@ -75,6 +93,49 @@ GTEST_TEST(PointCloudTest, TestExpectedNumThreads) {
 
 GTEST_TEST(PointCloudTest, Basic) {
   const int count = 5;
+
+  // Declare default values for each field to facilitate testing.
+  Matrix3Xf xyzs_expected(3, count);
+  xyzs_expected.transpose() <<
+    1, 2, 3,
+    10, 20, 30,
+    100, 200, 300,
+    4, 5, 6,
+    40, 50, 60;
+  Matrix3Xf normals_expected(3, count);
+  normals_expected.transpose() <<
+    1, 2, 3,
+    10, 20, 30,
+    100, 200, 300,
+    4, 5, 6,
+    40, 50, 60;
+  Matrix3X<uint8_t> rgbs_expected(3, count);
+  rgbs_expected.transpose() <<
+    1, 2, 3,
+    10, 20, 30,
+    100, 200, 255,
+    4, 5, 6,
+    40, 50, 60;
+  RowVectorXf descriptors_expected(count);
+  descriptors_expected << 1, 2, 3, 4, 5;
+
+  // Create a point cloud with default values.
+  auto CreatePointCloud = [&](pc_flags::Fields fields) {
+    PointCloud cloud(count, fields);
+    if (fields.contains(pc_flags::kXYZs)) {
+      cloud.mutable_xyzs() = xyzs_expected;
+    }
+    if (fields.contains(pc_flags::kNormals)) {
+      cloud.mutable_rgbs() = rgbs_expected;
+    }
+    if (fields.contains(pc_flags::kRGBs)) {
+      cloud.mutable_normals() = normals_expected;
+    }
+    if (fields.has_descriptor()) {
+      cloud.mutable_descriptors() = descriptors_expected;
+    }
+    return cloud;
+  };
 
   auto CheckFields = [count](auto values_expected, pc_flags::Fields fields,
                              auto get_mutable_values, auto get_values,
@@ -164,14 +225,7 @@ GTEST_TEST(PointCloudTest, Basic) {
             get_values(cloud).middleCols(small_size, large_size - small_size)));
   };
 
-  // Points.
-  Matrix3Xf xyzs_expected(3, count);
-  xyzs_expected.transpose() <<
-    1, 2, 3,
-    10, 20, 30,
-    100, 200, 300,
-    4, 5, 6,
-    40, 50, 60;
+  // XYZs.
   CheckFields(xyzs_expected, pc_flags::kXYZs,
               [](PointCloud& cloud) { return cloud.mutable_xyzs(); },
               [](PointCloud& cloud) { return cloud.xyzs(); },
@@ -179,13 +233,6 @@ GTEST_TEST(PointCloudTest, Basic) {
               [](PointCloud& cloud, int i) { return cloud.xyz(i); });
 
   // Normals.
-  Matrix3Xf normals_expected(3, count);
-  normals_expected.transpose() <<
-    1, 2, 3,
-    10, 20, 30,
-    100, 200, 300,
-    4, 5, 6,
-    40, 50, 60;
   CheckFields(normals_expected, pc_flags::kNormals,
               [](PointCloud& cloud) { return cloud.mutable_normals(); },
               [](PointCloud& cloud) { return cloud.normals(); },
@@ -193,13 +240,6 @@ GTEST_TEST(PointCloudTest, Basic) {
               [](PointCloud& cloud, int i) { return cloud.normal(i); });
 
   // RGBs.
-  Matrix3X<uint8_t> rgbs_expected(3, count);
-  rgbs_expected.transpose() <<
-    1, 2, 3,
-    10, 20, 30,
-    100, 200, 255,
-    4, 5, 6,
-    40, 50, 60;
   CheckFields(rgbs_expected, pc_flags::kRGBs,
             [](PointCloud& cloud) { return cloud.mutable_rgbs(); },
             [](PointCloud& cloud) { return cloud.rgbs(); },
@@ -207,9 +247,6 @@ GTEST_TEST(PointCloudTest, Basic) {
             [](PointCloud& cloud, int i) { return cloud.rgb(i); });
 
   // Descriptors (Curvature).
-  Eigen::RowVectorXf descriptors_expected(count);
-  descriptors_expected <<
-    1, 2, 3, 4, 5;
   CheckFields(descriptors_expected, pc_flags::kDescriptorCurvature,
               [](PointCloud& cloud) { return cloud.mutable_descriptors(); },
               [](PointCloud& cloud) { return cloud.descriptors(); },
@@ -218,17 +255,68 @@ GTEST_TEST(PointCloudTest, Basic) {
               },
               [](PointCloud& cloud, int i) { return cloud.descriptor(i); });
 
-  {  // Crop
-    PointCloud cloud(count, pc_flags::kXYZs | pc_flags::kNormals |
-                                pc_flags::kRGBs |
-                                pc_flags::kDescriptorCurvature);
-    cloud.mutable_xyzs() = xyzs_expected;
-    cloud.mutable_rgbs() = rgbs_expected;
-    cloud.mutable_normals() = normals_expected;
-    cloud.mutable_descriptors() = descriptors_expected;
+  // Test operator= between two clouds with different fields.
+  {
+    pc_flags::Fields xyz_rgb_normals =
+        (pc_flags::kXYZs | pc_flags::kNormals | pc_flags::kRGBs);
+    pc_flags::Fields all_fields =
+        (xyz_rgb_normals | pc_flags::kDescriptorCurvature);
 
-    PointCloud cropped =
-        cloud.Crop(Eigen::Vector3f{4, 5, 6}, Eigen::Vector3f{10, 20, 30});
+    const std::vector<std::pair<pc_flags::Fields, pc_flags::Fields>>
+        fields_pairs{{pc_flags::kXYZs, xyz_rgb_normals},
+                     {xyz_rgb_normals, pc_flags::kXYZs},
+                     {pc_flags::kXYZs, all_fields},
+                     {all_fields, pc_flags::kXYZs}};
+
+    for (const auto& [fields_to, fields_from] : fields_pairs) {
+      PointCloud cloud_to = CreatePointCloud(fields_to);
+      PointCloud cloud_from = CreatePointCloud(fields_from);
+
+      cloud_to = cloud_from;
+      CompareClouds(cloud_to, cloud_from);
+
+      PointCloud cloud_move_to = CreatePointCloud(fields_to);
+      cloud_move_to = std::move(cloud_from);
+      CompareClouds(cloud_to, cloud_move_to);
+    }
+  }
+
+  // Test `SetFields()` and its `skip_initialize` flag.
+  {
+    PointCloud cloud = CreatePointCloud(pc_flags::kXYZs);
+    EXPECT_TRUE(cloud.HasFields(pc_flags::kXYZs));
+    EXPECT_FALSE(cloud.HasFields(pc_flags::kNormals));
+
+    // Expand the fields.
+    cloud.SetFields((pc_flags::kXYZs | pc_flags::kNormals | pc_flags::kRGBs |
+                     pc_flags::kDescriptorCurvature),
+                    false);
+    EXPECT_TRUE(cloud.HasFields(pc_flags::kXYZs));
+    EXPECT_TRUE(cloud.HasFields(pc_flags::kNormals));
+    // Check the retained container is unchanged.
+    EXPECT_TRUE(CompareMatrices(cloud.xyzs(), xyzs_expected));
+    // Check the new containers are default-initialized.
+    EXPECT_TRUE((cloud.rgbs().array() == PointCloud::kDefaultColor).all());
+    EXPECT_TRUE((cloud.normals().array().isNaN()).all());
+    EXPECT_TRUE((cloud.descriptors().array().isNaN()).all());
+
+    // Set some values for the descriptor container.
+    cloud.mutable_descriptors() = descriptors_expected;
+    // Shrink the fields with a different descriptor. Also, skip initialization.
+    cloud.SetFields((pc_flags::kRGBs | pc_flags::kDescriptorFPFH), true);
+    EXPECT_TRUE(cloud.HasFields(pc_flags::kRGBs));
+    EXPECT_FALSE(cloud.HasFields(pc_flags::kXYZs));
+    // The rows size should be consistent with the new FPFH descriptor.
+    EXPECT_EQ(cloud.descriptors().rows(), 33);
+    EXPECT_FALSE((cloud.descriptors().array().isNaN()).all());
+  }
+
+  // Test point cloud cropping.
+  {
+    PointCloud cloud =
+        CreatePointCloud(pc_flags::kXYZs | pc_flags::kNormals |
+                         pc_flags::kRGBs | pc_flags::kDescriptorCurvature);
+    PointCloud cropped = cloud.Crop(Vector3f{4, 5, 6}, Vector3f{10, 20, 30});
     EXPECT_EQ(cropped.size(), 2);
     std::vector<int> indices{1, 3};
 
@@ -298,8 +386,7 @@ GTEST_TEST(PointCloudTest, Fields) {
     EXPECT_FALSE(simple_cloud.has_descriptors(pc_flags::kDescriptorCurvature));
 
     // Negative tests for construction.
-    EXPECT_THROW(PointCloud(1, pc_flags::kNone),
-                     std::runtime_error);
+    EXPECT_THROW(PointCloud(1, pc_flags::kNone), std::runtime_error);
     EXPECT_THROW(PointCloud(1, pc_flags::kDescriptorNone),
                  std::runtime_error);
   }
@@ -350,7 +437,7 @@ GTEST_TEST(PointCloud, Concatenate) {
     EXPECT_EQ(merged.size(), 6);
 
     if (f.contains(pc_flags::kXYZs)) {
-      Eigen::Matrix3Xf xyzs_expected(3, 6);
+      Matrix3Xf xyzs_expected(3, 6);
       xyzs_expected << clouds[0].xyzs(), clouds[1].xyzs(), clouds[2].xyzs();
       EXPECT_TRUE(CompareMatrices(merged.xyzs(), xyzs_expected));
     }
@@ -362,14 +449,14 @@ GTEST_TEST(PointCloud, Concatenate) {
     }
 
     if (f.contains(pc_flags::kNormals)) {
-      Eigen::Matrix3Xf normals_expected(3, 6);
+      Matrix3Xf normals_expected(3, 6);
       normals_expected << clouds[0].normals(), clouds[1].normals(),
           clouds[2].normals();
       EXPECT_TRUE(CompareMatrices(merged.normals(), normals_expected));
     }
 
     if (f.has_descriptor()) {
-      Eigen::RowVectorXf descriptors_expected(6);
+      RowVectorXf descriptors_expected(6);
       descriptors_expected << clouds[0].descriptors(), clouds[1].descriptors(),
           clouds[2].descriptors();
       EXPECT_TRUE(CompareMatrices(merged.descriptors(), descriptors_expected));
@@ -399,7 +486,7 @@ GTEST_TEST(PointCloudTest, FlipNormals) {
   // of positive and negative z values.  The z values are taken to be larger
   // than the x,y values so that the normals are vertical enough that the z
   // component determines if they should flip.
-  Eigen::Matrix3Xf original_normals(3, num_points);
+  Matrix3Xf original_normals(3, num_points);
   // clang-format off
   original_normals.transpose() <<
     0.12, 0.32,  1.0,
@@ -424,7 +511,7 @@ GTEST_TEST(PointCloudTest, FlipNormals) {
 
   // Orient toward positive z.
   cloud.mutable_normals() = original_normals;
-  cloud.FlipNormalsTowardPoint(Eigen::Vector3f{0, 0, 1});
+  cloud.FlipNormalsTowardPoint(Vector3f{0, 0, 1});
 
   CheckNormal(0, false);
   CheckNormal(1, false);
@@ -436,7 +523,7 @@ GTEST_TEST(PointCloudTest, FlipNormals) {
 
   // Orient toward negative z.
   cloud.mutable_normals() = original_normals;
-  cloud.FlipNormalsTowardPoint(Eigen::Vector3f{0, 0, -1});
+  cloud.FlipNormalsTowardPoint(Vector3f{0, 0, -1});
 
   CheckNormal(0, true);
   CheckNormal(1, true);
@@ -543,9 +630,8 @@ GTEST_TEST(PointCloudTest, VoxelizedDownSample) {
 
 // Checks that normal has unit magnitude and that normal == expected up to a
 // sign flip.
-void CheckNormal(const Eigen::Ref<const Eigen::Vector3f>& normal,
-                 const Eigen::Ref<const Eigen::Vector3f>& expected,
-                 double tolerance) {
+void CheckNormal(const Eigen::Ref<const Vector3f>& normal,
+                 const Eigen::Ref<const Vector3f>& expected, double tolerance) {
   EXPECT_NEAR(normal.norm(), 1.0, tolerance)
       << fmt::format("Normal {} does not have unit length.", fmt_eigen(normal));
   EXPECT_NEAR(std::abs(normal.dot(expected)), 1.0, tolerance)


### PR DESCRIPTION
As discussed in https://github.com/RobotLocomotion/drake/pull/18774#issuecomment-1437232982, this PR modified the code and relevant documentation to allow morphing fields after the construction of a PointCloud.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18987)
<!-- Reviewable:end -->
