### PR TITLE
[render] Improve error messages

### DIFF
--- a/geometry/render_gltf_client/internal_http_service.cc
+++ b/geometry/render_gltf_client/internal_http_service.cc
@@ -22,9 +22,9 @@ void ThrowIfFilesMissing(const FileFieldsMap& file_fields) {
   }
 
   if (missing_files.size() > 0) {
-    throw std::runtime_error(
-        fmt::format("Provided file fields had missing file(s): {}.",
-                    fmt::join(missing_files, ", ")));
+    throw std::runtime_error(fmt::format(
+        "RenderClient: provided file fields had missing file(s): {}.",
+        fmt::join(missing_files, ", ")));
   }
 }
 

--- a/geometry/render_gltf_client/internal_http_service_curl.cc
+++ b/geometry/render_gltf_client/internal_http_service_curl.cc
@@ -272,7 +272,7 @@ HttpResponse HttpServiceCurl::DoPostForm(
   if (fs::exists(temp_bin_out)) {
     cleanup_curl(curl, form, headerlist);
     throw std::runtime_error(fmt::format(
-        "HttpServiceCurl: refusing to overwrite temporary file '{}' that "
+        "RenderClient: refusing to overwrite temporary file '{}' that "
         "already exists, please cleanup temporary directory '{}'.",
         bin_out_path, temp_directory));
   }
@@ -282,7 +282,7 @@ HttpResponse HttpServiceCurl::DoPostForm(
   if (!bin_out.good()) {
     cleanup_curl(curl, form, headerlist);
     throw std::runtime_error(fmt::format(
-        "HttpServiceCurl: unable to open temporary file '{}'.", bin_out_path));
+        "RenderClient: unable to open temporary file '{}'.", bin_out_path));
   }
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &WriteFileData);
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, &bin_out);
@@ -292,7 +292,7 @@ HttpResponse HttpServiceCurl::DoPostForm(
   if (!bin_out.good()) {
     cleanup_curl(curl, form, headerlist);
     throw std::runtime_error(fmt::format(
-        "HttpServiceCurl: unable to wtite temporary file '{}'.", bin_out_path));
+        "RenderClient: unable to wtite temporary file '{}'.", bin_out_path));
   }
   if (verbose) {
     LogCurlDebugData(debug_data);

--- a/geometry/render_gltf_client/internal_render_client.cc
+++ b/geometry/render_gltf_client/internal_render_client.cc
@@ -240,21 +240,19 @@ std::string RenderClient::RenderOnServer(
     const std::string service_error_message =
         response.service_error_message.value_or("None.");
     throw std::runtime_error(fmt::format(
-        R"""(
-        ERROR doing POST:
-          URL:             {}
-          Service Message: {}
-          HTTP Code:       {}
-          Server Message:  {}
-        )""",
+        R"""(RenderClient: error from POST:
+  URL:             {}
+  Service Message: {}
+  HTTP Code:       {}
+  Server Message:  {})""",
         url, service_error_message, response.http_code, server_message));
   }
 
   // If the server did not respond with a file, there is nothing to load.
   if (!response.data_path.has_value()) {
     throw std::runtime_error(fmt::format(
-        "ERROR doing POST to {}, HTTP code={}: the server was supposed to "
-        "respond with a file but did not.",
+        "RenderClient: error from POST to {}, HTTP code={}: the server was "
+        "supposed to respond with a file but did not.",
         url, response.http_code));
   }
   const std::string bin_out_path = response.data_path.value();
@@ -293,7 +291,7 @@ std::string RenderClient::ComputeSha256(const std::string& path) {
   std::ifstream f_in(path, std::ios::binary);
   if (!f_in.good()) {
     throw std::runtime_error(
-        fmt::format("ComputeSha256: cannot open file '{}'.", path));
+        fmt::format("RenderClient: cannot open file '{}'.", path));
   }
   std::vector<unsigned char> hash(picosha2::k_digest_size);
   picosha2::hash256(f_in, hash.begin(), hash.end());
@@ -397,7 +395,7 @@ void RenderClient::LoadDepthImage(const std::string& path,
   } else if (ext == ".tiff") {
     ReadTiffFile(path, image_exporter);
   } else {
-    throw std::runtime_error("Unsupported file extension");
+    throw std::runtime_error("RenderClient: unsupported file extension");
   }
 
   const int width = depth_image_out->width();
@@ -434,7 +432,7 @@ void RenderClient::LoadDepthImage(const std::string& path,
     }
   } else {
     /* no cover */
-    throw std::runtime_error("Unsupported channel type");
+    throw std::runtime_error("RenderClient: unsupported channel type");
   }
 }
 

--- a/geometry/render_gltf_client/test/internal_http_service_curl_test.cc
+++ b/geometry/render_gltf_client/test/internal_http_service_curl_test.cc
@@ -37,7 +37,7 @@ GTEST_TEST(HttpServiceCurlTest, PostForm) {
     DRAKE_EXPECT_THROWS_MESSAGE(
         service.PostForm(temp_dir, url, {}, {}, verbose),
         fmt::format(
-            "HttpServiceCurl: refusing to overwrite temporary file '{}' that "
+            ".*refusing to overwrite temporary file '{}' that "
             "already exists, please cleanup temporary directory '{}'.",
             temp_file_path.string(), temp_dir));
     fs::remove(temp_file_path);
@@ -52,7 +52,7 @@ GTEST_TEST(HttpServiceCurlTest, PostForm) {
     DRAKE_EXPECT_THROWS_MESSAGE(
         service.PostForm(temp_dir, url, {}, {}, verbose),
         fmt::format(
-            "HttpServiceCurl: unable to open temporary file '{}.*\\.curl'.",
+            ".*unable to open temporary file '{}.*\\.curl'.",
             temp_dir));
     fs::permissions(temp_dir, orig_perms, fs::perm_options::replace);
   }

--- a/geometry/render_gltf_client/test/internal_render_client_test.cc
+++ b/geometry/render_gltf_client/test/internal_render_client_test.cc
@@ -315,13 +315,13 @@ TEST_F(RenderClientTest, RenderOnServerFieldsCheck) {
   image_type = RenderImageType::kColorRgba8U;
   DRAKE_EXPECT_THROWS_MESSAGE(
       client.RenderOnServer(color_camera_.core(), image_type, fake_scene_path_),
-      "[\\s\\S]*ERROR doing POST:[\\s\\S]*");
+      "[\\s\\S]*POST:[\\s\\S]*");
 
   // Check fields for a label render.
   image_type = RenderImageType::kLabel16I;
   DRAKE_EXPECT_THROWS_MESSAGE(
       client.RenderOnServer(color_camera_.core(), image_type, fake_scene_path_),
-      "[\\s\\S]*ERROR doing POST:[\\s\\S]*");
+      "[\\s\\S]*POST:[\\s\\S]*");
 
   /* Check fields for a depth render.  This test also includes a verification
    that the provided mime_type is propagated correctly.  There is no special
@@ -331,7 +331,7 @@ TEST_F(RenderClientTest, RenderOnServerFieldsCheck) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       client.RenderOnServer(depth_camera_.core(), image_type, fake_scene_path_,
                             mime_type, depth_range),
-      "[\\s\\S]*ERROR doing POST:[\\s\\S]*");
+      "[\\s\\S]*POST:[\\s\\S]*");
 }
 
 /* Tests bad `HttpResponse`s that have a server message provided. Edge cases
@@ -392,7 +392,7 @@ TEST_F(RenderClientTest, RenderOnServerNoFileReturn) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       client.RenderOnServer(color_camera_.core(), RenderImageType::kColorRgba8U,
                             fake_scene_path_),
-      "ERROR doing POST.*supposed to respond with a file but did not.");
+      ".*POST.*supposed to respond with a file but did not.");
 }
 
 TEST_F(RenderClientTest, RenderOnServerInvalidImageReturn) {
@@ -590,7 +590,7 @@ TEST_F(RenderClientTest, LoadDepthImageBad) {
   // Failure case 1: invalid extension.
   DRAKE_EXPECT_THROWS_MESSAGE(
       RenderClient::LoadDepthImage("/no/such/file_ext.foo", &ignored),
-      "Unsupported file extension");
+      ".*unsupported file extension");
 
   // Failure case 2: not a valid image file.
   DRAKE_EXPECT_THROWS_MESSAGE(


### PR DESCRIPTION
- Prefix error messages with "RenderClient".
- Remote extra indentation that ends up being printed.

+@zachfang for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19022)
<!-- Reviewable:end -->
