### PR TITLE
[py solvers] Fix branch and bound test vs solution ordering

### DIFF
--- a/bindings/pydrake/solvers/test/branch_and_bound_test.py
+++ b/bindings/pydrake/solvers/test/branch_and_bound_test.py
@@ -16,7 +16,7 @@ class TestMixedIntegerBranchAndBound(unittest.TestCase):
         x = prog.NewContinuousVariables(2)
         b = prog.NewBinaryVariables(2)
 
-        prog.AddLinearConstraint(x[0] + 2 * x[1] + b[0] == 2.)
+        prog.AddLinearConstraint(b[0] + x[0] + 2 * x[1] == 2)
         prog.AddLinearConstraint(x[0] - 3.1 * b[1] >= 1)
         prog.AddLinearConstraint(b[1] + 1.2 * x[1] - b[0] <= 5)
         prog.AddQuadraticCost(x[0] * x[0])
@@ -24,12 +24,26 @@ class TestMixedIntegerBranchAndBound(unittest.TestCase):
         dut1 = MixedIntegerBranchAndBound(prog, OsqpSolver().solver_id())
         solution_result = dut1.Solve()
         self.assertEqual(solution_result, SolutionResult.kSolutionFound)
-        self.assertAlmostEqual(dut1.GetOptimalCost(), 1.)
-        self.assertAlmostEqual(dut1.GetSubOptimalCost(0), 1.)
-        self.assertAlmostEqual(dut1.GetSolution(x[0], 0), 1.)
-        self.assertAlmostEqual(dut1.GetSolution(x[0], 1), 1.)
-        np.testing.assert_allclose(
-            dut1.GetSolution(x, 0), [1., 0.], atol=1e-12)
+
+        # The solutions are either x = [1.0, 0.0] or x = [1.0, 0.5].
+        # Both solutions have x₀ == 1.0 (and therefore cost == 1.0).
+        self.assertAlmostEqual(dut1.GetOptimalCost(), 1.0)
+        self.assertAlmostEqual(dut1.GetSubOptimalCost(0), 1.0)
+
+        # Start with x₀ because its simpler (always 1.0).
+        # Check the different overloads for GetSolution.
+        self.assertAlmostEqual(dut1.GetSolution(x[0], 0), 1.0)
+        self.assertAlmostEqual(dut1.GetSolution(x[0], 1), 1.0)
+        self.assertAlmostEqual(dut1.GetSolution(x, 0)[0], 1.0)
+        self.assertAlmostEqual(dut1.GetSolution(x, 1)[0], 1.0)
+        # For x₁ the optimal vs suboptimal ordering is not deterministic, so we
+        # need to allow for either order.
+        x1_solutions = sorted([
+            dut1.GetSolution(x[1], 0),
+            dut1.GetSolution(x[1], 1),
+        ])
+        self.assertAlmostEqual(x1_solutions[0], 0.0)
+        self.assertAlmostEqual(x1_solutions[1], 0.5)
 
         options = MixedIntegerBranchAndBound.Options()
         options.max_explored_nodes = 1


### PR DESCRIPTION
On Mac Ventura Arm, this was [spuriously failing](https://drake-cdash.csail.mit.edu/test/1051758745).  Towards #18327.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19403)
<!-- Reviewable:end -->
