### PR TITLE
Exposes SAP near rigid threshold

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -972,6 +972,14 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("contact_solver"), cls_doc.set_discrete_contact_solver.doc)
         .def("get_discrete_contact_solver", &Class::get_discrete_contact_solver,
             cls_doc.get_discrete_contact_solver.doc)
+        .def("set_sap_near_rigid_threshold",
+            &Class::set_sap_near_rigid_threshold,
+            py::arg("near_rigid_threshold") =
+                MultibodyPlantConfig{}.sap_near_rigid_threshold,
+            cls_doc.set_sap_near_rigid_threshold.doc)
+        .def("get_sap_near_rigid_threshold",
+            &Class::get_sap_near_rigid_threshold,
+            cls_doc.get_sap_near_rigid_threshold.doc)
         .def_static("GetDefaultContactSurfaceRepresentation",
             &Class::GetDefaultContactSurfaceRepresentation,
             py::arg("time_step"),

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2451,6 +2451,8 @@ class TestPlant(unittest.TestCase):
         for model in models:
             plant.set_discrete_contact_solver(model)
             self.assertEqual(plant.get_discrete_contact_solver(), model)
+        plant.get_sap_near_rigid_threshold()
+        plant.set_sap_near_rigid_threshold(near_rigid_threshold=0.03)
 
     def test_contact_surface_representation(self):
         for time_step in [0.0, 0.1]:

--- a/multibody/contact_solvers/sap/sap_friction_cone_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_friction_cone_constraint.cc
@@ -22,7 +22,7 @@ SapFrictionConeConstraint<T>::SapFrictionConeConstraint(int clique,
   DRAKE_DEMAND(p.mu >= 0.0);
   DRAKE_DEMAND(p.stiffness > 0.0);
   DRAKE_DEMAND(p.dissipation_time_scale >= 0.0);
-  DRAKE_DEMAND(p.beta > 0.0);
+  DRAKE_DEMAND(p.beta >= 0.0);
   DRAKE_DEMAND(p.sigma > 0.0);
   DRAKE_DEMAND(this->first_clique_jacobian().rows() == 3);
 }
@@ -40,7 +40,7 @@ SapFrictionConeConstraint<T>::SapFrictionConeConstraint(
   DRAKE_DEMAND(p.mu >= 0.0);
   DRAKE_DEMAND(p.stiffness > 0.0);
   DRAKE_DEMAND(p.dissipation_time_scale >= 0.0);
-  DRAKE_DEMAND(p.beta > 0.0);
+  DRAKE_DEMAND(p.beta >= 0.0);
   DRAKE_DEMAND(p.sigma > 0.0);
   DRAKE_DEMAND(this->first_clique_jacobian().rows() == 3);
   DRAKE_DEMAND(this->second_clique_jacobian().rows() == 3);

--- a/multibody/contact_solvers/sap/test/sap_friction_cone_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_friction_cone_constraint_test.cc
@@ -45,7 +45,7 @@ GTEST_TEST(SapFrictionConeConstraint, SingleCliqueConstraint) {
   const double mu = 0.5;
   const double stiffness = 1.0e5;
   const double dissipation_time_scale = 0.01;
-  const double beta = 0.1;
+  const double beta = 0.0;
   const double sigma = 1.0e-4;
   const int clique = 12;
   const double phi0 = -2.5e-3;
@@ -71,7 +71,7 @@ GTEST_TEST(SapFrictionConeConstraint, TwoCliquesConstraint) {
   const double mu = 0.5;
   const double stiffness = 1.0e5;
   const double dissipation_time_scale = 0.01;
-  const double beta = 0.1;
+  const double beta = 0.0;
   const double sigma = 1.0e-4;
   const int clique0 = 12;
   const int clique1 = 13;

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -970,7 +970,10 @@ void CompliantContactManager<T>::ExtractModelInfo() {
       // plant to symbolic and perform other supported queries such as
       // introspection and kinematics.
       if constexpr (!std::is_same_v<T, symbolic::Expression>) {
-        sap_driver_ = std::make_unique<SapDriver<T>>(this);
+        const double near_rigid_threshold =
+            plant().get_sap_near_rigid_threshold();
+        sap_driver_ =
+            std::make_unique<SapDriver<T>>(this, near_rigid_threshold);
       }
       break;
     case DiscreteContactSolver::kTamsi:

--- a/multibody/plant/deformable_driver.cc
+++ b/multibody/plant/deformable_driver.cc
@@ -1,5 +1,6 @@
 #include "drake/multibody/plant/deformable_driver.h"
 
+#include <limits>
 #include <memory>
 #include <string>
 #include <unordered_set>
@@ -244,12 +245,12 @@ void DeformableDriver<T>::AppendDiscreteContactPairs(
 
   for (const DeformableContactSurface<double>& surface :
        deformable_contact.contact_surfaces()) {
-    /* We use an arbitrarily large stiffness as the default stiffness so that
-     the contact is in near-rigid regime and the compliance is only used as
-     stabilization. */
-    const double default_contact_stiffness = 1.0e12;
-    const T k = GetCombinedPointContactStiffness(
-        surface.id_A(), surface.id_B(), default_contact_stiffness, inspector);
+    /* While our discrete solvers might model constraints as compliant, an
+    infinite stiffness indicates to use the stiffest approximation possible
+    without sacrifycing numerical conditioning. SAP will use the "near rigid"
+    regime approximation in this case. */
+    const T k = std::numeric_limits<double>::infinity();
+
     // TODO(xuchenhan-tri): Currently, body_B is guaranteed to be
     // non-deformable. When we support deformable vs. deformable contact, we
     // need to update this logic for retrieving body names.

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -336,6 +336,7 @@ MultibodyPlant<T>::MultibodyPlant(const MultibodyPlant<U>& other)
     num_collision_geometries_ = other.num_collision_geometries_;
     contact_model_ = other.contact_model_;
     contact_solver_enum_ = other.contact_solver_enum_;
+    sap_near_rigid_threshold_ = other.sap_near_rigid_threshold_;
     contact_surface_representation_ = other.contact_surface_representation_;
     // geometry_query_port_ is set during DeclareSceneGraphPorts() below.
     // geometry_pose_port_ is set during DeclareSceneGraphPorts() below.
@@ -600,6 +601,19 @@ template <typename T>
 DiscreteContactSolver MultibodyPlant<T>::get_discrete_contact_solver()
     const {
   return contact_solver_enum_;
+}
+
+template <typename T>
+void MultibodyPlant<T>::set_sap_near_rigid_threshold(
+    double near_rigid_threshold) {
+  DRAKE_MBP_THROW_IF_FINALIZED();
+  DRAKE_THROW_UNLESS(near_rigid_threshold >= 0.0);
+  sap_near_rigid_threshold_ = near_rigid_threshold;
+}
+
+template <typename T>
+double MultibodyPlant<T>::get_sap_near_rigid_threshold() const {
+  return sap_near_rigid_threshold_;
 }
 
 template <typename T>

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1766,6 +1766,27 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// Returns the contact solver type used for discrete %MultibodyPlant models.
   DiscreteContactSolver get_discrete_contact_solver() const;
 
+  /// Non-negative dimensionless number typically in the range [0.0, 1.0],
+  /// though larger values are allowed even if uncommon. This parameter controls
+  /// the "near rigid" regime of the SAP solver, β in section V.B of [Castro et
+  /// al., 2021]. It essentially controls a threshold value for the maximum
+  /// amount of stiffness SAP can handle robustly. Beyond this value, stiffness
+  /// saturates as explained in [Castro et al., 2021]. A value of 1.0 is a
+  /// conservative choice to avoid ill-conditioning that might lead to softer
+  /// than expected contact. If this is your case, consider turning off this
+  /// approximation by setting this parameter to zero. For difficult cases where
+  /// ill-conditioning is a problem, a small but non-zero number can be used,
+  /// e.g. 1.0e-3.
+  /// @throws std::exception if near_rigid_threshold is negative.
+  /// @throws std::exception if called post-finalize.
+  void set_sap_near_rigid_threshold(
+      double near_rigid_threshold =
+          MultibodyPlantConfig{}.sap_near_rigid_threshold);
+
+  /// @returns the SAP near rigid regime threshold.
+  /// @see See set_sap_near_rigid_threshold().
+  double get_sap_near_rigid_threshold() const;
+
   /// Return the default value for contact representation, given the desired
   /// time step. Discrete systems default to use polygons; continuous systems
   /// default to use triangles.
@@ -5225,6 +5246,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // with the default value in multibody_plant_config.h; there are already
   // assertions in the cc file that enforce this.
   DiscreteContactSolver contact_solver_enum_{DiscreteContactSolver::kTamsi};
+
+  // Near rigid regime parameter from [Castro et al., 2021]. Refer to
+  // set_near_rigid_threshold() for details.
+  double sap_near_rigid_threshold_{
+      MultibodyPlantConfig{}.sap_near_rigid_threshold};
 
   // User's choice of the representation of contact surfaces in discrete
   // systems. The default value is dependent on whether the system is

--- a/multibody/plant/multibody_plant_config.h
+++ b/multibody/plant/multibody_plant_config.h
@@ -21,6 +21,7 @@ struct MultibodyPlantConfig {
     a->Visit(DRAKE_NVP(stiction_tolerance));
     a->Visit(DRAKE_NVP(contact_model));
     a->Visit(DRAKE_NVP(discrete_contact_solver));
+    a->Visit(DRAKE_NVP(sap_near_rigid_threshold));
     a->Visit(DRAKE_NVP(contact_surface_representation));
     a->Visit(DRAKE_NVP(adjacent_bodies_collision_filters));
   }
@@ -52,6 +53,22 @@ struct MultibodyPlantConfig {
   /// - "tamsi"
   /// - "sap"
   std::string discrete_contact_solver{"tamsi"};
+
+  // TODO(amcastro-tri): Change default to zero, or simply eliminate.
+  /// Non-negative dimensionless number typically in the range [0.0, 1.0],
+  /// though larger values are allowed even if uncommon. This parameter controls
+  /// the "near rigid" regime of the SAP solver, β in section V.B of [Castro et
+  /// al., 2021]. It essentially controls a threshold value for the maximum
+  /// amount of stiffness SAP can handle robustly. Beyond this value, stiffness
+  /// saturates as explained in [Castro et al., 2021].
+  /// A value of 1.0 is a conservative choice to avoid numerical
+  /// ill-conditioning. However, this might introduce artificial softening of
+  /// the contact constraints. If this is your case try:
+  ///   1. Set this parameter to zero.
+  ///   2. For difficult problems (hundreds of contacts for instance), you might
+  ///      need to use a low value if the solver fails to converge.
+  ///      For instance, set values in the range (1e-3, 1e-2).
+  double sap_near_rigid_threshold{1.0};
 
   /// Configures the MultibodyPlant::set_contact_surface_representation().
   /// Refer to drake::geometry::HydroelasticContactRepresentation for details.

--- a/multibody/plant/multibody_plant_config_functions.cc
+++ b/multibody/plant/multibody_plant_config_functions.cc
@@ -22,6 +22,7 @@ AddResult AddMultibodyPlant(
   result.plant.set_discrete_contact_solver(
       internal::GetDiscreteContactSolverFromString(
           config.discrete_contact_solver));
+  result.plant.set_sap_near_rigid_threshold(config.sap_near_rigid_threshold);
   result.plant.set_contact_surface_representation(
       internal::GetContactSurfaceRepresentationFromString(
           config.contact_surface_representation));

--- a/multibody/plant/sap_driver.h
+++ b/multibody/plant/sap_driver.h
@@ -57,12 +57,15 @@ class SapDriver {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SapDriver);
 
-  // The newly constructed driver is used in the given `manager` to perform
-  // discrete updates using the SAP solver. This driver will user manager
-  // services to perform solver-agnostic multibody computations, e.g. contact
-  // kinematics. The given `manager` must outlive this driver.
-  // @pre manager != nullptr.
-  explicit SapDriver(const CompliantContactManager<T>* manager);
+  // Constructs a driver with the provided `near_rigid_threshold`.
+  // This is a dimensionless positive parameter typically in the range [0.0,
+  // 1.0] that controls the amount of regularization used to avoid
+  // ill-conditioning. Refer to [Castro et al., 2021] for details. A value of
+  // zero effectively turns-off this additional regularization.
+  // @pre manager is not nullptr.
+  // @pre near_rigid_threshold is positive.
+  explicit SapDriver(const CompliantContactManager<T>* manager,
+                     double near_rigid_threshold = 1.0);
 
   void set_sap_solver_parameters(
       const contact_solvers::internal::SapSolverParameters& parameters);
@@ -217,6 +220,8 @@ class SapDriver {
   // declare additional state, cache entries, ports, etc. After construction,
   // the driver only has const access to the manager.
   const CompliantContactManager<T>* const manager_{nullptr};
+  // Near rigid regime parameter for contact constraints.
+  const double near_rigid_threshold_;
   systems::CacheIndex contact_problem_;
   // Vector of joint damping coefficients, of size plant().num_velocities().
   // This information is extracted during the call to ExtractModelInfo().

--- a/multibody/plant/test/deformable_driver_contact_test.cc
+++ b/multibody/plant/test/deformable_driver_contact_test.cc
@@ -52,7 +52,6 @@ class CompliantContactManagerTester {
 class DeformableDriverContactTest : public ::testing::Test {
  protected:
   static constexpr double kDt = 0.001;
-  static constexpr double kPointContactStiffness = 1e6;
   static constexpr double kDissipationTimeScale = 0.1;
 
   void SetUp() override {
@@ -69,8 +68,7 @@ class DeformableDriverContactTest : public ::testing::Test {
     /* Register a rigid collision geometry intersecting with the bottom half of
      the deformable octahedrons. */
     geometry::ProximityProperties proximity_prop;
-    geometry::AddContactMaterial({}, kPointContactStiffness,
-                                 CoulombFriction<double>(1.0, 1.0),
+    geometry::AddContactMaterial({}, {}, CoulombFriction<double>(1.0, 1.0),
                                  &proximity_prop);
     // TODO(xuchenhan-tri): Modify this when resolution hint is no longer used
     //  as the trigger for contact with deformable bodies.
@@ -184,8 +182,8 @@ class DeformableDriverContactTest : public ::testing::Test {
     auto geometry = make_unique<GeometryInstance>(
         RigidTransformd(), make_unique<Sphere>(1.0), move(name));
     geometry::ProximityProperties props;
-    geometry::AddContactMaterial({}, kPointContactStiffness,
-                                 CoulombFriction<double>(1.0, 1.0), &props);
+    geometry::AddContactMaterial({}, {}, CoulombFriction<double>(1.0, 1.0),
+                                 &props);
     props.AddProperty(geometry::internal::kMaterialGroup,
                       geometry::internal::kRelaxationTime,
                       kDissipationTimeScale);
@@ -407,7 +405,8 @@ TEST_F(DeformableDriverContactTest, AppendDiscreteContactPairs) {
   /* tau for deformable body is set to kDissipationTimeScale and is unset for
    rigid body (which then assumes the default value, dt). */
   constexpr double expected_tau = kDissipationTimeScale + kDt;
-  constexpr double expected_k = kPointContactStiffness / 2.0;
+  // Stiffness is set to infinity for deformable contact pairs.
+  constexpr double expected_k = std::numeric_limits<double>::infinity();
   GeometryId id0 = model_->GetGeometryId(body_id0_);
   GeometryId id1 = model_->GetGeometryId(body_id1_);
 

--- a/multibody/plant/test/multibody_plant_config_functions_test.cc
+++ b/multibody/plant/test/multibody_plant_config_functions_test.cc
@@ -17,6 +17,7 @@ GTEST_TEST(MultibodyPlantConfigFunctionsTest, BasicTest) {
   config.time_step = 0.002;
   config.penetration_allowance = 0.003;
   config.stiction_tolerance = 0.004;
+  config.sap_near_rigid_threshold = 0.1;
   config.contact_model = "hydroelastic";
   config.contact_surface_representation = "polygon";
   config.adjacent_bodies_collision_filters = false;
@@ -24,8 +25,8 @@ GTEST_TEST(MultibodyPlantConfigFunctionsTest, BasicTest) {
   drake::systems::DiagramBuilder<double> builder;
   auto result = AddMultibodyPlant(config, &builder);
   EXPECT_EQ(result.plant.time_step(), 0.002);
-  EXPECT_EQ(result.plant.get_contact_model(),
-            ContactModel::kHydroelasticsOnly);
+  EXPECT_EQ(result.plant.get_sap_near_rigid_threshold(), 0.1);
+  EXPECT_EQ(result.plant.get_contact_model(), ContactModel::kHydroelasticsOnly);
   EXPECT_EQ(result.plant.get_contact_surface_representation(),
             geometry::HydroelasticContactRepresentation::kPolygon);
   EXPECT_EQ(result.plant.get_adjacent_bodies_collision_filters(), false);
@@ -39,6 +40,7 @@ penetration_allowance: 0.003
 stiction_tolerance: 0.004
 contact_model: hydroelastic
 discrete_contact_solver: sap
+sap_near_rigid_threshold: 0.01
 contact_surface_representation: triangle
 adjacent_bodies_collision_filters: false
 )""";
@@ -48,12 +50,12 @@ GTEST_TEST(MultibodyPlantConfigFunctionsTest, YamlTest) {
   drake::systems::DiagramBuilder<double> builder;
   auto result = AddMultibodyPlant(config, &builder);
   EXPECT_EQ(result.plant.time_step(), 0.002);
-  EXPECT_EQ(result.plant.get_contact_model(),
-            ContactModel::kHydroelasticsOnly);
+  EXPECT_EQ(result.plant.get_contact_model(), ContactModel::kHydroelasticsOnly);
   EXPECT_EQ(result.plant.get_contact_surface_representation(),
             geometry::HydroelasticContactRepresentation::kTriangle);
   EXPECT_EQ(result.plant.get_discrete_contact_solver(),
             DiscreteContactSolver::kSap);
+  EXPECT_EQ(result.plant.get_sap_near_rigid_threshold(), 0.01);
   EXPECT_EQ(result.plant.get_adjacent_bodies_collision_filters(), false);
   // There is no getter for penetration_allowance nor stiction_tolerance, so we
   // can't test them.

--- a/multibody/plant/test/sap_driver_test.cc
+++ b/multibody/plant/test/sap_driver_test.cc
@@ -185,10 +185,10 @@ TEST_F(SpheresStackTest, EvalContactProblemCache) {
     EXPECT_EQ(constraint->parameters().stiffness, discrete_pair.stiffness);
     EXPECT_EQ(constraint->parameters().dissipation_time_scale,
               discrete_pair.dissipation_time_scale);
-    // These two parameters, beta and sigma, are for now hard-code in the
-    // manager to these values. Here we simply tests they are consistent with
-    // those hard-coded values.
-    EXPECT_EQ(constraint->parameters().beta, 1.0);
+    EXPECT_EQ(constraint->parameters().beta,
+              plant_->get_sap_near_rigid_threshold());
+    // This parameter sigma is for now hard-code in the manager to these value.
+    // Here we simply test they are consistent with those hard-coded values.
     EXPECT_EQ(constraint->parameters().sigma, 1.0e-3);
 
     // Verify contact frame orientation matrix R_WC.


### PR DESCRIPTION
This PR exposes the parameter that controls the "near rigid" approximation used by SAP.
This parameter is used to avoid ill-conditioning for very stiff contact models. It turns out that our default value is too conservative and often leads to softened contact constraints. This is specially true in models with large mass ratios, typically gripper fingers on a much massive robot. 

While we should probably set this parameter to zero by default (meaning no near rigid conditioning), this PR simply exposes this parameters so that they can set it to zero themselves in cases for which softening is observed.

Marking high priority since several users run into this kind of problems.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19218)
<!-- Reviewable:end -->
