### PR TITLE
[planning] Add velocity bounds to subgraphs

### DIFF
--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -386,7 +386,9 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
         .def("AddPathLengthCost",
             py::overload_cast<double>(&Class::Subgraph::AddPathLengthCost),
             py::arg("weight") = 1.0,
-            subgraph_doc.AddPathLengthCost.doc_1args_weight);
+            subgraph_doc.AddPathLengthCost.doc_1args_weight)
+        .def("AddVelocityBounds", &Class::Subgraph::AddVelocityBounds,
+            py::arg("lb"), py::arg("ub"), subgraph_doc.AddVelocityBounds.doc);
 
     // EdgesBetweenSubgraphs
     const auto& subgraph_edges_doc =
@@ -428,6 +430,8 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
         .def("AddPathLengthCost",
             py::overload_cast<double>(&Class::AddPathLengthCost),
             py::arg("weight") = 1.0, cls_doc.AddPathLengthCost.doc_1args_weight)
+        .def("AddVelocityBounds", &Class::AddVelocityBounds, py::arg("lb"),
+            py::arg("ub"), cls_doc.AddVelocityBounds.doc)
         .def("SolvePath", &Class::SolvePath, py::arg("source"),
             py::arg("target"),
             py::arg("options") =

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -320,6 +320,8 @@ class TestTrajectoryOptimization(unittest.TestCase):
             np.array([[5.0, 5.0, 4.4, 4.4], [2.8, 5.0, 5.0, 2.8]])
         ]
 
+        max_vel = np.ones((2, 1))
+
         # We add a path length cost to the entire graph.
         # This can be called ahead of time or after adding the regions.
         gcs.AddPathLengthCost(weight=1.0)
@@ -333,6 +335,9 @@ class TestTrajectoryOptimization(unittest.TestCase):
         # Add the cost again, which is unnecessary for the optimization
         # but useful to check the binding with the default values.
         gcs.AddTimeCost()
+
+        # Add velocity bounds to the entire graph.
+        gcs.AddVelocityBounds(lb=-max_vel, ub=max_vel)
 
         # Add two subgraphs with different orders.
         main1 = gcs.AddRegions(
@@ -429,6 +434,9 @@ class TestTrajectoryOptimization(unittest.TestCase):
         # Add the cost again, which is unnecessary for the optimization
         # but useful to check the binding with the default values.
         main2.AddTimeCost()
+
+        # Add tighter velocity bounds to the main2 subgraph.
+        main2.AddVelocityBounds(lb=-0.5*max_vel, ub=0.5*max_vel)
 
         options = GraphOfConvexSetsOptions()
         options.convex_relaxation = True

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -111,6 +111,18 @@ class GcsTrajectoryOptimization final {
     */
     void AddPathLengthCost(double weight = 1.0);
 
+    /** Adds a linear velocity constraint to the subgraph `lb` ≤ q̇(t) ≤
+    `ub`.
+    @param lb is the lower bound of the velocity.
+    @param ub is the upper bound of the velocity.
+
+    @throws std::exception if subgraph order is zero, since the velocity is
+    defined as the derivative of the Bézier curve.
+    @throws std::exception if lb or ub are not of size num_positions().
+    */
+    void AddVelocityBounds(const Eigen::Ref<const Eigen::VectorXd>& lb,
+                           const Eigen::Ref<const Eigen::VectorXd>& ub);
+
    private:
     /* Constructs a new subgraph and copies the regions. */
     Subgraph(const geometry::optimization::ConvexSets& regions,
@@ -314,6 +326,21 @@ class GcsTrajectoryOptimization final {
   */
   void AddPathLengthCost(double weight = 1.0);
 
+  /** Adds a linear velocity constraint to the entire graph `lb` ≤ q̇(t) ≤
+  `ub`.
+  @param lb is the lower bound of the velocity.
+  @param ub is the upper bound of the velocity.
+
+  This constraint will be added to the entire graph. Since the velocity requires
+  forming the derivative of the Bézier curve, this constraint will only added to
+  all subgraphs with order greater than zero. Note that this constraint will be
+  applied even to subgraphs added in the future.
+
+  @throws std::exception if lb or ub are not of size num_positions().
+  */
+  void AddVelocityBounds(const Eigen::Ref<const Eigen::VectorXd>& lb,
+                         const Eigen::Ref<const Eigen::VectorXd>& ub);
+
   /** Formulates and solves the mixed-integer convex formulation of the
   shortest path problem on the whole graph. @see
   `geometry::optimization::GraphOfConvexSets::SolveShortestPath()` for further
@@ -355,6 +382,8 @@ class GcsTrajectoryOptimization final {
   std::vector<std::unique_ptr<EdgesBetweenSubgraphs>> subgraph_edges_;
   std::vector<double> global_time_costs_;
   std::vector<Eigen::MatrixXd> global_path_length_costs_;
+  std::vector<std::pair<Eigen::VectorXd, Eigen::VectorXd>>
+      global_velocity_bounds_{};
 };
 
 }  // namespace trajectory_optimization


### PR DESCRIPTION
This adds velocity bounds to the subgraphs, which enables useful minimum time planning.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19334)
<!-- Reviewable:end -->
