### PR TITLE
Add names to visualization systems (when possible)

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -579,6 +579,8 @@ void DoScalarDependentDefinitions(py::module m) {
             return out;
           },
           doc.DiagramBuilder.GetMutableSystems.doc)
+      .def("HasSubsystemNamed", &DiagramBuilder<T>::HasSubsystemNamed,
+          py::arg("name"), doc.DiagramBuilder.HasSubsystemNamed.doc)
       .def("GetSubsystemByName", &DiagramBuilder<T>::GetSubsystemByName,
           py::arg("name"), py_rvp::reference_internal,
           doc.DiagramBuilder.GetSubsystemByName.doc)

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -1041,6 +1041,8 @@ Note: The above is for the C++ documentation. For Python, use
             // Keep alive, ownership: `return` keeps `Context` alive.
             py::keep_alive<0, 3>(),
             doc.Diagram.GetMutableSubsystemState.doc_2args_subsystem_context)
+        .def("HasSubsystemNamed", &Diagram<T>::HasSubsystemNamed,
+            py::arg("name"), doc.Diagram.HasSubsystemNamed.doc)
         .def("GetSubsystemByName", &Diagram<T>::GetSubsystemByName,
             py::arg("name"), py_rvp::reference_internal,
             doc.Diagram.GetSubsystemByName.doc)

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -535,6 +535,7 @@ class TestGeneral(unittest.TestCase):
 
         diagram = builder.Build()
         self.assertEqual(adder0.get_name(), "adder0")
+        self.assertTrue(diagram.HasSubsystemNamed("adder0"))
         self.assertEqual(diagram.GetSubsystemByName("adder0"), adder0)
         self.assertEqual(
             diagram.GetSystems(),
@@ -886,6 +887,7 @@ class TestGeneral(unittest.TestCase):
             builder.ExportInput(adder1.get_input_port(0), "in0")
             builder.ExportInput(adder1.get_input_port(1), "in1")
             builder.ExportOutput(adder2.get_output_port(), "out")
+            self.assertTrue(builder.HasSubsystemNamed("adder1"))
             builder.GetSubsystemByName(name="adder1")
             builder.GetMutableSubsystemByName(name="adder2")
             self.assertEqual(len(builder.connection_map()), 1)

--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -526,8 +526,13 @@ const DrakeVisualizer<T>& DrakeVisualizer<T>::AddToBuilder(
     systems::DiagramBuilder<T>* builder,
     const systems::OutputPort<T>& query_object_port,
     lcm::DrakeLcmInterface* lcm, DrakeVisualizerParams params) {
+  const std::string aspirational_name =
+      fmt::format("drake_visualizer({})", params.role);
   auto& visualizer =
       *builder->template AddSystem<DrakeVisualizer<T>>(lcm, std::move(params));
+  if (!builder->HasSubsystemNamed(aspirational_name)) {
+    visualizer.set_name(aspirational_name);
+  }
   builder->Connect(query_object_port, visualizer.query_object_input_port());
   return visualizer;
 }

--- a/geometry/drake_visualizer.h
+++ b/geometry/drake_visualizer.h
@@ -199,13 +199,19 @@ class DrakeVisualizer final : public systems::LeafSystem<T> {
   //@{
 
   /** Connects the newly added DrakeVisualizer to the given SceneGraph's
-   QueryObject-valued output port.  */
+   QueryObject-valued output port.
+   The %DrakeVisualizer's name (see systems::SystemBase::set_name) will be set
+   to a sensible default value, unless the default name was already in use by
+   another system. */
   static const DrakeVisualizer<T>& AddToBuilder(
       systems::DiagramBuilder<T>* builder, const SceneGraph<T>& scene_graph,
       lcm::DrakeLcmInterface* lcm = nullptr, DrakeVisualizerParams params = {});
 
   /** Connects the newly added DrakeVisualizer to the given QueryObject-valued
-   output port.  */
+   output port.
+   The %DrakeVisualizer's name (see systems::SystemBase::set_name) will be set
+   to a sensible default value, unless the default name was already in use by
+   another system. */
   static const DrakeVisualizer<T>& AddToBuilder(
       systems::DiagramBuilder<T>* builder,
       const systems::OutputPort<T>& query_object_port,

--- a/geometry/meshcat_visualizer.cc
+++ b/geometry/meshcat_visualizer.cc
@@ -100,8 +100,13 @@ MeshcatVisualizer<T>& MeshcatVisualizer<T>::AddToBuilder(
     systems::DiagramBuilder<T>* builder,
     const systems::OutputPort<T>& query_object_port,
     std::shared_ptr<Meshcat> meshcat, MeshcatVisualizerParams params) {
+  const std::string aspirational_name =
+      fmt::format("meshcat_visualizer({})", params.prefix);
   auto& visualizer = *builder->template AddSystem<MeshcatVisualizer<T>>(
       std::move(meshcat), std::move(params));
+  if (!builder->HasSubsystemNamed(aspirational_name)) {
+    visualizer.set_name(aspirational_name);
+  }
   builder->Connect(query_object_port, visualizer.query_object_input_port());
   return visualizer;
 }

--- a/geometry/meshcat_visualizer.h
+++ b/geometry/meshcat_visualizer.h
@@ -133,14 +133,20 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
   /** Adds a MeshcatVisualizer and connects it to the given SceneGraph's
    QueryObject-valued output port. See
    MeshcatVisualizer::MeshcatVisualizer(MeshcatVisualizer*,
-   MeshcatVisualizerParams) for details. */
+   MeshcatVisualizerParams) for details.
+   The %MeshcatVisualizer's name (see systems::SystemBase::set_name) will be set
+   to a sensible default value, unless the default name was already in use by
+   another system. */
   static MeshcatVisualizer<T>& AddToBuilder(
       systems::DiagramBuilder<T>* builder, const SceneGraph<T>& scene_graph,
       std::shared_ptr<Meshcat> meshcat, MeshcatVisualizerParams params = {});
 
   /** Adds a MeshcatVisualizer and connects it to the given QueryObject-valued
    output port. See MeshcatVisualizer::MeshcatVisualizer(MeshcatVisualizer*,
-   MeshcatVisualizerParams) for details. */
+   MeshcatVisualizerParams) for details.
+   The %MeshcatVisualizer's name (see systems::SystemBase::set_name) will be set
+   to a sensible default value, unless the default name was already in use by
+   another system. */
   static MeshcatVisualizer<T>& AddToBuilder(
       systems::DiagramBuilder<T>* builder,
       const systems::OutputPort<T>& query_object_port,

--- a/geometry/test/drake_visualizer_test.cc
+++ b/geometry/test/drake_visualizer_test.cc
@@ -308,6 +308,9 @@ class DrakeVisualizerTest : public ::testing::Test {
           visualizer.query_object_input_port().template Eval<QueryObject<T>>(
               viz_context);
 
+      /* Confirm correct name.  */
+      EXPECT_EQ(visualizer.get_name(), "drake_visualizer(illustration)");
+
       /* Confirm correct connection.  */
       EXPECT_TRUE(sg_query_object.inspector().geometry_version().IsSameAs(
           viz_query_object.inspector().geometry_version(),
@@ -345,6 +348,7 @@ class DrakeVisualizerTest : public ::testing::Test {
                                          Rgba{0.1, 0.2, 0.3, 0.4}};
       const auto& visualizer =
           add_to_builder(&builder, port_source(scene_graph), &lcm_, params);
+      EXPECT_EQ(visualizer.get_name(), "drake_visualizer(perception)");
       const DrakeVisualizerParams& vis_params = Tester::get_params(visualizer);
       EXPECT_EQ(vis_params.publish_period, params.publish_period);
       EXPECT_EQ(vis_params.role, params.role);

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -144,6 +144,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Prefix) {
   // Absolute path.
   params.prefix = "/foo";
   SetUpDiagram(params);
+  EXPECT_EQ(visualizer_->get_name(), "meshcat_visualizer(/foo)");
   EXPECT_FALSE(meshcat_->HasPath("/foo/iiwa14"));
   diagram_->ForcedPublish(*context_);
   EXPECT_TRUE(meshcat_->HasPath("/foo/iiwa14"));
@@ -153,6 +154,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Prefix) {
   params.prefix = "foo";
   EXPECT_FALSE(meshcat_->HasPath("/drake/foo/iiwa14"));
   SetUpDiagram(params);
+  EXPECT_EQ(visualizer_->get_name(), "meshcat_visualizer(foo)");
   diagram_->ForcedPublish(*context_);
   EXPECT_TRUE(meshcat_->HasPath("/drake/foo/iiwa14"));
   EXPECT_FALSE(meshcat_->HasPath("/drake/visualizer"));

--- a/multibody/meshcat/contact_visualizer.cc
+++ b/multibody/meshcat/contact_visualizer.cc
@@ -129,6 +129,10 @@ const ContactVisualizer<T>& ContactVisualizer<T>::AddToBuilder(
   DRAKE_THROW_UNLESS(builder != nullptr);
   auto& result = *builder->template AddSystem<ContactVisualizer<T>>(
       std::move(meshcat), std::move(params));
+  const std::string aspirational_name = "meshcat_contact_visualizer";
+  if (!builder->HasSubsystemNamed(aspirational_name)) {
+    result.set_name(aspirational_name);
+  }
   builder->Connect(contact_results_port, result.contact_results_input_port());
   builder->Connect(query_object_port, result.query_object_input_port());
   return result;
@@ -141,6 +145,10 @@ const ContactVisualizer<T>& ContactVisualizer<T>::AddToBuilder(
   DRAKE_THROW_UNLESS(builder != nullptr);
   auto& result = *builder->template AddSystem<ContactVisualizer<T>>(
       std::move(meshcat), std::move(params));
+  const std::string aspirational_name = "meshcat_contact_visualizer";
+  if (!builder->HasSubsystemNamed(aspirational_name)) {
+    result.set_name(aspirational_name);
+  }
   builder->Connect(contact_results_port, result.contact_results_input_port());
   return result;
 }

--- a/multibody/meshcat/contact_visualizer.h
+++ b/multibody/meshcat/contact_visualizer.h
@@ -89,7 +89,10 @@ class ContactVisualizer final : public systems::LeafSystem<T> {
 
   /** Adds a ContactVisualizer and connects it to the given
   MultibodyPlant's multibody::ContactResults-valued output port and
-  geometry::QueryObject-valued output port. */
+  geometry::QueryObject-valued output port.
+  The %ContactVisualizer's name (see systems::SystemBase::set_name) will be set
+  to a sensible default value, unless the default name was already in use by
+  another system. */
   static const ContactVisualizer<T>& AddToBuilder(
       systems::DiagramBuilder<T>* builder, const MultibodyPlant<T>& plant,
       std::shared_ptr<geometry::Meshcat> meshcat,
@@ -97,7 +100,10 @@ class ContactVisualizer final : public systems::LeafSystem<T> {
 
   /** Adds a ContactVisualizer and connects it to the given
   multibody::ContactResults-valued output port and the given
-  geometry::QueryObject-valued output port. */
+  geometry::QueryObject-valued output port.
+  The %ContactVisualizer's name (see systems::SystemBase::set_name) will be set
+  to a sensible default value, unless the default name was already in use by
+  another system. */
   static const ContactVisualizer<T>& AddToBuilder(
       systems::DiagramBuilder<T>* builder,
       const systems::OutputPort<T>& contact_results_port,
@@ -107,6 +113,9 @@ class ContactVisualizer final : public systems::LeafSystem<T> {
 
   /** Adds a ContactVisualizer and connects it to the given
   multibody::ContactResults-valued output port.
+  The %ContactVisualizer's name (see systems::SystemBase::set_name) will be set
+  to a sensible default value, unless the default name was already in use by
+  another system.
   @warning This overload is dispreferred because it cannot show any geometry
   names in the visualizer. */
   static const ContactVisualizer<T>& AddToBuilder(

--- a/multibody/meshcat/test/contact_visualizer_test.cc
+++ b/multibody/meshcat/test/contact_visualizer_test.cc
@@ -109,6 +109,7 @@ class ContactVisualizerTest : public ::testing::Test {
 
   void PublishAndCheck(
       bool expect_geometry_names = false) {
+    EXPECT_EQ(visualizer_->get_name(), "meshcat_contact_visualizer");
     diagram_->ForcedPublish(*context_);
     if (expect_geometry_names) {
       EXPECT_TRUE(meshcat_->HasPath(

--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -352,6 +352,16 @@ void Diagram<T>::DoCalcImplicitTimeDerivativesResidual(
 }
 
 template <typename T>
+bool Diagram<T>::HasSubsystemNamed(std::string_view name) const {
+  for (const auto& child : registered_systems_) {
+    if (child->get_name() == name) {
+      return true;
+    }
+  }
+  return false;
+}
+
+template <typename T>
 const System<T>& Diagram<T>::GetSubsystemByName(std::string_view name) const {
   for (const auto& child : registered_systems_) {
     if (child->get_name() == name) {

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -140,6 +140,10 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
 
   std::unique_ptr<DiscreteValues<T>> AllocateDiscreteVariables() const final;
 
+  /// Returns true iff this contains a subsystem with the given name.
+  /// @see GetSubsystemByName()
+  bool HasSubsystemNamed(std::string_view name) const;
+
   /// Retrieves a const reference to the subsystem with name @p name returned
   /// by get_name().
   /// @throws std::exception if a match cannot be found.

--- a/systems/framework/diagram_builder.cc
+++ b/systems/framework/diagram_builder.cc
@@ -41,6 +41,16 @@ std::vector<System<T>*> DiagramBuilder<T>::GetMutableSystems() {
 }
 
 template <typename T>
+bool DiagramBuilder<T>::HasSubsystemNamed(std::string_view name) const {
+  for (const auto& child : registered_systems_) {
+    if (child->get_name() == name) {
+      return true;
+    }
+  }
+  return false;
+}
+
+template <typename T>
 const System<T>& DiagramBuilder<T>::GetSubsystemByName(
     std::string_view name) const {
   ThrowIfAlreadyBuilt();

--- a/systems/framework/diagram_builder.h
+++ b/systems/framework/diagram_builder.h
@@ -266,6 +266,10 @@ class DiagramBuilder {
   /// @see GetSystems()
   std::vector<System<T>*> GetMutableSystems();
 
+  /// Returns true iff this contains a subsystem with the given name.
+  /// @see GetSubsystemByName()
+  bool HasSubsystemNamed(std::string_view name) const;
+
   /// Retrieves a const reference to the subsystem with name @p name returned
   /// by get_name().
   /// @throws std::exception if a unique match cannot be found.

--- a/systems/framework/test/diagram_builder_test.cc
+++ b/systems/framework/test/diagram_builder_test.cc
@@ -716,6 +716,9 @@ GTEST_TEST(DiagramBuilderTest, GetByName) {
   DiagramBuilder<double> builder;
   auto adder = builder.AddNamedSystem<Adder>("adder", 1, 1);
   auto pass = builder.AddNamedSystem<PassThrough>("pass", 1);
+  EXPECT_TRUE(builder.HasSubsystemNamed("adder"));
+  EXPECT_TRUE(builder.HasSubsystemNamed("pass"));
+  EXPECT_FALSE(builder.HasSubsystemNamed("no-such-name"));
 
   // Plain by-name.
   EXPECT_EQ(&builder.GetSubsystemByName("adder"), adder);
@@ -755,12 +758,14 @@ GTEST_TEST(DiagramBuilderTest, GetByName) {
   // not the "pass" anymore
   auto bonus_pass = builder.AddNamedSystem<PassThrough>("pass", 1);
   EXPECT_EQ(&builder.GetSubsystemByName("adder"), adder);
+  EXPECT_TRUE(builder.HasSubsystemNamed("pass"));
   DRAKE_EXPECT_THROWS_MESSAGE(
       builder.GetMutableSubsystemByName("pass"),
       ".*multiple subsystems.*pass.*unique.*");
 
   // Once the system is reset to use unique name, both lookups succeed.
   bonus_pass->set_name("bonus_pass");
+  EXPECT_TRUE(builder.HasSubsystemNamed("bonus_pass"));
   EXPECT_EQ(&builder.GetSubsystemByName("pass"), pass);
   EXPECT_EQ(&builder.GetSubsystemByName("bonus_pass"), bonus_pass);
 }

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -974,11 +974,13 @@ TEST_F(DiagramTest, AllocateInputs) {
 }
 
 TEST_F(DiagramTest, GetSubsystemByName) {
+  EXPECT_TRUE(diagram_->HasSubsystemNamed("stateless"));
   const System<double>& stateless = diagram_->GetSubsystemByName("stateless");
   EXPECT_NE(
       dynamic_cast<const StatelessSystem<double>*>(&stateless),
       nullptr);
 
+  EXPECT_FALSE(diagram_->HasSubsystemNamed("not_a_subsystem"));
   DRAKE_EXPECT_THROWS_MESSAGE(
       diagram_->GetSubsystemByName("not_a_subsystem"),
       "System .* does not have a subsystem named not_a_subsystem");

--- a/visualization/test/visualization_config_functions_test.cc
+++ b/visualization/test/visualization_config_functions_test.cc
@@ -157,11 +157,11 @@ GTEST_TEST(VisualizationConfigFunctionsTest, ApplyDefault) {
   // Check that systems that we expect to have been added were actually added.
   for (const auto& name : {
            // For Meldis.
-           "DrakeVisualizer",
+           "drake_visualizer",
            "contact_results_publisher",
            // For Meshcat.
-           "MeshcatVisualizer",
-           "ContactVisualizer",
+           "meshcat_visualizer",
+           "meshcat_contact_visualizer",
        }) {
     SCOPED_TRACE(fmt::format("Checking for a system named like {}", name));
     int count = 0;
@@ -253,7 +253,7 @@ GTEST_TEST(VisualizationConfigFunctionsTest, NoMeshcat) {
   int meshcat_count = 0;
   for (const auto* system : builder.GetSystems()) {
     const std::string& name = system->get_name();
-    if (name.find("MeshcatVisualizer") != std::string::npos) {
+    if (name.find("meshcat_visualizer") != std::string::npos) {
       ++meshcat_count;
     }
   }


### PR DESCRIPTION
This was of interest to Russ so he could customize the systems _after_ they were added to the diagram.  Our config-application functions don't return pointers to the (many!) subsystems that they add, so the user needs to find them by name.  When they were memory-object names, that was not very easy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19075)
<!-- Reviewable:end -->
