### PR TITLE
[multibody] Add MatrixBlock class

### DIFF
--- a/multibody/contact_solvers/BUILD.bazel
+++ b/multibody/contact_solvers/BUILD.bazel
@@ -20,6 +20,7 @@ drake_cc_package_library(
         ":contact_solver_results",
         ":contact_solver_utils",
         ":linear_operator",
+        ":matrix_block",
         ":newton_with_bisection",
         ":pgs_solver",
         ":point_contact_data",
@@ -104,6 +105,17 @@ drake_cc_library(
         "//common:default_scalars",
         "//common:essential",
         "//common:nice_type_name",
+    ],
+)
+
+drake_cc_library(
+    name = "matrix_block",
+    srcs = ["matrix_block.cc"],
+    hdrs = ["matrix_block.h"],
+    deps = [
+        ":block_3x3_sparse_matrix",
+        "//common:default_scalars",
+        "//common:essential",
     ],
 )
 
@@ -197,6 +209,14 @@ drake_cc_googletest(
         ":block_sparse_matrix",
         ":linear_operator",
         "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "matrix_block_test",
+    deps = [
+        ":matrix_block",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/multibody/contact_solvers/matrix_block.cc
+++ b/multibody/contact_solvers/matrix_block.cc
@@ -1,0 +1,249 @@
+#include "drake/multibody/contact_solvers/matrix_block.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+template <class T>
+MatrixBlock<T>::MatrixBlock(Block3x3SparseMatrix<T> data)
+    : data_(std::move(data)), is_dense_(false) {}
+
+template <class T>
+MatrixBlock<T>::MatrixBlock(MatrixX<T> data)
+    : data_(std::move(data)), is_dense_(true) {}
+
+template <class T>
+int MatrixBlock<T>::rows() const {
+  return std::visit(
+      [](auto&& arg) {
+        /* We need the static_cast here because Eigen's rows() is `long`. */
+        return static_cast<int>(arg.rows());
+      },
+      data_);
+}
+
+template <class T>
+int MatrixBlock<T>::cols() const {
+  return std::visit(
+      [](auto&& arg) {
+        /* We need the static_cast here because Eigen's cols() is `long`. */
+        return static_cast<int>(arg.cols());
+      },
+      data_);
+}
+
+template <class T>
+void MatrixBlock<T>::MultiplyAndAddTo(const Eigen::Ref<const MatrixX<T>>& A,
+                                      EigenPtr<MatrixX<T>> y) const {
+  DRAKE_DEMAND(y != nullptr);
+  DRAKE_DEMAND(cols() == A.rows());
+  DRAKE_DEMAND(rows() == y->rows());
+  DRAKE_DEMAND(A.cols() == y->cols());
+
+  if (is_dense_) {
+    const MatrixX<T>& M_dense = std::get<MatrixX<T>>(data_);
+    *y += M_dense * A;
+    return;
+  }
+  const Block3x3SparseMatrix<T>& M_sparse =
+      std::get<Block3x3SparseMatrix<T>>(data_);
+  M_sparse.MultiplyAndAddTo(A, y);
+}
+
+template <class T>
+void MatrixBlock<T>::TransposeAndMultiplyAndAddTo(
+    const Eigen::Ref<const MatrixX<T>>& A, EigenPtr<MatrixX<T>> y) const {
+  DRAKE_DEMAND(y != nullptr);
+  DRAKE_DEMAND(cols() == y->rows());
+  DRAKE_DEMAND(rows() == A.rows());
+  DRAKE_DEMAND(A.cols() == y->cols());
+
+  if (is_dense_) {
+    const MatrixX<T>& M_dense = std::get<MatrixX<T>>(data_);
+    *y += M_dense.transpose() * A;
+    return;
+  }
+  const Block3x3SparseMatrix<T>& M_sparse =
+      std::get<Block3x3SparseMatrix<T>>(data_);
+  M_sparse.TransposeAndMultiplyAndAddTo(A, y);
+}
+
+// TODO(xuchenhan-tri): consider a double dispatch strategy where each block
+// type provides an API to operate on every other block type.
+template <class T>
+void MatrixBlock<T>::TransposeAndMultiplyAndAddTo(const MatrixBlock<T>& A,
+                                                 EigenPtr<MatrixX<T>> y) const {
+  DRAKE_DEMAND(y != nullptr);
+  DRAKE_DEMAND(cols() == y->rows());
+  DRAKE_DEMAND(rows() == A.rows());
+  DRAKE_DEMAND(A.cols() == y->cols());
+  if (A.is_dense_) {
+    const MatrixX<T>& A_dense = std::get<MatrixX<T>>(A.data_);
+    this->TransposeAndMultiplyAndAddTo(A_dense, y);
+    return;
+  }
+
+  /* A is sparse. */
+  const Block3x3SparseMatrix<T>& A_sparse =
+      std::get<Block3x3SparseMatrix<T>>(A.data_);
+  if (this->is_dense_) {
+    const MatrixX<T>& M_dense = std::get<MatrixX<T>>(this->data_);
+    A_sparse.LeftMultiplyAndAddTo(M_dense.transpose(), y);
+    return;
+  }
+
+  /* A and M are both sparse. */
+  const Block3x3SparseMatrix<T>& M_sparse =
+      std::get<Block3x3SparseMatrix<T>>(this->data_);
+  M_sparse.TransposeAndMultiplyAndAddTo(A_sparse, y);
+}
+
+// TODO(xuchenhan-tri): consider a double dispatch strategy where each block
+// type provides an API to operate on every other block type.
+template <class T>
+MatrixBlock<T> MatrixBlock<T>::LeftMultiplyByBlockDiagonal(
+    const std::vector<MatrixX<T>>& Gs, int start, int end) const {
+  DRAKE_DEMAND(start >= 0);
+  DRAKE_DEMAND(end >= start);
+  DRAKE_DEMAND(static_cast<int>(Gs.size()) > end);
+  /* Verify that the sizes of G and M is compatible. */
+  int G_rows = 0;
+  for (int i = start; i <= end; ++i) {
+    DRAKE_DEMAND(Gs[i].rows() == Gs[i].cols());
+    G_rows += Gs[i].rows();
+    if (!is_dense_) {
+      DRAKE_DEMAND(Gs[i].rows() == 3);
+    }
+  }
+  DRAKE_DEMAND(G_rows == rows());
+
+  if (is_dense_) {
+    const MatrixX<T>& M_dense = std::get<MatrixX<T>>(data_);
+    MatrixX<T> GM(rows(), cols());
+    int row_offset = 0;
+    for (int i = start; i <= end; ++i) {
+      const int rows = Gs[i].rows();
+      GM.middleRows(row_offset, rows).noalias() =
+          Gs[i] * M_dense.middleRows(row_offset, rows);
+      row_offset += rows;
+    }
+    return MatrixBlock<T>(std::move(GM));
+  }
+
+  const Block3x3SparseMatrix<T>& M_sparse =
+      std::get<Block3x3SparseMatrix<T>>(data_);
+  Block3x3SparseMatrix<T> GM(M_sparse.block_rows(), M_sparse.block_cols());
+  using Triplet = typename Block3x3SparseMatrix<T>::Triplet;
+  const std::vector<std::vector<Triplet>>& M_triplets = M_sparse.get_triplets();
+  std::vector<Triplet> GM_triplets;
+  GM_triplets.reserve(M_sparse.num_blocks());
+  for (const auto& row_data : M_triplets) {
+    for (const Triplet& t : row_data) {
+      const int block_row = std::get<0>(t);
+      const int block_col = std::get<1>(t);
+      const Matrix3<T>& M_block = std::get<2>(t);
+      GM_triplets.emplace_back(block_row, block_col,
+                               Gs[start + block_row] * M_block);
+    }
+  }
+  GM.SetFromTriplets(GM_triplets);
+  return MatrixBlock<T>(std::move(GM));
+}
+
+template <class T>
+void MatrixBlock<T>::MultiplyWithScaledTransposeAndAddTo(
+    const VectorX<T>& scale, EigenPtr<MatrixX<T>> y) const {
+  DRAKE_DEMAND(y != nullptr);
+  DRAKE_DEMAND(cols() == scale.size());
+  DRAKE_DEMAND(rows() == y->rows());
+  DRAKE_DEMAND(rows() == y->cols());
+
+  if (is_dense_) {
+    const MatrixX<T>& M_dense = std::get<MatrixX<T>>(data_);
+    *y += M_dense * scale.asDiagonal() * M_dense.transpose();
+    return;
+  }
+  const Block3x3SparseMatrix<T>& M_sparse =
+      std::get<Block3x3SparseMatrix<T>>(data_);
+  M_sparse.MultiplyWithScaledTransposeAndAddTo(scale, y);
+}
+
+template <class T>
+MatrixX<T> MatrixBlock<T>::MakeDenseMatrix() const {
+  if (is_dense_) {
+    return std::get<MatrixX<T>>(data_);
+  }
+  return std::get<Block3x3SparseMatrix<T>>(data_).MakeDenseMatrix();
+}
+
+template <typename T>
+MatrixBlock<T> StackMatrixBlocks(const std::vector<MatrixBlock<T>>& blocks) {
+  if (blocks.empty()) {
+    return {};
+  }
+
+  const bool is_dense = blocks[0].is_dense_;
+  const int cols = blocks[0].cols();
+  int rows = 0;
+  for (const auto& b : blocks) {
+    DRAKE_DEMAND(is_dense == b.is_dense_);
+    DRAKE_DEMAND(cols == b.cols());
+    rows += b.rows();
+  }
+
+  if (is_dense) {
+    MatrixX<T> result(rows, cols);
+    int row_offset = 0;
+    for (const auto& b : blocks) {
+      result.middleRows(row_offset, b.rows()) = std::get<MatrixX<T>>(b.data_);
+      row_offset += b.rows();
+    }
+    return MatrixBlock<T>(std::move(result));
+  }
+
+  /* Each entry in `blocks` is Block3x3SparseMatrix. */
+  DRAKE_DEMAND(rows % 3 == 0);
+  DRAKE_DEMAND(cols % 3 == 0);
+  const int block_rows = rows / 3;
+  const int block_cols = cols / 3;
+  int block_row_offset = 0;
+  Block3x3SparseMatrix<T> result(block_rows, block_cols);
+  using Triplet = typename Block3x3SparseMatrix<T>::Triplet;
+  std::vector<Triplet> result_triplets;
+  int nonzero_blocks = 0;
+  for (const auto& b : blocks) {
+    const Block3x3SparseMatrix<T>& entry =
+        std::get<Block3x3SparseMatrix<T>>(b.data_);
+    nonzero_blocks += entry.num_blocks();
+  }
+  result_triplets.reserve(nonzero_blocks);
+
+  for (const auto& b : blocks) {
+    const Block3x3SparseMatrix<T>& entry =
+        std::get<Block3x3SparseMatrix<T>>(b.data_);
+    const std::vector<std::vector<Triplet>>& b_triplets = entry.get_triplets();
+    for (const auto& row_data : b_triplets) {
+      for (const Triplet& t : row_data) {
+        const int block_row = std::get<0>(t) + block_row_offset;
+        const int block_col = std::get<1>(t);
+        const Matrix3<T>& m = std::get<2>(t);
+        result_triplets.emplace_back(block_row, block_col, m);
+      }
+    }
+    block_row_offset += entry.block_rows();
+  }
+  result.SetFromTriplets(result_triplets);
+  return MatrixBlock<T>(std::move(result));
+}
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    (&StackMatrixBlocks<T>))
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::contact_solvers::internal::MatrixBlock)

--- a/multibody/contact_solvers/matrix_block.h
+++ b/multibody/contact_solvers/matrix_block.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/block_3x3_sparse_matrix.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+template <typename T>
+class MatrixBlock;
+
+/* Row-wise concatenates the given vector of MatrixBlocks into a single
+ MatrixBlock. In other words, given blocks [b₁, b₂, ..., bₙ], the resulting
+ stacked matrix M is
+         _    _
+        |  b₁  |
+        |  b₂  |
+    M = |  ... |
+        |  ... |
+        |_ bₙ _|
+
+ @pre all entries in `blocks` have the same `cols()`.
+ @pre either all entries in `blocks` are dense, or all entries in `blocks` are
+ sparse.
+ @returns A MatrixBlock concatenating the given blocks row-wise that's dense if
+ all the given blocks are dense and sparse otherwise.
+ @tparam_default_scalar */
+template <typename T>
+MatrixBlock<T> StackMatrixBlocks(const std::vector<MatrixBlock<T>>& blocks);
+
+/* Data structure to store individual non-zero blocks of BlockSparseMatrix.
+ The MatrixBlock can either be dense or sparse, which is determined by how it is
+ constructed. Right now, the only sparsity pattern supported is block 3-by-3
+ (see Block3x3SparseMatrix). Once constructed, the MatrixBlock cannot change
+ from a dense representation to a sparse one or vice versa. This class provides
+ a series of matrix computation functions that exploits the sparsity if the
+ MatrixBlock is sparse and falls back to dense algebra otherwise. We use `M` to
+ denote `this` MatrixBlock throughout this class.
+ @tparam_default_scalar */
+template <class T>
+class MatrixBlock {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MatrixBlock);
+
+  /* Constructs an empty MatrixBlock of size 0-by-0. */
+  MatrixBlock() : MatrixBlock(MatrixX<T>::Zero(0, 0)) {}
+
+  /* Constructs a MatrixBlock with the given Block3x3SparseMatrix. */
+  explicit MatrixBlock(Block3x3SparseMatrix<T> data);
+
+  /* Constructs a MatrixBlock with the given Eigen dense matrix. */
+  explicit MatrixBlock(MatrixX<T> data);
+
+  int rows() const;
+  int cols() const;
+  int size() const {
+    return rows() * cols();
+  }
+
+  bool is_dense() const {
+    return is_dense_;
+  }
+
+  /* Performs *y += M * A.
+   @pre y != nullptr and the sizes of A and y are compatible with M. */
+  void MultiplyAndAddTo(const Eigen::Ref<const MatrixX<T>>& A,
+                        EigenPtr<MatrixX<T>> y) const;
+
+  /* Performs y += Mᵀ * A.
+   @pre y != nullptr and the sizes of A and y are compatible with M. */
+  void TransposeAndMultiplyAndAddTo(const Eigen::Ref<const MatrixX<T>>& A,
+                                   EigenPtr<MatrixX<T>> y) const;
+
+  // TODO(xuchenhan-tri): Consider writing the output to a MatrixBlock to
+  // preserve the sparsity structure if it exists.
+  /* Performs y += Mᵀ * A.
+   @pre y != nullptr and the sizes of A and y are compatible with M. */
+  void TransposeAndMultiplyAndAddTo(const MatrixBlock<T>& A,
+                                   EigenPtr<MatrixX<T>> y) const;
+
+  /* Computes G * M where G is a block diagonal matrix with the diagonal blocks
+   specified as a vector of dense matrices. In particular, the diagonal blocks
+   are [Gs[start], ..., Gs[end]]. The result is returned as a MatrixBlock,
+   sparse if M is sparse, dense otherwise.
+   @pre 0 <= start <= end < Gs.size().
+   @pre All matrices in Gs are square.
+   @pre Gs[start].rows() + ... + Gs[end].rows() == M.rows().
+   @pre If M is sparse, all matrices in Gs are 3x3. */
+  MatrixBlock<T> LeftMultiplyByBlockDiagonal(const std::vector<MatrixX<T>>& Gs,
+                                             int start, int end) const;
+
+  /* Performs y += M * scale.asDiagonal() * M.transpose().
+   @pre y != nullptr and the sizes of scale and y are compatible with M. */
+  void MultiplyWithScaledTransposeAndAddTo(const VectorX<T>& scale,
+                                         EigenPtr<MatrixX<T>> y) const;
+
+  /* Returns the MatrixBlock as an Eigen dense matrix. Useful for debugging and
+   testing. */
+  MatrixX<T> MakeDenseMatrix() const;
+
+ private:
+  friend MatrixBlock<T> StackMatrixBlocks<T>(
+      const std::vector<MatrixBlock<T>>& blocks);
+
+  std::variant<MatrixX<T>, Block3x3SparseMatrix<T>> data_;
+  bool is_dense_{};
+};
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/test/matrix_block_test.cc
+++ b/multibody/contact_solvers/test/matrix_block_test.cc
@@ -1,0 +1,189 @@
+#include "drake/multibody/contact_solvers/matrix_block.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+namespace {
+
+using Eigen::Matrix3d;
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+
+/* Returns an arbitrary non-zero matrix of size m-by-n.*/
+MatrixXd MakeArbitraryMatrix(int m, int n) {
+  MatrixXd A(m, n);
+  for (int i = 0; i < m; ++i) {
+    for (int j = 0; j < n; ++j) {
+      A(i, j) = 3 * i + 4 * j;
+    }
+  }
+  return A;
+}
+
+/* Returns an arbitrary Block3x3SparseMatrix with size 12-by-9. */
+Block3x3SparseMatrix<double> MakeBlockSparseMatrix() {
+  Block3x3SparseMatrix<double> sparse_matrix(4, 3);
+  std::vector<Block3x3SparseMatrix<double>::Triplet> triplets;
+  triplets.emplace_back(0, 0, Matrix3d::Constant(1.0));
+  triplets.emplace_back(2, 1, Matrix3d::Constant(2.0));
+  triplets.emplace_back(3, 2, Matrix3d::Constant(3.0));
+  sparse_matrix.SetFromTriplets(triplets);
+  EXPECT_EQ(sparse_matrix.num_blocks(), 3);
+  return sparse_matrix;
+}
+
+GTEST_TEST(MatrixBlockTest, Constructors) {
+  Block3x3SparseMatrix<double> sparse = MakeBlockSparseMatrix();
+  MatrixXd dense = sparse.MakeDenseMatrix();
+
+  const MatrixBlock<double> sparse_block(std::move(sparse));
+  const MatrixBlock<double> dense_block(std::move(dense));
+
+  EXPECT_EQ(sparse_block.rows(), 12);
+  EXPECT_EQ(dense_block.rows(), 12);
+  EXPECT_EQ(sparse_block.cols(), 9);
+  EXPECT_EQ(dense_block.cols(), 9);
+  EXPECT_EQ(sparse_block.size(), 12*9);
+  EXPECT_EQ(dense_block.size(), 12*9);
+  EXPECT_FALSE(sparse_block.is_dense());
+  EXPECT_TRUE(dense_block.is_dense());
+
+  EXPECT_TRUE(CompareMatrices(sparse_block.MakeDenseMatrix(),
+                              dense_block.MakeDenseMatrix()));
+}
+
+GTEST_TEST(MatrixBlockTest, MultiplyAndAddTo) {
+  const MatrixXd x = MakeArbitraryMatrix(9, 7);
+  Block3x3SparseMatrix<double> sparse_matrix = MakeBlockSparseMatrix();
+  const MatrixXd dense_matrix = sparse_matrix.MakeDenseMatrix();
+
+  const MatrixBlock<double> sparse_block(std::move(sparse_matrix));
+  const MatrixBlock<double> dense_block(dense_matrix);
+
+  /* Set the destinations to compatible-sized non-zero vectors. */
+  MatrixXd y1 = MakeArbitraryMatrix(12, 7);
+  MatrixXd y2 = y1;
+  MatrixXd expected_y = y1;
+
+  sparse_block.MultiplyAndAddTo(x, &y1);
+  dense_block.MultiplyAndAddTo(x, &y2);
+  expected_y += dense_matrix * x;
+
+  EXPECT_TRUE(CompareMatrices(y1, expected_y));
+  EXPECT_TRUE(CompareMatrices(y2, expected_y));
+}
+
+GTEST_TEST(MatrixBlockTest, TransposeAndMultiplyAndAddTo) {
+  Block3x3SparseMatrix<double> sparse_matrix = MakeBlockSparseMatrix();
+  const MatrixXd dense_matrix = sparse_matrix.MakeDenseMatrix();
+  const MatrixBlock<double> sparse_block(std::move(sparse_matrix));
+  const MatrixBlock<double> dense_block(dense_matrix);
+
+  /* Set destination to be compatible-sized non-zero matrices. */
+  MatrixXd y1 = MakeArbitraryMatrix(9, 9);
+  MatrixXd y2 = y1;
+  MatrixXd y3 = y1;
+  MatrixXd y4 = y1;
+  MatrixXd expected_y = y1;
+
+  expected_y += dense_matrix.transpose() * dense_matrix;
+  sparse_block.TransposeAndMultiplyAndAddTo(dense_block, &y1);
+  sparse_block.TransposeAndMultiplyAndAddTo(sparse_block, &y2);
+  dense_block.TransposeAndMultiplyAndAddTo(dense_block, &y3);
+  dense_block.TransposeAndMultiplyAndAddTo(sparse_block, &y4);
+
+  EXPECT_TRUE(CompareMatrices(y1, expected_y));
+  EXPECT_TRUE(CompareMatrices(y2, expected_y));
+  EXPECT_TRUE(CompareMatrices(y3, expected_y));
+  EXPECT_TRUE(CompareMatrices(y4, expected_y));
+}
+
+GTEST_TEST(MatrixBlockTest, LeftMultiplyByBlockDiagonal) {
+  Block3x3SparseMatrix<double> sparse_matrix = MakeBlockSparseMatrix();
+  const MatrixXd dense_matrix = sparse_matrix.MakeDenseMatrix();
+  const MatrixBlock<double> sparse_block(std::move(sparse_matrix));
+  const MatrixBlock<double> dense_block(dense_matrix);
+
+  const int num_Gs = 7;
+  std::vector<MatrixXd> Gs;
+  for (int i = 0; i < num_Gs; ++i) {
+    Gs.emplace_back(Matrix3d::Constant(3.14 * i));
+  }
+  const int start = 2;
+  const int end = 5;
+  const MatrixBlock<double> sparse_result =
+      sparse_block.LeftMultiplyByBlockDiagonal(Gs, start, end);
+  const MatrixBlock<double> dense_result =
+      dense_block.LeftMultiplyByBlockDiagonal(Gs, start, end);
+
+  /* Compute the expected results using dense matrices. */
+  MatrixXd dense_G = MatrixXd::Zero(12, 12);
+  for (int i = 0; i < 4; ++i) {
+    dense_G.block<3, 3>(3 * i, 3 * i) = Gs[start + i];
+  }
+  MatrixXd expected = dense_G * dense_matrix;
+
+  EXPECT_TRUE(CompareMatrices(sparse_result.MakeDenseMatrix(), expected));
+  EXPECT_TRUE(CompareMatrices(dense_result.MakeDenseMatrix(), expected));
+}
+
+GTEST_TEST(MatrixBlockTest, MultiplyWithScaledTransposeAndAddTo) {
+  Block3x3SparseMatrix<double> sparse_matrix = MakeBlockSparseMatrix();
+  const MatrixXd dense_matrix = sparse_matrix.MakeDenseMatrix();
+  const MatrixBlock<double> sparse_block(std::move(sparse_matrix));
+  const MatrixBlock<double> dense_block(dense_matrix);
+
+  /* Set scale and destination to be compatible-sized non-zero matrices. */
+  const VectorXd scale = MakeArbitraryMatrix(9, 1);
+  MatrixXd y1 = MakeArbitraryMatrix(12, 12);
+  MatrixXd y2 = y1;
+  MatrixXd expected = y1;
+
+  sparse_block.MultiplyWithScaledTransposeAndAddTo(scale, &y1);
+  dense_block.MultiplyWithScaledTransposeAndAddTo(scale, &y2);
+  expected += dense_matrix * scale.asDiagonal() * dense_matrix.transpose();
+  EXPECT_TRUE(CompareMatrices(y1, expected));
+  EXPECT_TRUE(CompareMatrices(y2, expected));
+}
+
+GTEST_TEST(MatrixBlockTest, StackMatrixBlock) {
+  Block3x3SparseMatrix<double> sparse_matrix1 = MakeBlockSparseMatrix();
+  const MatrixXd dense_matrix1 = sparse_matrix1.MakeDenseMatrix();
+  const MatrixBlock<double> sparse_block1(std::move(sparse_matrix1));
+  const MatrixBlock<double> dense_block1(dense_matrix1);
+
+  /* Make a second MatrixBlock that's different from the existing one. */
+  Block3x3SparseMatrix<double> sparse_matrix2(2, 3);
+  std::vector<Block3x3SparseMatrix<double>::Triplet> triplets;
+  triplets.emplace_back(0, 0, Matrix3d::Constant(4.0));
+  triplets.emplace_back(1, 1, Matrix3d::Constant(5.0));
+  sparse_matrix2.SetFromTriplets(triplets);
+  const MatrixXd dense_matrix2 = sparse_matrix2.MakeDenseMatrix();
+  const MatrixBlock<double> sparse_block2(std::move(sparse_matrix2));
+  const MatrixBlock<double> dense_block2(dense_matrix2);
+
+  std::vector<MatrixBlock<double>> dense_blocks = {dense_block1, dense_block2};
+  std::vector<MatrixBlock<double>> sparse_blocks = {sparse_block1,
+                                                    sparse_block2};
+
+  MatrixXd expected(dense_matrix1.rows() + dense_matrix2.rows(),
+                    dense_matrix1.cols());
+  expected.topRows(dense_matrix1.rows()) = dense_matrix1;
+  expected.bottomRows(dense_matrix2.rows()) = dense_matrix2;
+
+  const MatrixBlock<double> dense_stack = StackMatrixBlocks(dense_blocks);
+  const MatrixBlock<double> sparse_stack = StackMatrixBlocks(sparse_blocks);
+  EXPECT_TRUE(CompareMatrices(dense_stack.MakeDenseMatrix(), expected));
+  EXPECT_TRUE(CompareMatrices(sparse_stack.MakeDenseMatrix(), expected));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
MatrixBlock wraps around std::variant<MatrixX<T>, Block3x3SparseMatrix<T>> and provides a common set of API for a set of matrix operations that leverages sparsity when possible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19083)
<!-- Reviewable:end -->
