### PR TITLE
[prototype] RenderEngineVtk uses mtl file to get diffuse properties

### DIFF
--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -16,6 +16,7 @@ drake_cc_package_library(
         ":render_camera",
         ":render_engine",
         ":render_label",
+        ":render_mesh",
     ],
 )
 
@@ -59,6 +60,18 @@ drake_cc_library(
         "//common:essential",
         "//common:hash",
         "//systems/sensors:image",
+    ],
+)
+
+drake_cc_library(
+    name = "render_mesh",
+    srcs = ["render_mesh.cc"],
+    hdrs = ["render_mesh.h"],
+    interface_deps = [
+        "@tinyobjloader",
+    ],
+    deps = [
+        "//common:essential",
     ],
 )
 

--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -68,10 +68,12 @@ drake_cc_library(
     srcs = ["render_mesh.cc"],
     hdrs = ["render_mesh.h"],
     interface_deps = [
-        "@tinyobjloader",
+        "//common:diagnostic_policy",
+        "//common:essential",
+        "//geometry:rgba",
     ],
     deps = [
-        "//common:essential",
+        "@tinyobjloader",
     ],
 )
 
@@ -114,6 +116,18 @@ drake_cc_googletest(
         ":render_label",
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "render_mesh_test",
+    data = [":test_models"],
+    deps = [
+        ":render_mesh",
+        "//common:temp_directory",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+        "//multibody/parsing:diagnostic_policy_test_base",
     ],
 )
 

--- a/geometry/render/render_mesh.cc
+++ b/geometry/render/render_mesh.cc
@@ -1,9 +1,15 @@
 #include "drake/geometry/render/render_mesh.h"
 
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
 #include <map>
+#include <set>
 #include <tuple>
 
 #include <fmt/format.h>
+#include <tiny_obj_loader.h>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_types.h"
@@ -19,10 +25,47 @@ using std::map;
 using std::tuple;
 using std::vector;
 
-MeshData LoadMeshFromObj(const tinyobj::attrib_t attrib,
-                         vector<tinyobj::shape_t> shapes,
-                         std::string_view description) {
-  /* The parsed product needs to be further processed. The MeshData assumes
+// TODO(SeanCurtis-TRI): Add trouble shooting entry on OBJ support and
+// reference it in these errors/warnings.
+
+RenderMesh LoadMeshFromObj(const std::string& file_name,
+                           const drake::internal::DiagnosticPolicy& policy) {
+  tinyobj::ObjReaderConfig config;
+  config.triangulate = true;
+  config.vertex_color = false;
+  tinyobj::ObjReader reader;
+  const bool valid_parse = reader.ParseFromFile(file_name, config);
+
+  if (!valid_parse) {
+    throw std::runtime_error(fmt::format("Failed parsing the obj file: {}: {}",
+                                         file_name, reader.Error()));
+  }
+
+  // We better not get any errors if we have a valid parse.
+  DRAKE_DEMAND(reader.Error().empty());
+
+  const auto& shapes = reader.GetShapes();
+
+  bool faces_found = false;
+  for (const auto& shape : shapes) {
+    faces_found = shape.mesh.indices.size() > 0;
+    if (faces_found) break;
+  }
+  if (!faces_found) {
+    throw std::runtime_error(fmt::format("OBJ has no faces: {}", file_name));
+  }
+
+  if (!reader.Warning().empty()) {
+    std::cerr << reader.Warning() << "\n";
+    policy.Warning(reader.Warning());
+  }
+
+  const auto& attrib = reader.GetAttrib();
+
+  // All of the materials referenced by faces.
+  std::set<int> referenced_materials;
+
+  /* The parsed product needs to be further processed. The RenderMesh assumes
    that all vertex quantities (positions, normals, texture coordinates) are
    indexed with a common index; a face that references vertex i, will get its
    position from positions[i], its normal from normals[i], and its texture
@@ -68,14 +111,13 @@ MeshData LoadMeshFromObj(const tinyobj::attrib_t attrib,
   //   1. If normals are absent, generate normals so that we get faceted meshes.
   //   2. Make use of smoothing groups.
   if (attrib.normals.size() == 0) {
-    throw std::runtime_error(fmt::format(
-        "OBJ has no normals; RenderEngineGl requires OBJs with normals: {}",
-        description));
+    throw std::runtime_error(fmt::format("OBJ has no normals: {}", file_name));
   }
 
   bool has_tex_coord{attrib.texcoords.size() > 0};
 
   for (const auto& shape : shapes) {
+    std::cerr << "Shape: " << shape.name << "\n";
     /* Each face is a sequence of indices. All of the face indices are
      concatenated together in one long sequence: [i1, i2, ..., iN]. Because
      we have nothing but triangles, that sequence can be partitioned into
@@ -87,22 +129,26 @@ MeshData LoadMeshFromObj(const tinyobj::attrib_t attrib,
     const auto& shape_mesh = shape.mesh;
     const int num_faces = static_cast<int>(shape_mesh.num_face_vertices.size());
     for (int f = 0; f < num_faces; ++f) {
+      std::cerr << "   face: " << f << "\n";
       DRAKE_DEMAND(shape_mesh.num_face_vertices[f] == 3);
       /* Captures the [i0, i1, i2] new index values for the face.  */
       int face_vertices[3] = {-1, -1, -1};
       for (int i = 0; i < 3; ++i) {
+        std::cerr << "        vertex: " << i << "\n";
         const int position_index = shape_mesh.indices[v_index].vertex_index;
         const int norm_index = shape_mesh.indices[v_index].normal_index;
         const int uv_index = shape_mesh.indices[v_index].texcoord_index;
+        std::cerr << "             pos: " << position_index << "\n"
+                  << "            norm: " << norm_index << "\n"
+                  << "              uv: " << uv_index << "\n";
         if (norm_index < 0) {
           throw std::runtime_error(
-              fmt::format("Not all faces reference normals: {}", description));
+              fmt::format("Not all faces reference normals: {}", file_name));
         }
         if (has_tex_coord) {
           if (uv_index < 0) {
-            throw std::runtime_error(
-                fmt::format("Not all faces reference texture coordinates: {}",
-                            description));
+            throw std::runtime_error(fmt::format(
+                "Not all faces reference texture coordinates: {}", file_name));
           }
         } else {
           DRAKE_DEMAND(uv_index < 0);
@@ -132,13 +178,14 @@ MeshData LoadMeshFromObj(const tinyobj::attrib_t attrib,
         ++v_index;
       }
       triangles.emplace_back(&face_vertices[0]);
+      referenced_materials.insert(shape_mesh.material_ids[f]);
     }
   }
 
   DRAKE_DEMAND(positions.size() == normals.size());
   DRAKE_DEMAND(positions.size() == uvs.size());
 
-  MeshData mesh_data;
+  RenderMesh mesh_data;
   mesh_data.indices.resize(triangles.size(), 3);
   for (int t = 0; t < mesh_data.indices.rows(); ++t) {
     mesh_data.indices.row(t) = triangles[t].cast<unsigned int>();
@@ -155,6 +202,82 @@ MeshData LoadMeshFromObj(const tinyobj::attrib_t attrib,
   mesh_data.uvs.resize(uvs.size(), 2);
   for (int uv = 0; uv < mesh_data.uvs.rows(); ++uv) {
     mesh_data.uvs.row(uv) = uvs[uv].cast<float>();
+  }
+
+  std::cerr << "Referenced materials: ";
+  for (const int id : referenced_materials) {
+    std::cerr << " " << id;
+  }
+  std::cerr << "\n";
+  // If we've referenced material "-1", it means there is no material.
+  if (referenced_materials.size() == 1 && referenced_materials.count(-1) == 0) {
+    std::cerr << "  A single referenced material\n";
+    const auto& mat = reader.GetMaterials().front();
+    const Rgba diffuse(mat.diffuse[0], mat.diffuse[1], mat.diffuse[2],
+                       mat.dissolve);
+    const std::string diffuse_tex_name = [&mat, &file_name]() -> std::string {
+      if (mat.diffuse_texname.empty()) {
+        return mat.diffuse_texname;
+      }
+      std::filesystem::path tex_path(mat.diffuse_texname);
+      if (tex_path.is_absolute()) {
+        return mat.diffuse_texname;
+      }
+      std::filesystem::path obj_path(file_name);
+      // We're going to assume that the mtl file is in the same directory as
+      // the obj file. We don't *know* this is true and tiny_obj_loader
+      // doesn't give us this information. It'd be nice if it did. What if the
+      // OBJ references multiple mtl files? Ideally, `material_t` should come
+      // come with a string indicating either the mtl file it came from or
+      // the directory of that mtl file. Then relative paths of the referenced
+      // images can be properly interpreted.
+      std::filesystem::path obj_dir = obj_path.parent_path();
+      tex_path = (obj_dir / tex_path).lexically_normal();
+      return tex_path.string();
+    }();
+
+    // If texture is specified, it must be available.
+    bool valid = true;
+    std::cerr << "    texture name: " << diffuse_tex_name << "\n";
+    if (!diffuse_tex_name.empty()) {
+      std::ifstream tex_file(diffuse_tex_name);
+      if (!tex_file.is_open()) {
+        std::cerr << "      unable to open; dispatching warning!\n";
+        policy.Warning(fmt::format(
+            "The OBJ file's material requested an unavailable diffuse "
+            "texture image: {}. The parsed material will not be used.",
+            diffuse_tex_name));
+        valid = false;
+      }
+      if (!has_tex_coord) {
+        std::cerr << "      missing uvs; dispatching warning!\n";
+        policy.Warning(
+            fmt::format("The OBJ file's material requested a diffuse texture "
+                        "image: {}. However the mesh doesn't define texture "
+                        "coordinates. The parsed material will not be used.",
+                        diffuse_tex_name));
+        valid = false;
+      }
+    }
+
+    if (valid) {
+      std::cerr << "    Setting material!\n";
+      mesh_data.material =
+          RenderMaterial{.diffuse = diffuse, .diffuse_map = diffuse_tex_name};
+    }
+  } else if (referenced_materials.size() > 1) {
+    vector<std::string_view> mat_names;
+    std::transform(referenced_materials.begin(), referenced_materials.end(),
+                   std::back_inserter(mat_names), [&reader](int i) {
+                     return i < 0 ? std::string("__default__")
+                                  : fmt::format("'{}'",
+                                                reader.GetMaterials()[i].name);
+                   });
+    policy.Warning(fmt::format(
+        "Drake currently only supports OBJs that use a single material across "
+        "the whole mesh; for {}, {} materials were used: {}. The parsed "
+        "materials will not be used.",
+        file_name, referenced_materials.size(), fmt::join(mat_names, ", ")));
   }
 
   return mesh_data;

--- a/geometry/render/render_mesh.cc
+++ b/geometry/render/render_mesh.cc
@@ -1,0 +1,164 @@
+#include "drake/geometry/render/render_mesh.h"
+
+#include <map>
+#include <tuple>
+
+#include <fmt/format.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+using std::make_tuple;
+using std::map;
+using std::tuple;
+using std::vector;
+
+MeshData LoadMeshFromObj(const tinyobj::attrib_t attrib,
+                         vector<tinyobj::shape_t> shapes,
+                         std::string_view description) {
+  /* The parsed product needs to be further processed. The MeshData assumes
+   that all vertex quantities (positions, normals, texture coordinates) are
+   indexed with a common index; a face that references vertex i, will get its
+   position from positions[i], its normal from normals[i], and its texture
+   coordinate from uvs[i]. However, we _cannot_ assume that each vertex
+   position is associated with a single per-vertex quantity (normal, uv) in
+   the OBJ file. OBJ allows a vertex position to be associated with arbitrary
+   per-vertex quantities in each face definition independently. So, we need to
+   create the unique association here.
+
+   To accomplish this:
+    1. Every vertex referenced by a face in the parsed OBJ is a "meta"
+       vertex consisting of a tuple of indices: (p, n, uv), the index in
+       vertex positions, normals, and texture coordinates. For example,
+       imagine one face refers to meta index (p, n₀, uv) and another face
+       refers to index (p, n₁, uv). Although the two faces appear to share a
+       single vertex (and a common texture coordinate), those vertices have
+       different normals which require two different vertices in the mesh
+       data. We copy the vertex position and texture coordinate and then
+       associate one copy with each normal. A similar operation would apply if
+       they only differed in texture coordinate (or in both).
+    2. Given a mapping (p, n, uv) --> i (a mapping from the meta vertex in the
+       parsed OBJ data to the unique index in the resultant mesh data), we
+       can build the faces in the final mesh data by mapping the (p, n, uv)
+       tuple in the OBJ face specification to the final mesh data vertex
+       index i.
+    3. When done, we should have an equal number of vertex positions as
+       normals and texture coordinates. And all indices in the faces should be
+       valid indices into all three vectors of data.
+   NOTE: In the case of meta vertices (p, n₀, uv) and (p, n₁, uv) we are not
+   confirming that normals[n₀] and normals[n₁] are actually different normals;
+   we're assuming different indices implies different values. Again, the same
+   applies to different texture coordinate indices.  */
+
+  /* The map from (p, n, uv) --> i.  */
+  map<tuple<int, int, int>, int> obj_vertex_to_new_vertex;
+  /* Accumulators for vertex positions, normals, and triangles.  */
+  vector<Vector3d> positions;
+  vector<Vector3d> normals;
+  vector<Vector2d> uvs;
+  vector<Vector3<int>> triangles;
+
+  // TODO(SeanCurtis-TRI) Revisit how we handle normals:
+  //   1. If normals are absent, generate normals so that we get faceted meshes.
+  //   2. Make use of smoothing groups.
+  if (attrib.normals.size() == 0) {
+    throw std::runtime_error(fmt::format(
+        "OBJ has no normals; RenderEngineGl requires OBJs with normals: {}",
+        description));
+  }
+
+  bool has_tex_coord{attrib.texcoords.size() > 0};
+
+  for (const auto& shape : shapes) {
+    /* Each face is a sequence of indices. All of the face indices are
+     concatenated together in one long sequence: [i1, i2, ..., iN]. Because
+     we have nothing but triangles, that sequence can be partitioned into
+     triples, each representing one triangle:
+       [(i1, i2, i3), (i4, i5, i6), ..., (iN-2, iN-1, iN)].
+     We maintain an index into that long sequence (v_index) and simply
+     increment it knowing that every three increments takes us to a new face. */
+    int v_index = 0;
+    const auto& shape_mesh = shape.mesh;
+    const int num_faces = static_cast<int>(shape_mesh.num_face_vertices.size());
+    for (int f = 0; f < num_faces; ++f) {
+      DRAKE_DEMAND(shape_mesh.num_face_vertices[f] == 3);
+      /* Captures the [i0, i1, i2] new index values for the face.  */
+      int face_vertices[3] = {-1, -1, -1};
+      for (int i = 0; i < 3; ++i) {
+        const int position_index = shape_mesh.indices[v_index].vertex_index;
+        const int norm_index = shape_mesh.indices[v_index].normal_index;
+        const int uv_index = shape_mesh.indices[v_index].texcoord_index;
+        if (norm_index < 0) {
+          throw std::runtime_error(
+              fmt::format("Not all faces reference normals: {}", description));
+        }
+        if (has_tex_coord) {
+          if (uv_index < 0) {
+            throw std::runtime_error(
+                fmt::format("Not all faces reference texture coordinates: {}",
+                            description));
+          }
+        } else {
+          DRAKE_DEMAND(uv_index < 0);
+        }
+        const auto obj_indices =
+            make_tuple(position_index, norm_index, uv_index);
+        if (obj_vertex_to_new_vertex.count(obj_indices) == 0) {
+          obj_vertex_to_new_vertex[obj_indices] =
+              static_cast<int>(positions.size());
+          /* Guarantee that the positions.size() == normals.size() == uvs.size()
+           by always growing them in lock step.  */
+          positions.emplace_back(
+              Vector3d{attrib.vertices[3 * position_index],
+                       attrib.vertices[3 * position_index + 1],
+                       attrib.vertices[3 * position_index + 2]});
+          normals.emplace_back(attrib.normals[3 * norm_index],
+                               attrib.normals[3 * norm_index + 1],
+                               attrib.normals[3 * norm_index + 2]);
+          if (has_tex_coord) {
+            uvs.emplace_back(attrib.texcoords[2 * uv_index],
+                             attrib.texcoords[2 * uv_index + 1]);
+          } else {
+            uvs.emplace_back(0.0, 0.0);
+          }
+        }
+        face_vertices[i] = obj_vertex_to_new_vertex[obj_indices];
+        ++v_index;
+      }
+      triangles.emplace_back(&face_vertices[0]);
+    }
+  }
+
+  DRAKE_DEMAND(positions.size() == normals.size());
+  DRAKE_DEMAND(positions.size() == uvs.size());
+
+  MeshData mesh_data;
+  mesh_data.indices.resize(triangles.size(), 3);
+  for (int t = 0; t < mesh_data.indices.rows(); ++t) {
+    mesh_data.indices.row(t) = triangles[t].cast<unsigned int>();
+  }
+  mesh_data.positions.resize(positions.size(), 3);
+  for (int v = 0; v < mesh_data.positions.rows(); ++v) {
+    mesh_data.positions.row(v) = positions[v];
+  }
+  mesh_data.normals.resize(normals.size(), 3);
+  for (int n = 0; n < mesh_data.normals.rows(); ++n) {
+    mesh_data.normals.row(n) = normals[n].cast<float>();
+  }
+  mesh_data.has_tex_coord = has_tex_coord;
+  mesh_data.uvs.resize(uvs.size(), 2);
+  for (int uv = 0; uv < mesh_data.uvs.rows(); ++uv) {
+    mesh_data.uvs.row(uv) = uvs[uv].cast<float>();
+  }
+
+  return mesh_data;
+}
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/render_mesh.h
+++ b/geometry/render/render_mesh.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <vector>
+
+#include <Eigen/Dense>
+#include <tiny_obj_loader.h>
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/* The data representing a mesh. The triangle mesh is defined by `indices`. Row
+ t represents a triangle by the triplet of vertex indices: tᵥ₀, tᵥ₁, tᵥ₂. The
+ indices map into the rows of `positions`, `normals`, and `uvs`. I.e., for
+ vertex index v, the position of that vertex is at `positions.row(v)`, its
+ corresponding normal is at `normals.row(v)`, and its texture coordinates are at
+ `uvs.row(v)`.
+
+ For now, all vertex quantities (`positions`, `normals` and `uvs`) are
+ guaranteed (as well as the `indices` data). In the future, `uvs` may become
+ optional.  */
+struct MeshData {
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> positions;
+  Eigen::Matrix<float, Eigen::Dynamic, 3, Eigen::RowMajor> normals;
+  Eigen::Matrix<float, Eigen::Dynamic, 2, Eigen::RowMajor> uvs;
+  Eigen::Matrix<unsigned int, Eigen::Dynamic, 3, Eigen::RowMajor> indices;
+
+  /** See docs for `has_tex_coord` below.  */
+  static constexpr bool kHasTexCoordDefault{true};
+
+  /** This flag indicates that this mesh has texture coordinates to support
+   maps.
+   If True, the values of `uvs` will be nontrivial.
+   If False, the values of `uvs` will be all zeros, but will still have the
+   correct size.  */
+  bool has_tex_coord{kHasTexCoordDefault};
+};
+
+/* Loads a mesh's vertices and indices (faces) from an OBJ description given
+ in the input stream. It does not load textures. Note that while this
+ functionality seems similar to ReadObjToTriangleSurfaceMesh, RenderEngineGl
+ cannot use TriangleSurfaceMesh. Rendering requires normals and texture
+ coordinates; TriangleSurfaceMesh was not designed with those quantities in
+ mind.
+
+ If no texture coordinates are specified by the file, it will be indicated in
+ the returned MeshData. See MeshData::has_tex_coord for more detail.
+
+ @throws std::exception if a) tinyobj::LoadObj() fails, (b) there are no faces
+                           or normals, c) faces fail to reference normals, or d)
+                           faces fail to reference the texture coordinates if
+                           they are present.
+ @pre                              */
+MeshData LoadMeshFromObj(const tinyobj::attrib_t attrib,
+                         std::vector<tinyobj::shape_t> shapes,
+                         std::string_view description);
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/render_mesh.h
+++ b/geometry/render/render_mesh.h
@@ -1,59 +1,97 @@
 #pragma once
 
+#include <optional>
+#include <string>
 #include <vector>
 
 #include <Eigen/Dense>
-#include <tiny_obj_loader.h>
+
+#include "drake/common/diagnostic_policy.h"
+#include "drake/geometry/rgba.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
 
-/* The data representing a mesh. The triangle mesh is defined by `indices`. Row
- t represents a triangle by the triplet of vertex indices: tᵥ₀, tᵥ₁, tᵥ₂. The
- indices map into the rows of `positions`, `normals`, and `uvs`. I.e., for
- vertex index v, the position of that vertex is at `positions.row(v)`, its
- corresponding normal is at `normals.row(v)`, and its texture coordinates are at
- `uvs.row(v)`.
+/* Specifies a mesh material as currently supported by Drake. We expect this
+ definition to grow with time. */
+struct RenderMaterial {
+  Rgba diffuse;
+  std::string diffuse_map;
+};
+
+/* The data representing a mesh with a single material. The triangle mesh is
+ defined by `indices`. Row t represents a triangle by the triplet of vertex
+ indices: tᵥ₀, tᵥ₁, tᵥ₂. The indices map into the rows of `positions`,
+ `normals`, and `uvs`. I.e., for vertex index v, the position of that vertex is
+ at `positions.row(v)`, its corresponding normal is at `normals.row(v)`, and its
+ texture coordinates are at `uvs.row(v)`.
 
  For now, all vertex quantities (`positions`, `normals` and `uvs`) are
  guaranteed (as well as the `indices` data). In the future, `uvs` may become
  optional.  */
-struct MeshData {
+struct RenderMesh {
   Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> positions;
   Eigen::Matrix<float, Eigen::Dynamic, 3, Eigen::RowMajor> normals;
   Eigen::Matrix<float, Eigen::Dynamic, 2, Eigen::RowMajor> uvs;
   Eigen::Matrix<unsigned int, Eigen::Dynamic, 3, Eigen::RowMajor> indices;
 
-  /** See docs for `has_tex_coord` below.  */
+  /* See docs for `has_tex_coord` below.  */
   static constexpr bool kHasTexCoordDefault{true};
 
-  /** This flag indicates that this mesh has texture coordinates to support
+  /* This flag indicates that this mesh has texture coordinates to support
    maps.
    If True, the values of `uvs` will be nontrivial.
    If False, the values of `uvs` will be all zeros, but will still have the
    correct size.  */
   bool has_tex_coord{kHasTexCoordDefault};
+
+  /* The specification of the material intrinsically associated with this mesh
+   data. If it has no value, materials should be defined by user of the
+   RenderMesh. */
+  std::optional<RenderMaterial> material;
 };
 
-/* Loads a mesh's vertices and indices (faces) from an OBJ description given
- in the input stream. It does not load textures. Note that while this
- functionality seems similar to ReadObjToTriangleSurfaceMesh, RenderEngineGl
- cannot use TriangleSurfaceMesh. Rendering requires normals and texture
- coordinates; TriangleSurfaceMesh was not designed with those quantities in
- mind.
+// TODO(SeanCurtis-TRI): All of this explanation needs to go into the trouble-
+// shooting guide.
+// TODO(SeanCurtis-TRI): Modify the API to return a *set* of RenderMesh, each
+// with a unique material.
+/* Returns a single instance of RenderMesh from the indicated obj file.
+
+ Note: the mesh data's material will be defined iff the OBJ applies a single
+ valid material to the whole mesh. The material may be omitted for any number
+ of "validity" reasons, including (but not limited to):
+
+   - The .mtl file is referenced via *absolute* path.
+   - The .mtl file (which references an image relatively) is not in the same
+     directory as the .obj file.
+   - Specified texture image (map_Kd) is unavailable (or can't be found).
+   - Texture image specified but missing texture coordinates across all
+     triangles.
+   - Invalid material name referenced.
+   - Invalid mtl file referenced.
+
+ It is up to the caller to decide what material to provide if none is associated
+ with the mesh data.
+
+ Note: This API is similar to ReadObjToTriangleSurfaceMesh, but it differs in
+ several ways:
+
+    - Support of per-vertex data that TriangleSurfaceMesh doesn't support
+      (e.g., vertex normals, texture coordinates).
+    - Material semantics.
+    - The geometric data is reconditioned to be compatible with "geometry
+      buffer" applications. (See RenderMesh for details.)
 
  If no texture coordinates are specified by the file, it will be indicated in
- the returned MeshData. See MeshData::has_tex_coord for more detail.
+ the returned RenderMesh. See RenderMesh::has_tex_coord for more detail.
 
  @throws std::exception if a) tinyobj::LoadObj() fails, (b) there are no faces
                            or normals, c) faces fail to reference normals, or d)
                            faces fail to reference the texture coordinates if
-                           they are present.
- @pre                              */
-MeshData LoadMeshFromObj(const tinyobj::attrib_t attrib,
-                         std::vector<tinyobj::shape_t> shapes,
-                         std::string_view description);
+                           they are present. */
+RenderMesh LoadMeshFromObj(const std::string& obj_file_name,
+                           const drake::internal::DiagnosticPolicy& policy);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/render/test/meshes/box.obj.mtl
+++ b/geometry/render/test/meshes/box.obj.mtl
@@ -7,4 +7,4 @@ illum 2
 Ns 0.000000
 # N.B. The next line has trailing whitespace on purpose, to prove that Drake
 # ignores it during parsing.
-map_Kd -s 1 1 1 box.png 
+map_Kd -s 1 1 1 ../diag_gradient.png 

--- a/geometry/render/test/render_mesh_test.cc
+++ b/geometry/render/test/render_mesh_test.cc
@@ -1,0 +1,504 @@
+#include "drake/geometry/render/render_mesh.h"
+
+#include <filesystem>
+#include <fstream>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/temp_directory.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/parsing/test/diagnostic_policy_test_base.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+namespace fs = std::filesystem;
+
+/* The tests for this class are partitioned into several categories defined by
+ prefix:
+
+   - Geometry: evaluation of the geometry produced.
+   - WithMaterial: various valid spellings that should resolve into a single
+     mesh with a valid material specificaiton.
+   - NoMaterial: the reported RenderMesh has no material. In some cases, a
+     warning may be dispatched.
+   - Error: These test the cases in which we *throw* -- there is no recovery.
+ */
+class RenderMeshTest : public multibody::test::DiagnosticPolicyTestBase {
+ protected:
+  static fs::path WriteFile(std::string_view contents,
+                            std::string_view file_name,
+                            const fs::path& dir = kTempDir) {
+    std::cerr << contents << "\n";
+    const fs::path file_path = dir / file_name;
+    std::ofstream out(file_path);
+    DRAKE_DEMAND(out.is_open());
+    out << contents;
+    std::cerr << file_path << "\n";
+    return file_path;
+  }
+
+  static void SetUpTestSuite() {
+    // Make sure we have a valid texture with the mtl file that names it.
+    fs::path image_source_path(
+        FindResourceOrThrow("drake/geometry/render/test/diag_gradient.png"));
+    fs::path image_target_path = kTempDir / "diag_gradient.png";
+    fs::copy(image_source_path, image_target_path);
+
+    WriteFile(R"""(
+    newmtl test_material
+    Ka 0.1 0.1 0.1
+    Kd 1.0 1.0 1.0
+    Ks 1.0 1.0 1.0
+    d 1
+    illum 2
+    Ns 0
+  )""",
+              basic_mtl);
+
+    WriteFile(R"""(
+    newmtl test_material_1
+    Kd 1.0 1.0 1.0
+
+    newmtl test_material_2
+    Kd 1.0 0.0 0.0
+  )""",
+              multi_mtl);
+
+    WriteFile(R"""(
+    newmtl test_material
+    Ka 0.1 0.1 0.1
+    Kd 1.0 1.0 1.0
+    Ks 1.0 1.0 1.0
+    d 1
+    illum 2
+    Ns 0
+    map_Kd diag_gradient.png
+  )""",
+              texture_mtl);
+  }
+
+  static constexpr char basic_mtl[] = "basic.mtl";
+  static constexpr char multi_mtl[] = "multi.mtl";
+  static constexpr char texture_mtl[] = "texture.mtl";
+  static const fs::path kTempDir;
+};
+
+const fs::path RenderMeshTest::kTempDir = temp_directory();
+
+/* A vague smoke test of the geometry buffer data. Failure in this part of the
+ algorithm will be immediately obvious in any visualization. So, this doesn't
+ attempt to exhaustively confirm correctness. Just provide a couple of
+ indicators as an early CI warning against regression. */
+TEST_F(RenderMeshTest, GeometryData) {
+  /* Normals and UVs get copied for each vertex */
+  {
+    const fs::path obj_path = WriteFile(R"""(
+    v 0 0 0
+    v 0 1 0
+    v 0 0 1
+    vn 0 1 0
+    vt 0 1
+    f 1/1/1 2/1/1 3/1/1
+  )""",
+                                        "geo_simple.obj");
+    const RenderMesh data = LoadMeshFromObj(obj_path, diagnostic_policy_);
+    EXPECT_EQ(data.positions.rows(), 3);
+    EXPECT_EQ(data.normals.rows(), 3);
+    EXPECT_EQ(data.uvs.rows(), 3);
+    EXPECT_EQ(data.indices.rows(), 1);
+    EXPECT_TRUE(data.has_tex_coord);
+  }
+
+  /* No UVs creates a bunch of zero uv values. */
+  {
+    const fs::path obj_path = WriteFile(R"""(
+    v 0 0 0
+    v 0 1 0
+    v 0 0 1
+    vn 0 1 0
+    f 1//1 2//1 3//1
+  )""",
+                                        "geo_simple_no_uv.obj");
+    const RenderMesh data = LoadMeshFromObj(obj_path, diagnostic_policy_);
+    EXPECT_EQ(data.positions.rows(), 3);
+    EXPECT_EQ(data.normals.rows(), 3);
+    EXPECT_EQ(data.uvs.rows(), 3);
+    EXPECT_TRUE(CompareMatrices(data.uvs, Eigen::Matrix<float, 3, 2>::Zero()));
+    EXPECT_EQ(data.indices.rows(), 1);
+    EXPECT_FALSE(data.has_tex_coord);
+  }
+}
+
+/* Confirm that when a material is actually created, that the values get stored
+ as expected. This is the only time we'll peek under the hood at the material
+ values. */
+TEST_F(RenderMeshTest, WithMaterialValueTest) {
+  WriteFile(R"""(
+    newmtl ad_hoc_mat
+    Kd 0.25 0.5 0.75
+    d 0.125
+    map_Kd diag_gradient.png
+  )""",
+            "ad_hoc.mtl");
+  const fs::path obj_path = WriteFile(R"""(
+    mtllib ad_hoc.mtl
+    v 0 0 0
+    v 1 1 1
+    v 2 2 2
+    vn 0 1 0
+    vt 0 1
+    usemtl ad_hoc_mat
+    f 1/1/1 2/1/1 3/1/1)""",
+                                      "ad_hoc.obj");
+  const RenderMesh mesh = LoadMeshFromObj(obj_path, diagnostic_policy_);
+  ASSERT_TRUE(mesh.material.has_value());
+  EXPECT_EQ(mesh.material->diffuse, Rgba(0.25, 0.5, 0.75, 0.125));
+  EXPECT_EQ(mesh.material->diffuse_map,
+            (kTempDir / "diag_gradient.png").string());
+}
+
+/* An .mtl file with multiple material definitions is not a problem as long as
+ only one is used. */
+TEST_F(RenderMeshTest, WithMaterialExtraMaterialsDefined) {
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        usemtl test_material_1
+        f 1//1 2//1 3//1
+        f 1//1 2//1 3//1)""",
+                                                  multi_mtl),
+                                      "use_only_one_material.obj");
+  const RenderMesh mesh = LoadMeshFromObj(obj_path, diagnostic_policy_);
+  EXPECT_TRUE(mesh.material.has_value());
+}
+
+/* We're not sensitive to how many times `usemtl` is invoked, only that, at the
+ end of the day, a single material is applied to all faces. */
+TEST_F(RenderMeshTest, WithMaterialRedundantUsemtl) {
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        usemtl test_material
+        f 1//1 2//1 3//1
+        usemtl test_material
+        f 1//1 2//1 3//1)""",
+                                                  basic_mtl),
+                                      "redundant_usemtl.obj");
+  const RenderMesh mesh = LoadMeshFromObj(obj_path, diagnostic_policy_);
+  EXPECT_TRUE(mesh.material.has_value());
+}
+
+/* The image doesn't have to be collocated, just available. */
+TEST_F(RenderMeshTest, WithMaterialDislocatedTexture) {
+  const fs::path obj_dir = kTempDir / "dis_texture";
+  fs::create_directory(obj_dir);
+  const fs::path obj_path = WriteFile(R"""(
+    mtllib my.mtl
+    v 0 0 0
+    v 1 1 1
+    v 2 2 2
+    vn 0 1 0
+    vt 0 1
+    usemtl test_material
+    f 1/1/1 2/1/1 3/1/1)""",
+                                      "my.obj", obj_dir);
+  WriteFile(R"""(
+    newmtl test_material
+    Kd 1.0 1.0 1.0
+    d 1
+    map_Kd ../diag_gradient.png)""",
+            "my.mtl", obj_dir);
+  const RenderMesh mesh = LoadMeshFromObj(obj_path, diagnostic_policy_);
+  EXPECT_TRUE(mesh.material.has_value());
+  EXPECT_EQ(mesh.material->diffuse_map,
+            (kTempDir / "diag_gradient.png").string());
+}
+
+/* If the obj specifies no mtl, there will be no material and no warning. */
+TEST_F(RenderMeshTest, NoMaterialNoMtllib) {
+  const fs::path obj_path = WriteFile(R"""(
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        f 1//1 2//1 3//1)""",
+                                      "no_mtllib.obj");
+  const RenderMesh mesh = LoadMeshFromObj(obj_path, diagnostic_policy_);
+  EXPECT_FALSE(mesh.material.has_value());
+}
+
+/* If the obj doesn't actually *use* any materials, there will be no material
+ and no warning. */
+TEST_F(RenderMeshTest, NoMaterialNoUsemtl) {
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        f 1//1 2//1 3//1)""",
+                                                  basic_mtl),
+                                      "no_usemtl.obj");
+  const RenderMesh mesh = LoadMeshFromObj(obj_path, diagnostic_policy_);
+  EXPECT_FALSE(mesh.material.has_value());
+}
+
+/* If the applied material has a texture but the mesh doesn't have valid uvs,
+ there will be a warning and no material */
+TEST_F(RenderMeshTest, NoMaterialTextureWithoutUvs) {
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        usemtl test_material
+        f 1//1 2//1 3//1)""",
+                                                  texture_mtl),
+                                      "no_uvs_with_texture.obj");
+  const RenderMesh mesh = LoadMeshFromObj(obj_path, diagnostic_policy_);
+  EXPECT_FALSE(mesh.material.has_value());
+  EXPECT_THAT(TakeWarning(),
+              testing::MatchesRegex(".*requested a diffuse texture.*doesn't "
+                                    "define texture coordinates.*"));
+}
+
+/* If we can't find the specified mtl file, there will be warning and no
+ material. */
+TEST_F(RenderMeshTest, NoMaterialMissingMtl) {
+  const fs::path obj_path = WriteFile(R"""(
+        mtllib not_really_a.mtl
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        usemtl test_material
+        f 1//1 2//1 3//1)""",
+                                      "non_existent_mtl.obj");
+  const RenderMesh mesh = LoadMeshFromObj(obj_path, diagnostic_policy_);
+  EXPECT_FALSE(mesh.material.has_value());
+  EXPECT_THAT(
+      TakeWarning(),
+      testing::HasSubstr("Material file [ not_really_a.mtl ] not found"));
+}
+
+/* If the obj references an invalid material name, there will be a warning an
+ no material. */
+TEST_F(RenderMeshTest, NoMaterialBadMaterialName) {
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        usemtl bad_material
+        f 1//1 2//1 3//1)""",
+                                                  texture_mtl),
+                                      "bad_material_name.obj");
+  const RenderMesh mesh = LoadMeshFromObj(obj_path, diagnostic_policy_);
+  EXPECT_FALSE(mesh.material.has_value());
+  EXPECT_THAT(TakeWarning(),
+              testing::HasSubstr("material [ 'bad_material' ] not found"));
+}
+
+/* If the mtl file references a texture that can't be found, there will be a
+ warning and no material. */
+TEST_F(RenderMeshTest, NoMaterialUnavailableTexture) {
+  WriteFile("newmtl test_material\nmap_Kd cant_be_found.png\n",
+            "missing_texture.mtl");
+  const fs::path obj_path = WriteFile(R"""(
+        mtllib missing_texture.mtl
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        vt 0 1
+        usemtl test_material
+        f 1/1/1 2/1/1 3/1/1)""",
+                                      "missing_texture.obj");
+  const RenderMesh mesh = LoadMeshFromObj(obj_path, diagnostic_policy_);
+  EXPECT_FALSE(mesh.material.has_value());
+  EXPECT_THAT(
+      TakeWarning(),
+      testing::HasSubstr("requested an unavailable diffuse texture image"));
+}
+
+/* If the obj applies too many materials, there will be a warning and no
+ material. */
+TEST_F(RenderMeshTest, NoMaterialTooManyUsemtl) {
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        usemtl test_material_1
+        f 1//1 2//1 3//1        
+        usemtl test_material_2
+        f 1//1 2//1 3//1)""",
+                                                  multi_mtl),
+                                      "too_many_usemtl.obj");
+  const RenderMesh mesh = LoadMeshFromObj(obj_path, diagnostic_policy_);
+  EXPECT_FALSE(mesh.material.has_value());
+  EXPECT_THAT(
+      TakeWarning(),
+      testing::HasSubstr("use a single material across the whole mesh"));
+}
+
+/* If the obj applies a material to *some* of the faces, there will be a warning
+ and no material. */
+TEST_F(RenderMeshTest, NoMaterialDefaultedFaces) {
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        f 1//1 2//1 3//1        
+        usemtl test_material_2
+        f 1//1 2//1 3//1)""",
+                                                  multi_mtl),
+                                      "default_material_faces.obj");
+  const RenderMesh mesh = LoadMeshFromObj(obj_path, diagnostic_policy_);
+  EXPECT_FALSE(mesh.material.has_value());
+  EXPECT_THAT(
+      TakeWarning(),
+      testing::HasSubstr("use a single material across the whole mesh"));
+}
+
+/* If the obj references the mtl file with an absolute path, there will be a
+ warning and no material (due to tiny obj logic). */
+TEST_F(RenderMeshTest, NoMaterialObjMtlDislocationAbsolute) {
+  // Note: This is an absolute path that we imbed in the obj. This makes tinyobj
+  // angry.
+  const fs::path mtl_path = kTempDir / texture_mtl;
+  // This will be a *different* temp directory than for the test suite.
+  const fs::path obj_dir(temp_directory());
+  const fs::path obj_path = obj_dir / "mtl_elsewhere.obj";
+  {
+    std::ofstream out(obj_path);
+    DRAKE_DEMAND(out.is_open());
+    out << fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        vt 0 1
+        usemtl test_material
+        f 1/1/1 2/1/1 3/1/1)""",
+                       mtl_path.string());
+  }
+  const RenderMesh mesh = LoadMeshFromObj(obj_path, diagnostic_policy_);
+  EXPECT_FALSE(mesh.material.has_value());
+  // The tinyobj warning that the material library can't be found.
+  EXPECT_THAT(TakeWarning(), testing::HasSubstr("not found in a path"));
+}
+
+/* This test merely exposes a known flaw in the code. Images are defined
+ relative to the mtl file, but we don't know the mtl file that got read. So,
+ we *assume* mtl and obj are in the same place. If not, it can erroneously lead
+ to not being able to located used textures. The victory condition is that when
+ we fix this flaw, this test fails and we reverse the semantics: a valid
+ material is included in the resulting mesh data. */
+TEST_F(RenderMeshTest, NoMaterialObjMtlDislocationRelative) {
+  const fs::path obj_dir = kTempDir / "relative_obj";
+  fs::create_directory(obj_dir);
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib ../{}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        vt 0 1
+        usemtl test_material
+        f 1/1/1 2/1/1 3/1/1)""",
+                                                  texture_mtl),
+                                      "mtl_elsewhere.obj", obj_dir);
+  const RenderMesh mesh = LoadMeshFromObj(obj_path, diagnostic_policy_);
+  EXPECT_FALSE(mesh.material.has_value());
+  // Because of our limited access to parsing information, this will look like
+  // the image is unavailable.
+  EXPECT_THAT(
+      TakeWarning(),
+      testing::HasSubstr("requested an unavailable diffuse texture image"));
+}
+
+/* Generally, the error case names are self documenting. */
+
+TEST_F(RenderMeshTest, ErrorNonExistentFile) {
+  // The *surest* way to guarantee that tiny obj reports an invalid parse is to
+  // give it a non-existent file to parse. There are other circumstances, we
+  // won't worry about them. This is sufficient proof to show that failure to
+  // parse is handled.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      LoadMeshFromObj("__garbage_doesn't_exist__.obj", diagnostic_policy_),
+      "Failed parsing the obj file[^]*");
+}
+
+TEST_F(RenderMeshTest, ErrorNoFaces) {
+  // N.B. tinyobj doesn't validate the OBJ spec. It may read an entire non-OBJ
+  // file and not complain (it only cries if it sees something it considers is
+  // an OBJ artifact that is malformed). So, a garbage file will likewise get
+  // the same "no faces" error.
+  const fs::path obj_path1 = WriteFile("v 0 0 0\nv 1 1 1\n", "no_faces.obj");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      LoadMeshFromObj(obj_path1.string(), diagnostic_policy_),
+      "OBJ has no faces.*");
+
+  const fs::path obj_path2 = WriteFile("Generic\nContent\n", "not_an.obj");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      LoadMeshFromObj(obj_path2.string(), diagnostic_policy_),
+      "OBJ has no faces.*");
+}
+
+TEST_F(RenderMeshTest, ErrorNoNormals) {
+  const fs::path obj_path =
+      WriteFile("v 0 0 0\nv 1 1 1\nv 2 2 2\n f 1 2 3\n", "no_normals.obj");
+  DRAKE_EXPECT_THROWS_MESSAGE(LoadMeshFromObj(obj_path, diagnostic_policy_),
+                              "OBJ has no normals.*");
+}
+
+TEST_F(RenderMeshTest, ErrorFacesMissingNormals) {
+  const fs::path obj_path = WriteFile(R"""(
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        f 1//1 2//1 3//1
+        f 1 2 3)""",
+                                      "faces_missing_normals.obj");
+  DRAKE_EXPECT_THROWS_MESSAGE(LoadMeshFromObj(obj_path, diagnostic_policy_),
+                              "Not all faces reference normals.*");
+}
+
+TEST_F(RenderMeshTest, ErrorFacesMissingUvs) {
+  const fs::path obj_path = WriteFile(R"""(
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        vt 0 0
+        f 1/1/1 2/1/1 3/1/1
+        f 1//1 2//1 3//1)""",
+                                      "faces_missing_uvs.obj");
+  DRAKE_EXPECT_THROWS_MESSAGE(LoadMeshFromObj(obj_path, diagnostic_policy_),
+                              "Not all faces reference texture coord.*");
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render_vtk/BUILD.bazel
+++ b/geometry/render_vtk/BUILD.bazel
@@ -78,6 +78,8 @@ drake_cc_library(
         "//common:scope_exit",
         "//geometry:geometry_roles",
         "//geometry:shape_specification",
+        "//geometry/render:render_mesh",
+        "@tinyobjloader",
         "@vtk//:vtkCommonCore",
         "@vtk//:vtkFiltersSources",
     ],

--- a/geometry/render_vtk/internal_render_engine_vtk_base.h
+++ b/geometry/render_vtk/internal_render_engine_vtk_base.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include <vtkCylinderSource.h>
 #include <vtkSmartPointer.h>
 #include <vtkTexturedSphereSource.h>
@@ -39,6 +41,9 @@ void SetCylinderOptions(vtkCylinderSource* vtk_cylinder, double height,
 void TransformToDrakeCylinder(vtkTransform* transform,
                               vtkTransformPolyDataFilter* transform_filter,
                               vtkCylinderSource* vtk_cylinder);
+
+vtkSmartPointer<vtkPolyDataAlgorithm> DoObjStuff(
+    const std::string& file_name, PerceptionProperties* properties);
 
 }  // namespace internal
 }  // namespace render_vtk

--- a/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
@@ -65,6 +65,12 @@ const double kClipFar = 100.0;
 const double kZNear = 0.5;
 const double kZFar = 5.;
 const double kFovY = M_PI_4;
+/* Note: enabling this causes failures with two tests. Try running as:
+
+ bazel test //geometry/render_vtk:internal_render_engine_vtk_test \
+    --test_filter=-*DifferentCameras:*Intrinsics*
+
+ to get past the aberrant tests; they *should* pass with this disabled. */
 const bool kShowWindow = false;
 
 // The following tolerance is used due to a precision difference between Ubuntu
@@ -897,6 +903,40 @@ TEST_F(RenderEngineVtkTest, EllipsoidTest) {
       unordered_map<GeometryId, RigidTransformd>{{id, X_WV}});
   PerformCenterShapeTest(renderer_.get(), "Ellipsoid test: a extent");
 }
+
+/* Texture mesh semantics needs to change:
+
+  - Current tests - all ignore the mtl file and are wholly reliant on geometry
+    properties.
+    - MeshTest
+      - a bad value for ("phong", "diffuse_map") uses ("phong", "diffuse")
+    - TexturedMeshTest
+      - a good value for ("phong", "diffuse_map") uses it
+    - ImpliedMeshTest
+      - No diffuse specified in *property* looks for file of same name.
+  - New tests based on new semantics
+    - new semantics
+      - If obj has mtl, those materials should be used (Kd and map_Kd). Period.
+        - If the texture can't be found, it's omitted and the materials
+          diffuse value is used instead.
+      - If obj has no mtl then use the following in order of descending
+        priority.
+        - "foo.png" logic.
+        - ("phong", "diffuse")
+    - New tests
+      - MTL support
+        - Confirm that both Kd and map_Kd go through; make sure the map_Kd
+          file doesn't match names with the foo.obj. Simply picking weird values
+          for map_Kd and Kd should be sufficient to show they both come through.
+      - Missing MTL
+        - One case with implied texture (foo.obj with no mtllib does have a
+          foo.png present).
+        - Diffuse color fallback (no mtllib, no foo.png).
+  - Weird OBJ fun and games:
+    - mtl specifies multiple materials, only one is used by obj.
+    - mtl specifies one material, isn't used by any faces.
+    - obj doesn't apply materials to all faces.
+*/
 
 // Performs the shape-centered-in-the-image test with a mesh (which happens to
 // be a box). This simultaneously confirms that if a diffuse_map is specified

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -394,7 +394,7 @@ drake_cc_library(
     name = "diagnostic_policy_test_base",
     testonly = 1,
     hdrs = ["test/diagnostic_policy_test_base.h"],
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
     deps = [
         "//common:diagnostic_policy",
         "@gtest//:without_main",

--- a/multibody/parsing/test/diagnostic_policy_test_base.h
+++ b/multibody/parsing/test/diagnostic_policy_test_base.h
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/diagnostic_policy.h"
+#include "drake/common/text_logging.h"
 
 namespace drake {
 namespace multibody {


### PR DESCRIPTION
First stage, can I simply replace the old geoemtry with new geometry that has the same effect?

1. I need to convert general OBJ expression into buffer representation.
    - RenderEngineGl has code that does this, I'm stealing it outright.
2. Replace vtkOBJReader with this new function that returns a poly algorithm.
    - Tests pass.
3. We'll cheat for dealing with the materials.
     - Given the current logic, we'll simply stomp on the perception properties. Not a good solution, but this merely proves that the data *can* flow from tiny obj to vtk.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19194)
<!-- Reviewable:end -->
