### PR TITLE
[meshcat] Enable alpha adjustment of invisible geometry

### DIFF
--- a/geometry/meshcat_visualizer.cc
+++ b/geometry/meshcat_visualizer.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/meshcat_visualizer.h"
 
+#include <algorithm>
 #include <memory>
 #include <optional>
 #include <string>
@@ -257,9 +258,18 @@ void MeshcatVisualizer<T>::SetTransforms(
 
 template <typename T>
 void MeshcatVisualizer<T>::SetColorAlphas() const {
+  double max_alpha = 0.0;
+  for (const auto& [geom_id, path] : geometries_) {
+    max_alpha = std::max(max_alpha, colors_[geom_id].a());
+  }
+
   for (const auto& [geom_id, path] : geometries_) {
     Rgba color = colors_[geom_id];
-    color.update({}, {}, {}, alpha_value_ * color.a());
+    if (max_alpha == 0.0) {
+      color.update({}, {}, {}, alpha_value_);
+    } else {
+      color.update({}, {}, {}, alpha_value_ * color.a());
+    }
     meshcat_->SetProperty(path, "color",
                           {color.r(), color.g(), color.b(), color.a()});
   }

--- a/geometry/meshcat_visualizer_params.h
+++ b/geometry/meshcat_visualizer_params.h
@@ -58,21 +58,21 @@ struct MeshcatVisualizerParams {
   bool visible_by_default{true};
 
   /** When using the hydroelastic contact model, collision geometries that are
-  _declared_ as geometric primitives are frequently represented by some
-  discretely tessellated mesh when computing contact. It can be quite helpful
-  in assessing contact behavior to visualize these discrete meshes (in place of
-  the idealized primitives).
+   _declared_ as geometric primitives are frequently represented by some
+   discretely tessellated mesh when computing contact. It can be quite helpful
+   in assessing contact behavior to visualize these discrete meshes (in place
+   of the idealized primitives).
 
-  To visualize these representations it is necessary to request visualization
-  of geometries with the Role::kProximity role (see the role field). It is
-  further necessary to explicitly request the hydroelastic meshes where
-  available (setting show_hydroelastic to `true`).
+   To visualize these representations it is necessary to request visualization
+   of geometries with the Role::kProximity role (see the role field). It is
+   further necessary to explicitly request the hydroelastic meshes where
+   available (setting show_hydroelastic to `true`).
 
-  Setting this `show_hydroelastic` to `true` will have no apparent effect if
-  none of the collision meshes have a hydroelastic mesh associated with them.
+   Setting this `show_hydroelastic` to `true` will have no apparent effect if
+   none of the collision meshes have a hydroelastic mesh associated with them.
 
-  This option is ignored by MeshcatVisualizer<T> when T is not `double`, e.g.
-  if T == AutoDiffXd. */
+   This option is ignored by MeshcatVisualizer<T> when T is not `double`, e.g.
+   if T == AutoDiffXd. */
   bool show_hydroelastic{false};
 
   /** (Advanced) For a given geometry, if the GeometryProperties for our `role`


### PR DESCRIPTION
If geometry is invisible, the meshcat alpha sliders will never make it visible because MeshcatVisualizer simply multiplies geometry alpha by the slider value. To improve this somewhat, check if all geometry in a visualizer is invisible and if so use the absolute alpha slider value as the new alpha instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19287)
<!-- Reviewable:end -->
