### PR TITLE
[planning] Add velocity bounds to edges between subgraphs

### DIFF
--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -394,7 +394,10 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
     const auto& subgraph_edges_doc =
         doc.GcsTrajectoryOptimization.EdgesBetweenSubgraphs;
     py::class_<Class::EdgesBetweenSubgraphs>(
-        gcs_traj_opt, "EdgesBetweenSubgraphs", subgraph_edges_doc.doc);
+        gcs_traj_opt, "EdgesBetweenSubgraphs", subgraph_edges_doc.doc)
+        .def("AddVelocityBounds",
+            &Class::EdgesBetweenSubgraphs::AddVelocityBounds, py::arg("lb"),
+            py::arg("ub"), subgraph_edges_doc.AddVelocityBounds.doc);
 
     gcs_traj_opt  // BR
         .def(py::init<int>(), py::arg("num_positions"), cls_doc.ctor.doc)

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -408,20 +408,32 @@ class TestTrajectoryOptimization(unittest.TestCase):
         subspace_region = HPolyhedron(VPolytope(vertices[7]))
         subspace_point = Point([2.3, 3.5])
 
-        self.assertIsInstance(
-            gcs.AddEdges(from_subgraph=main1,
-                         to_subgraph=main2,
-                         subspace=subspace_point),
-            GcsTrajectoryOptimization.EdgesBetweenSubgraphs)
-        self.assertIsInstance(
-            gcs.AddEdges(main1, main2, subspace=subspace_region),
-            GcsTrajectoryOptimization.EdgesBetweenSubgraphs)
+        main1_to_main2_pt = gcs.AddEdges(main1, main2, subspace=subspace_point)
+        self.assertIsInstance(main1_to_main2_pt,
+                              GcsTrajectoryOptimization.EdgesBetweenSubgraphs)
+
+        main1_to_main2_region = gcs.AddEdges(main1,
+                                             main2,
+                                             subspace=subspace_region)
+        self.assertIsInstance(main1_to_main2_region,
+                              GcsTrajectoryOptimization.EdgesBetweenSubgraphs)
+
+        # Add half of the maximum velocity constraint at the subspace point
+        # and region.
+        main1_to_main2_pt.AddVelocityBounds(lb=-max_vel / 2, ub=max_vel / 2)
+        main1_to_main2_region.AddVelocityBounds(lb=-max_vel / 2,
+                                                ub=max_vel / 2)
 
         # We connect the start and goal regions to the rest of the graph.
         self.assertIsInstance(gcs.AddEdges(source, main1),
                               GcsTrajectoryOptimization.EdgesBetweenSubgraphs)
-        self.assertIsInstance(gcs.AddEdges(main2, target),
+        main2_to_target = gcs.AddEdges(main2, target)
+        self.assertIsInstance(main2_to_target,
                               GcsTrajectoryOptimization.EdgesBetweenSubgraphs)
+
+        # Add final zero velocity constraints.
+        main2_to_target.AddVelocityBounds(lb=np.zeros(dimension),
+                                          ub=np.zeros(dimension))
 
         # This weight matrix penalizes movement in the y direction three
         # times more than in the x direction only for the main2 subgraph.

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.cc
@@ -57,6 +57,7 @@ Subgraph::Subgraph(
     GcsTrajectoryOptimization* traj_opt)
     : regions_(regions),
       order_(order),
+      h_min_(h_min),
       name_(std::move(name)),
       traj_opt_(*traj_opt) {
   DRAKE_THROW_UNLESS(order >= 0);
@@ -128,6 +129,7 @@ Subgraph::Subgraph(
 
     vertices_.emplace_back(traj_opt_.gcs_.AddVertex(
         CartesianProduct(vertex_set), fmt::format("{}: {}", name, i)));
+    traj_opt->vertex_to_subgraph_[vertices_.back()] = this;
   }
 
   // Connect vertices with edges.
@@ -253,7 +255,9 @@ void Subgraph::AddVelocityBounds(const Eigen::Ref<const VectorXd>& lb,
 EdgesBetweenSubgraphs::EdgesBetweenSubgraphs(
     const Subgraph& from_subgraph, const Subgraph& to_subgraph,
     const ConvexSet* subspace, GcsTrajectoryOptimization* traj_opt)
-    : traj_opt_(*traj_opt) {
+    : traj_opt_(*traj_opt),
+      from_subgraph_order_(from_subgraph.order()),
+      to_subgraph_order_(to_subgraph.order()) {
   // Formulate edge costs and constraints.
   if (subspace != nullptr) {
     if (subspace->ambient_dimension() != num_positions()) {
@@ -376,6 +380,90 @@ bool EdgesBetweenSubgraphs::RegionsConnectThroughSubspace(
     subspace.AddPointInSetConstraints(&prog, x);
     solvers::MathematicalProgramResult result = solvers::Solve(prog);
     return result.is_success();
+  }
+}
+
+void EdgesBetweenSubgraphs::AddVelocityBounds(
+    const Eigen::Ref<const VectorXd>& lb,
+    const Eigen::Ref<const VectorXd>& ub) {
+  DRAKE_THROW_UNLESS(lb.size() == num_positions());
+  DRAKE_THROW_UNLESS(ub.size() == num_positions());
+
+  // We have q̇(t) = drds * dsdt = ṙ(s) / h, and h >= 0, so we
+  // use h * lb <= ṙ(s) <= h * ub, formulated as:
+  // - inf <=   h * lb - ṙ(s) <= 0
+  // - inf <= - h * ub + ṙ(s) <= 0
+
+  // We will enforce the velocity bounds on the last control point of the u set
+  // and on the first control point of the v set unless one of the sets are of
+  // order zero. In the zero order case, velocity doesn't matter since its a
+  // point.
+
+  if (from_subgraph_order_ == 0 && to_subgraph_order_ == 0) {
+    throw std::runtime_error(
+        "Cannot add velocity bounds to a subgraph edges where both subgraphs "
+        "have zero order.");
+  }
+
+  if (from_subgraph_order_ > 0) {
+    // Add velocity bounds to the last control point of the u set.
+
+    const MatrixX<Expression> u_rdot_control =
+        dynamic_pointer_cast_or_throw<BezierCurve<Expression>>(
+            u_r_trajectory_.MakeDerivative())
+            ->control_points();
+
+    MatrixXd b(u_h_.rows(), u_vars_.size());
+    DecomposeLinearExpressions(u_h_.cast<Expression>(), u_vars_, &b);
+
+    // Last control point velocity constraint.
+    MatrixXd M(num_positions(), u_vars_.size());
+    DecomposeLinearExpressions(u_rdot_control.col(u_rdot_control.cols() - 1),
+                               u_vars_, &M);
+    // TODO(wrangelvid) The matrix M might be sparse, so we could drop columns
+    // for both M and b here.
+    MatrixXd H(2 * num_positions(), M.cols());
+    H << M - ub * b, -M + lb * b;
+
+    const auto last_ctrl_pt_velocity_constraint =
+        std::make_shared<LinearConstraint>(
+            H, VectorXd::Constant(2 * num_positions(), -kInf),
+            VectorXd::Zero(2 * num_positions()));
+
+    for (Edge* edge : edges_) {
+      edge->AddConstraint(Binding<LinearConstraint>(
+          last_ctrl_pt_velocity_constraint, edge->xu()));
+    }
+  }
+
+  if (to_subgraph_order_ > 0) {
+    // Add velocity bounds to the first control point of the v set.
+    const MatrixX<Expression> v_rdot_control =
+        dynamic_pointer_cast_or_throw<BezierCurve<Expression>>(
+            v_r_trajectory_.MakeDerivative())
+            ->control_points();
+
+    MatrixXd b(v_h_.rows(), v_vars_.size());
+    DecomposeLinearExpressions(v_h_.cast<Expression>(), v_vars_, &b);
+
+    // First control point velocity constraint.
+    MatrixXd M(num_positions(), v_vars_.size());
+    DecomposeLinearExpressions(v_rdot_control.col(0), v_vars_, &M);
+    // TODO(wrangelvid) The matrix M might be sparse, so we could drop columns
+    // for both M and b here.
+
+    MatrixXd H(2 * num_positions(), M.cols());
+    H << M - ub * b, -M + lb * b;
+
+    const auto first_ctrl_pt_velocity_constraint =
+        std::make_shared<LinearConstraint>(
+            H, VectorXd::Constant(2 * num_positions(), -kInf),
+            VectorXd::Zero(2 * num_positions()));
+
+    for (Edge* edge : edges_) {
+      edge->AddConstraint(Binding<LinearConstraint>(
+          first_ctrl_pt_velocity_constraint, edge->xv()));
+    }
   }
 }
 
@@ -588,35 +676,49 @@ GcsTrajectoryOptimization::SolvePath(const Subgraph& source,
     // in case we get the relaxed solution.
     const double phi_inv = 1 / result.GetSolution(edge->phi());
     // Extract the control points from the solution.
-    const int num_control_points = (edge->xu().size() - 1) / num_positions();
+    const int num_control_points = vertex_to_subgraph_[&edge->u()]->order() + 1;
     const MatrixX<double> edge_path_points =
         phi_inv *
         Eigen::Map<MatrixX<double>>(result.GetSolution(edge->xu()).data(),
                                     num_positions(), num_control_points);
 
     // Extract the duration from the solution.
-    const double h = phi_inv * result.GetSolution(edge->xu()).tail<1>().value();
+    double h = phi_inv * result.GetSolution(edge->xu()).tail<1>().value();
     const double start_time =
         bezier_curves.empty() ? 0 : bezier_curves.back()->end_time();
-    bezier_curves.emplace_back(std::make_unique<BezierCurve<double>>(
-        start_time, start_time + h, edge_path_points));
+
+    // Skip edges with a single control point that spend near zero time in the
+    // region, since zero order continuity constraint is sufficient. These edges
+    // would result in a discontinuous trajectory for velocities and higher
+    // derivatives.
+    if (!(num_control_points == 1 &&
+          vertex_to_subgraph_[&edge->u()]->h_min_ == 0)) {
+      bezier_curves.emplace_back(std::make_unique<BezierCurve<double>>(
+          start_time, start_time + h, edge_path_points));
+    }
   }
 
   // Get the final control points from the solution.
   const double phi_inv = 1 / result.GetSolution(path_edges.back()->phi());
   const int num_control_points =
-      (path_edges.back()->xv().size() - 1) / num_positions();
+      vertex_to_subgraph_[&path_edges.back()->v()]->order() + 1;
   const MatrixX<double> edge_path_points =
       phi_inv * Eigen::Map<MatrixX<double>>(
                     result.GetSolution(path_edges.back()->xv()).data(),
                     num_positions(), num_control_points);
 
-  const double h =
+  double h =
       phi_inv * result.GetSolution(path_edges.back()->xv()).tail<1>().value();
   const double start_time =
       bezier_curves.empty() ? 0 : bezier_curves.back()->end_time();
-  bezier_curves.emplace_back(std::make_unique<BezierCurve<double>>(
-      start_time, start_time + h, edge_path_points));
+
+  // Skip edges with a single control point that spend near zero time in the
+  // region, since zero order continuity constraint is sufficient.
+  if (!(num_control_points == 1 &&
+        vertex_to_subgraph_[&path_edges.back()->v()]->h_min_ == 0)) {
+    bezier_curves.emplace_back(std::make_unique<BezierCurve<double>>(
+        start_time, start_time + h, edge_path_points));
+  }
 
   return {CompositeTrajectory<double>(bezier_curves), result};
 }


### PR DESCRIPTION
This adds velocity bounds on `EdgesBetweenSubgraphs`, which can be used to enable zero initial/final velocities, but also the proper use of delays in the graph.
It also fixes a bug when extracting the solution to ensure continuity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19357)
<!-- Reviewable:end -->
