### PR TITLE
[visualization] Add basic inertia visualizer

### DIFF
--- a/visualization/BUILD.bazel
+++ b/visualization/BUILD.bazel
@@ -12,6 +12,7 @@ drake_cc_package_library(
     name = "visualization",
     visibility = ["//visibility:public"],
     deps = [
+        ":inertia_visualizer",
         ":meshcat_pose_sliders",
         ":visualization_config",
         ":visualization_config_functions",
@@ -26,6 +27,17 @@ drake_cc_library(
         "//common:scope_exit",
         "//geometry:meshcat",
         "//systems/framework",
+    ],
+)
+
+drake_cc_library(
+    name = "inertia_visualizer",
+    srcs = ["inertia_visualizer.cc"],
+    hdrs = ["inertia_visualizer.h"],
+    deps = [
+        "//multibody/plant",
+        "//systems/framework:diagram_builder",
+        "//systems/framework:leaf_system",
     ],
 )
 
@@ -58,6 +70,7 @@ drake_cc_library(
         "//systems/lcm:lcm_buses",
     ],
     deps = [
+        ":inertia_visualizer",
         "//geometry:drake_visualizer",
         "//multibody/meshcat:contact_visualizer",
         "//multibody/plant:contact_results_to_lcm",
@@ -80,10 +93,27 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "visualization_config_functions_test",
     deps = [
+        ":inertia_visualizer",
         ":visualization_config_functions",
         "//common/test_utilities:expect_throws_message",
         "//lcm:drake_lcm",
         "//systems/analysis:simulator",
+    ],
+)
+
+drake_cc_googletest(
+    name = "inertia_visualizer_test",
+    data = [
+        "//geometry/render:test_models",
+        "//multibody/benchmarks/acrobot:models",
+    ],
+    deps = [
+        ":inertia_visualizer",
+        ":visualization_config_functions",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//geometry:meshcat",
+        "//geometry/test_utilities:meshcat_environment",
+        "//multibody/parsing",
     ],
 )
 

--- a/visualization/inertia_visualizer.cc
+++ b/visualization/inertia_visualizer.cc
@@ -1,0 +1,216 @@
+#include "drake/visualization/inertia_visualizer.h"
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+
+namespace drake {
+namespace visualization {
+
+using Eigen::Vector3d;
+using geometry::Ellipsoid;
+using geometry::FramePoseVector;
+using geometry::GeometryFrame;
+using geometry::GeometryInstance;
+using geometry::IllustrationProperties;
+using geometry::Rgba;
+using geometry::SceneGraph;
+using math::RigidTransform;
+using multibody::SpatialInertia;
+using systems::Context;
+using systems::DiagramBuilder;
+
+template <typename T>
+InertiaVisualizer<T>::InertiaVisualizer(
+    const multibody::MultibodyPlant<T>& plant, SceneGraph<T>* scene_graph) {
+  DRAKE_THROW_UNLESS(scene_graph != nullptr);
+  source_id_ = scene_graph->RegisterSource("inertia_visualizer");
+
+  // For all MbP bodies, except for those welded to the world ...
+  const std::vector<const multibody::Body<T>*> world_bodies =
+      plant.GetBodiesWeldedTo(plant.world_body());
+  const int num_bodies = plant.num_bodies();
+  for (multibody::BodyIndex i{0}; i < num_bodies; ++i) {
+    bool welded = false;
+    for (const auto* world_body : world_bodies) {
+      if (world_body->index() == i) {
+        welded = true;
+        break;
+      }
+    }
+    if (welded) {
+      continue;
+    }
+    const multibody::Body<T>& body = plant.get_body(i);
+
+    // Add a Bcm geometry frame.
+    Item item;
+    item.body = i;
+    item.Bo_frame = plant.GetBodyFrameIdIfExists(i).value();
+    item.Bcm_frame = scene_graph->RegisterFrame(
+        source_id_, SceneGraph<T>::world_frame_id(),
+        GeometryFrame{fmt::format(
+            "InertiaVisualizer::{}::{}",
+            plant.GetModelInstanceName(body.model_instance()), body.name())});
+
+    // Add an illustration ellipsoid to be placed at Bcm.
+    // This ellipsoid will be replaced by a properly-sized geometry in the
+    // subsequent call to UpdateItems() so its specifics don't matter.
+    auto ellipsoid = std::make_unique<Ellipsoid>(0.001, 0.001, 0.001);
+    auto geom = std::make_unique<GeometryInstance>(
+        RigidTransform<double>(), std::move(ellipsoid),
+        fmt::format("$inertia({})", i));
+    IllustrationProperties props;
+    props.AddProperty("meshcat", "accepting", "inertia");
+    // TODO(trowell-tri) This color is a placeholder until texturing is added.
+    // We set alpha to 0.0 here to support visualizers without alpha sliders.
+    // MeshcatVisualizer will update the alpha of this geometry based on the
+    // alpha slider's value.
+    props.AddProperty("phong", "diffuse", Rgba{0.0, 0.0, 1.0, 0.0});
+    geom->set_illustration_properties(std::move(props));
+    item.geometry = scene_graph->RegisterGeometry(source_id_, item.Bcm_frame,
+                                                  std::move(geom));
+    items_.push_back(std::move(item));
+  }
+
+  // Update the geometry information to reflect the initial inertia values
+  // from the plant.
+  UpdateItems(plant, *plant.CreateDefaultContext(), scene_graph);
+
+  this->DeclareAbstractInputPort("plant_geometry_pose",
+                                 Value<FramePoseVector<T>>());
+  this->DeclareAbstractOutputPort("geometry_pose",
+                                  &InertiaVisualizer<T>::CalcFramePoseOutput);
+}
+
+template <typename T>
+template <typename U>
+InertiaVisualizer<T>::InertiaVisualizer(const InertiaVisualizer<U>& other)
+    : source_id_{other.source_id_}, items_{other.items_} {}
+
+template <typename T>
+const InertiaVisualizer<T>& InertiaVisualizer<T>::AddToBuilder(
+    DiagramBuilder<T>* builder, const multibody::MultibodyPlant<T>& plant,
+    SceneGraph<T>* scene_graph) {
+  DRAKE_THROW_UNLESS(builder != nullptr);
+  DRAKE_THROW_UNLESS(scene_graph != nullptr);
+  auto result =
+      builder->template AddSystem<InertiaVisualizer<T>>(plant, scene_graph);
+  result->set_name("inertia_visualizer");
+  builder->Connect(plant.get_geometry_poses_output_port(),
+                   result->get_input_port());
+  builder->Connect(result->get_output_port(),
+                   scene_graph->get_source_pose_port(result->source_id_));
+  return *result;
+}
+
+template <typename T>
+InertiaVisualizer<T>::~InertiaVisualizer() = default;
+
+// TODO(trowell-tri): This method also needs to run whenever mass or inertia
+// changes in the plant.
+template <typename T>
+void InertiaVisualizer<T>::UpdateItems(
+    const multibody::MultibodyPlant<T>& plant, const Context<T>& plant_context,
+    SceneGraph<T>* scene_graph) {
+  for (auto& item : items_) {
+    const multibody::Body<T>& body = plant.get_body(item.body);
+
+    auto [ellipsoid, X_BBcm] =
+        internal::CalculateInertiaGeometry(body, plant_context);
+    item.X_BBcm = X_BBcm;
+    scene_graph->ChangeShape(source_id_, item.geometry, ellipsoid);
+  }
+}
+
+template <typename T>
+void InertiaVisualizer<T>::CalcFramePoseOutput(
+    const Context<T>& context, FramePoseVector<T>* poses) const {
+  const auto& plant_poses =
+      this->get_input_port().template Eval<FramePoseVector<T>>(context);
+
+  poses->clear();
+  for (const auto& item : items_) {
+    const RigidTransform<T>& X_WBo = plant_poses.value(item.Bo_frame);
+    const RigidTransform<T> X_WBcm = X_WBo * item.X_BBcm.template cast<T>();
+    poses->set_value(item.Bcm_frame, X_WBcm);
+  }
+}
+
+namespace internal {
+
+template <typename T>
+std::pair<Ellipsoid, RigidTransform<double>> CalculateInertiaGeometry(
+    const multibody::Body<T>& body, const Context<T>& plant_context) {
+  // Interrogate the plant context for the spatial inertia of body B about its
+  // origin Bo, expressed in body frame B.
+  const SpatialInertia<T> M_BBo =
+      body.CalcSpatialInertiaInBodyFrame(plant_context);
+  // Compute spatial inertia of B, about Bcm, expressed in B.
+  // TODO(trowell-tri) We're taking the moments as-is instead of finding the
+  // principal axes. Update this code to undo the rotations and find the
+  // principal moments when the appropriate code is landed in #19281.
+  const SpatialInertia<T> M_BBcm = M_BBo.Shift(M_BBo.get_com());
+
+  // Pose the ellipsoid at the center of mass.
+  RigidTransform<double> X_BoBcm =
+      RigidTransform<double>(ExtractDoubleOrThrow(M_BBo.get_com()));
+
+  // For a massless body, use a very tiny sphere, expressed as an ellipsoid
+  // for simplicity.
+  const double mass = ExtractDoubleOrThrow(M_BBcm.get_mass());
+  if (mass == 0) {
+    return std::pair<Ellipsoid, RigidTransform<double>>(
+        Ellipsoid(0.001, 0.001, 0.001), X_BoBcm);
+  }
+
+  // We need to find the equivalent solid ellipsoid for M_BBcm, as described by
+  // its semi-major axes (a, b, c) and density (p).
+  //
+  // Note that the scale of a, b, c relative to each other are independent of
+  // the mass; they only depend on Ixx, Iyy, Izz. So first, we'll convert the
+  // unit inertia to an ellipsoid to determine the relative axes. Then, we'll
+  // re-scale the axes to match the body's mass.
+  //
+  // Per multibody/tree/unit_inertia the unit inertia of a solid ellipsoid is:
+  //
+  //  Ixx = (b² + c²) / 5
+  //  Iyy = (a² + b²) / 5
+  //  Izz = (a² + c²) / 5
+  //
+  // Solving this for positive a b c, we have:
+  const Vector3d unit_inertia_moments =
+      ExtractDoubleOrThrow(M_BBcm.get_unit_inertia().get_moments());
+  const double Ixx = unit_inertia_moments(0);
+  const double Iyy = unit_inertia_moments(1);
+  const double Izz = unit_inertia_moments(2);
+  Vector3d abc{std::sqrt((5.0 / 2.0) * std::max(0.0, -Ixx + Iyy + Izz)),
+               std::sqrt((5.0 / 2.0) * std::max(0.0, +Ixx - Iyy + Izz)),
+               std::sqrt((5.0 / 2.0) * std::max(0.0, +Ixx + Iyy - Izz))};
+
+  // An ellipse that has one of its diameters >100x greater than another one
+  // does not render well on the screen, so we'll bound the relative scale of
+  // each of the unit ellipsoid's radii.
+  abc = abc.array().max(1e-2 * abc.maxCoeff());
+
+  // Assuming the ~density of water for the visualization ellipsoid, scale
+  // it to have a volume that matches the body's mass.
+  const double density = 1000.0;
+  const double solved_mass =
+      density * (4.0 / 3.0) * M_PI * abc(0) * abc(1) * abc(2);
+  const double volume_scale = mass / solved_mass;
+  const Vector3d scaled_abc = abc * std::cbrt(volume_scale);
+
+  return std::pair<Ellipsoid, RigidTransform<double>>(Ellipsoid(scaled_abc),
+                                                      X_BoBcm);
+}
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    (&CalculateInertiaGeometry<T>));
+
+}  // namespace internal
+}  // namespace visualization
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::visualization::InertiaVisualizer)

--- a/visualization/inertia_visualizer.h
+++ b/visualization/inertia_visualizer.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "drake/geometry/scene_graph.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace visualization {
+
+/** InertiaVisualizer provides illustration geometry to reflect the equivalent
+inertia of all bodies in a MultibodyPlant that are not welded to the world.
+
+Instead of constructing this system directly, most users should use
+AddDefaultVisualization() which automatically uses this system.
+
+ @system
+ name: InertiaVisualizer
+ input_ports:
+ - plant_geometry_pose
+ output_ports:
+ - geometry_pose
+ @endsystem
+
+@tparam_default_scalar
+@ingroup visualization */
+template <typename T>
+class InertiaVisualizer final : public systems::LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(InertiaVisualizer)
+
+  /** Creates an instance of %InertiaVisualizer.
+  The plant must be finalized. */
+  InertiaVisualizer(const multibody::MultibodyPlant<T>& plant,
+                    geometry::SceneGraph<T>* scene_graph);
+
+  /** Scalar-converting copy constructor. See @ref system_scalar_conversion. */
+  template <typename U>
+  explicit InertiaVisualizer(const InertiaVisualizer<U>& other);
+
+  ~InertiaVisualizer() final;
+
+  /** Adds a new InertiaVisualizer to the given `builder` and connects it to the
+  given `plant` and `scene_graph`. */
+  static const InertiaVisualizer<T>& AddToBuilder(
+      systems::DiagramBuilder<T>* builder,
+      const multibody::MultibodyPlant<T>& plant,
+      geometry::SceneGraph<T>* scene_graph);
+
+  /** (Advanced) Returns the source_id for our visualization geometries.
+  Most users will not need to use this. */
+  geometry::SourceId source_id() const { return source_id_; }
+
+ private:
+  template <typename>
+  friend class InertiaVisualizer;
+
+  /* Each piece of visualization geometry has an Item to track its associated
+  indices and BoBcm transform. */
+  struct Item {
+    multibody::BodyIndex body;
+    geometry::FrameId Bo_frame;
+    geometry::FrameId Bcm_frame;
+    geometry::GeometryId geometry;
+    math::RigidTransform<double> X_BBcm;
+  };
+
+  /* Updates `this->items_` to match the inertia values in the given context. */
+  void UpdateItems(const multibody::MultibodyPlant<T>& plant,
+                   const systems::Context<T>& plant_context,
+                   geometry::SceneGraph<T>* scene_graph);
+
+  /* Calculates the "geometry_pose" output port. */
+  void CalcFramePoseOutput(const systems::Context<T>& context,
+                           geometry::FramePoseVector<T>* poses) const;
+
+  geometry::SourceId source_id_;
+  std::vector<Item> items_;
+};
+
+namespace internal {
+/* Returns the inertia geometry Ellipsoid and the X_BoBcm that represents the
+given body's moments of inertia. */
+template <typename T>
+std::pair<geometry::Ellipsoid, math::RigidTransform<double>>
+CalculateInertiaGeometry(const multibody::Body<T>& body,
+                         const systems::Context<T>& plant_context);
+}  // namespace internal
+
+}  // namespace visualization
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::visualization::InertiaVisualizer)

--- a/visualization/test/inertia_visualizer_test.cc
+++ b/visualization/test/inertia_visualizer_test.cc
@@ -1,0 +1,322 @@
+#include "drake/visualization/inertia_visualizer.h"
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/text_logging.h"
+#include "drake/geometry/meshcat.h"
+#include "drake/geometry/test_utilities/meshcat_environment.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/visualization/visualization_config_functions.h"
+
+using drake::geometry::Ellipsoid;
+using drake::geometry::Meshcat;
+using drake::geometry::SceneGraph;
+using drake::multibody::AddMultibodyPlantSceneGraph;
+using drake::multibody::AddMultibodyPlantSceneGraphResult;
+using drake::multibody::MultibodyPlant;
+using drake::multibody::Parser;
+using drake::multibody::SpatialInertia;
+using Eigen::RowVector3d;
+using Eigen::Vector3d;
+using Matrix34d = Eigen::Matrix<double, 3, 4>;
+
+namespace drake {
+namespace visualization {
+namespace internal {
+namespace {
+
+// See visualization_config_functions_test for tests that InertiaVisualizers
+// are created in ApplyVisualizationConfig, as well as various parameter
+// setting tests.
+
+// This class allows testing that inertia visualization is being published.
+class InertiaVisualizerConfigTest : public ::testing::Test {
+ public:
+  InertiaVisualizerConfigTest()
+      : meshcat_{geometry::GetTestEnvironmentMeshcat()},
+        builder_{},
+        plant_and_scene_graph_{AddMultibodyPlantSceneGraph(&builder_, 0.0)},
+        plant_{plant_and_scene_graph_.plant},
+        scene_graph_{plant_and_scene_graph_.scene_graph} {}
+
+  void SetUpDiagramWithConfig(const VisualizationConfig& config) {
+    Parser parser(&plant_);
+    parser.SetStrictParsing();
+    meshcat_->Delete();
+    parser.AddModels(
+        FindResourceOrThrow("drake/multibody/benchmarks/acrobot/acrobot.sdf"));
+    plant_.Finalize();
+
+    ApplyVisualizationConfig(config, &builder_, nullptr, &plant_, &scene_graph_,
+                             meshcat_);
+
+    diagram_ = builder_.Build();
+    context_ = diagram_->CreateDefaultContext();
+    diagram_->ForcedPublish(*context_);
+  }
+
+ protected:
+  std::shared_ptr<Meshcat> meshcat_;
+  systems::DiagramBuilder<double> builder_;
+  AddMultibodyPlantSceneGraphResult<double> plant_and_scene_graph_;
+  MultibodyPlant<double>& plant_;
+  SceneGraph<double>& scene_graph_;
+  std::unique_ptr<systems::Diagram<double>> diagram_{};
+  std::unique_ptr<systems::Context<double>> context_{};
+};
+
+// Test that an added model has both illustration and inertia geometry by
+// default.
+TEST_F(InertiaVisualizerConfigTest, TestDefaultVisualizationConfig) {
+  VisualizationConfig config;
+  // TODO(trowell-tri) Remove the next line when inertia defaults to published.
+  config.publish_inertia = true;
+  SetUpDiagramWithConfig(config);
+
+  EXPECT_TRUE(meshcat_->HasPath("/drake/illustration/acrobot"));
+  EXPECT_TRUE(meshcat_->HasPath("/drake/inertia/InertiaVisualizer/acrobot"));
+}
+
+// Test that we can show illustration geometry without inertia.
+TEST_F(InertiaVisualizerConfigTest, IllustrationButNoInertiaConfig) {
+  VisualizationConfig config;
+  config.publish_inertia = false;
+  SetUpDiagramWithConfig(config);
+
+  EXPECT_TRUE(meshcat_->HasPath("/drake/illustration/acrobot"));
+  EXPECT_FALSE(meshcat_->HasPath("/drake/inertia/InertiaVisualizer/acrobot"));
+}
+
+// Test that we can show inertia geometry without illustration.
+TEST_F(InertiaVisualizerConfigTest, InertiaButNoIllustrationConfig) {
+  VisualizationConfig config;
+  config.publish_illustration = false;
+  // TODO(trowell-tri) Remove the next line when inertia defaults to published.
+  config.publish_inertia = true;
+  SetUpDiagramWithConfig(config);
+
+  EXPECT_FALSE(meshcat_->HasPath("/drake/illustration/acrobot"));
+  EXPECT_TRUE(meshcat_->HasPath("/drake/inertia/InertiaVisualizer/acrobot"));
+}
+
+// This class allows testing the results of inertia geometry calculation.
+//
+// The CalculateInertiaGeometryFor() method returns the inertia ellipsoid
+// and transform for a single-body model when passed a GeometryTestCase.
+class InertiaVisualizerGeometryTest
+    : public ::testing::TestWithParam<RowVector3d> {
+ public:
+  InertiaVisualizerGeometryTest()
+      : builder_{},
+        plant_and_scene_graph_{AddMultibodyPlantSceneGraph(&builder_, 0.001)},
+        plant_{plant_and_scene_graph_.plant},
+        scene_graph_{plant_and_scene_graph_.scene_graph} {};
+
+  struct GeometryTestCase {
+    // The visual_sdf_ should contain the visual element of the test fixture
+    // to clarify the geometry being modeled.
+    std::string visual_sdf;
+    double mass{0};
+    double moment_ixx{0};
+    double moment_iyy{0};
+    double moment_izz{0};
+  };
+
+  // Returns the value of CalculateInertiaGeometry for the given input.
+  std::pair<geometry::Ellipsoid, math::RigidTransform<double>>
+  CalculateInertiaGeometryFor(const GeometryTestCase& input) {
+    const Vector3d pose = GetParam().transpose();
+    // TODO(trowell-tri) Extend to allow configuring pose rpy.
+    static constexpr char kModelTemplate[] = R"""(
+          <?xml version='1.0'?>
+          <sdf version='1.7'>
+            <model name='test_model'>
+              <link name='test_body'>
+                <inertial>
+                  <mass>{}</mass>
+                  <pose>{} {} {} 0 0 0</pose>
+                  <inertia>
+                    <ixx>{}</ixx>
+                    <ixy>0</ixy>
+                    <ixz>0</ixz>
+                    <iyy>{}</iyy>
+                    <iyz>0</iyz>
+                    <izz>{}</izz>
+                  </inertia>
+                </inertial>
+                <visual name="test_visual">
+                  <pose>{} {} {} 0 0 0</pose>
+                  <geometry>
+                    {}
+                  </geometry>
+                </visual>
+              </link>
+            </model>
+          </sdf>
+          )""";
+    const std::string model =
+        fmt::format(kModelTemplate, input.mass, pose.x(), pose.y(), pose.z(),
+                    input.moment_ixx, input.moment_iyy, input.moment_izz,
+                    pose.x(), pose.y(), pose.z(), input.visual_sdf);
+    drake::log()->info("Using SDF model: {}", model);
+
+    multibody::Parser(&plant_).AddModelsFromString(model, "sdf");
+    plant_.Finalize();
+    const multibody::Body<double>& body = plant_.GetBodyByName("test_body");
+    return CalculateInertiaGeometry(body, *plant_.CreateDefaultContext());
+  }
+
+ protected:
+  systems::DiagramBuilder<double> builder_;
+  AddMultibodyPlantSceneGraphResult<double> plant_and_scene_graph_;
+  MultibodyPlant<double>& plant_;
+  SceneGraph<double>& scene_graph_;
+};
+
+// These tests need to compare results using a somewhat forgiving tolerance
+// because they do a lot of math where errors will accumulate. We don't expect
+// our code to be only a little bit wrong; any implementation errors should
+// cause fairly major differences, well above this tolerance.
+constexpr double kTolerance = 1e-10;
+
+// This matches the density used in the inertia visualizer implementation.
+constexpr double kNominalDensity = 1000.0;
+
+// Test that an ellipsoid model that uses the same nominal density as the
+// visualization ellipsoids has the same radii. This test has translation
+// but no rotation.
+// TODO(trowell-tri) Add rotation to the test when supported.
+TEST_P(InertiaVisualizerGeometryTest, EllipsoidTest) {
+  const Vector3d pose = GetParam().transpose();
+  constexpr double a = 3.0;
+  constexpr double b = 2.0;
+  constexpr double c = 1.0;
+  const auto M = SpatialInertia<double>::SolidEllipsoidWithDensity(
+      kNominalDensity, a, b, c);
+  const GeometryTestCase test_case{
+      .visual_sdf = fmt::format(
+          "<ellipsoid><radii>{} {} {}</radii></ellipsoid>", a, b, c),
+      .mass = M.get_mass(),
+      .moment_ixx = M.CalcRotationalInertia().get_moments()[0],
+      .moment_iyy = M.CalcRotationalInertia().get_moments()[1],
+      .moment_izz = M.CalcRotationalInertia().get_moments()[2],
+  };
+
+  auto [ellipsoid, transform] = CalculateInertiaGeometryFor(test_case);
+
+  EXPECT_TRUE(CompareMatrices(transform.translation(), pose));
+
+  EXPECT_NEAR(ellipsoid.a(), a, kTolerance);
+  EXPECT_NEAR(ellipsoid.b(), b, kTolerance);
+  EXPECT_NEAR(ellipsoid.c(), c, kTolerance);
+}
+
+// Test inertia geometry computations for a massless body posed with
+// translation but not rotation.
+// TODO(trowell-tri) Add rotation to the test when supported.
+TEST_P(InertiaVisualizerGeometryTest, ZeroMassTest) {
+  auto [ellipsoid, transform] = CalculateInertiaGeometryFor(
+      {.visual_sdf = "<sphere><radius>1.0</radius></sphere>"});
+
+  // Pose for zero inertia is ignored.
+  EXPECT_EQ(transform.IsExactlyIdentity(), true);
+
+  EXPECT_NEAR(ellipsoid.a(), 0.001, kTolerance);
+  EXPECT_NEAR(ellipsoid.b(), 0.001, kTolerance);
+  EXPECT_NEAR(ellipsoid.c(), 0.001, kTolerance);
+}
+
+// Test that the inertia visualization ellipsoid for a box that uses the same
+// nominal density as those ellipsoids has spatial inertia moments in the same
+// ratio as those of the box. This test has translation but no rotation.
+// TODO(trowell-tri) Add rotation to the test when supported.
+TEST_P(InertiaVisualizerGeometryTest, BoxTest) {
+  const Vector3d pose = GetParam().transpose();
+  constexpr double x = 3.0;
+  constexpr double y = 2.0;
+  constexpr double z = 1.0;
+  const auto M =
+      SpatialInertia<double>::SolidBoxWithDensity(kNominalDensity, x, y, z);
+  auto box_inertia = M.CalcRotationalInertia();
+  auto [ellipsoid, transform] = CalculateInertiaGeometryFor(
+      {.visual_sdf = fmt::format("<box><size>{} {} {}</size></box>", x, y, z),
+       .mass = M.get_mass(),
+       .moment_ixx = box_inertia.get_moments()[0],
+       .moment_iyy = box_inertia.get_moments()[1],
+       .moment_izz = box_inertia.get_moments()[2]});
+
+  EXPECT_TRUE(CompareMatrices(transform.translation(), pose));
+
+  const auto ellipsoid_M = SpatialInertia<double>::SolidEllipsoidWithDensity(
+      kNominalDensity, ellipsoid.a(), ellipsoid.b(), ellipsoid.c());
+  EXPECT_NEAR(ellipsoid_M.get_mass(), M.get_mass(), kTolerance);
+
+  // Check moments of the box and the ellipsoid are proportional to each other
+  // and the scale factor isn't too wide.
+  auto ellipsoid_inertia = ellipsoid_M.CalcRotationalInertia();
+  const Vector3d ratio = ellipsoid_inertia.get_moments().array() /
+                         box_inertia.get_moments().array();
+  SCOPED_TRACE(
+      fmt::format("box_inertia = {}; ellipsoid_inertia = {}; ratio = {}",
+                  box_inertia, ellipsoid_inertia, fmt_eigen(ratio)));
+  double scale = ratio(0);
+  EXPECT_LT(std::max(scale, 1 / scale), 2.0);
+  EXPECT_NEAR(ratio(1), scale, kTolerance);
+  EXPECT_NEAR(ratio(2), scale, kTolerance);
+}
+
+// Test inertia geometry computations for a thin rod model posed with
+// translation but not rotation.
+// TODO(trowell-tri) Add rotation to the test when supported.
+TEST_P(InertiaVisualizerGeometryTest, ThinRodTest) {
+  const Vector3d pose = GetParam().transpose();
+  // TODO(jwnimmer-tri) Our SDFormat parser erroneously rejects rods that are
+  // posed too far away.  We need to skip those test cases for now.
+  if (pose.maxCoeff() > 5) {
+    drake::log()->info("Skipping test case due to SDFormat parser bug");
+    return;
+  }
+  constexpr double length = 5.0;
+  const auto M =
+      SpatialInertia<double>::ThinRodWithMass(10, length, Vector3d(0, 0, 1));
+  const GeometryTestCase test_case{
+      .visual_sdf = fmt::format(
+          "<cylinder><radius>0.01</radius><length>{}</length></cylinder>",
+          length),
+      .mass = M.get_mass(),
+      .moment_ixx = M.CalcRotationalInertia().get_moments()[0],
+      .moment_iyy = M.CalcRotationalInertia().get_moments()[1],
+      .moment_izz = M.CalcRotationalInertia().get_moments()[2],
+  };
+
+  auto [ellipsoid, transform] = CalculateInertiaGeometryFor(test_case);
+
+  EXPECT_TRUE(CompareMatrices(transform.translation(), pose));
+
+  const auto ellipsoid_M = SpatialInertia<double>::SolidEllipsoidWithDensity(
+      kNominalDensity, ellipsoid.a(), ellipsoid.b(), ellipsoid.c());
+  EXPECT_NEAR(ellipsoid_M.get_mass(), M.get_mass(), kTolerance);
+
+  // Check that the ellipsoid dimensions are roughly shaped like a rod
+  // along the z-axis.
+  SCOPED_TRACE(fmt::format("abc = {} {} {}", ellipsoid.a(), ellipsoid.b(),
+                           ellipsoid.c()));
+  EXPECT_NEAR(ellipsoid.a(), ellipsoid.b(), kTolerance);
+  EXPECT_GT(ellipsoid.c(), ellipsoid.a() * 99);
+}
+
+INSTANTIATE_TEST_SUITE_P(Poses, InertiaVisualizerGeometryTest,
+                         testing::Values(RowVector3d{0, 0, 0},
+                                         RowVector3d{10, 20, 30},
+                                         RowVector3d{5, 2, 1},
+                                         RowVector3d{10, 200, 50}));
+
+}  // namespace
+}  // namespace internal
+}  // namespace visualization
+}  // namespace drake

--- a/visualization/visualization_config.h
+++ b/visualization/visualization_config.h
@@ -12,8 +12,8 @@ namespace visualization {
 
 // TODO(jwnimmer-tri or trowell-tri) Add an option to disable LCM entirely.
 
-/** Settings for what MultibodyPlant and SceneGraph should send to meldis
-and/or drake_visualizer.
+/** Settings for what MultibodyPlant and SceneGraph should send to meldis,
+Meshcat, and/or drake_visualizer.
 
 @experimental The exact configuration details (names and types) are subject to
 change as we polish this new feature.
@@ -29,6 +29,7 @@ struct VisualizationConfig {
     a->Visit(DRAKE_NVP(publish_proximity));
     a->Visit(DRAKE_NVP(default_proximity_color));
     a->Visit(DRAKE_NVP(publish_contacts));
+    a->Visit(DRAKE_NVP(publish_inertia));
     a->Visit(DRAKE_NVP(enable_meshcat_creation));
     a->Visit(DRAKE_NVP(delete_on_initialization_event));
     a->Visit(DRAKE_NVP(enable_alpha_sliders));
@@ -49,7 +50,7 @@ struct VisualizationConfig {
 
   /** The color to apply to any illustration geometry that hasn't defined one.
   The vector must be of size three (rgb) or four (rgba). */
-  geometry::Rgba default_illustration_color{0.9, 0.9, 0.9};
+  geometry::Rgba default_illustration_color{0.9, 0.9, 0.9, 1.0};
 
   /** Whether to show proximity geometry. */
   bool publish_proximity{true};
@@ -57,6 +58,10 @@ struct VisualizationConfig {
   /** The color to apply to any proximity geometry that hasn't defined one.
   The vector must be of size three (rgb) or four (rgba). */
   geometry::Rgba default_proximity_color{1, 0, 0, 0.5};
+
+  /** Whether to show body inertia. */
+  // TODO(trowell-tri) Enable this when we handle off-axis inertia moments.
+  bool publish_inertia{false};
 
   /** Whether to show contact forces. */
   bool publish_contacts{true};


### PR DESCRIPTION
Add the InertiaVisualizer and update ApplyVisualizationConfig() to add it by default. Inertia geometry is fully transparent for non-Meshcat visualizers (which do not offer alpha sliders).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19210)
<!-- Reviewable:end -->
