### PR TITLE
[multibody] Bump tolerance for free_body_test

### DIFF
--- a/multibody/benchmarks/free_body/test/multibody_plant_free_body_test.cc
+++ b/multibody/benchmarks/free_body/test/multibody_plant_free_body_test.cc
@@ -442,7 +442,7 @@ void TestKaneExactSolution(FreeBody torque_free_cylinder_kane,
 
   // Ensure Kane's quaternion time-derivative matches expected angular velocity.
   EXPECT_TRUE(math::IsQuaternionAndQuaternionDtEqualAngularVelocityExpressedInB(
-    quat_kane, quatDt_kane, w_expected, 8 * kEpsilon));
+    quat_kane, quatDt_kane, w_expected, 12 * kEpsilon));
 
   // Ensure expected quaternion time-derivative matches Kane's angular velocity.
   EXPECT_TRUE(math::IsQuaternionAndQuaternionDtEqualAngularVelocityExpressedInB(


### PR DESCRIPTION
On Mac Ventura Arm, this comparison was [slightly beyond tolerance](https://drake-cdash.csail.mit.edu/test/1051762247).  Towards #18327.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19400)
<!-- Reviewable:end -->
