### PR TITLE
Remove deprecated "register geometry to geometry" from SceneGraph

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry/geometry_py_scene_graph.cc
@@ -132,20 +132,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py_rvp::reference_internal, py::arg("geometry_id"),
             cls_doc.GetName.doc_1args_geometry_id)
         .def("GetShape", &Class::GetShape, py_rvp::reference_internal,
-            py::arg("geometry_id"), cls_doc.GetShape.doc);
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    // 2023-04-01 Deprecation removal.
-    cls  // BR
-        .def("GetPoseInParent",
-            WrapDeprecated(cls_doc.GetPoseInParent.doc_deprecated,
-                &Class::GetPoseInParent),
-            py_rvp::reference_internal, py::arg("geometry_id"),
-            cls_doc.GetPoseInParent.doc_deprecated);
-#pragma GCC diagnostic pop
-
-    cls  // BR
+            py::arg("geometry_id"), cls_doc.GetShape.doc)
         .def("GetPoseInFrame", &Class::GetPoseInFrame,
             py_rvp::reference_internal, py::arg("geometry_id"),
             cls_doc.GetPoseInFrame.doc)
@@ -209,28 +196,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::overload_cast<SourceId, FrameId,
                 std::unique_ptr<GeometryInstance>>(&Class::RegisterGeometry),
             py::arg("source_id"), py::arg("frame_id"), py::arg("geometry"),
-            cls_doc.RegisterGeometry.doc_3args);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    // 2023-04-01 Deprecation removal.
-    cls  // BR
-        .def("RegisterGeometry",
-            WrapDeprecated(cls_doc.RegisterGeometry.doc_deprecated_3args,
-                py::overload_cast<SourceId, GeometryId,
-                    std::unique_ptr<GeometryInstance>>(
-                    &Class::RegisterGeometry)),
-            py::arg("source_id"), py::arg("geometry_id"), py::arg("geometry"),
-            cls_doc.RegisterGeometry.doc_deprecated_3args)
-        .def("RegisterGeometry",
-            overload_cast_explicit<GeometryId, systems::Context<T>*, SourceId,
-                GeometryId, std::unique_ptr<GeometryInstance>>(
-                &Class::RegisterGeometry),
-            py::arg("context"), py::arg("source_id"), py::arg("geometry_id"),
-            py::arg("geometry"),
-            cls_doc.RegisterGeometry
-                .doc_4args_context_source_id_geometry_id_geometry);
-#pragma GCC diagnostic pop
-    cls  // BR
+            cls_doc.RegisterGeometry.doc_3args)
         .def("RegisterGeometry",
             overload_cast_explicit<GeometryId, systems::Context<T>*, SourceId,
                 FrameId, std::unique_ptr<GeometryInstance>>(

--- a/bindings/pydrake/geometry/test/scene_graph_test.py
+++ b/bindings/pydrake/geometry/test/scene_graph_test.py
@@ -43,15 +43,11 @@ class TestGeometrySceneGraph(unittest.TestCase):
                                           shape=mut.Sphere(1.),
                                           name="sphere1"))
         # We'll explicitly give sphere_2 a rigid hydroelastic representation.
-        with catch_drake_warnings(expected_count=1):
-            # 2023-04-01 Deprecation removal. Upon removal, register sphere_2
-            # against global_frame and keep it around for the hydroelastic
-            # tests.
-            sphere_2 = scene_graph.RegisterGeometry(
-                source_id=global_source, geometry_id=global_geometry,
-                geometry=mut.GeometryInstance(X_PG=RigidTransform_[float](),
-                                              shape=mut.Sphere(1.),
-                                              name="sphere2"))
+        sphere_2 = scene_graph.RegisterGeometry(
+            source_id=global_source, frame_id=global_frame,
+            geometry=mut.GeometryInstance(X_PG=RigidTransform_[float](),
+                                          shape=mut.Sphere(1.),
+                                          name="sphere2"))
         props = mut.ProximityProperties()
         mut.AddRigidHydroelasticProperties(resolution_hint=1, properties=props)
         scene_graph.AssignRole(source_id=global_source, geometry_id=sphere_2,
@@ -231,11 +227,6 @@ class TestGeometrySceneGraph(unittest.TestCase):
             inspector.GetName(geometry_id=global_geometry), "sphere1")
         self.assertIsInstance(inspector.GetShape(geometry_id=global_geometry),
                               mut.Sphere)
-        with catch_drake_warnings(expected_count=1):
-            # 2023-04-01 Deprecation removal.
-            self.assertIsInstance(
-                inspector.GetPoseInParent(geometry_id=global_geometry),
-                RigidTransform_[float])
         self.assertIsInstance(
             inspector.GetPoseInFrame(geometry_id=global_geometry),
             RigidTransform_[float])

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -530,13 +530,6 @@ const math::RigidTransform<double>& GeometryState<T>::GetPoseInFrame(
 }
 
 template <typename T>
-const math::RigidTransform<double>& GeometryState<T>::GetPoseInParent(
-    GeometryId geometry_id) const {
-  const auto& geometry = GetValueOrThrow(geometry_id, geometries_);
-  return geometry.X_PG();
-}
-
-template <typename T>
 std::variant<std::monostate, const TriangleSurfaceMesh<double>*,
              const VolumeMesh<double>*>
 GeometryState<T>::maybe_get_hydroelastic_mesh(GeometryId geometry_id) const {
@@ -895,51 +888,6 @@ void GeometryState<T>::ChangeShape(SourceId source_id, GeometryId geometry_id,
 }
 
 template <typename T>
-GeometryId GeometryState<T>::RegisterGeometryWithParent(
-    SourceId source_id, GeometryId parent_id,
-    std::unique_ptr<GeometryInstance> geometry) {
-  // There are three error conditions in the doxygen:
-  //    1. geometry == nullptr,
-  //    2. source_id is not a registered source, and
-  //    3. parent_id doesn't belong to source_id.
-  //
-  // Only #1 is tested directly. #2 and #3 are tested implicitly during the act
-  // of registering the geometry.
-
-  if (geometry == nullptr) {
-    throw std::logic_error(
-        "Registering null geometry to geometry " + to_string(parent_id) +
-            ", on source " + to_string(source_id) + ".");
-  }
-
-  // This confirms that parent_id exists at all.
-  InternalGeometry& parent_geometry =
-      GetMutableValueOrThrow(parent_id, &geometries_);
-  FrameId frame_id = parent_geometry.frame_id();
-
-  // This implicitly confirms that source_id is registered (condition #2) and
-  // that frame_id belongs to source_id. By construction, parent_id must
-  // belong to the same source as frame_id, so this tests condition #3.
-  GeometryId new_id = RegisterGeometry(source_id, frame_id, move(geometry));
-
-  // RegisterGeometry stores X_PG into X_FG_ (having assumed that  the
-  // parent was a frame). This replaces the stored X_PG value with the
-  // semantically correct value X_FG by concatenating X_FP with X_PG.
-
-  // Transform pose relative to geometry, to pose relative to frame.
-  InternalGeometry& new_geometry = geometries_[new_id];
-  // The call to `RegisterGeometry()` above stashed the pose X_PG into the
-  // X_FG_ vector assuming the parent was the frame. Replace it by concatenating
-  // its pose in parent, with its parent's pose in frame. NOTE: the pose is no
-  // longer available from geometry because of the `move(geometry)`.
-  const RigidTransform<double>& X_PG = new_geometry.X_FG();
-  const RigidTransform<double>& X_FP = parent_geometry.X_FG();
-  new_geometry.set_geometry_parent(parent_id, X_FP * X_PG);
-  parent_geometry.add_child(new_id);
-  return new_id;
-}
-
-template <typename T>
 GeometryId GeometryState<T>::RegisterAnchoredGeometry(
     SourceId source_id,
     std::unique_ptr<GeometryInstance> geometry) {
@@ -956,7 +904,21 @@ void GeometryState<T>::RemoveGeometry(SourceId source_id,
             "source " + to_string(source_id) + ", but the geometry doesn't "
             "belong to that source.");
   }
-  RemoveGeometryUnchecked(geometry_id, RemoveGeometryOrigin::kGeometry);
+
+  const InternalGeometry& geometry = GetValueOrThrow(geometry_id, geometries_);
+  auto& frame = GetMutableValueOrThrow(geometry.frame_id(), &frames_);
+  frame.remove_child(geometry_id);
+
+  RemoveProximityRole(geometry_id);
+  RemovePerceptionRole(geometry_id);
+  RemoveIllustrationRole(geometry_id);
+
+  // Clean up state collections.
+  kinematics_data_.X_WGs.erase(geometry_id);
+  kinematics_data_.q_WGs.erase(geometry_id);
+
+  // Remove from the geometries.
+  geometries_.erase(geometry_id);
 }
 
 template <typename T>
@@ -1432,49 +1394,6 @@ SourceId GeometryState<T>::get_source_id(GeometryId id) const {
                            " does not map to a registered geometry");
   }
   return geometry->source_id();
-}
-
-template <typename T>
-void GeometryState<T>::RemoveGeometryUnchecked(GeometryId geometry_id,
-                                               RemoveGeometryOrigin caller) {
-  const InternalGeometry& geometry = GetValueOrThrow(geometry_id, geometries_);
-
-  // TODO(SeanCurtis-TRI): When this gets invoked by RemoveFrame(), this
-  // recursive action will not be necessary, as all child geometries will
-  // automatically get removed. I've put it into a block so for future
-  // reference; simply add an if statement to determine if this is coming from
-  // frame removal.
-  {
-    for (auto child_id : geometry.child_geometry_ids()) {
-      RemoveGeometryUnchecked(child_id, RemoveGeometryOrigin::kRecurse);
-    }
-    // Remove the geometry from its frame's list of geometries.
-    auto& frame = GetMutableValueOrThrow(geometry.frame_id(), &frames_);
-    frame.remove_child(geometry_id);
-  }
-
-  RemoveProximityRole(geometry_id);
-  RemovePerceptionRole(geometry_id);
-  RemoveIllustrationRole(geometry_id);
-
-  if (caller == RemoveGeometryOrigin::kGeometry) {
-    // Only the geometry that this function is *directly* invoked on needs to
-    // remove itself from its possible parent geometry. If called recursively,
-    // it is because the parent geometry is being deleted anyways and removal
-    // is implicit in the deletion of that parent geometry.
-    if (std::optional<GeometryId> parent_id = geometry.parent_id()) {
-      auto& parent_geometry =
-          GetMutableValueOrThrow(*parent_id, &geometries_);
-      parent_geometry.remove_child(geometry_id);
-    }
-  }
-
-  // Clean up state collections.
-  kinematics_data_.X_WGs.erase(geometry_id);
-  kinematics_data_.q_WGs.erase(geometry_id);
-
-  // Remove from the geometries.
-  geometries_.erase(geometry_id);
 }
 
 template <typename T>

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -277,13 +277,6 @@ class GeometryState {
   const math::RigidTransform<double>& GetPoseInFrame(
       GeometryId geometry_id) const;
 
-  /** Implementation of SceneGraphInspector::X_PG().  */
-  DRAKE_DEPRECATED("2023-04-01",
-                   "Geometries are no longer posed with respect to other "
-                   "geometries -- only frames; use GetPoseInFrame().")
-  const math::RigidTransform<double>& GetPoseInParent(
-      GeometryId geometry_id) const;
-
   /** Implementation of
    SceneGraphInspector::maybe_get_hydroelastic_mesh().  */
   std::variant<std::monostate, const TriangleSurfaceMesh<double>*,
@@ -360,17 +353,6 @@ class GeometryState {
    parent FrameId.  */
   GeometryId RegisterGeometry(SourceId source_id, FrameId frame_id,
                               std::unique_ptr<GeometryInstance> geometry);
-
-  /** Implementation of
-   @ref SceneGraph::RegisterGeometry(SourceId,GeometryId,
-   std::unique_ptr<GeometryInstance>) "SceneGraph::RegisterGeometry()" with
-   parent GeometryId.  */
-  DRAKE_DEPRECATED("2023-04-01",
-                   "Geometries are no longer posed with respect to other "
-                   "geometries -- only frames.")
-  GeometryId RegisterGeometryWithParent(
-      SourceId source_id, GeometryId parent_id,
-      std::unique_ptr<GeometryInstance> geometry);
 
   // TODO(SeanCurtis-TRI): Consider deprecating this; it's now strictly a
   // wrapper for the more general `RegisterGeometry()`.
@@ -708,29 +690,6 @@ class GeometryState {
   // Gets the source id for the given frame id. Throws std::exception if the
   // geometry belongs to no registered source.
   SourceId get_source_id(GeometryId frame_id) const;
-
-  // The origin from where an invocation of RemoveGeometryUnchecked was called.
-  // The origin changes the work that is required.
-  // TODO(SeanCurtis-TRI): Add `kFrame` when this can be invoked by removing
-  // a frame.
-  enum class RemoveGeometryOrigin {
-    kGeometry,  // Invoked by RemoveGeometry().
-    kRecurse    // Invoked by recursive call in RemoveGeometryUnchecked.
-  };
-
-  // Performs the work necessary to remove the identified geometry from
-  // the world. The amount of work depends on the context from which this
-  // method is invoked:
-  //
-  //  - RemoveGeometry(): A specific geometry (and its corresponding
-  //    hierarchy) is being removed. In addition to recursively removing all
-  //    child geometries, it must also remove this geometry id from its parent
-  //    frame and, if it exists, its parent geometry.
-  //   - RemoveGeometryUnchecked(): This is the recursive call; it's parent
-  //    is already slated for removal, so parent references can be left alone.
-  // @throws std::exception if `geometry_id` is not in `geometries_`.
-  void RemoveGeometryUnchecked(GeometryId geometry_id,
-                               RemoveGeometryOrigin caller);
 
   // Recursively updates the frame and geometry _pose_ information for the tree
   // rooted at the given frame, whose parent's pose in the world frame is given

--- a/geometry/internal_geometry.cc
+++ b/geometry/internal_geometry.cc
@@ -12,17 +12,17 @@ namespace internal {
 using math::RigidTransform;
 using std::move;
 
-InternalGeometry::InternalGeometry(
-    SourceId source_id, std::unique_ptr<Shape> shape, FrameId frame_id,
-    GeometryId geometry_id, std::string name, RigidTransform<double> X_FG)
+InternalGeometry::InternalGeometry(SourceId source_id,
+                                   std::unique_ptr<Shape> shape,
+                                   FrameId frame_id, GeometryId geometry_id,
+                                   std::string name,
+                                   RigidTransform<double> X_FG)
     : shape_spec_(std::move(shape)),
       id_(geometry_id),
       name_(std::move(name)),
       source_id_(source_id),
       frame_id_(frame_id),
-      X_PG_(move(X_FG)),
-      X_FG_(X_PG_),
-      parent_geometry_id_(std::nullopt) {}
+      X_FG_(move(X_FG)) {}
 
 InternalGeometry::InternalGeometry(SourceId source_id,
                                    std::unique_ptr<Shape> shape,
@@ -35,9 +35,7 @@ InternalGeometry::InternalGeometry(SourceId source_id,
       name_(std::move(name)),
       source_id_(source_id),
       frame_id_(frame_id),
-      X_PG_(move(X_FG)),
-      X_FG_(X_PG_),
-      parent_geometry_id_(std::nullopt) {
+      X_FG_(move(X_FG)) {
   MeshBuilderForDeformable mesh_builder;
   // The mesh_builder builds the mesh in frame G.
   reference_mesh_ = mesh_builder.Build(*shape_spec_, resolution_hint);

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -159,11 +159,6 @@ class QueryObject {
   /** Reports the position of the frame indicated by `frame_id` relative to its
    parent frame. If the frame was registered with the world frame as its parent
    frame, this value will be identical to that returned by GetPoseInWorld().
-   <!-- 2023-04-01 Remove this note when we're done deprecating
-    SGI::GetPoseInParent(). -->
-   @note This is analogous to but distinct from
-   SceneGraphInspector::GetPoseInParent(). In this case, the pose will *always*
-   be relative to another frame.
    @throws std::exception if the frame `frame_id` is not valid.  */
   const math::RigidTransform<T>& GetPoseInParent(FrameId frame_id) const;
 

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -196,31 +196,6 @@ GeometryId SceneGraph<T>::RegisterGeometry(
 }
 
 template <typename T>
-GeometryId SceneGraph<T>::RegisterGeometry(
-    SourceId source_id, GeometryId geometry_id,
-    std::unique_ptr<GeometryInstance> geometry) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  // 2023-04-01 Deprecation removal.
-  return model_.RegisterGeometryWithParent(source_id, geometry_id,
-                                           std::move(geometry));
-#pragma GCC diagnostic pop
-}
-
-template <typename T>
-GeometryId SceneGraph<T>::RegisterGeometry(
-    Context<T>* context, SourceId source_id, GeometryId geometry_id,
-    std::unique_ptr<GeometryInstance> geometry) const {
-  auto& g_state = mutable_geometry_state(context);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  // 2023-04-01 Deprecation removal.
-  return g_state.RegisterGeometryWithParent(source_id, geometry_id,
-                                            std::move(geometry));
-#pragma GCC diagnostic pop
-}
-
-template <typename T>
 GeometryId SceneGraph<T>::RegisterAnchoredGeometry(
     SourceId source_id, std::unique_ptr<GeometryInstance> geometry) {
   return model_.RegisterAnchoredGeometry(source_id, std::move(geometry));

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -488,48 +488,6 @@ class SceneGraph final : public systems::LeafSystem<T> {
                               FrameId frame_id,
                               std::unique_ptr<GeometryInstance> geometry) const;
 
-  /** Registers a new rigid geometry G for this source. This hangs geometry G on
-   a previously registered geometry P (indicated by `geometry_id`). The pose of
-   the geometry is defined in a fixed pose relative to geometry P (i.e.,
-   `X_PG`). By induction, this geometry is effectively rigidly affixed to the
-   frame that P is affixed to. Returns the corresponding unique geometry id.
-
-   Roles will be assigned to the registered geometry if the corresponding
-   GeometryInstance `geometry` has had properties assigned.
-
-   This method modifies the underlying model and requires a new Context to be
-   allocated. Potentially modifies proximity, perception, and illustration
-   versions based on the roles assigned to the geometry (see @ref
-   scene_graph_versioning).
-
-   @param source_id    The id for the source registering the geometry.
-   @param geometry_id  The id for the parent geometry P.
-   @param geometry     The geometry G to add.
-   @return A unique identifier for the added geometry.
-   @throws std::exception if a) the `source_id` does _not_ map to a registered
-                          source,
-                          b) the `geometry_id` doesn't belong to the source,
-                          c) the `geometry` is equal to `nullptr`, or
-                          d) the geometry's name doesn't satisfy the
-                          requirements outlined in GeometryInstance.  */
-  DRAKE_DEPRECATED("2023-04-01",
-                   "Geometries are no longer posed with respect to other "
-                   "geometries; use RegisterGeometry(frame_id) instead.")
-  GeometryId RegisterGeometry(SourceId source_id, GeometryId geometry_id,
-                              std::unique_ptr<GeometryInstance> geometry);
-
-  /** systems::Context-modifying variant of RegisterGeometry(). Rather than
-   modifying %SceneGraph's model, it modifies the copy of the model stored in
-   the provided context.
-   @pydrake_mkdoc_identifier{4args_context_source_id_geometry_id_geometry}
-     */
-  DRAKE_DEPRECATED("2023-04-01",
-                   "Geometries are no longer posed with respect to other "
-                   "geometries -- only frames.")
-  GeometryId RegisterGeometry(systems::Context<T>* context, SourceId source_id,
-                              GeometryId geometry_id,
-                              std::unique_ptr<GeometryInstance> geometry) const;
-
   /** Registers a new _anchored_ geometry G for this source. This hangs geometry
    G from the world frame (W). Its pose is defined in that frame (i.e., `X_WG`).
    Returns the corresponding unique geometry id.

--- a/geometry/scene_graph_inspector.cc
+++ b/geometry/scene_graph_inspector.cc
@@ -196,16 +196,6 @@ const Shape& SceneGraphInspector<T>::GetShape(GeometryId geometry_id) const {
 }
 
 template <typename T>
-const math::RigidTransform<double>& SceneGraphInspector<T>::GetPoseInParent(
-    GeometryId geometry_id) const {
-  DRAKE_DEMAND(state_ != nullptr);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  return state_->GetPoseInParent(geometry_id);
-#pragma GCC diagnostic pop
-}
-
-template <typename T>
 const math::RigidTransform<double>& SceneGraphInspector<T>::GetPoseInFrame(
     GeometryId geometry_id) const {
   DRAKE_DEMAND(state_ != nullptr);

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -293,26 +293,7 @@ class SceneGraphInspector {
   const Shape& GetShape(GeometryId geometry_id) const;
 
   /** Reports the pose of the geometry G with the given `geometry_id` in its
-   registered _topological parent_ P, `X_PG`. That topological parent may be a
-   frame F or another geometry. If the geometry was registered directly to F,
-   then `X_PG = X_FG`.
-   @sa GetPoseInFrame()
-   @note For deformable geometries, this returns the pose of the reference mesh.
-   @throws std::exception if `geometry_id` does not map to a registered
-   geometry. */
-  DRAKE_DEPRECATED("2023-04-01",
-                   "Geometries are no longer posed with respect to other "
-                   "geometries -- only frames; use GetPoseInFrame().")
-  const math::RigidTransform<double>& GetPoseInParent(
-      GeometryId geometry_id) const;
-
-  /** Reports the pose of the geometry G with the given `geometry_id` in its
-   registered frame F (regardless of whether its _topological parent_ is another
-   geometry P or not). If the geometry was registered directly to the frame F,
-   then `X_PG = X_FG`.
-   <!-- 2023-04-01 When deprecation is complete, remove references to other
-    geometries. -->
-   @sa GetPoseInParent()
+   registered frame F.
    @note For deformable geometries, this returns the pose of the reference mesh.
    @throws std::exception if `geometry_id` does not map to a registered
    geometry. */

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -89,11 +89,6 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   inspector.GetFrameId(geometry_id);
   inspector.GetName(geometry_id);
   inspector.GetShape(geometry_id);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  // 2023-04-01 Deprecation removal.
-  inspector.GetPoseInParent(geometry_id);
-#pragma GCC diagnostic pop
   inspector.GetPoseInFrame(geometry_id);
   inspector.maybe_get_hydroelastic_mesh(geometry_id);
   inspector.GetProximityProperties(geometry_id);

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -235,14 +235,8 @@ TEST_F(SceneGraphTest, TopologyAfterAllocation) {
       scene_graph_.RegisterFrame(id, GeometryFrame("parent"));
   FrameId child_frame_id =
       scene_graph_.RegisterFrame(id, parent_frame_id, GeometryFrame("child"));
-  GeometryId parent_geometry_id = scene_graph_.RegisterGeometry(
+  GeometryId geometry_id = scene_graph_.RegisterGeometry(
       id, parent_frame_id, make_sphere_instance());
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  // 2023-04-01 Deprecation removal; delete all references to child_geometry_id.
-  GeometryId child_geometry_id = scene_graph_.RegisterGeometry(
-      id, parent_geometry_id, make_sphere_instance());
-#pragma GCC diagnostic pop
   GeometryId anchored_id =
       scene_graph_.RegisterAnchoredGeometry(id, make_sphere_instance());
   scene_graph_.RemoveGeometry(id, old_geometry_id);
@@ -256,8 +250,7 @@ TEST_F(SceneGraphTest, TopologyAfterAllocation) {
   // respectively.
   EXPECT_TRUE(model_inspector.BelongsToSource(parent_frame_id, id));
   EXPECT_TRUE(model_inspector.BelongsToSource(child_frame_id, id));
-  EXPECT_TRUE(model_inspector.BelongsToSource(parent_geometry_id, id));
-  EXPECT_TRUE(model_inspector.BelongsToSource(child_geometry_id, id));
+  EXPECT_TRUE(model_inspector.BelongsToSource(geometry_id, id));
   EXPECT_TRUE(model_inspector.BelongsToSource(anchored_id, id));
   // Removed geometry from SceneGraph; "invalid" id throws.
   EXPECT_THROW(model_inspector.BelongsToSource(old_geometry_id, id),
@@ -267,9 +260,7 @@ TEST_F(SceneGraphTest, TopologyAfterAllocation) {
                std::logic_error);
   EXPECT_THROW(context_inspector.BelongsToSource(child_frame_id, id),
                std::logic_error);
-  EXPECT_THROW(context_inspector.BelongsToSource(parent_geometry_id, id),
-               std::logic_error);
-  EXPECT_THROW(context_inspector.BelongsToSource(child_geometry_id, id),
+  EXPECT_THROW(context_inspector.BelongsToSource(geometry_id, id),
                std::logic_error);
   EXPECT_THROW(context_inspector.BelongsToSource(anchored_id, id),
                std::logic_error);
@@ -845,23 +836,12 @@ GTEST_TEST(SceneGraphContextModifier, RegisterGeometry) {
   EXPECT_EQ(1, inspector.NumGeometriesForFrame(frame_id));
   EXPECT_EQ(frame_id, inspector.GetFrameId(sphere_id_1));
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  // 2023-04-01 Deprecation removal.
-  // Test registration of geometry onto _geometry_.
-  GeometryId sphere_id_2 = scene_graph.RegisterGeometry(
-      context.get(), source_id, sphere_id_1, make_sphere_instance());
-  EXPECT_EQ(2, inspector.NumGeometriesForFrame(frame_id));
-  EXPECT_EQ(frame_id, inspector.GetFrameId(sphere_id_2));
-#pragma GCC diagnostic pop
-
-  // 2023-04-01 Change from sphere_id_2 to sphere_id_1.
   // Remove the geometry.
   DRAKE_EXPECT_NO_THROW(
-      scene_graph.RemoveGeometry(context.get(), source_id, sphere_id_2));
-  EXPECT_EQ(1, inspector.NumGeometriesForFrame(frame_id));
+      scene_graph.RemoveGeometry(context.get(), source_id, sphere_id_1));
+  EXPECT_EQ(0, inspector.NumGeometriesForFrame(frame_id));
   DRAKE_EXPECT_THROWS_MESSAGE(
-      inspector.GetFrameId(sphere_id_2),
+      inspector.GetFrameId(sphere_id_1),
       "Referenced geometry \\d+ has not been registered.");
 }
 


### PR DESCRIPTION
This does all the work of removing the public and internal APIs in support of registering a geometry relative to another geometry. In addition to removing the deprecated public APIs, it also removes some of the supporting artifacts that are no longer necessary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19177)
<!-- Reviewable:end -->
