### PR TITLE
Overload Trajectory::vector_values to accept Eigen::VectorXd

### DIFF
--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -240,8 +240,10 @@ struct Impl {
       cls  // BR
           .def(py::init<>())
           .def("value", &Class::value, py::arg("t"), cls_doc.value.doc)
-          .def(
-              "vector_values", &Class::vector_values, cls_doc.vector_values.doc)
+          .def("vector_values",
+              overload_cast_explicit<MatrixX<T>, const std::vector<T>&>(
+                  &Class::vector_values),
+              py::arg("t"), cls_doc.vector_values.doc)
           .def("has_derivative", &Class::has_derivative,
               cls_doc.has_derivative.doc)
           .def("EvalDerivative", &Class::EvalDerivative, py::arg("t"),

--- a/common/trajectories/test/piecewise_polynomial_test.cc
+++ b/common/trajectories/test/piecewise_polynomial_test.cc
@@ -287,13 +287,20 @@ GTEST_TEST(testPiecewisePolynomial, VectorValueTest) {
   // Note: Keep one negative time to confirm that negative values can work for
   // constant trajectories.
   const std::vector<double> times = {-1.5, 0, .5, 1, 1.5};
+  const Eigen::Map<const Eigen::VectorXd> etimes(times.data(), times.size());
   const Eigen::Vector3d value(1, 2, 3);
 
   const PiecewisePolynomial<double> col(value);
   Eigen::MatrixXd out = col.vector_values(times);
   EXPECT_EQ(out.rows(), 3);
   EXPECT_EQ(out.cols(), 5);
-  for (int i = 0; i < 4; i++) {
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_TRUE(CompareMatrices(out.col(i), value, 0));
+  }
+  out = col.vector_values(etimes);
+  EXPECT_EQ(out.rows(), 3);
+  EXPECT_EQ(out.cols(), 5);
+  for (int i = 0; i < 4; ++i) {
     EXPECT_TRUE(CompareMatrices(out.col(i), value, 0));
   }
 
@@ -301,7 +308,13 @@ GTEST_TEST(testPiecewisePolynomial, VectorValueTest) {
   out = row.vector_values(times);
   EXPECT_EQ(out.rows(), 5);
   EXPECT_EQ(out.cols(), 3);
-  for (int i = 0; i < 4; i++) {
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_TRUE(CompareMatrices(out.row(i), value.transpose(), 0));
+  }
+  out = row.vector_values(etimes);
+  EXPECT_EQ(out.rows(), 5);
+  EXPECT_EQ(out.cols(), 3);
+  for (int i = 0; i < 4; ++i) {
     EXPECT_TRUE(CompareMatrices(out.row(i), value.transpose(), 0));
   }
 

--- a/common/trajectories/trajectory.cc
+++ b/common/trajectories/trajectory.cc
@@ -7,19 +7,25 @@ namespace trajectories {
 
 template <typename T>
 MatrixX<T> Trajectory<T>::vector_values(const std::vector<T>& t) const {
+  return vector_values(Eigen::Map<const VectorX<T>>(t.data(), t.size()));
+}
+
+template <typename T>
+MatrixX<T> Trajectory<T>::vector_values(
+    const Eigen::Ref<const VectorX<T>>& t) const {
   if (cols() != 1 && rows() != 1) {
     throw std::runtime_error(
         "This method only supports vector-valued trajectories.");
   }
   if (cols() == 1) {
     MatrixX<T> values(rows(), t.size());
-    for (int i = 0; i < static_cast<int>(t.size()); i++) {
+    for (int i = 0; i < static_cast<int>(t.size()); ++i) {
       values.col(i) = value(t[i]);
     }
     return values;
   }
   MatrixX<T> values(t.size(), cols());
-  for (int i = 0; i < static_cast<int>(t.size()); i++) {
+  for (int i = 0; i < static_cast<int>(t.size()); ++i) {
     values.row(i) = value(t[i]);
   }
   return values;

--- a/common/trajectories/trajectory.h
+++ b/common/trajectories/trajectory.h
@@ -46,6 +46,16 @@ class Trajectory {
   MatrixX<T> vector_values(const std::vector<T>& t) const;
 
   /**
+   * If cols()==1, then evaluates the trajectory at each time @p t, and returns
+   * the results as a Matrix with the ith column corresponding to the ith time.
+   * Otherwise, if rows()==1, then evaluates the trajectory at each time @p t,
+   * and returns the results as a Matrix with the ith row corresponding to
+   * the ith time.
+   * @throws std::exception if both cols and rows are not equal to 1.
+   */
+  MatrixX<T> vector_values(const Eigen::Ref<const VectorX<T>>& t) const;
+
+  /**
    * Returns true iff the Trajectory provides and implementation for
    * EvalDerivative() and MakeDerivative().  The derivative need not be
    * continuous, but should return a result for all t for which value(t) returns


### PR DESCRIPTION
This makes it easier (in c++) to, for instance, using Eigen::LinSpaced to sample at regular intervals from a trajectory.

+@xuchenhan-tri for both reviews, please (if it's not too late).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19422)
<!-- Reviewable:end -->
