### PR TITLE
[visualization] Show hydro tesselation for proximity shapes

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -591,6 +591,7 @@ drake_cc_googletest(
     name = "meshcat_visualizer_test",
     data = [
         "//manipulation/models/iiwa_description:models",
+        "//multibody/meshcat:models",
     ],
     deps = [
         ":meshcat_visualizer",

--- a/geometry/meshcat_visualizer_params.h
+++ b/geometry/meshcat_visualizer_params.h
@@ -22,6 +22,7 @@ struct MeshcatVisualizerParams {
     a->Visit(DRAKE_NVP(delete_on_initialization_event));
     a->Visit(DRAKE_NVP(enable_alpha_slider));
     a->Visit(DRAKE_NVP(visible_by_default));
+    a->Visit(DRAKE_NVP(show_hydroelastic));
   }
 
   /** The duration (in simulation seconds) between attempts to update poses in
@@ -54,6 +55,24 @@ struct MeshcatVisualizerParams {
 
   /** Determines whether our meshcat path should be default to being visible. */
   bool visible_by_default{true};
+
+  /** When using the hydroelastic contact model, collision geometries that are
+  _declared_ as geometric primitives are frequently represented by some
+  discretely tessellated mesh when computing contact. It can be quite helpful
+  in assessing contact behavior to visualize these discrete meshes (in place of
+  the idealized primitives).
+
+  To visualize these representations it is necessary to request visualization
+  of geometries with the Role::kProximity role (see the role field). It is
+  further necessary to explicitly request the hydroelastic meshes where
+  available (setting show_hydroelastic to `true`).
+
+  Setting this `show_hydroelastic` to `true` will have no apparent effect if
+  none of the collision meshes have a hydroelastic mesh associated with them.
+
+  This option is ignored by MeshcatVisualizer<T> when T is not `double`, e.g.
+  if T == AutoDiffXd. */
+  bool show_hydroelastic{false};
 };
 
 }  // namespace geometry

--- a/visualization/test/visualization_config_functions_test.cc
+++ b/visualization/test/visualization_config_functions_test.cc
@@ -75,6 +75,7 @@ GTEST_TEST(VisualizationConfigFunctionsTest, ParamConversionDefault) {
   EXPECT_EQ(meshcat_params.at(0).enable_alpha_slider,
             config.enable_alpha_sliders);
   EXPECT_EQ(meshcat_params.at(0).visible_by_default, true);
+  EXPECT_EQ(meshcat_params.at(0).show_hydroelastic, false);
 
   EXPECT_EQ(meshcat_params.at(1).role, Role::kProximity);
   EXPECT_EQ(meshcat_params.at(1).publish_period, config.publish_period);
@@ -84,6 +85,7 @@ GTEST_TEST(VisualizationConfigFunctionsTest, ParamConversionDefault) {
   EXPECT_EQ(meshcat_params.at(1).enable_alpha_slider,
             config.enable_alpha_sliders);
   EXPECT_EQ(meshcat_params.at(1).visible_by_default, false);
+  EXPECT_EQ(meshcat_params.at(1).show_hydroelastic, true);
 
   const ContactVisualizerParams contact_params =
       ConvertVisualizationConfigToMeshcatContactParams(config);

--- a/visualization/visualization_config_functions.cc
+++ b/visualization/visualization_config_functions.cc
@@ -165,6 +165,7 @@ std::vector<MeshcatVisualizerParams> ConvertVisualizationConfigToMeshcatParams(
         config.delete_on_initialization_event;
     proximity.enable_alpha_slider = config.enable_alpha_sliders;
     proximity.visible_by_default = false;
+    proximity.show_hydroelastic = true;
     result.push_back(proximity);
   }
 


### PR DESCRIPTION
Towards #15738.

---

Note that this will increase the message bandwidth used for primitive collision shapes.  Now we'll send their tessellation surface, instead of just the primitive shape parameters.

---

Tested using:

`bazel run //examples/hydroelastic/ball_plate:ball_plate_run_dynamics -- -simulator_target_realtime_rate 0.001 --resolution_hint_factor=1`

![image](https://user-images.githubusercontent.com/17596505/228381457-2e3282bc-3418-40b6-b0c9-99cf1f4090c1.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19085)
<!-- Reviewable:end -->
