### PR TITLE
Add DRAKE_ALLOW_NETWORK governor

### DIFF
--- a/bindings/pydrake/geometry/BUILD.bazel
+++ b/bindings/pydrake/geometry/BUILD.bazel
@@ -110,6 +110,7 @@ drake_py_unittest(
 
 drake_py_unittest(
     name = "render_test",
+    allow_network = ["render_gltf_client"],
     deps = [
         ":geometry",
         "//bindings/pydrake/common/test_utilities",

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -42,6 +42,7 @@ drake_cc_package_library(
         ":is_cloneable",
         ":is_less_than_comparable",
         ":name_value",
+        ":network_policy",
         ":nice_type_name",
         ":pointer_cast",
         ":polynomial",
@@ -349,6 +350,15 @@ drake_cc_library(
 drake_cc_library(
     name = "name_value",
     hdrs = ["name_value.h"],
+    deps = [
+        ":essential",
+    ],
+)
+
+drake_cc_library(
+    name = "network_policy",
+    srcs = ["network_policy.cc"],
+    hdrs = ["network_policy.h"],
     deps = [
         ":essential",
     ],
@@ -955,6 +965,13 @@ drake_cc_googletest(
     name = "name_value_test",
     deps = [
         ":name_value",
+    ],
+)
+
+drake_cc_googletest(
+    name = "network_policy_test",
+    deps = [
+        ":network_policy",
     ],
 )
 

--- a/common/network_policy.cc
+++ b/common/network_policy.cc
@@ -1,0 +1,75 @@
+#include "drake/common/network_policy.h"
+
+#include <algorithm>
+#include <cstdlib>
+
+#include "drake/common/drake_throw.h"
+#include "drake/common/text_logging.h"
+
+namespace drake {
+namespace internal {
+namespace {
+
+bool IsAsciiLowercaseAlphaNumeric(std::string_view word) {
+  return std::all_of(word.begin(), word.end(), [](char ch) {
+    return ('a' <= ch && ch <= 'z') || ('0' <= ch && ch <= '9') || (ch == '_');
+  });
+}
+
+}  // namespace
+
+bool IsNetworkingAllowed(std::string_view component) {
+  DRAKE_THROW_UNLESS(component.length() > 0);
+  DRAKE_THROW_UNLESS(component != "none");
+  DRAKE_THROW_UNLESS(IsAsciiLowercaseAlphaNumeric(component));
+
+  // Unset or empty means allow-all.
+  const char* const env_cstr = std::getenv("DRAKE_ALLOW_NETWORK");
+  if (env_cstr == nullptr) {
+    return true;
+  }
+  if (*env_cstr == '\0') {
+    return true;
+  }
+  const std::string_view env_view{env_cstr};
+
+  // Set to "none" means deny-all.
+  if (env_view == "none") {
+    return false;
+  }
+
+  // Iterate over the colon-delimited tokens.
+  // N.B. We purposefully do not warn for unknown tokens because they may evolve
+  // over time and we don't want to force users to churn their policy variables
+  // to be congruent with their Drake version pin.
+  // TODO(jwnimmer-tri) As of C++20, use std::ranges::lazy_split_view.
+  bool match = false;
+  std::string_view worklist = env_view;
+  while (!worklist.empty()) {
+    std::string_view token;
+    auto delim = worklist.find(':');
+    if (delim == std::string_view::npos) {
+      token = worklist;
+      worklist = {};
+    } else {
+      token = worklist.substr(0, delim);
+      worklist.remove_prefix(delim + 1);
+    }
+    if (token == "none") {
+      static const logging::Warn log_once(
+          "Setting DRAKE_ALLOW_NETWORK={} combines 'none' with non-none "
+          "values; this is probably not what you wanted! The effect is "
+          "the same as just saying 'none' on its own; nothing is allowed!",
+          env_view);
+      return false;
+    }
+    if (token == component) {
+      match = true;
+    }
+  }
+
+  return match;
+}
+
+}  // namespace internal
+}  // namespace drake

--- a/common/network_policy.h
+++ b/common/network_policy.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <string_view>
+
+namespace drake {
+
+/** @addtogroup environment_variables
+@{
+@defgroup allow_network DRAKE_ALLOW_NETWORK
+
+Users can set the environment variable `DRAKE_ALLOW_NETWORK` to a
+colon-separated list to limit which components are permitted network access.
+
+If `DRAKE_ALLOW_NETWORK` is unset or set to the empty string, then all
+networking is allowed.
+
+The component values supported by Drake are:
+- <b>lcm</b> (see drake::lcm::DrakeLcm)
+- <b>meshcat</b> (see drake::geometry::Meshcat)
+- <b>package_map</b> (see drake::multibody::PackageMap)
+- <b>render_gltf_client</b> (see drake::geometry::MakeRenderEngineVtk())
+
+... as well as the special value <b>none</b>.
+
+The environment variable only governs the *network* access of the component.
+If the component also supports other mechanisms (e.g., files or memory buffers)
+those are unaffected.
+
+---
+
+For example, to allow only lcm and meshcat, run this command in your terminal:
+```sh
+export DRAKE_ALLOW_NETWORK=lcm:meshcat
+```
+
+To disable all networking, run this command in your terminal:
+```sh
+export DRAKE_ALLOW_NETWORK=none
+```
+@} */
+
+namespace internal {
+
+/* Returns true iff the given component is allowed to access the network based
+on the current value of the DRAKE_ALLOW_NETWORK environment variable.
+@param component is the name to query, which must be alphanumeric lowercase
+(underscores allowed) and must not be "none" nor the empty string. */
+bool IsNetworkingAllowed(std::string_view component);
+
+}  // namespace internal
+}  // namespace drake

--- a/common/test/network_policy_test.cc
+++ b/common/test/network_policy_test.cc
@@ -1,0 +1,64 @@
+#include "drake/common/network_policy.h"
+
+#include <stdlib.h>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace internal {
+namespace {
+
+constexpr const char kAllow[] = "DRAKE_ALLOW_NETWORK";
+
+GTEST_TEST(NetworkPolicyTest, Missing) {
+  ASSERT_EQ(::unsetenv(kAllow), 0);
+  EXPECT_TRUE(IsNetworkingAllowed("foo"));
+}
+
+GTEST_TEST(NetworkPolicyTest, Empty) {
+  ASSERT_EQ(::setenv(kAllow, "", 1), 0);
+  EXPECT_TRUE(IsNetworkingAllowed("foo"));
+}
+
+GTEST_TEST(NetworkPolicyTest, None) {
+  ASSERT_EQ(::setenv(kAllow, "none", 1), 0);
+  EXPECT_FALSE(IsNetworkingAllowed("foo"));
+}
+
+GTEST_TEST(NetworkPolicyTest, MixedNone) {
+  // N.B. This prints a spdlog warning.
+  ASSERT_EQ(::setenv(kAllow, "none:foo", 1), 0);
+  EXPECT_FALSE(IsNetworkingAllowed("foo"));
+}
+
+GTEST_TEST(NetworkPolicyTest, YesMatch) {
+  ASSERT_EQ(::setenv(kAllow, "foo", 1), 0);
+  EXPECT_TRUE(IsNetworkingAllowed("foo"));
+
+  ASSERT_EQ(::setenv(kAllow, "foo:bar", 1), 0);
+  EXPECT_TRUE(IsNetworkingAllowed("foo"));
+
+  ASSERT_EQ(::setenv(kAllow, "bar:foo:baz", 1), 0);
+  EXPECT_TRUE(IsNetworkingAllowed("foo"));
+}
+
+GTEST_TEST(NetworkPolicyTest, NoMatch) {
+  ASSERT_EQ(::setenv(kAllow, "bar", 1), 0);
+  EXPECT_FALSE(IsNetworkingAllowed("foo"));
+
+  ASSERT_EQ(::setenv(kAllow, "bar:baz", 1), 0);
+  EXPECT_FALSE(IsNetworkingAllowed("foo"));
+
+  ASSERT_EQ(::setenv(kAllow, ":bar:baz:", 1), 0);
+  EXPECT_FALSE(IsNetworkingAllowed("foo"));
+}
+
+GTEST_TEST(NetworkPolicyTest, BadName) {
+  EXPECT_THROW(IsNetworkingAllowed(""), std::exception);
+  EXPECT_THROW(IsNetworkingAllowed("none"), std::exception);
+  EXPECT_THROW(IsNetworkingAllowed("LCM"), std::exception);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace drake

--- a/doc/doxygen_cxx/doxygen.h
+++ b/doc/doxygen_cxx/doxygen.h
@@ -216,6 +216,7 @@ namespace solvers {
 
  This section provides an inventory of environment variables relevant to Drake.
 
+ - <b>\ref allow_network "DRAKE_ALLOW_NETWORK"</b>
  - <b>\ref drake::common::FindResource() "DRAKE_RESOURCE_ROOT"</b>
  - <b>\ref drake::solvers::GurobiSolver "GRB_LICENSE_FILE"</b> (see also 
    <a href="https://support.gurobi.com/hc/en-us/articles/360013417211-Where-do-I-place-the-Gurobi-license-file-gurobi-lic-">upstream documentation</a>)

--- a/examples/allegro_hand/joint_control/BUILD.bazel
+++ b/examples/allegro_hand/joint_control/BUILD.bazel
@@ -54,6 +54,7 @@ drake_cc_binary(
 drake_py_unittest(
     name = "run_twisting_mug_test",
     timeout = "moderate",
+    allow_network = ["lcm"],
     args = select({
         "//tools/cc_toolchain:debug": ["--compilation_mode=dbg"],
         "//conditions:default": ["--compilation_mode=opt"],

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -467,6 +467,7 @@ drake_cc_library(
     deps = [
         "//common:drake_export",
         "//common:find_resource",
+        "//common:network_policy",
         "//common:scope_exit",
         "//common:unused",
         "@common_robotics_utilities",
@@ -521,6 +522,15 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "@msgpack_internal//:msgpack",
+    ],
+)
+
+drake_cc_googletest(
+    name = "meshcat_denied_test",
+    allow_network = ["none"],
+    deps = [
+        ":meshcat",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -27,6 +27,7 @@
 #include "drake/common/drake_export.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/find_resource.h"
+#include "drake/common/network_policy.h"
 #include "drake/common/never_destroyed.h"
 #include "drake/common/scope_exit.h"
 #include "drake/common/text_logging.h"
@@ -546,6 +547,11 @@ class Meshcat::Impl {
         main_thread_id_(std::this_thread::get_id()),
         params_(params) {
     DRAKE_THROW_UNLESS(params.port.value_or(7000) >= 1024);
+    if (!drake::internal::IsNetworkingAllowed("meshcat")) {
+      throw std::runtime_error(
+          "Meshcat has been disabled via the DRAKE_ALLOW_NETWORK environment "
+          "variable");
+    }
 
     // Sanity-check the pattern, by passing it (along with dummy host and port
     // values) through to fmt to allow any fmt-specific exception to percolate.

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -126,7 +126,13 @@ in the visualizer.
 - All user objects can easily be cleared by a single, parameter-free call to
 Delete(). You are welcome to use absolute paths to organize your data, but the
 burden on tracking and cleaning them up lie on you.
-*/
+
+@section network_access Network access
+
+See MeshcatParams for options to control the hostname and port to bind to.
+
+See \ref allow_network "DRAKE_ALLOW_NETWORK" for an environment variable
+option to deny %Meshcat entirely. */
 class Meshcat {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Meshcat)

--- a/geometry/render_gltf_client/BUILD.bazel
+++ b/geometry/render_gltf_client/BUILD.bazel
@@ -31,10 +31,11 @@ drake_cc_library(
     visibility = ["//visibility:public"],
     interface_deps = [
         ":render_engine_gltf_client_params",
-        "//geometry/render:render_camera",
+        "//geometry/render:render_engine",
     ],
     deps = [
         ":internal_render_engine_gltf_client",
+        "//common:network_policy",
     ],
 )
 
@@ -125,11 +126,21 @@ drake_cc_library(
 
 drake_cc_googletest(
     name = "factory_test",
+    allow_network = ["render_gltf_client"],
     deps = [
         ":factory",
         ":internal_render_engine_gltf_client",
         ":render_engine_gltf_client_params",
         "//geometry/render:render_camera",
+    ],
+)
+
+drake_cc_googletest(
+    name = "factory_denied_test",
+    allow_network = ["none"],
+    deps = [
+        ":factory",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 
@@ -282,6 +293,7 @@ drake_py_unittest(
 drake_py_unittest(
     name = "integration_test",
     size = "medium",
+    allow_network = ["render_gltf_client"],
     data = [
         ":client_demo",
         ":server_demo",

--- a/geometry/render_gltf_client/factory.cc
+++ b/geometry/render_gltf_client/factory.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/render_gltf_client/factory.h"
 
+#include "drake/common/network_policy.h"
 #include "drake/geometry/render_gltf_client/internal_render_engine_gltf_client.h"
 
 namespace drake {
@@ -7,6 +8,12 @@ namespace geometry {
 
 std::unique_ptr<render::RenderEngine> MakeRenderEngineGltfClient(
     const RenderEngineGltfClientParams& params) {
+  if (!drake::internal::IsNetworkingAllowed("render_gltf_client")) {
+    throw std::runtime_error(
+        "RenderEngineGltfClient has been disabled via the DRAKE_ALLOW_NETWORK "
+        "environment variable");
+  }
+
   return std::make_unique<render_gltf_client::internal::RenderEngineGltfClient>(
       params);
 }

--- a/geometry/render_gltf_client/factory.h
+++ b/geometry/render_gltf_client/factory.h
@@ -26,7 +26,9 @@ namespace geometry {
    [`curl_global_init(CURL_GLOBAL_ALL | CURL_GLOBAL_ACK_EINTR)`][libcurl_init],
    the implication for consuming applications being:
  @note
-   1. If you intend to have your rendering take place in a threaded context,
+   1. See \ref allow_network "DRAKE_ALLOW_NETWORK" for an environment variable
+      option to deny remote rendering entirely.
+   2. If you intend to have your rendering take place in a threaded context,
       you **must** instantiate this RenderEngine via %MakeRenderEngineGltfClient
       from the main thread **before** spawning your threaded workers.  As soon
       as one of these RenderEngine instances has been constructed, libcurl will
@@ -41,7 +43,7 @@ namespace geometry {
       // After MakeRenderEngineGltfClient() function call, libcurl has been
       // initialized and you may now create threads if desired.
       @endcode
-   2. If you need to use a different initialization strategy for libcurl in your
+   3. If you need to use a different initialization strategy for libcurl in your
       application, you should first create the RenderEngine using
       %MakeRenderEngineGltfClient, then manually call
       [`curl_global_cleanup()`][libcurl_cleanup], followed by manually calling

--- a/geometry/render_gltf_client/test/factory_denied_test.cc
+++ b/geometry/render_gltf_client/test/factory_denied_test.cc
@@ -1,0 +1,18 @@
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/render_gltf_client/factory.h"
+
+namespace drake {
+namespace geometry {
+namespace {
+
+GTEST_TEST(FactoryDeniedTest, ExceptionMessage) {
+  const RenderEngineGltfClientParams params;
+  DRAKE_EXPECT_THROWS_MESSAGE(MakeRenderEngineGltfClient(params),
+                              ".*DRAKE_ALLOW_NETWORK.*");
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/meshcat_denied_test.cc
+++ b/geometry/test/meshcat_denied_test.cc
@@ -1,0 +1,16 @@
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/meshcat.h"
+
+namespace drake {
+namespace geometry {
+namespace {
+
+GTEST_TEST(MeshcatDeniedTest, ExceptionMessage) {
+  DRAKE_EXPECT_THROWS_MESSAGE(Meshcat{}, ".*DRAKE_ALLOW_NETWORK.*");
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake

--- a/lcm/BUILD.bazel
+++ b/lcm/BUILD.bazel
@@ -76,6 +76,7 @@ drake_cc_library(
         "//common:essential",
     ],
     deps = [
+        "//common:network_policy",
         "@glib",
         "@lcm",
     ],
@@ -136,12 +137,22 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "drake_lcm_test",
+    allow_network = ["lcm"],
     flaky = True,
     deps = [
         ":drake_lcm",
         ":lcmt_drake_signal_utils",
         "//common/test_utilities:expect_throws_message",
         "@lcm",
+    ],
+)
+
+drake_cc_googletest(
+    name = "drake_lcm_denied_test",
+    allow_network = ["none"],
+    deps = [
+        ":drake_lcm",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 
@@ -169,6 +180,7 @@ drake_cc_binary(
 
 drake_py_unittest(
     name = "initialization_sequence_test",
+    allow_network = ["lcm"],
     data = [
         ":initialization_sequence_test_stub",
     ],

--- a/lcm/drake_lcm.cc
+++ b/lcm/drake_lcm.cc
@@ -12,6 +12,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
+#include "drake/common/network_policy.h"
 #include "drake/common/text_logging.h"
 
 namespace drake {
@@ -46,6 +47,14 @@ class DrakeLcm::Impl {
       }
       if (lcm_url_.empty()) {
         lcm_url_ = kLcmDefaultUrl;
+      }
+    }
+    if (lcm_url_.substr(0, 7) != "memq://") {
+      if (!drake::internal::IsNetworkingAllowed("lcm")) {
+        throw std::runtime_error(fmt::format(
+            "LCM URL {} has been disabled via the DRAKE_ALLOW_NETWORK "
+            "environment variable",
+            lcm_url_));
       }
     }
   }

--- a/lcm/drake_lcm.h
+++ b/lcm/drake_lcm.h
@@ -23,6 +23,9 @@ namespace lcm {
 
 /**
  * A wrapper around a *real* LCM instance.
+ *
+ * See \ref allow_network "DRAKE_ALLOW_NETWORK" for an environment variable
+ * option to disable LCM network traffic (i.e., only allowing `memq://` URLs).
  */
 class DrakeLcm : public DrakeLcmInterface {
  public:

--- a/lcm/test/drake_lcm_denied_test.cc
+++ b/lcm/test/drake_lcm_denied_test.cc
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/lcm/drake_lcm.h"
+
+namespace drake {
+namespace lcm {
+namespace {
+
+GTEST_TEST(DrakeLcmDeniedTest, MemqIsFine) {
+  EXPECT_NO_THROW(DrakeLcm{"memq://foo"});
+}
+
+GTEST_TEST(DrakeLcmDeniedTest, ExceptionMessage) {
+  DRAKE_EXPECT_THROWS_MESSAGE(DrakeLcm{"udpm://239.255.76.67:7670"},
+                              ".*DRAKE_ALLOW_NETWORK.*");
+}
+
+}  // namespace
+}  // namespace lcm
+}  // namespace drake

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -73,6 +73,7 @@ drake_cc_library(
         "//common:find_cache",
         "//common:find_resource",
         "//common:find_runfiles",
+        "//common:network_policy",
         "//common:scope_exit",
         "//common/yaml",
         "@tinyxml2_internal//:tinyxml2",

--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -22,6 +22,7 @@
 #include "drake/common/find_cache.h"
 #include "drake/common/find_resource.h"
 #include "drake/common/find_runfiles.h"
+#include "drake/common/network_policy.h"
 #include "drake/common/never_destroyed.h"
 #include "drake/common/scope_exit.h"
 #include "drake/common/text_logging.h"
@@ -91,7 +92,8 @@ class PathWithMutex {
 
   /* Sets the path for a (currently-unfetched) path.
   @pre needs_fetch() is true.
-  @pre the lock() is currently held. */
+  @pre either the lock() is currently held or the caller has exclusive
+  access to `this` */
   void set_fetched_path(std::string path) {
     DRAKE_DEMAND(needs_fetch_);
     DRAKE_DEMAND(path_.empty());
@@ -194,6 +196,12 @@ class PackageData {
   The `package_name` is non-functional (only used when reporting errors). */
   void Merge(std::string_view package_name, const PackageData& other);
 
+  /* Checks whether a remote package is already in the cache and if so updates
+  this object so that GetPathWithAutomaticFetching() will return the already-
+  cached path instead of fetching anything.
+  @pre is_remote() is true. */
+  bool FindInCache();
+
   /* Returns the local filesystem path for this package. In case this package
   is remote and not already fetched, this function will fetch before returning.
   The `package_name` is non-functional (only used when reporting errors). */
@@ -218,6 +226,26 @@ class PackageData {
   std::optional<std::string> deprecation_;
 };
 
+/* Given a list of urls (i.e., the RemoteParams::urls), returns a copy of the
+list that reflects the current network policy (i.e., by removing any that are
+not allowed). */
+std::vector<std::string> GetAllowedUrls(const std::vector<std::string>& urls) {
+  std::vector<std::string> result(urls);
+  if (drake::internal::IsNetworkingAllowed("package_map")) {
+    return result;
+  }
+  auto should_deny = [](const auto& url) {
+    const bool is_allowed = url.substr(0, 7) == "file://";
+    if (!is_allowed) {
+      log()->trace("PackageMap ignoring '{}' due to DRAKE_ALLOW_NETWORK", url);
+    }
+    return !is_allowed;
+  };
+  result.erase(std::remove_if(result.begin(), result.end(), should_deny),
+               result.end());
+  return result;
+}
+
 /* A little helper struct that gathers the args for package_downloader into a
 single place to make it easy to convert to JSON. */
 struct DownloaderArgs {
@@ -231,6 +259,24 @@ struct DownloaderArgs {
   PackageMap::RemoteParams remote_params;
   std::string output_dir;
 };
+
+bool PackageData::FindInCache() {
+  DRAKE_DEMAND(is_remote());
+  if (!path_.needs_fetch()) {
+    return true;
+  }
+  internal::PathOrError cache = internal::FindOrCreateCache("package_map");
+  if (!cache.error.empty()) {
+    return false;
+  }
+  const fs::path package_dir = cache.abspath / remote_params_->sha256;
+  std::error_code ec;
+  if (!fs::is_directory(package_dir, ec)) {
+    return false;
+  }
+  path_.set_fetched_path(package_dir.string());
+  return true;
+}
 
 const std::string& PackageData::GetPathWithAutomaticFetching(
     std::string_view package_name) const {
@@ -276,6 +322,7 @@ const std::string& PackageData::GetPathWithAutomaticFetching(
   DownloaderArgs args{.package_name = std::string(package_name),
                       .remote_params = remote_params(),
                       .output_dir = package_dir.string()};
+  args.remote_params.urls = GetAllowedUrls(args.remote_params.urls);
   std::string json_filename = fs::path(cache_dir / ".fetch_XXXXXX").string();
   const int temp_fd = ::mkstemp(json_filename.data());
   ::close(temp_fd);
@@ -554,8 +601,24 @@ void PackageMap::AddRemote(std::string package_name, RemoteParams params) {
     }
   }
 
+  // We've finished checking that the params are well-formed.
+  auto package_data = PackageData::MakeRemote(std::move(params));
+
+  // If the user has denied networking AND there are no file:// urls AND the
+  // package is not yet cached, then we should fail-fast.
+  if (GetAllowedUrls(package_data.remote_params().urls).empty()) {
+    if (!package_data.FindInCache()) {
+      throw std::runtime_error(fmt::format(
+          "PackageMap::AddRemote on '{}' only provides network URLs (i.e., no "
+          "file:// fallbacks) but PackageMap networking has been disabled via "
+          "the DRAKE_ALLOW_NETWORK environment variable and the download cache "
+          "does not contain any matching file",
+          package_name));
+    }
+  }
+
   // Add it now. Emplace will handle rejection of duplicates.
-  impl_->Emplace(package_name, PackageData::MakeRemote(std::move(params)));
+  impl_->Emplace(package_name, std::move(package_data));
 }
 
 bool PackageMap::Contains(const std::string& package_name) const {

--- a/multibody/parsing/package_map.h
+++ b/multibody/parsing/package_map.h
@@ -126,7 +126,13 @@ class PackageMap final {
   be downloaded until necessary, i.e., when GetPath() is first called for the
   `package_name`. Throws if the `package_name` or `params` are invalid.
   Downloading requires a valid `/usr/bin/python3` interpreter, which will be
-  invoked as a subprocess. */
+  invoked as a subprocess.
+
+  See \ref allow_network "DRAKE_ALLOW_NETWORK" for an environment variable
+  option to disable network fetching. %AddRemote may still be used even with
+  network fetching disabled -- in that case, the urls must contain a "file://"
+  URL or the download cache must already contain a previously-downloaded copy
+  of the package (with the same sha256 checksum). */
   void AddRemote(std::string package_name, RemoteParams params);
 
   /** Crawls down the directory tree starting at `path` searching for

--- a/multibody/parsing/test/package_map_test.cc
+++ b/multibody/parsing/test/package_map_test.cc
@@ -395,7 +395,7 @@ GTEST_TEST(PackageMapTest, TestStreamingToString) {
   for (const auto& it : expected_packages) {
     package_map.Add(it.first, it.second);
   }
-  const std::string url = "http://127.0.0.1/missing.zip";
+  const std::string url = "file:///tmp/missing.zip";
   package_map.AddRemote("remote", {
       .urls = {url},
       .sha256 = std::string(64u, '0')});

--- a/tools/skylark/README.md
+++ b/tools/skylark/README.md
@@ -10,12 +10,25 @@ generic functions such as `pathutils.bzl`, and widely-used but drake-specific
 functions such as the `drake_{cc,java,py,...}.bzl` language-specific helpers.
 
 
-# Common options
+# Options shared across multiple macros
 
 Several of the macros in Drake (e.g., drake_cc_googletest, drake_py_unittest,
 etc.) provide for additional options beyond what is built-in to Bazel.  In
 cases where those options are shared across several different rules, we
 document the option here to avoid repetition.
+
+**allow_network**
+
+A list of components allowed to use the network, per IsNetworkingAllowed()
+in drake/common/network_policy.h. When empty or not set, defaults to allowing
+["meshcat"] but nothing else. You can set it to ["none"] to deny everything.
+
+We allow meshcat by default because it's mostly harmless, a bajillion tests use
+it by default, and it doesn't seem worthwhile to try to allow-list them all.
+
+Note that this does not affect network sandboxing (i.e., Bazel's block-network
+tag). Code outside of Drake purview can still access the network in tests (e.g.,
+license servers for commercial solvers).
 
 **num_threads**
 

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -1,5 +1,9 @@
 load("@cc//:compiler.bzl", "COMPILER_ID", "COMPILER_VERSION_MAJOR")
-load("//tools/skylark:kwargs.bzl", "incorporate_num_threads")
+load(
+    "//tools/skylark:kwargs.bzl",
+    "incorporate_allow_network",
+    "incorporate_num_threads",
+)
 
 # The CXX_FLAGS will be enabled for all C++ rules in the project
 # building with any compiler.
@@ -778,6 +782,7 @@ def drake_cc_test(
         copts = [],
         gcc_copts = [],
         clang_copts = [],
+        allow_network = None,
         num_threads = None,
         **kwargs):
     """Creates a rule to declare a C++ unit test.  Note that for almost all
@@ -787,6 +792,9 @@ def drake_cc_test(
     By default, sets name="test/${name}.cc" per Drake's filename convention.
     Unconditionally forces testonly=1.
 
+    @param allow_network (optional, default is ["meshcat"])
+        See drake/tools/skylark/README.md for details.
+
     @param num_threads (optional, default is 1)
         See drake/tools/skylark/README.md for details.
     """
@@ -795,6 +803,7 @@ def drake_cc_test(
     if not srcs:
         srcs = ["test/%s.cc" % name]
     kwargs["testonly"] = 1
+    kwargs = incorporate_allow_network(kwargs, allow_network = allow_network)
     kwargs = incorporate_num_threads(kwargs, num_threads = num_threads)
     new_copts = _platform_copts(copts, gcc_copts, clang_copts, cc_test = 1)
     new_srcs, add_deps = _maybe_add_pruned_private_hdrs_dep(

--- a/tools/skylark/drake_py.bzl
+++ b/tools/skylark/drake_py.bzl
@@ -1,5 +1,10 @@
 load("//tools/skylark:py.bzl", "py_binary", "py_library", "py_test")
-load("//tools/skylark:kwargs.bzl", "amend", "incorporate_num_threads")
+load(
+    "//tools/skylark:kwargs.bzl",
+    "amend",
+    "incorporate_allow_network",
+    "incorporate_num_threads",
+)
 
 def drake_py_library(
         name,
@@ -174,6 +179,9 @@ def drake_py_unittest(
     contain a __main__ handler nor a shebang line.  By default, sets test size
     to "small" to indicate a unit test.
 
+    @param allow_network (optional, default is ["meshcat"])
+        See drake/tools/skylark/README.md for details.
+
     @param num_threads (optional, default is 1)
         See drake/tools/skylark/README.md for details.
     """
@@ -182,6 +190,8 @@ def drake_py_unittest(
         fail("Changing srcs= is not allowed by drake_py_unittest." +
              " Use drake_py_test instead, if you need something weird.")
     srcs = ["test/%s.py" % name, helper]
+    allow_network = kwargs.pop("allow_network", None)
+    kwargs = incorporate_allow_network(kwargs, allow_network = allow_network)
     num_threads = kwargs.pop("num_threads", 1)
     kwargs = incorporate_num_threads(kwargs, num_threads = num_threads)
     drake_py_test(
@@ -203,6 +213,7 @@ def drake_py_test(
         deps = None,
         isolate = True,
         allow_import_unittest = False,
+        allow_network = None,
         num_threads = None,
         **kwargs):
     """A wrapper to insert Drake-specific customizations.
@@ -219,6 +230,9 @@ def drake_py_test(
         tests should use the `drake_py_unittest` macro instead of this one
         (thus disabling this interlock), but can override this parameter in
         case something unique is happening and the other macro can't be used.
+
+    @param allow_network (optional, default is ["meshcat"])
+        See drake/tools/skylark/README.md for details.
 
     @param num_threads (optional, default is 1)
         See drake/tools/skylark/README.md for details.

--- a/tools/skylark/kwargs.bzl
+++ b/tools/skylark/kwargs.bzl
@@ -78,3 +78,13 @@ def incorporate_num_threads(kwargs, *, num_threads):
         "GUROBI_NUM_THREADS": str(num_threads),
     })
     return kwargs
+
+def incorporate_allow_network(kwargs, *, allow_network):
+    if allow_network == None or len(allow_network) == 0:
+        allow_network = "meshcat"
+    else:
+        allow_network = ":".join(allow_network)
+    kwargs = amend(kwargs, "env", update = {
+        "DRAKE_ALLOW_NETWORK": allow_network,
+    })
+    return kwargs


### PR DESCRIPTION
Towards #15774 and #19046.  I think it's important to have our test-fixtures fail fast when PackageMap is going to hit the internet, before we can land #19046.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19050)
<!-- Reviewable:end -->
