### PR TITLE
[parsing] Fix mujoco default mesh name heuristic

### DIFF
--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -913,8 +913,12 @@ class MujocoParser {
 
       std::string file;
       if (ParseStringAttribute(mesh_node, "file", &file)) {
-        std::string name{file};
-        ParseStringAttribute(mesh_node, "name", &name);
+        std::string name;
+        if (!ParseStringAttribute(mesh_node, "name", &name)) {
+          // Per the mujoco docs, if the "name" attribute is omitted then the
+          // mesh name equals the file name without the path and extension.
+          name = std::filesystem::path(file).stem();
+        }
 
         Vector3d scale{1, 1, 1};
         if (ParseVectorAttribute(mesh_node, "scale", &scale)) {

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -408,8 +408,14 @@ class BoxMeshTest : public MujocoParserTest {
   }
 };
 
+TEST_F(BoxMeshTest, MeshFileDirectNoName) {
+  // Absolute path referencing the obj with the default heuristic for `name`.
+  std::string mesh_asset = fmt::format(R"""(<mesh file="{}"/>)""", box_obj_);
+  TestBoxMesh(box_obj_, mesh_asset);
+}
+
 TEST_F(BoxMeshTest, MeshFileDirect) {
-  // Absolute path, referencing the obj directly.
+  // Absolute path, referencing the obj directly and with a `name` attribute.
   std::string mesh_asset =
       fmt::format(R"""(<mesh name="box" file="{}"/>)""", box_obj_);
   TestBoxMesh(box_obj_, mesh_asset);


### PR DESCRIPTION
+@rpoyner-tri for both reviews, please.

I tried running https://github.com/kevinzakka/obj2mjcf/ and then ran into this parser bug.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19124)
<!-- Reviewable:end -->
