### PR TITLE
Avoid 'using std::move'

### DIFF
--- a/common/symbolic/expression/environment.cc
+++ b/common/symbolic/expression/environment.cc
@@ -19,7 +19,6 @@ namespace symbolic {
 
 using std::endl;
 using std::initializer_list;
-using std::move;
 using std::ostream;
 using std::ostringstream;
 using std::runtime_error;
@@ -61,7 +60,7 @@ Environment::Environment(const std::initializer_list<value_type> init)
 Environment::Environment(const std::initializer_list<key_type> vars)
     : Environment{BuildMap(vars)} {}
 
-Environment::Environment(map m) : map_{move(m)} {
+Environment::Environment(map m) : map_{std::move(m)} {
   for (const auto& p : map_) {
     throw_if_dummy(p.first);
     throw_if_nan(p.second);

--- a/common/symbolic/expression/test/variable_test.cc
+++ b/common/symbolic/expression/test/variable_test.cc
@@ -22,7 +22,6 @@ namespace symbolic {
 namespace {
 
 using std::map;
-using std::move;
 using std::unordered_map;
 using std::unordered_set;
 using std::vector;
@@ -81,7 +80,7 @@ TEST_F(VariableTest, MoveCopyPreserveId) {
   const size_t x_id{x.get_id()};
   const size_t x_hash{get_std_hash(x)};
   const Variable x_copied{x};
-  const Variable x_moved{move(x)};
+  const Variable x_moved{std::move(x)};
   EXPECT_EQ(x_id, x_copied.get_id());
   EXPECT_EQ(x_hash, get_std_hash(x_copied));
   EXPECT_EQ(x_id, x_moved.get_id());

--- a/common/symbolic/expression/variable.cc
+++ b/common/symbolic/expression/variable.cc
@@ -15,7 +15,6 @@
 
 using std::atomic;
 using std::make_shared;
-using std::move;
 using std::ostream;
 using std::ostringstream;
 using std::string;
@@ -41,7 +40,8 @@ size_t get_next_id(const Variable::Type type) {
 }  // namespace
 
 Variable::Variable(string name, const Type type)
-    : id_{get_next_id(type)}, name_{make_shared<const string>(move(name))} {
+    : id_{get_next_id(type)},
+      name_{make_shared<const string>(std::move(name))} {
   DRAKE_ASSERT(id_ > 0);
 }
 string Variable::get_name() const {

--- a/common/symbolic/expression/variables.cc
+++ b/common/symbolic/expression/variables.cc
@@ -18,7 +18,6 @@ using std::includes;
 using std::initializer_list;
 using std::inserter;
 using std::less;
-using std::move;
 using std::ostream;
 using std::ostream_iterator;
 using std::ostringstream;
@@ -129,7 +128,7 @@ Variables operator-(Variables vars, const Variable& var) {
   return vars;
 }
 
-Variables::Variables(set<Variable> vars) : vars_{move(vars)} {}
+Variables::Variables(set<Variable> vars) : vars_{std::move(vars)} {}
 
 Variables intersect(const Variables& vars1, const Variables& vars2) {
   set<Variable> intersection;
@@ -137,7 +136,7 @@ Variables intersect(const Variables& vars1, const Variables& vars2) {
                    vars2.vars_.end(),
                    inserter(intersection, intersection.begin()),
                    less<Variable>{});
-  return Variables{move(intersection)};
+  return Variables{std::move(intersection)};
 }
 
 ostream& operator<<(ostream& os, const Variables& vars) {

--- a/common/test/copyable_unique_ptr_test.cc
+++ b/common/test/copyable_unique_ptr_test.cc
@@ -14,7 +14,6 @@ namespace drake {
 namespace  {
 
 using std::make_unique;
-using std::move;
 using std::regex;
 using std::regex_match;
 using std::stringstream;

--- a/common/test/drake_bool_test.cc
+++ b/common/test/drake_bool_test.cc
@@ -10,8 +10,6 @@
 
 namespace drake {
 
-using std::move;
-
 using symbolic::Expression;
 using symbolic::Formula;
 using symbolic::Variable;

--- a/common/test/type_safe_index_test.cc
+++ b/common/test/type_safe_index_test.cc
@@ -22,7 +22,6 @@ namespace {
 
 using std::regex;
 using std::regex_match;
-using std::move;
 
 // Create dummy index types to exercise the functionality
 using AIndex = TypeSafeIndex<class A>;
@@ -35,7 +34,7 @@ GTEST_TEST(TypeSafeIndex, Constructor) {
   EXPECT_EQ(index, 1);                      // This also tests operator==(int).
   AIndex index2(index);                     // Copy constructor.
   EXPECT_EQ(index2, 1);
-  AIndex index3(move(index2));              // Move constructor.
+  AIndex index3(std::move(index2));              // Move constructor.
   EXPECT_EQ(index3, 1);
   EXPECT_FALSE(index2.is_valid());
 
@@ -62,7 +61,7 @@ GTEST_TEST(TypeSafeIndex, IndexAssignment) {
   // Move assignment.
   AIndex index3(2);
   EXPECT_NE(index3, index2);
-  index3 = move(index1);
+  index3 = std::move(index1);
   EXPECT_EQ(index3, index2);
   EXPECT_FALSE(index1.is_valid());
 
@@ -90,7 +89,7 @@ GTEST_TEST(TypeSafeIndex, IndexAssignment) {
     AIndex invalid;
     AIndex target(2);
     EXPECT_TRUE(target.is_valid());
-    DRAKE_EXPECT_NO_THROW(invalid = move(target));
+    DRAKE_EXPECT_NO_THROW(invalid = std::move(target));
     EXPECT_FALSE(target.is_valid());
     EXPECT_EQ(invalid, 2);
   }
@@ -99,7 +98,7 @@ GTEST_TEST(TypeSafeIndex, IndexAssignment) {
   {
     AIndex invalid;
     AIndex target(3);
-    DRAKE_EXPECT_NO_THROW(target = move(invalid));
+    DRAKE_EXPECT_NO_THROW(target = std::move(invalid));
     EXPECT_FALSE(target.is_valid());
     EXPECT_FALSE(invalid.is_valid());
   }

--- a/common/test_utilities/test/is_memcpy_movable_test.cc
+++ b/common/test_utilities/test/is_memcpy_movable_test.cc
@@ -10,7 +10,6 @@ namespace drake {
 namespace test {
 namespace {
 
-using std::move;
 using std::string;
 using std::unique_ptr;
 using std::make_unique;

--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -33,7 +33,6 @@ using math::RigidTransformd;
 using std::array;
 using std::make_unique;
 using std::map;
-using std::move;
 using std::set;
 using std::vector;
 using systems::Context;
@@ -337,8 +336,8 @@ internal::DeformableMeshData MakeDeformableMeshData(
   }
 
   // TODO(xuchenhan-tri): Read the color of the mesh from properties.
-  return {g_id, inspector.GetName(g_id), move(surface_to_volume_vertices),
-          move(surface_triangles), volume_vertex_count};
+  return {g_id, inspector.GetName(g_id), std::move(surface_to_volume_vertices),
+          std::move(surface_triangles), volume_vertex_count};
 }
 
 // Simple class for converting shape specifications into LCM-compatible shapes.

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -36,7 +36,6 @@ using render::ColorRenderCamera;
 using render::DepthRenderCamera;
 using std::make_pair;
 using std::make_unique;
-using std::move;
 using std::set;
 using std::string;
 using std::swap;
@@ -1161,7 +1160,7 @@ void GeometryState<T>::AddRenderer(
         "AddRenderer(): A renderer with the name '{}' already exists", name));
   }
   render::RenderEngine* render_engine = renderer.get();
-  render_engines_[name] = move(renderer);
+  render_engines_[name] = std::move(renderer);
   bool accepted = false;
   for (auto& id_geo_pair : geometries_) {
     InternalGeometry& geometry = id_geo_pair.second;

--- a/geometry/internal_geometry.cc
+++ b/geometry/internal_geometry.cc
@@ -10,7 +10,6 @@ namespace geometry {
 namespace internal {
 
 using math::RigidTransform;
-using std::move;
 
 InternalGeometry::InternalGeometry(SourceId source_id,
                                    std::unique_ptr<Shape> shape,
@@ -22,7 +21,7 @@ InternalGeometry::InternalGeometry(SourceId source_id,
       name_(std::move(name)),
       source_id_(source_id),
       frame_id_(frame_id),
-      X_FG_(move(X_FG)) {}
+      X_FG_(std::move(X_FG)) {}
 
 InternalGeometry::InternalGeometry(SourceId source_id,
                                    std::unique_ptr<Shape> shape,
@@ -35,7 +34,7 @@ InternalGeometry::InternalGeometry(SourceId source_id,
       name_(std::move(name)),
       source_id_(source_id),
       frame_id_(frame_id),
-      X_FG_(move(X_FG)) {
+      X_FG_(std::move(X_FG)) {
   MeshBuilderForDeformable mesh_builder;
   // The mesh_builder builds the mesh in frame G.
   reference_mesh_ = mesh_builder.Build(*shape_spec_, resolution_hint);

--- a/geometry/proximity/deformable_contact_geometries.cc
+++ b/geometry/proximity/deformable_contact_geometries.cc
@@ -12,7 +12,6 @@ namespace deformable {
 namespace {
 
 using std::make_unique;
-using std::move;
 using std::vector;
 
 /* Returns an approximation of the signed distance field inside the given
@@ -37,7 +36,7 @@ ApproximateSignedDistanceField(const VolumeMesh<double>* mesh) {
         -CalcDistanceToSurfaceMesh(vertex, surface_mesh));
   }
   return make_unique<VolumeMeshFieldLinear<double, double>>(
-      move(signed_distance), mesh);
+      std::move(signed_distance), mesh);
 }
 
 }  // namespace

--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -30,7 +30,6 @@ namespace internal {
 namespace hydroelastic {
 
 using std::make_unique;
-using std::move;
 
 SoftMesh& SoftMesh::operator=(const SoftMesh& s) {
   if (this == &s) return *this;
@@ -105,11 +104,11 @@ void Geometries::MakeShape(const ShapeType& shape, const ReifyData& data) {
   switch (data.type) {
     case HydroelasticType::kRigid: {
       auto hydro_geometry = MakeRigidRepresentation(shape, data.properties);
-      if (hydro_geometry) AddGeometry(data.id, move(*hydro_geometry));
+      if (hydro_geometry) AddGeometry(data.id, std::move(*hydro_geometry));
     } break;
     case HydroelasticType::kSoft: {
       auto hydro_geometry = MakeSoftRepresentation(shape, data.properties);
-      if (hydro_geometry) AddGeometry(data.id, move(*hydro_geometry));
+      if (hydro_geometry) AddGeometry(data.id, std::move(*hydro_geometry));
     } break;
     case HydroelasticType::kUndefined:
       // No action required.
@@ -120,13 +119,13 @@ void Geometries::MakeShape(const ShapeType& shape, const ReifyData& data) {
 void Geometries::AddGeometry(GeometryId id, SoftGeometry geometry) {
   DRAKE_DEMAND(hydroelastic_type(id) == HydroelasticType::kUndefined);
   supported_geometries_[id] = HydroelasticType::kSoft;
-  soft_geometries_.insert({id, move(geometry)});
+  soft_geometries_.insert({id, std::move(geometry)});
 }
 
 void Geometries::AddGeometry(GeometryId id, RigidGeometry geometry) {
   DRAKE_DEMAND(hydroelastic_type(id) == HydroelasticType::kUndefined);
   supported_geometries_[id] = HydroelasticType::kRigid;
-  rigid_geometries_.insert({id, move(geometry)});
+  rigid_geometries_.insert({id, std::move(geometry)});
 }
 
 // Validator interface for use with extracting valid properties. It is
@@ -204,7 +203,7 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
   auto mesh = make_unique<TriangleSurfaceMesh<double>>(
       MakeSphereSurfaceMesh<double>(sphere, edge_length));
 
-  return RigidGeometry(RigidMesh(move(mesh)));
+  return RigidGeometry(RigidMesh(std::move(mesh)));
 }
 
 std::optional<RigidGeometry> MakeRigidRepresentation(
@@ -216,7 +215,7 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
   auto mesh = make_unique<TriangleSurfaceMesh<double>>(
       MakeBoxSurfaceMesh<double>(box, 1.1 * box.size().maxCoeff()));
 
-  return RigidGeometry(RigidMesh(move(mesh)));
+  return RigidGeometry(RigidMesh(std::move(mesh)));
 }
 
 std::optional<RigidGeometry> MakeRigidRepresentation(
@@ -226,7 +225,7 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
   auto mesh = make_unique<TriangleSurfaceMesh<double>>(
       MakeCylinderSurfaceMesh<double>(cylinder, edge_length));
 
-  return RigidGeometry(RigidMesh(move(mesh)));
+  return RigidGeometry(RigidMesh(std::move(mesh)));
 }
 
 std::optional<RigidGeometry> MakeRigidRepresentation(
@@ -236,7 +235,7 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
   auto mesh = make_unique<TriangleSurfaceMesh<double>>(
       MakeCapsuleSurfaceMesh<double>(capsule, edge_length));
 
-  return RigidGeometry(RigidMesh(move(mesh)));
+  return RigidGeometry(RigidMesh(std::move(mesh)));
 }
 
 std::optional<RigidGeometry> MakeRigidRepresentation(
@@ -246,7 +245,7 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
   auto mesh = make_unique<TriangleSurfaceMesh<double>>(
       MakeEllipsoidSurfaceMesh<double>(ellipsoid, edge_length));
 
-  return RigidGeometry(RigidMesh(move(mesh)));
+  return RigidGeometry(RigidMesh(std::move(mesh)));
 }
 
 std::optional<RigidGeometry> MakeRigidRepresentation(
@@ -271,7 +270,7 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
         mesh_spec.filename())));
   }
 
-  return RigidGeometry(RigidMesh(move(mesh)));
+  return RigidGeometry(RigidMesh(std::move(mesh)));
 }
 
 std::optional<RigidGeometry> MakeRigidRepresentation(
@@ -281,7 +280,7 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
       make_unique<TriangleSurfaceMesh<double>>(ReadObjToTriangleSurfaceMesh(
           convex_spec.filename(), convex_spec.scale()));
 
-  return RigidGeometry(RigidMesh(move(mesh)));
+  return RigidGeometry(RigidMesh(std::move(mesh)));
 }
 
 std::optional<SoftGeometry> MakeSoftRepresentation(
@@ -302,7 +301,7 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
       MakeSpherePressureField(sphere, mesh.get(), hydroelastic_modulus));
 
-  return SoftGeometry(SoftMesh(move(mesh), move(pressure)));
+  return SoftGeometry(SoftMesh(std::move(mesh), std::move(pressure)));
 }
 
 std::optional<SoftGeometry> MakeSoftRepresentation(
@@ -318,7 +317,7 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
       MakeBoxPressureField(box, mesh.get(), hydroelastic_modulus));
 
-  return SoftGeometry(SoftMesh(move(mesh), move(pressure)));
+  return SoftGeometry(SoftMesh(std::move(mesh), std::move(pressure)));
 }
 
 std::optional<SoftGeometry> MakeSoftRepresentation(
@@ -335,7 +334,7 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
       MakeCylinderPressureField(cylinder, mesh.get(), hydroelastic_modulus));
 
-  return SoftGeometry(SoftMesh(move(mesh), move(pressure)));
+  return SoftGeometry(SoftMesh(std::move(mesh), std::move(pressure)));
 }
 
 std::optional<SoftGeometry> MakeSoftRepresentation(
@@ -352,7 +351,7 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
       MakeCapsulePressureField(capsule, mesh.get(), hydroelastic_modulus));
 
-  return SoftGeometry(SoftMesh(move(mesh), move(pressure)));
+  return SoftGeometry(SoftMesh(std::move(mesh), std::move(pressure)));
 }
 
 std::optional<SoftGeometry> MakeSoftRepresentation(
@@ -373,7 +372,7 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
       MakeEllipsoidPressureField(ellipsoid, mesh.get(), hydroelastic_modulus));
 
-  return SoftGeometry(SoftMesh(move(mesh), move(pressure)));
+  return SoftGeometry(SoftMesh(std::move(mesh), std::move(pressure)));
 }
 
 std::optional<SoftGeometry> MakeSoftRepresentation(
@@ -402,7 +401,7 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
       MakeConvexPressureField(mesh.get(), hydroelastic_modulus));
 
-  return SoftGeometry(SoftMesh(move(mesh), move(pressure)));
+  return SoftGeometry(SoftMesh(std::move(mesh), std::move(pressure)));
 }
 
 std::optional<SoftGeometry> MakeSoftRepresentation(
@@ -418,7 +417,7 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
       MakeVolumeMeshPressureField(mesh.get(), hydroelastic_modulus));
 
-  return SoftGeometry(SoftMesh(move(mesh), move(pressure)));
+  return SoftGeometry(SoftMesh(std::move(mesh), std::move(pressure)));
 }
 
 

--- a/geometry/proximity/polygon_surface_mesh.cc
+++ b/geometry/proximity/polygon_surface_mesh.cc
@@ -6,7 +6,6 @@ namespace drake {
 namespace geometry {
 
 using math::RigidTransform;
-using std::move;
 using std::vector;
 
 std::unique_ptr<SurfacePolygon> SurfacePolygon::copy_to_unique() const {
@@ -17,8 +16,8 @@ std::unique_ptr<SurfacePolygon> SurfacePolygon::copy_to_unique() const {
 template <typename T>
 PolygonSurfaceMesh<T>::PolygonSurfaceMesh(vector<int> face_data,
                                           vector<Vector3<T>> vertices)
-    : face_data_(move(face_data)),
-      vertices_M_(move(vertices)),
+    : face_data_(std::move(face_data)),
+      vertices_M_(std::move(vertices)),
       p_MSc_(Vector3<T>::Zero()) {
   /* Build the polygons and derived quantities from the given data. */
   int poly_count = -1;

--- a/geometry/proximity/test/contact_surface_test.cc
+++ b/geometry/proximity/test/contact_surface_test.cc
@@ -31,7 +31,6 @@ namespace {
 
 using Eigen::Vector3d;
 using std::make_unique;
-using std::move;
 using std::unique_ptr;
 using std::vector;
 

--- a/geometry/proximity/test/contact_surface_utility_test.cc
+++ b/geometry/proximity/test/contact_surface_utility_test.cc
@@ -23,7 +23,6 @@ using Eigen::AngleAxisd;
 using Eigen::Vector3d;
 using math::RigidTransformd;
 using math::RotationMatrixd;
-using std::move;
 using std::unique_ptr;
 using std::vector;
 

--- a/geometry/proximity/test/deformable_contact_geometries_test.cc
+++ b/geometry/proximity/test/deformable_contact_geometries_test.cc
@@ -17,7 +17,6 @@ namespace {
 using Eigen::Vector3d;
 using Eigen::VectorXd;
 using std::make_unique;
-using std::move;
 
 /* Constructs a coarse sphere (octahedron) whose vertices are transformed from
  the canonical sphere frame S to some arbitrary frame F. */
@@ -34,7 +33,7 @@ VolumeMesh<double> MakeTransformedSphere(double radius,
     vertices_F.push_back(X_FS * mesh_S.vertex(v));
   }
   std::vector<VolumeElement> tets_F(mesh_S.tetrahedra());
-  return VolumeMesh<double>(move(tets_F), move(vertices_F));
+  return VolumeMesh<double>(std::move(tets_F), std::move(vertices_F));
 }
 
 GTEST_TEST(DeformableGeometryTest, Constructor) {
@@ -168,7 +167,7 @@ GTEST_TEST(DeformableGeometryTest, UpdateVertexPositions) {
   VolumeMesh<double> mesh = MakeSphereVolumeMesh<double>(
       sphere, 0.5, TessellationStrategy::kDenseInteriorVertices);
   const int num_vertices = mesh.num_vertices();
-  DeformableGeometry deformable_geometry(move(mesh));
+  DeformableGeometry deformable_geometry(std::move(mesh));
   const VectorXd q = VectorXd::LinSpaced(3 * num_vertices, 0.0, 1.0);
   deformable_geometry.UpdateVertexPositions(q);
   const VolumeMesh<double> deformed_mesh =
@@ -185,8 +184,8 @@ GTEST_TEST(RigidGeometryTest, Pose) {
   const double resolution_hint = 0.5;
   auto mesh = make_unique<TriangleSurfaceMesh<double>>(
       MakeSphereSurfaceMesh<double>(sphere, resolution_hint));
-  auto rigid_mesh = make_unique<hydroelastic::RigidMesh>(move(mesh));
-  RigidGeometry rigid_geometry(move(rigid_mesh));
+  auto rigid_mesh = make_unique<hydroelastic::RigidMesh>(std::move(mesh));
+  RigidGeometry rigid_geometry(std::move(rigid_mesh));
   const math::RigidTransform<double> X_WG(
       math::RollPitchYaw<double>(-1.57, 0, 3), Vector3d(-0.3, -0.55, 0.36));
   rigid_geometry.set_pose_in_world(X_WG);

--- a/geometry/proximity/test/mesh_half_space_intersection_test.cc
+++ b/geometry/proximity/test/mesh_half_space_intersection_test.cc
@@ -29,7 +29,6 @@ using math::RigidTransformd;
 using math::RotationMatrix;
 using math::RotationMatrixd;
 using std::make_unique;
-using std::move;
 using std::pair;
 using std::unique_ptr;
 using std::vector;

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -43,7 +43,6 @@ using math::RigidTransform;
 using math::RigidTransformd;
 using std::make_shared;
 using std::make_unique;
-using std::move;
 using std::shared_ptr;
 using std::unique_ptr;
 using std::unordered_map;

--- a/geometry/query_results/contact_surface.cc
+++ b/geometry/query_results/contact_surface.cc
@@ -6,7 +6,6 @@ namespace drake {
 namespace geometry {
 
 using std::make_unique;
-using std::move;
 using std::unique_ptr;
 using std::vector;
 

--- a/geometry/query_results/deformable_contact.cc
+++ b/geometry/query_results/deformable_contact.cc
@@ -7,7 +7,6 @@ namespace geometry {
 namespace internal {
 
 using multibody::contact_solvers::internal::PartialPermutation;
-using std::move;
 
 namespace {
 
@@ -53,7 +52,7 @@ PartialPermutation ContactParticipation::CalcVertexPartialPermutation() const {
       permuted_vertex_indexes[v] = permuted_vertex_index++;
     }
   }
-  return PartialPermutation(move(permuted_vertex_indexes));
+  return PartialPermutation(std::move(permuted_vertex_indexes));
 }
 
 PartialPermutation ContactParticipation::CalcDofPermutation() const {
@@ -74,7 +73,7 @@ PartialPermutation ContactParticipation::CalcDofPartialPermutation() const {
       ++permuted_vertex_index;
     }
   }
-  return PartialPermutation(move(permuted_dof_indexes));
+  return PartialPermutation(std::move(permuted_dof_indexes));
 }
 
 template <typename T>
@@ -87,12 +86,12 @@ DeformableContactSurface<T>::DeformableContactSurface(
     std::optional<std::vector<Vector4<T>>> barycentric_coordinates_B)
     : id_A_(id_A),
       id_B_(id_B),
-      contact_mesh_W_(move(contact_mesh_W)),
-      signed_distances_(move(signed_distances)),
-      contact_vertex_indexes_A_(move(contact_vertex_indexes_A)),
-      barycentric_coordinates_A_(move(barycentric_coordinates_A)),
-      contact_vertex_indexes_B_(move(contact_vertex_indexes_B)),
-      barycentric_coordinates_B_(move(barycentric_coordinates_B)) {
+      contact_mesh_W_(std::move(contact_mesh_W)),
+      signed_distances_(std::move(signed_distances)),
+      contact_vertex_indexes_A_(std::move(contact_vertex_indexes_A)),
+      barycentric_coordinates_A_(std::move(barycentric_coordinates_A)),
+      contact_vertex_indexes_B_(std::move(contact_vertex_indexes_B)),
+      barycentric_coordinates_B_(std::move(barycentric_coordinates_B)) {
   const int num_contact_points = contact_mesh_W_.num_faces();
   DRAKE_DEMAND(num_contact_points ==
                static_cast<int>(signed_distances_.size()));
@@ -133,9 +132,9 @@ void DeformableContact<T>::AddDeformableRigidContactSurface(
                contact_mesh_W.num_faces());
   iter->second.Participate(participating_vertices);
   contact_surfaces_.emplace_back(
-      deformable_id, rigid_id, move(contact_mesh_W), move(signed_distances),
-      move(contact_vertex_indexes), move(barycentric_coordinates), std::nullopt,
-      std::nullopt);
+      deformable_id, rigid_id, std::move(contact_mesh_W),
+      std::move(signed_distances), std::move(contact_vertex_indexes),
+      std::move(barycentric_coordinates), std::nullopt, std::nullopt);
 }
 
 template class DeformableContactSurface<double>;

--- a/geometry/render_gl/internal_render_engine_gl.cc
+++ b/geometry/render_gl/internal_render_engine_gl.cc
@@ -20,7 +20,6 @@ using Eigen::Vector3d;
 using math::RigidTransformd;
 using std::make_shared;
 using std::make_unique;
-using std::move;
 using std::string;
 using std::unique_ptr;
 using std::unordered_map;
@@ -405,7 +404,7 @@ class DefaultLabelShader final : public ShaderProgram {
   */
   explicit DefaultLabelShader(
       std::function<Vector4<float>(const PerceptionProperties&)> label_encoder)
-      : ShaderProgram(), label_encoder_(move(label_encoder)) {
+      : ShaderProgram(), label_encoder_(std::move(label_encoder)) {
     LoadFromSources(kVertexShader, kFragmentShader);
     encoded_label_loc_ = GetUniformLocation("encoded_label");
   }
@@ -1110,7 +1109,7 @@ ShaderId RenderEngineGl::AddShader(std::unique_ptr<ShaderProgram> program,
                                    RenderType render_type) {
   const ShaderId shader_id = program->shader_id();
   shader_families_[render_type].insert({shader_id, vector<GeometryId>()});
-  shader_programs_[render_type][shader_id] = move(program);
+  shader_programs_[render_type][shader_id] = std::move(program);
   return shader_id;
 }
 
@@ -1125,7 +1124,7 @@ ShaderProgramData RenderEngineGl::GetShaderProgram(
       if (data.has_value()) {
         if (candidate_data->shader_id() < data->shader_id()) continue;
       }
-      data = move(candidate_data);
+      data = std::move(candidate_data);
     }
   }
   // There should always be, at least, the default shader that accepts the

--- a/geometry/test/collision_filter_manager_test.cc
+++ b/geometry/test/collision_filter_manager_test.cc
@@ -24,7 +24,6 @@ namespace {
 using math::RigidTransformd;
 using std::array;
 using std::make_unique;
-using std::move;
 using std::unique_ptr;
 
 // Convenience function for making a geometry instance.
@@ -176,7 +175,7 @@ GTEST_TEST(CollisionFilterManagerTest, MoveSemantics) {
   // Move construct a filter from the model. A modification to the copy should
   // be visible in the original model_filter but not the context.
   CollisionFilterManager model_filter = scene_graph.collision_filter_manager();
-  CollisionFilterManager copy_filter(move(model_filter));
+  CollisionFilterManager copy_filter(std::move(model_filter));
   copy_filter.Apply(
       CollisionFilterDeclaration().ExcludeWithin(GeometrySet{g_id1, g_id2}));
   EXPECT_TRUE(model_inspector.CollisionFiltered(g_id1, g_id2));
@@ -186,7 +185,7 @@ GTEST_TEST(CollisionFilterManagerTest, MoveSemantics) {
   // be visible to the context inspector but not model inspector.
   CollisionFilterManager context_filter =
       scene_graph.collision_filter_manager(context.get());
-  copy_filter = move(context_filter);
+  copy_filter = std::move(context_filter);
   copy_filter.Apply(
       CollisionFilterDeclaration().ExcludeWithin(GeometrySet{g_id1, g_id3}));
   EXPECT_FALSE(model_inspector.CollisionFiltered(g_id1, g_id3));

--- a/geometry/test/drake_visualizer_test.cc
+++ b/geometry/test/drake_visualizer_test.cc
@@ -39,7 +39,6 @@ using math::RigidTransformd;
 using math::RotationMatrixd;
 using std::make_unique;
 using std::map;
-using std::move;
 using std::string;
 using std::unique_ptr;
 using std::vector;
@@ -99,7 +98,7 @@ class PoseSource : public systems::LeafSystem<T> {
                                     &PoseSource<T>::ReadPoses);
   }
 
-  void SetPoses(FramePoseVector<T> poses) { poses_ = move(poses); }
+  void SetPoses(FramePoseVector<T> poses) { poses_ = std::move(poses); }
 
  private:
   void ReadPoses(const Context<T>&, FramePoseVector<T>* poses) const {
@@ -122,7 +121,7 @@ class ConfigurationSource : public systems::LeafSystem<T> {
 
   void SetConfigurations(
     GeometryConfigurationVector<T> configurations) {
-    configurations_ = move(configurations);
+    configurations_ = std::move(configurations);
   }
 
  private:
@@ -160,8 +159,8 @@ class DrakeVisualizerTest : public ::testing::Test {
   void ConfigureDiagram(DrakeVisualizerParams params = {}) {
     DiagramBuilder<T> builder;
     scene_graph_ = builder.template AddSystem<SceneGraph<T>>();
-    visualizer_ =
-        builder.template AddSystem<DrakeVisualizer<T>>(&lcm_, move(params));
+    visualizer_ = builder.template AddSystem<DrakeVisualizer<T>>(
+        &lcm_, std::move(params));
     builder.Connect(scene_graph_->get_query_output_port(),
                     visualizer_->query_object_input_port());
     pose_source_id_ = scene_graph_->RegisterSource(kPoseSourceName);
@@ -869,7 +868,7 @@ TYPED_TEST(DrakeVisualizerTest, VisualizeDeformableGeometry) {
       RigidTransformd::Identity(), make_unique<Sphere>(kRadius), "sphere");
   GeometryId g_id = this->scene_graph_->RegisterDeformableGeometry(
       this->configuration_source_id_, this->scene_graph_->world_frame_id(),
-      move(geometry_instance), kRezHint);
+      std::move(geometry_instance), kRezHint);
   const auto& inspector = this->scene_graph_->model_inspector();
   const VolumeMesh<double>* mesh = inspector.GetReferenceMesh(g_id);
   ASSERT_NE(mesh, nullptr);
@@ -954,7 +953,7 @@ TYPED_TEST(DrakeVisualizerTest, VisualizeHydroGeometry) {
         this->pose_source_id_, GeometryFrame(name, 0));
     const GeometryId g_id = this->scene_graph_->RegisterGeometry(
         this->pose_source_id_, f_id,
-        make_unique<GeometryInstance>(X_PG, move(shape_u_p), name));
+        make_unique<GeometryInstance>(X_PG, std::move(shape_u_p), name));
     this->scene_graph_->AssignRole(this->pose_source_id_, g_id, properties);
     poses.set_value(f_id, RigidTransform<T>{});
   };
@@ -984,7 +983,7 @@ TYPED_TEST(DrakeVisualizerTest, VisualizeHydroGeometry) {
   add_geometry(make_unique<Sphere>(1), "sphere", props, X_PSphere);
   add_geometry(make_unique<HalfSpace>(), "soft_half_space", props);
 
-  this->pose_source_->SetPoses(move(poses));
+  this->pose_source_->SetPoses(std::move(poses));
 
   /* Dispatch a load message. */
   auto context = this->diagram_->CreateDefaultContext();

--- a/geometry/test/geometry_frame_test.cc
+++ b/geometry/test/geometry_frame_test.cc
@@ -12,7 +12,6 @@ namespace geometry {
 namespace {
 
 using std::make_unique;
-using std::move;
 
 GTEST_TEST(GeometryFrameTest, Constructor) {
   // Case: use default frame group.

--- a/geometry/test/geometry_instance_test.cc
+++ b/geometry/test/geometry_instance_test.cc
@@ -14,7 +14,6 @@ namespace {
 
 using math::RigidTransformd;
 using std::make_unique;
-using std::move;
 
 // Confirms that the instance is copyable.
 GTEST_TEST(GeometryInstanceTest, IsCopyable) {

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -43,7 +43,6 @@ using math::RigidTransformd;
 using render::RenderLabel;
 using std::make_unique;
 using std::map;
-using std::move;
 using std::optional;
 using std::pair;
 using std::set;
@@ -425,7 +424,7 @@ class GeometryStateTestBase {
     if (add_renderer) {
       auto render_engine = make_unique<DummyRenderEngine>();
       render_engine_ = render_engine.get();
-      geometry_state_.AddRenderer(kDummyRenderName, move(render_engine));
+      geometry_state_.AddRenderer(kDummyRenderName, std::move(render_engine));
     }
   }
 
@@ -562,7 +561,7 @@ class GeometryStateTestBase {
     auto instance = make_unique<GeometryInstance>(
         RigidTransformd::Identity(), make_unique<Sphere>(sphere), "sphere");
     geometry_state_.RegisterDeformableGeometry(
-        s_id, InternalFrame::world_frame_id(), move(instance), kRezHint);
+        s_id, InternalFrame::world_frame_id(), std::move(instance), kRezHint);
     return s_id;
   }
 
@@ -1329,7 +1328,7 @@ TEST_F(GeometryStateTest, GetGeometryTest) {
     auto instance = make_unique<GeometryInstance>(
         RigidTransformd::Identity(), make_unique<Sphere>(1), "shape");
     const GeometryId new_id =
-        geometry_state_.RegisterGeometry(source_id_, f_id, move(instance));
+        geometry_state_.RegisterGeometry(source_id_, f_id, std::move(instance));
 
     // Build the expected answers.
     const auto first_geometry_iter = geometries_.begin() + i * kGeometryCount;
@@ -1489,7 +1488,7 @@ TEST_F(GeometryStateTest, RegisterGeometryGoodSource) {
   const FrameId f_id = geometry_state_.RegisterFrame(s_id, *frame_);
   const GeometryId expected_g_id = instance_->id();
   const GeometryId g_id =
-      geometry_state_.RegisterGeometry(s_id, f_id, move(instance_));
+      geometry_state_.RegisterGeometry(s_id, f_id, std::move(instance_));
   EXPECT_EQ(g_id, expected_g_id);
   EXPECT_EQ(geometry_state_.GetFrameId(g_id), f_id);
   EXPECT_TRUE(geometry_state_.BelongsToSource(g_id, s_id));
@@ -1525,7 +1524,7 @@ TEST_F(GeometryStateTest, AddGeometryUpdatesX_WG) {
     auto instance = make_unique<GeometryInstance>(
         instance_pose_, make_unique<Sphere>(1.0), "instance");
     const GeometryId g_id =
-        geometry_state_.RegisterGeometry(s_id, f_id, move(instance));
+        geometry_state_.RegisterGeometry(s_id, f_id, std::move(instance));
     const RigidTransformd X_WG_expected = X_WF * instance_->pose();
     EXPECT_TRUE(
         CompareMatrices(geometry_state_.get_pose_in_world(g_id).GetAsMatrix34(),
@@ -1538,9 +1537,9 @@ TEST_F(GeometryStateTest, RegisterDuplicateGeometry) {
   const SourceId s_id = NewSource();
   const FrameId f_id = geometry_state_.RegisterFrame(s_id, *frame_);
   auto instance_copy = make_unique<GeometryInstance>(*instance_);
-  geometry_state_.RegisterGeometry(s_id, f_id, move(instance_));
+  geometry_state_.RegisterGeometry(s_id, f_id, std::move(instance_));
   DRAKE_EXPECT_THROWS_MESSAGE(
-      geometry_state_.RegisterGeometry(s_id, f_id, move(instance_copy)),
+      geometry_state_.RegisterGeometry(s_id, f_id, std::move(instance_copy)),
       "Registering geometry with an id that has already been registered: \\d+");
 }
 
@@ -1549,7 +1548,7 @@ TEST_F(GeometryStateTest, RegisterGeometryMissingSource) {
   const SourceId s_id = SourceId::get_new_id();
   const FrameId f_id = FrameId::get_new_id();
   DRAKE_EXPECT_THROWS_MESSAGE(
-      geometry_state_.RegisterGeometry(s_id, f_id, move(instance_)),
+      geometry_state_.RegisterGeometry(s_id, f_id, std::move(instance_)),
       "Referenced geometry source \\d+ is not registered.");
 }
 
@@ -1558,7 +1557,7 @@ TEST_F(GeometryStateTest, RegisterGeometryMissingFrame) {
   const SourceId s_id = NewSource();
   const FrameId f_id = FrameId::get_new_id();
   DRAKE_EXPECT_THROWS_MESSAGE(
-      geometry_state_.RegisterGeometry(s_id, f_id, move(instance_)),
+      geometry_state_.RegisterGeometry(s_id, f_id, std::move(instance_)),
       "Referenced frame \\d+ for source \\d+\\,"
       " but the frame doesn't belong to the source.");
 }
@@ -1569,7 +1568,7 @@ TEST_F(GeometryStateTest, RegisterNullGeometry) {
   const FrameId f_id = geometry_state_.RegisterFrame(s_id, *frame_);
   unique_ptr<GeometryInstance> null_geometry;
   DRAKE_EXPECT_THROWS_MESSAGE(
-      geometry_state_.RegisterGeometry(s_id, f_id, move(null_geometry)),
+      geometry_state_.RegisterGeometry(s_id, f_id, std::move(null_geometry)),
       "Registering null geometry to frame \\d+, on source \\d+.");
 }
 
@@ -1580,7 +1579,7 @@ TEST_F(GeometryStateTest, RegisterAnchoredGeometry) {
       RigidTransformd::Identity(), make_unique<Sphere>(1), "sphere");
   const GeometryId expected_g_id = instance->id();
   const auto g_id =
-      geometry_state_.RegisterAnchoredGeometry(s_id, move(instance));
+      geometry_state_.RegisterAnchoredGeometry(s_id, std::move(instance));
   EXPECT_EQ(g_id, expected_g_id);
   EXPECT_TRUE(geometry_state_.BelongsToSource(g_id, s_id));
   const InternalGeometry* g = gs_tester_.GetGeometry(g_id);
@@ -1593,9 +1592,9 @@ TEST_F(GeometryStateTest, RegisterAnchoredGeometry) {
 TEST_F(GeometryStateTest, RegisterDuplicateAnchoredGeometry) {
   const SourceId s_id = NewSource();
   auto instance_copy = make_unique<GeometryInstance>(*instance_);
-  geometry_state_.RegisterAnchoredGeometry(s_id, move(instance_));
+  geometry_state_.RegisterAnchoredGeometry(s_id, std::move(instance_));
   DRAKE_EXPECT_THROWS_MESSAGE(
-      geometry_state_.RegisterAnchoredGeometry(s_id, move(instance_copy)),
+      geometry_state_.RegisterAnchoredGeometry(s_id, std::move(instance_copy)),
       "Registering geometry with an id that has already been "
       "registered: \\d+");
 }
@@ -1606,7 +1605,7 @@ TEST_F(GeometryStateTest, RegisterAnchoredGeometryInvalidSource) {
       RigidTransformd::Identity(), make_unique<Sphere>(1), "sphere");
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.RegisterAnchoredGeometry(SourceId::get_new_id(),
-                                               move(instance)),
+                                               std::move(instance)),
       "Referenced geometry source \\d+ is not registered.");
 }
 
@@ -1616,7 +1615,7 @@ TEST_F(GeometryStateTest, RegisterAnchoredNullGeometry) {
   unique_ptr<GeometryInstance> instance;
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.RegisterAnchoredGeometry(SourceId::get_new_id(),
-                                               move(instance)),
+                                               std::move(instance)),
       "Registering null geometry to frame \\d+, on source \\d+.");
 }
 
@@ -1635,8 +1634,8 @@ TEST_F(GeometryStateTest, RegisterDeformableGeometry) {
   auto instance1 = make_unique<GeometryInstance>(
       RigidTransformd::Identity(), make_unique<Sphere>(sphere), "sphere");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      geometry_state_.RegisterDeformableGeometry(s_id, f_id, move(instance1),
-                                                 kRezHint),
+      geometry_state_.RegisterDeformableGeometry(
+          s_id, f_id, std::move(instance1), kRezHint),
       "Registering deformable geometry.*non-world frame.*");
 
   /* Successful registration of deformable geometry. */
@@ -1646,7 +1645,7 @@ TEST_F(GeometryStateTest, RegisterDeformableGeometry) {
       X_WG, make_unique<Sphere>(sphere), "sphere");
   const GeometryId expected_g_id = instance2->id();
   const auto g_id = geometry_state_.RegisterDeformableGeometry(
-      s_id, InternalFrame::world_frame_id(), move(instance2), kRezHint);
+      s_id, InternalFrame::world_frame_id(), std::move(instance2), kRezHint);
   EXPECT_EQ(g_id, expected_g_id);
   EXPECT_TRUE(geometry_state_.IsDeformableGeometry(g_id));
 
@@ -1654,7 +1653,7 @@ TEST_F(GeometryStateTest, RegisterDeformableGeometry) {
   auto instance3 = make_unique<GeometryInstance>(
       RigidTransformd::Identity(), make_unique<Sphere>(sphere), "sphere");
   const GeometryId non_deformable_g_id =
-      geometry_state_.RegisterGeometry(s_id, f_id, move(instance3));
+      geometry_state_.RegisterGeometry(s_id, f_id, std::move(instance3));
   EXPECT_FALSE(geometry_state_.IsDeformableGeometry(non_deformable_g_id));
 
   // Verify the reference mesh of the deformable geometry matches the input.
@@ -1712,9 +1711,9 @@ TEST_F(GeometryStateTest, GetAllDeformableGeometryIds) {
 
   /* Register in counter-intuitive order. */
   geometry_state_.RegisterDeformableGeometry(
-      s2_id, InternalFrame::world_frame_id(), move(instance2), kRezHint);
+      s2_id, InternalFrame::world_frame_id(), std::move(instance2), kRezHint);
   geometry_state_.RegisterDeformableGeometry(
-      s1_id, InternalFrame::world_frame_id(), move(instance1), kRezHint);
+      s1_id, InternalFrame::world_frame_id(), std::move(instance1), kRezHint);
 
   /* Confirm that we get the expected ids in the expected order. */
   const vector<GeometryId> deformable_ids =
@@ -1956,7 +1955,7 @@ TEST_F(GeometryStateTest, SetGeometryConfiguration) {
       "deformable sphere");
   deformable_instance->set_proximity_properties(ProximityProperties());
   const auto deformable_id = geometry_state_.RegisterDeformableGeometry(
-      s_id, InternalFrame::world_frame_id(), move(deformable_instance),
+      s_id, InternalFrame::world_frame_id(), std::move(deformable_instance),
       /* resolution_hint */ 2.0);
   // Add a rigid geometry with a resolution hint (so that it can be in contact
   // with deformable geometries).
@@ -1965,10 +1964,10 @@ TEST_F(GeometryStateTest, SetGeometryConfiguration) {
       "rigid_box");
   ProximityProperties rigid_properties;
   rigid_properties.AddProperty(internal::kHydroGroup, internal::kRezHint, 1.0);
-  rigid_instance->set_proximity_properties(move(rigid_properties));
+  rigid_instance->set_proximity_properties(std::move(rigid_properties));
   const FrameId f_id =
       geometry_state_.RegisterFrame(s_id, GeometryFrame("frame"));
-  geometry_state_.RegisterGeometry(s_id, f_id, move(rigid_instance));
+  geometry_state_.RegisterGeometry(s_id, f_id, std::move(rigid_instance));
 
   // Update the deformable geometry's configuration by translating it away from
   // the rigid geometry.
@@ -3052,7 +3051,7 @@ TEST_F(GeometryStateTest, InstanceRoleAssignment) {
     auto instance = make_instance("instance2");
     instance->set_proximity_properties(ProximityProperties());
     const GeometryId g_id =
-        geometry_state_.RegisterGeometry(s_id, f_id, move(instance));
+        geometry_state_.RegisterGeometry(s_id, f_id, std::move(instance));
 
     const InternalGeometry* geometry = gs_tester_.GetGeometry(g_id);
     EXPECT_TRUE(geometry->has_proximity_role());
@@ -3065,7 +3064,7 @@ TEST_F(GeometryStateTest, InstanceRoleAssignment) {
     auto instance = make_instance("instance3");
     instance->set_illustration_properties(IllustrationProperties());
     const GeometryId g_id =
-        geometry_state_.RegisterGeometry(s_id, f_id, move(instance));
+        geometry_state_.RegisterGeometry(s_id, f_id, std::move(instance));
 
     const InternalGeometry* geometry = gs_tester_.GetGeometry(g_id);
     EXPECT_FALSE(geometry->has_proximity_role());
@@ -3078,7 +3077,7 @@ TEST_F(GeometryStateTest, InstanceRoleAssignment) {
     auto instance = make_instance("instance4");
     instance->set_perception_properties(perception_props);
     const GeometryId g_id =
-        geometry_state_.RegisterGeometry(s_id, f_id, move(instance));
+        geometry_state_.RegisterGeometry(s_id, f_id, std::move(instance));
 
     const InternalGeometry* geometry = gs_tester_.GetGeometry(g_id);
     EXPECT_FALSE(geometry->has_proximity_role());
@@ -3093,7 +3092,7 @@ TEST_F(GeometryStateTest, InstanceRoleAssignment) {
     instance->set_illustration_properties(IllustrationProperties());
     instance->set_perception_properties(perception_props);
     const GeometryId g_id =
-        geometry_state_.RegisterGeometry(s_id, f_id, move(instance));
+        geometry_state_.RegisterGeometry(s_id, f_id, std::move(instance));
 
     const InternalGeometry* geometry = gs_tester_.GetGeometry(g_id);
     EXPECT_TRUE(geometry->has_proximity_role());
@@ -3364,7 +3363,7 @@ TEST_F(GeometryStateTest, RemoveGeometryFromRenderer) {
   const string other_renderer_name = "alt_renderer";
   auto temp_engine = make_unique<DummyRenderEngine>();
   const DummyRenderEngine& other_engine = *temp_engine;
-  geometry_state_.AddRenderer(other_renderer_name, move(temp_engine));
+  geometry_state_.AddRenderer(other_renderer_name, std::move(temp_engine));
 
   SetUpSingleSourceTree(Assign::kPerception);
 
@@ -3440,7 +3439,7 @@ TEST_F(GeometryStateTest, RemoveFrameFromRenderer) {
   const string other_renderer_name = "alt_renderer";
   auto temp_engine = make_unique<DummyRenderEngine>();
   const DummyRenderEngine& other_engine = *temp_engine;
-  geometry_state_.AddRenderer(other_renderer_name, move(temp_engine));
+  geometry_state_.AddRenderer(other_renderer_name, std::move(temp_engine));
 
   SetUpSingleSourceTree(Assign::kPerception);
 
@@ -3549,7 +3548,7 @@ TEST_F(GeometryStateTest, AddRendererAfterGeometry) {
   // The new renderer has no geometry assigned.
   EXPECT_EQ(other_renderer->num_registered(), 0);
   const string other_name = "other";
-  geometry_state_.AddRenderer(other_name, move(new_renderer));
+  geometry_state_.AddRenderer(other_name, std::move(new_renderer));
   // The new renderer only has the geometries with perception properties
   // assigned.
   EXPECT_EQ(other_renderer->num_registered(),
@@ -3601,7 +3600,7 @@ TEST_F(GeometryStateTest, RespectAcceptingRendererProperty) {
   auto new_renderer = make_unique<DummyRenderEngine>();
   const DummyRenderEngine& second_renderer = *new_renderer.get();
   const string second_name = "second_renderer";
-  geometry_state_.AddRenderer(second_name, move(new_renderer));
+  geometry_state_.AddRenderer(second_name, std::move(new_renderer));
   ASSERT_TRUE(geometry_state_.HasRenderer(second_name));
 
   ASSERT_EQ(first_renderer.num_registered(), 0);
@@ -3626,7 +3625,7 @@ TEST_F(GeometryStateTest, RespectAcceptingRendererProperty) {
     PerceptionProperties properties(base_properties);
     properties.AddProperty("renderer", "accepting", set<string>{});
     const GeometryId id = geometries_[1];
-    geometry_state_.AssignRole(source_id_, id, move(properties));
+    geometry_state_.AssignRole(source_id_, id, std::move(properties));
     EXPECT_TRUE(first_renderer.is_registered(id));
     EXPECT_TRUE(second_renderer.is_registered(id));
   }
@@ -3637,7 +3636,7 @@ TEST_F(GeometryStateTest, RespectAcceptingRendererProperty) {
     properties.AddProperty("renderer", "accepting",
                            set<string>{kDummyRenderName});
     const GeometryId id = geometries_[2];
-    geometry_state_.AssignRole(source_id_, id, move(properties));
+    geometry_state_.AssignRole(source_id_, id, std::move(properties));
     EXPECT_TRUE(first_renderer.is_registered(id));
     EXPECT_FALSE(second_renderer.is_registered(id));
   }
@@ -3647,7 +3646,7 @@ TEST_F(GeometryStateTest, RespectAcceptingRendererProperty) {
     PerceptionProperties properties(base_properties);
     properties.AddProperty("renderer", "accepting", set<string>{second_name});
     const GeometryId id = geometries_[3];
-    geometry_state_.AssignRole(source_id_, id, move(properties));
+    geometry_state_.AssignRole(source_id_, id, std::move(properties));
     EXPECT_FALSE(first_renderer.is_registered(id));
     EXPECT_TRUE(second_renderer.is_registered(id));
   }
@@ -3657,7 +3656,7 @@ TEST_F(GeometryStateTest, RespectAcceptingRendererProperty) {
     PerceptionProperties properties(base_properties);
     properties.AddProperty("renderer", "accepting", set<string>{"junk"});
     const GeometryId id = geometries_[4];
-    geometry_state_.AssignRole(source_id_, id, move(properties));
+    geometry_state_.AssignRole(source_id_, id, std::move(properties));
     EXPECT_FALSE(first_renderer.is_registered(id));
     EXPECT_FALSE(second_renderer.is_registered(id));
   }
@@ -3668,7 +3667,7 @@ TEST_F(GeometryStateTest, RespectAcceptingRendererProperty) {
     properties.AddProperty("renderer", "accepting",
                            set<string>{kDummyRenderName, second_name});
     const GeometryId id = geometries_[5];
-    geometry_state_.AssignRole(source_id_, id, move(properties));
+    geometry_state_.AssignRole(source_id_, id, std::move(properties));
     EXPECT_TRUE(first_renderer.is_registered(id));
     EXPECT_TRUE(second_renderer.is_registered(id));
   }
@@ -3741,7 +3740,7 @@ TEST_F(GeometryStateTest, PostHocRenderEngineRespectAcceptingRenderer) {
   auto second_renderer_owned = make_unique<DummyRenderEngine>();
   const DummyRenderEngine& second_renderer = *second_renderer_owned.get();
 
-  geometry_state_.AddRenderer(second_name, move(second_renderer_owned));
+  geometry_state_.AddRenderer(second_name, std::move(second_renderer_owned));
   ASSERT_TRUE(geometry_state_.HasRenderer(second_name));
 
   EXPECT_EQ(second_renderer.num_registered(), 3);
@@ -3762,7 +3761,7 @@ TEST_F(GeometryStateTest, RendererPoseUpdate) {
   auto render_engine = make_unique<DummyRenderEngine>();
   DummyRenderEngine* second_engine = render_engine.get();
   const std::string second_engine_name = "second_engine";
-  geometry_state_.AddRenderer(second_engine_name, move(render_engine));
+  geometry_state_.AddRenderer(second_engine_name, std::move(render_engine));
 
   SetUpSingleSourceTree(Assign::kPerception);
 

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -115,7 +115,6 @@ using Eigen::Vector3d;
 
 using std::make_shared;
 using std::make_unique;
-using std::move;
 using std::shared_ptr;
 using std::unordered_map;
 using std::vector;
@@ -747,7 +746,7 @@ GTEST_TEST(ProximityEngineTests, MoveSemantics) {
   engine.AddAnchoredGeometry(sphere, pose, GeometryId::get_new_id());
   engine.AddDynamicGeometry(sphere, pose, GeometryId::get_new_id());
 
-  ProximityEngine<double> move_construct(move(engine));
+  ProximityEngine<double> move_construct(std::move(engine));
   EXPECT_EQ(move_construct.num_geometries(), 2);
   EXPECT_EQ(move_construct.num_anchored(), 1);
   EXPECT_EQ(move_construct.num_dynamic(), 1);
@@ -756,7 +755,7 @@ GTEST_TEST(ProximityEngineTests, MoveSemantics) {
   EXPECT_EQ(engine.num_dynamic(), 0);
 
   ProximityEngine<double> move_assign;
-  move_assign = move(move_construct);
+  move_assign = std::move(move_construct);
   EXPECT_EQ(move_assign.num_geometries(), 2);
   EXPECT_EQ(move_assign.num_anchored(), 1);
   EXPECT_EQ(move_assign.num_dynamic(), 1);

--- a/multibody/fem/petsc_symmetric_block_sparse_matrix.cc
+++ b/multibody/fem/petsc_symmetric_block_sparse_matrix.cc
@@ -232,20 +232,20 @@ class PetscSymmetricBlockSparseMatrix::Impl {
 
   SchurComplement<double> CalcSchurComplement(
       const vector<int>& D_block_indexes, const vector<int>& A_block_indexes) {
-    using std::move;
-
     MatrixXd D_complement;          // A - BD⁻¹Bᵀ.
     MatrixXd neg_Dinv_B_transpose;  // -D⁻¹Bᵀ.
 
     if (D_block_indexes.size() == 0) {
       D_complement = MakeDenseMatrix();
       neg_Dinv_B_transpose.resize(0, size_);
-      return SchurComplement(move(D_complement), move(neg_Dinv_B_transpose));
+      return SchurComplement(std::move(D_complement),
+                             std::move(neg_Dinv_B_transpose));
     }
     if (A_block_indexes.size() == 0) {
       D_complement.resize(0, 0);
       neg_Dinv_B_transpose.resize(size_, 0);
-      return SchurComplement(move(D_complement), move(neg_Dinv_B_transpose));
+      return SchurComplement(std::move(D_complement),
+                             std::move(neg_Dinv_B_transpose));
     }
     // Build indices to create the four blocks in the Schur complement.
     IS is0, is1;
@@ -303,7 +303,8 @@ class PetscSymmetricBlockSparseMatrix::Impl {
     ISDestroy(&is0);
     ISDestroy(&is1);
 
-    return SchurComplement(move(D_complement), move(neg_Dinv_B_transpose));
+    return SchurComplement(std::move(D_complement),
+                           std::move(neg_Dinv_B_transpose));
   }
 
   int size() const { return size_; }

--- a/multibody/fem/simplex_gaussian_quadrature.cc
+++ b/multibody/fem/simplex_gaussian_quadrature.cc
@@ -6,7 +6,6 @@ namespace fem {
 namespace internal {
 
 using std::make_pair;
-using std::move;
 
 /* Linear triangle quadrature. */
 template <>
@@ -18,7 +17,7 @@ SimplexGaussianQuadrature<2, 1>::ComputePointsAndWeights() {
   LocationsType points = {{{1.0 / 3.0, 1.0 / 3.0}}};
   /* For a unit triangle, area = 0.5. */
   WeightsType weights = {{0.5}};
-  return make_pair(move(points), move(weights));
+  return make_pair(std::move(points), std::move(weights));
 }
 
 /* Quadratic triangle quadrature. */
@@ -39,7 +38,7 @@ SimplexGaussianQuadrature<2, 2>::ComputePointsAndWeights() {
   points[2] = {1.0 / 6.0, 2.0 / 3.0};
   /* For a unit triangle, area = 0.5. */
   WeightsType weights = {{1.0 / 6.0, 1.0 / 6.0, 1.0 / 6.0}};
-  return make_pair(move(points), move(weights));
+  return make_pair(std::move(points), std::move(weights));
 }
 
 /* Cubic triangle quadrature. */
@@ -59,7 +58,7 @@ SimplexGaussianQuadrature<2, 3>::ComputePointsAndWeights() {
   points[3] = {0.2, 0.2};
   /* For a unit triangle, area = 0.5. */
   WeightsType weights = {{-9.0 / 32.0, 25.0 / 96.0, 25.0 / 96.0, 25.0 / 96.0}};
-  return make_pair(move(points), move(weights));
+  return make_pair(std::move(points), std::move(weights));
 }
 
 /* Linear tetrahedral quadrature. */
@@ -72,7 +71,7 @@ SimplexGaussianQuadrature<3, 1>::ComputePointsAndWeights() {
   LocationsType points = {{{0.25, 0.25, 0.25}}};
   /* For a unit tetrahedron, area = 1/6. */
   WeightsType weights = {{1.0 / 6.0}};
-  return make_pair(move(points), move(weights));
+  return make_pair(std::move(points), std::move(weights));
 }
 
 /* Quadratic tetrahedral quadrature. */
@@ -95,7 +94,7 @@ SimplexGaussianQuadrature<3, 2>::ComputePointsAndWeights() {
   points[3] = {b, b, b};
   /* For a unit tetrahedron, area = 1/6. */
   WeightsType weights = {{1.0 / 24.0, 1.0 / 24.0, 1.0 / 24.0, 1.0 / 24.0}};
-  return make_pair(move(points), move(weights));
+  return make_pair(std::move(points), std::move(weights));
 }
 
 /* Cubic tetrahedral quadrature. */
@@ -121,7 +120,7 @@ SimplexGaussianQuadrature<3, 3>::ComputePointsAndWeights() {
   /* For a unit tetrahedron, area = 1/6. */
   WeightsType weights = {
       {-2.0 / 15.0, 3.0 / 40.0, 3.0 / 40.0, 3.0 / 40.0, 3.0 / 40.0}};
-  return make_pair(move(points), move(weights));
+  return make_pair(std::move(points), std::move(weights));
 }
 }  // namespace internal
 }  // namespace fem

--- a/multibody/parsing/detail_sdf_geometry.cc
+++ b/multibody/parsing/detail_sdf_geometry.cc
@@ -29,7 +29,6 @@ namespace internal {
 
 using Eigen::Vector3d;
 using std::make_unique;
-using std::move;
 using std::set;
 using std::string;
 
@@ -287,7 +286,7 @@ std::optional<std::unique_ptr<GeometryInstance>>
     return nullptr;
   }
   auto instance =
-      make_unique<GeometryInstance>(X_LC, move(*shape), sdf_visual.Name());
+      make_unique<GeometryInstance>(X_LC, std::move(*shape), sdf_visual.Name());
   std::optional<IllustrationProperties> illustration_properties =
       MakeVisualPropertiesFromSdfVisual(
           diagnostic, sdf_visual, resolve_filename);
@@ -388,7 +387,7 @@ std::optional<IllustrationProperties> MakeVisualPropertiesFromSdfVisual(
       accepting = accepting->GetNextElement(kAcceptingTag);
     }
     DRAKE_DEMAND(accepting_names.size() > 0);
-    properties.AddProperty("renderer", "accepting", move(accepting_names));
+    properties.AddProperty("renderer", "accepting", std::move(accepting_names));
   }
 
   return properties;

--- a/multibody/plant/test/contact_properties_test.cc
+++ b/multibody/plant/test/contact_properties_test.cc
@@ -21,7 +21,6 @@ using geometry::SourceId;
 using geometry::Sphere;
 using math::RigidTransformd;
 using std::make_unique;
-using std::move;
 using std::unique_ptr;
 
 const CoulombFriction<double> kMuA(1.0, 1.0);
@@ -116,7 +115,7 @@ class ContactPropertiesTest : public ::testing::Test {
       props.AddProperty(geometry::internal::kHydroGroup,
                         geometry::internal::kComplianceType, *compliance_type);
     }
-    result->set_proximity_properties(move(props));
+    result->set_proximity_properties(std::move(props));
     return result;
   }
 

--- a/multibody/plant/test/contact_results_to_lcm_test.cc
+++ b/multibody/plant/test/contact_results_to_lcm_test.cc
@@ -34,7 +34,6 @@ using math::RigidTransform;
 using multibody::internal::FullBodyName;
 using std::function;
 using std::make_unique;
-using std::move;
 using std::nullopt;
 using std::optional;
 using std::string;

--- a/multibody/plant/test/deformable_boundary_condition_test.cc
+++ b/multibody/plant/test/deformable_boundary_condition_test.cc
@@ -23,7 +23,6 @@ using Eigen::Vector3d;
 using Eigen::Vector4d;
 using Eigen::VectorXd;
 using std::make_unique;
-using std::move;
 using std::unique_ptr;
 
 namespace drake {
@@ -124,15 +123,15 @@ class DeformableIntegrationTest : public ::testing::Test {
     ProximityProperties props;
     const CoulombFriction<double> kFriction{0.4, 0.4};
     geometry::AddContactMaterial({}, {}, kFriction, &props);
-    geometry->set_proximity_properties(move(props));
+    geometry->set_proximity_properties(std::move(props));
     fem::DeformableBodyConfig<double> body_config;
     body_config.set_youngs_modulus(kYoungsModulus);
     body_config.set_poissons_ratio(kPoissonsRatio);
     body_config.set_mass_density(kMassDensity);
     body_config.set_stiffness_damping_coefficient(kStiffnessDamping);
     constexpr double kRezHint = kRadius;
-    DeformableBodyId id =
-        model->RegisterDeformableBody(move(geometry), body_config, kRezHint);
+    DeformableBodyId id = model->RegisterDeformableBody(std::move(geometry),
+                                                        body_config, kRezHint);
     return id;
   }
 };

--- a/multibody/plant/test/deformable_driver_contact_kinematics_test.cc
+++ b/multibody/plant/test/deformable_driver_contact_kinematics_test.cc
@@ -23,7 +23,6 @@ using Eigen::MatrixXd;
 using Eigen::Vector3d;
 using Eigen::VectorXd;
 using std::make_unique;
-using std::move;
 
 namespace drake {
 namespace multibody {
@@ -63,12 +62,12 @@ DeformableBodyId RegisterDeformableOctahedron(DeformableModel<double>* model,
   geometry::ProximityProperties props;
   geometry::AddContactMaterial({}, {}, CoulombFriction<double>(1.0, 1.0),
                                &props);
-  geometry->set_proximity_properties(move(props));
+  geometry->set_proximity_properties(std::move(props));
   fem::DeformableBodyConfig<double> body_config;
   /* Make the resolution hint large enough so that we get an octahedron. */
   constexpr double kRezHint = 10.0;
   DeformableBodyId body_id =
-      model->RegisterDeformableBody(move(geometry), body_config, kRezHint);
+      model->RegisterDeformableBody(std::move(geometry), body_config, kRezHint);
   return body_id;
 }
 
@@ -97,7 +96,7 @@ class DeformableDriverContactKinematicsTest : public ::testing::Test {
     deformable_body_id_ = RegisterDeformableOctahedron(deformable_model.get(),
                                                        "deformable", X_WF_);
     model_ = deformable_model.get();
-    plant_->AddPhysicalModel(move(deformable_model));
+    plant_->AddPhysicalModel(std::move(deformable_model));
 
     /* Define proximity properties for all rigid geometries. */
     geometry::ProximityProperties rigid_proximity_props;
@@ -134,7 +133,7 @@ class DeformableDriverContactKinematicsTest : public ::testing::Test {
     plant_->Finalize();
     auto contact_manager = make_unique<CompliantContactManager<double>>();
     manager_ = contact_manager.get();
-    plant_->SetDiscreteUpdateManager(move(contact_manager));
+    plant_->SetDiscreteUpdateManager(std::move(contact_manager));
     driver_ = CompliantContactManagerTester::deformable_driver(*manager_);
 
     builder.Connect(model_->vertex_positions_port(),
@@ -312,7 +311,7 @@ GTEST_TEST(DeformableDriverContactKinematicsWithBcTest,
   /* Put the bottom vertex under bc. */
   model->SetWallBoundaryCondition(body_id, Vector3d(0, 0, -0.5),
                                   Vector3d(0, 0, 1));
-  plant.AddPhysicalModel(move(deformable_model));
+  plant.AddPhysicalModel(std::move(deformable_model));
 
   /* Define proximity properties for all rigid geometries. */
   geometry::ProximityProperties rigid_proximity_props;
@@ -335,7 +334,7 @@ GTEST_TEST(DeformableDriverContactKinematicsWithBcTest,
   plant.Finalize();
   auto contact_manager = make_unique<CompliantContactManager<double>>();
   const CompliantContactManager<double>* manager = contact_manager.get();
-  plant.SetDiscreteUpdateManager(move(contact_manager));
+  plant.SetDiscreteUpdateManager(std::move(contact_manager));
   const DeformableDriver<double>* driver =
       CompliantContactManagerTester::deformable_driver(*manager);
 

--- a/multibody/plant/test/deformable_driver_contact_test.cc
+++ b/multibody/plant/test/deformable_driver_contact_test.cc
@@ -26,7 +26,6 @@ using drake::systems::DiscreteStateIndex;
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
 using std::make_unique;
-using std::move;
 
 namespace drake {
 namespace multibody {
@@ -63,7 +62,7 @@ class DeformableDriverContactTest : public ::testing::Test {
     body_id1_ =
         RegisterDeformableOctahedron(deformable_model.get(), "deformable1");
     model_ = deformable_model.get();
-    plant_->AddPhysicalModel(move(deformable_model));
+    plant_->AddPhysicalModel(std::move(deformable_model));
     plant_->set_discrete_contact_solver(DiscreteContactSolver::kSap);
     /* Register a rigid collision geometry intersecting with the bottom half of
      the deformable octahedrons. */
@@ -82,7 +81,7 @@ class DeformableDriverContactTest : public ::testing::Test {
 
     auto contact_manager = make_unique<CompliantContactManager<double>>();
     manager_ = contact_manager.get();
-    plant_->SetDiscreteUpdateManager(move(contact_manager));
+    plant_->SetDiscreteUpdateManager(std::move(contact_manager));
     driver_ = CompliantContactManagerTester::deformable_driver(*manager_);
 
     builder.Connect(model_->vertex_positions_port(),
@@ -180,21 +179,21 @@ class DeformableDriverContactTest : public ::testing::Test {
   DeformableBodyId RegisterDeformableOctahedron(DeformableModel<double>* model,
                                                 std::string name) {
     auto geometry = make_unique<GeometryInstance>(
-        RigidTransformd(), make_unique<Sphere>(1.0), move(name));
+        RigidTransformd(), make_unique<Sphere>(1.0), std::move(name));
     geometry::ProximityProperties props;
     geometry::AddContactMaterial({}, {}, CoulombFriction<double>(1.0, 1.0),
                                  &props);
     props.AddProperty(geometry::internal::kMaterialGroup,
                       geometry::internal::kRelaxationTime,
                       kDissipationTimeScale);
-    geometry->set_proximity_properties(move(props));
+    geometry->set_proximity_properties(std::move(props));
     fem::DeformableBodyConfig<double> body_config;
     body_config.set_youngs_modulus(1e6);
     body_config.set_poissons_ratio(0.4);
     /* Make the resolution hint large enough so that we get an octahedron. */
     constexpr double kRezHint = 10.0;
-    DeformableBodyId body_id =
-        model->RegisterDeformableBody(move(geometry), body_config, kRezHint);
+    DeformableBodyId body_id = model->RegisterDeformableBody(
+        std::move(geometry), body_config, kRezHint);
     return body_id;
   }
 };

--- a/multibody/plant/test/deformable_driver_test.cc
+++ b/multibody/plant/test/deformable_driver_test.cc
@@ -19,7 +19,6 @@ using drake::math::RigidTransformd;
 using drake::multibody::fem::FemState;
 using drake::systems::Context;
 using std::make_unique;
-using std::move;
 
 namespace drake {
 namespace multibody {
@@ -36,13 +35,13 @@ class DeformableDriverTest : public ::testing::Test {
     constexpr double kRezHint = 0.5;
     body_id_ = RegisterSphere(deformable_model.get(), kRezHint);
     model_ = deformable_model.get();
-    plant_->AddPhysicalModel(move(deformable_model));
+    plant_->AddPhysicalModel(std::move(deformable_model));
     // N.B. Currently the manager only supports SAP.
     plant_->set_discrete_contact_solver(DiscreteContactSolver::kSap);
     plant_->Finalize();
     auto contact_manager = make_unique<CompliantContactManager<double>>();
     manager_ = contact_manager.get();
-    plant_->SetDiscreteUpdateManager(move(contact_manager));
+    plant_->SetDiscreteUpdateManager(std::move(contact_manager));
     driver_ = CompliantContactManagerTester::deformable_driver(*manager_);
 
     builder.Connect(model_->vertex_positions_port(),
@@ -93,11 +92,11 @@ class DeformableDriverTest : public ::testing::Test {
     geometry::ProximityProperties props;
     geometry::AddContactMaterial({}, {}, CoulombFriction<double>(1.0, 1.0),
                                  &props);
-    geometry->set_proximity_properties(move(props));
+    geometry->set_proximity_properties(std::move(props));
     fem::DeformableBodyConfig<double> body_config;
     body_config.set_youngs_modulus(1e6);
     DeformableBodyId body_id = model->RegisterDeformableBody(
-        move(geometry), body_config, resolution_hint);
+        std::move(geometry), body_config, resolution_hint);
     return body_id;
   }
 };
@@ -173,7 +172,7 @@ TEST_F(DeformableDriverTest, NextFemState) {
 
 /* Verifies that the discrete states are updated to match the FEM states. */
 TEST_F(DeformableDriverTest, CalcDiscreteStates) {
-  systems::Simulator<double> simulator(*diagram_, move(diagram_context_));
+  systems::Simulator<double> simulator(*diagram_, std::move(diagram_context_));
   simulator.Initialize();
   simulator.AdvanceTo(3 * kDt);
   const systems::DiscreteStateIndex state_index =

--- a/multibody/plant/test/deformable_integration_test.cc
+++ b/multibody/plant/test/deformable_integration_test.cc
@@ -28,7 +28,6 @@ using Eigen::Vector3d;
 using Eigen::Vector4d;
 using Eigen::VectorXd;
 using std::make_unique;
-using std::move;
 using std::unique_ptr;
 
 namespace drake {
@@ -144,7 +143,7 @@ class DeformableIntegrationTest : public ::testing::Test {
         RigidTransformd(), make_unique<Sphere>(0.1), move(name));
     ProximityProperties props;
     geometry::AddContactMaterial({}, {}, kFriction, &props);
-    geometry->set_proximity_properties(move(props));
+    geometry->set_proximity_properties(std::move(props));
     fem::DeformableBodyConfig<double> body_config;
     body_config.set_youngs_modulus(kYoungsModulus);
     body_config.set_poissons_ratio(kPoissonsRatio);
@@ -152,8 +151,8 @@ class DeformableIntegrationTest : public ::testing::Test {
     body_config.set_stiffness_damping_coefficient(kStiffnessDamping);
     /* Make the resolution hint large enough so that we get an octahedron. */
     constexpr double kRezHint = 10.0;
-    DeformableBodyId id =
-        model->RegisterDeformableBody(move(geometry), body_config, kRezHint);
+    DeformableBodyId id = model->RegisterDeformableBody(std::move(geometry),
+                                                        body_config, kRezHint);
     /* Verify that the geometry has 7 vertices and is indeed an octahedron. */
     const SceneGraphInspector<double>& inspector =
         scene_graph_->model_inspector();

--- a/multibody/tree/test/body_node_test.cc
+++ b/multibody/tree/test/body_node_test.cc
@@ -30,7 +30,6 @@ using Eigen::MatrixXd;
 using Eigen::Matrix3d;
 using Eigen::Vector3d;
 using math::RotationMatrix;
-using std::move;
 using systems::Context;
 
 // Friend access into BodyNode.

--- a/planning/collision_checker.cc
+++ b/planning/collision_checker.cc
@@ -38,7 +38,6 @@ using multibody::JointIndex;
 using multibody::ModelInstanceIndex;
 using multibody::MultibodyPlant;
 using multibody::world_model_instance;
-using std::move;
 using systems::Context;
 
 // Default interpolator; it uses SLERP for quaternion-valued groups of dofs and
@@ -764,7 +763,7 @@ std::vector<RobotCollisionType> CollisionChecker::ClassifyContextBodyCollisions(
 
 CollisionChecker::CollisionChecker(CollisionCheckerParams params,
                                    bool supports_parallel_checking)
-    : setup_model_(move(params.model)),
+    : setup_model_(std::move(params.model)),
       robot_model_instances_([&params]() {
         // Sort (and de-duplicate) the robot model instances for faster lookups.
         DRAKE_THROW_UNLESS(params.robot_model_instances.size() > 0);
@@ -790,7 +789,7 @@ CollisionChecker::CollisionChecker(CollisionCheckerParams params,
       Eigen::MatrixXd::Zero(plant().num_bodies(), plant().num_bodies());
   // Set parameters with safety checks.
   SetConfigurationDistanceFunction(
-      move(params.configuration_distance_function));
+      std::move(params.configuration_distance_function));
   set_edge_step_size(params.edge_step_size);
   SetPaddingAllRobotEnvironmentPairs(params.env_collision_padding);
   SetPaddingAllRobotRobotPairs(params.self_collision_padding);
@@ -809,7 +808,7 @@ CollisionChecker::CollisionChecker(const CollisionChecker&) = default;
 void CollisionChecker::AllocateContexts() {
   DRAKE_THROW_UNLESS(IsInitialSetup());
   // Move to a const model.
-  model_ = move(setup_model_);
+  model_ = std::move(setup_model_);
   // Make a diagram & plant context for each thread.
   const int num_omp_threads =
       common_robotics_utilities::openmp_helpers::GetNumOmpThreads();

--- a/planning/test/collision_avoidance_test.cc
+++ b/planning/test/collision_avoidance_test.cc
@@ -18,7 +18,6 @@ using drake::multibody::BodyIndex;
 using drake::multibody::default_model_instance;
 using drake::multibody::SpatialInertia;
 using Eigen::VectorXd;
-using std::move;
 using std::unique_ptr;
 
 double ZeroDistanceFunc(const VectorXd&, const VectorXd&) {
@@ -60,7 +59,7 @@ class DummyCollisionChecker final : public UnimplementedCollisionChecker {
   /* This clearance data will define the distance/jacobian data that will be
    given back to ComputeCollisionAvoidanceDisplacement() when invoking
    CalcRobotClearance(). */
-  void set_robot_clearance(RobotClearance data) { data_ = move(data); }
+  void set_robot_clearance(RobotClearance data) { data_ = std::move(data); }
 
  private:
   void DoUpdateContextPositions(
@@ -154,7 +153,7 @@ GTEST_TEST(ComputeCollisionAvoidanceDisplacementTest, WeightedCombinations) {
     RobotClearance clearance(kQSize);
     clearance.Append(robot_body, env_body, env_type, kMin - 0.1,
                      q1.transpose());
-    checker.set_robot_clearance(move(clearance));
+    checker.set_robot_clearance(std::move(clearance));
     const VectorXd grad =
         ComputeCollisionAvoidanceDisplacement(checker, q0, kMin, kMax);
     EXPECT_TRUE(CompareMatrices(grad, q1));
@@ -165,7 +164,7 @@ GTEST_TEST(ComputeCollisionAvoidanceDisplacementTest, WeightedCombinations) {
     RobotClearance clearance(kQSize);
     clearance.Append(robot_body, env_body, env_type, kMax + 0.1,
                      q1.transpose());
-    checker.set_robot_clearance(move(clearance));
+    checker.set_robot_clearance(std::move(clearance));
     const VectorXd grad =
         ComputeCollisionAvoidanceDisplacement(checker, q0, kMin, kMax);
     EXPECT_TRUE(CompareMatrices(grad, q0));
@@ -177,7 +176,7 @@ GTEST_TEST(ComputeCollisionAvoidanceDisplacementTest, WeightedCombinations) {
     RobotClearance clearance(kQSize);
     clearance.Append(robot_body, env_body, env_type, kMax - kRange * kWeight,
                      q1.transpose());
-    checker.set_robot_clearance(move(clearance));
+    checker.set_robot_clearance(std::move(clearance));
     const VectorXd grad =
         ComputeCollisionAvoidanceDisplacement(checker, q0, kMin, kMax);
     EXPECT_EQ(grad.size(), kQSize);
@@ -193,7 +192,7 @@ GTEST_TEST(ComputeCollisionAvoidanceDisplacementTest, WeightedCombinations) {
                      q1.transpose());
     clearance.Append(robot_body, env_body, env_type, kMax - kRange * kWeight2,
                      q2.transpose());
-    checker.set_robot_clearance(move(clearance));
+    checker.set_robot_clearance(std::move(clearance));
     const VectorXd grad =
         ComputeCollisionAvoidanceDisplacement(checker, q0, kMin, kMax);
     EXPECT_EQ(grad.size(), kQSize);

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -63,7 +63,6 @@ using std::is_permutation;
 using std::is_same_v;
 using std::make_shared;
 using std::map;
-using std::move;
 using std::numeric_limits;
 using std::pair;
 using std::runtime_error;

--- a/systems/rendering/test/multibody_position_to_geometry_pose_test.cc
+++ b/systems/rendering/test/multibody_position_to_geometry_pose_test.cc
@@ -18,7 +18,6 @@ using multibody::BodyIndex;
 using multibody::MultibodyPlant;
 using multibody::Parser;
 using std::make_unique;
-using std::move;
 
 GTEST_TEST(MultibodyPositionToGeometryPoseTest, BadConstruction) {
   {

--- a/systems/sensors/rgbd_sensor.cc
+++ b/systems/sensors/rgbd_sensor.cc
@@ -29,7 +29,6 @@ using geometry::render::DepthRange;
 using geometry::render::DepthRenderCamera;
 using math::RigidTransformd;
 using std::make_pair;
-using std::move;
 using std::pair;
 
 RgbdSensor::RgbdSensor(FrameId parent_id, const RigidTransformd& X_PB,
@@ -43,8 +42,8 @@ RgbdSensor::RgbdSensor(FrameId parent_id, const RigidTransformd& X_PB,
                        ColorRenderCamera color_camera,
                        DepthRenderCamera depth_camera)
     : parent_frame_id_(parent_id),
-      color_camera_(move(color_camera)),
-      depth_camera_(move(depth_camera)),
+      color_camera_(std::move(color_camera)),
+      depth_camera_(std::move(depth_camera)),
       X_PB_(X_PB) {
   const CameraInfo& color_intrinsics = color_camera_.core().intrinsics();
   const CameraInfo& depth_intrinsics = depth_camera_.core().intrinsics();
@@ -173,7 +172,7 @@ RgbdSensorDiscrete::RgbdSensorDiscrete(std::unique_ptr<RgbdSensor> camera,
   const auto& depth_camera_info = camera->depth_camera_info();
 
   DiagramBuilder<double> builder;
-  builder.AddSystem(move(camera));
+  builder.AddSystem(std::move(camera));
   query_object_port_ =
       builder.ExportInput(camera_->query_object_input_port(), "geometry_query");
 

--- a/systems/sensors/test/rgbd_sensor_test.cc
+++ b/systems/sensors/test/rgbd_sensor_test.cc
@@ -39,7 +39,6 @@ using math::RigidTransformd;
 using math::RollPitchYawd;
 using std::make_pair;
 using std::make_unique;
-using std::move;
 using std::unique_ptr;
 using std::vector;
 using systems::Context;


### PR DESCRIPTION
This risks severe ADL hazards, and will be Clang error soon.

Towards #18327.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19354)
<!-- Reviewable:end -->
