### PR TITLE
RenderEngine no longer ignores sensor pose in camera body

### DIFF
--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -1204,7 +1204,8 @@ void GeometryState<T>::RenderColorImage(const ColorRenderCamera& camera,
                                         FrameId parent_frame,
                                         const RigidTransformd& X_PC,
                                         ImageRgba8U* color_image_out) const {
-  const RigidTransformd X_WC = GetDoubleWorldPose(parent_frame) * X_PC;
+  const RigidTransformd X_WC =
+      CalcCameraWorldPose(camera.core(), parent_frame, X_PC);
   const render::RenderEngine& engine =
       GetRenderEngineOrThrow(camera.core().renderer_name());
   // TODO(SeanCurtis-TRI): Invoke UpdateViewpoint() as part of a calc cache
@@ -1218,7 +1219,8 @@ void GeometryState<T>::RenderDepthImage(const DepthRenderCamera& camera,
                                         FrameId parent_frame,
                                         const RigidTransformd& X_PC,
                                         ImageDepth32F* depth_image_out) const {
-  const RigidTransformd X_WC = GetDoubleWorldPose(parent_frame) * X_PC;
+  const RigidTransformd X_WC =
+      CalcCameraWorldPose(camera.core(), parent_frame, X_PC);
   const render::RenderEngine& engine =
       GetRenderEngineOrThrow(camera.core().renderer_name());
   // See note in RenderColorImage() about this const cast.
@@ -1231,7 +1233,8 @@ void GeometryState<T>::RenderLabelImage(const ColorRenderCamera& camera,
                                         FrameId parent_frame,
                                         const RigidTransformd& X_PC,
                                         ImageLabel16I* label_image_out) const {
-  const RigidTransformd X_WC = GetDoubleWorldPose(parent_frame) * X_PC;
+  const RigidTransformd X_WC =
+      CalcCameraWorldPose(camera.core(), parent_frame, X_PC);
   const render::RenderEngine& engine =
       GetRenderEngineOrThrow(camera.core().renderer_name());
   // See note in RenderColorImage() about this const cast.
@@ -1701,6 +1704,14 @@ const render::RenderEngine& GeometryState<T>::GetRenderEngineOrThrow(
 
   throw std::logic_error(
       fmt::format("No renderer exists with name: '{}'", renderer_name));
+}
+
+template <typename T>
+RigidTransformd GeometryState<T>::CalcCameraWorldPose(
+    const render::RenderCameraCore& core, FrameId parent_frame,
+    const RigidTransformd& X_PC) const {
+  return GetDoubleWorldPose(parent_frame) * X_PC *
+         core.sensor_pose_in_camera_body();
 }
 
 template <typename T>

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -792,6 +792,12 @@ class GeometryState {
   const render::RenderEngine& GetRenderEngineOrThrow(
       const std::string& renderer_name) const;
 
+  // Returns the world pose of the camera *sensor* based on camera properties,
+  // parent frame, and pose in parent.
+  math::RigidTransformd CalcCameraWorldPose(
+      const render::RenderCameraCore& core, FrameId parent_frame,
+      const math::RigidTransformd& X_PC) const;
+
   // Utility function to facilitate getting a double-valued pose for a frame,
   // regardless of T's actual type.
   math::RigidTransformd GetDoubleWorldPose(FrameId frame_id) const;

--- a/geometry/render_gl/internal_render_engine_gl.cc
+++ b/geometry/render_gl/internal_render_engine_gl.cc
@@ -466,6 +466,8 @@ RenderEngineGl::RenderEngineGl(RenderEngineGlParams params)
       parameters_(std::move(params)) {
   // Configuration of basic OpenGl state.
   opengl_context_->MakeCurrent();
+  glEnable(GL_CULL_FACE);
+  glCullFace(GL_BACK);
   glClipControl(GL_UPPER_LEFT, GL_NEGATIVE_ONE_TO_ONE);
   glClearDepth(1.0);
   glEnable(GL_DEPTH_TEST);

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -4383,12 +4383,152 @@ TEST_F(GeometryStateNoRendererTest, PerceptionRoleWithoutRenderer) {
       0);
 }
 
-// TODO(SeanCurtis-TRI): The `Render*Image` interface is insufficiently tested.
-//  GeometryState is a thin wrapper on the render engine, but GeometryState is
-//  responsible for:
-//    1. Confirming the parent frame is valid.
-//    2. Updating the camera pose.
-//    3. Calling the appropriate render engine.
+// GeometryState has three responsibilities when it comes to rendering:
+//
+//   1. Compute the correct camera pose in the world frame.
+//   2. Handle finding render engines by name (including *not* finding them).
+//   3. Call the appropriate RenderEngine API for the image type.
+//
+// For each of the Render*Image APIs, this establishes those three
+// responsibilities are met.
+class GeometryStateRenderTest : public ::testing::Test {
+ protected:
+  void SetUp() final {
+    const SourceId s_id = geometry_state_.RegisterNewSource("render_test");
+
+    // Add an arbitrarily posed frame (90° rotation around x-axis with non-zero
+    // offset) to serve as the parent frame for the camera.
+    X_WP_ = RigidTransformd(AngleAxis<double>(M_PI_2, Vector3d::UnitX()),
+                            Vector3d{1, 2, 3});
+    parent_id_ =
+        geometry_state_.RegisterFrame(s_id, GeometryFrame("parent_frame"));
+
+    // Equally arbitrary non-identity poses for the camera body in the parent
+    // frame and camera sensor in the camera body frame.
+    X_PC_ = RigidTransformd(AngleAxis<double>(M_PI_2, Vector3d::UnitY()),
+                            Vector3d{2, 3, 4});
+    X_CS_ = RigidTransformd(AngleAxis<double>(M_PI_2, Vector3d::UnitZ()),
+                            Vector3d{3, 4, 5});
+    // The expected pose of the camera *sensor* as passed to the render engine.
+    X_WS_ = X_WP_ * X_PC_ * X_CS_;
+
+    // Now add two render engines.
+    auto engine1 = std::make_unique<DummyRenderEngine>();
+    engine1_ = engine1.get();
+    geometry_state_.AddRenderer("engine1", std::move(engine1));
+    geometry_state_.AddRenderer("engine2",
+                                std::make_unique<DummyRenderEngine>());
+    // Make sure the geometry data knows the parent frame's pose.
+    GeometryStateTester<double> tester;
+    tester.set_state(&geometry_state_);
+    FramePoseVector<double> poses;
+    poses.set_value(parent_id_, X_WP_);
+    tester.SetFramePoses(s_id, poses, &tester.mutable_kinematics_data());
+  }
+
+  static int width() { return 4; }
+  static int height() { return 3; }
+  render::RenderCameraCore camera_core(std::string_view engine_name) const {
+    return render::RenderCameraCore(std::string(engine_name),
+                                    {width(), height(), M_PI / 4}, {0.25, 10},
+                                    X_CS_);
+  }
+
+  render::ColorRenderCamera color_camera(std::string_view engine_name) const {
+    return render::ColorRenderCamera(camera_core(engine_name));
+  }
+
+  render::DepthRenderCamera depth_camera(std::string_view engine_name) const {
+    return render::DepthRenderCamera(camera_core(engine_name), {1.0, 5.0});
+  }
+
+  GeometryState<double> geometry_state_;
+  FrameId parent_id_{};
+  // The pose of the *parent* frame P in world.
+  RigidTransformd X_WP_;
+  // The pose of the *camera* body frame C in the parent frame.
+  RigidTransformd X_PC_;
+  // The pose of the *sensor* frame S in the camera body frame.
+  RigidTransformd X_CS_;
+  // The concatenated pose of the sensor frame in the world.  See Setup().
+  RigidTransformd X_WS_;
+  DummyRenderEngine* engine1_{};
+};
+
+TEST_F(GeometryStateRenderTest, RenderColorImage) {
+  // The image doesn't matter; it will *not* get written to. It just needs to be
+  // compatible with the camera.
+  systems::sensors::ImageRgba8U image(width(), height());
+
+  // Case: valid render sets the viewport and calls the right API. We don't test
+  //  to confirm that the image is passed along, that would be screamingly
+  //  apparent.
+  geometry_state_.RenderColorImage(color_camera("engine1"), parent_id_,
+                                    X_PC_, &image);
+  EXPECT_TRUE(CompareMatrices(engine1_->last_updated_X_WC().GetAsMatrix4(),
+                              X_WS_.GetAsMatrix4(), 1e-15));
+  EXPECT_EQ(engine1_->num_color_renders(), 1);
+  EXPECT_EQ(engine1_->num_depth_renders(), 0);
+  EXPECT_EQ(engine1_->num_label_renders(), 0);
+
+  // Passing another *valid* name doesn't throw (it finds the *other* engine).
+  // But passing an invalid name throws.
+  EXPECT_NO_THROW(geometry_state_.RenderColorImage(
+      color_camera("engine2"), parent_id_, X_PC_, &image));
+  EXPECT_THROW(geometry_state_.RenderColorImage(color_camera("not_an_engine"),
+                                                parent_id_, X_PC_, &image),
+               std::exception);
+}
+
+TEST_F(GeometryStateRenderTest, RenderDepthImage) {
+  // The image doesn't matter; it will *not* get written to. It just needs to be
+  // compatible with the camera.
+  systems::sensors::ImageDepth32F image(width(), height());
+
+  // Case: valid render sets the viewport and calls the right API. We don't test
+  //  to confirm that the image is passed along, that would be screamingly
+  //  apparent.
+  geometry_state_.RenderDepthImage(depth_camera("engine1"), parent_id_, X_PC_,
+                                   &image);
+  EXPECT_TRUE(CompareMatrices(engine1_->last_updated_X_WC().GetAsMatrix4(),
+                              X_WS_.GetAsMatrix4(), 1e-15));
+  EXPECT_EQ(engine1_->num_color_renders(), 0);
+  EXPECT_EQ(engine1_->num_depth_renders(), 1);
+  EXPECT_EQ(engine1_->num_label_renders(), 0);
+
+  // Passing another *valid* name doesn't throw (it finds the *other* engine).
+  // But passing an invalid name throws.
+  EXPECT_NO_THROW(geometry_state_.RenderDepthImage(depth_camera("engine2"),
+                                                   parent_id_, X_PC_, &image));
+  EXPECT_THROW(geometry_state_.RenderDepthImage(depth_camera("not_an_engine"),
+                                                parent_id_, X_PC_, &image),
+               std::exception);
+}
+
+TEST_F(GeometryStateRenderTest, RenderLabelImage) {
+  // The image doesn't matter; it will *not* get written to. It just needs to be
+  // compatible with the camera.
+  systems::sensors::ImageLabel16I image(width(), height());
+
+  // Case: valid render sets the viewport and calls the right API. We don't test
+  //  to confirm that the image is passed along, that would be screamingly
+  //  apparent.
+  geometry_state_.RenderLabelImage(color_camera("engine1"), parent_id_, X_PC_,
+                                   &image);
+  EXPECT_TRUE(CompareMatrices(engine1_->last_updated_X_WC().GetAsMatrix4(),
+                              X_WS_.GetAsMatrix4(), 1e-15));
+  EXPECT_EQ(engine1_->num_color_renders(), 0);
+  EXPECT_EQ(engine1_->num_depth_renders(), 0);
+  EXPECT_EQ(engine1_->num_label_renders(), 1);
+
+  // Passing another *valid* name doesn't throw (it finds the *other* engine).
+  // But passing an invalid name throws.
+  EXPECT_NO_THROW(geometry_state_.RenderLabelImage(color_camera("engine2"),
+                                                   parent_id_, X_PC_, &image));
+  EXPECT_THROW(geometry_state_.RenderLabelImage(color_camera("not_an_engine"),
+                                                parent_id_, X_PC_, &image),
+               std::exception);
+}
 
 }  // namespace
 }  // namespace geometry


### PR DESCRIPTION
GeometryState didn't test its Render*Image responsibilities. As it turns out, they were defective. Specifically, the camera pose should be a concatenation of *three* transforms.

Given frames for the camera's parent (P), body (B), and sensor (S). The pose of the camera in the world should be X_WP * X_PB * X_BS. It was omitting the last transform. Generally, the sensor offset from the body has been identity so we've been "getting away with it".

- Incidentally enables back face culling in RenderEngineGl.
  - If the camera was inside a mesh (because, for example, the pose was not what one was expected), the view would be full of black because one would see the un-illuminated back of the mesh.
  - Enabling this is good; it'll help eliminate z-fighting for "skinny" geometry and no one should have been relying on it.
  - It might also improve performance as more triangles get dismissed for pointing the wrong way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19398)
<!-- Reviewable:end -->
