### PR TITLE
Fix the ordering of the Delassus operator approximation

### DIFF
--- a/multibody/contact_solvers/sap/sap_model.cc
+++ b/multibody/contact_solvers/sap/sap_model.cc
@@ -430,13 +430,8 @@ void SapModel<T>::CalcDelassusDiagonalApproximation(
   // Compute Delassus_diagonal as the rms norm of the diagonal block for the
   // i-th constraint.
   delassus_diagonal->resize(num_constraints);
-  int permuted_constraint_index = 0;
-  for (const ContactProblemGraph::ConstraintCluster& e :
-       problem().graph().clusters()) {
-    for (int i : e.constraint_index()) {
-      (*delassus_diagonal)[permuted_constraint_index++] =
-          W[i].norm() / W[i].rows();
-    }
+  for (int i = 0; i < num_constraints; ++i) {
+    (*delassus_diagonal)[i] = W[i].norm() / W[i].rows();
   }
 }
 


### PR DESCRIPTION
Both `SapConstraintBundle`'s constructor and `SapModel::CalcDelassusDiagonalApproximation()` document that the Delassus operator diagonal approximation is stored in the order constraints are enumerated in `SapProblem`.

`SapConstraintBundle` expects this order. However, `SapModel::CalcDelassusDiagonalApproximation()` was inconsistently ordering them by cluster. This can lead to very bad scaling of the constraints, specially so in problems with large mass ratios.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19082)
<!-- Reviewable:end -->
