### PR TITLE
[parsing] Install package_downloader

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -87,6 +87,7 @@ install(
         "//geometry:install",
         "//lcmtypes:install",
         "//manipulation/models:install_data",
+        "//multibody/parsing:install",
         "//setup:install",
         "//tools/install/libdrake:install",
         "//tools/workspace:install_external_packages",

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -10,6 +10,7 @@ load(
     "drake_py_library",
     "drake_py_unittest",
 )
+load("@drake//tools/install:install.bzl", "install_files")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load("@drake//tools/workspace:forward_files.bzl", "forward_files")
 load(
@@ -58,6 +59,7 @@ drake_cc_library(
     srcs = ["package_map.cc"],
     hdrs = ["package_map.h"],
     data = [
+        ":package_downloader.py",
         "//:package.xml",
         "@models_internal//:package.xml",
     ],
@@ -665,6 +667,13 @@ drake_cc_googletest(
         ":detail_misc",
         ":diagnostic_policy_test_base",
     ],
+)
+
+install_files(
+    name = "install",
+    dest = "share/drake/multibody/parsing",
+    files = ["package_downloader.py"],
+    visibility = ["//visibility:public"],
 )
 
 add_lint_tests()

--- a/tools/install/bazel/BUILD.bazel
+++ b/tools/install/bazel/BUILD.bazel
@@ -26,6 +26,7 @@ _BUILD_FILES_DATA = [
     ":drake__examples.BUILD.bazel",
     ":drake__geometry.BUILD.bazel",
     ":drake__manipulation.BUILD.bazel",
+    ":drake__multibody.BUILD.bazel",
 ]
 
 # Create repo.bzl by combining repo_template.bzl and its data dependencies.

--- a/tools/install/bazel/drake.BUILD.bazel
+++ b/tools/install/bazel/drake.BUILD.bazel
@@ -34,6 +34,7 @@ _EXPECTED_DRAKE_RUNFILES_PACKAGES = [
     "examples",
     "geometry",
     "manipulation",
+    "multibody",
 ]
 
 _COVERED_DRAKE_RUNFILES = _DRAKE_ROOT_PACKAGE_RUNFILES + [

--- a/tools/install/bazel/drake__multibody.BUILD.bazel
+++ b/tools/install/bazel/drake__multibody.BUILD.bazel
@@ -1,0 +1,20 @@
+# -*- bazel -*-
+
+# This is the @drake//multibody package.
+
+load("//:.manifest.bzl", "MANIFEST")
+
+package(default_visibility = ["//:__subpackages__"])
+
+_subdir = "multibody/"
+
+_runfiles = [
+    x[len(_subdir):]
+    for x in MANIFEST["runfiles"]["drake"]
+    if x.startswith(_subdir)
+]
+
+filegroup(
+    name = ".installed_runfiles",
+    data = _runfiles,
+)


### PR DESCRIPTION
Towards https://github.com/RobotLocomotion/drake/pull/18955 and https://github.com/RobotLocomotion/drake/issues/15774 and https://github.com/RobotLocomotion/drake/issues/9498.

I tested this manually by running the install, and confirming that the script made it into the install destination.

(It's a little bit unusual to commit this change on its own without actually calling the downloader anywhere yet, but the #18955 is so huge that I'd rather try to prune off as much as I can there.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19017)
<!-- Reviewable:end -->
