### PR TITLE
Add RenderMaterial to geometry/render

### DIFF
--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -16,6 +16,7 @@ drake_cc_package_library(
         ":render_camera",
         ":render_engine",
         ":render_label",
+        ":render_material",
     ],
 )
 
@@ -62,6 +63,21 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "render_material",
+    srcs = ["render_material.cc"],
+    hdrs = ["render_material.h"],
+    interface_deps = [
+        "//common:diagnostic_policy",
+        "//common:essential",
+        "//geometry:geometry_properties",
+        "//geometry:rgba",
+    ],
+    deps = [
+        "@tinyobjloader",
+    ],
+)
+
 # === test/ ===
 
 filegroup(
@@ -101,6 +117,16 @@ drake_cc_googletest(
         ":render_label",
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "render_material_test",
+    data = [":test_models"],
+    deps = [
+        ":render_material",
+        "//common/test_utilities:diagnostic_policy_test_base",
+        "//geometry:geometry_roles",
     ],
 )
 

--- a/geometry/render/render_material.cc
+++ b/geometry/render/render_material.cc
@@ -1,0 +1,112 @@
+#include "drake/geometry/render/render_material.h"
+
+#include <fstream>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/fmt_eigen.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+using drake::internal::DiagnosticPolicy;
+
+void MaybeWarnForRedundantMaterial(
+    const GeometryProperties& props, std::string_view mesh_name,
+    const DiagnosticPolicy& policy) {
+  std::vector<std::string> ignored_props;
+  if (props.HasProperty("phong", "diffuse")) {
+    ignored_props.push_back(fmt::format(
+        "('phong', 'diffuse') = {}",
+        fmt_eigen(props.GetProperty<Rgba>("phong", "diffuse").rgba())));
+  }
+  if (props.HasProperty("phong", "diffuse_map")) {
+    ignored_props.push_back(
+        fmt::format("('phong', 'diffuse_map') = {}",
+                    props.GetProperty<std::string>("phong", "diffuse_map")));
+  }
+  if (!ignored_props.empty()) {
+    policy.Warning(
+        fmt::format("The mesh {} has its own materials, but material "
+                    "properties have been defined as well. They will "
+                    "be ignored: {}",
+                    mesh_name, fmt::join(ignored_props, ", ")));
+  }
+}
+
+RenderMaterial MakeMeshFallbackMaterial(
+    const GeometryProperties& props, const std::filesystem::path& mesh_path,
+    const Rgba& default_diffuse,
+    const DiagnosticPolicy& policy) {
+  // If a material is indicated *at all* in the properties, that
+  // defines the material.
+  if (props.HasProperty("phong", "diffuse") ||
+      props.HasProperty("phong", "diffuse_map")) {
+    // This call must be guarded because it will create a valid material even if
+    // no properties have been defined.
+
+    // Why is the default color white?
+    //  We're here because the user specified *some* drake material property.
+    //  If it's *only* diffuse_map, then the underlying color must be white to
+    //  faithfully reproduce the texture. Obviously, if they've specified a
+    //  diffuse color, that will be used. Objects that request an invalid
+    //  texture will be drawn in white.
+    return DefineMaterial(props, Rgba(1, 1, 1), policy);
+  }
+
+  // Checks for foo.png for mesh filename foo.*. This the legacy behavior we
+  // want to do away with.
+  RenderMaterial material;
+
+  // This is the fall-through condition; the final priority in the protocol.
+  material.diffuse = default_diffuse;
+
+  if (!mesh_path.empty()) {
+    std::filesystem::path alt_texture_path(mesh_path);
+    alt_texture_path.replace_extension("png");
+    // If we find foo.png but can't access it, we'll *silently* treat it like
+    // we didn't find it. No value in warning for a behavior we're cutting.
+    if (std::ifstream(alt_texture_path).is_open()) {
+      material.diffuse = Rgba(1, 1, 1);
+      material.diffuse_map = alt_texture_path;
+    }
+  }
+  return material;
+}
+
+RenderMaterial DefineMaterial(
+    const GeometryProperties& props,
+    const Rgba& default_diffuse,
+    const DiagnosticPolicy& policy) {
+  RenderMaterial material;
+
+  material.diffuse_map =
+      props.GetPropertyOrDefault<std::string>("phong", "diffuse_map", "");
+  const bool has_texture = !material.diffuse_map.empty();
+  // Default of white with a declared texture, otherwise the given default.
+  material.diffuse = props.GetPropertyOrDefault<Rgba>(
+      "phong", "diffuse", has_texture ? Rgba(1, 1, 1) : default_diffuse);
+
+  if (has_texture) {
+    // Confirm it is available.
+    if (!std::ifstream(material.diffuse_map).is_open()) {
+      // TODO(SeanCurtis-TRI): It would be good to be able to tie this into
+      // some reference to the geometry under question. Ideally, the caller
+      // would provide a custom policy that would automatically decorate this
+      // message with the additional context.
+      policy.Warning(fmt::format(
+          "The ('phong', 'diffuse_map') property referenced a map that "
+          "could not be found: {}",
+          material.diffuse_map));
+      material.diffuse_map.clear();
+    }
+  }
+  return material;
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/render_material.h
+++ b/geometry/render/render_material.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+#include "drake/common/diagnostic_policy.h"
+#include "drake/geometry/geometry_properties.h"
+#include "drake/geometry/rgba.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/* Specifies a mesh material as currently supported by Drake. We expect this
+ definition to grow with time. */
+struct RenderMaterial {
+  /* The diffuse appearance at a point on a geometry surface is defined by the
+   channel-wise product of the `diffuse` and the image color of `diffuse_map`
+   applied as a texture according to the geometry's texture coordinates. If
+   `diffuse_map` is empty, it acts as the multiplicative identity. */
+  Rgba diffuse;
+  std::filesystem::path diffuse_map;
+};
+
+/* Dispatches a warning to the given diagnostic policy if the props contain a
+ material definition. It is assumed an intrinsic material has already been found
+ for the named mesh. */
+void MaybeWarnForRedundantMaterial(
+    const GeometryProperties& props, std::string_view mesh_name,
+    const drake::internal::DiagnosticPolicy& policy);
+
+/* If a mesh definition doesn't include a single material (e.g., as in an .mtl
+ file for an .obj mesh), this function applies a cascading priority for
+ otherwise defining a material for the mesh.
+
+ The material is defined with the following protocol:
+
+   - If the properties indicate a material at all, the material is derived
+     purely from the properties (e.g., ("phong", "diffuse_map") and
+     ("phong", "diffuse").
+   - Otherwise, if an image can be located with a "compatible name" (e.g.,
+     foo.png for a mesh foo.obj), a material with an unmodulated texture is
+     created.
+   - Finally, a diffuse material is created with the given default_diffuse
+     color value.
+
+ References to textures will be included in the material iff they can be read.
+
+ @pre The mesh (named by `mesh_filename`) is a valid mesh and did not have an
+      acceptable material definition). */
+RenderMaterial MakeMeshFallbackMaterial(
+    const GeometryProperties& props, const std::filesystem::path& mesh_path,
+    const Rgba& default_diffuse,
+    const drake::internal::DiagnosticPolicy& policy);
+
+/* Creates a RenderMaterial from the given set of geometry properties. If no
+ material properties exist, a material with the given default diffuse color is
+ returned.
+
+ If only a texture is specified, the diffuse color will be white. If the
+ texture is not available, the diffuse map will be cleared, but the color will
+ remain white, signaling a data error in the material specification.
+
+ The `default_diffuse` color is only applied in the total absence of material
+ properties. */
+RenderMaterial DefineMaterial(
+    const GeometryProperties& props,
+    const Rgba& default_diffuse = Rgba(1, 1, 1),
+    const drake::internal::DiagnosticPolicy& policy = {});
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/test/render_material_test.cc
+++ b/geometry/render/test/render_material_test.cc
@@ -1,0 +1,220 @@
+#include "drake/geometry/render/render_material.h"
+
+#include <filesystem>
+#include <fstream>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/diagnostic_policy_test_base.h"
+#include "drake/geometry/geometry_roles.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+namespace fs = std::filesystem;
+
+/* Confirms the expected diagnostic warnings in the presence of material
+ properties. */
+class MaybeWarnForRedundantMaterialTest
+    : public test::DiagnosticPolicyTestBase {};
+
+/* Confirm the presence of a diffuse color dispatches a warning. */
+TEST_F(MaybeWarnForRedundantMaterialTest, WarningsDispatchedDiffuseColor) {
+  PerceptionProperties props;
+  props.AddProperty("phong", "diffuse", Rgba(0.1, 0.2, 0.3, 0.4));
+  MaybeWarnForRedundantMaterial(props, "dummy_file_name", diagnostic_policy_);
+  EXPECT_THAT(TakeWarning(), testing::ContainsRegex(
+                                 "has its own materials.*'phong', 'diffuse'"));
+}
+
+/* Confirm the presence of a diffuse map dispatches a warning. */
+TEST_F(MaybeWarnForRedundantMaterialTest, WarningsDispatchedDiffuseMap) {
+  PerceptionProperties props;
+  props.AddProperty("phong", "diffuse_map", "no_such.png");
+  MaybeWarnForRedundantMaterial(props, "dummy_file_name", diagnostic_policy_);
+  EXPECT_THAT(TakeWarning(),
+              testing::MatchesRegex(
+                  ".*has its own materials.*'phong', 'diffuse_map'.*"));
+}
+
+/* Tests the DefineMaterial() function (with the potential to dispatch warnings
+ to a diagnostic policy). */
+class DefineMaterialTest : public test::DiagnosticPolicyTestBase {
+ protected:
+  Rgba default_diffuse() const { return Rgba(0.25, 0.5, 0.75, 0.5); }
+  PerceptionProperties props_;
+};
+
+/* When the properties provide no material properties, the default color is
+ used. */
+TEST_F(DefineMaterialTest, DefaultFallback) {
+  const RenderMaterial mat =
+      DefineMaterial(props_, default_diffuse(), diagnostic_policy_);
+
+  EXPECT_TRUE(mat.diffuse_map.empty());
+  EXPECT_EQ(mat.diffuse, default_diffuse());
+}
+
+/* When only the (phong, diffuse) is defined, it is used. */
+TEST_F(DefineMaterialTest, PhongDiffuseOnly) {
+  const Rgba diffuse(0.75, 0.75, 0.25, 0.25);
+  ASSERT_NE(diffuse, default_diffuse());
+  props_.AddProperty("phong", "diffuse", diffuse);
+
+  const RenderMaterial mat =
+      DefineMaterial(props_, default_diffuse(), diagnostic_policy_);
+
+  EXPECT_TRUE(mat.diffuse_map.empty());
+  EXPECT_EQ(mat.diffuse, diffuse);
+}
+
+/* When only the (phong, diffuse_map) is defined, it is used with a white
+ diffuse color. */
+TEST_F(DefineMaterialTest, PhongDiffuseMapOnly) {
+  const std::string tex_name =
+      FindResourceOrThrow("drake/geometry/render/test/diag_gradient.png");
+  props_.AddProperty("phong", "diffuse_map", tex_name);
+
+  const RenderMaterial mat =
+      DefineMaterial(props_, default_diffuse(), diagnostic_policy_);
+
+  EXPECT_EQ(mat.diffuse_map, tex_name);
+  EXPECT_EQ(mat.diffuse, Rgba(1, 1, 1));
+}
+
+/* When diffuse and diffuse_map are defined, both get used exactly. */
+TEST_F(DefineMaterialTest, PhongDiffuseAll) {
+  const Rgba diffuse(0.75, 0.75, 0.25, 0.25);
+  ASSERT_NE(diffuse, default_diffuse());
+  const std::string tex_name =
+      FindResourceOrThrow("drake/geometry/render/test/diag_gradient.png");
+  props_.AddProperty("phong", "diffuse_map", tex_name);
+  props_.AddProperty("phong", "diffuse", diffuse);
+
+  const RenderMaterial mat =
+      DefineMaterial(props_, default_diffuse(), diagnostic_policy_);
+
+  EXPECT_EQ(mat.diffuse_map, tex_name);
+  EXPECT_EQ(mat.diffuse, diffuse);
+}
+
+/* When (phong, diffuse_map) references a "bad" image, the image is omitted and
+ a warning is dispatched. The resulting material is simply white. */
+TEST_F(DefineMaterialTest, DiffuseMapError) {
+  props_.AddProperty("phong", "diffuse_map", "not_an_image.png");
+
+  const RenderMaterial mat =
+      DefineMaterial(props_, default_diffuse(), diagnostic_policy_);
+
+  EXPECT_TRUE(mat.diffuse_map.empty());
+  EXPECT_EQ(mat.diffuse, Rgba(1, 1, 1));
+  EXPECT_THAT(
+      TakeWarning(),
+      testing::MatchesRegex(".*referenced a map that could not be found.*"));
+}
+
+/* Tests the MakeMeshFallbackMaterial() function. This function should only
+ be called if the mesh has no intrinsic material. Its unique duties are:
+
+   - Determine if a material is defined *at all* in the geometry properties and
+     delegate to DefineMaterial() if so.
+   - Otherwise, look for foo.png for foo.obj and apply it if it exists.
+   - Otherwise simply apply a default-colored material.
+
+ The tests below assume:
+  1. That the invocation of DefineMaterial() is correct, and
+  2. DefineMaterial() has been sufficiently tested.
+
+ Note: the only diagnostic policy messages that get sent are attributable to
+ DefineMaterial(), so they are not directly accounted for in this test. */
+class MakeMeshFallbackMaterialTest : public test::DiagnosticPolicyTestBase {
+ protected:
+  static Rgba default_diffuse() { return Rgba(0.125, 0.25, 0.375, 0.5); }
+};
+
+/* No material defined in the properties and no foo.png --> default-colored
+ material. This doesn't test the case where foo.png *does* exist, but isn't
+ available. We're not testing the "unaccessible foo.png" case. Not worth it
+ in light of its imminent death.  */
+TEST_F(MakeMeshFallbackMaterialTest, DefaultDiffuseMaterial) {
+  PerceptionProperties props;
+
+  const RenderMaterial mat = MakeMeshFallbackMaterial(
+      props, "no_png_for_this.obj", default_diffuse(), diagnostic_policy_);
+
+  EXPECT_TRUE(mat.diffuse_map.empty());
+  EXPECT_EQ(mat.diffuse, default_diffuse());
+}
+
+/* No material defined in the properties, but foo.png exists and is available.*/
+TEST_F(MakeMeshFallbackMaterialTest, ValidFooPngMaterial) {
+  PerceptionProperties props;
+  const std::string tex_name =
+      FindResourceOrThrow("drake/geometry/render/test/meshes/box.png");
+  const fs::path tex_path(tex_name);
+  // N.B. The obj doesn't actually have to exist for this test to work.
+  fs::path obj_path = tex_path.parent_path() / "box.obj";
+
+  const RenderMaterial mat = MakeMeshFallbackMaterial(
+      props, obj_path.string(), default_diffuse(), diagnostic_policy_);
+
+  EXPECT_EQ(mat.diffuse_map, tex_name);
+  EXPECT_EQ(mat.diffuse, Rgba(1, 1, 1));
+}
+
+/* The presence of any material property should create a material.
+ MakeMeshFallbackMaterial() defers to DefineMaterial() in the presence of
+ material properties. For diffuse color, it passes a white default. We just need
+ evidence that suggests it gets called as expected.
+
+ We test properties independently and combined to make sure the parameters
+ are all passed to DefineMaterial(). We don't explicitly test for degenerate
+ cases (inaccessible texture), because DefineMaterial() handles that and has
+ been tested above.
+
+ As we extend the set of material properties Drake knows about, we should add
+ an independent test for each one, and each should likewise be added into the
+ PropertiesHaveEverything test. */
+TEST_F(MakeMeshFallbackMaterialTest, PropertiesHaveDiffuseColor) {
+  PerceptionProperties props;
+  props.AddProperty("phong", "diffuse", Rgba(0.25, 0.5, 0.75, 0.5));
+  const RenderMaterial mat = MakeMeshFallbackMaterial(
+      props, "doesn't_matter.obj", default_diffuse(), diagnostic_policy_);
+
+  EXPECT_TRUE(mat.diffuse_map.empty());
+  EXPECT_EQ(mat.diffuse, props.GetProperty<Rgba>("phong", "diffuse"));
+}
+
+TEST_F(MakeMeshFallbackMaterialTest, PropertiesHaveDiffuseMap) {
+  PerceptionProperties props;
+  const std::string tex_name =
+      FindResourceOrThrow("drake/geometry/render/test/diag_gradient.png");
+  props.AddProperty("phong", "diffuse_map", tex_name);
+  const RenderMaterial mat = MakeMeshFallbackMaterial(
+      props, "doesn't_matter.obj", default_diffuse(), diagnostic_policy_);
+
+  EXPECT_EQ(mat.diffuse_map, tex_name);
+  EXPECT_EQ(mat.diffuse, Rgba(1, 1, 1));
+}
+
+TEST_F(MakeMeshFallbackMaterialTest, PropertiesHaveEverything) {
+  PerceptionProperties props;
+  const std::string tex_name =
+      FindResourceOrThrow("drake/geometry/render/test/diag_gradient.png");
+  props.AddProperty("phong", "diffuse_map", tex_name);
+  props.AddProperty("phong", "diffuse", Rgba(0.25, 0.5, 0.75, 0.5));
+  const RenderMaterial mat = MakeMeshFallbackMaterial(
+      props, "doesn't_matter.obj", default_diffuse(), diagnostic_policy_);
+
+  EXPECT_EQ(mat.diffuse_map, tex_name);
+  EXPECT_EQ(mat.diffuse, props.GetProperty<Rgba>("phong", "diffuse"));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
Introduce the RenderMaterial type and utility functions:
 - Convert from GeometryProperties to RenderMaterial
 - Define fallback logic for when a mesh doesn't specify its own materials.
 - Provide a utility for mesh parsing to report when the mesh specifies its own materials as well as material properties.

Relates #18844

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19352)
<!-- Reviewable:end -->
