### PR TITLE
[tools] Fix deprecation assertion to skip color codes

### DIFF
--- a/tools/jupyter/test/failing_notebook_test.py
+++ b/tools/jupyter/test/failing_notebook_test.py
@@ -21,7 +21,7 @@ class TestFailingNotebook(unittest.TestCase):
         self.assertEqual(p.poll(), 1)
         message = stdout.decode("utf8")
         self.assertIn("CellExecutionError", message)
-        # NOTE: there can be color codes between the DrakeDeprecationWarning and
-        # the warning test, so assert for each separately.
+        # NOTE: there can be color codes between the DrakeDeprecationWarning
+        # and the warning test, so assert for each separately.
         self.assertIn("DrakeDeprecationWarning", message)
         self.assertIn("Deprecation example", message)


### PR DESCRIPTION
Newer jupyter releases will color DrakeDeprecationWarning.

See [slack discussion](https://drakedevelopers.slack.com/archives/C270MN28G/p1682610028062059), inbound unprovisioned issues on macOS should be resolved by this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19293)
<!-- Reviewable:end -->
