### PR TITLE
Add RenderMaterial to RenderMesh

### DIFF
--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -84,7 +84,11 @@ drake_cc_library(
     srcs = ["render_mesh.cc"],
     hdrs = ["render_mesh.h"],
     interface_deps = [
+        ":render_material",
+        "//common:diagnostic_policy",
         "//common:essential",
+        "//geometry:geometry_properties",
+        "//geometry:rgba",
     ],
     deps = [
         "@tinyobjloader",
@@ -149,8 +153,11 @@ drake_cc_googletest(
     deps = [
         ":render_mesh",
         "//common:find_resource",
+        "//common:temp_directory",
+        "//common/test_utilities:diagnostic_policy_test_base",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+        "//geometry:geometry_roles",
     ],
 )
 

--- a/geometry/render/render_material.cc
+++ b/geometry/render/render_material.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/render/render_material.h"
 
 #include <fstream>
+#include <string>
 #include <vector>
 
 #include <fmt/format.h>

--- a/geometry/render/render_material.h
+++ b/geometry/render/render_material.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <filesystem>
-#include <string>
 
 #include "drake/common/diagnostic_policy.h"
 #include "drake/geometry/geometry_properties.h"

--- a/geometry/render/render_mesh.cc
+++ b/geometry/render/render_mesh.cc
@@ -1,8 +1,10 @@
 #include "drake/geometry/render/render_mesh.h"
 
+#include <algorithm>
 #include <fstream>
-#include <istream>
 #include <map>
+#include <set>
+#include <string>
 #include <tuple>
 #include <vector>
 
@@ -16,47 +18,118 @@
 namespace drake {
 namespace geometry {
 namespace internal {
+namespace {
 
+using drake::internal::DiagnosticPolicy;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
 using std::make_tuple;
 using std::map;
-using std::string;
 using std::tuple;
 using std::vector;
 
-RenderMesh LoadRenderMeshFromObj(std::istream* input_stream,
-                                 const std::string& filename) {
-  tinyobj::attrib_t attrib;
-  vector<tinyobj::shape_t> shapes;
-  vector<tinyobj::material_t> materials;
-  string warn;
-  string err;
-  /* This renderer assumes everything is triangles -- we rely on tinyobj to
-   triangulate for us. */
-  const bool do_tinyobj_triangulation = true;
+/* Constructs a RenderMaterial from a single tinyobj material specification. */
+RenderMaterial MakeMaterialFromMtl(const tinyobj::material_t& mat,
+                                   const std::filesystem::path& obj_path,
+                                   const GeometryProperties& properties,
+                                   bool has_tex_coord,
+                                   const DiagnosticPolicy& policy) {
+  RenderMaterial result;
+  result.diffuse.set(mat.diffuse[0], mat.diffuse[1], mat.diffuse[2],
+                     mat.dissolve);
+  result.diffuse_map = [&mat, &obj_path]() -> std::string {
+    if (mat.diffuse_texname.empty()) {
+      return mat.diffuse_texname;
+    }
+    std::filesystem::path tex_path(mat.diffuse_texname);
+    if (tex_path.is_absolute()) {
+      return mat.diffuse_texname;
+    }
+    // There are three potential paths: path to obj, path to mtl, and path to
+    // texture image (png). We have the path to obj. The mtl is defined relative
+    // to the obj (inside the obj) and the png is defined relative to the
+    // mtl (defined in the mtl). However, tinyobj doesn't give us access to
+    // the mtl path to resolve image paths. For now, we're making the
+    // simplifying assumption that obj and mtl are in the same directory.
+    //
+    // What if the OBJ references multiple mtl files in disparate locations?
+    // Ideally, `material_t` should  come with a string indicating either the
+    // the mtl file it came from or the directory of that mtl file. Then
+    // relative paths of the referenced images can be properly interpreted.
+    // Or what is stored in material_t should be relative to the obj.
+    std::filesystem::path obj_dir = obj_path.parent_path();
+    return (obj_dir / tex_path).lexically_normal().string();
+  }();
 
-  drake::log()->trace("LoadRenderMeshFromObj('{}')", filename);
-
-  /* Tinyobj doesn't infer the search directory from the directory containing
-   the obj file. We have to provide that directory; of course, this assumes
-   that the material library reference is relative to the obj directory.
-   Ignore material-library file.  */
-  tinyobj::MaterialReader* material_reader = nullptr;
-  const bool ret =
-      tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, input_stream,
-                       material_reader, do_tinyobj_triangulation);
-  if (!ret) {
-    throw std::runtime_error(
-        fmt::format("tinyobj::LoadObj failed to load file: {}", filename));
+  // If texture is specified, it must be available and applicable.
+  if (!result.diffuse_map.empty()) {
+    std::ifstream tex_file(result.diffuse_map);
+    if (!tex_file.is_open()) {
+      policy.Warning(fmt::format(
+          "The OBJ file's material requested an unavailable diffuse texture "
+          "image: {}. The image will be omitted.",
+          result.diffuse_map.string()));
+      result.diffuse_map.clear();
+    }
+    if (!has_tex_coord) {
+      policy.Warning(fmt::format(
+          "The OBJ file's material requested a diffuse texture image: {}. "
+          "However the mesh doesn't define texture coordinates. The image "
+          "will be omitted.",
+          result.diffuse_map.string()));
+      result.diffuse_map.clear();
+    }
   }
 
-  if (shapes.empty()) {
+  MaybeWarnForRedundantMaterial(properties, obj_path.string(), policy);
+  return result;
+}
+
+}  // namespace
+
+// TODO(SeanCurtis-TRI): Add troubleshooting entry on OBJ support and
+// reference it in these errors/warnings.
+
+RenderMesh LoadRenderMeshFromObj(const std::filesystem::path& obj_path,
+                                 const GeometryProperties& properties,
+                                 const Rgba& default_diffuse,
+                                 const DiagnosticPolicy& policy) {
+  tinyobj::ObjReaderConfig config;
+  config.triangulate = true;
+  config.vertex_color = false;
+  tinyobj::ObjReader reader;
+  const bool valid_parse = reader.ParseFromFile(obj_path.string(), config);
+
+  if (!valid_parse) {
+    throw std::runtime_error(fmt::format("Failed parsing the obj file: {}: {}",
+                                         obj_path.string(), reader.Error()));
+  }
+
+  // We better not get any errors if we have a valid parse.
+  DRAKE_DEMAND(reader.Error().empty());
+
+  const vector<tinyobj::shape_t>& shapes = reader.GetShapes();
+
+  bool faces_found = false;
+  for (const auto& shape : shapes) {
+    faces_found = shape.mesh.indices.size() > 0;
+    if (faces_found) break;
+  }
+  if (!faces_found) {
     throw std::runtime_error(fmt::format(
         "The OBJ data appears to have no faces; it could be missing faces or "
         "might not be an OBJ file: {}",
-        filename));
+        obj_path.string()));
   }
+
+  if (!reader.Warning().empty()) {
+    policy.Warning(reader.Warning());
+  }
+
+  const tinyobj::attrib_t& attrib = reader.GetAttrib();
+
+  // All of the materials referenced by faces.
+  std::set<int> referenced_materials;
 
   /* The parsed product needs to be further processed. The RenderMesh assumes
    that all vertex quantities (positions, normals, texture coordinates) are
@@ -104,9 +177,8 @@ RenderMesh LoadRenderMeshFromObj(std::istream* input_stream,
   //   1. If normals are absent, generate normals so that we get faceted meshes.
   //   2. Make use of smoothing groups.
   if (attrib.normals.size() == 0) {
-    throw std::runtime_error(fmt::format(
-        "OBJ has no normals; RenderEngineGl requires OBJs with normals: {}",
-        filename));
+    throw std::runtime_error(
+        fmt::format("OBJ has no normals: {}", obj_path.string()));
   }
 
   bool has_tex_coord{attrib.texcoords.size() > 0};
@@ -131,13 +203,14 @@ RenderMesh LoadRenderMeshFromObj(std::istream* input_stream,
         const int norm_index = shape_mesh.indices[v_index].normal_index;
         const int uv_index = shape_mesh.indices[v_index].texcoord_index;
         if (norm_index < 0) {
-          throw std::runtime_error(
-              fmt::format("Not all faces reference normals: {}", filename));
+          throw std::runtime_error(fmt::format(
+              "Not all faces reference normals: {}", obj_path.string()));
         }
         if (has_tex_coord) {
           if (uv_index < 0) {
-            throw std::runtime_error(fmt::format(
-                "Not all faces reference texture coordinates: {}", filename));
+            throw std::runtime_error(
+                fmt::format("Not all faces reference texture coordinates: {}",
+                            obj_path.string()));
           }
         } else {
           DRAKE_DEMAND(uv_index < 0);
@@ -167,6 +240,7 @@ RenderMesh LoadRenderMeshFromObj(std::istream* input_stream,
         ++v_index;
       }
       triangles.emplace_back(&face_vertices[0]);
+      referenced_materials.insert(shape_mesh.material_ids[f]);
     }
   }
 
@@ -193,16 +267,38 @@ RenderMesh LoadRenderMeshFromObj(std::istream* input_stream,
     mesh_data.uvs.row(uv) = uvs[uv];
   }
 
-  return mesh_data;
-}
-
-RenderMesh LoadRenderMeshFromObj(const string& filename) {
-  std::ifstream input_stream(filename);
-  if (!input_stream.is_open()) {
-    throw std::runtime_error(
-        fmt::format("Cannot load the obj file '{}'", filename));
+  // If we've only used a single material in the OBJ, use it. If the only
+  // referenced material is "-1", it means there is no material.
+  if (referenced_materials.size() == 1 && referenced_materials.count(-1) == 0) {
+    mesh_data.material =
+        MakeMaterialFromMtl(reader.GetMaterials().front(), obj_path,
+                            properties, has_tex_coord, policy);
+  } else {
+    // We'll need to use the material fallback logic for meshes.
+    if (referenced_materials.size() > 1) {
+      vector<std::string_view> mat_names;
+      // If the referenced material is < 0 (typically -1), it represents the
+      // *unnamed* default material. We need to detect it and provide *some*
+      // name for the error. We choose __default__ as being conspicuous but with
+      // a low probability that it was actually chosen by the user.
+      std::transform(
+          referenced_materials.begin(), referenced_materials.end(),
+          std::back_inserter(mat_names), [&reader](int i) {
+            return i < 0 ? std::string("__default__")
+                         : fmt::format("'{}'", reader.GetMaterials()[i].name);
+          });
+      policy.Warning(fmt::format(
+          "Drake currently only supports OBJs that use a single material "
+          "across the whole mesh; for {}, {} materials were used: {}. The "
+          "parsed materials will not be used.",
+          obj_path.string(), referenced_materials.size(),
+          fmt::join(mat_names, ", ")));
+    }
+    mesh_data.material = MakeMeshFallbackMaterial(properties, obj_path,
+                                                  default_diffuse, policy);
   }
-  return LoadRenderMeshFromObj(&input_stream, filename);
+
+  return mesh_data;
 }
 
 }  // namespace internal

--- a/geometry/render/render_mesh.h
+++ b/geometry/render/render_mesh.h
@@ -1,20 +1,24 @@
 #pragma once
 
-#include <istream>
-#include <string>
+#include <filesystem>
 
 #include <Eigen/Dense>
+
+#include "drake/common/diagnostic_policy.h"
+#include "drake/geometry/geometry_properties.h"
+#include "drake/geometry/render/render_material.h"
+#include "drake/geometry/rgba.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
 
-/* The data representing a mesh. The triangle mesh is defined by `indices`. Row
- t represents a triangle by the triplet of vertex indices: tᵥ₀, tᵥ₁, tᵥ₂. The
- indices map into the rows of `positions`, `normals`, and `uvs`. I.e., for
- vertex index v, the position of that vertex is at `positions.row(v)`, its
- corresponding normal is at `normals.row(v)`, and its texture coordinates are at
- `uvs.row(v)`.
+/* The data representing a mesh with a single material. The triangle mesh is
+ defined by `indices`. Row t represents a triangle by the triplet of vertex
+ indices: tᵥ₀, tᵥ₁, tᵥ₂. The indices map into the rows of `positions`,
+ `normals`, and `uvs`. I.e., for vertex index v, the position of that vertex is
+ at `positions.row(v)`, its corresponding normal is at `normals.row(v)`, and its
+ texture coordinates are at `uvs.row(v)`.
 
  For now, all vertex quantities (`positions`, `normals` and `uvs`) are
  guaranteed (as well as the `indices` data). In the future, `uvs` may become
@@ -25,37 +29,82 @@ struct RenderMesh {
   Eigen::Matrix<double, Eigen::Dynamic, 2, Eigen::RowMajor> uvs;
   Eigen::Matrix<unsigned int, Eigen::Dynamic, 3, Eigen::RowMajor> indices;
 
-  /** See docs for `has_tex_coord` below.  */
+  /* See docs for `has_tex_coord` below.  */
   static constexpr bool kHasTexCoordDefault{true};
 
-  /** This flag indicates that this mesh has texture coordinates to support
+  // TODO(SeanCurtis-TRI): this flag was necessary when materials and meshes
+  // were resolved separately. Now that we resolve materials at the same time,
+  // we should maintain the invariants that the presence of a texture map
+  // implies the presence of texture coordinates. We make no guarantees about
+  // the opposite direction -- that should only be relevant to efforts to add a
+  // texture material to a RenderMesh that didn't originally parse into having
+  // a texture material. It may or may not work. It also means that this
+  // cannot be a struct; structs don't get to maintain invariants.
+  /* This flag indicates that this mesh has texture coordinates to support
    maps.
    If True, the values of `uvs` will be nontrivial.
    If False, the values of `uvs` will be all zeros, but will still have the
    correct size.  */
   bool has_tex_coord{kHasTexCoordDefault};
+
+  /* The specification of the material associated with this mesh data. */
+  RenderMaterial material;
 };
 
-/* Loads a mesh's vertices and indices (faces) from an OBJ description given
- in the input stream. It does not load textures. Note that while this
- functionality seems similar to ReadObjToTriangleSurfaceMesh, RenderEngineGl
- cannot use TriangleSurfaceMesh. Rendering requires normals and texture
- coordinates; TriangleSurfaceMesh was not designed with those quantities in
- mind.
+// TODO(SeanCurtis-TRI): All of this explanation, and general guidance for what
+// meshes (and which features) are supported, needs to go into the trouble-
+// shooting guide.
+// TODO(SeanCurtis-TRI): Modify the API to return a *set* of RenderMesh, each
+// with a unique material.
+/* Returns a single instance of RenderMesh from the indicated obj file.
+
+ The material definition will come from the obj's mtl file iff a single material
+ is applied to all faces in the obj. Otherwise, it applies the fallback
+ material protocol documented in MakeMeshFallbackMaterial() (the only time in
+ which the `properties` and `default_diffuse` parameters are used).
+
+ As long as there is a single material applied to all faces in the obj file,
+ the material will be derived from the material library, even if the material
+ specification is flawed. The derivation does its best to provide the "best"
+ approximation of the declared material. But the fact it was declared and
+ applied is respected. For example, the following are specification defects
+ that nevertheless result in a RenderMaterial _based_ on the mtl material and
+ _not_ on the fallback logic:
+
+   - Referencing a non-existent or unavailable texture.
+   - Failing to specify *any* material properties at all beyond its name.
+   - Specifying a texture but failing to provide texture coordinates.
+   - etc.
+
+ Note: This API is similar to ReadObjToTriangleSurfaceMesh, but it differs in
+ several ways:
+
+    - Support of per-vertex data that TriangleSurfaceMesh doesn't support
+      (e.g., vertex normals, texture coordinates).
+    - Material semantics.
+    - The geometric data is reconditioned to be compatible with "geometry
+      buffer" applications. (See RenderMesh for details.)
 
  If no texture coordinates are specified by the file, it will be indicated in
  the returned RenderMesh. See RenderMesh::has_tex_coord for more detail.
+
+ If the material includes texture paths, they will have been confirmed to both
+ exist and be accessible.
+
+ TODO(SeanCurtis-TRI): all throwing conditions should be converted to messages
+ on the policy. Problems that would produce an "empty" mesh (e.g., no
+ faces/normals) would log errors on the policy (and return the empty mesh).
+ Others, like no uvs referenced, should emit a warning and return a non-empty
+ mesh, representing the best approximation of what was parsed.
 
  @throws std::exception if a) tinyobj::LoadObj() fails, (b) there are no faces
                            or normals, c) faces fail to reference normals, or d)
                            faces fail to reference the texture coordinates if
                            they are present.  */
-RenderMesh LoadRenderMeshFromObj(std::istream* input_stream,
-                                 const std::string& filename = "from_string");
-
-/* Overload of LoadRenderMeshFromObj that reads the OBJ description from the
- given file. */
-RenderMesh LoadRenderMeshFromObj(const std::string& filename);
+RenderMesh LoadRenderMeshFromObj(
+    const std::filesystem::path& obj_path, const GeometryProperties& properties,
+    const Rgba& default_diffuse,
+    const drake::internal::DiagnosticPolicy& policy = {});
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/render/test/render_mesh_test.cc
+++ b/geometry/render/test/render_mesh_test.cc
@@ -1,121 +1,199 @@
 #include "drake/geometry/render/render_mesh.h"
 
-#include <sstream>
+#include <filesystem>
+#include <fstream>
 #include <vector>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/find_resource.h"
+#include "drake/common/never_destroyed.h"
+#include "drake/common/temp_directory.h"
+#include "drake/common/test_utilities/diagnostic_policy_test_base.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/geometry_roles.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
 namespace {
 
-using Eigen::AngleAxisf;
+using Eigen::AngleAxisd;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
 using std::vector;
 
-GTEST_TEST(LoadRenderMeshFromObjTest, ErrorModes) {
+namespace fs = std::filesystem;
+
+/* The tests for the function LoadRenderMeshFromObj are partitioned into two
+ broad categories indicated by prefix:
+
+   - Geometry: evaluation of the geometry produced.
+     - The tests confirm that the data gets processed as expected, including
+       expected error conditions.
+   - Material: evaluation of the material generation logic.
+     - LoadRenderMeshFromObj is responsible for defining a material from a
+       material library where possible and, failing that, creating a fallback
+       material using the RenderMaterial functions.
+     - There are many ways in which the library has problems, but we still get
+       a library-based material. These tests are prefixed as MaterialLibrary.
+     - Where the material library can't be used, we resort to the material
+       fallback logic. These are prefixed as MaterialFallback. */
+class LoadRenderMeshFromObjTest : public test::DiagnosticPolicyTestBase {
+ protected:
+  static fs::path WriteFile(std::string_view contents,
+                            std::string_view file_name,
+                            const fs::path& dir = temp_dir()) {
+    const fs::path file_path = dir / file_name;
+    std::ofstream out(file_path);
+    DRAKE_DEMAND(out.is_open());
+    out << contents;
+    return file_path;
+  }
+
+  static void SetUpTestSuite() {
+    // Make sure we have a valid texture in the same directory as the mtl file
+    // that names it.
+    fs::path image_source_path(
+        FindResourceOrThrow("drake/geometry/render/test/diag_gradient.png"));
+    fs::path image_target_path = temp_dir() / "diag_gradient.png";
+    fs::copy(image_source_path, image_target_path);
+
+    WriteFile(R"""(
+    newmtl test_material
+    Ka 0.1 0.1 0.1
+    Kd 0.5 1.0 1.0
+    Ks 1.0 1.0 1.0
+    d 1
+    illum 2
+    Ns 0
+  )""",
+              basic_mtl);
+
+    WriteFile(R"""(
+    newmtl test_material_1
+    Kd 1.0 0.0 1.0
+
+    newmtl test_material_2
+    Kd 1.0 0.0 0.0
+  )""",
+              multi_mtl);
+
+    WriteFile(R"""(
+    newmtl test_material
+    Ka 0.1 0.1 0.1
+    Kd 1.0 1.0 0.0
+    Ks 1.0 1.0 1.0
+    d 1
+    illum 2
+    Ns 0
+    map_Kd diag_gradient.png
+  )""",
+              texture_mtl);
+
+    WriteFile(R"""(
+    newmtl test_material
+    map_Kd diag_gradient.png
+  )""",
+              texture_only_mtl);
+  }
+
+  static fs::path temp_dir() {
+    static const never_destroyed<fs::path> temp_path(temp_directory());
+    return temp_path.access();
+  }
+
+  /* Specifies no material properties at all. */
+  static PerceptionProperties empty_props() { return {}; }
+
+  static constexpr char basic_mtl[] = "basic.mtl";
+  static constexpr char multi_mtl[] = "multi.mtl";
+  static constexpr char texture_mtl[] = "texture.mtl";
+  static constexpr char texture_only_mtl[] = "texture_only.mtl";
+};
+
+static_assert(
+    std::is_trivially_destructible_v<Rgba>,
+    "If this fails, kDefaultDiffuse needs to become a never-destroyed static.");
+const Rgba kDefaultDiffuse(0.75, 0.5, 0.25, 0.125);
+
+TEST_F(LoadRenderMeshFromObjTest, GeometryErrorModes) {
+  int error = -1;
+  {
+    // Case: file can't be parsed. The simplest way to achieve a invalid parse
+    // is simply for the file to not exist. Any other conditions that tinyobj
+    // considers a parse failure will get treated the same.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        LoadRenderMeshFromObj("__garbage_doesn't_exist__.obj", empty_props(),
+                              kDefaultDiffuse, diagnostic_policy_),
+        "Failed parsing the obj file[^]*");
+  }
   {
     // Case: Vertices only reports no faces found.
-    std::stringstream in_stream("v 1 2 3");
-    DRAKE_EXPECT_THROWS_MESSAGE(LoadRenderMeshFromObj(&in_stream),
-                                "The OBJ data appears to have no faces.*");
+    const fs::path obj_path =
+        WriteFile("v 1 2 3", fmt::format("error{}.obj", ++error));
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        LoadRenderMeshFromObj(obj_path, empty_props(), kDefaultDiffuse,
+                              diagnostic_policy_),
+        "The OBJ data appears to have no faces.*");
   }
   {
     // Case: Not an obj in any way reports as no faces.
-    std::stringstream in_stream("Not an obj\njust some\nmeaningles text.\n");
+    const fs::path obj_path =
+        WriteFile("Not an obj\njust some\nmeaningles text.\n",
+                  fmt::format("error{}.obj", ++error));
     DRAKE_EXPECT_THROWS_MESSAGE(
-        LoadRenderMeshFromObj(&in_stream),
+        LoadRenderMeshFromObj(obj_path, empty_props(), kDefaultDiffuse,
+                              diagnostic_policy_),
         "The OBJ data appears to have no faces.* might not be an OBJ file.+");
   }
   {
-    // Case: The obj has no normals. Note: the face specification is otherwise
-    // invalid in that it references vertex positions that don't exist.
-    std::stringstream in_stream("v 1 2 3\nf 1 2 3\n");
+    // Case: The obj has no normals.
+    const fs::path obj_path =
+        WriteFile("v 1 2 3\nf 1 1 1\n", fmt::format("error{}.obj", ++error));
     DRAKE_EXPECT_THROWS_MESSAGE(
-        LoadRenderMeshFromObj(&in_stream),
-        "OBJ has no normals; RenderEngineGl requires OBJs with normals.+");
+        LoadRenderMeshFromObj(obj_path, empty_props(), kDefaultDiffuse,
+                              diagnostic_policy_),
+        "OBJ has no normals.+");
   }
   {
-    // Case: Not all faces reference normals. Note: the face specification is
-    // otherwise invalid in that it references vertex positions that don't
-    // exist.
-    std::stringstream in_stream(R"""(
+    // Case: Not all faces reference normals.
+    const fs::path obj_path = WriteFile(R"""(
 v 1 2 3
 vn 0 0 1
 vt 0 1
-f 1 2 3
-)""");
-    DRAKE_EXPECT_THROWS_MESSAGE(LoadRenderMeshFromObj(&in_stream),
-                                "Not all faces reference normals.+");
+f 1 1 1
+f 1//1 1//1 1//1
+)""",
+                                        fmt::format("error{}.obj", ++error));
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        LoadRenderMeshFromObj(obj_path, empty_props(), kDefaultDiffuse,
+                              diagnostic_policy_),
+        "Not all faces reference normals.+");
   }
   {
-    // Case: Not all faces reference uvs. Note: the face specification is
-    // otherwise invalid in that it references vertex positions that don't
-    // exist.
-    std::stringstream in_stream(R"""(
+    // Case: Not all faces reference uvs.
+    const fs::path obj_path = WriteFile(R"""(
 v 1 2 3
 vn 0 0 1
 vt 0 0
-f 1//1 2//1 3//1
-)""");
-    DRAKE_EXPECT_THROWS_MESSAGE(LoadRenderMeshFromObj(&in_stream),
-                                "Not all faces reference texture.+");
+f 1//1 1//1 1//1
+)""",
+                                        fmt::format("error{}.obj", ++error));
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        LoadRenderMeshFromObj(obj_path, empty_props(), kDefaultDiffuse,
+                              diagnostic_policy_),
+        "Not all faces reference texture.+");
   }
 }
-
-GTEST_TEST(LoadRenderMeshFromObjTest, NoMeshUvs) {
-  // Update: This OBJ has no UVs, but we have now updated this to accept it.
-  std::stringstream in_stream(R"""(
-v 0.1 0.2 0.3
-v 0.4 0.5 0.6
-v -0.1 -0.2 -0.3
-vn 0 0 1
-f 1//1 2//1 3//1
-)""");
-  EXPECT_NO_THROW(LoadRenderMeshFromObj(&in_stream));
-}
-
-// Simply confirms that the filename variant of LoadRenderMeshFromObj
-// successfully dispatches files or errors, as appropriate. The actual parsing
-// functionality  is parsed via the stream interface.
-GTEST_TEST(LoadRenderMeshFromObjTest, ReadingFile) {
-  const std::string filename =
-      FindResourceOrThrow("drake/geometry/render/test/meshes/box.obj");
-
-  RenderMesh mesh_data = LoadRenderMeshFromObj(filename);
-  EXPECT_EQ(mesh_data.positions.rows(), 24);
-  EXPECT_EQ(mesh_data.normals.rows(), 24);
-  EXPECT_EQ(mesh_data.uvs.rows(), 24);
-  EXPECT_EQ(mesh_data.indices.rows(), 12);
-
-  DRAKE_EXPECT_THROWS_MESSAGE(LoadRenderMeshFromObj("Bad file name"),
-                              "Cannot load the obj file 'Bad file name'");
-}
-
-// Helpful struct for specifying multiple cases in the TriangluatePolygons test.
-struct TriangluateTestParmas {
-  std::string name;
-  std::string obj_spec;
-  int position_count;
-  // The expected normal and texture coordinate for the vertices in face 0 (f0).
-  Vector3d n0;
-  Vector2d uv0;
-  // The expected normal and texture coordinate for the vertices in face 1 (f1).
-  Vector3d n1;
-  Vector2d uv1;
-};
 
 // Confirms that non-triangular faces get triangulated. This also confirms that
 // duplication occurs due to associations of vertex positions with multiple
 // normals or texture coordinates.
-GTEST_TEST(LoadRenderMeshFromObjTest, TriangulatePolygons) {
+TEST_F(LoadRenderMeshFromObjTest, GeometryTriangulatePolygons) {
   /*
              o 4
             ╱  ╲            A five-sided polygon and a four-sided polygon
@@ -145,9 +223,22 @@ GTEST_TEST(LoadRenderMeshFromObjTest, TriangulatePolygons) {
   const Vector2d zero2 = Vector2d::Zero();
   const Vector2d ones2(1, 1);
 
+  // Specification of test case
+  struct TriangluateTestParmas {
+    std::string name;
+    std::string obj_spec;
+    int position_count;
+    // The expected normal and uv for the vertices in face 0 (f0).
+    Vector3d n0;
+    Vector2d uv0;
+    // The expected normal and uv for the vertices in face 1 (f1).
+    Vector3d n1;
+    Vector2d uv1;
+  };
+
   vector<TriangluateTestParmas> test_params{
       // Every vertex is associated with a single normal and texture coordinate.
-      {"Unique vertices", R"""(
+      {"unique_vertices", R"""(
       vn 0 0 1
       vt 0 0
       f 1/1/1 2/1/1 3/1/1 4/1/1 5/1/1
@@ -155,7 +246,7 @@ GTEST_TEST(LoadRenderMeshFromObjTest, TriangulatePolygons) {
        7, unit3_z, zero2, unit3_z, zero2},
       // Upper and lower faces have different normals; vertices 1 & 2 will be
       // duplicated.
-      {"Vertices with multiple normals", R"""(
+      {"vertices_with_multiple_normals", R"""(
       vn 0 0 1
       vn 0 1 0
       vt 0 0
@@ -164,7 +255,7 @@ GTEST_TEST(LoadRenderMeshFromObjTest, TriangulatePolygons) {
        9, unit3_z, zero2, unit3_y, zero2},
       // Upper and lower faces have different uvs; vertices 1 & 2 will be
       // duplicated.
-      {"Vertices with multiple uvs", R"""(
+      {"vertices_with_multiple_uvs", R"""(
       vn 0 0 1
       vt 0 0
       vt 1 1
@@ -175,10 +266,10 @@ GTEST_TEST(LoadRenderMeshFromObjTest, TriangulatePolygons) {
 
   for (const auto& params : test_params) {
     SCOPED_TRACE(params.name);
-    std::stringstream in_stream;
-    in_stream << positions;
-    in_stream << params.obj_spec;
-    RenderMesh mesh_data = LoadRenderMeshFromObj(&in_stream);
+    const fs::path obj_path = WriteFile(
+        fmt::format("{}{}", positions, params.obj_spec), params.name + ".obj");
+    const RenderMesh mesh_data = LoadRenderMeshFromObj(
+        obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
     EXPECT_EQ(mesh_data.positions.rows(), params.position_count);
     EXPECT_EQ(mesh_data.normals.rows(), params.position_count);
     EXPECT_EQ(mesh_data.uvs.rows(), params.position_count);
@@ -213,7 +304,7 @@ GTEST_TEST(LoadRenderMeshFromObjTest, TriangulatePolygons) {
 // Geometry already triangulated gets preserved. This doesn't do variations on
 // whether vertex positions need copying due to associations with multiple
 // normals/uvs. It relies on `TriangulatePolygons` to handle that.
-GTEST_TEST(LoadRenderMeshFromObjTest, PreserveTriangulation) {
+TEST_F(LoadRenderMeshFromObjTest, GeometryPreserveTriangulation) {
   /*
              o 4
             ╱  ╲
@@ -229,7 +320,7 @@ GTEST_TEST(LoadRenderMeshFromObjTest, PreserveTriangulation) {
           o──────o
           6      7
   */
-  std::stringstream in_stream(R"""(
+  const fs::path obj_path = WriteFile(R"""(
   v -1 -1 0
   v 1 -1 0
   v 2 1 0
@@ -244,8 +335,10 @@ GTEST_TEST(LoadRenderMeshFromObjTest, PreserveTriangulation) {
   f 3/1/1 4/1/1 5/1/1
   f 1/1/1 6/1/1 7/1/1
   f 1/1/1 7/1/1 2/1/1
-  )""");
-  RenderMesh mesh_data = LoadRenderMeshFromObj(&in_stream);
+  )""", "preserve_triangulation.obj");
+
+  const RenderMesh mesh_data = LoadRenderMeshFromObj(
+      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
   EXPECT_EQ(mesh_data.positions.rows(), 7);
   EXPECT_EQ(mesh_data.normals.rows(), 7);
   EXPECT_EQ(mesh_data.uvs.rows(), 7);
@@ -255,7 +348,7 @@ GTEST_TEST(LoadRenderMeshFromObjTest, PreserveTriangulation) {
 // The RenderMesh produces *new* vertices from what was in the OBJ based on what
 // vertex gets referenced by which faces. A vertex that doesn't get referenced
 // gets omitted.
-GTEST_TEST(LoadRenderMeshFromObjTest, RemoveUnreferencedVertices) {
+TEST_F(LoadRenderMeshFromObjTest, GeometryRemoveUnreferencedVertices) {
   /*
 
         4 o───────o 3
@@ -265,7 +358,7 @@ GTEST_TEST(LoadRenderMeshFromObjTest, RemoveUnreferencedVertices) {
     1, 6  o───────o 2
 
   */
-  std::stringstream in_stream(R"""(
+  const fs::path obj_path = WriteFile(R"""(
   v -1 -1 0  # First four corners form a box around the origin.
   v 1 -1 0
   v 1 1 0
@@ -276,12 +369,383 @@ GTEST_TEST(LoadRenderMeshFromObjTest, RemoveUnreferencedVertices) {
   vt 0 0
   f 1/1/1 2/1/1 3/1/1
   f 6/1/1 3/1/1 4/1/1
-  )""");
-  RenderMesh mesh_data = LoadRenderMeshFromObj(&in_stream);
+  )""", "unreferenced_vertices.obj");
+  const RenderMesh mesh_data = LoadRenderMeshFromObj(
+      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
   EXPECT_EQ(mesh_data.positions.rows(), 5);
   EXPECT_EQ(mesh_data.normals.rows(), 5);
   EXPECT_EQ(mesh_data.uvs.rows(), 5);
   EXPECT_EQ(mesh_data.indices.rows(), 2);
+}
+
+/* The OBJ has a single intrinsic material which only defines diffuse color. The
+ resulting material is the defined color. */
+TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryColorOnly) {
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        usemtl test_material
+        f 1//1 2//1 3//1)""",
+                                                  basic_mtl),
+                                      "intrinsic_color_mat.obj");
+  const RenderMesh mesh = LoadRenderMeshFromObj(
+      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  EXPECT_EQ(mesh.material.diffuse, Rgba(0.5, 1, 1));
+  EXPECT_EQ(mesh.material.diffuse_map, "");
+}
+
+/* The OBJ has a single intrinsic material which only defines diffuse texture.
+ The texture is in the same directory as the .mtl file. The resulting material
+ has a white diffuse color and the named texture. */
+TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryTextureOnly) {
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        vt 0 1
+        usemtl test_material
+        f 1/1/1 2/1/1 3/1/1)""",
+                                                  texture_only_mtl),
+                                      "intrinsic_texture_mat.obj");
+  const RenderMesh mesh = LoadRenderMeshFromObj(
+      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  EXPECT_EQ(mesh.material.diffuse, Rgba(1, 1, 1));
+  EXPECT_THAT(mesh.material.diffuse_map,
+              testing::EndsWith("diag_gradient.png"));
+}
+
+/* The OBJ has a single intrinsic material which defines color and texture. The
+ resulting material includes both color and texture. */
+TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryColorAndTexture) {
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        vt 0 1
+        usemtl test_material
+        f 1/1/1 2/1/1 3/1/1)""",
+                                                  texture_mtl),
+                                      "intrinsic_full_diffuse_mat.obj");
+  const RenderMesh mesh = LoadRenderMeshFromObj(
+      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  EXPECT_EQ(mesh.material.diffuse, Rgba(1, 1, 0));
+  EXPECT_THAT(mesh.material.diffuse_map,
+              testing::EndsWith("diag_gradient.png"));
+}
+
+/* The OBJ has a single intrinsic material which defines a diffuse texture.
+ The texture is in a *different* directory from the mtl file. But the mtl must
+ be in the same directory as the obj. (See notes in implementation.)
+ The resulting material has a *white* diffuse color and the named texture. */
+TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryDislocatedTexture) {
+  const fs::path obj_dir = temp_dir() / "dis_texture";
+  fs::create_directory(obj_dir);
+  const fs::path obj_path = WriteFile(R"""(
+    mtllib my.mtl
+    v 0 0 0
+    v 1 1 1
+    v 2 2 2
+    vn 0 1 0
+    vt 0 1
+    usemtl test_material
+    f 1/1/1 2/1/1 3/1/1)""",
+                                      "my.obj", obj_dir);
+  WriteFile(R"""(
+    newmtl test_material
+    Kd 1.0 1.0 1.0
+    d 1
+    map_Kd ../diag_gradient.png)""",
+            "my.mtl", obj_dir);
+  const RenderMesh mesh = LoadRenderMeshFromObj(
+      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  EXPECT_EQ(mesh.material.diffuse, Rgba(1, 1, 1));
+  EXPECT_EQ(mesh.material.diffuse_map,
+            (temp_dir() / "diag_gradient.png"));
+}
+
+/* The OBJ has multiple intrinsic materials *defined* in the .mtl file. But only
+ one is applied. That counts as a single intrinsic material. */
+TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryMultipleDefinedIntrinsic) {
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        vt 0 1
+        usemtl test_material_1
+        f 1/1/1 2/1/1 3/1/1)""",
+                                                  multi_mtl),
+                                      "use_only_one_material.obj");
+  const RenderMesh mesh = LoadRenderMeshFromObj(
+      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  EXPECT_EQ(mesh.material.diffuse, Rgba(1, 0, 1));
+  EXPECT_EQ(mesh.material.diffuse_map, "");
+}
+
+/* The OBJ has a single intrinsic material which defines a bad texture. The
+ resulting material has *only* the color value. */
+TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryColorAndBadTexture) {
+  WriteFile("newmtl test_material\nKd 1 0.5 1\nmap_Kd cant_be_found.png\n",
+            "missing_texture.mtl");
+  const fs::path obj_path = WriteFile(R"""(
+        mtllib missing_texture.mtl
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        vt 0 1
+        usemtl test_material
+        f 1/1/1 2/1/1 3/1/1)""",
+                                      "missing_texture.obj");
+  const RenderMesh mesh = LoadRenderMeshFromObj(
+      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  EXPECT_EQ(mesh.material.diffuse, Rgba(1, 0.5, 1));
+  EXPECT_EQ(mesh.material.diffuse_map, "");
+  EXPECT_THAT(
+      TakeWarning(),
+      testing::HasSubstr("requested an unavailable diffuse texture image"));
+}
+
+/* The OBJ has a single intrinsic material with a texture but no uvs. The
+ resulting material has *only* the color value (and a warning is dispatched). */
+TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryTextureButNoUvs) {
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        usemtl test_material
+        f 1//1 2//1 3//1)""",
+                                                  texture_mtl),
+                                      "no_uvs_with_texture.obj");
+  const RenderMesh mesh = LoadRenderMeshFromObj(
+      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  EXPECT_THAT(TakeWarning(),
+              testing::MatchesRegex(".*requested a diffuse texture.*doesn't "
+                                    "define texture coordinates.*"));
+  EXPECT_EQ(mesh.material.diffuse, Rgba(1, 1, 0));
+  EXPECT_EQ(mesh.material.diffuse_map, "");
+}
+
+/* This test merely exposes a known flaw in the code. Images are defined
+ relative to the mtl file, but we don't know the mtl file that got read. So,
+ we *assume* mtl and obj are in the same place. If not, it can erroneously lead
+ to not being able to locate used textures. The victory condition is that when
+ we fix this flaw, this test fails and we reverse the semantics: a valid
+ material is included in the resulting mesh data. */
+TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryObjMtlDislocation) {
+  const fs::path obj_dir = temp_dir() / "relative_obj";
+  fs::create_directory(obj_dir);
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib ../{}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        vt 0 1
+        usemtl test_material
+        f 1/1/1 2/1/1 3/1/1)""",
+                                                  texture_mtl),
+                                      "mtl_elsewhere.obj", obj_dir);
+  const RenderMesh mesh = LoadRenderMeshFromObj(
+      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  EXPECT_EQ(mesh.material.diffuse, Rgba(1, 1, 0));
+  EXPECT_EQ(mesh.material.diffuse_map, "");
+  // Because of our limited access to parsing information, this will look like
+  // the image is unavailable.
+  EXPECT_THAT(
+      TakeWarning(),
+      testing::HasSubstr("requested an unavailable diffuse texture image"));
+}
+
+/* The OBJ has multiple intrinsic materials *applied* to the mesh. The material
+ should be the fallback material and should be accompanied by a warning. When
+ we expand material support, this test can and should change. */
+TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackMultipleAppliedIntrinsic) {
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        usemtl test_material_1
+        f 1//1 2//1 3//1
+        usemtl test_material_2
+        f 1//1 2//1 3//1)""",
+                                                  multi_mtl),
+                                      "too_many_usemtl.obj");
+  const RenderMesh mesh = LoadRenderMeshFromObj(
+      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  EXPECT_EQ(mesh.material.diffuse, kDefaultDiffuse);
+  EXPECT_EQ(mesh.material.diffuse_map, "");
+  EXPECT_THAT(
+      TakeWarning(),
+      testing::HasSubstr("use a single material across the whole mesh"));
+}
+
+/* If the obj references the mtl file with an absolute path, there will be a
+ warning and default material (due to tiny obj logic). */
+TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackObjMtlDislocationAbsolute) {
+  // Note: This is an absolute path that we imbed in the obj. This makes tinyobj
+  // angry.
+  const fs::path mtl_path = temp_dir() / texture_mtl;
+  // This will be a *different* temp directory than for the test suite.
+  const fs::path obj_dir(temp_directory());
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        vt 0 1
+        usemtl test_material
+        f 1/1/1 2/1/1 3/1/1)""",
+                                                  mtl_path.string()),
+                                      "mtl_elsewhere.obj", obj_dir);
+  const RenderMesh mesh = LoadRenderMeshFromObj(
+      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  EXPECT_EQ(mesh.material.diffuse, kDefaultDiffuse);
+  EXPECT_EQ(mesh.material.diffuse_map, "");
+  // The tinyobj warning that the material library can't be found.
+  EXPECT_THAT(TakeWarning(), testing::HasSubstr("not found in a path"));
+}
+
+/* The obj explicitly applies a material to *some* of the faces. The material
+ gets defaulted and a warning given. */
+TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackDefaultedFaces) {
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        f 1//1 2//1 3//1
+        usemtl test_material
+        f 1//1 2//1 3//1)""",
+                                                  basic_mtl),
+                                      "default_material_faces.obj");
+  const RenderMesh mesh = LoadRenderMeshFromObj(
+      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  EXPECT_EQ(mesh.material.diffuse, kDefaultDiffuse);
+  EXPECT_EQ(mesh.material.diffuse_map, "");
+  EXPECT_THAT(
+      TakeWarning(),
+      testing::HasSubstr("use a single material across the whole mesh"));
+}
+
+/* If the obj references an invalid material name, there will be a warning and
+ a fallback material. */
+TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackBadMaterialName) {
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        usemtl bad_material
+        f 1//1 2//1 3//1)""",
+                                                  texture_mtl),
+                                      "bad_material_name.obj");
+  const RenderMesh mesh = LoadRenderMeshFromObj(
+      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  EXPECT_EQ(mesh.material.diffuse, kDefaultDiffuse);
+  EXPECT_EQ(mesh.material.diffuse_map, "");
+  EXPECT_THAT(TakeWarning(),
+              testing::HasSubstr("material [ 'bad_material' ] not found"));
+}
+
+/* If we can't find the specified mtl file, there will be warning and fallback
+ material. */
+TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackMissingMtl) {
+  const fs::path obj_path = WriteFile(R"""(
+        mtllib not_really_a.mtl
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        usemtl test_material
+        f 1//1 2//1 3//1)""",
+                                      "non_existent_mtl.obj");
+  const RenderMesh mesh = LoadRenderMeshFromObj(
+      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  EXPECT_EQ(mesh.material.diffuse, kDefaultDiffuse);
+  EXPECT_EQ(mesh.material.diffuse_map, "");
+  EXPECT_THAT(
+      TakeWarning(),
+      testing::HasSubstr("Material file [ not_really_a.mtl ] not found"));
+}
+
+/* The OBJ has no materials applied. The material should be the fallback
+ material. */
+TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackNoAppliedMaterial) {
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        f 1//1 2//1 3//1)""",
+                                                  basic_mtl),
+                                      "no_usemtl.obj");
+  const RenderMesh mesh = LoadRenderMeshFromObj(
+      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  EXPECT_EQ(mesh.material.diffuse, kDefaultDiffuse);
+  EXPECT_EQ(mesh.material.diffuse_map, "");
+}
+
+/* The OBJ references no material library. The material should be the fallback
+ material. */
+TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackNoMaterialLibrary) {
+  const fs::path obj_path = WriteFile(R"""(
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        f 1//1 2//1 3//1)""",
+                                      "no_mtllib.obj");
+  const RenderMesh mesh = LoadRenderMeshFromObj(
+      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  EXPECT_EQ(mesh.material.diffuse, kDefaultDiffuse);
+  EXPECT_EQ(mesh.material.diffuse_map, "");
+}
+
+/* If the mesh has a material library and material properties are *also*
+ defined, the material library should win but we *should* have warnings on
+ the material properties. There are multiple cases in which it would throw
+ (see tests in render_material.cc), we just need a simple indication that it
+ is being exercised. A single warning will provide sufficient evidence. */
+TEST_F(LoadRenderMeshFromObjTest, RedundantMaterialWarnings) {
+  // We just need an obj with *any* intrinsic material; we'll do color only.
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        usemtl test_material
+        f 1//1 2//1 3//1)""",
+                                                  basic_mtl),
+                                      "intrinsic_vs_props.obj");
+
+  PerceptionProperties props;
+  props.AddProperty("phong", "diffuse", Rgba(0.1, 0.2, 0.3, 0.4));
+  const RenderMesh mesh = LoadRenderMeshFromObj(
+      obj_path, props, kDefaultDiffuse, diagnostic_policy_);
+  // We still get the intrinsic material.
+  EXPECT_EQ(mesh.material.diffuse, Rgba(0.5, 1, 1));
+  EXPECT_EQ(mesh.material.diffuse_map, "");
+  EXPECT_THAT(
+      TakeWarning(),
+      testing::MatchesRegex(".*has its own materials.*'phong', 'diffuse'.*"));
 }
 
 }  // namespace

--- a/geometry/render_gl/internal_render_engine_gl.cc
+++ b/geometry/render_gl/internal_render_engine_gl.cc
@@ -885,7 +885,11 @@ OpenGlGeometry RenderEngineGl::GetBox() {
 OpenGlGeometry RenderEngineGl::GetMesh(const string& filename) {
   OpenGlGeometry mesh;
   if (meshes_.count(filename) == 0) {
-    RenderMesh mesh_data = LoadRenderMeshFromObj(filename);
+    // TODO(SeanCurtis-TRI): We're ignoring the declared perception properties
+    //  for the mesh. We need to pass it in and return a mesh *and* the
+    //  resulting material properties.
+    RenderMesh mesh_data = LoadRenderMeshFromObj(
+        filename, PerceptionProperties(), parameters_.default_diffuse);
     mesh = CreateGlGeometry(mesh_data);
     meshes_.insert({filename, mesh});
   } else {

--- a/tools/workspace/tinyobjloader/default_texture_color.patch
+++ b/tools/workspace/tinyobjloader/default_texture_color.patch
@@ -1,0 +1,21 @@
+--- tiny_obj_loader.h.orig	2017-04-24 15:34:45.000000000 -0400
++++ tiny_obj_loader.h	2019-06-19 15:57:29.479457051 -0400
+@@ -2297,12 +2297,13 @@ void LoadMtl(std::map<std::string, int> *material_map,
+       ParseTextureNameAndOption(&(material.diffuse_texname),
+                                 &(material.diffuse_texopt), token);
+ 
+-      // Set a decent diffuse default value if a diffuse texture is specified
+-      // without a matching Kd value.
++      // If only a diffuse map has been set, we want the final color to be
++      // fully defined by that specification. So, set the diffuse color to
++      // white.
+       if (!has_kd) {
+-        material.diffuse[0] = static_cast<real_t>(0.6);
+-        material.diffuse[1] = static_cast<real_t>(0.6);
+-        material.diffuse[2] = static_cast<real_t>(0.6);
++        material.diffuse[0] = static_cast<real_t>(1);
++        material.diffuse[1] = static_cast<real_t>(1);
++        material.diffuse[2] = static_cast<real_t>(1);
+       }
+ 
+       continue;

--- a/tools/workspace/tinyobjloader/repository.bzl
+++ b/tools/workspace/tinyobjloader/repository.bzl
@@ -19,5 +19,8 @@ def tinyobjloader_repository(
             # We replace tinyobjloader's implementation of float parsing with a
             # faster call to strtod_l.
             ":faster_float_parsing.patch",
+            # If only a diffuse texture is given (map_Kd) tinyobj modulates it
+            # to 60% grey. We prefer 100%.
+            ":default_texture_color.patch",
         ],
     )


### PR DESCRIPTION
- `RenderMesh` can now come back with material data in addition to the geometric data.
- `LoadRenderMeshFromObj()` signature has changed to provide sufficient data for material definition.
  - `RenderEngineGl` call has changed to patch around the change. `RenderEngineGl` still doesn't take advantage of this information. That will require further modifications.
- Implementation in `LoadRenderMeshFromObj()` has been updated to use the object-oriented version of `tinyobj`.
  - Some error messages have been made more agnostic -- no longer tied to a specific render engine implementation.
- Parsing is now wholly reliant on `tinyobj`; the unused/incompatible streaming version of the parser has simply been removed.
- Patch `tinyobj` to conform to Drake behavior: if `map_Kd` is supplied but `Kd` is not, `Kd` defaults to (1, 1, 1) (in `tinyobj` it was (0.6, 0.6, 0.6)).

This is the last prerequisite to update `RenderEngineVtk` to respect .mtl files and the new material protocol.

Relates https://github.com/RobotLocomotion/drake/issues/18844

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19364)
<!-- Reviewable:end -->
