### PR TITLE
[doc] Link from SpatialInertia to CalcSpatialInertia of meshes

### DIFF
--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -87,8 +87,13 @@ namespace multibody {
 /// checks are not performed when T is symbolic::Expression.
 ///
 /// @see To create a spatial inertia of a mesh, see
-/// @ref CalcSpatialInertia(const geometry::TriangleSurfaceMesh<double>&,
-///                         double).
+/// @ref CalcSpatialInertia(const geometry::TriangleSurfaceMesh<double>& mesh, double density). <!--# NOLINT-->
+///
+/// @see To create spatial inertia from most of geometry::Shape, see
+/// @ref CalcSpatialInertia(const geometry::Shape& shape, double density).
+///
+/// @see To create spatial inertia for a set of bodies, see
+/// @ref MultibodyPlant::CalcSpatialInertia().
 ///
 /// - [Jain 2010]  Jain, A., 2010. Robot and multibody dynamics: analysis and
 ///                algorithms. Springer Science & Business Media.

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -86,6 +86,10 @@ namespace multibody {
 /// which drake::scalar_predicate<T>::is_bool is `true`. For instance, validity
 /// checks are not performed when T is symbolic::Expression.
 ///
+/// @see To create a spatial inertia of a mesh, see
+/// @ref CalcSpatialInertia(const geometry::TriangleSurfaceMesh<double>&,
+///                         double).
+///
 /// - [Jain 2010]  Jain, A., 2010. Robot and multibody dynamics: analysis and
 ///                algorithms. Springer Science & Business Media.
 ///


### PR DESCRIPTION
I was working on SDFormat files and browsed documentation of [SpatialInertia](https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_spatial_inertia.html) and saw useful functions to help me set `<inertial>` blocks for HollowSphere, SolidBox, SolidCapsule, etc.  However, I didn't find the function for meshes.

I propose to make a doxygen link from SpatialInertia to CalcSpatialInertia(mesh).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19226)
<!-- Reviewable:end -->
