### PR TITLE
Remove extraneous calls to fmt

### DIFF
--- a/common/symbolic/polynomial.cc
+++ b/common/symbolic/polynomial.cc
@@ -840,7 +840,7 @@ Polynomial Polynomial::SubstituteAndExpand(
     const Monomial cur_monomial{var};
     if (substitutions->find(cur_monomial) != substitutions->cend()) {
       if (!substitutions->at(cur_monomial).EqualTo(cur_sub)) {
-        drake::log()->warn(fmt::format(
+        drake::log()->warn(
             "SubstituteAndExpand(): the passed substitutions_cached_data "
             "contains a different expansion for {} than is contained in "
             "indeterminate_substitutions. Substitutions_cached_data contains "
@@ -848,7 +848,7 @@ Polynomial Polynomial::SubstituteAndExpand(
             "likely that substitutions_cached_data is storing expansions which "
             "are inconsistent and so you should not trust the output of this "
             "method.",
-            cur_monomial, substitutions->at(cur_monomial), cur_sub));
+            cur_monomial, substitutions->at(cur_monomial), cur_sub);
       }
     } else {
       substitutions->emplace(cur_monomial, cur_sub);

--- a/geometry/optimization/cspace_free_polytope.cc
+++ b/geometry/optimization/cspace_free_polytope.cc
@@ -798,9 +798,9 @@ CspaceFreePolytope::FindSeparationCertificateGivenPolytope(
         }
       }
 
-      drake::log()->warn(fmt::format(
+      drake::log()->warn(
           "Cannot find Lagrangian multipliers and separating planes for \n{}",
-          bad_pairs));
+          bad_pairs);
     }
   }
   return ret;

--- a/multibody/optimization/toppra.cc
+++ b/multibody/optimization/toppra.cc
@@ -588,9 +588,9 @@ Toppra::ComputeForwardPass(double s_dot_0,
     solvers::MathematicalProgramResult result;
     solver.Solve(*forward_prog_, {}, {}, &result);
     if (!result.is_success()) {
-      drake::log()->error(fmt::format(
+      drake::log()->error(
           "Toppra failed to find the maximum path acceleration at knot {}/{}.",
-          knot, N));
+          knot, N);
       return std::nullopt;
     } else {
       ustar(knot) = result.GetSolution()(0);


### PR DESCRIPTION
The `drake::log()` functions already call format on the arguments, no need for `fmt::format` inside of a `log()->warn(...)`.

+@xuchenhan-tri for both reviews per schedule, please.

\CC @hongkai-dai @AlexandreAmice FYI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19115)
<!-- Reviewable:end -->
