### PR TITLE
Remove dead code

### DIFF
--- a/common/symbolic/expression/test/substitution_test.cc
+++ b/common/symbolic/expression/test/substitution_test.cc
@@ -4,7 +4,6 @@
 
 #include <functional>
 #include <stdexcept>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -14,9 +13,7 @@
 
 using std::exception;
 using std::function;
-using std::is_same;
 using std::pair;
-using std::result_of;
 using std::vector;
 
 namespace drake {


### PR DESCRIPTION
The newest macOS Xcode complains about this (see https://drake-jenkins.csail.mit.edu/view/Mac%20Ventura/job/mac-arm-ventura-clang-bazel-continuous-non-production-release/10/).

Towards #18327.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19360)
<!-- Reviewable:end -->
