### PR TITLE
[model_visualizer] Don't crash on a failed reload

### DIFF
--- a/bindings/pydrake/visualization/_model_visualizer.py
+++ b/bindings/pydrake/visualization/_model_visualizer.py
@@ -1,5 +1,6 @@
 import copy
 from enum import Enum
+import logging
 import time
 from webbrowser import open as _webbrowser_open
 
@@ -7,9 +8,12 @@ import numpy as np
 
 from pydrake.common.deprecation import deprecated
 from pydrake.geometry import (
+    Box,
     Cylinder,
     GeometryInstance,
     MakePhongIllustrationProperties,
+    MeshcatCone,
+    Rgba,
     StartMeshcat,
 )
 from pydrake.math import RigidTransform, RotationMatrix
@@ -328,13 +332,26 @@ class ModelVisualizer:
         self._diagram = None
         self._sliders = None
         self._context = None
+        self._remove_traffic_cone()
 
         # Populate the diagram builder again with the same packages and models.
         self._builder = RobotDiagramBuilder()
         self._builder.parser().package_map().AddMap(self._original_package_map)
+        try:
+            for filename in self._model_filenames:
+                self._builder.parser().AddModels(filename)
+            logging.getLogger("drake").info(f"Reload was successful")
+        except BaseException as e:
+            # If there's a parsing error, show it; don't crash.
+            logging.getLogger("drake").error(e)
+            logging.getLogger("drake").warning(
+                f"Click '{self._reload_button_name}' to try again")
+            # Clear the display to help indicate the failure to the user.
+            self._builder = RobotDiagramBuilder()
+            self._builder.parser().package_map().AddMap(
+                self._original_package_map)
+            self._add_traffic_cone()
         self._original_package_map = None
-        for filename in self._model_filenames:
-            self._builder.parser().AddModels(filename)
 
         # Finalize the rest of the systems and widgets.
         self.Finalize()
@@ -377,7 +394,8 @@ class ModelVisualizer:
         # Wait for the user to cancel us.
         stop_button_name = "Stop Running"
         if not loop_once:
-            print(f"Click '{stop_button_name}' or press Esc to quit")
+            logging.getLogger("drake").info(
+                f"Click '{stop_button_name}' or press Esc to quit")
 
         try:
             self._meshcat.AddButton(stop_button_name, "Escape")
@@ -514,3 +532,26 @@ class ModelVisualizer:
         )
         self._builder.scene_graph().RegisterGeometry(
             self._builder.plant().get_source_id(), frame_id, geom)
+
+    def _add_traffic_cone(self):
+        """Adds a traffic cone to the scene, indicating a parsing error."""
+        base_width = 0.4
+        base_thickness = 0.01
+        base = Box(base_width, base_width, base_thickness)
+        cone_height = 0.6
+        cone_radius = 0.75 * (base_width / 2)
+        cone = MeshcatCone(cone_height, cone_radius, cone_radius)
+
+        path = "/PARSE_ERROR"
+        orange = Rgba(1.0, 0.33, 0)
+        self._meshcat.SetObject(path=f"{path}/base", shape=base, rgba=orange)
+        self._meshcat.SetObject(path=f"{path}/cone", shape=cone, rgba=orange)
+        self._meshcat.SetTransform(f"{path}/base", RigidTransform(
+            [0, 0, base_thickness * 0.5]))
+        self._meshcat.SetTransform(f"{path}/cone", RigidTransform(
+            RotationMatrix.MakeYRotation(np.pi),
+            [0, 0, base_thickness + cone_height]))
+
+    def _remove_traffic_cone(self):
+        """Removes the traffic cone from the scene."""
+        self._meshcat.Delete("/PARSE_ERROR")

--- a/bindings/pydrake/visualization/model_visualizer.py
+++ b/bindings/pydrake/visualization/model_visualizer.py
@@ -35,6 +35,7 @@ resources then you will need to set that environment variable.
 """
 
 import argparse
+import logging
 import os
 
 from pydrake.visualization._model_visualizer import \
@@ -42,6 +43,14 @@ from pydrake.visualization._model_visualizer import \
 
 
 def _main():
+    # Use a few color highlights for the user's terminal output.
+    logging.addLevelName(logging.INFO, "\033[36mINFO\033[0m")
+    logging.addLevelName(logging.WARNING, "\033[33mWARNING\033[0m")
+    logging.addLevelName(logging.ERROR, "\033[31mERROR\033[0m")
+    format = "%(levelname)s: %(message)s"
+    logging.basicConfig(level=logging.INFO, format=format)
+
+    # Prepare to parse arguments.
     args_parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)

--- a/bindings/pydrake/visualization/test/model_visualizer_test.py
+++ b/bindings/pydrake/visualization/test/model_visualizer_test.py
@@ -225,6 +225,24 @@ class TestModelVisualizer(unittest.TestCase):
             dut._diagram.plant().GetMyContextFromRoot(dut._context))
         self.assertListEqual(list(original_q), list(joint_q))
 
+    def test_traffic_cone(self):
+        """
+        Checks that the traffic cone helpers don't crash.
+        """
+        meshcat = Meshcat()
+        dut = mut.ModelVisualizer(meshcat=meshcat)
+        path = "/PARSE_ERROR"
+        # The add & removes functions must work even when called too many, too
+        # few, or an unmatched number of times. It's not practical to have the
+        # calling code keep track of how often things are called, so the code
+        # must be robust to any ordering.
+        for _ in range(2):
+            dut._add_traffic_cone()
+        self.assertTrue(dut._meshcat.HasPath(path))
+        for _ in range(3):
+            dut._remove_traffic_cone()
+        self.assertFalse(dut._meshcat.HasPath(path))
+
     def test_webbrowser(self):
         """
         Checks that the webbrowser launch command is properly invoked.


### PR DESCRIPTION
As I was editing my model files and reloading, I got frustrated when the visualizer would crash any time I made a typo.

This is my attempt at the simplest possible change to mitigate that inconvenience:
- Use logging (not print) for terminal output.  This should work better for Jupyter, too.
- Use a hint of color in the terminal output to indicate the message severity.
- When the parser crashes, log the error and then replace the scene with a traffic cone.
- Allow "Reload" to reload the original files, after the user fixes their mistake.

![image](https://user-images.githubusercontent.com/17596505/227644158-410538fb-0365-439b-b849-73574cbd738d.png)

![image](https://user-images.githubusercontent.com/17596505/227644734-94389968-612f-4fe2-8b95-3c018c92bd8b.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19014)
<!-- Reviewable:end -->
