### PR TITLE
Generalize render_gl/MeshData into render/RenderMesh

### DIFF
--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -17,6 +17,7 @@ drake_cc_package_library(
         ":render_engine",
         ":render_label",
         ":render_material",
+        ":render_mesh",
     ],
 )
 
@@ -78,6 +79,18 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "render_mesh",
+    srcs = ["render_mesh.cc"],
+    hdrs = ["render_mesh.h"],
+    interface_deps = [
+        "//common:essential",
+    ],
+    deps = [
+        "@tinyobjloader",
+    ],
+)
+
 # === test/ ===
 
 filegroup(
@@ -127,6 +140,17 @@ drake_cc_googletest(
         ":render_material",
         "//common/test_utilities:diagnostic_policy_test_base",
         "//geometry:geometry_roles",
+    ],
+)
+
+drake_cc_googletest(
+    name = "render_mesh_test",
+    data = [":test_models"],
+    deps = [
+        ":render_mesh",
+        "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/geometry/render/render_mesh.cc
+++ b/geometry/render/render_mesh.cc
@@ -1,0 +1,210 @@
+#include "drake/geometry/render/render_mesh.h"
+
+#include <fstream>
+#include <istream>
+#include <map>
+#include <tuple>
+#include <vector>
+
+#include <fmt/format.h>
+#include <tiny_obj_loader.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/text_logging.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+using std::make_tuple;
+using std::map;
+using std::string;
+using std::tuple;
+using std::vector;
+
+RenderMesh LoadRenderMeshFromObj(std::istream* input_stream,
+                                 const std::string& filename) {
+  tinyobj::attrib_t attrib;
+  vector<tinyobj::shape_t> shapes;
+  vector<tinyobj::material_t> materials;
+  string warn;
+  string err;
+  /* This renderer assumes everything is triangles -- we rely on tinyobj to
+   triangulate for us. */
+  const bool do_tinyobj_triangulation = true;
+
+  drake::log()->trace("LoadRenderMeshFromObj('{}')", filename);
+
+  /* Tinyobj doesn't infer the search directory from the directory containing
+   the obj file. We have to provide that directory; of course, this assumes
+   that the material library reference is relative to the obj directory.
+   Ignore material-library file.  */
+  tinyobj::MaterialReader* material_reader = nullptr;
+  const bool ret =
+      tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, input_stream,
+                       material_reader, do_tinyobj_triangulation);
+  if (!ret) {
+    throw std::runtime_error(
+        fmt::format("tinyobj::LoadObj failed to load file: {}", filename));
+  }
+
+  if (shapes.empty()) {
+    throw std::runtime_error(fmt::format(
+        "The OBJ data appears to have no faces; it could be missing faces or "
+        "might not be an OBJ file: {}",
+        filename));
+  }
+
+  /* The parsed product needs to be further processed. The RenderMesh assumes
+   that all vertex quantities (positions, normals, texture coordinates) are
+   indexed with a common index; a face that references vertex i, will get its
+   position from positions[i], its normal from normals[i], and its texture
+   coordinate from uvs[i]. However, we _cannot_ assume that each vertex
+   position is associated with a single per-vertex quantity (normal, uv) in
+   the OBJ file. OBJ allows a vertex position to be associated with arbitrary
+   per-vertex quantities in each face definition independently. So, we need to
+   create the unique association here.
+
+   To accomplish this:
+    1. Every vertex referenced by a face in the parsed OBJ is a "meta"
+       vertex consisting of a tuple of indices: (p, n, uv), the index in
+       vertex positions, normals, and texture coordinates. For example,
+       imagine one face refers to meta index (p, n₀, uv) and another face
+       refers to index (p, n₁, uv). Although the two faces appear to share a
+       single vertex (and a common texture coordinate), those vertices have
+       different normals which require two different vertices in the mesh
+       data. We copy the vertex position and texture coordinate and then
+       associate one copy with each normal. A similar operation would apply if
+       they only differed in texture coordinate (or in both).
+    2. Given a mapping (p, n, uv) --> i (a mapping from the meta vertex in the
+       parsed OBJ data to the unique index in the resultant mesh data), we
+       can build the faces in the final mesh data by mapping the (p, n, uv)
+       tuple in the OBJ face specification to the final mesh data vertex
+       index i.
+    3. When done, we should have an equal number of vertex positions as
+       normals and texture coordinates. And all indices in the faces should be
+       valid indices into all three vectors of data.
+   NOTE: In the case of meta vertices (p, n₀, uv) and (p, n₁, uv) we are not
+   confirming that normals[n₀] and normals[n₁] are actually different normals;
+   we're assuming different indices implies different values. Again, the same
+   applies to different texture coordinate indices.  */
+
+  /* The map from (p, n, uv) --> i.  */
+  map<tuple<int, int, int>, int> obj_vertex_to_new_vertex;
+  /* Accumulators for vertex positions, normals, and triangles.  */
+  vector<Vector3d> positions;
+  vector<Vector3d> normals;
+  vector<Vector2d> uvs;
+  vector<Vector3<int>> triangles;
+
+  // TODO(SeanCurtis-TRI) Revisit how we handle normals:
+  //   1. If normals are absent, generate normals so that we get faceted meshes.
+  //   2. Make use of smoothing groups.
+  if (attrib.normals.size() == 0) {
+    throw std::runtime_error(fmt::format(
+        "OBJ has no normals; RenderEngineGl requires OBJs with normals: {}",
+        filename));
+  }
+
+  bool has_tex_coord{attrib.texcoords.size() > 0};
+
+  for (const auto& shape : shapes) {
+    /* Each face is a sequence of indices. All of the face indices are
+     concatenated together in one long sequence: [i1, i2, ..., iN]. Because
+     we have nothing but triangles, that sequence can be partitioned into
+     triples, each representing one triangle:
+       [(i1, i2, i3), (i4, i5, i6), ..., (iN-2, iN-1, iN)].
+     We maintain an index into that long sequence (v_index) and simply
+     increment it knowing that every three increments takes us to a new face. */
+    int v_index = 0;
+    const auto& shape_mesh = shape.mesh;
+    const int num_faces = static_cast<int>(shape_mesh.num_face_vertices.size());
+    for (int f = 0; f < num_faces; ++f) {
+      DRAKE_DEMAND(shape_mesh.num_face_vertices[f] == 3);
+      /* Captures the [i0, i1, i2] new index values for the face.  */
+      int face_vertices[3] = {-1, -1, -1};
+      for (int i = 0; i < 3; ++i) {
+        const int position_index = shape_mesh.indices[v_index].vertex_index;
+        const int norm_index = shape_mesh.indices[v_index].normal_index;
+        const int uv_index = shape_mesh.indices[v_index].texcoord_index;
+        if (norm_index < 0) {
+          throw std::runtime_error(
+              fmt::format("Not all faces reference normals: {}", filename));
+        }
+        if (has_tex_coord) {
+          if (uv_index < 0) {
+            throw std::runtime_error(fmt::format(
+                "Not all faces reference texture coordinates: {}", filename));
+          }
+        } else {
+          DRAKE_DEMAND(uv_index < 0);
+        }
+        const auto obj_indices =
+            make_tuple(position_index, norm_index, uv_index);
+        if (obj_vertex_to_new_vertex.count(obj_indices) == 0) {
+          obj_vertex_to_new_vertex[obj_indices] =
+              static_cast<int>(positions.size());
+          /* Guarantee that the positions.size() == normals.size() == uvs.size()
+           by always growing them in lock step.  */
+          positions.emplace_back(
+              Vector3d{attrib.vertices[3 * position_index],
+                       attrib.vertices[3 * position_index + 1],
+                       attrib.vertices[3 * position_index + 2]});
+          normals.emplace_back(attrib.normals[3 * norm_index],
+                               attrib.normals[3 * norm_index + 1],
+                               attrib.normals[3 * norm_index + 2]);
+          if (has_tex_coord) {
+            uvs.emplace_back(attrib.texcoords[2 * uv_index],
+                             attrib.texcoords[2 * uv_index + 1]);
+          } else {
+            uvs.emplace_back(0.0, 0.0);
+          }
+        }
+        face_vertices[i] = obj_vertex_to_new_vertex[obj_indices];
+        ++v_index;
+      }
+      triangles.emplace_back(&face_vertices[0]);
+    }
+  }
+
+  DRAKE_DEMAND(positions.size() == normals.size());
+  DRAKE_DEMAND(positions.size() == uvs.size());
+
+  RenderMesh mesh_data;
+  using indices_uint_t = decltype(mesh_data.indices)::Scalar;
+  mesh_data.indices.resize(triangles.size(), 3);
+  for (int t = 0; t < mesh_data.indices.rows(); ++t) {
+    mesh_data.indices.row(t) = triangles[t].cast<indices_uint_t>();
+  }
+  mesh_data.positions.resize(positions.size(), 3);
+  for (int v = 0; v < mesh_data.positions.rows(); ++v) {
+    mesh_data.positions.row(v) = positions[v];
+  }
+  mesh_data.normals.resize(normals.size(), 3);
+  for (int n = 0; n < mesh_data.normals.rows(); ++n) {
+    mesh_data.normals.row(n) = normals[n];
+  }
+  mesh_data.has_tex_coord = has_tex_coord;
+  mesh_data.uvs.resize(uvs.size(), 2);
+  for (int uv = 0; uv < mesh_data.uvs.rows(); ++uv) {
+    mesh_data.uvs.row(uv) = uvs[uv];
+  }
+
+  return mesh_data;
+}
+
+RenderMesh LoadRenderMeshFromObj(const string& filename) {
+  std::ifstream input_stream(filename);
+  if (!input_stream.is_open()) {
+    throw std::runtime_error(
+        fmt::format("Cannot load the obj file '{}'", filename));
+  }
+  return LoadRenderMeshFromObj(&input_stream, filename);
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/render_mesh.h
+++ b/geometry/render/render_mesh.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <istream>
+#include <string>
+
+#include <Eigen/Dense>
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/* The data representing a mesh. The triangle mesh is defined by `indices`. Row
+ t represents a triangle by the triplet of vertex indices: tᵥ₀, tᵥ₁, tᵥ₂. The
+ indices map into the rows of `positions`, `normals`, and `uvs`. I.e., for
+ vertex index v, the position of that vertex is at `positions.row(v)`, its
+ corresponding normal is at `normals.row(v)`, and its texture coordinates are at
+ `uvs.row(v)`.
+
+ For now, all vertex quantities (`positions`, `normals` and `uvs`) are
+ guaranteed (as well as the `indices` data). In the future, `uvs` may become
+ optional.  */
+struct RenderMesh {
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> positions;
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> normals;
+  Eigen::Matrix<double, Eigen::Dynamic, 2, Eigen::RowMajor> uvs;
+  Eigen::Matrix<unsigned int, Eigen::Dynamic, 3, Eigen::RowMajor> indices;
+
+  /** See docs for `has_tex_coord` below.  */
+  static constexpr bool kHasTexCoordDefault{true};
+
+  /** This flag indicates that this mesh has texture coordinates to support
+   maps.
+   If True, the values of `uvs` will be nontrivial.
+   If False, the values of `uvs` will be all zeros, but will still have the
+   correct size.  */
+  bool has_tex_coord{kHasTexCoordDefault};
+};
+
+/* Loads a mesh's vertices and indices (faces) from an OBJ description given
+ in the input stream. It does not load textures. Note that while this
+ functionality seems similar to ReadObjToTriangleSurfaceMesh, RenderEngineGl
+ cannot use TriangleSurfaceMesh. Rendering requires normals and texture
+ coordinates; TriangleSurfaceMesh was not designed with those quantities in
+ mind.
+
+ If no texture coordinates are specified by the file, it will be indicated in
+ the returned RenderMesh. See RenderMesh::has_tex_coord for more detail.
+
+ @throws std::exception if a) tinyobj::LoadObj() fails, (b) there are no faces
+                           or normals, c) faces fail to reference normals, or d)
+                           faces fail to reference the texture coordinates if
+                           they are present.  */
+RenderMesh LoadRenderMeshFromObj(std::istream* input_stream,
+                                 const std::string& filename = "from_string");
+
+/* Overload of LoadRenderMeshFromObj that reads the OBJ description from the
+ given file. */
+RenderMesh LoadRenderMeshFromObj(const std::string& filename);
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/test/render_mesh_test.cc
+++ b/geometry/render/test/render_mesh_test.cc
@@ -1,0 +1,290 @@
+#include "drake/geometry/render/render_mesh.h"
+
+#include <sstream>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+using Eigen::AngleAxisf;
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+using std::vector;
+
+GTEST_TEST(LoadRenderMeshFromObjTest, ErrorModes) {
+  {
+    // Case: Vertices only reports no faces found.
+    std::stringstream in_stream("v 1 2 3");
+    DRAKE_EXPECT_THROWS_MESSAGE(LoadRenderMeshFromObj(&in_stream),
+                                "The OBJ data appears to have no faces.*");
+  }
+  {
+    // Case: Not an obj in any way reports as no faces.
+    std::stringstream in_stream("Not an obj\njust some\nmeaningles text.\n");
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        LoadRenderMeshFromObj(&in_stream),
+        "The OBJ data appears to have no faces.* might not be an OBJ file.+");
+  }
+  {
+    // Case: The obj has no normals. Note: the face specification is otherwise
+    // invalid in that it references vertex positions that don't exist.
+    std::stringstream in_stream("v 1 2 3\nf 1 2 3\n");
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        LoadRenderMeshFromObj(&in_stream),
+        "OBJ has no normals; RenderEngineGl requires OBJs with normals.+");
+  }
+  {
+    // Case: Not all faces reference normals. Note: the face specification is
+    // otherwise invalid in that it references vertex positions that don't
+    // exist.
+    std::stringstream in_stream(R"""(
+v 1 2 3
+vn 0 0 1
+vt 0 1
+f 1 2 3
+)""");
+    DRAKE_EXPECT_THROWS_MESSAGE(LoadRenderMeshFromObj(&in_stream),
+                                "Not all faces reference normals.+");
+  }
+  {
+    // Case: Not all faces reference uvs. Note: the face specification is
+    // otherwise invalid in that it references vertex positions that don't
+    // exist.
+    std::stringstream in_stream(R"""(
+v 1 2 3
+vn 0 0 1
+vt 0 0
+f 1//1 2//1 3//1
+)""");
+    DRAKE_EXPECT_THROWS_MESSAGE(LoadRenderMeshFromObj(&in_stream),
+                                "Not all faces reference texture.+");
+  }
+}
+
+GTEST_TEST(LoadRenderMeshFromObjTest, NoMeshUvs) {
+  // Update: This OBJ has no UVs, but we have now updated this to accept it.
+  std::stringstream in_stream(R"""(
+v 0.1 0.2 0.3
+v 0.4 0.5 0.6
+v -0.1 -0.2 -0.3
+vn 0 0 1
+f 1//1 2//1 3//1
+)""");
+  EXPECT_NO_THROW(LoadRenderMeshFromObj(&in_stream));
+}
+
+// Simply confirms that the filename variant of LoadRenderMeshFromObj
+// successfully dispatches files or errors, as appropriate. The actual parsing
+// functionality  is parsed via the stream interface.
+GTEST_TEST(LoadRenderMeshFromObjTest, ReadingFile) {
+  const std::string filename =
+      FindResourceOrThrow("drake/geometry/render/test/meshes/box.obj");
+
+  RenderMesh mesh_data = LoadRenderMeshFromObj(filename);
+  EXPECT_EQ(mesh_data.positions.rows(), 24);
+  EXPECT_EQ(mesh_data.normals.rows(), 24);
+  EXPECT_EQ(mesh_data.uvs.rows(), 24);
+  EXPECT_EQ(mesh_data.indices.rows(), 12);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(LoadRenderMeshFromObj("Bad file name"),
+                              "Cannot load the obj file 'Bad file name'");
+}
+
+// Helpful struct for specifying multiple cases in the TriangluatePolygons test.
+struct TriangluateTestParmas {
+  std::string name;
+  std::string obj_spec;
+  int position_count;
+  // The expected normal and texture coordinate for the vertices in face 0 (f0).
+  Vector3d n0;
+  Vector2d uv0;
+  // The expected normal and texture coordinate for the vertices in face 1 (f1).
+  Vector3d n1;
+  Vector2d uv1;
+};
+
+// Confirms that non-triangular faces get triangulated. This also confirms that
+// duplication occurs due to associations of vertex positions with multiple
+// normals or texture coordinates.
+GTEST_TEST(LoadRenderMeshFromObjTest, TriangulatePolygons) {
+  /*
+             o 4
+            ╱  ╲            A five-sided polygon and a four-sided polygon
+           ╱    ╲           should be triangulated into three and two
+          ╱      ╲          triangles respectively. But with the same
+         ╱        ╲         vertices.
+        ╱    f0    ╲
+     5 o            o 3     The upper and lower polygons have *different*
+        ╲          ╱        normals. So, vertices 1 & 2 will be copied.
+         ╲        ╱         All vertices have the same texture coordinate, so
+       1  o──────o 2        its value does not trigger duplication.
+          │  f1  │
+          o──────o
+          6      7
+  */
+  constexpr char positions[] = R"""(
+  v -1 -1 0
+  v 1 -1 0
+  v 2 1 0
+  v 0 2 0
+  v -2 1 0
+  v -1 -2 0
+  v 1 -2 0)""";
+
+  const Vector3d unit3_z = Vector3d::UnitZ();
+  const Vector3d unit3_y = Vector3d::UnitY();
+  const Vector2d zero2 = Vector2d::Zero();
+  const Vector2d ones2(1, 1);
+
+  vector<TriangluateTestParmas> test_params{
+      // Every vertex is associated with a single normal and texture coordinate.
+      {"Unique vertices", R"""(
+      vn 0 0 1
+      vt 0 0
+      f 1/1/1 2/1/1 3/1/1 4/1/1 5/1/1
+      f 6/1/1 7/1/1 2/1/1 1/1/1)""",
+       7, unit3_z, zero2, unit3_z, zero2},
+      // Upper and lower faces have different normals; vertices 1 & 2 will be
+      // duplicated.
+      {"Vertices with multiple normals", R"""(
+      vn 0 0 1
+      vn 0 1 0
+      vt 0 0
+      f 1/1/1 2/1/1 3/1/1 4/1/1 5/1/1
+      f 6/1/2 7/1/2 2/1/2 1/1/2)""",
+       9, unit3_z, zero2, unit3_y, zero2},
+      // Upper and lower faces have different uvs; vertices 1 & 2 will be
+      // duplicated.
+      {"Vertices with multiple uvs", R"""(
+      vn 0 0 1
+      vt 0 0
+      vt 1 1
+      f 1/1/1 2/1/1 3/1/1 4/1/1 5/1/1
+      f 6/2/1 7/2/1 2/2/1 1/2/1)""",
+       9, unit3_z, zero2, unit3_z, ones2},
+  };
+
+  for (const auto& params : test_params) {
+    SCOPED_TRACE(params.name);
+    std::stringstream in_stream;
+    in_stream << positions;
+    in_stream << params.obj_spec;
+    RenderMesh mesh_data = LoadRenderMeshFromObj(&in_stream);
+    EXPECT_EQ(mesh_data.positions.rows(), params.position_count);
+    EXPECT_EQ(mesh_data.normals.rows(), params.position_count);
+    EXPECT_EQ(mesh_data.uvs.rows(), params.position_count);
+    // The two faces will always be triangulated into five triangles.
+    EXPECT_EQ(mesh_data.indices.rows(), 5);
+
+    // The first three triangles come from f0, and all have the expected normal
+    // and texture coordinate.
+    for (int t = 0; t < 3; ++t) {
+      for (int i = 0; i < 3; ++i) {
+        const int index = mesh_data.indices(t, i);
+        EXPECT_TRUE(CompareMatrices(mesh_data.normals.row(index),
+                                    params.n0.transpose()));
+        EXPECT_TRUE(CompareMatrices(mesh_data.uvs.row(index),
+                                    params.uv0.transpose()));
+      }
+    }
+    // The last two triangles come from f1 and all have the expected normal and
+    // texture coordinate.
+    for (int t = 3; t < 5; ++t) {
+      for (int i = 0; i < 3; ++i) {
+        const int index = mesh_data.indices(t, i);
+        EXPECT_TRUE(CompareMatrices(mesh_data.normals.row(index),
+                                    params.n1.transpose()));
+        EXPECT_TRUE(CompareMatrices(mesh_data.uvs.row(index),
+                                    params.uv1.transpose()));
+      }
+    }
+  }
+}
+
+// Geometry already triangulated gets preserved. This doesn't do variations on
+// whether vertex positions need copying due to associations with multiple
+// normals/uvs. It relies on `TriangulatePolygons` to handle that.
+GTEST_TEST(LoadRenderMeshFromObjTest, PreserveTriangulation) {
+  /*
+             o 4
+            ╱  ╲
+           ╱    ╲
+          ╱      ╲
+         ╱        ╲
+        ╱          ╲       Note: Ascii art makes drawing the following edges
+     5 o────────────o 3    nearly impossible.
+        ╲          ╱
+         ╲        ╱        Connect 2 to 5 to form two triangles.
+       1  o──────o 2
+          │      │         Connect 1 to 7 to form two triangles.
+          o──────o
+          6      7
+  */
+  std::stringstream in_stream(R"""(
+  v -1 -1 0
+  v 1 -1 0
+  v 2 1 0
+  v 0 2 0
+  v -2 1 0
+  v -1 -2 0
+  v 1 -2 0
+  vn 0 0 1
+  vt 0 0
+  f 1/1/1 2/1/1 5/1/1
+  f 2/1/1 3/1/1 5/1/1
+  f 3/1/1 4/1/1 5/1/1
+  f 1/1/1 6/1/1 7/1/1
+  f 1/1/1 7/1/1 2/1/1
+  )""");
+  RenderMesh mesh_data = LoadRenderMeshFromObj(&in_stream);
+  EXPECT_EQ(mesh_data.positions.rows(), 7);
+  EXPECT_EQ(mesh_data.normals.rows(), 7);
+  EXPECT_EQ(mesh_data.uvs.rows(), 7);
+  EXPECT_EQ(mesh_data.indices.rows(), 5);
+}
+
+// The RenderMesh produces *new* vertices from what was in the OBJ based on what
+// vertex gets referenced by which faces. A vertex that doesn't get referenced
+// gets omitted.
+GTEST_TEST(LoadRenderMeshFromObjTest, RemoveUnreferencedVertices) {
+  /*
+
+        4 o───────o 3
+          │     ╱ │
+          │   ╱   │   o 5
+          │ ╱     │
+    1, 6  o───────o 2
+
+  */
+  std::stringstream in_stream(R"""(
+  v -1 -1 0  # First four corners form a box around the origin.
+  v 1 -1 0
+  v 1 1 0
+  v -1 1 0
+  v 3 0 0    # Unreferenced vertex to the right of the box (omitted).
+  v -1 -1 0  # Duplicate of vertex 1 but propagated through.
+  vn 0 0 1
+  vt 0 0
+  f 1/1/1 2/1/1 3/1/1
+  f 6/1/1 3/1/1 4/1/1
+  )""");
+  RenderMesh mesh_data = LoadRenderMeshFromObj(&in_stream);
+  EXPECT_EQ(mesh_data.positions.rows(), 5);
+  EXPECT_EQ(mesh_data.normals.rows(), 5);
+  EXPECT_EQ(mesh_data.uvs.rows(), 5);
+  EXPECT_EQ(mesh_data.indices.rows(), 2);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render_gl/BUILD.bazel
+++ b/geometry/render_gl/BUILD.bazel
@@ -79,6 +79,7 @@ drake_cc_library_ubuntu_only(
         ":internal_texture_library",
         ":render_engine_gl_params",
         "//geometry/render:render_engine",
+        "//geometry/render:render_mesh",
         "//systems/sensors:image",
     ],
 )
@@ -164,6 +165,7 @@ drake_cc_library_ubuntu_only(
     hdrs = ["internal_shape_meshes.h"],
     interface_deps = [
         ":internal_opengl_context",
+        "//geometry/render:render_mesh",
     ],
     deps = [
         "//common:essential",

--- a/geometry/render_gl/internal_render_engine_gl.h
+++ b/geometry/render_gl/internal_render_engine_gl.h
@@ -11,6 +11,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/render/render_engine.h"
+#include "drake/geometry/render/render_mesh.h"
 #include "drake/geometry/render_gl/internal_buffer_dim.h"
 #include "drake/geometry/render_gl/internal_opengl_context.h"
 #include "drake/geometry/render_gl/internal_opengl_geometry.h"
@@ -159,7 +160,7 @@ class RenderEngineGl final : public render::RenderEngine {
 
   // Creates an OpenGlGeometry from the mesh defined by the given `mesh_data`.
   static OpenGlGeometry CreateGlGeometry(
-      const MeshData& mesh_data);
+      const geometry::internal::RenderMesh& mesh_data);
 
   // Sets the display window visibility and populates it with the _last_ image
   // rendered, if visible.

--- a/geometry/render_gl/internal_shape_meshes.h
+++ b/geometry/render_gl/internal_shape_meshes.h
@@ -5,60 +5,12 @@
 
 #include <Eigen/Dense>
 
-#include "drake/geometry/render_gl/internal_opengl_includes.h"
+#include "drake/geometry/render/render_mesh.h"
 
 namespace drake {
 namespace geometry {
 namespace render_gl {
 namespace internal {
-
-/* The data representing a mesh. The triangle mesh is defined by `indices`. Row
- t represents a triangle by the triplet of vertex indices: tᵥ₀, tᵥ₁, tᵥ₂. The
- indices map into the rows of `positions`, `normals`, and `uvs`. I.e., for
- vertex index v, the position of that vertex is at `positions.row(v)`, its
- corresponding normal is at `normals.row(v)`, and its texture coordinates are at
- `uvs.row(v)`.
-
- For now, all vertex quantities (`positions`, `normals` and `uvs`) are
- guaranteed (as well as the `indices` data). In the future, `uvs` may become
- optional.  */
-struct MeshData {
-  Eigen::Matrix<GLfloat, Eigen::Dynamic, 3, Eigen::RowMajor> positions;
-  Eigen::Matrix<GLfloat, Eigen::Dynamic, 3, Eigen::RowMajor> normals;
-  Eigen::Matrix<GLfloat, Eigen::Dynamic, 2, Eigen::RowMajor> uvs;
-  Eigen::Matrix<GLuint, Eigen::Dynamic, 3, Eigen::RowMajor> indices;
-
-  /** See docs for `has_tex_coord` below.  */
-  static constexpr bool kHasTexCoordDefault{true};
-
-  /** This flag indicates that this mesh has texture coordinates to support
-   maps.
-   If True, the values of `uvs` will be nontrivial.
-   If False, the values of `uvs` will be all zeros, but will still have the
-   correct size.  */
-  bool has_tex_coord{kHasTexCoordDefault};
-};
-
-/* Loads a mesh's vertices and indices (faces) from an OBJ description given
- in the input stream. It does not load textures. Note that while this
- functionality seems similar to ReadObjToTriangleSurfaceMesh, RenderEngineGl
- cannot use TriangleSurfaceMesh. Rendering requires normals and texture
- coordinates; TriangleSurfaceMesh was not designed with those quantities in
- mind.
-
- If no texture coordinates are specified by the file, it will be indicated in
- the returned MeshData. See MeshData::has_tex_coord for more detail.
-
- @throws std::exception if a) tinyobj::LoadObj() fails, (b) there are no faces
-                           or normals, c) faces fail to reference normals, or d)
-                           faces fail to reference the texture coordinates if
-                           they are present.  */
-MeshData LoadMeshFromObj(std::istream* input_stream,
-                         const std::string& filename = "from_string");
-
-/* Overload of LoadMeshFromObj that reads the OBJ description from the given
- file. */
-MeshData LoadMeshFromObj(const std::string& filename);
 
 // TODO(SeanCurtis-TRI): Provide a geodesic sphere (or a tessellation like that
 //  produced for hydroelastics).
@@ -78,8 +30,8 @@ MeshData LoadMeshFromObj(const std::string& filename);
                             with the sphere equator.
  @pre `longitude_bands` >= 3 and `latitude_bands` >= 2 (otherwise the sphere
       will have no volume).  */
-MeshData MakeLongLatUnitSphere(int longitude_bands = 50,
-                               int latitude_bands = 50);
+geometry::internal::RenderMesh MakeLongLatUnitSphere(int longitude_bands = 50,
+                                                     int latitude_bands = 50);
 
 /* Creates an OpenGL-compatible mesh representation of a unit cylinder; its
  radius and height are equal to 1. It is centered on the origin of its canonical
@@ -105,7 +57,8 @@ MeshData MakeLongLatUnitSphere(int longitude_bands = 50,
                     cylinder.
  @pre `num_strips` >= 3 (otherwise the cylinder will have no volume).
  @pre `num_bands` >= 1.  */
-MeshData MakeUnitCylinder(int num_strips = 50, int num_bands = 1);
+geometry::internal::RenderMesh MakeUnitCylinder(int num_strips = 50,
+                                                int num_bands = 1);
 
 /* Creates an OpenGL-compatible mesh reprepsenting a square patch. The patch
  has edge length `measure` units long. The square patch is defined lying on the
@@ -121,7 +74,8 @@ MeshData MakeUnitCylinder(int num_strips = 50, int num_bands = 1);
  two triangles).
  @pre `measure` > 0
  @pre `resolution >= 1`. */
-MeshData MakeSquarePatch(GLfloat measure = 200, int resolution = 1);
+geometry::internal::RenderMesh MakeSquarePatch(double measure = 200,
+                                               int resolution = 1);
 
 /* Creates an OpenGL-compatible mesh representation of the unit box - all edges
  are length 1. The box is centered on the origin of its canonical frame C with
@@ -139,7 +93,7 @@ MeshData MakeSquarePatch(GLfloat measure = 200, int resolution = 1);
 
 <!-- TODO(SeanCurtis-TRI): consider offering subdivisions if per-vertex
     properties yield undesirable artifacts for large boxes.  --> */
-MeshData MakeUnitBox();
+geometry::internal::RenderMesh MakeUnitBox();
 
 /* Creates an OpenGL-compatible mesh representation of a capsule with the given
  `radius` and `length`. The capsule is centered on the origin of its canonical
@@ -167,7 +121,8 @@ MeshData MakeUnitBox();
  @param length    The length of the cylindrical barrel.
  @pre `samples` >= 3 (otherwise the capsule will have no volume).
  @pre radius > 0 and length > 0.  */
-MeshData MakeCapsule(int samples, double radius, double length);
+geometry::internal::RenderMesh MakeCapsule(int samples, double radius,
+                                           double length);
 
 }  // namespace internal
 }  // namespace render_gl


### PR DESCRIPTION
We're pulling `MeshData` out of the `render_gl` infrastructure. It will serve as the interface for extracting mesh data (OBJ for now) for multiple render engine implementations. To do this:

1. Extract the struct and functions from `render_gl/internal_shape_meshes.*` into its own `render/render_mesh.*` shared locale.
2. Names have been changed. `MeshData` --> `RenderMesh` (it will eventually also carry material information). The `LoadMeshFromObj` name has been elaborated to differentiate other OBJ parsing targets.
3. The `RenderMesh` is no longer OpenGl specific; so we've removed the strong numerical types for `GLfloat` and the like.
   - This requires the consumers of the erstwhile `MeshData` to change how it handles the types.

Relates #18844

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19353)
<!-- Reviewable:end -->
