### PR TITLE
Add polyfill for std::ssize

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -94,6 +94,7 @@ drake_cc_library(
         "drake_throw.h",
         "eigen_types.h",
         "never_destroyed.h",
+        "ssize.h",
         "text_logging.h",
     ],
     deps = [
@@ -621,6 +622,13 @@ drake_cc_googletest(
     name = "bit_cast_test",
     deps = [
         ":bit_cast",
+    ],
+)
+
+drake_cc_googletest(
+    name = "ssize_test",
+    deps = [
+        ":essential",
     ],
 )
 

--- a/common/bit_cast.h
+++ b/common/bit_cast.h
@@ -20,7 +20,7 @@ using std::bit_cast;
 namespace drake {
 namespace internal {
 
-/** Implements C++20 https://en.cppreference.com/w/cpp/numeric/bit_cast (but
+/* Implements C++20 https://en.cppreference.com/w/cpp/numeric/bit_cast (but
 without the overload resolution guards, which are not necessary in our case.)
 (Once all of Drake's supported platforms offer std::bit_cast, we can remove
 this function in lieu of the std one.) */

--- a/common/ssize.h
+++ b/common/ssize.h
@@ -1,0 +1,44 @@
+#pragma once
+
+// Many C++20 std headers define ssize; pick one. This is needed even to
+// get the __cpp_lib_ssize define set.
+#include <vector>
+
+#ifdef __cpp_lib_ssize
+namespace drake {
+
+using std::ssize;
+
+}  // namespace drake
+#else  // __cpp_lib_ssize
+
+#include <cstddef>      // For std::ptrdiff_t
+#include <type_traits>  // For std::common_type_t, std::make_signed_t
+
+namespace drake {
+
+/** Implements C++20 %std::ssize() for earlier compilers. See
+https://en.cppreference.com/w/cpp/iterator/size for documentation. Will be
+removed once all Drake-supported platforms offer %std::ssize(). */
+
+// The implementations below are taken directly from the cppreference
+// documentation. BTW std::size() is already supported on all Drake platforms.
+
+template <class C>
+constexpr auto ssize(const C& c)
+    -> std::common_type_t<std::ptrdiff_t,
+                          std::make_signed_t<decltype(c.size())> > {
+  using R = std::common_type_t<std::ptrdiff_t,
+                               std::make_signed_t<decltype(c.size())> >;
+  return static_cast<R>(c.size());
+}
+
+/** This signature returns the size of built-in (C style) arrays. */
+template <class T, std::ptrdiff_t N>
+constexpr std::ptrdiff_t ssize(const T (&array)[N]) noexcept {
+  return N;
+}
+
+}  // namespace drake
+
+#endif  // __cpp_lib_ssize

--- a/common/test/ssize_test.cc
+++ b/common/test/ssize_test.cc
@@ -1,0 +1,28 @@
+#include "drake/common/ssize.h"
+
+#include <array>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace {
+
+// We have to polyfill for std::ssize() for C++ < C++20.
+GTEST_TEST(Ssize, BasicTest) {
+  int c[] = {-5, 10, 15};
+  EXPECT_EQ(ssize(c), 3);
+
+  std::array<double, 4> a = {1.0, 2.0, 3.0, 4.0};
+  EXPECT_EQ(ssize(a), 4);
+
+  std::string s = "abcdefg";
+  EXPECT_EQ(ssize(s), 7);
+
+  std::vector<int> v = {3, 1, 4, 1, 5, 9};
+  EXPECT_EQ(ssize(v), 6);
+}
+
+}  // namespace
+}  // namespace drake

--- a/multibody/constraint/test/constraint_solver_test.cc
+++ b/multibody/constraint/test/constraint_solver_test.cc
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/ssize.h"
 #include "drake/examples/rod2d/rod2d.h"
 #include "drake/solvers/unrevised_lemke_solver.h"
 
@@ -183,7 +184,7 @@ class Constraint2DSolverTest : public ::testing::Test {
 
     // Duplicate the contact points.
     std::vector<Vector2d> contacts_dup;
-    for (int i = 0; i < static_cast<int>(contacts.size()); ++i) {
+    for (int i = 0; i < ssize(contacts); ++i) {
       for (int j = 0; j < contact_points_dup; ++j)
         contacts_dup.push_back(contacts[i]);
     }
@@ -219,7 +220,7 @@ class Constraint2DSolverTest : public ::testing::Test {
     };
 
     // Update r with the new friction directions.
-    for (int i = 0; i < static_cast<int>(data->r.size()); ++i)
+    for (int i = 0; i < ssize(data->r); ++i)
       data->r[i] = new_friction_directions;
 
     // Resize kF (recall the vector always is zero for this 2D problem), gammaF,
@@ -355,7 +356,7 @@ class Constraint2DSolverTest : public ::testing::Test {
 
     // Duplicate the contact points.
     std::vector<Vector2d> contacts_dup;
-    for (int i = 0; i < static_cast<int>(contacts.size()); ++i) {
+    for (int i = 0; i < ssize(contacts); ++i) {
       for (int j = 0; j < contact_points_dup; ++j)
         contacts_dup.push_back(contacts[i]);
     }
@@ -393,7 +394,7 @@ class Constraint2DSolverTest : public ::testing::Test {
     data->gammaE.setZero(contacts.size());
 
     // Update r with the new friction directions per contact.
-    for (int i = 0; i < static_cast<int>(data->r.size()); ++i)
+    for (int i = 0; i < ssize(data->r); ++i)
       data->r[i] = new_friction_directions;
 
     // Add in empty rows to G, by default, allowing us to verify that no
@@ -838,7 +839,7 @@ class Constraint2DSolverTest : public ::testing::Test {
                 std::fabs(rod_->get_gravitational_acceleration());
             double normal_force_mag = 0;
             double fric_force = 0;
-            for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
+            for (int i = 0; i < ssize(contact_forces); ++i) {
               normal_force_mag += contact_forces[i][0];
               fric_force += contact_forces[i][1];
             }
@@ -974,7 +975,7 @@ class Constraint2DSolverTest : public ::testing::Test {
             // Verify that the frictional forces are maximized.
             double fnormal = 0;
             double ffrictional = 0;
-            for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
+            for (int i = 0; i < ssize(contact_forces); ++i) {
               fnormal += contact_forces[i][0];
               ffrictional += std::fabs(contact_forces[i][1]);
             }
@@ -1017,7 +1018,7 @@ class Constraint2DSolverTest : public ::testing::Test {
             // Verify that the frictional forces are maximized.
             double fnormal = 0;
             double ffrictional = 0;
-            for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
+            for (int i = 0; i < ssize(contact_forces); ++i) {
               fnormal += contact_forces[i][0];
               ffrictional += std::fabs(contact_forces[i][1]);
             }
@@ -1113,7 +1114,7 @@ class Constraint2DSolverTest : public ::testing::Test {
             // correct direction.
             double fnormal = 0;
             double ffrictional = 0;
-            for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
+            for (int i = 0; i < ssize(contact_forces); ++i) {
               fnormal += contact_forces[i][0];
               ffrictional += contact_forces[i][1];
               EXPECT_NEAR(ffrictional * ff_sign, mu_static * fnormal,
@@ -1160,7 +1161,7 @@ class Constraint2DSolverTest : public ::testing::Test {
             // Verify that the frictional forces are maximized.
             double fnormal = 0;
             double ffrictional = 0;
-            for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
+            for (int i = 0; i < ssize(contact_forces); ++i) {
               fnormal += contact_forces[i][0];
               ffrictional += contact_forces[i][1];
             }
@@ -1259,7 +1260,7 @@ class Constraint2DSolverTest : public ::testing::Test {
             // Verify that the frictional impulses are maximized.
             double jnormal = 0;
             double jfrictional = 0;
-            for (int i = 0; i < static_cast<int>(contact_impulses.size());
+            for (int i = 0; i < ssize(contact_impulses);
                  ++i) {
               jnormal += contact_impulses[i][0];
               jfrictional += contact_impulses[i][1];
@@ -1301,7 +1302,7 @@ class Constraint2DSolverTest : public ::testing::Test {
             // Verify that the frictional impulses are maximized.
             double jnormal = 0;
             double jfrictional = 0;
-            for (int i = 0; i < static_cast<int>(contact_impulses.size());
+            for (int i = 0; i < ssize(contact_impulses);
                  ++i) {
               jnormal += contact_impulses[i][0];
               jfrictional += std::fabs(contact_impulses[i][1]);
@@ -1381,7 +1382,7 @@ class Constraint2DSolverTest : public ::testing::Test {
           // the contact normal, points along the world y-axis, and the y-axis
           //  of the contact frame, which corresponds to a contact tangent
           // vector, points along the world x-axis.
-          for (int i = 0; i < static_cast<int>(frames.size()); ++i) {
+          for (int i = 0; i < ssize(frames); ++i) {
             EXPECT_LT(
                 std::fabs(frames[i].col(0).dot(Vector2<double>::UnitY()) - 1.0),
                 std::numeric_limits<double>::epsilon());
@@ -1512,7 +1513,7 @@ class Constraint2DSolverTest : public ::testing::Test {
       const double mg = std::fabs(rod_->get_gravitational_acceleration()) *
           rod_->get_rod_mass();
       double fN = 0, fF = 0;
-      for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
+      for (int i = 0; i < ssize(contact_forces); ++i) {
         fN += contact_forces[i][0];
         fF += std::fabs(contact_forces[i][1]);
       }
@@ -1610,7 +1611,7 @@ class Constraint2DSolverTest : public ::testing::Test {
       const double mg = std::fabs(rod_->get_gravitational_acceleration()) *
           rod_->get_rod_mass();
       double fN = 0, fF = 0;
-      for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
+      for (int i = 0; i < ssize(contact_forces); ++i) {
         fN += contact_forces[i][0];
         fF += std::fabs(contact_forces[i][1]);
       }
@@ -1705,7 +1706,7 @@ class Constraint2DSolverTest : public ::testing::Test {
     const double mg = std::fabs(rod_->get_gravitational_acceleration()) *
         rod_->get_rod_mass();
     double fN = 0, fF = 0;
-    for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
+    for (int i = 0; i < ssize(contact_forces); ++i) {
       fN += contact_forces[i][0];
       fF += contact_forces[i][1];
     }
@@ -1791,7 +1792,7 @@ class Constraint2DSolverTest : public ::testing::Test {
 
     // Verify that the normal contact impulses exactly oppose the pre-impact
     double fN = 0, fF = 0;
-    for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
+    for (int i = 0; i < ssize(contact_forces); ++i) {
       fN += contact_forces[i][0];
       fF += contact_forces[i][1];
     }
@@ -1892,7 +1893,7 @@ class Constraint2DSolverTest : public ::testing::Test {
     // Verify that the normal contact forces exactly oppose the discretized
     // force.
     double fN = 0, fF = 0;
-    for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
+    for (int i = 0; i < ssize(contact_forces); ++i) {
       fN += contact_forces[i][0];
       fF += contact_forces[i][1];
     }

--- a/multibody/contact_solvers/sap/contact_problem_graph.h
+++ b/multibody/contact_solvers/sap/contact_problem_graph.h
@@ -5,6 +5,7 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/sorted_pair.h"
+#include "drake/common/ssize.h"
 #include "drake/multibody/contact_solvers/sap/partial_permutation.h"
 
 namespace drake {
@@ -59,7 +60,7 @@ class ContactProblemGraph {
 
     const SortedPair<int>& cliques() const { return cliques_; }
     int num_constraints() const {
-      return static_cast<int>(constraint_index_.size());
+      return ssize(constraint_index_);
     }
     int num_total_constraint_equations() const {
       return num_constraint_equations_;
@@ -119,7 +120,7 @@ class ContactProblemGraph {
   int num_cliques() const { return num_cliques_; }
 
   /* Number of clusters (edges) in the graph. */
-  int num_clusters() const { return static_cast<int>(clusters_.size()); }
+  int num_clusters() const { return ssize(clusters_); }
 
   /* Number of constraints added with calls to AddConstraint(). */
   int num_constraints() const { return num_constraints_; }

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "drake/common/drake_throw.h"
+#include "drake/common/ssize.h"
 #include "drake/common/text_logging.h"
 #include "drake/common/unused.h"
 #include "drake/geometry/geometry_frame.h"
@@ -721,7 +722,7 @@ geometry::GeometryId MultibodyPlant<T>::RegisterVisualGeometry(
   }
   scene_graph_->AssignRole(*source_id_, id, perception_props);
 
-  DRAKE_ASSERT(static_cast<int>(visual_geometries_.size()) == num_bodies());
+  DRAKE_ASSERT(ssize(visual_geometries_) == num_bodies());
   visual_geometries_[body.index()].push_back(id);
   ++num_visual_geometries_;
   return id;
@@ -750,7 +751,7 @@ geometry::GeometryId MultibodyPlant<T>::RegisterCollisionGeometry(
       body, X_BG, shape, GetScopedName(*this, body.model_instance(), name));
 
   scene_graph_->AssignRole(*source_id_, id, std::move(properties));
-  DRAKE_ASSERT(static_cast<int>(collision_geometries_.size()) == num_bodies());
+  DRAKE_ASSERT(ssize(collision_geometries_) == num_bodies());
   collision_geometries_[body.index()].push_back(id);
   ++num_collision_geometries_;
   return id;
@@ -916,7 +917,7 @@ void MultibodyPlant<T>::CalcSpatialAccelerationsFromVdot(
     std::vector<SpatialAcceleration<T>>* A_WB_array) const {
   this->ValidateContext(context);
   DRAKE_THROW_UNLESS(A_WB_array != nullptr);
-  DRAKE_THROW_UNLESS(static_cast<int>(A_WB_array->size()) == num_bodies());
+  DRAKE_THROW_UNLESS(ssize(*A_WB_array) == num_bodies());
   internal_tree().CalcSpatialAccelerationsFromVdot(
       context, internal_tree().EvalPositionKinematics(context),
       internal_tree().EvalVelocityKinematics(context), known_vdot, A_WB_array);
@@ -1421,7 +1422,7 @@ std::vector<std::string> MultibodyPlant<T>::GetPositionNames(
     DRAKE_DEMAND(joint.position_start() >= position_offset);
     DRAKE_DEMAND(joint.position_start() + joint.num_positions() -
                      position_offset <=
-                 static_cast<int>(names.size()));
+                 ssize(names));
 
     const std::string prefix =
         add_model_instance_prefix
@@ -1484,7 +1485,7 @@ std::vector<std::string> MultibodyPlant<T>::GetVelocityNames(
     DRAKE_DEMAND(joint.velocity_start() >= velocity_offset);
     DRAKE_DEMAND(joint.velocity_start() + joint.num_velocities() -
                      velocity_offset <=
-                 static_cast<int>(names.size()));
+                 ssize(names));
 
     const std::string prefix =
         add_model_instance_prefix
@@ -1569,8 +1570,7 @@ std::vector<std::string> MultibodyPlant<T>::GetActuatorNames(
     const JointActuator<T>& actuator = get_joint_actuator(actuator_index);
     // Sanity check: indices are in range.
     DRAKE_DEMAND(actuator.input_start() >= offset);
-    DRAKE_DEMAND(actuator.input_start() - offset <
-                 static_cast<int>(names.size()));
+    DRAKE_DEMAND(actuator.input_start() - offset < ssize(names));
 
     const std::string prefix =
         add_model_instance_prefix
@@ -1877,7 +1877,7 @@ void MultibodyPlant<T>::CalcAndAddContactForcesByPenaltyMethod(
     std::vector<SpatialForce<T>>* F_BBo_W_array) const {
   this->ValidateContext(context);
   DRAKE_DEMAND(F_BBo_W_array != nullptr);
-  DRAKE_DEMAND(static_cast<int>(F_BBo_W_array->size()) == num_bodies());
+  DRAKE_DEMAND(ssize(*F_BBo_W_array) == num_bodies());
   if (num_collision_geometries() == 0) return;
 
   const ContactResults<T>& contact_results = EvalContactResults(context);
@@ -1949,7 +1949,7 @@ void MultibodyPlant<T>::CalcHydroelasticContactForces(
 
   std::vector<SpatialForce<T>>& F_BBo_W_array =
       contact_info_and_body_forces->F_BBo_W_array;
-  DRAKE_DEMAND(static_cast<int>(F_BBo_W_array.size()) == num_bodies());
+  DRAKE_DEMAND(ssize(F_BBo_W_array) == num_bodies());
   std::vector<HydroelasticContactInfo<T>>& contact_info =
       contact_info_and_body_forces->contact_info;
 
@@ -2350,7 +2350,7 @@ void MultibodyPlant<T>::CalcJointLockingIndices(
   // the plant stable.
   std::sort(indices.begin(), indices.end());
   internal::DemandIndicesValid(indices, num_velocities());
-  DRAKE_DEMAND(static_cast<int>(indices.size()) == unlocked_cursor);
+  DRAKE_DEMAND(ssize(indices) == unlocked_cursor);
 }
 
 template <typename T>
@@ -2399,7 +2399,7 @@ void MultibodyPlant<T>::CalcSpatialContactForcesContinuous(
       std::vector<SpatialForce<T>>* F_BBo_W_array) const {
   this->ValidateContext(context);
   DRAKE_DEMAND(F_BBo_W_array != nullptr);
-  DRAKE_DEMAND(static_cast<int>(F_BBo_W_array->size()) == num_bodies());
+  DRAKE_DEMAND(ssize(*F_BBo_W_array) == num_bodies());
   DRAKE_DEMAND(!is_discrete());
 
   // Forces can accumulate into F_BBo_W_array; initialize it to zero first.
@@ -2415,7 +2415,7 @@ void MultibodyPlant<T>::CalcAndAddSpatialContactForcesContinuous(
       std::vector<SpatialForce<T>>* F_BBo_W_array) const {
   this->ValidateContext(context);
   DRAKE_DEMAND(F_BBo_W_array != nullptr);
-  DRAKE_DEMAND(static_cast<int>(F_BBo_W_array->size()) == num_bodies());
+  DRAKE_DEMAND(ssize(*F_BBo_W_array) == num_bodies());
   DRAKE_DEMAND(!is_discrete());
 
   // Early exit if there are no contact forces.
@@ -2445,7 +2445,7 @@ void MultibodyPlant<T>::CalcAndAddSpatialContactForcesContinuous(
       const std::vector<SpatialForce<T>>& Fhydro_BBo_W_all =
           EvalHydroelasticContactForces(context).F_BBo_W_array;
       DRAKE_DEMAND(F_BBo_W_array->size() == Fhydro_BBo_W_all.size());
-      for (int i = 0; i < static_cast<int>(Fhydro_BBo_W_all.size()); ++i) {
+      for (int i = 0; i < ssize(Fhydro_BBo_W_all); ++i) {
         // Both sets of forces are applied to the body's origins and expressed
         // in frame W. They should simply sum.
         (*F_BBo_W_array)[i] += Fhydro_BBo_W_all[i];
@@ -2536,7 +2536,7 @@ void MultibodyPlant<T>::AddInForcesContinuous(
       forces->mutable_body_forces();
   const std::vector<SpatialForce<T>>& Fcontact_BBo_W_array =
       EvalSpatialContactForcesContinuous(context);
-  for (int i = 0; i < static_cast<int>(Fapp_BBo_W_array.size()); ++i)
+  for (int i = 0; i < ssize(Fapp_BBo_W_array); ++i)
     Fapp_BBo_W_array[i] += Fcontact_BBo_W_array[i];
 }
 
@@ -3158,7 +3158,7 @@ void MultibodyPlant<T>::CalcReactionForces(
     std::vector<SpatialForce<T>>* F_CJc_Jc_array) const {
   this->ValidateContext(context);
   DRAKE_DEMAND(F_CJc_Jc_array != nullptr);
-  DRAKE_DEMAND(static_cast<int>(F_CJc_Jc_array->size()) == num_joints());
+  DRAKE_DEMAND(ssize(*F_CJc_Jc_array) == num_joints());
 
   // Guard against failure to acquire the geometry input deep in the call graph.
   ValidateGeometryInput(context, get_reaction_forces_output_port());

--- a/multibody/tree/multibody_tree_topology.h
+++ b/multibody/tree/multibody_tree_topology.h
@@ -34,6 +34,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
+#include "drake/common/ssize.h"
 #include "drake/multibody/tree/multibody_tree_indexes.h"
 
 namespace drake {
@@ -410,7 +411,7 @@ struct BodyNodeTopology {
   std::vector<BodyNodeIndex> child_nodes;
 
   // Returns the number of children to this node.
-  int get_num_children() const { return static_cast<int>(child_nodes.size());}
+  int get_num_children() const { return ssize(child_nodes);}
 
 
   // Start and number of dofs for this node's mobilizer.
@@ -467,33 +468,33 @@ class MultibodyTreeTopology {
   // Returns the number of bodies in the multibody tree. This includes the
   // "world" body and therefore the minimum number of bodies after
   // MultibodyTree::Finalize() will always be one, not zero.
-  int num_bodies() const { return static_cast<int>(bodies_.size()); }
+  int num_bodies() const { return ssize(bodies_); }
 
   // Returns the number of physical frames in the multibody tree.
   int num_frames() const {
-    return static_cast<int>(frames_.size());
+    return ssize(frames_);
   }
 
   // Returns the number of mobilizers in the multibody tree. Since the "world"
   // body does not have a mobilizer, the number of mobilizers will always equal
   // the number of bodies minus one.
   int num_mobilizers() const {
-    return static_cast<int>(mobilizers_.size());
+    return ssize(mobilizers_);
   }
 
   // Returns the number of tree nodes. This must equal the number of bodies.
   int get_num_body_nodes() const {
-    return static_cast<int>(body_nodes_.size());
+    return ssize(body_nodes_);
   }
 
   // Returns the number of force elements in the topology.
   int num_force_elements() const {
-    return static_cast<int>(force_elements_.size());
+    return ssize(force_elements_);
   }
 
   // Returns the number of joint actuators in the topology.
   int num_joint_actuators() const {
-    return static_cast<int>(joint_actuators_.size());
+    return ssize(joint_actuators_);
   }
 
   // Returns the number of tree levels in the topology.
@@ -549,7 +550,7 @@ class MultibodyTreeTopology {
   // tree. In other words, the number of trees in the topology corresponds to
   // the number of children of the world body node (also called "base nodes").
   int num_trees() const {
-    return static_cast<int>(num_tree_velocities_.size());
+    return ssize(num_tree_velocities_);
   }
 
   // Returns the number of generalized velocities for the t-th tree.

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "drake/common/reset_on_copy.h"
+#include "drake/common/ssize.h"
 #include "drake/common/unused.h"
 #include "drake/common/value.h"
 #include "drake/systems/framework/cache.h"
@@ -181,12 +182,12 @@ class ContextBase : public internal::ContextMessageInterface {
   /** Returns the number of input ports in this context. */
   int num_input_ports() const {
     DRAKE_ASSERT(input_port_tickets_.size() == input_port_values_.size());
-    return static_cast<int>(input_port_tickets_.size());
+    return ssize(input_port_tickets_);
   }
 
   /** Returns the number of output ports represented in this context. */
   int num_output_ports() const {
-    return static_cast<int>(output_port_tickets_.size());
+    return ssize(output_port_tickets_);
   }
 
   /** Returns the dependency ticket associated with a particular input port. */

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "drake/common/drake_throw.h"
+#include "drake/common/ssize.h"
 #include "drake/common/unused.h"
 #include "drake/systems/framework/abstract_value_cloner.h"
 #include "drake/systems/framework/cache_entry.h"
@@ -183,13 +184,13 @@ class SystemBase : public internal::SystemMessageInterface {
   /** Returns the number of input ports currently allocated in this System.
   These are indexed from 0 to %num_input_ports()-1. */
   int num_input_ports() const {
-    return static_cast<int>(input_ports_.size());
+    return ssize(input_ports_);
   }
 
   /** Returns the number of output ports currently allocated in this System.
   These are indexed from 0 to %num_output_ports()-1. */
   int num_output_ports() const {
-    return static_cast<int>(output_ports_.size());
+    return ssize(output_ports_);
   }
 
   /** Returns a reference to an InputPort given its `port_index`.
@@ -238,7 +239,7 @@ class SystemBase : public internal::SystemMessageInterface {
   /** Returns the number nc of cache entries currently allocated in this System.
   These are indexed from 0 to nc-1. */
   int num_cache_entries() const {
-    return static_cast<int>(cache_entries_.size());
+    return ssize(cache_entries_);
   }
 
   /** Returns a reference to a CacheEntry given its `index`. */


### PR DESCRIPTION
Tired of writing `static_cast<int>(thing.size())` over and over to avoid warnings? C++20 adds the very handy std::ssize() ("signed size") template function allowing `ssize(thing)` instead for any `thing` that has a size() method.

Unfortunately we still have to support C++17 for a while longer. This PR provides a polyfill implementation of `drake::ssize()` that allows writing `ssize(thing)` whenever you are in the drake:: namespace. (You have to include `drake/common/ssize.h`.) This uses the library implementation when available otherwise fakes it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19199)
<!-- Reviewable:end -->
