### PR TITLE
[multibody] Including joint locking in forward dynamics computations

### DIFF
--- a/multibody/tree/body.h
+++ b/multibody/tree/body.h
@@ -210,14 +210,9 @@ class Body : public MultibodyElement<T> {
   }
 
   /// For a floating body, lock its inboard joint. Its generalized
-  /// velocities will be 0 until it is unlocked. Locking is not yet supported
-  /// for continuous-mode systems.
-  /// @throws std::exception if this body is not a floating body, or if the
-  /// parent model uses continuous state.
+  /// velocities will be 0 until it is unlocked.
+  /// @throws std::exception if this body is not a floating body.
   void Lock(systems::Context<T>* context) const {
-    // Body locking is only supported for discrete mode.
-    // TODO(sherm1): extend the design to support continuous-mode systems.
-    DRAKE_THROW_UNLESS(this->get_parent_tree().is_state_discrete());
     // TODO(rpoyner-tri): consider extending the design to allow locking on
     // non-floating bodies.
     if (!is_floating()) {
@@ -229,14 +224,9 @@ class Body : public MultibodyElement<T> {
         .Lock(context);
   }
 
-  /// For a floating body, unlock its inboard joint. Unlocking is not
-  /// yet supported for continuous-mode systems.
-  /// @throws std::exception if this body is not a floating body, or if the
-  /// parent model uses continuous state.
+  /// For a floating body, unlock its inboard joint.
+  /// @throws std::exception if this body is not a floating body.
   void Unlock(systems::Context<T>* context) const {
-    // Body locking is only supported for discrete mode.
-    // TODO(sherm1): extend the design to support continuous-mode systems.
-    DRAKE_THROW_UNLESS(this->get_parent_tree().is_state_discrete());
     // TODO(rpoyner-tri): consider extending the design to allow locking on
     // non-floating bodies.
     if (!is_floating()) {

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -339,24 +339,15 @@ class Joint : public MultibodyElement<T> {
   }
 
   /// Lock the joint. Its generalized velocities will be 0 until it is
-  /// unlocked. Locking is not yet supported for continuous-mode systems.
-  /// @throws std::exception if the parent model uses continuous state.
+  /// unlocked.
   void Lock(systems::Context<T>* context) const {
-    // Joint locking is only supported for discrete mode.
-    // TODO(sherm1): extend the design to support continuous-mode systems.
-    DRAKE_THROW_UNLESS(this->get_parent_tree().is_state_discrete());
     for (internal::Mobilizer<T>* mobilizer : implementation_->mobilizers_) {
       mobilizer->Lock(context);
     }
   }
 
-  /// Unlock the joint. Unlocking is not yet supported for continuous-mode
-  /// systems.
-  /// @throws std::exception if the parent model uses continuous state.
+  /// Unlock the joint.
   void Unlock(systems::Context<T>* context) const {
-    // Joint locking is only supported for discrete mode.
-    // TODO(sherm1): extend the design to support continuous-mode systems.
-    DRAKE_THROW_UNLESS(this->get_parent_tree().is_state_discrete());
     for (internal::Mobilizer<T>* mobilizer : implementation_->mobilizers_) {
       mobilizer->Unlock(context);
     }

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -638,13 +638,10 @@ class Mobilizer : public MultibodyElement<T> {
       const internal::BodyNode<T>* parent_node,
       const Body<T>* body, const Mobilizer<T>* mobilizer) const = 0;
 
-  /// Lock the mobilizer. Its generalized velocities will be 0 until it is
-  /// unlocked. Locking is not yet supported for continuous-mode systems.
-  /// @throws std::exception if the parent model uses continuous state.
+  // Lock the mobilizer. Its generalized velocities will be 0 until it is
+  // unlocked.
   void Lock(systems::Context<T>* context) const {
     // Joint locking is only supported for discrete mode.
-    // TODO(sherm1): extend the design to support continuous-mode systems.
-    DRAKE_THROW_UNLESS(this->get_parent_tree().is_state_discrete());
     context->get_mutable_abstract_parameter(is_locked_parameter_index_)
         .set_value(true);
     this->get_parent_tree()
@@ -653,18 +650,14 @@ class Mobilizer : public MultibodyElement<T> {
         .setZero();
   }
 
-  /// Unlock the mobilizer. Unlocking is not yet supported for continuous-mode
-  /// systems.
-  /// @throws std::exception if the parent model uses continuous state.
+  // Unlock the mobilizer. Unlocking is not yet supported for continuous-mode
+  // systems.
   void Unlock(systems::Context<T>* context) const {
-    // Joint locking is only supported for discrete mode.
-    // TODO(sherm1): extend the design to support continuous-mode systems.
-    DRAKE_THROW_UNLESS(this->get_parent_tree().is_state_discrete());
     context->get_mutable_abstract_parameter(is_locked_parameter_index_)
         .set_value(false);
   }
 
-  /// @return true if the mobilizer is locked, false otherwise.
+  // @return true if the mobilizer is locked, false otherwise.
   bool is_locked(const systems::Context<T>& context) const {
     return context.get_parameters().template get_abstract_parameter<bool>(
         is_locked_parameter_index_);

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1182,6 +1182,8 @@ void MultibodyTree<T>::CalcSpatialInertiasInWorld(
   const PositionKinematicsCache<T>& pc = this->EvalPositionKinematics(context);
 
   // Skip the world.
+  // TODO(joemasterjohn): Consider an optimization to avoid calculating spatial
+  // inertias for locked floating bodies.
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
     const Body<T>& body = get_body(body_index);
     const RigidTransform<T>& X_WB = pc.get_X_WB(body.node_index());
@@ -1253,6 +1255,8 @@ void MultibodyTree<T>::CalcSpatialAccelerationBias(
   // For the world body we opted for leaving Ab_WB initialized to NaN so that
   // an accidental usage (most likely indicating unnecessary math) in code would
   // immediately trigger a trail of NaNs that we can track to the source.
+  // TODO(joemasterjohn): Consider an optimization where we avoid computing
+  // `Ab_WB` for locked floating bodies.
   (*Ab_WB_all)[world_index()].SetNaN();
   for (BodyNodeIndex body_node_index(1); body_node_index < num_bodies();
        ++body_node_index) {
@@ -1276,6 +1280,8 @@ void MultibodyTree<T>::CalcArticulatedBodyForceBias(
   // For the world body we opted for leaving Zb_Bo_W initialized to NaN so that
   // an accidental usage (most likely indicating unnecessary math) in code would
   // immediately trigger a trail of NaNs that we can track to the source.
+  // TODO(joemasterjohn): Consider an optimization to avoid computing `Zb_Bo_W`
+  // for locked floating bodies.
   (*Zb_Bo_W_all)[world_index()].SetNaN();
   for (BodyNodeIndex body_node_index(1); body_node_index < num_bodies();
        ++body_node_index) {
@@ -2215,8 +2221,9 @@ void MultibodyTree<T>::CalcAcrossNodeJacobianWrtVExpressedInWorld(
   // Quick return on nv = 0. Nothing to compute.
   if (num_velocities() == 0) return;
 
-  for (BodyNodeIndex node_index(1);
-       node_index < num_bodies(); ++node_index) {
+  // TODO(joemasterjohn): Consider and optimization where we avoid computing
+  // `H_PB_W` for locked floating bodies.
+  for (BodyNodeIndex node_index(1); node_index < num_bodies(); ++node_index) {
     const BodyNode<T>& node = *body_nodes_[node_index];
 
     // The body-node hinge matrix is H_PB_W ∈ ℝ⁶ˣⁿᵐ, with nm ∈ [0; 6] the number

--- a/multibody/tree/multibody_tree_system.cc
+++ b/multibody/tree/multibody_tree_system.cc
@@ -214,23 +214,29 @@ void MultibodyTreeSystem<T>::Finalize() {
       {position_kinematics_cache_entry().ticket()}).cache_index();
 
   // Allocate articulated body inertia cache.
-  cache_indexes_.abi_cache_index = this->DeclareCacheEntry(
-      std::string("Articulated Body Inertia"),
-      ArticulatedBodyInertiaCache<T>(internal_tree().get_topology()),
-      &MultibodyTreeSystem<T>::CalcArticulatedBodyInertiaCache,
-      {this->configuration_ticket()}).cache_index();
+  cache_indexes_.abi_cache_index =
+      this->DeclareCacheEntry(
+              std::string("Articulated Body Inertia"),
+              ArticulatedBodyInertiaCache<T>(internal_tree().get_topology()),
+              &MultibodyTreeSystem<T>::CalcArticulatedBodyInertiaCache,
+              {this->configuration_ticket(), this->all_parameters_ticket()})
+          .cache_index();
 
-  cache_indexes_.spatial_acceleration_bias = this->DeclareCacheEntry(
-      std::string("spatial acceleration bias (Ab_WB)"),
-      std::vector<SpatialAcceleration<T>>(internal_tree().num_bodies()),
-      &MultibodyTreeSystem<T>::CalcSpatialAccelerationBias,
-      {this->kinematics_ticket()}).cache_index();
+  cache_indexes_.spatial_acceleration_bias =
+      this->DeclareCacheEntry(
+              std::string("spatial acceleration bias (Ab_WB)"),
+              std::vector<SpatialAcceleration<T>>(internal_tree().num_bodies()),
+              &MultibodyTreeSystem<T>::CalcSpatialAccelerationBias,
+              {this->kinematics_ticket(), this->all_parameters_ticket()})
+          .cache_index();
 
-  cache_indexes_.articulated_body_force_bias = this->DeclareCacheEntry(
-      std::string("ABI force bias cache (Zb_Bo_W)"),
-      std::vector<SpatialForce<T>>(internal_tree().num_bodies()),
-      &MultibodyTreeSystem<T>::CalcArticulatedBodyForceBias,
-      {this->kinematics_ticket()}).cache_index();
+  cache_indexes_.articulated_body_force_bias =
+      this->DeclareCacheEntry(
+              std::string("ABI force bias cache (Zb_Bo_W)"),
+              std::vector<SpatialForce<T>>(internal_tree().num_bodies()),
+              &MultibodyTreeSystem<T>::CalcArticulatedBodyForceBias,
+              {this->kinematics_ticket(), this->all_parameters_ticket()})
+          .cache_index();
 
   // Articulated Body Algorithm (ABA) force cache.
   cache_indexes_.articulated_body_forces = this->DeclareCacheEntry(


### PR DESCRIPTION
Towards #18983.

Considers joint locking parameters for mobilizers in plant forward dynamics computations. This has a twofold effect:
1. Enables joint locking in continous mode.
2. Enables the acurate calculation of free-motion velocities (v*) in SAP such that we can make the assumption that `Δv = v−v* = 0` for locked dofs in the SapProblem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19420)
<!-- Reviewable:end -->
