### PR TITLE
Improve error message for namedview

### DIFF
--- a/bindings/pydrake/common/containers.py
+++ b/bindings/pydrake/common/containers.py
@@ -116,7 +116,10 @@ class NamedViewBase:
     def __setattr__(self, name, value):
         """Prevent setting additional attributes."""
         if not hasattr(self, name):
-            raise AttributeError("Cannot add attributes!")
+            raise AttributeError(
+                "Cannot add attributes! The fields in this named view are"
+                f"{self.get_fields()}, but you tried to set '{name}'."
+            )
         object.__setattr__(self, name, value)
 
     def __len__(self):

--- a/bindings/pydrake/common/test/containers_test.py
+++ b/bindings/pydrake/common/test/containers_test.py
@@ -121,6 +121,8 @@ class TestNamedView(unittest.TestCase):
         np.testing.assert_equal(value, [3, 3])
         self.assertEqual(repr(view), "MyView(a=3, b=3)")
         self.assertEqual(str(view), repr(view))
+        with self.assertRaisesRegex(AttributeError, ".*('a', 'b').*"):
+            view.c = 42
 
     def test_Zero(self):
         MyView = namedview("MyView", ["a", "b"])


### PR DESCRIPTION
Previously, setting a bad attribute just said "Cannot add attributes!"

Now it says, e.g.  "Cannot add attributes! The fields in this named view are ('a', 'b'), but you tried to set 'c'."

+@rpoyner-tri for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19148)
<!-- Reviewable:end -->
