### PR TITLE
fix tamsi_solver.h document brackets error

### DIFF
--- a/multibody/plant/tamsi_solver.h
+++ b/multibody/plant/tamsi_solver.h
@@ -450,7 +450,7 @@ where `O₅(δt²) = O₂(‖vˢ⁺¹ − vˢ‖²) = O₂(‖O₄(δt)‖²)`. 
 We can now use Eq. (14) into Eq. (11) to arrive to:
 @verbatim
   (15)  M(qˢ) vˢ⁺¹ = M(qˢ) vˢ +
-        δt [τˢ + Jₙᵀ(qˢ) (fₙ(qˢ,vˢ) + O₆(δt)] + Jₜᵀ(qˢ) fₜ(vˢ⁺¹)) +
+        δt [τˢ + Jₙᵀ(qˢ) (fₙ(qˢ,vˢ) + O₆(δt)) + Jₜᵀ(qˢ) fₜ(vˢ⁺¹)] +
         O₁(δt²)
 @endverbatim
 which we can rewrite as:


### PR DESCRIPTION
I recently read the document about TAMSI-Solver and find a formula error in tamsi_solver.h. The brackets might be in error order. I fix that and create a pull request. I will be grateful if somebody can check it out.

https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_tamsi_solver.html equation (15)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19166)
<!-- Reviewable:end -->
