### PR TITLE
[visualization] Hide near-zero hydroelastic force or moment.

### DIFF
--- a/multibody/meshcat/BUILD.bazel
+++ b/multibody/meshcat/BUILD.bazel
@@ -127,6 +127,7 @@ drake_cc_library(
         ":contact_visualizer_params",
         "//geometry:meshcat",
         "//math:geometric_transform",
+        "@msgpack_internal//:msgpack",
     ],
 )
 

--- a/multibody/meshcat/BUILD.bazel
+++ b/multibody/meshcat/BUILD.bazel
@@ -65,6 +65,7 @@ drake_cc_googletest(
     deps = [
         ":hydroelastic_contact_visualizer",
         "//common/test_utilities:expect_no_throw",
+        "@msgpack_internal//:msgpack",
     ],
 )
 
@@ -127,7 +128,6 @@ drake_cc_library(
         ":contact_visualizer_params",
         "//geometry:meshcat",
         "//math:geometric_transform",
-        "@msgpack_internal//:msgpack",
     ],
 )
 

--- a/multibody/meshcat/hydroelastic_contact_visualizer.cc
+++ b/multibody/meshcat/hydroelastic_contact_visualizer.cc
@@ -70,7 +70,8 @@ void HydroelasticContactVisualizer::Update(
     if (force_norm >= params_.force_threshold) {
       meshcat_->SetTransform(path + "/force_C_W",
                              RigidTransformd(RotationMatrixd::MakeFromOneVector(
-                                 item.force_C_W, 2)), time);
+                                 item.force_C_W, 2)),
+                             time);
 
       // Stretch the cylinder in z.
       const double height = force_norm / params_.newtons_per_meter;
@@ -88,6 +89,9 @@ void HydroelasticContactVisualizer::Update(
           RigidTransformd(RotationMatrixd::MakeXRotation(M_PI),
                           Vector3d{0, 0, height + arrowhead_height}),
           time);
+      meshcat_->SetProperty(path + "/force_C_W", "visible", true, time);
+    } else {
+      meshcat_->SetProperty(path + "/force_C_W", "visible", false, time);
     }
     // Moment vector.
     if (moment_norm >= params_.moment_threshold) {
@@ -112,6 +116,9 @@ void HydroelasticContactVisualizer::Update(
           RigidTransformd(RotationMatrixd::MakeXRotation(M_PI),
                           Vector3d{0, 0, height + arrowhead_height}),
           time);
+      meshcat_->SetProperty(path + "/moment_C_W", "visible", true, time);
+    } else {
+      meshcat_->SetProperty(path + "/moment_C_W", "visible", false, time);
     }
 
     // Contact surface

--- a/multibody/meshcat/test/hydroelastic_contact_visualizer_test.cc
+++ b/multibody/meshcat/test/hydroelastic_contact_visualizer_test.cc
@@ -19,7 +19,7 @@ using Eigen::Matrix3Xi;
 using geometry::Meshcat;
 
 // Helper to query meshcat whether an item is visible or not.
-bool visible(Meshcat& meshcat, std::string_view path) {
+bool visible(const Meshcat& meshcat, std::string_view path) {
   std::string property = meshcat.GetPackedProperty(path, "visible");
   msgpack::object_handle oh =
       msgpack::unpack(property.data(), property.size());

--- a/multibody/meshcat/test/hydroelastic_contact_visualizer_test.cc
+++ b/multibody/meshcat/test/hydroelastic_contact_visualizer_test.cc
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_no_throw.h"
+#include "drake/geometry/meshcat_types.h"
 
 namespace drake {
 namespace multibody {
@@ -16,6 +17,15 @@ using Eigen::VectorXd;
 using Eigen::Matrix3Xd;
 using Eigen::Matrix3Xi;
 using geometry::Meshcat;
+
+// Helper to query meshcat whether an item is visible or not.
+bool visible(Meshcat& meshcat, std::string_view path) {
+  std::string property = meshcat.GetPackedProperty(path, "visible");
+  msgpack::object_handle oh =
+      msgpack::unpack(property.data(), property.size());
+  auto data = oh.get().as<geometry::internal::SetPropertyData<bool>>();
+  return data.value;
+}
 
 // Tests that zero force or moment doesn't crash.
 GTEST_TEST(HydroelasticContactVisualizer, TestZeroForceOrMoment) {
@@ -51,6 +61,11 @@ GTEST_TEST(HydroelasticContactVisualizer, TestZeroForceOrMoment) {
                      non_zero_force_C_W, zero_moment_C_W,
                      p_WV, faces, pressure});
     DRAKE_EXPECT_NO_THROW(visualizer.Update(0, items));
+
+    const std::string path = fmt::format("{}/{}+{}", params.prefix,
+                                         items[0].body_A, items[0].body_B);
+    EXPECT_TRUE(visible(*meshcat, path + "/force_C_W"));
+    EXPECT_FALSE(visible(*meshcat, path + "/moment_C_W"));
   }
   // Zero force / non-zero moment
   {
@@ -59,6 +74,11 @@ GTEST_TEST(HydroelasticContactVisualizer, TestZeroForceOrMoment) {
                      zero_force_C_W, non_zero_moment_C_W,
                      p_WV, faces, pressure});
     DRAKE_EXPECT_NO_THROW(visualizer.Update(0, items));
+
+    const std::string path = fmt::format("{}/{}+{}", params.prefix,
+                                         items[0].body_A, items[0].body_B);
+    EXPECT_FALSE(visible(*meshcat, path + "/force_C_W"));
+    EXPECT_TRUE(visible(*meshcat, path + "/moment_C_W"));
   }
 }
 


### PR DESCRIPTION
Before this fix, MeshCat used the arrows from the last sizable force or moment in the previous time step.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19112)
<!-- Reviewable:end -->
