### PR TITLE
[geometry] Ignore trailing whitespace in mtl files

### DIFF
--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -342,7 +342,7 @@ class MeshcatShapeReifier : public ShapeReifier {
         //  - "[^\s]+" matches the filename, and
         //  - "[$\r\n]" matches the end of string or end of line.
         // TODO(russt): This parsing could still be more robust.
-        std::regex map_regex(R"""(map_.+\s([^\s]+)[$\r\n])""");
+        std::regex map_regex(R"""(map_.+\s([^\s]+)\s*[$\r\n])""");
         for (std::sregex_iterator iter(meshfile_object.mtl_library.begin(),
                                        meshfile_object.mtl_library.end(),
                                        map_regex);

--- a/geometry/render/test/meshes/box.obj.mtl
+++ b/geometry/render/test/meshes/box.obj.mtl
@@ -5,4 +5,6 @@ Ks 1.000000 1.000000 1.000000
 d 1.000000
 illum 2
 Ns 0.000000
-map_Kd -s 1 1 1 box.png
+# N.B. The next line has trailing whitespace on purpose, to prove that Drake
+# ignores it during parsing.
+map_Kd -s 1 1 1 box.png 


### PR DESCRIPTION
For some reason, a lot of the `*.mtl` files in the YCB dataset contain this trailing whitespace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19129)
<!-- Reviewable:end -->
