### PR TITLE
[wheel] Pin `patchelf` to latest working version

### DIFF
--- a/tools/wheel/image/provision-python.sh
+++ b/tools/wheel/image/provision-python.sh
@@ -50,5 +50,8 @@ pip install \
     auditwheel
 
 if [[ "$(uname)" == "Linux" ]]; then
-    pip install patchelf
+    # TODO(19261): on 2023-04-24 the release of patchelf==0.18.0.0 results in
+    # misaligned sections.  For now we pin to the most recent working version.
+    # See: https://github.com/NixOS/patchelf/issues/492
+    pip install patchelf==0.17.2.1
 fi


### PR DESCRIPTION
Relates: #19261

The release of patchelf==0.18.0.0 has bugs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19262)
<!-- Reviewable:end -->
