### PR TITLE
[workspace] Switch pybind11 to upstream

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_render.cc
+++ b/bindings/pydrake/geometry/geometry_py_render.cc
@@ -38,10 +38,10 @@ using systems::sensors::PixelType;
 
 namespace {
 
-class PyRenderEngine : public py::wrapper<RenderEngine> {
+class PyRenderEngine : public wrapper<RenderEngine> {
  public:
   using Base = RenderEngine;
-  using BaseWrapper = py::wrapper<Base>;
+  using BaseWrapper = wrapper<Base>;
   PyRenderEngine() : BaseWrapper() {}
 
   void UpdateViewpoint(RigidTransformd const& X_WR) override {

--- a/bindings/pydrake/geometry/geometry_py_render.cc
+++ b/bindings/pydrake/geometry/geometry_py_render.cc
@@ -64,7 +64,11 @@ class PyRenderEngine : public wrapper<RenderEngine> {
   }
 
   std::unique_ptr<RenderEngine> DoClone() const override {
+#if 1
+    return nullptr;
+#else
     PYBIND11_OVERLOAD_PURE(std::unique_ptr<RenderEngine>, Base, DoClone);
+#endif
   }
 
   void DoRenderColorImage(ColorRenderCamera const& camera,

--- a/bindings/pydrake/planning/planning_py_collision_checker.cc
+++ b/bindings/pydrake/planning/planning_py_collision_checker.cc
@@ -286,6 +286,7 @@ void DefinePlanningCollisionChecker(py::module m) {
         m, "SceneGraphCollisionChecker", cls_doc.doc);
     // TODO(jwnimmer-tri) Bind the __init__(params=...) constructor here once
     // we've solved the unique_ptr vs shared_ptr binding lifetime issue.
+#if 0
     py::object params_ctor = m.attr("CollisionCheckerParams");
     cls  // BR
         .def(py::init([params_ctor](std::unique_ptr<RobotDiagram<double>> model,
@@ -309,8 +310,10 @@ void DefinePlanningCollisionChecker(py::module m) {
                 "See :class:`pydrake.planning.CollisionCheckerParams` for the "
                 "list of properties available here as kwargs.")
                 .c_str());
+#endif
   }
 
+#if 0
   {
     using Class = UnimplementedCollisionChecker;
     constexpr auto& cls_doc = doc.UnimplementedCollisionChecker;
@@ -344,6 +347,7 @@ void DefinePlanningCollisionChecker(py::module m) {
                 "list of properties available here as kwargs.")
                 .c_str());
   }
+#endif
 }
 
 }  // namespace internal

--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -596,8 +596,8 @@ should use the drake::pydrake::WrapToMatchInputShape function.
 In general, minimize the amount in which users may subclass C++ classes in
 Python. When you do wish to do this, ensure that you use a trampoline class
 in `pybind`, and ensure that the trampoline class inherits from the
-`py::wrapper<>` class specific to our fork of `pybind`. This ensures that no
-slicing happens with the subclassed instances.
+`wrapper<>` class within pydrake. This ensures that no slicing happens with
+the subclassed instances.
 
 @anchor PydrakeBazelDebug
 # Interactive Debugging with Bazel

--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -145,8 +145,27 @@ inline void ExecuteExtraPythonCode(py::module m, bool use_subdir = false) {
     }                                                                     \
   }
 
+/* XXX comment me */
+struct npy_format_descriptor_object {
+ public:
+  enum { value = py::detail::npy_api::NPY_OBJECT_ };
+  static py::dtype dtype() {
+    if (auto ptr = py::detail::npy_api::get().PyArray_DescrFromType_(value)) {
+      return py::reinterpret_borrow<py::dtype>(ptr);
+    }
+    py::pybind11_fail("Unsupported buffer format!");
+  }
+  static constexpr auto name = py::detail::_("object");
+};
+
 }  // namespace pydrake
 }  // namespace drake
 
-#define DRAKE_PYBIND11_NUMPY_OBJECT_DTYPE(Type) \
-  PYBIND11_NUMPY_OBJECT_DTYPE(Type)
+#define DRAKE_PYBIND11_NUMPY_OBJECT_DTYPE(Type)                   \
+  namespace pybind11 {                                            \
+  namespace detail {                                              \
+  template <>                                                     \
+  struct npy_format_descriptor<Type>                              \
+      : public ::drake::pydrake::npy_format_descriptor_object {}; \
+  }  /* namespace pybind11 */                                     \
+  }  // namespace pydrake

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -221,9 +221,9 @@ void SetSolverOptionBySolverType(MathematicalProgram* self,
 }
 
 // pybind11 trampoline class to permit overriding virtual functions in Python.
-class PySolverInterface : public py::wrapper<solvers::SolverInterface> {
+class PySolverInterface : public wrapper<solvers::SolverInterface> {
  public:
-  using Base = py::wrapper<solvers::SolverInterface>;
+  using Base = wrapper<solvers::SolverInterface>;
 
   PySolverInterface() : Base() {}
 

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -237,12 +237,14 @@ PYBIND11_MODULE(analysis, m) {
     auto cls = DefineTemplateClassWithDefault<Simulator<T>>(
         m, "Simulator", GetPyParam<T>(), doc.Simulator.doc);
     cls  // BR
+#if 0
         .def(py::init<const System<T>&, unique_ptr<Context<T>>>(),
             py::arg("system"), py::arg("context") = nullptr,
             // Keep alive, reference: `self` keeps `system` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, ownership: `context` keeps `self` alive.
             py::keep_alive<3, 1>(), doc.Simulator.ctor.doc)
+#endif
         .def("Initialize", &Simulator<T>::Initialize,
             doc.Simulator.Initialize.doc,
             py::arg("params") = InitializeParams{})
@@ -307,11 +309,13 @@ Parameter ``interruptible``:
             py_rvp::reference_internal, doc.Simulator.get_mutable_context.doc)
         .def("has_context", &Simulator<T>::has_context,
             doc.Simulator.has_context.doc)
+#if 0
         .def("reset_context", &Simulator<T>::reset_context, py::arg("context"),
             // Keep alive, ownership: `context` keeps `self` alive.
             py::keep_alive<2, 1>(), doc.Simulator.reset_context.doc)
         // TODO(eric.cousineau): Bind `release_context` once some form of the
         // PR RobotLocomotion/pybind11#33 lands. Presently, it fails.
+#endif
         .def("set_publish_every_time_step",
             &Simulator<T>::set_publish_every_time_step, py::arg("publish"),
             doc.Simulator.set_publish_every_time_step.doc)
@@ -398,6 +402,7 @@ Parameter ``interruptible``:
     using namespace drake::systems::analysis;
     constexpr auto& doc = pydrake_doc.drake.systems.analysis;
 
+#if 0
     m.def("RandomSimulation",
         WrapCallbacks([](const SimulatorFactory make_simulator,
                           const ScalarSystemFunction& output, double final_time,
@@ -407,6 +412,7 @@ Parameter ``interruptible``:
         }),
         py::arg("make_simulator"), py::arg("output"), py::arg("final_time"),
         py::arg("generator"), doc.RandomSimulation.doc);
+#endif
 
     py::class_<RandomSimulationResult>(
         m, "RandomSimulationResult", doc.RandomSimulationResult.doc)
@@ -416,6 +422,7 @@ Parameter ``interruptible``:
             &RandomSimulationResult::generator_snapshot,
             doc.RandomSimulationResult.generator_snapshot.doc);
 
+#if 0
     // Note: This hard-codes `parallelism` to be off, since parallel execution
     // of Python systems on multiple threads was thought to be unsupported. It's
     // possible that with `py::call_guard<py::gil_scoped_release>` it would
@@ -431,6 +438,7 @@ Parameter ``interruptible``:
         py::arg("make_simulator"), py::arg("output"), py::arg("final_time"),
         py::arg("num_samples"), py::arg("generator"),
         doc.MonteCarloSimulation.doc);
+#endif
 
     {
       using Class = RegionOfAttractionOptions;

--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -170,6 +170,7 @@ PYBIND11_MODULE(controllers, m) {
     using Class = PidControlledSystem<double>;
     constexpr auto& cls_doc = doc.PidControlledSystem;
     py::class_<Class, Diagram<double>>(m, "PidControlledSystem", cls_doc.doc)
+#if 0
         .def(py::init<std::unique_ptr<System<double>>, double, double, double,
                  int, int>(),
             py::arg("plant"), py::arg("kp"), py::arg("ki"), py::arg("kd"),
@@ -201,6 +202,7 @@ PYBIND11_MODULE(controllers, m) {
             py::arg("plant_input_port_index") = 0,
             // Keep alive, ownership: `plant` keeps `self` alive.
             py::keep_alive<2, 1>(), cls_doc.ctor.doc_7args_vector_gains)
+#endif
         .def("get_control_input_port", &Class::get_control_input_port,
             py_rvp::reference_internal, cls_doc.get_control_input_port.doc)
         .def("get_state_input_port", &Class::get_state_input_port,

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -561,8 +561,10 @@ Note: The above is for the C++ documentation. For Python, use
     };
     type_visit(def_to_scalar_type_maybe, CommonScalarPack{});
 
+#if 0
     using AllocCallback = typename LeafOutputPort<T>::AllocCallback;
     using CalcCallback = typename LeafOutputPort<T>::CalcCallback;
+#endif
     using CalcVectorCallback = typename LeafOutputPort<T>::CalcVectorCallback;
 
     auto leaf_system_cls =
@@ -591,6 +593,7 @@ Note: The above is for the C++ documentation. For Python, use
             doc.LeafSystem.DeclareAbstractParameter.doc)
         .def("DeclareNumericParameter", &PyLeafSystem::DeclareNumericParameter,
             py::arg("model_vector"), doc.LeafSystem.DeclareNumericParameter.doc)
+#if 0
         .def("DeclareAbstractOutputPort",
             WrapCallbacks([](PyLeafSystem* self, const std::string& name,
                               AllocCallback arg1, CalcCallback arg2,
@@ -604,6 +607,7 @@ Note: The above is for the C++ documentation. For Python, use
                 std::set<DependencyTicket>{SystemBase::all_sources_ticket()},
             doc.LeafSystem.DeclareAbstractOutputPort
                 .doc_4args_name_alloc_function_calc_function_prerequisites_of_calc)
+#endif
         .def(
             "DeclareVectorInputPort",
             [](PyLeafSystem* self, std::string name,
@@ -1223,6 +1227,7 @@ void DoScalarIndependentDefinitions(py::module m) {
           &SystemScalarConverter::IsConvertible<T, U>, GetPyParam<T, U>(),
           cls_doc.IsConvertible.doc);
       using system_scalar_converter_internal::AddPydrakeConverterFunction;
+#if 0
       using ConverterFunction =
           std::function<std::unique_ptr<System<T>>(const System<U>&)>;
       AddTemplateMethod(converter, "_Add",
@@ -1235,6 +1240,7 @@ void DoScalarIndependentDefinitions(py::module m) {
                 AddPydrakeConverterFunction(self, bare_func);
               }),
           GetPyParam<T, U>());
+#endif
     };
     // N.B. When changing the pairs of supported types below, ensure that these
     // reflect the stanzas for the advanced constructor of

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -59,9 +59,9 @@ class SystemBasePublic : public SystemBase {
 // Provides a templated 'namespace'.
 template <typename T>
 struct Impl {
-  class PySystem : public py::wrapper<System<T>> {
+  class PySystem : public wrapper<System<T>> {
    public:
-    using Base = py::wrapper<System<T>>;
+    using Base = wrapper<System<T>>;
     using Base::Base;
     // Expose protected methods for binding.
     using Base::DeclareInputPort;
@@ -116,9 +116,9 @@ struct Impl {
   // documentation:
   // http://pybind11.readthedocs.io/en/stable/advanced/classes.html#combining-virtual-functions-and-inheritance
   template <typename LeafSystemBase = LeafSystemPublic>
-  class PyLeafSystemBase : public py::wrapper<LeafSystemBase> {
+  class PyLeafSystemBase : public wrapper<LeafSystemBase> {
    public:
-    using Base = py::wrapper<LeafSystemBase>;
+    using Base = wrapper<LeafSystemBase>;
     using Base::Base;
 
     // Trampoline virtual methods.
@@ -185,9 +185,9 @@ struct Impl {
   // documentation:
   // http://pybind11.readthedocs.io/en/stable/advanced/classes.html#combining-virtual-functions-and-inheritance
   template <typename DiagramBase = DiagramPublic>
-  class PyDiagramBase : public py::wrapper<DiagramBase> {
+  class PyDiagramBase : public wrapper<DiagramBase> {
    public:
-    using Base = py::wrapper<DiagramBase>;
+    using Base = wrapper<DiagramBase>;
     using Base::Base;
 
     SystemBase::GraphvizFragment DoGetGraphvizFragment(
@@ -216,9 +216,9 @@ struct Impl {
     using Base::DoCalcVectorTimeDerivatives;
   };
 
-  class PyVectorSystem : public py::wrapper<VectorSystemPublic> {
+  class PyVectorSystem : public wrapper<VectorSystemPublic> {
    public:
-    using Base = py::wrapper<VectorSystemPublic>;
+    using Base = wrapper<VectorSystemPublic>;
     using Base::Base;
 
     void DoCalcVectorOutput(const Context<T>& context,
@@ -267,7 +267,7 @@ struct Impl {
     }
   };
 
-  class PySystemVisitor : public py::wrapper<SystemVisitor<T>> {
+  class PySystemVisitor : public wrapper<SystemVisitor<T>> {
    public:
     // Trampoline virtual methods.
     void VisitSystem(const System<T>& system) override {

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -40,9 +40,14 @@ class PySerializerInterface : public py::wrapper<SerializerInterface> {
   // `PySerializerInterface`). C++ implementations will use the bindings on the
   // interface below.
 
-  std::unique_ptr<AbstractValue> CreateDefaultValue() const override {
-    PYBIND11_OVERLOAD_PURE(std::unique_ptr<AbstractValue>, SerializerInterface,
-        CreateDefaultValue);
+  std::unique_ptr<AbstractValue> CreateDefaultValue() const final {
+    py::object value = CreateDefaultValuePython();
+    return value.template cast<const AbstractValue*>()->Clone();
+  }
+
+  py::object CreateDefaultValuePython() const {
+    PYBIND11_OVERLOAD_PURE_NAME(py::object, SerializerInterface,
+        "CreateDefaultValue", CreateDefaultValuePython);
   }
 
   void Deserialize(const void* message_bytes, int message_length,

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -28,9 +28,9 @@ namespace {
 
 // pybind11 trampoline class to permit overriding virtual functions in
 // Python.
-class PySerializerInterface : public py::wrapper<SerializerInterface> {
+class PySerializerInterface : public wrapper<SerializerInterface> {
  public:
-  using Base = py::wrapper<SerializerInterface>;
+  using Base = wrapper<SerializerInterface>;
 
   PySerializerInterface() : Base() {}
 

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -167,9 +167,9 @@ struct Impl {
     using Base::value;
   };
 
-  class PyTrajectory : public py::wrapper<TrajectoryPublic> {
+  class PyTrajectory : public wrapper<TrajectoryPublic> {
    public:
-    using Base = py::wrapper<TrajectoryPublic>;
+    using Base = wrapper<TrajectoryPublic>;
     using Base::Base;
 
     // Trampoline virtual methods.

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -209,15 +209,21 @@ struct Impl {
 
     std::unique_ptr<Trajectory<T>> DoMakeDerivative(
         int derivative_order) const override {
+#if 0
       PYBIND11_OVERLOAD_INT(std::unique_ptr<Trajectory<T>>, Trajectory<T>,
           "DoMakeDerivative", derivative_order);
+#endif
       // If the macro did not return, use default functionality.
       return Base::DoMakeDerivative(derivative_order);
     }
 
     std::unique_ptr<Trajectory<T>> Clone() const override {
+#if 1
+      throw std::runtime_error("PyTrajectory::Clone() is not implemented");
+#else
       PYBIND11_OVERLOAD_PURE(
           std::unique_ptr<Trajectory<T>>, Trajectory<T>, Clone);
+#endif
     }
   };
 

--- a/tools/workspace/pybind11/package.BUILD.bazel
+++ b/tools/workspace/pybind11/package.BUILD.bazel
@@ -57,6 +57,7 @@ cc_library(
     name = "pybind11",
     hdrs = _HDRS,
     includes = ["include"],
+    defines = ["PYBIND11_NAMESPACE=pybind11"],
     deps = [
         "@eigen",
         "@python",

--- a/tools/workspace/pybind11/repository.bzl
+++ b/tools/workspace/pybind11/repository.bzl
@@ -1,16 +1,13 @@
 load("//tools/workspace:generate_file.bzl", "generate_file")
 load("//tools/workspace:github.bzl", "github_archive")
 
-# Using the `drake` branch of this repository.
-_REPOSITORY = "RobotLocomotion/pybind11"
+_REPOSITORY = "pybind/pybind11"
 
-# When upgrading this commit, check the version header within
-#  https://github.com/RobotLocomotion/pybind11/blob/drake/include/pybind11/detail/common.h
-# and if it has changed, then update the version number in the two
+# When upgrading this commit, also fix the version number in the two
 # pybind11-*.cmake files in the current directory to match.
-_COMMIT = "1f8e0c3c4365ed01f2551d61c8ea3e558f690809"
+_COMMIT = "v2.11.1"
 
-_SHA256 = "9de2e78026ddbfbdfd3b28c60d53f8f6021a5512638478692c3677c9f6890fb6"
+_SHA256 = "d475978da0cdc2d43b73f30910786759d593a9d8ee05b1b6846d1eb16c6d2e0c"
 
 def pybind11_repository(
         name,


### PR DESCRIPTION
This is a work-in-progress branch for the epic journey of getting rid of our Drake-specific pybind11 fork.

My plan is to carve out pieces as they become ripe.

Closes #5842.
Closes #13058.

Relates #7856.
Relates #12811.
Relates #14373.
Relates #14387.
Relates #14838.

Prerequisites:
- [x] #19251
- [x] #19369
- [x] #19570
- [x] #19571
- [x] #19572

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19250)
<!-- Reviewable:end -->
