### PR TITLE
Update JointSlider documentation

### DIFF
--- a/multibody/meshcat/joint_sliders.cc
+++ b/multibody/meshcat/joint_sliders.cc
@@ -57,8 +57,9 @@ bool HasAnyDuplicatedValues(const std::map<int, std::string>& data) {
 }
 
 // Returns a mapping from an index within the plant's position vector to the
-// slider name that refers to it.  Note that the map is sparse; positions
-// without joints (e.g., a floating base) are not represented here.
+// slider name that refers to it. The map only includes positions associated
+// with *joints*. Positions without joints (e.g., deformable vertex positions)
+// are not represented here.
 //
 // When use_model_instance_name is set, both the joint name and model name will
 // be used to to form the slider name; otherwise, only the joint name is used,
@@ -142,17 +143,17 @@ JointSliders<T>::JointSliders(
     : meshcat_(std::move(meshcat)),
       plant_(plant),
       position_names_(GetPositionNames(plant)),
-      initial_value_(
+      nominal_value_(
           std::move(initial_value).value_or(GetDefaultPositions(plant))),
       is_registered_{true} {
   DRAKE_THROW_UNLESS(meshcat_ != nullptr);
   DRAKE_THROW_UNLESS(plant_ != nullptr);
 
   const int nq = plant->num_positions();
-  if (initial_value_.size() != nq) {
+  if (nominal_value_.size() != nq) {
     throw std::logic_error(fmt::format(
         "Expected initial_value of size {}, but got size {} instead",
-        nq, initial_value_.size()));
+        nq, nominal_value_.size()));
   }
 
   // Default any missing arguments; check (or widen) them to be of size == nq.
@@ -192,7 +193,7 @@ JointSliders<T>::JointSliders(
         upper_broadcast[position_index],
         upper_plant[position_index]);
     const double one_step = step_broadcast[position_index];
-    const double one_value = initial_value_[position_index];
+    const double one_value = nominal_value_[position_index];
     const std::string one_decrement_keycode =
         decrement_keycodes.size()
             ? std::move(decrement_keycodes[position_index])
@@ -236,7 +237,7 @@ void JointSliders<T>::CalcOutput(
   const int nq = plant_->num_positions();
   DRAKE_DEMAND(output->size() == nq);
   for (int i = 0; i < nq; ++i) {
-    (*output)[i] = initial_value_[i];
+    (*output)[i] = nominal_value_[i];
   }
   if (is_registered_) {
     for (const auto& [position_index, slider_name] : position_names_) {
@@ -316,9 +317,8 @@ void JointSliders<T>::SetPositions(const Eigen::VectorXd& q) {
         "Expected q of size {}, but got size {} instead",
         nq, q.size()));
   }
-  /* For all positions provided in q, update their value in initial_value_
-    including items without an associated slider (e.g., a floating base). */
-  initial_value_ = q;
+  /* For *all* positions provided in q, update their value in nominal_value_. */
+  nominal_value_ = q;
   if (is_registered_) {
     // For items with an associated slider, update the meshcat UI.
     // TODO(jwnimmer-tri) If SetPositions is in flight concurrently with a

--- a/multibody/meshcat/joint_sliders.h
+++ b/multibody/meshcat/joint_sliders.h
@@ -31,9 +31,8 @@ output_ports:
 The output port is of size `plant.num_positions()`, and the order of its
 elements matches `plant.GetPositions()`.
 
-At the moment, any positions that are not associated with joints (e.g.,
-floating-base "mobilizers") are held fixed at a nominal value.  In the future,
-this class might add in sliders for a floating base as well.
+Only positions associated with joints get sliders. All other positions are fixed
+at nominal values.
 
 Beware that the output port of this system always provides the sliders' current
 values, even if evaluated by multiple different downstream input ports during a
@@ -147,7 +146,9 @@ class JointSliders final : public systems::LeafSystem<T> {
   std::shared_ptr<geometry::Meshcat> meshcat_;
   const MultibodyPlant<T>* const plant_;
   const std::map<int, std::string> position_names_;
-  Eigen::VectorXd initial_value_;
+  /* The nominal values for all positions; positions with sliders will not use
+   their nominal value except for defining the slider's initial value. */
+  Eigen::VectorXd nominal_value_;
   std::atomic<bool> is_registered_;
 };
 


### PR DESCRIPTION
Update the documentation vis a vis floating bodies -- they are now driven by joints. Also clarify implementation details related to this - renaming "initial" values with "nominal" values as they are no longer strictly "initial" but *do* represent the values that state will be held at when sliders can't be provided.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19043)
<!-- Reviewable:end -->
