### PR TITLE
Adds basic GCS planner

### DIFF
--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -8,6 +8,7 @@
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
 #include "drake/planning/trajectory_optimization/direct_collocation.h"
 #include "drake/planning/trajectory_optimization/direct_transcription.h"
+#include "drake/planning/trajectory_optimization/gcs_trajectory_optimization.h"
 #include "drake/planning/trajectory_optimization/kinematic_trajectory_optimization.h"
 
 namespace drake {
@@ -346,6 +347,88 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
         .def("AddPathLengthCost", &Class::AddPathLengthCost,
             py::arg("weight") = 1.0, py::arg("use_conic_constraint") = false,
             cls_doc.AddPathLengthCost.doc);
+  }
+
+  {
+    using Class = GcsTrajectoryOptimization;
+    constexpr auto& cls_doc = doc.GcsTrajectoryOptimization;
+    py::class_<Class> gcs_traj_opt(m, "GcsTrajectoryOptimization", cls_doc.doc);
+
+    // Subgraph
+    const auto& subgraph_doc = doc.GcsTrajectoryOptimization.Subgraph;
+    py::class_<Class::Subgraph>(gcs_traj_opt, "Subgraph", subgraph_doc.doc)
+        .def("name", &Class::Subgraph::name, subgraph_doc.name.doc)
+        .def("order", &Class::Subgraph::order, subgraph_doc.order.doc)
+        .def("size", &Class::Subgraph::size, subgraph_doc.size.doc)
+        .def(
+            "regions",
+            [](Class::Subgraph* self) {
+              py::list out;
+              py::object self_py = py::cast(self, py_rvp::reference);
+              for (auto& region : self->regions()) {
+                const geometry::optimization::ConvexSet* region_raw =
+                    region.get();
+                py::object region_py = py::cast(region_raw, py_rvp::reference);
+                // Keep alive, ownership: `region` keeps `self` alive.
+                py_keep_alive(region_py, self_py);
+                out.append(region_py);
+              }
+              return out;
+            },
+            subgraph_doc.regions.doc)
+        .def("AddPathLengthCost",
+            py::overload_cast<const Eigen::MatrixXd&>(
+                &Class::Subgraph::AddPathLengthCost),
+            py::arg("weight_matrix"),
+            subgraph_doc.AddPathLengthCost.doc_1args_weight_matrix)
+        .def("AddPathLengthCost",
+            py::overload_cast<double>(&Class::Subgraph::AddPathLengthCost),
+            py::arg("weight") = 1.0,
+            subgraph_doc.AddPathLengthCost.doc_1args_weight);
+
+    // EdgesBetweenSubgraphs
+    const auto& subgraph_edges_doc =
+        doc.GcsTrajectoryOptimization.EdgesBetweenSubgraphs;
+    py::class_<Class::EdgesBetweenSubgraphs>(
+        gcs_traj_opt, "EdgesBetweenSubgraphs", subgraph_edges_doc.doc);
+
+    gcs_traj_opt  // BR
+        .def(py::init<int>(), py::arg("num_positions"), cls_doc.ctor.doc)
+        .def("num_positions", &Class::num_positions, cls_doc.num_positions.doc)
+        .def("GetGraphvizString", &Class::GetGraphvizString,
+            py::arg("result") = std::nullopt, py::arg("show_slack") = true,
+            py::arg("precision") = 3, py::arg("scientific") = false,
+            cls_doc.GetGraphvizString.doc)
+        .def("AddRegions",
+            py::overload_cast<const geometry::optimization::ConvexSets&,
+                const std::vector<std::pair<int, int>>&, int, double, double,
+                std::string>(&Class::AddRegions),
+            py_rvp::reference_internal, py::arg("regions"),
+            py::arg("edges_between_regions"), py::arg("order"),
+            py::arg("h_min") = 1e-6, py::arg("h_max") = 20,
+            py::arg("name") = "", cls_doc.AddRegions.doc_6args)
+        .def("AddRegions",
+            py::overload_cast<const geometry::optimization::ConvexSets&, int,
+                double, double, std::string>(&Class::AddRegions),
+            py_rvp::reference_internal, py::arg("regions"), py::arg("order"),
+            py::arg("h_min") = 1e-6, py::arg("h_max") = 20,
+            py::arg("name") = "", cls_doc.AddRegions.doc_5args)
+        .def("AddEdges", &Class::AddEdges, py_rvp::reference_internal,
+            py::arg("from_subgraph"), py::arg("to_subgraph"),
+            py::arg("subspace") = py::none(), cls_doc.AddEdges.doc)
+        .def("AddPathLengthCost",
+            py::overload_cast<const Eigen::MatrixXd&>(
+                &Class::AddPathLengthCost),
+            py::arg("weight_matrix"),
+            cls_doc.AddPathLengthCost.doc_1args_weight_matrix)
+        .def("AddPathLengthCost",
+            py::overload_cast<double>(&Class::AddPathLengthCost),
+            py::arg("weight") = 1.0, cls_doc.AddPathLengthCost.doc_1args_weight)
+        .def("SolvePath", &Class::SolvePath, py::arg("source"),
+            py::arg("target"),
+            py::arg("options") =
+                geometry::optimization::GraphOfConvexSetsOptions(),
+            cls_doc.SolvePath.doc);
   }
 }
 

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -11,9 +11,20 @@ from pydrake.planning import (
     DirectCollocation,
     DirectCollocationConstraint,
     DirectTranscription,
+    GcsTrajectoryOptimization,
     KinematicTrajectoryOptimization,
 )
-from pydrake.trajectories import PiecewisePolynomial, BsplineTrajectory
+from pydrake.geometry.optimization import (
+    GraphOfConvexSetsOptions,
+    HPolyhedron,
+    Point,
+    VPolytope,
+)
+from pydrake.trajectories import (
+    BsplineTrajectory,
+    CompositeTrajectory,
+    PiecewisePolynomial,
+)
 import pydrake.solvers as mp
 from pydrake.symbolic import Variable
 from pydrake.systems.framework import InputPortSelection
@@ -22,6 +33,11 @@ from pydrake.trajectories import PiecewisePolynomial, BsplineTrajectory
 from pydrake.symbolic import Variable
 from pydrake.systems.framework import InputPortSelection
 from pydrake.systems.primitives import LinearSystem
+
+
+def GurobiOrMosekSolverAvailable():
+    return (mp.MosekSolver().available() and mp.MosekSolver().enabled()) or (
+        mp.GurobiSolver().available() and mp.GurobiSolver().enabled())
 
 
 class TestTrajectoryOptimization(unittest.TestCase):
@@ -239,3 +255,195 @@ class TestTrajectoryOptimization(unittest.TestCase):
         q = trajopt.ReconstructTrajectory(result=result)
         self.assertIsInstance(q, BsplineTrajectory)
         trajopt.SetInitialGuess(trajectory=q)
+
+    def test_gcs_trajectory_optimization_2d(self):
+        """The following 2D environment has been presented in the GCS paper.
+
+        We have two possible starts, S1 and S2, and two possible goals,
+        G1 and G2. The goal is to find a the shortest path from either of
+        the starts to either of the goals while avoiding the obstacles.
+        Further we constraint the path to go through either the intermediate
+        point I or the subspace.
+
+    ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+    ░░      ░░░░░░░░                                      ░░░░░░░░         ░░
+    ░░      ░░░░░░░░                                      ░░░░░░░░         ░░
+    ░░      ░░░░░░░░                                      ░░░░░░░░    G1   ░░
+    ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+    ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+    ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+    ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+    ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+    ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+    ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+    ░░    S2░░░░░░░░      ░░░░░░░░░░ I ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+    ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+    ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░                       ░░
+    ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░                       ░░
+    ░░                                 ░░░░░░░░░░░░░      ░░░░░░░░░░░░░░░░░░░
+    ░░                          ░░░░░░░░░░░░░░░░░░░░                       ░░
+    ░░                        ░░░░░░░░░░░░░░░░░░░░░░░░░                 G2 ░░
+    ░░      ░░░░░░░░        ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░                  ░░
+    ░░      ░░░░░░░░          ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░                ░░
+    ░░      ░░░░░░░░            ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░              ░░
+    ░░      ░░░░░░░░              ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░            ░░
+    ░░      ░░░░░░░░                ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░          ░░
+    ░░      ░░░░░░░░                  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░        ░░
+    ░░      ░░░░░░░░                    ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░xxxxxx░░
+    ░░      ░░░░░░░░                      ░░░░░░░░░░░░░░░░░░░░░░░░░xxxxxxxx░░
+    ░░      ░░░░░░░░                        ░░░░░░░░░░░░░░░░░░░░░xxxxxxxxxx░░
+    ░░      ░░░░░░░░                          ░░░░░░░░░░░░░░░░░xxxxxxxxxxxx░░
+    ░░      ░░░░░░░░                            ░░░░░░░░░░░░░xxx Subspace x░░
+    ░░      ░░░░░░░░                                       xxxxxxxxxxxxxxxx░░
+    ░░  S1  ░░░░░░░░                                       xxxxxxxxxxxxxxxx░░
+    ░░      ░░░░░░░░                                       xxxxxxxxxxxxxxxx░░
+    ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+        """
+
+        dimension = 2
+        gcs = GcsTrajectoryOptimization(num_positions=dimension)
+        self.assertEqual(gcs.num_positions(), dimension)
+
+        # Define the collision free space.
+        vertices = [
+            np.array([[0.4, 0.4, 0.0, 0.0], [0.0, 5.0, 5.0, 0.0]]),
+            np.array([[0.4, 1.0, 1.0, 0.4], [2.4, 2.4, 2.6, 2.6]]),
+            np.array([[1.4, 1.4, 1.0, 1.0], [2.2, 4.6, 4.6, 2.2]]),
+            np.array([[1.4, 2.4, 2.4, 1.4], [2.2, 2.6, 2.8, 2.8]]),
+            np.array([[2.2, 2.4, 2.4, 2.2], [2.8, 2.8, 4.6, 4.6]]),
+            np.array([[1.4, 1.0, 1.0, 3.8, 3.8], [2.2, 2.2, 0.0, 0.0, 0.2]]),
+            np.array([[3.8, 3.8, 1.0, 1.0], [4.6, 5.0, 5.0, 4.6]]),
+            np.array([[5.0, 5.0, 4.8, 3.8, 3.8], [0.0, 1.2, 1.2, 0.2, 0.0]]),
+            np.array([[3.4, 4.8, 5.0, 5.0], [2.6, 1.2, 1.2, 2.6]]),
+            np.array([[3.4, 3.8, 3.8, 3.4], [2.6, 2.6, 4.6, 4.6]]),
+            np.array([[3.8, 4.4, 4.4, 3.8], [2.8, 2.8, 3.0, 3.0]]),
+            np.array([[5.0, 5.0, 4.4, 4.4], [2.8, 5.0, 5.0, 2.8]])
+        ]
+
+        # We add a the path length cost to the entire graph.
+        # This can be called ahead of time or after adding the regions.
+        gcs.AddPathLengthCost(weight=1.0)
+        # This cost is equivalent to the above.
+        # It will be added twice, which is unnecessary,
+        # but we do it to test the binding.
+        gcs.AddPathLengthCost(weight_matrix=np.eye(dimension))
+
+        # Add two subgraphs with different orders.
+        main1 = gcs.AddRegions(
+            regions=[HPolyhedron(VPolytope(v)) for v in vertices],
+            order=1,
+            name="main1")
+        self.assertIsInstance(main1, GcsTrajectoryOptimization.Subgraph)
+        self.assertEqual(main1.order(), 1)
+        self.assertEqual(main1.name(), "main1")
+        self.assertEqual(main1.size(), len(vertices))
+        self.assertIsInstance(main1.regions(), list)
+        self.assertIsInstance(main1.regions()[0], HPolyhedron)
+
+        # This adds the edges manually.
+        # Doing this is much faster since it avoids computing
+        # pairwise set intersection checks.
+        main2 = gcs.AddRegions(
+            regions=[HPolyhedron(VPolytope(v)) for v in vertices],
+            edges_between_regions=[(0, 1), (1, 0), (1, 2), (2, 1), (2, 3),
+                                   (3, 2), (2, 5), (5, 2), (2, 6), (6, 2),
+                                   (3, 4), (4, 3), (3, 5), (5, 3), (4, 6),
+                                   (6, 4), (5, 7), (7, 5), (6, 9), (9, 6),
+                                   (7, 8), (8, 7), (8, 9), (9, 8), (9, 10),
+                                   (10, 9), (10, 11), (11, 10)],
+            order=3,
+            name="main2")
+
+        self.assertIsInstance(main2, GcsTrajectoryOptimization.Subgraph)
+        self.assertEqual(main2.order(), 3)
+        self.assertEqual(main2.name(), "main2")
+        self.assertEqual(main2.size(), len(vertices))
+        self.assertIsInstance(main2.regions(), list)
+        self.assertIsInstance(main2.regions()[0], HPolyhedron)
+
+        # Add two start and goal regions.
+        start1 = np.array([0.2, 0.2])
+        start2 = np.array([0.3, 3.2])
+
+        goal1 = np.array([4.8, 4.8])
+        goal2 = np.array([4.9, 2.4])
+
+        source = gcs.AddRegions([Point(start1), Point(start2)],
+                                order=0,
+                                name="starts")
+        self.assertIsInstance(source, GcsTrajectoryOptimization.Subgraph)
+        self.assertEqual(source.order(), 0)
+        self.assertEqual(source.name(), "starts")
+        self.assertEqual(source.size(), 2)
+        self.assertIsInstance(source.regions(), list)
+        self.assertIsInstance(source.regions()[0], Point)
+
+        # Here we force a delay of 10 seconds at the goal.
+        target = gcs.AddRegions(regions=[Point(goal1),
+                                         Point(goal2)],
+                                order=0,
+                                h_min=10,
+                                h_max=10,
+                                name='goals')
+        self.assertIsInstance(target, GcsTrajectoryOptimization.Subgraph)
+        self.assertEqual(target.order(), 0)
+        self.assertEqual(target.name(), "goals")
+        self.assertEqual(target.size(), 2)
+        self.assertIsInstance(target.regions(), list)
+        self.assertIsInstance(target.regions()[0], Point)
+
+        # We connect the subgraphs main1 and main2 by constraining it to
+        # go through either of the subspaces.
+        subspace_region = HPolyhedron(VPolytope(vertices[7]))
+        subspace_point = Point([2.3, 3.5])
+
+        self.assertIsInstance(
+            gcs.AddEdges(from_subgraph=main1,
+                         to_subgraph=main2,
+                         subspace=subspace_point),
+            GcsTrajectoryOptimization.EdgesBetweenSubgraphs)
+        self.assertIsInstance(
+            gcs.AddEdges(main1, main2, subspace=subspace_region),
+            GcsTrajectoryOptimization.EdgesBetweenSubgraphs)
+
+        # We connect the start and goal regions to the rest of the graph.
+        self.assertIsInstance(gcs.AddEdges(source, main1),
+                              GcsTrajectoryOptimization.EdgesBetweenSubgraphs)
+        self.assertIsInstance(gcs.AddEdges(main2, target),
+                              GcsTrajectoryOptimization.EdgesBetweenSubgraphs)
+
+        # This weight matrix penalizes movement in the y direction three
+        # times more than in the x direction only for the main2 subgraph.
+        main2.AddPathLengthCost(weight_matrix=np.diag([1.0, 3.0]))
+
+        options = GraphOfConvexSetsOptions()
+        options.convex_relaxation = True
+        options.max_rounded_paths = 5
+
+        if not GurobiOrMosekSolverAvailable():
+            return
+
+        traj, result = gcs.SolvePath(source=source,
+                                     target=target,
+                                     options=options)
+
+        self.assertIsInstance(result, mp.MathematicalProgramResult)
+        self.assertIsInstance(traj, CompositeTrajectory)
+        self.assertTrue(result.is_success())
+        self.assertEqual(traj.rows(), dimension)
+
+        np.testing.assert_array_almost_equal(traj.value(traj.start_time()),
+                                             start2[:, None], 6)
+        np.testing.assert_array_almost_equal(traj.value(traj.end_time()),
+                                             goal2[:, None], 6)
+
+        # Check that the delay at the goal is respected.
+        np.testing.assert_array_almost_equal(traj.value(traj.end_time() - 10),
+                                             goal2[:, None], 6)
+        self.assertTrue(traj.end_time() - traj.start_time() >= 10)
+
+        self.assertIsInstance(
+            gcs.GetGraphvizString(result=result,
+                                  show_slack=True,
+                                  precision=3,
+                                  scientific=False), str)

--- a/planning/trajectory_optimization/BUILD.bazel
+++ b/planning/trajectory_optimization/BUILD.bazel
@@ -14,6 +14,7 @@ drake_cc_package_library(
     deps = [
         ":direct_collocation",
         ":direct_transcription",
+        ":gcs_trajectory_optimization",
         ":integration_constraint",
         ":kinematic_trajectory_optimization",
         ":multiple_shooting",
@@ -101,6 +102,18 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "gcs_trajectory_optimization",
+    srcs = ["gcs_trajectory_optimization.cc"],
+    hdrs = ["gcs_trajectory_optimization.h"],
+    deps = [
+        "//common",
+        "//common/trajectories:bezier_curve",
+        "//common/trajectories:composite_trajectory",
+        "//geometry/optimization:graph_of_convex_sets",
+    ],
+)
+
+drake_cc_library(
     name = "integration_constraint",
     srcs = ["integration_constraint.cc"],
     hdrs = ["integration_constraint.h"],
@@ -149,6 +162,18 @@ drake_cc_googletest(
         "//solvers:solve",
         "//systems/primitives:symbolic_vector_system",
         "//systems/primitives:trajectory_linear_system",
+    ],
+)
+
+drake_cc_googletest(
+    name = "gcs_trajectory_optimization_test",
+    deps = [
+        ":gcs_trajectory_optimization",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_no_throw",
+        "//common/test_utilities:expect_throws_message",
+        "//solvers:gurobi_solver",
+        "//solvers:mosek_solver",
     ],
 )
 

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.cc
@@ -1,0 +1,539 @@
+#include "drake/planning/trajectory_optimization/gcs_trajectory_optimization.h"
+
+#include <unordered_map>
+#include <unordered_set>
+
+#include "drake/common/pointer_cast.h"
+#include "drake/common/scope_exit.h"
+#include "drake/common/symbolic/decompose.h"
+#include "drake/geometry/optimization/cartesian_product.h"
+#include "drake/geometry/optimization/hpolyhedron.h"
+#include "drake/geometry/optimization/point.h"
+#include "drake/math/matrix_util.h"
+#include "drake/solvers/solve.h"
+
+namespace drake {
+namespace planning {
+namespace trajectory_optimization {
+
+using Subgraph = GcsTrajectoryOptimization::Subgraph;
+using EdgesBetweenSubgraphs = GcsTrajectoryOptimization::EdgesBetweenSubgraphs;
+
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+using geometry::optimization::CartesianProduct;
+using geometry::optimization::ConvexSet;
+using geometry::optimization::ConvexSets;
+using geometry::optimization::GraphOfConvexSets;
+using geometry::optimization::GraphOfConvexSetsOptions;
+using geometry::optimization::HPolyhedron;
+using geometry::optimization::Point;
+using solvers::Binding;
+using solvers::Constraint;
+using solvers::Cost;
+using solvers::L2NormCost;
+using solvers::LinearEqualityConstraint;
+using symbolic::DecomposeLinearExpressions;
+using symbolic::Expression;
+using symbolic::MakeMatrixContinuousVariable;
+using symbolic::MakeVectorContinuousVariable;
+using trajectories::BezierCurve;
+using trajectories::CompositeTrajectory;
+using trajectories::Trajectory;
+using Vertex = GraphOfConvexSets::Vertex;
+using Edge = GraphOfConvexSets::Edge;
+using VertexId = GraphOfConvexSets::VertexId;
+using EdgeId = GraphOfConvexSets::EdgeId;
+
+Subgraph::Subgraph(
+    const ConvexSets& regions,
+    const std::vector<std::pair<int, int>>& edges_between_regions, int order,
+    double h_min, double h_max, std::string name,
+    GcsTrajectoryOptimization* traj_opt)
+    : regions_(regions),
+      order_(order),
+      name_(std::move(name)),
+      traj_opt_(*traj_opt) {
+  DRAKE_THROW_UNLESS(order >= 0);
+  DRAKE_THROW_UNLESS(!regions_.empty());
+
+  // Make sure all regions have the same ambient dimension.
+  for (const std::unique_ptr<ConvexSet>& region : regions_) {
+    DRAKE_THROW_UNLESS(region != nullptr);
+    DRAKE_THROW_UNLESS(region->ambient_dimension() == num_positions());
+  }
+  // Make time scaling set once to avoid many allocations when adding the
+  // vertices to GCS.
+  const HPolyhedron time_scaling_set =
+      HPolyhedron::MakeBox(Vector1d(h_min), Vector1d(h_max));
+
+  // Allocating variables and control points to be used in the constraints.
+  // Bindings allow formulating the constraints once, and then pass them to all
+  // the edges.
+  // An edge goes from the vertex u to the vertex v. Where its control points
+  // and trajectories are needed for continuity constraints. Saving the
+  // variables for u simplifies the cost/constraint formulation for optional
+  // costs like the path length cost.
+  const MatrixX<symbolic::Variable> u_control =
+      MakeMatrixContinuousVariable(num_positions(), order_ + 1, "xu");
+  const MatrixX<symbolic::Variable> v_control =
+      MakeMatrixContinuousVariable(num_positions(), order_ + 1, "xv");
+  const Eigen::Map<const VectorX<symbolic::Variable>> u_control_vars(
+      u_control.data(), u_control.size());
+  const Eigen::Map<const VectorX<symbolic::Variable>> v_control_vars(
+      v_control.data(), v_control.size());
+
+  u_h_ = MakeVectorContinuousVariable(1, "hu");
+  const VectorX<symbolic::Variable> v_h = MakeVectorContinuousVariable(1, "hv");
+
+  u_vars_ = solvers::ConcatenateVariableRefList({u_control_vars, u_h_});
+  const VectorX<symbolic::Variable> edge_vars =
+      solvers::ConcatenateVariableRefList(
+          {u_control_vars, u_h_, v_control_vars, v_h});
+
+  u_r_trajectory_ = BezierCurve<Expression>(0, 1, u_control.cast<Expression>());
+
+  const auto v_r_trajectory =
+      BezierCurve<Expression>(0, 1, v_control.cast<Expression>());
+
+  // TODO(wrangelvid) Pull this out into a function once we have a better way to
+  // extract M from bezier curves.
+  const VectorX<Expression> path_continuity_error =
+      v_r_trajectory.control_points().col(0) -
+      u_r_trajectory_.control_points().col(order);
+  MatrixXd M(num_positions(), edge_vars.size());
+  DecomposeLinearExpressions(path_continuity_error, edge_vars, &M);
+  // TODO(wrangelvid) The matrix M might be sparse, so we could drop columns
+  // here.
+
+  const auto path_continuity_constraint =
+      std::make_shared<LinearEqualityConstraint>(
+          M, VectorXd::Zero(num_positions()));
+
+  // Add Regions with time scaling set.
+  for (size_t i = 0; i < regions_.size(); ++i) {
+    ConvexSets vertex_set;
+    // Assign each control point to a separate set.
+    const int num_points = order + 1;
+    vertex_set.reserve(num_points + 1);
+    vertex_set.insert(vertex_set.begin(), num_points,
+                      ConvexSets::value_type{*regions_[i]});
+    // Add time scaling set.
+    vertex_set.emplace_back(time_scaling_set);
+
+    vertices_.emplace_back(traj_opt_.gcs_.AddVertex(
+        CartesianProduct(vertex_set), fmt::format("{}: {}", name, i)));
+  }
+
+  // Connect vertices with edges.
+  for (const auto& [u_index, v_index] : edges_between_regions) {
+    // Add edge.
+    const Vertex& u = *vertices_[u_index];
+    const Vertex& v = *vertices_[v_index];
+    Edge* uv_edge = traj_opt_.AddEdge(u, v);
+
+    edges_.emplace_back(uv_edge);
+
+    // Add path continuity constraints.
+    uv_edge->AddConstraint(
+        Binding<Constraint>(path_continuity_constraint, {u.x(), v.x()}));
+  }
+}
+
+Subgraph::~Subgraph() = default;
+
+void Subgraph::AddPathLengthCost(const MatrixXd& weight_matrix) {
+  /*
+    We will upper bound the trajectory length by the sum of the distances
+    between the control points. ∑ ||rᵢ − rᵢ₊₁||₂
+
+    In the case of a Bézier curve, the path length is given by the integral of
+    the norm of the derivative of the curve.
+
+    So the previous upper bound is equivalent to: ∑ ||ṙᵢ||₂ / order
+    Because ||ṙᵢ||₂ = ||rᵢ₊₁ − rᵢ||₂ * order
+  */
+  DRAKE_THROW_UNLESS(weight_matrix.rows() == num_positions());
+  DRAKE_THROW_UNLESS(weight_matrix.cols() == num_positions());
+
+  if (order() == 0) {
+    throw std::runtime_error(
+        "Path length cost is not defined for a set of order 0.");
+  }
+
+  const MatrixX<Expression> u_rdot_control =
+      dynamic_pointer_cast_or_throw<BezierCurve<Expression>>(
+          u_r_trajectory_.MakeDerivative())
+          ->control_points();
+
+  for (int i = 0; i < u_rdot_control.cols(); ++i) {
+    MatrixXd M(num_positions(), u_vars_.size());
+    DecomposeLinearExpressions(u_rdot_control.col(i) / order(), u_vars_, &M);
+    // TODO(wrangelvid) The matrix M might be sparse, so we could drop columns
+    // here.
+
+    const auto path_length_cost = std::make_shared<L2NormCost>(
+        weight_matrix * M, VectorXd::Zero(num_positions()));
+
+    for (Vertex* v : vertices_) {
+      // The duration variable is the last element of the vertex.
+      v->AddCost(Binding<L2NormCost>(path_length_cost, v->x()));
+    }
+  }
+}
+
+void Subgraph::AddPathLengthCost(double weight) {
+  const MatrixXd weight_matrix =
+      weight * MatrixXd::Identity(num_positions(), num_positions());
+  return Subgraph::AddPathLengthCost(weight_matrix);
+}
+
+EdgesBetweenSubgraphs::EdgesBetweenSubgraphs(
+    const Subgraph& from_subgraph, const Subgraph& to_subgraph,
+    const ConvexSet* subspace, GcsTrajectoryOptimization* traj_opt)
+    : traj_opt_(*traj_opt) {
+  // Formulate edge costs and constraints.
+  if (subspace != nullptr) {
+    if (subspace->ambient_dimension() != num_positions()) {
+      throw std::runtime_error(
+          "Subspace dimension must match the number of positions.");
+    }
+    if (typeid(*subspace) != typeid(Point) &&
+        typeid(*subspace) != typeid(HPolyhedron)) {
+      throw std::runtime_error("Subspace must be a Point or HPolyhedron.");
+    }
+  }
+
+  // Allocating variables and control points to be used in the constraints.
+  // Bindings allow formulating the constraints once, and then pass
+  // them to all the edges.
+  // An edge goes from the vertex u to the vertex v. Where its control points
+  // and trajectories are needed for continuity constraints. Saving the
+  // variables for u simplifies the cost/constraint formulation for optional
+  // constraints like the velocity bounds.
+
+  const MatrixX<symbolic::Variable> u_control = MakeMatrixContinuousVariable(
+      num_positions(), from_subgraph.order() + 1, "xu");
+  const MatrixX<symbolic::Variable> v_control = MakeMatrixContinuousVariable(
+      num_positions(), to_subgraph.order() + 1, "xv");
+  Eigen::Map<const VectorX<symbolic::Variable>> u_control_vars(
+      u_control.data(), u_control.size());
+  Eigen::Map<const VectorX<symbolic::Variable>> v_control_vars(
+      v_control.data(), v_control.size());
+
+  u_h_ = MakeVectorContinuousVariable(1, "Tu");
+  v_h_ = MakeVectorContinuousVariable(1, "Tv");
+
+  u_vars_ = solvers::ConcatenateVariableRefList({u_control_vars, u_h_});
+  v_vars_ = solvers::ConcatenateVariableRefList({v_control_vars, v_h_});
+  const VectorX<symbolic::Variable> edge_vars =
+      solvers::ConcatenateVariableRefList(
+          {u_control_vars, u_h_, v_control_vars, v_h_});
+
+  u_r_trajectory_ = BezierCurve<Expression>(0, 1, u_control.cast<Expression>());
+
+  v_r_trajectory_ = BezierCurve<Expression>(0, 1, v_control.cast<Expression>());
+
+  // Zeroth order continuity constraints.
+  // TODO(wrangelvid) Pull this out into a function once we have a better way to
+  // extract M from bezier curves.
+  const VectorX<Expression> path_continuity_error =
+      v_r_trajectory_.control_points().col(0) -
+      u_r_trajectory_.control_points().col(from_subgraph.order());
+  MatrixXd M(num_positions(), edge_vars.size());
+  DecomposeLinearExpressions(path_continuity_error, edge_vars, &M);
+  // TODO(wrangelvid) The matrix M might be sparse, so we could drop columns
+  // here.
+
+  const auto path_continuity_constraint =
+      std::make_shared<LinearEqualityConstraint>(
+          M, VectorXd::Zero(num_positions()));
+
+  // TODO(wrangelvid) this can be parallelized.
+  for (int i = 0; i < from_subgraph.size(); ++i) {
+    for (int j = 0; j < to_subgraph.size(); ++j) {
+      if (from_subgraph.regions()[i]->IntersectsWith(
+              *to_subgraph.regions()[j])) {
+        if (subspace != nullptr) {
+          // Check if the regions are connected through the subspace.
+          if (!RegionsConnectThroughSubspace(*from_subgraph.regions()[i],
+                                             *to_subgraph.regions()[j],
+                                             *subspace)) {
+            continue;
+          }
+        }
+
+        // Add edge.
+        const Vertex& u = *from_subgraph.vertices_[i];
+        const Vertex& v = *to_subgraph.vertices_[j];
+        Edge* uv_edge = traj_opt_.AddEdge(u, v);
+        edges_.emplace_back(uv_edge);
+
+        // Add path continuity constraints.
+        uv_edge->AddConstraint(Binding<LinearEqualityConstraint>(
+            path_continuity_constraint, {u.x(), v.x()}));
+
+        if (subspace != nullptr) {
+          // Add subspace constraints to the first control point of the v
+          // vertex. Since we are using zeroth order continuity, the last
+          // control point
+          const auto vars = v.x().segment(0, num_positions());
+          solvers::MathematicalProgram prog;
+          const VectorX<symbolic::Variable> x =
+              prog.NewContinuousVariables(num_positions(), "x");
+          subspace->AddPointInSetConstraints(&prog, x);
+          for (const auto& binding : prog.GetAllConstraints()) {
+            const std::shared_ptr<Constraint>& constraint = binding.evaluator();
+            uv_edge->AddConstraint(Binding<Constraint>(constraint, vars));
+          }
+        }
+      }
+    }
+  }
+}
+
+EdgesBetweenSubgraphs::~EdgesBetweenSubgraphs() = default;
+
+bool EdgesBetweenSubgraphs::RegionsConnectThroughSubspace(
+    const ConvexSet& A, const ConvexSet& B, const ConvexSet& subspace) {
+  DRAKE_THROW_UNLESS(A.ambient_dimension() == B.ambient_dimension() &&
+                     A.ambient_dimension() == subspace.ambient_dimension());
+  // TODO(wrangelvid) Replace dynamic cast with a function that checks if the
+  // convex set degenerates to a point.
+  if (const Point* pt = dynamic_cast<const Point*>(&subspace)) {
+    // If the subspace is a point, then the point must be in both A and B.
+    return A.PointInSet(pt->x()) && B.PointInSet(pt->x());
+  } else {
+    // Otherwise, we can formulate a problem to check if a point is contained in
+    // A, B and the subspace.
+    solvers::MathematicalProgram prog;
+    const VectorX<symbolic::Variable> x =
+        prog.NewContinuousVariables(num_positions(), "x");
+    A.AddPointInSetConstraints(&prog, x);
+    B.AddPointInSetConstraints(&prog, x);
+    subspace.AddPointInSetConstraints(&prog, x);
+    solvers::MathematicalProgramResult result = solvers::Solve(prog);
+    return result.is_success();
+  }
+}
+
+GcsTrajectoryOptimization::GcsTrajectoryOptimization(int num_positions)
+    : num_positions_(num_positions) {
+  DRAKE_THROW_UNLESS(num_positions >= 1);
+}
+
+GcsTrajectoryOptimization::~GcsTrajectoryOptimization() = default;
+
+Subgraph& GcsTrajectoryOptimization::AddRegions(
+    const ConvexSets& regions,
+    const std::vector<std::pair<int, int>>& edges_between_regions, int order,
+    double h_min, double h_max, std::string name) {
+  Subgraph* subgraph = new Subgraph(regions, edges_between_regions, order,
+                                    h_min, h_max, std::move(name), this);
+
+  // Add global costs to the subgraph.
+  if (order > 0) {
+    // These costs rely on the derivative of the trajectory.
+    for (const MatrixXd& weight_matrix : global_path_length_costs_) {
+      subgraph->AddPathLengthCost(weight_matrix);
+    }
+  }
+  return *subgraphs_.emplace_back(subgraph);
+}
+
+Subgraph& GcsTrajectoryOptimization::AddRegions(const ConvexSets& regions,
+                                                int order, double h_min,
+                                                double h_max,
+                                                std::string name) {
+  if (name.empty()) {
+    name = fmt::format("S{}", subgraphs_.size());
+  }
+  // TODO(wrangelvid): This is O(n^2) and can be improved.
+  std::vector<std::pair<int, int>> edges_between_regions;
+  for (size_t i = 0; i < regions.size(); ++i) {
+    for (size_t j = i + 1; j < regions.size(); ++j) {
+      if (regions[i]->IntersectsWith(*regions[j])) {
+        // Regions are overlapping, add edge.
+        edges_between_regions.emplace_back(i, j);
+        edges_between_regions.emplace_back(j, i);
+      }
+    }
+  }
+
+  return GcsTrajectoryOptimization::AddRegions(
+      regions, edges_between_regions, order, h_min, h_max, std::move(name));
+}
+
+EdgesBetweenSubgraphs& GcsTrajectoryOptimization::AddEdges(
+    const Subgraph& from_subgraph, const Subgraph& to_subgraph,
+    const ConvexSet* subspace) {
+  return *subgraph_edges_.emplace_back(
+      new EdgesBetweenSubgraphs(from_subgraph, to_subgraph, subspace, this));
+}
+
+void GcsTrajectoryOptimization::AddPathLengthCost(
+    const MatrixXd& weight_matrix) {
+  // Add path length cost to each subgraph.
+  for (std::unique_ptr<Subgraph>& subgraph : subgraphs_) {
+    if (subgraph->order() > 0) {
+      subgraph->AddPathLengthCost(weight_matrix);
+    }
+  }
+  global_path_length_costs_.push_back(weight_matrix);
+}
+
+void GcsTrajectoryOptimization::AddPathLengthCost(double weight) {
+  const MatrixXd weight_matrix =
+      weight * MatrixXd::Identity(num_positions(), num_positions());
+  return GcsTrajectoryOptimization::AddPathLengthCost(weight_matrix);
+}
+
+std::pair<CompositeTrajectory<double>, solvers::MathematicalProgramResult>
+GcsTrajectoryOptimization::SolvePath(const Subgraph& source,
+                                     const Subgraph& target,
+                                     const GraphOfConvexSetsOptions& options) {
+  const VectorXd empty_vector;
+
+  VertexId source_id = source.vertices_[0]->id();
+  Vertex* dummy_source = nullptr;
+
+  VertexId target_id = target.vertices_[0]->id();
+  Vertex* dummy_target = nullptr;
+
+  if (source.size() != 1) {
+    // Source subgraph has more than one region. Add a dummy source vertex.
+    dummy_source = gcs_.AddVertex(Point(empty_vector), "Dummy source");
+    source_id = dummy_source->id();
+    for (const Vertex* v : source.vertices_) {
+      AddEdge(*dummy_source, *v);
+    }
+  }
+  const ScopeExit cleanup_dummy_source_before_returning([&]() {
+    if (dummy_source != nullptr) {
+      gcs_.RemoveVertex(dummy_source->id());
+    }
+  });
+
+  if (target.size() != 1) {
+    // Target subgraph has more than one region. Add a dummy target vertex.
+    dummy_target = gcs_.AddVertex(Point(empty_vector), "Dummy target");
+    target_id = dummy_target->id();
+    for (const Vertex* v : target.vertices_) {
+      AddEdge(*v, *dummy_target);
+    }
+  }
+  const ScopeExit cleanup_dummy_target_before_returning([&]() {
+    if (dummy_target != nullptr) {
+      gcs_.RemoveVertex(dummy_target->id());
+    }
+  });
+
+  solvers::MathematicalProgramResult result =
+      gcs_.SolveShortestPath(source_id, target_id, options);
+  if (!result.is_success()) {
+    return {CompositeTrajectory<double>({}), result};
+  }
+
+  // Extract the flow from the solution.
+  std::unordered_map<VertexId, std::vector<Edge*>> outgoing_edges;
+  std::unordered_map<EdgeId, double> flows;
+  for (Edge* edge : gcs_.Edges()) {
+    outgoing_edges[edge->u().id()].push_back(edge);
+    flows[edge->id()] = result.GetSolution(edge->phi());
+  }
+
+  // Extract the path by traversing the graph with a depth first search.
+  std::unordered_set<VertexId> visited_vertex_ids{source_id};
+  std::vector<VertexId> path_vertex_ids{source_id};
+  std::vector<Edge*> path_edges;
+  while (path_vertex_ids.back() != target_id) {
+    // Find the edge with the maximum flow from the current node.
+    double maximum_flow = 0;
+    VertexId max_flow_vertex_id;
+    Edge* max_flow_edge = nullptr;
+    for (Edge* e : outgoing_edges[path_vertex_ids.back()]) {
+      const double next_flow = flows[e->id()];
+      const VertexId next_vertex_id = e->v().id();
+
+      // If the edge has not been visited and has a flow greater than the
+      // current maximum, update the maximum flow and the vertex id.
+      if (visited_vertex_ids.count(e->v().id()) == 0 &&
+          next_flow > maximum_flow && next_flow > options.flow_tolerance) {
+        maximum_flow = next_flow;
+        max_flow_vertex_id = next_vertex_id;
+        max_flow_edge = e;
+      }
+    }
+
+    if (max_flow_edge == nullptr) {
+      // If no candidate edges are found, backtrack to the previous node and
+      // continue the search.
+      path_vertex_ids.pop_back();
+      DRAKE_DEMAND(!path_vertex_ids.empty());
+      continue;
+    } else {
+      // If the maximum flow is non-zero, add the vertex to the path and
+      // continue the search.
+      visited_vertex_ids.insert(max_flow_vertex_id);
+      path_vertex_ids.push_back(max_flow_vertex_id);
+      path_edges.push_back(max_flow_edge);
+    }
+  }
+
+  // Remove the dummy edges from the path.
+  if (dummy_source != nullptr) {
+    DRAKE_DEMAND(!path_edges.empty());
+    path_edges.erase(path_edges.begin());
+  }
+  if (dummy_target != nullptr) {
+    DRAKE_DEMAND(!path_edges.empty());
+    path_edges.erase(path_edges.end() - 1);
+  }
+
+  // Extract the path from the edges.
+  std::vector<copyable_unique_ptr<Trajectory<double>>> bezier_curves;
+  for (Edge* edge : path_edges) {
+    // Extract phi from the solution to rescale the control points and duration
+    // in case we get the relaxed solution.
+    const double phi_inv = 1 / result.GetSolution(edge->phi());
+    // Extract the control points from the solution.
+    const int num_control_points = (edge->xu().size() - 1) / num_positions();
+    const MatrixX<double> edge_path_points =
+        phi_inv *
+        Eigen::Map<MatrixX<double>>(result.GetSolution(edge->xu()).data(),
+                                    num_positions(), num_control_points);
+
+    // Extract the duration from the solution.
+    const double h = phi_inv * result.GetSolution(edge->xu()).tail<1>().value();
+    const double start_time =
+        bezier_curves.empty() ? 0 : bezier_curves.back()->end_time();
+    bezier_curves.emplace_back(std::make_unique<BezierCurve<double>>(
+        start_time, start_time + h, edge_path_points));
+  }
+
+  // Get the final control points from the solution.
+  const double phi_inv = 1 / result.GetSolution(path_edges.back()->phi());
+  const int num_control_points =
+      (path_edges.back()->xv().size() - 1) / num_positions();
+  const MatrixX<double> edge_path_points =
+      phi_inv * Eigen::Map<MatrixX<double>>(
+                    result.GetSolution(path_edges.back()->xv()).data(),
+                    num_positions(), num_control_points);
+
+  const double h =
+      phi_inv * result.GetSolution(path_edges.back()->xv()).tail<1>().value();
+  const double start_time =
+      bezier_curves.empty() ? 0 : bezier_curves.back()->end_time();
+  bezier_curves.emplace_back(std::make_unique<BezierCurve<double>>(
+      start_time, start_time + h, edge_path_points));
+
+  return {CompositeTrajectory<double>(bezier_curves), result};
+}
+
+Edge* GcsTrajectoryOptimization::AddEdge(const Vertex& u, const Vertex& v) {
+  return gcs_.AddEdge(u, v, fmt::format("{} -> {}", u.name(), v.name()));
+}
+
+}  // namespace trajectory_optimization
+}  // namespace planning
+}  // namespace drake

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -1,0 +1,345 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "drake/common/trajectories/bezier_curve.h"
+#include "drake/common/trajectories/composite_trajectory.h"
+#include "drake/geometry/optimization/convex_set.h"
+#include "drake/geometry/optimization/graph_of_convex_sets.h"
+
+namespace drake {
+namespace planning {
+namespace trajectory_optimization {
+
+/**
+GcsTrajectoryOptimization implements a simplified motion planning optimization
+problem introduced in the paper "Motion Planning around Obstacles with Convex
+Optimization."
+
+"Motion Planning around Obstacles with Convex Optimization" by Tobia Marcucci,
+Mark Petersen, David von Wrangel, Russ Tedrake. https://arxiv.org/abs/2205.04422
+
+Instead of using the full time-scaling curve, this problem uses a single
+time-scaling variable for each region. This formulation yields continuous
+trajectories, which are not differentiable at the transition times between the
+regions since non-convex continuity constraints are not supported yet. However,
+it supports continuity on the path for arbitrary degree. The resulting
+trajectories can be post-processed with e.g. Toppra in order to smooth out the
+timing rescaling.
+
+The ith piece of the composite trajectory is defined as q(t) = r((t - tᵢ) /
+hᵢ). r : [0, 1] → ℝⁿ is a the path, parametrized as a Bézier curve with order
+n. tᵢ and hᵢ are the initial time and duration of the ith sub-trajectory.
+
+This class supports the notion of a Subgraph of regions. This has proven useful
+to facilitate multi-modal motion planning such as: Subgraph A: find a
+collision-free trajectory for the robot to a grasping posture, Subgraph B: find
+a collision-free trajectory for the robot with the object in its hand to a
+placing posture, etc.
+*/
+class GcsTrajectoryOptimization final {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(GcsTrajectoryOptimization);
+
+  /** Constructs the motion planning problem.
+  @param num_positions is the dimension of the configuration space. */
+  explicit GcsTrajectoryOptimization(int num_positions);
+
+  ~GcsTrajectoryOptimization();
+
+  /** A Subgraph is a subset of the larger graph. It is defined by a set of
+  regions and edges between them based on intersection. From an API standpoint,
+  a Subgraph is useful to define a multi-modal motion planning problem. Further,
+  it allows different constraints and objects to be added to different
+  subgraphs. Note that the the GraphOfConvexSets does not differentiate between
+  subgraphs and can't be mixed with other instances of
+  GcsTrajectoryOptimization.
+  */
+  class Subgraph final {
+   public:
+    DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Subgraph);
+
+    ~Subgraph();
+
+    /** Returns the name of the subgraph. */
+    const std::string& name() const { return name_; }
+
+    /** Returns the order of the Bézier trajectory within the region. */
+    int order() const { return order_; }
+
+    /** Returns the number of vertices in the subgraph. */
+    int size() const { return vertices_.size(); }
+
+    /** Returns the regions associated with this subgraph before the
+    CartesianProduct. */
+    const geometry::optimization::ConvexSets& regions() const {
+      return regions_;
+    }
+
+    /** Adds multiple L2Norm Costs on the upper bound of the path length.
+    Since we cannot directly compute the path length of a Bézier curve, we
+    minimize the upper bound of the path integral by minimizing the sum of
+    distances between control points. For Bézier curves, this is equivalent to
+    the sum of the L2Norm of the derivative control points of the curve divided
+    by the order.
+
+    @param weight_matrix is the relative weight of each component for the cost.
+    The diagonal of the matrix is the weight for each dimension. The
+    off-diagonal elements are the weight for the cross terms, which can be used
+    to penalize diagonal movement.
+    @pre weight_matrix must be of size num_positions() x num_positions().
+    */
+    void AddPathLengthCost(const Eigen::MatrixXd& weight_matrix);
+
+    /** Adds multiple L2Norm Costs on the upper bound of the path length.
+    We upper bound the trajectory length by the sum of the distances between
+    control points. For Bézier curves, this is equivalent to the sum
+    of the L2Norm of the derivative control points of the curve divided by the
+    order.
+
+    @param weight is the relative weight of the cost.
+    */
+    void AddPathLengthCost(double weight = 1.0);
+
+   private:
+    /* Constructs a new subgraph and copies the regions. */
+    Subgraph(const geometry::optimization::ConvexSets& regions,
+             const std::vector<std::pair<int, int>>& regions_to_connect,
+             int order, double h_min, double h_max, std::string name,
+             GcsTrajectoryOptimization* traj_opt);
+
+    /* Convenience accessor, for brevity. */
+    int num_positions() const { return traj_opt_.num_positions(); }
+
+    const geometry::optimization::ConvexSets regions_;
+    const int order_;
+    const std::string name_;
+    GcsTrajectoryOptimization& traj_opt_;
+
+    std::vector<geometry::optimization::GraphOfConvexSets::Vertex*> vertices_;
+    std::vector<geometry::optimization::GraphOfConvexSets::Edge*> edges_;
+
+    // We keep track of the edge variables and trajectory since other
+    // constraints and costs will use these.
+    VectorX<symbolic::Variable> u_h_;
+    VectorX<symbolic::Variable> u_vars_;
+
+    // r(s)
+    trajectories::BezierCurve<symbolic::Expression> u_r_trajectory_;
+
+    friend class GcsTrajectoryOptimization;
+  };
+
+  /** EdgesBetweenSubgraphs are defined as the connecting edges between two
+  given subgraphs. These edges are a subset of the many other edges in the
+  larger graph. From an API standpoint, EdgesBetweenSubgraphs enable transitions
+  between Subgraphs, which can enable transitions between modes. Further, it
+  allows different constraints to be added in the transition between subgraphs.
+  Note that the EdgesBetweenSubgraphs can't be separated from the actual edges
+  in the GraphOfConvexSets framework, thus mixing it with other instances of
+  GCSTrajetoryOptimization is not supported.
+  */
+  class EdgesBetweenSubgraphs final {
+   public:
+    DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(EdgesBetweenSubgraphs);
+
+    ~EdgesBetweenSubgraphs();
+
+   private:
+    EdgesBetweenSubgraphs(const Subgraph& from_subgraph,
+                          const Subgraph& to_subgraph,
+                          const geometry::optimization::ConvexSet* subspace,
+                          GcsTrajectoryOptimization* traj_opt);
+
+    /* Convenience accessor, for brevity. */
+    int num_positions() const { return traj_opt_.num_positions(); }
+
+    bool RegionsConnectThroughSubspace(
+        const geometry::optimization::ConvexSet& A,
+        const geometry::optimization::ConvexSet& B,
+        const geometry::optimization::ConvexSet& subspace);
+
+    GcsTrajectoryOptimization& traj_opt_;
+
+    std::vector<geometry::optimization::GraphOfConvexSets::Edge*> edges_;
+
+    // We keep track of the edge variables and trajectory since other
+    // constraints and costs will use these.
+    VectorX<symbolic::Variable> u_h_;
+    VectorX<symbolic::Variable> u_vars_;
+    trajectories::BezierCurve<symbolic::Expression> u_r_trajectory_;
+
+    VectorX<symbolic::Variable> v_h_;
+    VectorX<symbolic::Variable> v_vars_;
+    trajectories::BezierCurve<symbolic::Expression> v_r_trajectory_;
+
+    friend class GcsTrajectoryOptimization;
+  };
+
+  /** Returns the number of position variables. */
+  int num_positions() const { return num_positions_; }
+
+  /** Returns a Graphviz string describing the graph vertices and edges.  If
+  `results` is supplied, then the graph will be annotated with the solution
+  values.
+  @param show_slacks determines whether the values of the intermediate
+  (slack) variables are also displayed in the graph.
+  @param precision sets the floating point precision (how many digits are
+  generated) of the annotations.
+  @param scientific sets the floating point formatting to scientific (if true)
+  or fixed (if false).
+  */
+  std::string GetGraphvizString(
+      const std::optional<solvers::MathematicalProgramResult>& result =
+          std::nullopt,
+      bool show_slack = true, int precision = 3,
+      bool scientific = false) const {
+    return gcs_.GetGraphvizString(result, show_slack, precision, scientific);
+  }
+
+  /** Creates a Subgraph with the given regions and indices.
+  @param regions represent the valid set a control point can be in. We retain a
+  copy of the regions since other functions may access them.
+  @param edges_between_regions is a list of pairs of indices into the regions
+  vector. For each pair representing an edge between two regions, an edge is
+  added within the subgraph. Note that the edges are directed so (i,j) will only
+  add an edge from region i to region j.
+  @param order is the order of the Bézier curve.
+  @param h_max is the maximum duration to spend in a region (seconds). Some
+  solvers struggle numerically with large values.
+  @param h_min is the minimum duration to spend in a region (seconds) if that
+  region is visited on the optimal path. Some cost and constraints are only
+  convex for h > 0. For example the perspective quadratic cost of the path
+  energy ||ṙ(s)||² / h becomes non-convex for h = 0. Otherwise h_min can be set
+  to 0.
+  @param name is the name of the subgraph. A default name will be provided.
+  */
+  Subgraph& AddRegions(
+      const geometry::optimization::ConvexSets& regions,
+      const std::vector<std::pair<int, int>>& edges_between_regions, int order,
+      double h_min = 1e-6, double h_max = 20, std::string name = "");
+
+  /** Creates a Subgraph with the given regions.
+  This function will compute the edges between the regions based on the set
+  intersections.
+  @param regions represent the valid set a control point can be in. We retain a
+  copy of the regions since other functions may access them.
+  @param order is the order of the Bézier curve.
+  @param h_max is the maximum duration to spend in a region (seconds). Some
+  solvers struggle numerically with large values.
+  @param h_min is the minimum duration to spend in a region (seconds) if that
+  region is visited on the optimal path. Some cost and constraints are only
+  convex for h > 0. For example the perspective quadratic cost of the path
+  energy ||ṙ(s)||² / h becomes non-convex for h = 0. Otherwise h_min can be set
+  to 0.
+  @param name is the name of the subgraph. A default name will be provided.
+  */
+  Subgraph& AddRegions(const geometry::optimization::ConvexSets& regions,
+                       int order, double h_min = 1e-6, double h_max = 20,
+                       std::string name = "");
+
+  /** Connects two subgraphs with directed edges.
+  @param from_subgraph is the subgraph to connect from. Must have been created
+  from a call to AddRegions() on this object, not some other optimization
+  program.
+  @param to_subgraph is the subgraph to connect to. Must have been created from
+  a call to AddRegions() on this object, not some other optimization program.
+  @param subspace is the subspace that the connecting control points must be in.
+  Subspace is optional. Only edges that connect through the subspace will be
+  added, and the subspace is added as a constraint on the connecting control
+  points. Subspaces of type point or HPolyhedron are supported since other sets
+  require constraints that are not yet supported by the GraphOfConvexSets::Edge
+  constraint, e.g., set containment of a HyperEllipsoid is formulated via
+  LorentzCone constraints. Workaround: Create a subgraph of zero order with the
+  subspace as the region and connect it between the two subgraphs. This works
+  because GraphOfConvexSet::Vertex , supports arbitrary instances of ConvexSets.
+  */
+  EdgesBetweenSubgraphs& AddEdges(
+      const Subgraph& from_subgraph, const Subgraph& to_subgraph,
+      const geometry::optimization::ConvexSet* subspace = nullptr);
+
+  /** Adds multiple L2Norm Costs on the upper bound of the path length.
+  Since we cannot directly compute the path length of a Bézier curve, we
+  minimize the upper bound of the path integral by minimizing the sum of
+  distances between control points. For Bézier curves, this is equivalent to the
+  sum of the L2Norm of the derivative control points of the curve divided by the
+  order.
+
+  This cost will be added to the entire graph. Since the path length is only
+  defined for Bézier curves that have two or more control points, this cost will
+  only added to all subgraphs with order greater than zero. Note that this cost
+  will be applied even to subgraphs added in the future.
+
+  @param weight_matrix is the relative weight of each component for the cost.
+  The diagonal of the matrix is the weight for each dimension. The
+  off-diagonal elements are the weight for the cross terms, which can be used
+  to penalize diagonal movement.
+  @pre weight_matrix must be of size num_positions() x num_positions().
+  */
+  void AddPathLengthCost(const Eigen::MatrixXd& weight_matrix);
+
+  /** Adds multiple L2Norm Costs on the upper bound of the path length.
+  Since we cannot directly compute the path length of a Bézier curve, we
+  minimize the upper bound of the path integral by minimizing the sum of
+  distances between control points. For Bézier curves, this is equivalent to the
+  sum of the L2Norm of the derivative control points of the curve divided by the
+  order.
+
+  This cost will be added to the entire graph. Since the path length is only
+  defined for Bézier curves that have two or more control points, this cost will
+  only added to all subgraphs with order greater than zero. Note that this cost
+  will be applied even to subgraphs added in the future.
+
+  @param weight is the relative weight of the cost.
+  */
+  void AddPathLengthCost(double weight = 1.0);
+
+  /** Formulates and solves the mixed-integer convex formulation of the
+  shortest path problem on the whole graph. @see
+  `geometry::optimization::GraphOfConvexSets::SolveShortestPath()` for further
+  details.
+
+  @param source specifies the source subgraph. Must have been created from a
+  call to AddRegions() on this object, not some other optimization program. If
+  the source is a subgraph with more than one region, an empty set will be added
+  and optimizer will choose the best region to start in. To start in a
+  particular point, consider adding a subgraph of order zero with a single
+  region of type Point.
+  @param target specifies the target subgraph. Must have been created from a
+  call to AddRegions() on this object, not some other optimization program. If
+  the target is a subgraph with more than one region, an empty set will be added
+  and optimizer will choose the best region to end in. To end in a particular
+  point, consider adding a subgraph of order zero with a single region of type
+  Point.
+  @param options include all settings for solving the shortest path problem.
+  @see `geometry::optimization::GraphOfConvexSetsOptions` for further details.
+  */
+  std::pair<trajectories::CompositeTrajectory<double>,
+            solvers::MathematicalProgramResult>
+  SolvePath(
+      const Subgraph& source, const Subgraph& target,
+      const geometry::optimization::GraphOfConvexSetsOptions& options = {});
+
+ private:
+  const int num_positions_;
+
+  // Adds a Edge to gcs_ with the name "{u.name} -> {v.name}".
+  geometry::optimization::GraphOfConvexSets::Edge* AddEdge(
+      const geometry::optimization::GraphOfConvexSets::Vertex& u,
+      const geometry::optimization::GraphOfConvexSets::Vertex& v);
+
+  geometry::optimization::GraphOfConvexSets gcs_;
+
+  // Store the subgraphs by reference.
+  std::vector<std::unique_ptr<Subgraph>> subgraphs_;
+  std::vector<std::unique_ptr<EdgesBetweenSubgraphs>> subgraph_edges_;
+  std::vector<Eigen::MatrixXd> global_path_length_costs_;
+};
+
+}  // namespace trajectory_optimization
+}  // namespace planning
+}  // namespace drake

--- a/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
@@ -1,0 +1,536 @@
+#include "drake/planning/trajectory_optimization/gcs_trajectory_optimization.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_no_throw.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/optimization/graph_of_convex_sets.h"
+#include "drake/geometry/optimization/hpolyhedron.h"
+#include "drake/geometry/optimization/point.h"
+#include "drake/geometry/optimization/vpolytope.h"
+#include "drake/solvers/gurobi_solver.h"
+#include "drake/solvers/mosek_solver.h"
+
+namespace drake {
+namespace planning {
+namespace trajectory_optimization {
+namespace {
+
+using Eigen::Vector2d;
+using geometry::optimization::ConvexSets;
+using geometry::optimization::GraphOfConvexSetsOptions;
+using geometry::optimization::HPolyhedron;
+using geometry::optimization::MakeConvexSets;
+using geometry::optimization::Point;
+using geometry::optimization::VPolytope;
+
+bool GurobiOrMosekSolverAvailable() {
+  return (solvers::MosekSolver::is_available() &&
+          solvers::MosekSolver::is_enabled()) ||
+         (solvers::GurobiSolver::is_available() &&
+          solvers::GurobiSolver::is_enabled());
+}
+
+GTEST_TEST(GcsTrajectoryOptimizationTest, Basic) {
+  const int kDimension = 2;
+  GcsTrajectoryOptimization gcs(kDimension);
+  EXPECT_EQ(gcs.num_positions(), kDimension);
+
+  // Add a single region (the unit box), and plan a line segment inside that
+  // box.
+  Vector2d start(-0.5, -0.5), goal(0.5, 0.5);
+
+  auto& regions =
+      gcs.AddRegions(MakeConvexSets(HPolyhedron::MakeUnitBox(kDimension)), 1);
+  auto& source = gcs.AddRegions(MakeConvexSets(Point(start)), 0);
+  auto& target = gcs.AddRegions(MakeConvexSets(Point(goal)), 0);
+
+  gcs.AddEdges(source, regions);
+  gcs.AddEdges(regions, target);
+
+  auto [traj, result] = gcs.SolvePath(source, target);
+  EXPECT_TRUE(result.is_success());
+  EXPECT_EQ(traj.rows(), 2);
+  EXPECT_EQ(traj.cols(), 1);
+  EXPECT_TRUE(CompareMatrices(traj.value(traj.start_time()), start, 1e-6));
+  EXPECT_TRUE(CompareMatrices(traj.value(traj.end_time()), goal, 1e-6));
+}
+
+GTEST_TEST(GcsTrajectoryOptimizationTest, InvalidPositions) {
+  /* Positions passed into GcsTrajectoryOptimization must be greater than 0.*/
+  DRAKE_EXPECT_THROWS_MESSAGE(GcsTrajectoryOptimization(0),
+                              ".*num_positions.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(GcsTrajectoryOptimization(-1),
+                              ".*num_positions.*");
+  DRAKE_EXPECT_NO_THROW(GcsTrajectoryOptimization(1));
+}
+
+GTEST_TEST(GcsTrajectoryOptimizationTest, InvalidOrder) {
+  /* Subgraph order must be non-negative.*/
+  const int kDimension = 2;
+  GcsTrajectoryOptimization gcs(kDimension);
+  EXPECT_EQ(gcs.num_positions(), kDimension);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      gcs.AddRegions(MakeConvexSets(HPolyhedron::MakeUnitBox(kDimension)), -1),
+      ".*order.*");
+
+  DRAKE_EXPECT_NO_THROW(
+      gcs.AddRegions(MakeConvexSets(HPolyhedron::MakeUnitBox(kDimension)), 0));
+}
+
+GTEST_TEST(GcsTrajectoryOptimizationTest, ZeroOrderPathLengthCost) {
+  /* Path length cost is not defined for a set of order 0.*/
+  const int kDimension = 2;
+  GcsTrajectoryOptimization gcs(kDimension);
+  EXPECT_EQ(gcs.num_positions(), kDimension);
+
+  auto& regions =
+      gcs.AddRegions(MakeConvexSets(HPolyhedron::MakeUnitBox(kDimension)), 0);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      regions.AddPathLengthCost(),
+      "Path length cost is not defined for a set of order 0.");
+  // This should consider the order of the subgraphs and not add the path length
+  // cost to the regions.
+  DRAKE_EXPECT_NO_THROW(gcs.AddPathLengthCost());
+}
+
+GTEST_TEST(GcsTrajectoryOptimizationTest, DisjointGraph) {
+  /* Adds four points to the graph without any edges. */
+  const int kDimension = 2;
+  GcsTrajectoryOptimization gcs(kDimension);
+  EXPECT_EQ(gcs.num_positions(), kDimension);
+
+  Vector2d start1(0.2, 0.2), start2(0.3, 3.2);
+  Vector2d goal1(4.8, 4.8), goal2(4.9, 2.4);
+
+  auto& source =
+      gcs.AddRegions(MakeConvexSets(Point(start1), Point(start2)), 0);
+
+  auto& target = gcs.AddRegions(MakeConvexSets(Point(goal1), Point(goal2)), 0);
+
+  if (!GurobiOrMosekSolverAvailable()) {
+    return;
+  }
+
+  // Define solver options.
+  GraphOfConvexSetsOptions options;
+  options.max_rounded_paths = 3;
+
+  auto [traj, result] = gcs.SolvePath(source, target, options);
+
+  EXPECT_FALSE(result.is_success());
+  // TODO(wrangelvid) Add a better way to check if composite trajectory is
+  // empty.
+  DRAKE_EXPECT_THROWS_MESSAGE(traj.rows(), ".*no segments.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(traj.cols(), ".*no segments.*");
+}
+
+GTEST_TEST(GcsTrajectoryOptimizationTest, InvalidSubspace) {
+  const int kDimension = 2;
+  GcsTrajectoryOptimization gcs(kDimension);
+  EXPECT_EQ(gcs.num_positions(), kDimension);
+
+  auto& regions1 =
+      gcs.AddRegions(MakeConvexSets(HPolyhedron::MakeUnitBox(kDimension)), 0);
+
+  auto& regions2 =
+      gcs.AddRegions(MakeConvexSets(HPolyhedron::MakeUnitBox(kDimension)), 0);
+
+  auto subspace_wrong_dimension = HPolyhedron::MakeUnitBox(kDimension + 1);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      gcs.AddEdges(regions1, regions2, &subspace_wrong_dimension),
+      "Subspace dimension must match the number of positions.");
+
+  Eigen::Matrix<double, 2, 4> vertices;
+  vertices << 5.0, 5.0, 4.4, 4.4, 2.8, 5.0, 5.0, 2.8;
+  VPolytope vertices_subspace{vertices};
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      gcs.AddEdges(regions1, regions2, &vertices_subspace),
+      "Subspace must be a Point or HPolyhedron.");
+}
+
+/* This 2D environment has been presented in the GCS paper.
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+░░      ░░░░░░░░                                      ░░░░░░░░         ░░
+░░      ░░░░░░░░                                      ░░░░░░░░         ░░
+░░      ░░░░░░░░                                      ░░░░░░░░    G    ░░
+░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░                       ░░
+░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░                       ░░
+░░                                 ░░░░░░░░░░░░░      ░░░░░░░░░░░░░░░░░░░
+░░                          ░░░░░░░░░░░░░░░░░░░░                       ░░
+░░                        ░░░░░░░░░░░░░░░░░░░░░░░░░                    ░░
+░░      ░░░░░░░░        ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░                  ░░
+░░      ░░░░░░░░          ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░                ░░
+░░      ░░░░░░░░            ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░              ░░
+░░      ░░░░░░░░              ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░            ░░
+░░      ░░░░░░░░                ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░          ░░
+░░      ░░░░░░░░                  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░        ░░
+░░      ░░░░░░░░                    ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░      ░░
+░░      ░░░░░░░░                      ░░░░░░░░░░░░░░░░░░░░░░░░░        ░░
+░░      ░░░░░░░░                        ░░░░░░░░░░░░░░░░░░░░░          ░░
+░░      ░░░░░░░░                          ░░░░░░░░░░░░░░░░░            ░░
+░░      ░░░░░░░░                            ░░░░░░░░░░░░░              ░░
+░░      ░░░░░░░░                                                       ░░
+░░  S   ░░░░░░░░                                                       ░░
+░░      ░░░░░░░░                                                       ░░
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+*/
+
+class SimpleEnv2D : public ::testing::Test {
+ protected:
+  SimpleEnv2D() {
+    Eigen::Matrix<double, 2, 4> vertices_1;
+    // clang-format off
+    vertices_1 << 0.4, 0.4, 0.0, 0.0,
+                  0.0, 5.0, 5.0, 0.0;
+    // clang-format on
+    HPolyhedron region_1{VPolytope(vertices_1)};
+
+    Eigen::Matrix<double, 2, 4> vertices_2;
+    // clang-format off
+    vertices_2 << 0.4, 1.0, 1.0, 0.4,
+                  2.4, 2.4, 2.6, 2.6;
+    // clang-format on
+    HPolyhedron region_2{VPolytope(vertices_2)};
+
+    Eigen::Matrix<double, 2, 4> vertices_3;
+    // clang-format off
+    vertices_3 << 1.4, 1.4, 1.0, 1.0,
+                  2.2, 4.6, 4.6, 2.2;
+    // clang-format on
+    HPolyhedron region_3{VPolytope(vertices_3)};
+
+    Eigen::Matrix<double, 2, 4> vertices_4;
+    // clang-format off
+    vertices_4 << 1.4, 2.4, 2.4, 1.4,
+                  2.2, 2.6, 2.8, 2.8;
+    // clang-format on
+    HPolyhedron region_4{VPolytope(vertices_4)};
+
+    Eigen::Matrix<double, 2, 4> vertices_5;
+    // clang-format off
+    vertices_5 << 2.2, 2.4, 2.4, 2.2,
+                  2.8, 2.8, 4.6, 4.6;
+    // clang-format on
+    HPolyhedron region_5{VPolytope(vertices_5)};
+
+    Eigen::Matrix<double, 2, 5> vertices_6;
+    // clang-format off
+    vertices_6 << 1.4, 1., 1., 3.8, 3.8,
+                  2.2, 2.2, 0.0, 0.0, 0.2;
+    // clang-format on
+    HPolyhedron region_6{VPolytope(vertices_6)};
+
+    Eigen::Matrix<double, 2, 4> vertices_7;
+    // clang-format off
+    vertices_7 << 3.8, 3.8, 1.0, 1.0,
+                  4.6, 5.0, 5.0, 4.6;
+    // clang-format on
+    HPolyhedron region_7{VPolytope(vertices_7)};
+
+    Eigen::Matrix<double, 2, 5> vertices_8;
+    // clang-format off
+    vertices_8 << 5.0, 5.0, 4.8, 3.8, 3.8,
+                  0.0, 1.2, 1.2, 0.2, 0.0;
+    // clang-format on
+    HPolyhedron region_8{VPolytope(vertices_8)};
+
+    Eigen::Matrix<double, 2, 4> vertices_9;
+    // clang-format off
+    vertices_9 << 3.4, 4.8, 5.0, 5.0,
+                  2.6, 1.2, 1.2, 2.6;
+    // clang-format on
+    HPolyhedron region_9{VPolytope(vertices_9)};
+
+    Eigen::Matrix<double, 2, 4> vertices_10;
+    // clang-format off
+    vertices_10 << 3.4, 3.8, 3.8, 3.4,
+                   2.6, 2.6, 4.6, 4.6;
+    // clang-format on
+    HPolyhedron region_10{VPolytope(vertices_10)};
+
+    Eigen::Matrix<double, 2, 4> vertices_11;
+    // clang-format off
+    vertices_11 << 3.8, 4.4, 4.4, 3.8,
+                   2.8, 2.8, 3.0, 3.0;
+    // clang-format on
+    HPolyhedron region_11{VPolytope(vertices_11)};
+
+    Eigen::Matrix<double, 2, 4> vertices_12;
+    // clang-format off
+    vertices_12 << 5.0, 5.0, 4.4, 4.4,
+                   2.8, 5.0, 5.0, 2.8;
+    // clang-format on
+    HPolyhedron region_12{VPolytope(vertices_12)};
+
+    regions_ = MakeConvexSets(region_1, region_2, region_3, region_4, region_5,
+                              region_6, region_7, region_8, region_9, region_10,
+                              region_11, region_12);
+  }
+  ConvexSets regions_;
+};
+
+TEST_F(SimpleEnv2D, BasicShortestPath) {
+  const int kDimension = 2;
+  GcsTrajectoryOptimization gcs(kDimension);
+  EXPECT_EQ(gcs.num_positions(), kDimension);
+
+  Vector2d start(0.2, 0.2), goal(4.8, 4.8);
+  auto& regions = gcs.AddRegions(regions_, 1);
+  auto& source = gcs.AddRegions(MakeConvexSets(Point(start)), 0);
+  auto& target = gcs.AddRegions(MakeConvexSets(Point(goal)), 0);
+
+  gcs.AddEdges(source, regions);
+  gcs.AddEdges(regions, target);
+
+  gcs.AddPathLengthCost();
+
+  if (!GurobiOrMosekSolverAvailable()) {
+    return;
+  }
+
+  // Define solver options.
+  GraphOfConvexSetsOptions options;
+  options.max_rounded_paths = 3;
+
+  auto [traj, result] = gcs.SolvePath(source, target, options);
+
+  EXPECT_TRUE(result.is_success());
+  EXPECT_TRUE(CompareMatrices(traj.value(traj.start_time()), start, 1e-6));
+  EXPECT_TRUE(CompareMatrices(traj.value(traj.end_time()), goal, 1e-6));
+}
+
+TEST_F(SimpleEnv2D, DurationDelay) {
+  /* The durations bounds in a subgraph can be used to enforce delays.*/
+  const int kDimension = 2;
+  const double kStartDelay = 10;
+  const double kGoalDelay = 20;
+
+  GcsTrajectoryOptimization gcs(kDimension);
+  EXPECT_EQ(gcs.num_positions(), kDimension);
+
+  // Add path length cost to whole graph before adding regions.
+  // New added regions will inherit this cost.
+  gcs.AddPathLengthCost();
+
+  Vector2d start(0.2, 0.2), goal(4.8, 4.8);
+  auto& regions = gcs.AddRegions(regions_, 1);
+  // Setting h_min = h_max = kStartDelay seconds will force to stay a the start
+  // of the trajectory for kStartDelay seconds.
+  auto& source =
+      gcs.AddRegions(MakeConvexSets(Point(start)), 0, kStartDelay, kStartDelay);
+  // Similarly for the goal, but with a delay of kGoalDelay seconds.
+  auto& target =
+      gcs.AddRegions(MakeConvexSets(Point(goal)), 0, kGoalDelay, kGoalDelay);
+
+  gcs.AddEdges(source, regions);
+  gcs.AddEdges(regions, target);
+
+  if (!GurobiOrMosekSolverAvailable()) {
+    return;
+  }
+
+  // Define solver options.
+  GraphOfConvexSetsOptions options;
+  options.max_rounded_paths = 3;
+
+  auto [traj, result] = gcs.SolvePath(source, target, options);
+
+  EXPECT_TRUE(result.is_success());
+  // The trajectory should stay at the start for kStartDelay seconds.
+  EXPECT_TRUE(CompareMatrices(traj.value(traj.start_time()), start, 1e-6));
+  EXPECT_TRUE(CompareMatrices(traj.value(kStartDelay), start, 1e-6));
+
+  // The trajectory should stay at the goal for kGaolDelay seconds.
+  EXPECT_TRUE(CompareMatrices(traj.value(traj.end_time()), goal, 1e-6));
+  EXPECT_TRUE(
+      CompareMatrices(traj.value(traj.end_time() - kGoalDelay), goal, 1e-6));
+
+  // The total trajectory duration should be at least kStartDelay + kGoalDelay.
+  EXPECT_TRUE(traj.end_time() - traj.start_time() >= kStartDelay + kGoalDelay);
+}
+
+TEST_F(SimpleEnv2D, MultiStartGoal) {
+  /* Planning between subgraphs also enables to select the shortest path
+  between multiple start and goal points.
+  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+  ░░      ░░░░░░░░                                      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░                                      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░                                      ░░░░░░░░    G1   ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+  ░░   S2 ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░                       ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░                       ░░
+  ░░                                 ░░░░░░░░░░░░░      ░░░░░░░░░░░░░░░░░░░
+  ░░                          ░░░░░░░░░░░░░░░░░░░░                       ░░
+  ░░                        ░░░░░░░░░░░░░░░░░░░░░░░░░                 G2 ░░
+  ░░      ░░░░░░░░        ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░                  ░░
+  ░░      ░░░░░░░░          ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░                ░░
+  ░░      ░░░░░░░░            ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░              ░░
+  ░░      ░░░░░░░░              ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░            ░░
+  ░░      ░░░░░░░░                ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░          ░░
+  ░░      ░░░░░░░░                  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░        ░░
+  ░░      ░░░░░░░░                    ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░      ░░
+  ░░      ░░░░░░░░                      ░░░░░░░░░░░░░░░░░░░░░░░░░        ░░
+  ░░      ░░░░░░░░                        ░░░░░░░░░░░░░░░░░░░░░          ░░
+  ░░      ░░░░░░░░                          ░░░░░░░░░░░░░░░░░            ░░
+  ░░      ░░░░░░░░                            ░░░░░░░░░░░░░              ░░
+  ░░      ░░░░░░░░                                                       ░░
+  ░░  S1  ░░░░░░░░                                                       ░░
+  ░░      ░░░░░░░░                                                       ░░
+  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+  */
+  const int kDimension = 2;
+
+  GcsTrajectoryOptimization gcs(kDimension);
+  EXPECT_EQ(gcs.num_positions(), kDimension);
+
+  Vector2d start1(0.2, 0.2), start2(0.3, 3.2);
+  Vector2d goal1(4.8, 4.8), goal2(4.9, 2.4);
+
+  auto& regions = gcs.AddRegions(regions_, 3);
+  auto& source =
+      gcs.AddRegions(MakeConvexSets(Point(start1), Point(start2)), 0);
+  auto& target = gcs.AddRegions(MakeConvexSets(Point(goal1), Point(goal2)), 0);
+
+  gcs.AddEdges(source, regions);
+  gcs.AddEdges(regions, target);
+
+  gcs.AddPathLengthCost();
+
+  if (!GurobiOrMosekSolverAvailable()) {
+    return;
+  }
+
+  // Define solver options.
+  GraphOfConvexSetsOptions options;
+  options.max_rounded_paths = 3;
+
+  auto [traj, result] = gcs.SolvePath(source, target, options);
+
+  EXPECT_TRUE(result.is_success());
+  EXPECT_TRUE(CompareMatrices(traj.value(traj.start_time()), start2, 1e-6));
+  EXPECT_TRUE(CompareMatrices(traj.value(traj.end_time()), goal2, 1e-6));
+}
+
+TEST_F(SimpleEnv2D, IntermediatePoint) {
+  /* Connecting two subgraphs with a subspace enables start to
+  goal planning with a desired intermediate point, I, somewhere along the path
+  or with a point contained in the subspace (lower right corner).
+  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+  ░░      ░░░░░░░░                                      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░                                      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░                                      ░░░░░░░░    G    ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░ I ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░      ░░░░░░░░         ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░                       ░░
+  ░░      ░░░░░░░░      ░░░░░░░░░░   ░░░░░░░░░░░░░                       ░░
+  ░░                                 ░░░░░░░░░░░░░      ░░░░░░░░░░░░░░░░░░░
+  ░░                          ░░░░░░░░░░░░░░░░░░░░                       ░░
+  ░░                        ░░░░░░░░░░░░░░░░░░░░░░░░░                    ░░
+  ░░      ░░░░░░░░        ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░                  ░░
+  ░░      ░░░░░░░░          ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░                ░░
+  ░░      ░░░░░░░░            ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░              ░░
+  ░░      ░░░░░░░░              ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░            ░░
+  ░░      ░░░░░░░░                ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░          ░░
+  ░░      ░░░░░░░░                  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░        ░░
+  ░░      ░░░░░░░░                    ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░xxxxxx░░
+  ░░      ░░░░░░░░                      ░░░░░░░░░░░░░░░░░░░░░░░░░xxxxxxxx░░
+  ░░      ░░░░░░░░                        ░░░░░░░░░░░░░░░░░░░░░xxxxxxxxxx░░
+  ░░      ░░░░░░░░                          ░░░░░░░░░░░░░░░░░xxxxxxxxxxxx░░
+  ░░      ░░░░░░░░                            ░░░░░░░░░░░░░xxx Subspace x░░
+  ░░      ░░░░░░░░                                       xxxxxxxxxxxxxxxx░░
+  ░░  S   ░░░░░░░░                                       xxxxxxxxxxxxxxxx░░
+  ░░      ░░░░░░░░                                       xxxxxxxxxxxxxxxx░░
+  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+  */
+  const int kDimension = 2;
+
+  GcsTrajectoryOptimization gcs(kDimension);
+  EXPECT_EQ(gcs.num_positions(), kDimension);
+
+  Vector2d start(0.2, 0.2), goal(4.8, 4.8), intermediate(2.3, 3.5);
+
+  // Both a Point and an HPolytope are valid subspaces.
+  Point subspace_point(intermediate);
+
+  Eigen::Matrix<double, 2, 5> vertices;
+  // clang-format off
+  vertices << 5.0, 5.0, 4.8, 3.8, 3.8,
+              0.0, 1.2, 1.2, 0.2, 0.0;
+  // clang-format on
+  HPolyhedron subspace_region{VPolytope(vertices)};
+
+  // We can have different order subgraphs.
+  // The trajectory from start to either subspace or intermidiate point will be
+  // of order 3 and the trajectory from intermediate to goal will be of order 2.
+  auto& main1 = gcs.AddRegions(regions_, 3, 1e-6, 20, "main1");
+  auto& main2 = gcs.AddRegions(regions_, 2, 1e-6, 20, "main2");
+
+  auto& source = gcs.AddRegions(MakeConvexSets(Point(start)), 0);
+  auto& target = gcs.AddRegions(MakeConvexSets(Point(goal)), 0);
+
+  // The following wiring will give GCS the choice to either go
+  // through subspace point or the subspace region.
+  gcs.AddEdges(source, main1);
+  // Connect the two subgraphs through the intermediate point.
+  gcs.AddEdges(main1, main2, &subspace_point);
+  // Connect the two subgraphs through the subspace region.
+  gcs.AddEdges(main1, main2, &subspace_region);
+  gcs.AddEdges(main2, target);
+
+  // We can add different costs to the individual subgraphs.
+  main1.AddPathLengthCost(5);
+
+  // This weight matrix penalizes movement in the y direction three times more
+  // than in the x direction.
+  Eigen::MatrixXd weight_matrix =
+      Eigen::MatrixXd::Identity(gcs.num_positions(), gcs.num_positions());
+  weight_matrix(1, 1) = 3.0;
+  main2.AddPathLengthCost(weight_matrix);
+
+  if (!GurobiOrMosekSolverAvailable()) {
+    return;
+  }
+
+  // Define solver options.
+  GraphOfConvexSetsOptions options;
+  options.max_rounded_paths = 3;
+
+  auto [traj, result] = gcs.SolvePath(source, target, options);
+
+  EXPECT_TRUE(result.is_success());
+  EXPECT_TRUE(CompareMatrices(traj.value(traj.start_time()), start, 1e-6));
+  EXPECT_TRUE(CompareMatrices(traj.value(traj.end_time()), goal, 1e-6));
+}
+
+}  // namespace
+}  // namespace trajectory_optimization
+}  // namespace planning
+}  // namespace drake


### PR DESCRIPTION
This adds a basic version of the motion planner introduced in the paper "Motion Planning around Obstacles with Convex
Optimization." by Tobia Marcucci,
Mark Petersen, David von Wrangel, Russ Tedrake. https://arxiv.org/abs/2205.04422

Instead of using the full time scaling curve, this `GCSTrajectoryOptimization` uses a single time
scaling variable for each region.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19239)
<!-- Reviewable:end -->
