### PR TITLE
[parsing] Improve parser_manual_test

### DIFF
--- a/multibody/parsing/test/parser_manual_test.cc
+++ b/multibody/parsing/test/parser_manual_test.cc
@@ -3,30 +3,49 @@
 #include "drake/multibody/parsing/parser.h"
 
 DEFINE_bool(scene_graph, true, "include/exclude scene graph");
-// TODO(rpoyner-tri): support parser flags, e.g. strict
-// TODO(rpoyner-tri): support adding package.xml files
+DEFINE_bool(strict, false, "enable strict parsing");
 
 namespace drake {
 namespace multibody {
 namespace {
 
 int do_main(int argc, char* argv[]) {
-  gflags::SetUsageMessage("[INPUT-FILE]\n"
+  gflags::SetUsageMessage("[INPUT-URL]\n"
                           "Run multibody parser; print errors if any");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   if (argc < 2) {
     drake::log()->error("missing input filename");
     return 1;
   }
+
+  // Hardcode a log pattern that gives us un-decorated error messages.
+  // This defeats the `-spdlog_pattern` command line option; oh well.
+  drake::logging::set_log_pattern("%v");
+
   MultibodyPlant<double> plant{0.0};
   drake::geometry::SceneGraph<double> scene_graph;
   if (FLAGS_scene_graph) {
     plant.RegisterAsSourceForSceneGraph(&scene_graph);
   }
   Parser parser{&plant};
+  parser.package_map().PopulateFromRosPackagePath();
+  if (FLAGS_strict) {
+    parser.SetStrictParsing();
+  }
 
   drake::log()->info("parsing {}", argv[1]);
-  std::vector<ModelInstanceIndex> models = parser.AddModels(argv[1]);
+
+  // Chances are good that parsing may end in an error (implemented as throw).
+  // For purposes of this tool, we should make its message usable. To do that,
+  // catch it and display it via logging. Yes, this violates the coding
+  // standard; in this case it makes the tool significantly more useful.
+  std::vector<ModelInstanceIndex> models;
+  try {
+    models = parser.AddModelsFromUrl(argv[1]);
+  } catch (const std::exception& e) {
+    drake::log()->error(e.what());
+  }
+
   drake::log()->info("Parsed {} models.", models.size());
   return models.empty();
 }


### PR DESCRIPTION
These changes push the manual test in the direction of being a useful tool for model checking and parser development.

* work more like //tools:model_visualizer
  * Support ROS_PACKAGE_PATH
  * Change the input type to URL
* Support strict parsing as an option
* Improve diagnostics output formatting