### PR TITLE
[geometry/optimization] Hotfix to IrisInConfigurationSpaceTest.StartingEllipse tolerance

### DIFF
--- a/geometry/optimization/test/iris_in_configuration_space_test.cc
+++ b/geometry/optimization/test/iris_in_configuration_space_test.cc
@@ -496,7 +496,7 @@ GTEST_TEST(IrisInConfigurationSpaceTest, StartingEllipse) {
 
   EXPECT_NEAR(region.MaximumVolumeInscribedEllipsoid().Volume(),
               iterative_region.MaximumVolumeInscribedEllipsoid().Volume(),
-              1e-7);
+              1e-6);
 }
 
 // A (somewhat contrived) example of a concave configuration-space obstacle


### PR DESCRIPTION
Closes #19282. @liangfok for all reviews.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19285)
<!-- Reviewable:end -->
