### PR TITLE
[solvers] Start nonlinear_program_test closer to solution

### DIFF
--- a/solvers/test/nonlinear_program_test.cc
+++ b/solvers/test/nonlinear_program_test.cc
@@ -534,7 +534,7 @@ GTEST_TEST(testNonlinearProgram, HeatExchangerDesignProblem) {
   // gradient.
   HeatExchangerDesignProblem prob;
   Eigen::VectorXd x_init(8);
-  x_init << 5000, 5000, 5000, 200, 350, 150, 225, 425;
+  x_init << 4999.4, 5000, 5000, 200, 350, 150, 225, 425;
   MathematicalProgramResult result;
   // The optimal solution given in Hock's reference has low precision, and the
   // magnitude of the solution is large, so we choose a large tolerance 0.2.


### PR DESCRIPTION
Relates: #18327.

This is almost certainly incorrect, probably there is something wrong with the solver on macOS arm64 Ventura.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19376)
<!-- Reviewable:end -->
