### PR TITLE
[install] Add missing runfiles to bazel drake_shared_library

### DIFF
--- a/tools/install/bazel/drake.BUILD.bazel
+++ b/tools/install/bazel/drake.BUILD.bazel
@@ -101,6 +101,9 @@ cc_library(
 
 cc_library(
     name = "drake_shared_library",
+    data = [
+        ":.all_runfiles",
+    ],
     deps = [
         ":.drake_headers",
         "@eigen",


### PR DESCRIPTION
This is the root cause of the [unspeakably awful hack in downstream CI](https://github.com/RobotLocomotion/drake-external-examples/blob/b5fc71e37860193826cbf4984c3caa4be7105460/drake_bazel_installed/apps/BUILD.bazel#L34-L45).

+@sammy-tri for both reviews per schedule, please.