### PR TITLE
Improve error message for unsupported geometries in proximity engine.

### DIFF
--- a/geometry/proximity/distance_to_shape_callback.cc
+++ b/geometry/proximity/distance_to_shape_callback.cc
@@ -273,11 +273,13 @@ bool Callback(fcl::CollisionObjectd* object_A_ptr,
         data.nearest_pairs.emplace_back(std::move(signed_pair));
       }
     } else {
-      throw std::logic_error(
-          fmt::format("Signed distance queries between shapes '{}' and '{}' "
-                      "are not supported for scalar type {}",
-                      GetGeometryName(*object_A_ptr),
-                      GetGeometryName(*object_B_ptr), NiceTypeName::Get<T>()));
+      throw std::logic_error(fmt::format(
+          "Signed distance queries between shapes '{}' and '{}' "
+          "are not supported for scalar type {}. See the documentation for "
+          "QueryObject::ComputeSignedDistancePairwiseClosestPoints() for the "
+          "full status of supported geometries.",
+          GetGeometryName(*object_A_ptr), GetGeometryName(*object_B_ptr),
+          NiceTypeName::Get<T>()));
     }
   }
   // Returning true would tell the broadphase manager to terminate early. Since

--- a/geometry/proximity/distance_to_shape_callback.h
+++ b/geometry/proximity/distance_to_shape_callback.h
@@ -180,7 +180,9 @@ void CalcDistanceFallback(const fcl::CollisionObjectd& a,
   // actually exists, it should be specialized below.
   throw std::logic_error(fmt::format(
       "Signed distance queries between shapes '{}' and '{}' "
-      "are not supported for scalar type {}",
+      "are not supported for scalar type {}. See the documentation for "
+      "QueryObject::ComputeSignedDistancePairwiseClosestPoints() for the "
+      "full status of supported geometries.",
       GetGeometryName(a), GetGeometryName(b), NiceTypeName::Get<T>()));
 }
 

--- a/geometry/proximity/penetration_as_point_pair_callback.cc
+++ b/geometry/proximity/penetration_as_point_pair_callback.cc
@@ -152,7 +152,9 @@ void CalcDistanceFallback(const fcl::CollisionObjectd& a,
   // actually exists, it should be specialized below.
   throw std::logic_error(fmt::format(
       "PenetrationAsPointPair() cannot be evaluated for shapes '{}' and '{}' "
-      "for scalar type {}",
+      "for scalar type {}. See the documentation for "
+      "QueryObject::ComputePointPairPenetration() for the full status of "
+      "supported geometries.",
       GetGeometryName(a), GetGeometryName(b), NiceTypeName::Get<T>()));
 }
 
@@ -416,7 +418,9 @@ bool Callback(fcl::CollisionObjectd* fcl_object_A_ptr,
   } else {
     throw std::logic_error(fmt::format(
         "Penetration queries between shapes '{}' and '{}' "
-        "are not supported for scalar type {}",
+        "are not supported for scalar type {}. See the documentation for "
+        "QueryObject::ComputePointPairPenetration() for the full status of "
+        "supported geometries.",
         GetGeometryName(*fcl_object_A_ptr), GetGeometryName(*fcl_object_B_ptr),
         NiceTypeName::Get<T>()));
   }

--- a/geometry/proximity/test/distance_sphere_to_shape_test.cc
+++ b/geometry/proximity/test/distance_sphere_to_shape_test.cc
@@ -84,7 +84,7 @@ GTEST_TEST(SphereShapeDistance, FallbackSupport) {
       CalcDistanceFallback<AutoDiffXd>(obj_a, obj_b, request,
                                        &distance_pair_ad),
       "Signed distance queries between shapes .+ and .+ are not supported for "
-      "scalar type .*AutoDiffXd");
+      "scalar type .*AutoDiffXd.*");
 }
 // TODO(SeanCurtis-TRI): Create a more general test framework when we have
 //  shape-shape primitives that *aren't* covered by the point-shape tests.

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -264,7 +264,7 @@ class QueryObject {
    | Ellipsoid | throwsᵉ | throwsᵉ  | throwsᵉ |  throwsᵉ  |   throwsᵉ  |   ░░░░░░   |  ░░░░░  |  ░░░░░  |
    | HalfSpace | throwsᵉ | throwsᵉ  | throwsᵉ |  throwsᵉ  |   throwsᵉ  |   throwsᵃ  |  ░░░░░  |  ░░░░░  |
    | Mesh      |    ᵇ    |    ᵇ     |    ᵇ    |     ᵇ     |      ᵇ     |     ᵇ      |    ᵇ    |  ░░░░░  |
-   | Sphere    | throwsᵉ | throwsᵉ  | throwsᵉ |  throwsᵉ  |   throwsᵉ  |    throwsᵉ  |    ᵇ    | throwsᵉ |
+   | Sphere    | throwsᵉ | throwsᵉ  | throwsᵉ |  throwsᵉ  |   throwsᵉ  |   throwsᵉ  |    ᵇ    | throwsᵉ |
    __*Table 3*__: Support for `T` = @ref drake::symbolic::Expression.
 
    - ᵃ Penetration depth between two HalfSpace instances has no meaning; either

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -262,7 +262,7 @@ class QueryObject {
    | Convex    | throwsᵉ | throwsᵉ  | throwsᵉ |  ░░░░░░░  |   ░░░░░░   |   ░░░░░░   |  ░░░░░  |  ░░░░░  |
    | Cylinder  | throwsᵉ | throwsᵉ  | throwsᵉ |  throwsᵉ  |   ░░░░░░   |   ░░░░░░   |  ░░░░░  |  ░░░░░  |
    | Ellipsoid | throwsᵉ | throwsᵉ  | throwsᵉ |  throwsᵉ  |   throwsᵉ  |   ░░░░░░   |  ░░░░░  |  ░░░░░  |
-   | HalfSpace | throwsᵉ | throwsᵉ  | throwsᵉ |  throwsᵉ  |   throwsᵉ  |   throwsᵉ  |  ░░░░░  |  ░░░░░  |
+   | HalfSpace | throwsᵉ | throwsᵉ  | throwsᵉ |  throwsᵉ  |   throwsᵉ  |   throwsᵃ  |  ░░░░░  |  ░░░░░  |
    | Mesh      |    ᵇ    |    ᵇ     |    ᵇ    |     ᵇ     |      ᵇ     |     ᵇ      |    ᵇ    |  ░░░░░  |
    | Sphere    | throwsᵉ | throwsᵉ  | throwsᵉ |  throwsᵉ  |   throwsᵉ  |    throwsᵉ  |    ᵇ    | throwsᵉ |
    __*Table 3*__: Support for `T` = @ref drake::symbolic::Expression.
@@ -540,7 +540,7 @@ class QueryObject {
    | Cylinder  | throwsᵇ |  throwsᵇ | throwsᵇ |  throwsᵇ  |   ░░░░░░   |   ░░░░░░   |  ░░░░░  |  ░░░░░  |
    | Ellipsoid | throwsᵇ |  throwsᵇ | throwsᵇ |  throwsᵇ  |  throwsᵇ   |   ░░░░░░   |  ░░░░░  |  ░░░░░  |
    | HalfSpace | throwsᵃ |  throwsᵃ | throwsᵃ |  throwsᵃ  |  throwsᵃ   |   throwsᵃ  |  ░░░░░  |  ░░░░░  |
-   | Mesh      |    ᶜ    |    ᶜ     |    ᶜ    |     ᶜ     |      ᶜ     |      ᵃ     |    ᶜ    |  ░░░░░  |
+   | Mesh      |    ᶜ    |    ᶜ     |    ᶜ    |     ᶜ     |      ᶜ     |   throwsᵃ  |    ᶜ    |  ░░░░░  |
    | Sphere    |  2e-15  |  throwsᵇ | throwsᵇ |  throwsᵇ  |  throwsᵇ   |    2e-15   |    ᶜ    |  5e-15  |
    __*Table 5*__: Worst observed error (in m) for 2mm penetration/separation
    between geometries approximately 20cm in size for `T` =
@@ -553,9 +553,9 @@ class QueryObject {
    | Convex    | throwsᵈ | throwsᵈ  | throwsᵈ |  ░░░░░░░  |   ░░░░░░   |   ░░░░░░   |  ░░░░░  |  ░░░░░  |
    | Cylinder  | throwsᵈ | throwsᵈ  | throwsᵈ |  throwsᵈ  |   ░░░░░░   |   ░░░░░░   |  ░░░░░  |  ░░░░░  |
    | Ellipsoid | throwsᵈ | throwsᵈ  | throwsᵈ |  throwsᵈ  |   throwsᵈ  |   ░░░░░░   |  ░░░░░  |  ░░░░░  |
-   | HalfSpace | throwsᵈ | throwsᵈ  | throwsᵈ |  throwsᵈ  |   throwsᵈ  |   throwsᵈ  |  ░░░░░  |  ░░░░░  |
-   | Mesh      |    ᵇ    |    ᵇ     |    ᵇ    |     ᵇ     |      ᵇ     |     ᵇ      |    ᵇ    |  ░░░░░  |
-   | Sphere    | throwsᵈ | throwsᵈ  | throwsᵈ |  throwsᵈ  |   throwsᵈ  |    throwsᵈ  |    ᵇ    | throwsᵈ |
+   | HalfSpace | throwsᵃ | throwsᵃ  | throwsᵃ |  throwsᵃ  |   throwsᵃ  |   throwsᵃ  |  ░░░░░  |  ░░░░░  |
+   | Mesh      |    ᶜ    |    ᶜ     |    ᶜ    |     ᶜ     |      ᶜ     |   throwsᵃ  |    ᶜ    |  ░░░░░  |
+   | Sphere    | throwsᵈ | throwsᵈ  | throwsᵈ |  throwsᵈ  |   throwsᵈ  |   throwsᵈ  |    ᶜ    | throwsᵈ |
    __*Table 6*__: Support for `T` = @ref drake::symbolic::Expression.
 
    - ᵃ We don't currently support queries between HalfSpace and any other shape

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -4334,7 +4334,7 @@ GTEST_TEST(ProximityEngineTests,
   DRAKE_EXPECT_THROWS_MESSAGE(
       engine.ComputeSignedDistancePairwiseClosestPoints(X_WGs, kInf),
       "Signed distance queries between shapes 'Box' and 'Box' are not "
-      "supported for scalar type drake::AutoDiffXd");
+      "supported for scalar type drake::AutoDiffXd.*");
 }
 
 // Tests that an unsupported geometry causes the engine to throw.
@@ -4353,15 +4353,15 @@ GTEST_TEST(ProximityEngineTests, ExpressionUnsupported) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       engine.ComputeSignedDistancePairwiseClosestPoints(X_WGs, kInf),
       "Signed distance queries between shapes 'Box' and 'Box' are not "
-      "supported for scalar type drake::symbolic::Expression");
+      "supported for scalar type drake::symbolic::Expression.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       engine.ComputeSignedDistancePairClosestPoints(id1, id2, X_WGs),
       "Signed distance queries between shapes 'Box' and 'Box' are not "
-      "supported for scalar type drake::symbolic::Expression");
+      "supported for scalar type drake::symbolic::Expression.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       engine.ComputePointPairPenetration(X_WGs),
       "Penetration queries between shapes 'Box' and 'Box' are not supported "
-      "for scalar type drake::symbolic::Expression");
+      "for scalar type drake::symbolic::Expression.*");
 }
 
 // Test fixture for deformable contact.


### PR DESCRIPTION
Now it points users to the supported geometry tables. Also fixes up a few errant footnotes in those geometry tables.

+@damrongguoy for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19275)
<!-- Reviewable:end -->
