### PR TITLE
Fix a bug when calling AddSosConstraint with a constant polynomial.

### DIFF
--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -1395,7 +1395,13 @@ pair<MatrixXDecisionVariable, VectorX<symbolic::Monomial>> DoAddSosConstraint(
     MathematicalProgram::NonnegativePolynomial type,
     const std::string& gram_name) {
   const symbolic::Polynomial p_expanded = p.Expand();
-  const VectorX<symbolic::Monomial> m = ConstructMonomialBasis(p_expanded);
+  VectorX<symbolic::Monomial> m;
+  if (p_expanded.TotalDegree() == 0) {
+    m.resize(1);
+    m(0) = symbolic::Monomial();
+  } else {
+    m = ConstructMonomialBasis(p_expanded);
+  }
   const MatrixXDecisionVariable Q =
       prog->AddSosConstraint(p_expanded, m, type, gram_name);
   return std::make_pair(Q, m);

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -3906,6 +3906,27 @@ GTEST_TEST(TestMathematicalProgram, AddSosConstraint) {
   EXPECT_EQ(gram2.rows(), 1);
 }
 
+GTEST_TEST(TestMathematicalProgram, AddSosConstraintConstant) {
+  // Call AddSosConstraint on a constant.
+  {
+    // Test with given monomial basis.
+    MathematicalProgram prog;
+    auto x = prog.NewIndeterminates<1>();
+    auto Q = prog.AddSosConstraint(
+        1, Vector1<symbolic::Monomial>(symbolic::Monomial()));
+    EXPECT_EQ(Q.rows(), 1);
+  }
+  {
+    // Test without given monomial basis.
+    MathematicalProgram prog;
+    auto x = prog.NewIndeterminates<1>();
+    auto [Q, m] = prog.AddSosConstraint(1);
+    EXPECT_EQ(Q.rows(), 1);
+    EXPECT_EQ(m.rows(), 1);
+    EXPECT_EQ(m(0).total_degree(), 0);
+  }
+}
+
 template <typename C>
 void RemoveCostTest(MathematicalProgram* prog,
                     const symbolic::Expression& cost1_expr,


### PR DESCRIPTION
When the polynomial is constant, its monomial basis should just be [1]. Previously our code fails to find this monomial basis.

Resolves #19231 