### PR TITLE
Increase mypy timeout for CI machines to 360 secs

### DIFF
--- a/tools/workspace/mypy_internal/patches/timeout.patch
+++ b/tools/workspace/mypy_internal/patches/timeout.patch
@@ -1,4 +1,4 @@
-Increase timeout from 30 seconds to 180 seconds
+Increase timeout from 30 seconds to 360 seconds
 
 --- mypy/moduleinspect.py
 +++ mypy/moduleinspect.py
@@ -7,7 +7,7 @@ Increase timeout from 30 seconds to 180 seconds
          Return the value read from the queue, or None if the process unexpectedly died.
          """
 -        max_iter = 600
-+        timeout_seconds = 180
++        timeout_seconds = 360
 +        timeout_increment = 0.05
 +        max_iter = int(timeout_seconds / timeout_increment)
          n = 0


### PR DESCRIPTION
Relates #18119. Linux CI jobs have been timing out again, increasing from "180 seconds" to "360 seconds" to try and give it enough time to poll the results.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19169)
<!-- Reviewable:end -->
