### PR TITLE
[parsing] Switch drake_models to a remote package

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -114,6 +114,7 @@ install_test(
     data = [
         ":install",
         _INSTALL_TEST_COMMANDS,
+        "@models_internal//:all",
     ],
     tags = [
         # Running acceptance tests under coverage (kcov) can fail for presently

--- a/common/find_cache.cc
+++ b/common/find_cache.cc
@@ -8,6 +8,7 @@
 #include <fmt/format.h>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/text_logging.h"
 
 namespace drake {
 namespace internal {
@@ -91,6 +92,7 @@ PathOrError FindOrCreateCache(std::string_view subdir) {
   if (!cache_dir_drake.error.empty()) {
     return cache_dir_drake;
   }
+  log()->debug("FindCache found {}", cache_dir_drake.abspath.string());
 
   // Create the requested subdirectory.
   return CreateDirectory(cache_dir_drake.abspath / subdir);

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -55,11 +55,19 @@ drake_cc_package_library(
     ],
 )
 
+genrule(
+    name = "drake_models_json",
+    srcs = ["@models_internal//:drake_repository_metadata.json"],
+    outs = ["drake_models.json"],
+    cmd = "cp $< $@",
+)
+
 drake_cc_library(
     name = "package_map",
     srcs = ["package_map.cc"],
     hdrs = ["package_map.h"],
     data = [
+        ":drake_models.json",
         ":package_downloader.py",
         "//:package.xml",
         "@models_internal//:package.xml",
@@ -693,7 +701,10 @@ drake_cc_googletest(
 install_files(
     name = "install",
     dest = "share/drake/multibody/parsing",
-    files = ["package_downloader.py"],
+    files = [
+        "drake_models.json",
+        "package_downloader.py",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/tools/install/bazel/drake.BUILD.bazel
+++ b/tools/install/bazel/drake.BUILD.bazel
@@ -5,11 +5,6 @@ load("//:.manifest.bzl", "MANIFEST")
 
 package(default_visibility = ["//:__subpackages__"])
 
-exports_files(
-    glob([".share_drake_models/**"], allow_empty = False),
-    visibility = ["@models_internal//:__pkg__"],
-)
-
 _DRAKE_RUNFILES = MANIFEST["runfiles"]["drake"]
 
 _DRAKE_SHLIBS = glob([
@@ -62,7 +57,6 @@ filegroup(
     name = ".all_runfiles",
     data = [
         "//:.installed_runfiles",
-        "@models_internal//:.installed_runfiles",
     ] + [
         "//{}:.installed_runfiles".format(x)
         for x in _EXPECTED_DRAKE_RUNFILES_PACKAGES

--- a/tools/install/bazel/generate_installed_files_manifest.bzl
+++ b/tools/install/bazel/generate_installed_files_manifest.bzl
@@ -29,8 +29,6 @@ def _impl(ctx):
     ]
     drake_runfiles = []
     drake_prologue = "share/drake/"
-    models_internal_runfiles = []
-    models_internal_prologue = "share/drake_models/"
     lcmtypes_drake_py_files = []
     lcmtypes_drake_py_prologue = PYTHON_SITE_PACKAGES_RELPATH + "/drake/"
     for dest in ctx.attr.target[InstallInfo].installed_files:
@@ -46,16 +44,12 @@ def _impl(ctx):
             ]):
                 continue
             drake_runfiles.append(relative_path)
-        elif dest.startswith(models_internal_prologue):
-            relative_path = dest[len(models_internal_prologue):]
-            models_internal_runfiles.append(relative_path)
         elif dest.startswith(lcmtypes_drake_py_prologue):
             relative_path = dest[len(lcmtypes_drake_py_prologue):]
             lcmtypes_drake_py_files.append(relative_path)
     content = {
         "runfiles": {
             "drake": sorted(drake_runfiles),
-            "models_internal": sorted(models_internal_runfiles),
         },
         "lcmtypes_drake_py": sorted(lcmtypes_drake_py_files),
         "python_site_packages_relpath": PYTHON_SITE_PACKAGES_RELPATH,

--- a/tools/install/bazel/repo_template.bzl
+++ b/tools/install/bazel/repo_template.bzl
@@ -5,8 +5,7 @@
 
 def drake_repository(name, *, excludes = [], **kwargs):
     """Declares the @drake repository based on an installed Drake binary image,
-    along with repositories for its dependencies @eigen, @fmt, and
-    @models_internal.
+    along with repositories for its dependencies @eigen and @fmt.
 
     This enables downstream BUILD files to refer to certain Drake targets when
     using precompiled Drake releases.
@@ -30,13 +29,6 @@ def drake_repository(name, *, excludes = [], **kwargs):
         _eigen_repository(name = "eigen")
     if "fmt" not in excludes:
         _fmt_repository(name = "fmt", drake_name = name)
-    if "models_internal" not in excludes:
-        # TODO(jwnimmer-tri) I'm not sure whether or not we should allow users
-        # to supply their own flavor of this repository.
-        _models_internal_repository(
-            name = "models_internal",
-            drake_name = name,
-        )
 
 def _drake_impl(repo_ctx):
     # Obtain the root of the @drake_loader repository (i.e., wherever this
@@ -93,13 +85,6 @@ def _drake_impl(repo_ctx):
     for relpath in _MANIFEST["runfiles"]["drake"]:
         repo_ctx.symlink(str(share_drake) + "/" + relpath, relpath)
 
-    # Symlink the RobotLocomotions/models data into @drake, so that our
-    # repository rule for @models_internal can refer to it.
-    repo_ctx.symlink(
-        prefix.get_child("share").get_child("drake_models"),
-        ".share_drake_models",
-    )
-
     # Symlink all drake LCM types to this repository's root package, since it
     # should be named `drake` (see bazelbuild/bazel#3998).
     if repo_ctx.name != "drake":
@@ -148,37 +133,6 @@ cc_library(
 
 _fmt_repository = repository_rule(
     implementation = _fmt_impl,
-    attrs = {
-        "drake_name": attr.string(mandatory = True),
-    },
-)
-
-def _models_internal_impl(repo_ctx):
-    repo_ctx.file("BUILD.bazel", """
-load("@{drake}//:.manifest.bzl", "MANIFEST")
-
-# Copy the model files from prefix/share/... into this repository.
-PATHNAMES = MANIFEST["runfiles"]["models_internal"]
-[
-    genrule(
-        name = "genrule_" + str(i),
-        srcs = ["@{drake}//:.share_drake_models/" + x],
-        outs = [x],
-        cmd = "cp $< $@",
-    )
-    for i, x in enumerate(PATHNAMES)
-]
-
-# Export the model files as a group for use by @drake.
-filegroup(
-    name = ".installed_runfiles",
-    data = PATHNAMES,
-    visibility = ["@{drake}//:__subpackages__"],
-)
-""".format(drake = repo_ctx.attr.drake_name), executable = False)
-
-_models_internal_repository = repository_rule(
-    implementation = _models_internal_impl,
     attrs = {
         "drake_name": attr.string(mandatory = True),
     },

--- a/tools/install/bazel/test/drake_bazel_installed_test.py
+++ b/tools/install/bazel/test/drake_bazel_installed_test.py
@@ -108,11 +108,22 @@ _set_log_level("trace")
 FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf")
 """)
 
-    # This test case confirms that @drake_models still works.
+    # This test case confirms that package://drake_models still works.
     with open(join(scratch_dir, "package_map_test.py"), "w") as f:
         f.write("""
+# The install_test runner provides a pre-populated XDG_CACHE_HOME.
+# Use it for our package_map cache to prevent hitting the internet.
+import os
+from pathlib import Path
+test_tmpdir = Path(os.environ["TEST_TMPDIR"])
+xdg_cache_home = Path(os.environ["XDG_CACHE_HOME"])
+(test_tmpdir / ".cache").symlink_to(xdg_cache_home)
+
+# Now we can check that drake_models works.
+from pydrake.common import _set_log_level
 from pydrake.multibody.parsing import PackageMap
-PackageMap()
+_set_log_level("trace")
+PackageMap().GetPath("drake_models")
 """)
 
     with open(join(scratch_dir, "import_all_test.py"), "w") as f:
@@ -136,6 +147,10 @@ import pydrake.all
         "--max_idle_secs=1",
         # Run all of the tests from the BUILD.bazel generated above.
         command, "//...", "--jobs=1",
+        # Allow reuse of the install_test's pre-populated cache.
+        "--test_env=XDG_CACHE_HOME",
+        # Deny networking.
+        "--test_env=DRAKE_ALLOW_NETWORK=none",
         # Enable verbosity.
         "--announce_rc",
         "--test_output=streamed",

--- a/tools/install/dockerhub/focal/Dockerfile
+++ b/tools/install/dockerhub/focal/Dockerfile
@@ -11,6 +11,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 # https://docs.deepnote.com/environment/custom-environments#custom-image-requirements
     python3-pip python-is-python3 \
   && rm -rf /var/lib/apt/lists/* \
+# Bake model data into the image up-front, instead of fetching on demand.
+  && PYTHONPATH=/opt/drake/lib/python3.8/site-packages python3 -c \
+    'from pydrake.all import PackageMap; PackageMap().GetPath("drake_models")' \
   && mv /opt/drake/bin/drake-visualizer /opt/drake/bin/drake-visualizer.image
 RUN printf '#!/bin/bash\n \
 echo "drake-visualizer is not supported on Docker containers.\n\

--- a/tools/install/dockerhub/jammy/Dockerfile
+++ b/tools/install/dockerhub/jammy/Dockerfile
@@ -10,6 +10,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 # Make python and pip available to meet the requirements for deepnote.com:
 # https://docs.deepnote.com/environment/custom-environments#custom-image-requirements
     python3-pip python-is-python3 \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+# Bake model data into the image up-front, instead of fetching on demand.
+  && PYTHONPATH=/opt/drake/lib/python3.10/site-packages python3 -c \
+    'from pydrake.all import PackageMap; PackageMap().GetPath("drake_models")' \
 ENV PATH="/opt/drake/bin:${PATH}" \
   PYTHONPATH="/opt/drake/lib/python3.10/site-packages:${PYTHONPATH}"

--- a/tools/install/install_test.py
+++ b/tools/install/install_test.py
@@ -1,6 +1,8 @@
 import argparse
 import functools
+import json
 import os
+from pathlib import Path
 import re
 import sys
 import unittest
@@ -19,6 +21,24 @@ class InstallTest(unittest.TestCase):
         assert not os.path.exists(cls._installation_folder)
         install_test_helper.install()
         assert os.path.isdir(cls._installation_folder)
+
+        # Locate the drake_models metadata.
+        drake_models = Path(os.environ["TEST_SRCDIR"]) / "models_internal"
+        with open(drake_models / "drake_repository_metadata.json") as f:
+            sha256 = json.load(f)["sha256"]
+
+        # Pre-populate the package_map cache directory with the drake_models
+        # data, so we don't hit the internet while testing.
+        test_tmpdir = Path(os.environ["TEST_TMPDIR"])
+        assert test_tmpdir.exists()
+        xdg_cache_home = test_tmpdir / ".cache"
+        package_map = xdg_cache_home / "drake" / "package_map"
+        package_map.mkdir(parents=True)
+        (package_map / sha256).symlink_to(drake_models)
+
+        # Also plumb it through as $XDG_CACHE_HOME for nested Bazel tests
+        # (which have their own unique nested $TEST_TMPDIR).
+        os.environ["XDG_CACHE_HOME"] = str(xdg_cache_home)
 
     def test_basic_paths(self):
         # Verify install directory content.

--- a/tools/wheel/image/build-wheel.sh
+++ b/tools/wheel/image/build-wheel.sh
@@ -90,10 +90,6 @@ cp -r -t ${WHEEL_SHARE_DIR}/drake \
     /opt/drake/share/drake/manipulation \
     /opt/drake/share/drake/multibody \
     /opt/drake/share/drake/tutorials
-# TODO(#15774) Eventually we will download these at runtime, instead of shipping
-# them in the wheel.
-cp -r -t ${WHEEL_SHARE_DIR} \
-    /opt/drake/share/drake_models
 
 if [[ "$(uname)" == "Linux" ]]; then
     mkdir -p ${WHEEL_SHARE_DIR}/drake/setup
@@ -101,15 +97,10 @@ if [[ "$(uname)" == "Linux" ]]; then
         /opt/drake/share/drake/setup/deepnote
 fi
 
-# TODO(mwoehlke-kitware) We need to remove these to keep the wheel from being
-# too large, but (per above), the whole of share/drake_models shouldn't be in
-# the wheel (and atlas's meshes should move into drake_models).
+# TODO(jwnimmer-tri) We need to remove this to keep the wheel from being too
+# large; the better fix is that Atlas's meshes should move into drake_models.
 rm -rf \
-    ${WHEEL_SHARE_DIR}/drake_models/franka_description \
-    ${WHEEL_SHARE_DIR}/drake_models/ur3e \
-    ${WHEEL_SHARE_DIR}/drake_models/ycb \
-    ${WHEEL_SHARE_DIR}/drake/examples/atlas \
-    ${WHEEL_SHARE_DIR}/drake_models/wsg_50_hydro_bubble
+    ${WHEEL_SHARE_DIR}/drake/examples/atlas
 
 if [[ "$(uname)" == "Linux" ]]; then
     export LD_LIBRARY_PATH=${WHEEL_DIR}/pydrake/lib:/opt/drake-dependencies/lib

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -87,7 +87,6 @@ _DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "gz_utils_internal",
     "lcm",
     "meshcat",
-    "models_internal",
     "msgpack_internal",
     "net_sf_jchart2d",
     "nanoflann_internal",

--- a/tools/workspace/github.bzl
+++ b/tools/workspace/github.bzl
@@ -264,12 +264,13 @@ def github_download_and_extract(
         mirrors = mirrors,
     )
 
+    strip_prefix = _strip_prefix(repository, commit, extra_strip_prefix)
     repository_ctx.download_and_extract(
         urls,
         output = output,
         sha256 = _sha256(sha256),
         type = "tar.gz",
-        stripPrefix = _strip_prefix(repository, commit, extra_strip_prefix),
+        stripPrefix = strip_prefix,
     )
 
     upgrade_advice = "\n".join(
@@ -285,6 +286,7 @@ def github_download_and_extract(
         version_pin = commit_pin,
         sha256 = sha256,
         urls = urls,
+        strip_prefix = strip_prefix,
         upgrade_advice = upgrade_advice,
     )
 

--- a/tools/workspace/models_internal/package.BUILD.bazel
+++ b/tools/workspace/models_internal/package.BUILD.bazel
@@ -4,6 +4,11 @@ load("@drake//tools/install:install.bzl", "install")
 
 package(default_visibility = ["//visibility:private"])
 
+exports_files(
+    ["drake_repository_metadata.json"],
+    visibility = ["@drake//multibody/parsing:__pkg__"],
+)
+
 # TODO(jwnimmer-tri) Add a real package.xml upstream.
 genrule(
     name = "package.xml_genrule",
@@ -13,39 +18,30 @@ genrule(
     visibility = ["//visibility:public"],
 )
 
+# Keep this list alpha-sorted.
+_SRCS = glob([
+    "dishes/**",
+    "franka_description/**",
+    "jaco_description/**",
+    "skydio_2/**",
+    "tri_homecart/**",
+    "ur3e/**",
+    "veggies/**",
+    "wsg_50_description/**",
+    "wsg_50_hydro_bubble/**",
+    "ycb/meshes/**",
+], allow_empty = False)
+
 exports_files(
-    # Keep this list alpha-sorted.
-    srcs = glob([
-        "dishes/**",
-        "franka_description/**",
-        "jaco_description/**",
-        "skydio_2/**",
-        "tri_homecart/**",
-        "ur3e/**",
-        "veggies/**",
-        "wsg_50_description/**",
-        "wsg_50_hydro_bubble/**",
-        "ycb/meshes/**",
-    ], allow_empty = False),
+    srcs = _SRCS,
     visibility = ["//visibility:public"],
 )
 
-# Install a subset of the models.
-install(
-    name = "install",
-    data = [
-        ":package.xml",
-    ] + glob([
-        # Keep this list alpha-sorted.
-        "franka_description/**",
-        "jaco_description/**",
-        "skydio_2/**",
-        "tri_homecart/**",
-        "ur3e/**",
-        "wsg_50_description/**",
-        "wsg_50_hydro_bubble/**",
-        "ycb/meshes/**",
-    ], allow_empty = False),
-    data_dest = "share/drake_models",
-    visibility = ["//visibility:public"],
+filegroup(
+    name = "all",
+    srcs = _SRCS + [
+        "drake_repository_metadata.json",
+        "package.xml",
+    ],
+    visibility = ["@drake//:__pkg__"],
 )


### PR DESCRIPTION
Closes #15774.

---

Local testing of a CMake install:

```console
$ bazel run //:install -- /home/jwnimmer/tmp/install
$ cd ~/tmp
$ env PYTHONPATH=install/lib/python3.10/site-packages python3
>>> from pydrake.all import PackageMap
>>> PackageMap().GetPath("drake_models")
INFO:drake:PackageMap: Downloading https://github.com/RobotLocomotion/models/archive/6751ba850fd46fee789a095edba7ad9fc99cd188.tar.gz
'/home/jwnimmer/.cache/drake/package_map/dc38658f7acb4d07442e6dae4d18818d31ac6cc6d66bf16913ef1b208692627c'
```

---

Local testing of an Ubuntu Wheel install:

```console
$ cd tmp
$ python3 -m venv env && env/bin/pip install 'https://drake-packages.csail.mit.edu/drake/experimental/drake-0.0.2023.3.24.16.25.24%2Bgit0cd06a59-cp310-cp310-manylinux_2_31_x86_64.whl'
$ env/bin/python3
>>> from pydrake.all import *
>>> path = PackageMap().GetPath("drake_models")
INFO:drake:PackageMap: Downloading https://github.com/RobotLocomotion/models/archive/6751ba850fd46fee789a095edba7ad9fc99cd188.tar.gz
>>> with open(f"{path}/README.md") as f: f.read()
'# models\n\nShareable large model files ...'
```

---

Local testing of a macOS Wheel install:

```console
% cd tmp
% python3 -m venv env && env/bin/pip install 'https://drake-packages.csail.mit.edu/drake/experimental/drake-0.0.2023.3.24.12.26.16%2Bgit0cd06a59-cp311-cp311-macosx_12_0_arm64.whl'
% env/bin/python3
>>> from pydrake.all import *
>>> path = PackageMap().GetPath("drake_models")
INFO:drake:PackageMap: Downloading https://github.com/RobotLocomotion/models/archive/6751ba850fd46fee789a095edba7ad9fc99cd188.tar.gz
>>> with open(f"{path}/README.md") as f: f.read()
... 
'# models\n\nShareable large model files ...'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19046)
<!-- Reviewable:end -->
