### PR TITLE
[geometry/optimization] Optionally return all results from GCS

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -499,20 +499,53 @@ void DefineGeometryOptimization(py::module m) {
                 py::arg("result") = std::nullopt, py::arg("show_slacks") = true,
                 py::arg("precision") = 3, py::arg("scientific") = false,
                 cls_doc.GetGraphvizString.doc)
-            .def("SolveShortestPath",
-                overload_cast_explicit<solvers::MathematicalProgramResult,
-                    GraphOfConvexSets::VertexId, GraphOfConvexSets::VertexId,
-                    const GraphOfConvexSetsOptions&>(
-                    &GraphOfConvexSets::SolveShortestPath),
+            .def(
+                "SolveShortestPath",
+                [](const GraphOfConvexSets& self,
+                    GraphOfConvexSets::VertexId source_id,
+                    GraphOfConvexSets::VertexId target_id,
+                    const GraphOfConvexSetsOptions& options) {
+                  return self.SolveShortestPath(source_id, target_id, options);
+                },
                 py::arg("source_id"), py::arg("target_id"),
                 py::arg("options") = GraphOfConvexSetsOptions(),
                 cls_doc.SolveShortestPath.doc_by_id)
-            .def("SolveShortestPath",
-                overload_cast_explicit<solvers::MathematicalProgramResult,
-                    const GraphOfConvexSets::Vertex&,
-                    const GraphOfConvexSets::Vertex&,
-                    const GraphOfConvexSetsOptions&>(
-                    &GraphOfConvexSets::SolveShortestPath),
+            .def(
+                "SolveShortestPath",
+                [](const GraphOfConvexSets& self,
+                    const GraphOfConvexSets::Vertex& source,
+                    const GraphOfConvexSets::Vertex& target,
+                    const GraphOfConvexSetsOptions& options) {
+                  return self.SolveShortestPath(source, target, options);
+                },
+                py::arg("source"), py::arg("target"),
+                py::arg("options") = GraphOfConvexSetsOptions(),
+                cls_doc.SolveShortestPath.doc_by_reference)
+            .def(
+                "SolveShortestPathAllResults",
+                [](const GraphOfConvexSets& self,
+                    GraphOfConvexSets::VertexId source_id,
+                    GraphOfConvexSets::VertexId target_id,
+                    const GraphOfConvexSetsOptions& options) {
+                  std::vector<solvers::MathematicalProgramResult> all_results;
+                  auto result = self.SolveShortestPath(
+                      source_id, target_id, options, &all_results);
+                  return py::make_tuple(result, all_results);
+                },
+                py::arg("source_id"), py::arg("target_id"),
+                py::arg("options") = GraphOfConvexSetsOptions(),
+                cls_doc.SolveShortestPath.doc_by_id)
+            .def(
+                "SolveShortestPathAllResults",
+                [](const GraphOfConvexSets& self,
+                    const GraphOfConvexSets::Vertex& source,
+                    const GraphOfConvexSets::Vertex& target,
+                    const GraphOfConvexSetsOptions& options) {
+                  std::vector<solvers::MathematicalProgramResult> all_results;
+                  auto result = self.SolveShortestPath(
+                      source, target, options, &all_results);
+                  return py::make_tuple(result, all_results);
+                },
                 py::arg("source"), py::arg("target"),
                 py::arg("options") = GraphOfConvexSetsOptions(),
                 cls_doc.SolveShortestPath.doc_by_reference);

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -489,8 +489,9 @@ class GraphOfConvexSets {
   */
   solvers::MathematicalProgramResult SolveShortestPath(
       VertexId source_id, VertexId target_id,
-      const GraphOfConvexSetsOptions& options =
-          GraphOfConvexSetsOptions()) const;
+      const GraphOfConvexSetsOptions& options = GraphOfConvexSetsOptions(),
+      std::vector<solvers::MathematicalProgramResult>* all_results =
+          nullptr) const;
 
   /** Convenience overload that takes const reference arguments for source and
   target.
@@ -498,8 +499,9 @@ class GraphOfConvexSets {
   */
   solvers::MathematicalProgramResult SolveShortestPath(
       const Vertex& source, const Vertex& target,
-      const GraphOfConvexSetsOptions& options =
-          GraphOfConvexSetsOptions()) const;
+      const GraphOfConvexSetsOptions& options = GraphOfConvexSetsOptions(),
+      std::vector<solvers::MathematicalProgramResult>* all_results =
+          nullptr) const;
 
  private:
   /* Facilitates testing. */
@@ -528,6 +530,17 @@ class GraphOfConvexSets {
       solvers::MathematicalProgram* prog,
       const solvers::Binding<solvers::Constraint>& binding,
       const solvers::VectorXDecisionVariable& vars) const;
+
+  void FillResult(
+      std::map<VertexId, std::vector<Edge*>> incoming_edges,
+      std::map<VertexId, std::vector<Edge*>> outgoing_edges,
+      std::vector<Edge*> excluded_edges,
+      std::map<VertexId, solvers::MatrixXDecisionVariable> vertex_edge_ell,
+      std::map<EdgeId, symbolic::Variable> relaxed_phi,
+      std::vector<symbolic::Variable> excluded_phi, VertexId target_id,
+      const solvers::MathematicalProgram& prog,
+      const GraphOfConvexSetsOptions& options,
+      solvers::MathematicalProgramResult* result) const;
 
   std::map<VertexId, std::unique_ptr<Vertex>> vertices_{};
   std::map<EdgeId, std::unique_ptr<Edge>> edges_{};

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -1313,19 +1313,20 @@ GTEST_TEST(ShortestPathTest, RoundedSolution) {
   GraphOfConvexSetsOptions options;
   options.convex_relaxation = true;
   options.preprocessing = false;
-  options.max_rounded_paths = 0;
-  auto relaxed_result =
-      spp.SolveShortestPath(source->id(), target->id(), options);
-  ASSERT_TRUE(relaxed_result.is_success());
-
-  options.preprocessing = true;
   options.max_rounded_paths = 10;
-  auto rounded_result =
-      spp.SolveShortestPath(source->id(), target->id(), options);
+  std::vector<MathematicalProgramResult> all_results;
+  MathematicalProgramResult rounded_result =
+      spp.SolveShortestPath(source->id(), target->id(), options, &all_results);
+  MathematicalProgramResult relaxed_result = all_results[0];
+  ASSERT_TRUE(relaxed_result.is_success());
   ASSERT_TRUE(rounded_result.is_success());
 
   EXPECT_LT(relaxed_result.get_optimal_cost(),
             rounded_result.get_optimal_cost());
+  for (size_t ii = 1; ii < all_results.size(); ++ii) {
+    EXPECT_LE(rounded_result.get_optimal_cost(),
+              all_results[ii].get_optimal_cost());
+  }
 
   const auto& edges = spp.Edges();
   for (size_t ii = 0; ii < edges.size(); ++ii) {
@@ -1663,11 +1664,12 @@ GTEST_TEST(ShortestPathTest, Figure9) {
   e23->AddConstraint(e23->xu()[1] == e23->xv()[1]);
   e34->AddConstraint(e34->xu()[1] == e34->xv()[1]);
 
-  auto relaxed_result = spp.SolveShortestPath(source->id(), target->id());
   GraphOfConvexSetsOptions options;
   options.max_rounded_paths = 1;
-  auto rounded_result =
-      spp.SolveShortestPath(source->id(), target->id(), options);
+  std::vector<MathematicalProgramResult> all_results;
+  MathematicalProgramResult rounded_result =
+      spp.SolveShortestPath(source->id(), target->id(), options, &all_results);
+  MathematicalProgramResult relaxed_result = all_results[0];
 
   ASSERT_TRUE(relaxed_result.is_success());
   EXPECT_EQ(rounded_result.get_solution_result(),


### PR DESCRIPTION
This allows the caller to see the relaxed solution as well as all of the rounded solutions from calling `SolveShortestPath`. If the user doesn't request all the results, this does not add any overhead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19271)
<!-- Reviewable:end -->
