### PR TITLE
[common] Add benchmark for Gemm on Expression

### DIFF
--- a/common/benchmarking/BUILD.bazel
+++ b/common/benchmarking/BUILD.bazel
@@ -13,7 +13,7 @@ drake_cc_googlebench_binary(
     add_test_rule = True,
     test_args = [
         # When testing, skip over Args() that are >= 100.
-        "--benchmark_filter=-/.00+/.$$",
+        "--benchmark_filter=-/.00+(/.)?$$",
     ],
     test_timeout = "moderate",
     deps = [
@@ -31,4 +31,4 @@ drake_py_experiment_binary(
     googlebench_binary = ":benchmark_polynomial",
 )
 
-add_lint_tests()
+add_lint_tests(enable_clang_format_lint = True)

--- a/common/benchmarking/benchmark_polynomial.cc
+++ b/common/benchmarking/benchmark_polynomial.cc
@@ -7,7 +7,7 @@
 namespace drake {
 namespace symbolic {
 namespace {
-void BenchmarkPolynomialEvaluatePartial(benchmark::State& state) {  // NOLINT
+void PolynomialEvaluatePartial(benchmark::State& state) {  // NOLINT
   Eigen::Matrix<symbolic::Variable, 12, 1> x =
       MakeVectorContinuousVariable(12, "x");
   const symbolic::Variables x_set(x);
@@ -44,7 +44,8 @@ void BenchmarkPolynomialEvaluatePartial(benchmark::State& state) {  // NOLINT
   }
 }
 
-void BenchmarkMatrixInnerProduct(benchmark::State& state) {  // NOLINT
+/* A benchmark for tr(Q @ X); Q's type is double, X's type is Variable. */
+void MatrixInnerProduct(benchmark::State& state) {  // NOLINT
   const int n = state.range(0);
   const bool sparse_Q = state.range(1);
   Eigen::MatrixXd Q(n, n);
@@ -76,10 +77,103 @@ void BenchmarkMatrixInnerProduct(benchmark::State& state) {  // NOLINT
   }
 }
 
-BENCHMARK(BenchmarkPolynomialEvaluatePartial)->Unit(benchmark::kMicrosecond);
-BENCHMARK(BenchmarkMatrixInnerProduct)
+/* Creates a pair of matrices with arbitrary data, and in some cases with some
+matrix elements populated as variables instead of constants. The data types of
+the returned matrices are T1 and T2, respectively.
+@tparam T1 must be either double or Expression.
+@tparam T2 must be either Variable or Expression. */
+template <typename T1, typename T2>
+std::pair<MatrixX<T1>, MatrixX<T2>> CreateGemmInput(int n) {
+  MatrixX<T1> A(n, n);
+  for (int i = 0; i < n; ++i) {
+    for (int j = 0; j < n; ++j) {
+      int k = i + 2 * j;
+      A(i, j) = std::cos(k);
+      if constexpr (std::is_same_v<T1, double>) {
+        // Nothing more to do.
+      } else {
+        static_assert(std::is_same_v<T1, Expression>);
+        if ((k % 3) == 0) {
+          A(i, j) *= Variable("X");
+        }
+      }
+    }
+  }
+
+  MatrixX<T2> B(n, n);
+  for (int i = 0; i < n; ++i) {
+    for (int j = 0; j < n; ++j) {
+      if constexpr (std::is_same_v<T2, Variable>) {
+        B(i, j) = Variable("X");
+      } else {
+        static_assert(std::is_same_v<T2, Expression>);
+        int k = i + 7 * j;
+        B(i, j) = std::cos(k);
+        if ((k % 3) == 0) {
+          B(i, j) *= Variable("X");
+        }
+      }
+    }
+  }
+
+  return {std::move(A), std::move(B)};
+}
+
+// Benchmarking four pairs of types is sufficient to cover all of the
+// interesting cases of symbolic matrix multiplication.
+
+// A benchmark for A @ B where A is T=double and B is T=Variable.
+void GemmDV(benchmark::State& state) {  // NOLINT
+  const int n = state.range(0);
+  const auto& [A, B] = CreateGemmInput<double, Variable>(n);
+  for (auto _ : state) {
+    (A * B).eval();
+  }
+}
+
+// A benchmark for A @ B where A is T=double and B is T=Expression.
+void GemmDE(benchmark::State& state) {  // NOLINT
+  const int n = state.range(0);
+  const auto& [A, B] = CreateGemmInput<double, Expression>(n);
+  for (auto _ : state) {
+    (A * B).eval();
+  }
+}
+
+// A benchmark for A @ B where A is T=Variable and B is T=Expression.
+void GemmVE(benchmark::State& state) {  // NOLINT
+  const int n = state.range(0);
+  const auto& [B, A] = CreateGemmInput<Expression, Variable>(n);
+  for (auto _ : state) {
+    (A * B).eval();
+  }
+}
+
+// A benchmark for A @ B where both matrix types are Expression.
+void GemmEE(benchmark::State& state) {  // NOLINT
+  const int n = state.range(0);
+  const auto& [A, B] = CreateGemmInput<Expression, Expression>(n);
+  for (auto _ : state) {
+    (A * B).eval();
+  }
+}
+
+BENCHMARK(PolynomialEvaluatePartial)->Unit(benchmark::kMicrosecond);
+BENCHMARK(MatrixInnerProduct)
     ->ArgsProduct({{10, 50, 100, 200}, {false, true}})
     ->Unit(benchmark::kSecond);
+BENCHMARK(GemmDV)
+    ->ArgsProduct({{10, 50, 100, 200}})
+    ->Unit(benchmark::kMillisecond);
+BENCHMARK(GemmDE)
+    ->ArgsProduct({{10, 50, 100, 200}})
+    ->Unit(benchmark::kMillisecond);
+BENCHMARK(GemmVE)
+    ->ArgsProduct({{10, 50, 100, 200}})
+    ->Unit(benchmark::kMillisecond);
+BENCHMARK(GemmEE)
+    ->ArgsProduct({{10, 50, 100, 200}})
+    ->Unit(benchmark::kMillisecond);
 }  // namespace
 }  // namespace symbolic
 }  // namespace drake


### PR DESCRIPTION
Towards #19202 and #10900.

---

Sample output:

```console
$ bazel-bin/common/benchmarking/benchmark_polynomial --benchmark_filter=Gemm
-----------------------------------------------------
Benchmark           Time             CPU   Iterations
-----------------------------------------------------
GemmDV/10       0.663 ms        0.663 ms          935
GemmDV/50         199 ms          199 ms            4
GemmDV/100       2809 ms         2809 ms            1
GemmDV/200      41299 ms        41295 ms            1
GemmDE/10       0.263 ms        0.263 ms         2675
GemmDE/50        70.7 ms         70.7 ms           10
GemmDE/100        971 ms          971 ms            1
GemmDE/200      13949 ms        13947 ms            1
GemmEE/10       0.442 ms        0.442 ms         1585
GemmEE/50         125 ms          125 ms            6
GemmEE/100       1655 ms         1655 ms            1
GemmEE/200      24911 ms        24909 ms            1
```

See #19304 for more results.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19303)
<!-- Reviewable:end -->
