### PR TITLE
Document direct_transcription::TimeStep

### DIFF
--- a/planning/trajectory_optimization/direct_transcription.h
+++ b/planning/trajectory_optimization/direct_transcription.h
@@ -16,7 +16,9 @@ namespace planning {
 namespace trajectory_optimization {
 
 // Helper struct holding a time-step value for continuous-time
-// DirectTranscription.
+// DirectTranscription. This is currently needed to disambiguate between the
+// constructors; DirectTranscription(system, context, int, int) could cast the
+// last int into a fixed_timestep or the input_port_index.
 struct TimeStep {
   double value{-1};
   explicit TimeStep(double step) : value(step) {}


### PR DESCRIPTION
Adds a note to remember why we have the atypical (and not very user friendly) TimeStep struct in direct_transcription.h.

+@jwnimmer-tri for both reviews, please?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19249)
<!-- Reviewable:end -->
