### PR TITLE
[planning] Improve performance of SceneGraphCollisionChecker through better collision filtering

### DIFF
--- a/bindings/pydrake/planning/planning_py_collision_checker.cc
+++ b/bindings/pydrake/planning/planning_py_collision_checker.cc
@@ -172,8 +172,15 @@ void DefinePlanningCollisionChecker(py::module m) {
             cls_doc.SetCollisionFilteredBetween
                 .doc_3args_bodyA_bodyB_filter_collision)
         .def("SetCollisionFilteredWithAllBodies",
-            &Class::SetCollisionFilteredWithAllBodies, py::arg("body_index"),
-            cls_doc.SetCollisionFilteredWithAllBodies.doc)
+            py::overload_cast<BodyIndex>(
+                &Class::SetCollisionFilteredWithAllBodies),
+            py::arg("body_index"),
+            cls_doc.SetCollisionFilteredWithAllBodies.doc_1args_body_index)
+        .def("SetCollisionFilteredWithAllBodies",
+            py::overload_cast<const Body<double>&>(
+                &Class::SetCollisionFilteredWithAllBodies),
+            py::arg("body"),
+            cls_doc.SetCollisionFilteredWithAllBodies.doc_1args_body)
         .def("CheckConfigCollisionFree", &Class::CheckConfigCollisionFree,
             py::arg("q"), cls_doc.CheckConfigCollisionFree.doc)
         .def("CheckContextConfigCollisionFree",

--- a/bindings/pydrake/planning/test/collision_checker_test.py
+++ b/bindings/pydrake/planning/test/collision_checker_test.py
@@ -318,6 +318,7 @@ class TestCollisionChecker(unittest.TestCase):
         dut.SetCollisionFilteredBetween(
             bodyA=env_body, bodyB=body, filter_collision=True)
         dut.SetCollisionFilteredWithAllBodies(body_index=body.index())
+        dut.SetCollisionFilteredWithAllBodies(body=body)
 
         dut.CheckConfigCollisionFree(q=q)
         dut.CheckContextConfigCollisionFree(model_context=ccc, q=q)

--- a/planning/collision_checker.cc
+++ b/planning/collision_checker.cc
@@ -796,6 +796,116 @@ std::vector<RobotCollisionType> CollisionChecker::ClassifyContextBodyCollisions(
   return DoClassifyContextBodyCollisions(*model_context);
 }
 
+Eigen::MatrixXi CollisionChecker::GenerateFilteredCollisionMatrix(
+    const CollisionChecker& checker,
+    const SceneGraphInspector<double>& inspector) {
+  const int num_bodies = checker.plant().num_bodies();
+  // Initialize matrix to zero (no filtered collisions).
+  Eigen::MatrixXi filtered_collisions =
+      Eigen::MatrixXi::Zero(num_bodies, num_bodies);
+
+  // Generate a mapping from body to subgraph for use in identifying welds.
+  std::vector<int> body_subgraph_mapping(num_bodies, -1);
+
+  const std::vector<std::set<BodyIndex>> subgraphs =
+      checker.plant().FindSubgraphsOfWeldedBodies();
+
+  for (size_t subgraph_id = 0; subgraph_id < subgraphs.size(); ++subgraph_id) {
+    const std::set<BodyIndex>& subgraph = subgraphs.at(subgraph_id);
+    for (const BodyIndex& body_id : subgraph) {
+      body_subgraph_mapping.at(body_id) = static_cast<int>(subgraph_id);
+    }
+  }
+
+  // For consistency, (B, B) is always filtered.
+  // Loop variables below use `int` for Eigen indexing compatibility.
+  for (int i = 0; i < num_bodies; ++i) {
+    filtered_collisions(i, i) = -1;
+
+    const int body_i_subgraph_id = body_subgraph_mapping.at(i);
+    // We expect FindSubgraphsOfWeldedBodies to cover all bodies, but check to
+    // make sure no bodies are left with the default subgraph id.
+    DRAKE_DEMAND(body_i_subgraph_id >= 0);
+
+    const bool i_is_robot = checker.IsPartOfRobot(BodyIndex(i));
+
+    const Body<double>& body_i = checker.get_body(BodyIndex(i));
+
+    const std::vector<GeometryId>& geometries_i =
+        checker.plant().GetCollisionGeometriesForBody(body_i);
+
+    for (int j = i + 1; j < num_bodies; ++j) {
+      const int body_j_subgraph_id = body_subgraph_mapping.at(j);
+
+      const bool j_is_robot = checker.IsPartOfRobot(BodyIndex(j));
+      // (Env, env) pairs are immutably filtered (marked -1).
+      if (!(i_is_robot || j_is_robot)) {
+        filtered_collisions(i, j) = -1;
+        filtered_collisions(j, i) = -1;
+        continue;
+      }
+
+      const Body<double>& body_j = checker.get_body(BodyIndex(j));
+
+      // Check if collisions between the geometries are already filtered.
+      bool collisions_filtered = false;
+      const std::vector<GeometryId>& geometries_j =
+          checker.plant().GetCollisionGeometriesForBody(body_j);
+      if (geometries_i.size() > 0 && geometries_j.size() > 0) {
+        collisions_filtered =
+            inspector.CollisionFiltered(geometries_i.at(0), geometries_j.at(0));
+        // Ensure that the collision filtering is homogeneous across all body
+        // geometries.
+        for (const auto& id_i : geometries_i) {
+          for (const auto& id_j : geometries_j) {
+            const bool current_filtered =
+                inspector.CollisionFiltered(id_i, id_j);
+            if (current_filtered != collisions_filtered) {
+              throw std::runtime_error(fmt::format(
+                  "SceneGraph's collision filters on the geometries of bodies "
+                  " {} [{}] and {} [{}] are not homogeneous",
+                  i, body_i.scoped_name(), j, body_j.scoped_name()));
+            }
+          }
+        }
+      }
+
+      // While MbP already filters collisions in SceneGraph between welded
+      // bodies, this is only recorded if both bodies have collision geometries
+      // when this filter is applied. Since we want to handle collision
+      // geometries added later, we must record if bodies are welded together.
+
+      // If the body pair has a welded path between them, it should be filtered.
+      const bool bodies_welded_together =
+          body_i_subgraph_id == body_j_subgraph_id;
+
+      // Add the filter accordingly.
+      if (collisions_filtered) {
+        // Filter the collision
+        log()->debug(
+            "Collision between body {} [{}] and body {} [{}] filtered "
+            "(filtered in SceneGraph)",
+            body_i.scoped_name(), i, body_j.scoped_name(), j);
+        filtered_collisions(i, j) = 1;
+        filtered_collisions(j, i) = 1;
+      } else if (bodies_welded_together) {
+        // Filter the collision
+        log()->debug(
+            "Collision between body {} [{}] and body {} [{}] filtered "
+            "(bodies are welded together)",
+            body_i.scoped_name(), i, body_j.scoped_name(), j);
+        filtered_collisions(i, j) = 1;
+        filtered_collisions(j, i) = 1;
+      } else {
+        log()->debug(
+            "Collision between body {} [{}] and body {} [{}] not filtered",
+            body_i.scoped_name(), i, body_j.scoped_name(), j);
+      }
+    }
+  }
+  return filtered_collisions;
+}
+
 CollisionChecker::CollisionChecker(CollisionCheckerParams params,
                                    bool supports_parallel_checking)
     : setup_model_(std::move(params.model)),
@@ -833,7 +943,8 @@ CollisionChecker::CollisionChecker(CollisionCheckerParams params,
       MakeDefaultConfigurationInterpolationFunction(
           GetQuaternionDofStartIndices(plant())));
   // Generate the filtered collision matrix.
-  nominal_filtered_collisions_ = GenerateFilteredCollisionMatrix();
+  nominal_filtered_collisions_ = GenerateFilteredCollisionMatrix(
+      *this, model().scene_graph().model_inspector());
   filtered_collisions_ = nominal_filtered_collisions_;
   log()->debug("Collision filter matrix:\n{}", fmt_eigen(filtered_collisions_));
 }
@@ -945,121 +1056,6 @@ void CollisionChecker::ValidateFilteredCollisionMatrix(
       }
     }
   }
-}
-
-Eigen::MatrixXi CollisionChecker::GenerateFilteredCollisionMatrix() const {
-  const auto& inspector = model().scene_graph().model_inspector();
-  return GenerateFilteredCollisionMatrix(*this, inspector);
-}
-
-Eigen::MatrixXi CollisionChecker::GenerateFilteredCollisionMatrix(
-    const CollisionChecker& checker,
-    const SceneGraphInspector<double>& inspector) {
-  const int num_bodies = checker.plant().num_bodies();
-  // Initialize matrix to zero (no filtered collisions).
-  Eigen::MatrixXi filtered_collisions =
-      Eigen::MatrixXi::Zero(num_bodies, num_bodies);
-
-  // Generate a mapping from body to subgraph for use in identifying welds.
-  std::vector<int> body_subgraph_mapping(num_bodies, -1);
-
-  const std::vector<std::set<BodyIndex>> subgraphs =
-      checker.plant().FindSubgraphsOfWeldedBodies();
-
-  for (size_t subgraph_id = 0; subgraph_id < subgraphs.size(); ++subgraph_id) {
-    const std::set<BodyIndex>& subgraph = subgraphs.at(subgraph_id);
-    for (const BodyIndex& body_id : subgraph) {
-      body_subgraph_mapping.at(body_id) = static_cast<int>(subgraph_id);
-    }
-  }
-
-  // For consistency, (B, B) is always filtered.
-  // Loop variables below use `int` for Eigen indexing compatibility.
-  for (int i = 0; i < num_bodies; ++i) {
-    filtered_collisions(i, i) = -1;
-
-    const int body_i_subgraph_id = body_subgraph_mapping.at(i);
-    // We expect FindSubgraphsOfWeldedBodies to cover all bodies, but check to
-    // make sure no bodies are left with the default subgraph id.
-    DRAKE_DEMAND(body_i_subgraph_id >= 0);
-
-    const bool i_is_robot = checker.IsPartOfRobot(BodyIndex(i));
-
-    const Body<double>& body_i = checker.get_body(BodyIndex(i));
-
-    const std::vector<GeometryId>& geometries_i =
-        checker.plant().GetCollisionGeometriesForBody(body_i);
-
-    for (int j = i + 1; j < num_bodies; ++j) {
-      const int body_j_subgraph_id = body_subgraph_mapping.at(j);
-
-      const bool j_is_robot = checker.IsPartOfRobot(BodyIndex(j));
-      // (Env, env) pairs are immutably filtered (marked -1).
-      if (!(i_is_robot || j_is_robot)) {
-        filtered_collisions(i, j) = -1;
-        filtered_collisions(j, i) = -1;
-        continue;
-      }
-
-      const Body<double>& body_j = checker.get_body(BodyIndex(j));
-
-      // Check if collisions between the geometries are already filtered.
-      bool collisions_filtered = false;
-      const std::vector<GeometryId>& geometries_j =
-          checker.plant().GetCollisionGeometriesForBody(body_j);
-      if (geometries_i.size() > 0 && geometries_j.size() > 0) {
-        collisions_filtered =
-            inspector.CollisionFiltered(geometries_i.at(0), geometries_j.at(0));
-        // Ensure that the collision filtering is homogeneous across all body
-        // geometries.
-        for (const auto& id_i : geometries_i) {
-          for (const auto& id_j : geometries_j) {
-            const bool current_filtered =
-                inspector.CollisionFiltered(id_i, id_j);
-            if (current_filtered != collisions_filtered) {
-              throw std::runtime_error(fmt::format(
-                  "SceneGraph's collision filters on the geometries of bodies "
-                  " {} [{}] and {} [{}] are not homogeneous",
-                  i, body_i.scoped_name(), j, body_j.scoped_name()));
-            }
-          }
-        }
-      }
-
-      // While MbP already filters collisions in SceneGraph between welded
-      // bodies, this is only recorded if both bodies have collision geometries
-      // when this filter is applied. Since we want to handle collision
-      // geometries added later, we must record if bodies are welded together.
-
-      // If the body pair has a welded path between them, it should be filtered.
-      const bool bodies_welded_together =
-          body_i_subgraph_id == body_j_subgraph_id;
-
-      // Add the filter accordingly.
-      if (collisions_filtered) {
-        // Filter the collision
-        log()->debug(
-            "Collision between body {} [{}] and body {} [{}] filtered "
-            "(filtered in SceneGraph)",
-            body_i.scoped_name(), i, body_j.scoped_name(), j);
-        filtered_collisions(i, j) = 1;
-        filtered_collisions(j, i) = 1;
-      } else if (bodies_welded_together) {
-        // Filter the collision
-        log()->debug(
-            "Collision between body {} [{}] and body {} [{}] filtered "
-            "(bodies are welded together)",
-            body_i.scoped_name(), i, body_j.scoped_name(), j);
-        filtered_collisions(i, j) = 1;
-        filtered_collisions(j, i) = 1;
-      } else {
-        log()->debug(
-            "Collision between body {} [{}] and body {} [{}] not filtered",
-            body_i.scoped_name(), i, body_j.scoped_name(), j);
-      }
-    }
-  }
-  return filtered_collisions;
 }
 
 void CollisionChecker::UpdateMaxCollisionPadding() {

--- a/planning/collision_checker.cc
+++ b/planning/collision_checker.cc
@@ -419,9 +419,8 @@ void CollisionChecker::SetCollisionFilterMatrix(
   // Now test for consistency.
   ValidateFilteredCollisionMatrix(filter_matrix, __func__);
   filtered_collisions_ = filter_matrix;
-  log()->debug("Set collision filter matrix to:\n{}",
-               fmt_eigen(filtered_collisions_));
-  UpdateMaxCollisionPadding();
+  // Allow derived checkers to peform any post-filter-change work.
+  DoUpdateCollisionFilters();
 }
 
 bool CollisionChecker::IsCollisionFilteredBetween(BodyIndex bodyA_index,
@@ -452,6 +451,8 @@ void CollisionChecker::SetCollisionFilteredBetween(BodyIndex bodyA_index,
   DRAKE_ASSERT(filtered_collisions_(int{bodyA_index}, int{bodyB_index}) != -1);
   filtered_collisions_(int{bodyA_index}, int{bodyB_index}) = encoded;
   filtered_collisions_(int{bodyB_index}, int{bodyA_index}) = encoded;
+  // Allow derived checkers to peform any post-filter-change work.
+  DoUpdateCollisionFilters();
 }
 
 void CollisionChecker::SetCollisionFilteredWithAllBodies(BodyIndex body_index) {
@@ -462,6 +463,8 @@ void CollisionChecker::SetCollisionFilteredWithAllBodies(BodyIndex body_index) {
   filtered_collisions_.col(body_index).setConstant(1);
   // Maintain the invariant that the diagonal is always -1.
   filtered_collisions_(int{body_index}, int{body_index}) = -1;
+  // Allow derived checkers to peform any post-filter-change work.
+  DoUpdateCollisionFilters();
 }
 
 bool CollisionChecker::CheckConfigCollisionFree(

--- a/planning/collision_checker.cc
+++ b/planning/collision_checker.cc
@@ -28,6 +28,7 @@ namespace planning {
 
 using geometry::GeometryId;
 using geometry::QueryObject;
+using geometry::SceneGraphInspector;
 using geometry::Shape;
 using math::RigidTransform;
 using multibody::Body;
@@ -419,7 +420,7 @@ void CollisionChecker::SetCollisionFilterMatrix(
   // Now test for consistency.
   ValidateFilteredCollisionMatrix(filter_matrix, __func__);
   filtered_collisions_ = filter_matrix;
-  // Allow derived checkers to peform any post-filter-change work.
+  // Allow derived checkers to perform any post-filter-change work.
   DoUpdateCollisionFilters();
 }
 
@@ -451,7 +452,7 @@ void CollisionChecker::SetCollisionFilteredBetween(BodyIndex bodyA_index,
   DRAKE_ASSERT(filtered_collisions_(int{bodyA_index}, int{bodyB_index}) != -1);
   filtered_collisions_(int{bodyA_index}, int{bodyB_index}) = encoded;
   filtered_collisions_(int{bodyB_index}, int{bodyA_index}) = encoded;
-  // Allow derived checkers to peform any post-filter-change work.
+  // Allow derived checkers to perform any post-filter-change work.
   DoUpdateCollisionFilters();
 }
 
@@ -463,7 +464,7 @@ void CollisionChecker::SetCollisionFilteredWithAllBodies(BodyIndex body_index) {
   filtered_collisions_.col(body_index).setConstant(1);
   // Maintain the invariant that the diagonal is always -1.
   filtered_collisions_(int{body_index}, int{body_index}) = -1;
-  // Allow derived checkers to peform any post-filter-change work.
+  // Allow derived checkers to perform any post-filter-change work.
   DoUpdateCollisionFilters();
 }
 
@@ -916,113 +917,8 @@ void CollisionChecker::ValidateFilteredCollisionMatrix(
 }
 
 Eigen::MatrixXi CollisionChecker::GenerateFilteredCollisionMatrix() const {
-  const int num_bodies = plant().num_bodies();
-  // Initialize matrix to zero (no filtered collisions).
-  Eigen::MatrixXi filtered_collisions =
-      Eigen::MatrixXi::Zero(num_bodies, num_bodies);
-
   const auto& inspector = model().scene_graph().model_inspector();
-
-  // Generate a mapping from body to subgraph for use in identifying welds.
-  std::vector<int> body_subgraph_mapping(num_bodies, -1);
-
-  const std::vector<std::set<BodyIndex>> subgraphs =
-      plant().FindSubgraphsOfWeldedBodies();
-
-  for (size_t subgraph_id = 0; subgraph_id < subgraphs.size(); ++subgraph_id) {
-    const std::set<BodyIndex>& subgraph = subgraphs.at(subgraph_id);
-    for (const BodyIndex& body_id : subgraph) {
-      body_subgraph_mapping.at(body_id) = static_cast<int>(subgraph_id);
-    }
-  }
-
-  // For consistency, (B, B) is always filtered.
-  // Loop variables below use `int` for Eigen indexing compatibility.
-  for (int i = 0; i < num_bodies; ++i) {
-    filtered_collisions(i, i) = -1;
-
-    const int body_i_subgraph_id = body_subgraph_mapping.at(i);
-    // We expect FindSubgraphsOfWeldedBodies to cover all bodies, but check to
-    // make sure no bodies are left with the default subgraph id.
-    DRAKE_DEMAND(body_i_subgraph_id >= 0);
-
-    const bool i_is_robot = IsPartOfRobot(BodyIndex(i));
-
-    const Body<double>& body_i = get_body(BodyIndex(i));
-
-    const std::vector<GeometryId>& geometries_i =
-        plant().GetCollisionGeometriesForBody(body_i);
-
-    for (int j = i + 1; j < num_bodies; ++j) {
-      const int body_j_subgraph_id = body_subgraph_mapping.at(j);
-
-      const bool j_is_robot = IsPartOfRobot(BodyIndex(j));
-      // (Env, env) pairs are immutably filtered (marked -1).
-      if (!(i_is_robot || j_is_robot)) {
-        filtered_collisions(i, j) = -1;
-        filtered_collisions(j, i) = -1;
-        continue;
-      }
-
-      const Body<double>& body_j = get_body(BodyIndex(j));
-
-      // Check if collisions between the geometries_i are already filtered.
-      bool collisions_filtered = false;
-      const std::vector<GeometryId>& geometries_j =
-          plant().GetCollisionGeometriesForBody(body_j);
-      if (geometries_i.size() > 0 && geometries_j.size() > 0) {
-        collisions_filtered =
-            inspector.CollisionFiltered(geometries_i.at(0), geometries_j.at(0));
-        // Ensure that the collision filtering is homogeneous across all body
-        // geometries.
-        for (const auto& id_i : geometries_i) {
-          for (const auto& id_j : geometries_j) {
-            const bool current_filtered =
-                inspector.CollisionFiltered(id_i, id_j);
-            if (current_filtered != collisions_filtered) {
-              throw std::runtime_error(fmt::format(
-                  "SceneGraph's collision filters on the geometries of bodies "
-                  " {} [{}] and {} [{}] are not homogeneous",
-                  i, body_i.scoped_name(), j, body_j.scoped_name()));
-            }
-          }
-        }
-      }
-
-      // While MbP already filters collisions in SceneGraph between welded
-      // bodies, this is only recorded if both bodies have collision geometries
-      // when this filter is applied. Since we want to handle collision
-      // geometries added later, we must record if bodies are welded together.
-
-      // If the body pair has a welded path between them, it should be filtered.
-      const bool bodies_welded_together =
-          body_i_subgraph_id == body_j_subgraph_id;
-
-      // Add the filter accordingly.
-      if (collisions_filtered) {
-        // Filter the collision
-        log()->debug(
-            "Collision between body {} [{}] and body {} [{}] filtered "
-            "(filtered in SceneGraph)",
-            body_i.scoped_name(), i, body_j.scoped_name(), j);
-        filtered_collisions(i, j) = 1;
-        filtered_collisions(j, i) = 1;
-      } else if (bodies_welded_together) {
-        // Filter the collision
-        log()->debug(
-            "Collision between body {} [{}] and body {} [{}] filtered "
-            "(bodies are welded together)",
-            body_i.scoped_name(), i, body_j.scoped_name(), j);
-        filtered_collisions(i, j) = 1;
-        filtered_collisions(j, i) = 1;
-      } else {
-        log()->debug(
-            "Collision between body {} [{}] and body {} [{}] not filtered",
-            body_i.scoped_name(), i, body_j.scoped_name(), j);
-      }
-    }
-  }
-  return filtered_collisions;
+  return ::drake::planning::GenerateFilteredCollisionMatrix(*this, inspector);
 }
 
 void CollisionChecker::UpdateMaxCollisionPadding() {
@@ -1158,6 +1054,116 @@ void CollisionChecker::StandaloneContextReferenceKeeper::
       standalone_context = standalone_contexts_.erase(standalone_context);
     }
   }
+}
+
+Eigen::MatrixXi GenerateFilteredCollisionMatrix(
+    const CollisionChecker& checker,
+    const SceneGraphInspector<double>& inspector) {
+  const int num_bodies = checker.plant().num_bodies();
+  // Initialize matrix to zero (no filtered collisions).
+  Eigen::MatrixXi filtered_collisions =
+      Eigen::MatrixXi::Zero(num_bodies, num_bodies);
+
+  // Generate a mapping from body to subgraph for use in identifying welds.
+  std::vector<int> body_subgraph_mapping(num_bodies, -1);
+
+  const std::vector<std::set<BodyIndex>> subgraphs =
+      checker.plant().FindSubgraphsOfWeldedBodies();
+
+  for (size_t subgraph_id = 0; subgraph_id < subgraphs.size(); ++subgraph_id) {
+    const std::set<BodyIndex>& subgraph = subgraphs.at(subgraph_id);
+    for (const BodyIndex& body_id : subgraph) {
+      body_subgraph_mapping.at(body_id) = static_cast<int>(subgraph_id);
+    }
+  }
+
+  // For consistency, (B, B) is always filtered.
+  // Loop variables below use `int` for Eigen indexing compatibility.
+  for (int i = 0; i < num_bodies; ++i) {
+    filtered_collisions(i, i) = -1;
+
+    const int body_i_subgraph_id = body_subgraph_mapping.at(i);
+    // We expect FindSubgraphsOfWeldedBodies to cover all bodies, but check to
+    // make sure no bodies are left with the default subgraph id.
+    DRAKE_DEMAND(body_i_subgraph_id >= 0);
+
+    const bool i_is_robot = checker.IsPartOfRobot(BodyIndex(i));
+
+    const Body<double>& body_i = checker.get_body(BodyIndex(i));
+
+    const std::vector<GeometryId>& geometries_i =
+        checker.plant().GetCollisionGeometriesForBody(body_i);
+
+    for (int j = i + 1; j < num_bodies; ++j) {
+      const int body_j_subgraph_id = body_subgraph_mapping.at(j);
+
+      const bool j_is_robot = checker.IsPartOfRobot(BodyIndex(j));
+      // (Env, env) pairs are immutably filtered (marked -1).
+      if (!(i_is_robot || j_is_robot)) {
+        filtered_collisions(i, j) = -1;
+        filtered_collisions(j, i) = -1;
+        continue;
+      }
+
+      const Body<double>& body_j = checker.get_body(BodyIndex(j));
+
+      // Check if collisions between the geometries_i are already filtered.
+      bool collisions_filtered = false;
+      const std::vector<GeometryId>& geometries_j =
+          checker.plant().GetCollisionGeometriesForBody(body_j);
+      if (geometries_i.size() > 0 && geometries_j.size() > 0) {
+        collisions_filtered =
+            inspector.CollisionFiltered(geometries_i.at(0), geometries_j.at(0));
+        // Ensure that the collision filtering is homogeneous across all body
+        // geometries.
+        for (const auto& id_i : geometries_i) {
+          for (const auto& id_j : geometries_j) {
+            const bool current_filtered =
+                inspector.CollisionFiltered(id_i, id_j);
+            if (current_filtered != collisions_filtered) {
+              throw std::runtime_error(fmt::format(
+                  "SceneGraph's collision filters on the geometries of bodies "
+                  " {} [{}] and {} [{}] are not homogeneous",
+                  i, body_i.scoped_name(), j, body_j.scoped_name()));
+            }
+          }
+        }
+      }
+
+      // While MbP already filters collisions in SceneGraph between welded
+      // bodies, this is only recorded if both bodies have collision geometries
+      // when this filter is applied. Since we want to handle collision
+      // geometries added later, we must record if bodies are welded together.
+
+      // If the body pair has a welded path between them, it should be filtered.
+      const bool bodies_welded_together =
+          body_i_subgraph_id == body_j_subgraph_id;
+
+      // Add the filter accordingly.
+      if (collisions_filtered) {
+        // Filter the collision
+        log()->debug(
+            "Collision between body {} [{}] and body {} [{}] filtered "
+            "(filtered in SceneGraph)",
+            body_i.scoped_name(), i, body_j.scoped_name(), j);
+        filtered_collisions(i, j) = 1;
+        filtered_collisions(j, i) = 1;
+      } else if (bodies_welded_together) {
+        // Filter the collision
+        log()->debug(
+            "Collision between body {} [{}] and body {} [{}] filtered "
+            "(bodies are welded together)",
+            body_i.scoped_name(), i, body_j.scoped_name(), j);
+        filtered_collisions(i, j) = 1;
+        filtered_collisions(j, i) = 1;
+      } else {
+        log()->debug(
+            "Collision between body {} [{}] and body {} [{}] not filtered",
+            body_i.scoped_name(), i, body_j.scoped_name(), j);
+      }
+    }
+  }
+  return filtered_collisions;
 }
 
 }  // namespace planning

--- a/planning/collision_checker.cc
+++ b/planning/collision_checker.cc
@@ -152,20 +152,6 @@ std::vector<int> CalcUncontrolledDofsThatKinematicallyAffectTheRobot(
   return result;
 }
 
-// Checks if two collision filter matrices are different.
-// Note: does not perform size checks, as all call sites enforce matching sizes.
-bool AreCollisionFilterMatricesDifferent(const Eigen::MatrixXi& matrixA,
-                                         const Eigen::MatrixXi& matrixB) {
-  for (int row = 0; row < matrixA.rows(); ++row) {
-    for (int col = 0; col < matrixA.cols(); ++col) {
-      if (matrixA(row, col) != matrixB(row, col)) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 }  // namespace
 
 CollisionChecker::~CollisionChecker() = default;
@@ -277,7 +263,7 @@ void CollisionChecker::RemoveAllAddedCollisionShapes(
   auto iter = geometry_groups_.find(group_name);
   if (iter != geometry_groups_.end()) {
     drake::log()->debug("Removing geometries from group [{}].", group_name);
-    DoRemoveAddedGeometries(iter->second);
+    RemoveAddedGeometries(iter->second);
     geometry_groups_.erase(iter);
   }
 }
@@ -285,7 +271,7 @@ void CollisionChecker::RemoveAllAddedCollisionShapes(
 void CollisionChecker::RemoveAllAddedCollisionShapes() {
   drake::log()->debug("Removing all added geometries");
   for (const auto& [group_name, group_ids] : geometry_groups_) {
-    DoRemoveAddedGeometries(group_ids);
+    RemoveAddedGeometries(group_ids);
   }
   geometry_groups_.clear();
 }
@@ -433,13 +419,12 @@ void CollisionChecker::SetCollisionFilterMatrix(
   }
   // Only perform additional work if the provided filter matrix is different
   // from the current matrix.
-  if (AreCollisionFilterMatricesDifferent(filtered_collisions_,
-                                          filter_matrix)) {
+  if (filtered_collisions_ != filter_matrix) {
     // Now test for consistency.
     ValidateFilteredCollisionMatrix(filter_matrix, __func__);
     filtered_collisions_ = filter_matrix;
     // Allow derived checkers to perform any post-filter-change work.
-    DoUpdateCollisionFilters();
+    UpdateCollisionFilters();
   }
 }
 
@@ -478,7 +463,7 @@ void CollisionChecker::SetCollisionFilteredBetween(BodyIndex bodyA_index,
     filtered_collisions_(int{bodyA_index}, int{bodyB_index}) = new_value;
     filtered_collisions_(int{bodyB_index}, int{bodyA_index}) = new_value;
     // Allow derived checkers to perform any post-filter-change work.
-    DoUpdateCollisionFilters();
+    UpdateCollisionFilters();
   }
 }
 
@@ -492,10 +477,9 @@ void CollisionChecker::SetCollisionFilteredWithAllBodies(BodyIndex body_index) {
   // Maintain the invariant that the diagonal is always -1.
   filtered_collisions_(int{body_index}, int{body_index}) = -1;
   // Only perform additional work if the filter matrix has changed.
-  if (AreCollisionFilterMatricesDifferent(prior_filter_matrix,
-                                          filtered_collisions_)) {
+  if (prior_filter_matrix != filtered_collisions_) {
     // Allow derived checkers to perform any post-filter-change work.
-    DoUpdateCollisionFilters();
+    UpdateCollisionFilters();
   }
 }
 
@@ -796,116 +780,6 @@ std::vector<RobotCollisionType> CollisionChecker::ClassifyContextBodyCollisions(
   return DoClassifyContextBodyCollisions(*model_context);
 }
 
-Eigen::MatrixXi CollisionChecker::GenerateFilteredCollisionMatrix(
-    const CollisionChecker& checker,
-    const SceneGraphInspector<double>& inspector) {
-  const int num_bodies = checker.plant().num_bodies();
-  // Initialize matrix to zero (no filtered collisions).
-  Eigen::MatrixXi filtered_collisions =
-      Eigen::MatrixXi::Zero(num_bodies, num_bodies);
-
-  // Generate a mapping from body to subgraph for use in identifying welds.
-  std::vector<int> body_subgraph_mapping(num_bodies, -1);
-
-  const std::vector<std::set<BodyIndex>> subgraphs =
-      checker.plant().FindSubgraphsOfWeldedBodies();
-
-  for (size_t subgraph_id = 0; subgraph_id < subgraphs.size(); ++subgraph_id) {
-    const std::set<BodyIndex>& subgraph = subgraphs.at(subgraph_id);
-    for (const BodyIndex& body_id : subgraph) {
-      body_subgraph_mapping.at(body_id) = static_cast<int>(subgraph_id);
-    }
-  }
-
-  // For consistency, (B, B) is always filtered.
-  // Loop variables below use `int` for Eigen indexing compatibility.
-  for (int i = 0; i < num_bodies; ++i) {
-    filtered_collisions(i, i) = -1;
-
-    const int body_i_subgraph_id = body_subgraph_mapping.at(i);
-    // We expect FindSubgraphsOfWeldedBodies to cover all bodies, but check to
-    // make sure no bodies are left with the default subgraph id.
-    DRAKE_DEMAND(body_i_subgraph_id >= 0);
-
-    const bool i_is_robot = checker.IsPartOfRobot(BodyIndex(i));
-
-    const Body<double>& body_i = checker.get_body(BodyIndex(i));
-
-    const std::vector<GeometryId>& geometries_i =
-        checker.plant().GetCollisionGeometriesForBody(body_i);
-
-    for (int j = i + 1; j < num_bodies; ++j) {
-      const int body_j_subgraph_id = body_subgraph_mapping.at(j);
-
-      const bool j_is_robot = checker.IsPartOfRobot(BodyIndex(j));
-      // (Env, env) pairs are immutably filtered (marked -1).
-      if (!(i_is_robot || j_is_robot)) {
-        filtered_collisions(i, j) = -1;
-        filtered_collisions(j, i) = -1;
-        continue;
-      }
-
-      const Body<double>& body_j = checker.get_body(BodyIndex(j));
-
-      // Check if collisions between the geometries are already filtered.
-      bool collisions_filtered = false;
-      const std::vector<GeometryId>& geometries_j =
-          checker.plant().GetCollisionGeometriesForBody(body_j);
-      if (geometries_i.size() > 0 && geometries_j.size() > 0) {
-        collisions_filtered =
-            inspector.CollisionFiltered(geometries_i.at(0), geometries_j.at(0));
-        // Ensure that the collision filtering is homogeneous across all body
-        // geometries.
-        for (const auto& id_i : geometries_i) {
-          for (const auto& id_j : geometries_j) {
-            const bool current_filtered =
-                inspector.CollisionFiltered(id_i, id_j);
-            if (current_filtered != collisions_filtered) {
-              throw std::runtime_error(fmt::format(
-                  "SceneGraph's collision filters on the geometries of bodies "
-                  " {} [{}] and {} [{}] are not homogeneous",
-                  i, body_i.scoped_name(), j, body_j.scoped_name()));
-            }
-          }
-        }
-      }
-
-      // While MbP already filters collisions in SceneGraph between welded
-      // bodies, this is only recorded if both bodies have collision geometries
-      // when this filter is applied. Since we want to handle collision
-      // geometries added later, we must record if bodies are welded together.
-
-      // If the body pair has a welded path between them, it should be filtered.
-      const bool bodies_welded_together =
-          body_i_subgraph_id == body_j_subgraph_id;
-
-      // Add the filter accordingly.
-      if (collisions_filtered) {
-        // Filter the collision
-        log()->debug(
-            "Collision between body {} [{}] and body {} [{}] filtered "
-            "(filtered in SceneGraph)",
-            body_i.scoped_name(), i, body_j.scoped_name(), j);
-        filtered_collisions(i, j) = 1;
-        filtered_collisions(j, i) = 1;
-      } else if (bodies_welded_together) {
-        // Filter the collision
-        log()->debug(
-            "Collision between body {} [{}] and body {} [{}] filtered "
-            "(bodies are welded together)",
-            body_i.scoped_name(), i, body_j.scoped_name(), j);
-        filtered_collisions(i, j) = 1;
-        filtered_collisions(j, i) = 1;
-      } else {
-        log()->debug(
-            "Collision between body {} [{}] and body {} [{}] not filtered",
-            body_i.scoped_name(), i, body_j.scoped_name(), j);
-      }
-    }
-  }
-  return filtered_collisions;
-}
-
 CollisionChecker::CollisionChecker(CollisionCheckerParams params,
                                    bool supports_parallel_checking)
     : setup_model_(std::move(params.model)),
@@ -943,8 +817,7 @@ CollisionChecker::CollisionChecker(CollisionCheckerParams params,
       MakeDefaultConfigurationInterpolationFunction(
           GetQuaternionDofStartIndices(plant())));
   // Generate the filtered collision matrix.
-  nominal_filtered_collisions_ = GenerateFilteredCollisionMatrix(
-      *this, model().scene_graph().model_inspector());
+  nominal_filtered_collisions_ = GenerateFilteredCollisionMatrix();
   filtered_collisions_ = nominal_filtered_collisions_;
   log()->debug("Collision filter matrix:\n{}", fmt_eigen(filtered_collisions_));
 }
@@ -1056,6 +929,116 @@ void CollisionChecker::ValidateFilteredCollisionMatrix(
       }
     }
   }
+}
+
+Eigen::MatrixXi CollisionChecker::GenerateFilteredCollisionMatrix() const {
+  const int num_bodies = plant().num_bodies();
+  // Initialize matrix to zero (no filtered collisions).
+  Eigen::MatrixXi filtered_collisions =
+      Eigen::MatrixXi::Zero(num_bodies, num_bodies);
+
+  const auto& inspector = model().scene_graph().model_inspector();
+
+  // Generate a mapping from body to subgraph for use in identifying welds.
+  std::vector<int> body_subgraph_mapping(num_bodies, -1);
+
+  const std::vector<std::set<BodyIndex>> subgraphs =
+      plant().FindSubgraphsOfWeldedBodies();
+
+  for (size_t subgraph_id = 0; subgraph_id < subgraphs.size(); ++subgraph_id) {
+    const std::set<BodyIndex>& subgraph = subgraphs.at(subgraph_id);
+    for (const BodyIndex& body_id : subgraph) {
+      body_subgraph_mapping.at(body_id) = static_cast<int>(subgraph_id);
+    }
+  }
+
+  // For consistency, (B, B) is always filtered.
+  // Loop variables below use `int` for Eigen indexing compatibility.
+  for (int i = 0; i < num_bodies; ++i) {
+    filtered_collisions(i, i) = -1;
+
+    const int body_i_subgraph_id = body_subgraph_mapping.at(i);
+    // We expect FindSubgraphsOfWeldedBodies to cover all bodies, but check to
+    // make sure no bodies are left with the default subgraph id.
+    DRAKE_DEMAND(body_i_subgraph_id >= 0);
+
+    const bool i_is_robot = IsPartOfRobot(BodyIndex(i));
+
+    const Body<double>& body_i = get_body(BodyIndex(i));
+
+    const std::vector<GeometryId>& geometries_i =
+        plant().GetCollisionGeometriesForBody(body_i);
+
+    for (int j = i + 1; j < num_bodies; ++j) {
+      const int body_j_subgraph_id = body_subgraph_mapping.at(j);
+
+      const bool j_is_robot = IsPartOfRobot(BodyIndex(j));
+      // (Env, env) pairs are immutably filtered (marked -1).
+      if (!(i_is_robot || j_is_robot)) {
+        filtered_collisions(i, j) = -1;
+        filtered_collisions(j, i) = -1;
+        continue;
+      }
+
+      const Body<double>& body_j = get_body(BodyIndex(j));
+
+      // Check if collisions between the geometries are already filtered.
+      bool collisions_filtered = false;
+      const std::vector<GeometryId>& geometries_j =
+          plant().GetCollisionGeometriesForBody(body_j);
+      if (geometries_i.size() > 0 && geometries_j.size() > 0) {
+        collisions_filtered =
+            inspector.CollisionFiltered(geometries_i.at(0), geometries_j.at(0));
+        // Ensure that the collision filtering is homogeneous across all body
+        // geometries.
+        for (const auto& id_i : geometries_i) {
+          for (const auto& id_j : geometries_j) {
+            const bool current_filtered =
+                inspector.CollisionFiltered(id_i, id_j);
+            if (current_filtered != collisions_filtered) {
+              throw std::runtime_error(fmt::format(
+                  "SceneGraph's collision filters on the geometries of bodies "
+                  " {} [{}] and {} [{}] are not homogeneous",
+                  i, body_i.scoped_name(), j, body_j.scoped_name()));
+            }
+          }
+        }
+      }
+
+      // While MbP already filters collisions in SceneGraph between welded
+      // bodies, this is only recorded if both bodies have collision geometries
+      // when this filter is applied. Since we want to handle collision
+      // geometries added later, we must record if bodies are welded together.
+
+      // If the body pair has a welded path between them, it should be filtered.
+      const bool bodies_welded_together =
+          body_i_subgraph_id == body_j_subgraph_id;
+
+      // Add the filter accordingly.
+      if (collisions_filtered) {
+        // Filter the collision
+        log()->debug(
+            "Collision between body {} [{}] and body {} [{}] filtered "
+            "(filtered in SceneGraph)",
+            body_i.scoped_name(), i, body_j.scoped_name(), j);
+        filtered_collisions(i, j) = 1;
+        filtered_collisions(j, i) = 1;
+      } else if (bodies_welded_together) {
+        // Filter the collision
+        log()->debug(
+            "Collision between body {} [{}] and body {} [{}] filtered "
+            "(bodies are welded together)",
+            body_i.scoped_name(), i, body_j.scoped_name(), j);
+        filtered_collisions(i, j) = 1;
+        filtered_collisions(j, i) = 1;
+      } else {
+        log()->debug(
+            "Collision between body {} [{}] and body {} [{}] not filtered",
+            body_i.scoped_name(), i, body_j.scoped_name(), j);
+      }
+    }
+  }
+  return filtered_collisions;
 }
 
 void CollisionChecker::UpdateMaxCollisionPadding() {

--- a/planning/collision_checker.h
+++ b/planning/collision_checker.h
@@ -664,6 +664,11 @@ class CollisionChecker {
    @throws std::exception if `body_index` refers to an environment body. */
   void SetCollisionFilteredWithAllBodies(multibody::BodyIndex body_index);
 
+  /** Overload that uses body references. */
+  void SetCollisionFilteredWithAllBodies(const multibody::Body<double>& body) {
+    SetCollisionFilteredWithAllBodies(body.index());
+  }
+
   //@}
 
   /** @name Configuration collision checking */
@@ -1042,6 +1047,12 @@ class CollisionChecker {
    @returns true if parallel checking is supported. */
   bool SupportsParallelChecking() const { return supports_parallel_checking_; }
 
+  /* (Internal use only.) Generates the collision filter matrix for the provided
+    collision checker and inspector. */
+  static Eigen::MatrixXi GenerateFilteredCollisionMatrix(
+      const CollisionChecker& checker,
+      const geometry::SceneGraphInspector<double>& inspector);
+
  protected:
   /** Derived classes declare upon construction whether they support parallel
    checking (see SupportsParallelChecking()).
@@ -1409,12 +1420,6 @@ class CollisionChecker {
   /* The names of all groups with added geometries. */
   std::map<std::string, std::vector<AddedShape>> geometry_groups_;
 };
-
-/* (Internal use only.) Generates the collision filter matrix for the provided
-  collision checker and inspector. */
-Eigen::MatrixXi GenerateFilteredCollisionMatrix(
-    const CollisionChecker& checker,
-    const geometry::SceneGraphInspector<double>& inspector);
 
 }  // namespace planning
 }  // namespace drake

--- a/planning/collision_checker.h
+++ b/planning/collision_checker.h
@@ -1047,8 +1047,22 @@ class CollisionChecker {
    @returns true if parallel checking is supported. */
   bool SupportsParallelChecking() const { return supports_parallel_checking_; }
 
-  /* (Internal use only.) Generates the collision filter matrix for the provided
-    collision checker and inspector. */
+  /* (Internal use only.) Generates the "nominal" filtered collision matrix.
+
+   The nominal filtered collision matrix has the following properties:
+
+      - All diagonal entries are set to -1 (a body colliding with itself
+        is meaningless).
+      - All environment-environment pairs are set to -1. CollisionChecker
+        ignores them; so it might as well be explicit about it in the matrix.
+      - For bodies I and J,
+        - if all geometries of I have "filtered collisions" (in the SceneGraph
+          sense), with all the geometries of J, the matrix is set to 1.
+        - If *no* geometries of I and J are filtered, the matrix is set to 0.
+        - If some geometry pairs are filtered, and some are not, an error is
+          thrown.
+      - If a welded path exists between two bodies (in the MultibodyPlant),
+        the matrix is set to 1. */
   static Eigen::MatrixXi GenerateFilteredCollisionMatrix(
       const CollisionChecker& checker,
       const geometry::SceneGraphInspector<double>& inspector);
@@ -1193,25 +1207,6 @@ class CollisionChecker {
       - All entries are either 0, 1, or -1. */
   void ValidateFilteredCollisionMatrix(const Eigen::MatrixXi& filtered,
                                        const char* func) const;
-
-  /* The "nominal" collision matrix. This is intended to be called only upon
-   construction.
-
-   The nominal filtered collision matrix has the following properties:
-
-      - All diagonal entries are set to -1 (a body colliding with itself
-        is meaningless).
-      - All environment-environment pairs are set to -1. CollisionChecker
-        ignores them; so it might as well be explicit about it in the matrix.
-      - For bodies I and J,
-        - if all geometries of I have "filtered collisions" (in the SceneGraph
-          sense), with all the geometries of J, the matrix is set to 1.
-        - If *no* geometries of I and J are filtered, the matrix is set to 0.
-        - If some geometry pairs are filtered, and some are not, an error is
-          thrown.
-      - If a welded path exists between two bodies (in the MultibodyPlant),
-        the matrix is set to 1. */
-  Eigen::MatrixXi GenerateFilteredCollisionMatrix() const;
 
   /* Updates the stored value representing the largest value found in the
    padding matrix -- this excludes the meaningless zeros on the diagonal. */

--- a/planning/collision_checker.h
+++ b/planning/collision_checker.h
@@ -1130,7 +1130,8 @@ class CollisionChecker {
       const std::vector<AddedShape>& shapes) = 0;
 
   /** Derived collision checkers can do further work in this function in
-   response to changes in collision filters. */
+   response to changes in collision filters. This is called after any changes
+   are made to the collision filter matrix. */
   virtual void DoUpdateCollisionFilters() = 0;
 
   /** Derived collision checkers are responsible for defining the reported
@@ -1408,6 +1409,12 @@ class CollisionChecker {
   /* The names of all groups with added geometries. */
   std::map<std::string, std::vector<AddedShape>> geometry_groups_;
 };
+
+/* (Internal use only.) Generates the collision filter matrix for the provided
+  collision checker and inspector. */
+Eigen::MatrixXi GenerateFilteredCollisionMatrix(
+    const CollisionChecker& checker,
+    const geometry::SceneGraphInspector<double>& inspector);
 
 }  // namespace planning
 }  // namespace drake

--- a/planning/collision_checker.h
+++ b/planning/collision_checker.h
@@ -1129,6 +1129,10 @@ class CollisionChecker {
   virtual void DoRemoveAddedGeometries(
       const std::vector<AddedShape>& shapes) = 0;
 
+  /** Derived collision checkers can do further work in this function in
+   response to changes in collision filters. */
+  virtual void DoUpdateCollisionFilters() = 0;
+
   /** Derived collision checkers are responsible for defining the reported
    measurements. But they must adhere to the characteristics documented on
    RobotClearance, e.g., one measurement per row. CollisionChecker guarantees

--- a/planning/collision_checker.h
+++ b/planning/collision_checker.h
@@ -1047,26 +1047,6 @@ class CollisionChecker {
    @returns true if parallel checking is supported. */
   bool SupportsParallelChecking() const { return supports_parallel_checking_; }
 
-  /* (Internal use only.) Generates the "nominal" filtered collision matrix.
-
-   The nominal filtered collision matrix has the following properties:
-
-      - All diagonal entries are set to -1 (a body colliding with itself
-        is meaningless).
-      - All environment-environment pairs are set to -1. CollisionChecker
-        ignores them; so it might as well be explicit about it in the matrix.
-      - For bodies I and J,
-        - if all geometries of I have "filtered collisions" (in the SceneGraph
-          sense), with all the geometries of J, the matrix is set to 1.
-        - If *no* geometries of I and J are filtered, the matrix is set to 0.
-        - If some geometry pairs are filtered, and some are not, an error is
-          thrown.
-      - If a welded path exists between two bodies (in the MultibodyPlant),
-        the matrix is set to 1. */
-  static Eigen::MatrixXi GenerateFilteredCollisionMatrix(
-      const CollisionChecker& checker,
-      const geometry::SceneGraphInspector<double>& inspector);
-
  protected:
   /** Derived classes declare upon construction whether they support parallel
    checking (see SupportsParallelChecking()).
@@ -1151,13 +1131,12 @@ class CollisionChecker {
   };
 
   /** Removes all of the given added shapes (if they exist) from the checker. */
-  virtual void DoRemoveAddedGeometries(
-      const std::vector<AddedShape>& shapes) = 0;
+  virtual void RemoveAddedGeometries(const std::vector<AddedShape>& shapes) = 0;
 
   /** Derived collision checkers can do further work in this function in
    response to changes in collision filters. This is called after any changes
    are made to the collision filter matrix. */
-  virtual void DoUpdateCollisionFilters() = 0;
+  virtual void UpdateCollisionFilters() = 0;
 
   /** Derived collision checkers are responsible for defining the reported
    measurements. But they must adhere to the characteristics documented on
@@ -1207,6 +1186,25 @@ class CollisionChecker {
       - All entries are either 0, 1, or -1. */
   void ValidateFilteredCollisionMatrix(const Eigen::MatrixXi& filtered,
                                        const char* func) const;
+
+  /* The "nominal" collision matrix. This is intended to be called only upon
+   construction.
+
+   The nominal filtered collision matrix has the following properties:
+
+      - All diagonal entries are set to -1 (a body colliding with itself
+        is meaningless).
+      - All environment-environment pairs are set to -1. CollisionChecker
+        ignores them; so it might as well be explicit about it in the matrix.
+      - For bodies I and J,
+        - if all geometries of I have "filtered collisions" (in the SceneGraph
+          sense), with all the geometries of J, the matrix is set to 1.
+        - If *no* geometries of I and J are filtered, the matrix is set to 0.
+        - If some geometry pairs are filtered, and some are not, an error is
+          thrown.
+      - If a welded path exists between two bodies (in the MultibodyPlant),
+        the matrix is set to 1. */
+  Eigen::MatrixXi GenerateFilteredCollisionMatrix() const;
 
   /* Updates the stored value representing the largest value found in the
    padding matrix -- this excludes the meaningless zeros on the diagonal. */

--- a/planning/scene_graph_collision_checker.h
+++ b/planning/scene_graph_collision_checker.h
@@ -58,12 +58,6 @@ class SceneGraphCollisionChecker final : public CollisionChecker {
 
   int DoMaxContextNumDistances(
       const CollisionCheckerContext& model_context) const final;
-
-  // Expose collision filter consistency for test purposes.
-  friend void EnforceCollisionFilterConsistency(
-      const SceneGraphCollisionChecker& checker);
-
-  bool CheckCollisionFilterConsistency() const;
 };
 
 }  // namespace planning

--- a/planning/scene_graph_collision_checker.h
+++ b/planning/scene_graph_collision_checker.h
@@ -47,6 +47,8 @@ class SceneGraphCollisionChecker final : public CollisionChecker {
   void DoRemoveAddedGeometries(
       const std::vector<CollisionChecker::AddedShape>& shapes) final;
 
+  void DoUpdateCollisionFilters() final;
+
   RobotClearance DoCalcContextRobotClearance(
       const CollisionCheckerContext& model_context,
       double influence_distance) const final;

--- a/planning/scene_graph_collision_checker.h
+++ b/planning/scene_graph_collision_checker.h
@@ -58,6 +58,9 @@ class SceneGraphCollisionChecker final : public CollisionChecker {
 
   int DoMaxContextNumDistances(
       const CollisionCheckerContext& model_context) const final;
+
+  // Applies filters defined in the filtered collision matrix to SceneGraph.
+  void ApplyCollisionFiltersToSceneGraph();
 };
 
 }  // namespace planning

--- a/planning/scene_graph_collision_checker.h
+++ b/planning/scene_graph_collision_checker.h
@@ -58,6 +58,12 @@ class SceneGraphCollisionChecker final : public CollisionChecker {
 
   int DoMaxContextNumDistances(
       const CollisionCheckerContext& model_context) const final;
+
+  // Expose collision filter consistency for test purposes.
+  friend void EnforceCollisionFilterConsistency(
+      const SceneGraphCollisionChecker& checker);
+
+  bool CheckCollisionFilterConsistency() const;
 };
 
 }  // namespace planning

--- a/planning/scene_graph_collision_checker.h
+++ b/planning/scene_graph_collision_checker.h
@@ -60,6 +60,10 @@ class SceneGraphCollisionChecker final : public CollisionChecker {
       const CollisionCheckerContext& model_context) const final;
 
   // Applies filters defined in the filtered collision matrix to SceneGraph.
+  // This must be called in the constructor to ensure that additional filters
+  // applied by CollisionChecker are present in SceneGraph, and after any
+  // geometry is added to SceneGraph, as any existing filters will not include
+  // the new geometry.
   void ApplyCollisionFiltersToSceneGraph();
 };
 

--- a/planning/scene_graph_collision_checker.h
+++ b/planning/scene_graph_collision_checker.h
@@ -44,10 +44,10 @@ class SceneGraphCollisionChecker final : public CollisionChecker {
       const geometry::Shape& shape,
       const math::RigidTransform<double>& X_AG) final;
 
-  void DoRemoveAddedGeometries(
+  void RemoveAddedGeometries(
       const std::vector<CollisionChecker::AddedShape>& shapes) final;
 
-  void DoUpdateCollisionFilters() final;
+  void UpdateCollisionFilters() final;
 
   RobotClearance DoCalcContextRobotClearance(
       const CollisionCheckerContext& model_context,

--- a/planning/test/collision_checker_test.cc
+++ b/planning/test/collision_checker_test.cc
@@ -237,7 +237,7 @@ class CollisionCheckerTester : public UnimplementedCollisionChecker {
   mutable VectorXd positions_for_classify_;
   // Updated with every call to DoCheckContextConfigCollisionFree().
   mutable VectorXd positions_for_check_;
-  // Updated with every call to DoUpdateCollisionFilters().
+  // Updated with every call to UpdateCollisionFilters().
   Eigen::MatrixXi updated_filter_matrix_;
 };
 
@@ -942,7 +942,7 @@ TEST_F(TrivialCollisionCheckerTest, SetCollisionFilterMatrix) {
   ASSERT_NO_THROW(dut_->SetCollisionFilterMatrix(no_filters));
   EXPECT_TRUE(CompareMatrices(dut_->GetFilteredCollisionMatrix(), no_filters));
   // Confirm that the collision filter matrix was updated before calling
-  // DoUpdateCollisionFilters().
+  // UpdateCollisionFilters().
   EXPECT_TRUE(CompareMatrices(dut_->updated_filter_matrix(),
                               dut_->GetFilteredCollisionMatrix()));
 
@@ -1204,7 +1204,7 @@ TEST_F(TrivialCollisionCheckerTest, SetCollisionFilteredBetween) {
     EXPECT_NO_THROW(
         dut_->SetCollisionFilterMatrix(dut_->GetFilteredCollisionMatrix()));
     // Confirm that the collision filter matrix was updated before calling
-    // DoUpdateCollisionFilters().
+    // UpdateCollisionFilters().
     EXPECT_TRUE(CompareMatrices(dut_->updated_filter_matrix(),
                                 dut_->GetFilteredCollisionMatrix()));
   }
@@ -1255,7 +1255,7 @@ TEST_F(TrivialCollisionCheckerTest, SetCollisionFilteredWithAllBodies) {
     // matrix and reports filters as expected.
     EXPECT_NO_THROW(dut_->SetCollisionFilteredWithAllBodies(b[3]));
     // Confirm that the collision filter matrix was updated before calling
-    // DoUpdateCollisionFilters().
+    // UpdateCollisionFilters().
     EXPECT_TRUE(CompareMatrices(dut_->updated_filter_matrix(),
                                 dut_->GetFilteredCollisionMatrix()));
     EXPECT_NO_THROW(
@@ -1271,7 +1271,7 @@ TEST_F(TrivialCollisionCheckerTest, SetCollisionFilteredWithAllBodies) {
     EXPECT_NO_THROW(
         dut_->SetCollisionFilteredWithAllBodies(dut_->get_body(b[2])));
     // Confirm that the collision filter matrix was updated before calling
-    // DoUpdateCollisionFilters().
+    // UpdateCollisionFilters().
     EXPECT_TRUE(CompareMatrices(dut_->updated_filter_matrix(),
                                 dut_->GetFilteredCollisionMatrix()));
     EXPECT_NO_THROW(

--- a/planning/test/collision_checker_test.cc
+++ b/planning/test/collision_checker_test.cc
@@ -144,7 +144,8 @@ class CollisionCheckerTester : public UnimplementedCollisionChecker {
   }
 
   void DoUpdateCollisionFilters() override {
-    // Don't need to do work; just don't throw.
+    // Capture the updated collision filter matrix.
+    updated_filter_matrix_ = GetFilteredCollisionMatrix();
   }
 
   RobotClearance DoCalcContextRobotClearance(
@@ -219,6 +220,12 @@ class CollisionCheckerTester : public UnimplementedCollisionChecker {
   // Returns the positions available in this checker from the most recent
   // Check*ConfigCollisionFree() call.
   const VectorXd& positions_for_check() const { return positions_for_check_; }
+
+  // Returns the filter matrix available in this checker from the most recent
+  // operation that modified the filter matrix.
+  const Eigen::MatrixXi& updated_filter_matrix() const {
+    return updated_filter_matrix_;
+  }
   //@}
 
  private:
@@ -230,6 +237,8 @@ class CollisionCheckerTester : public UnimplementedCollisionChecker {
   mutable VectorXd positions_for_classify_;
   // Updated with every call to DoCheckContextConfigCollisionFree().
   mutable VectorXd positions_for_check_;
+  // Updated with every call to DoUpdateCollisionFilters().
+  Eigen::MatrixXi updated_filter_matrix_;
 };
 
 // Makes a test checker for the given model and enumerated set of robot
@@ -932,6 +941,10 @@ TEST_F(TrivialCollisionCheckerTest, SetCollisionFilterMatrix) {
   EXPECT_FALSE(CompareMatrices(dut_->GetFilteredCollisionMatrix(), no_filters));
   ASSERT_NO_THROW(dut_->SetCollisionFilterMatrix(no_filters));
   EXPECT_TRUE(CompareMatrices(dut_->GetFilteredCollisionMatrix(), no_filters));
+  // Confirm that the collision filter matrix was updated before calling
+  // DoUpdateCollisionFilters().
+  EXPECT_TRUE(CompareMatrices(dut_->updated_filter_matrix(),
+                              dut_->GetFilteredCollisionMatrix()));
 
   // Now test the various ways we can throw.
 
@@ -1190,6 +1203,10 @@ TEST_F(TrivialCollisionCheckerTest, SetCollisionFilteredBetween) {
     EXPECT_FALSE(dut_->IsCollisionFilteredBetween(b[1], b[4]));
     EXPECT_NO_THROW(
         dut_->SetCollisionFilterMatrix(dut_->GetFilteredCollisionMatrix()));
+    // Confirm that the collision filter matrix was updated before calling
+    // DoUpdateCollisionFilters().
+    EXPECT_TRUE(CompareMatrices(dut_->updated_filter_matrix(),
+                                dut_->GetFilteredCollisionMatrix()));
   }
 
   {
@@ -1237,6 +1254,10 @@ TEST_F(TrivialCollisionCheckerTest, SetCollisionFilteredWithAllBodies) {
     // Setting a robot body (via index) doesn't throw, produces a consistent
     // matrix and reports filters as expected.
     EXPECT_NO_THROW(dut_->SetCollisionFilteredWithAllBodies(b[3]));
+    // Confirm that the collision filter matrix was updated before calling
+    // DoUpdateCollisionFilters().
+    EXPECT_TRUE(CompareMatrices(dut_->updated_filter_matrix(),
+                                dut_->GetFilteredCollisionMatrix()));
     EXPECT_NO_THROW(
         dut_->SetCollisionFilterMatrix(dut_->GetFilteredCollisionMatrix()));
     for (BodyIndex i(0); i < num_bodies; ++i) {
@@ -1249,6 +1270,10 @@ TEST_F(TrivialCollisionCheckerTest, SetCollisionFilteredWithAllBodies) {
     // matrix and reports filters as expected.
     EXPECT_NO_THROW(
         dut_->SetCollisionFilteredWithAllBodies(dut_->get_body(b[2])));
+    // Confirm that the collision filter matrix was updated before calling
+    // DoUpdateCollisionFilters().
+    EXPECT_TRUE(CompareMatrices(dut_->updated_filter_matrix(),
+                                dut_->GetFilteredCollisionMatrix()));
     EXPECT_NO_THROW(
         dut_->SetCollisionFilterMatrix(dut_->GetFilteredCollisionMatrix()));
     for (BodyIndex i(0); i < num_bodies; ++i) {

--- a/planning/test/collision_checker_test.cc
+++ b/planning/test/collision_checker_test.cc
@@ -1234,13 +1234,25 @@ TEST_F(TrivialCollisionCheckerTest, SetCollisionFilteredWithAllBodies) {
   }
 
   {
-    // Setting a robot body doesn't throw, produces a consistent matrix and
-    // reports filters as expected.
+    // Setting a robot body (via index) doesn't throw, produces a consistent
+    // matrix and reports filters as expected.
     EXPECT_NO_THROW(dut_->SetCollisionFilteredWithAllBodies(b[3]));
     EXPECT_NO_THROW(
         dut_->SetCollisionFilterMatrix(dut_->GetFilteredCollisionMatrix()));
     for (BodyIndex i(0); i < num_bodies; ++i) {
       EXPECT_TRUE(dut_->IsCollisionFilteredBetween(i, b[3]));
+    }
+  }
+
+  {
+    // Setting a robot body (via reference) doesn't throw, produces a consistent
+    // matrix and reports filters as expected.
+    EXPECT_NO_THROW(
+        dut_->SetCollisionFilteredWithAllBodies(dut_->get_body(b[2])));
+    EXPECT_NO_THROW(
+        dut_->SetCollisionFilterMatrix(dut_->GetFilteredCollisionMatrix()));
+    for (BodyIndex i(0); i < num_bodies; ++i) {
+      EXPECT_TRUE(dut_->IsCollisionFilteredBetween(i, b[2]));
     }
   }
 }

--- a/planning/test/collision_checker_test.cc
+++ b/planning/test/collision_checker_test.cc
@@ -143,6 +143,10 @@ class CollisionCheckerTester : public UnimplementedCollisionChecker {
     // Don't need to do work; just don't throw.
   }
 
+  void DoUpdateCollisionFilters() override {
+    // Don't need to do work; just don't throw.
+  }
+
   RobotClearance DoCalcContextRobotClearance(
       const CollisionCheckerContext&, double influence_dist) const override {
     // CollisionChecker promises that influence_dist is finite and non-negative.

--- a/planning/test/collision_checker_test.cc
+++ b/planning/test/collision_checker_test.cc
@@ -138,12 +138,12 @@ class CollisionCheckerTester : public UnimplementedCollisionChecker {
     return added_shape_id_;
   }
 
-  void DoRemoveAddedGeometries(
+  void RemoveAddedGeometries(
       const std::vector<CollisionChecker::AddedShape>& shapes) override {
     // Don't need to do work; just don't throw.
   }
 
-  void DoUpdateCollisionFilters() override {
+  void UpdateCollisionFilters() override {
     // Capture the updated collision filter matrix.
     updated_filter_matrix_ = GetFilteredCollisionMatrix();
   }

--- a/planning/test/scene_graph_collision_checker_test.cc
+++ b/planning/test/scene_graph_collision_checker_test.cc
@@ -103,6 +103,11 @@ Eigen::MatrixXi GenerateFilteredCollisionMatrixFromSceneGraphOnly(
   return filtered_collisions;
 }
 
+// Enforce that the collision filter matrix of the provided collision checker is
+// consistent with the filters applied in the SceneGraph context of every
+// collision checker context. Note: this check only covers bodies with
+// associated collision geometries, as SceneGraph cannot express filters between
+// bodies without geometries.
 void EnforceCollisionFilterConsistency(
     const SceneGraphCollisionChecker& checker) {
   const Eigen::MatrixXi& current_collision_filter_matrix =
@@ -144,7 +149,7 @@ void EnforceCollisionFilterConsistency(
           // bodies with geometries, so we only check pairs where both bodies
           // have associated geometries.
           if (i_has_geometries && j_has_geometries) {
-            inconsistencies++;
+            ++inconsistencies;
             drake::log()->error("Entry {},{} is inconsistent", i, j);
           } else {
             drake::log()->info("Entry {},{} is inconsistent (ignored)", i, j);

--- a/planning/unimplemented_collision_checker.cc
+++ b/planning/unimplemented_collision_checker.cc
@@ -46,12 +46,12 @@ UnimplementedCollisionChecker::DoAddCollisionShapeToBody(
   ThrowNotImplemented(__func__);
 }
 
-void UnimplementedCollisionChecker::DoRemoveAddedGeometries(
+void UnimplementedCollisionChecker::RemoveAddedGeometries(
     const std::vector<CollisionChecker::AddedShape>&) {
   ThrowNotImplemented(__func__);
 }
 
-void UnimplementedCollisionChecker::DoUpdateCollisionFilters() {
+void UnimplementedCollisionChecker::UpdateCollisionFilters() {
   ThrowNotImplemented(__func__);
 }
 

--- a/planning/unimplemented_collision_checker.cc
+++ b/planning/unimplemented_collision_checker.cc
@@ -51,6 +51,10 @@ void UnimplementedCollisionChecker::DoRemoveAddedGeometries(
   ThrowNotImplemented(__func__);
 }
 
+void UnimplementedCollisionChecker::DoUpdateCollisionFilters() {
+  ThrowNotImplemented(__func__);
+}
+
 RobotClearance UnimplementedCollisionChecker::DoCalcContextRobotClearance(
     const CollisionCheckerContext&, double) const {
   ThrowNotImplemented(__func__);

--- a/planning/unimplemented_collision_checker.h
+++ b/planning/unimplemented_collision_checker.h
@@ -52,10 +52,10 @@ class UnimplementedCollisionChecker : public CollisionChecker {
       const geometry::Shape& shape,
       const math::RigidTransform<double>& X_AG) override;
 
-  void DoRemoveAddedGeometries(
+  void RemoveAddedGeometries(
       const std::vector<CollisionChecker::AddedShape>& shapes) override;
 
-  void DoUpdateCollisionFilters() override;
+  void UpdateCollisionFilters() override;
 
   RobotClearance DoCalcContextRobotClearance(const CollisionCheckerContext&,
                                              double) const override;

--- a/planning/unimplemented_collision_checker.h
+++ b/planning/unimplemented_collision_checker.h
@@ -55,6 +55,8 @@ class UnimplementedCollisionChecker : public CollisionChecker {
   void DoRemoveAddedGeometries(
       const std::vector<CollisionChecker::AddedShape>& shapes) override;
 
+  void DoUpdateCollisionFilters() override;
+
   RobotClearance DoCalcContextRobotClearance(const CollisionCheckerContext&,
                                              double) const override;
 


### PR DESCRIPTION
Resolves #19386 by providing a new affordance for `CollisionChecker` implementations to perform additional collision filter updates when changes are made to the filtered collisions. This primarily exists so that `SceneGraphCollisionChecker` can convert allowed/excluded collisions into `SceneGraph`-native filter declarations.

+@SeanCurtis-TRI for feature review, as you're most familiar with `SceneGraph` filtering.

cc @jwnimmer-tri @sadraddini

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19387)
<!-- Reviewable:end -->
