### PR TITLE
Revert "Add geometry::optimization::MakeConvexSets"

### DIFF
--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -160,7 +160,6 @@ drake_cc_googletest(
     deps = [
         ":convex_set",
         "//common/test_utilities:eigen_matrix_compare",
-        "//common/test_utilities:limit_malloc",
         "//solvers:clp_solver",
     ],
 )

--- a/geometry/optimization/convex_set.h
+++ b/geometry/optimization/convex_set.h
@@ -244,22 +244,6 @@ std::unique_ptr<ConvexSet> ConvexSetCloner(const ConvexSet& other) {
 instances. */
 typedef std::vector<copyable_unique_ptr<ConvexSet>> ConvexSets;
 
-/** Helper function that allows the ConvexSets to be initialized from arguments
-containing ConvexSet references, or unique_ptr<ConvexSet> instances, or any
-object that can be assigned to ConvexSets::value_type. */
-template <typename... Args>
-ConvexSets MakeConvexSets(Args&&... args) {
-  ConvexSets sets;
-  constexpr size_t N = sizeof...(args);
-  sets.resize(N);
-  // This is a "constexpr for" loop for 0 <= I < N.
-  auto args_tuple = std::forward_as_tuple(std::forward<Args>(args)...);
-  [&]<size_t... I>(std::integer_sequence<size_t, I...> &&) {
-    ((sets[I] = std::get<I>(std::move(args_tuple))), ...);
-  }(std::make_index_sequence<N>{});
-  return sets;
-}
-
 }  // namespace optimization
 }  // namespace geometry
 }  // namespace drake


### PR DESCRIPTION
Dear @RussTedrake ,

 The on-call build cop, @SeanCurtis-TRI , believes that your PR #19207 may have
 broken one or more of Drake's continuous integration builds [1]. It is
 possible to break a build even if your PR passed continuous integration
 pre-merge because additional platforms are tested post-merge.

 The specific build failures under investigation are:
- https://drake-jenkins.csail.mit.edu/view/Weekly%20Production/job/linux-focal-clang-bazel-weekly-mosek-leak-sanitizer/
- https://drake-jenkins.csail.mit.edu/view/Weekly%20Production/job/linux-focal-clang-bazel-weekly-mosek-thread-sanitizer/
- https://drake-jenkins.csail.mit.edu/view/Weekly%20Production/job/linux-jammy-clang-bazel-weekly-mosek-leak-sanitizer/
- https://drake-jenkins.csail.mit.edu/view/Weekly%20Production/job/linux-jammy-clang-bazel-weekly-mosek-thread-sanitizer/

 Therefore, the build cop has created this revert PR and started a complete
 post-merge build to determine whether your PR was in fact the cause of the
 problem. If that build passes, this revert PR will be merged 60 minutes from
 now. You can then fix the problem at your leisure, and send a new PR to
 reinstate your change.

 If you believe your original PR did not actually break the build, please
 explain on this thread.

 If you believe you can fix the break promptly in lieu of a revert, please
 explain on this thread, and send a PR to the build cop for review ASAP.

 If you believe your original PR definitely did break the build and should be
 reverted, please review and LGTM this PR. This allows the build cop to merge
 without waiting for CI results.

 For advice on how to handle a build cop revert, see [2].

 Thanks!
 Your Friendly On-call Build Cop

 [1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
 [2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert