### PR TITLE
[geometry] Bump tolerance for mesh_plane_intersection_test

### DIFF
--- a/geometry/proximity/test/mesh_plane_intersection_test.cc
+++ b/geometry/proximity/test/mesh_plane_intersection_test.cc
@@ -1791,7 +1791,7 @@ TEST_F(MeshPlaneDerivativesTest, FaceNormalsWrtPosition) {
       EXPECT_TRUE(
           CompareMatrices(math::ExtractValue(tri_n_W), plane_n_W, 2 * kEps));
       EXPECT_TRUE(
-          CompareMatrices(math::ExtractGradient(tri_n_W), zeros, 10 * kEps));
+          CompareMatrices(math::ExtractGradient(tri_n_W), zeros, 16 * kEps));
     }
   };
 


### PR DESCRIPTION
On Mac Ventura Arm, this comparison was [slightly beyond tolerance](https://drake-cdash.csail.mit.edu/test/1051759841).  Towards #18327.

+@SeanCurtis-TRI for both reviews (as original author), please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19399)
<!-- Reviewable:end -->
