### PR TITLE
[doc] Support shorter URL for release notes index

### DIFF
--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -88,6 +88,7 @@ filegroup(
         "images/drake-logo.svg",
         "images/drake-logo-white.svg",
         "images/jenkins_bot_reviewable_comment.png",
+        "_release-notes/index.html",
     ] + glob([
         "_includes/*.html",
         "_includes/*.md",

--- a/doc/_release-notes/index.html
+++ b/doc/_release-notes/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting...</title>
+  <link rel="canonical" href="release_notes.html"/>
+  <meta http-equiv="refresh" content="0;url=release_notes.html"/>
+</head>
+<body>
+  <h1>Redirecting...</h1>
+  <a href="release_notes.html">Click here if you are not redirected.</a>
+  <script>location='release_notes.html'</script>
+</body>
+</html>


### PR DESCRIPTION
The longer URL looks silly when pasted into a slide deck.

Tested with `bazel run //doc:pages -- --serve` then open `http://127.0.0.1:8000/release_notes/` in a browser.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19126)
<!-- Reviewable:end -->
