### PR TITLE
[pydrake] Add math.matmul

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -472,6 +472,15 @@ drake_py_unittest(
 )
 
 drake_py_unittest(
+    name = "math_overloads_matrix_test",
+    deps = [
+        ":math_py",
+        "//bindings/pydrake/common/test_utilities:meta_py",
+        "//bindings/pydrake/common/test_utilities:numpy_compare_py",
+    ],
+)
+
+drake_py_unittest(
     name = "perception_test",
     deps = [
         ":perception_py",

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -595,6 +595,79 @@ void DoScalarIndependentDefinitions(py::module m) {
           NumericalGradientOption(NumericalGradientMethod::kForward),
       doc.ComputeNumericalGradient.doc);
 }
+
+template <typename T>
+std::string_view GetDtypeName() {
+  if constexpr (std::is_same_v<T, double>) {
+    return "float";
+  }
+  if constexpr (std::is_same_v<T, AutoDiffXd>) {
+    return "AutoDiffXd";
+  }
+  if constexpr (std::is_same_v<T, Variable>) {
+    return "Variable";
+  }
+  if constexpr (std::is_same_v<T, Expression>) {
+    return "Expression";
+  }
+}
+
+/* Binds a native C++ matmul(A, B) for wide variety of scalar types. This is
+important for performance until numpy allows us to define dtype-specific
+implementations. Doing a matmul elementwise with a C++ <=> Python call for every
+flop is extraordinarily slow.*/
+void DefineHeterogeneousMatmul(py::module m) {
+  const auto bind = [&m]<typename T1, typename T2>() {
+    using T3 = decltype(std::declval<T1>() * std::declval<T2>());
+    // To avoid too much doc spam, we'll use a more descriptive docstring for
+    // the first overload only.
+    const std::string_view extra_doc =
+        (std::is_same_v<T1, double> && std::is_same_v<T2, double>)
+            ? " The numpy matmul ``A @ B`` is typically slow when multiplying "
+              "user-defined dtypes such as AutoDiffXd or Expression. Use this "
+              "function for better performance, e.g., ``matmul(A, B)``. For a "
+              "dtype=float @ dtype=float, this might be a little slower than "
+              "numpy, but is provided here for convenience so that the user "
+              "doesn't need to be overly careful about the dtype of arguments."
+            : "";
+    const std::string doc = fmt::format(
+        "Matrix product for dtype={} @ dtype={} -> dtype={}.{}",
+        GetDtypeName<T1>(), GetDtypeName<T2>(), GetDtypeName<T3>(), extra_doc);
+    m.def(
+        "matmul",
+        [](const Eigen::Ref<const MatrixX<T1>, 0, StrideX>& A,
+            const Eigen::Ref<const MatrixX<T2>, 0, StrideX>& B) -> MatrixX<T3> {
+          if constexpr (std::is_same_v<T3, AutoDiffXd>) {
+            return A.template cast<AutoDiffXd>() *
+                   B.template cast<AutoDiffXd>();
+          } else {
+            return A * B;
+          }
+        },
+        doc.c_str());
+  };  // NOLINT(readability/braces)
+
+  // The ordering of the calls to `bind` here are sorted fastest-to-slowest to
+  // ensure that overload resolution chooses the fastest one.
+
+  // Bind a double-only overload for convenience.
+  bind.operator()<double, double>();
+
+  // Bind the AutoDiff-related overloads.
+  bind.operator()<double, AutoDiffXd>();
+  bind.operator()<AutoDiffXd, double>();
+  bind.operator()<AutoDiffXd, AutoDiffXd>();
+
+  // Bind the Expression-related overloads.
+  bind.operator()<double, Variable>();
+  bind.operator()<Variable, double>();
+  bind.operator()<double, Expression>();
+  bind.operator()<Expression, double>();
+  bind.operator()<Variable, Expression>();
+  bind.operator()<Expression, Variable>();
+  bind.operator()<Expression, Expression>();
+}
+
 }  // namespace
 
 PYBIND11_MODULE(math, m) {
@@ -610,6 +683,7 @@ PYBIND11_MODULE(math, m) {
   pydrake::internal::BindMathOperators<double>(&m);
   pydrake::internal::BindMathOperators<AutoDiffXd>(&m);
   pydrake::internal::BindMathOperators<Expression>(&m);
+  DefineHeterogeneousMatmul(m);
 
   DoScalarIndependentDefinitions(m);
   type_visit([m](auto dummy) { DoScalarDependentDefinitions(m, dummy); },

--- a/bindings/pydrake/test/math_overloads_matrix_test.py
+++ b/bindings/pydrake/test/math_overloads_matrix_test.py
@@ -1,0 +1,66 @@
+import pydrake.math as mut
+
+import itertools
+import unittest
+
+import numpy as np
+
+from pydrake.autodiffutils import AutoDiffXd
+from pydrake.common.test_utilities import meta, numpy_compare
+from pydrake.symbolic import (
+    Expression,
+    MakeMatrixContinuousVariable,
+    Variable,
+)
+
+
+def _matmul_dtype_pairs():
+    """Returns the list of type pairs (T1, T2) to use for testing functions
+    that operate on a pair of matrix inputs. We'll test all pairs *except* we
+    won't mix autodiff with symbolic.
+    """
+    types = (float, AutoDiffXd, Variable, Expression)
+    for T1, T2 in itertools.product(types, types):
+        has_autodiff = any([T in (AutoDiffXd,) for T in (T1, T2)])
+        has_symbolic = any([T in (Variable, Expression) for T in (T1, T2)])
+        if has_autodiff and has_symbolic:
+            continue
+        yield dict(T1=T1, T2=T2)
+
+
+class MathOverloadsMatrixTest(unittest.TestCase,
+                              metaclass=meta.ValueParameterizedTest):
+
+    def _astype(self, M, dtype, name):
+        """Returns matrix like M but with a new dtype."""
+        assert M.dtype == np.float64, M.dtype
+        if dtype is float:
+            return M
+        if dtype is AutoDiffXd:
+            # Return a copy with a non-zero gradient.
+            result = M.astype(dtype=AutoDiffXd)
+            result[0, 0] = AutoDiffXd(M[0, 0], np.array([1.0]))
+            return result
+        if dtype is Variable:
+            # Return a like-sized matrix of variables.
+            return MakeMatrixContinuousVariable(*M.shape, name)
+        if dtype is Expression:
+            # Return a like-sized matrix of variables promoted to expressions.
+            return self._astype(M, Variable, name).astype(dtype=Expression)
+        assert False
+
+    @meta.run_with_multiple_values(_matmul_dtype_pairs())
+    def test_matmul(self, *, T1, T2):
+        # Create some sample data for A @ B == [[11.0]].
+        A = np.array([[1.0, 2.0]])
+        B = np.array([[3.0, 4.0]]).T
+
+        # Convert the dtypes.
+        A_T1 = self._astype(A, T1, "A")
+        B_T2 = self._astype(B, T2, "B")
+
+        # Compare the fast overload the slow fallback.
+        actual = mut.matmul(A_T1, B_T2)
+        expected = A_T1 @ B_T2
+        self.assertEqual(actual.dtype, expected.dtype)
+        numpy_compare.assert_equal(actual, expected)

--- a/common/eigen_types.h
+++ b/common/eigen_types.h
@@ -147,6 +147,9 @@ using MatrixLikewise = Eigen::Matrix<Scalar,
     Derived::IsRowMajor ? Eigen::RowMajor : Eigen::ColMajor,
     Derived::MaxRowsAtCompileTime, Derived::MaxColsAtCompileTime>;
 
+/// A fully dynamic Eigen stride.
+using StrideX = Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>;
+
 /// A quaternion templated on scalar type.
 template <typename Scalar>
 using Quaternion = Eigen::Quaternion<Scalar>;


### PR DESCRIPTION
This is important for performance until numpy allows us to define dtype-specific implementations. Doing a matmul elementwise with a C++ <=> Python call for every flop is extraordinarily slow.

Towards #19202.  This provides the plumbing (which should already be a nice >20% speed win).  Follow-up work will optimize the actual computation (see #19304).

---
![image](https://user-images.githubusercontent.com/17596505/234984370-c7c69289-72ae-492d-aa72-a3fd1606e290.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19298)
<!-- Reviewable:end -->
