### PR TITLE
[geometry] MeshcatVisualizer can filter geometry via property

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -590,6 +590,7 @@ drake_cc_library(
 drake_cc_googletest(
     name = "meshcat_visualizer_test",
     data = [
+        "//geometry/render:test_models",
         "//manipulation/models/iiwa_description:models",
         "//multibody/meshcat:models",
     ],

--- a/geometry/meshcat_visualizer.cc
+++ b/geometry/meshcat_visualizer.cc
@@ -175,21 +175,28 @@ void MeshcatVisualizer<T>::SetObjects(
     while ((pos = frame_path.find("::", pos)) != std::string::npos) {
       frame_path.replace(pos++, 2, "/");
     }
-    if (frame_id != inspector.world_frame_id() &&
-        inspector.NumGeometriesForFrameWithRole(frame_id, params_.role) > 0) {
-      dynamic_frames_[frame_id] = frame_path;
-      frames_to_delete.erase(frame_id);  // Don't delete this one.
-    }
 
+    bool frame_has_any_geometry = false;
     for (GeometryId geom_id : inspector.GetGeometries(frame_id, params_.role)) {
+      const GeometryProperties& properties =
+          *inspector.GetProperties(geom_id, params_.role);
+      if (properties.HasProperty("meshcat", "accepting")) {
+        if (properties.GetProperty<std::string>("meshcat", "accepting") !=
+            params_.prefix) {
+          continue;
+        }
+      } else if (!params_.include_unspecified_accepting) {
+        continue;
+      }
+
       // Note: We use the frame_path/id instead of instance.GetName(geom_id),
       // which is a garbled mess of :: and _ and a memory address by default
       // when coming from MultibodyPlant.
       // TODO(russt): Use the geometry names if/when they are cleaned up.
       const std::string path =
           fmt::format("{}/{}", frame_path, geom_id.get_value());
-      const Rgba rgba = inspector.GetProperties(geom_id, params_.role)
-          ->GetPropertyOrDefault("phong", "diffuse", params_.default_color);
+      const Rgba rgba = properties.GetPropertyOrDefault("phong", "diffuse",
+                                                        params_.default_color);
       bool used_hydroelastic = false;
       if constexpr (std::is_same_v<T, double>) {
         if (params_.show_hydroelastic) {
@@ -217,6 +224,12 @@ void MeshcatVisualizer<T>::SetObjects(
       geometries_[geom_id] = path;
       colors_[geom_id] = rgba;
       geometries_to_delete.erase(geom_id);  // Don't delete this one.
+      frame_has_any_geometry = true;
+    }
+
+    if (frame_has_any_geometry && (frame_id != inspector.world_frame_id())) {
+      dynamic_frames_[frame_id] = frame_path;
+      frames_to_delete.erase(frame_id);  // Don't delete this one.
     }
   }
 

--- a/geometry/meshcat_visualizer_params.h
+++ b/geometry/meshcat_visualizer_params.h
@@ -23,6 +23,7 @@ struct MeshcatVisualizerParams {
     a->Visit(DRAKE_NVP(enable_alpha_slider));
     a->Visit(DRAKE_NVP(visible_by_default));
     a->Visit(DRAKE_NVP(show_hydroelastic));
+    a->Visit(DRAKE_NVP(include_unspecified_accepting));
   }
 
   /** The duration (in simulation seconds) between attempts to update poses in
@@ -73,6 +74,13 @@ struct MeshcatVisualizerParams {
   This option is ignored by MeshcatVisualizer<T> when T is not `double`, e.g.
   if T == AutoDiffXd. */
   bool show_hydroelastic{false};
+
+  /** (Advanced) For a given geometry, if the GeometryProperties for our `role`
+   has the property `(meshcat, accepting)` then the visualizer will show the
+   geometry only if the property's value matches our `prefix`. If that property
+   is absent then the geometry will be shown only if
+   `include_unspecified_accepting` is true. */
+  bool include_unspecified_accepting{true};
 };
 
 }  // namespace geometry

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -16,6 +16,8 @@ namespace drake {
 namespace geometry {
 namespace {
 
+using multibody::AddMultibodyPlantSceneGraph;
+
 // The tests in this file require a dependency on MultibodyPlant.  One could
 // implement the tests without that dependency, but not without duplicating (or
 // sharing) a significant amount of setup code like we see in
@@ -37,8 +39,7 @@ class MeshcatVisualizerWithIiwaTest : public ::testing::Test {
 
   void SetUpDiagram(MeshcatVisualizerParams params = {}) {
     systems::DiagramBuilder<double> builder;
-    auto [plant, scene_graph] =
-        multibody::AddMultibodyPlantSceneGraph(&builder, 0.001);
+    auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.001);
     plant_ = &plant;
     scene_graph_ = &scene_graph;
     multibody::Parser(plant_).AddModels(
@@ -344,8 +345,7 @@ GTEST_TEST(MeshcatVisualizerTest, HydroGeometry) {
   for (bool show_hydroelastic : {false, true}) {
     // Load a scene with hydroelastic geometry.
     systems::DiagramBuilder<double> builder;
-    auto [plant, scene_graph] =
-        multibody::AddMultibodyPlantSceneGraph(&builder, 0.001);
+    auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.001);
     multibody::Parser(&plant).AddModelsFromUrl(
         "package://drake/multibody/meshcat/test/hydroelastic.sdf");
     plant.Finalize();
@@ -389,8 +389,7 @@ GTEST_TEST(MeshcatVisualizerTest, MultipleModels) {
   auto meshcat = std::make_shared<Meshcat>();
 
   systems::DiagramBuilder<double> builder;
-  auto [plant, scene_graph] =
-      multibody::AddMultibodyPlantSceneGraph(&builder, 0.001);
+  auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.001);
   std::string urdf = FindResourceOrThrow(
       "drake/manipulation/models/iiwa_description/urdf/"
       "iiwa14_no_collision.urdf");
@@ -430,6 +429,61 @@ GTEST_TEST(MeshcatVisualizerTest, MultipleModels) {
     EXPECT_NE(meshcat->GetPackedTransform(fmt::format(
                   "/drake/visualizer/second/iiwa14/iiwa_link_{}", link)),
               "");
+  }
+}
+
+// Use geometry properties to control which geometry is shown.
+GTEST_TEST(MeshcatVisualizerTest, AcceptingProperty) {
+  for (bool include_unspecified_accepting : {true, false}) {
+    for (const std::string accepting : {"", "prefix", "no_match"}) {
+      SCOPED_TRACE(fmt::format("include_unspecified = {}, accepting_str = {}",
+                               include_unspecified_accepting,
+                               accepting.empty() ? "null" : accepting.c_str()));
+
+      // Load a simple model with one geometry.
+      auto meshcat = std::make_shared<Meshcat>();
+      systems::DiagramBuilder<double> builder;
+      auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.001);
+      multibody::Parser(&plant).AddModelsFromUrl(
+          "package://drake/geometry/render/test/box.sdf");
+      plant.Finalize();
+
+      // Add the accepting tag (if given) to the geometry.
+      auto& inspector = scene_graph.model_inspector();
+      const FrameId body_frame =
+          plant.GetBodyFrameIdOrThrow(plant.GetBodyByName("box").index());
+      const auto geom_ids =
+          inspector.GetGeometries(body_frame, Role::kIllustration);
+      DRAKE_DEMAND(geom_ids.size() == 1);
+      const GeometryId geom_id = *geom_ids.begin();
+      const IllustrationProperties* old_props =
+          scene_graph.model_inspector().GetIllustrationProperties(geom_id);
+      DRAKE_DEMAND(old_props != nullptr);
+      if (!accepting.empty()) {
+        IllustrationProperties new_props(*old_props);
+        new_props.AddProperty("meshcat", "accepting", accepting);
+        scene_graph.AssignRole(*plant.get_source_id(), geom_id, new_props,
+                               RoleAssign::kReplace);
+      }
+
+      // Create the visualizer.
+      MeshcatVisualizerParams params;
+      params.include_unspecified_accepting = include_unspecified_accepting;
+      params.prefix = "prefix";
+      MeshcatVisualizer<double>::AddToBuilder(&builder, scene_graph, meshcat,
+                                              params);
+      auto diagram = builder.Build();
+      auto context = diagram->CreateDefaultContext();
+
+      // Publish geometry. Check whether the shape was published.
+      const std::string geom_path =
+          fmt::format("prefix/box/box/{}", geom_id.get_value());
+      const bool should_show =
+          (accepting == "prefix") ||
+          (include_unspecified_accepting && accepting.empty());
+      diagram->ForcedPublish(*context);
+      EXPECT_EQ(meshcat->HasPath(geom_path), should_show);
+    }
   }
 }
 


### PR DESCRIPTION
Towards https://github.com/RobotLocomotion/drake/pull/19210.

This commit takes the hacky version of a prototype patch I'd previously donated to that PR and turns it into a more carefully-spelled change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19220)
<!-- Reviewable:end -->
