### PR TITLE
Removes unnecessary forward declaration from ManipulationStation

### DIFF
--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -18,8 +18,6 @@ namespace drake {
 namespace examples {
 namespace manipulation_station {
 
-template<typename T> class ManipulationStation;
-
 // This system computes the generalized forces on the IIWA arm of the
 // manipulation resulting from externally applied spatial forces.
 //


### PR DESCRIPTION
Remove in the attempt to fix #18980. It does not solve it, but definitely an unnecessary change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19004)
<!-- Reviewable:end -->
