### PR TITLE
[setup] Drop vestigial meshcat dependencies

### DIFF
--- a/setup/mac/binary_distribution/requirements.txt
+++ b/setup/mac/binary_distribution/requirements.txt
@@ -4,6 +4,3 @@ notebook
 Pillow
 pydot
 PyYAML
-pyzmq
-tornado
-u-msgpack-python

--- a/setup/mac/source_distribution/requirements-test-only.txt
+++ b/setup/mac/source_distribution/requirements-test-only.txt
@@ -2,4 +2,5 @@ flask
 jupyter
 pandas
 six
+u-msgpack-python
 websockets

--- a/setup/ubuntu/binary_distribution/packages-focal.txt
+++ b/setup/ubuntu/binary_distribution/packages-focal.txt
@@ -22,7 +22,6 @@ libjsoncpp1
 liblapack3
 liblz4-1
 liblzma5
-libmsgpackc2
 libmumps-seq-5.2.1
 libnetcdf15
 libnlopt-cxx0
@@ -49,8 +48,5 @@ python3-numpy
 python3-pil
 python3-pydot
 python3-pygame
-python3-tornado
-python3-u-msgpack
 python3-yaml
-python3-zmq
 zlib1g

--- a/setup/ubuntu/binary_distribution/packages-jammy.txt
+++ b/setup/ubuntu/binary_distribution/packages-jammy.txt
@@ -22,7 +22,6 @@ libjsoncpp25
 liblapack3
 liblz4-1
 liblzma5
-libmsgpackc2
 libmumps-seq-5.4
 libnetcdf19
 libnlopt-cxx0
@@ -51,8 +50,5 @@ python3-numpy
 python3-pil
 python3-pydot
 python3-pygame
-python3-tornado
-python3-u-msgpack
 python3-yaml
-python3-zmq
 zlib1g

--- a/setup/ubuntu/source_distribution/packages-focal-test-only.txt
+++ b/setup/ubuntu/source_distribution/packages-focal-test-only.txt
@@ -14,9 +14,9 @@ python3-pandas
 python3-psutil
 python3-requests
 python3-six
+python3-u-msgpack
 python3-uritemplate
 python3-websockets
 python3-yaml-dbg
-python3-zmq-dbg
 valgrind
 valgrind-dbg

--- a/setup/ubuntu/source_distribution/packages-jammy-test-only.txt
+++ b/setup/ubuntu/source_distribution/packages-jammy-test-only.txt
@@ -11,6 +11,7 @@ python3-pandas
 python3-psutil
 python3-requests
 python3-six
+python3-u-msgpack
 python3-uritemplate
 python3-websockets
 valgrind

--- a/tools/wheel/image/setup.py
+++ b/tools/wheel/image/setup.py
@@ -7,10 +7,8 @@ from setuptools import setup, find_packages, glob
 DRAKE_VERSION = os.environ.get('DRAKE_VERSION', '0.0.0')
 
 # Required python packages that will be pip installed along with pydrake
-# TODO Can we remove any of these?
 python_required = [
     'matplotlib',
-    'meshcat',
     'numpy',
     'pydot',
     'PyYAML',


### PR DESCRIPTION
Closes #19039.

Note that we cannot drop `libmsgpack-dev` from the setup scripts until the deprecation window for #18559 closes.

We keep `u-msgpack` as testonly because the `geometry/test/meshcat_websocket_client.py` still uses it.

---

Ubuntu Wheel testing:

```console
jwnimmer@call-cps:~/tmp$ python3 -m venv env
jwnimmer@call-cps:~/tmp$ env/bin/pip install https://drake-packages.csail.mit.edu/drake/experimental/drake-0.0.2023.3.28.19.34.49%2Bgita4109729-cp310-cp310-manylinux_2_31_x86_64.whl
Collecting drake==0.0.2023.3.28.19.34.49+gita4109729
...
jwnimmer@call-cps:~/tmp$ env/bin/python3 -c 'import pydrake.all'
jwnimmer@call-cps:~/tmp$ echo $?
0
```

---

macOS Wheel testing:

```console
% python3 --version
Python 3.11.2
% python3 -m venv env
% env/bin/pip install https://drake-packages.csail.mit.edu/drake/experimental/drake-0.0.2023.3.28.15.34.58%2Bgita4109729-cp311-cp311-macosx_12_0_arm64.whl
% env/bin/python3 -c 'import pydrake.all'
% echo $?
0
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19080)
<!-- Reviewable:end -->
