### PR TITLE
[visualization] By default, Meshcat proximity geometry is hidden

### DIFF
--- a/bindings/pydrake/geometry/test/visualizers_test.py
+++ b/bindings/pydrake/geometry/test/visualizers_test.py
@@ -274,6 +274,7 @@ class TestGeometryVisualizers(unittest.TestCase):
         params.default_color = mut.Rgba(0.5, 0.5, 0.5)
         params.prefix = "py_visualizer"
         params.delete_on_initialization_event = False
+        params.visible_by_default = True
         self.assertIn("publish_period", repr(params))
         copy.copy(params)
         vis = mut.MeshcatVisualizer_[T](meshcat=meshcat, params=params)

--- a/bindings/pydrake/visualization/_model_visualizer.py
+++ b/bindings/pydrake/visualization/_model_visualizer.py
@@ -313,10 +313,6 @@ class ModelVisualizer:
         # Publish draw messages with current state.
         self._diagram.ForcedPublish(self._context)
 
-        # Disable the proximity geometry at the start; it can be enabled by
-        # the checkbox in the meshcat controls.
-        self._meshcat.SetProperty("proximity", "visible", False)
-
         self._check_rep(finalized=True)
 
     def _reload(self):

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -599,6 +599,7 @@ drake_cc_googletest(
         "//multibody/plant",
         "//systems/analysis:simulator",
         "//systems/primitives:constant_vector_source",
+        "@msgpack_internal//:msgpack",
     ],
 )
 

--- a/geometry/meshcat_visualizer.cc
+++ b/geometry/meshcat_visualizer.cc
@@ -224,6 +224,7 @@ template <typename T>
 systems::EventStatus MeshcatVisualizer<T>::OnInitialization(
     const systems::Context<T>&) const {
   Delete();
+  meshcat_->SetProperty(params_.prefix, "visible", params_.visible_by_default);
   return systems::EventStatus::Succeeded();
 }
 

--- a/geometry/meshcat_visualizer_params.h
+++ b/geometry/meshcat_visualizer_params.h
@@ -21,6 +21,7 @@ struct MeshcatVisualizerParams {
     a->Visit(DRAKE_NVP(prefix));
     a->Visit(DRAKE_NVP(delete_on_initialization_event));
     a->Visit(DRAKE_NVP(enable_alpha_slider));
+    a->Visit(DRAKE_NVP(visible_by_default));
   }
 
   /** The duration (in simulation seconds) between attempts to update poses in
@@ -50,6 +51,9 @@ struct MeshcatVisualizerParams {
 
   /** Determines whether to enable the alpha slider for geometry display. */
   bool enable_alpha_slider{false};
+
+  /** Determines whether our meshcat path should be default to being visible. */
+  bool visible_by_default{true};
 };
 
 }  // namespace geometry

--- a/visualization/test/visualization_config_functions_test.cc
+++ b/visualization/test/visualization_config_functions_test.cc
@@ -74,6 +74,7 @@ GTEST_TEST(VisualizationConfigFunctionsTest, ParamConversionDefault) {
             config.delete_on_initialization_event);
   EXPECT_EQ(meshcat_params.at(0).enable_alpha_slider,
             config.enable_alpha_sliders);
+  EXPECT_EQ(meshcat_params.at(0).visible_by_default, true);
 
   EXPECT_EQ(meshcat_params.at(1).role, Role::kProximity);
   EXPECT_EQ(meshcat_params.at(1).publish_period, config.publish_period);
@@ -82,6 +83,7 @@ GTEST_TEST(VisualizationConfigFunctionsTest, ParamConversionDefault) {
             config.delete_on_initialization_event);
   EXPECT_EQ(meshcat_params.at(1).enable_alpha_slider,
             config.enable_alpha_sliders);
+  EXPECT_EQ(meshcat_params.at(1).visible_by_default, false);
 
   const ContactVisualizerParams contact_params =
       ConvertVisualizationConfigToMeshcatContactParams(config);

--- a/visualization/visualization_config_functions.cc
+++ b/visualization/visualization_config_functions.cc
@@ -151,6 +151,7 @@ std::vector<MeshcatVisualizerParams> ConvertVisualizationConfigToMeshcatParams(
     illustration.delete_on_initialization_event =
         config.delete_on_initialization_event;
     illustration.enable_alpha_slider = config.enable_alpha_sliders;
+    illustration.visible_by_default = true;
     result.push_back(illustration);
   }
 
@@ -163,6 +164,7 @@ std::vector<MeshcatVisualizerParams> ConvertVisualizationConfigToMeshcatParams(
     proximity.delete_on_initialization_event =
         config.delete_on_initialization_event;
     proximity.enable_alpha_slider = config.enable_alpha_sliders;
+    proximity.visible_by_default = false;
     result.push_back(proximity);
   }
 


### PR DESCRIPTION
Amends #18409.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19058)
<!-- Reviewable:end -->
