### PR TITLE
[common] Fix benchmark vs kcov.sh's broken args handling

### DIFF
--- a/common/benchmarking/BUILD.bazel
+++ b/common/benchmarking/BUILD.bazel
@@ -13,7 +13,7 @@ drake_cc_googlebench_binary(
     add_test_rule = True,
     test_args = [
         # When testing, skip over Args() that are >= 100.
-        "--benchmark_filter=-/.00+(/.)?$$",
+        "--benchmark_filter=-/.00",
     ],
     test_timeout = "moderate",
     deps = [


### PR DESCRIPTION
Amends #19303.

Closes #19327.

+@rpoyner-tri for both reviews, please.