### PR TITLE
[multibody] Use MatrixBlock to store constraint Jacobians

### DIFF
--- a/multibody/contact_solvers/BUILD.bazel
+++ b/multibody/contact_solvers/BUILD.bazel
@@ -45,6 +45,7 @@ drake_cc_library(
     srcs = ["block_sparse_matrix.cc"],
     hdrs = ["block_sparse_matrix.h"],
     deps = [
+        ":matrix_block",
         "//common:default_scalars",
         "//common:essential",
         "//common:unused",
@@ -169,6 +170,7 @@ drake_cc_library(
     srcs = ["supernodal_solver.cc"],
     hdrs = ["supernodal_solver.h"],
     interface_deps = [
+        ":matrix_block",
         "//common:essential",
     ],
     deps = [

--- a/multibody/contact_solvers/block_sparse_matrix.h
+++ b/multibody/contact_solvers/block_sparse_matrix.h
@@ -8,6 +8,7 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/matrix_block.h"
 
 namespace drake {
 namespace multibody {
@@ -18,11 +19,12 @@ template <typename T>
 class BlockSparseMatrixBuilder;
 
 // This class provides a representation for sparse matrices with a structure
-// consisting of dense blocks of non-zeros. While other storage formats such as
-// CRS (Compressed Row Storage) are popular (E.g. Eigen::SparseMatrix), a data
-// structure tailored to block-sparse matrices enables efficient algorithms
-// capable of exploiting highly optimized operations with dense blocks (e.g. via
-// AVX instructions).
+// consisting of MatrixBlocks, which are either dense blocks or blocks with
+// specific properties such as sparse, diagonal, or identity. (See
+// MatrixBlock). While other storage formats such as CRS (Compressed Row
+// Storage) are popular (E.g. Eigen::SparseMatrix), a data structure tailored to
+// block-sparse matrices enables efficient algorithms capable of exploiting
+// highly optimized operations with individual blocks.
 //
 // Instances of this class are meant to be built with BlockSparseMatrixBuilder
 // to ensure the consistency of block entries provided by users.
@@ -44,7 +46,7 @@ class BlockSparseMatrix {
   // A non-zero block entry is specified with the triplet {i, j, Bij}, where
   // (i,j) are the i-th and j-th block row and column respectively and Bij is
   // the dense block entry.
-  typedef std::tuple<int, int, MatrixX<T>> BlockTriplet;
+  typedef std::tuple<int, int, MatrixBlock<T>> BlockTriplet;
 
   // Constructs a zero sized matrix.
   // While non-empty matrices must be built with BlockSparseMatrixBuilder to
@@ -69,7 +71,7 @@ class BlockSparseMatrix {
   // Access to the b-th block. b must be in the range 0 to num_blocks()-1.
   // Blocks are indexed in the order they were added using a builder via
   // BlockSparseMatrixBuilder::PushBlock().
-  const MatrixX<T>& get_block(int b) const {
+  const MatrixBlock<T>& get_block(int b) const {
     DRAKE_DEMAND(b < num_blocks());
     return std::get<2>(blocks_[b]);
   }
@@ -197,7 +199,8 @@ class BlockSparseMatrixBuilder {
   // added block to column j or an exception is thrown.
   // @note Blocks of size zero are ignored.
   // @throws if block (i,j) was already added.
-  void PushBlock(int i, int j, const MatrixX<T>& Bij);
+  void PushBlock(int i, int j, MatrixX<T> Bij);
+  void PushBlock(int i, int j, MatrixBlock<T> Bij);
 
   // Makes a new BlockSparseMatrix.
   // If successful, the new BlockSparseMatrix is guaranteed to be properly

--- a/multibody/contact_solvers/sap/BUILD.bazel
+++ b/multibody/contact_solvers/sap/BUILD.bazel
@@ -55,6 +55,7 @@ drake_cc_library(
     deps = [
         "//common:default_scalars",
         "//common:essential",
+        "//multibody/contact_solvers:matrix_block",
     ],
 )
 

--- a/multibody/contact_solvers/sap/sap_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_constraint.cc
@@ -11,7 +11,7 @@ namespace contact_solvers {
 namespace internal {
 
 template <typename T>
-SapConstraint<T>::SapConstraint(int clique, VectorX<T> g, MatrixX<T> J)
+SapConstraint<T>::SapConstraint(int clique, VectorX<T> g, MatrixBlock<T> J)
     : first_clique_(clique),
       g_(std::move(g)),
       first_clique_jacobian_(std::move(J)) {
@@ -23,8 +23,8 @@ SapConstraint<T>::SapConstraint(int clique, VectorX<T> g, MatrixX<T> J)
 
 template <typename T>
 SapConstraint<T>::SapConstraint(int first_clique, int second_clique,
-                                VectorX<T> g, MatrixX<T> J_first_clique,
-                                MatrixX<T> J_second_clique)
+                                VectorX<T> g, MatrixBlock<T> J_first_clique,
+                                MatrixBlock<T> J_second_clique)
     : first_clique_(first_clique),
       second_clique_(second_clique),
       g_(std::move(g)),

--- a/multibody/contact_solvers/sap/sap_constraint.h
+++ b/multibody/contact_solvers/sap/sap_constraint.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/matrix_block.h"
 
 namespace drake {
 namespace multibody {
@@ -76,7 +78,12 @@ class SapConstraint {
      SapContactProblem::num_velocities(). This condition is enforced when the
      constraint is added to the contact problem instead of during construction
      here, see SapContactProblem::AddConstraint(). */
-  SapConstraint(int clique, VectorX<T> g, MatrixX<T> J);
+  SapConstraint(int clique, VectorX<T> g, MatrixBlock<T> J);
+
+  /* Alternative signature for the constructor for a constraint within a single
+   clique. that takes a dense Jacobian. */
+  SapConstraint(int clique, VectorX<T> g, MatrixX<T> J)
+      : SapConstraint(clique, std::move(g), MatrixBlock<T>(std::move(J))) {}
 
   /* Constructor for a constraint among DOFs between two cliques.
    @param[in] first_clique
@@ -107,7 +114,15 @@ class SapConstraint {
      condition is not enforced at construction but when the constraint is added
      to the contact problem, see SapContactProblem::AddConstraint(). */
   SapConstraint(int first_clique, int second_clique, VectorX<T> g,
-                MatrixX<T> J_first_clique, MatrixX<T> J_second_clique);
+                MatrixBlock<T> J_first_clique, MatrixBlock<T> J_second_clique);
+
+  /* Alternative signature for the constructor for constraint between two
+   cliques that takes dense Jacobians. */
+  SapConstraint(int first_clique, int second_clique, VectorX<T> g,
+                MatrixX<T> J_first_clique, MatrixX<T> J_second_clique)
+      : SapConstraint(first_clique, second_clique, std::move(g),
+                      MatrixBlock<T>(std::move(J_first_clique)),
+                      MatrixBlock<T>(std::move(J_second_clique))) {}
 
   virtual ~SapConstraint() = default;
 
@@ -136,13 +151,13 @@ class SapConstraint {
   const VectorX<T>& constraint_function() const { return g_; }
 
   /* Returns the Jacobian with respect to the DOFs of the first clique. */
-  const MatrixX<T>& first_clique_jacobian() const {
+  const MatrixBlock<T>& first_clique_jacobian() const {
     return first_clique_jacobian_;
   }
 
   /* Returns the Jacobian with respect to the DOFs of the second clique.
    It throws an exception if num_cliques() == 1. */
-  const MatrixX<T>& second_clique_jacobian() const {
+  const MatrixBlock<T>& second_clique_jacobian() const {
     if (num_cliques() == 1)
       throw std::logic_error(
           "This constraint only involves a single clique.");
@@ -203,8 +218,8 @@ class SapConstraint {
   int first_clique_{-1};
   int second_clique_{-1};
   VectorX<T> g_;
-  MatrixX<T> first_clique_jacobian_;
-  MatrixX<T> second_clique_jacobian_;
+  MatrixBlock<T> first_clique_jacobian_;
+  MatrixBlock<T> second_clique_jacobian_;
 };
 
 }  // namespace internal

--- a/multibody/contact_solvers/sap/sap_constraint_bundle.cc
+++ b/multibody/contact_solvers/sap/sap_constraint_bundle.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/contact_solvers/sap/sap_constraint_bundle.h"
 
+#include <utility>
+
 #include "drake/common/default_scalars.h"
 #include "drake/multibody/contact_solvers/sap/contact_problem_graph.h"
 
@@ -80,42 +82,39 @@ void SapConstraintBundle<T>::MakeConstraintBundleJacobian(
     const int c1 = cluster.cliques().second();
 
     // Allocate Jacobian blocks for this cluster of constraints.
-    MatrixX<T> J0, J1;
     const int num_rows = cluster.num_total_constraint_equations();
     const int nv0 = problem.num_velocities(c0);
-    J0.resize(num_rows, nv0);
-    if (c1 != c0) {  // If not a "loop" in the graph.
-      const int nv1 = problem.num_velocities(c1);
-      J1.resize(num_rows, nv1);
-    }
+    const int nv1 = problem.num_velocities(c1);
+    std::vector<MatrixBlock<T>> J0_blocks, J1_blocks;
 
     // Constraints are added in the order set by the graph.
-    int row_start = 0;
     for (int i : cluster.constraint_index()) {
       const SapConstraint<T>& c = problem.get_constraint(i);
-      const int ni = c.num_constraint_equations();
-
       // N.B. Each edge stores its cliques as a sorted pair. However, the pair
       // of cliques in the original constraints can be in arbitrary order.
       // Therefore below we must check to what clique in the original constraint
       // the group's cliques correspond to.
-
-      J0.middleRows(row_start, ni) = c0 == c.first_clique()
-                                         ? c.first_clique_jacobian()
-                                         : c.second_clique_jacobian();
+      J0_blocks.emplace_back(c0 == c.first_clique()
+                                 ? c.first_clique_jacobian()
+                                 : c.second_clique_jacobian());
       if (c1 != c0) {
-        J1.middleRows(row_start, ni) = c1 == c.first_clique()
-                                           ? c.first_clique_jacobian()
-                                           : c.second_clique_jacobian();
+        J1_blocks.emplace_back(c1 == c.first_clique()
+                                   ? c.first_clique_jacobian()
+                                   : c.second_clique_jacobian());
       }
-      row_start += ni;
     }
 
+    MatrixBlock<T> J0 = StackMatrixBlocks(J0_blocks);
+    DRAKE_DEMAND(J0.cols() == nv0);
+    DRAKE_DEMAND(J0.rows() == num_rows);
     const int participating_c0 = cliques_permutation.permuted_index(c0);
-    builder.PushBlock(block_row, participating_c0, J0);
+    builder.PushBlock(block_row, participating_c0, std::move(J0));
     if (c1 != c0) {
+      MatrixBlock<T> J1 = StackMatrixBlocks(J1_blocks);
+      DRAKE_DEMAND(J1.cols() == nv1);
+      DRAKE_DEMAND(J1.rows() == num_rows);
       const int participating_c1 = cliques_permutation.permuted_index(c1);
-      builder.PushBlock(block_row, participating_c1, J1);
+      builder.PushBlock(block_row, participating_c1, std::move(J1));
     }
   }
 

--- a/multibody/contact_solvers/sap/sap_friction_cone_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_friction_cone_constraint.cc
@@ -1,7 +1,6 @@
 #include "drake/multibody/contact_solvers/sap/sap_friction_cone_constraint.h"
 
 #include <algorithm>
-#include <utility>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/eigen_types.h"
@@ -13,7 +12,7 @@ namespace internal {
 
 template <typename T>
 SapFrictionConeConstraint<T>::SapFrictionConeConstraint(int clique,
-                                                        MatrixX<T> J,
+                                                        MatrixBlock<T> J,
                                                         const T& phi0,
                                                         const Parameters& p)
     : SapConstraint<T>(clique, Vector3<T>(0.0, 0.0, phi0), std::move(J)),
@@ -30,8 +29,8 @@ SapFrictionConeConstraint<T>::SapFrictionConeConstraint(int clique,
 
 template <typename T>
 SapFrictionConeConstraint<T>::SapFrictionConeConstraint(
-    int clique0, int clique1, MatrixX<T> J0, MatrixX<T> J1, const T& phi0,
-    const Parameters& p)
+    int clique0, int clique1, MatrixBlock<T> J0, MatrixBlock<T> J1,
+    const T& phi0, const Parameters& p)
     : SapConstraint<T>(clique0, clique1, Vector3<T>(0.0, 0.0, phi0),
                        std::move(J0), std::move(J1)),
       parameters_(p),

--- a/multibody/contact_solvers/sap/sap_friction_cone_constraint.h
+++ b/multibody/contact_solvers/sap/sap_friction_cone_constraint.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
@@ -93,8 +94,15 @@ class SapFrictionConeConstraint final : public SapConstraint<T> {
    exception is thrown.
    @param[in] phi0 The value of the signed distance at the previous time step.
    @param[in] parameters Constraint parameters. See Parameters for details. */
-  SapFrictionConeConstraint(int clique, MatrixX<T> J, const T& phi0,
+  SapFrictionConeConstraint(int clique, MatrixBlock<T> J, const T& phi0,
                             const Parameters& parameters);
+
+  /* Alternative constructor for a contact constraint involving a single clique
+   that takes a dense Jacobian. */
+  SapFrictionConeConstraint(int clique, MatrixX<T> J, const T& phi0,
+                            const Parameters& parameters)
+      : SapFrictionConeConstraint(clique, MatrixBlock<T>(std::move(J)), phi0,
+                                  parameters) {}
 
   /* Constructs a contact constraint for the case in which two cliques
    are involved.
@@ -108,8 +116,18 @@ class SapFrictionConeConstraint final : public SapConstraint<T> {
    velocities. It must have three rows or an exception is thrown.
    @param[in] phi0 The value of the signed distance at the previous time step.
    @param[in] parameters Constraint parameters. See Parameters for details. */
+  SapFrictionConeConstraint(int clique0, int clique1, MatrixBlock<T> J0,
+                            MatrixBlock<T> J1, const T& phi0,
+                            const Parameters& parameters);
+
+  /* Alternative constructor for a contact constraint involving two cliques
+   that takes a dense Jacobian. */
   SapFrictionConeConstraint(int clique0, int clique1, MatrixX<T> J0,
-                            MatrixX<T> J1, const T& phi0, const Parameters& p);
+                            MatrixX<T> J1, const T& phi0,
+                            const Parameters& parameters)
+      : SapFrictionConeConstraint(
+            clique0, clique1, MatrixBlock<T>(std::move(J0)),
+            MatrixBlock<T>(std::move(J1)), phi0, parameters) {}
 
   /* Returns the coefficient of friction for this constraint. */
   const T& mu() const { return parameters_.mu; }

--- a/multibody/contact_solvers/sap/sap_holonomic_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_holonomic_constraint.cc
@@ -35,7 +35,7 @@ SapHolonomicConstraint<T>::Parameters::Parameters(
 
 template <typename T>
 SapHolonomicConstraint<T>::SapHolonomicConstraint(int clique, VectorX<T> g,
-                                                  MatrixX<T> J,
+                                                  MatrixBlock<T> J,
                                                   Parameters parameters)
     : SapConstraint<T>(clique, std::move(g), std::move(J)),
       parameters_(std::move(parameters)) {
@@ -47,12 +47,10 @@ SapHolonomicConstraint<T>::SapHolonomicConstraint(int clique, VectorX<T> g,
 }
 
 template <typename T>
-SapHolonomicConstraint<T>::SapHolonomicConstraint(int first_clique,
-                                                  int second_clique,
-                                                  VectorX<T> g,
-                                                  MatrixX<T> J_first_clique,
-                                                  MatrixX<T> J_second_clique,
-                                                  Parameters parameters)
+SapHolonomicConstraint<T>::SapHolonomicConstraint(
+    int first_clique, int second_clique, VectorX<T> g,
+    MatrixBlock<T> J_first_clique, MatrixBlock<T> J_second_clique,
+    Parameters parameters)
     : SapConstraint<T>(first_clique, second_clique, std::move(g),
                        std::move(J_first_clique), std::move(J_second_clique)),
       parameters_(std::move(parameters)) {
@@ -65,7 +63,8 @@ SapHolonomicConstraint<T>::SapHolonomicConstraint(int first_clique,
 
 template <typename T>
 SapHolonomicConstraint<T>::SapHolonomicConstraint(int clique, VectorX<T> g,
-                                                  MatrixX<T> J, VectorX<T> b,
+                                                  MatrixBlock<T> J,
+                                                  VectorX<T> b,
                                                   Parameters parameters)
     : SapConstraint<T>(clique, std::move(g), std::move(J)),
       parameters_(std::move(parameters)),

--- a/multibody/contact_solvers/sap/sap_holonomic_constraint.h
+++ b/multibody/contact_solvers/sap/sap_holonomic_constraint.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
@@ -125,8 +126,15 @@ class SapHolonomicConstraint final : public SapConstraint<T> {
 
    @pre clique is non-negative.
    @pre g.size() == J.rows() == parameters.num_constraint_equations(). */
-  SapHolonomicConstraint(int clique, VectorX<T> g, MatrixX<T> J,
+  SapHolonomicConstraint(int clique, VectorX<T> g, MatrixBlock<T> J,
                          Parameters parameters);
+
+  /* Alternative holonomic constraint constructor for a single clique that takes
+   a dense Jacobian and zero bias. */
+  SapHolonomicConstraint(int clique, VectorX<T> g, MatrixX<T> J,
+                         Parameters parameters)
+      : SapHolonomicConstraint(clique, std::move(g),
+                               MatrixBlock<T>(std::move(J)), parameters) {}
 
   /* Constructs a holonomic constraint involving two cliques. The bias term b is
    zero.
@@ -143,8 +151,18 @@ class SapHolonomicConstraint final : public SapConstraint<T> {
    @pre g.size() == J_first_clique.rows() == J_second_clique.rows() ==
    parameters.num_constraint_equations(). */
   SapHolonomicConstraint(int first_clique, int second_clique, VectorX<T> g,
+                         MatrixBlock<T> J_first_clique,
+                         MatrixBlock<T> J_second_clique, Parameters parameters);
+
+  /* Alternative holonomic constraint constructor for two cliques that takes
+   dense Jacobians and zero bias. */
+  SapHolonomicConstraint(int first_clique, int second_clique, VectorX<T> g,
                          MatrixX<T> J_first_clique, MatrixX<T> J_second_clique,
-                         Parameters parameters);
+                         Parameters parameters)
+      : SapHolonomicConstraint(first_clique, second_clique, std::move(g),
+                               MatrixBlock<T>(std::move(J_first_clique)),
+                               MatrixBlock<T>(std::move(J_second_clique)),
+                               parameters) {}
 
   /* Single clique holonomic constraints with non-zero bias.
    @param[in] clique The clique involved in the constraint.
@@ -155,8 +173,16 @@ class SapHolonomicConstraint final : public SapConstraint<T> {
 
    @pre clique is non-negative.
    @pre g.size() == J.rows() == parameters.num_constraint_equations(). */
+  SapHolonomicConstraint(int clique, VectorX<T> g, MatrixBlock<T> J,
+                         VectorX<T> b, Parameters parameters);
+
+  /* Alternative holonomic constraint constructor for single clique that takes
+   a dense Jacobian and non-zero bias. */
   SapHolonomicConstraint(int clique, VectorX<T> g, MatrixX<T> J, VectorX<T> b,
-                         Parameters parameters);
+                         Parameters parameters)
+      : SapHolonomicConstraint(clique, std::move(g),
+                               MatrixBlock<T>(std::move(J)), std::move(b),
+                               parameters) {}
 
   const Parameters& parameters() const { return parameters_; }
 

--- a/multibody/contact_solvers/sap/test/sap_constraint_bundle_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_constraint_bundle_test.cc
@@ -141,30 +141,35 @@ TEST_F(SapConstraintBundleTest, VerifyJacobian) {
   BlockSparseMatrixBuilder<double> builder(3, 3, 5);
   // Cluster of constraints between cliques 0 and 2.
   MatrixXd J_cluster0_clique0(3, 1);
-  J_cluster0_clique0 << problem_->get_constraint(0).first_clique_jacobian(),
-      problem_->get_constraint(1).second_clique_jacobian();
+  J_cluster0_clique0
+      << problem_->get_constraint(0).first_clique_jacobian().MakeDenseMatrix(),
+      problem_->get_constraint(1).second_clique_jacobian().MakeDenseMatrix();
   builder.PushBlock(0, p.permuted_index(0), J_cluster0_clique0);
   MatrixXd J_cluster0_clique2(3, 3);
-  J_cluster0_clique2 << problem_->get_constraint(0).second_clique_jacobian(),
-      problem_->get_constraint(1).first_clique_jacobian();
+  J_cluster0_clique2
+      << problem_->get_constraint(0).second_clique_jacobian().MakeDenseMatrix(),
+      problem_->get_constraint(1).first_clique_jacobian().MakeDenseMatrix();
   builder.PushBlock(0, p.permuted_index(2), J_cluster0_clique2);
 
   // Cluster of constraints between cliques 0 and 1.
   MatrixXd J_cluster1_clique0(8, 1);
-  J_cluster1_clique0 << problem_->get_constraint(2).first_clique_jacobian(),
-      problem_->get_constraint(3).first_clique_jacobian(),
-      problem_->get_constraint(4).first_clique_jacobian();
+  J_cluster1_clique0
+      << problem_->get_constraint(2).first_clique_jacobian().MakeDenseMatrix(),
+      problem_->get_constraint(3).first_clique_jacobian().MakeDenseMatrix(),
+      problem_->get_constraint(4).first_clique_jacobian().MakeDenseMatrix();
   builder.PushBlock(1, p.permuted_index(0), J_cluster1_clique0);
   MatrixXd J_cluster1_clique1(8, 2);
-  J_cluster1_clique1 << problem_->get_constraint(2).second_clique_jacobian(),
-      problem_->get_constraint(3).second_clique_jacobian(),
-      problem_->get_constraint(4).second_clique_jacobian();
+  J_cluster1_clique1
+      << problem_->get_constraint(2).second_clique_jacobian().MakeDenseMatrix(),
+      problem_->get_constraint(3).second_clique_jacobian().MakeDenseMatrix(),
+      problem_->get_constraint(4).second_clique_jacobian().MakeDenseMatrix();
   builder.PushBlock(1, p.permuted_index(1), J_cluster1_clique1);
 
   // Cluster with only clique1.
   MatrixXd J_cluster2_clique1(6, 2);
-  J_cluster2_clique1 << problem_->get_constraint(5).first_clique_jacobian(),
-      problem_->get_constraint(6).first_clique_jacobian();
+  J_cluster2_clique1
+      << problem_->get_constraint(5).first_clique_jacobian().MakeDenseMatrix(),
+      problem_->get_constraint(6).first_clique_jacobian().MakeDenseMatrix();
   builder.PushBlock(2, p.permuted_index(1), J_cluster2_clique1);
 
   BlockSparseMatrix<double> Jblock = builder.Build();

--- a/multibody/contact_solvers/sap/test/sap_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_constraint_test.cc
@@ -67,7 +67,7 @@ GTEST_TEST(SapConstraint, SingleCliqueConstraint) {
   EXPECT_EQ(c.first_clique(), 12);
   EXPECT_THROW(c.second_clique(), std::exception);
   EXPECT_EQ(c.constraint_function(), Vector3d(1., 2., 3));
-  EXPECT_EQ(c.first_clique_jacobian(), J32);
+  EXPECT_EQ(c.first_clique_jacobian().MakeDenseMatrix(), J32);
   EXPECT_THROW(c.second_clique_jacobian(), std::exception);
 }
 
@@ -78,8 +78,8 @@ GTEST_TEST(SapConstraint, TwoCliquesConstraint) {
   EXPECT_EQ(c.first_clique(), 11);
   EXPECT_EQ(c.second_clique(), 7);
   EXPECT_EQ(c.constraint_function(), Vector3d(1., 2., 3));
-  EXPECT_EQ(c.first_clique_jacobian(), J32);
-  EXPECT_EQ(c.second_clique_jacobian(), J34);
+  EXPECT_EQ(c.first_clique_jacobian().MakeDenseMatrix(), J32);
+  EXPECT_EQ(c.second_clique_jacobian().MakeDenseMatrix(), J34);
 }
 
 GTEST_TEST(SapConstraint, SingleCliqueConstraintWrongArguments) {
@@ -123,7 +123,7 @@ GTEST_TEST(SapConstraint, SingleCliqueConstraintClone) {
   EXPECT_EQ(clone->first_clique(), 12);
   EXPECT_THROW(clone->second_clique(), std::exception);
   EXPECT_EQ(clone->constraint_function(), Vector3d(1., 2., 3));
-  EXPECT_EQ(clone->first_clique_jacobian(), J32);
+  EXPECT_EQ(clone->first_clique_jacobian().MakeDenseMatrix(), J32);
   EXPECT_THROW(clone->second_clique_jacobian(), std::exception);
 }
 
@@ -135,8 +135,8 @@ GTEST_TEST(SapConstraint, TwoCliquesConstraintClone) {
   EXPECT_EQ(clone->first_clique(), 11);
   EXPECT_EQ(clone->second_clique(), 7);
   EXPECT_EQ(clone->constraint_function(), Vector3d(1., 2., 3));
-  EXPECT_EQ(clone->first_clique_jacobian(), J32);
-  EXPECT_EQ(clone->second_clique_jacobian(), J34);
+  EXPECT_EQ(clone->first_clique_jacobian().MakeDenseMatrix(), J32);
+  EXPECT_EQ(clone->second_clique_jacobian().MakeDenseMatrix(), J34);
 }
 
 }  // namespace

--- a/multibody/contact_solvers/sap/test/sap_friction_cone_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_friction_cone_constraint_test.cc
@@ -57,7 +57,7 @@ GTEST_TEST(SapFrictionConeConstraint, SingleCliqueConstraint) {
   EXPECT_EQ(c.first_clique(), clique);
   EXPECT_THROW(c.second_clique(), std::exception);
   EXPECT_EQ(c.constraint_function(), Vector3d(0., 0., phi0));
-  EXPECT_EQ(c.first_clique_jacobian(), J32);
+  EXPECT_EQ(c.first_clique_jacobian().MakeDenseMatrix(), J32);
   EXPECT_THROW(c.second_clique_jacobian(), std::exception);
   EXPECT_EQ(c.mu(), mu);
   EXPECT_EQ(c.parameters().mu, mu);
@@ -85,8 +85,8 @@ GTEST_TEST(SapFrictionConeConstraint, TwoCliquesConstraint) {
   EXPECT_EQ(c.first_clique(), clique0);
   EXPECT_EQ(c.second_clique(), clique1);
   EXPECT_EQ(c.constraint_function(), Vector3d(0., 0., phi0));
-  EXPECT_EQ(c.first_clique_jacobian(), J32);
-  EXPECT_EQ(c.second_clique_jacobian(), J34);
+  EXPECT_EQ(c.first_clique_jacobian().MakeDenseMatrix(), J32);
+  EXPECT_EQ(c.second_clique_jacobian().MakeDenseMatrix(), J34);
   EXPECT_EQ(c.mu(), mu);
   EXPECT_EQ(c.parameters().mu, mu);
   EXPECT_EQ(c.parameters().stiffness, stiffness);
@@ -344,7 +344,7 @@ GTEST_TEST(SapFrictionConeConstraint, SingleCliqueConstraintClone) {
   EXPECT_EQ(clone->first_clique(), clique);
   EXPECT_THROW(clone->second_clique(), std::exception);
   EXPECT_EQ(clone->constraint_function(), Vector3d(0., 0., phi0));
-  EXPECT_EQ(clone->first_clique_jacobian(), J32);
+  EXPECT_EQ(clone->first_clique_jacobian().MakeDenseMatrix(), J32);
   EXPECT_THROW(clone->second_clique_jacobian(), std::exception);
   EXPECT_EQ(clone->mu(), mu);
   EXPECT_EQ(clone->parameters().mu, mu);
@@ -374,8 +374,8 @@ GTEST_TEST(SapFrictionConeConstraint, TwoCliquesConstraintClone) {
   EXPECT_EQ(clone->first_clique(), clique0);
   EXPECT_EQ(clone->second_clique(), clique1);
   EXPECT_EQ(clone->constraint_function(), Vector3d(0., 0., phi0));
-  EXPECT_EQ(clone->first_clique_jacobian(), J32);
-  EXPECT_EQ(clone->second_clique_jacobian(), J34);
+  EXPECT_EQ(clone->first_clique_jacobian().MakeDenseMatrix(), J32);
+  EXPECT_EQ(clone->second_clique_jacobian().MakeDenseMatrix(), J34);
   EXPECT_EQ(clone->mu(), mu);
   EXPECT_EQ(clone->parameters().mu, mu);
   EXPECT_EQ(clone->parameters().stiffness, stiffness);

--- a/multibody/contact_solvers/sap/test/sap_holonomic_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_holonomic_constraint_test.cc
@@ -69,7 +69,7 @@ TEST_F(SapHolonomicConstraintTests, SingleCliqueConstruction) {
   EXPECT_EQ(dut_->first_clique(), clique1_);
   EXPECT_THROW(dut_->second_clique(), std::exception);
   EXPECT_EQ(dut_->constraint_function(), g_);
-  EXPECT_EQ(dut_->first_clique_jacobian(), J_);
+  EXPECT_EQ(dut_->first_clique_jacobian().MakeDenseMatrix(), J_);
   EXPECT_THROW(dut_->second_clique_jacobian(), std::exception);
   EXPECT_EQ(dut_->bias(), b_);
   const SapHolonomicConstraint<double>::Parameters p =
@@ -101,8 +101,8 @@ TEST_F(SapHolonomicConstraintTests, TwoCliquesConstruction) {
   EXPECT_EQ(dut_->first_clique(), clique1);
   EXPECT_EQ(dut_->second_clique(), clique2);
   EXPECT_EQ(dut_->constraint_function(), g);
-  EXPECT_EQ(dut_->first_clique_jacobian(), J1);
-  EXPECT_EQ(dut_->second_clique_jacobian(), J2);
+  EXPECT_EQ(dut_->first_clique_jacobian().MakeDenseMatrix(), J1);
+  EXPECT_EQ(dut_->second_clique_jacobian().MakeDenseMatrix(), J2);
   EXPECT_EQ(dut_->bias(), Vector3d::Zero());
   EXPECT_EQ(dut_->parameters().impulse_lower_limits(),
             p.impulse_lower_limits());
@@ -289,7 +289,8 @@ TEST_F(SapHolonomicConstraintTests, Clone) {
   EXPECT_EQ(clone->first_clique(), clique1_);
   EXPECT_THROW(clone->second_clique(), std::exception);
   EXPECT_EQ(clone->constraint_function(), dut_->constraint_function());
-  EXPECT_EQ(clone->first_clique_jacobian(), dut_->first_clique_jacobian());
+  EXPECT_EQ(clone->first_clique_jacobian().MakeDenseMatrix(),
+            dut_->first_clique_jacobian().MakeDenseMatrix());
   EXPECT_THROW(clone->second_clique_jacobian(), std::exception);
   EXPECT_EQ(clone->bias(), dut_->bias());
   const SapHolonomicConstraint<double>::Parameters& p = dut_->parameters();

--- a/multibody/contact_solvers/sap/test/sap_limit_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_limit_constraint_test.cc
@@ -94,7 +94,8 @@ TEST_P(SapLimitConstraintTest, Construction) {
   EXPECT_EQ(dut_->first_clique(), clique_);
   EXPECT_THROW(dut_->second_clique(), std::exception);
   EXPECT_EQ(dut_->constraint_function(), MakeExpectedConstraintFunction());
-  EXPECT_EQ(dut_->first_clique_jacobian(), MakeExpectedJacobian());
+  EXPECT_EQ(dut_->first_clique_jacobian().MakeDenseMatrix(),
+            MakeExpectedJacobian());
   EXPECT_THROW(dut_->second_clique_jacobian(), std::exception);
   const SapLimitConstraint<double>::Parameters& p = GetParam();
   EXPECT_EQ(dut_->parameters().lower_limit(), p.lower_limit());
@@ -304,7 +305,8 @@ TEST_P(SapLimitConstraintTest, Clone) {
   EXPECT_EQ(clone->first_clique(), clique_);
   EXPECT_THROW(clone->second_clique(), std::exception);
   EXPECT_EQ(clone->constraint_function(), dut_->constraint_function());
-  EXPECT_EQ(clone->first_clique_jacobian(), dut_->first_clique_jacobian());
+  EXPECT_EQ(clone->first_clique_jacobian().MakeDenseMatrix(),
+            dut_->first_clique_jacobian().MakeDenseMatrix());
   EXPECT_THROW(clone->second_clique_jacobian(), std::exception);
   const SapLimitConstraint<double>::Parameters p = GetParam();
   EXPECT_EQ(clone->parameters().lower_limit(), p.lower_limit());

--- a/multibody/contact_solvers/sap/test/sap_model_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_model_test.cc
@@ -559,14 +559,18 @@ class DummyModelTest : public ::testing::Test {
       {
         const int c = constraint.first_clique();
         const MatrixXd& A = sap_problem_->dynamics_matrix()[c];
-        const MatrixXd& J = constraint.first_clique_jacobian();
-        W_approximation[i] += J * A.ldlt().solve(J.transpose());
+        const VectorXd& A_diag_inv = A.diagonal().cwiseInverse();
+        const MatrixXd& J =
+            constraint.first_clique_jacobian().MakeDenseMatrix();
+        W_approximation[i] += J * A_diag_inv.asDiagonal() * J.transpose();
       }
       if (constraint.num_cliques() == 2) {
         const int c = constraint.second_clique();
         const MatrixXd& A = sap_problem_->dynamics_matrix()[c];
-        const MatrixXd& J = constraint.second_clique_jacobian();
-        W_approximation[i] += J * A.ldlt().solve(J.transpose());
+        const VectorXd& A_diag_inv = A.diagonal().cwiseInverse();
+        const MatrixXd& J =
+            constraint.second_clique_jacobian().MakeDenseMatrix();
+        W_approximation[i] += J * A_diag_inv.asDiagonal() * J.transpose();
       }
     }
 

--- a/multibody/contact_solvers/supernodal_solver.h
+++ b/multibody/contact_solvers/supernodal_solver.h
@@ -8,6 +8,7 @@
 #include <Eigen/Dense>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/multibody/contact_solvers/matrix_block.h"
 
 #ifndef DRAKE_DOXYGEN_CXX
 // Forward declaration to avoid the inclusion of conex's headers within a Drake
@@ -22,7 +23,7 @@ namespace multibody {
 namespace contact_solvers {
 namespace internal {
 
-using BlockMatrixTriplet = std::tuple<int, int, Eigen::MatrixXd>;
+using BlockMatrixTriplet = std::tuple<int, int, MatrixBlock<double>>;
 
 // A supernodal Cholesky solver for solving the symmetric positive definite
 // system

--- a/multibody/contact_solvers/test/block_sparse_matrix_test.cc
+++ b/multibody/contact_solvers/test/block_sparse_matrix_test.cc
@@ -80,7 +80,8 @@ TEST_F(BlockSparseMatrixTest, AccessBlocks) {
   // entry of get_blocks().
   EXPECT_EQ(Jblk_.get_blocks().size(), 5u);
   for (int b = 0; b < Jblk_.num_blocks(); ++b) {
-    EXPECT_EQ(Jblk_.get_block(b), std::get<2>(Jblk_.get_blocks()[b]));
+    EXPECT_EQ(Jblk_.get_block(b).MakeDenseMatrix(),
+              std::get<2>(Jblk_.get_blocks()[b]).MakeDenseMatrix());
   }
 }
 

--- a/multibody/contact_solvers/test/supernodal_solver_test.cc
+++ b/multibody/contact_solvers/test/supernodal_solver_test.cc
@@ -106,9 +106,9 @@ std::vector<BlockMatrixTriplet> MakeBlockTriplets(
   for (int b = 0; b < num_blocks; ++b) {
     get<0>(triplets[b]) = block_positions[b].first;
     get<1>(triplets[b]) = block_positions[b].second;
-    get<2>(triplets[b]) =
+    get<2>(triplets[b]) = MatrixBlock<double>(
         A.block(dense_positions[b].first, dense_positions[b].second,
-                block_sizes[b].first, block_sizes[b].second);
+                block_sizes[b].first, block_sizes[b].second));
   }
   return triplets;
 }
@@ -505,25 +505,25 @@ GTEST_TEST(SupernodalSolver, FourStacks) {
   // clang-format on
   std::vector<BlockMatrixTriplet> Jtriplets;
   // Patch 0:
-  Jtriplets.push_back({0, 6, J3x6});
-  Jtriplets.push_back({0, 7, J3x6});
+  Jtriplets.push_back({0, 6, MatrixBlock<double>(J3x6)});
+  Jtriplets.push_back({0, 7, MatrixBlock<double>(J3x6)});
   // Patch 1:
-  Jtriplets.push_back({1, 4, J3x6});
-  Jtriplets.push_back({1, 5, J3x6});
+  Jtriplets.push_back({1, 4, MatrixBlock<double>(J3x6)});
+  Jtriplets.push_back({1, 5, MatrixBlock<double>(J3x6)});
   // Patch 2:
-  Jtriplets.push_back({2, 6, J3x6});
+  Jtriplets.push_back({2, 6, MatrixBlock<double>(J3x6)});
   // Patch 3:
-  Jtriplets.push_back({3, 0, J3x6});
+  Jtriplets.push_back({3, 0, MatrixBlock<double>(J3x6)});
   // Patch 4:
-  Jtriplets.push_back({4, 4, J3x6});
+  Jtriplets.push_back({4, 4, MatrixBlock<double>(J3x6)});
   // Patch 5:
-  Jtriplets.push_back({5, 2, J3x6});
+  Jtriplets.push_back({5, 2, MatrixBlock<double>(J3x6)});
   // Patch 6:
-  Jtriplets.push_back({6, 0, J3x6});
-  Jtriplets.push_back({6, 1, J3x6});
+  Jtriplets.push_back({6, 0, MatrixBlock<double>(J3x6)});
+  Jtriplets.push_back({6, 1, MatrixBlock<double>(J3x6)});
   // Patch 7:
-  Jtriplets.push_back({7, 2, J3x6});
-  Jtriplets.push_back({7, 3, J3x6});
+  Jtriplets.push_back({7, 2, MatrixBlock<double>(J3x6)});
+  Jtriplets.push_back({7, 3, MatrixBlock<double>(J3x6)});
   MatrixXd Gb(3, 3);
   // clang-format off
   Gb << 1, 2, 2,

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -178,6 +178,7 @@ drake_cc_library(
     deps = [
         "//common:default_scalars",
         "//math:geometric_transform",
+        "//multibody/contact_solvers:matrix_block",
         "//multibody/tree:multibody_tree_indexes",
     ],
 )

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -25,6 +25,7 @@ using drake::geometry::GeometryId;
 using drake::geometry::PenetrationAsPointPair;
 using drake::math::RotationMatrix;
 using drake::multibody::contact_solvers::internal::ContactSolverResults;
+using drake::multibody::contact_solvers::internal::MatrixBlock;
 using drake::multibody::internal::DiscreteContactPair;
 using drake::multibody::internal::MultibodyTreeTopology;
 using drake::systems::Context;
@@ -230,7 +231,7 @@ CompliantContactManager<T>::CalcContactKinematics(
                       Jv_AcBc_W.middleCols(
                           tree_topology().tree_velocities_start(treeA_index),
                           tree_topology().num_tree_velocities(treeA_index));
-      jacobian_blocks.emplace_back(treeA_index, std::move(J));
+      jacobian_blocks.emplace_back(treeA_index, MatrixBlock<T>(std::move(J)));
     }
 
     // Tree B contribution to contact Jacobian Jv_W_AcBc_C.
@@ -241,7 +242,7 @@ CompliantContactManager<T>::CalcContactKinematics(
                       Jv_AcBc_W.middleCols(
                           tree_topology().tree_velocities_start(treeB_index),
                           tree_topology().num_tree_velocities(treeB_index));
-      jacobian_blocks.emplace_back(treeB_index, std::move(J));
+      jacobian_blocks.emplace_back(treeB_index, MatrixBlock<T>(std::move(J)));
     }
 
     contact_kinematics.emplace_back(point_pair.phi0, std::move(jacobian_blocks),

--- a/multibody/plant/contact_pair_kinematics.h
+++ b/multibody/plant/contact_pair_kinematics.h
@@ -6,6 +6,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/math/rotation_matrix.h"
+#include "drake/multibody/contact_solvers/matrix_block.h"
 #include "drake/multibody/tree/multibody_tree_indexes.h"
 
 namespace drake {
@@ -25,7 +26,8 @@ struct ContactPairKinematics {
   struct JacobianTreeBlock {
     DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(JacobianTreeBlock);
 
-    JacobianTreeBlock(TreeIndex tree_in, Matrix3X<T> J_in)
+    JacobianTreeBlock(TreeIndex tree_in,
+                      contact_solvers::internal::MatrixBlock<T> J_in)
         : tree(tree_in), J(std::move(J_in)) {}
 
     // Index of the tree for this block.
@@ -33,7 +35,7 @@ struct ContactPairKinematics {
 
     // J.cols() must equal the number of generalized velocities for
     // the corresponding tree.
-    Matrix3X<T> J;
+    contact_solvers::internal::MatrixBlock<T> J;
   };
 
   ContactPairKinematics(T phi_in, std::vector<JacobianTreeBlock> jacobian_in,

--- a/multibody/plant/tamsi_driver.cc
+++ b/multibody/plant/tamsi_driver.cc
@@ -44,7 +44,7 @@ internal::ContactJacobians<T> TamsiDriver<T>::CalcContactJacobians(
       const int col_offset = topology.tree_velocities_start(tree_jacobian.tree);
       const int tree_nv = topology.num_tree_velocities(tree_jacobian.tree);
       contact_jacobians.Jc.block(row_offset, col_offset, 3, tree_nv) =
-          tree_jacobian.J;
+          tree_jacobian.J.MakeDenseMatrix();
     }
     contact_jacobians.Jt.middleRows(2 * i, 2) =
         contact_jacobians.Jc.middleRows(3 * i, 2);

--- a/multibody/plant/test/compliant_contact_manager_tester.h
+++ b/multibody/plant/test/compliant_contact_manager_tester.h
@@ -96,7 +96,8 @@ class CompliantContactManagerTester {
         const int col_offset =
             topology.tree_velocities_start(tree_jacobian.tree);
         const int tree_nv = topology.num_tree_velocities(tree_jacobian.tree);
-        J_AcBc_C.block(row_offset, col_offset, 3, tree_nv) = tree_jacobian.J;
+        J_AcBc_C.block(row_offset, col_offset, 3, tree_nv) =
+            tree_jacobian.J.MakeDenseMatrix();
       }
     }
     return J_AcBc_C;

--- a/multibody/plant/test/deformable_driver_contact_kinematics_test.cc
+++ b/multibody/plant/test/deformable_driver_contact_kinematics_test.cc
@@ -203,9 +203,11 @@ class DeformableDriverContactKinematicsTest : public ::testing::Test {
       EXPECT_TRUE(contact_kinematic.R_WC.IsNearlyEqualTo(expected_R_WC, 1e-12));
       if (dynamic_rigid_body) {
         ASSERT_EQ(contact_kinematic.jacobian.size(), 2);
-        const Matrix3X<double> J0 = contact_kinematic.jacobian[0].J;
+        const Matrix3X<double> J0 =
+            contact_kinematic.jacobian[0].J.MakeDenseMatrix();
         ASSERT_EQ(v0.size(), J0.cols());
-        const Matrix3X<double> J1 = contact_kinematic.jacobian[1].J;
+        const Matrix3X<double> J1 =
+            contact_kinematic.jacobian[1].J.MakeDenseMatrix();
         const Vector3d v_WR_F(0, 0, 0.5);
         const Vector3d v_WR = X_WF_.rotation() * v_WR_F;
         const Vector3d w_WR(0, 0, 0);
@@ -216,7 +218,8 @@ class DeformableDriverContactKinematicsTest : public ::testing::Test {
             CompareMatrices(J0 * v0 + J1 * v1, expected_v_DpRp_C, 1e-14));
       } else {
         ASSERT_EQ(contact_kinematic.jacobian.size(), 1);
-        const Matrix3X<double> J0 = contact_kinematic.jacobian[0].J;
+        const Matrix3X<double> J0 =
+            contact_kinematic.jacobian[0].J.MakeDenseMatrix();
         ASSERT_EQ(v0.size(), J0.cols());
         EXPECT_TRUE(CompareMatrices(J0 * v0, expected_v_DpRp_C, 1e-14));
       }
@@ -358,7 +361,8 @@ GTEST_TEST(DeformableDriverContactKinematicsWithBcTest,
         contact_kinematics[i];
     /* The first jacobian entry corresponds to the contribution of the
      deformable clique. */
-    const Matrix3X<double>& J = contact_kinematic.jacobian[0].J;
+    const Matrix3X<double>& J =
+        contact_kinematic.jacobian[0].J.MakeDenseMatrix();
     /* The jacobian isn't completely zero. */
     EXPECT_GT(J.norm(), 0.01);
     /* But the columns corresponding to the vertex under bc are set to zero. */

--- a/multibody/plant/test/sap_driver_ball_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_ball_constraints_test.cc
@@ -190,7 +190,7 @@ TEST_P(TwoBodiesTest, ConfirmConstraintProperties) {
   //        = [-[p_BQ]ₓ [I]] ⋅ V_WB - [-[p_AP]ₓ [I]] ⋅ V_WA
   //        = J_B ⋅ V_WB - J_A ⋅ V_WA
   if (expected_num_cliques == 1) {
-    const MatrixXd& J = constraint->first_clique_jacobian();
+    const MatrixXd& J = constraint->first_clique_jacobian().MakeDenseMatrix();
     // clang-format off
       const MatrixXd J_expected =
         (MatrixXd(3, 6) <<         0,  p_BQ_(2), -p_BQ_(1), 1, 0, 0,
@@ -199,7 +199,7 @@ TEST_P(TwoBodiesTest, ConfirmConstraintProperties) {
     // clang-format on
     EXPECT_TRUE(CompareMatrices(J, J_expected));
   } else {
-    const MatrixXd& Ja = constraint->first_clique_jacobian();
+    const MatrixXd& Ja = constraint->first_clique_jacobian().MakeDenseMatrix();
     // clang-format off
     const MatrixXd Ja_expected =
       -(MatrixXd(3, 6) <<         0,  p_AP_(2), -p_AP_(1), 1, 0, 0,
@@ -208,7 +208,7 @@ TEST_P(TwoBodiesTest, ConfirmConstraintProperties) {
     // clang-format on
     EXPECT_TRUE(CompareMatrices(Ja, Ja_expected));
 
-    const MatrixXd& Jb = constraint->second_clique_jacobian();
+    const MatrixXd& Jb = constraint->second_clique_jacobian().MakeDenseMatrix();
     // clang-format off
       const MatrixXd Jb_expected =
         (MatrixXd(3, 6) <<         0,  p_BQ_(2), -p_BQ_(1), 1, 0, 0,

--- a/multibody/plant/test/sap_driver_distance_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_distance_constraints_test.cc
@@ -197,17 +197,19 @@ TEST_P(TwoBodiesTest, ConfirmConstraintProperties) {
     // velocities first, followed by translational velocities (and the
     // relative positions of the bodies).
     if (expected_num_cliques == 1) {
-      const MatrixXd& J = constraint->first_clique_jacobian();
+      const MatrixXd& J = constraint->first_clique_jacobian().MakeDenseMatrix();
       const MatrixXd J_expected =
           (MatrixXd(1, 6) << 0, 0, 0, 1, 0, 0).finished();
       EXPECT_TRUE(CompareMatrices(J, J_expected));
     } else {
-      const MatrixXd& Ja = constraint->first_clique_jacobian();
+      const MatrixXd& Ja =
+          constraint->first_clique_jacobian().MakeDenseMatrix();
       const MatrixXd Ja_expected =
           (MatrixXd(1, 6) << 0, 0, 0, -1, 0, 0).finished();
       EXPECT_TRUE(CompareMatrices(Ja, Ja_expected));
 
-      const MatrixXd& Jb = constraint->second_clique_jacobian();
+      const MatrixXd& Jb =
+          constraint->second_clique_jacobian().MakeDenseMatrix();
       const MatrixXd Jb_expected =
           (MatrixXd(1, 6) << 0, 0, 0, 1, 0, 0).finished();
       EXPECT_TRUE(CompareMatrices(Jb, Jb_expected));

--- a/multibody/plant/test/sap_driver_joint_limits_test.cc
+++ b/multibody/plant/test/sap_driver_joint_limits_test.cc
@@ -653,7 +653,8 @@ TEST_F(KukaIiwaArmTests, CouplerConstraints) {
           (VectorXd::Unit(kNumJoints, left_index) -
            kCouplerGearRatio * VectorXd::Unit(kNumJoints, right_index))
               .transpose();
-      EXPECT_EQ(constraint->first_clique_jacobian(), J_expected);
+      EXPECT_EQ(constraint->first_clique_jacobian().MakeDenseMatrix(),
+                J_expected);
     } else {
       // The third constraint couples the two robot arms.
       const MatrixXd J0_expected =
@@ -661,8 +662,10 @@ TEST_F(KukaIiwaArmTests, CouplerConstraints) {
       const MatrixXd J1_expected =
           -kCouplerGearRatio *
           VectorXd::Unit(kNumJoints, 5 /* sixth joint. */).transpose();
-      EXPECT_EQ(constraint->first_clique_jacobian(), J0_expected);
-      EXPECT_EQ(constraint->second_clique_jacobian(), J1_expected);
+      EXPECT_EQ(constraint->first_clique_jacobian().MakeDenseMatrix(),
+                J0_expected);
+      EXPECT_EQ(constraint->second_clique_jacobian().MakeDenseMatrix(),
+                J1_expected);
     }
 
     // N.B. Default values implemented in

--- a/multibody/plant/test/sap_driver_test.cc
+++ b/multibody/plant/test/sap_driver_test.cc
@@ -174,12 +174,12 @@ TEST_F(SpheresStackTest, EvalContactProblemCache) {
               Vector3d(0., 0., pair_kinematics.phi));
     EXPECT_EQ(constraint->num_cliques(), pair_kinematics.jacobian.size());
     EXPECT_EQ(constraint->first_clique(), pair_kinematics.jacobian[0].tree);
-    EXPECT_EQ(constraint->first_clique_jacobian(),
-              pair_kinematics.jacobian[0].J);
+    EXPECT_EQ(constraint->first_clique_jacobian().MakeDenseMatrix(),
+              pair_kinematics.jacobian[0].J.MakeDenseMatrix());
     if (constraint->num_cliques() == 2) {
       EXPECT_EQ(constraint->second_clique(), pair_kinematics.jacobian[1].tree);
-      EXPECT_EQ(constraint->second_clique_jacobian(),
-                pair_kinematics.jacobian[1].J);
+      EXPECT_EQ(constraint->second_clique_jacobian().MakeDenseMatrix(),
+                pair_kinematics.jacobian[1].J.MakeDenseMatrix());
     }
     EXPECT_EQ(constraint->parameters().mu, discrete_pair.friction_coefficient);
     EXPECT_EQ(constraint->parameters().stiffness, discrete_pair.stiffness);


### PR DESCRIPTION
This involves several related changes:

1. Update BlockSparseMatrix to use MatrixBlock
2. SupernodalSolver uses MatrixBlock to leverage sparsity when the matrix stored in MatrixBlock is sparse.
3. SapConstraint uses MatrixBlocks instead of Eigen dense matrices.
4. ContactPairKinematics uses MatrixBlocks instead of Eigen dense matrices.
5. Estimate Delassus operator as J * diag(A)⁻¹ * Jᵀ.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19150)
<!-- Reviewable:end -->
