### PR TITLE
[planning] Removed unnecessary variables in constraints

### DIFF
--- a/planning/trajectory_optimization/gcs_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.cc
@@ -1,6 +1,7 @@
 #include "drake/planning/trajectory_optimization/gcs_trajectory_optimization.h"
 
 #include <limits>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -30,6 +31,7 @@ using geometry::optimization::GraphOfConvexSetsOptions;
 using geometry::optimization::HPolyhedron;
 using geometry::optimization::Point;
 using solvers::Binding;
+using solvers::ConcatenateVariableRefList;
 using solvers::Constraint;
 using solvers::Cost;
 using solvers::L2NormCost;
@@ -49,6 +51,60 @@ using VertexId = GraphOfConvexSets::VertexId;
 using EdgeId = GraphOfConvexSets::EdgeId;
 
 const double kInf = std::numeric_limits<double>::infinity();
+
+namespace {
+using VectorXb = Eigen::Matrix<bool, 1, Eigen::Dynamic>;
+
+// Given a list of matrices, return the matrices with every column where all
+// of the matrices are zero in that column, along with a boolean vector
+// indicating which columns were preserved (true) or removed (false).
+std::tuple<std::vector<MatrixXd>, VectorXb> CondenseToNonzeroColumns(
+    std::vector<MatrixXd> matrices) {
+  // Validate inputs.
+  DRAKE_DEMAND(matrices.size() > 0);
+  const int num_cols = matrices[0].cols();
+  for (const MatrixXd& matrix : matrices) {
+    DRAKE_DEMAND(matrix.cols() == num_cols);
+  }
+
+  // Find non-zero columns.
+  VectorXb nonzero_cols_mask = VectorXb::Constant(num_cols, false);
+  for (const MatrixXd& matrix : matrices) {
+    nonzero_cols_mask += matrix.cast<bool>().colwise().any();
+  }
+  const int nonzero_cols_count = nonzero_cols_mask.count();
+
+  // Create the output, copying only the non-zero columns.
+  std::vector<MatrixXd> condensed_matrices;
+  for (const MatrixXd& matrix : matrices) {
+    MatrixXd& condensed_matrix =
+        condensed_matrices.emplace_back(matrix.rows(), nonzero_cols_count);
+    int condensed_col = 0;
+    for (int orig_col = 0; orig_col < matrix.cols(); ++orig_col) {
+      if (nonzero_cols_mask(orig_col)) {
+        condensed_matrix.col(condensed_col) = matrix.col(orig_col);
+        condensed_col++;
+      }
+    }
+  }
+  return std::make_tuple(condensed_matrices, nonzero_cols_mask);
+}
+
+// Filters variables given a vector of variables along with a boolean vector
+// indicating which rows were preserved (true) or removed (false).
+VectorX<symbolic::Variable> FilterVariables(
+    const VectorX<symbolic::Variable>& vars,
+    const VectorXb& nonzero_cols_mask) {
+  VectorX<symbolic::Variable> vars_dense(nonzero_cols_mask.count());
+  int row = 0;
+  for (int i = 0; i < vars.size(); ++i) {
+    if (nonzero_cols_mask(i)) {
+      vars_dense(row++) = vars(i);
+    }
+  }
+  return vars_dense;
+}
+}  // namespace
 
 Subgraph::Subgraph(
     const ConvexSets& regions,
@@ -109,12 +165,14 @@ Subgraph::Subgraph(
       u_r_trajectory_.control_points().col(order);
   MatrixXd M(num_positions(), edge_vars.size());
   DecomposeLinearExpressions(path_continuity_error, edge_vars, &M);
-  // TODO(wrangelvid) The matrix M might be sparse, so we could drop columns
-  // here.
+  // Condense M to only keep non-zero columns.
+  const auto& [condensed_matrices, nonzero_cols_mask] =
+      CondenseToNonzeroColumns({M});
+  MatrixXd M_dense = condensed_matrices[0];
 
   const auto path_continuity_constraint =
       std::make_shared<LinearEqualityConstraint>(
-          M, VectorXd::Zero(num_positions()));
+          M_dense, VectorXd::Zero(num_positions()));
 
   // Add Regions with time scaling set.
   for (size_t i = 0; i < regions_.size(); ++i) {
@@ -142,8 +200,10 @@ Subgraph::Subgraph(
     edges_.emplace_back(uv_edge);
 
     // Add path continuity constraints.
-    uv_edge->AddConstraint(
-        Binding<Constraint>(path_continuity_constraint, {u.x(), v.x()}));
+    uv_edge->AddConstraint(Binding<Constraint>(
+        path_continuity_constraint,
+        FilterVariables(ConcatenateVariableRefList({u.x(), v.x()}),
+                        nonzero_cols_mask)));
   }
 }
 
@@ -187,15 +247,18 @@ void Subgraph::AddPathLengthCost(const MatrixXd& weight_matrix) {
   for (int i = 0; i < u_rdot_control.cols(); ++i) {
     MatrixXd M(num_positions(), u_vars_.size());
     DecomposeLinearExpressions(u_rdot_control.col(i) / order(), u_vars_, &M);
-    // TODO(wrangelvid) The matrix M might be sparse, so we could drop columns
-    // here.
+    // Condense M to only keep non-zero columns.
+    const auto& [condensed_matrices, nonzero_cols_mask] =
+        CondenseToNonzeroColumns({M});
+    MatrixXd M_dense = condensed_matrices[0];
 
     const auto path_length_cost = std::make_shared<L2NormCost>(
-        weight_matrix * M, VectorXd::Zero(num_positions()));
+        weight_matrix * M_dense, VectorXd::Zero(num_positions()));
 
     for (Vertex* v : vertices_) {
       // The duration variable is the last element of the vertex.
-      v->AddCost(Binding<L2NormCost>(path_length_cost, v->x()));
+      v->AddCost(Binding<L2NormCost>(
+          path_length_cost, FilterVariables(v->x(), nonzero_cols_mask)));
     }
   }
 }
@@ -236,18 +299,22 @@ void Subgraph::AddVelocityBounds(const Eigen::Ref<const VectorXd>& lb,
   for (int i = 0; i < u_rdot_control.cols(); ++i) {
     MatrixXd M(num_positions(), u_vars_.size());
     DecomposeLinearExpressions(u_rdot_control.col(i), u_vars_, &M);
-    // TODO(wrangelvid) The matrix M might be sparse, so we could drop columns
-    // for both M and b here.
+    // Condense M and b to only keep non-zero columns.
+    const auto& [condensed_matrices, nonzero_cols_mask] =
+        CondenseToNonzeroColumns({M, b});
+    MatrixXd M_dense = condensed_matrices[0];
+    MatrixXd b_dense = condensed_matrices[1];
 
-    MatrixXd H(2 * num_positions(), M.cols());
-    H << M - ub * b, -M + lb * b;
+    MatrixXd H(2 * num_positions(), nonzero_cols_mask.count());
+    H << M_dense - ub * b_dense, -M_dense + lb * b_dense;
 
     const auto velocity_constraint = std::make_shared<LinearConstraint>(
         H, VectorXd::Constant(2 * num_positions(), -kInf),
         VectorXd::Zero(2 * num_positions()));
 
     for (Vertex* v : vertices_) {
-      v->AddConstraint(Binding<LinearConstraint>(velocity_constraint, v->x()));
+      v->AddConstraint(Binding<LinearConstraint>(
+          velocity_constraint, FilterVariables(v->x(), nonzero_cols_mask)));
     }
   }
 }
@@ -308,12 +375,14 @@ EdgesBetweenSubgraphs::EdgesBetweenSubgraphs(
       u_r_trajectory_.control_points().col(from_subgraph.order());
   MatrixXd M(num_positions(), edge_vars.size());
   DecomposeLinearExpressions(path_continuity_error, edge_vars, &M);
-  // TODO(wrangelvid) The matrix M might be sparse, so we could drop columns
-  // here.
+  // Condense M to only keep non-zero columns.
+  const auto& [condensed_matrices, nonzero_cols_mask] =
+      CondenseToNonzeroColumns({M});
+  MatrixXd M_dense = condensed_matrices[0];
 
   const auto path_continuity_constraint =
       std::make_shared<LinearEqualityConstraint>(
-          M, VectorXd::Zero(num_positions()));
+          M_dense, VectorXd::Zero(num_positions()));
 
   // TODO(wrangelvid) this can be parallelized.
   for (int i = 0; i < from_subgraph.size(); ++i) {
@@ -337,7 +406,9 @@ EdgesBetweenSubgraphs::EdgesBetweenSubgraphs(
 
         // Add path continuity constraints.
         uv_edge->AddConstraint(Binding<LinearEqualityConstraint>(
-            path_continuity_constraint, {u.x(), v.x()}));
+            path_continuity_constraint,
+            FilterVariables(ConcatenateVariableRefList({u.x(), v.x()}),
+                            nonzero_cols_mask)));
 
         if (subspace != nullptr) {
           // Add subspace constraints to the first control point of the v
@@ -420,10 +491,14 @@ void EdgesBetweenSubgraphs::AddVelocityBounds(
     MatrixXd M(num_positions(), u_vars_.size());
     DecomposeLinearExpressions(u_rdot_control.col(u_rdot_control.cols() - 1),
                                u_vars_, &M);
-    // TODO(wrangelvid) The matrix M might be sparse, so we could drop columns
-    // for both M and b here.
-    MatrixXd H(2 * num_positions(), M.cols());
-    H << M - ub * b, -M + lb * b;
+    // Condense M and b to only keep non-zero columns.
+    const auto& [condensed_matrices, nonzero_cols_mask] =
+        CondenseToNonzeroColumns({M, b});
+    MatrixXd M_dense = condensed_matrices[0];
+    MatrixXd b_dense = condensed_matrices[1];
+
+    MatrixXd H(2 * num_positions(), nonzero_cols_mask.count());
+    H << M_dense - ub * b_dense, -M_dense + lb * b_dense;
 
     const auto last_ctrl_pt_velocity_constraint =
         std::make_shared<LinearConstraint>(
@@ -432,7 +507,8 @@ void EdgesBetweenSubgraphs::AddVelocityBounds(
 
     for (Edge* edge : edges_) {
       edge->AddConstraint(Binding<LinearConstraint>(
-          last_ctrl_pt_velocity_constraint, edge->xu()));
+          last_ctrl_pt_velocity_constraint,
+          FilterVariables(edge->xu(), nonzero_cols_mask)));
     }
   }
 
@@ -449,11 +525,14 @@ void EdgesBetweenSubgraphs::AddVelocityBounds(
     // First control point velocity constraint.
     MatrixXd M(num_positions(), v_vars_.size());
     DecomposeLinearExpressions(v_rdot_control.col(0), v_vars_, &M);
-    // TODO(wrangelvid) The matrix M might be sparse, so we could drop columns
-    // for both M and b here.
+    // Condense M and b to only keep non-zero columns.
+    const auto& [condensed_matrices, nonzero_cols_mask] =
+        CondenseToNonzeroColumns({M, b});
+    MatrixXd M_dense = condensed_matrices[0];
+    MatrixXd b_dense = condensed_matrices[1];
 
-    MatrixXd H(2 * num_positions(), M.cols());
-    H << M - ub * b, -M + lb * b;
+    MatrixXd H(2 * num_positions(), nonzero_cols_mask.count());
+    H << M_dense - ub * b_dense, -M_dense + lb * b_dense;
 
     const auto first_ctrl_pt_velocity_constraint =
         std::make_shared<LinearConstraint>(
@@ -462,7 +541,8 @@ void EdgesBetweenSubgraphs::AddVelocityBounds(
 
     for (Edge* edge : edges_) {
       edge->AddConstraint(Binding<LinearConstraint>(
-          first_ctrl_pt_velocity_constraint, edge->xv()));
+          first_ctrl_pt_velocity_constraint,
+          FilterVariables(edge->xv(), nonzero_cols_mask)));
     }
   }
 }
@@ -725,6 +805,35 @@ GcsTrajectoryOptimization::SolvePath(const Subgraph& source,
 
 Edge* GcsTrajectoryOptimization::AddEdge(const Vertex& u, const Vertex& v) {
   return gcs_.AddEdge(u, v, fmt::format("{} -> {}", u.name(), v.name()));
+}
+
+double GcsTrajectoryOptimization::EstimateComplexity() const {
+  double result = 0;
+  // TODO(ggould) A more correct computation estimate would be:
+  // If each vertex and edge problem were solved only once, the cost would be
+  // | constraint_var_sum = variables per constraint summed over constraints
+  // | cost_vars = total unique variables over all costs
+  // | constraint_vars = total unique variables over all constraints
+  // : constraint_var_sum * cost_vars * constraint_vars^2
+  // In fact each vertex must be solved at least as many times as it has
+  // edges, so multiply the vertex cost by the vertex's arity.
+  for (const auto* v : gcs_.Vertices()) {
+    for (const auto& c : v->GetCosts()) {
+      result += c.GetNumElements();
+    }
+    for (const auto& c : v->GetConstraints()) {
+      result += c.GetNumElements();
+    }
+  }
+  for (const auto* e : gcs_.Edges()) {
+    for (const auto& c : e->GetCosts()) {
+      result += c.GetNumElements();
+    }
+    for (const auto& c : e->GetConstraints()) {
+      result += c.GetNumElements();
+    }
+  }
+  return result;
 }
 
 }  // namespace trajectory_optimization

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -384,6 +384,12 @@ class GcsTrajectoryOptimization final {
       const Subgraph& source, const Subgraph& target,
       const geometry::optimization::GraphOfConvexSetsOptions& options = {});
 
+  /** Provide a heuristic estimate of the complexity of the underlying
+  GCS mathematical program, for regression testing purposes.
+  Here we sum the total number of variable appearances in our costs and
+  constraints as a rough approximation of the complexity of the subproblems. */
+  double EstimateComplexity() const;
+
  private:
   const int num_positions_;
 

--- a/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
@@ -119,6 +119,9 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, MinimumTimeVsPathLength) {
   // Add shortest path objective to compare against the minimum time objective.
   gcs.AddPathLengthCost();
 
+  // Nonregression bound on the complexity of the underlying GCS MICP.
+  EXPECT_LT(gcs.EstimateComplexity(), 1.5e2);
+
   if (!GurobiOrMosekSolverAvailable()) {
     return;
   }
@@ -268,6 +271,9 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, VelocityBoundsOnEdges) {
 
   // Bob wants to beat the time record!
   gcs.AddTimeCost();
+
+  // Nonregression bound on the complexity of the underlying GCS MICP.
+  EXPECT_LT(gcs.EstimateComplexity(), 1e2);
 
   if (!GurobiOrMosekSolverAvailable()) {
     return;
@@ -600,6 +606,9 @@ TEST_F(SimpleEnv2D, BasicShortestPath) {
 
   gcs.AddPathLengthCost();
 
+  // Nonregression bound on the complexity of the underlying GCS MICP.
+  EXPECT_LT(gcs.EstimateComplexity(), 1e3);
+
   if (!GurobiOrMosekSolverAvailable()) {
     return;
   }
@@ -641,6 +650,9 @@ TEST_F(SimpleEnv2D, DurationDelay) {
 
   gcs.AddEdges(source, regions);
   gcs.AddEdges(regions, target);
+
+  // Nonregression bound on the complexity of the underlying GCS MICP.
+  EXPECT_LT(gcs.EstimateComplexity(), 1e3);
 
   if (!GurobiOrMosekSolverAvailable()) {
     return;
@@ -724,6 +736,9 @@ TEST_F(SimpleEnv2D, MultiStartGoal) {
 
   gcs.AddPathLengthCost();
   gcs.AddTimeCost();
+
+  // Nonregression bound on the complexity of the underlying GCS MICP.
+  EXPECT_LT(gcs.EstimateComplexity(), 1e3);
 
   if (!GurobiOrMosekSolverAvailable()) {
     return;
@@ -832,6 +847,9 @@ TEST_F(SimpleEnv2D, IntermediatePoint) {
       Eigen::MatrixXd::Identity(gcs.num_positions(), gcs.num_positions());
   weight_matrix(1, 1) = 3.0;
   main2.AddPathLengthCost(weight_matrix);
+
+  // Nonregression bound on the complexity of the underlying GCS MICP.
+  EXPECT_LT(gcs.EstimateComplexity(), 1e3);
 
   if (!GurobiOrMosekSolverAvailable()) {
     return;


### PR DESCRIPTION
Many constraints, like the path continuity constraints or velocity bounds are enforced on just one control point. Thus it's the constraint matrices end up sparse, which can be mitigated by dropping the unnecssary columns and variables in those constraints.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19444)
<!-- Reviewable:end -->
