### PR TITLE
Make RenderEngineGl intelligently threadsafe

### DIFF
--- a/geometry/render_gl/BUILD.bazel
+++ b/geometry/render_gl/BUILD.bazel
@@ -313,8 +313,13 @@ drake_cc_googletest_ubuntu_only(
     ],
     tags = vtk_test_tags() + ["cpu:4"],
     deps = [
+        ":factory",
+        ":internal_render_engine_gl",
         ":internal_texture_library",
         "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//systems/sensors:image",
+        "//systems/sensors:image_writer",
     ],
 )
 

--- a/geometry/render_gl/factory.h
+++ b/geometry/render_gl/factory.h
@@ -25,9 +25,23 @@ extern const bool kHasRenderEngineGl;
  Drake ecosystem, only the visualization will be upside down. This has been
  documented in https://github.com/RobotLocomotion/drake/issues/14254.
 
- @warning %RenderEngineGl is not threadsafe. If a SceneGraph is instantiated
- with a RenderEngineGl and there are multiple Context instances for that
- SceneGraph, rendering in multiple threads may exhibit issues.
+ <b> Using RenderEngineGl in multiple threads </b>
+
+ Most importantly, a single %RenderEngineGl should *not* be exercised in
+ multiple threads. One thread, one %RenderEngineGl instance.
+
+ A %RenderEngineGl instance and its *clones* can be used in different threads
+ simultaneously, but *only* the rendering APIs are threadsafe. Do not mutate the
+ contents of the engine (e.g., adding/removing geometries, etc.) in parallel.
+
+ Two independently constructed %RenderEngineGl instances can be freely used in
+ different threads -- all APIs are available.
+
+ The expected workflow is to add a %RenderEngineGl instance a SceneGraph
+ instance (see SceneGraph::AddRenderer()) and then to populate SceneGraph with
+ the desired geometry. Each systems::Context allocated for that SceneGraph will
+ receive a clone of the original %RenderEngineGl. One systems::Context can be
+ used per thread to create rendered images in parallel.
 
  @throws std::exception if kHasRenderEngineGl is false. */
 std::unique_ptr<render::RenderEngine> MakeRenderEngineGl(

--- a/geometry/render_gl/internal_opengl_context.cc
+++ b/geometry/render_gl/internal_opengl_context.cc
@@ -79,8 +79,12 @@ static Display* display() {
   // program exits, but it seems not so evil to skip that.
   // (https://linux.die.net/man/3/xclosedisplay)
   // If problems crop up in the future, this can/should be investigated.
-  static Display* g_display = (XInitThreads(), XOpenDisplay(0));
-  DRAKE_THROW_UNLESS(g_display != nullptr);
+  static Display* g_display = []() {
+    XInitThreads();
+    Display* display = XOpenDisplay(0);
+    DRAKE_THROW_UNLESS(display != nullptr);
+    return display;
+  }();
   return g_display;
 }
 

--- a/geometry/render_gl/internal_opengl_context.cc
+++ b/geometry/render_gl/internal_opengl_context.cc
@@ -72,13 +72,25 @@ void GlDebugCallback(GLenum, GLenum type, GLuint, GLenum severity, GLsizei,
   }
 }
 
+static Display* display() {
+  // Turn Display into a singleton to make CI happy, since when we close and
+  // reopen the display on CI, we can't request a new OpenGL context.
+  // This pattern won't call the corresponding `XCloseDisplay()` when the
+  // program exits, but it seems not so evil to skip that.
+  // (https://linux.die.net/man/3/xclosedisplay)
+  // If problems crop up in the future, this can/should be investigated.
+  static Display* g_display = (XInitThreads(), XOpenDisplay(0));
+  DRAKE_THROW_UNLESS(g_display != nullptr);
+  return g_display;
+}
+
 }  // namespace
 
 class OpenGlContext::Impl {
  public:
   // Open an X display and initialize an OpenGL context. The display will be
   // open and ready for offscreen rendering, but no window is visible.
-  explicit Impl(bool debug) {
+  explicit Impl(bool debug, GLXContext source_context = NULL) : debug_(debug) {
     // See Offscreen Rendering section here:
     // https://sidvind.com/index.php?title=Opengl/windowless
 
@@ -102,6 +114,13 @@ class OpenGlContext::Impl {
                                   None};
     int fb_count = 0;
     const int screen_id = DefaultScreen(display());
+
+    // No matter what, we want to make sure that the context is not current
+    // at the conclusion of construction.
+    ScopeExit unbind([]() {
+      OpenGlContext::ClearCurrent();
+    });
+
     GLXFBConfig* fb_configs =
         glXChooseFBConfig(display(), screen_id, kVisualAttribs, &fb_count);
     ScopeExit guard([fb_configs]() { XFree(fb_configs); });
@@ -157,8 +176,8 @@ class OpenGlContext::Impl {
     // NOTE: The consts True and False come from gl/glx.h (indirectly), but
     // ultimately from X11/Xlib.h.
     // This requires a call to glXDestroyContext in the destructor.
-    context_ = glXCreateContextAttribsARB(display(), fb_configs[0], 0, True,
-                                          kContextAttribs);
+    context_ = glXCreateContextAttribsARB(
+        display(), fb_configs[0], source_context, True, kContextAttribs);
     if (context_ == nullptr) {
       throw std::runtime_error(
           "Error initializing OpenGL Context for RenderEngineGL; failed to "
@@ -171,17 +190,20 @@ class OpenGlContext::Impl {
 
     XSync(display(), False);
 
-    // Make it the current context.
-    MakeCurrent();
-
     // Enable debug.
     if (debug) {
+      MakeCurrent();
       drake::log()->info("Vendor: {}", GetGlVendor());
       glEnable(GL_DEBUG_OUTPUT);
+      glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
       glDebugMessageCallback(GlDebugCallback, 0);
     }
     is_complete = true;
   }
+
+  // Constructs a copy which shares the OpenGl objects stored on the GPU with
+  // `other`.
+  Impl(const Impl& other) : Impl(other.debug_, other.context_) {}
 
   ~Impl() {
     glXDestroyContext(display(), context_);
@@ -196,6 +218,10 @@ class OpenGlContext::Impl {
         !glXMakeCurrent(display(), window_, context_)) {
       throw std::runtime_error("Error making an OpenGL context current");
     }
+  }
+
+  bool IsCurrent() const {
+    return glXGetCurrentContext() == context_;
   }
 
   void DisplayWindow(const int width, const int height) {
@@ -268,19 +294,6 @@ class OpenGlContext::Impl {
   }
 
  private:
-  static Display* display() {
-    // Turn Display into a singleton to make CI happy, since when we close and
-    // reopen the display on CI, we can't request a new OpenGL context.
-    // This pattern won't call the corresponding `XCloseDisplay()` when the
-    // program exits, but it seems not so evil to skip that.
-    // (https://linux.die.net/man/3/xclosedisplay)
-    // TODO(duy): If problems crop up in the future, this can/should be
-    // investigated.
-    static Display* g_display = (XInitThreads(), XOpenDisplay(0));
-    DRAKE_THROW_UNLESS(g_display != nullptr);
-    return g_display;
-  }
-
   GLXContext context_{nullptr};
 
   // The associated window to support display of rendering results.
@@ -292,14 +305,23 @@ class OpenGlContext::Impl {
   // not yet understood.
   int window_width_{640};
   int window_height_{480};
+
+  const bool debug_{};
 };
 
 OpenGlContext::OpenGlContext(bool debug)
     : impl_(new OpenGlContext::Impl(debug)) {}
 
+OpenGlContext::OpenGlContext(const OpenGlContext& other)
+    : impl_(std::make_unique<OpenGlContext::Impl>(*other.impl_)) {}
+
 OpenGlContext::~OpenGlContext() = default;
 
 void OpenGlContext::MakeCurrent() const { impl_->MakeCurrent(); }
+
+void OpenGlContext::ClearCurrent() { glXMakeCurrent(display(), None, NULL); }
+
+bool OpenGlContext::IsCurrent() const { return impl_->IsCurrent(); }
 
 void OpenGlContext::DisplayWindow(const int width, const int height) {
   impl_->DisplayWindow(width, height);

--- a/geometry/render_gl/internal_opengl_context.h
+++ b/geometry/render_gl/internal_opengl_context.h
@@ -16,18 +16,43 @@ namespace internal {
  */
 class OpenGlContext {
  public:
-  /* Constructor. Initializes an OpenGL context.
+  /* Constructor. Initializes a brand new OpenGL context without any objects.
+
    @param debug  If debug is true, the OpenGl context will be a "debug" context,
    in that the OpenGl implementation's errors will be written to the Drake log.
    See https://www.khronos.org/opengl/wiki/Debug_Output for more information.
    */
   explicit OpenGlContext(bool debug = false);
 
+  /* Copy constructs a context that shares OpenGl objects with `other`.
+
+   - All %OpenGlContext instances share a common display.
+   - Each instance has a unique window/OpenGL objects for connecting an OpenGl
+     context to an X-windows display.
+   - Copying an %OpenGlContext is distinct from creating a new instance in that
+     all of the OpenGl objects (buffers, textures, display lists, etc.)
+     available to `other` will also be available to the copy. New instances have
+     no OpenGl objects. */
+  OpenGlContext(const OpenGlContext& other);
+
+  /* All other copy and move semantics are simply deleted. */
+  OpenGlContext& operator=(const OpenGlContext& other) = delete;
+  OpenGlContext(OpenGlContext&&) = delete;
+  OpenGlContext& operator=(OpenGlContext&&) = delete;
+
   ~OpenGlContext();
 
   /* Makes this context current.
    @throws std::exception if not successful.  */
   void MakeCurrent() const;
+
+  /* Clears the "current" context from the current thread. Note: if this context
+   has been bound in one thread and this called in another thread, the context
+   will still be bound in the first thread. */
+  static void ClearCurrent();
+
+  /* Reports if this context is bound to the current thread. */
+  bool IsCurrent() const;
 
   /* Displays the window at the given dimensions. Calling this redundantly (on
    an already visible window of the given size) has no effect.  */

--- a/geometry/render_gl/internal_render_engine_gl.h
+++ b/geometry/render_gl/internal_render_engine_gl.h
@@ -8,6 +8,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/render/render_engine.h"
@@ -27,7 +28,64 @@ namespace geometry {
 namespace render_gl {
 namespace internal {
 
-/** See documentation of MakeRenderEngineGl().  */
+/* See documentation of MakeRenderEngineGl().
+
+ A discussion on using RenderEngineGl in multiple threads.
+ --------------------------------------------------------
+
+ Most importantly, a single %RenderEngineGl should *not* be exercised in
+ multiple threads. One thread, one %RenderEngineGl instance.
+
+ A %RenderEngineGl instance and its *clone* can be used in different threads
+ simultaneously, but *only* the rendering APIs are threadsafe. Do not mutate the
+ contents of the engine (e.g., adding/removing geometries, etc.) in parallel.
+
+ Two independently constructed %RenderEngineGl instances can be freely used in
+ different threads -- all APIs are available.
+
+ Implementation of thread safety
+ -------------------------------
+
+ We expect the following common case:
+
+   - A SceneGraph gets populated with some model.
+   - We want to render multiple images of the contents of that world, perhaps
+     from different views or even different configurations - one rendering per
+     thread.
+
+ %RenderEngineGl relies on some basic assumptions to *efficiently* achieve this:
+
+   - The %RenderEngineGl will typically be part of a systems::Context (cloned
+     from SceneGraph's model engine) and each context will be used in a single
+     thread.
+   - OpenGl allows for multiple OpenGl "contexts" (not the same as
+     systems::Context) to share objects stored on the GPU. We use this to share
+     various rendering data like textures, meshes, etc., reducing memory
+     overhead and %RenderEngineGl cloning time.
+   - Each RenderEngineGl has its own OpenGlContext (which corresponds to an
+     "OpenGl context"). A cloned %RenderEngineGl instance gets a clone of the
+     source engine's OpenGlContext. When an OpenGlContext is cloned, the clone
+     shares the shareable objects of the source.
+
+ However, in sharing data across multiple OpenGl contexts not all data is
+ shareable, nor necessarily *should* be.
+
+   - OpenGl doesn't share "container" objects. This includes the Vertex Array
+     Objects (referenced in OpenGlGeometry) that stitch vertex and triangle data
+     into coherent meshes.
+   - OpenGl context state (such is which features are enabled/disabled, etc.)
+     are unique in each context. Each OpenGlContext needs to be configured
+     explicitly to have matching state.
+   - If a single OpenGl shader program is used across multiple threads, they
+     will conflict when setting the "uniform" parameters. For example, one
+     rendering thread, in setting the color of the object it will draw, can
+     change the color of an object being drawn in another thread. For now, we
+     avoid this by making sure each RenderEngineGl instance has its own
+     shader programs with their own uniform namespaces.
+
+ These exceptions to the "shared" data have to be explicitly managed for each
+ clone. Furthermore, the work has to be done with the engine's OpenGl context
+ bound. Currently, all of this "clean up" work is done in DoClone(). */
 class RenderEngineGl final : public render::RenderEngine {
  public:
   /** @name Does not allow public copy, move, or assignment  */
@@ -67,6 +125,11 @@ class RenderEngineGl final : public render::RenderEngine {
 
  private:
   friend class RenderEngineGlTester;
+
+  // Initializes the OpenGl state (e.g., enabling back face culling, etc.) This
+  // should be called upon construction and cloning.
+  // @pre `this` engine's OpenGl context should be bound.
+  void InitGlState();
 
   // Mangles the mesh data before adding it to the engine to support the
   // legacy behavior of mapping mesh.obj -> mesh.png, applying it as a diffuse
@@ -110,6 +173,9 @@ class RenderEngineGl final : public render::RenderEngine {
       systems::sensors::ImageLabel16I* label_image_out) const final;
 
   // Copy constructor used for cloning.
+  // Do *not* call this copy constructor directly. The resulting RenderEngineGl
+  // is not complete -- it will render nothing except the background color.
+  // Only call Clone() to get a copy.
   RenderEngineGl(const RenderEngineGl& other) = default;
 
   // Renders all geometries which use the given shader program for the given
@@ -184,6 +250,11 @@ class RenderEngineGl final : public render::RenderEngine {
   // all of the buffer data into the vertex array attributes.
   void CreateVertexArray(OpenGlGeometry* geometry) const;
 
+  // Updates the vertex arrays in all of the OpenGlGeometry instances owned by
+  // this render engine.
+  // @pre opengl_context_ has been bound.
+  void UpdateVertexArrays();
+
   // Sets the display window visibility and populates it with the _last_ image
   // rendered, if visible.
   // If `show_window` is true:
@@ -216,22 +287,26 @@ class RenderEngineGl final : public render::RenderEngine {
   // The cached value transformation between camera and world frames.
   math::RigidTransformd X_CW_;
 
-  // All clones of this context share the same underlying OpenGlContext. They
-  // also share the C++ abstractions of objects that *live* in the context:
+  // When the OpenGlContext gets copied, the copy shares the OpenGl objects
+  // created in GPU memory.
+  copyable_unique_ptr<OpenGlContext> opengl_context_;
+
+  // Various C++ classes store identifiers of objects in the OpenGl context.
+  // This includes:
   //
   //   OpenGlGeometry - the geometry buffers (copy safe)
   //   RenderTarget - frame buffer objects (copy safe)
   //   TextureLibrary - the textures (shared)
   //   ShaderProgram - the compiled shader programs (copy safe)
   //
-  // So, all of these quantities are simple copy-safe POD (e.g., OpenGlGeometry)
-  // or are stashed in a shared pointer.
-  std::shared_ptr<OpenGlContext> opengl_context_;
+  // So, all of these quantities can be safely copied verbatim.
 
-  // This texture library is coupled with the OpenGlContext. The texture
-  // identifiers in the library are instantiated in that context. Operations
-  // on this library must be invoked with the context bound. Both context and
-  // library are shared between a RenderEngineGl instance and all of its clones.
+  // OpenGl texture objects are shared across OpenGl contexts. The
+  // TextureLibrary simply stores the *identifiers* to those texture objects. A
+  // RenderEngineGl instance and its clones share the same TextureLibrary, so
+  // that if one instance loads a new texture into the GPU, they all have
+  // equal access to it (rather than blindly adding the same texture
+  // redundantly).
   std::shared_ptr<TextureLibrary> texture_library_;
 
   // The engine's configuration parameters.

--- a/geometry/render_gl/internal_shader_program.h
+++ b/geometry/render_gl/internal_shader_program.h
@@ -193,7 +193,7 @@ class ShaderProgram {
   /* Deletes the OpenGl program from the currently bound context. This should
    be a precursor to destroying the %ShaderProgram.
 
-   Ideally, this would be done in the constructor. However, the RenderEngineGl
+   Ideally, this would be done in the destructor. However, the RenderEngineGl
    infrastructure is not clearly wired to guarantee that the invocation of
    shader program destructors is preconditioned by a bound context.
 

--- a/geometry/render_gl/internal_shader_program.h
+++ b/geometry/render_gl/internal_shader_program.h
@@ -55,16 +55,25 @@ namespace internal {
    - It must specify a uniform mat4 called "T_DC" - this transforms
      vertices from the camera's frame C to the OpenGl normalized device frame
      D. This is a projective transform, taking points in ℜ³ and mapping them
-     to ℜ². */
+     to ℜ².
+
+ The %ShaderProgram stores the identifier for an OpenGl program. These programs
+ are included in the objects that are shared across OpenGl contexts. However,
+ when rendering in parallel, this sharing can be problematic. Setting uniforms'
+ values in one thread can leak through to the other threads, possibly changing
+ the rendered output. To make sure that one RenderEngineGl instance rendering
+ in one thread doesn't interfere with its clone in another thread, the clone
+ should call Relink() on each of its ShaderProgram instances with its own
+ context bound during the clone's construction -- this guarantees an independent
+ namespace for its uniforms (at the cost of increased GPU memory). Relink() is
+ not called automatically as part of the cloning, because the OpenGl context for
+ the cloned %ShaderProgram would have to be bound at the time of cloning. */
 class ShaderProgram {
  public:
   ShaderProgram() : id_(ShaderId::get_new_id()) {}
 
-  /* Note: we're using the default destructor and explicitly *not* cleaning up
-   the OpenGl context. This is consistent with how we treat all OpenGl objects:
-   RenderTarget, OpenGlGeometry, etc. We assume that destruction of the OpenGL
-   context will clean it up and the RenderEngineGl's footprint is sufficiently
-   small that no actual object management will be required.  */
+  /* The destructor is currently superficial. The real work is done by Free()
+   (see below for details).  */
   virtual ~ShaderProgram() = default;
 
   std::unique_ptr<ShaderProgram> Clone() const { return DoClone(); }
@@ -163,7 +172,48 @@ class ShaderProgram {
    identifier used in OpenGl APIs.  */
   ShaderId shader_id() const { return id_; }
 
+  /* TODO(SeanCurtis-TRI) This "relink" after cloning is a primitive solution to
+   the problem of unique uniform namespaces. I tried using program pipeline
+   objects but ended up with a worse outcome (might be programmer error). I have
+   yet to explore Uniform Buffer Objects -- this should be explored so that the
+   programs don't have to be relinked. Instead, each clone of ShaderProgram
+   would simply have a unique buffer object to guarantee thread independence. */
+
+  /* Constructs a new OpenGl program based on the already compiled shaders.
+
+   If `this` instance was cloned from another instance, this will create a
+   unique uniform namespace from the source instance. This is necessary if the
+   two instances are going to be exercised in parallel.
+
+   @pre `this` is a clone of a fully functional %ShaderProgram (i.e., the
+        shaders have been compiled and linked and we are ready to call Use()).
+   @pre The OpenGl context that possesses the compiled shaders is bound. */
+  void Relink();
+
+  /* Deletes the OpenGl program from the currently bound context. This should
+   be a precursor to destroying the %ShaderProgram.
+
+   Ideally, this would be done in the constructor. However, the RenderEngineGl
+   infrastructure is not clearly wired to guarantee that the invocation of
+   shader program destructors is preconditioned by a bound context.
+
+   Furthermore, it renders the destructor really brittle. The destructor only
+   "works" if someone outside the destructor has taken a special action. As long
+   as that is the requirement, that actor might as well couple *that* special
+   act with *this* special clean up. */
+  void Free();
+
  protected:
+  /* Extracts uniform ids from the linked program. After extracting the common
+   uniform identifiers, it invokes DoConfigureUniforms() so derived class can
+   extract their particular uniform ids. */
+  void ConfigureUniforms();
+
+  /* Invoked after successfully linking an OpenGl program. Derived classes
+   should use this to extract the ids of the program's unique uniform variables.
+   */
+  virtual void DoConfigureUniforms() = 0;
+
   /* The copy and move semantics are only made available for sub-classes so
    they can easily implement DoClone.  */
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ShaderProgram)
@@ -198,6 +248,11 @@ class ShaderProgram {
   ShaderId id_;
 
   GLuint gl_id_{0};
+
+  // The OpenGl identifiers for the vertex and fragment shaders; these are saved
+  // to facilitate copying the shader program (saving compilation time).
+  GLuint vertex_id_{0};
+  GLuint fragment_id_{0};
 
   // Locations of the projection matrix and the model view matrix in the
   // *supported* shader.

--- a/geometry/render_gl/internal_texture_library.cc
+++ b/geometry/render_gl/internal_texture_library.cc
@@ -31,6 +31,13 @@ std::optional<GLuint> TextureLibrary::GetTextureId(
   std::lock_guard<std::mutex> lock(mutex_);
   const auto iter = textures_.find(file_name);
   if (iter != textures_.end()) {
+    // This assertion attempts to validate the precondition. It will fail if an
+    // OpenGL context isn't bound, or if the "wrong" context is bound -- one
+    // that knows nothing of the texture recorded in the library. The test isn't
+    // perfect. Two different contexts can both use the same identifier but
+    // refer to different textures. However, this much test will be good to
+    // help CI detect if we've got systemic issues.
+    DRAKE_ASSERT(glIsTexture(iter->second));
     return iter->second;
   }
 

--- a/geometry/render_gl/internal_texture_library.h
+++ b/geometry/render_gl/internal_texture_library.h
@@ -42,8 +42,9 @@ namespace internal {
  instances -- the original and all instances *cloned* from it. The library
  is threadsafe for adding new textures to the OpenGl context such that if one
  instance loads a texture, the others will benefit from it instead of blindly
- duplicating the texture in memory. This works because the OpenGlContext is
- also shared across a family of RenderEngineGl instances. */
+ duplicating the texture in memory. This works because the cloned OpenGlContext
+ instances share texture objects in GPU memory; the texture ids in this
+ texture library apply equally well to every such OpenGl context. */
 class TextureLibrary {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TextureLibrary);

--- a/geometry/render_gl/test/internal_opengl_context_test.cc
+++ b/geometry/render_gl/test/internal_opengl_context_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/render_gl/internal_opengl_context.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 namespace drake {
@@ -8,23 +10,40 @@ namespace render_gl {
 namespace internal {
 namespace {
 
-// Tests that an OpenGL context can be obtained.
-GTEST_TEST(OpenGlContext, GetContext) {
-  OpenGlContext opengl_context{};
-  EXPECT_FALSE(glIsEnabled(GL_DEBUG_OUTPUT));
-  opengl_context.MakeCurrent();
-  // Test switching contexts and enabling debug mode.
-  OpenGlContext debug_context{true};
-  EXPECT_TRUE(glIsEnabled(GL_DEBUG_OUTPUT));
-  debug_context.MakeCurrent();
-  // Enable something on the current context.
-  EXPECT_FALSE(glIsEnabled(GL_BLEND));
-  glEnable(GL_BLEND);
-  EXPECT_TRUE(glIsEnabled(GL_BLEND));
-  // Back to original context.
-  opengl_context.MakeCurrent();
-  // The previous enable should have no effect on this context.
-  EXPECT_FALSE(glIsEnabled(GL_BLEND));
+// Tests the context binding APIs: IsCurrent(), MakeCurrent(), and
+// ClearCurrent().
+//
+//   - A created context isn't bound.
+//   - IsCurrent() correctly reports a context's status *for the current
+//     thread*.
+//   - MakeCurrent() binds the current thread.
+//     - Replacing any previously bound context.
+//   - ClearCurrent() clears any bound context.
+GTEST_TEST(OpenGlContextTest, BindingContexts) {
+  const OpenGlContext c1;
+  EXPECT_FALSE(c1.IsCurrent());
+  const OpenGlContext c2;
+  EXPECT_FALSE(c2.IsCurrent());
+
+  // Binding one means it is the only one that reports as bound.
+  c1.MakeCurrent();
+  EXPECT_TRUE(c1.IsCurrent());
+  EXPECT_FALSE(c2.IsCurrent());
+
+  // Binding another replaces the first.
+  c2.MakeCurrent();
+  EXPECT_FALSE(c1.IsCurrent());
+  EXPECT_TRUE(c2.IsCurrent());
+
+  // Calling ClearCurrent() clears them both.
+  OpenGlContext::ClearCurrent();
+  EXPECT_FALSE(c1.IsCurrent());
+  EXPECT_FALSE(c2.IsCurrent());
+
+  // Calling ClearCurrent() with nothing bound has no effect.
+  OpenGlContext::ClearCurrent();
+  EXPECT_FALSE(c1.IsCurrent());
+  EXPECT_FALSE(c2.IsCurrent());
 }
 
 GTEST_TEST(OpenGlContext, WindowVisibility) {
@@ -48,6 +67,79 @@ GTEST_TEST(OpenGlContext, WindowVisibility) {
   // Calling it again doesn't have any effect.
   opengl_context.HideWindow();
   EXPECT_FALSE(opengl_context.IsWindowViewable());
+}
+
+// Confirm that a context clone shares objects with its source.
+GTEST_TEST(OpenGlContextTest, CloneShares) {
+  const OpenGlContext source;
+  source.MakeCurrent();
+
+  // Create a buffer in source's context.
+  GLuint buffer;
+  glCreateFramebuffers(1, &buffer);
+  ASSERT_TRUE(glIsFramebuffer(buffer));
+  // Reject the null hypothesis -- not everything is a frame buffer.
+  ASSERT_FALSE(glIsFramebuffer(buffer + 1));
+
+  // Clone shares the frame buffer.
+  const OpenGlContext clone(source);
+  clone.MakeCurrent();
+  // It's still a frame buffer for the clone of the source context.
+  EXPECT_TRUE(glIsFramebuffer(buffer));
+
+  // However, a newly created OpenGlContext does *not* have the frame buffer.
+  const OpenGlContext independent;
+  independent.MakeCurrent();
+  ASSERT_FALSE(glIsFramebuffer(buffer));
+}
+
+GTEST_TEST(OpenGlContextTest, SourceSurvivesCloneDeath) {
+  const OpenGlContext source;
+  source.MakeCurrent();
+
+  // Create a buffer in source's context.
+  GLuint buffer;
+  glCreateFramebuffers(1, &buffer);
+
+  {
+    // Create and destroy the clone; the source isn't harmed.
+    const OpenGlContext clone(source);
+    clone.MakeCurrent();
+    // It's still a frame buffer with the clone of the source context.
+    ASSERT_TRUE(glIsFramebuffer(buffer));
+    // We'll destroy this context as we leave. Making sure the context isn't
+    // bound when the destructor is called will lead to its immediate
+    // destruction.
+    OpenGlContext::ClearCurrent();
+  }
+
+  // Even after the destruction of the sharing context, the buffer still exists
+  // in the original.
+  source.MakeCurrent();
+  ASSERT_TRUE(glIsFramebuffer(buffer));
+}
+
+GTEST_TEST(OpenGlContextTest, CloneSurvivesSourceDeath) {
+  // This will get defined from a source that gets destroyed.
+  std::unique_ptr<OpenGlContext> clone = nullptr;
+  GLuint buffer;
+
+  {
+    const OpenGlContext source;
+    source.MakeCurrent();
+
+    // Create a buffer in source's context.
+    glCreateFramebuffers(1, &buffer);
+
+    clone = std::make_unique<OpenGlContext>(source);
+
+    // Make sure the source isn't bound so its OpenGl objects get destroyed
+    // immediately.
+    OpenGlContext::ClearCurrent();
+  }
+
+  clone->MakeCurrent();
+  ASSERT_TRUE(glIsFramebuffer(buffer));
 }
 
 }  // namespace

--- a/geometry/render_gl/test/multithread_safety_test.cc
+++ b/geometry/render_gl/test/multithread_safety_test.cc
@@ -1,14 +1,25 @@
+#include <filesystem>
 #include <future>
 #include <optional>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
 #include "drake/common/ssize.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/text_logging.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/geometry_roles.h"
+#include "drake/geometry/render/render_label.h"
+#include "drake/geometry/render_gl/factory.h"
+#include "drake/geometry/render_gl/internal_opengl_context.h"
 #include "drake/geometry/render_gl/internal_texture_library.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/systems/sensors/image.h"
+#include "drake/systems/sensors/image_writer.h"
 
 namespace drake {
 namespace geometry {
@@ -27,11 +38,32 @@ class TextureLibraryTester {
 
 namespace {
 
+namespace fs = std::filesystem;
+
+using Eigen::AngleAxisd;
+using Eigen::Vector3d;
+using math::RigidTransformd;
+using math::RotationMatrixd;
+using render::ClippingRange;
+using render::ColorRenderCamera;
+using render::RenderCameraCore;
+using render::RenderEngine;
+using render_gl::internal::OpenGlContext;
 using render_gl::internal::TextureLibrary;
 using render_gl::internal::TextureLibraryTester;
+using systems::sensors::CameraInfo;
+using systems::sensors::ImageRgba8U;
+using systems::sensors::SaveToPng;
 
 /* We should be able to safely call GetTextureId in multiple threads. */
 GTEST_TEST(ThreadSafetyTest, TextureLibrary) {
+  constexpr int kNumThreads = 3;
+  /* TextureLibrary requires an OpenGlContext to be bound in each thread we
+   call GetTextureId(). So, we'll create one per thread. Each is a copy of a
+   single source context so they share GPU memory. */
+  OpenGlContext source;
+  std::vector<OpenGlContext> contexts(kNumThreads, source);
+
   TextureLibrary library;
   ASSERT_EQ(TextureLibraryTester::NumTextures(library), 0);
 
@@ -39,8 +71,9 @@ GTEST_TEST(ThreadSafetyTest, TextureLibrary) {
       FindResourceOrThrow("drake/geometry/render/test/meshes/box.png");
 
   std::atomic<int> num_errors{0};
-  auto work = [&library, &image_name, &num_errors] (int i) {
+  auto work = [&library, &image_name, &num_errors, &contexts] (int i) {
     try {
+      contexts[i].MakeCurrent();
       std::optional<GLuint> id = library.GetTextureId(image_name);
       if (!id.has_value()) {
         throw std::runtime_error("no valid texture id returned.");
@@ -52,9 +85,9 @@ GTEST_TEST(ThreadSafetyTest, TextureLibrary) {
   };
 
   std::vector<std::future<void>> futures;
-  futures.push_back(std::async(std::launch::async, work, 0));
-  futures.push_back(std::async(std::launch::async, work, 1));
-  futures.push_back(std::async(std::launch::async, work, 2));
+  for (int i = 0; i < kNumThreads; ++i) {
+    futures.push_back(std::async(std::launch::async, work, i));
+  }
 
   for (auto& future : futures) {
     future.get();
@@ -64,6 +97,267 @@ GTEST_TEST(ThreadSafetyTest, TextureLibrary) {
   ASSERT_EQ(num_errors, 0);
   /* There is still only a single texture in the library. */
   EXPECT_EQ(TextureLibraryTester::NumTextures(library), 1);
+}
+
+/* Tests two properties regarding OpenGlContexts and threads:
+ - A context bound in one thread cannot be bound in another (see `source`
+   below).
+ - Cloned contexts created in one thread can be bound in other threads, even
+   even if the original context is bound in a different thread. */
+GTEST_TEST(ThreadSafetyTest, OpenGlContext) {
+  std::vector<OpenGlContext> contexts;
+  /* The first is the "source" and we'll add two that are clones of it. */
+  contexts.emplace_back(false /* debug */);
+  contexts.emplace_back(contexts.front());
+  contexts.emplace_back(contexts.front());
+  const OpenGlContext& source = contexts.front();
+
+  /* We can bind the source in the main thread, no problem. */
+  ASSERT_NO_THROW(source.MakeCurrent());
+  ASSERT_TRUE(source.IsCurrent());
+
+  std::atomic<int> num_errors{0};
+  auto work = [&num_errors, &contexts](int i) {
+    try {
+      const OpenGlContext& context = contexts.at(i);
+      context.MakeCurrent();
+      if (i == 0) {
+        /* Successfully binding contexts[0] (aka source) *should've* been an
+         error. However, we are subject to an external library implementation
+         and we have observed that not all implementations are equally
+         compliant. For now we'll document the aberrant behavior, but not
+         trigger test failure -- as one of the aberrant sites is in CI. */
+        log()->warn(
+            "Worker 0 should not be able to bind the source context in a "
+            "worker thread. This indicates a deficiency in the underlying "
+            "libGL implementation from your operating system.");
+      }
+      /* We assume that if we get here context.IsCurrent() reports true. */
+    } catch (std::exception& e) {
+      /* We expect a single exception as evidence of correctness: 0 can't make
+       context current. In every other thread, record an error. */
+      if (i != 0) {
+        log()->error("Worker {} exception: {}", i, e.what());
+        ++num_errors;
+      }
+    }
+  };
+
+  std::vector<std::future<void>> futures;
+  /* Worker 0 will attempt to erroneously rebind `source`. */
+  futures.push_back(std::async(std::launch::async, work, 0));
+  futures.push_back(std::async(std::launch::async, work, 1));
+  futures.push_back(std::async(std::launch::async, work, 2));
+
+  for (auto& future : futures) {
+    future.get();
+  }
+
+  ASSERT_EQ(num_errors, 0);
+}
+
+/* Helper for variant resolution. */
+template<class... Ts>
+struct overloaded : Ts... { using Ts::operator()...; };
+// explicit deduction guide (not needed as of C++20)
+template<class... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
+
+/* Adds the given `shape` as an *anchored* geometry to the given `engine` at the
+ given position `p_WS` with the given `diffuse` definition. */
+void AddShape(const Shape& shape, const Vector3d& p_WS,
+              std::variant<Rgba, std::string> diffuse, RenderEngine* engine) {
+  PerceptionProperties material;
+  material.AddProperty("label", "id", render::RenderLabel::kDontCare);
+  std::visit(overloaded{[&material](const Rgba& rgba) {
+                          material.AddProperty("phong", "diffuse", rgba);
+                        },
+                        [&material](const std::string& diffuse_map) {
+                          material.AddProperty("phong", "diffuse_map",
+                                               diffuse_map);
+                        }},
+             diffuse);
+  engine->RegisterVisual(GeometryId::get_new_id(), shape, material,
+                         math::RigidTransformd(p_WS), false /* needs update */);
+}
+
+/* We use Vector4<int> to compare the pixel values in an image with an expected
+ Rgba value - should be vector of four ints in the range 0-255.
+ Note: we use int instead of ImageRgba8U::T because CompareMatrices below is
+ happier with signed ints than unsigned ints (specifically with focal+clang). */
+Vector4<int> RgbaVector(const Rgba& rgba) {
+  return rgba.rgba().unaryExpr([](double c) {
+    return static_cast<int>(c * 255 + 0.5);
+  });
+}
+
+Vector4<int> RgbaVector(const ImageRgba8U::T* data) {
+  return Vector4<int>(data[0], data[1], data[2], data[3]);
+}
+
+// TODO(SeanCurtis-TRI): This test subsumes the test in thread_test.cc (almost).
+// It should be expanded to include the AsyncMode features of that test and then
+// thread_test.cc can be removed.
+
+/* RenderEngineGl has to handle its OpenGlContext correctly to benefit from
+ the context's thread-independence and OpenGL object sharing. It does some extra
+ clean up work.
+
+ This test confirms that clones of RenderEngineGl do enough clean up. We
+ assume that creating RenderEngineGl instances from scratch must create
+ OpenGlContexts from scratch as well, so we don't explicitly test it.
+
+ The independence is tested similarly to the OpenGlContext above; one instance
+ is bound in the main thread. Its clones should be functional in their own
+ threads.
+
+ The scene is composed of multiple shape types (to make sure that what is
+ claimed to be shared *is* shared and what needs to be patched after cloning
+ is patched). One of the shapes will be textured to show that textures survive
+ cloning as well.
+
+      ┌───────────────────────┐
+      │                       │
+      │          Cyl          │  - Red half space filling the background.
+      │                       │  - Blue cylinder at 12 o'clock.
+      │     Sph       Box     │  - Green (via texture) box at 3 o'clock.
+      │                       │  - Yellow capsule at 6 o'clock.
+      │          Cap          │  - Orange sphere at 9 o'clock.
+      │                       │
+      └───────────────────────┘
+
+ N.B. If you set `show_window` to true in the camera settings, the camera will
+ be flipped vertically (the cylinder and capsule will change positions). This
+ is a documented property of how `show_window` works with RenderEngineGl (see
+ render_gl/factory.h).
+
+ To test the correctness of the rendered image, we'll sample the color on
+ each shape. The rendered images are saved to the test outputs.
+
+ What this doesn't test:
+
+   - Depth and label images. We assume that if the two color shaders get
+     handled properly during the clone, then the depth and label shader programs
+     do as well.
+   - Dynamic geometry. All of the geometries used are registered as *anchored*
+     for convenience (we can pose them when adding them). The logic for posing
+     the dynamic geometries doesn't depend on the OpenGlContext, so other tests
+     on correct posing of dynamic geometries are sufficient. */
+GTEST_TEST(ThreadSafetyTest, RenderEngineGl) {
+  std::unique_ptr<RenderEngine> source = MakeRenderEngineGl();
+
+  const Rgba red(1, 0, 0);
+  const Rgba blue(0, 0, 1);
+  const Rgba orange(1, 0.5, 0);
+  // The green of the texture box.png.
+  const Rgba green(4 / 255.0, 241 / 255.0, 33 / 255.0);
+  const Rgba yellow(1, 1, 0);
+
+  /* Background. */
+  AddShape(HalfSpace(), Vector3d(0, 0, -0.25), red, source.get());
+  /* 12 o'clock. */
+  AddShape(Cylinder(0.25, 0.25), Vector3d(0, 0.5, 0), blue, source.get());
+  /* 3 o'clock. */
+  AddShape(Box(0.5, 0.5, 0.5), Vector3d(0.5, 0, 0),
+           FindResourceOrThrow("drake/geometry/render/test/meshes/box.png"),
+           source.get());
+  /* 6 o'clock. */
+  AddShape(Capsule(0.25, 0.25), Vector3d(0, -0.5, 0), yellow, source.get());
+  /* 9 o'clock. */
+  AddShape(Sphere(0.25), Vector3d(-0.5, 0, 0), orange, source.get());
+
+  /* Pose of camera body in the world: Looking straight down from 3m above the
+   ground. Wy and Wx point to the top and right of the image, respectively. */
+  const RigidTransformd X_WC(
+      RotationMatrixd{AngleAxisd(M_PI, Vector3d::UnitY()) *
+                      AngleAxisd(M_PI, Vector3d::UnitZ())},
+      {0, 0, 3});
+  source->UpdateViewpoint(X_WC);
+
+  /* Create the clones. */
+  constexpr int kCloneCount = 3;
+  std::vector<std::unique_ptr<RenderEngine>> renderers;
+  for (int i = 0; i < kCloneCount; ++i) {
+    renderers.push_back(source->Clone());
+    renderers.back()->UpdateViewpoint(X_WC);
+  }
+
+  /* Create some renderings. */
+  const ColorRenderCamera camera(RenderCameraCore(
+      "color", CameraInfo(640, 480, M_PI_4), ClippingRange(0.01, 100.0), {}));
+
+  /* Sample the image at known locations to see if we have the expected colors.
+   */
+  auto check_image = [w = camera.core().intrinsics().width(),
+                      h = camera.core().intrinsics().height(), red, blue,
+                      orange, green, yellow](const ImageRgba8U& image) {
+    /* For the cylinder and box, the camera-facing face is big and flat and we
+     can sample the image in a large area and get the expected material color.
+     For the sphere and the capsule (orange and yellow, respectively), we
+     need to be more precise. */
+
+    // clang-format off
+    EXPECT_TRUE(CompareMatrices(RgbaVector(image.at(w / 2, h / 2)),
+                                RgbaVector(red), 1)) << "Half space";
+    EXPECT_TRUE(CompareMatrices(RgbaVector(image.at(w / 2, h / 4)),
+                                RgbaVector(blue), 1)) << "Cylinder";
+    EXPECT_TRUE(CompareMatrices(RgbaVector(image.at(w * 0.625, h / 2)),
+                                RgbaVector(green), 1)) << "Box";
+    EXPECT_TRUE(CompareMatrices(RgbaVector(image.at(w / 2, h * 0.73)),
+                                RgbaVector(yellow), 1)) << "Capsule";
+    EXPECT_TRUE(CompareMatrices(RgbaVector(image.at(w * 0.334, h / 2)),
+                                RgbaVector(orange), 1)) << "Sphere";
+    // clang-format on
+  };
+
+  /* Render from the main thread with the source engine; this should bind its
+   OpenGl context to the main thread. If any of the clones shared contexts
+   with it, they should be unable to bind their contexts in *other* threads. */
+  ImageRgba8U source_image(camera.core().intrinsics().width(),
+                           camera.core().intrinsics().height());
+  ASSERT_NO_THROW(source->RenderColorImage(camera, &source_image));
+  check_image(source_image);
+  if (const char* dir = std::getenv("TEST_UNDECLARED_OUTPUTS_DIR")) {
+    SaveToPng(source_image, fs::path(dir) / "source.png");
+  }
+
+  /* The multi-threaded work function; render and check the image. */
+  std::atomic<int> num_errors{0};
+  auto work = [&num_errors, &renderers, &check_image, &camera](int i) {
+    try {
+      RenderEngine& renderer = *renderers.at(i);
+      ImageRgba8U image(camera.core().intrinsics().width(),
+                        camera.core().intrinsics().height());
+      try {
+        renderer.RenderColorImage(camera, &image);
+      } catch (std::exception& e) {
+        log()->error("Worker {} render error: {}", i, e.what());
+        ++num_errors;
+        return;
+      }
+      /* The image actually rendered, test the contents. */
+      SCOPED_TRACE(fmt::format("Worker {}", i));
+      check_image(image);
+      if (const char* dir = std::getenv("TEST_UNDECLARED_OUTPUTS_DIR")) {
+        SaveToPng(image, fs::path(dir) / fmt::format("worker{}.png", i));
+      }
+    } catch (std::exception& e) {
+      ++num_errors;
+      log()->error("Unexpected non-rendering error for worker {}: {}", i,
+                   e.what());
+    }
+  };
+
+  std::vector<std::future<void>> futures;
+  for (int i = 0; i < kCloneCount; ++i) {
+    futures.push_back(std::async(std::launch::async, work, i));
+  }
+
+  for (auto& future : futures) {
+    future.get();
+  }
+
+  ASSERT_EQ(num_errors, 0);
 }
 
 }  // namespace


### PR DESCRIPTION
This allows a single RenderEngineGL to be cloned so that each clone can safely be used in different threads.

1. The OpenGlContext for each RenderEngineGl is thread-independent; binding one in one thread, doesn't preclude binding another in another thread.
2. OpenGlContexts that get cloned from each other share the same OpenGl artifacts (display lists, etc.) on the GPU.

Introduces a unit test that failed under the old non-threadsafe regime.

TODO:
 - Delete thread_test_2.cc
 - Change OpenGlContext so the test passes.
 - Chnage the test to make sure OpenGlContext can be tested directly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19426)
<!-- Reviewable:end -->
