### PR TITLE
[parsing] Improve SDFormat inertia handling

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -488,6 +488,7 @@ drake_cc_googletest(
     name = "detail_common_test",
     deps = [
         ":detail_misc",
+        "//common/test_utilities",
     ],
 )
 

--- a/multibody/parsing/detail_sdf_diagnostic.cc
+++ b/multibody/parsing/detail_sdf_diagnostic.cc
@@ -87,6 +87,7 @@ bool SDFormatDiagnostic::PropagateErrors(
 
 bool IsError(const sdf::Error& report) {
   switch (report.Code()) {
+    case sdf::ErrorCode::LINK_INERTIA_INVALID:
     case sdf::ErrorCode::ELEMENT_DEPRECATED:
     case sdf::ErrorCode::VERSION_DEPRECATED:
     case sdf::ErrorCode::NONE: {

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -159,24 +159,6 @@ std::string GetRelativeBodyName(
   }
 }
 
-// Given a gz::math::Inertial object, extract a RotationalInertia object
-// for the rotational inertia of body B, about its center of mass Bcm and,
-// expressed in the inertial frame Bi (as specified in <inertial> in the SDF
-// file.)
-RotationalInertia<double> ExtractRotationalInertiaAboutBcmExpressedInBi(
-    const gz::math::Inertiald &inertial) {
-  // TODO(amcastro-tri): Verify that gz::math::Inertial::MOI() ALWAYS is
-  // expresed in the body frame B, regardless of how a user might have
-  // specified frames in the sdf file. That is, that it always returns R_BBcm_B.
-  // TODO(amcastro-tri): Verify that gz::math::Inertial::MassMatrix()
-  // ALWAYS is in the inertial frame Bi, regardless of how a user might have
-  // specified frames in the sdf file. That is, that it always returns
-  // M_BBcm_Bi.
-  const gz::math::Matrix3d I = inertial.MassMatrix().Moi();
-  return RotationalInertia<double>(I(0, 0), I(1, 1), I(2, 2),
-                                   I(1, 0), I(2, 0), I(2, 1));
-}
-
 // This takes an `sdf::SemanticPose`, which defines a pose relative to a frame,
 // and resolves its value with respect to another frame.
 math::RigidTransformd ResolveRigidTransform(
@@ -220,17 +202,10 @@ std::string ResolveJointChildLinkName(
 // frame origin Bo and, expressed in body frame B, from a gz::Inertial
 // object.
 SpatialInertia<double> ExtractSpatialInertiaAboutBoExpressedInB(
+    const SDFormatDiagnostic& diagnostic,
+    const sdf::ElementPtr link_element,
     const gz::math::Inertiald& Inertial_BBcm_Bi) {
   double mass = Inertial_BBcm_Bi.MassMatrix().Mass();
-
-  const RotationalInertia<double> I_BBcm_Bi =
-      ExtractRotationalInertiaAboutBcmExpressedInBi(Inertial_BBcm_Bi);
-
-  // If this is a massless body, return a zero SpatialInertia.
-  if (mass == 0. && I_BBcm_Bi.get_moments().isZero() &&
-      I_BBcm_Bi.get_products().isZero()) {
-    return SpatialInertia<double>(mass, {0., 0., 0.}, {0., 0., 0});
-  }
 
   // Pose of the "<inertial>" frame Bi in the body frame B.
   // TODO(amcastro-tri): Verify we don't get funny results when X_BBi is not
@@ -241,20 +216,18 @@ SpatialInertia<double> ExtractSpatialInertiaAboutBoExpressedInB(
   // give us X_BI. Verify this.
   const RigidTransformd X_BBi = ToRigidTransform(Inertial_BBcm_Bi.Pose());
 
-  // B and Bi are not necessarily aligned.
-  const RotationMatrixd R_BBi = X_BBi.rotation();
-
-  // Re-express in frame B as needed.
-  const RotationalInertia<double> I_BBcm_B = I_BBcm_Bi.ReExpress(R_BBi);
-
-  // Bi's origin is at the COM as documented in
-  // http://sdformat.org/spec?ver=1.6&elem=link#inertial_pose
-  const Vector3d p_BoBcm_B = X_BBi.translation();
-
-  // Return the spatial inertia M_BBo_B of body B, about its body frame origin
-  // Bo, and expressed in the body frame B.
-  return SpatialInertia<double>::MakeFromCentralInertia(
-      mass, p_BoBcm_B, I_BBcm_B);
+  // TODO(amcastro-tri): Verify that gz::math::Inertial::MOI() ALWAYS is
+  // expresed in the body frame B, regardless of how a user might have
+  // specified frames in the sdf file. That is, that it always returns R_BBcm_B.
+  // TODO(amcastro-tri): Verify that gz::math::Inertial::MassMatrix()
+  // ALWAYS is in the inertial frame Bi, regardless of how a user might have
+  // specified frames in the sdf file. That is, that it always returns
+  // M_BBcm_Bi.
+  const gz::math::Matrix3d I = Inertial_BBcm_Bi.MassMatrix().Moi();
+  return ParseSpatialInertia(diagnostic.MakePolicyForNode(*link_element),
+                             X_BBi, mass,
+                             {.ixx = I(0, 0), .iyy = I(1, 1), .izz = I(2, 2),
+                              .ixy = I(1, 0), .ixz = I(2, 0), .iyz = I(2, 1)});
 }
 
 // Helper method to retrieve a Body given the name of the link specification.
@@ -924,7 +897,8 @@ std::optional<std::vector<LinkInfo>> AddLinksFromSpecification(
     const gz::math::Inertiald& Inertial_Bcm_Bi = link.Inertial();
 
     const SpatialInertia<double> M_BBo_B =
-        ExtractSpatialInertiaAboutBoExpressedInB(Inertial_Bcm_Bi);
+        ExtractSpatialInertiaAboutBoExpressedInB(
+            diagnostic, link_element, Inertial_Bcm_Bi);
 
     // Add a rigid body to model each link.
     const RigidBody<double>& body =

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -160,84 +160,18 @@ SpatialInertia<double> UrdfParser::ExtractSpatialInertiaAboutBoExpressedInB(
     ParseScalarAttribute(mass, "value", &body_mass);
   }
 
-  // If physical validity checks fail below, return a prepared plausible
-  // inertia instead. Use a plausible guess for the mass, letting actual mass
-  // validity checking happen later.
-  const double plausible_dummy_mass =
-      (std::isfinite(body_mass) && body_mass > 0.0) ? body_mass : 1.0;
-  // Construct a dummy inertia for a solid sphere, with the density of water,
-  // and radius deduced from the plausible mass.
-  static constexpr double kPlausibleDensity{1000};  // Water is 1000 kg/m³.
-  const double plausible_volume = plausible_dummy_mass / kPlausibleDensity;
-  // Volume = (4/3)π(radius)³, so radius = ³√(3/(4π))(volume).
-  const double plausible_radius =
-      std::cbrt((3.0 / (4.0 * M_PI)) * plausible_volume);
-  // Create Mdum_BBo_B, a plausible spatial inertia for B about Bo (B's origin).
-  // To do this, create Mdum_BBcm (a plausible spatial inertia for B about
-  // Bcm) as a solid sphere and then shift that spatial inertia from Bcm to Bo.
-  // Note: It is unwise to directly create a solid sphere about Bo as this does
-  // not guarantee that the spatial inertia about Bcm is valid. Bcm (B's center
-  // of mass) is the ground-truth point for validity tests.
-  const SpatialInertia<double> Mdum_BBcm =
-    SpatialInertia<double>::SolidSphereWithDensity(
-       kPlausibleDensity, plausible_radius);
-  // Bi's origin is at the COM as documented in
-  // http://wiki.ros.org/urdf/XML/link#Elements
-  const Vector3d& p_BoBcm_B = X_BBi.translation();
-  const SpatialInertia<double> Mdum_BBo_B = Mdum_BBcm.Shift(-p_BoBcm_B);
-
-  double ixx = 0;
-  double ixy = 0;
-  double ixz = 0;
-  double iyy = 0;
-  double iyz = 0;
-  double izz = 0;
-
+  InertiaInputs inputs;
   XMLElement* inertia = node->FirstChildElement("inertia");
   if (inertia) {
-    ParseScalarAttribute(inertia, "ixx", &ixx);
-    ParseScalarAttribute(inertia, "ixy", &ixy);
-    ParseScalarAttribute(inertia, "ixz", &ixz);
-    ParseScalarAttribute(inertia, "iyy", &iyy);
-    ParseScalarAttribute(inertia, "iyz", &iyz);
-    ParseScalarAttribute(inertia, "izz", &izz);
+    ParseScalarAttribute(inertia, "ixx", &inputs.ixx);
+    ParseScalarAttribute(inertia, "ixy", &inputs.ixy);
+    ParseScalarAttribute(inertia, "ixz", &inputs.ixz);
+    ParseScalarAttribute(inertia, "iyy", &inputs.iyy);
+    ParseScalarAttribute(inertia, "iyz", &inputs.iyz);
+    ParseScalarAttribute(inertia, "izz", &inputs.izz);
   }
-
-  // Yes, catching exceptions violates the coding standard. It is done here to
-  // capture math-aware exceptions into parse-time warnings, since non-physical
-  // inertias are all too common, and the thrown messages are actually pretty
-  // useful.
-  RotationalInertia<double> I_BBcm_Bi;
-  try {
-    // Use the factory method here; it doesn't change its diagnostic behavior
-    // between release and debug builds.
-    I_BBcm_Bi = RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
-            ixx, iyy, izz, ixy, ixz, iyz);
-  } catch (const std::exception& e) {
-    Warning(*node, e.what());
-    return Mdum_BBo_B;
-  }
-
-  // If this is a massless body, return a zero SpatialInertia.
-  if (body_mass == 0.0 && I_BBcm_Bi.get_moments().isZero() &&
-      I_BBcm_Bi.get_products().isZero()) {
-    return SpatialInertia<double>(
-        0.0, Vector3d::Zero(), UnitInertia<double>{0.0, 0.0, 0.0});
-  }
-  // B and Bi are not necessarily aligned.
-  const math::RotationMatrix<double> R_BBi(X_BBi.rotation());
-
-  // Re-express in frame B as needed.
-  const RotationalInertia<double> I_BBcm_B = I_BBcm_Bi.ReExpress(R_BBi);
-
-  try {
-    return SpatialInertia<double>::MakeFromCentralInertia(
-        body_mass, p_BoBcm_B, I_BBcm_B);
-  } catch (const std::exception& e) {
-    Warning(*node, e.what());
-    return Mdum_BBo_B;
-  }
-  DRAKE_UNREACHABLE();
+  return ParseSpatialInertia(diagnostic_.MakePolicyForNode(node),
+                             X_BBi, body_mass, inputs);
 }
 
 void UrdfParser::ParseBody(XMLElement* node, MaterialMap* materials) {

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -503,7 +503,7 @@ TEST_F(SdfParserTest, ZeroMassNonZeroInertia) {
   // Test that attempt to parse links with zero mass and non-zero inertia fails.
   AddSceneGraph();
   const std::string expected_message = ".*condition 'mass > 0' failed.";
-  DRAKE_EXPECT_THROWS_MESSAGE(ParseTestString(R"""(
+  ParseTestString(R"""(
 <model name='bad'>
   <link name='bad'>
     <inertial>
@@ -518,7 +518,8 @@ TEST_F(SdfParserTest, ZeroMassNonZeroInertia) {
       </inertia>
     </inertial>
   </link>
-</model>)"""), expected_message);
+</model>)""");
+  EXPECT_THAT(TakeWarning(), ::testing::MatchesRegex(expected_message));
 }
 
 TEST_F(SdfParserTest, FloatingBodyPose) {

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -158,6 +158,13 @@ namespace multibody {
 /// which drake::scalar_predicate<T>::is_bool is `true`. For instance, validity
 /// checks are not performed when T is symbolic::Expression.
 ///
+/// @note The methods of this class satisfy the "basic exception guarantee": if
+/// an exception is thrown, the program will still be in a valid
+/// state. Specifically, no resources are leaked, and all objects' invariants
+/// are intact. Be aware that RotationalInertia objects may contain invalid
+/// inertia data in cases where input checking is skipped.
+/// @see https://en.cppreference.com/w/cpp/language/exceptions
+///
 /// Various methods in this class require numerical (not symbolic) data types.
 ///
 /// @tparam_default_scalar

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -86,6 +86,13 @@ namespace multibody {
 /// which drake::scalar_predicate<T>::is_bool is `true`. For instance, validity
 /// checks are not performed when T is symbolic::Expression.
 ///
+/// @note The methods of this class satisfy the "basic exception guarantee": if
+/// an exception is thrown, the program will still be in a valid
+/// state. Specifically, no resources are leaked, and all objects' invariants
+/// are intact. Be aware that SpatialInertia objects may contain invalid
+/// inertia data in cases where input checking is skipped.
+/// @see https://en.cppreference.com/w/cpp/language/exceptions
+///
 /// @see To create a spatial inertia of a mesh, see
 /// @ref CalcSpatialInertia(const geometry::TriangleSurfaceMesh<double>& mesh, double density). <!--# NOLINT-->
 ///

--- a/multibody/tree/unit_inertia.h
+++ b/multibody/tree/unit_inertia.h
@@ -35,6 +35,13 @@ namespace multibody {
 /// Also notice that once a unit inertia is created, it _is_ the unit inertia
 /// of _some_ body, perhaps with scaled geometry from the user's intention.
 ///
+/// @note The methods of this class satisfy the "basic exception guarantee": if
+/// an exception is thrown, the program will still be in a valid
+/// state. Specifically, no resources are leaked, and all objects' invariants
+/// are intact. Be aware that UnitInertia objects may contain invalid inertia
+/// data in cases where input checking is skipped.
+/// @see https://en.cppreference.com/w/cpp/language/exceptions
+///
 /// @tparam_default_scalar
 template <typename T>
 class UnitInertia : public RotationalInertia<T> {


### PR DESCRIPTION
This patch brings inertia invalidity reporting under diagnostic policy, and relaxes inertia problems from hard throws to warnings.

The move to diagnostic policy means that inertia warnings give file names and line numbers, which make it easier to fix problems. In the case of SDFormat, this patch demotes the useless error message from the underlying sdformat library to a warning, and emits more detailed warnings in the later translation-to-Drake phase.

The move from hard throws to warnings means that models with non-physical inertias can still be used with non-simulation workflows, such as visualization, kinematics, and analysis.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19245)
<!-- Reviewable:end -->
