### PR TITLE
[planning] Adds a time cost to GcsTrajectoryOptimization

### DIFF
--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -376,6 +376,8 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
               return out;
             },
             subgraph_doc.regions.doc)
+        .def("AddTimeCost", &Class::Subgraph::AddTimeCost,
+            py::arg("weight") = 1.0, subgraph_doc.AddTimeCost.doc)
         .def("AddPathLengthCost",
             py::overload_cast<const Eigen::MatrixXd&>(
                 &Class::Subgraph::AddPathLengthCost),
@@ -416,6 +418,8 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
         .def("AddEdges", &Class::AddEdges, py_rvp::reference_internal,
             py::arg("from_subgraph"), py::arg("to_subgraph"),
             py::arg("subspace") = py::none(), cls_doc.AddEdges.doc)
+        .def("AddTimeCost", &Class::AddTimeCost, py::arg("weight") = 1.0,
+            cls_doc.AddTimeCost.doc)
         .def("AddPathLengthCost",
             py::overload_cast<const Eigen::MatrixXd&>(
                 &Class::AddPathLengthCost),

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -320,13 +320,19 @@ class TestTrajectoryOptimization(unittest.TestCase):
             np.array([[5.0, 5.0, 4.4, 4.4], [2.8, 5.0, 5.0, 2.8]])
         ]
 
-        # We add a the path length cost to the entire graph.
+        # We add a path length cost to the entire graph.
         # This can be called ahead of time or after adding the regions.
         gcs.AddPathLengthCost(weight=1.0)
         # This cost is equivalent to the above.
         # It will be added twice, which is unnecessary,
         # but we do it to test the binding.
         gcs.AddPathLengthCost(weight_matrix=np.eye(dimension))
+
+        # Add a mimimum time cost to the entire graph.
+        gcs.AddTimeCost(weight=1.0)
+        # Add the cost again, which is unnecessary for the optimization
+        # but useful to check the binding with the default values.
+        gcs.AddTimeCost()
 
         # Add two subgraphs with different orders.
         main1 = gcs.AddRegions(
@@ -415,6 +421,14 @@ class TestTrajectoryOptimization(unittest.TestCase):
         # This weight matrix penalizes movement in the y direction three
         # times more than in the x direction only for the main2 subgraph.
         main2.AddPathLengthCost(weight_matrix=np.diag([1.0, 3.0]))
+
+        # Adding this cost checks the python binding. It won't contribute to
+        # the solution since we already added the minimum time cost to the
+        # whole graph.
+        main2.AddTimeCost(weight=1.0)
+        # Add the cost again, which is unnecessary for the optimization
+        # but useful to check the binding with the default values.
+        main2.AddTimeCost()
 
         options = GraphOfConvexSetsOptions()
         options.convex_relaxation = True

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -80,6 +80,12 @@ class GcsTrajectoryOptimization final {
       return regions_;
     }
 
+    /** Adds a minimum time cost to all regions in the subgraph. The cost is the
+    sum of the time scaling variables.
+    @param weight is the relative weight of the cost.
+    */
+    void AddTimeCost(double weight = 1.0);
+
     /** Adds multiple L2Norm Costs on the upper bound of the path length.
     Since we cannot directly compute the path length of a Bézier curve, we
     minimize the upper bound of the path integral by minimizing the sum of
@@ -262,6 +268,16 @@ class GcsTrajectoryOptimization final {
       const Subgraph& from_subgraph, const Subgraph& to_subgraph,
       const geometry::optimization::ConvexSet* subspace = nullptr);
 
+  /** Adds a minimum time cost to all regions in the whole graph. The cost is
+  the sum of the time scaling variables.
+
+  This cost will be added to the entire graph. Note that this cost
+  will be applied even to subgraphs added in the future.
+
+  @param weight is the relative weight of the cost.
+  */
+  void AddTimeCost(double weight = 1.0);
+
   /** Adds multiple L2Norm Costs on the upper bound of the path length.
   Since we cannot directly compute the path length of a Bézier curve, we
   minimize the upper bound of the path integral by minimizing the sum of
@@ -337,6 +353,7 @@ class GcsTrajectoryOptimization final {
   // Store the subgraphs by reference.
   std::vector<std::unique_ptr<Subgraph>> subgraphs_;
   std::vector<std::unique_ptr<EdgesBetweenSubgraphs>> subgraph_edges_;
+  std::vector<double> global_time_costs_;
   std::vector<Eigen::MatrixXd> global_path_length_costs_;
 };
 

--- a/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
@@ -57,6 +57,9 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, Basic) {
   EXPECT_TRUE(CompareMatrices(traj.value(traj.end_time()), goal, 1e-6));
 }
 
+// TODO(wrangelvid) Add a dedicated test comparing time cost to path length
+// cost. Velocity bounds are required for that.
+
 GTEST_TEST(GcsTrajectoryOptimizationTest, InvalidPositions) {
   /* Positions passed into GcsTrajectoryOptimization must be greater than 0.*/
   DRAKE_EXPECT_THROWS_MESSAGE(GcsTrajectoryOptimization(0),
@@ -416,6 +419,7 @@ TEST_F(SimpleEnv2D, MultiStartGoal) {
   gcs.AddEdges(regions, target);
 
   gcs.AddPathLengthCost();
+  gcs.AddTimeCost();
 
   if (!GurobiOrMosekSolverAvailable()) {
     return;
@@ -507,6 +511,7 @@ TEST_F(SimpleEnv2D, IntermediatePoint) {
 
   // We can add different costs to the individual subgraphs.
   main1.AddPathLengthCost(5);
+  main1.AddTimeCost(1);
 
   // This weight matrix penalizes movement in the y direction three times more
   // than in the x direction.


### PR DESCRIPTION
This adds a minimum time objective. Rather than finding the shortest path, this allows users to find the fastest path. It becomes particularly useful once velocity bounds will be introduced.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19301)
<!-- Reviewable:end -->
