### PR TITLE
Rename SolutionResult::kUnknownError to kSolverSpecificError

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -1564,8 +1564,8 @@ for every column of ``prog_var_vals``. )""")
           doc.SolutionResult.kInfeasibleConstraints.doc)
       .value("kUnbounded", SolutionResult::kUnbounded,
           doc.SolutionResult.kUnbounded.doc)
-      .value("kUnknownError", SolutionResult::kUnknownError,
-          doc.SolutionResult.kUnknownError.doc)
+      .value("kSolverSpecificError", SolutionResult::kSolverSpecificError,
+          doc.SolutionResult.kSolverSpecificError.doc)
       .value("kInfeasibleOrUnbounded", SolutionResult::kInfeasibleOrUnbounded,
           doc.SolutionResult.kInfeasibleOrUnbounded.doc)
       .value("kIterationLimit", SolutionResult::kIterationLimit,

--- a/solvers/branch_and_bound.cc
+++ b/solvers/branch_and_bound.cc
@@ -37,7 +37,7 @@ MixedIntegerBranchAndBoundNode::MixedIntegerBranchAndBoundNode(
       fixed_binary_variable_{},
       fixed_binary_value_{-1},
       remaining_binary_variables_{binary_variables},
-      solution_result_{SolutionResult::kUnknownError},
+      solution_result_{SolutionResult::kSolverSpecificError},
       optimal_solution_is_integral_{OptimalSolutionIsIntegral::kUnknown},
       solver_id_{solver_id} {
   // Check if there are still binary variables.

--- a/solvers/clp_solver.cc
+++ b/solvers/clp_solver.cc
@@ -182,10 +182,10 @@ void SetSolution(
   SetBoundingBoxConstraintDualSolution(column_dual_sol,
                                        bb_con_dual_variable_indices, result);
   solver_details.status = model.status();
-  SolutionResult solution_result{SolutionResult::kUnknownError};
+  SolutionResult solution_result{SolutionResult::kSolverSpecificError};
   switch (solver_details.status) {
     case -1: {
-      solution_result = SolutionResult::kUnknownError;
+      solution_result = SolutionResult::kSolverSpecificError;
       break;
     }
     case 0: {
@@ -206,7 +206,7 @@ void SetSolution(
     }
     default: {
       // Merging multiple CLP status code into one Drake SolutionResult code.
-      solution_result = SolutionResult::kUnknownError;
+      solution_result = SolutionResult::kSolverSpecificError;
     }
   }
   double objective_val{-kInf};

--- a/solvers/csdp_solver.cc
+++ b/solvers/csdp_solver.cc
@@ -58,7 +58,7 @@ SolutionResult ConvertCsdpReturnToSolutionResult(int csdp_ret) {
     case 4:
       return SolutionResult::kIterationLimit;
     default:
-      return SolutionResult::kUnknownError;
+      return SolutionResult::kSolverSpecificError;
   }
 }
 

--- a/solvers/equality_constrained_qp_solver.cc
+++ b/solvers/equality_constrained_qp_solver.cc
@@ -188,7 +188,7 @@ void EqualityConstrainedQPSolver::DoSolve(
   }
 
   Eigen::VectorXd x{};
-  SolutionResult solution_result{SolutionResult::kUnknownError};
+  SolutionResult solution_result{SolutionResult::kSolverSpecificError};
   // lambda stores the dual variable solutions.
   Eigen::VectorXd lambda(num_constraints);
   if (num_constraints > 0) {

--- a/solvers/gurobi_solver.cc
+++ b/solvers/gurobi_solver.cc
@@ -1376,7 +1376,7 @@ void GurobiSolver::DoSolve(const MathematicalProgram& prog,
     }
   }
 
-  SolutionResult solution_result = SolutionResult::kUnknownError;
+  SolutionResult solution_result = SolutionResult::kSolverSpecificError;
 
   GurobiSolverDetails& solver_details =
       result->SetSolverDetailsType<GurobiSolverDetails>();

--- a/solvers/ipopt_solver.cc
+++ b/solvers/ipopt_solver.cc
@@ -619,7 +619,7 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
     SetAllConstraintDualSolution(*problem_, solver_details.lambda,
                                  constraint_dual_start_index_, result_);
 
-    result_->set_solution_result(SolutionResult::kUnknownError);
+    result_->set_solution_result(SolutionResult::kSolverSpecificError);
     switch (status) {
       case Ipopt::SUCCESS: {
         result_->set_solution_result(SolutionResult::kSolutionFound);
@@ -649,7 +649,7 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
         break;
       }
       default: {
-        result_->set_solution_result(SolutionResult::kUnknownError);
+        result_->set_solution_result(SolutionResult::kSolverSpecificError);
         break;
       }
     }

--- a/solvers/mathematical_program_result.cc
+++ b/solvers/mathematical_program_result.cc
@@ -15,7 +15,7 @@ SolverId UnknownId() {
 
 MathematicalProgramResult::MathematicalProgramResult()
     : decision_variable_index_{},
-      solution_result_{SolutionResult::kUnknownError},
+      solution_result_{SolutionResult::kSolverSpecificError},
       x_val_{0},
       optimal_cost_{NAN},
       solver_id_{UnknownId()},

--- a/solvers/moby_lcp_solver.cc
+++ b/solvers/moby_lcp_solver.cc
@@ -203,7 +203,7 @@ void MobyLCPSolver<T>::DoSolve(const MathematicalProgram& prog,
     bool solved = SolveLcpLemkeRegularized(constraint->M(), constraint->q(),
                                            &constraint_solution);
     if (!solved) {
-      result->set_solution_result(SolutionResult::kUnknownError);
+      result->set_solution_result(SolutionResult::kSolverSpecificError);
       return;
     }
     for (int i = 0; i < binding.evaluator()->num_vars(); ++i) {

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -247,7 +247,7 @@ void MosekSolver::DoSolve(const MathematicalProgram& prog,
     }
   }
 
-  result->set_solution_result(SolutionResult::kUnknownError);
+  result->set_solution_result(SolutionResult::kSolverSpecificError);
   // Run optimizer.
   if (rescode == MSK_RES_OK) {
     // TODO(hongkai.dai@tri.global): add trmcode to the returned struct.
@@ -288,7 +288,7 @@ void MosekSolver::DoSolve(const MathematicalProgram& prog,
         break;
       }
       default: {
-        result->set_solution_result(SolutionResult::kUnknownError);
+        result->set_solution_result(SolutionResult::kSolverSpecificError);
         break;
       }
     }

--- a/solvers/nlopt_solver.cc
+++ b/solvers/nlopt_solver.cc
@@ -517,29 +517,29 @@ void NloptSolver::DoSolve(const MathematicalProgram& prog,
           result->set_solution_result(SolutionResult::kUnbounded);
           minf = -std::numeric_limits<double>::infinity();
         } else {
-          result->set_solution_result(SolutionResult::kUnknownError);
+          result->set_solution_result(SolutionResult::kSolverSpecificError);
         }
         break;
       }
       default: {
-        result->set_solution_result(SolutionResult::kUnknownError);
+        result->set_solution_result(SolutionResult::kSolverSpecificError);
       }
     }
   } catch (std::invalid_argument&) {
     result->set_solution_result(SolutionResult::kInvalidInput);
   } catch (std::bad_alloc&) {
-    result->set_solution_result(SolutionResult::kUnknownError);
+    result->set_solution_result(SolutionResult::kSolverSpecificError);
   } catch (nlopt::roundoff_limited&) {
     if (minf < kUnboundedTol) {
       result->set_solution_result(SolutionResult::kUnbounded);
       minf = MathematicalProgram::kUnboundedCost;
     } else {
-      result->set_solution_result(SolutionResult::kUnknownError);
+      result->set_solution_result(SolutionResult::kSolverSpecificError);
     }
   } catch (nlopt::forced_stop&) {
-    result->set_solution_result(SolutionResult::kUnknownError);
+    result->set_solution_result(SolutionResult::kSolverSpecificError);
   } catch (std::runtime_error&) {
-    result->set_solution_result(SolutionResult::kUnknownError);
+    result->set_solution_result(SolutionResult::kSolverSpecificError);
   }
 
   result->set_optimal_cost(minf);

--- a/solvers/osqp_solver.cc
+++ b/solvers/osqp_solver.cc
@@ -460,7 +460,7 @@ void OsqpSolver::DoSolve(const MathematicalProgram& prog,
         break;
       }
       default: {
-        solution_result = SolutionResult::kUnknownError;
+        solution_result = SolutionResult::kSolverSpecificError;
         break;
       }
     }

--- a/solvers/scs_solver.cc
+++ b/solvers/scs_solver.cc
@@ -1098,7 +1098,7 @@ void ScsSolver::DoSolve(const MathematicalProgram& prog,
   solver_details.scs_setup_time = scs_info.setup_time;
   solver_details.scs_solve_time = scs_info.solve_time;
 
-  SolutionResult solution_result{SolutionResult::kUnknownError};
+  SolutionResult solution_result{SolutionResult::kSolverSpecificError};
   solver_details.y.resize(A_row_count);
   solver_details.s.resize(A_row_count);
   for (int i = 0; i < A_row_count; ++i) {

--- a/solvers/snopt_solver.cc
+++ b/solvers/snopt_solver.cc
@@ -995,7 +995,7 @@ void SetConstraintDualSolutions(
 }
 
 SolutionResult MapSnoptInfoToSolutionResult(int snopt_info) {
-  SolutionResult solution_result{SolutionResult::kUnknownError};
+  SolutionResult solution_result{SolutionResult::kSolverSpecificError};
   // Please refer to User's Guide for SNOPT Versions 7, section 8.6 on the
   // meaning of these snopt_info.
   if (snopt_info >= 1 && snopt_info <= 6) {

--- a/solvers/solution_result.cc
+++ b/solvers/solution_result.cc
@@ -16,8 +16,8 @@ std::string to_string(SolutionResult solution_result) {
       return "InfeasibleOrUnbounded";
     case SolutionResult::kIterationLimit:
       return "IterationLimit";
-    case SolutionResult::kUnknownError:
-      return "UnknownError";
+    case SolutionResult::kSolverSpecificError:
+      return "SolverSpecificError";
     case SolutionResult::kDualInfeasible:
       return "DualInfeasible";
   }

--- a/solvers/solution_result.h
+++ b/solvers/solution_result.h
@@ -12,7 +12,11 @@ enum SolutionResult {
   kInvalidInput = -1,           ///< Invalid input.
   kInfeasibleConstraints = -2,  ///< The primal is infeasible.
   kUnbounded = -3,              ///< The primal is unbounded.
-  kUnknownError = -4,           ///< Unknown error.
+  kUnknownError = -4,  ///< Deprecated name for kSolverSpecificError. This field
+                       ///< will be removed from Drake on or after 2023-09-01.
+  kSolverSpecificError =
+      -4,  ///< Solver-specific error (Try get_solver_details() or enabling
+           ///< verbose solver output)
   kInfeasibleOrUnbounded =
       -5,                ///< The primal is either infeasible or unbounded.
   kIterationLimit = -6,  ///< Reaches the iteration limits.

--- a/solvers/unrevised_lemke_solver.cc
+++ b/solvers/unrevised_lemke_solver.cc
@@ -113,7 +113,7 @@ void UnrevisedLemkeSolver<T>::DoSolve(const MathematicalProgram& prog,
     bool solved = SolveLcpLemke(constraint->M(), constraint->q(),
                                 &constraint_solution, &num_pivots);
     if (!solved) {
-      result->set_solution_result(SolutionResult::kUnknownError);
+      result->set_solution_result(SolutionResult::kSolverSpecificError);
       return;
     }
     for (int i = 0; i < binding.evaluator()->num_vars(); ++i) {


### PR DESCRIPTION
I had a student trip on this; it was incredibly frustrating to be working on a mathematical program only to have the solver apparently return "kUnknownError".  What they needed, instead, was a hint that they should look at the solver details, etc, to figure out the error.

+@hongkai-dai for feature review, please (and confirmation of the renaming idea).

fyi @jwnimmer-tri .  I spent some time trying to deprecate this more properly (both in c++ and python), but I couldn't find any of the proper affordances for deprecating an attribute of an enum.  I'm inclined to just make the breaking change (I suspect that it won't actually break anyone, but of course can't be sure).  wdyt?