### PR TITLE
Avoid ADL std::move

### DIFF
--- a/common/symbolic/generic_polynomial.cc
+++ b/common/symbolic/generic_polynomial.cc
@@ -353,7 +353,7 @@ Variables GetDecisionVariables(
 
 template <typename BasisElement>
 GenericPolynomial<BasisElement>::GenericPolynomial(MapType init)
-    : basis_element_to_coefficient_map_{move(init)},
+    : basis_element_to_coefficient_map_{std::move(init)},
       indeterminates_{
           GetIndeterminates<BasisElement>(basis_element_to_coefficient_map_)},
       decision_variables_{GetDecisionVariables<BasisElement>(

--- a/common/symbolic/polynomial.cc
+++ b/common/symbolic/polynomial.cc
@@ -370,7 +370,7 @@ Variables GetDecisionVariables(const Polynomial::MapType& m) {
 }  // namespace
 
 Polynomial::Polynomial(MapType map)
-    : monomial_to_coefficient_map_{move(map)},
+    : monomial_to_coefficient_map_{std::move(map)},
       indeterminates_{GetIndeterminates(monomial_to_coefficient_map_)},
       decision_variables_{GetDecisionVariables(monomial_to_coefficient_map_)} {
   // Remove all [monomial, coeff] pair in monomial_to_coefficient_map_ if

--- a/geometry/proximity/test/contact_surface_test.cc
+++ b/geometry/proximity/test/contact_surface_test.cc
@@ -58,10 +58,12 @@ unique_ptr<MeshType> GenerateMesh() {
       {0., 0., 0.}, {1., 0., 0.}, {1., 1., 0.}, {0., 1., 0.}};
   if constexpr (std::is_same_v<MeshType, TriangleSurfaceMesh<T>>) {
     vector<SurfaceTriangle> faces{{0, 1, 2}, {2, 3, 0}};
-    return make_unique<TriangleSurfaceMesh<T>>(move(faces), move(vertices));
+    return make_unique<TriangleSurfaceMesh<T>>(std::move(faces),
+                                               std::move(vertices));
   } else {
     vector<int> face_data{3, 0, 1, 2, 3, 2, 3, 0};
-    return make_unique<PolygonSurfaceMesh<T>>(move(face_data), move(vertices));
+    return make_unique<PolygonSurfaceMesh<T>>(std::move(face_data),
+                                              std::move(vertices));
   }
 }
 
@@ -71,7 +73,8 @@ unique_ptr<MeshFieldLinear<typename MeshType::ScalarType, MeshType>> MakeField(
     vector<typename MeshType::ScalarType>&& e_values, const MeshType& mesh) {
   using T = typename MeshType::ScalarType;
   if constexpr (std::is_same_v<MeshType, TriangleSurfaceMesh<T>>) {
-    return make_unique<MeshFieldLinear<T, MeshType>>(move(e_values), &mesh);
+    return make_unique<MeshFieldLinear<T, MeshType>>(std::move(e_values),
+                                                     &mesh);
   } else {
     // A MeshFieldLinear on PolygonSurfaceMesh requires the gradients to be
     // provided. So, we'll create the equivalent triangle mesh and field and
@@ -84,8 +87,8 @@ unique_ptr<MeshFieldLinear<typename MeshType::ScalarType, MeshType>> MakeField(
     for (int t = 0; t < tri_mesh->num_elements(); ++t) {
       e_grad.push_back(field.EvaluateGradient(t));
     }
-    return make_unique<MeshFieldLinear<T, MeshType>>(move(e_values), &mesh,
-                                                     move(e_grad));
+    return make_unique<MeshFieldLinear<T, MeshType>>(std::move(e_values), &mesh,
+                                                     std::move(e_grad));
   }
 }
 
@@ -116,10 +119,10 @@ ContactSurface<typename MeshType::ScalarType> TestContactSurface(
   const T e3{3.};
   vector<T> e_values = {e0, e1, e2, e3};
   unique_ptr<MeshFieldLinear<T, MeshType>> e_field =
-      MakeField(move(e_values), *surface_mesh);
+      MakeField(std::move(e_values), *surface_mesh);
 
-  ContactSurface<T> contact_surface(id_M, id_N, move(surface_mesh),
-                                    move(e_field));
+  ContactSurface<T> contact_surface(id_M, id_N, std::move(surface_mesh),
+                                    std::move(e_field));
 
   if (test_return_value) {
     // Start testing the ContactSurface<> data structure.
@@ -206,7 +209,7 @@ GTEST_TEST(ContactSurfaceTest, ConstituentGradients) {
   auto make_e_field = [](TriangleSurfaceMesh<double>* mesh) {
     vector<double> e_values{0, 1, 2, 3};
     return make_unique<TriangleSurfaceMeshFieldLinear<double, double>>(
-        move(e_values), mesh, false /* calc_gradient */);
+        std::move(e_values), mesh, false /* calc_gradient */);
   };
   vector<Vector3d> grad_e;
   for (int i = 0; i < surface_mesh->num_elements(); ++i) {
@@ -400,9 +403,9 @@ GTEST_TEST(ContactSurfaceTest, TestEqual) {
   vector<double> field2_values(field.values());
   field2_values.at(0) += 2.0;
   auto field2 = make_unique<TriangleSurfaceMeshFieldLinear<double, double>>(
-      move(field2_values), mesh2.get());
+      std::move(field2_values), mesh2.get());
   auto surface2 = ContactSurface<double>(surface.id_M(), surface.id_N(),
-                                         move(mesh2), move(field2));
+                                         std::move(mesh2), std::move(field2));
   EXPECT_FALSE(surface.Equal(surface2));
 }
 
@@ -423,9 +426,9 @@ GTEST_TEST(ContactSurfaceTest, TestSwapMAndN) {
   auto id_M = GeometryId::get_new_id();
   ASSERT_LT(id_N, id_M);
   ContactSurface<double> dut(
-      id_M, id_N, move(mesh),
+      id_M, id_N, std::move(mesh),
       make_unique<TriangleSurfaceMeshFieldLinear<double, double>>(
-          move(e_MN_values), mesh_pointer));
+          std::move(e_MN_values), mesh_pointer));
 
   // We rely on the underlying meshes and mesh fields to *do* the right thing.
   // These tests are just to confirm that those things changed where we

--- a/geometry/proximity/test/contact_surface_utility_test.cc
+++ b/geometry/proximity/test/contact_surface_utility_test.cc
@@ -258,7 +258,7 @@ class Polygon {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Polygon)
 
   Polygon(vector<Vector3d> vertices_P, const LinearFunction& func_P)
-      : vertices_P_(move(vertices_P)), func_P_(func_P) {}
+      : vertices_P_(std::move(vertices_P)), func_P_(func_P) {}
 
   const vector<Vector3d> vertices() const { return vertices_P_; }
   double EvalPressure(const Vector3d& p_PV) const { return func_P_(p_PV); }

--- a/geometry/proximity/test/mesh_field_linear_test.cc
+++ b/geometry/proximity/test/mesh_field_linear_test.cc
@@ -48,7 +48,7 @@ std::unique_ptr<TriangleSurfaceMesh<T>> GenerateMesh() {
   std::vector<Vector3<T>> vertices;
   for (int v = 0; v < 4; ++v) vertices.emplace_back(vertex_data[v]);
   auto surface_mesh = std::make_unique<TriangleSurfaceMesh<T>>(
-      move(faces), std::move(vertices));
+      std::move(faces), std::move(vertices));
   return surface_mesh;
 }
 

--- a/geometry/proximity/test/mesh_half_space_intersection_test.cc
+++ b/geometry/proximity/test/mesh_half_space_intersection_test.cc
@@ -80,7 +80,7 @@ TriangleSurfaceMesh<double> CreateBoxMesh(const RigidTransform<double>& X_FB) {
   faces.emplace_back(2, 6, 4);  // -Z face
 
   // Construct the mesh.
-  return {move(faces), move(vertices_F)};
+  return {std::move(faces), std::move(vertices_F)};
 }
 
 // Given a triangle mesh expressed in frame F, creates a "contact surface mesh"
@@ -111,7 +111,7 @@ MeshType RexpressAsContactMesh(
           X_WF.rotation() * mesh_F.face_normal(t_index).cast<T>();
       AddPolygonToTriangleMeshData(polygon, nhat_W, &triangles, &vertices_W);
     }
-    return {move(triangles), move(vertices_W)};
+    return {std::move(triangles), std::move(vertices_W)};
   } else {
     vector<int> face_data;
     face_data.reserve(mesh_F.num_triangles() * 4);
@@ -121,7 +121,7 @@ MeshType RexpressAsContactMesh(
         face_data.push_back(tri.vertex(i));
       }
     }
-    return {move(face_data), move(vertices_W)};
+    return {std::move(face_data), std::move(vertices_W)};
   }
 }
 
@@ -140,7 +140,7 @@ TriangleSurfaceMesh<double> CreateOneTriangleMesh(const Vector3d& v0,
                                                   const Vector3d& v2) {
   std::vector<Vector3d> vertices{{v0, v1, v2}};
   std::vector<SurfaceTriangle> faces{{0, 1, 2}};
-  return TriangleSurfaceMesh<double>(move(faces), move(vertices));
+  return TriangleSurfaceMesh<double>(std::move(faces), std::move(vertices));
 }
 
 // Helper for getting the appropriate mesh builder from an expected mesh type.
@@ -483,7 +483,8 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, InsideOrOnIntersection) {
     std::vector<Vector3d> vertices = {Vector3d(4, 5, 2), Vector3d(3, 5, 2),
                                       Vector3d(3, 5, 1), Vector3d(2, 5, 2)};
     std::vector<SurfaceTriangle> faces{{0, 1, 2}, {2, 1, 3}};
-    const TriangleSurfaceMesh<double> tri_mesh_F(move(faces), move(vertices));
+    const TriangleSurfaceMesh<double> tri_mesh_F(std::move(faces),
+                                                 std::move(vertices));
 
     // Verify the intersection.
     this->CallConstructTriangleHalfspaceIntersectionPolygon(tri_mesh_F, X_WF);
@@ -711,13 +712,13 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, QuadrilateralResults) {
       std::vector<SurfaceTriangle> expected_faces;
       AddPolygonToTriangleMeshData(polygon, nhat_W, &expected_faces,
                                    &expected_vertices_W);
-      expected_mesh_W = make_unique<MeshType>(move(expected_faces),
-                                              move(expected_vertices_W));
+      expected_mesh_W = make_unique<MeshType>(std::move(expected_faces),
+                                              std::move(expected_vertices_W));
     } else {
       std::vector<int> face_data;
       AddPolygonToPolygonMeshData(polygon, &face_data);
-      expected_mesh_W =
-          make_unique<MeshType>(move(face_data), move(expected_vertices_W));
+      expected_mesh_W = make_unique<MeshType>(std::move(face_data),
+                                              std::move(expected_vertices_W));
     }
 
     EXPECT_TRUE(this->MeshesEquivalent(*mesh_W, *expected_mesh_W));
@@ -793,13 +794,13 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, OutsideInsideOn) {
     std::vector<SurfaceTriangle> expected_faces;
     AddPolygonToTriangleMeshData(polygon, nhat_W, &expected_faces,
                                  &expected_vertices_W);
-    expected_mesh_W =
-        make_unique<MeshType>(move(expected_faces), move(expected_vertices_W));
+    expected_mesh_W = make_unique<MeshType>(std::move(expected_faces),
+                                            std::move(expected_vertices_W));
   } else {
     std::vector<int> face_data;
     AddPolygonToPolygonMeshData(polygon, &face_data);
-    expected_mesh_W =
-        make_unique<MeshType>(move(face_data), move(expected_vertices_W));
+    expected_mesh_W = make_unique<MeshType>(std::move(face_data),
+                                            std::move(expected_vertices_W));
   }
 
   EXPECT_TRUE(this->MeshesEquivalent(*mesh_W, *expected_mesh_W));
@@ -862,13 +863,13 @@ TYPED_TEST_P(MeshHalfSpaceValueTest, OneInsideTwoOutside) {
     std::vector<SurfaceTriangle> expected_faces;
     AddPolygonToTriangleMeshData(polygon, nhat_W, &expected_faces,
                                  &expected_vertices_W);
-    expected_mesh_W =
-        make_unique<MeshType>(move(expected_faces), move(expected_vertices_W));
+    expected_mesh_W = make_unique<MeshType>(std::move(expected_faces),
+                                            std::move(expected_vertices_W));
   } else {
     std::vector<int> face_data;
     AddPolygonToPolygonMeshData(polygon, &face_data);
-    expected_mesh_W =
-        make_unique<MeshType>(move(face_data), move(expected_vertices_W));
+    expected_mesh_W = make_unique<MeshType>(std::move(face_data),
+                                            std::move(expected_vertices_W));
   }
 
   EXPECT_TRUE(this->MeshesEquivalent(*mesh_W, *expected_mesh_W));
@@ -1256,8 +1257,8 @@ class MeshHalfSpaceDerivativesTest : public ::testing::Test {
     using Face = SurfaceTriangle;
     vector<Face> faces{{Face{0, 1, 2}}};
     id_R_ = GeometryId::get_new_id();
-    mesh_R_ =
-        make_unique<TriangleSurfaceMesh<double>>(move(faces), move(vertices));
+    mesh_R_ = make_unique<TriangleSurfaceMesh<double>>(std::move(faces),
+                                                       std::move(vertices));
     bvh_R_ = make_unique<Bvh<Obb, TriangleSurfaceMesh<double>>>(*mesh_R_);
   }
 

--- a/geometry/proximity/test/mesh_intersection_test.cc
+++ b/geometry/proximity/test/mesh_intersection_test.cc
@@ -1136,8 +1136,8 @@ class MeshMeshDerivativesTest : public ::testing::Test {
                               Vector3d{5, -5, 0},
                               Vector3d{0, 5, 0}};
     vector<SurfaceTriangle> faces{{0, 1, 2}};
-    tri_mesh_R_ =
-        make_unique<TriangleSurfaceMesh<double>>(move(faces), move(vertices));
+    tri_mesh_R_ = make_unique<TriangleSurfaceMesh<double>>(std::move(faces),
+                                                           std::move(vertices));
     bvh_R_ = make_unique<Bvh<Obb, TriangleSurfaceMesh<double>>>(*tri_mesh_R_);
     X_WR_ = HalfSpace::MakePose(Vector3d{1, 2, 3}.normalized(),
                                 Vector3d{0.25, 0.1, -0.2})

--- a/geometry/proximity/test/mesh_plane_intersection_test.cc
+++ b/geometry/proximity/test/mesh_plane_intersection_test.cc
@@ -172,7 +172,7 @@ class SliceTest
     // Make an arbitrary mesh field with heterogeneous values.
     vector<double> values{0.25, 0.5, 0.75, 1, -1};
     field_F_ = make_unique<VolumeMeshFieldLinear<double, double>>(
-        move(values), volume_mesh_F_.get());
+        std::move(values), volume_mesh_F_.get());
 
     cut_edges_.clear();
     const int tet_index = 0;
@@ -209,7 +209,7 @@ class SliceTest
     // Make an arbitrary mesh field with heterogeneous values.
     vector<double> values{0.25, 0.5, 0.75, 1, -1};
     field_F_ = make_unique<VolumeMeshFieldLinear<double, double>>(
-        move(values), volume_mesh_F_.get());
+        std::move(values), volume_mesh_F_.get());
 
     const int tet_index = 0;
     std::vector<Vector3<double>> polygon_vertices;
@@ -816,7 +816,7 @@ TEST_F(SliceTest, NoDoubleCounting) {
   VolumeMesh<double> mesh_M = TrivialVolumeMesh(I);
   // Make an arbitrary mesh field with heterogeneous values.
   vector<double> values{0.25, 0.5, 0.75, 1, -1};
-  VolumeMeshFieldLinear<double, double> field_M{move(values), &mesh_M};
+  VolumeMeshFieldLinear<double, double> field_M{std::move(values), &mesh_M};
 
   {
     // Slicing against tet 0 should intersect and produce the three faces.

--- a/geometry/proximity/test/polygon_surface_mesh_test.cc
+++ b/geometry/proximity/test/polygon_surface_mesh_test.cc
@@ -114,7 +114,7 @@ class PolygonSurfaceMeshTest : public ::testing::Test {
     for (const auto& polygon : polygons) {
       AddPolygon(polygon, &face_data, &vertices);
     }
-    return {move(face_data), move(vertices)};
+    return {std::move(face_data), std::move(vertices)};
   }
 };
 
@@ -194,7 +194,7 @@ TYPED_TEST(PolygonSurfaceMeshTest, MeshCentroid) {
     total_area_expected += polygon.area;
     scaled_centroid_expected += polygon.area * polygon.centroid;
   }
-  const PolygonSurfaceMesh<T> mesh(move(face_data), move(vertices));
+  const PolygonSurfaceMesh<T> mesh(std::move(face_data), std::move(vertices));
 
   ASSERT_TRUE(CompareMatrices(
       mesh.centroid(), scaled_centroid_expected / total_area_expected, 1e-15));
@@ -225,7 +225,7 @@ TYPED_TEST(PolygonSurfaceMeshTest, Area) {
     this->AddPolygon(polygon, &face_data, &vertices);
     expected_total_area += polygon.area;
   }
-  const PolygonSurfaceMesh<T> mesh(move(face_data), move(vertices));
+  const PolygonSurfaceMesh<T> mesh(std::move(face_data), std::move(vertices));
 
   ASSERT_NEAR(ExtractDoubleOrThrow(mesh.total_area()), expected_total_area,
               1e-15);
@@ -258,7 +258,7 @@ TYPED_TEST(PolygonSurfaceMeshTest, CalcBoundingBox) {
       max_corner = max_corner.array().max(v.array());
     }
   }
-  const PolygonSurfaceMesh<T> mesh(move(face_data), move(vertices));
+  const PolygonSurfaceMesh<T> mesh(std::move(face_data), std::move(vertices));
 
   const Vector3d center_expected = (min_corner + max_corner) / 2;
   const Vector3d size_expected = max_corner - min_corner;

--- a/geometry/proximity/test/triangle_surface_mesh_test.cc
+++ b/geometry/proximity/test/triangle_surface_mesh_test.cc
@@ -123,7 +123,7 @@ std::unique_ptr<TriangleSurfaceMesh<T>> TestSurfaceMesh(
   std::vector<Vector3<T>> vertices_W;
   for (int v = 0; v < 4; ++v) vertices_W.emplace_back(X_WM * vertex_data_M[v]);
   auto surface_mesh_W = std::make_unique<TriangleSurfaceMesh<T>>(
-      move(faces), std::move(vertices_W));
+      std::move(faces), std::move(vertices_W));
 
   EXPECT_EQ(2, surface_mesh_W->num_triangles());
   EXPECT_EQ(4, surface_mesh_W->num_vertices());

--- a/geometry/query_results/contact_surface.h
+++ b/geometry/query_results/contact_surface.h
@@ -433,10 +433,10 @@ class ContactSurface {
                  std::unique_ptr<std::vector<Vector3<T>>> grad_eN_W, int)
       : id_M_(id_M),
         id_N_(id_N),
-        mesh_W_(move(mesh_W)),
-        e_MN_(move(e_MN)),
-        grad_eM_W_(move(grad_eM_W)),
-        grad_eN_W_(move(grad_eN_W)) {
+        mesh_W_(std::move(mesh_W)),
+        e_MN_(std::move(e_MN)),
+        grad_eM_W_(std::move(grad_eM_W)),
+        grad_eN_W_(std::move(grad_eN_W)) {
     // If defined the gradient values must map 1-to-1 onto elements.
     if (is_triangle()) {
       DRAKE_THROW_UNLESS(grad_eM_W_ == nullptr ||

--- a/geometry/render_vtk/internal_render_engine_vtk.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk.cc
@@ -359,7 +359,7 @@ RenderEngineVtk::RenderEngineVtk(const RenderEngineVtk& other)
         vtkSmartPointer<vtkActor>::New()};
     clone_actor_array(other_id_actor_pair.second, &actors);
     const GeometryId id = other_id_actor_pair.first;
-    actors_.insert({id, move(actors)});
+    actors_.insert({id, std::move(actors)});
   }
 
   // Copy camera properties

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -546,7 +546,8 @@ TEST_F(SceneGraphTest, RoleManagementSmokeTest) {
   instance->set_proximity_properties(ProximityProperties());
   instance->set_perception_properties(PerceptionProperties());
 
-  GeometryId g_id = scene_graph_.RegisterGeometry(s_id, f_id, move(instance));
+  GeometryId g_id =
+      scene_graph_.RegisterGeometry(s_id, f_id, std::move(instance));
 
   const SceneGraphInspector<double>& inspector = scene_graph_.model_inspector();
   EXPECT_NE(inspector.GetProximityProperties(g_id), nullptr);

--- a/multibody/plant/test/contact_properties_test.cc
+++ b/multibody/plant/test/contact_properties_test.cc
@@ -59,10 +59,10 @@ class ContactPropertiesTest : public ::testing::Test {
     unique_ptr<GeometryInstance> geometry_D = MakeGeometryInstance(
         "D", kMuD, std::nullopt, kNegativeTauD, std::nullopt);
 
-    g_A_ = scene_graph_.RegisterGeometry(s_id, f_id, move(geometry_A));
-    g_B_ = scene_graph_.RegisterGeometry(s_id, f_id, move(geometry_B));
-    g_C_ = scene_graph_.RegisterGeometry(s_id, f_id, move(geometry_C));
-    g_D_ = scene_graph_.RegisterGeometry(s_id, f_id, move(geometry_D));
+    g_A_ = scene_graph_.RegisterGeometry(s_id, f_id, std::move(geometry_A));
+    g_B_ = scene_graph_.RegisterGeometry(s_id, f_id, std::move(geometry_B));
+    g_C_ = scene_graph_.RegisterGeometry(s_id, f_id, std::move(geometry_C));
+    g_D_ = scene_graph_.RegisterGeometry(s_id, f_id, std::move(geometry_D));
 
     scene_graph_ad_ = dynamic_pointer_cast<SceneGraph<AutoDiffXd>>(
         scene_graph_.ToAutoDiffXd());

--- a/multibody/plant/test/contact_results_to_lcm_test.cc
+++ b/multibody/plant/test/contact_results_to_lcm_test.cc
@@ -154,7 +154,8 @@ ContactSurface<T> MakeContactSurface(GeometryId id_M, GeometryId id_N,
   vertices.emplace_back(Vector3<double>(0.5, -0.5, -0.5) + offset);
   faces.emplace_back(0, 1, 2);
   faces.emplace_back(2, 3, 0);
-  auto mesh = make_unique<TriangleSurfaceMesh<T>>(move(faces), move(vertices));
+  auto mesh = make_unique<TriangleSurfaceMesh<T>>(std::move(faces),
+                                                  std::move(vertices));
 
   /* Create the "e" field values (i.e., "hydroelastic pressure") - simply
    increasing values at each vertex. */
@@ -164,8 +165,8 @@ ContactSurface<T> MakeContactSurface(GeometryId id_M, GeometryId id_N,
   TriangleSurfaceMesh<T>* mesh_pointer = mesh.get();
   EXPECT_EQ(mesh->num_triangles(), kNumFaces);
   return ContactSurface<T>(
-      id_M, id_N, move(mesh),
-      make_unique<MeshFieldLinear<T, TriangleSurfaceMesh<T>>>(move(e_MN),
+      id_M, id_N, std::move(mesh),
+      make_unique<MeshFieldLinear<T, TriangleSurfaceMesh<T>>>(std::move(e_MN),
                                                               mesh_pointer));
 }
 

--- a/multibody/plant/test/deformable_boundary_condition_test.cc
+++ b/multibody/plant/test/deformable_boundary_condition_test.cc
@@ -69,7 +69,7 @@ class DeformableIntegrationTest : public ::testing::Test {
     deformable_model->SetWallBoundaryCondition(
         body_id_, p_WQ_, n_W_);
     model_ = deformable_model.get();
-    plant_->AddPhysicalModel(move(deformable_model));
+    plant_->AddPhysicalModel(std::move(deformable_model));
     plant_->set_discrete_contact_solver(DiscreteContactSolver::kSap);
 
     /* Register a visual geometry for the "wall". */
@@ -85,7 +85,7 @@ class DeformableIntegrationTest : public ::testing::Test {
 
     auto contact_manager = make_unique<CompliantContactManager<double>>();
     manager_ = contact_manager.get();
-    plant_->SetDiscreteUpdateManager(move(contact_manager));
+    plant_->SetDiscreteUpdateManager(std::move(contact_manager));
     driver_ = CompliantContactManagerTester::deformable_driver(*manager_);
     /* Connect visualizer. Useful for when this test is used for debugging. */
     geometry::DrakeVisualizerd::AddToBuilder(&builder, *scene_graph_);
@@ -119,7 +119,7 @@ class DeformableIntegrationTest : public ::testing::Test {
   DeformableBodyId RegisterDeformableBall(DeformableModel<double>* model,
                                           std::string name) {
     auto geometry = make_unique<GeometryInstance>(
-        RigidTransformd(), make_unique<Sphere>(kRadius), move(name));
+        RigidTransformd(), make_unique<Sphere>(kRadius), std::move(name));
     ProximityProperties props;
     const CoulombFriction<double> kFriction{0.4, 0.4};
     geometry::AddContactMaterial({}, {}, kFriction, &props);

--- a/multibody/plant/test/deformable_driver_contact_kinematics_test.cc
+++ b/multibody/plant/test/deformable_driver_contact_kinematics_test.cc
@@ -57,8 +57,8 @@ class CompliantContactManagerTester {
 DeformableBodyId RegisterDeformableOctahedron(DeformableModel<double>* model,
                                               std::string name,
                                               const RigidTransformd& X_WF) {
-  auto geometry =
-      make_unique<GeometryInstance>(X_WF, make_unique<Sphere>(1.0), move(name));
+  auto geometry = make_unique<GeometryInstance>(X_WF, make_unique<Sphere>(1.0),
+                                                std::move(name));
   geometry::ProximityProperties props;
   geometry::AddContactMaterial({}, {}, CoulombFriction<double>(1.0, 1.0),
                                &props);

--- a/multibody/plant/test/deformable_integration_test.cc
+++ b/multibody/plant/test/deformable_integration_test.cc
@@ -76,7 +76,7 @@ class DeformableIntegrationTest : public ::testing::Test {
     body_id_ =
         RegisterDeformableOctahedron(deformable_model.get(), "deformable");
     model_ = deformable_model.get();
-    plant_->AddPhysicalModel(move(deformable_model));
+    plant_->AddPhysicalModel(std::move(deformable_model));
     plant_->set_discrete_contact_solver(DiscreteContactSolver::kSap);
 
     /* Register a rigid geometry that serves as an inclined plane. */
@@ -100,7 +100,7 @@ class DeformableIntegrationTest : public ::testing::Test {
 
     auto contact_manager = make_unique<CompliantContactManager<double>>();
     manager_ = contact_manager.get();
-    plant_->SetDiscreteUpdateManager(move(contact_manager));
+    plant_->SetDiscreteUpdateManager(std::move(contact_manager));
     driver_ = CompliantContactManagerTester::deformable_driver(*manager_);
     /* Connect visualizer. Useful for when this test is used for debugging. */
     geometry::DrakeVisualizerd::AddToBuilder(&builder, *scene_graph_);
@@ -140,7 +140,7 @@ class DeformableIntegrationTest : public ::testing::Test {
   DeformableBodyId RegisterDeformableOctahedron(DeformableModel<double>* model,
                                                 std::string name) {
     auto geometry = make_unique<GeometryInstance>(
-        RigidTransformd(), make_unique<Sphere>(0.1), move(name));
+        RigidTransformd(), make_unique<Sphere>(0.1), std::move(name));
     ProximityProperties props;
     geometry::AddContactMaterial({}, {}, kFriction, &props);
     geometry->set_proximity_properties(std::move(props));

--- a/multibody/plant/test/deformable_model_test.cc
+++ b/multibody/plant/test/deformable_model_test.cc
@@ -25,7 +25,7 @@ class DeformableModelTest : public ::testing::Test {
         AddMultibodyPlantSceneGraph(&builder_, kDt);
     auto deformable_model = make_unique<DeformableModel<double>>(plant_);
     deformable_model_ptr_ = deformable_model.get();
-    plant_->AddPhysicalModel(move(deformable_model));
+    plant_->AddPhysicalModel(std::move(deformable_model));
   }
 
   systems::DiagramBuilder<double> builder_;

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1915,7 +1915,7 @@ GTEST_TEST(MultibodyPlantTest, VisualGeometryRegistration) {
   // determine role assignment has happened.
   temp_engine->set_force_accept(true);
   const DummyRenderEngine& render_engine = *temp_engine;
-  scene_graph.AddRenderer("dummy", move(temp_engine));
+  scene_graph.AddRenderer("dummy", std::move(temp_engine));
   MultibodyPlant<double> plant(0.0);
   plant.RegisterAsSourceForSceneGraph(&scene_graph);
   EXPECT_EQ(render_engine.num_registered(), 0);

--- a/multibody/tree/test/body_node_test.cc
+++ b/multibody/tree/test/body_node_test.cc
@@ -53,7 +53,7 @@ namespace {
 class DummyBody : public Body<double> {
  public:
   DummyBody(std::string name, BodyIndex index)
-      : Body(move(name), ModelInstanceIndex(0)) {
+      : Body(std::move(name), ModelInstanceIndex(0)) {
     // We need a body index for the body node test to be happy.
     MultibodyElementTester::set_index(this, index);
   }

--- a/systems/rendering/multibody_position_to_geometry_pose.cc
+++ b/systems/rendering/multibody_position_to_geometry_pose.cc
@@ -19,7 +19,7 @@ MultibodyPositionToGeometryPose<T>::MultibodyPositionToGeometryPose(
 
 // Note: This constructor is not *obviously* correct. Compare it with this code:
 //   unique_ptr<Foo> f;
-//   bar(*f, move(f));
+//   bar(*f, std::move(f));
 // The invocation to bar may not be valid because the compiler can chose to
 // perform the move of f before the dereference (which would make the first
 // parameter a reference to null). However, this constructor works because:

--- a/systems/rendering/test/multibody_position_to_geometry_pose_test.cc
+++ b/systems/rendering/test/multibody_position_to_geometry_pose_test.cc
@@ -53,7 +53,7 @@ GTEST_TEST(MultibodyPositionToGeometryPoseTest, Ownership) {
                           "/iiwa7_no_collision.sdf"));
   mbp->Finalize();
 
-  const MultibodyPositionToGeometryPose<double> dut(move(mbp));
+  const MultibodyPositionToGeometryPose<double> dut(std::move(mbp));
   EXPECT_EQ(dut.get_input_port().size(),
             dut.multibody_plant().num_positions());
 
@@ -156,7 +156,7 @@ GTEST_TEST(MultibodyPositionToGeometryPoseTest, FullStateInput) {
   }
 
   // Test the ownership constructor also has the right size.
-  const MultibodyPositionToGeometryPose<double> owned_sys(move(mbp), true);
+  const MultibodyPositionToGeometryPose<double> owned_sys(std::move(mbp), true);
   EXPECT_EQ(owned_sys.get_input_port().size(),
             owned_sys.multibody_plant().num_multibody_states());
 }

--- a/systems/sensors/test/rgbd_sensor_test.cc
+++ b/systems/sensors/test/rgbd_sensor_test.cc
@@ -483,7 +483,7 @@ GTEST_TEST(RgbdSensorDiscrete, ImageHold) {
   RgbdSensor* sensor_raw = sensor.get();
   const double kPeriod = 0.1;
   const bool include_render_port = true;
-  RgbdSensorDiscrete discrete_sensor(move(sensor), kPeriod,
+  RgbdSensorDiscrete discrete_sensor(std::move(sensor), kPeriod,
                                      include_render_port);
 
   // This tests very *explicit* knowledge of what the wiring should be. As such,


### PR DESCRIPTION
Amends #19354.  In that PR, I only searched for the `using std::move;` statements.  Turns out, for things like move on a `std::unique_ptr`, we were getting away with ADL sometimes, too -- even in headers!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19356)
<!-- Reviewable:end -->
