### PR TITLE
[ignore] Enable from-source `patchelf` in wheel builds

### DIFF
--- a/tools/wheel/image/dependencies/projects.cmake
+++ b/tools/wheel/image/dependencies/projects.cmake
@@ -4,6 +4,12 @@ if(NOT APPLE)
     set(libxcrypt_url "https://github.com/besser82/libxcrypt/archive/v${libxcrypt_version}/libxcrypt-${libxcrypt_version}.tar.gz")
     set(libxcrypt_md5 "4828b1530f5bf35af0b45b35acc4db1d")
     list(APPEND ALL_PROJECTS libxcrypt)
+
+    # patchelf
+    set(patchelf_version 0.12)
+    set(patchelf_url "https://github.com/NixOS/patchelf/tarball/99c24238981b7b1084313aca8f5c493bb46f302c")
+    set(patchelf_md5 "9fa63224f9b73060ef6bd37f8effea8c")
+    list(APPEND ALL_PROJECTS patchelf)
 endif()
 
 # zlib

--- a/tools/wheel/image/dependencies/projects/patchelf.cmake
+++ b/tools/wheel/image/dependencies/projects/patchelf.cmake
@@ -1,0 +1,17 @@
+ExternalProject_Add(patchelf
+    URL ${patchelf_url}
+    URL_MD5 ${patchelf_md5}
+    ${COMMON_EP_ARGS}
+    BUILD_IN_SOURCE 1
+    PATCH_COMMAND ./bootstrap.sh
+    CONFIGURE_COMMAND ./configure
+        --prefix=${CMAKE_INSTALL_PREFIX}
+        --disable-shared
+        CFLAGS=-fPIC
+        CXXFLAGS=-fPIC
+    BUILD_COMMAND make
+    INSTALL_COMMAND make install
+    )
+
+# Note: patchelf is only used at build time, so there is no need to extract the
+# license for redistribution.

--- a/tools/wheel/image/provision-python.sh
+++ b/tools/wheel/image/provision-python.sh
@@ -48,7 +48,3 @@ pip install \
     setuptools \
     wheel \
     auditwheel
-
-if [[ "$(uname)" == "Linux" ]]; then
-    pip install patchelf
-fi


### PR DESCRIPTION
Reviving parts of #18163 to help enable testing for `patchelf` folks if desired.

Relates: #19261