### PR TITLE
Throw an error when Riccati equation is not solved for continuous time system.

### DIFF
--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -361,6 +361,7 @@ drake_cc_googletest(
     deps = [
         ":continuous_algebraic_riccati_equation",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/math/continuous_algebraic_riccati_equation.cc
+++ b/math/continuous_algebraic_riccati_equation.cc
@@ -22,13 +22,32 @@ Eigen::MatrixXd ContinuousAlgebraicRiccatiEquation(
   Eigen::MatrixXd H(2 * n, 2 * n);
 
   H << A, B * R_cholesky.solve(B.transpose()), Q, -A.transpose();
+  // For the closed-loop system ẋ = (A+BK)x (where K is the LQR controller
+  // gain), we denote the eigenvalues of A+BK as λ₁, ..., λₙ, then with Q
+  // satisfying the algebraic Riccati equation, the eigenvalues of H are λ₁,
+  // ..., λₙ and -λ₁, ..., -λₙ (refer to
+  // https://stanford.edu/class/ee363/lectures/clqr.pdf for more details). Since
+  // the LQR gains should stabilize the closed-loop system, we know that the
+  // real parts of λ₁, ..., λₙ should be strictly negative. Hence half of the
+  // eigenvalues of H should have strictly negative real parts, and the other
+  // half have strictly positive real parts.
+  if (H.determinant() == 0) {
+    // If H.determinant() is 0, then H must have at least one eigenvalue being
+    // 0, contradicting to the requirement on H.
+    throw std::runtime_error(
+        "ContinuousAlgebraicRiccatiEquation fails. The Hamiltonian is not "
+        "invertible. Either your (A, B) is not stabilizable, or (Q, A) is not "
+        "detectable.");
+    // TODO(hongkai.dai): actually check if (A, B) is stabilizable and (Q, A) is
+    // detectable.
+  }
 
   Eigen::MatrixXd Z = H;
   Eigen::MatrixXd Z_old;
 
   // these could be options
   const double tolerance = 1e-9;
-  const double max_iterations = 100;
+  const int max_iterations = 100;
 
   double relative_norm;
   size_t iteration = 0;

--- a/math/continuous_algebraic_riccati_equation.h
+++ b/math/continuous_algebraic_riccati_equation.h
@@ -12,7 +12,16 @@ namespace math {
 /// S A + A' S - S B R^{-1} B' S + Q = 0
 /// @f]
 ///
+/// @throws std::exception if the Hamiltanoian matrix
+/// <pre>
+/// ⌈A   BR⁻¹Bᵀ⌉
+/// ⌊Q      −Aᵀ⌋
+/// </pre>
+/// is not invertible.
 /// @throws std::exception if R is not positive definite.
+/// @note the pair (A, B) should be stabilizable, and (Q, A) should be
+/// detectable. For more information, please refer to page 526-527 of Linear
+/// Systems by Thomas Kailath.
 ///
 /// Based on the Matrix Sign Function method outlined in this paper:
 /// http://www.engr.iupui.edu/~skoskie/ECE684/Riccati_algorithms.pdf

--- a/math/test/continuous_algebraic_riccati_equation_test.cc
+++ b/math/test/continuous_algebraic_riccati_equation_test.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 
 using Eigen::MatrixXd;
 
@@ -58,6 +59,77 @@ GTEST_TEST(CARE, TestCare2) {
   Q << 1, 0, 0, 1;
   R1 << 1;
   SolveCAREandVerify(A1, B1, Q, R1);
+}
+
+// This test case is reported in
+// https://github.com/RobotLocomotion/drake/issues/19191
+GTEST_TEST(CARE, TestUndetectable) {
+  // The pair (Q, A) is not detectable. Hence the continuous algebraic Riccati
+  // equation will fail.
+  Eigen::MatrixXd A = Eigen::MatrixXd::Zero(12, 12);
+  A.topRightCorner<6, 6>() = Eigen::MatrixXd::Identity(6, 6);
+  A(6, 0) = -12;
+  A(6, 4) = 9;
+  A(7, 5) = -9;
+
+  Eigen::MatrixXd B = Eigen::MatrixXd::Zero(12, 4);
+  // clang-format off
+  B.bottomRows<4>() << 1, 1, 1, 1,
+                       7, -7, 7, -7,
+                       -59, 0, 59, 0,
+                       0, 99, 0, -99;
+  // clang-format on
+  Eigen::MatrixXd Q = Eigen::MatrixXd::Zero(12, 12);
+  Q(0, 0) = 10;
+  Q(1, 1) = 10;
+  Q(2, 2) = 10;
+  Eigen::MatrixXd R = Eigen::Matrix4d::Identity();
+  DRAKE_EXPECT_THROWS_MESSAGE(ContinuousAlgebraicRiccatiEquation(A, B, Q, R),
+                              "ContinuousAlgebraicRiccatiEquation fails.*");
+
+  // Test an example in which (A, B) is stabilizable and (Q, A) is detectable
+  // but (Q, A) is not observable. The example was created by Thomas Cohn in
+  // https://github.com/RobotLocomotion/drake/pull/19222#issuecomment-1516939077
+  A.resize(3, 3);
+  // clang-format off
+  A << 0, 1, 0,
+       0, 0, 1,
+       -1, -1, -1;
+  // clang-format on
+  B.resize(3, 1);
+  B << 0, 0, 1;
+  Q.resize(3, 3);
+  // clang-format off
+  Q << 1, 1, 0,
+       1, 1, 0,
+       0, 0, 0;
+  // clang-format on
+  R.resize(1, 1);
+  R << 1;
+  SolveCAREandVerify(A, B, Q, R);
+}
+
+GTEST_TEST(Care, TestUnstabilizable) {
+  // The pair (A, B) is not stabilizable.
+  Eigen::Matrix2d A;
+  // clang-format off
+  A << 0, 1,
+       0, 0;
+  // clang-format on
+  Eigen::Vector2d B(1, 0);
+  Eigen::Matrix2d Q = Eigen::Matrix2d::Identity();
+  Eigen::Matrix<double, 1, 1> R(1);
+  DRAKE_EXPECT_THROWS_MESSAGE(ContinuousAlgebraicRiccatiEquation(A, B, Q, R),
+                              "ContinuousAlgebraicRiccatiEquation fails.*");
+
+  // The pair (A, B) is stabilizable (but not controllable), so the Riccati
+  // equation should have a solution.
+  // clang-format off
+  A << -11, 30,
+       -4, 11;
+  // clang-format on
+  B << 10, 4;
+  SolveCAREandVerify(A, B, Q, R);
 }
 
 }  // namespace

--- a/systems/controllers/linear_quadratic_regulator.h
+++ b/systems/controllers/linear_quadratic_regulator.h
@@ -35,6 +35,8 @@ struct LinearQuadraticRegulatorResult {
 /// quadratic cost term S. The optimal feedback control is u = -Kx;
 ///
 /// @throws std::exception if R is not positive definite.
+/// @note The system (A₁, B) should be stabilizable, where A₁=A−BR⁻¹Nᵀ.
+/// @note The system (Q₁, A₁) should be detectable, where Q₁=Q−NR⁻¹Nᵀ.
 /// @ingroup control
 /// @pydrake_mkdoc_identifier{AB}
 ///


### PR DESCRIPTION
Riccati equation might not have a finite solution if the system is not stabilizable, or Q and R matrices are not positive definite.

Resolves #19191 
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19222)
<!-- Reviewable:end -->
