### PR TITLE
QueryObject allows signed distance between a filtered geometry pair

### DIFF
--- a/geometry/proximity/distance_to_shape_callback.cc
+++ b/geometry/proximity/distance_to_shape_callback.cc
@@ -236,8 +236,9 @@ bool Callback(fcl::CollisionObjectd* object_A_ptr,
   const EncodedData encoding_a(*object_A_ptr);
   const EncodedData encoding_b(*object_B_ptr);
 
-  const bool can_collide = data.collision_filter.CanCollideWith(
-      encoding_a.id(), encoding_b.id());
+  const bool can_collide =
+      data.collision_filter == nullptr ||
+      data.collision_filter->CanCollideWith(encoding_a.id(), encoding_b.id());
 
   if (can_collide) {
     // Throw if the geometry-pair isn't supported.

--- a/geometry/proximity/distance_to_shape_callback.h
+++ b/geometry/proximity/distance_to_shape_callback.h
@@ -40,7 +40,8 @@ struct CallbackData {
    all aliased in the data and require the aliased parameters to remain valid at
    least as long as the CallbackData instance.
 
-   @param collision_filter_in     The collision filter system. Aliased.
+   @param collision_filter_in     The collision filter system. Aliased. If null,
+                                  collision filters will not be considered.
    @param X_WGs_in                The T-valued poses. Aliased.
    @param max_distance_in         The maximum distance at which a pair is
                                   reported.
@@ -50,23 +51,22 @@ struct CallbackData {
       const std::unordered_map<GeometryId, math::RigidTransform<T>>* X_WGs_in,
       double max_distance_in,
       std::vector<SignedDistancePair<T>>* nearest_pairs_in)
-      : collision_filter(*collision_filter_in),
+      : collision_filter(collision_filter_in),
         X_WGs(*X_WGs_in),
         max_distance(max_distance_in),
         nearest_pairs(*nearest_pairs_in) {
-    DRAKE_DEMAND(collision_filter_in != nullptr);
     DRAKE_DEMAND(X_WGs_in != nullptr);
     DRAKE_DEMAND(nearest_pairs_in != nullptr);
   }
 
   /* The collision filter system.  */
-  const CollisionFilter& collision_filter;
+  const CollisionFilter* collision_filter{};
 
   /* The T-valued poses of all geometries.  */
   const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs;
 
   /* The maximum distance at which a pair's distance will be reported.  */
-  const double max_distance;
+  const double max_distance{};
 
   /* The distance query parameters.  */
   fcl::DistanceRequestd request;

--- a/geometry/proximity/test/distance_sphere_to_shape_test.cc
+++ b/geometry/proximity/test/distance_sphere_to_shape_test.cc
@@ -689,6 +689,12 @@ GTEST_TEST(Callback, RespectCollisionFiltering) {
   threshold = std::numeric_limits<double>::max();
   Callback<double>(&sphere_A, &sphere_B, &data, threshold);
   EXPECT_EQ(results.size(), 0u);
+
+  // However, if we explicitly request collision filters be ignored, it will do
+  // so.
+  data.collision_filter = nullptr;
+  Callback<double>(&sphere_A, &sphere_B, &data, threshold);
+  EXPECT_EQ(results.size(), 1u);
 }
 
 // Confirms that regardless of the order of the two objects, the result always

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -603,8 +603,8 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     std::vector<SignedDistancePair<T>> witness_pairs;
     double max_distance = std::numeric_limits<double>::infinity();
     // All these quantities are aliased in the callback data.
-    shape_distance::CallbackData<T> data{&collision_filter_, &X_WGs,
-                                         max_distance, &witness_pairs};
+    shape_distance::CallbackData<T> data{nullptr, &X_WGs, max_distance,
+                                         &witness_pairs};
     data.request.enable_nearest_points = true;
     data.request.enable_signed_distance = true;
     data.request.gjk_solver_type = fcl::GJKSolverType::GST_LIBCCD;
@@ -628,11 +628,9 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     CollisionObjectd* object_B = find_geometry(id_B);
     shape_distance::Callback<T>(object_A, object_B, &data, max_distance);
 
-    if (witness_pairs.size() == 0) {
-      throw std::runtime_error(fmt::format(
-          "The geometry pair ({}, {}) does not support a signed distance query",
-          id_A, id_B));
-    }
+    // If the callback didn't throw, it returned an actual value.
+    DRAKE_DEMAND(witness_pairs.size() > 0);
+
     return witness_pairs[0];
   }
 

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -600,6 +600,11 @@ class QueryObject {
    indicated by id. This function has the same restrictions on scalar report
    as ComputeSignedDistancePairwiseClosestPoints().
 
+   @note This query is unique among the distance queries in that it doesn't
+   respect collision filters. As long as the geometry ids refer to geometries
+   with proximity roles, signed distance can be computed (subject to supported
+   scalar tables above).
+
    <h3>Characterizing the returned values</h3>
 
    This method merely exercises the same mechanisms as
@@ -609,11 +614,10 @@ class QueryObject {
 
    @throws std::exception if either geometry id is invalid (e.g., doesn't refer
                           to an existing geometry, lacking proximity role,
-                          etc.), the pair (A, B) has been marked as filtered, or
-                          otherwise unsupported as indicated by the the scalar
-                          support table.
+                          etc.), the pair is unsupported as indicated by the
+                          scalar support table.
    @warning For Mesh shapes, their convex hulls are used in this query. It is
-            *not* computationally efficient or particularly accurate.  */
+            _not_ computationally efficient or particularly accurate.  */
   SignedDistancePair<T> ComputeSignedDistancePairClosestPoints(
       GeometryId geometry_id_A, GeometryId geometry_id_B) const;
 

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -906,7 +906,7 @@ GTEST_TEST(ProximityEngineTests, SignedDistancePairClosestPoint) {
                     "a signed distance query", bad_id));
   }
 
-  // Case: the pair is filtered.
+  // Case: the distance is evaluated even though the pair is filtered.
   {
     // I know the GeometrySet only has id_A and id_B, so I'll construct the
     // extracted set by hand.
@@ -916,10 +916,8 @@ GTEST_TEST(ProximityEngineTests, SignedDistancePairClosestPoint) {
     engine.collision_filter().Apply(
         CollisionFilterDeclaration().ExcludeWithin(GeometrySet{id_A, id_B}),
         extract_ids, false /* is_invariant */);
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        engine.ComputeSignedDistancePairClosestPoints(id_A, id_B, X_WGs),
-        fmt::format("The geometry pair \\({}, {}\\) does not support a signed "
-                    "distance query", id_A, id_B));
+    EXPECT_NO_THROW(
+        engine.ComputeSignedDistancePairClosestPoints(id_A, id_B, X_WGs));
   }
 }
 


### PR DESCRIPTION
Historically, requesting signed distance between two geometries that had been filtered would throw. While it might make sense to have the geometries filtered for contact, it might still be convenient to know how far they are. This changes the API to allow the caller to demand that collision filters be ignored.

closes #19135

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19176)
<!-- Reviewable:end -->
