### PR TITLE
Provide automatic sanitization of field names in `namedview`

### DIFF
--- a/bindings/pydrake/common/containers.py
+++ b/bindings/pydrake/common/containers.py
@@ -150,13 +150,19 @@ class NamedViewBase:
         return cls([0] * len(cls._fields))
 
 
-def _sanitize_field_name(x: str):
-    if x[0].isnumeric():
-        x = '_' + x
-    x = re.sub('[^a-zA-Z0-9_]', '_', x)
-    x = re.sub('__+', '_', x)
-    assert x.isidentifier(), f"Sanitization failed on {x}"
-    return x
+def _sanitize_field_name(name: str):
+    result = name
+    # Ensure the first character is a valid opener (e.g., no numbers allowed).
+    if not result[0].isidentifier():
+        result = "_" + result
+    # Ensure that each additional character is valid in turn, avoiding the
+    # special case for opening characters by prepending "_" during the check.
+    for i in range(1, len(result)):
+        if not ("_" + result[i]).isidentifier():
+            result = result[:i] + "_" + result[i+1:]
+    result = re.sub("__+", "_", result)
+    assert result.isidentifier(), f"Sanitization failed on {name} => {result}"
+    return result
 
 
 def namedview(name, fields, *, sanitize_field_names=True):

--- a/bindings/pydrake/common/containers.py
+++ b/bindings/pydrake/common/containers.py
@@ -172,9 +172,9 @@ def namedview(name, fields, *, sanitize_field_names=True):
     Similar to ``namedtuple``.
 
     If ``sanitize_field_names`` is True (the default), then any characters in
-    ``fields`` which are not valid in Python identifier (A-z, 0-9, and _ )
-    will be automatically replaced with `_`. Leading numbers will have `_`
-    inserted, and duplicate `_` will be replaced by a single `_`.
+    ``fields`` which are not valid in Python identifiers will be automatically
+    replaced with `_`. Leading numbers will have `_` inserted, and duplicate
+    `_` will be replaced by a single `_`.
 
     Example:
         ::

--- a/bindings/pydrake/common/test/containers_test.py
+++ b/bindings/pydrake/common/test/containers_test.py
@@ -130,3 +130,25 @@ class TestNamedView(unittest.TestCase):
         self.assertEqual(len(view), 2)
         self.assertEqual(view.a, 0)
         self.assertEqual(view.b, 0)
+
+    def test_name_sanitation(self):
+        MyView = namedview("MyView",
+                           ["$world_base", "iiwa::iiwa", "no spaces", "2var"])
+        self.assertEqual(MyView.get_fields(),
+                         ("_world_base", "iiwa_iiwa", "no_spaces", "_2var"))
+        view = MyView.Zero()
+        view._world_base = 3
+        view.iiwa_iiwa = 4
+        view.no_spaces = 5
+        view._2var = 6
+        np.testing.assert_equal(view[:], [3, 4, 5, 6])
+
+        MyView = namedview("MyView", ["$world_base", "iiwa::iiwa"],
+                           sanitize_field_names=False)
+        self.assertEqual(MyView.get_fields(), ("$world_base", "iiwa::iiwa"))
+
+    def test_uniqueness(self):
+        with self.assertRaisesRegex(AssertionError, ".*must be unique.*"):
+            namedview("MyView", ['a', 'a'])
+        with self.assertRaisesRegex(AssertionError, ".*must be unique.*"):
+            namedview("MyView", ['a_a', 'a__a'])

--- a/bindings/pydrake/common/test/containers_test.py
+++ b/bindings/pydrake/common/test/containers_test.py
@@ -133,14 +133,14 @@ class TestNamedView(unittest.TestCase):
 
     def test_name_sanitation(self):
         MyView = namedview("MyView",
-                           ["$world_base", "iiwa::iiwa", "no spaces", "2var"])
+                           ["$world_base", "iiwa::iiwa", "no spaces", "2vär"])
         self.assertEqual(MyView.get_fields(),
-                         ("_world_base", "iiwa_iiwa", "no_spaces", "_2var"))
+                         ("_world_base", "iiwa_iiwa", "no_spaces", "_2vär"))
         view = MyView.Zero()
         view._world_base = 3
         view.iiwa_iiwa = 4
         view.no_spaces = 5
-        view._2var = 6
+        view._2vär = 6
         np.testing.assert_equal(view[:], [3, 4, 5, 6])
 
         MyView = namedview("MyView", ["$world_base", "iiwa::iiwa"],


### PR DESCRIPTION
Related to #19164 -- MbP uses names which are not immediately useable as `namedview` fields.

After this PR (and now that #19174 has landed), we can do e.g.
```
PositionView = namedview("PositionView", plant.GetPositionNames())
StateView = namedview("StateView", plant.GetStateNames())
```

+@EricCousineau-TRI for feature review, please?  WDYT?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19196)
<!-- Reviewable:end -->
