### PR TITLE
[pydrake] Add binding for LinearComplementarityConstraint M and q.

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -1882,7 +1882,11 @@ void BindEvaluatorsAndBindings(py::module m) {
   py::class_<LinearComplementarityConstraint, Constraint,
       std::shared_ptr<LinearComplementarityConstraint>>(m,
       "LinearComplementarityConstraint",
-      doc.LinearComplementarityConstraint.doc);
+      doc.LinearComplementarityConstraint.doc)
+      .def("M", &LinearComplementarityConstraint::M,
+          doc.LinearComplementarityConstraint.M.doc)
+      .def("q", &LinearComplementarityConstraint::q,
+          doc.LinearComplementarityConstraint.q.doc);
 
   py::class_<ExponentialConeConstraint, Constraint,
       std::shared_ptr<ExponentialConeConstraint>>(

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -834,6 +834,8 @@ class TestMathematicalProgram(unittest.TestCase):
         M = np.array([[1, 3], [4, 1]])
         q = np.array([-16, -15])
         binding = prog.AddLinearComplementarityConstraint(M, q, x)
+        np.testing.assert_equal(binding.evaluator().M(), M)
+        np.testing.assert_equal(binding.evaluator().q(), q)
         self.assertEqual(len(prog.linear_complementarity_constraints()), 1)
         result = mp.Solve(prog)
         self.assertTrue(result.is_success())


### PR DESCRIPTION
Resolves #19290

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19445)
<!-- Reviewable:end -->
