### PR TITLE
[visualization] Use a mutable scene_graph for setup

### DIFF
--- a/bindings/pydrake/visualization/visualization_py_config.cc
+++ b/bindings/pydrake/visualization/visualization_py_config.cc
@@ -28,7 +28,14 @@ void DefineVisualizationConfig(py::module m) {
   }
 
   m  // BR
-      .def("ApplyVisualizationConfig", &ApplyVisualizationConfig,
+      .def("ApplyVisualizationConfig",
+          // TODO(jwnimmer-tri) On 2023-09-01 upon completion of deprecation,
+          // we can get rid of the overload_cast here.
+          py::overload_cast<const VisualizationConfig&,
+              systems::DiagramBuilder<double>*, const systems::lcm::LcmBuses*,
+              const multibody::MultibodyPlant<double>*,
+              geometry::SceneGraph<double>*, std::shared_ptr<geometry::Meshcat>,
+              lcm::DrakeLcmInterface*>(&ApplyVisualizationConfig),
           py::arg("config"), py::arg("builder"), py::arg("lcm_buses") = nullptr,
           py::arg("plant") = nullptr, py::arg("scene_graph") = nullptr,
           py::arg("meshcat") = nullptr, py::arg("lcm") = nullptr,

--- a/visualization/test/visualization_config_functions_test.cc
+++ b/visualization/test/visualization_config_functions_test.cc
@@ -335,6 +335,27 @@ GTEST_TEST(VisualizationConfigFunctionsTest, WrongSystemTypes) {
                               ".*not cast.*");
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+// Make sure the deprecated overload doesn't crash.
+GTEST_TEST(VisualizationConfigFunctionsTest, DeprecatedApply) {
+  DiagramBuilder<double> builder;
+  auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.0);
+  plant.Finalize();
+
+  // Call the deprecated overload (with const pointers).
+  const VisualizationConfig config;
+  const MultibodyPlant<double>* const const_plant = &plant;
+  const SceneGraph<double>* const const_scene_graph = &scene_graph;
+  ApplyVisualizationConfig(config, &builder, nullptr, const_plant,
+                           const_scene_graph);
+
+  // Simulate for a moment and make sure nothing crashes.
+  Simulator<double> simulator(builder.Build());
+  simulator.AdvanceTo(0.25);
+}
+#pragma GCC diagnostic pop
+
 }  // namespace
 }  // namespace internal
 }  // namespace visualization

--- a/visualization/visualization_config_functions.cc
+++ b/visualization/visualization_config_functions.cc
@@ -33,8 +33,12 @@ void ApplyVisualizationConfigImpl(const VisualizationConfig& config,
                                   DrakeLcmInterface* lcm,
                                   std::shared_ptr<geometry::Meshcat> meshcat,
                                   const MultibodyPlant<double>& plant,
-                                  const SceneGraph<double>& scene_graph,
+                                  SceneGraph<double>* scene_graph,
                                   DiagramBuilder<double>* builder) {
+  DRAKE_DEMAND(lcm != nullptr);
+  DRAKE_DEMAND(scene_graph != nullptr);
+  DRAKE_DEMAND(builder != nullptr);
+
   // This is required due to ConnectContactResultsToDrakeVisualizer().
   DRAKE_THROW_UNLESS(plant.is_finalized());
 
@@ -46,10 +50,10 @@ void ApplyVisualizationConfigImpl(const VisualizationConfig& config,
     // geometry. So long as that's true, we should not enable it.
     DrakeVisualizerParams oopsie = params;
     oopsie.show_hydroelastic = false;
-    DrakeVisualizer<double>::AddToBuilder(builder, scene_graph, lcm, oopsie);
+    DrakeVisualizer<double>::AddToBuilder(builder, *scene_graph, lcm, oopsie);
   }
   if (config.publish_contacts) {
-    ConnectContactResultsToDrakeVisualizer(builder, plant, scene_graph, lcm);
+    ConnectContactResultsToDrakeVisualizer(builder, plant, *scene_graph, lcm);
   }
 
   if (meshcat == nullptr && config.enable_meshcat_creation) {
@@ -61,7 +65,7 @@ void ApplyVisualizationConfigImpl(const VisualizationConfig& config,
     const std::vector<MeshcatVisualizerParams> all_meshcat_params =
         internal::ConvertVisualizationConfigToMeshcatParams(config);
     for (const MeshcatVisualizerParams& params : all_meshcat_params) {
-      MeshcatVisualizer<double>::AddToBuilder(builder, scene_graph, meshcat,
+      MeshcatVisualizer<double>::AddToBuilder(builder, *scene_graph, meshcat,
                                               params);
     }
     if (config.publish_contacts) {
@@ -78,7 +82,7 @@ void ApplyVisualizationConfig(const VisualizationConfig& config,
                               DiagramBuilder<double>* builder,
                               const LcmBuses* lcm_buses,
                               const MultibodyPlant<double>* plant,
-                              const SceneGraph<double>* scene_graph,
+                              SceneGraph<double>* scene_graph,
                               std::shared_ptr<geometry::Meshcat> meshcat,
                               DrakeLcmInterface* lcm) {
   DRAKE_THROW_UNLESS(builder != nullptr);
@@ -96,10 +100,45 @@ void ApplyVisualizationConfig(const VisualizationConfig& config,
   }
   if (scene_graph == nullptr) {
     scene_graph =
-        &builder->GetDowncastSubsystemByName<SceneGraph>("scene_graph");
+        &builder->GetMutableDowncastSubsystemByName<SceneGraph>("scene_graph");
   }
-  ApplyVisualizationConfigImpl(config, lcm, meshcat, *plant, *scene_graph,
+  ApplyVisualizationConfigImpl(config, lcm, meshcat, *plant, scene_graph,
                                builder);
+}
+
+// This is the deprecated overload.
+void ApplyVisualizationConfig(const VisualizationConfig& config,
+                              DiagramBuilder<double>* builder,
+                              const LcmBuses* lcm_buses,
+                              const MultibodyPlant<double>* plant,
+                              const SceneGraph<double>* scene_graph,
+                              std::shared_ptr<geometry::Meshcat> meshcat,
+                              DrakeLcmInterface* lcm) {
+  DRAKE_THROW_UNLESS(builder != nullptr);
+
+  // Respell the const scene_graph pointer that the user gave us into a mutable
+  // pointer instead. This is as simple as a const_cast, but first we need to
+  // confirm that the const pointer was referring to something inside `builder`
+  // to avoid any nasty surprises later on.
+  SceneGraph<double>* mutable_scene_graph = nullptr;
+  if (scene_graph != nullptr) {
+    for (System<double>* system : builder->GetMutableSystems()) {
+      DRAKE_DEMAND(system != nullptr);
+      if (system == scene_graph) {
+        mutable_scene_graph = const_cast<SceneGraph<double>*>(scene_graph);
+        break;
+      }
+    }
+    if (mutable_scene_graph == nullptr) {
+      throw std::logic_error(
+          "The const scene_graph provided to ApplyVisualizationConfig was not "
+          "a System owned by the provided builder");
+    }
+  }
+
+  // Delegate to the mutable overload.
+  ApplyVisualizationConfig(config, builder, lcm_buses, plant,
+                           mutable_scene_graph, std::move(meshcat), lcm);
 }
 
 void AddDefaultVisualization(DiagramBuilder<double>* builder,

--- a/visualization/visualization_config_functions.h
+++ b/visualization/visualization_config_functions.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 #include <vector>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/geometry/drake_visualizer_params.h"
 #include "drake/geometry/meshcat.h"
 #include "drake/geometry/meshcat_visualizer_params.h"
@@ -95,7 +97,33 @@ void ApplyVisualizationConfig(
     const VisualizationConfig& config, systems::DiagramBuilder<double>* builder,
     const systems::lcm::LcmBuses* lcm_buses = nullptr,
     const multibody::MultibodyPlant<double>* plant = nullptr,
-    const geometry::SceneGraph<double>* scene_graph = nullptr,
+    geometry::SceneGraph<double>* scene_graph = nullptr,
+    std::shared_ptr<geometry::Meshcat> meshcat = nullptr,
+    lcm::DrakeLcmInterface* lcm = nullptr);
+
+#ifndef DRAKE_DOXYGEN_CXX
+// Deprecation shim to help interpret a scene_graph nullptr literal as mutable,
+// to avoid ambiguous overloaded function calls for users.
+// TODO(jwnimmer-tri) Remove this on 2023-09-01 upon completion of deprecation.
+inline void ApplyVisualizationConfig(
+    const VisualizationConfig& config, systems::DiagramBuilder<double>* builder,
+    const systems::lcm::LcmBuses* lcm_buses,
+    const multibody::MultibodyPlant<double>* plant,
+    std::nullptr_t /* scene_graph */,
+    std::shared_ptr<geometry::Meshcat> meshcat = nullptr,
+    lcm::DrakeLcmInterface* lcm = nullptr) {
+  ApplyVisualizationConfig(config, builder, lcm_buses, plant,
+                           static_cast<geometry::SceneGraph<double>*>(nullptr),
+                           std::move(meshcat), lcm);
+}
+#endif
+
+DRAKE_DEPRECATED("2023-09-01", "Pass a non-const SceneGraph pointer")
+void ApplyVisualizationConfig(
+    const VisualizationConfig& config, systems::DiagramBuilder<double>* builder,
+    const systems::lcm::LcmBuses* lcm_buses,
+    const multibody::MultibodyPlant<double>* plant,
+    const geometry::SceneGraph<double>* scene_graph,
     std::shared_ptr<geometry::Meshcat> meshcat = nullptr,
     lcm::DrakeLcmInterface* lcm = nullptr);
 


### PR DESCRIPTION
Towards #19210.

This commit takes the hacky version of a prototype patch I'd previously donated to that PR and turns it into a more carefully-spelled change.

Given the forthcoming release date, this probably won't make it in, so I've elected to push the deprecation removal a little further into the future since it's low-cost to extend it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19217)
<!-- Reviewable:end -->
