### PR TITLE
Update optitrack driver version

### DIFF
--- a/tools/workspace/optitrack_driver/repository.bzl
+++ b/tools/workspace/optitrack_driver/repository.bzl
@@ -6,7 +6,7 @@ def optitrack_driver_repository(
     github_archive(
         name = name,
         repository = "RobotLocomotion/optitrack-driver",
-        commit = "795879a7e2eb910d8e7ab88dfad54d6ef67c9599",
-        sha256 = "588b380e1aafe03b1d6ddf7af242b2f5ae503abb60cd86d386caf17f045e649b",  # noqa
+        commit = "f9dab231878f612db5d7df45f1f9faf08d7a4319",
+        sha256 = "6d9355995113a40dc4e8e2dbddc1f5b615e1fde40a513a7cca77aae1f2be9304",  # noqa
         mirrors = mirrors,
     )


### PR DESCRIPTION
This has no direct effect on any drake usage of optitrack_driver, but does add new command line arguments to the installed optitrack_client which are useful when connecting to newer versions of the optitrack software in unicast mode.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19324)
<!-- Reviewable:end -->
