### PR TITLE
[symbolic] Speed up matmul

### DIFF
--- a/common/symbolic/expression/expression.cc
+++ b/common/symbolic/expression/expression.cc
@@ -1025,4 +1025,90 @@ double ExtractDoubleOrThrow(const symbolic::Expression& e) {
   return e.Evaluate();
 }
 
+namespace symbolic {
+namespace internal {
+namespace {
+
+template <typename T1, typename T2>
+Expression GenericGevv(const Eigen::Ref<const VectorX<T1>, 0, StrideX>& a,
+                       const Eigen::Ref<const VectorX<T2>, 0, StrideX>& b) {
+  DRAKE_ASSERT(a.size() == b.size());
+  ExpressionAddFactory fac;
+  for (int k = 0; k < a.size(); ++k) {
+    fac.AddExpression(a[k] * b[k]);
+  }
+  return std::move(fac).GetExpression();
+}
+
+template <typename T1, typename T2>
+void GenericGemm(const Eigen::Ref<const MatrixX<T1>, 0, StrideX>& left,
+                 const Eigen::Ref<const MatrixX<T2>, 0, StrideX>& right,
+                 EigenPtr<MatrixX<Expression>> result) {
+  // These checks are guaranteed by our header file functions that call us.
+  DRAKE_ASSERT(result != nullptr);
+  DRAKE_ASSERT(result->rows() == left.rows());
+  DRAKE_ASSERT(result->cols() == right.cols());
+  DRAKE_ASSERT(left.cols() == right.rows());
+
+  // Delegate to Gevv.
+  for (int i = 0; i < result->rows(); ++i) {
+    for (int j = 0; j < result->cols(); ++j) {
+      (*result)(i, j) = GenericGevv<T1, T2>(left.row(i), right.col(j));
+    }
+  }
+}
+
+}  // namespace
+
+template <bool reverse>
+void Gemm<reverse>::CalcDV(const MatrixRef<double>& D,
+                           const MatrixRef<Variable>& V,
+                           EigenPtr<MatrixX<Expression>> result) {
+  // We convert Variable => Expression up front, so the ExpressionVar cells get
+  // reused during the computation instead of creating lots of duplicates.
+  // TODO(jwnimmer-tri) If V contains duplicate variables (e.g., symmetric),
+  // it's possible that interning the duplicates would improve performance of
+  // subsequent operations.
+  CalcDE(D, V.template cast<Expression>(), result);
+}
+
+template <bool reverse>
+void Gemm<reverse>::CalcDE(const MatrixRef<double>& D,
+                           const MatrixRef<Expression>& E,
+                           EigenPtr<MatrixX<Expression>> result) {
+  if constexpr (!reverse) {
+    GenericGemm<double, Expression>(D, E, result);
+  } else {
+    GenericGemm<Expression, double>(E, D, result);
+  }
+}
+
+template <bool reverse>
+void Gemm<reverse>::CalcVE(const MatrixRef<Variable>& V,
+                           const MatrixRef<Expression>& E,
+                           EigenPtr<MatrixX<Expression>> result) {
+  // We convert Variable => Expression up front, so the ExpressionVar cells get
+  // reused during the computation instead of creating lots of duplicates.
+  // TODO(jwnimmer-tri) If V contains duplicate variables (e.g., symmetric),
+  // it's possible that interning the duplicates would improve performance of
+  // subsequent operations.
+  CalcEE(V.template cast<Expression>(), E, result);
+}
+
+template <bool reverse>
+void Gemm<reverse>::CalcEE(const MatrixRef<Expression>& A,
+                           const MatrixRef<Expression>& B,
+                           EigenPtr<MatrixX<Expression>> result) {
+  if constexpr (!reverse) {
+    GenericGemm<Expression, Expression>(A, B, result);
+  } else {
+    GenericGemm<Expression, Expression>(B, A, result);
+  }
+}
+
+template struct Gemm<false>;
+template struct Gemm<true>;
+
+}  // namespace internal
+}  // namespace symbolic
 }  // namespace drake

--- a/common/symbolic/expression/test/expression_matrix_test.cc
+++ b/common/symbolic/expression/test/expression_matrix_test.cc
@@ -157,6 +157,19 @@ TEST_F(SymbolicExpressionMatrixTest, EigenMul4) {
   EXPECT_EQ(M, M_expected);
 }
 
+TEST_F(SymbolicExpressionMatrixTest, EigenDot) {
+  const auto vec = Vector3<Expression>(x_, y_, z_);
+  const Expression expected = (x_ * x_) + (y_ * y_) + (z_ * z_);
+
+  const Expression dot1 = vec.dot(vec);
+  const Expression dot2 = vec.transpose() * vec;
+  const Eigen::Matrix<Expression, 1, 1> dot3 = vec.transpose() * vec;
+
+  EXPECT_TRUE(ExprEqual(dot1, expected));
+  EXPECT_TRUE(ExprEqual(dot2, expected));
+  EXPECT_TRUE(ExprEqual(dot3(0), expected));
+}
+
 TEST_F(SymbolicExpressionMatrixTest, EigenDiv) {
   auto const M(A_ / 2.0);
   Eigen::Matrix<Expression, 3, 2> M_expected;


### PR DESCRIPTION
Towards https://github.com/RobotLocomotion/drake/issues/19202 and https://github.com/RobotLocomotion/drake/issues/10900.

The crux of the improvement here is `GenericGevv` computing the inner product directly using `AddFactory`, without creating intermediate Expression nodes.

The calculation of `MatrixX<double> * MatrixX<Variable>` can still be _much_ better optimized.  That will come in a future commit (#19345).

---

For multiplying two matrices each with shape=(50, 50), this yields ~4x throughput compared to master (data shown below).  For shape=(200, 200), the throughput yield is more like ~11x.

On master:
```
------------------------------------------------------------
Benchmark                  Time             CPU   Iterations
------------------------------------------------------------
GemmDV/50_mean           225 ms          225 ms           10
GemmDE/50_mean          82.0 ms         82.0 ms           10
GemmEE/50_mean           151 ms          151 ms           10
```

On this branch:
```
------------------------------------------------------------
Benchmark                  Time             CPU   Iterations
------------------------------------------------------------
GemmDV/50_mean          63.9 ms         63.9 ms           10
GemmDE/50_mean          22.6 ms         22.6 ms           10
GemmEE/50_mean          43.4 ms         43.4 ms           10
```

The benchmark program is found at #19303.

---

I've successfully tested this against Anzu CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19304)
<!-- Reviewable:end -->
