### PR TITLE
[pydrake] Handle nulls in ImportError reporting

### DIFF
--- a/bindings/pydrake/__init__.py
+++ b/bindings/pydrake/__init__.py
@@ -41,7 +41,8 @@ except ImportError:
 try:
     from . import common
 except ImportError as e:
-    if '/pydrake/' in e.path and 'cannot open shared object file' in e.msg:
+    if ('cannot open shared object file' in (e.msg or '')
+            and '/pydrake/' in (e.path or '')):
         message = f'''
 Drake failed to load a required library. This could indicate an installation
 problem, or that your system is missing required distro-provided packages.


### PR DESCRIPTION
The fields of an ImportError might be None; don't crash with an even more obscure error in that case.

Noticed during https://github.com/RobotLocomotion/drake/pull/19103.

My cost / benefit on adding a regression test for this was in favor for punting.  We regression test the non-None case already; injecting the None seemed difficult.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19296)
<!-- Reviewable:end -->
