### PR TITLE
Update documentation for MultibodyTree macros

### DIFF
--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -55,10 +55,14 @@ enum class JacobianWrtVariable {
 /// @cond
 // Helper macro to throw an exception within methods that should not be called
 // post-finalize.
+// This macro is constant-time and, per Drake's style guide, we allow to call
+// it from within snake_case functions.
 #define DRAKE_MBT_THROW_IF_FINALIZED() ThrowIfFinalized(__func__)
 
 // Helper macro to throw an exception within methods that should not be called
 // pre-finalize.
+// This macro is constant-time and, per Drake's style guide, we allow to call
+// it from within snake_case functions.
 #define DRAKE_MBT_THROW_IF_NOT_FINALIZED() ThrowIfNotFinalized(__func__)
 /// @endcond
 


### PR DESCRIPTION
This PR updates the documentation for DRAKE_MBT_THROW_IF_FINALIZED and DRAKE_MBT_THROW_IF_NOT_FINALIZED to clearly state they are constant-time.
Per [review discussion](https://reviewable.io/reviews/RobotLocomotion/drake/18959#-NQS2K06B7e2iJXCUlli) it is ok to call these method from within snake_case methods. 
This PR simply documents this fact for future developers going through this code.

Refer to this [review discussion](https://reviewable.io/reviews/RobotLocomotion/drake/18959#-NQS2K06B7e2iJXCUlli) for further details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/18997)
<!-- Reviewable:end -->
