### PR TITLE
Throw exceptions for spatial inertia primitives with negative mass or density.

### DIFF
--- a/multibody/tree/spatial_inertia.cc
+++ b/multibody/tree/spatial_inertia.cc
@@ -6,6 +6,13 @@
 
 namespace drake {
 namespace multibody {
+// namespace {
+
+template <typename T>
+static const boolean<T> is_positive_and_finite(const T& value) {
+  using std::isfinite;
+  return isfinite(value) && value > 0;
+}
 
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::MakeUnitary() {
@@ -18,9 +25,9 @@ SpatialInertia<T> SpatialInertia<T>::MakeUnitary() {
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::PointMass(
     const T& mass, const Vector3<T>& position) {
-  if (mass <= 0) {
+  if (!is_positive_and_finite(mass)) {
     const std::string error_message = fmt::format(
-        "{}(): The mass of a particle is negative or zero: {}.",
+        "{}(): The mass of a particle is not positive and finite: {}.",
         __func__, mass);
     throw std::logic_error(error_message);
   }
@@ -39,17 +46,18 @@ SpatialInertia<T> SpatialInertia<T>::PointMass(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidBoxWithDensity(
     const T& density, const T& lx, const T& ly, const T& lz) {
-  if (density <= 0) {
+  if (!is_positive_and_finite(density)) {
     const std::string error_message = fmt::format(
-        "{}(): A solid box's density is negative or zero: {}.",
+        "{}(): A solid box's density is not positive and finite: {}.",
         __func__, density);
     throw std::logic_error(error_message);
   }
-  // Ensure lx, ly, lz are positive.
-  if (lx <= 0 || ly <= 0 || lz <= 0) {
+  if (!is_positive_and_finite(lx) ||
+      !is_positive_and_finite(ly) ||
+      !is_positive_and_finite(lz)) {
     const std::string error_message = fmt::format(
-        "{}(): One or more dimensions of a solid box is negative or zero: "
-        "({}, {}, {}).", __func__, lx, ly, lz);
+        "{}(): One or more dimensions of a solid box is not positive and "
+        "finite: ({}, {}, {}).", __func__, lx, ly, lz);
     throw std::logic_error(error_message);
   }
 
@@ -61,16 +69,18 @@ SpatialInertia<T> SpatialInertia<T>::SolidBoxWithDensity(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidBoxWithMass(
     const T& mass, const T& lx, const T& ly, const T& lz) {
-  if (mass <= 0) {
+  if (!is_positive_and_finite(mass)) {
     const std::string error_message = fmt::format(
-        "{}(): A solid box's mass is negative or zero: {}.", __func__, mass);
+        "{}(): A solid box's mass is not positive and finite: {}.",
+        __func__, mass);
     throw std::logic_error(error_message);
   }
-  // Ensure lx, ly, lz are positive.
-  if (lx <= 0 || ly <= 0 || lz <= 0) {
+  if (!is_positive_and_finite(lx) ||
+      !is_positive_and_finite(ly) ||
+      !is_positive_and_finite(lz)) {
     const std::string error_message = fmt::format(
-        "{}(): One or more dimensions of a solid box is negative or zero: "
-        "({}, {}, {}).", __func__, lx, ly, lz);
+        "{}(): One or more dimensions of a solid box is not positive and "
+        "finite: ({}, {}, {}).", __func__, lx, ly, lz);
     throw std::logic_error(error_message);
   }
   const Vector3<T> p_BoBcm_B = Vector3<T>::Zero();
@@ -81,16 +91,15 @@ SpatialInertia<T> SpatialInertia<T>::SolidBoxWithMass(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidCubeWithDensity(
     const T& density, const T& length) {
-  if (density <= 0) {
+  if (!is_positive_and_finite(density)) {
     const std::string error_message = fmt::format(
-        "{}(): A solid cube's density is negative or zero: {}.",
+        "{}(): A solid cube's density is not positive and finite: {}.",
         __func__, density);
     throw std::logic_error(error_message);
   }
-  // Ensure length is positive.
-  if (length <= 0) {
+  if (!is_positive_and_finite(length)) {
     const std::string error_message = fmt::format(
-        "{}(): The length of a solid cube is negative or zero: {}.",
+        "{}(): The length of a solid cube is not positive and finite: {}.",
         __func__, length);
     throw std::logic_error(error_message);
   }
@@ -103,15 +112,15 @@ SpatialInertia<T> SpatialInertia<T>::SolidCubeWithDensity(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidCubeWithMass(
     const T& mass, const T& length) {
-  if (mass <= 0) {
+  if (!is_positive_and_finite(mass)) {
     const std::string error_message = fmt::format(
-        "{}(): A solid cube's mass is negative or zero: {}.", __func__, mass);
+        "{}(): A solid cube's mass is not positive and finite: {}.",
+        __func__, mass);
     throw std::logic_error(error_message);
   }
-  // Ensure length is positive.
-  if (length <= 0) {
+  if (!is_positive_and_finite(length)) {
     const std::string error_message = fmt::format(
-        "{}(): The length of a solid cube is negative or zero: {}.",
+        "{}(): The length of a solid cube is not positive and finite: {}.",
         __func__, length);
     throw std::logic_error(error_message);
   }
@@ -125,17 +134,16 @@ template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidCapsuleWithDensity(
     const T& density, const T& radius, const T& length,
     const Vector3<T>& unit_vector) {
-  if (density <= 0) {
+  if (!is_positive_and_finite(density)) {
     const std::string error_message = fmt::format(
-        "{}(): A solid capsule's density is negative or zero: {}.",
+        "{}(): A solid capsule's density is not positive and finite: {}.",
         __func__, density);
     throw std::logic_error(error_message);
   }
-  // Ensure radius and length are positive.
-  if (radius <= 0 || length <= 0) {
+  if (!is_positive_and_finite(radius) || !is_positive_and_finite(length)) {
     const std::string error_message = fmt::format(
-        "{}(): A solid capsule's radius = {} or length = {} is "
-        "negative or zero.", __func__, radius, length);
+        "{}(): A solid capsule's radius = {} or length = {} is not "
+        "positive and finite.", __func__, radius, length);
     throw std::logic_error(error_message);
   }
 
@@ -153,17 +161,16 @@ template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidCylinderWithDensity(
     const T& density, const T& radius, const T& length,
     const Vector3<T>& unit_vector) {
-  if (density <= 0) {
+  if (!is_positive_and_finite(density)) {
     const std::string error_message = fmt::format(
-        "{}(): A solid cylinder's density is negative or zero: {}.",
+        "{}(): A solid cylinder's density is not positive and finite: {}.",
         __func__, density);
     throw std::logic_error(error_message);
   }
-  // Ensure radius and length are positive.
-  if (radius <= 0 || length <= 0) {
+  if (!is_positive_and_finite(radius) || !is_positive_and_finite(length)) {
     const std::string error_message = fmt::format(
-        "{}(): A solid cylinder's radius = {} or length = {} is "
-        "negative or zero.", __func__, radius, length);
+        "{}(): A solid cylinder's radius = {} or length = {} is not "
+        "positive and finite.", __func__, radius, length);
     throw std::logic_error(error_message);
   }
 
@@ -194,17 +201,16 @@ template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidCylinderWithDensityAboutEnd(
     const T& density, const T& radius, const T& length,
     const Vector3<T>& unit_vector) {
-  if (density <= 0) {
+  if (!is_positive_and_finite(density)) {
     const std::string error_message = fmt::format(
-        "{}(): A solid cylinder's density is negative or zero: {}.",
+        "{}(): A solid cylinder's density is not positive and finite: {}.",
         __func__, density);
     throw std::logic_error(error_message);
   }
-  // Ensure radius and length are positive.
-  if (radius <= 0 || length <= 0) {
+  if (!is_positive_and_finite(radius) || !is_positive_and_finite(length)) {
     const std::string error_message = fmt::format(
-        "{}(): A solid cylinder's radius = {} or length = {} is "
-        "negative or zero.", __func__, radius, length);
+        "{}(): A solid cylinder's radius = {} or length = {} is not "
+        "positive and finite.", __func__, radius, length);
     throw std::logic_error(error_message);
   }
   SpatialInertia<T> M_BBcm_B =
@@ -218,11 +224,10 @@ SpatialInertia<T> SpatialInertia<T>::SolidCylinderWithDensityAboutEnd(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::ThinRodWithMass(
     const T& mass, const T& length, const Vector3<T>& unit_vector) {
-  // Ensure mass and length are positive.
-  if (mass <= 0 || length <= 0) {
+  if (!is_positive_and_finite(mass) || !is_positive_and_finite(length)) {
     const std::string error_message = fmt::format(
-        "{}(): A thin rod's mass = {} or length = {} is negative or zero.",
-        __func__, mass, length);
+        "{}(): A thin rod's mass = {} or length = {} is not positive and "
+        "finite.", __func__, mass, length);
     throw std::logic_error(error_message);
   }
 
@@ -251,11 +256,10 @@ SpatialInertia<T> SpatialInertia<T>::ThinRodWithMass(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::ThinRodWithMassAboutEnd(
     const T& mass, const T& length, const Vector3<T>& unit_vector) {
-  // Ensure mass and length are positive.
-  if (mass <= 0 || length <= 0) {
+  if (!is_positive_and_finite(mass) || !is_positive_and_finite(length)) {
     const std::string error_message = fmt::format(
-        "{}(): A thin rod's mass = {} or length = {} is negative or zero.",
-        __func__, mass, length);
+        "{}(): A thin rod's mass = {} or length = {} is not positive and "
+        "finite.", __func__, mass, length);
     throw std::logic_error(error_message);
   }
 
@@ -269,17 +273,18 @@ SpatialInertia<T> SpatialInertia<T>::ThinRodWithMassAboutEnd(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidEllipsoidWithDensity(
     const T& density, const T& a, const T& b, const T& c) {
-  if (density <= 0) {
+  if (!is_positive_and_finite(density)) {
     const std::string error_message = fmt::format(
-       "{}(): A solid ellipsoid's density is negative or zero: {}.",
+       "{}(): A solid ellipsoid's density is not positive and finite: {}.",
        __func__, density);
     throw std::logic_error(error_message);
   }
-  // Ensure a, b, c are positive.
-  if (a <= 0 || b <= 0 || c <= 0) {
+  if (!is_positive_and_finite(a) ||
+      !is_positive_and_finite(b) ||
+      !is_positive_and_finite(c)) {
     const std::string error_message = fmt::format(
         "{}(): A solid ellipsoid's semi-axis a = {} or b = {} or c = {} "
-        "is negative or zero.", __func__, a, b, c);
+        "is not positive and finite.", __func__, a, b, c);
     throw std::logic_error(error_message);
   }
   const T volume = (4.0 / 3.0) * M_PI * a * b * c;  // 4/3 π a b c
@@ -292,16 +297,15 @@ SpatialInertia<T> SpatialInertia<T>::SolidEllipsoidWithDensity(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidSphereWithDensity(
     const T& density, const T& radius) {
-  if (density <= 0) {
+  if (!is_positive_and_finite(density)) {
     const std::string error_message = fmt::format(
-        "{}(): A solid sphere's density is negative or zero: {}.",
+        "{}(): A solid sphere's density is not positive and finite: {}.",
         __func__, density);
     throw std::logic_error(error_message);
   }
-  // Ensure radius is positive.
-  if (radius <= 0) {
+  if (!is_positive_and_finite(radius)) {
     const std::string error_message = fmt::format(
-        "{}(): A solid sphere's radius = {} is negative or zero.",
+        "{}(): A solid sphere's radius = {} is not positive and finite.",
         __func__, radius);
     throw std::logic_error(error_message);
   }
@@ -315,16 +319,15 @@ SpatialInertia<T> SpatialInertia<T>::SolidSphereWithDensity(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::HollowSphereWithDensity(
     const T& area_density, const T& radius) {
-  if (area_density <= 0) {
+  if (!is_positive_and_finite(area_density)) {
     const std::string error_message = fmt::format(
-        "{}(): A hollow sphere's area density is negative or zero: {}.",
+        "{}(): A hollow sphere's area density is not positive and finite: {}.",
         __func__, area_density);
     throw std::logic_error(error_message);
   }
-  // Ensure radius is positive.
-  if (radius <= 0) {
+  if (!is_positive_and_finite(radius)) {
     const std::string error_message = fmt::format(
-        "{}(): A hollow sphere's radius = {} is negative or zero.",
+        "{}(): A hollow sphere's radius = {} is not positive and finite.",
         __func__, radius);
     throw std::logic_error(error_message);
   }
@@ -339,9 +342,9 @@ template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidTetrahedronAboutPointWithDensity(
     const T& density, const Vector3<T>& p0, const Vector3<T>& p1,
     const Vector3<T>& p2, const Vector3<T>& p3) {
-  if (density <= 0) {
+  if (!is_positive_and_finite(density)) {
     const std::string error_message = fmt::format(
-        "{}(): A solid tetrahedron's density is negative or zero: {}.",
+        "{}(): A solid tetrahedron's density is not positive and finite: {}.",
         __func__, density);
     throw std::logic_error(error_message);
   }
@@ -365,9 +368,9 @@ template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidTetrahedronAboutVertexWithDensity(
     const T& density, const Vector3<T>& p1, const Vector3<T>& p2,
     const Vector3<T>& p3) {
-  if (density <= 0) {
+  if (!is_positive_and_finite(density)) {
     const std::string error_message = fmt::format(
-        "{}(): A solid tetrahedron's density is negative or zero: {}.",
+        "{}(): A solid tetrahedron's density is not positive and finite: {}.",
         __func__, density);
     throw std::logic_error(error_message);
   }
@@ -387,8 +390,9 @@ void SpatialInertia<T>::ThrowNotPhysicallyValid() const {
   std::string error_message = fmt::format(
           "Spatial inertia fails SpatialInertia::IsPhysicallyValid().");
   const T& mass = get_mass();
-  if (mass <= T(0)) {
-      error_message += fmt::format("\nmass = {} is negative or zero.\n", mass);
+  if (!is_positive_and_finite(mass)) {
+      error_message += fmt::format(
+          "\nmass = {} is not positive and finite.\n", mass);
   } else {
     error_message += fmt::format("{}", *this);
     WriteExtraCentralInertiaProperties(&error_message);
@@ -471,6 +475,7 @@ DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
         &operator<< )
 ))
 
+// }  // anonymous namespace
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/spatial_inertia.cc
+++ b/multibody/tree/spatial_inertia.cc
@@ -21,7 +21,8 @@ SpatialInertia<T> SpatialInertia<T>::PointMass(
   // Ensure mass is non-negative.
   if (mass < 0) {
     const std::string error_message = fmt::format(
-        "{}(): The mass of a particle is negative: {}.", __func__, mass);
+        "{}(): The mass of a particle is negative or zero: {}.",
+        __func__, mass);
     throw std::logic_error(error_message);
   }
 
@@ -42,7 +43,8 @@ SpatialInertia<T> SpatialInertia<T>::SolidBoxWithDensity(
   // Ensure density is non-negative.
   if (density < 0) {
     const std::string error_message = fmt::format(
-        "{}(): A solid box's density is negative: {}.", __func__, density);
+        "{}(): A solid box's density is negative or zero: {}.",
+        __func__, density);
     throw std::logic_error(error_message);
   }
   // Ensure lx, ly, lz are positive.
@@ -64,7 +66,7 @@ SpatialInertia<T> SpatialInertia<T>::SolidBoxWithMass(
   // Ensure mass is non-negative.
   if (mass < 0) {
     const std::string error_message = fmt::format(
-        "{}(): A solid box's mass is negative: {}.", __func__, mass);
+        "{}(): A solid box's mass is negative or zero: {}.", __func__, mass);
     throw std::logic_error(error_message);
   }
   // Ensure lx, ly, lz are positive.
@@ -85,7 +87,8 @@ SpatialInertia<T> SpatialInertia<T>::SolidCubeWithDensity(
   // Ensure density is non-negative.
   if (density < 0) {
     const std::string error_message = fmt::format(
-        "{}(): A solid cube's density is negative: {}.", __func__, density);
+        "{}(): A solid cube's density is negative or zero: {}.",
+        __func__, density);
     throw std::logic_error(error_message);
   }
   // Ensure length is positive.
@@ -107,7 +110,7 @@ SpatialInertia<T> SpatialInertia<T>::SolidCubeWithMass(
   // Ensure mass is non-negative.
   if (mass < 0) {
     const std::string error_message = fmt::format(
-        "{}(): A solid cube's mass is negative: {}.", __func__, mass);
+        "{}(): A solid cube's mass is negative or zero: {}.", __func__, mass);
     throw std::logic_error(error_message);
   }
   // Ensure length is positive.
@@ -130,7 +133,8 @@ SpatialInertia<T> SpatialInertia<T>::SolidCapsuleWithDensity(
   // Ensure density is non-negative.
   if (density < 0) {
     const std::string error_message = fmt::format(
-        "{}(): A solid capsule's density is negative: {}.", __func__, density);
+        "{}(): A solid capsule's density is negative or zero: {}.",
+        __func__, density);
     throw std::logic_error(error_message);
   }
   // Ensure radius and length are positive.
@@ -158,7 +162,8 @@ SpatialInertia<T> SpatialInertia<T>::SolidCylinderWithDensity(
   // Ensure density is non-negative.
   if (density < 0) {
     const std::string error_message = fmt::format(
-        "{}(): A solid cylinder's density is negative: {}.", __func__, density);
+        "{}(): A solid cylinder's density is negative or zero: {}.",
+        __func__, density);
     throw std::logic_error(error_message);
   }
   // Ensure radius and length are positive.
@@ -199,7 +204,8 @@ SpatialInertia<T> SpatialInertia<T>::SolidCylinderWithDensityAboutEnd(
   // Ensure density is non-negative.
   if (density < 0) {
     const std::string error_message = fmt::format(
-        "{}(): A solid cylinder's density is negative: {}.", __func__, density);
+        "{}(): A solid cylinder's density is negative or zero: {}.",
+        __func__, density);
     throw std::logic_error(error_message);
   }
   // Ensure radius and length are positive.
@@ -274,7 +280,8 @@ SpatialInertia<T> SpatialInertia<T>::SolidEllipsoidWithDensity(
   // Ensure density is non-negative.
   if (density < 0) {
     const std::string error_message = fmt::format(
-       "{}(): A solid ellipsoid's density is negative: {}.", __func__, density);
+       "{}(): A solid ellipsoid's density is negative or zero: {}.",
+       __func__, density);
     throw std::logic_error(error_message);
   }
   // Ensure a, b, c are positive.
@@ -297,7 +304,8 @@ SpatialInertia<T> SpatialInertia<T>::SolidSphereWithDensity(
   // Ensure density is non-negative.
   if (density < 0) {
     const std::string error_message = fmt::format(
-        "{}(): A solid sphere's density is negative: {}.", __func__, density);
+        "{}(): A solid sphere's density is negative or zero: {}.",
+        __func__, density);
     throw std::logic_error(error_message);
   }
   // Ensure radius is positive.
@@ -320,7 +328,7 @@ SpatialInertia<T> SpatialInertia<T>::HollowSphereWithDensity(
   // Ensure area_density is non-negative.
   if (area_density < 0) {
     const std::string error_message = fmt::format(
-        "{}(): A hollow sphere's area density is negative: {}.",
+        "{}(): A hollow sphere's area density is negative or zero: {}.",
         __func__, area_density);
     throw std::logic_error(error_message);
   }
@@ -345,7 +353,7 @@ SpatialInertia<T> SpatialInertia<T>::SolidTetrahedronAboutPointWithDensity(
   // Ensure density is non-negative.
   if (density < 0) {
     const std::string error_message = fmt::format(
-        "{}(): A solid tetrahedron's density is negative: {}.",
+        "{}(): A solid tetrahedron's density is negative or zero: {}.",
         __func__, density);
     throw std::logic_error(error_message);
   }
@@ -372,7 +380,7 @@ SpatialInertia<T> SpatialInertia<T>::SolidTetrahedronAboutVertexWithDensity(
   // Ensure density is non-negative.
   if (density < 0) {
     const std::string error_message = fmt::format(
-        "{}(): A solid tetrahedron's density is negative: {}.",
+        "{}(): A solid tetrahedron's density is negative or zero: {}.",
         __func__, density);
     throw std::logic_error(error_message);
   }
@@ -392,8 +400,8 @@ void SpatialInertia<T>::ThrowNotPhysicallyValid() const {
   std::string error_message = fmt::format(
           "Spatial inertia fails SpatialInertia::IsPhysicallyValid().");
   const T& mass = get_mass();
-  if (mass < T(0)) {
-      error_message += fmt::format("\nmass = {} is negative.\n", mass);
+  if (mass <= T(0)) {
+      error_message += fmt::format("\nmass = {} is negative or zero.\n", mass);
   } else {
     error_message += fmt::format("{}", *this);
     WriteExtraCentralInertiaProperties(&error_message);

--- a/multibody/tree/spatial_inertia.cc
+++ b/multibody/tree/spatial_inertia.cc
@@ -18,8 +18,7 @@ SpatialInertia<T> SpatialInertia<T>::MakeUnitary() {
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::PointMass(
     const T& mass, const Vector3<T>& position) {
-  // Ensure mass is non-negative.
-  if (mass < 0) {
+  if (mass <= 0) {
     const std::string error_message = fmt::format(
         "{}(): The mass of a particle is negative or zero: {}.",
         __func__, mass);
@@ -40,8 +39,7 @@ SpatialInertia<T> SpatialInertia<T>::PointMass(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidBoxWithDensity(
     const T& density, const T& lx, const T& ly, const T& lz) {
-  // Ensure density is non-negative.
-  if (density < 0) {
+  if (density <= 0) {
     const std::string error_message = fmt::format(
         "{}(): A solid box's density is negative or zero: {}.",
         __func__, density);
@@ -63,8 +61,7 @@ SpatialInertia<T> SpatialInertia<T>::SolidBoxWithDensity(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidBoxWithMass(
     const T& mass, const T& lx, const T& ly, const T& lz) {
-  // Ensure mass is non-negative.
-  if (mass < 0) {
+  if (mass <= 0) {
     const std::string error_message = fmt::format(
         "{}(): A solid box's mass is negative or zero: {}.", __func__, mass);
     throw std::logic_error(error_message);
@@ -84,8 +81,7 @@ SpatialInertia<T> SpatialInertia<T>::SolidBoxWithMass(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidCubeWithDensity(
     const T& density, const T& length) {
-  // Ensure density is non-negative.
-  if (density < 0) {
+  if (density <= 0) {
     const std::string error_message = fmt::format(
         "{}(): A solid cube's density is negative or zero: {}.",
         __func__, density);
@@ -107,8 +103,7 @@ SpatialInertia<T> SpatialInertia<T>::SolidCubeWithDensity(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidCubeWithMass(
     const T& mass, const T& length) {
-  // Ensure mass is non-negative.
-  if (mass < 0) {
+  if (mass <= 0) {
     const std::string error_message = fmt::format(
         "{}(): A solid cube's mass is negative or zero: {}.", __func__, mass);
     throw std::logic_error(error_message);
@@ -130,8 +125,7 @@ template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidCapsuleWithDensity(
     const T& density, const T& radius, const T& length,
     const Vector3<T>& unit_vector) {
-  // Ensure density is non-negative.
-  if (density < 0) {
+  if (density <= 0) {
     const std::string error_message = fmt::format(
         "{}(): A solid capsule's density is negative or zero: {}.",
         __func__, density);
@@ -159,8 +153,7 @@ template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidCylinderWithDensity(
     const T& density, const T& radius, const T& length,
     const Vector3<T>& unit_vector) {
-  // Ensure density is non-negative.
-  if (density < 0) {
+  if (density <= 0) {
     const std::string error_message = fmt::format(
         "{}(): A solid cylinder's density is negative or zero: {}.",
         __func__, density);
@@ -201,8 +194,7 @@ template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidCylinderWithDensityAboutEnd(
     const T& density, const T& radius, const T& length,
     const Vector3<T>& unit_vector) {
-  // Ensure density is non-negative.
-  if (density < 0) {
+  if (density <= 0) {
     const std::string error_message = fmt::format(
         "{}(): A solid cylinder's density is negative or zero: {}.",
         __func__, density);
@@ -277,8 +269,7 @@ SpatialInertia<T> SpatialInertia<T>::ThinRodWithMassAboutEnd(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidEllipsoidWithDensity(
     const T& density, const T& a, const T& b, const T& c) {
-  // Ensure density is non-negative.
-  if (density < 0) {
+  if (density <= 0) {
     const std::string error_message = fmt::format(
        "{}(): A solid ellipsoid's density is negative or zero: {}.",
        __func__, density);
@@ -301,8 +292,7 @@ SpatialInertia<T> SpatialInertia<T>::SolidEllipsoidWithDensity(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidSphereWithDensity(
     const T& density, const T& radius) {
-  // Ensure density is non-negative.
-  if (density < 0) {
+  if (density <= 0) {
     const std::string error_message = fmt::format(
         "{}(): A solid sphere's density is negative or zero: {}.",
         __func__, density);
@@ -325,8 +315,7 @@ SpatialInertia<T> SpatialInertia<T>::SolidSphereWithDensity(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::HollowSphereWithDensity(
     const T& area_density, const T& radius) {
-  // Ensure area_density is non-negative.
-  if (area_density < 0) {
+  if (area_density <= 0) {
     const std::string error_message = fmt::format(
         "{}(): A hollow sphere's area density is negative or zero: {}.",
         __func__, area_density);
@@ -350,8 +339,7 @@ template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidTetrahedronAboutPointWithDensity(
     const T& density, const Vector3<T>& p0, const Vector3<T>& p1,
     const Vector3<T>& p2, const Vector3<T>& p3) {
-  // Ensure density is non-negative.
-  if (density < 0) {
+  if (density <= 0) {
     const std::string error_message = fmt::format(
         "{}(): A solid tetrahedron's density is negative or zero: {}.",
         __func__, density);
@@ -377,8 +365,7 @@ template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidTetrahedronAboutVertexWithDensity(
     const T& density, const Vector3<T>& p1, const Vector3<T>& p2,
     const Vector3<T>& p3) {
-  // Ensure density is non-negative.
-  if (density < 0) {
+  if (density <= 0) {
     const std::string error_message = fmt::format(
         "{}(): A solid tetrahedron's density is negative or zero: {}.",
         __func__, density);

--- a/multibody/tree/spatial_inertia.cc
+++ b/multibody/tree/spatial_inertia.cc
@@ -39,6 +39,12 @@ SpatialInertia<T> SpatialInertia<T>::PointMass(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidBoxWithDensity(
     const T& density, const T& lx, const T& ly, const T& lz) {
+  // Ensure density is non-negative.
+  if (density < 0) {
+    const std::string error_message = fmt::format(
+        "{}(): A solid box's density is negative: {}.", __func__, density);
+    throw std::logic_error(error_message);
+  }
   // Ensure lx, ly, lz are positive.
   if (lx <= 0 || ly <= 0 || lz <= 0) {
     const std::string error_message = fmt::format(
@@ -55,6 +61,12 @@ SpatialInertia<T> SpatialInertia<T>::SolidBoxWithDensity(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidBoxWithMass(
     const T& mass, const T& lx, const T& ly, const T& lz) {
+  // Ensure mass is non-negative.
+  if (mass < 0) {
+    const std::string error_message = fmt::format(
+        "{}(): A solid box's mass is negative: {}.", __func__, mass);
+    throw std::logic_error(error_message);
+  }
   // Ensure lx, ly, lz are positive.
   if (lx <= 0 || ly <= 0 || lz <= 0) {
     const std::string error_message = fmt::format(
@@ -70,6 +82,12 @@ SpatialInertia<T> SpatialInertia<T>::SolidBoxWithMass(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidCubeWithDensity(
     const T& density, const T& length) {
+  // Ensure density is non-negative.
+  if (density < 0) {
+    const std::string error_message = fmt::format(
+        "{}(): A solid cube's density is negative: {}.", __func__, density);
+    throw std::logic_error(error_message);
+  }
   // Ensure length is positive.
   if (length <= 0) {
     const std::string error_message = fmt::format(
@@ -86,6 +104,12 @@ SpatialInertia<T> SpatialInertia<T>::SolidCubeWithDensity(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidCubeWithMass(
     const T& mass, const T& length) {
+  // Ensure mass is non-negative.
+  if (mass < 0) {
+    const std::string error_message = fmt::format(
+        "{}(): A solid cube's mass is negative: {}.", __func__, mass);
+    throw std::logic_error(error_message);
+  }
   // Ensure length is positive.
   if (length <= 0) {
     const std::string error_message = fmt::format(
@@ -103,6 +127,12 @@ template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidCapsuleWithDensity(
     const T& density, const T& radius, const T& length,
     const Vector3<T>& unit_vector) {
+  // Ensure density is non-negative.
+  if (density < 0) {
+    const std::string error_message = fmt::format(
+        "{}(): A solid capsule's density is negative: {}.", __func__, density);
+    throw std::logic_error(error_message);
+  }
   // Ensure radius and length are positive.
   if (radius <= 0 || length <= 0) {
     const std::string error_message = fmt::format(
@@ -125,6 +155,12 @@ template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidCylinderWithDensity(
     const T& density, const T& radius, const T& length,
     const Vector3<T>& unit_vector) {
+  // Ensure density is non-negative.
+  if (density < 0) {
+    const std::string error_message = fmt::format(
+        "{}(): A solid cylinder's density is negative: {}.", __func__, density);
+    throw std::logic_error(error_message);
+  }
   // Ensure radius and length are positive.
   if (radius <= 0 || length <= 0) {
     const std::string error_message = fmt::format(
@@ -160,6 +196,19 @@ template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidCylinderWithDensityAboutEnd(
     const T& density, const T& radius, const T& length,
     const Vector3<T>& unit_vector) {
+  // Ensure density is non-negative.
+  if (density < 0) {
+    const std::string error_message = fmt::format(
+        "{}(): A solid cylinder's density is negative: {}.", __func__, density);
+    throw std::logic_error(error_message);
+  }
+  // Ensure radius and length are positive.
+  if (radius <= 0 || length <= 0) {
+    const std::string error_message = fmt::format(
+        "{}(): A solid cylinder's radius = {} or length = {} is "
+        "negative or zero.", __func__, radius, length);
+    throw std::logic_error(error_message);
+  }
   SpatialInertia<T> M_BBcm_B =
       SpatialInertia<T>::SolidCylinderWithDensity(
           density, radius, length, unit_vector);
@@ -222,6 +271,12 @@ SpatialInertia<T> SpatialInertia<T>::ThinRodWithMassAboutEnd(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidEllipsoidWithDensity(
     const T& density, const T& a, const T& b, const T& c) {
+  // Ensure density is non-negative.
+  if (density < 0) {
+    const std::string error_message = fmt::format(
+       "{}(): A solid ellipsoid's density is negative: {}.", __func__, density);
+    throw std::logic_error(error_message);
+  }
   // Ensure a, b, c are positive.
   if (a <= 0 || b <= 0 || c <= 0) {
     const std::string error_message = fmt::format(
@@ -239,6 +294,12 @@ SpatialInertia<T> SpatialInertia<T>::SolidEllipsoidWithDensity(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidSphereWithDensity(
     const T& density, const T& radius) {
+  // Ensure density is non-negative.
+  if (density < 0) {
+    const std::string error_message = fmt::format(
+        "{}(): A solid sphere's density is negative: {}.", __func__, density);
+    throw std::logic_error(error_message);
+  }
   // Ensure radius is positive.
   if (radius <= 0) {
     const std::string error_message = fmt::format(
@@ -256,6 +317,13 @@ SpatialInertia<T> SpatialInertia<T>::SolidSphereWithDensity(
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::HollowSphereWithDensity(
     const T& area_density, const T& radius) {
+  // Ensure area_density is non-negative.
+  if (area_density < 0) {
+    const std::string error_message = fmt::format(
+        "{}(): A hollow sphere's area density is negative: {}.",
+        __func__, area_density);
+    throw std::logic_error(error_message);
+  }
   // Ensure radius is positive.
   if (radius <= 0) {
     const std::string error_message = fmt::format(
@@ -274,7 +342,13 @@ template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidTetrahedronAboutPointWithDensity(
     const T& density, const Vector3<T>& p0, const Vector3<T>& p1,
     const Vector3<T>& p2, const Vector3<T>& p3) {
-  DRAKE_THROW_UNLESS(density >= 0);
+  // Ensure density is non-negative.
+  if (density < 0) {
+    const std::string error_message = fmt::format(
+        "{}(): A solid tetrahedron's density is negative: {}.",
+        __func__, density);
+    throw std::logic_error(error_message);
+  }
   // This method calculates a tetrahedron B's spatial inertia M_BA about a
   // point A by forming 3 new position vectors, namely the position vectors
   // from B's vertex B0 to vertices B1, B2, B3 (B's other three vertices).
@@ -295,7 +369,13 @@ template <typename T>
 SpatialInertia<T> SpatialInertia<T>::SolidTetrahedronAboutVertexWithDensity(
     const T& density, const Vector3<T>& p1, const Vector3<T>& p2,
     const Vector3<T>& p3) {
-  DRAKE_THROW_UNLESS(density >= 0);
+  // Ensure density is non-negative.
+  if (density < 0) {
+    const std::string error_message = fmt::format(
+        "{}(): A solid tetrahedron's density is negative: {}.",
+        __func__, density);
+    throw std::logic_error(error_message);
+  }
   using std::abs;
   const T volume = (1.0 / 6.0) * abs(p1.cross(p2).dot(p3));
   const T mass = density * volume;

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -129,7 +129,7 @@ class SpatialInertia {
   /// @param[in] mass mass of the single particle (units of kg).
   /// @param[in] position vector from point P to Q, expressed in a frame B.
   /// @retval M_QP_B particle Q's spatial inertia about P, expressed in frame B.
-  /// @throws std::exception if mass is negative.
+  /// @throws std::exception if mass ≤ 0.
   static SpatialInertia<T> PointMass(const T& mass, const Vector3<T>& position);
 
   /// Creates a spatial inertia for a uniform density solid box B about its
@@ -139,8 +139,8 @@ class SpatialInertia {
   /// @param[in] ly length of the box in the By direction (meters).
   /// @param[in] lz length of the box in the Bz direction (meters).
   /// @retval M_BBo_B B's spatial inertia about Bo, expressed in B.
-  /// @throws std::exception if any of lx, ly, lz are zero or negative
-  /// or if density is negative.
+  /// @throws std::exception if density ≤ 0 or any of lx, ly, lz are zero or
+  /// negative.
   static SpatialInertia<T> SolidBoxWithDensity(
       const T& density, const T& lx, const T& ly, const T& lz);
 
@@ -151,8 +151,8 @@ class SpatialInertia {
   /// @param[in] ly length of the box in the By direction (meters).
   /// @param[in] lz length of the box in the Bz direction (meters).
   /// @retval M_BBo_B B's spatial inertia about Bo, expressed in B.
-  /// @throws std::exception if any of lx, ly, lz are zero or negative
-  /// or if mass is negative.
+  /// @throws std::exception if mass ≤ 0 or any of lx, ly, lz are zero or
+  /// negative.
   static SpatialInertia<T> SolidBoxWithMass(
       const T& mass, const T& lx, const T& ly, const T& lz);
 
@@ -165,8 +165,7 @@ class SpatialInertia {
   /// expressed in frame B is equal to M_BBo expressed in an arbitrary frame E.
   /// @note B's rotational inertia about Bo is triaxially symmetric, meaning
   /// B has an equal moment of inertia about any line passing through Bo.
-  /// @throws std::exception if length is zero or negative
-  /// or if density is negative.
+  /// @throws std::exception if density ≤ 0 or length ≤ 0.
   static SpatialInertia<T> SolidCubeWithDensity(
       const T& density, const T& length);
 
@@ -179,8 +178,7 @@ class SpatialInertia {
   /// expressed in frame B is equal to M_BBo expressed in an arbitrary frame E.
   /// @note B's rotational inertia about Bo is triaxially symmetric, meaning
   /// B has an equal moment of inertia about any line passing through Bo.
-  /// @throws std::exception if length is zero or negative
-  /// or if mass is negative.
+  /// @throws std::exception if mass ≤ 0 or length ≤ 0.
   static SpatialInertia<T> SolidCubeWithMass(
       const T& mass, const T& length);
 
@@ -195,8 +193,7 @@ class SpatialInertia {
   /// @note B's rotational inertia about Bo is axially symmetric, meaning B has
   /// an equal moment of inertia about any line that both passes through Bo
   /// and is perpendicular to unit_vector.
-  /// @throws std::exception if radius or length is zero or negative
-  /// or if density is negative.
+  /// @throws std::exception if density ≤ 0,  radius ≤ 0, or length ≤ 0.
   /// @pre ‖unit_vector‖ = 1; see UnitVector::SolidCapsule() for details.
   static SpatialInertia<T> SolidCapsuleWithDensity(
       const T& density, const T& radius, const T& length,
@@ -213,8 +210,7 @@ class SpatialInertia {
   /// @note B's rotational inertia about Bo is axially symmetric, meaning B has
   /// an equal moment of inertia about any line that both passes through Bo
   /// and is perpendicular to unit_vector.
-  /// @throws std::exception if radius or length is zero or negative
-  /// or if density is negative.
+  /// @throws std::exception if density ≤ 0, radius ≤ 0, or length ≤ 0.
   /// @pre ‖unit_vector‖ = 1.
   /// @see SolidCylinderWithDensityAboutEnd() to calculate M_BBp_B, B's spatial
   /// inertia about Bp (at the center of one of the cylinder's circular ends).
@@ -234,8 +230,7 @@ class SpatialInertia {
   /// @note B's rotational inertia about Bp is axially symmetric, meaning B has
   /// an equal moment of inertia about any line that both passes through Bp
   /// and is perpendicular to unit_vector.
-  /// @throws std::exception if radius or length is zero or negative
-  /// or if density is negative.
+  /// @throws std::exception if density ≤ 0, radius ≤ 0, or length ≤ 0.
   /// @pre ‖unit_vector‖ = 1.
   /// @see SolidCylinderWithDensity() to calculate M_BBcm_B, B's spatial
   /// inertia about Bcm (B's center of mass).
@@ -254,8 +249,7 @@ class SpatialInertia {
   /// an equal moment of inertia about any line that both passes through Bcm and
   /// is perpendicular to unit_vector. B has no (zero) rotational inertia about
   /// the line that passes through Bcm and is parallel to unit_vector.
-  /// @throws std::exception if length is zero or negative
-  /// or if mass is negative.
+  /// @throws std::exception if mass ≤ 0 or length ≤ 0.
   /// @pre ‖unit_vector‖ = 1.
   /// @see ThinRodWithMassAboutEnd() to calculate M_BBp_B, B's spatial inertia
   /// about Bp (one of the ends of rod B).
@@ -274,8 +268,7 @@ class SpatialInertia {
   /// an equal moment of inertia about any line that both passes through Bp and
   /// is perpendicular to unit_vector. B has no (zero) rotational inertia about
   /// the line that passes through Bp and is parallel to unit_vector.
-  /// @throws std::exception if mass or length is zero or negative
-  /// or if mass is negative.
+  /// @throws std::exception if mass ≤ 0 or length ≤ 0.
   /// @pre ‖unit_vector‖ = 1.
   /// @see ThinRodWithMass() to calculate M_BBcm_B, B's spatial inertia about
   /// Bcm (B's center of mass).
@@ -289,8 +282,8 @@ class SpatialInertia {
   /// @param[in] b length of ellipsoid semi-axis in the ellipsoid By direction.
   /// @param[in] c length of ellipsoid semi-axis in the ellipsoid Bz direction.
   /// @retval M_BBo_B B's spatial inertia about Bo, expressed in B.
-  /// @throws std::exception if any of a, b, c are zero or negative
-  /// or if density is negative.
+  /// @throws std::exception if density ≤ 0 or any of a, b, c are zero or
+  /// negative.
   static SpatialInertia<T> SolidEllipsoidWithDensity(
       const T& density, const T& a, const T& b, const T& c);
 
@@ -303,8 +296,7 @@ class SpatialInertia {
   /// frame B is equal to M_BBo expressed in an arbitrary frame E.
   /// @note B's rotational inertia about Bo is triaxially symmetric, meaning
   /// B's has an equal moment of inertia about any line passing through Bo.
-  /// @throws std::exception if radius is zero or negative
-  /// or if density is negative.
+  /// @throws std::exception if density ≤ 0 or radius ≤ 0.
   static SpatialInertia<T> SolidSphereWithDensity(
       const T& density, const T& radius);
 
@@ -318,8 +310,7 @@ class SpatialInertia {
   /// expressed in frame B is equal to M_BBo expressed in an arbitrary frame E.
   /// @note B's rotational inertia about Bo is triaxially symmetric, meaning
   /// B has an equal moment of inertia about any line passing through Bo.
-  /// @throws std::exception if radius is zero or negative
-  /// or if area_density is negative.
+  /// @throws std::exception if area_density ≤ 0 or radius ≤ 0.
   static SpatialInertia<T> HollowSphereWithDensity(
       const T& area_density, const T& radius);
 
@@ -334,7 +325,7 @@ class SpatialInertia {
   /// @retval M_BA_E B's spatial inertia about point A, expressed in E.
   /// @note In the common case, point A is Eo (the origin of the expressed-in
   /// frame E). The example below has point A as Wo (origin of world frame W).
-  /// @throws std::exception if density is negative.
+  /// @throws std::exception if density ≤ 0.
   /// @code{.cc}
   /// double density = 1000;
   /// Vector3<double> p_WoB0_W(1, 0, 0);
@@ -360,7 +351,7 @@ class SpatialInertia {
   /// @param[in] p2 position vector p_B0B2_E from B0 to B2, expressed in E.
   /// @param[in] p3 position vector p_B0B3_E from B0 to B3, expressed in E.
   /// @retval M_BB0_E B's spatial inertia about its vertex B0, expressed in E.
-  /// @throws std::exception if density is negative.
+  /// @throws std::exception if density ≤ 0.
   /// @see SolidTetrahedronAboutPointWithDensity() to calculate a spatial
   /// inertia about an arbitrary point.
   static SpatialInertia<T> SolidTetrahedronAboutVertexWithDensity(

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -139,7 +139,8 @@ class SpatialInertia {
   /// @param[in] ly length of the box in the By direction (meters).
   /// @param[in] lz length of the box in the Bz direction (meters).
   /// @retval M_BBo_B B's spatial inertia about Bo, expressed in B.
-  /// @throws std::exception if any of lx, ly, lz are zero or negative.
+  /// @throws std::exception if any of lx, ly, lz are zero or negative
+  /// or if density is negative.
   static SpatialInertia<T> SolidBoxWithDensity(
       const T& density, const T& lx, const T& ly, const T& lz);
 
@@ -150,7 +151,8 @@ class SpatialInertia {
   /// @param[in] ly length of the box in the By direction (meters).
   /// @param[in] lz length of the box in the Bz direction (meters).
   /// @retval M_BBo_B B's spatial inertia about Bo, expressed in B.
-  /// @throws std::exception if any of lx, ly, lz are zero or negative.
+  /// @throws std::exception if any of lx, ly, lz are zero or negative
+  /// or if mass is negative.
   static SpatialInertia<T> SolidBoxWithMass(
       const T& mass, const T& lx, const T& ly, const T& lz);
 
@@ -163,7 +165,8 @@ class SpatialInertia {
   /// expressed in frame B is equal to M_BBo expressed in an arbitrary frame E.
   /// @note B's rotational inertia about Bo is triaxially symmetric, meaning
   /// B has an equal moment of inertia about any line passing through Bo.
-  /// @throws std::exception if length is zero or negative.
+  /// @throws std::exception if length is zero or negative
+  /// or if density is negative.
   static SpatialInertia<T> SolidCubeWithDensity(
       const T& density, const T& length);
 
@@ -176,7 +179,8 @@ class SpatialInertia {
   /// expressed in frame B is equal to M_BBo expressed in an arbitrary frame E.
   /// @note B's rotational inertia about Bo is triaxially symmetric, meaning
   /// B has an equal moment of inertia about any line passing through Bo.
-  /// @throws std::exception if length is zero or negative.
+  /// @throws std::exception if length is zero or negative
+  /// or if mass is negative.
   static SpatialInertia<T> SolidCubeWithMass(
       const T& mass, const T& length);
 
@@ -186,12 +190,13 @@ class SpatialInertia {
   /// @param[in] radius radius of the cylinder/half-sphere part of the capsule.
   /// @param[in] length length of the cylindrical part of the capsule (meters).
   /// @param[in] unit_vector unit vector defining the axial direction of the
-  ///   cylindrical part of the capsule, expressed in B.
+  /// cylindrical part of the capsule, expressed in B.
   /// @retval M_BBo_B B's spatial inertia about Bo, expressed in B.
   /// @note B's rotational inertia about Bo is axially symmetric, meaning B has
-  ///   an equal moment of inertia about any line that both passes through Bo
-  ///   and is perpendicular to unit_vector.
-  /// @throws std::exception if radius or length is zero or negative.
+  /// an equal moment of inertia about any line that both passes through Bo
+  /// and is perpendicular to unit_vector.
+  /// @throws std::exception if radius or length is zero or negative
+  /// or if density is negative.
   /// @pre ‖unit_vector‖ = 1; see UnitVector::SolidCapsule() for details.
   static SpatialInertia<T> SolidCapsuleWithDensity(
       const T& density, const T& radius, const T& length,
@@ -203,12 +208,13 @@ class SpatialInertia {
   /// @param[in] radius radius of the cylinder (meters).
   /// @param[in] length length of cylinder in unit_vector direction (meters).
   /// @param[in] unit_vector unit vector defining the axial direction of the
-  ///   cylinder, expressed in B.
+  /// cylinder, expressed in B.
   /// @retval M_BBo_B B's spatial inertia about Bo, expressed in B.
   /// @note B's rotational inertia about Bo is axially symmetric, meaning B has
-  ///   an equal moment of inertia about any line that both passes through Bo
-  ///   and is perpendicular to unit_vector.
-  /// @throws std::exception if radius or length is zero or negative.
+  /// an equal moment of inertia about any line that both passes through Bo
+  /// and is perpendicular to unit_vector.
+  /// @throws std::exception if radius or length is zero or negative
+  /// or if density is negative.
   /// @pre ‖unit_vector‖ = 1.
   /// @see SolidCylinderWithDensityAboutEnd() to calculate M_BBp_B, B's spatial
   /// inertia about Bp (at the center of one of the cylinder's circular ends).
@@ -222,13 +228,14 @@ class SpatialInertia {
   /// @param[in] radius radius of cylinder (meters).
   /// @param[in] length length of cylinder in unit_vector direction (meters).
   /// @param[in] unit_vector unit vector defining the axial direction of the
-  ///   cylinder, expressed in B.
+  /// cylinder, expressed in B.
   /// @retval M_BBp_B B's spatial inertia about Bp, expressed in B.
   /// @note The position from Bp to Bcm is length / 2 * unit_vector.
   /// @note B's rotational inertia about Bp is axially symmetric, meaning B has
-  ///   an equal moment of inertia about any line that both passes through Bp
-  ///   and is perpendicular to unit_vector.
-  /// @throws std::exception if radius or length is zero or negative.
+  /// an equal moment of inertia about any line that both passes through Bp
+  /// and is perpendicular to unit_vector.
+  /// @throws std::exception if radius or length is zero or negative
+  /// or if density is negative.
   /// @pre ‖unit_vector‖ = 1.
   /// @see SolidCylinderWithDensity() to calculate M_BBcm_B, B's spatial
   /// inertia about Bcm (B's center of mass).
@@ -247,7 +254,8 @@ class SpatialInertia {
   /// an equal moment of inertia about any line that both passes through Bcm and
   /// is perpendicular to unit_vector. B has no (zero) rotational inertia about
   /// the line that passes through Bcm and is parallel to unit_vector.
-  /// @throws std::exception if length is zero or negative.
+  /// @throws std::exception if length is zero or negative
+  /// or if mass is negative.
   /// @pre ‖unit_vector‖ = 1.
   /// @see ThinRodWithMassAboutEnd() to calculate M_BBp_B, B's spatial inertia
   /// about Bp (one of the ends of rod B).
@@ -266,7 +274,8 @@ class SpatialInertia {
   /// an equal moment of inertia about any line that both passes through Bp and
   /// is perpendicular to unit_vector. B has no (zero) rotational inertia about
   /// the line that passes through Bp and is parallel to unit_vector.
-  /// @throws std::exception if mass or length is zero or negative.
+  /// @throws std::exception if mass or length is zero or negative
+  /// or if mass is negative.
   /// @pre ‖unit_vector‖ = 1.
   /// @see ThinRodWithMass() to calculate M_BBcm_B, B's spatial inertia about
   /// Bcm (B's center of mass).
@@ -280,7 +289,8 @@ class SpatialInertia {
   /// @param[in] b length of ellipsoid semi-axis in the ellipsoid By direction.
   /// @param[in] c length of ellipsoid semi-axis in the ellipsoid Bz direction.
   /// @retval M_BBo_B B's spatial inertia about Bo, expressed in B.
-  /// @throws std::exception if any of a, b, c are zero or negative.
+  /// @throws std::exception if any of a, b, c are zero or negative
+  /// or if density is negative.
   static SpatialInertia<T> SolidEllipsoidWithDensity(
       const T& density, const T& a, const T& b, const T& c);
 
@@ -289,11 +299,12 @@ class SpatialInertia {
   /// @param[in] density mass per volume (kg/m³).
   /// @param[in] radius sphere's radius (meters).
   /// @retval M_BBo B's spatial inertia about Bo. Since B's rotational inertia
-  ///   is triaxially symmetric, M_BBo_B = M_BBo_E, i.e., M_BBo expressed in
-  ///   frame B is equal to M_BBo expressed in an arbitrary frame E.
+  /// is triaxially symmetric, M_BBo_B = M_BBo_E, i.e., M_BBo expressed in
+  /// frame B is equal to M_BBo expressed in an arbitrary frame E.
   /// @note B's rotational inertia about Bo is triaxially symmetric, meaning
-  ///   B's has an equal moment of inertia about any line passing through Bo.
-  /// @throws std::exception if radius is zero or negative.
+  /// B's has an equal moment of inertia about any line passing through Bo.
+  /// @throws std::exception if radius is zero or negative
+  /// or if density is negative.
   static SpatialInertia<T> SolidSphereWithDensity(
       const T& density, const T& radius);
 
@@ -307,7 +318,8 @@ class SpatialInertia {
   /// expressed in frame B is equal to M_BBo expressed in an arbitrary frame E.
   /// @note B's rotational inertia about Bo is triaxially symmetric, meaning
   /// B has an equal moment of inertia about any line passing through Bo.
-  /// @throws std::exception if radius is zero or negative.
+  /// @throws std::exception if radius is zero or negative
+  /// or if area_density is negative.
   static SpatialInertia<T> HollowSphereWithDensity(
       const T& area_density, const T& radius);
 

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -334,7 +334,7 @@ class SpatialInertia {
   /// @retval M_BA_E B's spatial inertia about point A, expressed in E.
   /// @note In the common case, point A is Eo (the origin of the expressed-in
   /// frame E). The example below has point A as Wo (origin of world frame W).
-  /// @pre density ≥ 0.
+  /// @throws std::exception if density is negative.
   /// @code{.cc}
   /// double density = 1000;
   /// Vector3<double> p_WoB0_W(1, 0, 0);
@@ -360,7 +360,7 @@ class SpatialInertia {
   /// @param[in] p2 position vector p_B0B2_E from B0 to B2, expressed in E.
   /// @param[in] p3 position vector p_B0B3_E from B0 to B3, expressed in E.
   /// @retval M_BB0_E B's spatial inertia about its vertex B0, expressed in E.
-  /// @pre density ≥ 0.
+  /// @throws std::exception if density is negative.
   /// @see SolidTetrahedronAboutPointWithDensity() to calculate a spatial
   /// inertia about an arbitrary point.
   static SpatialInertia<T> SolidTetrahedronAboutVertexWithDensity(

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -129,7 +129,7 @@ class SpatialInertia {
   /// @param[in] mass mass of the single particle (units of kg).
   /// @param[in] position vector from point P to Q, expressed in a frame B.
   /// @retval M_QP_B particle Q's spatial inertia about P, expressed in frame B.
-  /// @throws std::exception if mass ≤ 0.
+  /// @throws std::exception if mass is not positive and finite.
   static SpatialInertia<T> PointMass(const T& mass, const Vector3<T>& position);
 
   /// Creates a spatial inertia for a uniform density solid box B about its
@@ -139,8 +139,8 @@ class SpatialInertia {
   /// @param[in] ly length of the box in the By direction (meters).
   /// @param[in] lz length of the box in the Bz direction (meters).
   /// @retval M_BBo_B B's spatial inertia about Bo, expressed in B.
-  /// @throws std::exception if density ≤ 0 or any of lx, ly, lz are zero or
-  /// negative.
+  /// @throws std::exception if density, lx, ly, or lz is not positive and
+  /// finite.
   static SpatialInertia<T> SolidBoxWithDensity(
       const T& density, const T& lx, const T& ly, const T& lz);
 
@@ -151,8 +151,7 @@ class SpatialInertia {
   /// @param[in] ly length of the box in the By direction (meters).
   /// @param[in] lz length of the box in the Bz direction (meters).
   /// @retval M_BBo_B B's spatial inertia about Bo, expressed in B.
-  /// @throws std::exception if mass ≤ 0 or any of lx, ly, lz are zero or
-  /// negative.
+  /// @throws std::exception if mass, lx, ly, or lz is not positive and finite.
   static SpatialInertia<T> SolidBoxWithMass(
       const T& mass, const T& lx, const T& ly, const T& lz);
 
@@ -165,7 +164,7 @@ class SpatialInertia {
   /// expressed in frame B is equal to M_BBo expressed in an arbitrary frame E.
   /// @note B's rotational inertia about Bo is triaxially symmetric, meaning
   /// B has an equal moment of inertia about any line passing through Bo.
-  /// @throws std::exception if density ≤ 0 or length ≤ 0.
+  /// @throws std::exception if density or length is not positive and finite.
   static SpatialInertia<T> SolidCubeWithDensity(
       const T& density, const T& length);
 
@@ -178,7 +177,7 @@ class SpatialInertia {
   /// expressed in frame B is equal to M_BBo expressed in an arbitrary frame E.
   /// @note B's rotational inertia about Bo is triaxially symmetric, meaning
   /// B has an equal moment of inertia about any line passing through Bo.
-  /// @throws std::exception if mass ≤ 0 or length ≤ 0.
+  /// @throws std::exception if mass or length is not positive and finite.
   static SpatialInertia<T> SolidCubeWithMass(
       const T& mass, const T& length);
 
@@ -193,7 +192,8 @@ class SpatialInertia {
   /// @note B's rotational inertia about Bo is axially symmetric, meaning B has
   /// an equal moment of inertia about any line that both passes through Bo
   /// and is perpendicular to unit_vector.
-  /// @throws std::exception if density ≤ 0,  radius ≤ 0, or length ≤ 0.
+  /// @throws std::exception if density, radius, or length is not positive and
+  /// finite.
   /// @pre ‖unit_vector‖ = 1; see UnitVector::SolidCapsule() for details.
   static SpatialInertia<T> SolidCapsuleWithDensity(
       const T& density, const T& radius, const T& length,
@@ -210,7 +210,8 @@ class SpatialInertia {
   /// @note B's rotational inertia about Bo is axially symmetric, meaning B has
   /// an equal moment of inertia about any line that both passes through Bo
   /// and is perpendicular to unit_vector.
-  /// @throws std::exception if density ≤ 0, radius ≤ 0, or length ≤ 0.
+  /// @throws std::exception if density, radius, or length is not positive and
+  /// finite.
   /// @pre ‖unit_vector‖ = 1.
   /// @see SolidCylinderWithDensityAboutEnd() to calculate M_BBp_B, B's spatial
   /// inertia about Bp (at the center of one of the cylinder's circular ends).
@@ -230,7 +231,8 @@ class SpatialInertia {
   /// @note B's rotational inertia about Bp is axially symmetric, meaning B has
   /// an equal moment of inertia about any line that both passes through Bp
   /// and is perpendicular to unit_vector.
-  /// @throws std::exception if density ≤ 0, radius ≤ 0, or length ≤ 0.
+  /// @throws std::exception if density, radius, or length is not positive and
+  /// finite.
   /// @pre ‖unit_vector‖ = 1.
   /// @see SolidCylinderWithDensity() to calculate M_BBcm_B, B's spatial
   /// inertia about Bcm (B's center of mass).
@@ -249,7 +251,7 @@ class SpatialInertia {
   /// an equal moment of inertia about any line that both passes through Bcm and
   /// is perpendicular to unit_vector. B has no (zero) rotational inertia about
   /// the line that passes through Bcm and is parallel to unit_vector.
-  /// @throws std::exception if mass ≤ 0 or length ≤ 0.
+  /// @throws std::exception if mass or length is not positive and finite.
   /// @pre ‖unit_vector‖ = 1.
   /// @see ThinRodWithMassAboutEnd() to calculate M_BBp_B, B's spatial inertia
   /// about Bp (one of the ends of rod B).
@@ -268,7 +270,7 @@ class SpatialInertia {
   /// an equal moment of inertia about any line that both passes through Bp and
   /// is perpendicular to unit_vector. B has no (zero) rotational inertia about
   /// the line that passes through Bp and is parallel to unit_vector.
-  /// @throws std::exception if mass ≤ 0 or length ≤ 0.
+  /// @throws std::exception if mass or length is not positive and finite.
   /// @pre ‖unit_vector‖ = 1.
   /// @see ThinRodWithMass() to calculate M_BBcm_B, B's spatial inertia about
   /// Bcm (B's center of mass).
@@ -282,8 +284,7 @@ class SpatialInertia {
   /// @param[in] b length of ellipsoid semi-axis in the ellipsoid By direction.
   /// @param[in] c length of ellipsoid semi-axis in the ellipsoid Bz direction.
   /// @retval M_BBo_B B's spatial inertia about Bo, expressed in B.
-  /// @throws std::exception if density ≤ 0 or any of a, b, c are zero or
-  /// negative.
+  /// @throws std::exception if density, a, b, or c is not positive and finite.
   static SpatialInertia<T> SolidEllipsoidWithDensity(
       const T& density, const T& a, const T& b, const T& c);
 
@@ -296,7 +297,7 @@ class SpatialInertia {
   /// frame B is equal to M_BBo expressed in an arbitrary frame E.
   /// @note B's rotational inertia about Bo is triaxially symmetric, meaning
   /// B's has an equal moment of inertia about any line passing through Bo.
-  /// @throws std::exception if density ≤ 0 or radius ≤ 0.
+  /// @throws std::exception if density or radius is not positive and finite.
   static SpatialInertia<T> SolidSphereWithDensity(
       const T& density, const T& radius);
 
@@ -310,7 +311,8 @@ class SpatialInertia {
   /// expressed in frame B is equal to M_BBo expressed in an arbitrary frame E.
   /// @note B's rotational inertia about Bo is triaxially symmetric, meaning
   /// B has an equal moment of inertia about any line passing through Bo.
-  /// @throws std::exception if area_density ≤ 0 or radius ≤ 0.
+  /// @throws std::exception if area_density or radius is not positive and
+  /// finite.
   static SpatialInertia<T> HollowSphereWithDensity(
       const T& area_density, const T& radius);
 
@@ -325,7 +327,7 @@ class SpatialInertia {
   /// @retval M_BA_E B's spatial inertia about point A, expressed in E.
   /// @note In the common case, point A is Eo (the origin of the expressed-in
   /// frame E). The example below has point A as Wo (origin of world frame W).
-  /// @throws std::exception if density ≤ 0.
+  /// @throws std::exception if density is not positive and finite.
   /// @code{.cc}
   /// double density = 1000;
   /// Vector3<double> p_WoB0_W(1, 0, 0);
@@ -351,7 +353,7 @@ class SpatialInertia {
   /// @param[in] p2 position vector p_B0B2_E from B0 to B2, expressed in E.
   /// @param[in] p3 position vector p_B0B3_E from B0 to B3, expressed in E.
   /// @retval M_BB0_E B's spatial inertia about its vertex B0, expressed in E.
-  /// @throws std::exception if density ≤ 0.
+  /// @throws std::exception if density is not positive and finite.
   /// @see SolidTetrahedronAboutPointWithDensity() to calculate a spatial
   /// inertia about an arbitrary point.
   static SpatialInertia<T> SolidTetrahedronAboutVertexWithDensity(

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -93,7 +93,7 @@ GTEST_TEST(SpatialInertia, PointMass) {
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::PointMass(-1, p_BpBcm_B),
-      "[^]* The mass of a particle is negative or zero: .*");
+      "[^]* The mass of a particle is not positive and finite: .*");
 }
 
 // Tests the static method for the spatial inertia of a solid box.
@@ -120,10 +120,10 @@ GTEST_TEST(SpatialInertia, SolidBoxWithDensityOrMass) {
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidBoxWithMass(-0.1, lx, ly, lz),
-      "[^]* A solid box's mass is negative or zero: .*.");
+      "[^]* A solid box's mass is not positive and finite: .*.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidBoxWithDensity(-9.3, lx, ly, lz),
-      "[^]* A solid box's density is negative or zero: .*.");
+      "[^]* A solid box's density is not positive and finite: .*.");
 
   // Ensure a negative or zero length, width, or height throws an exception.
   // There is not an exhaustive test of each parameter being zero or negative.
@@ -131,27 +131,27 @@ GTEST_TEST(SpatialInertia, SolidBoxWithDensityOrMass) {
   // single value sufficiently tests the full domain of invalid values.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidBoxWithDensity(density, 0, ly, lz),
-      "[^]* One or more dimensions of a solid box is negative or zero: "
+      "[^]* One or more dimensions of a solid box is not positive and finite: "
       "(.*, .*, .*).");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidBoxWithMass(mass, 0, ly, lz),
-      "[^]* One or more dimensions of a solid box is negative or zero: "
+      "[^]* One or more dimensions of a solid box is not positive and finite: "
       "(.*, .*, .*).");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidBoxWithDensity(density, ly, -0.1, lz),
-      "[^]* One or more dimensions of a solid box is negative or zero: "
+      "[^]* One or more dimensions of a solid box is not positive and finite: "
       "(.*, .*, .*).");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidBoxWithMass(mass, ly, -0.1, lz),
-      "[^]* One or more dimensions of a solid box is negative or zero: "
+      "[^]* One or more dimensions of a solid box is not positive and finite: "
       "(.*, .*, .*).");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidBoxWithDensity(density, ly, ly, -1E-15),
-      "[^]* One or more dimensions of a solid box is negative or zero: "
+      "[^]* One or more dimensions of a solid box is not positive and finite: "
       "(.*, .*, .*).");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidBoxWithMass(mass, ly, ly, -1E-15),
-      "[^]* One or more dimensions of a solid box is negative or zero: "
+      "[^]* One or more dimensions of a solid box is not positive and finite: "
       "(.*, .*, .*).");
 }
 
@@ -184,24 +184,24 @@ GTEST_TEST(SpatialInertia, SolidCubeWithDensity) {
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCubeWithMass(-0.1, length),
-      "[^]* A solid cube's mass is negative or zero: .*.");
+      "[^]* A solid cube's mass is not positive and finite: .*.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCubeWithDensity(-9.3, length),
-      "[^]* A solid cube's density is negative or zero: .*.");
+      "[^]* A solid cube's density is not positive and finite: .*.");
 
   // Ensure a negative or zero length throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCubeWithDensity(density, 0),
-      "[^]* The length of a solid cube is negative or zero: .*.");
+      "[^]* The length of a solid cube is not positive and finite: .*.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCubeWithMass(mass, 0),
-      "[^]* The length of a solid cube is negative or zero: .*.");
+      "[^]* The length of a solid cube is not positive and finite: .*.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCubeWithDensity(density, -1),
-      "[^]* The length of a solid cube is negative or zero: .*.");
+      "[^]* The length of a solid cube is not positive and finite: .*.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCubeWithMass(mass, -1),
-      "[^]* The length of a solid cube is negative or zero: .*.");
+      "[^]* The length of a solid cube is not positive and finite: .*.");
 }
 
 
@@ -234,7 +234,7 @@ GTEST_TEST(SpatialInertia, SolidCapsuleWithDensity) {
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCapsuleWithDensity(-9.3, r, l, unit_vec),
-      "[^]* A solid capsule's density is negative or zero: .*.");
+      "[^]* A solid capsule's density is not positive and finite: .*.");
 
   // Ensure a negative or zero radius or length throws an exception.
   // There is not an exhaustive test of each parameter being zero or negative.
@@ -243,11 +243,11 @@ GTEST_TEST(SpatialInertia, SolidCapsuleWithDensity) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCapsuleWithDensity(density, 0, l, unit_vec),
       "[^]* A solid capsule's radius = .* or length = .* "
-      "is negative or zero.");
+      "is not positive and finite.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCapsuleWithDensity(density, r, -2, unit_vec),
       "[^]* A solid capsule's radius = .* or length = .* "
-      "is negative or zero.");
+      "is not positive and finite.");
 }
 
 // Tests the static method for the spatial inertia of a solid cylinder.
@@ -299,33 +299,33 @@ GTEST_TEST(SpatialInertia, SolidCylinderWithDensity) {
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCylinderWithDensity(-9.3, r, l, unit_vec),
-      "[^]* A solid cylinder's density is negative or zero: .*.");
+      "[^]* A solid cylinder's density is not positive and finite: .*.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCylinderWithDensityAboutEnd(
           -9.3, r, l, unit_vec),
-      "[^]* A solid cylinder's density is negative or zero: .*.");
+      "[^]* A solid cylinder's density is not positive and finite: .*.");
 
   // Ensure a negative or zero radius throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCylinderWithDensity(density, 0, l, unit_vec),
       "[^]* A solid cylinder's radius = .* or length = .* "
-      "is negative or zero.");
+      "is not positive and finite.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCylinderWithDensityAboutEnd(density,
           -0.1, l, unit_vec),
       "[^]* A solid cylinder's radius = .* or length = .* "
-      "is negative or zero.");
+      "is not positive and finite.");
 
   // Ensure a negative or zero length throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCylinderWithDensity(density, r, 0, unit_vec),
       "[^]* A solid cylinder's radius = .* or length = .* "
-      "is negative or zero.");
+      "is not positive and finite.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCylinderWithDensityAboutEnd(density,
           r, -0.1, unit_vec),
       "[^]* A solid cylinder's radius = .* or length = .* "
-      "is negative or zero.");
+      "is not positive and finite.");
 
   // Ensure a bad unit vector throws an exception.
   const Vector3<double> bad_vec(1, 0.1, 0);
@@ -377,21 +377,21 @@ GTEST_TEST(SpatialInertia, ThinRodWithMass) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::ThinRodWithMass(-1.23, length, unit_vec),
       "[^]* A thin rod's mass = .* or length = .* "
-      "is negative or zero.");
+      "is not positive and finite.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::ThinRodWithMass(0, length, unit_vec),
       "[^]* A thin rod's mass = .* or length = .* "
-      "is negative or zero.");
+      "is not positive and finite.");
 
   // Ensure a negative or zero length throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::ThinRodWithMass(mass, -4.56, unit_vec),
       "[^]* A thin rod's mass = .* or length = .* "
-      "is negative or zero.");
+      "is not positive and finite.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::ThinRodWithMass(mass, 0, unit_vec),
       "[^]* A thin rod's mass = .* or length = .* "
-      "is negative or zero.");
+      "is not positive and finite.");
 
   // Ensure a bad unit vector throws an exception.
   const Vector3<double> bad_vec(1, 0.1, 0);
@@ -418,7 +418,7 @@ GTEST_TEST(SpatialInertia, SolidEllipsoidWithDensity) {
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidEllipsoidWithDensity(-9.3, a, b, c),
-      "[^]* A solid ellipsoid's density is negative or zero: .*.");
+      "[^]* A solid ellipsoid's density is not positive and finite: .*.");
 
   // Ensure a negative or zero semi-axis length throws an exception.
   // There is not an exhaustive test of each parameter being zero or negative.
@@ -427,15 +427,15 @@ GTEST_TEST(SpatialInertia, SolidEllipsoidWithDensity) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidEllipsoidWithDensity(density, 0, b, c),
       "[^]* A solid ellipsoid's semi-axis a = .* or b = .* or c = .* "
-      "is negative or zero.");
+      "is not positive and finite.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidEllipsoidWithDensity(density, a, -2, c),
       "[^]* A solid ellipsoid's semi-axis a = .* or b = .* or c = .* "
-      "is negative or zero.");
+      "is not positive and finite.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidEllipsoidWithDensity(density, a, b, -0.01),
       "[^]* A solid ellipsoid's semi-axis a = .* or b = .* or c = .* "
-      "is negative or zero.");
+      "is not positive and finite.");
 }
 
 // Tests the static method for the spatial inertia of a solid sphere.
@@ -454,15 +454,15 @@ GTEST_TEST(SpatialInertia, SolidSphereWithDensity) {
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidSphereWithDensity(-9.3, r),
-      "[^]* A solid sphere's density is negative or zero: .*.");
+      "[^]* A solid sphere's density is not positive and finite: .*.");
 
   // Ensure a negative or zero radius throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidSphereWithDensity(density, 0),
-      "[^]* A solid sphere's radius = .* is negative or zero.");
+      "[^]* A solid sphere's radius = .* is not positive and finite.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidSphereWithDensity(density, -0.2),
-      "[^]* A solid sphere's radius = .* is negative or zero.");
+      "[^]* A solid sphere's radius = .* is not positive and finite.");
 }
 
 // Tests the static method for the spatial inertia of a thin hollow sphere.
@@ -481,15 +481,15 @@ GTEST_TEST(SpatialInertia, HollowSphereWithDensity) {
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::HollowSphereWithDensity(-9.3, r),
-      "[^]* A hollow sphere's area density is negative or zero: .*.");
+      "[^]* A hollow sphere's area density is not positive and finite: .*.");
 
   // Ensure a negative or zero radius throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::HollowSphereWithDensity(area_density, 0),
-      "[^]* A hollow sphere's radius = .* is negative or zero.");
+      "[^]* A hollow sphere's radius = .* is not positive and finite.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::HollowSphereWithDensity(area_density, -0.2),
-      "[^]* A hollow sphere's radius = .* is negative or zero.");
+      "[^]* A hollow sphere's radius = .* is not positive and finite.");
 }
 
 // Test spatial inertia of a solid tetrahedron B about its vertex B0.
@@ -523,7 +523,7 @@ GTEST_TEST(SpatialInertia, SolidTetrahedronAboutVertex) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidTetrahedronAboutVertexWithDensity(
           -9.3, p1, p2, p3),
-      "[^]* A solid tetrahedron's density is negative or zero: .*.");
+      "[^]* A solid tetrahedron's density is not positive and finite: .*.");
 }
 
 // Test spatial inertia of a solid tetrahedron about an arbitrary point A.
@@ -568,7 +568,7 @@ GTEST_TEST(SpatialInertia, SolidTetrahedronAboutPoint) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidTetrahedronAboutPointWithDensity(
           -9.3, p_AB0, p_AB1, p_AB3, p_AB2),
-      "[^]* A solid tetrahedron's density is negative or zero: .*.");
+      "[^]* A solid tetrahedron's density is not positive and finite: .*.");
 }
 
 // Test the construction from the mass, center of mass, and unit inertia of a

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -119,9 +119,12 @@ GTEST_TEST(SpatialInertia, SolidBoxWithDensityOrMass) {
   EXPECT_TRUE(CompareMatrices(M_with_mass.CopyToFullMatrix6(),
                               M_with_density.CopyToFullMatrix6()));
 
-  // Ensure a negative density throws an exception.
+  // Ensure a negative mass or density throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      SpatialInertia<double>::SolidBoxWithDensity(-0.1, lx, ly, lz),
+      SpatialInertia<double>::SolidBoxWithMass(-0.1, lx, ly, lz),
+      "[^]* A solid box's mass is negative: .*.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SpatialInertia<double>::SolidBoxWithDensity(-9.3, lx, ly, lz),
       "[^]* A solid box's density is negative: .*.");
 
   // Ensure a negative or zero length, width, or height throws an exception.
@@ -181,6 +184,14 @@ GTEST_TEST(SpatialInertia, SolidCubeWithDensity) {
   EXPECT_TRUE(CompareMatrices(M_with_mass.CopyToFullMatrix6(),
       M_with_density.CopyToFullMatrix6()));
 
+  // Ensure a negative mass or density throws an exception.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SpatialInertia<double>::SolidCubeWithMass(-0.1, length),
+      "[^]* A solid cube's mass is negative: .*.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SpatialInertia<double>::SolidCubeWithDensity(-9.3, length),
+      "[^]* A solid cube's density is negative: .*.");
+
   // Ensure a negative or zero length throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCubeWithDensity(density, 0),
@@ -223,6 +234,11 @@ GTEST_TEST(SpatialInertia, SolidCapsuleWithDensity) {
   M = SpatialInertia<double>::SolidCapsuleWithDensity(density, r, l, unit_vec);
   EXPECT_TRUE(
       CompareMatrices(M_expected.CopyToFullMatrix6(), M.CopyToFullMatrix6()));
+
+  // Ensure a negative density throws an exception.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SpatialInertia<double>::SolidCapsuleWithDensity(-9.3, r, l, unit_vec),
+      "[^]* A solid capsule's density is negative: .*.");
 
   // Ensure a negative or zero radius or length throws an exception.
   // There is not an exhaustive test of each parameter being zero or negative.
@@ -285,18 +301,34 @@ GTEST_TEST(SpatialInertia, SolidCylinderWithDensity) {
   EXPECT_TRUE(
       CompareMatrices(M_expected.CopyToFullMatrix6(), M.CopyToFullMatrix6()));
 
-  // Ensure a negative or zero radius or length throws an exception.
-  // There is not an exhaustive test of each parameter being zero or negative.
-  // Instead, each parameter is tested with a single bad value and we assume a
-  // single value sufficiently tests the full domain of invalid values.
+  // Ensure a negative density throws an exception.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SpatialInertia<double>::SolidCylinderWithDensity(-9.3, r, l, unit_vec),
+      "[^]* A solid cylinder's density is negative: .*.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SpatialInertia<double>::SolidCylinderWithDensityAboutEnd(
+          -9.3, r, l, unit_vec),
+      "[^]* A solid cylinder's density is negative: .*.");
+
+  // Ensure a negative or zero radius throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCylinderWithDensity(density, 0, l, unit_vec),
       "[^]* A solid cylinder's radius = .* or length = .* "
       "is negative or zero.");
-
   DRAKE_EXPECT_THROWS_MESSAGE(
-      SpatialInertia<double>::SolidCylinderWithDensity(density,
+      SpatialInertia<double>::SolidCylinderWithDensityAboutEnd(density,
           -0.1, l, unit_vec),
+      "[^]* A solid cylinder's radius = .* or length = .* "
+      "is negative or zero.");
+
+  // Ensure a negative or zero length throws an exception.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SpatialInertia<double>::SolidCylinderWithDensity(density, r, 0, unit_vec),
+      "[^]* A solid cylinder's radius = .* or length = .* "
+      "is negative or zero.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SpatialInertia<double>::SolidCylinderWithDensityAboutEnd(density,
+          r, -0.1, unit_vec),
       "[^]* A solid cylinder's radius = .* or length = .* "
       "is negative or zero.");
 
@@ -347,7 +379,7 @@ GTEST_TEST(SpatialInertia, ThinRodWithMass) {
   EXPECT_TRUE(CompareMatrices(
       M_BBp_B.CopyToFullMatrix6(), M.CopyToFullMatrix6(), kTolerance));
 
-  // Ensure a negative or zero mass or length throws an exception.
+  // Ensure a negative or zero mass throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::ThinRodWithMass(-1.23, length, unit_vec),
       "[^]* A thin rod's mass = .* or length = .* "
@@ -357,11 +389,11 @@ GTEST_TEST(SpatialInertia, ThinRodWithMass) {
       "[^]* A thin rod's mass = .* or length = .* "
       "is negative or zero.");
 
+  // Ensure a negative or zero length throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::ThinRodWithMass(mass, -4.56, unit_vec),
       "[^]* A thin rod's mass = .* or length = .* "
       "is negative or zero.");
-
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::ThinRodWithMass(mass, 0, unit_vec),
       "[^]* A thin rod's mass = .* or length = .* "
@@ -389,6 +421,11 @@ GTEST_TEST(SpatialInertia, SolidEllipsoidWithDensity) {
       SpatialInertia<double>::SolidEllipsoidWithDensity(density, a, b, c);
   EXPECT_TRUE(
       CompareMatrices(M_expected.CopyToFullMatrix6(), M.CopyToFullMatrix6()));
+
+  // Ensure a negative density throws an exception.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SpatialInertia<double>::SolidEllipsoidWithDensity(-9.3, a, b, c),
+      "[^]* A solid ellipsoid's density is negative: .*.");
 
   // Ensure a negative or zero semi-axis length throws an exception.
   // There is not an exhaustive test of each parameter being zero or negative.
@@ -422,6 +459,11 @@ GTEST_TEST(SpatialInertia, SolidSphereWithDensity) {
   EXPECT_TRUE(
       CompareMatrices(M_expected.CopyToFullMatrix6(), M.CopyToFullMatrix6()));
 
+  // Ensure a negative density throws an exception.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SpatialInertia<double>::SolidSphereWithDensity(-9.3, r),
+      "[^]* A solid sphere's density is negative: .*.");
+
   // Ensure a negative or zero radius throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidSphereWithDensity(density, 0),
@@ -444,6 +486,11 @@ GTEST_TEST(SpatialInertia, HollowSphereWithDensity) {
       SpatialInertia<double>::HollowSphereWithDensity(area_density, r);
   EXPECT_TRUE(
       CompareMatrices(M_expected.CopyToFullMatrix6(), M.CopyToFullMatrix6()));
+
+  // Ensure a negative area density throws an exception.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SpatialInertia<double>::HollowSphereWithDensity(-9.3, r),
+      "[^]* A hollow sphere's area density is negative: .*.");
 
   // Ensure a negative or zero radius throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -481,6 +528,12 @@ GTEST_TEST(SpatialInertia, SolidTetrahedronAboutVertex) {
           density, p2, p1, p3);
   EXPECT_TRUE(CompareMatrices(M_BB0_expected.CopyToFullMatrix6(),
                               M_BB0.CopyToFullMatrix6(), kTolerance));
+
+  // Ensure a negative density throws an exception.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SpatialInertia<double>::SolidTetrahedronAboutVertexWithDensity(
+          -9.3, p1, p2, p3),
+      "[^]* A solid tetrahedron's density is negative: .*.");
 }
 
 // Test spatial inertia of a solid tetrahedron about an arbitrary point A.
@@ -517,10 +570,16 @@ GTEST_TEST(SpatialInertia, SolidTetrahedronAboutPoint) {
                               M_BA.CopyToFullMatrix6(), kTolerance));
 
   // Ensure nothing changes if two arguments are switched (e.g., p_AB2, p_AB3).
-  M_BA = SpatialInertia<double>::SolidTetrahedronAboutPointWithDensity(density,
-      p_AB0, p_AB1, p_AB3, p_AB2);
+  M_BA = SpatialInertia<double>::SolidTetrahedronAboutPointWithDensity(
+      density, p_AB0, p_AB1, p_AB3, p_AB2);
   EXPECT_TRUE(CompareMatrices(M_BA_expected.CopyToFullMatrix6(),
                               M_BA.CopyToFullMatrix6(), kTolerance));
+
+  // Ensure a negative density throws an exception.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SpatialInertia<double>::SolidTetrahedronAboutPointWithDensity(
+          -9.3, p_AB0, p_AB1, p_AB3, p_AB2),
+      "[^]* A solid tetrahedron's density is negative: .*.");
 }
 
 // Test the construction from the mass, center of mass, and unit inertia of a

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -91,10 +91,9 @@ GTEST_TEST(SpatialInertia, PointMass) {
   EXPECT_TRUE(CompareMatrices(
       M_BBcm_B_expected.CopyToFullMatrix6(), M_BBcm_B.CopyToFullMatrix6()));
 
-  // Ensure a negative mass throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::PointMass(-1, p_BpBcm_B),
-      "[^]* The mass of a particle is negative: .*");
+      "[^]* The mass of a particle is negative or zero: .*");
 }
 
 // Tests the static method for the spatial inertia of a solid box.
@@ -119,13 +118,12 @@ GTEST_TEST(SpatialInertia, SolidBoxWithDensityOrMass) {
   EXPECT_TRUE(CompareMatrices(M_with_mass.CopyToFullMatrix6(),
                               M_with_density.CopyToFullMatrix6()));
 
-  // Ensure a negative mass or density throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidBoxWithMass(-0.1, lx, ly, lz),
-      "[^]* A solid box's mass is negative: .*.");
+      "[^]* A solid box's mass is negative or zero: .*.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidBoxWithDensity(-9.3, lx, ly, lz),
-      "[^]* A solid box's density is negative: .*.");
+      "[^]* A solid box's density is negative or zero: .*.");
 
   // Ensure a negative or zero length, width, or height throws an exception.
   // There is not an exhaustive test of each parameter being zero or negative.
@@ -184,13 +182,12 @@ GTEST_TEST(SpatialInertia, SolidCubeWithDensity) {
   EXPECT_TRUE(CompareMatrices(M_with_mass.CopyToFullMatrix6(),
       M_with_density.CopyToFullMatrix6()));
 
-  // Ensure a negative mass or density throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCubeWithMass(-0.1, length),
-      "[^]* A solid cube's mass is negative: .*.");
+      "[^]* A solid cube's mass is negative or zero: .*.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCubeWithDensity(-9.3, length),
-      "[^]* A solid cube's density is negative: .*.");
+      "[^]* A solid cube's density is negative or zero: .*.");
 
   // Ensure a negative or zero length throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -235,10 +232,9 @@ GTEST_TEST(SpatialInertia, SolidCapsuleWithDensity) {
   EXPECT_TRUE(
       CompareMatrices(M_expected.CopyToFullMatrix6(), M.CopyToFullMatrix6()));
 
-  // Ensure a negative density throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCapsuleWithDensity(-9.3, r, l, unit_vec),
-      "[^]* A solid capsule's density is negative: .*.");
+      "[^]* A solid capsule's density is negative or zero: .*.");
 
   // Ensure a negative or zero radius or length throws an exception.
   // There is not an exhaustive test of each parameter being zero or negative.
@@ -300,15 +296,14 @@ GTEST_TEST(SpatialInertia, SolidCylinderWithDensity) {
       density, r, l, unit_vec);
   EXPECT_TRUE(
       CompareMatrices(M_expected.CopyToFullMatrix6(), M.CopyToFullMatrix6()));
-
-  // Ensure a negative density throws an exception.
+  .
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCylinderWithDensity(-9.3, r, l, unit_vec),
-      "[^]* A solid cylinder's density is negative: .*.");
+      "[^]* A solid cylinder's density is negative or zero: .*.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCylinderWithDensityAboutEnd(
           -9.3, r, l, unit_vec),
-      "[^]* A solid cylinder's density is negative: .*.");
+      "[^]* A solid cylinder's density is negative or zero: .*.");
 
   // Ensure a negative or zero radius throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -379,7 +374,6 @@ GTEST_TEST(SpatialInertia, ThinRodWithMass) {
   EXPECT_TRUE(CompareMatrices(
       M_BBp_B.CopyToFullMatrix6(), M.CopyToFullMatrix6(), kTolerance));
 
-  // Ensure a negative or zero mass throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::ThinRodWithMass(-1.23, length, unit_vec),
       "[^]* A thin rod's mass = .* or length = .* "
@@ -422,10 +416,9 @@ GTEST_TEST(SpatialInertia, SolidEllipsoidWithDensity) {
   EXPECT_TRUE(
       CompareMatrices(M_expected.CopyToFullMatrix6(), M.CopyToFullMatrix6()));
 
-  // Ensure a negative density throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidEllipsoidWithDensity(-9.3, a, b, c),
-      "[^]* A solid ellipsoid's density is negative: .*.");
+      "[^]* A solid ellipsoid's density is negative or zero: .*.");
 
   // Ensure a negative or zero semi-axis length throws an exception.
   // There is not an exhaustive test of each parameter being zero or negative.
@@ -459,10 +452,9 @@ GTEST_TEST(SpatialInertia, SolidSphereWithDensity) {
   EXPECT_TRUE(
       CompareMatrices(M_expected.CopyToFullMatrix6(), M.CopyToFullMatrix6()));
 
-  // Ensure a negative density throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidSphereWithDensity(-9.3, r),
-      "[^]* A solid sphere's density is negative: .*.");
+      "[^]* A solid sphere's density is negative or zero: .*.");
 
   // Ensure a negative or zero radius throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -487,10 +479,9 @@ GTEST_TEST(SpatialInertia, HollowSphereWithDensity) {
   EXPECT_TRUE(
       CompareMatrices(M_expected.CopyToFullMatrix6(), M.CopyToFullMatrix6()));
 
-  // Ensure a negative area density throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::HollowSphereWithDensity(-9.3, r),
-      "[^]* A hollow sphere's area density is negative: .*.");
+      "[^]* A hollow sphere's area density is negative or zero: .*.");
 
   // Ensure a negative or zero radius throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -529,11 +520,10 @@ GTEST_TEST(SpatialInertia, SolidTetrahedronAboutVertex) {
   EXPECT_TRUE(CompareMatrices(M_BB0_expected.CopyToFullMatrix6(),
                               M_BB0.CopyToFullMatrix6(), kTolerance));
 
-  // Ensure a negative density throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidTetrahedronAboutVertexWithDensity(
           -9.3, p1, p2, p3),
-      "[^]* A solid tetrahedron's density is negative: .*.");
+      "[^]* A solid tetrahedron's density is negative or zero: .*.");
 }
 
 // Test spatial inertia of a solid tetrahedron about an arbitrary point A.
@@ -575,11 +565,10 @@ GTEST_TEST(SpatialInertia, SolidTetrahedronAboutPoint) {
   EXPECT_TRUE(CompareMatrices(M_BA_expected.CopyToFullMatrix6(),
                               M_BA.CopyToFullMatrix6(), kTolerance));
 
-  // Ensure a negative density throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidTetrahedronAboutPointWithDensity(
           -9.3, p_AB0, p_AB1, p_AB3, p_AB2),
-      "[^]* A solid tetrahedron's density is negative: .*.");
+      "[^]* A solid tetrahedron's density is negative or zero: .*.");
 }
 
 // Test the construction from the mass, center of mass, and unit inertia of a

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -296,7 +296,7 @@ GTEST_TEST(SpatialInertia, SolidCylinderWithDensity) {
       density, r, l, unit_vec);
   EXPECT_TRUE(
       CompareMatrices(M_expected.CopyToFullMatrix6(), M.CopyToFullMatrix6()));
-  .
+
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidCylinderWithDensity(-9.3, r, l, unit_vec),
       "[^]* A solid cylinder's density is negative or zero: .*.");

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -119,6 +119,11 @@ GTEST_TEST(SpatialInertia, SolidBoxWithDensityOrMass) {
   EXPECT_TRUE(CompareMatrices(M_with_mass.CopyToFullMatrix6(),
                               M_with_density.CopyToFullMatrix6()));
 
+  // Ensure a negative density throws an exception.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SpatialInertia<double>::SolidBoxWithDensity(-0.1, lx, ly, lz),
+      "[^]* A solid box's density is negative: .*.");
+
   // Ensure a negative or zero length, width, or height throws an exception.
   // There is not an exhaustive test of each parameter being zero or negative.
   // Instead, each parameter is tested with a single bad value and we assume a


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19192)
<!-- Reviewable:end -->
