### PR TITLE
Move ConvexSet cloning to vtable instead of std::function

### DIFF
--- a/geometry/optimization/cartesian_product.h
+++ b/geometry/optimization/cartesian_product.h
@@ -69,6 +69,8 @@ class CartesianProduct final : public ConvexSet {
   using ConvexSet::PointInSet;
 
  private:
+  std::unique_ptr<ConvexSet> DoClone() const final;
+
   bool DoIsBounded() const final;
 
   bool DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,

--- a/geometry/optimization/convex_set.cc
+++ b/geometry/optimization/convex_set.cc
@@ -11,18 +11,12 @@ namespace drake {
 namespace geometry {
 namespace optimization {
 
-ConvexSet::ConvexSet(
-    std::function<std::unique_ptr<ConvexSet>(const ConvexSet&)> cloner,
-    int ambient_dimension)
-    : cloner_(std::move(cloner)), ambient_dimension_(ambient_dimension) {
+ConvexSet::ConvexSet(int ambient_dimension)
+    : ambient_dimension_(ambient_dimension) {
   DRAKE_THROW_UNLESS(ambient_dimension >= 0);
 }
 
 ConvexSet::~ConvexSet() = default;
-
-std::unique_ptr<ConvexSet> ConvexSet::Clone() const {
-  return cloner_(*this);
-}
 
 bool ConvexSet::IntersectsWith(const ConvexSet& other) const {
   DRAKE_THROW_UNLESS(other.ambient_dimension() == this->ambient_dimension());

--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -111,18 +111,18 @@ bool IsRedundant(const Eigen::Ref<const MatrixXd>& c, double d,
 
 }  // namespace
 
-HPolyhedron::HPolyhedron() : ConvexSet(&ConvexSetCloner<HPolyhedron>, 0) {}
+HPolyhedron::HPolyhedron() : ConvexSet(0) {}
 
 HPolyhedron::HPolyhedron(const Eigen::Ref<const MatrixXd>& A,
                          const Eigen::Ref<const VectorXd>& b)
-    : ConvexSet(&ConvexSetCloner<HPolyhedron>, A.cols()), A_{A}, b_{b} {
+    : ConvexSet(A.cols()), A_{A}, b_{b} {
   CheckInvariants();
 }
 
 HPolyhedron::HPolyhedron(const QueryObject<double>& query_object,
                          GeometryId geometry_id,
                          std::optional<FrameId> reference_frame)
-    : ConvexSet(&ConvexSetCloner<HPolyhedron>, 3) {
+    : ConvexSet(3) {
   std::pair<MatrixXd, VectorXd> Ab_G;
   query_object.inspector().GetShape(geometry_id).Reify(this, &Ab_G);
 
@@ -137,7 +137,7 @@ HPolyhedron::HPolyhedron(const QueryObject<double>& query_object,
 }
 
 HPolyhedron::HPolyhedron(const VPolytope& vpoly)
-    : ConvexSet(&ConvexSetCloner<HPolyhedron>, vpoly.ambient_dimension()) {
+    : ConvexSet(vpoly.ambient_dimension()) {
   orgQhull::Qhull qhull;
   qhull.runQhull("", vpoly.ambient_dimension(), vpoly.vertices().cols(),
                  vpoly.vertices().data(), "");
@@ -524,6 +524,10 @@ std::set<int> HPolyhedron::FindRedundant(double tol) const {
 
 bool HPolyhedron::IsEmpty() const {
   return DoIsEmpty(A_, b_);
+}
+
+std::unique_ptr<ConvexSet> HPolyhedron::DoClone() const {
+  return std::make_unique<HPolyhedron>(*this);
 }
 
 bool HPolyhedron::DoPointInSet(const Eigen::Ref<const VectorXd>& x,

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -208,6 +208,8 @@ class HPolyhedron final : public ConvexSet {
   [[nodiscard]] HPolyhedron DoIntersectionWithChecks(const HPolyhedron& other,
                                                      double tol) const;
 
+  std::unique_ptr<ConvexSet> DoClone() const final;
+
   bool DoIsBounded() const final;
 
   bool DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,

--- a/geometry/optimization/hyperellipsoid.cc
+++ b/geometry/optimization/hyperellipsoid.cc
@@ -32,9 +32,7 @@ using symbolic::Variable;
 
 Hyperellipsoid::Hyperellipsoid(const Eigen::Ref<const MatrixXd>& A,
                                const Eigen::Ref<const VectorXd>& center)
-    : ConvexSet(&ConvexSetCloner<Hyperellipsoid>, center.size()),
-      A_{A},
-      center_{center} {
+    : ConvexSet(center.size()), A_{A}, center_{center} {
   DRAKE_THROW_UNLESS(A.cols() == center.size());
   DRAKE_THROW_UNLESS(A.allFinite());  // to ensure the set is non-empty.
 }
@@ -42,7 +40,7 @@ Hyperellipsoid::Hyperellipsoid(const Eigen::Ref<const MatrixXd>& A,
 Hyperellipsoid::Hyperellipsoid(const QueryObject<double>& query_object,
                                GeometryId geometry_id,
                                std::optional<FrameId> reference_frame)
-    : ConvexSet(&ConvexSetCloner<Hyperellipsoid>, 3) {
+    : ConvexSet(3) {
   Eigen::Matrix3d A_G;
   query_object.inspector().GetShape(geometry_id).Reify(this, &A_G);
   // p_GG_varᵀ * A_Gᵀ * A_G * p_GG_var ≤ 1
@@ -162,6 +160,10 @@ Hyperellipsoid Hyperellipsoid::MakeHypersphere(
 Hyperellipsoid Hyperellipsoid::MakeUnitBall(int dim) {
   DRAKE_THROW_UNLESS(dim > 0);
   return Hyperellipsoid(MatrixXd::Identity(dim, dim), VectorXd::Zero(dim));
+}
+
+std::unique_ptr<ConvexSet> Hyperellipsoid::DoClone() const {
+  return std::make_unique<Hyperellipsoid>(*this);
 }
 
 bool Hyperellipsoid::DoIsBounded() const {

--- a/geometry/optimization/hyperellipsoid.h
+++ b/geometry/optimization/hyperellipsoid.h
@@ -90,6 +90,8 @@ class Hyperellipsoid final : public ConvexSet {
   static Hyperellipsoid MakeUnitBall(int dim);
 
  private:
+  std::unique_ptr<ConvexSet> DoClone() const final;
+
   bool DoIsBounded() const final;
 
   bool DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,

--- a/geometry/optimization/intersection.cc
+++ b/geometry/optimization/intersection.cc
@@ -17,8 +17,7 @@ using solvers::VectorXDecisionVariable;
 using symbolic::Variable;
 
 Intersection::Intersection(const ConvexSets& sets)
-    : ConvexSet(&ConvexSetCloner<Intersection>, sets[0]->ambient_dimension()),
-      sets_{sets} {
+    : ConvexSet(sets[0]->ambient_dimension()), sets_{sets} {
   for (int i = 1; i < ssize(sets_); ++i) {
     DRAKE_THROW_UNLESS(sets_[i]->ambient_dimension() ==
                        sets_[0]->ambient_dimension());
@@ -26,7 +25,7 @@ Intersection::Intersection(const ConvexSets& sets)
 }
 
 Intersection::Intersection(const ConvexSet& setA, const ConvexSet& setB)
-    : ConvexSet(&ConvexSetCloner<Intersection>, setA.ambient_dimension()) {
+    : ConvexSet(setA.ambient_dimension()) {
   DRAKE_THROW_UNLESS(setB.ambient_dimension() == setA.ambient_dimension());
   sets_.emplace_back(setA.Clone());
   sets_.emplace_back(setB.Clone());
@@ -37,6 +36,10 @@ Intersection::~Intersection() = default;
 const ConvexSet& Intersection::element(int index) const {
   DRAKE_THROW_UNLESS(0 <= index && index < ssize(sets_));
   return *sets_[index];
+}
+
+std::unique_ptr<ConvexSet> Intersection::DoClone() const {
+  return std::make_unique<Intersection>(*this);
 }
 
 bool Intersection::DoIsBounded() const {

--- a/geometry/optimization/intersection.h
+++ b/geometry/optimization/intersection.h
@@ -35,6 +35,8 @@ class Intersection final : public ConvexSet {
   const ConvexSet& element(int i) const;
 
  private:
+  std::unique_ptr<ConvexSet> DoClone() const final;
+
   bool DoIsBounded() const final;
 
   bool DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,

--- a/geometry/optimization/minkowski_sum.cc
+++ b/geometry/optimization/minkowski_sum.cc
@@ -27,8 +27,7 @@ using solvers::VectorXDecisionVariable;
 using symbolic::Variable;
 
 MinkowskiSum::MinkowskiSum(const ConvexSets& sets)
-    : ConvexSet(&ConvexSetCloner<MinkowskiSum>,
-                sets.size() > 0 ? sets[0]->ambient_dimension() : 0),
+    : ConvexSet(sets.size() > 0 ? sets[0]->ambient_dimension() : 0),
       sets_(sets) {
   for (int i = 1; i < ssize(sets_); ++i) {
     DRAKE_THROW_UNLESS(sets_[i]->ambient_dimension() ==
@@ -37,7 +36,7 @@ MinkowskiSum::MinkowskiSum(const ConvexSets& sets)
 }
 
 MinkowskiSum::MinkowskiSum(const ConvexSet& setA, const ConvexSet& setB)
-    : ConvexSet(&ConvexSetCloner<MinkowskiSum>, setA.ambient_dimension()) {
+    : ConvexSet(setA.ambient_dimension()) {
   DRAKE_THROW_UNLESS(setB.ambient_dimension() == setA.ambient_dimension());
   sets_.emplace_back(setA.Clone());
   sets_.emplace_back(setB.Clone());
@@ -46,7 +45,7 @@ MinkowskiSum::MinkowskiSum(const ConvexSet& setA, const ConvexSet& setB)
 MinkowskiSum::MinkowskiSum(const QueryObject<double>& query_object,
                            GeometryId geometry_id,
                            std::optional<FrameId> reference_frame)
-    : ConvexSet(&ConvexSetCloner<MinkowskiSum>, 3) {
+    : ConvexSet(3) {
   Capsule capsule(1., 1.);
   query_object.inspector().GetShape(geometry_id).Reify(this, &capsule);
 
@@ -77,6 +76,10 @@ MinkowskiSum::~MinkowskiSum() = default;
 const ConvexSet& MinkowskiSum::term(int index) const {
   DRAKE_THROW_UNLESS(0 <= index && index < ssize(sets_));
   return *sets_[index];
+}
+
+std::unique_ptr<ConvexSet> MinkowskiSum::DoClone() const {
+  return std::make_unique<MinkowskiSum>(*this);
 }
 
 bool MinkowskiSum::DoIsBounded() const {

--- a/geometry/optimization/minkowski_sum.h
+++ b/geometry/optimization/minkowski_sum.h
@@ -57,6 +57,8 @@ class MinkowskiSum final : public ConvexSet {
   using ConvexSet::PointInSet;
 
  private:
+  std::unique_ptr<ConvexSet> DoClone() const final;
+
   bool DoIsBounded() const final;
 
   bool DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,

--- a/geometry/optimization/point.cc
+++ b/geometry/optimization/point.cc
@@ -21,12 +21,12 @@ using std::sqrt;
 using symbolic::Variable;
 
 Point::Point(const Eigen::Ref<const VectorXd>& x)
-    : ConvexSet(&ConvexSetCloner<Point>, x.size()), x_{x} {}
+    : ConvexSet(x.size()), x_{x} {}
 
 Point::Point(const QueryObject<double>& query_object, GeometryId geometry_id,
              std::optional<FrameId> reference_frame,
              double maximum_allowable_radius)
-    : ConvexSet(&ConvexSetCloner<Point>, 3) {
+    : ConvexSet(3) {
   double radius = -1.0;
   query_object.inspector().GetShape(geometry_id).Reify(this, &radius);
   if (radius > maximum_allowable_radius) {
@@ -49,6 +49,10 @@ Point::~Point() = default;
 void Point::set_x(const Eigen::Ref<const VectorXd>& x) {
   DRAKE_THROW_UNLESS(x.size() == x_.size());
   x_ = x;
+}
+
+std::unique_ptr<ConvexSet> Point::DoClone() const {
+  return std::make_unique<Point>(*this);
 }
 
 bool Point::DoPointInSet(const Eigen::Ref<const VectorXd>& x,

--- a/geometry/optimization/point.h
+++ b/geometry/optimization/point.h
@@ -44,6 +44,8 @@ class Point final : public ConvexSet {
   void set_x(const Eigen::Ref<const Eigen::VectorXd>& x);
 
  private:
+  std::unique_ptr<ConvexSet> DoClone() const final;
+
   bool DoIsBounded() const final { return true; }
 
   bool DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,

--- a/geometry/optimization/spectrahedron.cc
+++ b/geometry/optimization/spectrahedron.cc
@@ -36,11 +36,10 @@ VectorXDecisionVariable GetVariablesByIndex(
 
 }  // namespace
 
-Spectrahedron::Spectrahedron()
-    : ConvexSet(&ConvexSetCloner<Spectrahedron>, 0) {}
+Spectrahedron::Spectrahedron() : ConvexSet(0) {}
 
 Spectrahedron::Spectrahedron(const MathematicalProgram& prog)
-    : ConvexSet(&ConvexSetCloner<Spectrahedron>, prog.num_vars()) {
+    : ConvexSet(prog.num_vars()) {
   for (const ProgramAttribute& attr : prog.required_capabilities()) {
     if (supported_attributes().count(attr) < 1) {
       throw std::runtime_error(fmt::format(
@@ -66,6 +65,10 @@ const ProgramAttributes& Spectrahedron::supported_attributes() {
                         ProgramAttribute::kLinearEqualityConstraint,
                         ProgramAttribute::kPositiveSemidefiniteConstraint}};
   return kSupportedAttributes.access();
+}
+
+std::unique_ptr<ConvexSet> Spectrahedron::DoClone() const {
+  return std::make_unique<Spectrahedron>(*this);
 }
 
 bool Spectrahedron::DoIsBounded() const {

--- a/geometry/optimization/spectrahedron.h
+++ b/geometry/optimization/spectrahedron.h
@@ -39,6 +39,8 @@ class Spectrahedron final : public ConvexSet {
   // matrices.
 
  private:
+  std::unique_ptr<ConvexSet> DoClone() const final;
+
   bool DoIsBounded() const final;
 
   bool DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -82,13 +82,12 @@ MatrixXd OrderCounterClockwise(const MatrixXd& vertices) {
 }  // namespace
 
 VPolytope::VPolytope(const Eigen::Ref<const MatrixXd>& vertices)
-    : ConvexSet(&ConvexSetCloner<VPolytope>, vertices.rows()),
-      vertices_{vertices} {}
+    : ConvexSet(vertices.rows()), vertices_{vertices} {}
 
 VPolytope::VPolytope(const QueryObject<double>& query_object,
                      GeometryId geometry_id,
                      std::optional<FrameId> reference_frame)
-    : ConvexSet(&ConvexSetCloner<VPolytope>, 3) {
+    : ConvexSet(3) {
   Matrix3Xd vertices;
   query_object.inspector().GetShape(geometry_id).Reify(this, &vertices);
 
@@ -101,7 +100,7 @@ VPolytope::VPolytope(const QueryObject<double>& query_object,
 }
 
 VPolytope::VPolytope(const HPolyhedron& hpoly)
-    : ConvexSet(&ConvexSetCloner<VPolytope>, hpoly.ambient_dimension()) {
+    : ConvexSet(hpoly.ambient_dimension()) {
   DRAKE_THROW_UNLESS(hpoly.IsBounded());
 
   MatrixXd coeffs(hpoly.A().rows(), hpoly.A().cols() + 1);
@@ -286,6 +285,10 @@ void VPolytope::WriteObj(const std::filesystem::path& filename) const {
     fmt::print(file, "f {}\n", fmt::join(face_indices, " "));
   }
   file.close();
+}
+
+std::unique_ptr<ConvexSet> VPolytope::DoClone() const {
+  return std::make_unique<VPolytope>(*this);
 }
 
 bool VPolytope::DoPointInSet(const Eigen::Ref<const VectorXd>& x,

--- a/geometry/optimization/vpolytope.h
+++ b/geometry/optimization/vpolytope.h
@@ -82,6 +82,8 @@ class VPolytope final : public ConvexSet {
   void WriteObj(const std::filesystem::path& filename) const;
 
  private:
+  std::unique_ptr<ConvexSet> DoClone() const final;
+
   bool DoIsBounded() const final { return true; }
 
   bool DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,


### PR DESCRIPTION
Towards #19311.  Amends #15266.

This class is `@experimental`, so no deprecation is required.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19336)
<!-- Reviewable:end -->
