### PR TITLE
Adds python binding for Polynomial<T>::EvaluateUnivariate()

### DIFF
--- a/bindings/pydrake/polynomial_py.cc
+++ b/bindings/pydrake/polynomial_py.cc
@@ -32,6 +32,13 @@ void DoScalarDependentDefinitions(py::module m, T) {
       .def("IsAffine", &Class::IsAffine, cls_doc.IsAffine.doc)
       .def("GetCoefficients", &Class::GetCoefficients,
           cls_doc.GetCoefficients.doc)
+      .def(
+          "EvaluateUnivariate",
+          [](const Class* self, const T& x, int derivative_order) {
+            return self->EvaluateUnivariate(x, derivative_order);
+          },
+          py::arg("x"), py::arg("derivative_order") = 0,
+          cls_doc.EvaluateUnivariate.doc)
       .def("Derivative", &Class::Derivative, py::arg("derivative_order") = 1,
           cls_doc.Derivative.doc)
       .def("Integral", &Class::Integral, py::arg("integration_constant") = 0.0,

--- a/bindings/pydrake/test/polynomial_test.py
+++ b/bindings/pydrake/test/polynomial_test.py
@@ -4,6 +4,7 @@ import unittest
 from pydrake.common import ToleranceType
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.polynomial import Polynomial_
+from pydrake.symbolic import Expression
 
 
 class TestPolynomial(unittest.TestCase):
@@ -31,6 +32,13 @@ class TestPolynomial(unittest.TestCase):
         self.assertEqual(p_i.GetDegree(), 3)
         numpy_compare.assert_equal(
             p.CoefficientsAlmostEqual(p, 1e-14, ToleranceType.kRelative), True)
+
+        x = 1.3
+        y = p.EvaluateUnivariate(x=x, derivative_order=0)
+        if T == Expression:
+            self.assertTrue(y.EqualTo(1 + 2 * x + 3 * x**2))
+        else:
+            self.assertAlmostEqual(y, 1 + 2 * x + 3 * x**2)
 
     @numpy_compare.check_all_types
     def test_arithmetic(self, T):


### PR DESCRIPTION
This came up in my response to a [StackOverflow question](https://stackoverflow.com/questions/75894087/pydrake-evaluate-piecewisepolynomial-with-symbolic-expression).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19118)
<!-- Reviewable:end -->
