### PR TITLE
ShapeReifier can configure default behavior

### DIFF
--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -174,40 +174,44 @@ Sphere::Sphere(double radius)
 
 ShapeReifier::~ShapeReifier() = default;
 
-void ShapeReifier::ImplementGeometry(const Box&, void*) {
-  ThrowUnsupportedGeometry("Box");
+void ShapeReifier::ImplementGeometry(const Box& box, void*) {
+  DefaultImplementGeometry(box);
 }
 
-void ShapeReifier::ImplementGeometry(const Capsule&, void*) {
-  ThrowUnsupportedGeometry("Capsule");
+void ShapeReifier::ImplementGeometry(const Capsule& capsule, void*) {
+  DefaultImplementGeometry(capsule);
 }
 
-void ShapeReifier::ImplementGeometry(const Convex&, void*) {
-  ThrowUnsupportedGeometry("Convex");
+void ShapeReifier::ImplementGeometry(const Convex& convex, void*) {
+  DefaultImplementGeometry(convex);
 }
 
-void ShapeReifier::ImplementGeometry(const Cylinder&, void*) {
-  ThrowUnsupportedGeometry("Cylinder");
+void ShapeReifier::ImplementGeometry(const Cylinder& cylinder, void*) {
+  DefaultImplementGeometry(cylinder);
 }
 
-void ShapeReifier::ImplementGeometry(const Ellipsoid&, void*) {
-  ThrowUnsupportedGeometry("Ellipsoid");
+void ShapeReifier::ImplementGeometry(const Ellipsoid& ellipsoid, void*) {
+  DefaultImplementGeometry(ellipsoid);
 }
 
-void ShapeReifier::ImplementGeometry(const HalfSpace&, void*) {
-  ThrowUnsupportedGeometry("HalfSpace");
+void ShapeReifier::ImplementGeometry(const HalfSpace& hs, void*) {
+  DefaultImplementGeometry(hs);
 }
 
-void ShapeReifier::ImplementGeometry(const Mesh&, void*) {
-  ThrowUnsupportedGeometry("Mesh");
+void ShapeReifier::ImplementGeometry(const Mesh& mesh, void*) {
+  DefaultImplementGeometry(mesh);
 }
 
-void ShapeReifier::ImplementGeometry(const MeshcatCone&, void*) {
-  ThrowUnsupportedGeometry("MeshcatCone");
+void ShapeReifier::ImplementGeometry(const MeshcatCone& cone, void*) {
+  DefaultImplementGeometry(cone);
 }
 
-void ShapeReifier::ImplementGeometry(const Sphere&, void*) {
-  ThrowUnsupportedGeometry("Sphere");
+void ShapeReifier::ImplementGeometry(const Sphere& sphere, void*) {
+  DefaultImplementGeometry(sphere);
+}
+
+void ShapeReifier::DefaultImplementGeometry(const Shape& shape) {
+  ThrowUnsupportedGeometry(ShapeName(shape).name());
 }
 
 void ShapeReifier::ThrowUnsupportedGeometry(const std::string& shape_name) {

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -451,6 +451,8 @@ class ShapeReifier {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ShapeReifier)
   ShapeReifier() = default;
 
+  virtual void DefaultImplementGeometry(const Shape& shape);
+
   /** Derived ShapeReifiers can replace the default message for unsupported
    geometries by overriding this method. The name of the unsupported shape type
    is given as the single parameter.  */

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -558,6 +558,33 @@ TEST_F(DefaultReifierTest, UnsupportedGeometry) {
                               "This class (.+) does not support Sphere.");
 }
 
+// Test confirms that the default unsupported functionality can be replaced.
+// We'll simply replace it with a no-op. Contrast this with DefaultReifierTest.
+class OverrideDeafultGeometryTest : public ShapeReifier,
+                                    public ::testing::Test {
+ public:
+  using ShapeReifier::ThrowUnsupportedGeometry;
+  void DefaultImplementGeometry(const Shape&) final{};
+};
+
+// Tests default implementation of virtual functions for each shape.
+TEST_F(OverrideDeafultGeometryTest, UnsupportedGeometry) {
+  // Confirm that throwing mechanism hasn't changed. If the subsequent calls
+  // don't throw, it's not because this function's behavior has changed.
+  DRAKE_EXPECT_THROWS_MESSAGE(this->ThrowUnsupportedGeometry("Foo"),
+                              "This class (.+) does not support Foo.");
+
+  // Confirm the default behavior no longer throws.
+  EXPECT_NO_THROW(this->ImplementGeometry(Box(1, 1, 1), nullptr));
+  EXPECT_NO_THROW(this->ImplementGeometry(Capsule(1, 2), nullptr));
+  EXPECT_NO_THROW(this->ImplementGeometry(Convex("a", 1), nullptr));
+  EXPECT_NO_THROW(this->ImplementGeometry(Cylinder(1, 2), nullptr));
+  EXPECT_NO_THROW(this->ImplementGeometry(Ellipsoid(1, 1, 1), nullptr));
+  EXPECT_NO_THROW(this->ImplementGeometry(HalfSpace(), nullptr));
+  EXPECT_NO_THROW(this->ImplementGeometry(Mesh("foo", 1), nullptr));
+  EXPECT_NO_THROW(this->ImplementGeometry(Sphere(0.5), nullptr));
+}
+
 GTEST_TEST(ShapeName, SimpleReification) {
   ShapeName name;
 


### PR DESCRIPTION
Historically, the default behavior for an unimplemented `Shape` in a `ShapeReifier` has been to throw. It was possible for derived reifiers to tweak the message thrown, but the behavior was fixed.

This is very clunky of a reifier wants to make use any API that takes a `const Shape&` as its type. The call would have to be explicitly implemented across all types.

This adds the `DefaultImplementGeometry()` virtual method. Its implementation is the same historical behavior: throw with whatever message is provided. But now it can be overridden so that the reifier can redirect an arbitrary subset of shape types to another API as default behavior.