### PR TITLE
[common] Fix FindResource vs non-source Bazel builds

### DIFF
--- a/common/test/resource_tool_installed_test.py
+++ b/common/test/resource_tool_installed_test.py
@@ -2,6 +2,7 @@
 """
 
 import os
+from pathlib import Path
 import unittest
 import subprocess
 import sys
@@ -10,71 +11,87 @@ import install_test_helper
 
 
 class TestResourceTool(unittest.TestCase):
-    def test_install_and_run(self):
-        install_dir = install_test_helper.get_install_dir()
-        resource_subfolder = "share/drake/"
-        installed_sentinel = os.path.join(install_dir,
-                                          resource_subfolder,
-                                          ".drake-find_resource-sentinel")
-        # Verifies that the sentinel file exists in the installed directory.
-        # If it has been removed, we need to update this test.
-        self.assertTrue(os.path.isfile(installed_sentinel))
-        # Create a resource in the temporary directory.
-        tmp_dir = install_test_helper.create_temporary_dir()
 
-        resource_folder = os.path.join(tmp_dir, resource_subfolder)
-        test_folder = os.path.join(resource_folder, "common/test")
-        os.makedirs(test_folder)
+    def setUp(self):
+        # Establish the path to resource_tool.
+        self._install_dir = Path(install_test_helper.get_install_dir())
+        self._resource_tool = (
+            self._install_dir / "share/drake/common/resource_tool")
+        self.assertTrue(self._resource_tool.is_file())
+
+        # Establish the path to the sentinel dotfile.
+        self._resource_subfolder = Path("share/drake")
+        self._installed_sentinel = (
+            self._install_dir / self._resource_subfolder
+            / ".drake-find_resource-sentinel")
+        self.assertTrue(self._installed_sentinel.is_file())
+
+        # A valid, well-known resource path.
+        self._resource = "drake/examples/pendulum/Pendulum.urdf"
+
+    def test_basic_finding(self):
+        """The installed resource_tool uses the installed files by default."""
+        absolute_path = install_test_helper.check_output(
+            [self._resource_tool, "--print_resource_path", self._resource],
+            stderr=subprocess.STDOUT).strip()
+        self.assertTrue(Path(absolute_path).is_file(),
+                        f"Path does not exist: {absolute_path}")
+
+    def test_ignores_runfiles(self):
+        """The installed resource_tool ignores non-Drake runfiles."""
+        tool_env = dict(os.environ)
+        tool_env["TEST_SRCDIR"] = "/tmp"
+        absolute_path = install_test_helper.check_output(
+            [self._resource_tool, "--print_resource_path", self._resource],
+            env=tool_env, stderr=subprocess.STDOUT).strip()
+        self.assertTrue(Path(absolute_path).is_file(),
+                        f"Path does not exist: {absolute_path}")
+
+    def test_resource_root_environ(self):
+        """The installed resource_tool obeys DRAKE_RESOURCE_ROOT."""
+        # Create a resource in the temporary directory.
+        tmp_dir = Path(install_test_helper.create_temporary_dir())
+
+        resource_folder = tmp_dir / self._resource_subfolder
+        test_folder = resource_folder / "common/test"
+        test_folder.mkdir(parents=True)
         # Create sentinel file.
-        sentinel = os.path.join(resource_folder,
-                                os.path.basename(installed_sentinel))
-        os.symlink(installed_sentinel, sentinel)
+        sentinel = resource_folder / self._installed_sentinel.name
+        sentinel.symlink_to(self._installed_sentinel)
         # Create resource file.
-        resource = os.path.join(test_folder, "tmp_resource")
+        resource = test_folder / "tmp_resource"
         resource_data = "tmp_resource"
         with open(resource, "w") as f:
             f.write(resource_data)
 
         # Cross-check the resource root environment variable name.
         env_name = "DRAKE_RESOURCE_ROOT"
-        resource_tool = os.path.join(
-            install_dir, "share/drake/common/resource_tool")
         output_name = install_test_helper.check_output(
-            [resource_tool,
-             "--print_resource_root_environment_variable_name",
-             ],
-            ).strip()
+            [self._resource_tool,
+             "--print_resource_root_environment_variable_name"]).strip()
         self.assertEqual(output_name, env_name)
 
         # Use the installed resource_tool to find a resource.
         tool_env = dict(os.environ)
-        tool_env[env_name] = os.path.join(tmp_dir, "share")
+        tool_env[env_name] = tmp_dir / "share"
         absolute_path = install_test_helper.check_output(
-            [resource_tool,
-             "--print_resource_path",
-             "drake/common/test/tmp_resource",
-             ],
-            env=tool_env,
-            ).strip()
+            [self._resource_tool,
+             "--print_resource_path", "drake/common/test/tmp_resource"],
+            env=tool_env).strip()
         with open(absolute_path, 'r') as data:
             self.assertEqual(data.read(), resource_data)
 
         # Use the installed resource_tool to find a resource, but with a bogus
         # DRAKE_RESOURCE_ROOT that should be ignored.
-        tool_env[env_name] = os.path.join(tmp_dir, "share", "drake")
+        tool_env[env_name] = tmp_dir / "share/drake"
         full_text = install_test_helper.check_output(
-            [resource_tool,
-             "--print_resource_path",
-             "drake/examples/pendulum/Pendulum.urdf",
-             ],
-            env=tool_env,
-            stderr=subprocess.STDOUT,
-            ).strip()
+            [self._resource_tool, "--print_resource_path", self._resource],
+            env=tool_env, stderr=subprocess.STDOUT).strip()
         warning = full_text.splitlines()[0]
         absolute_path = full_text.splitlines()[-1]
         self.assertIn("FindResource ignoring DRAKE_RESOURCE_ROOT", warning)
-        self.assertTrue(os.path.exists(absolute_path),
-                        absolute_path + " does not exist")
+        self.assertTrue(Path(absolute_path).is_file(),
+                        f"Path does not exist: {absolute_path}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When a user installs Drake via pip or apt, but still uses Bazel as their build & test system, then previously we'd get confused and try to use Bazel runfiles to find Drake resources. Instead, we should fall back to the other mechanism (library-relative paths) in this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19206)
<!-- Reviewable:end -->
