### PR TITLE
[parsing] PackageMap better encapsulates PackageData

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -68,7 +68,8 @@ drake_cc_library(
         "//common:essential",
     ],
     deps = [
-        "//common",
+        "//common:find_resource",
+        "//common:find_runfiles",
         "@tinyxml2_internal//:tinyxml2",
     ],
 )

--- a/multibody/parsing/package_map.h
+++ b/multibody/parsing/package_map.h
@@ -154,14 +154,8 @@ class PackageMap final {
   void CrawlForPackages(const std::string& path, bool stop_at_package = false,
                         const std::vector<std::string_view>& stop_markers = {});
 
-  /* This method is the same as Add() except if package_name is already present
-  with a different path, then this method prints a warning and returns false
-  without adding the new path. Returns true otherwise. */
-  bool AddPackageIfNew(const std::string& package_name,
-                       const std::string& path);
-
   /* Our member data is forward declared to hide implementation details. */
-  struct Impl;
+  class Impl;
   std::unique_ptr<Impl> impl_;
 };
 

--- a/multibody/parsing/test/package_map_test.cc
+++ b/multibody/parsing/test/package_map_test.cc
@@ -144,7 +144,7 @@ GTEST_TEST(PackageMapTest, TestManualPopulation) {
   // Adding a duplicate package with a different path throws.
   DRAKE_EXPECT_THROWS_MESSAGE(
       package_map.Add("package_foo", "package_baz"),
-      ".*conflicts with.*");
+      ".*paths are not eq.*");
   // Adding a package with a nonexistent path throws.
   DRAKE_EXPECT_THROWS_MESSAGE(
       package_map.Add("garbage", "garbage"),
@@ -163,6 +163,16 @@ GTEST_TEST(PackageMapTest, TestManualPopulation) {
   VerifyMatch(package_map, std::map<string, string>());
 
   EXPECT_THROW(package_map.Remove("package_baz"), std::runtime_error);
+}
+
+// Default-constructed maps must always be merge-able.
+GTEST_TEST(PackageMapTest, AddDefaultConstructedMaps) {
+  const PackageMap foo;
+  const PackageMap bar;
+  PackageMap dut;
+  dut.AddMap(foo);
+  dut.AddMap(bar);
+  EXPECT_EQ(dut.size(), foo.size());
 }
 
 // Tests that PackageMaps can be combined via AddMap.
@@ -219,7 +229,42 @@ GTEST_TEST(PackageMapTest, TestAddMap) {
   // Combining package maps with a conflicting package + path throws.
   DRAKE_EXPECT_THROWS_MESSAGE(
       package_map_1_copy.AddMap(package_map_conflicting),
-      ".*conflicts with.*");
+      ".*paths are not eq.*");
+}
+
+// Tests that combining via AddMap retains deprecation information
+GTEST_TEST(PackageMapTest, TestAddMapDeprecated) {
+  PackageMap dut = PackageMap::MakeEmpty();
+  dut.Add("default", ".");
+
+  // The deprecation comes along while merging.
+  PackageMap hats = PackageMap::MakeEmpty();
+  hats.Add("hats", ".");
+  hats.SetDeprecated("hats", "I like hats.");
+  dut.AddMap(hats);
+  EXPECT_EQ(dut.size(), 2);
+  EXPECT_EQ(dut.GetDeprecated("default").value_or(""), "");
+  EXPECT_EQ(dut.GetDeprecated("hats").value_or(""), "I like hats.");
+
+  // An *existing* deprecation on the dut remains intact when merging in
+  // another map that doesn't have any deprecation.
+  PackageMap temp = PackageMap::MakeEmpty();
+  temp.Add("hats", ".");
+  dut.AddMap(temp);
+  EXPECT_EQ(dut.GetDeprecated("hats").value_or(""), "I like hats.");
+
+  // Likewise even if the merged map is deprecated with some new message.
+  temp.SetDeprecated("hats", "Ignored!");
+  dut.AddMap(temp);
+  EXPECT_EQ(dut.GetDeprecated("hats").value_or(""), "I like hats.");
+
+  // However, merging a deprecated package onto an undeprecated does inherit
+  // the deprecation.
+  temp = PackageMap::MakeEmpty();
+  temp.Add("default", ".");
+  temp.SetDeprecated("default", "Oh nelly!");
+  dut.AddMap(temp);
+  EXPECT_EQ(dut.GetDeprecated("default").value_or(""), "Oh nelly!");
 }
 
 // Tests that PackageMap can be populated by a package.xml.
@@ -249,7 +294,7 @@ GTEST_TEST(PackageMapTest, TestPopulateFromXml) {
       "package.xml");
   DRAKE_EXPECT_THROWS_MESSAGE(
       package_map.AddPackageXml(conflicting_xml_filename),
-      ".*conflicts with.*");
+      ".*paths are not eq.*");
 }
 
 // Tests that PackageMap can be populated by crawling down a directory tree.
@@ -375,7 +420,7 @@ GTEST_TEST(PackageMapTest, TestDeprecation) {
       "package_map_test_package_b is deprecated, and will be removed on or "
           "around 2038-01-19. Please use the 'drake' package instead."
     },
-    {"package_map_test_package_d", ""},
+    {"package_map_test_package_d", "(no explanation given)"},
   };
   const string root_path = GetTestDataRoot();
   PackageMap package_map;


### PR DESCRIPTION
Towards https://github.com/RobotLocomotion/drake/issues/15774 and https://github.com/RobotLocomotion/drake/issues/9498.

See for the https://github.com/RobotLocomotion/drake/pull/18955 next PR that takes advantage of the encapsulation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19020)
<!-- Reviewable:end -->
