### PR TITLE
DiscreteDerivative sets suppress_initial_transient=true by default

### DIFF
--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -163,7 +163,7 @@ PYBIND11_MODULE(primitives, m) {
     DefineTemplateClassWithDefault<DiscreteDerivative<T>, LeafSystem<T>>(
         m, "DiscreteDerivative", GetPyParam<T>(), doc.DiscreteDerivative.doc)
         .def(py::init<int, double, bool>(), py::arg("num_inputs"),
-            py::arg("time_step"), py::arg("suppress_initial_transient") = false,
+            py::arg("time_step"), py::arg("suppress_initial_transient") = true,
             doc.DiscreteDerivative.ctor.doc)
         .def("time_step", &DiscreteDerivative<T>::time_step,
             doc.DiscreteDerivative.time_step.doc)
@@ -386,7 +386,7 @@ PYBIND11_MODULE(primitives, m) {
         Diagram<T>>(m, "StateInterpolatorWithDiscreteDerivative",
         GetPyParam<T>(), doc.StateInterpolatorWithDiscreteDerivative.doc)
         .def(py::init<int, double, bool>(), py::arg("num_positions"),
-            py::arg("time_step"), py::arg("suppress_initial_transient") = false,
+            py::arg("time_step"), py::arg("suppress_initial_transient") = true,
             doc.StateInterpolatorWithDiscreteDerivative.ctor.doc)
         .def("suppress_initial_transient",
             &StateInterpolatorWithDiscreteDerivative<

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -716,18 +716,18 @@ class TestGeneral(unittest.TestCase):
         self.assertEqual(discrete_derivative.get_input_port(0).size(), 5)
         self.assertEqual(discrete_derivative.get_output_port(0).size(), 5)
         self.assertEqual(discrete_derivative.time_step(), 0.5)
-        self.assertFalse(discrete_derivative.suppress_initial_transient())
+        self.assertTrue(discrete_derivative.suppress_initial_transient())
 
         discrete_derivative = DiscreteDerivative(
-            num_inputs=5, time_step=0.5, suppress_initial_transient=True)
-        self.assertTrue(discrete_derivative.suppress_initial_transient())
+            num_inputs=5, time_step=0.5, suppress_initial_transient=False)
+        self.assertFalse(discrete_derivative.suppress_initial_transient())
 
     def test_state_interpolator_with_discrete_derivative(self):
         state_interpolator = StateInterpolatorWithDiscreteDerivative(
             num_positions=5, time_step=0.4)
         self.assertEqual(state_interpolator.get_input_port(0).size(), 5)
         self.assertEqual(state_interpolator.get_output_port(0).size(), 10)
-        self.assertFalse(state_interpolator.suppress_initial_transient())
+        self.assertTrue(state_interpolator.suppress_initial_transient())
 
         # test set_initial_position using context
         context = state_interpolator.CreateDefaultContext()

--- a/multibody/inverse_kinematics/differential_inverse_kinematics_integrator.h
+++ b/multibody/inverse_kinematics/differential_inverse_kinematics_integrator.h
@@ -17,23 +17,23 @@ produce joint position commands.
 In each evaluation, DoDifferentialInverseKinematics uses a linearization of the
 robot kinematics around a nominal position. The nominal position is obtained by
 either:
-1) If the optional boolean (abstract-)valued input port `use_robot_state` is
+1. If the optional boolean (abstract-)valued input port `use_robot_state` is
    connected and set to `true`, then differential IK is computed using the
    `robot_state` input port (which must also be connected). Note: Using
    measured joint positions in a feedback loop can lead to undamped
    oscillations in the redundant joints; we hope to resolve this and are
    tracking it in #9773.
-2) Otherwise, differential IK is computed using this System's internal state,
+2. Otherwise, differential IK is computed using this System's internal state,
    representing the current joint position command. This is equivalent to
    integrating (open loop) the velocity commands obtained from the differential
    IK solutions.
 
 It is also important to set the initial state of the integrator:
-1) If the `robot_state` port is connected, then the initial state of the
+1. If the `robot_state` port is connected, then the initial state of the
    integrator is set to match the positions from this port (the port accepts
    the state vector with positions and velocities for easy of use with
    MultibodyPlant, but only the positions are used).
-2) Otherwise, it is highly recommended that the user call `SetPosition()` to
+2. Otherwise, it is highly recommended that the user call SetPositions() to
    initialize the integrator state.
 
 @system

--- a/systems/primitives/discrete_derivative.h
+++ b/systems/primitives/discrete_derivative.h
@@ -34,6 +34,9 @@ namespace systems {
 ///   x₀[0], x₁[0], x₂[0] are initialized in the Context (default is zeros).
 /// </pre>
 ///
+/// @note Calling set_input_history() effectively disables the transient
+/// suppression by setting x_2 = 2.
+///
 /// @note For dynamical systems, a derivative should not be computed in
 /// continuous-time, i.e. `y(t) = (u(t) - u[n])/(t-n*h)`. This is numerically
 /// unstable since the time interval `t-n*h` could be arbitrarily close to
@@ -55,9 +58,12 @@ class DiscreteDerivative final : public LeafSystem<T> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiscreteDerivative)
 
   /// Constructor taking @p num_inputs, the size of the vector to be
-  /// differentiated, and @p time_step, the sampling interval.
+  /// differentiated, and @p time_step, the sampling interval. If @p
+  /// suppress_initial_transient is true (the default), then the output will be
+  /// zero for the first two time steps (see the class documentation for
+  /// details and exceptions).
   DiscreteDerivative(int num_inputs, double time_step,
-                     bool suppress_initial_transient = false);
+                     bool suppress_initial_transient = true);
 
   /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
   template <typename U>
@@ -147,11 +153,14 @@ class StateInterpolatorWithDiscreteDerivative final : public Diagram<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(StateInterpolatorWithDiscreteDerivative)
 
-  /// Constructor taking @p num_positions, the size of the position vector
-  /// to be differentiated, and @p time_step, the sampling interval.
+  /// Constructor taking @p num_positions, the size of the position vector to
+  /// be differentiated, and @p time_step, the sampling interval. If @p
+  /// suppress_initial_transient is true (the default), then the velocity
+  /// output will be zero for the first two time steps (see the
+  /// DiscreteDerivative class documentation for details and exceptions).
   StateInterpolatorWithDiscreteDerivative(
       int num_positions, double time_step,
-      bool suppress_initial_transient = false);
+      bool suppress_initial_transient = true);
 
   /// Returns the `suppress_initial_transient` passed to the constructor.
   bool suppress_initial_transient() const;

--- a/systems/primitives/test/discrete_derivative_test.cc
+++ b/systems/primitives/test/discrete_derivative_test.cc
@@ -109,7 +109,7 @@ GTEST_TEST(DiscreteDerivativeTest, ToSymbolic) {
 // This confirms that we've correctly conditioned the extra state for the
 // update counter to be declared only when strictly required.
 GTEST_TEST(DiscreteDerivativeTest, IsAffine) {
-  const DiscreteDerivative<double> dut(2, 0.1);
+  const DiscreteDerivative<double> dut(2, 0.1, false);
   auto symbolic = dut.ToSymbolic();
   SystemSymbolicInspector inspector(*symbolic);
   EXPECT_TRUE(inspector.IsTimeInvariant());


### PR DESCRIPTION
Also adds missing documentation and fixes up the doxygen for the related DifferentialInverseKinematicIntegrator.

+@jwnimmer-tri for both reviews, please?

I think this is a worthwhile change. Almost everyone wants the suppression; anyone who calls `set_input_history` manually has this default effectively overwritten.  The cost of not using the suppression is high (huge initial transients), and the cost of having extra suppression is low.

Inspired by https://stackoverflow.com/q/75981586/9510020.

Does this need to be labeled a breaking change?  I could find our policy on this in the developer docs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19247)
<!-- Reviewable:end -->
