### PR TITLE
Extend DRAKE_THROW_UNLESS with value arguments

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -801,8 +801,10 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "drake_throw_test",
     deps = [
+        ":autodiff",
         ":essential",
         "//common/test_utilities:expect_no_throw",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/common/drake_assert_and_throw.cc
+++ b/common/drake_assert_and_throw.cc
@@ -50,10 +50,23 @@ void Abort(const char* condition, const char* func, const char* file,
 }
 
 // Declared in drake_throw.h.
+// If the suffix should end with punctuation, the caller must provide it.
 void Throw(const char* condition, const char* func, const char* file,
-           int line) {
+           int line, std::string_view suffix) {
   std::ostringstream what;
   PrintFailureDetailTo(what, condition, func, file, line);
+  if (!suffix.empty()) {
+    what << " " << suffix;
+  }
+  throw assertion_error(what.str().c_str());
+}
+
+// Declared in drake_throw.h.
+void ThrowWithSuffix(const std::string& condition, const char* func,
+                     const char* file, int line, const std::string& suffix) {
+  std::ostringstream what;
+  PrintFailureDetailTo(what, condition.c_str(), func, file, line);
+  what << " " << suffix;
   throw assertion_error(what.str().c_str());
 }
 

--- a/common/drake_throw.h
+++ b/common/drake_throw.h
@@ -1,37 +1,104 @@
 #pragma once
 
+#include <string>
 #include <type_traits>
+#include <vector>
+
+#include <fmt/format.h>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/fmt_eigen.h"
 
-/// @file
-/// Provides a convenient wrapper to throw an exception when a condition is
-/// unmet.  This is similar to an assertion, but uses exceptions instead of
-/// ::abort(), and cannot be disabled.
+/** @file
+ Provides a convenient wrapper to throw an exception when a condition is
+ unmet.  This is similar to an assertion, but uses exceptions instead of
+ ::abort(), and cannot be disabled.
+ */
 
 namespace drake {
 namespace internal {
 // Throw an error message.
 [[noreturn]] void Throw(const char* condition, const char* func,
-                        const char* file, int line);
+                        const char* file, int line,
+                        std::string_view suffix = std::string_view());
+
+/* The following infrastructure lets us iterate through a list of macro variadic
+ arguments (up to length four).
+ See https://codecraft.co/2014/11/25/variadic-macros-tricks/ for explanation.
+*/
+
+// Support up to *four* variadic arguments.
+#define _GET_NTH_ARG(_1, _2, _3, _4, N, ...) N
+// Macros for encoding a value expression into its value. _e is short for
+// _encode.
+#define _e(s, x) ::drake::internal::RecordExpressionValue(#x, x, s);
+#define _e_0(...)
+#define _e_1(s, value) _e(s, value)
+#define _e_2(s, value, ...) _e(s, value) _e_1(s, __VA_ARGS__)
+#define _e_3(s, value, ...) _e(s, value) _e_2(s, __VA_ARGS__)
+#define _e_4(s, value, ...) _e(s, value) _e_3(s, __VA_ARGS__)
+
+#define ENCODE_EACH(s, ...)                                                   \
+    /* NOLINTNEXTLINE(whitespace/comma) */                                    \
+    _GET_NTH_ARG(__VA_ARGS__ __VA_OPT__(,) _e_4, _e_3, _e_2, _e_1, _e_0)      \
+        (s, __VA_ARGS__)
+
+
+// Records the spelling of an expression and its reported value as:
+//
+//   expr = value
+//
+// adding it to the vector of recorded expression values.
+template <typename T>
+void RecordExpressionValue(const char* expr, const T& value,
+                           std::vector<std::string>* recorded) {
+  std::string value_s;
+  if constexpr (::drake::is_eigen_type<T>::value) {
+    value_s = fmt::format("{}", fmt_eigen(value));
+  } else {
+    if constexpr (std::is_convertible_v<T, std::string>) {
+      // Give string-like values surrounding quotes.
+      value_s = fmt::format("\"{}\"", value);
+    } else {
+      value_s = fmt::format("{}", value);
+    }
+  }
+  recorded->emplace_back(fmt::format("{} = {}", expr, value_s));
+}
+
+[[noreturn]] void ThrowWithSuffix(const std::string& condition,
+                                  const char* func, const char* file, int line,
+                                  const std::string& suffix);
 }  // namespace internal
 }  // namespace drake
 
-/// Evaluates @p condition and iff the value is false will throw an exception
-/// with a message showing at least the condition text, function name, file,
-/// and line.
-///
-/// The condition must not be a pointer, where we'd implicitly rely on its
-/// nullness. Instead, always write out "!= nullptr" to be precise.
-///
-/// Correct: `DRAKE_THROW_UNLESS(foo != nullptr);`
-/// Incorrect: `DRAKE_THROW_UNLESS(foo);`
-///
-/// Because this macro is intended to provide a useful exception message to
-/// users, we should err on the side of extra detail about the failure. The
-/// meaning of "foo" isolated within error message text does not make it
-/// clear that a null pointer is the proximate cause of the problem.
-#define DRAKE_THROW_UNLESS(condition)                                         \
+/** Evaluates @p condition and iff the value is false will throw an exception
+ with a message showing at least the condition text, function name, file,
+ and line.
+
+ In addition to the @p condition, up to four value expressions can be provided.
+ Each value expression and its value will be included in the error message. For
+ example:
+
+    `DRAKE_THROW_UNLESS(v1.norm() == 1, v1, v1.norm());`
+
+ Will include the the values of the vector v1 as well as its norm in the
+ message. If too many value expressions are specified, this will most likely
+ produce a compiler error referencing "ENCODE_EACH".
+
+ The condition must not be a pointer, where we'd implicitly rely on its
+ nullness. Instead, always write out "!= nullptr" to be precise.
+
+ Correct: `DRAKE_THROW_UNLESS(foo != nullptr);`
+ Incorrect: `DRAKE_THROW_UNLESS(foo);`
+
+ Because this macro is intended to provide a useful exception message to
+ users, we should err on the side of extra detail about the failure. The
+ meaning of "foo" isolated within error message text does not make it
+ clear that a null pointer is the proximate cause of the problem.
+ */
+#define DRAKE_THROW_UNLESS(condition, ...)                                    \
   do {                                                                        \
     typedef ::drake::assert::ConditionTraits<                                 \
         typename std::remove_cv_t<decltype(condition)>> Trait;                \
@@ -42,6 +109,11 @@ namespace internal {
         "DRAKE_THROW_UNLESS(foo != nullptr), do not write DRAKE_THROW_UNLESS" \
         "(foo) and rely on implicit pointer-to-bool conversion.");            \
     if (!Trait::Evaluate(condition)) {                                        \
-      ::drake::internal::Throw(#condition, __func__, __FILE__, __LINE__);     \
+      std::vector<std::string> expr_strings;                                  \
+      ENCODE_EACH(&expr_strings, __VA_ARGS__);        \
+      ::drake::internal::Throw(                                               \
+          #condition, __func__, __FILE__, __LINE__,                           \
+          fmt::format("{}{}", fmt::join(expr_strings, ", "),                  \
+                      expr_strings.size() > 0 ? "." : ""));                   \
     }                                                                         \
   } while (0)

--- a/common/test/drake_throw_test.cc
+++ b/common/test/drake_throw_test.cc
@@ -1,16 +1,82 @@
 #include "drake/common/drake_throw.h"
 
 #include <stdexcept>
+#include <string>
 
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_no_throw.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 
 namespace {
 
 GTEST_TEST(DrakeThrowTest, BasicTest) {
   DRAKE_EXPECT_NO_THROW(DRAKE_THROW_UNLESS(true));
   EXPECT_THROW(DRAKE_THROW_UNLESS(false), std::runtime_error);
+}
+
+// The test tests two things:
+//
+//   1. Provided value expressions get encoded as expected.
+//   2. Regression guaranteeing that four value expressions are supported.
+//
+// If we have hiccups with value expressions of various types, these tests can
+// be extended to explicitly test those types.
+GTEST_TEST(DrakeThrowTest, ThrowWithValues) {
+  // Create a collection of lvalues.
+  const std::string msg = "a string";
+  const double d = 7;
+  const int i = 13;
+  const char bytes[] = "beef";
+  // const Eigen::Vector3d bytes(1, 2, 3);
+
+  // Ensure it works with up to four values.
+  DRAKE_EXPECT_NO_THROW(DRAKE_THROW_UNLESS(true, d));
+  DRAKE_EXPECT_NO_THROW(DRAKE_THROW_UNLESS(true, d, i));
+  DRAKE_EXPECT_NO_THROW(DRAKE_THROW_UNLESS(true, d, i, msg));
+  DRAKE_EXPECT_NO_THROW(DRAKE_THROW_UNLESS(true, d, i, msg, bytes));
+
+  // Note: Our DRAKE_EXPECT_THROWS_MESSAGE doesn't like the do {} while(0) body
+  // of the DRAKE_THROW_UNLESS expression. To placate it, we place the
+  // invocation in a lambda to make things happier.
+  auto f1 = [&](int count) {
+    switch (count) {
+      case 1:
+        DRAKE_THROW_UNLESS(false, d);
+        return;
+      case 2:
+        DRAKE_THROW_UNLESS(false, d, msg);
+        return;
+      case 3:
+        DRAKE_THROW_UNLESS(false, d, msg, i);
+        return;
+      case 4:
+        DRAKE_THROW_UNLESS(false, d, msg, i, bytes);
+        return;
+    }
+    DRAKE_UNREACHABLE();
+  };
+
+  DRAKE_EXPECT_THROWS_MESSAGE(f1(1), ".*d = 7.");
+  DRAKE_EXPECT_THROWS_MESSAGE(f1(2), ".*d = 7, msg = \"a string\".");
+  DRAKE_EXPECT_THROWS_MESSAGE(f1(3), ".*d = 7, msg = \"a string\", i = 13.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      f1(4), ".*d = 7, msg = \"a string\", i = 13, bytes = \"beef\".");
+}
+
+GTEST_TEST(DrakeThrowTest, ThrowWithEigenValues) {
+  const std::string details = "These are details";
+  const Eigen::Vector3d v1(1, 2, 3);
+
+  auto f1 = [&]() {
+    DRAKE_THROW_UNLESS(false, v1, details);
+  };
+  DRAKE_EXPECT_THROWS_MESSAGE(f1(), ".*v1 = 1\n2\n3, details = .*");
+
+  auto f2 = [&]() {
+    DRAKE_THROW_UNLESS(false, v1.transpose(), details);
+  };
+  DRAKE_EXPECT_THROWS_MESSAGE(f2(), ".*v1.transpose.. = 1 2 3, details = .*");
 }
 
 }  // namespace

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/shape_specification.h"
 
 #include <algorithm>
+#include <cmath>
 #include <filesystem>
 #include <limits>
 
@@ -13,6 +14,13 @@
 
 namespace drake {
 namespace geometry {
+namespace {
+
+bool is_positive_finite(double value) {
+  return std::isfinite(value) && value > 0;
+}
+
+}
 
 using math::RigidTransform;
 
@@ -44,12 +52,9 @@ Shape::Shape(ShapeTag<S>) {
 Box::Box(double width, double depth, double height)
     : Shape(ShapeTag<Box>()),
       size_(width, depth, height) {
-  if (width <= 0 || depth <= 0 || height <= 0) {
-    throw std::logic_error(
-        fmt::format("Box width, depth, and height should all be > 0 (were {}, "
-                    "{}, and {}, respectively).",
-                    width, depth, height));
-  }
+  DRAKE_THROW_UNLESS(is_positive_finite(width), width);
+  DRAKE_THROW_UNLESS(is_positive_finite(depth), depth);
+  DRAKE_THROW_UNLESS(is_positive_finite(height), height);
 }
 
 Box::Box(const Vector3<double>& measures)
@@ -61,12 +66,8 @@ Box Box::MakeCube(double edge_size) {
 
 Capsule::Capsule(double radius, double length)
     : Shape(ShapeTag<Capsule>()), radius_(radius), length_(length) {
-  if (radius <= 0 || length <= 0) {
-    throw std::logic_error(
-        fmt::format("Capsule radius and length should both be > 0 (were {} "
-                    "and {}, respectively).",
-                    radius, length));
-  }
+  DRAKE_THROW_UNLESS(is_positive_finite(radius), radius);
+  DRAKE_THROW_UNLESS(is_positive_finite(length), length);
 }
 
 Capsule::Capsule(const Vector2<double>& measures)
@@ -76,21 +77,15 @@ Convex::Convex(const std::string& filename, double scale)
     : Shape(ShapeTag<Convex>()),
       filename_(std::filesystem::absolute(filename)),
       scale_(scale) {
-  if (std::abs(scale) < 1e-8) {
-    throw std::logic_error("Convex |scale| cannot be < 1e-8.");
-  }
+  DRAKE_THROW_UNLESS(std::isfinite(scale) && std::abs(scale) >= 1e-8, scale);
 }
 
 Cylinder::Cylinder(double radius, double length)
     : Shape(ShapeTag<Cylinder>()),
       radius_(radius),
       length_(length) {
-  if (radius <= 0 || length <= 0) {
-    throw std::logic_error(
-        fmt::format("Cylinder radius and length should both be > 0 (were {} "
-                    "and {}, respectively).",
-                    radius, length));
-  }
+  DRAKE_THROW_UNLESS(is_positive_finite(radius), radius);
+  DRAKE_THROW_UNLESS(is_positive_finite(length), length);
 }
 
 Cylinder::Cylinder(const Vector2<double>& measures)
@@ -98,12 +93,9 @@ Cylinder::Cylinder(const Vector2<double>& measures)
 
 Ellipsoid::Ellipsoid(double a, double b, double c)
     : Shape(ShapeTag<Ellipsoid>()), radii_(a, b, c) {
-  if (a <= 0 || b <= 0 || c <= 0) {
-    throw std::logic_error(
-        fmt::format("Ellipsoid lengths of principal semi-axes a, b, and c "
-                    "should all be > 0 (were {}, {}, and {}, respectively).",
-                    a, b, c));
-  }
+  DRAKE_THROW_UNLESS(is_positive_finite(a), a);
+  DRAKE_THROW_UNLESS(is_positive_finite(b), b);
+  DRAKE_THROW_UNLESS(is_positive_finite(c), c);
 }
 
 Ellipsoid::Ellipsoid(const Vector3<double>& measures)
@@ -146,19 +138,14 @@ Mesh::Mesh(const std::string& filename, double scale)
     : Shape(ShapeTag<Mesh>()),
       filename_(std::filesystem::absolute(filename)),
       scale_(scale) {
-  if (std::abs(scale) < 1e-8) {
-    throw std::logic_error("Mesh |scale| cannot be < 1e-8.");
-  }
+  DRAKE_THROW_UNLESS(std::isfinite(scale) && std::abs(scale) >= 1e-8, scale);
 }
 
 MeshcatCone::MeshcatCone(double height, double a, double b)
     : Shape(ShapeTag<MeshcatCone>()), height_(height), a_(a), b_(b) {
-  if (height <= 0 || a <= 0 || b <= 0) {
-    throw std::logic_error(fmt::format(
-        "MeshcatCone parameters height, a, and b should all be > 0 (they were "
-        "{}, {}, and {}, respectively).",
-        height, a, b));
-  }
+  DRAKE_THROW_UNLESS(is_positive_finite(height), height);
+  DRAKE_THROW_UNLESS(is_positive_finite(a), a);
+  DRAKE_THROW_UNLESS(is_positive_finite(b), b);
 }
 
 MeshcatCone::MeshcatCone(const Vector3<double>& measures)
@@ -166,10 +153,7 @@ MeshcatCone::MeshcatCone(const Vector3<double>& measures)
 
 Sphere::Sphere(double radius)
     : Shape(ShapeTag<Sphere>()), radius_(radius) {
-  if (radius < 0) {
-    throw std::logic_error(
-        fmt::format("Sphere radius should be >= 0 (was {}).", radius));
-  }
+  DRAKE_THROW_UNLESS(std::isfinite(radius) && radius >= 0, radius);
 }
 
 ShapeReifier::~ShapeReifier() = default;

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -112,17 +112,17 @@ class Box final : public Shape {
   /** Constructs a box with the given `width`, `depth`, and `height`, which
    specify the box's dimension along the canonical x-, y-, and z-axes,
    respectively.
-   @throws std::exception if `width`, `depth` or `height` are not strictly
-   positive. */
+   @throws std::exception if any measure is not finite positive. */
   Box(double width, double depth, double height);
 
   /** Constructs a box with a vector of measures: width, depth, and height --
    the box's dimensions along the canonical x-, y-, and z-axes, respectively.
-   @throws std::exception if the measures are not strictly positive. */
+   @throws std::exception if any measures is not finite positive. */
   explicit Box(const Vector3<double>& measures);
 
   /** Constructs a cube with the given `edge_size` for its width, depth, and
-   height. */
+   height.
+   @throw std::exception if edge_Size is not finite positive. */
   static Box MakeCube(double edge_size);
 
   /** Returns the box's dimension along the x axis. */
@@ -153,12 +153,12 @@ class Capsule final : public Shape {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Capsule)
 
   /** Constructs a capsule with the given `radius` and `length`.
-   @throws std::exception if `radius` or `length` are not strictly positive.
+   @throws std::exception if any measure is not finite positive.
    */
   Capsule(double radius, double length);
 
   /** Constructs a capsule with a vector of measures: radius and length.
-   @throws std::exception if the measures are not strictly positive. */
+   @throws std::exception if any measure is not finite positive. */
   explicit Capsule(const Vector2<double>& measures);
 
   double radius() const { return radius_; }
@@ -216,12 +216,11 @@ class Cylinder final : public Shape {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Cylinder)
 
   /** Constructs a cylinder with the given `radius` and `length`.
-   @throws std::exception if `radius` or `length` are not strictly positive.
-   */
+   @throws std::exception if any measure is not finite positive. */
   Cylinder(double radius, double length);
 
   /** Constructs a cylinder with a vector of measures: radius and length.
-   @throws std::exception if the measures are not strictly positive. */
+   @throws std::exception if any measure is not finite positive. */
   explicit Cylinder(const Vector2<double>& measures);
 
   double radius() const { return radius_; }
@@ -248,14 +247,13 @@ class Ellipsoid final : public Shape {
   /** Constructs an ellipsoid with the given lengths of its principal
    semi-axes, with a, b, and c measured along the x-, y-, and z- axes of the
    canonical frame, respectively.
-   @throws std::exception if `a`, `b`, or `c` are not strictly positive.
-   */
+   @throws std::exception if any measure is not finite positive. */
   Ellipsoid(double a, double b, double c);
 
   /** Constructs an ellipsoid with a vector of measures: the lengths of its
    principal semi-axes, with a, b, and c measured along the x-, y-, and z- axes
    of the canonical frame, respectively.
-   @throws std::exception if the measures are not strictly positive. */
+   @throws std::exception if any measure is not finite positive. */
   explicit Ellipsoid(const Vector3<double>& measures);
 
   double a() const { return radii_(0); }
@@ -348,13 +346,12 @@ class MeshcatCone final : public Shape {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MeshcatCone)
 
   /** Constructs the parameterized cone.
-   @throws std::exception if `height`, `a`, or `b` are not strictly positive.
-   */
+   @throws std::exception if any measure is not finite positive. */
   explicit MeshcatCone(double height, double a = 1.0, double b = 1.0);
 
   /** Constructs a cone with a vector of measures: height and principal
    semi-axes.
-   @throws std::exception if the measures are not strictly positive. */
+   @throws std::exception if any measure is not finite positive. */
   explicit MeshcatCone(const Vector3<double>& measures);
 
   double height() const { return height_; }
@@ -374,8 +371,8 @@ class Sphere final : public Shape {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Sphere)
 
   /** Constructs a sphere with the given `radius`.
-   @throws std::exception if `radius` is negative. Note that a zero radius is
-   considered valid. */
+   @throws std::exception if `radius` is not finite *non-negative*. Note that a
+                              zero radius is considered valid. */
   explicit Sphere(double radius);
 
   double radius() const { return radius_; }

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -17,6 +17,8 @@ namespace drake {
 namespace geometry {
 namespace {
 
+using Eigen::Vector2d;
+using Eigen::Vector3d;
 using math::RigidTransformd;
 using std::unique_ptr;
 
@@ -472,66 +474,46 @@ GTEST_TEST(ShapeTest, Constructors) {
 // Confirms that shape parameters are validated. For the vector-based
 // constructors, we only provide a single invocation, relying on the idea that
 // it forwards construction to the validating constructor with individual
-// parameters.
+// parameters. We test the error message to confirm that the erroneous value
+// is part of the message. We don't worry about the *rest* of the message,
+// relyibng DRAKE_THROW_UNLESS to do the right thing.
+//
+// We haven't included explicit tests for infinity or NaN.
 GTEST_TEST(ShapeTest, NumericalValidation) {
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      Box(2, 0, 2), "Box width, depth, and height should all be > 0.+");
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      Box(3, 1, -1), "Box width, depth, and height should all be > 0.+");
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      Box(Vector3<double>{3, 1, -1}),
-      "Box width, depth, and height should all be > 0.+");
+  DRAKE_EXPECT_THROWS_MESSAGE(Box(2, 0, 2), ".*failed. depth = 0.");
+  DRAKE_EXPECT_THROWS_MESSAGE(Box(3, 1, -1), ".*failed. height = -1.");
+  DRAKE_EXPECT_THROWS_MESSAGE(Box(Vector3d{-2, 1, 3}), ".*failed. width = -2.");
   DRAKE_EXPECT_THROWS_MESSAGE(Box::MakeCube(0),
-                              "Box width, depth, and height should "
-                              "all be > 0.+");
+                              ".*failed. width = 0.");
 
-  DRAKE_EXPECT_THROWS_MESSAGE(Capsule(0, 1),
-                              "Capsule radius and length should both be > 0.+");
-  DRAKE_EXPECT_THROWS_MESSAGE(Capsule(0.5, -1),
-                              "Capsule radius and length should both be > 0.+");
-  DRAKE_EXPECT_THROWS_MESSAGE(Capsule(Vector2<double>{0.5, -1}),
-                              "Capsule radius and length should both be > 0.+");
+  DRAKE_EXPECT_THROWS_MESSAGE(Capsule(0, 1), ".*failed. radius = 0.");
+  DRAKE_EXPECT_THROWS_MESSAGE(Capsule(0.5, -1), ".*failed. length = -1.");
+  DRAKE_EXPECT_THROWS_MESSAGE(Capsule(Vector2d{0.5, -1}),
+                              ".*failed. length = -1.");
 
-  DRAKE_EXPECT_THROWS_MESSAGE(Convex("bar", 0),
-                              "Convex .scale. cannot be < 1e-8.");
+  DRAKE_EXPECT_THROWS_MESSAGE(Convex("bar", 0), ".*failed. scale = 0.");
   DRAKE_EXPECT_NO_THROW(Convex("foo", -1));  // Special case for negative scale.
 
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      Cylinder(0, 1), "Cylinder radius and length should both be > 0.+");
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      Cylinder(0.5, -1), "Cylinder radius and length should both be > 0.+");
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      Cylinder(Vector2<double>{0.5, -1}),
-      "Cylinder radius and length should both be > 0.+");
+  DRAKE_EXPECT_THROWS_MESSAGE(Cylinder(0, 1), ".*failed. radius = 0.");
+  DRAKE_EXPECT_THROWS_MESSAGE(Cylinder(0.5, -1), ".*failed. length = -1.");
+  DRAKE_EXPECT_THROWS_MESSAGE(Cylinder(Vector2d{0.5, -1}),
+                              ".*failed. length = -1.");
 
-  DRAKE_EXPECT_THROWS_MESSAGE(Ellipsoid(0, 1, 1),
-                              "Ellipsoid lengths of principal semi-axes a, b, "
-                              "and c should all be > 0.+");
-  DRAKE_EXPECT_THROWS_MESSAGE(Ellipsoid(1, 0, 1),
-                              "Ellipsoid lengths of principal semi-axes a, b, "
-                              "and c should all be > 0.+");
-  DRAKE_EXPECT_THROWS_MESSAGE(Ellipsoid(1, 1, 0),
-                              "Ellipsoid lengths of principal semi-axes a, b, "
-                              "and c should all be > 0.+");
-  DRAKE_EXPECT_THROWS_MESSAGE(Ellipsoid(Vector3<double>{1, 1, 0}),
-                              "Ellipsoid lengths of principal semi-axes a, b, "
-                              "and c should all be > 0.+");
+  DRAKE_EXPECT_THROWS_MESSAGE(Ellipsoid(0, 1, 1), ".*failed. a = 0.");
+  DRAKE_EXPECT_THROWS_MESSAGE(Ellipsoid(1, 0, 1), ".*failed. b = 0.");
+  DRAKE_EXPECT_THROWS_MESSAGE(Ellipsoid(1, 1, 0), ".*failed. c = 0.");
+  DRAKE_EXPECT_THROWS_MESSAGE(Ellipsoid(Vector3d{1, 1, 0}), ".*failed. c = 0.");
 
-  DRAKE_EXPECT_THROWS_MESSAGE(Mesh("foo", 1e-9),
-                              "Mesh .scale. cannot be < 1e-8.");
+  DRAKE_EXPECT_THROWS_MESSAGE(Mesh("foo", 1e-9), ".*failed. scale = 1e-09.");
   DRAKE_EXPECT_NO_THROW(Mesh("foo", -1));  // Special case for negative scale.
 
-  DRAKE_EXPECT_THROWS_MESSAGE(MeshcatCone(0, 1, 1),
-                              "MeshcatCone parameters .+ should all be > 0.*");
-  DRAKE_EXPECT_THROWS_MESSAGE(MeshcatCone(1, 0, 1),
-                              "MeshcatCone parameters .+ should all be > 0.*");
-  DRAKE_EXPECT_THROWS_MESSAGE(MeshcatCone(1, 1, 0),
-                              "MeshcatCone parameters .+ should all be > 0.*");
-  DRAKE_EXPECT_THROWS_MESSAGE(MeshcatCone(Vector3<double>{1, 1, 0}),
-                              "MeshcatCone parameters .+ should all be > 0.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(MeshcatCone(0, 1, 1), ".*failed. height = 0.");
+  DRAKE_EXPECT_THROWS_MESSAGE(MeshcatCone(1, 0, 1), ".*failed. a = 0.");
+  DRAKE_EXPECT_THROWS_MESSAGE(MeshcatCone(1, 1, 0), ".*failed. b = 0.");
+  DRAKE_EXPECT_THROWS_MESSAGE(MeshcatCone(Vector3d{1, 1, 0}),
+                              ".*failed. b = 0.");
 
-  DRAKE_EXPECT_THROWS_MESSAGE(Sphere(-0.5),
-                              "Sphere radius should be >= 0.+");
+  DRAKE_EXPECT_THROWS_MESSAGE(Sphere(-0.5), ".*failed. radius = -0.5.");
   DRAKE_EXPECT_NO_THROW(Sphere(0));  // Special case for 0 radius.
 }
 


### PR DESCRIPTION
DRAKE_THROW_UNLESS historically took a single parameter: a boolean expression serving as a throwing condition. if the condition was false, a message would print out the failed condition.

However, if the condition were expressed in lvalues, the message could be inscrutable:

    DRAKE_THROW_UNLESS(x > threshold)

would include the following information:

    "Condition 'x > threshold' failed."

with no insight as to what x or threshold are.

Now, up to four value expressions can be passed along with the condition:

    DRAKE_THROW_UNLESS(x > threshold, x, threshold)

Producing (something like):

    "Condition 'x > threshold' failed. x = -inf, threshold = 1e-09."