### PR TITLE
Add a default constructor to all ConvexSet subclasses

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -81,6 +81,7 @@ void DefineGeometryOptimization(py::module m) {
   {
     const auto& cls_doc = doc.CartesianProduct;
     py::class_<CartesianProduct, ConvexSet>(m, "CartesianProduct", cls_doc.doc)
+        .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init([](const std::vector<ConvexSet*>& sets) {
           return std::make_unique<CartesianProduct>(CloneConvexSets(sets));
         }),
@@ -110,6 +111,7 @@ void DefineGeometryOptimization(py::module m) {
   {
     const auto& cls_doc = doc.HPolyhedron;
     py::class_<HPolyhedron, ConvexSet>(m, "HPolyhedron", cls_doc.doc)
+        .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
                  const Eigen::Ref<const Eigen::VectorXd>&>(),
             py::arg("A"), py::arg("b"), cls_doc.ctor.doc_2args)
@@ -171,6 +173,7 @@ void DefineGeometryOptimization(py::module m) {
   {
     const auto& cls_doc = doc.Hyperellipsoid;
     py::class_<Hyperellipsoid, ConvexSet>(m, "Hyperellipsoid", cls_doc.doc)
+        .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
                  const Eigen::Ref<const Eigen::VectorXd>&>(),
             py::arg("A"), py::arg("center"), cls_doc.ctor.doc_2args)
@@ -203,6 +206,7 @@ void DefineGeometryOptimization(py::module m) {
   {
     const auto& cls_doc = doc.Intersection;
     py::class_<Intersection, ConvexSet>(m, "Intersection", cls_doc.doc)
+        .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init([](const std::vector<ConvexSet*>& sets) {
           return std::make_unique<Intersection>(CloneConvexSets(sets));
         }),
@@ -219,6 +223,7 @@ void DefineGeometryOptimization(py::module m) {
   {
     const auto& cls_doc = doc.MinkowskiSum;
     py::class_<MinkowskiSum, ConvexSet>(m, "MinkowskiSum", cls_doc.doc)
+        .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init([](const std::vector<ConvexSet*>& sets) {
           return std::make_unique<MinkowskiSum>(CloneConvexSets(sets));
         }),
@@ -238,6 +243,7 @@ void DefineGeometryOptimization(py::module m) {
   {
     const auto& cls_doc = doc.Point;
     py::class_<Point, ConvexSet>(m, "Point", cls_doc.doc)
+        .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init<const Eigen::Ref<const Eigen::VectorXd>&>(), py::arg("x"),
             cls_doc.ctor.doc_1args)
         .def(py::init<const QueryObject<double>&, GeometryId,
@@ -264,6 +270,7 @@ void DefineGeometryOptimization(py::module m) {
   {
     const auto& cls_doc = doc.VPolytope;
     py::class_<VPolytope, ConvexSet>(m, "VPolytope", cls_doc.doc)
+        .def(py::init<>(), cls_doc.ctor.doc)
         .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&>(),
             py::arg("vertices"), cls_doc.ctor.doc_vertices)
         .def(py::init<const HPolyhedron&>(), py::arg("H"),

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -40,6 +40,7 @@ class TestGeometryOptimization(unittest.TestCase):
         self.z = self.prog.NewContinuousVariables(2, "z")
 
     def test_point_convex_set(self):
+        mut.Point()
         p = np.array([11.1, 12.2, 13.3])
         point = mut.Point(p)
         self.assertEqual(point.ambient_dimension(), 3)
@@ -53,6 +54,7 @@ class TestGeometryOptimization(unittest.TestCase):
         # builds from shape.
 
     def test_h_polyhedron(self):
+        mut.HPolyhedron()
         hpoly = mut.HPolyhedron(A=self.A, b=self.b)
         self.assertEqual(hpoly.ambient_dimension(), 3)
         np.testing.assert_array_equal(hpoly.A(), self.A)
@@ -158,6 +160,7 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertEqual(hpoly.A().shape, (4, 3))
 
     def test_hyper_ellipsoid(self):
+        mut.Hyperellipsoid()
         ellipsoid = mut.Hyperellipsoid(A=self.A, center=self.b)
         self.assertEqual(ellipsoid.ambient_dimension(), 3)
         np.testing.assert_array_equal(ellipsoid.A(), self.A)
@@ -196,6 +199,7 @@ class TestGeometryOptimization(unittest.TestCase):
         np.testing.assert_array_equal(e_ball3.center(), [0, 0, 0])
 
     def test_minkowski_sum(self):
+        mut.MinkowskiSum()
         point = mut.Point(np.array([11.1, 12.2, 13.3]))
         hpoly = mut.HPolyhedron(A=self.A, b=self.b)
         sum = mut.MinkowskiSum(setA=point, setB=hpoly)
@@ -216,6 +220,7 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertEqual(s.ambient_dimension(), 6)
 
     def test_v_polytope(self):
+        mut.VPolytope()
         vertices = np.array([[0.0, 1.0, 2.0], [3.0, 7.0, 5.0]])
         vpoly = mut.VPolytope(vertices=vertices)
         self.assertEqual(vpoly.ambient_dimension(), 2)
@@ -289,6 +294,7 @@ class TestGeometryOptimization(unittest.TestCase):
         return length
 
     def test_cartesian_product(self):
+        mut.CartesianProduct()
         point = mut.Point(np.array([11.1, 12.2, 13.3]))
         h_box = mut.HPolyhedron.MakeBox(
             lb=[-1, -1, -1], ub=[1, 1, 1])
@@ -306,6 +312,7 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertIsInstance(sum2.factor(1), mut.HPolyhedron)
 
     def test_intersection(self):
+        mut.Intersection()
         point = mut.Point(np.array([0.1, 0.2, 0.3]))
         h_box = mut.HPolyhedron.MakeBox(
             lb=[-1, -1, -1], ub=[1, 1, 1])

--- a/geometry/optimization/cartesian_product.h
+++ b/geometry/optimization/cartesian_product.h
@@ -27,6 +27,9 @@ class CartesianProduct final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CartesianProduct)
 
+  /** Constructs a default (zero-dimensional) set. */
+  CartesianProduct();
+
   /** Constructs the product from a vector of convex sets. */
   explicit CartesianProduct(const ConvexSets& sets);
 

--- a/geometry/optimization/convex_set.cc
+++ b/geometry/optimization/convex_set.cc
@@ -20,6 +20,9 @@ ConvexSet::~ConvexSet() = default;
 
 bool ConvexSet::IntersectsWith(const ConvexSet& other) const {
   DRAKE_THROW_UNLESS(other.ambient_dimension() == this->ambient_dimension());
+  if (ambient_dimension() == 0) {
+    return false;
+  }
   solvers::MathematicalProgram prog{};
   const auto& x = prog.NewContinuousVariables(this->ambient_dimension(), "x");
   this->AddPointInSetConstraints(&prog, x);
@@ -28,11 +31,20 @@ bool ConvexSet::IntersectsWith(const ConvexSet& other) const {
   return result.is_success();
 }
 
+void ConvexSet::AddPointInSetConstraints(
+    solvers::MathematicalProgram* prog,
+    const Eigen::Ref<const solvers::VectorXDecisionVariable>& vars) const {
+  DRAKE_THROW_UNLESS(vars.size() == ambient_dimension());
+  DRAKE_THROW_UNLESS(ambient_dimension() > 0);
+  return DoAddPointInSetConstraints(prog, vars);
+}
+
 std::vector<solvers::Binding<solvers::Constraint>>
 ConvexSet::AddPointInNonnegativeScalingConstraints(
     solvers::MathematicalProgram* prog,
     const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
     const symbolic::Variable& t) const {
+  DRAKE_THROW_UNLESS(ambient_dimension() > 0);
   DRAKE_THROW_UNLESS(x.size() == ambient_dimension());
   std::vector<solvers::Binding<solvers::Constraint>> constraints =
       DoAddPointInNonnegativeScalingConstraints(prog, x, t);
@@ -49,6 +61,7 @@ ConvexSet::AddPointInNonnegativeScalingConstraints(
     const Eigen::Ref<const Eigen::VectorXd>& c, double d,
     const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
     const Eigen::Ref<const solvers::VectorXDecisionVariable>& t) const {
+  DRAKE_THROW_UNLESS(ambient_dimension() > 0);
   DRAKE_THROW_UNLESS(A.rows() == ambient_dimension());
   DRAKE_THROW_UNLESS(A.rows() == b.rows());
   DRAKE_THROW_UNLESS(A.cols() == x.size());

--- a/geometry/optimization/convex_set.h
+++ b/geometry/optimization/convex_set.h
@@ -81,26 +81,33 @@ class ConvexSet : public ShapeReifier {
   finite lower and upper bound for the set.  Note: for some derived classes,
   this check is trivial, but for others it can require solving an (typically
   small) optimization problem.  Check the derived class documentation for any
-  notes. */
-  bool IsBounded() const { return DoIsBounded(); }
+  notes. When ambient_dimension is zero, always returns true. */
+  bool IsBounded() const {
+    if (ambient_dimension() == 0) {
+      return true;
+    }
+    return DoIsBounded();
+  }
 
-  /** Returns true iff the point x is contained in the set. */
+  /** Returns true iff the point x is contained in the set.  When
+  ambient_dimension is zero, returns false. */
   bool PointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,
                   double tol = 0) const {
     DRAKE_THROW_UNLESS(x.size() == ambient_dimension());
+    if (ambient_dimension() == 0) {
+      return false;
+    }
     return DoPointInSet(x, tol);
   }
 
   // Note: I would like to return the Binding, but the type is subclass
   // dependent.
   /** Adds a constraint to an existing MathematicalProgram enforcing that the
-  point defined by vars is inside the set. */
+  point defined by vars is inside the set.
+  @throws std::exception if ambient_dimension() == 0 */
   void AddPointInSetConstraints(
       solvers::MathematicalProgram* prog,
-      const Eigen::Ref<const solvers::VectorXDecisionVariable>& vars) const {
-    DRAKE_THROW_UNLESS(vars.size() == ambient_dimension());
-    return DoAddPointInSetConstraints(prog, vars);
-  }
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& vars) const;
 
   /** Let S be this convex set.  When S is bounded, this method adds the convex
   constraints to imply
@@ -114,7 +121,8 @@ class ConvexSet : public ShapeReifier {
   In this case, the constraints imply t ≥ 0, x ∈ t S ⊕ rec(S), where rec(S) is
   the recession cone of S (the asymptotic directions in which S is not bounded)
   and ⊕ is the Minkowski sum.  For t > 0, this is equivalent to x ∈ t S, but for
-  t = 0, we have only x ∈ rec(S). */
+  t = 0, we have only x ∈ rec(S).
+  @throws std::exception if ambient_dimension() == 0 */
   std::vector<solvers::Binding<solvers::Constraint>>
   AddPointInNonnegativeScalingConstraints(
       solvers::MathematicalProgram* prog,
@@ -139,7 +147,8 @@ class ConvexSet : public ShapeReifier {
   where rec(S) is the recession cone of S (the asymptotic directions in which S
   is not bounded) and ⊕ is the Minkowski sum.  For c' * t + d > 0, this is
   equivalent to A * x + b ∈ (c' * t + d) S, but for c' * t + d = 0, we have
-  only A * x + b ∈ rec(S). */
+  only A * x + b ∈ rec(S).
+  @throws std::exception if ambient_dimension() == 0 */
   std::vector<solvers::Binding<solvers::Constraint>>
   AddPointInNonnegativeScalingConstraints(
       solvers::MathematicalProgram* prog,
@@ -177,23 +186,27 @@ class ConvexSet : public ShapeReifier {
   /** Non-virtual interface implementation for Clone(). */
   virtual std::unique_ptr<ConvexSet> DoClone() const = 0;
 
-  /** Non-virtual interface implementation for IsBounded(). */
+  /** Non-virtual interface implementation for IsBounded().
+  @pre ambient_dimension() > 0 */
   virtual bool DoIsBounded() const = 0;
 
   /** Non-virtual interface implementation for PointInSet().
-  @pre x.size() == ambient_dimension() */
+  @pre x.size() == ambient_dimension()
+  @pre ambient_dimension() > 0 */
   virtual bool DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,
                             double tol) const = 0;
 
   /** Non-virtual interface implementation for AddPointInSetConstraints().
-  @pre vars.size() == ambient_dimension() */
+  @pre vars.size() == ambient_dimension()
+  @pre ambient_dimension() > 0 */
   virtual void DoAddPointInSetConstraints(
       solvers::MathematicalProgram* prog,
       const Eigen::Ref<const solvers::VectorXDecisionVariable>& vars) const = 0;
 
   /** Non-virtual interface implementation for
   AddPointInNonnegativeScalingConstraints().
-  @pre x.size() == ambient_dimension() */
+  @pre x.size() == ambient_dimension()
+  @pre ambient_dimension() > 0 */
   virtual std::vector<solvers::Binding<solvers::Constraint>>
   DoAddPointInNonnegativeScalingConstraints(
       solvers::MathematicalProgram* prog,
@@ -205,6 +218,7 @@ class ConvexSet : public ShapeReifier {
   constraints needed to keep the point A * x + b in the non-negative scaling of
   the set. Note that subclasses do not need to add the constraint c * t + d ≥ 0
   as it is already added.
+  @pre ambient_dimension() > 0
   @pre A.rows() == ambient_dimension()
   @pre A.rows() == b.rows()
   @pre A.cols() == x.size()

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -175,6 +175,7 @@ class GraphOfConvexSets {
     /** Adds a constraint to this vertex, described by a symbolic::Formula @p f
     containing *only* elements of x() as variables.
     @throws std::exception if f.GetFreeVariables() is not a subset of x().
+    @throws std::exception if ambient_dimension() == 0.
     @pydrake_mkdoc_identifier{formula}
     */
     solvers::Binding<solvers::Constraint> AddConstraint(
@@ -183,6 +184,7 @@ class GraphOfConvexSets {
     /** Adds a constraint to this vertex.  @p binding must contain *only*
     elements of x() as variables.
     @throws std::exception if binding.variables() is not a subset of x().
+    @throws std::exception if ambient_dimension() == 0.
     @pydrake_mkdoc_identifier{binding}
     */
     solvers::Binding<solvers::Constraint> AddConstraint(
@@ -212,8 +214,6 @@ class GraphOfConvexSets {
     */
     Eigen::VectorXd GetSolution(
         const solvers::MathematicalProgramResult& result) const;
-
-    // TODO(russt): Support AddCost/AddConstraint directly on the vertices.
 
    private:
     // Constructs a new vertex.
@@ -311,6 +311,8 @@ class GraphOfConvexSets {
     containing *only* elements of xu() and xv() as variables.
     @throws std::exception if f.GetFreeVariables() is not a subset of xu() ∪
     xv().
+    @throws std::exception if xu() ∪ xv() is empty, i.e., when both vertices
+    have an ambient dimension of zero.
     @pydrake_mkdoc_identifier{formula}
     */
     solvers::Binding<solvers::Constraint> AddConstraint(
@@ -320,6 +322,8 @@ class GraphOfConvexSets {
     elements of xu() and xv() as variables.
     @throws std::exception if binding.variables() is not a subset of xu() ∪
     xv().
+    @throws std::exception if xu() ∪ xv() is empty, i.e., when both vertices
+    have an ambient dimension of zero.
     @pydrake_mkdoc_identifier{binding}
     */
     solvers::Binding<solvers::Constraint> AddConstraint(

--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -115,7 +115,7 @@ HPolyhedron::HPolyhedron() : ConvexSet(0) {}
 
 HPolyhedron::HPolyhedron(const Eigen::Ref<const MatrixXd>& A,
                          const Eigen::Ref<const VectorXd>& b)
-    : ConvexSet(A.cols()), A_{A}, b_{b} {
+    : ConvexSet(A.cols()), A_(A), b_(b) {
   CheckInvariants();
 }
 

--- a/geometry/optimization/hyperellipsoid.cc
+++ b/geometry/optimization/hyperellipsoid.cc
@@ -30,9 +30,12 @@ using solvers::VectorXDecisionVariable;
 using std::sqrt;
 using symbolic::Variable;
 
+Hyperellipsoid::Hyperellipsoid()
+    : Hyperellipsoid(MatrixXd(0, 0), VectorXd(0)) {}
+
 Hyperellipsoid::Hyperellipsoid(const Eigen::Ref<const MatrixXd>& A,
                                const Eigen::Ref<const VectorXd>& center)
-    : ConvexSet(center.size()), A_{A}, center_{center} {
+    : ConvexSet(center.size()), A_(A), center_(center) {
   DRAKE_THROW_UNLESS(A.cols() == center.size());
   DRAKE_THROW_UNLESS(A.allFinite());  // to ensure the set is non-empty.
 }
@@ -81,6 +84,9 @@ double volume_of_unit_sphere(int dim) {
 }  // namespace
 
 double Hyperellipsoid::Volume() const {
+  if (ambient_dimension() == 0) {
+    return 0.0;
+  }
   if (A_.rows() < A_.cols()) {
     return std::numeric_limits<double>::infinity();
   }
@@ -90,6 +96,7 @@ double Hyperellipsoid::Volume() const {
 
 std::pair<double, VectorXd> Hyperellipsoid::MinimumUniformScalingToTouch(
     const ConvexSet& other) const {
+  DRAKE_THROW_UNLESS(ambient_dimension() > 0);
   DRAKE_THROW_UNLESS(other.ambient_dimension() == ambient_dimension());
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables(ambient_dimension());

--- a/geometry/optimization/hyperellipsoid.h
+++ b/geometry/optimization/hyperellipsoid.h
@@ -28,6 +28,9 @@ class Hyperellipsoid final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Hyperellipsoid)
 
+  /** Constructs a default (zero-dimensional) set. */
+  Hyperellipsoid();
+
   /** Constructs the ellipsoid.
   @pre A.cols() == center.size(). */
   Hyperellipsoid(const Eigen::Ref<const Eigen::MatrixXd>& A,
@@ -58,7 +61,8 @@ class Hyperellipsoid final : public ConvexSet {
   that if center ∈ other, then we expect scaling = 0 and x = center (up to
   precision).
   @pre `other` must have the same ambient_dimension as this.
-  @returns the minimal scaling and the witness point, x, on other. */
+  @returns the minimal scaling and the witness point, x, on other.
+  @throws std::exception if ambient_dimension() == 0 */
   std::pair<double, Eigen::VectorXd> MinimumUniformScalingToTouch(
       const ConvexSet& other) const;
 

--- a/geometry/optimization/intersection.cc
+++ b/geometry/optimization/intersection.cc
@@ -16,13 +16,26 @@ using solvers::MathematicalProgram;
 using solvers::VectorXDecisionVariable;
 using symbolic::Variable;
 
-Intersection::Intersection(const ConvexSets& sets)
-    : ConvexSet(sets[0]->ambient_dimension()), sets_{sets} {
-  for (int i = 1; i < ssize(sets_); ++i) {
-    DRAKE_THROW_UNLESS(sets_[i]->ambient_dimension() ==
-                       sets_[0]->ambient_dimension());
+namespace {
+
+int GetAmbientDimension(const ConvexSets& sets) {
+  if (sets.empty()) {
+    return 0;
   }
+  const int ambient_dimension = sets[0]->ambient_dimension();
+  for (const copyable_unique_ptr<ConvexSet>& set : sets) {
+    DRAKE_THROW_UNLESS(set != nullptr);
+    DRAKE_THROW_UNLESS(set->ambient_dimension() == ambient_dimension);
+  }
+  return ambient_dimension;
 }
+
+}  // namespace
+
+Intersection::Intersection() : Intersection(ConvexSets{}) {}
+
+Intersection::Intersection(const ConvexSets& sets)
+    : ConvexSet(GetAmbientDimension(sets)), sets_(sets) {}
 
 Intersection::Intersection(const ConvexSet& setA, const ConvexSet& setB)
     : ConvexSet(setA.ambient_dimension()) {

--- a/geometry/optimization/intersection.h
+++ b/geometry/optimization/intersection.h
@@ -19,6 +19,9 @@ class Intersection final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Intersection)
 
+  /** Constructs a default (zero-dimensional) set. */
+  Intersection();
+
   /** Constructs the intersection from a vector of convex sets. */
   explicit Intersection(const ConvexSets& sets);
 

--- a/geometry/optimization/minkowski_sum.cc
+++ b/geometry/optimization/minkowski_sum.cc
@@ -26,14 +26,26 @@ using solvers::Solve;
 using solvers::VectorXDecisionVariable;
 using symbolic::Variable;
 
-MinkowskiSum::MinkowskiSum(const ConvexSets& sets)
-    : ConvexSet(sets.size() > 0 ? sets[0]->ambient_dimension() : 0),
-      sets_(sets) {
-  for (int i = 1; i < ssize(sets_); ++i) {
-    DRAKE_THROW_UNLESS(sets_[i]->ambient_dimension() ==
-                       sets_[0]->ambient_dimension());
+namespace {
+
+int GetAmbientDimension(const ConvexSets& sets) {
+  if (sets.empty()) {
+    return 0;
   }
+  const int ambient_dimension = sets[0]->ambient_dimension();
+  for (const copyable_unique_ptr<ConvexSet>& set : sets) {
+    DRAKE_THROW_UNLESS(set != nullptr);
+    DRAKE_THROW_UNLESS(set->ambient_dimension() == ambient_dimension);
+  }
+  return ambient_dimension;
 }
+
+}  // namespace
+
+MinkowskiSum::MinkowskiSum() : MinkowskiSum(ConvexSets{}) {}
+
+MinkowskiSum::MinkowskiSum(const ConvexSets& sets)
+    : ConvexSet(GetAmbientDimension(sets)), sets_(sets) {}
 
 MinkowskiSum::MinkowskiSum(const ConvexSet& setA, const ConvexSet& setB)
     : ConvexSet(setA.ambient_dimension()) {

--- a/geometry/optimization/minkowski_sum.h
+++ b/geometry/optimization/minkowski_sum.h
@@ -21,6 +21,9 @@ class MinkowskiSum final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MinkowskiSum)
 
+  /** Constructs a default (zero-dimensional) set. */
+  MinkowskiSum();
+
   /** Constructs the sum from a vector of convex sets. */
   explicit MinkowskiSum(const ConvexSets& sets);
 

--- a/geometry/optimization/point.cc
+++ b/geometry/optimization/point.cc
@@ -20,8 +20,10 @@ using solvers::VectorXDecisionVariable;
 using std::sqrt;
 using symbolic::Variable;
 
+Point::Point() : Point(VectorXd(0)) {}
+
 Point::Point(const Eigen::Ref<const VectorXd>& x)
-    : ConvexSet(x.size()), x_{x} {}
+    : ConvexSet(x.size()), x_(x) {}
 
 Point::Point(const QueryObject<double>& query_object, GeometryId geometry_id,
              std::optional<FrameId> reference_frame,

--- a/geometry/optimization/point.h
+++ b/geometry/optimization/point.h
@@ -19,6 +19,9 @@ class Point final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Point)
 
+  /** Constructs a default (zero-dimensional) set. */
+  Point();
+
   /** Constructs a Point. */
   explicit Point(const Eigen::Ref<const Eigen::VectorXd>& x);
 

--- a/geometry/optimization/test/cartesian_product_test.cc
+++ b/geometry/optimization/test/cartesian_product_test.cc
@@ -56,6 +56,16 @@ GTEST_TEST(CartesianProductTest, BasicTest) {
   EXPECT_FALSE(S2.PointInSet(out));
 }
 
+GTEST_TEST(CartesianProductTest, DefaultCtor) {
+  const CartesianProduct dut;
+  EXPECT_EQ(dut.num_factors(), 0);
+  EXPECT_NO_THROW(dut.Clone());
+  EXPECT_EQ(dut.ambient_dimension(), 0);
+  EXPECT_FALSE(dut.IntersectsWith(dut));
+  EXPECT_TRUE(dut.IsBounded());
+  EXPECT_FALSE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
+}
+
 GTEST_TEST(CartesianProductTest, FromSceneGraph) {
   const RigidTransformd X_WG{math::RollPitchYawd(.1, .2, 3),
                              Vector3d{.5, .87, .1}};

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -224,7 +224,7 @@ TEST_F(TwoPoints, Basic) {
   EXPECT_EQ(g_.Edges().at(0), e_);
 }
 
-// Confirms that I can add costs (both ways) and get the solution.
+// Confirms that we can add costs (both ways) and get the solution.
 // The correctness of the added costs will be established by the solution tests.
 TEST_F(TwoPoints, AddCost) {
   auto [ell0, b0] = e_->AddCost((e_->xv().head<2>() - e_->xu()).squaredNorm());
@@ -269,7 +269,7 @@ TEST_F(TwoPoints, AddCost) {
   DRAKE_EXPECT_THROWS_MESSAGE(v_->AddCost(other_var), ".*IsSubsetOf.*");
 }
 
-// Confirms that I can add constraints (both ways).
+// Confirms that we can add constraints (both ways).
 // The correctness of the added constraints will be established by the solution
 // tests.
 TEST_F(TwoPoints, AddConstraint) {
@@ -307,9 +307,19 @@ TEST_F(TwoPoints, AddConstraint) {
                               ".*IsSubsetOf.*");
 }
 
-/*
-Let's me test with one edge defintely on the optimal path, and one definitely
-off it.
+GTEST_TEST(GraphOfConvexSetsTest, TwoNullPointsConstraint) {
+  GraphOfConvexSets g;
+  Point pu(Eigen::VectorXd::Zero(0));
+  Point pv(Eigen::VectorXd::Zero(0));
+  Vertex* u = g.AddVertex(pu, "u");
+  Vertex* v = g.AddVertex(pv, "v");
+  Edge* e = g.AddEdge(u->id(), v->id(), "e");
+  DRAKE_EXPECT_THROWS_MESSAGE(e->AddConstraint(symbolic::Formula::True()),
+                              ".*total.*ambient.*dimension.*");
+}
+
+/* A graph with one edge definitely on the optimal path, and one definitely off
+it.
 ┌──────┐         ┌──────┐
 │source├──e_on──►│target│
 └───┬──┘         └──────┘
@@ -1097,7 +1107,7 @@ GTEST_TEST(ShortestPathTest, TwoStepLoopConstraint) {
   EXPECT_EQ(non_zero_edges, 6);
 }
 
-// Test that all optimization variables are properly set, even when constrained
+// Tests that all optimization variables are properly set, even when constrained
 // to be on or off.
 GTEST_TEST(ShortestPathTest, PhiConstraint) {
   GraphOfConvexSets spp;

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -44,6 +44,10 @@ GTEST_TEST(HPolyhedronTest, DefaultConstructor) {
   EXPECT_EQ(H.ambient_dimension(), 0);
   EXPECT_EQ(H.A().size(), 0);
   EXPECT_EQ(H.b().size(), 0);
+  EXPECT_NO_THROW(H.Clone());
+  EXPECT_FALSE(H.IntersectsWith(H));
+  EXPECT_TRUE(H.IsBounded());
+  EXPECT_FALSE(H.PointInSet(Eigen::VectorXd::Zero(0)));
 }
 
 GTEST_TEST(HPolyhedronTest, UnitBoxTest) {

--- a/geometry/optimization/test/hyperellipsoid_test.cc
+++ b/geometry/optimization/test/hyperellipsoid_test.cc
@@ -84,6 +84,20 @@ GTEST_TEST(HyperellipsoidTest, UnitSphereTest) {
   // sphere is rotationally symmetric.
 }
 
+GTEST_TEST(HyperellipsoidTest, DefaultCtor) {
+  const Hyperellipsoid dut;
+  EXPECT_EQ(dut.A().rows(), 0);
+  EXPECT_EQ(dut.A().cols(), 0);
+  EXPECT_EQ(dut.center().size(), 0);
+  EXPECT_EQ(dut.Volume(), 0.0);
+  EXPECT_THROW(dut.MinimumUniformScalingToTouch(dut), std::exception);
+  EXPECT_NO_THROW(dut.Clone());
+  EXPECT_EQ(dut.ambient_dimension(), 0);
+  EXPECT_FALSE(dut.IntersectsWith(dut));
+  EXPECT_TRUE(dut.IsBounded());
+  EXPECT_FALSE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
+}
+
 GTEST_TEST(HyperellipsoidTest, ScaledSphereTest) {
   const double radius = 0.1;
   auto [scene_graph, geom_id] =

--- a/geometry/optimization/test/intersection_test.cc
+++ b/geometry/optimization/test/intersection_test.cc
@@ -58,6 +58,16 @@ GTEST_TEST(IntersectionTest, BasicTest) {
   EXPECT_FALSE(S2.PointInSet(out));
 }
 
+GTEST_TEST(IntersectionTest, DefaultCtor) {
+  const Intersection dut;
+  EXPECT_EQ(dut.num_elements(), 0);
+  EXPECT_NO_THROW(dut.Clone());
+  EXPECT_EQ(dut.ambient_dimension(), 0);
+  EXPECT_FALSE(dut.IntersectsWith(dut));
+  EXPECT_TRUE(dut.IsBounded());
+  EXPECT_FALSE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
+}
+
 GTEST_TEST(IntersectionTest, TwoBoxes) {
   HPolyhedron H1 = HPolyhedron::MakeBox(Vector2d{0, 0}, Vector2d{2, 2});
   HPolyhedron H2 = HPolyhedron::MakeBox(Vector2d{1, -1}, Vector2d{3, 1});

--- a/geometry/optimization/test/minkowski_sum_test.cc
+++ b/geometry/optimization/test/minkowski_sum_test.cc
@@ -53,6 +53,16 @@ GTEST_TEST(MinkowskiSumTest, BasicTest) {
   EXPECT_FALSE(S2.PointInSet(out));
 }
 
+GTEST_TEST(MinkowskiSumTest, DefaultCtor) {
+  const MinkowskiSum dut;
+  EXPECT_EQ(dut.num_terms(), 0);
+  EXPECT_NO_THROW(dut.Clone());
+  EXPECT_EQ(dut.ambient_dimension(), 0);
+  EXPECT_FALSE(dut.IntersectsWith(dut));
+  EXPECT_TRUE(dut.IsBounded());
+  EXPECT_FALSE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
+}
+
 GTEST_TEST(MinkowskiSumTest, FromSceneGraph) {
   const RigidTransformd X_WG{math::RollPitchYawd(.1, .2, 3),
                              Vector3d{.5, .87, .1}};

--- a/geometry/optimization/test/point_test.cc
+++ b/geometry/optimization/test/point_test.cc
@@ -58,6 +58,19 @@ GTEST_TEST(PointTest, BasicTest) {
   EXPECT_TRUE(CompareMatrices(p2_W, P.x()));
 }
 
+GTEST_TEST(PointTest, DefaultCtor) {
+  const Point dut;
+  EXPECT_EQ(dut.x().size(), 0);
+  EXPECT_NO_THROW(dut.Clone());
+  EXPECT_EQ(dut.ambient_dimension(), 0);
+  EXPECT_FALSE(dut.IntersectsWith(dut));
+  EXPECT_TRUE(dut.IsBounded());
+  EXPECT_FALSE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
+
+  Point P;
+  EXPECT_NO_THROW(P.set_x(Eigen::VectorXd::Zero(0)));
+}
+
 GTEST_TEST(PointTest, FromSceneGraphTest) {
   Vector3d p_W{1.2, 4.5, -2.8};
 

--- a/geometry/optimization/test/vpolytope_test.cc
+++ b/geometry/optimization/test/vpolytope_test.cc
@@ -66,6 +66,18 @@ GTEST_TEST(VPolytopeTest, TriangleTest) {
   }
 }
 
+GTEST_TEST(VPolytopeTest, DefaultCtor) {
+  const VPolytope dut;
+  EXPECT_NO_THROW(dut.GetMinimalRepresentation());
+  EXPECT_EQ(dut.vertices().size(), 0);
+  EXPECT_EQ(dut.CalcVolume(), 0.0);
+  EXPECT_NO_THROW(dut.Clone());
+  EXPECT_EQ(dut.ambient_dimension(), 0);
+  EXPECT_FALSE(dut.IntersectsWith(dut));
+  EXPECT_TRUE(dut.IsBounded());
+  EXPECT_FALSE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
+}
+
 GTEST_TEST(VPolytopeTest, UnitBoxTest) {
   VPolytope V = VPolytope::MakeUnitBox(3);
   EXPECT_EQ(V.ambient_dimension(), 3);

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -81,8 +81,10 @@ MatrixXd OrderCounterClockwise(const MatrixXd& vertices) {
 
 }  // namespace
 
+VPolytope::VPolytope() : VPolytope(MatrixXd(0, 0)) {}
+
 VPolytope::VPolytope(const Eigen::Ref<const MatrixXd>& vertices)
-    : ConvexSet(vertices.rows()), vertices_{vertices} {}
+    : ConvexSet(vertices.rows()), vertices_(vertices) {}
 
 VPolytope::VPolytope(const QueryObject<double>& query_object,
                      GeometryId geometry_id,
@@ -188,6 +190,9 @@ VPolytope VPolytope::MakeUnitBox(int dim) {
 }
 
 VPolytope VPolytope::GetMinimalRepresentation() const {
+  if (ambient_dimension() == 0) {
+    return VPolytope();
+  }
   orgQhull::Qhull qhull;
   qhull.runQhull("", vertices_.rows(), vertices_.cols(), vertices_.data(), "");
   if (qhull.qhullStatus() != 0) {
@@ -218,6 +223,9 @@ VPolytope VPolytope::GetMinimalRepresentation() const {
 }
 
 double VPolytope::CalcVolume() const {
+  if (ambient_dimension() == 0) {
+    return 0.0;
+  }
   orgQhull::Qhull qhull;
   try {
     qhull.runQhull("", ambient_dimension(), vertices_.cols(), vertices_.data(),

--- a/geometry/optimization/vpolytope.h
+++ b/geometry/optimization/vpolytope.h
@@ -26,6 +26,9 @@ class VPolytope final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(VPolytope)
 
+  /** Constructs a default (zero-dimensional) set. */
+  VPolytope();
+
   /** Constructs the polytope from a d-by-n matrix, where d is the ambient
   dimension, and n is the number of vertices.  The vertices do not have to be
   ordered, nor minimal (they can contain points inside their convex hull).

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.cc
@@ -362,8 +362,9 @@ EdgesBetweenSubgraphs::~EdgesBetweenSubgraphs() = default;
 
 bool EdgesBetweenSubgraphs::RegionsConnectThroughSubspace(
     const ConvexSet& A, const ConvexSet& B, const ConvexSet& subspace) {
-  DRAKE_THROW_UNLESS(A.ambient_dimension() == B.ambient_dimension() &&
-                     A.ambient_dimension() == subspace.ambient_dimension());
+  DRAKE_THROW_UNLESS(A.ambient_dimension() > 0);
+  DRAKE_THROW_UNLESS(A.ambient_dimension() == B.ambient_dimension());
+  DRAKE_THROW_UNLESS(A.ambient_dimension() == subspace.ambient_dimension());
   // TODO(wrangelvid) Replace dynamic cast with a function that checks if the
   // convex set degenerates to a point.
   if (const Point* pt = dynamic_cast<const Point*>(&subspace)) {


### PR DESCRIPTION
The user can already create such a set by moving-from an existing object. Making it directly constructible instead makes it easier to operate on and unit test these objects.

Add some missing nullptr checks.

---

Towards #19311.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19321)
<!-- Reviewable:end -->
