### PR TITLE
Skip render_gltf_client integration tests that fail on macOS

### DIFF
--- a/geometry/render_gltf_client/test/integration_test.py
+++ b/geometry/render_gltf_client/test/integration_test.py
@@ -35,6 +35,11 @@ DEPTH_PIXEL_THRESHOLD = 0.001  # Depth measurement tolerance in meters.
 LABEL_PIXEL_THRESHOLD = 0
 INVALID_PIXEL_FRACTION = 0.2
 
+# TODO(#19305) Remove this once the skipped tests reliably pass on macOS.
+_SKIP = False
+if "darwin" in sys.platform:
+    _SKIP = True
+
 
 class TestIntegration(unittest.TestCase):
     def setUp(self):
@@ -215,6 +220,7 @@ class TestIntegration(unittest.TestCase):
         # normalization, e.g., meshes, cameras, materials, accessors, etc.
         self.assertCountEqual(actual["nodes"], expected["nodes"])
 
+    @unittest.skipIf(_SKIP, "Skipped on macOS, see #19305")
     def test_integration(self):
         """Quantitatively compares the images rendered by RenderEngineVtk and
         RenderEngineGltfClient via a fully exercised RPC pipeline.
@@ -260,6 +266,7 @@ class TestIntegration(unittest.TestCase):
             )
             self.assert_error_fraction_less(label_diff, INVALID_PIXEL_FRACTION)
 
+    @unittest.skipIf(_SKIP, "Skipped on macOS, see #19305")
     def test_gltf_conversion(self):
         """Checks that the fundamental structure of the generated glTF files is
         preserved.  The comparison of the exact texture information is not in


### PR DESCRIPTION
Relates to #19305.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19306)
<!-- Reviewable:end -->
