### PR TITLE
Support passing a MathematicalProgram to the DirectCollocation constructor

### DIFF
--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -213,13 +213,13 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
                  const systems::Context<double>&, int, double, double,
                  std::variant<systems::InputPortSelection,
                      systems::InputPortIndex>,
-                 bool>(),
+                 bool, solvers::MathematicalProgram*>(),
             py::arg("system"), py::arg("context"), py::arg("num_time_samples"),
             py::arg("minimum_timestep"), py::arg("maximum_timestep"),
             py::arg("input_port_index") =
                 systems::InputPortSelection::kUseFirstInputIfItExists,
             py::arg("assume_non_continuous_states_are_fixed") = false,
-            cls_doc.ctor.doc);
+            py::arg("prog") = nullptr, cls_doc.ctor.doc);
   }
 
   {

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -39,6 +39,7 @@ class TestTrajectoryOptimization(unittest.TestCase):
             input_port_index=InputPortSelection.kUseFirstInputIfItExists,
             assume_non_continuous_states_are_fixed=False)
         prog = dircol.prog()
+        num_initial_vars = prog.num_vars()
 
         # Spell out most of the methods, regardless of whether they make sense
         # as a consistent optimization.  The goal is to check the bindings,
@@ -137,6 +138,20 @@ class TestTrajectoryOptimization(unittest.TestCase):
         self.assertIsInstance(c[0].evaluator(), mp.LinearEqualityConstraint)
         self.assertEqual(len(prog.linear_equality_constraints()),
                          nc + 2*num_time_samples)
+
+        # Add a second direct collocation problem to the same prog.
+        num_vars = prog.num_vars()
+        dircol2 = DirectCollocation(
+            plant,
+            context,
+            num_time_samples=num_time_samples,
+            minimum_timestep=0.2,
+            maximum_timestep=0.5,
+            input_port_index=InputPortSelection.kUseFirstInputIfItExists,
+            assume_non_continuous_states_are_fixed=False,
+            prog=prog)
+        self.assertEqual(dircol.prog(), dircol2.prog())
+        self.assertEqual(prog.num_vars(), num_vars + num_initial_vars)
 
     def test_direct_transcription(self):
         # Integrator.

--- a/planning/trajectory_optimization/direct_collocation.h
+++ b/planning/trajectory_optimization/direct_collocation.h
@@ -36,25 +36,31 @@ class DirectCollocation : public MultipleShooting {
   ///
   /// @param system A dynamical system to be used in the dynamic constraints.
   /// This system must support System::ToAutoDiffXd. Note that this is aliased
-  /// for the lifetime of this object. @param context Required to describe any
-  /// parameters of the system.  The values of the state in this context do not
-  /// have any effect.  This context will also be "cloned" by the optimization;
-  /// changes to the context after calling this method will NOT impact the
-  /// trajectory optimization. @param num_time_samples The number of
-  /// breakpoints in the trajectory. @param minimum_timestep Minimum spacing
-  /// between sample times. @param maximum_timestep Maximum spacing between
-  /// sample times. @param input_port_index A valid input port index for @p
-  /// system or InputPortSelection.  All other inputs on the system will be
-  /// left disconnected (if they are disconnected in @p context) or will be
-  /// fixed to their current values (if they are connected/fixed in @p
-  /// context). @default kUseFirstInputIfItExists. @param
-  /// assume_non_continuous_states_are_fixed Boolean which, if true, allows
-  /// this algorithm to optimize without considering the dynamics of any
+  /// for the lifetime of this object.
+  /// @param context Required to describe any parameters of the system.  The
+  /// values of the state in this context do not have any effect.  This context
+  /// will also be "cloned" by the optimization; changes to the context after
+  /// calling this method will NOT impact the trajectory optimization.
+  /// @param num_time_samples The number of breakpoints in the trajectory.
+  /// @param minimum_timestep Minimum spacing between sample times.
+  /// @param maximum_timestep Maximum spacing between sample times.
+  /// @param input_port_index A valid input port index for @p system or
+  /// InputPortSelection.  All other inputs on the system will be left
+  /// disconnected (if they are disconnected in @p context) or will be fixed to
+  /// their current values (if they are connected/fixed in @p context).
+  /// @default kUseFirstInputIfItExists.
+  /// @param assume_non_continuous_states_are_fixed Boolean which, if true,
+  /// allows this algorithm to optimize without considering the dynamics of any
   /// non-continuous states. This is helpful for optimizing systems that might
   /// have some additional book-keeping variables in their state. Only use this
   /// if you are sure that the dynamics of the additional state variables
   /// cannot impact the dynamics of the continuous states. @default false.
-  ///
+  /// @param prog (optional).  If non-null, then additional decision variables,
+  /// costs, and constraints will be added into the existing
+  /// MathematicalProgram. This can be useful for, e.g., combining multiple
+  /// trajectory optimizations into a single program, coupled by a few
+  /// constraints.  If nullptr, then a new MathematicalProgram will be
+  /// allocated.
   /// @throws std::exception if `system` is not supported by this direct
   /// collocation method.
   DirectCollocation(
@@ -64,14 +70,12 @@ class DirectCollocation : public MultipleShooting {
       std::variant<systems::InputPortSelection, systems::InputPortIndex>
           input_port_index =
               systems::InputPortSelection::kUseFirstInputIfItExists,
-      bool assume_non_continuous_states_are_fixed = false);
+      bool assume_non_continuous_states_are_fixed = false,
+      solvers::MathematicalProgram* prog = nullptr);
 
   // NOTE: The fixed timestep constructor, which would avoid adding h as
-  // decision variables, has been removed since it complicates the API and code.
-  // Unlike other trajectory optimization transcriptions, direct collocation
-  // will not be a convex optimization even if the sample times are fixed, so
-  // there is little advantage to actually removing the variables.  Setting
-  // minimum_timestep == maximum_timestep should be essentially just as good.
+  // decision variables, has been (temporarily) removed since it complicates
+  // the API and code.
 
   ~DirectCollocation() override {}
 

--- a/planning/trajectory_optimization/multiple_shooting.cc
+++ b/planning/trajectory_optimization/multiple_shooting.cc
@@ -32,55 +32,61 @@ using trajectories::PiecewisePolynomial;
 // u control input
 
 MultipleShooting::MultipleShooting(int num_inputs, int num_states,
-                                   int num_time_samples, double fixed_timestep)
+                                   int num_time_samples, double fixed_timestep,
+                                   solvers::MathematicalProgram* prog)
     : MultipleShooting(num_inputs, num_states, num_time_samples,
                        false /* timesteps_are_decision_variables */,
-                       fixed_timestep, fixed_timestep) {}
+                       fixed_timestep, fixed_timestep, prog) {}
 
 MultipleShooting::MultipleShooting(
     const solvers::VectorXDecisionVariable& input,
     const solvers::VectorXDecisionVariable& state, int num_time_samples,
-    double fixed_timestep)
+    double fixed_timestep, solvers::MathematicalProgram* prog)
     : MultipleShooting(input, state, num_time_samples, std::nullopt,
-                       fixed_timestep, fixed_timestep) {}
+                       fixed_timestep, fixed_timestep, prog) {}
 
 MultipleShooting::MultipleShooting(int num_inputs, int num_states,
                                    int num_time_samples,
                                    double minimum_timestep,
-                                   double maximum_timestep)
+                                   double maximum_timestep,
+                                   solvers::MathematicalProgram* prog)
     : MultipleShooting(num_inputs, num_states, num_time_samples,
                        true /* timesteps_are_decision_variables */,
-                       minimum_timestep, maximum_timestep) {}
+                       minimum_timestep, maximum_timestep, prog) {}
 
 MultipleShooting::MultipleShooting(
     const solvers::VectorXDecisionVariable& input,
     const solvers::VectorXDecisionVariable& state,
     const solvers::DecisionVariable& time, int num_time_samples,
-    double minimum_timestep, double maximum_timestep)
+    double minimum_timestep, double maximum_timestep,
+    solvers::MathematicalProgram* prog)
     : MultipleShooting(input, state, num_time_samples, time, minimum_timestep,
-                       maximum_timestep) {}
+                       maximum_timestep, prog) {}
 
 MultipleShooting::MultipleShooting(int num_inputs, int num_states,
                                    int num_time_samples,
                                    bool timesteps_are_decision_variables,
                                    double minimum_timestep,
-                                   double maximum_timestep)
+                                   double maximum_timestep,
+                                   solvers::MathematicalProgram* prog)
     : MultipleShooting(
           MakeVectorContinuousVariable(num_inputs, "u"),
           MakeVectorContinuousVariable(num_states, "x"), num_time_samples,
           timesteps_are_decision_variables
-              ? std::optional<solvers::DecisionVariable>{
-                  solvers::DecisionVariable{"t"}}
+              ? std::optional<
+                    solvers::DecisionVariable>{solvers::DecisionVariable{"t"}}
               : std::nullopt,
-          minimum_timestep, maximum_timestep) {}
+          minimum_timestep, maximum_timestep, prog) {}
 
 MultipleShooting::MultipleShooting(
     const solvers::VectorXDecisionVariable& input,
     const solvers::VectorXDecisionVariable& state, int num_time_samples,
     const std::optional<solvers::DecisionVariable>& time_var,
-    double minimum_timestep, double maximum_timestep)
-    : owned_prog_(std::make_unique<solvers::MathematicalProgram>()),
-      prog_(*owned_prog_),
+    double minimum_timestep, double maximum_timestep,
+    solvers::MathematicalProgram* prog)
+    : owned_prog_(prog ? nullptr
+                       : std::make_unique<solvers::MathematicalProgram>()),
+      prog_(prog ? *prog : *owned_prog_),
       num_inputs_(input.size()),
       num_states_(state.size()),
       N_(num_time_samples),

--- a/planning/trajectory_optimization/multiple_shooting.h
+++ b/planning/trajectory_optimization/multiple_shooting.h
@@ -398,8 +398,15 @@ class MultipleShooting {
   /// @param num_states Number of states at each sample point.
   /// @param num_time_samples Number of time samples.
   /// @param fixed_timestep The spacing between sample times.
+  /// @param prog (optional).  If non-null, then additional decision variables,
+  /// costs, and constraints will be added into the existing
+  /// MathematicalProgram. This can be useful for, e.g., combining multiple
+  /// trajectory optimizations into a single program, coupled by a few
+  /// constraints.  If nullptr, then a new MathematicalProgram will be
+  /// allocated.
   MultipleShooting(int num_inputs, int num_states, int num_time_samples,
-                   double fixed_timestep);
+                   double fixed_timestep,
+                   solvers::MathematicalProgram* prog = nullptr);
 
   /// Constructs a MultipleShooting instance with fixed sample times. It uses
   /// the provided `input` and `state` as placeholders instead of creating new
@@ -409,9 +416,16 @@ class MultipleShooting {
   /// @param state Placeholder variables for state.
   /// @param num_time_samples Number of time samples.
   /// @param fixed_timestep The spacing between sample times.
+  /// @param prog (optional).  If non-null, then additional decision variables,
+  /// costs, and constraints will be added into the existing
+  /// MathematicalProgram. This can be useful for, e.g., combining multiple
+  /// trajectory optimizations into a single program, coupled by a few
+  /// constraints.  If nullptr, then a new MathematicalProgram will be
+  /// allocated.
   MultipleShooting(const solvers::VectorXDecisionVariable& input,
                    const solvers::VectorXDecisionVariable& state,
-                   int num_time_samples, double fixed_timestep);
+                   int num_time_samples, double fixed_timestep,
+                   solvers::MathematicalProgram* prog = nullptr);
 
   /// Constructs a MultipleShooting instance with sample times as decision
   /// variables.  It creates new placeholder variables for input, state, and
@@ -422,8 +436,15 @@ class MultipleShooting {
   /// @param num_time_samples Number of time samples.
   /// @param minimum_timestep Minimum spacing between sample times.
   /// @param maximum_timestep Maximum spacing between sample times.
+  /// @param prog (optional).  If non-null, then additional decision variables,
+  /// costs, and constraints will be added into the existing
+  /// MathematicalProgram. This can be useful for, e.g., combining multiple
+  /// trajectory optimizations into a single program, coupled by a few
+  /// constraints.  If nullptr, then a new MathematicalProgram will be
+  /// allocated.
   MultipleShooting(int num_inputs, int num_states, int num_time_samples,
-                   double minimum_timestep, double maximum_timestep);
+                   double minimum_timestep, double maximum_timestep,
+                   solvers::MathematicalProgram* prog = nullptr);
 
   /// Constructs a MultipleShooting instance with sample times as decision
   /// variables. It uses the provided `input`, `state`, and `time` as
@@ -435,10 +456,17 @@ class MultipleShooting {
   /// @param num_time_samples Number of time samples.
   /// @param minimum_timestep Minimum spacing between sample times.
   /// @param maximum_timestep Maximum spacing between sample times.
+  /// @param prog (optional).  If non-null, then additional decision variables,
+  /// costs, and constraints will be added into the existing
+  /// MathematicalProgram. This can be useful for, e.g., combining multiple
+  /// trajectory optimizations into a single program, coupled by a few
+  /// constraints.  If nullptr, then a new MathematicalProgram will be
+  /// allocated.
   MultipleShooting(const solvers::VectorXDecisionVariable& input,
                    const solvers::VectorXDecisionVariable& state,
                    const solvers::DecisionVariable& time, int num_time_samples,
-                   double minimum_timestep, double maximum_timestep);
+                   double minimum_timestep, double maximum_timestep,
+                   solvers::MathematicalProgram* prog = nullptr);
 
   /// Replaces e.g. placeholder_x_var_ with x_vars_ at time interval
   /// @p interval_index, for all placeholder variables.
@@ -476,11 +504,13 @@ class MultipleShooting {
                    const solvers::VectorXDecisionVariable& state,
                    int num_time_samples,
                    const std::optional<solvers::DecisionVariable>& time_var,
-                   double minimum_timestep, double maximum_timestep);
+                   double minimum_timestep, double maximum_timestep,
+                   solvers::MathematicalProgram* prog = nullptr);
 
   MultipleShooting(int num_inputs, int num_states, int num_time_samples,
                    bool timesteps_are_decision_variables,
-                   double minimum_timestep, double maximum_timestep);
+                   double minimum_timestep, double maximum_timestep,
+                   solvers::MathematicalProgram* prog = nullptr);
 
   virtual void DoAddRunningCost(const symbolic::Expression& g) = 0;
 
@@ -488,8 +518,6 @@ class MultipleShooting {
   symbolic::Substitution ConstructPlaceholderVariableSubstitution(
       int interval_index) const;
 
-  // TODO(russt): Add a constructor whichs take a MathematicalProgram&
-  // as an argument.
   const std::unique_ptr<solvers::MathematicalProgram> owned_prog_;
   solvers::MathematicalProgram& prog_;
 

--- a/planning/trajectory_optimization/test/direct_collocation_test.cc
+++ b/planning/trajectory_optimization/test/direct_collocation_test.cc
@@ -75,6 +75,29 @@ GTEST_TEST(DirectCollocationConstraint, AutoDiffXdConstructor) {
   constraint.Eval(x, &y);
 }
 
+GTEST_TEST(DirectCollocation, PassProgToConstructor) {
+  const std::unique_ptr<LinearSystem<double>> system = MakeSimpleLinearSystem();
+  const std::unique_ptr<Context<double>> context =
+      system->CreateDefaultContext();
+
+  const int kNumSampleTimes = 4;
+  const double kTimeStep = .1;
+  solvers::MathematicalProgram prog;
+  DirectCollocation dircol(
+      system.get(), *context, kNumSampleTimes, kTimeStep, kTimeStep,
+      systems::InputPortSelection::kUseFirstInputIfItExists, false, &prog);
+
+  EXPECT_EQ(&prog, &dircol.prog());
+  const int num_vars = prog.num_vars();
+
+  // Add a second direct collocation problem to the same prog.
+  DirectCollocation dircol2(
+      system.get(), *context, kNumSampleTimes, kTimeStep, kTimeStep,
+      systems::InputPortSelection::kUseFirstInputIfItExists, false, &prog);
+  EXPECT_EQ(&prog, &dircol2.prog());
+  EXPECT_EQ(prog.num_vars(), num_vars * 2);
+}
+
 GTEST_TEST(DirectCollocation, TestAddRunningCost) {
   const std::unique_ptr<LinearSystem<double>> system = MakeSimpleLinearSystem();
   const std::unique_ptr<Context<double>> context =

--- a/planning/trajectory_optimization/test/multiple_shooting_test.cc
+++ b/planning/trajectory_optimization/test/multiple_shooting_test.cc
@@ -28,27 +28,32 @@ typedef PiecewisePolynomial<double> PiecewisePolynomialType;
 class MyDirectTrajOpt : public MultipleShooting {
  public:
   MyDirectTrajOpt(const int num_inputs, const int num_states,
-                  const int num_time_samples, const double fixed_timestep)
+                  const int num_time_samples, const double fixed_timestep,
+                  solvers::MathematicalProgram* prog = nullptr)
       : MultipleShooting(num_inputs, num_states, num_time_samples,
-                         fixed_timestep) {}
+                         fixed_timestep, prog) {}
 
   MyDirectTrajOpt(const int num_inputs, const int num_states,
                   const int num_time_samples, const double min_timestep,
-                  const double max_timestep)
+                  const double max_timestep,
+                  solvers::MathematicalProgram* prog = nullptr)
       : MultipleShooting(num_inputs, num_states, num_time_samples, min_timestep,
-                         max_timestep) {}
+                         max_timestep, prog) {}
 
   MyDirectTrajOpt(const solvers::VectorXDecisionVariable& input,
                   const solvers::VectorXDecisionVariable& state,
-                  const int num_time_samples, const double fixed_timestep)
-      : MultipleShooting(input, state, num_time_samples, fixed_timestep) {}
+                  const int num_time_samples, const double fixed_timestep,
+                  solvers::MathematicalProgram* prog = nullptr)
+      : MultipleShooting(input, state, num_time_samples, fixed_timestep,
+                         prog) {}
 
   MyDirectTrajOpt(const solvers::VectorXDecisionVariable& input,
                   const solvers::VectorXDecisionVariable& state,
                   const symbolic::Variable& time, const int num_time_samples,
-                  const double min_timestep, const double max_timestep)
+                  const double min_timestep, const double max_timestep,
+                  solvers::MathematicalProgram* prog = nullptr)
       : MultipleShooting(input, state, time, num_time_samples, min_timestep,
-                         max_timestep) {}
+                         max_timestep, prog) {}
 
   PiecewisePolynomial<double> ReconstructInputTrajectory(
       const solvers::MathematicalProgramResult&) const override {
@@ -96,6 +101,24 @@ GTEST_TEST(MultipleShootingTest, FixedTimestepTest) {
   EXPECT_THROW(trajopt.AddDurationBounds(0, 1), std::runtime_error);
 }
 
+GTEST_TEST(MultipleShootingTest, FixedTimestepWithProgTest) {
+  const int kNumInputs{1};
+  const int kNumStates{2};
+  const int kNumSampleTimes{2};
+  const double kFixedTimeStep{0.1};
+  solvers::MathematicalProgram prog;
+
+  MyDirectTrajOpt trajopt(kNumInputs, kNumStates, kNumSampleTimes,
+                          kFixedTimeStep, &prog);
+  EXPECT_EQ(&prog, &trajopt.prog());
+  EXPECT_EQ(prog.num_vars(), 6);
+
+  MyDirectTrajOpt trajopt2(kNumInputs, kNumStates, kNumSampleTimes,
+                           kFixedTimeStep, &prog);
+  EXPECT_EQ(&prog, &trajopt2.prog());
+  EXPECT_EQ(prog.num_vars(), 12);
+}
+
 GTEST_TEST(MultipleShootingTest, FixedTimestepTestWithPlaceholderVariables) {
   const VectorX<symbolic::Variable> input{
       symbolic::MakeVectorContinuousVariable(3, "my_input")};
@@ -126,6 +149,12 @@ GTEST_TEST(MultipleShootingTest, FixedTimestepTestWithPlaceholderVariables) {
   EXPECT_THROW(trajopt.AddTimeIntervalBounds(0, .1), std::runtime_error);
   EXPECT_THROW(trajopt.AddEqualTimeIntervalsConstraints(), std::runtime_error);
   EXPECT_THROW(trajopt.AddDurationBounds(0, 1), std::runtime_error);
+
+  // Now use the constructor which takes a prog.
+  MyDirectTrajOpt trajopt2(input, state, kNumSampleTimes, kFixedTimeStep,
+                           &trajopt.prog());
+  EXPECT_EQ(trajopt.prog().num_vars(),
+            2 * (input.size() + state.size()) * kNumSampleTimes);
 }
 
 GTEST_TEST(MultipleShootingTest, VariableTimestepTestWithPlaceholderVariables) {
@@ -160,6 +189,13 @@ GTEST_TEST(MultipleShootingTest, VariableTimestepTestWithPlaceholderVariables) {
   EXPECT_EQ(times.size(), 2);
   EXPECT_NEAR(times[0], 0.0, kSolverTolerance);
   EXPECT_NEAR(times[1], 0.1, kSolverTolerance);
+
+  // Now use the constructor which takes a prog.
+  MyDirectTrajOpt trajopt2(input, state, time, kNumSampleTimes, kMinTimeStep,
+                           kMaxTimeStep, &trajopt.prog());
+  EXPECT_EQ(trajopt.prog().num_vars(),
+            2 * (input.size() + state.size()) * kNumSampleTimes +
+                2 /* time variables */);
 }
 
 GTEST_TEST(MultipleShootingTest, VariableTimestepTest) {
@@ -181,6 +217,11 @@ GTEST_TEST(MultipleShootingTest, VariableTimestepTest) {
   EXPECT_EQ(times.size(), 2);
   EXPECT_NEAR(times[0], 0.0, kSolverTolerance);
   EXPECT_NEAR(times[1], 0.1, kSolverTolerance);
+
+  // Now use the constructor which takes a prog.
+  MyDirectTrajOpt trajopt2(kNumInputs, kNumStates, kNumSampleTimes,
+                           kMinTimeStep, kMaxTimeStep, &trajopt.prog());
+  EXPECT_EQ(trajopt.prog().num_vars(), 14);
 }
 
 GTEST_TEST(MultipleShootingTest, PlaceholderVariableTest) {


### PR DESCRIPTION
This enables adding multiple direct collocation programs into the same MathematicalProgram, which is important for enabling e.g. hybrid trajectory optimization. This has been a TODO, and was a major reason that we switched MultipleShooting to has-a prog (from is-a prog).

+@hongkai-dai for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19156)
<!-- Reviewable:end -->
