### PR TITLE
Revert "Support IRIS initial ellipse (#19257)"

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -309,8 +309,6 @@ void DefineGeometryOptimization(py::module m) {
         .def_readwrite("configuration_obstacles",
             &IrisOptions::configuration_obstacles,
             cls_doc.configuration_obstacles.doc)
-        .def_readwrite("starting_ellipse", &IrisOptions::starting_ellipse,
-            cls_doc.starting_ellipse.doc)
         .def_readwrite("num_additional_constraint_infeasible_samples",
             &IrisOptions::num_additional_constraint_infeasible_samples,
             cls_doc.num_additional_constraint_infeasible_samples.doc)

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -378,7 +378,6 @@ class TestGeometryOptimization(unittest.TestCase):
         options.termination_threshold = 0.1
         options.relative_termination_threshold = 0.01
         options.random_seed = 1314
-        options.starting_ellipse = mut.Hyperellipsoid.MakeUnitBall(3)
         self.assertNotIn("object at 0x", repr(options))
         region = mut.Iris(
             obstacles=obstacles, sample=[2, 3.4, 5],

--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -49,8 +49,7 @@ HPolyhedron Iris(const ConvexSets& obstacles, const Ref<const VectorXd>& sample,
   }
   DRAKE_DEMAND(domain.IsBounded());
   const double kEpsilonEllipsoid = 1e-2;
-  Hyperellipsoid E = options.starting_ellipse.value_or(
-      Hyperellipsoid::MakeHypersphere(kEpsilonEllipsoid, sample));
+  Hyperellipsoid E = Hyperellipsoid::MakeHypersphere(kEpsilonEllipsoid, sample);
   HPolyhedron P = domain;
 
   // On each iteration, we will build the collision-free polytope represented as
@@ -638,8 +637,7 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
                                        plant.GetPositionUpperLimits());
   DRAKE_DEMAND(P.A().rows() == 2 * nq);
   const double kEpsilonEllipsoid = 1e-2;
-  Hyperellipsoid E = options.starting_ellipse.value_or(
-      Hyperellipsoid::MakeHypersphere(kEpsilonEllipsoid, sample));
+  Hyperellipsoid E = Hyperellipsoid::MakeHypersphere(kEpsilonEllipsoid, sample);
 
   // Make all of the convex sets and supporting quantities.
   auto query_object =

--- a/geometry/optimization/iris.h
+++ b/geometry/optimization/iris.h
@@ -62,11 +62,6 @@ struct IrisOptions {
   pass in such configuration space obstacles. */
   ConvexSets configuration_obstacles{};
 
-  /** The initial hyperepllipsoid that IRIS will use for calculating hyperplanes
-  in the first iteration. If no hyperellipsoid is provided, a small hypershpere
-  centered at the given sample will be used. */
-  std::optional<Hyperellipsoid> starting_ellipse{};
-
   /** By default, IRIS in configuration space certifies regions for collision
   avoidance constraints and joint limits. This option can be used to pass
   additional constraints that should be satisfied by the IRIS region. We accept

--- a/geometry/optimization/test/iris_test.cc
+++ b/geometry/optimization/test/iris_test.cc
@@ -133,37 +133,6 @@ GTEST_TEST(IrisTest, MultipleBoxes) {
   EXPECT_FALSE(region.PointInSet(Vector2d(0.0, -.99)));
 }
 
-GTEST_TEST(IrisTest, StartingEllipse) {
-  ConvexSets obstacles;
-  obstacles.emplace_back(VPolytope::MakeBox(Vector2d(.1, .5), Vector2d(1, 1)));
-  obstacles.emplace_back(
-      VPolytope::MakeBox(Vector2d(-1, -1), Vector2d(-.1, -.5)));
-  obstacles.emplace_back(
-      HPolyhedron::MakeBox(Vector2d(.1, -1), Vector2d(1, -.5)));
-  obstacles.emplace_back(
-      HPolyhedron::MakeBox(Vector2d(-1, .5), Vector2d(-.1, 1)));
-  const HPolyhedron domain = HPolyhedron::MakeUnitBox(2);
-
-  const Vector2d sample{0, 0};  // center of the bounding box.
-  IrisOptions options;
-  // Use narrow ellipse that stretches along y-axis.
-  Eigen::Matrix2d A;
-  A << 0.1, 0, 0, 0.01;
-  Hyperellipsoid E(A, sample);
-  options.starting_ellipse = E;
-  const HPolyhedron region = Iris(obstacles, sample, domain, options);
-  EXPECT_EQ(region.b().size(), 8);  // 4 from bbox + 1 from each obstacle.
-
-  // The initial ellipsoid will cause the region to expand in y, but the
-  // polytope will use the inner corners to define the separating hyperplanes.
-  // Check that the boundary points on the y-axis are in, and the boundary
-  // points on the x-axis are not.
-  EXPECT_TRUE(region.PointInSet(Vector2d(0.0, .99)));
-  EXPECT_TRUE(region.PointInSet(Vector2d(0.0, -.99)));
-  EXPECT_FALSE(region.PointInSet(Vector2d(.99, 0.0)));
-  EXPECT_FALSE(region.PointInSet(Vector2d(-.99, 0.0)));
-}
-
 GTEST_TEST(IrisTest, TerminationConditions) {
   ConvexSets obstacles;
   obstacles.emplace_back(VPolytope::MakeBox(Vector2d(.1, .5), Vector2d(1, 1)));


### PR DESCRIPTION
 Dear @mpetersen94,

 The on-call build cop, @liangfok, believes that your PR #19257 may have
 broken one or more of Drake's continuous integration builds [1]. It is
 possible to break a build even if your PR passed continuous integration
 pre-merge because additional platforms are tested post-merge.

 The specific build failure under investigation is:
https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-x86-monterey-clang-bazel-nightly-everything-debug/171/consoleFull

 Therefore, the build cop has created this revert PR and started a complete
 post-merge build to determine whether your PR was in fact the cause of the
 problem. If that build passes, this revert PR will be merged 60 minutes from
 now. You can then fix the problem at your leisure, and send a new PR to
 reinstate your change.

 If you believe your original PR did not actually break the build, please
 explain on this thread.

 If you believe you can fix the break promptly in lieu of a revert, please
 explain on this thread, and send a PR to the build cop for review ASAP.

 If you believe your original PR definitely did break the build and should be
 reverted, please review and LGTM this PR. This allows the build cop to merge
 without waiting for CI results.

 For advice on how to handle a build cop revert, see [2].

 Thanks!
 Your Friendly On-call Build Cop

 [1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
 [2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19282)
<!-- Reviewable:end -->
