### PR TITLE
[common] Begin preparing for clang-format linting

### DIFF
--- a/common/autodiff_overloads.h
+++ b/common/autodiff_overloads.h
@@ -115,11 +115,10 @@ pow(const Eigen::AutoDiffScalar<DerTypeA>& base,
   // The two AutoDiffScalars being exponentiated must have the same matrix
   // type. This includes, but is not limited to, the same scalar type and
   // the same dimension.
-  static_assert(
-      std::is_same_v<
-          typename internal::remove_all<DerTypeA>::type::PlainObject,
-          typename internal::remove_all<DerTypeB>::type::PlainObject>,
-      "The derivative types must match.");
+  static_assert(std::is_same_v<
+                    typename internal::remove_all<DerTypeA>::type::PlainObject,
+                    typename internal::remove_all<DerTypeB>::type::PlainObject>,
+                "The derivative types must match.");
 
   internal::make_coherent(base.derivatives(), exponent.derivatives());
 
@@ -128,8 +127,8 @@ pow(const Eigen::AutoDiffScalar<DerTypeA>& base,
   const auto& y = exponent.value();
   const auto& ygrad = exponent.derivatives();
 
-  using std::pow;
   using std::log;
+  using std::pow;
   const auto x_to_the_y = pow(x, y);
   if (ygrad.isZero(std::numeric_limits<double>::epsilon()) ||
       ygrad.size() == 0) {
@@ -145,8 +144,8 @@ pow(const Eigen::AutoDiffScalar<DerTypeA>& base,
       // df/dv_i = (∂f/∂x * dx/dv_i) + (∂f/∂y * dy/dv_i)
       // ∂f/∂x is y*x^(y-1)
       y * pow(x, y - 1) * xgrad +
-      // ∂f/∂y is (x^y)*ln(x)
-      x_to_the_y * log(x) * ygrad);
+          // ∂f/∂y is (x^y)*ln(x)
+          x_to_the_y * log(x) * ygrad);
 }
 
 }  // namespace Eigen
@@ -205,8 +204,7 @@ if_then_else(bool f_cond, const Eigen::AutoDiffScalar<DerType1>& x,
   typedef Eigen::AutoDiffScalar<
       typename Eigen::internal::remove_all<DerType2>::type::PlainObject>
       ADS2;
-  static_assert(std::is_same_v<ADS1, ADS2>,
-                "The derivative types must match.");
+  static_assert(std::is_same_v<ADS1, ADS2>, "The derivative types must match.");
   return f_cond ? ADS1(x) : ADS2(y);
 }
 

--- a/common/cond.h
+++ b/common/cond.h
@@ -36,7 +36,7 @@ ScalarType cond(const ScalarType& e) {
   return e;
 }
 template <typename ScalarType, typename... Rest>
-ScalarType cond(const decltype(ScalarType() < ScalarType()) & f_cond,
+ScalarType cond(const decltype(ScalarType() < ScalarType())& f_cond,
                 const ScalarType& e_then, Rest... rest) {
   return if_then_else(f_cond, e_then, cond(rest...));
 }

--- a/common/copyable_unique_ptr.h
+++ b/common/copyable_unique_ptr.h
@@ -377,8 +377,7 @@ class copyable_unique_ptr : public std::unique_ptr<T> {
   // when an integer argument is provided.
   template <typename U = T>
   static constexpr std::enable_if_t<
-      std::is_same_v<decltype(U(std::declval<const U&>())), U>,
-      bool>
+      std::is_same_v<decltype(U(std::declval<const U&>())), U>, bool>
   can_copy(int) {
     return true;
   }
@@ -425,12 +424,13 @@ class copyable_unique_ptr : public std::unique_ptr<T> {
 
 // TODO(jwnimmer-tri) On 2023-06-01 also remove the <ostream> include above.
 template <class charT, class traits, class T>
-DRAKE_DEPRECATED("2023-06-01",
+DRAKE_DEPRECATED(
+    "2023-06-01",
     "Use fmt or spdlog for logging, not operator<<. "
     "See https://github.com/RobotLocomotion/drake/issues/17742 for details.")
-std::basic_ostream<charT, traits>& operator<<(
-    std::basic_ostream<charT, traits>& os,
-    const copyable_unique_ptr<T>& cu_ptr) {
+std::basic_ostream<charT, traits>&
+operator<<(std::basic_ostream<charT, traits>& os,
+           const copyable_unique_ptr<T>& cu_ptr) {
   os << cu_ptr.get();
   return os;
 }

--- a/common/diagnostic_policy.cc
+++ b/common/diagnostic_policy.cc
@@ -55,13 +55,11 @@ void DiagnosticPolicy::Error(std::string message) const {
   this->Error(d);
 }
 
-void DiagnosticPolicy::WarningDefaultAction(
-    const DiagnosticDetail& detail) {
+void DiagnosticPolicy::WarningDefaultAction(const DiagnosticDetail& detail) {
   log()->warn(detail.FormatWarning());
 }
 
-void DiagnosticPolicy::ErrorDefaultAction(
-    const DiagnosticDetail& detail) {
+void DiagnosticPolicy::ErrorDefaultAction(const DiagnosticDetail& detail) {
   throw std::runtime_error(detail.FormatError());
 }
 

--- a/common/drake_assert_and_throw.cc
+++ b/common/drake_assert_and_throw.cc
@@ -82,6 +82,6 @@ void AssertionFailed(const char* condition, const char* func, const char* file,
 // This method is intended ONLY for use by pydrake bindings, and thus is not
 // declared in any header file, to discourage anyone from using it.
 extern "C" void drake_set_assertion_failure_to_throw_exception() {
-  drake::internal::AssertionConfig::singleton().
-      assertion_failures_are_exceptions = true;
+  drake::internal::AssertionConfig::singleton()
+      .assertion_failures_are_exceptions = true;
 }

--- a/common/drake_bool.h
+++ b/common/drake_bool.h
@@ -42,7 +42,9 @@ typename Derived::Scalar all(const Eigen::DenseBase<Derived>& m) {
     // `all` holds vacuously when there is nothing to check.
     return Boolish{true};
   }
-  return m.redux([](const Boolish& v1, const Boolish& v2) { return v1 && v2; });
+  return m.redux([](const Boolish& v1, const Boolish& v2) {
+    return v1 && v2;
+  });
 }
 
 /// Checks if unary predicate @p pred holds for all elements in the matrix @p m.
@@ -66,7 +68,9 @@ typename Derived::Scalar any(const Eigen::DenseBase<Derived>& m) {
     // `any` is vacuously false when there is nothing to check.
     return Boolish{false};
   }
-  return m.redux([](const Boolish& v1, const Boolish& v2) { return v1 || v2; });
+  return m.redux([](const Boolish& v1, const Boolish& v2) {
+    return v1 || v2;
+  });
 }
 
 /// Checks if unary predicate @p pred holds for at least one element in the
@@ -83,7 +87,9 @@ boolean<typename Derived::Scalar> any_of(
 template <typename Derived>
 typename Derived::Scalar none(const Eigen::MatrixBase<Derived>& m) {
   using Boolish = typename Derived::Scalar;
-  const auto negate = [](const Boolish& v) -> Boolish { return !v; };
+  const auto negate = [](const Boolish& v) -> Boolish {
+    return !v;
+  };
   return drake::all(m.unaryExpr(negate));
 }
 
@@ -100,10 +106,9 @@ boolean<typename Derived::Scalar> none_of(
 /// Overloads if_then_else for Eigen vectors of `m_then` and `m_else` values
 /// with with a single `f_cond` condition to toggle them all at once.
 template <typename T, int Rows>
-auto if_then_else(
-    const boolean<T>& f_cond,
-    const Eigen::Matrix<T, Rows, 1>& m_then,
-    const Eigen::Matrix<T, Rows, 1>& m_else) {
+auto if_then_else(const boolean<T>& f_cond,
+                  const Eigen::Matrix<T, Rows, 1>& m_then,
+                  const Eigen::Matrix<T, Rows, 1>& m_else) {
   DRAKE_THROW_UNLESS(m_then.rows() == m_else.rows());
   const int rows = m_then.rows();
   Eigen::Matrix<T, Rows, 1> result(rows);

--- a/common/drake_copyable.h
+++ b/common/drake_copyable.h
@@ -30,10 +30,10 @@ class Foo {
 };
 </pre>
 */
-#define DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Classname)      \
-  Classname(const Classname&) = delete;                 \
-  void operator=(const Classname&) = delete;            \
-  Classname(Classname&&) = delete;                      \
+#define DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Classname) \
+  Classname(const Classname&) = delete;            \
+  void operator=(const Classname&) = delete;       \
+  Classname(Classname&&) = delete;                 \
   void operator=(Classname&&) = delete;
 
 /** DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN defaults the special member

--- a/common/drake_deprecated.h
+++ b/common/drake_deprecated.h
@@ -56,10 +56,9 @@ Sample uses: @code
 
 #else  // DRAKE_DOXYGEN_CXX
 
-#define DRAKE_DEPRECATED(removal_date, message)         \
-  [[deprecated(                                         \
-  "\nDRAKE DEPRECATED: " message                        \
-  "\nThe deprecated code will be removed from Drake"    \
-  " on or after " removal_date ".")]]
+#define DRAKE_DEPRECATED(removal_date, message)                   \
+  [[deprecated("\nDRAKE DEPRECATED: " message                     \
+               "\nThe deprecated code will be removed from Drake" \
+               " on or after " removal_date ".")]]
 
 #endif  // DRAKE_DOXYGEN_CXX

--- a/common/extract_double.h
+++ b/common/extract_double.h
@@ -5,17 +5,19 @@
 namespace drake {
 
 /// Returns @p scalar as a double.  Never throws.
-inline double ExtractDoubleOrThrow(double scalar) { return scalar; }
+inline double ExtractDoubleOrThrow(double scalar) {
+  return scalar;
+}
 
 /// Returns @p matrix as an Eigen::Matrix<double, ...> with the same size
 /// allocation as @p matrix.  Calls ExtractDoubleOrThrow on each element of the
 /// matrix, and therefore throws if any one of the extractions fail.
 template <typename Derived>
-typename std::enable_if_t<
-    std::is_same_v<typename Derived::Scalar, double>,
-    MatrixLikewise<double, Derived>>
+typename std::enable_if_t<std::is_same_v<typename Derived::Scalar, double>,
+                          MatrixLikewise<double, Derived>>
 ExtractDoubleOrThrow(const Eigen::MatrixBase<Derived>& matrix) {
-  return matrix.unaryExpr([](const typename Derived::Scalar& value) {
+  return matrix
+      .unaryExpr([](const typename Derived::Scalar& value) {
         return ExtractDoubleOrThrow(value);
       })
       .eval();

--- a/common/find_loaded_library.cc
+++ b/common/find_loaded_library.cc
@@ -4,19 +4,19 @@
 
 #include "drake/common/drake_throw.h"
 
+// clang-format off
 #ifdef __APPLE__
 #include <dlfcn.h>
-
 #include <mach-o/dyld.h>
 #include <mach-o/dyld_images.h>
-#else  // Not __APPLE__
+#else
 #include <libgen.h>  // dirname
-#include <string.h>
-#include <unistd.h>
-
 #include <link.h>
 #include <linux/limits.h>  // PATH_MAX
+#include <string.h>
+#include <unistd.h>
 #endif
+// clang-format on
 
 using std::string;
 
@@ -29,16 +29,15 @@ namespace drake {
 
 namespace {
 // Reads memory from MacOS specific structures into an `unsigned char*`.
-unsigned char * ReadProcessMemory(mach_vm_address_t addr,
-                                  mach_msg_type_number_t* size) {
+unsigned char* ReadProcessMemory(mach_vm_address_t addr,
+                                 mach_msg_type_number_t* size) {
   vm_offset_t readMem;
 
-  kern_return_t kr = vm_read(mach_task_self(), addr, *size,
-                             &readMem, size);
+  kern_return_t kr = vm_read(mach_task_self(), addr, *size, &readMem, size);
   if (kr != KERN_SUCCESS) {
     return NULL;
   }
-  return (reinterpret_cast<unsigned char *>(readMem));
+  return (reinterpret_cast<unsigned char*>(readMem));
 }
 }  // namespace
 // Gets the list of all the dynamic libraries that have been loaded. Finds
@@ -49,35 +48,33 @@ std::optional<string> LoadedLibraryPath(const string& library_name) {
   mach_msg_type_number_t count = TASK_DYLD_INFO_COUNT;
   // Getinformation from current process.
   if (task_info(mach_task_self(), TASK_DYLD_INFO,
-    reinterpret_cast<task_info_t>(&dyld_info), &count) == KERN_SUCCESS) {
+                reinterpret_cast<task_info_t>(&dyld_info),
+                &count) == KERN_SUCCESS) {
     // Recover list of dynamic libraries.
     mach_msg_type_number_t size = sizeof(dyld_all_image_infos);
     unsigned char* data =
-      ReadProcessMemory(dyld_info.all_image_info_addr, &size);
+        ReadProcessMemory(dyld_info.all_image_info_addr, &size);
     if (!data) {
       return std::nullopt;
     }
-    dyld_all_image_infos* infos =
-      reinterpret_cast<dyld_all_image_infos *>(data);
+    dyld_all_image_infos* infos = reinterpret_cast<dyld_all_image_infos*>(data);
 
     // Recover number of dynamic libraries in list.
     mach_msg_type_number_t size2 =
-      sizeof(dyld_image_info) * infos->infoArrayCount;
+        sizeof(dyld_image_info) * infos->infoArrayCount;
     unsigned char* info_addr = ReadProcessMemory(
         reinterpret_cast<mach_vm_address_t>(infos->infoArray), &size2);
     if (!info_addr) {
       return std::nullopt;
     }
-    dyld_image_info* info =
-      reinterpret_cast<dyld_image_info*>(info_addr);
+    dyld_image_info* info = reinterpret_cast<dyld_image_info*>(info_addr);
 
     // Loop over the dynamic libraries until `library_name` is found.
-    for (uint32_t i=0; i < infos->infoArrayCount; i++) {
-      const char * pos_slash = strrchr(info[i].imageFilePath, '/');
+    for (uint32_t i = 0; i < infos->infoArrayCount; i++) {
+      const char* pos_slash = strrchr(info[i].imageFilePath, '/');
       if (!strcmp(pos_slash + 1, library_name.c_str())) {
         // Path is always absolute on MacOS.
-        return string(info[i].imageFilePath,
-          pos_slash - info[i].imageFilePath);
+        return string(info[i].imageFilePath, pos_slash - info[i].imageFilePath);
       }
     }
   }
@@ -90,7 +87,7 @@ std::optional<string> LoadedLibraryPath(const string& library_name) {
 // This function is specific to Linux.
 std::optional<string> LoadedLibraryPath(const std::string& library_name) {
   void* handle = dlopen(NULL, RTLD_NOW);
-  link_map *map;
+  link_map* map;
   dlinfo(handle, RTLD_DI_LINKMAP, &map);
   // Loop over loaded shared objects until `library_name` is found.
   while (map) {
@@ -103,10 +100,10 @@ std::optional<string> LoadedLibraryPath(const std::string& library_name) {
     if (pos_slash && !strcmp(pos_slash + 1, library_name.c_str())) {
       // Check if path is relative. If so, make it absolute.
       if (map->l_name[0] != '/') {
-        std::string argv0 = std::filesystem::read_symlink({
-            "/proc/self/exe"}).string();
+        std::string argv0 =
+            std::filesystem::read_symlink({"/proc/self/exe"}).string();
         return string(dirname(&argv0[0])) + "/" +
-              string(map->l_name, pos_slash - map->l_name);
+               string(map->l_name, pos_slash - map->l_name);
       } else {
         return string(map->l_name, pos_slash - map->l_name);
       }

--- a/common/find_loaded_library.h
+++ b/common/find_loaded_library.h
@@ -10,5 +10,4 @@ namespace drake {
 /// process. Otherwise it returns an empty optional.
 std::optional<std::string> LoadedLibraryPath(const std::string& library_name);
 
-
 }  // namespace drake

--- a/common/find_resource.cc
+++ b/common/find_resource.cc
@@ -23,16 +23,16 @@ namespace fs = std::filesystem;
 
 using Result = FindResourceResult;
 
-std::optional<string>
-Result::get_absolute_path() const {
+std::optional<string> Result::get_absolute_path() const {
   return absolute_path_;
 }
 
-string
-Result::get_absolute_path_or_throw() const {
+string Result::get_absolute_path_or_throw() const {
   // If we have a path, return it.
   const auto& optional_path = get_absolute_path();
-  if (optional_path) { return *optional_path; }
+  if (optional_path) {
+    return *optional_path;
+  }
 
   // Otherwise, throw the error message.
   const auto& optional_error = get_error_message();
@@ -40,8 +40,7 @@ Result::get_absolute_path_or_throw() const {
   throw std::runtime_error(*optional_error);
 }
 
-std::optional<string>
-Result::get_error_message() const {
+std::optional<string> Result::get_error_message() const {
   // If an error has been set, return it.
   if (error_message_ != std::nullopt) {
     DRAKE_ASSERT(absolute_path_ == std::nullopt);
@@ -97,8 +96,8 @@ void Result::CheckInvariants() {
     DRAKE_DEMAND(error_message_ == std::nullopt);
   } else {
     // For our "non-empty" state, we must have exactly one of success or error.
-    DRAKE_DEMAND(
-        (absolute_path_ == std::nullopt) != (error_message_ == std::nullopt));
+    DRAKE_DEMAND((absolute_path_ == std::nullopt) !=
+                 (error_message_ == std::nullopt));
   }
   // When non-nullopt, the path and error cannot be the empty string.
   DRAKE_DEMAND((absolute_path_ == std::nullopt) || !absolute_path_->empty());
@@ -122,9 +121,8 @@ bool IsRelativePath(const string& path) {
 // Taking `root` to be Drake's resource root, confirm that the sentinel file
 // exists and return the found resource_path (or an error if either the
 // sentinel or resource_path was missing).
-Result CheckAndMakeResult(
-    const string& root_description, const string& root,
-    const string& resource_path) {
+Result CheckAndMakeResult(const string& root_description, const string& root,
+                          const string& resource_path) {
   DRAKE_DEMAND(!root_description.empty());
   DRAKE_DEMAND(!root.empty());
   DRAKE_DEMAND(!resource_path.empty());
@@ -133,21 +131,25 @@ Result CheckAndMakeResult(
 
   // Check for the sentinel.
   if (!fs::is_regular_file({root + "/" + kSentinelRelpath})) {
-    return Result::make_error(resource_path, fmt::format(
-        "Could not find Drake resource_path '{}' because {} specified a "
-        "resource root of '{}' but that root did not contain the expected "
-        "sentinel file '{}'.",
-        resource_path, root_description, root, kSentinelRelpath));
+    return Result::make_error(
+        resource_path,
+        fmt::format(
+            "Could not find Drake resource_path '{}' because {} specified a "
+            "resource root of '{}' but that root did not contain the expected "
+            "sentinel file '{}'.",
+            resource_path, root_description, root, kSentinelRelpath));
   }
 
   // Check for the resource_path.
   const string abspath = root + '/' + resource_path;
   if (!fs::is_regular_file({abspath})) {
-    return Result::make_error(resource_path, fmt::format(
-        "Could not find Drake resource_path '{}' because {} specified a "
-        "resource root of '{}' but that root did not contain the expected "
-        "file '{}'.",
-        resource_path, root_description, root, abspath));
+    return Result::make_error(
+        resource_path,
+        fmt::format(
+            "Could not find Drake resource_path '{}' because {} specified a "
+            "resource root of '{}' but that root did not contain the expected "
+            "file '{}'.",
+            resource_path, root_description, root, abspath));
   }
 
   return Result::make_success(resource_path, abspath);
@@ -159,28 +161,28 @@ std::optional<string> MaybeGetEnvironmentResourceRoot() {
   const char* const env_name = kDrakeResourceRootEnvironmentVariableName;
   const char* const env_value = getenv(env_name);
   if (!env_value) {
-    log()->debug(
-        "FindResource ignoring {} because it is not set.",
-        env_name);
+    log()->debug("FindResource ignoring {} because it is not set.", env_name);
     return std::nullopt;
   }
   const std::string root{env_value};
   if (!fs::is_directory({root})) {
     static const logging::Warn log_once(
-        "FindResource ignoring {}='{}' because it does not exist.",
-        env_name, env_value);
+        "FindResource ignoring {}='{}' because it does not exist.", env_name,
+        env_value);
     return std::nullopt;
   }
   if (!fs::is_directory({root + "/drake"})) {
     static const logging::Warn log_once(
         "FindResource ignoring {}='{}' because it does not contain a 'drake' "
-        "subdirectory.", env_name, env_value);
+        "subdirectory.",
+        env_name, env_value);
     return std::nullopt;
   }
   if (!fs::is_regular_file({root + "/" + kSentinelRelpath})) {
     static const logging::Warn log_once(
         "FindResource ignoring {}='{}' because it does not contain the "
-        "expected sentinel file '{}'.", env_name, env_value, kSentinelRelpath);
+        "expected sentinel file '{}'.",
+        env_name, env_value, kSentinelRelpath);
     return std::nullopt;
   }
   return root;
@@ -198,8 +200,10 @@ std::optional<string> MaybeGetInstallResourceRoot() {
     if (fs::is_directory({root})) {
       return root;
     } else {
-      log()->debug("FindResource ignoring CMake install candidate '{}' "
-                   "because it does not exist", root);
+      log()->debug(
+          "FindResource ignoring CMake install candidate '{}' because it does "
+          "not exist",
+          root);
     }
   } else {
     log()->debug("FindResource has no CMake install candidate");
@@ -226,15 +230,17 @@ Result FindResource(const string& resource_path) {
   // compatibility with the original semantics of this function; if we want to
   // offer a function that takes paths without "drake", we can use a new name.
   if (!IsRelativePath(resource_path)) {
-    return Result::make_error(resource_path, fmt::format(
-        "Drake resource_path '{}' is not a relative path.",
-        resource_path));
+    return Result::make_error(
+        resource_path,
+        fmt::format("Drake resource_path '{}' is not a relative path.",
+                    resource_path));
   }
   const string prefix("drake/");
   if (!StartsWith(resource_path, prefix)) {
-    return Result::make_error(resource_path, fmt::format(
-        "Drake resource_path '{}' does not start with {}.",
-        resource_path, prefix));
+    return Result::make_error(
+        resource_path,
+        fmt::format("Drake resource_path '{}' does not start with {}.",
+                    resource_path, prefix));
   }
 
   // We will check each potential resource root one by one.  The first root
@@ -266,19 +272,19 @@ Result FindResource(const string& resource_path) {
 
   // (3) Check the `libdrake_marker.so` location in the install tree.
   if (auto guess = MaybeGetInstallResourceRoot()) {
-    return CheckAndMakeResult(
-        "Drake CMake install marker",
-        *guess, resource_path);
+    return CheckAndMakeResult("Drake CMake install marker", *guess,
+                              resource_path);
   }
 
   // No resource roots were found.
-  return Result::make_error(resource_path, fmt::format(
-      "Could not find Drake resource_path '{}' because no resource roots of "
-      "any kind could be found: {} is unset, a {} could not be created or "
-      "did not contain {}, and there is no Drake CMake install marker.",
-      resource_path, kDrakeResourceRootEnvironmentVariableName,
-      "bazel::tools::cpp::runfiles::Runfiles",
-      kSentinelRelpath));
+  return Result::make_error(
+      resource_path,
+      fmt::format(
+          "Could not find Drake resource_path '{}' because no resource roots "
+          "of any kind could be found: {} is unset, a {} could not be created "
+          "or did not contain {}, and there is no Drake CMake install marker.",
+          resource_path, kDrakeResourceRootEnvironmentVariableName,
+          "bazel::tools::cpp::runfiles::Runfiles", kSentinelRelpath));
 }
 
 string FindResourceOrThrow(const string& resource_path) {

--- a/common/find_resource.h
+++ b/common/find_resource.h
@@ -41,14 +41,14 @@ class FindResourceResult {
   /// @pre neither string parameter is empty
   /// @param resource_path the value passed to FindResource
   /// @param base_path an absolute base path that precedes resource_path
-  static FindResourceResult make_success(
-      std::string resource_path, std::string absolute_path);
+  static FindResourceResult make_success(std::string resource_path,
+                                         std::string absolute_path);
 
   /// Returns an error result (the requested resource was NOT found).
   /// @pre neither string parameter is empty
   /// @param resource_path the value passed to FindResource
-  static FindResourceResult make_error(
-      std::string resource_path, std::string error_message);
+  static FindResourceResult make_error(std::string resource_path,
+                                       std::string error_message);
 
   /// Returns an empty error result (no requested resource).
   static FindResourceResult make_empty();

--- a/common/find_runfiles.cc
+++ b/common/find_runfiles.cc
@@ -67,8 +67,7 @@ RunfilesSingleton Create() {
     argv0 = argv0.c_str();  // Remove trailing nil bytes.
     drake::log()->debug("_NSGetExecutablePath = {}", argv0);
 #else
-    const std::string& argv0 = fs::read_symlink({
-        "/proc/self/exe"}).string();
+    const std::string& argv0 = fs::read_symlink({"/proc/self/exe"}).string();
     drake::log()->debug("readlink(/proc/self/exe) = {}", argv0);
 #endif
     result.runfiles.reset(Runfiles::Create(argv0, &bazel_error));
@@ -97,8 +96,8 @@ RunfilesSingleton Create() {
       bazel_error = "RUNFILES_DIR was not provided by the Runfiles object";
       result.runfiles.reset();
     } else if (!fs::is_directory({result.runfiles_dir})) {
-      bazel_error = fmt::format(
-          "RUNFILES_DIR '{}' does not exist", result.runfiles_dir);
+      bazel_error =
+          fmt::format("RUNFILES_DIR '{}' does not exist", result.runfiles_dir);
       result.runfiles.reset();
     }
   }
@@ -108,9 +107,8 @@ RunfilesSingleton Create() {
     result.runfiles_dir.clear();
     result.error = fmt::format(
         "{} (created using {} with TEST_SRCDIR={} and "
-            "RUNFILES_MANIFEST_FILE={} and RUNFILES_DIR={})",
-        bazel_error, mechanism,
-        nullable_to_string(std::getenv("TEST_SRCDIR")),
+        "RUNFILES_MANIFEST_FILE={} and RUNFILES_DIR={})",
+        bazel_error, mechanism, nullable_to_string(std::getenv("TEST_SRCDIR")),
         nullable_to_string(std::getenv("RUNFILES_MANIFEST_FILE")),
         nullable_to_string(std::getenv("RUNFILES_DIR")));
     drake::log()->debug("FindRunfile error: {}", result.error);

--- a/common/fmt.h
+++ b/common/fmt.h
@@ -125,40 +125,38 @@ refer to the given `ARG` name which will be of type `const TYPE& ARG`.
 `format_as` customization point with this feature built-in. If so, then we can
 update this macro to use that spelling, and eventually deprecate the macro once
 Drake drops support for earlier version of fmt. */
-#define DRAKE_FORMATTER_AS(TEMPLATE_ARGS, NAMESPACE, TYPE, ARG, EXPR)         \
-  /* Specializes the Converter<> class template for our TYPE. */              \
-  namespace drake::internal::formatter_as {                                   \
-  template <TEMPLATE_ARGS>                                                    \
-  struct Converter<NAMESPACE::TYPE> {                                         \
-    using InputType = NAMESPACE::TYPE;                                        \
-    static auto call(const InputType& ARG) { return EXPR; }                   \
-  };                                                                          \
-                                                                              \
-  /* Provides the fmt::formatter<TYPE> implementation. */                     \
-  template <TEMPLATE_ARGS>                                                    \
-  struct Formatter<NAMESPACE::TYPE>                                           \
-      : fmt::formatter<typename Traits<NAMESPACE::TYPE>::OutputType> {        \
-    using MyTraits = Traits<NAMESPACE::TYPE>;                                 \
-    /* Shadow our base class member function template of the same name. */    \
-    template <typename FormatContext>                                         \
-    auto format(const typename MyTraits::InputType& x,                        \
-                FormatContext& ctx) DRAKE_FMT8_CONST {                        \
-      /* Call the base class member function after laundering the object   */ \
-      /* through the user's provided format_as function. Older versions of */ \
-      /* fmt have const-correctness bugs, which we can fix with some good  */ \
-      /* old fashioned const_cast-ing here.                                */ \
-      using Base = typename MyTraits::OutputTypeFormatter;                    \
-      const Base* const self = this;                                          \
-      return const_cast<Base*>(self)->format(                                 \
-          MyTraits::Functor::call(x),                                         \
-          ctx);                                                               \
-    }                                                                         \
-  };                                                                          \
-  } /* namespace drake::internal::formatter_as */                             \
-                                                                              \
-  /* Specializes the fmt::formatter<> class template for TYPE. */             \
-  namespace fmt {                                                             \
-  template <TEMPLATE_ARGS>                                                    \
-  struct formatter<NAMESPACE::TYPE>                                           \
-      : drake::internal::formatter_as::Formatter<NAMESPACE::TYPE> {};         \
+#define DRAKE_FORMATTER_AS(TEMPLATE_ARGS, NAMESPACE, TYPE, ARG, EXPR)          \
+  /* Specializes the Converter<> class template for our TYPE. */               \
+  namespace drake::internal::formatter_as {                                    \
+  template <TEMPLATE_ARGS>                                                     \
+  struct Converter<NAMESPACE::TYPE> {                                          \
+    using InputType = NAMESPACE::TYPE;                                         \
+    static auto call(const InputType& ARG) { return EXPR; }                    \
+  };                                                                           \
+                                                                               \
+  /* Provides the fmt::formatter<TYPE> implementation. */                      \
+  template <TEMPLATE_ARGS>                                                     \
+  struct Formatter<NAMESPACE::TYPE>                                            \
+      : fmt::formatter<typename Traits<NAMESPACE::TYPE>::OutputType> {         \
+    using MyTraits = Traits<NAMESPACE::TYPE>;                                  \
+    /* Shadow our base class member function template of the same name. */     \
+    template <typename FormatContext>                                          \
+    auto format(const typename MyTraits::InputType& x,                         \
+                FormatContext& ctx) DRAKE_FMT8_CONST {                         \
+      /* Call the base class member function after laundering the object   */  \
+      /* through the user's provided format_as function. Older versions of */  \
+      /* fmt have const-correctness bugs, which we can fix with some good  */  \
+      /* old fashioned const_cast-ing here.                                */  \
+      using Base = typename MyTraits::OutputTypeFormatter;                     \
+      const Base* const self = this;                                           \
+      return const_cast<Base*>(self)->format(MyTraits::Functor::call(x), ctx); \
+    }                                                                          \
+  };                                                                           \
+  } /* namespace drake::internal::formatter_as */                              \
+                                                                               \
+  /* Specializes the fmt::formatter<> class template for TYPE. */              \
+  namespace fmt {                                                              \
+  template <TEMPLATE_ARGS>                                                     \
+  struct formatter<NAMESPACE::TYPE>                                            \
+      : drake::internal::formatter_as::Formatter<NAMESPACE::TYPE> {};          \
   } /* namespace fmt */

--- a/common/fmt_ostream.h
+++ b/common/fmt_ostream.h
@@ -20,19 +20,26 @@ types that provide `operator<<` support but not `fmt::formatter<T>` support.
 Once we stop using `FMT_DEPRECATED_OSTREAM=1`, compilation errors will help you
 understand where you are required to use this wrapper. */
 template <typename T>
-auto fmt_streamed(const T& ref) { return fmt::streamed(ref); }
-#else  // FMT_VERSION
+auto fmt_streamed(const T& ref) {
+  return fmt::streamed(ref);
+}
+#else   // FMT_VERSION
 namespace internal {
-template <typename T> struct streamed_ref { const T& ref; };
+template <typename T>
+struct streamed_ref {
+  const T& ref;
+};
 }  // namespace internal
 template <typename T>
-internal::streamed_ref<T> fmt_streamed(const T& ref) { return {ref}; }
+internal::streamed_ref<T> fmt_streamed(const T& ref) {
+  return {ref};
+}
 #endif  // FMT_VERSION
 
 // Compatibility shim for fmt::ostream_formatter.
 #if FMT_VERSION >= 90000
 using fmt::ostream_formatter;
-#else  // FMT_VERSION
+#else   // FMT_VERSION
 /** When using fmt >= 9, this is an alias for fmt::ostream_formatter.
 When using fmt < 9, this uses a polyfill instead. */
 struct ostream_formatter : fmt::formatter<std::string_view> {

--- a/common/hash.h
+++ b/common/hash.h
@@ -247,9 +247,7 @@ class FNV1aHasher {
   }
 
   /// Returns the hash.
-  explicit constexpr operator size_t() noexcept {
-    return hash_;
-  }
+  explicit constexpr operator size_t() noexcept { return hash_; }
 
  private:
   static_assert(sizeof(result_type) == (64 / 8), "We require a 64-bit size_t");

--- a/common/identifier.cc
+++ b/common/identifier.cc
@@ -16,7 +16,7 @@ static std::atomic<int64_t> g_prior_identifier;
 
 }  // namespace
 
-int64_t get_new_identifier()  {
+int64_t get_new_identifier() {
   // Note that 0 is reserved for the uninitialized Identifier created by the
   // default constructor, so we have an invariant that get_new_identifier() > 0.
   // Overflowing an int64_t is not a hazard we need to worry about.

--- a/common/identifier.h
+++ b/common/identifier.h
@@ -260,6 +260,5 @@ struct hash<drake::Identifier<Tag>> : public drake::DefaultHash {};
 // TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
 namespace fmt {
 template <typename Tag>
-struct formatter<drake::Identifier<Tag>>
-    : drake::ostream_formatter {};
+struct formatter<drake::Identifier<Tag>> : drake::ostream_formatter {};
 }  // namespace fmt

--- a/common/is_approx_equal_abstol.h
+++ b/common/is_approx_equal_abstol.h
@@ -13,10 +13,8 @@ template <typename DerivedA, typename DerivedB>
 bool is_approx_equal_abstol(const Eigen::MatrixBase<DerivedA>& m1,
                             const Eigen::MatrixBase<DerivedB>& m2,
                             double tolerance) {
-  return (
-      (m1.rows() == m2.rows()) &&
-      (m1.cols() == m2.cols()) &&
-      ((m1 - m2).template lpNorm<Eigen::Infinity>() <= tolerance));
+  return ((m1.rows() == m2.rows()) && (m1.cols() == m2.cols()) &&
+          ((m1 - m2).template lpNorm<Eigen::Infinity>() <= tolerance));
 }
 
 /// Returns true if and only if a simple greedy search reveals a permutation
@@ -57,6 +55,5 @@ bool IsApproxEqualAbsTolWithPermutedColumns(
   }
   return true;
 }
-
 
 }  // namespace drake

--- a/common/is_cloneable.h
+++ b/common/is_cloneable.h
@@ -18,11 +18,10 @@ struct is_cloneable_helper : std::false_type {};
 // prefers this overload over the default overload.
 template <typename T>
 struct is_cloneable_helper<
-    T,
-    typename std::enable_if_t<std::is_same_v<
-        decltype(std::declval<const T>().Clone().release()),
-        typename std::remove_const_t<T>*>>>
-    : std::true_type {};
+    T, typename std::enable_if_t<
+           std::is_same_v<decltype(std::declval<const T>().Clone().release()),
+                          typename std::remove_const_t<T>*>>> : std::true_type {
+};
 
 }  // namespace is_cloneable_internal
 
@@ -79,7 +78,6 @@ struct is_cloneable_helper<
  @tparam  T  The class to test for cloneability.
  */
 template <typename T>
-using is_cloneable =
-    is_cloneable_internal::is_cloneable_helper<T, void>;
+using is_cloneable = is_cloneable_internal::is_cloneable_helper<T, void>;
 
 }  // namespace drake

--- a/common/is_less_than_comparable.h
+++ b/common/is_less_than_comparable.h
@@ -12,7 +12,7 @@ namespace is_less_than_comparable_internal {
 
 // Default case; assumes that a class is *not* less-than comparable.
 template <typename T, typename = void>
-struct is_less_than_comparable_helper : std::false_type { };
+struct is_less_than_comparable_helper : std::false_type {};
 
 // Special sauce for SFINAE. Only compiles if it can finds the method
 // `operator<`. If this exists, the is_less_than_comparable implicitly

--- a/common/nice_type_name.cc
+++ b/common/nice_type_name.cc
@@ -118,8 +118,8 @@ string NiceTypeName::RemoveNamespaces(const string& canonical) {
   return no_namespace.empty() ? canonical : no_namespace;
 }
 
-std::string NiceTypeName::GetWithPossibleOverride(
-      const void* ptr, const std::type_info& info) {
+std::string NiceTypeName::GetWithPossibleOverride(const void* ptr,
+                                                  const std::type_info& info) {
   internal::NiceTypeNamePtrOverride ptr_override =
       internal::GetNiceTypeNamePtrOverride();
   if (ptr_override) {

--- a/common/nice_type_name.h
+++ b/common/nice_type_name.h
@@ -108,8 +108,8 @@ class NiceTypeName {
   // No instances of this class should be created.
   NiceTypeName() = delete;
 
-  static std::string GetWithPossibleOverride(
-      const void* ptr, const std::type_info& info);
+  static std::string GetWithPossibleOverride(const void* ptr,
+                                             const std::type_info& info);
 };
 
 }  // namespace drake

--- a/common/pointer_cast.h
+++ b/common/pointer_cast.h
@@ -37,7 +37,9 @@ std::unique_ptr<T> static_pointer_cast(std::unique_ptr<U>&& other) noexcept {
 template <class T, class U>
 std::unique_ptr<T> dynamic_pointer_cast(std::unique_ptr<U>&& other) noexcept {
   T* result = dynamic_cast<T*>(other.get());
-  if (!result) { return nullptr; }
+  if (!result) {
+    return nullptr;
+  }
   other.release();
   return std::unique_ptr<T>(result);
 }
@@ -57,16 +59,14 @@ std::unique_ptr<T> dynamic_pointer_cast_or_throw(std::unique_ptr<U>&& other) {
   if (!other) {
     throw std::logic_error(fmt::format(
         "Cannot cast a unique_ptr<{}> containing nullptr to unique_ptr<{}>.",
-        NiceTypeName::Get<U>(),
-        NiceTypeName::Get<T>()));
+        NiceTypeName::Get<U>(), NiceTypeName::Get<T>()));
   }
   T* result = dynamic_cast<T*>(other.get());
   if (!result) {
     throw std::logic_error(fmt::format(
         "Cannot cast a unique_ptr<{}> containing an object of type {} to "
         "unique_ptr<{}>.",
-        NiceTypeName::Get<U>(),
-        NiceTypeName::Get(*other),
+        NiceTypeName::Get<U>(), NiceTypeName::Get(*other),
         NiceTypeName::Get<T>()));
   }
   other.release();
@@ -83,17 +83,15 @@ std::unique_ptr<T> dynamic_pointer_cast_or_throw(std::unique_ptr<U>&& other) {
 template <class T, class U>
 T* dynamic_pointer_cast_or_throw(U* other) {
   if (!other) {
-    throw std::logic_error(fmt::format(
-        "Cannot cast a nullptr {}* to {}*.",
-        NiceTypeName::Get<U>(),
-        NiceTypeName::Get<T>()));
+    throw std::logic_error(fmt::format("Cannot cast a nullptr {}* to {}*.",
+                                       NiceTypeName::Get<U>(),
+                                       NiceTypeName::Get<T>()));
   }
   T* result = dynamic_cast<T*>(other);
   if (!result) {
     throw std::logic_error(fmt::format(
         "Cannot cast a {}* pointing to an object of type {} to {}*.",
-        NiceTypeName::Get<U>(),
-        NiceTypeName::Get(*other),
+        NiceTypeName::Get<U>(), NiceTypeName::Get(*other),
         NiceTypeName::Get<T>()));
   }
   return result;

--- a/common/polynomial.cc
+++ b/common/polynomial.cc
@@ -21,8 +21,7 @@ using std::vector;
 
 namespace drake {
 template <typename T>
-bool Polynomial<T>::Monomial::HasSameExponents(
-    const Monomial& other) const {
+bool Polynomial<T>::Monomial::HasSameExponents(const Monomial& other) const {
   if (terms.size() != other.terms.size()) return false;
 
   for (typename vector<Term>::const_iterator iter = terms.begin();
@@ -53,8 +52,7 @@ Polynomial<T>::Polynomial(const T& scalar) {
 }
 
 template <typename T>
-Polynomial<T>::Polynomial(const T coefficient,
-                                        const vector<Term>& terms) {
+Polynomial<T>::Polynomial(const T coefficient, const vector<Term>& terms) {
   Monomial m;
   m.coefficient = coefficient;
   m.terms = terms;
@@ -78,16 +76,12 @@ Polynomial<T>::Polynomial(const T coefficient,
 
 template <typename T>
 Polynomial<T>::Polynomial(
-    typename vector<
-        typename Polynomial<T>::Monomial>::const_iterator start,
-    typename vector<typename Polynomial<T>::Monomial>::
-        const_iterator finish) {
+    typename vector<typename Polynomial<T>::Monomial>::const_iterator start,
+    typename vector<typename Polynomial<T>::Monomial>::const_iterator finish) {
   is_univariate_ = true;
-  for (
-      typename vector<
-          typename Polynomial<T>::Monomial>::const_iterator iter =
-          start;
-      iter != finish; iter++)
+  for (typename vector<typename Polynomial<T>::Monomial>::const_iterator iter =
+           start;
+       iter != finish; iter++)
     monomials_.push_back(*iter);
   MakeMonomialsUnique();
 }
@@ -105,8 +99,7 @@ Polynomial<T>::Polynomial(const string& varname, const unsigned int num) {
 }
 
 template <typename T>
-Polynomial<T>::Polynomial(const T& coeff,
-                                        const VarType& v) {
+Polynomial<T>::Polynomial(const T& coeff, const VarType& v) {
   Monomial m;
   m.coefficient = coeff;
   Term t;
@@ -158,14 +151,16 @@ int Polynomial<T>::Monomial::GetDegreeOf(VarType v) const {
 }
 
 template <typename T>
-typename Polynomial<T>::Monomial
-Polynomial<T>::Monomial::Factor(const Monomial& divisor) const {
+typename Polynomial<T>::Monomial Polynomial<T>::Monomial::Factor(
+    const Monomial& divisor) const {
   Monomial error, result;
   error.coefficient = 0;
   result.coefficient = coefficient / divisor.coefficient;
   for (const Term& term : terms) {
     const PowerType divisor_power = divisor.GetDegreeOf(term.var);
-    if (term.power < divisor_power) { return error; }
+    if (term.power < divisor_power) {
+      return error;
+    }
     Term new_term;
     new_term.var = term.var;
     new_term.power = term.power - divisor_power;
@@ -174,7 +169,9 @@ Polynomial<T>::Monomial::Factor(const Monomial& divisor) const {
     }
   }
   for (const Term& divisor_term : divisor.terms) {
-    if (!GetDegreeOf(divisor_term.var)) { return error; }
+    if (!GetDegreeOf(divisor_term.var)) {
+      return error;
+    }
   }
   return result;
 }
@@ -202,8 +199,7 @@ bool Polynomial<T>::IsAffine() const {
 }
 
 template <typename T>
-typename Polynomial<T>::VarType
-Polynomial<T>::GetSimpleVariable() const {
+typename Polynomial<T>::VarType Polynomial<T>::GetSimpleVariable() const {
   if (monomials_.size() != 1) return 0;
   if (monomials_[0].terms.size() != 1) return 0;
   if (monomials_[0].terms[0].power != 1) return 0;
@@ -231,8 +227,7 @@ VectorX<T> Polynomial<T>::GetCoefficients() const {
 }
 
 template <typename T>
-std::set<typename Polynomial<T>::VarType>
-Polynomial<T>::GetVariables() const {
+std::set<typename Polynomial<T>::VarType> Polynomial<T>::GetVariables() const {
   std::set<Polynomial<T>::VarType> vars;
   for (const Monomial& monomial : monomials_) {
     for (const Term& term : monomial.terms) {
@@ -264,8 +259,7 @@ Polynomial<T> Polynomial<T>::EvaluatePartial(
 }
 
 template <typename T>
-void Polynomial<T>::Subs(const VarType& orig,
-                               const VarType& replacement) {
+void Polynomial<T>::Subs(const VarType& orig, const VarType& replacement) {
   for (typename vector<Monomial>::iterator iter = monomials_.begin();
        iter != monomials_.end(); iter++) {
     for (typename vector<Term>::iterator t = iter->terms.begin();
@@ -301,8 +295,7 @@ Polynomial<T> Polynomial<T>::Substitute(
 }  // namespace drake
 
 template <typename T>
-Polynomial<T> Polynomial<T>::Derivative(
-    int derivative_order) const {
+Polynomial<T> Polynomial<T>::Derivative(int derivative_order) const {
   DRAKE_DEMAND(derivative_order >= 0);
   if (!is_univariate_)
     throw runtime_error(
@@ -314,8 +307,8 @@ Polynomial<T> Polynomial<T>::Derivative(
 
   for (typename vector<Monomial>::const_iterator iter = monomials_.begin();
        iter != monomials_.end(); iter++) {
-    if (!iter->terms.empty() && (
-            iter->terms[0].power >= static_cast<PowerType>(derivative_order))) {
+    if (!iter->terms.empty() &&
+        (iter->terms[0].power >= static_cast<PowerType>(derivative_order))) {
       Monomial m = *iter;
       for (int k = 0; k < derivative_order;
            k++) {  // take the remaining derivatives
@@ -331,11 +324,9 @@ Polynomial<T> Polynomial<T>::Derivative(
 }
 
 template <typename T>
-Polynomial<T> Polynomial<T>::Integral(
-    const T& integration_constant) const {
+Polynomial<T> Polynomial<T>::Integral(const T& integration_constant) const {
   if (!is_univariate_)
-    throw runtime_error(
-        "Integral is only defined for univariate polynomials");
+    throw runtime_error("Integral is only defined for univariate polynomials");
   Polynomial<T> ret = *this;
 
   for (typename vector<Monomial>::iterator iter = ret.monomials_.begin();
@@ -366,8 +357,7 @@ Polynomial<T> Polynomial<T>::Integral(
 }
 
 template <typename T>
-bool Polynomial<T>::operator==(
-    const Polynomial<T>& other) const {
+bool Polynomial<T>::operator==(const Polynomial<T>& other) const {
   // Comparison of unsorted vectors is faster copying them into std::set
   // btrees rather than using std::is_permutation().
   // TODO(#2216) switch from multiset to set for further performance gains.
@@ -379,8 +369,7 @@ bool Polynomial<T>::operator==(
 }
 
 template <typename T>
-Polynomial<T>& Polynomial<T>::operator+=(
-    const Polynomial<T>& other) {
+Polynomial<T>& Polynomial<T>::operator+=(const Polynomial<T>& other) {
   for (const auto& iter : other.monomials_) {
     monomials_.push_back(iter);
   }
@@ -389,8 +378,7 @@ Polynomial<T>& Polynomial<T>::operator+=(
 }
 
 template <typename T>
-Polynomial<T>& Polynomial<T>::operator-=(
-    const Polynomial<T>& other) {
+Polynomial<T>& Polynomial<T>::operator-=(const Polynomial<T>& other) {
   for (const auto& iter : other.monomials_) {
     monomials_.push_back(iter);
     monomials_.back().coefficient *= T{-1};
@@ -400,8 +388,7 @@ Polynomial<T>& Polynomial<T>::operator-=(
 }
 
 template <typename T>
-Polynomial<T>& Polynomial<T>::operator*=(
-    const Polynomial<T>& other) {
+Polynomial<T>& Polynomial<T>::operator*=(const Polynomial<T>& other) {
   vector<Monomial> new_monomials;
 
   for (const auto& iter : monomials_) {
@@ -432,8 +419,7 @@ Polynomial<T>& Polynomial<T>::operator*=(
 }
 
 template <typename T>
-Polynomial<T>& Polynomial<T>::operator+=(
-    const T& scalar) {
+Polynomial<T>& Polynomial<T>::operator+=(const T& scalar) {
   // add to the constant monomial if I have one
   for (typename vector<Monomial>::iterator iter = monomials_.begin();
        iter != monomials_.end(); iter++) {
@@ -451,8 +437,7 @@ Polynomial<T>& Polynomial<T>::operator+=(
 }
 
 template <typename T>
-Polynomial<T>& Polynomial<T>::operator-=(
-    const T& scalar) {
+Polynomial<T>& Polynomial<T>::operator-=(const T& scalar) {
   // add to the constant monomial if I have one
   for (typename vector<Monomial>::iterator iter = monomials_.begin();
        iter != monomials_.end(); iter++) {
@@ -470,8 +455,7 @@ Polynomial<T>& Polynomial<T>::operator-=(
 }
 
 template <typename T>
-Polynomial<T>& Polynomial<T>::operator*=(
-    const T& scalar) {
+Polynomial<T>& Polynomial<T>::operator*=(const T& scalar) {
   for (typename vector<Monomial>::iterator iter = monomials_.begin();
        iter != monomials_.end(); iter++) {
     iter->coefficient *= scalar;
@@ -480,8 +464,7 @@ Polynomial<T>& Polynomial<T>::operator*=(
 }
 
 template <typename T>
-Polynomial<T>& Polynomial<T>::operator/=(
-    const T& scalar) {
+Polynomial<T>& Polynomial<T>::operator/=(const T& scalar) {
   for (typename vector<Monomial>::iterator iter = monomials_.begin();
        iter != monomials_.end(); iter++) {
     iter->coefficient /= scalar;
@@ -490,24 +473,21 @@ Polynomial<T>& Polynomial<T>::operator/=(
 }
 
 template <typename T>
-const Polynomial<T> Polynomial<T>::operator+(
-    const Polynomial& other) const {
+const Polynomial<T> Polynomial<T>::operator+(const Polynomial& other) const {
   Polynomial<T> ret = *this;
   ret += other;
   return ret;
 }
 
 template <typename T>
-const Polynomial<T> Polynomial<T>::operator-(
-    const Polynomial& other) const {
+const Polynomial<T> Polynomial<T>::operator-(const Polynomial& other) const {
   Polynomial<T> ret = *this;
   ret -= other;
   return ret;
 }
 
 template <typename T>
-const Polynomial<T> Polynomial<T>::operator-()
-    const {
+const Polynomial<T> Polynomial<T>::operator-() const {
   Polynomial<T> ret = *this;
   for (typename vector<Monomial>::iterator iter = ret.monomials_.begin();
        iter != ret.monomials_.end(); iter++) {
@@ -517,16 +497,14 @@ const Polynomial<T> Polynomial<T>::operator-()
 }
 
 template <typename T>
-const Polynomial<T> Polynomial<T>::operator*(
-    const Polynomial<T>& other) const {
+const Polynomial<T> Polynomial<T>::operator*(const Polynomial<T>& other) const {
   Polynomial<T> ret = *this;
   ret *= other;
   return ret;
 }
 
 template <typename T>
-const Polynomial<T> Polynomial<T>::operator/(
-    const T& scalar) const {
+const Polynomial<T> Polynomial<T>::operator/(const T& scalar) const {
   Polynomial<T> ret = *this;
   ret /= scalar;
   return ret;
@@ -629,9 +607,8 @@ bool Polynomial<T>::IsValidVariableName(const string name) {
 }
 
 template <typename T>
-typename Polynomial<T>::VarType
-Polynomial<T>::VariableNameToId(const string name,
-                                              const unsigned int m) {
+typename Polynomial<T>::VarType Polynomial<T>::VariableNameToId(
+    const string name, const unsigned int m) {
   DRAKE_THROW_UNLESS(IsValidVariableName(name));
   unsigned int multiplier = 1;
   VarType name_part = 0;
@@ -643,8 +620,7 @@ Polynomial<T>::VariableNameToId(const string name,
     multiplier *= kNumNameChars + 1;
   }
   if (name_part > kMaxNamePart) {
-    throw runtime_error("name " + name +
-                        " (" + std::to_string(name_part) +
+    throw runtime_error("name " + name + " (" + std::to_string(name_part) +
                         ") exceeds max allowed");
   }
   const VarType maxId = std::numeric_limits<VarType>::max() / 2 / kMaxNamePart;
@@ -660,9 +636,9 @@ string Polynomial<T>::IdToVariableName(const VarType id) {
                                                 // doing the trig support here
 
   unsigned int m = id / 2 / kMaxNamePart;
-  unsigned int multiplier = static_cast<unsigned int>(
-      std::pow(static_cast<double>(kNumNameChars + 1),
-               static_cast<int>(kNameLength) - 1));
+  unsigned int multiplier =
+      static_cast<unsigned int>(std::pow(static_cast<double>(kNumNameChars + 1),
+                                         static_cast<int>(kNameLength) - 1));
   char name[kNameLength + 1];
   int j = 0;
   for (int i = 0; i < static_cast<int>(kNameLength); i++) {

--- a/common/polynomial.h
+++ b/common/polynomial.h
@@ -91,7 +91,7 @@ class Polynomial {
     /// A comparison to allow std::lexicographical_compare on this class; does
     /// not reflect any sort of mathematical total order.
     bool operator<(const Monomial& other) const {
-      return ((coefficient < other.coefficient)  ||
+      return ((coefficient < other.coefficient) ||
               ((coefficient == other.coefficient) && (terms < other.terms)));
     }
 
@@ -244,8 +244,8 @@ class Polynomial {
   typename Product<T, U>::type EvaluateMultivariate(
       const std::map<VarType, U>& var_values) const {
     using std::pow;
-    typedef typename std::remove_const_t<
-      typename Product<T, U>::type> ProductType;
+    typedef typename std::remove_const_t<typename Product<T, U>::type>
+        ProductType;
     ProductType value = 0;
     for (const Monomial& monomial : monomials_) {
       ProductType monomial_value = monomial.coefficient;
@@ -268,8 +268,7 @@ class Polynomial {
    * Returns a Polynomial in which each variable in var_values has been
    * replaced with its value and constants appropriately combined.
    */
-  Polynomial EvaluatePartial(
-      const std::map<VarType, T>& var_values) const;
+  Polynomial EvaluatePartial(const std::map<VarType, T>& var_values) const;
 
   /// Replaces all instances of variable orig with replacement.
   void Subs(const VarType& orig, const VarType& replacement);
@@ -325,42 +324,36 @@ class Polynomial {
 
   const Polynomial operator*(const Polynomial& other) const;
 
-  friend const Polynomial operator+(const Polynomial& p,
-                                    const T& scalar) {
+  friend const Polynomial operator+(const Polynomial& p, const T& scalar) {
     Polynomial ret = p;
     ret += scalar;
     return ret;
   }
 
-  friend const Polynomial operator+(const T& scalar,
-                                    const Polynomial& p) {
+  friend const Polynomial operator+(const T& scalar, const Polynomial& p) {
     Polynomial ret = p;
     ret += scalar;
     return ret;
   }
 
-  friend const Polynomial operator-(const Polynomial& p,
-                                    const T& scalar) {
+  friend const Polynomial operator-(const Polynomial& p, const T& scalar) {
     Polynomial ret = p;
     ret -= scalar;
     return ret;
   }
 
-  friend const Polynomial operator-(const T& scalar,
-                                    const Polynomial& p) {
+  friend const Polynomial operator-(const T& scalar, const Polynomial& p) {
     Polynomial ret = -p;
     ret += scalar;
     return ret;
   }
 
-  friend const Polynomial operator*(const Polynomial& p,
-                                    const T& scalar) {
+  friend const Polynomial operator*(const Polynomial& p, const T& scalar) {
     Polynomial ret = p;
     ret *= scalar;
     return ret;
   }
-  friend const Polynomial operator*(const T& scalar,
-                                    const Polynomial& p) {
+  friend const Polynomial operator*(const T& scalar, const Polynomial& p) {
     Polynomial ret = p;
     ret *= scalar;
     return ret;
@@ -452,8 +445,7 @@ class Polynomial {
   /** Variable name/ID conversion facility. */
   static bool IsValidVariableName(const std::string name);
 
-  static VarType VariableNameToId(const std::string name,
-                                  unsigned int m = 1);
+  static VarType VariableNameToId(const std::string name, unsigned int m = 1);
 
   static std::string IdToVariableName(const VarType id);
   //@}
@@ -482,9 +474,8 @@ class Polynomial {
 
 /** Provides power function for Polynomial. */
 template <typename T>
-Polynomial<T> pow(
-    const Polynomial<T>& base,
-    typename Polynomial<T>::PowerType exponent) {
+Polynomial<T> pow(const Polynomial<T>& base,
+                  typename Polynomial<T>::PowerType exponent) {
   DRAKE_DEMAND(exponent >= 0);
   if (exponent == 0) {
     return Polynomial<T>{1.0};
@@ -523,8 +514,7 @@ typedef Eigen::Matrix<Polynomiald, Eigen::Dynamic, 1> VectorXPoly;
 // TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
 namespace fmt {
 template <typename T>
-struct formatter<drake::Polynomial<T>>
-    : drake::ostream_formatter {};
+struct formatter<drake::Polynomial<T>> : drake::ostream_formatter {};
 template <>
 struct formatter<drake::Polynomial<double>::Monomial>
     : drake::ostream_formatter {};

--- a/common/random.cc
+++ b/common/random.cc
@@ -43,4 +43,3 @@ template double CalcProbabilityDensity<double>(
 template AutoDiffXd CalcProbabilityDensity<AutoDiffXd>(
     RandomDistribution, const Eigen::Ref<const VectorX<AutoDiffXd>>&);
 }  // namespace drake
-

--- a/common/random.h
+++ b/common/random.h
@@ -29,8 +29,7 @@ class RandomGenerator {
   RandomGenerator() = default;
 
   /// Creates a generator using given `seed`.
-  explicit RandomGenerator(result_type seed)
-      : generator_(CreateEngine(seed)) {}
+  explicit RandomGenerator(result_type seed) : generator_(CreateEngine(seed)) {}
 
   static constexpr result_type min() { return Engine::min(); }
   static constexpr result_type max() { return Engine::max(); }

--- a/common/reset_after_move.h
+++ b/common/reset_after_move.h
@@ -66,14 +66,14 @@ class reset_after_move {
   reset_after_move(const reset_after_move&) = default;
   reset_after_move& operator=(const reset_after_move&) = default;
   reset_after_move(reset_after_move&& other) noexcept(
-      std::is_nothrow_default_constructible_v<T> &&
-      std::is_nothrow_move_assignable_v<T>) {
+      std::is_nothrow_default_constructible_v<T>&&
+          std::is_nothrow_move_assignable_v<T>) {
     value_ = std::move(other.value_);
     other.value_ = T{};
   }
   reset_after_move& operator=(reset_after_move&& other) noexcept(
-      std::is_nothrow_default_constructible_v<T> &&
-      std::is_nothrow_move_assignable_v<T>) {
+      std::is_nothrow_default_constructible_v<T>&&
+          std::is_nothrow_move_assignable_v<T>) {
     if (this != &other) {
       value_ = std::move(other.value_);
       other.value_ = T{};

--- a/common/reset_on_copy.h
+++ b/common/reset_on_copy.h
@@ -98,8 +98,7 @@ class reset_on_copy {
   /// construction if possible. This is an implicit conversion, so that
   /// %reset_on_copy<T> behaves more like the unwrapped type.
   // NOLINTNEXTLINE(runtime/explicit)
-  reset_on_copy(T&& value) noexcept(
-      std::is_nothrow_move_constructible_v<T>)
+  reset_on_copy(T&& value) noexcept(std::is_nothrow_move_constructible_v<T>)
       : value_(std::move(value)) {}
 
   /// @name Implements copy/move construction and assignment.
@@ -176,7 +175,7 @@ class reset_on_copy {
   // this to `value_ = T{}` which would introduce an additional dependence on
   // the behavior of T's copy assignment operator.
   void destruct_and_reset_value() {
-    value_.~T();  // Invokes destructor if there is one.
+    value_.~T();        // Invokes destructor if there is one.
     new (&value_) T{};  // Placement new; no heap activity.
   }
 

--- a/common/resource_tool.cc
+++ b/common/resource_tool.cc
@@ -7,9 +7,8 @@
 DEFINE_string(
     print_resource_path, "",
     "Given the relative path of a resource within Drake, e.g., "
-    "`drake/examples/pendulum/Pendulum.urdf`, "
-    "find the resource and print its absolute path, e.g., "
-    "`/home/user/tmp/drake/examples/pendulum/Pendulum.urdf`");
+    "`drake/examples/pendulum/Pendulum.urdf`, find the resource and print its "
+    "absolute path, e.g., `/home/user/drake/examples/pendulum/Pendulum.urdf`");
 DEFINE_bool(
     print_resource_root_environment_variable_name, false,
     "Print the name of the environment variable that provides the "
@@ -40,14 +39,11 @@ int main(int argc, char* argv[]) {
 
   const FindResourceResult& result = FindResource(FLAGS_print_resource_path);
   if (result.get_absolute_path()) {
-    std::cout << *result.get_absolute_path()
-              << "\n";
+    std::cout << *result.get_absolute_path() << "\n";
     return 0;
   }
 
-  std::cerr << "resource_tool: "
-            << result.get_error_message().value()
-            << "\n";
+  std::cerr << "resource_tool: " << result.get_error_message().value() << "\n";
   return 1;
 }
 

--- a/common/scope_exit.h
+++ b/common/scope_exit.h
@@ -36,8 +36,7 @@ class ScopeExit final {
   /// Creates a resource that will call `func` when destroyed.  Note that
   /// `func()` should not throw an exception, since it will typically be
   /// invoked during stack unwinding.
-  explicit ScopeExit(std::function<void()> func)
-      : func_(std::move(func)) {
+  explicit ScopeExit(std::function<void()> func) : func_(std::move(func)) {
     DRAKE_THROW_UNLESS(func_ != nullptr);
   }
 
@@ -50,9 +49,7 @@ class ScopeExit final {
   }
 
   /// Disarms this guard, so that the destructor has no effect.
-  void Disarm() {
-    func_ = nullptr;
-  }
+  void Disarm() { func_ = nullptr; }
 
  private:
   std::function<void()> func_;

--- a/common/sorted_pair.h
+++ b/common/sorted_pair.h
@@ -34,18 +34,19 @@ namespace drake {
 /// @tparam T A template type that provides `operator<`.
 template <class T>
 struct SortedPair {
-  static_assert(is_less_than_comparable<T>::value, "SortedPair can only be used"
-      " with types that can be compared using the less-than operator"
-      " (operator<).");
+  static_assert(is_less_than_comparable<T>::value,
+                "SortedPair can only be used with types that can be compared "
+                "using the less-than operator (operator<).");
 
   /// The default constructor creates `first()` and `second()` using T's default
   /// constructor, iff T has a default constructor.  Otherwise, this constructor
   /// is not available.
 #ifndef DRAKE_DOXYGEN_CXX
   template <typename T1 = T,
-      typename std::enable_if_t<std::is_constructible_v<T1>, bool> = true>
+            typename std::enable_if_t<std::is_constructible_v<T1>, bool> = true>
 #endif
-  SortedPair() {}
+  SortedPair() {
+  }
 
   /// Rvalue reference constructor, permits constructing with std::unique_ptr
   /// types, for example.
@@ -61,14 +62,16 @@ struct SortedPair {
 
   /// Constructs a %SortedPair from two objects.
   SortedPair(const T& a, const T& b) : first_(a), second_(b) {
-    if (second_ < first_)
+    if (second_ < first_) {
       std::swap(first_, second_);
+    }
   }
 
   /// Type-converting copy constructor.
   template <class U>
-  SortedPair(SortedPair<U>&& u) : first_{std::forward<T>(u.first())},
-      second_{std::forward<T>(u.second())} {}
+  SortedPair(SortedPair<U>&& u)
+      : first_{std::forward<T>(u.first())},
+        second_{std::forward<T>(u.second())} {}
 
   // N.B. We leave all of the copy/move/assign operations implicitly declared,
   // so that iff T provides that operation, then we will also provide it.  Do
@@ -80,8 +83,9 @@ struct SortedPair {
   void set(U&& a, U&& b) {
     first_ = std::forward<U>(a);
     second_ = std::forward<U>(b);
-    if (second_ < first_)
+    if (second_ < first_) {
       std::swap(first_, second_);
+    }
   }
 
   /// Gets the first (according to `operator<`) of the objects.
@@ -99,7 +103,7 @@ struct SortedPair {
   /// Implements the @ref hash_append concept.
   template <class HashAlgorithm>
   friend void hash_append(HashAlgorithm& hasher, const SortedPair& p) noexcept {
-     using drake::hash_append;
+    using drake::hash_append;
     hash_append(hasher, p.first_);
     hash_append(hasher, p.second_);
   }
@@ -118,17 +122,19 @@ struct SortedPair {
   //@}
 
  private:
-  T first_{};          // The first of the two objects, according to operator<.
-  T second_{};         // The second of the two objects, according to operator<.
+  T first_{};   // The first of the two objects, according to operator<.
+  T second_{};  // The second of the two objects, according to operator<.
 };
 
 template <typename T>
-DRAKE_DEPRECATED("2023-06-01",
+DRAKE_DEPRECATED(
+    "2023-06-01",
     "Use fmt or spdlog for logging, not operator<<. "
     "Add an #include <fmt/ranges.h> to format SortedPair as a range."
     "See https://github.com/RobotLocomotion/drake/issues/17742 for background.")
 // TODO(jwnimmer-tri) On 2023-06-01 also remove the <ostream> include.
-inline std::ostream& operator<<(std::ostream& out, const SortedPair<T>& pair) {
+inline std::ostream&
+operator<<(std::ostream& out, const SortedPair<T>& pair) {
   out << "(" << pair.first() << ", " << pair.second() << ")";
   return out;
 }
@@ -148,8 +154,7 @@ inline bool operator<(const SortedPair<T>& x, const SortedPair<T>& y) {
 
 /// Determine whether two SortedPair objects are not equal using `operator==`.
 template <class T>
-inline bool operator!=(
-    const SortedPair<T>& x, const SortedPair<T>& y) {
+inline bool operator!=(const SortedPair<T>& x, const SortedPair<T>& y) {
   return !(x == y);
 }
 
@@ -167,8 +172,7 @@ inline bool operator<=(const SortedPair<T>& x, const SortedPair<T>& y) {
 
 /// Determines whether `x >= y` using `operator<`.
 template <class T>
-inline bool
-operator>=(const SortedPair<T>& x, const SortedPair<T>& y) {
+inline bool operator>=(const SortedPair<T>& x, const SortedPair<T>& y) {
   return !(x < y);
 }
 
@@ -177,10 +181,10 @@ operator>=(const SortedPair<T>& x, const SortedPair<T>& y) {
 /// @param y  The second_ object.
 /// @return A newly-constructed SortedPair object.
 template <class T>
-inline constexpr SortedPair<typename std::decay<T>::type>
-MakeSortedPair(T&& x, T&& y) {
-  return SortedPair<
-      typename std::decay<T>::type>(std::forward<T>(x), std::forward<T>(y));
+inline constexpr SortedPair<typename std::decay<T>::type> MakeSortedPair(
+    T&& x, T&& y) {
+  return SortedPair<typename std::decay<T>::type>(std::forward<T>(x),
+                                                  std::forward<T>(y));
 }
 
 }  // namespace drake
@@ -195,8 +199,7 @@ void swap(drake::SortedPair<T>& t, drake::SortedPair<T>& u) {
 
 /// Provides std::hash<SortedPair<T>>.
 template <class T>
-struct hash<drake::SortedPair<T>>
-    : public drake::DefaultHash {};
+struct hash<drake::SortedPair<T>> : public drake::DefaultHash {};
 #if defined(__GLIBCXX__)
 // https://gcc.gnu.org/onlinedocs/libstdc++/manual/unordered_associative.html
 template <class T>

--- a/common/test/resource_tool_test.py
+++ b/common/test/resource_tool_test.py
@@ -86,7 +86,7 @@ class TestResourceTool(unittest.TestCase):
         output = output.replace("\n", " ")
         m = re.search(
             (r"-print_resource_path.*`(drake.*)`.*"
-             + r"absolute path.*?`/home/user/tmp/(drake/.*?)`"),
+             + r"absolute path.*?`/home/user/(drake/.*?)`"),
             output)
         self.assertTrue(m is not None, "Could not match in " + repr(output))
 

--- a/common/text_logging.cc
+++ b/common/text_logging.cc
@@ -79,13 +79,20 @@ std::string logging::set_log_level(const std::string& level) {
   }
   drake::log()->set_level(value);
   switch (prev_value) {
-    case spdlog::level::trace: return "trace";
-    case spdlog::level::debug: return "debug";
-    case spdlog::level::info: return "info";
-    case spdlog::level::warn: return "warn";
-    case spdlog::level::err: return "err";
-    case spdlog::level::critical: return "critical";
-    case spdlog::level::off: return "off";
+    case spdlog::level::trace:
+      return "trace";
+    case spdlog::level::debug:
+      return "debug";
+    case spdlog::level::info:
+      return "info";
+    case spdlog::level::warn:
+      return "warn";
+    case spdlog::level::err:
+      return "err";
+    case spdlog::level::critical:
+      return "critical";
+    case spdlog::level::off:
+      return "off";
     default: {
       // N.B. `spdlog::level::level_enum` is not a `enum class`, so the
       // compiler does not know that it has a closed set of values. For

--- a/common/text_logging.h
+++ b/common/text_logging.h
@@ -53,25 +53,25 @@ DRAKE_FORMATTER_AS(). Grep around in Drake's existing code to find examples. */
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
 
 // Provide operative macros only when spdlog is available and Debug is enabled.
-#define DRAKE_LOGGER_TRACE(...)                                               \
-  do {                                                                        \
-    /* Capture the drake::log() in a temporary, using a relatively unique */  \
-    /* variable name to avoid potential variable name shadowing warnings. */  \
-    ::drake::logging::logger* const drake_spdlog_macro_logger_alias =         \
-        ::drake::log();                                                       \
-    if (drake_spdlog_macro_logger_alias->level() <= spdlog::level::trace) {   \
-      SPDLOG_LOGGER_TRACE(drake_spdlog_macro_logger_alias, __VA_ARGS__);      \
-    }                                                                         \
+#define DRAKE_LOGGER_TRACE(...)                                              \
+  do {                                                                       \
+    /* Capture the drake::log() in a temporary, using a relatively unique */ \
+    /* variable name to avoid potential variable name shadowing warnings. */ \
+    ::drake::logging::logger* const drake_spdlog_macro_logger_alias =        \
+        ::drake::log();                                                      \
+    if (drake_spdlog_macro_logger_alias->level() <= spdlog::level::trace) {  \
+      SPDLOG_LOGGER_TRACE(drake_spdlog_macro_logger_alias, __VA_ARGS__);     \
+    }                                                                        \
   } while (0)
-#define DRAKE_LOGGER_DEBUG(...)                                               \
-  do {                                                                        \
-    /* Capture the drake::log() in a temporary, using a relatively unique */  \
-    /* variable name to avoid potential variable name shadowing warnings. */  \
-    ::drake::logging::logger* const drake_spdlog_macro_logger_alias =         \
-        ::drake::log();                                                       \
-    if (drake_spdlog_macro_logger_alias->level() <= spdlog::level::debug) {   \
-      SPDLOG_LOGGER_DEBUG(drake_spdlog_macro_logger_alias, __VA_ARGS__);      \
-    }                                                                         \
+#define DRAKE_LOGGER_DEBUG(...)                                              \
+  do {                                                                       \
+    /* Capture the drake::log() in a temporary, using a relatively unique */ \
+    /* variable name to avoid potential variable name shadowing warnings. */ \
+    ::drake::logging::logger* const drake_spdlog_macro_logger_alias =        \
+        ::drake::log();                                                      \
+    if (drake_spdlog_macro_logger_alias->level() <= spdlog::level::debug) {  \
+      SPDLOG_LOGGER_DEBUG(drake_spdlog_macro_logger_alias, __VA_ARGS__);     \
+    }                                                                        \
   } while (0)
 
 #else
@@ -135,12 +135,18 @@ class logger {
   template <typename... Args>
   void critical(const char*, const Args&...) {}
 
-  template <typename T> void trace(const T&) {}
-  template <typename T> void debug(const T&) {}
-  template <typename T> void info(const T&) {}
-  template <typename T> void warn(const T&) {}
-  template <typename T> void error(const T&) {}
-  template <typename T> void critical(const T&) {}
+  template <typename T>
+  void trace(const T&) {}
+  template <typename T>
+  void debug(const T&) {}
+  template <typename T>
+  void info(const T&) {}
+  template <typename T>
+  void warn(const T&) {}
+  template <typename T>
+  void error(const T&) {}
+  template <typename T>
+  void critical(const T&) {}
 };
 
 // A stubbed-out version of `spdlog::sinks::sink`.

--- a/common/timer.cc
+++ b/common/timer.cc
@@ -2,9 +2,13 @@
 
 namespace drake {
 
-SteadyTimer::SteadyTimer() { Start(); }
+SteadyTimer::SteadyTimer() {
+  Start();
+}
 
-void SteadyTimer::Start() { start_time_ = clock::now(); }
+void SteadyTimer::Start() {
+  start_time_ = clock::now();
+}
 
 double SteadyTimer::Tick() {
   return std::chrono::duration<double>(clock::now() - start_time_).count();

--- a/common/type_safe_index.h
+++ b/common/type_safe_index.h
@@ -253,8 +253,8 @@ class TypeSafeIndex {
     DRAKE_ASSERT_VOID(
         AssertValid(index_, "Post-decrementing an invalid index."));
     --index_;
-    DRAKE_ASSERT_VOID(AssertValid(
-        index_, "Post-decrementing produced an invalid index."));
+    DRAKE_ASSERT_VOID(
+        AssertValid(index_, "Post-decrementing produced an invalid index."));
     return TypeSafeIndex(index_ + 1);
   }
   ///@}
@@ -266,9 +266,8 @@ class TypeSafeIndex {
   /// In Debug builds, this method asserts that the resulting index is
   /// non-negative.
   TypeSafeIndex& operator+=(int i) {
-    DRAKE_ASSERT_VOID(
-        AssertValid(index_,
-                    "In-place addition with an int on an invalid index."));
+    DRAKE_ASSERT_VOID(AssertValid(
+        index_, "In-place addition with an int on an invalid index."));
     DRAKE_ASSERT_VOID(AssertNoOverflow(
         i, "In-place addition with an int produced an invalid index."));
     index_ += i;
@@ -315,8 +314,8 @@ class TypeSafeIndex {
   TypeSafeIndex<Tag>& operator-=(const TypeSafeIndex<Tag>& other) {
     DRAKE_ASSERT_VOID(AssertValid(
         index_, "In-place subtraction with another index invalid LHS."));
-    DRAKE_ASSERT_VOID(AssertValid(other.index_,
-        "In-place subtraction with another index invalid RHS."));
+    DRAKE_ASSERT_VOID(AssertValid(
+        other.index_, "In-place subtraction with another index invalid RHS."));
     // No test for overflow; it would only be necessary if other had a negative
     // index value. In that case, it would be invalid and that would be caught
     // by the previous assertion.
@@ -363,12 +362,12 @@ class TypeSafeIndex {
 
   /// Allow equality test with unsigned integers.
   template <typename U>
-  typename std::enable_if_t<
-      std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
+  typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>,
+                            bool>
   operator==(const U& value) const {
     DRAKE_ASSERT_VOID(AssertValid(index_, "Testing == with invalid index."));
     return value <= static_cast<U>(kMaxIndex) &&
-        index_ == static_cast<int>(value);
+           index_ == static_cast<int>(value);
   }
 
   /// Prevent equality tests with indices of other tags.
@@ -385,12 +384,12 @@ class TypeSafeIndex {
 
   /// Allow inequality test with unsigned integers.
   template <typename U>
-  typename std::enable_if_t<
-      std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
+  typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>,
+                            bool>
   operator!=(const U& value) const {
     DRAKE_ASSERT_VOID(AssertValid(index_, "Testing != with invalid index."));
     return value > static_cast<U>(kMaxIndex) ||
-        index_ != static_cast<int>(value);
+           index_ != static_cast<int>(value);
   }
 
   /// Prevent inequality test with indices of other tags.
@@ -400,19 +399,18 @@ class TypeSafeIndex {
   /// Allow less than test with indices of this tag.
   bool operator<(const TypeSafeIndex<Tag>& other) const {
     DRAKE_ASSERT_VOID(AssertValid(index_, "Testing < with invalid LHS."));
-    DRAKE_ASSERT_VOID(
-        AssertValid(other.index_, "Testing < with invalid RHS."));
+    DRAKE_ASSERT_VOID(AssertValid(other.index_, "Testing < with invalid RHS."));
     return index_ < other.index_;
   }
 
   /// Allow less than test with unsigned integers.
   template <typename U>
-  typename std::enable_if_t<
-      std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
+  typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>,
+                            bool>
   operator<(const U& value) const {
     DRAKE_ASSERT_VOID(AssertValid(index_, "Testing < with invalid index."));
     return value > static_cast<U>(kMaxIndex) ||
-        index_ < static_cast<int>(value);
+           index_ < static_cast<int>(value);
   }
 
   /// Prevent less than test with indices of other tags.
@@ -429,12 +427,12 @@ class TypeSafeIndex {
 
   /// Allow less than or equals test with unsigned integers.
   template <typename U>
-  typename std::enable_if_t<
-      std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
+  typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>,
+                            bool>
   operator<=(const U& value) const {
     DRAKE_ASSERT_VOID(AssertValid(index_, "Testing <= with invalid index."));
     return value > static_cast<U>(kMaxIndex) ||
-        index_ <= static_cast<int>(value);
+           index_ <= static_cast<int>(value);
   }
 
   /// Prevent less than or equals test with indices of other tags.
@@ -444,15 +442,14 @@ class TypeSafeIndex {
   /// Allow greater than test with indices of this tag.
   bool operator>(const TypeSafeIndex<Tag>& other) const {
     DRAKE_ASSERT_VOID(AssertValid(index_, "Testing > with invalid LHS."));
-    DRAKE_ASSERT_VOID(
-        AssertValid(other.index_, "Testing > with invalid RHS."));
+    DRAKE_ASSERT_VOID(AssertValid(other.index_, "Testing > with invalid RHS."));
     return index_ > other.index_;
   }
 
   /// Allow greater than test with unsigned integers.
   template <typename U>
-  typename std::enable_if_t<
-      std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
+  typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>,
+                            bool>
   operator>(const U& value) const {
     DRAKE_ASSERT_VOID(AssertValid(index_, "Testing > with invalid index."));
     return value <= static_cast<U>(kMaxIndex) &&
@@ -473,8 +470,8 @@ class TypeSafeIndex {
 
   /// Allow greater than or equals test with unsigned integers.
   template <typename U>
-  typename std::enable_if_t<
-      std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
+  typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>,
+                            bool>
   operator>=(const U& value) const {
     DRAKE_ASSERT_VOID(AssertValid(index_, "Testing >= with invalid index."));
     return value <= static_cast<U>(kMaxIndex) &&
@@ -519,9 +516,7 @@ class TypeSafeIndex {
 
   // This value helps distinguish indices that are invalid through construction
   // or moves versus user manipulation.
-  enum {
-    kDefaultInvalid = -1234567
-  };
+  enum { kDefaultInvalid = -1234567 };
 
   int index_{kDefaultInvalid};
 
@@ -537,43 +532,37 @@ class TypeSafeIndex {
 };
 
 template <typename Tag, typename U>
-typename std::enable_if_t<
-    std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
+typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
 operator==(const U& value, const TypeSafeIndex<Tag>& tag) {
   return tag.operator==(value);
 }
 
 template <typename Tag, typename U>
-typename std::enable_if_t<
-    std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
+typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
 operator!=(const U& value, const TypeSafeIndex<Tag>& tag) {
   return tag.operator!=(value);
 }
 
 template <typename Tag, typename U>
-typename std::enable_if_t<
-    std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
+typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
 operator<(const U& value, const TypeSafeIndex<Tag>& tag) {
   return tag >= value;
 }
 
 template <typename Tag, typename U>
-typename std::enable_if_t<
-    std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
+typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
 operator<=(const U& value, const TypeSafeIndex<Tag>& tag) {
   return tag > value;
 }
 
 template <typename Tag, typename U>
-typename std::enable_if_t<
-    std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
+typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
 operator>(const U& value, const TypeSafeIndex<Tag>& tag) {
   return tag <= value;
 }
 
 template <typename Tag, typename U>
-typename std::enable_if_t<
-    std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
+typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
 operator>=(const U& value, const TypeSafeIndex<Tag>& tag) {
   return tag < value;
 }
@@ -590,6 +579,5 @@ struct hash<drake::TypeSafeIndex<Tag>> : public drake::DefaultHash {};
 // TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
 namespace fmt {
 template <typename Tag>
-struct formatter<drake::TypeSafeIndex<Tag>>
-    : drake::ostream_formatter {};
+struct formatter<drake::TypeSafeIndex<Tag>> : drake::ostream_formatter {};
 }  // namespace fmt

--- a/common/unused.h
+++ b/common/unused.h
@@ -47,7 +47,7 @@ namespace drake {
 /// }
 /// @endcode
 ///
-template <typename ... Args>
-void unused(const Args& ...) {}
+template <typename... Args>
+void unused(const Args&...) {}
 
 }  // namespace drake

--- a/common/value.cc
+++ b/common/value.cc
@@ -33,7 +33,8 @@ int ReportZeroHash(const std::type_info& detail) {
       " See drake/common/test/value_test.cc for an example.",
       bad_class, bad_class);
   if (!has_warned) {
-    log()->warn(message +
+    log()->warn(
+        message +
         " This is the first instance of an impaired T within this process."
         " Additional instances will not be warned about, but you may set"
         " the drake::log() level to 'debug' to see all instances.");
@@ -47,8 +48,7 @@ int ReportZeroHash(const std::type_info& detail) {
 AbstractValue::~AbstractValue() = default;
 
 std::string AbstractValue::GetNiceTypeName() const {
-  return NiceTypeName::Canonicalize(
-      NiceTypeName::Demangle(type_info().name()));
+  return NiceTypeName::Canonicalize(NiceTypeName::Demangle(type_info().name()));
 }
 
 void AbstractValue::ThrowCastError(const std::string& requested_type) const {
@@ -56,13 +56,14 @@ void AbstractValue::ThrowCastError(const std::string& requested_type) const {
   const auto static_type = NiceTypeName::Get(static_type_info());
   if (dynamic_type != static_type) {
     throw std::logic_error(fmt::format(
-         "AbstractValue: a request to cast to '{}' failed because the value "
-         "was created using the static type '{}' (with a dynamic type of "
-         "'{}').", requested_type, static_type, dynamic_type));
+        "AbstractValue: a request to cast to '{}' failed because the value "
+        "was created using the static type '{}' (with a dynamic type of '{}').",
+        requested_type, static_type, dynamic_type));
   }
   throw std::logic_error(fmt::format(
-     "AbstractValue: a request to cast to '{}' failed because the value "
-     "was created using the static type '{}'.", requested_type, static_type));
+      "AbstractValue: a request to cast to '{}' failed because the value was "
+      "created using the static type '{}'.",
+      requested_type, static_type));
 }
 
 }  // namespace drake

--- a/common/value.h
+++ b/common/value.h
@@ -32,17 +32,16 @@ using ValueTraits = ValueTraitsImpl<T, std::is_copy_constructible_v<T>>;
 // In our ctor overload that copies into the storage, choose_copy == true.
 template <bool choose_copy, typename T, typename Arg1, typename... Args>
 using ValueForwardingCtorEnabled = typename std::enable_if_t<
-  // There must be such a constructor.
-  std::is_constructible_v<T, Arg1, Args...> &&
-  // Disable this ctor when given T directly; in that case, we
-  // should call our Value(const T&) ctor above, not try to copy-
-  // construct a T(const T&).
-  !std::is_same_v<T, Arg1> &&
-  !std::is_same_v<T&, Arg1> &&
-  // Only allow real ctors, not POD "constructor"s.
-  !std::is_fundamental_v<T> &&
-  // Disambiguate our copy implementation from our clone implementation.
-  (choose_copy == std::is_copy_constructible_v<T>)>;
+    // There must be such a constructor.
+    std::is_constructible_v<T, Arg1, Args...> &&
+    // Disable this ctor when given T directly; in that case, we
+    // should call our Value(const T&) ctor above, not try to copy-
+    // construct a T(const T&).
+    !std::is_same_v<T, Arg1> && !std::is_same_v<T&, Arg1> &&
+    // Only allow real ctors, not POD "constructor"s.
+    !std::is_fundamental_v<T> &&
+    // Disambiguate our copy implementation from our clone implementation.
+    (choose_copy == std::is_copy_constructible_v<T>)>;
 
 template <typename T>
 using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
@@ -73,9 +72,8 @@ class AbstractValue {
   /// Constructs an AbstractValue using T's default constructor, if available.
   /// This is only available for T's that support default construction.
 #if !defined(DRAKE_DOXYGEN_CXX)
-  template <typename T,
-            typename = typename std::enable_if_t<
-                std::is_default_constructible_v<T>>>
+  template <typename T, typename = typename std::enable_if_t<
+                            std::is_default_constructible_v<T>>>
 #endif
   static std::unique_ptr<AbstractValue> Make();
 
@@ -89,7 +87,9 @@ class AbstractValue {
   /// AbstractValue::Make<T>() or Value<T>::Value().  If T does not match, a
   /// std::logic_error will be thrown with a helpful error message.
   template <typename T>
-  const T& get_value() const { return cast<T>().get_value(); }
+  const T& get_value() const {
+    return cast<T>().get_value();
+  }
 
   /// Returns the value wrapped in this AbstractValue as mutable reference.
   /// The reference remains valid only until this object is set or destroyed.
@@ -97,14 +97,18 @@ class AbstractValue {
   /// AbstractValue::Make<T>() or Value<T>::Value().  If T does not match, a
   /// std::logic_error will be thrown with a helpful error message.
   template <typename T>
-  T& get_mutable_value() { return cast<T>().get_mutable_value(); }
+  T& get_mutable_value() {
+    return cast<T>().get_mutable_value();
+  }
 
   /// Sets the value wrapped in this AbstractValue.
   /// @tparam T The originally declared type of this AbstractValue, e.g., from
   /// AbstractValue::Make<T>() or Value<T>::Value().  If T does not match, a
   /// std::logic_error will be thrown with a helpful error message.
   template <typename T>
-  void set_value(const T& v) { cast<T>().set_value(v); }
+  void set_value(const T& v) {
+    cast<T>().set_value(v);
+  }
 
   /// Returns the value wrapped in this AbstractValue, if T matches the
   /// originally declared type of this AbstractValue.
@@ -149,16 +153,21 @@ class AbstractValue {
   // Use a struct argument (instead of a bare size_t) so that no code
   // tries to convert a single-element numeric initializer_list to
   // a `const AbstractValue&`.  (This works around a bug in GCC 5.)
-  struct Wrap { size_t value{}; };
-  explicit AbstractValue(Wrap hash)
-      : type_hash_(hash.value) {}
+  struct Wrap {
+    size_t value{};
+  };
+  explicit AbstractValue(Wrap hash) : type_hash_(hash.value) {}
 #endif
 
  private:
-  template <typename T> bool is_maybe_matched() const;
-  template <typename T> const Value<T>& cast() const;
-  template <typename T> Value<T>& cast();
-  template <typename T> [[noreturn]] void ThrowCastError() const;
+  template <typename T>
+  bool is_maybe_matched() const;
+  template <typename T>
+  const Value<T>& cast() const;
+  template <typename T>
+  Value<T>& cast();
+  template <typename T>
+  [[noreturn]] void ThrowCastError() const;
   [[noreturn]] void ThrowCastError(const std::string&) const;
 
   // The TypeHash<T>::value supplied by the Value<T> constructor.
@@ -191,20 +200,17 @@ class Value : public AbstractValue {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Value)
 
-  static_assert(
-      std::is_same_v<T, internal::remove_cvref_t<T>>,
-      "T should not have const, volatile, or reference qualifiers.");
+  static_assert(std::is_same_v<T, internal::remove_cvref_t<T>>,
+                "T should not have const, volatile, or reference qualifiers.");
 
-  static_assert(
-      !std::is_pointer_v<T> && !std::is_array_v<T>,
-      "T cannot be a pointer or array.");
+  static_assert(!std::is_pointer_v<T> && !std::is_array_v<T>,
+                "T cannot be a pointer or array.");
 
   /// Constructs a Value<T> using T's default constructor, if available.
   /// This is only available for T's that support default construction.
 #if !defined(DRAKE_DOXYGEN_CXX)
-  template <typename T1 = T,
-            typename = typename std::enable_if_t<
-                std::is_default_constructible_v<T1>>>
+  template <typename T1 = T, typename = typename std::enable_if_t<
+                                 std::is_default_constructible_v<T1>>>
 #endif
   Value();
 
@@ -219,12 +225,14 @@ class Value : public AbstractValue {
   explicit Value(Args&&... args);
 #else
   // This overload is for copyable T.
-  template <typename Arg1, typename... Args, typename =
-      typename internal::ValueForwardingCtorEnabled<true, T, Arg1, Args...>>
+  template <typename Arg1, typename... Args,
+            typename = typename internal::ValueForwardingCtorEnabled<
+                true, T, Arg1, Args...>>
   explicit Value(Arg1&& arg1, Args&&... args);
   // This overload is for cloneable T.
-  template <typename Arg1, typename... Args, typename = void, typename =
-      typename internal::ValueForwardingCtorEnabled<false, T, Arg1, Args...>>
+  template <typename Arg1, typename... Args, typename = void,
+            typename = typename internal::ValueForwardingCtorEnabled<
+                false, T, Arg1, Args...>>
   explicit Value(Arg1&& arg1, Args&&... args);
 #endif
 
@@ -252,8 +260,8 @@ class Value : public AbstractValue {
   const std::type_info& static_type_info() const final;
 
   // A using-declaration adds these methods into our class's Doxygen.
-  using AbstractValue::static_type_info;
   using AbstractValue::GetNiceTypeName;
+  using AbstractValue::static_type_info;
 
  private:
   using Traits = internal::ValueTraits<T>;
@@ -334,7 +342,9 @@ constexpr bool hash_template_argument_from_pretty_func(
     const char* clang_iter = clang_spelling;
     const char* pretty_iter = p;
     for (; *clang_iter != 0 && *pretty_iter != 0; ++clang_iter, ++pretty_iter) {
-      if (*clang_iter != *pretty_iter) { break; }
+      if (*clang_iter != *pretty_iter) {
+        break;
+      }
     }
     // ... and if we found the entire clang_spelling, emit gcc_spelling instead.
     if (*clang_iter == 0) {
@@ -422,8 +432,8 @@ struct TypeHasher {
     const bool discard_nested = false;
     const bool discard_cast = false;
     return hash_template_argument_from_pretty_func(
-        __PRETTY_FUNCTION__, which_argument,
-        discard_nested, discard_cast, result);
+        __PRETTY_FUNCTION__, which_argument, discard_nested, discard_cast,
+        result);
   }
 };
 
@@ -461,8 +471,8 @@ struct TypeHasher<T<Args...>, false> {
     const bool discard_nested = true;
     const bool discard_cast = false;
     bool success = hash_template_argument_from_pretty_func(
-        __PRETTY_FUNCTION__, which_argument,
-        discard_nested, discard_cast, result);
+        __PRETTY_FUNCTION__, which_argument, discard_nested, discard_cast,
+        result);
     // Then, hash the "<Args...>".  Add delimiters so that parameter pack
     // nesting is correctly hashed.
     result->add_byte('<');
@@ -481,8 +491,8 @@ struct ValueHasher {
     const bool discard_nested = false;
     const bool discard_cast = true;
     return hash_template_argument_from_pretty_func(
-        __PRETTY_FUNCTION__, which_argument,
-        discard_nested, discard_cast, result);
+        __PRETTY_FUNCTION__, which_argument, discard_nested, discard_cast,
+        result);
   }
 };
 
@@ -496,16 +506,16 @@ struct TypeHasher<T, true> {
     const int which_argument = 0;
     const bool discard_nested = true;
     const bool discard_cast = false;
-    hash_template_argument_from_pretty_func(
-        __PRETTY_FUNCTION__, which_argument,
-        discard_nested, discard_cast, result);
+    hash_template_argument_from_pretty_func(__PRETTY_FUNCTION__, which_argument,
+                                            discard_nested, discard_cast,
+                                            result);
     // Then, hash the "<U=u>".
     using U = typename T::NonTypeTemplateParameter::value_type;
     result->add_byte('<');
     bool success = TypeHasher<U>::calc(result);
     result->add_byte('=');
     success = success &&
-        ValueHasher<U, T::NonTypeTemplateParameter::value>::calc(result);
+              ValueHasher<U, T::NonTypeTemplateParameter::value>::calc(result);
     result->add_byte('>');
     return success;
   }
@@ -538,8 +548,8 @@ struct IntPackHasher<N, Ns...> {
 };
 
 // Specializes TypeHasher for Eigen-like types.
-template <template <typename, int, int...> class T,
-          typename U, int N, int... Ns>
+template <template <typename, int, int...> class T, typename U, int N,
+          int... Ns>
 struct TypeHasher<T<U, N, Ns...>, false> {
   static constexpr bool calc(FNV1aHasher* result) {
     // First, hash just the "T" template template type, not the "<U, N, Ns...>".
@@ -547,8 +557,8 @@ struct TypeHasher<T<U, N, Ns...>, false> {
     const bool discard_nested = true;
     const bool discard_cast = false;
     bool success = hash_template_argument_from_pretty_func(
-        __PRETTY_FUNCTION__, which_argument,
-        discard_nested, discard_cast, result);
+        __PRETTY_FUNCTION__, which_argument, discard_nested, discard_cast,
+        result);
     // Then, hash the "<U, N, Ns...>".  Add delimiters so that parameter pack
     // nesting is correctly hashed.
     result->add_byte('<');
@@ -643,9 +653,7 @@ struct ValueTraitsImpl<T, false> {
   static void reinitialize_if_necessary(Storage* value) {
     *value = std::make_unique<T>();
   }
-  static Storage to_storage(const T& other) {
-    return Storage{other.Clone()};
-  }
+  static Storage to_storage(const T& other) { return Storage{other.Clone()}; }
   static Storage to_storage(std::unique_ptr<T> other) {
     DRAKE_DEMAND(other.get() != nullptr);
     return Storage{std::move(other)};
@@ -669,14 +677,18 @@ std::unique_ptr<AbstractValue> AbstractValue::Make(const T& value) {
 
 template <typename T>
 const T* AbstractValue::maybe_get_value() const {
-  if (!is_maybe_matched<T>()) { return nullptr; }
+  if (!is_maybe_matched<T>()) {
+    return nullptr;
+  }
   auto& self = static_cast<const Value<T>&>(*this);
   return &self.get_value();
 }
 
 template <typename T>
 T* AbstractValue::maybe_get_mutable_value() {
-  if (!is_maybe_matched<T>()) { return nullptr; }
+  if (!is_maybe_matched<T>()) {
+    return nullptr;
+  }
   auto& self = static_cast<Value<T>&>(*this);
   return &self.get_mutable_value();
 }
@@ -688,21 +700,25 @@ template <typename T>
 bool AbstractValue::is_maybe_matched() const {
   constexpr auto hash = internal::TypeHash<T>::value;
   internal::ReportUseOfTypeHash<T, hash>::used();
-  return (kDrakeAssertIsArmed || !hash) ? (typeid(T) == static_type_info()) :
-      (hash == type_hash_);
+  return (kDrakeAssertIsArmed || !hash) ? (typeid(T) == static_type_info())
+                                        : (hash == type_hash_);
 }
 
 // Casts this to a `const Value<T>&`, with error checking that throws.
 template <typename T>
 const Value<T>& AbstractValue::cast() const {
-  if (!is_maybe_matched<T>()) { ThrowCastError<T>(); }
+  if (!is_maybe_matched<T>()) {
+    ThrowCastError<T>();
+  }
   return static_cast<const Value<T>&>(*this);
 }
 
 // Casts this to a `Value<T>&`, with error checking that throws.
 template <typename T>
 Value<T>& AbstractValue::cast() {
-  if (!is_maybe_matched<T>()) { ThrowCastError<T>(); }
+  if (!is_maybe_matched<T>()) {
+    ThrowCastError<T>();
+  }
   return static_cast<Value<T>&>(*this);
 }
 
@@ -716,8 +732,7 @@ void AbstractValue::ThrowCastError() const {
 template <typename T>
 template <typename T1, typename T2>
 Value<T>::Value()
-    : AbstractValue(Wrap{internal::TypeHash<T>::value}),
-      value_{} {
+    : AbstractValue(Wrap{internal::TypeHash<T>::value}), value_{} {
   internal::ReportUseOfTypeHash<T, internal::TypeHash<T>::value>::used();
   Traits::reinitialize_if_necessary(&value_);
 }
@@ -743,8 +758,8 @@ template <typename T>
 template <typename Arg1, typename... Args, typename, typename>
 Value<T>::Value(Arg1&& arg1, Args&&... args)
     : AbstractValue(Wrap{internal::TypeHash<T>::value}),
-      value_{std::make_unique<T>(
-          std::forward<Arg1>(arg1), std::forward<Args>(args)...)} {
+      value_{std::make_unique<T>(std::forward<Arg1>(arg1),
+                                 std::forward<Args>(args)...)} {
   internal::ReportUseOfTypeHash<T, internal::TypeHash<T>::value>::used();
 }
 


### PR DESCRIPTION
This fixes about 90% of the lint in `common/*.{h,cc}`.  Before we enable the linter in the build system, we'll also need to de-lint the unit tests along with the remaining 10%.

For the most part, this is an automatically-generated change.  In a few places, I've manually adjusted the code a little so that the auto-formatting yields a more readable result.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19272)
<!-- Reviewable:end -->
