### PR TITLE
Model directives fail to load deep nested weld tests

### DIFF
--- a/multibody/parsing/detail_dmd_parser.cc
+++ b/multibody/parsing/detail_dmd_parser.cc
@@ -41,7 +41,7 @@ void AddWeld(
         info.child_frame_name = child_frame.name();
       }
     }
-    DRAKE_DEMAND(found);
+    DRAKE_THROW_UNLESS(found);
   }
 }
 

--- a/multibody/parsing/test/process_model_directives_test.cc
+++ b/multibody/parsing/test/process_model_directives_test.cc
@@ -371,6 +371,35 @@ GTEST_TEST(ProcessModelDirectivesTest, ErrorMessages) {
   }
 }
 
+// Test model directives failure to load welds with a deep nested child.
+GTEST_TEST(ProcessModelDirectivesTest, DeepNestedChildWelds) {
+  ModelDirectives directives = LoadModelDirectives(
+      FindResourceOrThrow(std::string(kTestDir) +
+                          "/deep_child_weld.dmd.yaml"));
+  MultibodyPlant<double> plant(0.0);
+
+  EXPECT_EXIT(
+      ProcessModelDirectives(directives, &plant, nullptr,
+                             make_parser(&plant).get()),
+      ::testing::KilledBySignal(SIGABRT),
+      R"(.*abort: Failure at .* in AddWeld\(\): condition 'found' failed.*)");
+}
+
+// Test model directives failure to load welds with a child to a
+// deep nested frame.
+GTEST_TEST(ProcessModelDirectivesTest, DeepNestedChildFrameWelds) {
+  ModelDirectives directives = LoadModelDirectives(
+      FindResourceOrThrow(std::string(kTestDir) +
+                          "/deep_child_frame_weld.dmd.yaml"));
+  MultibodyPlant<double> plant(0.0);
+
+  EXPECT_EXIT(
+      ProcessModelDirectives(directives, &plant, nullptr,
+                             make_parser(&plant).get()),
+      ::testing::KilledBySignal(SIGABRT),
+      R"(.*abort: Failure at .* in AddWeld\(\): condition 'found' failed.*)");
+}
+
 }  // namespace
 }  // namespace parsing
 }  // namespace multibody

--- a/multibody/parsing/test/process_model_directives_test.cc
+++ b/multibody/parsing/test/process_model_directives_test.cc
@@ -378,11 +378,10 @@ GTEST_TEST(ProcessModelDirectivesTest, DeepNestedChildWelds) {
                           "/deep_child_weld.dmd.yaml"));
   MultibodyPlant<double> plant(0.0);
 
-  EXPECT_EXIT(
+  DRAKE_EXPECT_THROWS_MESSAGE(
       ProcessModelDirectives(directives, &plant, nullptr,
-                             make_parser(&plant).get()),
-      ::testing::KilledBySignal(SIGABRT),
-      R"(.*abort: Failure at .* in AddWeld\(\): condition 'found' failed.*)");
+        make_parser(&plant).get()),
+        R"(.*Failure at .* in AddWeld\(\): condition 'found' failed.*)");
 }
 
 // Test model directives failure to load welds with a child to a
@@ -393,11 +392,10 @@ GTEST_TEST(ProcessModelDirectivesTest, DeepNestedChildFrameWelds) {
                           "/deep_child_frame_weld.dmd.yaml"));
   MultibodyPlant<double> plant(0.0);
 
-  EXPECT_EXIT(
+  DRAKE_EXPECT_THROWS_MESSAGE(
       ProcessModelDirectives(directives, &plant, nullptr,
-                             make_parser(&plant).get()),
-      ::testing::KilledBySignal(SIGABRT),
-      R"(.*abort: Failure at .* in AddWeld\(\): condition 'found' failed.*)");
+        make_parser(&plant).get()),
+        R"(.*Failure at .* in AddWeld\(\): condition 'found' failed.*)");
 }
 
 }  // namespace

--- a/multibody/parsing/test/process_model_directives_test/deep_child_frame_weld.dmd.yaml
+++ b/multibody/parsing/test/process_model_directives_test/deep_child_frame_weld.dmd.yaml
@@ -1,0 +1,19 @@
+directives:
+
+- add_model:
+    name: top_level_model
+    file: package://process_model_directives_test/model_with_directly_nested_models.sdf
+
+- add_model:
+    name: simple_model
+    file: package://process_model_directives_test/simple_model.sdf
+
+- add_frame:
+    name: top_injected_frame
+    X_PF:
+      base_frame: top_level_model::robot1::robot_base
+      translation: [1, 2, 3]
+
+- add_weld:
+    parent: simple_model::base
+    child: top_injected_frame

--- a/multibody/parsing/test/process_model_directives_test/deep_child_weld.dmd.yaml
+++ b/multibody/parsing/test/process_model_directives_test/deep_child_weld.dmd.yaml
@@ -1,0 +1,13 @@
+directives:
+
+- add_model:
+    name: top_level_model
+    file: package://process_model_directives_test/model_with_directly_nested_models.sdf
+
+- add_model:
+    name: simple_model
+    file: package://process_model_directives_test/simple_model.sdf
+
+- add_weld:
+    parent: simple_model::base
+    child: top_level_model::robot1::robot_base

--- a/multibody/parsing/test/process_model_directives_test/model_with_directly_nested_models.sdf
+++ b/multibody/parsing/test/process_model_directives_test/model_with_directly_nested_models.sdf
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<sdf xmlns:drake="http://drake.mit.edu" version="1.7">
+  <model name="scoped_model">
+    <link name="base"/>
+    <model name="robot1">
+      <link name="robot_base"/>
+      <frame name="tool_frame">
+        <pose relative_to="robot_base">1 2 3  0 0 0</pose>
+      </frame>
+    </model>
+    <frame name="frame">
+      <pose relative_to="base">1 2 3  0 0 0</pose>
+    </frame>
+  </model>
+</sdf>


### PR DESCRIPTION
As suggested by VC regarding the changes in https://github.com/RobotLocomotion/drake/pull/17223.

This PR adds a test that serves as an example that Model Directives currently fails to load welds with a deep nested child and welds to a frame with a deep nested base frame.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19090)
<!-- Reviewable:end -->
