### PR TITLE
[geometry/optimization] Opt-in to clang-format lint

### DIFF
--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -343,4 +343,4 @@ drake_cc_googletest(
     ],
 )
 
-add_lint_tests()
+add_lint_tests(enable_clang_format_lint = True)

--- a/geometry/optimization/cspace_free_polytope.h
+++ b/geometry/optimization/cspace_free_polytope.h
@@ -319,10 +319,11 @@ class CspaceFreePolytope {
    margin between the i'th face C.row(i)<=d(i) to the inscribed ellipsoid.
    */
   enum EllipsoidMarginCost {
-    kSum,            ///< Maximize ∑ᵢδᵢ
-    kGeometricMean,  ///< Maximize the geometric mean power(∏ᵢ (δᵢ + ε), 1/n)
-                     ///< where n is C.rows(),
-                     ///< ε=FindPolytopeGivenLagrangianOptions.ellipsoid_margin_epsilon. NOLINT
+    /** Maximize ∑ᵢδᵢ */
+    kSum,
+    /** Maximize the geometric mean power(∏ᵢ (δᵢ + ε), 1/n) where n is C.rows(),
+    ε=FindPolytopeGivenLagrangianOptions.ellipsoid_margin_epsilon. */
+    kGeometricMean,
   };
 
   struct FindPolytopeGivenLagrangianOptions {

--- a/geometry/optimization/test/convex_set_solving_test.cc
+++ b/geometry/optimization/test/convex_set_solving_test.cc
@@ -14,8 +14,8 @@ using Eigen::Vector2d;
 // incompatible when MOSEK might be used.
 
 GTEST_TEST(ConvexSetTest, IntersectsWithTest) {
-/* Test that IntersectsWith() yields correct results for the following
-arrangement of boxes:
+  /* Test that IntersectsWith() yields correct results for the following
+  arrangement of boxes:
      5                ┏━━━━━━━━━┓
                       ┃      C  ┃
      4      ┏━━━━━━━━━┃━━━━┓    ┃
@@ -28,7 +28,7 @@ arrangement of boxes:
        ┃  A      ┃
      0 ┗━━━━━━━━━┛
        0    1    2    3    4    5
-*/
+  */
   HPolyhedron set_A = HPolyhedron::MakeBox(Vector2d(0, 0), Vector2d(2, 2));
   HPolyhedron set_B = HPolyhedron::MakeBox(Vector2d(1, 1), Vector2d(4, 4));
   HPolyhedron set_C = HPolyhedron::MakeBox(Vector2d(3, 3), Vector2d(5, 5));

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -155,8 +155,8 @@ VPolytope::VPolytope(const HPolyhedron& hpoly)
       vertex_A.row(jj) = Eigen::Map<Eigen::RowVectorXd, Eigen::Unaligned>(
           hyperplane.data(), hyperplane.size());
     }
-    vertices_.col(ii) = vertex_A.partialPivLu().solve(VectorXd::Ones(
-                            incident_hyperplanes.count())) +
+    vertices_.col(ii) = vertex_A.partialPivLu().solve(
+                            VectorXd::Ones(incident_hyperplanes.count())) +
                         eigen_center;
     ii++;
   }


### PR DESCRIPTION
This asks local tests (and CI tests) to enforce that `clang-format` has been run on all files in this directory.  This should help all contributors overcome most formatting hurdles prior to code review.

Towards #4843.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19331)
<!-- Reviewable:end -->
