### PR TITLE
Implements ExpressionCost

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -822,9 +822,7 @@ void BindMathematicalProgram(py::module m) {
       .def("AddCost",
           static_cast<Binding<Cost> (MathematicalProgram::*)(
               const Expression&)>(&MathematicalProgram::AddCost),
-          // N.B. There is no corresponding C++ method, so the docstring here
-          // is a literal, not a reference to documentation_pybind.h
-          "Adds a cost expression.")
+          py::arg("e"), doc.MathematicalProgram.AddCost.doc_1args_e)
       .def(
           "AddCost",
           [](MathematicalProgram* self, const std::shared_ptr<Cost>& obj,

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -203,9 +203,11 @@ drake_cc_library(
     srcs = ["cost.cc"],
     hdrs = ["cost.h"],
     interface_deps = [
+        ":decision_variable",
         ":evaluator_base",
     ],
     deps = [
+        ":constraint",
         "//math:gradient",
     ],
 )

--- a/solvers/create_cost.cc
+++ b/solvers/create_cost.cc
@@ -97,10 +97,8 @@ Binding<PolynomialCost> ParsePolynomialCost(const symbolic::Expression& e) {
 
 Binding<Cost> ParseCost(const symbolic::Expression& e) {
   if (!e.is_polynomial()) {
-    ostringstream oss;
-    oss << "Expression " << e << " is not a polynomial. ParseCost does not"
-        << " support non-polynomial expression.\n";
-    throw runtime_error(oss.str());
+    auto cost = make_shared<ExpressionCost>(e);
+    return CreateBinding(cost, cost->vars());
   }
   const symbolic::Polynomial poly{e};
   const int total_degree{poly.TotalDegree()};

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -1040,8 +1040,6 @@ class MathematicalProgram {
 
   /**
    * Add a quadratic cost term of the form 0.5*x'*Q*x + b'*x + c.
-   * Notice that in the optimization program, the constant term `c` in the cost
-   * is ignored.
    * @param e A quadratic symbolic expression.
    * @param is_convex Whether the cost is already known to be convex. If
    * is_convex=nullopt (the default), then Drake will determine if `e` is a
@@ -1195,14 +1193,7 @@ class MathematicalProgram {
 
   /**
    * Adds a cost in the symbolic form.
-   * Note that the constant part of the cost is ignored. So if you set
-   * `e = x + 2`, then only the cost on `x` is added, the constant term 2 is
-   * ignored.
-   * @param e The linear or quadratic expression of the cost.
-   * @pre `e` is linear or `e` is quadratic. Otherwise throws a runtime error.
    * @return The newly created cost, together with the bound variables.
-   *
-   * @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
    */
   Binding<Cost> AddCost(const symbolic::Expression& e);
 

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -2798,7 +2798,7 @@ void CheckAddedSymbolicQuadraticCostUserFun(const MathematicalProgram& prog,
   EXPECT_EQ(binding.variables(), prog.quadratic_costs().back().variables());
 
   auto cnstr = prog.quadratic_costs().back().evaluator();
-  // Check the added cost is 0.5 * x' * Q * x + b' * x
+  // Check the added cost is 0.5 * x' * Q * x + b' * x + c
   const auto& x_bound = binding.variables();
   const Expression e_added = 0.5 * x_bound.dot(cnstr->Q() * x_bound) +
                              cnstr->b().dot(x_bound) + cnstr->c();
@@ -2831,6 +2831,11 @@ GTEST_TEST(TestMathematicalProgram, AddSymbolicQuadraticCost) {
   Expression e2 = x.transpose() * x + 1;
   CheckAddedSymbolicQuadraticCost(&prog, e2, true);
   EXPECT_TRUE(prog.quadratic_costs().back().evaluator()->is_convex());
+  // Confirm that const terms are respected.
+  auto b = prog.AddQuadraticCost(e2);
+  VectorXd y(1);
+  b.evaluator()->Eval(Vector3d::Zero(), &y);
+  EXPECT_EQ(y[0], 1);
 
   // Identity diagonal term.
   Expression e3 = x(0) * x(0) + x(1) * x(1) + 2;
@@ -3135,9 +3140,6 @@ GTEST_TEST(TestMathematicalProgram, TestAddCostThrowError) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>();
 
-  // Add a non-polynomial cost.
-  EXPECT_THROW(prog.AddCost(sin(x(0))), runtime_error);
-
   // Add a cost containing variable not included in the mathematical program.
   Variable y("y");
   DRAKE_EXPECT_THROWS_MESSAGE(prog.AddCost(x(0) + y),
@@ -3160,6 +3162,27 @@ GTEST_TEST(TestMathematicalProgram, TestAddGenericCost) {
   GenericPtr quadratic_cost(new QuadraticCost(Matrix1d(1), Vector1d(1)));
   prog.AddCost(quadratic_cost, x);
   EXPECT_EQ(prog.quadratic_costs().size(), 1);
+}
+
+GTEST_TEST(TestMathematicalProgram, TestAddGenericCostExpression) {
+  MathematicalProgram prog;
+  Variable x = prog.NewContinuousVariables<1>()[0];
+  Variable y = prog.NewContinuousVariables<1>()[0];
+
+  using std::atan2;
+  auto b = prog.AddCost(atan2(y, x));
+  EXPECT_EQ(prog.generic_costs().size(), 1);
+  Vector2d x_test(0.5, 0.2);
+  Vector1d y_expected(atan2(0.2, 0.5));
+  EXPECT_TRUE(CompareMatrices(prog.EvalBinding(b, x_test), y_expected));
+}
+
+// Confirm that even constant costs are supported.
+GTEST_TEST(TestMathematicalProgram, TestAddCostConstant) {
+  MathematicalProgram prog;
+
+  auto b = prog.AddCost(Expression(0.5));
+  EXPECT_EQ(prog.linear_costs().size(), 1);
 }
 
 GTEST_TEST(TestMathematicalProgram, TestClone) {


### PR DESCRIPTION
Most importantly, now AddCost(Expression) will succeed, even if it is passed in an Expression that is non-Polynomial.

Resolves #17897.

+@jwnimmer-tri for feature review, please?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19405)
<!-- Reviewable:end -->
