### PR TITLE
[pybind11] Hotfix: nerf pybind coverage

### DIFF
--- a/tools/workspace/pybind11/BUILD.bazel
+++ b/tools/workspace/pybind11/BUILD.bazel
@@ -167,6 +167,9 @@ drake_py_unittest(
         ":pybind_coverage_test_actual_data",
         ":pybind_coverage_test_expected_data",
     ],
+    # Nerf this test with a manual tag until issues with pandas 2.0 (used in
+    # macos unprovisioned CI builds) are resolved.
+    tags = ["manual"],
     deps = [":mkdoc"],
 )
 

--- a/tools/workspace/pybind11/pybind_coverage_xml_parser.py
+++ b/tools/workspace/pybind11/pybind_coverage_xml_parser.py
@@ -342,5 +342,6 @@ class FileCoverage:
             final_row[col] = df[col].sum()
 
         final_row["FileName"] = "TOTAL"
-        self.df_pruned = df.append(final_row, ignore_index=True)
+        self.df_pruned = pandas.concat([df, pandas.DataFrame([final_row])],
+                                       ignore_index=True, sort=False)
         logging.debug("Coverage = {}".format(str(final_row["Coverage"])))


### PR DESCRIPTION
This was failing on macOS unprovisioned builds that used pandas 2.0.

Because the affected files are used in both build (genrule) and test steps, do a minimal patch to avoid build-phase failures.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19140)
<!-- Reviewable:end -->
