### PR TITLE
[solvers] MathematicalProgram adds and stores QuadraticConstraint.

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -1039,6 +1039,24 @@ void BindMathematicalProgram(py::module m) {
           },
           doc.MathematicalProgram.AddBoundingBoxConstraint
               .doc_3args_double_double_constEigenMatrixBase)
+      .def("AddQuadraticConstraint",
+          static_cast<Binding<QuadraticConstraint> (MathematicalProgram::*)(
+              const Eigen::Ref<const Eigen::MatrixXd>&,
+              const Eigen::Ref<const Eigen::VectorXd>&, double, double,
+              const Eigen::Ref<const VectorXDecisionVariable>&,
+              std::optional<QuadraticConstraint::HessianType>)>(
+              &MathematicalProgram::AddQuadraticConstraint),
+          py::arg("Q"), py::arg("b"), py::arg("lb"), py::arg("ub"),
+          py::arg("vars"), py::arg("hessian_type") = std::nullopt,
+          doc.MathematicalProgram.AddQuadraticConstraint.doc_6args)
+      .def("AddQuadraticConstraint",
+          static_cast<Binding<QuadraticConstraint> (MathematicalProgram::*)(
+              const symbolic::Expression&, double, double,
+              std::optional<QuadraticConstraint::HessianType>)>(
+              &MathematicalProgram::AddQuadraticConstraint),
+          py::arg("e"), py::arg("lb"), py::arg("ub"),
+          py::arg("hessian_type") = std::nullopt,
+          doc.MathematicalProgram.AddQuadraticConstraint.doc_4args)
       .def("AddLorentzConeConstraint",
           static_cast<Binding<LorentzConeConstraint> (MathematicalProgram::*)(
               const Eigen::Ref<const VectorX<drake::symbolic::Expression>>&,
@@ -1366,6 +1384,8 @@ void BindMathematicalProgram(py::module m) {
           doc.MathematicalProgram.l2norm_costs.doc)
       .def("linear_constraints", &MathematicalProgram::linear_constraints,
           doc.MathematicalProgram.linear_constraints.doc)
+      .def("quadratic_constraints", &MathematicalProgram::quadratic_constraints,
+          doc.MathematicalProgram.quadratic_constraints.doc)
       .def("lorentz_cone_constraints",
           &MathematicalProgram::lorentz_cone_constraints,
           doc.MathematicalProgram.lorentz_cone_constraints.doc)
@@ -1876,6 +1896,7 @@ void BindEvaluatorsAndBindings(py::module m) {
   auto constraint_binding = RegisterBinding<Constraint>(&m);
   DefBindingCastConstructor<Constraint>(&constraint_binding);
   RegisterBinding<LinearConstraint>(&m);
+  RegisterBinding<QuadraticConstraint>(&m);
   RegisterBinding<LorentzConeConstraint>(&m);
   RegisterBinding<RotatedLorentzConeConstraint>(&m);
   RegisterBinding<LinearEqualityConstraint>(&m);

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -1191,6 +1191,20 @@ class TestMathematicalProgram(unittest.TestCase):
         prog.SetDecisionVariableValueInVector(x_matrix, x0_matrix, guess)
         self.assertFalse(any([np.isnan(i) for i in guess]))
 
+    def test_quadratic_constraint(self):
+        prog = mp.MathematicalProgram()
+        x = prog.NewContinuousVariables(3)
+        hessian_type = mp.QuadraticConstraint.HessianType.kPositiveSemidefinite
+        constraint1 = prog.AddQuadraticConstraint(
+            Q=np.eye(2), b=np.array([1., 2.]), lb=0., ub=1., vars=x[:2],
+            hessian_type=hessian_type)
+        self.assertEqual(len(prog.quadratic_constraints()), 1)
+
+        hessian_type = mp.QuadraticConstraint.HessianType.kIndefinite
+        constraint2 = prog.AddQuadraticConstraint(
+            x[0] * x[0] - x[2] * x[2], 1, 2, hessian_type=hessian_type)
+        self.assertEqual(len(prog.quadratic_constraints()), 2)
+
     @unittest.skipIf(
         SNOPT_NO_GUROBI,
         "SNOPT is unable to solve this problem (#10653).")

--- a/solvers/create_constraint.cc
+++ b/solvers/create_constraint.cc
@@ -493,7 +493,8 @@ Binding<LinearEqualityConstraint> DoParseLinearEqualityConstraint(
 }
 
 Binding<QuadraticConstraint> ParseQuadraticConstraint(
-    const symbolic::Expression& e, double lower_bound, double upper_bound) {
+    const symbolic::Expression& e, double lower_bound, double upper_bound,
+    std::optional<QuadraticConstraint::HessianType> hessian_type) {
   // First build an Eigen vector that contains all the bound variables.
   auto p = symbolic::ExtractVariablesFromExpression(e);
   const auto& vars_vec = p.first;
@@ -510,10 +511,10 @@ Binding<QuadraticConstraint> ParseQuadraticConstraint(
                                          &constant_term);
   // The constraint to be imposed is
   // lb - k ≤ 0.5 xᵀQx + bᵀx ≤ ub - k
-  return CreateBinding(
-      make_shared<QuadraticConstraint>(Q, b, lower_bound - constant_term,
-                                       upper_bound - constant_term),
-      vars_vec);
+  return CreateBinding(make_shared<QuadraticConstraint>(
+                           Q, b, lower_bound - constant_term,
+                           upper_bound - constant_term, hessian_type),
+                       vars_vec);
 }
 
 shared_ptr<Constraint> MakePolynomialConstraint(

--- a/solvers/create_constraint.h
+++ b/solvers/create_constraint.h
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <memory>
+#include <optional>
 #include <set>
 #include <type_traits>
 #include <unordered_map>
@@ -186,7 +187,9 @@ ParseLinearEqualityConstraint(const Eigen::MatrixBase<DerivedV>& V,
  * constraint binding.
  */
 [[nodiscard]] Binding<QuadraticConstraint> ParseQuadraticConstraint(
-    const symbolic::Expression& e, double lower_bound, double upper_bound);
+    const symbolic::Expression& e, double lower_bound, double upper_bound,
+    std::optional<QuadraticConstraint::HessianType> hessian_type =
+        std::nullopt);
 
 /*
  * Assist MathematicalProgram::AddPolynomialConstraint(...).

--- a/solvers/get_program_type.cc
+++ b/solvers/get_program_type.cc
@@ -203,7 +203,7 @@ bool IsNLP(const MathematicalProgram& prog) {
   // 2. It is not an LCP (A program with only linear complementarity
   // constraints).
   // 3. It has at least one of : generic costs, generic constraints, non-convex
-  // quadratic cost, linear complementarity constraints.
+  // quadratic cost, linear complementarity constraints, quadratic constraints.
   const bool has_generic_cost =
       prog.required_capabilities().count(ProgramAttribute::kGenericCost) > 0;
   const bool has_nonconvex_quadratic_cost =
@@ -211,6 +211,9 @@ bool IsNLP(const MathematicalProgram& prog) {
   const bool has_generic_constraint =
       prog.required_capabilities().count(ProgramAttribute::kGenericConstraint) >
       0;
+  const bool has_quadratic_constraint =
+      prog.required_capabilities().count(
+          ProgramAttribute::kQuadraticConstraint) > 0;
   const bool no_binary_variable = prog.required_capabilities().count(
                                       ProgramAttribute::kBinaryVariable) == 0;
   const bool has_linear_complementarity_constraint =
@@ -220,7 +223,8 @@ bool IsNLP(const MathematicalProgram& prog) {
       SatisfiesProgramType(GetRequirementsLCP(), prog.required_capabilities());
   return no_binary_variable && !is_LCP &&
          (has_generic_cost || has_nonconvex_quadratic_cost ||
-          has_generic_constraint || has_linear_complementarity_constraint);
+          has_generic_constraint || has_quadratic_constraint ||
+          has_linear_complementarity_constraint);
 }
 }  // namespace
 

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -1865,6 +1865,58 @@ class MathematicalProgram {
         Eigen::Matrix<double, kSize, 1>::Constant(vars.size(), ub), flat_vars);
   }
 
+  /** Adds quadratic constraint.
+   The quadratic constraint is of the form
+   lb ≤ .5 xᵀQx + bᵀx ≤ ub
+   where `x` might be a subset of the decision variables in this
+   MathematicalProgram.
+   @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
+   */
+  Binding<QuadraticConstraint> AddConstraint(
+      const Binding<QuadraticConstraint>& binding);
+
+  /** Adds quadratic constraint
+   lb ≤ .5 xᵀQx + bᵀx ≤ ub
+   @param vars x in the documentation above.
+   @param hessian_type Whether the Hessian is positive semidefinite, negative
+   semidefinite or indefinite. Drake will check the type if
+   hessian_type=std::nullopt. Specifying the hessian type will speed this
+   method up.
+   @pre hessian_type should be correct if it is not std::nullopt, as we will
+   blindly trust it in the downstream code.
+   */
+  Binding<QuadraticConstraint> AddQuadraticConstraint(
+      const Eigen::Ref<const Eigen::MatrixXd>& Q,
+      const Eigen::Ref<const Eigen::VectorXd>& b, double lb, double ub,
+      const Eigen::Ref<const VectorXDecisionVariable>& vars,
+      std::optional<QuadraticConstraint::HessianType> hessian_type =
+          std::nullopt);
+
+  /** Adds quadratic constraint
+   lb ≤ .5 xᵀQx + bᵀx ≤ ub
+   @param vars x in the documentation above.
+   @param hessian_type Whether the Hessian is positive semidefinite, negative
+   semidefinite or indefinite. Drake will check the type if
+   hessian_type=std::nullopt. Specifying the hessian type will speed this
+   method up.
+   @pre hessian_type should be correct if it is not std::nullopt, as we will
+   blindly trust it in the downstream code.
+   */
+  Binding<QuadraticConstraint> AddQuadraticConstraint(
+      const Eigen::Ref<const Eigen::MatrixXd>& Q,
+      const Eigen::Ref<const Eigen::VectorXd>& b, double lb, double ub,
+      const VariableRefList& vars,
+      std::optional<QuadraticConstraint::HessianType> hessian_type =
+          std::nullopt);
+
+  /** Overloads AddQuadraticConstraint, impose lb <= e <= ub where `e` is a
+   quadratic expression.
+   */
+  Binding<QuadraticConstraint> AddQuadraticConstraint(
+      const symbolic::Expression& e, double lb, double ub,
+      std::optional<QuadraticConstraint::HessianType> hessian_type =
+          std::nullopt);
+
   /**
    * Adds Lorentz cone constraint referencing potentially a subset
    * of the decision variables.
@@ -2849,6 +2901,12 @@ class MathematicalProgram {
     return linear_constraints_;
   }
 
+  /** Getter for quadratic constraints. */
+  const std::vector<Binding<QuadraticConstraint>>& quadratic_constraints()
+      const {
+    return quadratic_constraints_;
+  }
+
   /** Getter for Lorentz cone constraints. */
   const std::vector<Binding<LorentzConeConstraint>>& lorentz_cone_constraints()
       const {
@@ -3431,13 +3489,13 @@ class MathematicalProgram {
   std::vector<Binding<QuadraticCost>> quadratic_costs_;
   std::vector<Binding<LinearCost>> linear_costs_;
   std::vector<Binding<L2NormCost>> l2norm_costs_;
-  // TODO(naveenoid) : quadratic_constraints_
 
   // note: linear_constraints_ does not include linear_equality_constraints_
   std::vector<Binding<Constraint>> generic_constraints_;
   std::vector<Binding<LinearConstraint>> linear_constraints_;
   std::vector<Binding<LinearEqualityConstraint>> linear_equality_constraints_;
   std::vector<Binding<BoundingBoxConstraint>> bbox_constraints_;
+  std::vector<Binding<QuadraticConstraint>> quadratic_constraints_;
   std::vector<Binding<LorentzConeConstraint>> lorentz_cone_constraint_;
   std::vector<Binding<RotatedLorentzConeConstraint>>
       rotated_lorentz_cone_constraint_;

--- a/solvers/nlopt_solver.cc
+++ b/solvers/nlopt_solver.cc
@@ -430,6 +430,10 @@ void NloptSolver::DoSolve(const MathematicalProgram& prog,
     WrapConstraint(prog, c, constraint_tol, &opt, &wrapped_vector);
   }
 
+  for (const auto& c : prog.quadratic_constraints()) {
+    WrapConstraint(prog, c, constraint_tol, &opt, &wrapped_vector);
+  }
+
   for (const auto& c : prog.lorentz_cone_constraints()) {
     WrapConstraint(prog, c, constraint_tol, &opt, &wrapped_vector);
   }
@@ -490,6 +494,7 @@ void NloptSolver::DoSolve(const MathematicalProgram& prog,
         constraint_test(prog.bounding_box_constraints());
         constraint_test(prog.linear_constraints());
         constraint_test(prog.linear_equality_constraints());
+        constraint_test(prog.quadratic_constraints());
         constraint_test(prog.lorentz_cone_constraints());
         constraint_test(prog.rotated_lorentz_cone_constraints());
 

--- a/solvers/snopt_solver.cc
+++ b/solvers/snopt_solver.cc
@@ -370,10 +370,10 @@ int SingleNonlinearConstraintSize<LinearComplementarityConstraint>(
 }
 
 // Evaluate a single nonlinear constraints. For generic Constraint,
-// LorentzConeConstraint, RotatedLorentzConeConstraint, we call Eval function
-// of the constraint directly. For some other constraint, such as
-// LinearComplementaryConstraint, we will evaluate its nonlinear constraint
-// differently, than its Eval function.
+// QuadraticConstraint, LorentzConeConstraint, RotatedLorentzConeConstraint, we
+// call Eval function of the constraint directly. For some other constraint,
+// such as LinearComplementaryConstraint, we will evaluate its nonlinear
+// constraint differently, than its Eval function.
 template <typename C>
 void EvaluateSingleNonlinearConstraint(
     const C& constraint, const Eigen::Ref<const AutoDiffVecXd>& tx,
@@ -606,6 +606,9 @@ void EvaluateCostsConstraints(
   EvaluateNonlinearConstraints(
       current_problem, current_problem.generic_constraints(), F, &G_w_duplicate,
       &constraint_index, &grad_index, xvec);
+  EvaluateNonlinearConstraints(
+      current_problem, current_problem.quadratic_constraints(), F,
+      &G_w_duplicate, &constraint_index, &grad_index, xvec);
   EvaluateNonlinearConstraints(
       current_problem, current_problem.lorentz_cone_constraints(), F,
       &G_w_duplicate, &constraint_index, &grad_index, xvec);
@@ -983,6 +986,8 @@ void SetConstraintDualSolutions(
     MathematicalProgramResult* result) {
   SetConstraintDualSolution(prog.generic_constraints(), Fmul,
                             constraint_dual_start_index, result);
+  SetConstraintDualSolution(prog.quadratic_constraints(), Fmul,
+                            constraint_dual_start_index, result);
   SetConstraintDualSolution(prog.lorentz_cone_constraints(), Fmul,
                             constraint_dual_start_index, result);
   SetConstraintDualSolution(prog.rotated_lorentz_cone_constraints(), Fmul,
@@ -1052,6 +1057,9 @@ void UpdateNumConstraintsAndGradients(
   UpdateNumNonlinearConstraintsAndGradients(
       prog.generic_constraints(), num_nonlinear_constraints, max_num_gradients,
       constraint_dual_start_index);
+  UpdateNumNonlinearConstraintsAndGradients(
+      prog.quadratic_constraints(), num_nonlinear_constraints,
+      max_num_gradients, constraint_dual_start_index);
   UpdateNumNonlinearConstraintsAndGradients(
       prog.lorentz_cone_constraints(), num_nonlinear_constraints,
       max_num_gradients, constraint_dual_start_index);
@@ -1212,6 +1220,9 @@ void SolveWithGivenOptions(
   size_t constraint_index = 1;
   UpdateConstraintBoundsAndGradients(
       prog, prog.generic_constraints(), &Flow, &Fupp, &iGfun_w_duplicate,
+      &jGvar_w_duplicate, &constraint_index, &grad_index);
+  UpdateConstraintBoundsAndGradients(
+      prog, prog.quadratic_constraints(), &Flow, &Fupp, &iGfun_w_duplicate,
       &jGvar_w_duplicate, &constraint_index, &grad_index);
   UpdateConstraintBoundsAndGradients(
       prog, prog.lorentz_cone_constraints(), &Flow, &Fupp, &iGfun_w_duplicate,

--- a/solvers/test/ipopt_solver_test.cc
+++ b/solvers/test/ipopt_solver_test.cc
@@ -356,6 +356,13 @@ GTEST_TEST(TestLP, PoorScaling) {
   TestLPPoorScaling2(solver, true, 1E-4);
 }
 
+TEST_F(QuadraticEqualityConstrainedProgram1, test) {
+  IpoptSolver solver;
+  if (solver.available()) {
+    CheckSolution(solver, Eigen::Vector2d(0.5, 0.8), std::nullopt, 1E-6);
+  }
+}
+
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -2758,6 +2758,51 @@ GTEST_TEST(TestMathematicalProgram, AddL2NormCost) {
   EXPECT_EQ(new_prog->l2norm_costs().size(), 1u);
 }
 
+GTEST_TEST(TestMathematicalProgram, AddQuadraticConstraint) {
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<3>();
+  auto constraint1 = prog.AddConstraint(Binding<QuadraticConstraint>(
+      std::make_shared<QuadraticConstraint>(Eigen::Matrix2d::Identity(),
+                                            Eigen::Vector2d::Ones(), 0, 1),
+      x.head<2>()));
+  EXPECT_GT(prog.required_capabilities().count(
+                ProgramAttribute::kQuadraticConstraint),
+            0);
+  ASSERT_EQ(prog.quadratic_constraints().size(), 1);
+  EXPECT_EQ(prog.quadratic_constraints()[0].evaluator().get(),
+            constraint1.evaluator().get());
+  EXPECT_EQ(prog.quadratic_constraints()[0].variables(), x.head<2>());
+
+  auto constraint2 = prog.AddQuadraticConstraint(
+      -Eigen::Matrix2d::Identity(), Eigen::Vector2d::Ones(), 0, 1, x.tail<2>(),
+      QuadraticConstraint::HessianType::kNegativeSemidefinite);
+  EXPECT_GT(prog.required_capabilities().count(
+                ProgramAttribute::kQuadraticConstraint),
+            0);
+  EXPECT_EQ(prog.quadratic_constraints().size(), 2);
+
+  auto constraint3 =
+      prog.AddQuadraticConstraint(x(0) * x(0) - x(1) * x(1), 0, 1);
+  EXPECT_GT(prog.required_capabilities().count(
+                ProgramAttribute::kQuadraticConstraint),
+            0);
+  EXPECT_EQ(prog.quadratic_constraints().size(), 3);
+  EXPECT_EQ(constraint3.evaluator()->hessian_type(),
+            QuadraticConstraint::HessianType::kIndefinite);
+
+  prog.RemoveConstraint(constraint2);
+  EXPECT_GT(prog.required_capabilities().count(
+                ProgramAttribute::kQuadraticConstraint),
+            0);
+  EXPECT_EQ(prog.quadratic_constraints().size(), 2);
+  prog.RemoveConstraint(constraint1);
+  prog.RemoveConstraint(constraint3);
+  EXPECT_TRUE(prog.quadratic_constraints().empty());
+  EXPECT_EQ(prog.required_capabilities().count(
+                ProgramAttribute::kQuadraticConstraint),
+            0);
+}
+
 GTEST_TEST(TestMathematicalProgram, AddL2NormCostUsingConicConstraint) {
   MathematicalProgram prog{};
   auto x = prog.NewContinuousVariables<2>();

--- a/solvers/test/nlopt_solver_test.cc
+++ b/solvers/test/nlopt_solver_test.cc
@@ -56,6 +56,14 @@ GTEST_TEST(NloptSolverTest, SetAlgorithm) {
       solver.Solve(prog, Eigen::VectorXd::Ones(2), solver_options);
   ASSERT_TRUE(result.is_success());
 }
+
+TEST_F(QuadraticEqualityConstrainedProgram1, Test) {
+  NloptSolver solver;
+  if (solver.is_available()) {
+    CheckSolution(solver, Eigen::Vector2d(0.5, 0.8), std::nullopt, 1E-4,
+                  false /* check dual */);
+  }
+}
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/optimization_examples.h
+++ b/solvers/test/optimization_examples.h
@@ -974,6 +974,23 @@ class DuplicatedVariableNonlinearProgram1 : public ::testing::Test {
   std::unique_ptr<MathematicalProgram> prog_;
   Vector2<symbolic::Variable> x_;
 };
+
+// Test a nonlinear program with quadratic constraints.
+// max x + 2*y
+// s.t x² + y² = 1
+class QuadraticEqualityConstrainedProgram1 : public ::testing::Test {
+ public:
+  QuadraticEqualityConstrainedProgram1();
+
+  void CheckSolution(
+      const SolverInterface& solver, const Eigen::Vector2d& x_init,
+      const std::optional<SolverOptions>& solver_options = std::nullopt,
+      double tol = 1E-7, bool check_dual = true) const;
+
+ protected:
+  std::unique_ptr<MathematicalProgram> prog_;
+  Vector2<symbolic::Variable> x_;
+};
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/snopt_solver_test.cc
+++ b/solvers/test/snopt_solver_test.cc
@@ -16,6 +16,7 @@
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/test/linear_program_examples.h"
 #include "drake/solvers/test/mathematical_program_test_util.h"
+#include "drake/solvers/test/optimization_examples.h"
 #include "drake/solvers/test/quadratic_program_examples.h"
 #include "drake/solvers/test/second_order_cone_program_examples.h"
 
@@ -647,6 +648,13 @@ GTEST_TEST(SnoptTest, TestCostExceptionHandling) {
     DRAKE_EXPECT_THROWS_MESSAGE(
         solver.Solve(prog),
         "Exception.*SNOPT.*ThrowCost.*");
+  }
+}
+
+TEST_F(QuadraticEqualityConstrainedProgram1, test) {
+  SnoptSolver solver;
+  if (solver.available()) {
+    CheckSolution(solver, Eigen::Vector2d(0.5, 0.8), std::nullopt, 1E-6);
   }
 }
 


### PR DESCRIPTION
Currently except for IPOPT/NLOP/SNOPT (which support generic nonlinear constraints), none of the other solvers will support quadratic constraints.

In the future PRs, I will modify each solver wrapper to support convex quadratic constraint.

Towards #6341

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19016)
<!-- Reviewable:end -->
