### PR TITLE
Introduce new SapConstraint APIs implemented in terms of older APIs.

### DIFF
--- a/multibody/contact_solvers/sap/BUILD.bazel
+++ b/multibody/contact_solvers/sap/BUILD.bazel
@@ -55,6 +55,8 @@ drake_cc_library(
     deps = [
         "//common:default_scalars",
         "//common:essential",
+        "//common:unused",
+        "//common:value",
         "//multibody/contact_solvers:matrix_block",
     ],
 )
@@ -182,6 +184,7 @@ drake_cc_googletest(
         ":sap_constraint_bundle",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+        "//math:gradient",
         "//multibody/contact_solvers:block_sparse_matrix",
     ],
 )

--- a/multibody/contact_solvers/sap/sap_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_constraint.cc
@@ -40,6 +40,88 @@ SapConstraint<T>::SapConstraint(int first_clique, int second_clique,
                      first_clique_jacobian().rows());
 }
 
+template <typename T>
+std::unique_ptr<AbstractValue> SapConstraint<T>::MakeData(
+    const T& time_step,
+    const Eigen::Ref<const VectorX<T>>& delassus_estimation) const {
+  DRAKE_DEMAND(delassus_estimation.size() == num_constraint_equations());
+  return DoMakeData(time_step, delassus_estimation);
+}
+
+template <typename T>
+void SapConstraint<T>::CalcData(const Eigen::Ref<const VectorX<T>>& vc,
+                                AbstractValue* data) const {
+  DRAKE_DEMAND(vc.size() == num_constraint_equations());
+  DRAKE_DEMAND(data != nullptr);
+  DoCalcData(vc, data);
+}
+
+template <typename T>
+T SapConstraint<T>::CalcCost(const AbstractValue& data) const {
+  return DoCalcCost(data);
+}
+
+template <typename T>
+void SapConstraint<T>::CalcImpulse(const AbstractValue& data,
+                                   EigenPtr<VectorX<T>> gamma) const {
+  DRAKE_DEMAND(gamma != nullptr);
+  DoCalcImpulse(data, gamma);
+}
+
+template <typename T>
+void SapConstraint<T>::CalcCostHessian(const AbstractValue& data,
+                                       MatrixX<T>* G) const {
+  DRAKE_DEMAND(G != nullptr);
+  DoCalcCostHessian(data, G);
+}
+
+template <typename T>
+std::unique_ptr<AbstractValue> SapConstraint<T>::DoMakeData(
+    const T& time_step,
+    const Eigen::Ref<const VectorX<T>>& delassus_estimation) const {
+  // TODO(amcastro-tri): make use of the full Delassus estimation, not just the
+  // mean.
+  const T wi = delassus_estimation.sum() / delassus_estimation.size();
+  VectorX<T> v_hat = CalcBiasTerm(time_step, wi);
+  VectorX<T> R = CalcDiagonalRegularization(time_step, wi);
+  SapConstraintData<T> data(std::move(R), std::move(v_hat));
+  return AbstractValue::Make(data);
+}
+
+template <typename T>
+void SapConstraint<T>::DoCalcData(const Eigen::Ref<const VectorX<T>>& vc,
+                                  AbstractValue* abstract_data) const {
+  auto& data = abstract_data->get_mutable_value<SapConstraintData<T>>();
+  const VectorX<T>& R_inv = data.R_inv();
+  const VectorX<T>& v_hat = data.v_hat();
+  data.mutable_vc() = vc;
+  data.mutable_y() = R_inv.asDiagonal() * (v_hat - vc);
+  Project(data.y(), data.R(), &data.mutable_gamma(), &data.mutable_dPdy());
+}
+
+template <typename T>
+T SapConstraint<T>::DoCalcCost(const AbstractValue& abstract_data) const {
+  const auto& data = abstract_data.get_value<SapConstraintData<T>>();
+  const VectorX<T>& R = data.R();
+  const VectorX<T>& gamma = data.gamma();
+  const T cost = 0.5 * gamma.dot(R.asDiagonal() * gamma);
+  return cost;
+}
+
+template <typename T>
+void SapConstraint<T>::DoCalcImpulse(const AbstractValue& abstract_data,
+                                     EigenPtr<VectorX<T>> gamma) const {
+  const auto& data = abstract_data.get_value<SapConstraintData<T>>();
+  *gamma = data.gamma();
+}
+
+template <typename T>
+void SapConstraint<T>::DoCalcCostHessian(const AbstractValue& abstract_data,
+                                         MatrixX<T>* G) const {
+  const auto& data = abstract_data.get_value<SapConstraintData<T>>();
+  *G = data.dPdy() * data.R_inv().asDiagonal();
+}
+
 }  // namespace internal
 }  // namespace contact_solvers
 }  // namespace multibody

--- a/multibody/contact_solvers/sap/sap_constraint.h
+++ b/multibody/contact_solvers/sap/sap_constraint.h
@@ -5,12 +5,77 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/unused.h"
+#include "drake/common/value.h"
 #include "drake/multibody/contact_solvers/matrix_block.h"
 
 namespace drake {
 namespace multibody {
 namespace contact_solvers {
 namespace internal {
+
+// TODO(amcastro-tri): SapConstraintData is only temporary to aid the migration
+// towards #19392 and it will soon be removed.
+/* Class to store data needed for SapConstraint computations. */
+template <typename T>
+class SapConstraintData {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SapConstraintData);
+
+  /* Constructs data for a SapLimitConstraint.
+     @param R Regularization parameters.
+     @param v_hat Bias term.
+     @warning Data stored is left uninitialized to avoid the cost of an
+     unnecessary initialization. */
+  SapConstraintData(VectorX<T> R, VectorX<T> v_hat) {
+    const int nk = R.size();
+    parameters_.R.resize(nk);
+    parameters_.R_inv.resize(nk);
+    parameters_.v_hat.resize(nk);
+    parameters_.R = R;
+    parameters_.R_inv = R.cwiseInverse();
+    parameters_.v_hat = v_hat;
+    vc_.resize(nk);
+    y_.resize(nk);
+    gamma_.resize(nk);
+    dPdy_.resize(nk, nk);
+  }
+
+  /* Regularization R. */
+  const VectorX<T>& R() const { return parameters_.R; }
+
+  /* Inverse of the regularization, R⁻¹. */
+  const VectorX<T>& R_inv() const { return parameters_.R_inv; }
+
+  /* Constraint bias. */
+  const VectorX<T>& v_hat() const { return parameters_.v_hat; }
+
+  /* Const access. */
+  const VectorX<T>& vc() const { return vc_; }
+  const VectorX<T>& y() const { return y_; }
+  const VectorX<T>& gamma() const { return gamma_; }
+  const MatrixX<T>& dPdy() const { return dPdy_; }
+
+  /* Mutable access. */
+  VectorX<T>& mutable_vc() { return vc_; }
+  VectorX<T>& mutable_y() { return y_; }
+  VectorX<T>& mutable_gamma() { return gamma_; }
+  MatrixX<T>& mutable_dPdy() { return dPdy_; }
+
+ private:
+  // This struct stores parameters that remain const after construction.
+  struct ConstParameters {
+    VectorX<T> R;      // Regularization R.
+    VectorX<T> R_inv;  // Inverse of regularization R.
+    VectorX<T> v_hat;  // Constraint velocity bias.
+  };
+  ConstParameters parameters_;
+
+  VectorX<T> vc_;
+  VectorX<T> y_;      // Un-projected impulse y = −R⁻¹⋅(vc−v̂)
+  VectorX<T> gamma_;  // Impulse.
+  MatrixX<T> dPdy_;   // Gradient of the projection γ = P(y) w.r.t. y.
+};
 
 /* This class serves to represent constraints supported by the SapSolver as
 described in [Castro et al., 2021].
@@ -61,6 +126,15 @@ two cliques, see issue #16575.
 template <typename T>
 class SapConstraint {
  public:
+  /* We do not allow copy, move, or assignment generally to avoid slicing.
+    Protected copy construction is enabled for sub-classes to use in their
+    implementation of DoClone(). */
+  //@{
+  SapConstraint& operator=(const SapConstraint&) = delete;
+  SapConstraint(SapConstraint&&) = delete;
+  SapConstraint& operator=(SapConstraint&&) = delete;
+  //@}
+
   /* Constructor for a constraint among DOFs within a single `clique`.
    @param[in] clique
      Index of a clique in the SapContactProblem where this constraint will be
@@ -160,6 +234,85 @@ class SapConstraint {
     return second_clique_jacobian_;
   }
 
+  /* Makes data used by this constraint to perform computations. Different
+   constraints can opt to use `time_step` and a diagonal approximation of the
+   Delassus operator in `delassus_estimation` to pre-compute scale quantities to
+   condition the problem better.
+   N.B. Specific constraints can choose to ignore `time_step` and
+   `delassus_estimation` making a new data that does not depend on either of
+   them. Refer to the documentation for specific constraint types.
+   @pre delassus_estimation.size() equals num_constraint_equations(). */
+  std::unique_ptr<AbstractValue> MakeData(
+      const T& time_step,
+      const Eigen::Ref<const VectorX<T>>& delassus_estimation) const;
+
+  /* Computes constraint data as a function of constraint velocities `vc`.
+   This method can be as simple as a copy of `vc` into `data`, though specific
+   constraints might want to compute commonly occurring terms in the computation
+   of the cost, impulses and Hessian into `data` to be reused.
+   @pre vc.size() equals num_constraint_equations().
+   @pre data does not equal nullptr. */
+  void CalcData(const Eigen::Ref<const VectorX<T>>& vc,
+                AbstractValue* data) const;
+
+  /* Computes the constraint cost ℓ(vc) function of constraint velocities vc.
+   @post The cost ℓ(vc) is a convex function of vc, as required by the SAP
+   formulation. */
+  T CalcCost(const AbstractValue& data) const;
+
+  /* Computes the impulse according to:
+       γ(vc) = −∂ℓ/∂vc.
+   @pre gamma does not equal nullptr. */
+  void CalcImpulse(const AbstractValue& data, EigenPtr<VectorX<T>> gamma) const;
+
+  /* Computes the constraint Hessian as:
+       G(vc) = ∂²ℓ/∂vc² = -∂γ/∂vc.
+   @post The constraint Hessian G(vc) is
+   symmetric positive semi-definite, since ℓ(vc) is a convex function of vc as
+   required by the SAP formulation.
+   @pre G does not equal nullptr. */
+  void CalcCostHessian(const AbstractValue& data, MatrixX<T>* G) const;
+
+  /* Polymorphic deep-copy into a new instance. */
+  std::unique_ptr<SapConstraint<T>> Clone() const { return DoClone(); }
+
+ protected:
+  /* Protected copy construction is enabled for sub-classes to use in their
+   implementation of DoClone(). */
+  SapConstraint(const SapConstraint&) = default;
+
+  // @group NVI implementations. Specific constraints must implement these
+  // methods. Refer to the specific NVI documentation for details.
+  // Proper argument sizes and valid non-null pointers are already guaranteed by
+  // checks in the correspondng NVIs.
+  // TODO(amcastro-tri): Make these pure virtual per #19392.
+  // @{
+  virtual std::unique_ptr<AbstractValue> DoMakeData(
+      const T& time_step,
+      const Eigen::Ref<const VectorX<T>>& delassus_estimation) const;
+  virtual void DoCalcData(const Eigen::Ref<const VectorX<T>>& vc,
+                          AbstractValue* data) const;
+  virtual T DoCalcCost(const AbstractValue& data) const;
+  virtual void DoCalcImpulse(const AbstractValue& data,
+                             EigenPtr<VectorX<T>> gamma) const;
+  virtual void DoCalcCostHessian(const AbstractValue& data,
+                                 MatrixX<T>* G) const;
+
+  /* Clone() implementation. Derived classes must override to provide
+   polymorphic deep-copy into a new instance. */
+  virtual std::unique_ptr<SapConstraint<T>> DoClone() const = 0;
+
+  // @}
+
+  // TODO(amcastro-tri): Remove this group of methods below per #19392.
+  // N.B. To aid migration towards #19392, the default implementations all
+  // abort. This will guarantee that all current (and future) derived classes
+  // have overridden these methods; failure to do so would lead to a program
+  // abort. This allows older implementations in terms of these methods to
+  // coexist with newly migrated constraints that implement the new DoCalcFoo()
+  // APIs. Once the migration is complete, these virtual APIs will be removed
+  // and the DoCalcFoo() APIs will be made pure virtual.
+
   /* Computes the projection γ = P(y) onto the convex set specific to a
    constraint in the norm defined by the diagonal positive matrix R, i.e. the
    norm ‖x‖ = sqrt(xᵀ⋅R⋅x). Refer to [Castro et al., 2021] for details.
@@ -174,7 +327,13 @@ class SapConstraint {
   virtual void Project(const Eigen::Ref<const VectorX<T>>& y,
                        const Eigen::Ref<const VectorX<T>>& R,
                        EigenPtr<VectorX<T>> gamma,
-                       MatrixX<T>* dPdy = nullptr) const = 0;
+                       MatrixX<T>* dPdy = nullptr) const {
+    unused(y);
+    unused(R);
+    unused(gamma);
+    unused(dPdy);
+    DRAKE_UNREACHABLE();
+  }
 
   /* Computes the bias term v̂ used to compute the constraint impulses before
    projection y = −R⁻¹⋅(vc − v̂).
@@ -187,7 +346,11 @@ class SapConstraint {
    Thus far we are assuming the same scalar factor can be used for all
    constraint equations effectively.
    TODO(amcastro-tri): Consider making wi a vector quantity. */
-  virtual VectorX<T> CalcBiasTerm(const T& time_step, const T& wi) const = 0;
+  virtual VectorX<T> CalcBiasTerm(const T& time_step, const T& wi) const {
+    unused(time_step);
+    unused(wi);
+    DRAKE_UNREACHABLE();
+  }
 
   /* Computes the regularization R used to compute the constraint impulses
    before projection as y = −R⁻¹⋅(vc − v̂).
@@ -201,14 +364,11 @@ class SapConstraint {
    constraint equations effectively.
    TODO(amcastro-tri): Consider making wi a vector quantity. */
   virtual VectorX<T> CalcDiagonalRegularization(const T& time_step,
-                                                const T& wi) const = 0;
-
-  /* Derived classes must override to provide polymorphic deep-copy into a new
-   instance. */
-  virtual std::unique_ptr<SapConstraint<T>> Clone() const = 0;
-
- protected:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SapConstraint);
+                                                const T& wi) const {
+    unused(time_step);
+    unused(wi);
+    DRAKE_UNREACHABLE();
+  }
 
  private:
   int first_clique_{-1};

--- a/multibody/contact_solvers/sap/sap_friction_cone_constraint.h
+++ b/multibody/contact_solvers/sap/sap_friction_cone_constraint.h
@@ -3,7 +3,6 @@
 #include <memory>
 #include <utility>
 
-#include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/contact_solvers/sap/sap_constraint.h"
 
@@ -65,7 +64,15 @@ namespace internal {
 template <typename T>
 class SapFrictionConeConstraint final : public SapConstraint<T> {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SapFrictionConeConstraint);
+  /* We do not allow copy, move, or assignment generally to avoid slicing.
+    Protected copy construction is enabled for sub-classes to use in their
+    implementation of DoClone(). */
+  //@{
+  SapFrictionConeConstraint& operator=(const SapFrictionConeConstraint&) =
+      delete;
+  SapFrictionConeConstraint(SapFrictionConeConstraint&&) = delete;
+  SapFrictionConeConstraint& operator=(SapFrictionConeConstraint&&) = delete;
+  //@}
 
   /* Numerical parameters that define the constraint. Refer to this class's
    documentation for details. */
@@ -152,11 +159,16 @@ class SapFrictionConeConstraint final : public SapConstraint<T> {
   VectorX<T> CalcDiagonalRegularization(const T& time_step,
                                         const T& wi) const final;
 
-  std::unique_ptr<SapConstraint<T>> Clone() const final {
-    return std::make_unique<SapFrictionConeConstraint<T>>(*this);
+ private:
+  /* Private copy construction is enabled to use in the implementation of
+   DoClone(). */
+  SapFrictionConeConstraint(const SapFrictionConeConstraint&) = default;
+
+  std::unique_ptr<SapConstraint<T>> DoClone() const final {
+    return std::unique_ptr<SapFrictionConeConstraint<T>>(
+        new SapFrictionConeConstraint<T>(*this));
   }
 
- private:
   Parameters parameters_;
   T phi0_;
 };

--- a/multibody/contact_solvers/sap/sap_holonomic_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_holonomic_constraint.cc
@@ -151,11 +151,6 @@ void SapHolonomicConstraint<T>::Project(const Eigen::Ref<const VectorX<T>>& y,
   }
 }
 
-template <typename T>
-std::unique_ptr<SapConstraint<T>> SapHolonomicConstraint<T>::Clone() const {
-  return std::make_unique<SapHolonomicConstraint<T>>(*this);
-}
-
 }  // namespace internal
 }  // namespace contact_solvers
 }  // namespace multibody

--- a/multibody/contact_solvers/sap/sap_holonomic_constraint.h
+++ b/multibody/contact_solvers/sap/sap_holonomic_constraint.h
@@ -3,7 +3,6 @@
 #include <memory>
 #include <utility>
 
-#include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/contact_solvers/sap/sap_constraint.h"
 
@@ -65,7 +64,14 @@ namespace internal {
 template <typename T>
 class SapHolonomicConstraint final : public SapConstraint<T> {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SapHolonomicConstraint);
+  /* We do not allow copy, move, or assignment generally to avoid slicing.
+    Protected copy construction is enabled for sub-classes to use in their
+    implementation of DoClone(). */
+  //@{
+  SapHolonomicConstraint& operator=(const SapHolonomicConstraint&) = delete;
+  SapHolonomicConstraint(SapHolonomicConstraint&&) = delete;
+  SapHolonomicConstraint& operator=(SapHolonomicConstraint&&) = delete;
+  //@}
 
   /* Numerical parameters that define the constraint. Refer to this class's
    documentation for details. */
@@ -204,9 +210,16 @@ class SapHolonomicConstraint final : public SapConstraint<T> {
   VectorX<T> CalcDiagonalRegularization(const T& time_step,
                                         const T& wi) const final;
 
-  std::unique_ptr<SapConstraint<T>> Clone() const final;
-
  private:
+  /* Private copy construction is enabled to use in the implementation of
+   DoClone(). */
+  SapHolonomicConstraint(const SapHolonomicConstraint&) = default;
+
+  std::unique_ptr<SapConstraint<T>> DoClone() const final {
+    return std::unique_ptr<SapHolonomicConstraint<T>>(
+        new SapHolonomicConstraint<T>(*this));
+  }
+
   Parameters parameters_;
   VectorX<T> bias_;
 };

--- a/multibody/contact_solvers/sap/sap_limit_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_limit_constraint.cc
@@ -99,11 +99,6 @@ void SapLimitConstraint<T>::Project(const Eigen::Ref<const VectorX<T>>& y,
 }
 
 template <typename T>
-std::unique_ptr<SapConstraint<T>> SapLimitConstraint<T>::Clone() const {
-  return std::make_unique<SapLimitConstraint<T>>(*this);
-}
-
-template <typename T>
 VectorX<T> SapLimitConstraint<T>::CalcConstraintFunction(const T& q0,
                                                          const T& ql,
                                                          const T& qu) {

--- a/multibody/contact_solvers/sap/sap_limit_constraint.h
+++ b/multibody/contact_solvers/sap/sap_limit_constraint.h
@@ -3,7 +3,6 @@
 #include <limits>
 #include <memory>
 
-#include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/contact_solvers/sap/sap_constraint.h"
 
@@ -67,7 +66,14 @@ namespace internal {
 template <typename T>
 class SapLimitConstraint final : public SapConstraint<T> {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SapLimitConstraint);
+  /* We do not allow copy, move, or assignment generally to avoid slicing.
+    Protected copy construction is enabled for sub-classes to use in their
+    implementation of DoClone(). */
+  //@{
+  SapLimitConstraint& operator=(const SapLimitConstraint&) = delete;
+  SapLimitConstraint(SapLimitConstraint&&) = delete;
+  SapLimitConstraint& operator=(SapLimitConstraint&&) = delete;
+  //@}
 
   /* Numerical parameters that define the constraint. Refer to this class's
    documentation for details. */
@@ -145,8 +151,6 @@ class SapLimitConstraint final : public SapConstraint<T> {
   VectorX<T> CalcDiagonalRegularization(const T& time_step,
                                         const T& wi) const final;
 
-  std::unique_ptr<SapConstraint<T>> Clone() const final;
-
  private:
   /* Computes the constraint function g(q0) as a function of q0 for given lower
    limit ql and upper limit qu.
@@ -159,6 +163,15 @@ class SapLimitConstraint final : public SapConstraint<T> {
    constraint. */
   static MatrixX<T> CalcConstraintJacobian(int clique_dof, int clique_nv,
                                            const T& ql, const T& qu);
+
+  /* Private copy construction is enabled to use in the implementation of
+   DoClone(). */
+  SapLimitConstraint(const SapLimitConstraint&) = default;
+
+  std::unique_ptr<SapConstraint<T>> DoClone() const final {
+    return std::unique_ptr<SapLimitConstraint<T>>(
+        new SapLimitConstraint<T>(*this));
+  }
 
   Parameters parameters_;
   int clique_dof_{-1};  // Initialized to an invalid value.

--- a/multibody/contact_solvers/sap/sap_solver.cc
+++ b/multibody/contact_solvers/sap/sap_solver.cc
@@ -257,7 +257,6 @@ T SapSolver<T>::CalcCostAlongLine(
   if (d2ell_dalpha2 != nullptr) DRAKE_DEMAND(d2ell_dalpha2_scratch != nullptr);
 
   // Data.
-  const VectorX<T>& R = model_->constraints_bundle().R();
   const VectorX<T>& v_star = model_->v_star();
 
   // Search direction quantities at state v.
@@ -284,7 +283,7 @@ T SapSolver<T>::CalcCostAlongLine(
   const VectorX<T>& gamma = model_->EvalImpulses(context_alpha);
 
   // Regularizer cost.
-  const T ellR = 0.5 * gamma.dot(R.asDiagonal() * gamma);
+  const T ellR = model_->EvalConstraintsCost(context_alpha);
 
   // Momentum cost. We use the O(n) strategy described in [Castro et al., 2021].
   // The momentum cost is: ellA(α) = 0.5‖v(α)−v*‖², where ‖⋅‖ is the norm

--- a/multibody/contact_solvers/sap/test/sap_constraint_bundle_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_constraint_bundle_test.cc
@@ -4,8 +4,10 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/autodiff.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/multibody/contact_solvers/sap/contact_problem_graph.h"
 #include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
 
@@ -37,58 +39,60 @@ MatrixXd MakeJacobian(int rows, int cols) {
 // is clique + 1. We use this constraint to test that the constraint bundle
 // properly composes projections.
 // The constraint has a single numeric parameter `param` to define an arbitrary
-// projection function within Project() as gamma = param * R * y.
-class TestConstraint final : public SapConstraint<double> {
+// projection function such that gamma = -param * vc.
+template <typename T>
+class TestConstraint final : public SapConstraint<T> {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(TestConstraint);
-
-  TestConstraint(int clique, int size, double param)
-      : SapConstraint<double>(clique, VectorXd::Zero(size),
-                              MakeJacobian(size, clique + 1)),
+  TestConstraint(int clique, int size, T param)
+      : SapConstraint<T>(clique, VectorX<T>::Zero(size),
+                         MakeJacobian(size, clique + 1)),
         param_(param) {}
 
-  TestConstraint(int clique0, int clique1, int size, double param)
-      : SapConstraint<double>(clique0, clique1, VectorXd::Zero(size),
-                              MakeJacobian(size, clique0 + 1),
-                              MakeJacobian(size, clique1 + 1)),
+  TestConstraint(int clique0, int clique1, int size, T param)
+      : SapConstraint<T>(clique0, clique1, VectorX<T>::Zero(size),
+                         MakeJacobian(size, clique0 + 1),
+                         MakeJacobian(size, clique1 + 1)),
         param_(param) {}
 
   // Implements a fake projection operation where the result is given by:
-  //   gamma = param * R * y, and
-  //   dPdy = param * R
+  //   cost = 0.5 * param * ||vc||^2
+  //   gamma = -param * vc, and
+  //   G = param * Id
   // This is only meant to verify input and output arguments are properly
   // sliced by Constraintbundle.
-  void Project(const Eigen::Ref<const VectorX<double>>& y,
-               const Eigen::Ref<const VectorX<double>>& R,
-               EigenPtr<VectorX<double>> gamma,
-               MatrixX<double>* dPdy) const final {
-    *gamma = param_ * (R.asDiagonal() * y);
-    if (dPdy != nullptr) {
-      *dPdy = param_ * R.asDiagonal();
-    }
-  };
-
-  // Implements a non-zero bias term with arbitrary non-zero values.
-  // More precisely vhat = -2.0 * [1, num_constraint_equations()].
-  VectorX<double> CalcBiasTerm(const double&, const double&) const final {
-    return -2.0 * VectorX<double>::LinSpaced(num_constraint_equations(), 1.0,
-                                             num_constraint_equations());
+  std::unique_ptr<AbstractValue> DoMakeData(
+      const T& time_step,
+      const Eigen::Ref<const VectorX<T>>& delassus_estimation) const final {
+    // Data to store constraint velocities vc only.
+    return AbstractValue::Make(VectorX<T>(this->num_constraint_equations()));
   }
-
-  // Implements regularization with arbitrary non-zero values.
-  // More precisely, R = [1, num_constraint_equations()].
-  VectorX<double> CalcDiagonalRegularization(const double& time_step,
-                                             const double& wi) const final {
-    return VectorX<double>::LinSpaced(num_constraint_equations(), 1.0,
-                                      num_constraint_equations());
+  void DoCalcData(const Eigen::Ref<const VectorX<T>>& vc,
+                  AbstractValue* data) const final {
+    data->get_mutable_value<VectorX<T>>() = vc;
   }
-
-  std::unique_ptr<SapConstraint<double>> Clone() const final {
-    return std::make_unique<TestConstraint>(*this);
+  T DoCalcCost(const AbstractValue& data) const final {
+    const VectorX<T> vc = data.get_value<VectorX<T>>();
+    return 0.5 * param_ * vc.squaredNorm();
+  }
+  void DoCalcImpulse(const AbstractValue& data,
+                     EigenPtr<VectorX<T>> gamma) const final {
+    const VectorX<T> vc = data.get_value<VectorX<T>>();
+    *gamma = -param_ * vc;
+  }
+  void DoCalcCostHessian(const AbstractValue& data, MatrixX<T>* G) const final {
+    const VectorX<T> vc = data.get_value<VectorX<T>>();
+    const int nk = vc.size();
+    *G = param_ * MatrixX<T>::Identity(nk, nk);
   }
 
  private:
-  double param_{0.0};
+  TestConstraint(const TestConstraint&) = default;
+
+  std::unique_ptr<SapConstraint<T>> DoClone() const final {
+    return std::unique_ptr<TestConstraint<T>>(new TestConstraint<T>(*this));
+  }
+
+  T param_{0.0};
 };
 
 namespace {
@@ -100,33 +104,41 @@ class SapConstraintBundleTest : public ::testing::Test {
  public:
   void SetUp() override {
     const double time_step = 1.0e-3;
-    std::vector<MatrixXd> A = {MatrixXd::Ones(1, 1), MatrixXd::Ones(2, 2),
-                               MatrixXd::Ones(3, 3)};
-    VectorXd v_star = VectorXd::LinSpaced(6, 1., 6.);
-    problem_ = std::make_unique<SapContactProblem<double>>(
+    std::vector<MatrixX<AutoDiffXd>> A = {MatrixX<AutoDiffXd>::Ones(1, 1),
+                                          MatrixX<AutoDiffXd>::Ones(2, 2),
+                                          MatrixX<AutoDiffXd>::Ones(3, 3)};
+    VectorX<AutoDiffXd> v_star = VectorX<AutoDiffXd>::LinSpaced(6, 1., 6.);
+    problem_ = std::make_unique<SapContactProblem<AutoDiffXd>>(
         time_step, std::move(A), std::move(v_star));
     // First cluster of constraints between cliques 0 and 2.
-    problem_->AddConstraint(std::make_unique<TestConstraint>(0, 2, 1, 1.0));
-    problem_->AddConstraint(std::make_unique<TestConstraint>(2, 0, 2, 2.0));
+    problem_->AddConstraint(
+        std::make_unique<TestConstraint<AutoDiffXd>>(0, 2, 1, 1.0));
+    problem_->AddConstraint(
+        std::make_unique<TestConstraint<AutoDiffXd>>(2, 0, 2, 2.0));
     // A second cluster of constraints between cliques 0 and 1.
-    problem_->AddConstraint(std::make_unique<TestConstraint>(0, 1, 3, 3.0));
-    problem_->AddConstraint(std::make_unique<TestConstraint>(0, 1, 2, 4.0));
-    problem_->AddConstraint(std::make_unique<TestConstraint>(0, 1, 3, 5.0));
+    problem_->AddConstraint(
+        std::make_unique<TestConstraint<AutoDiffXd>>(0, 1, 3, 3.0));
+    problem_->AddConstraint(
+        std::make_unique<TestConstraint<AutoDiffXd>>(0, 1, 2, 4.0));
+    problem_->AddConstraint(
+        std::make_unique<TestConstraint<AutoDiffXd>>(0, 1, 3, 5.0));
     // A third cluster only involving clique 1.
-    problem_->AddConstraint(std::make_unique<TestConstraint>(1, 4, 6.0));
-    problem_->AddConstraint(std::make_unique<TestConstraint>(1, 2, 7.0));
+    problem_->AddConstraint(
+        std::make_unique<TestConstraint<AutoDiffXd>>(1, 4, 6.0));
+    problem_->AddConstraint(
+        std::make_unique<TestConstraint<AutoDiffXd>>(1, 2, 7.0));
 
-    delassus_diagonal_.resize(7);
-    delassus_diagonal_ = VectorXd::LinSpaced(7, 1., 7.0);
+    delassus_diagonal_.resize(17);
+    delassus_diagonal_ = VectorX<AutoDiffXd>::LinSpaced(17, 1., 7.0);
 
-    bundle_ = std::make_unique<SapConstraintBundle<double>>(problem_.get(),
-                                                            delassus_diagonal_);
+    bundle_ = std::make_unique<SapConstraintBundle<AutoDiffXd>>(
+        problem_.get(), delassus_diagonal_);
   }
 
  protected:
-  std::unique_ptr<SapContactProblem<double>> problem_;
-  VectorXd delassus_diagonal_;
-  std::unique_ptr<SapConstraintBundle<double>> bundle_;
+  std::unique_ptr<SapContactProblem<AutoDiffXd>> problem_;
+  VectorX<AutoDiffXd> delassus_diagonal_;
+  std::unique_ptr<SapConstraintBundle<AutoDiffXd>> bundle_;
 };
 
 TEST_F(SapConstraintBundleTest, VerifyJacobian) {
@@ -138,27 +150,27 @@ TEST_F(SapConstraintBundleTest, VerifyJacobian) {
 
   // Build the expected block sparse Jacobian.
   const PartialPermutation& p = problem_->graph().participating_cliques();
-  BlockSparseMatrixBuilder<double> builder(3, 3, 5);
+  BlockSparseMatrixBuilder<AutoDiffXd> builder(3, 3, 5);
   // Cluster of constraints between cliques 0 and 2.
-  MatrixXd J_cluster0_clique0(3, 1);
+  MatrixX<AutoDiffXd> J_cluster0_clique0(3, 1);
   J_cluster0_clique0
       << problem_->get_constraint(0).first_clique_jacobian().MakeDenseMatrix(),
       problem_->get_constraint(1).second_clique_jacobian().MakeDenseMatrix();
   builder.PushBlock(0, p.permuted_index(0), J_cluster0_clique0);
-  MatrixXd J_cluster0_clique2(3, 3);
+  MatrixX<AutoDiffXd> J_cluster0_clique2(3, 3);
   J_cluster0_clique2
       << problem_->get_constraint(0).second_clique_jacobian().MakeDenseMatrix(),
       problem_->get_constraint(1).first_clique_jacobian().MakeDenseMatrix();
   builder.PushBlock(0, p.permuted_index(2), J_cluster0_clique2);
 
   // Cluster of constraints between cliques 0 and 1.
-  MatrixXd J_cluster1_clique0(8, 1);
+  MatrixX<AutoDiffXd> J_cluster1_clique0(8, 1);
   J_cluster1_clique0
       << problem_->get_constraint(2).first_clique_jacobian().MakeDenseMatrix(),
       problem_->get_constraint(3).first_clique_jacobian().MakeDenseMatrix(),
       problem_->get_constraint(4).first_clique_jacobian().MakeDenseMatrix();
   builder.PushBlock(1, p.permuted_index(0), J_cluster1_clique0);
-  MatrixXd J_cluster1_clique1(8, 2);
+  MatrixX<AutoDiffXd> J_cluster1_clique1(8, 2);
   J_cluster1_clique1
       << problem_->get_constraint(2).second_clique_jacobian().MakeDenseMatrix(),
       problem_->get_constraint(3).second_clique_jacobian().MakeDenseMatrix(),
@@ -166,103 +178,51 @@ TEST_F(SapConstraintBundleTest, VerifyJacobian) {
   builder.PushBlock(1, p.permuted_index(1), J_cluster1_clique1);
 
   // Cluster with only clique1.
-  MatrixXd J_cluster2_clique1(6, 2);
+  MatrixX<AutoDiffXd> J_cluster2_clique1(6, 2);
   J_cluster2_clique1
       << problem_->get_constraint(5).first_clique_jacobian().MakeDenseMatrix(),
       problem_->get_constraint(6).first_clique_jacobian().MakeDenseMatrix();
   builder.PushBlock(2, p.permuted_index(1), J_cluster2_clique1);
 
-  BlockSparseMatrix<double> Jblock = builder.Build();
+  BlockSparseMatrix<AutoDiffXd> Jblock = builder.Build();
 
   EXPECT_EQ(bundle_->J().MakeDenseMatrix(), Jblock.MakeDenseMatrix());
 }
 
-// Verify CalcUnprojectedImpulses() produces y = −R⁻¹⋅(vc−v̂).
-TEST_F(SapConstraintBundleTest, CalcUnprojectedImpulses) {
-  const VectorXd& R = bundle_->R();
-  const VectorXd& vhat = bundle_->vhat();
-  const VectorXd vc =
-      VectorXd::LinSpaced(problem_->num_constraint_equations(), -1.0, 5.0);
-  VectorXd y(problem_->num_constraint_equations());
-  bundle_->CalcUnprojectedImpulses(vc, &y);
-  const VectorXd y_expected = R.cwiseInverse().asDiagonal() * (vhat - vc);
-  EXPECT_TRUE(CompareMatrices(y, y_expected));
-}
-
-TEST_F(SapConstraintBundleTest, ProjectImpulses) {
-  // Each constraint projects the corresponding segment yᵢ of y into the convex
-  // set Cᵢ defined by the constraint using the norm defined by the positive
-  // diagonal matrix Rᵢ. In this test we do not verify the projection function,
-  // but we only verify that the bundle correctly composes each projection
-  // function into the full projection P for the entire bundle.
-  // TestConstraint implements the test projection (not really a projection but
-  // not relevant for this test) gammaᵢ = paramᵢ * Rᵢ * yᵢ. At construction, we
-  // specified paramᵢ = i + 1.
-
-  // clang-format off
-  const VectorXd all_params = (VectorXd(problem_->num_constraint_equations()) <<
-    1.,              // constraint 0, param = 1., of size 1.
-    2., 2.,          // constraint 1, param = 2., of size 2.
-    3., 3., 3.,      // constraint 2, param = 3., of size 3.
-    4., 4.,          // constraint 3, param = 4., of size 2.
-    5., 5., 5.,      // constraint 4, param = 5., of size 3.
-    6., 6., 6., 6.,  // constraint 5, param = 6., of size 4.
-    7., 7.)          // constraint 6, param = 7., of size 2.
-  .finished();
-  // clang-format on
-
-  const auto& R = bundle_->R();
-  const VectorXd y =
-      VectorXd::LinSpaced(problem_->num_constraint_equations(), 1., 17.);
-  const VectorXd gamma_expected = all_params.array() * R.array() * y.array();
-
-  VectorXd gamma(problem_->num_constraint_equations());
-  std::vector<MatrixXd> dPdy(problem_->num_constraints());
-  bundle_->ProjectImpulses(y, &gamma, &dPdy);
-  EXPECT_TRUE(CompareMatrices(gamma, gamma_expected,
-                              std::numeric_limits<double>::epsilon(),
+TEST_F(SapConstraintBundleTest, VerifyGradients) {
+  const AutoDiffXd time_step = 0.02;
+  SapConstraintBundleData data =
+      bundle_->MakeData(time_step, delassus_diagonal_);
+  const VectorXd vc = VectorXd::LinSpaced(17, -1.0, 2.5);  // Arbitrary values.
+  const VectorX<AutoDiffXd> vc_ad = drake::math::InitializeAutoDiff(vc);
+  bundle_->CalcData(vc_ad, &data);
+  const AutoDiffXd cost = bundle_->CalcCost(data);
+  VectorX<AutoDiffXd> gamma(vc.size());
+  bundle_->CalcImpulses(data, &gamma);
+  const VectorXd minus_cost_gradient = -cost.derivatives();
+  EXPECT_TRUE(CompareMatrices(gamma, minus_cost_gradient,
+                              20 * std::numeric_limits<double>::epsilon(),
                               MatrixCompareType::relative));
 
-  // For this case we expect dPdyᵢ = paramᵢ * Rᵢ.
-  std::vector<MatrixXd> dPdy_expected;
+  // Extract Hessian computed by automatic differentiation of gamma.
+  MatrixXd Gdense = -math::ExtractGradient(gamma, gamma.size());
+  std::vector<MatrixXd> minus_gamma_gradient(problem_->num_constraints());
   int offset = 0;
-  const VectorXi constraint_size =
-      (VectorXi(problem_->num_constraints()) << 1, 2, 3, 2, 3, 4, 2).finished();
-  for (int i = 0; i < problem_->num_constraints(); ++i) {
-    const int size = constraint_size(i);
-    const double param = i + 1;
-    const MatrixXd dPdy_i = R.segment(offset, size).asDiagonal() * param;
-    offset += size;
-    dPdy_expected.push_back(dPdy_i);
+  for (int k = 0; k < problem_->num_constraints(); ++k) {
+    const auto& c = problem_->get_constraint(k);
+    const int nk = c.num_constraint_equations();
+    MatrixXd& Gk = minus_gamma_gradient[k];
+    Gk.resize(nk, nk);
+    Gk = Gdense.block(offset, offset, nk, nk);
+    offset += nk;
   }
 
-  for (int i = 0; i < bundle_->num_constraints(); ++i) {
-    EXPECT_TRUE(CompareMatrices(dPdy[i], dPdy_expected[i],
-                                std::numeric_limits<double>::epsilon(),
-                                MatrixCompareType::relative));
-  }
-
-  // Verify the computation of the Hessian. For this case we expect
-  // Gᵢ = paramᵢ * Iᵢ₊₁.
-  std::vector<MatrixXd> G(problem_->num_constraints());
-  bundle_->ProjectImpulsesAndCalcConstraintsHessian(y, &gamma, &G);
-  EXPECT_TRUE(CompareMatrices(gamma, gamma_expected,
-                              std::numeric_limits<double>::epsilon(),
-                              MatrixCompareType::relative));
-
-  // G = ∇²ℓ = d²ℓ/dvc² = dP/dy⋅R⁻¹
-  std::vector<MatrixXd> G_expected(problem_->num_constraints());
-  offset = 0;
-  for (int i = 0; i < problem_->num_constraints(); ++i) {
-    const int size = constraint_size(i);
-    const double param = i + 1;
-    G_expected[i].resize(size, size);
-    G_expected[i] = param * MatrixXd::Identity(size, size);
-    offset += size;
-  }
-  for (int i = 0; i < bundle_->num_constraints(); ++i) {
-    EXPECT_TRUE(CompareMatrices(G[i], G_expected[i],
-                                std::numeric_limits<double>::epsilon(),
+  std::vector<MatrixX<AutoDiffXd>> G(problem_->num_constraints());
+  bundle_->CalcImpulsesAndConstraintsHessian(data, &gamma, &G);
+  for (int k = 0; k < problem_->num_constraints(); ++k) {
+    const MatrixXd Gk = math::ExtractValue(G[k]);
+    EXPECT_TRUE(CompareMatrices(Gk, minus_gamma_gradient[k],
+                                20 * std::numeric_limits<double>::epsilon(),
                                 MatrixCompareType::relative));
   }
 }

--- a/multibody/contact_solvers/sap/test/sap_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_constraint_test.cc
@@ -31,8 +31,6 @@ const MatrixXd J34 =
 
 class TestConstraint final : public SapConstraint<double> {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(TestConstraint);
-
   // These constructor set up an arbitrary constraint for one and two cliques.
   TestConstraint(int clique, VectorXd g, MatrixXd J)
       : SapConstraint<double>(clique, std::move(g), std::move(J)) {}
@@ -55,8 +53,12 @@ class TestConstraint final : public SapConstraint<double> {
                                              const double&) const final {
     return Vector3d::Zero();
   }
-  std::unique_ptr<SapConstraint<double>> Clone() const final {
-    return std::make_unique<TestConstraint>(*this);
+
+ private:
+  TestConstraint(const TestConstraint&) = default;
+
+  std::unique_ptr<SapConstraint<double>> DoClone() const final {
+    return std::unique_ptr<TestConstraint>(new TestConstraint(*this));
   }
 };
 

--- a/multibody/contact_solvers/sap/test/sap_contact_problem_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_contact_problem_test.cc
@@ -36,8 +36,6 @@ const Eigen::Matrix4d S44 =
 // Only indexes and constraint sizes matter for the unit tests in this file.
 class TestConstraint final : public SapConstraint<double> {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(TestConstraint);
-
   // Constructor for a constraint on a single clique.
   TestConstraint(int num_constraint_equations, int clique, int clique_nv)
       : SapConstraint<double>(
@@ -65,8 +63,12 @@ class TestConstraint final : public SapConstraint<double> {
                                              const double&) const final {
     return VectorXd::Zero(this->num_constraint_equations());
   }
-  std::unique_ptr<SapConstraint<double>> Clone() const final {
-    return std::make_unique<TestConstraint>(*this);
+
+ private:
+  TestConstraint(const TestConstraint&) = default;
+
+  std::unique_ptr<SapConstraint<double>> DoClone() const final {
+    return std::unique_ptr<TestConstraint>(new TestConstraint(*this));
   }
 };
 

--- a/multibody/contact_solvers/sap/test/sap_model_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_model_test.cc
@@ -34,7 +34,7 @@ namespace {
 
 // With SAP we can model implicit springs using constraints. For these
 // constraint the projection is the identity, i.e. γ = P(y) = y.
-// For testing purposes, this is a simple constraints that models a spring
+// For testing purposes, this is a simple constraint that models a spring
 // between a particle mass and the origin. The spring has stiffness k and
 // damping d = tau_d * k, where tau_d is the dissipation time scale. That is,
 // the force applied by this constraint on the mass is γ/δt = −k⋅x − d⋅v, where
@@ -42,42 +42,65 @@ namespace {
 template <typename T>
 class SpringConstraint final : public SapConstraint<T> {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SpringConstraint);
+  struct Data {
+    Vector3<T> vc;
+    T R;
+    Vector3<T> v_hat;
+  };
 
   // Model a spring attached to `clique`, expected to be a 3D particle.
-  explicit SpringConstraint(int clique, Vector3<T> x, T k, T tau_d)
+  SpringConstraint(int clique, Vector3<T> x0, T k, T tau_d)
       // N.B. For this constraint the Jacobian is the identity matrix.
-      : SapConstraint<T>(clique, std::move(x), Matrix3<T>::Identity()),
+      : SapConstraint<T>(clique, std::move(x0), Matrix3<T>::Identity()),
         k_(k),
         tau_d_(tau_d) {}
 
-  // Bias and regularization setup so that:
-  //   γ = y = -δt⋅(k⋅x + d⋅v) = −R⁻¹⋅(v−v̂).
-  VectorX<T> CalcBiasTerm(const T& time_step, const T&) const final {
-    return -this->constraint_function() / (time_step + tau_d_);
-  }
-  VectorX<T> CalcDiagonalRegularization(const T& time_step,
-                                        const T&) const final {
-    const T R = 1. / (time_step * (time_step + tau_d_) * k_);
-    return Vector3<T>(R, R, R);
+  std::unique_ptr<AbstractValue> DoMakeData(
+      const T& time_step, const Eigen::Ref<const VectorX<T>>&) const final {
+    using std::max;
+    Data data;
+    // Bias and regularization setup so that:
+    //   γ = y = -δt⋅(k⋅x + d⋅v) = −R⁻¹⋅(v−v̂).
+    data.R = 1. / (time_step * (time_step + tau_d_) * k_);
+    data.v_hat = -this->constraint_function() / (time_step + tau_d_);
+    return AbstractValue::Make(data);
   }
 
-  // For this constraint the projection is the identity operation.
-  void Project(const Eigen::Ref<const VectorX<double>>& y,
-               const Eigen::Ref<const VectorX<double>>& R,
-               EigenPtr<VectorX<double>> gamma,
-               MatrixX<double>* dPdy) const final {
-    (*gamma) = y;
-    if (dPdy != nullptr) dPdy->setIdentity(3, 3);
-  };
+  void DoCalcData(const Eigen::Ref<const VectorX<T>>& vc,
+                  AbstractValue* data) const final {
+    data->get_mutable_value<Data>().vc = vc;
+  }
 
-  std::unique_ptr<SapConstraint<T>> Clone() const final {
-    return std::make_unique<SpringConstraint<T>>(*this);
+  T DoCalcCost(const AbstractValue& data) const final {
+    const Vector3<T>& vc = data.get_value<Data>().vc;
+    const Vector3<T>& v_hat = data.get_value<Data>().v_hat;
+    const T& R = data.get_value<Data>().R;
+    const T cost = 0.5 / R * (vc - v_hat).squaredNorm();
+    return cost;
+  }
+
+  void DoCalcImpulse(const AbstractValue& data,
+                     EigenPtr<VectorX<T>> gamma) const final {
+    const Vector3<T>& vc = data.get_value<Data>().vc;
+    const Vector3<T>& v_hat = data.get_value<Data>().v_hat;
+    const T& R = data.get_value<Data>().R;
+    *gamma = -(vc - v_hat) / R;
+  }
+
+  void DoCalcCostHessian(const AbstractValue& data, MatrixX<T>* G) const final {
+    const T& R = data.get_value<Data>().R;
+    *G = Matrix3<T>::Identity() / R;
   }
 
  private:
+  SpringConstraint(const SpringConstraint&) = default;
+
+  std::unique_ptr<SapConstraint<T>> DoClone() const override {
+    return std::unique_ptr<SpringConstraint<T>>(new SpringConstraint<T>(*this));
+  }
+
   T k_{0.0};      // Stiffness, in N/m.
-  T tau_d_{0.0};  // Dissipation time scale, in N⋅s/m.
+  T tau_d_{0.0};  // Dissipation time scale, in seconds.
 };
 
 // Sets up a simple problem for two 3D particles, six DOFs.
@@ -194,7 +217,8 @@ TEST_F(SpringMassTest, ProblemData) {
   // For this case, J = I₃ and M = m₁⋅I₃. Therefore W = J⋅M⁻¹⋅Jᵀ = I₃/m₁.
   // Then the diagonal approximation is ‖W‖ᵣₘₛ = ‖W‖/3 = (m₁√3)⁻¹.
   const VectorXd W_diag = SapModelTester::delassus_diagonal(*sap_model_);
-  const VectorXd W_diag_expected = Vector1d(1.0 / model_.mass1() / sqrt(3.0));
+  const VectorXd W_diag_expected =
+      Vector3d::Constant(1.0 / model_.mass1() / sqrt(3.0));
   EXPECT_TRUE(CompareMatrices(W_diag, W_diag_expected, kEpsilon,
                               MatrixCompareType::relative));
 }
@@ -232,8 +256,6 @@ TEST_F(SpringMassTest, EvalMomentumCost) {
 template <typename T>
 class DummyConstraint final : public SapConstraint<T> {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DummyConstraint);
-
   DummyConstraint(int clique, MatrixX<T> J, VectorX<T> R, VectorX<T> v_hat)
       // N.B. For this constraint the Jacobian is the identity matrix.
       : SapConstraint<T>(clique, VectorX<T>::Zero(R.size()), std::move(J)),
@@ -248,35 +270,37 @@ class DummyConstraint final : public SapConstraint<T> {
         R_(std::move(R)),
         v_hat_(std::move(v_hat)) {}
 
-  // Returns the bias v_hat provided at construction.
-  VectorX<T> CalcBiasTerm(const T&, const T&) const final { return v_hat_; }
-  // Returns the regularization R provided at construction.
-  VectorX<T> CalcDiagonalRegularization(const T&, const T&) const final {
-    return R_;
+  std::unique_ptr<AbstractValue> DoMakeData(
+      const T& time_step,
+      const Eigen::Ref<const VectorX<T>>& delassus_estimation) const final {
+    // Data to store constraint velocities vc only.
+    return AbstractValue::Make(VectorX<T>(this->num_constraint_equations()));
   }
-
-  // Dummy projection for testing. γ = P(y) = max(0, y), where max() is applied
-  // componentwise. dγ/dy = H(y), where H() is the Heaviside function, also
-  // applied componentwise.
-  void Project(const Eigen::Ref<const VectorX<T>>& y,
-               const Eigen::Ref<const VectorX<T>>&, EigenPtr<VectorX<T>> gamma,
-               MatrixX<T>* dPdy) const final {
-    (*gamma) = y.cwiseMax(0.);
-    if (dPdy != nullptr) {
-      dPdy->resize(this->num_constraint_equations(),
-                   this->num_constraint_equations());
-      dPdy->setZero();
-      dPdy->diagonal() = y.unaryExpr([](const T& x) {
-        return x >= 0. ? 1.0 : 0.0;
-      });
-    }
-  };
-
-  std::unique_ptr<SapConstraint<T>> Clone() const final {
-    return std::make_unique<DummyConstraint<T>>(*this);
+  void DoCalcData(const Eigen::Ref<const VectorX<T>>& vc,
+                  AbstractValue* data) const final {
+    data->get_mutable_value<VectorX<T>>() = vc;
+  }
+  T DoCalcCost(const AbstractValue& data) const final {
+    const VectorX<T>& vc = data.get_value<VectorX<T>>();
+    VectorX<T> gamma(vc.size());
+    this->CalcImpulse(data, &gamma);
+    const T cost = 0.5 * gamma.dot(R_.asDiagonal() * gamma);
+    return cost;
+  }
+  void DoCalcImpulse(const AbstractValue& data,
+                     EigenPtr<VectorX<T>> gamma) const final {
+    const VectorX<T>& vc = data.get_value<VectorX<T>>();
+    *gamma = -(R_.cwiseInverse().asDiagonal() * (vc - v_hat_));
+  }
+  void DoCalcCostHessian(const AbstractValue&, MatrixX<T>* G) const final {
+    *G = R_.cwiseInverse().asDiagonal();
   }
 
  private:
+  std::unique_ptr<SapConstraint<T>> DoClone() const final {
+    return std::unique_ptr<DummyConstraint<T>>(new DummyConstraint<T>(*this));
+  }
+
   VectorX<T> R_;
   VectorX<T> v_hat_;
 };
@@ -496,7 +520,6 @@ class DummyModelTest : public ::testing::Test {
     // The constraint bundle is tested elsewhere. Therefore we use it here to
     // obtain the data we need for this test.
     J_ = sap_model_->constraints_bundle().J().MakeDenseMatrix();
-    R_ = sap_model_->constraints_bundle().R();
 
     // For testing, we make the Jacobian matrix with indexes as specified in the
     // original model.
@@ -580,10 +603,14 @@ class DummyModelTest : public ::testing::Test {
     // The i-th entry in W_diagonal_approximation must contain the approximation
     // corresponding to the i-th constraint.
     VectorXd W_diagonal_approximation =
-        VectorXd::Zero(sap_problem_->num_constraints());
+        VectorXd::Zero(sap_problem_->num_constraint_equations());
+    int offset = 0;
     for (int i = 0; i < sap_problem_->num_constraints(); ++i) {
-      W_diagonal_approximation[i] =
-          W_approximation[i].norm() / W_approximation[i].rows();
+      const SapConstraint<double>& constraint = sap_problem_->get_constraint(i);
+      const int ni = constraint.num_constraint_equations();
+      W_diagonal_approximation.segment(offset, ni)
+          .setConstant(W_approximation[i].norm() / W_approximation[i].rows());
+      offset += ni;
     }
 
     // We make cluster_indexes store constraint indexes in the order specified
@@ -621,7 +648,6 @@ class DummyModelTest : public ::testing::Test {
   std::vector<MatrixXd> dynamics_matrix_;
   MatrixXd A_;
   MatrixXd J_;
-  VectorXd R_;
   MatrixXd J_not_permuted_;
 };
 
@@ -729,10 +755,12 @@ TEST_F(DummyModelTest, Impulses) {
   sap_model_->SetVelocities(v, context_.get());
   const auto& bundle = sap_model_->constraints_bundle();
   const VectorXd& vc = sap_model_->EvalConstraintVelocities(*context_);
-  VectorXd y(sap_model_->num_constraint_equations());
-  bundle.CalcUnprojectedImpulses(vc, &y);
+  const VectorXd not_used(vc.size());
+  SapConstraintBundleData data =
+      bundle.MakeData(sap_model_->time_step(), not_used);
+  bundle.CalcData(vc, &data);
   VectorXd gamma_expected(sap_model_->num_constraint_equations());
-  bundle.ProjectImpulses(y, &gamma_expected);
+  bundle.CalcImpulses(data, &gamma_expected);
 
   // Impulses.
   const VectorXd& gamma = sap_model_->EvalImpulses(*context_);
@@ -747,13 +775,22 @@ TEST_F(DummyModelTest, Impulses) {
 }
 
 TEST_F(DummyModelTest, PrimalCost) {
+  // Since the bundle is separately unit tested, we
+  // use it to obtain the expected values of constraints cost.
   const VectorXd v = arbitrary_v();
   sap_model_->SetVelocities(v, context_.get());
-  const VectorXd& gamma = sap_model_->EvalImpulses(*context_);
-  const double cost = sap_model_->EvalCost(*context_);
+  const auto& bundle = sap_model_->constraints_bundle();
+  const VectorXd& vc = sap_model_->EvalConstraintVelocities(*context_);
+  const VectorXd not_used(vc.size());
+  SapConstraintBundleData data =
+      bundle.MakeData(sap_model_->time_step(), not_used);
+  bundle.CalcData(vc, &data);
+  const double constraints_cost = bundle.CalcCost(data);
   const double expected_cost =
-      0.5 * (v - v_star_).transpose() * A_ * (v - v_star_) +
-      0.5 * gamma.dot(R_.cwiseProduct(gamma));
+      0.5 * (v - v_star_).transpose() * A_ * (v - v_star_) + constraints_cost;
+
+  // Verify the value of the cost returned by the model.
+  const double cost = sap_model_->EvalCost(*context_);
   EXPECT_NEAR(cost, expected_cost, kEpsilon * expected_cost);
 }
 

--- a/multibody/contact_solvers/sap/test/sap_solver_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_solver_test.cc
@@ -675,8 +675,6 @@ INSTANTIATE_TEST_SUITE_P(
 template <typename T>
 class LimitConstraint final : public SapConstraint<T> {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LimitConstraint);
-
   // Constructs a limit constraint on `clique` with lower limit vl, upper
   // limit vu and regularization R.
   LimitConstraint(int clique, const VectorX<T>& vl, const VectorX<T>& vu,
@@ -721,10 +719,6 @@ class LimitConstraint final : public SapConstraint<T> {
     }
   };
 
-  std::unique_ptr<SapConstraint<T>> Clone() const final {
-    return std::make_unique<LimitConstraint<T>>(*this);
-  }
-
  private:
   static VectorX<T> ConcatenateVectors(const VectorX<T>& v1,
                                        const VectorX<T>& v2) {
@@ -748,6 +742,12 @@ class LimitConstraint final : public SapConstraint<T> {
     J.topRows(nv) = MatrixX<T>::Identity(nv, nv);
     J.bottomRows(nv) = -MatrixX<T>::Identity(nv, nv);
     return J;
+  }
+
+  LimitConstraint(const LimitConstraint&) = default;
+
+  std::unique_ptr<SapConstraint<T>> DoClone() const final {
+    return std::unique_ptr<LimitConstraint<T>>(new LimitConstraint<T>(*this));
   }
 
   VectorX<T> R_;     // Regularization.


### PR DESCRIPTION
Towards landing the full PR #19392.

This PR introduces the new set of `SapConstraint` APIs but implements them in terms of the old APIs so that we can make the migration towards #19392 progressively. Therefore specific constraints are not touched in this PR.

The PR also teaches `SapConstraintBundle`, `SapModel` and `SapSolver` how to use the new APIs. With these new APIs the cost assigned to each constraint no longer needs to have the form of a quadratic regularizer. This will allow us to introduce more complex models of contact.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19402)
<!-- Reviewable:end -->
