### PR TITLE
Fix fmt for fs::path

### DIFF
--- a/geometry/render/render_material.cc
+++ b/geometry/render/render_material.cc
@@ -99,8 +99,8 @@ RenderMaterial DefineMaterial(
       // message with the additional context.
       policy.Warning(fmt::format(
           "The ('phong', 'diffuse_map') property referenced a map that "
-          "could not be found: {}",
-          material.diffuse_map));
+          "could not be found: '{}'",
+          material.diffuse_map.string()));
       material.diffuse_map.clear();
     }
   }


### PR DESCRIPTION
Amends #19352.

This is required for macOS.  By default on that platform, `std::filesystem::path` is not formattable unless we include a special header file.

Example failuire: https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/mac-arm-monterey-clang-bazel-continuous-release/672/consoleFull

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19359)
<!-- Reviewable:end -->
