### PR TITLE
Improve error message for xyz mobilizers in singularity.

### DIFF
--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -488,6 +488,7 @@ drake_cc_googletest(
         ":mobilizer_tester",
         ":tree",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 
@@ -497,6 +498,7 @@ drake_cc_googletest(
         ":mobilizer_tester",
         ":tree",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/multibody/tree/space_xyz_floating_mobilizer.cc
+++ b/multibody/tree/space_xyz_floating_mobilizer.cc
@@ -7,6 +7,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/math/rotation_matrix.h"
+#include "drake/multibody/tree/body.h"
 #include "drake/multibody/tree/multibody_tree.h"
 
 namespace drake {
@@ -153,7 +154,16 @@ void SpaceXYZFloatingMobilizer<T>::DoCalcNMatrix(
   const T cp = cos(angles[1]);
   // Demand for the computation to be away from a state for which Einv_F is
   // singular.
-  DRAKE_DEMAND(abs(cp) > 1.0e-3);
+  if (abs(cp) < 1.0e-3) {
+    // TODO(russt): Add a "likely associated with SpaceXYZFloatingJoint" to
+    // match the error in space_xyz_mobilizer pending #19065.
+    throw std::runtime_error(fmt::format(
+        "The SpaceXYZFloatingMobilizer between body {} and body {} has reached "
+        "a singularity. This occurs when the pitch angle takes values near π/2 "
+        "+ kπ, ∀ k ∈ ℤ. At the current configuration, we have pitch = {}. "
+        "Consider using a QuaternionFloatingJoint instead.",
+        this->inboard_body().name(), this->outboard_body().name(), angles[1]));
+  }
 
   const T sp = sin(angles[1]);
   const T sy = sin(angles[2]);
@@ -271,7 +281,16 @@ void SpaceXYZFloatingMobilizer<T>::MapVelocityToQDot(
 
   const Vector3<T> angles = get_angles(context);
   const T cp = cos(angles[1]);
-  DRAKE_DEMAND(abs(cp) > 1.0e-3);
+  if (abs(cp) < 1.0e-3) {
+    // TODO(russt): Add a "likely associated with SpaceXYZFloatingJoint" to
+    // match the error in space_xyz_mobilizer pending #19065.
+    throw std::runtime_error(fmt::format(
+        "The SpaceXYZFloatingMobilizer between body {} and body {} has reached "
+        "a singularity. This occurs when the pitch angle takes values near π/2 "
+        "+ kπ, ∀ k ∈ ℤ. At the current configuration, we have pitch = {}. "
+        "Consider using a QuaternionFloatingJoint instead.",
+        this->inboard_body().name(), this->outboard_body().name(), angles[1]));
+  }
 
   const T& w0 = v[0];
   const T& w1 = v[1];

--- a/multibody/tree/space_xyz_mobilizer.cc
+++ b/multibody/tree/space_xyz_mobilizer.cc
@@ -7,6 +7,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/math/rotation_matrix.h"
+#include "drake/multibody/tree/body.h"
 #include "drake/multibody/tree/multibody_tree.h"
 
 namespace drake {
@@ -148,7 +149,16 @@ void SpaceXYZMobilizer<T>::DoCalcNMatrix(
   const T cp = cos(angles[1]);
   // Demand for the computation to be away from a state for which Einv_F is
   // singular.
-  DRAKE_DEMAND(abs(cp) > 1.0e-3);
+  if (abs(cp) < 1.0e-3) {
+    throw std::runtime_error(fmt::format(
+        "The SpaceXYZMobilizer (likely associated with a BallRpyJoint) between "
+        "body {} and body {} has reached a singularity. This occurs when the "
+        "pitch angle takes values near π/2 + kπ, ∀ k ∈ ℤ. At the current "
+        "configuration, we have pitch = {}. Drake does not yet support a "
+        "comparable joint using quaternions, but the feature request is "
+        "tracked in https://github.com/RobotLocomotion/drake/issues/12404.",
+        this->inboard_body().name(), this->outboard_body().name(), angles[1]));
+  }
 
   const T sp = sin(angles[1]);
   const T sy = sin(angles[2]);
@@ -259,7 +269,16 @@ void SpaceXYZMobilizer<T>::MapVelocityToQDot(
 
   const Vector3<T> angles = get_angles(context);
   const T cp = cos(angles[1]);
-  DRAKE_DEMAND(abs(cp) > 1.0e-3);
+  if (abs(cp) < 1.0e-3) {
+    throw std::runtime_error(fmt::format(
+        "The SpaceXYZMobilizer (likely associated with a BallRpyJoint) between "
+        "body {} and body {} has reached a singularity. This occurs when the "
+        "pitch angle takes values near π/2 + kπ, ∀ k ∈ ℤ. At the current "
+        "configuration, we have pitch = {}. Drake does not yet support a "
+        "comparable joint using quaternions, but the feature request is "
+        "tracked in https://github.com/RobotLocomotion/drake/issues/12404.",
+        this->inboard_body().name(), this->outboard_body().name(), angles[1]));
+  }
 
   const T& w0 = v[0];
   const T& w1 = v[1];

--- a/multibody/tree/test/space_xyz_floating_mobilizer_test.cc
+++ b/multibody/tree/test/space_xyz_floating_mobilizer_test.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/tree/multibody_tree-inl.h"
@@ -213,6 +214,24 @@ TEST_F(SpaceXYZFloatingMobilizerTest, MapUsesNplus) {
   EXPECT_TRUE(CompareMatrices(v, Nplus * qdot, kTolerance,
                               MatrixCompareType::relative));
 }
+
+TEST_F(SpaceXYZFloatingMobilizerTest, SingularityError) {
+  // Set state in singularity
+  const Vector3d rpy_value(M_PI / 3, M_PI / 2, M_PI / 5);
+  mobilizer_->set_angles(context_.get(), rpy_value);
+
+  // Set arbitrary qdot and MapVelocityToQDot.
+  const Vector6<double> v = (Vector6<double>() << 1, 2, 3, 4, 5, 6).finished();
+  Vector6<double> qdot;
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      mobilizer_->MapVelocityToQDot(*context_, v, &qdot), ".*singularity.*");
+
+  // Compute N.
+  MatrixX<double> N(6, 6);
+  DRAKE_EXPECT_THROWS_MESSAGE(mobilizer_->CalcNMatrix(*context_, &N),
+                              ".*singularity.*");
+}
+
 
 }  // namespace
 }  // namespace internal

--- a/multibody/tree/test/space_xyz_mobilizer_test.cc
+++ b/multibody/tree/test/space_xyz_mobilizer_test.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/tree/multibody_tree-inl.h"
@@ -142,6 +143,24 @@ TEST_F(SpaceXYZMobilizerTest, MapUsesNplus) {
   EXPECT_TRUE(CompareMatrices(v, Nplus * qdot, kTolerance,
                               MatrixCompareType::relative));
 }
+
+TEST_F(SpaceXYZMobilizerTest, SingularityError) {
+  // Set state in singularity
+  const Vector3d rpy_value(M_PI / 3, M_PI / 2, M_PI / 5);
+  mobilizer_->set_angles(context_.get(), rpy_value);
+
+  // Set arbitrary qdot and MapVelocityToQDot.
+  const Vector3<double> v = (Vector3<double>() << 1, 2, 3).finished();
+  Vector3<double> qdot;
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      mobilizer_->MapVelocityToQDot(*context_, v, &qdot), ".*singularity.*");
+
+  // Compute N.
+  MatrixX<double> N(3, 3);
+  DRAKE_EXPECT_THROWS_MESSAGE(mobilizer_->CalcNMatrix(*context_, &N),
+                              ".*singularity.*");
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace multibody


### PR DESCRIPTION
Previously, users saw `DRAKE_DEMAND(abs(cp) > 1.0e-3)` and had no idea where it was coming from. Now they should get a more helpful error message.

+@xuchenhan-tri for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19406)
<!-- Reviewable:end -->
