### PR TITLE
[multibody] Add Block3x3SparseMatrix

### DIFF
--- a/multibody/contact_solvers/BUILD.bazel
+++ b/multibody/contact_solvers/BUILD.bazel
@@ -14,6 +14,7 @@ drake_cc_package_library(
     name = "contact_solvers",
     visibility = ["//visibility:public"],
     deps = [
+        ":block_3x3_sparse_matrix",
         ":block_sparse_matrix",
         ":contact_solver",
         ":contact_solver_results",
@@ -25,6 +26,16 @@ drake_cc_package_library(
         ":sparse_linear_operator",
         ":supernodal_solver",
         ":system_dynamics_data",
+    ],
+)
+
+drake_cc_library(
+    name = "block_3x3_sparse_matrix",
+    srcs = ["block_3x3_sparse_matrix.cc"],
+    hdrs = ["block_3x3_sparse_matrix.h"],
+    deps = [
+        "//common:default_scalars",
+        "//common:essential",
     ],
 )
 
@@ -160,6 +171,14 @@ drake_cc_library(
     deps = [
         ":linear_operator",
         "//common:default_scalars",
+    ],
+)
+
+drake_cc_googletest(
+    name = "block_3x3_sparse_matrix_test",
+    deps = [
+        ":block_3x3_sparse_matrix",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/multibody/contact_solvers/block_3x3_sparse_matrix.cc
+++ b/multibody/contact_solvers/block_3x3_sparse_matrix.cc
@@ -1,0 +1,228 @@
+#include "drake/multibody/contact_solvers/block_3x3_sparse_matrix.h"
+
+#include <algorithm>
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+namespace {
+
+template <typename T>
+using Triplet = typename Block3x3SparseMatrix<T>::Triplet;
+/* Given a vector of Triplets with the same block row index that is sorted
+ in increasing block column index, merge entries that have the same block
+ column index in place by summing them up. After this function, the triplets in
+ `data` is still sorted in increasing block column index but does not contain
+ duplicate block column indices, and the size of the vector is equal to the
+ number of unique block column indices. */
+template <typename T>
+void MergeDuplicates(std::vector<Triplet<T>>* data) {
+  DRAKE_DEMAND(data != nullptr);
+  if (data->empty()) return;
+  const int block_row = std::get<0>((*data)[0]);
+  /* Traverse the vector with slow/fast pointer where the fast pointer is the
+   source and the slow pointer is the destination. */
+  int slow = 0;
+  int fast = 0;
+  int slow_col = std::get<1>((*data)[slow]);
+  Matrix3<T> value = Matrix3<T>::Zero();
+  while (fast < static_cast<int>(data->size())) {
+    const Triplet<T>& t = (*data)[fast];
+    const int fast_col = std::get<1>(t);
+    if (fast_col == slow_col) {
+      value += std::get<2>(t);
+    } else {
+      (*data)[slow++] = {block_row, slow_col, value};
+      slow_col = fast_col;
+      value = std::get<2>(t);
+    }
+    ++fast;
+  }
+  /* Don't forget to write down the last batch of triplets. */
+  (*data)[slow++] = {block_row, slow_col, value};
+  data->resize(slow);
+}
+
+}  // namespace
+
+template <class T>
+void Block3x3SparseMatrix<T>::SetFromTriplets(
+    const std::vector<Triplet>& triplets) {
+  /* Clear all existing data. */
+  for (std::vector<Triplet>& row : row_data_) {
+    row.clear();
+  }
+  for (std::vector<Index>& indices : col_to_indices_) {
+    indices.clear();
+  }
+
+  /* Populate `row_data_` and `col_to_indices_`. */
+  for (const Triplet& t : triplets) {
+    const int block_row = std::get<0>(t);
+    const int block_col = std::get<1>(t);
+    DRAKE_DEMAND(0 <= block_row && block_row < block_rows_);
+    DRAKE_DEMAND(0 <= block_col && block_col < block_cols_);
+    row_data_[block_row].push_back(t);
+  }
+
+  /* Maintain the ordering invariance in `row_data_` and compute the total
+   number of non-zero blocks. */
+  num_blocks_ = 0;
+  for (int r = 0; r < block_rows_; ++r) {
+    std::sort(row_data_[r].begin(), row_data_[r].end(),
+              [](const Triplet& t1, const Triplet& t2) {
+                const int col_1 = std::get<1>(t1);
+                const int col_2 = std::get<1>(t2);
+                return col_1 < col_2;
+              });
+    MergeDuplicates<T>(&(row_data_[r]));
+    num_blocks_ += row_data_[r].size();
+  }
+
+  for (int block_row = 0; block_row < static_cast<int>(row_data_.size());
+       ++block_row) {
+    for (int flat_index = 0;
+         flat_index < static_cast<int>(row_data_[block_row].size());
+         ++flat_index) {
+      const int block_col = std::get<1>(row_data_[block_row][flat_index]);
+      col_to_indices_[block_col].push_back({block_row, flat_index});
+    }
+  }
+}
+
+template <class T>
+void Block3x3SparseMatrix<T>::MultiplyAndAddTo(
+    const Eigen::Ref<const MatrixX<T>>& A, EigenPtr<MatrixX<T>> y) const {
+  DRAKE_DEMAND(y != nullptr);
+  DRAKE_DEMAND(A.rows() == cols());
+  DRAKE_DEMAND(y->rows() == rows());
+  for (const std::vector<Triplet>& row : row_data_) {
+    for (const Triplet& triplet : row) {
+      const int block_row = std::get<0>(triplet);
+      const int block_col = std::get<1>(triplet);
+      const Matrix3<T>& m = std::get<2>(triplet);
+      y->template middleRows<3>(3 * block_row) +=
+          m * A.template middleRows<3>(3 * block_col);
+    }
+  }
+}
+
+template <class T>
+void Block3x3SparseMatrix<T>::LeftMultiplyAndAddTo(
+    const Eigen::Ref<const MatrixX<T>>& A, EigenPtr<MatrixX<T>> y) const {
+  DRAKE_DEMAND(y != nullptr);
+  DRAKE_DEMAND(A.cols() == rows());
+  DRAKE_DEMAND(y->rows() == A.rows());
+  for (const std::vector<Triplet>& row : row_data_) {
+    for (const Triplet& triplet : row) {
+      const int block_row = std::get<0>(triplet);
+      const int block_col = std::get<1>(triplet);
+      const Matrix3<T>& m = std::get<2>(triplet);
+      y->template middleCols<3>(3 * block_col) +=
+          A.template middleCols<3>(3 * block_row) * m;
+    }
+  }
+}
+
+template <class T>
+void Block3x3SparseMatrix<T>::TransposeAndMultiplyAndAddTo(
+    const Eigen::Ref<const MatrixX<T>>& A, EigenPtr<MatrixX<T>> y) const {
+  DRAKE_DEMAND(y != nullptr);
+  DRAKE_DEMAND(rows() == A.rows());
+  DRAKE_DEMAND(y->rows() == cols());
+  for (const std::vector<Triplet>& row : row_data_) {
+    for (const Triplet& triplet : row) {
+      const int block_row = std::get<0>(triplet);
+      const int block_col = std::get<1>(triplet);
+      const Matrix3<T>& m = std::get<2>(triplet);
+      y->template middleRows<3>(3 * block_col) +=
+          m.transpose() * A.template middleRows<3>(3 * block_row);
+    }
+  }
+}
+
+template <class T>
+void Block3x3SparseMatrix<T>::TransposeAndMultiplyAndAddTo(
+    const Block3x3SparseMatrix<T>& A, EigenPtr<MatrixX<T>> y) const {
+  DRAKE_DEMAND(y != nullptr);
+  DRAKE_DEMAND(rows() == A.rows());
+  DRAKE_DEMAND(y->rows() == this->cols());
+  DRAKE_DEMAND(y->cols() == A.cols());
+
+  if (A.row_data_.empty() || this->row_data_.empty()) {
+    return;
+  }
+
+  /* We are performing yᵢⱼ += ∑ₖ Mₖᵢᵀ * Aₖⱼ. For each ij block in y, we need to
+   sum over block row indices, k, where Mₖᵢ and Aₖⱼ both have non-zero blocks.
+   We do this by looping over block row indices. For each block row k, we find
+   all blocks of A and M that have k as block row index. Then we loop over their
+   block column indices (i for M and j for A), perform the dense multiplication,
+   and add to the corresponding block in y. */
+  for (int k = 0; k < block_rows_; ++k) {
+    for (const Triplet& m : row_data_[k]) {
+      const int i = std::get<1>(m);  // block column index of M block
+      const Matrix3<T>& M_ki = std::get<2>(m);
+      for (const Triplet& a : A.row_data_[k]) {
+        const int j = std::get<1>(a);  // block column index of A block
+        const Matrix3<T>& A_kj = std::get<2>(a);
+        y->template block<3, 3>(3 * i, 3 * j) += M_ki.transpose() * A_kj;
+      }
+    }
+  }
+}
+
+template <class T>
+void Block3x3SparseMatrix<T>::MultiplyWithScaledTransposeAndAddTo(
+    const VectorX<T>& scale, EigenPtr<MatrixX<T>> y) const {
+  DRAKE_DEMAND(y != nullptr);
+  DRAKE_DEMAND(cols() == scale.size());
+  DRAKE_DEMAND(rows() == y->rows());
+  DRAKE_DEMAND(rows() == y->cols());
+  /* Let y be the result, then we are computing
+   yᵢⱼ += ∑ₖ Mᵢₖ * scaleₖ * Mⱼₖ. */
+  for (int k = 0; k < block_cols_; ++k) {
+    const std::vector<Index>& indices = col_to_indices_[k];
+    const auto scale_block = scale.template segment<3>(3 * k);
+    for (int a = 0; a < static_cast<int>(indices.size()); ++a) {
+      const Triplet& t1 = row_data_[indices[a].row][indices[a].flat];
+      const int i = std::get<0>(t1);
+      const Matrix3<T>& M_ik = std::get<2>(t1);
+      for (int b = a; b < static_cast<int>(indices.size()); ++b) {
+        const Triplet& t2 = row_data_[indices[b].row][indices[b].flat];
+        const int j = std::get<0>(t2);
+        const Matrix3<T>& M_kj = std::get<2>(t2);
+        const Matrix3<T> y_ij =
+            M_ik * scale_block.asDiagonal() * M_kj.transpose();
+        y->template block<3, 3>(3 * i, 3 * j) += y_ij;
+        /* Exploit symmetry. */
+        if (a != b) {
+          y->template block<3, 3>(3 * j, 3 * i) += y_ij.transpose();
+        }
+      }
+    }
+  }
+}
+
+template <class T>
+MatrixX<T> Block3x3SparseMatrix<T>::MakeDenseMatrix() const {
+  MatrixX<T> result = MatrixX<T>::Zero(rows(), cols());
+  for (const std::vector<Triplet>& row : row_data_) {
+    for (const Triplet& triplet : row) {
+      const int block_row = std::get<0>(triplet);
+      const int block_col = std::get<1>(triplet);
+      const Matrix3<T>& m = std::get<2>(triplet);
+      result.template block<3, 3>(3 * block_row, 3 * block_col) = m;
+    }
+  }
+  return result;
+}
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::contact_solvers::internal::Block3x3SparseMatrix)

--- a/multibody/contact_solvers/block_3x3_sparse_matrix.h
+++ b/multibody/contact_solvers/block_3x3_sparse_matrix.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <tuple>
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+/* A sparse matrix data structure composed of m-by-n block submatrices, where
+ each submatrix is of size 3-by-3. Only the non-zero submatrices are stored for
+ efficiency. We use `M` to denote `this` Block3x3SparseMatrix throughout this
+ class.
+ @tparam_default_scalar */
+template <class T>
+class Block3x3SparseMatrix {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Block3x3SparseMatrix);
+
+  /* A triplet is a tuple (i, j, value) defining a non-zero submatrix where i is
+   the block row index, j is the block column index, and value is a 3x3 dense
+   matrix. */
+  using Triplet = std::tuple<int, int, Matrix3<T>>;
+
+  /* Creates a Block3x3SparseMatrix with capacity for
+   `block_rows`-by-`block_cols` block submatrices. The matrix is initialized to
+   be empty, i.e. no non-zero blocks. */
+  Block3x3SparseMatrix(int block_rows, int block_cols)
+      : row_data_(block_rows),
+        block_rows_(block_rows),
+        block_cols_(block_cols),
+        col_to_indices_(block_cols) {
+    DRAKE_DEMAND(block_rows >= 0);
+    DRAKE_DEMAND(block_cols >= 0);
+  }
+
+  /* Fills `this` matrix with the given vector of triplets. The input vector of
+   triplets does not have to be sorted. Duplicated items (i.e. triplet with the
+   same block row and column index) are summed. Therefore, num_blocks() returns
+   the number of non-repeated non-zero blocks in the resulting matrix. The
+   contents in `this` matrix prior to the call to this function is destroyed.
+   @pre The block row and column indices for each triplet in the given vector is
+   within [0, block_rows) and [0, column_blocks) prescribed in the constructor
+   of this class. */
+  void SetFromTriplets(const std::vector<Triplet>& triplets);
+
+  int rows() const { return block_rows_ * 3; }
+  int cols() const { return block_cols_ * 3; }
+  int block_rows() const { return block_rows_; }
+  int block_cols() const { return block_cols_; }
+
+  /* Performs y += M * A.
+   @pre y != nullptr and the sizes of A and y are compatible with this matrix.
+  */
+  void MultiplyAndAddTo(const Eigen::Ref<const MatrixX<T>>& A,
+                        EigenPtr<MatrixX<T>> y) const;
+
+  /* Performs y += A * M.
+   @pre y != nullptr and the sizes of A and y are compatible with this matrix.
+  */
+  void LeftMultiplyAndAddTo(const Eigen::Ref<const MatrixX<T>>& A,
+                            EigenPtr<MatrixX<T>> y) const;
+
+  /* Performs y += Mᵀ * A, where A is dense.
+   @pre y != nullptr and the sizes of A and y are compatible with this matrix.
+  */
+  void TransposeAndMultiplyAndAddTo(const Eigen::Ref<const MatrixX<T>>& A,
+                                    EigenPtr<MatrixX<T>> y) const;
+
+  /* Performs y += Mᵀ * A, where A is also 3x3 block sparse.
+   @pre y != nullptr and the sizes of A and y are compatible with this matrix.
+  */
+  void TransposeAndMultiplyAndAddTo(const Block3x3SparseMatrix<T>& A,
+                                    EigenPtr<MatrixX<T>> y) const;
+
+  /* Performs y += M * scale.asDiagonal() * M.transpose().
+   @pre y != nullptr and the sizes of scale and y are compatible with this
+   matrix. */
+  void MultiplyWithScaledTransposeAndAddTo(const VectorX<T>& scale,
+                                           EigenPtr<MatrixX<T>> y) const;
+
+  /* Returns the non-zero blocks in the matrix in a row-major fashion. Within
+   each block row (result[row]), the blocks are sorted in increasing column
+   indices. The returned std::vector always has size `block_rows()`. If
+   result[row] is empty, then it means that there's no non-zero block in that
+   block row. */
+  const std::vector<std::vector<Triplet>>& get_triplets() const {
+    return row_data_;
+  }
+
+  /* Returns the number of non-zero blocks.
+   @note the result might not be equal to the number of triplets passed into
+   `SetFromTriplets` as duplicated blocks are summed. */
+  int num_blocks() const { return num_blocks_; }
+
+  /* Returns the matrix as an Eigen dense matrix. Useful for debugging. */
+  MatrixX<T> MakeDenseMatrix() const;
+
+ private:
+  /* We store the non-zero blocks in the matrix in a row-major fashion. Within
+   each row, the blocks are sorted in increasing column indices.
+   row_data_.size() is always equal to block_rows() and row_data_ never stores
+   duplicated blocks. If row_data_[i] is empty, then it means that there's no
+   non-zero block in that block row. */
+  std::vector<std::vector<Triplet>> row_data_;
+  int block_rows_{};
+  int block_cols_{};
+  int num_blocks_{};
+
+  /* Index into `row_data_`. For a given `index`,
+   row_data_[index.row][index.flat] retrieves the corresponding triplet. */
+  struct Index {
+    int row;
+    int flat;
+  };
+  /* For each block column j, col_to_indices_[j] contains all the indices
+   corresponding to non-zero entries in block column j in increasing row index.
+   That is, col_to_indices_[j][i1].row < col_to_indices_[j][i2].row if i1 < i2.
+   The same information can be computed from `row_data_`, but we store this
+   redundant, precomputed information for convenience. */
+  std::vector<std::vector<Index>> col_to_indices_;
+};
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/test/block_3x3_sparse_matrix_test.cc
+++ b/multibody/contact_solvers/test/block_3x3_sparse_matrix_test.cc
@@ -1,0 +1,151 @@
+#include "drake/multibody/contact_solvers/block_3x3_sparse_matrix.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+namespace {
+
+using Eigen::Matrix3d;
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+
+/* Returns an arbitrary non-zero matrix of size m-by-n.*/
+MatrixXd MakeArbitraryMatrix(int m, int n) {
+  MatrixXd A(m, n);
+  for (int i = 0; i < m; ++i) {
+    for (int j = 0; j < n; ++j) {
+      A(i, j) = 3 * i + 4 * j;
+    }
+  }
+  return A;
+}
+
+/* Returns a dummy 3x3 matrix with all entries in the matrix equal to the given
+ value. */
+Matrix3d MakeMatrix(double value) {
+  return value * Matrix3d::Ones();
+}
+
+/* Returns an arbitrary Block3x3SparseMatrix with size 12-by-9. */
+Block3x3SparseMatrix<double> MakeBlockSparseMatrix() {
+  Block3x3SparseMatrix<double> sparse_matrix(4, 3);
+  std::vector<Block3x3SparseMatrix<double>::Triplet> triplets;
+  triplets.emplace_back(0, 0, MakeMatrix(1.0));
+  triplets.emplace_back(0, 0, MakeMatrix(2.0));
+  triplets.emplace_back(0, 1, MakeMatrix(3.0));
+  triplets.emplace_back(0, 1, MakeMatrix(4.0));
+  triplets.emplace_back(2, 1, MakeMatrix(5.0));
+  triplets.emplace_back(3, 2, MakeMatrix(6.0));
+  sparse_matrix.SetFromTriplets(triplets);
+  EXPECT_EQ(sparse_matrix.num_blocks(), 4);
+  return sparse_matrix;
+}
+
+GTEST_TEST(Block3x3SparseMatrixTest, Size) {
+  const Block3x3SparseMatrix<double> sparse_matrix(4, 3);
+  EXPECT_EQ(sparse_matrix.rows(), 12);
+  EXPECT_EQ(sparse_matrix.cols(), 9);
+  EXPECT_EQ(sparse_matrix.block_rows(), 4);
+  EXPECT_EQ(sparse_matrix.block_cols(), 3);
+}
+
+GTEST_TEST(Block3x3SparseMatrixTest, SetFromTriplets) {
+  Block3x3SparseMatrix<double> sparse_matrix = MakeBlockSparseMatrix();
+  MatrixXd expected_matrix(12, 9);
+  expected_matrix.topLeftCorner<3, 3>() = MakeMatrix(3.0);
+  expected_matrix.block<3, 3>(0, 3) = MakeMatrix(7.0);
+  expected_matrix.block<3, 3>(6, 3) = MakeMatrix(5.0);
+  expected_matrix.bottomRightCorner<3, 3>() = MakeMatrix(6.0);
+  EXPECT_EQ(sparse_matrix.MakeDenseMatrix(), expected_matrix);
+
+  /* Verify that setting the sparse matrix with a new vector of triplets resets
+   the matrix. */
+  std::vector<Block3x3SparseMatrix<double>::Triplet> triplets;
+  triplets.emplace_back(2, 2, MakeMatrix(4.0));
+  sparse_matrix.SetFromTriplets(triplets);
+  expected_matrix.setZero();
+  expected_matrix.block<3, 3>(6, 6) = MakeMatrix(4.0);
+  EXPECT_EQ(sparse_matrix.MakeDenseMatrix(), expected_matrix);
+  EXPECT_EQ(sparse_matrix.num_blocks(), 1);
+}
+
+GTEST_TEST(Block3x3SparseMatrixTest, MultiplyAndAddTo) {
+  const MatrixXd A = MakeArbitraryMatrix(9, 7);
+  const Block3x3SparseMatrix<double> sparse_matrix = MakeBlockSparseMatrix();
+  const MatrixXd dense_matrix = sparse_matrix.MakeDenseMatrix();
+
+  /* Set the destinations to compatible-sized non-zero matrices. */
+  MatrixXd y1 = MakeArbitraryMatrix(12, 7);
+  MatrixXd y2 = y1;
+
+  sparse_matrix.MultiplyAndAddTo(A, &y1);
+  y2 += dense_matrix * A;
+  EXPECT_TRUE(CompareMatrices(y1, y2));
+}
+
+GTEST_TEST(Block3x3SparseMatrixTest, LeftMultiplyAndAddTo) {
+  const Block3x3SparseMatrix<double> sparse_matrix = MakeBlockSparseMatrix();
+  const MatrixXd dense_matrix = sparse_matrix.MakeDenseMatrix();
+
+  const MatrixXd A = MakeArbitraryMatrix(7, 12);
+
+  /* Set the destinations to compatible-sized non-zero matrices. */
+  MatrixXd y1 = MakeArbitraryMatrix(7, 9);
+  MatrixXd y2 = y1;
+
+  sparse_matrix.LeftMultiplyAndAddTo(A, &y1);
+  y2 += A * dense_matrix;
+  EXPECT_TRUE(CompareMatrices(y1, y2));
+}
+
+GTEST_TEST(Block3x3SparseMatrixTest, TransposeAndMultiplyAndAddTo) {
+  const Block3x3SparseMatrix<double> sparse_matrix = MakeBlockSparseMatrix();
+  const MatrixXd dense_matrix = sparse_matrix.MakeDenseMatrix();
+
+  const MatrixXd A = MakeArbitraryMatrix(12, 6);
+
+  /* Test the sparse-dense multiplication. */
+  /* Set the destinations to compatible-sized non-zero matrices. */
+  MatrixXd y1 = MakeArbitraryMatrix(9, 6);
+  MatrixXd y2 = y1;
+
+  sparse_matrix.TransposeAndMultiplyAndAddTo(A, &y1);
+  y2 += dense_matrix.transpose() * A;
+  EXPECT_TRUE(CompareMatrices(y1, y2));
+
+  /* Test the sparse-sparse multiplication. */
+  Block3x3SparseMatrix<double> A_sparse(4, 2);
+  std::vector<Block3x3SparseMatrix<double>::Triplet> triplets;
+  triplets.emplace_back(0, 1, MakeMatrix(4.0));
+  triplets.emplace_back(2, 1, MakeMatrix(5.0));
+  A_sparse.SetFromTriplets(triplets);
+
+  sparse_matrix.TransposeAndMultiplyAndAddTo(A_sparse, &y1);
+  y2 += dense_matrix.transpose() * A_sparse.MakeDenseMatrix();
+  EXPECT_TRUE(CompareMatrices(y1, y2));
+}
+
+GTEST_TEST(Block3x3SparseMatrixTest, MultiplyWithScaledTransposeAndAddTo) {
+  const Block3x3SparseMatrix<double> sparse_matrix = MakeBlockSparseMatrix();
+  const MatrixXd dense_matrix = sparse_matrix.MakeDenseMatrix();
+  const VectorXd scale = VectorXd::LinSpaced(9, 0.0, 1.0);
+
+  /* Set the destinations to compatible-sized non-zero matrices. */
+  MatrixXd y1 = MakeArbitraryMatrix(12, 12);
+  MatrixXd y2 = y1;
+
+  sparse_matrix.MultiplyWithScaledTransposeAndAddTo(scale, &y1);
+  y2 += dense_matrix * scale.asDiagonal() * dense_matrix.transpose();
+  EXPECT_TRUE(CompareMatrices(y1, y2));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Block3x3SparseMatrix is a highly-specialized sparse matrix data structure that stores data as 3x3 dense blocks. It provides a minimal set of APIs to support the matrix operations required for constraint Jacobians in SAP. It is particularly useful for constraints involving deformable bodies where the non-zero entries usually assume a 3x3 block structure (i.e. each constraint has 3 constraint equations and dofs involved in the constraint also come in groups of 3 as the x,y,z coordinates of the deformable mesh vertex involved in the constraint).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19000)
<!-- Reviewable:end -->
