### PR TITLE
[abseil] Fix TSan linking errors

### DIFF
--- a/common/symbolic/expression/BUILD.bazel
+++ b/common/symbolic/expression/BUILD.bazel
@@ -52,6 +52,7 @@ drake_cc_library(
         "//common:random",
     ],
     deps = [
+        "@abseil_cpp_internal//absl/container:flat_hash_set",
         "@abseil_cpp_internal//absl/container:inlined_vector",
         "@fmt",
     ],

--- a/common/symbolic/expression/expression.cc
+++ b/common/symbolic/expression/expression.cc
@@ -6,8 +6,8 @@
 #include <algorithm>
 #include <ios>
 #include <stdexcept>
-#include <unordered_set>
 
+#include "absl/container/flat_hash_set.h"
 #include "absl/container/inlined_vector.h"
 #include <fmt/format.h>
 
@@ -1077,7 +1077,7 @@ void Gemm<reverse>::CalcDV(const MatrixRef<double>& D,
   absl::InlinedVector<Expression, kSmallSize> inner_vars_as_expr;
   inner_vars_as_expr.reserve(max_k);
   // The unique_ids is used to efficiently de-duplicate vars.
-  std::unordered_set<Variable::Id> unique_ids;
+  absl::flat_hash_set<Variable::Id> unique_ids;
   unique_ids.reserve(max_k);
   // The var_index[k] refers to the index in inner_vars[] for that variable.
   // We have inner_vars[var_index[k]] == V(k, j) during the j'th row loop,

--- a/common/symbolic/expression/test/mixing_scalar_types_test.cc
+++ b/common/symbolic/expression/test/mixing_scalar_types_test.cc
@@ -469,8 +469,8 @@ TEST_F(SymbolicMixingScalarTypesTest, MatrixMatrixMultiplicationVarDouble) {
 TEST_F(SymbolicMixingScalarTypesTest, MatrixMatrixMultiplicationVarDoubleHeap) {
   M_double_fixed_ = Eigen::Matrix2d::Identity();
   const int expected_alloc =
-      // The temporary unordered_set.
-      5
+      // The temporary flat_hash_set.
+      1
       // One expression cell for each variable.
       + 4;
   LimitMalloc guard({.max_num_allocations = expected_alloc});
@@ -532,8 +532,8 @@ TEST_F(SymbolicMixingScalarTypesTest, MatrixMatrixMultiplicationDoubleVar) {
 TEST_F(SymbolicMixingScalarTypesTest, MatrixMatrixMultiplicationDoubleVarHeap) {
   M_double_fixed_ = Eigen::Matrix2d::Identity();
   const int expected_alloc =
-      // The temporary unordered_set.
-      5
+      // The temporary flat_hash_set.
+      1
       // One expression cell for each variable.
       + 4;
   LimitMalloc guard({.max_num_allocations = expected_alloc});

--- a/tools/workspace/abseil_cpp_internal/patches/hidden_visibility.patch
+++ b/tools/workspace/abseil_cpp_internal/patches/hidden_visibility.patch
@@ -2,8 +2,8 @@ Use hidden symbol visibility for Abseil's C++ code.
 
 This probably improves linker and loader throughput.
 
---- absl/base/config.h.orig	2022-03-08 13:01:16.000000000 -0800
-+++ absl/base/config.h	2022-03-13 13:46:02.698469827 -0700
+--- absl/base/config.h.orig
++++ absl/base/config.h
 @@ -153,7 +153,7 @@
  #define ABSL_INTERNAL_C_SYMBOL(x) x
  #elif ABSL_OPTION_USE_INLINE_NAMESPACE == 1
@@ -13,3 +13,14 @@ This probably improves linker and loader throughput.
  #define ABSL_NAMESPACE_END }
  #define ABSL_INTERNAL_C_SYMBOL_HELPER_2(x, v) x##_##v
  #define ABSL_INTERNAL_C_SYMBOL_HELPER_1(x, v) \
+--- absl/synchronization/mutex.cc.orig
++++ absl/synchronization/mutex.cc
+@@ -2784,7 +2784,7 @@
+ }
+ 
+ #ifdef ABSL_HAVE_THREAD_SANITIZER
+-extern "C" void __tsan_read1(void *addr);
++extern "C" void __tsan_read1(void *addr) __attribute__((visibility ("default")));
+ #else
+ #define __tsan_read1(addr)  // do nothing if TSan not enabled
+ #endif


### PR DESCRIPTION
This also reverts #19361, amending #19345.

When the linker resolves abseil's call to `__tsan_read1`, we want it to search the public symbols of our library dependencies (i.e., `libtsan`, which provides this symbol), not the hidden symbols within `libdrake` (which does not provide this symbol).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19363)
<!-- Reviewable:end -->
