### PR TITLE
Implement SapLimitConstraint in terms of new APIs introduced in #19402

### DIFF
--- a/multibody/contact_solvers/sap/BUILD.bazel
+++ b/multibody/contact_solvers/sap/BUILD.bazel
@@ -223,6 +223,7 @@ drake_cc_googletest(
     name = "sap_limit_constraint_test",
     deps = [
         ":sap_limit_constraint",
+        ":validate_constraint_gradients",
         "//common:pointer_cast",
         "//common/test_utilities:eigen_matrix_compare",
     ],

--- a/multibody/contact_solvers/sap/sap_constraint.h
+++ b/multibody/contact_solvers/sap/sap_constraint.h
@@ -251,18 +251,24 @@ class SapConstraint {
    constraints might want to compute commonly occurring terms in the computation
    of the cost, impulses and Hessian into `data` to be reused.
    @pre vc.size() equals num_constraint_equations().
-   @pre data does not equal nullptr. */
+   @pre data does not equal nullptr.
+   @pre data was created via MakeData() on `this` object and therefore the type
+   wrapped by AbstractValue is consistent with the concrete subclass. */
   void CalcData(const Eigen::Ref<const VectorX<T>>& vc,
                 AbstractValue* data) const;
 
   /* Computes the constraint cost ℓ(vc) function of constraint velocities vc.
    @post The cost ℓ(vc) is a convex function of vc, as required by the SAP
-   formulation. */
+   formulation.
+   @pre data was created via MakeData() on `this` object and therefore the type
+   wrapped by AbstractValue is consistent with the concrete subclass. */
   T CalcCost(const AbstractValue& data) const;
 
   /* Computes the impulse according to:
        γ(vc) = −∂ℓ/∂vc.
-   @pre gamma does not equal nullptr. */
+   @pre gamma does not equal nullptr.
+   @pre data was created via MakeData() on `this` object and therefore the type
+   wrapped by AbstractValue is consistent with the concrete subclass. */
   void CalcImpulse(const AbstractValue& data, EigenPtr<VectorX<T>> gamma) const;
 
   /* Computes the constraint Hessian as:
@@ -271,7 +277,9 @@ class SapConstraint {
    @post The constraint Hessian G(vc) is
    symmetric positive semi-definite, since ℓ(vc) is a convex function of vc as
    required by the SAP formulation.
-   @pre G does not equal nullptr. */
+   @pre G does not equal nullptr.
+   @pre data was created via MakeData() on `this` object and therefore the type
+   wrapped by AbstractValue is consistent with the concrete subclass. */
   void CalcCostHessian(const AbstractValue& data, MatrixX<T>* G) const;
 
   /* Polymorphic deep-copy into a new instance. */
@@ -281,6 +289,14 @@ class SapConstraint {
   /* Protected copy construction is enabled for sub-classes to use in their
    implementation of DoClone(). */
   SapConstraint(const SapConstraint&) = default;
+
+  /* Helper to pack `data` of type `U` into an AbstractValue.
+   Derived constraint classes can use this helper to implement DoMakeData(). */
+  template <typename U>
+  static std::unique_ptr<AbstractValue> MoveAndMakeAbstractValue(U&& data) {
+    auto owned_data = std::make_unique<U>(std::move(data));
+    return std::make_unique<Value<U>>(std::move(owned_data));
+  }
 
   // @group NVI implementations. Specific constraints must implement these
   // methods. Refer to the specific NVI documentation for details.

--- a/multibody/contact_solvers/sap/sap_limit_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_limit_constraint.cc
@@ -46,59 +46,6 @@ SapLimitConstraint<T>::SapLimitConstraint(int clique, int clique_dof,
       q0_{q0} {}
 
 template <typename T>
-VectorX<T> SapLimitConstraint<T>::CalcBiasTerm(const T& time_step,
-                                               const T&) const {
-  return -this->constraint_function() /
-         (time_step + parameters_.dissipation_time_scale());
-}
-
-template <typename T>
-VectorX<T> SapLimitConstraint<T>::CalcDiagonalRegularization(
-    const T& time_step, const T& wi) const {
-  using std::max;
-
-  // Rigid approximation constant: Rₙ = β²/(4π²)⋅wᵢ when the contact frequency
-  // ωₙ is below the limit ωₙ⋅δt ≤ 2π. That is, the period is Tₙ = β⋅δt. See
-  // [Castro et al., 2021] for details.
-  const double beta_factor =
-      parameters_.beta() * parameters_.beta() / (4.0 * M_PI * M_PI);
-
-  const T& k = parameters_.stiffness();
-  const T& taud = parameters_.dissipation_time_scale();
-
-  const T R = max(beta_factor * wi, 1.0 / (time_step * k * (time_step + taud)));
-
-  return VectorX<T>::Constant(this->num_constraint_equations(), R);
-}
-
-template <typename T>
-void SapLimitConstraint<T>::Project(const Eigen::Ref<const VectorX<T>>& y,
-                                    const Eigen::Ref<const VectorX<T>>&,
-                                    EigenPtr<VectorX<T>> gamma,
-                                    MatrixX<T>* dPdy) const {
-  DRAKE_DEMAND(gamma != nullptr);
-  DRAKE_DEMAND(gamma->size() == this->num_constraint_equations());
-  constexpr double kInf = std::numeric_limits<double>::infinity();
-  const T& ql = parameters_.lower_limit();
-  const T& qu = parameters_.upper_limit();
-
-  *gamma = y.array().max(0.0);
-  if (dPdy != nullptr) {
-    const int nk = this->num_constraint_equations();
-    // Resizing is no-op if already the proper size.
-    (*dPdy) = MatrixX<T>::Zero(nk, nk);
-    int i = 0;
-    if (ql > -kInf) {
-      if (y(i) > 0.0) (*dPdy)(i, i) = 1;
-      i++;
-    }
-    if (qu < kInf) {
-      if (y(i) > 0.0) (*dPdy)(i, i) = 1;
-    }
-  }
-}
-
-template <typename T>
 VectorX<T> SapLimitConstraint<T>::CalcConstraintFunction(const T& q0,
                                                          const T& ql,
                                                          const T& qu) {
@@ -134,6 +81,79 @@ MatrixX<T> SapLimitConstraint<T>::CalcConstraintJacobian(int clique_dof,
   if (qu < kInf) J(i, clique_dof) = -1;
 
   return J;
+}
+
+template <typename T>
+std::unique_ptr<AbstractValue> SapLimitConstraint<T>::DoMakeData(
+    const T& time_step,
+    const Eigen::Ref<const VectorX<T>>& delassus_estimation) const {
+  using std::max;
+
+  // Estimate regularization based on near-rigid regime threshold.
+  // Rigid approximation constant: Rₙ = β²/(4π²)⋅wᵢ when the contact frequency
+  // ωₙ is below the limit ωₙ⋅δt ≤ 2π. That is, the period is Tₙ = β⋅δt. See
+  // [Castro et al., 2021] for details.
+  const double beta_factor =
+      parameters_.beta() * parameters_.beta() / (4.0 * M_PI * M_PI);
+
+  const T& k = parameters_.stiffness();
+  const T& taud = parameters_.dissipation_time_scale();
+
+  VectorX<T> R = (beta_factor * delassus_estimation)
+                     .cwiseMax(1.0 / (time_step * k * (time_step + taud)));
+  VectorX<T> v_hat = -this->constraint_function() / (time_step + taud);
+
+  // Make data.
+  SapLimitConstraintData<T> data(std::move(R), std::move(v_hat));
+  return SapConstraint<T>::MoveAndMakeAbstractValue(std::move(data));
+}
+
+template <typename T>
+void SapLimitConstraint<T>::DoCalcData(const Eigen::Ref<const VectorX<T>>& vc,
+                                       AbstractValue* abstract_data) const {
+  auto& data = abstract_data->get_mutable_value<SapLimitConstraintData<T>>();
+  const VectorX<T>& R_inv = data.R_inv();
+  const VectorX<T>& v_hat = data.v_hat();
+  data.mutable_vc() = vc;
+  data.mutable_y() = R_inv.asDiagonal() * (v_hat - vc);
+  data.mutable_gamma() = data.y().array().max(0.0);
+}
+
+template <typename T>
+T SapLimitConstraint<T>::DoCalcCost(const AbstractValue& abstract_data) const {
+  const auto& data = abstract_data.get_value<SapLimitConstraintData<T>>();
+  const VectorX<T>& R = data.R();
+  const VectorX<T>& gamma = data.gamma();
+  const T cost = 0.5 * gamma.dot(R.asDiagonal() * gamma);
+  return cost;
+}
+
+template <typename T>
+void SapLimitConstraint<T>::DoCalcImpulse(const AbstractValue& abstract_data,
+                                          EigenPtr<VectorX<T>> gamma) const {
+  const auto& data = abstract_data.get_value<SapLimitConstraintData<T>>();
+  *gamma = data.gamma();
+}
+
+template <typename T>
+void SapLimitConstraint<T>::DoCalcCostHessian(
+    const AbstractValue& abstract_data, MatrixX<T>* G) const {
+  const auto& data = abstract_data.get_value<SapLimitConstraintData<T>>();
+  constexpr double kInf = std::numeric_limits<double>::infinity();
+  const T& ql = parameters_.lower_limit();
+  const T& qu = parameters_.upper_limit();
+  const VectorX<T>& y = data.y();
+  const VectorX<T>& R_inv = data.R_inv();
+
+  G->setZero();
+  int i = 0;
+  if (ql > -kInf) {
+    if (y(i) > 0.0) (*G)(i, i) = R_inv(i);
+    ++i;
+  }
+  if (qu < kInf) {
+    if (y(i) > 0.0) (*G)(i, i) = R_inv(i);
+  }
 }
 
 }  // namespace internal

--- a/multibody/contact_solvers/sap/sap_limit_constraint.h
+++ b/multibody/contact_solvers/sap/sap_limit_constraint.h
@@ -2,7 +2,9 @@
 
 #include <limits>
 #include <memory>
+#include <utility>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/contact_solvers/sap/sap_constraint.h"
 
@@ -10,6 +12,60 @@ namespace drake {
 namespace multibody {
 namespace contact_solvers {
 namespace internal {
+
+/* Structure to store data needed for SapLimitConstraint computations.
+ @tparam_nonsymbolic_scalar */
+template <typename T>
+class SapLimitConstraintData {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SapLimitConstraintData);
+
+  /* Constructs data for a SapLimitConstraint.
+    Refer to SapLimitConstraint's documentation for further details.
+    @param R Regularization parameters.
+    @param v_hat Bias term. */
+  SapLimitConstraintData(VectorX<T> R, VectorX<T> v_hat) {
+    const int nk = R.size();
+    parameters_.R_inv = R.cwiseInverse();
+    parameters_.R = std::move(R);
+    parameters_.v_hat = std::move(v_hat);
+    vc_.resize(nk);
+    y_.resize(nk);
+    gamma_.resize(nk);
+  }
+
+  /* Regularization R. */
+  const VectorX<T>& R() const { return parameters_.R; }
+
+  /* Inverse of the regularization, R⁻¹. */
+  const VectorX<T>& R_inv() const { return parameters_.R_inv; }
+
+  /* Constraint bias. */
+  const VectorX<T>& v_hat() const { return parameters_.v_hat; }
+
+  /* Const access. */
+  const VectorX<T>& vc() const { return vc_; }
+  const VectorX<T>& y() const { return y_; }
+  const VectorX<T>& gamma() const { return gamma_; }
+
+  /* Mutable access. */
+  VectorX<T>& mutable_vc() { return vc_; }
+  VectorX<T>& mutable_y() { return y_; }
+  VectorX<T>& mutable_gamma() { return gamma_; }
+
+ private:
+  // Values stored in this struct remain const after construction.
+  struct ConstParameters {
+    VectorX<T> R;  // Regularization R.
+    VectorX<T> R_inv;
+    VectorX<T> v_hat;  // Constraint velocity bias.
+  };
+  ConstParameters parameters_;
+
+  VectorX<T> vc_;     // Constraint velocity.
+  VectorX<T> y_;      // Un-projected impulse y = −R⁻¹⋅(vc−v̂).
+  VectorX<T> gamma_;  // Projected impulse γ = P(y).
+};
 
 /* Implements limit constraints for the SAP solver, [Castro et al., 2021]. This
  constraint is used to impose a (compliant, see below) limit on the i-th degree
@@ -134,24 +190,11 @@ class SapLimitConstraint final : public SapConstraint<T> {
   /* Returns the position provided at construction. */
   const T& position() const { return q0_; }
 
-  /* Implements the projection operation. In this case P(y) = (y)₊, independent
-   of the regularization R. Refer to SapConstraint::Project() for details. */
-  void Project(const Eigen::Ref<const VectorX<T>>& y,
-               const Eigen::Ref<const VectorX<T>>& R,
-               EigenPtr<VectorX<T>> gamma,
-               MatrixX<T>* dPdy = nullptr) const final;
-
-  /* Computes bias term. Refer to SapConstraint::CalcBiasTerm() for details. */
-  VectorX<T> CalcBiasTerm(const T& time_step, const T& wi) const final;
-
-  /* Computes the diagonal of the regularization matrix (positive diagonal) R.
-   This computes R = [Ri, Ri] (or R = [Ri] if only one limit is imposed) with
-     Ri = max(β²/(4π²)⋅wᵢ, (δt⋅(δt+tau_d)⋅k)⁻¹),
-   Refer to [Castro et al., 2021] for details. */
-  VectorX<T> CalcDiagonalRegularization(const T& time_step,
-                                        const T& wi) const final;
-
  private:
+  /* Private copy construction is enabled to use in the implementation of
+    DoClone(). */
+  SapLimitConstraint(const SapLimitConstraint&) = default;
+
   /* Computes the constraint function g(q0) as a function of q0 for given lower
    limit ql and upper limit qu.
    @pre lower_limit < +∞
@@ -164,10 +207,17 @@ class SapLimitConstraint final : public SapConstraint<T> {
   static MatrixX<T> CalcConstraintJacobian(int clique_dof, int clique_nv,
                                            const T& ql, const T& qu);
 
-  /* Private copy construction is enabled to use in the implementation of
-   DoClone(). */
-  SapLimitConstraint(const SapLimitConstraint&) = default;
-
+  /* Implementations of SapConstraint NVI functions. */
+  std::unique_ptr<AbstractValue> DoMakeData(
+      const T& time_step,
+      const Eigen::Ref<const VectorX<T>>& delassus_estimation) const override;
+  void DoCalcData(const Eigen::Ref<const VectorX<T>>& vc,
+                  AbstractValue* data) const override;
+  T DoCalcCost(const AbstractValue& abstract_data) const override;
+  void DoCalcImpulse(const AbstractValue& abstract_data,
+                     EigenPtr<VectorX<T>> gamma) const override;
+  void DoCalcCostHessian(const AbstractValue& abstract_data,
+                         MatrixX<T>* G) const override;
   std::unique_ptr<SapConstraint<T>> DoClone() const final {
     return std::unique_ptr<SapLimitConstraint<T>>(
         new SapLimitConstraint<T>(*this));

--- a/multibody/contact_solvers/sap/test/sap_limit_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_limit_constraint_test.cc
@@ -2,8 +2,11 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/autodiff.h"
 #include "drake/common/pointer_cast.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/multibody/contact_solvers/sap/validate_constraint_gradients.h"
 
 using Eigen::Matrix2d;
 using Eigen::Matrix3d;
@@ -20,14 +23,33 @@ namespace {
 
 constexpr double kInf = std::numeric_limits<double>::infinity();
 
-class SapLimitConstraintTest
-    : public testing::TestWithParam<SapLimitConstraint<double>::Parameters> {
+struct TestConfig {
+  // This is a gtest test suffix; no underscores or spaces.
+  std::string description;
+  SapLimitConstraint<double>::Parameters p;
+};
+
+// This provides the suffix for each test parameter: the test config
+// description.
+std::ostream& operator<<(std::ostream& out, const TestConfig& c) {
+  out << c.description;
+  return out;
+}
+
+class SapLimitConstraintTest : public testing::TestWithParam<TestConfig> {
  public:
   // Makes a SapLimitConstraint from this->GetParam() and an arbitrary clique,
   // clique_dof and clique_nv.
   void SetUp() override {
-    dut_ = std::make_unique<SapLimitConstraint<double>>(
-        clique_, clique_dof_, clique_nv_, q0_, GetParam());
+    const SapLimitConstraint<double>::Parameters& p = GetParam().p;
+    dut_ = std::make_unique<SapLimitConstraint<double>>(clique_, clique_dof_,
+                                                        clique_nv_, q0_, p);
+
+    SapLimitConstraint<AutoDiffXd>::Parameters p_ad(
+        p.lower_limit(), p.upper_limit(), p.stiffness(),
+        p.dissipation_time_scale(), p.beta());
+    dut_ad_ = std::make_unique<SapLimitConstraint<AutoDiffXd>>(
+        clique_, clique_dof_, clique_nv_, q0_, p_ad);
   }
 
   // Returns the expected number of equations for the parameters specified for
@@ -35,7 +57,7 @@ class SapLimitConstraintTest
   // to have two equations, and only one equation when just one of the limits is
   // finite.
   int expected_num_equations() const {
-    const SapLimitConstraint<double>::Parameters& p = GetParam();
+    const SapLimitConstraint<double>::Parameters& p = GetParam().p;
     int num_equations = 0;
     if (p.lower_limit() > -kInf) ++num_equations;
     if (p.upper_limit() < kInf) ++num_equations;
@@ -44,7 +66,7 @@ class SapLimitConstraintTest
 
   // The expected constraint function g(q).
   VectorXd MakeExpectedConstraintFunction() const {
-    const SapLimitConstraint<double>::Parameters& p = GetParam();
+    const SapLimitConstraint<double>::Parameters& p = GetParam().p;
     VectorXd g;
     if (p.lower_limit() == -kInf) {
       // Upper limit only.
@@ -61,7 +83,7 @@ class SapLimitConstraintTest
 
   // The expected constraint Jacobian J(q).
   MatrixXd MakeExpectedJacobian() const {
-    const SapLimitConstraint<double>::Parameters& p = GetParam();
+    const SapLimitConstraint<double>::Parameters& p = GetParam().p;
     MatrixXd J;
     if (p.lower_limit() == -kInf) {
       // Upper limit only.
@@ -84,7 +106,9 @@ class SapLimitConstraintTest
   const int clique_dof_{3};
   const int clique_nv_{7};
   const double q0_{3.1};
+  const double time_step_{2.0e-3};
   std::unique_ptr<SapLimitConstraint<double>> dut_;
+  std::unique_ptr<SapLimitConstraint<AutoDiffXd>> dut_ad_;
 };
 
 // Bare minimum sanity checks on a newly constructed limit constraint.
@@ -97,7 +121,7 @@ TEST_P(SapLimitConstraintTest, Construction) {
   EXPECT_EQ(dut_->first_clique_jacobian().MakeDenseMatrix(),
             MakeExpectedJacobian());
   EXPECT_THROW(dut_->second_clique_jacobian(), std::exception);
-  const SapLimitConstraint<double>::Parameters& p = GetParam();
+  const SapLimitConstraint<double>::Parameters& p = GetParam().p;
   EXPECT_EQ(dut_->parameters().lower_limit(), p.lower_limit());
   EXPECT_EQ(dut_->parameters().upper_limit(), p.upper_limit());
   EXPECT_EQ(dut_->parameters().stiffness(), p.stiffness());
@@ -108,25 +132,27 @@ TEST_P(SapLimitConstraintTest, Construction) {
 
 // Unit tests SapLimitConstraintTest::CalcBias().
 TEST_P(SapLimitConstraintTest, CalcBias) {
-  const double dissipation_time_scale = GetParam().dissipation_time_scale();
+  const double dissipation_time_scale = GetParam().p.dissipation_time_scale();
   const double time_step = 5e-3;
-  const double delassus_approximation = NAN;  // Does not participate.
-  const VectorXd vhat = dut_->CalcBiasTerm(time_step, delassus_approximation);
-  const VectorXd vhat_expected =
+  const VectorXd delassus_approximation = VectorXd::Constant(
+      dut_->num_constraint_equations(), NAN);  // Does not participate.
+  std::unique_ptr<AbstractValue> abstract_data =
+      dut_->MakeData(time_step, delassus_approximation);
+  const auto& data = abstract_data->get_value<SapLimitConstraintData<double>>();
+
+  const VectorXd v_hat_expected =
       -dut_->constraint_function() / (time_step + dissipation_time_scale);
-  EXPECT_TRUE(CompareMatrices(vhat, vhat_expected,
+  EXPECT_TRUE(CompareMatrices(data.v_hat(), v_hat_expected,
                               std::numeric_limits<double>::epsilon(),
                               MatrixCompareType::relative));
 }
 
-// Unit tests SapLimitConstraintTest::CalcRegularizationSoft() in the "soft"
-// regime, as defined in [Castro et al., 2021].
 // This test uses the constraint parameters supplied by GetParam() to create a
 // new set of parameters where only the stiffness is modified so that the
 // constraint is in the "soft" regime. The size of the constraint (1 or 2)
 // still depends on the upper/lower limits supplied through GetParam().
 TEST_P(SapLimitConstraintTest, CalcRegularizationSoft) {
-  SapLimitConstraint<double>::Parameters p0 = GetParam();
+  SapLimitConstraint<double>::Parameters p0 = GetParam().p;
   // We make a copy of the parameters and change the stiffness to be very soft
   // to ensure we are in the "soft" regime.
   const double soft_stiffness = 0.5;
@@ -136,9 +162,11 @@ TEST_P(SapLimitConstraintTest, CalcRegularizationSoft) {
   const SapLimitConstraint<double> c(clique_, clique_dof_, clique_nv_, q0_, p);
 
   const double time_step = 5e-3;
-  const double delassus_approximation = 1.5;
-  const VectorXd R =
-      c.CalcDiagonalRegularization(time_step, delassus_approximation);
+  const VectorXd delassus_approximation =
+      VectorXd::Constant(c.num_constraint_equations(), 1.5);
+  std::unique_ptr<AbstractValue> abstract_data =
+      c.MakeData(time_step, delassus_approximation);
+  const auto& data = abstract_data->get_value<SapLimitConstraintData<double>>();
 
   const double Rvalue =
       1. /
@@ -146,19 +174,17 @@ TEST_P(SapLimitConstraintTest, CalcRegularizationSoft) {
 
   const VectorXd R_expected =
       VectorXd::Constant(expected_num_equations(), Rvalue);
-  EXPECT_TRUE(CompareMatrices(R, R_expected,
+  EXPECT_TRUE(CompareMatrices(data.R(), R_expected,
                               std::numeric_limits<double>::epsilon(),
                               MatrixCompareType::relative));
 }
 
-// Unit tests SapLimitConstraintTest::CalcRegularizationSoft() in the
-// "near-rigid" regime, as defined in [Castro et al., 2021].
 // This test uses the constraint parameters supplied by GetParam() to create a
 // new set of parameters where only the stiffness is modified so that the
 // constraint is in the "near-rigid" regime. The size of the constraint (1 or 2)
 // still depends on the upper/lower limits supplied through GetParam().
 TEST_P(SapLimitConstraintTest, CalcRegularizationNearRigid) {
-  SapLimitConstraint<double>::Parameters p0 = GetParam();
+  SapLimitConstraint<double>::Parameters p0 = GetParam().p;
   // We make a copy of the parameters and change the stiffness to be very high
   // to ensure we are in the "near-rigid" regime.
   const double near_rigid_stiffness = 1.0e12;
@@ -168,131 +194,93 @@ TEST_P(SapLimitConstraintTest, CalcRegularizationNearRigid) {
   const SapLimitConstraint<double> c(clique_, clique_dof_, clique_nv_, q0_, p);
 
   const double time_step = 5e-3;
-  const double delassus_approximation = 1.5;
-  const VectorXd R =
-      c.CalcDiagonalRegularization(time_step, delassus_approximation);
-
-  const double Rvalue =
-      p.beta() * p.beta() / (4 * M_PI * M_PI) * delassus_approximation;
+  const VectorXd delassus_approximation =
+      VectorXd::Constant(c.num_constraint_equations(), 1.5);
+  std::unique_ptr<AbstractValue> abstract_data =
+      c.MakeData(time_step, delassus_approximation);
+  const auto& data = abstract_data->get_value<SapLimitConstraintData<double>>();
 
   const VectorXd R_expected =
-      VectorXd::Constant(expected_num_equations(), Rvalue);
-  EXPECT_TRUE(CompareMatrices(R, R_expected,
+      p.beta() * p.beta() / (4 * M_PI * M_PI) * delassus_approximation;
+
+  EXPECT_TRUE(CompareMatrices(data.R(), R_expected,
                               std::numeric_limits<double>::epsilon(),
                               MatrixCompareType::relative));
 }
 
-// Test projection when impulses are positive.
-TEST_P(SapLimitConstraintTest, ProjectPositiveImpulses) {
+// This test validates the implementation of analytical constraint gradient and
+// Hessian against numerical results obtained with automatic differentiation.
+TEST_P(SapLimitConstraintTest, ValidateConstraintGradients) {
   const int ne = expected_num_equations();
-  // Result should not depend on R.
-  const VectorXd R = VectorXd::Constant(ne, NAN);
+  VectorX<AutoDiffXd> delassus_estimation =
+      VectorX<AutoDiffXd>::Constant(ne, 1.5);  // Arbitrary value.
+  std::unique_ptr<AbstractValue> abstract_data =
+      dut_ad_->MakeData(time_step_, delassus_estimation);
+  const auto& data =
+      abstract_data->get_value<SapLimitConstraintData<AutoDiffXd>>();
 
-  // Positive impulses.
-  const VectorXd y = VectorXd::LinSpaced(ne, 1.2, 3.4);
-  VectorXd gamma;
-  gamma.resize(ne);
-  MatrixXd dPdy;
-  dut_->Project(y, R, &gamma, &dPdy);
-  EXPECT_TRUE(CompareMatrices(gamma, y, std::numeric_limits<double>::epsilon(),
-                              MatrixCompareType::relative));
-  EXPECT_TRUE(CompareMatrices(dPdy, MatrixXd::Identity(ne, ne),
-                              std::numeric_limits<double>::epsilon(),
-                              MatrixCompareType::relative));
-}
+  // Helper to make a new vector v such that v < x componentwise.
+  auto make_lower_vector = [](const VectorXd& x) {
+    VectorXd v(x.size());
+    for (int i = 0; i < x.size(); ++i) {
+      if (x(i) < 0) {
+        v(i) = 1.1 * x(i);
+      } else if (x(i) > 0) {
+        v(i) = 0.9 * x(i);
+      } else {  // v(i) = 0
+        v(i) = -1.0;
+      }
+    }
+    return v;
+  };
 
-// Test projection when impulses are negative.
-TEST_P(SapLimitConstraintTest, ProjectNegativeImpulses) {
-  const int ne = expected_num_equations();
-  // Result should not depend on R.
-  const VectorXd R = VectorXd::Constant(ne, NAN);
+  // Helper to make a new vector v such that v > x componentwise.
+  auto make_greater_vector = [](const VectorXd& x) {
+    VectorXd v(x.size());
+    for (int i = 0; i < x.size(); ++i) {
+      if (x(i) < 0) {
+        v(i) = 0.9 * x(i);
+      } else if (x(i) > 0) {
+        v(i) = 1.1 * x(i);
+      } else {  // v(i) = 0
+        v(i) = 1.0;
+      }
+    }
+    return v;
+  };
 
-  // Negative impulses.
-  const VectorXd y = VectorXd::LinSpaced(ne, -5.2, -1.1);
-  VectorXd gamma;
-  gamma.resize(ne);
-  MatrixXd dPdy;
-  dut_->Project(y, R, &gamma, &dPdy);
-  EXPECT_TRUE(CompareMatrices(gamma, VectorXd::Zero(ne),
-                              std::numeric_limits<double>::epsilon(),
-                              MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(dPdy, MatrixXd::Zero(ne, ne),
-                              std::numeric_limits<double>::epsilon(),
-                              MatrixCompareType::absolute));
-}
+  // Helper to validate gradients at the constraint velocity vc.
+  // It returns impulses at vc.
+  auto validate_gradients = [&](const VectorXd& vc) {
+    VectorX<AutoDiffXd> gamma_ad(ne);
+    VectorX<AutoDiffXd> vc_ad = drake::math::InitializeAutoDiff(vc);
+    dut_ad_->CalcData(vc_ad, abstract_data.get());
+    dut_ad_->CalcImpulse(*abstract_data, &gamma_ad);
+    const VectorXd gamma = math::ExtractValue(gamma_ad);
+    ValidateConstraintGradients(*dut_ad_, *abstract_data);
+    return gamma;
+  };
 
-// Test projection when lower limit impulse (if constrained) is positive and
-// upper lower impulse (if constrained) is negative.
-TEST_P(SapLimitConstraintTest, PositiveLowerImpulseAndNegativeUpperImpulse) {
-  const SapLimitConstraint<double>::Parameters p = GetParam();
-  const int ne = expected_num_equations();
-  // Result should not depend on R.
-  const VectorXd R = VectorXd::Constant(ne, NAN);
+  // Impulses for the limit constraint are computed according to:
+  //  γ = (−R⁻¹⋅(vc−v̂))₊
+  // Therefore the constraint is active when vc < v̂ and not active otherwise.
+  const VectorXd& v_hat = math::ExtractValue(data.v_hat());
 
-  VectorXd y = VectorXd::Zero(ne);
-  int i = 0;
-  if (p.lower_limit() != -kInf) y(i++) = 1.3;  // Arbitrary positive impulse.
-  if (p.upper_limit() != kInf) y(i++) = -0.2;  // Arbitrary negative impulse.
-  ASSERT_EQ(i, ne);                            // Sanity check.
-
-  // Expected values:
-  // For the upper limit (if != kInf) we know that projection and its derivative
-  // will be zero . Therefore we only need to setup the nonzero values for the
-  // lower limit.
-  VectorXd gamma_expected = VectorXd::Zero(ne);
-  MatrixXd dPdy_expected = MatrixXd::Zero(ne, ne);
-  if (p.lower_limit() != -kInf) {
-    gamma_expected(0) = 1.3;
-    dPdy_expected(0, 0) = 1.0;
+  // Constraint is active.
+  {
+    const VectorXd vc = make_lower_vector(v_hat);
+    const VectorXd gamma = validate_gradients(vc);
+    // We expect non-zero impulses.
+    EXPECT_TRUE((gamma.array() > 0.0).all());
   }
 
-  VectorXd gamma;
-  gamma.resize(ne);
-  MatrixXd dPdy;
-  dut_->Project(y, R, &gamma, &dPdy);
-  EXPECT_TRUE(CompareMatrices(gamma, gamma_expected,
-                              std::numeric_limits<double>::epsilon(),
-                              MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(dPdy, dPdy_expected,
-                              std::numeric_limits<double>::epsilon(),
-                              MatrixCompareType::absolute));
-}
-
-// Test projection when lower limit impulse (if constrained) is negative and
-// upper lower impulse (if constrained) is positive.
-TEST_P(SapLimitConstraintTest, NegativeLowerImpulseAndPositiveUpperImpulse) {
-  const SapLimitConstraint<double>::Parameters p = GetParam();
-  const int ne = expected_num_equations();
-  // Result should not depend on R.
-  const VectorXd R = VectorXd::Constant(ne, NAN);
-
-  VectorXd y = VectorXd::Zero(ne);
-  int i = 0;
-  if (p.lower_limit() != -kInf) y(i++) = -0.2;  // Arbitrary negative impulse.
-  if (p.upper_limit() != kInf) y(i++) = 1.3;    // Arbitrary positive impulse.
-  ASSERT_EQ(i, ne);                             // Sanity check.
-
-  // Expected values:
-  // For the lower limit (if != -kInf) we know that projection and its
-  // derivative will be zero . Therefore we only need to setup the nonzero
-  // values for the upper limit.
-  VectorXd gamma_expected = VectorXd::Zero(ne);
-  MatrixXd dPdy_expected = MatrixXd::Zero(ne, ne);
-  if (p.upper_limit() != kInf) {
-    gamma_expected(ne - 1) = 1.3;
-    dPdy_expected(ne - 1, ne - 1) = 1.0;
+  // Constraint is not active.
+  {
+    const VectorXd vc = make_greater_vector(v_hat);
+    const VectorXd gamma = validate_gradients(vc);
+    // We expect zero impulses.
+    EXPECT_TRUE((gamma.array() == 0.0).all());
   }
-
-  VectorXd gamma;
-  gamma.resize(ne);
-  MatrixXd dPdy;
-  dut_->Project(y, R, &gamma, &dPdy);
-  EXPECT_TRUE(CompareMatrices(gamma, gamma_expected,
-                              std::numeric_limits<double>::epsilon(),
-                              MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(dPdy, dPdy_expected,
-                              std::numeric_limits<double>::epsilon(),
-                              MatrixCompareType::absolute));
 }
 
 TEST_P(SapLimitConstraintTest, Clone) {
@@ -308,7 +296,7 @@ TEST_P(SapLimitConstraintTest, Clone) {
   EXPECT_EQ(clone->first_clique_jacobian().MakeDenseMatrix(),
             dut_->first_clique_jacobian().MakeDenseMatrix());
   EXPECT_THROW(clone->second_clique_jacobian(), std::exception);
-  const SapLimitConstraint<double>::Parameters p = GetParam();
+  const SapLimitConstraint<double>::Parameters p = GetParam().p;
   EXPECT_EQ(clone->parameters().lower_limit(), p.lower_limit());
   EXPECT_EQ(clone->parameters().upper_limit(), p.upper_limit());
   EXPECT_EQ(clone->parameters().stiffness(), p.stiffness());
@@ -317,16 +305,27 @@ TEST_P(SapLimitConstraintTest, Clone) {
   EXPECT_EQ(clone->parameters().beta(), p.beta());
 }
 
-const SapLimitConstraint<double>::Parameters lower_only{0.5, kInf, 1.0e5, 0.01,
-                                                        0.5};
-const SapLimitConstraint<double>::Parameters upper_only{-kInf, 2.3, 1.0e5, 0.01,
-                                                        0.5};
-const SapLimitConstraint<double>::Parameters lower_and_upper{-0.3, 2.3, 1.0e5,
-                                                             0.01, 0.5};
+// Generate cases with finite and infinite lower/upper bounds.
+std::vector<TestConfig> MakeTestCases() {
+  return std::vector<TestConfig>{
+      {
+          .description = "LowerOnly",
+          .p = {0.5, kInf, 1.0e5, 0.01, 0.5},
+      },
+      {
+          .description = "UpperOnly",
+          .p = {-kInf, 2.3, 1.0e5, 0.01, 0.5},
+      },
+      {
+          .description = "LowerAndUpper",
+          .p = {-0.5, 2.3, 1.0e5, 0.01, 0.5},
+      },
+  };
+}
 
 INSTANTIATE_TEST_SUITE_P(SapLimitConstraintTest, SapLimitConstraintTest,
-                         testing::Values(lower_only, upper_only,
-                                         lower_and_upper));
+                         testing::ValuesIn(MakeTestCases()),
+                         testing::PrintToStringParamName());
 
 }  // namespace
 }  // namespace internal


### PR DESCRIPTION
Follow up to https://github.com/RobotLocomotion/drake/pull/19402, this PR implements the SAP limit constraints in terms of the newly introduced APIs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19452)
<!-- Reviewable:end -->
