### PR TITLE
[geometry/optimization] Support IRIS initial ellipse

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -309,6 +309,8 @@ void DefineGeometryOptimization(py::module m) {
         .def_readwrite("configuration_obstacles",
             &IrisOptions::configuration_obstacles,
             cls_doc.configuration_obstacles.doc)
+        .def_readwrite("starting_ellipse", &IrisOptions::starting_ellipse,
+            cls_doc.starting_ellipse.doc)
         .def_readwrite("num_additional_constraint_infeasible_samples",
             &IrisOptions::num_additional_constraint_infeasible_samples,
             cls_doc.num_additional_constraint_infeasible_samples.doc)

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -378,6 +378,7 @@ class TestGeometryOptimization(unittest.TestCase):
         options.termination_threshold = 0.1
         options.relative_termination_threshold = 0.01
         options.random_seed = 1314
+        options.starting_ellipse = mut.Hyperellipsoid.MakeUnitBall(3)
         self.assertNotIn("object at 0x", repr(options))
         region = mut.Iris(
             obstacles=obstacles, sample=[2, 3.4, 5],

--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -49,7 +49,8 @@ HPolyhedron Iris(const ConvexSets& obstacles, const Ref<const VectorXd>& sample,
   }
   DRAKE_DEMAND(domain.IsBounded());
   const double kEpsilonEllipsoid = 1e-2;
-  Hyperellipsoid E = Hyperellipsoid::MakeHypersphere(kEpsilonEllipsoid, sample);
+  Hyperellipsoid E = options.starting_ellipse.value_or(
+      Hyperellipsoid::MakeHypersphere(kEpsilonEllipsoid, sample));
   HPolyhedron P = domain;
 
   // On each iteration, we will build the collision-free polytope represented as
@@ -638,7 +639,8 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
                                        plant.GetPositionUpperLimits());
   DRAKE_DEMAND(P.A().rows() == 2 * nq);
   const double kEpsilonEllipsoid = 1e-2;
-  Hyperellipsoid E = Hyperellipsoid::MakeHypersphere(kEpsilonEllipsoid, sample);
+  Hyperellipsoid E = options.starting_ellipse.value_or(
+      Hyperellipsoid::MakeHypersphere(kEpsilonEllipsoid, sample));
 
   // Make all of the convex sets and supporting quantities.
   auto query_object =

--- a/geometry/optimization/iris.h
+++ b/geometry/optimization/iris.h
@@ -62,6 +62,11 @@ struct IrisOptions {
   pass in such configuration space obstacles. */
   ConvexSets configuration_obstacles{};
 
+  /** The initial hyperepllipsoid that IRIS will use for calculating hyperplanes
+  in the first iteration. If no hyperellipsoid is provided, a small hypershpere
+  centered at the given sample will be used. */
+  std::optional<Hyperellipsoid> starting_ellipse{};
+
   /** By default, IRIS in configuration space certifies regions for collision
   avoidance constraints and joint limits. This option can be used to pass
   additional constraints that should be satisfied by the IRIS region. We accept

--- a/geometry/optimization/test/iris_in_configuration_space_test.cc
+++ b/geometry/optimization/test/iris_in_configuration_space_test.cc
@@ -428,15 +428,7 @@ GTEST_TEST(IrisInConfigurationSpaceTest, DoublePendulum) {
   EXPECT_FALSE(region.PointInSet(Vector2d{-.4, -.3}));
 }
 
-// A block on a vertical track, free to rotate (in the plane) with width `w` and
-// height `h`, plus a ground plane at z=0.  The true configuration space is
-// min(q₀ ± .5w sin(q₁) ± .5h cos(q₁)) ≥ 0, where the min is over the ±.  These
-// regions are visualized at https://www.desmos.com/calculator/ok5ckpa1kp.
-GTEST_TEST(IrisInConfigurationSpaceTest, BlockOnGround) {
-  const double w = 2.0;
-  const double h = 1.0;
-  const std::string block_urdf = fmt::format(
-      R"(
+const char block_urdf[] = R"(
 <robot name="block">
   <link name="fixed">
     <collision name="ground">
@@ -457,7 +449,7 @@ GTEST_TEST(IrisInConfigurationSpaceTest, BlockOnGround) {
   </joint>
   <link name="link2">
     <collision name="block">
-      <geometry><box size="{w} 1 {h}"/></geometry>
+      <geometry><box size="2 1 1"/></geometry>
     </collision>
   </link>
   <joint name="joint2" type="revolute">
@@ -467,9 +459,14 @@ GTEST_TEST(IrisInConfigurationSpaceTest, BlockOnGround) {
     <child link="link2"/>
   </joint>
 </robot>
-)",
-      fmt::arg("w", w), fmt::arg("h", h));
+)";
 
+// A block on a vertical track, free to rotate (in the plane) with width `w` of
+// 2 and height `h` of 1, plus a ground plane at z=0.  The true configuration
+// space is min(q₀ ± .5w sin(q₁) ± .5h cos(q₁)) ≥ 0, where the min is over the
+// ±. These regions are visualized at
+// https://www.desmos.com/calculator/ok5ckpa1kp.
+GTEST_TEST(IrisInConfigurationSpaceTest, BlockOnGround) {
   const Vector2d sample{1.0, 0.0};
   IrisOptions options;
   HPolyhedron region = IrisFromUrdf(block_urdf, sample, options);
@@ -484,6 +481,22 @@ GTEST_TEST(IrisInConfigurationSpaceTest, BlockOnGround) {
   EXPECT_EQ(region.ambient_dimension(), 2);
   // Confirm that we've found a substantial region.
   EXPECT_GE(region.MaximumVolumeInscribedEllipsoid().Volume(), 2.0);
+}
+
+GTEST_TEST(IrisInConfigurationSpaceTest, StartingEllipse) {
+  const Vector2d sample{1.0, 0.0};
+  IrisOptions options;
+  options.iteration_limit = 2;
+  HPolyhedron region = IrisFromUrdf(block_urdf, sample, options);
+
+  options.iteration_limit = 1;
+  HPolyhedron iterative_region = IrisFromUrdf(block_urdf, sample, options);
+  options.starting_ellipse = iterative_region.MaximumVolumeInscribedEllipsoid();
+  iterative_region = IrisFromUrdf(block_urdf, sample, options);
+
+  EXPECT_NEAR(region.MaximumVolumeInscribedEllipsoid().Volume(),
+              iterative_region.MaximumVolumeInscribedEllipsoid().Volume(),
+              1e-7);
 }
 
 // A (somewhat contrived) example of a concave configuration-space obstacle


### PR DESCRIPTION
Enables specifying a starting ellipse to use for either `Iris` or `IrisInConfigurationSpace`. Useful for region refinement or taking additional growth steps if iteration limit terminated too soon.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19257)
<!-- Reviewable:end -->
